### PR TITLE
docs: rework README intro with BYO-LLM tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # Cycling Coach
 
-AI-powered cycling coach you can chat with on Telegram or in the terminal. Connect your [intervals.icu](https://intervals.icu) account to pull real training data — the coach analyzes your fitness, builds periodized plans, and pushes structured workouts straight to your calendar (auto-syncs to Garmin, Wahoo, Hammerhead, COROS, Suunto, and Zwift).
+AI cycling coaching agent. Bring your own LLM API key, connect [intervals.icu](https://intervals.icu) for real athlete data, chat via Telegram or CLI.
+
+## What it does
+
+- Analyzes fitness, fatigue, and form from your real rides
+- Builds periodized plans toward your goal event
+- Pushes structured workouts to your intervals.icu calendar (auto-syncs to Garmin, Wahoo, Hammerhead, COROS, Suunto, Zwift)
 
 ## How it works
 


### PR DESCRIPTION
## Summary
- Replace the old README intro paragraph with a tighter tagline that highlights bring-your-own LLM API key, intervals.icu integration, and Telegram/CLI chat.
- Move the device-sync and periodization details into a new **What it does** section (three bullets).

## Test plan
- [x] README renders as expected on GitHub (tagline + What it does + existing How it works section).