### PR TITLE
feat(tools): structured intervals.icu workout serializer

### DIFF
--- a/skills/intervals-icu.md
+++ b/skills/intervals-icu.md
@@ -71,15 +71,97 @@ Peak power at standard durations reveals athlete strengths:
 
 ## Calendar / Events
 
-### Pushing Workouts
-When creating events on the intervals.icu calendar:
-- `start_date_local`: ISO date string for the workout day
-- `category`: "WORKOUT" for planned sessions
-- `type`: "Ride" for cycling workouts
-- `name`: Descriptive name (e.g., "Sweet Spot 2x20")
-- `moving_time`: Duration in seconds
-- `icu_training_load`: Planned load
-- `description`: Workout details, interval structure, coaching notes
+### Pushing Workouts — use `intervals_create_workout`
+
+The tool takes a **structured** workout (not prose). It serializes the steps into the intervals.icu
+native format so the power chart renders on the calendar and the workout syncs to head units.
+
+Input shape:
+- `date`: "YYYY-MM-DD"
+- `workout.name`: short title shown on the calendar card
+- `workout.steps`: ordered array of steps
+
+Each top-level step is either a **simple step** or a **set** (repeating group).
+
+**Simple step**:
+```json
+{
+  "type": "warmup" | "steady" | "interval" | "ramp" | "recovery" | "rest" | "cooldown" | "freeride",
+  "duration": { "value": <number>, "unit": "seconds" | "minutes" },
+  "power": { "kind": "percent_ftp" | "watts" | "zone",
+             "value": <number>,        // single target
+             "low": <number>, "high": <number>  // range (required for ramps) },
+  "cadence": { "target": 90 }  // or { "low": 85, "high": 95 }
+}
+```
+
+**Set step**:
+```json
+{
+  "type": "set",
+  "repeat": 3,
+  "interval": { <simple step> },
+  "recovery": { <simple step> }
+}
+```
+
+Rules:
+- Power is optional only for `freeride` and `rest`. All other step types should have a power target.
+- Ramps **require** `power.low` and `power.high` (the ramp bounds).
+- For zone targets, `value` / `low` / `high` are integers 1–7 (cycling power zones). `Z2` defaults
+  to the power zone for Ride workouts.
+- Ramps are most reliably expressed as `percent_ftp` ranges (e.g. `low: 55, high: 75`). Zone-based
+  ramps may not render — prefer `percent_ftp` for warmup ramps.
+- Durations are time-only: `seconds` or `minutes`. Distance-based workouts are not supported here.
+- `moving_time` and `icu_training_load` are computed from the steps — do not pass them.
+
+### Example: Z2 endurance 90min
+
+```json
+{
+  "date": "2026-04-17",
+  "workout": {
+    "name": "Z2 Endurance 90min",
+    "steps": [
+      { "type": "warmup",   "duration": { "value": 10, "unit": "minutes" }, "power": { "kind": "percent_ftp", "low": 50, "high": 65 }, "cadence": { "low": 85, "high": 95 } },
+      { "type": "steady",   "duration": { "value": 70, "unit": "minutes" }, "power": { "kind": "percent_ftp", "low": 56, "high": 75 }, "cadence": { "low": 85, "high": 95 } },
+      { "type": "cooldown", "duration": { "value": 10, "unit": "minutes" }, "power": { "kind": "percent_ftp", "value": 50 }, "cadence": { "low": 85, "high": 95 } }
+    ]
+  }
+}
+```
+
+### Example: Sweet Spot 3×15
+
+```json
+{
+  "date": "2026-04-18",
+  "workout": {
+    "name": "Sweet Spot 3x15",
+    "steps": [
+      { "type": "warmup",   "duration": { "value": 15, "unit": "minutes" }, "power": { "kind": "percent_ftp", "low": 50, "high": 65 } },
+      {
+        "type": "set", "repeat": 3,
+        "interval": { "type": "interval", "duration": { "value": 15, "unit": "minutes" }, "power": { "kind": "percent_ftp", "low": 88, "high": 94 }, "cadence": { "low": 85, "high": 95 } },
+        "recovery": { "type": "recovery", "duration": { "value":  4, "unit": "minutes" }, "power": { "kind": "percent_ftp", "value": 50 } }
+      },
+      { "type": "cooldown", "duration": { "value": 10, "unit": "minutes" }, "power": { "kind": "percent_ftp", "value": 50 } }
+    ]
+  }
+}
+```
+
+### Athlete-facing narrative goes in chat, not the workout
+
+The calendar description is steps-only. Write the "why", the feel cues, hydration notes, and any
+coaching color in your **chat reply** to the athlete — never inside the tool call. The athlete
+reads coaching in chat; the head unit reads steps from intervals.icu.
+
+### On validation errors
+
+If the tool returns `{ error: "invalid_workout", details: <msg> }`, the structured input failed
+validation (e.g. ramp missing low/high, zone outside 1–7, power range inverted). Read the message,
+fix the offending step, and retry.
 
 ### Auto-Sync
 Workouts pushed to intervals.icu calendar automatically sync to:

--- a/skills/workout-design.md
+++ b/skills/workout-design.md
@@ -69,3 +69,65 @@ Every workout follows: Warmup → Main Set → Cooldown
 - Outdoor: Better for long rides, group rides, race simulation
 - Prescribe indoor for: weekday intervals, time-crunched sessions
 - Prescribe outdoor for: weekend long rides, endurance rides
