### PR TITLE
fix(docker): build only cycling-coach subgraph; skip stubs entirely

### DIFF
--- a/packages/cycling-coach/Dockerfile
+++ b/packages/cycling-coach/Dockerfile
@@ -12,19 +12,27 @@ WORKDIR /app
 # Honor the packageManager pin in root package.json.
 RUN corepack enable
 
-# Workspace manifests first for cache hits on dep installs.
+# Workspace manifests + lockfile for cache hits on dep installs. Only the
+# packages cycling-coach actually depends on (core + sport-cycling + itself);
+# the 4 stub packages aren't part of the binary and don't need to be visible.
+# `pnpm install --filter cycling-coach...` resolves only the cycling-coach
+# subgraph and ignores the absent stub workspace dirs.
 COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
 COPY packages/core/package.json ./packages/core/
 COPY packages/sport-cycling/package.json ./packages/sport-cycling/
 COPY packages/cycling-coach/package.json ./packages/cycling-coach/
 
-RUN pnpm install --frozen-lockfile
+RUN pnpm install --filter cycling-coach... --frozen-lockfile
 
 # Source after deps for cache reuse.
 COPY tools ./tools
-COPY packages ./packages
+COPY packages/core ./packages/core
+COPY packages/sport-cycling ./packages/sport-cycling
+COPY packages/cycling-coach ./packages/cycling-coach
 
-RUN pnpm -r build
+# Only build what cycling-coach needs (`...` = the package + all its deps in
+# topo order). Stubs aren't even copied into the image.
+RUN pnpm --filter cycling-coach... build
 
 # pnpm deploy: produces a self-contained dir with prod-only deps,
 # resolves workspace:* to actual files, the pnpm-canonical Docker pattern.


### PR DESCRIPTION
## Summary

Wave 3's first Railway deploy failed at `pnpm -r build`. Root cause: the 4 stub packages' devDeps (notably `tsup`) weren't installed in node_modules — yet `pnpm -r build` walked all 7 workspace packages and tried to build the stubs.

The cycling-coach binary only depends on `@enduragent/core` and `@enduragent/sport-cycling` (workspace:* devDeps post-PR #51). Building the stubs is wasted work that produces nothing for the runtime bundle.

## Fix

Focused-subgraph approach end-to-end:
1. COPY only the 3 manifests cycling-coach actually needs.
2. `pnpm install --filter cycling-coach... --frozen-lockfile` resolves only the cycling-coach subgraph.
3. COPY only the 3 source dirs.
4. `pnpm --filter cycling-coach... build` builds the same subgraph in topo order.

The 4 stub packages aren't part of the build context, install graph, or build step. Smaller image, faster builds, no stub package.jsons to keep in sync.

## Risk note

`pnpm install --filter X... --frozen-lockfile` with a partial workspace (3/7 dirs present) is the slightly less-tested path. If pnpm rejects the partial workspace topology against the lockfile, fallback is to COPY all 7 manifests and rely on `--filter` only at build time.

## Test plan

- [ ] After merge: Railway picks up the new Dockerfile, install/build succeed, runtime bundle stage works, Telegram bot comes up