### PR TITLE
feat(core): add /review command for coaching reviews of training sessions

### DIFF
--- a/.changeset/review-command.md
+++ b/.changeset/review-command.md
@@ -1,0 +1,8 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Added /review — get a coaching review of your last training session, with depth that auto-scales by activity type.
+User-facing: Use /review deep for race-style analysis or /review brief for a quick check; you can also pass natural language like /review my saturday ride.
+
+Adds two Pure-Core intervals.icu tools (`intervals_fetch_activity` and `intervals_fetch_streams`) so the agent can pull per-rep splits and raw streams when it needs them, plus a `WORKOUT_REVIEW_RULES` system-prompt block that drives the 3-questions framework, depth tiers (Tier A ~50 words / Tier B ~200 / Tier C ~500–600), the `Reply 'show numbers'` + `/review deep` footer, and the trademark cleanup (no NP/CTL/ATL/IF/TSS/TSB or "true FTP" in athlete-facing review output — uses Load / Intensity / Fitness / Fatigue / Form / weighted avg power instead). Cycling-specific guidance lives in `sport-cycling/SOUL.md` (30-min activity-clustering rule, jargon list, substitution table) and `sport-cycling/skills/review.md` (decoupling thresholds, best-efforts duration ladder, fade-pattern catalog, indoor-vs-outdoor signals).

--- a/packages/core/src/agent/intervals-tools.ts
+++ b/packages/core/src/agent/intervals-tools.ts
@@ -59,6 +59,59 @@ export function createPureCoreIntervalsTools(
       },
     }),
 
