### PR TITLE
Remove VOLUME directive from Dockerfile (Railway compat)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,5 @@ RUN addgroup -S app && adduser -S -G app app \
     && chown -R app:app /data /app
 
 USER app
-VOLUME ["/data"]
 
 CMD ["node", "dist/index.js"]


### PR DESCRIPTION
## Summary

Railway's Metal builder rejects Dockerfiles containing the `VOLUME` directive — it wants all volume management to go through Railway Volumes (configured via the UI) rather than image-baked declarations. Build error from a fresh deploy attempt:

```
dockerfile invalid: docker VOLUME at Line 33 is not supported, use Railway Volumes
```

The `VOLUME` line was a soft hint anyway — it created an anonymous volume on `docker run` if no `-v` was passed, which is hard to discover and easy to lose. The README already tells users to mount a named volume explicitly (`-v cycling-coach-data:/data`), so removing it doesn't change the documented Docker workflow.

## Test plan

- [x] `docker build -t cycling-coach .` — succeeds locally
- [x] `docker run --env-file ... -v cycling-coach-data:/data cycling-coach` — bot starts and responds to /status (verified before this fix; behavior unchanged)
- [ ] Railway redeploy of `feat/cloud-deploy` follow-up succeeds past the snapshot/analyze phase