### PR TITLE
chore(cycling-coach): add changeset for package README

### DIFF
--- a/.changeset/cycling-coach-package-readme.md
+++ b/.changeset/cycling-coach-package-readme.md
@@ -1,0 +1,5 @@
+---
+"cycling-coach": patch
+---
+
+Add a package-level README so npmjs.com renders install/usage docs instead of the "This package does not have a README" placeholder. The README has been missing from npm since the monorepo split moved publishing to `packages/cycling-coach/`.


### PR DESCRIPTION
## Summary

Follow-up to #75. The README PR was merged without a changeset, so `cycling-coach@2026.5.4` won't bump and the new README won't be republished — npmjs.com keeps showing the "no README" placeholder.

This PR adds a `patch` changeset for `cycling-coach` so the next Version Packages PR bumps the CalVer version and republishes the package, landing the README on npm.

## Test plan

- [ ] Merge → release workflow opens a Version Packages PR with `cycling-coach` bumped
- [ ] Merge that PR → `cycling-coach@<new-calver>` published to npm
- [ ] Visit https://www.npmjs.com/package/cycling-coach and confirm the README renders