### PR TITLE
feat(auth): add ChatGPT subscription OAuth (OpenAI Codex)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,15 @@ Cycling Coach (CLI mode). Type your message:
 > /quit
 ```
 
-**Where to get API keys:**
-- **LLM**: [Anthropic Console](https://console.anthropic.com/), [OpenAI Platform](https://platform.openai.com/), or [Google AI Studio](https://aistudio.google.com/)
+**LLM provider options:**
+- **Anthropic (Claude)** — console API key from [Anthropic Console](https://console.anthropic.com/). Recommended default.
+- **OpenAI (GPT)** — console API key from [OpenAI Platform](https://platform.openai.com/).
+- **Google (Gemini)** — console API key from [Google AI Studio](https://aistudio.google.com/).
+- **OpenAI Codex (ChatGPT subscription) — experimental** — browser OAuth sign-in with your ChatGPT Plus / Pro / Business / Edu / Enterprise account. No API key needed; uses your subscription quota. Minimum tier: ChatGPT Plus ($20/mo). Select it in `cycling-coach setup` to start the OAuth flow. On hard rate-limit failures the bot retries up to 4× with backoff (~35s total) before reporting the error to the chat.
+
+Anthropic's Claude Pro/Max subscription does **not** support OAuth for third-party tools (per Anthropic ToS) — the only supported Anthropic path here is the console API key.
+
+**Where to get other keys:**
 - **intervals.icu**: [intervals.icu/settings](https://intervals.icu/settings) > Developer Settings
 - **Telegram**: Message [@BotFather](https://t.me/BotFather) > `/newbot`
 
@@ -141,6 +148,15 @@ intervals:
 
 telegram:
   bot_token: "123456:ABC..."
+```
+
+For the Codex OAuth path, the config has no `api_key` — tokens live in `~/.cycling-coach/auth-profiles.json` (mode `0600`) and rotate automatically:
+
+```yaml
+llm:
+  provider: openai-codex
+  model: gpt-5.4
+  auth_profile: openai-codex
 ```
 
 Env vars take precedence over YAML.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cycling Coach
 
