### PR TITLE
fix: sync package-lock.json for npm ci

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cycling-coach",
-  "version": "0.0.1",
+  "version": "2026.4.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cycling-coach",
-      "version": "0.0.1",
+      "version": "2026.4.16",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.69",
@@ -17,6 +17,9 @@
         "intervals-icu-api": "^0.1.2",
         "yaml": "^2.8.3",
         "zod": "^4.3.6"
+      },
+      "bin": {
+        "cycling-coach": "dist/index.js"
       },
       "devDependencies": {
         "@types/node": "^25.6.0",


### PR DESCRIPTION
Lockfile was out of sync — missing @emnapi/core and @emnapi/runtime. Caused npm ci to fail in release workflow.