### PR TITLE
chore(core): strip false section-11 attribution from concurrency/io

### DIFF
--- a/packages/core/src/concurrency/abort-budget.ts
+++ b/packages/core/src/concurrency/abort-budget.ts
@@ -1,5 +1,3 @@
-// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
-
 /**
  * Compose a per-runSync orchestrator signal with a per-request timeout
  * budget. Either source aborting fires the returned signal. Used by the

--- a/packages/core/src/concurrency/clock.ts
+++ b/packages/core/src/concurrency/clock.ts
@@ -1,5 +1,3 @@
-// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
-
 /**
  * Injectable clock primitives for horizontal-layer orchestrators (Reference's
  * `runSync` + `Scheduler`, plus future Decision/Heartbeat/Coaching Loop

--- a/packages/core/src/concurrency/cooldown.ts
+++ b/packages/core/src/concurrency/cooldown.ts
@@ -1,5 +1,3 @@
-// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
-
 /**
  * Per-key cooldown tracker for `/sync` rate-limiting. In-process by design
  * (Decision 5 in F4 spec) — Reference is single-operator; restart-spam is

--- a/packages/core/src/concurrency/mutex.ts
+++ b/packages/core/src/concurrency/mutex.ts
@@ -1,5 +1,3 @@
-// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
-
 /**
  * Non-reentrant async mutex per ADR-0011. Single-owner with a FIFO waiter
  * queue. Each waiter has its own acquire-timeout — timed-out waiters never

--- a/packages/core/src/io/atomic-write-file-sync.ts
+++ b/packages/core/src/io/atomic-write-file-sync.ts
@@ -1,5 +1,3 @@
-// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
-
 import {
   closeSync,
   fdatasyncSync,

--- a/packages/core/src/io/atomic-write-json.ts
+++ b/packages/core/src/io/atomic-write-json.ts
@@ -1,5 +1,3 @@
-// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
-
 import { open, rename, unlink } from "node:fs/promises";
 import { randomBytes } from "node:crypto";
 

--- a/packages/core/src/io/safe-read-json.ts
+++ b/packages/core/src/io/safe-read-json.ts
@@ -1,5 +1,3 @@
-// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
-
 import { readFileSync } from "node:fs";
 import type { ZodTypeAny } from "zod";
 


### PR DESCRIPTION
## Summary

Strips the `// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.` header from 7 source files in `packages/core/src/concurrency/` and `packages/core/src/io/`.

`NOTICE.md` scopes the section-11 port to `packages/core/src/reference/`. These 7 files live outside that scope. Investigation against section-11's actual source (`sync.py` + `SECTION_11.md`) confirms they are project-original code, not derivative works.

## Files changed (7)

| File | Section-11 antecedent? | Verdict |
|------|------------------------|---------|
| `src/io/atomic-write-file-sync.ts` | `sync.py:9419-9423` uses write-temp + `os.replace` | Same well-known technique, different language. Standard pattern, not derivation. |
| `src/io/atomic-write-json.ts` | Same as above | Same. |
| `src/io/safe-read-json.ts` | `sync.py` inlines `json.load(f)` in try/except. No dedicated abstraction. | Project-original. Zod-strict drift gate already credited in `NOTICE.md` modifications. |
| `src/concurrency/abort-budget.ts` | None. `AbortSignal` is a JS-specific API. | Project-original. |
| `src/concurrency/clock.ts` | None. Python tests use `freezegun`/`patch`, not a Clock interface. | Project-original. |
| `src/concurrency/cooldown.ts` | Only training-domain cooldown mentions + a 10-min stale-lockfile check (different mechanism). | Project-original. |
| `src/concurrency/mutex.ts` | `sync.py:9590-9679` — file-based lockfile with PID + stale detection. Entirely different mechanism. | Project-original implementation; concept of "prevent concurrent sync" may have informed design, but no code or algorithm is lifted. |

## Why this matters

The MIT license requires the copyright notice in "all copies or substantial portions of the Software." None of these 7 files lifts a substantial portion of section-11:

- The atomic-write pattern (write-temp + fsync + rename) is a 25-line standard technique documented in countless infrastructure codebases.
- The concurrency primitives (`AbortSignal.any`, async FIFO mutex, in-memory rate limiter, Clock interface) have no section-11 counterpart — section-11 is Python and uses a file-based lockfile.

Overclaiming derivation is worse than no claim: it tells readers section-11 has patterns that aren't there, devalues genuine attribution on the Reference submodule, and creates work for any future maintainer auditing the port.

## Relationship to PR #101

This is a companion to #101, which strips the same false attribution from 15 test/helper files. Different rationale, different scope:

- **#101** — tests are not derivative works (section-11 has no TS test substrate to port from)
- **This PR** — concurrency/io files are project-original code outside `NOTICE.md`'s stated port scope

The two PRs are independent; either can land in any order.

## Test plan

- [x] `pnpm --filter @enduragent/core test` — 537 passed (1 skipped: optional fixture-stability test)
- [x] `git grep -lE 'Adapted from CrankAddict/section-11' -- 'packages/core/src/concurrency/**' 'packages/core/src/io/**'` returns empty