### PR TITLE
fix: use deploy key for release workflow push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
           fetch-depth: 0
 
       - uses: actions/setup-node@v4


### PR DESCRIPTION
Use SSH deploy key to push version commit to main. Deploy keys can bypass rulesets, GITHUB_TOKEN cannot on personal repos.