### PR TITLE
ci(release): prefill workflow_dispatch form so manual release is one click

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,9 +20,18 @@ on:
       - 'duathlon-coach@*'
   workflow_dispatch:
     inputs:
+      package:
+        description: 'Package to release'
+        type: choice
+        default: cycling-coach
+        options:
+          - cycling-coach
+          - running-coach
+          - duathlon-coach
       tag:
-        description: 'Tag to release from (e.g., cycling-coach@2026.5.2). Tag must already exist.'
-        required: true
+        description: 'Tag (leave empty to use packages/<package>/package.json version on main)'
+        required: false
+        default: ''
 
 # PG-16: per-job least-privilege; id-token only on publish.
 permissions:
@@ -36,13 +45,34 @@ jobs:
       version: ${{ steps.parse.outputs.version }}
       ref: ${{ steps.parse.outputs.ref }}
     steps:
+      # Needed only when workflow_dispatch is invoked with an empty tag input —
+      # we resolve the version from packages/<package>/package.json on the
+      # dispatched ref. Cheap enough to always run; keeps the resolver simple.
+      - uses: actions/checkout@v4
       - id: parse
-        # Tag format is <package>@<version>. For tag-push events, github.ref_name
-        # is the tag (e.g. "cycling-coach@2026.5.2"). For workflow_dispatch,
-        # github.event.inputs.tag is what the operator typed.
+        # Three trigger paths produce a tag string:
+        #   push:tags          -> github.ref_name is the tag (cycling-coach@2026.5.2)
+        #   workflow_dispatch  -> if inputs.tag is non-empty, use it verbatim;
+        #                         otherwise build <inputs.package>@<package.json version>
+        #                         so the operator can dispatch with a single click
+        #                         after a Version-PR merge without typing the tag.
         run: |
           set -euo pipefail
-          TAG="${{ github.event.inputs.tag || github.ref_name }}"
+          INPUT_TAG="${{ github.event.inputs.tag }}"
+          if [ -n "$INPUT_TAG" ]; then
+            TAG="$INPUT_TAG"
+          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            PKG="${{ github.event.inputs.package }}"
+            if [ ! -f "packages/$PKG/package.json" ]; then
+              echo "::error::packages/$PKG/package.json not found on this ref"
+              exit 1
+            fi
+            VERSION=$(node -p "require('./packages/$PKG/package.json').version")
+            TAG="$PKG@$VERSION"
+            echo "::notice::Empty tag input — resolved to $TAG via packages/$PKG/package.json"
+          else
+            TAG="${{ github.ref_name }}"
+          fi
           PACKAGE="${TAG%@*}"
           VERSION="${TAG#*@}"
           if [ "$PACKAGE" = "$TAG" ] || [ "$VERSION" = "$TAG" ]; then


### PR DESCRIPTION
## Summary

Make manual release dispatch zero-typing for the common case.

**Before.** "Tag to release from" was a required text input. Even after PR #79 lands and most releases auto-dispatch, you'll still want manual dispatch for the rare case (re-run after a flake; re-publish an older version). Today that's two clicks plus typing `cycling-coach@2026.5.6`.

**After.** Click `Run workflow` → click `Run`. Done.

## How

`workflow_dispatch` input `default:` values are static at workflow-parse time, so I can't dynamically pull "current `cycling-coach` version" into the form field. The standard workaround: sentinel-driven resolution.

```yaml
workflow_dispatch:
  inputs:
    package:
      type: choice
      default: cycling-coach
      options: [cycling-coach, running-coach, duathlon-coach]
    tag:
      description: 'Tag (leave empty to use packages/<package>/package.json version on main)'
      required: false
      default: ''
```

`parse-tag` now resolves an empty `tag` input to `<package>@<package.json version>` by reading `packages/<package>/package.json` on the dispatched ref. A non-empty tag is used verbatim (so re-publishing an older version still works — just type the tag).

The `push:tags` path is unchanged. The auto-dispatch path added in PR #79 always passes a non-empty tag and so skips the resolver entirely — these two PRs are independent.

## Operator UX after both PRs land

- **Common case**: merge "Version Packages" PR → release auto-dispatches (PR #79). Nothing to click.
- **Manual fallback**: open Actions → Release → `Run workflow` → `Run` (defaults to current `cycling-coach` version). One click.
- **Re-publish older version**: same flow, but type the historical tag in the `Tag` field.

## Test plan

- [x] `yaml.parse(release.yml)` — both inputs present, choice options correct, parse-tag job has `actions/checkout` then the resolver step.
- [ ] After merge, dispatch from the Actions UI with empty tag; verify the resolver logs `Empty tag input — resolved to cycling-coach@<v> via packages/cycling-coach/package.json` and the run targets the correct ref.
- [ ] Dispatch with an explicit historical tag (e.g. `cycling-coach@2026.5.4`); verify the resolver uses it verbatim.