### PR TITLE
feat(core): compact summaries with adaptive chunking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ docs/
 .idea/
 scripts/
 .claude
+CLAUDE.local.md
 .tests/

--- a/SOUL.md
+++ b/SOUL.md
@@ -19,14 +19,24 @@ You are a structured, data-driven cycling coach.
 - When intervals.icu has eFTP data, use it as a working baseline. Recommend a proper FTP test early in the plan, but don't block coaching advice on it. Note estimated zones as "estimated (based on eFTP)" so the athlete knows. Flag eFTP values below 80W or above 450W as likely incorrect.
 - If no eFTP or ride data exists, explain why testing matters, but still answer general coaching questions (warmup, nutrition, recovery, technique)
 
+## Response Length
+
+Match response length to question complexity:
+
+- **Quick question** (zone lookup, yes/no, single fact) → 1-3 sentences
+- **Explanation** (how sweet spot works, recovery advice, race tactics) → short paragraph + bullets, stay under 10 bullet points
+- **Workout prescription** → structured interval table only, no essay around it
+- **Training plan** ��� table or phased list, this is the ONE case where longer output is OK
+
+Never pad a short answer with background the athlete didn't ask for. If they ask "what zone is sweet spot?" answer the zone — don't explain the physiology of lactate threshold.
+
 ## Communication
-- Concise, direct — athletes don't want essays
 - If a question has a short answer, give the short answer
 - Use tables and bullet points, not paragraphs
 - Use cycling terminology (FTP, TSS, IF, CTL, ATL, TSB, sweet spot, threshold)
 - Format workouts as structured intervals (warmup → main → cooldown)
 - Always include estimated TSS/IF for planned workouts
-- Always answer the athlete's question first, then add caveats or recommendations. Never lead with refusal or redirect.
-- Never be sarcastic, dismissive, or mocking — even if the athlete ignores your advice repeatedly. A good coach stays patient and professional.
-- Never respond with only an emoji, a single word, or a dismissive non-answer. Every response must provide substantive coaching value.
-- If you've recommended something (like an FTP test) and the athlete hasn't done it, mention it briefly at the end — don't let it dominate every response
+- Answer the athlete's question first, then add caveats briefly. Never lead with refusal or redirect.
+- Stay patient and professional — even if the athlete ignores your advice repeatedly
+- Every response must provide substantive coaching value — no emoji-only or single-word answers
+- If you've recommended something (like an FTP test) and the athlete hasn't done it, mention it once at the end — don't repeat it every response

--- a/SOUL.md
+++ b/SOUL.md
@@ -21,6 +21,8 @@ You are a structured, data-driven cycling coach.
 
 ## Communication
 - Concise, direct — athletes don't want essays
+- If a question has a short answer, give the short answer
+- Use tables and bullet points, not paragraphs
 - Use cycling terminology (FTP, TSS, IF, CTL, ATL, TSB, sweet spot, threshold)
 - Format workouts as structured intervals (warmup → main → cooldown)
 - Always include estimated TSS/IF for planned workouts

