### PR TITLE
feat(telegram): per-user-id allowlist with one-message claim flow

### DIFF
--- a/.changeset/telegram-allowlist.md
+++ b/.changeset/telegram-allowlist.md
@@ -1,0 +1,17 @@
+---
+"cycling-coach": patch
+"@enduragent/core": patch
+---
+
+User-facing: Tightened access — the bot now only responds to authorized Telegram senders. Existing operators: send `/start` once after upgrading, the bot prompts to claim ownership.
+
+Adds a per-user-ID allowlist to the Telegram channel. New behavior:
+
+- **Auth middleware** registered before any handler (factory-wrap pattern) filters every inbound message on `from.id`. Strangers in pairing mode get a one-time challenge with their own user-ID and instructions; allowlist mode silently drops.
+- **Migration:** no auto-claim. Default policy is `pairing` whenever `~/.cycling-coach/allowed-senders.json` is missing. On interactive startup (TTY), the bot prompts to claim. Headless paths fall back to pairing-mode + CLI claim.
+- **CLI:** `cycling-coach add-sender <id>`, `remove-sender <id>`, `list-senders`. PID lockfile serializes mutations.
+- **Persistence:** atomic `.tmp` + rename, mode `0o600`, dir mode tightened to `0o700`. Schema-validated on load with explicit fallback to `pairing` on malformed input. Transformer-pattern `saveAllowedSenders` ensures the read-modify-write cycle is atomic per process (closes a TOCTOU class).
+- **`notifyUpdate`** now filters its broadcast list against `allowFrom`, so pre-allowlist strangers' chat-ids stop receiving update pings.
+- **No proactive Telegram broadcast** under any branch (operator constraint). Migration diagnostics go to stderr only.
+
+Env vars: `CYCLING_COACH_OPERATOR_ID` (single ID, file precedence beats env), `CYCLING_COACH_DM_POLICY=open` (debug escape), `CYCLING_COACH_SETUP_CAPTURE_TIMEOUT_MS` (default 60s), `CYCLING_COACH_CAPTURE_CONFIRM_TIMEOUT_MS` (default 5min).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,12 @@ docs(plan): add battle plan for rate limit fix
 - Lowercase after the colon
 - One logical change per commit when practical
 
+## Telegram allowlist file
+
+The bot enforces a per-user-ID allowlist via `~/.cycling-coach/allowed-senders.json` (mode `0600`). Schema and validation live in `packages/core/src/channels/allowed-senders.ts`. CLI mutations (`add-sender`, `remove-sender`) acquire a PID lockfile at `~/.cycling-coach/.allowed-senders.lock` so concurrent invocations serialize cleanly. **Do not edit `allowed-senders.json` by hand while the bot is running** — the bot re-reads it on every inbound message, but a hand-edit during a write will lose updates. Use the CLI subcommands instead.
+
+`dmPolicy: "open"` is rejected when read from the file (defense in depth — only settable via the `CYCLING_COACH_DM_POLICY=open` env var, intended for debugging). The setup wizard never offers it.
+
 ## Versioning
 
 Calendar-based for npm-published binaries: `YYYY.M.D` (e.g., `2026.4.16` — first release of the day; `2026.4.16-1` — patch later the same day; `2026.4.17` — next day). Private workspace packages (`@enduragent/*`, stub binaries) use SemVer and are not published. See ADR-0007 and ADR-0009.

--- a/README.md
+++ b/README.md
@@ -107,6 +107,43 @@ Note: `npm run dev` runs TypeScript directly (via tsx). `npm run build` produces
 
 Free-form chat works too — ask anything about training, report an injury, request plan adjustments.
 
+## Privacy
+
+Cycling Coach restricts Telegram interactions to a configured allowlist of user IDs. Only senders in `~/.cycling-coach/allowed-senders.json` (or set via the `CYCLING_COACH_OPERATOR_ID` env var, single ID) can interact with the bot. Random Telegram users who discover your bot's username are dropped at the middleware layer.
+
+### First-time setup
+
+The setup wizard prompts you to send `/start` from your Telegram account; the wizard captures your user ID and writes the allowlist file automatically — you never type your numeric ID.
+
+### Migration for existing installs
+
+When you run `cycling-coach` on an upgraded install with no allowlist yet:
+
+- **Interactive shell (TTY available):** the bot prompts you to send `/start` from your Telegram app. It captures your user ID, asks you to confirm, and writes the allowlist. Total friction: one Telegram message + one keypress. **You never type your user ID anywhere.**
+- **Non-interactive (Docker, systemd, fly.io, `cycling-coach &`):** the bot starts in pairing mode. DM it once — the reply contains your Telegram user ID and the exact CLI command to run. Copy-paste from the reply: `cycling-coach add-sender <id>`. Total friction: about 30 seconds.
+
+### Adding friends
+
+`cycling-coach add-sender <userId>`
+
+A friend's user ID appears in the bot's pairing-challenge reply when they first try to message it.
+
+### Removing senders
+
+`cycling-coach remove-sender <userId>`
+
+If you remove the only allowed sender, the bot drops back into pairing mode automatically.
+
+### Listing the allowlist
+
+`cycling-coach list-senders`
+
+Prints the current policy, allowed senders with their `addedAt` timestamps, and any session files left on disk from prior conversations (useful for identifying who's been DM-ing the bot).
+
+### Stranger sessions left over from before the upgrade
+
+Pre-upgrade, the bot accepted DMs from anyone who knew its username. Their session files (`~/.cycling-coach/sessions/telegram:<chat-id>.jsonl`) remain on disk after migration — they're no longer queryable through the bot, but they still exist. Manual deletion is safe (`rm` of any chat-ID that isn't yours). A `cycling-coach prune-sessions` CLI is tracked as a follow-up.
+
 ## What the agent can do
 
 ### Cycling logic (runs locally, no API calls)

--- a/packages/core/src/channels/allowed-senders.ts
+++ b/packages/core/src/channels/allowed-senders.ts
@@ -1,0 +1,421 @@
+import {
+  chmodSync,
+  closeSync,
+  createReadStream,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+  writeSync,
+} from "node:fs";
+import { constants as fsConstants } from "node:fs";
+import { join } from "node:path";
+import { z } from "zod";
+import { enumerateTelegramSessions } from "./telegram-sessions.js";
+
+export type DmPolicy = "pairing" | "allowlist" | "open";
+
+export const ALLOWED_SENDERS_FILE = "allowed-senders.json";
+
+export interface AllowedSenders {
+  version: 1;
+  dmPolicy: DmPolicy;
+  allowFrom: string[];
+  primaryOperator: string | null;
+  capturedAt: string | null;
+  addedAt: Record<string, string>;
+  [unknownKey: string]: unknown;
+}
+
+export function defaultPairingState(): AllowedSenders {
+  return {
+    version: 1,
+    dmPolicy: "pairing",
+    allowFrom: [],
+    primaryOperator: null,
+    capturedAt: null,
+    addedAt: {},
+  };
+}
+
+/**
+ * Telegram user-ids: positive integer with at least 2 digits, no leading zero.
+ * Telegram never assigns 0 or single-digit IDs; the regex rejects malformed
+ * env-var fragments and bare 0 while staying length-agnostic on the high end.
+ */
+export const SENDER_ID_RE = /^[1-9]\d+$/;
+const OPERATOR_ID_ENV = "CYCLING_COACH_OPERATOR_ID";
+const DM_POLICY_ENV = "CYCLING_COACH_DM_POLICY";
+
+function loadFromEnv(): AllowedSenders | null {
+  const raw = process.env[OPERATOR_ID_ENV];
+  if (raw === undefined || raw === "") return null;
+  if (!SENDER_ID_RE.test(raw)) {
+    console.error(
+      `[security] ${OPERATOR_ID_ENV}="${raw}" is not a valid Telegram user-id (must be a positive integer ≥ 2 digits, no leading zero). Falling through to default.`,
+    );
+    return null;
+  }
+  return {
+    version: 1,
+    dmPolicy: "allowlist",
+    allowFrom: [raw],
+    primaryOperator: raw,
+    capturedAt: null,
+    addedAt: {},
+  };
+}
+
+// Zod accepts file shapes that originated from older revisions or hand-edits:
+// strings/numbers in `allowFrom` are coerced to strings, invalid items are
+// dropped (with a stderr warning per item), unknown top-level fields pass
+// through for forward-compat. `dmPolicy: "open"` is rejected here on purpose —
+// it can only be set via the CYCLING_COACH_DM_POLICY env var.
+const senderIdSchema = z
+  .union([z.string(), z.number()])
+  .transform((v) => String(v))
+  .refine((s) => SENDER_ID_RE.test(s));
+
+function validateSchema(parsed: unknown, path: string): AllowedSenders | null {
+  const schema = z
+    .object({
+      version: z.literal(1),
+      dmPolicy: z.union([z.literal("pairing"), z.literal("allowlist")]),
+      allowFrom: z.array(z.unknown()).transform((arr) => {
+        const out: string[] = [];
+        for (const item of arr) {
+          const r = senderIdSchema.safeParse(item);
+          if (r.success) out.push(r.data);
+          else console.error(
+            `[security] ${path}: dropped invalid allowFrom entry ${JSON.stringify(item)}.`,
+          );
+        }
+        return out;
+      }),
+      primaryOperator: z.union([z.string().regex(SENDER_ID_RE), z.null()]).optional(),
+      capturedAt: z.string().nullable().optional(),
+      addedAt: z.record(z.string(), z.string()).optional(),
+    })
+    .passthrough();
+
+  const result = schema.safeParse(parsed);
+  if (!result.success) {
+    const issue = result.error.issues[0];
+    const field = issue.path.join(".") || "root";
+    console.error(
+      `[security] ${path}: invalid ${field}; falling back to default-pairing.`,
+    );
+    return null;
+  }
+  if (result.data.allowFrom.length === 0 && result.data.dmPolicy === "allowlist") {
+    console.error(
+      `[security] ${path}: allowlist mode with no valid allowFrom entries; falling back to default-pairing.`,
+    );
+    return null;
+  }
+  return result.data as AllowedSenders;
+}
+
+function loadFromFile(dataDir: string): AllowedSenders | null {
+  const path = join(dataDir, ALLOWED_SENDERS_FILE);
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf-8");
+  } catch {
+    return null;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    console.error(
+      `[security] ${path} is not valid JSON (${err instanceof Error ? err.message : String(err)}); falling back to default-pairing.`,
+    );
+    return null;
+  }
+  return validateSchema(parsed, path);
+}
+
+// Cache parsed AllowedSenders by file mtime. The auth middleware calls
+// loadAllowedSenders on every inbound message; caching avoids re-running JSON
+// parse + zod validation when the file hasn't changed. saveAllowedSenders
+// invalidates this cache after committing a write. Note: cache is keyed by
+// dataDir so a single process serving multiple homes still works.
+//
+// HFS+ has 1-second mtime granularity — two writes within the same second
+// won't invalidate. macOS APFS, Linux ext4, and NTFS are sub-millisecond.
+// Telegram caps inbound to 30 msg/sec/bot so this is a non-issue in practice.
+const fileCache = new Map<string, { mtimeMs: number; value: AllowedSenders }>();
+
+function loadFromFileCached(dataDir: string): AllowedSenders | null {
+  const path = join(dataDir, ALLOWED_SENDERS_FILE);
+  let mtimeMs: number;
+  try {
+    mtimeMs = statSync(path).mtimeMs;
+  } catch {
+    fileCache.delete(dataDir);
+    return null;
+  }
+  const cached = fileCache.get(dataDir);
+  if (cached && cached.mtimeMs === mtimeMs) return cached.value;
+  const fresh = loadFromFile(dataDir);
+  if (fresh) fileCache.set(dataDir, { mtimeMs, value: fresh });
+  else fileCache.delete(dataDir);
+  return fresh;
+}
+
+export type AllowedSendersSource = "file" | "env" | "default-pairing";
+
+export interface AllowedSendersLoad {
+  state: AllowedSenders;
+  source: AllowedSendersSource;
+}
+
+export function loadAllowedSendersWithSource(dataDir: string): AllowedSendersLoad {
+  const fromFile = loadFromFileCached(dataDir);
+  const baseAndSource: AllowedSendersLoad = fromFile
+    ? { state: fromFile, source: "file" }
+    : (() => {
+        const fromEnv = loadFromEnv();
+        return fromEnv
+          ? { state: fromEnv, source: "env" }
+          : { state: defaultPairingState(), source: "default-pairing" };
+      })();
+
+  // CYCLING_COACH_DM_POLICY=open is env-var-only (cannot be set via file). The
+  // override preserves base.allowFrom so notifyUpdate's filter still has the
+  // operator's friends list to broadcast to. Source flips to "env" since the
+  // override is what determined the effective policy.
+  if (process.env[DM_POLICY_ENV] === "open") {
+    return { state: { ...baseAndSource.state, dmPolicy: "open" }, source: "env" };
+  }
+  return baseAndSource;
+}
+
+export function loadAllowedSenders(dataDir: string): AllowedSenders {
+  return loadAllowedSendersWithSource(dataDir).state;
+}
+
+// ─── PID lockfile ────────────────────────────────────────────────────────────
+// Serialize cross-process writes to allowed-senders.json. Lockfile lives at
+// <dataDir>/.allowed-senders.lock; content is "<pid>\n<isoTimestamp>". Stale
+// locks (dead PID OR timestamp older than 60s) are reclaimed automatically.
+
+const LOCK_FILE = ".allowed-senders.lock";
+const LOCK_FRESH_WINDOW_MS = 60_000;
+
+export class LockfileContentionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "LockfileContentionError";
+  }
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    // ESRCH = no such process; EPERM = exists but we lack signal perms (still alive).
+    if ((err as NodeJS.ErrnoException).code === "EPERM") return true;
+    return false;
+  }
+}
+
+function lockfileIsStale(lockPath: string): boolean {
+  let raw: string;
+  try {
+    raw = readFileSync(lockPath, "utf-8");
+  } catch {
+    return true;
+  }
+  const [pidStr, ts] = raw.split("\n");
+  const pid = Number(pidStr);
+  if (!Number.isFinite(pid) || pid <= 0) return true;
+  const tsMs = ts ? Date.parse(ts) : NaN;
+  if (!Number.isFinite(tsMs)) return true;
+  if (Date.now() - tsMs > LOCK_FRESH_WINDOW_MS) return true;
+  if (!isProcessAlive(pid)) return true;
+  return false;
+}
+
+function acquireLockfile(dataDir: string): string {
+  const lockPath = join(dataDir, LOCK_FILE);
+  const content = `${process.pid}\n${new Date().toISOString()}`;
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      const fd = openSync(lockPath, fsConstants.O_CREAT | fsConstants.O_EXCL | fsConstants.O_WRONLY, 0o600);
+      try {
+        writeSync(fd, content);
+      } finally {
+        closeSync(fd);
+      }
+      return lockPath;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
+      if (lockfileIsStale(lockPath)) {
+        try { unlinkSync(lockPath); } catch { /* race: another process cleaned it */ }
+        continue;
+      }
+      throw new LockfileContentionError(
+        `Another ${process.argv[1] ?? "cycling-coach"} process holds ${lockPath}; try again in a moment.`,
+      );
+    }
+  }
+  throw new LockfileContentionError(`Failed to acquire ${lockPath} after stale-reclaim retry.`);
+}
+
+function releaseLockfile(lockPath: string): void {
+  try {
+    unlinkSync(lockPath);
+  } catch {
+    // Already gone or never created — nothing to do.
+  }
+}
+
+function ensureDataDirSecure(dataDir: string): void {
+  // mkdirSync with `mode` is a no-op on existing dirs, so explicit chmod is the
+  // only path that tightens upgrade installs that pre-date this enforcement.
+  if (existsSync(dataDir)) {
+    const mode = statSync(dataDir).mode & 0o777;
+    if (mode !== 0o700) {
+      chmodSync(dataDir, 0o700);
+      console.error(
+        `[security] Tightened ${dataDir} permissions from 0o${mode.toString(8)} to 0o700.`,
+      );
+    }
+  } else {
+    mkdirSync(dataDir, { recursive: true, mode: 0o700 });
+  }
+}
+
+export function saveAllowedSenders(
+  dataDir: string,
+  transform: (current: AllowedSenders | null) => AllowedSenders,
+): AllowedSenders {
+  ensureDataDirSecure(dataDir);
+
+  const lockPath = acquireLockfile(dataDir);
+  try {
+    // Read inside the lock so the transformer sees the latest disk state —
+    // closes a TOCTOU class where a load-then-save outside the lock could
+    // clobber a concurrent writer's commit. Bypass the mtime cache here: the
+    // cache reflects the LAST committed write from this process, but a peer
+    // process may have written since then and we must see that.
+    const current = loadFromFile(dataDir);
+    const next = transform(current);
+
+    const path = join(dataDir, ALLOWED_SENDERS_FILE);
+    const tmp = `${path}.tmp`;
+    writeFileSync(tmp, JSON.stringify(next, null, 2), { mode: 0o600 });
+    renameSync(tmp, path);
+    // Refresh the cache with the fresh state + post-rename mtime so the next
+    // read in this process is a cache hit.
+    try {
+      fileCache.set(dataDir, { mtimeMs: statSync(path).mtimeMs, value: next });
+    } catch {
+      fileCache.delete(dataDir);
+    }
+    return next;
+  } finally {
+    releaseLockfile(lockPath);
+  }
+}
+
+function assertSenderId(id: string): void {
+  if (!SENDER_ID_RE.test(id)) {
+    throw new Error(
+      `Invalid sender id ${JSON.stringify(id)}: must be a positive integer (≥ 2 digits, no leading zero).`,
+    );
+  }
+}
+
+export function addSender(dataDir: string, senderId: string): void {
+  assertSenderId(senderId);
+  const nowIso = new Date().toISOString();
+  saveAllowedSenders(dataDir, (current) => {
+    const base = current ?? defaultPairingState();
+    if (base.allowFrom.includes(senderId)) {
+      // Idempotent — keep dmPolicy "allowlist" if it isn't already.
+      if (base.dmPolicy === "pairing") {
+        return { ...base, dmPolicy: "allowlist" };
+      }
+      return base;
+    }
+    return {
+      ...base,
+      dmPolicy: "allowlist",
+      allowFrom: [...base.allowFrom, senderId],
+      addedAt: { ...base.addedAt, [senderId]: nowIso },
+      primaryOperator: base.primaryOperator ?? senderId,
+    };
+  });
+}
+
+interface SessionCandidate {
+  chatId: string;
+  lineCount: number;
+  mtime: number;
+  lastModified: string;
+}
+
+async function countLines(path: string): Promise<number> {
+  let n = 0;
+  let lastByte = -1;
+  try {
+    for await (const buf of createReadStream(path) as AsyncIterable<Buffer>) {
+      for (let i = 0; i < buf.length; i++) {
+        if (buf[i] === 0x0a) n++;
+        lastByte = buf[i];
+      }
+    }
+  } catch {
+    return 0;
+  }
+  // Trailing content without a final newline still counts as one line.
+  if (lastByte !== -1 && lastByte !== 0x0a) n++;
+  return n;
+}
+
+export async function readKnownSessions(dataDir: string): Promise<SessionCandidate[]> {
+  const sessions = enumerateTelegramSessions(dataDir);
+  return Promise.all(
+    sessions.map(async (s) => ({
+      chatId: s.chatId,
+      lineCount: await countLines(s.path),
+      mtime: s.mtimeMs,
+      lastModified: new Date(s.mtimeMs).toISOString(),
+    })),
+  );
+}
+
+export async function listSenders(dataDir: string): Promise<{
+  senders: AllowedSenders;
+  sessionCandidates: SessionCandidate[];
+}> {
+  return {
+    senders: loadAllowedSenders(dataDir),
+    sessionCandidates: await readKnownSessions(dataDir),
+  };
+}
+
+export function removeSender(dataDir: string, senderId: string): void {
+  saveAllowedSenders(dataDir, (current) => {
+    if (!current) return defaultPairingState();
+    if (!current.allowFrom.includes(senderId)) return current;
+    const filtered = current.allowFrom.filter((id) => id !== senderId);
+    const { [senderId]: _dropped, ...remainingAddedAt } = current.addedAt;
+    return {
+      ...current,
+      allowFrom: filtered,
+      addedAt: remainingAddedAt,
+      dmPolicy: filtered.length === 0 ? "pairing" : current.dmPolicy,
+      primaryOperator:
+        current.primaryOperator === senderId ? null : current.primaryOperator,
+    };
+  });
+}

