### PR TITLE
fix(release): add repository field to cycling-coach for OIDC provenance

### DIFF
--- a/packages/cycling-coach/package.json
+++ b/packages/cycling-coach/package.json
@@ -11,6 +11,15 @@
     "dist"
   ],
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/yerzhansa/cycling-coach.git",
+    "directory": "packages/cycling-coach"
+  },
+  "homepage": "https://github.com/yerzhansa/cycling-coach#readme",
+  "bugs": {
+    "url": "https://github.com/yerzhansa/cycling-coach/issues"
+  },
   "scripts": {
     "build": "tsup",
     "check": "tsc --noEmit",


### PR DESCRIPTION
## Summary

Real progress on the previous run — OIDC handshake succeeded, npm received the publish request, generated a sigstore provenance attestation, then **rejected with 422**:

```
Error verifying sigstore provenance bundle: Failed to validate repository
information: package.json: "repository.url" is "", expected to match
"https://github.com/yerzhansa/cycling-coach" from provenance
```

When publishing under OIDC, npm signs an attestation that includes the GitHub repo URL from the workflow context, then cross-checks against `package.json:repository.url`. The Wave 3 refactor moved cycling-coach into `packages/cycling-coach/` but dropped `repository`/`homepage`/`bugs` along the way.

## Fix

Add all three fields. `repository.directory` points to the subdirectory per npm's monorepo convention.

## Test plan

- [ ] CI passes
- [ ] After merge: publish reaches the registry, OIDC succeeds, sigstore provenance validates against repository.url, cycling-coach@2026.5.1 lands on npm with verifiable provenance