### PR TITLE
chore: gitignore .ralph/ loop state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@ scripts/
 CLAUDE.local.md
 .tests/
 .agents/
+.ralph/
 skills-lock.json


### PR DESCRIPTION
## Summary

- Adds `.ralph/` to `.gitignore` — a local-only working directory for ralph-loop autonomous ticket iterations (preflight script, driver, prompt template, per-iteration handoffs and state).
- Matches the existing pattern for personal tooling (`.claude`, `.tests/`, `.agents/`, `CLAUDE.local.md`) — none of which ship.

One-line change. No code paths touched.

## Test plan

- [x] `.gitignore` rule confirmed locally (`.ralph/` artifacts no longer show in `git status`)
- [x] No tracked file references `.ralph/` (`git grep .ralph` is empty)