### PR TITLE
ci(release): auto-dispatch release.yml after Version-PR merge

### DIFF
--- a/.github/workflows/version-pr.yml
+++ b/.github/workflows/version-pr.yml
@@ -26,6 +26,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      actions: write   # for `gh workflow run release.yml` after a Version-PR merge
     steps:
       - uses: actions/checkout@v4
         with:
@@ -51,12 +52,19 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Push tags for publishable packages on Version-PR merge
+      - name: Push tags and dispatch release for publishable packages on Version-PR merge
         # Closes the manual gap between "Version PR merged" and "release fires".
         # When the operator merges the changesets-bot PR, package.json versions
         # bump on main but no tag is created — release.yml never sees it. This
         # step pushes <name>@<version> for every non-private packages/*/package.json
-        # whose tag is missing on origin; each pushed tag triggers release.yml.
+        # whose tag is missing on origin, then dispatches release.yml for it.
+        #
+        # Why dispatch instead of relying on the `push: tags:` trigger in
+        # release.yml: GitHub blocks workflow runs from events triggered by
+        # GITHUB_TOKEN as an anti-recursion measure, EXCEPT for workflow_dispatch
+        # and repository_dispatch (documented exception). Tag pushes from this
+        # job use GITHUB_TOKEN, so the tag-push event is silently dropped by
+        # release.yml. workflow_dispatch is the supported escape hatch.
         #
         # Gated to push events (skip workflow_dispatch — that path is for
         # operator-driven re-runs of the changesets step itself, not for
@@ -81,5 +89,6 @@ jobs:
             fi
             git tag "$TAG"
             git push origin "$TAG"
-            echo "::notice::Pushed tag $TAG (release.yml will fire)"
+            gh workflow run release.yml --ref main -f tag="$TAG"
+            echo "::notice::Pushed tag $TAG and dispatched release.yml"
           done


### PR DESCRIPTION
## Summary

Future Version-PR merges will publish automatically — no more manual `gh workflow run release.yml -f tag=...` step.

**Root cause.** Tag pushes that use `secrets.GITHUB_TOKEN` don't fire workflow runs. From [GitHub's docs on automatic token authentication](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow):

> Events triggered by the GITHUB_TOKEN, with the exception of workflow_dispatch and repository_dispatch, will not create a new workflow run.

So when `version-pr.yml` pushed `cycling-coach@2026.5.6` after the Version PR merge, release.yml's `push: tags:` trigger silently dropped it. The operator had to dispatch the workflow by hand from the Actions UI, filling in the "Tag to release from" input.

**Fix.** Use the documented exception. After pushing each tag, dispatch `release.yml` with the tag as input:

```sh
gh workflow run release.yml --ref main -f tag="$TAG"
```

`release.yml`'s `parse-tag` job already reads from `${{ github.event.inputs.tag || github.ref_name }}` (line 45), so the dispatched path produces an identical run to the tag-push path — no changes needed in release.yml.

**Permission added.** `actions: write` on the `version-pr` job so the GitHub CLI can call the Actions API. No PAT, no GitHub App, no new secret.

The `push: tags:` trigger in release.yml stays — useful when a tag is pushed manually from a developer's terminal or via the GitHub UI's "Draft a new release" page (neither path is GITHUB_TOKEN-gated).

## Test plan

- [x] `node --input-type=module ... yaml.parse(...)` — version-pr.yml parses, permissions block contains `contents,pull-requests,actions`.
- [ ] Real validation requires the next Version-PR merge to land. Will confirm by watching for an auto-triggered Release run on the next merged Version PR (no manual dispatch step).
- [ ] If anything goes wrong on the next merge, the manual fallback (`gh workflow run release.yml -f tag=...`) still works — release.yml's `workflow_dispatch:` trigger is unchanged.