### PR TITLE
fix(core): clarify setup backend errors and runtime banner

### DIFF
--- a/.changeset/fix-setup-ux-clarity.md
+++ b/.changeset/fix-setup-ux-clarity.md
@@ -1,0 +1,9 @@
+---
+"cycling-coach": patch
+---
+
+Clarify three setup-wizard and runtime messages that were easy to misread.
+
+- **`op` errors are no longer truncated mid-word.** When `op` failed (typically because the 1Password desktop app needs a restart), the wizard previously printed `1Password CLI unavailable (other: this, update the 1Password app...)` — the `slice(-200)` chopped the leading word off. The wizard now extracts a clean single-line summary (strips `[ERROR] yyyy/mm/dd hh:mm:ss` log prefix, caps at a word boundary) and translates the most common failure mode to an actionable hint: `1Password backend not offered — 1Password desktop app integration unavailable; quit and reopen the 1Password app, then re-run setup.`
+- **Keychain and 1Password writes now confirm where the secret landed.** Previously the wizard wrote the secret to the chosen backend silently and the only visible result was a `SecretRef` object in `config.yaml` — easy to misread as "the secret is stored in YAML". Each successful write now prints e.g. `Stored telegram.bot_token in macOS Keychain (service: cycling-coach, account: telegram_bot_token). config.yaml stores a /usr/bin/security reference, not the secret.`
+- **Telegram-mode banner is explicit.** `Cycling Coach is running. Waiting for messages...` looked identical to an idle CLI prompt; now reads `Cycling Coach (Telegram mode) is running. Open Telegram and message your bot — Ctrl+C to stop.`

