### PR TITLE
fix(ci): join changeset version + CalVer bump with &&

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,9 +107,10 @@ jobs:
       - name: Create Version PR or publish
         uses: changesets/action@v1.4.10   # PG-15: latest in 1.4.x series
         with:
-          version: |
-            pnpm exec changeset version
-            pnpm exec tsx tools/bump-binaries-to-calver.ts
+          # changesets/action `version` expects a single shell command, not a
+          # multi-line script. The `|` literal block was concatenating the two
+          # lines into one command and the changesets CLI rejected the args.
+          version: pnpm exec changeset version && pnpm exec tsx tools/bump-binaries-to-calver.ts
           publish: pnpm publish -r --access public --no-git-checks
           # `pnpm publish -r` walks all packages and publishes the ones whose
           # version isn't already on npm (idempotent on partial-publish failure).


### PR DESCRIPTION
## Summary

The `version:` field used a YAML literal block (`|`) to put two commands on separate lines, but `changesets/action` passes that whole string as a single shell command. Result was a malformed invocation:

```
pnpm exec changeset version pnpm exec tsx tools/bump-binaries-to-calver.ts
```

…which the changesets CLI rejected with `Too many arguments passed to changesets — we only accept the command name as an argument`.

Joining them with `&&` gives changesets/action a valid single command; also short-circuits so the CalVer bump doesn't run on a half-baked state if `changeset version` fails.

## Test plan

- [ ] Repo setting: **Settings → Actions → General → Workflow permissions** must have *"Allow GitHub Actions to create and approve pull requests"* checked. Without this the publish step's last action (open the Version PR) will fail with `HttpError: GitHub Actions is not permitted to create or approve pull requests`. Surfaced on the previous release run.
- [ ] After merge: release run reaches publish, version step succeeds, changesets/action opens a Version PR bumping cycling-coach to today's CalVer.