### PR TITLE
chore(ci): make whole release workflow manual-only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,11 @@
 name: Release
 
 on:
-  # build/test/smoke run on every push to main as a regression signal.
-  # The publish job is gated below so it only fires when manually dispatched
-  # (Actions tab → Release → Run workflow). Lets the Version PR / changesets
-  # flow stay deliberate: write a changeset → push → bot opens Version PR →
-  # merge it → manually click Run workflow to actually publish.
-  push:
-    branches: [main]
+  # Manual-only. The whole release pipeline (build → test → smoke → publish)
+  # runs when an operator clicks "Run workflow" on the Release workflow page.
+  # Push-to-main never triggers anything here — PR CI (`.github/workflows/
+  # ci.yml`) is what catches regressions before merge. Release runs are a
+  # deliberate, separately-billed action.
   workflow_dispatch:
 
 # PG-16: per-job least-privilege; id-token only on publish.
@@ -88,9 +86,6 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     needs: [build, test, smoke]
-    # Manual-only — never runs on a push trigger. Click "Run workflow" on
-    # the Release workflow page after merging a Version PR to ship.
-    if: github.event_name == 'workflow_dispatch'
     # Serialize publish runs so two pushes to main on the same day can't both
     # query npm, see the same "latest" version, and race on suffix selection.
     # cancel-in-progress: false — never abort an in-flight publish; queue and run.


### PR DESCRIPTION
## Summary

Push-to-main no longer triggers any `release.yml` jobs. The whole pipeline (build → test → smoke → publish) only runs when an operator clicks **"Run workflow"** on the Release workflow page.

## Why

PR CI (`ci.yml`) already runs build + test on every PR before merge — that's where regressions get caught. The continuous build/test/smoke on every main push (which option B from earlier preserved) was redundant signal. Run [25216081553](https://github.com/yerzhansa/cycling-coach/actions/runs/25216081553) was the latest example: a Dockerfile-only fix triggered the full release pipeline for nothing useful.

Release runs are now fully deliberate — matches how the Version PR / changesets flow already felt.

## Trigger flow now

1. Write a changeset → push → bot opens "Version Packages" PR
2. Merge that PR (versions/CHANGELOG land on main, **nothing else fires**)
3. Go to https://github.com/yerzhansa/cycling-coach/actions/workflows/release.yml → "Run workflow" → main → click
4. build/test/smoke/publish all run; cycling-coach ships to npm + GitHub Release

## Cleanup

The `if: github.event_name == 'workflow_dispatch'` guard on the publish job is no longer needed (only trigger IS workflow_dispatch).

## Test plan

- [ ] After merge: a regular push to main runs nothing in release.yml
- [ ] Click "Run workflow": all 4 jobs run end-to-end