--- a/packages/core/src/channels/html-escape.ts
+++ b/packages/core/src/channels/html-escape.ts
@@ -1,0 +1,19 @@
+/**
+ * HTML escape helpers for Telegram message HTML.
+ *
+ * `escapeHtmlText` escapes only the three chars Telegram requires inside
+ * element bodies (`&<>`). Use this for `<pre>` and `<code>` block content
+ * where `"` and `'` are literal text and don't need encoding.
+ *
+ * `escapeHtmlAttr` additionally escapes `"` and `'` for defense-in-depth in
+ * attribute-like contexts (and arbitrary user-supplied strings interpolated
+ * into surrounding markup).
+ */
+
+export function escapeHtmlText(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+export function escapeHtmlAttr(s: string): string {
+  return escapeHtmlText(s).replace(/"/g, "&quot;").replace(/'/g, "&#39;");
+}

--- a/packages/core/src/channels/operator-capture.ts
+++ b/packages/core/src/channels/operator-capture.ts
@@ -1,0 +1,149 @@
+import { Bot } from "grammy";
+import type { BinaryConfig } from "../binary.js";
+import {
+  defaultPairingState,
+  saveAllowedSenders,
+  LockfileContentionError,
+  SENDER_ID_RE,
+} from "./allowed-senders.js";
+
+export type CaptureStatus =
+  | "captured"
+  | "declined"
+  | "timeout"
+  | "getme-failed"
+  | "lockfile-contention"
+  | "write-failed";
+
+export interface CaptureResult {
+  status: CaptureStatus;
+  capturedId?: string;
+  botUsername?: string;
+  reason?: string;
+}
+
+export interface ConfirmInfo {
+  capturedId: string;
+  senderUsername: string | undefined;
+  senderFirstName: string | undefined;
+  botUsername: string;
+  binaryName: string;
+}
+
+export interface CaptureOpts {
+  botToken: string;
+  binary: BinaryConfig;
+  dataDir: string;
+  timeoutMs?: number;
+  confirm: (info: ConfirmInfo) => Promise<boolean>;
+  log?: (line: string) => void;
+}
+
+interface CapturedFrom {
+  id: number;
+  username?: string;
+  first_name?: string;
+}
+
+export async function captureAndPersistOperator(opts: CaptureOpts): Promise<CaptureResult> {
+  const log = opts.log ?? ((s: string) => console.log(s));
+  const timeoutMs = opts.timeoutMs ?? 60_000;
+  const bot = new Bot(opts.botToken);
+
+  // Validate the token via getMe BEFORE opening any capture window — typo'd
+  // tokens fail fast with a clear error instead of silently 401-looping.
+  let me: { is_bot: boolean; username?: string };
+  try {
+    me = await bot.api.getMe();
+  } catch (err) {
+    return {
+      status: "getme-failed",
+      reason: err instanceof Error ? err.message : String(err),
+    };
+  }
+  if (!me.is_bot || !me.username) {
+    return {
+      status: "getme-failed",
+      reason: "Bot token does not resolve to a valid Telegram bot.",
+    };
+  }
+  const botUsername = me.username;
+  log(`Capturing for @${botUsername}. Send /start now.`);
+
+  let capturedFrom: CapturedFrom | undefined;
+
+  bot.use(async (ctx) => {
+    if (ctx.chat?.type !== "private") return;
+    if (typeof ctx.from?.id !== "number") return;
+    const id = String(ctx.from.id);
+    if (!SENDER_ID_RE.test(id)) return;
+    capturedFrom = {
+      id: ctx.from.id,
+      username: ctx.from.username,
+      first_name: ctx.from.first_name,
+    };
+    // Stop polling so bot.start() resolves and the race completes.
+    void bot.stop();
+  });
+
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+  await Promise.race([
+    bot.start(),
+    new Promise<void>((res) => {
+      timeoutHandle = setTimeout(() => {
+        void bot.stop();
+        res();
+      }, timeoutMs);
+    }),
+  ]);
+  if (timeoutHandle) clearTimeout(timeoutHandle);
+
+  if (!capturedFrom) return { status: "timeout", botUsername };
+
+  const capturedId = String(capturedFrom.id);
+
+  const ok = await opts.confirm({
+    capturedId,
+    senderUsername: capturedFrom.username,
+    senderFirstName: capturedFrom.first_name,
+    botUsername,
+    binaryName: opts.binary.binaryName,
+  });
+  if (!ok) return { status: "declined", botUsername, capturedId };
+
+  const nowIso = new Date().toISOString();
+  try {
+    saveAllowedSenders(opts.dataDir, (current) => {
+      const base = current ?? defaultPairingState();
+      const merged = base.allowFrom.includes(capturedId)
+        ? base.allowFrom
+        : [...base.allowFrom, capturedId];
+      return {
+        ...base,
+        dmPolicy: "allowlist",
+        allowFrom: merged,
+        primaryOperator: capturedId,
+        addedAt: { ...base.addedAt, [capturedId]: nowIso },
+        capturedAt: nowIso,
+      };
+    });
+    return { status: "captured", capturedId, botUsername };
+  } catch (err) {
+    // Map every save error to a non-fatal CaptureResult; helper never throws,
+    // so callers can surface a warning and continue starting the bot.
+    if (err instanceof LockfileContentionError) {
+      return {
+        status: "lockfile-contention",
+        botUsername,
+        capturedId,
+        reason: err.message,
+      };
+    }
+    return {
+      status: "write-failed",
+      botUsername,
+      capturedId,
+      reason: err instanceof Error ? err.message : String(err),
+    };
+  }
+}

--- a/packages/core/src/channels/telegram-access.ts
+++ b/packages/core/src/channels/telegram-access.ts
@@ -1,0 +1,104 @@
+import type { Context, MiddlewareFn } from "grammy";
+import { loadAllowedSenders, type AllowedSenders } from "./allowed-senders.js";
+import { escapeHtmlAttr } from "./html-escape.js";
+
+export type { DmPolicy } from "./allowed-senders.js";
+
+export interface AuthDecision {
+  allow: boolean;
+  pairingChallenge?: string;
+}
+
+export function buildPairingChallenge(
+  senderId: string | number,
+  senderName: string | undefined,
+  binaryName: string,
+): string {
+  const idStr = String(senderId);
+  const safeName = senderName ? escapeHtmlAttr(senderName) : "there";
+  const safeBin = escapeHtmlAttr(binaryName);
+  // Include the literal CLI command for the operator AND the "ask the bot owner"
+  // fallback. Operators copy-paste from their own message to authorize themselves;
+  // strangers see they cannot self-authorize.
+  return [
+    `<b>This bot is private.</b>`,
+    ``,
+    `Hi ${safeName} — your Telegram user ID is <code>${escapeHtmlAttr(idStr)}</code>.`,
+    ``,
+    `<b>If you're the bot owner:</b> run`,
+    `<pre>${safeBin} add-sender ${escapeHtmlAttr(idStr)}</pre>`,
+    `from a shell on the host where the bot runs, then send your message again.`,
+    ``,
+    `Otherwise: ask the bot owner to authorize your user ID.`,
+  ].join("\n");
+}
+
+export function evaluateAccess(ctx: Context, allowed: AllowedSenders): AuthDecision {
+  if (ctx.chat?.type !== "private") return { allow: false };
+  const fromId = ctx.from?.id;
+  if (fromId === undefined) return { allow: false };
+  if (typeof fromId !== "number") return { allow: false };
+
+  const senderId = String(fromId);
+  if (allowed.allowFrom.includes(senderId)) return { allow: true };
+  if (allowed.dmPolicy === "open") return { allow: true };
+
+  // Sender not allowlisted. Pairing mode → return challenge; allowlist → silent drop.
+  if (allowed.dmPolicy === "pairing") {
+    // Challenge body is constructed by the caller (createAuthMiddleware) so it can
+    // pass through binaryName / senderName / HTML escaping.
+    return { allow: false, pairingChallenge: senderId };
+  }
+  return { allow: false };
+}
+
+export interface CreateAuthMiddlewareOpts {
+  dataDir: string;
+  binaryName: string;
+  challengeRateLimit: Map<string, number>;
+  challengeMinIntervalMs: number;
+}
+
+const RATE_LIMIT_MAX_ENTRIES = 1000;
+
+function recordChallenge(map: Map<string, number>, senderId: string, now: number): void {
+  if (map.has(senderId)) map.delete(senderId); // bump to MRU position
+  map.set(senderId, now);
+  while (map.size > RATE_LIMIT_MAX_ENTRIES) {
+    const oldestKey = map.keys().next().value;
+    if (oldestKey === undefined) break;
+    map.delete(oldestKey);
+  }
+}
+
+export function createAuthMiddleware(opts: CreateAuthMiddlewareOpts): MiddlewareFn<Context> {
+  return async (ctx, next) => {
+    try {
+      const allowed = loadAllowedSenders(opts.dataDir);
+      const decision = evaluateAccess(ctx, allowed);
+      if (decision.allow) {
+        await next();
+        return;
+      }
+      // Drop. Optionally reply with pairing-challenge (rate-limited per-sender).
+      if (decision.pairingChallenge) {
+        const senderId = decision.pairingChallenge;
+        const now = Date.now();
+        const last = opts.challengeRateLimit.get(senderId) ?? 0;
+        if (now - last < opts.challengeMinIntervalMs) return;
+        recordChallenge(opts.challengeRateLimit, senderId, now);
+        const html = buildPairingChallenge(
+          senderId,
+          ctx.from?.first_name,
+          opts.binaryName,
+        );
+        await ctx.reply(html, { parse_mode: "HTML" });
+      }
+    } catch (err) {
+      // Fail closed: log to stderr, drop the update without calling next().
+      console.error(
+        `[security] middleware error: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  };
+}

--- a/packages/core/src/channels/telegram-sessions.ts
+++ b/packages/core/src/channels/telegram-sessions.ts
@@ -1,0 +1,39 @@
+import { readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * On-disk Telegram session metadata, used by both the access-control surface
+ * (notifyUpdate broadcast filter, list-senders CLI) and the updater
+ * (getKnownTelegramChatIds). One walker so the filename convention
+ * (`telegram:<chatId>.jsonl`) lives in a single place.
+ */
+export interface TelegramSessionFile {
+  chatId: string;
+  path: string;
+  mtimeMs: number;
+}
+
+const PREFIX = "telegram:";
+const SUFFIX = ".jsonl";
+
+export function enumerateTelegramSessions(dataDir: string): TelegramSessionFile[] {
+  const sessionsDir = join(dataDir, "sessions");
+  let entries: string[];
+  try {
+    entries = readdirSync(sessionsDir);
+  } catch {
+    return [];
+  }
+  const out: TelegramSessionFile[] = [];
+  for (const name of entries) {
+    if (!name.startsWith(PREFIX) || !name.endsWith(SUFFIX)) continue;
+    const chatId = name.slice(PREFIX.length, -SUFFIX.length);
+    const path = join(sessionsDir, name);
+    try {
+      out.push({ chatId, path, mtimeMs: statSync(path).mtimeMs });
+    } catch {
+      // File disappeared between readdir and stat — skip.
+    }
+  }
+  return out;
+}

--- a/packages/core/src/channels/telegram.ts
+++ b/packages/core/src/channels/telegram.ts
@@ -11,6 +11,9 @@ import {
   setLastNotifiedVersion,
 } from "../updater.js";
 import { buildWhatsNewMessage } from "../release-notes.js";
+import { createAuthMiddleware } from "./telegram-access.js";
+import { loadAllowedSenders, loadAllowedSendersWithSource } from "./allowed-senders.js";
+import { escapeHtmlText } from "./html-escape.js";
 
 function formatRateLimitWait(err: unknown): string {
   const ms = extractRetryAfterMs(err);
@@ -39,8 +42,52 @@ const WELCOME_MESSAGE =
   "/update — Check for and install updates\n\n" +
   "Or just chat with me about your training!";
 
-export function createTelegramBot(token: string, agent: CoachAgent, binary: BinaryConfig): Bot {
-  const bot = new Bot(token);
+// Module-private factory: every Bot in this module is constructed here, with
+// the auth middleware registered FIRST. Future maintainers cannot add a handler
+// ahead of auth without modifying this function — and reviewers scrutinize
+// changes here because this file holds the security model.
+function createSecuredBot(opts: {
+  token: string;
+  binary: BinaryConfig;
+  dataDir: string;
+}): Bot {
+  const bot = new Bot(opts.token);
+
+  // Per-sender pairing-challenge rate-limit map (process-lifetime; LRU-bounded).
+  const challengeRateLimit = new Map<string, number>();
+  bot.use(
+    createAuthMiddleware({
+      dataDir: opts.dataDir,
+      binaryName: opts.binary.binaryName,
+      challengeRateLimit,
+      challengeMinIntervalMs: 60_000,
+    }),
+  );
+
+  return bot;
+}
+
+function logSecurityStartup(dataDir: string, binaryName: string): void {
+  const { state, source } = loadAllowedSendersWithSource(dataDir);
+  const primary = state.primaryOperator ?? "none";
+  console.error(
+    `[security] Telegram allowlist: ${state.dmPolicy} mode (${state.allowFrom.length} allowed senders, primary: ${primary}). Source: ${source}.`,
+  );
+  if (state.dmPolicy === "pairing" && state.allowFrom.length === 0) {
+    console.error(
+      `[security] No allowed senders configured. DM the bot to receive your user-ID, then run \`${binaryName} add-sender <id>\` to authorize yourself.`,
+    );
+  }
+}
+
+export function createTelegramBot(
+  token: string,
+  agent: CoachAgent,
+  binary: BinaryConfig,
+  dataDir: string,
+): Bot {
+  logSecurityStartup(dataDir, binary.binaryName);
+  const bot = createSecuredBot({ token, binary, dataDir });
   const greeted = new Set<number>();
 
   // ── Commands ────────────────────────────────────────────────────────────
@@ -298,10 +345,6 @@ function extractTables(md: string): { text: string; tables: string[] } {
   return { text: out.join("\n"), tables };
 }
 
-function escapeHtml(s: string): string {
-  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-}
-
 function renderTableAsPre(header: string[], rows: string[][]): string {
   const cols = Math.max(header.length, ...rows.map((r) => r.length));
   const widths: number[] = [];
@@ -312,7 +355,7 @@ function renderTableAsPre(header: string[], rows: string[][]): string {
   }
   const fmt = (r: string[]) =>
     Array.from({ length: cols }, (_, c) => (r[c] ?? "").padEnd(widths[c])).join("  ").trimEnd();
-  const text = [fmt(header), ...rows.map(fmt)].map(escapeHtml).join("\n");
+  const text = [fmt(header), ...rows.map(fmt)].map(escapeHtmlText).join("\n");
   return `<pre>${text}</pre>`;
 }
 
@@ -443,7 +486,14 @@ export async function notifyUpdate(bot: Bot, dataDir: string, binary: BinaryConf
 
     if (getLastNotifiedVersion(dataDir) === info.latest) return;
 
-    const chatIds = getKnownTelegramChatIds(dataDir);
+    // Filter the broadcast list against the current allowlist. Pre-update
+    // strangers' chat-ids may still be in getKnownTelegramChatIds (their session
+    // files persist on disk) but must NOT receive update notifications.
+    const allowed = loadAllowedSenders(dataDir);
+    const allowSet = new Set(allowed.allowFrom);
+    const knownChats = getKnownTelegramChatIds(dataDir);
+    const chatIds =
+      allowed.dmPolicy === "open" ? knownChats : knownChats.filter((id) => allowSet.has(id));
     const message = `Update available: ${info.current} → ${info.latest}\nSend /whatsnew to see what changed, /update to install.`;
 
     for (const chatId of chatIds) {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -94,7 +94,7 @@ function env(key: string): string | undefined {
   return process.env[key];
 }
 
-function envInt(key: string): number | undefined {
+export function envInt(key: string): number | undefined {
   const v = process.env[key];
   if (v === undefined) return undefined;
   const n = parseInt(v, 10);

--- a/packages/core/src/run-binary.ts
+++ b/packages/core/src/run-binary.ts
@@ -1,7 +1,15 @@
 import { parseArgs } from "node:util";
+import { createInterface as createReadlineInterface } from "node:readline";
 import type { Sport } from "./sport.js";
 import type { BinaryConfig } from "./binary.js";
 import type { Memory } from "./memory/store.js";
+import { CONFIG_DIR, envInt } from "./config.js";
+import {
+  addSender,
+  removeSender,
+  listSenders,
+  loadAllowedSenders,
+} from "./channels/allowed-senders.js";
 
 export interface RunBinaryHooks {
   /** Called once per process at startup, after Memory exists, before any chat handler is reachable. */
@@ -12,15 +20,18 @@ function usage(binary: BinaryConfig): string {
   return `Usage: ${binary.binaryName} [command]
 
 Commands:
-  setup    Interactive wizard to create the config file
-  version  Show current version
-  (none)   Start the coaching agent (Telegram or CLI mode)
+  setup                     Interactive wizard to create the config file
+  version                   Show current version
+  add-sender <userId>       Authorize a Telegram user-id to interact with the bot
+  remove-sender <userId>    Revoke a previously-authorized Telegram user-id
+  list-senders              Show current allowlist + known session candidates
+  (none)                    Start the coaching agent (Telegram or CLI mode)
 
 Options:
-  --help   Show this help message`;
+  --help                    Show this help message`;
 }
 
-function parseCommand(binary: BinaryConfig): string | null {
+function parseCommand(binary: BinaryConfig): { command: string | null; positionals: string[] } {
   const { positionals, values } = parseArgs({
     allowPositionals: true,
     options: { help: { type: "boolean" } },
@@ -30,7 +41,171 @@ function parseCommand(binary: BinaryConfig): string | null {
     console.log(usage(binary));
     process.exit(0);
   }
-  return positionals[0] ?? null;
+  return { command: positionals[0] ?? null, positionals };
+}
+
+// Readline-based confirmation for startup capture: renders a multi-line prompt
+// to make the bot username visually prominent, parses with decline-on-ambiguous
+// semantics, declines cleanly on SIGINT, and times out after
+// CYCLING_COACH_CAPTURE_CONFIRM_TIMEOUT_MS (default 5 min).
+
+interface MakeReadlineConfirmOpts {
+  timeoutMs: number;
+  /** Inject for tests. Defaults to node:readline createInterface. */
+  createInterface?: (opts: {
+    input: NodeJS.ReadableStream;
+    output: NodeJS.WritableStream;
+  }) => {
+    question(prompt: string, cb: (answer: string) => void): void;
+    on(event: "SIGINT", cb: () => void): unknown;
+    close(): void;
+  };
+  /** Inject for tests. */
+  log?: (line: string) => void;
+}
+
+export function _parseConfirmAnswer(input: string): boolean {
+  const trimmed = input.trim().toLowerCase();
+  if (trimmed === "" || trimmed === "y" || trimmed === "yes") return true;
+  // Anything outside {y, yes, Enter, n, no} → decline-on-ambiguous (no re-prompt).
+  return false;
+}
+
+export function makeReadlineConfirm(
+  opts: MakeReadlineConfirmOpts,
+): (info: {
+  capturedId: string;
+  senderUsername: string | undefined;
+  senderFirstName: string | undefined;
+  botUsername: string;
+  binaryName: string;
+}) => Promise<boolean> {
+  const log = opts.log ?? ((s: string) => console.log(s));
+  const create = opts.createInterface ?? createReadlineInterface;
+
+  return async (info) => {
+    log("");
+    log("==========================================================");
+    log(`  Captured operator ID for @${info.botUsername}`);
+    log("==========================================================");
+    log(`  User ID:      ${info.capturedId}`);
+    log(`  Telegram:     @${info.senderUsername ?? "—"}`);
+    log(`  Display name: ${info.senderFirstName ?? "—"}`);
+    log("==========================================================");
+    log("");
+
+    const rl = create({ input: process.stdin, output: process.stdout });
+
+    return new Promise<boolean>((resolve) => {
+      let settled = false;
+      const finish = (value: boolean) => {
+        if (settled) return;
+        settled = true;
+        try {
+          rl.close();
+        } catch {
+          /* ignore */
+        }
+        resolve(value);
+      };
+
+      const timer = setTimeout(() => finish(false), opts.timeoutMs);
+
+      rl.on("SIGINT", () => {
+        clearTimeout(timer);
+        finish(false);
+      });
+
+      rl.question("Save this as the primary operator? [Y/n]: ", (answer: string) => {
+        clearTimeout(timer);
+        finish(_parseConfirmAnswer(answer));
+      });
+    });
+  };
+}
+
+async function runStartupCapture(
+  botToken: string,
+  binary: BinaryConfig,
+  dataDir: string,
+): Promise<void> {
+  console.log(
+    `\n${binary.displayName} has no allowed senders configured.\n` +
+      `Send /start to your bot from Telegram within 60 seconds to claim ownership.\n` +
+      `(Press Ctrl+C to skip — you can run \`${binary.binaryName} add-sender <id>\` later.)\n`,
+  );
+  const { captureAndPersistOperator } = await import("./channels/operator-capture.js");
+  const captureTimeoutMs = envInt("CYCLING_COACH_SETUP_CAPTURE_TIMEOUT_MS") ?? 60_000;
+  const confirmTimeoutMs = envInt("CYCLING_COACH_CAPTURE_CONFIRM_TIMEOUT_MS") ?? 300_000;
+  const result = await captureAndPersistOperator({
+    botToken,
+    binary,
+    dataDir,
+    timeoutMs: captureTimeoutMs,
+    confirm: makeReadlineConfirm({ timeoutMs: confirmTimeoutMs }),
+  });
+  if (result.status === "captured") {
+    console.log(`Operator registered (id: ${result.capturedId}). Starting bot...`);
+  } else {
+    console.log(
+      `Operator not captured (${result.status}). Bot will start in pairing mode — DM it to receive your user-ID, then run \`${binary.binaryName} add-sender <id>\`.`,
+    );
+  }
+}
+
+const MUTATORS: Record<
+  "add-sender" | "remove-sender",
+  { fn: (dir: string, id: string) => void; verb: string }
+> = {
+  "add-sender": { fn: addSender, verb: "Added" },
+  "remove-sender": { fn: removeSender, verb: "Removed" },
+};
+
+async function runAllowlistCommand(
+  command: "add-sender" | "remove-sender" | "list-senders",
+  positionals: string[],
+  binary: BinaryConfig,
+): Promise<void> {
+  const reportError = (err: unknown): never => {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`Error: ${msg}`);
+    return process.exit(1);
+  };
+
+  if (command === "add-sender" || command === "remove-sender") {
+    const { fn, verb } = MUTATORS[command];
+    const id = positionals[1];
+    if (!id) {
+      console.error(`Usage: ${binary.binaryName} ${command} <userId>`);
+      process.exit(1);
+    }
+    try {
+      fn(CONFIG_DIR, id);
+    } catch (err) {
+      reportError(err);
+    }
+    console.log(`${verb} sender ${id}.`);
+    process.exit(0);
+  }
+
+  let result: Awaited<ReturnType<typeof listSenders>>;
+  try {
+    result = await listSenders(CONFIG_DIR);
+  } catch (err) {
+    return reportError(err);
+  }
+  console.log(`Policy: ${result.senders.dmPolicy}`);
+  console.log(`Primary operator: ${result.senders.primaryOperator ?? "—"}`);
+  console.log(`Allowed senders (${result.senders.allowFrom.length}):`);
+  for (const id of result.senders.allowFrom) {
+    const added = result.senders.addedAt[id];
+    console.log(`  ${id}${added ? `  added ${added}` : ""}`);
+  }
+  console.log(`Session candidates (${result.sessionCandidates.length}):`);
+  for (const c of result.sessionCandidates) {
+    console.log(`  ${c.chatId}  ${c.lineCount} lines  last modified ${c.lastModified}`);
+  }
+  process.exit(0);
 }
 
 export async function runStartupHook(
@@ -52,7 +227,7 @@ export async function runBinary(
   binary: BinaryConfig,
   hooks: RunBinaryHooks = {},
 ): Promise<void> {
-  const command = parseCommand(binary);
+  const { command, positionals } = parseCommand(binary);
 
   if (command === "setup") {
     const { runSetup } = await import("./setup.js");
@@ -65,6 +240,11 @@ export async function runBinary(
   if (command === "version") {
     const { getCurrentVersion } = await import("./updater.js");
     console.log(`${binary.binaryName} v${getCurrentVersion(binary.binaryName)}`);
+    return;
+  }
+
+  if (command === "add-sender" || command === "remove-sender" || command === "list-senders") {
+    await runAllowlistCommand(command, positionals, binary);
     return;
   }
 
@@ -101,8 +281,22 @@ export async function runBinary(
   await runStartupHook(agent.getMemory(), hooks.onStartup);
 
   if (config.telegram.botToken) {
+    // Interactive startup capture: when no allowlist is set up yet AND we have
+    // a TTY AND a token, run the same one-message claim flow the setup wizard
+    // uses. Non-TTY paths (Docker, systemd, fly.io) skip the prompt and fall
+    // back to pairing-mode + pairing-challenge CLI.
+    const allowed = loadAllowedSenders(config.dataDir);
+    const needsCapture =
+      allowed.dmPolicy === "pairing" &&
+      allowed.allowFrom.length === 0 &&
+      Boolean(config.telegram.botToken) &&
+      process.stdin.isTTY === true;
+    if (needsCapture) {
+      await runStartupCapture(config.telegram.botToken, binary, config.dataDir);
+    }
+
     const { createTelegramBot, notifyUpdate } = await import("./channels/telegram.js");
-    const bot = createTelegramBot(config.telegram.botToken, agent, binary);
+    const bot = createTelegramBot(config.telegram.botToken, agent, binary, config.dataDir);
     console.log(
       `${binary.displayName} (Telegram mode) is running. Open Telegram and message your bot — Ctrl+C to stop.`,
     );

--- a/packages/core/src/setup.ts
+++ b/packages/core/src/setup.ts
@@ -3,7 +3,9 @@ import { spawn } from "node:child_process";
 import { existsSync, mkdirSync, writeFileSync, readFileSync, unlinkSync } from "node:fs";
 import { stringify as toYaml } from "yaml";
 import type { BinaryConfig } from "./binary.js";
-import { CONFIG_DIR, CONFIG_FILE, readConfigYaml } from "./config.js";
+import { CONFIG_DIR, CONFIG_FILE, envInt, readConfigYaml } from "./config.js";
+import { captureAndPersistOperator } from "./channels/operator-capture.js";
+import { loadAllowedSenders } from "./channels/allowed-senders.js";
 import { runCodexLogin } from "./auth/openai-codex-login.js";
 import { loadProfile, saveProfile, type OAuthCredential } from "./auth/profiles.js";
 import { isSecretRef, type SecretRef } from "./secrets/types.js";
@@ -468,7 +470,89 @@ async function _runWizardCore(ctx: WizardCtx, binary: BinaryConfig): Promise<voi
     }
   }
 
+  // Operator capture runs AFTER config.yaml is committed: cancelling at the
+  // confirm-write prompt above leaves no orphan allowed-senders.json. Only fires
+  // for plain-string tokens — SecretRef tokens (1Password / keychain) defer to
+  // the CLI `add-sender` path. Capture is opportunistic; any failure logs and
+  // continues without aborting the wizard.
+  const tgToken = (merged.telegram as { bot_token?: unknown } | undefined)?.bot_token;
+  if (typeof tgToken === "string" && tgToken.length > 0) {
+    await runOperatorCaptureStep(tgToken, binary, ctx);
+  }
+
   outro(`Config written to ${CONFIG_FILE}\n  Run \`${binary.binaryName}\` to start.`);
+}
+
+async function runOperatorCaptureStep(
+  botToken: string,
+  binary: BinaryConfig,
+  ctx: WizardCtx,
+): Promise<void> {
+  const existing = loadAllowedSenders(CONFIG_DIR);
+  const hasAllowlist = existing.allowFrom.length > 0;
+  if (hasAllowlist) {
+    const reCapture = await confirm({
+      message: `Operator already configured (id: ${existing.primaryOperator ?? "—"}; allowFrom has ${existing.allowFrom.length} entr${existing.allowFrom.length === 1 ? "y" : "ies"}). Re-capture? This preserves all existing entries.`,
+      initialValue: false,
+    });
+    handleCancel(reCapture, ctx, binary);
+    if (!reCapture) {
+      log.info("Skipping operator capture; existing allowlist preserved.");
+      return;
+    }
+  }
+
+  log.info(
+    `Setup will register your Telegram account as the primary operator. Send /start to your bot from your Telegram app within 60 seconds.`,
+  );
+  const timeoutMs = envInt("CYCLING_COACH_SETUP_CAPTURE_TIMEOUT_MS") ?? 60_000;
+  const result = await captureAndPersistOperator({
+    botToken,
+    binary,
+    dataDir: CONFIG_DIR,
+    timeoutMs,
+    confirm: async (info) => {
+      const ok = await confirm({
+        message:
+          `Captured operator id ${info.capturedId} (Telegram: @${info.senderUsername ?? "—"}, name: ${info.senderFirstName ?? "—"}) for bot @${info.botUsername}. Save?`,
+        initialValue: true,
+      });
+      handleCancel(ok, ctx, binary);
+      return Boolean(ok);
+    },
+    log: (line) => log.info(line),
+  });
+
+  switch (result.status) {
+    case "captured":
+      log.success(`Operator registered (id: ${result.capturedId}).`);
+      return;
+    case "declined":
+      log.warn(
+        `Capture discarded. Run \`${binary.binaryName} add-sender <id>\` later to authorize yourself.`,
+      );
+      return;
+    case "timeout":
+      log.warn(
+        `No /start received within the capture window. Run \`${binary.binaryName} add-sender <id>\` once you know your Telegram user-id (DM the bot to receive it).`,
+      );
+      return;
+    case "getme-failed":
+      log.warn(
+        `Bot token did not resolve to a valid Telegram bot (${result.reason ?? "unknown error"}). Skipping capture; re-run \`${binary.binaryName} setup\` once the token is fixed.`,
+      );
+      return;
+    case "lockfile-contention":
+      log.warn(
+        `Allowlist lockfile is held by another process. Run \`${binary.binaryName} add-sender <id>\` once it releases.`,
+      );
+      return;
+    case "write-failed":
+      log.warn(
+        `Failed to persist allowlist (${result.reason ?? "unknown error"}). Run \`${binary.binaryName} add-sender <id>\` once the underlying issue is fixed.`,
+      );
+      return;
+  }
 }
 
 function isNonEmptySecret(value: unknown): boolean {

--- a/packages/core/src/updater.ts
+++ b/packages/core/src/updater.ts
@@ -1,7 +1,8 @@
-import { readFileSync, readdirSync, writeFileSync, mkdirSync } from "node:fs";
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { execSync } from "node:child_process";
 import { createRequire } from "node:module";
 import { join } from "node:path";
+import { enumerateTelegramSessions } from "./channels/telegram-sessions.js";
 
 export interface UpdateInfo {
   current: string;
@@ -105,14 +106,7 @@ export function selfUpdate(binaryName: string): void {
 }
 
 export function getKnownTelegramChatIds(dataDir: string): string[] {
-  const sessionsDir = join(dataDir, "sessions");
-  try {
-    return readdirSync(sessionsDir)
-      .filter((f) => f.startsWith("telegram:") && f.endsWith(".jsonl"))
-      .map((f) => f.replace("telegram:", "").replace(".jsonl", ""));
-  } catch {
-    return [];
-  }
+  return enumerateTelegramSessions(dataDir).map((s) => s.chatId);
 }
 
 const NOTIFIED_VERSION_FILE = "last-notified-version";

--- a/packages/core/tests/allowed-senders.test.ts
+++ b/packages/core/tests/allowed-senders.test.ts
@@ -1,0 +1,543 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  loadAllowedSenders,
+  saveAllowedSenders,
+  defaultPairingState,
+  addSender,
+  removeSender,
+  listSenders,
+  readKnownSessions,
+  type AllowedSenders,
+} from "../src/channels/allowed-senders.js";
+
+let dataDir: string;
+const ENV_KEYS = ["CYCLING_COACH_OPERATOR_ID"];
+let savedEnv: Record<string, string | undefined>;
+
+beforeEach(() => {
+  dataDir = mkdtempSync(join(tmpdir(), "cc-allowlist-"));
+  savedEnv = {};
+  for (const k of ENV_KEYS) {
+    savedEnv[k] = process.env[k];
+    delete process.env[k];
+  }
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (savedEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = savedEnv[k];
+  }
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+describe("loadAllowedSenders — defaults", () => {
+  it("returns default-pairing state when no file and no env-var (fresh install)", () => {
+    const result = loadAllowedSenders(dataDir);
+    expect(result).toEqual(defaultPairingState());
+    expect(result.dmPolicy).toBe("pairing");
+    expect(result.allowFrom).toEqual([]);
+    expect(result.primaryOperator).toBeNull();
+    expect(result.version).toBe(1);
+    expect(result.capturedAt).toBeNull();
+    expect(result.addedAt).toEqual({});
+  });
+});
+
+describe("loadAllowedSenders — CYCLING_COACH_OPERATOR_ID env-var", () => {
+  it("CYCLING_COACH_OPERATOR_ID=12345 → allowlist mode with single operator", () => {
+    process.env.CYCLING_COACH_OPERATOR_ID = "12345";
+    const result = loadAllowedSenders(dataDir);
+    expect(result.dmPolicy).toBe("allowlist");
+    expect(result.allowFrom).toEqual(["12345"]);
+    expect(result.primaryOperator).toBe("12345");
+  });
+
+  it("=0 (leading zero) → rejected, falls through to default + log", () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    process.env.CYCLING_COACH_OPERATOR_ID = "0";
+    const result = loadAllowedSenders(dataDir);
+    expect(result).toEqual(defaultPairingState());
+    expect(errSpy).toHaveBeenCalledWith(expect.stringContaining("[security]"));
+    errSpy.mockRestore();
+  });
+
+  it("=abc (non-numeric) → rejected, falls through to default", () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    process.env.CYCLING_COACH_OPERATOR_ID = "abc";
+    const result = loadAllowedSenders(dataDir);
+    expect(result).toEqual(defaultPairingState());
+    expect(errSpy).toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+
+  it("= (empty) → ignored silently, falls through to default", () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    process.env.CYCLING_COACH_OPERATOR_ID = "";
+    const result = loadAllowedSenders(dataDir);
+    expect(result).toEqual(defaultPairingState());
+    expect(errSpy).not.toHaveBeenCalled(); // empty is "unset", no warn
+    errSpy.mockRestore();
+  });
+
+  it("=1 (single digit, fails ≥2-digit rule) → rejected", () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    process.env.CYCLING_COACH_OPERATOR_ID = "1";
+    const result = loadAllowedSenders(dataDir);
+    expect(result).toEqual(defaultPairingState());
+  });
+});
+
+describe("loadAllowedSenders — file precedence", () => {
+  it("file present beats env-var (file > env > default)", () => {
+    process.env.CYCLING_COACH_OPERATOR_ID = "99999";
+    writeFileSync(
+      join(dataDir, "allowed-senders.json"),
+      JSON.stringify({
+        version: 1,
+        dmPolicy: "allowlist",
+        allowFrom: ["12345"],
+        primaryOperator: "12345",
+        capturedAt: "2026-05-09T10:00:00.000Z",
+        addedAt: { "12345": "2026-05-09T10:00:00.000Z" },
+      }),
+    );
+    const result = loadAllowedSenders(dataDir);
+    expect(result.dmPolicy).toBe("allowlist");
+    expect(result.allowFrom).toEqual(["12345"]);
+    expect(result.primaryOperator).toBe("12345");
+    expect(result.capturedAt).toBe("2026-05-09T10:00:00.000Z");
+  });
+});
+
+describe("loadAllowedSenders — schema validation", () => {
+  function writeRaw(content: string): void {
+    writeFileSync(join(dataDir, "allowed-senders.json"), content);
+  }
+
+  it("malformed JSON → default-pairing, log to stderr (does NOT throw)", () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    writeRaw("{not valid json");
+    const result = loadAllowedSenders(dataDir);
+    expect(result).toEqual(defaultPairingState());
+    expect(errSpy).toHaveBeenCalledWith(expect.stringContaining("[security]"));
+    errSpy.mockRestore();
+  });
+
+  it("future version (version: 99) → default-pairing + log", () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    writeRaw(
+      JSON.stringify({
+        version: 99,
+        dmPolicy: "allowlist",
+        allowFrom: ["12345"],
+        primaryOperator: "12345",
+      }),
+    );
+    const result = loadAllowedSenders(dataDir);
+    expect(result).toEqual(defaultPairingState());
+    expect(errSpy).toHaveBeenCalledWith(expect.stringContaining("version"));
+    errSpy.mockRestore();
+  });
+
+  it("invalid dmPolicy → default-pairing + log", () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    writeRaw(
+      JSON.stringify({
+        version: 1,
+        dmPolicy: "totally-not-a-policy",
+        allowFrom: ["12345"],
+      }),
+    );
+    const result = loadAllowedSenders(dataDir);
+    expect(result.dmPolicy).toBe("pairing");
+    expect(result.allowFrom).toEqual([]);
+    expect(errSpy).toHaveBeenCalledWith(expect.stringContaining("dmPolicy"));
+    errSpy.mockRestore();
+  });
+
+  it('S8: dmPolicy "open" from file is rejected → default-pairing (env-var-only)', () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    writeRaw(
+      JSON.stringify({
+        version: 1,
+        dmPolicy: "open",
+        allowFrom: [],
+      }),
+    );
+    const result = loadAllowedSenders(dataDir);
+    expect(result.dmPolicy).toBe("pairing");
+    expect(errSpy).toHaveBeenCalledWith(expect.stringContaining("dmPolicy"));
+    errSpy.mockRestore();
+  });
+
+  it("missing dmPolicy → default-pairing", () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    writeRaw(JSON.stringify({ version: 1, allowFrom: ["12345"] }));
+    const result = loadAllowedSenders(dataDir);
+    expect(result.dmPolicy).toBe("pairing");
+  });
+
+  it("S2: allowFrom number entries coerced to strings", () => {
+    writeRaw(
+      JSON.stringify({
+        version: 1,
+        dmPolicy: "allowlist",
+        allowFrom: [12345],
+        primaryOperator: "12345",
+      }),
+    );
+    const result = loadAllowedSenders(dataDir);
+    expect(result.allowFrom).toEqual(["12345"]);
+  });
+
+  it("S2: allowFrom not an array → fall back to pairing", () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    writeRaw(
+      JSON.stringify({
+        version: 1,
+        dmPolicy: "allowlist",
+        allowFrom: "12345",
+      }),
+    );
+    const result = loadAllowedSenders(dataDir);
+    expect(result.dmPolicy).toBe("pairing");
+    expect(result.allowFrom).toEqual([]);
+    expect(errSpy).toHaveBeenCalledWith(expect.stringContaining("allowFrom"));
+    errSpy.mockRestore();
+  });
+
+  it("S2: allowFrom invalid items filtered, valid items kept", () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    writeRaw(
+      JSON.stringify({
+        version: 1,
+        dmPolicy: "allowlist",
+        allowFrom: ["abc", "0", "12345", null, "1", "67890"],
+        primaryOperator: "12345",
+      }),
+    );
+    const result = loadAllowedSenders(dataDir);
+    expect(result.dmPolicy).toBe("allowlist");
+    expect(result.allowFrom).toEqual(["12345", "67890"]);
+    // Per-dropped-item warning expected for each of: "abc", "0", null, "1"
+    expect(errSpy.mock.calls.length).toBeGreaterThanOrEqual(4);
+    errSpy.mockRestore();
+  });
+
+  it("S2: allowFrom empty after filtering AND allowlist mode → fall back to pairing", () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    writeRaw(
+      JSON.stringify({
+        version: 1,
+        dmPolicy: "allowlist",
+        allowFrom: ["abc", "0"],
+      }),
+    );
+    const result = loadAllowedSenders(dataDir);
+    expect(result.dmPolicy).toBe("pairing");
+    expect(result.allowFrom).toEqual([]);
+  });
+
+  it("forward-compat: unknown top-level fields preserved on load", () => {
+    writeRaw(
+      JSON.stringify({
+        version: 1,
+        dmPolicy: "allowlist",
+        allowFrom: ["12345"],
+        primaryOperator: "12345",
+        capturedAt: null,
+        addedAt: {},
+        // Hypothetical future fields:
+        lastUsedAt: { "12345": "2026-05-09T10:00:00.000Z" },
+        provenance: "wizard",
+      }),
+    );
+    const result = loadAllowedSenders(dataDir);
+    expect(result.lastUsedAt).toEqual({ "12345": "2026-05-09T10:00:00.000Z" });
+    expect(result.provenance).toBe("wizard");
+  });
+});
+
+describe("saveAllowedSenders — transformer pattern, round-trip", () => {
+  it("transformer receives null on first save; resulting state is loadable", () => {
+    const seenCurrent: Array<unknown> = [];
+    const saved = saveAllowedSenders(dataDir, (current) => {
+      seenCurrent.push(current);
+      return {
+        ...defaultPairingState(),
+        dmPolicy: "allowlist",
+        allowFrom: ["12345"],
+        primaryOperator: "12345",
+        capturedAt: "2026-05-09T10:00:00.000Z",
+        addedAt: { "12345": "2026-05-09T10:00:00.000Z" },
+      };
+    });
+    expect(seenCurrent).toEqual([null]);
+    expect(saved.dmPolicy).toBe("allowlist");
+    expect(saved.allowFrom).toEqual(["12345"]);
+
+    const reloaded = loadAllowedSenders(dataDir);
+    expect(reloaded.dmPolicy).toBe("allowlist");
+    expect(reloaded.allowFrom).toEqual(["12345"]);
+    expect(reloaded.primaryOperator).toBe("12345");
+    expect(reloaded.capturedAt).toBe("2026-05-09T10:00:00.000Z");
+    expect(reloaded.addedAt).toEqual({ "12345": "2026-05-09T10:00:00.000Z" });
+  });
+
+  it("transformer receives current state on second save (read happens inside save)", () => {
+    saveAllowedSenders(dataDir, () => ({
+      ...defaultPairingState(),
+      dmPolicy: "allowlist",
+      allowFrom: ["12345"],
+      primaryOperator: "12345",
+    }));
+    const seen: Array<unknown> = [];
+    saveAllowedSenders(dataDir, (current) => {
+      seen.push(current);
+      return {
+        ...(current as AllowedSenders),
+        allowFrom: [...((current as AllowedSenders).allowFrom), "67890"],
+      };
+    });
+    expect(seen).toHaveLength(1);
+    const seenState = seen[0] as AllowedSenders;
+    expect(seenState.dmPolicy).toBe("allowlist");
+    expect(seenState.allowFrom).toEqual(["12345"]);
+    const reloaded = loadAllowedSenders(dataDir);
+    expect(reloaded.allowFrom).toEqual(["12345", "67890"]);
+  });
+
+  it("forward-compat: round-trip through saveAllowedSenders preserves unknown top-level fields", () => {
+    saveAllowedSenders(dataDir, () => ({
+      ...defaultPairingState(),
+      dmPolicy: "allowlist",
+      allowFrom: ["12345"],
+      primaryOperator: "12345",
+      lastUsedAt: { "12345": "2026-05-09T10:00:00.000Z" },
+    }) as AllowedSenders);
+    saveAllowedSenders(dataDir, (current) => ({
+      ...(current as AllowedSenders),
+      allowFrom: [...((current as AllowedSenders).allowFrom), "67890"],
+    }));
+    const reloaded = loadAllowedSenders(dataDir);
+    expect(reloaded.lastUsedAt).toEqual({ "12345": "2026-05-09T10:00:00.000Z" });
+    expect(reloaded.allowFrom).toEqual(["12345", "67890"]);
+  });
+});
+
+describe("addSender / removeSender — validation and lifecycle", () => {
+  it('addSender("abc") throws (non-numeric)', () => {
+    expect(() => addSender(dataDir, "abc")).toThrow(/positive integer/);
+  });
+
+  it('addSender("0") throws (leading-zero rejected)', () => {
+    expect(() => addSender(dataDir, "0")).toThrow(/positive integer/);
+  });
+
+  it('addSender("1") throws (single-digit rejected by ^[1-9]\\d+$)', () => {
+    expect(() => addSender(dataDir, "1")).toThrow(/positive integer/);
+  });
+
+  it('addSender("12345") then removeSender("12345") cycles dmPolicy: pairing → allowlist → pairing', () => {
+    expect(loadAllowedSenders(dataDir).dmPolicy).toBe("pairing");
+
+    addSender(dataDir, "12345");
+    const afterAdd = loadAllowedSenders(dataDir);
+    expect(afterAdd.dmPolicy).toBe("allowlist");
+    expect(afterAdd.allowFrom).toEqual(["12345"]);
+    expect(afterAdd.primaryOperator).toBe("12345");
+    expect(afterAdd.addedAt["12345"]).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+
+    removeSender(dataDir, "12345");
+    const afterRemove = loadAllowedSenders(dataDir);
+    expect(afterRemove.dmPolicy).toBe("pairing");
+    expect(afterRemove.allowFrom).toEqual([]);
+    expect(afterRemove.primaryOperator).toBeNull();
+    expect(afterRemove.addedAt["12345"]).toBeUndefined();
+  });
+
+  it("addSender is idempotent — re-adding the same id is a no-op for allowFrom", () => {
+    addSender(dataDir, "12345");
+    addSender(dataDir, "12345");
+    const result = loadAllowedSenders(dataDir);
+    expect(result.allowFrom).toEqual(["12345"]);
+  });
+
+  it("addSender preserves existing allowFrom (Set-union); does not change primaryOperator if already set", () => {
+    addSender(dataDir, "12345");
+    addSender(dataDir, "67890");
+    const result = loadAllowedSenders(dataDir);
+    expect(result.allowFrom).toEqual(["12345", "67890"]);
+    expect(result.primaryOperator).toBe("12345"); // first sender stays primary
+  });
+
+  it("removeSender on non-allowlisted id is a no-op (does not throw)", () => {
+    addSender(dataDir, "12345");
+    removeSender(dataDir, "99999");
+    expect(loadAllowedSenders(dataDir).allowFrom).toEqual(["12345"]);
+  });
+
+  it("removeSender of primaryOperator clears primaryOperator (other entries promoted to no-primary)", () => {
+    addSender(dataDir, "12345");
+    addSender(dataDir, "67890");
+    removeSender(dataDir, "12345");
+    const result = loadAllowedSenders(dataDir);
+    expect(result.allowFrom).toEqual(["67890"]);
+    expect(result.primaryOperator).toBeNull();
+  });
+});
+
+describe("saveAllowedSenders — PID lockfile", () => {
+  const lockPath = () => join(dataDir, ".allowed-senders.lock");
+
+  it("happy path: two writes in series both succeed; lockfile is cleaned between", () => {
+    addSender(dataDir, "12345");
+    expect(existsSync(lockPath())).toBe(false);
+    addSender(dataDir, "67890");
+    expect(existsSync(lockPath())).toBe(false);
+    expect(loadAllowedSenders(dataDir).allowFrom).toEqual(["12345", "67890"]);
+  });
+
+  it("contention with live PID + fresh timestamp → LockfileContentionError", async () => {
+    const { LockfileContentionError } = await import(
+      "../src/channels/allowed-senders.js"
+    );
+    // Plant a lockfile claiming THIS process owns it (this process IS alive).
+    writeFileSync(lockPath(), `${process.pid}\n${new Date().toISOString()}`);
+    expect(() => addSender(dataDir, "12345")).toThrow(LockfileContentionError);
+    // Cleanup so afterEach doesn't fail
+    rmSync(lockPath(), { force: true });
+  });
+
+  it("stale lockfile (dead PID, old timestamp) is reclaimed", () => {
+    // PID 999999 is almost certainly not alive; old timestamp regardless ensures reclaim.
+    const oldTs = new Date(Date.now() - 10 * 60 * 1000).toISOString();
+    writeFileSync(lockPath(), `999999\n${oldTs}`);
+    addSender(dataDir, "12345");
+    expect(existsSync(lockPath())).toBe(false);
+    expect(loadAllowedSenders(dataDir).allowFrom).toEqual(["12345"]);
+  });
+
+  it("malformed lockfile is treated as stale and reclaimed", () => {
+    writeFileSync(lockPath(), "this is not a valid lockfile");
+    addSender(dataDir, "12345");
+    expect(existsSync(lockPath())).toBe(false);
+  });
+
+  it("T1 (CRITICAL): concurrent addSender preserves both writes (transformer pattern)", async () => {
+    // In a single process this is serial via the sync save loop; the test guards
+    // against any future refactor that re-introduces load-then-save-outside-lock.
+    await Promise.all([
+      Promise.resolve().then(() => addSender(dataDir, "11111")),
+      Promise.resolve().then(() => addSender(dataDir, "22222")),
+    ]);
+    const result = loadAllowedSenders(dataDir);
+    expect(result.allowFrom.sort()).toEqual(["11111", "22222"]);
+  });
+
+  it("T1: corrupt file → next addSender succeeds via defaultPairingState() base", () => {
+    writeFileSync(join(dataDir, "allowed-senders.json"), "{not valid json");
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    addSender(dataDir, "12345");
+    const result = loadAllowedSenders(dataDir);
+    expect(result.allowFrom).toEqual(["12345"]);
+    expect(result.dmPolicy).toBe("allowlist");
+  });
+});
+
+describe("listSenders / readKnownSessions", () => {
+  function seedSession(chatId: string, lines: number): void {
+    const sessionsDir = join(dataDir, "sessions");
+    mkdirSync(sessionsDir, { recursive: true });
+    const file = join(sessionsDir, `telegram:${chatId}.jsonl`);
+    const content = Array.from({ length: lines })
+      .map((_, i) => JSON.stringify({ role: i % 2 === 0 ? "user" : "assistant", content: "x", ts: Date.now() }))
+      .join("\n");
+    writeFileSync(file, content);
+  }
+
+  it("readKnownSessions returns chatId/lineCount/mtime per session file", async () => {
+    seedSession("12345", 4);
+    seedSession("67890", 12);
+    const sessions = await readKnownSessions(dataDir);
+    const byId = new Map(sessions.map((s) => [s.chatId, s]));
+    expect(byId.get("12345")?.lineCount).toBe(4);
+    expect(byId.get("67890")?.lineCount).toBe(12);
+    expect(byId.get("12345")?.mtime).toBeGreaterThan(0);
+  });
+
+  it("readKnownSessions returns empty array when sessions dir does not exist", async () => {
+    expect(await readKnownSessions(dataDir)).toEqual([]);
+  });
+
+  it("listSenders returns current allowed-senders state plus session candidates", async () => {
+    addSender(dataDir, "12345");
+    seedSession("12345", 4);
+    seedSession("99999", 2);
+    const result = await listSenders(dataDir);
+    expect(result.senders.dmPolicy).toBe("allowlist");
+    expect(result.senders.allowFrom).toEqual(["12345"]);
+    expect(result.sessionCandidates.length).toBe(2);
+    const chatIds = result.sessionCandidates.map((c) => c.chatId).sort();
+    expect(chatIds).toEqual(["12345", "99999"]);
+  });
+});
+
+describe("loadAllowedSenders — mtime cache", () => {
+  it("re-uses parsed state when mtime is unchanged (cache hit)", () => {
+    addSender(dataDir, "12345");
+    // First call populates / refreshes the cache.
+    const first = loadAllowedSenders(dataDir);
+    // Spy on JSON.parse to detect cache hits.
+    const parseSpy = vi.spyOn(JSON, "parse");
+    const second = loadAllowedSenders(dataDir);
+    const third = loadAllowedSenders(dataDir);
+    expect(parseSpy).not.toHaveBeenCalled();
+    expect(second).toEqual(first);
+    expect(third).toEqual(first);
+    parseSpy.mockRestore();
+  });
+
+  it("write via saveAllowedSenders → next load reflects the change", () => {
+    addSender(dataDir, "12345");
+    expect(loadAllowedSenders(dataDir).allowFrom).toEqual(["12345"]);
+    addSender(dataDir, "67890");
+    expect(loadAllowedSenders(dataDir).allowFrom).toEqual(["12345", "67890"]);
+  });
+
+  it("file deleted out-of-band → cache cleared, default returned", () => {
+    addSender(dataDir, "12345");
+    expect(loadAllowedSenders(dataDir).dmPolicy).toBe("allowlist");
+    rmSync(join(dataDir, "allowed-senders.json"));
+    const result = loadAllowedSenders(dataDir);
+    expect(result.dmPolicy).toBe("pairing");
+    expect(result.allowFrom).toEqual([]);
+  });
+});
+
+describe("saveAllowedSenders — data-dir perms (S3)", () => {
+  it("tightens pre-existing dataDir from 0o755 to 0o700 and logs", () => {
+    chmodSync(dataDir, 0o755);
+    expect(statSync(dataDir).mode & 0o777).toBe(0o755);
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    addSender(dataDir, "12345");
+    expect(statSync(dataDir).mode & 0o777).toBe(0o700);
+    expect(errSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/\[security\].*permissions.*0o700/),
+    );
+    errSpy.mockRestore();
+  });
+});

--- a/packages/core/tests/helpers/scripted-prompts.ts
+++ b/packages/core/tests/helpers/scripted-prompts.ts
@@ -24,7 +24,7 @@ export function scriptedPrompts(answers: ScriptedAnswers) {
     intro: vi.fn(),
     outro: vi.fn(),
     cancel: vi.fn(),
-    log: { info: vi.fn(), success: vi.fn(), error: vi.fn() },
+    log: { info: vi.fn(), success: vi.fn(), error: vi.fn(), warn: vi.fn() },
     note: vi.fn(),
     isCancel: () => false,
     select: vi.fn(async () => selects[s++]),

--- a/packages/core/tests/operator-capture.test.ts
+++ b/packages/core/tests/operator-capture.test.ts
@@ -1,0 +1,368 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { cyclingBinary } from "./helpers/cycling-binary-fixture.js";
+import {
+  defaultPairingState,
+  saveAllowedSenders,
+  loadAllowedSenders,
+} from "../src/channels/allowed-senders.js";
+
+// ─── Fake grammy Bot factory ─────────────────────────────────────────────────
+// Each test sets up its desired bot behavior by pushing onto these queues.
+
+interface FakeBot {
+  api: { getMe: ReturnType<typeof vi.fn> };
+  use: ReturnType<typeof vi.fn>;
+  start: ReturnType<typeof vi.fn>;
+  stop: ReturnType<typeof vi.fn>;
+  fireUpdate: (ctx: unknown) => Promise<void>;
+}
+
+function makeFakeBot(opts: {
+  getMe: () => Promise<{ is_bot: boolean; username?: string }>;
+  /** when bot.start() is called, the test can decide to fire an update or never resolve */
+  onStart?: (bot: FakeBot) => void;
+}): FakeBot {
+  let middleware: ((ctx: unknown, next: () => Promise<void>) => Promise<void>) | undefined;
+  let stopResolver: (() => void) | undefined;
+  const bot: FakeBot = {
+    api: { getMe: vi.fn(opts.getMe) },
+    use: vi.fn((mw: typeof middleware) => {
+      middleware = mw;
+    }),
+    start: vi.fn(
+      () =>
+        new Promise<void>((res) => {
+          stopResolver = res;
+          opts.onStart?.(bot);
+        }),
+    ),
+    stop: vi.fn(async () => {
+      stopResolver?.();
+    }),
+    fireUpdate: async (ctx) => {
+      if (!middleware) throw new Error("Test bug: bot.use was never called");
+      await middleware(ctx, async () => undefined);
+    },
+  };
+  return bot;
+}
+
+let dataDir: string;
+let savedEnv: string | undefined;
+let nextBots: FakeBot[] = [];
+
+beforeEach(() => {
+  dataDir = mkdtempSync(join(tmpdir(), "cc-capture-"));
+  savedEnv = process.env.CYCLING_COACH_OPERATOR_ID;
+  delete process.env.CYCLING_COACH_OPERATOR_ID;
+  nextBots = [];
+  vi.resetModules();
+  vi.doMock("grammy", () => ({
+    Bot: function FakeBot(this: unknown, _token: string) {
+      const next = nextBots.shift();
+      if (!next) throw new Error("Test bug: no fake bot queued");
+      return next;
+    },
+  }));
+});
+
+afterEach(() => {
+  if (savedEnv === undefined) delete process.env.CYCLING_COACH_OPERATOR_ID;
+  else process.env.CYCLING_COACH_OPERATOR_ID = savedEnv;
+  rmSync(dataDir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+  vi.doUnmock("grammy");
+});
+
+async function importHelper() {
+  return (await import("../src/channels/operator-capture.js")).captureAndPersistOperator;
+}
+
+describe("captureAndPersistOperator — getMe gate", () => {
+  it("getMe rejects → status: 'getme-failed', no bot.start() invoked", async () => {
+    const bot = makeFakeBot({
+      getMe: async () => {
+        throw new Error("401 Unauthorized");
+      },
+    });
+    nextBots.push(bot);
+    const captureAndPersistOperator = await importHelper();
+    const result = await captureAndPersistOperator({
+      botToken: "FAKE",
+      binary: cyclingBinary,
+      dataDir,
+      confirm: async () => true,
+    });
+    expect(result.status).toBe("getme-failed");
+    expect(bot.start).not.toHaveBeenCalled();
+  });
+
+  it("getMe returns is_bot:false → status: 'getme-failed'", async () => {
+    const bot = makeFakeBot({
+      getMe: async () => ({ is_bot: false, username: "notabot" }),
+    });
+    nextBots.push(bot);
+    const captureAndPersistOperator = await importHelper();
+    const result = await captureAndPersistOperator({
+      botToken: "FAKE",
+      binary: cyclingBinary,
+      dataDir,
+      confirm: async () => true,
+    });
+    expect(result.status).toBe("getme-failed");
+    expect(bot.start).not.toHaveBeenCalled();
+  });
+
+  it("getMe returns empty username → status: 'getme-failed'", async () => {
+    const bot = makeFakeBot({
+      getMe: async () => ({ is_bot: true, username: "" }),
+    });
+    nextBots.push(bot);
+    const captureAndPersistOperator = await importHelper();
+    const result = await captureAndPersistOperator({
+      botToken: "FAKE",
+      binary: cyclingBinary,
+      dataDir,
+      confirm: async () => true,
+    });
+    expect(result.status).toBe("getme-failed");
+  });
+});
+
+describe("captureAndPersistOperator — capture flow", () => {
+  it("captures + confirm true → file written, status 'captured'", async () => {
+    const bot = makeFakeBot({
+      getMe: async () => ({ is_bot: true, username: "testbot" }),
+      onStart: async (b) => {
+        await b.fireUpdate({
+          chat: { type: "private", id: 12345 },
+          from: { id: 12345, username: "alice", first_name: "Alice" },
+        });
+      },
+    });
+    nextBots.push(bot);
+    const confirm = vi.fn(async () => true);
+    const captureAndPersistOperator = await importHelper();
+    const result = await captureAndPersistOperator({
+      botToken: "FAKE",
+      binary: cyclingBinary,
+      dataDir,
+      confirm,
+    });
+    expect(result.status).toBe("captured");
+    expect(result.capturedId).toBe("12345");
+    expect(result.botUsername).toBe("testbot");
+    expect(confirm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        capturedId: "12345",
+        senderUsername: "alice",
+        senderFirstName: "Alice",
+        botUsername: "testbot",
+        binaryName: "cycling-coach",
+      }),
+    );
+    expect(existsSync(join(dataDir, "allowed-senders.json"))).toBe(true);
+    const reloaded = loadAllowedSenders(dataDir);
+    expect(reloaded.dmPolicy).toBe("allowlist");
+    expect(reloaded.allowFrom).toEqual(["12345"]);
+    expect(reloaded.primaryOperator).toBe("12345");
+  });
+
+  it("captures + confirm false → status 'declined', no file written", async () => {
+    const bot = makeFakeBot({
+      getMe: async () => ({ is_bot: true, username: "testbot" }),
+      onStart: async (b) => {
+        await b.fireUpdate({
+          chat: { type: "private", id: 12345 },
+          from: { id: 12345, username: "alice", first_name: "Alice" },
+        });
+      },
+    });
+    nextBots.push(bot);
+    const captureAndPersistOperator = await importHelper();
+    const result = await captureAndPersistOperator({
+      botToken: "FAKE",
+      binary: cyclingBinary,
+      dataDir,
+      confirm: async () => false,
+    });
+    expect(result.status).toBe("declined");
+    expect(existsSync(join(dataDir, "allowed-senders.json"))).toBe(false);
+  });
+
+  it("timeout → status 'timeout', no file written", async () => {
+    const bot = makeFakeBot({
+      getMe: async () => ({ is_bot: true, username: "testbot" }),
+      // onStart absent → bot.start() never resolves; only the timer wakes it.
+    });
+    nextBots.push(bot);
+    const captureAndPersistOperator = await importHelper();
+    const result = await captureAndPersistOperator({
+      botToken: "FAKE",
+      binary: cyclingBinary,
+      dataDir,
+      timeoutMs: 50,
+      confirm: async () => true,
+    });
+    expect(result.status).toBe("timeout");
+    expect(existsSync(join(dataDir, "allowed-senders.json"))).toBe(false);
+  });
+
+  it("captured from.id failing ^[1-9]\\d+$ → 'getme-failed' (defense-in-depth)", async () => {
+    const bot = makeFakeBot({
+      getMe: async () => ({ is_bot: true, username: "testbot" }),
+      onStart: async (b) => {
+        await b.fireUpdate({
+          chat: { type: "private", id: 0 },
+          from: { id: 0, username: "x", first_name: "x" }, // id=0 violates regex
+        });
+      },
+    });
+    nextBots.push(bot);
+    const captureAndPersistOperator = await importHelper();
+    const result = await captureAndPersistOperator({
+      botToken: "FAKE",
+      binary: cyclingBinary,
+      dataDir,
+      timeoutMs: 100,
+      confirm: async () => true,
+    });
+    // Either the bad id is rejected at capture (timeout) or surfaced as getme-failed.
+    expect(["getme-failed", "timeout"]).toContain(result.status);
+    expect(existsSync(join(dataDir, "allowed-senders.json"))).toBe(false);
+  });
+
+  it("non-private chat ctx is ignored during capture window", async () => {
+    const bot = makeFakeBot({
+      getMe: async () => ({ is_bot: true, username: "testbot" }),
+      onStart: async (b) => {
+        // Group-chat update fires but capture should ignore it; capture window
+        // then expires.
+        await b.fireUpdate({
+          chat: { type: "group", id: -1234 },
+          from: { id: 12345, username: "alice", first_name: "Alice" },
+        });
+      },
+    });
+    nextBots.push(bot);
+    const captureAndPersistOperator = await importHelper();
+    const result = await captureAndPersistOperator({
+      botToken: "FAKE",
+      binary: cyclingBinary,
+      dataDir,
+      timeoutMs: 50,
+      confirm: async () => true,
+    });
+    expect(result.status).toBe("timeout");
+  });
+});
+
+describe("captureAndPersistOperator — re-capture preserves allowFrom (S11)", () => {
+  it("Set-unions captured id into existing allowFrom; updates primaryOperator", async () => {
+    saveAllowedSenders(dataDir, () => ({
+      ...defaultPairingState(),
+      dmPolicy: "allowlist",
+      allowFrom: ["op-old", "friend"].map((s) => (s === "op-old" ? "11111" : "22222")),
+      primaryOperator: "11111",
+      capturedAt: "2026-01-01T00:00:00.000Z",
+    }));
+    const bot = makeFakeBot({
+      getMe: async () => ({ is_bot: true, username: "testbot" }),
+      onStart: async (b) => {
+        await b.fireUpdate({
+          chat: { type: "private", id: 33333 },
+          from: { id: 33333, username: "newop", first_name: "New" },
+        });
+      },
+    });
+    nextBots.push(bot);
+    const captureAndPersistOperator = await importHelper();
+    const result = await captureAndPersistOperator({
+      botToken: "FAKE",
+      binary: cyclingBinary,
+      dataDir,
+      confirm: async () => true,
+    });
+    expect(result.status).toBe("captured");
+    const reloaded = loadAllowedSenders(dataDir);
+    expect(reloaded.allowFrom.sort()).toEqual(["11111", "22222", "33333"]);
+    expect(reloaded.primaryOperator).toBe("33333");
+    expect(reloaded.capturedAt).not.toBe("2026-01-01T00:00:00.000Z"); // refreshed
+  });
+});
+
+describe("captureAndPersistOperator — write-failed mapping (T2)", () => {
+  it.each([
+    ["ENOSPC", "no space left on device"],
+    ["EACCES", "permission denied"],
+    ["EROFS", "read-only filesystem"],
+    ["EIO", "input/output error"],
+    ["GENERIC", "totally unexpected"],
+  ])("save throwing %s → status 'write-failed'", async (_code, message) => {
+    vi.doMock("../src/channels/allowed-senders.js", async () => {
+      const real = await vi.importActual<typeof import("../src/channels/allowed-senders.js")>(
+        "../src/channels/allowed-senders.js",
+      );
+      return {
+        ...real,
+        saveAllowedSenders: vi.fn(() => {
+          throw new Error(message);
+        }),
+      };
+    });
+    const bot = makeFakeBot({
+      getMe: async () => ({ is_bot: true, username: "testbot" }),
+      onStart: async (b) => {
+        await b.fireUpdate({
+          chat: { type: "private", id: 12345 },
+          from: { id: 12345, username: "alice", first_name: "Alice" },
+        });
+      },
+    });
+    nextBots.push(bot);
+    const captureAndPersistOperator = await importHelper();
+    const result = await captureAndPersistOperator({
+      botToken: "FAKE",
+      binary: cyclingBinary,
+      dataDir,
+      confirm: async () => true,
+    });
+    expect(result.status).toBe("write-failed");
+    expect(result.reason).toContain(message);
+  });
+
+  it("save throwing LockfileContentionError → status 'lockfile-contention'", async () => {
+    vi.doMock("../src/channels/allowed-senders.js", async () => {
+      const real = await vi.importActual<typeof import("../src/channels/allowed-senders.js")>(
+        "../src/channels/allowed-senders.js",
+      );
+      return {
+        ...real,
+        saveAllowedSenders: vi.fn(() => {
+          throw new real.LockfileContentionError("held");
+        }),
+      };
+    });
+    const bot = makeFakeBot({
+      getMe: async () => ({ is_bot: true, username: "testbot" }),
+      onStart: async (b) => {
+        await b.fireUpdate({
+          chat: { type: "private", id: 12345 },
+          from: { id: 12345, username: "alice", first_name: "Alice" },
+        });
+      },
+    });
+    nextBots.push(bot);
+    const captureAndPersistOperator = await importHelper();
+    const result = await captureAndPersistOperator({
+      botToken: "FAKE",
+      binary: cyclingBinary,
+      dataDir,
+      confirm: async () => true,
+    });
+    expect(result.status).toBe("lockfile-contention");
+  });
+});

--- a/packages/core/tests/run-binary-allowlist.test.ts
+++ b/packages/core/tests/run-binary-allowlist.test.ts
@@ -1,0 +1,342 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { cyclingBinary } from "./helpers/cycling-binary-fixture.js";
+import {
+  defaultPairingState,
+  saveAllowedSenders,
+  loadAllowedSenders,
+} from "../src/channels/allowed-senders.js";
+import { _parseConfirmAnswer } from "../src/run-binary.js";
+
+let tempHome: string;
+let origHome: string | undefined;
+let origArgv: string[];
+let exitSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  tempHome = mkdtempSync(join(tmpdir(), "cc-rb-allow-"));
+  origHome = process.env.HOME;
+  process.env.HOME = tempHome;
+  mkdirSync(join(tempHome, ".cycling-coach"), { recursive: true });
+  origArgv = process.argv;
+  vi.resetModules();
+  exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+    throw new Error(`__exit_${code ?? 0}`);
+  }) as never);
+});
+
+afterEach(() => {
+  process.env.HOME = origHome;
+  process.argv = origArgv;
+  exitSpy.mockRestore();
+  rmSync(tempHome, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+const dataDir = () => join(tempHome ?? "", ".cycling-coach");
+const ALLOWLIST = () => join(dataDir(), "allowed-senders.json");
+
+const stubSport = {
+  id: "stub",
+  soul: "",
+  skills: {},
+  memorySections: [],
+  mustPreserveTokens: () => [],
+  intervalsActivityTypes: [],
+  athleteProfileSchema: { parse: () => ({}) },
+  tools: () => [],
+};
+
+describe("CLI subcommands — allowlist mutations", () => {
+  it("add-sender abc → exits 1 with 'positive integer' message", async () => {
+    process.argv = ["node", "cycling-coach", "add-sender", "abc"];
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { runBinary } = await import("../src/run-binary.js");
+    await expect(runBinary(stubSport as never, cyclingBinary)).rejects.toThrow("__exit_1");
+    expect(errSpy.mock.calls.some((c) => String(c[0]).match(/positive integer/))).toBe(true);
+    errSpy.mockRestore();
+  });
+
+  it("add-sender 0 → exits 1 (regex rejects)", async () => {
+    process.argv = ["node", "cycling-coach", "add-sender", "0"];
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const { runBinary } = await import("../src/run-binary.js");
+    await expect(runBinary(stubSport as never, cyclingBinary)).rejects.toThrow("__exit_1");
+  });
+
+  it("add-sender 12345 → file written, exits 0", async () => {
+    process.argv = ["node", "cycling-coach", "add-sender", "12345"];
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    const { runBinary } = await import("../src/run-binary.js");
+    await expect(runBinary(stubSport as never, cyclingBinary)).rejects.toThrow("__exit_0");
+    expect(existsSync(ALLOWLIST())).toBe(true);
+    const reloaded = loadAllowedSenders(dataDir());
+    expect(reloaded.allowFrom).toEqual(["12345"]);
+    expect(reloaded.dmPolicy).toBe("allowlist");
+  });
+
+  it("add-sender (no id) → exits 1 with usage message", async () => {
+    process.argv = ["node", "cycling-coach", "add-sender"];
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { runBinary } = await import("../src/run-binary.js");
+    await expect(runBinary(stubSport as never, cyclingBinary)).rejects.toThrow("__exit_1");
+    expect(errSpy.mock.calls.some((c) => String(c[0]).includes("Usage:"))).toBe(true);
+    errSpy.mockRestore();
+  });
+
+  it("remove-sender 12345 → file updated, exits 0", async () => {
+    saveAllowedSenders(dataDir(), () => ({
+      ...defaultPairingState(),
+      dmPolicy: "allowlist",
+      allowFrom: ["12345", "67890"],
+      primaryOperator: "12345",
+    }));
+    process.argv = ["node", "cycling-coach", "remove-sender", "12345"];
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    const { runBinary } = await import("../src/run-binary.js");
+    await expect(runBinary(stubSport as never, cyclingBinary)).rejects.toThrow("__exit_0");
+    const reloaded = loadAllowedSenders(dataDir());
+    expect(reloaded.allowFrom).toEqual(["67890"]);
+  });
+
+  it("list-senders prints policy, allowFrom, addedAt", async () => {
+    saveAllowedSenders(dataDir(), () => ({
+      ...defaultPairingState(),
+      dmPolicy: "allowlist",
+      allowFrom: ["12345"],
+      primaryOperator: "12345",
+      addedAt: { "12345": "2026-05-09T10:00:00.000Z" },
+    }));
+    process.argv = ["node", "cycling-coach", "list-senders"];
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const { runBinary } = await import("../src/run-binary.js");
+    await expect(runBinary(stubSport as never, cyclingBinary)).rejects.toThrow("__exit_0");
+    const printed = logSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(printed).toContain("Policy: allowlist");
+    expect(printed).toContain("Primary operator: 12345");
+    expect(printed).toContain("12345");
+    logSpy.mockRestore();
+  });
+});
+
+describe("makeReadlineConfirm — parsing matrix (T4)", () => {
+  it.each([
+    // [input, expected]
+    ["", true],
+    ["y", true],
+    ["Y", true],
+    ["yes", true],
+    ["YES", true],
+    [" yes ", true],
+    ["\nyes\n", true],
+    ["n", false],
+    ["N", false],
+    ["no", false],
+    ["NO", false],
+    [" no ", false],
+    ["yes please", false],
+    ["yeah", false],
+    ["yep", false],
+    ["hmm", false],
+    ["да", false],
+    ["1", false],
+    ["true", false],
+  ])("parses %j → %s", (input, expected) => {
+    expect(_parseConfirmAnswer(input)).toBe(expected);
+  });
+});
+
+describe("startup-capture predicate (T3)", () => {
+  // We exercise the predicate by mocking loadAllowedSenders to control its output.
+  // The real wiring is verified by the integration sweep — these tests guard the
+  // T3 invariants (env-var case rejection, no-token skip, file-already-set skip).
+
+  function setupBaseMocks(opts: {
+    isTTY: boolean;
+    botToken: string;
+    allowFromInFile?: string[];
+    operatorIdEnv?: string;
+  }): { captureFn: ReturnType<typeof vi.fn> } {
+    Object.defineProperty(process.stdin, "isTTY", { value: opts.isTTY, configurable: true });
+
+    if (opts.allowFromInFile && opts.allowFromInFile.length > 0) {
+      saveAllowedSenders(dataDir(), () => ({
+        ...defaultPairingState(),
+        dmPolicy: "allowlist",
+        allowFrom: opts.allowFromInFile!,
+        primaryOperator: opts.allowFromInFile![0],
+      }));
+    }
+    if (opts.operatorIdEnv !== undefined) {
+      process.env.CYCLING_COACH_OPERATOR_ID = opts.operatorIdEnv;
+    } else {
+      delete process.env.CYCLING_COACH_OPERATOR_ID;
+    }
+
+    const captureFn = vi.fn(async () => ({
+      status: "timeout" as const,
+      botUsername: "testbot",
+    }));
+    vi.doMock("../src/channels/operator-capture.js", () => ({
+      captureAndPersistOperator: captureFn,
+    }));
+
+    // Stub config + LLM dispatch + agent so we can run the bot-start path.
+    vi.doMock("../src/config.js", async () => {
+      const real = await vi.importActual<typeof import("../src/config.js")>("../src/config.js");
+      return {
+        ...real,
+        loadConfig: () => ({
+          llm: { provider: "anthropic", model: "x", apiKey: "sk-x" },
+          telegram: { botToken: opts.botToken },
+          intervals: { apiKey: "x", athleteId: "x" },
+          dataDir: dataDir(),
+        }),
+        resolveConfigSecrets: async (c: unknown) => c,
+      };
+    });
+    // Skip CoachAgent construction (relies on pi-ai) — replace with a stub.
+    vi.doMock("../src/agent/coach-agent.js", () => ({
+      CoachAgent: class {
+        constructor() {}
+        getMemory() { return {} as never; }
+        chat() { return Promise.resolve("ok"); }
+        hasSession() { return false; }
+        resetSession() { return Promise.resolve(); }
+      },
+    }));
+    // Stub the telegram bot construction so we don't actually try to start polling.
+    vi.doMock("../src/channels/telegram.js", () => ({
+      createTelegramBot: vi.fn(() => ({
+        start: vi.fn(),
+        api: { sendMessage: vi.fn() },
+      })),
+      notifyUpdate: vi.fn(async () => undefined),
+    }));
+
+    return { captureFn };
+  }
+
+  afterEach(() => {
+    delete process.env.CYCLING_COACH_OPERATOR_ID;
+    vi.doUnmock("../src/channels/operator-capture.js");
+    vi.doUnmock("../src/config.js");
+    vi.doUnmock("../src/agent/coach-agent.js");
+    vi.doUnmock("../src/channels/telegram.js");
+  });
+
+  it("TTY + no file + token + no env → capture invoked", async () => {
+    process.argv = ["node", "cycling-coach"];
+    const { captureFn } = setupBaseMocks({ isTTY: true, botToken: "TOKEN" });
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const { runBinary } = await import("../src/run-binary.js");
+    await runBinary(stubSport as never, cyclingBinary);
+    expect(captureFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("no TTY → capture NOT invoked; bot starts in pairing mode", async () => {
+    process.argv = ["node", "cycling-coach"];
+    const { captureFn } = setupBaseMocks({ isTTY: false, botToken: "TOKEN" });
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const { runBinary } = await import("../src/run-binary.js");
+    await runBinary(stubSport as never, cyclingBinary);
+    expect(captureFn).not.toHaveBeenCalled();
+  });
+
+  it("env-var CYCLING_COACH_OPERATOR_ID set → capture NOT invoked", async () => {
+    process.argv = ["node", "cycling-coach"];
+    const { captureFn } = setupBaseMocks({
+      isTTY: true,
+      botToken: "TOKEN",
+      operatorIdEnv: "12345",
+    });
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const { runBinary } = await import("../src/run-binary.js");
+    await runBinary(stubSport as never, cyclingBinary);
+    expect(captureFn).not.toHaveBeenCalled();
+  });
+
+  it("T3: invalid env-var → loadAllowedSenders falls through to default-pairing → capture invoked", async () => {
+    process.argv = ["node", "cycling-coach"];
+    const { captureFn } = setupBaseMocks({
+      isTTY: true,
+      botToken: "TOKEN",
+      operatorIdEnv: "abc",
+    });
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const { runBinary } = await import("../src/run-binary.js");
+    await runBinary(stubSport as never, cyclingBinary);
+    expect(captureFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("file already exists with non-empty allowFrom → capture NOT invoked", async () => {
+    process.argv = ["node", "cycling-coach"];
+    const { captureFn } = setupBaseMocks({
+      isTTY: true,
+      botToken: "TOKEN",
+      allowFromInFile: ["12345"],
+    });
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const { runBinary } = await import("../src/run-binary.js");
+    await runBinary(stubSport as never, cyclingBinary);
+    expect(captureFn).not.toHaveBeenCalled();
+  });
+
+  it("getme-failed result → bot still starts (capture is non-fatal)", async () => {
+    process.argv = ["node", "cycling-coach"];
+    Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+    delete process.env.CYCLING_COACH_OPERATOR_ID;
+    const captureFn = vi.fn(async () => ({
+      status: "getme-failed" as const,
+      reason: "401",
+    }));
+    vi.doMock("../src/channels/operator-capture.js", () => ({
+      captureAndPersistOperator: captureFn,
+    }));
+    vi.doMock("../src/config.js", async () => {
+      const real = await vi.importActual<typeof import("../src/config.js")>("../src/config.js");
+      return {
+        ...real,
+        loadConfig: () => ({
+          llm: { provider: "anthropic", model: "x", apiKey: "sk-x" },
+          telegram: { botToken: "TOKEN" },
+          intervals: { apiKey: "x", athleteId: "x" },
+          dataDir: dataDir(),
+        }),
+        resolveConfigSecrets: async (c: unknown) => c,
+      };
+    });
+    vi.doMock("../src/agent/coach-agent.js", () => ({
+      CoachAgent: class {
+        constructor() {}
+        getMemory() { return {} as never; }
+      },
+    }));
+    const startSpy = vi.fn();
+    vi.doMock("../src/channels/telegram.js", () => ({
+      createTelegramBot: vi.fn(() => ({ start: startSpy, api: { sendMessage: vi.fn() } })),
+      notifyUpdate: vi.fn(async () => undefined),
+    }));
+
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const { runBinary } = await import("../src/run-binary.js");
+    await runBinary(stubSport as never, cyclingBinary);
+    expect(captureFn).toHaveBeenCalledTimes(1);
+    expect(startSpy).toHaveBeenCalledTimes(1); // bot started despite getme-failed
+  });
+});

--- a/packages/core/tests/setup-allowlist.test.ts
+++ b/packages/core/tests/setup-allowlist.test.ts
@@ -1,0 +1,309 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { stringify as toYaml } from "yaml";
+
+import { scriptedPrompts } from "./helpers/scripted-prompts.js";
+import { cyclingBinary } from "./helpers/cycling-binary-fixture.js";
+import {
+  defaultPairingState,
+  saveAllowedSenders,
+  loadAllowedSenders,
+  type AllowedSenders,
+} from "../src/channels/allowed-senders.js";
+
+let tempHome: string;
+let origHome: string | undefined;
+let origStdinTTY: boolean | undefined;
+let origStdoutTTY: boolean | undefined;
+
+beforeEach(() => {
+  tempHome = mkdtempSync(join(tmpdir(), "cc-setup-allow-"));
+  origHome = process.env.HOME;
+  process.env.HOME = tempHome;
+  mkdirSync(join(tempHome, ".cycling-coach"), { recursive: true });
+  origStdinTTY = process.stdin.isTTY;
+  origStdoutTTY = process.stdout.isTTY;
+  Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+  Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
+  vi.resetModules();
+  vi.doMock("../src/secrets/backends/detect.js", () => ({
+    detectBackends: vi.fn(async () => ({
+      op: { state: "unavailable", reason: "not-on-path" },
+      keychain: { available: false },
+    })),
+  }));
+});
+
+afterEach(() => {
+  process.env.HOME = origHome;
+  Object.defineProperty(process.stdin, "isTTY", { value: origStdinTTY, configurable: true });
+  Object.defineProperty(process.stdout, "isTTY", { value: origStdoutTTY, configurable: true });
+  rmSync(tempHome, { recursive: true, force: true });
+  vi.restoreAllMocks();
+  vi.doUnmock("@clack/prompts");
+  vi.doUnmock("../src/channels/operator-capture.js");
+  vi.doUnmock("../src/secrets/backends/detect.js");
+});
+
+const CONFIG = () => join(tempHome, ".cycling-coach", "config.yaml");
+const ALLOWLIST = () => join(tempHome, ".cycling-coach", "allowed-senders.json");
+
+function seedConfig(obj: Record<string, unknown>): void {
+  writeFileSync(CONFIG(), toYaml(obj), { mode: 0o600 });
+}
+
+interface MockCaptureSpec {
+  status: "captured" | "declined" | "timeout" | "getme-failed" | "lockfile-contention" | "write-failed";
+  capturedId?: string;
+  botUsername?: string;
+  reason?: string;
+  /** Callback the test runs to simulate post-capture confirm + write to disk. */
+  onCapture?: (dataDir: string) => void;
+}
+
+function mockOperatorCapture(spec: MockCaptureSpec): ReturnType<typeof vi.fn> {
+  const fn = vi.fn(async (opts: { dataDir: string; confirm: (info: unknown) => Promise<boolean> }) => {
+    if (spec.status === "captured") {
+      // Simulate the capture flow's confirm prompt being invoked, then writing the file.
+      const ok = await opts.confirm({
+        capturedId: spec.capturedId ?? "12345",
+        senderUsername: "alice",
+        senderFirstName: "Alice",
+        botUsername: spec.botUsername ?? "testbot",
+        binaryName: "cycling-coach",
+      });
+      if (!ok) return { status: "declined" as const };
+      spec.onCapture?.(opts.dataDir);
+      return {
+        status: "captured" as const,
+        capturedId: spec.capturedId ?? "12345",
+        botUsername: spec.botUsername ?? "testbot",
+      };
+    }
+    if (spec.status === "declined") {
+      // Simulate confirm prompt firing but operator declines.
+      await opts.confirm({
+        capturedId: spec.capturedId ?? "12345",
+        senderUsername: "alice",
+        senderFirstName: "Alice",
+        botUsername: spec.botUsername ?? "testbot",
+        binaryName: "cycling-coach",
+      });
+      return { status: "declined" as const };
+    }
+    return {
+      status: spec.status,
+      capturedId: spec.capturedId,
+      botUsername: spec.botUsername,
+      reason: spec.reason,
+    };
+  });
+  vi.doMock("../src/channels/operator-capture.js", () => ({
+    captureAndPersistOperator: fn,
+  }));
+  return fn;
+}
+
+describe("setup wizard — operator capture integration (Phase 5)", () => {
+  it("H1 (CRITICAL): cancel-at-config-confirm leaves NO orphan allowed-senders.json", async () => {
+    seedConfig({
+      llm: { provider: "anthropic", model: "claude-sonnet-4-6", api_key: "sk-ant-keep" },
+      telegram: { bot_token: "tg-keep" },
+    });
+    const beforeBytes = readFileSync(CONFIG());
+    vi.doMock("@clack/prompts", () =>
+      scriptedPrompts({
+        selects: ["anthropic", "claude-sonnet-4-6", "plain"],
+        passwords: ["", "", ""], // anthropic key keep, intervals keep, telegram keep
+        texts: ["", ""], // intervals athlete-id keep (not asked) and other text
+        confirms: [false], // decline the "Update config?" confirm
+      }),
+    );
+    const captureFn = mockOperatorCapture({ status: "captured" });
+
+    const { runSetup } = await import("../src/setup.js");
+    await runSetup(cyclingBinary);
+
+    expect(readFileSync(CONFIG())).toEqual(beforeBytes); // config unchanged
+    expect(existsSync(ALLOWLIST())).toBe(false); // CRITICAL: no orphan
+    expect(captureFn).not.toHaveBeenCalled(); // capture never ran
+  });
+
+  it("captures operator when confirm:true at the captured-id prompt", async () => {
+    // Fresh install: no prior config or allowlist.
+    vi.doMock("@clack/prompts", () =>
+      scriptedPrompts({
+        selects: ["anthropic", "claude-sonnet-4-6", "plain"],
+        passwords: ["sk-ant-fresh", "", "BOT-TOKEN-1234"],
+        texts: ["", "i42"],
+        confirms: [true, true], // update config, save captured operator
+      }),
+    );
+    const captureFn = mockOperatorCapture({
+      status: "captured",
+      capturedId: "12345",
+      botUsername: "testbot",
+      onCapture: (dataDir) => {
+        // Simulate the helper's transformer-based persistence.
+        saveAllowedSenders(dataDir, () => ({
+          ...defaultPairingState(),
+          dmPolicy: "allowlist",
+          allowFrom: ["12345"],
+          primaryOperator: "12345",
+          capturedAt: new Date().toISOString(),
+        }));
+      },
+    });
+
+    const { runSetup } = await import("../src/setup.js");
+    await runSetup(cyclingBinary);
+
+    expect(captureFn).toHaveBeenCalledTimes(1);
+    expect(existsSync(ALLOWLIST())).toBe(true);
+    const reloaded = loadAllowedSenders(join(tempHome, ".cycling-coach"));
+    expect(reloaded.dmPolicy).toBe("allowlist");
+    expect(reloaded.allowFrom).toEqual(["12345"]);
+    expect(reloaded.primaryOperator).toBe("12345");
+  });
+
+  it("declined at captured-id prompt → no allowed-senders.json written", async () => {
+    vi.doMock("@clack/prompts", () =>
+      scriptedPrompts({
+        selects: ["anthropic", "claude-sonnet-4-6", "plain"],
+        passwords: ["sk-ant-fresh", "", "BOT-TOKEN-1234"],
+        texts: ["", "i42"],
+        confirms: [true, false], // update config, decline save
+      }),
+    );
+    const captureFn = mockOperatorCapture({ status: "declined" });
+
+    const { runSetup } = await import("../src/setup.js");
+    await runSetup(cyclingBinary);
+
+    expect(captureFn).toHaveBeenCalledTimes(1);
+    expect(existsSync(ALLOWLIST())).toBe(false);
+  });
+
+  it("capture timeout → wizard continues, no file written", async () => {
+    vi.doMock("@clack/prompts", () =>
+      scriptedPrompts({
+        selects: ["anthropic", "claude-sonnet-4-6", "plain"],
+        passwords: ["sk-ant-fresh", "", "BOT-TOKEN-1234"],
+        texts: ["", "i42"],
+        confirms: [true], // update config (capture flow doesn't confirm — timeout before confirm)
+      }),
+    );
+    const captureFn = mockOperatorCapture({ status: "timeout" });
+
+    const { runSetup } = await import("../src/setup.js");
+    await runSetup(cyclingBinary);
+
+    expect(captureFn).toHaveBeenCalledTimes(1);
+    expect(existsSync(ALLOWLIST())).toBe(false);
+    expect(existsSync(CONFIG())).toBe(true); // config.yaml still committed
+  });
+
+  it("getme-failed → wizard does NOT abort; logs warning", async () => {
+    vi.doMock("@clack/prompts", () =>
+      scriptedPrompts({
+        selects: ["anthropic", "claude-sonnet-4-6", "plain"],
+        passwords: ["sk-ant-fresh", "", "BAD-TOKEN"],
+        texts: ["", "i42"],
+        confirms: [true],
+      }),
+    );
+    const captureFn = mockOperatorCapture({ status: "getme-failed", reason: "401 Unauthorized" });
+
+    const { runSetup } = await import("../src/setup.js");
+    await runSetup(cyclingBinary);
+
+    expect(captureFn).toHaveBeenCalledTimes(1);
+    expect(existsSync(ALLOWLIST())).toBe(false);
+    expect(existsSync(CONFIG())).toBe(true);
+  });
+
+  it("re-run with existing allowlist + answer N to re-capture → file unchanged (idempotency)", async () => {
+    seedConfig({
+      llm: { provider: "anthropic", model: "claude-sonnet-4-6", api_key: "sk-ant-keep" },
+      telegram: { bot_token: "tg-keep" },
+    });
+    const existing: AllowedSenders = {
+      ...defaultPairingState(),
+      dmPolicy: "allowlist",
+      allowFrom: ["12345", "67890"],
+      primaryOperator: "12345",
+      capturedAt: "2026-01-01T00:00:00.000Z",
+      addedAt: { "12345": "2026-01-01T00:00:00.000Z", "67890": "2026-01-02T00:00:00.000Z" },
+    };
+    saveAllowedSenders(join(tempHome, ".cycling-coach"), () => existing);
+    const beforeBytes = readFileSync(ALLOWLIST());
+
+    vi.doMock("@clack/prompts", () =>
+      scriptedPrompts({
+        selects: ["anthropic", "claude-sonnet-4-6", "plain"],
+        passwords: ["", "", ""],
+        texts: ["", ""],
+        confirms: [true, false], // update config, decline re-capture
+      }),
+    );
+    const captureFn = mockOperatorCapture({ status: "captured" });
+
+    const { runSetup } = await import("../src/setup.js");
+    await runSetup(cyclingBinary);
+
+    expect(captureFn).not.toHaveBeenCalled(); // skipped per re-capture decline
+    expect(readFileSync(ALLOWLIST())).toEqual(beforeBytes); // byte-for-byte unchanged
+  });
+
+  it("S11 re-capture preserves existing allowFrom (Set-union)", async () => {
+    seedConfig({
+      llm: { provider: "anthropic", model: "claude-sonnet-4-6", api_key: "sk-ant-keep" },
+      telegram: { bot_token: "tg-keep" },
+    });
+    saveAllowedSenders(join(tempHome, ".cycling-coach"), () => ({
+      ...defaultPairingState(),
+      dmPolicy: "allowlist",
+      allowFrom: ["11111", "22222"],
+      primaryOperator: "11111",
+    }));
+
+    vi.doMock("@clack/prompts", () =>
+      scriptedPrompts({
+        selects: ["anthropic", "claude-sonnet-4-6", "plain"],
+        passwords: ["", "", ""],
+        texts: ["", ""],
+        confirms: [true, true, true], // update config, re-capture YES, save captured
+      }),
+    );
+    const captureFn = mockOperatorCapture({
+      status: "captured",
+      capturedId: "33333",
+      onCapture: (dataDir) => {
+        saveAllowedSenders(dataDir, (current) => {
+          const base = current ?? defaultPairingState();
+          const merged = base.allowFrom.includes("33333")
+            ? base.allowFrom
+            : [...base.allowFrom, "33333"];
+          return {
+            ...base,
+            dmPolicy: "allowlist",
+            allowFrom: merged,
+            primaryOperator: "33333",
+            addedAt: { ...base.addedAt, "33333": new Date().toISOString() },
+            capturedAt: new Date().toISOString(),
+          };
+        });
+      },
+    });
+
+    const { runSetup } = await import("../src/setup.js");
+    await runSetup(cyclingBinary);
+
+    expect(captureFn).toHaveBeenCalledTimes(1);
+    const reloaded = loadAllowedSenders(join(tempHome, ".cycling-coach"));
+    expect(reloaded.allowFrom.sort()).toEqual(["11111", "22222", "33333"]);
+    expect(reloaded.primaryOperator).toBe("33333"); // updated to new operator
+  });
+});

--- a/packages/core/tests/telegram-access.test.ts
+++ b/packages/core/tests/telegram-access.test.ts
@@ -1,0 +1,315 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { Context } from "grammy";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  evaluateAccess,
+  buildPairingChallenge,
+  createAuthMiddleware,
+} from "../src/channels/telegram-access.js";
+import {
+  defaultPairingState,
+  saveAllowedSenders,
+  type AllowedSenders,
+} from "../src/channels/allowed-senders.js";
+
+function makeAllowed(overrides: Partial<AllowedSenders> = {}): AllowedSenders {
+  return { ...defaultPairingState(), ...overrides } as AllowedSenders;
+}
+
+function makeCtx(opts: {
+  chatType?: "private" | "group" | "supergroup" | "channel";
+  fromId?: number | string | undefined;
+}): Context {
+  const ctx: Partial<Context> = {};
+  if (opts.chatType !== undefined) {
+    (ctx as { chat?: unknown }).chat = { type: opts.chatType, id: 0 };
+  }
+  if (opts.fromId !== undefined) {
+    (ctx as { from?: unknown }).from = { id: opts.fromId };
+  }
+  return ctx as Context;
+}
+
+describe("evaluateAccess — chat-type and from-id guards", () => {
+  it("rejects non-private chats (group)", () => {
+    const ctx = makeCtx({ chatType: "group", fromId: 12345 });
+    const result = evaluateAccess(ctx, makeAllowed({ dmPolicy: "allowlist", allowFrom: ["12345"] }));
+    expect(result.allow).toBe(false);
+  });
+
+  it("rejects non-private chats (channel)", () => {
+    const ctx = makeCtx({ chatType: "channel", fromId: 12345 });
+    const result = evaluateAccess(ctx, makeAllowed({ dmPolicy: "allowlist", allowFrom: ["12345"] }));
+    expect(result.allow).toBe(false);
+  });
+
+  it("rejects when ctx.from is undefined (service messages)", () => {
+    const ctx = makeCtx({ chatType: "private", fromId: undefined });
+    const result = evaluateAccess(ctx, makeAllowed({ dmPolicy: "allowlist", allowFrom: ["12345"] }));
+    expect(result.allow).toBe(false);
+  });
+
+  it("rejects when typeof ctx.from.id !== 'number' (grammy version-drift guard)", () => {
+    const ctx = makeCtx({ chatType: "private", fromId: "12345" as unknown as number });
+    const result = evaluateAccess(ctx, makeAllowed({ dmPolicy: "allowlist", allowFrom: ["12345"] }));
+    expect(result.allow).toBe(false);
+  });
+});
+
+describe("evaluateAccess — allowlist matching", () => {
+  it("allows when String(from.id) ∈ allowFrom (allowlist mode)", () => {
+    const ctx = makeCtx({ chatType: "private", fromId: 12345 });
+    const result = evaluateAccess(
+      ctx,
+      makeAllowed({ dmPolicy: "allowlist", allowFrom: ["12345"], primaryOperator: "12345" }),
+    );
+    expect(result).toEqual({ allow: true });
+  });
+
+  it("allows when dmPolicy is 'open' (env-var-only escape hatch)", () => {
+    const ctx = makeCtx({ chatType: "private", fromId: 99999 });
+    const result = evaluateAccess(ctx, makeAllowed({ dmPolicy: "open", allowFrom: [] }));
+    expect(result).toEqual({ allow: true });
+  });
+
+  it("denies (silent) when dmPolicy is 'allowlist' and sender not in allowFrom", () => {
+    const ctx = makeCtx({ chatType: "private", fromId: 99999 });
+    const result = evaluateAccess(
+      ctx,
+      makeAllowed({ dmPolicy: "allowlist", allowFrom: ["12345"], primaryOperator: "12345" }),
+    );
+    expect(result.allow).toBe(false);
+    expect(result.pairingChallenge).toBeUndefined();
+  });
+
+  it("emits pairingChallenge marker when dmPolicy is 'pairing' and sender not allowlisted", () => {
+    const ctx = makeCtx({ chatType: "private", fromId: 99999 });
+    const result = evaluateAccess(ctx, makeAllowed({ dmPolicy: "pairing", allowFrom: [] }));
+    expect(result.allow).toBe(false);
+    expect(result.pairingChallenge).toBe("99999");
+  });
+});
+
+describe("buildPairingChallenge — HTML body", () => {
+  it("includes sender's user-ID, owner CLI command, and 'ask the bot owner' fallback (S5)", () => {
+    const html = buildPairingChallenge("99999", "Stranger", "cycling-coach");
+    expect(html).toContain("99999");
+    expect(html).toContain("cycling-coach add-sender 99999");
+    expect(html).toContain("ask the bot owner");
+  });
+
+  it("HTML-escapes sender name (XSS in pairing reply)", () => {
+    const html = buildPairingChallenge("99999", "<script>alert(1)</script>", "cycling-coach");
+    expect(html).not.toContain("<script>");
+    expect(html).toContain("&lt;script&gt;");
+  });
+
+  it("HTML-escapes ampersand and quote in sender name", () => {
+    const html = buildPairingChallenge("99999", 'Bob & "the Builder"', "cycling-coach");
+    expect(html).toContain("&amp;");
+    expect(html).toContain("&quot;");
+  });
+
+  it("HTML-escapes binaryName defensively (constant in practice)", () => {
+    const html = buildPairingChallenge("99999", undefined, "evil<bin>");
+    expect(html).not.toContain("<bin>");
+    expect(html).toContain("&lt;bin&gt;");
+  });
+
+  it("handles undefined senderName (service-message edge)", () => {
+    const html = buildPairingChallenge("99999", undefined, "cycling-coach");
+    expect(html).toContain("99999");
+  });
+
+  it("accepts numeric senderId and stringifies it", () => {
+    const html = buildPairingChallenge(12345, "Alice", "cycling-coach");
+    expect(html).toContain("12345");
+  });
+});
+
+describe("createAuthMiddleware — gating", () => {
+  let dataDir: string;
+  beforeEach(() => {
+    dataDir = mkdtempSync(join(tmpdir(), "cc-mw-"));
+  });
+  afterEach(() => {
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  function makeMwCtx(opts: {
+    chatType?: "private" | "group";
+    fromId?: number;
+    fromFirstName?: string;
+  }): Context & { reply: ReturnType<typeof vi.fn> } {
+    const ctx: Record<string, unknown> = {
+      reply: vi.fn(async () => undefined),
+    };
+    if (opts.chatType !== undefined) {
+      ctx.chat = { type: opts.chatType, id: opts.fromId ?? 0 };
+    }
+    if (opts.fromId !== undefined) {
+      ctx.from = { id: opts.fromId, first_name: opts.fromFirstName };
+    }
+    return ctx as Context & { reply: ReturnType<typeof vi.fn> };
+  }
+
+  it("calls next() for allowed senders (allowlist mode)", async () => {
+    saveAllowedSenders(dataDir, () => ({
+      ...defaultPairingState(),
+      dmPolicy: "allowlist",
+      allowFrom: ["12345"],
+      primaryOperator: "12345",
+    }));
+    const mw = createAuthMiddleware({
+      dataDir,
+      binaryName: "cycling-coach",
+      challengeRateLimit: new Map(),
+      challengeMinIntervalMs: 60_000,
+    });
+    const ctx = makeMwCtx({ chatType: "private", fromId: 12345 });
+    const next = vi.fn(async () => undefined);
+    await mw(ctx, next);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(ctx.reply).not.toHaveBeenCalled();
+  });
+
+  it("sends pairing-challenge HTML and does NOT call next() for stranger in pairing mode", async () => {
+    // dataDir empty + no env → default-pairing mode
+    const mw = createAuthMiddleware({
+      dataDir,
+      binaryName: "cycling-coach",
+      challengeRateLimit: new Map(),
+      challengeMinIntervalMs: 60_000,
+    });
+    const ctx = makeMwCtx({ chatType: "private", fromId: 99999, fromFirstName: "Stranger" });
+    const next = vi.fn(async () => undefined);
+    await mw(ctx, next);
+    expect(next).not.toHaveBeenCalled();
+    expect(ctx.reply).toHaveBeenCalledTimes(1);
+    const [html, options] = (ctx.reply as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(html).toContain("99999");
+    expect(html).toContain("cycling-coach add-sender 99999");
+    expect(options).toEqual({ parse_mode: "HTML" });
+  });
+
+  it("does NOT call next() for stranger in allowlist mode (silent drop, no reply)", async () => {
+    saveAllowedSenders(dataDir, () => ({
+      ...defaultPairingState(),
+      dmPolicy: "allowlist",
+      allowFrom: ["12345"],
+      primaryOperator: "12345",
+    }));
+    const mw = createAuthMiddleware({
+      dataDir,
+      binaryName: "cycling-coach",
+      challengeRateLimit: new Map(),
+      challengeMinIntervalMs: 60_000,
+    });
+    const ctx = makeMwCtx({ chatType: "private", fromId: 99999 });
+    const next = vi.fn(async () => undefined);
+    await mw(ctx, next);
+    expect(next).not.toHaveBeenCalled();
+    expect(ctx.reply).not.toHaveBeenCalled();
+  });
+
+  it("rate-limit (H2): same sender messaging twice within window → only one reply", async () => {
+    const map = new Map<string, number>();
+    const mw = createAuthMiddleware({
+      dataDir,
+      binaryName: "cycling-coach",
+      challengeRateLimit: map,
+      challengeMinIntervalMs: 60_000,
+    });
+    const ctx1 = makeMwCtx({ chatType: "private", fromId: 99999 });
+    const ctx2 = makeMwCtx({ chatType: "private", fromId: 99999 });
+    const next = vi.fn(async () => undefined);
+    await mw(ctx1, next);
+    await mw(ctx2, next);
+    expect(ctx1.reply).toHaveBeenCalledTimes(1);
+    expect(ctx2.reply).not.toHaveBeenCalled();
+  });
+
+  it("rate-limit: different senders are rate-limited independently", async () => {
+    const map = new Map<string, number>();
+    const mw = createAuthMiddleware({
+      dataDir,
+      binaryName: "cycling-coach",
+      challengeRateLimit: map,
+      challengeMinIntervalMs: 60_000,
+    });
+    const ctxA = makeMwCtx({ chatType: "private", fromId: 11111 });
+    const ctxB = makeMwCtx({ chatType: "private", fromId: 22222 });
+    const next = vi.fn(async () => undefined);
+    await mw(ctxA, next);
+    await mw(ctxB, next);
+    expect(ctxA.reply).toHaveBeenCalledTimes(1);
+    expect(ctxB.reply).toHaveBeenCalledTimes(1);
+  });
+
+  it("rate-limit: same sender after window elapses → second reply fires", async () => {
+    const map = new Map<string, number>();
+    // Pre-seed map to simulate the previous reply was 70s ago.
+    map.set("99999", Date.now() - 70_000);
+    const mw = createAuthMiddleware({
+      dataDir,
+      binaryName: "cycling-coach",
+      challengeRateLimit: map,
+      challengeMinIntervalMs: 60_000,
+    });
+    const ctx = makeMwCtx({ chatType: "private", fromId: 99999 });
+    const next = vi.fn(async () => undefined);
+    await mw(ctx, next);
+    expect(ctx.reply).toHaveBeenCalledTimes(1);
+  });
+
+  it("rate-limit map LRU bound: 1001 distinct senders → map size stays ≤ 1000", async () => {
+    const map = new Map<string, number>();
+    const mw = createAuthMiddleware({
+      dataDir,
+      binaryName: "cycling-coach",
+      challengeRateLimit: map,
+      challengeMinIntervalMs: 60_000,
+    });
+    const next = vi.fn(async () => undefined);
+    for (let i = 0; i < 1001; i++) {
+      const ctx = makeMwCtx({ chatType: "private", fromId: 100000 + i });
+      // eslint-disable-next-line no-await-in-loop
+      await mw(ctx, next);
+    }
+    expect(map.size).toBeLessThanOrEqual(1000);
+    // The *last-seen* sender should still be in the map (not the first).
+    expect(map.has("101000")).toBe(true);
+    expect(map.has("100000")).toBe(false);
+  });
+
+  it("fail-closed: load throws → drops update without calling next() and logs to stderr", async () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    // Use an obviously-illegal dataDir so loadAllowedSenders+saveAllowedSenders throw.
+    // (loadAllowedSenders by itself only logs — but the inner ensureDataDirSecure inside
+    // a real save would throw on a bad path. To force a throw inside load, we instead
+    // pass a path that triggers the JSON read error: write a directory in place of the file.)
+    // Simpler: throw from a custom middleware via stubbing — use a Map proxy that throws.
+    const throwingMap = new Proxy(new Map<string, number>(), {
+      get(_target, prop) {
+        if (prop === "get") {
+          return () => { throw new Error("synthetic boom"); };
+        }
+        return Reflect.get(_target, prop);
+      },
+    }) as Map<string, number>;
+    const mw = createAuthMiddleware({
+      dataDir,
+      binaryName: "cycling-coach",
+      challengeRateLimit: throwingMap,
+      challengeMinIntervalMs: 60_000,
+    });
+    const ctx = makeMwCtx({ chatType: "private", fromId: 99999 });
+    const next = vi.fn(async () => undefined);
+    await mw(ctx, next);
+    expect(next).not.toHaveBeenCalled();
+    expect(errSpy).toHaveBeenCalledWith(expect.stringContaining("[security] middleware error"));
+    errSpy.mockRestore();
+  });
+});

--- a/packages/core/tests/telegram-bot.test.ts
+++ b/packages/core/tests/telegram-bot.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { cyclingBinary } from "./helpers/cycling-binary-fixture.js";
+import {
+  defaultPairingState,
+  saveAllowedSenders,
+} from "../src/channels/allowed-senders.js";
+
+let dataDir: string;
+const ENV_KEYS = ["CYCLING_COACH_OPERATOR_ID", "CYCLING_COACH_DM_POLICY"];
+let savedEnv: Record<string, string | undefined>;
+
+beforeEach(() => {
+  dataDir = mkdtempSync(join(tmpdir(), "cc-tg-bot-"));
+  mkdirSync(join(dataDir, "sessions"), { recursive: true });
+  savedEnv = {};
+  for (const k of ENV_KEYS) {
+    savedEnv[k] = process.env[k];
+    delete process.env[k];
+  }
+  vi.resetModules();
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (savedEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = savedEnv[k];
+  }
+  rmSync(dataDir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+  vi.doUnmock("grammy");
+  vi.doUnmock("../src/updater.js");
+  vi.doUnmock("../src/channels/allowed-senders.js");
+});
+
+function seedSession(chatId: string): void {
+  writeFileSync(
+    join(dataDir, "sessions", `telegram:${chatId}.jsonl`),
+    JSON.stringify({ role: "user", content: "x", ts: Date.now() }),
+  );
+}
+
+describe("notifyUpdate — broadcast filtering (L3)", () => {
+  it("filters chat-ids to allowFrom subset (allowlist mode)", async () => {
+    seedSession("11111"); // allowed
+    seedSession("22222"); // allowed
+    seedSession("99999"); // stranger from before allowlist
+    saveAllowedSenders(dataDir, () => ({
+      ...defaultPairingState(),
+      dmPolicy: "allowlist",
+      allowFrom: ["11111", "22222"],
+      primaryOperator: "11111",
+    }));
+
+    vi.doMock("../src/updater.js", async () => {
+      const real = await vi.importActual<typeof import("../src/updater.js")>(
+        "../src/updater.js",
+      );
+      return {
+        ...real,
+        checkForUpdate: vi.fn(async () => ({
+          current: "2026.5.5",
+          latest: "2026.5.10",
+          updateAvailable: true,
+        })),
+        getKnownTelegramChatIds: vi.fn(() => ["11111", "22222", "99999"]),
+        getLastNotifiedVersion: vi.fn(() => null),
+        setLastNotifiedVersion: vi.fn(),
+      };
+    });
+
+    const sendMessage = vi.fn(async () => undefined);
+    const fakeBot = { api: { sendMessage } } as unknown as Parameters<
+      typeof import("../src/channels/telegram.js")["notifyUpdate"]
+    >[0];
+
+    const { notifyUpdate } = await import("../src/channels/telegram.js");
+    await notifyUpdate(fakeBot, dataDir, cyclingBinary);
+
+    const calledIds = sendMessage.mock.calls.map((c) => String(c[0])).sort();
+    expect(calledIds).toEqual(["11111", "22222"]);
+    expect(calledIds).not.toContain("99999");
+  });
+
+  it("broadcasts to all known chats when CYCLING_COACH_DM_POLICY=open (env-var-only escape)", async () => {
+    seedSession("11111");
+    seedSession("99999");
+    saveAllowedSenders(dataDir, () => ({
+      ...defaultPairingState(),
+      dmPolicy: "allowlist",
+      allowFrom: ["11111"],
+      primaryOperator: "11111",
+    }));
+    process.env.CYCLING_COACH_DM_POLICY = "open";
+
+    vi.doMock("../src/updater.js", async () => {
+      const real = await vi.importActual<typeof import("../src/updater.js")>(
+        "../src/updater.js",
+      );
+      return {
+        ...real,
+        checkForUpdate: vi.fn(async () => ({
+          current: "2026.5.5",
+          latest: "2026.5.10",
+          updateAvailable: true,
+        })),
+        getKnownTelegramChatIds: vi.fn(() => ["11111", "99999"]),
+        getLastNotifiedVersion: vi.fn(() => null),
+        setLastNotifiedVersion: vi.fn(),
+      };
+    });
+
+    const sendMessage = vi.fn(async () => undefined);
+    const fakeBot = { api: { sendMessage } } as unknown as Parameters<
+      typeof import("../src/channels/telegram.js")["notifyUpdate"]
+    >[0];
+
+    const { notifyUpdate } = await import("../src/channels/telegram.js");
+    await notifyUpdate(fakeBot, dataDir, cyclingBinary);
+
+    const calledIds = sendMessage.mock.calls.map((c) => String(c[0])).sort();
+    expect(calledIds).toEqual(["11111", "99999"]);
+  });
+
+  it("does NOT broadcast in default-pairing mode (no allowed senders → empty filter)", async () => {
+    seedSession("99999");
+
+    vi.doMock("../src/updater.js", async () => {
+      const real = await vi.importActual<typeof import("../src/updater.js")>(
+        "../src/updater.js",
+      );
+      return {
+        ...real,
+        checkForUpdate: vi.fn(async () => ({
+          current: "2026.5.5",
+          latest: "2026.5.10",
+          updateAvailable: true,
+        })),
+        getKnownTelegramChatIds: vi.fn(() => ["99999"]),
+        getLastNotifiedVersion: vi.fn(() => null),
+        setLastNotifiedVersion: vi.fn(),
+      };
+    });
+
+    const sendMessage = vi.fn(async () => undefined);
+    const fakeBot = { api: { sendMessage } } as unknown as Parameters<
+      typeof import("../src/channels/telegram.js")["notifyUpdate"]
+    >[0];
+
+    const { notifyUpdate } = await import("../src/channels/telegram.js");
+    await notifyUpdate(fakeBot, dataDir, cyclingBinary);
+
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe("createTelegramBot — startup diagnostic + no security broadcast", () => {
+  it("REGRESSION (CRITICAL): startup with no allowed-senders.json does NOT call bot.api.sendMessage", async () => {
+    // Mock grammy.Bot so we can spy on sendMessage and avoid network calls.
+    const sendMessage = vi.fn(async () => undefined);
+    const use = vi.fn();
+    const command = vi.fn();
+    const on = vi.fn();
+    const bot = { api: { sendMessage }, use, command, on };
+
+    vi.doMock("grammy", () => ({
+      Bot: function FakeBot() {
+        return bot;
+      },
+    }));
+
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const agent = { chat: vi.fn(), resetSession: vi.fn(), hasSession: vi.fn() };
+
+    const { createTelegramBot } = await import("../src/channels/telegram.js");
+    const result = createTelegramBot(
+      "FAKE_TOKEN",
+      agent as unknown as Parameters<typeof createTelegramBot>[1],
+      cyclingBinary,
+      dataDir,
+    );
+    expect(result).toBe(bot);
+
+    // No bot.api.sendMessage anywhere in createTelegramBot — security info goes
+    // to stderr only (the operator-constraint).
+    expect(sendMessage).not.toHaveBeenCalled();
+    // Auth middleware is registered first.
+    expect(use).toHaveBeenCalled();
+    // Diagnostic stderr logging fired.
+    expect(errSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/\[security\] Telegram allowlist: pairing mode/),
+    );
+    expect(errSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/No allowed senders configured.*cycling-coach add-sender/),
+    );
+    errSpy.mockRestore();
+  });
+
+  it("startup diagnostic logs primary operator id when allowed-senders.json exists", async () => {
+    saveAllowedSenders(dataDir, () => ({
+      ...defaultPairingState(),
+      dmPolicy: "allowlist",
+      allowFrom: ["12345"],
+      primaryOperator: "12345",
+    }));
+
+    const sendMessage = vi.fn(async () => undefined);
+    const bot = { api: { sendMessage }, use: vi.fn(), command: vi.fn(), on: vi.fn() };
+    vi.doMock("grammy", () => ({
+      Bot: function FakeBot() {
+        return bot;
+      },
+    }));
+
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const agent = { chat: vi.fn(), resetSession: vi.fn(), hasSession: vi.fn() };
+    const { createTelegramBot } = await import("../src/channels/telegram.js");
+    createTelegramBot(
+      "FAKE",
+      agent as unknown as Parameters<typeof createTelegramBot>[1],
+      cyclingBinary,
+      dataDir,
+    );
+
+    const allLogs = errSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(allLogs).toMatch(/\[security\] Telegram allowlist: allowlist mode \(1 allowed senders, primary: 12345\)/);
+    expect(allLogs).not.toMatch(/No allowed senders configured/);
+    errSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary

- New auth middleware filters every inbound message on `from.id` (defense-in-depth + grammy version-drift guard). Unknown senders in pairing mode get a rate-limited HTML challenge containing their own user-id and the literal CLI command for the operator.
- **Migration: no auto-claim heuristic.** Default policy is `pairing` whenever `~/.cycling-coach/allowed-senders.json` is absent. Interactive startup (TTY) prompts the operator to send `/start` once and confirms before writing; non-TTY paths fall back to pairing + `cycling-coach add-sender <id>`. Setup wizard runs the same capture flow after `config.yaml` is committed (so cancelling the wizard leaves no orphan file).
- **Persistence:** atomic `.tmp` + `renameSync`, mode `0o600`, data-dir tightened to `0o700` even on pre-existing dirs. PID lockfile inside `saveAllowedSenders` serializes wizard / CLI / startup-capture writes. Zod schema-validated on load with explicit fallback to `pairing` on malformed input. **Transformer-pattern** `saveAllowedSenders(dataDir, current => newState)` reads the current file *inside* the lockfile so read-modify-write is atomic per process — closes a TOCTOU class.
- **`notifyUpdate`** now filters its broadcast list against `allowFrom` so pre-update strangers' chat-ids stop receiving update pings.
- **No proactive Telegram broadcast** announcing the security change under any branch (operator constraint). Migration diagnostics go to stderr only.
- `dmPolicy: "open"` is rejected when read from the file (defense in depth) — only settable via `CYCLING_COACH_DM_POLICY=open` env var.
- Mtime-keyed cache on the per-message hot path (`loadAllowedSenders` skips JSON parse + zod re-validation on cache hit). Streaming line-count for `list-senders` so MB-scale session files don't stall the CLI. Shared `enumerateTelegramSessions` walker between updater and access path.

**Env vars:** `CYCLING_COACH_OPERATOR_ID` (single-id, file > env > default), `CYCLING_COACH_DM_POLICY=open` (debug escape), `CYCLING_COACH_SETUP_CAPTURE_TIMEOUT_MS` (default 60s), `CYCLING_COACH_CAPTURE_CONFIRM_TIMEOUT_MS` (default 5min).

## Test plan

- [x] 411 unit tests pass (`pnpm --filter @enduragent/core test`)
- [x] 82 sport-cycling + 4 cycling-coach package tests pass
- [x] All packages type-check (`pnpm -r check`)
- [x] Runtime smoke: non-TTY `cycling-coach </dev/null` → bot starts in pairing mode, `[security]` lines emitted to stderr, no orphan file
- [x] Runtime smoke: hand-edited `allowed-senders.json` with `dmPolicy: "open"` → falls back to pairing, warning logged
- [x] Runtime smoke: stranger session file present + no allowlist → bot defaults to pairing, **no auto-claim**
- [x] Runtime smoke: Ctrl+C during interactive startup-capture polling → clean exit, no zombies, no orphan file
- [ ] (Manual, needs live Telegram) Fresh setup wizard captures operator and writes allowlist
- [ ] (Manual) Operator decline at capture-confirm leaves no orphan file
- [ ] (Manual) Re-capture preserves existing `allowFrom` (Set-union)
- [ ] (Manual) Pairing-challenge rate-limit: 3 stranger DMs in 5s produce only one challenge reply