### PR TITLE
feat(core): port effective_monotony from the Reference layer's upstream (F8.2b)

### DIFF
--- a/packages/core/src/reference/metrics/load-management.ts
+++ b/packages/core/src/reference/metrics/load-management.ts
@@ -168,6 +168,49 @@ export function computePrimarySportMonotony(input: MetricInput): number | null {
   return roundHalfEven(meanLoad / stdevLoad, 2);
 }
 
+/**
+ * Effective monotony — the selector that picks between total and
+ * primary-sport monotony for downstream alert thresholds.
+ *
+ * Multi-sport athletes' total monotony can be inflated by a consistent
+ * cross-training Load floor; the primary-sport variant isolates the
+ * dominant modality. This selector switches to the primary-sport value
+ * when (a) more than one sport family appeared in the 7-day window AND
+ * (b) the primary-sport computation produced a non-null result.
+ * Otherwise falls through to total monotony (which itself may be null).
+ *
+ * Pure composition — no new math. Calls the sibling compute functions
+ * for the two candidate values and the shared per-sport aggregator for
+ * the multi-sport check. The duplicate aggregation work (getDailyLoad
+ * runs three times across this call's transitive helpers) is intentional:
+ * the discipline rewards line-by-line transliteration over optimization,
+ * and the snapshot gate would catch any drift from a structural rewrite.
+ *
+ * Upstream source mirrored line-by-line: `sync.py:3081-3082` inside
+ * `_calculate_derived_metrics`. The `daily_tss_by_sport` Python local
+ * is the same map produced by the per-sport aggregation helper at
+ * `sync.py:3646-3675`. See `NOTICE.md` for upstream attribution.
+ *
+ * Return shape is the raw upstream output (number or null), not a
+ * discriminated-union envelope. Raw compute functions feed the parity
+ * gate; a sibling envelope wrapper will feed the curator when the
+ * curator integration lands.
+ */
+export function computeEffectiveMonotony(input: MetricInput): number | null {
+  const fixture = input.fixture as { activities?: Activity[] };
+  const activities = fixture.activities ?? [];
+
+  const dailyLoadBySport = getDailyLoadBySport(activities, 7, input.frozenNow);
+  const isMultiSport = dailyLoadBySport.size > 1;
+
+  const primarySportMonotony = computePrimarySportMonotony(input);
+  const monotony = computeMonotony(input);
+
+  return isMultiSport && primarySportMonotony !== null
+    ? primarySportMonotony
+    : monotony;
+}
+
 // Mirrors `SPORT_FAMILIES` at sync.py:290-308. Unmapped types fall
 // through to "other" at the lookup site.
 const SPORT_FAMILIES: Record<string, string> = {

--- a/packages/core/src/reference/metrics/registry.ts
+++ b/packages/core/src/reference/metrics/registry.ts
@@ -11,6 +11,7 @@
 import type { MetricInput } from "./metric-input.js";
 import {
   computeAcwr,
+  computeEffectiveMonotony,
   computeMonotony,
   computePrimarySportMonotony,
 } from "./load-management.js";
@@ -23,4 +24,5 @@ export const METRIC_REGISTRY: Record<string, MetricRegistryEntry> = {
   acwr: { compute: computeAcwr },
   monotony: { compute: computeMonotony },
   primary_sport_monotony: { compute: computePrimarySportMonotony },
+  effective_monotony: { compute: computeEffectiveMonotony },
 };


### PR DESCRIPTION
## Summary

Ports `effective_monotony` — the pure selector that picks between total and primary-sport monotony for downstream alert thresholds.

```
isMultiSport = dailyLoadBySport.size > 1
effective = primarySportMonotony if (isMultiSport AND primarySportMonotony !== null)
                                 else monotony
```

Mirrors the upstream Python line-by-line at `sync.py:3081-3082` inside `_calculate_derived_metrics`. The `daily_tss_by_sport` multi-sport gate uses the same per-sport aggregator at `sync.py:3646-3675` (already shared with `primary_sport_monotony`).

Multi-sport athletes' total monotony can be inflated by a consistent cross-training Load floor; the primary-sport variant isolates the dominant modality. The selector switches to it only when both conditions hold; otherwise it falls through to total monotony (which itself may be null).

## Implementation notes

Composes the existing `computeMonotony` + `computePrimarySportMonotony` + `getDailyLoadBySport` — no new math. The duplicate aggregation work (`getDailyLoad` runs three times across the transitive helpers) is intentional: the discipline rewards line-by-line transliteration over optimization, and the snapshot gate would catch any drift from a structural rewrite. A future PR may extract a shared aggregation step if the rule-of-three case strengthens (currently 2 metrics share the pattern; 3rd would justify extraction per the open `getActivities(input)` helper ticket).

## Methodology

Line-by-line port; no deviation. `tools/intentional-deviations.yaml` unchanged.

## Test plan

- [x] `pnpm check-parity --metric=effective_monotony --fixture=all` exits 0 bit-identical across all 3 fixtures
  - realistic-athlete: 0.78 (multi-sport path: `isMultiSport=true`, `primarySportMonotony=0.78` → returns 0.78)
  - data-gap-mid-history: 2.08 (single-sport fallthrough: returns `monotony=2.08`)
  - new-athlete-empty: null (empty-map fallthrough: returns `monotony=null`)
- [x] `pnpm check-parity --all` → 4 metrics × 3 fixtures = 12 cells OK (no regression on acwr / monotony / primary_sport_monotony); unregistered-snapshot WARN count drops 49 → 48
- [x] Vitest reference-parity + snapshot-loop suites green (26/26)