### PR TITLE
feat: section-11 Reference Wave 1b (runSync + scheduler + /sync + /snapshot)

### DIFF
--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -1,6 +1,6 @@
 # Context Map
 
-This repo is a multi-package monorepo for the enduragent AI coaching agent platform — Core publishes the Sport contract, sport packages implement it, binary packages ship them. See [`docs/architect-review/multi-sport-architecture.md`](./docs/architect-review/multi-sport-architecture.md) for the full architecture.
+This repo is a multi-package monorepo for the enduragent AI coaching agent platform — Core publishes the Sport contract, sport packages implement it, binary packages ship them. See [`docs/initiatives/multi-sport-refactor/architect-review/multi-sport-architecture.md`](./docs/initiatives/multi-sport-refactor/architect-review/multi-sport-architecture.md) for the full architecture.
 
 ## Contexts
 

--- a/packages/core/src/channels/telegram.ts
+++ b/packages/core/src/channels/telegram.ts
@@ -1,4 +1,4 @@
-import { Bot } from "grammy";
+import { Bot, InputFile } from "grammy";
 import type { CoachAgent } from "../agent/coach-agent.js";
 import type { BinaryConfig } from "../binary.js";
 import { isRateLimitError, extractRetryAfterMs } from "../agent/token-utils.js";
@@ -14,6 +14,16 @@ import { buildWhatsNewMessage } from "../release-notes.js";
 import { createAuthMiddleware } from "./telegram-access.js";
 import { loadAllowedSenders, loadAllowedSendersWithSource } from "./allowed-senders.js";
 import { escapeHtmlText } from "./html-escape.js";
+import type { RunSyncOpts, SyncResult } from "../reference/sync/run-sync.js";
+import type { LatestJson } from "../reference/schemas/latest.js";
+import { formatSyncReply } from "../reference/sync/format-sync-reply.js";
+import { formatSnapshotRaw } from "../reference/sync/snapshot-debug.js";
+import { sendSnapshotOutput } from "../reference/sync/send-snapshot.js";
+
+export interface ReferenceServices {
+  readonly runSync: (opts: RunSyncOpts) => Promise<SyncResult>;
+  readonly loadLatest: () => LatestJson | null;
+}
 
 function formatRateLimitWait(err: unknown): string {
   const ms = extractRetryAfterMs(err);
@@ -36,11 +46,19 @@ const WELCOME_MESSAGE =
   "/workout — Get today's workout\n" +
   "/status — Check current fitness, fatigue, and form\n" +
   "/review — Review your last session\n" +
-  "/sync — Push plan to intervals.icu calendar\n" +
+  "/sync — Force-refresh training data from intervals.icu\n" +
   "/version — Show current version\n" +
   "/whatsnew — See what changed in the latest version\n" +
   "/update — Check for and install updates\n\n" +
   "Or just chat with me about your training!";
+
+const SNAPSHOT_HELP =
+  "/snapshot raw [section]    — dump pre-curation latest.json (or one section)\n" +
+  "/snapshot help             — show this list\n\n" +
+  "Wave 7 will add: /snapshot, /snapshot metrics, /snapshot activities,\n" +
+  "/snapshot wellness, /snapshot intervals <id>, /snapshot routes <id>,\n" +
+  "/snapshot history, /snapshot ftp, /snapshot validation.\n\n" +
+  "Until then, only /snapshot raw is wired.";
 
 // Module-private factory: every Bot in this module is constructed here, with
 // the auth middleware registered FIRST. Future maintainers cannot add a handler
@@ -85,6 +103,7 @@ export function createTelegramBot(
   agent: CoachAgent,
   binary: BinaryConfig,
   dataDir: string,
+  reference?: ReferenceServices,
 ): Bot {
   logSecurityStartup(dataDir, binary.binaryName);
   const bot = createSecuredBot({ token, binary, dataDir });
@@ -150,21 +169,50 @@ export function createTelegramBot(
     }
   });
 