+    intervals_fetch_activity: tool({
+      description:
+        "Fetch a single activity from intervals.icu by ID. Returns the full Activity " +
+        "object including per-rep `icu_intervals` (lap/interval splits with avg power, " +
+        "HR, time), `analyzed` flag (null while analysis still in progress), " +
+        "`paired_event_id` (link to planned workout), zone times, and the headline " +
+        "metrics from the list view. Use this for Tier B+ workout reviews; for " +
+        "summary-only Tier A, use `intervals_fetch_activities`.",
+      inputSchema: zodSchema(
+        z.object({
+          activityId: z.number().int().describe("Activity ID from intervals_fetch_activities"),
+        }),
+      ),
+      execute: async (input: { activityId: number }) => {
+        const result = await intervals.activities.get(String(input.activityId));
+        if (!result.ok) return { error: result.error.kind };
+        return result.value;
+      },
+    }),
+
+    intervals_fetch_streams: tool({
+      description:
+        "Fetch raw time-series streams for an activity (watts, heartrate, cadence, " +
+        "time, altitude, distance, lat, lng). Returns an object with each requested " +
+        "type as a sample array. EXPENSIVE: a 3-hour ride is ~10,800 samples per " +
+        "type. ONLY call for Tier C deep reviews (races + explicit 'deep' override). " +
+        "For Tier A/B reviews, use `intervals_fetch_activities` and " +
+        "`intervals_fetch_activity` instead. Default types are watts, heartrate, " +
+        "cadence, time, altitude.",
+      inputSchema: zodSchema(
+        z.object({
+          activityId: z.number().int().describe("Activity ID"),
+          types: z
+            .array(z.string())
+            .optional()
+            .describe(
+              "Stream types to fetch. Defaults to ['watts','heartrate','cadence','time','altitude']. " +
+                "Other valid types: distance, lat, lng, temp, smooth_grade.",
+            ),
+        }),
+      ),
+      execute: async (input: { activityId: number; types?: string[] }) => {
+        // Treat empty array the same as omitted — defensively handle the LLM
+        // calling with `types: []` "to play it safe" instead of dropping the field.
+        const types = input.types?.length
+          ? input.types
+          : ["watts", "heartrate", "cadence", "time", "altitude"];
+        const result = await intervals.activities.getStreams(String(input.activityId), types);
+        if (!result.ok) return { error: result.error.kind };
+        return result.value;
+      },
+    }),
+
     intervals_delete_workout: tool({
       description:
         "Delete a scheduled workout from the intervals.icu calendar by event ID. " +

--- a/packages/core/src/agent/system-prompt.ts
+++ b/packages/core/src/agent/system-prompt.ts
@@ -5,6 +5,92 @@ import type { Memory } from "../memory/store.js";
 // SYSTEM PROMPT BUILDER
 // ============================================================================
 
+const WORKOUT_REVIEW_RULES = `# Workout Review (when user types /review or asks to review a session)
+
+You are reviewing a *training session* — one or more activities clustered close in
+time. A "session" here is what actually happened on the road; a "workout" is the
+planned prescription on the calendar (calendar event, paired_event_id). Don't conflate
+the two.
+
+## Detecting the trigger
+- Slash command: message begins with \`/review\`.
+- Natural language: "review my last ride", "how was my Saturday session", etc.
+
+## Parsing arguments after /review
+Args after \`/review\` may include depth flags AND/OR a natural-language scoping hint.
+Parse depth keywords first, treat any remaining text as a scoping hint.
+- Depth keywords: \`brief\` / \`summary\` (force Tier A) — \`deep\` / \`in depth\` (force Tier C + technical vocab).
+- Scoping hint: e.g., "saturday", "yesterday", "the climbing one", "last week's race".
+- If the hint is ambiguous (multiple recent activities match), ask the athlete to clarify before proceeding.
+
+## Selecting the session
+1. Call \`intervals_fetch_activities\` for the last 7 days, newest first.
+2. If empty: reply "No activity in the last 7 days — want me to look further back?" and stop.
+3. If newest activity is older than 7 days: reply "Your last session was X days ago — want me to review that?" and stop until the athlete confirms.
+4. Otherwise: the most recent activity (and any activities clustered with it under the sport-specific gap rule in the SOUL — 30 min for cycling, 60 min for running) form the session under review.
+5. If earlier same-day sessions exist, mention them briefly as load context — do not deep-review them.
+6. If activity \`analyzed\` is null/missing: open the review with "(analysis still in progress — using headline numbers)" and proceed with what the activity object exposes. Don't fabricate per-interval metrics that depend on full analysis.
+
+## Multi-activity sessions (1–3 activities clustered)
+A session may span 2–3 activities (e.g., a runner's warmup + intervals + cooldown FITs). Treat them as a single unit. For per-rep insight at Tier B+, fetch detail only on the activity matching the planned workout or with WORK intervals — warmup and cooldown FITs typically have no intervals worth reviewing. Never fetch detail on every FIT in the cluster.
+
+## Depth — auto-scaled by activity type
+- **Tier A (~50 words)**: recovery / commute / unstructured Z2 endurance. Activity-summary fields only — call only \`intervals_fetch_activities\`. Headline numbers + form context + one-line takeaway. NO per-rep table.
+- **Tier B (~200 words)**: structured intervals (workout type matched, has WORK intervals). Call \`intervals_fetch_activity\` for \`icu_intervals\` per-rep splits. Per-rep insight in PROSE (not a table by default).
+- **Tier C (~500–600 words)**: races (\`race=true\` or \`sub_type=RACE\` — auto-upgrade) or any session with explicit \`deep\` / \`in depth\`. Call \`intervals_fetch_activity\` AND \`intervals_fetch_streams\` (limit to watts, heartrate, cadence, time, altitude). Pacing curve, fueling timeline, best-efforts, decoupling per quartile, HRR after final effort.
+
+Manual overrides:
+- \`deep\` / \`in depth\` in the message → force Tier C on any session.
+- \`brief\` / \`summary\` → force Tier A.
+
+## Vocabulary — controlled by depth flag (no memory state)
+- Default \`/review\` (any tier without explicit override) → **mixed**: plain language by default; if a technical term is genuinely the takeaway, define in parens on first use within the message.
+- \`/review brief\` → **mixed** (depth flag controls tier only, vocab stays default).
+- \`/review deep\` → **technical**: use technical terms freely, no parens-explanations. The athlete who typed "deep" is asking for the deep version.
+- Race auto-upgrade to Tier C (no explicit \`deep\`) → **mixed** (system inference, not user request — keep default vocab).
+
+## The 3-questions framework (mandatory output structure)
+Every review answers these three questions in order:
+1. **Did it go well?** (1–2 sentences — the gut check.)
+2. **What's one thing to fix or notice?** (One specific actionable item, or "nothing — this was clean".)
+3. **What does this mean for the next session?** (One recommendation.)
+Plus a 4th when concerning: **Is the bigger picture still on track?** (Form / wellness trends / streaks.)
+
+**Filter rule:** every metric mentioned must answer one of those four questions. If a metric doesn't help answer "did it go well / fix this / next session / bigger picture", it doesn't appear.
+
+## Output style
+- **Prose-only.** No tables, no metric-list dumps in the default review.
+- **Numbers on demand.** When the athlete replies "show numbers" (or similar), emit the Tier B / Tier C numeric breakdown as a compact table.
+- One Telegram message — don't split into multi-message walls.
+
+### Footer (mandatory)
+- **Tier A and Tier B**: end the review with TWO lines:
+    Reply 'show numbers' for the full breakdown.
+    For a deeper analysis, type /review deep.
+- **Tier C** (forced via \`deep\` or auto-upgrade on race): end with ONE line:
+    Reply 'show numbers' for the full breakdown.
+  (No \`/review deep\` line — the review is already deep.)
+- This footer is non-negotiable. It appears even on short Tier A reviews.
+
+## Trademark / glossary rules — non-negotiable
+NEVER use these tokens in any review output:
+- **NP** or "Normalized Power" → use "weighted avg power" or drop entirely.
+- **TSS** → use "Load".
+- **IF** → use "Intensity".
+- **CTL** → use "Fitness".
+- **ATL** → use "Fatigue".
+- **TSB** → use "Form".
+- "true FTP" → drop "true"; just say "FTP".
+
+These are Peaksware trademarks; do not surface the abbreviations in athlete-facing output.
+
+## Edge cases
+- Re-review same activity: just review again. Cost is low; the athlete may want a different angle.
+- No \`paired_event_id\`: skip the plan-compliance section silently.
+- Streams call fails: degrade to Tier B (note "stream data unavailable for deep review" briefly), don't error out.
+- Streams payload is empty or missing watts/heartrate (manual entry, indoor without power, virtual ride with no recorded streams): note "stream data not available for this activity" and degrade to Tier B — do NOT invent pacing curves or best-efforts content.
+- \`intervals_fetch_activities\` returns \`{ error: ... }\`: relay the error to the athlete in plain language; do not invent a review. Translate the raw \`error.kind\` to a friendly phrase: \`Unauthorized\` → "I don't have access to your intervals.icu account", \`RateLimit\` → "intervals.icu rate-limited me — try again in a minute", \`NotFound\` → "couldn't find that activity", \`Network\` / \`Timeout\` → "couldn't reach intervals.icu", anything else → "something went wrong fetching your data". Never surface the raw \`kind\` token.`;
+
 export function buildSystemPrompt(
   persona: SportPersona,
   memory: Memory,
@@ -27,6 +113,10 @@ export function buildSystemPrompt(
   // appendCurrentTimeLine() so it stays fresh across long sessions and
   // doesn't go stale crossing local midnight. See user-time.ts.
   parts.push(`# Current Date & Time\n\nTime zone: ${tz}`);
+
+  // Output rules ride the recency slot — review block is last so its rules
+  // sit closest to the user message in the prompt.
+  parts.push(WORKOUT_REVIEW_RULES);
 
   return parts.join("\n\n---\n\n");
 }

--- a/packages/core/src/channels/telegram.ts
+++ b/packages/core/src/channels/telegram.ts
@@ -32,6 +32,7 @@ const WELCOME_MESSAGE =
   "/plan — Generate a training plan\n" +
   "/workout — Get today's workout\n" +
   "/status — Check current fitness, fatigue, and form\n" +
+  "/review — Review your last session\n" +
   "/sync — Push plan to intervals.icu calendar\n" +
   "/version — Show current version\n" +
   "/whatsnew — See what changed in the latest version\n" +
@@ -114,6 +115,26 @@ export function createTelegramBot(token: string, agent: CoachAgent, binary: Bina
         await ctx.reply(`Rate limited — please try again in ${formatRateLimitWait(err)}.`);
       } else {
         await ctx.reply("Sorry, something went wrong. Please try again.");
+      }
+    }
+  });
+
+  bot.command("review", async (ctx) => {
+    const args = (ctx.match ?? "").trim();
+    await ctx.reply(
+      args ? `Reviewing your last session (${args})...` : "Reviewing your last session...",
+    );
+    const chatId = `telegram:${ctx.chat.id}`;
+    try {
+      const message = args ? `/review ${args}` : "/review";
+      const response = await agent.chat(chatId, message);
+      await sendLongMessage(ctx, response);
+    } catch (err) {
+      console.error("Error in /review:", err);
+      if (isRateLimitError(err)) {
+        await ctx.reply(`Rate limited — please try again in ${formatRateLimitWait(err)}.`);
+      } else {
+        await ctx.reply("Sorry, something went wrong reviewing your session. Please try again.");
       }
     }
   });

