### PR TITLE
feat(core): port monotony + primary_sport_monotony from the Reference layer's upstream (F8.2 / F8.2a)

### DIFF
--- a/packages/core/src/reference/metrics/load-management.ts
+++ b/packages/core/src/reference/metrics/load-management.ts
@@ -99,6 +99,97 @@ export function computeMonotony(input: MetricInput): number | null {
   return roundHalfEven(meanLoad / stdevLoad, 2);
 }
 
+/**
+ * Primary-sport monotony — Foster monotony restricted to the trailing
+ * 7-day series for the highest-Load sport family.
+ *
+ * Multi-sport athletes get inflated total monotony when cross-training
+ * adds a consistent Load floor across days. Restricting the series to
+ * one modality isolates the actual load variation. Primary-sport
+ * selection ties break on insertion order (first sport encountered in
+ * the fixture wins) — see `getDailyLoadBySport` for why.
+ *
+ * Returns `null` when:
+ *   - no activity with Load > 0 falls in the window (the per-sport map
+ *     is empty),
+ *   - the primary sport has fewer than 3 active days (Foster's signal
+ *     needs at least 3 non-zero observations to be meaningful),
+ *   - the primary sport's daily series has length ≤ 1 (cannot happen
+ *     for the fixed 7-day window, but the Python guards it),
+ *   - the sample standard deviation of the primary sport's daily series
+ *     is 0 (constant non-zero series).
+ *
+ * Otherwise returns `round(mean / stdev, 2)` with half-to-even rounding
+ * to mirror Python's `round()` bit-identically.
+ *
+ * Upstream source mirrored line-by-line: `sync.py:3044-3076`
+ * (`_calculate_derived_metrics`) plus the per-sport aggregation helper
+ * at `sync.py:3646-3675` (`_get_daily_tss_by_sport`) and the sport-family
+ * lookup at `sync.py:290-308` (`SPORT_FAMILIES`). The 7-day window
+ * pre-filter mirrors the call-site filter at `sync.py:2337-2338`. See
+ * `NOTICE.md` for upstream attribution.
+ *
+ * Return shape is the raw upstream output (number or null), not a
+ * discriminated-union envelope. Raw compute functions feed the parity
+ * gate; a sibling envelope wrapper will feed the curator when the
+ * curator integration lands.
+ *
+ * @see Foster, C. (1998). Monitoring training in athletes with reference
+ *      to overtraining syndrome. Med Sci Sports Exerc 30(7):1164-1168.
+ *      DOI: 10.1097/00005768-199807000-00023
+ */
+export function computePrimarySportMonotony(input: MetricInput): number | null {
+  const fixture = input.fixture as { activities?: Activity[] };
+  const activities = fixture.activities ?? [];
+
+  const dailyLoadBySport = getDailyLoadBySport(activities, 7, input.frozenNow);
+  if (dailyLoadBySport.size === 0) return null;
+
+  let primaryDays: number[] | undefined;
+  let maxTotal = -Infinity;
+  for (const days of dailyLoadBySport.values()) {
+    let total = 0;
+    for (const d of days) total += d;
+    if (total > maxTotal) {
+      maxTotal = total;
+      primaryDays = days;
+    }
+  }
+  if (primaryDays === undefined) return null;
+
+  let activeDays = 0;
+  for (const d of primaryDays) if (d > 0) activeDays += 1;
+  if (activeDays < 3 || primaryDays.length <= 1) return null;
+
+  const meanLoad = arithmeticMean(primaryDays);
+  const stdevLoad = sampleStdev(primaryDays, meanLoad);
+  if (stdevLoad <= 0) return null;
+
+  return roundHalfEven(meanLoad / stdevLoad, 2);
+}
+
+// Mirrors `SPORT_FAMILIES` at sync.py:290-308. Unmapped types fall
+// through to "other" at the lookup site.
+const SPORT_FAMILIES: Record<string, string> = {
+  Ride: "cycling",
+  VirtualRide: "cycling",
+  MountainBikeRide: "cycling",
+  GravelRide: "cycling",
+  EBikeRide: "cycling",
+  VirtualSki: "ski",
+  NordicSki: "ski",
+  Walk: "walk",
+  Hike: "walk",
+  Run: "run",
+  VirtualRun: "run",
+  TrailRun: "run",
+  Swim: "swim",
+  Rowing: "rowing",
+  WeightTraining: "strength",
+  Yoga: "other",
+  Workout: "other",
+};
+
 function arithmeticMean(values: number[]): number {
   let total = 0;
   for (const v of values) total += v;
@@ -138,6 +229,48 @@ function getDailyLoad(
   for (let i = days - 1; i >= 0; i--) {
     const date = isoDateDaysBefore(frozenNow, i);
     result.push(dailyLoad.get(date) ?? 0);
+  }
+  return result;
+}
+
+// Map insertion order matches the order each sport family is first
+// encountered while iterating `activities`. Python `defaultdict` exhibits
+// the same property, and `max(dict, key=dict.get)` returns the first key
+// with the maximum value when scanning insertion order — so preserving
+// this order is what keeps primary-sport tiebreaks bit-identical.
+function getDailyLoadBySport(
+  activities: Activity[],
+  days: number,
+  frozenNow: string,
+): Map<string, number[]> {
+  const windowDates = new Set<string>();
+  for (let i = days - 1; i >= 0; i--) {
+    windowDates.add(isoDateDaysBefore(frozenNow, i));
+  }
+
+  const bySport = new Map<string, Map<string, number>>();
+  for (const act of activities) {
+    const load = act.icu_training_load || 0;
+    if (load <= 0) continue;
+    const dateStr = act.start_date_local.slice(0, 10);
+    if (!windowDates.has(dateStr)) continue;
+    const sportFamily = SPORT_FAMILIES[act.type] ?? "other";
+    let dailyMap = bySport.get(sportFamily);
+    if (dailyMap === undefined) {
+      dailyMap = new Map<string, number>();
+      bySport.set(sportFamily, dailyMap);
+    }
+    dailyMap.set(dateStr, (dailyMap.get(dateStr) ?? 0) + load);
+  }
+
+  const result = new Map<string, number[]>();
+  for (const [sport, dailyMap] of bySport) {
+    const dailyArray: number[] = [];
+    for (let i = days - 1; i >= 0; i--) {
+      const date = isoDateDaysBefore(frozenNow, i);
+      dailyArray.push(dailyMap.get(date) ?? 0);
+    }
+    result.set(sport, dailyArray);
   }
   return result;
 }

--- a/packages/core/src/reference/metrics/load-management.ts
+++ b/packages/core/src/reference/metrics/load-management.ts
@@ -26,10 +26,10 @@ import type { MetricInput } from "./metric-input.js";
  * `sync.py:3629-3644` (the daily-load aggregator). See `NOTICE.md` for
  * upstream attribution.
  *
- * Return shape is the raw upstream output (number or null), not the
- * discriminated-union envelope from ADR-0014; per the 2026-05-21 ADR-0014
- * scope clarification, raw compute functions feed the parity gate and a
- * sibling envelope wrapper feeds the curator.
+ * Return shape is the raw upstream output (number or null), not a
+ * discriminated-union envelope. Raw compute functions feed the parity
+ * gate; a sibling envelope wrapper will feed the curator when the
+ * curator integration lands.
  *
  * @see Gabbett, T.J. (2016). The training-injury prevention paradox:
  *      should athletes be training smarter and harder?
@@ -50,6 +50,77 @@ export function computeAcwr(input: MetricInput): number | null {
 
   if (chronicLoad <= 0) return null;
   return roundHalfEven(acuteLoad / chronicLoad, 2);
+}
+
+/**
+ * Training monotony (Foster 1998).
+ *
+ * Monotony = mean(dailyLoad) / sampleStdev(dailyLoad) over the trailing
+ * 7 days (today and the six prior). The aggregator is the same one
+ * ACWR uses — calendar-window length, days with no activity contribute 0.
+ *
+ * Returns `null` when:
+ *   - fewer than 2 daily values are available (cannot happen for the
+ *     fixed 7-day window, but the Python guards it),
+ *   - every day's Load is 0 (rest week / empty fixture),
+ *   - the sample standard deviation is 0 (constant non-zero series).
+ *
+ * Otherwise returns `round(mean / stdev, 2)` with half-to-even rounding
+ * to mirror Python's `round()` bit-identically.
+ *
+ * Upstream source mirrored line-by-line: `sync.py:3030-3041`
+ * (`_calculate_derived_metrics`). The daily aggregator at
+ * `sync.py:3629-3644` is shared with ACWR. See `NOTICE.md` for upstream
+ * attribution.
+ *
+ * Return shape is the raw upstream output (number or null), not a
+ * discriminated-union envelope. Raw compute functions feed the parity
+ * gate; a sibling envelope wrapper will feed the curator when the
+ * curator integration lands.
+ *
+ * @see Foster, C. (1998). Monitoring training in athletes with reference
+ *      to overtraining syndrome. Med Sci Sports Exerc 30(7):1164-1168.
+ *      DOI: 10.1097/00005768-199807000-00023
+ */
+export function computeMonotony(input: MetricInput): number | null {
+  const fixture = input.fixture as { activities?: Activity[] };
+  const activities = fixture.activities ?? [];
+
+  const dailyLoad7d = getDailyLoad(activities, 7, input.frozenNow);
+
+  if (dailyLoad7d.length <= 1 || !dailyLoad7d.some((d) => d !== 0)) {
+    return null;
+  }
+
+  const meanLoad = arithmeticMean(dailyLoad7d);
+  const stdevLoad = sampleStdev(dailyLoad7d, meanLoad);
+  if (stdevLoad <= 0) return null;
+
+  return roundHalfEven(meanLoad / stdevLoad, 2);
+}
+
+function arithmeticMean(values: number[]): number {
+  let total = 0;
+  for (const v of values) total += v;
+  return total / values.length;
+}
+
+// Python `statistics.stdev` uses the numerically stable two-pass
+// `sum((x-c)**2) - sum(x-c)**2 / n` correction so the residual mean
+// drift cancels out. Mirror the same accumulation order so the float
+// result matches bit-for-bit on inputs that aren't exactly centered on
+// the recomputed mean.
+function sampleStdev(values: number[], xbar: number): number {
+  const n = values.length;
+  let total = 0;
+  let total2 = 0;
+  for (const x of values) {
+    const d = x - xbar;
+    total += d * d;
+    total2 += d;
+  }
+  const ss = total - (total2 * total2) / n;
+  return Math.sqrt(ss / (n - 1));
 }
 
 function getDailyLoad(

--- a/packages/core/src/reference/metrics/registry.ts
+++ b/packages/core/src/reference/metrics/registry.ts
@@ -9,7 +9,11 @@
  */
 
 import type { MetricInput } from "./metric-input.js";
-import { computeAcwr, computeMonotony } from "./load-management.js";
+import {
+  computeAcwr,
+  computeMonotony,
+  computePrimarySportMonotony,
+} from "./load-management.js";
 
 export interface MetricRegistryEntry {
   compute: (input: MetricInput) => unknown;
@@ -18,4 +22,5 @@ export interface MetricRegistryEntry {
 export const METRIC_REGISTRY: Record<string, MetricRegistryEntry> = {
   acwr: { compute: computeAcwr },
   monotony: { compute: computeMonotony },
+  primary_sport_monotony: { compute: computePrimarySportMonotony },
 };

--- a/packages/core/src/reference/metrics/registry.ts
+++ b/packages/core/src/reference/metrics/registry.ts
@@ -9,7 +9,7 @@
  */
 
 import type { MetricInput } from "./metric-input.js";
-import { computeAcwr } from "./load-management.js";
+import { computeAcwr, computeMonotony } from "./load-management.js";
 
 export interface MetricRegistryEntry {
   compute: (input: MetricInput) => unknown;
@@ -17,4 +17,5 @@ export interface MetricRegistryEntry {
 
 export const METRIC_REGISTRY: Record<string, MetricRegistryEntry> = {
   acwr: { compute: computeAcwr },
+  monotony: { compute: computeMonotony },
 };


### PR DESCRIPTION
## Summary

Ports two Foster monotony metrics from the Reference layer's upstream into `packages/core/src/reference/metrics/load-management.ts`. Both follow the porting discipline (line-by-line mirror; no deviations; parity gate is the only enforcement surface).

### `monotony` (F8.2)

Foster 1998 monotony: `mean(dailyLoad_7d) / sampleStdev(dailyLoad_7d)`. Returns null when n < 2, the series is all zero, or the sample stdev is zero. TS uses the stable two-pass stdev formula (`sum((x-c)^2) - sum(x-c)^2/n`) for bit-identical float match with Python's `statistics.stdev`. Mirrors the upstream Python line-by-line.

### `primary_sport_monotony` (F8.2a)

Foster monotony restricted to the trailing 7-day series for the highest-Load sport family. Multi-sport athletes get inflated total monotony when cross-training adds a consistent Load floor across days; restricting to one modality isolates the actual load variation.

Mirrors the upstream Python line-by-line:

- `sync.py:3044-3076` (`_calculate_derived_metrics`) — primary-sport selection (max total Load over the window) + Foster mean/stdev
- `sync.py:3646-3675` (`_get_daily_tss_by_sport`) — per-sport daily Load aggregation; preserves `defaultdict` insertion order so the primary-sport tiebreak matches Python's `max()` scan
- `sync.py:290-308` — `SPORT_FAMILIES` lookup table; unmapped types fall through to `"other"`
- `sync.py:2337-2338` — 7-day window pre-filter at the call site

Returns null when the per-sport map is empty, the primary sport has fewer than 3 active days, the series has length ≤ 1, or the sample stdev is 0.

Both metrics: `round(mean / stdev, 2)` with half-to-even rounding to mirror Python's `round()` bit-identically. Returned as raw upstream output (number or null), not a discriminated-union envelope — that wrapper lands when the curator integration arrives.

## Methodology

Line-by-line port. No optimizations that touch float-accumulation order, branch ordering, or rounding. No deviations; `tools/intentional-deviations.yaml` unchanged. Citation: Foster, C. (1998). Monitoring training in athletes with reference to overtraining syndrome. *Med Sci Sports Exerc* 30(7):1164-1168. DOI: 10.1097/00005768-199807000-00023.

## Test plan

- [x] `pnpm check-parity --metric=monotony --fixture=all` exits 0 bit-identical across all 3 fixtures
- [x] `pnpm check-parity --metric=primary_sport_monotony --fixture=all` exits 0 bit-identical across all 3 fixtures
  - realistic-athlete: 0.78
  - data-gap-mid-history: 2.08
  - new-athlete-empty: null
- [x] Vitest suite — port itself adds no new tests; parity gate is the spec