### PR TITLE
feat(release): auto-create GitHub Release per published package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,6 +132,12 @@ jobs:
           # version isn't already on npm (idempotent on partial-publish failure).
           # `--no-git-checks` skips pnpm's "must be on a clean git tag" check —
           # changesets/action commits version bumps but doesn't tag per package.
+          # createGithubReleases: auto-create a GitHub Release for every
+          # successfully published package. Tag format is `<name>@<version>`
+          # for monorepo packages — diverges from the pre-Wave-3 `v<version>`
+          # tags but is the changesets convention. Releases page becomes the
+          # canonical changelog surface (in addition to per-package CHANGELOG.md).
+          createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # No NPM_TOKEN — OIDC trusted publisher per PG-7.


### PR DESCRIPTION
## Summary

Adds `createGithubReleases: true` to the changesets/action call. Every successful publish now also produces a GitHub Release (with the CHANGELOG entry as the body) — closing the loop where npm has the new version but the Releases page sits frozen at v2026.4.26.

## Tag format

- **Pre-Wave-3 (manual era)**: `v2026.4.26`, `v2026.4.17`, etc. — simple `v<version>` tags
- **Going forward (changesets-managed)**: `cycling-coach@2026.5.x` — the changesets monorepo convention

The format change is unavoidable; changesets/action doesn't have a custom-format option for monorepos. The v2026.4.x tags stay in place for historical continuity, and **v2026.5.1 was just backfilled manually** via `gh release create` to bridge the format change visibly.

## What this also confirms

The Releases page becomes a real changelog surface (in addition to per-package `CHANGELOG.md`). For users browsing https://github.com/yerzhansa/cycling-coach/releases, the latest release is now the actual latest published version.

## Test plan

- [ ] After merge: next manual publish (workflow_dispatch) creates a `cycling-coach@<version>` GitHub Release with the changelog body