--- a/packages/core/tests/intervals-tools-fetch-activity.test.ts
+++ b/packages/core/tests/intervals-tools-fetch-activity.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import type { IntervalsClient } from "intervals-icu-api";
+import { createPureCoreIntervalsTools } from "../src/agent/intervals-tools.js";
+
+type AnyResult = { ok: true; value: unknown } | { ok: false; error: { kind: string } };
+
+function makeFakeIntervals(getResult: AnyResult, capture: { calledWith?: string }): IntervalsClient {
+  const fake = {
+    activities: {
+      get: async (activityId: string) => {
+        capture.calledWith = activityId;
+        return getResult;
+      },
+    },
+  };
+  return fake as unknown as IntervalsClient;
+}
+
+describe("intervals_fetch_activity", () => {
+  it("is exported from createPureCoreIntervalsTools", () => {
+    const fake = makeFakeIntervals({ ok: true, value: {} }, {});
+    const tools = createPureCoreIntervalsTools(fake);
+    expect(tools.intervals_fetch_activity).toBeDefined();
+  });
+
+  it("returns the activity object verbatim on success", async () => {
+    const activity = {
+      id: 12345,
+      type: "Ride",
+      icu_intervals: [{ id: 1, average_watts: 250 }],
+      analyzed: "2026-05-01T10:00:00Z",
+      paired_event_id: 5000,
+    };
+    const capture: { calledWith?: string } = {};
+    const fake = makeFakeIntervals({ ok: true, value: activity }, capture);
+    const tools = createPureCoreIntervalsTools(fake);
+    const tool = tools.intervals_fetch_activity!;
+
+    const result = await tool.execute!({ activityId: 12345 }, {} as never);
+
+    expect(result).toEqual(activity);
+    expect(capture.calledWith).toBe("12345");
+  });
+
+  it("returns { error: kind } on SDK error", async () => {
+    const capture: { calledWith?: string } = {};
+    const fake = makeFakeIntervals({ ok: false, error: { kind: "not_found" } }, capture);
+    const tools = createPureCoreIntervalsTools(fake);
+    const tool = tools.intervals_fetch_activity!;
+
+    const result = await tool.execute!({ activityId: 99999 }, {} as never);
+
+    expect(result).toEqual({ error: "not_found" });
+  });
+
+  it("description references Tier B+ and key fields", () => {
+    const fake = makeFakeIntervals({ ok: true, value: {} }, {});
+    const tools = createPureCoreIntervalsTools(fake);
+    const description = (tools.intervals_fetch_activity as { description: string }).description;
+    expect(description).toMatch(/Tier B\+/);
+    expect(description).toMatch(/icu_intervals/);
+    expect(description).toMatch(/analyzed/);
+    expect(description).toMatch(/paired_event_id/);
+  });
+});

