### PR TITLE
test(intervals): add MSW mocks for intervals.icu API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
       },
       "devDependencies": {
         "@types/node": "^25.6.0",
+        "msw": "^2.13.3",
         "oxfmt": "^0.45.0",
         "oxlint": "^1.60.0",
         "tsx": "^4.21.0",
@@ -583,12 +584,118 @@
       "integrity": "sha512-jlnyfxfev/2o68HlvAGRocAXgdPPX5QabG7jZlbqC2r9DZyWBfzTlg+nu3O3Fy4EhgLWu28hZ/8wr7DsNamP9A==",
       "license": "MIT"
     },
+    "node_modules/@inquirer/ansi": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.2.tgz",
+      "integrity": "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "5.1.21",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.21.tgz",
+      "integrity": "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "10.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.2.tgz",
+      "integrity": "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^2.0.0",
+        "signal-exit": "^4.1.0",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
+      "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.10.tgz",
+      "integrity": "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.41.3",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.3.tgz",
+      "integrity": "sha512-cXu86tF4VQVfwz8W1SPbhoRyHJkti6mjH/XJIxp40jhO4j2k1m4KYrEykxqWPkFF3vrK4rgQppBh//AwyGSXPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.3",
@@ -608,6 +715,31 @@
         "@emnapi/core": "^1.7.1",
         "@emnapi/runtime": "^1.7.1"
       }
+    },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.0",
@@ -1497,6 +1629,29 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
       "version": "1.0.0-rc.15",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
@@ -1590,6 +1745,13 @@
       "dependencies": {
         "undici-types": "~7.19.0"
       }
+    },
+    "node_modules/@types/statuses": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
+      "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@vercel/oidc": {
       "version": "3.1.0",
@@ -1743,6 +1905,32 @@
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1763,12 +1951,89 @@
         "node": ">=18"
       }
     },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -1796,6 +2061,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-module-lexer": {
       "version": "2.0.0",
@@ -1844,6 +2116,16 @@
         "@esbuild/win32-arm64": "0.27.7",
         "@esbuild/win32-ia32": "0.27.7",
         "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/estree-walker": {
@@ -1917,6 +2199,16 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/get-tsconfig": {
       "version": "4.13.7",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
@@ -1945,6 +2237,23 @@
         "node": "^12.20.0 || >=14.13.1"
       }
     },
+    "node_modules/graphql": {
+      "version": "16.13.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.2.tgz",
+      "integrity": "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
+    "node_modules/headers-polyfill": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.3.tgz",
+      "integrity": "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/intervals-icu-api": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/intervals-icu-api/-/intervals-icu-api-0.1.2.tgz",
@@ -1957,6 +2266,23 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-schema": {
       "version": "0.4.0",
@@ -2241,6 +2567,62 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/msw": {
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.13.3.tgz",
+      "integrity": "sha512-/F49bxavkNGfreMlrKmTxZs6YorjfMbbDLd89Q3pWi+cXGtQQNXXaHt4MkXN7li91xnQJ24HWXqW9QDm5id33w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@inquirer/confirm": "^5.0.0",
+        "@mswjs/interceptors": "^0.41.2",
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@types/statuses": "^2.0.6",
+        "cookie": "^1.0.2",
+        "graphql": "^16.12.0",
+        "headers-polyfill": "^4.0.2",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "path-to-regexp": "^6.3.0",
+        "picocolors": "^1.1.1",
+        "rettime": "^0.11.7",
+        "statuses": "^2.0.2",
+        "strict-event-emitter": "^0.5.1",
+        "tough-cookie": "^6.0.0",
+        "type-fest": "^5.2.0",
+        "until-async": "^3.0.2",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "msw": "cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mswjs"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.8.x"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mute-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -2304,6 +2686,13 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/openapi-typescript-helpers/-/openapi-typescript-helpers-0.1.0.tgz",
       "integrity": "sha512-OKTGPthhivLw/fHz6c3OPtg72vi86qaMlqbJuVJ23qOvQ+53uw1n7HdmkJFibloF7QEjDrDkzJiOJuockM/ljw==",
+      "license": "MIT"
+    },
+    "node_modules/outvariant": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/oxfmt": {
@@ -2391,6 +2780,13 @@
         }
       }
     },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -2448,6 +2844,16 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
