### PR TITLE
chore: gitignore .specify/ — Spec Kit local tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,5 @@ CLAUDE.local.md
 .tests/
 .agents/
 .ralph/
+.specify/
 skills-lock.json


### PR DESCRIPTION
Gitignore `.specify/` — GitHub Spec Kit's local config (templates, constitution, scripts), kept local alongside `.ralph/` and `.claude/`.

Spec Kit is local methodology tooling for the Reference-layer workflow; its config is not a shipped artifact, so it stays out of git. Also keeps the working tree clean for the local tooling that requires it.