### PR TITLE
docs(cycling-coach): add package README for npm

### DIFF
--- a/packages/cycling-coach/README.md
+++ b/packages/cycling-coach/README.md
@@ -12,13 +12,6 @@ cycling-coach setup
 cycling-coach
 ```
 
-If you'd rather not install globally, drop the `-g` and use `npx`:
-
-```bash
-npx cycling-coach setup
-npx cycling-coach
-```
-
 The setup wizard asks for your LLM provider — an API key for Anthropic / OpenAI / Google, **or OAuth sign-in with your ChatGPT subscription** (no API key needed). Then optionally connects [intervals.icu](https://intervals.icu) and Telegram. After setup, `cycling-coach` starts in CLI mode — or Telegram mode if you provided a bot token.
 
 ```
@@ -73,6 +66,17 @@ Free-form chat works too — ask anything about training, report an injury, requ
 - `sessions/<chatId>.jsonl` — per-chat history
 
 The agent reads memory at the start of each conversation and writes to it when significant decisions are made (new goal, plan change, injury).
+
+## Troubleshooting
+
+**`cycling-coach: command not found`** — if you installed without the `-g` flag, the binary isn't on your `$PATH`. Either re-install globally (`npm install -g cycling-coach`), or run it via `npx`:
+
+```bash
+npx cycling-coach setup
+npx cycling-coach
+```
+
+`npx` ships with Node.js, so no extra install step is needed.
 
 ## More
 

--- a/packages/cycling-coach/README.md
+++ b/packages/cycling-coach/README.md
@@ -16,10 +16,12 @@ The setup wizard asks for your LLM provider — an API key for Anthropic / OpenA
 
 ```
 Cycling Coach (CLI mode). Type your message:
-> Calculate my zones for FTP 280
+> Create a 2-hour Z2 ride with sprints
+> Create 3x15 min sweet spot intervals
+> Create VO2max intervals
+> Review my last ride
 > Build me a 12-week plan for a gran fondo
 > What should I do today?
-> /quit
 ```
 
 ## What it does

