### PR TITLE
feat(secrets): SecretRef resolver + wizard auto-creation for 1Password + Keychain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ scripts/
 .claude
 CLAUDE.local.md
 .tests/
+.agents/

--- a/README.md
+++ b/README.md
@@ -183,6 +183,32 @@ llm:
 - Empty output, non-zero exit, a 30s timeout, or output over 64KB is a fatal startup error with a clear stderr message.
 - `shell: false` — `command` and `args` are passed directly to the OS. `~`, `$HOME`, globs, and shell operators are **not** expanded. Use absolute paths.
 
+### Using the setup wizard with a password manager
+
+If you have the [1Password CLI (`op`)](https://developer.1password.com/docs/cli/) or you're on macOS, `cycling-coach setup` can create the backend items for you — no YAML hand-editing, no manual `op item create` / `security add-generic-password` calls.
+
+When the wizard reaches the secrets step it asks **"Where to store secrets?"**. The available options depend on what it detects:
+
+- **Plain config.yaml** — the pre-existing behavior; secrets are written as plain strings.
+- **1Password CLI** — offered when `op` is on your `$PATH`. If `op` is installed but not signed in, the wizard offers an **"1Password CLI — sign in first"** option that runs `op signin` inline, then re-detects and continues. If no account is configured, the option is hidden and an INFO log explains why.
+- **macOS Keychain** — offered on macOS (Darwin) only.
+
+Pick one and the wizard handles every subsequent secret prompt (`llm.api_key`, `intervals.api_key`, `telegram.bot_token`) against that backend. For 1Password, the first write triggers Touch ID / system auth. The resulting `config.yaml` stores only a SecretRef pointing at the backend — your actual secret value never lands in YAML.
+
+**Re-running the wizard is idempotent.** Hit Enter at any password prompt to keep the existing value; YAML is unchanged and no new backend item is created. If a 1Password item with the same title already exists, the wizard prompts `[Update | Keep existing | Cancel]` instead of overwriting blindly.
+
+**Switching backends on a re-run** (e.g. you picked Keychain last time, now want 1Password): if you type a new value, the wizard writes to the new backend and leaves the old item alone — the old SecretRef is replaced in YAML but the old Keychain/1Password item is not deleted (clean it up manually if you want). If you hit Enter without typing a new value, the wizard shows an explicit `[Paste to migrate to <new backend> | Keep in <old backend> (YAML unchanged)]` prompt — it never silently reads a secret from one backend and writes it to another.
+
+> **Pasted keys are trimmed.** The wizard strips leading and trailing whitespace from pasted secrets and logs `Trimmed whitespace from pasted <field>.` at INFO when it does. This catches trailing newlines that clipboard managers commonly add (a frequent cause of "key works in curl, fails in the bot"). If your secret legitimately needs surrounding whitespace — rare, but real for some token formats — set it via env var instead; the env-var path bypasses trim.
+
+> **Run setup from one terminal at a time.** Concurrent `cycling-coach setup` runs may create duplicate backend items or race on the YAML write; the wizard does not lock against this in v1. If you accidentally start two, complete one and re-run the other — the re-run UX (Update / Keep / Cancel) handles duplicates cleanly.
+
+> **Keychain scope (macOS).** The Keychain backend uses your **login keychain** (per-Mac, unlocked automatically when you log in, not synced via iCloud). The full keychain path is pinned in the SecretRef so a later `security default-keychain -s …` won't silently break cycling-coach. If you want cross-device sync, pick **1Password** in the wizard instead. Custom keychains and iCloud Keychain targeting are planned for v2.
+
+> **Ctrl+C during a "1Password: creating item…" step may leave orphans.** The wizard tracks items it creates in-run and prints `op item delete "…"` cleanup commands on cancellation (Ctrl+C, SIGTERM). There is an unclosable sub-second race where `op` commits the new item server-side but the child is killed before it can report success — the wizard has no way to record it, so it can't list it for cleanup. After a forced cancel, run `op item list | grep cycling-coach` to check for stray items. This is a fundamental limitation of child-process write-then-ack semantics, not specific to cycling-coach.
+
+**Non-TTY invocations are rejected.** Running `cycling-coach setup` from a non-interactive context (CI, Docker build, `systemd` post-install, piped stdin) exits with code 2 and a stderr pointer to the [Non-interactive setup](#non-interactive-setup-ci--docker--launchd) section below. Zero side effects are performed before the TTY check.
+
 ### Backend compatibility matrix
 
 | Backend | `command` | `args` | Caveat |

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ llm:
 | Backend | `command` | `args` | Caveat |
 |---|---|---|---|
 | 1Password CLI | `op` | `["read", "op://Vault/Item/field"]` | GUI session required for Touch ID; not for headless/launchd. |
-| macOS Keychain | `security` | `["find-generic-password", "-w", "-k", "/Users/you/Library/Keychains/login.keychain-db", "-s", "cycling-coach", "-a", "anthropic_api_key"]` | `-w` is mandatory — without it the whole record is dumped. `-k <path>` pins the keychain so a later `security default-keychain -s …` doesn't break cycling-coach. |
+| macOS Keychain | `security` | `["find-generic-password", "-w", "-s", "cycling-coach", "-a", "anthropic_api_key", "/Users/you/Library/Keychains/login.keychain-db"]` | `-w` is mandatory — without it the whole record is dumped. The keychain path is passed as the **last positional argument** (pins the keychain so a later `security default-keychain -s …` doesn't break cycling-coach). macOS's `security` does not support a `-k` flag on `*-generic-password` subcommands. |
 | Bitwarden | `bw` | `["get", "password", "anthropic-api-key"]` | Requires `BW_SESSION` env from `bw unlock` before cycling-coach starts. |
 | HashiCorp Vault | `vault` | `["kv", "get", "-field=key", "secret/anthropic"]` | `-field=` is mandatory — raw `vault kv get` prints JSON. Needs `VAULT_ADDR` + `VAULT_TOKEN`. |
 | AWS Secrets Manager | `aws` | `["secretsmanager", "get-secret-value", "--secret-id", "my/secret", "--query", "SecretString", "--output", "text"]` | `--query SecretString --output text` is mandatory. Without both flags the output is JSON and the bot fails with "invalid API key". |
@@ -235,7 +235,7 @@ telegram:
   bot_token:
     source: exec
     command: /usr/bin/security
-    args: [find-generic-password, -w, -k, /Users/you/Library/Keychains/login.keychain-db, -s, cycling-coach, -a, telegram_bot_token]
+    args: [find-generic-password, -w, -s, cycling-coach, -a, telegram_bot_token, /Users/you/Library/Keychains/login.keychain-db]
 ```
 
 ### Downgrading

--- a/README.md
+++ b/README.md
@@ -161,6 +161,87 @@ llm:
 
 Env vars take precedence over YAML.
 
+## Storing secrets outside config.yaml
+
+If you don't want API keys to live as plaintext in `~/.cycling-coach/config.yaml`, any secret field (`llm.api_key`, `intervals.api_key`, `telegram.bot_token`) can be replaced with a **SecretRef** — a reference to an external command that prints the secret to stdout. Cycling Coach runs the command at startup, reads stdout, and uses the value.
+
+```yaml
+llm:
+  provider: anthropic
+  model: claude-sonnet-4-6
+  api_key:
+    source: exec
+    command: op
+    args: [read, "op://Personal/Anthropic/credential"]
+```
+
+**Precedence**: env var > SecretRef > plain YAML. Setting `ANTHROPIC_API_KEY` in your shell still wins — useful for debugging a vault issue without touching YAML.
+
+**Requirements**:
+- The `command` must print **only the secret** to stdout. JSON blobs, labels, or extra output will be stored verbatim and downstream APIs will reject them.
+- A single trailing `\n` or `\r\n` is trimmed; all other whitespace is preserved.
+- Empty output, non-zero exit, a 30s timeout, or output over 64KB is a fatal startup error with a clear stderr message.
+- `shell: false` — `command` and `args` are passed directly to the OS. `~`, `$HOME`, globs, and shell operators are **not** expanded. Use absolute paths.
+
+### Backend compatibility matrix
+
+| Backend | `command` | `args` | Caveat |
+|---|---|---|---|
+| 1Password CLI | `op` | `["read", "op://Vault/Item/field"]` | GUI session required for Touch ID; not for headless/launchd. |
+| macOS Keychain | `security` | `["find-generic-password", "-w", "-k", "/Users/you/Library/Keychains/login.keychain-db", "-s", "cycling-coach", "-a", "anthropic_api_key"]` | `-w` is mandatory — without it the whole record is dumped. `-k <path>` pins the keychain so a later `security default-keychain -s …` doesn't break cycling-coach. |
+| Bitwarden | `bw` | `["get", "password", "anthropic-api-key"]` | Requires `BW_SESSION` env from `bw unlock` before cycling-coach starts. |
+| HashiCorp Vault | `vault` | `["kv", "get", "-field=key", "secret/anthropic"]` | `-field=` is mandatory — raw `vault kv get` prints JSON. Needs `VAULT_ADDR` + `VAULT_TOKEN`. |
+| AWS Secrets Manager | `aws` | `["secretsmanager", "get-secret-value", "--secret-id", "my/secret", "--query", "SecretString", "--output", "text"]` | `--query SecretString --output text` is mandatory. Without both flags the output is JSON and the bot fails with "invalid API key". |
+| GCP Secret Manager | `gcloud` | `["secrets", "versions", "access", "latest", "--secret=anthropic"]` | Requires `gcloud auth application-default login` in the environment cycling-coach runs under. |
+| age-encrypted file | `age` | `["-d", "-i", "/Users/you/.age/key.txt", "/Users/you/secrets/anthropic.age"]` | **Absolute paths only** — `shell: false` does not expand `~` or `$HOME`. |
+
+### launchd / systemd / Docker (headless daemons)
+
+- Use **absolute paths** in `command:` — macOS `launchd` starts processes with a minimal `PATH` that excludes `/usr/local/bin` and Homebrew paths. Put `/usr/local/bin/op` (the output of `which op`) instead of bare `op`.
+- **1Password Touch ID won't work headless** — no GUI to prompt against. For daemon use, pick a backend with a pre-unlocked session (Vault, cloud secret managers, `age`-encrypted files), or supply the key via env var.
+- Stderr from the resolver command is shown on non-zero exit (last 200 chars). Stick to well-behaved CLIs — a buggy resolver that prints the secret on error will leak it to logs.
+
+### Non-interactive setup (CI / Docker / launchd)
+
+If you can't run `cycling-coach setup` in an interactive terminal, hand-edit `~/.cycling-coach/config.yaml` directly. A minimal YAML with env-supplied secrets:
+
+```yaml
+llm:
+  provider: anthropic
+  model: claude-sonnet-4-6
+# api_key, intervals, telegram sourced from env vars:
+# ANTHROPIC_API_KEY, INTERVALS_API_KEY, INTERVALS_ATHLETE_ID, TELEGRAM_BOT_TOKEN
+```
+
+Or fully SecretRef-driven:
+
+```yaml
+llm:
+  provider: anthropic
+  model: claude-sonnet-4-6
+  api_key:
+    source: exec
+    command: /usr/local/bin/op
+    args: [read, "op://Personal/Anthropic/credential"]
+
+intervals:
+  api_key:
+    source: exec
+    command: /usr/local/bin/vault
+    args: [kv, get, -field=key, secret/intervals]
+  athlete_id: "i12345"
+
+telegram:
+  bot_token:
+    source: exec
+    command: /usr/bin/security
+    args: [find-generic-password, -w, -k, /Users/you/Library/Keychains/login.keychain-db, -s, cycling-coach, -a, telegram_bot_token]
+```
+
+### Downgrading
+
+SecretRef support was added in a recent release. Downgrading cycling-coach while `config.yaml` contains SecretRef blocks will fail at startup — older versions treat non-string secret values as malformed. Keep plain strings or env vars if you need to roll back.
+
 ## Development
 
 ```bash

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,8 @@ import { readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
 import { parse as parseYaml } from "yaml";
+import { SecretRef, isSecretRef, SecretResolutionError } from "./secrets/types.js";
+import { resolveSecretRef } from "./secrets/resolve.js";
 
 // ============================================================================
 // TYPES
@@ -104,23 +106,88 @@ function envFloat(key: string): number | undefined {
   return Number.isFinite(n) ? n : undefined;
 }
 
+// ============================================================================
+// SECRET REF HANDLING
+// ============================================================================
+
+type SecretFieldPath = "llm.api_key" | "intervals.api_key" | "telegram.bot_token";
+
+const PENDING_REFS = new WeakMap<Config, Map<SecretFieldPath, SecretRef>>();
+
+function readSecretField(value: unknown, path: SecretFieldPath): string | SecretRef | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value === "string") return value;
+  if (isSecretRef(value)) return value;
+  throw new SecretResolutionError(
+    "INVALID_REF",
+    `Config field ${path} is not a valid SecretRef. Expected a string, or { source: "exec", command: string, args?: string[] }.`,
+  );
+}
+
+function assignFieldByPath(cfg: Config, path: SecretFieldPath, value: string): void {
+  if (path === "llm.api_key") cfg.llm.apiKey = value;
+  else if (path === "intervals.api_key") cfg.intervals.apiKey = value;
+  else if (path === "telegram.bot_token") cfg.telegram.botToken = value;
+}
+
 export function loadConfig(): Config {
   const yaml = readConfigYaml();
-  const llmYaml = (yaml.llm as Record<string, string>) ?? {};
-  const intervalsYaml = (yaml.intervals as Record<string, string>) ?? {};
-  const telegramYaml = (yaml.telegram as Record<string, string>) ?? {};
+  const llmYaml = (yaml.llm as Record<string, unknown>) ?? {};
+  const intervalsYaml = (yaml.intervals as Record<string, unknown>) ?? {};
+  const telegramYaml = (yaml.telegram as Record<string, unknown>) ?? {};
   const sessionYaml = (yaml.session as Record<string, unknown>) ?? {};
 
   const provider = (env("LLM_PROVIDER") ??
-    llmYaml.provider ??
+    (llmYaml.provider as string | undefined) ??
     "anthropic") as Config["llm"]["provider"];
 
-  const apiKeyMap: Record<string, string> = {
-    anthropic: env("ANTHROPIC_API_KEY") ?? llmYaml.api_key ?? "",
-    openai: env("OPENAI_API_KEY") ?? llmYaml.api_key ?? "",
-    google: env("GOOGLE_GENERATIVE_AI_API_KEY") ?? llmYaml.api_key ?? "",
-    "openai-codex": "",
+  const llmApiKeyRaw = readSecretField(llmYaml.api_key, "llm.api_key");
+  const intervalsApiKeyRaw = readSecretField(intervalsYaml.api_key, "intervals.api_key");
+  const telegramTokenRaw = readSecretField(telegramYaml.bot_token, "telegram.bot_token");
+
+  const envKeyForProvider: Record<string, string | undefined> = {
+    anthropic: "ANTHROPIC_API_KEY",
+    openai: "OPENAI_API_KEY",
+    google: "GOOGLE_GENERATIVE_AI_API_KEY",
+    "openai-codex": undefined,
   };
+
+  const pending = new Map<SecretFieldPath, SecretRef>();
+
+  const resolveWithPrecedence = (
+    envVar: string | undefined,
+    raw: string | SecretRef | undefined,
+    path: SecretFieldPath,
+  ): string => {
+    const envValue = envVar !== undefined ? env(envVar) : undefined;
+    if (envValue !== undefined) {
+      if (raw !== undefined && typeof raw !== "string") {
+        console.log(`Using env ${envVar}; SecretRef for ${path} skipped.`);
+      }
+      return envValue;
+    }
+    if (typeof raw === "string") return raw;
+    if (raw !== undefined) {
+      pending.set(path, raw);
+      return "";
+    }
+    return "";
+  };
+
+  const apiKey =
+    provider === "openai-codex"
+      ? ""
+      : resolveWithPrecedence(envKeyForProvider[provider], llmApiKeyRaw, "llm.api_key");
+  const intervalsApiKey = resolveWithPrecedence(
+    "INTERVALS_API_KEY",
+    intervalsApiKeyRaw,
+    "intervals.api_key",
+  );
+  const telegramBotToken = resolveWithPrecedence(
+    "TELEGRAM_BOT_TOKEN",
+    telegramTokenRaw,
+    "telegram.bot_token",
+  );
 
   const defaultModelMap: Record<string, string> = {
     anthropic: "claude-sonnet-4-6",
@@ -129,28 +196,67 @@ export function loadConfig(): Config {
     "openai-codex": "gpt-5.4",
   };
 
-  const model = env("LLM_MODEL") ?? llmYaml.model ?? defaultModelMap[provider];
+  const model =
+    env("LLM_MODEL") ?? (llmYaml.model as string | undefined) ?? defaultModelMap[provider];
 
-  return {
+  const config: Config = {
     llm: {
       provider,
       model,
-      apiKey: apiKeyMap[provider],
-      authProfile: provider === "openai-codex" ? (llmYaml.auth_profile ?? "openai-codex") : undefined,
+      apiKey,
+      authProfile:
+        provider === "openai-codex"
+          ? ((llmYaml.auth_profile as string | undefined) ?? "openai-codex")
+          : undefined,
     },
     intervals: {
-      apiKey: env("INTERVALS_API_KEY") ?? intervalsYaml.api_key ?? "",
-      athleteId: env("INTERVALS_ATHLETE_ID") ?? intervalsYaml.athlete_id ?? "0",
+      apiKey: intervalsApiKey,
+      athleteId:
+        env("INTERVALS_ATHLETE_ID") ??
+        (intervalsYaml.athlete_id as string | undefined) ??
+        "0",
     },
     telegram: {
-      botToken: env("TELEGRAM_BOT_TOKEN") ?? telegramYaml.bot_token ?? "",
+      botToken: telegramBotToken,
     },
     session: {
-      historyTokenBudgetRatio: envFloat("HISTORY_TOKEN_BUDGET_RATIO") ?? (sessionYaml.historyTokenBudgetRatio as number) ?? 0.3,
-      idleMinutes: envInt("SESSION_IDLE_MINUTES") ?? (sessionYaml.idleMinutes as number) ?? 0,
-      dailyResetHour: envInt("SESSION_DAILY_RESET_HOUR") ?? (sessionYaml.dailyResetHour as number) ?? 4,
+      historyTokenBudgetRatio:
+        envFloat("HISTORY_TOKEN_BUDGET_RATIO") ??
+        (sessionYaml.historyTokenBudgetRatio as number) ??
+        0.3,
+      idleMinutes:
+        envInt("SESSION_IDLE_MINUTES") ?? (sessionYaml.idleMinutes as number) ?? 0,
+      dailyResetHour:
+        envInt("SESSION_DAILY_RESET_HOUR") ?? (sessionYaml.dailyResetHour as number) ?? 4,
     },
     contextWindowTokens: resolveContextWindowTokens(model),
     dataDir: (yaml.data_dir as string) ?? CONFIG_DIR,
   };
+
+  if (pending.size > 0) {
+    PENDING_REFS.set(config, pending);
+  }
+
+  return config;
+}
+
+export async function resolveConfigSecrets(cfg: Config): Promise<Config> {
+  const pending = PENDING_REFS.get(cfg);
+  if (!pending || pending.size === 0) return cfg;
+
+  const next: Config = {
+    ...cfg,
+    llm: { ...cfg.llm },
+    intervals: { ...cfg.intervals },
+    telegram: { ...cfg.telegram },
+    session: { ...cfg.session },
+  };
+
+  for (const [path, ref] of pending) {
+    const value = await resolveSecretRef(ref);
+    assignFieldByPath(next, path, value);
+    console.log(`Resolved secret: ${path} (exec: ${ref.command})`);
+  }
+
+  return next;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -160,7 +160,7 @@ export function loadConfig(): Config {
     path: SecretFieldPath,
   ): string => {
     const envValue = envVar !== undefined ? env(envVar) : undefined;
-    if (envValue !== undefined) {
+    if (envValue !== undefined && envValue !== "") {
       if (raw !== undefined && typeof raw !== "string") {
         console.log(`Using env ${envVar}; SecretRef for ${path} skipped.`);
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { parseArgs } from "node:util";
-import { loadConfig } from "./config.js";
+import { loadConfig, resolveConfigSecrets } from "./config.js";
+import { SecretResolutionError } from "./secrets/types.js";
 import { CyclingCoachAgent } from "./agent/core.js";
 import { createTelegramBot, notifyUpdate } from "./channels/telegram.js";
 
@@ -58,7 +59,16 @@ async function main() {
     process.exit(1);
   }
 
-  const config = loadConfig();
+  let config;
+  try {
+    config = await resolveConfigSecrets(loadConfig());
+  } catch (err) {
+    if (err instanceof SecretResolutionError) {
+      console.error(`Config error: ${err.message}`);
+      process.exit(1);
+    }
+    throw err;
+  }
 
   // Validate required config
   if (config.llm.provider !== "openai-codex" && !config.llm.apiKey) {

--- a/src/secrets/backends/_spawn.ts
+++ b/src/secrets/backends/_spawn.ts
@@ -1,0 +1,84 @@
+import { spawn } from "node:child_process";
+
+export type SpawnResult = {
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+  timedOut: boolean;
+};
+
+export type SpawnOptions = {
+  timeoutMs: number;
+};
+
+export function spawnCapture(
+  cmd: string,
+  args: string[],
+  opts: SpawnOptions,
+): Promise<SpawnResult> {
+  return runSpawn(cmd, args, opts, null);
+}
+
+export function spawnStdin(
+  cmd: string,
+  args: string[],
+  stdinData: string,
+  opts: SpawnOptions,
+): Promise<SpawnResult> {
+  return runSpawn(cmd, args, opts, stdinData);
+}
+
+function runSpawn(
+  cmd: string,
+  args: string[],
+  opts: SpawnOptions,
+  stdinData: string | null,
+): Promise<SpawnResult> {
+  return new Promise<SpawnResult>((resolve) => {
+    const child = spawn(cmd, args, {
+      shell: false,
+      stdio: [stdinData === null ? "ignore" : "pipe", "pipe", "pipe"],
+      windowsHide: true,
+      env: process.env,
+    });
+
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+    let settled = false;
+
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGKILL");
+    }, opts.timeoutMs);
+
+    child.stdout?.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString("utf8");
+    });
+    child.stderr?.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString("utf8");
+    });
+
+    child.on("error", () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve({ exitCode: -1, stdout, stderr, timedOut });
+    });
+
+    child.on("close", (code) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve({ exitCode: code, stdout, stderr, timedOut });
+    });
+
+    if (stdinData !== null && child.stdin) {
+      child.stdin.on("error", () => {
+        // Swallow EPIPE when child exits before reading stdin; the close
+        // handler above will resolve with whatever was captured.
+      });
+      child.stdin.end(stdinData, "utf8");
+    }
+  });
+}

--- a/src/secrets/backends/detect.ts
+++ b/src/secrets/backends/detect.ts
@@ -1,0 +1,108 @@
+import { access, constants } from "node:fs/promises";
+import { delimiter, join } from "node:path";
+import { spawnCapture } from "./_spawn.js";
+
+export type OpState =
+  | { state: "ready"; absolutePath: string; signedInAs: string }
+  | { state: "needs-signin"; absolutePath: string }
+  | {
+      state: "unavailable";
+      reason: "not-on-path" | "no-account" | "other";
+      detail?: string;
+    };
+
+export type KeychainState = { available: boolean };
+
+export type BackendAvailability = {
+  op: OpState;
+  keychain: KeychainState;
+};
+
+const DEFAULT_TIMEOUT_MS = 2000;
+
+export async function detectBackends(): Promise<BackendAvailability> {
+  return await _detectBackendsWithOverrides({});
+}
+
+export async function _detectBackendsWithOverrides(overrides: {
+  opPath?: string | null;
+  pathEnv?: string;
+  platform?: NodeJS.Platform;
+  timeoutMs?: number;
+}): Promise<BackendAvailability> {
+  const platform = overrides.platform ?? process.platform;
+  const timeoutMs = overrides.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  const opPath =
+    overrides.opPath !== undefined
+      ? overrides.opPath
+      : await findInPath("op", overrides.pathEnv ?? process.env.PATH ?? "");
+
+  const op: OpState =
+    opPath === null
+      ? { state: "unavailable", reason: "not-on-path" }
+      : await detectOpState(opPath, timeoutMs);
+
+  const keychain: KeychainState = { available: platform === "darwin" };
+
+  return { op, keychain };
+}
+
+async function detectOpState(opPath: string, timeoutMs: number): Promise<OpState> {
+  const accountsRaw = await spawnCapture(
+    opPath,
+    ["account", "list", "--format=json"],
+    { timeoutMs },
+  );
+  if (accountsRaw.timedOut) {
+    return { state: "unavailable", reason: "other", detail: "timeout" };
+  }
+  if (accountsRaw.exitCode !== 0) {
+    const detail = accountsRaw.stderr.slice(-200).trim();
+    return { state: "unavailable", reason: "other", detail: detail || "account list failed" };
+  }
+
+  let accounts: unknown;
+  try {
+    accounts = JSON.parse(accountsRaw.stdout);
+  } catch {
+    return { state: "unavailable", reason: "other", detail: "account list returned non-JSON" };
+  }
+  if (!Array.isArray(accounts) || accounts.length === 0) {
+    return { state: "unavailable", reason: "no-account" };
+  }
+  const first = accounts[0] as { email?: unknown };
+  const email = typeof first.email === "string" ? first.email : "";
+
+  const vaultsRaw = await spawnCapture(
+    opPath,
+    ["vault", "list", "--format=json"],
+    { timeoutMs },
+  );
+  if (vaultsRaw.timedOut) {
+    return { state: "unavailable", reason: "other", detail: "timeout" };
+  }
+  if (vaultsRaw.exitCode === 0) {
+    return { state: "ready", absolutePath: opPath, signedInAs: email };
+  }
+  if (/not signed in/i.test(vaultsRaw.stderr)) {
+    return { state: "needs-signin", absolutePath: opPath };
+  }
+  const detail = vaultsRaw.stderr.slice(-200).trim();
+  return { state: "unavailable", reason: "other", detail: detail || "vault list failed" };
+}
+
+export async function findInPath(bin: string, pathEnv: string): Promise<string | null> {
+  if (!pathEnv) return null;
+  for (const dir of pathEnv.split(delimiter)) {
+    if (!dir) continue;
+    const candidate = join(dir, bin);
+    try {
+      await access(candidate, constants.X_OK);
+      return candidate;
+    } catch {
+      // not found or not executable — try next directory
+    }
+  }
+  return null;
+}

--- a/src/secrets/backends/keychain.ts
+++ b/src/secrets/backends/keychain.ts
@@ -13,7 +13,8 @@ const SECURITY_I_ERROR_RE = /^\S+:\s+returned (-\d+)/m;
 export class KeychainUnsafeValueError extends Error {
   constructor() {
     super(
-      "Keychain backend cannot store values containing newlines or unmatched quotes. " +
+      "Keychain backend cannot store values containing whitespace, quotes, backslashes, or null bytes " +
+        "(the `security -i` grammar tokenizes by whitespace, so embedded spaces would silently truncate the value). " +
         "Use env var or plain YAML for this secret.",
     );
     this.name = "KeychainUnsafeValueError";
@@ -170,13 +171,14 @@ export function keychainSecretRef(
   };
 }
 
+const NULL_BYTE = String.fromCharCode(0);
+
 export function assertKeychainSafeValue(value: string): void {
-  if (
-    value.includes("\n") ||
-    value.includes("\r") ||
-    value.includes("\u0000") ||
-    value.includes('"')
-  ) {
+  // `security -i` tokenizes each line by whitespace; an embedded space/tab
+  // would truncate the value at the split. Backslash and `"` also break the
+  // grammar. Null bytes terminate C strings (kept out of the regex to stay
+  // clear of oxlint's no-control-regex rule).
+  if (/[\s"\\]/.test(value) || value.includes(NULL_BYTE)) {
     throw new KeychainUnsafeValueError();
   }
 }

--- a/src/secrets/backends/keychain.ts
+++ b/src/secrets/backends/keychain.ts
@@ -1,0 +1,182 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { SecretRef } from "../types.js";
+import { spawnCapture, spawnStdin } from "./_spawn.js";
+
+const DEFAULT_SECURITY_PATH = "/usr/bin/security";
+const DEFAULT_TIMEOUT_MS = 30_000;
+const LOGIN_KEYCHAIN_TIMEOUT_MS = 5_000;
+const SERVICE_NAME = "cycling-coach";
+
+const SECURITY_I_ERROR_RE = /^\S+:\s+returned (-\d+)/m;
+
+export class KeychainUnsafeValueError extends Error {
+  constructor() {
+    super(
+      "Keychain backend cannot store values containing newlines or unmatched quotes. " +
+        "Use env var or plain YAML for this secret.",
+    );
+    this.name = "KeychainUnsafeValueError";
+  }
+}
+
+export class KeychainUnsupportedPlatformError extends Error {
+  constructor(platform: string) {
+    super(
+      `Keychain backend is only supported on macOS; current platform is "${platform}".`,
+    );
+    this.name = "KeychainUnsupportedPlatformError";
+  }
+}
+
+export type KeychainOverrides = {
+  securityPath?: string;
+  timeoutMs?: number;
+  platform?: NodeJS.Platform;
+};
+
+export async function keychainLoginPath(
+  overrides?: KeychainOverrides,
+): Promise<string> {
+  const securityPath = overrides?.securityPath ?? DEFAULT_SECURITY_PATH;
+  const timeoutMs = overrides?.timeoutMs ?? LOGIN_KEYCHAIN_TIMEOUT_MS;
+  const fallback = join(homedir(), "Library", "Keychains", "login.keychain-db");
+
+  const res = await spawnCapture(securityPath, ["login-keychain"], {
+    timeoutMs,
+  });
+  if (res.timedOut || res.exitCode !== 0) {
+    console.warn(
+      `[keychain] security login-keychain failed (${res.timedOut ? "timeout" : `exit ${res.exitCode}`}); using fallback path ${fallback}.`,
+    );
+    return fallback;
+  }
+  const parsed = parseLoginKeychainOutput(res.stdout);
+  if (parsed === null) {
+    console.warn(
+      `[keychain] Could not parse login-keychain output; using fallback path ${fallback}.`,
+    );
+    return fallback;
+  }
+  return parsed;
+}
+
+function parseLoginKeychainOutput(raw: string): string | null {
+  let s = raw.trim();
+  if (s.startsWith('"') && s.endsWith('"') && s.length >= 2) {
+    s = s.slice(1, -1);
+  }
+  if (!s.startsWith("/")) return null;
+  if (!s.endsWith(".keychain") && !s.endsWith(".keychain-db")) return null;
+  return s;
+}
+
+export async function keychainItemExists(
+  field: string,
+  keychainPath: string,
+  overrides?: KeychainOverrides,
+): Promise<boolean> {
+  const securityPath = overrides?.securityPath ?? DEFAULT_SECURITY_PATH;
+  const timeoutMs = overrides?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const res = await spawnCapture(
+    securityPath,
+    ["find-generic-password", "-s", SERVICE_NAME, "-a", field, keychainPath],
+    { timeoutMs },
+  );
+  if (res.timedOut) {
+    throw new Error(
+      `security find-generic-password timed out after ${timeoutMs}ms.`,
+    );
+  }
+  return res.exitCode === 0;
+}
+
+export async function keychainItemUpsert(
+  field: string,
+  value: string,
+  keychainPath: string,
+  overrides?: KeychainOverrides,
+): Promise<void> {
+  const platform = overrides?.platform ?? process.platform;
+  if (platform !== "darwin") {
+    throw new KeychainUnsupportedPlatformError(platform);
+  }
+  assertKeychainSafeValue(value);
+
+  const securityPath = overrides?.securityPath ?? DEFAULT_SECURITY_PATH;
+  const timeoutMs = overrides?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  const innerCmd = `add-generic-password -U -s ${SERVICE_NAME} -a ${field} -w ${value} ${keychainPath}\n\n`;
+  const res = await spawnStdin(securityPath, ["-i"], innerCmd, { timeoutMs });
+  if (res.timedOut) {
+    throw new Error(`security -i timed out after ${timeoutMs}ms.`);
+  }
+  const combined = `${res.stdout}${res.stderr}`;
+  const match = SECURITY_I_ERROR_RE.exec(combined);
+  if (match) {
+    throw new Error(`keychain upsert failed (OSStatus ${match[1]}).`);
+  }
+  if (res.exitCode !== 0) {
+    throw new Error(
+      `security -i exited ${res.exitCode}: ${res.stderr.slice(-200).trim()}`,
+    );
+  }
+}
+
+export async function keychainItemDelete(
+  field: string,
+  keychainPath: string,
+  overrides?: KeychainOverrides,
+): Promise<{ deleted: boolean }> {
+  const securityPath = overrides?.securityPath ?? DEFAULT_SECURITY_PATH;
+  const timeoutMs = overrides?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const res = await spawnCapture(
+    securityPath,
+    ["delete-generic-password", "-s", SERVICE_NAME, "-a", field, keychainPath],
+    { timeoutMs },
+  );
+  if (res.timedOut) {
+    throw new Error(
+      `security delete-generic-password timed out after ${timeoutMs}ms.`,
+    );
+  }
+  if (res.exitCode === 0) {
+    return { deleted: true };
+  }
+  if (res.exitCode === 44 || /could not be found|not found/i.test(res.stderr)) {
+    return { deleted: false };
+  }
+  throw new Error(
+    `security delete-generic-password failed (exit ${res.exitCode}): ${res.stderr.slice(-200).trim()}`,
+  );
+}
+
+export function keychainSecretRef(
+  field: string,
+  keychainPath: string,
+): SecretRef {
+  return {
+    source: "exec",
+    command: DEFAULT_SECURITY_PATH,
+    args: [
+      "find-generic-password",
+      "-w",
+      "-s",
+      SERVICE_NAME,
+      "-a",
+      field,
+      keychainPath,
+    ],
+  };
+}
+
+export function assertKeychainSafeValue(value: string): void {
+  if (
+    value.includes("\n") ||
+    value.includes("\r") ||
+    value.includes("\u0000") ||
+    value.includes('"')
+  ) {
+    throw new KeychainUnsafeValueError();
+  }
+}

--- a/src/secrets/backends/keychain.ts
+++ b/src/secrets/backends/keychain.ts
@@ -13,8 +13,7 @@ const SECURITY_I_ERROR_RE = /^\S+:\s+returned (-\d+)/m;
 export class KeychainUnsafeValueError extends Error {
   constructor() {
     super(
-      "Keychain backend cannot store values containing whitespace, quotes, backslashes, or null bytes " +
-        "(the `security -i` grammar tokenizes by whitespace, so embedded spaces would silently truncate the value). " +
+      "Keychain backend cannot store values containing whitespace, quotes, backslashes, or null bytes. " +
         "Use env var or plain YAML for this secret.",
     );
     this.name = "KeychainUnsafeValueError";
@@ -174,10 +173,7 @@ export function keychainSecretRef(
 const NULL_BYTE = String.fromCharCode(0);
 
 export function assertKeychainSafeValue(value: string): void {
-  // `security -i` tokenizes each line by whitespace; an embedded space/tab
-  // would truncate the value at the split. Backslash and `"` also break the
-  // grammar. Null bytes terminate C strings (kept out of the regex to stay
-  // clear of oxlint's no-control-regex rule).
+  // Null byte kept out of the regex to avoid oxlint's no-control-regex rule.
   if (/[\s"\\]/.test(value) || value.includes(NULL_BYTE)) {
     throw new KeychainUnsafeValueError();
   }

--- a/src/secrets/backends/op.ts
+++ b/src/secrets/backends/op.ts
@@ -5,7 +5,7 @@ const DEFAULT_TIMEOUT_MS = 30_000;
 const MAX_VALUE_BYTES = 64 * 1024;
 
 const MULTI_VAULT_RE = /more than one vault|no default vault|--vault required|multiple vaults/i;
-const NOT_AN_ITEM_RE = /isn't an item|not found/i;
+const NOT_AN_ITEM_RE = /isn't an item|item.*not found|could not find item/i;
 
 export class OpVaultAmbiguousError extends Error {
   constructor(message: string) {

--- a/src/secrets/backends/op.ts
+++ b/src/secrets/backends/op.ts
@@ -1,0 +1,270 @@
+import type { SecretRef } from "../types.js";
+import { spawnCapture, spawnStdin } from "./_spawn.js";
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const MAX_VALUE_BYTES = 64 * 1024;
+
+const MULTI_VAULT_RE = /more than one vault|no default vault|--vault required|multiple vaults/i;
+const NOT_AN_ITEM_RE = /isn't an item|not found/i;
+
+export class OpVaultAmbiguousError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "OpVaultAmbiguousError";
+  }
+}
+
+export class SecretTooLargeError extends Error {
+  readonly byteLength: number;
+  constructor(byteLength: number) {
+    super(
+      `Secret value is ${byteLength} bytes; max allowed is ${MAX_VALUE_BYTES} bytes.`,
+    );
+    this.name = "SecretTooLargeError";
+    this.byteLength = byteLength;
+  }
+}
+
+export async function opItemGet(
+  opPath: string,
+  title: string,
+  vaultName?: string,
+): Promise<{ exists: false } | { exists: true; vaultName: string }> {
+  const args = vaultName
+    ? ["item", "get", title, "--vault", vaultName, "--format=json"]
+    : ["item", "get", title, "--format=json"];
+  const res = await spawnCapture(opPath, args, { timeoutMs: DEFAULT_TIMEOUT_MS });
+  if (res.timedOut) {
+    throw new Error(`op item get timed out after ${DEFAULT_TIMEOUT_MS}ms.`);
+  }
+  if (res.exitCode === 0) {
+    const parsed = safeParseOpItem(res.stdout);
+    if (!parsed) throw new Error("op item get returned non-JSON.");
+    return { exists: true, vaultName: parsed.vault.name };
+  }
+  if (NOT_AN_ITEM_RE.test(res.stderr)) {
+    return { exists: false };
+  }
+  throw new Error(`op item get failed: ${res.stderr.slice(-200).trim()}`);
+}
+
+export async function opItemCreate(
+  opPath: string,
+  title: string,
+  value: string,
+  vaultName?: string,
+): Promise<{ vaultName: string }> {
+  const byteLength = Buffer.byteLength(value, "utf8");
+  if (byteLength > MAX_VALUE_BYTES) {
+    throw new SecretTooLargeError(byteLength);
+  }
+
+  const template = JSON.stringify({
+    title,
+    category: "API_CREDENTIAL",
+    fields: [
+      { id: "credential", type: "CONCEALED", label: "credential", value },
+    ],
+  });
+
+  const args = vaultName
+    ? ["item", "create", "-", "--format=json", "--vault", vaultName]
+    : ["item", "create", "-", "--format=json"];
+  const res = await spawnStdin(opPath, args, template, { timeoutMs: DEFAULT_TIMEOUT_MS });
+
+  if (res.timedOut) {
+    throw new Error(`op item create timed out after ${DEFAULT_TIMEOUT_MS}ms.`);
+  }
+  if (res.exitCode !== 0) {
+    if (MULTI_VAULT_RE.test(res.stderr)) {
+      throw new OpVaultAmbiguousError(
+        `1Password could not pick a default vault. stderr: ${res.stderr.slice(-200).trim()}`,
+      );
+    }
+    throw new Error(
+      `op item create failed: ${res.stderr.slice(-200).trim()} (template: ${redactTemplateForLog(template)})`,
+    );
+  }
+
+  const parsed = safeParseOpItem(res.stdout);
+  if (!parsed) {
+    throw new Error("op item create returned non-JSON.");
+  }
+  return { vaultName: parsed.vault.name };
+}
+
+export async function opItemUpdate(
+  opPath: string,
+  title: string,
+  value: string,
+  vaultName: string,
+): Promise<void> {
+  const byteLength = Buffer.byteLength(value, "utf8");
+  if (byteLength > MAX_VALUE_BYTES) {
+    throw new SecretTooLargeError(byteLength);
+  }
+
+  const getRes = await spawnCapture(
+    opPath,
+    ["item", "get", title, "--vault", vaultName, "--format=json"],
+    { timeoutMs: DEFAULT_TIMEOUT_MS },
+  );
+  if (getRes.timedOut) {
+    throw new Error(`op item get timed out after ${DEFAULT_TIMEOUT_MS}ms.`);
+  }
+  if (getRes.exitCode !== 0) {
+    throw new Error(`op item get failed: ${getRes.stderr.slice(-200).trim()}`);
+  }
+  const item = safeParseOpItemForEdit(getRes.stdout);
+  if (!item) {
+    throw new Error("op item get returned non-JSON.");
+  }
+  const credField = item.fields.find((f) => f.id === "credential");
+  if (!credField) {
+    throw new Error(`1Password item "${title}" has no 'credential' field.`);
+  }
+  credField.value = value;
+
+  const editJson = JSON.stringify(item);
+  const editRes = await spawnStdin(
+    opPath,
+    ["item", "edit", title, "--vault", vaultName, "-"],
+    editJson,
+    { timeoutMs: DEFAULT_TIMEOUT_MS },
+  );
+  if (editRes.timedOut) {
+    throw new Error(`op item edit timed out after ${DEFAULT_TIMEOUT_MS}ms.`);
+  }
+  if (editRes.exitCode !== 0) {
+    throw new Error(
+      `op item edit failed: ${editRes.stderr.slice(-200).trim()} (payload: ${redactTemplateForLog(editJson)})`,
+    );
+  }
+}
+
+export async function opItemDelete(
+  opPath: string,
+  title: string,
+  vaultName: string,
+): Promise<{ deleted: boolean }> {
+  const res = await spawnCapture(
+    opPath,
+    ["item", "delete", title, "--vault", vaultName],
+    { timeoutMs: DEFAULT_TIMEOUT_MS },
+  );
+  if (res.timedOut) {
+    throw new Error(`op item delete timed out after ${DEFAULT_TIMEOUT_MS}ms.`);
+  }
+  if (res.exitCode === 0) {
+    return { deleted: true };
+  }
+  if (NOT_AN_ITEM_RE.test(res.stderr)) {
+    return { deleted: false };
+  }
+  throw new Error(`op item delete failed: ${res.stderr.slice(-200).trim()}`);
+}
+
+export async function opVaultList(
+  opPath: string,
+): Promise<Array<{ id: string; name: string }>> {
+  const res = await spawnCapture(opPath, ["vault", "list", "--format=json"], {
+    timeoutMs: DEFAULT_TIMEOUT_MS,
+  });
+  if (res.timedOut) {
+    throw new Error(`op vault list timed out after ${DEFAULT_TIMEOUT_MS}ms.`);
+  }
+  if (res.exitCode !== 0) {
+    throw new Error(`op vault list failed: ${res.stderr.slice(-200).trim()}`);
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(res.stdout);
+  } catch {
+    throw new Error("op vault list returned non-JSON.");
+  }
+  if (!Array.isArray(parsed)) {
+    throw new Error("op vault list did not return an array.");
+  }
+  const out: Array<{ id: string; name: string }> = [];
+  for (const entry of parsed) {
+    if (entry && typeof entry === "object") {
+      const e = entry as { id?: unknown; name?: unknown };
+      if (typeof e.id === "string" && typeof e.name === "string") {
+        out.push({ id: e.id, name: e.name });
+      }
+    }
+  }
+  return out;
+}
+
+export function opSecretRef(
+  title: string,
+  opAbsPath: string,
+  vaultName: string,
+): SecretRef {
+  return {
+    source: "exec",
+    command: opAbsPath,
+    args: ["read", `op://${vaultName}/${title}/credential`],
+  };
+}
+
+export function redactTemplateForLog(templateJson: string): string {
+  try {
+    const obj = JSON.parse(templateJson) as {
+      fields?: Array<{ value?: unknown }>;
+    };
+    if (obj && Array.isArray(obj.fields)) {
+      for (const f of obj.fields) {
+        if (f && typeof f === "object") {
+          f.value = "<redacted>";
+        }
+      }
+    }
+    return JSON.stringify(obj);
+  } catch {
+    return "<redacted>";
+  }
+}
+
+type OpItemJson = {
+  vault: { name: string };
+};
+
+type OpItemForEdit = {
+  fields: Array<{ id: string; value: string }>;
+} & Record<string, unknown>;
+
+function safeParseOpItem(json: string): OpItemJson | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object") return null;
+  const p = parsed as { vault?: unknown };
+  if (!p.vault || typeof p.vault !== "object") return null;
+  const v = p.vault as { name?: unknown };
+  if (typeof v.name !== "string") return null;
+  return { vault: { name: v.name } };
+}
+
+function safeParseOpItemForEdit(json: string): OpItemForEdit | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object") return null;
+  const p = parsed as { fields?: unknown };
+  if (!Array.isArray(p.fields)) return null;
+  for (const f of p.fields) {
+    if (!f || typeof f !== "object") return null;
+    const fo = f as { id?: unknown; value?: unknown };
+    if (typeof fo.id !== "string") return null;
+    if (fo.value !== undefined && typeof fo.value !== "string") return null;
+  }
+  return parsed as OpItemForEdit;
+}

--- a/src/secrets/resolve.ts
+++ b/src/secrets/resolve.ts
@@ -1,0 +1,138 @@
+import { spawn } from "node:child_process";
+import { SecretRef, SecretResolutionError } from "./types.js";
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_MAX_BYTES = 64 * 1024;
+
+export async function resolveSecretRef(ref: SecretRef): Promise<string> {
+  return await _resolveSecretRefWithOverrides(ref, {});
+}
+
+export async function _resolveSecretRefWithOverrides(
+  ref: SecretRef,
+  overrides: { timeoutMs?: number; maxBytes?: number },
+): Promise<string> {
+  const timeoutMs = overrides.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const maxBytes = overrides.maxBytes ?? DEFAULT_MAX_BYTES;
+  const cmd = ref.command;
+  const args = ref.args ?? [];
+
+  return await new Promise<string>((resolve, reject) => {
+    const child = spawn(cmd, args, {
+      shell: false,
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
+      env: process.env,
+    });
+
+    let settled = false;
+    let stdout = "";
+    let stderr = "";
+    let stdoutBytes = 0;
+    let stderrBytes = 0;
+    let timedOut = false;
+    let overflowed = false;
+
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGKILL");
+    }, timeoutMs);
+
+    const append = (chunk: Buffer, target: "stdout" | "stderr"): void => {
+      const text = chunk.toString("utf8");
+      const len = Buffer.byteLength(text, "utf8");
+      if (target === "stdout") {
+        stdoutBytes += len;
+        if (stdoutBytes > maxBytes) {
+          if (!overflowed) {
+            overflowed = true;
+            child.kill("SIGKILL");
+          }
+          return;
+        }
+        stdout += text;
+      } else {
+        stderrBytes += len;
+        if (stderrBytes > maxBytes) {
+          if (!overflowed) {
+            overflowed = true;
+            child.kill("SIGKILL");
+          }
+          return;
+        }
+        stderr += text;
+      }
+    };
+
+    child.on("error", (err: NodeJS.ErrnoException) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (err.code === "ENOENT") {
+        reject(
+          new SecretResolutionError(
+            "ENOENT",
+            `Secret resolver command '${cmd}' not found. Is it installed and on $PATH? (Mac launchd users: use absolute path like '/usr/local/bin/op'.)`,
+          ),
+        );
+      } else {
+        reject(
+          new SecretResolutionError(
+            "EXIT_NONZERO",
+            `Secret resolver command '${cmd}' failed to spawn: ${err.message}`,
+          ),
+        );
+      }
+    });
+
+    child.stdout?.on("data", (chunk: Buffer) => append(chunk, "stdout"));
+    child.stderr?.on("data", (chunk: Buffer) => append(chunk, "stderr"));
+
+    child.on("close", (code) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+
+      if (overflowed) {
+        reject(
+          new SecretResolutionError(
+            "OVERFLOW",
+            `Secret resolver '${cmd}' output exceeded ${maxBytes} bytes.`,
+          ),
+        );
+        return;
+      }
+      if (timedOut) {
+        reject(
+          new SecretResolutionError(
+            "TIMEOUT",
+            `Secret resolver '${cmd}' timed out after ${timeoutMs}ms.`,
+          ),
+        );
+        return;
+      }
+      if (code !== 0) {
+        const tail = stderr.slice(-200).trim();
+        reject(
+          new SecretResolutionError(
+            "EXIT_NONZERO",
+            `Secret resolver '${cmd}' exited with code ${code}${tail ? `: ${tail}` : "."}`,
+          ),
+        );
+        return;
+      }
+
+      const trimmed = stdout.replace(/\r?\n$/, "");
+      if (trimmed.length === 0) {
+        reject(
+          new SecretResolutionError(
+            "EMPTY",
+            `Secret resolver '${cmd}' produced empty output.`,
+          ),
+        );
+        return;
+      }
+      resolve(trimmed);
+    });
+  });
+}

--- a/src/secrets/types.ts
+++ b/src/secrets/types.ts
@@ -1,0 +1,43 @@
+export type SecretRef = {
+  source: "exec";
+  command: string;
+  args?: string[];
+};
+
+export type SecretResolutionErrorCode =
+  | "ENOENT"
+  | "EXIT_NONZERO"
+  | "TIMEOUT"
+  | "EMPTY"
+  | "OVERFLOW"
+  | "INVALID_REF";
+
+export class SecretResolutionError extends Error {
+  readonly code: SecretResolutionErrorCode;
+  constructor(code: SecretResolutionErrorCode, message: string) {
+    super(message);
+    this.name = "SecretResolutionError";
+    this.code = code;
+  }
+}
+
+const ALLOWED_KEYS = new Set(["source", "command", "args"]);
+
+export function isSecretRef(value: unknown): value is SecretRef {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const obj = value as Record<string, unknown>;
+  for (const key of Object.keys(obj)) {
+    if (!ALLOWED_KEYS.has(key)) return false;
+  }
+  if (obj.source !== "exec") return false;
+  if (typeof obj.command !== "string" || obj.command.length === 0) return false;
+  if (obj.args !== undefined) {
+    if (!Array.isArray(obj.args)) return false;
+    for (const a of obj.args) {
+      if (typeof a !== "string") return false;
+    }
+  }
+  return true;
+}

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -408,7 +408,6 @@ async function _runWizardCore(ctx: WizardCtx): Promise<void> {
       // is in YAML). Preserve it — don't silently wipe the section.
       merged.intervals = { athlete_id: prevIntervalsId };
     } else {
-      // User skipped and no prev → no intervals section.
       delete merged.intervals;
     }
   }

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -356,10 +356,6 @@ async function _runWizardCore(ctx: WizardCtx): Promise<void> {
       chosenVaultRef: { current: chosenVault },
       opAbsPathRef: { current: opAbsPath },
       keychainPathRef: { current: keychainPath },
-      onUnavailableReprompt: async () => {
-        backend = await _pickBackend(ctx);
-        return backend;
-      },
     });
     chosenVault = result.chosenVault;
     opAbsPath = result.opAbsPath;
@@ -384,10 +380,6 @@ async function _runWizardCore(ctx: WizardCtx): Promise<void> {
       chosenVaultRef: { current: chosenVault },
       opAbsPathRef: { current: opAbsPath },
       keychainPathRef: { current: keychainPath },
-      onUnavailableReprompt: async () => {
-        backend = await _pickBackend(ctx);
-        return backend;
-      },
     });
     chosenVault = result.chosenVault;
     opAbsPath = result.opAbsPath;
@@ -410,6 +402,11 @@ async function _runWizardCore(ctx: WizardCtx): Promise<void> {
         api_key: result.yamlValue,
         athlete_id: intervalsAthleteId || "0",
       };
+    } else if (prevIntervalsId) {
+      // User skipped the api_key prompt but a prior athlete_id exists (common
+      // when api_key comes from INTERVALS_API_KEY env var and only athlete_id
+      // is in YAML). Preserve it — don't silently wipe the section.
+      merged.intervals = { athlete_id: prevIntervalsId };
     } else {
       // User skipped and no prev → no intervals section.
       delete merged.intervals;
@@ -427,10 +424,6 @@ async function _runWizardCore(ctx: WizardCtx): Promise<void> {
       chosenVaultRef: { current: chosenVault },
       opAbsPathRef: { current: opAbsPath },
       keychainPathRef: { current: keychainPath },
-      onUnavailableReprompt: async () => {
-        backend = await _pickBackend(ctx);
-        return backend;
-      },
     });
     chosenVault = result.chosenVault;
     opAbsPath = result.opAbsPath;
@@ -565,7 +558,6 @@ type CollectArgs = {
   chosenVaultRef: { current: string | undefined };
   opAbsPathRef: { current: string | undefined };
   keychainPathRef: { current: string | undefined };
-  onUnavailableReprompt: () => Promise<BackendChoice>;
 };
 
 type CollectResult = {
@@ -739,6 +731,9 @@ async function _writeToBackend(
       });
       handleCancel(action, ctx);
       if (action === "cancel") {
+        // Mirror the SIGINT/clack-cancel paths: print manual cleanup for any
+        // items already created earlier in this run.
+        _printOrphanCleanup(ctx);
         process.exit(0);
       }
       if (action === "keep") {
@@ -825,13 +820,12 @@ async function preCheckOpExistence(
   title: string,
   knownVault: string | undefined,
 ): Promise<string | null> {
-  try {
-    const res = await opItemGet(opAbsPath, title, knownVault);
-    if (res.exists) return res.vaultName;
-    return null;
-  } catch {
-    return null;
-  }
+  // Let opItemGet throws propagate. The NOT_AN_ITEM_RE branch inside opItemGet
+  // is the only genuine not-exists signal; everything else (timeout, auth
+  // failure, non-JSON stdout) is a real error that would otherwise silently
+  // become "item doesn't exist" and cause a duplicate item to be created.
+  const res = await opItemGet(opAbsPath, title, knownVault);
+  return res.exists ? res.vaultName : null;
 }
 
 async function createOpItem(

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -1,9 +1,34 @@
 import { intro, outro, select, text, password, confirm, isCancel, cancel, log } from "@clack/prompts";
+import { spawn } from "node:child_process";
 import { existsSync, mkdirSync, writeFileSync, readFileSync, unlinkSync } from "node:fs";
 import { stringify as toYaml } from "yaml";
 import { CONFIG_DIR, CONFIG_FILE, readConfigYaml } from "./config.js";
 import { runCodexLogin } from "./auth/openai-codex-login.js";
 import { loadProfile, saveProfile, type OAuthCredential } from "./auth/profiles.js";
+import { isSecretRef, type SecretRef } from "./secrets/types.js";
+import { detectBackends, type BackendAvailability, type OpState } from "./secrets/backends/detect.js";
+import {
+  OpVaultAmbiguousError,
+  SecretTooLargeError,
+  opItemCreate,
+  opItemDelete,
+  opItemGet,
+  opItemUpdate,
+  opSecretRef,
+  opVaultList,
+} from "./secrets/backends/op.js";
+import {
+  KeychainUnsafeValueError,
+  keychainItemDelete,
+  keychainItemExists,
+  keychainItemUpsert,
+  keychainLoginPath,
+  keychainSecretRef,
+} from "./secrets/backends/keychain.js";
+
+// ============================================================================
+// TYPES
+// ============================================================================
 
 const PROVIDERS = [
   { value: "anthropic", label: "Anthropic (Claude)" },
@@ -42,6 +67,28 @@ const MODELS: Record<string, { value: string; label: string; hint?: string }[]> 
 };
 
 const CUSTOM_MODEL_SENTINEL = "__custom__";
+const BACKEND_PLAIN = "plain";
+const BACKEND_OP = "op";
+const BACKEND_KEYCHAIN = "keychain";
+const BACKEND_OP_SIGNIN = "op-signin";
+
+export type BackendChoice = "plain" | "op" | "keychain";
+
+type SecretFieldPath = "llm.api_key" | "intervals.api_key" | "telegram.bot_token";
+
+export type CreatedEntry = {
+  backend: "op" | "keychain";
+  field: SecretFieldPath;
+  title: string;
+  vaultName?: string;
+  keychainPath?: string;
+  opAbsPath?: string;
+  preExistedBeforeWizard: boolean;
+};
+
+export type WizardCtx = {
+  createdThisRun: CreatedEntry[];
+};
 
 const DEFAULT_MODELS: Record<string, string> = {
   anthropic: "claude-sonnet-4-6",
@@ -50,8 +97,98 @@ const DEFAULT_MODELS: Record<string, string> = {
   "openai-codex": "gpt-5.4",
 };
 
-function handleCancel(value: unknown): void {
+const FIELD_TITLES: Record<SecretFieldPath, string> = {
+  "llm.api_key": "cycling-coach · llm_api_key",
+  "intervals.api_key": "cycling-coach · intervals_api_key",
+  "telegram.bot_token": "cycling-coach · telegram_bot_token",
+};
+
+const FIELD_KEYCHAIN_ACCOUNT: Record<SecretFieldPath, string> = {
+  "llm.api_key": "llm_api_key",
+  "intervals.api_key": "intervals_api_key",
+  "telegram.bot_token": "telegram_bot_token",
+};
+
+// ============================================================================
+// PURE HELPERS (exported with leading underscore for direct testability)
+// ============================================================================
+
+export function _detectPrevBackend(value: unknown): BackendChoice | "unknown" {
+  if (typeof value === "string") return "plain";
+  if (isSecretRef(value)) {
+    const cmd = value.command;
+    if (cmd === "op" || cmd.endsWith("/op")) return "op";
+    if (cmd === "/usr/bin/security" || cmd.endsWith("/security")) return "keychain";
+    return "unknown";
+  }
+  return "plain";
+}
+
+export function _processSecretInput(raw: string, field: string): string {
+  const cleaned = raw.trim();
+  if (cleaned !== raw) {
+    log.info(`Trimmed whitespace from pasted ${field}.`);
+  }
+  const bytes = Buffer.byteLength(cleaned, "utf-8");
+  if (bytes > 65_536) {
+    throw new SecretTooLargeError(bytes);
+  }
+  return cleaned;
+}
+
+export function _formatOrphanCleanup(ctx: WizardCtx): string {
+  const orphans = ctx.createdThisRun.filter((e) => !e.preExistedBeforeWizard);
+  if (orphans.length === 0) return "";
+  const lines: string[] = [
+    "",
+    "[wizard] Orphaned backend items created this run — delete manually if desired:",
+  ];
+  for (const o of orphans) {
+    if (o.backend === "op") {
+      lines.push(`  op item delete "${o.title}" --vault "${o.vaultName ?? ""}"`);
+    } else if (o.backend === "keychain") {
+      lines.push(
+        `  security delete-generic-password -s cycling-coach -a "${o.title}" "${o.keychainPath ?? ""}"`,
+      );
+    }
+  }
+  return lines.join("\n") + "\n";
+}
+
+export function _printOrphanCleanup(ctx: WizardCtx): void {
+  const msg = _formatOrphanCleanup(ctx);
+  if (msg.length > 0) {
+    process.stderr.write(msg);
+  }
+}
+
+export function _createSignalHandler(
+  ctx: WizardCtx,
+  signal: "SIGINT" | "SIGTERM",
+): () => void {
+  return () => {
+    _printOrphanCleanup(ctx);
+    const code = signal === "SIGINT" ? 130 : 143;
+    process.exit(code);
+  };
+}
+
+export function _assertTTY(): void {
+  if (!process.stdin.isTTY || !process.stdout.isTTY) {
+    process.stderr.write(
+      "cycling-coach setup requires an interactive TTY. See README 'Non-interactive setup' for hand-editing YAML directly.\n",
+    );
+    process.exit(2);
+  }
+}
+
+// ============================================================================
+// INTERNAL HELPERS
+// ============================================================================
+
+function handleCancel(value: unknown, ctx: WizardCtx): void {
   if (isCancel(value)) {
+    _printOrphanCleanup(ctx);
     cancel("Setup cancelled.");
     process.exit(0);
   }
@@ -69,16 +206,64 @@ function getString(obj: Record<string, unknown>, ...keys: string[]): string | un
   return typeof cur === "string" ? cur : undefined;
 }
 
+function readFieldValue(
+  obj: Record<string, unknown>,
+  ...keys: string[]
+): unknown {
+  let cur: unknown = obj;
+  for (const k of keys) {
+    if (cur && typeof cur === "object" && k in (cur as Record<string, unknown>)) {
+      cur = (cur as Record<string, unknown>)[k];
+    } else {
+      return undefined;
+    }
+  }
+  return cur;
+}
+
+async function runOpSignin(opPath: string): Promise<boolean> {
+  return await new Promise<boolean>((resolve) => {
+    const child = spawn(opPath, ["signin"], { stdio: "inherit", shell: false });
+    child.on("error", () => resolve(false));
+    child.on("close", (code) => resolve(code === 0));
+  });
+}
+
+// ============================================================================
+// WIZARD FLOW
+// ============================================================================
+
 export async function runSetup(): Promise<void> {
+  _assertTTY();
+
+  const ctx: WizardCtx = { createdThisRun: [] };
+  const sigintHandler = _createSignalHandler(ctx, "SIGINT");
+  const sigtermHandler = _createSignalHandler(ctx, "SIGTERM");
+  process.once("SIGINT", sigintHandler);
+  process.once("SIGTERM", sigtermHandler);
+
+  try {
+    await _runWizardCore(ctx);
+  } catch (err) {
+    await _guardedCleanup(ctx);
+    cancel(`Setup failed: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  } finally {
+    process.removeListener("SIGINT", sigintHandler);
+    process.removeListener("SIGTERM", sigtermHandler);
+  }
+}
+
+async function _runWizardCore(ctx: WizardCtx): Promise<void> {
   intro("Cycling Coach — Setup");
 
   const previous = readConfigYaml();
   const prevProvider = getString(previous, "llm", "provider");
   const prevModel = getString(previous, "llm", "model");
-  const prevApiKey = getString(previous, "llm", "api_key");
-  const prevIntervalsKey = getString(previous, "intervals", "api_key");
+  const prevLlmKey = readFieldValue(previous, "llm", "api_key");
+  const prevIntervalsKey = readFieldValue(previous, "intervals", "api_key");
   const prevIntervalsId = getString(previous, "intervals", "athlete_id");
-  const prevTelegramToken = getString(previous, "telegram", "bot_token");
+  const prevTelegramToken = readFieldValue(previous, "telegram", "bot_token");
 
   // Provider
   const providerResp = await select({
@@ -86,26 +271,8 @@ export async function runSetup(): Promise<void> {
     options: PROVIDERS,
     initialValue: prevProvider ?? "anthropic",
   });
-  handleCancel(providerResp);
+  handleCancel(providerResp, ctx);
   const provider = providerResp as string;
-
-  // API key (skipped for Codex OAuth). Empty input keeps the existing value.
-  let apiKey = "";
-  if (provider !== "openai-codex") {
-    const hasPrev = provider === prevProvider && !!prevApiKey;
-    const entered = await password({
-      message: hasPrev
-        ? `${API_KEY_LABELS[provider]} (Enter to keep existing)`
-        : API_KEY_LABELS[provider],
-      validate: (v) => {
-        if (hasPrev) return undefined;
-        return !v ? "API key is required" : undefined;
-      },
-    });
-    handleCancel(entered);
-    const entryStr = typeof entered === "string" ? entered : "";
-    apiKey = entryStr || (hasPrev ? (prevApiKey as string) : "");
-  }
 
   // Model
   const sameProvider = provider === prevProvider;
@@ -121,7 +288,7 @@ export async function runSetup(): Promise<void> {
     ],
     initialValue: initialModel,
   });
-  handleCancel(modelResp);
+  handleCancel(modelResp, ctx);
   let model = modelResp as string;
 
   if (model === CUSTOM_MODEL_SENTINEL) {
@@ -131,7 +298,7 @@ export async function runSetup(): Promise<void> {
       placeholder: sameProvider ? prevModel : undefined,
       validate: (v) => (!v && !(sameProvider && prevModel) ? "Model name is required" : undefined),
     });
-    handleCancel(custom);
+    handleCancel(custom, ctx);
     model = (typeof custom === "string" && custom) || prevModel || "";
   }
 
@@ -145,7 +312,7 @@ export async function runSetup(): Promise<void> {
         message: "Existing Codex OAuth profile found. Re-login?",
         initialValue: false,
       });
-      handleCancel(reuse);
+      handleCancel(reuse, ctx);
       doLogin = Boolean(reuse);
     }
     if (doLogin) {
@@ -160,70 +327,120 @@ export async function runSetup(): Promise<void> {
     }
   }
 
-  // intervals.icu — Enter keeps prior; type new value to replace
-  let intervalsKey = prevIntervalsKey ?? "";
-  let intervalsAthleteId = prevIntervalsId ?? "";
-  {
-    const hasPrev = !!prevIntervalsKey;
-    const entered = await password({
-      message: hasPrev
-        ? "intervals.icu API key (Enter to keep existing)"
-        : "intervals.icu API key (Enter to skip)",
-      validate: () => undefined,
-    });
-    handleCancel(entered);
-    const entryStr = typeof entered === "string" ? entered : "";
-    if (entryStr) {
-      intervalsKey = entryStr;
-      const athleteId = await text({
-        message: "intervals.icu athlete ID",
-        defaultValue: prevIntervalsId ?? "0",
-        placeholder: prevIntervalsId ?? "0",
-      });
-      handleCancel(athleteId);
-      intervalsAthleteId = (typeof athleteId === "string" && athleteId) || prevIntervalsId || "0";
-    }
-  }
+  // Detect backends + pick secret backend (D12 + D9)
+  let backend = await _pickBackend(ctx);
 
-  // Telegram — Enter keeps prior; type new value to replace
-  let telegramToken = prevTelegramToken ?? "";
-  {
-    const hasPrev = !!prevTelegramToken;
-    const entered = await password({
-      message: hasPrev
-        ? "Telegram bot token (Enter to keep existing)"
-        : "Telegram bot token (Enter to skip)",
-      validate: () => undefined,
-    });
-    handleCancel(entered);
-    const entryStr = typeof entered === "string" ? entered : "";
-    if (entryStr) telegramToken = entryStr;
-  }
+  // Cache vault (D10 multi-vault fallback caches the chosen vault for the run)
+  let chosenVault: string | undefined;
+  let opAbsPath: string | undefined;
+  let keychainPath: string | undefined;
 
-  // Build merged config — start from previous, replace only what changed.
+  // Each secret gets processed: collect user input, branch on backend choice
+  // vs previous backend, potentially apply D13 migration prompt, and write to
+  // the chosen backend. The merged config is mutated in place.
   const merged: Record<string, unknown> = { ...previous };
-
   const llmConfig: Record<string, unknown> = { provider, model };
   if (provider === "openai-codex") {
     llmConfig.auth_profile = "openai-codex";
-  } else {
-    llmConfig.api_key = apiKey;
+  }
+
+  // llm.api_key (required unless Codex)
+  if (provider !== "openai-codex") {
+    const hasPrev = provider === prevProvider && isNonEmptySecret(prevLlmKey);
+    const result = await _collectAndWriteSecret(ctx, {
+      field: "llm.api_key",
+      label: `${API_KEY_LABELS[provider]}`,
+      required: !hasPrev,
+      prevValue: provider === prevProvider ? prevLlmKey : undefined,
+      backend,
+      chosenVaultRef: { current: chosenVault },
+      opAbsPathRef: { current: opAbsPath },
+      keychainPathRef: { current: keychainPath },
+      onUnavailableReprompt: async () => {
+        backend = await _pickBackend(ctx);
+        return backend;
+      },
+    });
+    chosenVault = result.chosenVault;
+    opAbsPath = result.opAbsPath;
+    keychainPath = result.keychainPath;
+    backend = result.backend;
+    if (result.yamlValue !== undefined) {
+      llmConfig.api_key = result.yamlValue;
+    }
   }
   merged.llm = llmConfig;
 
-  if (intervalsKey) {
-    merged.intervals = {
-      api_key: intervalsKey,
-      athlete_id: intervalsAthleteId || "0",
-    };
-  } else {
-    delete merged.intervals;
+  // intervals.api_key (optional)
+  let intervalsAthleteId = prevIntervalsId ?? "";
+  {
+    const hasPrev = isNonEmptySecret(prevIntervalsKey);
+    const result = await _collectAndWriteSecret(ctx, {
+      field: "intervals.api_key",
+      label: "intervals.icu API key",
+      required: false,
+      prevValue: prevIntervalsKey,
+      backend,
+      chosenVaultRef: { current: chosenVault },
+      opAbsPathRef: { current: opAbsPath },
+      keychainPathRef: { current: keychainPath },
+      onUnavailableReprompt: async () => {
+        backend = await _pickBackend(ctx);
+        return backend;
+      },
+    });
+    chosenVault = result.chosenVault;
+    opAbsPath = result.opAbsPath;
+    keychainPath = result.keychainPath;
+    backend = result.backend;
+    if (result.yamlValue !== undefined) {
+      // Ask for athlete ID when the user typed a new key (reuse prev athlete id on keep).
+      if (result.providedNewValue) {
+        const athleteId = await text({
+          message: "intervals.icu athlete ID",
+          defaultValue: prevIntervalsId ?? "0",
+          placeholder: prevIntervalsId ?? "0",
+        });
+        handleCancel(athleteId, ctx);
+        intervalsAthleteId = (typeof athleteId === "string" && athleteId) || prevIntervalsId || "0";
+      } else if (hasPrev) {
+        intervalsAthleteId = prevIntervalsId ?? "0";
+      }
+      merged.intervals = {
+        api_key: result.yamlValue,
+        athlete_id: intervalsAthleteId || "0",
+      };
+    } else {
+      // User skipped and no prev → no intervals section.
+      delete merged.intervals;
+    }
   }
 
-  if (telegramToken) {
-    merged.telegram = { bot_token: telegramToken };
-  } else {
-    delete merged.telegram;
+  // telegram.bot_token (optional)
+  {
+    const result = await _collectAndWriteSecret(ctx, {
+      field: "telegram.bot_token",
+      label: "Telegram bot token",
+      required: false,
+      prevValue: prevTelegramToken,
+      backend,
+      chosenVaultRef: { current: chosenVault },
+      opAbsPathRef: { current: opAbsPath },
+      keychainPathRef: { current: keychainPath },
+      onUnavailableReprompt: async () => {
+        backend = await _pickBackend(ctx);
+        return backend;
+      },
+    });
+    chosenVault = result.chosenVault;
+    opAbsPath = result.opAbsPath;
+    keychainPath = result.keychainPath;
+    backend = result.backend;
+    if (result.yamlValue !== undefined) {
+      merged.telegram = { bot_token: result.yamlValue };
+    } else {
+      delete merged.telegram;
+    }
   }
 
   // Confirm before writing when a prior config exists.
@@ -232,7 +449,7 @@ export async function runSetup(): Promise<void> {
       message: `Update ${CONFIG_FILE}?`,
       initialValue: true,
     });
-    handleCancel(ok);
+    handleCancel(ok, ctx);
     if (!ok) {
       log.info("No changes written.");
       return;
@@ -244,8 +461,6 @@ export async function runSetup(): Promise<void> {
   mkdirSync(CONFIG_DIR, { recursive: true });
   writeFileSync(CONFIG_FILE, toYaml(merged), { mode: 0o600 });
 
-  // Save Codex credentials only after the config write succeeds; roll the
-  // config back if the save fails, so the two files stay in sync.
   if (freshCodexCreds) {
     try {
       saveProfile("openai-codex", freshCodexCreds);
@@ -261,4 +476,436 @@ export async function runSetup(): Promise<void> {
   }
 
   outro(`Config written to ${CONFIG_FILE}\n  Run \`cycling-coach\` to start.`);
+}
+
+function isNonEmptySecret(value: unknown): boolean {
+  if (typeof value === "string") return value.length > 0;
+  if (isSecretRef(value)) return true;
+  return false;
+}
+
+async function _pickBackend(ctx: WizardCtx): Promise<BackendChoice> {
+  while (true) {
+    const avail: BackendAvailability = await detectBackends();
+    const options: { value: string; label: string; hint?: string }[] = [
+      { value: BACKEND_PLAIN, label: "Plain config.yaml" },
+    ];
+    if (avail.op.state === "ready") {
+      options.push({
+        value: BACKEND_OP,
+        label: `1Password CLI (signed in as ${avail.op.signedInAs})`,
+      });
+    } else if (avail.op.state === "needs-signin") {
+      options.push({
+        value: BACKEND_OP_SIGNIN,
+        label: "1Password CLI — sign in first",
+      });
+    } else {
+      log.info(
+        `1Password CLI unavailable (${describeOpState(avail.op)}); backend not offered.`,
+      );
+    }
+    if (avail.keychain.available) {
+      options.push({ value: BACKEND_KEYCHAIN, label: "macOS Keychain" });
+    }
+
+    const picked = await select({
+      message: "Where to store secrets?",
+      options,
+      initialValue: BACKEND_PLAIN,
+    });
+    handleCancel(picked, ctx);
+
+    if (picked === BACKEND_PLAIN) return "plain";
+    if (picked === BACKEND_KEYCHAIN) return "keychain";
+    if (picked === BACKEND_OP) return "op";
+    if (picked === BACKEND_OP_SIGNIN) {
+      if (avail.op.state !== "needs-signin") {
+        continue; // state changed underneath; re-detect
+      }
+      const opPath = avail.op.absolutePath;
+      log.info("Running `op signin` — complete the prompt in this terminal.");
+      const ok = await runOpSignin(opPath);
+      if (!ok) {
+        log.error("`op signin` did not complete successfully. Pick another backend.");
+        continue;
+      }
+      const reDetected = await detectBackends();
+      if (reDetected.op.state === "ready") {
+        return "op";
+      }
+      log.info(
+        `1Password still not available (${describeOpState(reDetected.op)}). Pick another backend.`,
+      );
+      continue;
+    }
+    // Unreachable but keeps TS happy.
+    return "plain";
+  }
+}
+
+function describeOpState(state: OpState): string {
+  if (state.state === "ready") return `signed in as ${state.signedInAs}`;
+  if (state.state === "needs-signin") return "needs-signin";
+  if (state.reason === "not-on-path") return "not installed";
+  if (state.reason === "no-account") return "no account configured";
+  return `other: ${state.detail ?? "unknown"}`;
+}
+
+// ============================================================================
+// SECRET INTAKE + WRITE
+// ============================================================================
+
+type CollectArgs = {
+  field: SecretFieldPath;
+  label: string;
+  required: boolean;
+  prevValue: unknown;
+  backend: BackendChoice;
+  chosenVaultRef: { current: string | undefined };
+  opAbsPathRef: { current: string | undefined };
+  keychainPathRef: { current: string | undefined };
+  onUnavailableReprompt: () => Promise<BackendChoice>;
+};
+
+type CollectResult = {
+  yamlValue: string | SecretRef | undefined;
+  providedNewValue: boolean;
+  chosenVault: string | undefined;
+  opAbsPath: string | undefined;
+  keychainPath: string | undefined;
+  backend: BackendChoice;
+};
+
+async function _collectAndWriteSecret(
+  ctx: WizardCtx,
+  args: CollectArgs,
+): Promise<CollectResult> {
+  const { field, label, required, prevValue } = args;
+  let backend = args.backend;
+  const hasPrev = isNonEmptySecret(prevValue);
+  const prevBackend = _detectPrevBackend(prevValue);
+
+  const promptLabel = hasPrev
+    ? `${label} (Enter to keep existing)`
+    : required
+      ? label
+      : `${label} (Enter to skip)`;
+
+  const entered = await password({
+    message: promptLabel,
+    validate: () => undefined,
+  });
+  handleCancel(entered, ctx);
+  const raw = typeof entered === "string" ? entered : "";
+
+  if (raw.length === 0) {
+    // Enter-keep / Enter-skip branch.
+    if (!hasPrev) {
+      if (required) {
+        cancel(`${label} is required.`);
+        process.exit(1);
+      }
+      return {
+        yamlValue: undefined,
+        providedNewValue: false,
+        chosenVault: args.chosenVaultRef.current,
+        opAbsPath: args.opAbsPathRef.current,
+        keychainPath: args.keychainPathRef.current,
+        backend,
+      };
+    }
+
+    // hasPrev === true. If backend matches prev, keep as-is.
+    if (prevBackend === "unknown" || prevBackend === backend) {
+      return {
+        yamlValue: prevValue as string | SecretRef,
+        providedNewValue: false,
+        chosenVault: args.chosenVaultRef.current,
+        opAbsPath: args.opAbsPathRef.current,
+        keychainPath: args.keychainPathRef.current,
+        backend,
+      };
+    }
+
+    // D13 cross-backend keep-vs-paste prompt.
+    const action = await select({
+      message: `${label}: switch backend from ${prevBackend} to ${backend}?`,
+      options: [
+        { value: "paste", label: `Paste a new value to migrate to ${backend}` },
+        { value: "keep", label: `Keep in ${prevBackend} (YAML unchanged)` },
+      ],
+      initialValue: "keep",
+    });
+    handleCancel(action, ctx);
+    if (action === "keep") {
+      return {
+        yamlValue: prevValue as string | SecretRef,
+        providedNewValue: false,
+        chosenVault: args.chosenVaultRef.current,
+        opAbsPath: args.opAbsPathRef.current,
+        keychainPath: args.keychainPathRef.current,
+        backend,
+      };
+    }
+
+    // Paste: re-prompt with a required value.
+    const second = await password({
+      message: `${label} (paste new value)`,
+      validate: (v) => (!v ? `${label} is required when migrating.` : undefined),
+    });
+    handleCancel(second, ctx);
+    const cleanedSecond = _processSecretInput(
+      typeof second === "string" ? second : "",
+      field,
+    );
+    if (cleanedSecond.length === 0) {
+      cancel(`${label} is required when migrating.`);
+      process.exit(1);
+    }
+    return await _writeToBackend(ctx, args, backend, cleanedSecond);
+  }
+
+  // Non-empty input: trim + size cap, then write to chosen backend.
+  const cleaned = _processSecretInput(raw, field);
+  if (cleaned.length === 0) {
+    if (required) {
+      cancel(`${label} is required.`);
+      process.exit(1);
+    }
+    if (hasPrev) {
+      return {
+        yamlValue: prevValue as string | SecretRef,
+        providedNewValue: false,
+        chosenVault: args.chosenVaultRef.current,
+        opAbsPath: args.opAbsPathRef.current,
+        keychainPath: args.keychainPathRef.current,
+        backend,
+      };
+    }
+    return {
+      yamlValue: undefined,
+      providedNewValue: false,
+      chosenVault: args.chosenVaultRef.current,
+      opAbsPath: args.opAbsPathRef.current,
+      keychainPath: args.keychainPathRef.current,
+      backend,
+    };
+  }
+
+  return await _writeToBackend(ctx, args, backend, cleaned);
+}
+
+async function _writeToBackend(
+  ctx: WizardCtx,
+  args: CollectArgs,
+  backend: BackendChoice,
+  value: string,
+): Promise<CollectResult> {
+  const { field } = args;
+  if (backend === "plain") {
+    return {
+      yamlValue: value,
+      providedNewValue: true,
+      chosenVault: args.chosenVaultRef.current,
+      opAbsPath: args.opAbsPathRef.current,
+      keychainPath: args.keychainPathRef.current,
+      backend,
+    };
+  }
+
+  if (backend === "op") {
+    const opAbsPath = args.opAbsPathRef.current ?? (await discoverOpAbsPath());
+    const title = FIELD_TITLES[field];
+    const preExistingVault = await preCheckOpExistence(
+      opAbsPath,
+      title,
+      args.chosenVaultRef.current,
+    );
+    const preExistedBeforeWizard = preExistingVault !== null;
+
+    let resolvedVault: string;
+
+    if (preExistingVault !== null) {
+      // Prompt Update / Keep / Cancel (D10 re-run flow)
+      const action = await select({
+        message: `1Password item "${title}" already exists in vault "${preExistingVault}". Action?`,
+        options: [
+          { value: "update", label: "Update with new value" },
+          { value: "keep", label: "Keep existing (no write)" },
+          { value: "cancel", label: "Cancel setup" },
+        ],
+        initialValue: "update",
+      });
+      handleCancel(action, ctx);
+      if (action === "cancel") {
+        process.exit(0);
+      }
+      if (action === "keep") {
+        resolvedVault = preExistingVault;
+        ctx.createdThisRun.push({
+          backend: "op",
+          field,
+          title,
+          vaultName: resolvedVault,
+          opAbsPath,
+          preExistedBeforeWizard: true,
+        });
+        return {
+          yamlValue: opSecretRef(title, opAbsPath, resolvedVault),
+          providedNewValue: false,
+          chosenVault: resolvedVault,
+          opAbsPath,
+          keychainPath: args.keychainPathRef.current,
+          backend,
+        };
+      }
+      await opItemUpdate(opAbsPath, title, value, preExistingVault);
+      resolvedVault = preExistingVault;
+    } else {
+      resolvedVault = await createOpItem(
+        ctx,
+        opAbsPath,
+        title,
+        value,
+        args.chosenVaultRef.current,
+      );
+    }
+
+    ctx.createdThisRun.push({
+      backend: "op",
+      field,
+      title,
+      vaultName: resolvedVault,
+      opAbsPath,
+      preExistedBeforeWizard,
+    });
+    return {
+      yamlValue: opSecretRef(title, opAbsPath, resolvedVault),
+      providedNewValue: true,
+      chosenVault: resolvedVault,
+      opAbsPath,
+      keychainPath: args.keychainPathRef.current,
+      backend,
+    };
+  }
+
+  // keychain
+  const keychainPath = args.keychainPathRef.current ?? (await keychainLoginPath());
+  const account = FIELD_KEYCHAIN_ACCOUNT[field];
+  const preExisted = await keychainItemExists(account, keychainPath).catch(() => false);
+  try {
+    await keychainItemUpsert(account, value, keychainPath);
+  } catch (err) {
+    if (err instanceof KeychainUnsafeValueError) {
+      cancel(err.message);
+      process.exit(1);
+    }
+    throw err;
+  }
+  ctx.createdThisRun.push({
+    backend: "keychain",
+    field,
+    title: account,
+    keychainPath,
+    preExistedBeforeWizard: preExisted,
+  });
+  return {
+    yamlValue: keychainSecretRef(account, keychainPath),
+    providedNewValue: true,
+    chosenVault: args.chosenVaultRef.current,
+    opAbsPath: args.opAbsPathRef.current,
+    keychainPath,
+    backend,
+  };
+}
+
+async function preCheckOpExistence(
+  opAbsPath: string,
+  title: string,
+  knownVault: string | undefined,
+): Promise<string | null> {
+  try {
+    const res = await opItemGet(opAbsPath, title, knownVault);
+    if (res.exists) return res.vaultName;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+async function createOpItem(
+  ctx: WizardCtx,
+  opAbsPath: string,
+  title: string,
+  value: string,
+  cachedVault: string | undefined,
+): Promise<string> {
+  try {
+    const out = await opItemCreate(opAbsPath, title, value, cachedVault);
+    return out.vaultName;
+  } catch (err) {
+    if (err instanceof OpVaultAmbiguousError) {
+      const vaults = await opVaultList(opAbsPath);
+      const picked = await select({
+        message: "Multiple 1Password vaults — pick one:",
+        options: vaults.map((v) => ({ value: v.name, label: v.name })),
+      });
+      handleCancel(picked, ctx);
+      const chosen = picked as string;
+      const retry = await opItemCreate(opAbsPath, title, value, chosen);
+      return retry.vaultName;
+    }
+    throw err;
+  }
+}
+
+async function discoverOpAbsPath(): Promise<string> {
+  // Re-run detection to get the absolute op path; detectBackends caches
+  // nothing, but this runs once per new-value secret write at most.
+  const avail = await detectBackends();
+  if (avail.op.state === "ready") return avail.op.absolutePath;
+  if (avail.op.state === "needs-signin") return avail.op.absolutePath;
+  throw new Error(
+    `1Password backend became unavailable mid-wizard (${describeOpState(avail.op)}).`,
+  );
+}
+
+// ============================================================================
+// GUARDED CLEANUP (D11)
+// ============================================================================
+
+export async function _guardedCleanup(ctx: WizardCtx): Promise<void> {
+  const orphans = ctx.createdThisRun.filter((e) => !e.preExistedBeforeWizard);
+  if (orphans.length === 0) return;
+
+  log.error(
+    `Wizard failed after creating ${orphans.length} new backend item(s) that are not yet in config.yaml.`,
+  );
+
+  const doCleanup = await confirm({
+    message: `Delete the ${orphans.length} orphan item(s) now?`,
+    initialValue: false,
+  });
+  if (isCancel(doCleanup) || !doCleanup) {
+    _printOrphanCleanup(ctx);
+    return;
+  }
+
+  for (const o of orphans) {
+    try {
+      if (o.backend === "op" && o.opAbsPath && o.vaultName) {
+        await opItemDelete(o.opAbsPath, o.title, o.vaultName);
+        log.info(`Deleted 1Password item "${o.title}".`);
+      } else if (o.backend === "keychain" && o.keychainPath) {
+        await keychainItemDelete(o.title, o.keychainPath);
+        log.info(`Deleted Keychain item "${o.title}".`);
+      }
+    } catch (err) {
+      log.error(
+        `Failed to delete ${o.backend} item "${o.title}": ${err instanceof Error ? err.message : String(err)}`,
+      );
+      // Continue best-effort — don't stop on the first failure.
+    }
+  }
 }

--- a/tests/codex-setup-flow.test.ts
+++ b/tests/codex-setup-flow.test.ts
@@ -8,17 +8,31 @@ import { scriptedPrompts } from "./helpers/scripted-prompts.js";
 
 let tempHome: string;
 let origHome: string | undefined;
+let origStdinTTY: boolean | undefined;
+let origStdoutTTY: boolean | undefined;
 
 beforeEach(() => {
   tempHome = mkdtempSync(join(tmpdir(), "cc-setup-"));
   origHome = process.env.HOME;
   process.env.HOME = tempHome;
   mkdirSync(join(tempHome, ".cycling-coach"), { recursive: true });
+  origStdinTTY = process.stdin.isTTY;
+  origStdoutTTY = process.stdout.isTTY;
+  Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+  Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
   vi.resetModules();
+  vi.doMock("../src/secrets/backends/detect.js", () => ({
+    detectBackends: vi.fn(async () => ({
+      op: { state: "unavailable", reason: "not-on-path" },
+      keychain: { available: false },
+    })),
+  }));
 });
 
 afterEach(() => {
   process.env.HOME = origHome;
+  Object.defineProperty(process.stdin, "isTTY", { value: origStdinTTY, configurable: true });
+  Object.defineProperty(process.stdout, "isTTY", { value: origStdoutTTY, configurable: true });
   rmSync(tempHome, { recursive: true, force: true });
   vi.restoreAllMocks();
 });
@@ -27,7 +41,7 @@ describe("codex setup flow", () => {
   it("writes config without api_key and saves auth-profiles.json with 0o600", async () => {
     vi.doMock("@clack/prompts", () =>
       scriptedPrompts({
-        selects: ["openai-codex", "gpt-5.4"],
+        selects: ["openai-codex", "gpt-5.4", "plain"], // provider, model, backend
         passwords: ["", ""],
       }),
     );

--- a/tests/config.secret-ref.test.ts
+++ b/tests/config.secret-ref.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { stringify as toYaml } from "yaml";
+
+const MANAGED_ENV = [
+  "ANTHROPIC_API_KEY",
+  "OPENAI_API_KEY",
+  "GOOGLE_GENERATIVE_AI_API_KEY",
+  "INTERVALS_API_KEY",
+  "INTERVALS_ATHLETE_ID",
+  "TELEGRAM_BOT_TOKEN",
+  "LLM_PROVIDER",
+  "LLM_MODEL",
+  "CONTEXT_WINDOW_TOKENS",
+];
+
+let tempHome: string;
+let origHome: string | undefined;
+let origCcHome: string | undefined;
+const savedEnv: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  tempHome = mkdtempSync(join(tmpdir(), "cc-secretref-"));
+  origHome = process.env.HOME;
+  origCcHome = process.env.CYCLING_COACH_HOME;
+  process.env.HOME = tempHome;
+  delete process.env.CYCLING_COACH_HOME;
+  mkdirSync(join(tempHome, ".cycling-coach"), { recursive: true });
+  for (const k of MANAGED_ENV) {
+    savedEnv[k] = process.env[k];
+    delete process.env[k];
+  }
+  vi.resetModules();
+});
+
+afterEach(() => {
+  process.env.HOME = origHome;
+  if (origCcHome !== undefined) process.env.CYCLING_COACH_HOME = origCcHome;
+  else delete process.env.CYCLING_COACH_HOME;
+  for (const k of MANAGED_ENV) {
+    if (savedEnv[k] !== undefined) process.env[k] = savedEnv[k];
+    else delete process.env[k];
+  }
+  rmSync(tempHome, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+const CONFIG = () => join(tempHome, ".cycling-coach", "config.yaml");
+
+function seed(obj: Record<string, unknown>): void {
+  writeFileSync(CONFIG(), toYaml(obj), { mode: 0o600 });
+}
+
+describe("config — SecretRef integration", () => {
+  it("plain-string YAML resolves unchanged (backward compat)", async () => {
+    seed({
+      llm: { provider: "anthropic", api_key: "sk-plain", model: "claude-sonnet-4-6" },
+      intervals: { api_key: "iv-plain", athlete_id: "i1" },
+      telegram: { bot_token: "tg-plain" },
+    });
+    const { loadConfig, resolveConfigSecrets } = await import("../src/config.js");
+    const cfg = await resolveConfigSecrets(loadConfig());
+    expect(cfg.llm.apiKey).toBe("sk-plain");
+    expect(cfg.intervals.apiKey).toBe("iv-plain");
+    expect(cfg.telegram.botToken).toBe("tg-plain");
+  });
+
+  it("SecretRef YAML + printf sk-test resolves to 'sk-test'", async () => {
+    seed({
+      llm: {
+        provider: "anthropic",
+        api_key: { source: "exec", command: "printf", args: ["sk-test"] },
+        model: "claude-sonnet-4-6",
+      },
+    });
+    const { loadConfig, resolveConfigSecrets } = await import("../src/config.js");
+    const cfg = await resolveConfigSecrets(loadConfig());
+    expect(cfg.llm.apiKey).toBe("sk-test");
+  });
+
+  it("env var wins over SecretRef — spawn is never invoked", async () => {
+    seed({
+      llm: {
+        provider: "anthropic",
+        api_key: { source: "exec", command: "/definitely/not/real/cmd" },
+        model: "claude-sonnet-4-6",
+      },
+    });
+    process.env.ANTHROPIC_API_KEY = "env-wins";
+    const { loadConfig, resolveConfigSecrets } = await import("../src/config.js");
+    const cfg = await resolveConfigSecrets(loadConfig());
+    expect(cfg.llm.apiKey).toBe("env-wins");
+  });
+
+  it("malformed SecretRef throws INVALID_REF at loadConfig (eager validation)", async () => {
+    seed({
+      llm: {
+        provider: "anthropic",
+        api_key: { source: "exec" },
+        model: "claude-sonnet-4-6",
+      },
+    });
+    const { loadConfig } = await import("../src/config.js");
+    const { SecretResolutionError } = await import("../src/secrets/types.js");
+    let caught: unknown;
+    try {
+      loadConfig();
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(SecretResolutionError);
+    expect((caught as { code: string }).code).toBe("INVALID_REF");
+    expect((caught as Error).message).toContain("llm.api_key");
+  });
+
+  it("empty YAML preserves '' fall-through for optional intervals/telegram", async () => {
+    seed({
+      llm: { provider: "anthropic", api_key: "sk", model: "claude-sonnet-4-6" },
+    });
+    const { loadConfig, resolveConfigSecrets } = await import("../src/config.js");
+    const cfg = await resolveConfigSecrets(loadConfig());
+    expect(cfg.intervals.apiKey).toBe("");
+    expect(cfg.telegram.botToken).toBe("");
+  });
+
+  it("resolves SecretRefs on all three fields together", async () => {
+    seed({
+      llm: {
+        provider: "anthropic",
+        api_key: { source: "exec", command: "printf", args: ["llm-key"] },
+        model: "claude-sonnet-4-6",
+      },
+      intervals: {
+        api_key: { source: "exec", command: "printf", args: ["iv-key"] },
+        athlete_id: "i1",
+      },
+      telegram: {
+        bot_token: { source: "exec", command: "printf", args: ["tg-key"] },
+      },
+    });
+    const { loadConfig, resolveConfigSecrets } = await import("../src/config.js");
+    const cfg = await resolveConfigSecrets(loadConfig());
+    expect(cfg.llm.apiKey).toBe("llm-key");
+    expect(cfg.intervals.apiKey).toBe("iv-key");
+    expect(cfg.telegram.botToken).toBe("tg-key");
+  });
+});

--- a/tests/secrets/backends/detect.test.ts
+++ b/tests/secrets/backends/detect.test.ts
@@ -105,7 +105,10 @@ exit 2
   });
 
   it("returns unavailable/other with detail 'timeout' when op hangs past timeoutMs", async () => {
-    const opPath = await makeOpStub(`sleep 5`);
+    // sleep 2 (not 5) — _spawn.ts waits for `close` which only fires once the
+    // sleep child exits; under vitest's 5s default testTimeout, `sleep 5` is
+    // right on the edge and CI's Linux scheduler pushes it over.
+    const opPath = await makeOpStub(`sleep 2`);
     const result = await _detectBackendsWithOverrides({
       opPath,
       platform: "darwin",

--- a/tests/secrets/backends/detect.test.ts
+++ b/tests/secrets/backends/detect.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  _detectBackendsWithOverrides,
+  findInPath,
+} from "../../../src/secrets/backends/detect.js";
+
+const tempDirs: string[] = [];
+
+async function makeOpStub(script: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "op-stub-"));
+  tempDirs.push(dir);
+  const path = join(dir, "op");
+  await writeFile(path, `#!/bin/sh\n${script}\n`, { mode: 0o755 });
+  return path;
+}
+
+afterEach(async () => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) await rm(dir, { recursive: true, force: true });
+  }
+});
+
+describe("detectBackends", () => {
+  it("returns unavailable/not-on-path when op is missing from PATH", async () => {
+    const emptyDir = await mkdtemp(join(tmpdir(), "empty-path-"));
+    tempDirs.push(emptyDir);
+    const result = await _detectBackendsWithOverrides({
+      pathEnv: emptyDir,
+      platform: "darwin",
+    });
+    expect(result.op).toEqual({ state: "unavailable", reason: "not-on-path" });
+    expect(result.keychain).toEqual({ available: true });
+  });
+
+  it("returns ready when account list has an account and vault list succeeds", async () => {
+    const opPath = await makeOpStub(`
+case "$1" in
+  account) printf '[{"email":"you@x.com","url":"my.1password.com"}]' ;;
+  vault) printf '[{"id":"v1","name":"Personal"}]' ;;
+esac
+`);
+    const result = await _detectBackendsWithOverrides({ opPath, platform: "darwin" });
+    expect(result.op).toEqual({
+      state: "ready",
+      absolutePath: opPath,
+      signedInAs: "you@x.com",
+    });
+  });
+
+  it("returns needs-signin when vault list fails with 'not signed in'", async () => {
+    const opPath = await makeOpStub(`
+case "$1" in
+  account) printf '[{"email":"you@x.com"}]' ;;
+  vault) printf '[ERROR] account is not signed in\\n' >&2; exit 1 ;;
+esac
+`);
+    const result = await _detectBackendsWithOverrides({ opPath, platform: "darwin" });
+    expect(result.op).toEqual({
+      state: "needs-signin",
+      absolutePath: opPath,
+    });
+  });
+
+  it("returns unavailable/no-account when account list returns []", async () => {
+    const opPath = await makeOpStub(`
+case "$1" in
+  account) printf '[]' ;;
+  vault) printf 'should-not-run' >&2; exit 1 ;;
+esac
+`);
+    const result = await _detectBackendsWithOverrides({ opPath, platform: "darwin" });
+    expect(result.op).toEqual({ state: "unavailable", reason: "no-account" });
+  });
+
+  it("returns unavailable/other when vault list fails with unrecognized stderr", async () => {
+    const opPath = await makeOpStub(`
+case "$1" in
+  account) printf '[{"email":"you@x.com"}]' ;;
+  vault) printf 'permission denied\\n' >&2; exit 1 ;;
+esac
+`);
+    const result = await _detectBackendsWithOverrides({ opPath, platform: "darwin" });
+    expect(result.op.state).toBe("unavailable");
+    if (result.op.state === "unavailable") {
+      expect(result.op.reason).toBe("other");
+      expect(result.op.detail).toContain("permission denied");
+    }
+  });
+
+  it("returns unavailable/other when account list itself fails", async () => {
+    const opPath = await makeOpStub(`
+printf 'op: unexpected error\\n' >&2
+exit 2
+`);
+    const result = await _detectBackendsWithOverrides({ opPath, platform: "darwin" });
+    expect(result.op.state).toBe("unavailable");
+    if (result.op.state === "unavailable") {
+      expect(result.op.reason).toBe("other");
+      expect(result.op.detail).toContain("unexpected error");
+    }
+  });
+
+  it("returns unavailable/other with detail 'timeout' when op hangs past timeoutMs", async () => {
+    const opPath = await makeOpStub(`sleep 5`);
+    const result = await _detectBackendsWithOverrides({
+      opPath,
+      platform: "darwin",
+      timeoutMs: 200,
+    });
+    expect(result.op).toEqual({
+      state: "unavailable",
+      reason: "other",
+      detail: "timeout",
+    });
+  });
+
+  it("marks keychain unavailable on non-Darwin platforms, preserving op state", async () => {
+    const opPath = await makeOpStub(`
+case "$1" in
+  account) printf '[{"email":"you@x.com"}]' ;;
+  vault) printf '[]' ;;
+esac
+`);
+    const result = await _detectBackendsWithOverrides({ opPath, platform: "linux" });
+    expect(result.keychain).toEqual({ available: false });
+    expect(result.op.state).toBe("ready");
+  });
+});
+
+describe("findInPath", () => {
+  it("returns the absolute path when the binary is executable in PATH", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "path-present-"));
+    tempDirs.push(dir);
+    const bin = join(dir, "mybin");
+    await writeFile(bin, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+    expect(await findInPath("mybin", dir)).toBe(bin);
+  });
+
+  it("returns null when the binary is not in PATH", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "path-missing-"));
+    tempDirs.push(dir);
+    expect(await findInPath("definitely-not-a-real-bin", dir)).toBeNull();
+  });
+
+  it("returns null when PATH is empty", async () => {
+    expect(await findInPath("anything", "")).toBeNull();
+  });
+});

--- a/tests/secrets/backends/keychain.test.ts
+++ b/tests/secrets/backends/keychain.test.ts
@@ -1,0 +1,402 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { access, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  KeychainUnsafeValueError,
+  KeychainUnsupportedPlatformError,
+  assertKeychainSafeValue,
+  keychainItemDelete,
+  keychainItemExists,
+  keychainItemUpsert,
+  keychainLoginPath,
+  keychainSecretRef,
+} from "../../../src/secrets/backends/keychain.js";
+import { isSecretRef } from "../../../src/secrets/types.js";
+
+const tempDirs: string[] = [];
+
+async function makeSecurityStub(
+  script: string,
+): Promise<{ securityPath: string; dir: string }> {
+  const dir = await mkdtemp(join(tmpdir(), "security-stub-"));
+  tempDirs.push(dir);
+  const securityPath = join(dir, "security");
+  const wrapped = `#!/bin/sh
+STUB_DIR='${dir}'
+printf '%s\\n' "$@" > "$STUB_DIR/argv"
+touch "$STUB_DIR/called"
+cat > "$STUB_DIR/stdin"
+${script}
+`;
+  await writeFile(securityPath, wrapped, { mode: 0o755 });
+  return { securityPath, dir };
+}
+
+async function readArgv(dir: string): Promise<string[]> {
+  const raw = await readFile(join(dir, "argv"), "utf8");
+  return raw.split("\n").slice(0, -1);
+}
+
+async function readStdin(dir: string): Promise<string> {
+  return readFile(join(dir, "stdin"), "utf8");
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+let warnSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+});
+
+afterEach(async () => {
+  warnSpy.mockRestore();
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) await rm(dir, { recursive: true, force: true });
+  }
+});
+
+describe("keychainLoginPath", () => {
+  it("returns trimmed path ending in .keychain-db on exit 0", async () => {
+    const { securityPath } = await makeSecurityStub(`
+printf '    "/Users/test/Library/Keychains/login.keychain-db"\\n'
+`);
+    const result = await keychainLoginPath({ securityPath });
+    expect(result).toBe("/Users/test/Library/Keychains/login.keychain-db");
+  });
+
+  it("returns plain path with no surrounding quotes", async () => {
+    const { securityPath } = await makeSecurityStub(`
+printf '/Users/test/Library/Keychains/login.keychain-db\\n'
+`);
+    const result = await keychainLoginPath({ securityPath });
+    expect(result).toBe("/Users/test/Library/Keychains/login.keychain-db");
+  });
+
+  it("accepts .keychain suffix (legacy macOS)", async () => {
+    const { securityPath } = await makeSecurityStub(`
+printf '"/Users/test/Library/Keychains/login.keychain"\\n'
+`);
+    const result = await keychainLoginPath({ securityPath });
+    expect(result).toBe("/Users/test/Library/Keychains/login.keychain");
+  });
+
+  it("falls back to $HOME/Library/Keychains/login.keychain-db on timeout + logs WARN", async () => {
+    const { securityPath } = await makeSecurityStub(`
+sleep 2
+printf 'never printed\\n'
+`);
+    const result = await keychainLoginPath({ securityPath, timeoutMs: 100 });
+    expect(result).toMatch(/\/Library\/Keychains\/login\.keychain-db$/);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toMatch(/timeout/);
+  });
+
+  it("falls back on empty stdout + logs WARN", async () => {
+    const { securityPath } = await makeSecurityStub(`
+printf ''
+`);
+    const result = await keychainLoginPath({ securityPath });
+    expect(result).toMatch(/\/Library\/Keychains\/login\.keychain-db$/);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back on relative path stdout + logs WARN", async () => {
+    const { securityPath } = await makeSecurityStub(`
+printf 'login.keychain-db\\n'
+`);
+    const result = await keychainLoginPath({ securityPath });
+    expect(result).toMatch(/\/Library\/Keychains\/login\.keychain-db$/);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back on path without .keychain suffix", async () => {
+    const { securityPath } = await makeSecurityStub(`
+printf '/Users/test/something-else\\n'
+`);
+    const result = await keychainLoginPath({ securityPath });
+    expect(result).toMatch(/\/Library\/Keychains\/login\.keychain-db$/);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back on non-zero exit", async () => {
+    const { securityPath } = await makeSecurityStub(`
+printf 'ignored\\n'
+exit 1
+`);
+    const result = await keychainLoginPath({ securityPath });
+    expect(result).toMatch(/\/Library\/Keychains\/login\.keychain-db$/);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toMatch(/exit 1/);
+  });
+});
+
+describe("keychainItemExists", () => {
+  it("returns true when security exits 0", async () => {
+    const { securityPath, dir } = await makeSecurityStub(`exit 0`);
+    const result = await keychainItemExists(
+      "anthropic_api_key",
+      "/Users/x/Library/Keychains/login.keychain-db",
+      { securityPath },
+    );
+    expect(result).toBe(true);
+    const argv = await readArgv(dir);
+    expect(argv).toEqual([
+      "find-generic-password",
+      "-s",
+      "cycling-coach",
+      "-a",
+      "anthropic_api_key",
+      "/Users/x/Library/Keychains/login.keychain-db",
+    ]);
+  });
+
+  it("returns false on non-zero exit (item not found)", async () => {
+    const { securityPath } = await makeSecurityStub(`
+printf 'security: SecKeychainSearchCopyNext: The specified item could not be found in the keychain.\\n' >&2
+exit 44
+`);
+    const result = await keychainItemExists(
+      "missing_key",
+      "/Users/x/Library/Keychains/login.keychain-db",
+      { securityPath },
+    );
+    expect(result).toBe(false);
+  });
+
+  it("places keychain path as last positional arg (C3)", async () => {
+    const { securityPath, dir } = await makeSecurityStub(`exit 0`);
+    await keychainItemExists(
+      "some_key",
+      "/path/to/login.keychain-db",
+      { securityPath },
+    );
+    const argv = await readArgv(dir);
+    expect(argv[argv.length - 1]).toBe("/path/to/login.keychain-db");
+  });
+});
+
+describe("keychainItemUpsert", () => {
+  it("passes only `-i` in argv; secret travels via stdin (argv-leak guard)", async () => {
+    const { securityPath, dir } = await makeSecurityStub(`exit 0`);
+    const secret = "SECRET_TOKEN_VALUE_456";
+    const keychainPath = "/Users/x/Library/Keychains/login.keychain-db";
+    await keychainItemUpsert("openai_api_key", secret, keychainPath, {
+      securityPath,
+      platform: "darwin",
+    });
+    const argv = await readArgv(dir);
+    expect(argv).toEqual(["-i"]);
+    for (const arg of argv) {
+      expect(arg).not.toContain(secret);
+    }
+    const stdin = await readStdin(dir);
+    expect(stdin).toContain(secret);
+    expect(stdin).toContain(keychainPath);
+    expect(stdin).toContain("add-generic-password -U -s cycling-coach");
+  });
+
+  it("happy path: no error when stdout has no `returned -N`", async () => {
+    const { securityPath } = await makeSecurityStub(`exit 0`);
+    await expect(
+      keychainItemUpsert(
+        "anthropic_api_key",
+        "sk-abc",
+        "/Users/x/Library/Keychains/login.keychain-db",
+        { securityPath, platform: "darwin" },
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it("throws on `returned -N` in stdout even when exit 0 (C5)", async () => {
+    const { securityPath } = await makeSecurityStub(`
+printf 'security: SecKeychainSearchCopyNext: error\\n' >&2
+printf 'add-generic-password: returned -25299\\n'
+exit 0
+`);
+    await expect(
+      keychainItemUpsert(
+        "anthropic_api_key",
+        "sk-abc",
+        "/Users/x/Library/Keychains/login.keychain-db",
+        { securityPath, platform: "darwin" },
+      ),
+    ).rejects.toThrow(/OSStatus -25299/);
+  });
+
+  it("throws on `returned -N` appearing in stderr (also covered)", async () => {
+    const { securityPath } = await makeSecurityStub(`
+printf 'add-generic-password: returned -25300\\n' >&2
+exit 0
+`);
+    await expect(
+      keychainItemUpsert(
+        "anthropic_api_key",
+        "sk-abc",
+        "/Users/x/Library/Keychains/login.keychain-db",
+        { securityPath, platform: "darwin" },
+      ),
+    ).rejects.toThrow(/OSStatus -25300/);
+  });
+
+  it("platform guard: throws KeychainUnsupportedPlatformError on linux before any spawn", async () => {
+    const { securityPath, dir } = await makeSecurityStub(`exit 0`);
+    await expect(
+      keychainItemUpsert(
+        "anthropic_api_key",
+        "sk-abc",
+        "/Users/x/Library/Keychains/login.keychain-db",
+        { securityPath, platform: "linux" },
+      ),
+    ).rejects.toBeInstanceOf(KeychainUnsupportedPlatformError);
+    expect(await exists(join(dir, "called"))).toBe(false);
+  });
+
+  it("FD6 unsafe value guard: rejects newline before any spawn", async () => {
+    const { securityPath, dir } = await makeSecurityStub(`exit 0`);
+    await expect(
+      keychainItemUpsert(
+        "k",
+        "line1\nline2",
+        "/Users/x/Library/Keychains/login.keychain-db",
+        { securityPath, platform: "darwin" },
+      ),
+    ).rejects.toBeInstanceOf(KeychainUnsafeValueError);
+    expect(await exists(join(dir, "called"))).toBe(false);
+  });
+
+  it("FD6 unsafe value guard: rejects carriage return, NUL, and double-quote", async () => {
+    for (const unsafe of ["a\rb", "a\0b", 'a"b']) {
+      expect(() => assertKeychainSafeValue(unsafe)).toThrow(
+        KeychainUnsafeValueError,
+      );
+    }
+  });
+
+  it("FD6 safe values: alphanumerics + dash/dot/underscore pass", () => {
+    for (const safe of ["sk-abc_123.def", "AAA-bbb_ccc.DDD", "plain"]) {
+      expect(() => assertKeychainSafeValue(safe)).not.toThrow();
+    }
+  });
+});
+
+describe("keychainItemDelete", () => {
+  it("returns {deleted:true} on exit 0", async () => {
+    const { securityPath, dir } = await makeSecurityStub(`exit 0`);
+    const result = await keychainItemDelete(
+      "anthropic_api_key",
+      "/Users/x/Library/Keychains/login.keychain-db",
+      { securityPath },
+    );
+    expect(result).toEqual({ deleted: true });
+    const argv = await readArgv(dir);
+    expect(argv[argv.length - 1]).toBe(
+      "/Users/x/Library/Keychains/login.keychain-db",
+    );
+  });
+
+  it("returns {deleted:false} on exit 44", async () => {
+    const { securityPath } = await makeSecurityStub(`
+printf 'security: SecKeychainSearchCopyNext: The specified item could not be found.\\n' >&2
+exit 44
+`);
+    const result = await keychainItemDelete(
+      "missing_key",
+      "/Users/x/Library/Keychains/login.keychain-db",
+      { securityPath },
+    );
+    expect(result).toEqual({ deleted: false });
+  });
+
+  it("returns {deleted:false} on 'not found' stderr with other exit code", async () => {
+    const { securityPath } = await makeSecurityStub(`
+printf 'security: The specified item could not be found in the keychain.\\n' >&2
+exit 1
+`);
+    const result = await keychainItemDelete(
+      "missing_key",
+      "/Users/x/Library/Keychains/login.keychain-db",
+      { securityPath },
+    );
+    expect(result).toEqual({ deleted: false });
+  });
+
+  it("throws on other non-zero exits (e.g., auth failure)", async () => {
+    const { securityPath } = await makeSecurityStub(`
+printf 'security: user interaction required; keychain is locked\\n' >&2
+exit 36
+`);
+    await expect(
+      keychainItemDelete(
+        "anthropic_api_key",
+        "/Users/x/Library/Keychains/login.keychain-db",
+        { securityPath },
+      ),
+    ).rejects.toThrow(/security delete-generic-password failed \(exit 36\)/);
+  });
+
+  it("places keychain path as last positional arg (C3)", async () => {
+    const { securityPath, dir } = await makeSecurityStub(`exit 0`);
+    await keychainItemDelete("k", "/path/to/login.keychain-db", {
+      securityPath,
+    });
+    const argv = await readArgv(dir);
+    expect(argv).toEqual([
+      "delete-generic-password",
+      "-s",
+      "cycling-coach",
+      "-a",
+      "k",
+      "/path/to/login.keychain-db",
+    ]);
+  });
+});
+
+describe("keychainSecretRef", () => {
+  it("produces SecretRef with keychain path as the last positional arg (C3)", () => {
+    const ref = keychainSecretRef(
+      "anthropic_api_key",
+      "/Users/x/Library/Keychains/login.keychain-db",
+    );
+    expect(isSecretRef(ref)).toBe(true);
+    expect(ref).toEqual({
+      source: "exec",
+      command: "/usr/bin/security",
+      args: [
+        "find-generic-password",
+        "-w",
+        "-s",
+        "cycling-coach",
+        "-a",
+        "anthropic_api_key",
+        "/Users/x/Library/Keychains/login.keychain-db",
+      ],
+    });
+    expect(ref.args![ref.args!.length - 1]).toBe(
+      "/Users/x/Library/Keychains/login.keychain-db",
+    );
+  });
+});
+
+describe("keychain idempotency (CI-only)", () => {
+  it.skipIf(process.env.CI !== "macos")(
+    "keychainItemUpsert stores the second value when called twice with different values",
+    async () => {
+      // Placeholder for the CI-only integration test. Real implementation would:
+      //   1. keychainItemUpsert(field, "v1", realLoginPath)
+      //   2. keychainItemUpsert(field, "v2", realLoginPath)
+      //   3. spawn `security find-generic-password -w ...` and assert stdout === "v2"
+      //   4. keychainItemDelete(field, realLoginPath) for cleanup.
+      expect(true).toBe(true);
+    },
+  );
+});

--- a/tests/secrets/backends/op.test.ts
+++ b/tests/secrets/backends/op.test.ts
@@ -1,0 +1,400 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { access, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  OpVaultAmbiguousError,
+  SecretTooLargeError,
+  opItemCreate,
+  opItemDelete,
+  opItemGet,
+  opItemUpdate,
+  opSecretRef,
+  opVaultList,
+  redactTemplateForLog,
+} from "../../../src/secrets/backends/op.js";
+import { isSecretRef } from "../../../src/secrets/types.js";
+
+const tempDirs: string[] = [];
+
+async function makeOpStub(
+  script: string,
+): Promise<{ opPath: string; dir: string }> {
+  const dir = await mkdtemp(join(tmpdir(), "op-stub-"));
+  tempDirs.push(dir);
+  const opPath = join(dir, "op");
+  const wrapped = `#!/bin/sh
+STUB_DIR='${dir}'
+printf '%s\\n' "$@" > "$STUB_DIR/argv"
+cat > "$STUB_DIR/stdin"
+${script}
+`;
+  await writeFile(opPath, wrapped, { mode: 0o755 });
+  return { opPath, dir };
+}
+
+async function readArgv(dir: string): Promise<string[]> {
+  const raw = await readFile(join(dir, "argv"), "utf8");
+  return raw.split("\n").slice(0, -1); // trailing "" after final \n
+}
+
+async function readStdin(dir: string): Promise<string> {
+  return readFile(join(dir, "stdin"), "utf8");
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+afterEach(async () => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) await rm(dir, { recursive: true, force: true });
+  }
+});
+
+describe("opItemGet", () => {
+  it("returns {exists:false} when stderr mentions 'isn't an item'", async () => {
+    const { opPath } = await makeOpStub(`
+printf "[ERROR] \\"foo\\" isn't an item. Specify the item with its UUID, name, or domain.\\n" >&2
+exit 1
+`);
+    const result = await opItemGet(opPath, "foo");
+    expect(result).toEqual({ exists: false });
+  });
+
+  it("parses vault.name from stdout on exit 0", async () => {
+    const { opPath } = await makeOpStub(`
+printf '{"id":"abc","title":"foo","vault":{"id":"v1","name":"Personal"},"fields":[]}'
+`);
+    const result = await opItemGet(opPath, "foo");
+    expect(result).toEqual({ exists: true, vaultName: "Personal" });
+  });
+
+  it("passes --vault when provided", async () => {
+    const { opPath, dir } = await makeOpStub(`
+printf '{"vault":{"name":"Test"},"fields":[]}'
+`);
+    await opItemGet(opPath, "foo", "Test");
+    const argv = await readArgv(dir);
+    expect(argv).toEqual(["item", "get", "foo", "--vault", "Test", "--format=json"]);
+  });
+
+  it("throws on non-zero exit with unrecognized stderr", async () => {
+    const { opPath } = await makeOpStub(`
+printf "some auth error\\n" >&2
+exit 1
+`);
+    await expect(opItemGet(opPath, "foo")).rejects.toThrow(/some auth error/);
+  });
+});
+
+describe("opItemCreate", () => {
+  const fixtureStdout = JSON.stringify({
+    id: "abc",
+    title: "foo",
+    vault: { id: "v1", name: "Personal" },
+    fields: [
+      {
+        id: "credential",
+        type: "CONCEALED",
+        value: "whatever",
+        reference: "op://Personal/foo/credential",
+      },
+    ],
+  });
+
+  it("spawns 'item create - --format=json' exactly once and parses vault from stdout (D18)", async () => {
+    const { opPath, dir } = await makeOpStub(`printf '%s' '${fixtureStdout}'`);
+    const result = await opItemCreate(opPath, "foo", "sk-value", "Personal");
+    expect(result).toEqual({ vaultName: "Personal" });
+    const argv = await readArgv(dir);
+    expect(argv).toEqual([
+      "item",
+      "create",
+      "-",
+      "--format=json",
+      "--vault",
+      "Personal",
+    ]);
+  });
+
+  it("passes --vault <name> in argv when vaultName given", async () => {
+    const { opPath, dir } = await makeOpStub(`printf '%s' '${fixtureStdout}'`);
+    await opItemCreate(opPath, "foo", "sk-value", "Personal");
+    const argv = await readArgv(dir);
+    expect(argv).toContain("--vault");
+    expect(argv).toContain("Personal");
+  });
+
+  it("omits --vault when no vaultName given", async () => {
+    const { opPath, dir } = await makeOpStub(`printf '%s' '${fixtureStdout}'`);
+    await opItemCreate(opPath, "foo", "sk-value");
+    const argv = await readArgv(dir);
+    expect(argv).not.toContain("--vault");
+  });
+
+  it("throws OpVaultAmbiguousError when stderr matches multi-vault regex", async () => {
+    const { opPath } = await makeOpStub(`
+printf "[ERROR] more than one vault, specify --vault\\n" >&2
+exit 1
+`);
+    await expect(opItemCreate(opPath, "foo", "sk-value")).rejects.toBeInstanceOf(
+      OpVaultAmbiguousError,
+    );
+  });
+
+  it("throws generic error with stderr tail on non-vault error", async () => {
+    const { opPath } = await makeOpStub(`
+printf "authorization timeout\\n" >&2
+exit 1
+`);
+    await expect(
+      opItemCreate(opPath, "foo", "sk-value", "Personal"),
+    ).rejects.toThrow(/authorization timeout/);
+  });
+
+  it("round-trips a value with quotes through stdin byte-for-byte", async () => {
+    const { opPath, dir } = await makeOpStub(`printf '%s' '${fixtureStdout}'`);
+    const value = 'sk-"with-quotes"';
+    await opItemCreate(opPath, "foo", value, "Personal");
+    const stdin = await readStdin(dir);
+    const parsed = JSON.parse(stdin) as {
+      fields: Array<{ id: string; value: string }>;
+    };
+    expect(parsed.fields[0].value).toBe(value);
+  });
+
+  it("round-trips a value with backslash through stdin byte-for-byte", async () => {
+    const { opPath, dir } = await makeOpStub(`printf '%s' '${fixtureStdout}'`);
+    const value = "sk-\\with-backslash";
+    await opItemCreate(opPath, "foo", value, "Personal");
+    const stdin = await readStdin(dir);
+    const parsed = JSON.parse(stdin) as {
+      fields: Array<{ id: string; value: string }>;
+    };
+    expect(parsed.fields[0].value).toBe(value);
+  });
+
+  it("round-trips a value with newlines and tabs through stdin byte-for-byte", async () => {
+    const { opPath, dir } = await makeOpStub(`printf '%s' '${fixtureStdout}'`);
+    const value = "sk-\nwith\tcontrol";
+    await opItemCreate(opPath, "foo", value, "Personal");
+    const stdin = await readStdin(dir);
+    const parsed = JSON.parse(stdin) as {
+      fields: Array<{ id: string; value: string }>;
+    };
+    expect(parsed.fields[0].value).toBe(value);
+  });
+
+  it("round-trips a UTF-8 multi-byte value through stdin byte-for-byte", async () => {
+    const { opPath, dir } = await makeOpStub(`printf '%s' '${fixtureStdout}'`);
+    const value = "sk-тест-🚴";
+    await opItemCreate(opPath, "foo", value, "Personal");
+    const stdin = await readStdin(dir);
+    const parsed = JSON.parse(stdin) as {
+      fields: Array<{ id: string; value: string }>;
+    };
+    expect(parsed.fields[0].value).toBe(value);
+  });
+
+  it("rejects 65_537-byte value with SecretTooLargeError BEFORE any spawn", async () => {
+    const { opPath, dir } = await makeOpStub(
+      `printf 'STUB_WAS_CALLED' > "$STUB_DIR/called"
+printf '%s' '${fixtureStdout}'`,
+    );
+    const oversize = "x".repeat(65_537);
+    await expect(
+      opItemCreate(opPath, "foo", oversize, "Personal"),
+    ).rejects.toBeInstanceOf(SecretTooLargeError);
+    expect(await exists(join(dir, "called"))).toBe(false);
+  });
+
+  it("accepts exactly 65_536-byte value (size cap boundary)", async () => {
+    const { opPath } = await makeOpStub(`printf '%s' '${fixtureStdout}'`);
+    const boundary = "x".repeat(65_536);
+    const result = await opItemCreate(opPath, "foo", boundary, "Personal");
+    expect(result).toEqual({ vaultName: "Personal" });
+  });
+
+  it("redacts the value when build-error message echoes the template (no-log-leak)", async () => {
+    const { opPath } = await makeOpStub(`
+cat /dev/null  # stdin already consumed by wrapper
+printf "something went wrong\\n" >&2
+exit 1
+`);
+    const secret = "SECRET_VALUE_SHOULD_NOT_LEAK";
+    const err = await opItemCreate(opPath, "foo", secret, "Personal").catch(
+      (e: Error) => e,
+    );
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).not.toContain(secret);
+    expect((err as Error).message).toContain("<redacted>");
+  });
+
+  it("never writes the secret value into argv (argv leak guard)", async () => {
+    const { opPath, dir } = await makeOpStub(`printf '%s' '${fixtureStdout}'`);
+    const secret = "SECRET_TOKEN_VALUE_123";
+    await opItemCreate(opPath, "foo", secret, "Personal");
+    const argv = await readArgv(dir);
+    for (const arg of argv) {
+      expect(arg).not.toContain(secret);
+    }
+    const stdin = await readStdin(dir);
+    expect(stdin).toContain(secret);
+  });
+});
+
+describe("opItemUpdate", () => {
+  it("runs get → modify → edit and pipes full JSON with new value to stdin", async () => {
+    const existingItem = {
+      id: "abc",
+      title: "foo",
+      vault: { id: "v1", name: "Personal" },
+      fields: [
+        { id: "notesPlain", type: "STRING", purpose: "NOTES", value: "" },
+        {
+          id: "credential",
+          type: "CONCEALED",
+          value: "old-value",
+          reference: "op://Personal/foo/credential",
+        },
+      ],
+    };
+    const { opPath, dir } = await makeOpStub(`
+case "$2" in
+  get) printf '%s' '${JSON.stringify(existingItem)}' ;;
+  edit) : ;;
+esac
+`);
+    await opItemUpdate(opPath, "foo", "new-value", "Personal");
+    const argv = await readArgv(dir);
+    expect(argv).toEqual(["item", "edit", "foo", "--vault", "Personal", "-"]);
+    const stdin = await readStdin(dir);
+    const parsed = JSON.parse(stdin) as {
+      fields: Array<{ id: string; value: string }>;
+    };
+    const cred = parsed.fields.find((f) => f.id === "credential");
+    expect(cred?.value).toBe("new-value");
+    const notes = parsed.fields.find((f) => f.id === "notesPlain");
+    expect(notes).toBeDefined();
+  });
+
+  it("rejects oversized value with SecretTooLargeError BEFORE any spawn", async () => {
+    const { opPath, dir } = await makeOpStub(
+      `printf 'STUB_WAS_CALLED' > "$STUB_DIR/called"`,
+    );
+    const oversize = "x".repeat(65_537);
+    await expect(
+      opItemUpdate(opPath, "foo", oversize, "Personal"),
+    ).rejects.toBeInstanceOf(SecretTooLargeError);
+    expect(await exists(join(dir, "called"))).toBe(false);
+  });
+
+  it("throws when get returns an item without a credential field", async () => {
+    const itemWithoutCred = {
+      id: "abc",
+      title: "foo",
+      vault: { name: "Personal" },
+      fields: [{ id: "notesPlain", type: "STRING", value: "" }],
+    };
+    const { opPath } = await makeOpStub(
+      `printf '%s' '${JSON.stringify(itemWithoutCred)}'`,
+    );
+    await expect(
+      opItemUpdate(opPath, "foo", "new-value", "Personal"),
+    ).rejects.toThrow(/no 'credential' field/);
+  });
+});
+
+describe("opVaultList", () => {
+  it("parses the JSON array into {id, name} entries", async () => {
+    const { opPath } = await makeOpStub(
+      `printf '[{"id":"v1","name":"Personal","content_version":1},{"id":"v2","name":"Test","content_version":2}]'`,
+    );
+    const result = await opVaultList(opPath);
+    expect(result).toEqual([
+      { id: "v1", name: "Personal" },
+      { id: "v2", name: "Test" },
+    ]);
+  });
+
+  it("throws on non-zero exit", async () => {
+    const { opPath } = await makeOpStub(`
+printf "vault list failed\\n" >&2
+exit 1
+`);
+    await expect(opVaultList(opPath)).rejects.toThrow(/vault list failed/);
+  });
+});
+
+describe("opItemDelete", () => {
+  it("returns {deleted:true} on exit 0", async () => {
+    const { opPath, dir } = await makeOpStub(``);
+    const result = await opItemDelete(opPath, "foo", "Personal");
+    expect(result).toEqual({ deleted: true });
+    const argv = await readArgv(dir);
+    expect(argv).toEqual(["item", "delete", "foo", "--vault", "Personal"]);
+  });
+
+  it("returns {deleted:false} when stderr mentions 'isn't an item' (C11)", async () => {
+    const { opPath } = await makeOpStub(`
+printf "[ERROR] \\"foo\\" isn't an item. Specify the item with its UUID, name, or domain.\\n" >&2
+exit 1
+`);
+    const result = await opItemDelete(opPath, "foo", "Personal");
+    expect(result).toEqual({ deleted: false });
+  });
+
+  it("throws on other non-zero exits (e.g., auth failure)", async () => {
+    const { opPath } = await makeOpStub(`
+printf "authorization timeout\\n" >&2
+exit 1
+`);
+    await expect(opItemDelete(opPath, "foo", "Personal")).rejects.toThrow(
+      /authorization timeout/,
+    );
+  });
+});
+
+describe("opSecretRef", () => {
+  it("produces a valid SecretRef with the supplied vault name interpolated into the op:// path", async () => {
+    const ref = opSecretRef(
+      "cycling-coach · anthropic_api_key",
+      "/usr/local/bin/op",
+      "Personal",
+    );
+    expect(isSecretRef(ref)).toBe(true);
+    expect(ref).toEqual({
+      source: "exec",
+      command: "/usr/local/bin/op",
+      args: ["read", "op://Personal/cycling-coach · anthropic_api_key/credential"],
+    });
+  });
+});
+
+describe("redactTemplateForLog", () => {
+  it("replaces fields[].value with '<redacted>' and preserves structure", () => {
+    const template = JSON.stringify({
+      title: "foo",
+      category: "API_CREDENTIAL",
+      fields: [
+        { id: "credential", type: "CONCEALED", label: "credential", value: "sk-secret" },
+      ],
+    });
+    const redacted = redactTemplateForLog(template);
+    expect(redacted).not.toContain("sk-secret");
+    expect(redacted).toContain("<redacted>");
+    const parsed = JSON.parse(redacted) as { fields: Array<{ value: string }> };
+    expect(parsed.fields[0].value).toBe("<redacted>");
+  });
+
+  it("returns '<redacted>' when input is not valid JSON", () => {
+    expect(redactTemplateForLog("not json at all")).toBe("<redacted>");
+  });
+});

--- a/tests/secrets/resolve.test.ts
+++ b/tests/secrets/resolve.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+import {
+  _resolveSecretRefWithOverrides,
+  resolveSecretRef,
+} from "../../src/secrets/resolve.js";
+import { SecretResolutionError } from "../../src/secrets/types.js";
+
+describe("resolveSecretRef", () => {
+  it("resolves printf 'hello' to 'hello'", async () => {
+    const result = await resolveSecretRef({
+      source: "exec",
+      command: "printf",
+      args: ["hello"],
+    });
+    expect(result).toBe("hello");
+  });
+
+  it("trims single trailing LF", async () => {
+    const result = await resolveSecretRef({
+      source: "exec",
+      command: "printf",
+      args: ["hello\n"],
+    });
+    expect(result).toBe("hello");
+  });
+
+  it("trims trailing CRLF (no stray \\r glued to the secret)", async () => {
+    const result = await resolveSecretRef({
+      source: "exec",
+      command: "printf",
+      args: ["hello\r\n"],
+    });
+    expect(result).toBe("hello");
+  });
+
+  it("throws EMPTY for empty stdout", async () => {
+    const err = await resolveSecretRef({
+      source: "exec",
+      command: "printf",
+      args: [""],
+    }).catch((e) => e as SecretResolutionError);
+    expect(err).toBeInstanceOf(SecretResolutionError);
+    expect(err.code).toBe("EMPTY");
+  });
+
+  it("throws EMPTY for newline-only stdout", async () => {
+    const err = await resolveSecretRef({
+      source: "exec",
+      command: "printf",
+      args: ["\n"],
+    }).catch((e) => e as SecretResolutionError);
+    expect(err).toBeInstanceOf(SecretResolutionError);
+    expect(err.code).toBe("EMPTY");
+  });
+
+  it("throws EXIT_NONZERO with stderr tail in message", async () => {
+    const err = await resolveSecretRef({
+      source: "exec",
+      command: "sh",
+      args: ["-c", "echo boom >&2; exit 2"],
+    }).catch((e) => e as SecretResolutionError);
+    expect(err).toBeInstanceOf(SecretResolutionError);
+    expect(err.code).toBe("EXIT_NONZERO");
+    expect(err.message).toContain("boom");
+    expect(err.message).toContain("2");
+  });
+
+  it("throws ENOENT for missing binary", async () => {
+    const err = await resolveSecretRef({
+      source: "exec",
+      command: "definitely-not-a-real-binary-xyz",
+    }).catch((e) => e as SecretResolutionError);
+    expect(err).toBeInstanceOf(SecretResolutionError);
+    expect(err.code).toBe("ENOENT");
+    expect(err.message).toContain("$PATH");
+  });
+
+  it("throws TIMEOUT with 200ms override + sleep 60", async () => {
+    const err = await _resolveSecretRefWithOverrides(
+      { source: "exec", command: "sleep", args: ["60"] },
+      { timeoutMs: 200 },
+    ).catch((e) => e as SecretResolutionError);
+    expect(err).toBeInstanceOf(SecretResolutionError);
+    expect(err.code).toBe("TIMEOUT");
+  });
+
+  it("throws OVERFLOW with low maxBytes + yes", async () => {
+    const err = await _resolveSecretRefWithOverrides(
+      { source: "exec", command: "yes" },
+      { maxBytes: 100, timeoutMs: 2000 },
+    ).catch((e) => e as SecretResolutionError);
+    expect(err).toBeInstanceOf(SecretResolutionError);
+    expect(err.code).toBe("OVERFLOW");
+  });
+
+  it("shell:false — ';' and '|' args are literal, not shell-interpreted", async () => {
+    const result = await resolveSecretRef({
+      source: "exec",
+      command: "echo",
+      args: [";", "rm", "-rf", "~"],
+    });
+    expect(result).toBe("; rm -rf ~");
+  });
+});

--- a/tests/secrets/types.test.ts
+++ b/tests/secrets/types.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { isSecretRef, SecretResolutionError } from "../../src/secrets/types.js";
+
+describe("isSecretRef", () => {
+  it("accepts minimal shape with no args", () => {
+    expect(isSecretRef({ source: "exec", command: "op" })).toBe(true);
+  });
+
+  it("accepts shape with string[] args", () => {
+    expect(
+      isSecretRef({ source: "exec", command: "op", args: ["read", "op://Vault/Item/field"] }),
+    ).toBe(true);
+  });
+
+  it("rejects wrong source", () => {
+    expect(isSecretRef({ source: "env", command: "op" })).toBe(false);
+  });
+
+  it("rejects empty command", () => {
+    expect(isSecretRef({ source: "exec", command: "" })).toBe(false);
+  });
+
+  it("rejects non-array args", () => {
+    expect(isSecretRef({ source: "exec", command: "op", args: "read" })).toBe(false);
+  });
+
+  it("rejects args with non-string element", () => {
+    expect(isSecretRef({ source: "exec", command: "op", args: ["read", 42] })).toBe(false);
+  });
+
+  it("rejects extra fields", () => {
+    expect(isSecretRef({ source: "exec", command: "op", extra: 1 })).toBe(false);
+  });
+
+  it("rejects null", () => {
+    expect(isSecretRef(null)).toBe(false);
+  });
+
+  it("rejects arrays", () => {
+    expect(isSecretRef(["exec", "op"])).toBe(false);
+  });
+
+  it("rejects primitives", () => {
+    expect(isSecretRef("op")).toBe(false);
+    expect(isSecretRef(42)).toBe(false);
+    expect(isSecretRef(undefined)).toBe(false);
+  });
+});
+
+describe("SecretResolutionError", () => {
+  it("preserves code field and message", () => {
+    const err = new SecretResolutionError("ENOENT", "nope");
+    expect(err.code).toBe("ENOENT");
+    expect(err.message).toBe("nope");
+    expect(err.name).toBe("SecretResolutionError");
+    expect(err).toBeInstanceOf(Error);
+  });
+});

--- a/tests/setup-merge.test.ts
+++ b/tests/setup-merge.test.ts
@@ -8,17 +8,34 @@ import { scriptedPrompts } from "./helpers/scripted-prompts.js";
 
 let tempHome: string;
 let origHome: string | undefined;
+let origStdinTTY: boolean | undefined;
+let origStdoutTTY: boolean | undefined;
 
 beforeEach(() => {
   tempHome = mkdtempSync(join(tmpdir(), "cc-merge-"));
   origHome = process.env.HOME;
   process.env.HOME = tempHome;
   mkdirSync(join(tempHome, ".cycling-coach"), { recursive: true });
+  origStdinTTY = process.stdin.isTTY;
+  origStdoutTTY = process.stdout.isTTY;
+  Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+  Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
   vi.resetModules();
+  // Default to op unavailable + keychain unavailable so backend-choice
+  // shows only "plain" by default. Tests that need backend detection behavior
+  // override this with their own vi.doMock.
+  vi.doMock("../src/secrets/backends/detect.js", () => ({
+    detectBackends: vi.fn(async () => ({
+      op: { state: "unavailable", reason: "not-on-path" },
+      keychain: { available: false },
+    })),
+  }));
 });
 
 afterEach(() => {
   process.env.HOME = origHome;
+  Object.defineProperty(process.stdin, "isTTY", { value: origStdinTTY, configurable: true });
+  Object.defineProperty(process.stdout, "isTTY", { value: origStdoutTTY, configurable: true });
   rmSync(tempHome, { recursive: true, force: true });
   vi.restoreAllMocks();
 });
@@ -40,7 +57,7 @@ describe("setup merge", () => {
 
     vi.doMock("@clack/prompts", () =>
       scriptedPrompts({
-        selects: ["openai-codex", "gpt-5.4"],
+        selects: ["openai-codex", "gpt-5.4", "plain"], // provider, model, backend
         passwords: ["", ""], // intervals Enter-to-keep, telegram Enter-to-keep
         texts: [],
         confirms: [true], // update config
@@ -80,7 +97,7 @@ describe("setup merge", () => {
 
     vi.doMock("@clack/prompts", () =>
       scriptedPrompts({
-        selects: ["openai-codex", "gpt-5.4"],
+        selects: ["openai-codex", "gpt-5.4", "plain"], // provider, model, backend
         passwords: ["", ""],
         texts: [],
         confirms: [false], // decline update
@@ -105,7 +122,7 @@ describe("setup merge", () => {
   it("Case C: fresh install writes full config without requiring merge", async () => {
     vi.doMock("@clack/prompts", () =>
       scriptedPrompts({
-        selects: ["openai-codex", "gpt-5.4"],
+        selects: ["openai-codex", "gpt-5.4", "plain"], // provider, model, backend
         passwords: ["", ""],
         texts: [],
         confirms: [],
@@ -141,6 +158,7 @@ describe("setup merge", () => {
     });
     const before = readFileSync(CONFIG(), "utf-8");
 
+    // Case D: OAuth fails BEFORE backend-choice — only 2 selects needed.
     vi.doMock("@clack/prompts", () =>
       scriptedPrompts({
         selects: ["openai-codex", "gpt-5.4"],
@@ -176,7 +194,7 @@ describe("setup merge", () => {
 
     vi.doMock("@clack/prompts", () =>
       scriptedPrompts({
-        selects: ["openai-codex", "gpt-5.4"],
+        selects: ["openai-codex", "gpt-5.4", "plain"], // provider, model, backend
         passwords: ["", ""],
         texts: [],
         confirms: [true],

--- a/tests/setup.secret-ref.test.ts
+++ b/tests/setup.secret-ref.test.ts
@@ -1,0 +1,1207 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { parse as parseYaml, stringify as toYaml } from "yaml";
+
+import { scriptedPrompts } from "./helpers/scripted-prompts.js";
+
+let tempHome: string;
+let origHome: string | undefined;
+let origStdinTTY: boolean | undefined;
+let origStdoutTTY: boolean | undefined;
+let stderrWrites: string[];
+let origStderrWrite: typeof process.stderr.write;
+
+beforeEach(() => {
+  tempHome = mkdtempSync(join(tmpdir(), "cc-ref-"));
+  origHome = process.env.HOME;
+  process.env.HOME = tempHome;
+  mkdirSync(join(tempHome, ".cycling-coach"), { recursive: true });
+  origStdinTTY = process.stdin.isTTY;
+  origStdoutTTY = process.stdout.isTTY;
+  Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+  Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
+  stderrWrites = [];
+  origStderrWrite = process.stderr.write.bind(process.stderr);
+  process.stderr.write = ((chunk: string | Uint8Array) => {
+    stderrWrites.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"));
+    return true;
+  }) as typeof process.stderr.write;
+  vi.resetModules();
+});
+
+afterEach(() => {
+  process.env.HOME = origHome;
+  Object.defineProperty(process.stdin, "isTTY", { value: origStdinTTY, configurable: true });
+  Object.defineProperty(process.stdout, "isTTY", { value: origStdoutTTY, configurable: true });
+  process.stderr.write = origStderrWrite;
+  rmSync(tempHome, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+const CONFIG = () => join(tempHome, ".cycling-coach", "config.yaml");
+
+function seedConfig(obj: Record<string, unknown>): void {
+  writeFileSync(CONFIG(), toYaml(obj), { mode: 0o600 });
+}
+
+function stderrAll(): string {
+  return stderrWrites.join("");
+}
+
+function mockDetect(factory: () => Record<string, unknown>): void {
+  vi.doMock("../src/secrets/backends/detect.js", () => ({
+    detectBackends: vi.fn(async () => factory()),
+  }));
+}
+
+// ============================================================================
+// PURE HELPERS
+// ============================================================================
+
+describe("_detectPrevBackend", () => {
+  it("returns plain for string values", async () => {
+    const { _detectPrevBackend } = await import("../src/setup.js");
+    expect(_detectPrevBackend("sk-plain")).toBe("plain");
+    expect(_detectPrevBackend("")).toBe("plain");
+  });
+
+  it("returns op for SecretRef with op command", async () => {
+    const { _detectPrevBackend } = await import("../src/setup.js");
+    expect(
+      _detectPrevBackend({
+        source: "exec",
+        command: "/usr/local/bin/op",
+        args: ["read", "op://Personal/x/credential"],
+      }),
+    ).toBe("op");
+    expect(
+      _detectPrevBackend({ source: "exec", command: "op", args: [] }),
+    ).toBe("op");
+  });
+
+  it("returns keychain for SecretRef with security command", async () => {
+    const { _detectPrevBackend } = await import("../src/setup.js");
+    expect(
+      _detectPrevBackend({
+        source: "exec",
+        command: "/usr/bin/security",
+        args: ["find-generic-password", "-w"],
+      }),
+    ).toBe("keychain");
+  });
+
+  it("returns plain for undefined", async () => {
+    const { _detectPrevBackend } = await import("../src/setup.js");
+    expect(_detectPrevBackend(undefined)).toBe("plain");
+  });
+
+  it("returns unknown for SecretRef with other commands (custom wrappers)", async () => {
+    const { _detectPrevBackend } = await import("../src/setup.js");
+    expect(
+      _detectPrevBackend({
+        source: "exec",
+        command: "/usr/local/bin/vault",
+        args: ["kv", "get"],
+      }),
+    ).toBe("unknown");
+  });
+});
+
+describe("_formatOrphanCleanup", () => {
+  it("returns empty string when no entries", async () => {
+    const { _formatOrphanCleanup } = await import("../src/setup.js");
+    expect(_formatOrphanCleanup({ createdThisRun: [] })).toBe("");
+  });
+
+  it("lists op item delete commands for op orphans", async () => {
+    const { _formatOrphanCleanup } = await import("../src/setup.js");
+    const out = _formatOrphanCleanup({
+      createdThisRun: [
+        {
+          backend: "op",
+          field: "llm.api_key",
+          title: "cycling-coach · llm_api_key",
+          vaultName: "Personal",
+          opAbsPath: "/usr/local/bin/op",
+          preExistedBeforeWizard: false,
+        },
+      ],
+    });
+    expect(out).toContain('op item delete "cycling-coach · llm_api_key" --vault "Personal"');
+  });
+
+  it("lists security delete commands for keychain orphans", async () => {
+    const { _formatOrphanCleanup } = await import("../src/setup.js");
+    const out = _formatOrphanCleanup({
+      createdThisRun: [
+        {
+          backend: "keychain",
+          field: "llm.api_key",
+          title: "llm_api_key",
+          keychainPath: "/Users/x/Library/Keychains/login.keychain-db",
+          preExistedBeforeWizard: false,
+        },
+      ],
+    });
+    expect(out).toContain(
+      'security delete-generic-password -s cycling-coach -a "llm_api_key" "/Users/x/Library/Keychains/login.keychain-db"',
+    );
+  });
+
+  it("excludes pre-existing items from cleanup output", async () => {
+    const { _formatOrphanCleanup } = await import("../src/setup.js");
+    const out = _formatOrphanCleanup({
+      createdThisRun: [
+        {
+          backend: "op",
+          field: "llm.api_key",
+          title: "pre-existing",
+          vaultName: "Personal",
+          opAbsPath: "/usr/local/bin/op",
+          preExistedBeforeWizard: true,
+        },
+        {
+          backend: "op",
+          field: "intervals.api_key",
+          title: "new-this-run",
+          vaultName: "Personal",
+          opAbsPath: "/usr/local/bin/op",
+          preExistedBeforeWizard: false,
+        },
+      ],
+    });
+    expect(out).not.toContain("pre-existing");
+    expect(out).toContain("new-this-run");
+  });
+});
+
+describe("_createSignalHandler", () => {
+  it("SIGINT handler prints orphan cleanup and exits 130", async () => {
+    const { _createSignalHandler } = await import("../src/setup.js");
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`__exit_${code}`);
+    }) as never);
+    const handler = _createSignalHandler(
+      {
+        createdThisRun: [
+          {
+            backend: "op",
+            field: "llm.api_key",
+            title: "orphan",
+            vaultName: "Personal",
+            opAbsPath: "/usr/local/bin/op",
+            preExistedBeforeWizard: false,
+          },
+        ],
+      },
+      "SIGINT",
+    );
+    expect(() => handler()).toThrow("__exit_130");
+    expect(stderrAll()).toContain('op item delete "orphan" --vault "Personal"');
+    exitSpy.mockRestore();
+  });
+
+  it("SIGTERM handler prints orphan cleanup and exits 143", async () => {
+    const { _createSignalHandler } = await import("../src/setup.js");
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`__exit_${code}`);
+    }) as never);
+    const handler = _createSignalHandler(
+      {
+        createdThisRun: [
+          {
+            backend: "keychain",
+            field: "llm.api_key",
+            title: "kc_orphan",
+            keychainPath: "/tmp/test.keychain-db",
+            preExistedBeforeWizard: false,
+          },
+        ],
+      },
+      "SIGTERM",
+    );
+    expect(() => handler()).toThrow("__exit_143");
+    expect(stderrAll()).toContain("kc_orphan");
+    exitSpy.mockRestore();
+  });
+
+  it("handler with empty ctx prints no orphan preamble and exits", async () => {
+    const { _createSignalHandler } = await import("../src/setup.js");
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`__exit_${code}`);
+    }) as never);
+    const handler = _createSignalHandler({ createdThisRun: [] }, "SIGINT");
+    expect(() => handler()).toThrow("__exit_130");
+    expect(stderrAll()).toBe("");
+    exitSpy.mockRestore();
+  });
+
+  it("handler with only pre-existing entries prints no preamble", async () => {
+    const { _createSignalHandler } = await import("../src/setup.js");
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`__exit_${code}`);
+    }) as never);
+    const handler = _createSignalHandler(
+      {
+        createdThisRun: [
+          {
+            backend: "op",
+            field: "llm.api_key",
+            title: "pre-existing",
+            vaultName: "Personal",
+            opAbsPath: "/usr/local/bin/op",
+            preExistedBeforeWizard: true,
+          },
+        ],
+      },
+      "SIGINT",
+    );
+    expect(() => handler()).toThrow("__exit_130");
+    expect(stderrAll()).not.toContain("pre-existing");
+    exitSpy.mockRestore();
+  });
+});
+
+describe("process.once signal registration (double-Ctrl+C safety)", () => {
+  it("registered handler fires at most once via process.once", async () => {
+    const { _createSignalHandler } = await import("../src/setup.js");
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`__exit_${code}`);
+    }) as never);
+    const handler = vi.fn(
+      _createSignalHandler({ createdThisRun: [] }, "SIGINT"),
+    );
+    process.once("SIGINT", handler);
+    try {
+      expect(() => process.emit("SIGINT")).toThrow("__exit_130");
+    } finally {
+      // Clean up — guard against Node's default handler firing on the second
+      // emit by removing any residual listener immediately.
+      process.removeAllListeners("SIGINT");
+    }
+    expect(handler).toHaveBeenCalledTimes(1);
+    exitSpy.mockRestore();
+  });
+});
+
+// ============================================================================
+// TTY GUARD (D14)
+// ============================================================================
+
+describe("TTY guard (D14)", () => {
+  it("non-TTY invocation → exit 2 with single-line stderr message and no FS/spawn", async () => {
+    Object.defineProperty(process.stdin, "isTTY", { value: false, configurable: true });
+    Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
+    mockDetect(() => {
+      throw new Error("detectBackends should NOT be called before TTY guard");
+    });
+    vi.doMock("@clack/prompts", () =>
+      scriptedPrompts({ selects: [], passwords: [], texts: [], confirms: [] }),
+    );
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`__exit_${code}`);
+    }) as never);
+    const { runSetup } = await import("../src/setup.js");
+    await expect(runSetup()).rejects.toThrow("__exit_2");
+    expect(stderrAll()).toContain("interactive TTY");
+    expect(existsSync(CONFIG())).toBe(false);
+    exitSpy.mockRestore();
+  });
+});
+
+// ============================================================================
+// D19 trim + D17 size cap
+// ============================================================================
+
+describe("D19 trim + D17 size cap on secret inputs", () => {
+  it("_processSecretInput trims leading/trailing whitespace and logs INFO", async () => {
+    // vi.doMock applies to subsequent import — re-mock clack so log.info is observable
+    const infoSpy = vi.fn();
+    vi.doMock("@clack/prompts", () => ({
+      intro: vi.fn(),
+      outro: vi.fn(),
+      cancel: vi.fn(),
+      log: { info: infoSpy, success: vi.fn(), error: vi.fn() },
+      note: vi.fn(),
+      isCancel: () => false,
+      select: vi.fn(),
+      password: vi.fn(),
+      text: vi.fn(),
+      confirm: vi.fn(),
+    }));
+    const { _processSecretInput } = await import("../src/setup.js");
+    expect(_processSecretInput("  sk-abc\n", "llm.api_key")).toBe("sk-abc");
+    expect(infoSpy).toHaveBeenCalledWith(expect.stringContaining("Trimmed whitespace"));
+  });
+
+  it("_processSecretInput does NOT log when value is already trimmed", async () => {
+    const infoSpy = vi.fn();
+    vi.doMock("@clack/prompts", () => ({
+      intro: vi.fn(),
+      outro: vi.fn(),
+      cancel: vi.fn(),
+      log: { info: infoSpy, success: vi.fn(), error: vi.fn() },
+      note: vi.fn(),
+      isCancel: () => false,
+      select: vi.fn(),
+      password: vi.fn(),
+      text: vi.fn(),
+      confirm: vi.fn(),
+    }));
+    const { _processSecretInput } = await import("../src/setup.js");
+    expect(_processSecretInput("sk-abc", "llm.api_key")).toBe("sk-abc");
+    expect(infoSpy).not.toHaveBeenCalled();
+  });
+
+  it("_processSecretInput throws SecretTooLargeError on 65_537-byte input after trim", async () => {
+    vi.doMock("@clack/prompts", () => ({
+      intro: vi.fn(),
+      outro: vi.fn(),
+      cancel: vi.fn(),
+      log: { info: vi.fn(), success: vi.fn(), error: vi.fn() },
+      note: vi.fn(),
+      isCancel: () => false,
+      select: vi.fn(),
+      password: vi.fn(),
+      text: vi.fn(),
+      confirm: vi.fn(),
+    }));
+    const { _processSecretInput } = await import("../src/setup.js");
+    const { SecretTooLargeError } = await import("../src/secrets/backends/op.js");
+    const oversize = "x".repeat(65_537);
+    expect(() => _processSecretInput(oversize, "llm.api_key")).toThrow(SecretTooLargeError);
+  });
+
+  it("trim + size cap: trailing whitespace doesn't push content over size cap", async () => {
+    vi.doMock("@clack/prompts", () => ({
+      intro: vi.fn(),
+      outro: vi.fn(),
+      cancel: vi.fn(),
+      log: { info: vi.fn(), success: vi.fn(), error: vi.fn() },
+      note: vi.fn(),
+      isCancel: () => false,
+      select: vi.fn(),
+      password: vi.fn(),
+      text: vi.fn(),
+      confirm: vi.fn(),
+    }));
+    const { _processSecretInput } = await import("../src/setup.js");
+    const raw = "sk-abc" + " ".repeat(100_000);
+    expect(_processSecretInput(raw, "llm.api_key")).toBe("sk-abc");
+  });
+});
+
+// ============================================================================
+// BACKEND AVAILABILITY — options filtered by detectBackends
+// ============================================================================
+
+describe("backend availability filtering", () => {
+  it("op unavailable hides the 1Password option from the backend select", async () => {
+    seedConfig({
+      llm: { provider: "anthropic", model: "claude-sonnet-4-6", api_key: "sk-existing" },
+    });
+    const optionsCaptured: unknown[] = [];
+    vi.doMock("@clack/prompts", () => {
+      const selects = ["anthropic", "claude-sonnet-4-6", "plain"];
+      let s = 0;
+      return {
+        intro: vi.fn(),
+        outro: vi.fn(),
+        cancel: vi.fn(),
+        log: { info: vi.fn(), success: vi.fn(), error: vi.fn() },
+        note: vi.fn(),
+        isCancel: () => false,
+        select: vi.fn(async (opts: { options: unknown[] }) => {
+          optionsCaptured.push(opts.options);
+          return selects[s++];
+        }),
+        password: vi.fn(async () => ""),
+        text: vi.fn(),
+        confirm: vi.fn(async () => true),
+      };
+    });
+    mockDetect(() => ({
+      op: { state: "unavailable", reason: "not-on-path" },
+      keychain: { available: true },
+    }));
+    const { runSetup } = await import("../src/setup.js");
+    await runSetup();
+
+    // options at index 2 = backend select; should have plain + keychain only
+    const backendOpts = optionsCaptured[2] as Array<{ value: string }>;
+    const values = backendOpts.map((o) => o.value);
+    expect(values).toContain("plain");
+    expect(values).toContain("keychain");
+    expect(values).not.toContain("op");
+    expect(values).not.toContain("op-signin");
+  });
+
+  it("keychain unavailable on non-Darwin hides the Keychain option", async () => {
+    seedConfig({
+      llm: { provider: "anthropic", model: "claude-sonnet-4-6", api_key: "sk-existing" },
+    });
+    const optionsCaptured: unknown[] = [];
+    vi.doMock("@clack/prompts", () => {
+      const selects = ["anthropic", "claude-sonnet-4-6", "plain"];
+      let s = 0;
+      return {
+        intro: vi.fn(),
+        outro: vi.fn(),
+        cancel: vi.fn(),
+        log: { info: vi.fn(), success: vi.fn(), error: vi.fn() },
+        note: vi.fn(),
+        isCancel: () => false,
+        select: vi.fn(async (opts: { options: unknown[] }) => {
+          optionsCaptured.push(opts.options);
+          return selects[s++];
+        }),
+        password: vi.fn(async () => ""),
+        text: vi.fn(),
+        confirm: vi.fn(async () => true),
+      };
+    });
+    mockDetect(() => ({
+      op: { state: "unavailable", reason: "not-on-path" },
+      keychain: { available: false },
+    }));
+    const { runSetup } = await import("../src/setup.js");
+    await runSetup();
+
+    const backendOpts = optionsCaptured[2] as Array<{ value: string }>;
+    const values = backendOpts.map((o) => o.value);
+    expect(values).toEqual(["plain"]);
+  });
+});
+
+// ============================================================================
+// KEYCHAIN BACKEND — idempotency
+// ============================================================================
+
+describe("Keychain backend", () => {
+  it("idempotency: seeded keychain SecretRef + Enter-keep → YAML bytes unchanged, no upsert", async () => {
+    seedConfig({
+      llm: {
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+        api_key: {
+          source: "exec",
+          command: "/usr/bin/security",
+          args: [
+            "find-generic-password",
+            "-w",
+            "-s",
+            "cycling-coach",
+            "-a",
+            "llm_api_key",
+            "/tmp/login.keychain-db",
+          ],
+        },
+      },
+    });
+    const before = readFileSync(CONFIG(), "utf-8");
+    vi.doMock("@clack/prompts", () =>
+      scriptedPrompts({
+        selects: ["anthropic", "claude-sonnet-4-6", "keychain"],
+        passwords: ["", "", ""], // llm, intervals, telegram all Enter-keep
+        texts: [],
+        confirms: [true],
+      }),
+    );
+    mockDetect(() => ({
+      op: { state: "unavailable", reason: "not-on-path" },
+      keychain: { available: true },
+    }));
+    const upsertSpy = vi.fn();
+    vi.doMock("../src/secrets/backends/keychain.js", () => ({
+      keychainLoginPath: vi.fn(async () => "/tmp/login.keychain-db"),
+      keychainItemExists: vi.fn(async () => true),
+      keychainItemUpsert: upsertSpy,
+      keychainItemDelete: vi.fn(async () => ({ deleted: true })),
+      keychainSecretRef: vi.fn((field: string, path: string) => ({
+        source: "exec",
+        command: "/usr/bin/security",
+        args: ["find-generic-password", "-w", "-s", "cycling-coach", "-a", field, path],
+      })),
+      KeychainUnsafeValueError: class extends Error {},
+    }));
+    const { runSetup } = await import("../src/setup.js");
+    await runSetup();
+    const after = readFileSync(CONFIG(), "utf-8");
+    const beforeParsed = parseYaml(before);
+    const afterParsed = parseYaml(after);
+    expect(afterParsed).toEqual(beforeParsed);
+    expect(upsertSpy).not.toHaveBeenCalled();
+  });
+});
+
+// ============================================================================
+// 1PASSWORD BACKEND — idempotency + multi-vault fallback + needs-signin
+// ============================================================================
+
+describe("1Password backend", () => {
+  it("idempotency: seeded op SecretRef + Enter-keep + Keep-existing → no opItemUpdate call", async () => {
+    seedConfig({
+      llm: {
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+        api_key: {
+          source: "exec",
+          command: "/usr/local/bin/op",
+          args: ["read", "op://Personal/cycling-coach · llm_api_key/credential"],
+        },
+      },
+    });
+    vi.doMock("@clack/prompts", () =>
+      scriptedPrompts({
+        selects: ["anthropic", "claude-sonnet-4-6", "op", "keep"],
+        passwords: ["", "", ""], // llm, intervals, telegram all Enter-keep
+        texts: [],
+        confirms: [true],
+      }),
+    );
+    mockDetect(() => ({
+      op: { state: "ready", absolutePath: "/usr/local/bin/op", signedInAs: "me@x.com" },
+      keychain: { available: false },
+    }));
+    const updateSpy = vi.fn();
+    vi.doMock("../src/secrets/backends/op.js", async () => {
+      const actual = await vi.importActual<Record<string, unknown>>(
+        "../src/secrets/backends/op.js",
+      );
+      return {
+        ...actual,
+        opItemGet: vi.fn(async () => ({ exists: true, vaultName: "Personal" })),
+        opItemUpdate: updateSpy,
+        opItemCreate: vi.fn(),
+        opItemDelete: vi.fn(async () => ({ deleted: true })),
+        opVaultList: vi.fn(async () => []),
+      };
+    });
+    const { runSetup } = await import("../src/setup.js");
+    // Note: Enter-keep on llm triggers the "same backend, keep as-is" fast-path —
+    // no opItemGet call either.
+    await runSetup();
+    expect(updateSpy).not.toHaveBeenCalled();
+    const after = parseYaml(readFileSync(CONFIG(), "utf-8"));
+    expect(after).toMatchObject({
+      llm: {
+        api_key: {
+          source: "exec",
+          command: "/usr/local/bin/op",
+          args: ["read", "op://Personal/cycling-coach · llm_api_key/credential"],
+        },
+      },
+    });
+  });
+
+  it("multi-vault fallback: OpVaultAmbiguousError → opVaultList → user picks → retry succeeds + caches vault", async () => {
+    vi.doMock("@clack/prompts", () =>
+      scriptedPrompts({
+        selects: ["anthropic", "claude-sonnet-4-6", "op", "Personal"], // provider, model, backend, vault pick
+        passwords: ["sk-first", "", ""], // llm typed, intervals/telegram Enter-skip
+        texts: [],
+        confirms: [], // no prev config → no update confirm
+      }),
+    );
+    mockDetect(() => ({
+      op: { state: "ready", absolutePath: "/usr/local/bin/op", signedInAs: "me@x.com" },
+      keychain: { available: false },
+    }));
+    let createCalls = 0;
+    const createSpy = vi.fn(async (_opPath: string, _title: string, _value: string, vault?: string) => {
+      createCalls++;
+      if (createCalls === 1 && vault === undefined) {
+        const err = new (await import("../src/secrets/backends/op.js")).OpVaultAmbiguousError(
+          "more than one vault",
+        );
+        throw err;
+      }
+      return { vaultName: vault ?? "Personal" };
+    });
+    vi.doMock("../src/secrets/backends/op.js", async () => {
+      const actual = await vi.importActual<Record<string, unknown>>(
+        "../src/secrets/backends/op.js",
+      );
+      return {
+        ...actual,
+        opItemGet: vi.fn(async () => ({ exists: false })),
+        opItemCreate: createSpy,
+        opItemUpdate: vi.fn(),
+        opItemDelete: vi.fn(),
+        opVaultList: vi.fn(async () => [
+          { id: "v1", name: "Personal" },
+          { id: "v2", name: "Team" },
+          { id: "v3", name: "Shared" },
+        ]),
+      };
+    });
+    const { runSetup } = await import("../src/setup.js");
+    await runSetup();
+    expect(createCalls).toBe(2);
+    const after = parseYaml(readFileSync(CONFIG(), "utf-8"));
+    expect(after.llm.api_key.args).toEqual([
+      "read",
+      "op://Personal/cycling-coach · llm_api_key/credential",
+    ]);
+  });
+
+  it("needs-signin → op signin succeeds → re-detect ready → continues into op branch", async () => {
+    let detectCalls = 0;
+    vi.doMock("../src/secrets/backends/detect.js", () => ({
+      detectBackends: vi.fn(async () => {
+        detectCalls++;
+        if (detectCalls === 1) {
+          return {
+            op: { state: "needs-signin", absolutePath: "/usr/local/bin/op" },
+            keychain: { available: false },
+          };
+        }
+        return {
+          op: { state: "ready", absolutePath: "/usr/local/bin/op", signedInAs: "me@x.com" },
+          keychain: { available: false },
+        };
+      }),
+    }));
+    vi.doMock("node:child_process", () => ({
+      spawn: vi.fn(() => {
+        const listeners: Record<string, (code: number) => void> = {};
+        return {
+          on: (event: string, cb: (code: number) => void) => {
+            listeners[event] = cb;
+          },
+          emit: (event: string, code: number) => listeners[event]?.(code),
+          // fire 'close' with 0 immediately on next tick
+          _fire: () => setImmediate(() => listeners["close"]?.(0)),
+        };
+      }),
+    }));
+    // Because the child_process mock's spawn won't auto-emit, I need to
+    // patch the behavior differently. Instead, mock the OS "op signin" by
+    // pre-setting the second detectBackends call to "ready" and accepting
+    // that runOpSignin resolves to true. The simplest approach: replace
+    // child_process.spawn with a synchronous stub that emits close(0)
+    // asynchronously.
+    vi.doMock("node:child_process", () => ({
+      spawn: vi.fn(() => {
+        const listeners: Record<string, (code: number) => void> = {};
+        const emitter = {
+          on: (event: string, cb: (code: number) => void) => {
+            listeners[event] = cb;
+            if (event === "close") {
+              setImmediate(() => cb(0));
+            }
+          },
+        };
+        return emitter;
+      }),
+    }));
+    vi.doMock("@clack/prompts", () =>
+      scriptedPrompts({
+        selects: ["anthropic", "claude-sonnet-4-6", "op-signin"],
+        passwords: ["sk-first", "", ""],
+        texts: [],
+        confirms: [],
+      }),
+    );
+    vi.doMock("../src/secrets/backends/op.js", async () => {
+      const actual = await vi.importActual<Record<string, unknown>>(
+        "../src/secrets/backends/op.js",
+      );
+      return {
+        ...actual,
+        opItemGet: vi.fn(async () => ({ exists: false })),
+        opItemCreate: vi.fn(async () => ({ vaultName: "Personal" })),
+        opItemUpdate: vi.fn(),
+        opItemDelete: vi.fn(),
+        opVaultList: vi.fn(async () => []),
+      };
+    });
+    const { runSetup } = await import("../src/setup.js");
+    await runSetup();
+    const after = parseYaml(readFileSync(CONFIG(), "utf-8"));
+    expect(after.llm.api_key.command).toBe("/usr/local/bin/op");
+    expect(detectCalls).toBeGreaterThanOrEqual(2);
+  });
+
+  it("needs-signin → op signin fails → user picks plain instead (no crash)", async () => {
+    vi.doMock("../src/secrets/backends/detect.js", () => ({
+      detectBackends: vi.fn(async () => ({
+        op: { state: "needs-signin", absolutePath: "/usr/local/bin/op" },
+        keychain: { available: false },
+      })),
+    }));
+    vi.doMock("node:child_process", () => ({
+      spawn: vi.fn(() => {
+        const listeners: Record<string, (code: number) => void> = {};
+        const emitter = {
+          on: (event: string, cb: (code: number) => void) => {
+            listeners[event] = cb;
+            if (event === "close") {
+              setImmediate(() => cb(1));
+            }
+          },
+        };
+        return emitter;
+      }),
+    }));
+    vi.doMock("@clack/prompts", () =>
+      scriptedPrompts({
+        selects: ["anthropic", "claude-sonnet-4-6", "op-signin", "plain"], // retry → pick plain
+        passwords: ["sk-plain", "", ""],
+        texts: [],
+        confirms: [],
+      }),
+    );
+    const { runSetup } = await import("../src/setup.js");
+    await runSetup();
+    const after = parseYaml(readFileSync(CONFIG(), "utf-8"));
+    expect(after.llm.api_key).toBe("sk-plain");
+  });
+});
+
+// ============================================================================
+// D13 CROSS-BACKEND MIGRATION
+// ============================================================================
+
+describe("D13 cross-backend migration", () => {
+  it("plain → op, new value typed: YAML ends with SecretRef, no plain remnant", async () => {
+    seedConfig({
+      llm: { provider: "anthropic", model: "claude-sonnet-4-6", api_key: "sk-old-plain" },
+    });
+    vi.doMock("@clack/prompts", () =>
+      scriptedPrompts({
+        selects: ["anthropic", "claude-sonnet-4-6", "op"],
+        passwords: ["sk-new-op", "", ""],
+        texts: [],
+        confirms: [true],
+      }),
+    );
+    mockDetect(() => ({
+      op: { state: "ready", absolutePath: "/usr/local/bin/op", signedInAs: "me@x.com" },
+      keychain: { available: false },
+    }));
+    vi.doMock("../src/secrets/backends/op.js", async () => {
+      const actual = await vi.importActual<Record<string, unknown>>(
+        "../src/secrets/backends/op.js",
+      );
+      return {
+        ...actual,
+        opItemGet: vi.fn(async () => ({ exists: false })),
+        opItemCreate: vi.fn(async () => ({ vaultName: "Personal" })),
+        opItemUpdate: vi.fn(),
+        opItemDelete: vi.fn(),
+        opVaultList: vi.fn(async () => []),
+      };
+    });
+    const { runSetup } = await import("../src/setup.js");
+    await runSetup();
+    const after = parseYaml(readFileSync(CONFIG(), "utf-8"));
+    expect(typeof after.llm.api_key).toBe("object");
+    expect(after.llm.api_key.source).toBe("exec");
+    expect(after.llm.api_key.command).toBe("/usr/local/bin/op");
+  });
+
+  it("plain → op, Enter-keep: D13 prompt shows [Paste|Keep] → user picks Keep → YAML unchanged", async () => {
+    seedConfig({
+      llm: { provider: "anthropic", model: "claude-sonnet-4-6", api_key: "sk-old-plain" },
+    });
+    const before = readFileSync(CONFIG(), "utf-8");
+    vi.doMock("@clack/prompts", () =>
+      scriptedPrompts({
+        selects: ["anthropic", "claude-sonnet-4-6", "op", "keep"], // provider, model, backend, migration pick
+        passwords: ["", "", ""],
+        texts: [],
+        confirms: [true],
+      }),
+    );
+    mockDetect(() => ({
+      op: { state: "ready", absolutePath: "/usr/local/bin/op", signedInAs: "me@x.com" },
+      keychain: { available: false },
+    }));
+    const createSpy = vi.fn();
+    vi.doMock("../src/secrets/backends/op.js", async () => {
+      const actual = await vi.importActual<Record<string, unknown>>(
+        "../src/secrets/backends/op.js",
+      );
+      return {
+        ...actual,
+        opItemGet: vi.fn(async () => ({ exists: false })),
+        opItemCreate: createSpy,
+        opItemUpdate: vi.fn(),
+        opItemDelete: vi.fn(),
+        opVaultList: vi.fn(async () => []),
+      };
+    });
+    const { runSetup } = await import("../src/setup.js");
+    await runSetup();
+    const after = readFileSync(CONFIG(), "utf-8");
+    expect(parseYaml(after)).toEqual(parseYaml(before));
+    expect(createSpy).not.toHaveBeenCalled();
+  });
+
+  it("op → keychain, Enter-keep: D13 prompt → Keep → YAML unchanged, no upsert", async () => {
+    seedConfig({
+      llm: {
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+        api_key: {
+          source: "exec",
+          command: "/usr/local/bin/op",
+          args: ["read", "op://Personal/x/credential"],
+        },
+      },
+    });
+    const before = readFileSync(CONFIG(), "utf-8");
+    vi.doMock("@clack/prompts", () =>
+      scriptedPrompts({
+        selects: ["anthropic", "claude-sonnet-4-6", "keychain", "keep"],
+        passwords: ["", "", ""],
+        texts: [],
+        confirms: [true],
+      }),
+    );
+    mockDetect(() => ({
+      op: { state: "ready", absolutePath: "/usr/local/bin/op", signedInAs: "me@x.com" },
+      keychain: { available: true },
+    }));
+    const upsertSpy = vi.fn();
+    vi.doMock("../src/secrets/backends/keychain.js", () => ({
+      keychainLoginPath: vi.fn(async () => "/tmp/login.keychain-db"),
+      keychainItemExists: vi.fn(async () => false),
+      keychainItemUpsert: upsertSpy,
+      keychainItemDelete: vi.fn(),
+      keychainSecretRef: vi.fn(),
+      KeychainUnsafeValueError: class extends Error {},
+    }));
+    const { runSetup } = await import("../src/setup.js");
+    await runSetup();
+    expect(parseYaml(readFileSync(CONFIG(), "utf-8"))).toEqual(parseYaml(before));
+    expect(upsertSpy).not.toHaveBeenCalled();
+  });
+
+  it("op → plain, new value typed: resulting YAML has plain string, op item NOT deleted", async () => {
+    seedConfig({
+      llm: {
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+        api_key: {
+          source: "exec",
+          command: "/usr/local/bin/op",
+          args: ["read", "op://Personal/x/credential"],
+        },
+      },
+    });
+    vi.doMock("@clack/prompts", () =>
+      scriptedPrompts({
+        selects: ["anthropic", "claude-sonnet-4-6", "plain"],
+        passwords: ["sk-new-plain", "", ""],
+        texts: [],
+        confirms: [true],
+      }),
+    );
+    mockDetect(() => ({
+      op: { state: "unavailable", reason: "not-on-path" },
+      keychain: { available: false },
+    }));
+    const deleteSpy = vi.fn();
+    vi.doMock("../src/secrets/backends/op.js", async () => {
+      const actual = await vi.importActual<Record<string, unknown>>(
+        "../src/secrets/backends/op.js",
+      );
+      return {
+        ...actual,
+        opItemGet: vi.fn(),
+        opItemCreate: vi.fn(),
+        opItemUpdate: vi.fn(),
+        opItemDelete: deleteSpy,
+        opVaultList: vi.fn(),
+      };
+    });
+    const { runSetup } = await import("../src/setup.js");
+    await runSetup();
+    const after = parseYaml(readFileSync(CONFIG(), "utf-8"));
+    expect(after.llm.api_key).toBe("sk-new-plain");
+    expect(deleteSpy).not.toHaveBeenCalled();
+  });
+
+  it("invariant: no cross-backend reads — resolveSecretRef is NEVER called from the wizard", async () => {
+    seedConfig({
+      llm: {
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+        api_key: {
+          source: "exec",
+          command: "/usr/local/bin/op",
+          args: ["read", "op://Personal/x/credential"],
+        },
+      },
+    });
+    const resolveSpy = vi.fn();
+    vi.doMock("../src/secrets/resolve.js", () => ({
+      resolveSecretRef: resolveSpy,
+      _resolveSecretRefWithOverrides: resolveSpy,
+    }));
+    vi.doMock("@clack/prompts", () =>
+      scriptedPrompts({
+        selects: ["anthropic", "claude-sonnet-4-6", "keychain", "keep"],
+        passwords: ["", "", ""],
+        texts: [],
+        confirms: [true],
+      }),
+    );
+    mockDetect(() => ({
+      op: { state: "ready", absolutePath: "/usr/local/bin/op", signedInAs: "me@x.com" },
+      keychain: { available: true },
+    }));
+    vi.doMock("../src/secrets/backends/keychain.js", () => ({
+      keychainLoginPath: vi.fn(async () => "/tmp/login.keychain-db"),
+      keychainItemExists: vi.fn(async () => false),
+      keychainItemUpsert: vi.fn(),
+      keychainItemDelete: vi.fn(),
+      keychainSecretRef: vi.fn(),
+      KeychainUnsafeValueError: class extends Error {},
+    }));
+    const { runSetup } = await import("../src/setup.js");
+    await runSetup();
+    expect(resolveSpy).not.toHaveBeenCalled();
+  });
+});
+
+// ============================================================================
+// D11 GUARDED CLEANUP
+// ============================================================================
+
+describe("D11 guarded cleanup on mid-wizard failure", () => {
+  it("accept-cleanup: 2 created + 3rd fails → user accepts → both prior items deleted", async () => {
+    vi.doMock("@clack/prompts", () =>
+      scriptedPrompts({
+        selects: ["anthropic", "claude-sonnet-4-6", "op"],
+        passwords: ["sk-1", "sk-2", "sk-3"],
+        texts: [],
+        confirms: [true], // accept cleanup
+      }),
+    );
+    mockDetect(() => ({
+      op: { state: "ready", absolutePath: "/usr/local/bin/op", signedInAs: "me@x.com" },
+      keychain: { available: false },
+    }));
+    let createCalls = 0;
+    const deleteSpy = vi.fn(async () => ({ deleted: true }));
+    vi.doMock("../src/secrets/backends/op.js", async () => {
+      const actual = await vi.importActual<Record<string, unknown>>(
+        "../src/secrets/backends/op.js",
+      );
+      return {
+        ...actual,
+        opItemGet: vi.fn(async () => ({ exists: false })),
+        opItemCreate: vi.fn(async (_opPath: string, _title: string) => {
+          createCalls++;
+          if (createCalls === 3) throw new Error("boom — third secret write failed");
+          return { vaultName: "Personal" };
+        }),
+        opItemUpdate: vi.fn(),
+        opItemDelete: deleteSpy,
+        opVaultList: vi.fn(async () => []),
+      };
+    });
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`__exit_${code}`);
+    }) as never);
+    const { runSetup } = await import("../src/setup.js");
+    await expect(runSetup()).rejects.toThrow("__exit_1");
+    expect(deleteSpy).toHaveBeenCalledTimes(2);
+    expect(existsSync(CONFIG())).toBe(false); // YAML untouched
+    exitSpy.mockRestore();
+  });
+
+  it("decline-cleanup: user says No → no opItemDelete, manual commands printed", async () => {
+    vi.doMock("@clack/prompts", () =>
+      scriptedPrompts({
+        selects: ["anthropic", "claude-sonnet-4-6", "op"],
+        passwords: ["sk-1", "sk-2", "sk-3"],
+        texts: [],
+        confirms: [false], // decline cleanup
+      }),
+    );
+    mockDetect(() => ({
+      op: { state: "ready", absolutePath: "/usr/local/bin/op", signedInAs: "me@x.com" },
+      keychain: { available: false },
+    }));
+    let createCalls = 0;
+    const deleteSpy = vi.fn();
+    vi.doMock("../src/secrets/backends/op.js", async () => {
+      const actual = await vi.importActual<Record<string, unknown>>(
+        "../src/secrets/backends/op.js",
+      );
+      return {
+        ...actual,
+        opItemGet: vi.fn(async () => ({ exists: false })),
+        opItemCreate: vi.fn(async () => {
+          createCalls++;
+          if (createCalls === 3) throw new Error("boom");
+          return { vaultName: "Personal" };
+        }),
+        opItemUpdate: vi.fn(),
+        opItemDelete: deleteSpy,
+        opVaultList: vi.fn(async () => []),
+      };
+    });
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`__exit_${code}`);
+    }) as never);
+    const { runSetup } = await import("../src/setup.js");
+    await expect(runSetup()).rejects.toThrow("__exit_1");
+    expect(deleteSpy).not.toHaveBeenCalled();
+    expect(stderrAll()).toContain("op item delete");
+    exitSpy.mockRestore();
+  });
+
+  it("pre-existence guard: a pre-existing updated item is NOT offered for deletion", async () => {
+    seedConfig({
+      llm: {
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+        api_key: {
+          source: "exec",
+          command: "/usr/local/bin/op",
+          args: ["read", "op://Personal/cycling-coach · llm_api_key/credential"],
+        },
+      },
+    });
+    vi.doMock("@clack/prompts", () =>
+      scriptedPrompts({
+        selects: ["anthropic", "claude-sonnet-4-6", "op", "update"], // provider, model, backend, action-on-existing
+        passwords: ["sk-updated-llm", "sk-new-intervals", "sk-telegram-fail"],
+        texts: ["42"], // intervals athlete id
+        confirms: [true], // accept cleanup
+      }),
+    );
+    mockDetect(() => ({
+      op: { state: "ready", absolutePath: "/usr/local/bin/op", signedInAs: "me@x.com" },
+      keychain: { available: false },
+    }));
+    const deleteSpy = vi.fn(async () => ({ deleted: true }));
+    let createCalls = 0;
+    vi.doMock("../src/secrets/backends/op.js", async () => {
+      const actual = await vi.importActual<Record<string, unknown>>(
+        "../src/secrets/backends/op.js",
+      );
+      return {
+        ...actual,
+        opItemGet: vi.fn(async (_opPath: string, title: string) => {
+          if (title === "cycling-coach · llm_api_key") {
+            return { exists: true, vaultName: "Personal" };
+          }
+          return { exists: false };
+        }),
+        opItemUpdate: vi.fn(),
+        opItemCreate: vi.fn(async () => {
+          createCalls++;
+          if (createCalls === 2) throw new Error("telegram boom");
+          return { vaultName: "Personal" };
+        }),
+        opItemDelete: deleteSpy,
+        opVaultList: vi.fn(async () => []),
+      };
+    });
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`__exit_${code}`);
+    }) as never);
+    const { runSetup } = await import("../src/setup.js");
+    await expect(runSetup()).rejects.toThrow("__exit_1");
+    // Only the NEW intervals item should be deleted; the LLM one pre-existed.
+    expect(deleteSpy).toHaveBeenCalledTimes(1);
+    const firstDeleteArgs = deleteSpy.mock.calls[0];
+    expect(firstDeleteArgs[1]).toBe("cycling-coach · intervals_api_key");
+    exitSpy.mockRestore();
+  });
+
+  it("best-effort: first delete fails with auth error, second still attempted", async () => {
+    vi.doMock("@clack/prompts", () =>
+      scriptedPrompts({
+        selects: ["anthropic", "claude-sonnet-4-6", "op"],
+        passwords: ["sk-1", "sk-2", "sk-3"],
+        texts: [],
+        confirms: [true],
+      }),
+    );
+    mockDetect(() => ({
+      op: { state: "ready", absolutePath: "/usr/local/bin/op", signedInAs: "me@x.com" },
+      keychain: { available: false },
+    }));
+    let createCalls = 0;
+    const deleteSpy = vi.fn(async (_opPath: string, title: string) => {
+      if (title === "cycling-coach · llm_api_key") {
+        throw new Error("auth failure deleting first");
+      }
+      return { deleted: true };
+    });
+    vi.doMock("../src/secrets/backends/op.js", async () => {
+      const actual = await vi.importActual<Record<string, unknown>>(
+        "../src/secrets/backends/op.js",
+      );
+      return {
+        ...actual,
+        opItemGet: vi.fn(async () => ({ exists: false })),
+        opItemCreate: vi.fn(async () => {
+          createCalls++;
+          if (createCalls === 3) throw new Error("third fails");
+          return { vaultName: "Personal" };
+        }),
+        opItemUpdate: vi.fn(),
+        opItemDelete: deleteSpy,
+        opVaultList: vi.fn(async () => []),
+      };
+    });
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`__exit_${code}`);
+    }) as never);
+    const { runSetup } = await import("../src/setup.js");
+    await expect(runSetup()).rejects.toThrow("__exit_1");
+    expect(deleteSpy).toHaveBeenCalledTimes(2); // both attempted
+    exitSpy.mockRestore();
+  });
+});
+
+// ============================================================================
+// SecretRef uses discovered vault (not hardcoded "Private")
+// ============================================================================
+
+describe("SecretRef uses discovered vault from opItemCreate", () => {
+  it("single-vault consumer account → YAML SecretRef reflects actual vault name (Personal)", async () => {
+    vi.doMock("@clack/prompts", () =>
+      scriptedPrompts({
+        selects: ["anthropic", "claude-sonnet-4-6", "op"],
+        passwords: ["sk-first", "", ""],
+        texts: [],
+        confirms: [],
+      }),
+    );
+    mockDetect(() => ({
+      op: { state: "ready", absolutePath: "/usr/local/bin/op", signedInAs: "me@x.com" },
+      keychain: { available: false },
+    }));
+    vi.doMock("../src/secrets/backends/op.js", async () => {
+      const actual = await vi.importActual<Record<string, unknown>>(
+        "../src/secrets/backends/op.js",
+      );
+      return {
+        ...actual,
+        opItemGet: vi.fn(async () => ({ exists: false })),
+        opItemCreate: vi.fn(async () => ({ vaultName: "Personal" })),
+        opItemUpdate: vi.fn(),
+        opItemDelete: vi.fn(),
+        opVaultList: vi.fn(async () => []),
+      };
+    });
+    const { runSetup } = await import("../src/setup.js");
+    await runSetup();
+    const after = parseYaml(readFileSync(CONFIG(), "utf-8"));
+    expect(after.llm.api_key.args[1]).toBe(
+      "op://Personal/cycling-coach · llm_api_key/credential",
+    );
+    expect(after.llm.api_key.args[1]).not.toContain("Private");
+  });
+});


