### PR TITLE
feat(core): F8 ACWR port + snapshot harness allowlist

### DIFF
--- a/.changeset/reference-acwr-first-metric.md
+++ b/.changeset/reference-acwr-first-metric.md
@@ -1,0 +1,15 @@
+---
+"@enduragent/core": patch
+---
+
+User-facing: ACWR (load freshness ratio) now computed in the reference layer — the first metric in F8 with bit-identical parity against the upstream protocol.
+
+- Added `packages/core/src/reference/metrics/load-management.ts` with `computeAcwr`. Line-by-line port of `sync.py:3023-3028` + `sync.py:3629-3644` (`_get_daily_tss`). Cites Gabbett 2016 (Br J Sports Med 50:273-280, DOI 10.1136/bjsports-2015-095788) for the underlying acute/chronic load model.
+- Registered ACWR in `tools/check-metric-parity.ts`'s `METRIC_REGISTRY`. The gate signature now passes `{ fixture, frozenNow }` to compute functions so date-relative math can match the snapshot anchor.
+- Extended `tools/snapshot-section-11.ts` to iterate over an explicit `HARNESS_FIXTURES` allowlist (realistic-athlete + new-athlete-empty + data-gap-mid-history), with per-fixture `frozenNow`. Fixtures owned by other test suites (F7 reference substrate's `post-break-resume`, `zero-activities`) live alongside but are intentionally excluded from the snapshot harness.
+- New golden fixtures:
+  - `new-athlete-empty.json` — zero activities, zero wellness, zero ftp_history; forces every "no data" branch (ACWR returns `null` from `chronic_load <= 0`).
+  - `data-gap-mid-history.json` — 21 activities split by a 28-day gap; the resumed week populates the acute window while chronic is mostly depleted, so ACWR resolves to 3.51 (above-1.5 spike territory).
+- Bit-identical parity holds across all 3 fixtures: `pnpm check-parity --metric=acwr --fixture=all` exits 0 with `0.81 / null / 3.51`.
+
+No deviation registered in `tools/intentional-deviations.yaml` — ACWR is a faithful transliteration. Discipline: `docs/adr/0016-metric-porting-discipline.md`.

--- a/packages/core/src/reference/metrics/README.md
+++ b/packages/core/src/reference/metrics/README.md
@@ -14,6 +14,13 @@ the second `describe` in `tests/reference-strict-schemas.test.ts`, which
 scans `metrics/*.ts` for `export const *Schema` declarations and asserts
 each appears in the barrel.
 
+Per the 2026-05-21 ADR-0014 scope clarification, this rule applies to
+**envelope schemas** (the curator-facing discriminated unions). Raw
+`compute*` functions that feed the parity gate are NOT barrel-exported —
+they are called via `METRIC_REGISTRY` (`./registry.ts`) which statically
+imports each compute function from its sibling file. The barrel is the
+curator-consumable surface; the registry is the gate-consumable surface.
+
 **Rule 2 — optional-chaining discipline**: when a metric reads an
 `.optional()` field on `Activity`/`WellnessDay`/etc. (e.g.,
 `activity.icu_intervals`, `wellness.bodyFat`), use optional-chaining or

--- a/packages/core/src/reference/metrics/load-management.ts
+++ b/packages/core/src/reference/metrics/load-management.ts
@@ -1,0 +1,95 @@
+/**
+ * Reference layer — load-management metrics.
+ *
+ * Computers in this module port the metric math from the Reference layer's
+ * upstream protocol. See `NOTICE.md` for license attribution.
+ */
+
+import type { Activity } from "../schemas/inputs.js";
+
+import type { MetricInput } from "./metric-input.js";
+
+/**
+ * Acute:Chronic Workload Ratio (Gabbett 2016).
+ *
+ * Acute load = mean daily Load over the trailing 7 days (today and the
+ * six prior days). Chronic load = mean daily Load over the trailing 28
+ * days. Days with no activity contribute 0; the denominator is the
+ * calendar window length, not the count of active days.
+ *
+ * Returns `round(acute / chronic, 2)` when chronic > 0, else `null`. The
+ * round is half-to-even (banker's rounding) to mirror Python's `round()`
+ * behaviour bit-identically.
+ *
+ * Upstream source mirrored line-by-line: `sync.py:3023-3028`
+ * (`_calculate_derived_metrics`) plus the per-day aggregation helper at
+ * `sync.py:3629-3644` (the daily-load aggregator). See `NOTICE.md` for
+ * upstream attribution.
+ *
+ * Return shape is the raw upstream output (number or null), not the
+ * discriminated-union envelope from ADR-0014; per the 2026-05-21 ADR-0014
+ * scope clarification, raw compute functions feed the parity gate and a
+ * sibling envelope wrapper feeds the curator.
+ *
+ * @see Gabbett, T.J. (2016). The training-injury prevention paradox:
+ *      should athletes be training smarter and harder?
+ *      Br J Sports Med 50(5):273-280. DOI: 10.1136/bjsports-2015-095788
+ */
+export function computeAcwr(input: MetricInput): number | null {
+  const fixture = input.fixture as { activities?: Activity[] };
+  const activities = fixture.activities ?? [];
+
+  const dailyLoad7d = getDailyLoad(activities, 7, input.frozenNow);
+  const dailyLoad28d = getDailyLoad(activities, 28, input.frozenNow);
+
+  const load7dTotal = dailyLoad7d.reduce((s, t) => s + t, 0);
+  const load28dTotal = dailyLoad28d.reduce((s, t) => s + t, 0);
+
+  const acuteLoad = load7dTotal ? load7dTotal / 7 : 0;
+  const chronicLoad = load28dTotal ? load28dTotal / 28 : 0;
+
+  if (chronicLoad <= 0) return null;
+  return roundHalfEven(acuteLoad / chronicLoad, 2);
+}
+
+function getDailyLoad(
+  activities: Activity[],
+  days: number,
+  frozenNow: string,
+): number[] {
+  const dailyLoad = new Map<string, number>();
+  for (const act of activities) {
+    const dateStr = act.start_date_local.slice(0, 10);
+    const load = act.icu_training_load || 0;
+    dailyLoad.set(dateStr, (dailyLoad.get(dateStr) ?? 0) + load);
+  }
+  const result: number[] = [];
+  for (let i = days - 1; i >= 0; i--) {
+    const date = isoDateDaysBefore(frozenNow, i);
+    result.push(dailyLoad.get(date) ?? 0);
+  }
+  return result;
+}
+
+function isoDateDaysBefore(isoNow: string, daysBefore: number): string {
+  const datePart = isoNow.slice(0, 10);
+  const [y, m, d] = datePart.split("-").map(Number) as [number, number, number];
+  const utc = new Date(Date.UTC(y, m - 1, d));
+  utc.setUTCDate(utc.getUTCDate() - daysBefore);
+  return utc.toISOString().slice(0, 10);
+}
+
+// Python's `round(x, n)` uses banker's rounding (round-half-to-even) and
+// diverges from `Math.round(x*10**n)/10**n` (round-half-up) for values
+// exactly at the half boundary. Mirroring Python keeps the gate
+// bit-identical on any future ACWR value that lands at the boundary.
+function roundHalfEven(value: number, decimals: number): number {
+  const factor = 10 ** decimals;
+  const scaled = value * factor;
+  const floor = Math.floor(scaled);
+  const diff = scaled - floor;
+  const epsilon = 1e-9;
+  if (diff < 0.5 - epsilon) return floor / factor;
+  if (diff > 0.5 + epsilon) return (floor + 1) / factor;
+  return (floor % 2 === 0 ? floor : floor + 1) / factor;
+}

--- a/packages/core/src/reference/metrics/metric-input.ts
+++ b/packages/core/src/reference/metrics/metric-input.ts
@@ -1,0 +1,13 @@
+/**
+ * The contract between a metric port and the parity gate.
+ *
+ * The gate (`tools/check-metric-parity.ts`) loads each metric's snapshot,
+ * resolves the registry entry to a function in this directory, and calls
+ * it with this input shape. `frozenNow` matches the snapshot's
+ * `frozen_now` field so the metric can derive date-relative windows that
+ * line up with the captured oracle.
+ */
+export interface MetricInput {
+  fixture: unknown;
+  frozenNow: string;
+}

--- a/packages/core/src/reference/metrics/registry.ts
+++ b/packages/core/src/reference/metrics/registry.ts
@@ -1,0 +1,20 @@
+/**
+ * Authoritative list of metrics the parity gate can assert. Each entry
+ * holds the typed compute function directly — the gate calls
+ * `entry.compute(input)` without dynamic imports or path resolution.
+ *
+ * Adding a metric: implement it in a sibling file, import its `compute*`
+ * function here, and register the entry. The Vitest matrix at
+ * `packages/core/tests/reference-parity.test.ts` picks it up automatically.
+ */
+
+import type { MetricInput } from "./metric-input.js";
+import { computeAcwr } from "./load-management.js";
+
+export interface MetricRegistryEntry {
+  compute: (input: MetricInput) => unknown;
+}
+
+export const METRIC_REGISTRY: Record<string, MetricRegistryEntry> = {
+  acwr: { compute: computeAcwr },
+};

--- a/packages/core/tests/fixtures/golden/data-gap-mid-history.json
+++ b/packages/core/tests/fixtures/golden/data-gap-mid-history.json
@@ -1,0 +1,2232 @@
+{
+  "activities": [
+    {
+      "id": 100020,
+      "start_date_local": "2026-05-19T07:00:00",
+      "type": "Ride",
+      "name": "Endurance",
+      "moving_time": 2571,
+      "elapsed_time": 2601,
+      "icu_training_load": 50,
+      "icu_intensity": 72.5,
+      "average_heartrate": 128,
+      "icu_zone_times": [
+        {
+          "id": "Z1",
+          "secs": 257
+        },
+        {
+          "id": "Z2",
+          "secs": 1414
+        },
+        {
+          "id": "Z3",
+          "secs": 514
+        },
+        {
+          "id": "Z4",
+          "secs": 257
+        },
+        {
+          "id": "Z5",
+          "secs": 77
+        },
+        {
+          "id": "Z6",
+          "secs": 26
+        },
+        {
+          "id": "Z7",
+          "secs": 26
+        }
+      ],
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "decoupling": -3,
+      "icu_efficiency_factor": 1,
+      "fitnessAtEnd": 30,
+      "fatigueAtEnd": 45
+    },
+    {
+      "id": 100019,
+      "start_date_local": "2026-05-18T07:00:00",
+      "type": "Ride",
+      "name": "Endurance",
+      "moving_time": 3600,
+      "elapsed_time": 3630,
+      "icu_training_load": 70,
+      "icu_intensity": 72.5,
+      "average_heartrate": 136,
+      "icu_zone_times": [
+        {
+          "id": "Z1",
+          "secs": 360
+        },
+        {
+          "id": "Z2",
+          "secs": 1980
+        },
+        {
+          "id": "Z3",
+          "secs": 720
+        },
+        {
+          "id": "Z4",
+          "secs": 360
+        },
+        {
+          "id": "Z5",
+          "secs": 108
+        },
+        {
+          "id": "Z6",
+          "secs": 36
+        },
+        {
+          "id": "Z7",
+          "secs": 36
+        }
+      ],
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "decoupling": -3,
+      "icu_efficiency_factor": 1,
+      "fitnessAtEnd": 30,
+      "fatigueAtEnd": 45
+    },
+    {
+      "id": 100018,
+      "start_date_local": "2026-05-17T07:00:00",
+      "type": "Ride",
+      "name": "Endurance",
+      "moving_time": 2571,
+      "elapsed_time": 2601,
+      "icu_training_load": 50,
+      "icu_intensity": 72.5,
+      "average_heartrate": 128,
+      "icu_zone_times": [
+        {
+          "id": "Z1",
+          "secs": 257
+        },
+        {
+          "id": "Z2",
+          "secs": 1414
+        },
+        {
+          "id": "Z3",
+          "secs": 514
+        },
+        {
+          "id": "Z4",
+          "secs": 257
+        },
+        {
+          "id": "Z5",
+          "secs": 77
+        },
+        {
+          "id": "Z6",
+          "secs": 26
+        },
+        {
+          "id": "Z7",
+          "secs": 26
+        }
+      ],
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "decoupling": -3,
+      "icu_efficiency_factor": 1,
+      "fitnessAtEnd": 30,
+      "fatigueAtEnd": 45
+    },
+    {
+      "id": 100017,
+      "start_date_local": "2026-05-16T07:00:00",
+      "type": "Ride",
+      "name": "Endurance",
+      "moving_time": 3600,
+      "elapsed_time": 3630,
+      "icu_training_load": 70,
+      "icu_intensity": 72.5,
+      "average_heartrate": 136,
+      "icu_zone_times": [
+        {
+          "id": "Z1",
+          "secs": 360
+        },
+        {
+          "id": "Z2",
+          "secs": 1980
+        },
+        {
+          "id": "Z3",
+          "secs": 720
+        },
+        {
+          "id": "Z4",
+          "secs": 360
+        },
+        {
+          "id": "Z5",
+          "secs": 108
+        },
+        {
+          "id": "Z6",
+          "secs": 36
+        },
+        {
+          "id": "Z7",
+          "secs": 36
+        }
+      ],
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "decoupling": -3,
+      "icu_efficiency_factor": 1,
+      "fitnessAtEnd": 30,
+      "fatigueAtEnd": 45
+    },
+    {
+      "id": 100016,
+      "start_date_local": "2026-05-15T07:00:00",
+      "type": "Ride",
+      "name": "Endurance",
+      "moving_time": 2571,
+      "elapsed_time": 2601,
+      "icu_training_load": 50,
+      "icu_intensity": 72.5,
+      "average_heartrate": 128,
+      "icu_zone_times": [
+        {
+          "id": "Z1",
+          "secs": 257
+        },
+        {
+          "id": "Z2",
+          "secs": 1414
+        },
+        {
+          "id": "Z3",
+          "secs": 514
+        },
+        {
+          "id": "Z4",
+          "secs": 257
+        },
+        {
+          "id": "Z5",
+          "secs": 77
+        },
+        {
+          "id": "Z6",
+          "secs": 26
+        },
+        {
+          "id": "Z7",
+          "secs": 26
+        }
+      ],
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "decoupling": -3,
+      "icu_efficiency_factor": 1,
+      "fitnessAtEnd": 30,
+      "fatigueAtEnd": 45
+    },
+    {
+      "id": 100015,
+      "start_date_local": "2026-05-14T07:00:00",
+      "type": "Ride",
+      "name": "Endurance",
+      "moving_time": 3600,
+      "elapsed_time": 3630,
+      "icu_training_load": 70,
+      "icu_intensity": 72.5,
+      "average_heartrate": 136,
+      "icu_zone_times": [
+        {
+          "id": "Z1",
+          "secs": 360
+        },
+        {
+          "id": "Z2",
+          "secs": 1980
+        },
+        {
+          "id": "Z3",
+          "secs": 720
+        },
+        {
+          "id": "Z4",
+          "secs": 360
+        },
+        {
+          "id": "Z5",
+          "secs": 108
+        },
+        {
+          "id": "Z6",
+          "secs": 36
+        },
+        {
+          "id": "Z7",
+          "secs": 36
+        }
+      ],
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "decoupling": -3,
+      "icu_efficiency_factor": 1,
+      "fitnessAtEnd": 30,
+      "fatigueAtEnd": 45
+    },
+    {
+      "id": 100014,
+      "start_date_local": "2026-05-13T07:00:00",
+      "type": "Ride",
+      "name": "Endurance",
+      "moving_time": 2571,
+      "elapsed_time": 2601,
+      "icu_training_load": 50,
+      "icu_intensity": 72.5,
+      "average_heartrate": 128,
+      "icu_zone_times": [
+        {
+          "id": "Z1",
+          "secs": 257
+        },
+        {
+          "id": "Z2",
+          "secs": 1414
+        },
+        {
+          "id": "Z3",
+          "secs": 514
+        },
+        {
+          "id": "Z4",
+          "secs": 257
+        },
+        {
+          "id": "Z5",
+          "secs": 77
+        },
+        {
+          "id": "Z6",
+          "secs": 26
+        },
+        {
+          "id": "Z7",
+          "secs": 26
+        }
+      ],
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "decoupling": -3,
+      "icu_efficiency_factor": 1,
+      "fitnessAtEnd": 30,
+      "fatigueAtEnd": 45
+    },
+    {
+      "id": 100013,
+      "start_date_local": "2026-04-14T07:00:00",
+      "type": "Ride",
+      "name": "Endurance",
+      "moving_time": 4114,
+      "elapsed_time": 4144,
+      "icu_training_load": 80,
+      "icu_intensity": 72.5,
+      "average_heartrate": 138,
+      "icu_zone_times": [
+        {
+          "id": "Z1",
+          "secs": 411
+        },
+        {
+          "id": "Z2",
+          "secs": 2263
+        },
+        {
+          "id": "Z3",
+          "secs": 823
+        },
+        {
+          "id": "Z4",
+          "secs": 411
+        },
+        {
+          "id": "Z5",
+          "secs": 123
+        },
+        {
+          "id": "Z6",
+          "secs": 41
+        },
+        {
+          "id": "Z7",
+          "secs": 41
+        }
+      ],
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "decoupling": -3,
+      "icu_efficiency_factor": 1,
+      "fitnessAtEnd": 30,
+      "fatigueAtEnd": 45
+    },
+    {
+      "id": 100012,
+      "start_date_local": "2026-04-13T07:00:00",
+      "type": "Ride",
+      "name": "Endurance",
+      "moving_time": 3086,
+      "elapsed_time": 3116,
+      "icu_training_load": 60,
+      "icu_intensity": 72.5,
+      "average_heartrate": 130,
+      "icu_zone_times": [
+        {
+          "id": "Z1",
+          "secs": 309
+        },
+        {
+          "id": "Z2",
+          "secs": 1697
+        },
+        {
+          "id": "Z3",
+          "secs": 617
+        },
+        {
+          "id": "Z4",
+          "secs": 309
+        },
+        {
+          "id": "Z5",
+          "secs": 93
+        },
+        {
+          "id": "Z6",
+          "secs": 31
+        },
+        {
+          "id": "Z7",
+          "secs": 31
+        }
+      ],
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "decoupling": -3,
+      "icu_efficiency_factor": 1,
+      "fitnessAtEnd": 30,
+      "fatigueAtEnd": 45
+    },
+    {
+      "id": 100011,
+      "start_date_local": "2026-04-12T07:00:00",
+      "type": "Ride",
+      "name": "Endurance",
+      "moving_time": 4114,
+      "elapsed_time": 4144,
+      "icu_training_load": 80,
+      "icu_intensity": 72.5,
+      "average_heartrate": 138,
+      "icu_zone_times": [
+        {
+          "id": "Z1",
+          "secs": 411
+        },
+        {
+          "id": "Z2",
+          "secs": 2263
+        },
+        {
+          "id": "Z3",
+          "secs": 823
+        },
+        {
+          "id": "Z4",
+          "secs": 411
+        },
+        {
+          "id": "Z5",
+          "secs": 123
+        },
+        {
+          "id": "Z6",
+          "secs": 41
+        },
+        {
+          "id": "Z7",
+          "secs": 41
+        }
+      ],
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "decoupling": -3,
+      "icu_efficiency_factor": 1,
+      "fitnessAtEnd": 30,
+      "fatigueAtEnd": 45
+    },
+    {
+      "id": 100010,
+      "start_date_local": "2026-04-11T07:00:00",
+      "type": "Ride",
+      "name": "Endurance",
+      "moving_time": 3086,
+      "elapsed_time": 3116,
+      "icu_training_load": 60,
+      "icu_intensity": 72.5,
+      "average_heartrate": 130,
+      "icu_zone_times": [
+        {
+          "id": "Z1",
+          "secs": 309
+        },
+        {
+          "id": "Z2",
+          "secs": 1697
+        },
+        {
+          "id": "Z3",
+          "secs": 617
+        },
+        {
+          "id": "Z4",
+          "secs": 309
+        },
+        {
+          "id": "Z5",
+          "secs": 93
+        },
+        {
+          "id": "Z6",
+          "secs": 31
+        },
+        {
+          "id": "Z7",
+          "secs": 31
+        }
+      ],
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "decoupling": -3,
+      "icu_efficiency_factor": 1,
+      "fitnessAtEnd": 30,
+      "fatigueAtEnd": 45
+    },
+    {
+      "id": 100009,
+      "start_date_local": "2026-04-10T07:00:00",
+      "type": "Ride",
+      "name": "Endurance",
+      "moving_time": 4114,
+      "elapsed_time": 4144,
+      "icu_training_load": 80,
+      "icu_intensity": 72.5,
+      "average_heartrate": 138,
+      "icu_zone_times": [
+        {
+          "id": "Z1",
+          "secs": 411
+        },
+        {
+          "id": "Z2",
+          "secs": 2263
+        },
+        {
+          "id": "Z3",
+          "secs": 823
+        },
+        {
+          "id": "Z4",
+          "secs": 411
+        },
+        {
+          "id": "Z5",
+          "secs": 123
+        },
+        {
+          "id": "Z6",
+          "secs": 41
+        },
+        {
+          "id": "Z7",
+          "secs": 41
+        }
+      ],
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "decoupling": -3,
+      "icu_efficiency_factor": 1,
+      "fitnessAtEnd": 30,
+      "fatigueAtEnd": 45
+    },
+    {
+      "id": 100008,
+      "start_date_local": "2026-04-09T07:00:00",
+      "type": "Ride",
+      "name": "Endurance",
+      "moving_time": 3086,
+      "elapsed_time": 3116,
+      "icu_training_load": 60,
+      "icu_intensity": 72.5,
+      "average_heartrate": 130,
+      "icu_zone_times": [
+        {
+          "id": "Z1",
+          "secs": 309
+        },
+        {
+          "id": "Z2",
+          "secs": 1697
+        },
+        {
+          "id": "Z3",
+          "secs": 617
+        },
+        {
+          "id": "Z4",
+          "secs": 309
+        },
+        {
+          "id": "Z5",
+          "secs": 93
+        },
+        {
+          "id": "Z6",
+          "secs": 31
+        },
+        {
+          "id": "Z7",
+          "secs": 31
+        }
+      ],
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "decoupling": -3,
+      "icu_efficiency_factor": 1,
+      "fitnessAtEnd": 30,
+      "fatigueAtEnd": 45
+    },
+    {
+      "id": 100007,
+      "start_date_local": "2026-04-08T07:00:00",
+      "type": "Ride",
+      "name": "Endurance",
+      "moving_time": 4114,
+      "elapsed_time": 4144,
+      "icu_training_load": 80,
+      "icu_intensity": 72.5,
+      "average_heartrate": 138,
+      "icu_zone_times": [
+        {
+          "id": "Z1",
+          "secs": 411
+        },
+        {
+          "id": "Z2",
+          "secs": 2263
+        },
+        {
+          "id": "Z3",
+          "secs": 823
+        },
+        {
+          "id": "Z4",
+          "secs": 411
+        },
+        {
+          "id": "Z5",
+          "secs": 123
+        },
+        {
+          "id": "Z6",
+          "secs": 41
+        },
+        {
+          "id": "Z7",
+          "secs": 41
+        }
+      ],
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "decoupling": -3,
+      "icu_efficiency_factor": 1,
+      "fitnessAtEnd": 30,
+      "fatigueAtEnd": 45
+    },
+    {
+      "id": 100006,
+      "start_date_local": "2026-04-07T07:00:00",
+      "type": "Ride",
+      "name": "Endurance",
+      "moving_time": 3086,
+      "elapsed_time": 3116,
+      "icu_training_load": 60,
+      "icu_intensity": 72.5,
+      "average_heartrate": 130,
+      "icu_zone_times": [
+        {
+          "id": "Z1",
+          "secs": 309
+        },
+        {
+          "id": "Z2",
+          "secs": 1697
+        },
+        {
+          "id": "Z3",
+          "secs": 617
+        },
+        {
+          "id": "Z4",
+          "secs": 309
+        },
+        {
+          "id": "Z5",
+          "secs": 93
+        },
+        {
+          "id": "Z6",
+          "secs": 31
+        },
+        {
+          "id": "Z7",
+          "secs": 31
+        }
+      ],
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "decoupling": -3,
+      "icu_efficiency_factor": 1,
+      "fitnessAtEnd": 30,
+      "fatigueAtEnd": 45
+    },
+    {
+      "id": 100005,
+      "start_date_local": "2026-04-06T07:00:00",
+      "type": "Ride",
+      "name": "Endurance",
+      "moving_time": 4114,
+      "elapsed_time": 4144,
+      "icu_training_load": 80,
+      "icu_intensity": 72.5,
+      "average_heartrate": 138,
+      "icu_zone_times": [
+        {
+          "id": "Z1",
+          "secs": 411
+        },
+        {
+          "id": "Z2",
+          "secs": 2263
+        },
+        {
+          "id": "Z3",
+          "secs": 823
+        },
+        {
+          "id": "Z4",
+          "secs": 411
+        },
+        {
+          "id": "Z5",
+          "secs": 123
+        },
+        {
+          "id": "Z6",
+          "secs": 41
+        },
+        {
+          "id": "Z7",
+          "secs": 41
+        }
+      ],
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "decoupling": -3,
+      "icu_efficiency_factor": 1,
+      "fitnessAtEnd": 30,
+      "fatigueAtEnd": 45
+    },
+    {
+      "id": 100004,
+      "start_date_local": "2026-04-05T07:00:00",
+      "type": "Ride",
+      "name": "Endurance",
+      "moving_time": 3086,
+      "elapsed_time": 3116,
+      "icu_training_load": 60,
+      "icu_intensity": 72.5,
+      "average_heartrate": 130,
+      "icu_zone_times": [
+        {
+          "id": "Z1",
+          "secs": 309
+        },
+        {
+          "id": "Z2",
+          "secs": 1697
+        },
+        {
+          "id": "Z3",
+          "secs": 617
+        },
+        {
+          "id": "Z4",
+          "secs": 309
+        },
+        {
+          "id": "Z5",
+          "secs": 93
+        },
+        {
+          "id": "Z6",
+          "secs": 31
+        },
+        {
+          "id": "Z7",
+          "secs": 31
+        }
+      ],
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "decoupling": -3,
+      "icu_efficiency_factor": 1,
+      "fitnessAtEnd": 30,
+      "fatigueAtEnd": 45
+    },
+    {
+      "id": 100003,
+      "start_date_local": "2026-04-04T07:00:00",
+      "type": "Ride",
+      "name": "Endurance",
+      "moving_time": 4114,
+      "elapsed_time": 4144,
+      "icu_training_load": 80,
+      "icu_intensity": 72.5,
+      "average_heartrate": 138,
+      "icu_zone_times": [
+        {
+          "id": "Z1",
+          "secs": 411
+        },
+        {
+          "id": "Z2",
+          "secs": 2263
+        },
+        {
+          "id": "Z3",
+          "secs": 823
+        },
+        {
+          "id": "Z4",
+          "secs": 411
+        },
+        {
+          "id": "Z5",
+          "secs": 123
+        },
+        {
+          "id": "Z6",
+          "secs": 41
+        },
+        {
+          "id": "Z7",
+          "secs": 41
+        }
+      ],
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "decoupling": -3,
+      "icu_efficiency_factor": 1,
+      "fitnessAtEnd": 30,
+      "fatigueAtEnd": 45
+    },
+    {
+      "id": 100002,
+      "start_date_local": "2026-04-03T07:00:00",
+      "type": "Ride",
+      "name": "Endurance",
+      "moving_time": 3086,
+      "elapsed_time": 3116,
+      "icu_training_load": 60,
+      "icu_intensity": 72.5,
+      "average_heartrate": 130,
+      "icu_zone_times": [
+        {
+          "id": "Z1",
+          "secs": 309
+        },
+        {
+          "id": "Z2",
+          "secs": 1697
+        },
+        {
+          "id": "Z3",
+          "secs": 617
+        },
+        {
+          "id": "Z4",
+          "secs": 309
+        },
+        {
+          "id": "Z5",
+          "secs": 93
+        },
+        {
+          "id": "Z6",
+          "secs": 31
+        },
+        {
+          "id": "Z7",
+          "secs": 31
+        }
+      ],
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "decoupling": -3,
+      "icu_efficiency_factor": 1,
+      "fitnessAtEnd": 30,
+      "fatigueAtEnd": 45
+    },
+    {
+      "id": 100001,
+      "start_date_local": "2026-04-02T07:00:00",
+      "type": "Ride",
+      "name": "Endurance",
+      "moving_time": 4114,
+      "elapsed_time": 4144,
+      "icu_training_load": 80,
+      "icu_intensity": 72.5,
+      "average_heartrate": 138,
+      "icu_zone_times": [
+        {
+          "id": "Z1",
+          "secs": 411
+        },
+        {
+          "id": "Z2",
+          "secs": 2263
+        },
+        {
+          "id": "Z3",
+          "secs": 823
+        },
+        {
+          "id": "Z4",
+          "secs": 411
+        },
+        {
+          "id": "Z5",
+          "secs": 123
+        },
+        {
+          "id": "Z6",
+          "secs": 41
+        },
+        {
+          "id": "Z7",
+          "secs": 41
+        }
+      ],
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "decoupling": -3,
+      "icu_efficiency_factor": 1,
+      "fitnessAtEnd": 30,
+      "fatigueAtEnd": 45
+    },
+    {
+      "id": 100000,
+      "start_date_local": "2026-04-01T07:00:00",
+      "type": "Ride",
+      "name": "Endurance",
+      "moving_time": 3086,
+      "elapsed_time": 3116,
+      "icu_training_load": 60,
+      "icu_intensity": 72.5,
+      "average_heartrate": 130,
+      "icu_zone_times": [
+        {
+          "id": "Z1",
+          "secs": 309
+        },
+        {
+          "id": "Z2",
+          "secs": 1697
+        },
+        {
+          "id": "Z3",
+          "secs": 617
+        },
+        {
+          "id": "Z4",
+          "secs": 309
+        },
+        {
+          "id": "Z5",
+          "secs": 93
+        },
+        {
+          "id": "Z6",
+          "secs": 31
+        },
+        {
+          "id": "Z7",
+          "secs": 31
+        }
+      ],
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "decoupling": -3,
+      "icu_efficiency_factor": 1,
+      "fitnessAtEnd": 30,
+      "fatigueAtEnd": 45
+    }
+  ],
+  "wellness": [
+    {
+      "id": "2026-03-25",
+      "weight": null,
+      "restingHR": 60,
+      "hrv": 50,
+      "sleepSecs": 28800,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 200
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 15,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-03-26",
+      "weight": null,
+      "restingHR": 60,
+      "hrv": 50,
+      "sleepSecs": 28800,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 200
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 15,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-03-27",
+      "weight": null,
+      "restingHR": 60,
+      "hrv": 50,
+      "sleepSecs": 28800,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 200
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 15,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-03-28",
+      "weight": null,
+      "restingHR": 60,
+      "hrv": 50,
+      "sleepSecs": 28800,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 200
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 15,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-03-29",
+      "weight": null,
+      "restingHR": 60,
+      "hrv": 50,
+      "sleepSecs": 28800,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 200
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 15,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-03-30",
+      "weight": null,
+      "restingHR": 60,
+      "hrv": 50,
+      "sleepSecs": 28800,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 200
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 15,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-03-31",
+      "weight": null,
+      "restingHR": 60,
+      "hrv": 50,
+      "sleepSecs": 28800,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 200
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 15,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-04-01",
+      "weight": null,
+      "restingHR": 60,
+      "hrv": 50,
+      "sleepSecs": 28800,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 200
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 18,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-04-02",
+      "weight": null,
+      "restingHR": 60,
+      "hrv": 50,
+      "sleepSecs": 28800,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 200
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 18.5,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-04-03",
+      "weight": null,
+      "restingHR": 60,
+      "hrv": 50,
+      "sleepSecs": 28800,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 200
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 19,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-04-04",
+      "weight": null,
+      "restingHR": 60,
+      "hrv": 50,
+      "sleepSecs": 28800,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 200
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 19.5,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-04-05",
+      "weight": null,
+      "restingHR": 60,
+      "hrv": 50,
+      "sleepSecs": 28800,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 200
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 20,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-04-06",
+      "weight": null,
+      "restingHR": 60,
+      "hrv": 50,
+      "sleepSecs": 28800,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 200
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 20.5,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-04-07",
+      "weight": null,
+      "restingHR": 60,
+      "hrv": 50,
+      "sleepSecs": 28800,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 200
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 21,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-04-08",
+      "weight": null,
+      "restingHR": 60,
+      "hrv": 50,
+      "sleepSecs": 28800,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 200
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 21.5,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-04-09",
+      "weight": null,
+      "restingHR": 60,
+      "hrv": 50,
+      "sleepSecs": 28800,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 200
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 22,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-04-10",
+      "weight": null,
+      "restingHR": 60,
+      "hrv": 50,
+      "sleepSecs": 28800,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 200
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 22.5,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-04-11",
+      "weight": null,
+      "restingHR": 60,
+      "hrv": 50,
+      "sleepSecs": 28800,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 200
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 23,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-04-12",
+      "weight": null,
+      "restingHR": 60,
+      "hrv": 50,
+      "sleepSecs": 28800,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 200
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 23.5,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-04-13",
+      "weight": null,
+      "restingHR": 60,
+      "hrv": 50,
+      "sleepSecs": 28800,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 200
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 24,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-04-14",
+      "weight": null,
+      "restingHR": 60,
+      "hrv": 50,
+      "sleepSecs": 28800,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 200
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 24.5,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-04-15",
+      "weight": null,
+      "restingHR": 60,
+      "hrv": 50,
+      "sleepSecs": 28800,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 200
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 25,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-04-16",
+      "weight": null,
+      "restingHR": 60,
+      "hrv": 50,
+      "sleepSecs": 28800,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 200
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 24.4,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-04-17",
+      "weight": null,
+      "restingHR": 60,
+      "hrv": 50,
+      "sleepSecs": 28800,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 200
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 23.8,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-04-18",
+      "weight": null,
+      "restingHR": 60,
+      "hrv": 50,
+      "sleepSecs": 28800,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 200
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 23.3,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-04-19",
+      "weight": null,
+      "restingHR": 60,
+      "hrv": 50,
+      "sleepSecs": 28800,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 200
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 22.7,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-04-20",
+      "weight": null,
+      "restingHR": 60,
+      "hrv": 50,
+      "sleepSecs": 28800,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 200
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 22.2,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-04-21",
+      "weight": null,
+      "restingHR": 60,
+      "hrv": 50,
+      "sleepSecs": 28800,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 200
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 21.7,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-04-22",
+      "weight": null,
+      "restingHR": 60,
+      "hrv": 50,
+      "sleepSecs": 28800,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 200
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 21.2,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-04-23",
+      "weight": null,
+      "restingHR": 60,
+      "hrv": 50,
+      "sleepSecs": 28800,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 200
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 20.7,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-04-24",
+      "weight": null,
+      "restingHR": 60,
+      "hrv": 50,
+      "sleepSecs": 28800,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 200
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 20.2,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-04-25",
+      "weight": null,
+      "restingHR": 60,
+      "hrv": 50,
+      "sleepSecs": 28800,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 200
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 19.7,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-04-26",
+      "weight": null,
+      "restingHR": 60,
+      "hrv": 50,
+      "sleepSecs": 28800,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 200
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 19.2,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-04-27",
+      "weight": null,
+      "restingHR": 60,
+      "hrv": 50,
+      "sleepSecs": 28800,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 200
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 18.8,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-04-28",
+      "weight": null,
+      "restingHR": 60,
+      "hrv": 50,
+      "sleepSecs": 28800,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 200
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 18.3,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-04-29",
+      "weight": null,
+      "restingHR": 60,
+      "hrv": 50,
+      "sleepSecs": 28800,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 200
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 17.9,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-04-30",
+      "weight": null,
+      "restingHR": 60,
+      "hrv": 50,
+      "sleepSecs": 28800,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 200
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 17.5,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-05-01",
+      "weight": null,
+      "restingHR": 60,
+      "hrv": 50,
+      "sleepSecs": 28800,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 200
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 17.1,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-05-02",
+      "weight": null,
+      "restingHR": 60,
+      "hrv": 50,
+      "sleepSecs": 28800,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 200
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 16.7,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-05-03",
+      "weight": null,
+      "restingHR": 60,
+      "hrv": 50,
+      "sleepSecs": 28800,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 200
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 16.3,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-05-04",
+      "weight": null,
+      "restingHR": 60,
+      "hrv": 50,
+      "sleepSecs": 28800,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 200
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 15.9,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-05-05",
+      "weight": null,
+      "restingHR": 60,
+      "hrv": 50,
+      "sleepSecs": 28800,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 200
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 15.5,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-05-06",
+      "weight": null,
+      "restingHR": 60,
+      "hrv": 50,
+      "sleepSecs": 28800,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 200
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 15.2,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-05-07",
+      "weight": null,
+      "restingHR": 60,
+      "hrv": 50,
+      "sleepSecs": 28800,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 200
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 14.8,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-05-08",
+      "weight": null,
+      "restingHR": 60,
+      "hrv": 50,
+      "sleepSecs": 28800,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 200
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 14.5,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-05-09",
+      "weight": null,
+      "restingHR": 60,
+      "hrv": 50,
+      "sleepSecs": 28800,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 200
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 14.1,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-05-10",
+      "weight": null,
+      "restingHR": 60,
+      "hrv": 50,
+      "sleepSecs": 28800,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 200
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 13.8,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-05-11",
+      "weight": null,
+      "restingHR": 60,
+      "hrv": 50,
+      "sleepSecs": 28800,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 200
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 13.5,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-05-12",
+      "weight": null,
+      "restingHR": 60,
+      "hrv": 50,
+      "sleepSecs": 28800,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 200
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 13.1,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-05-13",
+      "weight": null,
+      "restingHR": 60,
+      "hrv": 50,
+      "sleepSecs": 28800,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 200
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 10.3,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-05-14",
+      "weight": null,
+      "restingHR": 60,
+      "hrv": 50,
+      "sleepSecs": 28800,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 200
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 10.6,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-05-15",
+      "weight": null,
+      "restingHR": 60,
+      "hrv": 50,
+      "sleepSecs": 28800,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 200
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 10.9,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-05-16",
+      "weight": null,
+      "restingHR": 60,
+      "hrv": 50,
+      "sleepSecs": 28800,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 200
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 11.2,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-05-17",
+      "weight": null,
+      "restingHR": 60,
+      "hrv": 50,
+      "sleepSecs": 28800,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 200
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 11.5,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-05-18",
+      "weight": null,
+      "restingHR": 60,
+      "hrv": 50,
+      "sleepSecs": 28800,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 200
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 11.8,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-05-19",
+      "weight": null,
+      "restingHR": 60,
+      "hrv": 50,
+      "sleepSecs": 28800,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 200
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 12.1,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    }
+  ],
+  "ftp_history": [
+    {
+      "date": "2026-03-25",
+      "ftp": 200,
+      "source": "estimate"
+    }
+  ]
+}

--- a/packages/core/tests/fixtures/golden/new-athlete-empty.json
+++ b/packages/core/tests/fixtures/golden/new-athlete-empty.json
@@ -1,0 +1,5 @@
+{
+  "activities": [],
+  "wellness": [],
+  "ftp_history": []
+}

--- a/packages/core/tests/fixtures/snapshots/data-gap-mid-history/acwr.json
+++ b/packages/core/tests/fixtures/snapshots/data-gap-mid-history/acwr.json
@@ -1,0 +1,8 @@
+{
+  "metric": "acwr",
+  "athlete": "data-gap-mid-history",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-20T12:00:00",
+  "value": 3.51
+}

--- a/packages/core/tests/fixtures/snapshots/data-gap-mid-history/acwr_interpretation.json
+++ b/packages/core/tests/fixtures/snapshots/data-gap-mid-history/acwr_interpretation.json
@@ -1,0 +1,8 @@
+{
+  "metric": "acwr_interpretation",
+  "athlete": "data-gap-mid-history",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-20T12:00:00",
+  "value": "danger"
+}

--- a/packages/core/tests/fixtures/snapshots/data-gap-mid-history/benchmark_indoor.json
+++ b/packages/core/tests/fixtures/snapshots/data-gap-mid-history/benchmark_indoor.json
@@ -1,0 +1,14 @@
+{
+  "metric": "benchmark_indoor",
+  "athlete": "data-gap-mid-history",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-20T12:00:00",
+  "value": {
+    "benchmark_index": null,
+    "benchmark_percentage": null,
+    "current_ftp": null,
+    "ftp_8_weeks_ago": null,
+    "seasonal_expected": null
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/data-gap-mid-history/benchmark_outdoor.json
+++ b/packages/core/tests/fixtures/snapshots/data-gap-mid-history/benchmark_outdoor.json
@@ -1,0 +1,14 @@
+{
+  "metric": "benchmark_outdoor",
+  "athlete": "data-gap-mid-history",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-20T12:00:00",
+  "value": {
+    "benchmark_index": null,
+    "benchmark_percentage": null,
+    "current_ftp": null,
+    "ftp_8_weeks_ago": null,
+    "seasonal_expected": null
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/data-gap-mid-history/calculation_timestamp.json
+++ b/packages/core/tests/fixtures/snapshots/data-gap-mid-history/calculation_timestamp.json
@@ -1,0 +1,8 @@
+{
+  "metric": "calculation_timestamp",
+  "athlete": "data-gap-mid-history",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-20T12:00:00",
+  "value": "2026-05-20T12:00:00"
+}

--- a/packages/core/tests/fixtures/snapshots/data-gap-mid-history/capability.json
+++ b/packages/core/tests/fixtures/snapshots/data-gap-mid-history/capability.json
@@ -1,0 +1,62 @@
+{
+  "metric": "capability",
+  "athlete": "data-gap-mid-history",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-20T12:00:00",
+  "value": {
+    "dfa_a1_profile": null,
+    "durability": {
+      "high_drift_count_28d": 0,
+      "high_drift_count_7d": 0,
+      "mean_decoupling_28d": null,
+      "mean_decoupling_7d": null,
+      "note": "Steady-state power sessions only (VI <= 1.05, VI > 0, >= 90min, power data). Negative decoupling = strong durability. Trend compares 7d vs 28d mean (+/-1% = stable). Alerts require N28>=5 (alarm) or N7>=3 AND N28>=5 (declining warning) for statistical reliability.",
+      "qualifying_sessions_28d": 0,
+      "qualifying_sessions_7d": 0,
+      "reliability_limited": true,
+      "reliability_note": "insufficient qualifying sessions for alert evaluation: 7d N=0 (min 3), 28d N=0 (min 5)",
+      "trend": null
+    },
+    "efficiency_factor": {
+      "mean_ef_28d": null,
+      "mean_ef_7d": null,
+      "note": "Steady-state cycling sessions only (VI <= 1.05, VI > 0, >= 20min, power+HR data). Rising EF = improving aerobic efficiency. Compare like-for-like sessions only — EF varies with intensity. Trend compares 7d vs 28d mean (+/-0.03 = stable).",
+      "qualifying_sessions_28d": 0,
+      "qualifying_sessions_7d": 0,
+      "trend": null
+    },
+    "hr_curve_delta": {
+      "anchors": null,
+      "note": "Insufficient HR data in one or both windows.",
+      "rotation_index": null,
+      "window_days": 28
+    },
+    "hrrc": {
+      "mean_hrrc_28d": null,
+      "mean_hrrc_7d": null,
+      "note": "HRRc = heart rate recovery (largest 60s HR drop in bpm after exceeding threshold HR for >1 min). Higher = better parasympathetic recovery. Null when threshold not reached, recording stopped before cooldown, or no HR data. Trend: 7d mean vs 28d mean, >10% = meaningful (min 1 session/7d, 3 sessions/28d). Display only — not wired into readiness_decision signals.",
+      "qualifying_sessions_28d": 0,
+      "qualifying_sessions_7d": 0,
+      "trend": null
+    },
+    "power_curve_delta": {
+      "anchors": null,
+      "note": "Insufficient power data in one or both windows.",
+      "rotation_index": null,
+      "window_days": 28
+    },
+    "sustainability_profile": {
+      "note": "No sustainability data available."
+    },
+    "tid_comparison": {
+      "classification_28d": "Pyramidal",
+      "classification_7d": "Pyramidal",
+      "drift": "consistent",
+      "note": "Compares 7d vs 28d Seiler TID to detect distribution shifts. pi_delta positive = more polarized acutely.",
+      "pi_28d": null,
+      "pi_7d": null,
+      "pi_delta": null
+    }
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/data-gap-mid-history/consistency_details.json
+++ b/packages/core/tests/fixtures/snapshots/data-gap-mid-history/consistency_details.json
@@ -1,0 +1,13 @@
+{
+  "metric": "consistency_details",
+  "athlete": "data-gap-mid-history",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-20T12:00:00",
+  "value": {
+    "completed_days": 6,
+    "matched_days": 0,
+    "note": "No planned workouts in period",
+    "planned_days": 0
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/data-gap-mid-history/consistency_index.json
+++ b/packages/core/tests/fixtures/snapshots/data-gap-mid-history/consistency_index.json
@@ -1,0 +1,8 @@
+{
+  "metric": "consistency_index",
+  "athlete": "data-gap-mid-history",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-20T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/data-gap-mid-history/data_quality.json
+++ b/packages/core/tests/fixtures/snapshots/data-gap-mid-history/data_quality.json
@@ -1,0 +1,18 @@
+{
+  "metric": "data_quality",
+  "athlete": "data-gap-mid-history",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-20T12:00:00",
+  "value": {
+    "activities_28d": 7,
+    "activities_7d": 6,
+    "ftp_history_days": {
+      "indoor": 0,
+      "outdoor": 0
+    },
+    "hrv_data_points": 6,
+    "planned_workouts_7d": 0,
+    "rhr_data_points": 6
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/data-gap-mid-history/easy_time_ratio.json
+++ b/packages/core/tests/fixtures/snapshots/data-gap-mid-history/easy_time_ratio.json
@@ -1,0 +1,8 @@
+{
+  "metric": "easy_time_ratio",
+  "athlete": "data-gap-mid-history",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-20T12:00:00",
+  "value": 0.65
+}

--- a/packages/core/tests/fixtures/snapshots/data-gap-mid-history/easy_time_ratio_note.json
+++ b/packages/core/tests/fixtures/snapshots/data-gap-mid-history/easy_time_ratio_note.json
@@ -1,0 +1,8 @@
+{
+  "metric": "easy_time_ratio_note",
+  "athlete": "data-gap-mid-history",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-20T12:00:00",
+  "value": "Easy time (Z1+Z2) / Total - target ~80% in polarized training"
+}

--- a/packages/core/tests/fixtures/snapshots/data-gap-mid-history/effective_monotony.json
+++ b/packages/core/tests/fixtures/snapshots/data-gap-mid-history/effective_monotony.json
@@ -1,0 +1,8 @@
+{
+  "metric": "effective_monotony",
+  "athlete": "data-gap-mid-history",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-20T12:00:00",
+  "value": 2.08
+}

--- a/packages/core/tests/fixtures/snapshots/data-gap-mid-history/eftp.json
+++ b/packages/core/tests/fixtures/snapshots/data-gap-mid-history/eftp.json
@@ -1,0 +1,8 @@
+{
+  "metric": "eftp",
+  "athlete": "data-gap-mid-history",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-20T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/data-gap-mid-history/grey_zone_note.json
+++ b/packages/core/tests/fixtures/snapshots/data-gap-mid-history/grey_zone_note.json
@@ -1,0 +1,8 @@
+{
+  "metric": "grey_zone_note",
+  "athlete": "data-gap-mid-history",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-20T12:00:00",
+  "value": "Gray Zone % (Z3/tempo) - minimize in polarized training"
+}

--- a/packages/core/tests/fixtures/snapshots/data-gap-mid-history/grey_zone_percentage.json
+++ b/packages/core/tests/fixtures/snapshots/data-gap-mid-history/grey_zone_percentage.json
@@ -1,0 +1,8 @@
+{
+  "metric": "grey_zone_percentage",
+  "athlete": "data-gap-mid-history",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-20T12:00:00",
+  "value": 20
+}

--- a/packages/core/tests/fixtures/snapshots/data-gap-mid-history/hard_days_note.json
+++ b/packages/core/tests/fixtures/snapshots/data-gap-mid-history/hard_days_note.json
@@ -1,0 +1,8 @@
+{
+  "metric": "hard_days_note",
+  "athlete": "data-gap-mid-history",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-20T12:00:00",
+  "value": "Power ladder: z3+ >= 30min, z4+ >= 10min, z5+ >= 5min, z6+ >= 2min, z7 >= 1min. HR fallback (when no power): z4+ >= 10min, z5+ >= 5min. Per Seiler 3-zone model + Foster. HR-based days flagged with intensity_basis: hr"
+}

--- a/packages/core/tests/fixtures/snapshots/data-gap-mid-history/hard_days_this_week.json
+++ b/packages/core/tests/fixtures/snapshots/data-gap-mid-history/hard_days_this_week.json
@@ -1,0 +1,8 @@
+{
+  "metric": "hard_days_this_week",
+  "athlete": "data-gap-mid-history",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-20T12:00:00",
+  "value": 0
+}

--- a/packages/core/tests/fixtures/snapshots/data-gap-mid-history/hrv_baseline_28d.json
+++ b/packages/core/tests/fixtures/snapshots/data-gap-mid-history/hrv_baseline_28d.json
@@ -1,0 +1,8 @@
+{
+  "metric": "hrv_baseline_28d",
+  "athlete": "data-gap-mid-history",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-20T12:00:00",
+  "value": 50
+}

--- a/packages/core/tests/fixtures/snapshots/data-gap-mid-history/hrv_baseline_7d.json
+++ b/packages/core/tests/fixtures/snapshots/data-gap-mid-history/hrv_baseline_7d.json
@@ -1,0 +1,8 @@
+{
+  "metric": "hrv_baseline_7d",
+  "athlete": "data-gap-mid-history",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-20T12:00:00",
+  "value": 50
+}

--- a/packages/core/tests/fixtures/snapshots/data-gap-mid-history/latest_hrv.json
+++ b/packages/core/tests/fixtures/snapshots/data-gap-mid-history/latest_hrv.json
@@ -1,0 +1,8 @@
+{
+  "metric": "latest_hrv",
+  "athlete": "data-gap-mid-history",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-20T12:00:00",
+  "value": 50
+}

--- a/packages/core/tests/fixtures/snapshots/data-gap-mid-history/latest_rhr.json
+++ b/packages/core/tests/fixtures/snapshots/data-gap-mid-history/latest_rhr.json
@@ -1,0 +1,8 @@
+{
+  "metric": "latest_rhr",
+  "athlete": "data-gap-mid-history",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-20T12:00:00",
+  "value": 60
+}

--- a/packages/core/tests/fixtures/snapshots/data-gap-mid-history/load_recovery_ratio.json
+++ b/packages/core/tests/fixtures/snapshots/data-gap-mid-history/load_recovery_ratio.json
@@ -1,0 +1,8 @@
+{
+  "metric": "load_recovery_ratio",
+  "athlete": "data-gap-mid-history",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-20T12:00:00",
+  "value": 3.6
+}

--- a/packages/core/tests/fixtures/snapshots/data-gap-mid-history/monotony.json
+++ b/packages/core/tests/fixtures/snapshots/data-gap-mid-history/monotony.json
@@ -1,0 +1,8 @@
+{
+  "metric": "monotony",
+  "athlete": "data-gap-mid-history",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-20T12:00:00",
+  "value": 2.08
+}

--- a/packages/core/tests/fixtures/snapshots/data-gap-mid-history/monotony_interpretation.json
+++ b/packages/core/tests/fixtures/snapshots/data-gap-mid-history/monotony_interpretation.json
@@ -1,0 +1,8 @@
+{
+  "metric": "monotony_interpretation",
+  "athlete": "data-gap-mid-history",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-20T12:00:00",
+  "value": "elevated"
+}

--- a/packages/core/tests/fixtures/snapshots/data-gap-mid-history/multi_sport_detected.json
+++ b/packages/core/tests/fixtures/snapshots/data-gap-mid-history/multi_sport_detected.json
@@ -1,0 +1,8 @@
+{
+  "metric": "multi_sport_detected",
+  "athlete": "data-gap-mid-history",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-20T12:00:00",
+  "value": false
+}

--- a/packages/core/tests/fixtures/snapshots/data-gap-mid-history/p_max.json
+++ b/packages/core/tests/fixtures/snapshots/data-gap-mid-history/p_max.json
@@ -1,0 +1,8 @@
+{
+  "metric": "p_max",
+  "athlete": "data-gap-mid-history",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-20T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/data-gap-mid-history/phase_detected.json
+++ b/packages/core/tests/fixtures/snapshots/data-gap-mid-history/phase_detected.json
@@ -1,0 +1,8 @@
+{
+  "metric": "phase_detected",
+  "athlete": "data-gap-mid-history",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-20T12:00:00",
+  "value": "Base"
+}

--- a/packages/core/tests/fixtures/snapshots/data-gap-mid-history/phase_detection.json
+++ b/packages/core/tests/fixtures/snapshots/data-gap-mid-history/phase_detection.json
@@ -1,0 +1,38 @@
+{
+  "metric": "phase_detection",
+  "athlete": "data-gap-mid-history",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-20T12:00:00",
+  "value": {
+    "basis": {
+      "data_quality": "good",
+      "stream_1": {
+        "acwr_trend": null,
+        "ctl_slope": null,
+        "hard_day_pattern": 0,
+        "weeks_available": 4
+      },
+      "stream_2": {
+        "current_week_hard_days_completed": 0,
+        "current_week_hard_days_total": 0,
+        "hard_sessions_planned": 0,
+        "next_week_load": null,
+        "plan_coverage_current_week": 0,
+        "plan_coverage_next_week": 0,
+        "planned_tss_delta": null,
+        "race_proximity": null
+      },
+      "stream_agreement": null
+    },
+    "confidence": "medium",
+    "dossier_agreement": null,
+    "dossier_declared": null,
+    "phase": "Base",
+    "phase_duration_weeks": 1,
+    "previous_phase": null,
+    "reason_codes": [
+      "NO_PLANNED_WORKOUTS"
+    ]
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/data-gap-mid-history/phase_triggers.json
+++ b/packages/core/tests/fixtures/snapshots/data-gap-mid-history/phase_triggers.json
@@ -1,0 +1,10 @@
+{
+  "metric": "phase_triggers",
+  "athlete": "data-gap-mid-history",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-20T12:00:00",
+  "value": [
+    "NO_PLANNED_WORKOUTS"
+  ]
+}

--- a/packages/core/tests/fixtures/snapshots/data-gap-mid-history/power_model_source.json
+++ b/packages/core/tests/fixtures/snapshots/data-gap-mid-history/power_model_source.json
@@ -1,0 +1,8 @@
+{
+  "metric": "power_model_source",
+  "athlete": "data-gap-mid-history",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-20T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/data-gap-mid-history/primary_sport.json
+++ b/packages/core/tests/fixtures/snapshots/data-gap-mid-history/primary_sport.json
@@ -1,0 +1,8 @@
+{
+  "metric": "primary_sport",
+  "athlete": "data-gap-mid-history",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-20T12:00:00",
+  "value": "cycling"
+}

--- a/packages/core/tests/fixtures/snapshots/data-gap-mid-history/primary_sport_monotony.json
+++ b/packages/core/tests/fixtures/snapshots/data-gap-mid-history/primary_sport_monotony.json
@@ -1,0 +1,8 @@
+{
+  "metric": "primary_sport_monotony",
+  "athlete": "data-gap-mid-history",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-20T12:00:00",
+  "value": 2.08
+}

--- a/packages/core/tests/fixtures/snapshots/data-gap-mid-history/primary_sport_tss_7d.json
+++ b/packages/core/tests/fixtures/snapshots/data-gap-mid-history/primary_sport_tss_7d.json
@@ -1,0 +1,8 @@
+{
+  "metric": "primary_sport_tss_7d",
+  "athlete": "data-gap-mid-history",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-20T12:00:00",
+  "value": 360
+}

--- a/packages/core/tests/fixtures/snapshots/data-gap-mid-history/quality_intensity_note.json
+++ b/packages/core/tests/fixtures/snapshots/data-gap-mid-history/quality_intensity_note.json
@@ -1,0 +1,8 @@
+{
+  "metric": "quality_intensity_note",
+  "athlete": "data-gap-mid-history",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-20T12:00:00",
+  "value": "Quality Intensity % (Z4+/threshold+) - target ~20% in polarized training"
+}

--- a/packages/core/tests/fixtures/snapshots/data-gap-mid-history/quality_intensity_percentage.json
+++ b/packages/core/tests/fixtures/snapshots/data-gap-mid-history/quality_intensity_percentage.json
@@ -1,0 +1,8 @@
+{
+  "metric": "quality_intensity_percentage",
+  "athlete": "data-gap-mid-history",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-20T12:00:00",
+  "value": 15
+}

--- a/packages/core/tests/fixtures/snapshots/data-gap-mid-history/recovery_index.json
+++ b/packages/core/tests/fixtures/snapshots/data-gap-mid-history/recovery_index.json
@@ -1,0 +1,8 @@
+{
+  "metric": "recovery_index",
+  "athlete": "data-gap-mid-history",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-20T12:00:00",
+  "value": 1
+}

--- a/packages/core/tests/fixtures/snapshots/data-gap-mid-history/recovery_index_yesterday.json
+++ b/packages/core/tests/fixtures/snapshots/data-gap-mid-history/recovery_index_yesterday.json
@@ -1,0 +1,8 @@
+{
+  "metric": "recovery_index_yesterday",
+  "athlete": "data-gap-mid-history",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-20T12:00:00",
+  "value": 1
+}

--- a/packages/core/tests/fixtures/snapshots/data-gap-mid-history/rhr_baseline_28d.json
+++ b/packages/core/tests/fixtures/snapshots/data-gap-mid-history/rhr_baseline_28d.json
@@ -1,0 +1,8 @@
+{
+  "metric": "rhr_baseline_28d",
+  "athlete": "data-gap-mid-history",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-20T12:00:00",
+  "value": 60
+}

--- a/packages/core/tests/fixtures/snapshots/data-gap-mid-history/rhr_baseline_7d.json
+++ b/packages/core/tests/fixtures/snapshots/data-gap-mid-history/rhr_baseline_7d.json
@@ -1,0 +1,8 @@
+{
+  "metric": "rhr_baseline_7d",
+  "athlete": "data-gap-mid-history",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-20T12:00:00",
+  "value": 60
+}

--- a/packages/core/tests/fixtures/snapshots/data-gap-mid-history/seasonal_context.json
+++ b/packages/core/tests/fixtures/snapshots/data-gap-mid-history/seasonal_context.json
@@ -1,0 +1,8 @@
+{
+  "metric": "seasonal_context",
+  "athlete": "data-gap-mid-history",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-20T12:00:00",
+  "value": "Build / Early Race Season"
+}

--- a/packages/core/tests/fixtures/snapshots/data-gap-mid-history/seiler_tid_28d.json
+++ b/packages/core/tests/fixtures/snapshots/data-gap-mid-history/seiler_tid_28d.json
@@ -1,0 +1,18 @@
+{
+  "metric": "seiler_tid_28d",
+  "athlete": "data-gap-mid-history",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-20T12:00:00",
+  "value": {
+    "classification": "Pyramidal",
+    "polarization_index": null,
+    "z1_pct": 65,
+    "z1_seconds": 13704,
+    "z2_pct": 20,
+    "z2_seconds": 4216,
+    "z3_pct": 15,
+    "z3_seconds": 3164,
+    "zone_basis": "power"
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/data-gap-mid-history/seiler_tid_28d_primary.json
+++ b/packages/core/tests/fixtures/snapshots/data-gap-mid-history/seiler_tid_28d_primary.json
@@ -1,0 +1,19 @@
+{
+  "metric": "seiler_tid_28d_primary",
+  "athlete": "data-gap-mid-history",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-20T12:00:00",
+  "value": {
+    "classification": "Pyramidal",
+    "polarization_index": null,
+    "sport": "cycling",
+    "z1_pct": 65,
+    "z1_seconds": 13704,
+    "z2_pct": 20,
+    "z2_seconds": 4216,
+    "z3_pct": 15,
+    "z3_seconds": 3164,
+    "zone_basis": "power"
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/data-gap-mid-history/seiler_tid_7d.json
+++ b/packages/core/tests/fixtures/snapshots/data-gap-mid-history/seiler_tid_7d.json
@@ -1,0 +1,18 @@
+{
+  "metric": "seiler_tid_7d",
+  "athlete": "data-gap-mid-history",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-20T12:00:00",
+  "value": {
+    "classification": "Pyramidal",
+    "polarization_index": null,
+    "z1_pct": 65,
+    "z1_seconds": 12033,
+    "z2_pct": 20,
+    "z2_seconds": 3702,
+    "z3_pct": 15,
+    "z3_seconds": 2778,
+    "zone_basis": "power"
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/data-gap-mid-history/seiler_tid_7d_primary.json
+++ b/packages/core/tests/fixtures/snapshots/data-gap-mid-history/seiler_tid_7d_primary.json
@@ -1,0 +1,19 @@
+{
+  "metric": "seiler_tid_7d_primary",
+  "athlete": "data-gap-mid-history",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-20T12:00:00",
+  "value": {
+    "classification": "Pyramidal",
+    "polarization_index": null,
+    "sport": "cycling",
+    "z1_pct": 65,
+    "z1_seconds": 12033,
+    "z2_pct": 20,
+    "z2_seconds": 3702,
+    "z3_pct": 15,
+    "z3_seconds": 2778,
+    "zone_basis": "power"
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/data-gap-mid-history/strain.json
+++ b/packages/core/tests/fixtures/snapshots/data-gap-mid-history/strain.json
@@ -1,0 +1,8 @@
+{
+  "metric": "strain",
+  "athlete": "data-gap-mid-history",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-20T12:00:00",
+  "value": 749
+}

--- a/packages/core/tests/fixtures/snapshots/data-gap-mid-history/stress_tolerance.json
+++ b/packages/core/tests/fixtures/snapshots/data-gap-mid-history/stress_tolerance.json
@@ -1,0 +1,8 @@
+{
+  "metric": "stress_tolerance",
+  "athlete": "data-gap-mid-history",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-20T12:00:00",
+  "value": 3.6
+}

--- a/packages/core/tests/fixtures/snapshots/data-gap-mid-history/tss_28d_total.json
+++ b/packages/core/tests/fixtures/snapshots/data-gap-mid-history/tss_28d_total.json
@@ -1,0 +1,8 @@
+{
+  "metric": "tss_28d_total",
+  "athlete": "data-gap-mid-history",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-20T12:00:00",
+  "value": 410
+}

--- a/packages/core/tests/fixtures/snapshots/data-gap-mid-history/tss_7d_total.json
+++ b/packages/core/tests/fixtures/snapshots/data-gap-mid-history/tss_7d_total.json
@@ -1,0 +1,8 @@
+{
+  "metric": "tss_7d_total",
+  "athlete": "data-gap-mid-history",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-20T12:00:00",
+  "value": 360
+}

--- a/packages/core/tests/fixtures/snapshots/data-gap-mid-history/vo2max.json
+++ b/packages/core/tests/fixtures/snapshots/data-gap-mid-history/vo2max.json
@@ -1,0 +1,8 @@
+{
+  "metric": "vo2max",
+  "athlete": "data-gap-mid-history",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-20T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/data-gap-mid-history/w_prime.json
+++ b/packages/core/tests/fixtures/snapshots/data-gap-mid-history/w_prime.json
@@ -1,0 +1,8 @@
+{
+  "metric": "w_prime",
+  "athlete": "data-gap-mid-history",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-20T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/data-gap-mid-history/w_prime_kj.json
+++ b/packages/core/tests/fixtures/snapshots/data-gap-mid-history/w_prime_kj.json
@@ -1,0 +1,8 @@
+{
+  "metric": "w_prime_kj",
+  "athlete": "data-gap-mid-history",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-20T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/data-gap-mid-history/zone_distribution_7d.json
+++ b/packages/core/tests/fixtures/snapshots/data-gap-mid-history/zone_distribution_7d.json
@@ -1,0 +1,15 @@
+{
+  "metric": "zone_distribution_7d",
+  "athlete": "data-gap-mid-history",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-20T12:00:00",
+  "value": {
+    "total_hours": 5.14,
+    "z1_hours": 0.51,
+    "z2_hours": 2.83,
+    "z3_hours": 1.03,
+    "z4_plus_hours": 0.77,
+    "zone_basis": "power"
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/manifest.json
+++ b/packages/core/tests/fixtures/snapshots/manifest.json
@@ -3,6 +3,8 @@
   "section_11_protocol_version": "3.112",
   "section_11_commit_date": "2026-04-30T21:50:59+02:00",
   "fixtures": [
+    "data-gap-mid-history",
+    "new-athlete-empty",
     "realistic-athlete"
   ],
   "metrics": [

--- a/packages/core/tests/fixtures/snapshots/new-athlete-empty/acwr.json
+++ b/packages/core/tests/fixtures/snapshots/new-athlete-empty/acwr.json
@@ -1,0 +1,8 @@
+{
+  "metric": "acwr",
+  "athlete": "new-athlete-empty",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/new-athlete-empty/acwr_interpretation.json
+++ b/packages/core/tests/fixtures/snapshots/new-athlete-empty/acwr_interpretation.json
@@ -1,0 +1,8 @@
+{
+  "metric": "acwr_interpretation",
+  "athlete": "new-athlete-empty",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/new-athlete-empty/benchmark_indoor.json
+++ b/packages/core/tests/fixtures/snapshots/new-athlete-empty/benchmark_indoor.json
@@ -1,0 +1,14 @@
+{
+  "metric": "benchmark_indoor",
+  "athlete": "new-athlete-empty",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "benchmark_index": null,
+    "benchmark_percentage": null,
+    "current_ftp": null,
+    "ftp_8_weeks_ago": null,
+    "seasonal_expected": null
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/new-athlete-empty/benchmark_outdoor.json
+++ b/packages/core/tests/fixtures/snapshots/new-athlete-empty/benchmark_outdoor.json
@@ -1,0 +1,14 @@
+{
+  "metric": "benchmark_outdoor",
+  "athlete": "new-athlete-empty",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "benchmark_index": null,
+    "benchmark_percentage": null,
+    "current_ftp": null,
+    "ftp_8_weeks_ago": null,
+    "seasonal_expected": null
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/new-athlete-empty/calculation_timestamp.json
+++ b/packages/core/tests/fixtures/snapshots/new-athlete-empty/calculation_timestamp.json
@@ -1,0 +1,8 @@
+{
+  "metric": "calculation_timestamp",
+  "athlete": "new-athlete-empty",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": "2026-05-10T12:00:00"
+}

--- a/packages/core/tests/fixtures/snapshots/new-athlete-empty/capability.json
+++ b/packages/core/tests/fixtures/snapshots/new-athlete-empty/capability.json
@@ -1,0 +1,62 @@
+{
+  "metric": "capability",
+  "athlete": "new-athlete-empty",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "dfa_a1_profile": null,
+    "durability": {
+      "high_drift_count_28d": 0,
+      "high_drift_count_7d": 0,
+      "mean_decoupling_28d": null,
+      "mean_decoupling_7d": null,
+      "note": "Steady-state power sessions only (VI <= 1.05, VI > 0, >= 90min, power data). Negative decoupling = strong durability. Trend compares 7d vs 28d mean (+/-1% = stable). Alerts require N28>=5 (alarm) or N7>=3 AND N28>=5 (declining warning) for statistical reliability.",
+      "qualifying_sessions_28d": 0,
+      "qualifying_sessions_7d": 0,
+      "reliability_limited": true,
+      "reliability_note": "insufficient qualifying sessions for alert evaluation: 7d N=0 (min 3), 28d N=0 (min 5)",
+      "trend": null
+    },
+    "efficiency_factor": {
+      "mean_ef_28d": null,
+      "mean_ef_7d": null,
+      "note": "Steady-state cycling sessions only (VI <= 1.05, VI > 0, >= 20min, power+HR data). Rising EF = improving aerobic efficiency. Compare like-for-like sessions only — EF varies with intensity. Trend compares 7d vs 28d mean (+/-0.03 = stable).",
+      "qualifying_sessions_28d": 0,
+      "qualifying_sessions_7d": 0,
+      "trend": null
+    },
+    "hr_curve_delta": {
+      "anchors": null,
+      "note": "Insufficient HR data in one or both windows.",
+      "rotation_index": null,
+      "window_days": 28
+    },
+    "hrrc": {
+      "mean_hrrc_28d": null,
+      "mean_hrrc_7d": null,
+      "note": "HRRc = heart rate recovery (largest 60s HR drop in bpm after exceeding threshold HR for >1 min). Higher = better parasympathetic recovery. Null when threshold not reached, recording stopped before cooldown, or no HR data. Trend: 7d mean vs 28d mean, >10% = meaningful (min 1 session/7d, 3 sessions/28d). Display only — not wired into readiness_decision signals.",
+      "qualifying_sessions_28d": 0,
+      "qualifying_sessions_7d": 0,
+      "trend": null
+    },
+    "power_curve_delta": {
+      "anchors": null,
+      "note": "Insufficient power data in one or both windows.",
+      "rotation_index": null,
+      "window_days": 28
+    },
+    "sustainability_profile": {
+      "note": "No sustainability data available."
+    },
+    "tid_comparison": {
+      "classification_28d": null,
+      "classification_7d": null,
+      "drift": null,
+      "note": "Compares 7d vs 28d Seiler TID to detect distribution shifts. Insufficient data in one or both windows.",
+      "pi_28d": null,
+      "pi_7d": null,
+      "pi_delta": null
+    }
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/new-athlete-empty/consistency_details.json
+++ b/packages/core/tests/fixtures/snapshots/new-athlete-empty/consistency_details.json
@@ -1,0 +1,13 @@
+{
+  "metric": "consistency_details",
+  "athlete": "new-athlete-empty",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "completed_days": 0,
+    "matched_days": 0,
+    "note": "No planned workouts in period",
+    "planned_days": 0
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/new-athlete-empty/consistency_index.json
+++ b/packages/core/tests/fixtures/snapshots/new-athlete-empty/consistency_index.json
@@ -1,0 +1,8 @@
+{
+  "metric": "consistency_index",
+  "athlete": "new-athlete-empty",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/new-athlete-empty/data_quality.json
+++ b/packages/core/tests/fixtures/snapshots/new-athlete-empty/data_quality.json
@@ -1,0 +1,18 @@
+{
+  "metric": "data_quality",
+  "athlete": "new-athlete-empty",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "activities_28d": 0,
+    "activities_7d": 0,
+    "ftp_history_days": {
+      "indoor": 0,
+      "outdoor": 0
+    },
+    "hrv_data_points": 0,
+    "planned_workouts_7d": 0,
+    "rhr_data_points": 0
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/new-athlete-empty/easy_time_ratio.json
+++ b/packages/core/tests/fixtures/snapshots/new-athlete-empty/easy_time_ratio.json
@@ -1,0 +1,8 @@
+{
+  "metric": "easy_time_ratio",
+  "athlete": "new-athlete-empty",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/new-athlete-empty/easy_time_ratio_note.json
+++ b/packages/core/tests/fixtures/snapshots/new-athlete-empty/easy_time_ratio_note.json
@@ -1,0 +1,8 @@
+{
+  "metric": "easy_time_ratio_note",
+  "athlete": "new-athlete-empty",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": "Easy time (Z1+Z2) / Total - target ~80% in polarized training"
+}

--- a/packages/core/tests/fixtures/snapshots/new-athlete-empty/effective_monotony.json
+++ b/packages/core/tests/fixtures/snapshots/new-athlete-empty/effective_monotony.json
@@ -1,0 +1,8 @@
+{
+  "metric": "effective_monotony",
+  "athlete": "new-athlete-empty",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/new-athlete-empty/eftp.json
+++ b/packages/core/tests/fixtures/snapshots/new-athlete-empty/eftp.json
@@ -1,0 +1,8 @@
+{
+  "metric": "eftp",
+  "athlete": "new-athlete-empty",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/new-athlete-empty/grey_zone_note.json
+++ b/packages/core/tests/fixtures/snapshots/new-athlete-empty/grey_zone_note.json
@@ -1,0 +1,8 @@
+{
+  "metric": "grey_zone_note",
+  "athlete": "new-athlete-empty",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": "Gray Zone % (Z3/tempo) - minimize in polarized training"
+}

--- a/packages/core/tests/fixtures/snapshots/new-athlete-empty/grey_zone_percentage.json
+++ b/packages/core/tests/fixtures/snapshots/new-athlete-empty/grey_zone_percentage.json
@@ -1,0 +1,8 @@
+{
+  "metric": "grey_zone_percentage",
+  "athlete": "new-athlete-empty",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/new-athlete-empty/hard_days_note.json
+++ b/packages/core/tests/fixtures/snapshots/new-athlete-empty/hard_days_note.json
@@ -1,0 +1,8 @@
+{
+  "metric": "hard_days_note",
+  "athlete": "new-athlete-empty",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": "Power ladder: z3+ >= 30min, z4+ >= 10min, z5+ >= 5min, z6+ >= 2min, z7 >= 1min. HR fallback (when no power): z4+ >= 10min, z5+ >= 5min. Per Seiler 3-zone model + Foster. HR-based days flagged with intensity_basis: hr"
+}

--- a/packages/core/tests/fixtures/snapshots/new-athlete-empty/hard_days_this_week.json
+++ b/packages/core/tests/fixtures/snapshots/new-athlete-empty/hard_days_this_week.json
@@ -1,0 +1,8 @@
+{
+  "metric": "hard_days_this_week",
+  "athlete": "new-athlete-empty",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 0
+}

--- a/packages/core/tests/fixtures/snapshots/new-athlete-empty/hrv_baseline_28d.json
+++ b/packages/core/tests/fixtures/snapshots/new-athlete-empty/hrv_baseline_28d.json
@@ -1,0 +1,8 @@
+{
+  "metric": "hrv_baseline_28d",
+  "athlete": "new-athlete-empty",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/new-athlete-empty/hrv_baseline_7d.json
+++ b/packages/core/tests/fixtures/snapshots/new-athlete-empty/hrv_baseline_7d.json
@@ -1,0 +1,8 @@
+{
+  "metric": "hrv_baseline_7d",
+  "athlete": "new-athlete-empty",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/new-athlete-empty/latest_hrv.json
+++ b/packages/core/tests/fixtures/snapshots/new-athlete-empty/latest_hrv.json
@@ -1,0 +1,8 @@
+{
+  "metric": "latest_hrv",
+  "athlete": "new-athlete-empty",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/new-athlete-empty/latest_rhr.json
+++ b/packages/core/tests/fixtures/snapshots/new-athlete-empty/latest_rhr.json
@@ -1,0 +1,8 @@
+{
+  "metric": "latest_rhr",
+  "athlete": "new-athlete-empty",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/new-athlete-empty/load_recovery_ratio.json
+++ b/packages/core/tests/fixtures/snapshots/new-athlete-empty/load_recovery_ratio.json
@@ -1,0 +1,8 @@
+{
+  "metric": "load_recovery_ratio",
+  "athlete": "new-athlete-empty",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/new-athlete-empty/monotony.json
+++ b/packages/core/tests/fixtures/snapshots/new-athlete-empty/monotony.json
@@ -1,0 +1,8 @@
+{
+  "metric": "monotony",
+  "athlete": "new-athlete-empty",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/new-athlete-empty/monotony_interpretation.json
+++ b/packages/core/tests/fixtures/snapshots/new-athlete-empty/monotony_interpretation.json
@@ -1,0 +1,8 @@
+{
+  "metric": "monotony_interpretation",
+  "athlete": "new-athlete-empty",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/new-athlete-empty/multi_sport_detected.json
+++ b/packages/core/tests/fixtures/snapshots/new-athlete-empty/multi_sport_detected.json
@@ -1,0 +1,8 @@
+{
+  "metric": "multi_sport_detected",
+  "athlete": "new-athlete-empty",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": false
+}

--- a/packages/core/tests/fixtures/snapshots/new-athlete-empty/p_max.json
+++ b/packages/core/tests/fixtures/snapshots/new-athlete-empty/p_max.json
@@ -1,0 +1,8 @@
+{
+  "metric": "p_max",
+  "athlete": "new-athlete-empty",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/new-athlete-empty/phase_detected.json
+++ b/packages/core/tests/fixtures/snapshots/new-athlete-empty/phase_detected.json
@@ -1,0 +1,8 @@
+{
+  "metric": "phase_detected",
+  "athlete": "new-athlete-empty",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": "Base"
+}

--- a/packages/core/tests/fixtures/snapshots/new-athlete-empty/phase_detection.json
+++ b/packages/core/tests/fixtures/snapshots/new-athlete-empty/phase_detection.json
@@ -1,0 +1,38 @@
+{
+  "metric": "phase_detection",
+  "athlete": "new-athlete-empty",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "basis": {
+      "data_quality": "good",
+      "stream_1": {
+        "acwr_trend": null,
+        "ctl_slope": null,
+        "hard_day_pattern": 0,
+        "weeks_available": 4
+      },
+      "stream_2": {
+        "current_week_hard_days_completed": 0,
+        "current_week_hard_days_total": 0,
+        "hard_sessions_planned": 0,
+        "next_week_load": null,
+        "plan_coverage_current_week": 0,
+        "plan_coverage_next_week": 0,
+        "planned_tss_delta": null,
+        "race_proximity": null
+      },
+      "stream_agreement": null
+    },
+    "confidence": "medium",
+    "dossier_agreement": null,
+    "dossier_declared": null,
+    "phase": "Base",
+    "phase_duration_weeks": 1,
+    "previous_phase": null,
+    "reason_codes": [
+      "NO_PLANNED_WORKOUTS"
+    ]
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/new-athlete-empty/phase_triggers.json
+++ b/packages/core/tests/fixtures/snapshots/new-athlete-empty/phase_triggers.json
@@ -1,0 +1,10 @@
+{
+  "metric": "phase_triggers",
+  "athlete": "new-athlete-empty",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": [
+    "NO_PLANNED_WORKOUTS"
+  ]
+}

--- a/packages/core/tests/fixtures/snapshots/new-athlete-empty/power_model_source.json
+++ b/packages/core/tests/fixtures/snapshots/new-athlete-empty/power_model_source.json
@@ -1,0 +1,8 @@
+{
+  "metric": "power_model_source",
+  "athlete": "new-athlete-empty",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/new-athlete-empty/primary_sport.json
+++ b/packages/core/tests/fixtures/snapshots/new-athlete-empty/primary_sport.json
@@ -1,0 +1,8 @@
+{
+  "metric": "primary_sport",
+  "athlete": "new-athlete-empty",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/new-athlete-empty/primary_sport_monotony.json
+++ b/packages/core/tests/fixtures/snapshots/new-athlete-empty/primary_sport_monotony.json
@@ -1,0 +1,8 @@
+{
+  "metric": "primary_sport_monotony",
+  "athlete": "new-athlete-empty",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/new-athlete-empty/primary_sport_tss_7d.json
+++ b/packages/core/tests/fixtures/snapshots/new-athlete-empty/primary_sport_tss_7d.json
@@ -1,0 +1,8 @@
+{
+  "metric": "primary_sport_tss_7d",
+  "athlete": "new-athlete-empty",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/new-athlete-empty/quality_intensity_note.json
+++ b/packages/core/tests/fixtures/snapshots/new-athlete-empty/quality_intensity_note.json
@@ -1,0 +1,8 @@
+{
+  "metric": "quality_intensity_note",
+  "athlete": "new-athlete-empty",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": "Quality Intensity % (Z4+/threshold+) - target ~20% in polarized training"
+}

--- a/packages/core/tests/fixtures/snapshots/new-athlete-empty/quality_intensity_percentage.json
+++ b/packages/core/tests/fixtures/snapshots/new-athlete-empty/quality_intensity_percentage.json
@@ -1,0 +1,8 @@
+{
+  "metric": "quality_intensity_percentage",
+  "athlete": "new-athlete-empty",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/new-athlete-empty/recovery_index.json
+++ b/packages/core/tests/fixtures/snapshots/new-athlete-empty/recovery_index.json
@@ -1,0 +1,8 @@
+{
+  "metric": "recovery_index",
+  "athlete": "new-athlete-empty",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/new-athlete-empty/recovery_index_yesterday.json
+++ b/packages/core/tests/fixtures/snapshots/new-athlete-empty/recovery_index_yesterday.json
@@ -1,0 +1,8 @@
+{
+  "metric": "recovery_index_yesterday",
+  "athlete": "new-athlete-empty",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/new-athlete-empty/rhr_baseline_28d.json
+++ b/packages/core/tests/fixtures/snapshots/new-athlete-empty/rhr_baseline_28d.json
@@ -1,0 +1,8 @@
+{
+  "metric": "rhr_baseline_28d",
+  "athlete": "new-athlete-empty",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/new-athlete-empty/rhr_baseline_7d.json
+++ b/packages/core/tests/fixtures/snapshots/new-athlete-empty/rhr_baseline_7d.json
@@ -1,0 +1,8 @@
+{
+  "metric": "rhr_baseline_7d",
+  "athlete": "new-athlete-empty",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/new-athlete-empty/seasonal_context.json
+++ b/packages/core/tests/fixtures/snapshots/new-athlete-empty/seasonal_context.json
@@ -1,0 +1,8 @@
+{
+  "metric": "seasonal_context",
+  "athlete": "new-athlete-empty",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": "Build / Early Race Season"
+}

--- a/packages/core/tests/fixtures/snapshots/new-athlete-empty/seiler_tid_28d.json
+++ b/packages/core/tests/fixtures/snapshots/new-athlete-empty/seiler_tid_28d.json
@@ -1,0 +1,18 @@
+{
+  "metric": "seiler_tid_28d",
+  "athlete": "new-athlete-empty",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "classification": null,
+    "polarization_index": null,
+    "z1_pct": null,
+    "z1_seconds": 0,
+    "z2_pct": null,
+    "z2_seconds": 0,
+    "z3_pct": null,
+    "z3_seconds": 0,
+    "zone_basis": null
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/new-athlete-empty/seiler_tid_28d_primary.json
+++ b/packages/core/tests/fixtures/snapshots/new-athlete-empty/seiler_tid_28d_primary.json
@@ -1,0 +1,8 @@
+{
+  "metric": "seiler_tid_28d_primary",
+  "athlete": "new-athlete-empty",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/new-athlete-empty/seiler_tid_7d.json
+++ b/packages/core/tests/fixtures/snapshots/new-athlete-empty/seiler_tid_7d.json
@@ -1,0 +1,18 @@
+{
+  "metric": "seiler_tid_7d",
+  "athlete": "new-athlete-empty",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "classification": null,
+    "polarization_index": null,
+    "z1_pct": null,
+    "z1_seconds": 0,
+    "z2_pct": null,
+    "z2_seconds": 0,
+    "z3_pct": null,
+    "z3_seconds": 0,
+    "zone_basis": null
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/new-athlete-empty/seiler_tid_7d_primary.json
+++ b/packages/core/tests/fixtures/snapshots/new-athlete-empty/seiler_tid_7d_primary.json
@@ -1,0 +1,8 @@
+{
+  "metric": "seiler_tid_7d_primary",
+  "athlete": "new-athlete-empty",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/new-athlete-empty/strain.json
+++ b/packages/core/tests/fixtures/snapshots/new-athlete-empty/strain.json
@@ -1,0 +1,8 @@
+{
+  "metric": "strain",
+  "athlete": "new-athlete-empty",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/new-athlete-empty/stress_tolerance.json
+++ b/packages/core/tests/fixtures/snapshots/new-athlete-empty/stress_tolerance.json
@@ -1,0 +1,8 @@
+{
+  "metric": "stress_tolerance",
+  "athlete": "new-athlete-empty",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/new-athlete-empty/tss_28d_total.json
+++ b/packages/core/tests/fixtures/snapshots/new-athlete-empty/tss_28d_total.json
@@ -1,0 +1,8 @@
+{
+  "metric": "tss_28d_total",
+  "athlete": "new-athlete-empty",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 0
+}

--- a/packages/core/tests/fixtures/snapshots/new-athlete-empty/tss_7d_total.json
+++ b/packages/core/tests/fixtures/snapshots/new-athlete-empty/tss_7d_total.json
@@ -1,0 +1,8 @@
+{
+  "metric": "tss_7d_total",
+  "athlete": "new-athlete-empty",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 0
+}

--- a/packages/core/tests/fixtures/snapshots/new-athlete-empty/vo2max.json
+++ b/packages/core/tests/fixtures/snapshots/new-athlete-empty/vo2max.json
@@ -1,0 +1,8 @@
+{
+  "metric": "vo2max",
+  "athlete": "new-athlete-empty",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/new-athlete-empty/w_prime.json
+++ b/packages/core/tests/fixtures/snapshots/new-athlete-empty/w_prime.json
@@ -1,0 +1,8 @@
+{
+  "metric": "w_prime",
+  "athlete": "new-athlete-empty",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/new-athlete-empty/w_prime_kj.json
+++ b/packages/core/tests/fixtures/snapshots/new-athlete-empty/w_prime_kj.json
@@ -1,0 +1,8 @@
+{
+  "metric": "w_prime_kj",
+  "athlete": "new-athlete-empty",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/new-athlete-empty/zone_distribution_7d.json
+++ b/packages/core/tests/fixtures/snapshots/new-athlete-empty/zone_distribution_7d.json
@@ -1,0 +1,15 @@
+{
+  "metric": "zone_distribution_7d",
+  "athlete": "new-athlete-empty",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "total_hours": 0,
+    "z1_hours": 0,
+    "z2_hours": 0,
+    "z3_hours": 0,
+    "z4_plus_hours": 0,
+    "zone_basis": null
+  }
+}

--- a/tools/check-metric-parity.ts
+++ b/tools/check-metric-parity.ts
@@ -22,6 +22,15 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import { parse as parseYaml } from "yaml";
 import { z } from "zod";
 
+import type { MetricInput } from "../packages/core/src/reference/metrics/metric-input.js";
+import {
+  METRIC_REGISTRY,
+  type MetricRegistryEntry,
+} from "../packages/core/src/reference/metrics/registry.js";
+
+export type { MetricInput, MetricRegistryEntry };
+export { METRIC_REGISTRY };
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 export const REPO_ROOT = resolve(__dirname, "..");
@@ -34,28 +43,6 @@ const FIXTURES_ROOT = resolve(
   "packages/core/tests/fixtures/golden",
 );
 const DEVIATIONS_PATH = resolve(REPO_ROOT, "tools/intentional-deviations.yaml");
-
-// ─── Metric registry ────────────────────────────────────────────────────
-//
-// How to add a metric:
-//
-//   1. Implement the metric in `packages/core/src/reference/metrics/<file>.ts`
-//      with the signature `(fixture: <FixtureShape>) => <ValueType>`.
-//   2. Add an entry below, with `module` pointing at the TS module
-//      (this-file-relative) and `exportName` matching the exported
-//      function. The CLI will dynamically `import()` it.
-//   3. Re-run `pnpm test`. The Vitest matrix at
-//      `packages/core/tests/reference-parity.test.ts` automatically
-//      picks up new entries.
-//
-// An empty registry is correct: the Vitest matrix produces zero cases
-// and `pnpm test` continues to pass.
-export interface MetricRegistryEntry {
-  module: string;
-  exportName: string;
-}
-
-export const METRIC_REGISTRY: Record<string, MetricRegistryEntry> = {};
 
 // ─── Deviation registry ─────────────────────────────────────────────────
 //
@@ -316,20 +303,7 @@ export async function runParityCheck(args: {
   const snap = loadSnapshot(args.fixture, args.metric);
   const fixture = loadGoldenFixture(args.fixture);
 
-  const moduleSpecifier = entry.module.startsWith(".")
-    ? pathToFileURL(resolve(__dirname, entry.module)).href
-    : entry.module;
-  const mod = (await import(moduleSpecifier)) as Record<string, unknown>;
-  const computeFn = mod[entry.exportName] as
-    | ((input: unknown) => unknown)
-    | undefined;
-  if (typeof computeFn !== "function") {
-    throw new Error(
-      `metric '${args.metric}' registry entry resolves to ${entry.module}#${entry.exportName} ` +
-        "but that export is not a function",
-    );
-  }
-  const actual = computeFn(fixture);
+  const actual = entry.compute({ fixture, frozenNow: snap.frozen_now });
   const diff = deepCompare(snap.value, actual);
 
   const deviation = findDeviation(args.metric);

--- a/tools/intentional-deviations.yaml
+++ b/tools/intentional-deviations.yaml
@@ -220,30 +220,28 @@ deviations:
       rename + REST_DAY_RECOVERY_HOURS removal). Status lives there;
       this entry remains anchored to the 2026-05-21 revert decision.
 
-# ─── Pre-F8 audit (T02, 2026-05-21) ──────────────────────────────────────
+# Pre-port deviation audit (2026-05-21)
 #
-# Mechanical sweep over shipped Reference layer code (Waves 1, 1b, F7)
-# against section-11/examples/sync.py to surface undiscovered constant
-# or behavioral drift before F8 starts adding domain math.
+# Mechanical sweep over the shipped non-metric Reference layer code
+# (sync infrastructure + schemas + concurrency + io primitives) against
+# section-11/examples/sync.py to surface undiscovered constant or
+# behavioral drift before metric math starts landing.
 #
 # Scope (TS):
-#   packages/core/src/reference/sync/**.ts          (10 files)
-#   packages/core/src/reference/schemas/**.ts       (10 files)
-#   packages/core/src/reference/*.ts top-level      (freshness, runtime,
-#                                                    paths, services,
-#                                                    sport-adapter,
-#                                                    trademark-policy,
-#                                                    preserve-tokens,
-#                                                    index)
-#   packages/core/src/concurrency/*.ts              (4 files)
-#   packages/core/src/io/*.ts                       (3 files)
+#   packages/core/src/reference/sync/**.ts
+#   packages/core/src/reference/schemas/**.ts
+#   packages/core/src/reference/*.ts top-level (freshness, runtime,
+#     paths, services, sport-adapter, trademark-policy, preserve-tokens,
+#     index)
+#   packages/core/src/concurrency/*.ts
+#   packages/core/src/io/*.ts
 #
-# Out of scope (no domain math shipped yet, or different wave):
-#   packages/core/src/reference/metrics/            (F8+ — Wave 2)
-#   packages/core/src/reference/validation/         (Wave 4)
-#   packages/core/src/reference/curator/            (Wave 5)
-#   packages/core/src/reference/units/              (Wave 6)
-#   packages/core/src/reference/audit/              (Wave 7)
+# Out of scope (no domain math shipped, audited per-metric on port):
+#   packages/core/src/reference/metrics/
+#   packages/core/src/reference/validation/
+#   packages/core/src/reference/curator/
+#   packages/core/src/reference/units/
+#   packages/core/src/reference/audit/
 #
 # Patterns searched in section-11/examples/sync.py:
 #   - Module-level UPPER_CASE constants (lines ~250-330):
@@ -268,7 +266,7 @@ deviations:
 #   | Latest display window         | days_back default = 7        | LATEST_RETENTION_DAYS = 7 (freshness.ts)      |
 #   | Week-start convention         | WEEK_START_DAY = 0 (Monday)  | WeeklyRollupSchema "Monday" (inputs.ts:144)   |
 #   | Per-request HTTP timeout      | timeout=30 (intervals.icu)   | PER_REQUEST_TIMEOUT_MS = 30_000 (freshness)   |
-#   | Cache file names              | *.json (latest/history/etc.) | runtime.ts JSDoc lists same five filenames    |
+#   | Cache file names              | *.json (latest/history/etc.) | paths.ts JSDoc lists same five filenames      |
 #
 # TS-only architecture (no section-11 counterpart — not deviations):
 #
@@ -286,22 +284,17 @@ deviations:
 #     indefinitely (no explicit retention rule); the 90-day TS choice is
 #     a cache-layer policy, not a port of a section-11 number.
 #
-# Wave-2+ domain math NOT shipped yet (cannot be audited until ported):
+# Domain math in sync.py NOT yet ported (cannot be audited until ported;
+# each lands as a `deviations:` entry above if drift is introduced):
 #
-#   - days_for_acwr = 28 (sync.py:2275)        → F8 metric work
-#   - SUSTAINABILITY_WINDOW_DAYS = 42 (line 328) → Wave 3+
-#   - BLOCK_WINDOW_DAYS = 28 / BOUNDARY_WIDTH_DAYS = 4 (lines 2833-2834)
-#                                              → Wave 4 validation
-#   - DFA_* family (lines 277-283)             → Wave 3+ capability
-#   - Event lookahead 90 d / near-future 42 d (lines 2391, 2397)
-#                                              → compliance / F11
-#   - Power-curve windows (lines 2466-2468)    → Wave 3+ capability
+#   - days_for_acwr = 28 (sync.py:2275)
+#   - SUSTAINABILITY_WINDOW_DAYS = 42 (sync.py:328)
+#   - BLOCK_WINDOW_DAYS = 28 / BOUNDARY_WIDTH_DAYS = 4 (sync.py:2833-2834)
+#   - DFA_* family (sync.py:277-283)
+#   - Event lookahead 90 d / near-future 42 d (sync.py:2391, 2397)
+#   - Power-curve windows (sync.py:2466-2468)
 #
-# Verdict: 0 undiscovered deviations in the shipped Reference layer.
-# The drift surface is metric math (Waves 2+); the cache + sync
-# infrastructure shipped in Waves 1, 1b, F7 mirrors section-11's
-# constants where the two layers semantically overlap.
-#
-# Coverage time: ~50 min. Reviewer: Yerzhan (operator). Method: grep
-# audit of UPPER_CASE constants + day-window literals + timeout values
-# across both codebases, cross-walked into the table above.
+# Verdict: 0 undiscovered deviations in the shipped non-metric Reference
+# layer. The drift surface is metric math; the cache + sync infrastructure
+# already mirrors section-11's constants where the two layers semantically
+# overlap.

--- a/tools/intentional-deviations.yaml
+++ b/tools/intentional-deviations.yaml
@@ -43,6 +43,14 @@
 #     when a metric being ported has a `pending` entry; surfaces the
 #     deviation when porting against an `approved-cite` entry.
 #
+# Companion artifact (footer of this file):
+#   The bottom of this file carries a one-time Reference-layer baseline
+#   audit. Subsequent porting drift is audited PER-METRIC via
+#   /port-metric (which writes entries directly to `deviations:` above),
+#   NOT by appending additional bulk-audit footers here. Keep the
+#   footer count = 1; if you find yourself appending a second, that's
+#   a sign the audit log should be lifted to a separate markdown file.
+#
 # Lifecycle: every entry starts `pending` and stays there until a human
 # review (see porting-discipline §Phase 4) records a decision. No agent
 # may flip status without an explicit human instruction citing literature
@@ -220,12 +228,13 @@ deviations:
       rename + REST_DAY_RECOVERY_HOURS removal). Status lives there;
       this entry remains anchored to the 2026-05-21 revert decision.
 
-# Pre-port deviation audit (2026-05-21)
+# Reference-layer baseline audit (2026-05-21)
 #
 # Mechanical sweep over the shipped non-metric Reference layer code
 # (sync infrastructure + schemas + concurrency + io primitives) against
-# section-11/examples/sync.py to surface undiscovered constant or
-# behavioral drift before metric math starts landing.
+# section-11/examples/sync.py to surface undiscovered constant drift
+# before metric math starts landing. Behavioral drift is out of scope
+# for this sweep — it's enforced by the parity gate, not by audit.
 #
 # Scope (TS):
 #   packages/core/src/reference/sync/**.ts

--- a/tools/intentional-deviations.yaml
+++ b/tools/intentional-deviations.yaml
@@ -219,3 +219,89 @@ deviations:
       rev 7 inline rewrite + F7 schema rev to drop weeklyRecoveryProxyHours
       rename + REST_DAY_RECOVERY_HOURS removal). Status lives there;
       this entry remains anchored to the 2026-05-21 revert decision.
+
+# ─── Pre-F8 audit (T02, 2026-05-21) ──────────────────────────────────────
+#
+# Mechanical sweep over shipped Reference layer code (Waves 1, 1b, F7)
+# against section-11/examples/sync.py to surface undiscovered constant
+# or behavioral drift before F8 starts adding domain math.
+#
+# Scope (TS):
+#   packages/core/src/reference/sync/**.ts          (10 files)
+#   packages/core/src/reference/schemas/**.ts       (10 files)
+#   packages/core/src/reference/*.ts top-level      (freshness, runtime,
+#                                                    paths, services,
+#                                                    sport-adapter,
+#                                                    trademark-policy,
+#                                                    preserve-tokens,
+#                                                    index)
+#   packages/core/src/concurrency/*.ts              (4 files)
+#   packages/core/src/io/*.ts                       (3 files)
+#
+# Out of scope (no domain math shipped yet, or different wave):
+#   packages/core/src/reference/metrics/            (F8+ — Wave 2)
+#   packages/core/src/reference/validation/         (Wave 4)
+#   packages/core/src/reference/curator/            (Wave 5)
+#   packages/core/src/reference/units/              (Wave 6)
+#   packages/core/src/reference/audit/              (Wave 7)
+#
+# Patterns searched in section-11/examples/sync.py:
+#   - Module-level UPPER_CASE constants (lines ~250-330):
+#       INTERVAL_SCAN_HOURS, INTERVAL_RETENTION_DAYS, WEEK_START_DAY,
+#       SUSTAINABILITY_WINDOW_DAYS, DFA_* family, FTP_HISTORY_FILE,
+#       HISTORY_FILE, INTERVALS_FILE, ROUTES_FILE.
+#   - Function-local windows: days_back, days_for_acwr, BLOCK_WINDOW_DAYS,
+#     BOUNDARY_WIDTH_DAYS, event lookahead (90 d / 42 d).
+#   - HTTP timeouts: `timeout=30` (intervals.icu), `timeout=10` (GitHub),
+#     `timeout=60` (zip download).
+#   - Retry / backoff (none in section-11; transient → skip-cache-write).
+#   - Zone schema constants (Z1-Z7 enumeration).
+#
+# Cross-walk verdict — semantic-role pairs that DO match (no deviation):
+#
+#   | Role                          | section-11 (sync.py)         | Reference (TS)                                |
+#   |-------------------------------|------------------------------|-----------------------------------------------|
+#   | Intervals cache retention     | INTERVAL_RETENTION_DAYS = 14 | INTERVALS_RETENTION_DAYS = 14 (freshness.ts)  |
+#   | Daily history window          | daily_90d naming + behavior  | HISTORY_DAILY_DAYS = 90 (freshness.ts)        |
+#   | Weekly history window         | weekly_180d naming           | HISTORY_WEEKLY_DAYS = 180 (freshness.ts)      |
+#   | Monthly history span          | monthly_3y naming            | HISTORY_MONTHLY_YEARS = 3 (freshness.ts)      |
+#   | Latest display window         | days_back default = 7        | LATEST_RETENTION_DAYS = 7 (freshness.ts)      |
+#   | Week-start convention         | WEEK_START_DAY = 0 (Monday)  | WeeklyRollupSchema "Monday" (inputs.ts:144)   |
+#   | Per-request HTTP timeout      | timeout=30 (intervals.icu)   | PER_REQUEST_TIMEOUT_MS = 30_000 (freshness)   |
+#   | Cache file names              | *.json (latest/history/etc.) | runtime.ts JSDoc lists same five filenames    |
+#
+# TS-only architecture (no section-11 counterpart — not deviations):
+#
+#   - Freshness model (FRESH_MS / STALE_MS / CRITICAL_MS) — Reference is a
+#     long-running cache; section-11 is a one-shot script with no
+#     freshness concept.
+#   - Orchestration timeouts (MUTEX_*, SYNC_OPERATION_TIMEOUT_MS,
+#     SYNC_COOLDOWN_MS) — ADR-0011 territory; section-11 single-threaded.
+#   - Periodic sync cadence (SCHEDULED_SYNC_INTERVAL_MS = 30 min) —
+#     section-11 runs on demand or external cron.
+#   - Telegram dispatch (TELEGRAM_MAX_CHUNK = 4096,
+#     SNAPSHOT_DOCUMENT_THRESHOLD_* , DEFAULT_TRANSIENT_BACKOFF_MS,
+#     MAX_RETRY_AFTER_SEC) — channel concerns, off section-11's path.
+#   - ROUTES_RETENTION_DAYS = 90 — section-11 keeps routes.json
+#     indefinitely (no explicit retention rule); the 90-day TS choice is
+#     a cache-layer policy, not a port of a section-11 number.
+#
+# Wave-2+ domain math NOT shipped yet (cannot be audited until ported):
+#
+#   - days_for_acwr = 28 (sync.py:2275)        → F8 metric work
+#   - SUSTAINABILITY_WINDOW_DAYS = 42 (line 328) → Wave 3+
+#   - BLOCK_WINDOW_DAYS = 28 / BOUNDARY_WIDTH_DAYS = 4 (lines 2833-2834)
+#                                              → Wave 4 validation
+#   - DFA_* family (lines 277-283)             → Wave 3+ capability
+#   - Event lookahead 90 d / near-future 42 d (lines 2391, 2397)
+#                                              → compliance / F11
+#   - Power-curve windows (lines 2466-2468)    → Wave 3+ capability
+#
+# Verdict: 0 undiscovered deviations in the shipped Reference layer.
+# The drift surface is metric math (Waves 2+); the cache + sync
+# infrastructure shipped in Waves 1, 1b, F7 mirrors section-11's
+# constants where the two layers semantically overlap.
+#
+# Coverage time: ~50 min. Reviewer: Yerzhan (operator). Method: grep
+# audit of UPPER_CASE constants + day-window literals + timeout values
+# across both codebases, cross-walked into the table above.

--- a/tools/snapshot-section-11.README.md
+++ b/tools/snapshot-section-11.README.md
@@ -33,12 +33,16 @@ imports. No network calls are made.
 ```
 packages/core/tests/fixtures/snapshots/
 ├── manifest.json
-└── realistic-athlete/
-    ├── acwr.json
-    ├── monotony.json
-    ├── strain.json
-    ├── ... (52 per-metric files)
-    └── zone_distribution_7d.json
+├── realistic-athlete/
+│   ├── acwr.json
+│   ├── monotony.json
+│   ├── strain.json
+│   ├── ... (52 per-metric files)
+│   └── zone_distribution_7d.json
+├── new-athlete-empty/
+│   └── ... (52 per-metric files, most `value: null` because no activities/wellness)
+└── data-gap-mid-history/
+    └── ... (52 per-metric files; ACWR is non-null because the resumed week populates the acute window)
 ```
 
 Each per-metric file:
@@ -67,13 +71,18 @@ The manifest pins the oracle:
   "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
   "section_11_protocol_version": "3.112",
   "section_11_commit_date": "2026-04-28T18:14:07+00:00",
-  "fixtures": ["realistic-athlete"],
-  "metrics": [ ... 52 names ... ],
+  "fixtures": ["data-gap-mid-history", "new-athlete-empty", "realistic-athlete"],
+  "metrics": [ ... 52 names — union across all fixtures ... ],
   "pyodide_version": "0.29.4",
   "frozen_now": "2026-05-10T12:00:00",
   "offline_mode": "A_stub_requests_plus_monkey_patch"
 }
 ```
+
+The `frozen_now` field carries the harness's default anchor. Per-fixture
+overrides (e.g., `data-gap-mid-history` uses `2026-05-20T12:00:00` to
+catch its resumed week in the acute window) are recorded in each
+per-snapshot wrapper's `frozen_now` field, not in the manifest top-level.
 
 `section_11_commit_date` is derived deterministically from the
 section-11 SHA's commit object (`git show -s --format=%cI`). It
@@ -91,11 +100,16 @@ of these change:
    value diffs alongside it before committing — those diffs ARE the
    upstream-change signal.
 2. **New golden fixture** is added under `packages/core/tests/fixtures/golden/`.
-   Extend the harness's fixture list (currently a single hardcoded
-   slug) to capture against the new athlete.
-3. **`FROZEN_NOW` is moved.** The clock anchor is currently a
-   script-level constant; bumping it shifts every rolling-window
-   metric. Coordinate with the PR description.
+   Add an entry to the `HARNESS_FIXTURES` allowlist in
+   `tools/snapshot-section-11.ts` (slug + frozenNow + description) and
+   re-run. Fixtures owned by other test suites (e.g., F7 reference
+   substrate's `post-break-resume` and `zero-activities`) live in the
+   same dir but are intentionally excluded from the harness — they
+   don't conform to sync.py's input contract.
+3. **A fixture's `frozenNow` anchor is moved.** Anchors live on each
+   `HARNESS_FIXTURES` entry (with `DEFAULT_FROZEN_NOW` as the fallback);
+   bumping one shifts every rolling-window metric for that fixture.
+   Coordinate with the PR description.
 4. **pyodide version bump.** Verify the manifest's `pyodide_version`
    reflects the new install, then re-run.
 
@@ -341,22 +355,27 @@ currently provision.
 
 ## Frozen clock
 
-`FROZEN_NOW = "2026-05-10T12:00:00"` is hardcoded in the harness.
-Rationale: the realistic-athlete fixture's last activity is 2026-05-09;
-anchoring "now" to one day later puts the activity within the 7-day
-ACWR window and gives every rolling metric non-trivial input. If the
-fixture is re-sanitized with a different date range, move this
-constant in lockstep.
+The harness exports a `DEFAULT_FROZEN_NOW = "2026-05-10T12:00:00"` anchor
+and the `HARNESS_FIXTURES` allowlist binds a `frozenNow` to each fixture.
+Most fixtures use the default; `data-gap-mid-history` overrides to
+`2026-05-20T12:00:00` so its resumed week lands inside the 7d acute
+window. Per-snapshot wrappers record the exact anchor each metric was
+captured against (`frozen_now` field); the manifest top-level reports
+the default. If a fixture's date range shifts, move its allowlist entry
+in lockstep.
 
 ## Adding a new athlete
 
-Today the harness has a single hardcoded slug (`realistic-athlete`).
-To capture a second fixture (e.g., `post-break-resume`, `zero-activities`):
+The harness iterates over the `HARNESS_FIXTURES` allowlist in
+`tools/snapshot-section-11.ts`. To add a fixture:
 
-1. Add the slug to a `FIXTURES` array in `tools/snapshot-section-11.ts`
-   (replace the hardcoded `ATHLETE_SLUG`/`FIXTURE_REL` constants).
-2. Re-run `pnpm snapshot:section-11`. The script will create one
-   subdirectory per slug and one combined `manifest.json`.
+1. Hand-craft `packages/core/tests/fixtures/golden/<slug>.json` with the
+   intervals.icu envelope shape.
+2. Append an entry to `HARNESS_FIXTURES` — `slug`, `frozenNow`, and a
+   `description` explaining the branches the fixture exercises and the
+   reason for its anchor.
+3. Re-run `pnpm snapshot:section-11`. The script creates one subdirectory
+   per slug and rewrites `manifest.json`.
 
 The 3-golden cap from `packages/core/tests/fixtures/README.md` applies
 — don't sprawl. Synthetic regression fixtures get their own targeted

--- a/tools/snapshot-section-11.ts
+++ b/tools/snapshot-section-11.ts
@@ -15,8 +15,14 @@
  */
 
 import { execSync } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { basename, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { loadPyodide } from "pyodide";
@@ -31,18 +37,47 @@ const SECTION_11_REPO =
   process.env.SECTION_11_REPO ?? resolve(REPO_ROOT, "../section-11");
 const SYNC_PY_PATH = join(SECTION_11_REPO, "examples/sync.py");
 
-const DEFAULT_FIXTURE_REL = "packages/core/tests/fixtures/golden/realistic-athlete.json";
-const ATHLETE_SLUG = "realistic-athlete";
+const GOLDEN_DIR_REL = "packages/core/tests/fixtures/golden";
 const SNAPSHOT_ROOT_REL = "packages/core/tests/fixtures/snapshots";
 
-// Anchor "now" inside the fixture's data window so date-relative
-// filters in sync.py return non-empty slices. The realistic-athlete
-// fixture's last activity is 2026-05-09; pinning to 2026-05-10
-// gives ACWR a populated 7d window and keeps the 28d window
-// representative. Future fixtures may store this alongside the
-// data; for now it's a script-level constant documented in the
-// README.
-const FROZEN_NOW = "2026-05-10T12:00:00";
+// Default anchor used when SNAPSHOT_FIXTURE_PATH points at a fixture not
+// in the allowlist (determinism/contract tests). The manifest's
+// `frozen_now` field also takes this value as the default; per-fixture
+// overrides ride through each per-snapshot wrapper's `frozen_now` field.
+const DEFAULT_FROZEN_NOW = "2026-05-10T12:00:00";
+
+// Allowlist of golden fixtures the snapshot harness processes. Adding a
+// fixture is an explicit edit here — the golden dir also holds fixtures
+// owned by other tests (F7 reference substrate's `post-break-resume`,
+// `zero-activities`) that don't conform to sync.py's contract and must
+// not be run through this harness. Each entry's `description` field
+// carries the rationale for the slug + the anchor it chose.
+interface HarnessFixtureConfig {
+  slug: string;
+  frozenNow: string;
+  description: string;
+}
+
+const HARNESS_FIXTURES: HarnessFixtureConfig[] = [
+  {
+    slug: "realistic-athlete",
+    frozenNow: DEFAULT_FROZEN_NOW,
+    description:
+      "Happy-path baseline — sanitized real athlete bundle. Exercises the populated branches of every metric. Anchor 2026-05-10 sits one day after the fixture's last activity.",
+  },
+  {
+    slug: "new-athlete-empty",
+    frozenNow: DEFAULT_FROZEN_NOW,
+    description:
+      "Zero activities, zero wellness, zero ftp_history. Forces every 'no data' branch — ACWR div-by-zero, monotony of empty week, recovery_index no-contributors. Anchor doesn't matter; reuses the default.",
+  },
+  {
+    slug: "data-gap-mid-history",
+    frozenNow: "2026-05-20T12:00:00",
+    description:
+      "21 activities split by a 28-day gap (14 days 2026-04-01..04-14, gap 04-15..05-12, 7 days resumed 05-13..05-19). Exercises EWMA decay through the gap, ACWR chronic window seeing zeros, monotony on the resumed week. Anchor 2026-05-20 catches the resumed week in the 7d acute window.",
+  },
+];
 
 function readPyodideVersion(): string {
   const pkg = JSON.parse(
@@ -80,6 +115,25 @@ function readSyncPyVersion(syncPySource: string): string {
 
 function ensureDir(path: string): void {
   mkdirSync(path, { recursive: true });
+}
+
+interface FixtureEntry {
+  slug: string;
+  path: string;
+  frozenNow: string;
+}
+
+function resolveAllowlistedFixtures(goldenDir: string): FixtureEntry[] {
+  return HARNESS_FIXTURES.map(({ slug, frozenNow }) => {
+    const path = join(goldenDir, `${slug}.json`);
+    if (!existsSync(path)) {
+      throw new Error(
+        `Allowlisted harness fixture not found: ${path}. ` +
+          `Either create it or remove the entry from HARNESS_FIXTURES in tools/snapshot-section-11.ts.`,
+      );
+    }
+    return { slug, path, frozenNow };
+  });
 }
 
 const HARNESS_PROLOGUE = `
@@ -317,23 +371,103 @@ if "__error__" not in derived:
 OUTPUT_JSON = json.dumps(derived, default=str, sort_keys=True)
 `;
 
+async function processFixture(
+  pyodide: Awaited<ReturnType<typeof loadPyodide>>,
+  fixture: FixtureEntry,
+  snapshotRoot: string,
+  sha: string,
+  protocolVersion: string,
+): Promise<{ metrics: string[]; frozenNow: string }> {
+  const fixtureJson = readFileSync(fixture.path, "utf8");
+
+  pyodide.globals.set("FROZEN_NOW", fixture.frozenNow);
+  pyodide.globals.set("FIXTURE_JSON", fixtureJson);
+
+  await pyodide.runPythonAsync(HARNESS_PROLOGUE);
+  const outputJson = pyodide.globals.get("OUTPUT_JSON") as string;
+  const derived = JSON.parse(outputJson) as Record<string, unknown>;
+
+  if ("__error__" in derived) {
+    const err = derived.__error__ as {
+      type: string;
+      message: string;
+      traceback: string;
+    };
+    throw new Error(
+      `section-11 metric computation raised ${err.type} for fixture '${fixture.slug}': ${err.message}\n${err.traceback}`,
+    );
+  }
+
+  if ("__contract_violation__" in derived) {
+    const violation = derived.__contract_violation__ as {
+      missing_keys: string[];
+      total_accesses: number;
+      message: string;
+    };
+    const lines = violation.missing_keys.map((k) => `  - ${k}`).join("\n");
+    throw new Error(
+      `fixture/sync.py contract violation for '${fixture.slug}': ${violation.missing_keys.length} ` +
+        `unique missing key(s) read silently as None ` +
+        `(${violation.total_accesses} total .get() accesses):\n${lines}\n\n` +
+        violation.message,
+    );
+  }
+
+  const snapshotDir = join(snapshotRoot, fixture.slug);
+  ensureDir(snapshotDir);
+
+  const metrics: string[] = [];
+  for (const [name, value] of Object.entries(derived)) {
+    const filePath = join(snapshotDir, `${name}.json`);
+    const wrapper = {
+      metric: name,
+      athlete: fixture.slug,
+      section_11_sha: sha,
+      section_11_protocol_version: protocolVersion,
+      frozen_now: fixture.frozenNow,
+      value,
+    } satisfies Snapshot;
+    writeFileSync(filePath, `${JSON.stringify(wrapper, null, 2)}\n`);
+    metrics.push(name);
+  }
+  metrics.sort();
+  return { metrics, frozenNow: fixture.frozenNow };
+}
+
 async function main(): Promise<void> {
-  // `SNAPSHOT_FIXTURE_PATH` overrides the input fixture path —
-  // used by the contract-validation test to point at deliberately
-  // corrupted fixtures without disturbing the committed golden one.
-  // Defaults to the canonical realistic-athlete fixture.
-  const fixturePath = process.env.SNAPSHOT_FIXTURE_PATH
-    ? resolve(process.env.SNAPSHOT_FIXTURE_PATH)
-    : resolve(REPO_ROOT, DEFAULT_FIXTURE_REL);
+  // `SNAPSHOT_FIXTURE_PATH` overrides the input — used by the
+  // contract-validation/determinism tests to point at a single
+  // deliberately corrupted or temp fixture without touching the
+  // committed golden set. When unset, every `.json` under
+  // `packages/core/tests/fixtures/golden/` is processed.
   // `SNAPSHOT_OUT_DIR` overrides the snapshot output root — used by the
   // determinism test to write to temp dirs instead of clobbering the
   // committed snapshots. Defaults to the canonical SNAPSHOT_ROOT_REL.
   const snapshotRoot = process.env.SNAPSHOT_OUT_DIR
     ? resolve(process.env.SNAPSHOT_OUT_DIR)
     : resolve(REPO_ROOT, SNAPSHOT_ROOT_REL);
-  const snapshotDirRel = join(SNAPSHOT_ROOT_REL, ATHLETE_SLUG);
-  const snapshotDir = join(snapshotRoot, ATHLETE_SLUG);
+  const goldenDir = resolve(REPO_ROOT, GOLDEN_DIR_REL);
   const manifestPath = join(snapshotRoot, "manifest.json");
+
+  let fixtures: FixtureEntry[];
+  if (process.env.SNAPSHOT_FIXTURE_PATH) {
+    const path = resolve(process.env.SNAPSHOT_FIXTURE_PATH);
+    if (!existsSync(path)) {
+      throw new Error(`Fixture not found: ${path}`);
+    }
+    fixtures = [
+      {
+        slug: basename(path).replace(/\.json$/, ""),
+        path,
+        frozenNow: DEFAULT_FROZEN_NOW,
+      },
+    ];
+  } else {
+    if (!existsSync(goldenDir)) {
+      throw new Error(`Golden fixtures dir not found: ${goldenDir}`);
+    }
+    fixtures = resolveAllowlistedFixtures(goldenDir);
+  }
 
   if (!existsSync(SYNC_PY_PATH)) {
     throw new Error(
@@ -342,12 +476,8 @@ async function main(): Promise<void> {
         `or clone CrankAddict/section-11 to ../section-11.`,
     );
   }
-  if (!existsSync(fixturePath)) {
-    throw new Error(`Fixture not found: ${fixturePath}`);
-  }
 
   const syncPySource = readFileSync(SYNC_PY_PATH, "utf8");
-  const fixtureJson = readFileSync(fixturePath, "utf8");
   const sha = readSection11Sha();
   const commitDate = readSection11CommitDate(sha);
   const protocolVersion = readSyncPyVersion(syncPySource);
@@ -365,70 +495,45 @@ async function main(): Promise<void> {
     },
   });
 
-  pyodide.globals.set("FROZEN_NOW", FROZEN_NOW);
   pyodide.globals.set("SYNC_PY_PATH", SYNC_PY_PATH);
   pyodide.globals.set("SYNC_PY_SOURCE", syncPySource);
-  pyodide.globals.set("FIXTURE_JSON", fixtureJson);
 
-  await pyodide.runPythonAsync(HARNESS_PROLOGUE);
-  const outputJson = pyodide.globals.get("OUTPUT_JSON") as string;
-  const derived = JSON.parse(outputJson) as Record<string, unknown>;
-
-  if ("__error__" in derived) {
-    const err = derived.__error__ as { type: string; message: string; traceback: string };
-    throw new Error(
-      `section-11 metric computation raised ${err.type}: ${err.message}\n${err.traceback}`,
+  const results: { slug: string; metrics: string[] }[] = [];
+  for (const fixture of fixtures) {
+    const { metrics } = await processFixture(
+      pyodide,
+      fixture,
+      snapshotRoot,
+      sha,
+      protocolVersion,
     );
+    results.push({ slug: fixture.slug, metrics });
   }
 
-  if ("__contract_violation__" in derived) {
-    const violation = derived.__contract_violation__ as {
-      missing_keys: string[];
-      total_accesses: number;
-      message: string;
-    };
-    const lines = violation.missing_keys.map((k) => `  - ${k}`).join("\n");
-    throw new Error(
-      `fixture/sync.py contract violation: ${violation.missing_keys.length} ` +
-        `unique missing key(s) read silently as None ` +
-        `(${violation.total_accesses} total .get() accesses):\n${lines}\n\n` +
-        violation.message,
-    );
-  }
-
-  ensureDir(snapshotDir);
-
-  const metrics: string[] = [];
-  for (const [name, value] of Object.entries(derived)) {
-    const filePath = join(snapshotDir, `${name}.json`);
-    const wrapper = {
-      metric: name,
-      athlete: ATHLETE_SLUG,
-      section_11_sha: sha,
-      section_11_protocol_version: protocolVersion,
-      frozen_now: FROZEN_NOW,
-      value,
-    } satisfies Snapshot;
-    writeFileSync(filePath, `${JSON.stringify(wrapper, null, 2)}\n`);
-    metrics.push(name);
-  }
-  metrics.sort();
+  const fixtureSlugs = results.map((r) => r.slug).sort();
+  const allMetrics = [...new Set(results.flatMap((r) => r.metrics))].sort();
 
   const manifest: Manifest = {
     section_11_sha: sha,
     section_11_protocol_version: protocolVersion,
     section_11_commit_date: commitDate,
-    fixtures: [ATHLETE_SLUG],
-    metrics,
+    fixtures: fixtureSlugs,
+    metrics: allMetrics,
     pyodide_version: pyodideVersion,
-    frozen_now: FROZEN_NOW,
+    frozen_now: DEFAULT_FROZEN_NOW,
     offline_mode: "A_stub_requests_plus_monkey_patch",
   };
   writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
 
+  for (const { slug, metrics } of results) {
+    // eslint-disable-next-line no-console
+    console.log(
+      `[snapshot] wrote ${metrics.length} per-metric files under ${join(SNAPSHOT_ROOT_REL, slug)}/`,
+    );
+  }
   // eslint-disable-next-line no-console
   console.log(
-    `[snapshot] wrote ${metrics.length} per-metric files under ${snapshotDirRel}/ + manifest`,
+    `[snapshot] manifest pins ${fixtureSlugs.length} fixture(s) + ${allMetrics.length} metric(s)`,
   );
 }
 


### PR DESCRIPTION
## Summary

First real metric port lands: **ACWR** mirrors `sync.py:3023-3028` line-by-line and asserts bit-identical parity (`0.81 / null / 3.51`) across three fixtures. The supporting infrastructure — edge-case fixtures, harness allowlist, registry relocation — lands in the same PR because each piece is too small to PR independently and they fit together as one convergence step.

PR includes 4 commits:

- `feat(core)` ACWR port + snapshot harness allowlist (the new work)
- `chore(tools)` document pre-F8 deviation audit coverage (T02)
- `chore(tools)` code-review cleanup on pre-port audit footer
- `chore(tools)` architect-review tightenings on baseline-audit footer

## What changed

### ACWR port (T12)

- `packages/core/src/reference/metrics/load-management.ts` — `computeAcwr` returns the raw upstream shape (`number | null`). Mirrors `sync.py:3023-3028` plus `sync.py:3629-3644` (the daily-load aggregator) line-by-line. JSDoc cites Gabbett 2016 (DOI 10.1136/bjsports-2015-095788). Helpers: `getDailyLoad`, `isoDateDaysBefore`, `roundHalfEven` (banker's rounding to match Python's `round()`).
- Per the ADR-0014 scope clarification (local doc; see commit message), raw `compute*` functions are gate-asserted; the discriminated-union envelope is built by a sibling wrapper at the curator boundary. No envelope ships in this PR.

### Edge-case fixtures (T11)

- `packages/core/tests/fixtures/golden/new-athlete-empty.json` — zero activities/wellness/ftp_history. Forces every no-data branch.
- `packages/core/tests/fixtures/golden/data-gap-mid-history.json` — 21 activities split by a 28-day gap (14 pre-gap → gap → 7 resumed). The resumed week populates the acute window against a depleted chronic baseline, so ACWR resolves to `3.51`.

### Harness allowlist

- `tools/snapshot-section-11.ts` extended to iterate over a `HARNESS_FIXTURES` allowlist (slug + per-fixture frozen_now + description). F7-substrate fixtures (`post-break-resume`, `zero-activities`) live in the same golden dir but are intentionally excluded — they don't conform to sync.py's input contract.
- Per-fixture `frozen_now` rides through each snapshot wrapper; the manifest's top-level field is the default.

### Architecture follow-ups (from in-PR review)

- `METRIC_REGISTRY` moved from `tools/check-metric-parity.ts` into `packages/core/src/reference/metrics/registry.ts`. The registry statically imports each compute function — no dynamic `import()` resolution.
- `MetricInput` type lives at `packages/core/src/reference/metrics/metric-input.ts`. The metric layer owns its parameter contract; the gate consumes it from the package (correct dependency direction).
- Gate's `runParityCheck` simplifies to `entry.compute({fixture, frozenNow})` — no path resolution, no `exportName` lookup, no "not a function" runtime check.

### Pre-F8 deviation audit (T02)

The three `chore(tools)` commits add a baseline-audit footer to `tools/intentional-deviations.yaml` documenting the mechanical sweep over Reference-layer non-metric code (sync infrastructure, schemas, concurrency, I/O primitives) against `sync.py`. Verdict: 0 undiscovered deviations in the shipped non-metric Reference code. The drift surface is metric math (audited per-metric on port).

## Test plan

- [x] `pnpm check-parity --metric=acwr --fixture=all` exits 0 bit-identical across all 3 fixtures (`0.81 / null / 3.51`)
- [x] `pnpm --filter @enduragent/core test` — 665 passed / 2 skipped
- [x] `pnpm check:trademarks` clean (57 files)
- [x] `pnpm snapshot:section-11` re-runs deterministically (same snapshot bytes as committed)
- [x] Snapshot determinism + contract tests still pass with the new allowlist
- [x] No deviation registered for ACWR (faithful transliteration)