### PR TITLE
refactor: Core/Sport seam — Waves 1+2 of #47

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN npm ci
 
 COPY tsconfig.json ./
 COPY src ./src
+COPY packages ./packages
 RUN npm run build
 
 # ── runtime ────────────────────────────────────────────────────────────────

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "cycling-coach",
       "version": "2026.4.17",
       "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.69",
         "@ai-sdk/google": "^3.0.63",
@@ -876,30 +879,13 @@
         "sisteransi": "^1.0.5"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
+    "node_modules/@cycling-coach/core": {
+      "resolved": "packages/core",
+      "link": true
     },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
+    "node_modules/@cycling-coach/sport-cycling": {
+      "resolved": "packages/sport-cycling",
+      "link": true
     },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
@@ -4644,6 +4630,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@inquirer/confirm": "^5.0.0",
         "@mswjs/interceptors": "^0.41.2",
@@ -4992,6 +4979,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5455,6 +5443,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -5544,6 +5533,7 @@
       "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -5799,6 +5789,7 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -5856,6 +5847,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -5868,6 +5860,25 @@
       "peerDependencies": {
         "zod": "^3.25.28 || ^4"
       }
+    },
+    "packages/core": {
+      "name": "@cycling-coach/core",
+      "version": "0.0.0-private",
+      "license": "MIT",
+      "dependencies": {
+        "ai": "^6.0.158",
+        "intervals-icu-api": "^0.1.2",
+        "zod": "^4.3.6"
+      },
+      "devDependencies": {
+        "@types/node": "^25.6.0",
+        "typescript": "^6.0.2"
+      }
+    },
+    "packages/sport-cycling": {
+      "name": "@cycling-coach/sport-cycling",
+      "version": "0.0.0-private",
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,14 +15,15 @@
   "scripts": {
     "dev": "tsx --env-file=.env src/index.ts",
     "setup": "tsx --env-file=.env src/index.ts setup",
-    "build": "tsc",
+    "build:core": "tsc -p packages/core",
+    "build": "npm run build:core && tsc",
     "prepublishOnly": "npm run build",
     "test": "vitest run",
     "test:watch": "vitest",
     "lint": "oxlint src/ tests/",
     "fmt": "oxfmt src/ tests/",
     "fmt:check": "oxfmt --check src/ tests/",
-    "check": "tsc --noEmit && oxlint src/ tests/"
+    "check": "npm run build:core && tsc --noEmit && oxlint src/ tests/"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.69",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,9 @@
   "engines": {
     "node": ">=20"
   },
+  "workspaces": [
+    "packages/*"
+  ],
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,5 +4,20 @@
   "private": true,
   "description": "Sport-agnostic infrastructure for AI coaching agents (agent loop, memory, secrets, channels, LLM, intervals.icu). Publishes the Sport contract.",
   "type": "module",
-  "license": "MIT"
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "license": "MIT",
+  "scripts": {
+    "build": "tsc",
+    "check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "ai": "^6.0.158",
+    "intervals-icu-api": "^0.1.2",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.0",
+    "typescript": "^6.0.2"
+  }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@cycling-coach/core",
+  "version": "0.0.0-private",
+  "private": true,
+  "description": "Sport-agnostic infrastructure for AI coaching agents (agent loop, memory, secrets, channels, LLM, intervals.icu). Publishes the Sport contract.",
+  "type": "module",
+  "license": "MIT"
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -21,3 +21,9 @@ export type {
   SecretsResolver,
 } from "./secrets.js";
 export type { IntervalsClient } from "./intervals.js";
+
+export { CORE_SHARED_SECTIONS } from "./memory/shared-sections.js";
+export {
+  getEffectiveSections,
+  _resetWarnCacheForTesting,
+} from "./memory/effective-sections.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,0 +1,23 @@
+export type {
+  Binary,
+  CoreDeps,
+  IntervalsActivityType,
+  MemorySectionSpec,
+  Person,
+  RunBinaryArgs,
+  Sport,
+  SportId,
+  SportMemoryShape,
+  SportPersona,
+  ToolRegistration,
+} from "./sport.js";
+
+export type { GenerateOpts, GenerateResult, LLM } from "./llm.js";
+export type { MemorySnapshot, MemoryStore } from "./memory.js";
+export type {
+  EnvSecretRef,
+  ExecSecretRef,
+  SecretRef,
+  SecretsResolver,
+} from "./secrets.js";
+export type { IntervalsClient } from "./intervals.js";

--- a/packages/core/src/intervals.ts
+++ b/packages/core/src/intervals.ts
@@ -1,0 +1,6 @@
+/**
+ * intervals.icu client surface re-exported through Core so Sport packages
+ * import their dependency on intervals from `@cycling-coach/core` rather
+ * than depending on `intervals-icu-api` directly.
+ */
+export type { IntervalsClient } from "intervals-icu-api";

--- a/packages/core/src/llm.ts
+++ b/packages/core/src/llm.ts
@@ -1,0 +1,33 @@
+import type {
+  FinishReason,
+  LanguageModelUsage,
+  ModelMessage,
+  StopCondition,
+  ToolSet,
+} from "ai";
+
+export interface GenerateOpts {
+  system?: string;
+  messages?: ModelMessage[];
+  prompt?: string;
+  tools?: ToolSet;
+  stopWhen?: StopCondition<any> | Array<StopCondition<any>>;
+  maxSteps?: number;
+  maxOutputTokens?: number;
+}
+
+export interface GenerateResult {
+  text: string;
+  toolCalls: Array<{
+    type: "tool-call";
+    toolCallId: string;
+    toolName: string;
+    input: unknown;
+  }>;
+  finishReason: FinishReason;
+  usage: LanguageModelUsage;
+}
+
+export interface LLM {
+  generate(opts: GenerateOpts): Promise<GenerateResult>;
+}

--- a/packages/core/src/memory.ts
+++ b/packages/core/src/memory.ts
@@ -14,6 +14,9 @@ export interface MemoryStore {
   /** Replaces the named section's content; appends if section is missing. */
   writeSection(section: string, content: string): void;
 
+  /** Returns the named section's body, or null if file or section is absent. */
+  readSection(section: string): string | null;
+
   /**
    * Renames `from` section to `to`. Lossless:
    * - "renamed": `from` existed, `to` did not — header rewritten in place.

--- a/packages/core/src/memory.ts
+++ b/packages/core/src/memory.ts
@@ -1,0 +1,45 @@
+/**
+ * Sport-agnostic memory abstractions consumed by Core and Sports.
+ *
+ * `MemoryStore` is the writable surface tools and the agent loop use.
+ * `MemorySnapshot` is a read-only sectioned view passed to a Sport's
+ * `mustPreserveTokens` function so it can derive data-bound tokens
+ * (e.g. "FTP 247W") from current memory state.
+ */
+
+export interface MemoryStore {
+  /** Returns full MEMORY.md contents, or "" if absent. */
+  readMemory(): string;
+
+  /** Replaces the named section's content; appends if section is missing. */
+  writeSection(section: string, content: string): void;
+
+  /** Reads today's daily-notes file (or for `date` when supplied). */
+  readDailyNotes(date?: string): string;
+
+  /** Appends a note to today's daily-notes file. */
+  appendDailyNote(note: string, date?: string): void;
+
+  /** Persists the active training plan as JSON. */
+  savePlan(plan: unknown): void;
+
+  /** Loads the active training plan, or null if none. */
+  loadPlan(): unknown | null;
+
+  /** Sync point invoked after compaction or memory flush. */
+  reload(): void;
+
+  /** Composed string Core feeds into the system prompt's Athlete Context. */
+  getContext(): string;
+}
+
+export interface MemorySnapshot {
+  /** Returns section content, or null if section is empty/absent. */
+  read(sectionName: string): string | null;
+
+  /** True if the section exists and has non-empty content. */
+  has(sectionName: string): boolean;
+
+  /** All section names visible in this snapshot. */
+  listSections(): readonly string[];
+}

--- a/packages/core/src/memory.ts
+++ b/packages/core/src/memory.ts
@@ -14,6 +14,15 @@ export interface MemoryStore {
   /** Replaces the named section's content; appends if section is missing. */
   writeSection(section: string, content: string): void;
 
+  /**
+   * Renames `from` section to `to`. Lossless:
+   * - "renamed": `from` existed, `to` did not — header rewritten in place.
+   * - "noop":    file missing or `from` not present.
+   * - "merged":  both `from` and `to` exist — bodies concatenated under `to`,
+   *              `from` block removed.
+   */
+  renameSection(from: string, to: string): "renamed" | "noop" | "merged";
+
   /** Reads today's daily-notes file (or for `date` when supplied). */
   readDailyNotes(date?: string): string;
 

--- a/packages/core/src/memory/effective-sections.ts
+++ b/packages/core/src/memory/effective-sections.ts
@@ -1,34 +1,50 @@
 import type { MemorySectionSpec, Sport } from "../sport.js";
 import { CORE_SHARED_SECTIONS } from "./shared-sections.js";
 
-// Module-level cache: memoizes warn-once per (sport.id, section.name) pair
+// Module-level cache: memoizes warn-once per (sport.id, section.name, kind)
 // across the process lifetime. Without this, every createTools / memory_flush
-// call would re-fire the same transitional warnings. Process-scoped is correct
-// — the warning is about a code/config bug that won't change without a restart.
+// call would re-fire the same warnings. Process-scoped is correct — the
+// warning is about a code/config bug that won't change without a restart.
 const WARNED = new Set<string>();
+
+const CORE_NAMES: ReadonlySet<string> = new Set(CORE_SHARED_SECTIONS.map((s) => s.name));
+
+function warnOnce(key: string, message: string): void {
+  if (WARNED.has(key)) return;
+  WARNED.add(key);
+  console.warn(message);
+}
 
 /**
  * Composes Core's shared sections with a sport's declared sections,
  * deduplicated by name with Core-wins on collision (per ADR-0003).
- * A sport that mistakenly declares a Core-shared name silently gets
- * Core's spec rather than crashing in production; a console.warn fires
- * once per (sport.id, name) pair.
+ * Two distinct misuse warnings:
+ * - "core-collision": sport declares a Core-shared name → Core's spec wins
+ * - "self-dup": sport's array contains the same name twice → first wins
+ * Both fire once per (sport.id, name) pair via the module-level cache.
  */
 export function getEffectiveSections(sport: Sport): readonly MemorySectionSpec[] {
   const seen = new Map<string, MemorySectionSpec>();
   for (const spec of CORE_SHARED_SECTIONS) {
     seen.set(spec.name, spec);
   }
+  const sportNamesSeen = new Set<string>();
   for (const spec of sport.memorySections) {
-    if (seen.has(spec.name)) {
-      const key = `${sport.id}:${spec.name}`;
-      if (!WARNED.has(key)) {
-        WARNED.add(key);
-        console.warn(
-          `Sport "${sport.id}" declares section "${spec.name}" which is Core-shared; ` +
-            `using Core's spec. Remove from sport.memorySections to silence this warning.`,
-        );
-      }
+    if (sportNamesSeen.has(spec.name)) {
+      warnOnce(
+        `${sport.id}:${spec.name}:self-dup`,
+        `Sport "${sport.id}" declares section "${spec.name}" more than once in ` +
+          `memorySections; using the first occurrence.`,
+      );
+      continue;
+    }
+    sportNamesSeen.add(spec.name);
+    if (CORE_NAMES.has(spec.name)) {
+      warnOnce(
+        `${sport.id}:${spec.name}:core-collision`,
+        `Sport "${sport.id}" declares section "${spec.name}" which is Core-shared; ` +
+          `using Core's spec. Remove from sport.memorySections to silence this warning.`,
+      );
       continue;
     }
     seen.set(spec.name, spec);

--- a/packages/core/src/memory/effective-sections.ts
+++ b/packages/core/src/memory/effective-sections.ts
@@ -1,0 +1,42 @@
+import type { MemorySectionSpec, Sport } from "../sport.js";
+import { CORE_SHARED_SECTIONS } from "./shared-sections.js";
+
+// Module-level cache: memoizes warn-once per (sport.id, section.name) pair
+// across the process lifetime. Without this, every createTools / memory_flush
+// call would re-fire the same transitional warnings. Process-scoped is correct
+// — the warning is about a code/config bug that won't change without a restart.
+const WARNED = new Set<string>();
+
+/**
+ * Composes Core's shared sections with a sport's declared sections,
+ * deduplicated by name with Core-wins on collision (per ADR-0003).
+ * A sport that mistakenly declares a Core-shared name silently gets
+ * Core's spec rather than crashing in production; a console.warn fires
+ * once per (sport.id, name) pair.
+ */
+export function getEffectiveSections(sport: Sport): readonly MemorySectionSpec[] {
+  const seen = new Map<string, MemorySectionSpec>();
+  for (const spec of CORE_SHARED_SECTIONS) {
+    seen.set(spec.name, spec);
+  }
+  for (const spec of sport.memorySections) {
+    if (seen.has(spec.name)) {
+      const key = `${sport.id}:${spec.name}`;
+      if (!WARNED.has(key)) {
+        WARNED.add(key);
+        console.warn(
+          `Sport "${sport.id}" declares section "${spec.name}" which is Core-shared; ` +
+            `using Core's spec. Remove from sport.memorySections to silence this warning.`,
+        );
+      }
+      continue;
+    }
+    seen.set(spec.name, spec);
+  }
+  return Array.from(seen.values());
+}
+
+/** Test-only escape hatch — reset the warn cache between unit tests. */
+export function _resetWarnCacheForTesting(): void {
+  WARNED.clear();
+}

--- a/packages/core/src/memory/shared-sections.ts
+++ b/packages/core/src/memory/shared-sections.ts
@@ -1,0 +1,38 @@
+import type { MemorySectionSpec } from "../sport.js";
+
+/**
+ * The truly-universal sections that any endurance athlete carries
+ * regardless of sport. Sport packages declare additional sport-prefixed
+ * sections (e.g. cycling-profile, running-profile). Per ADR-0003.
+ */
+export const CORE_SHARED_SECTIONS: readonly MemorySectionSpec[] = [
+  {
+    name: "person",
+    description:
+      "Name, weight (kg), age, available training days per week. " +
+      "Sport-specific physiology (FTP, VDOT, max HR) goes to the sport-prefixed profile section.",
+  },
+  {
+    name: "schedule",
+    description: "Weekly training availability, time windows, blackout days",
+  },
+  {
+    name: "goals",
+    description:
+      "Target events, race dates, fitness targets, milestones " +
+      "(e.g., 'sub-3:30 century in October', 'reach 280W FTP by Q3')",
+  },
+  {
+    name: "preferences",
+    description: "Coaching style, training environment, communication preferences",
+  },
+  {
+    name: "notes",
+    description: "Anything else important not covered by other sections",
+  },
+  {
+    name: "medical-history",
+    description:
+      "Chronic conditions, medications, long-term injuries — facts that persist across sports",
+  },
+];

--- a/packages/core/src/secrets.ts
+++ b/packages/core/src/secrets.ts
@@ -1,0 +1,12 @@
+/**
+ * Sport-agnostic secrets resolution. Sports receive a `SecretsResolver`
+ * via CoreDeps and never see backend specifics (env, exec, 1Password, etc.).
+ */
+
+export type ExecSecretRef = { source: "exec"; command: string; args?: string[] };
+export type EnvSecretRef = { source: "env"; var: string };
+export type SecretRef = ExecSecretRef | EnvSecretRef;
+
+export interface SecretsResolver {
+  resolve(ref: SecretRef): Promise<string>;
+}

--- a/packages/core/src/sport.ts
+++ b/packages/core/src/sport.ts
@@ -1,0 +1,115 @@
+import type { Tool } from "ai";
+import type { z } from "zod";
+import type { IntervalsClient } from "./intervals.js";
+import type { LLM } from "./llm.js";
+import type { MemorySnapshot, MemoryStore } from "./memory.js";
+import type { SecretsResolver } from "./secrets.js";
+
+// ─── Identity ──────────────────────────────────────────────────────────
+/** Closed literal union — adding a sport requires a Core bump. Intentional. */
+export type SportId = "cycling" | "running" | "duathlon";
+
+/** intervals.icu activity-type filter values. */
+export type IntervalsActivityType = "Ride" | "Run" | "VirtualRide" | "TrailRun";
+
+// ─── Shared kernel ─────────────────────────────────────────────────────
+/** Every sport's profile schema must extend this. */
+export interface Person {
+  weight: number;
+  age: number;
+  availableDays: number;
+}
+
+// ─── Memory section spec (ADR-0003) ────────────────────────────────────
+export interface MemorySectionSpec {
+  /** Bare for Core (`person`, `goals`); sport-prefixed for sports (`cycling-profile`). */
+  name: string;
+  /** Description shown to the LLM in section headers + memory_write tool docs. */
+  description: string;
+  /** Optional Zod schema; when present, Core validates writes. */
+  schema?: z.ZodTypeAny;
+}
+
+// ─── Tool registration (ADR-0004) ──────────────────────────────────────
+export interface ToolRegistration {
+  name: string;
+  description: string;
+  inputSchema: z.ZodTypeAny;
+  tool: Tool;
+}
+
+// ─── Runtime services Core provides to tool factories ──────────────────
+/**
+ * `intervals` is nullable because intervals.icu is BYOK-optional — users
+ * without an intervals API key still run the agent. Sport.tools() filters
+ * intervals-bound tools when null.
+ */
+export interface CoreDeps {
+  llm: LLM;
+  intervals: IntervalsClient | null;
+  memory: MemoryStore;
+  secrets: SecretsResolver;
+}
+
+// ─── Sport: the plug-point ─────────────────────────────────────────────
+export interface Sport {
+  readonly id: SportId;
+
+  /** Soul prompt — coaching identity, voice, principles. */
+  readonly soul: string;
+
+  /** Skill prompts indexed by skill name (e.g. "build_plan", "assess_workout"). */
+  readonly skills: Readonly<Record<string, string>>;
+
+  /** Sport-prefixed memory sections. Core auto-merges shared sections at runtime. */
+  readonly memorySections: readonly MemorySectionSpec[];
+
+  /**
+   * Phrases the LLM must never drop during compaction. Either:
+   *   - a static array of literal tokens (e.g. ["FTP", "VDOT"]), OR
+   *   - a function that derives tokens from the current memory state, for
+   *     data-bound values like "FTP 247W" or specific bike models.
+   * Compaction calls the function (if provided) just before each compaction
+   * pass, so the protected list reflects the athlete's current data.
+   */
+  readonly mustPreserveTokens:
+    | readonly string[]
+    | ((memory: MemorySnapshot) => readonly string[]);
+
+  /** intervals.icu activity types this sport reads/writes. */
+  readonly intervalsActivityTypes: readonly IntervalsActivityType[];
+
+  /** Zod schema for the athlete profile. Drives validation AND wizard prompts. */
+  readonly athleteProfileSchema: z.ZodTypeAny;
+
+  /** The one and only method: tools need runtime services. */
+  tools(deps: CoreDeps): readonly ToolRegistration[];
+}
+
+// ─── Consumer-narrowed slices (interface segregation via Pick) ─────────
+/** Slice consumed by the system-prompt builder. */
+export type SportPersona = Pick<Sport, "soul" | "skills">;
+
+/** Slice consumed by the memory store factory and the compaction module. */
+export type SportMemoryShape = Pick<Sport, "memorySections" | "mustPreserveTokens">;
+
+// ─── Binary: deployment-shell config (ADR-0001) ────────────────────────
+export interface Binary {
+  readonly name: string;
+  readonly displayName: string;
+  readonly dataSubdir: string;
+  readonly keychainPrefix: string;
+}
+
+// ─── Entry point ───────────────────────────────────────────────────────
+export interface RunBinaryArgs {
+  sport: Sport;
+  binary: Binary;
+}
+
+/**
+ * Entry point for binary packages. Implementation lands in commits 14-16
+ * when src/agent/ moves to packages/core/src/. Phase 1A keeps the existing
+ * CyclingCoachAgent class as the run loop.
+ */
+export declare function runBinary(args: RunBinaryArgs): Promise<void>;

--- a/packages/core/src/sport.ts
+++ b/packages/core/src/sport.ts
@@ -107,9 +107,5 @@ export interface RunBinaryArgs {
   binary: Binary;
 }
 
-/**
- * Entry point for binary packages. Implementation lands in commits 14-16
- * when src/agent/ moves to packages/core/src/. Phase 1A keeps the existing
- * CyclingCoachAgent class as the run loop.
- */
+/** Entry point for binary packages. */
 export declare function runBinary(args: RunBinaryArgs): Promise<void>;

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/sport-cycling/package.json
+++ b/packages/sport-cycling/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@cycling-coach/sport-cycling",
+  "version": "0.0.0-private",
+  "private": true,
+  "description": "Cycling sport package — soul, skills, tools, schemas, must-preserve tokens. Implements the Sport contract from @cycling-coach/core.",
+  "type": "module",
+  "license": "MIT"
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - "packages/*"

--- a/src/agent/compaction.ts
+++ b/src/agent/compaction.ts
@@ -1,4 +1,5 @@
 import type { ModelMessage } from "ai";
+import type { MemorySnapshot, SportMemoryShape } from "@cycling-coach/core";
 import {
   estimateTokens,
   estimateMessagesTokens,
@@ -28,11 +29,22 @@ const REQUIRED_SUMMARY_SECTIONS = [
 ] as const;
 
 // ============================================================================
-// PROMPTS
+// PROMPT BUILDERS (sport-parameterized)
 // ============================================================================
 
-const MUST_PRESERVE = `MUST PRESERVE:
-- Athlete profile details (FTP, weight, experience, schedule, goals)
+function resolveTokens(
+  spec: SportMemoryShape["mustPreserveTokens"],
+  memory: MemorySnapshot,
+): readonly string[] {
+  return typeof spec === "function" ? spec(memory) : spec;
+}
+
+function buildMustPreserveBlock(tokens: readonly string[]): string {
+  const tokensClause = tokens.length > 0
+    ? `\n\nPreserve these literal tokens exactly: ${tokens.join(", ")}.`
+    : "";
+  return `MUST PRESERVE:
+- Athlete profile details
 - Current training plan status and phase
 - Recent workout feedback and performance trends
 - Decisions made about training approach
@@ -43,9 +55,11 @@ Preserve all specific numbers exactly as written (watts, kg, percentages,
 dates, distances, durations).
 
 PRIORITIZE recent context over older history.
-The coach needs to know what was being discussed, not just what topics were covered.`;
+The coach needs to know what was being discussed, not just what topics were covered.${tokensClause}`;
+}
 
-const SUMMARIZE_PROMPT = `Summarize the following conversation concisely — aim for 300-500 words total.
+function buildSummarizePrompt(tokens: readonly string[]): string {
+  return `Summarize the following conversation concisely — aim for 300-500 words total.
 Use bullet points, not paragraphs. Omit generic advice that can be re-derived.
 
 Use these exact section headings:
@@ -54,9 +68,11 @@ Use these exact section headings:
 ## Discussion Context
 ## Pending Questions
 
-${MUST_PRESERVE}`;
+${buildMustPreserveBlock(tokens)}`;
+}
 
-const DROPPED_MESSAGES_PROMPT = `Incorporate these older conversation messages into the existing summary.
+function buildDroppedMessagesPrompt(tokens: readonly string[]): string {
+  return `Incorporate these older conversation messages into the existing summary.
 
 Produce a compact, factual summary — aim for 300-500 words total.
 Use bullet points, not paragraphs. Omit generic advice that can be re-derived.
@@ -67,7 +83,8 @@ Use these exact section headings:
 ## Discussion Context
 ## Pending Questions
 
-${MUST_PRESERVE}`;
+${buildMustPreserveBlock(tokens)}`;
+}
 
 // ============================================================================
 // HELPERS
@@ -164,13 +181,19 @@ export function auditSummaryQuality(summary: string): { ok: boolean; missing: st
 export async function summarizeDroppedMessages(params: {
   dropped: ModelMessage[];
   llm: LLM;
+  mustPreserveTokens: SportMemoryShape["mustPreserveTokens"];
+  memory: MemorySnapshot;
   previousSummary?: string;
   maxRetries?: number;
   contextWindowTokens?: number;
 }): Promise<string> {
-  const { dropped, llm, previousSummary, maxRetries = 1, contextWindowTokens } = params;
+  const { dropped, llm, mustPreserveTokens, memory, previousSummary, maxRetries = 1, contextWindowTokens } = params;
 
   if (dropped.length === 0) return previousSummary ?? "";
+
+  const tokens = resolveTokens(mustPreserveTokens, memory);
+  const droppedPrompt = buildDroppedMessagesPrompt(tokens);
+  const mustPreserveBlock = buildMustPreserveBlock(tokens);
 
   const chunks = computeAdaptiveChunks(dropped, contextWindowTokens);
   // Fallback: if adaptive chunking returns empty (shouldn't happen), use single chunk
@@ -181,7 +204,7 @@ export async function summarizeDroppedMessages(params: {
   for (const chunk of chunks) {
     const transcript = formatTranscript(chunk);
     const prompt = [
-      DROPPED_MESSAGES_PROMPT,
+      droppedPrompt,
       (summary ?? previousSummary) ? `\nExisting summary of earlier context:\n${summary ?? previousSummary}` : "",
       `\nMessages to incorporate:\n${transcript}`,
     ].join("\n");
@@ -207,7 +230,7 @@ export async function summarizeDroppedMessages(params: {
   for (let attempt = 0; attempt < maxRetries; attempt++) {
     try {
       const { text } = await llm.generate({
-        prompt: `Restructure the following summary to include ALL required section headings: ${audit.missing.join(", ")}.\n\n${best}\n\n${MUST_PRESERVE}`,
+        prompt: `Restructure the following summary to include ALL required section headings: ${audit.missing.join(", ")}.\n\n${best}\n\n${mustPreserveBlock}`,
         maxOutputTokens: MAX_SUMMARY_TOKENS,
       });
       const retryAudit = auditSummaryQuality(text);
@@ -228,11 +251,13 @@ export async function summarizeDroppedMessages(params: {
 export async function summarizeInStages(params: {
   messages: ModelMessage[];
   llm: LLM;
+  mustPreserveTokens: SportMemoryShape["mustPreserveTokens"];
+  memory: MemorySnapshot;
   recentToKeep?: number;
   previousSummary?: string;
   contextWindowTokens?: number;
 }): Promise<ModelMessage[]> {
-  const { messages, llm, recentToKeep = 4, previousSummary, contextWindowTokens } = params;
+  const { messages, llm, mustPreserveTokens, memory, recentToKeep = 4, previousSummary, contextWindowTokens } = params;
 
   const keepCount = Math.min(recentToKeep, messages.length);
   const toSummarize = messages.slice(0, messages.length - keepCount);
@@ -241,6 +266,9 @@ export async function summarizeInStages(params: {
   if (toSummarize.length === 0) {
     return messages;
   }
+
+  const tokens = resolveTokens(mustPreserveTokens, memory);
+  const summarizePrompt = buildSummarizePrompt(tokens);
 
   const chunks = computeAdaptiveChunks(toSummarize, contextWindowTokens);
 
@@ -254,7 +282,7 @@ export async function summarizeInStages(params: {
       : "";
 
     const { text } = await llm.generate({
-      prompt: `${SUMMARIZE_PROMPT}${contextPrefix}\n\n${transcript}`,
+      prompt: `${summarizePrompt}${contextPrefix}\n\n${transcript}`,
       maxOutputTokens: MAX_SUMMARY_TOKENS,
     });
     summary = capSummary(text);

--- a/src/agent/compaction.ts
+++ b/src/agent/compaction.ts
@@ -36,7 +36,13 @@ function resolveTokens(
   spec: SportMemoryShape["mustPreserveTokens"],
   memory: MemorySnapshot,
 ): readonly string[] {
-  return typeof spec === "function" ? spec(memory) : spec;
+  if (typeof spec !== "function") return spec;
+  try {
+    return spec(memory);
+  } catch (err) {
+    console.warn("Sport.mustPreserveTokens function threw; using empty list", err);
+    return [];
+  }
 }
 
 function buildMustPreserveBlock(tokens: readonly string[]): string {
@@ -44,7 +50,7 @@ function buildMustPreserveBlock(tokens: readonly string[]): string {
     ? `\n\nPreserve these literal tokens exactly: ${tokens.join(", ")}.`
     : "";
   return `MUST PRESERVE:
-- Athlete profile details
+- Athlete profile details (FTP, weight, experience, schedule, goals)
 - Current training plan status and phase
 - Recent workout feedback and performance trends
 - Decisions made about training approach

--- a/src/agent/compaction.ts
+++ b/src/agent/compaction.ts
@@ -29,7 +29,7 @@ const REQUIRED_SUMMARY_SECTIONS = [
 ] as const;
 
 // ============================================================================
-// PROMPT BUILDERS (sport-parameterized)
+// PROMPT BUILDERS
 // ============================================================================
 
 function resolveTokens(
@@ -203,9 +203,10 @@ export async function summarizeDroppedMessages(params: {
 
   for (const chunk of chunks) {
     const transcript = formatTranscript(chunk);
+    const carriedSummary = summary ?? previousSummary;
     const prompt = [
       droppedPrompt,
-      (summary ?? previousSummary) ? `\nExisting summary of earlier context:\n${summary ?? previousSummary}` : "",
+      carriedSummary ? `\nExisting summary of earlier context:\n${carriedSummary}` : "",
       `\nMessages to incorporate:\n${transcript}`,
     ].join("\n");
 

--- a/src/agent/core.ts
+++ b/src/agent/core.ts
@@ -1,11 +1,13 @@
 import { stepCountIs } from "ai";
-import type { ModelMessage } from "ai";
+import type { ModelMessage, ToolSet } from "ai";
 import { IntervalsClient } from "intervals-icu-api";
+import type { CoreDeps, MemoryStore, SecretsResolver } from "@cycling-coach/core";
+import type { LLM as LLMInterface } from "@cycling-coach/core";
 import type { Config } from "../config.js";
+import { resolveSecretRef } from "../secrets/resolve.js";
 import { Memory } from "./memory.js";
 import { ChatStore } from "./chat-store.js";
 import { buildSystemPrompt } from "./system-prompt.js";
-import { createTools } from "./tools.js";
 import { withSessionLock } from "./session-lock.js";
 import { splitHistoryByBudget, makeSummaryMessage } from "./history-limit.js";
 import {
@@ -45,7 +47,7 @@ export class CyclingCoachAgent {
   private config: Config;
   private memory: Memory;
   private chatStore: ChatStore;
-  private tools: ReturnType<typeof createTools>;
+  private tools: ToolSet;
   private systemPrompt: string;
 
   constructor(config: Config) {
@@ -61,7 +63,15 @@ export class CyclingCoachAgent {
         })
       : null;
 
-    this.tools = createTools(this.memory, intervals);
+    const secrets: SecretsResolver = { resolve: resolveSecretRef };
+    const coreDeps: CoreDeps = {
+      llm: this.llm as unknown as LLMInterface,
+      intervals,
+      memory: this.memory as unknown as MemoryStore,
+      secrets,
+    };
+    const registrations = cyclingSport.tools(coreDeps);
+    this.tools = Object.fromEntries(registrations.map((r) => [r.name, r.tool])) as ToolSet;
     this.systemPrompt = buildSystemPrompt(cyclingSport, this.memory);
   }
 

--- a/src/agent/core.ts
+++ b/src/agent/core.ts
@@ -22,6 +22,8 @@ import { summarizeInStages, summarizeDroppedMessages } from "./compaction.js";
 import { runMemoryFlush } from "./memory-flush.js";
 import { evaluateSessionFreshness } from "./session-freshness.js";
 import { LLM } from "./llm.js";
+import { createMemorySnapshot } from "./memory-snapshot.js";
+import { cyclingSport } from "../cycling/sport.js";
 
 const MAX_OVERFLOW_ATTEMPTS = 3;
 const MAX_TIMEOUT_ATTEMPTS = 2;
@@ -101,6 +103,8 @@ export class CyclingCoachAgent {
           const summary = await summarizeDroppedMessages({
             dropped,
             llm: this.llm,
+            mustPreserveTokens: cyclingSport.mustPreserveTokens,
+            memory: createMemorySnapshot(this.memory),
             previousSummary,
             contextWindowTokens: this.config.contextWindowTokens,
           });
@@ -131,7 +135,13 @@ export class CyclingCoachAgent {
         // Preemptive: compact before sending if over budget
         if (shouldCompact({ messages, systemPrompt: this.systemPrompt, contextWindowTokens: this.config.contextWindowTokens })) {
           await runMemoryFlush({ llm: this.llm, messages, memory: this.memory });
-          messages = await summarizeInStages({ messages, llm: this.llm, contextWindowTokens: this.config.contextWindowTokens });
+          messages = await summarizeInStages({
+            messages,
+            llm: this.llm,
+            mustPreserveTokens: cyclingSport.mustPreserveTokens,
+            memory: createMemorySnapshot(this.memory),
+            contextWindowTokens: this.config.contextWindowTokens,
+          });
           this.memory.reload();
         }
 
@@ -154,7 +164,13 @@ export class CyclingCoachAgent {
           if (isContextOverflowError(err) && overflowAttempts < MAX_OVERFLOW_ATTEMPTS) {
             overflowAttempts++;
             await runMemoryFlush({ llm: this.llm, messages, memory: this.memory });
-            messages = await summarizeInStages({ messages, llm: this.llm, contextWindowTokens: this.config.contextWindowTokens });
+            messages = await summarizeInStages({
+            messages,
+            llm: this.llm,
+            mustPreserveTokens: cyclingSport.mustPreserveTokens,
+            memory: createMemorySnapshot(this.memory),
+            contextWindowTokens: this.config.contextWindowTokens,
+          });
             this.memory.reload();
             continue;
           }
@@ -163,7 +179,13 @@ export class CyclingCoachAgent {
             const ratio = estimateMessagesTokens(messages) / this.config.contextWindowTokens;
             if (ratio > TIMEOUT_COMPACTION_THRESHOLD) {
               timeoutAttempts++;
-              messages = await summarizeInStages({ messages, llm: this.llm, contextWindowTokens: this.config.contextWindowTokens });
+              messages = await summarizeInStages({
+            messages,
+            llm: this.llm,
+            mustPreserveTokens: cyclingSport.mustPreserveTokens,
+            memory: createMemorySnapshot(this.memory),
+            contextWindowTokens: this.config.contextWindowTokens,
+          });
               this.memory.reload();
               continue;
             }

--- a/src/agent/core.ts
+++ b/src/agent/core.ts
@@ -1,8 +1,7 @@
 import { stepCountIs } from "ai";
 import type { ModelMessage, ToolSet } from "ai";
 import { IntervalsClient } from "intervals-icu-api";
-import type { CoreDeps, MemoryStore, SecretsResolver } from "@cycling-coach/core";
-import type { LLM as LLMInterface } from "@cycling-coach/core";
+import type { CoreDeps, SecretsResolver } from "@cycling-coach/core";
 import type { Config } from "../config.js";
 import { resolveSecretRef } from "../secrets/resolve.js";
 import { Memory } from "./memory.js";
@@ -65,14 +64,32 @@ export class CyclingCoachAgent {
 
     const secrets: SecretsResolver = { resolve: resolveSecretRef };
     const coreDeps: CoreDeps = {
-      llm: this.llm as unknown as LLMInterface,
+      llm: this.llm,
       intervals,
-      memory: this.memory as unknown as MemoryStore,
+      memory: this.memory,
       secrets,
     };
     const registrations = cyclingSport.tools(coreDeps);
     this.tools = Object.fromEntries(registrations.map((r) => [r.name, r.tool])) as ToolSet;
     this.systemPrompt = buildSystemPrompt(cyclingSport, this.memory);
+  }
+
+  private async flushMemory(messages: ModelMessage[]): Promise<void> {
+    await runMemoryFlush({
+      llm: this.llm,
+      messages,
+      memory: this.memory,
+      memorySections: cyclingSport.memorySections,
+    });
+  }
+
+  private compactionParams() {
+    return {
+      llm: this.llm,
+      mustPreserveTokens: cyclingSport.mustPreserveTokens,
+      memory: createMemorySnapshot(this.memory),
+      contextWindowTokens: this.config.contextWindowTokens,
+    };
   }
 
   async chat(chatId: string, userMessage: string): Promise<string> {
@@ -89,12 +106,7 @@ export class CyclingCoachAgent {
       if (!fresh) {
         // Flush memory before reset, then archive
         if (history.length > 0) {
-          await runMemoryFlush({
-            llm: this.llm,
-            messages: history,
-            memory: this.memory,
-            memorySections: cyclingSport.memorySections,
-          });
+          await this.flushMemory(history);
         }
         this.chatStore.archiveAndReset(chatId);
         history = [];
@@ -117,11 +129,8 @@ export class CyclingCoachAgent {
         try {
           const summary = await summarizeDroppedMessages({
             dropped,
-            llm: this.llm,
-            mustPreserveTokens: cyclingSport.mustPreserveTokens,
-            memory: createMemorySnapshot(this.memory),
             previousSummary,
-            contextWindowTokens: this.config.contextWindowTokens,
+            ...this.compactionParams(),
           });
           summaryMsg = makeSummaryMessage(summary);
           this.chatStore.overwriteHistory(chatId, [summaryMsg, ...kept]);
@@ -149,19 +158,8 @@ export class CyclingCoachAgent {
       while (true) {
         // Preemptive: compact before sending if over budget
         if (shouldCompact({ messages, systemPrompt: this.systemPrompt, contextWindowTokens: this.config.contextWindowTokens })) {
-          await runMemoryFlush({
-            llm: this.llm,
-            messages,
-            memory: this.memory,
-            memorySections: cyclingSport.memorySections,
-          });
-          messages = await summarizeInStages({
-            messages,
-            llm: this.llm,
-            mustPreserveTokens: cyclingSport.mustPreserveTokens,
-            memory: createMemorySnapshot(this.memory),
-            contextWindowTokens: this.config.contextWindowTokens,
-          });
+          await this.flushMemory(messages);
+          messages = await summarizeInStages({ messages, ...this.compactionParams() });
           this.memory.reload();
         }
 
@@ -183,19 +181,8 @@ export class CyclingCoachAgent {
           // Reactive: context overflow → flush + compact + retry
           if (isContextOverflowError(err) && overflowAttempts < MAX_OVERFLOW_ATTEMPTS) {
             overflowAttempts++;
-            await runMemoryFlush({
-              llm: this.llm,
-              messages,
-              memory: this.memory,
-              memorySections: cyclingSport.memorySections,
-            });
-            messages = await summarizeInStages({
-              messages,
-              llm: this.llm,
-              mustPreserveTokens: cyclingSport.mustPreserveTokens,
-              memory: createMemorySnapshot(this.memory),
-              contextWindowTokens: this.config.contextWindowTokens,
-            });
+            await this.flushMemory(messages);
+            messages = await summarizeInStages({ messages, ...this.compactionParams() });
             this.memory.reload();
             continue;
           }
@@ -204,13 +191,7 @@ export class CyclingCoachAgent {
             const ratio = estimateMessagesTokens(messages) / this.config.contextWindowTokens;
             if (ratio > TIMEOUT_COMPACTION_THRESHOLD) {
               timeoutAttempts++;
-              messages = await summarizeInStages({
-                messages,
-                llm: this.llm,
-                mustPreserveTokens: cyclingSport.mustPreserveTokens,
-                memory: createMemorySnapshot(this.memory),
-                contextWindowTokens: this.config.contextWindowTokens,
-              });
+              messages = await summarizeInStages({ messages, ...this.compactionParams() });
               this.memory.reload();
               continue;
             }
@@ -239,12 +220,7 @@ export class CyclingCoachAgent {
     // Flush before reset to avoid losing un-persisted context
     const { messages: history } = this.chatStore.load(chatId);
     if (history.length > 0) {
-      await runMemoryFlush({
-            llm: this.llm,
-            messages: history,
-            memory: this.memory,
-            memorySections: cyclingSport.memorySections,
-          });
+      await this.flushMemory(history);
     }
     this.chatStore.archiveAndReset(chatId);
   }

--- a/src/agent/core.ts
+++ b/src/agent/core.ts
@@ -1,7 +1,7 @@
 import { stepCountIs } from "ai";
 import type { ModelMessage, ToolSet } from "ai";
 import { IntervalsClient } from "intervals-icu-api";
-import type { CoreDeps, SecretsResolver } from "@cycling-coach/core";
+import { getEffectiveSections, type CoreDeps, type SecretsResolver } from "@cycling-coach/core";
 import type { Config } from "../config.js";
 import { resolveSecretRef } from "../secrets/resolve.js";
 import { Memory } from "./memory.js";
@@ -79,7 +79,7 @@ export class CyclingCoachAgent {
       llm: this.llm,
       messages,
       memory: this.memory,
-      memorySections: cyclingSport.memorySections,
+      memorySections: getEffectiveSections(cyclingSport),
     });
   }
 

--- a/src/agent/core.ts
+++ b/src/agent/core.ts
@@ -62,7 +62,7 @@ export class CyclingCoachAgent {
       : null;
 
     this.tools = createTools(this.memory, intervals);
-    this.systemPrompt = buildSystemPrompt(this.memory);
+    this.systemPrompt = buildSystemPrompt(cyclingSport, this.memory);
   }
 
   async chat(chatId: string, userMessage: string): Promise<string> {
@@ -90,7 +90,7 @@ export class CyclingCoachAgent {
         history = [];
       }
 
-      this.systemPrompt = buildSystemPrompt(this.memory);
+      this.systemPrompt = buildSystemPrompt(cyclingSport, this.memory);
 
       const budget = computeHistoryTokenBudget({
         contextWindowTokens: this.config.contextWindowTokens,

--- a/src/agent/core.ts
+++ b/src/agent/core.ts
@@ -79,7 +79,12 @@ export class CyclingCoachAgent {
       if (!fresh) {
         // Flush memory before reset, then archive
         if (history.length > 0) {
-          await runMemoryFlush({ llm: this.llm, messages: history, memory: this.memory });
+          await runMemoryFlush({
+            llm: this.llm,
+            messages: history,
+            memory: this.memory,
+            memorySections: cyclingSport.memorySections,
+          });
         }
         this.chatStore.archiveAndReset(chatId);
         history = [];
@@ -134,7 +139,12 @@ export class CyclingCoachAgent {
       while (true) {
         // Preemptive: compact before sending if over budget
         if (shouldCompact({ messages, systemPrompt: this.systemPrompt, contextWindowTokens: this.config.contextWindowTokens })) {
-          await runMemoryFlush({ llm: this.llm, messages, memory: this.memory });
+          await runMemoryFlush({
+            llm: this.llm,
+            messages,
+            memory: this.memory,
+            memorySections: cyclingSport.memorySections,
+          });
           messages = await summarizeInStages({
             messages,
             llm: this.llm,
@@ -163,14 +173,19 @@ export class CyclingCoachAgent {
           // Reactive: context overflow → flush + compact + retry
           if (isContextOverflowError(err) && overflowAttempts < MAX_OVERFLOW_ATTEMPTS) {
             overflowAttempts++;
-            await runMemoryFlush({ llm: this.llm, messages, memory: this.memory });
+            await runMemoryFlush({
+              llm: this.llm,
+              messages,
+              memory: this.memory,
+              memorySections: cyclingSport.memorySections,
+            });
             messages = await summarizeInStages({
-            messages,
-            llm: this.llm,
-            mustPreserveTokens: cyclingSport.mustPreserveTokens,
-            memory: createMemorySnapshot(this.memory),
-            contextWindowTokens: this.config.contextWindowTokens,
-          });
+              messages,
+              llm: this.llm,
+              mustPreserveTokens: cyclingSport.mustPreserveTokens,
+              memory: createMemorySnapshot(this.memory),
+              contextWindowTokens: this.config.contextWindowTokens,
+            });
             this.memory.reload();
             continue;
           }
@@ -180,12 +195,12 @@ export class CyclingCoachAgent {
             if (ratio > TIMEOUT_COMPACTION_THRESHOLD) {
               timeoutAttempts++;
               messages = await summarizeInStages({
-            messages,
-            llm: this.llm,
-            mustPreserveTokens: cyclingSport.mustPreserveTokens,
-            memory: createMemorySnapshot(this.memory),
-            contextWindowTokens: this.config.contextWindowTokens,
-          });
+                messages,
+                llm: this.llm,
+                mustPreserveTokens: cyclingSport.mustPreserveTokens,
+                memory: createMemorySnapshot(this.memory),
+                contextWindowTokens: this.config.contextWindowTokens,
+              });
               this.memory.reload();
               continue;
             }
@@ -214,7 +229,12 @@ export class CyclingCoachAgent {
     // Flush before reset to avoid losing un-persisted context
     const { messages: history } = this.chatStore.load(chatId);
     if (history.length > 0) {
-      await runMemoryFlush({ llm: this.llm, messages: history, memory: this.memory });
+      await runMemoryFlush({
+            llm: this.llm,
+            messages: history,
+            memory: this.memory,
+            memorySections: cyclingSport.memorySections,
+          });
     }
     this.chatStore.archiveAndReset(chatId);
   }

--- a/src/agent/llm.ts
+++ b/src/agent/llm.ts
@@ -3,6 +3,7 @@ import { createAnthropic } from "@ai-sdk/anthropic";
 import { createOpenAI } from "@ai-sdk/openai";
 import { createGoogleGenerativeAI } from "@ai-sdk/google";
 import type { LanguageModel } from "ai";
+import type { LLM as LLMInterface } from "@cycling-coach/core";
 
 import type { Config } from "../config.js";
 import { codexGenerateText } from "./codex-bridge.js";
@@ -14,7 +15,7 @@ export type { GenerateOpts, GenerateResult } from "./llm-types.js";
 // LLM DISPATCH
 // ============================================================================
 
-export class LLM {
+export class LLM implements LLMInterface {
   private config: Config;
   private aiSdkModel: LanguageModel | null;
 

--- a/src/agent/memory-flush.ts
+++ b/src/agent/memory-flush.ts
@@ -1,6 +1,7 @@
 import { tool, zodSchema, stepCountIs } from "ai";
 import type { ModelMessage } from "ai";
 import { z } from "zod";
+import type { MemorySectionSpec } from "@cycling-coach/core";
 import type { Memory } from "./memory.js";
 import { createMemoryReadTool } from "./tools.js";
 import type { LLM } from "./llm.js";
@@ -12,7 +13,7 @@ import type { LLM } from "./llm.js";
 export const SOFT_THRESHOLD_RATIO = 0.8;
 
 // ============================================================================
-// PROMPTS
+// PROMPTS (sport-parameterized)
 // ============================================================================
 
 const MEMORY_FLUSH_SYSTEM_PROMPT = `You are reviewing a conversation to extract and save important athlete
@@ -20,37 +21,33 @@ information before it is summarized. Use the memory_write tool to save
 details into the appropriate section. Each section is fully replaced on
 write, so include ALL current facts for that section, not just new ones.`;
 
-const MEMORY_FLUSH_USER_PROMPT = `Review this conversation and save athlete details to structured memory
+function buildFlushUserPrompt(sections: readonly MemorySectionSpec[]): string {
+  const sectionList = sections.map((s) => `- "${s.name}": ${s.description}`).join("\n");
+  return `Review this conversation and save athlete details to structured memory
 sections. First read existing memory with memory_read, then write each
 section that has new or updated information.
 
 Write to these sections using memory_write:
-- "profile": FTP, weight, age, W/kg, experience level, max HR, resting HR
-- "schedule": Training days, availability, weekly structure
-- "goals": Target events, FTP targets, race dates, milestones
-- "equipment": Bikes, trainer, power meter, head unit, indoor setup
-- "health": Injuries, sleep patterns, recovery needs, HRV
-- "preferences": Indoor/outdoor, coaching style, cross-training
-- "notes": Anything else important
+${sectionList}
 
 For each section you write, include ALL current facts for that section
 (both from memory and from the conversation). This fully replaces the
 section content — omitted facts will be lost.
 
 Only write sections that have new or changed information.`;
+}
 
 // ============================================================================
 // APPEND-ONLY MEMORY WRITE TOOL
 // ============================================================================
 
-function createFlushMemoryWriteTool(memory: Memory) {
+function createFlushMemoryWriteTool(memory: Memory, sections: readonly MemorySectionSpec[]) {
+  const sectionNames = sections.map((s) => s.name) as [string, ...string[]];
   return tool({
     description: "Write to a memory section (replaces entire section content)",
     inputSchema: zodSchema(
       z.object({
-        section: z
-          .enum(["profile", "schedule", "goals", "equipment", "health", "preferences", "notes"])
-          .describe("Which section to write"),
+        section: z.enum(sectionNames).describe("Which section to write"),
         content: z.string().describe("Complete section content — include ALL facts for this section"),
       }),
     ),
@@ -69,9 +66,10 @@ export async function runMemoryFlush(params: {
   llm: LLM;
   messages: ModelMessage[];
   memory: Memory;
+  memorySections: readonly MemorySectionSpec[];
 }): Promise<void> {
   const flushTools = {
-    memory_write: createFlushMemoryWriteTool(params.memory),
+    memory_write: createFlushMemoryWriteTool(params.memory, params.memorySections),
     memory_read: createMemoryReadTool(params.memory),
   };
 
@@ -79,7 +77,7 @@ export async function runMemoryFlush(params: {
     system: MEMORY_FLUSH_SYSTEM_PROMPT,
     messages: [
       ...params.messages,
-      { role: "user" as const, content: MEMORY_FLUSH_USER_PROMPT },
+      { role: "user" as const, content: buildFlushUserPrompt(params.memorySections) },
     ],
     tools: flushTools,
     stopWhen: stepCountIs(5),

--- a/src/agent/memory-flush.ts
+++ b/src/agent/memory-flush.ts
@@ -24,9 +24,10 @@ function buildFlushUserPrompt(sections: readonly MemorySectionSpec[]): string {
   const sectionList = sections.map((s) => `- "${s.name}": ${s.description}`).join("\n");
   // The transitional migration clause helps the LLM redistribute legacy
   // content (chronic facts in cycling-history, body data in cycling-profile)
-  // to the right destinations after the section rename. Remove once the
-  // chronic_facts_stuck_in_cycling_history warn stays silent for an extended
-  // period — likely after one or two flushes per existing user.
+  // to the right destinations after the section rename.
+  // TODO(wave-2-cleanup): remove this clause and the surrounding text
+  // when the `chronic_facts_stuck_in_cycling_history` log event has been
+  // silent for ~30 days post-deploy. Saves ~40 input tokens per flush.
   return `Review this conversation and save athlete details to structured memory
 sections. First read existing memory with memory_read, then write each
 section that has new or updated information.
@@ -114,6 +115,12 @@ export async function runMemoryFlush(params: {
   memory: MemoryStore;
   memorySections: readonly MemorySectionSpec[];
 }): Promise<void> {
+  if (params.memorySections.length === 0) {
+    throw new Error(
+      "runMemoryFlush requires at least one memory section. " +
+        "Pass getEffectiveSections(sport) — Core's shared sections guarantee non-empty.",
+    );
+  }
   const flushTools = {
     memory_write: createFlushMemoryWriteTool(params.memory, params.memorySections),
     memory_read: createMemoryReadTool(params.memory),

--- a/src/agent/memory-flush.ts
+++ b/src/agent/memory-flush.ts
@@ -76,8 +76,8 @@ function createFlushMemoryWriteTool(memory: MemoryStore, sections: readonly Memo
 // structured warn if chronic content (which belongs in `medical-history`) is
 // still parked in cycling-history — observability for the Wave 2 migration's
 // "convergence over 1-3 flushes" assumption from ADR-0003. Substring matching
-// is intentional (catches "antihypertensive"); expand the list as we observe
-// real data.
+// is intentional (catches plurals like "medications" via "medication"); expand
+// the list as we observe real data.
 const CHRONIC_KEYWORDS = [
   "hypertension",
   "diabetes",

--- a/src/agent/memory-flush.ts
+++ b/src/agent/memory-flush.ts
@@ -22,10 +22,11 @@ write, so include ALL current facts for that section, not just new ones.`;
 
 function buildFlushUserPrompt(sections: readonly MemorySectionSpec[]): string {
   const sectionList = sections.map((s) => `- "${s.name}": ${s.description}`).join("\n");
-  // Transitional migration clause (added in commit 11b). Helps the LLM
-  // redistribute legacy content from the cycling-history rename to the right
-  // destinations. Remove in a future cleanup commit once the chronic-keyword
-  // scan from commit 11c stays silent for an extended period.
+  // The transitional migration clause helps the LLM redistribute legacy
+  // content (chronic facts in cycling-history, body data in cycling-profile)
+  // to the right destinations after the section rename. Remove once the
+  // chronic_facts_stuck_in_cycling_history warn stays silent for an extended
+  // period — likely after one or two flushes per existing user.
   return `Review this conversation and save athlete details to structured memory
 sections. First read existing memory with memory_read, then write each
 section that has new or updated information.

--- a/src/agent/memory-flush.ts
+++ b/src/agent/memory-flush.ts
@@ -22,6 +22,10 @@ write, so include ALL current facts for that section, not just new ones.`;
 
 function buildFlushUserPrompt(sections: readonly MemorySectionSpec[]): string {
   const sectionList = sections.map((s) => `- "${s.name}": ${s.description}`).join("\n");
+  // Transitional migration clause (added in commit 11b). Helps the LLM
+  // redistribute legacy content from the cycling-history rename to the right
+  // destinations. Remove in a future cleanup commit once the chronic-keyword
+  // scan from commit 11c stays silent for an extended period.
   return `Review this conversation and save athlete details to structured memory
 sections. First read existing memory with memory_read, then write each
 section that has new or updated information.
@@ -32,6 +36,11 @@ ${sectionList}
 For each section you write, include ALL current facts for that section
 (both from memory and from the conversation). This fully replaces the
 section content — omitted facts will be lost.
+
+Note (transitional, post-migration): if \`cycling-profile\` contains weight,
+age, or available training days, move them to \`person\`. If \`cycling-history\`
+contains chronic conditions or long-term medications (hypertension, lisinopril,
+diabetes), move them to \`medical-history\`.
 
 Only write sections that have new or changed information.`;
 }

--- a/src/agent/memory-flush.ts
+++ b/src/agent/memory-flush.ts
@@ -1,8 +1,7 @@
 import { tool, zodSchema, stepCountIs } from "ai";
 import type { ModelMessage } from "ai";
 import { z } from "zod";
-import type { MemorySectionSpec } from "@cycling-coach/core";
-import type { Memory } from "./memory.js";
+import type { MemorySectionSpec, MemoryStore } from "@cycling-coach/core";
 import { createMemoryReadTool } from "./tools.js";
 import type { LLM } from "./llm.js";
 
@@ -13,7 +12,7 @@ import type { LLM } from "./llm.js";
 export const SOFT_THRESHOLD_RATIO = 0.8;
 
 // ============================================================================
-// PROMPTS (sport-parameterized)
+// PROMPTS
 // ============================================================================
 
 const MEMORY_FLUSH_SYSTEM_PROMPT = `You are reviewing a conversation to extract and save important athlete
@@ -41,7 +40,7 @@ Only write sections that have new or changed information.`;
 // APPEND-ONLY MEMORY WRITE TOOL
 // ============================================================================
 
-function createFlushMemoryWriteTool(memory: Memory, sections: readonly MemorySectionSpec[]) {
+function createFlushMemoryWriteTool(memory: MemoryStore, sections: readonly MemorySectionSpec[]) {
   const sectionNames = sections.map((s) => s.name) as [string, ...string[]];
   return tool({
     description: "Write to a memory section (replaces entire section content)",
@@ -65,7 +64,7 @@ function createFlushMemoryWriteTool(memory: Memory, sections: readonly MemorySec
 export async function runMemoryFlush(params: {
   llm: LLM;
   messages: ModelMessage[];
-  memory: Memory;
+  memory: MemoryStore;
   memorySections: readonly MemorySectionSpec[];
 }): Promise<void> {
   const flushTools = {

--- a/src/agent/memory-flush.ts
+++ b/src/agent/memory-flush.ts
@@ -67,6 +67,43 @@ function createFlushMemoryWriteTool(memory: MemoryStore, sections: readonly Memo
 }
 
 // ============================================================================
+// CHRONIC-KEYWORD CONVERGENCE SCAN
+// ============================================================================
+
+// Substring matches against `cycling-history` body after each flush. Fires a
+// structured warn if chronic content (which belongs in `medical-history`) is
+// still parked in cycling-history — observability for the Wave 2 migration's
+// "convergence over 1-3 flushes" assumption from ADR-0003. Substring matching
+// is intentional (catches "antihypertensive"); expand the list as we observe
+// real data.
+const CHRONIC_KEYWORDS = [
+  "hypertension",
+  "diabetes",
+  "asthma",
+  "chronic",
+  "lisinopril",
+  "metformin",
+  "statins",
+  "long-term",
+  "medication",
+] as const;
+
+function scanForStuckChronic(memory: MemoryStore): void {
+  const cyclingHistory = memory.readSection("cycling-history");
+  if (!cyclingHistory) return;
+  const lower = cyclingHistory.toLowerCase();
+  const matches = CHRONIC_KEYWORDS.filter((k) => lower.includes(k));
+  if (matches.length === 0) return;
+  console.warn(
+    JSON.stringify({
+      event: "chronic_facts_stuck_in_cycling_history",
+      keywords: matches,
+      hint: "Run another memory_flush; if persists, manually move to medical-history",
+    }),
+  );
+}
+
+// ============================================================================
 // MEMORY FLUSH
 // ============================================================================
 
@@ -93,4 +130,5 @@ export async function runMemoryFlush(params: {
   });
 
   params.memory.reload();
+  scanForStuckChronic(params.memory);
 }

--- a/src/agent/memory-snapshot.ts
+++ b/src/agent/memory-snapshot.ts
@@ -1,0 +1,42 @@
+import type { MemorySnapshot, MemoryStore } from "@cycling-coach/core";
+
+/**
+ * Wraps a MemoryStore in a frozen-at-call-time read-only sectioned view.
+ *
+ * Sport.mustPreserveTokens (function form) takes this view to derive
+ * data-bound tokens (e.g. "FTP 247W") from the current memory state.
+ *
+ * Sections are parsed from MEMORY.md's `## name` headers — see the
+ * Memory class's writeSection() format.
+ */
+export function createMemorySnapshot(store: MemoryStore): MemorySnapshot {
+  const sections = parseSectionsFromMarkdown(store.readMemory());
+  return {
+    read(name: string): string | null {
+      const body = sections.get(name);
+      return body && body.length > 0 ? body : null;
+    },
+    has(name: string): boolean {
+      const body = sections.get(name);
+      return body !== undefined && body.length > 0;
+    },
+    listSections(): readonly string[] {
+      return Array.from(sections.keys());
+    },
+  };
+}
+
+function parseSectionsFromMarkdown(content: string): Map<string, string> {
+  const sections = new Map<string, string>();
+  if (!content) return sections;
+  // Split on lines starting with "## " (section headers).
+  const parts = content.split(/^## /m);
+  for (const raw of parts) {
+    if (!raw.trim()) continue;
+    const newline = raw.indexOf("\n");
+    const name = (newline >= 0 ? raw.slice(0, newline) : raw).trim();
+    const body = (newline >= 0 ? raw.slice(newline + 1) : "").trim();
+    sections.set(name, body);
+  }
+  return sections;
+}

--- a/src/agent/memory.ts
+++ b/src/agent/memory.ts
@@ -49,6 +49,19 @@ export class Memory implements MemoryStore {
     }
   }
 
+  readSection(section: string): string | null {
+    const path = join(this.memoryDir, "MEMORY.md");
+    if (!existsSync(path)) return null;
+    const existing = readFileSync(path, "utf-8");
+    const marker = `## ${section}`;
+    const parts = existing.split(/(?=^## )/m);
+    const block = parts.find((p) => p.startsWith(marker + "\n"));
+    if (!block) return null;
+    // Strip header line and any trailing newline; return raw body (may be empty).
+    const body = block.slice(block.indexOf("\n") + 1);
+    return body.endsWith("\n") ? body.slice(0, -1) : body;
+  }
+
   renameSection(from: string, to: string): "renamed" | "noop" | "merged" {
     const path = join(this.memoryDir, "MEMORY.md");
     if (!existsSync(path)) return "noop";

--- a/src/agent/memory.ts
+++ b/src/agent/memory.ts
@@ -49,6 +49,32 @@ export class Memory implements MemoryStore {
     }
   }
 
+  renameSection(from: string, to: string): "renamed" | "noop" | "merged" {
+    const path = join(this.memoryDir, "MEMORY.md");
+    if (!existsSync(path)) return "noop";
+
+    const existing = readFileSync(path, "utf-8");
+    const fromMarker = `## ${from}`;
+    const toMarker = `## ${to}`;
+    const parts = existing.split(/(?=^## )/m);
+    const fromIdx = parts.findIndex((p) => p.startsWith(fromMarker + "\n"));
+    if (fromIdx < 0) return "noop";
+
+    const bodyOf = (block: string) => block.slice(block.indexOf("\n") + 1);
+    const toIdx = parts.findIndex((p) => p.startsWith(toMarker + "\n"));
+
+    if (toIdx >= 0) {
+      parts[toIdx] = `${toMarker}\n${bodyOf(parts[toIdx])}\n${bodyOf(parts[fromIdx])}`;
+      parts.splice(fromIdx, 1);
+      writeFileSync(path, parts.join(""), "utf-8");
+      return "merged";
+    }
+
+    parts[fromIdx] = `${toMarker}\n${bodyOf(parts[fromIdx])}`;
+    writeFileSync(path, parts.join(""), "utf-8");
+    return "renamed";
+  }
+
   /** @deprecated Use writeSection instead */
   appendMemory(entry: string): void {
     const path = join(this.memoryDir, "MEMORY.md");

--- a/src/agent/memory.ts
+++ b/src/agent/memory.ts
@@ -1,11 +1,12 @@
 import { readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
 import { join } from "node:path";
+import type { MemoryStore } from "@cycling-coach/core";
 
 // ============================================================================
 // MEMORY SYSTEM
 // ============================================================================
 
-export class Memory {
+export class Memory implements MemoryStore {
   private memoryDir: string;
   private plansDir: string;
 

--- a/src/agent/memory.ts
+++ b/src/agent/memory.ts
@@ -6,6 +6,10 @@ import type { MemoryStore } from "@cycling-coach/core";
 // MEMORY SYSTEM
 // ============================================================================
 
+const SECTION_SPLIT = /(?=^## )/m;
+const markerOf = (section: string) => `## ${section}`;
+const bodyOf = (block: string) => block.slice(block.indexOf("\n") + 1);
+
 export class Memory implements MemoryStore {
   private memoryDir: string;
   private plansDir: string;
@@ -28,7 +32,7 @@ export class Memory implements MemoryStore {
   writeSection(section: string, content: string): void {
     const path = join(this.memoryDir, "MEMORY.md");
     const existing = this.readMemory();
-    const marker = `## ${section}`;
+    const marker = markerOf(section);
     const newBlock = `${marker}\n${content}\n`;
 
     if (!existing) {
@@ -36,15 +40,14 @@ export class Memory implements MemoryStore {
       return;
     }
 
-    // Split by section headers, find and replace the matching one
-    const parts = existing.split(/(?=^## )/m);
+    const parts = existing.split(SECTION_SPLIT);
     const idx = parts.findIndex((p) => p.startsWith(marker + "\n"));
 
     if (idx >= 0) {
       parts[idx] = newBlock;
       writeFileSync(path, parts.join(""), "utf-8");
     } else {
-      // No matching section → append at end (preserves legacy content)
+      // Append at end (preserves legacy content not covered by any known section)
       writeFileSync(path, existing.trimEnd() + "\n\n" + newBlock, "utf-8");
     }
   }
@@ -52,13 +55,11 @@ export class Memory implements MemoryStore {
   readSection(section: string): string | null {
     const path = join(this.memoryDir, "MEMORY.md");
     if (!existsSync(path)) return null;
-    const existing = readFileSync(path, "utf-8");
-    const marker = `## ${section}`;
-    const parts = existing.split(/(?=^## )/m);
+    const marker = markerOf(section);
+    const parts = readFileSync(path, "utf-8").split(SECTION_SPLIT);
     const block = parts.find((p) => p.startsWith(marker + "\n"));
     if (!block) return null;
-    // Strip header line and any trailing newline; return raw body (may be empty).
-    const body = block.slice(block.indexOf("\n") + 1);
+    const body = bodyOf(block);
     return body.endsWith("\n") ? body.slice(0, -1) : body;
   }
 
@@ -66,14 +67,12 @@ export class Memory implements MemoryStore {
     const path = join(this.memoryDir, "MEMORY.md");
     if (!existsSync(path)) return "noop";
 
-    const existing = readFileSync(path, "utf-8");
-    const fromMarker = `## ${from}`;
-    const toMarker = `## ${to}`;
-    const parts = existing.split(/(?=^## )/m);
+    const fromMarker = markerOf(from);
+    const toMarker = markerOf(to);
+    const parts = readFileSync(path, "utf-8").split(SECTION_SPLIT);
     const fromIdx = parts.findIndex((p) => p.startsWith(fromMarker + "\n"));
     if (fromIdx < 0) return "noop";
 
-    const bodyOf = (block: string) => block.slice(block.indexOf("\n") + 1);
     const toIdx = parts.findIndex((p) => p.startsWith(toMarker + "\n"));
 
     if (toIdx >= 0) {

--- a/src/agent/memory.ts
+++ b/src/agent/memory.ts
@@ -26,7 +26,11 @@ export class Memory implements MemoryStore {
   readMemory(): string {
     const path = join(this.memoryDir, "MEMORY.md");
     if (!existsSync(path)) return "";
-    return readFileSync(path, "utf-8");
+    // Normalize CRLF → LF so section parsing works for files authored on
+    // Windows or pasted from sources like Word/Notion. The marker check
+    // `parts[idx].startsWith(marker + "\n")` would otherwise miss CRLF
+    // headers and silently no-op every rename / read.
+    return readFileSync(path, "utf-8").replace(/\r\n/g, "\n");
   }
 
   writeSection(section: string, content: string): void {
@@ -53,10 +57,10 @@ export class Memory implements MemoryStore {
   }
 
   readSection(section: string): string | null {
-    const path = join(this.memoryDir, "MEMORY.md");
-    if (!existsSync(path)) return null;
+    const content = this.readMemory();
+    if (!content) return null;
     const marker = markerOf(section);
-    const parts = readFileSync(path, "utf-8").split(SECTION_SPLIT);
+    const parts = content.split(SECTION_SPLIT);
     const block = parts.find((p) => p.startsWith(marker + "\n"));
     if (!block) return null;
     const body = bodyOf(block);
@@ -65,11 +69,12 @@ export class Memory implements MemoryStore {
 
   renameSection(from: string, to: string): "renamed" | "noop" | "merged" {
     const path = join(this.memoryDir, "MEMORY.md");
-    if (!existsSync(path)) return "noop";
+    const content = this.readMemory();
+    if (!content) return "noop";
 
     const fromMarker = markerOf(from);
     const toMarker = markerOf(to);
-    const parts = readFileSync(path, "utf-8").split(SECTION_SPLIT);
+    const parts = content.split(SECTION_SPLIT);
     const fromIdx = parts.findIndex((p) => p.startsWith(fromMarker + "\n"));
     if (fromIdx < 0) return "noop";
 

--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -1,22 +1,18 @@
-import { readFileSync, readdirSync } from "node:fs";
-import { join, resolve } from "node:path";
+import type { SportPersona } from "@cycling-coach/core";
 import { Memory } from "./memory.js";
 
 // ============================================================================
-// SYSTEM PROMPT BUILDER
+// SYSTEM PROMPT BUILDER (sport-parameterized)
 // ============================================================================
 
-const PROJECT_ROOT = resolve(import.meta.dirname, "../..");
-
-export function buildSystemPrompt(memory: Memory): string {
-  const soul = loadSoul();
-  const skills = loadSkills();
+export function buildSystemPrompt(persona: SportPersona, memory: Memory): string {
+  const skillsContent = Object.values(persona.skills).join("\n\n---\n\n");
   const context = memory.getContext();
 
-  const parts = [soul];
+  const parts = [persona.soul];
 
-  if (skills) {
-    parts.push("# Domain Knowledge\n\n" + skills);
+  if (skillsContent) {
+    parts.push("# Domain Knowledge\n\n" + skillsContent);
   }
 
   if (context) {
@@ -26,18 +22,4 @@ export function buildSystemPrompt(memory: Memory): string {
   parts.push(`# Current Date\n\nToday is ${new Date().toISOString().split("T")[0]}.`);
 
   return parts.join("\n\n---\n\n");
-}
-
-function loadSoul(): string {
-  const soulPath = join(PROJECT_ROOT, "SOUL.md");
-  return readFileSync(soulPath, "utf-8");
-}
-
-function loadSkills(): string {
-  const skillsDir = join(PROJECT_ROOT, "skills");
-  const files = readdirSync(skillsDir)
-    .filter((f) => f.endsWith(".md"))
-    .sort();
-
-  return files.map((f) => readFileSync(join(skillsDir, f), "utf-8")).join("\n\n---\n\n");
 }

--- a/src/agent/system-prompt.ts
+++ b/src/agent/system-prompt.ts
@@ -1,8 +1,8 @@
 import type { SportPersona } from "@cycling-coach/core";
-import { Memory } from "./memory.js";
+import type { Memory } from "./memory.js";
 
 // ============================================================================
-// SYSTEM PROMPT BUILDER (sport-parameterized)
+// SYSTEM PROMPT BUILDER
 // ============================================================================
 
 export function buildSystemPrompt(persona: SportPersona, memory: Memory): string {

--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -17,8 +17,16 @@ import type {
   RaceType,
   IntervalsWorkoutInput,
 } from "../cycling/index.js";
-import type { MemoryStore } from "@cycling-coach/core";
+import type { MemorySectionSpec, MemoryStore } from "@cycling-coach/core";
 import type { IntervalsClient } from "intervals-icu-api";
+
+function buildMemoryWriteDescription(sections: readonly MemorySectionSpec[]): string {
+  const sectionList = sections.map((s) => `${s.name} (${s.description})`).join("; ");
+  return (
+    "Write to long-term memory (replaces section content) or daily notes. " +
+    `Sections: ${sectionList}.`
+  );
+}
 
 // ============================================================================
 // HELPERS
@@ -42,7 +50,12 @@ export function createMemoryReadTool(memory: MemoryStore) {
 // TOOL BUILDER
 // ============================================================================
 
-export function createTools(memory: MemoryStore, intervals: IntervalsClient | null) {
+export function createTools(
+  memory: MemoryStore,
+  intervals: IntervalsClient | null,
+  sections: readonly MemorySectionSpec[],
+) {
+  const sectionNames = sections.map((s) => s.name) as [string, ...string[]];
   return {
     // ── Cycling logic tools (local, no API) ─────────────────────────────
 
@@ -158,19 +171,14 @@ export function createTools(memory: MemoryStore, intervals: IntervalsClient | nu
     memory_read: createMemoryReadTool(memory),
 
     memory_write: tool({
-      description:
-        "Write to long-term memory (replaces section content) or daily notes. " +
-        "Use sections to organize athlete data: profile (FTP, weight, age, experience), " +
-        "schedule (training days, availability), goals (target events, FTP targets), " +
-        "equipment (bikes, trainer, power meter), health (injuries, HR, sleep), " +
-        "preferences (indoor/outdoor, coaching style), notes (anything else).",
+      description: buildMemoryWriteDescription(sections),
       inputSchema: zodSchema(
         z.object({
           type: z
             .enum(["memory", "daily"])
             .describe("'memory' for long-term facts, 'daily' for today's notes"),
           section: z
-            .enum(["profile", "schedule", "goals", "equipment", "health", "preferences", "notes"])
+            .enum(sectionNames)
             .optional()
             .describe("Memory section to write to (required when type='memory'). Replaces the section content."),
           content: z.string().describe("The information to save"),

--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -17,7 +17,7 @@ import type {
   RaceType,
   IntervalsWorkoutInput,
 } from "../cycling/index.js";
-import type { Memory } from "./memory.js";
+import type { MemoryStore } from "@cycling-coach/core";
 import type { IntervalsClient } from "intervals-icu-api";
 
 // ============================================================================
@@ -30,7 +30,7 @@ const daysEnum = z.enum(["mon", "tue", "wed", "thu", "fri", "sat", "sun"]);
 // SHARED TOOL FACTORIES
 // ============================================================================
 
-export function createMemoryReadTool(memory: Memory) {
+export function createMemoryReadTool(memory: MemoryStore) {
   return tool({
     description: "Read long-term athlete memory, today's notes, and current plan state",
     inputSchema: zodSchema(z.object({})),
@@ -42,7 +42,7 @@ export function createMemoryReadTool(memory: Memory) {
 // TOOL BUILDER
 // ============================================================================
 
-export function createTools(memory: Memory, intervals: IntervalsClient | null) {
+export function createTools(memory: MemoryStore, intervals: IntervalsClient | null) {
   return {
     // ── Cycling logic tools (local, no API) ─────────────────────────────
 

--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -55,6 +55,12 @@ export function createTools(
   intervals: IntervalsClient | null,
   sections: readonly MemorySectionSpec[],
 ) {
+  if (sections.length === 0) {
+    throw new Error(
+      "createTools requires at least one MemorySectionSpec. " +
+        "Pass getEffectiveSections(sport) — Core's shared sections guarantee non-empty.",
+    );
+  }
   const sectionNames = sections.map((s) => s.name) as [string, ...string[]];
   return {
     // ── Cycling logic tools (local, no API) ─────────────────────────────

--- a/src/cycling/migrate-legacy-sections.ts
+++ b/src/cycling/migrate-legacy-sections.ts
@@ -1,0 +1,25 @@
+import type { MemoryStore } from "@cycling-coach/core";
+
+const LEGACY_RENAMES = [
+  ["profile", "cycling-profile"],
+  ["equipment", "cycling-equipment"],
+  ["health", "cycling-history"],
+] as const;
+
+export function migrateCyclingLegacySections(memory: MemoryStore): void {
+  for (const [from, to] of LEGACY_RENAMES) {
+    try {
+      const outcome = memory.renameSection(from, to);
+      console.log(JSON.stringify({ event: "section_rename", from, to, outcome }));
+    } catch (err) {
+      console.warn(
+        JSON.stringify({
+          event: "section_rename_failed",
+          from,
+          to,
+          error: String(err),
+        }),
+      );
+    }
+  }
+}

--- a/src/cycling/sport.ts
+++ b/src/cycling/sport.ts
@@ -28,7 +28,7 @@ function loadSkills(): Record<string, string> {
   );
 }
 
-const CYCLING_VOCABULARY: readonly string[] = [
+export const CYCLING_VOCABULARY: readonly string[] = [
   "FTP",
   "W/kg",
   "Coggan",

--- a/src/cycling/sport.ts
+++ b/src/cycling/sport.ts
@@ -39,10 +39,10 @@ const CYCLING_VOCABULARY: readonly string[] = [
 
 const memorySections: readonly MemorySectionSpec[] = [
   { name: "profile", description: "FTP, weight, age, experience level, max HR, resting HR, W/kg" },
-  { name: "schedule", description: "Training days, weekly availability, scheduling preferences" },
+  { name: "schedule", description: "Training days, availability, weekly structure" },
   { name: "goals", description: "Target events, FTP targets, race dates, milestones" },
   { name: "equipment", description: "Bikes, trainer, power meter, head unit, indoor setup" },
-  { name: "health", description: "Injuries, sleep patterns, recovery needs, HRV, resting HR" },
+  { name: "health", description: "Injuries, sleep patterns, recovery needs, HRV" },
   { name: "preferences", description: "Indoor/outdoor, coaching style, cross-training" },
   { name: "notes", description: "Anything else important" },
 ];

--- a/src/cycling/sport.ts
+++ b/src/cycling/sport.ts
@@ -63,7 +63,21 @@ export const cyclingSport: Sport = {
   soul: loadSoul(),
   skills: loadSkills(),
   memorySections,
-  mustPreserveTokens: (_memory: MemorySnapshot): readonly string[] => CYCLING_VOCABULARY,
+  mustPreserveTokens: (memory: MemorySnapshot): readonly string[] => {
+    const tokens: string[] = [...CYCLING_VOCABULARY];
+    const profile = memory.read("cycling-profile");
+    if (profile) {
+      // \bFTP\b prevents matching "SoftPlate" etc. Separator class accepts FTP 247,
+      // FTP: 247, FTP, 247, FTP - 247. Unit optional. Digit range 2-3 (50-999W)
+      // rejects 4-digit year collisions like "FTP test 2024-06: 240W" → matches 240,
+      // not 2024. Trailing \b ensures we don't capture "FTP 247abc". First match
+      // only — historical FTPs aren't identity-defining and would balloon
+      // false-positive surface.
+      const match = profile.match(/\bFTP\b[\s:,-]*(\d{2,3})\s*[wW]?\b/);
+      if (match) tokens.push(`FTP ${match[1]}W`);
+    }
+    return tokens;
+  },
   intervalsActivityTypes: ["Ride", "VirtualRide"],
   athleteProfileSchema,
   tools: (deps: CoreDeps): readonly ToolRegistration[] => {

--- a/src/cycling/sport.ts
+++ b/src/cycling/sport.ts
@@ -1,0 +1,76 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { z } from "zod";
+import type {
+  CoreDeps,
+  MemorySectionSpec,
+  MemorySnapshot,
+  Sport,
+  ToolRegistration,
+} from "@cycling-coach/core";
+import type { Memory } from "../agent/memory.js";
+import { createTools } from "../agent/tools.js";
+import { athleteProfileSchema } from "./schemas.js";
+
+const PROJECT_ROOT = resolve(import.meta.dirname, "../..");
+
+function loadSoul(): string {
+  return readFileSync(join(PROJECT_ROOT, "SOUL.md"), "utf-8");
+}
+
+function loadSkills(): Record<string, string> {
+  const skillsDir = join(PROJECT_ROOT, "skills");
+  return Object.fromEntries(
+    readdirSync(skillsDir)
+      .filter((f) => f.endsWith(".md"))
+      .sort()
+      .map((f) => [f.replace(/\.md$/, ""), readFileSync(join(skillsDir, f), "utf-8")]),
+  );
+}
+
+const CYCLING_VOCABULARY: readonly string[] = [
+  "FTP",
+  "W/kg",
+  "Coggan",
+  "VO2max",
+  "watts",
+  "sweet spot",
+  "TTE",
+];
+
+const memorySections: readonly MemorySectionSpec[] = [
+  { name: "profile", description: "FTP, weight, age, experience level, max HR, resting HR, W/kg" },
+  { name: "schedule", description: "Training days, weekly availability, scheduling preferences" },
+  { name: "goals", description: "Target events, FTP targets, race dates, milestones" },
+  { name: "equipment", description: "Bikes, trainer, power meter, head unit, indoor setup" },
+  { name: "health", description: "Injuries, sleep patterns, recovery needs, HRV, resting HR" },
+  { name: "preferences", description: "Indoor/outdoor, coaching style, cross-training" },
+  { name: "notes", description: "Anything else important" },
+];
+
+export const cyclingSport: Sport = {
+  id: "cycling",
+  soul: loadSoul(),
+  skills: loadSkills(),
+  memorySections,
+  mustPreserveTokens: (_memory: MemorySnapshot): readonly string[] => CYCLING_VOCABULARY,
+  intervalsActivityTypes: ["Ride", "VirtualRide"],
+  athleteProfileSchema,
+  tools: (deps: CoreDeps): readonly ToolRegistration[] => {
+    // Phase 1A cast: deps.memory is MemoryStore (interface); the legacy
+    // createTools signature still wants the concrete Memory class because of
+    // private fields. Memory structurally satisfies MemoryStore at runtime.
+    // Commit 6 widens createTools/createMemoryReadTool to MemoryStore.
+    const toolset = createTools(deps.memory as unknown as Memory, deps.intervals);
+    return Object.entries(toolset).map(([name, t]) => ({
+      name,
+      description: (t as { description?: string }).description ?? "",
+      // Vercel AI SDK wraps the original Zod schema into FlexibleSchema; the raw
+      // ZodTypeAny is not recoverable from the Tool object. Commit 8 redefines
+      // each tool with explicit registration metadata so this placeholder goes
+      // away. No Core consumer reads ToolRegistration.inputSchema in commit 3.
+      inputSchema: z.unknown(),
+      tool: t,
+    }));
+  },
+};

--- a/src/cycling/sport.ts
+++ b/src/cycling/sport.ts
@@ -8,7 +8,6 @@ import type {
   Sport,
   ToolRegistration,
 } from "@cycling-coach/core";
-import type { Memory } from "../agent/memory.js";
 import { createTools } from "../agent/tools.js";
 import { athleteProfileSchema } from "./schemas.js";
 
@@ -57,18 +56,12 @@ export const cyclingSport: Sport = {
   intervalsActivityTypes: ["Ride", "VirtualRide"],
   athleteProfileSchema,
   tools: (deps: CoreDeps): readonly ToolRegistration[] => {
-    // Phase 1A cast: deps.memory is MemoryStore (interface); the legacy
-    // createTools signature still wants the concrete Memory class because of
-    // private fields. Memory structurally satisfies MemoryStore at runtime.
-    // Commit 6 widens createTools/createMemoryReadTool to MemoryStore.
-    const toolset = createTools(deps.memory as unknown as Memory, deps.intervals);
+    const toolset = createTools(deps.memory, deps.intervals);
     return Object.entries(toolset).map(([name, t]) => ({
       name,
       description: (t as { description?: string }).description ?? "",
-      // Vercel AI SDK wraps the original Zod schema into FlexibleSchema; the raw
-      // ZodTypeAny is not recoverable from the Tool object. Commit 8 redefines
-      // each tool with explicit registration metadata so this placeholder goes
-      // away. No Core consumer reads ToolRegistration.inputSchema in commit 3.
+      // Vercel AI SDK wraps the Zod schema into a FlexibleSchema that
+      // doesn't expose the raw ZodTypeAny; introspection lives on `tool`.
       inputSchema: z.unknown(),
       tool: t,
     }));

--- a/src/cycling/sport.ts
+++ b/src/cycling/sport.ts
@@ -1,12 +1,13 @@
 import { readFileSync, readdirSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { z } from "zod";
-import type {
-  CoreDeps,
-  MemorySectionSpec,
-  MemorySnapshot,
-  Sport,
-  ToolRegistration,
+import {
+  getEffectiveSections,
+  type CoreDeps,
+  type MemorySectionSpec,
+  type MemorySnapshot,
+  type Sport,
+  type ToolRegistration,
 } from "@cycling-coach/core";
 import { createTools } from "../agent/tools.js";
 import { athleteProfileSchema } from "./schemas.js";
@@ -38,13 +39,23 @@ const CYCLING_VOCABULARY: readonly string[] = [
 ];
 
 const memorySections: readonly MemorySectionSpec[] = [
-  { name: "profile", description: "FTP, weight, age, experience level, max HR, resting HR, W/kg" },
-  { name: "schedule", description: "Training days, availability, weekly structure" },
-  { name: "goals", description: "Target events, FTP targets, race dates, milestones" },
-  { name: "equipment", description: "Bikes, trainer, power meter, head unit, indoor setup" },
-  { name: "health", description: "Injuries, sleep patterns, recovery needs, HRV" },
-  { name: "preferences", description: "Indoor/outdoor, coaching style, cross-training" },
-  { name: "notes", description: "Anything else important" },
+  {
+    name: "cycling-profile",
+    description:
+      "FTP (watts), max HR, resting HR, W/kg ratio, experience level. " +
+      "Body data lives in `person`; this is cycling-specific physiology.",
+  },
+  {
+    name: "cycling-equipment",
+    description: "Bikes, trainer, power meter, head unit, indoor setup",
+  },
+  {
+    name: "cycling-history",
+    description:
+      "Cycling-specific injuries (knee, lower back, fit issues), FTP test history, " +
+      "recovery patterns from rides, ride-related sleep/HRV trends. " +
+      "Chronic conditions belong in `medical-history`, not here.",
+  },
 ];
 
 export const cyclingSport: Sport = {
@@ -56,7 +67,7 @@ export const cyclingSport: Sport = {
   intervalsActivityTypes: ["Ride", "VirtualRide"],
   athleteProfileSchema,
   tools: (deps: CoreDeps): readonly ToolRegistration[] => {
-    const toolset = createTools(deps.memory, deps.intervals);
+    const toolset = createTools(deps.memory, deps.intervals, getEffectiveSections(cyclingSport));
     return Object.entries(toolset).map(([name, t]) => ({
       name,
       description: (t as { description?: string }).description ?? "",

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { parseArgs } from "node:util";
 import { loadConfig, resolveConfigSecrets } from "./config.js";
 import { SecretResolutionError } from "./secrets/types.js";
 import { CyclingCoachAgent } from "./agent/core.js";
+import { migrateCyclingLegacySections } from "./cycling/migrate-legacy-sections.js";
 import { createTelegramBot, notifyUpdate } from "./channels/telegram.js";
 
 // ============================================================================
@@ -79,6 +80,11 @@ async function main() {
   }
 
   const agent = new CyclingCoachAgent(config);
+
+  // One-shot migration of legacy cycling-coach section names. Runs once
+  // per process at startup, after Memory exists, before any chat handler
+  // is reachable. Idempotent — noop on already-migrated data.
+  migrateCyclingLegacySections(agent.getMemory());
 
   if (config.telegram.botToken) {
     // Telegram mode

--- a/tests/chronic-keyword-scan.test.ts
+++ b/tests/chronic-keyword-scan.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ModelMessage } from "ai";
+import type { MemorySectionSpec } from "@cycling-coach/core";
+import { Memory } from "../src/agent/memory.js";
+import { runMemoryFlush } from "../src/agent/memory-flush.js";
+import type { LLM } from "../src/agent/llm.js";
+
+// LLM stub that produces no tool calls — runMemoryFlush completes quickly,
+// then the post-flush scan runs. Lets us assert scan behavior without the
+// real LLM rewriting the file.
+function noopLLM(): LLM {
+  return {
+    async generate() {
+      return {
+        text: "",
+        toolCalls: [],
+        finishReason: "stop" as const,
+        usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+      };
+    },
+  } as unknown as LLM;
+}
+
+const SECTIONS: readonly MemorySectionSpec[] = [
+  { name: "cycling-history", description: "cycling-specific history" },
+  { name: "medical-history", description: "chronic conditions" },
+];
+
+const NO_MESSAGES: ModelMessage[] = [];
+
+// ─── Memory.readSection unit tests ───────────────────────────────────
+
+describe("Memory.readSection", () => {
+  let dataDir: string;
+  let memoryFile: string;
+
+  beforeEach(() => {
+    dataDir = mkdtempSync(join(tmpdir(), "cc-readsec-"));
+    memoryFile = join(dataDir, "memory", "MEMORY.md");
+  });
+
+  afterEach(() => {
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it("returns null when file is absent", () => {
+    const memory = new Memory(dataDir);
+    expect(memory.readSection("cycling-history")).toBeNull();
+  });
+
+  it("returns null when section is absent", () => {
+    const memory = new Memory(dataDir);
+    writeFileSync(memoryFile, "## schedule\nMon, Wed, Fri\n", "utf-8");
+    expect(memory.readSection("cycling-history")).toBeNull();
+  });
+
+  it("returns body without header or trailing newline", () => {
+    const memory = new Memory(dataDir);
+    writeFileSync(
+      memoryFile,
+      "## cycling-history\nKnee twinge resolved\n## schedule\nMon\n",
+      "utf-8",
+    );
+    expect(memory.readSection("cycling-history")).toBe("Knee twinge resolved");
+  });
+
+  it("returns empty string for an empty section body", () => {
+    const memory = new Memory(dataDir);
+    writeFileSync(memoryFile, "## cycling-history\n## schedule\nMon\n", "utf-8");
+    expect(memory.readSection("cycling-history")).toBe("");
+  });
+});
+
+// ─── post-flush chronic-keyword scan ──────────────────────────────────
+
+describe("post-flush chronic-keyword scan", () => {
+  let dataDir: string;
+  let memoryFile: string;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    dataDir = mkdtempSync(join(tmpdir(), "cc-scan-"));
+    mkdirSync(join(dataDir, "memory"), { recursive: true });
+    memoryFile = join(dataDir, "memory", "MEMORY.md");
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    rmSync(dataDir, { recursive: true, force: true });
+    warnSpy.mockRestore();
+  });
+
+  function warnEvents(): Array<Record<string, unknown>> {
+    return warnSpy.mock.calls
+      .map((args) => {
+        try {
+          return JSON.parse(String(args[0]));
+        } catch {
+          return null;
+        }
+      })
+      .filter((e): e is Record<string, unknown> => e !== null);
+  }
+
+  it("does not warn when cycling-history is absent", async () => {
+    const memory = new Memory(dataDir);
+    await runMemoryFlush({
+      llm: noopLLM(),
+      messages: NO_MESSAGES,
+      memory,
+      memorySections: SECTIONS,
+    });
+    expect(
+      warnEvents().filter((e) => e.event === "chronic_facts_stuck_in_cycling_history"),
+    ).toHaveLength(0);
+  });
+
+  it("does not warn when cycling-history has no chronic keywords", async () => {
+    writeFileSync(memoryFile, "## cycling-history\nKnee twinge resolved\n", "utf-8");
+    const memory = new Memory(dataDir);
+    await runMemoryFlush({
+      llm: noopLLM(),
+      messages: NO_MESSAGES,
+      memory,
+      memorySections: SECTIONS,
+    });
+    expect(
+      warnEvents().filter((e) => e.event === "chronic_facts_stuck_in_cycling_history"),
+    ).toHaveLength(0);
+  });
+
+  it("warns once with the keyword in payload when 'hypertension' is present", async () => {
+    writeFileSync(
+      memoryFile,
+      "## cycling-history\nFTP test history; hypertension noted at intake.\n",
+      "utf-8",
+    );
+    const memory = new Memory(dataDir);
+    await runMemoryFlush({
+      llm: noopLLM(),
+      messages: NO_MESSAGES,
+      memory,
+      memorySections: SECTIONS,
+    });
+    const stuck = warnEvents().filter(
+      (e) => e.event === "chronic_facts_stuck_in_cycling_history",
+    );
+    expect(stuck).toHaveLength(1);
+    expect(stuck[0].keywords).toEqual(["hypertension"]);
+    expect(stuck[0].hint).toContain("memory_flush");
+  });
+
+  it("collects multiple chronic keywords into one warn with all listed", async () => {
+    writeFileSync(
+      memoryFile,
+      "## cycling-history\nHypertension; lisinopril 10mg; long-term meds.\n",
+      "utf-8",
+    );
+    const memory = new Memory(dataDir);
+    await runMemoryFlush({
+      llm: noopLLM(),
+      messages: NO_MESSAGES,
+      memory,
+      memorySections: SECTIONS,
+    });
+    const stuck = warnEvents().filter(
+      (e) => e.event === "chronic_facts_stuck_in_cycling_history",
+    );
+    expect(stuck).toHaveLength(1);
+    expect(stuck[0].keywords).toEqual(
+      expect.arrayContaining(["hypertension", "lisinopril", "long-term"]),
+    );
+  });
+
+  it('substring match catches plural variants like "medications"', async () => {
+    writeFileSync(
+      memoryFile,
+      "## cycling-history\nOn medications since 2022.\n",
+      "utf-8",
+    );
+    const memory = new Memory(dataDir);
+    await runMemoryFlush({
+      llm: noopLLM(),
+      messages: NO_MESSAGES,
+      memory,
+      memorySections: SECTIONS,
+    });
+    const stuck = warnEvents().filter(
+      (e) => e.event === "chronic_facts_stuck_in_cycling_history",
+    );
+    expect(stuck).toHaveLength(1);
+    expect(stuck[0].keywords).toContain("medication");
+  });
+
+  it("matches case-insensitively", async () => {
+    writeFileSync(memoryFile, "## cycling-history\nDIABETES diagnosis 2020.\n", "utf-8");
+    const memory = new Memory(dataDir);
+    await runMemoryFlush({
+      llm: noopLLM(),
+      messages: NO_MESSAGES,
+      memory,
+      memorySections: SECTIONS,
+    });
+    const stuck = warnEvents().filter(
+      (e) => e.event === "chronic_facts_stuck_in_cycling_history",
+    );
+    expect(stuck).toHaveLength(1);
+    expect(stuck[0].keywords).toContain("diabetes");
+  });
+});

--- a/tests/compaction.test.ts
+++ b/tests/compaction.test.ts
@@ -59,7 +59,7 @@ const VALID_FOUR_SECTION_SUMMARY = [
   "- None outstanding",
 ].join("\n");
 
-const CYCLING_VOCABULARY = ["FTP", "W/kg", "Coggan", "VO2max", "watts", "sweet spot", "TTE"];
+import { CYCLING_VOCABULARY } from "../src/cycling/sport.js";
 
 const EMPTY_SNAPSHOT: MemorySnapshot = {
   read: () => null,

--- a/tests/compaction.test.ts
+++ b/tests/compaction.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from "vitest";
+import type { ModelMessage } from "ai";
+import {
+  auditSummaryQuality,
+  summarizeDroppedMessages,
+  summarizeInStages,
+} from "../src/agent/compaction.js";
+import type { LLM } from "../src/agent/llm.js";
+
+// ─── Test helpers ─────────────────────────────────────────────────────
+
+interface SpyLLM extends LLM {
+  capturedPrompts: string[];
+  capturedMessages: ModelMessage[][];
+}
+
+function createSpyLLM(response: string): SpyLLM {
+  const capturedPrompts: string[] = [];
+  const capturedMessages: ModelMessage[][] = [];
+  const spy = {
+    capturedPrompts,
+    capturedMessages,
+    async generate(opts: { prompt?: string; messages?: ModelMessage[] }) {
+      if (opts.prompt !== undefined) capturedPrompts.push(opts.prompt);
+      if (opts.messages !== undefined) capturedMessages.push(opts.messages);
+      return {
+        text: response,
+        toolCalls: [],
+        finishReason: "stop" as const,
+        usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+      };
+    },
+  };
+  return spy as unknown as SpyLLM;
+}
+
+const REPRESENTATIVE_CONVERSATION: ModelMessage[] = [
+  { role: "user", content: "My FTP is 247W and I weigh 72kg." },
+  { role: "assistant", content: "Got it. Logging FTP=247W, weight=72kg." },
+  { role: "user", content: "I train Monday, Wednesday, and Friday." },
+  { role: "assistant", content: "Schedule noted: Mon/Wed/Fri." },
+  { role: "user", content: "Goal: lift FTP to 280W by August for the Gran Fondo." },
+  { role: "assistant", content: "Target: FTP 280W by 2026-08, race type gran_fondo." },
+  { role: "user", content: "Bike is Trek Madone, power meter is Quarq DZero." },
+  { role: "assistant", content: "Equipment logged." },
+  { role: "user", content: "I had a knee issue last winter; it flares with high volume." },
+  { role: "assistant", content: "Health note: prior knee issue, watch high-volume blocks." },
+];
+
+const VALID_FOUR_SECTION_SUMMARY = [
+  "## Athlete Profile",
+  "- FTP 247W, 72kg, training Mon/Wed/Fri",
+  "## Training Status",
+  "- Build phase, target FTP 280W",
+  "## Discussion Context",
+  "- Goal-setting and equipment review",
+  "## Pending Questions",
+  "- None outstanding",
+].join("\n");
+
+// ─── Compaction smoke test (Wave 1 commit 4 baseline) ─────────────────
+//
+// Establishes the pre-parameterization baseline for compaction's
+// must-preserve behavior. Commit 5 parameterizes the MUST_PRESERVE block
+// against `sport.mustPreserveTokens`; this test should still pass after
+// that change because cyclingSport's vocabulary list overlaps with the
+// existing categorical instructions ("FTP", "W/kg" → still appear in
+// the prompt; the wording "athlete profile details" gets replaced by
+// the explicit token list).
+
+describe("compaction (baseline before sport parameterization)", () => {
+  it("summarizeDroppedMessages prompt instructs the LLM to preserve athlete data", async () => {
+    const spy = createSpyLLM(VALID_FOUR_SECTION_SUMMARY);
+
+    await summarizeDroppedMessages({
+      dropped: REPRESENTATIVE_CONVERSATION,
+      llm: spy,
+    });
+
+    expect(spy.capturedPrompts.length).toBeGreaterThan(0);
+    const prompt = spy.capturedPrompts[0];
+
+    // Hard contract: every compaction prompt must carry the
+    // MUST-PRESERVE instruction.
+    expect(prompt).toContain("MUST PRESERVE");
+
+    // Loose contract: today the prompt enumerates categories ("FTP, weight,
+    // experience, schedule, goals"). After commit 5 it will enumerate
+    // explicit tokens from `cyclingSport.mustPreserveTokens` instead. Either
+    // way, the FTP token and the user's actual data must surface.
+    expect(prompt).toContain("FTP");
+    expect(prompt).toContain("247W");
+    expect(prompt).toContain("72kg");
+  });
+
+  it("summarizeInStages prompt also carries the MUST-PRESERVE instruction", async () => {
+    const spy = createSpyLLM(VALID_FOUR_SECTION_SUMMARY);
+
+    await summarizeInStages({
+      messages: REPRESENTATIVE_CONVERSATION,
+      llm: spy,
+      recentToKeep: 2,
+    });
+
+    expect(spy.capturedPrompts.length).toBeGreaterThan(0);
+    expect(spy.capturedPrompts[0]).toContain("MUST PRESERVE");
+  });
+
+  it("auditSummaryQuality accepts a summary with all four required sections", () => {
+    const audit = auditSummaryQuality(VALID_FOUR_SECTION_SUMMARY);
+    expect(audit.ok).toBe(true);
+    expect(audit.missing).toEqual([]);
+  });
+
+  it("auditSummaryQuality flags a summary missing required sections", () => {
+    const partial = "## Athlete Profile\n- FTP 247W\n## Discussion Context\n- foo";
+    const audit = auditSummaryQuality(partial);
+    expect(audit.ok).toBe(false);
+    expect(audit.missing).toContain("## Training Status");
+    expect(audit.missing).toContain("## Pending Questions");
+  });
+});

--- a/tests/compaction.test.ts
+++ b/tests/compaction.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import type { ModelMessage } from "ai";
+import type { MemorySnapshot } from "@cycling-coach/core";
 import {
   auditSummaryQuality,
   summarizeDroppedMessages,
@@ -58,52 +59,83 @@ const VALID_FOUR_SECTION_SUMMARY = [
   "- None outstanding",
 ].join("\n");
 
-// ─── Compaction smoke test (Wave 1 commit 4 baseline) ─────────────────
-//
-// Establishes the pre-parameterization baseline for compaction's
-// must-preserve behavior. Commit 5 parameterizes the MUST_PRESERVE block
-// against `sport.mustPreserveTokens`; this test should still pass after
-// that change because cyclingSport's vocabulary list overlaps with the
-// existing categorical instructions ("FTP", "W/kg" → still appear in
-// the prompt; the wording "athlete profile details" gets replaced by
-// the explicit token list).
+const CYCLING_VOCABULARY = ["FTP", "W/kg", "Coggan", "VO2max", "watts", "sweet spot", "TTE"];
 
-describe("compaction (baseline before sport parameterization)", () => {
-  it("summarizeDroppedMessages prompt instructs the LLM to preserve athlete data", async () => {
+const EMPTY_SNAPSHOT: MemorySnapshot = {
+  read: () => null,
+  has: () => false,
+  listSections: () => [],
+};
+
+// ─── Compaction smoke test ────────────────────────────────────────────
+//
+// After commit 5 the MUST-PRESERVE block is parameterized against
+// `sport.mustPreserveTokens`. The test passes the cycling vocabulary
+// directly so the assertions don't depend on cyclingSport's runtime
+// state.
+
+describe("compaction (sport-parameterized)", () => {
+  it("summarizeDroppedMessages prompt carries MUST-PRESERVE + sport tokens + transcript data", async () => {
     const spy = createSpyLLM(VALID_FOUR_SECTION_SUMMARY);
 
     await summarizeDroppedMessages({
       dropped: REPRESENTATIVE_CONVERSATION,
       llm: spy,
+      mustPreserveTokens: CYCLING_VOCABULARY,
+      memory: EMPTY_SNAPSHOT,
     });
 
     expect(spy.capturedPrompts.length).toBeGreaterThan(0);
     const prompt = spy.capturedPrompts[0];
 
-    // Hard contract: every compaction prompt must carry the
-    // MUST-PRESERVE instruction.
+    // Hard contract: every compaction prompt carries the MUST-PRESERVE
+    // instruction.
     expect(prompt).toContain("MUST PRESERVE");
 
-    // Loose contract: today the prompt enumerates categories ("FTP, weight,
-    // experience, schedule, goals"). After commit 5 it will enumerate
-    // explicit tokens from `cyclingSport.mustPreserveTokens` instead. Either
-    // way, the FTP token and the user's actual data must surface.
+    // Sport-vocabulary tokens flow through.
     expect(prompt).toContain("FTP");
+    expect(prompt).toContain("W/kg");
+    expect(prompt).toContain("Coggan");
+
+    // Transcript data is included verbatim.
     expect(prompt).toContain("247W");
     expect(prompt).toContain("72kg");
   });
 
-  it("summarizeInStages prompt also carries the MUST-PRESERVE instruction", async () => {
+  it("summarizeDroppedMessages with function-form tokens calls the function with the snapshot", async () => {
+    const spy = createSpyLLM(VALID_FOUR_SECTION_SUMMARY);
+    const calls: MemorySnapshot[] = [];
+
+    await summarizeDroppedMessages({
+      dropped: REPRESENTATIVE_CONVERSATION,
+      llm: spy,
+      mustPreserveTokens: (snap) => {
+        calls.push(snap);
+        return ["FTP 247W", "DYNAMIC_TOKEN"];
+      },
+      memory: EMPTY_SNAPSHOT,
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toBe(EMPTY_SNAPSHOT);
+    expect(spy.capturedPrompts[0]).toContain("FTP 247W");
+    expect(spy.capturedPrompts[0]).toContain("DYNAMIC_TOKEN");
+  });
+
+  it("summarizeInStages prompt also carries the MUST-PRESERVE instruction and tokens", async () => {
     const spy = createSpyLLM(VALID_FOUR_SECTION_SUMMARY);
 
     await summarizeInStages({
       messages: REPRESENTATIVE_CONVERSATION,
       llm: spy,
+      mustPreserveTokens: CYCLING_VOCABULARY,
+      memory: EMPTY_SNAPSHOT,
       recentToKeep: 2,
     });
 
     expect(spy.capturedPrompts.length).toBeGreaterThan(0);
     expect(spy.capturedPrompts[0]).toContain("MUST PRESERVE");
+    expect(spy.capturedPrompts[0]).toContain("FTP");
   });
 
   it("auditSummaryQuality accepts a summary with all four required sections", () => {

--- a/tests/cycling-must-preserve.test.ts
+++ b/tests/cycling-must-preserve.test.ts
@@ -1,8 +1,6 @@
 import { describe, it, expect } from "vitest";
 import type { MemorySnapshot } from "@cycling-coach/core";
-import { cyclingSport } from "../src/cycling/sport.js";
-
-const CYCLING_VOCABULARY = ["FTP", "W/kg", "Coggan", "VO2max", "watts", "sweet spot", "TTE"];
+import { cyclingSport, CYCLING_VOCABULARY } from "../src/cycling/sport.js";
 
 function snapshot(sections: Record<string, string | null>): MemorySnapshot {
   return {
@@ -58,16 +56,16 @@ describe("cyclingSport.mustPreserveTokens", () => {
     expect(tokens.some((t) => t.startsWith("FTP "))).toBe(false);
   });
 
-  it("rejects 4-digit year collisions: 'FTP test 2024-06: 240W' → captures 240, not 2024", () => {
+  it("rejects 4-digit year collisions: 'FTP test 2024-06: 240W' → captures 247, not 2024", () => {
+    // The first "FTP" is followed by " test" — separator class doesn't match
+    // letters, so capture fails there. Regex moves to "current FTP 247W" and
+    // captures 247. Pinned to assert the deterministic outcome.
     const tokens = resolve({
       "cycling-profile": "FTP test 2024-06: 240W resulted in current FTP 247W",
     });
+    expect(tokens).toContain("FTP 247W");
     expect(tokens).not.toContain("FTP 2024W");
-    // First match: "FTP test 2024-06" → no separator-class match for "test"
-    // means the regex starts at the next FTP. Could be 240W or 247W depending
-    // on regex match positioning. Either is acceptable; "FTP 2024W" is the
-    // failure mode we explicitly reject.
-    expect(tokens.some((t) => t === "FTP 240W" || t === "FTP 247W")).toBe(true);
+    expect(tokens).not.toContain("FTP 240W");
   });
 
   it("rejects 4-digit FTP values (intentional guard against year capture)", () => {

--- a/tests/cycling-must-preserve.test.ts
+++ b/tests/cycling-must-preserve.test.ts
@@ -89,4 +89,10 @@ describe("cyclingSport.mustPreserveTokens", () => {
       }),
     ).toContain("FTP 280W");
   });
+
+  it("captures FTP at end of line (no trailing punctuation)", () => {
+    expect(
+      resolve({ "cycling-profile": "Max HR 188\nFTP 280W\nResting HR 52" }),
+    ).toContain("FTP 280W");
+  });
 });

--- a/tests/cycling-must-preserve.test.ts
+++ b/tests/cycling-must-preserve.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import type { MemorySnapshot } from "@cycling-coach/core";
+import { cyclingSport } from "../src/cycling/sport.js";
+
+const CYCLING_VOCABULARY = ["FTP", "W/kg", "Coggan", "VO2max", "watts", "sweet spot", "TTE"];
+
+function snapshot(sections: Record<string, string | null>): MemorySnapshot {
+  return {
+    read: (name: string) => sections[name] ?? null,
+    has: (name: string) => sections[name] != null && sections[name] !== "",
+    listSections: () => Object.keys(sections),
+  };
+}
+
+function resolve(sections: Record<string, string | null>): readonly string[] {
+  const fn = cyclingSport.mustPreserveTokens;
+  if (typeof fn !== "function") throw new Error("expected function form");
+  return fn(snapshot(sections));
+}
+
+describe("cyclingSport.mustPreserveTokens", () => {
+  it("returns CYCLING_VOCABULARY only when cycling-profile is absent", () => {
+    expect(resolve({})).toEqual(CYCLING_VOCABULARY);
+  });
+
+  it('adds "FTP 247W" when profile contains "FTP 247W"', () => {
+    expect(resolve({ "cycling-profile": "FTP 247W, 72kg" })).toContain("FTP 247W");
+  });
+
+  it('normalizes unit-less "FTP 247" to "FTP 247W"', () => {
+    expect(resolve({ "cycling-profile": "FTP 247, 72kg" })).toContain("FTP 247W");
+  });
+
+  it('handles "FTP: 247W" (colon separator)', () => {
+    expect(resolve({ "cycling-profile": "FTP: 247W" })).toContain("FTP 247W");
+  });
+
+  it('handles "FTP - 247" (dash separator)', () => {
+    expect(resolve({ "cycling-profile": "FTP - 247" })).toContain("FTP 247W");
+  });
+
+  it("returns first match only when multiple FTPs are present", () => {
+    const tokens = resolve({
+      "cycling-profile": "FTP 247W (current). Earlier FTP 235W in March.",
+    });
+    expect(tokens).toContain("FTP 247W");
+    expect(tokens).not.toContain("FTP 235W");
+  });
+
+  it("returns vocabulary only for new athletes (cycling-profile present, no FTP)", () => {
+    expect(resolve({ "cycling-profile": "Beginner; weight tracking only." })).toEqual(
+      CYCLING_VOCABULARY,
+    );
+  });
+
+  it("rejects unrealistically low FTP (< 50W) via 2-digit minimum", () => {
+    const tokens = resolve({ "cycling-profile": "FTP 5W (placeholder)" });
+    expect(tokens.some((t) => t.startsWith("FTP "))).toBe(false);
+  });
+
+  it("rejects 4-digit year collisions: 'FTP test 2024-06: 240W' → captures 240, not 2024", () => {
+    const tokens = resolve({
+      "cycling-profile": "FTP test 2024-06: 240W resulted in current FTP 247W",
+    });
+    expect(tokens).not.toContain("FTP 2024W");
+    // First match: "FTP test 2024-06" → no separator-class match for "test"
+    // means the regex starts at the next FTP. Could be 240W or 247W depending
+    // on regex match positioning. Either is acceptable; "FTP 2024W" is the
+    // failure mode we explicitly reject.
+    expect(tokens.some((t) => t === "FTP 240W" || t === "FTP 247W")).toBe(true);
+  });
+
+  it("rejects 4-digit FTP values (intentional guard against year capture)", () => {
+    const tokens = resolve({ "cycling-profile": "FTP 1000W" });
+    expect(tokens.some((t) => t.startsWith("FTP "))).toBe(false);
+  });
+
+  it("rejects trailing junk: 'FTP 247abc' → no capture (word boundary)", () => {
+    const tokens = resolve({ "cycling-profile": "FTP 247abc" });
+    expect(tokens.some((t) => t.startsWith("FTP "))).toBe(false);
+  });
+
+  it("captures FTP at start of section", () => {
+    expect(resolve({ "cycling-profile": "FTP 280W. Max HR 188." })).toContain("FTP 280W");
+  });
+
+  it("captures FTP after newline / mid-section", () => {
+    expect(
+      resolve({
+        "cycling-profile": "Max HR 188.\nFTP 280W.\nResting HR 52.",
+      }),
+    ).toContain("FTP 280W");
+  });
+});

--- a/tests/effective-sections.test.ts
+++ b/tests/effective-sections.test.ts
@@ -107,4 +107,35 @@ describe("getEffectiveSections", () => {
     expect(getEffectiveSections(sport)).toEqual(CORE_SHARED_SECTIONS);
     expect(warnSpy).not.toHaveBeenCalled();
   });
+
+  it("warns when sport's memorySections array contains an in-array duplicate", () => {
+    const sport = makeSport("cycling", [
+      { name: "cycling-profile", description: "first" },
+      { name: "cycling-profile", description: "second (dup)" },
+    ]);
+    const effective = getEffectiveSections(sport);
+
+    // First wins; only one cycling-profile in the result.
+    expect(effective.filter((s) => s.name === "cycling-profile")).toHaveLength(1);
+    expect(effective.find((s) => s.name === "cycling-profile")!.description).toBe("first");
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain("more than once");
+    expect(warnSpy.mock.calls[0][0]).toContain('"cycling-profile"');
+  });
+
+  it("distinguishes in-array duplicate from Core-shared collision (separate warn keys)", () => {
+    const sport = makeSport("cycling", [
+      { name: "schedule", description: "core overlap" },
+      { name: "cycling-profile", description: "first" },
+      { name: "cycling-profile", description: "second (dup)" },
+    ]);
+    getEffectiveSections(sport);
+
+    // 1 core-collision warn + 1 self-dup warn = 2 distinct warns.
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+    const messages = warnSpy.mock.calls.map((c) => String(c[0]));
+    expect(messages.some((m) => m.includes("Core-shared"))).toBe(true);
+    expect(messages.some((m) => m.includes("more than once"))).toBe(true);
+  });
 });

--- a/tests/effective-sections.test.ts
+++ b/tests/effective-sections.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  CORE_SHARED_SECTIONS,
+  getEffectiveSections,
+  _resetWarnCacheForTesting,
+  type MemorySectionSpec,
+  type Sport,
+} from "@cycling-coach/core";
+
+function makeSport(id: string, sections: readonly MemorySectionSpec[]): Sport {
+  return {
+    id,
+    soul: "",
+    skills: {},
+    memorySections: sections,
+    mustPreserveTokens: () => [],
+    intervalsActivityTypes: [],
+    athleteProfileSchema: {} as never,
+    tools: () => [],
+  };
+}
+
+describe("getEffectiveSections", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    _resetWarnCacheForTesting();
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it("returns Core sections + sport sections in stable order with no overlap", () => {
+    const sport = makeSport("cycling", [
+      { name: "cycling-profile", description: "FTP, max HR" },
+      { name: "cycling-equipment", description: "Bikes, trainer" },
+    ]);
+    const effective = getEffectiveSections(sport);
+
+    expect(effective.map((s) => s.name)).toEqual([
+      ...CORE_SHARED_SECTIONS.map((s) => s.name),
+      "cycling-profile",
+      "cycling-equipment",
+    ]);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('warns once when sport declares a Core-shared name (e.g. "schedule")', () => {
+    const sport = makeSport("cycling", [
+      { name: "schedule", description: "sport-side schedule (overlap)" },
+      { name: "cycling-profile", description: "FTP" },
+    ]);
+    const effective = getEffectiveSections(sport);
+
+    // Core's "schedule" wins
+    const schedule = effective.find((s) => s.name === "schedule");
+    expect(schedule?.description).toBe(
+      CORE_SHARED_SECTIONS.find((s) => s.name === "schedule")!.description,
+    );
+    // No duplicate "schedule" entries
+    expect(effective.filter((s) => s.name === "schedule")).toHaveLength(1);
+    // Effective list still ends with the unique sport section
+    expect(effective[effective.length - 1].name).toBe("cycling-profile");
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain('Sport "cycling"');
+    expect(warnSpy.mock.calls[0][0]).toContain('section "schedule"');
+  });
+
+  it("warns once per overlapping name when sport declares multiple", () => {
+    const sport = makeSport("cycling", [
+      { name: "schedule", description: "x" },
+      { name: "goals", description: "y" },
+      { name: "preferences", description: "z" },
+    ]);
+    getEffectiveSections(sport);
+
+    expect(warnSpy).toHaveBeenCalledTimes(3);
+  });
+
+  it("memoizes warns — calling N times with same overlap fires warn only once", () => {
+    const sport = makeSport("cycling", [{ name: "schedule", description: "x" }]);
+
+    getEffectiveSections(sport);
+    getEffectiveSections(sport);
+    getEffectiveSections(sport);
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("memoizes per (sport.id, name) — different sports warn independently for the same name", () => {
+    const cycling = makeSport("cycling", [{ name: "schedule", description: "c" }]);
+    const running = makeSport("running", [{ name: "schedule", description: "r" }]);
+
+    getEffectiveSections(cycling);
+    getEffectiveSections(running);
+
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+    expect(warnSpy.mock.calls[0][0]).toContain('"cycling"');
+    expect(warnSpy.mock.calls[1][0]).toContain('"running"');
+  });
+
+  it("returns CORE_SHARED_SECTIONS exactly when sport.memorySections is empty", () => {
+    const sport = makeSport("cycling", []);
+    expect(getEffectiveSections(sport)).toEqual(CORE_SHARED_SECTIONS);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/tests/empty-section-guards.test.ts
+++ b/tests/empty-section-guards.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ModelMessage } from "ai";
+import { createTools } from "../src/agent/tools.js";
+import { runMemoryFlush } from "../src/agent/memory-flush.js";
+import { Memory } from "../src/agent/memory.js";
+import type { LLM } from "../src/agent/llm.js";
+
+// Both consumers convert the section list into a non-empty Zod enum
+// (`z.enum([...] as [string, ...string[]])`). An empty list crashes Zod
+// with an opaque message; the explicit guard surfaces a real diagnostic.
+
+function noopLLM(): LLM {
+  return {
+    async generate() {
+      return {
+        text: "",
+        toolCalls: [],
+        finishReason: "stop" as const,
+        usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+      };
+    },
+  } as unknown as LLM;
+}
+
+describe("createTools — empty-section guard", () => {
+  let dataDir: string;
+
+  beforeEach(() => {
+    dataDir = mkdtempSync(join(tmpdir(), "cc-guard-"));
+  });
+  afterEach(() => {
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it("throws a clear error when sections is empty", () => {
+    const memory = new Memory(dataDir);
+    expect(() => createTools(memory, null, [])).toThrow(/at least one MemorySectionSpec/);
+  });
+});
+
+describe("runMemoryFlush — empty-section guard", () => {
+  let dataDir: string;
+
+  beforeEach(() => {
+    dataDir = mkdtempSync(join(tmpdir(), "cc-guard-"));
+  });
+  afterEach(() => {
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it("throws a clear error when memorySections is empty", async () => {
+    const memory = new Memory(dataDir);
+    await expect(
+      runMemoryFlush({
+        llm: noopLLM(),
+        messages: [] as ModelMessage[],
+        memory,
+        memorySections: [],
+      }),
+    ).rejects.toThrow(/at least one memory section/);
+  });
+});

--- a/tests/helpers/base-agent-config.ts
+++ b/tests/helpers/base-agent-config.ts
@@ -1,0 +1,23 @@
+/**
+ * Minimal config for constructing CyclingCoachAgent in tests. Uses the
+ * openai-codex provider with empty apiKey so no real LLM is reachable.
+ */
+export function baseAgentConfig(dataDir: string) {
+  return {
+    llm: {
+      provider: "openai-codex" as const,
+      model: "gpt-5.4",
+      apiKey: "",
+      authProfile: "openai-codex",
+    },
+    intervals: { apiKey: "", athleteId: "0" },
+    telegram: { botToken: "" },
+    session: {
+      historyTokenBudgetRatio: 0.3,
+      idleMinutes: 0,
+      dailyResetHour: 4,
+    },
+    contextWindowTokens: 272_000,
+    dataDir,
+  };
+}

--- a/tests/memory-rename-section.test.ts
+++ b/tests/memory-rename-section.test.ts
@@ -105,4 +105,23 @@ describe("Memory.renameSection", () => {
       "## cycling-profile\n## schedule\nMon, Wed, Fri\n",
     );
   });
+
+  it('renames a CRLF-encoded MEMORY.md (Windows-authored or pasted from Word)', () => {
+    const memory = new Memory(dataDir);
+    const path = join(dataDir, "memory", "MEMORY.md");
+    // Real-world failure mode: file written with CRLF line endings. Without
+    // normalization the marker check fails (sees `## profile\r\n` which does
+    // not startsWith `## profile\n`) and the rename silently no-ops.
+    writeFileSync(
+      path,
+      "## profile\r\nFTP 247W, 72kg\r\n## schedule\r\nMon, Wed, Fri\r\n",
+      "utf-8",
+    );
+
+    expect(memory.renameSection("profile", "cycling-profile")).toBe("renamed");
+    // Output is LF-normalized (Node writeFileSync emits LF).
+    expect(readFileSync(path, "utf-8")).toBe(
+      "## cycling-profile\nFTP 247W, 72kg\n## schedule\nMon, Wed, Fri\n",
+    );
+  });
 });

--- a/tests/memory-rename-section.test.ts
+++ b/tests/memory-rename-section.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Memory } from "../src/agent/memory.js";
+
+describe("Memory.renameSection", () => {
+  let dataDir: string;
+
+  beforeEach(() => {
+    dataDir = mkdtempSync(join(tmpdir(), "cc-rename-"));
+  });
+
+  afterEach(() => {
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it('returns "noop" and creates no file when MEMORY.md is absent', () => {
+    const memory = new Memory(dataDir);
+    expect(memory.renameSection("profile", "cycling-profile")).toBe("noop");
+    expect(existsSync(join(dataDir, "memory", "MEMORY.md"))).toBe(false);
+  });
+
+  it('returns "noop" and leaves file unchanged when section is absent', () => {
+    const memory = new Memory(dataDir);
+    const path = join(dataDir, "memory", "MEMORY.md");
+    const original = "## schedule\nMon, Wed, Fri\n## goals\nSub-3:30 century\n";
+    writeFileSync(path, original, "utf-8");
+
+    expect(memory.renameSection("profile", "cycling-profile")).toBe("noop");
+    expect(readFileSync(path, "utf-8")).toBe(original);
+  });
+
+  it('renames a section in the middle of the file, preserving header order and neighbors', () => {
+    const memory = new Memory(dataDir);
+    const path = join(dataDir, "memory", "MEMORY.md");
+    writeFileSync(
+      path,
+      "## schedule\nMon, Wed, Fri\n## profile\nFTP 247W, 72kg\n## goals\nSub-3:30 century\n",
+      "utf-8",
+    );
+
+    expect(memory.renameSection("profile", "cycling-profile")).toBe("renamed");
+    expect(readFileSync(path, "utf-8")).toBe(
+      "## schedule\nMon, Wed, Fri\n## cycling-profile\nFTP 247W, 72kg\n## goals\nSub-3:30 century\n",
+    );
+  });
+
+  it('renames the last section, matching writeSection trailing-newline style', () => {
+    const memory = new Memory(dataDir);
+    const path = join(dataDir, "memory", "MEMORY.md");
+    // writeSection writes "## section\ncontent\n" — trailing \n on each block.
+    // After rename, the same shape should hold for the (now last) renamed section.
+    memory.writeSection("schedule", "Mon, Wed, Fri");
+    memory.writeSection("health", "Knee twinge resolved");
+    const beforeRename = readFileSync(path, "utf-8");
+    expect(beforeRename.endsWith("## health\nKnee twinge resolved\n")).toBe(true);
+
+    expect(memory.renameSection("health", "cycling-history")).toBe("renamed");
+    const after = readFileSync(path, "utf-8");
+    expect(after.endsWith("## cycling-history\nKnee twinge resolved\n")).toBe(true);
+    // schedule (the prior section) should be untouched
+    expect(after.includes("## schedule\nMon, Wed, Fri\n")).toBe(true);
+  });
+
+  it('merges bodies under `to` when both sections exist; `from` block removed', () => {
+    const memory = new Memory(dataDir);
+    const path = join(dataDir, "memory", "MEMORY.md");
+    writeFileSync(
+      path,
+      "## cycling-history\nKnee twinge resolved\n## schedule\nMon, Wed, Fri\n## health\nHypertension; lisinopril 10mg\n",
+      "utf-8",
+    );
+
+    expect(memory.renameSection("health", "cycling-history")).toBe("merged");
+    const after = readFileSync(path, "utf-8");
+    // health block must be gone
+    expect(after.includes("## health")).toBe(false);
+    // cycling-history must contain both bodies, separated by one blank line
+    expect(after).toBe(
+      "## cycling-history\nKnee twinge resolved\n\nHypertension; lisinopril 10mg\n## schedule\nMon, Wed, Fri\n",
+    );
+  });
+
+  it('is idempotent: A→B then A→B yields "renamed" then "noop", file stable after second call', () => {
+    const memory = new Memory(dataDir);
+    const path = join(dataDir, "memory", "MEMORY.md");
+    writeFileSync(path, "## profile\nFTP 247W, 72kg\n## schedule\nMon, Wed, Fri\n", "utf-8");
+
+    expect(memory.renameSection("profile", "cycling-profile")).toBe("renamed");
+    const afterFirst = readFileSync(path, "utf-8");
+    expect(memory.renameSection("profile", "cycling-profile")).toBe("noop");
+    const afterSecond = readFileSync(path, "utf-8");
+    expect(afterSecond).toBe(afterFirst);
+  });
+
+  it('renames a section with empty body correctly', () => {
+    const memory = new Memory(dataDir);
+    const path = join(dataDir, "memory", "MEMORY.md");
+    // Empty body: header line, then immediately the next section's header.
+    writeFileSync(path, "## profile\n## schedule\nMon, Wed, Fri\n", "utf-8");
+
+    expect(memory.renameSection("profile", "cycling-profile")).toBe("renamed");
+    expect(readFileSync(path, "utf-8")).toBe(
+      "## cycling-profile\n## schedule\nMon, Wed, Fri\n",
+    );
+  });
+});

--- a/tests/migrate-cycling-legacy-sections.test.ts
+++ b/tests/migrate-cycling-legacy-sections.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { MemoryStore } from "@cycling-coach/core";
+import { Memory } from "../src/agent/memory.js";
+import { migrateCyclingLegacySections } from "../src/cycling/migrate-legacy-sections.js";
+
+describe("migrateCyclingLegacySections", () => {
+  let dataDir: string;
+  let memoryFile: string;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    dataDir = mkdtempSync(join(tmpdir(), "cc-migrate-"));
+    memoryFile = join(dataDir, "memory", "MEMORY.md");
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    rmSync(dataDir, { recursive: true, force: true });
+    logSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+
+  function logEvents(): Array<Record<string, unknown>> {
+    return logSpy.mock.calls.map((args) => JSON.parse(String(args[0])));
+  }
+
+  function warnEvents(): Array<Record<string, unknown>> {
+    return warnSpy.mock.calls.map((args) => JSON.parse(String(args[0])));
+  }
+
+  // ── per-rename behavior ──────────────────────────────────────────────
+
+  it("renames profile → cycling-profile when only legacy exists", () => {
+    const memory = new Memory(dataDir);
+    writeFileSync(memoryFile, "## profile\nFTP 247W, 72kg\n", "utf-8");
+
+    migrateCyclingLegacySections(memory);
+
+    expect(readFileSync(memoryFile, "utf-8")).toBe("## cycling-profile\nFTP 247W, 72kg\n");
+    expect(logEvents()).toContainEqual({
+      event: "section_rename",
+      from: "profile",
+      to: "cycling-profile",
+      outcome: "renamed",
+    });
+  });
+
+  it("renames equipment → cycling-equipment when only legacy exists", () => {
+    const memory = new Memory(dataDir);
+    writeFileSync(memoryFile, "## equipment\nTrek Émonda, Wahoo Kickr\n", "utf-8");
+
+    migrateCyclingLegacySections(memory);
+
+    expect(readFileSync(memoryFile, "utf-8")).toBe(
+      "## cycling-equipment\nTrek Émonda, Wahoo Kickr\n",
+    );
+    expect(logEvents()).toContainEqual({
+      event: "section_rename",
+      from: "equipment",
+      to: "cycling-equipment",
+      outcome: "renamed",
+    });
+  });
+
+  it("renames health → cycling-history when only legacy exists", () => {
+    const memory = new Memory(dataDir);
+    writeFileSync(memoryFile, "## health\nHypertension; lisinopril 10mg\n", "utf-8");
+
+    migrateCyclingLegacySections(memory);
+
+    expect(readFileSync(memoryFile, "utf-8")).toBe(
+      "## cycling-history\nHypertension; lisinopril 10mg\n",
+    );
+    expect(logEvents()).toContainEqual({
+      event: "section_rename",
+      from: "health",
+      to: "cycling-history",
+      outcome: "renamed",
+    });
+  });
+
+  it("emits noop for each legacy section absent", () => {
+    const memory = new Memory(dataDir);
+    writeFileSync(memoryFile, "## schedule\nMon, Wed, Fri\n", "utf-8");
+
+    migrateCyclingLegacySections(memory);
+
+    expect(readFileSync(memoryFile, "utf-8")).toBe("## schedule\nMon, Wed, Fri\n");
+    const outcomes = logEvents().map((e) => e.outcome);
+    expect(outcomes).toEqual(["noop", "noop", "noop"]);
+  });
+
+  it("merges when both legacy and target exist (per rename)", () => {
+    const memory = new Memory(dataDir);
+    writeFileSync(
+      memoryFile,
+      "## cycling-profile\nFTP 250W\n## profile\nFTP 247W, 72kg\n",
+      "utf-8",
+    );
+
+    migrateCyclingLegacySections(memory);
+
+    expect(readFileSync(memoryFile, "utf-8")).toBe(
+      "## cycling-profile\nFTP 250W\n\nFTP 247W, 72kg\n",
+    );
+    expect(logEvents()).toContainEqual({
+      event: "section_rename",
+      from: "profile",
+      to: "cycling-profile",
+      outcome: "merged",
+    });
+  });
+
+  // ── end-to-end ──────────────────────────────────────────────────────
+
+  it("migrates a realistic legacy MEMORY.md in one call; Core-shared sections untouched", () => {
+    const memory = new Memory(dataDir);
+    writeFileSync(
+      memoryFile,
+      "## profile\nFTP 247W, 72kg\n" +
+        "## schedule\nMon, Wed, Fri\n" +
+        "## goals\nSub-3:30 century in October\n" +
+        "## equipment\nTrek Émonda\n" +
+        "## health\nHypertension; lisinopril 10mg\n" +
+        "## preferences\nIndoor when raining\n" +
+        "## notes\nCurious about VO2max blocks\n",
+      "utf-8",
+    );
+
+    migrateCyclingLegacySections(memory);
+
+    const after = readFileSync(memoryFile, "utf-8");
+    // legacy names gone
+    expect(after.includes("## profile\n")).toBe(false);
+    expect(after.includes("## equipment\n")).toBe(false);
+    expect(after.includes("## health\n")).toBe(false);
+    // cycling-prefixed names present with original content
+    expect(after.includes("## cycling-profile\nFTP 247W, 72kg\n")).toBe(true);
+    expect(after.includes("## cycling-equipment\nTrek Émonda\n")).toBe(true);
+    expect(after.includes("## cycling-history\nHypertension; lisinopril 10mg\n")).toBe(true);
+    // Core-shared sections untouched
+    expect(after.includes("## schedule\nMon, Wed, Fri\n")).toBe(true);
+    expect(after.includes("## goals\nSub-3:30 century in October\n")).toBe(true);
+    expect(after.includes("## preferences\nIndoor when raining\n")).toBe(true);
+    expect(after.includes("## notes\nCurious about VO2max blocks\n")).toBe(true);
+  });
+
+  it("is idempotent — second call yields identical file state", () => {
+    const memory = new Memory(dataDir);
+    writeFileSync(
+      memoryFile,
+      "## profile\nFTP 247W\n## equipment\nTrek\n## health\nHypertension\n",
+      "utf-8",
+    );
+
+    migrateCyclingLegacySections(memory);
+    const afterFirst = readFileSync(memoryFile, "utf-8");
+    migrateCyclingLegacySections(memory);
+    const afterSecond = readFileSync(memoryFile, "utf-8");
+
+    expect(afterSecond).toBe(afterFirst);
+    // After second call, every rename should be a noop.
+    const secondCallEvents = logEvents().slice(3);
+    expect(secondCallEvents.map((e) => e.outcome)).toEqual(["noop", "noop", "noop"]);
+  });
+
+  // ── failure handling ────────────────────────────────────────────────
+
+  it("survives partial failure: prior renames stay committed, function does not throw", () => {
+    // Stub MemoryStore that throws on the third call only.
+    let calls = 0;
+    const captured: Array<[string, string]> = [];
+    const stub: MemoryStore = {
+      readMemory: () => "",
+      writeSection: () => {},
+      readDailyNotes: () => "",
+      appendDailyNote: () => {},
+      savePlan: () => {},
+      loadPlan: () => null,
+      reload: () => {},
+      getContext: () => "",
+      renameSection: (from, to) => {
+        calls++;
+        captured.push([from, to]);
+        if (calls === 3) throw new Error("disk full");
+        return "renamed";
+      },
+    };
+
+    expect(() => migrateCyclingLegacySections(stub)).not.toThrow();
+
+    // All three rename attempts were made (loop continued past the failure).
+    expect(captured).toEqual([
+      ["profile", "cycling-profile"],
+      ["equipment", "cycling-equipment"],
+      ["health", "cycling-history"],
+    ]);
+    // First two emit success; third emits failure.
+    expect(logEvents()).toHaveLength(2);
+    expect(warnEvents()).toContainEqual({
+      event: "section_rename_failed",
+      from: "health",
+      to: "cycling-history",
+      error: "Error: disk full",
+    });
+  });
+});

--- a/tests/migration-integration.test.ts
+++ b/tests/migration-integration.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { CyclingCoachAgent } from "../src/agent/core.js";
+import { migrateCyclingLegacySections } from "../src/cycling/migrate-legacy-sections.js";
+
+// Steps 1-3 of the Wave 2 integration test, per
+// docs/battle-plan-core-sport-seam-wave-2.md commit 10. Deterministic:
+// pre-seed legacy MEMORY.md → construct agent → invoke the wired-up
+// migrator → assert post-migration file shape. Steps 4-5 (LLM-driven
+// chronic-fact redistribution canary) ship with commit 11b.
+
+describe("Wave 2 migration — binary startup integration (steps 1-3)", () => {
+  let dataDir: string;
+  let memoryFile: string;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    dataDir = mkdtempSync(join(tmpdir(), "cc-migrate-int-"));
+    mkdirSync(join(dataDir, "memory"), { recursive: true });
+    memoryFile = join(dataDir, "memory", "MEMORY.md");
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    rmSync(dataDir, { recursive: true, force: true });
+    logSpy.mockRestore();
+  });
+
+  function baseConfig() {
+    return {
+      llm: {
+        provider: "openai-codex" as const,
+        model: "gpt-5.4",
+        apiKey: "",
+        authProfile: "openai-codex",
+      },
+      intervals: { apiKey: "", athleteId: "0" },
+      telegram: { botToken: "" },
+      session: {
+        historyTokenBudgetRatio: 0.3,
+        idleMinutes: 0,
+        dailyResetHour: 4,
+      },
+      contextWindowTokens: 272_000,
+      dataDir,
+    };
+  }
+
+  it("migrates legacy section names through agent.getMemory() at startup", () => {
+    // Step 1: pre-seed fixture with full legacy shape.
+    writeFileSync(
+      memoryFile,
+      "## profile\nFTP 247W, 72kg\n" +
+        "## schedule\nMon, Wed, Fri\n" +
+        "## goals\nSub-3:30 century in October\n" +
+        "## equipment\nTrek Émonda, Wahoo Kickr\n" +
+        "## health\nHypertension; lisinopril 10mg; knee twinge resolved\n" +
+        "## preferences\nIndoor when raining\n" +
+        "## notes\nCurious about VO2max blocks\n",
+      "utf-8",
+    );
+
+    // Step 2: construct the agent (mirrors src/index.ts startup path).
+    const agent = new CyclingCoachAgent(baseConfig());
+
+    // Wiring: this is exactly what src/index.ts does immediately after
+    // agent construction. The integration test asserts that calling the
+    // migrator via the agent's getMemory() accessor produces the expected
+    // file shape — proving the seam used by the binary is correct.
+    migrateCyclingLegacySections(agent.getMemory());
+
+    // Step 3: assert post-migration file shape.
+    const after = readFileSync(memoryFile, "utf-8");
+
+    // Legacy names absent
+    expect(after).not.toMatch(/^## profile$/m);
+    expect(after).not.toMatch(/^## equipment$/m);
+    expect(after).not.toMatch(/^## health$/m);
+
+    // Cycling-prefixed names present with original content
+    expect(after).toContain("## cycling-profile\nFTP 247W, 72kg\n");
+    expect(after).toContain("## cycling-equipment\nTrek Émonda, Wahoo Kickr\n");
+    expect(after).toContain(
+      "## cycling-history\nHypertension; lisinopril 10mg; knee twinge resolved\n",
+    );
+
+    // Core-shared sections untouched
+    expect(after).toContain("## schedule\nMon, Wed, Fri\n");
+    expect(after).toContain("## goals\nSub-3:30 century in October\n");
+    expect(after).toContain("## preferences\nIndoor when raining\n");
+    expect(after).toContain("## notes\nCurious about VO2max blocks\n");
+  });
+
+  it("is a no-op for fresh installs (no MEMORY.md present)", () => {
+    // No file pre-seeded. Construct agent, run migrator, file should not be created.
+    const agent = new CyclingCoachAgent(baseConfig());
+    expect(() => migrateCyclingLegacySections(agent.getMemory())).not.toThrow();
+
+    const events = logSpy.mock.calls.map((args) => JSON.parse(String(args[0])));
+    expect(events.map((e) => e.outcome)).toEqual(["noop", "noop", "noop"]);
+  });
+
+  it("is idempotent — second call after construction leaves file unchanged", () => {
+    writeFileSync(memoryFile, "## profile\nFTP 247W\n## schedule\nMon, Wed, Fri\n", "utf-8");
+
+    const agent = new CyclingCoachAgent(baseConfig());
+    migrateCyclingLegacySections(agent.getMemory());
+    const afterFirst = readFileSync(memoryFile, "utf-8");
+
+    migrateCyclingLegacySections(agent.getMemory());
+    const afterSecond = readFileSync(memoryFile, "utf-8");
+
+    expect(afterSecond).toBe(afterFirst);
+    expect(afterFirst).toContain("## cycling-profile\nFTP 247W\n");
+  });
+});

--- a/tests/migration-integration.test.ts
+++ b/tests/migration-integration.test.ts
@@ -4,12 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { CyclingCoachAgent } from "../src/agent/core.js";
 import { migrateCyclingLegacySections } from "../src/cycling/migrate-legacy-sections.js";
-
-// Steps 1-3 of the Wave 2 integration test, per
-// docs/battle-plan-core-sport-seam-wave-2.md commit 10. Deterministic:
-// pre-seed legacy MEMORY.md → construct agent → invoke the wired-up
-// migrator → assert post-migration file shape. Steps 4-5 (LLM-driven
-// chronic-fact redistribution canary) ship with commit 11b.
+import { baseAgentConfig } from "./helpers/base-agent-config.js";
 
 describe("Wave 2 migration — binary startup integration (steps 1-3)", () => {
   let dataDir: string;
@@ -28,26 +23,6 @@ describe("Wave 2 migration — binary startup integration (steps 1-3)", () => {
     logSpy.mockRestore();
   });
 
-  function baseConfig() {
-    return {
-      llm: {
-        provider: "openai-codex" as const,
-        model: "gpt-5.4",
-        apiKey: "",
-        authProfile: "openai-codex",
-      },
-      intervals: { apiKey: "", athleteId: "0" },
-      telegram: { botToken: "" },
-      session: {
-        historyTokenBudgetRatio: 0.3,
-        idleMinutes: 0,
-        dailyResetHour: 4,
-      },
-      contextWindowTokens: 272_000,
-      dataDir,
-    };
-  }
-
   it("migrates legacy section names through agent.getMemory() at startup", () => {
     // Step 1: pre-seed fixture with full legacy shape.
     writeFileSync(
@@ -63,7 +38,7 @@ describe("Wave 2 migration — binary startup integration (steps 1-3)", () => {
     );
 
     // Step 2: construct the agent (mirrors src/index.ts startup path).
-    const agent = new CyclingCoachAgent(baseConfig());
+    const agent = new CyclingCoachAgent(baseAgentConfig(dataDir));
 
     // Wiring: this is exactly what src/index.ts does immediately after
     // agent construction. The integration test asserts that calling the
@@ -95,7 +70,7 @@ describe("Wave 2 migration — binary startup integration (steps 1-3)", () => {
 
   it("is a no-op for fresh installs (no MEMORY.md present)", () => {
     // No file pre-seeded. Construct agent, run migrator, file should not be created.
-    const agent = new CyclingCoachAgent(baseConfig());
+    const agent = new CyclingCoachAgent(baseAgentConfig(dataDir));
     expect(() => migrateCyclingLegacySections(agent.getMemory())).not.toThrow();
 
     const events = logSpy.mock.calls.map((args) => JSON.parse(String(args[0])));
@@ -105,7 +80,7 @@ describe("Wave 2 migration — binary startup integration (steps 1-3)", () => {
   it("is idempotent — second call after construction leaves file unchanged", () => {
     writeFileSync(memoryFile, "## profile\nFTP 247W\n## schedule\nMon, Wed, Fri\n", "utf-8");
 
-    const agent = new CyclingCoachAgent(baseConfig());
+    const agent = new CyclingCoachAgent(baseAgentConfig(dataDir));
     migrateCyclingLegacySections(agent.getMemory());
     const afterFirst = readFileSync(memoryFile, "utf-8");
 

--- a/tests/retry-loop-codex.test.ts
+++ b/tests/retry-loop-codex.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdtempSync, rmSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { baseAgentConfig } from "./helpers/base-agent-config.js";
 
 let tempHome: string;
 let origHome: string | undefined;
@@ -22,26 +23,6 @@ afterEach(() => {
   rmSync(tempHome, { recursive: true, force: true });
   vi.restoreAllMocks();
 });
-
-function baseConfig() {
-  return {
-    llm: {
-      provider: "openai-codex" as const,
-      model: "gpt-5.4",
-      apiKey: "",
-      authProfile: "openai-codex",
-    },
-    intervals: { apiKey: "", athleteId: "0" },
-    telegram: { botToken: "" },
-    session: {
-      historyTokenBudgetRatio: 0.3,
-      idleMinutes: 0,
-      dailyResetHour: 4,
-    },
-    contextWindowTokens: 272_000,
-    dataDir,
-  };
-}
 
 async function setupAgent(complete: ReturnType<typeof vi.fn>) {
   const model = {
@@ -73,7 +54,7 @@ async function setupAgent(complete: ReturnType<typeof vi.fn>) {
   }));
 
   const { CyclingCoachAgent } = await import("../src/agent/core.js");
-  return new CyclingCoachAgent(baseConfig());
+  return new CyclingCoachAgent(baseAgentConfig(dataDir));
 }
 
 function mkAssistant(text: string, stopReason: "stop" | "length" = "stop") {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,10 @@
     "resolveJsonModule": true,
     "declaration": true,
     "declarationMap": true,
-    "sourceMap": true
+    "sourceMap": true,
+    "paths": {
+      "@cycling-coach/core": ["./packages/core/dist/index.d.ts"]
+    }
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist", "tests"]


### PR DESCRIPTION
## Summary

Implements waves 1 and 2 of the Core/Sport seam refactor (#47).

**Wave 1 (9 commits — `beed8ff`..`aedeec2`)** — extracted the `Sport` contract and parameterized agent code against it:
- `packages/core/` materializes `Sport` interface + paired contracts (`MemoryStore`, `MemorySnapshot`, `CoreDeps`, `ToolRegistration`, `LLM`, `SecretsResolver`, etc.)
- `cyclingSport` literal at `src/cycling/sport.ts`
- Compaction (`mustPreserveTokens`) + memory-flush (`memorySections`) parameterized against the sport
- System-prompt building takes soul + skills from sport (no more `PROJECT_ROOT` file IO)
- Tools registered via `cyclingSport.tools(coreDeps)`
- pnpm workspace skeleton + private packages

**Wave 2 (10 commits — `7da2080`..`170c73b`)** — memory section migration + cycling token enrichment:
- `Memory.renameSection` primitive (sport-agnostic) + cycling migrator (one-shot rename `profile/equipment/health` → `cycling-profile/cycling-equipment/cycling-history` at startup)
- `CORE_SHARED_SECTIONS` (universal sections: person, schedule, goals, preferences, notes, medical-history) + `getEffectiveSections(sport)` with Core-wins-on-collision dedupe and warn memoization
- Atomic flip: `cyclingSport` declares only the 3 cycling-prefixed sections; consumers (`memory_write` tool, `runMemoryFlush`) read effective list
- `mustPreserveTokens` derives the athlete's FTP value from `cycling-profile` for compaction preservation (year-collision-safe regex `\d{2,3}`)
- Post-flush chronic-keyword scan (`chronic_facts_stuck_in_cycling_history` log event) for observability on multi-flush convergence — replaces optimistic "convergence in one flush" claim
- QA hardening (CRLF normalization in `Memory.readMemory`, in-array duplicate detection in `getEffectiveSections`, empty-list guards in `createTools` + `runMemoryFlush`, migration-clause TODO marker)

**Behavior changes for existing cycling-coach users:**
- First binary restart triggers one-shot section-name migration (idempotent, structured `section_rename` log per outcome)
- LLM redistributes chronic facts from `cycling-history` → `medical-history` over 1-3 subsequent flushes (observable via the chronic-keyword log event)
- Workspace activation: `package.json` adds `"workspaces": ["packages/*"]`. Wave 2 is the first runtime consumer of `@cycling-coach/core` (Wave 1 used types-only, erased at compile time)

**ADR touched:** ADR-0003 amended with memory-section migration mechanics (resolves deferred Q8 from architect-review).

## ⚠️ Known follow-up before tagging release

This PR's `dist/` emits literal `import { getEffectiveSections } from "@cycling-coach/core"` in `dist/cycling/sport.js` and `dist/agent/core.js`. tsc's `paths` mapping is type-only — it doesn't bundle. In a `npm i -g cycling-coach` install, the runtime won't find `@cycling-coach/core` and will crash on first import.

**Wave 3 (planned next) bundles via tsup, which fixes this.** Don't tag a release between this merge and Wave 3 ship.

## Test plan

- [ ] CI passes `npm test` (312 passed, 1 skipped locally; 0 regressions)
- [ ] CI passes `npm run check` (typecheck + lint clean)
- [ ] **Manual LLM canary before tagging the next release:** run binary against a copy of real `~/.cycling-coach/memory/MEMORY.md`; drive a chat that mentions weight + a recent ride; verify after 1-3 flushes that `## person` contains weight/age, `## medical-history` contains chronic facts, `## cycling-history` no longer mentions hypertension/lisinopril, and the `chronic_facts_stuck_in_cycling_history` log event is silent on the 3rd flush.
- [ ] Hold release tag until Wave 3 (tsup bundling) is merged.