### PR TITLE
refactor(core): move ReferenceServices to reference/services.ts (PR A)

### DIFF
--- a/packages/core/src/channels/telegram.ts
+++ b/packages/core/src/channels/telegram.ts
@@ -14,16 +14,10 @@ import { buildWhatsNewMessage } from "../release-notes.js";
 import { createAuthMiddleware } from "./telegram-access.js";
 import { loadAllowedSenders, loadAllowedSendersWithSource } from "./allowed-senders.js";
 import { escapeHtmlText } from "./html-escape.js";
-import type { RunSyncOpts, SyncResult } from "../reference/sync/run-sync.js";
-import type { LatestJson } from "../reference/schemas/latest.js";
+import type { ReferenceServices } from "../reference/services.js";
 import { formatSyncReply } from "../reference/sync/format-sync-reply.js";
 import { formatSnapshotRaw } from "../reference/sync/snapshot-debug.js";
 import { sendSnapshotOutput } from "../reference/sync/send-snapshot.js";
-
-export interface ReferenceServices {
-  readonly runSync: (opts: RunSyncOpts) => Promise<SyncResult>;
-  readonly loadLatest: () => LatestJson | null;
-}
 
 function formatRateLimitWait(err: unknown): string {
   const ms = extractRetryAfterMs(err);

--- a/packages/core/src/reference/CONTEXT.md
+++ b/packages/core/src/reference/CONTEXT.md
@@ -12,6 +12,7 @@ Reference lives **inside core** at `packages/core/src/reference/` per the Refere
 reference/
 ├── CONTEXT.md          (you are here)
 ├── index.ts            (public barrel — wired into packages/core/src/index.ts)
+├── services.ts         (ReferenceServices — service-aggregate exposed to channels per ADR-0010)
 ├── sport-adapter.ts    (the per-sport seam type — ReferenceSportAdapter + DfaSummary + PowerCurveDelta)
 ├── freshness.ts        (single-source-of-truth constants: freshness, retention, mutex/cooldown timings)
 ├── paths.ts            (referenceDataDir(binaryName) — composes via getCoachHome)
@@ -57,6 +58,13 @@ There is no `migrate-v1-to-v2.ts`. The gate handles drift via discard-and-resync
 ## Sport seam (per ADR-0010)
 
 Sports plug into Reference via the optional `Sport.referenceAdapters?(): readonly ReferenceSportAdapter[]` method (lands type-only in Wave 1; cycling implementation in Wave 3). Each adapter declares activity types it handles, plus declarative metadata (zone basis, decoupling basis, sustainability anchors, DFA-validated flag) and optional algorithm hooks (`computeDfa`, `computePowerCurve`). Two startup invariants — disjoint coverage + subset coverage of `sport.intervalsActivityTypes` — are enforced by Reference's dispatcher (Wave 3 / F12).
+
+## Channel seam (`services.ts`)
+
+Reference exposes a `ReferenceServices` aggregate to downstream channels (Telegram in Wave 1b; CLI / web later) via `services.ts`. The channel imports the type; Reference does not import from channels. Per ADR-0010, layers own their contracts — and this aggregate IS Reference's. Future waves extend `ReferenceServices` in place rather than per-channel:
+
+- Wave 5 / F19 — adds `maybeRefreshIfStale()` for the curator's lazy-sync trigger.
+- Wave 7 — adds operator-facing scheduler controls (`/sync now`, `/scheduler stop`, etc.).
 
 ## Relationships
 

--- a/packages/core/src/reference/index.ts
+++ b/packages/core/src/reference/index.ts
@@ -11,6 +11,9 @@ export type {
   ReferenceSportAdapter,
 } from "./sport-adapter.js";
 
+// ─── Service-aggregate type for downstream channels ───────────────────
+export type { ReferenceServices } from "./services.js";
+
 // ─── Constants ────────────────────────────────────────────────────────
 export {
   FRESH_MS,

--- a/packages/core/src/reference/services.ts
+++ b/packages/core/src/reference/services.ts
@@ -1,0 +1,14 @@
+// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
+
+import type { RunSyncOpts, SyncResult } from "./sync/run-sync.js";
+import type { LatestJson } from "./schemas/latest.js";
+
+/**
+ * Service-aggregate contract that Reference exposes to downstream channels.
+ * Owned by the Reference layer per ADR-0010 — channels import this; Reference
+ * does not import from channels.
+ */
+export interface ReferenceServices {
+  readonly runSync: (opts: RunSyncOpts) => Promise<SyncResult>;
+  readonly loadLatest: () => LatestJson | null;
+}


### PR DESCRIPTION
## Summary

PR A of the 6-PR architectural followup sequence after Reference Wave 1b (PR #91 merged). Moves the \`ReferenceServices\` interface from \`channels/telegram.ts\` into \`reference/services.ts\` so Reference owns its own service-aggregate contract per ADR-0010.

- New \`packages/core/src/reference/services.ts\` (~14 lines, canonical home).
- \`reference/index.ts\` re-exports for the public barrel.
- \`channels/telegram.ts\` imports the type; the redundant pass-through re-export was dropped per /simplify (no in-repo consumer).
- \`reference/CONTEXT.md\` documents the new channel seam.

## Why this matters before Wave 2

Without this move, Wave 5's curator would import \`ReferenceServices\` from a Telegram file, making the import graph look circular even when it type-checks. Wave 7's \`/snapshot metrics\`, \`/snapshot wellness\` etc. would each grow \`ReferenceServices\` — every commit touching \`channels/telegram.ts\` for type-only reasons. Fixing it after Wave 2 means N+1 caller updates instead of one file move.

## Reviews on this PR

- **/simplify** — caught two findings. Dropped the redundant \`telegram.ts\` re-export (no in-repo consumer). Trimmed forward-looking docstring narrating Wave 5/F19 and Wave 7 work (per CLAUDE.md "don't reference future work"; that content lives in \`reference/CONTEXT.md\` instead).
- **/architect** — confirmed the realized shape matches the recommendation. Confirmed \`services.ts\` (data shape) and PR B's planned \`runtime.ts\` (live instance) are the right two-file split. Confirmed the \`RunSyncOpts\` channel leak (Medium) is correctly deferred to PR B's \`bootstrapReference()\` adapter.
- **/qa-engineer** — skipped. Type-only refactor with no behavior change; no edge-case / error-handling / reliability surface to review.

## Test plan

- [x] \`pnpm -r build\` — all 7 workspace packages compile clean (ESM + DTS)
- [x] \`pnpm --filter @enduragent/core test\` — 517 pass + 1 skipped (macOS-only \`keychain.test.ts\` conditional, unrelated)
- [x] \`pnpm --filter sport-cycling test\` — 82 pass
- [x] \`pnpm check:trademarks\` — 33 files clean
- [ ] CI green (build, type-check, tests, trademark lint)

## Out of scope (deferred to subsequent PRs in the sequence)

- **PR B** — \`bootstrapReference()\` extraction + behavioral test replacing source-anchor test + narrow \`RunSyncRequest\` (channels only see \`chatId\`).
- **PR C** — promote primitives to \`core/concurrency/\` + B2 mutex constructor input validation.
- **PR D** — \`SyncResult\` discriminated union + A1+A2 abort propagation + body-error logging.
- **PR E** — run-sync polish (cache-write table + clock injection + phase cleanup).
- **PR F** — Wave 4-5 forward-design scaffolding (\`maybeRefreshIfStale\` stub + extended error_state schema).

Full sequence in \`docs/initiatives/section-11/learnings/reference-wave-1b-followups-architect-review.md\` (gitignored).