### PR TITLE
feat(core): Wave 4-5 forward-design scaffolding (PR F)

### DIFF
--- a/packages/core/src/reference/index.ts
+++ b/packages/core/src/reference/index.ts
@@ -62,4 +62,10 @@ export {
   ERROR_STATE_SCHEMA_VERSION,
   ErrorStateSchema,
   type ErrorState,
+  ErrorPhaseSchema,
+  type ErrorPhase,
+  ErrorCallerSchema,
+  type ErrorCaller,
+  ErrorMitigationSchema,
+  type ErrorMitigation,
 } from "./schemas/index.js";

--- a/packages/core/src/reference/runtime.ts
+++ b/packages/core/src/reference/runtime.ts
@@ -93,6 +93,8 @@ export async function bootstrapReference(
     runSync: (req) => runSyncInternal({ caller: "/sync", chatId: req.chatId }),
     loadLatest: (): LatestJson | null =>
       safeReadJson<LatestJson>(join(referenceDataPath, "latest.json"), LatestJsonSchema),
+    // Wave 1b stub; Wave 5 fills (see ReferenceServices.maybeRefreshIfStale).
+    maybeRefreshIfStale: () => Promise.resolve({ kind: "fresh" }),
   };
 
   return { services, scheduler };

--- a/packages/core/src/reference/schemas/error-state.ts
+++ b/packages/core/src/reference/schemas/error-state.ts
@@ -5,6 +5,14 @@ import { z } from "zod";
 export const ERROR_STATE_SCHEMA_VERSION = "1";
 
 /**
+ * Single source of truth for sync-caller vocabulary, shared between
+ * `run-sync.ts`'s `SyncCaller` type and on-disk `error_state.json`'s
+ * `caller` field. Adding a caller (e.g., a future `"operator"`) here
+ * updates the runtime opt and the schema in lockstep.
+ */
+export const SYNC_CALLERS = ["scheduled", "lazy", "/sync"] as const;
+
+/**
  * `error_state.json` — when the Layer-1 sync gate rejects a fresh sync
  * (e.g., intervals.icu schema drift), it writes this file. The curator
  * reads it at turn start to decide whether to inject an "I cannot validate
@@ -25,6 +33,35 @@ export const ErrorPhaseSchema = z.enum([
 
 export type ErrorPhase = z.infer<typeof ErrorPhaseSchema>;
 
+/**
+ * Wave 4's sync gate populates `mitigation` so the curator (Wave 5) can
+ * choose: force-resync (transient), block-coaching (data corruption that
+ * could mislead the athlete), or warn-only (non-blocking inconsistency).
+ * The schema lands in Wave 1b so on-disk format doesn't need a version
+ * bump when Wave 4 begins writing the field.
+ */
+export const ErrorMitigationSchema = z.enum([
+  "force_resync",
+  "block_coaching",
+  "warn_only",
+]);
+
+export type ErrorMitigation = z.infer<typeof ErrorMitigationSchema>;
+
+/**
+ * `caller` records which orchestrator entry-point triggered the failure —
+ * curator (Wave 5) uses it to decide whether to surface the failure to the
+ * athlete (a `/sync` failure goes to the athlete; a scheduled failure stays
+ * internal until the staleness band crosses a threshold).
+ *
+ * Derived from `SYNC_CALLERS` (this file) so the on-disk schema cannot
+ * drift from the runtime opt's `SyncCaller` type, which `run-sync.ts`
+ * re-derives from `ErrorCaller`.
+ */
+export const ErrorCallerSchema = z.enum(SYNC_CALLERS);
+
+export type ErrorCaller = z.infer<typeof ErrorCallerSchema>;
+
 export const ErrorStateSchema = z
   .object({
     schema_version: z.string(),
@@ -32,6 +69,14 @@ export const ErrorStateSchema = z
     detail: z.string(),
     ts: z.string(),
     phase: ErrorPhaseSchema.optional(),
+    caller: ErrorCallerSchema.optional(),
+    /** e.g., "ftp_source_check". */
+    gate_check: z.string().optional(),
+    /** Any JSON-serializable value; gate-check writers should keep these small for log readability. */
+    expected: z.unknown().optional(),
+    /** Any JSON-serializable value; gate-check writers should keep these small for log readability. */
+    observed: z.unknown().optional(),
+    mitigation: ErrorMitigationSchema.optional(),
   })
   .strict();
 

--- a/packages/core/src/reference/schemas/index.ts
+++ b/packages/core/src/reference/schemas/index.ts
@@ -22,4 +22,10 @@ export {
   ERROR_STATE_SCHEMA_VERSION,
   ErrorStateSchema,
   type ErrorState,
+  ErrorPhaseSchema,
+  type ErrorPhase,
+  ErrorCallerSchema,
+  type ErrorCaller,
+  ErrorMitigationSchema,
+  type ErrorMitigation,
 } from "./error-state.js";