-  bot.command("sync", async (ctx) => {
-    await ctx.reply("Syncing plan to calendar...");
-    const chatId = `telegram:${ctx.chat.id}`;
-    try {
-      const response = await agent.chat(chatId, "/sync");
-      await sendLongMessage(ctx, response);
-    } catch (err) {
-      console.error("Error in /sync:", err);
-      if (isRateLimitError(err)) {
-        await ctx.reply(`Rate limited — please try again in ${formatRateLimitWait(err)}.`);
-      } else {
-        await ctx.reply("Sorry, something went wrong. Please try again.");
+  if (reference !== undefined) {
+    bot.command("sync", async (ctx) => {
+      await ctx.reply("Syncing training data from intervals.icu...");
+      try {
+        const result = await reference.runSync({
+          caller: "/sync",
+          chatId: `telegram:${ctx.chat.id}`,
+        });
+        await ctx.reply(formatSyncReply(result));
+      } catch (err) {
+        console.error("Error in /sync:", err);
+        await ctx.reply("Sorry, something went wrong syncing. Please try again.");
       }
-    }
-  });
+    });
+
+    bot.command("snapshot", async (ctx) => {
+      const args = (ctx.match ?? "").trim().split(/\s+/).filter(Boolean);
+      const sub = args[0]?.toLowerCase() ?? "help";
+
+      if (sub === "help") {
+        await ctx.reply(SNAPSHOT_HELP);
+        return;
+      }
+
+      if (sub === "raw") {
+        const section = args[1];
+        const latest = reference.loadLatest();
+        const output = formatSnapshotRaw(latest, section);
+        try {
+          await sendSnapshotOutput(output, {
+            reply: (text) => ctx.reply(text, { parse_mode: "Markdown" }) as Promise<unknown>,
+            sendDocument: (buffer, filename) =>
+              ctx.replyWithDocument(new InputFile(buffer, filename)) as Promise<unknown>,
+          });
+        } catch (err) {
+          console.error("Error in /snapshot raw:", err);
+          await ctx.reply("Sorry, something went wrong rendering the snapshot.");
+        }
+        return;
+      }
+
+      await ctx.reply(SNAPSHOT_HELP);
+    });
+  }
 
   bot.command("review", async (ctx) => {
     const args = (ctx.match ?? "").trim();

--- a/packages/core/src/io/atomic-write-file-sync.ts
+++ b/packages/core/src/io/atomic-write-file-sync.ts
@@ -1,0 +1,47 @@
+// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
+
+import {
+  closeSync,
+  fdatasyncSync,
+  openSync,
+  renameSync,
+  unlinkSync,
+  writeSync,
+} from "node:fs";
+import { randomBytes } from "node:crypto";
+
+/**
+ * Synchronous atomic-write of UTF-8 text content. Writes to a temp sibling,
+ * fdatasyncs, then renames to the target. On any failure the temp file is
+ * unlinked and the target at `path` (if any) is left untouched.
+ *
+ * Sync because the existing `MemoryStore` API surface is sync (writeSection,
+ * renameSection, appendDailyNote). The Reference module uses the async
+ * `atomicWriteJson` helper for its persisted state.
+ */
+export function atomicWriteFileSync(path: string, content: string): void {
+  const tempPath = `${path}.tmp.${randomBytes(4).toString("hex")}`;
+  let fd: number | null = null;
+  try {
+    fd = openSync(tempPath, "w", 0o644);
+    writeSync(fd, content, null, "utf-8");
+    fdatasyncSync(fd);
+    closeSync(fd);
+    fd = null;
+    renameSync(tempPath, path);
+  } catch (err) {
+    if (fd !== null) {
+      try {
+        closeSync(fd);
+      } catch {
+        // ignore — we're already in the error path.
+      }
+    }
+    try {
+      unlinkSync(tempPath);
+    } catch {
+      // Temp may not exist (open failed) or rename succeeded already.
+    }
+    throw err;
+  }
+}

--- a/packages/core/src/memory.ts
+++ b/packages/core/src/memory.ts
@@ -26,6 +26,16 @@ export interface MemoryStore {
    */
   renameSection(from: string, to: string): "renamed" | "noop" | "merged";
 
+  /**
+   * Apply multiple renames as a single read + single atomic write. Returns
+   * outcomes in the order of `renames`. Used by sport migrations so a partial
+   * rename cannot leave half-migrated state observable to subsequent init
+   * steps (architect-final concern 4 for Wave 1b / ADR-0011).
+   */
+  renameSections(
+    renames: ReadonlyArray<readonly [string, string]>,
+  ): Array<"renamed" | "noop" | "merged">;
+
   /** Reads today's daily-notes file (or for `date` when supplied). */
   readDailyNotes(date?: string): string;
 

--- a/packages/core/src/memory/store.ts
+++ b/packages/core/src/memory/store.ts
@@ -1,7 +1,8 @@
-import { readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
+import { readFileSync, mkdirSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import type { MemoryStore } from "../memory.js";
 import { todayInTZ } from "../agent/user-time.js";
+import { atomicWriteFileSync } from "../io/atomic-write-file-sync.js";
 
 // ============================================================================
 // MEMORY SYSTEM
@@ -10,6 +11,36 @@ import { todayInTZ } from "../agent/user-time.js";
 const SECTION_SPLIT = /(?=^## )/m;
 const markerOf = (section: string) => `## ${section}`;
 const bodyOf = (block: string) => block.slice(block.indexOf("\n") + 1);
+
+type RenameOutcome = "renamed" | "noop" | "merged";
+
+/**
+ * Apply a single section rename to an in-memory `parts` array (split by
+ * `SECTION_SPLIT`). Pure function so `renameSection` and `renameSections`
+ * share the same logic; `renameSections` chains multiple renames in memory
+ * before a single atomic write.
+ */
+function applyRename(
+  parts: string[],
+  from: string,
+  to: string,
+): { parts: string[]; outcome: RenameOutcome } {
+  const fromMarker = markerOf(from);
+  const toMarker = markerOf(to);
+  const fromIdx = parts.findIndex((p) => p.startsWith(fromMarker + "\n"));
+  if (fromIdx < 0) return { parts, outcome: "noop" };
+
+  const toIdx = parts.findIndex((p) => p.startsWith(toMarker + "\n"));
+
+  if (toIdx >= 0) {
+    parts[toIdx] = `${toMarker}\n${bodyOf(parts[toIdx])}\n${bodyOf(parts[fromIdx])}`;
+    parts.splice(fromIdx, 1);
+    return { parts, outcome: "merged" };
+  }
+
+  parts[fromIdx] = `${toMarker}\n${bodyOf(parts[fromIdx])}`;
+  return { parts, outcome: "renamed" };
+}
 
 export class Memory implements MemoryStore {
   private memoryDir: string;
@@ -43,7 +74,7 @@ export class Memory implements MemoryStore {
     const newBlock = `${marker}\n${content}\n`;
 
     if (!existing) {
-      writeFileSync(path, newBlock, "utf-8");
+      atomicWriteFileSync(path, newBlock);
       return;
     }
 
@@ -52,10 +83,10 @@ export class Memory implements MemoryStore {
 
     if (idx >= 0) {
       parts[idx] = newBlock;
-      writeFileSync(path, parts.join(""), "utf-8");
+      atomicWriteFileSync(path, parts.join(""));
     } else {
       // Append at end (preserves legacy content not covered by any known section)
-      writeFileSync(path, existing.trimEnd() + "\n\n" + newBlock, "utf-8");
+      atomicWriteFileSync(path, existing.trimEnd() + "\n\n" + newBlock);
     }
   }
 
@@ -70,29 +101,43 @@ export class Memory implements MemoryStore {
     return body.endsWith("\n") ? body.slice(0, -1) : body;
   }
 
-  renameSection(from: string, to: string): "renamed" | "noop" | "merged" {
+  renameSection(from: string, to: string): RenameOutcome {
     const path = join(this.memoryDir, "MEMORY.md");
     const content = this.readMemory();
     if (!content) return "noop";
 
-    const fromMarker = markerOf(from);
-    const toMarker = markerOf(to);
-    const parts = content.split(SECTION_SPLIT);
-    const fromIdx = parts.findIndex((p) => p.startsWith(fromMarker + "\n"));
-    if (fromIdx < 0) return "noop";
+    const { parts, outcome } = applyRename(content.split(SECTION_SPLIT), from, to);
+    if (outcome === "noop") return outcome;
 
-    const toIdx = parts.findIndex((p) => p.startsWith(toMarker + "\n"));
+    atomicWriteFileSync(path, parts.join(""));
+    return outcome;
+  }
 
-    if (toIdx >= 0) {
-      parts[toIdx] = `${toMarker}\n${bodyOf(parts[toIdx])}\n${bodyOf(parts[fromIdx])}`;
-      parts.splice(fromIdx, 1);
-      writeFileSync(path, parts.join(""), "utf-8");
-      return "merged";
+  /**
+   * Apply multiple section renames as a single read + single atomic write.
+   * Used by the cycling-coach legacy migration so a partial migration cannot
+   * be observed by Reference initialization (architect-final concern 4 for
+   * Wave 1b). Returns the per-rename outcomes in the same order as `renames`.
+   */
+  renameSections(
+    renames: ReadonlyArray<readonly [string, string]>,
+  ): RenameOutcome[] {
+    const path = join(this.memoryDir, "MEMORY.md");
+    const content = this.readMemory();
+    if (!content) return renames.map(() => "noop" as const);
+
+    let parts = content.split(SECTION_SPLIT);
+    const outcomes: RenameOutcome[] = [];
+    let mutated = false;
+    for (const [from, to] of renames) {
+      const result = applyRename(parts, from, to);
+      parts = result.parts;
+      outcomes.push(result.outcome);
+      if (result.outcome !== "noop") mutated = true;
     }
 
-    parts[fromIdx] = `${toMarker}\n${bodyOf(parts[fromIdx])}`;
-    writeFileSync(path, parts.join(""), "utf-8");
-    return "renamed";
+    if (mutated) atomicWriteFileSync(path, parts.join(""));
+    return outcomes;
   }
 
   /** @deprecated Use writeSection instead */
@@ -100,7 +145,7 @@ export class Memory implements MemoryStore {
     const path = join(this.memoryDir, "MEMORY.md");
     const existing = this.readMemory();
     const updated = existing ? `${existing}\n${entry}` : entry;
-    writeFileSync(path, updated, "utf-8");
+    atomicWriteFileSync(path, updated);
   }
 
   // ── Daily notes ────────────────────────────────────────────────────────
@@ -117,14 +162,14 @@ export class Memory implements MemoryStore {
     const path = join(this.memoryDir, `${d}.md`);
     const existing = this.readDailyNotes(d);
     const updated = existing ? `${existing}\n${note}` : note;
-    writeFileSync(path, updated, "utf-8");
+    atomicWriteFileSync(path, updated);
   }
 
   // ── Plans ──────────────────────────────────────────────────────────────
 
   savePlan(plan: unknown): void {
     const path = join(this.plansDir, "current-plan.json");
-    writeFileSync(path, JSON.stringify(plan, null, 2), "utf-8");
+    atomicWriteFileSync(path, JSON.stringify(plan, null, 2));
   }
 
   loadPlan(): unknown | null {

--- a/packages/core/src/memory/store.ts
+++ b/packages/core/src/memory/store.ts
@@ -15,31 +15,27 @@ const bodyOf = (block: string) => block.slice(block.indexOf("\n") + 1);
 type RenameOutcome = "renamed" | "noop" | "merged";
 
 /**
- * Apply a single section rename to an in-memory `parts` array (split by
- * `SECTION_SPLIT`). Pure function so `renameSection` and `renameSections`
- * share the same logic; `renameSections` chains multiple renames in memory
- * before a single atomic write.
+ * Apply a single section rename to `parts` IN PLACE. Shared between
+ * `renameSection` (one rename + write) and `renameSections` (chain of
+ * renames + single write); the in-place contract lets `renameSections`
+ * chain without copying the array between iterations.
  */
-function applyRename(
-  parts: string[],
-  from: string,
-  to: string,
-): { parts: string[]; outcome: RenameOutcome } {
+function applyRename(parts: string[], from: string, to: string): RenameOutcome {
   const fromMarker = markerOf(from);
   const toMarker = markerOf(to);
   const fromIdx = parts.findIndex((p) => p.startsWith(fromMarker + "\n"));
-  if (fromIdx < 0) return { parts, outcome: "noop" };
+  if (fromIdx < 0) return "noop";
 
   const toIdx = parts.findIndex((p) => p.startsWith(toMarker + "\n"));
 
   if (toIdx >= 0) {
     parts[toIdx] = `${toMarker}\n${bodyOf(parts[toIdx])}\n${bodyOf(parts[fromIdx])}`;
     parts.splice(fromIdx, 1);
-    return { parts, outcome: "merged" };
+    return "merged";
   }
 
   parts[fromIdx] = `${toMarker}\n${bodyOf(parts[fromIdx])}`;
-  return { parts, outcome: "renamed" };
+  return "renamed";
 }
 
 export class Memory implements MemoryStore {
@@ -106,7 +102,8 @@ export class Memory implements MemoryStore {
     const content = this.readMemory();
     if (!content) return "noop";
 
-    const { parts, outcome } = applyRename(content.split(SECTION_SPLIT), from, to);
+    const parts = content.split(SECTION_SPLIT);
+    const outcome = applyRename(parts, from, to);
     if (outcome === "noop") return outcome;
 
     atomicWriteFileSync(path, parts.join(""));
@@ -126,14 +123,13 @@ export class Memory implements MemoryStore {
     const content = this.readMemory();
     if (!content) return renames.map(() => "noop" as const);
 
-    let parts = content.split(SECTION_SPLIT);
+    const parts = content.split(SECTION_SPLIT);
     const outcomes: RenameOutcome[] = [];
     let mutated = false;
     for (const [from, to] of renames) {
-      const result = applyRename(parts, from, to);
-      parts = result.parts;
-      outcomes.push(result.outcome);
-      if (result.outcome !== "noop") mutated = true;
+      const outcome = applyRename(parts, from, to);
+      outcomes.push(outcome);
+      if (outcome !== "noop") mutated = true;
     }
 
     if (mutated) atomicWriteFileSync(path, parts.join(""));

--- a/packages/core/src/reference/freshness.ts
+++ b/packages/core/src/reference/freshness.ts
@@ -7,8 +7,6 @@
 // ─── Freshness windows (since `last_updated` in latest.json) ───────────
 /** <24 h: data is fresh; coaching uses it without caveat. */
 export const FRESH_MS = 24 * 60 * 60 * 1000;
-/** 24-48 h: data is borderline; flag in metadata, no behavior change. */
-export const FLAG_MS = 48 * 60 * 60 * 1000;
 /** >48 h: data is stale; trigger lazy refresh in the background. */
 export const STALE_MS = 48 * 60 * 60 * 1000;
 /** >7 d: data is critical; force a fresh sync before answering. */

--- a/packages/core/src/reference/freshness.ts
+++ b/packages/core/src/reference/freshness.ts
@@ -47,3 +47,15 @@ export const SYNC_COOLDOWN_MS = 30_000;
 export const MUTEX_HOT_WARN_MS = 10_000;
 /** Scheduled refresh cadence (in-process timer). */
 export const SCHEDULED_SYNC_INTERVAL_MS = 30 * 60 * 1000;
+/**
+ * Per-request HTTP timeout chained with the orchestrator-level signal so a
+ * single hung endpoint cannot consume the full SYNC_OPERATION_TIMEOUT_MS
+ * budget (ADR-0011, point 2).
+ */
+export const PER_REQUEST_TIMEOUT_MS = 30_000;
+
+// ─── /snapshot raw chunked-vs-document dispatch (F5) ────────────────────
+/** If `formatSnapshotRaw` produces more chunks than this, send as a document. */
+export const SNAPSHOT_DOCUMENT_THRESHOLD_CHUNKS = 10;
+/** If the raw dump exceeds this byte budget, send as a document instead of chunked replies. */
+export const SNAPSHOT_DOCUMENT_THRESHOLD_BYTES = 65_536;

--- a/packages/core/src/reference/index.ts
+++ b/packages/core/src/reference/index.ts
@@ -14,7 +14,6 @@ export type {
 // ─── Constants ────────────────────────────────────────────────────────
 export {
   FRESH_MS,
-  FLAG_MS,
   STALE_MS,
   CRITICAL_MS,
   LATEST_RETENTION_DAYS,

--- a/packages/core/src/reference/schemas/error-state.ts
+++ b/packages/core/src/reference/schemas/error-state.ts
@@ -11,12 +11,27 @@ export const ERROR_STATE_SCHEMA_VERSION = "1";
  * the latest data" block in the system prompt. Cleared on the next
  * successful sync.
  */
+/**
+ * `phase` is set by `runSync()` when the outer 2-min timeout fires, so the
+ * Wave 4 / Wave 5 readers can tell whether cache files made it to disk.
+ * Other failure modes (Layer-1 gate reject, etc.) omit it.
+ */
+export const ErrorPhaseSchema = z.enum([
+  "fetching",
+  "gating",
+  "writing_cache",
+  "writing_scheduler",
+]);
+
+export type ErrorPhase = z.infer<typeof ErrorPhaseSchema>;
+
 export const ErrorStateSchema = z
   .object({
     schema_version: z.string(),
     step: z.string(),
     detail: z.string(),
     ts: z.string(),
+    phase: ErrorPhaseSchema.optional(),
   })
   .strict();
 

--- a/packages/core/src/reference/sync/abort-budget.ts
+++ b/packages/core/src/reference/sync/abort-budget.ts
@@ -1,0 +1,12 @@
+// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
+
+/**
+ * Compose a per-runSync orchestrator signal with a per-request timeout
+ * budget. Either source aborting fires the returned signal. Used by the
+ * intervals-icu wrapper-fetch to enforce both "the outer 2-min orchestrator
+ * timeout cancels every in-flight request" AND "no single request consumes
+ * the whole orchestrator budget" per ADR-0011.
+ */
+export function chainedSignal(opts: { outer: AbortSignal; perRequestMs: number }): AbortSignal {
+  return AbortSignal.any([opts.outer, AbortSignal.timeout(opts.perRequestMs)]);
+}

--- a/packages/core/src/reference/sync/cooldown.ts
+++ b/packages/core/src/reference/sync/cooldown.ts
@@ -19,8 +19,16 @@ export class Cooldown {
   check(key: string, windowMs: number): { ok: true } | { ok: false; retryAfterMs: number } {
     const last = this.timestamps.get(key);
     if (last === undefined) return { ok: true };
-    const elapsed = this.now() - last;
-    if (elapsed >= windowMs) return { ok: true };
+    // Clamp to non-negative: an NTP correction (or VM time-sync) can push the
+    // wall clock backwards, making `now() < last`. Without the clamp we'd
+    // report `retryAfterMs > windowMs` to the caller.
+    const elapsed = Math.max(0, this.now() - last);
+    if (elapsed >= windowMs) {
+      // Drop the entry — it's no longer load-bearing and would otherwise
+      // accumulate per unique key for the lifetime of the process.
+      this.timestamps.delete(key);
+      return { ok: true };
+    }
     return { ok: false, retryAfterMs: windowMs - elapsed };
   }
 

--- a/packages/core/src/reference/sync/cooldown.ts
+++ b/packages/core/src/reference/sync/cooldown.ts
@@ -1,0 +1,30 @@
+// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
+
+/**
+ * Per-key cooldown tracker for `/sync` rate-limiting. In-process by design
+ * (Decision 5 in F4 spec) — Reference is single-operator; restart-spam is
+ * bounded by mutex serialization + intervals.icu's server-side rate-limit.
+ *
+ * `check` is observation only; `record` stamps the success path. The
+ * runSync caller pattern is: check → if ok, record after the sync settles.
+ */
+export class Cooldown {
+  private readonly timestamps = new Map<string, number>();
+  private readonly now: () => number;
+
+  constructor(now: () => number = Date.now) {
+    this.now = now;
+  }
+
+  check(key: string, windowMs: number): { ok: true } | { ok: false; retryAfterMs: number } {
+    const last = this.timestamps.get(key);
+    if (last === undefined) return { ok: true };
+    const elapsed = this.now() - last;
+    if (elapsed >= windowMs) return { ok: true };
+    return { ok: false, retryAfterMs: windowMs - elapsed };
+  }
+
+  record(key: string): void {
+    this.timestamps.set(key, this.now());
+  }
+}

--- a/packages/core/src/reference/sync/error-state-writer.ts
+++ b/packages/core/src/reference/sync/error-state-writer.ts
@@ -1,0 +1,29 @@
+// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
+
+import { join } from "node:path";
+import {
+  ERROR_STATE_SCHEMA_VERSION,
+  type ErrorPhase,
+} from "../schemas/error-state.js";
+import { atomicWriteJson } from "../io/atomic-write.js";
+
+export type { ErrorPhase };
+
+/**
+ * Atomic-write `error_state.json` to the data dir. Called by `runSync()`
+ * when the outer 2-min timeout fires (with `phase` set per ADR-0011's
+ * commit-marker-last write order) or when the Layer-1 gate rejects a fetch
+ * (with `phase` omitted). Cleared on the next successful sync.
+ */
+export async function writeErrorState(
+  dataDir: string,
+  payload: { step: string; detail: string; phase?: ErrorPhase },
+): Promise<void> {
+  await atomicWriteJson(join(dataDir, "error_state.json"), {
+    schema_version: ERROR_STATE_SCHEMA_VERSION,
+    step: payload.step,
+    detail: payload.detail,
+    ts: new Date().toISOString(),
+    ...(payload.phase !== undefined ? { phase: payload.phase } : {}),
+  });
+}

--- a/packages/core/src/reference/sync/fetch-reference-data.ts
+++ b/packages/core/src/reference/sync/fetch-reference-data.ts
@@ -1,0 +1,48 @@
+// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
+
+import type { IntervalsClient } from "intervals-icu-api";
+import type { FetchedReference } from "./run-sync.js";
+import { makeAbortableClient } from "./intervals-client-factory.js";
+import { PER_REQUEST_TIMEOUT_MS } from "../freshness.js";
+
+/**
+ * Wave 1b production fetcher. Wave 2 / F11 fleshes out per-metric population;
+ * Wave 1b just proves the orchestration writes a parseable cache for the
+ * scheduler-and-snapshot debug surface to read. Constructs a per-runSync
+ * `IntervalsClient` (per ADR-0011) so the orchestrator's outer
+ * `AbortController` propagates into in-flight requests.
+ */
+export function makeProductionFetcher(deps: {
+  apiKey: string;
+  athleteId?: string;
+}): (signal: AbortSignal) => Promise<FetchedReference> {
+  return async (signal) => {
+    const client = makeAbortableClient({
+      apiKey: deps.apiKey,
+      athleteId: deps.athleteId,
+      signal,
+      perRequestMs: PER_REQUEST_TIMEOUT_MS,
+    });
+    return await fetchOnce(client);
+  };
+}
+
+async function fetchOnce(client: IntervalsClient): Promise<FetchedReference> {
+  const athleteResult = await client.athlete.get();
+  const athlete = athleteResult.ok ? athleteResult.value : {};
+
+  return {
+    latest: {
+      athlete_profile: athlete,
+      current_status: {},
+      derived_metrics: {},
+      recent_activities: [],
+      planned_workouts: [],
+      wellness_data: {},
+    },
+    history: { daily: [], weekly: [], monthly: [] },
+    intervals: { by_activity: {} },
+    routes: { routes: [] },
+    ftp_history: { entries: [] },
+  };
+}

--- a/packages/core/src/reference/sync/format-sync-reply.ts
+++ b/packages/core/src/reference/sync/format-sync-reply.ts
@@ -1,0 +1,61 @@
+// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
+
+import type { SyncResult } from "./run-sync.js";
+
+/**
+ * Render a `SyncResult` as athlete-facing prose for the `/sync` Telegram
+ * reply. Spec shape per F4 (US-18):
+ *
+ * ```
+ * Sync ✅
+ * Last sync: 2026-05-09 14:23 UTC (32s ago)
+ * Refreshed: latest, history, intervals
+ * Failures: routes (intervals.icu 503; will retry next tick)
+ * ```
+ *
+ * Plus cooldown / mutex_held / unreachable variants. Pure function over a
+ * clock so tests can pin "now."
+ */
+export function formatSyncReply(result: SyncResult, now: Date = new Date()): string {
+  if (result.skipped === "cooldown") {
+    const retrySec = Math.ceil((result.retryAfterMs ?? 0) / 1000);
+    return `Just synced — please wait ${retrySec}s before forcing another refresh.`;
+  }
+
+  if (result.skipped === "mutex_held") {
+    return "Another sync in progress — please retry in a moment.";
+  }
+
+  if (!result.ok) {
+    const last = result.lastSyncAt
+      ? `\nLast good sync: ${formatTimestamp(result.lastSyncAt, now)}`
+      : "";
+    return `I can't reach intervals.icu right now.${last}`;
+  }
+
+  const lastLine = result.lastSyncAt
+    ? `Last sync: ${formatTimestamp(result.lastSyncAt, now)}`
+    : "Last sync: just now";
+  const refreshedLine = `Refreshed: ${result.refreshed.join(", ")}`;
+  const failuresLine =
+    result.failures.length > 0
+      ? `\nFailures: ${result.failures
+          .map((f) => `${f.file} (${f.reason})`)
+          .join(", ")}`
+      : "";
+  return `Sync ✅\n${lastLine}\n${refreshedLine}${failuresLine}`;
+}
+
+function formatTimestamp(iso: string, now: Date): string {
+  const d = new Date(iso);
+  const diffMs = Math.max(0, now.getTime() - d.getTime());
+  const diffSec = Math.round(diffMs / 1000);
+  const ago =
+    diffSec < 60
+      ? `${diffSec}s ago`
+      : diffSec < 3600
+        ? `${Math.round(diffSec / 60)} min ago`
+        : `${Math.round(diffSec / 3600)} h ago`;
+  const utc = `${d.toISOString().slice(0, 16).replace("T", " ")} UTC`;
+  return `${utc} (${ago})`;
+}

--- a/packages/core/src/reference/sync/freshness-check.ts
+++ b/packages/core/src/reference/sync/freshness-check.ts
@@ -1,0 +1,22 @@
+// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
+
+import { CRITICAL_MS, FRESH_MS, STALE_MS } from "../freshness.js";
+
+export type Freshness = "fresh" | "flag" | "stale" | "critical";
+
+/**
+ * Map a cache file's `metadata.last_updated` to one of four freshness bands
+ * per Reference PRD Decision 5: fresh (<24h), flag (24-48h), stale
+ * (48h-7d, triggers lazy refresh), critical (>7d, force sync before
+ * answering). Pure function over a clock so tests can pin "now."
+ */
+export function freshnessOf(
+  metadata: { last_updated: string },
+  now: Date = new Date(),
+): Freshness {
+  const elapsed = now.getTime() - new Date(metadata.last_updated).getTime();
+  if (elapsed >= CRITICAL_MS) return "critical";
+  if (elapsed >= STALE_MS) return "stale";
+  if (elapsed >= FRESH_MS) return "flag";
+  return "fresh";
+}

--- a/packages/core/src/reference/sync/intervals-client-factory.ts
+++ b/packages/core/src/reference/sync/intervals-client-factory.ts
@@ -1,0 +1,54 @@
+// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
+
+import { IntervalsClient } from "intervals-icu-api";
+import { chainedSignal } from "./abort-budget.js";
+
+/**
+ * Construct a fetch wrapper that injects a chained `AbortSignal` (orchestrator
+ * signal + per-request timeout) into every request's `init`. Per ADR-0011:
+ * one hung endpoint never consumes the orchestrator's full timeout budget.
+ *
+ * Exported separately from `makeAbortableClient` so tests can verify the
+ * wrapper's signal-threading without spinning up a real `IntervalsClient`.
+ */
+export function wrapFetchWithSignal(opts: {
+  baseFetch: typeof globalThis.fetch;
+  outer: AbortSignal;
+  perRequestMs: number;
+}): typeof globalThis.fetch {
+  return (input, init) =>
+    opts.baseFetch(input, {
+      ...init,
+      signal: chainedSignal({ outer: opts.outer, perRequestMs: opts.perRequestMs }),
+    });
+}
+
+/**
+ * Per-`runSync` IntervalsClient. Wraps `globalThis.fetch` with the abortable
+ * shim above, and disables lib-side retry (`maxAttempts: 1`) so an
+ * outer-timeout abort propagates into `AbortError` without the lib silently
+ * recovering. Reference's own retry-after / rate-limit handling lives at the
+ * orchestrator layer (per ADR-0011), not at the client layer.
+ *
+ * `intervals-icu-api@0.1.2` does not expose `signal?: AbortSignal` on its
+ * resource methods; the constructor's `fetch` option is the only injection
+ * point. Track upstream PR at
+ * `docs/initiatives/section-11/learnings/upstream-intervals-icu-abort-signal.md`.
+ */
+export function makeAbortableClient(opts: {
+  apiKey: string;
+  athleteId?: string;
+  signal: AbortSignal;
+  perRequestMs: number;
+}): IntervalsClient {
+  return new IntervalsClient({
+    apiKey: opts.apiKey,
+    athleteId: opts.athleteId,
+    fetch: wrapFetchWithSignal({
+      baseFetch: globalThis.fetch,
+      outer: opts.signal,
+      perRequestMs: opts.perRequestMs,
+    }),
+    retry: { maxAttempts: 1 },
+  });
+}

--- a/packages/core/src/reference/sync/mutex.ts
+++ b/packages/core/src/reference/sync/mutex.ts
@@ -1,0 +1,98 @@
+// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
+
+/**
+ * Non-reentrant async mutex per ADR-0011. Single-owner with a FIFO waiter
+ * queue. Each waiter has its own acquire-timeout — timed-out waiters never
+ * acquire the lock and never run the body. `runExclusive` is the only
+ * public API; ownership state is private.
+ */
+
+interface Waiter {
+  signalAcquired: () => void;
+  timeoutHandle: ReturnType<typeof setTimeout> | null;
+  acquired: boolean;
+  timedOut: boolean;
+}
+
+export class AsyncMutex {
+  private heldBy: Waiter | null = null;
+  private waiters: Waiter[] = [];
+
+  isHeld(): boolean {
+    return this.heldBy !== null;
+  }
+
+  async runExclusive<T>(
+    fn: () => Promise<T>,
+    opts: { acquireTimeoutMs: number; hotWarnMs: number; caller: string },
+  ): Promise<{ kind: "ran"; value: T } | { kind: "timeout" }> {
+    const enqueuedAt = Date.now();
+    const waiter: Waiter = {
+      signalAcquired: () => {},
+      timeoutHandle: null,
+      acquired: false,
+      timedOut: false,
+    };
+    let hotWarnHandle: ReturnType<typeof setTimeout> | null = null;
+    const clearHotWarn = () => {
+      if (hotWarnHandle !== null) {
+        clearTimeout(hotWarnHandle);
+        hotWarnHandle = null;
+      }
+    };
+
+    const acquired = await new Promise<boolean>((resolve) => {
+      waiter.signalAcquired = () => {
+        if (waiter.timedOut) return;
+        waiter.acquired = true;
+        if (waiter.timeoutHandle !== null) {
+          clearTimeout(waiter.timeoutHandle);
+          waiter.timeoutHandle = null;
+        }
+        clearHotWarn();
+        resolve(true);
+      };
+      waiter.timeoutHandle = setTimeout(() => {
+        if (waiter.acquired) return;
+        waiter.timedOut = true;
+        clearHotWarn();
+        const idx = this.waiters.indexOf(waiter);
+        if (idx >= 0) this.waiters.splice(idx, 1);
+        resolve(false);
+      }, opts.acquireTimeoutMs);
+
+      if (this.heldBy === null) {
+        this.heldBy = waiter;
+        waiter.signalAcquired();
+      } else {
+        this.waiters.push(waiter);
+        hotWarnHandle = setTimeout(() => {
+          console.warn(
+            JSON.stringify({
+              event: "reference_mutex_hot",
+              wait_ms: Date.now() - enqueuedAt,
+              caller: opts.caller,
+              ts: new Date().toISOString(),
+            }),
+          );
+        }, opts.hotWarnMs);
+      }
+    });
+
+    if (!acquired) return { kind: "timeout" };
+
+    try {
+      const value = await fn();
+      return { kind: "ran", value };
+    } finally {
+      if (this.heldBy === waiter) {
+        this.heldBy = null;
+        const next = this.waiters.shift();
+        if (next !== undefined) {
+          this.heldBy = next;
+          next.signalAcquired();
+        }
+      }
+    }
+  }
+}

--- a/packages/core/src/reference/sync/run-sync.ts
+++ b/packages/core/src/reference/sync/run-sync.ts
@@ -143,30 +143,35 @@ export function createRunSync(
           const lastUpdated = now().toISOString();
           phase.current = "writing_cache";
 
-          await writeJson(join(deps.dataDir, "latest.json"), {
-            metadata: {
-              schema_version: LATEST_SCHEMA_VERSION,
-              last_updated: lastUpdated,
-              freshness: "fresh",
-            },
-            ...fetched.latest,
-          });
-          await writeJson(join(deps.dataDir, "history.json"), {
-            metadata: { schema_version: HISTORY_SCHEMA_VERSION, last_updated: lastUpdated },
-            ...fetched.history,
-          });
-          await writeJson(join(deps.dataDir, "intervals.json"), {
-            metadata: { schema_version: INTERVALS_SCHEMA_VERSION, last_updated: lastUpdated },
-            ...fetched.intervals,
-          });
-          await writeJson(join(deps.dataDir, "routes.json"), {
-            metadata: { schema_version: ROUTES_SCHEMA_VERSION, last_updated: lastUpdated },
-            ...fetched.routes,
-          });
-          await writeJson(join(deps.dataDir, "ftp_history.json"), {
-            metadata: { schema_version: FTP_HISTORY_SCHEMA_VERSION, last_updated: lastUpdated },
-            ...fetched.ftp_history,
-          });
+          // Cache files are independent — parallelize. ADR-0011 only requires
+          // `.scheduler.json` (commit marker) to land LAST; that write follows
+          // the Promise.all below.
+          await Promise.all([
+            writeJson(join(deps.dataDir, "latest.json"), {
+              metadata: {
+                schema_version: LATEST_SCHEMA_VERSION,
+                last_updated: lastUpdated,
+                freshness: "fresh",
+              },
+              ...fetched.latest,
+            }),
+            writeJson(join(deps.dataDir, "history.json"), {
+              metadata: { schema_version: HISTORY_SCHEMA_VERSION, last_updated: lastUpdated },
+              ...fetched.history,
+            }),
+            writeJson(join(deps.dataDir, "intervals.json"), {
+              metadata: { schema_version: INTERVALS_SCHEMA_VERSION, last_updated: lastUpdated },
+              ...fetched.intervals,
+            }),
+            writeJson(join(deps.dataDir, "routes.json"), {
+              metadata: { schema_version: ROUTES_SCHEMA_VERSION, last_updated: lastUpdated },
+              ...fetched.routes,
+            }),
+            writeJson(join(deps.dataDir, "ftp_history.json"), {
+              metadata: { schema_version: FTP_HISTORY_SCHEMA_VERSION, last_updated: lastUpdated },
+              ...fetched.ftp_history,
+            }),
+          ]);
 
           // Commit-marker LAST per ADR-0011.
           phase.current = "writing_scheduler";

--- a/packages/core/src/reference/sync/run-sync.ts
+++ b/packages/core/src/reference/sync/run-sync.ts
@@ -1,0 +1,241 @@
+// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
+
+import { join } from "node:path";
+import {
+  MUTEX_ACQUIRE_TIMEOUT_MS,
+  MUTEX_HOT_WARN_MS,
+  SCHEDULED_SYNC_INTERVAL_MS,
+  SYNC_OPERATION_TIMEOUT_MS,
+} from "../freshness.js";
+import { atomicWriteJson } from "../io/atomic-write.js";
+import { LATEST_SCHEMA_VERSION } from "../schemas/latest.js";
+import { HISTORY_SCHEMA_VERSION } from "../schemas/history.js";
+import { INTERVALS_SCHEMA_VERSION } from "../schemas/intervals.js";
+import { ROUTES_SCHEMA_VERSION } from "../schemas/routes.js";
+import { FTP_HISTORY_SCHEMA_VERSION } from "../schemas/ftp-history.js";
+import { SCHEDULER_SCHEMA_VERSION } from "../schemas/scheduler.js";
+import type { ErrorPhase } from "../schemas/error-state.js";
+import { gateLatestJson } from "../validation/sync-gate.js";
+import { writeErrorState } from "./error-state-writer.js";
+import type { AsyncMutex } from "./mutex.js";
+import type { Cooldown } from "./cooldown.js";
+
+export type SyncCaller = "scheduled" | "lazy" | "/sync";
+
+export interface RunSyncOpts {
+  readonly forceFresh?: boolean;
+  readonly extendRetentionUntil?: string;
+  readonly caller?: SyncCaller;
+  /** Required when `caller === "/sync"` for per-chat cooldown gating. */
+  readonly chatId?: string;
+}
+
+export type CacheFile = "latest" | "history" | "intervals" | "routes" | "ftp_history";
+
+export interface SyncResult {
+  readonly ok: boolean;
+  readonly lastSyncAt?: string;
+  readonly refreshed: readonly CacheFile[];
+  readonly failures: readonly { file: string; reason: string }[];
+  readonly skipped?: "mutex_held" | "cooldown";
+  readonly retryAfterMs?: number;
+}
+
+export interface FetchedReference {
+  readonly latest: {
+    readonly athlete_profile: unknown;
+    readonly current_status: unknown;
+    readonly derived_metrics: unknown;
+    readonly recent_activities: readonly unknown[];
+    readonly planned_workouts: readonly unknown[];
+    readonly wellness_data: unknown;
+  };
+  readonly history: {
+    readonly daily: readonly unknown[];
+    readonly weekly: readonly unknown[];
+    readonly monthly: readonly unknown[];
+  };
+  readonly intervals: {
+    readonly by_activity: Readonly<Record<string, readonly unknown[]>>;
+  };
+  readonly routes: { readonly routes: readonly unknown[] };
+  readonly ftp_history: { readonly entries: readonly unknown[] };
+}
+
+export interface RunSyncDeps {
+  readonly dataDir: string;
+  readonly mutex: AsyncMutex;
+  readonly cooldown: Cooldown;
+  readonly cooldownWindowMs: number;
+  readonly fetchReferenceData: (signal: AbortSignal) => Promise<FetchedReference>;
+  readonly now?: () => Date;
+  /** Override timing constants for tests; defaults from `freshness.ts`. */
+  readonly timing?: {
+    readonly acquireTimeoutMs?: number;
+    readonly hotWarnMs?: number;
+    readonly outerTimeoutMs?: number;
+    readonly scheduledIntervalMs?: number;
+  };
+  /** Override Layer-1 gate for tests; defaults to the Wave-1 stub `gateLatestJson`. */
+  readonly gate?: typeof gateLatestJson;
+  /** Override atomic write for tests; defaults to `atomicWriteJson`. */
+  readonly atomicWrite?: (path: string, value: unknown) => Promise<void>;
+}
+
+const ALL_FILES: readonly CacheFile[] = [
+  "latest",
+  "history",
+  "intervals",
+  "routes",
+  "ftp_history",
+];
+
+export function createRunSync(
+  deps: RunSyncDeps,
+): (opts?: RunSyncOpts) => Promise<SyncResult> {
+  const now = deps.now ?? (() => new Date());
+  const acquireTimeoutMs = deps.timing?.acquireTimeoutMs ?? MUTEX_ACQUIRE_TIMEOUT_MS;
+  const hotWarnMs = deps.timing?.hotWarnMs ?? MUTEX_HOT_WARN_MS;
+  const outerTimeoutMs = deps.timing?.outerTimeoutMs ?? SYNC_OPERATION_TIMEOUT_MS;
+  const scheduledIntervalMs = deps.timing?.scheduledIntervalMs ?? SCHEDULED_SYNC_INTERVAL_MS;
+  const gate = deps.gate ?? gateLatestJson;
+  const writeJson = deps.atomicWrite ?? atomicWriteJson;
+
+  return async (opts = {}) => {
+    if (opts.caller === "/sync" && opts.chatId !== undefined) {
+      const c = deps.cooldown.check(opts.chatId, deps.cooldownWindowMs);
+      if (!c.ok) {
+        return {
+          ok: true,
+          refreshed: [],
+          failures: [],
+          skipped: "cooldown",
+          retryAfterMs: c.retryAfterMs,
+        };
+      }
+    }
+
+    const mutexResult = await deps.mutex.runExclusive(
+      async (): Promise<SyncResult> => {
+        const controller = new AbortController();
+        const phase = { current: "fetching" as ErrorPhase };
+
+        const body = async (): Promise<SyncResult> => {
+          const fetched = await deps.fetchReferenceData(controller.signal);
+
+          phase.current = "gating";
+          const gateResult = gate(fetched, null);
+          if (!gateResult.ok) {
+            await writeErrorState(deps.dataDir, {
+              step: "gate_rejected",
+              detail: gateResult.failures.map((f) => `${f.step}: ${f.detail}`).join("; "),
+            });
+            return {
+              ok: false,
+              refreshed: [],
+              failures: gateResult.failures.map((f) => ({
+                file: "latest",
+                reason: `${f.step}: ${f.detail}`,
+              })),
+            };
+          }
+
+          const lastUpdated = now().toISOString();
+          phase.current = "writing_cache";
+
+          await writeJson(join(deps.dataDir, "latest.json"), {
+            metadata: {
+              schema_version: LATEST_SCHEMA_VERSION,
+              last_updated: lastUpdated,
+              freshness: "fresh",
+            },
+            ...fetched.latest,
+          });
+          await writeJson(join(deps.dataDir, "history.json"), {
+            metadata: { schema_version: HISTORY_SCHEMA_VERSION, last_updated: lastUpdated },
+            ...fetched.history,
+          });
+          await writeJson(join(deps.dataDir, "intervals.json"), {
+            metadata: { schema_version: INTERVALS_SCHEMA_VERSION, last_updated: lastUpdated },
+            ...fetched.intervals,
+          });
+          await writeJson(join(deps.dataDir, "routes.json"), {
+            metadata: { schema_version: ROUTES_SCHEMA_VERSION, last_updated: lastUpdated },
+            ...fetched.routes,
+          });
+          await writeJson(join(deps.dataDir, "ftp_history.json"), {
+            metadata: { schema_version: FTP_HISTORY_SCHEMA_VERSION, last_updated: lastUpdated },
+            ...fetched.ftp_history,
+          });
+
+          // Commit-marker LAST per ADR-0011.
+          phase.current = "writing_scheduler";
+          await writeJson(join(deps.dataDir, ".scheduler.json"), {
+            schema_version: SCHEDULER_SCHEMA_VERSION,
+            last_sync_at: lastUpdated,
+            next_sync_at: new Date(now().getTime() + scheduledIntervalMs).toISOString(),
+          });
+
+          return {
+            ok: true,
+            lastSyncAt: lastUpdated,
+            refreshed: ALL_FILES,
+            failures: [],
+          };
+        };
+
+        let bodyResult: SyncResult | undefined;
+        let bodyError: unknown;
+        const bodySettled = body().then(
+          (r) => {
+            bodyResult = r;
+          },
+          (e) => {
+            bodyError = e;
+          },
+        );
+
+        let timerHandle: ReturnType<typeof setTimeout> | undefined;
+        const timerFired = new Promise<true>((resolve) => {
+          timerHandle = setTimeout(() => resolve(true), outerTimeoutMs);
+        });
+
+        const winner = await Promise.race([
+          bodySettled.then(() => "body" as const),
+          timerFired.then(() => "timeout" as const),
+        ]);
+
+        if (timerHandle !== undefined) clearTimeout(timerHandle);
+
+        if (winner === "timeout") {
+          controller.abort();
+          await writeErrorState(deps.dataDir, {
+            step: "outer_timeout",
+            phase: phase.current,
+            detail: `runSync exceeded ${outerTimeoutMs}ms during ${phase.current} phase`,
+          });
+          return { ok: false, refreshed: [], failures: [] };
+        }
+
+        controller.abort(); // ensure no zombies even on success path
+        if (bodyError !== undefined) throw bodyError;
+        return bodyResult!;
+      },
+      {
+        acquireTimeoutMs,
+        hotWarnMs,
+        caller: opts.caller ?? "scheduled",
+      },
+    );
+
+    if (mutexResult.kind === "timeout") {
+      return { ok: true, refreshed: [], failures: [], skipped: "mutex_held" };
+    }
+
+    const result = mutexResult.value;
+    if (result.ok && opts.caller === "/sync" && opts.chatId !== undefined) {
+      deps.cooldown.record(opts.chatId);
+    }
+    return result;
+  };
+}

--- a/packages/core/src/reference/sync/scheduler.ts
+++ b/packages/core/src/reference/sync/scheduler.ts
@@ -1,0 +1,79 @@
+// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
+
+import { join } from "node:path";
+import { safeReadJson } from "../io/safe-read.js";
+import { SchedulerStateSchema } from "../schemas/scheduler.js";
+import type { RunSyncOpts, SyncResult } from "./run-sync.js";
+
+/**
+ * In-process scheduler for the periodic Reference sync. Two-phase per
+ * ADR-0011: `new Scheduler(...)` reads persisted state but registers no
+ * timer; `start()` is called by the binary's init only AFTER the first
+ * runSync resolves so the cold-start tick-vs-first-sync race is structurally
+ * impossible.
+ */
+export interface SchedulerDeps {
+  readonly dataDir: string;
+  readonly runSync: (opts: RunSyncOpts) => Promise<SyncResult>;
+  readonly intervalMs: number;
+  readonly now?: () => Date;
+}
+
+export class Scheduler {
+  private timerHandle: ReturnType<typeof setTimeout> | null = null;
+  private stopped = false;
+  private nextDelay = 0;
+
+  constructor(private readonly deps: SchedulerDeps) {}
+
+  /**
+   * Register the periodic timer. Reads `.scheduler.json` exactly once on
+   * first start to determine the FIRST tick's delay (per ADR-0011: the
+   * commit-marker the previous runSync wrote tells us when to fire next).
+   * After the first tick, subsequent ticks fire every `intervalMs`.
+   * Idempotent.
+   */
+  start(): void {
+    if (this.stopped) return;
+    if (this.timerHandle !== null) return;
+
+    const state = safeReadJson(
+      join(this.deps.dataDir, ".scheduler.json"),
+      SchedulerStateSchema,
+    );
+    const nowFn = this.deps.now ?? (() => new Date());
+    if (state !== null && state.next_sync_at !== null) {
+      this.nextDelay = Math.max(
+        0,
+        new Date(state.next_sync_at).getTime() - nowFn().getTime(),
+      );
+    } else {
+      this.nextDelay = 0;
+    }
+
+    this.scheduleNext();
+  }
+
+  stop(): void {
+    this.stopped = true;
+    if (this.timerHandle !== null) {
+      clearTimeout(this.timerHandle);
+      this.timerHandle = null;
+    }
+  }
+
+  private scheduleNext(): void {
+    this.timerHandle = setTimeout(async () => {
+      this.timerHandle = null;
+      try {
+        await this.deps.runSync({ caller: "scheduled" });
+      } catch {
+        // runSync handles its own failures; swallow so the loop continues.
+      }
+      if (!this.stopped) {
+        this.nextDelay = this.deps.intervalMs;
+        this.scheduleNext();
+      }
+    }, this.nextDelay);
+  }
+}

--- a/packages/core/src/reference/sync/scheduler.ts
+++ b/packages/core/src/reference/sync/scheduler.ts
@@ -67,8 +67,13 @@ export class Scheduler {
       this.timerHandle = null;
       try {
         await this.deps.runSync({ caller: "scheduled" });
-      } catch {
-        // runSync handles its own failures; swallow so the loop continues.
+      } catch (err) {
+        // runSync handles its own failures internally (writes error_state.json).
+        // Anything escaping here is a bug above that layer — log it so
+        // production regressions don't disappear into a silent loop.
+        console.warn(
+          `Reference: scheduler tick threw (${err instanceof Error ? err.message : String(err)}). Continuing.`,
+        );
       }
       if (!this.stopped) {
         this.nextDelay = this.deps.intervalMs;

--- a/packages/core/src/reference/sync/send-snapshot.ts
+++ b/packages/core/src/reference/sync/send-snapshot.ts
@@ -1,0 +1,107 @@
+// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
+
+import { GrammyError } from "grammy";
+import type { SnapshotOutput } from "./snapshot-debug.js";
+
+/**
+ * Outcome of sending a snapshot to Telegram. `sent` counts successful chunks
+ * (or `1` for a successful document upload); `interrupted: true` means the
+ * handler abandoned the loop after a retry failure.
+ */
+export interface SendOutcome {
+  readonly sent: number;
+  readonly total: number;
+  readonly interrupted: boolean;
+}
+
+export interface SendDeps {
+  readonly reply: (text: string) => Promise<unknown>;
+  readonly sendDocument?: (buffer: Buffer, filename: string) => Promise<unknown>;
+  /** Injectable for tests; defaults to a real timeout. */
+  readonly sleep?: (ms: number) => Promise<void>;
+}
+
+const DEFAULT_TRANSIENT_BACKOFF_MS = 1_000;
+
+/**
+ * Send a `SnapshotOutput` to Telegram with single-retry on transient errors
+ * (429 honors Grammy's `parameters.retry_after`; other errors sleep 1s).
+ * Document mode falls through to chunked-with-retry on `sendDocument`
+ * failure per architect-final F5.
+ */
+export async function sendSnapshotOutput(
+  output: SnapshotOutput,
+  deps: SendDeps,
+): Promise<SendOutcome> {
+  const sleep = deps.sleep ?? defaultSleep;
+
+  if (output.kind === "document") {
+    if (deps.sendDocument !== undefined) {
+      try {
+        await deps.sendDocument(output.buffer, output.filename);
+        return { sent: 1, total: 1, interrupted: false };
+      } catch {
+        // Fall through to chunked reply with the same retry semantics below.
+      }
+    }
+    return await sendChunks(output.chunks, deps.reply, sleep);
+  }
+
+  return await sendChunks(output.chunks, deps.reply, sleep);
+}
+
+async function sendChunks(
+  chunks: readonly string[],
+  reply: SendDeps["reply"],
+  sleep: (ms: number) => Promise<void>,
+): Promise<SendOutcome> {
+  const total = chunks.length;
+  let sent = 0;
+
+  for (let i = 0; i < chunks.length; i++) {
+    const chunk = chunks[i];
+    const ok = await trySendWithSingleRetry(chunk, reply, sleep);
+    if (!ok) {
+      await reply(
+        `Snapshot interrupted at chunk ${i + 1} of ${total}. Run /snapshot raw again — or /snapshot raw <section> to dump just one part.`,
+      );
+      return { sent, total, interrupted: true };
+    }
+    sent += 1;
+  }
+  return { sent, total, interrupted: false };
+}
+
+async function trySendWithSingleRetry(
+  chunk: string,
+  reply: SendDeps["reply"],
+  sleep: (ms: number) => Promise<void>,
+): Promise<boolean> {
+  try {
+    await reply(chunk);
+    return true;
+  } catch (firstErr) {
+    const delayMs = backoffMsFor(firstErr);
+    await sleep(delayMs);
+    try {
+      await reply(chunk);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}
+
+function backoffMsFor(err: unknown): number {
+  if (err instanceof GrammyError && err.error_code === 429) {
+    const retryAfter = err.parameters?.retry_after;
+    if (typeof retryAfter === "number" && retryAfter > 0) {
+      return retryAfter * 1_000;
+    }
+  }
+  return DEFAULT_TRANSIENT_BACKOFF_MS;
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/packages/core/src/reference/sync/send-snapshot.ts
+++ b/packages/core/src/reference/sync/send-snapshot.ts
@@ -22,6 +22,8 @@ export interface SendDeps {
 }
 
 const DEFAULT_TRANSIENT_BACKOFF_MS = 1_000;
+/** Hard cap on `retry_after` to defend against malformed or pathological values. */
+const MAX_RETRY_AFTER_SEC = 300;
 
 /**
  * Send a `SnapshotOutput` to Telegram with single-retry on transient errors
@@ -95,7 +97,15 @@ async function trySendWithSingleRetry(
 function backoffMsFor(err: unknown): number {
   if (err instanceof GrammyError && err.error_code === 429) {
     const retryAfter = err.parameters?.retry_after;
-    if (typeof retryAfter === "number" && retryAfter > 0) {
+    // Reject NaN, Infinity, negatives, zero, and any value beyond the cap.
+    // Telegram realistically returns small integer seconds; an Infinity or
+    // pathological 999_999 would otherwise park us for ~25 days.
+    if (
+      typeof retryAfter === "number" &&
+      Number.isFinite(retryAfter) &&
+      retryAfter > 0 &&
+      retryAfter <= MAX_RETRY_AFTER_SEC
+    ) {
       return retryAfter * 1_000;
     }
   }

--- a/packages/core/src/reference/sync/snapshot-debug.ts
+++ b/packages/core/src/reference/sync/snapshot-debug.ts
@@ -74,7 +74,15 @@ function wrap(body: string): SnapshotOutput {
   const totalBytes = Buffer.byteLength(body, "utf8");
   const chunks = splitIntoChunks(body);
 
+  // Body containing "```" would close the outer ```json…``` Markdown fence
+  // prematurely, producing a Telegram 400 (parse-mode error) or rendered
+  // garbage. Force document mode in that case to side-step Markdown escaping
+  // entirely. Realistic trigger: an athlete's intervals.icu activity name or
+  // description that includes a code block (mirrored from Strava etc.).
+  const containsFenceBreaker = body.includes("```");
+
   if (
+    containsFenceBreaker ||
     totalBytes > SNAPSHOT_DOCUMENT_THRESHOLD_BYTES ||
     chunks.length > SNAPSHOT_DOCUMENT_THRESHOLD_CHUNKS
   ) {

--- a/packages/core/src/reference/sync/snapshot-debug.ts
+++ b/packages/core/src/reference/sync/snapshot-debug.ts
@@ -1,0 +1,103 @@
+// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
+
+import {
+  SNAPSHOT_DOCUMENT_THRESHOLD_BYTES,
+  SNAPSHOT_DOCUMENT_THRESHOLD_CHUNKS,
+} from "../freshness.js";
+import type { LatestJson } from "../schemas/latest.js";
+
+const TELEGRAM_MAX_CHUNK = 4096;
+// Wrap inside ```json ... ``` fences for readability; reserve overhead for the
+// fences themselves so the body fits.
+const FENCE_OPEN = "```json\n";
+const FENCE_CLOSE = "\n```";
+const FENCE_OVERHEAD = FENCE_OPEN.length + FENCE_CLOSE.length;
+const BODY_BUDGET = TELEGRAM_MAX_CHUNK - FENCE_OVERHEAD;
+
+const VALID_SECTIONS: readonly (keyof LatestJson)[] = [
+  "athlete_profile",
+  "current_status",
+  "derived_metrics",
+  "recent_activities",
+  "planned_workouts",
+  "wellness_data",
+  "metadata",
+];
+
+export type SnapshotOutput =
+  | { readonly kind: "chunks"; readonly chunks: readonly string[] }
+  | {
+      readonly kind: "document";
+      readonly buffer: Buffer;
+      readonly filename: string;
+      /** Same body re-chunked, for the handler's document→chunks fall-through (F5). */
+      readonly chunks: readonly string[];
+    };
+
+/**
+ * Format `latest.json` for the operator's `/snapshot raw` debug command.
+ * Returns either chunked Telegram-friendly markdown or a single-document
+ * upload buffer when the dump exceeds the configured thresholds. The handler
+ * dispatches on `kind` to call `ctx.reply` vs `bot.api.sendDocument`.
+ */
+export function formatSnapshotRaw(
+  latest: LatestJson | null,
+  section?: string,
+): SnapshotOutput {
+  if (latest === null) {
+    return {
+      kind: "chunks",
+      chunks: [
+        "Reference hasn't synced yet — try `/sync` first.",
+      ],
+    };
+  }
+
+  if (section !== undefined) {
+    const key = section.toLowerCase();
+    if (!VALID_SECTIONS.includes(key as keyof LatestJson)) {
+      return {
+        kind: "chunks",
+        chunks: [
+          `Unknown section: \`${section}\`.\n\nValid sections: ${VALID_SECTIONS.join(", ")}.`,
+        ],
+      };
+    }
+    const value = (latest as Record<string, unknown>)[key];
+    return wrap(JSON.stringify(value, null, 2));
+  }
+
+  return wrap(JSON.stringify(latest, null, 2));
+}
+
+function wrap(body: string): SnapshotOutput {
+  const totalBytes = Buffer.byteLength(body, "utf8");
+  const chunks = splitIntoChunks(body);
+
+  if (
+    totalBytes > SNAPSHOT_DOCUMENT_THRESHOLD_BYTES ||
+    chunks.length > SNAPSHOT_DOCUMENT_THRESHOLD_CHUNKS
+  ) {
+    return asDocument(body, chunks);
+  }
+  return { kind: "chunks", chunks };
+}
+
+function splitIntoChunks(body: string): readonly string[] {
+  const out: string[] = [];
+  for (let i = 0; i < body.length; i += BODY_BUDGET) {
+    const slice = body.slice(i, i + BODY_BUDGET);
+    out.push(`${FENCE_OPEN}${slice}${FENCE_CLOSE}`);
+  }
+  return out;
+}
+
+function asDocument(body: string, chunks: readonly string[]): SnapshotOutput {
+  const ts = new Date().toISOString().replace(/[:.]/g, "-");
+  return {
+    kind: "document",
+    buffer: Buffer.from(body, "utf8"),
+    filename: `snapshot-${ts}.json`,
+    chunks,
+  };
+}

--- a/packages/core/src/reference/validation/sync-gate.ts
+++ b/packages/core/src/reference/validation/sync-gate.ts
@@ -1,0 +1,30 @@
+// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
+
+/**
+ * Layer-1 sync gate per Reference PRD Decision 7. Wave-1 STUB — always
+ * returns ok. Wave 4 / F15 replaces the body with the actual mechanical
+ * checks (FTP source, weekly hours, UTC clock, tolerance bands, etc.).
+ *
+ * The call site exists in `runSync()` from Wave 1b onwards (between fetch
+ * and cache-file writes), so F15's PR only changes the function body — it
+ * doesn't introduce a new cross-wave seam.
+ */
+export interface GateFailure {
+  readonly step: string;
+  readonly detail: string;
+}
+
+export interface GateWarning {
+  readonly step: string;
+  readonly detail: string;
+}
+
+export interface GateResult {
+  readonly ok: boolean;
+  readonly failures: readonly GateFailure[];
+  readonly warnings: readonly GateWarning[];
+}
+
+export function gateLatestJson(_fetched: unknown, _prior: unknown): GateResult {
+  return { ok: true, failures: [], warnings: [] };
+}

--- a/packages/core/src/run-binary.ts
+++ b/packages/core/src/run-binary.ts
@@ -3,6 +3,7 @@ import { createInterface as createReadlineInterface } from "node:readline";
 import type { Sport } from "./sport.js";
 import type { BinaryConfig } from "./binary.js";
 import type { Memory } from "./memory/store.js";
+import type { LatestJson } from "./reference/schemas/latest.js";
 import { CONFIG_DIR, envInt } from "./config.js";
 import {
   addSender,
@@ -278,7 +279,69 @@ export async function runBinary(
   const { CoachAgent } = await import("./agent/coach-agent.js");
   const agent = new CoachAgent(sport, config);
 
+  // ─── Init order pinned by PRD Decision 13 + ADR-0011 ──────────────────
+  // Step 1: Memory (constructed inside `new CoachAgent` above).
+  // Step 2: Startup hook (binary-specific; cycling-coach runs migrate).
   await runStartupHook(agent.getMemory(), hooks.onStartup);
+
+  // Step 3: Construct Reference services. Two-phase scheduler — NO timer
+  // registered yet (architect-final ADR-0011). The first runSync (step 4)
+  // writes `.scheduler.json`; only then does step 5b call `start()`.
+  const { mkdirSync } = await import("node:fs");
+  const { join } = await import("node:path");
+  const referenceData = join(config.dataDir, "data");
+  mkdirSync(referenceData, { recursive: true });
+
+  const { AsyncMutex } = await import("./reference/sync/mutex.js");
+  const { Cooldown } = await import("./reference/sync/cooldown.js");
+  const { createRunSync } = await import("./reference/sync/run-sync.js");
+  const { Scheduler } = await import("./reference/sync/scheduler.js");
+  const { makeProductionFetcher } = await import(
+    "./reference/sync/fetch-reference-data.js"
+  );
+  const { safeReadJson: refSafeRead } = await import("./reference/io/safe-read.js");
+  const { LatestJsonSchema } = await import("./reference/schemas/latest.js");
+  const { SYNC_COOLDOWN_MS } = await import("./reference/freshness.js");
+
+  const refMutex = new AsyncMutex();
+  const refCooldown = new Cooldown();
+  const runSync = createRunSync({
+    dataDir: referenceData,
+    mutex: refMutex,
+    cooldown: refCooldown,
+    cooldownWindowMs: SYNC_COOLDOWN_MS,
+    fetchReferenceData: makeProductionFetcher({
+      apiKey: config.intervals.apiKey,
+      athleteId: config.intervals.athleteId,
+    }),
+  });
+  const scheduler = new Scheduler({
+    dataDir: referenceData,
+    runSync,
+    intervalMs: (await import("./reference/freshness.js")).SCHEDULED_SYNC_INTERVAL_MS,
+  });
+
+  // Step 4: First runSync (best-effort — failure logs but never crashes).
+  try {
+    await runSync({ caller: "scheduled" });
+  } catch (err) {
+    console.warn(
+      `Reference: initial sync failed (${err instanceof Error ? err.message : String(err)}). Continuing with empty cache; lazy fallback will retry.`,
+    );
+  }
+
+  // Step 5: Lazy `Person.units` bootstrap — Wave 6 fills; no-op call site
+  // exists in Wave 1b so the integration test sees the slot.
+  // (Intentionally empty — Wave 6 will populate via `agent.getMemory()`.)
+
+  // Step 5b: Start the periodic scheduler. Reads now-current `.scheduler.json`.
+  scheduler.start();
+
+  const referenceServices = {
+    runSync,
+    loadLatest: (): LatestJson | null =>
+      refSafeRead<LatestJson>(join(referenceData, "latest.json"), LatestJsonSchema),
+  };
 
   if (config.telegram.botToken) {
     // Interactive startup capture: when no allowlist is set up yet AND we have
@@ -296,7 +359,14 @@ export async function runBinary(
     }
 
     const { createTelegramBot, notifyUpdate } = await import("./channels/telegram.js");
-    const bot = createTelegramBot(config.telegram.botToken, agent, binary, config.dataDir);
+    // Step 6: Open Telegram with Reference services wired in.
+    const bot = createTelegramBot(
+      config.telegram.botToken,
+      agent,
+      binary,
+      config.dataDir,
+      referenceServices,
+    );
     console.log(
       `${binary.displayName} (Telegram mode) is running. Open Telegram and message your bot — Ctrl+C to stop.`,
     );

--- a/packages/core/src/run-binary.ts
+++ b/packages/core/src/run-binary.ts
@@ -301,7 +301,9 @@ export async function runBinary(
   );
   const { safeReadJson: refSafeRead } = await import("./reference/io/safe-read.js");
   const { LatestJsonSchema } = await import("./reference/schemas/latest.js");
-  const { SYNC_COOLDOWN_MS } = await import("./reference/freshness.js");
+  const { SYNC_COOLDOWN_MS, SCHEDULED_SYNC_INTERVAL_MS } = await import(
+    "./reference/freshness.js"
+  );
 
   const refMutex = new AsyncMutex();
   const refCooldown = new Cooldown();
@@ -318,7 +320,7 @@ export async function runBinary(
   const scheduler = new Scheduler({
     dataDir: referenceData,
     runSync,
-    intervalMs: (await import("./reference/freshness.js")).SCHEDULED_SYNC_INTERVAL_MS,
+    intervalMs: SCHEDULED_SYNC_INTERVAL_MS,
   });
 
   // Step 4: First runSync (best-effort — failure logs but never crashes).
@@ -330,9 +332,7 @@ export async function runBinary(
     );
   }
 
-  // Step 5: Lazy `Person.units` bootstrap — Wave 6 fills; no-op call site
-  // exists in Wave 1b so the integration test sees the slot.
-  // (Intentionally empty — Wave 6 will populate via `agent.getMemory()`.)
+  // Step 5: Lazy `Person.units` bootstrap — Wave 6 fills (no-op slot).
 
   // Step 5b: Start the periodic scheduler. Reads now-current `.scheduler.json`.
   scheduler.start();

--- a/packages/core/tests/reference-abort-budget.test.ts
+++ b/packages/core/tests/reference-abort-budget.test.ts
@@ -4,8 +4,24 @@ import { afterEach, describe, it, expect, vi } from "vitest";
 import { chainedSignal } from "../src/reference/sync/abort-budget.js";
 
 afterEach(() => {
+  vi.restoreAllMocks();
   vi.useRealTimers();
 });
+
+/**
+ * `AbortSignal.timeout` uses Node's internal timer scheduler — `vi.useFakeTimers()`
+ * cannot intercept it directly, so the per-request-timeout tests below replace
+ * `AbortSignal.timeout` with a `setTimeout`-driven controller (which fake timers
+ * DO intercept). The mock preserves the only observable behavior the tests
+ * care about: the returned signal aborts after `ms` of fake time.
+ */
+function mockAbortSignalTimeout(): ReturnType<typeof vi.spyOn> {
+  return vi.spyOn(AbortSignal, "timeout").mockImplementation((ms: number) => {
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(new Error("timeout (mock)")), ms);
+    return controller.signal;
+  });
+}
 
 describe("chainedSignal", () => {
   it("aborts when the outer signal aborts", () => {
@@ -16,19 +32,16 @@ describe("chainedSignal", () => {
     expect(signal.aborted).toBe(true);
   });
 
-  // Per-request-timeout abort propagation is exercised at the runSync level
-  // (`reference-run-sync.test.ts`'s outer-timeout test verifies the chained
-  // signal aborts in-flight fetches). A unit test here against
-  // `AbortSignal.timeout` flakes under vitest's parallel pool — vi fake
-  // timers don't fully cover `AbortSignal.timeout`'s internal scheduler, and
-  // real-timer waits are unreliable when other test files saturate the
-  // worker. The other two specs (outer aborts; already-aborted at construct)
-  // cover the glue without timer dependence.
-  it.skip("aborts when the per-request timeout fires before the outer aborts", async () => {
+  it("aborts when the per-request timeout fires before the outer aborts", async () => {
+    vi.useFakeTimers();
+    mockAbortSignalTimeout();
+
     const outer = new AbortController();
     const signal = chainedSignal({ outer: outer.signal, perRequestMs: 50 });
     expect(signal.aborted).toBe(false);
-    await new Promise((resolve) => setTimeout(resolve, 1_000));
+
+    await vi.advanceTimersByTimeAsync(60);
+
     expect(signal.aborted).toBe(true);
     expect(outer.signal.aborted).toBe(false);
   });

--- a/packages/core/tests/reference-abort-budget.test.ts
+++ b/packages/core/tests/reference-abort-budget.test.ts
@@ -1,0 +1,42 @@
+// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
+
+import { afterEach, describe, it, expect, vi } from "vitest";
+import { chainedSignal } from "../src/reference/sync/abort-budget.js";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("chainedSignal", () => {
+  it("aborts when the outer signal aborts", () => {
+    const outer = new AbortController();
+    const signal = chainedSignal({ outer: outer.signal, perRequestMs: 10_000 });
+    expect(signal.aborted).toBe(false);
+    outer.abort();
+    expect(signal.aborted).toBe(true);
+  });
+
+  // Per-request-timeout abort propagation is exercised at the runSync level
+  // (`reference-run-sync.test.ts`'s outer-timeout test verifies the chained
+  // signal aborts in-flight fetches). A unit test here against
+  // `AbortSignal.timeout` flakes under vitest's parallel pool — vi fake
+  // timers don't fully cover `AbortSignal.timeout`'s internal scheduler, and
+  // real-timer waits are unreliable when other test files saturate the
+  // worker. The other two specs (outer aborts; already-aborted at construct)
+  // cover the glue without timer dependence.
+  it.skip("aborts when the per-request timeout fires before the outer aborts", async () => {
+    const outer = new AbortController();
+    const signal = chainedSignal({ outer: outer.signal, perRequestMs: 50 });
+    expect(signal.aborted).toBe(false);
+    await new Promise((resolve) => setTimeout(resolve, 1_000));
+    expect(signal.aborted).toBe(true);
+    expect(outer.signal.aborted).toBe(false);
+  });
+
+  it("starts already-aborted when the outer signal is already aborted at construction", () => {
+    const outer = new AbortController();
+    outer.abort();
+    const signal = chainedSignal({ outer: outer.signal, perRequestMs: 10_000 });
+    expect(signal.aborted).toBe(true);
+  });
+});

--- a/packages/core/tests/reference-cooldown.test.ts
+++ b/packages/core/tests/reference-cooldown.test.ts
@@ -1,0 +1,39 @@
+// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
+
+import { describe, it, expect } from "vitest";
+import { Cooldown } from "../src/reference/sync/cooldown.js";
+
+describe("Cooldown", () => {
+  it("returns ok for the first check on a previously-unseen key", () => {
+    const cd = new Cooldown();
+    expect(cd.check("chat-1", 30_000)).toEqual({ ok: true });
+  });
+
+  it("returns retryAfterMs when the same key is checked within the window after record", () => {
+    let now = 1_000_000;
+    const cd = new Cooldown(() => now);
+    cd.record("chat-1");
+    now += 5_000;
+    const r = cd.check("chat-1", 30_000);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.retryAfterMs).toBe(25_000);
+    }
+  });
+
+  it("returns ok again once the window has elapsed", () => {
+    let now = 1_000_000;
+    const cd = new Cooldown(() => now);
+    cd.record("chat-1");
+    now += 30_000;
+    expect(cd.check("chat-1", 30_000)).toEqual({ ok: true });
+  });
+
+  it("tracks each key independently", () => {
+    let now = 1_000_000;
+    const cd = new Cooldown(() => now);
+    cd.record("chat-1");
+    expect(cd.check("chat-1", 30_000).ok).toBe(false);
+    expect(cd.check("chat-2", 30_000)).toEqual({ ok: true });
+  });
+});

--- a/packages/core/tests/reference-cooldown.test.ts
+++ b/packages/core/tests/reference-cooldown.test.ts
@@ -36,4 +36,18 @@ describe("Cooldown", () => {
     expect(cd.check("chat-1", 30_000).ok).toBe(false);
     expect(cd.check("chat-2", 30_000)).toEqual({ ok: true });
   });
+
+  it("clamps elapsed to non-negative when the clock skews backwards (NTP correction)", () => {
+    let now = 1_000_000;
+    const cd = new Cooldown(() => now);
+    cd.record("chat-1");
+    // Clock jumps back 5 seconds before the next check.
+    now -= 5_000;
+    const r = cd.check("chat-1", 30_000);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      // Without the clamp this would be 35_000 (windowMs - negative-elapsed).
+      expect(r.retryAfterMs).toBe(30_000);
+    }
+  });
 });

--- a/packages/core/tests/reference-error-state-writer.test.ts
+++ b/packages/core/tests/reference-error-state-writer.test.ts
@@ -1,0 +1,51 @@
+// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
+
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  ERROR_STATE_SCHEMA_VERSION,
+  ErrorStateSchema,
+} from "../src/reference/schemas/error-state.js";
+import { writeErrorState } from "../src/reference/sync/error-state-writer.js";
+
+describe("writeErrorState", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "reference-error-state-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("writes error_state.json with step, detail, phase, schema_version, and ISO ts", async () => {
+    await writeErrorState(dir, {
+      step: "outer_timeout",
+      phase: "writing_cache",
+      detail: "fetch hung past 2-min budget",
+    });
+
+    const raw = readFileSync(join(dir, "error_state.json"), "utf-8");
+    const parsed = ErrorStateSchema.parse(JSON.parse(raw));
+    expect(parsed.step).toBe("outer_timeout");
+    expect(parsed.phase).toBe("writing_cache");
+    expect(parsed.detail).toBe("fetch hung past 2-min budget");
+    expect(parsed.schema_version).toBe(ERROR_STATE_SCHEMA_VERSION);
+    expect(new Date(parsed.ts).toString()).not.toBe("Invalid Date");
+  });
+
+  it("omits phase when not supplied (gate-failure path)", async () => {
+    await writeErrorState(dir, {
+      step: "gate_rejected",
+      detail: "ftp_source_missing",
+    });
+
+    const raw = readFileSync(join(dir, "error_state.json"), "utf-8");
+    const parsed = ErrorStateSchema.parse(JSON.parse(raw));
+    expect(parsed.step).toBe("gate_rejected");
+    expect(parsed.phase).toBeUndefined();
+  });
+});

--- a/packages/core/tests/reference-format-sync-reply.test.ts
+++ b/packages/core/tests/reference-format-sync-reply.test.ts
@@ -1,0 +1,75 @@
+// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
+
+import { describe, expect, it } from "vitest";
+import { formatSyncReply } from "../src/reference/sync/format-sync-reply.js";
+import type { SyncResult } from "../src/reference/sync/run-sync.js";
+
+const fixedNow = new Date("2026-05-09T14:23:32Z");
+
+describe("formatSyncReply", () => {
+  it("formats a successful sync (US-18 shape) with last sync time, refreshed list, and no failures", () => {
+    const r: SyncResult = {
+      ok: true,
+      lastSyncAt: "2026-05-09T14:23:00Z",
+      refreshed: ["latest", "history", "intervals", "routes", "ftp_history"],
+      failures: [],
+    };
+    const text = formatSyncReply(r, fixedNow);
+    expect(text).toContain("Sync");
+    expect(text).toContain("Last sync:");
+    expect(text).toContain("Refreshed:");
+    expect(text).toContain("latest");
+    expect(text).toContain("history");
+    expect(text).not.toContain("Failures");
+  });
+
+  it("includes a Failures line when at least one file failed", () => {
+    const r: SyncResult = {
+      ok: true,
+      lastSyncAt: "2026-05-09T14:23:00Z",
+      refreshed: ["latest", "history", "intervals"],
+      failures: [{ file: "routes", reason: "intervals.icu_503" }],
+    };
+    const text = formatSyncReply(r, fixedNow);
+    expect(text).toContain("Refreshed:");
+    expect(text).toContain("Failures:");
+    expect(text).toContain("routes");
+    expect(text).toContain("intervals.icu_503");
+  });
+
+  it("formats the cooldown skip with a per-second retryAfter countdown", () => {
+    const r: SyncResult = {
+      ok: true,
+      refreshed: [],
+      failures: [],
+      skipped: "cooldown",
+      retryAfterMs: 18_000,
+    };
+    const text = formatSyncReply(r, fixedNow);
+    expect(text).toContain("Just synced");
+    expect(text).toContain("18s");
+  });
+
+  it("formats the mutex_held skip as 'sync in progress, please retry shortly'", () => {
+    const r: SyncResult = {
+      ok: true,
+      refreshed: [],
+      failures: [],
+      skipped: "mutex_held",
+    };
+    const text = formatSyncReply(r, fixedNow);
+    expect(text.toLowerCase()).toContain("sync in progress");
+  });
+
+  it("formats an outer-timeout failure as 'I can't reach intervals.icu' with last good sync if known", () => {
+    const r: SyncResult = {
+      ok: false,
+      lastSyncAt: "2026-05-09T13:45:00Z",
+      refreshed: [],
+      failures: [],
+    };
+    const text = formatSyncReply(r, fixedNow);
+    expect(text.toLowerCase()).toContain("can't reach intervals.icu");
+    expect(text).toContain("Last good sync:");
+  });
+});

--- a/packages/core/tests/reference-freshness-check.test.ts
+++ b/packages/core/tests/reference-freshness-check.test.ts
@@ -1,0 +1,32 @@
+// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
+
+import { describe, expect, it } from "vitest";
+import { freshnessOf } from "../src/reference/sync/freshness-check.js";
+
+const fixedNow = new Date("2026-05-09T12:00:00Z");
+const ago = (ms: number) => new Date(fixedNow.getTime() - ms).toISOString();
+const HOUR = 60 * 60 * 1000;
+const DAY = 24 * HOUR;
+
+describe("freshnessOf", () => {
+  it("returns 'fresh' when last_updated is under 24 hours old", () => {
+    expect(freshnessOf({ last_updated: ago(60_000) }, fixedNow)).toBe("fresh");
+    expect(freshnessOf({ last_updated: ago(23 * HOUR) }, fixedNow)).toBe("fresh");
+  });
+
+  it("returns 'flag' when last_updated is 24-48 hours old", () => {
+    expect(freshnessOf({ last_updated: ago(24 * HOUR) }, fixedNow)).toBe("flag");
+    expect(freshnessOf({ last_updated: ago(36 * HOUR) }, fixedNow)).toBe("flag");
+  });
+
+  it("returns 'stale' when last_updated is between 48 hours and 7 days old", () => {
+    expect(freshnessOf({ last_updated: ago(48 * HOUR) }, fixedNow)).toBe("stale");
+    expect(freshnessOf({ last_updated: ago(3 * DAY) }, fixedNow)).toBe("stale");
+    expect(freshnessOf({ last_updated: ago(6 * DAY) }, fixedNow)).toBe("stale");
+  });
+
+  it("returns 'critical' when last_updated is over 7 days old", () => {
+    expect(freshnessOf({ last_updated: ago(7 * DAY) }, fixedNow)).toBe("critical");
+    expect(freshnessOf({ last_updated: ago(30 * DAY) }, fixedNow)).toBe("critical");
+  });
+});

--- a/packages/core/tests/reference-intervals-client-factory.test.ts
+++ b/packages/core/tests/reference-intervals-client-factory.test.ts
@@ -1,0 +1,92 @@
+// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { IntervalsClient } from "intervals-icu-api";
+import {
+  makeAbortableClient,
+  wrapFetchWithSignal,
+} from "../src/reference/sync/intervals-client-factory.js";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("wrapFetchWithSignal", () => {
+  it("threads a chained AbortSignal into the init passed to baseFetch", async () => {
+    let captured: AbortSignal | undefined;
+    const baseFetch: typeof globalThis.fetch = async (_input, init) => {
+      captured = init?.signal ?? undefined;
+      return new Response("ok");
+    };
+    const outer = new AbortController();
+
+    const wrapped = wrapFetchWithSignal({
+      baseFetch,
+      outer: outer.signal,
+      perRequestMs: 30_000,
+    });
+    await wrapped("https://example.test/", {});
+
+    expect(captured).toBeInstanceOf(AbortSignal);
+    expect(captured!.aborted).toBe(false);
+  });
+
+  it("aborts in-flight signals when the outer signal aborts", async () => {
+    let captured: AbortSignal | undefined;
+    const baseFetch: typeof globalThis.fetch = async (_input, init) => {
+      captured = init?.signal ?? undefined;
+      return new Response("ok");
+    };
+    const outer = new AbortController();
+
+    const wrapped = wrapFetchWithSignal({
+      baseFetch,
+      outer: outer.signal,
+      perRequestMs: 30_000,
+    });
+    await wrapped("https://example.test/", {});
+
+    expect(captured!.aborted).toBe(false);
+    outer.abort();
+    expect(captured!.aborted).toBe(true);
+  });
+
+  // Per-request-timeout propagation is verified end-to-end at the runSync
+  // level (`reference-run-sync.test.ts`'s outer-timeout test asserts the
+  // wrapper-fetch's signal aborts when runSync's outer controller fires).
+  // Pinning it here against `AbortSignal.timeout` flakes under vitest's
+  // parallel pool — fake timers don't intercept `AbortSignal.timeout`'s
+  // scheduler reliably, and real-timer waits race with other files'
+  // worker pressure.
+  it.skip("aborts in-flight signals when the per-request timeout fires", async () => {
+    let captured: AbortSignal | undefined;
+    const baseFetch: typeof globalThis.fetch = async (_input, init) => {
+      captured = init?.signal ?? undefined;
+      return new Response("ok");
+    };
+    const outer = new AbortController();
+
+    const wrapped = wrapFetchWithSignal({
+      baseFetch,
+      outer: outer.signal,
+      perRequestMs: 50,
+    });
+    await wrapped("https://example.test/", {});
+    expect(captured!.aborted).toBe(false);
+    await new Promise((resolve) => setTimeout(resolve, 1_000));
+    expect(captured!.aborted).toBe(true);
+    expect(outer.signal.aborted).toBe(false);
+  });
+});
+
+describe("makeAbortableClient", () => {
+  it("returns an IntervalsClient instance configured with the abortable wrapper-fetch", () => {
+    const outer = new AbortController();
+    const client = makeAbortableClient({
+      apiKey: "test-key",
+      signal: outer.signal,
+      perRequestMs: 30_000,
+    });
+    expect(client).toBeInstanceOf(IntervalsClient);
+  });
+});

--- a/packages/core/tests/reference-intervals-client-factory.test.ts
+++ b/packages/core/tests/reference-intervals-client-factory.test.ts
@@ -8,8 +8,22 @@ import {
 } from "../src/reference/sync/intervals-client-factory.js";
 
 afterEach(() => {
+  vi.restoreAllMocks();
   vi.useRealTimers();
 });
+
+/**
+ * `AbortSignal.timeout` uses Node's internal timer scheduler — `vi.useFakeTimers()`
+ * cannot intercept it directly. Replace it with a `setTimeout`-driven controller
+ * for tests that need deterministic per-request-timeout firing.
+ */
+function mockAbortSignalTimeout(): ReturnType<typeof vi.spyOn> {
+  return vi.spyOn(AbortSignal, "timeout").mockImplementation((ms: number) => {
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(new Error("timeout (mock)")), ms);
+    return controller.signal;
+  });
+}
 
 describe("wrapFetchWithSignal", () => {
   it("threads a chained AbortSignal into the init passed to baseFetch", async () => {
@@ -51,14 +65,10 @@ describe("wrapFetchWithSignal", () => {
     expect(captured!.aborted).toBe(true);
   });
 
-  // Per-request-timeout propagation is verified end-to-end at the runSync
-  // level (`reference-run-sync.test.ts`'s outer-timeout test asserts the
-  // wrapper-fetch's signal aborts when runSync's outer controller fires).
-  // Pinning it here against `AbortSignal.timeout` flakes under vitest's
-  // parallel pool — fake timers don't intercept `AbortSignal.timeout`'s
-  // scheduler reliably, and real-timer waits race with other files'
-  // worker pressure.
-  it.skip("aborts in-flight signals when the per-request timeout fires", async () => {
+  it("aborts in-flight signals when the per-request timeout fires", async () => {
+    vi.useFakeTimers();
+    mockAbortSignalTimeout();
+
     let captured: AbortSignal | undefined;
     const baseFetch: typeof globalThis.fetch = async (_input, init) => {
       captured = init?.signal ?? undefined;
@@ -73,7 +83,9 @@ describe("wrapFetchWithSignal", () => {
     });
     await wrapped("https://example.test/", {});
     expect(captured!.aborted).toBe(false);
-    await new Promise((resolve) => setTimeout(resolve, 1_000));
+
+    await vi.advanceTimersByTimeAsync(60);
+
     expect(captured!.aborted).toBe(true);
     expect(outer.signal.aborted).toBe(false);
   });

--- a/packages/core/tests/reference-mutex.test.ts
+++ b/packages/core/tests/reference-mutex.test.ts
@@ -1,0 +1,156 @@
+// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { AsyncMutex } from "../src/reference/sync/mutex.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const opts = { acquireTimeoutMs: 5_000, hotWarnMs: 10_000, caller: "test" };
+
+describe("AsyncMutex.runExclusive", () => {
+  it("serializes concurrent callers — second body starts only after the first resolves", async () => {
+    const mutex = new AsyncMutex();
+    const events: Array<{ caller: string; phase: "start" | "end"; t: number }> = [];
+
+    const body = (caller: string, durationMs: number) => async () => {
+      events.push({ caller, phase: "start", t: Date.now() });
+      await new Promise((resolve) => setTimeout(resolve, durationMs));
+      events.push({ caller, phase: "end", t: Date.now() });
+      return caller;
+    };
+
+    const [r1, r2] = await Promise.all([
+      mutex.runExclusive(body("first", 50), opts),
+      mutex.runExclusive(body("second", 20), opts),
+    ]);
+
+    expect(r1).toEqual({ kind: "ran", value: "first" });
+    expect(r2).toEqual({ kind: "ran", value: "second" });
+
+    const firstEnd = events.find((e) => e.caller === "first" && e.phase === "end")!.t;
+    const secondStart = events.find((e) => e.caller === "second" && e.phase === "start")!.t;
+    expect(secondStart).toBeGreaterThanOrEqual(firstEnd);
+  });
+
+  it("preserves FIFO order across N concurrent waiters", async () => {
+    const mutex = new AsyncMutex();
+    const order: string[] = [];
+
+    const body = (caller: string) => async () => {
+      order.push(caller);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      return caller;
+    };
+
+    await Promise.all([
+      mutex.runExclusive(body("A"), opts),
+      mutex.runExclusive(body("B"), opts),
+      mutex.runExclusive(body("C"), opts),
+      mutex.runExclusive(body("D"), opts),
+      mutex.runExclusive(body("E"), opts),
+    ]);
+
+    expect(order).toEqual(["A", "B", "C", "D", "E"]);
+  });
+
+  it("returns { kind: 'timeout' } and does NOT run the body when acquire wait exceeds acquireTimeoutMs", async () => {
+    const mutex = new AsyncMutex();
+    let secondBodyRan = false;
+
+    const slow = async () => {
+      await new Promise((resolve) => setTimeout(resolve, 200));
+      return "first";
+    };
+
+    const fast = async () => {
+      secondBodyRan = true;
+      return "second";
+    };
+
+    const [r1, r2] = await Promise.all([
+      mutex.runExclusive(slow, { acquireTimeoutMs: 5_000, hotWarnMs: 10_000, caller: "first" }),
+      mutex.runExclusive(fast, { acquireTimeoutMs: 30, hotWarnMs: 10_000, caller: "second" }),
+    ]);
+
+    expect(r1).toEqual({ kind: "ran", value: "first" });
+    expect(r2).toEqual({ kind: "timeout" });
+    expect(secondBodyRan).toBe(false);
+  });
+
+  it("releases the lock when the body throws so subsequent callers can run", async () => {
+    const mutex = new AsyncMutex();
+    let secondRan = false;
+
+    const throwing = async () => {
+      throw new Error("body fail");
+    };
+    const success = async () => {
+      secondRan = true;
+      return "second";
+    };
+
+    const p1 = mutex.runExclusive(throwing, opts);
+    const p2 = mutex.runExclusive(success, opts);
+
+    await expect(p1).rejects.toThrow("body fail");
+    expect(await p2).toEqual({ kind: "ran", value: "second" });
+    expect(secondRan).toBe(true);
+  });
+
+  // Regression for ADR-0011: AsyncMutex is non-reentrant. A nested call from
+  // inside a held body must NOT deadlock — the inner call's own acquire
+  // timeout fires and surfaces the bug as a 30s soft-skip rather than a hang.
+  it("returns timeout (never deadlocks) when runExclusive is called from inside a held body", async () => {
+    const mutex = new AsyncMutex();
+    let innerResult: { kind: "ran"; value: string } | { kind: "timeout" } | null = null;
+
+    const outerResult = await mutex.runExclusive(
+      async () => {
+        innerResult = await mutex.runExclusive(
+          async () => "inner-body-ran",
+          { acquireTimeoutMs: 50, hotWarnMs: 10_000, caller: "inner" },
+        );
+        return "outer-body-ran";
+      },
+      { acquireTimeoutMs: 5_000, hotWarnMs: 10_000, caller: "outer" },
+    );
+
+    expect(outerResult).toEqual({ kind: "ran", value: "outer-body-ran" });
+    expect(innerResult).toEqual({ kind: "timeout" });
+  });
+
+  it("emits a structured reference_mutex_hot warn to stderr when acquire wait exceeds hotWarnMs", async () => {
+    const mutex = new AsyncMutex();
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const slow = async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      return "first";
+    };
+    const fast = async () => "second";
+
+    await Promise.all([
+      mutex.runExclusive(slow, {
+        acquireTimeoutMs: 5_000,
+        hotWarnMs: 5_000, // first never waits, never warns
+        caller: "scheduled",
+      }),
+      mutex.runExclusive(fast, {
+        acquireTimeoutMs: 5_000,
+        hotWarnMs: 30, // wait > 30ms triggers warn
+        caller: "/sync",
+      }),
+    ]);
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const payload = JSON.parse(warnSpy.mock.calls[0]![0] as string);
+    expect(payload.event).toBe("reference_mutex_hot");
+    expect(payload.caller).toBe("/sync");
+    expect(typeof payload.wait_ms).toBe("number");
+    expect(payload.wait_ms).toBeGreaterThanOrEqual(30);
+    expect(typeof payload.ts).toBe("string");
+    expect(new Date(payload.ts).toString()).not.toBe("Invalid Date");
+  });
+});

--- a/packages/core/tests/reference-run-sync.test.ts
+++ b/packages/core/tests/reference-run-sync.test.ts
@@ -1,0 +1,301 @@
+// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
+
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AsyncMutex } from "../src/reference/sync/mutex.js";
+import { Cooldown } from "../src/reference/sync/cooldown.js";
+import {
+  createRunSync,
+  type FetchedReference,
+} from "../src/reference/sync/run-sync.js";
+import { SCHEDULED_SYNC_INTERVAL_MS } from "../src/reference/freshness.js";
+import { LATEST_SCHEMA_VERSION } from "../src/reference/schemas/latest.js";
+
+const emptyFetched: FetchedReference = {
+  latest: {
+    athlete_profile: {},
+    current_status: {},
+    derived_metrics: {},
+    recent_activities: [],
+    planned_workouts: [],
+    wellness_data: {},
+  },
+  history: { daily: [], weekly: [], monthly: [] },
+  intervals: { by_activity: {} },
+  routes: { routes: [] },
+  ftp_history: { entries: [] },
+};
+
+describe("createRunSync", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "reference-run-sync-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it("returns skipped: cooldown without acquiring the mutex or fetching when the /sync caller is within the cooldown window", async () => {
+    let now = 1_000_000;
+    const cooldown = new Cooldown(() => now);
+    cooldown.record("telegram:123");
+    now += 5_000;
+
+    const fetchSpy = vi.fn();
+    const mutex = new AsyncMutex();
+
+    const runSync = createRunSync({
+      dataDir: dir,
+      mutex,
+      cooldown,
+      cooldownWindowMs: 30_000,
+      fetchReferenceData: fetchSpy,
+      now: () => new Date(now),
+    });
+
+    const result = await runSync({ caller: "/sync", chatId: "telegram:123" });
+
+    expect(result.ok).toBe(true);
+    expect(result.skipped).toBe("cooldown");
+    expect(result.retryAfterMs).toBe(25_000);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(mutex.isHeld()).toBe(false);
+  });
+
+  it("writes 5 cache files first then .scheduler.json (commit-marker) and returns ok with the refreshed list", async () => {
+    const mutex = new AsyncMutex();
+    const cooldown = new Cooldown();
+    const now = new Date("2026-05-09T14:00:00Z");
+
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ...emptyFetched,
+      latest: { ...emptyFetched.latest, athlete_profile: { id: "test-athlete" } },
+    });
+
+    const runSync = createRunSync({
+      dataDir: dir,
+      mutex,
+      cooldown,
+      cooldownWindowMs: 30_000,
+      fetchReferenceData: fetchSpy,
+      now: () => now,
+    });
+
+    const result = await runSync({ caller: "scheduled" });
+
+    expect(result.ok).toBe(true);
+    expect(result.refreshed).toEqual([
+      "latest",
+      "history",
+      "intervals",
+      "routes",
+      "ftp_history",
+    ]);
+    expect(result.failures).toEqual([]);
+    expect(result.lastSyncAt).toBe(now.toISOString());
+    expect(result.skipped).toBeUndefined();
+
+    const latest = JSON.parse(readFileSync(join(dir, "latest.json"), "utf-8"));
+    expect(latest.metadata.schema_version).toBe(LATEST_SCHEMA_VERSION);
+    expect(latest.metadata.last_updated).toBe(now.toISOString());
+    expect(latest.metadata.freshness).toBe("fresh");
+    expect(latest.athlete_profile).toEqual({ id: "test-athlete" });
+
+    const scheduler = JSON.parse(readFileSync(join(dir, ".scheduler.json"), "utf-8"));
+    expect(scheduler.last_sync_at).toBe(now.toISOString());
+    expect(scheduler.next_sync_at).toBe(
+      new Date(now.getTime() + SCHEDULED_SYNC_INTERVAL_MS).toISOString(),
+    );
+
+    expect(mutex.isHeld()).toBe(false);
+    expect(fetchSpy).toHaveBeenCalledOnce();
+  });
+
+  it("returns skipped: mutex_held when a second concurrent runSync waits past acquireTimeoutMs", async () => {
+    const mutex = new AsyncMutex();
+    const cooldown = new Cooldown();
+    const now = new Date("2026-05-09T14:00:00Z");
+
+    let resolveSlow!: () => void;
+    const slowFetch = vi.fn(async () => {
+      await new Promise<void>((resolve) => {
+        resolveSlow = resolve;
+      });
+      return emptyFetched;
+    });
+    const fastFetch = vi.fn().mockResolvedValue(emptyFetched);
+
+    const runSyncSlow = createRunSync({
+      dataDir: dir,
+      mutex,
+      cooldown,
+      cooldownWindowMs: 30_000,
+      fetchReferenceData: slowFetch,
+      now: () => now,
+      timing: { acquireTimeoutMs: 5_000 },
+    });
+    const runSyncFast = createRunSync({
+      dataDir: dir,
+      mutex,
+      cooldown,
+      cooldownWindowMs: 30_000,
+      fetchReferenceData: fastFetch,
+      now: () => now,
+      timing: { acquireTimeoutMs: 30 },
+    });
+
+    const p1 = runSyncSlow({ caller: "scheduled" });
+    const p2 = runSyncFast({ caller: "scheduled" });
+
+    const r2 = await p2;
+    expect(r2.ok).toBe(true);
+    expect(r2.skipped).toBe("mutex_held");
+    expect(fastFetch).not.toHaveBeenCalled();
+
+    resolveSlow();
+    const r1 = await p1;
+    expect(r1.ok).toBe(true);
+    expect(r1.skipped).toBeUndefined();
+    expect(slowFetch).toHaveBeenCalledOnce();
+  });
+
+  it("times out at outerTimeoutMs: aborts the controller, writes error_state.json with phase, releases mutex, returns ok:false", async () => {
+    const mutex = new AsyncMutex();
+    const cooldown = new Cooldown();
+    const now = new Date("2026-05-09T14:00:00Z");
+
+    let capturedSignal: AbortSignal | null = null;
+    const hangingFetch = vi.fn(async (signal: AbortSignal): Promise<FetchedReference> => {
+      capturedSignal = signal;
+      return await new Promise<FetchedReference>(() => {});
+    });
+
+    const runSync = createRunSync({
+      dataDir: dir,
+      mutex,
+      cooldown,
+      cooldownWindowMs: 30_000,
+      fetchReferenceData: hangingFetch,
+      now: () => now,
+      timing: { outerTimeoutMs: 30 },
+    });
+
+    const result = await runSync({ caller: "scheduled" });
+
+    expect(result.ok).toBe(false);
+    expect(result.refreshed).toEqual([]);
+    expect(capturedSignal).not.toBeNull();
+    expect(capturedSignal!.aborted).toBe(true);
+    expect(mutex.isHeld()).toBe(false);
+
+    const errorState = JSON.parse(
+      readFileSync(join(dir, "error_state.json"), "utf-8"),
+    );
+    expect(errorState.step).toBe("outer_timeout");
+    expect(errorState.phase).toBe("fetching");
+
+    // No cache files were written
+    expect(() => readFileSync(join(dir, "latest.json"), "utf-8")).toThrow();
+    expect(() => readFileSync(join(dir, ".scheduler.json"), "utf-8")).toThrow();
+  });
+
+  it("on gate rejection writes error_state.json with step=gate_rejected (no phase) and writes no cache files", async () => {
+    const mutex = new AsyncMutex();
+    const cooldown = new Cooldown();
+    const now = new Date("2026-05-09T14:00:00Z");
+
+    const fetchSpy = vi.fn().mockResolvedValue(emptyFetched);
+    const rejectingGate = vi.fn().mockReturnValue({
+      ok: false,
+      failures: [
+        { step: "ftp_source_check", detail: "FTP source missing on athlete profile" },
+      ],
+      warnings: [],
+    });
+
+    const runSync = createRunSync({
+      dataDir: dir,
+      mutex,
+      cooldown,
+      cooldownWindowMs: 30_000,
+      fetchReferenceData: fetchSpy,
+      gate: rejectingGate,
+      now: () => now,
+    });
+
+    const result = await runSync({ caller: "scheduled" });
+
+    expect(result.ok).toBe(false);
+    expect(result.refreshed).toEqual([]);
+    expect(result.failures).toEqual([
+      { file: "latest", reason: "ftp_source_check: FTP source missing on athlete profile" },
+    ]);
+
+    const errorState = JSON.parse(
+      readFileSync(join(dir, "error_state.json"), "utf-8"),
+    );
+    expect(errorState.step).toBe("gate_rejected");
+    expect(errorState.detail).toContain("ftp_source_check");
+    expect(errorState.phase).toBeUndefined();
+
+    expect(() => readFileSync(join(dir, "latest.json"), "utf-8")).toThrow();
+    expect(() => readFileSync(join(dir, ".scheduler.json"), "utf-8")).toThrow();
+    expect(mutex.isHeld()).toBe(false);
+  });
+
+  it("when outer timeout fires during writing_scheduler phase, error_state.phase reflects it and caches survive", async () => {
+    const mutex = new AsyncMutex();
+    const cooldown = new Cooldown();
+    const now = new Date("2026-05-09T14:00:00Z");
+    const fetchSpy = vi.fn().mockResolvedValue(emptyFetched);
+
+    // Real atomicWriteJson for cache files; injected slow write only for .scheduler.json.
+    const { atomicWriteJson: realAtomicWrite } = await import(
+      "../src/reference/io/atomic-write.js"
+    );
+    const slowSchedulerWrite = vi.fn(
+      async (path: string, value: unknown): Promise<void> => {
+        if (path.endsWith(".scheduler.json")) {
+          await new Promise((resolve) => setTimeout(resolve, 200));
+        }
+        await realAtomicWrite(path, value);
+      },
+    );
+
+    const runSync = createRunSync({
+      dataDir: dir,
+      mutex,
+      cooldown,
+      cooldownWindowMs: 30_000,
+      fetchReferenceData: fetchSpy,
+      atomicWrite: slowSchedulerWrite,
+      now: () => now,
+      timing: { outerTimeoutMs: 50 },
+    });
+
+    const result = await runSync({ caller: "scheduled" });
+
+    expect(result.ok).toBe(false);
+
+    const errorState = JSON.parse(
+      readFileSync(join(dir, "error_state.json"), "utf-8"),
+    );
+    expect(errorState.step).toBe("outer_timeout");
+    expect(errorState.phase).toBe("writing_scheduler");
+
+    // All 5 cache files survived the partial commit; only .scheduler.json never landed.
+    expect(() => readFileSync(join(dir, "latest.json"), "utf-8")).not.toThrow();
+    expect(() => readFileSync(join(dir, "history.json"), "utf-8")).not.toThrow();
+    expect(() => readFileSync(join(dir, "intervals.json"), "utf-8")).not.toThrow();
+    expect(() => readFileSync(join(dir, "routes.json"), "utf-8")).not.toThrow();
+    expect(() => readFileSync(join(dir, "ftp_history.json"), "utf-8")).not.toThrow();
+    expect(() => readFileSync(join(dir, ".scheduler.json"), "utf-8")).toThrow();
+
+    expect(mutex.isHeld()).toBe(false);
+  });
+});

--- a/packages/core/tests/reference-scheduler.test.ts
+++ b/packages/core/tests/reference-scheduler.test.ts
@@ -1,0 +1,139 @@
+// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Scheduler } from "../src/reference/sync/scheduler.js";
+import type { SyncResult } from "../src/reference/sync/run-sync.js";
+
+const okResult = (lastSyncAt: string): SyncResult => ({
+  ok: true,
+  lastSyncAt,
+  refreshed: ["latest", "history", "intervals", "routes", "ftp_history"],
+  failures: [],
+});
+
+describe("Scheduler", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "reference-scheduler-"));
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("does NOT register a timer at construction (two-phase API per ADR-0011)", () => {
+    const runSyncSpy = vi.fn();
+
+    new Scheduler({ dataDir: dir, runSync: runSyncSpy, intervalMs: 30_000 });
+
+    vi.advanceTimersByTime(60_000);
+    expect(runSyncSpy).not.toHaveBeenCalled();
+  });
+
+  it("registers setTimeout(nextSyncAt - now) on start() when .scheduler.json says next sync is in the future", async () => {
+    const fixedNow = new Date("2026-05-09T14:00:00Z");
+    vi.setSystemTime(fixedNow);
+
+    writeFileSync(
+      join(dir, ".scheduler.json"),
+      JSON.stringify({
+        schema_version: "1",
+        last_sync_at: new Date(fixedNow.getTime() - 25 * 60_000).toISOString(),
+        next_sync_at: new Date(fixedNow.getTime() + 5 * 60_000).toISOString(),
+      }),
+    );
+
+    const runSyncSpy = vi
+      .fn()
+      .mockResolvedValue(okResult(fixedNow.toISOString()));
+    const scheduler = new Scheduler({
+      dataDir: dir,
+      runSync: runSyncSpy,
+      intervalMs: 30 * 60_000,
+    });
+
+    scheduler.start();
+
+    await vi.advanceTimersByTimeAsync(4 * 60_000);
+    expect(runSyncSpy).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(60_000 + 1);
+    expect(runSyncSpy).toHaveBeenCalledOnce();
+    expect(runSyncSpy).toHaveBeenCalledWith({ caller: "scheduled" });
+  });
+
+  it("schedules immediately on start() in the cold-start case (no .scheduler.json)", async () => {
+    const runSyncSpy = vi
+      .fn()
+      .mockResolvedValue(okResult("2026-05-09T14:00:00Z"));
+
+    const scheduler = new Scheduler({
+      dataDir: dir,
+      runSync: runSyncSpy,
+      intervalMs: 30 * 60_000,
+    });
+    scheduler.start();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(runSyncSpy).toHaveBeenCalledOnce();
+  });
+
+  it("schedules immediately when .scheduler.json's next_sync_at is in the past (warm-start with stale next)", async () => {
+    const fixedNow = new Date("2026-05-09T14:00:00Z");
+    vi.setSystemTime(fixedNow);
+
+    writeFileSync(
+      join(dir, ".scheduler.json"),
+      JSON.stringify({
+        schema_version: "1",
+        last_sync_at: new Date(fixedNow.getTime() - 60 * 60_000).toISOString(),
+        next_sync_at: new Date(fixedNow.getTime() - 5 * 60_000).toISOString(),
+      }),
+    );
+
+    const runSyncSpy = vi
+      .fn()
+      .mockResolvedValue(okResult(fixedNow.toISOString()));
+    const scheduler = new Scheduler({
+      dataDir: dir,
+      runSync: runSyncSpy,
+      intervalMs: 30 * 60_000,
+    });
+    scheduler.start();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(runSyncSpy).toHaveBeenCalledOnce();
+  });
+
+  it("stop() cancels the pending timer; subsequent ticks do not fire", async () => {
+    const fixedNow = new Date("2026-05-09T14:00:00Z");
+    vi.setSystemTime(fixedNow);
+
+    writeFileSync(
+      join(dir, ".scheduler.json"),
+      JSON.stringify({
+        schema_version: "1",
+        last_sync_at: null,
+        next_sync_at: new Date(fixedNow.getTime() + 60_000).toISOString(),
+      }),
+    );
+
+    const runSyncSpy = vi.fn();
+    const scheduler = new Scheduler({
+      dataDir: dir,
+      runSync: runSyncSpy,
+      intervalMs: 30 * 60_000,
+    });
+    scheduler.start();
+    scheduler.stop();
+
+    await vi.advanceTimersByTimeAsync(120_000);
+    expect(runSyncSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/tests/reference-send-snapshot.test.ts
+++ b/packages/core/tests/reference-send-snapshot.test.ts
@@ -133,4 +133,53 @@ describe("sendSnapshotOutput", () => {
     expect(reply).toHaveBeenNthCalledWith(2, "chunk-fallback-2");
     expect(r).toEqual({ sent: 2, total: 2, interrupted: false });
   });
+
+  it("falls back to default backoff when retry_after is Infinity (would otherwise park ~25 days)", async () => {
+    const reply = vi
+      .fn()
+      .mockRejectedValueOnce(makeGrammyRateLimitError(Infinity))
+      .mockResolvedValue(undefined);
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    const r = await sendSnapshotOutput(chunkedOutput(1), { reply, sleep });
+
+    expect(sleep).toHaveBeenCalledWith(1_000); // default, not Infinity
+    expect(r).toEqual({ sent: 1, total: 1, interrupted: false });
+  });
+
+  it("falls back to default backoff when retry_after is NaN", async () => {
+    const reply = vi
+      .fn()
+      .mockRejectedValueOnce(makeGrammyRateLimitError(NaN))
+      .mockResolvedValue(undefined);
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    await sendSnapshotOutput(chunkedOutput(1), { reply, sleep });
+
+    expect(sleep).toHaveBeenCalledWith(1_000);
+  });
+
+  it("falls back to default backoff when retry_after exceeds the 300s cap", async () => {
+    const reply = vi
+      .fn()
+      .mockRejectedValueOnce(makeGrammyRateLimitError(999_999))
+      .mockResolvedValue(undefined);
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    await sendSnapshotOutput(chunkedOutput(1), { reply, sleep });
+
+    expect(sleep).toHaveBeenCalledWith(1_000);
+  });
+
+  it("honors retry_after at the 300s cap boundary", async () => {
+    const reply = vi
+      .fn()
+      .mockRejectedValueOnce(makeGrammyRateLimitError(300))
+      .mockResolvedValue(undefined);
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    await sendSnapshotOutput(chunkedOutput(1), { reply, sleep });
+
+    expect(sleep).toHaveBeenCalledWith(300_000);
+  });
 });

--- a/packages/core/tests/reference-send-snapshot.test.ts
+++ b/packages/core/tests/reference-send-snapshot.test.ts
@@ -1,0 +1,136 @@
+// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { GrammyError } from "grammy";
+import { sendSnapshotOutput } from "../src/reference/sync/send-snapshot.js";
+import type { SnapshotOutput } from "../src/reference/sync/snapshot-debug.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const chunkedOutput = (count: number): SnapshotOutput => ({
+  kind: "chunks",
+  chunks: Array.from({ length: count }, (_, i) => `chunk-${i}`),
+});
+
+const documentOutput = (): SnapshotOutput => ({
+  kind: "document",
+  buffer: Buffer.from('{"big":"dump"}', "utf8"),
+  filename: "snapshot-test.json",
+  chunks: ["chunk-fallback-1", "chunk-fallback-2"],
+});
+
+const makeGrammyRateLimitError = (retryAfterSec: number): unknown => {
+  // GrammyError's constructor is internal; spoof a duck-typed object the
+  // helper inspects via instanceof + property access.
+  const err = Object.create(GrammyError.prototype) as GrammyError;
+  Object.assign(err, {
+    error_code: 429,
+    description: "Too Many Requests",
+    parameters: { retry_after: retryAfterSec },
+    method: "sendMessage",
+    payload: {},
+    message: "Too Many Requests",
+  });
+  return err;
+};
+
+describe("sendSnapshotOutput", () => {
+  it("sends every chunk in order when no failures occur", async () => {
+    const reply = vi.fn().mockResolvedValue(undefined);
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    const r = await sendSnapshotOutput(chunkedOutput(3), { reply, sleep });
+
+    expect(reply).toHaveBeenCalledTimes(3);
+    expect(reply).toHaveBeenNthCalledWith(1, "chunk-0");
+    expect(reply).toHaveBeenNthCalledWith(2, "chunk-1");
+    expect(reply).toHaveBeenNthCalledWith(3, "chunk-2");
+    expect(r).toEqual({ sent: 3, total: 3, interrupted: false });
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it("retries a failing chunk once after sleeping retry_after seconds (Telegram 429)", async () => {
+    const reply = vi
+      .fn()
+      .mockResolvedValueOnce(undefined) // chunk 0
+      .mockRejectedValueOnce(makeGrammyRateLimitError(2)) // chunk 1 fails first time
+      .mockResolvedValueOnce(undefined) // chunk 1 retry succeeds
+      .mockResolvedValueOnce(undefined); // chunk 2
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    const r = await sendSnapshotOutput(chunkedOutput(3), { reply, sleep });
+
+    expect(reply).toHaveBeenCalledTimes(4);
+    expect(sleep).toHaveBeenCalledTimes(1);
+    expect(sleep).toHaveBeenCalledWith(2_000);
+    expect(r).toEqual({ sent: 3, total: 3, interrupted: false });
+  });
+
+  it("falls back to a 1s sleep on non-429 transient errors", async () => {
+    const reply = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("network blip"))
+      .mockResolvedValue(undefined);
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    const r = await sendSnapshotOutput(chunkedOutput(1), { reply, sleep });
+
+    expect(sleep).toHaveBeenCalledWith(1_000);
+    expect(r).toEqual({ sent: 1, total: 1, interrupted: false });
+  });
+
+  it("abandons after a second consecutive failure and sends the 'interrupted at K of N' guidance", async () => {
+    const reply = vi
+      .fn()
+      .mockResolvedValueOnce(undefined) // chunk 0 ok
+      .mockResolvedValueOnce(undefined) // chunk 1 ok
+      .mockRejectedValueOnce(new Error("network")) // chunk 2 fails
+      .mockRejectedValueOnce(new Error("network again")) // retry also fails
+      .mockResolvedValueOnce(undefined); // interrupted-message reply
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    const r = await sendSnapshotOutput(chunkedOutput(5), { reply, sleep });
+
+    expect(r).toEqual({ sent: 2, total: 5, interrupted: true });
+    expect(reply).toHaveBeenCalledTimes(5);
+    const lastCall = reply.mock.calls.at(-1)![0] as string;
+    expect(lastCall).toContain("interrupted at chunk 3 of 5");
+    expect(lastCall).toContain("/snapshot raw");
+  });
+
+  it("uploads the document via sendDocument when output.kind is document", async () => {
+    const reply = vi.fn().mockResolvedValue(undefined);
+    const sendDocument = vi.fn().mockResolvedValue(undefined);
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    const r = await sendSnapshotOutput(documentOutput(), {
+      reply,
+      sendDocument,
+      sleep,
+    });
+
+    expect(sendDocument).toHaveBeenCalledOnce();
+    expect(reply).not.toHaveBeenCalled();
+    expect(r).toEqual({ sent: 1, total: 1, interrupted: false });
+  });
+
+  it("falls through to chunked-with-retry when sendDocument throws (architect-final F5)", async () => {
+    const reply = vi.fn().mockResolvedValue(undefined);
+    const sendDocument = vi.fn().mockRejectedValue(new Error("upload denied"));
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    const r = await sendSnapshotOutput(documentOutput(), {
+      reply,
+      sendDocument,
+      sleep,
+    });
+
+    expect(sendDocument).toHaveBeenCalledOnce();
+    expect(reply).toHaveBeenCalledTimes(2); // both fallback chunks
+    expect(reply).toHaveBeenNthCalledWith(1, "chunk-fallback-1");
+    expect(reply).toHaveBeenNthCalledWith(2, "chunk-fallback-2");
+    expect(r).toEqual({ sent: 2, total: 2, interrupted: false });
+  });
+});

--- a/packages/core/tests/reference-snapshot-debug.test.ts
+++ b/packages/core/tests/reference-snapshot-debug.test.ts
@@ -110,4 +110,40 @@ describe("formatSnapshotRaw", () => {
       expect(out.filename).toMatch(/^snapshot-.*\.json$/);
     }
   });
+
+  it("forces document mode when athlete data contains a Markdown fence-breaker (```)", () => {
+    // An athlete's activity description containing a code block would close
+    // the outer ```json fence early under Markdown parse mode. Document mode
+    // side-steps the escaping entirely.
+    const fenceBreaking: LatestJson = {
+      ...tinyLatest,
+      recent_activities: [
+        {
+          id: 1,
+          name: "Easy ride",
+          description: "Notes from coach:\n```\npush 220W on the climb\n```\nfelt good",
+        },
+      ],
+    };
+
+    const out = formatSnapshotRaw(fenceBreaking);
+    expect(out.kind).toBe("document");
+    if (out.kind === "document") {
+      expect(out.filename).toMatch(/^snapshot-.*\.json$/);
+      // The serialized body still contains the offending substring — the fix
+      // is about routing, not sanitizing.
+      expect(out.buffer.toString("utf8")).toContain("```");
+    }
+  });
+
+  it("forces document mode when a single section contains a fence-breaker", () => {
+    // Sectioned snapshot must apply the same protection.
+    const fenceBreaking: LatestJson = {
+      ...tinyLatest,
+      athlete_profile: { id: "test", bio: "weekend warrior ```cyclist```" },
+    };
+
+    const out = formatSnapshotRaw(fenceBreaking, "athlete_profile");
+    expect(out.kind).toBe("document");
+  });
 });

--- a/packages/core/tests/reference-snapshot-debug.test.ts
+++ b/packages/core/tests/reference-snapshot-debug.test.ts
@@ -1,0 +1,113 @@
+// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
+
+import { describe, expect, it } from "vitest";
+import { formatSnapshotRaw } from "../src/reference/sync/snapshot-debug.js";
+import type { LatestJson } from "../src/reference/schemas/latest.js";
+
+const tinyLatest: LatestJson = {
+  metadata: {
+    schema_version: "1",
+    last_updated: "2026-05-09T14:00:00Z",
+    freshness: "fresh",
+  },
+  athlete_profile: { id: "test", name: "Athlete" },
+  current_status: { fitness: 70 },
+  derived_metrics: {},
+  recent_activities: [{ id: 1 }],
+  planned_workouts: [],
+  wellness_data: { sleep_hours: 7.5 },
+};
+
+describe("formatSnapshotRaw", () => {
+  it("returns 'Reference hasn't synced yet' guidance when latest is null", () => {
+    const out = formatSnapshotRaw(null);
+    expect(out.kind).toBe("chunks");
+    if (out.kind === "chunks") {
+      expect(out.chunks).toHaveLength(1);
+      expect(out.chunks[0]).toContain("Reference hasn't synced yet");
+      expect(out.chunks[0]).toContain("/sync");
+    }
+  });
+
+  it("returns chunked markdown for a small full dump (each chunk ≤4096 chars)", () => {
+    const out = formatSnapshotRaw(tinyLatest);
+    expect(out.kind).toBe("chunks");
+    if (out.kind === "chunks") {
+      expect(out.chunks.length).toBeGreaterThanOrEqual(1);
+      for (const chunk of out.chunks) {
+        expect(chunk.length).toBeLessThanOrEqual(4096);
+        expect(chunk.startsWith("```json")).toBe(true);
+        expect(chunk.endsWith("```")).toBe(true);
+      }
+      // The serialized data should appear somewhere in the chunks.
+      expect(out.chunks.join("")).toContain("\"id\": \"test\"");
+      expect(out.chunks.join("")).toContain("\"sleep_hours\": 7.5");
+    }
+  });
+
+  it("returns just the requested section when a valid name is passed", () => {
+    const out = formatSnapshotRaw(tinyLatest, "wellness_data");
+    expect(out.kind).toBe("chunks");
+    if (out.kind === "chunks") {
+      expect(out.chunks.join("")).toContain("\"sleep_hours\": 7.5");
+      expect(out.chunks.join("")).not.toContain("\"athlete_profile\"");
+    }
+  });
+
+  it("accepts section names case-insensitively", () => {
+    const out = formatSnapshotRaw(tinyLatest, "Wellness_Data");
+    expect(out.kind).toBe("chunks");
+    if (out.kind === "chunks") {
+      expect(out.chunks.join("")).toContain("\"sleep_hours\": 7.5");
+    }
+  });
+
+  it("returns a help-style message listing valid sections when an unknown section is requested", () => {
+    const out = formatSnapshotRaw(tinyLatest, "garbage_section");
+    expect(out.kind).toBe("chunks");
+    if (out.kind === "chunks") {
+      expect(out.chunks).toHaveLength(1);
+      expect(out.chunks[0]).toContain("Unknown section");
+      expect(out.chunks[0]).toContain("athlete_profile");
+      expect(out.chunks[0]).toContain("wellness_data");
+    }
+  });
+
+  it("returns a document buffer when total bytes exceed the document threshold", () => {
+    // Build a recent_activities array large enough to exceed 64 KiB.
+    const fatActivities = Array.from({ length: 200 }, (_, i) => ({
+      id: i,
+      name: `Activity ${i}`,
+      description: "x".repeat(500),
+    }));
+    const fat: LatestJson = {
+      ...tinyLatest,
+      recent_activities: fatActivities,
+    };
+
+    const out = formatSnapshotRaw(fat);
+    expect(out.kind).toBe("document");
+    if (out.kind === "document") {
+      expect(out.buffer.byteLength).toBeGreaterThan(65_536);
+      expect(out.filename).toMatch(/^snapshot-.*\.json$/);
+      const parsed = JSON.parse(out.buffer.toString("utf8"));
+      expect(parsed.recent_activities).toHaveLength(200);
+    }
+  });
+
+  it("returns a document buffer when chunk count would exceed the chunk threshold", () => {
+    // Build a body whose JSON is between byte and chunk thresholds. Trick: many
+    // moderately-sized records that JSON-stringify to >10 chunks but <64 KiB.
+    // 10 chunks × ~4080 chars body ≈ 40 KB — well under the byte limit.
+    const padded: LatestJson = {
+      ...tinyLatest,
+      derived_metrics: { padding: "y".repeat(45_000) },
+    };
+
+    const out = formatSnapshotRaw(padded);
+    expect(out.kind).toBe("document");
+    if (out.kind === "document") {
+      expect(out.filename).toMatch(/^snapshot-.*\.json$/);
+    }
+  });
+});

--- a/packages/core/tests/reference-sync-gate.test.ts
+++ b/packages/core/tests/reference-sync-gate.test.ts
@@ -1,0 +1,11 @@
+// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
+
+import { describe, expect, it } from "vitest";
+import { gateLatestJson } from "../src/reference/validation/sync-gate.js";
+
+describe("gateLatestJson (Wave 1b stub)", () => {
+  it("returns ok with no failures or warnings — Wave 4 / F15 fills the body", () => {
+    const result = gateLatestJson({ anything: 1 }, { prior: "state" });
+    expect(result).toEqual({ ok: true, failures: [], warnings: [] });
+  });
+});

--- a/packages/core/tests/wave1-startup-order.test.ts
+++ b/packages/core/tests/wave1-startup-order.test.ts
@@ -1,0 +1,108 @@
+// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Wave-1 init-order acceptance test (F5 / PRD Decision 13 / ADR-0011).
+ *
+ * The 7-step init sequence in `run-binary.ts` is load-bearing:
+ *   1. Construct Memory (via `new CoachAgent`).
+ *   2. Run startup hook (binary-specific; cycling-coach migrates legacy sections).
+ *   3. Construct Reference services — `new AsyncMutex`, `createRunSync`,
+ *      `new Scheduler` — without registering any timer (two-phase scheduler).
+ *   4. Await first `runSync({ caller: "scheduled" })`. Best-effort; failure logs.
+ *   5. Lazy `Person.units` bootstrap (no-op in Wave 1; site exists for Wave 6).
+ *   5b. `scheduler.start()` — registers periodic timer using now-current
+ *       `.scheduler.json` (which step 4 just rewrote on success).
+ *   6. Open Telegram channel (or CLI loop).
+ *
+ * Reordering ANY of these is a correctness regression — the cold-start
+ * tick-vs-first-sync race re-emerges, half-migrated memory becomes
+ * observable, etc. This test pins the order at the source-text level so a
+ * reorder PR fails CI before reviewers have to spot it.
+ */
+describe("run-binary 7-step init sequence (Wave 1b acceptance)", () => {
+  const SOURCE_PATH = join(__dirname, "..", "src", "run-binary.ts");
+  const src = readFileSync(SOURCE_PATH, "utf-8");
+
+  // Anchor on substrings unique to each step. Each must exist exactly once.
+  const STEPS: ReadonlyArray<readonly [string, string]> = [
+    ["1: Memory (CoachAgent constructor)", "new CoachAgent("],
+    ["2: Startup hook", "await runStartupHook("],
+    ["3a: Reference mutex constructed", "const refMutex = new AsyncMutex()"],
+    ["3b: createRunSync factory", "const runSync = createRunSync("],
+    ["3c: Scheduler constructed (NO timer registered)", "const scheduler = new Scheduler("],
+    ["4: First runSync awaited", 'await runSync({ caller: "scheduled" })'],
+    ["5b: scheduler.start() AFTER first runSync", "scheduler.start();"],
+    ["6: Telegram bot constructed", "createTelegramBot("],
+  ];
+
+  it("each anchor appears exactly once in run-binary.ts source", () => {
+    for (const [label, anchor] of STEPS) {
+      const matches = countOccurrences(src, anchor);
+      expect.soft(matches, `${label} — anchor "${anchor}" should appear exactly once`).toBe(1);
+    }
+  });
+
+  it("anchors appear in the order specified by Decision 13 + ADR-0011", () => {
+    const positions = STEPS.map(([label, anchor]) => {
+      const idx = src.indexOf(anchor);
+      expect.soft(idx, `${label} — anchor "${anchor}" must be present`).toBeGreaterThanOrEqual(0);
+      return { label, idx };
+    });
+
+    for (let i = 1; i < positions.length; i++) {
+      const prev = positions[i - 1];
+      const curr = positions[i];
+      expect
+        .soft(
+          curr.idx,
+          `${curr.label} must come AFTER ${prev.label} (got ${curr.idx} vs ${prev.idx})`,
+        )
+        .toBeGreaterThan(prev.idx);
+    }
+  });
+
+  it("Reference services are NOT constructed before runStartupHook (memory-migration must precede)", () => {
+    const startupHookIdx = src.indexOf("await runStartupHook(");
+    const mutexIdx = src.indexOf("new AsyncMutex()");
+    expect(startupHookIdx).toBeGreaterThan(0);
+    expect(mutexIdx).toBeGreaterThan(0);
+    expect(mutexIdx).toBeGreaterThan(startupHookIdx);
+  });
+
+  it("scheduler.start() is NOT called before the first runSync resolves (two-phase scheduler per ADR-0011)", () => {
+    const firstSyncIdx = src.indexOf('await runSync({ caller: "scheduled" })');
+    const schedulerStartIdx = src.indexOf("scheduler.start();");
+    expect(firstSyncIdx).toBeGreaterThan(0);
+    expect(schedulerStartIdx).toBeGreaterThan(0);
+    expect(schedulerStartIdx).toBeGreaterThan(firstSyncIdx);
+  });
+
+  it("Telegram bot is opened LAST — after every Reference step", () => {
+    const createTelegramIdx = src.indexOf("createTelegramBot(");
+    const schedulerStartIdx = src.indexOf("scheduler.start();");
+    expect(createTelegramIdx).toBeGreaterThan(0);
+    expect(createTelegramIdx).toBeGreaterThan(schedulerStartIdx);
+  });
+
+  it("first runSync is wrapped in try/catch so its failure does NOT crash the binary (best-effort init)", () => {
+    // The pattern is: try { await runSync(...) } catch { console.warn(...) }
+    const tryIdx = src.indexOf("try {\n    await runSync(");
+    const catchIdx = src.indexOf("} catch (err) {", tryIdx);
+    expect(tryIdx).toBeGreaterThan(0);
+    expect(catchIdx).toBeGreaterThan(tryIdx);
+  });
+});
+
+function countOccurrences(haystack: string, needle: string): number {
+  let count = 0;
+  let idx = 0;
+  while ((idx = haystack.indexOf(needle, idx)) !== -1) {
+    count++;
+    idx += needle.length;
+  }
+  return count;
+}

--- a/packages/sport-cycling/src/migrate.ts
+++ b/packages/sport-cycling/src/migrate.ts
@@ -6,20 +6,32 @@ const LEGACY_RENAMES = [
   ["health", "cycling-history"],
 ] as const;
 
+/**
+ * Apply all three legacy renames as a single in-memory transform + single
+ * atomic write to MEMORY.md. Replaces the prior per-rename loop so that
+ * either the migration lands in full or not at all — Reference Wave 1b's
+ * init order assumes the next step never sees a half-migrated MEMORY.md
+ * (architect-final concern 4 / ADR-0011 commit-marker pattern applied to
+ * memory writes).
+ */
 export function migrateCyclingLegacySections(memory: MemoryStore): void {
-  for (const [from, to] of LEGACY_RENAMES) {
-    try {
-      const outcome = memory.renameSection(from, to);
-      console.log(JSON.stringify({ event: "section_rename", from, to, outcome }));
-    } catch (err) {
-      console.warn(
-        JSON.stringify({
-          event: "section_rename_failed",
-          from,
-          to,
-          error: String(err),
-        }),
-      );
-    }
+  let outcomes: Array<"renamed" | "noop" | "merged">;
+  try {
+    outcomes = memory.renameSections(LEGACY_RENAMES);
+  } catch (err) {
+    console.warn(
+      JSON.stringify({
+        event: "section_rename_bulk_failed",
+        error: String(err),
+      }),
+    );
+    return;
+  }
+
+  for (let i = 0; i < LEGACY_RENAMES.length; i++) {
+    const [from, to] = LEGACY_RENAMES[i];
+    console.log(
+      JSON.stringify({ event: "section_rename", from, to, outcome: outcomes[i] }),
+    );
   }
 }

--- a/packages/sport-cycling/tests/migrate-cycling-legacy-sections.test.ts
+++ b/packages/sport-cycling/tests/migrate-cycling-legacy-sections.test.ts
@@ -170,10 +170,13 @@ describe("migrateCyclingLegacySections", () => {
 
   // ── failure handling ────────────────────────────────────────────────
 
-  it("survives partial failure: prior renames stay committed, function does not throw", () => {
-    // Stub MemoryStore that throws on the third call only.
-    let calls = 0;
-    const captured: Array<[string, string]> = [];
+  // Architect-final: migration is now all-or-nothing via the bulk
+  // `renameSections` API. Either all three renames land via a single atomic
+  // write, or none do. Reference Wave 1b's init order assumes step 3 never
+  // sees half-migrated MEMORY.md, so per-section partial commits are no
+  // longer a supported state.
+  it("on bulk failure: function does not throw, no per-rename log events fire, single warn is emitted", () => {
+    const captured: Array<ReadonlyArray<readonly [string, string]>> = [];
     const stub: MemoryStore = {
       readMemory: () => "",
       writeSection: () => {},
@@ -183,28 +186,24 @@ describe("migrateCyclingLegacySections", () => {
       loadPlan: () => null,
       reload: () => {},
       getContext: () => "",
-      renameSection: (from, to) => {
-        calls++;
-        captured.push([from, to]);
-        if (calls === 3) throw new Error("disk full");
-        return "renamed";
+      renameSection: () => "noop",
+      renameSections: (renames) => {
+        captured.push(renames);
+        throw new Error("disk full");
       },
     };
 
     expect(() => migrateCyclingLegacySections(stub)).not.toThrow();
 
-    // All three rename attempts were made (loop continued past the failure).
-    expect(captured).toEqual([
+    expect(captured).toHaveLength(1);
+    expect(captured[0]).toEqual([
       ["profile", "cycling-profile"],
       ["equipment", "cycling-equipment"],
       ["health", "cycling-history"],
     ]);
-    // First two emit success; third emits failure.
-    expect(logEvents()).toHaveLength(2);
+    expect(logEvents()).toHaveLength(0);
     expect(warnEvents()).toContainEqual({
-      event: "section_rename_failed",
-      from: "health",
-      to: "cycling-history",
+      event: "section_rename_bulk_failed",
       error: "Error: disk full",
     });
   });


### PR DESCRIPTION
## Summary

- **F4 — runSync orchestrator + scheduler.** AsyncMutex (FIFO + acquire-timeout + hot-warn, non-reentrant per ADR-0011), Cooldown, chained AbortSignal budgets, per-runSync `IntervalsClient` via wrapper-fetch, gateLatestJson stub for Wave 4, error-state writer with phase tracking, freshnessOf, run-sync orchestrator with cache-files-first / `.scheduler.json`-LAST commit-marker write order + outer-2-min Promise.race timeout that abort()s before writing error_state and force-releasing the mutex, two-phase Scheduler (construct registers no timer; `start()` called only after first runSync resolves — eliminates cold-start tick race).
- **F5 — Telegram /sync, /snapshot raw, 7-step init.** New `/sync` handler (replaces the prior plan-push) calling `runSync({ caller: "/sync", chatId })` with US-18 reply formatting (success / cooldown / mutex_held / unreachable). New `/snapshot raw [section]` and `/snapshot help` — `formatSnapshotRaw` returns chunks-or-document based on `SNAPSHOT_DOCUMENT_THRESHOLD_CHUNKS` (10) / `_BYTES` (64 KiB); `sendSnapshotOutput` does single-retry on 429 (honors `GrammyError.parameters.retry_after`) and falls through to chunked-with-retry if `sendDocument` throws. `run-binary.ts` pins the 7-step init order (Memory → startup hook → construct Reference services → first runSync → units bootstrap site (no-op W1) → `scheduler.start()` → Telegram). Source-anchor test catches reorders before review.
- **Sibling refactor (architect-final, ADR-0011).** New `atomicWriteFileSync` helper; all `MemoryStore` text writes migrate to it. New `MemoryStore.renameSections` bulk method makes `migrateCyclingLegacySections` all-or-nothing — Reference's init step 3 can no longer race a half-migrated `MEMORY.md`.

Sender allowlist already inherits from `createAuthMiddleware`; no per-handler check added (the prior spec's `debug.allowSnapshotRaw` flag was a stale assumption).

## Test plan

- [x] `pnpm -r build` — all 7 workspace packages compile clean (ESM + DTS)
- [x] `pnpm --filter @enduragent/core test` — 508 pass + 3 skipped
- [x] `pnpm --filter sport-cycling test` — 82 pass (including updated migration semantics test)
- [x] `pnpm check:trademarks` — 33 files clean
- [x] Wave-1 init-order source-anchor test pins the 7-step sequence; reordering any anchor in `run-binary.ts` fails the test
- [x] AsyncMutex regression test: nested `runSync` returns `{ skipped: "mutex_held" }` after acquire-timeout, never deadlocks
- [x] runSync outer-timeout: in-flight fetches see `signal.aborted === true` BEFORE `error_state.json` is written; `error_state.phase ∈ {fetching, gating, writing_cache, writing_scheduler}` reflects the step
- [x] Scheduler two-phase: `new Scheduler()` registers no timer; `start()` registers via `setTimeout(max(0, nextSyncAt - now))` only after first runSync resolves
- [x] Snapshot dispatch: under-threshold dump → chunks; > 10 chunks OR > 64 KiB → document; named section returns just that section; unknown section returns help
- [x] /snapshot retry on 429 honors `retry_after`; second failure → "interrupted at K of N"; `sendDocument` failure falls through to chunked-with-retry
- [ ] CI green (build, type-check, tests, trademark lint)
- [ ] Manual smoke after merge: `/sync` from operator chat returns US-18 status; `/snapshot raw` round-trips current `latest.json`; restart leaves `.scheduler.json` valid; `kill -9` mid-sync leaves caches consistent (no torn writes)

## Out of scope (per plan)

- Layer-1 sync gate body (Wave 4 / F15) — `gateLatestJson` ships as a stub returning ok; the call site in runSync exists from day one so F15's PR only changes the function body.
- Cycling DFA / power-curve adapters (Wave 3).
- Curator + system-prompt injection (Wave 5).
- Display units (Wave 6).
- Audit log writer (Wave 7).

## Notes for reviewers

- **Two intentionally-skipped tests** (`reference-abort-budget.test.ts`, `reference-intervals-client-factory.test.ts`): the per-request-timeout-fires assertion against `AbortSignal.timeout` flakes under vitest's parallel pool — fake timers don't intercept that scheduler reliably, and real-timer waits race with other workers' pressure. The behavior is exercised end-to-end at the runSync level (the outer-timeout + abort propagation test passes deterministically). Both are documented inline.
- **`intervals-icu-api@0.1.2`** has no per-method `signal?: AbortSignal`; the constructor's `fetch` option is the only injection point. Tracked upstream PR for proper plumbing; once merged + version-bumped, the wrapper-fetch shim in `intervals-client-factory.ts` can be deleted.