### PR TITLE
chore(core): F7 architect-review follow-ups (#100)

### DIFF
--- a/.changeset/reference-f7-architect-followups.md
+++ b/.changeset/reference-f7-architect-followups.md
@@ -1,0 +1,12 @@
+---
+"@enduragent/core": patch
+---
+
+Reference Wave-2 substrate — architect-review follow-ups on top of F7.
+
+- **Tightened the `metrics/` re-export gate.** Added a second describe block to `tests/reference-strict-schemas.test.ts` that scans `metrics/*.ts` for `export const *Schema` declarations and asserts each appears in the `metrics/index.ts` barrel. Previously the README's Rule 1 ("every metric schema must be re-exported") was reviewer-enforced — the existing `length > 0` check still passed because the cache barrel supplied the count, so a missed F8/F9/F10/F11 re-export would slip through. Skipped today because no metric schemas declared yet; activates when F8 lands the first one.
+- **Branded the rename layer's return types** so the anti-corruption boundary (ADR-0012) is enforced at the type level. `renameTpFieldsOnActivity` / `renameTpFieldsOnWellnessRow` now return `RenamedActivityRow` / `RenamedWellnessRow` (phantom-branded with a `unique symbol`). Two new helpers `parseRenamedActivity(row)` and `parseRenamedWellnessRow(row)` accept only branded input — a sync-path author who calls `ActivitySchema.parse(apiResponse)` directly bypasses the rename layer; the parse helpers turn that bypass into a type error. Defense-in-depth only — the schemas remain publicly exported, so the brand catches forgetfulness, not malice. Pair with `assertNoTpKeysRemain` for nested-aggregate drift.
+- **Stripped the section-11 attribution comment from `metrics/index.ts`.** The barrel is a project-original contract scaffold (it adapts no upstream code); per the just-merged commit `dc5bca4` discipline, attribution belongs only on files that genuinely originate from section-11.
+- **Documentation.** `metrics/README.md` Rule 1 now points at the mechanical gate; Rule 3 gains the rule-of-three corollary ("and when the third metric does need it, extract it"). `reference/CONTEXT.md`'s F8-wiring obligation now tells future authors to go through `parseRenamedActivity` / `parseRenamedWellnessRow` instead of calling the schemas directly.
+
+Pure-infra changeset — athletes don't notice; this tightens drift gates that protect Wave 2 metric authors.

--- a/packages/core/src/reference/CONTEXT.md
+++ b/packages/core/src/reference/CONTEXT.md
@@ -69,13 +69,14 @@ intervals.icu emits seven fields named in TP-trademarked vocabulary. Reference r
 | `activity.icu_ctl` | `fitnessAtEnd` |
 | `activity.icu_atl` | `fatigueAtEnd` |
 
-Two functions + a defensive walker live in `sync/rename-tp-fields.ts`:
+Two functions + a defensive walker + two type-gated parsers live in `sync/rename-tp-fields.ts`:
 
-- `renameTpFieldsOnWellnessRow(raw, summary?)` — five wellness renames.
-- `renameTpFieldsOnActivity(raw, summary?)` — two activity renames.
+- `renameTpFieldsOnWellnessRow(raw, summary?) → RenamedWellnessRow` — five wellness renames.
+- `renameTpFieldsOnActivity(raw, summary?) → RenamedActivityRow` — two activity renames.
 - `assertNoTpKeysRemain(value)` — recursive walker that throws if any TP-denylist key survives anywhere in the input (defense-in-depth for the "intervals.icu adds nested TP aggregates" failure mode). The error path uses `[<index>]` array form only — never includes row-id values — so operator log forwarding stays safe.
+- `parseRenamedActivity(row: RenamedActivityRow) → Activity` and `parseRenamedWellnessRow(row: RenamedWellnessRow) → WellnessDay` — type-gated parse helpers. The branded input type is the type-level half of the anti-corruption boundary: a sync-path author who calls `ActivitySchema.parse(apiResponse)` directly bypasses the rename layer; using the parse helper makes that bypass a type error. Defense-in-depth only — the schemas remain publicly exported, so the brand catches forgetfulness, not malice.
 
-**F8 wiring obligation.** F8 (Wave 2) activates `sync/fetch-reference-data.ts`. When that wiring lands, fetch-reference-data MUST call the rename layer between the API-response parse and the cache-write step. The rename layer is also wired into the operator fixture CLI (`tools/sanitize-fixture.ts`); both call sites stay in lockstep so the typed surface is consistent across sync paths.
+**F8 wiring obligation.** F8 (Wave 2) activates `sync/fetch-reference-data.ts`. When that wiring lands, fetch-reference-data MUST go through `parseRenamedActivity` / `parseRenamedWellnessRow` (which forces the rename call by virtue of their input type) instead of calling `ActivitySchema.parse` / `WellnessDaySchema.parse` directly. The rename layer is also wired into the operator fixture CLI (`tools/sanitize-fixture.ts`); both call sites stay in lockstep so the typed surface is consistent across sync paths.
 
 **Naming-collision callout.** intervals.icu's `WellnessRecord` lib type declares a `fatigue` field (subjective 1–5 scale, athlete-reported). Our Banister-derived `fatigue` (renamed from `atl`) has different semantics. The lib's field rides through via the `z.looseObject` index signature; no future feature should consume both under the same name. If a future feature needs the subjective scale, promote it under a different name (e.g., `subjectiveFatigue`).
 

--- a/packages/core/src/reference/index.ts
+++ b/packages/core/src/reference/index.ts
@@ -92,6 +92,10 @@ export {
 } from "./trademark-policy.js";
 export {
   assertNoTpKeysRemain,
+  parseRenamedActivity,
+  parseRenamedWellnessRow,
   renameTpFieldsOnActivity,
   renameTpFieldsOnWellnessRow,
+  type RenamedActivityRow,
+  type RenamedWellnessRow,
 } from "./sync/rename-tp-fields.js";

--- a/packages/core/src/reference/metrics/README.md
+++ b/packages/core/src/reference/metrics/README.md
@@ -9,7 +9,10 @@ strict-test won't catch it — the schema bypasses the drift gate silently.
 
 **Rule 1 — re-export discipline**: every Zod schema declared inside
 `metrics/*.ts` MUST be re-exported from `metrics/index.ts`. Add the
-re-export in the same PR that adds the schema.
+re-export in the same PR that adds the schema. Mechanically enforced by
+the second `describe` in `tests/reference-strict-schemas.test.ts`, which
+scans `metrics/*.ts` for `export const *Schema` declarations and asserts
+each appears in the barrel.
 
 **Rule 2 — optional-chaining discipline**: when a metric reads an
 `.optional()` field on `Activity`/`WellnessDay`/etc. (e.g.,
@@ -46,9 +49,9 @@ until the third metric needs it; until then, inlining is cheaper than a
 shared abstraction that freezes the wrong shape. ADR-0009 ("defer library
 publishing until a real second consumer exists") is the project's published
 stance against this kind of speculative extraction; it applies one layer
-down too.
+down too. **And when the third metric does need it, extract it** —
+otherwise F11 review opens with four identical copy-pastes.
 
-All three rules are currently enforced by reviewer attention. A future PR may
-add a mechanical lint check (e.g., a build-time script that diffs declared
-schemas against re-exported ones, plus an ESLint rule banning
-`'<input-field>' in <obj>` for known-optional fields).
+Rule 1 is mechanically gated (see above). Rules 2 and 3 are enforced by
+reviewer attention. A future PR may add an ESLint rule banning
+`'<input-field>' in <obj>` for known-optional fields.

--- a/packages/core/src/reference/metrics/index.ts
+++ b/packages/core/src/reference/metrics/index.ts
@@ -1,5 +1,3 @@
-// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
-//
 // Re-export discipline: all metric output schemas MUST be re-exported here
 // or they bypass the strict-schemas regression test (see
 // `tests/reference-strict-schemas.test.ts`). README.md in this directory

--- a/packages/core/src/reference/sync/rename-tp-fields.ts
+++ b/packages/core/src/reference/sync/rename-tp-fields.ts
@@ -19,6 +19,7 @@
 // parse and any downstream consumer — this is the single anti-corruption
 // boundary for this vocabulary. See ADR-0012 + reference/CONTEXT.md.
 
+import { ActivitySchema, WellnessDaySchema, type Activity, type WellnessDay } from "../schemas/inputs.js";
 import { TP_DENYLIST_FIELDS } from "../trademark-policy.js";
 
 export interface NormalizedWellnessFields {
@@ -33,6 +34,20 @@ export interface NormalizedActivityFields {
   fitnessAtEnd?: number | null;
   fatigueAtEnd?: number | null;
 }
+
+// Phantom brand carried only in the type system — at runtime the value is
+// a plain object. The unique symbol makes the brand structurally
+// inaccessible from any module that doesn't import this file, so a future
+// sync-path author can't fake the type by hand-shaping a `Record<string,
+// unknown>` and asserting it. The only legitimate way to obtain a branded
+// row is to call `renameTpFieldsOnActivity` / `renameTpFieldsOnWellnessRow`.
+declare const __renamedBrand: unique symbol;
+
+export type RenamedActivityRow = Record<string, unknown> &
+  NormalizedActivityFields & { readonly [__renamedBrand]: "activity" };
+
+export type RenamedWellnessRow = Record<string, unknown> &
+  NormalizedWellnessFields & { readonly [__renamedBrand]: "wellness" };
 
 /** Aggregator passed by the operator CLI to surface non-number TP values
  *  (real-world drift: API ships a string or boolean where a number was
@@ -112,12 +127,8 @@ function applyKeyRename(
 export function renameTpFieldsOnWellnessRow(
   raw: Record<string, unknown>,
   summary?: RenameSummary,
-): Record<string, unknown> & NormalizedWellnessFields {
-  return applyKeyRename(raw, WELLNESS_TP_TO_PLAIN, WELLNESS_TP_SET, summary) as Record<
-    string,
-    unknown
-  > &
-    NormalizedWellnessFields;
+): RenamedWellnessRow {
+  return applyKeyRename(raw, WELLNESS_TP_TO_PLAIN, WELLNESS_TP_SET, summary) as RenamedWellnessRow;
 }
 
 /**
@@ -128,12 +139,32 @@ export function renameTpFieldsOnWellnessRow(
 export function renameTpFieldsOnActivity(
   raw: Record<string, unknown>,
   summary?: RenameSummary,
-): Record<string, unknown> & NormalizedActivityFields {
-  return applyKeyRename(raw, ACTIVITY_TP_TO_PLAIN, ACTIVITY_TP_SET, summary) as Record<
-    string,
-    unknown
-  > &
-    NormalizedActivityFields;
+): RenamedActivityRow {
+  return applyKeyRename(raw, ACTIVITY_TP_TO_PLAIN, ACTIVITY_TP_SET, summary) as RenamedActivityRow;
+}
+
+/**
+ * Parse a renamed activity row into a typed Activity. The branded input
+ * type is the type-level enforcement of ADR-0012's anti-corruption
+ * boundary: a future sync-path author who calls `ActivitySchema.parse(raw)`
+ * directly bypasses the rename layer; this helper makes that bypass
+ * a type error. F4-style sync paths SHOULD use this instead of calling
+ * `ActivitySchema.parse` themselves.
+ *
+ * Defense-in-depth only — `ActivitySchema` is still publicly exported for
+ * tests and historical callers, so the brand catches forgetfulness, not
+ * malice. Pair with `assertNoTpKeysRemain` for nested-aggregate drift.
+ */
+export function parseRenamedActivity(row: RenamedActivityRow): Activity {
+  return ActivitySchema.parse(row);
+}
+
+/**
+ * Parse a renamed wellness row into a typed WellnessDay. See
+ * `parseRenamedActivity` for the contract.
+ */
+export function parseRenamedWellnessRow(row: RenamedWellnessRow): WellnessDay {
+  return WellnessDaySchema.parse(row);
 }
 
 const DENYLIST_SET: ReadonlySet<string> = new Set(TP_DENYLIST_FIELDS);

--- a/packages/core/tests/reference-rename-tp-fields.test.ts
+++ b/packages/core/tests/reference-rename-tp-fields.test.ts
@@ -12,6 +12,8 @@ import { describe, expect, it } from "vitest";
 
 import {
   assertNoTpKeysRemain,
+  parseRenamedActivity,
+  parseRenamedWellnessRow,
   renameTpFieldsOnActivity,
   renameTpFieldsOnWellnessRow,
   type RenameSummary,
@@ -236,5 +238,65 @@ describe("assertNoTpKeysRemain", () => {
       ],
     };
     expect(() => assertNoTpKeysRemain(cleanBundle)).not.toThrow();
+  });
+});
+
+describe("parseRenamedActivity / parseRenamedWellnessRow — branded type gate", () => {
+  // Type-level test: the branded input type forces sync-path authors
+  // through the rename layer. The runtime body just delegates to the
+  // schema parse; the load-bearing piece is the type signature, exercised
+  // here by composing rename → parse and asserting the resulting Activity
+  // has the post-rename fields.
+
+  it("parseRenamedActivity accepts the output of renameTpFieldsOnActivity and returns a typed Activity", () => {
+    const renamed = renameTpFieldsOnActivity({
+      id: 17654321,
+      start_date_local: "2026-04-15T07:00:00",
+      type: "Ride",
+      moving_time: 3600,
+      elapsed_time: 3700,
+      icu_ctl: 52.1,
+      icu_atl: 38.4,
+    });
+    const activity = parseRenamedActivity(renamed);
+    expect(activity.fitnessAtEnd).toBe(52.1);
+    expect(activity.fatigueAtEnd).toBe(38.4);
+    // TP source keys never appear on the typed surface — the rename layer
+    // strips them and the schema's named fields don't include them.
+    expect((activity as Record<string, unknown>).icu_ctl).toBeUndefined();
+    expect((activity as Record<string, unknown>).icu_atl).toBeUndefined();
+  });
+
+  it("parseRenamedWellnessRow accepts the output of renameTpFieldsOnWellnessRow", () => {
+    const renamed = renameTpFieldsOnWellnessRow({
+      id: "2026-04-15",
+      weight: 70,
+      restingHR: 50,
+      hrv: 80,
+      sleepSecs: 28800,
+      sleepQuality: 4,
+      ctl: 52.1,
+      atl: 38.4,
+    });
+    const day = parseRenamedWellnessRow(renamed);
+    expect(day.fitness).toBe(52.1);
+    expect(day.fatigue).toBe(38.4);
+    expect((day as Record<string, unknown>).ctl).toBeUndefined();
+    expect((day as Record<string, unknown>).atl).toBeUndefined();
+  });
+
+  it("type system rejects un-renamed input — checked via @ts-expect-error", () => {
+    // The directive below fails the build if the line *does* type-check.
+    // That's the load-bearing assertion: a sync-path author who skips the
+    // rename call gets a type error, not a silent runtime bypass.
+    const unrenamedRaw: Record<string, unknown> = {
+      id: 17654321,
+      start_date_local: "2026-04-15T07:00:00",
+      type: "Ride",
+      moving_time: 3600,
+      elapsed_time: 3700,
+    };
+    // @ts-expect-error — RenamedActivityRow brand cannot be conjured from a plain Record
+    parseRenamedActivity(unrenamedRaw);
   });
 });

--- a/packages/core/tests/reference-strict-schemas.test.ts
+++ b/packages/core/tests/reference-strict-schemas.test.ts
@@ -1,3 +1,7 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
 import { describe, it, expect } from "vitest";
 import { z } from "zod";
 
@@ -81,4 +85,66 @@ describe("Reference Zod schemas — every object schema declares .strict()", () 
       `Schema ${name} is not strict: ${result.reason ?? "unknown reason"}`,
     ).toBe(true);
   });
