### PR TITLE
ralph: batch — 2026-05-25

### DIFF
--- a/packages/core/src/reference/metrics/load-management.test.ts
+++ b/packages/core/src/reference/metrics/load-management.test.ts
@@ -4,6 +4,7 @@ import {
   computeEffectiveMonotony,
   computeMonotony,
   computeMonotonyInterpretation,
+  computeRecoveryIndex,
   computeStrain,
 } from "./load-management.js";
 import type { MetricInput } from "./metric-input.js";
@@ -116,5 +117,73 @@ describe("computeMonotonyInterpretation", () => {
     );
     expect(out).toContain(`primary sport ${computeEffectiveMonotony(multi)}`);
     expect(out).toContain(`total ${computeMonotony(multi)}`);
+  });
+});
+
+// computeRecoveryIndex reads only id, hrv, and restingHR from the
+// trailing 7-day wellness window; bit-identity against the upstream on
+// the populated path is the parity matrix's job (realistic-athlete = 0.91,
+// data-gap-mid-history = 1). These rows isolate the ratio formula and the
+// edge cases the three fixtures don't separate.
+function wellnessInput(
+  wellness: { id: string; hrv: number | null; restingHR: number | null }[],
+  frozenNow: string,
+): MetricInput {
+  return { fixture: { wellness }, frozenNow };
+}
+
+describe("computeRecoveryIndex", () => {
+  const FROZEN = "2026-05-10T12:00:00";
+
+  it("returns (latestHrv/hrvBaseline) ÷ (latestRhr/rhrBaseline), rounded half-to-even", () => {
+    // Window 05-04..05-10. HRV baseline mean(40,50)=45, RHR baseline 60,
+    // latest (05-10) HRV 50 / RHR 60 ⇒ (50/45)/(60/60) ⇒ round(1.111…)=1.11.
+    const result = computeRecoveryIndex(
+      wellnessInput(
+        [
+          { id: "2026-05-09", hrv: 40, restingHR: 60 },
+          { id: "2026-05-10", hrv: 50, restingHR: 60 },
+        ],
+        FROZEN,
+      ),
+    );
+    expect(result).toBe(1.11);
+  });
+
+  it("returns Unknown (null) when there is no wellness data", () => {
+    expect(computeRecoveryIndex(wellnessInput([], FROZEN))).toBeNull();
+  });
+
+  it("returns Unknown (null) when the latest HRV reading is out of band", () => {
+    // 5ms RMSSD is below the 10-250 validity band ⇒ latest HRV rejected ⇒
+    // the ratio guard fails even though a baseline exists from prior days.
+    const result = computeRecoveryIndex(
+      wellnessInput(
+        [
+          { id: "2026-05-09", hrv: 45, restingHR: 60 },
+          { id: "2026-05-10", hrv: 5, restingHR: 60 },
+        ],
+        FROZEN,
+      ),
+    );
+    expect(result).toBeNull();
+  });
+
+  it("reads the LAST in-window row as latest, in fixture order — not the chronologically latest", () => {
+    // Rows supplied with the earlier date last. The upstream takes
+    // wellness_7d[-1] (last array element), so latest = the 05-08 row
+    // (HRV 40), not the 05-10 row. Baseline mean(50,40)=45 ⇒
+    // (40/45)/(60/60) ⇒ round(0.888…)=0.89. Chronological-latest would
+    // give 1.11.
+    const result = computeRecoveryIndex(
+      wellnessInput(
+        [
+          { id: "2026-05-10", hrv: 50, restingHR: 60 },
+          { id: "2026-05-08", hrv: 40, restingHR: 60 },
+        ],
+        FROZEN,
+      ),
+    );
+    expect(result).toBe(0.89);
   });
 });

--- a/packages/core/src/reference/metrics/load-management.test.ts
+++ b/packages/core/src/reference/metrics/load-management.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   computeEffectiveMonotony,
+  computeLoadRecoveryRatio,
   computeMonotony,
   computeMonotonyInterpretation,
   computeRecoveryIndex,
@@ -212,5 +213,56 @@ describe("computeRecoveryIndex", () => {
       ),
     );
     expect(result).toBe(0.89);
+  });
+});
+
+// computeLoadRecoveryRatio reads activities (for weekly Load) and the
+// trailing 7-day wellness window (for the recovery index). These rows
+// isolate the ratio formula and the recovery-index cascade; bit-identity
+// on the populated path is the parity matrix's job (realistic-athlete =
+// 2.8, data-gap-mid-history = 3.6).
+function loadRecoveryInput(
+  activities: { start_date_local: string; icu_training_load: number }[],
+  wellness: { id: string; hrv: number | null; restingHR: number | null }[],
+  frozenNow: string,
+): MetricInput {
+  return { fixture: { activities, wellness }, frozenNow };
+}
+
+describe("computeLoadRecoveryRatio", () => {
+  const FROZEN = "2026-05-10T12:00:00";
+
+  it("returns weeklyLoad / (recoveryIndex × 100), rounded half-to-even", () => {
+    // Window 05-04..05-10. Loads 50/50/100 ⇒ weekly Load 200. Wellness
+    // baseline mean(40,50)=45, latest (05-10) HRV 50 / RHR 60 ⇒ ri 1.11.
+    // 200 / (1.11 × 100) = 200 / 111 ⇒ round(1.801…, 1) = 1.8.
+    const result = computeLoadRecoveryRatio(
+      loadRecoveryInput(
+        [
+          { start_date_local: "2026-05-06T08:00:00", icu_training_load: 50 },
+          { start_date_local: "2026-05-08T08:00:00", icu_training_load: 50 },
+          { start_date_local: "2026-05-10T08:00:00", icu_training_load: 100 },
+        ],
+        [
+          { id: "2026-05-09", hrv: 40, restingHR: 60 },
+          { id: "2026-05-10", hrv: 50, restingHR: 60 },
+        ],
+        FROZEN,
+      ),
+    );
+    expect(result).toBe(1.8);
+  });
+
+  it("cascades Unknown: recovery index null ⇒ load-recovery ratio null", () => {
+    // Activities present, but no wellness ⇒ recovery index null ⇒ the
+    // `ri and ri > 0` guard fails ⇒ null, even with weekly Load > 0.
+    const result = computeLoadRecoveryRatio(
+      loadRecoveryInput(
+        [{ start_date_local: "2026-05-10T08:00:00", icu_training_load: 100 }],
+        [],
+        FROZEN,
+      ),
+    );
+    expect(result).toBeNull();
   });
 });

