### PR TITLE
feat(config): add CYCLING_COACH_HOME to separate dev and prod data dirs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,8 @@ TELEGRAM_BOT_TOKEN=123456:ABC-DEF...
 # SESSION_IDLE_MINUTES=0
 # SESSION_DAILY_RESET_HOUR=4
 # CONTEXT_WINDOW_TOKENS=200000
+
+# Data directory (optional). Overrides the default ~/.cycling-coach.
+# Point `npm run dev` at a separate dir so it does not share config, sessions,
+# memory, or auth profiles with the globally-installed `cycling-coach` CLI.
+# CYCLING_COACH_HOME=~/.cycling-coach-dev

--- a/README.md
+++ b/README.md
@@ -172,6 +172,21 @@ npm run fmt         # oxfmt
 npm run build       # tsc → dist/
 ```
 
+### Separating dev from prod
+
+Set `CYCLING_COACH_HOME` to isolate `npm run dev` from the globally-installed
+`cycling-coach` CLI. Each dir has its own `config.yaml`, `auth-profiles.json`,
+`sessions/`, and `memory/`, so dev and prod never collide:
+
+```bash
+# .env (loaded only by `npm run dev`)
+CYCLING_COACH_HOME=~/.cycling-coach-dev
+```
+
+The global install keeps using `~/.cycling-coach`. For full isolation, run
+`npm run setup` once against the dev home to register a separate Telegram bot
+token and (recommended) a separate intervals.icu athlete.
+
 ## Project structure
 
 ```

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   ],
   "scripts": {
     "dev": "tsx --env-file=.env src/index.ts",
+    "setup": "tsx --env-file=.env src/index.ts setup",
     "build": "tsc",
     "prepublishOnly": "npm run build",
     "test": "vitest run",

--- a/src/config.ts
+++ b/src/config.ts
@@ -34,7 +34,18 @@ export interface Config {
 // CONFIG LOADING
 // ============================================================================
 
-export const CONFIG_DIR = join(homedir(), ".cycling-coach");
+function resolveConfigDir(): string {
+  const override = process.env.CYCLING_COACH_HOME;
+  if (override && override.length > 0) {
+    if (override === "~" || override.startsWith("~/")) {
+      return join(homedir(), override.slice(1));
+    }
+    return override;
+  }
+  return join(homedir(), ".cycling-coach");
+}
+
+export const CONFIG_DIR = resolveConfigDir();
 export const CONFIG_FILE = join(CONFIG_DIR, "config.yaml");
 
 export function readConfigYaml(): Record<string, unknown> {


### PR DESCRIPTION
## Summary

- `src/config.ts` resolves `CONFIG_DIR` from `CYCLING_COACH_HOME` (with `~/` expansion) at module load, falling back to `~/.cycling-coach`.
- Lets `npm run dev` point at a separate home (e.g. `~/.cycling-coach-dev`) so it does not share `config.yaml`, `auth-profiles.json`, `sessions/`, `memory/`, or `plans/` with the globally installed `cycling-coach` CLI.
- Adds the `npm run setup` script — already referenced by `src/auth/profiles.ts:23` error messages, but never actually defined.
- Documents the variable in `.env.example` and a new "Separating dev from prod" section in the README.

## Why

Before this change, both `npm run dev` and the globally installed `cycling-coach` CLI read/write the same `~/.cycling-coach` directory — dev runs overwrite prod memory, and both Telegram bots compete for the same updates. An env-var-overridable home is the common pattern (compare Claude Code's `CLAUDE_CONFIG_DIR`, git's `GIT_DIR`).

Note: full external-service isolation still needs a separate Telegram bot token and (recommended) a separate intervals.icu athlete in the dev config — the env var only isolates local state.

## Test plan

- [x] `npm run check` — 0 warnings, 0 errors
- [x] `npm test` — 112/112 passing
- [x] `CYCLING_COACH_HOME=~/.cycling-coach-dev` → `$HOME/.cycling-coach-dev` (tilde expanded)
- [x] `CYCLING_COACH_HOME=/tmp/cc-abs` → `/tmp/cc-abs` (absolute respected)
- [x] Unset → `$HOME/.cycling-coach` (default)
- [ ] `npm run setup` writes to dev dir when `CYCLING_COACH_HOME` is set in `.env`