--- a/packages/core/src/run-binary.ts
+++ b/packages/core/src/run-binary.ts
@@ -103,7 +103,9 @@ export async function runBinary(
   if (config.telegram.botToken) {
     const { createTelegramBot, notifyUpdate } = await import("./channels/telegram.js");
     const bot = createTelegramBot(config.telegram.botToken, agent, binary);
-    console.log(`${binary.displayName} is running. Waiting for messages...`);
+    console.log(
+      `${binary.displayName} (Telegram mode) is running. Open Telegram and message your bot — Ctrl+C to stop.`,
+    );
     bot.start();
     notifyUpdate(bot, config.dataDir, binary).catch(() => {});
   } else {

--- a/packages/core/src/secrets/backends/detect.ts
+++ b/packages/core/src/secrets/backends/detect.ts
@@ -92,20 +92,25 @@ async function detectOpState(opPath: string, timeoutMs: number): Promise<OpState
   return { state: "unavailable", reason: "other", detail };
 }
 
-// Pull a clean, single-line summary out of `op` stderr. Strips the
-// "[ERROR] yyyy/mm/dd hh:mm:ss " log prefix, keeps the leading line (where op
-// puts its headline), and caps length at a word boundary so the message stays
-// readable in `describeOpState`.
+// op puts its headline on the first stderr line; everything below is context
+// or a docs URL we don't want to surface in describeOpState.
+const OP_LOG_DATETIME_RE = /^\[\w+\]\s+\d{4}\/\d{2}\/\d{2}\s+\d{2}:\d{2}:\d{2}\s+/;
+const OP_LOG_LEVEL_RE = /^\[\w+\]\s+/;
+const OP_STDERR_MAX_LEN = 240;
+// Don't word-break if the boundary lands too early — we'd throw away most of
+// the message just to avoid one mid-word cut.
+const OP_STDERR_MIN_WORDBREAK = 80;
+
 export function cleanOpStderr(stderr: string): string {
   const lines = stderr.split(/\r?\n/).map((l) => l.trim()).filter(Boolean);
   if (lines.length === 0) return "";
-  let line = lines[0]
-    .replace(/^\[\w+\]\s+\d{4}\/\d{2}\/\d{2}\s+\d{2}:\d{2}:\d{2}\s+/, "")
-    .replace(/^\[\w+\]\s+/, "");
-  const MAX = 240;
-  if (line.length > MAX) {
-    const cut = line.lastIndexOf(" ", MAX);
-    line = (cut > 80 ? line.slice(0, cut) : line.slice(0, MAX)) + "…";
+  let line = lines[0].replace(OP_LOG_DATETIME_RE, "").replace(OP_LOG_LEVEL_RE, "");
+  if (line.length > OP_STDERR_MAX_LEN) {
+    const cut = line.lastIndexOf(" ", OP_STDERR_MAX_LEN);
+    line =
+      (cut > OP_STDERR_MIN_WORDBREAK
+        ? line.slice(0, cut)
+        : line.slice(0, OP_STDERR_MAX_LEN)) + "…";
   }
   return line;
 }

--- a/packages/core/src/secrets/backends/detect.ts
+++ b/packages/core/src/secrets/backends/detect.ts
@@ -58,8 +58,8 @@ async function detectOpState(opPath: string, timeoutMs: number): Promise<OpState
     return { state: "unavailable", reason: "other", detail: "timeout" };
   }
   if (accountsRaw.exitCode !== 0) {
-    const detail = accountsRaw.stderr.slice(-200).trim();
-    return { state: "unavailable", reason: "other", detail: detail || "account list failed" };
+    const detail = cleanOpStderr(accountsRaw.stderr) || "account list failed";
+    return { state: "unavailable", reason: "other", detail };
   }
 
   let accounts: unknown;
@@ -88,8 +88,26 @@ async function detectOpState(opPath: string, timeoutMs: number): Promise<OpState
   if (/not signed in/i.test(vaultsRaw.stderr)) {
     return { state: "needs-signin", absolutePath: opPath };
   }
-  const detail = vaultsRaw.stderr.slice(-200).trim();
-  return { state: "unavailable", reason: "other", detail: detail || "vault list failed" };
+  const detail = cleanOpStderr(vaultsRaw.stderr) || "vault list failed";
+  return { state: "unavailable", reason: "other", detail };
+}
+
+// Pull a clean, single-line summary out of `op` stderr. Strips the
+// "[ERROR] yyyy/mm/dd hh:mm:ss " log prefix, keeps the leading line (where op
+// puts its headline), and caps length at a word boundary so the message stays
+// readable in `describeOpState`.
+export function cleanOpStderr(stderr: string): string {
+  const lines = stderr.split(/\r?\n/).map((l) => l.trim()).filter(Boolean);
+  if (lines.length === 0) return "";
+  let line = lines[0]
+    .replace(/^\[\w+\]\s+\d{4}\/\d{2}\/\d{2}\s+\d{2}:\d{2}:\d{2}\s+/, "")
+    .replace(/^\[\w+\]\s+/, "");
+  const MAX = 240;
+  if (line.length > MAX) {
+    const cut = line.lastIndexOf(" ", MAX);
+    line = (cut > 80 ? line.slice(0, cut) : line.slice(0, MAX)) + "…";
+  }
+  return line;
 }
 
 export async function findInPath(bin: string, pathEnv: string): Promise<string | null> {

--- a/packages/core/src/setup.ts
+++ b/packages/core/src/setup.ts
@@ -494,9 +494,7 @@ async function _pickBackend(ctx: WizardCtx, binary: BinaryConfig): Promise<Backe
         label: "1Password CLI — sign in first",
       });
     } else {
-      log.info(
-        `1Password CLI unavailable (${describeOpState(avail.op)}); backend not offered.`,
-      );
+      log.info(`1Password backend not offered — ${describeOpState(avail.op)}.`);
     }
     if (avail.keychain.available) {
       options.push({ value: BACKEND_KEYCHAIN, label: "macOS Keychain" });
@@ -528,7 +526,7 @@ async function _pickBackend(ctx: WizardCtx, binary: BinaryConfig): Promise<Backe
         return "op";
       }
       log.info(
-        `1Password still not available (${describeOpState(reDetected.op)}). Pick another backend.`,
+        `1Password still unavailable — ${describeOpState(reDetected.op)}. Pick another backend.`,
       );
       continue;
     }
@@ -539,10 +537,17 @@ async function _pickBackend(ctx: WizardCtx, binary: BinaryConfig): Promise<Backe
 
 function describeOpState(state: OpState): string {
   if (state.state === "ready") return `signed in as ${state.signedInAs}`;
-  if (state.state === "needs-signin") return "needs-signin";
+  if (state.state === "needs-signin") return "needs sign-in";
   if (state.reason === "not-on-path") return "not installed";
   if (state.reason === "no-account") return "no account configured";
-  return `other: ${state.detail ?? "unknown"}`;
+  const detail = state.detail ?? "unknown";
+  if (/desktop app|update the 1Password app|1password\.app/i.test(detail)) {
+    return "1Password desktop app integration unavailable; quit and reopen the 1Password app, then re-run setup";
+  }
+  if (/biometric|touch id|locked/i.test(detail)) {
+    return "1Password is locked; unlock the desktop app and re-run setup";
+  }
+  return `op CLI error: ${detail}`;
 }
 
 // ============================================================================
