### PR TITLE
fix(ci): wrap changeset version + CalVer bump in package.json script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,10 +107,11 @@ jobs:
       - name: Create Version PR or publish
         uses: changesets/action@v1.4.10   # PG-15: latest in 1.4.x series
         with:
-          # changesets/action `version` expects a single shell command, not a
-          # multi-line script. The `|` literal block was concatenating the two
-          # lines into one command and the changesets CLI rejected the args.
-          version: pnpm exec changeset version && pnpm exec tsx tools/bump-binaries-to-calver.ts
+          # changesets/action runs `version` via execa without a shell, so
+          # shell metacharacters (`&&`, `|`, multi-line) don't work — they
+          # become literal args. Wrap the two-step into a package.json script
+          # where pnpm's own shell handles the chaining.
+          version: pnpm release-version
           publish: pnpm publish -r --access public --no-git-checks
           # `pnpm publish -r` walks all packages and publishes the ones whose
           # version isn't already on npm (idempotent on partial-publish failure).

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "lint": "oxlint packages/",
     "fmt": "oxfmt packages/",
     "fmt:check": "oxfmt --check packages/",
-    "check": "pnpm -r build && oxlint packages/"
+    "check": "pnpm -r build && oxlint packages/",
+    "release-version": "changeset version && tsx tools/bump-binaries-to-calver.ts"
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.0",


### PR DESCRIPTION
## Summary

Third attempt at unblocking the publish job. The previous attempts failed because `changesets/action` runs the `version:` field via `execa` without a shell — so shell metacharacters (`&&`, multi-line `|`) become literal args to the changeset CLI, which rejects them with `Too many arguments passed to changesets`.

This wraps the two-step (`changeset version` → CalVer override) in a `release-version` script in the root package.json. pnpm's own script runner uses a shell, so `&&` chains work normally. The workflow now just calls `pnpm release-version`.

## Verified

- `pnpm release-version --help` locally chained both commands correctly (and was reset after — that local run actually bumped cycling-coach to `2026.5.1`, confirming the chain works end-to-end). The bumped state was reverted before pushing.

## Test plan

- [ ] After merge: release run reaches publish, the script chain runs, changesets/action commits the bumps and opens a Version PR for `cycling-coach`