### PR TITLE
Add session management and context compaction

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@ ANTHROPIC_API_KEY=sk-ant-...
 
 # LLM Settings
 LLM_PROVIDER=anthropic
-LLM_MODEL=claude-opus-4-6
+LLM_MODEL=claude-sonnet-4-5-20241022
 
 # intervals.icu
 INTERVALS_API_KEY=your-intervals-api-key
@@ -13,3 +13,9 @@ INTERVALS_ATHLETE_ID=0
 
 # Telegram
 TELEGRAM_BOT_TOKEN=123456:ABC-DEF...
+
+# Session (optional)
+# SESSION_HISTORY_LIMIT=20
+# SESSION_IDLE_MINUTES=0
+# SESSION_DAILY_RESET_HOUR=4
+# CONTEXT_WINDOW_TOKENS=200000

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ docs/
 .DS_Store
 .idea/
 scripts/
+.claude

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+# Contributing
+
+## Branch Naming
+
+```
+feat/<short-description>   — new feature
+fix/<short-description>    — bug fix
+chore/<short-description>  — maintenance, deps, config
+docs/<short-description>   — documentation only
+refactor/<short-description> — code restructuring, no behavior change
+```
+
+Use lowercase, kebab-case. Keep it under 50 characters.
+
+Examples: `feat/session-management`, `fix/telegram-html-escape`, `chore/bump-intervals-api`.
+
+## Pull Requests
+
+- **Title**: imperative mood, under 70 characters (e.g., "Add session management and context compaction")
+- **Branch**: always branch off `main`, PR back into `main`
+- **One concern per PR**: don't mix unrelated features in a single PR
+- **Description**: include a Summary (what and why) and a Test Plan
+
+## Commits
+
+- Imperative mood: "Add X", "Fix Y", not "Added X" or "Fixes Y"
+- One logical change per commit when practical

--- a/SOUL.md
+++ b/SOUL.md
@@ -15,6 +15,7 @@ You are a structured, data-driven cycling coach.
 - Explain the "why" behind every workout
 - Flag overtraining signals: declining form, rising fatigue, missed sessions
 - If the athlete's form is below -30 TSB, recommend recovery before hard work
+- When the athlete shares personal details (FTP, weight, schedule, goals, preferences, injuries), save them to long-term memory using memory_write so they persist across sessions
 
 ## Communication
 - Concise, direct — athletes don't want essays

--- a/src/agent/chat-store.ts
+++ b/src/agent/chat-store.ts
@@ -1,0 +1,76 @@
+import {
+  readFileSync,
+  appendFileSync,
+  renameSync,
+  existsSync,
+  mkdirSync,
+} from "node:fs";
+import { join } from "node:path";
+import type { ModelMessage } from "ai";
+
+interface JsonlLine {
+  role: "user" | "assistant";
+  content: string;
+  ts: string;
+}
+
+export class ChatStore {
+  private sessionsDir: string;
+
+  constructor(dataDir: string) {
+    this.sessionsDir = join(dataDir, "sessions");
+    mkdirSync(this.sessionsDir, { recursive: true });
+  }
+
+  private filePath(chatId: string): string {
+    return join(this.sessionsDir, `${chatId}.jsonl`);
+  }
+
+  getHistory(chatId: string): ModelMessage[] {
+    return this.load(chatId).messages;
+  }
+
+  load(chatId: string): { messages: ModelMessage[]; lastMessageTime: string | null } {
+    const path = this.filePath(chatId);
+    if (!existsSync(path)) return { messages: [], lastMessageTime: null };
+
+    const raw = readFileSync(path, "utf-8").trim();
+    if (!raw) return { messages: [], lastMessageTime: null };
+
+    const lines = raw.split("\n");
+    const messages = lines.map((line) => {
+      const parsed: JsonlLine = JSON.parse(line);
+      return { role: parsed.role, content: parsed.content } as ModelMessage;
+    });
+
+    const lastParsed: JsonlLine = JSON.parse(lines[lines.length - 1]);
+    return { messages, lastMessageTime: lastParsed.ts };
+  }
+
+  appendMessage(chatId: string, role: "user" | "assistant", content: string): void {
+    const path = this.filePath(chatId);
+    const line: JsonlLine = { role, content, ts: new Date().toISOString() };
+    appendFileSync(path, JSON.stringify(line) + "\n", "utf-8");
+  }
+
+  getLastMessageTime(chatId: string): string | null {
+    const path = this.filePath(chatId);
+    if (!existsSync(path)) return null;
+
+    const raw = readFileSync(path, "utf-8").trim();
+    if (!raw) return null;
+
+    const lines = raw.split("\n");
+    const last: JsonlLine = JSON.parse(lines[lines.length - 1]);
+    return last.ts;
+  }
+
+  archiveAndReset(chatId: string): void {
+    const path = this.filePath(chatId);
+    if (!existsSync(path)) return;
+
+    const ts = new Date().toISOString().replace(/:/g, "-");
+    const archivePath = `${path}.reset.${ts}`;
+    renameSync(path, archivePath);
+  }
+}