--- a/packages/core/src/reference/services.ts
+++ b/packages/core/src/reference/services.ts
@@ -14,6 +14,23 @@ export interface RunSyncRequest {
 }
 
 /**
+ * Outcome of `maybeRefreshIfStale()`. Discriminated union for symmetry with
+ * `SyncResult` (PR D) — Wave 5's curator dispatches on `kind` rather than
+ * checking for a string sentinel:
+ *
+ *   - `fresh` — `latest.json`'s freshness band is "fresh"; no sync was run.
+ *   - `synced` — freshness band crossed the "stale" or "critical" threshold;
+ *                a lazy `runSync({ caller: "lazy" })` was fired and produced
+ *                the embedded `SyncResult`.
+ *
+ * Wave 1b stub returns `{ kind: "fresh" }` unconditionally; Wave 5's curator
+ * fills the body with the freshness-band check and lazy-fire dispatch.
+ */
+export type StaleCheckResult =
+  | { readonly kind: "fresh" }
+  | { readonly kind: "synced"; readonly result: SyncResult };
+
+/**
  * Service-aggregate contract that Reference exposes to downstream channels.
  * Owned by the Reference layer per ADR-0010 — channels import this; Reference
  * does not import from channels.
@@ -21,4 +38,16 @@ export interface RunSyncRequest {
 export interface ReferenceServices {
   readonly runSync: (req: RunSyncRequest) => Promise<SyncResult>;
   readonly loadLatest: () => LatestJson | null;
+  /**
+   * Wave 5 / F19 fills. Curator calls this at turn start when `latest.json`'s
+   * freshness band is "stale" or "critical" — the lazy-fire path that
+   * complements scheduled syncs. Lazy-fired runSyncs share the mutex,
+   * cooldown, and outer-timeout discipline of scheduled syncs (per ADR-0011).
+   *
+   * Wave 1b stub: returns `{ kind: "fresh" }`. Declaring the seam now means
+   * Wave 5 is a body-only PR (no interface change, no curator/channel
+   * scrambling), and any new channel added in the meantime will see the
+   * full contract instead of a half-shape.
+   */
+  readonly maybeRefreshIfStale: () => Promise<StaleCheckResult>;
 }

--- a/packages/core/src/reference/sync/run-sync.ts
+++ b/packages/core/src/reference/sync/run-sync.ts
@@ -14,14 +14,19 @@ import { INTERVALS_SCHEMA_VERSION } from "../schemas/intervals.js";
 import { ROUTES_SCHEMA_VERSION } from "../schemas/routes.js";
 import { FTP_HISTORY_SCHEMA_VERSION } from "../schemas/ftp-history.js";
 import { SCHEDULER_SCHEMA_VERSION } from "../schemas/scheduler.js";
-import type { ErrorPhase } from "../schemas/error-state.js";
+import type { ErrorPhase, ErrorCaller } from "../schemas/error-state.js";
 import { gateLatestJson } from "../validation/sync-gate.js";
 import { writeErrorState } from "./error-state-writer.js";
 import type { AsyncMutex } from "../../concurrency/mutex.js";
 import type { Cooldown } from "../../concurrency/cooldown.js";
 import type { Clock } from "../../concurrency/clock.js";
 
-export type SyncCaller = "scheduled" | "lazy" | "/sync";
+/**
+ * Re-exported from `error-state.ts` so the runtime opt and the on-disk
+ * persisted schema share a single source of truth (`SYNC_CALLERS` tuple).
+ * Adding a new caller updates both in lockstep.
+ */
+export type SyncCaller = ErrorCaller;
 
 export interface RunSyncOpts {
   readonly forceFresh?: boolean;

--- a/packages/core/tests/reference-error-state-writer.test.ts
+++ b/packages/core/tests/reference-error-state-writer.test.ts
@@ -49,3 +49,42 @@ describe("writeErrorState", () => {
     expect(parsed.phase).toBeUndefined();
   });
 });