--- a/src/agent/chat-store.ts
+++ b/src/agent/chat-store.ts
@@ -1,5 +1,6 @@
 import {
   readFileSync,
+  writeFileSync,
   appendFileSync,
   renameSync,
   existsSync,
@@ -7,9 +8,10 @@ import {
 } from "node:fs";
 import { join } from "node:path";
 import type { ModelMessage } from "ai";
+import { messageText } from "./token-utils.js";
 
 interface JsonlLine {
-  role: "user" | "assistant";
+  role: "user" | "assistant" | "system";
   content: string;
   ts: string;
 }
@@ -26,10 +28,6 @@ export class ChatStore {
     return join(this.sessionsDir, `${chatId}.jsonl`);
   }
 
-  getHistory(chatId: string): ModelMessage[] {
-    return this.load(chatId).messages;
-  }
-
   load(chatId: string): { messages: ModelMessage[]; lastMessageTime: string | null } {
     const path = this.filePath(chatId);
     if (!existsSync(path)) return { messages: [], lastMessageTime: null };
@@ -37,14 +35,20 @@ export class ChatStore {
     const raw = readFileSync(path, "utf-8").trim();
     if (!raw) return { messages: [], lastMessageTime: null };
 
-    const lines = raw.split("\n");
-    const messages = lines.map((line) => {
-      const parsed: JsonlLine = JSON.parse(line);
-      return { role: parsed.role, content: parsed.content } as ModelMessage;
-    });
+    const parsed = raw.split("\n").map((line) => JSON.parse(line) as JsonlLine);
+    const messages = parsed.map(
+      (p) => ({ role: p.role, content: p.content }) as ModelMessage,
+    );
 
-    const lastParsed: JsonlLine = JSON.parse(lines[lines.length - 1]);
-    return { messages, lastMessageTime: lastParsed.ts };
+    let lastMessageTime: string | null = null;
+    for (let i = parsed.length - 1; i >= 0; i--) {
+      if (parsed[i].role !== "system") {
+        lastMessageTime = parsed[i].ts;
+        break;
+      }
+    }
+
+    return { messages, lastMessageTime };
   }
 
   appendMessage(chatId: string, role: "user" | "assistant", content: string): void {
@@ -53,16 +57,22 @@ export class ChatStore {
     appendFileSync(path, JSON.stringify(line) + "\n", "utf-8");
   }
 
-  getLastMessageTime(chatId: string): string | null {
+  overwriteHistory(chatId: string, messages: ModelMessage[]): void {
     const path = this.filePath(chatId);
-    if (!existsSync(path)) return null;
-
-    const raw = readFileSync(path, "utf-8").trim();
-    if (!raw) return null;
-
-    const lines = raw.split("\n");
-    const last: JsonlLine = JSON.parse(lines[lines.length - 1]);
-    return last.ts;
+    const tmpPath = `${path}.tmp`;
+    const now = new Date().toISOString();
+    const content = messages
+      .map((m) => {
+        const line: JsonlLine = {
+          role: m.role as JsonlLine["role"],
+          content: messageText(m),
+          ts: now,
+        };
+        return JSON.stringify(line);
+      })
+      .join("\n") + "\n";
+    writeFileSync(tmpPath, content, "utf-8");
+    renameSync(tmpPath, path);
   }
 
   archiveAndReset(chatId: string): void {

--- a/src/agent/compaction.ts
+++ b/src/agent/compaction.ts
@@ -1,12 +1,31 @@
 import { generateText } from "ai";
 import type { LanguageModel, ModelMessage } from "ai";
-import { estimateTokens, estimateMessagesTokens } from "./token-utils.js";
+import {
+  estimateTokens,
+  estimateMessagesTokens,
+  messageText,
+  SAFETY_MARGIN,
+  MIN_PROMPT_BUDGET_TOKENS,
+  SUMMARIZATION_OVERHEAD_TOKENS,
+} from "./token-utils.js";
+import { makeSummaryMessage } from "./history-limit.js";
 
 // ============================================================================
 // CONSTANTS
 // ============================================================================
 
-export const COMPACTION_CHUNKS = 2;
+const MAX_SUMMARY_CHARS = 4_000;
+const SUMMARY_TRUNCATED_MARKER = "\n\n[Summary truncated]";
+const MAX_SUMMARY_TOKENS = 2048;
+const BASE_CHUNK_RATIO = 0.4;
+const MIN_CHUNK_RATIO = 0.15;
+
+const REQUIRED_SUMMARY_SECTIONS = [
+  "## Athlete Profile",
+  "## Training Status",
+  "## Discussion Context",
+  "## Pending Questions",
+] as const;
 
 // ============================================================================
 // PROMPTS
@@ -26,57 +45,184 @@ dates, distances, durations).
 PRIORITIZE recent context over older history.
 The coach needs to know what was being discussed, not just what topics were covered.`;
 
-const SUMMARIZE_PROMPT = `Summarize the following conversation concisely.
+const SUMMARIZE_PROMPT = `Summarize the following conversation concisely — aim for 300-500 words total.
+Use bullet points, not paragraphs. Omit generic advice that can be re-derived.
+
+Use these exact section headings:
+## Athlete Profile
+## Training Status
+## Discussion Context
+## Pending Questions
 
 ${MUST_PRESERVE}`;
 
-const MERGE_PROMPT = `Merge these partial summaries into a single cohesive summary.
+const DROPPED_MESSAGES_PROMPT = `Incorporate these older conversation messages into the existing summary.
+
+Produce a compact, factual summary — aim for 300-500 words total.
+Use bullet points, not paragraphs. Omit generic advice that can be re-derived.
+
+Use these exact section headings:
+## Athlete Profile
+## Training Status
+## Discussion Context
+## Pending Questions
 
 ${MUST_PRESERVE}`;
 
 // ============================================================================
-// CHUNK SPLITTING
+// HELPERS
 // ============================================================================
 
-export function splitMessagesByTokenShare(
+function formatTranscript(messages: ModelMessage[]): string {
+  return messages.map((m) => `${m.role}: ${messageText(m)}`).join("\n");
+}
+
+function capSummary(summary: string): string {
+  if (summary.length <= MAX_SUMMARY_CHARS) return summary;
+  return summary.slice(0, MAX_SUMMARY_CHARS) + SUMMARY_TRUNCATED_MARKER;
+}
+
+export function computeAdaptiveChunkRatio(
   messages: ModelMessage[],
-  parts: number,
-): ModelMessage[][] {
-  if (messages.length === 0) return [];
-  if (parts <= 1) return [messages];
+  contextWindowTokens: number,
+): number {
+  if (messages.length === 0) return BASE_CHUNK_RATIO;
 
   const totalTokens = estimateMessagesTokens(messages);
-  const targetPerChunk = totalTokens / parts;
+  const avgTokens = totalTokens / messages.length;
+  const safeAvgTokens = avgTokens * SAFETY_MARGIN;
+  const avgRatio = safeAvgTokens / contextWindowTokens;
 
+  if (avgRatio > 0.1) {
+    const reduction = Math.min(avgRatio * 2, BASE_CHUNK_RATIO - MIN_CHUNK_RATIO);
+    return Math.max(MIN_CHUNK_RATIO, BASE_CHUNK_RATIO - reduction);
+  }
+
+  return BASE_CHUNK_RATIO;
+}
+
+export function chunkMessagesByMaxTokens(
+  messages: ModelMessage[],
+  maxTokens: number,
+): ModelMessage[][] {
+  if (messages.length === 0) return [];
+
+  const safeMax = Math.floor(maxTokens / SAFETY_MARGIN);
   const chunks: ModelMessage[][] = [];
   let current: ModelMessage[] = [];
   let currentTokens = 0;
 
-  for (let i = 0; i < messages.length; i++) {
-    const msg = messages[i];
-    const msgTokens = estimateTokens(typeof msg.content === "string" ? msg.content : "");
+  for (const msg of messages) {
+    const msgTokens = estimateTokens(messageText(msg));
 
-    current.push(msg);
-    currentTokens += msgTokens;
-
-    // Check if we should split — but never split in the middle of a user/assistant pair
-    const isAtTurnBoundary =
-      msg.role === "assistant" || i === messages.length - 1;
-    const hasEnoughTokens = currentTokens >= targetPerChunk;
-    const hasMoreChunksNeeded = chunks.length < parts - 1;
-
-    if (isAtTurnBoundary && hasEnoughTokens && hasMoreChunksNeeded) {
+    if (currentTokens + msgTokens > safeMax && current.length > 0) {
       chunks.push(current);
       current = [];
       currentTokens = 0;
     }
+
+    current.push(msg);
+    currentTokens += msgTokens;
   }
 
-  if (current.length > 0) {
-    chunks.push(current);
-  }
-
+  if (current.length > 0) chunks.push(current);
   return chunks;
+}
+
+const DEFAULT_CONTEXT_WINDOW = 200_000;
+
+function computeAdaptiveChunks(
+  messages: ModelMessage[],
+  contextWindowTokens?: number,
+): ModelMessage[][] {
+  if (messages.length === 0) return [];
+  const ctxWindow = contextWindowTokens ?? DEFAULT_CONTEXT_WINDOW;
+  const adaptiveRatio = computeAdaptiveChunkRatio(messages, ctxWindow);
+  const maxChunkTokens = Math.max(
+    MIN_PROMPT_BUDGET_TOKENS,
+    Math.floor(ctxWindow * adaptiveRatio) - SUMMARIZATION_OVERHEAD_TOKENS,
+  );
+  return chunkMessagesByMaxTokens(messages, maxChunkTokens);
+}
+
+// ============================================================================
+// QUALITY AUDIT
+// ============================================================================
+
+export function auditSummaryQuality(summary: string): { ok: boolean; missing: string[] } {
+  const lower = summary.toLowerCase();
+  const missing = REQUIRED_SUMMARY_SECTIONS.filter(
+    (section) => !lower.includes(section.toLowerCase()),
+  );
+  return missing.length === 0 ? { ok: true, missing: [] } : { ok: false, missing };
+}
+
+// ============================================================================
+// DROPPED MESSAGE SUMMARIZATION
+// ============================================================================
+
+export async function summarizeDroppedMessages(params: {
+  dropped: ModelMessage[];
+  model: LanguageModel;
+  previousSummary?: string;
+  maxRetries?: number;
+  contextWindowTokens?: number;
+}): Promise<string> {
+  const { dropped, model, previousSummary, maxRetries = 1, contextWindowTokens } = params;
+
+  if (dropped.length === 0) return previousSummary ?? "";
+
+  const chunks = computeAdaptiveChunks(dropped, contextWindowTokens);
+  // Fallback: if adaptive chunking returns empty (shouldn't happen), use single chunk
+  if (chunks.length === 0) chunks.push(dropped);
+
+  let summary: string | undefined;
+
+  for (const chunk of chunks) {
+    const transcript = formatTranscript(chunk);
+    const prompt = [
+      DROPPED_MESSAGES_PROMPT,
+      (summary ?? previousSummary) ? `\nExisting summary of earlier context:\n${summary ?? previousSummary}` : "",
+      `\nMessages to incorporate:\n${transcript}`,
+    ].join("\n");
+
+    try {
+      const { text } = await generateText({
+        model,
+        prompt,
+        maxOutputTokens: MAX_SUMMARY_TOKENS,
+        maxRetries: 0,
+      });
+      summary = text;
+    } catch (err) {
+      console.warn("Dropped message summarization LLM call failed, using fallback", err);
+    }
+  }
+
+  if (summary === undefined) return capSummary(previousSummary ?? "");
+
+  // Quality guard with retry
+  const audit = auditSummaryQuality(summary);
+  if (audit.ok) return capSummary(summary);
+
+  let best: string = summary;
+  for (let attempt = 0; attempt < maxRetries; attempt++) {
+    try {
+      const { text } = await generateText({
+        model,
+        prompt: `Restructure the following summary to include ALL required section headings: ${audit.missing.join(", ")}.\n\n${best}\n\n${MUST_PRESERVE}`,
+        maxOutputTokens: MAX_SUMMARY_TOKENS,
+        maxRetries: 0,
+      });
+      const retryAudit = auditSummaryQuality(text);
+      if (retryAudit.ok) return capSummary(text);
+      best = text;
+    } catch (err) {
+      console.warn("Dropped message summarization retry failed", err);
+    }
+  }
+
+  return capSummary(best);
 }
 
 // ============================================================================
@@ -87,10 +233,11 @@ export async function summarizeInStages(params: {
   messages: ModelMessage[];
   model: LanguageModel;
   recentToKeep?: number;
+  previousSummary?: string;
+  contextWindowTokens?: number;
 }): Promise<ModelMessage[]> {
-  const { messages, model, recentToKeep = 4 } = params;
+  const { messages, model, recentToKeep = 4, previousSummary, contextWindowTokens } = params;
 
-  // Determine how many recent messages to preserve (keep recent turns intact)
   const keepCount = Math.min(recentToKeep, messages.length);
   const toSummarize = messages.slice(0, messages.length - keepCount);
   const recent = messages.slice(messages.length - keepCount);
@@ -99,42 +246,25 @@ export async function summarizeInStages(params: {
     return messages;
   }
 
-  // Split into chunks
-  const chunks = splitMessagesByTokenShare(toSummarize, COMPACTION_CHUNKS);
+  const chunks = computeAdaptiveChunks(toSummarize, contextWindowTokens);
 
-  // Summarize each chunk
-  const summaries: string[] = [];
+  // Thread previousSummary through chunk loop
+  let summary = previousSummary;
   for (const chunk of chunks) {
-    const transcript = chunk
-      .map((m) => `${m.role}: ${typeof m.content === "string" ? m.content : ""}`)
-      .join("\n");
+    const transcript = formatTranscript(chunk);
+
+    const contextPrefix = summary
+      ? `\nExisting summary of earlier context:\n${summary}\n\n`
+      : "";
 
     const { text } = await generateText({
       model,
-      prompt: `${SUMMARIZE_PROMPT}\n\n${transcript}`,
+      prompt: `${SUMMARIZE_PROMPT}${contextPrefix}\n\n${transcript}`,
+      maxOutputTokens: MAX_SUMMARY_TOKENS,
+      maxRetries: 0,
     });
-    summaries.push(text);
+    summary = capSummary(text);
   }
 
-  // Merge if multiple summaries
-  let finalSummary: string;
-  if (summaries.length === 1) {
-    finalSummary = summaries[0];
-  } else {
-    const numbered = summaries
-      .map((s, i) => `Summary ${i + 1}:\n${s}`)
-      .join("\n\n");
-
-    const { text } = await generateText({
-      model,
-      prompt: `${MERGE_PROMPT}\n\n${numbered}`,
-    });
-    finalSummary = text;
-  }
-
-  // Return summary as system message + recent messages
-  return [
-    { role: "system" as const, content: `[Previous conversation summary]\n${finalSummary}` },
-    ...recent,
-  ];
+  return [makeSummaryMessage(summary!), ...recent];
 }

--- a/src/agent/core.ts
+++ b/src/agent/core.ts
@@ -5,15 +5,15 @@ import { createGoogleGenerativeAI } from "@ai-sdk/google";
 import type { LanguageModel, ModelMessage } from "ai";
 import { IntervalsClient } from "intervals-icu-api";
 import type { Config } from "../config.js";
-import { getHistoryLimit } from "../config.js";
 import { Memory } from "./memory.js";
 import { ChatStore } from "./chat-store.js";
 import { buildSystemPrompt } from "./system-prompt.js";
 import { createTools } from "./tools.js";
 import { withSessionLock } from "./session-lock.js";
-import { limitHistoryTurns } from "./history-limit.js";
+import { splitHistoryByBudget, makeSummaryMessage } from "./history-limit.js";
 import {
   shouldCompact,
+  computeHistoryTokenBudget,
   isContextOverflowError,
   isTimeoutError,
   isRateLimitError,
@@ -21,7 +21,7 @@ import {
   estimateMessagesTokens,
   TIMEOUT_COMPACTION_THRESHOLD,
 } from "./token-utils.js";
-import { summarizeInStages } from "./compaction.js";
+import { summarizeInStages, summarizeDroppedMessages } from "./compaction.js";
 import { runMemoryFlush } from "./memory-flush.js";
 import { evaluateSessionFreshness } from "./session-freshness.js";
 
@@ -87,10 +87,43 @@ export class CyclingCoachAgent {
 
       this.systemPrompt = buildSystemPrompt(this.memory);
 
-      const limited = limitHistoryTurns(history, getHistoryLimit(this.config, chatId));
+      const budget = computeHistoryTokenBudget({
+        contextWindowTokens: this.config.contextWindowTokens,
+        systemPrompt: this.systemPrompt,
+        budgetRatio: this.config.session.historyTokenBudgetRatio,
+      });
+      const { kept, dropped, previousSummary } = splitHistoryByBudget({
+        messages: history,
+        tokenBudget: budget,
+      });
+
+      let summaryMsg: ModelMessage | undefined;
+      if (dropped.length > 0) {
+        try {
+          const summary = await summarizeDroppedMessages({
+            dropped,
+            model: this.model,
+            previousSummary,
+            contextWindowTokens: this.config.contextWindowTokens,
+          });
+          summaryMsg = makeSummaryMessage(summary);
+          this.chatStore.overwriteHistory(chatId, [summaryMsg, ...kept]);
+        } catch (err) {
+          console.warn("Dropped message summarization failed, continuing without summary", err);
+          if (previousSummary) {
+            summaryMsg = makeSummaryMessage(previousSummary);
+          }
+        }
+      } else if (previousSummary) {
+        summaryMsg = makeSummaryMessage(previousSummary);
+      }
 
       // Build messages array with new user message
-      let messages: ModelMessage[] = [...limited, { role: "user", content: userMessage }];
+      let messages: ModelMessage[] = [
+        ...(summaryMsg ? [summaryMsg] : []),
+        ...kept,
+        { role: "user", content: userMessage },
+      ];
 
       let overflowAttempts = 0;
       let timeoutAttempts = 0;
@@ -100,7 +133,7 @@ export class CyclingCoachAgent {
         // Preemptive: compact before sending if over budget
         if (shouldCompact({ messages, systemPrompt: this.systemPrompt, contextWindowTokens: this.config.contextWindowTokens })) {
           await runMemoryFlush({ model: this.model, messages, memory: this.memory });
-          messages = await summarizeInStages({ messages, model: this.model });
+          messages = await summarizeInStages({ messages, model: this.model, contextWindowTokens: this.config.contextWindowTokens });
           this.memory.reload();
         }
 
@@ -124,7 +157,7 @@ export class CyclingCoachAgent {
           if (isContextOverflowError(err) && overflowAttempts < MAX_OVERFLOW_ATTEMPTS) {
             overflowAttempts++;
             await runMemoryFlush({ model: this.model, messages, memory: this.memory });
-            messages = await summarizeInStages({ messages, model: this.model });
+            messages = await summarizeInStages({ messages, model: this.model, contextWindowTokens: this.config.contextWindowTokens });
             this.memory.reload();
             continue;
           }
@@ -133,7 +166,7 @@ export class CyclingCoachAgent {
             const ratio = estimateMessagesTokens(messages) / this.config.contextWindowTokens;
             if (ratio > TIMEOUT_COMPACTION_THRESHOLD) {
               timeoutAttempts++;
-              messages = await summarizeInStages({ messages, model: this.model });
+              messages = await summarizeInStages({ messages, model: this.model, contextWindowTokens: this.config.contextWindowTokens });
               this.memory.reload();
               continue;
             }
@@ -159,8 +192,8 @@ export class CyclingCoachAgent {
   }
 
   async resetSession(chatId: string): Promise<void> {
-    // Memory flush before ANY reset — fixes OpenClaw bug #50891
-    const history = this.chatStore.getHistory(chatId);
+    // Flush before reset to avoid losing un-persisted context
+    const { messages: history } = this.chatStore.load(chatId);
     if (history.length > 0) {
       await runMemoryFlush({ model: this.model, messages: history, memory: this.memory });
     }

--- a/src/agent/history-limit.ts
+++ b/src/agent/history-limit.ts
@@ -1,17 +1,56 @@
 import type { ModelMessage } from "ai";
+import { estimateTokens, estimateMessagesTokens, messageText } from "./token-utils.js";
 
-export function limitHistoryTurns(messages: ModelMessage[], limit: number): ModelMessage[] {
-  if (!limit || limit <= 0 || messages.length === 0) return messages;
-  let userCount = 0;
-  let lastUserIndex = messages.length;
-  for (let i = messages.length - 1; i >= 0; i--) {
-    if (messages[i].role === "user") {
-      userCount++;
-      if (userCount > limit) {
-        return messages.slice(lastUserIndex);
-      }
-      lastUserIndex = i;
-    }
+export const SUMMARY_PREFIX = "[Previous conversation summary]";
+
+export interface SplitResult {
+  kept: ModelMessage[];
+  dropped: ModelMessage[];
+  previousSummary: string | undefined;
+}
+
+export function splitHistoryByBudget(params: {
+  messages: ModelMessage[];
+  tokenBudget: number;
+}): SplitResult {
+  const { messages, tokenBudget } = params;
+
+  if (messages.length === 0) {
+    return { kept: [], dropped: [], previousSummary: undefined };
   }
-  return messages;
+
+  // Extract existing summary from messages[0] if present
+  let previousSummary: string | undefined;
+  let conversationMessages: ModelMessage[];
+
+  const first = messages[0];
+  if (
+    first.role === "system" &&
+    typeof first.content === "string" &&
+    first.content.startsWith(SUMMARY_PREFIX)
+  ) {
+    previousSummary = first.content.slice(SUMMARY_PREFIX.length + 1); // skip prefix + newline
+    conversationMessages = messages.slice(1);
+  } else {
+    previousSummary = undefined;
+    conversationMessages = messages;
+  }
+
+  // Drop oldest messages until within token budget (keep at least 1)
+  let startIdx = 0;
+  let totalTokens = estimateMessagesTokens(conversationMessages);
+
+  while (totalTokens > tokenBudget && startIdx < conversationMessages.length - 1) {
+    totalTokens -= estimateTokens(messageText(conversationMessages[startIdx]));
+    startIdx++;
+  }
+
+  const dropped = conversationMessages.slice(0, startIdx);
+  const kept = conversationMessages.slice(startIdx);
+
+  return { kept, dropped, previousSummary };
+}
+
+export function makeSummaryMessage(summaryText: string): ModelMessage {
+  return { role: "system", content: `${SUMMARY_PREFIX}\n${summaryText}` };
 }

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -3,11 +3,13 @@ export { Memory } from "./memory.js";
 export { buildSystemPrompt } from "./system-prompt.js";
 export { createTools } from "./tools.js";
 export { withSessionLock } from "./session-lock.js";
-export { limitHistoryTurns } from "./history-limit.js";
+export { splitHistoryByBudget, makeSummaryMessage, SUMMARY_PREFIX } from "./history-limit.js";
 export { ChatStore } from "./chat-store.js";
 export {
   estimateTokens,
   estimateMessagesTokens,
+  messageText,
+  computeHistoryTokenBudget,
   shouldCompact,
   isContextOverflowError,
   isTimeoutError,
@@ -17,9 +19,15 @@ export {
   SAFETY_MARGIN,
   RESERVE_TOKENS,
   MIN_PROMPT_BUDGET_TOKENS,
-  MIN_PROMPT_BUDGET_RATIO,
   TIMEOUT_COMPACTION_THRESHOLD,
+  SUMMARIZATION_OVERHEAD_TOKENS,
 } from "./token-utils.js";
-export { summarizeInStages, splitMessagesByTokenShare } from "./compaction.js";
+export {
+  summarizeInStages,
+  summarizeDroppedMessages,
+  auditSummaryQuality,
+  computeAdaptiveChunkRatio,
+  chunkMessagesByMaxTokens,
+} from "./compaction.js";
 export { runMemoryFlush } from "./memory-flush.js";
 export { evaluateSessionFreshness, resolveDailyResetAtMs } from "./session-freshness.js";

--- a/src/agent/token-utils.ts
+++ b/src/agent/token-utils.ts
@@ -3,20 +3,33 @@ import { APICallError } from "@ai-sdk/provider";
 
 export const CHARS_PER_TOKEN = 4;
 export const SAFETY_MARGIN = 1.2;
-export const RESERVE_TOKENS = 4096;
+export const RESERVE_TOKENS = 20_000;
 export const MIN_PROMPT_BUDGET_TOKENS = 8000;
-export const MIN_PROMPT_BUDGET_RATIO = 0.5;
 export const TIMEOUT_COMPACTION_THRESHOLD = 0.65;
+export const SUMMARIZATION_OVERHEAD_TOKENS = 4096;
+
+export function messageText(m: ModelMessage): string {
+  return typeof m.content === "string" ? m.content : "";
+}
 
 export function estimateTokens(text: string): number {
   return Math.ceil((text.length / CHARS_PER_TOKEN) * SAFETY_MARGIN);
 }
 
 export function estimateMessagesTokens(messages: ModelMessage[]): number {
-  return messages.reduce(
-    (sum, m) => sum + estimateTokens(typeof m.content === "string" ? m.content : ""),
-    0,
-  );
+  return messages.reduce((sum, m) => sum + estimateTokens(messageText(m)), 0);
+}
+
+export function computeHistoryTokenBudget(params: {
+  contextWindowTokens: number;
+  systemPrompt: string;
+  budgetRatio: number;
+}): number {
+  const raw =
+    Math.floor(params.contextWindowTokens * params.budgetRatio) -
+    estimateTokens(params.systemPrompt) -
+    RESERVE_TOKENS;
+  return Math.max(raw, MIN_PROMPT_BUDGET_TOKENS);
 }
 
 export function shouldCompact(params: {

--- a/src/config.ts
+++ b/src/config.ts
@@ -21,10 +21,9 @@ export interface Config {
     botToken: string;
   };
   session: {
-    historyLimit: number;
+    historyTokenBudgetRatio: number;
     idleMinutes: number;
     dailyResetHour: number;
-    channels: Record<string, { historyLimit?: number }>;
   };
   contextWindowTokens: number;
   dataDir: string;
@@ -48,6 +47,7 @@ function loadYamlConfig(): Record<string, unknown> {
 // ============================================================================
 
 const CONTEXT_WINDOWS: Record<string, number> = {
+  "claude-haiku-4-5-20251001": 200_000,
   "claude-sonnet-4-5-20241022": 200_000,
   "gpt-4o": 128_000,
   "gemini-2.0-flash": 1_000_000,
@@ -64,15 +64,6 @@ function resolveContextWindowTokens(model: string): number {
 }
 
 // ============================================================================
-// HISTORY LIMIT RESOLUTION
-// ============================================================================
-
-export function getHistoryLimit(config: Config, chatId: string): number {
-  const channel = chatId.split(":")[0];
-  return config.session.channels[channel]?.historyLimit ?? config.session.historyLimit;
-}
-
-// ============================================================================
 // CONFIG LOADING
 // ============================================================================
 
@@ -84,6 +75,13 @@ function envInt(key: string): number | undefined {
   const v = process.env[key];
   if (v === undefined) return undefined;
   const n = parseInt(v, 10);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+function envFloat(key: string): number | undefined {
+  const v = process.env[key];
+  if (v === undefined) return undefined;
+  const n = parseFloat(v);
   return Number.isFinite(n) ? n : undefined;
 }
 
@@ -112,14 +110,6 @@ export function loadConfig(): Config {
 
   const model = env("LLM_MODEL") ?? llmYaml.model ?? defaultModelMap[provider];
 
-  const channelsYaml = (sessionYaml.channels as Record<string, Record<string, unknown>>) ?? {};
-  const channels: Record<string, { historyLimit?: number }> = {};
-  for (const [name, ch] of Object.entries(channelsYaml)) {
-    channels[name] = {
-      historyLimit: typeof ch.historyLimit === "number" ? ch.historyLimit : undefined,
-    };
-  }
-
   return {
     llm: {
       provider,
@@ -134,10 +124,9 @@ export function loadConfig(): Config {
       botToken: env("TELEGRAM_BOT_TOKEN") ?? telegramYaml.bot_token ?? "",
     },
     session: {
-      historyLimit: envInt("SESSION_HISTORY_LIMIT") ?? (sessionYaml.historyLimit as number) ?? 20,
+      historyTokenBudgetRatio: envFloat("HISTORY_TOKEN_BUDGET_RATIO") ?? (sessionYaml.historyTokenBudgetRatio as number) ?? 0.3,
       idleMinutes: envInt("SESSION_IDLE_MINUTES") ?? (sessionYaml.idleMinutes as number) ?? 0,
       dailyResetHour: envInt("SESSION_DAILY_RESET_HOUR") ?? (sessionYaml.dailyResetHour as number) ?? 4,
-      channels,
     },
     contextWindowTokens: resolveContextWindowTokens(model),
     dataDir: (yaml.data_dir as string) ?? CONFIG_DIR,


### PR DESCRIPTION
## Summary

Port three anti-bloat mechanisms from OpenClaw to fix summarization producing 21K char summaries (nearly as verbose as the messages they replace), with compaction requests taking 100-145s.

- **Hard output cap**: `maxOutputTokens: 2048` on all summarization `generateText()` calls + `capSummary()` at 4K chars as safety net
- **Adaptive chunk sizing**: replace fixed 2-chunk split with dynamic ratio (0.15–0.40 of context window) based on average message size — more chunks for bloated messages, fewer for normal ones
- **Prompt discipline**: both prompts now target 300-500 words, require bullet points, omit generic re-derivable advice, and enforce section headings (`## Athlete Profile`, `## Training Status`, `## Discussion Context`, `## Pending Questions`)
- **Token-based history budget**: replace count-based `historyLimit` with `historyTokenBudgetRatio` (default 0.3) for more precise context management
- **Quality guard**: `auditSummaryQuality()` checks for required sections, retries with structured restructure prompt if missing
- **Dead code cleanup**: remove `splitMessagesByTokenShare`, `getHistory`, `getHistoryLimit`, `historyLimit`/`channels` config

### Files changed

| File | Changes |
|------|---------|
| `src/agent/compaction.ts` | New: `capSummary`, `computeAdaptiveChunkRatio`, `chunkMessagesByMaxTokens`, `computeAdaptiveChunks`, `auditSummaryQuality`, `summarizeDroppedMessages`. Updated: `summarizeInStages`. Removed: `splitMessagesByTokenShare`, `COMPACTION_CHUNKS`, `MERGE_PROMPT` |
| `src/agent/token-utils.ts` | New: `SUMMARIZATION_OVERHEAD_TOKENS`, `messageText`, `computeHistoryTokenBudget`. Updated: `RESERVE_TOKENS` (4096→20000). Removed: `MIN_PROMPT_BUDGET_RATIO` |
| `src/agent/history-limit.ts` | Replaced `limitHistoryTurns` with `splitHistoryByBudget` + `makeSummaryMessage` |
| `src/agent/core.ts` | Wired token-based budget, `summarizeDroppedMessages`, `contextWindowTokens` to all summarization calls |
| `src/agent/chat-store.ts` | New: `overwriteHistory`. Updated: `load` (system role support, skip system for lastMessageTime). Removed: `getHistory`, `getLastMessageTime` |
| `src/config.ts` | New: `historyTokenBudgetRatio`, `envFloat`, Haiku context window. Removed: `historyLimit`, `channels`, `getHistoryLimit` |
| `SOUL.md` | Simplified communication rules |

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 56/56 tests pass
- [ ] Run 40-message tone-stability scenario — verify summaries stay under 4K chars
- [ ] Run 40-message scenario — verify no 100s+ compaction calls
- [ ] Verify context retention at messages 36-40 (FTP, goal, schedule recalled)