+});
+
+/**
+ * Re-export-discipline gate for metrics/. The barrel walker above only
+ * fires on schemas that *did* reach `metrics/index.ts`. A metric author
+ * who declares `LoadManagementSchema` in `metrics/load-management.ts` but
+ * forgets the re-export silently bypasses the strict-gate. This test
+ * scans every `metrics/*.ts` sibling, extracts top-level
+ * `export const *Schema = ...` declarations, and asserts each one appears
+ * in the imported barrel. Contract documented in `metrics/README.md`
+ * (Rule 1).
+ *
+ * Scope: top-level `export const FooSchema` only. Multi-line declarations,
+ * re-exports through `export {}` aliases, and conditionally-exported
+ * schemas are out of scope — adding any of those should be paired with a
+ * tightening of the regex.
+ */
+
+const METRICS_DIR = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "src",
+  "reference",
+  "metrics",
+);
+const SCHEMA_DECL_RE = /^export\s+const\s+([A-Z][A-Za-z0-9_]*Schema)\b/gm;
+
+function declaredMetricSchemas(): Array<readonly [string, string]> {
+  const found: Array<readonly [string, string]> = [];
+  for (const entry of readdirSync(METRICS_DIR, { withFileTypes: true })) {
+    if (!entry.isFile()) continue;
+    if (!entry.name.endsWith(".ts")) continue;
+    if (entry.name === "index.ts") continue;
+    if (entry.name.endsWith(".test.ts")) continue;
+    const source = readFileSync(resolve(METRICS_DIR, entry.name), "utf-8");
+    for (const match of source.matchAll(SCHEMA_DECL_RE)) {
+      found.push([entry.name, match[1]]);
+    }
+  }
+  return found;
+}
+
+describe("metrics/ re-export discipline (metrics/README.md Rule 1)", () => {
+  const declared = declaredMetricSchemas();
+  const barrelExports = new Set(Object.keys(metricsBarrel));
+
+  if (declared.length === 0) {
+    it.skip("no metric schemas declared yet — gate becomes active when F8 lands the first one", () => {});
+    return;
+  }
+
+  it.each(declared)(
+    "%s declares export const %s — barrel re-exports it",
+    (file, name) => {
+      expect(
+        barrelExports.has(name),
+        `${file} declares \`export const ${name}\` but it is missing from metrics/index.ts. ` +
+          `Add the re-export in the same PR per metrics/README.md Rule 1, or the schema bypasses ` +
+          `the strict-gate above.`,
+      ).toBe(true);
+    },
+  );
 });


