### PR TITLE
fix(ci): pin changesets/action to real tag v1.4.10

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,7 +105,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm -r build
       - name: Create Version PR or publish
-        uses: changesets/action@v1.4   # PG-15: pin major version
+        uses: changesets/action@v1.4.10   # PG-15: latest in 1.4.x series
         with:
           version: |
             pnpm exec changeset version


### PR DESCRIPTION
## Summary

The previous pin `changesets/action@v1.4` failed the publish job — it isn't an actual tag on the changesets/action repo. Only `v1.4.0`–`v1.4.10` (and newer `v1.5`/`v1.6`/`v1.7` lines) exist. Updating to `v1.4.10` (latest patch in the 1.4 series) — matches the intent of battle-plan PG-15.

Caught by the release run after PR #54 merged, where build/test/smoke all passed but publish died at `Set up job` with "Unable to resolve action `changesets/action@v1.4`".

## Test plan

- [ ] After merge: release run reaches the publish job successfully; changesets/action either creates a Version PR (first time) or runs the publish step (if a Version PR is already merged)