### PR TITLE
chore(ci): gate publish job behind workflow_dispatch (manual button)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,14 @@
 name: Release
 
 on:
+  # build/test/smoke run on every push to main as a regression signal.
+  # The publish job is gated below so it only fires when manually dispatched
+  # (Actions tab → Release → Run workflow). Lets the Version PR / changesets
+  # flow stay deliberate: write a changeset → push → bot opens Version PR →
+  # merge it → manually click Run workflow to actually publish.
   push:
     branches: [main]
+  workflow_dispatch:
 
 # PG-16: per-job least-privilege; id-token only on publish.
 permissions:
@@ -82,6 +88,9 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     needs: [build, test, smoke]
+    # Manual-only — never runs on a push trigger. Click "Run workflow" on
+    # the Release workflow page after merging a Version PR to ship.
+    if: github.event_name == 'workflow_dispatch'
     # Serialize publish runs so two pushes to main on the same day can't both
     # query npm, see the same "latest" version, and race on suffix selection.
     # cancel-in-progress: false — never abort an in-flight publish; queue and run.


### PR DESCRIPTION
## Summary

Push-to-main keeps running build/test/smoke (continuous regression signal on the default branch). The **publish job now only runs when manually triggered** via Actions tab → Release → "Run workflow".

## Why

`changesets/action`'s row-3 behavior — "no changesets, but local version > npm" — was making every CI/Dockerfile/Railway fix retry the publish step after the Version PR merge. The publishes weren't *bad* (they were silent no-ops once npm caught up), but every push spent 2 min running a publish job that didn't need to run.

A manual button makes "I want to publish now" an explicit action.

## Where the button is

`https://github.com/yerzhansa/cycling-coach/actions/workflows/release.yml` → **Run workflow** dropdown on the right side of the page → pick branch `main` → click.

## New release flow

1. Write a changeset: `pnpm changeset` → describe the bump
2. Push to main / merge a PR with the changeset
3. The bot opens a "Version Packages" PR
4. Merge that PR (deletes the changeset, bumps versions, updates CHANGELOG)
5. **Click "Run workflow" on the Release page** ← new step
6. cycling-coach@new-version lands on npm

## Test plan

- [ ] After merge: a regular push to main runs build/test/smoke only — publish job is skipped
- [ ] Click "Run workflow": all 4 jobs run including publish (which will be a no-op since 2026.5.1 already matches npm)