### PR TITLE
fix(telegram): render markdown tables as monospace fallback

### DIFF
--- a/.changeset/fix-telegram-tables.md
+++ b/.changeset/fix-telegram-tables.md
@@ -2,7 +2,8 @@
 "cycling-coach": patch
 ---
 
-Fix markdown tables sent by the bot rendering as literal pipe-separated text in Telegram. Telegram has no table primitive in any parse mode, so the fix has two layers:
+Fix markdown tables sent by the bot rendering as literal pipe-separated text in Telegram. Telegram has no table primitive in any parse mode, so the fix has three layers:
 
 - **Steer the source.** `sport-cycling/SOUL.md` now tells the LLM to format workout prescriptions as a structured interval list (one step per line: warmup → main → cooldown) and training plans as a phased list. Workouts are inherently sequential and read better on mobile as `3× 10min Z4 (240–260W) / 5min Z2 between` than as a 4-column grid.
 - **Defense in depth.** `markdownToTelegramHtml` now extracts any markdown tables that slip through and renders them as `<pre>` (monospace) blocks with columns padded and cell content HTML-escaped. Wide tables still wrap on phones, but the columns line up.
+- **Chunker safety.** Long messages that exceed the 4096-char Telegram limit are now split with `<pre>` blocks treated as indivisible units. If a `<pre>` block alone exceeds the limit, its rows are split across multiple wrapped `<pre>...</pre>` chunks so Telegram never receives an unclosed tag. Also fixes a pre-existing ordering bug where the inline-code regex ate fence backticks and broke fenced code blocks.

--- a/.changeset/fix-telegram-tables.md
+++ b/.changeset/fix-telegram-tables.md
@@ -1,0 +1,8 @@
+---
+"cycling-coach": patch
+---
+
+Fix markdown tables sent by the bot rendering as literal pipe-separated text in Telegram. Telegram has no table primitive in any parse mode, so the fix has two layers:
+
+- **Steer the source.** `sport-cycling/SOUL.md` now tells the LLM to format workout prescriptions as a structured interval list (one step per line: warmup → main → cooldown) and training plans as a phased list. Workouts are inherently sequential and read better on mobile as `3× 10min Z4 (240–260W) / 5min Z2 between` than as a 4-column grid.
+- **Defense in depth.** `markdownToTelegramHtml` now extracts any markdown tables that slip through and renders them as `<pre>` (monospace) blocks with columns padded and cell content HTML-escaped. Wide tables still wrap on phones, but the columns line up.

