### PR TITLE
fix(railway): point Railway at the relocated Dockerfile

### DIFF
--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "packages/cycling-coach/Dockerfile"
+  },
+  "deploy": {
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 10
+  }
+}


### PR DESCRIPTION
## Summary

Railway has been failing every deploy since Wave 3 merged because the Dockerfile moved from `/Dockerfile` (root) to `packages/cycling-coach/Dockerfile` per ADR-0006, and the Railway service was still auto-detecting the old location.

This adds `railway.json` at repo root with `dockerfilePath: packages/cycling-coach/Dockerfile`. Build context stays at repo root (Railway default), which is what the Dockerfile already assumes — its first `COPY` pulls `pnpm-workspace.yaml`, `pnpm-lock.yaml`, and root `package.json` from `.`.

## What was missed during Wave 3

Battle-plan PG-2 specifically called out: *"Add Railway service config note to PR description"* — i.e., flag the operator action. That note was added to the PR description, but the corresponding code change (a Railway config file or a UI update) never landed. This PR closes that gap with the code-controlled option.

## Test plan

- [ ] After merge: Railway picks up `railway.json`, finds the Dockerfile, build succeeds, deploy goes green
- [ ] Telegram bot reachable as before