### PR TITLE
fix: use npm install in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
           registry-url: https://registry.npmjs.org
           cache: npm
 
-      - run: npm ci
+      - run: npm install
       - run: npm run check
       - run: npm test
       - run: npm run build


### PR DESCRIPTION
npm ci fails due to lockfile version mismatch (local npm 11 vs runner npm 10). npm install works — dirty lockfile is harmless since only package.json is staged.