### PR TITLE
chore(ci): shrink release smoke matrix to cycling-coach only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,11 @@ jobs:
       contents: read
     strategy:
       matrix:
-        binary: [cycling-coach, running-coach, duathlon-coach]
+        # Only published binaries belong here. Per ADR-0009, running-coach and
+        # duathlon-coach are private workspace stubs — pnpm pack would fetch
+        # their unpublished @enduragent/* deps and fail the smoke install.
+        # Add them back when they graduate to real npm-published binaries.
+        binary: [cycling-coach]
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v3


### PR DESCRIPTION
## Summary

Per ADR-0009 (PR #51), running-coach and duathlon-coach are private workspace stubs. Their `@enduragent/*` deps aren't on npm, so the smoke job's `npm install --omit=dev` step hits a 404 and fails the whole release before publish can run. This shrinks the smoke matrix to just `cycling-coach`.

The previous PR #51 missed updating release.yml — caught when watching the post-merge release run fail on the running-coach smoke step.

## Test plan

- [ ] CI on this PR passes (the smoke matrix only needs cycling-coach now)
- [ ] After merge: release run completes through smoke + publish, cycling-coach actually ships