### PR TITLE
fix: add repository url for npm provenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,5 +43,9 @@
   "engines": {
     "node": ">=20"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/yerzhansa/cycling-coach.git"
+  }
 }


### PR DESCRIPTION
npm provenance requires repository.url in package.json to match the GitHub repo.