--- a/packages/cycling-coach/README.md
+++ b/packages/cycling-coach/README.md
@@ -1,0 +1,81 @@
+# Cycling Coach
+
+AI cycling coaching agent. Bring your own LLM API key **or sign in with a ChatGPT Plus subscription**, connect [intervals.icu](https://intervals.icu) for real athlete data, chat via Telegram or CLI.
+
+## Install
+
+Requires [Node.js](https://nodejs.org/) 20+.
+
+```bash
+npm install -g cycling-coach
+cycling-coach setup
+cycling-coach
+```
+
+If you'd rather not install globally, drop the `-g` and use `npx`:
+
+```bash
+npx cycling-coach setup
+npx cycling-coach
+```
+
+The setup wizard asks for your LLM provider — an API key for Anthropic / OpenAI / Google, **or OAuth sign-in with your ChatGPT subscription** (no API key needed). Then optionally connects [intervals.icu](https://intervals.icu) and Telegram. After setup, `cycling-coach` starts in CLI mode — or Telegram mode if you provided a bot token.
+
+```
+Cycling Coach (CLI mode). Type your message:
+> Calculate my zones for FTP 280
+> Build me a 12-week plan for a gran fondo
+> What should I do today?
+> /quit
+```
+
+## What it does
+
+- Analyzes fitness, fatigue, and form from your real rides
+- Builds periodized plans toward your goal event
+- Pushes structured workouts to your intervals.icu calendar (auto-syncs to Garmin, Wahoo, Hammerhead, COROS, Suunto, Zwift)
+
+## LLM provider options
+
+- **Anthropic (Claude)** — API key from [Anthropic Console](https://console.anthropic.com/). Recommended default.
+- **OpenAI (GPT)** — API key from [OpenAI Platform](https://platform.openai.com/).
+- **Google (Gemini)** — API key from [Google AI Studio](https://aistudio.google.com/).
+- **ChatGPT subscription (experimental)** — browser OAuth sign-in with your ChatGPT Plus / Pro / Business / Edu / Enterprise account. No API key; uses your subscription quota. Models: `gpt-5.4` (recommended) and `gpt-5.4-mini` (faster, smaller context). Cost is covered by the subscription regardless of which model you pick.
+
+Anthropic's Claude Pro/Max subscription does **not** support OAuth for third-party tools — the only supported Anthropic path is the console API key.
+
+## Optional integrations
+
+- **intervals.icu** API key from [intervals.icu/settings](https://intervals.icu/settings) > Developer Settings.
+- **Telegram bot** token from [@BotFather](https://t.me/BotFather) (`/newbot`).
+
+## Telegram commands
+
+| Command | What it does |
+|---------|-------------|
+| `/start` | Welcome message + available commands |
+| `/plan` | Builds a periodized plan, asks to push to calendar |
+| `/workout` | Suggests today's workout from current fitness, fatigue, and form |
+| `/status` | Shows fitness, fatigue, form, and coaching notes |
+| `/sync` | Pushes next 1-2 weeks of planned workouts to intervals.icu |
+
+Free-form chat works too — ask anything about training, report an injury, request plan adjustments.
+
+## Where state lives
+
+`~/.cycling-coach/` (override with `CYCLING_COACH_HOME`):
+
+- `config.yaml` — provider/model selection (env vars take precedence)
+- `auth-profiles.json` — OAuth tokens (mode `0600`, rotated automatically)
+- `memory/MEMORY.md` — long-term: goals, injury history, preferences
+- `memory/YYYY-MM-DD.md` — daily conversation notes
+- `plans/current-plan.json` — active training plan
+- `sessions/<chatId>.jsonl` — per-chat history
+
+The agent reads memory at the start of each conversation and writes to it when significant decisions are made (new goal, plan change, injury).
+
+## More
+
+- **Cloud deploy** (Docker, Railway, Fly), **secrets backends** (1Password, macOS Keychain, Vault, AWS/GCP Secret Manager, age, env), **architecture diagram**, and **development setup** — see the [GitHub repo](https://github.com/yerzhansa/cycling-coach#readme).
+- **Issues**: <https://github.com/yerzhansa/cycling-coach/issues>
+- **License**: MIT

--- a/packages/cycling-coach/README.md
+++ b/packages/cycling-coach/README.md
@@ -82,6 +82,6 @@ npx cycling-coach
 
 ## More
 
-- **Cloud deploy** (Docker, Railway, Fly), **secrets backends** (1Password, macOS Keychain, Vault, AWS/GCP Secret Manager, age, env), **architecture diagram**, and **development setup** — see the [GitHub repo](https://github.com/yerzhansa/cycling-coach#readme).
+- **Secrets backends** (1Password, macOS Keychain, Vault, AWS/GCP Secret Manager, age, env), **architecture diagram**, and **development setup** — see the [GitHub repo](https://github.com/yerzhansa/cycling-coach#readme).
 - **Issues**: <https://github.com/yerzhansa/cycling-coach/issues>
 - **License**: MIT


### PR DESCRIPTION
## Summary

The published `cycling-coach` package has had no README on npm since the monorepo split (commit `6eb44fb`). npm publishes from `packages/cycling-coach/`, but only the repo root had a `README.md` — so npmjs.com renders the "This package does not have a README" placeholder.

This PR adds a focused, consumer-oriented `packages/cycling-coach/README.md` covering:

- Install (global + `npx` alternative for users who don't pass `-g`)
- LLM provider options (Anthropic / OpenAI / Google / ChatGPT subscription)
- Optional integrations (intervals.icu, Telegram)
- Telegram commands
- Where state lives (`~/.cycling-coach/`)

Cloud deploy, secrets backends (1Password / Keychain / Vault / age / env), architecture diagram, and development setup stay in the root README and are linked from the package README — no duplication.

No `package.json` change needed: npm always includes `README` regardless of the `files` field, so this will appear on npmjs.com on the next `changeset publish`.

## Test plan

- [ ] Visual review of the rendered README on the PR diff
- [ ] After merge + next publish, confirm npmjs.com/package/cycling-coach renders the README