### PR TITLE
fix(ci): upgrade npm CLI before publish so OIDC handshake works

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,6 +104,13 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm -r build
+      # Node 22 bundles npm 10.x, but OIDC trusted-publisher support landed in
+      # npm 11.5.1. `pnpm publish` proxies to whatever `npm` is on PATH for the
+      # actual HTTP PUT, so the registry call needs a recent npm to negotiate
+      # the OIDC handshake. Without this, publish fails with `404 - PUT
+      # https://registry.npmjs.org/<pkg>` (no auth token sent).
+      - name: Upgrade npm CLI to support OIDC
+        run: npm install -g npm@latest && npm --version
       - name: Create Version PR or publish
         uses: changesets/action@v1.4.10   # PG-15: latest in 1.4.x series
         with:


### PR DESCRIPTION
## Summary

The publish run from PR #58 merge failed at the actual `pnpm publish` step:

```
404 Not Found - PUT https://registry.npmjs.org/cycling-coach
'cycling-coach@2026.5.1' is not in this registry.
```

Cause: Node 22 bundles **npm 10.x**, but OIDC trusted-publisher support in the npm CLI only landed in **11.5.1**. `pnpm publish` proxies to whatever `npm` is on PATH for the actual registry HTTP PUT, so without a recent npm there's no OIDC handshake — the request goes out with a placeholder/empty token, and npm responds 404 (it rejects unauthenticated PUTs to existing package names with 404, not 401).

## Fix

Add `npm install -g npm@latest` immediately before `changesets/action` runs. pnpm then proxies into a CLI that supports the trusted-publisher flow. No code changes elsewhere — OIDC is already configured on npm side and `id-token: write` is already on the publish job.

## Test plan

- [ ] CI passes
- [ ] After merge: trigger a release run (need a new changeset, since the previous one was consumed by PR #58 — I'll add a tiny "no-op" changeset to retry the publish, OR we can manually trigger via workflow_dispatch)
- [ ] cycling-coach@2026.5.1 actually shows up on npm