### PR TITLE
fix(ci): unblock release — smoke install + 1Password test

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,17 +63,21 @@ jobs:
       - run: pnpm -r build
       - name: Pack and smoke ${{ matrix.binary }}
         # PG-8: no `|| true`; set -euo pipefail; 30s timeout (cold Alpine OK).
-        # pnpm pack rewrites workspace:* to actual versions in the tarball.
-        # Use npm install (not pnpm) to simulate end-user `npm i -g <binary>`.
+        # Install the packed tarball as a *dependency* in a fresh consumer
+        # project. This is what end users do (`npm i -g <binary>` resolves
+        # only `dependencies`, never devDependencies). Installing in-place via
+        # `npm install --omit=dev` doesn't work — npm resolves the full
+        # dep graph (including devDeps) before applying --omit, so unpublished
+        # workspace devDeps cause 404s.
         run: |
           set -euo pipefail
           cd packages/${{ matrix.binary }}
-          pnpm pack --pack-destination /tmp/smoke-${{ matrix.binary }}
-          mkdir -p /tmp/smoke-extract-${{ matrix.binary }}
-          tar -xf /tmp/smoke-${{ matrix.binary }}/*.tgz -C /tmp/smoke-extract-${{ matrix.binary }} --strip-components=1
-          cd /tmp/smoke-extract-${{ matrix.binary }}
-          npm install --omit=dev
-          timeout 30 node dist/index.js --help
+          pnpm pack --pack-destination /tmp/smoke-pack-${{ matrix.binary }}
+          mkdir -p /tmp/smoke-consumer-${{ matrix.binary }}
+          cd /tmp/smoke-consumer-${{ matrix.binary }}
+          npm init -y > /dev/null
+          npm install /tmp/smoke-pack-${{ matrix.binary }}/*.tgz
+          timeout 30 node node_modules/${{ matrix.binary }}/dist/index.js --help
 
   publish:
     runs-on: ubuntu-latest

--- a/packages/core/tests/setup.secret-ref.test.ts
+++ b/packages/core/tests/setup.secret-ref.test.ts
@@ -658,10 +658,7 @@ describe("1Password backend", () => {
     ]);
   });
 
-  // 15s timeout — the spawn mock chain (child_process → detectBackends re-poll
-  // → @clack/prompts) is timing-sensitive under CI load and has flaked the
-  // default 5s twice. Bumping is cheaper than a full rewrite of the mock setup.
-  it("needs-signin → op signin succeeds → re-detect ready → continues into op branch", { timeout: 15000 }, async () => {
+  it("needs-signin → op signin succeeds → re-detect ready → continues into op branch", async () => {
     let detectCalls = 0;
     vi.doMock("../src/secrets/backends/detect.js", () => ({
       detectBackends: vi.fn(async () => {
@@ -678,38 +675,17 @@ describe("1Password backend", () => {
         };
       }),
     }));
+    // Stub child_process.spawn so the `op signin` call resolves immediately
+    // with a successful exit code. setImmediate (not synchronous) so the
+    // listener registration order in runOpSignin is preserved.
     vi.doMock("node:child_process", () => ({
-      spawn: vi.fn(() => {
-        const listeners: Record<string, (code: number) => void> = {};
-        return {
-          on: (event: string, cb: (code: number) => void) => {
-            listeners[event] = cb;
-          },
-          emit: (event: string, code: number) => listeners[event]?.(code),
-          // fire 'close' with 0 immediately on next tick
-          _fire: () => setImmediate(() => listeners["close"]?.(0)),
-        };
-      }),
-    }));
-    // Because the child_process mock's spawn won't auto-emit, I need to
-    // patch the behavior differently. Instead, mock the OS "op signin" by
-    // pre-setting the second detectBackends call to "ready" and accepting
-    // that runOpSignin resolves to true. The simplest approach: replace
-    // child_process.spawn with a synchronous stub that emits close(0)
-    // asynchronously.
-    vi.doMock("node:child_process", () => ({
-      spawn: vi.fn(() => {
-        const listeners: Record<string, (code: number) => void> = {};
-        const emitter = {
-          on: (event: string, cb: (code: number) => void) => {
-            listeners[event] = cb;
-            if (event === "close") {
-              setImmediate(() => cb(0));
-            }
-          },
-        };
-        return emitter;
-      }),
+      spawn: vi.fn(() => ({
+        on: (event: string, cb: (code: number) => void) => {
+          if (event === "close") {
+            setImmediate(() => cb(0));
+          }
+        },
+      })),
     }));
     vi.doMock("@clack/prompts", () =>
       scriptedPrompts({


### PR DESCRIPTION
## Summary

Two CI fixes that together unblock the release pipeline post-PR #51 (defer library publishing).

### 1. Smoke step now installs as a dep, not in-place

The smoke step was running `npm install --omit=dev` inside the extracted tarball directory. That fails on the new layout — cycling-coach's package.json has `@enduragent/core` and `@enduragent/sport-cycling` as devDependencies (post-PR #51, where they're bundled via tsup), and npm resolves the full dep graph before applying `--omit=dev`, hitting a 404.

End users never do that. They run `npm i -g cycling-coach` which only ever installs `dependencies`. This rewrites the smoke step to actually simulate that flow:

```bash
mkdir consumer && cd consumer
npm init -y
npm install /path/to/cycling-coach.tgz
node node_modules/cycling-coach/dist/index.js --help
```

### 2. Delete dead duplicate vi.doMock in 1Password signin test

The test had two consecutive `vi.doMock("node:child_process", ...)` calls. The first registered a stub that never auto-fired the close event; the author left a comment realizing this and added a second stub that does. Vitest's behavior with two doMocks for the same module inside the same test is racy, which made the test flake — bumped the timeout to 15s in PR #53, and even that timed out in CI.

Deleting the dead first mock resolves the race. Test now passes in ~4ms (vs. timing out at 15s). The 15s timeout from PR #53 is removed since it's no longer needed.

## Test plan

- [ ] CI on this PR: test job + (after merge) the next release run's smoke job both pass
- [ ] After merge: release run completes through publish; cycling-coach actually ships to npm with a CalVer bump