### PR TITLE
fix: release workflow commits version bump to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,10 +50,10 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          sed -i "s/\"version\": \".*\"/\"version\": \"${VERSION}\"/" package.json
-          git add package.json
+          npm version "${VERSION}" --no-git-tag-version
+          git add package.json package-lock.json
           git diff --cached --quiet && echo "Version already ${VERSION}, skipping commit" || git commit -m "${VERSION}"
-          git tag "v${VERSION}"
+          git tag -f "v${VERSION}"
           git push origin main --tags
 
       - name: Publish to npm


### PR DESCRIPTION
Commits version bump via GitHub Actions with enforce_admins bypass. Uses npm version for both package.json and package-lock.json. Tags with -f to handle retries.