--- a/packages/core/src/reference/metrics/load-management.test.ts
+++ b/packages/core/src/reference/metrics/load-management.test.ts
@@ -1,15 +1,24 @@
 import { describe, expect, it } from "vitest";
 
-import { computeStrain } from "./load-management.js";
+import {
+  computeEffectiveMonotony,
+  computeMonotony,
+  computeMonotonyInterpretation,
+  computeStrain,
+} from "./load-management.js";
 import type { MetricInput } from "./metric-input.js";
 
-// computeStrain reads only start_date_local and icu_training_load through
-// the shared daily-Load aggregator; the full Activity shape is exercised
-// by the parity matrix against golden fixtures. These synthetic rows
-// isolate the strain formula and its monotony cascade. `fixture` is typed
+// These computers read only start_date_local, icu_training_load, and (for
+// the per-sport split) type through the shared daily-Load aggregators; the
+// full Activity shape is exercised by the parity matrix against golden
+// fixtures. These synthetic rows isolate the formulae. `fixture` is typed
 // `unknown` at the gate boundary, so minimal rows ride through untyped.
 function input(
-  activities: { start_date_local: string; icu_training_load: number }[],
+  activities: {
+    start_date_local: string;
+    icu_training_load: number;
+    type?: string;
+  }[],
   frozenNow: string,
 ): MetricInput {
   return { fixture: { activities }, frozenNow };
@@ -37,5 +46,75 @@ describe("computeStrain", () => {
   it("cascades Unknown: monotony null ⇒ strain null", () => {
     // No activity in the window ⇒ every daily Load is 0 ⇒ monotony null.
     expect(computeStrain(input([], FROZEN))).toBeNull();
+  });
+});
+
+describe("computeMonotonyInterpretation", () => {
+  const FROZEN = "2026-05-10T12:00:00";
+
+  it("cascades Unknown: effective monotony null ⇒ interpretation null", () => {
+    // No activity in the window ⇒ monotony null ⇒ effective null ⇒ Unknown.
+    expect(computeMonotonyInterpretation(input([], FROZEN))).toBeNull();
+  });
+
+  it('returns the bare "normal" band when effective monotony ≤ 2.0', () => {
+    // Single sport family, low monotony (0.73) ⇒ no multi-sport annotation.
+    const result = computeMonotonyInterpretation(
+      input(
+        [
+          { start_date_local: "2026-05-06T08:00:00", icu_training_load: 50 },
+          { start_date_local: "2026-05-08T08:00:00", icu_training_load: 50 },
+          { start_date_local: "2026-05-10T08:00:00", icu_training_load: 100 },
+        ],
+        FROZEN,
+      ),
+    );
+    expect(result).toBe("normal");
+  });
+
+  it('returns the bare "elevated" band when effective monotony > 2.0', () => {
+    // Single sport family, near-flat Load across all 7 days ⇒ high monotony.
+    const result = computeMonotonyInterpretation(
+      input(
+        [
+          { start_date_local: "2026-05-04T08:00:00", icu_training_load: 100 },
+          { start_date_local: "2026-05-05T08:00:00", icu_training_load: 100 },
+          { start_date_local: "2026-05-06T08:00:00", icu_training_load: 100 },
+          { start_date_local: "2026-05-07T08:00:00", icu_training_load: 100 },
+          { start_date_local: "2026-05-08T08:00:00", icu_training_load: 100 },
+          { start_date_local: "2026-05-09T08:00:00", icu_training_load: 100 },
+          { start_date_local: "2026-05-10T08:00:00", icu_training_load: 95 },
+        ],
+        FROZEN,
+      ),
+    );
+    expect(result).toBe("elevated");
+  });
+
+  it("annotates the multi-sport-inflation band with both monotony values", () => {
+    // A varied Ride series (primary) plus a consistent Run floor on the
+    // otherwise-empty days: the floor inflates total monotony above the
+    // primary-sport value, so effective (= primary) < total triggers the
+    // annotated branch. The exact values are composed from the sibling
+    // computers; bit-identity against the upstream is the parity matrix's
+    // job (realistic-athlete covers this branch).
+    const multi = input(
+      [
+        { start_date_local: "2026-05-06T08:00:00", icu_training_load: 50, type: "Ride" },
+        { start_date_local: "2026-05-08T08:00:00", icu_training_load: 100, type: "Ride" },
+        { start_date_local: "2026-05-09T08:00:00", icu_training_load: 50, type: "Ride" },
+        { start_date_local: "2026-05-10T08:00:00", icu_training_load: 100, type: "Ride" },
+        { start_date_local: "2026-05-04T08:00:00", icu_training_load: 30, type: "Run" },
+        { start_date_local: "2026-05-05T08:00:00", icu_training_load: 30, type: "Run" },
+        { start_date_local: "2026-05-07T08:00:00", icu_training_load: 30, type: "Run" },
+      ],
+      FROZEN,
+    );
+    const out = computeMonotonyInterpretation(multi);
+    expect(out).toMatch(
+      /^normal \(primary sport .+, total .+ inflated by multi-sport\)$/,
+    );
+    expect(out).toContain(`primary sport ${computeEffectiveMonotony(multi)}`);
+    expect(out).toContain(`total ${computeMonotony(multi)}`);
   });
 });

--- a/packages/core/src/reference/metrics/load-management.test.ts
+++ b/packages/core/src/reference/metrics/load-management.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { computeStrain } from "./load-management.js";
+import type { MetricInput } from "./metric-input.js";
+
+// computeStrain reads only start_date_local and icu_training_load through
+// the shared daily-Load aggregator; the full Activity shape is exercised
+// by the parity matrix against golden fixtures. These synthetic rows
+// isolate the strain formula and its monotony cascade. `fixture` is typed
+// `unknown` at the gate boundary, so minimal rows ride through untyped.
+function input(
+  activities: { start_date_local: string; icu_training_load: number }[],
+  frozenNow: string,
+): MetricInput {
+  return { fixture: { activities }, frozenNow };
+}
+
+describe("computeStrain", () => {
+  const FROZEN = "2026-05-10T12:00:00";
+
+  it("returns weekly Load × monotony, rounded half-to-even", () => {
+    // 7-day window 05-04..05-10. Loads 50 (05-06) + 50 (05-08) + 100
+    // (05-10) ⇒ weekly Load 200, monotony 0.73 ⇒ round(200 × 0.73) = 146.
+    const result = computeStrain(
+      input(
+        [
+          { start_date_local: "2026-05-06T08:00:00", icu_training_load: 50 },
+          { start_date_local: "2026-05-08T08:00:00", icu_training_load: 50 },
+          { start_date_local: "2026-05-10T08:00:00", icu_training_load: 100 },
+        ],
+        FROZEN,
+      ),
+    );
+    expect(result).toBe(146);
+  });
+
+  it("cascades Unknown: monotony null ⇒ strain null", () => {
+    // No activity in the window ⇒ every daily Load is 0 ⇒ monotony null.
+    expect(computeStrain(input([], FROZEN))).toBeNull();
+  });
+});

--- a/packages/core/src/reference/metrics/load-management.test.ts
+++ b/packages/core/src/reference/metrics/load-management.test.ts
@@ -6,6 +6,7 @@ import {
   computeMonotonyInterpretation,
   computeRecoveryIndex,
   computeStrain,
+  computeStressTolerance,
 } from "./load-management.js";
 import type { MetricInput } from "./metric-input.js";
 
@@ -47,6 +48,32 @@ describe("computeStrain", () => {
   it("cascades Unknown: monotony null ⇒ strain null", () => {
     // No activity in the window ⇒ every daily Load is 0 ⇒ monotony null.
     expect(computeStrain(input([], FROZEN))).toBeNull();
+  });
+});
+
+describe("computeStressTolerance", () => {
+  const FROZEN = "2026-05-10T12:00:00";
+
+  it("returns (strain / monotony) / 100, rounded half-to-even", () => {
+    // Same window as the strain test: loads 50/50/100 ⇒ weekly Load 200,
+    // monotony 0.73, strain round(200 × 0.73) = 146. Stress tolerance is
+    // (146 / 0.73) / 100 = 200 / 100 = round(2.0, 1) = 2.
+    const result = computeStressTolerance(
+      input(
+        [
+          { start_date_local: "2026-05-06T08:00:00", icu_training_load: 50 },
+          { start_date_local: "2026-05-08T08:00:00", icu_training_load: 50 },
+          { start_date_local: "2026-05-10T08:00:00", icu_training_load: 100 },
+        ],
+        FROZEN,
+      ),
+    );
+    expect(result).toBe(2);
+  });
+
+  it("cascades Unknown: monotony null ⇒ strain null ⇒ stress tolerance null", () => {
+    // No activity in the window ⇒ monotony null ⇒ strain null ⇒ null.
+    expect(computeStressTolerance(input([], FROZEN))).toBeNull();
   });
 });
 

--- a/packages/core/src/reference/metrics/load-management.ts
+++ b/packages/core/src/reference/metrics/load-management.ts
@@ -5,7 +5,7 @@
  * upstream protocol. See `NOTICE.md` for license attribution.
  */
 
-import type { Activity } from "../schemas/inputs.js";
+import type { Activity, WellnessDay } from "../schemas/inputs.js";
 
 import { getActivities, type MetricInput } from "./metric-input.js";
 
@@ -295,6 +295,97 @@ export function computeMonotonyInterpretation(input: MetricInput): string | null
   }
   if (effectiveMonotony > 2.0) return "elevated";
   return "normal";
