### PR TITLE
Fix memory duplication with section-based writes

### DIFF
--- a/src/agent/memory-flush.ts
+++ b/src/agent/memory-flush.ts
@@ -14,36 +14,47 @@ export const SOFT_THRESHOLD_RATIO = 0.8;
 // PROMPTS
 // ============================================================================
 
-const MEMORY_FLUSH_SYSTEM_PROMPT = `You are reviewing a conversation to extract and save important information
-before it is summarized. Use the memory_write tool to save any athlete
-details that are not already in memory.`;
+const MEMORY_FLUSH_SYSTEM_PROMPT = `You are reviewing a conversation to extract and save important athlete
+information before it is summarized. Use the memory_write tool to save
+details into the appropriate section. Each section is fully replaced on
+write, so include ALL current facts for that section, not just new ones.`;
 
-const MEMORY_FLUSH_USER_PROMPT = `Review this conversation and save any athlete details not already in
-long-term memory. Focus on:
-- Personal metrics (FTP, weight, max HR, resting HR)
-- Training schedule and availability
-- Goals, target events, and race dates
-- Injuries, limitations, or recovery needs
-- Equipment and trainer/outdoor preferences
-- Past training history and experience level
+const MEMORY_FLUSH_USER_PROMPT = `Review this conversation and save athlete details to structured memory
+sections. First read existing memory with memory_read, then write each
+section that has new or updated information.
 
-Only save facts not already in memory. Use memory_write with type "memory"
-for each distinct piece of information.`;
+Write to these sections using memory_write:
+- "profile": FTP, weight, age, W/kg, experience level, max HR, resting HR
+- "schedule": Training days, availability, weekly structure
+- "goals": Target events, FTP targets, race dates, milestones
+- "equipment": Bikes, trainer, power meter, head unit, indoor setup
+- "health": Injuries, sleep patterns, recovery needs, HRV
+- "preferences": Indoor/outdoor, coaching style, cross-training
+- "notes": Anything else important
+
+For each section you write, include ALL current facts for that section
+(both from memory and from the conversation). This fully replaces the
+section content — omitted facts will be lost.
+
+Only write sections that have new or changed information.`;
 
 // ============================================================================
 // APPEND-ONLY MEMORY WRITE TOOL
 // ============================================================================
 
-function createAppendOnlyMemoryWriteTool(memory: Memory) {
+function createFlushMemoryWriteTool(memory: Memory) {
   return tool({
-    description: "Append to long-term athlete memory (append-only during memory flush)",
+    description: "Write to a memory section (replaces entire section content)",
     inputSchema: zodSchema(
       z.object({
-        content: z.string().describe("The information to save"),
+        section: z
+          .enum(["profile", "schedule", "goals", "equipment", "health", "preferences", "notes"])
+          .describe("Which section to write"),
+        content: z.string().describe("Complete section content — include ALL facts for this section"),
       }),
     ),
-    execute: async (input: { content: string }) => {
-      memory.appendMemory(input.content);
+    execute: async (input: { section: string; content: string }) => {
+      memory.writeSection(input.section, input.content);
       return { saved: true };
     },
   });
@@ -59,7 +70,7 @@ export async function runMemoryFlush(params: {
   memory: Memory;
 }): Promise<void> {
   const flushTools = {
-    memory_write: createAppendOnlyMemoryWriteTool(params.memory),
+    memory_write: createFlushMemoryWriteTool(params.memory),
     memory_read: createMemoryReadTool(params.memory),
   };
 

--- a/src/agent/memory.ts
+++ b/src/agent/memory.ts
@@ -24,6 +24,31 @@ export class Memory {
     return readFileSync(path, "utf-8");
   }
 
+  writeSection(section: string, content: string): void {
+    const path = join(this.memoryDir, "MEMORY.md");
+    const existing = this.readMemory();
+    const marker = `## ${section}`;
+    const newBlock = `${marker}\n${content}\n`;
+
+    if (!existing) {
+      writeFileSync(path, newBlock, "utf-8");
+      return;
+    }
+
+    // Split by section headers, find and replace the matching one
+    const parts = existing.split(/(?=^## )/m);
+    const idx = parts.findIndex((p) => p.startsWith(marker + "\n"));
+
+    if (idx >= 0) {
+      parts[idx] = newBlock;
+      writeFileSync(path, parts.join(""), "utf-8");
+    } else {
+      // No matching section → append at end (preserves legacy content)
+      writeFileSync(path, existing.trimEnd() + "\n\n" + newBlock, "utf-8");
+    }
+  }
+
+  /** @deprecated Use writeSection instead */
   appendMemory(entry: string): void {
     const path = join(this.memoryDir, "MEMORY.md");
     const existing = this.readMemory();

--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -154,18 +154,27 @@ export function createTools(memory: Memory, intervals: IntervalsClient | null) {
     memory_read: createMemoryReadTool(memory),
 
     memory_write: tool({
-      description: "Write to long-term memory (athlete facts, goals, preferences) or daily notes",
+      description:
+        "Write to long-term memory (replaces section content) or daily notes. " +
+        "Use sections to organize athlete data: profile (FTP, weight, age, experience), " +
+        "schedule (training days, availability), goals (target events, FTP targets), " +
+        "equipment (bikes, trainer, power meter), health (injuries, HR, sleep), " +
+        "preferences (indoor/outdoor, coaching style), notes (anything else).",
       inputSchema: zodSchema(
         z.object({
           type: z
             .enum(["memory", "daily"])
             .describe("'memory' for long-term facts, 'daily' for today's notes"),
+          section: z
+            .enum(["profile", "schedule", "goals", "equipment", "health", "preferences", "notes"])
+            .optional()
+            .describe("Memory section to write to (required when type='memory'). Replaces the section content."),
           content: z.string().describe("The information to save"),
         }),
       ),
-      execute: async (input: { type: "memory" | "daily"; content: string }) => {
+      execute: async (input: { type: "memory" | "daily"; section?: string; content: string }) => {
         if (input.type === "memory") {
-          memory.appendMemory(input.content);
+          memory.writeSection(input.section ?? "notes", input.content);
         } else {
           memory.appendDailyNote(input.content);
         }


### PR DESCRIPTION
## Summary
- Replace blind `appendMemory` with `writeSection` — each section (Profile, Schedule, Goals, Equipment, Health, Preferences, Notes) is fully replaced on write, not appended
- Update both write paths: agent `memory_write` tool and `runMemoryFlush` pipeline
- Flush prompt updated to instruct LLM to organize by section and include ALL current facts per section
- Saves ~875 tokens per request (5KB → ~1.5KB MEMORY.md)

Fixes BUG-4 (memory duplication) from `.tests/endurance-test-report.md`.

## Design
Battle plan: `docs/battle-plan-memory-dedup.md`
Verified with `/verify-battle-plan` — caught and fixed a regex bug before shipping.

## Test plan
- [ ] Write same section 5 times → file size stays constant (idempotent)
- [ ] Write different sections → all sections present, no cross-contamination
- [ ] Multiline section content fully replaced on update (no leftover lines)
- [ ] Legacy MEMORY.md without markers preserved on first structured write
- [ ] `memory_write` with `type: "daily"` still appends to daily notes