--- a/packages/core/tests/intervals-tools-fetch-streams.test.ts
+++ b/packages/core/tests/intervals-tools-fetch-streams.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import type { IntervalsClient } from "intervals-icu-api";
+import { createPureCoreIntervalsTools } from "../src/agent/intervals-tools.js";
+
+type AnyResult = { ok: true; value: unknown } | { ok: false; error: { kind: string } };
+
+function makeFakeIntervals(
+  result: AnyResult,
+  capture: { activityId?: string; types?: string[] },
+): IntervalsClient {
+  const fake = {
+    activities: {
+      getStreams: async (activityId: string, types: string[]) => {
+        capture.activityId = activityId;
+        capture.types = types;
+        return result;
+      },
+    },
+  };
+  return fake as unknown as IntervalsClient;
+}
+
+describe("intervals_fetch_streams", () => {
+  it("is exported from createPureCoreIntervalsTools", () => {
+    const fake = makeFakeIntervals({ ok: true, value: {} }, {});
+    const tools = createPureCoreIntervalsTools(fake);
+    expect(tools.intervals_fetch_streams).toBeDefined();
+  });
+
+  it("calls SDK with default five types when types omitted", async () => {
+    const capture: { activityId?: string; types?: string[] } = {};
+    const fake = makeFakeIntervals({ ok: true, value: { watts: [] } }, capture);
+    const tools = createPureCoreIntervalsTools(fake);
+    const tool = tools.intervals_fetch_streams!;
+
+    await tool.execute!({ activityId: 12345 }, {} as never);
+
+    expect(capture.activityId).toBe("12345");
+    expect(capture.types).toEqual(["watts", "heartrate", "cadence", "time", "altitude"]);
+  });
+
+  it("forwards explicit types verbatim to SDK", async () => {
+    const capture: { activityId?: string; types?: string[] } = {};
+    const fake = makeFakeIntervals({ ok: true, value: {} }, capture);
+    const tools = createPureCoreIntervalsTools(fake);
+    const tool = tools.intervals_fetch_streams!;
+
+    await tool.execute!({ activityId: 999, types: ["watts", "heartrate"] }, {} as never);
+
+    expect(capture.types).toEqual(["watts", "heartrate"]);
+  });
+
+  it("treats empty types array the same as omitted (uses defaults)", async () => {
+    const capture: { activityId?: string; types?: string[] } = {};
+    const fake = makeFakeIntervals({ ok: true, value: {} }, capture);
+    const tools = createPureCoreIntervalsTools(fake);
+    const tool = tools.intervals_fetch_streams!;
+
+    await tool.execute!({ activityId: 1, types: [] }, {} as never);
+
+    expect(capture.types).toEqual(["watts", "heartrate", "cadence", "time", "altitude"]);
+  });
+
+  it("returns the stream payload verbatim on success", async () => {
+    const streams = { watts: [100, 200, 300], time: [0, 1, 2] };
+    const fake = makeFakeIntervals({ ok: true, value: streams }, {});
+    const tools = createPureCoreIntervalsTools(fake);
+    const tool = tools.intervals_fetch_streams!;
+
+    const result = await tool.execute!({ activityId: 1 }, {} as never);
+
+    expect(result).toEqual(streams);
+  });
+
+  it("returns { error: kind } on SDK error", async () => {
+    const fake = makeFakeIntervals({ ok: false, error: { kind: "not_found" } }, {});
+    const tools = createPureCoreIntervalsTools(fake);
+    const tool = tools.intervals_fetch_streams!;
+
+    const result = await tool.execute!({ activityId: 1 }, {} as never);
+
+    expect(result).toEqual({ error: "not_found" });
+  });
+
+  it("description carries the cost-warning language", () => {
+    const fake = makeFakeIntervals({ ok: true, value: {} }, {});
+    const tools = createPureCoreIntervalsTools(fake);
+    const description = (tools.intervals_fetch_streams as { description: string }).description;
+    expect(description).toContain("EXPENSIVE");
+    expect(description).toContain("ONLY call for Tier C");
+  });
+});

