### PR TITLE
feat: add /update command and startup update notifier

### DIFF
--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -1,6 +1,7 @@
 import { Bot } from "grammy";
 import type { CyclingCoachAgent } from "../agent/core.js";
 import { isRateLimitError, extractRetryAfterMs } from "../agent/token-utils.js";
+import { checkForUpdate, selfUpdate, getKnownTelegramChatIds } from "../updater.js";
 
 function formatRateLimitWait(err: unknown): string {
   const ms = extractRetryAfterMs(err);
@@ -33,7 +34,8 @@ export function createTelegramBot(token: string, agent: CyclingCoachAgent): Bot 
         "/plan — Generate a training plan\n" +
         "/workout — Get today's workout\n" +
         "/status — Check current fitness, fatigue, and form\n" +
-        "/sync — Push plan to intervals.icu calendar\n\n" +
+        "/sync — Push plan to intervals.icu calendar\n" +
+        "/update — Check for and install updates\n\n" +
         "Or just chat with me about your training!",
     );
   });
@@ -99,6 +101,26 @@ export function createTelegramBot(token: string, agent: CyclingCoachAgent): Bot 
       } else {
         await ctx.reply("Sorry, something went wrong. Please try again.");
       }
+    }
+  });
+
+  bot.command("update", async (ctx) => {
+    await ctx.reply("Checking for updates...");
+    try {
+      const info = await checkForUpdate();
+      if (!info) {
+        await ctx.reply("Could not check for updates. Try again later.");
+        return;
+      }
+      if (!info.updateAvailable) {
+        await ctx.reply(`You're on the latest version (${info.current}).`);
+        return;
+      }
+      await ctx.reply(`Updating ${info.current} → ${info.latest}...\nThe bot will restart after installation.`);
+      selfUpdate();
+    } catch (err) {
+      console.error("Error in /update:", err);
+      await ctx.reply("Update failed. Please run `npm install -g cycling-coach@latest` manually.");
     }
   });
 
@@ -198,5 +220,29 @@ async function sendLongMessage(
 
   for (const chunk of chunks) {
     await ctx.reply(chunk, { parse_mode: "HTML" });
+  }
+}
+
+// ============================================================================
+// STARTUP UPDATE NOTIFICATION
+// ============================================================================
+
+export async function notifyUpdate(bot: Bot, dataDir: string): Promise<void> {
+  try {
+    const info = await checkForUpdate();
+    if (!info?.updateAvailable) return;
+
+    const chatIds = getKnownTelegramChatIds(dataDir);
+    const message = `Update available: ${info.current} → ${info.latest}\nSend /update to install.`;
+
+    for (const chatId of chatIds) {
+      try {
+        await bot.api.sendMessage(chatId, message);
+      } catch {
+        // Chat may no longer exist or bot was removed
+      }
+    }
+  } catch {
+    // Non-critical — don't crash the bot
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@
 import { parseArgs } from "node:util";
 import { loadConfig } from "./config.js";
 import { CyclingCoachAgent } from "./agent/core.js";
-import { createTelegramBot } from "./channels/telegram.js";
+import { createTelegramBot, notifyUpdate } from "./channels/telegram.js";
 
 // ============================================================================
 // CLI ROUTING
@@ -66,6 +66,7 @@ async function main() {
     const bot = createTelegramBot(config.telegram.botToken, agent);
     console.log("Starting Telegram bot...");
     bot.start();
+    notifyUpdate(bot, config.dataDir).catch(() => {});
   } else {
     // CLI mode — read from stdin
     console.log("Cycling Coach (CLI mode). Type your message:");

--- a/src/updater.ts
+++ b/src/updater.ts
@@ -1,0 +1,51 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { execSync } from "node:child_process";
+import { resolve, join } from "node:path";
+
+const PROJECT_ROOT = resolve(import.meta.dirname, "..");
+const PACKAGE_NAME = "cycling-coach";
+const REGISTRY_URL = `https://registry.npmjs.org/${PACKAGE_NAME}/latest`;
+
+export interface UpdateInfo {
+  current: string;
+  latest: string;
+  updateAvailable: boolean;
+}
+
+export function getCurrentVersion(): string {
+  const pkg = JSON.parse(readFileSync(join(PROJECT_ROOT, "package.json"), "utf-8"));
+  return pkg.version;
+}
+
+export async function checkForUpdate(): Promise<UpdateInfo | null> {
+  try {
+    const res = await fetch(REGISTRY_URL, { signal: AbortSignal.timeout(5000) });
+    if (!res.ok) return null;
+    const data = (await res.json()) as { version: string };
+    const current = getCurrentVersion();
+    return {
+      current,
+      latest: data.version,
+      updateAvailable: data.version !== current,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function selfUpdate(): void {
+  console.log("Installing cycling-coach@latest...");
+  execSync(`npm install -g ${PACKAGE_NAME}@latest`, { stdio: "inherit" });
+  process.exit(0);
+}
+
+export function getKnownTelegramChatIds(dataDir: string): string[] {
+  const sessionsDir = join(dataDir, "sessions");
+  try {
+    return readdirSync(sessionsDir)
+      .filter((f) => f.startsWith("telegram:") && f.endsWith(".jsonl"))
+      .map((f) => f.replace("telegram:", "").replace(".jsonl", ""));
+  } catch {
+    return [];
+  }
+}


### PR DESCRIPTION
## Summary
- `/update` Telegram command: checks npm for newer version, installs, exits for restart
- Startup notification: on bot start, sends update message to known Telegram chats
- New `src/updater.ts` module with registry check, self-update, and chat ID discovery
- All errors silenced — update check never crashes the bot

## Test plan
- [ ] `/update` when on latest → "You're on the latest version"
- [ ] `/update` when outdated → installs and exits
- [ ] Bot startup with outdated version → sends notification to Telegram
- [ ] Offline/no registry → silently skips