### PR TITLE
fix(telegram): stop /update from looping on every restart

### DIFF
--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -1,7 +1,14 @@
 import { Bot } from "grammy";
 import type { CyclingCoachAgent } from "../agent/core.js";
 import { isRateLimitError, extractRetryAfterMs } from "../agent/token-utils.js";
-import { checkForUpdate, selfUpdate, getKnownTelegramChatIds, getCurrentVersion } from "../updater.js";
+import {
+  checkForUpdate,
+  selfUpdate,
+  getKnownTelegramChatIds,
+  getCurrentVersion,
+  getLastNotifiedVersion,
+  setLastNotifiedVersion,
+} from "../updater.js";
 
 function formatRateLimitWait(err: unknown): string {
   const ms = extractRetryAfterMs(err);
@@ -125,7 +132,9 @@ export function createTelegramBot(token: string, agent: CyclingCoachAgent): Bot 
         return;
       }
       await ctx.reply(`Updating ${info.current} → ${info.latest}...\nThe bot will stop after installation. Run \`cycling-coach\` to start it again.`);
-      selfUpdate();
+      // Stop polling first so Telegram commits the /update offset — otherwise
+      // Telegram re-sends /update on next startup and we loop forever.
+      void bot.stop().then(selfUpdate);
     } catch (err) {
       console.error("Error in /update:", err);
       await ctx.reply("Update failed. Please run `npm install -g cycling-coach@latest` manually.");
@@ -247,6 +256,8 @@ export async function notifyUpdate(bot: Bot, dataDir: string): Promise<void> {
     const info = await checkForUpdate();
     if (!info?.updateAvailable) return;
 
+    if (getLastNotifiedVersion(dataDir) === info.latest) return;
+
     const chatIds = getKnownTelegramChatIds(dataDir);
     const message = `Update available: ${info.current} → ${info.latest}\nSend /update to install.`;
 
@@ -257,6 +268,8 @@ export async function notifyUpdate(bot: Bot, dataDir: string): Promise<void> {
         // Chat may no longer exist or bot was removed
       }
     }
+
+    setLastNotifiedVersion(dataDir, info.latest);
   } catch {
     // Non-critical — don't crash the bot
   }

--- a/src/updater.ts
+++ b/src/updater.ts
@@ -1,4 +1,4 @@
-import { readFileSync, readdirSync } from "node:fs";
+import { readFileSync, readdirSync, writeFileSync, mkdirSync } from "node:fs";
 import { execSync } from "node:child_process";
 import { resolve, join } from "node:path";
 
@@ -47,5 +47,24 @@ export function getKnownTelegramChatIds(dataDir: string): string[] {
       .map((f) => f.replace("telegram:", "").replace(".jsonl", ""));
   } catch {
     return [];
+  }
+}
+
+const NOTIFIED_VERSION_FILE = "last-notified-version";
+
+export function getLastNotifiedVersion(dataDir: string): string | null {
+  try {
+    return readFileSync(join(dataDir, NOTIFIED_VERSION_FILE), "utf-8").trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+export function setLastNotifiedVersion(dataDir: string, version: string): void {
+  try {
+    mkdirSync(dataDir, { recursive: true });
+    writeFileSync(join(dataDir, NOTIFIED_VERSION_FILE), version);
+  } catch {
+    // Non-critical — don't crash the bot
   }
 }


### PR DESCRIPTION
## Summary

Two bugs caused "Update available" and "Checking for updates..." / "Updating..." to repeat on every bot startup:

1. **notifyUpdate had no dedup** — re-sent the "Update available" message on every restart. Now records the notified version under \`{dataDir}/last-notified-version\` and skips if already notified for that version.
2. **/update handler exited before committing the Telegram offset** — \`selfUpdate()\` called \`process.exit(0)\` before grammy could confirm the \`/update\` message via \`getUpdates\`, so Telegram re-delivered it on every restart, causing an infinite loop. Fix: call \`bot.stop()\` first (grammy's stop() commits the offset via \`getUpdates({ offset, limit: 1 })\`), then run \`selfUpdate()\`.

## Test plan

- [x] \`npm test\` — 85/85 pass
- [x] \`npm run check\` — typecheck + lint clean
- [ ] After merge + release: trigger /update in Telegram and confirm no message repetition on restart
- [ ] Confirm \`last-notified-version\` file is created under \`~/.cycling-coach/\` after the first notification