### PR TITLE
feat(telegram): add /whatsnew command + release-notes plumbing

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -18,6 +18,28 @@ When the PR merges to main, a "Version PR" will be opened (or updated) by the ch
 
 We let the bot's PR handle commits, not the local CLI. Local `pnpm exec changeset` only writes the `.changeset/*.md` file; the bot does the actual version bump + CHANGELOG generation in its own commit.
 
+## User-facing notes
+
+The Telegram bot's `/whatsnew` command surfaces release notes to athletes. To keep that view athlete-friendly and free of engineering chatter, prefix any user-visible change with a `User-facing:` line at the top of the changeset body:
+
+```
+---
+"cycling-coach": patch
+---
+
+User-facing: Added /review command to summarize last week's training.
+
+Engineering details (anything you want — code refs, hash, rationale). Ignored by /whatsnew.
+```
+
+Rules:
+
+- One sentence per `User-facing:` line, written in plain English in the bot's voice.
+- Multiple user-visible changes in one changeset → multiple `User-facing:` lines, each becomes a bullet.
+- Pure-infra changes (CI, publishing, build tooling, internal refactors) omit the line — they stay in `CHANGELOG.md` for git history but don't reach athletes.
+- The line is parsed by a simple regex (`/User-facing:\s*(.+)$/i`); anything after the colon on the same line is the bullet text.
+- The convention propagates from `.changeset/*.md` → `CHANGELOG.md` → GitHub Release body automatically; `/whatsnew` reads the GitHub Release body.
+
 ## Binary packages and CalVer
 
 Library packages (`@enduragent/*`) follow SemVer via standard changesets bumps.