--- a/packages/core/src/channels/telegram.ts
+++ b/packages/core/src/channels/telegram.ts
@@ -176,7 +176,7 @@ export function createTelegramBot(token: string, agent: CoachAgent, binary: Bina
 // MARKDOWN → TELEGRAM HTML
 // ============================================================================
 
-function markdownToTelegramHtml(md: string): string {
+export function markdownToTelegramHtml(md: string): string {
   // Telegram has no table primitive. Extract tables first so the bullet-point
   // regex below doesn't mangle their leading `|`, then restore as <pre> blocks.
   const { text, tables } = extractTables(md);
@@ -192,11 +192,12 @@ function markdownToTelegramHtml(md: string): string {
   html = html.replace(/(?<!\w)\*([^*]+?)\*(?!\w)/g, "<i>$1</i>");
   html = html.replace(/(?<!\w)_([^_]+?)_(?!\w)/g, "<i>$1</i>");
 
+  // Code blocks: ```...``` → <pre>...</pre> (must run before inline-code, otherwise the
+  // single-backtick regex eats pairs of fence backticks and breaks the block).
+  html = html.replace(/```[\w]*\n?([\s\S]*?)```/g, "<pre>$1</pre>");
+
   // Inline code: `text` → <code>text</code>
   html = html.replace(/`([^`]+?)`/g, "<code>$1</code>");
-
-  // Code blocks: ```...``` → <pre>...</pre>
-  html = html.replace(/```[\w]*\n?([\s\S]*?)```/g, "<pre>$1</pre>");
 
   // Strikethrough: ~~text~~ → <s>text</s>
   html = html.replace(/~~(.+?)~~/g, "<s>$1</s>");
@@ -278,36 +279,110 @@ function renderTableAsPre(header: string[], rows: string[][]): string {
 
 const TELEGRAM_MAX_LENGTH = 4096;
 
+type RenderUnit = { kind: "line"; text: string } | { kind: "pre"; text: string };
+
+// Group consecutive lines that belong to the same multi-line <pre> block, so the chunker
+// can treat them as one indivisible unit. Single-line <pre>...</pre> stays a "line".
+function tokenizeHtml(html: string): RenderUnit[] {
+  const units: RenderUnit[] = [];
+  const lines = html.split("\n");
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i];
+    const openIdx = line.indexOf("<pre>");
+    const closeOnSame = openIdx >= 0 ? line.indexOf("</pre>", openIdx) : -1;
+    if (openIdx >= 0 && closeOnSame < 0) {
+      let j = i + 1;
+      while (j < lines.length && !lines[j].includes("</pre>")) j++;
+      if (j < lines.length) {
+        units.push({ kind: "pre", text: lines.slice(i, j + 1).join("\n") });
+        i = j + 1;
+        continue;
+      }
+      // Unclosed <pre> — fall through and treat each line individually.
+    }
+    units.push({ kind: "line", text: line });
+    i++;
+  }
+  return units;
+}
+
+// Split a <pre> block whose own length exceeds maxLen into multiple wrapped <pre> chunks
+// so each chunk Telegram receives has a matching open/close tag.
+function splitPreBlock(block: string, maxLen: number): string[] {
+  const inner = block.replace(/^<pre>/, "").replace(/<\/pre>$/, "");
+  const wrapOverhead = "<pre></pre>".length;
+  const out: string[] = [];
+  let current = "";
+  for (const row of inner.split("\n")) {
+    const candidate = current ? `${current}\n${row}` : row;
+    if (candidate.length + wrapOverhead <= maxLen) {
+      current = candidate;
+      continue;
+    }
+    if (current) {
+      out.push(`<pre>${current}</pre>`);
+      current = row;
+      if (current.length + wrapOverhead <= maxLen) continue;
+    }
+    // Single row alone exceeds the budget — hard-split, wrap each piece.
+    const sliceMax = Math.max(1, maxLen - wrapOverhead);
+    for (let k = 0; k < row.length; k += sliceMax) {
+      out.push(`<pre>${row.slice(k, k + sliceMax)}</pre>`);
+    }
+    current = "";
+  }
+  if (current) out.push(`<pre>${current}</pre>`);
+  return out;
+}
+
+export function chunkHtml(html: string, maxLen: number = TELEGRAM_MAX_LENGTH): string[] {
+  if (html.length <= maxLen) return [html];
+
+  const chunks: string[] = [];
+  let current = "";
+  const flush = () => {
+    if (current) {
+      chunks.push(current);
+      current = "";
+    }
+  };
+
+  for (const unit of tokenizeHtml(html)) {
+    const text = unit.text;
+    const joinCost = current ? 1 : 0;
+
+    if (current.length + text.length + joinCost <= maxLen) {
+      current += (current ? "\n" : "") + text;
+      continue;
+    }
+
+    flush();
+
+    if (text.length <= maxLen) {
+      current = text;
+      continue;
+    }
+
+    if (unit.kind === "pre") {
+      chunks.push(...splitPreBlock(text, maxLen));
+    } else {
+      for (let i = 0; i < text.length; i += maxLen) {
+        chunks.push(text.slice(i, i + maxLen));
+      }
+    }
+  }
+
+  flush();
+  return chunks;
+}
+
 async function sendLongMessage(
   ctx: { reply: (text: string, options?: Record<string, unknown>) => Promise<unknown> },
   text: string,
 ): Promise<void> {
   const html = markdownToTelegramHtml(text);
-
-  if (html.length <= TELEGRAM_MAX_LENGTH) {
-    await ctx.reply(html, { parse_mode: "HTML" });
-    return;
-  }
-
-  // Split on paragraph boundaries, hard-split lines that exceed the limit
-  const chunks: string[] = [];
-  let current = "";
-  for (const line of html.split("\n")) {
-    if (line.length > TELEGRAM_MAX_LENGTH) {
-      if (current) { chunks.push(current); current = ""; }
-      for (let i = 0; i < line.length; i += TELEGRAM_MAX_LENGTH) {
-        chunks.push(line.slice(i, i + TELEGRAM_MAX_LENGTH));
-      }
-    } else if (current.length + line.length + 1 > TELEGRAM_MAX_LENGTH) {
-      chunks.push(current);
-      current = line;
-    } else {
-      current += (current ? "\n" : "") + line;
-    }
-  }
-  if (current) chunks.push(current);
-
-  for (const chunk of chunks) {
+  for (const chunk of chunkHtml(html)) {
     await ctx.reply(chunk, { parse_mode: "HTML" });
   }
 }

--- a/packages/core/src/channels/telegram.ts
+++ b/packages/core/src/channels/telegram.ts
@@ -278,22 +278,25 @@ function renderTableAsPre(header: string[], rows: string[][]): string {
 // ============================================================================
 
 const TELEGRAM_MAX_LENGTH = 4096;
+const PRE_OPEN = "<pre>";
+const PRE_CLOSE = "</pre>";
+const PRE_OVERHEAD = PRE_OPEN.length + PRE_CLOSE.length;
 
 type RenderUnit = { kind: "line"; text: string } | { kind: "pre"; text: string };
 
-// Group consecutive lines that belong to the same multi-line <pre> block, so the chunker
-// can treat them as one indivisible unit. Single-line <pre>...</pre> stays a "line".
+// Group multi-line <pre> blocks so the chunker treats each as one indivisible unit
+// (Telegram rejects chunks with unmatched <pre>/</pre>).
 function tokenizeHtml(html: string): RenderUnit[] {
   const units: RenderUnit[] = [];
   const lines = html.split("\n");
   let i = 0;
   while (i < lines.length) {
     const line = lines[i];
-    const openIdx = line.indexOf("<pre>");
-    const closeOnSame = openIdx >= 0 ? line.indexOf("</pre>", openIdx) : -1;
+    const openIdx = line.indexOf(PRE_OPEN);
+    const closeOnSame = openIdx >= 0 ? line.indexOf(PRE_CLOSE, openIdx) : -1;
     if (openIdx >= 0 && closeOnSame < 0) {
       let j = i + 1;
-      while (j < lines.length && !lines[j].includes("</pre>")) j++;
+      while (j < lines.length && !lines[j].includes(PRE_CLOSE)) j++;
       if (j < lines.length) {
         units.push({ kind: "pre", text: lines.slice(i, j + 1).join("\n") });
         i = j + 1;
@@ -311,28 +314,27 @@ function tokenizeHtml(html: string): RenderUnit[] {
 // so each chunk Telegram receives has a matching open/close tag.
 function splitPreBlock(block: string, maxLen: number): string[] {
   const inner = block.replace(/^<pre>/, "").replace(/<\/pre>$/, "");
-  const wrapOverhead = "<pre></pre>".length;
   const out: string[] = [];
   let current = "";
   for (const row of inner.split("\n")) {
     const candidate = current ? `${current}\n${row}` : row;
-    if (candidate.length + wrapOverhead <= maxLen) {
+    if (candidate.length + PRE_OVERHEAD <= maxLen) {
       current = candidate;
       continue;
     }
     if (current) {
-      out.push(`<pre>${current}</pre>`);
+      out.push(`${PRE_OPEN}${current}${PRE_CLOSE}`);
       current = row;
-      if (current.length + wrapOverhead <= maxLen) continue;
+      if (current.length + PRE_OVERHEAD <= maxLen) continue;
     }
     // Single row alone exceeds the budget — hard-split, wrap each piece.
-    const sliceMax = Math.max(1, maxLen - wrapOverhead);
+    const sliceMax = Math.max(1, maxLen - PRE_OVERHEAD);
     for (let k = 0; k < row.length; k += sliceMax) {
-      out.push(`<pre>${row.slice(k, k + sliceMax)}</pre>`);
+      out.push(`${PRE_OPEN}${row.slice(k, k + sliceMax)}${PRE_CLOSE}`);
     }
     current = "";
   }
-  if (current) out.push(`<pre>${current}</pre>`);
+  if (current) out.push(`${PRE_OPEN}${current}${PRE_CLOSE}`);
   return out;
 }
 

--- a/packages/core/src/channels/telegram.ts
+++ b/packages/core/src/channels/telegram.ts
@@ -177,12 +177,10 @@ export function createTelegramBot(token: string, agent: CoachAgent, binary: Bina
 // ============================================================================
 
 function markdownToTelegramHtml(md: string): string {
-  // Telegram has no table primitive in any parse mode. Extract markdown tables first
-  // and stash them as placeholders so the other regex passes don't mangle their contents.
-  // They get rendered into <pre> (monospace) blocks at the end, with cell content already
-  // HTML-escaped.
-  const tables: string[] = [];
-  let html = extractTables(md, tables);
+  // Telegram has no table primitive. Extract tables first so the bullet-point
+  // regex below doesn't mangle their leading `|`, then restore as <pre> blocks.
+  const { text, tables } = extractTables(md);
+  let html = text;
 
   // Headers: ### Title → <b>Title</b>
   html = html.replace(/^#{1,6}\s+(.+)$/gm, "<b>$1</b>");
@@ -210,10 +208,7 @@ function markdownToTelegramHtml(md: string): string {
   html = html.replace(/&(?!amp;|lt;|gt;)/g, "&amp;");
   html = html.replace(/<(?!\/?(?:b|i|u|s|code|pre)>)/g, "&lt;");
 
-  // Restore tables (already-rendered <pre> blocks with escaped cell content).
-  html = html.replace(/ TBL(\d+) /g, (_, idx) => tables[Number(idx)] ?? "");
-
-  return html;
+  return html.replace(/\[\[__TBL_(\d+)__\]\]/g, (_, idx) => tables[Number(idx)] ?? "");
 }
 
 const TABLE_SEPARATOR_RE = /^\s*\|?\s*:?-{2,}:?\s*(\|\s*:?-{2,}:?\s*)+\|?\s*$/;
@@ -233,8 +228,9 @@ function parseTableRow(line: string): string[] {
     .map((s) => s.trim());
 }
 
-function extractTables(md: string, tables: string[]): string {
+function extractTables(md: string): { text: string; tables: string[] } {
   const lines = md.split("\n");
+  const tables: string[] = [];
   const out: string[] = [];
   let i = 0;
   while (i < lines.length) {
@@ -247,16 +243,19 @@ function extractTables(md: string, tables: string[]): string {
         rows.push(parseTableRow(lines[j]));
         j++;
       }
-      const idx = tables.length;
+      out.push(`[[__TBL_${tables.length}__]]`);
       tables.push(renderTableAsPre(header, rows));
-      out.push(` TBL${idx} `);
       i = j;
     } else {
       out.push(lines[i]);
       i++;
     }
   }
-  return out.join("\n");
+  return { text: out.join("\n"), tables };
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
 function renderTableAsPre(header: string[], rows: string[][]): string {
@@ -269,9 +268,7 @@ function renderTableAsPre(header: string[], rows: string[][]): string {
   }
   const fmt = (r: string[]) =>
     Array.from({ length: cols }, (_, c) => (r[c] ?? "").padEnd(widths[c])).join("  ").trimEnd();
-  const escape = (s: string) =>
-    s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-  const text = [fmt(header), ...rows.map(fmt)].map(escape).join("\n");
+  const text = [fmt(header), ...rows.map(fmt)].map(escapeHtml).join("\n");
   return `<pre>${text}</pre>`;
 }
 

--- a/packages/core/src/channels/telegram.ts
+++ b/packages/core/src/channels/telegram.ts
@@ -177,7 +177,12 @@ export function createTelegramBot(token: string, agent: CoachAgent, binary: Bina
 // ============================================================================
 
 function markdownToTelegramHtml(md: string): string {
-  let html = md;
+  // Telegram has no table primitive in any parse mode. Extract markdown tables first
+  // and stash them as placeholders so the other regex passes don't mangle their contents.
+  // They get rendered into <pre> (monospace) blocks at the end, with cell content already
+  // HTML-escaped.
+  const tables: string[] = [];
+  let html = extractTables(md, tables);
 
   // Headers: ### Title → <b>Title</b>
   html = html.replace(/^#{1,6}\s+(.+)$/gm, "<b>$1</b>");
@@ -205,7 +210,69 @@ function markdownToTelegramHtml(md: string): string {
   html = html.replace(/&(?!amp;|lt;|gt;)/g, "&amp;");
   html = html.replace(/<(?!\/?(?:b|i|u|s|code|pre)>)/g, "&lt;");
 
+  // Restore tables (already-rendered <pre> blocks with escaped cell content).
+  html = html.replace(/ TBL(\d+) /g, (_, idx) => tables[Number(idx)] ?? "");
+
   return html;
+}
+
+const TABLE_SEPARATOR_RE = /^\s*\|?\s*:?-{2,}:?\s*(\|\s*:?-{2,}:?\s*)+\|?\s*$/;
+
+function isTableRow(line: string | undefined): boolean {
+  if (!line) return false;
+  const t = line.trim();
+  return t.startsWith("|") && t.endsWith("|") && t.length > 1;
+}
+
+function parseTableRow(line: string): string[] {
+  return line
+    .trim()
+    .replace(/^\|/, "")
+    .replace(/\|$/, "")
+    .split("|")
+    .map((s) => s.trim());
+}
+
+function extractTables(md: string, tables: string[]): string {
+  const lines = md.split("\n");
+  const out: string[] = [];
+  let i = 0;
+  while (i < lines.length) {
+    const next = lines[i + 1];
+    if (isTableRow(lines[i]) && next !== undefined && TABLE_SEPARATOR_RE.test(next)) {
+      const header = parseTableRow(lines[i]);
+      const rows: string[][] = [];
+      let j = i + 2;
+      while (j < lines.length && isTableRow(lines[j])) {
+        rows.push(parseTableRow(lines[j]));
+        j++;
+      }
+      const idx = tables.length;
+      tables.push(renderTableAsPre(header, rows));
+      out.push(` TBL${idx} `);
+      i = j;
+    } else {
+      out.push(lines[i]);
+      i++;
+    }
+  }
+  return out.join("\n");
+}
+
+function renderTableAsPre(header: string[], rows: string[][]): string {
+  const cols = Math.max(header.length, ...rows.map((r) => r.length));
+  const widths: number[] = [];
+  for (let c = 0; c < cols; c++) {
+    let w = (header[c] ?? "").length;
+    for (const r of rows) w = Math.max(w, (r[c] ?? "").length);
+    widths.push(w);
+  }
+  const fmt = (r: string[]) =>
+    Array.from({ length: cols }, (_, c) => (r[c] ?? "").padEnd(widths[c])).join("  ").trimEnd();
+  const escape = (s: string) =>
+    s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  const text = [fmt(header), ...rows.map(fmt)].map(escape).join("\n");
+  return `<pre>${text}</pre>`;
 }
 
 // ============================================================================

--- a/packages/core/tests/telegram-md.test.ts
+++ b/packages/core/tests/telegram-md.test.ts
@@ -149,4 +149,19 @@ describe("chunkHtml", () => {
       expect(c.length).toBeLessThanOrEqual(MAX);
     }
   });
+
+  it("preserves consecutive multi-line <pre> blocks across chunking", () => {
+    const pre1 = "<pre>a\nb\nc</pre>";
+    const pre2 = "<pre>d\ne\nf</pre>";
+    // Two paragraphs of filler force chunking; both <pre> blocks must end up intact.
+    const filler = "x".repeat(2500);
+    const html = `${pre1}\n\n${filler}\n\n${pre2}\n\n${filler}`;
+    expect(html.length).toBeGreaterThan(MAX);
+    const chunks = chunkHtml(html);
+    expect(chunks.join("\n")).toContain(pre1);
+    expect(chunks.join("\n")).toContain(pre2);
+    for (const c of chunks) {
+      expect((c.match(/<pre>/g) ?? []).length).toBe((c.match(/<\/pre>/g) ?? []).length);
+    }
+  });
 });

--- a/packages/core/tests/telegram-md.test.ts
+++ b/packages/core/tests/telegram-md.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from "vitest";
+import { markdownToTelegramHtml, chunkHtml } from "../src/channels/telegram.js";
+
+describe("markdownToTelegramHtml", () => {
+  it("passes plain markdown through with existing transforms", () => {
+    const out = markdownToTelegramHtml("# Hello\n\nSome **bold** and *italic*.\n- one\n- two");
+    expect(out).toContain("<b>Hello</b>");
+    expect(out).toContain("<b>bold</b>");
+    expect(out).toContain("<i>italic</i>");
+    expect(out).toContain("• one");
+  });
+
+  it("renders a basic markdown table as a padded <pre> block", () => {
+    const md = `| Phase | Duration |\n|-------|----------|\n| Warmup | 10min |\n| Main | 30min |`;
+    const out = markdownToTelegramHtml(md);
+    expect(out.startsWith("<pre>")).toBe(true);
+    expect(out.endsWith("</pre>")).toBe(true);
+    // Header padded to widest cell ("Warmup" = 6); columns separated by two spaces.
+    expect(out).toContain("Phase   Duration");
+    expect(out).toContain("Warmup  10min");
+    expect(out).toContain("Main    30min");
+  });
+
+  it("escapes HTML special chars inside table cells", () => {
+    const md = `| Day | Plan |\n|-----|------|\n| Mon | <easy> & rest |`;
+    const out = markdownToTelegramHtml(md);
+    expect(out).toContain("&lt;easy&gt;");
+    expect(out).toContain("&amp;");
+    expect(out).not.toContain("<easy>");
+  });
+
+  it("renders multiple tables as separate <pre> blocks", () => {
+    const md = `| A | B |\n|---|---|\n| 1 | 2 |\n\n| C | D |\n|---|---|\n| 3 | 4 |`;
+    const out = markdownToTelegramHtml(md);
+    const matches = out.match(/<pre>[\s\S]*?<\/pre>/g) ?? [];
+    expect(matches.length).toBe(2);
+  });
+
+  it("leaves a malformed table (no separator) as plain pipes", () => {
+    const md = `| not | a | table |\n| really | not | one |`;
+    const out = markdownToTelegramHtml(md);
+    expect(out).not.toContain("<pre>");
+    expect(out).toContain("|");
+  });
+
+  it("does not let italic regex match the placeholder content", () => {
+    const md = `| _hidden_ | x |\n|----------|---|\n| a | b |`;
+    const out = markdownToTelegramHtml(md);
+    expect(out).toContain("<pre>");
+    // The leading underscore in "_hidden_" stays literal inside the <pre>;
+    // it should NOT have been turned into <i>hidden</i> by the italic pass.
+    expect(out).not.toContain("<i>hidden</i>");
+  });
+
+  it("renders a header-only table (no body rows) without crashing", () => {
+    const md = `| Col1 | Col2 |\n|------|------|`;
+    const out = markdownToTelegramHtml(md);
+    expect(out).toContain("<pre>");
+    expect(out).toContain("Col1");
+    expect(out).toContain("Col2");
+  });
+
+  it("renders a table at the very start of a message cleanly", () => {
+    const md = `| A | B |\n|---|---|\n| 1 | 2 |\n\nFollow-up text.`;
+    const out = markdownToTelegramHtml(md);
+    expect(out.startsWith("<pre>")).toBe(true);
+    expect(out).toContain("Follow-up text.");
+  });
+
+  it("renders a table at the very end of a message cleanly", () => {
+    const md = `Intro text.\n\n| A | B |\n|---|---|\n| 1 | 2 |`;
+    const out = markdownToTelegramHtml(md);
+    expect(out).toContain("Intro text.");
+    expect(out.trimEnd().endsWith("</pre>")).toBe(true);
+  });
+
+  it("coexists with markdown code blocks (both become separate <pre> blocks)", () => {
+    const md = "```\nsome code\n```\n\n| A | B |\n|---|---|\n| 1 | 2 |";
+    const out = markdownToTelegramHtml(md);
+    const preBlocks = out.match(/<pre>[\s\S]*?<\/pre>/g) ?? [];
+    expect(preBlocks.length).toBe(2);
+    expect(out).toContain("some code");
+    expect(out).toContain("1");
+  });
+});
+
+describe("chunkHtml", () => {
+  const MAX = 4096;
+
+  it("returns a single chunk when the message fits", () => {
+    expect(chunkHtml("short message")).toEqual(["short message"]);
+  });
+
+  it("splits on line boundaries when there is no <pre> block", () => {
+    const line = "x".repeat(2000);
+    const html = `${line}\n${line}\n${line}`;
+    const chunks = chunkHtml(html);
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const c of chunks) expect(c.length).toBeLessThanOrEqual(MAX);
+  });
+
+  it("keeps a multi-line <pre> block whole when the surrounding text pushes total over the limit", () => {
+    const para = "x".repeat(2500);
+    const pre = "<pre>row1\nrow2\nrow3\nrow4</pre>";
+    const html = `${para}\n\n${para}\n\n${pre}`;
+    expect(html.length).toBeGreaterThan(MAX);
+    const chunks = chunkHtml(html);
+    expect(chunks.length).toBeGreaterThan(1);
+    // Whichever chunk contains <pre> must also contain </pre> on the same chunk.
+    const preChunk = chunks.find((c) => c.includes("<pre>"));
+    expect(preChunk).toBeDefined();
+    expect(preChunk).toContain("</pre>");
+    expect(preChunk).toContain("row4");
+  });
+
+  it("splits a <pre> block whose own size exceeds the limit into multiple wrapped <pre> chunks", () => {
+    const row = "row content padding ".repeat(20); // ~400 chars
+    const rows = Array.from({ length: 30 }, (_, i) => `${i}: ${row}`).join("\n");
+    const pre = `<pre>${rows}</pre>`;
+    expect(pre.length).toBeGreaterThan(MAX);
+    const chunks = chunkHtml(pre);
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const c of chunks) {
+      expect(c.length).toBeLessThanOrEqual(MAX);
+      // Every chunk that contains <pre> content must have a matching close, and vice versa.
+      const opens = (c.match(/<pre>/g) ?? []).length;
+      const closes = (c.match(/<\/pre>/g) ?? []).length;
+      expect(opens).toBe(closes);
+    }
+  });
+
+  it("hard-splits a single non-<pre> line longer than the limit", () => {
+    const line = "y".repeat(MAX + 500);
+    const chunks = chunkHtml(line);
+    expect(chunks.length).toBe(2);
+    for (const c of chunks) expect(c.length).toBeLessThanOrEqual(MAX);
+    expect(chunks.join("")).toBe(line);
+  });
+
+  it("invariant: every chunk has matching <pre>/</pre> tag counts", () => {
+    const filler = "lorem ipsum dolor sit amet ".repeat(200); // ~5400 chars
+    const pre = `<pre>${"x".repeat(50)}\n${"y".repeat(50)}\n${"z".repeat(50)}</pre>`;
+    const html = `${filler}\n${pre}\n${filler}`;
+    const chunks = chunkHtml(html);
+    for (const c of chunks) {
+      const opens = (c.match(/<pre>/g) ?? []).length;
+      const closes = (c.match(/<\/pre>/g) ?? []).length;
+      expect(opens).toBe(closes);
+      expect(c.length).toBeLessThanOrEqual(MAX);
+    }
+  });
+});

--- a/packages/sport-cycling/SOUL.md
+++ b/packages/sport-cycling/SOUL.md
@@ -25,14 +25,14 @@ Match response length to question complexity:
 
 - **Quick question** (zone lookup, yes/no, single fact) → 1-3 sentences
 - **Explanation** (how sweet spot works, recovery advice, race tactics) → short paragraph + bullets, stay under 10 bullet points
-- **Workout prescription** → structured interval table only, no essay around it
-- **Training plan** ��� table or phased list, this is the ONE case where longer output is OK
+- **Workout prescription** → structured interval list, one step per line (e.g., `Warmup: 10min Z2` / `Main: 3× 10min Z4 (240–260W), 5min Z2 between` / `Cooldown: 10min Z2`). No essay around it.
+- **Training plan** → phased list, one workout per line within each phase. This is the ONE case where longer output is OK.
 
 Never pad a short answer with background the athlete didn't ask for. If they ask "what zone is sweet spot?" answer the zone — don't explain the physiology of lactate threshold.
 
 ## Communication
 - If a question has a short answer, give the short answer
-- Use tables and bullet points, not paragraphs
+- Use bullet points and short vertical lists (one item per line), not paragraphs or wide tables — the output renders in a narrow mobile chat
 - Use cycling terminology (FTP, load, intensity, fitness, fatigue, form, sweet spot, threshold)
 - Format workouts as structured intervals (warmup → main → cooldown)
 - Always include estimated load/intensity for planned workouts


### PR DESCRIPTION
## Summary

Telegram has no table primitive in any parse mode (Markdown, MarkdownV2, HTML), so markdown tables produced by the LLM rendered as literal pipe-separated text in chats. Root-cause fix in two layers:

- **Steer the source** — `packages/sport-cycling/SOUL.md`: the three "table" directives now point the LLM to vertical interval lists ("one step per line: warmup → main → cooldown"). Workouts are inherently sequential and read better on mobile as `3× 10min Z4 (240–260W) / 5min Z2 between` than as a 4-column grid.
- **Defense in depth** — `packages/core/src/channels/telegram.ts`: `markdownToTelegramHtml` now extracts markdown tables to placeholders before the other regex passes, then restores them as `<pre>` blocks with columns padded and cell content HTML-escaped. Tables that slip past the SOUL guidance still render legibly in monospace.

Trade-off: bold/italic *inside* table cells stays as literal `**...**` because Telegram disallows nested entities inside `<pre>`. Acceptable since the LLM is now steered away from tables to begin with.

## Test plan

- [x] `pnpm check` clean in `packages/core`
- [x] `pnpm test` — 236 passing, 1 skipped
- [x] Smoke test of `markdownToTelegramHtml`: basic table, special chars (`<`, `&`) escaped, plain markdown untouched, multiple tables in one message, malformed table left alone
- [ ] Manual: send a workout request to the bot; confirm response uses vertical lists and any stray table renders as monospace