+}
+
+/**
+ * Recovery index — the morning HRV/RHR readiness ratio.
+ *
+ * Reads the trailing 7-day wellness window (today and the six prior
+ * calendar days, in fixture order) and forms a two-contributor ratio:
+ * the day's HRV relative to its 7-day baseline, divided by the day's
+ * resting HR relative to its 7-day baseline. Above 1.0 reads as good
+ * recovery, below 1.0 as suppressed.
+ *
+ *   ri = (latestHrv / hrvBaseline7d) / (latestRhr / rhrBaseline7d)
+ *
+ * Baselines are the mean of the in-window readings, rounded to 1
+ * decimal: HRV readings filtered to the physiological band (10-250ms
+ * RMSSD, sensor-error rejection), resting-HR readings filtered to
+ * truthy values. "Latest" is the last reading in the window (HRV gated
+ * by the same validity band, resting HR taken raw). Returns `null` when
+ * any of the two latest readings or two baselines is missing or zero,
+ * mirroring the upstream truthiness guard — so an empty or wellness-free
+ * window cascades to Unknown.
+ *
+ * Upstream source mirrored line-by-line: `sync.py:3089-3115`
+ * (`_calculate_derived_metrics`) — the 7-day baseline block plus the
+ * recovery-index ratio — and the validity band at `sync.py:6225-6231`
+ * (`_is_valid_hrv`). The 7-day window matches the harness call-site slice
+ * (`wellness_7d`); see `NOTICE.md` for upstream attribution.
+ *
+ * Two-contributor, 7-day-baseline shape per the deviation registry's
+ * `recovery_index` `approved-revert` entry in
+ * `tools/intentional-deviations.yaml` (the 28-day / 4-contributor
+ * z-score variant was reviewed and rejected for lack of literature).
+ *
+ * Return shape is the raw upstream output (number or null), not a
+ * discriminated-union envelope. Raw compute functions feed the parity
+ * gate; a sibling envelope wrapper will feed the curator when the
+ * curator integration lands.
+ */
+export function computeRecoveryIndex(input: MetricInput): number | null {
+  const wellness7d = getWellnessWindow(input, 7);
+
+  const hrvValues7d = wellness7d
+    .map((w) => w.hrv)
+    .filter((v): v is number => isValidHrv(v));
+  const rhrValues7d = wellness7d
+    .map((w) => w.restingHR)
+    .filter((v): v is number => !!v);
+
+  const hrvBaseline7d =
+    hrvValues7d.length > 0 ? roundHalfEven(arithmeticMean(hrvValues7d), 1) : null;
+  const rhrBaseline7d =
+    rhrValues7d.length > 0 ? roundHalfEven(arithmeticMean(rhrValues7d), 1) : null;
+
+  const latest = wellness7d.length > 0 ? wellness7d[wellness7d.length - 1]! : null;
+  const latestHrvRaw = latest ? latest.hrv : null;
+  const latestHrv = isValidHrv(latestHrvRaw) ? latestHrvRaw : null;
+  const latestRhr = latest ? latest.restingHR : null;
+
+  if (latestHrv && latestRhr && hrvBaseline7d && rhrBaseline7d) {
+    const hrvRatio = latestHrv / hrvBaseline7d;
+    const rhrRatio = latestRhr / rhrBaseline7d;
+    return rhrRatio > 0 ? roundHalfEven(hrvRatio / rhrRatio, 2) : null;
+  }
+  return null;
+}
+
+// Mirrors `_is_valid_hrv` at sync.py:6225-6231: rejects null and
+// out-of-band readings (valid RMSSD is 10-250ms), filtering sensor
+// errors while preserving legitimate elite-athlete highs.
+function isValidHrv(value: number | null | undefined): value is number {
+  return value !== null && value !== undefined && value >= 10 && value <= 250;
+}
+
+// The 7-day wellness window the upstream reads as `wellness_7d`: rows
+// whose `id` date falls in [frozenNow-(days-1), frozenNow], inclusive,
+// in fixture order. Mirrors the harness `_within(_wellness_all, "id",
+// ...)` slice — the inclusive lexicographic date comparison and the
+// preserved input order matter, because the recovery index reads the
+// LAST row of this list (`wellness_7d[-1]`), not the chronologically
+// latest. Fixtures are trusted at the gate boundary (Zod ran upstream
+// of snapshot capture), matching the `getActivities` cast.
+function getWellnessWindow(input: MetricInput, days: number): WellnessDay[] {
+  const fixture = input.fixture as { wellness?: WellnessDay[] };
+  const wellness = fixture.wellness ?? [];
+  const oldest = isoDateDaysBefore(input.frozenNow, days - 1);
+  const today = input.frozenNow.slice(0, 10);
+  return wellness.filter((w) => {
+    if (typeof w.id !== "string") return false;
+    const d = w.id.slice(0, 10);
+    return oldest <= d && d <= today;
+  });
 }
 
 // Python's f-string interpolates a float via str(), which renders an

