### PR TITLE
fix(docker): add --legacy to pnpm deploy for pnpm 10 compat

### DIFF
--- a/packages/cycling-coach/Dockerfile
+++ b/packages/cycling-coach/Dockerfile
@@ -36,7 +36,13 @@ RUN pnpm --filter cycling-coach... build
 
 # pnpm deploy: produces a self-contained dir with prod-only deps,
 # resolves workspace:* to actual files, the pnpm-canonical Docker pattern.
-RUN pnpm --filter cycling-coach --prod deploy /app/runtime-bundle
+# --legacy: pnpm 10 made `inject-workspace-packages=true` required for
+# `deploy` by default; without that workspace setting, deploy errors with
+# ERR_PNPM_DEPLOY_NONINJECTED_WORKSPACE. We don't need the injection model
+# (cycling-coach bundles @enduragent/* via tsup; workspace deps live in
+# devDependencies and get stripped by --prod anyway), so the legacy flag
+# is the right opt-out.
+RUN pnpm --filter cycling-coach --prod --legacy deploy /app/runtime-bundle
 
 # ── runtime ────────────────────────────────────────────────────────────────
 FROM node:22-alpine AS runtime


### PR DESCRIPTION
## Summary

Railway hit `ERR_PNPM_DEPLOY_NONINJECTED_WORKSPACE` on the deploy step:

> By default, starting from pnpm v10, we only deploy from workspaces that have "inject-workspace-packages=true" set. If you want to deploy without using injected dependencies, run "pnpm deploy" with the "--legacy" flag.

## Why `--legacy` (not setting `inject-workspace-packages=true`)

The injection model copies workspace deps as actual files instead of symlinks. That's useful when you carry symlinks across stages and they break. **We don't need it**: cycling-coach bundles `@enduragent/*` via tsup `noExternal`, those packages live in `devDependencies` (post-PR #51), and `--prod` strips devDeps from the deploy bundle anyway. The runtime bundle has zero workspace deps to inject.

Legacy deploy is the explicit, documented opt-out for exactly this situation.

## Test plan

- [ ] After merge: Railway picks up the new Dockerfile, deploy step completes, runtime stage produces an image, the Telegram bot connects