### PR TITLE
fix(release): bump-binaries also rewrites CHANGELOG header

### DIFF
--- a/tools/bump-binaries-to-calver.ts
+++ b/tools/bump-binaries-to-calver.ts
@@ -30,7 +30,7 @@
  *   operator rather than silently corrupting state.
  */
 import { execSync } from "node:child_process";
-import { readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 const BINARY_PACKAGES = ["cycling-coach"];
@@ -70,6 +70,32 @@ function nextCalVer(pkg: string, base: string): string {
 const packagesDir = "packages";
 const today = todayCalVer();
 
+/**
+ * After overriding package.json, rewrite the latest `## <version>` header in
+ * CHANGELOG.md so it matches. `changeset version` writes the SemVer header
+ * before our override runs, so without this the header lags by one release.
+ * Only the FIRST `## ` line is rewritten — historical entries are preserved.
+ */
+function rewriteChangelogHeader(pkg: string, oldVersion: string, newVersion: string): void {
+  const changelogPath = join(packagesDir, pkg, "CHANGELOG.md");
+  if (!existsSync(changelogPath)) return;
+  const contents = readFileSync(changelogPath, "utf-8");
+  const headerNeedle = `## ${oldVersion}`;
+  const headerIndex = contents.indexOf(headerNeedle);
+  if (headerIndex === -1) {
+    console.warn(
+      `${pkg}: CHANGELOG.md has no '${headerNeedle}' header to rewrite — leaving as-is`,
+    );
+    return;
+  }
+  const updated =
+    contents.slice(0, headerIndex) +
+    `## ${newVersion}` +
+    contents.slice(headerIndex + headerNeedle.length);
+  writeFileSync(changelogPath, updated);
+  console.log(`${pkg}: CHANGELOG.md header ${oldVersion} → ${newVersion}`);
+}
+
 for (const pkg of BINARY_PACKAGES) {
   const pkgJsonPath = join(packagesDir, pkg, "package.json");
   let pkgJson: { version: string; [k: string]: unknown };
@@ -79,12 +105,14 @@ for (const pkg of BINARY_PACKAGES) {
     console.error(`skip: ${pkgJsonPath} not found`);
     continue;
   }
+  const oldVersion = pkgJson.version;
   const newVersion = nextCalVer(pkg, today);
-  if (newVersion === pkgJson.version) {
+  if (newVersion === oldVersion) {
     console.log(`${pkg}: already ${newVersion} (no bump)`);
     continue;
   }
   pkgJson.version = newVersion;
   writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2) + "\n");
-  console.log(`${pkg}: ${pkgJson.version}`);
+  rewriteChangelogHeader(pkg, oldVersion, newVersion);
+  console.log(`${pkg}: ${oldVersion} → ${newVersion}`);
 }


### PR DESCRIPTION
## Summary

`changeset version` writes both `package.json` and `CHANGELOG.md` using its SemVer bump (e.g. `2026.5.0` from a minor on `2026.4.26`). Our CalVer override then patches `package.json` to today's CalVer (`2026.5.1`) but **leaves `CHANGELOG.md` with the stale `## 2026.5.0` header** — surfaced by PR #58.

This extends `tools/bump-binaries-to-calver.ts` with a post-bump pass that rewrites the first `## <oldVersion>` line to `## <newVersion>` in the package's CHANGELOG. Only the latest entry is touched; historical entries keep their original headers. No-op (with a warning) if the file doesn't exist or no matching header is found.

## Note on PR #58

PR #58's CHANGELOG was generated before this fix landed and still has `## 2026.5.0`. I'll separately push a hand-edit to PR #58's branch (`changeset-release/main`) to align that one — easier than closing/recreating the whole Version PR.

## Test plan

- [ ] CI passes
- [ ] After merge: future Version PRs from changesets/action have matching package.json + CHANGELOG headers