### PR TITLE
chore: switch to calendar versioning (YYYY.M.D)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cycling-coach",
-  "version": "0.0.1",
+  "version": "2026.4.16",
   "description": "AI cycling coaching agent — BYOK + intervals.icu + Telegram",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Switch from semver to calendar versioning. Next release will be v2026.4.16.