### PR TITLE
fix: prevent setup wizard from exiting before writing config

### DIFF
--- a/src/setup.ts
+++ b/src/setup.ts
@@ -44,11 +44,14 @@ async function askProvider(
 
 export async function runSetup(): Promise<void> {
   const rl = createInterface({ input: process.stdin, output: process.stdout });
+  let done = false;
 
   // Handle Ctrl+C
   rl.on("close", () => {
-    console.log("\n  Setup cancelled.");
-    process.exit(0);
+    if (!done) {
+      console.log("\n  Setup cancelled.");
+      process.exit(0);
+    }
   });
 
   try {
@@ -66,6 +69,7 @@ export async function runSetup(): Promise<void> {
 
     const telegramToken = await ask(rl, "  Telegram bot token (optional, Enter to skip): ");
 
+    done = true;
     rl.close();
 
     // Check existing config


### PR DESCRIPTION
The close handler on readline fired on normal rl.close() after collecting all inputs, not just on Ctrl+C. Added a done flag so the handler only exits on actual cancellation.