+
+## Mapping to `intervals_create_workout`
+
+When pushing a workout to the calendar, pass the structured shape (never prose — see
+`intervals-icu.md`). Step types map to what's actually happening:
+
+| Step                          | Use                                                      |
+| ----------------------------- | -------------------------------------------------------- |
+| `warmup`                      | Pre-set progressive build-up                             |
+| `ramp`                        | Transition with `low`+`high` power bounds                |
+| `steady`                      | Single block at one intensity (e.g. Z2 endurance)        |
+| `interval`                    | Work effort inside a set (sweet spot, threshold, VO2max) |
+| `recovery`                    | Easy spin between intervals inside a set                 |
+| `rest`                        | Off-bike-style complete rest (rare in cycling)           |
+| `cooldown`                    | Post-set easy spin                                       |
+| `freeride`                    | No power target (Zwift freeride / outdoor easy)          |
+| `set { repeat, interval, recovery }` | Group repeated intervals (e.g. 3×15 sweet spot)  |
+
+### Sweet Spot 3×15 → tool input
+
+```json
+{
+  "name": "Sweet Spot 3x15",
+  "steps": [
+    { "type": "warmup",   "duration": { "value": 15, "unit": "minutes" }, "power": { "kind": "percent_ftp", "low": 50, "high": 65 } },
+    { "type": "set", "repeat": 3,
+      "interval": { "type": "interval", "duration": { "value": 15, "unit": "minutes" }, "power": { "kind": "percent_ftp", "low": 88, "high": 94 }, "cadence": { "low": 85, "high": 95 } },
+      "recovery": { "type": "recovery", "duration": { "value":  4, "unit": "minutes" }, "power": { "kind": "percent_ftp", "value": 50 } } },
+    { "type": "cooldown", "duration": { "value": 10, "unit": "minutes" }, "power": { "kind": "percent_ftp", "value": 50 } }
+  ]
+}
+```
+
+### Z2 Endurance 90min → tool input
+
+```json
+{
+  "name": "Z2 Endurance 90min",
+  "steps": [
+    { "type": "warmup",   "duration": { "value": 10, "unit": "minutes" }, "power": { "kind": "percent_ftp", "low": 50, "high": 65 }, "cadence": { "low": 85, "high": 95 } },
+    { "type": "steady",   "duration": { "value": 70, "unit": "minutes" }, "power": { "kind": "percent_ftp", "low": 56, "high": 75 }, "cadence": { "low": 85, "high": 95 } },
+    { "type": "cooldown", "duration": { "value": 10, "unit": "minutes" }, "power": { "kind": "percent_ftp", "value": 50 } }
+  ]
+}
+```
+
+### VO2max 5×4 → tool input
+
+```json
+{
+  "name": "VO2max 5x4",
+  "steps": [
+    { "type": "warmup",   "duration": { "value": 15, "unit": "minutes" }, "power": { "kind": "percent_ftp", "low": 50, "high": 70 } },
+    { "type": "set", "repeat": 5,
+      "interval": { "type": "interval", "duration": { "value": 4, "unit": "minutes" }, "power": { "kind": "percent_ftp", "low": 106, "high": 120 }, "cadence": { "low": 95, "high": 105 } },
+      "recovery": { "type": "recovery", "duration": { "value": 4, "unit": "minutes" }, "power": { "kind": "percent_ftp", "value": 50 } } },
+    { "type": "cooldown", "duration": { "value": 10, "unit": "minutes" }, "power": { "kind": "percent_ftp", "value": 50 } }
+  ]
+}
+```
+
+Narrative (feel, hydration, coaching cues) goes in your chat reply — not inside the tool call.