@@ -2457,6 +2863,13 @@
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
+    },
+    "node_modules/rettime": {
+      "version": "0.11.7",
+      "resolved": "https://registry.npmjs.org/rettime/-/rettime-0.11.7.tgz",
+      "integrity": "sha512-DoAm1WjR1eH7z8sHPtvvUMIZh4/CSKkGCz6CxPqOrEAnOGtOuHSnSE9OC+razqxKuf4ub7pAYyl/vZV0vGs5tg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/rolldown": {
       "version": "1.0.0-rc.15",
@@ -2499,6 +2912,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2516,12 +2942,70 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/std-env": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
       "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -2577,6 +3061,39 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
+      "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.28"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
+      "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -2612,6 +3129,22 @@
         "fsevents": "~2.3.3"
       }
     },
+    "node_modules/type-fest": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.5.0.tgz",
+      "integrity": "sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/typescript": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
@@ -2633,6 +3166,16 @@
       "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/until-async": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/until-async/-/until-async-3.0.2.tgz",
+      "integrity": "sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/kettanaito"
+      }
     },
     "node_modules/valibot": {
       "version": "1.3.1",
@@ -2850,6 +3393,31 @@
         "node": ">=8"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yaml": {
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
@@ -2864,6 +3432,48 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yoctocolors-cjs": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
+      "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/zod": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@ai-sdk/openai": "^3.0.52",
         "ai": "^6.0.158",
         "grammy": "^1.42.0",
-        "intervals-icu-api": "^0.1.1",
+        "intervals-icu-api": "^0.1.2",
         "yaml": "^2.8.3",
         "zod": "^4.3.6"
       },

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@ai-sdk/openai": "^3.0.52",
     "ai": "^6.0.158",
     "grammy": "^1.42.0",
-    "intervals-icu-api": "^0.1.1",
+    "intervals-icu-api": "^0.1.2",
     "yaml": "^2.8.3",
     "zod": "^4.3.6"
   },

