### PR TITLE
fix(test): bump 1Password signin-flow timeout to 15s

### DIFF
--- a/packages/core/tests/setup.secret-ref.test.ts
+++ b/packages/core/tests/setup.secret-ref.test.ts
@@ -658,7 +658,10 @@ describe("1Password backend", () => {
     ]);
   });
 
-  it("needs-signin → op signin succeeds → re-detect ready → continues into op branch", async () => {
+  // 15s timeout — the spawn mock chain (child_process → detectBackends re-poll
+  // → @clack/prompts) is timing-sensitive under CI load and has flaked the
+  // default 5s twice. Bumping is cheaper than a full rewrite of the mock setup.
+  it("needs-signin → op signin succeeds → re-detect ready → continues into op branch", { timeout: 15000 }, async () => {
     let detectCalls = 0;
     vi.doMock("../src/secrets/backends/detect.js", () => ({
       detectBackends: vi.fn(async () => {


### PR DESCRIPTION
## Summary

`setup.secret-ref.test.ts:661` (the 1Password "needs-signin → ready" flow test) has flaked the default 5s timeout twice in two days — once locally during the PR #51 verification, once on PR #52 CI. The mock chain (`child_process.spawn` → `detectBackends` re-poll → `@clack/prompts`) is timing-sensitive under load.

## Fix

Bump the per-test timeout to 15s via vitest's `it("...", { timeout }, fn)` signature. The happy-path completes in ~200ms; 15s is pure headroom for CI flake.

## Why not refactor the mock?

The mock surface is large (multiple `vi.doMock` calls plus a custom event-emitter for `spawn`). A timeout bump is ~1 LoC; a rewrite is significant work for a marginal win. If this test continues to flake even at 15s, the underlying flakiness is real and worth a structural fix.

## Test plan

- [ ] CI passes (no other tests touched, just the timeout)