### PR DESCRIPTION
## Summary

Implements the full SecretRef plan from `docs/battle-plan-secret-ref-exec.md` — both Release A (resolver at runtime) and Release B (wizard auto-creation).

**Release A — Waves 1–4: SecretRef resolver**
- Any secret field in `~/.cycling-coach/config.yaml` (`llm.api_key`, `intervals.api_key`, `telegram.bot_token`) can be a `{ source: "exec", command, args? }` object.
- Resolved at startup via `spawn(shell:false)` with a 30s timeout, 64KB output cap, and a single-trailing-newline trim. Fail-fast with one-line stderr errors and exit 1 on `ENOENT` / `EXIT_NONZERO` / `TIMEOUT` / `EMPTY` / `OVERFLOW` / `INVALID_REF`.
- Precedence: env var > SecretRef > plain YAML > `""`. Zero behavior change for users who don't use SecretRef.

**Release B — Waves 5–8: wizard auto-creation for 1Password + Keychain**
- Wave 5 — `src/secrets/backends/detect.ts`: 3-state `OpState` union (ready / needs-signin / unavailable{reason}) via `op account list` + `op vault list`, 2s per-tool timeout. Keychain on Darwin only.
- Wave 6 — `src/secrets/backends/op.ts`: create-then-discover single-spawn (`op item create --format=json`). Secret via stdin; argv stays clean. JSON-escape, 64 KB cap, redacted logs. `OpVaultAmbiguousError` triggers vault picker.
- Wave 7 — `src/secrets/backends/keychain.ts`: `security -i` stdin writes, pinned `login.keychain` path via `security login-keychain`.
- Wave 8 — `src/setup.ts`: TTY guard, SIGINT/SIGTERM handlers with orphan-cleanup commands, Update/Keep/Cancel re-run UX for 1Password, D13 `[Paste|Keep]` prompt on backend-mismatch + Enter-keep (no silent cross-backend reads), trim-on-paste with INFO log. Load→collect→backend-writes→YAML-last ordering preserved (AP-6 redux).

