### PR TITLE
Make README beginner-friendly and use intervals.icu terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # Cycling Coach
 
-AI-powered cycling coach you can chat with on Telegram or in the terminal. Connect your [intervals.icu](https://intervals.icu) account to pull real training data — the coach analyzes your fitness, builds periodized plans, and pushes structured workouts straight to your calendar (auto-syncs to Garmin/Wahoo).
+AI-powered cycling coach you can chat with on Telegram or in the terminal. Connect your [intervals.icu](https://intervals.icu) account to pull real training data — the coach analyzes your fitness, builds periodized plans, and pushes structured workouts straight to your calendar (auto-syncs to Garmin, Wahoo, Hammerhead, COROS, Suunto, and Zwift).
 
 ## How it works
 
-1. **You send a message** — via Telegram or the command line ("Build me a 12-week gran fondo plan", "What should I ride today?", "My knee hurts")
+1. **You send a message** — via Telegram or the command line ("Build me a 12-week gran fondo plan", "What should I ride today?")
 2. **The coach reads your history** — goals, past conversations, injury notes, and preferences stored locally on your machine
-3. **It pulls your real data** — current fitness (CTL), fatigue (ATL), form (TSB), recent rides, FTP, and zones from intervals.icu
+3. **It pulls your real data** — current fitness, fatigue, form, recent rides, FTP, and zones from intervals.icu
 4. **It runs cycling logic** — zone calculations, periodization models, feasibility checks, workout structure — all deterministic, no guessing
 5. **An LLM puts it together** — Claude, GPT, or Gemini interprets everything and responds like a knowledgeable coach
-6. **Workouts land on your calendar** — structured intervals pushed to intervals.icu, which syncs to your Garmin or Wahoo head unit
+6. **Workouts land on your calendar** — structured intervals pushed to intervals.icu, which syncs to Garmin, Wahoo, Hammerhead, COROS, Suunto, and Zwift
 
 ## Setup
 
@@ -94,8 +94,8 @@ The bot starts polling. Open your bot in Telegram and send `/start`.
 |---------|-------------|
 | `/start` | Welcome message + available commands |
 | `/plan` | Fetches your intervals.icu data, builds a periodized plan, asks to push to calendar |
-| `/workout` | Checks your current form (CTL/ATL/TSB), suggests today's workout with structured intervals |
-| `/status` | Shows fitness (CTL), fatigue (ATL), form (TSB), and coaching notes |
+| `/workout` | Checks your current fitness, fatigue, and form — suggests today's workout with structured intervals |
+| `/status` | Shows fitness, fatigue, form, and coaching notes |
 | `/sync` | Pushes next 1-2 weeks of planned workouts to intervals.icu calendar |
 
 Free-form chat works too — ask anything about training, report an injury, request plan adjustments.
@@ -112,9 +112,9 @@ Free-form chat works too — ask anything about training, report an injury, requ
 ### intervals.icu integration
 
 - Fetch athlete profile (FTP, weight, max HR, zones)
-- Fetch recent activities (TSS, IF, duration)
-- Fetch wellness data (CTL, ATL → TSB, HRV, resting HR, sleep)
-- Push workouts to calendar → auto-syncs to Garmin/Wahoo
+- Fetch recent activities (load, intensity, duration)
+- Fetch wellness data (fitness, fatigue, form, HRV, resting HR, sleep)
+- Push workouts to calendar → auto-syncs to Garmin, Wahoo, Hammerhead, COROS, Suunto, and Zwift
 
 ### Memory
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,35 @@ AI-powered cycling coach you can chat with on Telegram or in the terminal. Conne
 
 ## How it works
 
+```
+┌─────────────────────────────────────────────────────────┐
+│  You                                                    │
+│  Telegram / CLI                                         │
+└────────────────────────┬────────────────────────────────┘
+                         │
+                         ▼
+┌─────────────────────────────────────────────────────────┐
+│  Cycling Coach Agent                                    │
+│                                                         │
+│  ┌──────────────┐  ┌─────────────┐  ┌───────────────┐  │
+│  │ Coaching      │  │ Cycling     │  │ Memory        │  │
+│  │ persona &     │  │ logic       │  │ goals, notes, │  │
+│  │ domain skills │  │ zones, plans│  │ preferences   │  │
+│  └──────────────┘  └─────────────┘  └───────────────┘  │
+│                                                         │
+│  ┌──────────────────────────────────────────────────┐   │
+│  │ intervals.icu API                                │   │
+│  │ fitness · fatigue · form · rides · push workouts │   │
+│  └──────────────────────────────────────────────────┘   │
+└────────────────────────┬────────────────────────────────┘
+                         │
+                         ▼
+┌─────────────────────────────────────────────────────────┐
+│  LLM  (Claude / GPT / Gemini)                           │
+│  Interprets data + coaching knowledge → response        │
+└─────────────────────────────────────────────────────────┘
+```
+
 1. **You send a message** — via Telegram or the command line ("Build me a 12-week gran fondo plan", "What should I ride today?")
 2. **The coach reads your history** — goals, past conversations, injury notes, and preferences stored locally on your machine
 3. **It pulls your real data** — current fitness, fatigue, form, recent rides, FTP, and zones from intervals.icu

--- a/SOUL.md
+++ b/SOUL.md
@@ -3,7 +3,7 @@
 You are a structured, data-driven cycling coach.
 
 ## Principles
-- Always check the athlete's current form (CTL/ATL/TSB) before suggesting intensity
+- Always check the athlete's current fitness, fatigue, and form before suggesting intensity
 - Consistency beats heroic efforts — 4 solid weeks > 1 incredible week + 3 weeks off
 - Recovery is training — never skip recovery weeks
 - Adapt to the athlete, not the other way around
@@ -14,7 +14,7 @@ You are a structured, data-driven cycling coach.
 - Use power zones (% FTP), never arbitrary watt numbers
 - Explain the "why" behind every workout
 - Flag overtraining signals: declining form, rising fatigue, missed sessions
-- If the athlete's form is below -30 TSB, recommend recovery before hard work
+- If the athlete's form is below -30, recommend recovery before hard work
 - When the athlete shares personal details (FTP, weight, schedule, goals, preferences, injuries), save them to long-term memory using memory_write so they persist across sessions
 - When intervals.icu has eFTP data, use it as a working baseline. Recommend a proper FTP test early in the plan, but don't block coaching advice on it. Note estimated zones as "estimated (based on eFTP)" so the athlete knows. Flag eFTP values below 80W or above 450W as likely incorrect.
 - If no eFTP or ride data exists, explain why testing matters, but still answer general coaching questions (warmup, nutrition, recovery, technique)
@@ -33,9 +33,9 @@ Never pad a short answer with background the athlete didn't ask for. If they ask
 ## Communication
 - If a question has a short answer, give the short answer
 - Use tables and bullet points, not paragraphs
-- Use cycling terminology (FTP, TSS, IF, CTL, ATL, TSB, sweet spot, threshold)
+- Use cycling terminology (FTP, load, intensity, fitness, fatigue, form, sweet spot, threshold)
 - Format workouts as structured intervals (warmup → main → cooldown)
-- Always include estimated TSS/IF for planned workouts
+- Always include estimated load/intensity for planned workouts
 - Answer the athlete's question first, then add caveats briefly. Never lead with refusal or redirect.
 - Stay patient and professional — even if the athlete ignores your advice repeatedly
 - Every response must provide substantive coaching value — no emoji-only or single-word answers

--- a/skills/intervals-icu.md
+++ b/skills/intervals-icu.md
@@ -2,47 +2,47 @@
 
 ## Key Metrics
 
-### CTL (Chronic Training Load) — "Fitness"
-- Rolling ~42-day exponentially weighted average of daily TSS
+### Fitness (Chronic Training Load)
+- Rolling ~42-day exponentially weighted average of daily load
 - Higher = more aerobically fit (adapted to training stress)
 - Typical range: 30 (recreational) → 80+ (competitive) → 120+ (elite)
 - Builds slowly (~1 point/week with consistent training)
 
-### ATL (Acute Training Load) — "Fatigue"
-- Rolling ~7-day exponentially weighted average of daily TSS
+### Fatigue (Acute Training Load)
+- Rolling ~7-day exponentially weighted average of daily load
 - Higher = more fatigued from recent training
 - Spikes after hard blocks, drops during recovery
-- Should periodically exceed CTL (training stimulus)
+- Should periodically exceed fitness (training stimulus)
 
-### TSB (Training Stress Balance) — "Form"
-- TSB = CTL - ATL
+### Form (Training Stress Balance)
+- Form = fitness - fatigue
 - Positive: Fresh, recovered (good for racing, not enough training stimulus)
 - Slightly negative (-10 to -20): Functional overreaching (optimal training zone)
 - Very negative (< -30): Accumulated fatigue (need recovery)
 - Race day target: +5 to +15
 
-### TSS (Training Stress Score)
+### Load (Training Stress)
 - Quantifies how hard a single ride was
-- TSS = (duration × NP × IF) / (FTP × 3600) × 100
-- A 1-hour ride at FTP = 100 TSS
-- Easy ride: 30-50 TSS, Hard interval session: 70-100 TSS, Long ride: 150-250 TSS
+- Load = (duration × norm power × intensity) / (FTP × 3600) × 100
+- A 1-hour ride at FTP = 100 load
+- Easy ride: 30-50, Hard interval session: 70-100, Long ride: 150-250
 
-### IF (Intensity Factor)
-- IF = NP / FTP
+### Intensity
+- Intensity = norm power / FTP
 - < 0.75: Recovery/endurance
 - 0.75-0.85: Tempo
 - 0.85-0.95: Sweet spot
 - 0.95-1.05: Threshold
 - > 1.05: VO2max / anaerobic
 
-### NP (Normalized Power)
+### Norm Power (Normalized Power)
 - Smoothed power that accounts for variability
 - Better represents physiological cost than average power
-- Outdoor rides: NP >> average power (variability)
-- Indoor ERG: NP ≈ average power
+- Outdoor rides: norm power >> average power (variability)
+- Indoor ERG: norm power ≈ average power
 
 ### VI (Variability Index)
-- VI = NP / Average Power
+- VI = norm power / average power
 - 1.0 = perfectly steady (indoor ERG)
 - 1.05-1.1 = typical outdoor ride
 - > 1.15 = highly variable (criterium, mountain ride)
@@ -78,7 +78,7 @@ When creating events on the intervals.icu calendar:
 - `type`: "Ride" for cycling workouts
 - `name`: Descriptive name (e.g., "Sweet Spot 2x20")
 - `moving_time`: Duration in seconds
-- `icu_training_load`: Planned TSS
+- `icu_training_load`: Planned load
 - `description`: Workout details, interval structure, coaching notes
 
 ### Auto-Sync

--- a/skills/race-prep.md
+++ b/skills/race-prep.md
@@ -47,7 +47,7 @@ Purpose: Activate legs without fatiguing them.
 - 3x 30s at 120% FTP with 2min recovery
 - 2x 1min at threshold with 3min recovery
 - 10min cooldown
-- Total: ~40min, TSS ~30
+- Total: ~40min, load ~30
 
 ## Pre-Race Nutrition Reminders
 

--- a/skills/recovery.md
+++ b/skills/recovery.md
@@ -3,7 +3,7 @@
 ## Overtraining Warning Signs
 
 ### Data Signals
-- TSB below -30 for more than 3 consecutive days
+- Form below -30 for more than 3 consecutive days
 - Resting heart rate elevated 5+ bpm above baseline
 - HRV declining trend over 7+ days
 - Power at threshold declining despite training
@@ -18,7 +18,7 @@
 
 ## When to Replace a Hard Session with Recovery
 
-1. TSB is below -30 → recovery ride instead
+1. Form is below -30 → recovery ride instead
 2. Two consecutive missed sessions → restart with easy week
 3. Athlete reports pain (not soreness) → full rest day
 4. Resting HR elevated → easy day only
@@ -31,7 +31,7 @@
 - Cadence: 90+ RPM in easy gear
 - Structure: Flat terrain, no climbs
 - Goal: Blood flow without stress
-- TSS: < 20
+- Load: < 20
 
 ## Deload Week Design
 

--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -226,7 +226,7 @@ function createIntervalsTools(client: IntervalsClient) {
 
     intervals_fetch_activities: tool({
       description:
-        "Fetch recent activities from intervals.icu. Returns rides with TSS, IF, duration, distance.",
+        "Fetch recent activities from intervals.icu. Returns rides with load, intensity, duration, distance.",
       inputSchema: zodSchema(
         z.object({
           oldest: z.string().describe("Oldest date (YYYY-MM-DD)"),
@@ -245,7 +245,7 @@ function createIntervalsTools(client: IntervalsClient) {
 
     intervals_fetch_wellness: tool({
       description:
-        "Fetch wellness data from intervals.icu (CTL, ATL, weight, HRV, resting HR, sleep). TSB = CTL - ATL.",
+        "Fetch wellness data from intervals.icu (fitness, fatigue, weight, HRV, resting HR, sleep). Form = fitness - fatigue.",
       inputSchema: zodSchema(
         z.object({
           oldest: z.string().describe("Start date (YYYY-MM-DD)"),
@@ -269,7 +269,7 @@ function createIntervalsTools(client: IntervalsClient) {
           date: z.string().describe("Workout date (YYYY-MM-DD)"),
           name: z.string().describe("Workout name"),
           movingTime: z.number().int().describe("Duration in seconds"),
-          trainingLoad: z.number().optional().describe("Planned TSS"),
+          trainingLoad: z.number().optional().describe("Planned load"),
           description: z.string().optional().describe("Workout details"),
         }),
       ),

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -32,7 +32,7 @@ export function createTelegramBot(token: string, agent: CyclingCoachAgent): Bot 
         "Commands:\n" +
         "/plan — Generate a training plan\n" +
         "/workout — Get today's workout\n" +
-        "/status — Check current form (CTL/ATL/TSB)\n" +
+        "/status — Check current fitness, fatigue, and form\n" +
         "/sync — Push plan to intervals.icu calendar\n\n" +
         "Or just chat with me about your training!",
     );


### PR DESCRIPTION
## Summary
- Rename H1 header from `cycling-coach` to `Cycling Coach`
- Replace architecture diagram in "How it works" with plain-language step-by-step walkthrough
- Expand "Clone and install" with Node.js/npm explanation and download link for non-developer cyclists
- Mention Zwift, Hammerhead, COROS, and Suunto alongside Garmin/Wahoo
- Replace CTL/ATL/TSB/TSS/IF with intervals.icu terms (fitness, fatigue, form, load, intensity) across all files

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Confirm all links (nodejs.org, intervals.icu) resolve
- [ ] Grep for CTL/ATL/TSB/TSS to confirm no remaining occurrences outside CLAUDE.local.md