### PR TITLE
refactor(core): extract getActivities(input) helper for Reference-layer metrics

### DIFF
--- a/packages/core/src/reference/metrics/load-management.ts
+++ b/packages/core/src/reference/metrics/load-management.ts
@@ -7,7 +7,7 @@
 
 import type { Activity } from "../schemas/inputs.js";
 
-import type { MetricInput } from "./metric-input.js";
+import { getActivities, type MetricInput } from "./metric-input.js";
 
 /**
  * Acute:Chronic Workload Ratio (Gabbett 2016).
@@ -36,8 +36,7 @@ import type { MetricInput } from "./metric-input.js";
  *      Br J Sports Med 50(5):273-280. DOI: 10.1136/bjsports-2015-095788
  */
 export function computeAcwr(input: MetricInput): number | null {
-  const fixture = input.fixture as { activities?: Activity[] };
-  const activities = fixture.activities ?? [];
+  const activities = getActivities(input);
 
   const dailyLoad7d = getDailyLoad(activities, 7, input.frozenNow);
   const dailyLoad28d = getDailyLoad(activities, 28, input.frozenNow);
@@ -83,8 +82,7 @@ export function computeAcwr(input: MetricInput): number | null {
  *      DOI: 10.1097/00005768-199807000-00023
  */
 export function computeMonotony(input: MetricInput): number | null {
-  const fixture = input.fixture as { activities?: Activity[] };
-  const activities = fixture.activities ?? [];
+  const activities = getActivities(input);
 
   const dailyLoad7d = getDailyLoad(activities, 7, input.frozenNow);
 
@@ -139,8 +137,7 @@ export function computeMonotony(input: MetricInput): number | null {
  *      DOI: 10.1097/00005768-199807000-00023
  */
 export function computePrimarySportMonotony(input: MetricInput): number | null {
-  const fixture = input.fixture as { activities?: Activity[] };
-  const activities = fixture.activities ?? [];
+  const activities = getActivities(input);
 
   const dailyLoadBySport = getDailyLoadBySport(activities, 7, input.frozenNow);
   if (dailyLoadBySport.size === 0) return null;
@@ -197,8 +194,7 @@ export function computePrimarySportMonotony(input: MetricInput): number | null {
  * curator integration lands.
  */
 export function computeEffectiveMonotony(input: MetricInput): number | null {
-  const fixture = input.fixture as { activities?: Activity[] };
-  const activities = fixture.activities ?? [];
+  const activities = getActivities(input);
 
   const dailyLoadBySport = getDailyLoadBySport(activities, 7, input.frozenNow);
   const isMultiSport = dailyLoadBySport.size > 1;

--- a/packages/core/src/reference/metrics/metric-input.ts
+++ b/packages/core/src/reference/metrics/metric-input.ts
@@ -1,3 +1,5 @@
+import type { Activity } from "../schemas/inputs.js";
+
 /**
  * The contract between a metric port and the parity gate.
  *
@@ -10,4 +12,13 @@
 export interface MetricInput {
   fixture: unknown;
   frozenNow: string;
+}
+
+// Fixtures are trusted at the gate boundary; this helper does not
+// re-validate (Zod ran upstream of the snapshot capture). When a wellness
+// metric joins the port (e.g. recovery_index), add a sibling
+// `getWellness(input)` the same way rather than widening this one.
+export function getActivities(input: MetricInput): Activity[] {
+  const fixture = input.fixture as { activities?: Activity[] };
+  return fixture.activities ?? [];
 }


### PR DESCRIPTION
## Summary

Rule-of-three extract surfaced by the architect review of the primary_sport_monotony port. All four Reference-layer load-management metrics opened with the same trusted-fixture cast:

```ts
const fixture = input.fixture as { activities?: Activity[] };
const activities = fixture.activities ?? [];
```

This PR collapses that idiom to `const activities = getActivities(input);` and lifts the cast into `packages/core/src/reference/metrics/metric-input.ts` next to the `MetricInput` contract.

Refactor scope grew from the ticket's named three (`computeAcwr`, `computeMonotony`, `computePrimarySportMonotony`) to four — `computeEffectiveMonotony` landed after the ticket was filed and carries the identical idiom. Leaving it un-refactored would have created a half-finished cleanup.

Helper deliberately does not Zod-validate: fixtures are trusted at the gate boundary (Zod ran upstream of snapshot capture). When a wellness metric joins (recovery_index), add a sibling `getWellness(input)` the same way — comment in `metric-input.ts` flags the pattern.

## Test plan

- [x] `pnpm check-parity --metric=acwr --fixture=all` — OK across 3 fixtures
- [x] `pnpm check-parity --metric=monotony --fixture=all` — OK across 3 fixtures
- [x] `pnpm check-parity --metric=primary_sport_monotony --fixture=all` — OK across 3 fixtures
- [x] `pnpm check-parity --metric=effective_monotony --fixture=all` — OK across 3 fixtures (regression check on the bonus 4th refactor)
- [x] `pnpm --filter @enduragent/core test` — 674 passed, 2 skipped, 68 files