### PR TITLE
fix(telegram): stop re-greeting returning users after restart

### DIFF
--- a/.changeset/welcome-on-restart-fix.md
+++ b/.changeset/welcome-on-restart-fix.md
@@ -1,0 +1,7 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: The bot no longer greets you with the "Welcome to Cycling Coach!" message after a redeploy or `/update`. Existing chats with an on-disk session are recognized as returning.
+
+The previous "have I greeted this chat yet?" tracking was an in-memory `Set` (`packages/core/src/channels/telegram.ts`), wiped on every process restart — so every existing user was treated as a newcomer on their first message after a Railway deploy or self-update. The fix consults the persisted session file in `~/.cycling-coach/sessions/telegram:<chatId>.jsonl` as a durable signal for "returning user" before showing the welcome.

--- a/packages/core/src/agent/chat-store.ts
+++ b/packages/core/src/agent/chat-store.ts
@@ -28,6 +28,10 @@ export class ChatStore {
     return join(this.sessionsDir, `${chatId}.jsonl`);
   }
 
+  hasSession(chatId: string): boolean {
+    return existsSync(this.filePath(chatId));
+  }
+
   load(chatId: string): { messages: ModelMessage[]; lastMessageTime: string | null } {
     const path = this.filePath(chatId);
     if (!existsSync(path)) return { messages: [], lastMessageTime: null };

--- a/packages/core/src/agent/coach-agent.ts
+++ b/packages/core/src/agent/coach-agent.ts
@@ -231,6 +231,10 @@ export class CoachAgent {
     });
   }
 
+  hasSession(chatId: string): boolean {
+    return this.chatStore.hasSession(chatId);
+  }
+
   async resetSession(chatId: string): Promise<void> {
     // Flush before reset to avoid losing un-persisted context
     const { messages: history } = this.chatStore.load(chatId);

--- a/packages/core/src/channels/telegram.ts
+++ b/packages/core/src/channels/telegram.ts
@@ -147,10 +147,14 @@ export function createTelegramBot(token: string, agent: CoachAgent, binary: Bina
   bot.on("message:text", async (ctx) => {
     const chatId = `telegram:${ctx.chat.id}`;
 
-    // Welcome newcomers on their very first message
+    // Welcome newcomers on their very first message. `greeted` is in-memory,
+    // so after a process restart we consult the on-disk session to tell
+    // returning users from true newcomers.
     if (!greeted.has(ctx.chat.id)) {
       greeted.add(ctx.chat.id);
-      await ctx.reply(WELCOME_MESSAGE);
+      if (!agent.hasSession(chatId)) {
+        await ctx.reply(WELCOME_MESSAGE);
+      }
     }
 
     try {


### PR DESCRIPTION
## Summary
- Telegram bot was re-sending the welcome message every time the process restarted (Railway redeploy, `/update`, crash) — the "have I greeted this chat yet?" check used an in-memory `Set` that was wiped on each boot.
- Sessions are already persisted to `~/.cycling-coach/sessions/telegram:<chatId>.jsonl`, so this consults the on-disk session as a durable signal for "returning user" before sending `WELCOME_MESSAGE`.
- The in-memory `Set` is kept as a per-process cache so we only consult disk once per chat per process.

## Test plan
- [x] `npx tsc --noEmit` clean in `packages/core`
- [ ] Restart the bot (or run `/update`) and message it from an existing chat — should go straight to the agent reply without a welcome message.
- [ ] Brand-new chat with no on-disk session — should still receive the welcome message on first text.
- [ ] `/start` from any chat — still resets the session and shows the welcome (unchanged behavior).