### PR TITLE
fix(core): timezone-aware "today" — fixes midnight date drift (#50)

### DIFF
--- a/.changeset/fix-tz-issue-50.md
+++ b/.changeset/fix-tz-issue-50.md
@@ -1,0 +1,7 @@
+---
+"cycling-coach": patch
+---
+
+Fix dates near local midnight in any non-UTC timezone (closes #50).
+
+The system prompt now carries the IANA timezone name (cache-stable) and a fresh `Current time:` line is appended to each user message. Five "today" call-sites — system prompt, daily-notes filename, intervals_delete_workout past-workout guard, race countdown, daily session-reset hour — now share one resolved athlete TZ instead of computing UTC independently. Resolution chain: `COACH_TZ` env > `session.timezone` (config.yaml) > host TZ (warning) > `"UTC"` (loud warning).

--- a/packages/core/src/agent/coach-agent.ts
+++ b/packages/core/src/agent/coach-agent.ts
@@ -26,6 +26,7 @@ import { runMemoryFlush } from "./memory-flush.js";
 import { evaluateSessionFreshness } from "./session-freshness.js";
 import { LLM } from "../llm.js";
 import { createMemorySnapshot } from "../memory/snapshot.js";
+import { resolveUserTimezone, appendCurrentTimeLine } from "./user-time.js";
 
 const MAX_OVERFLOW_ATTEMPTS = 3;
 const MAX_TIMEOUT_ATTEMPTS = 2;
@@ -50,12 +51,14 @@ export class CoachAgent {
   private chatStore: ChatStore;
   private tools: ToolSet;
   private systemPrompt: string;
+  private tz: string;
 
   constructor(sport: Sport, config: Config) {
     this.sport = sport;
     this.config = config;
     this.llm = new LLM(config);
-    this.memory = new Memory(config.dataDir);
+    this.tz = resolveUserTimezone(config.session.timezone);
+    this.memory = new Memory(config.dataDir, this.tz);
     this.chatStore = new ChatStore(config.dataDir);
 
     const intervals = config.intervals.apiKey
@@ -71,6 +74,7 @@ export class CoachAgent {
       intervals,
       memory: this.memory,
       secrets,
+      tz: this.tz,
     };
     const registrations = sport.tools(coreDeps);
     this.tools = Object.fromEntries(registrations.map((r) => [r.name, r.tool])) as ToolSet;
@@ -105,6 +109,7 @@ export class CoachAgent {
         lastMessageTime,
         dailyResetHour: this.config.session.dailyResetHour,
         idleMinutes: this.config.session.idleMinutes,
+        tz: this.tz,
       });
 
       if (!fresh) {
@@ -116,7 +121,7 @@ export class CoachAgent {
         history = [];
       }
 
-      this.systemPrompt = buildSystemPrompt(this.sport, this.memory);
+      this.systemPrompt = buildSystemPrompt(this.sport, this.memory, this.tz);
 
       const budget = computeHistoryTokenBudget({
         contextWindowTokens: this.config.contextWindowTokens,
@@ -148,11 +153,17 @@ export class CoachAgent {
         summaryMsg = makeSummaryMessage(previousSummary);
       }
 
+      // Append a fresh "Current time:" line to the user message so the LLM
+      // always sees the athlete's local time on this turn — even when the
+      // system prompt (cached) carries only the TZ name. Idempotent: safe
+      // across the retry/compaction loop below.
+      const userMessageWithTime = appendCurrentTimeLine(userMessage, this.tz);
+
       // Build messages array with new user message
       let messages: ModelMessage[] = [
         ...(summaryMsg ? [summaryMsg] : []),
         ...kept,
-        { role: "user", content: userMessage },
+        { role: "user", content: userMessageWithTime },
       ];
 
       let overflowAttempts = 0;

--- a/packages/core/src/agent/intervals-tools.ts
+++ b/packages/core/src/agent/intervals-tools.ts
@@ -2,6 +2,7 @@ import { tool, zodSchema } from "ai";
 import { z } from "zod";
 import type { IntervalsClient } from "intervals-icu-api";
 import type { IntervalsActivityType } from "../sport.js";
+import { todayInTZ } from "./user-time.js";
 
 // intervals-icu-api's TypeScript types declare snake_case fields, but the runtime
 // runs `camelCaseKeys` over every parsed response. So the types lie: at runtime we
@@ -17,8 +18,15 @@ type IntervalsEventRuntime = {
 /**
  * Pure-Core intervals tools per ADR-0004 — no sport-specific config needed.
  * Wired by the binary entry point alongside the sport's own tools().
+ *
+ * `tz` is the athlete's IANA timezone — used so "today" in the past-workout
+ * guard agrees with `event.startDateLocal` (which is in athlete-local frame),
+ * not with UTC.
  */
-export function createPureCoreIntervalsTools(intervals: IntervalsClient | null) {
+export function createPureCoreIntervalsTools(
+  intervals: IntervalsClient | null,
+  tz: string = "UTC",
+) {
   if (!intervals) return {};
   return {
     intervals_fetch_athlete: tool({
@@ -66,7 +74,7 @@ export function createPureCoreIntervalsTools(intervals: IntervalsClient | null) 
         const fetched = await intervals.events.get(input.eventId);
         if (!fetched.ok) return { error: fetched.error.kind };
         const event = fetched.value as unknown as IntervalsEventRuntime;
-        const today = new Date().toISOString().split("T")[0];
+        const today = todayInTZ(tz);
         const eventDate = event.startDateLocal.slice(0, 10);
         if (eventDate < today) {
           return {

--- a/packages/core/src/agent/session-freshness.ts
+++ b/packages/core/src/agent/session-freshness.ts
@@ -1,24 +1,64 @@
+import { todayInTZ } from "./user-time.js";
+
 // ============================================================================
 // SESSION FRESHNESS
 // ============================================================================
 
-export function resolveDailyResetAtMs(hour: number): number {
+/**
+ * Compute the most recent occurrence of `hour:00` in the athlete's TZ as a
+ * UTC ms timestamp. If the current moment is before today's reset hour
+ * (athlete-local), returns yesterday's reset hour. DST transition may shift
+ * by ~1h on the changeover day — acceptable for daily-reset semantics.
+ */
+export function resolveDailyResetAtMs(hour: number, tz: string = "UTC"): number {
   const now = new Date();
-  const today = new Date(now);
-  today.setHours(hour, 0, 0, 0);
-
-  // If current time is before the reset hour, use yesterday's reset time
-  if (now.getTime() < today.getTime()) {
-    today.setDate(today.getDate() - 1);
+  const todayResetMs = resetHourMs(tz, hour, now);
+  if (now.getTime() < todayResetMs) {
+    return resetHourMs(tz, hour, new Date(todayResetMs - 86_400_000));
   }
+  return todayResetMs;
+}
 
-  return today.getTime();
+function resetHourMs(tz: string, hour: number, anchor: Date): number {
+  const ymd = todayInTZ(tz, anchor);
+  const [y, m, d] = ymd.split("-").map(Number);
+  // Treat the wall-clock {y, m, d, hour, 0, 0} in tz as if it were UTC, then
+  // subtract the TZ offset at that moment to get the true UTC ms.
+  const naive = Date.UTC(y, m - 1, d, hour, 0, 0);
+  return naive - tzOffsetMs(tz, new Date(naive));
+}
+
+function tzOffsetMs(tz: string, when: Date): number {
+  const parts: Record<string, string> = {};
+  const dtf = new Intl.DateTimeFormat("en-US", {
+    timeZone: tz,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  });
+  for (const p of dtf.formatToParts(when)) {
+    if (p.type !== "literal") parts[p.type] = p.value;
+  }
+  const asUTC = Date.UTC(
+    +parts.year,
+    +parts.month - 1,
+    +parts.day,
+    +parts.hour % 24,
+    +parts.minute,
+    +parts.second,
+  );
+  return asUTC - when.getTime();
 }
 
 export function evaluateSessionFreshness(params: {
   lastMessageTime: string | null;
   dailyResetHour: number;
   idleMinutes: number;
+  tz?: string;
 }): { fresh: boolean; reason?: "daily" | "idle" } {
   // No history = fresh (new session)
   if (!params.lastMessageTime) {
@@ -32,7 +72,7 @@ export function evaluateSessionFreshness(params: {
   const now = Date.now();
 
   // Daily: stale if last message before most recent reset hour
-  const dailyResetAt = resolveDailyResetAtMs(params.dailyResetHour);
+  const dailyResetAt = resolveDailyResetAtMs(params.dailyResetHour, params.tz);
   if (updatedAt < dailyResetAt) {
     return { fresh: false, reason: "daily" };
   }

--- a/packages/core/src/agent/system-prompt.ts
+++ b/packages/core/src/agent/system-prompt.ts
@@ -5,7 +5,11 @@ import type { Memory } from "../memory/store.js";
 // SYSTEM PROMPT BUILDER
 // ============================================================================
 
-export function buildSystemPrompt(persona: SportPersona, memory: Memory): string {
+export function buildSystemPrompt(
+  persona: SportPersona,
+  memory: Memory,
+  tz: string = "UTC",
+): string {
   const skillsContent = Object.values(persona.skills).join("\n\n---\n\n");
   const context = memory.getContext();
 
@@ -19,7 +23,10 @@ export function buildSystemPrompt(persona: SportPersona, memory: Memory): string
     parts.push("# Athlete Context\n\n" + context);
   }
 
-  parts.push(`# Current Date\n\nToday is ${new Date().toISOString().split("T")[0]}.`);
+  // Time zone only — never the date. The date goes per-message via
+  // appendCurrentTimeLine() so it stays fresh across long sessions and
+  // doesn't go stale crossing local midnight. See user-time.ts.
+  parts.push(`# Current Date & Time\n\nTime zone: ${tz}`);
 
   return parts.join("\n\n---\n\n");
 }

--- a/packages/core/src/agent/user-time.ts
+++ b/packages/core/src/agent/user-time.ts
@@ -1,0 +1,119 @@
+// ============================================================================
+// USER TIME — timezone-aware date/time helpers
+// ============================================================================
+//
+// Ported from openclaw (`src/agents/{date-time,current-time}.ts`). Solves the
+// "today is the wrong day near midnight" class of bug by:
+//   1. Resolving the athlete timezone once via a tiered fallback chain.
+//   2. Putting only the *timezone name* in the system prompt (cache-stable).
+//   3. Appending a fresh, idempotent "Current time:" line to each user message.
+
+const FALLBACK_TZ = "UTC";
+
+/**
+ * Resolve an IANA timezone string. Tries the configured value first, validating
+ * via `Intl.DateTimeFormat`; falls back to host TZ, then "UTC". Logs a warning
+ * whenever it falls back so misconfiguration is visible (vs silently UTC).
+ */
+export function resolveUserTimezone(configured?: string): string {
+  const trimmed = configured?.trim();
+  if (trimmed) {
+    if (isValidTimezone(trimmed)) return trimmed;
+    console.warn(`Invalid timezone "${trimmed}"; falling back to host TZ.`);
+  }
+  const host = Intl.DateTimeFormat().resolvedOptions().timeZone?.trim();
+  if (host && isValidTimezone(host)) {
+    if (!trimmed) {
+      console.warn(
+        `No timezone configured; using host TZ "${host}". Set COACH_TZ or session.timezone in config.yaml to silence this warning.`,
+      );
+    }
+    return host;
+  }
+  console.warn(`No usable host TZ; falling back to "${FALLBACK_TZ}".`);
+  return FALLBACK_TZ;
+}
+
+export function isValidTimezone(tz: string): boolean {
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: tz }).format(new Date());
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Today's calendar date in `tz` as YYYY-MM-DD. en-CA emits ISO-style by default.
+ */
+export function todayInTZ(tz: string, now: Date = new Date()): string {
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone: tz,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(now);
+}
+
+function ordinalSuffix(day: number): string {
+  if (day >= 11 && day <= 13) return "th";
+  switch (day % 10) {
+    case 1: return "st";
+    case 2: return "nd";
+    case 3: return "rd";
+    default: return "th";
+  }
+}
+
+/**
+ * Friendly local-time string: "Monday, May 3rd, 2026 - 16:55". 24-hour format.
+ * Returns undefined if the platform's Intl can't format under `tz`.
+ */
+export function formatTimeInTZ(date: Date, tz: string): string | undefined {
+  try {
+    const parts = new Intl.DateTimeFormat("en-US", {
+      timeZone: tz,
+      weekday: "long",
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+      hourCycle: "h23",
+    }).formatToParts(date);
+    const map: Record<string, string> = {};
+    for (const p of parts) if (p.type !== "literal") map[p.type] = p.value;
+    if (!map.weekday || !map.year || !map.month || !map.day || !map.hour || !map.minute) {
+      return undefined;
+    }
+    const dayNum = parseInt(map.day, 10);
+    return `${map.weekday}, ${map.month} ${dayNum}${ordinalSuffix(dayNum)}, ${map.year} - ${map.hour}:${map.minute}`;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Compose the per-message time line: friendly local + bare UTC.
+ * Example: "Current time: Sunday, May 3rd, 2026 - 20:55 (Asia/Tokyo) / 2026-05-03 11:55 UTC"
+ */
+export function buildCurrentTimeLine(tz: string, nowMs: number = Date.now()): string {
+  const date = new Date(nowMs);
+  const local = formatTimeInTZ(date, tz) ?? date.toISOString();
+  const utc = date.toISOString().replace("T", " ").slice(0, 16) + " UTC";
+  return `Current time: ${local} (${tz}) / ${utc}`;
+}
+
+/**
+ * Append the time line to `text`. Idempotent — safe to call repeatedly across
+ * the agent's retry/compaction loop (won't double-append).
+ */
+export function appendCurrentTimeLine(
+  text: string,
+  tz: string,
+  nowMs: number = Date.now(),
+): string {
+  const base = text.trimEnd();
+  if (!base || base.includes("Current time:")) return base;
+  return `${base}\n${buildCurrentTimeLine(tz, nowMs)}`;
+}

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -27,6 +27,8 @@ export interface Config {
     historyTokenBudgetRatio: number;
     idleMinutes: number;
     dailyResetHour: number;
+    /** Athlete IANA timezone (e.g. "Europe/Berlin"). Empty = resolver picks host TZ. */
+    timezone: string;
   };
   contextWindowTokens: number;
   dataDir: string;
@@ -228,6 +230,8 @@ export function loadConfig(): Config {
         envInt("SESSION_IDLE_MINUTES") ?? (sessionYaml.idleMinutes as number) ?? 0,
       dailyResetHour:
         envInt("SESSION_DAILY_RESET_HOUR") ?? (sessionYaml.dailyResetHour as number) ?? 4,
+      timezone:
+        env("COACH_TZ") ?? (sessionYaml.timezone as string | undefined) ?? "",
     },
     contextWindowTokens: resolveContextWindowTokens(model),
     dataDir: (yaml.data_dir as string) ?? CONFIG_DIR,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -127,6 +127,14 @@ export {
   createPureCoreIntervalsTools,
   createCoreToolsWithSportConfig,
 } from "./agent/intervals-tools.js";
+export {
+  appendCurrentTimeLine,
+  buildCurrentTimeLine,
+  formatTimeInTZ,
+  isValidTimezone,
+  resolveUserTimezone,
+  todayInTZ,
+} from "./agent/user-time.js";
 
 // ─── Auth ─────────────────────────────────────────────────────────────
 export {

--- a/packages/core/src/memory/store.ts
+++ b/packages/core/src/memory/store.ts
@@ -1,6 +1,7 @@
 import { readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import type { MemoryStore } from "../memory.js";
+import { todayInTZ } from "../agent/user-time.js";
 
 // ============================================================================
 // MEMORY SYSTEM
@@ -13,10 +14,12 @@ const bodyOf = (block: string) => block.slice(block.indexOf("\n") + 1);
 export class Memory implements MemoryStore {
   private memoryDir: string;
   private plansDir: string;
+  private tz: string;
 
-  constructor(dataDir: string) {
+  constructor(dataDir: string, tz: string = "UTC") {
     this.memoryDir = join(dataDir, "memory");
     this.plansDir = join(dataDir, "plans");
+    this.tz = tz;
     mkdirSync(this.memoryDir, { recursive: true });
     mkdirSync(this.plansDir, { recursive: true });
   }
@@ -103,14 +106,14 @@ export class Memory implements MemoryStore {
   // ── Daily notes ────────────────────────────────────────────────────────
 
   readDailyNotes(date?: string): string {
-    const d = date ?? todayString();
+    const d = date ?? todayInTZ(this.tz);
     const path = join(this.memoryDir, `${d}.md`);
     if (!existsSync(path)) return "";
     return readFileSync(path, "utf-8");
   }
 
   appendDailyNote(note: string, date?: string): void {
-    const d = date ?? todayString();
+    const d = date ?? todayInTZ(this.tz);
     const path = join(this.memoryDir, `${d}.md`);
     const existing = this.readDailyNotes(d);
     const updated = existing ? `${existing}\n${note}` : note;
@@ -165,8 +168,4 @@ export class Memory implements MemoryStore {
 
     return parts.join("\n\n");
   }
-}
-
-function todayString(): string {
-  return new Date().toISOString().split("T")[0];
 }

--- a/packages/core/src/sport.ts
+++ b/packages/core/src/sport.ts
@@ -49,6 +49,9 @@ export interface CoreDeps {
   intervals: IntervalsClient | null;
   memory: MemoryStore;
   secrets: SecretsResolver;
+  /** Athlete IANA timezone, resolved by Core. Used so tools see the same
+   * "today" the system prompt references. */
+  tz: string;
 }
 
 // ─── Sport: the plug-point ─────────────────────────────────────────────

--- a/packages/core/tests/user-time.test.ts
+++ b/packages/core/tests/user-time.test.ts
@@ -1,0 +1,242 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  appendCurrentTimeLine,
+  buildCurrentTimeLine,
+  isValidTimezone,
+  resolveUserTimezone,
+  todayInTZ,
+} from "../src/agent/user-time.js";
+import { Memory } from "../src/memory/store.js";
+import { buildSystemPrompt } from "../src/agent/system-prompt.js";
+import { resolveDailyResetAtMs } from "../src/agent/session-freshness.js";
+import { createPureCoreIntervalsTools } from "../src/agent/intervals-tools.js";
+import type { IntervalsClient } from "intervals-icu-api";
+
+// ────────────────────────────────────────────────────────────────────────
+// resolveUserTimezone — chain: configured (validated) → host → "UTC"
+// ────────────────────────────────────────────────────────────────────────
+
+describe("resolveUserTimezone", () => {
+  it("returns the configured TZ when valid IANA", () => {
+    expect(resolveUserTimezone("Europe/Berlin")).toBe("Europe/Berlin");
+    expect(resolveUserTimezone("Asia/Tokyo")).toBe("Asia/Tokyo");
+  });
+
+  it("falls through invalid configured value to host TZ", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const result = resolveUserTimezone("Not/A/Real/Zone");
+    expect(result).not.toBe("Not/A/Real/Zone");
+    expect(isValidTimezone(result)).toBe(true);
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("uses host TZ when nothing configured (with warning)", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const result = resolveUserTimezone(undefined);
+    expect(isValidTimezone(result)).toBe(true);
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("treats whitespace as unset", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const result = resolveUserTimezone("   ");
+    expect(isValidTimezone(result)).toBe(true);
+    warn.mockRestore();
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// todayInTZ — emits YYYY-MM-DD in athlete-local frame
+// ────────────────────────────────────────────────────────────────────────
+
+describe("todayInTZ", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("UTC noon: today is the same calendar day in every zone", () => {
+    vi.setSystemTime(new Date("2026-05-01T12:00:00Z"));
+    expect(todayInTZ("UTC")).toBe("2026-05-01");
+    expect(todayInTZ("Asia/Tokyo")).toBe("2026-05-01");
+    expect(todayInTZ("America/Los_Angeles")).toBe("2026-05-01");
+  });
+
+  it("UTC+9 just past local midnight: athlete sees the next day", () => {
+    // 2026-05-01T02:00:00+09:00 = 2026-04-30T17:00Z
+    vi.setSystemTime(new Date("2026-04-30T17:00:00Z"));
+    expect(todayInTZ("UTC")).toBe("2026-04-30");
+    expect(todayInTZ("Asia/Tokyo")).toBe("2026-05-01"); // ← AC1
+  });
+
+  it("UTC-7 (PDT) just before local midnight: athlete still on the previous day", () => {
+    // 2026-04-30T23:00 PDT (UTC-7) = 2026-05-01T06:00Z
+    vi.setSystemTime(new Date("2026-05-01T06:00:00Z"));
+    expect(todayInTZ("UTC")).toBe("2026-05-01");
+    expect(todayInTZ("America/Los_Angeles")).toBe("2026-04-30"); // ← AC1
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// appendCurrentTimeLine — idempotent, includes both local + UTC
+// ────────────────────────────────────────────────────────────────────────
+
+describe("appendCurrentTimeLine", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("appends local + UTC time", () => {
+    vi.setSystemTime(new Date("2026-05-03T11:55:00Z"));
+    const out = appendCurrentTimeLine("hi", "Asia/Tokyo");
+    expect(out).toContain("Current time:");
+    expect(out).toContain("Asia/Tokyo");
+    expect(out).toContain("2026-05-03 11:55 UTC");
+  });
+
+  it("is idempotent — second call leaves the message unchanged", () => {
+    vi.setSystemTime(new Date("2026-05-03T11:55:00Z"));
+    const once = appendCurrentTimeLine("hi", "UTC");
+    const twice = appendCurrentTimeLine(once, "UTC");
+    expect(twice).toBe(once);
+  });
+
+  it("returns empty string for empty input (no time line on no message)", () => {
+    expect(appendCurrentTimeLine("", "UTC")).toBe("");
+    expect(appendCurrentTimeLine("   \n  ", "UTC")).toBe("");
+  });
+});
+
+describe("buildCurrentTimeLine", () => {
+  it("includes weekday + ordinal day + 24h time + UTC", () => {
+    // 2026-05-03 11:55 UTC = 20:55 in Asia/Tokyo (UTC+9)
+    const line = buildCurrentTimeLine("Asia/Tokyo", Date.parse("2026-05-03T11:55:00Z"));
+    expect(line).toContain("Sunday");
+    expect(line).toContain("3rd");
+    expect(line).toContain("20:55");
+    expect(line).toContain("(Asia/Tokyo)");
+    expect(line).toContain("2026-05-03 11:55 UTC");
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// AC1 + AC2 — system prompt TZ name and daily-notes filename agree
+// ────────────────────────────────────────────────────────────────────────
+
+describe("integration: system prompt + daily notes agree on 'today'", () => {
+  let dataDir: string;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    dataDir = mkdtempSync(join(tmpdir(), "cc-tz-"));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it("Asia/Tokyo at local 02:00 → both see 2026-05-01", () => {
+    // 2026-05-01T02:00 JST (UTC+9) = 2026-04-30T17:00Z
+    vi.setSystemTime(new Date("2026-04-30T17:00:00Z"));
+    const tz = "Asia/Tokyo";
+    const memory = new Memory(dataDir, tz);
+    memory.appendDailyNote("rode 60min Z2");
+
+    expect(existsSync(join(dataDir, "memory", "2026-05-01.md"))).toBe(true);
+    expect(existsSync(join(dataDir, "memory", "2026-04-30.md"))).toBe(false);
+
+    const persona = { soul: "soul", skills: {} };
+    const sp = buildSystemPrompt(persona, memory, tz);
+    expect(sp).toContain(`Time zone: ${tz}`);
+    expect(sp).not.toMatch(/Today is /); // never bake the date into the prompt
+  });
+
+  it("America/Los_Angeles at local 23:00 → both see 2026-04-30", () => {
+    vi.setSystemTime(new Date("2026-05-01T06:00:00Z")); // 23:00 PDT (UTC-7) on Apr 30
+    const tz = "America/Los_Angeles";
+    const memory = new Memory(dataDir, tz);
+    memory.appendDailyNote("rest day");
+
+    expect(existsSync(join(dataDir, "memory", "2026-04-30.md"))).toBe(true);
+    expect(existsSync(join(dataDir, "memory", "2026-05-01.md"))).toBe(false);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// AC3 — intervals_delete_workout past-workout check uses athlete TZ
+// ────────────────────────────────────────────────────────────────────────
+
+function makeFakeIntervals(eventDateLocal: string): IntervalsClient {
+  const deleteCalls: number[] = [];
+  const fake = {
+    events: {
+      get: async (_id: number) => ({
+        ok: true,
+        value: { id: _id, startDateLocal: eventDateLocal },
+      }),
+      delete: async (id: number) => {
+        deleteCalls.push(id);
+        return { ok: true };
+      },
+    },
+    _deleteCalls: deleteCalls,
+  };
+  return fake as unknown as IntervalsClient;
+}
+
+describe("intervals_delete_workout (AC3)", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("UTC-8 athlete at local 22:00 May 1: deleting today's workout is allowed", async () => {
+    // 2026-05-01T22:00 PDT = 2026-05-02T05:00Z
+    vi.setSystemTime(new Date("2026-05-02T05:00:00Z"));
+    const tz = "America/Los_Angeles";
+    const fake = makeFakeIntervals("2026-05-01T18:00:00");
+    const tools = createPureCoreIntervalsTools(fake, tz);
+    const tool = tools.intervals_delete_workout!;
+
+    const result = (await tool.execute!({ eventId: 42 }, {} as never)) as { deleted?: true; error?: string };
+    expect(result.deleted).toBe(true);
+    expect(result.error).toBeUndefined();
+  });
+
+  it("workout dated yesterday is refused as past_workout_protected", async () => {
+    vi.setSystemTime(new Date("2026-05-02T05:00:00Z"));
+    const tz = "America/Los_Angeles";
+    const fake = makeFakeIntervals("2026-04-30T18:00:00");
+    const tools = createPureCoreIntervalsTools(fake, tz);
+    const tool = tools.intervals_delete_workout!;
+
+    const result = (await tool.execute!({ eventId: 99 }, {} as never)) as { error?: string };
+    expect(result.error).toBe("past_workout_protected");
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// AC6 — dailyResetHour resolves in athlete TZ, not host TZ
+// ────────────────────────────────────────────────────────────────────────
+
+describe("resolveDailyResetAtMs (AC6)", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("returns today 04:00 in tz when current time is past it", () => {
+    // 2026-05-03 10:00 JST (UTC+9) = 2026-05-03 01:00 UTC
+    vi.setSystemTime(new Date("2026-05-03T01:00:00Z"));
+    const reset = resolveDailyResetAtMs(4, "Asia/Tokyo");
+    // 04:00 JST = 19:00 UTC the previous day
+    expect(new Date(reset).toISOString()).toBe("2026-05-02T19:00:00.000Z");
+  });
+
+  it("returns yesterday 04:00 in tz when current time is before today's reset", () => {
+    // 2026-05-03 02:00 JST = 2026-05-02 17:00 UTC, before today's 04:00 reset
+    vi.setSystemTime(new Date("2026-05-02T17:00:00Z"));
+    const reset = resolveDailyResetAtMs(4, "Asia/Tokyo");
+    // Yesterday's 04:00 JST = 2026-05-01 19:00 UTC
+    expect(new Date(reset).toISOString()).toBe("2026-05-01T19:00:00.000Z");
+  });
+});

--- a/packages/sport-cycling/src/periodization.ts
+++ b/packages/sport-cycling/src/periodization.ts
@@ -202,12 +202,13 @@ export function selectPeriodizationModel(
  * - Race + date: ceil(daysUntil / 7), clamped 8-24
  * - Race + no date: lookup by race type
  * - General: lookup by experience
+ *
+ * `tz` (IANA, default "UTC") frames "today" and the race date as local-midnight
+ * to local-midnight, so the count doesn't drift by a day at TZ boundaries.
  */
-export function computeTotalWeeks(profile: AthleteProfile): number {
+export function computeTotalWeeks(profile: AthleteProfile, tz: string = "UTC"): number {
   if (profile.goalType === "race" && profile.raceDate) {
-    const daysUntil = Math.ceil(
-      (new Date(profile.raceDate).getTime() - Date.now()) / (1000 * 60 * 60 * 24),
-    );
+    const daysUntil = daysBetweenLocal(todayInTZ(tz), profile.raceDate);
     const weeks = Math.ceil(daysUntil / 7);
     return Math.max(8, Math.min(24, weeks));
   }
@@ -217,4 +218,25 @@ export function computeTotalWeeks(profile: AthleteProfile): number {
   }
 
   return DEFAULT_TOTAL_WEEKS_BY_EXPERIENCE[profile.experienceLevel];
+}
+
+function todayInTZ(tz: string): string {
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone: tz,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(new Date());
+}
+
+/**
+ * Whole-day diff between two YYYY-MM-DD strings. Date.UTC ignores DST, so this
+ * is exact for calendar-day arithmetic regardless of timezone.
+ */
+function daysBetweenLocal(fromYmd: string, toYmd: string): number {
+  const [fy, fm, fd] = fromYmd.split("-").map(Number);
+  const [ty, tm, td] = toYmd.split("-").map(Number);
+  return Math.ceil(
+    (Date.UTC(ty, tm - 1, td) - Date.UTC(fy, fm - 1, fd)) / (1000 * 60 * 60 * 24),
+  );
 }

--- a/packages/sport-cycling/src/plan-builder.ts
+++ b/packages/sport-cycling/src/plan-builder.ts
@@ -26,8 +26,8 @@ import {
 // MAIN ENTRY POINT
 // ============================================================================
 
-export function buildPlanSkeleton(profile: AthleteProfile): TrainingPlan {
-  const totalWeeks = computeTotalWeeks(profile);
+export function buildPlanSkeleton(profile: AthleteProfile, tz: string = "UTC"): TrainingPlan {
+  const totalWeeks = computeTotalWeeks(profile, tz);
   const model = selectPeriodizationModel(profile, totalWeeks);
   const cycleLength = 7;
 

--- a/packages/sport-cycling/src/sport.ts
+++ b/packages/sport-cycling/src/sport.ts
@@ -78,9 +78,9 @@ export const cyclingSport: Sport = {
     // sport-specific cycling tools.
     const toolset = {
       ...createMemoryTools(deps.memory, sections),
-      ...createPureCoreIntervalsTools(deps.intervals),
+      ...createPureCoreIntervalsTools(deps.intervals, deps.tz),
       ...createCoreToolsWithSportConfig(deps.intervals, cyclingSport.intervalsActivityTypes),
-      ...createCyclingTools(deps.memory, deps.intervals),
+      ...createCyclingTools(deps.memory, deps.intervals, deps.tz),
     };
     return Object.entries(toolset).map(([name, t]) => ({
       name,

--- a/packages/sport-cycling/src/tools.ts
+++ b/packages/sport-cycling/src/tools.ts
@@ -29,7 +29,11 @@ const daysEnum = z.enum(["mon", "tue", "wed", "thu", "fri", "sat", "sun"]);
  * intervals tools live in `@enduragent/core`'s `createPureCoreIntervalsTools`
  * and `createCoreToolsWithSportConfig`.
  */
-export function createCyclingTools(memory: MemoryStore, intervals: IntervalsClient | null) {
+export function createCyclingTools(
+  memory: MemoryStore,
+  intervals: IntervalsClient | null,
+  tz: string = "UTC",
+) {
   return {
     calculate_zones: tool({
       description: "Calculate 6 power zones from FTP watts",
@@ -81,7 +85,7 @@ export function createCyclingTools(memory: MemoryStore, intervals: IntervalsClie
         generalGoalTarget?: string;
       }) => {
         const profile: AthleteProfile = { ...params, needsExtraRecovery: false };
-        const plan = buildPlanSkeleton(profile);
+        const plan = buildPlanSkeleton(profile, tz);
         memory.savePlan(plan);
         return plan;
       },

--- a/packages/sport-cycling/tests/periodization.test.ts
+++ b/packages/sport-cycling/tests/periodization.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { selectPeriodizationModel, computeTotalWeeks } from "../src/periodization.js";
 import type { AthleteProfile } from "../src/schemas.js";
 
@@ -96,5 +96,45 @@ describe("computeTotalWeeks", () => {
       experienceLevel: "beginner",
     });
     expect(computeTotalWeeks(p)).toBe(8);
+  });
+
+  // AC4 — daysUntil is local-midnight-to-local-midnight in athlete TZ.
+  // Without the fix, `new Date("2026-08-15")` is parsed as UTC midnight, so
+  // a Pacific athlete at local 23:00 on Aug 14 would see daysUntil = 0
+  // (instead of 1) — and the week count would drop by 1 vs an athlete in UTC.
+  describe("AC4: race countdown is athlete-local", () => {
+    beforeEach(() => vi.useFakeTimers());
+    afterEach(() => vi.useRealTimers());
+
+    it("America/Los_Angeles at local 23:00 on Aug 14 → 1 day, 8 weeks (clamped)", () => {
+      // 2026-08-14T23:00 PDT = 2026-08-15T06:00Z
+      vi.setSystemTime(new Date("2026-08-15T06:00:00Z"));
+      const p = makeProfile({
+        goalType: "race",
+        raceDate: "2026-08-15",
+      });
+      expect(computeTotalWeeks(p, "America/Los_Angeles")).toBe(8);
+    });
+
+    it("Asia/Tokyo at local 02:00 on Aug 15 → 0 days, 8 weeks (clamped)", () => {
+      // 2026-08-15T02:00+09:00 = 2026-08-14T17:00Z
+      vi.setSystemTime(new Date("2026-08-14T17:00:00Z"));
+      const p = makeProfile({
+        goalType: "race",
+        raceDate: "2026-08-15",
+      });
+      expect(computeTotalWeeks(p, "Asia/Tokyo")).toBe(8);
+    });
+
+    it("12-week race date counts the same in any TZ", () => {
+      vi.setSystemTime(new Date("2026-05-01T12:00:00Z"));
+      const p = makeProfile({
+        goalType: "race",
+        raceDate: "2026-07-24", // 84 days = 12 weeks
+      });
+      expect(computeTotalWeeks(p, "UTC")).toBe(12);
+      expect(computeTotalWeeks(p, "Asia/Tokyo")).toBe(12);
+      expect(computeTotalWeeks(p, "America/Los_Angeles")).toBe(12);
+    });
   });
 });


### PR DESCRIPTION
## Summary

Closes #50. The bot was computing "today" as the **UTC** calendar date in five independent places, with no athlete-timezone configuration anywhere. Athletes in any non-UTC zone saw wrong dates around their local midnight — wrong date in the system prompt, daily notes saved to yesterday's file, today's intervals.icu workouts refused as "past", race countdowns off by a day at boundaries, and a server-local (not athlete-local) daily session reset.

This PR ports the openclaw pattern wholesale (`src/agents/{date-time,current-time}.ts`) and routes every "today" through one resolved IANA timezone:

- **System prompt carries the TZ name only** (cache-stable). Replaces `Today is YYYY-MM-DD` with `Time zone: <iana>`.
- **Fresh `Current time:` line appended per-message** via an idempotent helper (`includes("Current time:")` guard makes it safe across the retry/compaction loop). Gives the LLM both local and UTC frames every turn — never goes stale crossing local midnight.
- **One TZ value, five call-sites:** system prompt, daily-notes filename, intervals delete guard, race countdown, daily-reset hour. They cannot disagree on "today" because they all read from the same resolved string.
- **Resolution chain:** `COACH_TZ` env → `session.timezone` (yaml) → host TZ (warning logged) → `"UTC"` (loud warning). Validated via `new Intl.DateTimeFormat({ timeZone: ... })` in try/catch.

### Files

*New*
- `packages/core/src/agent/user-time.ts` — `resolveUserTimezone`, `todayInTZ`, `formatTimeInTZ`, `appendCurrentTimeLine`, `buildCurrentTimeLine`, `isValidTimezone`.
- `packages/core/tests/user-time.test.ts` — 17 tests (TZ resolution chain, `todayInTZ` under three frozen clocks, idempotent append, intervals delete past-workout guard, daily-reset hour in athlete TZ, end-to-end agreement between system prompt + daily notes).

*Modified*
- `packages/core/src/config.ts` — `session.timezone` field + `COACH_TZ` env.
- `packages/core/src/sport.ts` — `tz: string` on `CoreDeps`.
- `packages/core/src/agent/system-prompt.ts` — TZ name only, no date.
- `packages/core/src/agent/coach-agent.ts` — resolves TZ in constructor, propagates everywhere, appends per-message time line.
- `packages/core/src/memory/store.ts` — Memory takes optional `tz`; daily-notes filename uses athlete-local frame.
- `packages/core/src/agent/intervals-tools.ts` — past-workout guard uses `todayInTZ(tz)` so it agrees with `event.startDateLocal`'s frame.
- `packages/core/src/agent/session-freshness.ts` — `dailyResetHour` resolved in athlete TZ via Intl-based offset math (DST off by ~1h on changeover day, acceptable for daily-reset semantics).
- `packages/sport-cycling/src/periodization.ts` — `computeTotalWeeks(profile, tz?)` does local-midnight ↔ local-midnight via `Date.UTC` calendar diff (no UTC-parse drift on `raceDate`).
- `packages/sport-cycling/src/{plan-builder,tools,sport}.ts` — thread `tz` through.

## Test plan

- [x] `pnpm -r check` — typecheck clean across all 7 packages
- [x] `pnpm -r test` — core 229 pass / 1 skip; sport-cycling 82 pass; cycling-coach 4 pass
- [x] `pnpm -w run lint` — 0 warnings, 0 errors (oxlint, 98 files)
- [x] Frozen-clock regression tests under `Asia/Tokyo` (UTC+9, no DST), `America/Los_Angeles` (PDT/PST), and `UTC` covering AC1, AC2, AC3, AC4, AC6
- [x] Idempotent append verified — `appendCurrentTimeLine` called twice on the same string is a no-op
- [ ] Manual smoke: live bot in Telegram with `COACH_TZ` set, send a message near local midnight and verify the `Current time:` line + system prompt agree

## Out of scope (follow-ups)

- Telegram `/set-timezone` command with city-name resolution via the existing LLM (UX, separate PR)
- intervals.icu auto-detect from `Athlete.timezone` on first run
- Lint rule forbidding raw `toISOString().split("T")[0]` outside `user-time.ts`
- One-shot migration script for daily-notes files saved under wrong UTC names