### PR TITLE
feat(setup): replace readline with @clack/prompts TUI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@ai-sdk/anthropic": "^3.0.69",
         "@ai-sdk/google": "^3.0.63",
         "@ai-sdk/openai": "^3.0.52",
+        "@clack/prompts": "^1.2.0",
         "ai": "^6.0.158",
         "grammy": "^1.42.0",
         "intervals-icu-api": "^0.1.2",
@@ -128,29 +129,26 @@
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
+    "node_modules/@clack/core": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.2.0.tgz",
+      "integrity": "sha512-qfxof/3T3t9DPU/Rj3OmcFyZInceqj/NVtO9rwIuJqCUgh32gwPjpFQQp/ben07qKlhpwq7GzfWpST4qdJ5Drg==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
+        "fast-wrap-ansi": "^0.1.3",
+        "sisteransi": "^1.0.5"
       }
     },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
+    "node_modules/@clack/prompts": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.2.0.tgz",
+      "integrity": "sha512-4jmztR9fMqPMjz6H/UZXj0zEmE43ha1euENwkckKKel4XpSfokExPo5AiVStdHSAlHekz4d0CA/r45Ok1E4D3w==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
-        "tslib": "^2.4.0"
+        "@clack/core": "1.2.0",
+        "fast-string-width": "^1.1.0",
+        "fast-wrap-ansi": "^0.1.3",
+        "sisteransi": "^1.0.5"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1769,6 +1767,7 @@
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.19.0"
       }
@@ -2193,6 +2192,30 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/fast-string-truncated-width": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-1.2.1.tgz",
+      "integrity": "sha512-Q9acT/+Uu3GwGj+5w/zsGuQjh9O1TyywhIwAxHudtWrgF09nHOPrvTLhQevPbttcxjr/SNN7mJmfOw/B1bXgow==",
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-1.1.0.tgz",
+      "integrity": "sha512-O3fwIVIH5gKB38QNbdg+3760ZmGz0SZMgvwJbA1b2TGXceKE6A2cOlfogh1iw8lr049zPyd7YADHy+B7U4W9bQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^1.2.0"
+      }
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.1.6.tgz",
+      "integrity": "sha512-HlUwET7a5gqjURj70D5jl7aC3Zmy4weA1SHUfM0JFI0Ptq987NH2TwbBFLoERhfwk+E+eaq4EK3jXoT+R3yp3w==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^1.1.0"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -2601,6 +2624,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@inquirer/confirm": "^5.0.0",
         "@mswjs/interceptors": "^0.41.2",
@@ -2833,6 +2857,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2949,6 +2974,12 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "license": "MIT"
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -3139,6 +3170,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -3175,6 +3207,7 @@
       "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3220,6 +3253,7 @@
       "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -3445,6 +3479,7 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -3502,6 +3537,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@ai-sdk/anthropic": "^3.0.69",
     "@ai-sdk/google": "^3.0.63",
     "@ai-sdk/openai": "^3.0.52",
+    "@clack/prompts": "^1.2.0",
     "ai": "^6.0.158",
     "grammy": "^1.42.0",
     "intervals-icu-api": "^0.1.2",

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -1,9 +1,13 @@
-import { createInterface } from "node:readline/promises";
+import { intro, outro, select, text, password, confirm, isCancel, cancel } from "@clack/prompts";
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { stringify as toYaml } from "yaml";
 import { CONFIG_DIR, CONFIG_FILE } from "./config.js";
 
