### PR TITLE
fix(core): only notify on real upgrades — CalVer-aware updateAvailable

### DIFF
--- a/.changeset/fix-update-direction-check.md
+++ b/.changeset/fix-update-direction-check.md
@@ -1,0 +1,9 @@
+---
+"cycling-coach": patch
+---
+
+Fix `/update` and the npm-update notification suggesting a downgrade when the running bot is ahead of npm.
+
+The version comparison was a string `!==`, so any difference between the running bot's `package.json` version and `registry.npmjs.org/<name>/latest` triggered "Update available" — including cases where the running version was newer (e.g. a Railway deploy from `main` whose CalVer is bumped before the corresponding npm publish has succeeded). On every restart the hosted bot would broadcast `Update available: <new> → <old>` to every chat, and `/update` would `npm install -g …@latest` the older version.
+
+Replaced with a CalVer-aware comparison (`YYYY.M.D[-N]` parsed into a 4-tuple). Returns true only when latest is strictly newer. Same-day re-release suffix `-N` is treated as newer than the unsuffixed release per the project's CalVer convention (inverts standard semver, which is why we don't use the `semver` package here).

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -157,6 +157,7 @@ export {
   getCurrentVersion,
   getKnownTelegramChatIds,
   getLastNotifiedVersion,
+  isUpdateAvailable,
   selfUpdate,
   setLastNotifiedVersion,
 } from "./updater.js";

--- a/packages/core/src/updater.ts
+++ b/packages/core/src/updater.ts
@@ -9,6 +9,41 @@ export interface UpdateInfo {
   updateAvailable: boolean;
 }
 
