### PR TITLE
fix: use npm ci and handle unchanged version in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
           registry-url: https://registry.npmjs.org
           cache: npm
 
-      - run: npm install
+      - run: npm ci
       - run: npm run check
       - run: npm test
       - run: npm run build
@@ -44,7 +44,7 @@ jobs:
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "Releasing v${version}"
 
-      - name: Bump version and tag
+      - name: Bump version, commit, and tag
         env:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
@@ -52,7 +52,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           sed -i "s/\"version\": \".*\"/\"version\": \"${VERSION}\"/" package.json
           git add package.json
-          git commit -m "${VERSION}"
+          git diff --cached --quiet && echo "Version already ${VERSION}, skipping commit" || git commit -m "${VERSION}"
           git tag "v${VERSION}"
           git push origin main --tags
 


### PR DESCRIPTION
## Summary
- `npm ci` instead of `npm install` — doesn't dirty package-lock.json
- Skip commit when version in package.json already matches (just tag)

Fixes the failed release run: https://github.com/yerzhansa/cycling-coach/actions/runs/24520270995