### PR DESCRIPTION
Stacked on top of #100. Three architect-review follow-ups, each scoped to one drift gate. Pure-infra; athletes don't notice.

## Summary

- **Mechanical re-export-discipline gate for `metrics/`.** `tests/reference-strict-schemas.test.ts` gains a second describe block that scans `metrics/*.ts` for `export const *Schema` and asserts each appears in the `metrics/index.ts` barrel. Previously the README's Rule 1 was reviewer-enforced — the existing `length > 0` check still passed because the cache barrel supplied the count, so a missed F8/F9/F10/F11 re-export would slip through silently. Skipped today, activates when F8 lands the first metric schema.
- **Branded the rename layer's return types** so ADR-0012's anti-corruption boundary is type-enforced where it was previously discipline-enforced. `renameTpFieldsOnActivity` / `renameTpFieldsOnWellnessRow` now return `RenamedActivityRow` / `RenamedWellnessRow` (phantom-branded with a `unique symbol`). New helpers `parseRenamedActivity(row)` / `parseRenamedWellnessRow(row)` accept only branded input — a sync-path author who calls `ActivitySchema.parse(apiResponse)` directly bypasses the rename layer; the parse helpers turn that bypass into a type error. Defense-in-depth only — the schemas remain publicly exported, so the brand catches forgetfulness, not malice. Pair with `assertNoTpKeysRemain` for nested-aggregate drift.
- **Stripped the section-11 attribution from `metrics/index.ts`.** Empty barrel scaffold is project-original; per dc5bca4 attribution belongs only on files that genuinely originate from section-11.
- **Doc pass.** `metrics/README.md` Rule 1 now points at the mechanical gate; Rule 3 gains the rule-of-three corollary ("and when the third metric does need it, extract it"). `reference/CONTEXT.md`'s F8-wiring obligation tells future authors to use `parseRenamedActivity` / `parseRenamedWellnessRow` instead of calling the schemas directly.

## Test plan

- [x] `pnpm --filter @enduragent/core test` — 639 passed / 3 skipped (3 added: branded-type gate ×2 acceptance + 1 `@ts-expect-error` on un-renamed input)
- [x] `pnpm -r build` — clean across all packages
- [x] `pnpm check:trademarks` — 48 file(s) clean
- [x] New "metrics/ re-export discipline" describe is correctly skipped today (no metric schemas yet); will fail loud when F8 declares one without re-exporting.
- [x] `@ts-expect-error` on `parseRenamedActivity(unrenamedRaw)` proves the brand type-rejects un-renamed input — if the brand ever silently dies, this directive starts erroring.