### PR TITLE
feat(release): auto-push <pkg>@<v> tags on Version-PR merge

### DIFF
--- a/.github/workflows/version-pr.yml
+++ b/.github/workflows/version-pr.yml
@@ -50,3 +50,36 @@ jobs:
           # changesets exist, it's a no-op.
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push tags for publishable packages on Version-PR merge
+        # Closes the manual gap between "Version PR merged" and "release fires".
+        # When the operator merges the changesets-bot PR, package.json versions
+        # bump on main but no tag is created — release.yml never sees it. This
+        # step pushes <name>@<version> for every non-private packages/*/package.json
+        # whose tag is missing on origin; each pushed tag triggers release.yml.
+        #
+        # Gated to push events (skip workflow_dispatch — that path is for
+        # operator-driven re-runs of the changesets step itself, not for
+        # tagging) and to commits whose message starts with "Version Packages",
+        # the changesets/action default PR title that the squash-merge inherits.
+        if: github.event_name == 'push' && startsWith(github.event.head_commit.message, 'Version Packages')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          for pkg_json in packages/*/package.json; do
+            PRIVATE=$(node -p "require('./$pkg_json').private === true")
+            if [ "$PRIVATE" = "true" ]; then
+              continue
+            fi
+            NAME=$(node -p "require('./$pkg_json').name")
+            VERSION=$(node -p "require('./$pkg_json').version")
+            TAG="$NAME@$VERSION"
+            if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
+              echo "::notice::Tag $TAG already on origin — skipping"
+              continue
+            fi
+            git tag "$TAG"
+            git push origin "$TAG"
+            echo "::notice::Pushed tag $TAG (release.yml will fire)"
+          done

--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -36,4 +36,9 @@ After Wave 3 of the Core/Sport seam refactor (issue #47):
 
 ## Release flow
 
-Changesets-driven (`.changeset/*.md` + `pnpm exec changeset` CLI). The publish workflow runs on push:main, gates on build + test + smoke, then merges the bot's Version PR to publish via OIDC trusted publisher (no NPM_TOKEN). Currently only `cycling-coach` is publishable (per ADR-0009); `pnpm publish -r` skips the private libraries and stub binaries automatically. `tools/bump-binaries-to-calver.ts` overrides changesets' SemVer bumps with today's CalVer for published binaries.
+Changesets-driven, tag-triggered, two-workflow split:
+
+1. **`version-pr.yml`** runs on every push to `main`. It (a) opens or updates the bot-managed "Version Packages" PR whenever unconsumed `.changeset/*.md` files exist, and (b) when that PR is merged, auto-pushes `<package>@<version>` tags for every non-private bumped package. The tag push is what fires the next workflow.
+2. **`release.yml`** runs on tag push (`cycling-coach@*`, `running-coach@*`, `duathlon-coach@*`). It gates on build + test + smoke-install of the packed tarball, then publishes to npm via OIDC trusted publisher (no `NPM_TOKEN`), and auto-creates the GitHub Release with notes pulled from `CHANGELOG.md`.
+
+Currently only `cycling-coach` is publishable (per ADR-0009); the other six packages are `private: true` and skipped by both the changesets bump path and the tag-push step. `tools/bump-binaries-to-calver.ts` overrides changesets' SemVer bumps with today's CalVer for the publishable binaries (handles same-day re-releases by querying npm). See `CONTRIBUTING.md` for the contributor-side steps.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,10 +62,19 @@ docs(plan): add battle plan for rate limit fix
 
 ## Versioning
 
-Calendar-based: `YYYY.M.D`
+Calendar-based for npm-published binaries: `YYYY.M.D` (e.g., `2026.4.16` — first release of the day; `2026.4.16-1` — patch later the same day; `2026.4.17` — next day). Private workspace packages (`@enduragent/*`, stub binaries) use SemVer and are not published. See ADR-0007 and ADR-0009.
 
-- `2026.4.16` — first release of the day
-- `2026.4.16-1` — patch later the same day
-- `2026.4.17` — next day's release
+## Releasing
 
-To release: bump `version` in `package.json`, tag `vYYYY.M.D`, push the tag, create a GitHub Release. The publish workflow handles npm automatically.
+Changesets-driven and CI-automated. Contributors do **not** create tags or GitHub Releases by hand — those steps are wrong, and the tag namespace is `<package>@<version>` (e.g., `cycling-coach@2026.5.4`), not `vYYYY.M.D`.
+
+1. **Add a changeset to your PR.** Run `pnpm exec changeset`, pick the affected publishable package(s), describe the change in athlete-readable language. Commit the resulting `.changeset/<slug>.md`. A PR with a user-visible change but no changeset will skip release — this is intentional, not a bug.
+2. **Merge your PR to `main`.** `version-pr.yml` opens (or updates) a bot-managed "Version Packages" PR aggregating all pending changesets.
+3. **Merge the "Version Packages" PR when ready to ship.** It bumps `package.json` + CHANGELOG.md for the listed packages plus their internal dependents (per `updateInternalDependencies: "patch"` in `.changeset/config.json`). On merge, `version-pr.yml` then auto-pushes `<package>@<version>` tags for every **non-private** bumped package.
+4. **`release.yml` fires on the tag.** It builds, runs tests, packs the binary and smoke-installs the tarball, publishes to npm via OIDC trusted publisher (no `NPM_TOKEN`), and auto-creates the GitHub Release with notes extracted from `CHANGELOG.md`.
+
+Today only `cycling-coach` is `private: false`, so only `cycling-coach@<v>` is tagged. When a stub binary (`running-coach`, `duathlon-coach`) graduates by flipping `private: false`, it auto-tags on the next Version-PR merge.
+
+**If a release fails partway** (e.g., a flaky smoke test), re-run `release.yml` via Actions → "Run workflow" with the existing tag as input. `workflow_dispatch` is a fallback for re-running on a tag that already exists — it does **not** create the tag, so don't use it before the version-PR-merge has pushed one.
+
+`tools/bump-binaries-to-calver.ts` runs after `changeset version` to override the SemVer bump for binary packages with today's CalVer (handles same-day re-releases by querying npm).


### PR DESCRIPTION
## Summary

Merging a "Version Packages" PR bumps `package.json` on main but doesn't create a tag — and `release.yml` is tag-triggered, so without a tag nothing publishes. Operators were tagging manually, with two recurring failure modes:

- GitHub UI "Draft a new release" with `vYYYY.M.D` — wrong namespace; `release.yml` only triggers on `cycling-coach@*`, `running-coach@*`, `duathlon-coach@*`, so the workflow never fires.
- `workflow_dispatch` of `release.yml` against a tag that doesn't exist — the build job's `actions/checkout` step requires the tag to be on the remote already; fetch fails, build dies.

This PR closes the gap. After a Version-PR merge, `version-pr.yml` walks `packages/*/package.json`, skips anything `private: true`, and pushes `<name>@<version>` for every tag that isn't already on origin. Each pushed tag fires `release.yml` for that package.

The new step is gated to:
- `push` events only — `workflow_dispatch` re-runs of `version-pr.yml` won't tag (those are for re-running the changesets step alone).
- Commits whose message starts with `"Version Packages"` — the changesets/action default PR title, which the squash-merge inherits.

`git ls-remote --exit-code --tags` makes re-runs idempotent. Today only `cycling-coach` is `private: false`, so only `cycling-coach@<v>` gets tagged. When `running-coach` / `duathlon-coach` flip to non-private, they auto-tag on the same merge — `release.yml`'s trigger globs already cover them, no workflow change needed.

Also fixes stale release docs:
- `CONTRIBUTING.md` — replaced the wrong "tag `vYYYY.M.D`, push, draft a release" instructions with the actual changesets-driven flow. Explicit note that the tag namespace is `<package>@<version>` and `workflow_dispatch` does not create tags.
- `CONTEXT-MAP.md` — updated the "Release flow" section to describe the two-workflow split and the new auto-tag step.

## Test plan

- [ ] Merge this PR. Should not fire any tag push (commit message won't start with "Version Packages").
- [ ] `cycling-coach@2026.5.4` (the version already on `main` from PR #73) needs a one-time manual tag push since it predates this automation: `git tag cycling-coach@2026.5.4 origin/main && git push origin cycling-coach@2026.5.4`. Confirm `release.yml` fires and ships `2026.5.4` to npm.
- [ ] On the next Version-PR merge after that, verify `version-pr.yml` logs show `Pushed tag cycling-coach@<v>` and `release.yml` then runs against the new tag without any human action.
- [ ] Confirm npm publish and GitHub Release both land as expected.
- [ ] Manual escape hatch still works: `git tag <pkg>@<v> <sha> && git push origin <pkg>@<v>` if automation is bypassed (e.g., GitHub Actions outage on the version-pr-merge run).

## Caveat

If a "Tag protection rule" is configured in repo Settings → Tags excluding `github-actions[bot]`, the push will 403. The default repo has no such rule; check Settings only if the first run fails.