@@ -759,6 +764,7 @@ async function _writeToBackend(
       }
       await opItemUpdate(opAbsPath, title, value, preExistingVault);
       resolvedVault = preExistingVault;
+      log.success(`Updated ${field} in 1Password vault "${resolvedVault}".`);
     } else {
       resolvedVault = await createOpItem(
         ctx,
@@ -768,6 +774,7 @@ async function _writeToBackend(
         args.chosenVaultRef.current,
         binary,
       );
+      log.success(`Stored ${field} in 1Password vault "${resolvedVault}".`);
     }
 
     ctx.createdThisRun.push({
@@ -801,6 +808,9 @@ async function _writeToBackend(
     }
     throw err;
   }
+  log.success(
+    `${preExisted ? "Updated" : "Stored"} ${field} in macOS Keychain (service: ${binary.keychainPrefix}, account: ${account}). config.yaml stores a /usr/bin/security reference, not the secret.`,
+  );
   ctx.createdThisRun.push({
     backend: "keychain",
     field,

--- a/packages/core/src/setup.ts
+++ b/packages/core/src/setup.ts
@@ -535,16 +535,19 @@ async function _pickBackend(ctx: WizardCtx, binary: BinaryConfig): Promise<Backe
   }
 }
 
+const OP_DESKTOP_APP_HINT_RE = /desktop app|update the 1Password app|1password\.app/i;
+const OP_LOCKED_HINT_RE = /biometric|touch id|locked/i;
+
 function describeOpState(state: OpState): string {
   if (state.state === "ready") return `signed in as ${state.signedInAs}`;
   if (state.state === "needs-signin") return "needs sign-in";
   if (state.reason === "not-on-path") return "not installed";
   if (state.reason === "no-account") return "no account configured";
   const detail = state.detail ?? "unknown";
-  if (/desktop app|update the 1Password app|1password\.app/i.test(detail)) {
+  if (OP_DESKTOP_APP_HINT_RE.test(detail)) {
     return "1Password desktop app integration unavailable; quit and reopen the 1Password app, then re-run setup";
   }
-  if (/biometric|touch id|locked/i.test(detail)) {
+  if (OP_LOCKED_HINT_RE.test(detail)) {
     return "1Password is locked; unlock the desktop app and re-run setup";
   }
   return `op CLI error: ${detail}`;


### PR DESCRIPTION
## Summary

Three UX gaps in the setup wizard and runtime banner made correct behavior easy to misread:

1. **`op` errors truncated mid-word.** `detect.ts` did `stderr.slice(-200)`, which on a 1Password desktop-app integration failure produced `1Password CLI unavailable (other: this, update the 1Password app...)` — a sentence that starts mid-word. Replaced with `cleanOpStderr` that takes the leading line, strips the `[ERROR] yyyy/mm/dd hh:mm:ss ` log prefix, and caps at a word boundary.
2. **Wizard never confirmed where a secret landed.** A user who picked "macOS Keychain" then saw a verbose `SecretRef` block in `config.yaml` and concluded the secret was stored in YAML. Added `log.success` lines after every Keychain and 1Password write, with the explicit reminder that `config.yaml` stores a `/usr/bin/security` reference, not the secret.
3. **Telegram-mode banner indistinguishable from CLI mode.** `Cycling Coach is running. Waiting for messages...` looks identical to an idle CLI prompt. Now reads `Cycling Coach (Telegram mode) is running. Open Telegram and message your bot — Ctrl+C to stop.`

`describeOpState` also gained pattern-based translation for the two most common `op` failure modes (desktop-app integration and locked vault) so the user sees an actionable next step rather than raw stderr.

## Test plan

- [x] `pnpm --filter @enduragent/core exec vitest run` — all 236 tests pass, no new failures.
- [x] `pnpm --filter @enduragent/core exec tsc --noEmit` — clean.
- [x] `pnpm dev` against the modified core — banner shows `(Telegram mode)` and the new "Open Telegram and message your bot" hint.
- [x] Stub `op` exiting 1 with the real desktop-app stderr → `_detectBackendsWithOverrides` returns the cleaned single-line detail; `describeOpState` produces `1Password desktop app integration unavailable; quit and reopen the 1Password app, then re-run setup`.
- [x] Real `keychainItemUpsert` against `login.keychain-db` with a temp account → entry created via `security`, success message renders correctly, entry deleted.