--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -5,6 +5,9 @@ import {
   buildPlanSkeleton,
   assessGoalFeasibility,
   getSampleWeek,
+  serializeIntervalsWorkout,
+  intervalsWorkoutInputSchema,
+  InvalidWorkoutError,
 } from "../cycling/index.js";
 import type {
   AthleteProfile,
@@ -12,6 +15,7 @@ import type {
   VolumeTier,
   DayOfWeek,
   RaceType,
+  IntervalsWorkoutInput,
 } from "../cycling/index.js";
 import type { Memory } from "./memory.js";
 import type { IntervalsClient } from "intervals-icu-api";
@@ -263,31 +267,37 @@ function createIntervalsTools(client: IntervalsClient) {
     }),
 
     intervals_create_workout: tool({
-      description: "Create a workout on the intervals.icu calendar. Auto-syncs to Garmin/Wahoo.",
+      description:
+        "Create a structured workout on the intervals.icu calendar. Auto-syncs to Garmin/Wahoo. " +
+        "Supply the workout as structured steps — the tool serializes them into the intervals.icu " +
+        "native description syntax so the power chart renders. Put athlete-facing coaching narrative " +
+        "(feel, notes, hydration) in your chat reply, not in this tool.",
       inputSchema: zodSchema(
         z.object({
           date: z.string().describe("Workout date (YYYY-MM-DD)"),
-          name: z.string().describe("Workout name"),
-          movingTime: z.number().int().describe("Duration in seconds"),
-          trainingLoad: z.number().optional().describe("Planned load"),
-          description: z.string().optional().describe("Workout details"),
+          workout: intervalsWorkoutInputSchema.describe(
+            "Structured workout: name + ordered steps. Top-level steps can be simple (warmup/steady/interval/ramp/recovery/rest/cooldown/freeride) or a set {type:'set', repeat, interval, recovery}. Durations use seconds or minutes only. Power targets: {kind:'percent_ftp'|'watts'|'zone', value} or {kind, low, high} for ranges. Ramps require low+high.",
+          ),
         }),
       ),
-      execute: async (input: {
-        date: string;
-        name: string;
-        movingTime: number;
-        trainingLoad?: number;
-        description?: string;
-      }) => {
+      execute: async (input: { date: string; workout: IntervalsWorkoutInput }) => {
+        let serialized: ReturnType<typeof serializeIntervalsWorkout>;
+        try {
+          serialized = serializeIntervalsWorkout(input.workout);
+        } catch (err) {
+          if (err instanceof InvalidWorkoutError) {
+            return { error: "invalid_workout", details: err.message };
+          }
+          throw err;
+        }
         const result = await client.events.create({
           start_date_local: `${input.date}T00:00:00`,
           category: "WORKOUT",
-          name: input.name,
+          name: input.workout.name,
           type: "Ride",
-          moving_time: input.movingTime,
-          icu_training_load: input.trainingLoad,
-          description: input.description,
+          moving_time: serialized.movingTime,
+          icu_training_load: serialized.trainingLoad,
+          description: serialized.description,
         });
         if (!result.ok) return { error: result.error.kind };
         return { created: true, event: result.value };

--- a/src/cycling/index.ts
+++ b/src/cycling/index.ts
@@ -22,4 +22,11 @@ export type { SampleWorkout, WorkoutType } from "./templates.js";
 
 export { buildPlanSkeleton } from "./plan-builder.js";
 
+export {
+  serializeIntervalsWorkout,
+  intervalsWorkoutInputSchema,
+  InvalidWorkoutError,
+} from "./intervals-serializer.js";
+export type { IntervalsWorkoutInput } from "./intervals-serializer.js";
+
 export * from "./schemas.js";

--- a/src/cycling/intervals-serializer.ts
+++ b/src/cycling/intervals-serializer.ts
@@ -1,0 +1,348 @@
+import { z } from "zod";
+
+export class InvalidWorkoutError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "InvalidWorkoutError";
+  }
+}
+
+// ============================================================================
+// SCHEMA
+// ============================================================================
+
+const stepTypeSchema = z.enum([
+  "warmup",
+  "steady",
+  "interval",
+  "ramp",
+  "recovery",
+  "rest",
+  "cooldown",
+  "freeride",
+]);
+
+const powerKindSchema = z.enum(["watts", "percent_ftp", "zone"]);
+
+const powerTargetSchema = z.object({
+  kind: powerKindSchema,
+  value: z.number().positive().optional(),
+  low: z.number().positive().optional(),
+  high: z.number().positive().optional(),
+});
+
+const durationSchema = z.object({
+  value: z.number().positive(),
+  unit: z.enum(["seconds", "minutes"]),
+});
+
+const cadenceSchema = z.object({
+  target: z.number().int().positive().max(200).optional(),
+  low: z.number().int().positive().max(200).optional(),
+  high: z.number().int().positive().max(200).optional(),
+});
+
+const simpleStepSchema = z.object({
+  type: stepTypeSchema,
+  duration: durationSchema,
+  power: powerTargetSchema.optional(),
+  cadence: cadenceSchema.optional(),
+  label: z.string().max(120).optional(),
+});
+
+const setStepSchema = z.object({
+  type: z.literal("set"),
+  repeat: z.number().int().min(1).max(20),
+  interval: simpleStepSchema,
+  recovery: simpleStepSchema,
+});
+
+export const intervalsWorkoutInputSchema = z.object({
+  name: z.string().min(1).max(120),
+  steps: z.array(z.union([simpleStepSchema, setStepSchema])).min(1).max(40),
+});
+
+export type IntervalsWorkoutInput = z.infer<typeof intervalsWorkoutInputSchema>;
+
+type SimpleStep = z.infer<typeof simpleStepSchema>;
+type SetStep = z.infer<typeof setStepSchema>;
+type PowerTarget = z.infer<typeof powerTargetSchema>;
+type CadenceTarget = z.infer<typeof cadenceSchema>;
+type AnyStep = SimpleStep | SetStep;
+type DurationInput = z.infer<typeof durationSchema>;
+
+// ============================================================================
+// CONSTANTS
+// ============================================================================
+
+// Intensity midpoints per zone (fraction of FTP). Used for load estimation.
+const ZONE_INTENSITY: Record<number, number> = {
+  1: 0.45,
+  2: 0.65,
+  3: 0.83,
+  4: 0.91,
+  5: 1.0,
+  6: 1.13,
+  7: 1.3,
+};
+
+const MAX_WATTS = 1500;
+const MAX_PERCENT_FTP = 200;
+const MAX_ZONE = 7;
+const MIN_ZONE = 1;
+
+// ============================================================================
+// SERIALIZATION
+// ============================================================================
+
+function toSeconds(d: DurationInput): number {
+  return d.unit === "seconds" ? d.value : d.value * 60;
+}
+
+function formatDuration(d: DurationInput): string {
+  const total = Math.round(toSeconds(d));
+  if (total < 60) return `${total}s`;
+  const minutes = Math.floor(total / 60);
+  const seconds = total % 60;
+  return seconds === 0 ? `${minutes}m` : `${minutes}m${seconds}`;
+}
+
+function assertZone(n: number, path: string): void {
+  if (!Number.isInteger(n) || n < MIN_ZONE || n > MAX_ZONE) {
+    throw new InvalidWorkoutError(`${path}: zone must be an integer ${MIN_ZONE}-${MAX_ZONE}, got ${n}`);
+  }
+}
+
+function formatPower(p: PowerTarget, isRamp: boolean, path: string): string {
+  const hasRange = p.low !== undefined && p.high !== undefined;
+  const hasValue = p.value !== undefined;
+
+  if (isRamp) {
+    if (!hasRange) {
+      throw new InvalidWorkoutError(`${path}: ramp requires power.low and power.high`);
+    }
+    if (p.low! > p.high!) {
+      throw new InvalidWorkoutError(`${path}: power.low (${p.low}) > power.high (${p.high})`);
+    }
+    if (p.kind === "zone") {
+      assertZone(p.low!, `${path}.power.low`);
+      assertZone(p.high!, `${path}.power.high`);
+      return `ramp Z${p.low}-Z${p.high}`;
+    }
+    if (p.kind === "percent_ftp") return `ramp ${p.low}-${p.high}%`;
+    return `ramp ${p.low}-${p.high}w`;
+  }
+
+  if (hasRange) {
+    if (p.low! > p.high!) {
+      throw new InvalidWorkoutError(`${path}: power.low (${p.low}) > power.high (${p.high})`);
+    }
+    if (p.kind === "zone") {
+      assertZone(p.low!, `${path}.power.low`);
+      assertZone(p.high!, `${path}.power.high`);
+      return `Z${p.low}-Z${p.high}`;
+    }
+    if (p.kind === "percent_ftp") return `${p.low}-${p.high}%`;
+    return `${p.low}-${p.high}w`;
+  }
+
+  if (hasValue) {
+    if (p.kind === "zone") {
+      assertZone(p.value!, `${path}.power.value`);
+      return `Z${p.value}`;
+    }
+    if (p.kind === "percent_ftp") return `${p.value}%`;
+    return `${p.value}w`;
+  }
+
+  throw new InvalidWorkoutError(`${path}: power requires 'value' or 'low'+'high'`);
+}
+
+function formatCadence(c: CadenceTarget, path: string): string {
+  if (c.low !== undefined && c.high !== undefined) {
+    if (c.low > c.high) {
+      throw new InvalidWorkoutError(`${path}: cadence.low (${c.low}) > cadence.high (${c.high})`);
+    }
+    return `${c.low}-${c.high}rpm`;
+  }
+  if (c.target !== undefined) return `${c.target}rpm`;
+  return "";
+}
+
+function formatStepLine(step: SimpleStep, path: string): string {
+  const parts: string[] = [formatDuration(step.duration)];
+  if (step.power) {
+    parts.push(formatPower(step.power, step.type === "ramp", path));
+  } else if (step.type === "ramp") {
+    throw new InvalidWorkoutError(`${path}: ramp step requires a power target`);
+  }
+  if (step.cadence) {
+    const cad = formatCadence(step.cadence, path);
+    if (cad) parts.push(cad);
+  }
+  const body = parts.join(" ");
+  return step.label ? `- ${body} ${step.label}` : `- ${body}`;
+}
+
+function sectionLabelFor(type: SimpleStep["type"] | "set"): string {
+  if (type === "warmup") return "Warmup";
+  if (type === "cooldown") return "Cooldown";
+  return "Main set";
+}
+
+function validatePowerBounds(p: PowerTarget, path: string): void {
+  const check = (v: number | undefined, name: string) => {
+    if (v === undefined) return;
+    if (p.kind === "watts" && v > MAX_WATTS) {
+      throw new InvalidWorkoutError(`${path}.power.${name}: ${v}w exceeds sanity bound ${MAX_WATTS}w`);
+    }
+    if (p.kind === "percent_ftp" && v > MAX_PERCENT_FTP) {
+      throw new InvalidWorkoutError(`${path}.power.${name}: ${v}% exceeds sanity bound ${MAX_PERCENT_FTP}%`);
+    }
+  };
+  check(p.value, "value");
+  check(p.low, "low");
+  check(p.high, "high");
+}
+
+function validateSimpleStep(step: SimpleStep, path: string): void {
+  if (step.duration.value <= 0) {
+    throw new InvalidWorkoutError(`${path}: duration must be positive`);
+  }
+  if (step.type === "ramp" && !step.power) {
+    throw new InvalidWorkoutError(`${path}: ramp step requires a power target`);
+  }
+  if (step.power) {
+    const p = step.power;
+    const hasValue = p.value !== undefined;
+    const hasRange = p.low !== undefined && p.high !== undefined;
+    if (!hasValue && !hasRange) {
+      throw new InvalidWorkoutError(`${path}: power requires 'value' or 'low'+'high'`);
+    }
+    if (step.type === "ramp" && !hasRange) {
+      throw new InvalidWorkoutError(`${path}: ramp requires power.low and power.high`);
+    }
+    validatePowerBounds(p, path);
+  }
+}
+
+function validateStep(step: AnyStep, path: string): void {
+  if (step.type === "set") {
+    validateSimpleStep(step.interval, `${path}.interval`);
+    validateSimpleStep(step.recovery, `${path}.recovery`);
+    return;
+  }
+  validateSimpleStep(step, path);
+}
+
+// ============================================================================
+// LOAD ESTIMATION
+// ============================================================================
+
+function intensityFor(step: SimpleStep, ftpWatts: number | undefined): number | undefined {
+  if (!step.power) return 0; // freeride/rest: counts zero load
+  const p = step.power;
+  const mid = (a?: number, b?: number): number | undefined =>
+    a !== undefined && b !== undefined ? (a + b) / 2 : undefined;
+
+  if (p.kind === "zone") {
+    const z = p.value ?? mid(p.low, p.high);
+    if (z === undefined) return undefined;
+    const lo = Math.floor(z);
+    const hi = Math.ceil(z);
+    const loI = ZONE_INTENSITY[lo];
+    const hiI = ZONE_INTENSITY[hi];
+    if (loI === undefined || hiI === undefined) return undefined;
+    return (loI + hiI) / 2;
+  }
+
+  if (p.kind === "percent_ftp") {
+    const pct = p.value ?? mid(p.low, p.high);
+    return pct === undefined ? undefined : pct / 100;
+  }
+
+  // watts
+  if (ftpWatts === undefined) return undefined;
+  const w = p.value ?? mid(p.low, p.high);
+  return w === undefined ? undefined : w / ftpWatts;
+}
+
+function computeLoad(steps: AnyStep[], ftpWatts: number | undefined): number | undefined {
+  let sum = 0;
+  let anyPower = false;
+  let wattsNoFtp = false;
+
+  const visit = (step: AnyStep, multiplier: number): void => {
+    if (step.type === "set") {
+      visit(step.interval, multiplier * step.repeat);
+      visit(step.recovery, multiplier * step.repeat);
+      return;
+    }
+    const secs = toSeconds(step.duration) * multiplier;
+    const intensity = intensityFor(step, ftpWatts);
+    if (intensity === undefined) {
+      if (step.power?.kind === "watts") wattsNoFtp = true;
+      return;
+    }
+    if (intensity > 0) anyPower = true;
+    sum += secs * intensity * intensity;
+  };
+
+  for (const s of steps) visit(s, 1);
+
+  if (wattsNoFtp) return undefined;
+  if (!anyPower) return undefined;
+  return Math.round((sum / 3600) * 100);
+}
+
+function totalSeconds(steps: AnyStep[]): number {
+  let total = 0;
+  const visit = (step: AnyStep, multiplier: number): void => {
+    if (step.type === "set") {
+      visit(step.interval, multiplier * step.repeat);
+      visit(step.recovery, multiplier * step.repeat);
+      return;
+    }
+    total += toSeconds(step.duration) * multiplier;
+  };
+  for (const s of steps) visit(s, 1);
+  return Math.round(total);
+}
+
+// ============================================================================
+// PUBLIC API
+// ============================================================================
+
+export function serializeIntervalsWorkout(
+  input: IntervalsWorkoutInput,
+  opts?: { ftpWatts?: number },
+): { description: string; movingTime: number; trainingLoad: number | undefined } {
+  const parsed = intervalsWorkoutInputSchema.parse(input);
+  parsed.steps.forEach((s, i) => validateStep(s, `steps[${i}]`));
+
+  const lines: string[] = [];
+  let currentLabel: string | null = null;
+
+  parsed.steps.forEach((step, i) => {
+    const label = sectionLabelFor(step.type);
+    if (label !== currentLabel) {
+      if (lines.length > 0) lines.push("");
+      lines.push(label);
+      currentLabel = label;
+    }
+    const path = `steps[${i}]`;
+    if (step.type === "set") {
+      lines.push(`${step.repeat}x`);
+      lines.push(formatStepLine(step.interval, `${path}.interval`));
+      lines.push(formatStepLine(step.recovery, `${path}.recovery`));
+    } else {
+      lines.push(formatStepLine(step, path));
+    }
+  });
+
+  return {
+    description: lines.join("\n"),
+    movingTime: totalSeconds(parsed.steps),
+    trainingLoad: computeLoad(parsed.steps, opts?.ftpWatts),
+  };
+}

--- a/tests/intervals-serializer.test.ts
+++ b/tests/intervals-serializer.test.ts
@@ -1,0 +1,520 @@
+import { describe, it, expect } from "vitest";
+import {
+  serializeIntervalsWorkout,
+  intervalsWorkoutInputSchema,
+  InvalidWorkoutError,
+  type IntervalsWorkoutInput,
+} from "../src/cycling/intervals-serializer.js";
+
+describe("serializeIntervalsWorkout — description output", () => {
+  it("emits a Z2 endurance workout as percent-ftp range", () => {
+    const input: IntervalsWorkoutInput = {
+      name: "Z2 Endurance 90min",
+      steps: [
+        {
+          type: "warmup",
+          duration: { value: 10, unit: "minutes" },
+          power: { kind: "percent_ftp", low: 50, high: 65 },
+          cadence: { low: 85, high: 95 },
+        },
+        {
+          type: "steady",
+          duration: { value: 70, unit: "minutes" },
+          power: { kind: "percent_ftp", low: 56, high: 75 },
+          cadence: { low: 85, high: 95 },
+        },
+        {
+          type: "cooldown",
+          duration: { value: 10, unit: "minutes" },
+          power: { kind: "percent_ftp", value: 50 },
+          cadence: { low: 85, high: 95 },
+        },
+      ],
+    };
+
+    const { description } = serializeIntervalsWorkout(input);
+
+    expect(description).toContain("Warmup");
+    expect(description).toContain("- 10m 50-65% 85-95rpm");
+    expect(description).toContain("Main set");
+    expect(description).toContain("- 70m 56-75% 85-95rpm");
+    expect(description).toContain("Cooldown");
+    expect(description).toContain("- 10m 50% 85-95rpm");
+  });
+
+  it("emits a sweet-spot set with Nx line and interval+recovery lines", () => {
+    const input: IntervalsWorkoutInput = {
+      name: "Sweet Spot 3x15",
+      steps: [
+        {
+          type: "warmup",
+          duration: { value: 15, unit: "minutes" },
+          power: { kind: "percent_ftp", low: 50, high: 65 },
+        },
+        {
+          type: "set",
+          repeat: 3,
+          interval: {
+            type: "interval",
+            duration: { value: 15, unit: "minutes" },
+            power: { kind: "percent_ftp", low: 88, high: 94 },
+            cadence: { low: 85, high: 95 },
+            label: "Sweet spot",
+          },
+          recovery: {
+            type: "recovery",
+            duration: { value: 4, unit: "minutes" },
+            power: { kind: "percent_ftp", value: 50 },
+          },
+        },
+        {
+          type: "cooldown",
+          duration: { value: 10, unit: "minutes" },
+          power: { kind: "percent_ftp", value: 50 },
+        },
+      ],
+    };
+
+    const { description } = serializeIntervalsWorkout(input);
+
+    expect(description).toMatch(/^Warmup$/m);
+    expect(description).toContain("- 15m 50-65%");
+    expect(description).toContain("Main set");
+    expect(description).toMatch(/^3x$/m);
+    expect(description).toContain("- 15m 88-94% 85-95rpm Sweet spot");
+    expect(description).toContain("- 4m 50%");
+    expect(description).toContain("Cooldown");
+    expect(description).toContain("- 10m 50%");
+  });
+
+  it("emits a ramp step with the 'ramp' keyword and bounds", () => {
+    const input: IntervalsWorkoutInput = {
+      name: "Ramp warmup",
+      steps: [
+        {
+          type: "ramp",
+          duration: { value: 10, unit: "minutes" },
+          power: { kind: "percent_ftp", low: 50, high: 80 },
+        },
+      ],
+    };
+
+    const { description } = serializeIntervalsWorkout(input);
+    expect(description).toContain("- 10m ramp 50-80%");
+  });
+
+  it("emits zone shorthand when kind is zone", () => {
+    const input: IntervalsWorkoutInput = {
+      name: "Zone targeted",
+      steps: [
+        {
+          type: "steady",
+          duration: { value: 60, unit: "minutes" },
+          power: { kind: "zone", value: 2 },
+        },
+      ],
+    };
+
+    const { description } = serializeIntervalsWorkout(input);
+    expect(description).toContain("- 60m Z2");
+  });
+
+  it("emits watts target with absolute values", () => {
+    const input: IntervalsWorkoutInput = {
+      name: "Watts target",
+      steps: [
+        {
+          type: "steady",
+          duration: { value: 30, unit: "minutes" },
+          power: { kind: "watts", low: 150, high: 180 },
+        },
+      ],
+    };
+
+    const { description } = serializeIntervalsWorkout(input);
+    expect(description).toContain("- 30m 150-180w");
+  });
+
+  it("formats sub-minute durations as seconds", () => {
+    const input: IntervalsWorkoutInput = {
+      name: "Short sprints",
+      steps: [
+        {
+          type: "interval",
+          duration: { value: 30, unit: "seconds" },
+          power: { kind: "percent_ftp", value: 150 },
+        },
+      ],
+    };
+
+    const { description } = serializeIntervalsWorkout(input);
+    expect(description).toContain("- 30s 150%");
+  });
+
+  it("formats 90-second durations as 1m30", () => {
+    const input: IntervalsWorkoutInput = {
+      name: "90s effort",
+      steps: [
+        {
+          type: "interval",
+          duration: { value: 90, unit: "seconds" },
+          power: { kind: "percent_ftp", value: 120 },
+        },
+      ],
+    };
+
+    const { description } = serializeIntervalsWorkout(input);
+    expect(description).toContain("- 1m30 120%");
+  });
+
+  it("emits duration-only line for freeride with no power", () => {
+    const input: IntervalsWorkoutInput = {
+      name: "Outdoor easy",
+      steps: [
+        {
+          type: "freeride",
+          duration: { value: 60, unit: "minutes" },
+          label: "Keep it easy",
+        },
+      ],
+    };
+
+    const { description } = serializeIntervalsWorkout(input);
+    expect(description).toContain("- 60m Keep it easy");
+  });
+
+  it("does not repeat the section label for consecutive same-section steps", () => {
+    const input: IntervalsWorkoutInput = {
+      name: "Two warmup steps",
+      steps: [
+        {
+          type: "warmup",
+          duration: { value: 5, unit: "minutes" },
+          power: { kind: "percent_ftp", value: 50 },
+        },
+        {
+          type: "warmup",
+          duration: { value: 5, unit: "minutes" },
+          power: { kind: "percent_ftp", value: 60 },
+        },
+      ],
+    };
+
+    const { description } = serializeIntervalsWorkout(input);
+    const warmupCount = (description.match(/^Warmup$/gm) ?? []).length;
+    expect(warmupCount).toBe(1);
+  });
+});
+
+describe("serializeIntervalsWorkout — movingTime", () => {
+  it("sums simple step durations", () => {
+    const input: IntervalsWorkoutInput = {
+      name: "Test",
+      steps: [
+        { type: "warmup", duration: { value: 10, unit: "minutes" }, power: { kind: "percent_ftp", value: 55 } },
+        { type: "steady", duration: { value: 30, unit: "minutes" }, power: { kind: "percent_ftp", value: 65 } },
+        { type: "cooldown", duration: { value: 5, unit: "minutes" }, power: { kind: "percent_ftp", value: 50 } },
+      ],
+    };
+
+    const { movingTime } = serializeIntervalsWorkout(input);
+    expect(movingTime).toBe(45 * 60);
+  });
+
+  it("multiplies set durations by repeat count", () => {
+    const input: IntervalsWorkoutInput = {
+      name: "Test",
+      steps: [
+        { type: "warmup", duration: { value: 10, unit: "minutes" }, power: { kind: "percent_ftp", value: 55 } },
+        {
+          type: "set",
+          repeat: 3,
+          interval: { type: "interval", duration: { value: 15, unit: "minutes" }, power: { kind: "percent_ftp", value: 90 } },
+          recovery: { type: "recovery", duration: { value: 4, unit: "minutes" }, power: { kind: "percent_ftp", value: 50 } },
+        },
+        { type: "cooldown", duration: { value: 10, unit: "minutes" }, power: { kind: "percent_ftp", value: 50 } },
+      ],
+    };
+
+    // 10 + (15+4)*3 + 10 = 77 min
+    const { movingTime } = serializeIntervalsWorkout(input);
+    expect(movingTime).toBe(77 * 60);
+  });
+
+  it("handles mixed seconds/minutes", () => {
+    const input: IntervalsWorkoutInput = {
+      name: "Test",
+      steps: [
+        { type: "steady", duration: { value: 90, unit: "seconds" }, power: { kind: "percent_ftp", value: 70 } },
+        { type: "steady", duration: { value: 2, unit: "minutes" }, power: { kind: "percent_ftp", value: 70 } },
+      ],
+    };
+
+    const { movingTime } = serializeIntervalsWorkout(input);
+    expect(movingTime).toBe(90 + 120);
+  });
+});
+
+describe("serializeIntervalsWorkout — trainingLoad", () => {
+  it("computes load ≈ 40 for a pure Z2 60min ride", () => {
+    const input: IntervalsWorkoutInput = {
+      name: "Z2 60min",
+      steps: [
+        {
+          type: "steady",
+          duration: { value: 60, unit: "minutes" },
+          power: { kind: "percent_ftp", value: 65 },
+        },
+      ],
+    };
+
+    const { trainingLoad } = serializeIntervalsWorkout(input);
+    // 60min at 65% FTP: intensity=0.65, load = 3600 * 0.65^2 / 3600 * 100 = 42.25 → 42
+    expect(trainingLoad).toBe(42);
+  });
+
+  it("returns undefined when any step uses watts and ftpWatts is missing", () => {
+    const input: IntervalsWorkoutInput = {
+      name: "Watts workout",
+      steps: [
+        {
+          type: "steady",
+          duration: { value: 60, unit: "minutes" },
+          power: { kind: "watts", value: 200 },
+        },
+      ],
+    };
+
+    const { trainingLoad } = serializeIntervalsWorkout(input);
+    expect(trainingLoad).toBeUndefined();
+  });
+
+  it("computes load from watts when ftpWatts is provided", () => {
+    const input: IntervalsWorkoutInput = {
+      name: "Watts workout",
+      steps: [
+        {
+          type: "steady",
+          duration: { value: 60, unit: "minutes" },
+          power: { kind: "watts", value: 200 },
+        },
+      ],
+    };
+
+    const { trainingLoad } = serializeIntervalsWorkout(input, { ftpWatts: 200 });
+    // intensity = 200/200 = 1.0, load = 100
+    expect(trainingLoad).toBe(100);
+  });
+
+  it("returns undefined when no step has a power target", () => {
+    const input: IntervalsWorkoutInput = {
+      name: "Freeride",
+      steps: [
+        {
+          type: "freeride",
+          duration: { value: 60, unit: "minutes" },
+        },
+      ],
+    };
+
+    const { trainingLoad } = serializeIntervalsWorkout(input);
+    expect(trainingLoad).toBeUndefined();
+  });
+});
+
+describe("serializeIntervalsWorkout — validation", () => {
+  it("rejects empty steps array at schema level", () => {
+    const bad = { name: "Empty", steps: [] };
+    expect(() => serializeIntervalsWorkout(bad as IntervalsWorkoutInput)).toThrow();
+  });
+
+  it("rejects ramp without power.low and power.high", () => {
+    const input = {
+      name: "Bad ramp",
+      steps: [
+        {
+          type: "ramp" as const,
+          duration: { value: 10, unit: "minutes" as const },
+          power: { kind: "percent_ftp" as const, value: 70 },
+        },
+      ],
+    };
+
+    expect(() => serializeIntervalsWorkout(input)).toThrow(InvalidWorkoutError);
+    expect(() => serializeIntervalsWorkout(input)).toThrow(/ramp requires power\.low and power\.high/);
+  });
+
+  it("rejects ramp with no power target at all", () => {
+    const input = {
+      name: "Bad ramp",
+      steps: [
+        {
+          type: "ramp" as const,
+          duration: { value: 10, unit: "minutes" as const },
+        },
+      ],
+    };
+
+    expect(() => serializeIntervalsWorkout(input)).toThrow(InvalidWorkoutError);
+  });
+
+  it("rejects zone values outside 1-7", () => {
+    const input = {
+      name: "Bad zone",
+      steps: [
+        {
+          type: "steady" as const,
+          duration: { value: 30, unit: "minutes" as const },
+          power: { kind: "zone" as const, value: 8 },
+        },
+      ],
+    };
+
+    expect(() => serializeIntervalsWorkout(input)).toThrow(InvalidWorkoutError);
+    expect(() => serializeIntervalsWorkout(input)).toThrow(/zone must be an integer/);
+  });
+
+  it("rejects percent_ftp above sanity bound", () => {
+    const input = {
+      name: "Absurd percent",
+      steps: [
+        {
+          type: "interval" as const,
+          duration: { value: 30, unit: "seconds" as const },
+          power: { kind: "percent_ftp" as const, value: 250 },
+        },
+      ],
+    };
+
+    expect(() => serializeIntervalsWorkout(input)).toThrow(InvalidWorkoutError);
+    expect(() => serializeIntervalsWorkout(input)).toThrow(/exceeds sanity bound/);
+  });
+
+  it("rejects watts above sanity bound", () => {
+    const input = {
+      name: "Absurd watts",
+      steps: [
+        {
+          type: "interval" as const,
+          duration: { value: 5, unit: "seconds" as const },
+          power: { kind: "watts" as const, value: 2000 },
+        },
+      ],
+    };
+
+    expect(() => serializeIntervalsWorkout(input)).toThrow(InvalidWorkoutError);
+  });
+
+  it("rejects power with no value and no range", () => {
+    const input = {
+      name: "Empty power",
+      steps: [
+        {
+          type: "steady" as const,
+          duration: { value: 30, unit: "minutes" as const },
+          power: { kind: "percent_ftp" as const },
+        },
+      ],
+    };
+
+    expect(() => serializeIntervalsWorkout(input)).toThrow(InvalidWorkoutError);
+  });
+
+  it("rejects power.low greater than power.high", () => {
+    const input = {
+      name: "Inverted range",
+      steps: [
+        {
+          type: "steady" as const,
+          duration: { value: 30, unit: "minutes" as const },
+          power: { kind: "percent_ftp" as const, low: 90, high: 70 },
+        },
+      ],
+    };
+
+    expect(() => serializeIntervalsWorkout(input)).toThrow(InvalidWorkoutError);
+  });
+
+  it("rejects cadence.low greater than cadence.high", () => {
+    const input = {
+      name: "Inverted cadence",
+      steps: [
+        {
+          type: "steady" as const,
+          duration: { value: 30, unit: "minutes" as const },
+          power: { kind: "percent_ftp" as const, value: 65 },
+          cadence: { low: 100, high: 80 },
+        },
+      ],
+    };
+
+    expect(() => serializeIntervalsWorkout(input)).toThrow(InvalidWorkoutError);
+  });
+
+  it("rejects set with repeat > 20 at schema level", () => {
+    const input = {
+      name: "Too many repeats",
+      steps: [
+        {
+          type: "set" as const,
+          repeat: 21,
+          interval: {
+            type: "interval" as const,
+            duration: { value: 1, unit: "minutes" as const },
+            power: { kind: "percent_ftp" as const, value: 110 },
+          },
+          recovery: {
+            type: "recovery" as const,
+            duration: { value: 1, unit: "minutes" as const },
+            power: { kind: "percent_ftp" as const, value: 50 },
+          },
+        },
+      ],
+    };
+
+    expect(() => serializeIntervalsWorkout(input)).toThrow();
+  });
+
+  it("rejects top-level steps array longer than 40", () => {
+    const step = {
+      type: "steady" as const,
+      duration: { value: 1, unit: "minutes" as const },
+      power: { kind: "percent_ftp" as const, value: 65 },
+    };
+    const input = {
+      name: "Too many steps",
+      steps: Array.from({ length: 41 }, () => step),
+    };
+
+    expect(() => serializeIntervalsWorkout(input)).toThrow();
+  });
+});
+
+describe("intervalsWorkoutInputSchema", () => {
+  it("rejects distance-based durations (schema enum)", () => {
+    const result = intervalsWorkoutInputSchema.safeParse({
+      name: "Distance",
+      steps: [
+        {
+          type: "steady",
+          duration: { value: 10, unit: "distance_km" },
+          power: { kind: "percent_ftp", value: 70 },
+        },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects missing name", () => {
+    const result = intervalsWorkoutInputSchema.safeParse({
+      steps: [
+        {
+          type: "steady",
+          duration: { value: 10, unit: "minutes" },
+          power: { kind: "percent_ftp", value: 70 },
+        },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- `intervals_create_workout` now accepts a structured `workout` object (name + ordered steps) instead of free-form `name`/`movingTime`/`description` fields.
- New `src/cycling/intervals-serializer.ts` converts the structured shape into the intervals.icu native description syntax so the power chart renders in the app.
- `skills/workout-design.md` + `skills/intervals-icu.md` updated with the new mapping and examples (sweet spot, Z2 endurance, VO2max).

## Test plan

- [x] \`npm test\` — new \`tests/intervals-serializer.test.ts\` covers simple/ramp/set/validation cases; 85/85 pass
- [x] \`npm run check\` — typecheck + lint clean
- [ ] After merge: send a /workout via Telegram, confirm the power chart renders in intervals.icu