### PR TITLE
chore(core,tools): post-F8.2a hygiene follow-ups from /architect triage

### DIFF
--- a/packages/core/src/reference/metrics/load-management.ts
+++ b/packages/core/src/reference/metrics/load-management.ts
@@ -196,11 +196,15 @@ function arithmeticMean(values: number[]): number {
   return total / values.length;
 }
 
-// Python `statistics.stdev` uses the numerically stable two-pass
-// `sum((x-c)**2) - sum(x-c)**2 / n` correction so the residual mean
-// drift cancels out. Mirror the same accumulation order so the float
-// result matches bit-for-bit on inputs that aren't exactly centered on
-// the recomputed mean.
+// Python's `statistics.stdev` uses Fraction-exact internal arithmetic
+// (`statistics._sum`); the TS port cannot reproduce that in pure float.
+// This two-pass Neumaier-style correction
+// (`sum((x-c)^2) - sum(x-c)^2/n`) is the closest float-only
+// approximation. Bit-identity to Python holds empirically on captured
+// fixtures because the final `roundHalfEven(_, 2)` masks sub-0.005
+// drift. A future fixture whose unrounded mean/stdev lands near a
+// rounding boundary may surface as a gate failure — treat as a real
+// divergence to triage, not as proof of algorithm equivalence.
 function sampleStdev(values: number[], xbar: number): number {
   const n = values.length;
   let total = 0;
@@ -254,7 +258,13 @@ function getDailyLoadBySport(
     if (load <= 0) continue;
     const dateStr = act.start_date_local.slice(0, 10);
     if (!windowDates.has(dateStr)) continue;
-    const sportFamily = SPORT_FAMILIES[act.type] ?? "other";
+    // Object.hasOwn guards against prototype-chain lookups: a fixture
+    // with act.type === "toString" / "constructor" / "__proto__" would
+    // otherwise resolve to an inherited Function reference (truthy, so
+    // `?? "other"` does not fire) and pollute the bySport key set.
+    const sportFamily = Object.hasOwn(SPORT_FAMILIES, act.type)
+      ? SPORT_FAMILIES[act.type]
+      : "other";
     let dailyMap = bySport.get(sportFamily);
     if (dailyMap === undefined) {
       dailyMap = new Map<string, number>();

--- a/tools/check-metric-parity.ts
+++ b/tools/check-metric-parity.ts
@@ -277,6 +277,33 @@ export function listFixtures(): string[] {
     .sort();
 }
 
+// Returns the set of metric names that have at least one snapshot file
+// on disk across any fixture directory. Used by `--all` to surface
+// metrics that have an oracle snapshot but no TS implementation in the
+// registry — without it, those snapshots silently sit unverified and
+// `--all` reports an all-green signal that is weaker than it appears.
+export function listMetricsWithSnapshotsOnDisk(): string[] {
+  const fixtures = listFixtures();
+  const metrics = new Set<string>();
+  for (const fixture of fixtures) {
+    let entries: import("node:fs").Dirent[];
+    try {
+      entries = readdirSync(join(SNAPSHOTS_ROOT, fixture), {
+        withFileTypes: true,
+      });
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") continue;
+      throw err;
+    }
+    for (const entry of entries) {
+      if (entry.isFile() && entry.name.endsWith(".json")) {
+        metrics.add(entry.name.slice(0, -".json".length));
+      }
+    }
+  }
+  return [...metrics].sort();
+}
+
 // ─── Parity check ──────────────────────────────────────────────────────
 
 export interface ParityResult {
@@ -296,7 +323,13 @@ export async function runParityCheck(args: {
   metric: string;
   fixture: string;
 }): Promise<ParityResult> {
-  const entry = METRIC_REGISTRY[args.metric];
+  // Object.hasOwn guards against prototype-chain lookups: `--metric=toString`
+  // would otherwise resolve to `Object.prototype.toString` (a Function) and
+  // crash with an opaque `entry.compute is not a function` instead of a
+  // clean RegistryMissError.
+  const entry = Object.hasOwn(METRIC_REGISTRY, args.metric)
+    ? METRIC_REGISTRY[args.metric]
+    : undefined;
   if (!entry) {
     throw new RegistryMissError(args.metric);
   }
@@ -346,6 +379,7 @@ interface CliArgs {
   fixture?: string;
   all?: boolean;
   json?: boolean;
+  strict?: boolean;
 }
 
 function parseCli(argv: string[]): CliArgs {
@@ -364,6 +398,9 @@ function parseCli(argv: string[]): CliArgs {
         break;
       case "json":
         out.json = true;
+        break;
+      case "strict":
+        out.strict = true;
         break;
       default:
         throw new Error(`unknown flag: ${tok}`);
@@ -409,6 +446,10 @@ async function main(): Promise<number> {
     console.error("[parity] --all and --metric are mutually exclusive");
     return 2;
   }
+  if (args.strict && !args.all) {
+    console.error("[parity] --strict requires --all");
+    return 2;
+  }
 
   const pairs: { metric: string; fixture: string }[] = [];
   if (args.all) {
@@ -451,16 +492,43 @@ async function main(): Promise<number> {
     }
   }
 
+  // Audit-only check: when running --all, surface metrics that have a
+  // snapshot on disk but no entry in METRIC_REGISTRY. Without this, --all
+  // reports an all-green signal that silently excludes ~40 unimplemented
+  // metrics. --strict promotes the warning to an exit-2 error.
+  let unregisteredOnDisk: string[] = [];
+  if (args.all) {
+    const registered = new Set(listRegisteredMetrics());
+    unregisteredOnDisk = listMetricsWithSnapshotsOnDisk().filter(
+      (m) => !registered.has(m),
+    );
+  }
+
   if (args.json) {
-    process.stdout.write(`${JSON.stringify({ results }, null, 2)}\n`);
+    process.stdout.write(
+      `${JSON.stringify({ results, unregistered_on_disk: unregisteredOnDisk }, null, 2)}\n`,
+    );
   } else {
     for (const r of results) {
       if (r.passed) console.log(formatHumanPass(r));
       else console.error(formatHumanDiff(r));
     }
+    if (unregisteredOnDisk.length > 0) {
+      const level = args.strict ? "ERROR" : "WARN";
+      console.error(
+        `[parity] ${level}: ${unregisteredOnDisk.length} metric(s) have snapshots on disk but no METRIC_REGISTRY entry:`,
+      );
+      for (const m of unregisteredOnDisk) console.error(`  - ${m}`);
+      if (!args.strict) {
+        console.error(
+          "[parity]   (these snapshots were NOT verified; pass --strict to fail on this)",
+        );
+      }
+    }
   }
 
   if (registryMissed > 0) return 2;
+  if (args.strict && unregisteredOnDisk.length > 0) return 2;
   if (failed > 0) return 1;
   return 0;
 }


### PR DESCRIPTION
## Summary

Three small follow-ups from the /architect triage of PR #111 (F8.2 + F8.2a Foster monotony port). All low-risk; the parity gate is green on every registered metric × fixture combination.

**Stacked on #111** — base ref is `chore/pre-f8-deviation-audit-v2`. Merge #111 first **without** `--delete-branch` so this PR's base ref survives, then retarget to `main` and merge.

### 1. `sampleStdev` JSDoc — drop overpromise, name Python's actual algorithm

The previous comment claimed bit-identical match to Python's `statistics.stdev` via a two-pass Neumaier-style correction. That misattributes Python — `statistics.stdev(data)` (no `xbar` arg) routes through Fraction-exact `statistics._sum`, which a pure-float TS port cannot reproduce. Bit-identity holds empirically on the 3 captured fixtures because the final `roundHalfEven(_, 2)` quantization masks sub-0.005 drift, NOT because the algorithms are equivalent. New comment says so honestly and flags the gate-failure path for future fixtures near rounding boundaries.

### 2. Prototype-pollution guards on `SPORT_FAMILIES` and `METRIC_REGISTRY`

Both are `Record<string, T>` object literals inheriting `Object.prototype`. Bracket lookups for keys like `\"toString\"`, `\"constructor\"`, `\"__proto__\"` resolve to inherited Function references — truthy, so a `?? \"other\"` (or `if (!entry)`) fallback never fires.

- `SPORT_FAMILIES[act.type]` (load-management.ts) would let a fixture with `type: \"toString\"` insert a Function as a Map key in `bySport`, diverging from Python's `dict.get(type, \"other\")`.
- `METRIC_REGISTRY[args.metric]` (check-metric-parity.ts) would let `--metric=toString` crash with opaque `entry.compute is not a function` instead of a clean `RegistryMissError`.

Both sites now use `Object.hasOwn(...)` at the lookup.

### 3. Parity gate `--strict` mode + unregistered-snapshot audit

`pnpm check-parity --all` previously iterated only `listRegisteredMetrics() × listFixtures()`, silently skipping the ~49 metrics with snapshot files on disk but no `METRIC_REGISTRY` entry (effective_monotony, strain, primary_sport, recovery_index, vo2max, w_prime, etc. — F8/F9/F10 wave scope). Operators saw \"all green\" while the bulk of the section-11 oracle sat unverified.

New behavior:

- `pnpm check-parity --all` → runs the registered cells, then prints `WARN: 49 metric(s) have snapshots on disk but no METRIC_REGISTRY entry: ...` at the end. Exit 0 if registered cells pass.
- `pnpm check-parity --all --strict` → same, with `ERROR:` prefix; exit 2 if any unregistered metric exists.
- `pnpm check-parity --strict` (no `--all`) → clean error \"--strict requires --all\", exit 2.
- JSON output includes `unregistered_on_disk: string[]`.

Added a `listMetricsWithSnapshotsOnDisk()` discovery helper alongside `listFixtures()` / `listRegisteredMetrics()`.

## Test plan

- [x] `pnpm check-parity --metric=acwr --fixture=all` → 3 OK
- [x] `pnpm check-parity --metric=monotony --fixture=all` → 3 OK
- [x] `pnpm check-parity --metric=primary_sport_monotony --fixture=all` → 3 OK
- [x] `pnpm check-parity --all` → 9 OK + WARN list of 49 unregistered metrics, exit 0
- [x] `pnpm check-parity --all --strict` → 9 OK + ERROR list, exit 2
- [x] `pnpm check-parity --strict` (no --all) → clean error, exit 2
- [x] `pnpm check-parity --metric=toString --fixture=realistic-athlete` → clean RegistryMissError, exit 2 (previously opaque TypeError)
- [x] Reference-parity / snapshot-loop / snapshot-contract test suites green