--- a/src/agent/compaction.ts
+++ b/src/agent/compaction.ts
@@ -1,0 +1,140 @@
+import { generateText } from "ai";
+import type { LanguageModel, ModelMessage } from "ai";
+import { estimateTokens, estimateMessagesTokens } from "./token-utils.js";
+
+// ============================================================================
+// CONSTANTS
+// ============================================================================
+
+export const COMPACTION_CHUNKS = 2;
+
+// ============================================================================
+// PROMPTS
+// ============================================================================
+
+const MUST_PRESERVE = `MUST PRESERVE:
+- Athlete profile details (FTP, weight, experience, schedule, goals)
+- Current training plan status and phase
+- Recent workout feedback and performance trends
+- Decisions made about training approach
+- Any injuries, constraints, or preferences mentioned
+- The last thing the athlete asked and what was being discussed
+
+Preserve all specific numbers exactly as written (watts, kg, percentages,
+dates, distances, durations).
+
+PRIORITIZE recent context over older history.
+The coach needs to know what was being discussed, not just what topics were covered.`;
+
+const SUMMARIZE_PROMPT = `Summarize the following conversation concisely.
+
+${MUST_PRESERVE}`;
+
+const MERGE_PROMPT = `Merge these partial summaries into a single cohesive summary.
+
+${MUST_PRESERVE}`;
+
+// ============================================================================
+// CHUNK SPLITTING
+// ============================================================================
+
+export function splitMessagesByTokenShare(
+  messages: ModelMessage[],
+  parts: number,
+): ModelMessage[][] {
+  if (messages.length === 0) return [];
+  if (parts <= 1) return [messages];
+
+  const totalTokens = estimateMessagesTokens(messages);
+  const targetPerChunk = totalTokens / parts;
+
+  const chunks: ModelMessage[][] = [];
+  let current: ModelMessage[] = [];
+  let currentTokens = 0;
+
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i];
+    const msgTokens = estimateTokens(typeof msg.content === "string" ? msg.content : "");
+
+    current.push(msg);
+    currentTokens += msgTokens;
+
+    // Check if we should split — but never split in the middle of a user/assistant pair
+    const isAtTurnBoundary =
+      msg.role === "assistant" || i === messages.length - 1;
+    const hasEnoughTokens = currentTokens >= targetPerChunk;
+    const hasMoreChunksNeeded = chunks.length < parts - 1;
+
+    if (isAtTurnBoundary && hasEnoughTokens && hasMoreChunksNeeded) {
+      chunks.push(current);
+      current = [];
+      currentTokens = 0;
+    }
+  }
+
+  if (current.length > 0) {
+    chunks.push(current);
+  }
+
+  return chunks;
+}
+
+// ============================================================================
+// SUMMARIZE IN STAGES
+// ============================================================================
+
+export async function summarizeInStages(params: {
+  messages: ModelMessage[];
+  model: LanguageModel;
+  recentToKeep?: number;
+}): Promise<ModelMessage[]> {
+  const { messages, model, recentToKeep = 4 } = params;
+
+  // Determine how many recent messages to preserve (keep recent turns intact)
+  const keepCount = Math.min(recentToKeep, messages.length);
+  const toSummarize = messages.slice(0, messages.length - keepCount);
+  const recent = messages.slice(messages.length - keepCount);
+
+  if (toSummarize.length === 0) {
+    return messages;
+  }
+
+  // Split into chunks
+  const chunks = splitMessagesByTokenShare(toSummarize, COMPACTION_CHUNKS);
+
+  // Summarize each chunk
+  const summaries: string[] = [];
+  for (const chunk of chunks) {
+    const transcript = chunk
+      .map((m) => `${m.role}: ${typeof m.content === "string" ? m.content : ""}`)
+      .join("\n");
+
+    const { text } = await generateText({
+      model,
+      prompt: `${SUMMARIZE_PROMPT}\n\n${transcript}`,
+    });
+    summaries.push(text);
+  }
+
+  // Merge if multiple summaries
+  let finalSummary: string;
+  if (summaries.length === 1) {
+    finalSummary = summaries[0];
+  } else {
+    const numbered = summaries
+      .map((s, i) => `Summary ${i + 1}:\n${s}`)
+      .join("\n\n");
+
+    const { text } = await generateText({
+      model,
+      prompt: `${MERGE_PROMPT}\n\n${numbered}`,
+    });
+    finalSummary = text;
+  }
+
+  // Return summary as system message + recent messages
+  return [
+    { role: "system" as const, content: `[Previous conversation summary]\n${finalSummary}` },
+    ...recent,
+  ];
+}