-AI cycling coaching agent. Bring your own LLM API key, connect [intervals.icu](https://intervals.icu) for real athlete data, chat via Telegram or CLI.
+AI cycling coaching agent. Bring your own LLM API key **or sign in with a ChatGPT Plus subscription**, connect [intervals.icu](https://intervals.icu) for real athlete data, chat via Telegram or CLI.
 
 ## What it does
 
@@ -58,7 +58,7 @@ cycling-coach setup
 cycling-coach
 ```
 
-The setup wizard asks for your LLM API key and optionally connects [intervals.icu](https://intervals.icu) and Telegram. After setup, `cycling-coach` starts in CLI mode — or Telegram mode if you provided a bot token.
+The setup wizard asks for your LLM provider — an API key for Anthropic / OpenAI / Google, **or OAuth sign-in with your ChatGPT subscription** (no API key needed). Then optionally connects [intervals.icu](https://intervals.icu) and Telegram. After setup, `cycling-coach` starts in CLI mode — or Telegram mode if you provided a bot token.
 
 ```
 Cycling Coach (CLI mode). Type your message:
@@ -72,7 +72,7 @@ Cycling Coach (CLI mode). Type your message:
 - **Anthropic (Claude)** — console API key from [Anthropic Console](https://console.anthropic.com/). Recommended default.
 - **OpenAI (GPT)** — console API key from [OpenAI Platform](https://platform.openai.com/).
 - **Google (Gemini)** — console API key from [Google AI Studio](https://aistudio.google.com/).
-- **OpenAI Codex (ChatGPT subscription) — experimental** — browser OAuth sign-in with your ChatGPT Plus / Pro / Business / Edu / Enterprise account. No API key needed; uses your subscription quota. Minimum tier: ChatGPT Plus ($20/mo). Select it in `cycling-coach setup` to start the OAuth flow. On hard rate-limit failures the bot retries up to 4× with backoff (~35s total) before reporting the error to the chat.
+- **OpenAI Codex (ChatGPT subscription) — experimental** — browser OAuth sign-in with your ChatGPT Plus / Pro / Business / Edu / Enterprise account. No API key needed; the bot uses your subscription quota. Minimum tier: ChatGPT Plus ($20/mo). Select it in `cycling-coach setup` to start the OAuth flow. Models offered in the wizard: `gpt-5.4` (balanced, recommended) and `gpt-5.4-mini` (faster, smaller context). Cost is covered by the subscription regardless of which model you pick — the choice is speed vs capability, not price. On hard rate-limit failures the bot retries up to 4× with backoff (~35s total) before reporting the error to the chat.
 
 Anthropic's Claude Pro/Max subscription does **not** support OAuth for third-party tools (per Anthropic ToS) — the only supported Anthropic path here is the console API key.
 
@@ -165,7 +165,7 @@ Env vars take precedence over YAML.
 
 ```bash
 npm run check       # tsc --noEmit + oxlint
-npm test            # vitest (28 tests)
+npm test            # vitest (112 tests)
 npm run test:watch  # vitest watch mode
 npm run lint        # oxlint
 npm run fmt         # oxfmt
@@ -194,7 +194,7 @@ src/
   index.ts           # Entry point
 skills/              # Markdown domain knowledge (loaded into system prompt)
 SOUL.md              # Coaching persona
-tests/               # 28 tests
+tests/               # 112 tests
 ```
 
 ## Tech stack

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@ai-sdk/google": "^3.0.63",
         "@ai-sdk/openai": "^3.0.52",
         "@clack/prompts": "^1.2.0",
+        "@mariozechner/pi-ai": "0.67.6",
         "ai": "^6.0.158",
         "grammy": "^1.42.0",
         "intervals-icu-api": "^0.1.2",
@@ -129,6 +130,730 @@
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.90.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.90.0.tgz",
+      "integrity": "sha512-MzZtPabJF1b0FTDl6Z6H5ljphPwACLGP13lu8MTiB8jXaW/YXlpOp+Po2cVou3MPM5+f5toyLnul9whKCy7fBg==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-runtime": {
+      "version": "3.1031.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1031.0.tgz",
+      "integrity": "sha512-ZgiSo2wslPXlv7wK4m2ULu2VfimbVRRlho0DqXhlvZGEqvtC209cMOxfPZWJ79Fz9sf0IzmWFkDtvMYjnwyLfw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.0",
+        "@aws-sdk/credential-provider-node": "^3.972.31",
+        "@aws-sdk/eventstream-handler-node": "^3.972.14",
+        "@aws-sdk/middleware-eventstream": "^3.972.10",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-user-agent": "^3.972.30",
+        "@aws-sdk/middleware-websocket": "^3.972.16",
+        "@aws-sdk/region-config-resolver": "^3.972.12",
+        "@aws-sdk/token-providers": "3.1031.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.7",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.16",
+        "@smithy/config-resolver": "^4.4.16",
+        "@smithy/core": "^3.23.15",
+        "@smithy/eventstream-serde-browser": "^4.2.14",
+        "@smithy/eventstream-serde-config-resolver": "^4.3.14",
+        "@smithy/eventstream-serde-node": "^4.2.14",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.30",
+        "@smithy/middleware-retry": "^4.5.3",
+        "@smithy/middleware-serde": "^4.2.18",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.5.3",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.11",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.47",
+        "@smithy/util-defaults-mode-node": "^4.2.52",
+        "@smithy/util-endpoints": "^3.4.1",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.2",
+        "@smithy/util-stream": "^4.5.23",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.974.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.0.tgz",
+      "integrity": "sha512-8j+dMtyDqNXFmi09CBdz8TY6Ltf2jhfHuP6ZvG4zVjndRc6JF0aeBUbRwQLndbptFCsdctRQgdNWecy4TIfXAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/xml-builder": "^3.972.18",
+        "@smithy/core": "^3.23.15",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.11",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.26",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.26.tgz",
+      "integrity": "sha512-WBHAMxyPdgeJY6ZGLvq9mJwzZ+GaNUROQbfdVshtMsDVBrZTj5ZuFjKclSjSHvKSHJ4Y4O2yvI/aA/hrJbYfng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.28",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.28.tgz",
+      "integrity": "sha512-+1DwCjjpo1WoiZTN08yGitI3nUwZUSQWVWFrW4C46HqZwACjcUQ7C66tnKPBTVxrEYYDOP11A6Afmu1L6ylt3g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/node-http-handler": "^4.5.3",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.11",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-stream": "^4.5.23",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.30",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.30.tgz",
+      "integrity": "sha512-Fg1oJcoijwOZjTxdbx+ubqbQl8YEQ4Cwhjw6TWzQjuDEvQYNhnCXW2pN7eKtdTrdE4a6+5TVKGSm2I+i2BKIQg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.0",
+        "@aws-sdk/credential-provider-env": "^3.972.26",
+        "@aws-sdk/credential-provider-http": "^3.972.28",
+        "@aws-sdk/credential-provider-login": "^3.972.30",
+        "@aws-sdk/credential-provider-process": "^3.972.26",
+        "@aws-sdk/credential-provider-sso": "^3.972.30",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.30",
+        "@aws-sdk/nested-clients": "^3.996.20",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.30",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.30.tgz",
+      "integrity": "sha512-nchIrrI/7dgjG1bW/DEWOJc00K9n+kkl6B8Mk0KO6d4GfWBOXlVr9uHp7CJR9FIrjmov5SGjHXG2q9XAtkRw6Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.0",
+        "@aws-sdk/nested-clients": "^3.996.20",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.31",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.31.tgz",
+      "integrity": "sha512-99OHVQ6eZ5DTxiOWgHdjBMvLqv7xoY4jLK6nZ1NcNSQbAnYZkQNIHi/VqInc9fnmg7of9si/z+waE6YL9OQIlw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.26",
+        "@aws-sdk/credential-provider-http": "^3.972.28",
+        "@aws-sdk/credential-provider-ini": "^3.972.30",
+        "@aws-sdk/credential-provider-process": "^3.972.26",
+        "@aws-sdk/credential-provider-sso": "^3.972.30",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.30",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.26",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.26.tgz",
+      "integrity": "sha512-jibxNld3m+vbmQwn98hcQ+fLIVrx3cQuhZlSs1/hix48SjDS5/pjMLwpmtLD/lFnd6ve1AL4o1bZg3X1WRa2SQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.30",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.30.tgz",
+      "integrity": "sha512-honYIM17F/+QSWJRE84T4u//ofqEi7rLbnwmIpu7fgFX5PML78wbtdSAy5Xwyve3TLpE9/f9zQx0aBVxSjAOPw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.0",
+        "@aws-sdk/nested-clients": "^3.996.20",
+        "@aws-sdk/token-providers": "3.1031.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.30",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.30.tgz",
+      "integrity": "sha512-CyL4oWUlONQRN2SsYMVrA9Z3i3QfLWTQctI8tuKbjNGCVVDCnJf/yMbSJCOZgpPFRtxh7dgQwvpqwmJm+iytmw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.0",
+        "@aws-sdk/nested-clients": "^3.996.20",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-handler-node": {
+      "version": "3.972.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.14.tgz",
+      "integrity": "sha512-m4X56gxG76/CKfxNVbOFuYwnAZcHgS6HOH8lgp15HoGHIAVTcZfZrXvcYzJFOMLEJgVn+JHBu6EiNV+xSNXXFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/eventstream-codec": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-eventstream": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.10.tgz",
+      "integrity": "sha512-QUqLs7Af1II9X4fCRAu+EGHG3KHyOp4RkuLhRKoA3NuFlh6TL8i+zXBl8w2LUxqm44B/Kom45hgSlwA1SpTsXQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.10.tgz",
+      "integrity": "sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.10.tgz",
+      "integrity": "sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.11.tgz",
+      "integrity": "sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.972.30",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.30.tgz",
+      "integrity": "sha512-lCz6JfelhjD6Eco1urXM2rOYRaxROSqeoY6IEKx+soegFJOajmIBCMHTAWuJl25Wf9IAST+i0/yOk9G3rMV26A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.7",
+        "@smithy/core": "^3.23.15",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-retry": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-websocket": {
+      "version": "3.972.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.16.tgz",
+      "integrity": "sha512-86+S9oCyRVGzoMRpQhxkArp7kD2K75GPmaNevd9B6EyNhWoNvnCZZ3WbgN4j7ZT+jvtvBCGZvI2XHsWZJ+BRIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-format-url": "^3.972.10",
+        "@smithy/eventstream-codec": "^4.2.14",
+        "@smithy/eventstream-serde-browser": "^4.2.14",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.996.20",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.20.tgz",
+      "integrity": "sha512-bzPdsNQnCh6TvvUmTHLZlL8qgyME6mNiUErcRMyJPywIl1BEu2VZRShel3mUoSh89bOBEXEWtjocDMolFxd/9A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.0",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-user-agent": "^3.972.30",
+        "@aws-sdk/region-config-resolver": "^3.972.12",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.7",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.16",
+        "@smithy/config-resolver": "^4.4.16",
+        "@smithy/core": "^3.23.15",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.30",
+        "@smithy/middleware-retry": "^4.5.3",
+        "@smithy/middleware-serde": "^4.2.18",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.5.3",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.11",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.47",
+        "@smithy/util-defaults-mode-node": "^4.2.52",
+        "@smithy/util-endpoints": "^3.4.1",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.972.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.12.tgz",
+      "integrity": "sha512-QQI43Mxd53nBij0pm8HXC+t4IOC6gnhhZfzxE0OATQyO6QfPV4e+aTIRRuAJKA6Nig/cR8eLwPryqYTX9ZrjAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/config-resolver": "^4.4.16",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1031.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1031.0.tgz",
+      "integrity": "sha512-zj/PvnbQK/2KJNln5K2QRI9HSsy+B4emz2gbQyUHkk6l7Lidu83P/9tfmC2cJXkcC3vdmyKH2DP3Iw/FDfKQuQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.0",
+        "@aws-sdk/nested-clients": "^3.996.20",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.996.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.7.tgz",
+      "integrity": "sha512-ty4LQxN1QC+YhUP28NfEgZDEGXkyqOQy+BDriBozqHsrYO4JMgiPhfizqOGF7P+euBTZ5Ez6SKlLAMCLo8tzmw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-endpoints": "^3.4.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-format-url": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.972.10.tgz",
+      "integrity": "sha512-DEKiHNJVtNxdyTeQspzY+15Po/kHm6sF0Cs4HV9Q2+lplB63+DrvdeiSoOSdWEWAoO2RcY1veoXVDz2tWxWCgQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/querystring-builder": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.10.tgz",
+      "integrity": "sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.973.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.16.tgz",
+      "integrity": "sha512-ccvu0FNCI0C6OqmxI/tWn7BD8qGooWuURssiIM+6vbksFO8opXR4JOGtGYPj8QYzN/vfwNYrcK344PPbYuvzRg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "^3.972.30",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.18",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.18.tgz",
+      "integrity": "sha512-BMDNVG1ETXRhl1tnisQiYBef3RShJ1kfZA7x7afivTFMLirfHNTb6U71K569HNXhSXbQZsweHvSDZ6euBw8hPA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "fast-xml-parser": "5.5.8",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@clack/core": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.2.0.tgz",
@@ -149,31 +874,6 @@
         "fast-string-width": "^1.1.0",
         "fast-wrap-ansi": "^0.1.3",
         "sisteransi": "^1.0.5"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -629,6 +1329,29 @@
         "node": ">=18"
       }
     },
+    "node_modules/@google/genai": {
+      "version": "1.50.1",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.50.1.tgz",
+      "integrity": "sha512-YbkX7H9+1Pt8wOt7DDREy8XSoiL6fRDzZQRyaVBarFf8MR3zHGqVdvM4cLbDXqPhxqvegZShgfxb8kw9C7YhAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@grammyjs/types": {
       "version": "3.26.0",
       "resolved": "https://registry.npmjs.org/@grammyjs/types/-/types-3.26.0.tgz",
@@ -729,6 +1452,43 @@
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@mariozechner/pi-ai": {
+      "version": "0.67.6",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.67.6.tgz",
+      "integrity": "sha512-muGq9wG+nOjuJrk4nCy3FWUfK2MPQMmGS6yVApVZB8A6R/4HyiSBRHOafnh1nfamudkcy90lDqUtVfLfwpHSFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@anthropic-ai/sdk": "^0.90.0",
+        "@aws-sdk/client-bedrock-runtime": "^3.1030.0",
+        "@google/genai": "^1.40.0",
+        "@mistralai/mistralai": "1.14.1",
+        "@sinclair/typebox": "^0.34.41",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "chalk": "^5.6.2",
+        "openai": "6.26.0",
+        "partial-json": "^0.1.7",
+        "proxy-agent": "^6.5.0",
+        "undici": "^7.19.1",
+        "zod-to-json-schema": "^3.24.6"
+      },
+      "bin": {
+        "pi-ai": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@mistralai/mistralai": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-1.14.1.tgz",
+      "integrity": "sha512-IiLmmZFCCTReQgPAT33r7KQ1nYo5JPdvGkrkZqA8qQ2qB1GHgs5LoP5K2ICyrjnpw2n8oSxMM/VP+liiKcGNlQ==",
+      "dependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-to-json-schema": "^3.24.1"
+      }
     },
     "node_modules/@mswjs/interceptors": {
       "version": "0.41.3",
@@ -1457,6 +2217,70 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.15",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
@@ -1744,10 +2568,660 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.34.49",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
+      "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
+      "license": "MIT"
+    },
+    "node_modules/@smithy/config-resolver": {
+      "version": "4.4.16",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.16.tgz",
+      "integrity": "sha512-GFlGPNLZKrGfqWpqVb31z7hvYCA9ZscfX1buYnvvMGcRYsQQnhH+4uN6mWWflcD5jB4OXP/LBrdpukEdjl41tg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "@smithy/util-endpoints": "^3.4.1",
+        "@smithy/util-middleware": "^4.2.14",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.23.15",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.15.tgz",
+      "integrity": "sha512-E7GVCgsQttzfujEZb6Qep005wWf4xiL4x06apFEtzQMWYBPggZh/0cnOxPficw5cuK/YjjkehKoIN4YUaSh0UQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-stream": "^4.5.23",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/uuid": "^1.1.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.14.tgz",
+      "integrity": "sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-codec": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.14.tgz",
+      "integrity": "sha512-erZq0nOIpzfeZdCyzZjdJb4nVSKLUmSkaQUVkRGQTXs30gyUGeKnrYEg+Xe1W5gE3aReS7IgsvANwVPxSzY6Pw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-browser": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.14.tgz",
+      "integrity": "sha512-8IelTCtTctWRbb+0Dcy+C0aICh1qa0qWXqgjcXDmMuCvPJRnv26hiDZoAau2ILOniki65mCPKqOQs/BaWvO4CQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-config-resolver": {
+      "version": "4.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.14.tgz",
+      "integrity": "sha512-sqHiHpYRYo3FJlaIxD1J8PhbcmJAm7IuM16mVnwSkCToD7g00IBZzKuiLNMGmftULmEUX6/UAz8/NN5uMP8bVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-node": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.14.tgz",
+      "integrity": "sha512-Ht/8BuGlKfFTy0H3+8eEu0vdpwGztCnaLLXtpXNdQqiR7Hj4vFScU3T436vRAjATglOIPjJXronY+1WxxNLSiw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-universal": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.14.tgz",
+      "integrity": "sha512-lWyt4T2XQZUZgK3tQ3Wn0w3XBvZsK/vjTuJl6bXbnGZBHH0ZUSONTYiK9TgjTTzU54xQr3DRFwpjmhp0oLm3gg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-codec": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.3.17",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.17.tgz",
+      "integrity": "sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/querystring-builder": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-base64": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-node": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.14.tgz",
+      "integrity": "sha512-8ZBDY2DD4wr+GGjTpPtiglEsqr0lUP+KHqgZcWczFf6qeZ/YRjMIOoQWVQlmwu7EtxKTd8YXD8lblmYcpBIA1g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/invalid-dependency": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.14.tgz",
+      "integrity": "sha512-c21qJiTSb25xvvOp+H2TNZzPCngrvl5vIPqPB8zQ/DmJF4QWXO19x1dWfMJZ6wZuuWUPPm0gV8C0cU3+ifcWuw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+      "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-content-length": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.14.tgz",
+      "integrity": "sha512-xhHq7fX4/3lv5NHxLUk3OeEvl0xZ+Ek3qIbWaCL4f9JwgDZEclPBElljaZCAItdGPQl/kSM4LPMOpy1MYgprpw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint": {
+      "version": "4.4.30",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.30.tgz",
+      "integrity": "sha512-qS2XqhKeXmdZ4nEQ4cOxIczSP/Y91wPAHYuRwmWDCh975B7/57uxsm5d6sisnUThn2u2FwzMdJNM7AbO1YPsPg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.15",
+        "@smithy/middleware-serde": "^4.2.18",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-middleware": "^4.2.14",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.5.3.tgz",
+      "integrity": "sha512-TE8dJNi6JuxzGSxMCVd3i9IEWDndCl3bmluLsBNDWok8olgj65OfkndMhl9SZ7m14c+C5SQn/PcUmrDl57rSFw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.15",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/service-error-classification": "^4.2.14",
+        "@smithy/smithy-client": "^4.12.11",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.2",
+        "@smithy/uuid": "^1.1.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-serde": {
+      "version": "4.2.18",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.18.tgz",
+      "integrity": "sha512-M6CSgnp3v4tYz9ynj2JHbA60woBZcGqEwNjTKjBsNHPV26R1ZX52+0wW8WsZU18q45jD0tw2wL22S17Ze9LpEw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.15",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-stack": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.14.tgz",
+      "integrity": "sha512-2dvkUKLuFdKsCRmOE4Mn63co0Djtsm+JMh0bYZQupN1pJwMeE8FmQmRLLzzEMN0dnNi7CDCYYH8F0EVwWiPBeA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-config-provider": {
+      "version": "4.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.14.tgz",
+      "integrity": "sha512-S+gFjyo/weSVL0P1b9Ts8C/CwIfNCgUPikk3sl6QVsfE/uUuO+QsF+NsE/JkpvWqqyz1wg7HFdiaZuj5CoBMRg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.5.3.tgz",
+      "integrity": "sha512-lc5jFL++x17sPhIwMWJ3YOnqmSjw/2Po6VLDlUIXvxVWRuJwRXnJ4jOBBLB0cfI5BB5ehIl02Fxr1PDvk/kxDw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/querystring-builder": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/property-provider": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.14.tgz",
+      "integrity": "sha512-WuM31CgfsnQ/10i7NYr0PyxqknD72Y5uMfUMVSniPjbEPceiTErb4eIqJQ+pdxNEAUEWrewrGjIRjVbVHsxZiQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/protocol-http": {
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.14.tgz",
+      "integrity": "sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-builder": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.14.tgz",
+      "integrity": "sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-uri-escape": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-parser": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.14.tgz",
+      "integrity": "sha512-hr+YyqBD23GVvRxGGrcc/oOeNlK3PzT5Fu4dzrDXxzS1LpFiuL2PQQqKPs87M79aW7ziMs+nvB3qdw77SqE7Lw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/service-error-classification": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.14.tgz",
+      "integrity": "sha512-vVimoUnGxlx4eLLQbZImdOZFOe+Zh+5ACntv8VxZuGP72LdWu5GV3oEmCahSEReBgRJoWjypFkrehSj7BWx1HQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/shared-ini-file-loader": {
+      "version": "4.4.9",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.9.tgz",
+      "integrity": "sha512-495/V2I15SHgedSJoDPD23JuSfKAp726ZI1V0wtjB07Wh7q/0tri/0e0DLefZCHgxZonrGKt/OCTpAtP1wE1kQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.14.tgz",
+      "integrity": "sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.2",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-uri-escape": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/smithy-client": {
+      "version": "4.12.11",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.11.tgz",
+      "integrity": "sha512-wzz/Wa1CH/Tlhxh0s4DQPEcXSxSVfJ59AZcUh9Gu0c6JTlKuwGf4o/3P2TExv0VbtPFt8odIBG+eQGK2+vTECg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.15",
+        "@smithy/middleware-endpoint": "^4.4.30",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-stream": "^4.5.23",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.1.tgz",
+      "integrity": "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/url-parser": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.14.tgz",
+      "integrity": "sha512-p06BiBigJ8bTA3MgnOfCtDUWnAMY0YfedO/GRpmc7p+wg3KW8vbXy1xwSu5ASy0wV7rRYtlfZOIKH4XqfhjSQQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/querystring-parser": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-base64": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
+      "integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-browser": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.2.tgz",
+      "integrity": "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-node": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.3.tgz",
+      "integrity": "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+      "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-config-provider": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.2.tgz",
+      "integrity": "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "4.3.47",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.47.tgz",
+      "integrity": "sha512-zlIuXai3/SHjQUQ8y3g/woLvrH573SK2wNjcDaHu5e9VOcC0JwM1MI0Sq0GZJyN3BwSUneIhpjZ18nsiz5AtQw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/smithy-client": "^4.12.11",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-node": {
+      "version": "4.2.52",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.52.tgz",
+      "integrity": "sha512-cQBz8g68Vnw1W2meXlkb3D/hXJU+Taiyj9P8qLJtjREEV9/Td65xi4A/H1sRQ8EIgX5qbZbvdYPKygKLholZ3w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/config-resolver": "^4.4.16",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/smithy-client": "^4.12.11",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-endpoints": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.4.1.tgz",
+      "integrity": "sha512-wMxNDZJrgS5mQV9oxCs4TWl5767VMgOfqfZ3JHyCkMtGC2ykW9iPqMvFur695Otcc5yxLG8OKO/80tsQBxrhXg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
+      "integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-middleware": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.14.tgz",
+      "integrity": "sha512-1Su2vj9RYNDEv/V+2E+jXkkwGsgR7dc4sfHn9Z7ruzQHJIEni9zzw5CauvRXlFJfmgcqYP8fWa0dkh2Q2YaQyw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-retry": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.2.tgz",
+      "integrity": "sha512-2+KTsJEwTi63NUv4uR9IQ+IFT1yu6Rf6JuoBK2WKaaJ/TRvOiOVGcXAsEqX/TQN2thR9yII21kPUJq1UV/WI2A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/service-error-classification": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream": {
+      "version": "4.5.23",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.23.tgz",
+      "integrity": "sha512-N6on1+ngJ3RznZOnDWNveIwnTSlqxNnXuNAh7ez889ZZaRdXoNRTXKgmYOLe6dB0gCmAVtuRScE1hymQFl4hpg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/node-http-handler": "^4.5.3",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-uri-escape": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
+      "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/uuid": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz",
+      "integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@tootallnate/quickjs-emscripten": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
@@ -1790,11 +3264,16 @@
       "version": "25.6.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.19.0"
       }
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
     },
     "node_modules/@types/statuses": {
       "version": "2.0.6",
@@ -1937,6 +3416,15 @@
         "node": ">=6.5"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ai": {
       "version": "6.0.158",
       "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.158.tgz",
@@ -1953,6 +3441,39 @@
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/ansi-regex": {
@@ -1991,6 +3512,68 @@
         "node": ">=12"
       }
     },
+    "node_modules/ast-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/basic-ftp": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
+      "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -1999,6 +3582,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/cli-width": {
@@ -2085,6 +3680,15 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2102,6 +3706,20 @@
         }
       }
     },
+    "node_modules/degenerator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.13.4",
+        "escodegen": "^2.1.0",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -2110,6 +3728,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/emoji-regex": {
@@ -2178,6 +3805,49 @@
         "node": ">=6"
       }
     },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -2186,6 +3856,15 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/event-target-shim": {
@@ -2216,6 +3895,18 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
     "node_modules/fast-string-truncated-width": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-1.2.1.tgz",
@@ -2231,6 +3922,22 @@
         "fast-string-truncated-width": "^1.2.0"
       }
     },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fast-wrap-ansi": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.1.6.tgz",
@@ -2238,6 +3945,41 @@
       "license": "MIT",
       "dependencies": {
         "fast-string-width": "^1.1.0"
+      }
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
+      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.5.8",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
+      "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.2.0",
+        "strnum": "^2.2.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/fdir": {
@@ -2258,6 +4000,41 @@
         }
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2271,6 +4048,61 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gaxios/node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/gaxios/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/get-caller-file": {
@@ -2294,6 +4126,46 @@
       },
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/get-uri": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+      "license": "MIT",
+      "dependencies": {
+        "basic-ftp": "^5.0.2",
+        "data-uri-to-buffer": "^6.0.2",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/google-auth-library": {
+      "version": "10.6.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/grammy": {
@@ -2328,6 +4200,32 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/intervals-icu-api": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/intervals-icu-api/-/intervals-icu-api-0.1.2.tgz",
@@ -2339,6 +4237,15 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/is-fullwidth-code-point": {
@@ -2358,11 +4265,60 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "node_modules/json-schema": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
       "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
@@ -2625,6 +4581,21 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -2648,6 +4619,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@inquirer/confirm": "^5.0.0",
         "@mswjs/interceptors": "^0.41.2",
@@ -2715,6 +4687,35 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/netmask": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
+      "integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -2745,6 +4746,27 @@
         "https://opencollective.com/debug"
       ],
       "license": "MIT"
+    },
+    "node_modules/openai": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
+      "integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
     },
     "node_modules/openapi-fetch": {
       "version": "0.17.0",
@@ -2853,6 +4875,72 @@
         }
       }
     },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pac-proxy-agent": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/quickjs-emscripten": "^0.23.0",
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "get-uri": "^6.0.1",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.6",
+        "pac-resolver": "^7.0.1",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-resolver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "license": "MIT",
+      "dependencies": {
+        "degenerator": "^5.0.0",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/partial-json": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
+      "integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
+      "license": "MIT"
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-to-regexp": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
@@ -2880,6 +4968,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2916,11 +5005,69 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/protobufjs": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/proxy-agent": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.6",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.1.0",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -2934,6 +5081,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/rettime": {
@@ -2977,6 +5133,26 @@
         "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
@@ -3002,6 +5178,54 @@
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.0.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -3071,6 +5295,18 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/strnum": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/tagged-tag": {
       "version": "1.0.0",
@@ -3178,13 +5414,17 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
     },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/tsx": {
       "version": "4.21.0",
@@ -3192,6 +5432,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -3228,6 +5469,7 @@
       "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3236,11 +5478,19 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.19.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
       "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/until-async": {
@@ -3273,6 +5523,7 @@
       "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -3435,6 +5686,15 @@
         }
       }
     },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -3483,6 +5743,27 @@
         "node": ">=8"
       }
     },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -3498,6 +5779,7 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -3555,8 +5837,18 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@ai-sdk/google": "^3.0.63",
     "@ai-sdk/openai": "^3.0.52",
     "@clack/prompts": "^1.2.0",
+    "@mariozechner/pi-ai": "0.67.6",
     "ai": "^6.0.158",
     "grammy": "^1.42.0",
     "intervals-icu-api": "^0.1.2",

