### PR TITLE
fix: include SOUL.md and skills/ in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "cycling-coach": "dist/index.js"
   },
   "files": [
-    "dist"
+    "dist",
+    "SOUL.md",
+    "skills"
   ],
   "scripts": {
     "dev": "tsx --env-file=.env src/index.ts",


### PR DESCRIPTION
Without these files, cycling-coach crashes on startup with ENOENT for SOUL.md.