--- a/.changeset/whatsnew-command.md
+++ b/.changeset/whatsnew-command.md
@@ -1,0 +1,10 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Added /whatsnew — see what changed in the latest version without leaving Telegram.
+User-facing: Update notifications now point to /whatsnew so you can decide whether to /update.
+
+Adds a new `/whatsnew` command that fetches the latest GitHub Release body for the running binary and renders only the lines tagged `User-facing:` in the underlying changesets. Engineering details, hashes, and infra-only changesets stay in `CHANGELOG.md` for git history but never reach athletes.
+
+Convention is documented in `.changeset/README.md`. The bot makes one anonymous GitHub API call per `/whatsnew` invocation (no caching); GitHub Releases are auto-created by `release.yml` so no extra release-process work is needed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,8 @@ Calendar-based for npm-published binaries: `YYYY.M.D` (e.g., `2026.4.16` — fir
 Changesets-driven and CI-automated. Contributors do **not** create tags or GitHub Releases by hand — those steps are wrong, and the tag namespace is `<package>@<version>` (e.g., `cycling-coach@2026.5.4`), not `vYYYY.M.D`.
 
 1. **Add a changeset to your PR.** Run `pnpm exec changeset`, pick the affected publishable package(s), describe the change in athlete-readable language. Commit the resulting `.changeset/<slug>.md`. A PR with a user-visible change but no changeset will skip release — this is intentional, not a bug.
+
+   For user-visible changes, add a `User-facing: <one-sentence description>` line at the top of the changeset body — see `.changeset/README.md` for the convention. The bot's `/whatsnew` command surfaces only those lines to athletes; engineering details, hashes, and infra-only changesets stay in `CHANGELOG.md` for git history but never reach users.
 2. **Merge your PR to `main`.** `version-pr.yml` opens (or updates) a bot-managed "Version Packages" PR aggregating all pending changesets.
 3. **Merge the "Version Packages" PR when ready to ship.** It bumps `package.json` + CHANGELOG.md for the listed packages plus their internal dependents (per `updateInternalDependencies: "patch"` in `.changeset/config.json`). On merge, `version-pr.yml` then auto-pushes `<package>@<version>` tags for every **non-private** bumped package.
 4. **`release.yml` fires on the tag.** It builds, runs tests, packs the binary and smoke-installs the tarball, publishes to npm via OIDC trusted publisher (no `NPM_TOKEN`), and auto-creates the GitHub Release with notes extracted from `CHANGELOG.md`.

--- a/packages/core/src/channels/telegram.ts
+++ b/packages/core/src/channels/telegram.ts
@@ -10,6 +10,7 @@ import {
   getLastNotifiedVersion,
   setLastNotifiedVersion,
 } from "../updater.js";
+import { buildWhatsNewMessage } from "../release-notes.js";
 
 function formatRateLimitWait(err: unknown): string {
   const ms = extractRetryAfterMs(err);
@@ -33,6 +34,7 @@ const WELCOME_MESSAGE =
   "/status — Check current fitness, fatigue, and form\n" +
   "/sync — Push plan to intervals.icu calendar\n" +
   "/version — Show current version\n" +
+  "/whatsnew — See what changed in the latest version\n" +
   "/update — Check for and install updates\n\n" +
   "Or just chat with me about your training!";
 
@@ -118,6 +120,27 @@ export function createTelegramBot(token: string, agent: CoachAgent, binary: Bina
 
   bot.command("version", async (ctx) => {
     await ctx.reply(`${binary.displayName} v${getCurrentVersion(binary.binaryName)}`);
+  });
+
+  bot.command("whatsnew", async (ctx) => {
+    await ctx.reply("Fetching release notes...");
+    try {
+      const info = await checkForUpdate(binary.binaryName);
+      if (!info) {
+        await ctx.reply("Couldn't reach npm to check the latest version. Try again later.");
+        return;
+      }
+      const message = await buildWhatsNewMessage({
+        binaryName: binary.binaryName,
+        currentVersion: info.current,
+        latestVersion: info.latest,
+        updateAvailable: info.updateAvailable,
+      });
+      await sendLongMessage(ctx, message);
+    } catch (err) {
+      console.error("Error in /whatsnew:", err);
+      await ctx.reply("Sorry, couldn't fetch release notes. Please try again.");
+    }
   });
 
   bot.command("update", async (ctx) => {
@@ -405,7 +428,7 @@ export async function notifyUpdate(bot: Bot, dataDir: string, binary: BinaryConf
     if (getLastNotifiedVersion(dataDir) === info.latest) return;
 
     const chatIds = getKnownTelegramChatIds(dataDir);
-    const message = `Update available: ${info.current} → ${info.latest}\nSend /update to install.`;
+    const message = `Update available: ${info.current} → ${info.latest}\nSend /whatsnew to see what changed, /update to install.`;
 
     for (const chatId of chatIds) {
       try {

--- a/packages/core/src/channels/telegram.ts
+++ b/packages/core/src/channels/telegram.ts
@@ -130,12 +130,7 @@ export function createTelegramBot(token: string, agent: CoachAgent, binary: Bina
         await ctx.reply("Couldn't reach npm to check the latest version. Try again later.");
         return;
       }
-      const message = await buildWhatsNewMessage({
-        binaryName: binary.binaryName,
-        currentVersion: info.current,
-        latestVersion: info.latest,
-        updateAvailable: info.updateAvailable,
-      });
+      const message = await buildWhatsNewMessage(binary.binaryName, info);
       await sendLongMessage(ctx, message);
     } catch (err) {
       console.error("Error in /whatsnew:", err);

--- a/packages/core/src/release-notes.ts
+++ b/packages/core/src/release-notes.ts
@@ -1,0 +1,108 @@
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { join } from "node:path";
+
+export interface RepoInfo {
+  owner: string;
+  name: string;
+}
+
+export function parseRepoFromUrl(url: string): RepoInfo | null {
+  const m = url.match(/github\.com[/:]([^/]+)\/([^/.]+?)(?:\.git)?(?:#.*)?$/);
+  if (!m) return null;
+  return { owner: m[1], name: m[2] };
+}
+
+export function getRepoForBinary(binaryName: string): RepoInfo | null {
+  const tryParse = (pkgPath: string): RepoInfo | null => {
+    try {
+      const pkg = JSON.parse(readFileSync(pkgPath, "utf-8")) as { repository?: { url?: string } | string };
+      const url = typeof pkg.repository === "string" ? pkg.repository : pkg.repository?.url;
+      return url ? parseRepoFromUrl(url) : null;
+    } catch {
+      return null;
+    }
+  };
+
+  try {
+    const requireFn = createRequire(import.meta.url);
+    const installed = tryParse(requireFn.resolve(`${binaryName}/package.json`));
+    if (installed) return installed;
+  } catch {
+    // fall through to dev fallback
+  }
+  return tryParse(join(process.cwd(), "package.json"));
+}
+
+export function parseUserFacing(body: string): string[] {
+  const out: string[] = [];
+  for (const raw of body.split("\n")) {
+    const m = raw.match(/User-facing:\s*(.+?)\s*$/i);
+    if (m && m[1]) out.push(m[1].trim());
+  }
+  return out;
+}
+
+export async function fetchReleaseBody(
+  repo: RepoInfo,
+  tag: string,
+  timeoutMs = 5000,
+): Promise<string | null> {
+  try {
+    const res = await fetch(
+      `https://api.github.com/repos/${repo.owner}/${repo.name}/releases/tags/${encodeURIComponent(tag)}`,
+      {
+        signal: AbortSignal.timeout(timeoutMs),
+        headers: { Accept: "application/vnd.github+json" },
+      },
+    );
+    if (!res.ok) return null;
+    const data = (await res.json()) as { body?: string };
+    return data.body ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export interface WhatsNewArgs {
+  binaryName: string;
+  currentVersion: string;
+  latestVersion: string;
+  updateAvailable: boolean;
+}
+
+export async function buildWhatsNewMessage(args: WhatsNewArgs): Promise<string> {
+  const repo = getRepoForBinary(args.binaryName);
+  if (!repo) {
+    return `Couldn't locate the GitHub repository for ${args.binaryName}.`;
+  }
+
+  const tag = `${args.binaryName}@${args.latestVersion}`;
+  const releaseUrl = `https://github.com/${repo.owner}/${repo.name}/releases/tag/${tag}`;
+  const body = await fetchReleaseBody(repo, tag);
+
+  const lines: string[] = [];
+  lines.push(`**What's new in ${args.latestVersion}**`);
+  lines.push("");
+
+  if (body === null) {
+    lines.push(`Couldn't fetch release notes from GitHub. See ${releaseUrl}`);
+  } else {
+    const userFacing = parseUserFacing(body);
+    if (userFacing.length > 0) {
+      for (const line of userFacing) lines.push(`- ${line}`);
+    } else {
+      lines.push(`_No athlete-facing summary written for this release._`);
+      lines.push(`Full notes: ${releaseUrl}`);
+    }
+  }
+
+  lines.push("");
+  if (args.updateAvailable) {
+    lines.push(`You're on ${args.currentVersion}. Send /update to install ${args.latestVersion}.`);
+  } else {
+    lines.push(`You're up to date.`);
+  }
+
+  return lines.join("\n");
+}

--- a/packages/core/src/release-notes.ts
+++ b/packages/core/src/release-notes.ts
@@ -1,6 +1,4 @@
-import { readFileSync } from "node:fs";
-import { createRequire } from "node:module";
-import { join } from "node:path";
+import { readBinaryPackageJson, type UpdateInfo } from "./updater.js";
 
 export interface RepoInfo {
   owner: string;
@@ -14,24 +12,10 @@ export function parseRepoFromUrl(url: string): RepoInfo | null {
 }
 
 export function getRepoForBinary(binaryName: string): RepoInfo | null {
-  const tryParse = (pkgPath: string): RepoInfo | null => {
-    try {
-      const pkg = JSON.parse(readFileSync(pkgPath, "utf-8")) as { repository?: { url?: string } | string };
-      const url = typeof pkg.repository === "string" ? pkg.repository : pkg.repository?.url;
-      return url ? parseRepoFromUrl(url) : null;
-    } catch {
-      return null;
-    }
-  };
-
-  try {
-    const requireFn = createRequire(import.meta.url);
-    const installed = tryParse(requireFn.resolve(`${binaryName}/package.json`));
-    if (installed) return installed;
-  } catch {
-    // fall through to dev fallback
-  }
-  return tryParse(join(process.cwd(), "package.json"));
+  const pkg = readBinaryPackageJson(binaryName);
+  const repo = pkg?.repository as { url?: string } | string | undefined;
+  const url = typeof repo === "string" ? repo : repo?.url;
+  return url ? parseRepoFromUrl(url) : null;
 }
 
 export function parseUserFacing(body: string): string[] {
@@ -64,25 +48,26 @@ export async function fetchReleaseBody(
   }
 }
 
-export interface WhatsNewArgs {
-  binaryName: string;
-  currentVersion: string;
-  latestVersion: string;
-  updateAvailable: boolean;
-}
-
-export async function buildWhatsNewMessage(args: WhatsNewArgs): Promise<string> {
-  const repo = getRepoForBinary(args.binaryName);
+/**
+ * Build the `/whatsnew` reply for the latest published version of `binaryName`.
+ * Always shows the latest version's notes (per product decision) — when the
+ * user is up to date that's their version's notes; when behind, it's a preview
+ * of what `/update` will install. Renders only `User-facing:` lines extracted
+ * from the GitHub Release body; engineering details and changeset hashes never
+ * surface to athletes.
+ */
+export async function buildWhatsNewMessage(binaryName: string, info: UpdateInfo): Promise<string> {
+  const repo = getRepoForBinary(binaryName);
   if (!repo) {
-    return `Couldn't locate the GitHub repository for ${args.binaryName}.`;
+    return `Couldn't locate the GitHub repository for ${binaryName}.`;
   }
 
-  const tag = `${args.binaryName}@${args.latestVersion}`;
+  const tag = `${binaryName}@${info.latest}`;
   const releaseUrl = `https://github.com/${repo.owner}/${repo.name}/releases/tag/${tag}`;
   const body = await fetchReleaseBody(repo, tag);
 
   const lines: string[] = [];
-  lines.push(`**What's new in ${args.latestVersion}**`);
+  lines.push(`**What's new in ${info.latest}**`);
   lines.push("");
 
   if (body === null) {
@@ -98,8 +83,8 @@ export async function buildWhatsNewMessage(args: WhatsNewArgs): Promise<string> 
   }
 
   lines.push("");
-  if (args.updateAvailable) {
-    lines.push(`You're on ${args.currentVersion}. Send /update to install ${args.latestVersion}.`);
+  if (info.updateAvailable) {
+    lines.push(`You're on ${info.current}. Send /update to install ${info.latest}.`);
   } else {
     lines.push(`You're up to date.`);
   }

--- a/packages/core/src/updater.ts
+++ b/packages/core/src/updater.ts
@@ -44,23 +44,40 @@ export function isUpdateAvailable(latest: string, current: string): boolean {
   return false;
 }
 
-export function getCurrentVersion(binaryName: string): string {
-  // Installed-binary path: resolve via Node's module-resolution to find the
-  // binary package's package.json wherever pnpm/npm placed it.
+/**
+ * Read the binary's package.json — installed path first (via Node's module
+ * resolution), cwd fallback for dev. Memoized: package.json doesn't change
+ * mid-process, and `/update` exits the process before installing a new
+ * version, so the cache is naturally invalidated by restart.
+ */
+const pkgCache = new Map<string, Record<string, unknown> | null>();
+export function readBinaryPackageJson(binaryName: string): Record<string, unknown> | null {
+  if (pkgCache.has(binaryName)) return pkgCache.get(binaryName) ?? null;
+
+  const tryRead = (path: string): Record<string, unknown> | null => {
+    try {
+      return JSON.parse(readFileSync(path, "utf-8")) as Record<string, unknown>;
+    } catch {
+      return null;
+    }
+  };
+
+  let pkg: Record<string, unknown> | null = null;
   try {
     const requireFn = createRequire(import.meta.url);
-    const pkgPath = requireFn.resolve(`${binaryName}/package.json`);
-    const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
-    return pkg.version;
+    pkg = tryRead(requireFn.resolve(`${binaryName}/package.json`));
   } catch {
-    // Dev-time fallback: cwd is the repo root which contains the binary's package.json.
-    try {
-      const pkg = JSON.parse(readFileSync(join(process.cwd(), "package.json"), "utf-8"));
-      return pkg.version;
-    } catch {
-      return "unknown";
-    }
+    // resolve() threw (binary not installed via npm) — fall through
   }
+  if (!pkg) pkg = tryRead(join(process.cwd(), "package.json"));
+
+  pkgCache.set(binaryName, pkg);
+  return pkg;
+}
+
+export function getCurrentVersion(binaryName: string): string {
+  const pkg = readBinaryPackageJson(binaryName);
+  return (pkg?.version as string | undefined) ?? "unknown";
 }
 
 export async function checkForUpdate(binaryName: string): Promise<UpdateInfo | null> {

--- a/packages/core/tests/release-notes.test.ts
+++ b/packages/core/tests/release-notes.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+
+import { parseRepoFromUrl, parseUserFacing } from "../src/release-notes.js";
+
+describe("parseRepoFromUrl", () => {
+  it("parses git+https URL with .git suffix", () => {
+    expect(parseRepoFromUrl("git+https://github.com/foo/bar.git")).toEqual({ owner: "foo", name: "bar" });
+  });
+
+  it("parses ssh URL", () => {
+    expect(parseRepoFromUrl("git@github.com:foo/bar.git")).toEqual({ owner: "foo", name: "bar" });
+  });
+
+  it("parses bare https URL without .git", () => {
+    expect(parseRepoFromUrl("https://github.com/foo/bar")).toEqual({ owner: "foo", name: "bar" });
+  });
+
+  it("ignores trailing #readme fragment", () => {
+    expect(parseRepoFromUrl("https://github.com/foo/bar#readme")).toEqual({ owner: "foo", name: "bar" });
+  });
+
+  it("returns null for non-GitHub host", () => {
+    expect(parseRepoFromUrl("https://gitlab.com/foo/bar.git")).toBeNull();
+  });
+
+  it("returns null for malformed input", () => {
+    expect(parseRepoFromUrl("not-a-url")).toBeNull();
+  });
+});
+
+describe("parseUserFacing", () => {
+  it("extracts a single user-facing line and drops the changeset hash prefix", () => {
+    const body = "- abc1234: User-facing: Added /review command.\n\n  Engineering: stuff.";
+    expect(parseUserFacing(body)).toEqual(["Added /review command."]);
+  });
+
+  it("extracts multiple user-facing lines", () => {
+    const body = [
+      "- abc: User-facing: First change.",
+      "- def: User-facing: Second change.",
+    ].join("\n");
+    expect(parseUserFacing(body)).toEqual(["First change.", "Second change."]);
+  });
+
+  it("returns empty when no user-facing lines exist", () => {
+    expect(parseUserFacing("- abc: Pure infra change.\n\n  Engineering details only.")).toEqual([]);
+  });
+
+  it("is case-insensitive", () => {
+    const body = "user-facing: lowercase works.\nUSER-FACING: caps works.";
+    expect(parseUserFacing(body)).toEqual(["lowercase works.", "caps works."]);
+  });
+
+  it("trims surrounding whitespace from the captured text", () => {
+    expect(parseUserFacing("User-facing:    padded value   ")).toEqual(["padded value"]);
+  });
+
+  it("matches when the line is indented inside a sub-bullet", () => {
+    const body = "  - User-facing: Indented entry.";
+    expect(parseUserFacing(body)).toEqual(["Indented entry."]);
+  });
+
+  it("ignores empty captures", () => {
+    expect(parseUserFacing("User-facing:\nUser-facing: real one.")).toEqual(["real one."]);
+  });
+});


### PR DESCRIPTION
> Replaces #85 which auto-closed when its base branch (#84) was deleted on merge.

## Summary
- Adds \`/whatsnew\` — fetches the latest GitHub Release body for the running binary and renders only the lines tagged \`User-facing:\` in the underlying changesets. Engineering details, hashes, and infra-only changesets stay in \`CHANGELOG.md\` for git history but never reach athletes.
- Tweaks the startup update notification to point at \`/whatsnew\` so users can see what changed before deciding to \`/update\`.
- Documents the \`User-facing:\` convention in \`.changeset/README.md\` and \`CONTRIBUTING.md\`.
- New module \`packages/core/src/release-notes.ts\` is pure (no LLM, no agent dependency) — makes one anonymous GitHub API call per \`/whatsnew\` invocation (no caching).
- Refactor: extracts \`readBinaryPackageJson\` from \`updater.ts\` (memoized) so both \`getCurrentVersion\` and \`getRepoForBinary\` share it instead of duplicating the resolve + cwd-fallback dance.

## Bot output (athlete view)
\`\`\`
What's new in 2026.5.7
- Added /whatsnew — see what changed in the latest version without leaving Telegram.
- Update notifications now point to /whatsnew so you can decide whether to /update.

You're on 2026.5.6. Send /update to install 2026.5.7.
\`\`\`

## Convention
Each \`.changeset/*.md\` may include one or more \`User-facing:\` lines at the top of its body. Multiple lines → multiple bullets. Pure-infra changesets omit the line. The line propagates \`.changeset/*.md\` → \`CHANGELOG.md\` → GitHub Release body automatically.

## Test plan
- [x] \`npx tsc --noEmit\` clean in \`packages/core\`
- [x] \`npx vitest run tests/release-notes.test.ts\` — 13/13 passing
- [ ] Run the bot, send \`/whatsnew\` from a chat — should fetch the latest release, parse \`User-facing:\` lines from the GitHub Release body, render bullets, and append the version-status footer.
- [ ] Test with a release that has no \`User-facing:\` lines — should show the placeholder + GitHub link.
- [ ] Trigger \`notifyUpdate\` — broadcast should now mention \`/whatsnew\` alongside \`/update\`.