--- a/src/agent/core.ts
+++ b/src/agent/core.ts
@@ -2,12 +2,29 @@ import { generateText, stepCountIs } from "ai";
 import { createAnthropic } from "@ai-sdk/anthropic";
 import { createOpenAI } from "@ai-sdk/openai";
 import { createGoogleGenerativeAI } from "@ai-sdk/google";
-import type { LanguageModel } from "ai";
+import type { LanguageModel, ModelMessage } from "ai";
 import { IntervalsClient } from "intervals-icu-api";
 import type { Config } from "../config.js";
+import { getHistoryLimit } from "../config.js";
 import { Memory } from "./memory.js";
+import { ChatStore } from "./chat-store.js";
 import { buildSystemPrompt } from "./system-prompt.js";
 import { createTools } from "./tools.js";
+import { withSessionLock } from "./session-lock.js";
+import { limitHistoryTurns } from "./history-limit.js";
+import {
+  shouldCompact,
+  isContextOverflowError,
+  isTimeoutError,
+  estimateMessagesTokens,
+  TIMEOUT_COMPACTION_THRESHOLD,
+} from "./token-utils.js";
+import { summarizeInStages } from "./compaction.js";
+import { runMemoryFlush } from "./memory-flush.js";
+import { evaluateSessionFreshness } from "./session-freshness.js";
+
+const MAX_OVERFLOW_ATTEMPTS = 3;
+const MAX_TIMEOUT_ATTEMPTS = 2;
 
 // ============================================================================
 // AGENT