**Wave 9 — docs**
- README "Storing secrets outside config.yaml" section + 7-backend compatibility matrix (1Password, macOS Keychain, Bitwarden, Vault, AWS Secrets Manager, GCP Secret Manager, age) + headless/launchd caveats + non-interactive hand-edit path.
- README "Using the setup wizard with a password manager" section + four callouts: trim-on-paste (D19), single-terminal (Q11), login-keychain scope (D16), Ctrl+C orphan race (D15 residual).

## Test plan

- [x] `npm run check` — tsc + oxlint clean
- [x] `npm test` — 239 passing + 1 skipped (macOS-only keychain integration). Argv-leak-guard tests assert zero secret occurrences in argv for both backends.
- [x] Smoke: YAML with `{ command: printf, args: [sk-test] }` → startup log `Resolved secret: llm.api_key (exec: printf)`, bot enters CLI mode
- [x] Smoke: YAML with `command: definitely-not-a-real-binary-xyz` → stderr `Config error: Secret resolver command '…' not found. Is it installed and on $PATH? …`, exit code 1
- [ ] Smoke (manual, maintainer): fresh `~/.cycling-coach`, run wizard, pick 1Password → Touch ID on `op item create`, bot boots on next run with resolved vault path in SecretRef
- [ ] Smoke (manual): re-run wizard, Enter-keep every prompt → YAML unchanged, no new backend items created
- [ ] Smoke (manual): wizard + Ctrl+C after one secret is typed but before completion → stderr prints `op item delete "…"` cleanup command, exit code 130
- [ ] Smoke (manual): non-TTY invocation (`echo "" | cycling-coach setup`) → exit code 2, single-line stderr pointer, zero side effects