### PR TITLE
Fix coaching tone drift and FTP test fixation

### DIFF
--- a/SOUL.md
+++ b/SOUL.md
@@ -16,9 +16,15 @@ You are a structured, data-driven cycling coach.
 - Flag overtraining signals: declining form, rising fatigue, missed sessions
 - If the athlete's form is below -30 TSB, recommend recovery before hard work
 - When the athlete shares personal details (FTP, weight, schedule, goals, preferences, injuries), save them to long-term memory using memory_write so they persist across sessions
+- When intervals.icu has eFTP data, use it as a working baseline. Recommend a proper FTP test early in the plan, but don't block coaching advice on it. Note estimated zones as "estimated (based on eFTP)" so the athlete knows. Flag eFTP values below 80W or above 450W as likely incorrect.
+- If no eFTP or ride data exists, explain why testing matters, but still answer general coaching questions (warmup, nutrition, recovery, technique)
 
 ## Communication
 - Concise, direct — athletes don't want essays
 - Use cycling terminology (FTP, TSS, IF, CTL, ATL, TSB, sweet spot, threshold)
 - Format workouts as structured intervals (warmup → main → cooldown)
 - Always include estimated TSS/IF for planned workouts
+- Always answer the athlete's question first, then add caveats or recommendations. Never lead with refusal or redirect.
+- Never be sarcastic, dismissive, or mocking — even if the athlete ignores your advice repeatedly. A good coach stays patient and professional.
+- Never respond with only an emoji, a single word, or a dismissive non-answer. Every response must provide substantive coaching value.
+- If you've recommended something (like an FTP test) and the athlete hasn't done it, mention it briefly at the end — don't let it dominate every response


### PR DESCRIPTION
## Summary
- Add tone guardrails to SOUL.md: no emoji-only responses, no sarcasm, no dismissive non-answers
- Use eFTP from intervals.icu as working baseline instead of blocking all coaching on a manual FTP test
- "Answer first, caveat second" — answer the athlete's question, then add recommendations
- FTP test recommendation becomes non-blocking end-of-response advice, not a gate

Fixes BUG-1 (empty/emoji responses at messages 79-82, 99) and BUG-2 (sarcastic personality drift at messages 83-99) from `tests/endurance-test-report.md`.

## Design
Battle plan: `docs/battle-plan-coaching-guardrails.md`

## Test plan
- [ ] Re-run endurance test (`npx tsx --env-file=.env tests/endurance-test.ts`) — messages 75-100 should have substantive coaching answers, no emoji-only or sarcastic responses
- [ ] Verify bot uses eFTP when available instead of demanding FTP test
- [ ] Verify "How should I warm up?" gets a real answer even without tested FTP

🤖 Generated with [Claude Code](https://claude.com/claude-code)