### PR TITLE
chore(core): consolidate upstream attribution to NOTICE.md + README Credits

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -77,15 +77,8 @@ copy; the following modifications were applied during the port:
   disk; `formatQuantity(quantity, athleteUnits)` renders to the athlete's
   preferred system. Section-11's mixed-units assumptions are removed.
 
-### Where the upstream credit appears in source
+### Canonical attribution surfaces
 
-- `packages/core/src/reference/CONTEXT.md` opens with a section-11 credit
-  paragraph.
-- Each ported file in `packages/core/src/reference/`,
-  `packages/core/src/concurrency/`, and the JSON I/O helpers under
-  `packages/core/src/io/` carries a one-line header comment:
-  `// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.`
-- This file (`NOTICE.md`) and the [`README.md` Credits section](./README.md#credits)
-  are the canonical attribution surfaces.
-
-The full upstream repository is at https://github.com/CrankAddict/section-11.
+This file (`NOTICE.md`) and the [`README.md` Credits section](./README.md#credits)
+are the canonical attribution surfaces. The full upstream repository is at
+https://github.com/CrankAddict/section-11.

--- a/packages/core/src/reference/CONTEXT.md
+++ b/packages/core/src/reference/CONTEXT.md
@@ -1,6 +1,6 @@
 # Reference
 
-Reference is a port of [section-11](https://github.com/CrankAddict/section-11) (CrankAddict, MIT, protocol v11.43). See [`NOTICE.md`](../../../../NOTICE.md) for full attribution and the list of modifications introduced during the port. Per-file boilerplate convention: every file under `packages/core/src/reference/` carries a one-line header comment — `// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.` — establishing the credit at the source.
+Reference is a port of [section-11](https://github.com/CrankAddict/section-11) (CrankAddict, MIT, protocol v11.43). See [`NOTICE.md`](../../../../NOTICE.md) for full attribution and the list of modifications introduced during the port. NOTICE.md is the canonical attribution surface; the repo does not carry per-file header boilerplate.
 
 Reference is the **data + sport-aware adapter substrate** that grounds coaching in verified athlete numerics. Without Reference, the agent answered training questions from whatever fragments the LLM remembered + whatever live `intervals_fetch_*` call happened to fire that turn — a fragile composition that drifted across sessions and produced different numbers for the same question depending on what slipped through compaction. Reference replaces that with a curated `latest.json` snapshot injected into every system prompt, plus `reference_read_*` tools for the LLM to ask for derived metrics by name.
 
@@ -103,6 +103,6 @@ Reference exposes a `ReferenceServices` aggregate to downstream channels (Telegr
 
 ## Out of scope (Wave 1)
 
-The placeholder directories `metrics/`, `validation/`, `curator/`, `units/`, `audit/` are reserved for future waves. Each ships its own focused PR with its own per-file section-11 attribution boilerplate.
+The placeholder directories `metrics/`, `validation/`, `curator/`, `units/`, `audit/` are reserved for future waves. Each ships its own focused PR.
 
 For the full per-wave plan, see `docs/initiatives/section-11/features/reference/`.

--- a/packages/core/src/reference/freshness.ts
+++ b/packages/core/src/reference/freshness.ts
@@ -1,4 +1,3 @@
-// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
 //
 // Single source of truth for Reference's freshness, retention, and sync-loop
 // timing constants. Imported by every Reference module that needs a window;

--- a/packages/core/src/reference/index.ts
+++ b/packages/core/src/reference/index.ts
@@ -1,5 +1,3 @@
-// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
-
 // ─── Per-sport seam type (ADR-0010) ───────────────────────────────────
 export type {
   DfaSummary,

--- a/packages/core/src/reference/paths.ts
+++ b/packages/core/src/reference/paths.ts
@@ -1,5 +1,3 @@
-// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
-
 import { join } from "node:path";
 import { getCoachHome } from "../coach-home.js";
 

--- a/packages/core/src/reference/preserve-tokens.ts
+++ b/packages/core/src/reference/preserve-tokens.ts
@@ -1,5 +1,3 @@
-// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
-
 /**
  * Reference-owned MUST-PRESERVE compaction tokens — metric and framework
  * names whose verbatim form must survive 200-turn sessions. Each sport's

--- a/packages/core/src/reference/runtime.ts
+++ b/packages/core/src/reference/runtime.ts
@@ -1,5 +1,3 @@
-// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
-
 import { mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { AsyncMutex } from "../concurrency/mutex.js";

--- a/packages/core/src/reference/schemas/cache-index.ts
+++ b/packages/core/src/reference/schemas/cache-index.ts
@@ -1,4 +1,3 @@
-// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
 //
 // Cache-schemas-only barrel — used by the strict-schemas regression test
 // (tests/reference-strict-schemas.test.ts) which scopes to cache schemas

--- a/packages/core/src/reference/schemas/error-state.ts
+++ b/packages/core/src/reference/schemas/error-state.ts
@@ -1,5 +1,3 @@
-// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
-
 import { z } from "zod";
 
 export const ERROR_STATE_SCHEMA_VERSION = "1";

--- a/packages/core/src/reference/schemas/ftp-history.ts
+++ b/packages/core/src/reference/schemas/ftp-history.ts
@@ -1,5 +1,3 @@
-// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
-
 import { z } from "zod";
 
 export const FTP_HISTORY_SCHEMA_VERSION = "1";

--- a/packages/core/src/reference/schemas/history.ts
+++ b/packages/core/src/reference/schemas/history.ts
@@ -1,5 +1,3 @@
-// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
-
 import { z } from "zod";
 
 export const HISTORY_SCHEMA_VERSION = "1";

--- a/packages/core/src/reference/schemas/index.ts
+++ b/packages/core/src/reference/schemas/index.ts
@@ -1,4 +1,3 @@
-// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
 //
 // The strict-schemas regression test scopes to cache-index.ts only; input
 // schemas use z.looseObject() and are excluded from the strict-gate by design.

--- a/packages/core/src/reference/schemas/inputs.ts
+++ b/packages/core/src/reference/schemas/inputs.ts
@@ -1,4 +1,3 @@
-// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
 //
 // Why z.looseObject and not .strict(): cache schemas gate against on-disk
 // drift via .strict(). Input schemas project upstream-API responses we

--- a/packages/core/src/reference/schemas/intervals.ts
+++ b/packages/core/src/reference/schemas/intervals.ts
@@ -1,5 +1,3 @@
-// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
-
 import { z } from "zod";
 
 export const INTERVALS_SCHEMA_VERSION = "1";

--- a/packages/core/src/reference/schemas/latest.ts
+++ b/packages/core/src/reference/schemas/latest.ts
@@ -1,5 +1,3 @@
-// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
-
 import { z } from "zod";
 
 // Bump this only when THIS file's shape changes — never in lockstep with

--- a/packages/core/src/reference/schemas/routes.ts
+++ b/packages/core/src/reference/schemas/routes.ts
@@ -1,5 +1,3 @@
-// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
-
 import { z } from "zod";
 
 export const ROUTES_SCHEMA_VERSION = "1";

--- a/packages/core/src/reference/schemas/scheduler.ts
+++ b/packages/core/src/reference/schemas/scheduler.ts
@@ -1,5 +1,3 @@
-// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
-
 import { z } from "zod";
 
 export const SCHEDULER_SCHEMA_VERSION = "1";

--- a/packages/core/src/reference/services.ts
+++ b/packages/core/src/reference/services.ts
@@ -1,5 +1,3 @@
-// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
-
 import type { SyncResult } from "./sync/run-sync.js";
 import type { LatestJson } from "./schemas/latest.js";
 

--- a/packages/core/src/reference/sport-adapter.ts
+++ b/packages/core/src/reference/sport-adapter.ts
@@ -1,5 +1,3 @@
-// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
-
 import type { Activity } from "intervals-icu-api";
 import type { IntervalsActivityType } from "../sport.js";
 

--- a/packages/core/src/reference/sync/error-state-writer.ts
+++ b/packages/core/src/reference/sync/error-state-writer.ts
@@ -1,5 +1,3 @@
-// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
-
 import { join } from "node:path";
 import {
   ERROR_STATE_SCHEMA_VERSION,

--- a/packages/core/src/reference/sync/fetch-reference-data.ts
+++ b/packages/core/src/reference/sync/fetch-reference-data.ts
@@ -1,5 +1,3 @@
-// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
-
 import type { IntervalsClient } from "intervals-icu-api";
 import type { FetchedReference } from "./run-sync.js";
 import { makeAbortableClient } from "./intervals-client-factory.js";

--- a/packages/core/src/reference/sync/format-sync-reply.ts
+++ b/packages/core/src/reference/sync/format-sync-reply.ts
@@ -1,5 +1,3 @@
-// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
-
 import type { SyncResult } from "./run-sync.js";
 
 /**

--- a/packages/core/src/reference/sync/freshness-check.ts
+++ b/packages/core/src/reference/sync/freshness-check.ts
@@ -1,5 +1,3 @@
-// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
-
 import { CRITICAL_MS, FRESH_MS, STALE_MS } from "../freshness.js";
 
 export type Freshness = "fresh" | "flag" | "stale" | "critical";

--- a/packages/core/src/reference/sync/intervals-client-factory.ts
+++ b/packages/core/src/reference/sync/intervals-client-factory.ts
@@ -1,5 +1,3 @@
-// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
-
 import { IntervalsClient } from "intervals-icu-api";
 import { chainedSignal } from "../../concurrency/abort-budget.js";
 

--- a/packages/core/src/reference/sync/run-sync.ts
+++ b/packages/core/src/reference/sync/run-sync.ts
@@ -1,5 +1,3 @@
-// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
-
 import { join } from "node:path";
 import {
   MUTEX_ACQUIRE_TIMEOUT_MS,

--- a/packages/core/src/reference/sync/scheduler.ts
+++ b/packages/core/src/reference/sync/scheduler.ts
@@ -1,5 +1,3 @@
-// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
-
 import { join } from "node:path";
 import { safeReadJson } from "../../io/safe-read-json.js";
 import { SchedulerStateSchema } from "../schemas/scheduler.js";

--- a/packages/core/src/reference/sync/send-snapshot.ts
+++ b/packages/core/src/reference/sync/send-snapshot.ts
@@ -1,5 +1,3 @@
-// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
-
 import { GrammyError } from "grammy";
 import type { SnapshotOutput } from "./snapshot-debug.js";
 

--- a/packages/core/src/reference/sync/snapshot-debug.ts
+++ b/packages/core/src/reference/sync/snapshot-debug.ts
@@ -1,5 +1,3 @@
-// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
-
 import {
   SNAPSHOT_DOCUMENT_THRESHOLD_BYTES,
   SNAPSHOT_DOCUMENT_THRESHOLD_CHUNKS,

--- a/packages/core/src/reference/validation/sync-gate.ts
+++ b/packages/core/src/reference/validation/sync-gate.ts
@@ -1,5 +1,3 @@
-// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.
-
 /**
  * Layer-1 sync gate per Reference PRD Decision 7. Wave-1 STUB — always
  * returns ok. Wave 4 / F15 replaces the body with the actual mechanical


### PR DESCRIPTION
## Summary

Strip the per-file `// Adapted from CrankAddict/section-11 (MIT, 2026); see NOTICE.md.` header from 27 derivative files under `packages/core/src/reference/`. NOTICE.md (repo root) travels with the package and is what MIT requires for the copyright notice; per-file annotation was convention, not a license obligation, and reinforced a "section-11 port" identity in code surfaces that should describe what the project owns and ships (the Reference layer) rather than its upstream.

## Why

The project's voice should describe what it *is* (Reference layer, Sport contract, snapshot harness), not what it *derives from*. NOTICE.md plus the README Credits section already carry the canonical attribution; the per-file headers added noise on top of that without earning their place. Stripping them makes the codebase read like an independent platform that credits its foundations in the legally-required surfaces, rather than a header-tagged port.

## Changes

- **27 `.ts` files** under `packages/core/src/reference/` — header line removed; following blank line preserved as standard import-block prefix.
- **`NOTICE.md`** — "Where the upstream credit appears in source" subsection trimmed to "Canonical attribution surfaces" (single paragraph pointing at NOTICE.md + README Credits). MIT verbatim license + modifications list above it are unchanged.
- **`packages/core/src/reference/CONTEXT.md`** — drops the "Per-file boilerplate convention" sentence from the opening paragraph and the per-file attribution clause from the out-of-scope section.

No source code logic changed. No schemas changed. No public API affected.

## MIT compliance note

MIT requires "the above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software." NOTICE.md sits at the repo root and ships in every clone / npm tarball; that satisfies the obligation. Per-file marking is a stronger-than-required convention many projects skip without legal issue.

## Test plan

- [x] `pnpm lint` — only the pre-existing empty-file warning on `packages/core/src/reference/metrics/index.ts` (unrelated)
- [x] `pnpm vitest run packages/core/tests/reference-*.test.ts` — 147 tests pass across 16 files
- [x] Grep verifies zero remaining `Adapted from CrankAddict/section-11` mentions in checked-in source (only build artifacts under `dist/` remain, which are gitignored and regenerate on build)