+/**
+ * Parse a CalVer string `YYYY.M.D` (with optional same-day re-release suffix
+ * `-N`) into a comparable 4-tuple. Returns null for unparseable input —
+ * "unknown" (the getCurrentVersion fallback) or a malformed npm response.
+ *
+ * Note: this is NOT semver. The project's binaries use CalVer where `-N`
+ * means "newer same-day re-release", whereas semver treats `-N` as an older
+ * pre-release. Using `semver.gt` here would silently miss every same-day
+ * patch notification.
+ */
+function calverParts(v: string): [number, number, number, number] | null {
+  const m = v.match(/^(\d+)\.(\d+)\.(\d+)(?:-(\d+))?$/);
+  if (!m) return null;
+  return [Number(m[1]), Number(m[2]), Number(m[3]), m[4] ? Number(m[4]) : 0];
+}
+
+/**
+ * True only when `latest` is strictly newer than `current` in CalVer order.
+ *
+ * String inequality (the original implementation) misfires when the running
+ * bot is *ahead* of npm — e.g. a Railway deploy from `main` self-reports the
+ * just-bumped 2026.5.4 while npm is still at 2026.5.1 from the prior
+ * publish. `!==` says "different" → broadcast → users get a "downgrade as
+ * upgrade" notification on every restart.
+ */
+export function isUpdateAvailable(latest: string, current: string): boolean {
+  const l = calverParts(latest);
+  const c = calverParts(current);
+  if (!l || !c) return false;
+  for (let i = 0; i < 4; i++) {
+    if (l[i] !== c[i]) return l[i] > c[i];
+  }
+  return false;
+}
+
 export function getCurrentVersion(binaryName: string): string {
   // Installed-binary path: resolve via Node's module-resolution to find the
   // binary package's package.json wherever pnpm/npm placed it.
@@ -39,7 +74,7 @@ export async function checkForUpdate(binaryName: string): Promise<UpdateInfo | n
     return {
       current,
       latest: data.version,
-      updateAvailable: data.version !== current,
+      updateAvailable: isUpdateAvailable(data.version, current),
     };
   } catch {
     return null;

--- a/packages/core/tests/updater.test.ts
+++ b/packages/core/tests/updater.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { isUpdateAvailable } from "../src/updater.js";
+
+// Regression: the original `data.version !== current` returned true for ANY
+// inequality, including the case where the running bot is ahead of npm — a
+// Railway deploy from `main` hits this every restart while the publish
+// pipeline lags behind. Users got "Update available: 2026.5.3 → 2026.5.1"
+// which is a downgrade dressed as an upgrade.
+describe("isUpdateAvailable", () => {
+  it("returns true when latest > current (real upgrade)", () => {
+    expect(isUpdateAvailable("2026.5.3", "2026.5.1")).toBe(true);
+  });
+
+  it("returns false when latest < current (the Railway-ahead-of-npm case)", () => {
+    expect(isUpdateAvailable("2026.5.1", "2026.5.3")).toBe(false);
+  });
+
+  it("returns false when latest === current", () => {
+    expect(isUpdateAvailable("2026.5.3", "2026.5.3")).toBe(false);
+  });
+
+  it('returns false when current is "unknown" (no throw)', () => {
+    expect(isUpdateAvailable("2026.5.3", "unknown")).toBe(false);
+  });
+
+  it("returns false when latest is malformed (no throw)", () => {
+    expect(isUpdateAvailable("not-a-version", "2026.5.3")).toBe(false);
+  });
+
+  it("respects semver patch ordering (10 > 9, not lex)", () => {
+    expect(isUpdateAvailable("2026.5.10", "2026.5.9")).toBe(true);
+    expect(isUpdateAvailable("2026.5.9", "2026.5.10")).toBe(false);
+  });
+
+  it("CalVer same-day re-release suffix is treated as NEWER", () => {
+    // The project's CalVer scheme: 2026.5.3 → 2026.5.3-1 → 2026.5.3-2 ships
+    // suffix bumps as same-day re-releases that come AFTER the original.
+    // (This inverts standard semver, where -1 is a pre-release.)
+    expect(isUpdateAvailable("2026.5.3-1", "2026.5.3")).toBe(true);
+    expect(isUpdateAvailable("2026.5.3-2", "2026.5.3-1")).toBe(true);
+    expect(isUpdateAvailable("2026.5.3", "2026.5.3-1")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Fix the bug where the running bot offers users a **downgrade** dressed as an upgrade.

`checkForUpdate()` compared `data.version !== current` (string inequality), so any difference triggered "Update available" — including the case where the running bot is *ahead* of npm. The Railway-hosted bot deploys from `main`, so its CalVer gets bumped (e.g. `2026.5.3`) before the publish pipeline catches up (npm still on `2026.5.1`). On every restart the hosted bot would broadcast `Update available: 2026.5.3 → 2026.5.1` to every chat, and `/update` would `npm install -g cycling-coach@latest` the older version.

Replaced with `isUpdateAvailable(latest, current)` — a CalVer-aware 4-tuple parse that returns true only when latest is strictly newer.

## Behavior matrix

| current (running) | latest (npm) | before | after |
|---|---|---|---|
| 2026.5.1 | 2026.5.3 | broadcast ✓ | broadcast ✓ |
| 2026.5.3 | 2026.5.1 | **broadcast (BUG)** | silent ✓ |
| 2026.5.3 | 2026.5.3 | silent | silent ✓ |
| 2026.5.3 | 2026.5.3-1 | broadcast ✓ | broadcast ✓ (suffix = newer) |
| 2026.5.3-1 | 2026.5.3 | broadcast ✗ | silent ✓ |
| `unknown` | 2026.5.3 | broadcast ✗ | silent ✓ (no throw) |

## Why not `semver`

The project's CalVer scheme treats `2026.5.3 → 2026.5.3-1` as a **same-day re-release that is newer**. Standard semver inverts this: `-1` is a pre-release, older than the stable. `semver.gt("2026.5.3-1", "2026.5.3") === false`, so using semver would silently miss every same-day patch notification. Custom 4-tuple parser handles the project's convention correctly with no external dep.

## Files

- `packages/core/src/updater.ts` — added `isUpdateAvailable()` + `calverParts()` helper, `checkForUpdate()` uses them.
- `packages/core/src/index.ts` — exports `isUpdateAvailable`.
- `packages/core/tests/updater.test.ts` — 7 tests pinning every row of the matrix above plus semver patch-vs-lex ordering (`10 > 9`).

## Test plan

- [x] `pnpm -r check` — typecheck clean across all 7 packages
- [x] `pnpm -r test` — core 219 pass / 1 skip (added 7); sport-cycling 79 pass; cycling-coach 4 pass
- [x] `pnpm -w run lint` — 0 warnings, 0 errors
- [ ] Manual: restart Railway bot after merge + publish; confirm no "Update available" message goes out while Railway and npm match.