-const PROVIDERS = ["anthropic", "openai", "google"] as const;
+const PROVIDERS = [
+  { value: "anthropic", label: "Anthropic (Claude)" },
+  { value: "openai", label: "OpenAI (GPT)" },
+  { value: "google", label: "Google (Gemini)" },
+];
 
 const API_KEY_LABELS: Record<string, string> = {
   anthropic: "Anthropic API key",
@@ -11,139 +15,118 @@ const API_KEY_LABELS: Record<string, string> = {
   google: "Google AI API key",
 };
 
-const MODELS: Record<string, string[]> = {
-  anthropic: ["claude-sonnet-4-6", "claude-haiku-4-5-20251001", "claude-opus-4-6"],
-  openai: ["gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano", "o4-mini"],
-  google: ["gemini-2.5-flash", "gemini-2.5-pro", "gemini-2.5-flash-lite"],
+const MODELS: Record<string, { value: string; label: string; hint?: string }[]> = {
+  anthropic: [
+    { value: "claude-sonnet-4-6", label: "Claude Sonnet 4.6", hint: "recommended" },
+    { value: "claude-haiku-4-5-20251001", label: "Claude Haiku 4.5", hint: "fast & cheap" },
+    { value: "claude-opus-4-6", label: "Claude Opus 4.6", hint: "most capable" },
+  ],
+  openai: [
+    { value: "gpt-5.4", label: "GPT-5.4", hint: "recommended" },
+    { value: "gpt-5.4-mini", label: "GPT-5.4 Mini", hint: "fast & cheap" },
+    { value: "gpt-5.4-nano", label: "GPT-5.4 Nano", hint: "cheapest" },
+    { value: "o4-mini", label: "o4-mini", hint: "reasoning" },
+  ],
+  google: [
+    { value: "gemini-2.5-flash", label: "Gemini 2.5 Flash", hint: "recommended" },
+    { value: "gemini-2.5-pro", label: "Gemini 2.5 Pro", hint: "most capable" },
+    { value: "gemini-2.5-flash-lite", label: "Gemini 2.5 Flash Lite", hint: "cheapest" },
+  ],
 };
 
-async function ask(
-  rl: ReturnType<typeof createInterface>,
-  prompt: string,
-): Promise<string> {
-  const answer = await rl.question(prompt);
-  return answer.trim();
-}
-
-async function askRequired(
-  rl: ReturnType<typeof createInterface>,
-  prompt: string,
-): Promise<string> {
-  let value = "";
-  while (!value) {
-    value = await ask(rl, prompt);
-    if (!value) console.log("  This field is required.");
-  }
-  return value;
-}
-
-async function askProvider(
-  rl: ReturnType<typeof createInterface>,
-): Promise<string> {
-  while (true) {
-    const value = await ask(rl, "  LLM provider (anthropic/openai/google) [anthropic]: ");
-    if (!value) return "anthropic";
-    if (PROVIDERS.includes(value as (typeof PROVIDERS)[number])) return value;
-    console.log("  Must be one of: anthropic, openai, google");
-  }
-}
-
-async function askModel(
-  rl: ReturnType<typeof createInterface>,
-  provider: string,
-): Promise<string> {
-  const models = MODELS[provider] ?? [];
-  console.log("  Model:");
-  for (let i = 0; i < models.length; i++) {
-    console.log(`    [${i + 1}] ${models[i]}${i === 0 ? " (default)" : ""}`);
-  }
-  console.log("    or type a model name");
-
-  while (true) {
-    const value = await ask(rl, "  > ");
-    if (!value) return models[0];
-
-    const num = parseInt(value, 10);
-    if (num >= 1 && num <= models.length) return models[num - 1];
-    if (Number.isNaN(num)) return value;
-
-    console.log(`  Must be 1-${models.length} or a model name`);
+function handleCancel(value: unknown): asserts value is string | boolean {
+  if (isCancel(value)) {
+    cancel("Setup cancelled.");
+    process.exit(0);
   }
 }
 
 export async function runSetup(): Promise<void> {
-  const rl = createInterface({ input: process.stdin, output: process.stdout });
-  let done = false;
+  intro("Cycling Coach — Setup");
 
-  // Handle Ctrl+C
-  rl.on("close", () => {
-    if (!done) {
-      console.log("\n  Setup cancelled.");
+  // Provider
+  const provider = await select({
+    message: "LLM provider",
+    options: PROVIDERS,
+  });
+  handleCancel(provider);
+
+  // API key
+  const apiKey = await password({
+    message: API_KEY_LABELS[provider],
+    validate: (v) => (!v ? "API key is required" : undefined),
+  });
+  handleCancel(apiKey);
+
+  // Model
+  const model = await select({
+    message: "Model",
+    options: MODELS[provider] ?? [],
+  });
+  handleCancel(model);
+
+  // intervals.icu (optional)
+  const intervalsKey = await text({
+    message: "intervals.icu API key",
+    placeholder: "Enter to skip",
+  });
+  handleCancel(intervalsKey);
+
+  let intervalsAthleteId = "";
+  if (intervalsKey) {
+    const athleteId = await text({
+      message: "intervals.icu athlete ID",
+      defaultValue: "0",
+      placeholder: "0",
+    });
+    handleCancel(athleteId);
+    intervalsAthleteId = athleteId || "0";
+  }
+
+  // Telegram (optional)
+  const telegramToken = await text({
+    message: "Telegram bot token",
+    placeholder: "Enter to skip",
+  });
+  handleCancel(telegramToken);
+
+  // Overwrite check
+  if (existsSync(CONFIG_FILE)) {
+    const overwrite = await confirm({
+      message: `${CONFIG_FILE} already exists. Overwrite?`,
+    });
+    handleCancel(overwrite);
+    if (!overwrite) {
+      cancel("Setup cancelled.");
       process.exit(0);
     }
-  });
-
-  try {
-    console.log("\n  Cycling Coach — Setup\n");
-
-    const provider = await askProvider(rl);
-    const apiKey = await askRequired(rl, `  ${API_KEY_LABELS[provider]}: `);
-    const model = await askModel(rl, provider);
-
-    const intervalsKey = await ask(rl, "  intervals.icu API key (optional, Enter to skip): ");
-    let intervalsAthleteId = "";
-    if (intervalsKey) {
-      intervalsAthleteId = await ask(rl, "  intervals.icu athlete ID [0]: ");
-      if (!intervalsAthleteId) intervalsAthleteId = "0";
-    }
-
-    const telegramToken = await ask(rl, "  Telegram bot token (optional, Enter to skip): ");
-
-    done = true;
-    rl.close();
-
-    // Check existing config
-    if (existsSync(CONFIG_FILE)) {
-      const confirm = createInterface({ input: process.stdin, output: process.stdout });
-      const answer = await confirm.question(`\n  ${CONFIG_FILE} already exists. Overwrite? (y/N): `);
-      confirm.close();
-      if (answer.trim().toLowerCase() !== "y") {
-        console.log("  Setup cancelled.");
-        return;
-      }
-    }
-
-    // Build config object — only include non-empty sections
-    const config: Record<string, unknown> = {
-      llm: {
-        provider,
-        model,
-        api_key: apiKey,
-      },
-    };
-
-    if (intervalsKey) {
-      config.intervals = {
-        api_key: intervalsKey,
-        athlete_id: intervalsAthleteId,
-      };
-    }
-
-    if (telegramToken) {
-      config.telegram = {
-        bot_token: telegramToken,
-      };
-    }
-
-    // Write config
-    mkdirSync(CONFIG_DIR, { recursive: true });
-    writeFileSync(CONFIG_FILE, toYaml(config), { mode: 0o600 });
-
-    console.log(`\n  Config written to ${CONFIG_FILE}\n`);
-    console.log("  Run `cycling-coach` to start.\n");
-  } catch (err) {
-    // readline throws on Ctrl+C in some Node versions
-    if ((err as NodeJS.ErrnoException).code === "ERR_USE_AFTER_CLOSE") return;
-    throw err;
   }
+
+  // Build config — only include non-empty sections
+  const config: Record<string, unknown> = {
+    llm: {
+      provider,
+      model,
+      api_key: apiKey,
+    },
+  };
+
+  if (intervalsKey) {
+    config.intervals = {
+      api_key: intervalsKey,
+      athlete_id: intervalsAthleteId,
+    };
+  }
+
+  if (telegramToken) {
+    config.telegram = {
+      bot_token: telegramToken,
+    };
+  }
+
+  // Write config
+  mkdirSync(CONFIG_DIR, { recursive: true });
+  writeFileSync(CONFIG_FILE, toYaml(config), { mode: 0o600 });
+
+  outro(`Config written to ${CONFIG_FILE}\n  Run \`cycling-coach\` to start.`);
 }


### PR DESCRIPTION
## Summary
- Arrow-key select for provider and model (no more typing numbers)
- Password masking for API keys
- Styled intro/outro boxes
- Proper Ctrl+C handling
- Adds `@clack/prompts` dependency (4 KB gzipped)

## Test plan
- [ ] `cycling-coach setup` — select provider with arrows, verify password masking
- [ ] Ctrl+C at any step shows "Setup cancelled"
- [ ] Config written correctly to ~/.cycling-coach/config.yaml