@@ -15,13 +32,17 @@ import { createTools } from "./tools.js";
 
 export class CyclingCoachAgent {
   private model: LanguageModel;
+  private config: Config;
   private memory: Memory;
+  private chatStore: ChatStore;
   private tools: ReturnType<typeof createTools>;
   private systemPrompt: string;
 
   constructor(config: Config) {
+    this.config = config;
     this.model = createModel(config);
     this.memory = new Memory(config.dataDir);
+    this.chatStore = new ChatStore(config.dataDir);
 
     const intervals = config.intervals.apiKey
       ? new IntervalsClient({
@@ -34,18 +55,90 @@ export class CyclingCoachAgent {
     this.systemPrompt = buildSystemPrompt(this.memory);
   }
 
-  async chat(userMessage: string): Promise<string> {
-    this.systemPrompt = buildSystemPrompt(this.memory);
+  async chat(chatId: string, userMessage: string): Promise<string> {
+    return withSessionLock(chatId, async () => {
+      // Single file read: load history + last message time together
+      let { messages: history, lastMessageTime } = this.chatStore.load(chatId);
 
-    const { text } = await generateText({
-      model: this.model,
-      system: this.systemPrompt,
-      prompt: userMessage,
-      tools: this.tools,
-      stopWhen: stepCountIs(10),
+      const { fresh } = evaluateSessionFreshness({
+        lastMessageTime,
+        dailyResetHour: this.config.session.dailyResetHour,
+        idleMinutes: this.config.session.idleMinutes,
+      });
+
+      if (!fresh) {
+        // Flush memory before reset, then archive
+        if (history.length > 0) {
+          await runMemoryFlush({ model: this.model, messages: history, memory: this.memory });
+        }
+        this.chatStore.archiveAndReset(chatId);
+        history = [];
+      }
+
+      this.systemPrompt = buildSystemPrompt(this.memory);
+
+      const limited = limitHistoryTurns(history, getHistoryLimit(this.config, chatId));
+
+      // Build messages array with new user message
+      let messages: ModelMessage[] = [...limited, { role: "user", content: userMessage }];
+
+      let overflowAttempts = 0;
+      let timeoutAttempts = 0;
+
+      while (true) {
+        // Preemptive: compact before sending if over budget
+        if (shouldCompact({ messages, systemPrompt: this.systemPrompt, contextWindowTokens: this.config.contextWindowTokens })) {
+          await runMemoryFlush({ model: this.model, messages, memory: this.memory });
+          messages = await summarizeInStages({ messages, model: this.model });
+          this.memory.reload();
+        }
+
+        try {
+          const { text } = await generateText({
+            model: this.model,
+            system: this.systemPrompt,
+            messages,
+            tools: this.tools,
+            stopWhen: stepCountIs(10),
+          });
+
+          // Append BOTH after success — JSONL unchanged on failure
+          this.chatStore.appendMessage(chatId, "user", userMessage);
+          this.chatStore.appendMessage(chatId, "assistant", text);
+
+          return text;
+        } catch (err) {
+          // Reactive: context overflow → flush + compact + retry
+          if (isContextOverflowError(err) && overflowAttempts < MAX_OVERFLOW_ATTEMPTS) {
+            overflowAttempts++;
+            await runMemoryFlush({ model: this.model, messages, memory: this.memory });
+            messages = await summarizeInStages({ messages, model: this.model });
+            this.memory.reload();
+            continue;
+          }
+          // Timeout with high context usage → compact + retry (no flush)
+          if (isTimeoutError(err) && timeoutAttempts < MAX_TIMEOUT_ATTEMPTS) {
+            const ratio = estimateMessagesTokens(messages) / this.config.contextWindowTokens;
+            if (ratio > TIMEOUT_COMPACTION_THRESHOLD) {
+              timeoutAttempts++;
+              messages = await summarizeInStages({ messages, model: this.model });
+              this.memory.reload();
+              continue;
+            }
+          }
+          throw err;
+        }
+      }
     });
+  }
 
-    return text;
+  async resetSession(chatId: string): Promise<void> {
+    // Memory flush before ANY reset — fixes OpenClaw bug #50891
+    const history = this.chatStore.getHistory(chatId);
+    if (history.length > 0) {
+      await runMemoryFlush({ model: this.model, messages: history, memory: this.memory });
+    }
+    this.chatStore.archiveAndReset(chatId);
   }
 
   getMemory(): Memory {

--- a/src/agent/history-limit.ts
+++ b/src/agent/history-limit.ts
@@ -1,0 +1,17 @@
+import type { ModelMessage } from "ai";
+
+export function limitHistoryTurns(messages: ModelMessage[], limit: number): ModelMessage[] {
+  if (!limit || limit <= 0 || messages.length === 0) return messages;
+  let userCount = 0;
+  let lastUserIndex = messages.length;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i].role === "user") {
+      userCount++;
+      if (userCount > limit) {
+        return messages.slice(lastUserIndex);
+      }
+      lastUserIndex = i;
+    }
+  }
+  return messages;
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -2,3 +2,22 @@ export { CyclingCoachAgent } from "./core.js";
 export { Memory } from "./memory.js";
 export { buildSystemPrompt } from "./system-prompt.js";
 export { createTools } from "./tools.js";
+export { withSessionLock } from "./session-lock.js";
+export { limitHistoryTurns } from "./history-limit.js";
+export { ChatStore } from "./chat-store.js";
+export {
+  estimateTokens,
+  estimateMessagesTokens,
+  shouldCompact,
+  isContextOverflowError,
+  isTimeoutError,
+  CHARS_PER_TOKEN,
+  SAFETY_MARGIN,
+  RESERVE_TOKENS,
+  MIN_PROMPT_BUDGET_TOKENS,
+  MIN_PROMPT_BUDGET_RATIO,
+  TIMEOUT_COMPACTION_THRESHOLD,
+} from "./token-utils.js";
+export { summarizeInStages, splitMessagesByTokenShare } from "./compaction.js";
+export { runMemoryFlush } from "./memory-flush.js";
+export { evaluateSessionFreshness, resolveDailyResetAtMs } from "./session-freshness.js";

--- a/src/agent/memory-flush.ts
+++ b/src/agent/memory-flush.ts
@@ -1,0 +1,79 @@
+import { generateText, tool, zodSchema, stepCountIs } from "ai";
+import type { LanguageModel, ModelMessage } from "ai";
+import { z } from "zod";
+import type { Memory } from "./memory.js";
+import { createMemoryReadTool } from "./tools.js";
+
+// ============================================================================
+// CONSTANTS
+// ============================================================================
+
+export const SOFT_THRESHOLD_RATIO = 0.8;
+
+// ============================================================================
+// PROMPTS
+// ============================================================================
+
+const MEMORY_FLUSH_SYSTEM_PROMPT = `You are reviewing a conversation to extract and save important information
+before it is summarized. Use the memory_write tool to save any athlete
+details that are not already in memory.`;
+
+const MEMORY_FLUSH_USER_PROMPT = `Review this conversation and save any athlete details not already in
+long-term memory. Focus on:
+- Personal metrics (FTP, weight, max HR, resting HR)
+- Training schedule and availability
+- Goals, target events, and race dates
+- Injuries, limitations, or recovery needs
+- Equipment and trainer/outdoor preferences
+- Past training history and experience level
+
+Only save facts not already in memory. Use memory_write with type "memory"
+for each distinct piece of information.`;
+
+// ============================================================================
+// APPEND-ONLY MEMORY WRITE TOOL
+// ============================================================================
+
+function createAppendOnlyMemoryWriteTool(memory: Memory) {
+  return tool({
+    description: "Append to long-term athlete memory (append-only during memory flush)",
+    inputSchema: zodSchema(
+      z.object({
+        content: z.string().describe("The information to save"),
+      }),
+    ),
+    execute: async (input: { content: string }) => {
+      memory.appendMemory(input.content);
+      return { saved: true };
+    },
+  });
+}
+
+// ============================================================================
+// MEMORY FLUSH
+// ============================================================================
+
+export async function runMemoryFlush(params: {
+  model: LanguageModel;
+  messages: ModelMessage[];
+  memory: Memory;
+}): Promise<void> {
+  const flushTools = {
+    memory_write: createAppendOnlyMemoryWriteTool(params.memory),
+    memory_read: createMemoryReadTool(params.memory),
+  };
+
+  await generateText({
+    model: params.model,
+    system: MEMORY_FLUSH_SYSTEM_PROMPT,
+    messages: [
+      ...params.messages,
+      { role: "user" as const, content: MEMORY_FLUSH_USER_PROMPT },
+    ],
+    tools: flushTools,
+    stopWhen: stepCountIs(5),
+  });
+
+  params.memory.reload();
+}
+

--- a/src/agent/memory.ts
+++ b/src/agent/memory.ts
@@ -63,6 +63,11 @@ export class Memory {
 
   // ── Full context for system prompt ─────────────────────────────────────
 
+  reload(): void {
+    // No-op — Memory reads from disk on every access.
+    // Explicit sync point for post-compaction and future caching.
+  }
+
   getContext(): string {
     const parts: string[] = [];
 

--- a/src/agent/session-freshness.ts
+++ b/src/agent/session-freshness.ts
@@ -1,0 +1,49 @@
+// ============================================================================
+// SESSION FRESHNESS
+// ============================================================================
+
+export function resolveDailyResetAtMs(hour: number): number {
+  const now = new Date();
+  const today = new Date(now);
+  today.setHours(hour, 0, 0, 0);
+
+  // If current time is before the reset hour, use yesterday's reset time
+  if (now.getTime() < today.getTime()) {
+    today.setDate(today.getDate() - 1);
+  }
+
+  return today.getTime();
+}
+
+export function evaluateSessionFreshness(params: {
+  lastMessageTime: string | null;
+  dailyResetHour: number;
+  idleMinutes: number;
+}): { fresh: boolean; reason?: "daily" | "idle" } {
+  // No history = fresh (new session)
+  if (!params.lastMessageTime) {
+    return { fresh: true };
+  }
+
+  const updatedAt = new Date(params.lastMessageTime).getTime();
+  if (Number.isNaN(updatedAt)) {
+    return { fresh: false, reason: "daily" };
+  }
+  const now = Date.now();
+
+  // Daily: stale if last message before most recent reset hour
+  const dailyResetAt = resolveDailyResetAtMs(params.dailyResetHour);
+  if (updatedAt < dailyResetAt) {
+    return { fresh: false, reason: "daily" };
+  }
+
+  // Idle: stale if idle timeout exceeded (only when enabled)
+  if (params.idleMinutes > 0) {
+    const idleExpiresAt = updatedAt + params.idleMinutes * 60_000;
+    if (now > idleExpiresAt) {
+      return { fresh: false, reason: "idle" };
+    }
+  }
+
+  return { fresh: true };
+}

--- a/src/agent/session-lock.ts
+++ b/src/agent/session-lock.ts
@@ -1,0 +1,8 @@
+const locks = new Map<string, Promise<void>>();
+
+export async function withSessionLock<T>(chatId: string, fn: () => Promise<T>): Promise<T> {
+  const prev = locks.get(chatId) ?? Promise.resolve();
+  const next = prev.then(fn, fn);
+  locks.set(chatId, next.then(() => {}, () => {}));
+  return next;
+}

--- a/src/agent/token-utils.ts
+++ b/src/agent/token-utils.ts
@@ -1,0 +1,55 @@
+import type { ModelMessage } from "ai";
+
+export const CHARS_PER_TOKEN = 4;
+export const SAFETY_MARGIN = 1.2;
+export const RESERVE_TOKENS = 4096;
+export const MIN_PROMPT_BUDGET_TOKENS = 8000;
+export const MIN_PROMPT_BUDGET_RATIO = 0.5;
+export const TIMEOUT_COMPACTION_THRESHOLD = 0.65;
+
+export function estimateTokens(text: string): number {
+  return Math.ceil((text.length / CHARS_PER_TOKEN) * SAFETY_MARGIN);
+}
+
+export function estimateMessagesTokens(messages: ModelMessage[]): number {
+  return messages.reduce(
+    (sum, m) => sum + estimateTokens(typeof m.content === "string" ? m.content : ""),
+    0,
+  );
+}
+
+export function shouldCompact(params: {
+  messages: ModelMessage[];
+  systemPrompt: string;
+  contextWindowTokens: number;
+}): boolean {
+  const estimated =
+    estimateMessagesTokens(params.messages) + estimateTokens(params.systemPrompt);
+  const budget = params.contextWindowTokens - RESERVE_TOKENS;
+  return estimated > budget;
+}
+
+export function isContextOverflowError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  const msg = err.message.toLowerCase();
+  return (
+    msg.includes("context_length") ||
+    msg.includes("context window") ||
+    msg.includes("maximum context") ||
+    msg.includes("token limit") ||
+    msg.includes("too many tokens") ||
+    msg.includes("content_too_large")
+  );
+}
+
+export function isTimeoutError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  const msg = err.message.toLowerCase();
+  return (
+    msg.includes("timeout") ||
+    msg.includes("timed out") ||
+    msg.includes("deadline exceeded") ||
+    err.name === "TimeoutError" ||
+    ("code" in err && (err as { code: string }).code === "ETIMEDOUT")
+  );
+}

--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -23,6 +23,18 @@ import type { IntervalsClient } from "intervals-icu-api";
 const daysEnum = z.enum(["mon", "tue", "wed", "thu", "fri", "sat", "sun"]);
 
 // ============================================================================
+// SHARED TOOL FACTORIES
+// ============================================================================
+
+export function createMemoryReadTool(memory: Memory) {
+  return tool({
+    description: "Read long-term athlete memory, today's notes, and current plan state",
+    inputSchema: zodSchema(z.object({})),
+    execute: async () => memory.getContext() || "No athlete data stored yet.",
+  });
+}
+
+// ============================================================================
 // TOOL BUILDER
 // ============================================================================
 
@@ -139,11 +151,7 @@ export function createTools(memory: Memory, intervals: IntervalsClient | null) {
 
     // ── Memory tools ─────────────────────────────────────────────────────
 
-    memory_read: tool({
-      description: "Read long-term athlete memory, today's notes, and current plan state",
-      inputSchema: zodSchema(z.object({})),
-      execute: async () => memory.getContext() || "No athlete data stored yet.",
-    }),
+    memory_read: createMemoryReadTool(memory),
 
     memory_write: tool({
       description: "Write to long-term memory (athlete facts, goals, preferences) or daily notes",

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -11,6 +11,11 @@ export function createTelegramBot(token: string, agent: CyclingCoachAgent): Bot 
   // ── Commands ────────────────────────────────────────────────────────────
 
   bot.command("start", async (ctx) => {
+    try {
+      await agent.resetSession(`telegram:${ctx.chat.id}`);
+    } catch (err) {
+      console.error("Error resetting session:", err);
+    }
     await ctx.reply(
       "Welcome to Cycling Coach!\n\n" +
         "I'm your AI cycling coach. I can build training plans, suggest workouts, " +
@@ -26,73 +31,131 @@ export function createTelegramBot(token: string, agent: CyclingCoachAgent): Bot 
 
   bot.command("plan", async (ctx) => {
     await ctx.reply("Analyzing your data and building a plan...");
-    const response = await agent.chat(
-      "Generate a training plan for me. Fetch my athlete data first, " +
-        "then build a periodized plan skeleton based on my profile. " +
-        "Show me the plan summary and ask if I want to push it to my calendar.",
-    );
-    await sendLongMessage(ctx, response);
+    const chatId = `telegram:${ctx.chat.id}`;
+    try {
+      const response = await agent.chat(chatId, "/plan");
+      await sendLongMessage(ctx, response);
+    } catch (err) {
+      console.error("Error in /plan:", err);
+      await ctx.reply("Sorry, something went wrong generating your plan. Please try again.");
+    }
   });
 
   bot.command("workout", async (ctx) => {
     await ctx.reply("Checking your form and plan...");
-    const response = await agent.chat(
-      "What should my workout be today? Check my current form (CTL/ATL/TSB), " +
-        "look at what phase I'm in, and suggest an appropriate workout. " +
-        "Include the structured intervals and estimated TSS.",
-    );
-    await sendLongMessage(ctx, response);
+    const chatId = `telegram:${ctx.chat.id}`;
+    try {
+      const response = await agent.chat(chatId, "/workout");
+      await sendLongMessage(ctx, response);
+    } catch (err) {
+      console.error("Error in /workout:", err);
+      await ctx.reply("Sorry, something went wrong. Please try again.");
+    }
   });
 
   bot.command("status", async (ctx) => {
     await ctx.reply("Fetching your fitness data...");
-    const response = await agent.chat(
-      "Show me my current training status. Fetch my wellness data for the last 2 weeks. " +
-        "Show CTL (fitness), ATL (fatigue), TSB (form), and any trends. " +
-        "Give me a coaching note about my current readiness.",
-    );
-    await sendLongMessage(ctx, response);
+    const chatId = `telegram:${ctx.chat.id}`;
+    try {
+      const response = await agent.chat(chatId, "/status");
+      await sendLongMessage(ctx, response);
+    } catch (err) {
+      console.error("Error in /status:", err);
+      await ctx.reply("Sorry, something went wrong. Please try again.");
+    }
   });
 
   bot.command("sync", async (ctx) => {
     await ctx.reply("Syncing plan to calendar...");
-    const response = await agent.chat(
-      "Load my current plan and sync the next 1-2 weeks of workouts to my " +
-        "intervals.icu calendar. Confirm what was pushed.",
-    );
-    await sendLongMessage(ctx, response);
+    const chatId = `telegram:${ctx.chat.id}`;
+    try {
+      const response = await agent.chat(chatId, "/sync");
+      await sendLongMessage(ctx, response);
+    } catch (err) {
+      console.error("Error in /sync:", err);
+      await ctx.reply("Sorry, something went wrong. Please try again.");
+    }
   });
 
   // ── Free-form chat ──────────────────────────────────────────────────────
 
   bot.on("message:text", async (ctx) => {
-    const response = await agent.chat(ctx.message.text);
-    await sendLongMessage(ctx, response);
+    const chatId = `telegram:${ctx.chat.id}`;
+    try {
+      const response = await agent.chat(chatId, ctx.message.text);
+      await sendLongMessage(ctx, response);
+    } catch (err) {
+      console.error("Error in chat:", err);
+      await ctx.reply("Sorry, something went wrong. Please try again.");
+    }
   });
 
   return bot;
 }
 
 // ============================================================================
-// HELPERS
+// MARKDOWN → TELEGRAM HTML
+// ============================================================================
+
+function markdownToTelegramHtml(md: string): string {
+  let html = md;
+
+  // Headers: ### Title → <b>Title</b>
+  html = html.replace(/^#{1,6}\s+(.+)$/gm, "<b>$1</b>");
+
+  // Bold: **text** → <b>text</b>
+  html = html.replace(/\*\*(.+?)\*\*/g, "<b>$1</b>");
+
+  // Italic: *text* or _text_ → <i>text</i>
+  html = html.replace(/(?<!\w)\*([^*]+?)\*(?!\w)/g, "<i>$1</i>");
+  html = html.replace(/(?<!\w)_([^_]+?)_(?!\w)/g, "<i>$1</i>");
+
+  // Inline code: `text` → <code>text</code>
+  html = html.replace(/`([^`]+?)`/g, "<code>$1</code>");
+
+  // Code blocks: ```...``` → <pre>...</pre>
+  html = html.replace(/```[\w]*\n?([\s\S]*?)```/g, "<pre>$1</pre>");
+
+  // Strikethrough: ~~text~~ → <s>text</s>
+  html = html.replace(/~~(.+?)~~/g, "<s>$1</s>");
+
+  // Bullet points: - item → • item
+  html = html.replace(/^[-*]\s+/gm, "• ");
+
+  // Escape remaining HTML-special chars (but not our tags)
+  html = html.replace(/&(?!amp;|lt;|gt;)/g, "&amp;");
+  html = html.replace(/<(?!\/?(?:b|i|u|s|code|pre)>)/g, "&lt;");
+
+  return html;
+}
+
+// ============================================================================
+// SEND WITH CHUNKING
 // ============================================================================
 
 const TELEGRAM_MAX_LENGTH = 4096;
 
 async function sendLongMessage(
-  ctx: { reply: (text: string) => Promise<unknown> },
+  ctx: { reply: (text: string, options?: Record<string, unknown>) => Promise<unknown> },
   text: string,
 ): Promise<void> {
-  if (text.length <= TELEGRAM_MAX_LENGTH) {
-    await ctx.reply(text);
+  const html = markdownToTelegramHtml(text);
+
+  if (html.length <= TELEGRAM_MAX_LENGTH) {
+    await ctx.reply(html, { parse_mode: "HTML" });
     return;
   }
 
-  // Split on paragraph boundaries
+  // Split on paragraph boundaries, hard-split lines that exceed the limit
   const chunks: string[] = [];
   let current = "";
-  for (const line of text.split("\n")) {
-    if (current.length + line.length + 1 > TELEGRAM_MAX_LENGTH) {
+  for (const line of html.split("\n")) {
+    if (line.length > TELEGRAM_MAX_LENGTH) {
+      if (current) { chunks.push(current); current = ""; }
+      for (let i = 0; i < line.length; i += TELEGRAM_MAX_LENGTH) {
+        chunks.push(line.slice(i, i + TELEGRAM_MAX_LENGTH));
+      }
+    } else if (current.length + line.length + 1 > TELEGRAM_MAX_LENGTH) {
       chunks.push(current);
       current = line;
     } else {
@@ -102,6 +165,6 @@ async function sendLongMessage(
   if (current) chunks.push(current);
 
   for (const chunk of chunks) {
-    await ctx.reply(chunk);
+    await ctx.reply(chunk, { parse_mode: "HTML" });
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -20,6 +20,13 @@ export interface Config {
   telegram: {
     botToken: string;
   };
+  session: {
+    historyLimit: number;
+    idleMinutes: number;
+    dailyResetHour: number;
+    channels: Record<string, { historyLimit?: number }>;
+  };
+  contextWindowTokens: number;
   dataDir: string;
 }
 
@@ -36,8 +43,48 @@ function loadYamlConfig(): Record<string, unknown> {
   return (parseYaml(raw) as Record<string, unknown>) ?? {};
 }
 
+// ============================================================================
+// CONTEXT WINDOW RESOLUTION
+// ============================================================================
+
+const CONTEXT_WINDOWS: Record<string, number> = {
+  "claude-sonnet-4-5-20241022": 200_000,
+  "gpt-4o": 128_000,
+  "gemini-2.0-flash": 1_000_000,
+};
+
+function resolveContextWindowTokens(model: string): number {
+  const envTokens = parseInt(process.env.CONTEXT_WINDOW_TOKENS ?? "", 10);
+  if (envTokens > 0) return envTokens;
+
+  const known = CONTEXT_WINDOWS[model];
+  if (known) return known;
+
+  return 200_000;
+}
+
+// ============================================================================
+// HISTORY LIMIT RESOLUTION
+// ============================================================================
+
+export function getHistoryLimit(config: Config, chatId: string): number {
+  const channel = chatId.split(":")[0];
+  return config.session.channels[channel]?.historyLimit ?? config.session.historyLimit;
+}
+
+// ============================================================================
+// CONFIG LOADING
+// ============================================================================
+
 function env(key: string): string | undefined {
   return process.env[key];
+}
+
+function envInt(key: string): number | undefined {
+  const v = process.env[key];
+  if (v === undefined) return undefined;
+  const n = parseInt(v, 10);
+  return Number.isFinite(n) ? n : undefined;
 }
 
 export function loadConfig(): Config {
@@ -45,6 +92,7 @@ export function loadConfig(): Config {
   const llmYaml = (yaml.llm as Record<string, string>) ?? {};
   const intervalsYaml = (yaml.intervals as Record<string, string>) ?? {};
   const telegramYaml = (yaml.telegram as Record<string, string>) ?? {};
+  const sessionYaml = (yaml.session as Record<string, unknown>) ?? {};
 
   const provider = (env("LLM_PROVIDER") ??
     llmYaml.provider ??
@@ -56,16 +104,26 @@ export function loadConfig(): Config {
     google: env("GOOGLE_GENERATIVE_AI_API_KEY") ?? llmYaml.api_key ?? "",
   };
 
-  const modelMap: Record<string, string> = {
-    anthropic: "claude-opus-4-6",
+  const defaultModelMap: Record<string, string> = {
+    anthropic: "claude-sonnet-4-5-20241022",
     openai: "gpt-4o",
     google: "gemini-2.0-flash",
   };
 
+  const model = env("LLM_MODEL") ?? llmYaml.model ?? defaultModelMap[provider];
+
+  const channelsYaml = (sessionYaml.channels as Record<string, Record<string, unknown>>) ?? {};
+  const channels: Record<string, { historyLimit?: number }> = {};
+  for (const [name, ch] of Object.entries(channelsYaml)) {
+    channels[name] = {
+      historyLimit: typeof ch.historyLimit === "number" ? ch.historyLimit : undefined,
+    };
+  }
+
   return {
     llm: {
       provider,
-      model: env("LLM_MODEL") ?? llmYaml.model ?? modelMap[provider],
+      model,
       apiKey: apiKeyMap[provider],
     },
     intervals: {
@@ -75,6 +133,13 @@ export function loadConfig(): Config {
     telegram: {
       botToken: env("TELEGRAM_BOT_TOKEN") ?? telegramYaml.bot_token ?? "",
     },
+    session: {
+      historyLimit: envInt("SESSION_HISTORY_LIMIT") ?? (sessionYaml.historyLimit as number) ?? 20,
+      idleMinutes: envInt("SESSION_IDLE_MINUTES") ?? (sessionYaml.idleMinutes as number) ?? 0,
+      dailyResetHour: envInt("SESSION_DAILY_RESET_HOUR") ?? (sessionYaml.dailyResetHour as number) ?? 4,
+      channels,
+    },
+    contextWindowTokens: resolveContextWindowTokens(model),
     dataDir: (yaml.data_dir as string) ?? CONFIG_DIR,
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,7 +47,7 @@ async function main() {
       }
 
       try {
-        const response = await agent.chat(input);
+        const response = await agent.chat("cli", input);
         console.log("\n" + response + "\n");
       } catch (err) {
         console.error("Error:", err);


### PR DESCRIPTION
## Summary
- Add persistent chat history (JSONL per session), daily/idle session reset, and per-session locking
- Add context window compaction with memory flush before summarization to handle long conversations
- Add Telegram markdown-to-HTML formatting and error handling for all commands
- Add CONTRIBUTING.md with branch naming, PR, and commit conventions

## Test plan
- [ ] Verify session persistence across bot restarts (`~/.cycling-coach/sessions/`)
- [ ] Test daily reset by setting `SESSION_DAILY_RESET_HOUR` to current hour
- [ ] Test idle timeout with `SESSION_IDLE_MINUTES=1`
- [ ] Verify memory flush extracts athlete details before session reset
- [ ] Confirm Telegram messages render bold, italic, and code blocks correctly
- [ ] Run endurance test: `npx tsx --env-file=.env tests/endurance-test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)