--- a/src/agent/codex-bridge.ts
+++ b/src/agent/codex-bridge.ts
@@ -325,10 +325,14 @@ export async function codexGenerateText(
 
   const piMessages: PiMessage[] = convertMessages(initialMessages);
 
+  // Fetch the token once per request. The step loop runs well within the
+  // 5-minute refresh threshold and pi-ai's internal retries are already
+  // short-circuited, so a refresh during the loop is not a concern.
+  const apiKey = await getFreshToken(profileName);
+
   let lastAssistant: AssistantMessage | undefined;
 
   for (let step = 0; step < limit; step++) {
-    const apiKey = await getFreshToken(profileName);
     const context: Context = {
       systemPrompt: system,
       messages: piMessages,
@@ -360,11 +364,12 @@ export async function codexGenerateText(
 
     if (!tools) break;
 
-    const modelMessages = piToModelMessages(piMessages);
-    for (const call of calls) {
-      const result = await executeToolCall(call, tools, modelMessages);
-      piMessages.push(result);
-    }
+    // Run tool calls in parallel to match AI SDK behavior; Promise.all
+    // preserves result order so the pi-ai context stays aligned.
+    const results = await Promise.all(
+      calls.map((call) => executeToolCall(call, tools, initialMessages)),
+    );
+    for (const result of results) piMessages.push(result);
   }
 
   if (!lastAssistant) {
@@ -400,19 +405,3 @@ function getModelOrThrow(modelId: string) {
   }
 }
 
-// ============================================================================
-// HELPERS
-// ============================================================================
-
-function piToModelMessages(piMessages: PiMessage[]): ModelMessage[] {
-  const out: ModelMessage[] = [];
-  for (const m of piMessages) {
-    if (m.role === "user") {
-      out.push({ role: "user", content: extractText(m.content) });
-    } else if (m.role === "assistant") {
-      const text = collectText(m);
-      if (text) out.push({ role: "assistant", content: text });
-    }
-  }
-  return out;
-}

--- a/src/agent/codex-bridge.ts
+++ b/src/agent/codex-bridge.ts
@@ -1,0 +1,418 @@
+import { asSchema } from "@ai-sdk/provider-utils";
+import { complete, getModel } from "@mariozechner/pi-ai";
+import type {
+  AssistantMessage,
+  Context,
+  Message as PiMessage,
+  StopReason,
+  TextContent,
+  Tool as PiTool,
+  ToolCall as PiToolCall,
+  ToolResultMessage,
+  Usage as PiUsage,
+} from "@mariozechner/pi-ai";
+import type {
+  FinishReason,
+  LanguageModelUsage,
+  ModelMessage,
+  ToolSet,
+} from "ai";
+
+import { getFreshToken } from "../auth/profiles.js";
+import type { GenerateOpts, GenerateResult } from "./llm-types.js";
+
+const DEFAULT_STEP_LIMIT = 10;
+
+// Pi-ai's codex provider retries 429/5xx internally and ignores maxRetryDelayMs;
+// our outer loop in core.ts owns backoff. Throwing an Error whose message
+// contains PI_AI_NO_RETRY_MARKER triggers pi-ai's no-retry escape
+// (openai-codex-responses.js: the retry loop skips when the message matches).
+// Do not rephrase the marker without verifying pi-ai still honors it.
+const RETRYABLE_HTTP_STATUSES = new Set([429, 500, 502, 503, 504]);
+const PI_AI_NO_RETRY_MARKER = "usage limit";
+
+const onCodexResponse = async ({ status }: { status: number }): Promise<void> => {
+  if (RETRYABLE_HTTP_STATUSES.has(status)) {
+    throw new Error(`${PI_AI_NO_RETRY_MARKER} blocked client retry (status=${status})`);
+  }
+};
+
+// ============================================================================
+// ERROR NORMALIZATION
+// ============================================================================
+
+/**
+ * Pi-ai throws plain Error instances with human messages. Our retry loop in
+ * core.ts relies on token-utils predicates that look for specific substrings.
+ * Rewrite the message so those predicates trigger correctly without having to
+ * teach them about pi-ai's error surface.
+ */
+function normalizeError(err: unknown): Error {
+  if (!(err instanceof Error)) return new Error(String(err));
+  const msg = err.message ?? "";
+  const lower = msg.toLowerCase();
+
+  if (/usage.?limit|rate.?limit|too many requests|429/i.test(msg)) {
+    const out = new Error(`Rate limit exceeded: ${msg}`);
+    out.name = "RateLimitError";
+    return out;
+  }
+
+  if (/request was aborted|timeout|timed out|deadline/i.test(lower)) {
+    const out = new Error(`Request timeout: ${msg}`);
+    out.name = "TimeoutError";
+    return out;
+  }
+
+  if (
+    /context.?length|context.?window|maximum context|token limit|too many tokens|content_too_large|exceeds the maximum/i.test(
+      lower,
+    )
+  ) {
+    const out = new Error(`Context overflow: ${msg}`);
+    out.name = "ContextOverflowError";
+    return out;
+  }
+
+  return err;
+}
+
+// ============================================================================
+// MESSAGE CONVERSION: AI SDK ModelMessage[] → pi-ai Context
+// ============================================================================
+
+function extractText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .map((part) => {
+      if (typeof part === "string") return part;
+      if (part && typeof part === "object" && "type" in part) {
+        const p = part as { type: string; text?: string };
+        if (p.type === "text" && typeof p.text === "string") return p.text;
+      }
+      return "";
+    })
+    .join("");
+}
+
+function convertMessages(messages: ModelMessage[]): PiMessage[] {
+  const out: PiMessage[] = [];
+
+  for (const m of messages) {
+    if (m.role === "system") {
+      // System is carried separately on Context; ignore here.
+      continue;
+    }
+
+    if (m.role === "user") {
+      out.push({
+        role: "user",
+        content: extractText(m.content),
+        timestamp: Date.now(),
+      });
+      continue;
+    }
+
+    if (m.role === "assistant") {
+      const parts: (TextContent | PiToolCall)[] = [];
+      if (typeof m.content === "string") {
+        if (m.content) parts.push({ type: "text", text: m.content });
+      } else if (Array.isArray(m.content)) {
+        for (const p of m.content) {
+          if (p.type === "text" && p.text) {
+            parts.push({ type: "text", text: p.text });
+          } else if (p.type === "tool-call") {
+            parts.push({
+              type: "toolCall",
+              id: p.toolCallId,
+              name: p.toolName,
+              arguments: (p.input ?? {}) as Record<string, unknown>,
+            });
+          }
+        }
+      }
+      out.push({
+        role: "assistant",
+        content: parts,
+        api: "openai-codex-responses",
+        provider: "openai-codex",
+        model: "",
+        usage: emptyUsage(),
+        stopReason: "stop",
+        timestamp: Date.now(),
+      });
+      continue;
+    }
+
+    if (m.role === "tool") {
+      if (!Array.isArray(m.content)) continue;
+      for (const p of m.content) {
+        if (p.type !== "tool-result") continue;
+        out.push({
+          role: "toolResult",
+          toolCallId: p.toolCallId,
+          toolName: p.toolName,
+          content: [{ type: "text", text: stringifyToolOutput(p.output) }],
+          isError: false,
+          timestamp: Date.now(),
+        });
+      }
+    }
+  }
+
+  return out;
+}
+
+function stringifyToolOutput(output: unknown): string {
+  if (output && typeof output === "object" && "type" in output) {
+    const o = output as { type: string; value?: unknown };
+    if (o.type === "text" && typeof o.value === "string") return o.value;
+    if (o.type === "error-text" && typeof o.value === "string") return o.value;
+    if (o.type === "json") return JSON.stringify(o.value);
+    if (o.type === "error-json") return JSON.stringify(o.value);
+  }
+  return typeof output === "string" ? output : JSON.stringify(output);
+}
+
+function emptyUsage(): PiUsage {
+  return {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: 0,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+  };
+}
+
+// ============================================================================
+// TOOL CONVERSION: AI SDK ToolSet → pi-ai Tool[]
+// ============================================================================
+
+async function convertTools(tools: ToolSet | undefined): Promise<PiTool[]> {
+  if (!tools) return [];
+  const out: PiTool[] = [];
+  for (const [name, t] of Object.entries(tools)) {
+    const schema = asSchema(t.inputSchema);
+    const json = await Promise.resolve(schema.jsonSchema);
+    out.push({
+      name,
+      description: t.description ?? "",
+      parameters: json as PiTool["parameters"],
+    });
+  }
+  return out;
+}
+
+// ============================================================================
+// RESULT CONVERSION: pi-ai AssistantMessage → AI SDK GenerateResult
+// ============================================================================
+
+function mapStopReason(reason: StopReason): FinishReason {
+  switch (reason) {
+    case "stop":
+      return "stop";
+    case "length":
+      return "length";
+    case "toolUse":
+      return "tool-calls";
+    case "aborted":
+      return "other";
+    case "error":
+      return "error";
+    default:
+      return "other";
+  }
+}
+
+function mapUsage(u: PiUsage): LanguageModelUsage {
+  return {
+    inputTokens: u.input,
+    outputTokens: u.output,
+    totalTokens: u.totalTokens,
+    reasoningTokens: undefined,
+    cachedInputTokens: u.cacheRead,
+    inputTokenDetails: {
+      noCacheTokens: undefined,
+      cacheReadTokens: u.cacheRead,
+      cacheWriteTokens: u.cacheWrite,
+    },
+    outputTokenDetails: {
+      reasoningTokens: undefined,
+      acceptedPredictionTokens: undefined,
+      rejectedPredictionTokens: undefined,
+    },
+  } as unknown as LanguageModelUsage;
+}
+
+function collectText(msg: AssistantMessage): string {
+  return msg.content
+    .filter((b): b is TextContent => b.type === "text")
+    .map((b) => b.text)
+    .join("");
+}
+
+function collectToolCalls(msg: AssistantMessage): PiToolCall[] {
+  return msg.content.filter((b): b is PiToolCall => b.type === "toolCall");
+}
+
+// ============================================================================
+// TOOL EXECUTION
+// ============================================================================
+
+async function executeToolCall(
+  call: PiToolCall,
+  tools: ToolSet,
+  messages: ModelMessage[],
+  abortSignal?: AbortSignal,
+): Promise<ToolResultMessage> {
+  const tool = tools[call.name];
+  if (!tool || typeof tool.execute !== "function") {
+    return {
+      role: "toolResult",
+      toolCallId: call.id,
+      toolName: call.name,
+      content: [{ type: "text", text: `Tool "${call.name}" not found` }],
+      isError: true,
+      timestamp: Date.now(),
+    };
+  }
+
+  try {
+    const result = await tool.execute(call.arguments, {
+      toolCallId: call.id,
+      messages,
+      abortSignal,
+    });
+    return {
+      role: "toolResult",
+      toolCallId: call.id,
+      toolName: call.name,
+      content: [{ type: "text", text: typeof result === "string" ? result : JSON.stringify(result) }],
+      isError: false,
+      timestamp: Date.now(),
+    };
+  } catch (err) {
+    return {
+      role: "toolResult",
+      toolCallId: call.id,
+      toolName: call.name,
+      content: [{ type: "text", text: err instanceof Error ? err.message : String(err) }],
+      isError: true,
+      timestamp: Date.now(),
+    };
+  }
+}
+
+// ============================================================================
+// MAIN ENTRYPOINT
+// ============================================================================
+
+export async function codexGenerateText(
+  opts: GenerateOpts & { modelId: string; profileName: string; stepLimit?: number },
+): Promise<GenerateResult> {
+  const { system, messages, prompt, tools, modelId, profileName, maxOutputTokens, stepLimit } = opts;
+
+  const initialMessages: ModelMessage[] = prompt
+    ? [{ role: "user", content: prompt }]
+    : (messages ?? []);
+
+  const piTools = await convertTools(tools);
+
+  const model = getModelOrThrow(modelId);
+  const limit = stepLimit ?? DEFAULT_STEP_LIMIT;
+
+  const piMessages: PiMessage[] = convertMessages(initialMessages);
+
+  let lastAssistant: AssistantMessage | undefined;
+
+  for (let step = 0; step < limit; step++) {
+    const apiKey = await getFreshToken(profileName);
+    const context: Context = {
+      systemPrompt: system,
+      messages: piMessages,
+      tools: piTools,
+    };
+
+    let assistant: AssistantMessage;
+    try {
+      assistant = await complete(model, context, {
+        apiKey,
+        maxTokens: maxOutputTokens,
+        onResponse: onCodexResponse,
+      });
+    } catch (err) {
+      throw normalizeError(err);
+    }
+
+    if (assistant.stopReason === "error" || assistant.stopReason === "aborted") {
+      throw normalizeError(new Error(assistant.errorMessage ?? "Codex request failed"));
+    }
+
+    lastAssistant = assistant;
+    piMessages.push(assistant);
+
+    const calls = collectToolCalls(assistant);
+    if (calls.length === 0 || assistant.stopReason !== "toolUse") {
+      break;
+    }
+
+    if (!tools) break;
+
+    const modelMessages = piToModelMessages(piMessages);
+    for (const call of calls) {
+      const result = await executeToolCall(call, tools, modelMessages);
+      piMessages.push(result);
+    }
+  }
+
+  if (!lastAssistant) {
+    throw new Error("Codex completion returned no assistant message");
+  }
+
+  const toolCalls = collectToolCalls(lastAssistant).map((c) => ({
+    type: "tool-call" as const,
+    toolCallId: c.id,
+    toolName: c.name,
+    input: c.arguments,
+  }));
+
+  return {
+    text: collectText(lastAssistant),
+    toolCalls: toolCalls as GenerateResult["toolCalls"],
+    finishReason: mapStopReason(lastAssistant.stopReason),
+    usage: mapUsage(lastAssistant.usage),
+  };
+}
+
+// ============================================================================
+// MODEL RESOLUTION
+// ============================================================================
+
+function getModelOrThrow(modelId: string) {
+  // Fall back to gpt-5.4 template for IDs not in pi-ai's catalog (e.g. pro).
+  try {
+    return getModel("openai-codex", modelId as "gpt-5.4");
+  } catch {
+    const fallback = getModel("openai-codex", "gpt-5.4");
+    return { ...fallback, id: modelId, name: modelId };
+  }
+}
+
+// ============================================================================
+// HELPERS
+// ============================================================================
+
+function piToModelMessages(piMessages: PiMessage[]): ModelMessage[] {
+  const out: ModelMessage[] = [];
+  for (const m of piMessages) {
+    if (m.role === "user") {
+      out.push({ role: "user", content: extractText(m.content) });
+    } else if (m.role === "assistant") {
+      const text = collectText(m);
+      if (text) out.push({ role: "assistant", content: text });
+    }
+  }
+  return out;
+}

--- a/src/agent/compaction.ts
+++ b/src/agent/compaction.ts
@@ -1,5 +1,4 @@
-import { generateText } from "ai";
-import type { LanguageModel, ModelMessage } from "ai";
+import type { ModelMessage } from "ai";
 import {
   estimateTokens,
   estimateMessagesTokens,
@@ -9,6 +8,7 @@ import {
   SUMMARIZATION_OVERHEAD_TOKENS,
 } from "./token-utils.js";
 import { makeSummaryMessage } from "./history-limit.js";
+import type { LLM } from "./llm.js";
 
 // ============================================================================
 // CONSTANTS
@@ -163,12 +163,12 @@ export function auditSummaryQuality(summary: string): { ok: boolean; missing: st
 
 export async function summarizeDroppedMessages(params: {
   dropped: ModelMessage[];
-  model: LanguageModel;
+  llm: LLM;
   previousSummary?: string;
   maxRetries?: number;
   contextWindowTokens?: number;
 }): Promise<string> {
-  const { dropped, model, previousSummary, maxRetries = 1, contextWindowTokens } = params;
+  const { dropped, llm, previousSummary, maxRetries = 1, contextWindowTokens } = params;
 
   if (dropped.length === 0) return previousSummary ?? "";
 
@@ -187,11 +187,9 @@ export async function summarizeDroppedMessages(params: {
     ].join("\n");
 
     try {
-      const { text } = await generateText({
-        model,
+      const { text } = await llm.generate({
         prompt,
         maxOutputTokens: MAX_SUMMARY_TOKENS,
-        maxRetries: 0,
       });
       summary = text;
     } catch (err) {
@@ -208,11 +206,9 @@ export async function summarizeDroppedMessages(params: {
   let best: string = summary;
   for (let attempt = 0; attempt < maxRetries; attempt++) {
     try {
-      const { text } = await generateText({
-        model,
+      const { text } = await llm.generate({
         prompt: `Restructure the following summary to include ALL required section headings: ${audit.missing.join(", ")}.\n\n${best}\n\n${MUST_PRESERVE}`,
         maxOutputTokens: MAX_SUMMARY_TOKENS,
-        maxRetries: 0,
       });
       const retryAudit = auditSummaryQuality(text);
       if (retryAudit.ok) return capSummary(text);
@@ -231,12 +227,12 @@ export async function summarizeDroppedMessages(params: {
 
 export async function summarizeInStages(params: {
   messages: ModelMessage[];
-  model: LanguageModel;
+  llm: LLM;
   recentToKeep?: number;
   previousSummary?: string;
   contextWindowTokens?: number;
 }): Promise<ModelMessage[]> {
-  const { messages, model, recentToKeep = 4, previousSummary, contextWindowTokens } = params;
+  const { messages, llm, recentToKeep = 4, previousSummary, contextWindowTokens } = params;
 
   const keepCount = Math.min(recentToKeep, messages.length);
   const toSummarize = messages.slice(0, messages.length - keepCount);
@@ -257,11 +253,9 @@ export async function summarizeInStages(params: {
       ? `\nExisting summary of earlier context:\n${summary}\n\n`
       : "";
 
-    const { text } = await generateText({
-      model,
+    const { text } = await llm.generate({
       prompt: `${SUMMARIZE_PROMPT}${contextPrefix}\n\n${transcript}`,
       maxOutputTokens: MAX_SUMMARY_TOKENS,
-      maxRetries: 0,
     });
     summary = capSummary(text);
   }

--- a/src/agent/core.ts
+++ b/src/agent/core.ts
@@ -1,8 +1,5 @@
-import { generateText, stepCountIs } from "ai";
-import { createAnthropic } from "@ai-sdk/anthropic";
-import { createOpenAI } from "@ai-sdk/openai";
-import { createGoogleGenerativeAI } from "@ai-sdk/google";
-import type { LanguageModel, ModelMessage } from "ai";
+import { stepCountIs } from "ai";
+import type { ModelMessage } from "ai";
 import { IntervalsClient } from "intervals-icu-api";
 import type { Config } from "../config.js";
 import { Memory } from "./memory.js";
@@ -24,6 +21,7 @@ import {
 import { summarizeInStages, summarizeDroppedMessages } from "./compaction.js";
 import { runMemoryFlush } from "./memory-flush.js";
 import { evaluateSessionFreshness } from "./session-freshness.js";
+import { LLM } from "./llm.js";
 
 const MAX_OVERFLOW_ATTEMPTS = 3;
 const MAX_TIMEOUT_ATTEMPTS = 2;
@@ -41,7 +39,7 @@ function sleep(ms: number): Promise<void> {
 // ============================================================================
 
 export class CyclingCoachAgent {
-  private model: LanguageModel;
+  private llm: LLM;
   private config: Config;
   private memory: Memory;
   private chatStore: ChatStore;
@@ -50,7 +48,7 @@ export class CyclingCoachAgent {
 
   constructor(config: Config) {
     this.config = config;
-    this.model = createModel(config);
+    this.llm = new LLM(config);
     this.memory = new Memory(config.dataDir);
     this.chatStore = new ChatStore(config.dataDir);
 
@@ -79,7 +77,7 @@ export class CyclingCoachAgent {
       if (!fresh) {
         // Flush memory before reset, then archive
         if (history.length > 0) {
-          await runMemoryFlush({ model: this.model, messages: history, memory: this.memory });
+          await runMemoryFlush({ llm: this.llm, messages: history, memory: this.memory });
         }
         this.chatStore.archiveAndReset(chatId);
         history = [];
@@ -102,7 +100,7 @@ export class CyclingCoachAgent {
         try {
           const summary = await summarizeDroppedMessages({
             dropped,
-            model: this.model,
+            llm: this.llm,
             previousSummary,
             contextWindowTokens: this.config.contextWindowTokens,
           });
@@ -132,19 +130,18 @@ export class CyclingCoachAgent {
       while (true) {
         // Preemptive: compact before sending if over budget
         if (shouldCompact({ messages, systemPrompt: this.systemPrompt, contextWindowTokens: this.config.contextWindowTokens })) {
-          await runMemoryFlush({ model: this.model, messages, memory: this.memory });
-          messages = await summarizeInStages({ messages, model: this.model, contextWindowTokens: this.config.contextWindowTokens });
+          await runMemoryFlush({ llm: this.llm, messages, memory: this.memory });
+          messages = await summarizeInStages({ messages, llm: this.llm, contextWindowTokens: this.config.contextWindowTokens });
           this.memory.reload();
         }
 
         try {
-          const { text } = await generateText({
-            model: this.model,
+          const { text } = await this.llm.generate({
             system: this.systemPrompt,
             messages,
             tools: this.tools,
-            maxRetries: 0,
             stopWhen: stepCountIs(10),
+            maxSteps: 10,
           });
 
           // Append BOTH after success — JSONL unchanged on failure
@@ -156,8 +153,8 @@ export class CyclingCoachAgent {
           // Reactive: context overflow → flush + compact + retry
           if (isContextOverflowError(err) && overflowAttempts < MAX_OVERFLOW_ATTEMPTS) {
             overflowAttempts++;
-            await runMemoryFlush({ model: this.model, messages, memory: this.memory });
-            messages = await summarizeInStages({ messages, model: this.model, contextWindowTokens: this.config.contextWindowTokens });
+            await runMemoryFlush({ llm: this.llm, messages, memory: this.memory });
+            messages = await summarizeInStages({ messages, llm: this.llm, contextWindowTokens: this.config.contextWindowTokens });
             this.memory.reload();
             continue;
           }
@@ -166,7 +163,7 @@ export class CyclingCoachAgent {
             const ratio = estimateMessagesTokens(messages) / this.config.contextWindowTokens;
             if (ratio > TIMEOUT_COMPACTION_THRESHOLD) {
               timeoutAttempts++;
-              messages = await summarizeInStages({ messages, model: this.model, contextWindowTokens: this.config.contextWindowTokens });
+              messages = await summarizeInStages({ messages, llm: this.llm, contextWindowTokens: this.config.contextWindowTokens });
               this.memory.reload();
               continue;
             }
@@ -195,33 +192,12 @@ export class CyclingCoachAgent {
     // Flush before reset to avoid losing un-persisted context
     const { messages: history } = this.chatStore.load(chatId);
     if (history.length > 0) {
-      await runMemoryFlush({ model: this.model, messages: history, memory: this.memory });
+      await runMemoryFlush({ llm: this.llm, messages: history, memory: this.memory });
     }
     this.chatStore.archiveAndReset(chatId);
   }
 
   getMemory(): Memory {
     return this.memory;
-  }
-}
-
-// ============================================================================
-// MODEL FACTORY
-// ============================================================================
-
-function createModel(config: Config): LanguageModel {
-  switch (config.llm.provider) {
-    case "anthropic": {
-      const anthropic = createAnthropic({ apiKey: config.llm.apiKey });
-      return anthropic(config.llm.model);
-    }
-    case "openai": {
-      const openai = createOpenAI({ apiKey: config.llm.apiKey });
-      return openai(config.llm.model);
-    }
-    case "google": {
-      const google = createGoogleGenerativeAI({ apiKey: config.llm.apiKey });
-      return google(config.llm.model);
-    }
   }
 }

--- a/src/agent/llm-types.ts
+++ b/src/agent/llm-types.ts
@@ -1,0 +1,29 @@
+import type {
+  FinishReason,
+  LanguageModelUsage,
+  ModelMessage,
+  StopCondition,
+  ToolSet,
+} from "ai";
+
+export interface GenerateOpts {
+  system?: string;
+  messages?: ModelMessage[];
+  prompt?: string;
+  tools?: ToolSet;
+  stopWhen?: StopCondition<any> | Array<StopCondition<any>>;
+  maxSteps?: number;
+  maxOutputTokens?: number;
+}
+
+export interface GenerateResult {
+  text: string;
+  toolCalls: Array<{
+    type: "tool-call";
+    toolCallId: string;
+    toolName: string;
+    input: unknown;
+  }>;
+  finishReason: FinishReason;
+  usage: LanguageModelUsage;
+}

--- a/src/agent/llm.ts
+++ b/src/agent/llm.ts
@@ -1,0 +1,82 @@
+import { generateText } from "ai";
+import { createAnthropic } from "@ai-sdk/anthropic";
+import { createOpenAI } from "@ai-sdk/openai";
+import { createGoogleGenerativeAI } from "@ai-sdk/google";
+import type { LanguageModel } from "ai";
+
+import type { Config } from "../config.js";
+import { codexGenerateText } from "./codex-bridge.js";
+import type { GenerateOpts, GenerateResult } from "./llm-types.js";
+
+export type { GenerateOpts, GenerateResult } from "./llm-types.js";
+
+// ============================================================================
+// LLM DISPATCH
+// ============================================================================
+
+export class LLM {
+  private config: Config;
+  private aiSdkModel: LanguageModel | null;
+
+  constructor(config: Config) {
+    this.config = config;
+    this.aiSdkModel = config.llm.provider === "openai-codex" ? null : buildAiSdkModel(config);
+  }
+
+  async generate(opts: GenerateOpts): Promise<GenerateResult> {
+    if (this.config.llm.provider === "openai-codex") {
+      return await codexGenerateText({
+        ...opts,
+        modelId: this.config.llm.model,
+        profileName: this.config.llm.authProfile ?? "openai-codex",
+        stepLimit: opts.maxSteps,
+      });
+    }
+
+    if (!this.aiSdkModel) {
+      throw new Error("AI SDK model not initialized");
+    }
+
+    const base = {
+      model: this.aiSdkModel,
+      system: opts.system,
+      tools: opts.tools,
+      stopWhen: opts.stopWhen,
+      maxOutputTokens: opts.maxOutputTokens,
+      maxRetries: 0,
+    };
+    const result = opts.prompt !== undefined
+      ? await generateText({ ...base, prompt: opts.prompt })
+      : await generateText({ ...base, messages: opts.messages ?? [] });
+
+    return {
+      text: result.text,
+      toolCalls: result.toolCalls as GenerateResult["toolCalls"],
+      finishReason: result.finishReason,
+      usage: result.usage,
+    };
+  }
+}
+
+// ============================================================================
+// AI SDK MODEL FACTORY
+// ============================================================================
+
+function buildAiSdkModel(config: Config): LanguageModel {
+  switch (config.llm.provider) {
+    case "anthropic": {
+      const anthropic = createAnthropic({ apiKey: config.llm.apiKey });
+      return anthropic(config.llm.model);
+    }
+    case "openai": {
+      const openai = createOpenAI({ apiKey: config.llm.apiKey });
+      return openai(config.llm.model);
+    }
+    case "google": {
+      const google = createGoogleGenerativeAI({ apiKey: config.llm.apiKey });
+      return google(config.llm.model);
+    }
+    case "openai-codex":
+      throw new Error("openai-codex is handled via the bridge, not AI SDK");
+  }
+}

--- a/src/agent/memory-flush.ts
+++ b/src/agent/memory-flush.ts
@@ -1,8 +1,9 @@
-import { generateText, tool, zodSchema, stepCountIs } from "ai";
-import type { LanguageModel, ModelMessage } from "ai";
+import { tool, zodSchema, stepCountIs } from "ai";
+import type { ModelMessage } from "ai";
 import { z } from "zod";
 import type { Memory } from "./memory.js";
 import { createMemoryReadTool } from "./tools.js";
+import type { LLM } from "./llm.js";
 
 // ============================================================================
 // CONSTANTS
@@ -65,7 +66,7 @@ function createFlushMemoryWriteTool(memory: Memory) {
 // ============================================================================
 
 export async function runMemoryFlush(params: {
-  model: LanguageModel;
+  llm: LLM;
   messages: ModelMessage[];
   memory: Memory;
 }): Promise<void> {
@@ -74,8 +75,7 @@ export async function runMemoryFlush(params: {
     memory_read: createMemoryReadTool(params.memory),
   };
 
-  await generateText({
-    model: params.model,
+  await params.llm.generate({
     system: MEMORY_FLUSH_SYSTEM_PROMPT,
     messages: [
       ...params.messages,
@@ -83,8 +83,8 @@ export async function runMemoryFlush(params: {
     ],
     tools: flushTools,
     stopWhen: stepCountIs(5),
+    maxSteps: 5,
   });
 
   params.memory.reload();
 }
-

--- a/src/auth/openai-codex-login.ts
+++ b/src/auth/openai-codex-login.ts
@@ -1,0 +1,87 @@
+import { spawn } from "node:child_process";
+import { note, text, isCancel, log } from "@clack/prompts";
+import { loginOpenAICodex } from "@mariozechner/pi-ai/oauth";
+import type { OAuthCredential } from "./profiles.js";
+
+const LOCAL_CALLBACK_FALLBACK_MS = 120_000;
+
+function isHeadless(): boolean {
+  if (!process.stdout.isTTY) return true;
+  if (process.env.SSH_CONNECTION) return true;
+  if (process.platform === "linux" && !process.env.DISPLAY) return true;
+  return false;
+}
+
+function openUrl(url: string): void {
+  const opener =
+    process.platform === "darwin"
+      ? "open"
+      : process.platform === "win32"
+        ? "start"
+        : "xdg-open";
+  try {
+    const child = spawn(opener, [url], {
+      detached: true,
+      stdio: "ignore",
+      shell: process.platform === "win32",
+    });
+    child.unref();
+  } catch {
+    // Fall through — the URL is also printed for manual paste.
+  }
+}
+
+async function promptForCode(message: string): Promise<string> {
+  const value = await text({
+    message,
+    validate: (v) => (!v ? "Value is required" : undefined),
+  });
+  if (isCancel(value)) throw new Error("OAuth cancelled by user");
+  return typeof value === "string" ? value : "";
+}
+
+export async function runCodexLogin(): Promise<OAuthCredential> {
+  const headless = isHeadless();
+
+  const creds = await loginOpenAICodex({
+    originator: "cycling-coach",
+    onAuth: ({ url }) => {
+      if (headless) {
+        note(
+          [
+            "Headless environment detected.",
+            "Open this URL in a browser on your LOCAL machine,",
+            "complete sign-in, then paste the redirect URL back here.",
+          ].join("\n"),
+          "OpenAI Codex OAuth",
+        );
+      } else {
+        note(
+          "A browser will open for OpenAI sign-in.\nIf it doesn't open, copy the URL below:",
+          "OpenAI Codex OAuth",
+        );
+      }
+      // Print the URL outside the boxed note so long links are not hard-wrapped
+      // with whitespace/newlines inserted by the box renderer.
+      console.log(url);
+      if (!headless) openUrl(url);
+    },
+    onPrompt: async (prompt) => await promptForCode(prompt.message),
+    onProgress: (msg) => log.info(msg),
+    onManualCodeInput: async () => {
+      if (!headless) {
+        await new Promise((resolve) => setTimeout(resolve, LOCAL_CALLBACK_FALLBACK_MS));
+      }
+      return await promptForCode("Paste the authorization code (or full redirect URL)");
+    },
+  });
+
+  return {
+    type: "oauth",
+    access: creds.access,
+    refresh: creds.refresh,
+    expires: creds.expires,
+    accountId: typeof creds.accountId === "string" ? creds.accountId : undefined,
+    email: typeof creds.email === "string" ? creds.email : undefined,
+  };
+}

--- a/src/auth/profiles.ts
+++ b/src/auth/profiles.ts
@@ -1,0 +1,109 @@
+import { readFileSync, writeFileSync, existsSync, chmodSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { refreshOpenAICodexToken } from "@mariozechner/pi-ai/oauth";
+
+// ============================================================================
+// TYPES
+// ============================================================================
+
+export interface OAuthCredential {
+  type: "oauth";
+  access: string;
+  refresh: string;
+  expires: number;
+  accountId?: string;
+  email?: string;
+}
+
+export class RefreshTokenReusedError extends Error {
+  constructor(public readonly profile: string, cause: unknown) {
+    super(
+      `OAuth refresh token for "${profile}" has been invalidated. Re-run \`npm run setup\` or \`cycling-coach setup\` to reauthenticate.`,
+    );
+    this.name = "RefreshTokenReusedError";
+    this.cause = cause;
+  }
+}
+
+// ============================================================================
+// STORAGE
+// ============================================================================
+
+const PROFILES_FILE = join(homedir(), ".cycling-coach", "auth-profiles.json");
+const REFRESH_THRESHOLD_MS = 5 * 60 * 1000;
+
+type ProfilesFile = Record<string, OAuthCredential>;
+
+function readAll(): ProfilesFile {
+  if (!existsSync(PROFILES_FILE)) return {};
+  try {
+    const raw = readFileSync(PROFILES_FILE, "utf-8");
+    return JSON.parse(raw) as ProfilesFile;
+  } catch {
+    return {};
+  }
+}
+
+function writeAll(profiles: ProfilesFile): void {
+  writeFileSync(PROFILES_FILE, JSON.stringify(profiles, null, 2), { mode: 0o600 });
+  // Ensure perms on existing files created before this write
+  chmodSync(PROFILES_FILE, 0o600);
+}
+
+export function loadProfile(name: string): OAuthCredential | null {
+  const all = readAll();
+  return all[name] ?? null;
+}
+
+export function saveProfile(name: string, cred: OAuthCredential): void {
+  const all = readAll();
+  all[name] = cred;
+  writeAll(all);
+}
+
+function isExpiredOrUnusable(cred: OAuthCredential): boolean {
+  if (!Number.isFinite(cred.expires)) return true;
+  return Date.now() > cred.expires - REFRESH_THRESHOLD_MS;
+}
+
+// ============================================================================
+// REFRESH
+// ============================================================================
+
+export async function getFreshToken(name: string): Promise<string> {
+  const cred = loadProfile(name);
+  if (!cred) {
+    throw new Error(`No OAuth profile "${name}". Run \`cycling-coach setup\` to create one.`);
+  }
+
+  if (!isExpiredOrUnusable(cred)) {
+    return cred.access;
+  }
+
+  if (name !== "openai-codex") {
+    throw new Error(`Refresh not implemented for profile "${name}"`);
+  }
+
+  let refreshed;
+  try {
+    refreshed = await refreshOpenAICodexToken(cred.refresh);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (/refresh.*reuse|invalid.*refresh|Failed to refresh/i.test(msg)) {
+      throw new RefreshTokenReusedError(name, err);
+    }
+    throw err;
+  }
+
+  const next: OAuthCredential = {
+    type: "oauth",
+    access: refreshed.access,
+    refresh: refreshed.refresh,
+    expires: refreshed.expires,
+    accountId: typeof refreshed.accountId === "string" ? refreshed.accountId : cred.accountId,
+    email: cred.email,
+  };
+  saveProfile(name, next);
+  return next.access;
+}

--- a/src/auth/profiles.ts
+++ b/src/auth/profiles.ts
@@ -1,7 +1,8 @@
 import { readFileSync, writeFileSync, existsSync, chmodSync } from "node:fs";
 import { join } from "node:path";
-import { homedir } from "node:os";
 import { refreshOpenAICodexToken } from "@mariozechner/pi-ai/oauth";
+
+import { CONFIG_DIR } from "../config.js";
 
 // ============================================================================
 // TYPES
@@ -30,7 +31,7 @@ export class RefreshTokenReusedError extends Error {
 // STORAGE
 // ============================================================================
 
-const PROFILES_FILE = join(homedir(), ".cycling-coach", "auth-profiles.json");
+const PROFILES_FILE = join(CONFIG_DIR, "auth-profiles.json");
 const REFRESH_THRESHOLD_MS = 5 * 60 * 1000;
 
 type ProfilesFile = Record<string, OAuthCredential>;

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,9 +9,10 @@ import { parse as parseYaml } from "yaml";
 
 export interface Config {
   llm: {
-    provider: "anthropic" | "openai" | "google";
+    provider: "anthropic" | "openai" | "google" | "openai-codex";
     model: string;
     apiKey: string;
+    authProfile?: string;
   };
   intervals: {
     apiKey: string;
@@ -36,10 +37,14 @@ export interface Config {
 export const CONFIG_DIR = join(homedir(), ".cycling-coach");
 export const CONFIG_FILE = join(CONFIG_DIR, "config.yaml");
 
-function loadYamlConfig(): Record<string, unknown> {
+export function readConfigYaml(): Record<string, unknown> {
   if (!existsSync(CONFIG_FILE)) return {};
   const raw = readFileSync(CONFIG_FILE, "utf-8");
-  return (parseYaml(raw) as Record<string, unknown>) ?? {};
+  try {
+    return (parseYaml(raw) as Record<string, unknown>) ?? {};
+  } catch {
+    return {};
+  }
 }
 
 // ============================================================================
@@ -51,6 +56,9 @@ const CONTEXT_WINDOWS: Record<string, number> = {
   "claude-haiku-4-5-20251001": 200_000,
   "gpt-4o": 128_000,
   "gemini-2.0-flash": 1_000_000,
+  "gpt-5.4": 272_000,
+  "gpt-5.4-mini": 272_000,
+  "gpt-5.4-pro": 272_000,
 };
 
 function resolveContextWindowTokens(model: string): number {
@@ -86,7 +94,7 @@ function envFloat(key: string): number | undefined {
 }
 
 export function loadConfig(): Config {
-  const yaml = loadYamlConfig();
+  const yaml = readConfigYaml();
   const llmYaml = (yaml.llm as Record<string, string>) ?? {};
   const intervalsYaml = (yaml.intervals as Record<string, string>) ?? {};
   const telegramYaml = (yaml.telegram as Record<string, string>) ?? {};
@@ -100,12 +108,14 @@ export function loadConfig(): Config {
     anthropic: env("ANTHROPIC_API_KEY") ?? llmYaml.api_key ?? "",
     openai: env("OPENAI_API_KEY") ?? llmYaml.api_key ?? "",
     google: env("GOOGLE_GENERATIVE_AI_API_KEY") ?? llmYaml.api_key ?? "",
+    "openai-codex": "",
   };
 
   const defaultModelMap: Record<string, string> = {
     anthropic: "claude-sonnet-4-6",
     openai: "gpt-4o",
     google: "gemini-2.0-flash",
+    "openai-codex": "gpt-5.4",
   };
 
   const model = env("LLM_MODEL") ?? llmYaml.model ?? defaultModelMap[provider];
@@ -115,6 +125,7 @@ export function loadConfig(): Config {
       provider,
       model,
       apiKey: apiKeyMap[provider],
+      authProfile: provider === "openai-codex" ? (llmYaml.auth_profile ?? "openai-codex") : undefined,
     },
     intervals: {
       apiKey: env("INTERVALS_API_KEY") ?? intervalsYaml.api_key ?? "",

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,9 @@ async function main() {
   if (command === "setup") {
     const { runSetup } = await import("./setup.js");
     await runSetup();
-    return;
+    // pi-ai's OAuth callback server may leave socket/timer handles alive;
+    // exit explicitly so the wizard returns the shell.
+    process.exit(0);
   }
 
   if (command === "version") {
@@ -59,7 +61,7 @@ async function main() {
   const config = loadConfig();
 
   // Validate required config
-  if (!config.llm.apiKey) {
+  if (config.llm.provider !== "openai-codex" && !config.llm.apiKey) {
     console.error(
       "No LLM API key found. Run `cycling-coach setup` to configure, or set ANTHROPIC_API_KEY, OPENAI_API_KEY, or GOOGLE_GENERATIVE_AI_API_KEY.",
     );

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -1,12 +1,15 @@
-import { intro, outro, select, text, password, confirm, isCancel, cancel } from "@clack/prompts";
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { intro, outro, select, text, password, confirm, isCancel, cancel, log } from "@clack/prompts";
+import { existsSync, mkdirSync, writeFileSync, readFileSync, unlinkSync } from "node:fs";
 import { stringify as toYaml } from "yaml";
-import { CONFIG_DIR, CONFIG_FILE } from "./config.js";
+import { CONFIG_DIR, CONFIG_FILE, readConfigYaml } from "./config.js";
+import { runCodexLogin } from "./auth/openai-codex-login.js";
+import { loadProfile, saveProfile, type OAuthCredential } from "./auth/profiles.js";
 
 const PROVIDERS = [
   { value: "anthropic", label: "Anthropic (Claude)" },
   { value: "openai", label: "OpenAI (GPT)" },
   { value: "google", label: "Google (Gemini)" },
+  { value: "openai-codex", label: "OpenAI Codex (ChatGPT subscription)", hint: "experimental" },
 ];
 
 const API_KEY_LABELS: Record<string, string> = {
@@ -32,114 +35,228 @@ const MODELS: Record<string, { value: string; label: string; hint?: string }[]> 
     { value: "gemini-2.5-pro", label: "Gemini 2.5 Pro", hint: "most capable" },
     { value: "gemini-2.5-flash-lite", label: "Gemini 2.5 Flash Lite", hint: "cheapest" },
   ],
+  "openai-codex": [
+    { value: "gpt-5.4", label: "GPT-5.4", hint: "recommended" },
+    { value: "gpt-5.4-mini", label: "GPT-5.4 Mini", hint: "fast & cheap" },
+  ],
 };
 
-function handleCancel(value: unknown): asserts value is string | boolean {
+const DEFAULT_MODELS: Record<string, string> = {
+  anthropic: "claude-sonnet-4-6",
+  openai: "gpt-5.4",
+  google: "gemini-2.5-flash",
+  "openai-codex": "gpt-5.4",
+};
+
+function handleCancel(value: unknown): void {
   if (isCancel(value)) {
     cancel("Setup cancelled.");
     process.exit(0);
   }
 }
 
+function getString(obj: Record<string, unknown>, ...keys: string[]): string | undefined {
+  let cur: unknown = obj;
+  for (const k of keys) {
+    if (cur && typeof cur === "object" && k in (cur as Record<string, unknown>)) {
+      cur = (cur as Record<string, unknown>)[k];
+    } else {
+      return undefined;
+    }
+  }
+  return typeof cur === "string" ? cur : undefined;
+}
+
 export async function runSetup(): Promise<void> {
   intro("Cycling Coach — Setup");
 
+  const previous = readConfigYaml();
+  const prevProvider = getString(previous, "llm", "provider");
+  const prevModel = getString(previous, "llm", "model");
+  const prevApiKey = getString(previous, "llm", "api_key");
+  const prevIntervalsKey = getString(previous, "intervals", "api_key");
+  const prevIntervalsId = getString(previous, "intervals", "athlete_id");
+  const prevTelegramToken = getString(previous, "telegram", "bot_token");
+
   // Provider
-  const provider = await select({
+  const providerResp = await select({
     message: "LLM provider",
     options: PROVIDERS,
+    initialValue: prevProvider ?? "anthropic",
   });
-  handleCancel(provider);
+  handleCancel(providerResp);
+  const provider = providerResp as string;
 
-  // API key
-  const apiKey = await password({
-    message: API_KEY_LABELS[provider],
-    validate: (v) => (!v ? "API key is required" : undefined),
-  });
-  handleCancel(apiKey);
+  // API key (skipped for Codex OAuth). Empty input keeps the existing value.
+  let apiKey = "";
+  if (provider !== "openai-codex") {
+    const hasPrev = provider === prevProvider && !!prevApiKey;
+    const entered = await password({
+      message: hasPrev
+        ? `${API_KEY_LABELS[provider]} (Enter to keep existing)`
+        : API_KEY_LABELS[provider],
+      validate: (v) => {
+        if (hasPrev) return undefined;
+        return !v ? "API key is required" : undefined;
+      },
+    });
+    handleCancel(entered);
+    const entryStr = typeof entered === "string" ? entered : "";
+    apiKey = entryStr || (hasPrev ? (prevApiKey as string) : "");
+  }
 
   // Model
-  const modelOptions = [
-    ...(MODELS[provider] ?? []),
-    { value: "__custom__", label: "Other (type model name)" },
-  ];
-  let model = await select({
+  const sameProvider = provider === prevProvider;
+  const knownModel = MODELS[provider]?.some((m) => m.value === prevModel);
+  const initialModel = sameProvider && prevModel
+    ? (knownModel ? prevModel : "__custom__")
+    : DEFAULT_MODELS[provider];
+  const modelResp = await select({
     message: "Model",
-    options: modelOptions,
+    options: [
+      ...(MODELS[provider] ?? []),
+      { value: "__custom__", label: "Other (type model name)" },
+    ],
+    initialValue: initialModel,
   });
-  handleCancel(model);
+  handleCancel(modelResp);
+  let model = modelResp as string;
 
   if (model === "__custom__") {
     const custom = await text({
       message: "Model name",
-      validate: (v) => (!v ? "Model name is required" : undefined),
+      defaultValue: sameProvider ? prevModel : undefined,
+      placeholder: sameProvider ? prevModel : undefined,
+      validate: (v) => (!v && !(sameProvider && prevModel) ? "Model name is required" : undefined),
     });
     handleCancel(custom);
-    model = custom;
+    model = (typeof custom === "string" && custom) || prevModel || "";
   }
 
-  // intervals.icu (optional)
-  const intervalsKey = await text({
-    message: "intervals.icu API key",
-    placeholder: "Enter to skip",
-  });
-  handleCancel(intervalsKey);
-
-  let intervalsAthleteId = "";
-  if (intervalsKey) {
-    const athleteId = await text({
-      message: "intervals.icu athlete ID",
-      defaultValue: "0",
-      placeholder: "0",
-    });
-    handleCancel(athleteId);
-    intervalsAthleteId = athleteId || "0";
-  }
-
-  // Telegram (optional)
-  const telegramToken = await text({
-    message: "Telegram bot token",
-    placeholder: "Enter to skip",
-  });
-  handleCancel(telegramToken);
-
-  // Overwrite check
-  if (existsSync(CONFIG_FILE)) {
-    const overwrite = await confirm({
-      message: `${CONFIG_FILE} already exists. Overwrite?`,
-    });
-    handleCancel(overwrite);
-    if (!overwrite) {
-      cancel("Setup cancelled.");
-      process.exit(0);
+  // Codex OAuth — reuse existing profile unless the operator asks to re-login
+  let freshCodexCreds: OAuthCredential | null = null;
+  if (provider === "openai-codex") {
+    const existing = loadProfile("openai-codex");
+    let doLogin = true;
+    if (existing) {
+      const reuse = await confirm({
+        message: "Existing Codex OAuth profile found. Re-login?",
+        initialValue: false,
+      });
+      handleCancel(reuse);
+      doLogin = Boolean(reuse);
+    }
+    if (doLogin) {
+      log.info("Starting OAuth sign-in. ChatGPT Plus or higher required.");
+      try {
+        freshCodexCreds = await runCodexLogin();
+        log.success("OpenAI Codex OAuth complete.");
+      } catch (err) {
+        cancel(`OAuth sign-in failed: ${err instanceof Error ? err.message : String(err)}`);
+        process.exit(1);
+      }
     }
   }
 
-  // Build config — only include non-empty sections
-  const config: Record<string, unknown> = {
-    llm: {
-      provider,
-      model,
-      api_key: apiKey,
-    },
-  };
+  // intervals.icu — Enter keeps prior; type new value to replace
+  let intervalsKey = prevIntervalsKey ?? "";
+  let intervalsAthleteId = prevIntervalsId ?? "";
+  {
+    const hasPrev = !!prevIntervalsKey;
+    const entered = await password({
+      message: hasPrev
+        ? "intervals.icu API key (Enter to keep existing)"
+        : "intervals.icu API key (Enter to skip)",
+      validate: () => undefined,
+    });
+    handleCancel(entered);
+    const entryStr = typeof entered === "string" ? entered : "";
+    if (entryStr) {
+      intervalsKey = entryStr;
+      const athleteId = await text({
+        message: "intervals.icu athlete ID",
+        defaultValue: prevIntervalsId ?? "0",
+        placeholder: prevIntervalsId ?? "0",
+      });
+      handleCancel(athleteId);
+      intervalsAthleteId = (typeof athleteId === "string" && athleteId) || prevIntervalsId || "0";
+    }
+  }
+
+  // Telegram — Enter keeps prior; type new value to replace
+  let telegramToken = prevTelegramToken ?? "";
+  {
+    const hasPrev = !!prevTelegramToken;
+    const entered = await password({
+      message: hasPrev
+        ? "Telegram bot token (Enter to keep existing)"
+        : "Telegram bot token (Enter to skip)",
+      validate: () => undefined,
+    });
+    handleCancel(entered);
+    const entryStr = typeof entered === "string" ? entered : "";
+    if (entryStr) telegramToken = entryStr;
+  }
+
+  // Build merged config — start from previous, replace only what changed.
+  const merged: Record<string, unknown> = { ...previous };
+
+  const llmConfig: Record<string, unknown> = { provider, model };
+  if (provider === "openai-codex") {
+    llmConfig.auth_profile = "openai-codex";
+  } else {
+    llmConfig.api_key = apiKey;
+  }
+  merged.llm = llmConfig;
 
   if (intervalsKey) {
-    config.intervals = {
+    merged.intervals = {
       api_key: intervalsKey,
-      athlete_id: intervalsAthleteId,
+      athlete_id: intervalsAthleteId || "0",
     };
+  } else {
+    delete merged.intervals;
   }
 
   if (telegramToken) {
-    config.telegram = {
-      bot_token: telegramToken,
-    };
+    merged.telegram = { bot_token: telegramToken };
+  } else {
+    delete merged.telegram;
   }
 
-  // Write config
+  // Confirm before writing when a prior config exists.
+  if (existsSync(CONFIG_FILE)) {
+    const ok = await confirm({
+      message: `Update ${CONFIG_FILE}?`,
+      initialValue: true,
+    });
+    handleCancel(ok);
+    if (!ok) {
+      log.info("No changes written.");
+      return;
+    }
+  }
+
+  const originalBytes = existsSync(CONFIG_FILE) ? readFileSync(CONFIG_FILE) : null;
+
   mkdirSync(CONFIG_DIR, { recursive: true });
-  writeFileSync(CONFIG_FILE, toYaml(config), { mode: 0o600 });
+  writeFileSync(CONFIG_FILE, toYaml(merged), { mode: 0o600 });
+
+  // Save Codex credentials only after the config write succeeds; roll the
+  // config back if the save fails, so the two files stay in sync.
+  if (freshCodexCreds) {
+    try {
+      saveProfile("openai-codex", freshCodexCreds);
+    } catch (err) {
+      if (originalBytes) {
+        writeFileSync(CONFIG_FILE, originalBytes, { mode: 0o600 });
+      } else {
+        try { unlinkSync(CONFIG_FILE); } catch { /* best-effort */ }
+      }
+      cancel(`Failed to save OAuth profile: ${err instanceof Error ? err.message : String(err)}`);
+      process.exit(1);
+    }
+  }
 
   outro(`Config written to ${CONFIG_FILE}\n  Run \`cycling-coach\` to start.`);
 }

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -37,7 +37,7 @@ const MODELS: Record<string, { value: string; label: string; hint?: string }[]> 
   ],
   "openai-codex": [
     { value: "gpt-5.4", label: "GPT-5.4", hint: "recommended" },
-    { value: "gpt-5.4-mini", label: "GPT-5.4 Mini", hint: "fast & cheap" },
+    { value: "gpt-5.4-mini", label: "GPT-5.4 Mini", hint: "faster" },
   ],
 };
 

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -41,6 +41,8 @@ const MODELS: Record<string, { value: string; label: string; hint?: string }[]> 
   ],
 };
 
+const CUSTOM_MODEL_SENTINEL = "__custom__";
+
 const DEFAULT_MODELS: Record<string, string> = {
   anthropic: "claude-sonnet-4-6",
   openai: "gpt-5.4",
@@ -109,20 +111,20 @@ export async function runSetup(): Promise<void> {
   const sameProvider = provider === prevProvider;
   const knownModel = MODELS[provider]?.some((m) => m.value === prevModel);
   const initialModel = sameProvider && prevModel
-    ? (knownModel ? prevModel : "__custom__")
+    ? (knownModel ? prevModel : CUSTOM_MODEL_SENTINEL)
     : DEFAULT_MODELS[provider];
   const modelResp = await select({
     message: "Model",
     options: [
       ...(MODELS[provider] ?? []),
-      { value: "__custom__", label: "Other (type model name)" },
+      { value: CUSTOM_MODEL_SENTINEL, label: "Other (type model name)" },
     ],
     initialValue: initialModel,
   });
   handleCancel(modelResp);
   let model = modelResp as string;
 
-  if (model === "__custom__") {
+  if (model === CUSTOM_MODEL_SENTINEL) {
     const custom = await text({
       message: "Model name",
       defaultValue: sameProvider ? prevModel : undefined,

--- a/tests/auth-profiles.test.ts
+++ b/tests/auth-profiles.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync, statSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir, homedir } from "node:os";
+import { join } from "node:path";
+
+// Redirect $HOME so the profile file lands in a temp dir.
+let tempHome: string;
+let origHome: string | undefined;
+
+beforeEach(() => {
+  tempHome = mkdtempSync(join(tmpdir(), "cc-auth-"));
+  origHome = process.env.HOME;
+  process.env.HOME = tempHome;
+  vi.resetModules();
+});
+
+afterEach(() => {
+  process.env.HOME = origHome;
+  rmSync(tempHome, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+function profilesPath(): string {
+  return join(homedir(), ".cycling-coach", "auth-profiles.json");
+}
+
+async function loadModule() {
+  const mod = await import("../src/auth/profiles.js");
+  return mod;
+}
+
+describe("auth/profiles", () => {
+  it("loadProfile returns null when file is missing", async () => {
+    const { loadProfile } = await loadModule();
+    expect(loadProfile("openai-codex")).toBeNull();
+  });
+
+  it("saveProfile writes 0o600 file and loadProfile returns the saved data", async () => {
+    const { saveProfile, loadProfile } = await loadModule();
+    const cred = {
+      type: "oauth" as const,
+      access: "a",
+      refresh: "r",
+      expires: Date.now() + 60_000,
+      accountId: "acct",
+      email: "foo@example.com",
+    };
+    // Parent directory is created by loadConfig usually — create here.
+    const { mkdirSync } = await import("node:fs");
+    mkdirSync(join(tempHome, ".cycling-coach"), { recursive: true });
+    saveProfile("openai-codex", cred);
+
+    const st = statSync(profilesPath());
+    expect(st.mode & 0o777).toBe(0o600);
+
+    const loaded = loadProfile("openai-codex");
+    expect(loaded).toEqual(cred);
+  });
+
+  it("getFreshToken returns cached access when not near expiry", async () => {
+    const { saveProfile, getFreshToken } = await loadModule();
+    const { mkdirSync } = await import("node:fs");
+    mkdirSync(join(tempHome, ".cycling-coach"), { recursive: true });
+    saveProfile("openai-codex", {
+      type: "oauth",
+      access: "cached-access",
+      refresh: "refresh",
+      expires: Date.now() + 60 * 60_000,
+    });
+    const token = await getFreshToken("openai-codex");
+    expect(token).toBe("cached-access");
+  });
+
+  it("getFreshToken refreshes when expires is non-finite", async () => {
+    const { mkdirSync } = await import("node:fs");
+    mkdirSync(join(tempHome, ".cycling-coach"), { recursive: true });
+
+    vi.doMock("@mariozechner/pi-ai/oauth", () => ({
+      refreshOpenAICodexToken: vi.fn(async () => ({
+        access: "new-access",
+        refresh: "new-refresh",
+        expires: Date.now() + 60 * 60_000,
+        accountId: "acct",
+      })),
+      loginOpenAICodex: vi.fn(),
+    }));
+
+    const { saveProfile, getFreshToken } = await loadModule();
+    saveProfile("openai-codex", {
+      type: "oauth",
+      access: "old",
+      refresh: "old-refresh",
+      expires: Number.NaN,
+    });
+    const token = await getFreshToken("openai-codex");
+    expect(token).toBe("new-access");
+
+    const saved = JSON.parse(readFileSync(profilesPath(), "utf-8"));
+    expect(saved["openai-codex"].access).toBe("new-access");
+    expect(saved["openai-codex"].refresh).toBe("new-refresh");
+  });
+
+  it("getFreshToken refreshes when within 5-min threshold", async () => {
+    const { mkdirSync } = await import("node:fs");
+    mkdirSync(join(tempHome, ".cycling-coach"), { recursive: true });
+
+    vi.doMock("@mariozechner/pi-ai/oauth", () => ({
+      refreshOpenAICodexToken: vi.fn(async () => ({
+        access: "rotated",
+        refresh: "rotated-refresh",
+        expires: Date.now() + 3_600_000,
+        accountId: "acct",
+      })),
+      loginOpenAICodex: vi.fn(),
+    }));
+
+    const { saveProfile, getFreshToken } = await loadModule();
+    saveProfile("openai-codex", {
+      type: "oauth",
+      access: "old",
+      refresh: "old-refresh",
+      expires: Date.now() + 2 * 60_000, // 2 min from now — inside threshold
+    });
+    const token = await getFreshToken("openai-codex");
+    expect(token).toBe("rotated");
+  });
+
+  it("getFreshToken surfaces RefreshTokenReusedError on refresh failure", async () => {
+    const { mkdirSync } = await import("node:fs");
+    mkdirSync(join(tempHome, ".cycling-coach"), { recursive: true });
+
+    vi.doMock("@mariozechner/pi-ai/oauth", () => ({
+      refreshOpenAICodexToken: vi.fn(async () => {
+        throw new Error("Failed to refresh OpenAI Codex token");
+      }),
+      loginOpenAICodex: vi.fn(),
+    }));
+
+    const { saveProfile, getFreshToken, RefreshTokenReusedError } = await loadModule();
+    saveProfile("openai-codex", {
+      type: "oauth",
+      access: "old",
+      refresh: "revoked",
+      expires: Date.now() - 1000,
+    });
+
+    await expect(getFreshToken("openai-codex")).rejects.toBeInstanceOf(RefreshTokenReusedError);
+  });
+
+  it("survives a corrupt profiles file", async () => {
+    const { mkdirSync } = await import("node:fs");
+    mkdirSync(join(tempHome, ".cycling-coach"), { recursive: true });
+    writeFileSync(profilesPath(), "not-json{{", { mode: 0o600 });
+
+    const { loadProfile } = await loadModule();
+    expect(loadProfile("openai-codex")).toBeNull();
+  });
+});

--- a/tests/codex-bridge.test.ts
+++ b/tests/codex-bridge.test.ts
@@ -1,0 +1,265 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Test the bridge's error normalization and result mapping. Mocks pi-ai's
+// `complete` / `getModel` and auth profile access.
+
+let tempHome: string;
+let origHome: string | undefined;
+
+beforeEach(() => {
+  tempHome = mkdtempSync(join(tmpdir(), "cc-bridge-"));
+  origHome = process.env.HOME;
+  process.env.HOME = tempHome;
+  mkdirSync(join(tempHome, ".cycling-coach"), { recursive: true });
+  vi.resetModules();
+});
+
+afterEach(() => {
+  process.env.HOME = origHome;
+  rmSync(tempHome, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+async function loadBridgeWithMocks(opts: {
+  complete: ReturnType<typeof vi.fn>;
+  getModel?: ReturnType<typeof vi.fn>;
+  freshToken?: ReturnType<typeof vi.fn>;
+}) {
+  const getModel =
+    opts.getModel ??
+    vi.fn(() => ({
+      id: "gpt-5.4",
+      name: "gpt-5.4",
+      api: "openai-codex-responses",
+      provider: "openai-codex",
+      baseUrl: "https://chatgpt.com/backend-api",
+      reasoning: true,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 272_000,
+      maxTokens: 128_000,
+    }));
+
+  vi.doMock("@mariozechner/pi-ai", () => ({
+    complete: opts.complete,
+    getModel,
+  }));
+
+  vi.doMock("../src/auth/profiles.js", () => ({
+    getFreshToken: opts.freshToken ?? vi.fn(async () => "test-access-token"),
+  }));
+
+  const { codexGenerateText } = await import("../src/agent/codex-bridge.js");
+  return { codexGenerateText, getModel };
+}
+
+function asstMsg(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    role: "assistant" as const,
+    content: [{ type: "text" as const, text: "hello" }],
+    api: "openai-codex-responses",
+    provider: "openai-codex",
+    model: "gpt-5.4",
+    usage: {
+      input: 10,
+      output: 5,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 15,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: "stop" as const,
+    timestamp: Date.now(),
+    ...overrides,
+  };
+}
+
+describe("codex-bridge", () => {
+  it("returns {text, finishReason, usage} for a simple completion", async () => {
+    const complete = vi.fn(async () => asstMsg());
+    const { codexGenerateText } = await loadBridgeWithMocks({ complete });
+
+    const result = await codexGenerateText({
+      system: "sys",
+      messages: [{ role: "user", content: "hi" }],
+      modelId: "gpt-5.4",
+      profileName: "openai-codex",
+    });
+
+    expect(result.text).toBe("hello");
+    expect(result.finishReason).toBe("stop");
+    expect(result.usage.inputTokens).toBe(10);
+    expect(result.usage.outputTokens).toBe(5);
+    expect(complete).toHaveBeenCalledTimes(1);
+  });
+
+  it("maps pi-ai rate-limit errors so isRateLimitError() recognizes them", async () => {
+    const complete = vi.fn(async () => {
+      throw new Error("You have hit your ChatGPT usage limit (plus plan). Try again in ~5 min.");
+    });
+    const { codexGenerateText } = await loadBridgeWithMocks({ complete });
+
+    const { isRateLimitError } = await import("../src/agent/token-utils.js");
+
+    try {
+      await codexGenerateText({
+        messages: [{ role: "user", content: "hi" }],
+        modelId: "gpt-5.4",
+        profileName: "openai-codex",
+      });
+      throw new Error("should have thrown");
+    } catch (err) {
+      expect(isRateLimitError(err)).toBe(true);
+    }
+  });
+
+  it("maps 'Request was aborted' to a timeout-shaped error", async () => {
+    const complete = vi.fn(async () => {
+      throw new Error("Request was aborted");
+    });
+    const { codexGenerateText } = await loadBridgeWithMocks({ complete });
+
+    const { isTimeoutError } = await import("../src/agent/token-utils.js");
+
+    try {
+      await codexGenerateText({
+        messages: [{ role: "user", content: "hi" }],
+        modelId: "gpt-5.4",
+        profileName: "openai-codex",
+      });
+      throw new Error("should have thrown");
+    } catch (err) {
+      expect(isTimeoutError(err)).toBe(true);
+    }
+  });
+
+  it("maps context-length errors so isContextOverflowError() recognizes them", async () => {
+    const complete = vi.fn(async () => {
+      throw new Error("Request exceeds the maximum context length of 272000 tokens");
+    });
+    const { codexGenerateText } = await loadBridgeWithMocks({ complete });
+
+    const { isContextOverflowError } = await import("../src/agent/token-utils.js");
+
+    try {
+      await codexGenerateText({
+        messages: [{ role: "user", content: "hi" }],
+        modelId: "gpt-5.4",
+        profileName: "openai-codex",
+      });
+      throw new Error("should have thrown");
+    } catch (err) {
+      expect(isContextOverflowError(err)).toBe(true);
+    }
+  });
+
+  it("calls getFreshToken before each request and forwards the token as apiKey", async () => {
+    const complete = vi.fn(async () => asstMsg());
+    const freshToken = vi.fn(async () => "fresh-token-abc");
+    const { codexGenerateText } = await loadBridgeWithMocks({ complete, freshToken });
+
+    await codexGenerateText({
+      messages: [{ role: "user", content: "hi" }],
+      modelId: "gpt-5.4",
+      profileName: "openai-codex",
+    });
+
+    expect(freshToken).toHaveBeenCalledWith("openai-codex");
+    expect(complete).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.any(Object),
+      expect.objectContaining({ apiKey: "fresh-token-abc", onResponse: expect.any(Function) }),
+    );
+  });
+
+  it("surfaces finishReason=length so isContextOverflowError can catch it upstream via retry", async () => {
+    const complete = vi.fn(async () =>
+      asstMsg({ stopReason: "length", content: [{ type: "text", text: "truncated" }] }),
+    );
+    const { codexGenerateText } = await loadBridgeWithMocks({ complete });
+    const res = await codexGenerateText({
+      messages: [{ role: "user", content: "hi" }],
+      modelId: "gpt-5.4",
+      profileName: "openai-codex",
+    });
+    expect(res.finishReason).toBe("length");
+  });
+
+  it("passes onResponse that throws 'usage limit' on retryable HTTP statuses", async () => {
+    let capturedOnResponse:
+      | ((r: { status: number; headers: Record<string, string> }) => Promise<void> | void)
+      | undefined;
+    const complete = vi.fn(async (_m: unknown, _c: unknown, opts: { onResponse?: typeof capturedOnResponse }) => {
+      capturedOnResponse = opts.onResponse;
+      return asstMsg();
+    });
+    const { codexGenerateText } = await loadBridgeWithMocks({ complete });
+
+    await codexGenerateText({
+      messages: [{ role: "user", content: "hi" }],
+      modelId: "gpt-5.4",
+      profileName: "openai-codex",
+    });
+
+    expect(typeof capturedOnResponse).toBe("function");
+
+    for (const status of [429, 500, 502, 503, 504]) {
+      await expect(capturedOnResponse!({ status, headers: {} })).rejects.toThrow(/usage limit/);
+    }
+
+    for (const status of [200, 201, 204, 301, 400, 401, 403, 404]) {
+      await expect(capturedOnResponse!({ status, headers: {} })).resolves.toBeUndefined();
+    }
+  });
+
+  it("stops the tool-calling loop at stepLimit", async () => {
+    // Always return a toolCall — the bridge would loop forever if stepLimit
+    // weren't honored. Empty tools set → executeToolCall returns an error
+    // result but the loop still cycles until stepLimit.
+    const complete = vi.fn(async () =>
+      asstMsg({
+        stopReason: "toolUse",
+        content: [{ type: "toolCall", id: "c1", name: "noop", arguments: {} }],
+      }),
+    );
+    const { codexGenerateText } = await loadBridgeWithMocks({ complete });
+
+    await codexGenerateText({
+      messages: [{ role: "user", content: "hi" }],
+      tools: {} as never,
+      modelId: "gpt-5.4",
+      profileName: "openai-codex",
+      stepLimit: 3,
+    });
+
+    expect(complete).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not leak fake tokens via console.warn/error", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const secretToken = "fresh-token-abc-secret";
+    const complete = vi.fn(async () => asstMsg());
+    const { codexGenerateText } = await loadBridgeWithMocks({
+      complete,
+      freshToken: vi.fn(async () => secretToken),
+    });
+
+    await codexGenerateText({
+      messages: [{ role: "user", content: "hi" }],
+      modelId: "gpt-5.4",
+      profileName: "openai-codex",
+    });
+
+    const allLogs = [...warnSpy.mock.calls, ...errSpy.mock.calls]
+      .flat()
+      .map((arg) => (typeof arg === "string" ? arg : JSON.stringify(arg)))
+      .join(" ");
+    expect(allLogs).not.toContain(secretToken);
+    expect(allLogs).not.toContain("test-access-token");
+  });
+});

--- a/tests/codex-setup-flow.test.ts
+++ b/tests/codex-setup-flow.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync, readFileSync, existsSync, mkdirSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { parse as parseYaml } from "yaml";
+
+let tempHome: string;
+let origHome: string | undefined;
+
+beforeEach(() => {
+  tempHome = mkdtempSync(join(tmpdir(), "cc-setup-"));
+  origHome = process.env.HOME;
+  process.env.HOME = tempHome;
+  mkdirSync(join(tempHome, ".cycling-coach"), { recursive: true });
+  vi.resetModules();
+});
+
+afterEach(() => {
+  process.env.HOME = origHome;
+  rmSync(tempHome, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+describe("codex setup flow", () => {
+  it("writes config without api_key and saves auth-profiles.json with 0o600", async () => {
+    // Answers the wizard returns, in order. First: provider. Then: model.
+    // Then intervals key (skip). Then telegram token (skip).
+    const answers = ["openai-codex", "gpt-5.4", "", ""];
+    let answerIdx = 0;
+    const nextAnswer = () => answers[answerIdx++];
+
+    vi.doMock("@clack/prompts", () => ({
+      intro: vi.fn(),
+      outro: vi.fn(),
+      cancel: vi.fn(),
+      log: { info: vi.fn(), success: vi.fn(), error: vi.fn() },
+      note: vi.fn(),
+      isCancel: () => false,
+      select: vi.fn(async () => nextAnswer()),
+      text: vi.fn(async () => nextAnswer()),
+      password: vi.fn(async () => nextAnswer()),
+      confirm: vi.fn(async () => true),
+    }));
+
+    vi.doMock("../src/auth/openai-codex-login.js", () => ({
+      runCodexLogin: vi.fn(async () => ({
+        type: "oauth",
+        access: "fake-access",
+        refresh: "fake-refresh",
+        expires: Date.now() + 3_600_000,
+        accountId: "acct",
+      })),
+    }));
+
+    const { runSetup } = await import("../src/setup.js");
+    await runSetup();
+
+    const configPath = join(tempHome, ".cycling-coach", "config.yaml");
+    expect(existsSync(configPath)).toBe(true);
+    const yaml = parseYaml(readFileSync(configPath, "utf-8")) as Record<string, unknown>;
+    const llm = yaml.llm as Record<string, unknown>;
+    expect(llm.provider).toBe("openai-codex");
+    expect(llm.model).toBe("gpt-5.4");
+    expect(llm.api_key).toBeUndefined();
+    expect(llm.auth_profile).toBe("openai-codex");
+
+    const profilesPath = join(tempHome, ".cycling-coach", "auth-profiles.json");
+    expect(existsSync(profilesPath)).toBe(true);
+    const st = statSync(profilesPath);
+    expect(st.mode & 0o777).toBe(0o600);
+
+    const saved = JSON.parse(readFileSync(profilesPath, "utf-8"));
+    expect(saved["openai-codex"].access).toBe("fake-access");
+    expect(saved["openai-codex"].refresh).toBe("fake-refresh");
+  });
+});

--- a/tests/codex-setup-flow.test.ts
+++ b/tests/codex-setup-flow.test.ts
@@ -4,6 +4,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { parse as parseYaml } from "yaml";
 
+import { scriptedPrompts } from "./helpers/scripted-prompts.js";
+
 let tempHome: string;
 let origHome: string | undefined;
 
@@ -23,24 +25,12 @@ afterEach(() => {
 
 describe("codex setup flow", () => {
   it("writes config without api_key and saves auth-profiles.json with 0o600", async () => {
-    // Answers the wizard returns, in order. First: provider. Then: model.
-    // Then intervals key (skip). Then telegram token (skip).
-    const answers = ["openai-codex", "gpt-5.4", "", ""];
-    let answerIdx = 0;
-    const nextAnswer = () => answers[answerIdx++];
-
-    vi.doMock("@clack/prompts", () => ({
-      intro: vi.fn(),
-      outro: vi.fn(),
-      cancel: vi.fn(),
-      log: { info: vi.fn(), success: vi.fn(), error: vi.fn() },
-      note: vi.fn(),
-      isCancel: () => false,
-      select: vi.fn(async () => nextAnswer()),
-      text: vi.fn(async () => nextAnswer()),
-      password: vi.fn(async () => nextAnswer()),
-      confirm: vi.fn(async () => true),
-    }));
+    vi.doMock("@clack/prompts", () =>
+      scriptedPrompts({
+        selects: ["openai-codex", "gpt-5.4"],
+        passwords: ["", ""],
+      }),
+    );
 
     vi.doMock("../src/auth/openai-codex-login.js", () => ({
       runCodexLogin: vi.fn(async () => ({

--- a/tests/helpers/scripted-prompts.ts
+++ b/tests/helpers/scripted-prompts.ts
@@ -1,0 +1,35 @@
+import { vi } from "vitest";
+
+export interface ScriptedAnswers {
+  selects?: unknown[];
+  passwords?: string[];
+  texts?: string[];
+  confirms?: boolean[];
+}
+
+/**
+ * Returns a drop-in `vi.doMock` factory for `@clack/prompts` that replays
+ * pre-scripted answers per prompt type. Use in setup-wizard tests.
+ */
+export function scriptedPrompts(answers: ScriptedAnswers) {
+  const selects = answers.selects ?? [];
+  const passwords = answers.passwords ?? [];
+  const texts = answers.texts ?? [];
+  const confirms = answers.confirms ?? [];
+  let s = 0;
+  let p = 0;
+  let t = 0;
+  let c = 0;
+  return {
+    intro: vi.fn(),
+    outro: vi.fn(),
+    cancel: vi.fn(),
+    log: { info: vi.fn(), success: vi.fn(), error: vi.fn() },
+    note: vi.fn(),
+    isCancel: () => false,
+    select: vi.fn(async () => selects[s++]),
+    password: vi.fn(async () => passwords[p++]),
+    text: vi.fn(async () => texts[t++]),
+    confirm: vi.fn(async () => confirms[c++]),
+  };
+}

--- a/tests/llm-dispatch.test.ts
+++ b/tests/llm-dispatch.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+import type { Config } from "../src/config.js";
+
+function codexConfig(): Config {
+  return {
+    llm: { provider: "openai-codex", model: "gpt-5.4", apiKey: "", authProfile: "openai-codex" },
+    intervals: { apiKey: "", athleteId: "0" },
+    telegram: { botToken: "" },
+    session: { historyTokenBudgetRatio: 0.3, idleMinutes: 0, dailyResetHour: 4 },
+    contextWindowTokens: 272_000,
+    dataDir: "/tmp/cc-dispatch-test",
+  };
+}
+
+type Captured = { stepLimit: number | undefined; called: number };
+
+async function runCodex(opts: Parameters<import("../src/agent/llm.js").LLM["generate"]>[0]): Promise<Captured> {
+  const captured: Captured = { stepLimit: undefined, called: 0 };
+  vi.doMock("../src/agent/codex-bridge.js", () => ({
+    codexGenerateText: vi.fn(async (o: { stepLimit?: number }) => {
+      captured.stepLimit = o.stepLimit;
+      captured.called++;
+      return { text: "ok", toolCalls: [], finishReason: "stop", usage: {} };
+    }),
+  }));
+  const { LLM } = await import("../src/agent/llm.js");
+  const llm = new LLM(codexConfig());
+  await llm.generate(opts);
+  return captured;
+}
+
+beforeEach(() => {
+  vi.resetModules();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("LLM dispatch — codex path forwards maxSteps to bridge", () => {
+  it("forwards opts.maxSteps to the bridge as stepLimit", async () => {
+    const captured = await runCodex({
+      messages: [{ role: "user", content: "hi" }],
+      maxSteps: 5,
+    });
+    expect(captured.called).toBe(1);
+    expect(captured.stepLimit).toBe(5);
+  });
+
+  it("forwards undefined when maxSteps is not provided (bridge applies its own default)", async () => {
+    const captured = await runCodex({ messages: [{ role: "user", content: "hi" }] });
+    expect(captured.stepLimit).toBeUndefined();
+  });
+});

--- a/tests/retry-loop-codex.test.ts
+++ b/tests/retry-loop-codex.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+let tempHome: string;
+let origHome: string | undefined;
+let dataDir: string;
+
+beforeEach(() => {
+  tempHome = mkdtempSync(join(tmpdir(), "cc-retry-"));
+  origHome = process.env.HOME;
+  process.env.HOME = tempHome;
+  dataDir = join(tempHome, ".cycling-coach");
+  mkdirSync(dataDir, { recursive: true });
+  mkdirSync(join(dataDir, "memory"), { recursive: true });
+  vi.resetModules();
+});
+
+afterEach(() => {
+  process.env.HOME = origHome;
+  rmSync(tempHome, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+function baseConfig() {
+  return {
+    llm: {
+      provider: "openai-codex" as const,
+      model: "gpt-5.4",
+      apiKey: "",
+      authProfile: "openai-codex",
+    },
+    intervals: { apiKey: "", athleteId: "0" },
+    telegram: { botToken: "" },
+    session: {
+      historyTokenBudgetRatio: 0.3,
+      idleMinutes: 0,
+      dailyResetHour: 4,
+    },
+    contextWindowTokens: 272_000,
+    dataDir,
+  };
+}
+
+async function setupAgent(complete: ReturnType<typeof vi.fn>) {
+  const model = {
+    id: "gpt-5.4",
+    name: "gpt-5.4",
+    api: "openai-codex-responses",
+    provider: "openai-codex",
+    baseUrl: "https://chatgpt.com/backend-api",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 272_000,
+    maxTokens: 128_000,
+  };
+
+  vi.doMock("@mariozechner/pi-ai", () => ({
+    complete,
+    getModel: vi.fn(() => model),
+  }));
+  vi.doMock("@mariozechner/pi-ai/oauth", () => ({
+    refreshOpenAICodexToken: vi.fn(),
+    loginOpenAICodex: vi.fn(),
+  }));
+  vi.doMock("../src/auth/profiles.js", () => ({
+    getFreshToken: vi.fn(async () => "token"),
+    loadProfile: vi.fn(),
+    saveProfile: vi.fn(),
+    RefreshTokenReusedError: class extends Error {},
+  }));
+
+  const { CyclingCoachAgent } = await import("../src/agent/core.js");
+  return new CyclingCoachAgent(baseConfig());
+}
+
+function mkAssistant(text: string, stopReason: "stop" | "length" = "stop") {
+  return {
+    role: "assistant" as const,
+    content: [{ type: "text" as const, text }],
+    api: "openai-codex-responses",
+    provider: "openai-codex",
+    model: "gpt-5.4",
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason,
+    timestamp: Date.now(),
+  };
+}
+
+describe("retry loop on Codex path", () => {
+  it("retries after a rate-limit error and then succeeds", async () => {
+    let n = 0;
+    const complete = vi.fn(async () => {
+      n++;
+      if (n === 1) {
+        throw new Error("You have hit your ChatGPT usage limit (plus plan). Try again in ~1 min.");
+      }
+      return mkAssistant("recovered");
+    });
+
+    // Short-circuit backoff so the test doesn't wait 5s.
+    vi.useFakeTimers();
+    const agent = await setupAgent(complete);
+
+    const chatPromise = agent.chat("test-chat", "hello");
+    // Advance all timers until the promise resolves.
+    await vi.advanceTimersByTimeAsync(10_000);
+    const text = await chatPromise;
+
+    expect(text).toBe("recovered");
+    expect(complete).toHaveBeenCalledTimes(2);
+
+    vi.useRealTimers();
+  });
+
+  it("propagates the error after MAX_RATE_LIMIT_ATTEMPTS exhausts", async () => {
+    const complete = vi.fn(async () => {
+      throw new Error("rate_limit_exceeded: too many requests");
+    });
+    vi.useFakeTimers();
+    const agent = await setupAgent(complete);
+
+    // Attach a catch handler immediately so Node doesn't report an unhandled rejection
+    // when backoff sleeps drain before the assertion runs.
+    const chatPromise = agent.chat("test-chat-2", "hello");
+    const settled = chatPromise.then(
+      (v) => ({ ok: true as const, value: v }),
+      (err: unknown) => ({ ok: false as const, error: err }),
+    );
+    await vi.advanceTimersByTimeAsync(120_000);
+    const outcome = await settled;
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok) {
+      expect(String((outcome.error as Error).message)).toMatch(/rate/i);
+    }
+    expect(complete.mock.calls.length).toBeGreaterThanOrEqual(2);
+
+    vi.useRealTimers();
+  });
+
+  it("compacts and retries after a context-overflow error on the codex path", async () => {
+    let n = 0;
+    const complete = vi.fn(async () => {
+      n++;
+      if (n === 1) {
+        throw new Error("Request exceeds the maximum context length of 272000 tokens");
+      }
+      return mkAssistant("recovered-after-compaction");
+    });
+
+    const agent = await setupAgent(complete);
+    const text = await agent.chat("test-chat-overflow", "hello");
+
+    expect(text).toBe("recovered-after-compaction");
+    // 1 overflow + 1 memory flush during compaction + 1 retry success = 3
+    expect(complete).toHaveBeenCalledTimes(3);
+  });
+});

--- a/tests/setup-merge.test.ts
+++ b/tests/setup-merge.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { parse as parseYaml, stringify as toYaml } from "yaml";
+
+let tempHome: string;
+let origHome: string | undefined;
+
+beforeEach(() => {
+  tempHome = mkdtempSync(join(tmpdir(), "cc-merge-"));
+  origHome = process.env.HOME;
+  process.env.HOME = tempHome;
+  mkdirSync(join(tempHome, ".cycling-coach"), { recursive: true });
+  vi.resetModules();
+});
+
+afterEach(() => {
+  process.env.HOME = origHome;
+  rmSync(tempHome, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+const CONFIG = () => join(tempHome, ".cycling-coach", "config.yaml");
+const PROFILES = () => join(tempHome, ".cycling-coach", "auth-profiles.json");
+
+function seedConfig(obj: Record<string, unknown>): void {
+  writeFileSync(CONFIG(), toYaml(obj), { mode: 0o600 });
+}
+
+function scriptedPrompts(answers: {
+  selects: unknown[];
+  passwords: string[];
+  texts: string[];
+  confirms: boolean[];
+}) {
+  let s = 0;
+  let p = 0;
+  let t = 0;
+  let c = 0;
+  return {
+    intro: vi.fn(),
+    outro: vi.fn(),
+    cancel: vi.fn(),
+    log: { info: vi.fn(), success: vi.fn(), error: vi.fn() },
+    note: vi.fn(),
+    isCancel: () => false,
+    select: vi.fn(async () => answers.selects[s++]),
+    password: vi.fn(async () => answers.passwords[p++]),
+    text: vi.fn(async () => answers.texts[t++]),
+    confirm: vi.fn(async () => answers.confirms[c++]),
+  };
+}
+
+describe("setup merge", () => {
+  it("Case A: switching provider to Codex preserves intervals and telegram", async () => {
+    seedConfig({
+      llm: { provider: "anthropic", model: "claude-sonnet-4-6", api_key: "sk-ant-keep" },
+      intervals: { api_key: "intv-keep", athlete_id: "i42" },
+      telegram: { bot_token: "tg-keep" },
+    });
+
+    vi.doMock("@clack/prompts", () =>
+      scriptedPrompts({
+        selects: ["openai-codex", "gpt-5.4"],
+        passwords: ["", ""], // intervals Enter-to-keep, telegram Enter-to-keep
+        texts: [],
+        confirms: [true], // update config
+      }),
+    );
+    vi.doMock("../src/auth/openai-codex-login.js", () => ({
+      runCodexLogin: vi.fn(async () => ({
+        type: "oauth",
+        access: "fresh-access",
+        refresh: "fresh-refresh",
+        expires: Date.now() + 3_600_000,
+      })),
+    }));
+
+    const { runSetup } = await import("../src/setup.js");
+    await runSetup();
+
+    const merged = parseYaml(readFileSync(CONFIG(), "utf-8")) as Record<string, any>;
+    expect(merged.llm.provider).toBe("openai-codex");
+    expect(merged.llm.model).toBe("gpt-5.4");
+    expect(merged.llm.api_key).toBeUndefined();
+    expect(merged.llm.auth_profile).toBe("openai-codex");
+    expect(merged.intervals).toEqual({ api_key: "intv-keep", athlete_id: "i42" });
+    expect(merged.telegram).toEqual({ bot_token: "tg-keep" });
+
+    const saved = JSON.parse(readFileSync(PROFILES(), "utf-8"));
+    expect(saved["openai-codex"].access).toBe("fresh-access");
+  });
+
+  it("Case B: declining the update confirm leaves both files untouched", async () => {
+    seedConfig({
+      llm: { provider: "anthropic", model: "claude-sonnet-4-6", api_key: "sk-ant-keep" },
+      intervals: { api_key: "intv-keep", athlete_id: "i42" },
+      telegram: { bot_token: "tg-keep" },
+    });
+    const before = readFileSync(CONFIG(), "utf-8");
+
+    vi.doMock("@clack/prompts", () =>
+      scriptedPrompts({
+        selects: ["openai-codex", "gpt-5.4"],
+        passwords: ["", ""],
+        texts: [],
+        confirms: [false], // decline update
+      }),
+    );
+    vi.doMock("../src/auth/openai-codex-login.js", () => ({
+      runCodexLogin: vi.fn(async () => ({
+        type: "oauth",
+        access: "fresh-access",
+        refresh: "fresh-refresh",
+        expires: Date.now() + 3_600_000,
+      })),
+    }));
+
+    const { runSetup } = await import("../src/setup.js");
+    await runSetup();
+
+    expect(readFileSync(CONFIG(), "utf-8")).toBe(before);
+    expect(existsSync(PROFILES())).toBe(false);
+  });
+
+  it("Case C: fresh install writes full config without requiring merge", async () => {
+    vi.doMock("@clack/prompts", () =>
+      scriptedPrompts({
+        selects: ["openai-codex", "gpt-5.4"],
+        passwords: ["", ""],
+        texts: [],
+        confirms: [],
+      }),
+    );
+    vi.doMock("../src/auth/openai-codex-login.js", () => ({
+      runCodexLogin: vi.fn(async () => ({
+        type: "oauth",
+        access: "a",
+        refresh: "r",
+        expires: Date.now() + 3_600_000,
+      })),
+    }));
+
+    const { runSetup } = await import("../src/setup.js");
+    await runSetup();
+
+    const config = parseYaml(readFileSync(CONFIG(), "utf-8")) as Record<string, any>;
+    expect(config.llm).toEqual({
+      provider: "openai-codex",
+      model: "gpt-5.4",
+      auth_profile: "openai-codex",
+    });
+    expect(config.intervals).toBeUndefined();
+    expect(config.telegram).toBeUndefined();
+    expect(existsSync(PROFILES())).toBe(true);
+  });
+
+  it("Case D: OAuth login failure leaves config.yaml and auth-profiles.json untouched", async () => {
+    seedConfig({
+      llm: { provider: "anthropic", model: "claude-sonnet-4-6", api_key: "sk-ant-keep" },
+      intervals: { api_key: "intv-keep", athlete_id: "i42" },
+    });
+    const before = readFileSync(CONFIG(), "utf-8");
+
+    vi.doMock("@clack/prompts", () =>
+      scriptedPrompts({
+        selects: ["openai-codex", "gpt-5.4"],
+        passwords: [],
+        texts: [],
+        confirms: [],
+      }),
+    );
+    vi.doMock("../src/auth/openai-codex-login.js", () => ({
+      runCodexLogin: vi.fn(async () => {
+        throw new Error("OAuth cancelled by user");
+      }),
+    }));
+
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`__exit_${code ?? 0}`);
+    }) as never);
+
+    const { runSetup } = await import("../src/setup.js");
+    await expect(runSetup()).rejects.toThrow(/__exit_1/);
+
+    expect(readFileSync(CONFIG(), "utf-8")).toBe(before);
+    expect(existsSync(PROFILES())).toBe(false);
+    exitSpy.mockRestore();
+  });
+
+  it("preserves unknown top-level keys on merge", async () => {
+    seedConfig({
+      llm: { provider: "anthropic", model: "claude-sonnet-4-6", api_key: "sk-ant-keep" },
+      data_dir: "/custom/dir",
+      session: { idleMinutes: 15 },
+    });
+
+    vi.doMock("@clack/prompts", () =>
+      scriptedPrompts({
+        selects: ["openai-codex", "gpt-5.4"],
+        passwords: ["", ""],
+        texts: [],
+        confirms: [true],
+      }),
+    );
+    vi.doMock("../src/auth/openai-codex-login.js", () => ({
+      runCodexLogin: vi.fn(async () => ({
+        type: "oauth",
+        access: "a",
+        refresh: "r",
+        expires: Date.now() + 3_600_000,
+      })),
+    }));
+
+    const { runSetup } = await import("../src/setup.js");
+    await runSetup();
+
+    const merged = parseYaml(readFileSync(CONFIG(), "utf-8")) as Record<string, any>;
+    expect(merged.data_dir).toBe("/custom/dir");
+    expect(merged.session).toEqual({ idleMinutes: 15 });
+  });
+});

--- a/tests/setup-merge.test.ts
+++ b/tests/setup-merge.test.ts
@@ -4,6 +4,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { parse as parseYaml, stringify as toYaml } from "yaml";
 
+import { scriptedPrompts } from "./helpers/scripted-prompts.js";
+
 let tempHome: string;
 let origHome: string | undefined;
 
@@ -26,30 +28,6 @@ const PROFILES = () => join(tempHome, ".cycling-coach", "auth-profiles.json");
 
 function seedConfig(obj: Record<string, unknown>): void {
   writeFileSync(CONFIG(), toYaml(obj), { mode: 0o600 });
-}
-
-function scriptedPrompts(answers: {
-  selects: unknown[];
-  passwords: string[];
-  texts: string[];
-  confirms: boolean[];
-}) {
-  let s = 0;
-  let p = 0;
-  let t = 0;
-  let c = 0;
-  return {
-    intro: vi.fn(),
-    outro: vi.fn(),
-    cancel: vi.fn(),
-    log: { info: vi.fn(), success: vi.fn(), error: vi.fn() },
-    note: vi.fn(),
-    isCancel: () => false,
-    select: vi.fn(async () => answers.selects[s++]),
-    password: vi.fn(async () => answers.passwords[p++]),
-    text: vi.fn(async () => answers.texts[t++]),
-    confirm: vi.fn(async () => answers.confirms[c++]),
-  };
 }
 
 describe("setup merge", () => {


### PR DESCRIPTION
## Summary
- Adds a fourth LLM provider, `openai-codex`, that authenticates via OpenAI's Codex OAuth flow against `chatgpt.com/backend-api` through `@mariozechner/pi-ai`. Operators on a ChatGPT Plus/Pro subscription can BYO subscription instead of paying for an API key.
- Introduces a dispatch layer (`src/agent/llm.ts`) + bridge (`src/agent/codex-bridge.ts`) so Codex routes through pi-ai while Anthropic/OpenAI/Google keep the existing AI SDK path — tools, session store, and retry loop unchanged.
- Setup wizard is now non-destructive: `~/.cycling-coach/config.yaml` is loaded, mutated, and written back. Pressing Enter on any prompt keeps the prior value, unknown top-level keys round-trip, and the OAuth token save is deferred until after the config write so cancelling never leaves orphan tokens on disk.

## Details
- OAuth profile stored at `~/.cycling-coach/auth-profiles.json` (mode `0600`) with lazy refresh; Grammy processes updates sequentially so no mutex is needed.
- Pi-ai's hardcoded 4× retry on `429/5xx` short-circuited via an `onResponse` callback (pi-ai's internal `"usage limit"` escape hatch) so the outer `core.ts` loop owns backoff with full visibility. Worst-case retry amplification: 4 HTTP calls on hard 429, down from a theoretical 16.
- Long OAuth URL is printed outside the `@clack/prompts` `note()` box so the line-wrap whitespace doesn't end up in the pasted URL.
- Reference docs: `docs/battle-plan-codex-oauth.md`, `docs/battle-plan-codex-oauth-fixes.md`, `docs/battle-plan-codex-oauth-setup-merge.md` (all gitignored; kept for future-self context).

## Test plan
- [x] `npm run check` — tsc + oxlint clean
- [x] `npm test` — 15 files / 112 tests pass, including new suites: `auth-profiles`, `codex-bridge`, `codex-setup-flow`, `llm-dispatch`, `retry-loop-codex`, `setup-merge`
- [x] Ran `npm run dev -- setup`, picked `openai-codex`, completed browser OAuth; `config.yaml` retained `intervals` + `telegram` blocks, `auth-profiles.json` written with mode `0600`
- [ ] Live chat round-trip on Codex provider (via `LLM_PROVIDER=openai-codex LLM_MODEL=gpt-5.4 TELEGRAM_BOT_TOKEN= npm run dev`) — needs operator verification
- [ ] Induced-rate-limit observation in production to confirm outer-loop backoff behavior