### PR TITLE
chore(release): defer library publishing; cycling-coach bundles workspace code

### DIFF
--- a/.changeset/initial-binaries.md
+++ b/.changeset/initial-binaries.md
@@ -1,7 +1,5 @@
 ---
 "cycling-coach": minor
-"running-coach": minor
-"duathlon-coach": minor
 ---
 
-Initial Wave 3 release with multi-package architecture. Cycling-coach binary now bundles via tsup (Wave 2's runtime resolution bug is fixed by externalizing @enduragent/* and letting npm dedupe at install). Running-coach and duathlon-coach are alpha placeholders.
+First release after the Core/Sport seam refactor (issue #47). cycling-coach is now bundled via tsup — `@enduragent/core` and `@enduragent/sport-cycling` are inlined into the binary's `dist/index.js` rather than being declared as runtime dependencies. End users continue to install a single npm package; the workspace split is invisible to them. Stub binaries (`running-coach`, `duathlon-coach`) and library packages (`@enduragent/*`) are private and not published — they will be published when the first external consumer needs them. See ADR-0010.

--- a/.changeset/initial-core.md
+++ b/.changeset/initial-core.md
@@ -1,5 +1,0 @@
----
-"@enduragent/core": major
----
-
-Initial public release. Sport-agnostic infrastructure for AI coaching agents — agent loop, memory, secrets, channels (Telegram), LLM transport, intervals.icu client, setup wizard, runBinary entry-point. Publishes the Sport contract.

--- a/.changeset/initial-sport-cycling.md
+++ b/.changeset/initial-sport-cycling.md
@@ -1,5 +1,0 @@
----
-"@enduragent/sport-cycling": major
----
-
-Initial public release. Cycling sport package — soul, skills, tools, schemas, FTP-based zones, must-preserve tokens. Implements the Sport contract from @enduragent/core.

--- a/.changeset/initial-sport-duathlon.md
+++ b/.changeset/initial-sport-duathlon.md
@@ -1,5 +1,0 @@
----
-"@enduragent/sport-duathlon": patch
----
-
-Initial placeholder. Real implementation pending.

--- a/.changeset/initial-sport-running.md
+++ b/.changeset/initial-sport-running.md
@@ -1,5 +1,0 @@
----
-"@enduragent/sport-running": patch
----
-
-Initial placeholder. Real implementation pending.

--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -29,11 +29,11 @@ If sport-cycling improves its FTP-test guidance, sport-duathlon inherits the imp
 
 After Wave 3 of the Core/Sport seam refactor (issue #47):
 
-- **Core** — implemented at `packages/core/`. Sport-agnostic; no cycling vocabulary leaks. Three-category tool split per ADR-0004 (Pure-Core memory + intervals tools live in Core; sport-injected config flows in via `BinaryConfig`/`Sport.intervalsActivityTypes`). Published as `@enduragent/core` (SemVer 1.0.0).
-- **Cycling** — implemented at `packages/sport-cycling/`. SOUL.md + skills/*.md inlined into the bundle via tsup `.md: text` loader and skills.generated.ts codegen. Published as `@enduragent/sport-cycling` (SemVer 1.0.0).
-- **Cycling Coach** — implemented at `packages/cycling-coach/`. 7-line bin shim. Published as `cycling-coach` (CalVer continues).
-- **Running, Duathlon, Running Coach, Duathlon Coach** — empty stubs at `packages/{sport-running,sport-duathlon,running-coach,duathlon-coach}/`. Published as alpha placeholders (0.0.1 / 2026.4.30) to reserve npm names and exercise the publish pipeline.
+- **Core** — implemented at `packages/core/`. Sport-agnostic; no cycling vocabulary leaks. Three-category tool split per ADR-0004 (Pure-Core memory + intervals tools live in Core; sport-injected config flows in via `BinaryConfig`/`Sport.intervalsActivityTypes`). Private workspace package (`@enduragent/core`); bundled into the `cycling-coach` binary at publish time, not separately published. See ADR-0009.
+- **Cycling** — implemented at `packages/sport-cycling/`. SOUL.md + skills/*.md inlined into the bundle via tsup `.md: text` loader and skills.generated.ts codegen. Private workspace package (`@enduragent/sport-cycling`); bundled into the `cycling-coach` binary at publish time, not separately published.
+- **Cycling Coach** — implemented at `packages/cycling-coach/`. 7-line bin shim. Published as `cycling-coach` on npm (CalVer continues). The published tarball is self-contained — `@enduragent/*` workspace code is inlined via `tsup` `noExternal`.
+- **Running, Duathlon, Running Coach, Duathlon Coach** — empty stubs at `packages/{sport-running,sport-duathlon,running-coach,duathlon-coach}/`. Private workspace packages (SemVer); not published. They graduate to public CalVer-versioned npm binaries once a real implementation lands.
 
-## Wave 3 release flow
+## Release flow
 
-Changesets-driven (`.changeset/*.md` + `pnpm exec changeset` CLI). The publish workflow runs on push:main, gates on build + test + smoke (matrix across the 3 binary packages), then merges the bot's Version PR to publish via OIDC trusted publisher (no NPM_TOKEN). `tools/bump-binaries-to-calver.ts` overrides changesets' SemVer bumps for binary packages with today's CalVer.
+Changesets-driven (`.changeset/*.md` + `pnpm exec changeset` CLI). The publish workflow runs on push:main, gates on build + test + smoke, then merges the bot's Version PR to publish via OIDC trusted publisher (no NPM_TOKEN). Currently only `cycling-coach` is publishable (per ADR-0009); `pnpm publish -r` skips the private libraries and stub binaries automatically. `tools/bump-binaries-to-calver.ts` overrides changesets' SemVer bumps with today's CalVer for published binaries.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@enduragent/core",
   "version": "0.0.0",
-  "private": false,
+  "private": true,
   "description": "Sport-agnostic infrastructure for AI coaching agents (agent loop, memory, secrets, channels, LLM, intervals.icu). Publishes the Sport contract.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/cycling-coach/CONTEXT.md
+++ b/packages/cycling-coach/CONTEXT.md
@@ -4,7 +4,7 @@ The published `cycling-coach` npm binary. A 7-line shim that wires the cycling s
 
 ## Status: published
 
-Bundled via tsup with `@enduragent/*` externalized — npm dedupes Core and sport-cycling at install time, fixing Wave 2's runtime resolution bug. CalVer scheme (`YYYY.M.D[-N]`) continues; library deps follow SemVer.
+Bundled via tsup with `@enduragent/*` **inlined** (`noExternal`). The published tarball's `dist/index.js` contains all the workspace code — Core, sport-cycling, and the binary shim — so end users install one self-contained package. CalVer scheme (`YYYY.M.D[-N]`) continues. Library packages stay private workspace deps until an external consumer needs them; see ADR-0009.
 
 ## What lives here
 

--- a/packages/cycling-coach/package.json
+++ b/packages/cycling-coach/package.json
@@ -17,10 +17,22 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@enduragent/core": "workspace:*",
-    "@enduragent/sport-cycling": "workspace:*"
+    "@ai-sdk/anthropic": "^3.0.69",
+    "@ai-sdk/google": "^3.0.63",
+    "@ai-sdk/openai": "^3.0.52",
+    "@ai-sdk/provider": "^3.0.9",
+    "@ai-sdk/provider-utils": "^4.0.24",
+    "@clack/prompts": "^1.2.0",
+    "@mariozechner/pi-ai": "0.67.6",
+    "ai": "^6.0.158",
+    "grammy": "^1.42.0",
+    "intervals-icu-api": "^0.1.2",
+    "yaml": "^2.8.3",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@enduragent/core": "workspace:*",
+    "@enduragent/sport-cycling": "workspace:*",
     "@types/node": "^25.6.0",
     "tsup": "^8.4.0",
     "typescript": "^6.0.2",

--- a/packages/cycling-coach/tsup.config.ts
+++ b/packages/cycling-coach/tsup.config.ts
@@ -6,10 +6,10 @@ export default defineConfig({
   sourcemap: true,
   clean: true,
   splitting: false,
-  // Externalize @enduragent/* explicitly. tsup's default already externalizes
-  // dependencies, but the explicit regex makes the multi-package dedup
-  // contract obvious to a reader.
-  external: [/^@enduragent\//],
+  // Bundle @enduragent/* into the binary. The libs are private workspace
+  // packages (not published to npm) — bundling makes the published tarball
+  // self-contained. See ADR-0010.
+  noExternal: [/^@enduragent\//],
   // Shebang for the bin field — npm preserves bin permissions on publish.
   banner: { js: "#!/usr/bin/env node" },
 });

--- a/packages/duathlon-coach/CONTEXT.md
+++ b/packages/duathlon-coach/CONTEXT.md
@@ -4,4 +4,4 @@ Not yet implemented. Tracked in issue #47. When implemented, this binary will wr
 
 ## Status: alpha — empty stub
 
-The package exists on npm to reserve the binary name and exercise the publish pipeline. The current `duathlon-coach` CLI prints a status banner and exits.
+Private workspace package — not currently published. Existing `duathlon-coach@0.0.0` placeholder on npm stays as-is until a real implementation lands; at that point this package flips to `private: false`, adopts CalVer, and ships as a real binary. See ADR-0009.

--- a/packages/duathlon-coach/package.json
+++ b/packages/duathlon-coach/package.json
@@ -1,7 +1,7 @@
 {
   "name": "duathlon-coach",
-  "version": "2026.4.30",
-  "private": false,
+  "version": "0.0.1",
+  "private": true,
   "description": "AI duathlon coaching agent (alpha — not yet implemented).",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/running-coach/CONTEXT.md
+++ b/packages/running-coach/CONTEXT.md
@@ -4,4 +4,4 @@ Not yet implemented. Tracked in issue #47. When implemented, this binary will wr
 
 ## Status: alpha — empty stub
 
-The package exists on npm to reserve the binary name and exercise the publish pipeline. The current `running-coach` CLI prints a status banner and exits.
+Private workspace package — not currently published. Existing `running-coach@0.0.0` placeholder on npm stays as-is until a real implementation lands; at that point this package flips to `private: false`, adopts CalVer, and ships as a real binary. See ADR-0009.

--- a/packages/running-coach/package.json
+++ b/packages/running-coach/package.json
@@ -1,7 +1,7 @@
 {
   "name": "running-coach",
-  "version": "2026.4.30",
-  "private": false,
+  "version": "0.0.1",
+  "private": true,
   "description": "AI running coaching agent (alpha — not yet implemented).",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/sport-cycling/package.json
+++ b/packages/sport-cycling/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@enduragent/sport-cycling",
   "version": "0.0.0",
-  "private": false,
+  "private": true,
   "description": "Cycling sport package — soul, skills, tools, schemas, must-preserve tokens. Implements the Sport contract from @enduragent/core.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/sport-duathlon/CONTEXT.md
+++ b/packages/sport-duathlon/CONTEXT.md
@@ -4,4 +4,4 @@ Not yet implemented. Tracked in issue #47. When implemented, this context will o
 
 ## Status: alpha — empty stub
 
-The package exists on npm to reserve the name and exercise the publish pipeline. No real Sport implementation yet.
+Private workspace package — not published to npm. Becomes a published `@enduragent/sport-duathlon` (SemVer) when a real Sport implementation lands and an external consumer needs it. See ADR-0009.

--- a/packages/sport-duathlon/package.json
+++ b/packages/sport-duathlon/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@enduragent/sport-duathlon",
   "version": "0.0.1",
-  "private": false,
+  "private": true,
   "description": "Duathlon coordinator sport package (alpha — not yet implemented). Composes sport-cycling + sport-running per ADR-0002.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/sport-running/CONTEXT.md
+++ b/packages/sport-running/CONTEXT.md
@@ -4,4 +4,4 @@ Not yet implemented. Tracked in issue #47. When implemented, this context will o
 
 ## Status: alpha — empty stub
 
-The package exists on npm to reserve the name and exercise the publish pipeline. No real Sport implementation yet.
+Private workspace package — not published to npm. Becomes a published `@enduragent/sport-running` (SemVer) when a real Sport implementation lands and an external consumer needs it. See ADR-0009.

--- a/packages/sport-running/package.json
+++ b/packages/sport-running/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@enduragent/sport-running",
   "version": "0.0.1",
-  "private": false,
+  "private": true,
   "description": "Running sport package (alpha — not yet implemented). Implements the Sport contract from @enduragent/core.",
   "type": "module",
   "main": "dist/index.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,13 +93,49 @@ importers:
 
   packages/cycling-coach:
     dependencies:
+      '@ai-sdk/anthropic':
+        specifier: ^3.0.69
+        version: 3.0.72(zod@4.4.1)
+      '@ai-sdk/google':
+        specifier: ^3.0.63
+        version: 3.0.65(zod@4.4.1)
+      '@ai-sdk/openai':
+        specifier: ^3.0.52
+        version: 3.0.54(zod@4.4.1)
+      '@ai-sdk/provider':
+        specifier: ^3.0.9
+        version: 3.0.9
+      '@ai-sdk/provider-utils':
+        specifier: ^4.0.24
+        version: 4.0.24(zod@4.4.1)
+      '@clack/prompts':
+        specifier: ^1.2.0
+        version: 1.3.0
+      '@mariozechner/pi-ai':
+        specifier: 0.67.6
+        version: 0.67.6(ws@8.20.0)(zod@4.4.1)
+      ai:
+        specifier: ^6.0.158
+        version: 6.0.170(zod@4.4.1)
+      grammy:
+        specifier: ^1.42.0
+        version: 1.42.0
+      intervals-icu-api:
+        specifier: ^0.1.2
+        version: 0.1.2(typescript@6.0.3)
+      yaml:
+        specifier: ^2.8.3
+        version: 2.8.3
+      zod:
+        specifier: ^4.3.6
+        version: 4.4.1
+    devDependencies:
       '@enduragent/core':
         specifier: workspace:*
         version: link:../core
       '@enduragent/sport-cycling':
         specifier: workspace:*
         version: link:../sport-cycling
-    devDependencies:
       '@types/node':
         specifier: ^25.6.0
         version: 25.6.0

--- a/tools/bump-binaries-to-calver.ts
+++ b/tools/bump-binaries-to-calver.ts
@@ -1,9 +1,14 @@
 #!/usr/bin/env tsx
 /**
- * Override changesets' SemVer bumps on binary packages with CalVer (YYYY.M.D[-N]).
- * Library packages (@enduragent/*) keep changesets' SemVer bumps.
+ * Override changesets' SemVer bumps on published binary packages with CalVer
+ * (YYYY.M.D[-N]). All other packages (libs, private stub binaries) keep
+ * changesets' SemVer bumps.
  *
  * Run after `pnpm exec changeset version` in CI, before `pnpm publish -r`.
+ *
+ * Currently the only published binary is `cycling-coach`. When `running-coach`
+ * or `duathlon-coach` graduate from private stubs to real npm-published
+ * binaries, add their names to BINARY_PACKAGES. See ADR-0010.
  *
  * Same-day re-release strategy:
  *   The -N suffix handles multiple binary releases on a single day. The next
@@ -22,14 +27,13 @@
  *   and log a warning naming the failed package + reason. On a first publish
  *   this is correct; on a subsequent publish with no network the publish step
  *   will fail with a "version already exists" error — surfaced clearly to the
- *   operator rather than silently corrupting state. The 30s cap bounds the
- *   worst-case CI overhead at 30s × N binaries (currently 3, so 90s).
+ *   operator rather than silently corrupting state.
  */
 import { execSync } from "node:child_process";
 import { readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
-const BINARY_PACKAGES = ["cycling-coach", "running-coach", "duathlon-coach"];
+const BINARY_PACKAGES = ["cycling-coach"];
 
 function todayCalVer(): string {
   const now = new Date();


### PR DESCRIPTION
## Summary

- Only `cycling-coach` ships to npm. `@enduragent/*` libs and stub binaries (`running-coach`, `duathlon-coach`) are now `private: true` and skipped by `pnpm publish -r`.
- `cycling-coach` bundles `@enduragent/core` + `@enduragent/sport-cycling` via tsup `noExternal`. Published tarball is self-contained — `dependencies` lists the 12 transitive third-party runtime deps directly.
- Versioning rule clarified: **CalVer for npm-published binaries** (just `cycling-coach`), **SemVer for everything else** (libs + private stubs).

## Why

No external consumer needs `@enduragent/*` libs yet (cycling-coach is the only consumer, and it's in this same workspace). Publishing 7 packages doubles OIDC setup, multiplies changelogs, and ships `0.0.0` placeholder stub binaries that nobody installs. Deferring the lib publish until a real consumer materializes drops the operator surface from 7 OIDC trust configs to 1.

The workspace boundaries (Core / Sport / Binary) stay intact — this is a publishing-strategy decision, not an architectural reversal. Reverse path (flip `private: false`, configure OIDC on that one package, ship) is documented.

## Verification

- `pnpm test` — 323 passed / 1 skipped, all green
- `pnpm -r build` — all 7 packages build clean
- `pnpm pack` on cycling-coach — 187 KB tarball, zero `@enduragent/` runtime imports in `dist/index.js`
- End-to-end install simulation: `npm install <tarball>` from a consumer project resolves cleanly (skips devDeps as expected); `node dist/index.js --help` prints the expected usage.

## Test plan

- [ ] Configure OIDC trusted publisher for **`cycling-coach` only** at npmjs.com (one-time, was originally planned for 7 packages)
- [ ] First publish run after merge: watch the publish job logs; verify only `cycling-coach` ships and `pnpm publish -r` reports `private` skips for the other six
- [ ] Confirm CalVer increment on `cycling-coach` (was `2026.4.26`; should advance to today's date or `-N` suffix)

## Notes

- Decision recorded in `docs/adr/0009-defer-library-publishing.md` (local-only per repo convention; full reasoning + reverse path).
- ADR-0007 (all-CalVer) amended with a supersession note for libraries.
- `CONTEXT-MAP.md` and 5 per-package `CONTEXT.md` updated to reflect the new state (these ship).