+
+describe("ErrorStateSchema (forward-design)", () => {
+  it("accepts the Wave 4 fields (caller, gate_check, expected, observed, mitigation)", () => {
+    // Wave 4's sync-gate writers will populate these fields. Wave 1b
+    // doesn't write them, but the on-disk schema accepts them now so
+    // Wave 4 doesn't need a schema_version bump. Locks in field names so
+    // a typo (e.g. `gate-check` vs `gate_check`) gets caught even before
+    // Wave 4 writes its first sample.
+    const wave4Sample = {
+      schema_version: ERROR_STATE_SCHEMA_VERSION,
+      step: "gate_rejected",
+      detail: "FTP source missing on athlete profile",
+      ts: new Date().toISOString(),
+      caller: "scheduled",
+      gate_check: "ftp_source_check",
+      expected: { source: "test" },
+      observed: { source: null },
+      mitigation: "warn_only",
+    };
+    const parsed = ErrorStateSchema.parse(wave4Sample);
+    expect(parsed.caller).toBe("scheduled");
+    expect(parsed.gate_check).toBe("ftp_source_check");
+    expect(parsed.mitigation).toBe("warn_only");
+  });
+
+  it("rejects unknown fields (.strict() boundary)", () => {
+    // Forward-compat hard line: unrecognized fields are rejected so a
+    // typo in a future writer fails loud instead of silently persisting.
+    expect(() =>
+      ErrorStateSchema.parse({
+        schema_version: ERROR_STATE_SCHEMA_VERSION,
+        step: "gate_rejected",
+        detail: "x",
+        ts: new Date().toISOString(),
+        future_field_typo: "nope",
+      }),
+    ).toThrow();
+  });
+});

--- a/packages/core/tests/reference-runtime.test.ts
+++ b/packages/core/tests/reference-runtime.test.ts
@@ -190,5 +190,24 @@ describe("bootstrapReference (behavioral)", () => {
     expect(runtime.services.loadLatest()).toBeNull();
     runtime.scheduler.stop();
   });
+
+  it("services.maybeRefreshIfStale stub does not trigger a sync (Wave 5 fills body)", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(emptyFetched);
+
+    const runtime = await bootstrapReference({
+      dataDir,
+      intervals: { apiKey: "test-key" },
+      fetchReferenceData: fetchSpy,
+    });
+
+    const result = await runtime.services.maybeRefreshIfStale();
+    expect(result.kind).toBe("fresh");
+    // The stub MUST NOT trigger an extra fetch — only the bootstrap sync ran.
+    // This assertion survives Wave 5 (Wave 5's body MAY fire syncs based on
+    // freshness band; this test will need a re-shape then).
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    runtime.scheduler.stop();
+  });
 });
 


### PR DESCRIPTION
## Summary

PR F (final) of the 6-PR architectural followup sequence. Two scaffolds Wave 4 (sync gate) and Wave 5 (curator) will fill so each becomes a body-only PR — no contract churn, no channel scrambling.

## F.1 services.maybeRefreshIfStale stub

Adds a lazy-refresh seam to `ReferenceServices`:

```ts
export type StaleCheckResult =
  | { readonly kind: \"fresh\" }
  | { readonly kind: \"synced\"; readonly result: SyncResult };

export interface ReferenceServices {
  readonly runSync: (req: RunSyncRequest) => Promise<SyncResult>;
  readonly loadLatest: () => LatestJson | null;
  readonly maybeRefreshIfStale: () => Promise<StaleCheckResult>;
}
```

The union shape mirrors PR D's `SyncResult` so curator code dispatching on both stays uniform. Wave 1b body returns `{ kind: \"fresh\" }`; Wave 5 fills the freshness-band check + lazy-fire dispatch (`runSync({ caller: \"lazy\" })`).

## F.2 Extended error_state.json schema

Adds five optional fields the Wave 4 sync gate will populate: `caller`, `gate_check`, `expected`, `observed`, `mitigation`. Two new closed enums:
- `ErrorCallerSchema` — `scheduled | lazy | \"/sync\"`
- `ErrorMitigationSchema` — `force_resync | block_coaching | warn_only`

Wave 1b writers omit the new fields; Wave 4 won't need a schema_version bump because all five are `.optional()` and `.strict()` still rejects typos.

## Single source of truth

`SYNC_CALLERS` tuple lives in `error-state.ts` (durability boundary wins per architect review). `run-sync.ts` derives `SyncCaller = ErrorCaller`. Adding a new caller (e.g., a future `\"operator\"`) updates the runtime opt and the persisted schema in lockstep.

## Tests

- 537 passed, 1 pre-existing skip
- New `reference-runtime` test: stub does not trigger extra sync at bootstrap
- New `ErrorStateSchema (forward-design)` describe block: accepts the 5 new fields, rejects unknown fields via `.strict()`

## Reviews

- ✅ /simplify (unified `SYNC_CALLERS` source of truth, dropped redundant `as const`, trimmed WHAT-style JSDoc, moved schema-only tests out of writer's describe)
- ✅ /architect (load-bearing decisions validated; `StaleCheckResult` union, `services.ts` placement, schema-as-source-of-truth, `expected`/`observed: unknown` for forward-compat all confirmed)
- ⏭️ /qa-engineer skipped (forward-design scaffolds with no new external behavior)

## Test plan

- [x] `pnpm test` — 537 passed
- [x] `pnpm -r build` — clean
- [x] CI green (will watch)

## Sequence (final)

PR A (#92) → PR B (#93) → PR C (#94) → PR D (#95) → PR E (#96) → **PR F (this)** → Wave 2 starts

The contract surface Wave 2 inherits is now stable.