### PR TITLE
chore(skills): convert table-shaped skills to vertical lists

### DIFF
--- a/packages/sport-cycling/skills/periodization.md
+++ b/packages/sport-cycling/skills/periodization.md
@@ -32,23 +32,19 @@ Default/fallback model. Versatile for most athletes without specific needs.
 
 ## Phase Allocation
 
-| Phase | Purpose | Intensity |
-|-------|---------|-----------|
-| Base Building | Aerobic foundation, volume buildup | 85% easy / 10% tempo / 5% threshold |
-| Aerobic Development | Extend endurance, tempo work | 80% easy / 15% tempo / 5% threshold |
-| Threshold | FTP development, race-pace work | 70% easy / 20% threshold / 10% VO2max |
-| VO2max | Top-end power, short sharp efforts | 65% easy / 15% threshold / 20% VO2max |
-| Race Prep | Event-specific simulation | 60% easy / 25% race-pace / 15% VO2max |
-| Taper | Reduce volume, maintain intensity | 85% easy / 15% light efforts |
+- **Base Building** — aerobic foundation, volume buildup. 85% easy / 10% tempo / 5% threshold.
+- **Aerobic Development** — extend endurance, tempo work. 80% easy / 15% tempo / 5% threshold.
+- **Threshold** — FTP development, race-pace work. 70% easy / 20% threshold / 10% VO2max.
+- **VO2max** — top-end power, short sharp efforts. 65% easy / 15% threshold / 20% VO2max.
+- **Race Prep** — event-specific simulation. 60% easy / 25% race-pace / 15% VO2max.
+- **Taper** — reduce volume, maintain intensity. 85% easy / 15% light efforts.
 
 ## Build:Recovery Ratios
 
-| Level | Ratio | Meaning |
-|-------|-------|---------|
-| Beginner | 2:1 | 2 build weeks, 1 recovery week |
-| Intermediate | 3:1 | 3 build weeks, 1 recovery week |
-| Advanced | 3:1 | 3 build weeks, 1 recovery week |
-| Elite | 4:1 | 4 build weeks, 1 recovery week |
+- **Beginner:** 2:1 — 2 build weeks, 1 recovery week
+- **Intermediate:** 3:1 — 3 build weeks, 1 recovery week
+- **Advanced:** 3:1 — 3 build weeks, 1 recovery week
+- **Elite:** 4:1 — 4 build weeks, 1 recovery week
 
 ## Volume Progression Multipliers
 

--- a/packages/sport-cycling/skills/race-prep.md
+++ b/packages/sport-cycling/skills/race-prep.md
@@ -2,12 +2,10 @@
 
 ## Taper Duration by Race Type
 
-| Race Type | Taper Weeks | Volume Reduction |
-|-----------|-------------|------------------|
-| Century (100mi) | 2 weeks | 40-50% |
-| Gran Fondo | 2 weeks | 40-50% |
-| Criterium | 1 week | 30-40% |
-| Time Trial | 1 week | 30-40% |
+- **Century (100mi):** 2 weeks taper, 40-50% volume reduction
+- **Gran Fondo:** 2 weeks taper, 40-50% volume reduction
+- **Criterium:** 1 week taper, 30-40% volume reduction
+- **Time Trial:** 1 week taper, 30-40% volume reduction
 
 ## Taper Strategy
 

--- a/packages/sport-cycling/skills/workout-design.md
+++ b/packages/sport-cycling/skills/workout-design.md
@@ -75,17 +75,15 @@ Every workout follows: Warmup → Main Set → Cooldown
 When pushing a workout to the calendar, pass the structured shape (never prose — see
 `intervals-icu.md`). Step types map to what's actually happening:
 
-| Step                          | Use                                                      |
-| ----------------------------- | -------------------------------------------------------- |
-| `warmup`                      | Pre-set progressive build-up                             |
-| `ramp`                        | Transition with `low`+`high` power bounds                |
-| `steady`                      | Single block at one intensity (e.g. Z2 endurance)        |
-| `interval`                    | Work effort inside a set (sweet spot, threshold, VO2max) |
-| `recovery`                    | Easy spin between intervals inside a set                 |
-| `rest`                        | Off-bike-style complete rest (rare in cycling)           |
-| `cooldown`                    | Post-set easy spin                                       |
-| `freeride`                    | No power target (Zwift freeride / outdoor easy)          |
-| `set { repeat, interval, recovery }` | Group repeated intervals (e.g. 3×15 sweet spot)  |
+- `warmup` — pre-set progressive build-up
+- `ramp` — transition with `low`+`high` power bounds
+- `steady` — single block at one intensity (e.g. Z2 endurance)
+- `interval` — work effort inside a set (sweet spot, threshold, VO2max)
+- `recovery` — easy spin between intervals inside a set
+- `rest` — off-bike-style complete rest (rare in cycling)
+- `cooldown` — post-set easy spin
+- `freeride` — no power target (Zwift freeride / outdoor easy)
+- `set { repeat, interval, recovery }` — group repeated intervals (e.g. 3×15 sweet spot)
 
 ### Sweet Spot 3×15 → tool input
 


### PR DESCRIPTION
## Summary

Telegram has no markdown table primitive, so any table that survives in LLM output renders as raw pipe-separated text (or, after PR #81, as a monospace `<pre>` block — legible but visually heavy on mobile). PR #81 steered the cycling SOUL toward vertical interval lists and added the `<pre>` fallback as defense in depth. This PR removes the remaining table-shaped reference content from cycling skill files so the LLM has nothing to copy back. The defense-in-depth fallback stays; this just trims the source.

**Converted to vertical lists** (short, label + facts shape):
- `packages/sport-cycling/skills/race-prep.md` — "Taper Duration by Race Type" (4×3).
- `packages/sport-cycling/skills/periodization.md` — "Phase Allocation" (6×3) and "Build:Recovery Ratios" (4×3).
- `packages/sport-cycling/skills/workout-design.md` — `intervals_create_workout` step types (9×2).

**Kept as a table** (true reference matrix; horizontal cross-zone comparison is the point):
- `packages/sport-cycling/skills/zone-reference.md` — Zone × Name × %FTP × RPE × Description (6×5). The channel-side `<pre>` fallback from PR #81 handles rendering.

`SOUL.md` was already updated in PR #81 and is not touched here. No code or non-skill content was modified. `sport-running` and `sport-duathlon` packages have no `skills/` directories yet, so nothing to do there.

## Test plan

- [ ] Manual visual check: send a workout / taper / periodization / step-types question to the bot and confirm the response uses vertical lists (no `|---|---|` rows).
- [ ] Manual visual check: ask "what's Z4?" — confirm the kept zone-reference table renders via the `<pre>` fallback from PR #81 and is readable on a phone.
- [ ] No automated test — these are content edits, not behavior changes.