--- a/package.json
+++ b/package.json
@@ -15,22 +15,23 @@
     "check": "tsc --noEmit && oxlint src/ tests/"
   },
   "dependencies": {
-    "ai": "^6.0.158",
     "@ai-sdk/anthropic": "^3.0.69",
-    "@ai-sdk/openai": "^3.0.52",
     "@ai-sdk/google": "^3.0.63",
-    "intervals-icu-api": "^0.1.1",
+    "@ai-sdk/openai": "^3.0.52",
+    "ai": "^6.0.158",
     "grammy": "^1.42.0",
-    "zod": "^4.3.6",
-    "yaml": "^2.8.3"
+    "intervals-icu-api": "^0.1.1",
+    "yaml": "^2.8.3",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
-    "typescript": "^6.0.2",
-    "tsx": "^4.21.0",
-    "vitest": "^4.1.4",
     "@types/node": "^25.6.0",
+    "msw": "^2.13.3",
+    "oxfmt": "^0.45.0",
     "oxlint": "^1.60.0",
-    "oxfmt": "^0.45.0"
+    "tsx": "^4.21.0",
+    "typescript": "^6.0.2",
+    "vitest": "^4.1.4"
   },
   "engines": {
     "node": ">=20"

--- a/tests/helpers/mock-intervals.ts
+++ b/tests/helpers/mock-intervals.ts
@@ -1,0 +1,360 @@
+/**
+ * MSW mock server for intervals.icu API.
+ *
+ * Intercepts fetch calls to https://intervals.icu so tests run without
+ * hitting the real API.  Exports a factory that returns the server plus
+ * a mutable array of every workout POSTed via the events endpoint.
+ *
+ * Usage:
+ *   const { server, createdWorkouts } = createMockIntervalsServer();
+ *   server.listen({ onUnhandledRequest: "bypass" });
+ *   // ... run agent ...
+ *   server.close();
+ *   console.log(createdWorkouts); // inspect created workouts
+ */
+
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface MockAthlete {
+  id: string;
+  icu_ftp: number;
+  icu_weight: number;
+  max_hr: number;
+  icu_resting_hr: number;
+  name: string;
+  email: string;
+  sex: string;
+  city: string;
+  country: string;
+  bio: string;
+  locale: string;
+  date_of_birth: string;
+  sport_settings: SportSetting[];
+  [key: string]: unknown;
+}
+
+interface SportSetting {
+  types: string[];
+  ftp: number;
+  ftp_type: string;
+  lthr: number;
+  max_hr: number;
+  resting_hr: number;
+  weight: number;
+  power_zones: PowerZone[];
+  hr_zones: HrZone[];
+}
+
+interface PowerZone {
+  name: string;
+  min: number;
+  max: number;
+}
+
+interface HrZone {
+  name: string;
+  min: number;
+  max: number;
+}
+
+export interface MockActivity {
+  id: number;
+  start_date_local: string;
+  name: string;
+  type: string;
+  moving_time: number;
+  elapsed_time: number;
+  distance: number;
+  icu_training_load: number;
+  icu_intensity: number;
+  average_watts: number;
+  average_heartrate: number;
+  max_heartrate: number;
+  total_elevation_gain: number;
+  [key: string]: unknown;
+}
+
+export interface MockWellness {
+  id: string;
+  ctl: number;
+  atl: number;
+  rampRate: number;
+  ctlLoad: number;
+  atlLoad: number;
+  sportInfo: Record<string, unknown>;
+  weight: number;
+  restingHR: number;
+  hrv: number;
+  hrvSDNN: number;
+  sleepSecs: number;
+  sleepQuality: number;
+  [key: string]: unknown;
+}
+
+export interface CreatedWorkout {
+  id: number;
+  start_date_local: string;
+  category: string;
+  name: string;
+  type: string;
+  moving_time: number;
+  icu_training_load?: number;
+  description?: string;
+  [key: string]: unknown;
+}
+
+export interface MockIntervalsOptions {
+  athlete?: Partial<MockAthlete>;
+  activities?: Partial<MockActivity>[];
+  wellness?: Partial<MockWellness>[];
+}
+
+// ---------------------------------------------------------------------------
+// Default data factories
+// ---------------------------------------------------------------------------
+
+function defaultAthlete(overrides: Partial<MockAthlete> = {}): MockAthlete {
+  const ftp = overrides.icu_ftp ?? 200;
+  const maxHr = overrides.max_hr ?? 190;
+  const restHr = overrides.icu_resting_hr ?? 52;
+  const weight = overrides.icu_weight ?? 75;
+
+  return {
+    id: "i12345",
+    name: "Test Athlete",
+    email: "test@example.com",
+    sex: "M",
+    city: "Test City",
+    country: "US",
+    bio: "",
+    locale: "en",
+    date_of_birth: "1992-06-15",
+    icu_ftp: ftp,
+    icu_weight: weight,
+    max_hr: maxHr,
+    icu_resting_hr: restHr,
+    sport_settings: [
+      {
+        types: ["Ride", "VirtualRide"],
+        ftp,
+        ftp_type: "POWER",
+        lthr: Math.round(maxHr * 0.82),
+        max_hr: maxHr,
+        resting_hr: restHr,
+        weight,
+        power_zones: [
+          { name: "Z1 Recovery", min: 0, max: Math.round(ftp * 0.55) },
+          { name: "Z2 Endurance", min: Math.round(ftp * 0.55), max: Math.round(ftp * 0.75) },
+          { name: "Z3 Tempo", min: Math.round(ftp * 0.75), max: Math.round(ftp * 0.9) },
+          { name: "Z4 Threshold", min: Math.round(ftp * 0.9), max: Math.round(ftp * 1.05) },
+          { name: "Z5 VO2max", min: Math.round(ftp * 1.05), max: Math.round(ftp * 1.2) },
+          { name: "Z6 Anaerobic", min: Math.round(ftp * 1.2), max: Math.round(ftp * 1.5) },
+          { name: "Z7 Neuromuscular", min: Math.round(ftp * 1.5), max: 2000 },
+        ],
+        hr_zones: [
+          { name: "Z1", min: restHr, max: Math.round(restHr + (maxHr - restHr) * 0.6) },
+          { name: "Z2", min: Math.round(restHr + (maxHr - restHr) * 0.6), max: Math.round(restHr + (maxHr - restHr) * 0.7) },
+          { name: "Z3", min: Math.round(restHr + (maxHr - restHr) * 0.7), max: Math.round(restHr + (maxHr - restHr) * 0.8) },
+          { name: "Z4", min: Math.round(restHr + (maxHr - restHr) * 0.8), max: Math.round(restHr + (maxHr - restHr) * 0.9) },
+          { name: "Z5", min: Math.round(restHr + (maxHr - restHr) * 0.9), max: maxHr },
+        ],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function defaultActivities(overrides?: Partial<MockActivity>[]): MockActivity[] {
+  if (overrides) {
+    return overrides.map((o, i) => ({
+      id: i + 1000,
+      start_date_local: o.start_date_local ?? isoDateNDaysAgo(14 - i),
+      name: o.name ?? "Ride",
+      type: "Ride",
+      moving_time: 3600,
+      elapsed_time: 4000,
+      distance: 30000,
+      icu_training_load: 60,
+      icu_intensity: 0.7,
+      average_watts: 155,
+      average_heartrate: 138,
+      max_heartrate: 170,
+      total_elevation_gain: 200,
+      ...o,
+    }));
+  }
+
+  // Generate ~10 realistic recent rides over the past 14 days
+  const rides: MockActivity[] = [
+    ride(1001, 1, "Recovery Spin", 2700, 40, 120, 115, 135),
+    ride(1002, 2, "Sweet Spot Intervals", 5400, 85, 185, 152, 175),
+    ride(1003, 4, "Zone 2 Endurance", 7200, 65, 150, 135, 155),
+    ride(1004, 5, "VO2max Intervals", 4800, 95, 210, 158, 185),
+    ride(1005, 7, "Long Ride", 9000, 110, 148, 138, 168),
+    ride(1006, 8, "Recovery Spin", 2700, 38, 118, 112, 130),
+    ride(1007, 9, "Tempo Ride", 5400, 78, 168, 148, 170),
+    ride(1008, 11, "Sweet Spot 2x20", 5400, 88, 182, 155, 178),
+    ride(1009, 12, "Zone 2 Endurance", 6300, 58, 148, 132, 152),
+    ride(1010, 13, "Group Ride", 7200, 100, 175, 150, 188),
+  ];
+  return rides;
+}
+
+function ride(
+  id: number,
+  daysAgo: number,
+  name: string,
+  movingTime: number,
+  tss: number,
+  avgWatts: number,
+  avgHr: number,
+  maxHr: number,
+): MockActivity {
+  return {
+    id,
+    start_date_local: `${isoDateNDaysAgo(daysAgo)}T08:00:00`,
+    name,
+    type: "Ride",
+    moving_time: movingTime,
+    elapsed_time: Math.round(movingTime * 1.12),
+    distance: Math.round((movingTime / 3600) * 28 * 1000), // ~28 km/h average
+    icu_training_load: tss,
+    icu_intensity: Math.round((tss / (movingTime / 3600)) * 0.01 * 100) / 100,
+    average_watts: avgWatts,
+    average_heartrate: avgHr,
+    max_heartrate: maxHr,
+    total_elevation_gain: Math.round((movingTime / 3600) * 150),
+  };
+}
+
+function defaultWellness(overrides?: Partial<MockWellness>[]): MockWellness[] {
+  if (overrides) {
+    return overrides.map((o, i) => ({
+      id: isoDateNDaysAgo(7 - i),
+      ctl: 55,
+      atl: 48,
+      rampRate: 0.5,
+      ctlLoad: 55,
+      atlLoad: 48,
+      sportInfo: {},
+      weight: 75,
+      restingHR: 52,
+      hrv: 45,
+      hrvSDNN: 48,
+      sleepSecs: 27000,
+      sleepQuality: 3,
+      ...o,
+    }));
+  }
+
+  // 7 days of wellness data with slight daily variation
+  return Array.from({ length: 7 }, (_, i) => {
+    const day = 7 - i;
+    const ctlBase = 55;
+    const atlBase = 48;
+    return {
+      id: isoDateNDaysAgo(day),
+      ctl: ctlBase + Math.round((Math.sin(i * 0.8) * 2) * 10) / 10,
+      atl: atlBase + Math.round((Math.sin(i * 1.2) * 4) * 10) / 10,
+      rampRate: Math.round((0.3 + Math.sin(i * 0.5) * 0.3) * 10) / 10,
+      ctlLoad: ctlBase + Math.round(Math.sin(i * 0.8) * 2 * 10) / 10,
+      atlLoad: atlBase + Math.round(Math.sin(i * 1.2) * 4 * 10) / 10,
+      sportInfo: {},
+      weight: 75 + Math.round(Math.sin(i * 0.7) * 0.3 * 10) / 10,
+      restingHR: 50 + Math.round(Math.random() * 4),
+      hrv: 42 + Math.round(Math.random() * 8),
+      hrvSDNN: 45 + Math.round(Math.random() * 10),
+      sleepSecs: 25200 + Math.round(Math.random() * 3600),
+      sleepQuality: 3,
+    };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function isoDateNDaysAgo(n: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() - n);
+  return d.toISOString().slice(0, 10);
+}
+
+// ---------------------------------------------------------------------------
+// Server factory
+// ---------------------------------------------------------------------------
+
+export function createMockIntervalsServer(options: MockIntervalsOptions = {}) {
+  const athlete = defaultAthlete(options.athlete);
+  const activities = defaultActivities(options.activities);
+  const wellness = defaultWellness(options.wellness);
+  const createdWorkouts: CreatedWorkout[] = [];
+  let nextEventId = 5000;
+
+  const handlers = [
+    // GET /api/v1/athlete/:id — athlete profile
+    http.get("https://intervals.icu/api/v1/athlete/:id", () => {
+      return HttpResponse.json(athlete);
+    }),
+
+    // GET /api/v1/athlete/:id/activities — recent activities
+    http.get("https://intervals.icu/api/v1/athlete/:id/activities", ({ request }) => {
+      const url = new URL(request.url);
+      const oldest = url.searchParams.get("oldest");
+      const newest = url.searchParams.get("newest");
+
+      let filtered = activities;
+      if (oldest) {
+        filtered = filtered.filter((a) => a.start_date_local >= oldest);
+      }
+      if (newest) {
+        filtered = filtered.filter((a) => a.start_date_local <= newest + "T23:59:59");
+      }
+      return HttpResponse.json(filtered);
+    }),
+
+    // GET /api/v1/athlete/:id/wellness — wellness/fitness data
+    http.get("https://intervals.icu/api/v1/athlete/:id/wellness", ({ request }) => {
+      const url = new URL(request.url);
+      const oldest = url.searchParams.get("oldest");
+      const newest = url.searchParams.get("newest");
+
+      let filtered = wellness;
+      if (oldest) {
+        filtered = filtered.filter((w) => w.id >= oldest);
+      }
+      if (newest) {
+        filtered = filtered.filter((w) => w.id <= newest);
+      }
+      return HttpResponse.json(filtered);
+    }),
+
+    // POST /api/v1/athlete/:id/events — create workout
+    http.post("https://intervals.icu/api/v1/athlete/:id/events", async ({ request }) => {
+      const body = (await request.json()) as Record<string, unknown>;
+      const eventId = nextEventId++;
+      const workout: CreatedWorkout = {
+        id: eventId,
+        start_date_local: (body.start_date_local as string) ?? "",
+        category: (body.category as string) ?? "WORKOUT",
+        name: (body.name as string) ?? "",
+        type: (body.type as string) ?? "Ride",
+        moving_time: (body.moving_time as number) ?? 0,
+        icu_training_load: body.icu_training_load as number | undefined,
+        description: body.description as string | undefined,
+        ...body,
+      };
+      createdWorkouts.push(workout);
+      return HttpResponse.json({ id: eventId, ...body }, { status: 200 });
+    }),
+  ];
+
+  const server = setupServer(...handlers);
+
+  return { server, createdWorkouts };
+}


### PR DESCRIPTION
## Summary

- Add `msw` as a dev dependency for mocking HTTP requests in test scenarios
- Add `tests/helpers/mock-intervals.ts` — reusable mock server factory that intercepts intervals.icu API calls
  - Canned athlete profile (FTP, weight, zones), recent activities, and wellness data
  - POST handler captures every created workout for test assertions
  - Configurable via options object with sensible defaults (200W FTP, 75kg, CTL ~55)

Enables test scenarios in `.tests/` to run without hitting the real intervals.icu API. First consumer: structured workouts push scenario (`25msg-structured-workouts-icu.ts`).

## Test plan

- [ ] `npm install` succeeds with new dependency
- [ ] `npx tsx --env-file=.env .tests/scenarios/25msg-structured-workouts-icu.ts` runs with mocked API (no real intervals.icu calls)
- [ ] `createdWorkouts` array captures all POSTed workouts
- [ ] Existing unit tests still pass: `npx vitest run`