### PR TITLE
docs: add terminal hint for beginners

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ AI-powered cycling coach you can chat with on Telegram or in the terminal. Conne
 
 Requires [Node.js](https://nodejs.org/) 20+ (comes with npm).
 
+Open **Terminal** (Mac/Linux) or **PowerShell** (Windows) and run:
+
 ```bash
 npm install -g cycling-coach
 cycling-coach setup


### PR DESCRIPTION
Tell newcomers to open Terminal/PowerShell before running install commands.