### PR TITLE
chore(core): strip false section-11 attribution from test files

### DIFF
--- a/packages/core/tests/concurrency-abort-budget.test.ts
+++ b/packages/core/tests/concurrency-abort-budget.test.ts
@@ -1,5 +1,3 @@
-// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
-
 import { afterEach, describe, it, expect, vi } from "vitest";
 import { chainedSignal } from "../src/concurrency/abort-budget.js";
 

--- a/packages/core/tests/concurrency-cooldown.test.ts
+++ b/packages/core/tests/concurrency-cooldown.test.ts
@@ -1,5 +1,3 @@
-// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
-
 import { describe, it, expect } from "vitest";
 import { Cooldown } from "../src/concurrency/cooldown.js";
 

--- a/packages/core/tests/concurrency-mutex.test.ts
+++ b/packages/core/tests/concurrency-mutex.test.ts
@@ -1,5 +1,3 @@
-// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
-
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { AsyncMutex } from "../src/concurrency/mutex.js";
 

--- a/packages/core/tests/helpers/reference-fixtures.ts
+++ b/packages/core/tests/helpers/reference-fixtures.ts
@@ -1,5 +1,3 @@
-// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
-
 import type { FetchedReference } from "../../src/reference/sync/run-sync.js";
 
 /**

--- a/packages/core/tests/reference-error-state-writer.test.ts
+++ b/packages/core/tests/reference-error-state-writer.test.ts
@@ -1,5 +1,3 @@
-// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
-
 import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";

--- a/packages/core/tests/reference-format-sync-reply.test.ts
+++ b/packages/core/tests/reference-format-sync-reply.test.ts
@@ -1,5 +1,3 @@
-// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
-
 import { describe, expect, it } from "vitest";
 import { formatSyncReply } from "../src/reference/sync/format-sync-reply.js";
 import type { SyncResult } from "../src/reference/sync/run-sync.js";

--- a/packages/core/tests/reference-freshness-check.test.ts
+++ b/packages/core/tests/reference-freshness-check.test.ts
@@ -1,5 +1,3 @@
-// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
-
 import { describe, expect, it } from "vitest";
 import { freshnessOf } from "../src/reference/sync/freshness-check.js";
 

--- a/packages/core/tests/reference-intervals-client-factory.test.ts
+++ b/packages/core/tests/reference-intervals-client-factory.test.ts
@@ -1,5 +1,3 @@
-// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
-
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { IntervalsClient } from "intervals-icu-api";
 import {

--- a/packages/core/tests/reference-run-sync.test.ts
+++ b/packages/core/tests/reference-run-sync.test.ts
@@ -1,5 +1,3 @@
-// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
-
 import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";

--- a/packages/core/tests/reference-runtime.test.ts
+++ b/packages/core/tests/reference-runtime.test.ts
@@ -1,5 +1,3 @@
-// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
-
 import { mkdtempSync, rmSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";

--- a/packages/core/tests/reference-scheduler.test.ts
+++ b/packages/core/tests/reference-scheduler.test.ts
@@ -1,5 +1,3 @@
-// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
-
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";

--- a/packages/core/tests/reference-send-snapshot.test.ts
+++ b/packages/core/tests/reference-send-snapshot.test.ts
@@ -1,5 +1,3 @@
-// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
-
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { GrammyError } from "grammy";
 import { sendSnapshotOutput } from "../src/reference/sync/send-snapshot.js";

--- a/packages/core/tests/reference-snapshot-debug.test.ts
+++ b/packages/core/tests/reference-snapshot-debug.test.ts
@@ -1,5 +1,3 @@
-// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
-
 import { describe, expect, it } from "vitest";
 import { formatSnapshotRaw } from "../src/reference/sync/snapshot-debug.js";
 import type { LatestJson } from "../src/reference/schemas/latest.js";

--- a/packages/core/tests/reference-sync-gate.test.ts
+++ b/packages/core/tests/reference-sync-gate.test.ts
@@ -1,5 +1,3 @@
-// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
-
 import { describe, expect, it } from "vitest";
 import { gateLatestJson } from "../src/reference/validation/sync-gate.js";
 

--- a/packages/core/tests/run-binary-init-order.test.ts
+++ b/packages/core/tests/run-binary-init-order.test.ts
@@ -1,5 +1,3 @@
-// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
-
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";


### PR DESCRIPTION
## Summary

- Strips the `// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.` header from 15 test/helper files where the claim is false.
- `NOTICE.md` scopes the port to `packages/core/src/reference/`. section-11 itself has no TypeScript test substrate to port from, so tests for ported logic aren't derivative works.
- Genuine attribution remains on every file under `packages/core/src/reference/` that originates from section-11.

## Files changed (15)

3 concurrency test files:
- `packages/core/tests/concurrency-abort-budget.test.ts`
- `packages/core/tests/concurrency-cooldown.test.ts`
- `packages/core/tests/concurrency-mutex.test.ts`

11 Reference test files:
- `packages/core/tests/reference-error-state-writer.test.ts`
- `packages/core/tests/reference-format-sync-reply.test.ts`
- `packages/core/tests/reference-freshness-check.test.ts`
- `packages/core/tests/reference-intervals-client-factory.test.ts`
- `packages/core/tests/reference-run-sync.test.ts`
- `packages/core/tests/reference-runtime.test.ts`
- `packages/core/tests/reference-scheduler.test.ts`
- `packages/core/tests/reference-send-snapshot.test.ts`
- `packages/core/tests/reference-snapshot-debug.test.ts`
- `packages/core/tests/reference-sync-gate.test.ts`
- `packages/core/tests/run-binary-init-order.test.ts`

1 test helper:
- `packages/core/tests/helpers/reference-fixtures.ts`

Diff: `15 files changed, 30 deletions(-)` — one attribution line + one blank line per file.

## Out of scope (separate decision)

7 source files outside the stated port scope still claim the attribution:
- `packages/core/src/concurrency/{abort-budget,clock,cooldown,mutex}.ts`
- `packages/core/src/io/{atomic-write-file-sync,atomic-write-json,safe-read-json}.ts`

These need a judgment call before fixing: either widen `NOTICE.md` to cover them, or strip the attribution. Pending investigation against section-11's source.

## Test plan

- [x] `pnpm --filter @enduragent/core test` — 537 passed (1 skipped: the optional fixture-stability test that requires `docs/mocks/`)
- [x] Verified no test file under `packages/core/tests/` still claims the attribution: `git grep -lE 'Adapted from CrankAddict/section-11' -- 'packages/core/tests/**'` returns empty.