--- a/packages/core/tests/system-prompt-review-rules.test.ts
+++ b/packages/core/tests/system-prompt-review-rules.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import { buildSystemPrompt } from "../src/agent/system-prompt.js";
+import type { SportPersona } from "../src/sport.js";
+import type { Memory } from "../src/memory/store.js";
+
+function makeFakeMemory(context = ""): Memory {
+  return {
+    getContext: () => context,
+  } as unknown as Memory;
+}
+
+const persona: SportPersona = {
+  soul: "# Cycling Coach\n\nYou are a cycling coach.",
+  skills: { example: "# Example Skill\n\nSome cycling content." },
+};
+
+describe("buildSystemPrompt — WORKOUT_REVIEW_RULES placement", () => {
+  it("places WORKOUT_REVIEW_RULES as the LAST section", () => {
+    const prompt = buildSystemPrompt(persona, makeFakeMemory("athlete context"));
+    const sections = prompt.split("\n\n---\n\n");
+    const last = sections[sections.length - 1];
+    expect(last).toMatch(/^# Workout Review/);
+    expect(last).toContain("3-questions framework");
+  });
+
+  it("places WORKOUT_REVIEW_RULES last even when context is empty", () => {
+    const prompt = buildSystemPrompt(persona, makeFakeMemory(""));
+    const sections = prompt.split("\n\n---\n\n");
+    const last = sections[sections.length - 1];
+    expect(last).toMatch(/^# Workout Review/);
+  });
+
+  it("places WORKOUT_REVIEW_RULES last when skills are empty", () => {
+    const prompt = buildSystemPrompt({ ...persona, skills: {} }, makeFakeMemory("ctx"));
+    const sections = prompt.split("\n\n---\n\n");
+    expect(sections[sections.length - 1]).toMatch(/^# Workout Review/);
+  });
+
+  it("preserves [soul, skills, context, time, review-rules] order", () => {
+    const prompt = buildSystemPrompt(persona, makeFakeMemory("ctx"));
+    const sections = prompt.split("\n\n---\n\n");
+    expect(sections[0]).toContain("Cycling Coach");
+    expect(sections[1]).toMatch(/^# Domain Knowledge/);
+    expect(sections[2]).toMatch(/^# Athlete Context/);
+    expect(sections[3]).toMatch(/^# Current Date & Time/);
+    expect(sections[4]).toMatch(/^# Workout Review/);
+    expect(sections.length).toBe(5);
+  });
+});
+
+describe("WORKOUT_REVIEW_RULES content", () => {
+  const prompt = buildSystemPrompt(persona, makeFakeMemory(""));
+
+  it("contains the 3-questions framework heading", () => {
+    expect(prompt).toContain("3-questions framework");
+  });
+
+  it("contains the show-numbers footer line", () => {
+    expect(prompt).toContain("Reply 'show numbers' for the full breakdown.");
+  });
+
+  it("contains the deeper-analysis footer line", () => {
+    expect(prompt).toContain("For a deeper analysis, type /review deep.");
+  });
+
+  it("lists all six trademark forbids", () => {
+    for (const tok of ["NP", "TSS", "IF", "CTL", "ATL", "TSB"]) {
+      expect(prompt).toContain(`**${tok}**`);
+    }
+  });
+
+  it("forbids 'true FTP'", () => {
+    expect(prompt).toContain('"true FTP"');
+  });
+
+  it("declares Tier A/B/C word budgets", () => {
+    expect(prompt).toContain("~50 words");
+    expect(prompt).toContain("~200 words");
+    expect(prompt).toContain("~500–600 words");
+  });
+
+  it("declares depth-flag → vocabulary mapping (mixed default, technical for deep)", () => {
+    expect(prompt).toMatch(/Default `\/review`.*\*\*mixed\*\*/);
+    expect(prompt).toMatch(/`\/review deep`.*\*\*technical\*\*/);
+  });
+
+  it("contains the multi-activity coordination clause", () => {
+    expect(prompt).toContain("only on the activity matching the planned workout");
+  });
+
+  it("contains the natural-language scoping clause", () => {
+    expect(prompt).toMatch(/remaining text as a scoping hint/);
+  });
+});

--- a/packages/sport-cycling/SOUL.md
+++ b/packages/sport-cycling/SOUL.md
@@ -40,3 +40,48 @@ Never pad a short answer with background the athlete didn't ask for. If they ask
 - Stay patient and professional — even if the athlete ignores your advice repeatedly
 - Every response must provide substantive coaching value — no emoji-only or single-word answers
 - If you've recommended something (like an FTP test) and the athlete hasn't done it, mention it once at the end — don't repeat it every response
+
+## Review
+
+When the athlete asks for a review (`/review`, "review my last ride", etc.), follow the
+Core "Workout Review" prompt block. The cycling-specific rules:
+
+### Activity grouping
+- A *training session* is one activity OR multiple activities clustered together. For
+  cycling, cluster activities whose start times are within **30 minutes** of each other —
+  cyclists rarely sub-divide a session into multiple FIT files. Use activity names and
+  sub_type (WARMUP/COOLDOWN) as additional grouping signal. If grouping is ambiguous,
+  say so explicitly and offer to regroup.
+- Earlier same-day sessions are mentioned briefly as load context, not deep-reviewed.
+
+### Cycling vocabulary
+The athlete may use any of these technical cycling terms in conversation; use them in
+review output when the depth flag is `deep` (technical vocabulary):
+*decoupling, VI (variability index), weighted-power, sweet spot, sweet-spot decoupling,
+W' balance, polarization, lactate threshold, ramp test, FRC, anaerobic capacity,
+torque-effectiveness, pedal-smoothness*. For default and `brief` (mixed vocabulary),
+keep these terms but define on first use within the message ("decoupling — how much
+your heart rate climbed relative to power").
+
+### Cycling-specific tier guidance
+- **Tier A** examples: recovery spin <60 min Z1, commute, unstructured Z2 endurance under
+  90 min.
+- **Tier B** examples: sweet-spot 3×15, threshold 2×20, VO2 5×4, over-unders, structured
+  base intervals.
+- **Tier C** examples: races (criterium, time-trial, gran fondo, century), key benchmark
+  rides, anything the athlete tagged "key session".
+
+### Cycling trademark cleanup (review output only)
+NEVER use these tokens in any cycling review output. Use the substitute on the right.
+
+| Forbidden | Use instead |
+|---|---|
+| TSS | Load |
+| NP / Normalized Power | weighted avg power (or drop) |
+| IF | Intensity |
+| CTL | Fitness |
+| ATL | Fatigue |
+| TSB | Form |
+| "true FTP" | "FTP" (drop "true") |
+
+These are Peaksware trademarks. Surface the substitute, not the abbreviation.

--- a/packages/sport-cycling/skills/review.md
+++ b/packages/sport-cycling/skills/review.md
@@ -1,0 +1,97 @@
+# Workout Review
+
+Cycling-specific analysis content for workout reviews. The structural rules
+(3-questions, prose voice, depth tiers, footer) live in Core's review-rules block;
+the trademark forbids and gap rule live in SOUL.md. This file teaches the analysis.
+
+## Decoupling — what the number means
+
+Decoupling is the percentage drift between heart rate and power across the session.
+Lower is better; positive = HR drift up at same power = aerobic fatigue.
+
+| Decoupling | Read as |
+|---|---|
+| < 2% | Excellent aerobic durability. Athlete is well-fueled and within their aerobic capacity. |
+| 2–5% | Normal for endurance work. Mild aerobic stress. |
+| 5–10% | Moderate fade. Worth flagging — fueling, sleep, intensity, or duration is at the edge. |
+| > 10% | Significant fade. Question 2 of the 3-questions framework gets attention here. |
+
+These bands assume Z2/endurance work. Threshold and above will drift more by design,
+so 5–8% on a sweet-spot or threshold session is the expected physiological response,
+not fade — interpret accordingly.
+
+Per-quartile decoupling (Tier C only) reveals fade *pattern*: stable across quartiles =
+strong day; rising in Q3/Q4 = late fade (typically fueling or pacing); rising linearly
+from Q1 = was hot from the start.
+
+## Best-efforts duration ladder
+
+For Tier C reviews of races and structured Tier B reviews when the athlete
+crushed a peak effort, identify standard best-efforts durations:
+
+| Duration | What it tells you |
+|---|---|
+| 1 min | Anaerobic / VO2max ceiling. Top 1-min in 6 weeks = peaking. |
+| 5 min | VO2max-aligned. Tracks fitness build directly. |
+| 20 min | Threshold proxy. Best 20-min of the year usually within FTP test territory. |
+| 60 min | True endurance threshold. Longer races (~1 h time trial) live here. |
+
+Compare to memory's stored FTP if available. The 20-min FTP test convention already
+applies a 0.95 multiplier, so a best 20-min around 105% FTP is consistent with current
+FTP — not under-estimated. A best 20-min above ~108% FTP is the real signal that FTP
+may be under-estimated. A best 20-min of ~88% FTP on a hard ride suggests fatigue or
+that the day didn't elicit a max effort.
+
+## Cycling fade patterns
+
+Common signal patterns to recognize in races and long Tier B sessions:
+
+- **Even effort**: power and HR both stable across quartiles. The athlete paced well.
+  Praise it.
+- **Early-hot**: Q1 power 5–10% above Q4 average; HR rises proportionally. Athlete went
+  out too hard. Question 2: "next race, hold first 15 min at target".
+- **Late-fade**: Q1–Q3 power steady, Q4 drops 8–15% with HR holding or rising. Aerobic
+  exhaustion. Often fueling or duration. Question 3: "fuel earlier, finish stronger".
+- **Surge-recover**: power oscillates ±15% in long bursts (group rides, hilly terrain).
+  Not a fade — an intentional or terrain-driven pattern. Don't flag as a problem unless
+  it impacted the main set.
+- **HR-led decoupling**: power steady, HR rising 8–10 bpm across the ride. Heat,
+  dehydration, or under-recovery. Tier B note: "consider hydration / sleep before
+  next hard day".
+
+## Indoor vs outdoor signals
+
+Reviewing differs by venue:
+
+- **Indoor**: HR runs ~3–5 bpm higher at the same power even with a fan. Coasting is
+  near-zero (no terrain), so VI is naturally close to 1.0. Sweat rate is higher → flag
+  hydration if duration > 60 min.
+- **Outdoor**: VI > 1.05 is normal due to terrain and traffic. Don't penalize the
+  athlete for high VI on outdoor rides; only flag if a structured interval session
+  shows VI > 1.10 (suggesting they didn't hold steady on what should have been steady).
+
+## Show numbers follow-up format
+
+When the athlete replies "show numbers" (or "give me the table", "the data", "details",
+etc.):
+- After Tier A → emit the Tier B numeric breakdown.
+- After Tier B / C → emit a compact markdown table.
+
+Tier B / C "show numbers" table shape:
+
+| Metric | Value |
+|---|---|
+| Duration (moving) | mm:ss |
+| Distance | km |
+| Load | int |
+| Intensity | 0.NN |
+| Avg power / weighted avg power | W |
+| Avg HR / max HR | bpm |
+| Avg cadence | rpm |
+| Fitness / Fatigue / Form | n / n / n |
+
+If `icu_intervals` present, follow the headline table with a per-rep table:
+
+| Rep | Target W | Actual avg W | Avg HR | Time |
+
+Keep it compact. The athlete asked for numbers — no prose around the table.


### PR DESCRIPTION
## Summary

- Adds `/review` Telegram command (and CLI natural-language path) that returns a coaching review of the athlete's most recent training session, with depth auto-scaling by activity type — Tier A ~50 words for recovery rides, Tier B ~200 for structured intervals, Tier C ~500–600 for races (or any session with `/review deep`).
- Two new Pure-Core intervals.icu tools — `intervals_fetch_activity` (per-rep `icu_intervals` for Tier B+) and `intervals_fetch_streams` (raw watts/HR/cadence/time/altitude for Tier C). Streams description carries an explicit cost guard since the prompt is the only enforcement against misroutes.
- New `WORKOUT_REVIEW_RULES` block at the END of the system prompt with the 3-questions framework, depth tiers, depth-flag → vocab mapping, multi-activity coordination rule, mandatory show-numbers + `/review deep` footer, and the trademark cleanup (no NP/CTL/ATL/IF/TSS/TSB/"true FTP" — uses Load/Intensity/Fitness/Fatigue/Form/weighted avg power instead).
- Cycling-specific guidance: `sport-cycling/SOUL.md` gets a `## Review` section (30-min cluster gap, jargon list, substitution table); `sport-cycling/skills/review.md` is new (decoupling thresholds, best-efforts duration ladder, fade-pattern catalog, indoor-vs-outdoor signals, show-numbers table format).
- Welcome message lists `/review` between `/status` and `/sync`.
- Includes a `User-facing:` changeset so `/whatsnew` renders the change for athletes.

## Test plan

- [x] `pnpm --filter @enduragent/core test` — 290 pass / 1 skipped (existing) — adds 24 new tests across `intervals-tools-fetch-activity`, `intervals-tools-fetch-streams`, `system-prompt-review-rules`.
- [x] `pnpm --filter @enduragent/sport-cycling test` — 82 pass.
- [x] `pnpm --filter @enduragent/core check` and `pnpm --filter @enduragent/sport-cycling check` — clean.
- [x] `pnpm -r build` — all 7 packages build cleanly with the new skill inlined into the cycling-coach bundle.
- [ ] Runtime smoke: send `/review` in Telegram against a real intervals.icu account; verify two-line footer on Tier A/B and one-line on Tier C; verify `/review deep` uses technical vocabulary; verify trademark abbreviations never appear (case-sensitive regex sweep).
- [ ] Multi-FIT cluster session reviewed as one session, not three.
- [ ] `analyzed=null` activity surfaces "(analysis still in progress)" note instead of fabricating per-rep metrics.
- [ ] 8+ days old → confirms before reviewing.
- [ ] "show numbers" follow-up after Tier A produces the Tier B numeric table.
- [ ] Endurance scenarios (`.tests/scenarios/30msg-review-feature.ts`) — local-only, gitignored — run with `npx tsx --env-file=.env .tests/scenarios/30msg-review-feature.ts`.