--- a/packages/core/src/reference/metrics/load-management.ts
+++ b/packages/core/src/reference/metrics/load-management.ts
@@ -207,6 +207,46 @@ export function computeEffectiveMonotony(input: MetricInput): number | null {
     : monotony;
 }
 
+/**
+ * Training strain (Foster 1998).
+ *
+ * Strain = weekly Load × total monotony, where weekly Load is the sum of
+ * the trailing 7-day daily-Load series (the aggregator ACWR and monotony
+ * share) and monotony is the already-rounded total monotony. Foster
+ * associates strain above ~3500-4000 with overtraining.
+ *
+ * Returns `null` whenever monotony is falsy — `null` (the empty/rest-week
+ * cascade) or `0`. This mirrors the upstream `if monotony else None`
+ * guard, so an Unknown monotony cascades to an Unknown strain.
+ *
+ * Otherwise returns `round(weeklyLoad × monotony, 0)` with half-to-even
+ * rounding to mirror Python's `round()` bit-identically.
+ *
+ * Upstream source mirrored line-by-line: `sync.py:3087`
+ * (`_calculate_derived_metrics`). `tss_7d_total` is the sum of the 7-day
+ * series from the daily aggregator at `sync.py:3629-3644`, shared with
+ * ACWR and monotony. See `NOTICE.md` for upstream attribution.
+ *
+ * Return shape is the raw upstream output (number or null), not a
+ * discriminated-union envelope. Raw compute functions feed the parity
+ * gate; a sibling envelope wrapper will feed the curator when the
+ * curator integration lands.
+ *
+ * @see Foster, C. (1998). Monitoring training in athletes with reference
+ *      to overtraining syndrome. Med Sci Sports Exerc 30(7):1164-1168.
+ *      DOI: 10.1097/00005768-199807000-00023
+ */
+export function computeStrain(input: MetricInput): number | null {
+  const monotony = computeMonotony(input);
+  if (!monotony) return null;
+
+  const activities = getActivities(input);
+  const dailyLoad7d = getDailyLoad(activities, 7, input.frozenNow);
+  const load7dTotal = dailyLoad7d.reduce((s, t) => s + t, 0);
+
+  return roundHalfEven(load7dTotal * monotony, 0);
+}
+
 // Mirrors `SPORT_FAMILIES` at sync.py:290-308. Unmapped types fall
 // through to "other" at the lookup site.
 const SPORT_FAMILIES: Record<string, string> = {

--- a/packages/core/src/reference/metrics/load-management.ts
+++ b/packages/core/src/reference/metrics/load-management.ts
@@ -248,6 +248,50 @@ export function computeStrain(input: MetricInput): number | null {
 }
 
 /**
+ * Stress tolerance — strain normalised by monotony, scaled to a 0-100
+ * reference band.
+ *
+ *   stressTolerance = (strain / monotony) / 100
+ *
+ * Both inputs are the already-rounded total-monotony quantities the
+ * strain metric uses: `strain` is `round(weeklyLoad × monotony, 0)` and
+ * `monotony` is `round(mean / stdev, 2)`. Because `strain` carries the
+ * `monotony` factor, the ratio collapses to roughly `weeklyLoad / 100`,
+ * but the upstream computes it from the two rounded locals — so the
+ * port does too, rather than short-cutting to weekly Load. The result
+ * is rounded half-to-even to 1 decimal.
+ *
+ * Returns `null` whenever `strain` or `monotony` is falsy (`null` from
+ * the empty/rest-week cascade, or `0`), mirroring the upstream
+ * `if strain and monotony else None` guard — so an Unknown monotony
+ * cascades through Unknown strain to an Unknown stress tolerance.
+ *
+ * Upstream source mirrored line-by-line: `sync.py:3131`
+ * (`_calculate_derived_metrics`). `strain` and `monotony` are the locals
+ * at `sync.py:3087` and `sync.py:3037`, both built from the daily
+ * aggregator at `sync.py:3629-3644` shared with ACWR. See `NOTICE.md`
+ * for upstream attribution.
+ *
+ * Mirrors `sync.py:3131` line-by-line per the deviation registry's
+ * `stress_tolerance` `approved-revert` entry in
+ * `tools/intentional-deviations.yaml` (the capacity-cap family proposed
+ * in an earlier spec revision was reviewed and reverted; ADR-0015 is
+ * superseded).
+ *
+ * Return shape is the raw upstream output (number or null), not a
+ * discriminated-union envelope. Raw compute functions feed the parity
+ * gate; a sibling envelope wrapper will feed the curator when the
+ * curator integration lands.
+ */
+export function computeStressTolerance(input: MetricInput): number | null {
+  const strain = computeStrain(input);
+  const monotony = computeMonotony(input);
+  if (!strain || !monotony) return null;
+
+  return roundHalfEven(strain / monotony / 100, 1);
+}
+
+/**
  * Monotony interpretation band — the human-readable verdict on monotony,
  * multi-sport aware.
  *

--- a/packages/core/src/reference/metrics/load-management.ts
+++ b/packages/core/src/reference/metrics/load-management.ts
@@ -405,6 +405,50 @@ export function computeRecoveryIndex(input: MetricInput): number | null {
   return null;
 }
 
+/**
+ * Load-recovery ratio — weekly Load weighed against autonomic recovery.
+ *
+ *   loadRecoveryRatio = weeklyLoad / (recoveryIndex × 100)
+ *
+ * The numerator is the sum of the trailing 7-day daily-Load series (the
+ * aggregator ACWR, monotony, and strain share). The denominator is the
+ * recovery index — the morning HRV/RHR readiness ratio — scaled by 100,
+ * so a healthier autonomic signal shrinks the ratio. The result is
+ * rounded half-to-even to 1 decimal.
+ *
+ * Returns `null` whenever the recovery index is falsy (`null` from the
+ * empty/wellness-free cascade, or `0`) or non-positive, mirroring the
+ * upstream `if ri and ri > 0 else None` guard — so an Unknown recovery
+ * index cascades to an Unknown load-recovery ratio.
+ *
+ * Upstream source mirrored line-by-line: `sync.py:3135`
+ * (`_calculate_derived_metrics`). `tss_7d_total` is the sum of the 7-day
+ * series from the daily aggregator at `sync.py:3629-3644`, shared with
+ * ACWR; `ri` is the recovery-index local at `sync.py:3113`. See
+ * `NOTICE.md` for upstream attribution.
+ *
+ * Mirrors `sync.py:3135` line-by-line per the deviation registry's
+ * `load_recovery_ratio` `approved-revert` entry in
+ * `tools/intentional-deviations.yaml` (the time-proxy-denominator family
+ * proposed in an earlier spec revision was reviewed and reverted for lack
+ * of literature).
+ *
+ * Return shape is the raw upstream output (number or null), not a
+ * discriminated-union envelope. Raw compute functions feed the parity
+ * gate; a sibling envelope wrapper will feed the curator when the
+ * curator integration lands.
+ */
+export function computeLoadRecoveryRatio(input: MetricInput): number | null {
+  const ri = computeRecoveryIndex(input);
+  if (!ri || ri <= 0) return null;
+
+  const activities = getActivities(input);
+  const dailyLoad7d = getDailyLoad(activities, 7, input.frozenNow);
+  const load7dTotal = dailyLoad7d.reduce((s, t) => s + t, 0);
+
+  return roundHalfEven(load7dTotal / (ri * 100), 1);
+}
+
 // Mirrors `_is_valid_hrv` at sync.py:6225-6231: rejects null and
 // out-of-band readings (valid RMSSD is 10-250ms), filtering sensor
 // errors while preserving legitimate elite-athlete highs.

--- a/packages/core/src/reference/metrics/load-management.ts
+++ b/packages/core/src/reference/metrics/load-management.ts
@@ -247,6 +247,66 @@ export function computeStrain(input: MetricInput): number | null {
   return roundHalfEven(load7dTotal * monotony, 0);
 }
 
+/**
+ * Monotony interpretation band — the human-readable verdict on monotony,
+ * multi-sport aware.
+ *
+ * Reads the three already-computed monotony quantities — total monotony,
+ * effective monotony (the selector that prefers primary-sport monotony
+ * when multi-sport is detected), and the multi-sport flag (more than one
+ * sport family in the trailing 7-day window). The band is driven by
+ * effective monotony against a single threshold of 2.0:
+ *
+ *   - effective monotony Unknown ⇒ Unknown (cascades from monotony),
+ *   - multi-sport inflation (multi-sport AND total monotony truthy AND
+ *     effective < total) ⇒ an annotated string naming both values, with
+ *     "elevated"/"normal" chosen by effective > 2.0,
+ *   - otherwise ⇒ the bare "elevated"/"normal", chosen by effective > 2.0.
+ *
+ * Upstream source mirrored line-by-line: `sync.py:3473-3491`
+ * (`_interpret_monotony`). The three inputs are the call-site locals at
+ * `sync.py:3362-3363` — `monotony` (computeMonotony), `effective_monotony`
+ * (computeEffectiveMonotony), and `is_multi_sport`
+ * (`len(daily_tss_by_sport) > 1`, sync.py:3081). See `NOTICE.md` for
+ * upstream attribution.
+ *
+ * Return shape is the raw upstream output (string or null), not a
+ * discriminated-union envelope. Raw compute functions feed the parity
+ * gate; a sibling envelope wrapper will feed the curator when the
+ * curator integration lands.
+ *
+ * @see Foster, C. (1998). Monitoring training in athletes with reference
+ *      to overtraining syndrome. Med Sci Sports Exerc 30(7):1164-1168.
+ *      DOI: 10.1097/00005768-199807000-00023
+ */
+export function computeMonotonyInterpretation(input: MetricInput): string | null {
+  const totalMonotony = computeMonotony(input);
+  const effectiveMonotony = computeEffectiveMonotony(input);
+
+  const activities = getActivities(input);
+  const isMultiSport = getDailyLoadBySport(activities, 7, input.frozenNow).size > 1;
+
+  if (effectiveMonotony === null) return null;
+  if (isMultiSport && totalMonotony && effectiveMonotony < totalMonotony) {
+    if (effectiveMonotony > 2.0) {
+      return `elevated (primary sport ${pyFloatStr(effectiveMonotony)}, total ${pyFloatStr(totalMonotony)} inflated by multi-sport)`;
+    }
+    return `normal (primary sport ${pyFloatStr(effectiveMonotony)}, total ${pyFloatStr(totalMonotony)} inflated by multi-sport)`;
+  }
+  if (effectiveMonotony > 2.0) return "elevated";
+  return "normal";
+}
+
+// Python's f-string interpolates a float via str(), which renders an
+// integer-valued float with a trailing ".0" (str(2.0) == "2.0"); JS
+// String(2.0) drops it ("2"). The monotony inputs here are round(_, 2)
+// floats, so the only divergence from shortest-round-trip repr — shared
+// by both runtimes — is that integer case. Reproduce Python's rendering
+// so an integer-valued monotony interpolates bit-identically.
+function pyFloatStr(value: number): string {
+  return Number.isInteger(value) ? `${value}.0` : `${value}`;
+}
+
 // Mirrors `SPORT_FAMILIES` at sync.py:290-308. Unmapped types fall
 // through to "other" at the lookup site.
 const SPORT_FAMILIES: Record<string, string> = {

--- a/packages/core/src/reference/metrics/registry.ts
+++ b/packages/core/src/reference/metrics/registry.ts
@@ -12,6 +12,7 @@ import type { MetricInput } from "./metric-input.js";
 import {
   computeAcwr,
   computeEffectiveMonotony,
+  computeLoadRecoveryRatio,
   computeMonotony,
   computeMonotonyInterpretation,
   computePrimarySportMonotony,
@@ -33,4 +34,5 @@ export const METRIC_REGISTRY: Record<string, MetricRegistryEntry> = {
   strain: { compute: computeStrain },
   recovery_index: { compute: computeRecoveryIndex },
   stress_tolerance: { compute: computeStressTolerance },
+  load_recovery_ratio: { compute: computeLoadRecoveryRatio },
 };

--- a/packages/core/src/reference/metrics/registry.ts
+++ b/packages/core/src/reference/metrics/registry.ts
@@ -13,6 +13,7 @@ import {
   computeAcwr,
   computeEffectiveMonotony,
   computeMonotony,
+  computeMonotonyInterpretation,
   computePrimarySportMonotony,
   computeStrain,
 } from "./load-management.js";
@@ -26,5 +27,6 @@ export const METRIC_REGISTRY: Record<string, MetricRegistryEntry> = {
   monotony: { compute: computeMonotony },
   primary_sport_monotony: { compute: computePrimarySportMonotony },
   effective_monotony: { compute: computeEffectiveMonotony },
+  monotony_interpretation: { compute: computeMonotonyInterpretation },
   strain: { compute: computeStrain },
 };

--- a/packages/core/src/reference/metrics/registry.ts
+++ b/packages/core/src/reference/metrics/registry.ts
@@ -17,6 +17,7 @@ import {
   computePrimarySportMonotony,
   computeRecoveryIndex,
   computeStrain,
+  computeStressTolerance,
 } from "./load-management.js";
 
 export interface MetricRegistryEntry {
@@ -31,4 +32,5 @@ export const METRIC_REGISTRY: Record<string, MetricRegistryEntry> = {
   monotony_interpretation: { compute: computeMonotonyInterpretation },
   strain: { compute: computeStrain },
   recovery_index: { compute: computeRecoveryIndex },
+  stress_tolerance: { compute: computeStressTolerance },
 };

--- a/packages/core/src/reference/metrics/registry.ts
+++ b/packages/core/src/reference/metrics/registry.ts
@@ -15,6 +15,7 @@ import {
   computeMonotony,
   computeMonotonyInterpretation,
   computePrimarySportMonotony,
+  computeRecoveryIndex,
   computeStrain,
 } from "./load-management.js";
 
@@ -29,4 +30,5 @@ export const METRIC_REGISTRY: Record<string, MetricRegistryEntry> = {
   effective_monotony: { compute: computeEffectiveMonotony },
   monotony_interpretation: { compute: computeMonotonyInterpretation },
   strain: { compute: computeStrain },
+  recovery_index: { compute: computeRecoveryIndex },
 };

--- a/packages/core/src/reference/metrics/registry.ts
+++ b/packages/core/src/reference/metrics/registry.ts
@@ -14,6 +14,7 @@ import {
   computeEffectiveMonotony,
   computeMonotony,
   computePrimarySportMonotony,
+  computeStrain,
 } from "./load-management.js";
 
 export interface MetricRegistryEntry {
@@ -25,4 +26,5 @@ export const METRIC_REGISTRY: Record<string, MetricRegistryEntry> = {
   monotony: { compute: computeMonotony },
   primary_sport_monotony: { compute: computePrimarySportMonotony },
   effective_monotony: { compute: computeEffectiveMonotony },
+  strain: { compute: computeStrain },
 };

--- a/tools/snapshot-section-11.README.md
+++ b/tools/snapshot-section-11.README.md
@@ -167,19 +167,25 @@ itself (the orchestrating method that wraps `_calculate_derived_metrics`)
 and are therefore **absent entirely** from this snapshot set, not merely
 null:
 
-- `ramp_rate` — derived by `collect_training_data` from wellness data
-  (api `rampRate` + decay smoothing, see `sync.py` around line 2399 and
-  the emit at line 2674). Bypassed by the direct-call path. Tracked as
-  a follow-up: the harness either needs to call `collect_training_data`
-  end-to-end (with a fixture-mapped `_intervals_get` stub) or expose
-  `ramp_rate` via an additional capture site.
+- `ramp_rate` — emitted by `collect_training_data` from wellness data
+  (intervals.icu's `rampRate` + decay smoothing, see `sync.py` around
+  line 2399 and the emit at line 2674). **Intentionally not captured.**
+  We decided not to port a `ramp_rate` metric at all: intervals.icu
+  computes the value server-side and hands it to us finished, so there
+  is no algorithm worth porting — the Reference layer consumes it
+  directly as `weeklyFitnessChange` (the renamed input field) where a
+  fitness-trend signal is needed. The harness deliberately stays
+  direct-call-only and does NOT drive `collect_training_data`
+  end-to-end. Decision recorded local-only; not a gap to close.
 
-These gaps are intentional for the first oracle pass. Future waves
-will either (a) extend the harness to invoke `collect_training_data`
-end-to-end with a richer fixture-mapped `_intervals_get` stub, or
-(b) extend the fixture format to ship pre-aggregated stream-derived
-inputs. The snapshot baseline locks in "given these inputs, these
-metrics are null" — which is itself a useful regression signal.
+These gaps are intentional for the first oracle pass. The null-valued
+inputs above (power/HR curves, `sustainability_curves`, `power_model`,
+`vo2max`, etc.) are deferred to the capability/stream wave, which will
+either extend the harness or extend the fixture format to supply them.
+The one absent-entirely entry, `ramp_rate`, is NOT such a gap — that
+metric is intentionally not ported (see above), so no harness extension
+is planned for it. The snapshot baseline locks in "given these inputs,
+these metrics are null" — which is itself a useful regression signal.
 
 ## Contract validation
 
@@ -259,10 +265,12 @@ scope.
 
 **Absent-from-output (1):**
 `ramp_rate`. Emitted only by `collect_training_data`, not by the
-direct-call path used here. F8 metric — needs the harness invocation
-path fix listed above before T12 can port it.
+direct-call path used here. **Intentionally not captured** — the
+`ramp_rate` metric is not ported (intervals.icu computes it; the
+Reference layer consumes `weeklyFitnessChange` directly). Not a gap
+to close; see "Known gaps" above.
 
-**F8 metric coverage (6 of 7 populated, 1 absent):**
+**F8 metric coverage (6 metrics — `ramp_rate` dropped, not ported):**
 
 | F8 metric | Status | Snapshot value |
 | --- | --- | --- |
@@ -272,7 +280,7 @@ path fix listed above before T12 can port it.
 | `recovery_index` | populated | 0.91 |
 | `stress_tolerance` | populated | 2.6 |
 | `load_recovery_ratio` | populated | 2.8 |
-| `ramp_rate` | **absent** | — (gap above) |
+| `ramp_rate` | **not ported** | — (sourced from intervals.icu) |
 
 ## Determinism
 


### PR DESCRIPTION
## Summary

Autonomous batch via the ralph loop (2-phase build/verify evaluator). Each task came from a frozen, human-authored queue (`.ralph/tasks.json`); a builder implemented it (metrics via `/port-metric`), and a separate fresh-context critic verified the diff against the task's verify commands, spec trace, and rubric. Each task was verified locally before merge into `ralph/queue` with `--no-ff`. This PR is the single human-review gate.

## Tasks shipped

### 1. port load-recovery ratio (reverted per T01)

- `computeLoadRecoveryRatio(input)` ported in `load-management.ts`, mirroring
  the upstream line `round(tss_7d_total / (ri * 100), 1) if ri and ri > 0 else
  None` (`sync.py:3135`) line-by-line. Reuses the already-ported
  `computeRecoveryIndex` for `ri` and the same trailing-7-day daily-Load sum
  (`getDailyLoad(...).reduce`) that ACWR/monotony/strain use for
  `tss_7d_total`; divides weekly Load by `ri × 100`, rounds half-to-even to 1
  dp. The guard `if (!ri || ri <= 0) return null;` mirrors `if ri and ri > 0`
  (`!ri` catches null/0, `ri <= 0` catches non-positive). [1a285da]
- Registered as `load_recovery_ratio: { compute: computeLoadRecoveryRatio }`
  in `METRIC_REGISTRY` (registry.ts); the Vitest parity matrix auto-fans-out
  the 3 fixtures. Done-when: "registered in METRIC_REGISTRY" ✓. [1a285da]
- Cascades Unknown from recovery_index (Done-when: "Unknown when ri is None or
  ≤ 0"): empty/wellness-free window ⇒ `computeRecoveryIndex` returns null ⇒
  `!ri` ⇒ `null`. Verified by the `new-athlete-empty` snapshot (null) and a
  focused unit test. [1a285da]
- `pnpm check-parity --metric=load_recovery_ratio --fixture=all` → 3/3 OK,
  exit 0 (`data-gap-mid-history` = 3.6, `new-athlete-empty` = null,
  `realistic-athlete` = 2.8), each flagged `(deviation: approved-revert)` —
  audit only; the TS is bit-identical to the upstream snapshot.
- `pnpm check-parity --all` → exit 0, 27/27 OK (9 metrics × 3 fixtures), no
  regression.
- 2 focused unit tests added to `load-management.test.ts` (ratio formula
  returns `weeklyLoad / (ri × 100)` = 1.8 for a worked example; recovery-index
  null ⇒ ratio null cascade even with weekly Load > 0). A `loadRecoveryInput`
  helper supplies both activities and wellness on one fixture.
- `.ralph/smoke.sh --fast` → exit 0 (703 core pass / 2 skipped; 82
  sport-cycling; trademark lint 58 files clean).


### 2. port the monotony interpretation band

- `computeMonotonyInterpretation(input)` ported in `load-management.ts`,
  mirroring the upstream interpretation branch line-by-line (`sync.py:3473-3491`,
  `_interpret_monotony`). Three inputs are the call-site locals at
  `sync.py:3362-3363`: total monotony (`computeMonotony`), effective monotony
  (`computeEffectiveMonotony`), and `is_multi_sport`
  (`getDailyLoadBySport(...).size > 1`, mirrors `len(daily_tss_by_sport) > 1`
  at sync.py:3081). Band logic: effective null ⇒ null; multi-sport inflation
  (multi-sport AND total truthy AND effective < total) ⇒ annotated
  "elevated/normal (primary sport X, total Y inflated by multi-sport)" by
  effective > 2.0; otherwise bare "elevated"/"normal" by effective > 2.0. [a95686e]
- Registered as `monotony_interpretation: { compute: computeMonotonyInterpretation }`
  in `METRIC_REGISTRY` (registry.ts); the Vitest parity matrix auto-fans-out the
  3 fixtures. [a95686e]
- Cascade satisfied (Done-when): effective monotony Unknown ⇒ interpretation
  Unknown. Verified by the `new-athlete-empty` snapshot (null) and a focused
  unit test. [a95686e]
- `pnpm check-parity --metric=monotony_interpretation --fixture=all` → 3/3 OK
  (exit 0): `data-gap-mid-history` ("elevated"), `new-athlete-empty` (null),
  `realistic-athlete` ("normal (primary sport 0.78, total 0.97 inflated by
  multi-sport)").
- `.ralph/smoke.sh --fast` → exit 0 (686 core pass / 2 skipped; 82 sport-cycling;
  trademark lint 58 files clean).
- No deviation: `monotony_interpretation` has no entry in
  `tools/intentional-deviations.yaml` and needs none — the TS is bit-identical
  to the upstream. Phase 4 decision tree not entered.


### 3. port recovery index (reverted per T01)

- `computeRecoveryIndex(input)` ported in `load-management.ts`, mirroring the
  upstream 7-day-baseline block + the recovery-index ratio line-by-line
  (`sync.py:3089-3115`) plus the HRV validity band (`sync.py:6225-6231`,
  `_is_valid_hrv`). Formula: `(latestHrv/hrvBaseline7d) / (latestRhr/rhrBaseline7d)`
  rounded half-to-even to 2 dp; `null` when any of the two latest readings or two
  baselines is missing/zero (the upstream truthiness guard). Two-contributor,
  7-day baseline per the `approved-revert` registry entry — NOT the rejected
  28-day / 4-contributor z-score. [5704e66]
- Reads `WellnessDay[]` (Done-when): new local `getWellnessWindow(input, 7)`
  helper builds the upstream `wellness_7d` slice — rows whose `id` date is in
  `[frozenNow-6, frozenNow]` inclusive, **in fixture order**, mirroring the
  harness `_within(_wellness_all, "id", ...)`. The recovery index reads the LAST
  row of that list (`wellness_7d[-1]`), not the chronologically latest — a focused
  unit test pins this order-preservation. [5704e66]
- Unknown when no wellness data (Done-when): empty/wellness-free window ⇒ empty
  baselines ⇒ guard fails ⇒ `null`. Verified by the `new-athlete-empty` snapshot
  (null) and a focused unit test. [5704e66]
- Registered as `recovery_index: { compute: computeRecoveryIndex }` in
  `METRIC_REGISTRY` (registry.ts); the Vitest parity matrix auto-fans-out the
  3 fixtures. [5704e66]
- `pnpm check-parity --metric=recovery_index --fixture=all` → 3/3 OK, exit 0
  (`data-gap-mid-history` = 1, `new-athlete-empty` = null, `realistic-athlete` =
  0.91), each flagged `(deviation: approved-revert)` (audit only — bit-identical
  to the upstream).
- `pnpm check-parity --all` → exit 0, 21/21 OK (7 metrics × 3 fixtures), no
  regression.
- 4 focused unit tests added to `load-management.test.ts` (ratio formula;
  no-wellness ⇒ null; out-of-band latest HRV ⇒ null; last-array-element-as-latest
  ordering). `.ralph/smoke.sh --fast` → exit 0 (693 core pass / 2 skipped;
  82 sport-cycling; trademark lint 58 files clean).


### 4. port the Foster strain metric

- `computeStrain(input)` ported in `load-management.ts` mirroring the upstream
  derived-metrics line `strain = round(tss_7d_total * monotony, 0) if monotony
  else None` (sync.py:3087) — weekly Load × total monotony, half-to-even round
  to whole number. Foster 1998 cited in JSDoc (DOI 10.1097/00005768-199807000-00023). [1429327]
- Registered as `strain: { compute: computeStrain }` in `METRIC_REGISTRY`
  (registry.ts); the Vitest parity matrix auto-fans-out the 3 new cases. [1429327]
- Cascade satisfied: monotony falsy (null/0) ⇒ strain null. Verified by the
  `new-athlete-empty` snapshot (monotony null ⇒ strain null) and a focused unit
  test in the new `load-management.test.ts`. [1429327]
- `pnpm check-parity --metric=strain --fixture=all` → 3/3 OK (exit 0):
  `data-gap-mid-history` (749), `new-athlete-empty` (null), `realistic-athlete` (249).
- No deviation: `strain` has no entry in `tools/intentional-deviations.yaml` and
  needs none — the TS is bit-identical to the upstream. Phase 4 tree not entered.


### 5. port stress tolerance (reverted per T01)

- `computeStressTolerance(input)` ported in `load-management.ts`, mirroring
  the upstream line `round((strain / monotony) / 100, 1) if strain and monotony
  else None` (`sync.py:3131`) line-by-line. Reuses the already-rounded
  `computeStrain` (`round(weeklyLoad × monotony, 0)`) and `computeMonotony`
  (`round(mean/stdev, 2)`) locals — the same two quantities the upstream
  `strain` (3087) and `monotony` (3037) locals carry — divides strain by
  monotony, scales by /100, rounds half-to-even to 1 dp. Returns `null`
  whenever either is falsy (`null` or `0`), the upstream `if strain and
  monotony` guard. [fb6d5a2]
- Registered as `stress_tolerance: { compute: computeStressTolerance }` in
  `METRIC_REGISTRY` (registry.ts); the Vitest parity matrix auto-fans-out the
  3 fixtures. Done-when: "registered in METRIC_REGISTRY" ✓. [fb6d5a2]
- Cascades Unknown from monotony (Done-when): monotony null/0 ⇒ `computeStrain`
  returns null ⇒ `!strain` ⇒ `null`. Verified by the `new-athlete-empty`
  snapshot (null) and a focused unit test. [fb6d5a2]
- `pnpm check-parity --metric=stress_tolerance --fixture=all` → 3/3 OK, exit 0
  (`data-gap-mid-history` = 3.6, `new-athlete-empty` = null, `realistic-athlete`
  = 2.6), each flagged `(deviation: approved-revert)` — audit only, the TS is
  bit-identical to the upstream snapshot.
- `pnpm check-parity --all` → exit 0, 24/24 OK (8 metrics × 3 fixtures), no
  regression. (WARN lists future-wave unregistered snapshots, incl.
  `load_recovery_ratio` — the next task — expected, not a failure.)
- 2 focused unit tests added to `load-management.test.ts` (ratio formula
  returns `(strain/monotony)/100`; no-activity ⇒ monotony null ⇒ strain null ⇒
  null cascade). `.ralph/smoke.sh --fast` → exit 0 (698 core pass / 2 skipped;
  82 sport-cycling; trademark lint 58 files clean).


## Test plan

- [x] Each iter's task Verify: commands exited 0 (per the verify phase)
- [x] `.ralph/smoke.sh` green after each merge into `ralph/queue`
- [x] No iter shipped with any rubric dimension < 3
- [x] No new `pending` entries in `tools/intentional-deviations.yaml`
