### PR TITLE
feat(core): port the Reference layer's intensity-distribution metrics

### DIFF
--- a/.changeset/reference-distribution-intensity-metrics.md
+++ b/.changeset/reference-distribution-intensity-metrics.md
@@ -1,0 +1,15 @@
+---
+"@enduragent/core": patch
+---
+
+User-facing: Training-intensity distribution is now computed in the reference layer — the 7-day zone breakdown, the grey-zone / quality-intensity / easy-time shares, and the Seiler 3-zone time-in-distribution (7-day and 28-day, all-sport and primary-sport) with the Treff polarization index and a polarized / pyramidal / threshold classification.
+
+- Added the distribution metrics to `packages/core/src/reference/metrics/distribution.ts` — line-by-line ports of `_get_activity_zones`, `_aggregate_zones`, `_aggregate_seiler_zones`, `_build_seiler_tid`, `_calculate_polarization_index`, and `_classify_tid` (`sync.py:3683-3993`). Seiler 3-zone intensity model per Seiler 2010 (Int J Sports Physiol Perform 5(3):276-291); polarization index per Treff et al.
+- All registered in `tools/check-metric-parity.ts`'s `METRIC_REGISTRY`; bit-identical against the oracle across the realistic-athlete + boundary fixtures (`pnpm check-parity --all` exits 0).
+- Bit-identity hardening on the load + distribution metrics:
+  - `roundHalfEven` rewritten as an exact dyadic-rational round (matches CPython `round()` on every boundary) and hoisted into one shared `metrics/rounding.ts` imported by both metric modules.
+  - `total_time` and `selectPrimarySport` now reproduce the oracle's grouped, Neumaier-compensated summation order instead of a flat accumulator, so a fractional `secs` can't drift a rounding boundary.
+  - `icu_zone_times` is constrained to object-form only; the HR-zone reader guards a non-numeric bin so a malformed array can't poison the zone sums.
+- Added a differential fuzz-parity harness (`tools/fuzz-parity.ts`) that runs randomized fixtures through both the oracle and the TS registry and fails on any divergence, vacuous run, oracle error, or contract violation.
+
+No deviations registered in `tools/intentional-deviations.yaml` — all faithful transliterations under the metric-porting discipline (literature-or-revert; no architect intuition).

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ CLAUDE.local.md
 .ralph/
 .specify/
 skills-lock.json
+# fuzz-parity divergence / oracle-error captures (dev-time only, never committed)
+packages/core/tests/fixtures/_fuzz-fail/

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "check:trademarks": "tsx tools/check-trademarks.ts",
     "release-version": "changeset version && tsx tools/bump-binaries-to-calver.ts",
     "snapshot:section-11": "tsx tools/snapshot-section-11.ts",
-    "check-parity": "tsx tools/check-metric-parity.ts"
+    "check-parity": "tsx tools/check-metric-parity.ts",
+    "fuzz-parity": "tsx tools/fuzz-parity.ts"
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.0",

--- a/packages/core/src/reference/index.ts
+++ b/packages/core/src/reference/index.ts
@@ -81,6 +81,8 @@ export {
   type ZoneTimes,
   ZoneTimeEntrySchema,
   type ZoneTimeEntry,
+  IcuZoneTimeEntrySchema,
+  type IcuZoneTimeEntry,
 } from "./schemas/index.js";
 
 // ─── Trademark policy + anti-corruption layer (ADR-0012) ──────────────

--- a/packages/core/src/reference/metrics/distribution.test.ts
+++ b/packages/core/src/reference/metrics/distribution.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+
+import { computeZoneDistribution7d } from "./distribution.js";
+import type { MetricInput } from "./metric-input.js";
+
+// The golden fixtures only exercise the power-zone and empty-window paths,
+// so these synthetic rows isolate the substrate branches the parity matrix
+// can't reach: HR fallback, mixed basis, no-zone-data, the z4+ fold, and
+// the trailing-window cutoff. `fixture` is typed `unknown` at the gate
+// boundary, so minimal rows — including the flat `icu_hr_zone_times` array
+// that isn't on the typed Activity surface — ride through untyped.
+function input(activities: unknown[], frozenNow: string): MetricInput {
+  return { fixture: { activities }, frozenNow };
+}
+
+const FROZEN = "2026-05-10T12:00:00";
+
+describe("computeZoneDistribution7d", () => {
+  it("sums power zones into hours and folds z4..z7 into z4_plus", () => {
+    // One in-window Ride: z1 3600, z2 3600, z3 1800, z4 600, z5 600.
+    // total 10200s. z4_plus = 600 + 600 = 1200s.
+    const result = computeZoneDistribution7d(
+      input(
+        [
+          {
+            type: "Ride",
+            start_date_local: "2026-05-09T08:00:00",
+            icu_zone_times: [
+              { id: "Z1", secs: 3600 },
+              { id: "Z2", secs: 3600 },
+              { id: "Z3", secs: 1800 },
+              { id: "Z4", secs: 600 },
+              { id: "Z5", secs: 600 },
+            ],
+          },
+        ],
+        FROZEN,
+      ),
+    );
+
+    expect(result).toEqual({
+      total_hours: 2.83, // 10200 / 3600 = 2.8333… → 2.83
+      z1_hours: 1,
+      z2_hours: 1,
+      z3_hours: 0.5,
+      z4_plus_hours: 0.33, // 1200 / 3600 = 0.3333… → 0.33
+      zone_basis: "power",
+    });
+  });
+
+  it("falls back to HR zones (flat seconds array) when no power zones", () => {
+    // icu_hr_zone_times is index-mapped to z1..z7; the 0-second bin is
+    // skipped. z1 720, z3 1800, z4 600 ⇒ total 3120s, z4_plus 600s.
+    const result = computeZoneDistribution7d(
+      input(
+        [
+          {
+            type: "Run",
+            start_date_local: "2026-05-08T08:00:00",
+            icu_hr_zone_times: [720, 0, 1800, 600],
+          },
+        ],
+        FROZEN,
+      ),
+    );
+
+    expect(result.zone_basis).toBe("hr");
+    expect(result.total_hours).toBe(0.87); // 3120 / 3600 = 0.8666… → 0.87
+    expect(result.z2_hours).toBe(0); // the 0-second z2 bin was skipped
+    expect(result.z4_plus_hours).toBe(0.17); // 600 / 3600 = 0.1666… → 0.17
+  });
+
+  it("reports mixed basis when power- and HR-based activities both contribute", () => {
+    const result = computeZoneDistribution7d(
+      input(
+        [
+          {
+            type: "Ride",
+            start_date_local: "2026-05-09T08:00:00",
+            icu_zone_times: [{ id: "Z2", secs: 3600 }],
+          },
+          {
+            type: "Run",
+            start_date_local: "2026-05-08T08:00:00",
+            icu_hr_zone_times: [3600],
+          },
+        ],
+        FROZEN,
+      ),
+    );
+
+    expect(result.zone_basis).toBe("mixed");
+    expect(result.total_hours).toBe(2); // 3600 + 3600 = 7200s = 2h
+  });
+
+  it("returns all-zero hours and null basis when no activity has zone data", () => {
+    const result = computeZoneDistribution7d(
+      input(
+        [
+          { type: "WeightTraining", start_date_local: "2026-05-09T08:00:00" },
+        ],
+        FROZEN,
+      ),
+    );
+
+    expect(result).toEqual({
+      total_hours: 0,
+      z1_hours: 0,
+      z2_hours: 0,
+      z3_hours: 0,
+      z4_plus_hours: 0,
+      zone_basis: null,
+    });
+  });
+
+  it("excludes activities outside the trailing 7-day window", () => {
+    // Window is 2026-05-04..2026-05-10. The 05-03 ride is one day too old.
+    const result = computeZoneDistribution7d(
+      input(
+        [
+          {
+            type: "Ride",
+            start_date_local: "2026-05-03T08:00:00",
+            icu_zone_times: [{ id: "Z2", secs: 3600 }],
+          },
+        ],
+        FROZEN,
+      ),
+    );
+
+    expect(result.total_hours).toBe(0);
+    expect(result.zone_basis).toBeNull();
+  });
+});

--- a/packages/core/src/reference/metrics/distribution.test.ts
+++ b/packages/core/src/reference/metrics/distribution.test.ts
@@ -490,6 +490,56 @@ describe("computeSeilerTid", () => {
     expect(result.z3_pct).toBe(20);
   });
 
+  it("pins the PI=2.0 knife-edge where log10 is the cross-runtime-fragile op", () => {
+    // These two rows sit just either side of the Polarized/Pyramidal line —
+    // the one place the metric depends on `Math.log10` matching the oracle's
+    // libm bit-for-bit (see the note at calculatePolarizationIndex). They pin
+    // the emitted PI so any future log10 reimplementation must be re-validated
+    // against the oracle here, not just on the boundary-dodging golden fixtures.
+
+    // Just below: SeilerZ1/Z2/Z3 = 8220/800/980, raw 100.695,
+    // log10 = 2.00300… → PI 2.0, not > 2.0 ⇒ Pyramidal.
+    const below = computeSeilerTid(
+      input(
+        [
+          {
+            type: "Ride",
+            start_date_local: "2026-05-09T08:00:00",
+            icu_zone_times: [
+              { id: "Z1", secs: 8220 },
+              { id: "Z3", secs: 800 },
+              { id: "Z4", secs: 980 },
+            ],
+          },
+        ],
+        FROZEN,
+      ),
+    );
+    expect(below.polarization_index).toBe(2);
+    expect(below.classification).toBe("Pyramidal");
+
+    // Just above: 8200/800/1000, raw 102.5, log10 = 2.01072… → PI 2.01 > 2.0
+    // ⇒ Polarized. A 1-ULP log10 disagreement near here would flip the label.
+    const above = computeSeilerTid(
+      input(
+        [
+          {
+            type: "Ride",
+            start_date_local: "2026-05-09T08:00:00",
+            icu_zone_times: [
+              { id: "Z1", secs: 8200 },
+              { id: "Z3", secs: 800 },
+              { id: "Z4", secs: 1000 },
+            ],
+          },
+        ],
+        FROZEN,
+      ),
+    );
+    expect(above.polarization_index).toBe(2.01);
+    expect(above.classification).toBe("Polarized");
+  });
+
   it("substitutes Z2=0 with 0.01 in the PI formula", () => {
     // SeilerZ1 = 8000, SeilerZ2 = 0, SeilerZ3 = 2000. fracs 0.8/0.0/0.20.
     // z1>z3>z2 (0.8>0.2>0); effective Z2 = 0.01.

--- a/packages/core/src/reference/metrics/distribution.test.ts
+++ b/packages/core/src/reference/metrics/distribution.test.ts
@@ -7,6 +7,7 @@ import {
   computeGreyZonePercentage,
   computeQualityIntensityNote,
   computeQualityIntensityPercentage,
+  computeSeilerTid,
   computeZoneDistribution7d,
 } from "./distribution.js";
 import type { MetricInput } from "./metric-input.js";
@@ -352,5 +353,218 @@ describe("computeEasyTimeRatioNote", () => {
     expect(computeEasyTimeRatioNote()).toBe(
       "Easy time (Z1+Z2) / Total - target ~80% in polarized training",
     );
+  });
+});
+
+describe("computeSeilerTid", () => {
+  // The seven-zone fold into Seiler's model: SeilerZ1 = z1+z2,
+  // SeilerZ2 = z3, SeilerZ3 = z4+z5+z6+z7. The golden fixtures only land
+  // the Pyramidal-with-null-PI branch; these synthetic rows isolate the
+  // classification and polarization-index branches the parity matrix can't
+  // reach.
+
+  it("folds seven zones into the Seiler 3-zone model and classifies Pyramidal (PI null)", () => {
+    // SeilerZ1 = 5000+1000 = 6000, SeilerZ2 = 3000, SeilerZ3 = 1000.
+    // total 10000 ⇒ fracs 0.6/0.3/0.1. z1>z2>z3 ⇒ Pyramidal. PI null
+    // because the polarized gate (z1>z3>z2) fails (z3 0.1 < z2 0.3).
+    const result = computeSeilerTid(
+      input(
+        [
+          {
+            type: "Ride",
+            start_date_local: "2026-05-09T08:00:00",
+            icu_zone_times: [
+              { id: "Z1", secs: 5000 },
+              { id: "Z2", secs: 1000 },
+              { id: "Z3", secs: 3000 },
+              { id: "Z4", secs: 1000 },
+            ],
+          },
+        ],
+        FROZEN,
+      ),
+    );
+
+    expect(result).toEqual({
+      z1_seconds: 6000,
+      z2_seconds: 3000,
+      z3_seconds: 1000,
+      z1_pct: 60,
+      z2_pct: 30,
+      z3_pct: 10,
+      polarization_index: null,
+      classification: "Pyramidal",
+      zone_basis: "power",
+    });
+  });
+
+  it("computes the Treff polarization index and classifies Polarized when Z1>Z3>Z2 and PI>2.0", () => {
+    // SeilerZ1 = 7500, SeilerZ2 = 500, SeilerZ3 = 2000. fracs 0.75/0.05/0.20.
+    // PI = log10((0.75/0.05) × 0.20 × 100) = log10(300) = 2.48 > 2.0.
+    const result = computeSeilerTid(
+      input(
+        [
+          {
+            type: "Ride",
+            start_date_local: "2026-05-09T08:00:00",
+            icu_zone_times: [
+              { id: "Z1", secs: 7500 },
+              { id: "Z3", secs: 500 },
+              { id: "Z4", secs: 2000 },
+            ],
+          },
+        ],
+        FROZEN,
+      ),
+    );
+
+    expect(result.polarization_index).toBe(2.48);
+    expect(result.classification).toBe("Polarized");
+    expect(result.z1_pct).toBe(75);
+    expect(result.z2_pct).toBe(5);
+    expect(result.z3_pct).toBe(20);
+  });
+
+  it("substitutes Z2=0 with 0.01 in the PI formula", () => {
+    // SeilerZ1 = 8000, SeilerZ2 = 0, SeilerZ3 = 2000. fracs 0.8/0.0/0.20.
+    // z1>z3>z2 (0.8>0.2>0); effective Z2 = 0.01.
+    // PI = log10((0.8/0.01) × 0.20 × 100) = log10(1600) = 3.2 > 2.0.
+    const result = computeSeilerTid(
+      input(
+        [
+          {
+            type: "Ride",
+            start_date_local: "2026-05-09T08:00:00",
+            icu_zone_times: [
+              { id: "Z1", secs: 8000 },
+              { id: "Z4", secs: 2000 },
+            ],
+          },
+        ],
+        FROZEN,
+      ),
+    );
+
+    expect(result.z2_seconds).toBe(0);
+    expect(result.z2_pct).toBe(0);
+    expect(result.polarization_index).toBe(3.2);
+    expect(result.classification).toBe("Polarized");
+  });
+
+  it("falls back to Pyramidal when the structure is polarized but PI <= 2.0", () => {
+    // SeilerZ1 = 5000, SeilerZ2 = 2000, SeilerZ3 = 3000. fracs 0.5/0.2/0.3.
+    // z1>z3>z2 so the PI gate opens; PI = log10((0.5/0.2) × 0.3 × 100) =
+    // log10(75) = 1.88 ≤ 2.0, so not Polarized. Pyramidal needs z1>z2>z3
+    // (fails: z3 0.3 > z2 0.2), and Z2/Z3 aren't dominant ⇒ final fallback.
+    const result = computeSeilerTid(
+      input(
+        [
+          {
+            type: "Ride",
+            start_date_local: "2026-05-09T08:00:00",
+            icu_zone_times: [
+              { id: "Z1", secs: 5000 },
+              { id: "Z3", secs: 2000 },
+              { id: "Z4", secs: 3000 },
+            ],
+          },
+        ],
+        FROZEN,
+      ),
+    );
+
+    expect(result.polarization_index).toBe(1.88);
+    expect(result.classification).toBe("Pyramidal");
+  });
+
+  it("classifies Base when Z3 is near zero and Z1 dominates", () => {
+    // SeilerZ1 = 9900, SeilerZ2 = 100, SeilerZ3 = 0. fracs 0.99/0.01/0.0.
+    // z3_frac 0 < 0.01 and z1 dominant ⇒ Base; PI null (z3 < 0.01).
+    const result = computeSeilerTid(
+      input(
+        [
+          {
+            type: "Ride",
+            start_date_local: "2026-05-09T08:00:00",
+            icu_zone_times: [
+              { id: "Z1", secs: 9900 },
+              { id: "Z3", secs: 100 },
+            ],
+          },
+        ],
+        FROZEN,
+      ),
+    );
+
+    expect(result.classification).toBe("Base");
+    expect(result.polarization_index).toBeNull();
+    expect(result.z3_seconds).toBe(0);
+  });
+
+  it("classifies Threshold when Seiler Z2 (tempo) dominates", () => {
+    // SeilerZ1 = 2000, SeilerZ2 = 6000, SeilerZ3 = 2000. fracs 0.2/0.6/0.2.
+    const result = computeSeilerTid(
+      input(
+        [
+          {
+            type: "Ride",
+            start_date_local: "2026-05-09T08:00:00",
+            icu_zone_times: [
+              { id: "Z1", secs: 2000 },
+              { id: "Z3", secs: 6000 },
+              { id: "Z4", secs: 2000 },
+            ],
+          },
+        ],
+        FROZEN,
+      ),
+    );
+
+    expect(result.classification).toBe("Threshold");
+    expect(result.polarization_index).toBeNull();
+  });
+
+  it("classifies High Intensity when Seiler Z3 (hard) dominates", () => {
+    // SeilerZ1 = 2000, SeilerZ2 = 2000, SeilerZ3 = 6000. fracs 0.2/0.2/0.6.
+    const result = computeSeilerTid(
+      input(
+        [
+          {
+            type: "Ride",
+            start_date_local: "2026-05-09T08:00:00",
+            icu_zone_times: [
+              { id: "Z1", secs: 2000 },
+              { id: "Z3", secs: 2000 },
+              { id: "Z4", secs: 6000 },
+            ],
+          },
+        ],
+        FROZEN,
+      ),
+    );
+
+    expect(result.classification).toBe("High Intensity");
+    expect(result.polarization_index).toBeNull();
+  });
+
+  it("returns zero seconds and null fields when total zone time is zero", () => {
+    const result = computeSeilerTid(
+      input(
+        [{ type: "WeightTraining", start_date_local: "2026-05-09T08:00:00" }],
+        FROZEN,
+      ),
+    );
+
+    expect(result).toEqual({
+      z1_seconds: 0,
+      z2_seconds: 0,
+      z3_seconds: 0,
+      z1_pct: null,
+      z2_pct: null,
+      z3_pct: null,
+      polarization_index: null,
+      classification: null,
+      zone_basis: null,
+    });
   });
 });

--- a/packages/core/src/reference/metrics/distribution.test.ts
+++ b/packages/core/src/reference/metrics/distribution.test.ts
@@ -82,6 +82,32 @@ describe("computeZoneDistribution7d", () => {
     expect(result.z4_plus_hours).toBe(0.17); // 600 / 3600 = 0.1666… → 0.17
   });
 
+  it("drops a non-numeric icu_hr_zone_times bin instead of poisoning the zone sum", () => {
+    // icu_hr_zone_times rides through unschematized (it isn't on the typed
+    // Activity surface), so a malformed string bin can reach the reader. The
+    // guard coerces it to 0 and skips it; without the guard `z2Time += "bad"`
+    // would string-concat and NaN the total. The upstream keeps the string
+    // and raises on the sum, so this input can't be captured by the gate.
+    const result = computeZoneDistribution7d(
+      input(
+        [
+          {
+            type: "Run",
+            start_date_local: "2026-05-08T08:00:00",
+            icu_hr_zone_times: [720, "bad", 1800],
+          },
+        ],
+        FROZEN,
+      ),
+    );
+
+    expect(result.zone_basis).toBe("hr");
+    expect(result.z1_hours).toBe(0.2); // 720 / 3600
+    expect(result.z2_hours).toBe(0); // the "bad" bin coerced to 0 and skipped
+    expect(result.z3_hours).toBe(0.5); // 1800 / 3600
+    expect(result.total_hours).toBe(0.7); // (720 + 1800) / 3600 — no string poison
+  });
+
   it("reports mixed basis and places each activity's zones correctly", () => {
     // Power Ride contributes Z2; HR Run's flat array maps index 0 → z1. The
     // per-zone assertions pin the HR index→zone mapping: an off-by-one that

--- a/packages/core/src/reference/metrics/distribution.test.ts
+++ b/packages/core/src/reference/metrics/distribution.test.ts
@@ -8,6 +8,7 @@ import {
   computeQualityIntensityNote,
   computeQualityIntensityPercentage,
   computeSeilerTid,
+  computeSeilerTidPrimary,
   computeZoneDistribution7d,
 } from "./distribution.js";
 import type { MetricInput } from "./metric-input.js";
@@ -566,5 +567,134 @@ describe("computeSeilerTid", () => {
       classification: null,
       zone_basis: null,
     });
+  });
+});
+
+describe("computeSeilerTidPrimary", () => {
+  // The golden fixtures are cycling-only, so the sport-family filter is a
+  // no-op there and the primary variant equals the all-sport one (plus the
+  // sport key). These synthetic rows isolate the multi-sport branches the
+  // parity matrix can't reach: primary selection by Load, the filter
+  // excluding non-primary activities, the insertion-order tiebreak, and the
+  // null path when no activity carries Load.
+
+  it("restricts aggregation to the highest-Load family and appends its name as sport", () => {
+    // Cycling Load 100 > Run Load 50 ⇒ primary = cycling. Only the ride
+    // enters the aggregation; the run's all-hard HR zones (which would push
+    // SeilerZ3 to 9000 and flip the basis to mixed) are excluded. SeilerZ1
+    // = 5000+1000, SeilerZ2 = 3000, SeilerZ3 = 1000 ⇒ 0.6/0.3/0.1 Pyramidal.
+    const result = computeSeilerTidPrimary(
+      input(
+        [
+          {
+            type: "Ride",
+            icu_training_load: 100,
+            start_date_local: "2026-05-09T08:00:00",
+            icu_zone_times: [
+              { id: "Z1", secs: 5000 },
+              { id: "Z2", secs: 1000 },
+              { id: "Z3", secs: 3000 },
+              { id: "Z4", secs: 1000 },
+            ],
+          },
+          {
+            type: "Run",
+            icu_training_load: 50,
+            start_date_local: "2026-05-08T08:00:00",
+            icu_hr_zone_times: [0, 0, 0, 9000],
+          },
+        ],
+        FROZEN,
+      ),
+    );
+
+    expect(result).toEqual({
+      z1_seconds: 6000,
+      z2_seconds: 3000,
+      z3_seconds: 1000,
+      z1_pct: 60,
+      z2_pct: 30,
+      z3_pct: 10,
+      polarization_index: null,
+      classification: "Pyramidal",
+      zone_basis: "power",
+      sport: "cycling",
+    });
+  });
+
+  it("breaks a Load tie in favour of the first-encountered family", () => {
+    // Run and Ride both carry Load 100. `max(sport_totals, key=...)` returns
+    // the first key at the maximum in insertion order, so the run (listed
+    // first) wins. Only its HR zones enter: SeilerZ1 = 6000+3000, SeilerZ2 =
+    // 1000, SeilerZ3 = 0 ⇒ 0.9/0.1/0.0 ⇒ Base; sport "run", basis "hr".
+    const result = computeSeilerTidPrimary(
+      input(
+        [
+          {
+            type: "Run",
+            icu_training_load: 100,
+            start_date_local: "2026-05-08T08:00:00",
+            icu_hr_zone_times: [6000, 3000, 1000],
+          },
+          {
+            type: "Ride",
+            icu_training_load: 100,
+            start_date_local: "2026-05-09T08:00:00",
+            icu_zone_times: [{ id: "Z4", secs: 9000 }],
+          },
+        ],
+        FROZEN,
+      ),
+    );
+
+    expect(result?.sport).toBe("run");
+    expect(result?.zone_basis).toBe("hr");
+    expect(result?.classification).toBe("Base");
+    expect(result?.z3_seconds).toBe(0);
+  });
+
+  it("returns null when no in-window activity carries Load (even with zone data)", () => {
+    // Zone data is present but Load is 0, so the upstream `primary_sport`
+    // stays None and the variant is never built — null, unlike the all-sport
+    // metric which would still aggregate the zone time.
+    const rows = [
+      {
+        type: "Ride",
+        icu_training_load: 0,
+        start_date_local: "2026-05-09T08:00:00",
+        icu_zone_times: [{ id: "Z1", secs: 3600 }],
+      },
+    ];
+
+    expect(computeSeilerTidPrimary(input(rows, FROZEN))).toBeNull();
+    // The all-sport variant still has data — confirming the null is the
+    // primary-sport gate, not an empty window.
+    expect(computeSeilerTid(input(rows, FROZEN)).z1_seconds).toBe(3600);
+  });
+
+  it("equals the all-sport build plus the sport key for a single-family window", () => {
+    const rows = [
+      {
+        type: "Ride",
+        icu_training_load: 80,
+        start_date_local: "2026-05-09T08:00:00",
+        icu_zone_times: [
+          { id: "Z1", secs: 5000 },
+          { id: "Z3", secs: 3000 },
+          { id: "Z4", secs: 2000 },
+        ],
+      },
+      {
+        type: "VirtualRide",
+        icu_training_load: 40,
+        start_date_local: "2026-05-08T08:00:00",
+        icu_zone_times: [{ id: "Z2", secs: 1000 }],
+      },
+    ];
+
+    const all = computeSeilerTid(input(rows, FROZEN));
+    const primary = computeSeilerTidPrimary(input(rows, FROZEN));
+
+    expect(primary).toEqual({ ...all, sport: "cycling" });
   });
 });

--- a/packages/core/src/reference/metrics/distribution.test.ts
+++ b/packages/core/src/reference/metrics/distribution.test.ts
@@ -82,7 +82,12 @@ describe("computeZoneDistribution7d", () => {
     expect(result.z4_plus_hours).toBe(0.17); // 600 / 3600 = 0.1666… → 0.17
   });
 
-  it("reports mixed basis when power- and HR-based activities both contribute", () => {
+  it("reports mixed basis and places each activity's zones correctly", () => {
+    // Power Ride contributes Z2; HR Run's flat array maps index 0 → z1. The
+    // per-zone assertions pin the HR index→zone mapping: an off-by-one that
+    // mapped index 0 → z2 would leave total_hours=2 and zone_basis="mixed"
+    // unchanged (z2 would just become 2h, z1 0h), so total/basis alone can't
+    // catch it.
     const result = computeZoneDistribution7d(
       input(
         [
@@ -101,8 +106,44 @@ describe("computeZoneDistribution7d", () => {
       ),
     );
 
-    expect(result.zone_basis).toBe("mixed");
-    expect(result.total_hours).toBe(2); // 3600 + 3600 = 7200s = 2h
+    expect(result).toEqual({
+      total_hours: 2, // 3600 (power Z2) + 3600 (HR z1) = 7200s = 2h
+      z1_hours: 1, // HR Run, flat-array index 0 → z1
+      z2_hours: 1, // power Ride Z2
+      z3_hours: 0,
+      z4_plus_hours: 0,
+      zone_basis: "mixed",
+    });
+  });
+
+  it("prefers power zones over HR when a single activity carries both", () => {
+    // A dual-recorded Ride with both icu_zone_times (power) and
+    // icu_hr_zone_times (HR). The default preference is power-first, so the
+    // power Z2 is used and the HR array is ignored — basis "power", not "hr".
+    // Flipping the preference order (returning HR when power also exists)
+    // would surface here as basis "hr" and z1 0.5h instead.
+    const result = computeZoneDistribution7d(
+      input(
+        [
+          {
+            type: "Ride",
+            start_date_local: "2026-05-09T08:00:00",
+            icu_zone_times: [{ id: "Z2", secs: 3600 }],
+            icu_hr_zone_times: [1800], // index 0 → z1; ignored when power wins
+          },
+        ],
+        FROZEN,
+      ),
+    );
+
+    expect(result).toEqual({
+      total_hours: 1, // only the power Z2 (3600s); the HR 1800s is not counted
+      z1_hours: 0,
+      z2_hours: 1,
+      z3_hours: 0,
+      z4_plus_hours: 0,
+      zone_basis: "power",
+    });
   });
 
   it("returns all-zero hours and null basis when no activity has zone data", () => {
@@ -299,26 +340,47 @@ describe("computeEasyTimeRatio", () => {
     expect(result).toBe(0.71);
   });
 
-  it("rounds half-to-even at the 2-dp boundary like Python's round", () => {
-    // easy 1250s, total 5000s ⇒ 0.25 exactly — no boundary. Use easy 1500s,
-    // total 4000s ⇒ 0.375 → round(0.375, 2) half-to-even = 0.38.
-    const result = computeEasyTimeRatio(
+  it("rounds half-to-even on the true value at the 2-dp boundary like Python's round", () => {
+    // easy 500s / total 4000s = 0.125 exactly: an even-floor tie that rounds
+    // DOWN to 0.12 (round-half-away would give 0.13). 0.375 — the prior
+    // fixture here — has an odd floor, so half-even and half-away agree and it
+    // could not discriminate the rounding mode.
+    const evenTieDown = computeEasyTimeRatio(
       input(
         [
           {
             type: "Ride",
             start_date_local: "2026-05-09T08:00:00",
             icu_zone_times: [
-              { id: "Z1", secs: 1500 },
-              { id: "Z4", secs: 2500 },
+              { id: "Z1", secs: 500 },
+              { id: "Z4", secs: 3500 },
             ],
           },
         ],
         FROZEN,
       ),
     );
+    expect(evenTieDown).toBe(0.12);
 
-    expect(result).toBe(0.38);
+    // easy 18s / total 3600s = 0.005: the nearest double is 0.005000…0104,
+    // strictly above 0.005, so Python rounds UP to 0.01. Scaling by 100 first
+    // gave 0.4999…94 and rounded to 0 — the bug this pins.
+    const aboveHalfBoundary = computeEasyTimeRatio(
+      input(
+        [
+          {
+            type: "Ride",
+            start_date_local: "2026-05-09T08:00:00",
+            icu_zone_times: [
+              { id: "Z1", secs: 18 },
+              { id: "Z4", secs: 3582 },
+            ],
+          },
+        ],
+        FROZEN,
+      ),
+    );
+    expect(aboveHalfBoundary).toBe(0.01);
   });
 
   it("returns null when no activity has zone time", () => {

--- a/packages/core/src/reference/metrics/distribution.test.ts
+++ b/packages/core/src/reference/metrics/distribution.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  computeEasyTimeRatio,
+  computeEasyTimeRatioNote,
   computeGreyZoneNote,
   computeGreyZonePercentage,
   computeQualityIntensityNote,
@@ -263,6 +265,92 @@ describe("computeQualityIntensityNote", () => {
   it("returns the static polarized-training note constant", () => {
     expect(computeQualityIntensityNote()).toBe(
       "Quality Intensity % (Z4+/threshold+) - target ~20% in polarized training",
+    );
+  });
+});
+
+describe("computeEasyTimeRatio", () => {
+  it("returns the (Z1+Z2) share of total zone time as a bare ratio, rounded to 2 dp", () => {
+    // z1 3600, z2 3600, z3 1800, z4 600, z5 600 ⇒ total 10200s,
+    // easy 7200s. ratio 7200 / 10200 = 0.70588… → round(…, 2) = 0.71.
+    const result = computeEasyTimeRatio(
+      input(
+        [
+          {
+            type: "Ride",
+            start_date_local: "2026-05-09T08:00:00",
+            icu_zone_times: [
+              { id: "Z1", secs: 3600 },
+              { id: "Z2", secs: 3600 },
+              { id: "Z3", secs: 1800 },
+              { id: "Z4", secs: 600 },
+              { id: "Z5", secs: 600 },
+            ],
+          },
+        ],
+        FROZEN,
+      ),
+    );
+
+    expect(result).toBe(0.71);
+  });
+
+  it("rounds half-to-even at the 2-dp boundary like Python's round", () => {
+    // easy 1250s, total 5000s ⇒ 0.25 exactly — no boundary. Use easy 1500s,
+    // total 4000s ⇒ 0.375 → round(0.375, 2) half-to-even = 0.38.
+    const result = computeEasyTimeRatio(
+      input(
+        [
+          {
+            type: "Ride",
+            start_date_local: "2026-05-09T08:00:00",
+            icu_zone_times: [
+              { id: "Z1", secs: 1500 },
+              { id: "Z4", secs: 2500 },
+            ],
+          },
+        ],
+        FROZEN,
+      ),
+    );
+
+    expect(result).toBe(0.38);
+  });
+
+  it("returns null when no activity has zone time", () => {
+    const result = computeEasyTimeRatio(
+      input(
+        [{ type: "WeightTraining", start_date_local: "2026-05-09T08:00:00" }],
+        FROZEN,
+      ),
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when the window is empty", () => {
+    // The only ride is one day older than the trailing 7-day window.
+    const result = computeEasyTimeRatio(
+      input(
+        [
+          {
+            type: "Ride",
+            start_date_local: "2026-05-03T08:00:00",
+            icu_zone_times: [{ id: "Z1", secs: 3600 }],
+          },
+        ],
+        FROZEN,
+      ),
+    );
+
+    expect(result).toBeNull();
+  });
+});
+
+describe("computeEasyTimeRatioNote", () => {
+  it("returns the static polarized-training note constant", () => {
+    expect(computeEasyTimeRatioNote()).toBe(
+      "Easy time (Z1+Z2) / Total - target ~80% in polarized training",
     );
   });
 });

--- a/packages/core/src/reference/metrics/distribution.test.ts
+++ b/packages/core/src/reference/metrics/distribution.test.ts
@@ -8,6 +8,7 @@ import {
   computeQualityIntensityNote,
   computeQualityIntensityPercentage,
   computeSeilerTid,
+  computeSeilerTid28d,
   computeSeilerTidPrimary,
   computeZoneDistribution7d,
 } from "./distribution.js";
@@ -696,5 +697,89 @@ describe("computeSeilerTidPrimary", () => {
     const primary = computeSeilerTidPrimary(input(rows, FROZEN));
 
     expect(primary).toEqual({ ...all, sport: "cycling" });
+  });
+});
+
+describe("computeSeilerTid28d", () => {
+  // The golden fixtures are cycling-only, so the parity matrix already
+  // exercises the 28d window against the snapshot. These synthetic rows
+  // isolate the one thing that distinguishes this from the 7d variant: the
+  // wider aggregation window. The Seiler fold / PI / classifier logic is the
+  // shared `buildSeilerTid` substrate already covered by `computeSeilerTid`.
+
+  it("aggregates an activity that falls outside the 7d window but inside 28d", () => {
+    // FROZEN 2026-05-10: the 7d window is [05-04, 05-10], the 28d window is
+    // [04-13, 05-10]. The 04-25 ride is too old for 7d but in-window for 28d.
+    // SeilerZ1 = 5000+1000 = 6000, SeilerZ2 = 3000, SeilerZ3 = 1000.
+    // total 10000 ⇒ 0.6/0.3/0.1 ⇒ Pyramidal, PI null.
+    const rows = [
+      {
+        type: "Ride",
+        start_date_local: "2026-04-25T08:00:00",
+        icu_zone_times: [
+          { id: "Z1", secs: 5000 },
+          { id: "Z2", secs: 1000 },
+          { id: "Z3", secs: 3000 },
+          { id: "Z4", secs: 1000 },
+        ],
+      },
+    ];
+
+    expect(computeSeilerTid28d(input(rows, FROZEN))).toEqual({
+      z1_seconds: 6000,
+      z2_seconds: 3000,
+      z3_seconds: 1000,
+      z1_pct: 60,
+      z2_pct: 30,
+      z3_pct: 10,
+      polarization_index: null,
+      classification: "Pyramidal",
+      zone_basis: "power",
+    });
+    // The same row is empty for the 7d builder — confirming the only
+    // difference is the window, not the aggregation.
+    expect(computeSeilerTid(input(rows, FROZEN)).z1_seconds).toBe(0);
+  });
+
+  it("excludes activities older than the trailing 28-day window", () => {
+    // 04-12 is one day older than the 28d window [04-13, 05-10].
+    const result = computeSeilerTid28d(
+      input(
+        [
+          {
+            type: "Ride",
+            start_date_local: "2026-04-12T08:00:00",
+            icu_zone_times: [{ id: "Z2", secs: 3600 }],
+          },
+        ],
+        FROZEN,
+      ),
+    );
+
+    expect(result.z1_seconds).toBe(0);
+    expect(result.z2_seconds).toBe(0);
+    expect(result.z3_seconds).toBe(0);
+    expect(result.zone_basis).toBeNull();
+  });
+
+  it("returns zero seconds and null fields when total zone time is zero", () => {
+    const result = computeSeilerTid28d(
+      input(
+        [{ type: "WeightTraining", start_date_local: "2026-04-25T08:00:00" }],
+        FROZEN,
+      ),
+    );
+
+    expect(result).toEqual({
+      z1_seconds: 0,
+      z2_seconds: 0,
+      z3_seconds: 0,
+      z1_pct: null,
+      z2_pct: null,
+      z3_pct: null,
+      polarization_index: null,
+      classification: null,
+      zone_basis: null,
+    });
   });
 });

--- a/packages/core/src/reference/metrics/distribution.test.ts
+++ b/packages/core/src/reference/metrics/distribution.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from "vitest";
 import {
   computeGreyZoneNote,
   computeGreyZonePercentage,
+  computeQualityIntensityNote,
+  computeQualityIntensityPercentage,
   computeZoneDistribution7d,
 } from "./distribution.js";
 import type { MetricInput } from "./metric-input.js";
@@ -196,6 +198,71 @@ describe("computeGreyZoneNote", () => {
   it("returns the static polarized-training note constant", () => {
     expect(computeGreyZoneNote()).toBe(
       "Gray Zone % (Z3/tempo) - minimize in polarized training",
+    );
+  });
+});
+
+describe("computeQualityIntensityPercentage", () => {
+  it("returns the Z4+ share of total zone time, rounded to 1 dp", () => {
+    // z1 3600, z2 3600, z3 1800, z4 600, z5 600 ⇒ total 10200s,
+    // z4_plus 1200s. share 1200 / 10200 = 0.117647… → 11.7647% →
+    // round(11.7647, 1) = 11.8.
+    const result = computeQualityIntensityPercentage(
+      input(
+        [
+          {
+            type: "Ride",
+            start_date_local: "2026-05-09T08:00:00",
+            icu_zone_times: [
+              { id: "Z1", secs: 3600 },
+              { id: "Z2", secs: 3600 },
+              { id: "Z3", secs: 1800 },
+              { id: "Z4", secs: 600 },
+              { id: "Z5", secs: 600 },
+            ],
+          },
+        ],
+        FROZEN,
+      ),
+    );
+
+    expect(result).toBe(11.8);
+  });
+
+  it("returns null when no activity has zone time", () => {
+    const result = computeQualityIntensityPercentage(
+      input(
+        [{ type: "WeightTraining", start_date_local: "2026-05-09T08:00:00" }],
+        FROZEN,
+      ),
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when the window is empty", () => {
+    // The only ride is one day older than the trailing 7-day window.
+    const result = computeQualityIntensityPercentage(
+      input(
+        [
+          {
+            type: "Ride",
+            start_date_local: "2026-05-03T08:00:00",
+            icu_zone_times: [{ id: "Z4", secs: 3600 }],
+          },
+        ],
+        FROZEN,
+      ),
+    );
+
+    expect(result).toBeNull();
+  });
+});
+
+describe("computeQualityIntensityNote", () => {
+  it("returns the static polarized-training note constant", () => {
+    expect(computeQualityIntensityNote()).toBe(
+      "Quality Intensity % (Z4+/threshold+) - target ~20% in polarized training",
     );
   });
 });

--- a/packages/core/src/reference/metrics/distribution.test.ts
+++ b/packages/core/src/reference/metrics/distribution.test.ts
@@ -9,6 +9,7 @@ import {
   computeQualityIntensityPercentage,
   computeSeilerTid,
   computeSeilerTid28d,
+  computeSeilerTid28dPrimary,
   computeSeilerTidPrimary,
   computeZoneDistribution7d,
 } from "./distribution.js";
@@ -781,5 +782,112 @@ describe("computeSeilerTid28d", () => {
       classification: null,
       zone_basis: null,
     });
+  });
+});
+
+describe("computeSeilerTid28dPrimary", () => {
+  // The golden fixtures are cycling-only, so the parity matrix already
+  // exercises this against the snapshot. These synthetic rows isolate the two
+  // things that distinguish it from its siblings: (1) the primary family is
+  // chosen from the 7d window (like the 7d-primary variant) while the Seiler
+  // fold runs over the wider 28d window (like the 28d all-sport variant), and
+  // (2) the family filter still excludes non-primary activities.
+
+  it("selects the primary family from the 7d window, then aggregates it over 28d", () => {
+    // FROZEN 2026-05-10: 7d window [05-04, 05-10], 28d window [04-13, 05-10].
+    // 7d Load: cycling 100 > run 50 ⇒ primary = cycling. The 28d build then
+    // pulls in the 04-25 ride (cycling, outside 7d but inside 28d) and excludes
+    // the 04-24 run. Cycling zones: Z1 2000 + (Z1 4000, Z3 3000, Z4 1000) ⇒
+    // SeilerZ1 6000, SeilerZ2 3000, SeilerZ3 1000 ⇒ 0.6/0.3/0.1 Pyramidal.
+    const rows = [
+      {
+        type: "Ride",
+        icu_training_load: 100,
+        start_date_local: "2026-05-09T08:00:00",
+        icu_zone_times: [{ id: "Z1", secs: 2000 }],
+      },
+      {
+        type: "Run",
+        icu_training_load: 50,
+        start_date_local: "2026-05-08T08:00:00",
+        icu_hr_zone_times: [0, 0, 0, 9000],
+      },
+      {
+        type: "Ride",
+        icu_training_load: 0,
+        start_date_local: "2026-04-25T08:00:00",
+        icu_zone_times: [
+          { id: "Z1", secs: 4000 },
+          { id: "Z3", secs: 3000 },
+          { id: "Z4", secs: 1000 },
+        ],
+      },
+      {
+        type: "Run",
+        icu_training_load: 0,
+        start_date_local: "2026-04-24T08:00:00",
+        icu_hr_zone_times: [0, 0, 0, 9000],
+      },
+    ];
+
+    expect(computeSeilerTid28dPrimary(input(rows, FROZEN))).toEqual({
+      z1_seconds: 6000,
+      z2_seconds: 3000,
+      z3_seconds: 1000,
+      z1_pct: 60,
+      z2_pct: 30,
+      z3_pct: 10,
+      polarization_index: null,
+      classification: "Pyramidal",
+      zone_basis: "power",
+      sport: "cycling",
+    });
+    // The 7d-primary variant sees only the 05-09 ride for cycling ⇒ all Z1.
+    expect(computeSeilerTidPrimary(input(rows, FROZEN))?.z1_seconds).toBe(2000);
+  });
+
+  it("returns null when the 7d window carries no Load, even if the 28d window does", () => {
+    // The only ride is at 04-25 — inside the 28d window but outside the 7d
+    // window. `primary_sport` derives from `activities_7d`, which is empty, so
+    // it stays None and the variant is never built.
+    const rows = [
+      {
+        type: "Ride",
+        icu_training_load: 100,
+        start_date_local: "2026-04-25T08:00:00",
+        icu_zone_times: [{ id: "Z1", secs: 3600 }],
+      },
+    ];
+
+    expect(computeSeilerTid28dPrimary(input(rows, FROZEN))).toBeNull();
+    // The 28d all-sport variant still aggregates it — confirming the null is
+    // the 7d-derived primary-sport gate, not an empty 28d window.
+    expect(computeSeilerTid28d(input(rows, FROZEN)).z1_seconds).toBe(3600);
+  });
+
+  it("equals the 28d all-sport build plus the sport key for a single-family window", () => {
+    const rows = [
+      {
+        type: "Ride",
+        icu_training_load: 80,
+        start_date_local: "2026-05-09T08:00:00",
+        icu_zone_times: [
+          { id: "Z1", secs: 5000 },
+          { id: "Z3", secs: 3000 },
+          { id: "Z4", secs: 2000 },
+        ],
+      },
+      {
+        type: "VirtualRide",
+        icu_training_load: 40,
+        start_date_local: "2026-04-25T08:00:00",
+        icu_zone_times: [{ id: "Z2", secs: 1000 }],
+      },
+    ];
+
+    const all = computeSeilerTid28d(input(rows, FROZEN));
+    const primary = computeSeilerTid28dPrimary(input(rows, FROZEN));
+
+    expect(primary).toEqual({ ...all, sport: "cycling" });
   });
 });

--- a/packages/core/src/reference/metrics/distribution.test.ts
+++ b/packages/core/src/reference/metrics/distribution.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { computeZoneDistribution7d } from "./distribution.js";
+import {
+  computeGreyZoneNote,
+  computeGreyZonePercentage,
+  computeZoneDistribution7d,
+} from "./distribution.js";
 import type { MetricInput } from "./metric-input.js";
 
 // The golden fixtures only exercise the power-zone and empty-window paths,
@@ -130,5 +134,68 @@ describe("computeZoneDistribution7d", () => {
 
     expect(result.total_hours).toBe(0);
     expect(result.zone_basis).toBeNull();
+  });
+});
+
+describe("computeGreyZonePercentage", () => {
+  it("returns the Z3 share of total zone time, rounded to 1 dp", () => {
+    // z1 3600, z2 3600, z3 1800, z4 600 ⇒ total 9600s, z3 share
+    // 1800 / 9600 = 0.1875 → 18.75% → round(18.75, 1) = 18.8 (half-to-even).
+    const result = computeGreyZonePercentage(
+      input(
+        [
+          {
+            type: "Ride",
+            start_date_local: "2026-05-09T08:00:00",
+            icu_zone_times: [
+              { id: "Z1", secs: 3600 },
+              { id: "Z2", secs: 3600 },
+              { id: "Z3", secs: 1800 },
+              { id: "Z4", secs: 600 },
+            ],
+          },
+        ],
+        FROZEN,
+      ),
+    );
+
+    expect(result).toBe(18.8);
+  });
+
+  it("returns null when no activity has zone time", () => {
+    const result = computeGreyZonePercentage(
+      input(
+        [{ type: "WeightTraining", start_date_local: "2026-05-09T08:00:00" }],
+        FROZEN,
+      ),
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when the window is empty", () => {
+    // The only ride is one day older than the trailing 7-day window.
+    const result = computeGreyZonePercentage(
+      input(
+        [
+          {
+            type: "Ride",
+            start_date_local: "2026-05-03T08:00:00",
+            icu_zone_times: [{ id: "Z3", secs: 3600 }],
+          },
+        ],
+        FROZEN,
+      ),
+    );
+
+    expect(result).toBeNull();
+  });
+});
+
+describe("computeGreyZoneNote", () => {
+  it("returns the static polarized-training note constant", () => {
+    expect(computeGreyZoneNote()).toBe(
+      "Gray Zone % (Z3/tempo) - minimize in polarized training",
+    );
   });
 });

--- a/packages/core/src/reference/metrics/distribution.ts
+++ b/packages/core/src/reference/metrics/distribution.ts
@@ -389,8 +389,15 @@ function getActivityZones(
   if (Array.isArray(icuHrZoneTimes) && icuHrZoneTimes.length > 0) {
     const hz: Record<string, number> = {};
     icuHrZoneTimes.forEach((secs, idx) => {
-      if (idx < ZONE_LABELS.length && secs) {
-        hz[ZONE_LABELS[idx]] = secs as number;
+      // Mirror the power-zone guard above: coerce a non-numeric bin to 0 (then
+      // skipped by the truthiness check) instead of storing it. icu_hr_zone_times
+      // is read off the raw, unvalidated record, so a malformed string bin can
+      // reach here — the upstream keeps it and raises on the later sum (an
+      // unportable input the parity gate can't capture), but concatenating a
+      // string into our running zone sums is strictly worse than dropping it.
+      const numericSecs = typeof secs === "number" ? secs : 0;
+      if (idx < ZONE_LABELS.length && numericSecs) {
+        hz[ZONE_LABELS[idx]] = numericSecs;
       }
     });
     if (Object.keys(hz).length > 0) hrZones = hz;
@@ -576,6 +583,9 @@ function selectPrimarySport(activities: Activity[]): string | null {
   const loadByFamilyDate = new Map<string, Map<string, number>>();
 
   for (const act of activities) {
+    // `|| 0` maps a hypothetical NaN load to 0 (skipped); the upstream `or 0`
+    // would keep it (NaN <= 0 is False). Unreachable divergence: z.number()
+    // rejects NaN at the schema boundary, so a NaN load never reaches here.
     const load = act.icu_training_load || 0;
     if (load <= 0) continue;
     const date =

--- a/packages/core/src/reference/metrics/distribution.ts
+++ b/packages/core/src/reference/metrics/distribution.ts
@@ -505,6 +505,18 @@ function calculatePolarizationIndex(
 
   const raw = (z1Frac / effectiveZ2) * z3Frac * 100;
   if (raw <= 0) return null;
+  // `raw` is built from `× ÷` only — correctly-rounded IEEE-754, so identical
+  // across runtimes — but `log10` is the one transcendental in the metric path
+  // and the only op here NOT bit-identical to the oracle by construction. It is
+  // not correctly-rounded by IEEE-754: V8's `Math.log10` and the oracle's libm
+  // (Pyodide/emscripten) are different implementations free to disagree in the
+  // last ULP. A disagreement that straddles a 2-dp midpoint flips the emitted
+  // PI and — through `pi > 2.0` in `classifyTid` — the Polarized/Pyramidal
+  // label. The measure is ~1e-14 per call (the 1-ULP split must land on an
+  // X.XX5 boundary), so unlike sum/stdev/round (reproduced exact-rationally in
+  // `statistics.ts` / `rounding.ts`) this is an accepted residual, not closed.
+  // Closing it means mirroring the oracle's exact log10 — its rounding errors
+  // included; a "more accurate" log10 would diverge from the oracle MORE.
   return roundHalfEven(Math.log10(raw), 2);
 }
 

--- a/packages/core/src/reference/metrics/distribution.ts
+++ b/packages/core/src/reference/metrics/distribution.ts
@@ -54,6 +54,36 @@ export function computeZoneDistribution7d(input: MetricInput): ZoneDistribution7
   };
 }
 
+/**
+ * Grey-zone percentage — the share of trailing-7-day zone time spent in
+ * Z3 (tempo). Per Seiler's polarized model this is the band to minimize
+ * ("too much pain for too little gain"). Returns `null` when no zone time
+ * was accumulated. There is no low/ok/high band classification — the
+ * upstream emits the bare percentage.
+ *
+ * Mirrors `sync.py:3149` line-by-line:
+ *   round((z3_time / total_zone_time) * 100, 1) if total_zone_time > 0 else None
+ */
+export function computeGreyZonePercentage(input: MetricInput): number | null {
+  const activities7d = getActivitiesInWindow(getActivities(input), 7, input.frozenNow);
+  const totals = aggregateZones(activities7d, DEFAULT_ZONE_PREFERENCE);
+
+  if (totals.totalTime > 0) {
+    return roundHalfEven((totals.z3Time / totals.totalTime) * 100, 1);
+  }
+  return null;
+}
+
+/**
+ * Static companion note the upstream emits alongside the grey-zone
+ * percentage. A constant string — mirrors `sync.py:3385` exactly.
+ */
+const GREY_ZONE_NOTE = "Gray Zone % (Z3/tempo) - minimize in polarized training";
+
+export function computeGreyZoneNote(): string {
+  return GREY_ZONE_NOTE;
+}
+
 // ─── Zone substrate ───────────────────────────────────────────────────
 //
 // Shared by every distribution-tier metric (grey-zone %, quality-intensity

--- a/packages/core/src/reference/metrics/distribution.ts
+++ b/packages/core/src/reference/metrics/distribution.ts
@@ -146,6 +146,52 @@ export function computeEasyTimeRatioNote(): string {
   return EASY_TIME_RATIO_NOTE;
 }
 
+/**
+ * 7-day Seiler training-intensity distribution (TID).
+ *
+ * Folds the seven training zones into Seiler's three-zone model over the
+ * trailing-7-day window (per Treff et al. 2019, *The Polarization-Index*,
+ * Front. Physiol. 10:707, doi:10.3389/fphys.2019.00707):
+ *   - Seiler Z1 = z1 + z2  (below LT1, "easy")
+ *   - Seiler Z2 = z3       (between LT1 and LT2, "threshold/grey")
+ *   - Seiler Z3 = z4 + z5 + z6 + z7  (above LT2, "hard")
+ *
+ * Emits the three zone-second totals, their percentage shares (round 1 dp),
+ * the Treff polarization index (a `log10` score, `null` unless the
+ * distribution is structurally polarized — see `calculatePolarizationIndex`),
+ * the TID classification (Base / Polarized / Pyramidal / Threshold / High
+ * Intensity), and the aggregate `zone_basis`. When no zone time accumulated
+ * (`total_seconds == 0`) every percentage, the index, the classification, and
+ * the basis are `null` while the second totals are `0`.
+ *
+ * Upstream source mirrored line-by-line: `sync.py:3993` (`_build_seiler_tid`,
+ * called with `activities_7d` and no sport-family filter at `sync.py:3164`)
+ * over `sync.py:3866` (`_aggregate_seiler_zones`), `sync.py:3930`
+ * (`_calculate_polarization_index`) and `sync.py:3958` (`_classify_tid`).
+ * The polarization index and classification are emitted as fields of this
+ * metric, not as standalone metrics. See `NOTICE.md` for upstream attribution.
+ *
+ * Return shape is the raw upstream output, not a discriminated-union
+ * envelope. Raw compute functions feed the parity gate; a sibling envelope
+ * wrapper will feed the curator when the curator integration lands.
+ */
+export interface SeilerTid {
+  z1_seconds: number;
+  z2_seconds: number;
+  z3_seconds: number;
+  z1_pct: number | null;
+  z2_pct: number | null;
+  z3_pct: number | null;
+  polarization_index: number | null;
+  classification: string | null;
+  zone_basis: "power" | "hr" | "mixed" | null;
+}
+
+export function computeSeilerTid(input: MetricInput): SeilerTid {
+  const activities7d = getActivitiesInWindow(getActivities(input), 7, input.frozenNow);
+  return buildSeilerTid(activities7d, null);
+}
+
 // ─── Zone substrate ───────────────────────────────────────────────────
 //
 // Shared by every distribution-tier metric (grey-zone %, quality-intensity
@@ -294,6 +340,144 @@ function getActivityZones(
   }
 
   return { zones: {}, basis: null };
+}
+
+// ─── Seiler TID substrate ─────────────────────────────────────────────
+//
+// The Seiler three-zone aggregation + Treff polarization index + TID
+// classifier. Mirrors `_aggregate_seiler_zones`, `_calculate_polarization_index`,
+// `_classify_tid` and `_build_seiler_tid` line-by-line. Note the Seiler
+// aggregation defaults an unmapped/missing sport family to "other" (NOT
+// `null`, as the seven-zone `_aggregate_zones` does) — this only changes
+// the zone-preference lookup, which is inert under the harness's empty
+// preference, but is mirrored faithfully because it is a distinct upstream
+// function.
+
+interface SeilerZoneTotals {
+  z1Seconds: number;
+  z2Seconds: number;
+  z3Seconds: number;
+  totalSeconds: number;
+  zoneBasis: "power" | "hr" | "mixed" | null;
+}
+
+function aggregateSeilerZones(
+  activities: Activity[],
+  sportFamilyFilter: string | null,
+): SeilerZoneTotals {
+  let sz1 = 0;
+  let sz2 = 0;
+  let sz3 = 0;
+  const basisSet = new Set<string>();
+
+  for (const act of activities) {
+    const activityType = act.type ?? "Unknown";
+    const actSportFamily = Object.hasOwn(SPORT_FAMILIES, activityType)
+      ? SPORT_FAMILIES[activityType]
+      : "other";
+    if (sportFamilyFilter) {
+      if (actSportFamily !== sportFamilyFilter) continue;
+    }
+
+    const { zones, basis } = getActivityZones(act, actSportFamily, DEFAULT_ZONE_PREFERENCE);
+
+    if (Object.keys(zones).length > 0) {
+      if (basis) basisSet.add(basis);
+      sz1 += (zones.z1 ?? 0) + (zones.z2 ?? 0);
+      sz2 += zones.z3 ?? 0;
+      sz3 += (zones.z4 ?? 0) + (zones.z5 ?? 0) + (zones.z6 ?? 0) + (zones.z7 ?? 0);
+    }
+  }
+
+  const totalSeconds = sz1 + sz2 + sz3;
+
+  let zoneBasis: "power" | "hr" | "mixed" | null;
+  if (basisSet.size > 1) {
+    zoneBasis = "mixed";
+  } else if (basisSet.size === 1) {
+    zoneBasis = basisSet.values().next().value as "power" | "hr";
+  } else {
+    zoneBasis = null;
+  }
+
+  return { z1Seconds: sz1, z2Seconds: sz2, z3Seconds: sz3, totalSeconds, zoneBasis };
+}
+
+// Treff Polarization Index: PI = log10((Z1 / Z2) × Z3 × 100). Computed only
+// when the distribution is structurally polarized (Z1 > Z3 > Z2 and
+// Z3 >= 0.01); Z2 = 0 is substituted with 0.01. Mirrors `sync.py:3930`.
+function calculatePolarizationIndex(
+  z1Frac: number,
+  z2Frac: number,
+  z3Frac: number,
+): number | null {
+  if (z3Frac < 0.01) return null;
+  if (!(z1Frac > z3Frac && z3Frac > z2Frac)) return null;
+
+  const effectiveZ2 = z2Frac > 0 ? z2Frac : 0.01;
+
+  const raw = (z1Frac / effectiveZ2) * z3Frac * 100;
+  if (raw <= 0) return null;
+  return roundHalfEven(Math.log10(raw), 2);
+}
+
+// TID classification with the upstream's explicit priority order to avoid
+// overlaps. Mirrors `sync.py:3958`.
+function classifyTid(
+  z1Frac: number,
+  z2Frac: number,
+  z3Frac: number,
+  pi: number | null,
+): string {
+  if (z3Frac < 0.01 && z1Frac >= z2Frac && z1Frac >= z3Frac) return "Base";
+  if (z1Frac > z3Frac && z3Frac > z2Frac && pi !== null && pi > 2.0) return "Polarized";
+  if (z1Frac > z2Frac && z2Frac > z3Frac) return "Pyramidal";
+  if (z2Frac >= z1Frac && z2Frac >= z3Frac) return "Threshold";
+  if (z3Frac >= z1Frac && z3Frac >= z2Frac) return "High Intensity";
+  return "Pyramidal";
+}
+
+// Build the complete Seiler TID structure. Mirrors `sync.py:3993`.
+function buildSeilerTid(
+  activities: Activity[],
+  sportFamilyFilter: string | null,
+): SeilerTid {
+  const zones = aggregateSeilerZones(activities, sportFamilyFilter);
+  const total = zones.totalSeconds;
+  const zoneBasis = zones.zoneBasis;
+
+  if (total === 0) {
+    return {
+      z1_seconds: 0,
+      z2_seconds: 0,
+      z3_seconds: 0,
+      z1_pct: null,
+      z2_pct: null,
+      z3_pct: null,
+      polarization_index: null,
+      classification: null,
+      zone_basis: null,
+    };
+  }
+
+  const z1Frac = zones.z1Seconds / total;
+  const z2Frac = zones.z2Seconds / total;
+  const z3Frac = zones.z3Seconds / total;
+
+  const pi = calculatePolarizationIndex(z1Frac, z2Frac, z3Frac);
+  const classification = classifyTid(z1Frac, z2Frac, z3Frac, pi);
+
+  return {
+    z1_seconds: zones.z1Seconds,
+    z2_seconds: zones.z2Seconds,
+    z3_seconds: zones.z3Seconds,
+    z1_pct: roundHalfEven(z1Frac * 100, 1),
+    z2_pct: roundHalfEven(z2Frac * 100, 1),
+    z3_pct: roundHalfEven(z3Frac * 100, 1),
+    polarization_index: pi,
+    classification,
+    zone_basis: zoneBasis,
+  };
 }
 
 // The trailing 7-day activity window the upstream reads as `activities_7d`:

--- a/packages/core/src/reference/metrics/distribution.ts
+++ b/packages/core/src/reference/metrics/distribution.ts
@@ -1,0 +1,247 @@
+/**
+ * Reference layer — training-zone distribution metrics.
+ *
+ * This module lands the zone substrate the distribution tier builds on:
+ * per-activity zone-time extraction (power-preferred, HR fallback) and
+ * the trailing-window aggregation into Z1/Z2/Z3/Z4+ totals. The metric
+ * math is ported from the Reference layer's upstream protocol. See
+ * `NOTICE.md` for license attribution.
+ */
+
+import type { Activity } from "../schemas/inputs.js";
+
+import { getActivities, type MetricInput } from "./metric-input.js";
+
+/**
+ * 7-day zone-hours distribution.
+ *
+ * Each zone's accumulated seconds over the trailing 7-day window, divided
+ * by 3600 and rounded half-to-even to 2 dp. `z4_plus_hours` folds the four
+ * hard zones (z4..z7) into one bucket per the Seiler polarized framing
+ * (Z1–Z2 easy, Z3 grey/tempo, Z4+ hard). `zone_basis` reports whether the
+ * underlying times came from power zones, HR zones, both (`"mixed"`), or
+ * no zone data at all (`null`).
+ *
+ * Upstream source mirrored line-by-line: `sync.py:3376-3382` (emit) over
+ * the totals from `_aggregate_zones` (`sync.py:3814`), which in turn calls
+ * the per-activity `_get_activity_zones` (`sync.py:3683`). See `NOTICE.md`
+ * for upstream attribution.
+ *
+ * Return shape is the raw upstream output, not a discriminated-union
+ * envelope. Raw compute functions feed the parity gate; a sibling envelope
+ * wrapper will feed the curator when the curator integration lands.
+ */
+export interface ZoneDistribution7d {
+  total_hours: number;
+  z1_hours: number;
+  z2_hours: number;
+  z3_hours: number;
+  z4_plus_hours: number;
+  zone_basis: "power" | "hr" | "mixed" | null;
+}
+
+export function computeZoneDistribution7d(input: MetricInput): ZoneDistribution7d {
+  const activities7d = getActivitiesInWindow(getActivities(input), 7, input.frozenNow);
+  const totals = aggregateZones(activities7d, DEFAULT_ZONE_PREFERENCE);
+
+  return {
+    z1_hours: roundHalfEven(totals.z1Time / 3600, 2),
+    z2_hours: roundHalfEven(totals.z2Time / 3600, 2),
+    z3_hours: roundHalfEven(totals.z3Time / 3600, 2),
+    z4_plus_hours: roundHalfEven(totals.z4PlusTime / 3600, 2),
+    total_hours: roundHalfEven(totals.totalTime / 3600, 2),
+    zone_basis: totals.zoneBasis,
+  };
+}
+
+// ─── Zone substrate ───────────────────────────────────────────────────
+//
+// Shared by every distribution-tier metric (grey-zone %, quality-intensity
+// %, easy-time ratio, Seiler TID). Mirrors `_get_activity_zones` and
+// `_aggregate_zones` line-by-line.
+
+interface ZoneTotals {
+  z1Time: number;
+  z2Time: number;
+  z3Time: number;
+  z4PlusTime: number;
+  totalTime: number;
+  zoneBasis: "power" | "hr" | "mixed" | null;
+}
+
+// `self.zone_preference or {}` (sync.py:375). The parity harness
+// instantiates the upstream without a preference, so the default is the
+// power-preferred / HR-fallback path; the substrate still honours a
+// per-sport-family `"hr"` preference when one is supplied.
+const DEFAULT_ZONE_PREFERENCE: Record<string, string> = {};
+
+// Mirrors `SPORT_FAMILIES` at sync.py:290-308. In `_aggregate_zones` the
+// lookup defaults to `None` for unmapped types (NOT "other"), so an
+// unmapped type yields no `prefer_hr` and rides the power-preferred path.
+const SPORT_FAMILIES: Record<string, string> = {
+  Ride: "cycling",
+  VirtualRide: "cycling",
+  MountainBikeRide: "cycling",
+  GravelRide: "cycling",
+  EBikeRide: "cycling",
+  VirtualSki: "ski",
+  NordicSki: "ski",
+  Walk: "walk",
+  Hike: "walk",
+  Run: "run",
+  VirtualRun: "run",
+  TrailRun: "run",
+  Swim: "swim",
+  Rowing: "rowing",
+  WeightTraining: "strength",
+  Yoga: "other",
+  Workout: "other",
+};
+
+const ZONE_IDS = new Set(["z1", "z2", "z3", "z4", "z5", "z6", "z7"]);
+const ZONE_LABELS = ["z1", "z2", "z3", "z4", "z5", "z6", "z7"] as const;
+
+// Aggregate per-activity zone times across the window. Mirrors
+// `_aggregate_zones` (sync.py:3814): only activities that yield a non-empty
+// zone dict contribute; `z4_plus` folds z4..z7; `total` sums every present
+// zone value; the aggregate basis is "mixed" when both power- and HR-based
+// activities appear, the single basis when only one does, else null.
+function aggregateZones(
+  activities: Activity[],
+  zonePreference: Record<string, string>,
+): ZoneTotals {
+  let z1Time = 0;
+  let z2Time = 0;
+  let z3Time = 0;
+  let z4PlusTime = 0;
+  let totalTime = 0;
+  const basisSet = new Set<string>();
+
+  for (const act of activities) {
+    // Object.hasOwn guards prototype-chain lookups: a fixture with
+    // act.type === "toString"/"constructor" would otherwise resolve to an
+    // inherited Function reference instead of falling through to null.
+    const sportFamily = Object.hasOwn(SPORT_FAMILIES, act.type)
+      ? SPORT_FAMILIES[act.type]
+      : null;
+    const { zones, basis } = getActivityZones(act, sportFamily, zonePreference);
+
+    if (Object.keys(zones).length > 0) {
+      if (basis) basisSet.add(basis);
+      z1Time += zones.z1 ?? 0;
+      z2Time += zones.z2 ?? 0;
+      z3Time += zones.z3 ?? 0;
+      z4PlusTime += (zones.z4 ?? 0) + (zones.z5 ?? 0) + (zones.z6 ?? 0) + (zones.z7 ?? 0);
+      for (const v of Object.values(zones)) totalTime += v;
+    }
+  }
+
+  let zoneBasis: "power" | "hr" | "mixed" | null;
+  if (basisSet.size > 1) {
+    zoneBasis = "mixed";
+  } else if (basisSet.size === 1) {
+    zoneBasis = basisSet.values().next().value as "power" | "hr";
+  } else {
+    zoneBasis = null;
+  }
+
+  return { z1Time, z2Time, z3Time, z4PlusTime, totalTime, zoneBasis };
+}
+
+// Extract one activity's zone times. Mirrors `_get_activity_zones`
+// (sync.py:3683): power zones come from `icu_zone_times` (list of
+// `{id, secs}`), HR zones from `icu_hr_zone_times` (flat seconds array
+// indexed to z1..z7, skipping zero/empty bins). Default is power-preferred
+// with HR fallback; a sport family configured for `"hr"` flips that.
+function getActivityZones(
+  activity: Activity,
+  sportFamily: string | null,
+  zonePreference: Record<string, string>,
+): { zones: Record<string, number>; basis: "power" | "hr" | null } {
+  const preferHr = sportFamily !== null && zonePreference[sportFamily] === "hr";
+
+  // `icu_hr_zone_times` is not on the typed Activity surface (the schema
+  // carries the object-form `hr_zone_times`); read both zone sets off the
+  // raw fixture record the way the upstream `.get()` does.
+  const raw = activity as Record<string, unknown>;
+
+  let powerZones: Record<string, number> | null = null;
+  const icuZoneTimes = raw.icu_zone_times;
+  if (Array.isArray(icuZoneTimes) && icuZoneTimes.length > 0) {
+    const pz: Record<string, number> = {};
+    for (const zone of icuZoneTimes) {
+      const obj =
+        typeof zone === "object" && zone !== null
+          ? (zone as { id?: unknown; secs?: unknown })
+          : {};
+      const zoneId = (typeof obj.id === "string" ? obj.id : "").toLowerCase();
+      const secs = typeof obj.secs === "number" ? obj.secs : 0;
+      if (ZONE_IDS.has(zoneId)) pz[zoneId] = secs;
+    }
+    if (Object.keys(pz).length > 0) powerZones = pz;
+  }
+
+  let hrZones: Record<string, number> | null = null;
+  const icuHrZoneTimes = raw.icu_hr_zone_times;
+  if (Array.isArray(icuHrZoneTimes) && icuHrZoneTimes.length > 0) {
+    const hz: Record<string, number> = {};
+    icuHrZoneTimes.forEach((secs, idx) => {
+      if (idx < ZONE_LABELS.length && secs) {
+        hz[ZONE_LABELS[idx]] = secs as number;
+      }
+    });
+    if (Object.keys(hz).length > 0) hrZones = hz;
+  }
+
+  if (preferHr) {
+    if (hrZones) return { zones: hrZones, basis: "hr" };
+    if (powerZones) return { zones: powerZones, basis: "power" };
+  } else {
+    if (powerZones) return { zones: powerZones, basis: "power" };
+    if (hrZones) return { zones: hrZones, basis: "hr" };
+  }
+
+  return { zones: {}, basis: null };
+}
+
+// The trailing 7-day activity window the upstream reads as `activities_7d`:
+// rows whose `start_date_local` date falls in [frozenNow-(days-1),
+// frozenNow], inclusive, in fixture order. Mirrors the harness
+// `_within(_activities_all, "start_date_local", ...)` slice — an inclusive
+// lexicographic date comparison over the YYYY-MM-DD prefix.
+function getActivitiesInWindow(
+  activities: Activity[],
+  days: number,
+  frozenNow: string,
+): Activity[] {
+  const oldest = isoDateDaysBefore(frozenNow, days - 1);
+  const today = frozenNow.slice(0, 10);
+  return activities.filter((a) => {
+    if (typeof a.start_date_local !== "string") return false;
+    const d = a.start_date_local.slice(0, 10);
+    return oldest <= d && d <= today;
+  });
+}
+
+function isoDateDaysBefore(isoNow: string, daysBefore: number): string {
+  const datePart = isoNow.slice(0, 10);
+  const [y, m, d] = datePart.split("-").map(Number) as [number, number, number];
+  const utc = new Date(Date.UTC(y, m - 1, d));
+  utc.setUTCDate(utc.getUTCDate() - daysBefore);
+  return utc.toISOString().slice(0, 10);
+}
+
+// Python's `round(x, n)` uses banker's rounding (round-half-to-even) and
+// diverges from `Math.round(x*10**n)/10**n` (round-half-up) for values
+// exactly at the half boundary. Mirroring Python keeps the gate
+// bit-identical on any zone-hours value that lands at the boundary.
+function roundHalfEven(value: number, decimals: number): number {
+  const factor = 10 ** decimals;
+  const scaled = value * factor;
+  const floor = Math.floor(scaled);
+  const diff = scaled - floor;
+  const epsilon = 1e-9;
+  if (diff < 0.5 - epsilon) return floor / factor;
+  if (diff > 0.5 + epsilon) return (floor + 1) / factor;
+  return (floor % 2 === 0 ? floor : floor + 1) / factor;
+}

--- a/packages/core/src/reference/metrics/distribution.ts
+++ b/packages/core/src/reference/metrics/distribution.ts
@@ -192,6 +192,40 @@ export function computeSeilerTid(input: MetricInput): SeilerTid {
   return buildSeilerTid(activities7d, null);
 }
 
+/**
+ * 7-day Seiler TID restricted to the athlete's primary sport family.
+ *
+ * The primary sport is the family carrying the greatest accumulated Load
+ * over the trailing-7-day window. With that family as the
+ * `sport_family_filter`, only its activities enter the aggregation, while
+ * each activity's own sport family still drives its zone-preference lookup
+ * (the filter controls inclusion, not zone selection). The result is the
+ * same shape as `seiler_tid_7d` plus a `sport` key naming the family.
+ *
+ * Returns `null` when there is no primary sport — i.e. no in-window
+ * activity carries Load > 0, so the upstream `primary_sport` stays `None`
+ * and the variant is never built.
+ *
+ * Upstream source mirrored line-by-line: the call site at `sync.py:3166-3171`
+ * (`_build_seiler_tid(activities_7d, sport_family_filter=primary_sport)`
+ * then `["sport"] = primary_sport`) over the same Seiler substrate as
+ * `computeSeilerTid`. The `primary_sport` derivation mirrors `sync.py:3048-3056`
+ * (`_get_daily_tss_by_sport` then `max(sport_totals, key=sport_totals.get)`).
+ * See `NOTICE.md` for upstream attribution.
+ */
+export interface SeilerTidPrimary extends SeilerTid {
+  sport: string;
+}
+
+export function computeSeilerTidPrimary(input: MetricInput): SeilerTidPrimary | null {
+  const activities7d = getActivitiesInWindow(getActivities(input), 7, input.frozenNow);
+
+  const primarySport = selectPrimarySport(activities7d);
+  if (!primarySport) return null;
+
+  return { ...buildSeilerTid(activities7d, primarySport), sport: primarySport };
+}
+
 // ─── Zone substrate ───────────────────────────────────────────────────
 //
 // Shared by every distribution-tier metric (grey-zone %, quality-intensity
@@ -478,6 +512,42 @@ function buildSeilerTid(
     classification,
     zone_basis: zoneBasis,
   };
+}
+
+// Primary sport family = the family with the greatest accumulated Load over
+// the window. Mirrors the inline derivation at `sync.py:3048-3056`:
+// `_get_daily_tss_by_sport(activities_7d, days=7)` builds per-family daily
+// arrays (each value being summed Load, skipping rows with Load <= 0,
+// unmapped types grouped as "other"), then
+// `max(sport_totals, key=sport_totals.get)` picks the family whose summed
+// days are largest. Because every passed activity is already inside the
+// window, summing each family's Load directly equals `sum(days)`. `max`
+// returns the first key at the maximum in dict-insertion order, so totals
+// are tracked in first-encountered order and ties resolve to the earliest
+// family — keeping the selection bit-identical. Returns `null` when no
+// in-window activity carries Load > 0 (upstream `primary_sport` is `None`).
+function selectPrimarySport(activities: Activity[]): string | null {
+  const totals = new Map<string, number>();
+
+  for (const act of activities) {
+    const load = act.icu_training_load || 0;
+    if (load <= 0) continue;
+    const activityType = act.type ?? "Unknown";
+    const sportFamily = Object.hasOwn(SPORT_FAMILIES, activityType)
+      ? SPORT_FAMILIES[activityType]
+      : "other";
+    totals.set(sportFamily, (totals.get(sportFamily) ?? 0) + load);
+  }
+
+  let primary: string | null = null;
+  let maxTotal = -Infinity;
+  for (const [sport, total] of totals) {
+    if (total > maxTotal) {
+      maxTotal = total;
+      primary = sport;
+    }
+  }
+  return primary;
 }
 
 // The trailing 7-day activity window the upstream reads as `activities_7d`:

--- a/packages/core/src/reference/metrics/distribution.ts
+++ b/packages/core/src/reference/metrics/distribution.ts
@@ -115,6 +115,37 @@ export function computeQualityIntensityNote(): string {
   return QUALITY_INTENSITY_NOTE;
 }
 
+/**
+ * Easy-time ratio — the share of trailing-7-day zone time spent in Z1+Z2
+ * (the "easy" work below LT1). Per Seiler's polarized model the target is
+ * ~0.80. Unlike the grey-zone and quality-intensity metrics this is a bare
+ * ratio, not a percentage: no ×100, rounded to 2 dp. Returns `null` when no
+ * zone time was accumulated.
+ *
+ * Mirrors `sync.py:3159` line-by-line:
+ *   round((z1_time + z2_time) / total_zone_time, 2) if total_zone_time > 0 else None
+ */
+export function computeEasyTimeRatio(input: MetricInput): number | null {
+  const activities7d = getActivitiesInWindow(getActivities(input), 7, input.frozenNow);
+  const totals = aggregateZones(activities7d, DEFAULT_ZONE_PREFERENCE);
+
+  if (totals.totalTime > 0) {
+    return roundHalfEven((totals.z1Time + totals.z2Time) / totals.totalTime, 2);
+  }
+  return null;
+}
+
+/**
+ * Static companion note the upstream emits alongside the easy-time ratio.
+ * A constant string — mirrors `sync.py:3389` exactly.
+ */
+const EASY_TIME_RATIO_NOTE =
+  "Easy time (Z1+Z2) / Total - target ~80% in polarized training";
+
+export function computeEasyTimeRatioNote(): string {
+  return EASY_TIME_RATIO_NOTE;
+}
+
 // ─── Zone substrate ───────────────────────────────────────────────────
 //
 // Shared by every distribution-tier metric (grey-zone %, quality-intensity

--- a/packages/core/src/reference/metrics/distribution.ts
+++ b/packages/core/src/reference/metrics/distribution.ts
@@ -11,6 +11,8 @@
 import type { Activity } from "../schemas/inputs.js";
 
 import { getActivities, type MetricInput } from "./metric-input.js";
+import { roundHalfEven } from "./rounding.js";
+import { pythonSum } from "./statistics.js";
 
 /**
  * 7-day zone-hours distribution.
@@ -566,33 +568,44 @@ function buildSeilerTid(
 }
 
 // Primary sport family = the family with the greatest accumulated Load over
-// the window. Mirrors the inline derivation at `sync.py:3048-3056`:
-// `_get_daily_tss_by_sport(activities_7d, days=7)` builds per-family daily
-// arrays (each value being summed Load, skipping rows with Load <= 0,
-// unmapped types grouped as "other"), then
-// `max(sport_totals, key=sport_totals.get)` picks the family whose summed
-// days are largest. Because every passed activity is already inside the
-// window, summing each family's Load directly equals `sum(days)`. `max`
-// returns the first key at the maximum in dict-insertion order, so totals
-// are tracked in first-encountered order and ties resolve to the earliest
-// family — keeping the selection bit-identical. Returns `null` when no
-// in-window activity carries Load > 0 (upstream `primary_sport` is `None`).
+// the window. Mirrors the inline derivation at `sync.py:3048-3056` over
+// `_get_daily_tss_by_sport` (`sync.py:3646-3675`): Load is bucketed per
+// (sport family, date) in activity order (skipping rows with Load <= 0,
+// unmapped types grouped as "other"), each family's daily buckets are then
+// summed and `max(sport_totals, key=sport_totals.get)` picks the largest.
+// Float addition is non-associative, so the per-date bucketing is reproduced
+// rather than collapsed to a flat per-family sum — that keeps the argmax
+// input bit-identical at a near-tie. The absent window days the upstream sums
+// as 0 are a no-op (`x + 0 === x`), so iterating only the present dates in
+// ascending order matches `sum(daily_array)` exactly. `max` returns the first
+// key at the maximum in dict-insertion order, so families are tracked in
+// first-encountered order and ties resolve to the earliest. Returns `null`
+// when no in-window activity carries Load > 0 (upstream `primary_sport` is
+// `None`).
 function selectPrimarySport(activities: Activity[]): string | null {
-  const totals = new Map<string, number>();
+  const loadByFamilyDate = new Map<string, Map<string, number>>();
 
   for (const act of activities) {
     const load = act.icu_training_load || 0;
     if (load <= 0) continue;
+    const date =
+      typeof act.start_date_local === "string" ? act.start_date_local.slice(0, 10) : "";
     const activityType = act.type ?? "Unknown";
     const sportFamily = Object.hasOwn(SPORT_FAMILIES, activityType)
       ? SPORT_FAMILIES[activityType]
       : "other";
-    totals.set(sportFamily, (totals.get(sportFamily) ?? 0) + load);
+    let byDate = loadByFamilyDate.get(sportFamily);
+    if (!byDate) {
+      byDate = new Map();
+      loadByFamilyDate.set(sportFamily, byDate);
+    }
+    byDate.set(date, (byDate.get(date) ?? 0) + load);
   }
 
   let primary: string | null = null;
   let maxTotal = -Infinity;
-  for (const [sport, total] of totals) {
+  for (const [sport, byDate] of loadByFamilyDate) {
+    const total = pythonSum([...byDate.keys()].sort().map((date) => byDate.get(date) as number));
     if (total > maxTotal) {
       maxTotal = total;
       primary = sport;
@@ -626,19 +639,4 @@ function isoDateDaysBefore(isoNow: string, daysBefore: number): string {
   const utc = new Date(Date.UTC(y, m - 1, d));
   utc.setUTCDate(utc.getUTCDate() - daysBefore);
   return utc.toISOString().slice(0, 10);
-}
-
-// Python's `round(x, n)` uses banker's rounding (round-half-to-even) and
-// diverges from `Math.round(x*10**n)/10**n` (round-half-up) for values
-// exactly at the half boundary. Mirroring Python keeps the gate
-// bit-identical on any zone-hours value that lands at the boundary.
-function roundHalfEven(value: number, decimals: number): number {
-  const factor = 10 ** decimals;
-  const scaled = value * factor;
-  const floor = Math.floor(scaled);
-  const diff = scaled - floor;
-  const epsilon = 1e-9;
-  if (diff < 0.5 - epsilon) return floor / factor;
-  if (diff > 0.5 + epsilon) return (floor + 1) / factor;
-  return (floor % 2 === 0 ? floor : floor + 1) / factor;
 }

--- a/packages/core/src/reference/metrics/distribution.ts
+++ b/packages/core/src/reference/metrics/distribution.ts
@@ -357,7 +357,7 @@ function aggregateZones(
       z2Time += zones.z2 ?? 0;
       z3Time += zones.z3 ?? 0;
       z4PlusTime += (zones.z4 ?? 0) + (zones.z5 ?? 0) + (zones.z6 ?? 0) + (zones.z7 ?? 0);
-      for (const v of Object.values(zones)) totalTime += v;
+      totalTime += pythonSum(Object.values(zones));
     }
   }
 

--- a/packages/core/src/reference/metrics/distribution.ts
+++ b/packages/core/src/reference/metrics/distribution.ts
@@ -84,6 +84,37 @@ export function computeGreyZoneNote(): string {
   return GREY_ZONE_NOTE;
 }
 
+/**
+ * Quality-intensity percentage — the share of trailing-7-day zone time
+ * spent in Z4+ (above LT2, the "hard" work). Per Seiler's polarized model
+ * this is the band to target at ~20%. Returns `null` when no zone time was
+ * accumulated. There is no low/ok/high band classification — the upstream
+ * emits the bare percentage.
+ *
+ * Mirrors `sync.py:3154` line-by-line:
+ *   round((z4_plus_time / total_zone_time) * 100, 1) if total_zone_time > 0 else None
+ */
+export function computeQualityIntensityPercentage(input: MetricInput): number | null {
+  const activities7d = getActivitiesInWindow(getActivities(input), 7, input.frozenNow);
+  const totals = aggregateZones(activities7d, DEFAULT_ZONE_PREFERENCE);
+
+  if (totals.totalTime > 0) {
+    return roundHalfEven((totals.z4PlusTime / totals.totalTime) * 100, 1);
+  }
+  return null;
+}
+
+/**
+ * Static companion note the upstream emits alongside the quality-intensity
+ * percentage. A constant string — mirrors `sync.py:3387` exactly.
+ */
+const QUALITY_INTENSITY_NOTE =
+  "Quality Intensity % (Z4+/threshold+) - target ~20% in polarized training";
+
+export function computeQualityIntensityNote(): string {
+  return QUALITY_INTENSITY_NOTE;
+}
+
 // ─── Zone substrate ───────────────────────────────────────────────────
 //
 // Shared by every distribution-tier metric (grey-zone %, quality-intensity

--- a/packages/core/src/reference/metrics/distribution.ts
+++ b/packages/core/src/reference/metrics/distribution.ts
@@ -499,9 +499,14 @@ function calculatePolarizationIndex(
   // PI and — through `pi > 2.0` in `classifyTid` — the Polarized/Pyramidal
   // label. The measure is ~1e-14 per call (the 1-ULP split must land on an
   // X.XX5 boundary), so unlike sum/stdev/round (reproduced exact-rationally in
-  // `statistics.ts` / `rounding.ts`) this is an accepted residual, not closed.
-  // Closing it means mirroring the oracle's exact log10 — its rounding errors
-  // included; a "more accurate" log10 would diverge from the oracle MORE.
+  // `statistics.ts` / `rounding.ts`) this residual is deliberately accepted:
+  // reproducing the oracle's exact libm log10 is ~200 lines of version-pinned,
+  // table-driven musl transliteration re-verified on every Pyodide bump — not
+  // worth closing a ~1e-14 gap. The tolerance-zero gate is the safety net: if a
+  // fixture ever lands on the boundary it turns red HERE (caught in CI, never
+  // shipped silently), and the fix is then to regenerate that snapshot or
+  // reproduce the exact log10. A "more accurate" log10 would diverge MORE, not
+  // less — the target is the oracle's bits, not correctness.
   return roundHalfEven(Math.log10(raw), 2);
 }
 

--- a/packages/core/src/reference/metrics/distribution.ts
+++ b/packages/core/src/reference/metrics/distribution.ts
@@ -226,6 +226,24 @@ export function computeSeilerTidPrimary(input: MetricInput): SeilerTidPrimary | 
   return { ...buildSeilerTid(activities7d, primarySport), sport: primarySport };
 }
 
+/**
+ * 28-day Seiler training-intensity distribution (TID) — the chronic window.
+ *
+ * Identical to `computeSeilerTid` in every respect except the aggregation
+ * window: the same all-sport Seiler builder runs over the trailing 28 days
+ * instead of 7. Pairing the acute (7d) and chronic (28d) distributions is
+ * what lets the upstream detect intensity-distribution drift.
+ *
+ * Upstream source mirrored line-by-line: `sync.py:3184`
+ * (`_build_seiler_tid(activities_28d)`, no sport-family filter), the same
+ * builder (`sync.py:3993`) as the 7-day variant over the wider window. See
+ * `NOTICE.md` for upstream attribution.
+ */
+export function computeSeilerTid28d(input: MetricInput): SeilerTid {
+  const activities28d = getActivitiesInWindow(getActivities(input), 28, input.frozenNow);
+  return buildSeilerTid(activities28d, null);
+}
+
 // ─── Zone substrate ───────────────────────────────────────────────────
 //
 // Shared by every distribution-tier metric (grey-zone %, quality-intensity

--- a/packages/core/src/reference/metrics/distribution.ts
+++ b/packages/core/src/reference/metrics/distribution.ts
@@ -12,6 +12,7 @@ import type { Activity } from "../schemas/inputs.js";
 
 import { getActivities, type MetricInput } from "./metric-input.js";
 import { roundHalfEven } from "./rounding.js";
+import { SPORT_FAMILIES } from "./sport-families.js";
 import { pythonSum } from "./statistics.js";
 
 /**
@@ -299,29 +300,6 @@ interface ZoneTotals {
 // power-preferred / HR-fallback path; the substrate still honours a
 // per-sport-family `"hr"` preference when one is supplied.
 const DEFAULT_ZONE_PREFERENCE: Record<string, string> = {};
-
-// Mirrors `SPORT_FAMILIES` at sync.py:290-308. In `_aggregate_zones` the
-// lookup defaults to `None` for unmapped types (NOT "other"), so an
-// unmapped type yields no `prefer_hr` and rides the power-preferred path.
-const SPORT_FAMILIES: Record<string, string> = {
-  Ride: "cycling",
-  VirtualRide: "cycling",
-  MountainBikeRide: "cycling",
-  GravelRide: "cycling",
-  EBikeRide: "cycling",
-  VirtualSki: "ski",
-  NordicSki: "ski",
-  Walk: "walk",
-  Hike: "walk",
-  Run: "run",
-  VirtualRun: "run",
-  TrailRun: "run",
-  Swim: "swim",
-  Rowing: "rowing",
-  WeightTraining: "strength",
-  Yoga: "other",
-  Workout: "other",
-};
 
 const ZONE_IDS = new Set(["z1", "z2", "z3", "z4", "z5", "z6", "z7"]);
 const ZONE_LABELS = ["z1", "z2", "z3", "z4", "z5", "z6", "z7"] as const;

--- a/packages/core/src/reference/metrics/distribution.ts
+++ b/packages/core/src/reference/metrics/distribution.ts
@@ -244,6 +244,39 @@ export function computeSeilerTid28d(input: MetricInput): SeilerTid {
   return buildSeilerTid(activities28d, null);
 }
 
+/**
+ * 28-day Seiler TID restricted to the athlete's primary sport family — the
+ * chronic-window counterpart to `computeSeilerTidPrimary`.
+ *
+ * The primary sport is still the family carrying the greatest accumulated
+ * Load over the trailing-7-day window (the upstream derives it once from
+ * `activities_7d`), but the Seiler aggregation runs over the wider 28-day
+ * window with that family as the `sport_family_filter`. The result is the
+ * same shape as `seiler_tid_28d` plus a `sport` key naming the family.
+ *
+ * Returns `null` when there is no primary sport — i.e. no in-window-7d
+ * activity carries Load > 0, so the upstream `primary_sport` stays `None`
+ * and the variant is never built.
+ *
+ * Upstream source mirrored line-by-line: the call site at `sync.py:3186-3191`
+ * (`_build_seiler_tid(activities_28d, sport_family_filter=primary_sport)`
+ * then `["sport"] = primary_sport`) over the same Seiler substrate as
+ * `computeSeilerTid28d`. The `primary_sport` derivation mirrors
+ * `sync.py:3048-3056` (`_get_daily_tss_by_sport(activities_7d, days=7)` then
+ * `max(sport_totals, key=sport_totals.get)`). See `NOTICE.md` for upstream
+ * attribution.
+ */
+export function computeSeilerTid28dPrimary(input: MetricInput): SeilerTidPrimary | null {
+  const activities = getActivities(input);
+  const activities7d = getActivitiesInWindow(activities, 7, input.frozenNow);
+  const activities28d = getActivitiesInWindow(activities, 28, input.frozenNow);
+
+  const primarySport = selectPrimarySport(activities7d);
+  if (!primarySport) return null;
+
+  return { ...buildSeilerTid(activities28d, primarySport), sport: primarySport };
+}
+
 // ─── Zone substrate ───────────────────────────────────────────────────
 //
 // Shared by every distribution-tier metric (grey-zone %, quality-intensity

--- a/packages/core/src/reference/metrics/load-management.test.ts
+++ b/packages/core/src/reference/metrics/load-management.test.ts
@@ -5,6 +5,7 @@ import {
   computeLoadRecoveryRatio,
   computeMonotony,
   computeMonotonyInterpretation,
+  computePrimarySportMonotony,
   computeRecoveryIndex,
   computeStrain,
   computeStressTolerance,
@@ -350,5 +351,77 @@ describe("load aggregators — malformed start_date_local is dropped, not thrown
       withMalformed = computeEffectiveMonotony(fixtureOf([...wellFormed, missingDate]));
     }).not.toThrow();
     expect(withMalformed).toBe(baseline);
+  });
+});
+
+describe("computePrimarySportMonotony", () => {
+  const FROZEN = "2026-05-10T12:00:00";
+
+  // The primary sport is the family with the greatest 7-day Load; the
+  // selector uses a strict `total > maxTotal`, so on an exact tie the first
+  // family encountered in fixture order wins (mirroring Python's
+  // `max(dict, key=dict.get)` insertion-order semantics). No golden fixture
+  // hits a deliberate tie, so pin it here.
+  it("breaks an exact Load tie toward the first sport family in fixture order", () => {
+    // Ride and Run each total 300 over the window but with different daily
+    // spreads, so their isolated monotony values differ — which makes the
+    // tiebreak observable.
+    const rideRows = [
+      { start_date_local: "2026-05-04T08:00:00", icu_training_load: 100, type: "Ride" },
+      { start_date_local: "2026-05-05T08:00:00", icu_training_load: 100, type: "Ride" },
+      { start_date_local: "2026-05-06T08:00:00", icu_training_load: 100, type: "Ride" },
+    ];
+    const runRows = [
+      { start_date_local: "2026-05-07T08:00:00", icu_training_load: 50, type: "Run" },
+      { start_date_local: "2026-05-08T08:00:00", icu_training_load: 100, type: "Run" },
+      { start_date_local: "2026-05-09T08:00:00", icu_training_load: 150, type: "Run" },
+    ];
+
+    const rideMonotony = computePrimarySportMonotony(input(rideRows, FROZEN));
+    const runMonotony = computePrimarySportMonotony(input(runRows, FROZEN));
+
+    // Precondition: the two families are distinguishable, so the tiebreak
+    // assertions below aren't vacuous.
+    expect(rideMonotony).not.toBeNull();
+    expect(runMonotony).not.toBeNull();
+    expect(rideMonotony).not.toBe(runMonotony);
+
+    // Equal totals → the first-listed family wins, both orderings round.
+    expect(computePrimarySportMonotony(input([...rideRows, ...runRows], FROZEN))).toBe(
+      rideMonotony,
+    );
+    expect(computePrimarySportMonotony(input([...runRows, ...rideRows], FROZEN))).toBe(
+      runMonotony,
+    );
+  });
+});
+
+describe("computeEffectiveMonotony", () => {
+  const FROZEN = "2026-05-10T12:00:00";
+
+  // Selector branch B: a multi-sport window, but the primary sport's own
+  // monotony is null (here the highest-Load family has fewer than 3 active
+  // days), so the selector falls back to total monotony. Before this, only
+  // the interpretation test and the parity matrix touched the selector — the
+  // primary-null fallback was never pinned directly.
+  it("falls back to total monotony when multi-sport but primary-sport monotony is null", () => {
+    const rows = [
+      // Ride is the highest-Load family (600) but only 2 active days, so its
+      // primary-sport monotony is null (the computer needs ≥ 3).
+      { start_date_local: "2026-05-09T08:00:00", icu_training_load: 300, type: "Ride" },
+      { start_date_local: "2026-05-10T08:00:00", icu_training_load: 300, type: "Ride" },
+      // Run is a second family (so the window is multi-sport) with 3 days.
+      { start_date_local: "2026-05-04T08:00:00", icu_training_load: 50, type: "Run" },
+      { start_date_local: "2026-05-05T08:00:00", icu_training_load: 50, type: "Run" },
+      { start_date_local: "2026-05-06T08:00:00", icu_training_load: 50, type: "Run" },
+    ];
+    const multiSport = input(rows, FROZEN);
+
+    // Multi-sport (Ride + Run) yet the primary family's monotony is null.
+    expect(computePrimarySportMonotony(multiSport)).toBeNull();
+
+    const total = computeMonotony(multiSport);
+    expect(total).not.toBeNull();
+    expect(computeEffectiveMonotony(multiSport)).toBe(total);
   });
 });

--- a/packages/core/src/reference/metrics/load-management.test.ts
+++ b/packages/core/src/reference/metrics/load-management.test.ts
@@ -27,6 +27,30 @@ function input(
   return { fixture: { activities }, frozenNow };
 }
 
+describe("computeMonotony", () => {
+  const FROZEN = "2026-05-10T12:00:00";
+
+  it("rounds on the exact mean/stdev at a 2-dp boundary, not the float ones", () => {
+    // 7-day window 05-04..05-10, one activity per day with loads whose exact
+    // mean is 123.5 and exact stdev 100.0 ⇒ ratio exactly 1.235 ⇒ Python
+    // round-half-to-even = 1.24. The previous float mean/stdev nudged the
+    // ratio just under 1.235 and rounded to 1.23. Monotony is order-
+    // independent under exact arithmetic, so the day assignment is arbitrary.
+    const loads = [21.2, 154.3, 268.1, 122.0, 34.6, 33.1, 231.2];
+    const days = ["04", "05", "06", "07", "08", "09", "10"];
+    const result = computeMonotony(
+      input(
+        loads.map((load, i) => ({
+          start_date_local: `2026-05-${days[i]}T08:00:00`,
+          icu_training_load: load,
+        })),
+        FROZEN,
+      ),
+    );
+    expect(result).toBe(1.24);
+  });
+});
+
 describe("computeStrain", () => {
   const FROZEN = "2026-05-10T12:00:00";
 
@@ -44,6 +68,25 @@ describe("computeStrain", () => {
       ),
     );
     expect(result).toBe(146);
+  });
+
+  it("sums weekly Load with Neumaier compensation at a round-0 boundary", () => {
+    // Daily loads 9.7/266.4/239.5/9.4 sum to exactly 525.0 under the oracle's
+    // compensated sum() (3.12+); a naive reduce gives 524.999…9. With monotony
+    // 0.62 the product is 325.5 → round-half-even = 326. Naive summation made
+    // it 325.499…9 → 325. Pins the pythonSum fix end-to-end.
+    const result = computeStrain(
+      input(
+        [
+          { start_date_local: "2026-05-06T08:00:00", icu_training_load: 9.7 },
+          { start_date_local: "2026-05-07T08:00:00", icu_training_load: 266.4 },
+          { start_date_local: "2026-05-08T08:00:00", icu_training_load: 239.5 },
+          { start_date_local: "2026-05-09T08:00:00", icu_training_load: 9.4 },
+        ],
+        FROZEN,
+      ),
+    );
+    expect(result).toBe(326);
   });
 
   it("cascades Unknown: monotony null ⇒ strain null", () => {

--- a/packages/core/src/reference/metrics/load-management.test.ts
+++ b/packages/core/src/reference/metrics/load-management.test.ts
@@ -309,3 +309,46 @@ describe("computeLoadRecoveryRatio", () => {
     expect(result).toBeNull();
   });
 });
+
+describe("load aggregators — malformed start_date_local is dropped, not thrown", () => {
+  const FROZEN = "2026-05-10T12:00:00";
+
+  // The load aggregators run over raw, unwindowed activities, so a row with a
+  // non-string start_date_local reaches the date slice (the distribution path
+  // is pre-windowed and never sees one). The oracle's window filter silently
+  // drops such rows; we must match — drop the row, compute over the rest —
+  // rather than throwing on it.
+  const wellFormed = [
+    { start_date_local: "2026-05-06T08:00:00", icu_training_load: 50, type: "Ride" },
+    { start_date_local: "2026-05-08T08:00:00", icu_training_load: 50, type: "Ride" },
+    { start_date_local: "2026-05-10T08:00:00", icu_training_load: 100, type: "Ride" },
+  ];
+
+  function fixtureOf(activities: unknown[]): MetricInput {
+    return { fixture: { activities }, frozenNow: FROZEN };
+  }
+
+  it("computeMonotony drops a null-date row (getDailyLoad)", () => {
+    const baseline = computeMonotony(fixtureOf(wellFormed));
+    expect(baseline).not.toBeNull();
+
+    const nullDate = { start_date_local: null, icu_training_load: 999, type: "Ride" };
+    let withMalformed: number | null = null;
+    expect(() => {
+      withMalformed = computeMonotony(fixtureOf([...wellFormed, nullDate]));
+    }).not.toThrow();
+    expect(withMalformed).toBe(baseline);
+  });
+
+  it("computeEffectiveMonotony drops a missing-date row (getDailyLoadBySport)", () => {
+    const baseline = computeEffectiveMonotony(fixtureOf(wellFormed));
+    expect(baseline).not.toBeNull();
+
+    const missingDate = { icu_training_load: 999, type: "Ride" };
+    let withMalformed: number | null = null;
+    expect(() => {
+      withMalformed = computeEffectiveMonotony(fixtureOf([...wellFormed, missingDate]));
+    }).not.toThrow();
+    expect(withMalformed).toBe(baseline);
+  });
+});

--- a/packages/core/src/reference/metrics/load-management.ts
+++ b/packages/core/src/reference/metrics/load-management.ts
@@ -8,6 +8,8 @@
 import type { Activity, WellnessDay } from "../schemas/inputs.js";
 
 import { getActivities, type MetricInput } from "./metric-input.js";
+import { roundHalfEven } from "./rounding.js";
+import { mean, pythonSum, sampleStdev } from "./statistics.js";
 
 /**
  * Acute:Chronic Workload Ratio (Gabbett 2016).
@@ -41,8 +43,8 @@ export function computeAcwr(input: MetricInput): number | null {
   const dailyLoad7d = getDailyLoad(activities, 7, input.frozenNow);
   const dailyLoad28d = getDailyLoad(activities, 28, input.frozenNow);
 
-  const load7dTotal = dailyLoad7d.reduce((s, t) => s + t, 0);
-  const load28dTotal = dailyLoad28d.reduce((s, t) => s + t, 0);
+  const load7dTotal = pythonSum(dailyLoad7d);
+  const load28dTotal = pythonSum(dailyLoad28d);
 
   const acuteLoad = load7dTotal ? load7dTotal / 7 : 0;
   const chronicLoad = load28dTotal ? load28dTotal / 28 : 0;
@@ -90,8 +92,8 @@ export function computeMonotony(input: MetricInput): number | null {
     return null;
   }
 
-  const meanLoad = arithmeticMean(dailyLoad7d);
-  const stdevLoad = sampleStdev(dailyLoad7d, meanLoad);
+  const meanLoad = mean(dailyLoad7d);
+  const stdevLoad = sampleStdev(dailyLoad7d);
   if (stdevLoad <= 0) return null;
 
   return roundHalfEven(meanLoad / stdevLoad, 2);
@@ -145,8 +147,7 @@ export function computePrimarySportMonotony(input: MetricInput): number | null {
   let primaryDays: number[] | undefined;
   let maxTotal = -Infinity;
   for (const days of dailyLoadBySport.values()) {
-    let total = 0;
-    for (const d of days) total += d;
+    const total = pythonSum(days);
     if (total > maxTotal) {
       maxTotal = total;
       primaryDays = days;
@@ -158,8 +159,8 @@ export function computePrimarySportMonotony(input: MetricInput): number | null {
   for (const d of primaryDays) if (d > 0) activeDays += 1;
   if (activeDays < 3 || primaryDays.length <= 1) return null;
 
-  const meanLoad = arithmeticMean(primaryDays);
-  const stdevLoad = sampleStdev(primaryDays, meanLoad);
+  const meanLoad = mean(primaryDays);
+  const stdevLoad = sampleStdev(primaryDays);
   if (stdevLoad <= 0) return null;
 
   return roundHalfEven(meanLoad / stdevLoad, 2);
@@ -242,7 +243,7 @@ export function computeStrain(input: MetricInput): number | null {
 
   const activities = getActivities(input);
   const dailyLoad7d = getDailyLoad(activities, 7, input.frozenNow);
-  const load7dTotal = dailyLoad7d.reduce((s, t) => s + t, 0);
+  const load7dTotal = pythonSum(dailyLoad7d);
 
   return roundHalfEven(load7dTotal * monotony, 0);
 }
@@ -388,9 +389,9 @@ export function computeRecoveryIndex(input: MetricInput): number | null {
     .filter((v): v is number => !!v);
 
   const hrvBaseline7d =
-    hrvValues7d.length > 0 ? roundHalfEven(arithmeticMean(hrvValues7d), 1) : null;
+    hrvValues7d.length > 0 ? roundHalfEven(mean(hrvValues7d), 1) : null;
   const rhrBaseline7d =
-    rhrValues7d.length > 0 ? roundHalfEven(arithmeticMean(rhrValues7d), 1) : null;
+    rhrValues7d.length > 0 ? roundHalfEven(mean(rhrValues7d), 1) : null;
 
   const latest = wellness7d.length > 0 ? wellness7d[wellness7d.length - 1]! : null;
   const latestHrvRaw = latest ? latest.hrv : null;
@@ -444,7 +445,7 @@ export function computeLoadRecoveryRatio(input: MetricInput): number | null {
 
   const activities = getActivities(input);
   const dailyLoad7d = getDailyLoad(activities, 7, input.frozenNow);
-  const load7dTotal = dailyLoad7d.reduce((s, t) => s + t, 0);
+  const load7dTotal = pythonSum(dailyLoad7d);
 
   return roundHalfEven(load7dTotal / (ri * 100), 1);
 }
@@ -507,34 +508,6 @@ const SPORT_FAMILIES: Record<string, string> = {
   Yoga: "other",
   Workout: "other",
 };
-
-function arithmeticMean(values: number[]): number {
-  let total = 0;
-  for (const v of values) total += v;
-  return total / values.length;
-}
-
-// Python's `statistics.stdev` uses Fraction-exact internal arithmetic
-// (`statistics._sum`); the TS port cannot reproduce that in pure float.
-// This two-pass Neumaier-style correction
-// (`sum((x-c)^2) - sum(x-c)^2/n`) is the closest float-only
-// approximation. Bit-identity to Python holds empirically on captured
-// fixtures because the final `roundHalfEven(_, 2)` masks sub-0.005
-// drift. A future fixture whose unrounded mean/stdev lands near a
-// rounding boundary may surface as a gate failure — treat as a real
-// divergence to triage, not as proof of algorithm equivalence.
-function sampleStdev(values: number[], xbar: number): number {
-  const n = values.length;
-  let total = 0;
-  let total2 = 0;
-  for (const x of values) {
-    const d = x - xbar;
-    total += d * d;
-    total2 += d;
-  }
-  const ss = total - (total2 * total2) / n;
-  return Math.sqrt(ss / (n - 1));
-}
 
 function getDailyLoad(
   activities: Activity[],
@@ -609,19 +582,4 @@ function isoDateDaysBefore(isoNow: string, daysBefore: number): string {
   const utc = new Date(Date.UTC(y, m - 1, d));
   utc.setUTCDate(utc.getUTCDate() - daysBefore);
   return utc.toISOString().slice(0, 10);
-}
-
-// Python's `round(x, n)` uses banker's rounding (round-half-to-even) and
-// diverges from `Math.round(x*10**n)/10**n` (round-half-up) for values
-// exactly at the half boundary. Mirroring Python keeps the gate
-// bit-identical on any future ACWR value that lands at the boundary.
-function roundHalfEven(value: number, decimals: number): number {
-  const factor = 10 ** decimals;
-  const scaled = value * factor;
-  const floor = Math.floor(scaled);
-  const diff = scaled - floor;
-  const epsilon = 1e-9;
-  if (diff < 0.5 - epsilon) return floor / factor;
-  if (diff > 0.5 + epsilon) return (floor + 1) / factor;
-  return (floor % 2 === 0 ? floor : floor + 1) / factor;
 }

--- a/packages/core/src/reference/metrics/load-management.ts
+++ b/packages/core/src/reference/metrics/load-management.ts
@@ -495,7 +495,14 @@ function getDailyLoad(
 ): number[] {
   const dailyLoad = new Map<string, number>();
   for (const act of activities) {
-    const dateStr = act.start_date_local.slice(0, 10);
+    // The load aggregators run over raw, unwindowed activities, so a
+    // non-string start_date_local reaches here (the distribution path is
+    // pre-filtered by getActivitiesInWindow and never sees one). The oracle's
+    // window filter drops such rows; bucketing them under "" is equivalent —
+    // the result array only ever reads real dates — and avoids throwing on
+    // malformed fixture input. Mirrors the guard in selectPrimarySport.
+    const dateStr =
+      typeof act.start_date_local === "string" ? act.start_date_local.slice(0, 10) : "";
     const load = act.icu_training_load || 0;
     dailyLoad.set(dateStr, (dailyLoad.get(dateStr) ?? 0) + load);
   }
@@ -526,7 +533,10 @@ function getDailyLoadBySport(
   for (const act of activities) {
     const load = act.icu_training_load || 0;
     if (load <= 0) continue;
-    const dateStr = act.start_date_local.slice(0, 10);
+    // Guarded like getDailyLoad: a non-string date buckets to "", which is
+    // never a window date, so the row is dropped — matching the oracle.
+    const dateStr =
+      typeof act.start_date_local === "string" ? act.start_date_local.slice(0, 10) : "";
     if (!windowDates.has(dateStr)) continue;
     // Object.hasOwn guards against prototype-chain lookups: a fixture
     // with act.type === "toString" / "constructor" / "__proto__" would

--- a/packages/core/src/reference/metrics/load-management.ts
+++ b/packages/core/src/reference/metrics/load-management.ts
@@ -503,6 +503,8 @@ function getDailyLoad(
     // malformed fixture input. Mirrors the guard in selectPrimarySport.
     const dateStr =
       typeof act.start_date_local === "string" ? act.start_date_local.slice(0, 10) : "";
+    // `|| 0` maps a hypothetical NaN load to 0; the upstream `or 0` keeps NaN.
+    // Unreachable: z.number() rejects NaN at the schema boundary.
     const load = act.icu_training_load || 0;
     dailyLoad.set(dateStr, (dailyLoad.get(dateStr) ?? 0) + load);
   }
@@ -531,6 +533,8 @@ function getDailyLoadBySport(
 
   const bySport = new Map<string, Map<string, number>>();
   for (const act of activities) {
+    // `|| 0` maps a hypothetical NaN load to 0 (skipped); the upstream `or 0`
+    // keeps NaN. Unreachable: z.number() rejects NaN at the schema boundary.
     const load = act.icu_training_load || 0;
     if (load <= 0) continue;
     // Guarded like getDailyLoad: a non-string date buckets to "", which is

--- a/packages/core/src/reference/metrics/load-management.ts
+++ b/packages/core/src/reference/metrics/load-management.ts
@@ -9,6 +9,7 @@ import type { Activity, WellnessDay } from "../schemas/inputs.js";
 
 import { getActivities, type MetricInput } from "./metric-input.js";
 import { roundHalfEven } from "./rounding.js";
+import { SPORT_FAMILIES } from "./sport-families.js";
 import { mean, pythonSum, sampleStdev } from "./statistics.js";
 
 /**
@@ -486,28 +487,6 @@ function getWellnessWindow(input: MetricInput, days: number): WellnessDay[] {
 function pyFloatStr(value: number): string {
   return Number.isInteger(value) ? `${value}.0` : `${value}`;
 }
-
-// Mirrors `SPORT_FAMILIES` at sync.py:290-308. Unmapped types fall
-// through to "other" at the lookup site.
-const SPORT_FAMILIES: Record<string, string> = {
-  Ride: "cycling",
-  VirtualRide: "cycling",
-  MountainBikeRide: "cycling",
-  GravelRide: "cycling",
-  EBikeRide: "cycling",
-  VirtualSki: "ski",
-  NordicSki: "ski",
-  Walk: "walk",
-  Hike: "walk",
-  Run: "run",
-  VirtualRun: "run",
-  TrailRun: "run",
-  Swim: "swim",
-  Rowing: "rowing",
-  WeightTraining: "strength",
-  Yoga: "other",
-  Workout: "other",
-};
 
 function getDailyLoad(
   activities: Activity[],

--- a/packages/core/src/reference/metrics/registry.test.ts
+++ b/packages/core/src/reference/metrics/registry.test.ts
@@ -1,38 +1,57 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
 import { describe, expect, it } from "vitest";
 
-import * as distribution from "./distribution.js";
-import * as loadManagement from "./load-management.js";
 import { METRIC_REGISTRY } from "./registry.js";
 
 // Inverse coverage. The parity gate warns when a snapshot on disk has no
 // METRIC_REGISTRY entry, but nothing asserts the other direction — that every
 // compute* function shipped in a metric module is actually wired into the
 // registry. Without this, a contributor can port a metric, forget to register
-// it, and still ship green CI: the new metric is simply never checked. This
-// test fails the moment an exported compute* function is missing from the
-// registry.
+// it, and still ship green CI: the new metric is simply never checked.
+//
+// Discovery is filesystem-driven (the same readdirSync(METRICS_DIR) walk as
+// tests/reference-strict-schemas.test.ts) so a NEW metric module —
+// capability.ts, compliance.ts, … — is picked up automatically. A hardcoded
+// module list would silently exempt the next file added, recreating the very
+// gap this test exists to close.
+const METRICS_DIR = dirname(fileURLToPath(import.meta.url));
+const COMPUTE_EXPORT_RE = /^export\s+(?:async\s+)?(?:function|const)\s+(compute[A-Z][A-Za-z0-9_]*)\b/gm;
+
+function exportedComputeFns(): Array<readonly [string, string]> {
+  const found: Array<readonly [string, string]> = [];
+  for (const entry of readdirSync(METRICS_DIR, { withFileTypes: true })) {
+    if (!entry.isFile()) continue;
+    if (!entry.name.endsWith(".ts")) continue;
+    if (entry.name === "index.ts") continue;
+    if (entry.name.endsWith(".test.ts")) continue;
+    const source = readFileSync(resolve(METRICS_DIR, entry.name), "utf-8");
+    for (const match of source.matchAll(COMPUTE_EXPORT_RE)) {
+      found.push([entry.name, match[1]]);
+    }
+  }
+  return found;
+}
+
 describe("METRIC_REGISTRY inverse coverage", () => {
-  it("registers every compute* function exported from the metric modules", () => {
-    const registered = new Set<unknown>(
-      Object.values(METRIC_REGISTRY).map((entry) => entry.compute),
+  it("registers every compute* function exported from a metric module", () => {
+    // Each registry entry holds the imported function directly, so its `.name`
+    // is the declared export name — compare against that rather than function
+    // identity, which sidesteps any ESM module-instance mismatch.
+    const registeredNames = new Set(
+      Object.values(METRIC_REGISTRY).map((entry) => entry.compute.name),
     );
 
-    const exported: string[] = [];
-    const unregistered: string[] = [];
-    for (const [moduleName, mod] of [
-      ["distribution", distribution],
-      ["load-management", loadManagement],
-    ] as const) {
-      for (const [name, value] of Object.entries(mod)) {
-        if (!name.startsWith("compute") || typeof value !== "function") continue;
-        exported.push(`${moduleName}.${name}`);
-        if (!registered.has(value)) unregistered.push(`${moduleName}.${name}`);
-      }
-    }
+    const exported = exportedComputeFns();
+    const unregistered = exported
+      .filter(([, name]) => !registeredNames.has(name))
+      .map(([file, name]) => `${file}: ${name}`);
 
     // Vacuity guard: discovery must find at least the registered set, or the
     // assertion below would pass trivially on an empty list.
-    expect(exported.length).toBeGreaterThanOrEqual(Object.keys(METRIC_REGISTRY).length);
+    expect(exported.length).toBeGreaterThanOrEqual(registeredNames.size);
     expect(unregistered).toEqual([]);
   });
 });

--- a/packages/core/src/reference/metrics/registry.test.ts
+++ b/packages/core/src/reference/metrics/registry.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import * as distribution from "./distribution.js";
+import * as loadManagement from "./load-management.js";
+import { METRIC_REGISTRY } from "./registry.js";
+
+// Inverse coverage. The parity gate warns when a snapshot on disk has no
+// METRIC_REGISTRY entry, but nothing asserts the other direction — that every
+// compute* function shipped in a metric module is actually wired into the
+// registry. Without this, a contributor can port a metric, forget to register
+// it, and still ship green CI: the new metric is simply never checked. This
+// test fails the moment an exported compute* function is missing from the
+// registry.
+describe("METRIC_REGISTRY inverse coverage", () => {
+  it("registers every compute* function exported from the metric modules", () => {
+    const registered = new Set<unknown>(
+      Object.values(METRIC_REGISTRY).map((entry) => entry.compute),
+    );
+
+    const exported: string[] = [];
+    const unregistered: string[] = [];
+    for (const [moduleName, mod] of [
+      ["distribution", distribution],
+      ["load-management", loadManagement],
+    ] as const) {
+      for (const [name, value] of Object.entries(mod)) {
+        if (!name.startsWith("compute") || typeof value !== "function") continue;
+        exported.push(`${moduleName}.${name}`);
+        if (!registered.has(value)) unregistered.push(`${moduleName}.${name}`);
+      }
+    }
+
+    // Vacuity guard: discovery must find at least the registered set, or the
+    // assertion below would pass trivially on an empty list.
+    expect(exported.length).toBeGreaterThanOrEqual(Object.keys(METRIC_REGISTRY).length);
+    expect(unregistered).toEqual([]);
+  });
+});

--- a/packages/core/src/reference/metrics/registry.ts
+++ b/packages/core/src/reference/metrics/registry.ts
@@ -11,6 +11,8 @@
 import {
   computeGreyZoneNote,
   computeGreyZonePercentage,
+  computeQualityIntensityNote,
+  computeQualityIntensityPercentage,
   computeZoneDistribution7d,
 } from "./distribution.js";
 import {
@@ -43,4 +45,6 @@ export const METRIC_REGISTRY: Record<string, MetricRegistryEntry> = {
   zone_distribution_7d: { compute: computeZoneDistribution7d },
   grey_zone_percentage: { compute: computeGreyZonePercentage },
   grey_zone_note: { compute: computeGreyZoneNote },
+  quality_intensity_percentage: { compute: computeQualityIntensityPercentage },
+  quality_intensity_note: { compute: computeQualityIntensityNote },
 };

--- a/packages/core/src/reference/metrics/registry.ts
+++ b/packages/core/src/reference/metrics/registry.ts
@@ -17,6 +17,7 @@ import {
   computeQualityIntensityPercentage,
   computeSeilerTid,
   computeSeilerTid28d,
+  computeSeilerTid28dPrimary,
   computeSeilerTidPrimary,
   computeZoneDistribution7d,
 } from "./distribution.js";
@@ -57,4 +58,5 @@ export const METRIC_REGISTRY: Record<string, MetricRegistryEntry> = {
   seiler_tid_7d: { compute: computeSeilerTid },
   seiler_tid_7d_primary: { compute: computeSeilerTidPrimary },
   seiler_tid_28d: { compute: computeSeilerTid28d },
+  seiler_tid_28d_primary: { compute: computeSeilerTid28dPrimary },
 };

--- a/packages/core/src/reference/metrics/registry.ts
+++ b/packages/core/src/reference/metrics/registry.ts
@@ -8,7 +8,11 @@
  * `packages/core/tests/reference-parity.test.ts` picks it up automatically.
  */
 
-import { computeZoneDistribution7d } from "./distribution.js";
+import {
+  computeGreyZoneNote,
+  computeGreyZonePercentage,
+  computeZoneDistribution7d,
+} from "./distribution.js";
 import {
   computeAcwr,
   computeEffectiveMonotony,
@@ -37,4 +41,6 @@ export const METRIC_REGISTRY: Record<string, MetricRegistryEntry> = {
   stress_tolerance: { compute: computeStressTolerance },
   load_recovery_ratio: { compute: computeLoadRecoveryRatio },
   zone_distribution_7d: { compute: computeZoneDistribution7d },
+  grey_zone_percentage: { compute: computeGreyZonePercentage },
+  grey_zone_note: { compute: computeGreyZoneNote },
 };

--- a/packages/core/src/reference/metrics/registry.ts
+++ b/packages/core/src/reference/metrics/registry.ts
@@ -8,7 +8,7 @@
  * `packages/core/tests/reference-parity.test.ts` picks it up automatically.
  */
 
-import type { MetricInput } from "./metric-input.js";
+import { computeZoneDistribution7d } from "./distribution.js";
 import {
   computeAcwr,
   computeEffectiveMonotony,
@@ -20,6 +20,7 @@ import {
   computeStrain,
   computeStressTolerance,
 } from "./load-management.js";
+import type { MetricInput } from "./metric-input.js";
 
 export interface MetricRegistryEntry {
   compute: (input: MetricInput) => unknown;
@@ -35,4 +36,5 @@ export const METRIC_REGISTRY: Record<string, MetricRegistryEntry> = {
   recovery_index: { compute: computeRecoveryIndex },
   stress_tolerance: { compute: computeStressTolerance },
   load_recovery_ratio: { compute: computeLoadRecoveryRatio },
+  zone_distribution_7d: { compute: computeZoneDistribution7d },
 };

--- a/packages/core/src/reference/metrics/registry.ts
+++ b/packages/core/src/reference/metrics/registry.ts
@@ -16,6 +16,7 @@ import {
   computeQualityIntensityNote,
   computeQualityIntensityPercentage,
   computeSeilerTid,
+  computeSeilerTidPrimary,
   computeZoneDistribution7d,
 } from "./distribution.js";
 import {
@@ -53,4 +54,5 @@ export const METRIC_REGISTRY: Record<string, MetricRegistryEntry> = {
   easy_time_ratio: { compute: computeEasyTimeRatio },
   easy_time_ratio_note: { compute: computeEasyTimeRatioNote },
   seiler_tid_7d: { compute: computeSeilerTid },
+  seiler_tid_7d_primary: { compute: computeSeilerTidPrimary },
 };

--- a/packages/core/src/reference/metrics/registry.ts
+++ b/packages/core/src/reference/metrics/registry.ts
@@ -9,6 +9,8 @@
  */
 
 import {
+  computeEasyTimeRatio,
+  computeEasyTimeRatioNote,
   computeGreyZoneNote,
   computeGreyZonePercentage,
   computeQualityIntensityNote,
@@ -47,4 +49,6 @@ export const METRIC_REGISTRY: Record<string, MetricRegistryEntry> = {
   grey_zone_note: { compute: computeGreyZoneNote },
   quality_intensity_percentage: { compute: computeQualityIntensityPercentage },
   quality_intensity_note: { compute: computeQualityIntensityNote },
+  easy_time_ratio: { compute: computeEasyTimeRatio },
+  easy_time_ratio_note: { compute: computeEasyTimeRatioNote },
 };

--- a/packages/core/src/reference/metrics/registry.ts
+++ b/packages/core/src/reference/metrics/registry.ts
@@ -15,6 +15,7 @@ import {
   computeGreyZonePercentage,
   computeQualityIntensityNote,
   computeQualityIntensityPercentage,
+  computeSeilerTid,
   computeZoneDistribution7d,
 } from "./distribution.js";
 import {
@@ -51,4 +52,5 @@ export const METRIC_REGISTRY: Record<string, MetricRegistryEntry> = {
   quality_intensity_note: { compute: computeQualityIntensityNote },
   easy_time_ratio: { compute: computeEasyTimeRatio },
   easy_time_ratio_note: { compute: computeEasyTimeRatioNote },
+  seiler_tid_7d: { compute: computeSeilerTid },
 };

--- a/packages/core/src/reference/metrics/registry.ts
+++ b/packages/core/src/reference/metrics/registry.ts
@@ -16,6 +16,7 @@ import {
   computeQualityIntensityNote,
   computeQualityIntensityPercentage,
   computeSeilerTid,
+  computeSeilerTid28d,
   computeSeilerTidPrimary,
   computeZoneDistribution7d,
 } from "./distribution.js";
@@ -55,4 +56,5 @@ export const METRIC_REGISTRY: Record<string, MetricRegistryEntry> = {
   easy_time_ratio_note: { compute: computeEasyTimeRatioNote },
   seiler_tid_7d: { compute: computeSeilerTid },
   seiler_tid_7d_primary: { compute: computeSeilerTidPrimary },
+  seiler_tid_28d: { compute: computeSeilerTid28d },
 };

--- a/packages/core/src/reference/metrics/rounding.test.ts
+++ b/packages/core/src/reference/metrics/rounding.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import { roundHalfEven } from "./rounding.js";
+
+// Reference values are Python `round(x, n)` outputs, captured directly from
+// CPython. They are chosen to discriminate the two ways a naive
+// implementation fails:
+//   - scaled-binary (`Math.round(x*10**n)/10**n` or a decimal lib seeded from
+//     the shortest string) gets 0.005 and 0.025 wrong;
+//   - naive half-away (`toFixed`) gets the even-tie cases 0.015, 0.125, 0.625,
+//     2.675 wrong.
+// Passing every row proves agreement with Python's round-half-to-even on the
+// *true* IEEE-754 value, which is what the parity gate asserts.
+describe("roundHalfEven matches Python round()", () => {
+  const twoDp: Array<[number, number]> = [
+    [0.005, 0.01], // exact double > 0.005 → up; scaled form gives 0
+    [0.015, 0.01], // even-tie down; half-away gives 0.02
+    [0.025, 0.03], // exact double > 0.025 → up; scaled form gives 0.02
+    [0.045, 0.04], // even-tie down; half-away gives 0.05
+    [0.125, 0.12], // exact tie, floor even → down; half-away gives 0.13
+    [0.135, 0.14],
+    [0.375, 0.38],
+    [0.625, 0.62], // exact tie, floor even → down; half-away gives 0.63
+    [0.875, 0.88],
+    [2.675, 2.67], // even-tie down; half-away gives 2.68
+  ];
+
+  const oneDp: Array<[number, number]> = [
+    [0.05, 0.1],
+    [0.15, 0.1], // even-tie down
+    [0.25, 0.2], // even-tie down
+    [0.35, 0.3], // even-tie down
+    [0.45, 0.5],
+    [2.85, 2.9],
+    [2.95, 3.0],
+    [28.75, 28.8],
+  ];
+
+  const zeroDp: Array<[number, number]> = [
+    [0.5, 0],
+    [1.5, 2],
+    [2.5, 2], // even-tie down
+    [3.5, 4],
+  ];
+
+  it.each(twoDp)("round(%f, 2) === %f", (value, expected) => {
+    expect(roundHalfEven(value, 2)).toBe(expected);
+  });
+
+  it.each(oneDp)("round(%f, 1) === %f", (value, expected) => {
+    expect(roundHalfEven(value, 1)).toBe(expected);
+  });
+
+  it.each(zeroDp)("round(%f, 0) === %f", (value, expected) => {
+    expect(roundHalfEven(value, 0)).toBe(expected);
+  });
+
+  it("rounds the true value, not the base-10 scaling (regression for the F8/F9 bug)", () => {
+    // 18s / 3600 = 0.005 h. The scaled form computed 0.005*100 = 0.4999…94 and
+    // rounded to 0, dropping the bin; Python keeps it at 0.01.
+    expect(roundHalfEven(18 / 3600, 2)).toBe(0.01);
+    expect(roundHalfEven(90 / 3600, 2)).toBe(0.03);
+  });
+
+  it("handles sign, zero, and non-finite inputs like Python", () => {
+    expect(roundHalfEven(-0.125, 2)).toBe(-0.12);
+    expect(roundHalfEven(-2.5, 0)).toBe(-2);
+    expect(roundHalfEven(0, 2)).toBe(0);
+    expect(roundHalfEven(Number.NaN, 2)).toBeNaN();
+    expect(roundHalfEven(Number.POSITIVE_INFINITY, 2)).toBe(Number.POSITIVE_INFINITY);
+  });
+});

--- a/packages/core/src/reference/metrics/rounding.ts
+++ b/packages/core/src/reference/metrics/rounding.ts
@@ -1,0 +1,61 @@
+/**
+ * Reference layer — Python-compatible decimal rounding.
+ *
+ * The upstream rounds every emitted metric with Python's builtin
+ * `round(x, n)`, which is round-half-to-even (banker's) applied to the
+ * *true* value of the IEEE-754 double — not to a base-10 reconstruction of
+ * it. Reproducing that bit-for-bit is the whole job: the parity gate asserts
+ * tolerance-zero equality against snapshots Python produced, so any rounding
+ * that disagrees on even one boundary flips the gate red.
+ *
+ * The obvious `Math.round(value * 10**n) / 10**n` is wrong, and so is every
+ * decimal library seeded from a number's shortest round-trip string
+ * (`new Decimal(0.005)` → "0.005"): both decide the half-distance from a
+ * value that has already lost the sub-ULP information Python rounds on.
+ * Concretely, `0.005` is stored as 0.005000000000000000104…, so Python
+ * rounds it *up* to `0.01`; scaling by 100 yields `0.49999999999999994`,
+ * which rounds *down* to `0`. ~1.3% of `secs/3600` values and ~10% of
+ * one-dp percentages diverge that way.
+ *
+ * So we round the exact rational the double represents. A finite double is
+ * `mantissa × 2^exponent` with both integers; multiply by `10^decimals`,
+ * round the resulting exact fraction to the nearest integer with ties to
+ * even, then divide back. All of it is done in `BigInt`, so there is no
+ * intermediate float error to decide the boundary wrongly.
+ */
+export function roundHalfEven(value: number, decimals: number): number {
+  if (!Number.isFinite(value) || value === 0) return value;
+
+  const view = new DataView(new ArrayBuffer(8));
+  view.setFloat64(0, value);
+  const bits = view.getBigUint64(0);
+
+  const negative = (bits >> 63n) & 1n;
+  const rawExponent = Number((bits >> 52n) & 0x7ffn);
+  let mantissa = bits & 0xf_ffff_ffff_ffffn;
+  let exponent: number;
+  if (rawExponent === 0) {
+    exponent = -1074; // subnormal
+  } else {
+    mantissa |= 0x10_0000_0000_0000n; // restore the implicit leading 1
+    exponent = rawExponent - 1075;
+  }
+
+  // |value| × 10^decimals expressed as the exact fraction numerator/denominator.
+  let numerator = mantissa * 10n ** BigInt(decimals);
+  let denominator = 1n;
+  if (exponent >= 0) numerator <<= BigInt(exponent);
+  else denominator <<= BigInt(-exponent);
+
+  let quotient = numerator / denominator;
+  const remainder = numerator % denominator;
+  const doubleRemainder = 2n * remainder;
+  // Round half to even: round up when past the half, or exactly at the half
+  // with an odd quotient.
+  if (doubleRemainder > denominator || (doubleRemainder === denominator && quotient % 2n === 1n)) {
+    quotient += 1n;
+  }
+
+  const magnitude = Number(quotient) / 10 ** decimals;
+  return negative === 1n ? -magnitude : magnitude;
+}

--- a/packages/core/src/reference/metrics/sport-families.ts
+++ b/packages/core/src/reference/metrics/sport-families.ts
@@ -1,0 +1,35 @@
+/**
+ * Reference layer — activity-type → sport-family lookup.
+ *
+ * Mirrors the `SPORT_FAMILIES` table at `sync.py:290-308`, the single
+ * upstream class constant shared by the daily-Load-by-sport aggregator,
+ * the seven-zone aggregator, and the Seiler aggregator. See `NOTICE.md`
+ * for license attribution.
+ *
+ * Only the TABLE lives here. The default for an UNMAPPED type is decided
+ * at each call site, because the upstream functions disagree: the
+ * seven-zone `_aggregate_zones` defaults to `null` (no `prefer_hr`, rides
+ * the power-preferred path), while `_get_daily_tss_by_sport` and
+ * `_aggregate_seiler_zones` default to `"other"`. Callers guard with
+ * `Object.hasOwn(SPORT_FAMILIES, type)` and supply their own fallback —
+ * don't fold a default into this table.
+ */
+export const SPORT_FAMILIES: Record<string, string> = {
+  Ride: "cycling",
+  VirtualRide: "cycling",
+  MountainBikeRide: "cycling",
+  GravelRide: "cycling",
+  EBikeRide: "cycling",
+  VirtualSki: "ski",
+  NordicSki: "ski",
+  Walk: "walk",
+  Hike: "walk",
+  Run: "run",
+  VirtualRun: "run",
+  TrailRun: "run",
+  Swim: "swim",
+  Rowing: "rowing",
+  WeightTraining: "strength",
+  Yoga: "other",
+  Workout: "other",
+};

--- a/packages/core/src/reference/metrics/statistics.test.ts
+++ b/packages/core/src/reference/metrics/statistics.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import { roundHalfEven } from "./rounding.js";
+import { mean, pythonSum, sampleStdev } from "./statistics.js";
+
+// Reference values are CPython 3.10 `statistics.mean` / `statistics.stdev`
+// outputs, captured directly (3.10 is the snapshot oracle). They are chosen
+// to discriminate the exact-rational path from a naive float `sum/n` +
+// two-pass stdev: the floats agree to many digits but diverge in the last
+// ULPs, and that drift can flip the final `round(_, 2)` at a boundary.
+describe("mean matches CPython statistics.mean", () => {
+  const cases: Array<[number[], number]> = [
+    [[21.2, 154.3, 268.1, 122.0, 34.6, 33.1, 231.2], 123.5],
+    [[0.1, 0.2, 0.3], 0.2],
+    [[50, 50, 50, 50, 50, 50, 55], 50.714285714285715],
+    [[60, 0, 0, 90, 0, 0, 120], 38.57142857142857],
+    [[48.5, 52.3, 49.9, 51.1, 50.0, 47.7, 53.2], 50.385714285714286],
+    [[100.0, 100.1, 99.9, 100.2, 99.8, 100.05, 99.95], 100.0],
+    [[42.5], 42.5],
+  ];
+
+  it.each(cases)("mean(%j) === %f", (values, expected) => {
+    expect(mean(values)).toBe(expected);
+  });
+});
+
+describe("sampleStdev matches CPython statistics.stdev", () => {
+  const cases: Array<[number[], number]> = [
+    [[21.2, 154.3, 268.1, 122.0, 34.6, 33.1, 231.2], 100.0],
+    [[0.1, 0.2, 0.3], 0.09999999999999999],
+    [[50, 50, 50, 50, 50, 50, 55], 1.889822365046136],
+    [[60, 0, 0, 90, 0, 0, 120], 51.1300861947808],
+    [[48.5, 52.3, 49.9, 51.1, 50.0, 47.7, 53.2], 1.9684414913229968],
+    [[100.0, 100.1, 99.9, 100.2, 99.8, 100.05, 99.95], 0.13228756555322918],
+  ];
+
+  it.each(cases)("stdev(%j) === %f", (values, expected) => {
+    expect(sampleStdev(values)).toBe(expected);
+  });
+});
+
+describe("pythonSum matches CPython 3.12+ sum() (Neumaier)", () => {
+  it("compensates like the builtin, not naive left-to-right", () => {
+    // CPython 3.12+ `sum()` uses Neumaier compensated summation. This daily-
+    // load array sums to exactly 525.0 under the oracle; a naive reduce gives
+    // 524.9999999999999, which flips round(525 × 0.62, 0) from 326 to 325.
+    const daily = [0, 0, 9.7, 266.4, 239.5, 9.4, 0];
+    expect(pythonSum(daily)).toBe(525);
+    expect(daily.reduce((s, t) => s + t, 0)).toBe(524.9999999999999); // the bug
+  });
+
+  it("equals exact sums where naive accumulation also would", () => {
+    expect(pythonSum([])).toBe(0);
+    expect(pythonSum([90, 0, 120, 0, 0, 75, 0])).toBe(285);
+  });
+});
+
+describe("monotony boundary regression (exact-vs-float drift)", () => {
+  it("rounds at the 2-dp boundary on the true mean/stdev, not the float ones", () => {
+    // Daily loads where the exact mean (123.5) and exact stdev (100.0) give
+    // a ratio of exactly 1.235 → Python round-half-to-even = 1.24. A naive
+    // float sum/n + two-pass stdev nudged the ratio just under 1.235 and
+    // rounded to 1.23 — the deleted helpers' bug. This is the case the three
+    // tidy golden fixtures could never surface (~1 in 2M random vectors).
+    const loads = [21.2, 154.3, 268.1, 122.0, 34.6, 33.1, 231.2];
+    const m = mean(loads);
+    const s = sampleStdev(loads);
+    expect(m).toBe(123.5);
+    expect(s).toBe(100.0);
+    expect(roundHalfEven(m / s, 2)).toBe(1.24);
+  });
+});

--- a/packages/core/src/reference/metrics/statistics.ts
+++ b/packages/core/src/reference/metrics/statistics.ts
@@ -1,0 +1,228 @@
+/**
+ * Reference layer — Python-compatible exact statistics.
+ *
+ * The upstream computes total/primary-sport monotony and the wellness
+ * baselines with Python's `statistics.mean` / `statistics.stdev`, which
+ * accumulate in exact rational arithmetic (`Fraction`) and round to a
+ * double only at the very end. A naive float `sum/n` and a float two-pass
+ * stdev diverge from that in the last ULPs, and the divergence can survive
+ * the final `round(_, 2)` at a boundary — e.g. daily loads
+ * `[21.2, 154.3, 268.1, 122.0, 34.6, 33.1, 231.2]` give float monotony
+ * `1.23` where Python gives `1.24`. The parity gate is tolerance-zero, so
+ * we reproduce the exact-rational path in `BigInt`.
+ *
+ * Target semantics are the snapshot oracle, which runs the upstream under
+ * Pyodide (CPython 3.13):
+ *
+ *   mean(data)  = float(Σxᵢ / n)                  — nearest double
+ *   stdev(data) = correctly-rounded √(Σ(xᵢ − mean)² / (n − 1))
+ *
+ * `mean` is version-stable. `stdev` is NOT: CPython ≤3.11 returned
+ * `math.sqrt(float(variance))` (two rounding steps), but 3.12+ rounds the
+ * square root of the *exact* variance fraction once, via
+ * `_float_sqrt_of_frac` (round-to-odd integer sqrt, then a single
+ * round-to-nearest-even). The two disagree by a ULP often enough
+ * (~13% of vectors) that mirroring the wrong one is itself a deviation, so
+ * we reproduce the 3.12+ correctly-rounded path. `stdev` derives its own
+ * exact mean internally, independent of the value `mean()` returns.
+ *
+ * Each finite double is the exact dyadic rational `num / 2^k` (`num`
+ * signed, `k ≥ 0`); sums of such rationals stay exact in `BigInt`, so the
+ * only rounding is the single correctly-rounded `ratioToDouble` at the end
+ * — mirroring `float(Fraction)`.
+ */
+
+function bitLength(value: bigint): number {
+  return value.toString(2).length;
+}
+
+// Python `sum(values)` on CPython 3.12+ — which switched the builtin from
+// naive left-to-right accumulation to Neumaier compensated summation for
+// floats (bpo-43475). The two disagree by a ULP often enough to flip a
+// downstream `round()` boundary: e.g. summing the daily-load array
+// [0, 0, 9.7, 266.4, 239.5, 9.4, 0] gives 525.0 here but 524.999…9 naively,
+// which moves `round(tss × 0.62, 0)` from 326 to 325. Mirror the oracle.
+export function pythonSum(values: number[]): number {
+  let sum = 0;
+  let compensation = 0;
+  for (const x of values) {
+    const t = sum + x;
+    compensation += Math.abs(sum) >= Math.abs(x) ? sum - t + x : x - t + sum;
+    sum = t;
+  }
+  return sum + compensation;
+}
+
+// A finite double as the exact rational `num / 2^k` (k ≥ 0, num signed).
+function toRatio(value: number): { num: bigint; k: bigint } {
+  const view = new DataView(new ArrayBuffer(8));
+  view.setFloat64(0, value);
+  const bits = view.getBigUint64(0);
+
+  const negative = (bits >> 63n) & 1n;
+  const rawExponent = Number((bits >> 52n) & 0x7ffn);
+  let mantissa = bits & 0xf_ffff_ffff_ffffn;
+  let exponent: number;
+  if (rawExponent === 0) {
+    exponent = -1074; // subnormal
+  } else {
+    mantissa |= 0x10_0000_0000_0000n; // restore the implicit leading 1
+    exponent = rawExponent - 1075;
+  }
+
+  let num: bigint;
+  let k: bigint;
+  if (exponent >= 0) {
+    num = mantissa << BigInt(exponent);
+    k = 0n;
+  } else {
+    num = mantissa;
+    k = BigInt(-exponent);
+  }
+  return { num: negative === 1n ? -num : num, k };
+}
+
+// Correctly-rounded (ties to even) double nearest to `numerator / denominator`,
+// matching Python's `float(Fraction(numerator, denominator))`. `denominator`
+// must be a positive integer.
+function ratioToDouble(numerator: bigint, denominator: bigint): number {
+  if (numerator === 0n) return 0;
+  const negative = numerator < 0n;
+  const num = negative ? -numerator : numerator;
+  const den = denominator;
+
+  // Scale so the integer quotient lands in [2^53, 2^55): 54 or 55 bits, a
+  // 53-bit significand plus at least one round bit. `bitLength` brackets
+  // log2 to ±1, so `54 - approx` guarantees ≥ 54 bits — only ever too wide.
+  const approx = bitLength(num) - bitLength(den);
+  let shift = 54 - approx;
+  const scaledNum = shift >= 0 ? num << BigInt(shift) : num;
+  const scaledDen = shift >= 0 ? den : den << BigInt(-shift);
+
+  let quotient = scaledNum / scaledDen;
+  let remainder = scaledNum % scaledDen;
+
+  // Shed surplus low bits down to exactly 54, folding any dropped 1 into the
+  // sticky remainder so the round decision still sees it.
+  let bits = bitLength(quotient);
+  while (bits > 54) {
+    if ((quotient & 1n) === 1n) remainder = 1n;
+    quotient >>= 1n;
+    shift -= 1;
+    bits -= 1;
+  }
+
+  // quotient ∈ [2^53, 2^54): one round bit below the 53-bit significand.
+  const roundBit = quotient & 1n;
+  let mantissa = quotient >> 1n;
+  let exponent = shift - 1; // value ≈ mantissa · 2^(−exponent)
+  if (roundBit === 1n) {
+    if (remainder !== 0n) {
+      mantissa += 1n; // strictly past the half → up
+    } else if ((mantissa & 1n) === 1n) {
+      mantissa += 1n; // exact half → ties to even
+    }
+  }
+  if (mantissa === 1n << 53n) {
+    mantissa >>= 1n; // rounding carried out of 53 bits
+    exponent -= 1;
+  }
+
+  const magnitude = Number(mantissa) * 2 ** -exponent;
+  return negative ? -magnitude : magnitude;
+}
+
+// Σ of the values' exact rationals over the common denominator 2^maxK, as an
+// integer numerator plus that shared maxK. Shared by `mean` and `sampleStdev`.
+function exactSums(values: number[]): {
+  sx: bigint; // Σ xᵢ · 2^maxK   (i.e. Σxᵢ over denominator 2^maxK)
+  sxx: bigint; // Σ xᵢ² · 2^(2·maxK)  (Σxᵢ² over denominator 2^(2·maxK))
+  maxK: bigint;
+} {
+  const ratios = values.map(toRatio);
+  let maxK = 0n;
+  for (const r of ratios) if (r.k > maxK) maxK = r.k;
+
+  let sx = 0n;
+  let sxx = 0n;
+  for (const r of ratios) {
+    sx += r.num << (maxK - r.k);
+    sxx += (r.num * r.num) << (2n * maxK - 2n * r.k);
+  }
+  return { sx, sxx, maxK };
+}
+
+function gcd(a: bigint, b: bigint): bigint {
+  let x = a < 0n ? -a : a;
+  let y = b < 0n ? -b : b;
+  while (y !== 0n) [x, y] = [y, x % y];
+  return x;
+}
+
+function bigIntSqrt(value: bigint): bigint {
+  if (value < 2n) return value;
+  let x = value;
+  let y = (x + 1n) >> 1n;
+  while (y < x) {
+    x = y;
+    y = (x + value / x) >> 1n;
+  }
+  return x;
+}
+
+// Python `statistics._integer_sqrt_of_frac_rto` — √(n/m) to the nearest
+// integer using round-to-odd (sets the low bit when n/m is not a perfect
+// square, so the subsequent round-to-nearest-even can't double-round).
+function integerSqrtOfFracRto(n: bigint, m: bigint): bigint {
+  const a = bigIntSqrt(n / m);
+  return a * a * m !== n ? a | 1n : a;
+}
+
+const SQRT_BIT_WIDTH = 2 * 53 + 3; // 2 · mantissa-digits + 3
+
+// Python `statistics._float_sqrt_of_frac` — correctly-rounded √(n/m). The
+// round-to-odd integer sqrt is scaled so the final `numerator / denominator`
+// (numerator ≤ 53 bits, denominator a power of two) is exact except for the
+// single round-to-nearest-even of the division.
+function floatSqrtOfFrac(n: bigint, m: bigint): number {
+  if (n === 0n) return 0;
+  const q = Math.floor((bitLength(n) - bitLength(m) - SQRT_BIT_WIDTH) / 2);
+  let numerator: bigint;
+  let denominator: bigint;
+  if (q >= 0) {
+    numerator = integerSqrtOfFracRto(n, m << BigInt(2 * q)) << BigInt(q);
+    denominator = 1n;
+  } else {
+    numerator = integerSqrtOfFracRto(n << BigInt(-2 * q), m);
+    denominator = 1n << BigInt(-q);
+  }
+  return Number(numerator) / Number(denominator);
+}
+
+// Python `statistics.mean(values)` — float(Σxᵢ / n).
+export function mean(values: number[]): number {
+  const n = BigInt(values.length);
+  const { sx, maxK } = exactSums(values);
+  return ratioToDouble(sx, n << maxK);
+}
+
+// Python `statistics.stdev(values)` on CPython 3.12+ — the correctly-rounded
+// square root of the exact variance (exact sum of squared deviations over
+// n − 1). The variance fraction is reduced first, matching the `Fraction`
+// `mss.numerator/mss.denominator` the upstream passes in. Requires n ≥ 2.
+export function sampleStdev(values: number[]): number {
+  const n = BigInt(values.length);
+  const { sx, sxx, maxK } = exactSums(values);
+
+  // ss = Σ(xᵢ − mean)² = Σxᵢ² − (Σxᵢ)²/n, exact:
+  //   ss = (sxx·n − sx²) / (2^(2·maxK) · n)
+  //   variance = ss / (n − 1) = (sxx·n − sx²) / (2^(2·maxK) · n · (n − 1))
+  let varianceNum = sxx * n - sx * sx;
+  let varianceDen = (1n << (2n * maxK)) * n * (n - 1n);
+  const g = gcd(varianceNum, varianceDen);
+  if (g > 1n) {
+    varianceNum /= g;
+    varianceDen /= g;
+  }
+  return floatSqrtOfFrac(varianceNum, varianceDen);
+}

--- a/packages/core/src/reference/metrics/statistics.ts
+++ b/packages/core/src/reference/metrics/statistics.ts
@@ -180,10 +180,15 @@ function integerSqrtOfFracRto(n: bigint, m: bigint): bigint {
 
 const SQRT_BIT_WIDTH = 2 * 53 + 3; // 2 · mantissa-digits + 3
 
-// Python `statistics._float_sqrt_of_frac` — correctly-rounded √(n/m). The
-// round-to-odd integer sqrt is scaled so the final `numerator / denominator`
-// (numerator ≤ 53 bits, denominator a power of two) is exact except for the
-// single round-to-nearest-even of the division.
+// Python `statistics._float_sqrt_of_frac` — correctly-rounded √(n/m).
+// SQRT_BIT_WIDTH scales the round-to-odd integer sqrt so `numerator` carries
+// ~mant_dig+2 (≈55) significant bits — NOT ≤53 — with its low bit set as a
+// sticky round bit (round-to-odd) so that narrowing it to a 53-bit double is
+// correctly rounded. `denominator` (and the `<< q` factor) are powers of two,
+// so `Number(numerator) / Number(denominator)` only shifts the binary exponent
+// — no second rounding. The lone rounding is `Number(numerator)`, which
+// round-to-odd makes exact. A non-power-of-two denominator would round a second
+// time and defeat round-to-odd, diverging from CPython's Fraction-exact sqrt.
 function floatSqrtOfFrac(n: bigint, m: bigint): number {
   if (n === 0n) return 0;
   const q = Math.floor((bitLength(n) - bitLength(m) - SQRT_BIT_WIDTH) / 2);
@@ -199,7 +204,9 @@ function floatSqrtOfFrac(n: bigint, m: bigint): number {
   return Number(numerator) / Number(denominator);
 }
 
-// Python `statistics.mean(values)` — float(Σxᵢ / n).
+// Python `statistics.mean(values)` — float(Σxᵢ / n). `mean([])` returns 0
+// (ratioToDouble short-circuits on a zero numerator), not NaN and not the
+// StatisticsError Python raises; every caller guards a non-empty input.
 export function mean(values: number[]): number {
   const n = BigInt(values.length);
   const { sx, maxK } = exactSums(values);
@@ -209,7 +216,11 @@ export function mean(values: number[]): number {
 // Python `statistics.stdev(values)` on CPython 3.12+ — the correctly-rounded
 // square root of the exact variance (exact sum of squared deviations over
 // n − 1). The variance fraction is reduced first, matching the `Fraction`
-// `mss.numerator/mss.denominator` the upstream passes in. Requires n ≥ 2.
+// `mss.numerator/mss.denominator` the upstream passes in. Requires n ≥ 2;
+// below that it returns 0 (varianceNum is 0n, so floatSqrtOfFrac short-circuits
+// before the n−1 = 0 denominator divides — no throw), not the NaN the
+// pre-rewrite float impl produced. 0 is guard-friendly: callers gate on
+// `stdev <= 0`, which 0 satisfies but NaN would have slipped through.
 export function sampleStdev(values: number[]): number {
   const n = BigInt(values.length);
   const { sx, sxx, maxK } = exactSums(values);

--- a/packages/core/src/reference/metrics/statistics.ts
+++ b/packages/core/src/reference/metrics/statistics.ts
@@ -30,6 +30,17 @@
  * signed, `k ≥ 0`); sums of such rationals stay exact in `BigInt`, so the
  * only rounding is the single correctly-rounded `ratioToDouble` at the end
  * — mirroring `float(Fraction)`.
+ *
+ * Out of scope here, by policy: transcendentals (`log`/`exp`/`pow`/trig).
+ * IEEE-754 does not mandate correctly-rounded transcendentals, so V8's `Math.*`
+ * and the oracle's libm (Pyodide/emscripten) may disagree in the last ULP. We
+ * do NOT reproduce the oracle's libm for these — V8's `Math.*` is used directly
+ * and the last-ULP agreement is accepted as a platform fidelity residual. The
+ * first instance is `polarization_index`'s `log10` (see `distribution.ts`):
+ * ~1e-14 reachability, and the tolerance-zero gate would surface a
+ * boundary-straddle in CI rather than ship it. Future transcendental metrics
+ * inherit this acceptance unless a real fixture trips the gate — at which point
+ * the choice is regenerate-the-snapshot or reproduce-the-exact-libm for that op.
  */
 
 function bitLength(value: bigint): number {

--- a/packages/core/src/reference/schemas/inputs.ts
+++ b/packages/core/src/reference/schemas/inputs.ts
@@ -22,11 +22,11 @@ export const IcuIntervalRepSchema = z.looseObject({
 });
 export type IcuIntervalRep = z.infer<typeof IcuIntervalRepSchema>;
 
-/** Per-bin zone-time entry as returned by intervals.icu. The API returns
- *  the object form `{id: "Z1", secs: N}` for native bins and the bare
- *  `number` form for pre-flattened payloads. The lib's own ActivitySchema
- *  encodes the same union; we mirror it here so `z.looseObject()` keeps
- *  its promise — real intervals.icu shape rides through unmodified. */
+/** Per-bin zone-time entry. The pace/HR zone-time fields can appear either as
+ *  the object form `{id: "Z1", secs: N}` or a bare-number form (pre-flattened
+ *  seconds); this union stays permissive for those because their shape isn't
+ *  pinned to the oracle. `icu_zone_times` is the exception — it is object-form
+ *  ONLY (see `IcuZoneTimeEntrySchema`). */
 export const ZoneTimeEntrySchema = z.union([
   z.number().nonnegative(),
   z.looseObject({
@@ -35,6 +35,21 @@ export const ZoneTimeEntrySchema = z.union([
   }),
 ]);
 export type ZoneTimeEntry = z.infer<typeof ZoneTimeEntrySchema>;
+
+/** `icu_zone_times` entry — object form `{id, secs}` only, never a bare number.
+ *  The upstream protocol reads this field with `zone.get("id")` /
+ *  `zone.get("secs")` and raises `AttributeError` on a bare number (an `int`
+ *  has no `.get`). So a bare-number entry is a shape the oracle cannot process
+ *  and the parity gate can never capture; accepting it here would only let it
+ *  reach the read side, which doesn't recognize it and silently undercounts the
+ *  activity's zone time. Reject it at the boundary — object-form is the API's
+ *  native bin shape (confirmed against the upstream's `_get_activity_zones`)
+ *  and the only portable one. */
+export const IcuZoneTimeEntrySchema = z.looseObject({
+  id: z.string().optional(),
+  secs: z.number().nonnegative(),
+});
+export type IcuZoneTimeEntry = z.infer<typeof IcuZoneTimeEntrySchema>;
 
 /** Time-in-zone breakdown — Seiler 3-zone bins are derived from these. */
 export const ZoneTimesSchema = z.looseObject({
@@ -70,12 +85,14 @@ export const ActivitySchema = z.looseObject({
   average_watts: z.number().nullable().optional(),
   average_heartrate: z.number().nullable().optional(),
 
-  // Zone-time breakdowns. See ZoneTimeEntrySchema above for the
-  // number-vs-object union the API actually returns. Nullable because
-  // intervals.icu writes `null` (not just absent) for activities that
-  // lack the zone-time series — e.g., a strength session has no
-  // pace_zone_times and the API ships the field with a null value.
-  icu_zone_times: z.array(ZoneTimeEntrySchema).nullable().optional(),
+  // Zone-time breakdowns. `icu_zone_times` is object-form only
+  // (IcuZoneTimeEntrySchema) — the shape the upstream reads and the only one
+  // the parity gate can capture; the pace/HR fields stay on the permissive
+  // union since their shape isn't pinned. Nullable because intervals.icu
+  // writes `null` (not just absent) for activities that lack the zone-time
+  // series — e.g., a strength session has no pace_zone_times and the API
+  // ships the field with a null value.
+  icu_zone_times: z.array(IcuZoneTimeEntrySchema).nullable().optional(),
   pace_zone_times: z.array(ZoneTimeEntrySchema).nullable().optional(),
   hr_zone_times: z.array(ZoneTimeEntrySchema).nullable().optional(),
 

--- a/packages/core/src/reference/schemas/inputs.ts
+++ b/packages/core/src/reference/schemas/inputs.ts
@@ -44,10 +44,12 @@ export type ZoneTimeEntry = z.infer<typeof ZoneTimeEntrySchema>;
  *  reach the read side, which doesn't recognize it and silently undercounts the
  *  activity's zone time. Reject it at the boundary — object-form is the API's
  *  native bin shape (confirmed against the upstream's `_get_activity_zones`)
- *  and the only portable one. */
+ *  and the only portable one. `secs` is optional: the oracle reads it as
+ *  `zone.get("secs", 0)` and the reader coerces a missing value to 0, so a
+ *  `{ id }`-only bin is processable (contributes 0), not a parse failure. */
 export const IcuZoneTimeEntrySchema = z.looseObject({
   id: z.string().optional(),
-  secs: z.number().nonnegative(),
+  secs: z.number().nonnegative().optional(),
 });
 export type IcuZoneTimeEntry = z.infer<typeof IcuZoneTimeEntrySchema>;
 

--- a/packages/core/tests/fixtures/golden/boundary-monotony.json
+++ b/packages/core/tests/fixtures/golden/boundary-monotony.json
@@ -1,0 +1,363 @@
+{
+  "activities": [
+    {
+      "id": "bm0",
+      "start_date_local": "2026-05-04T08:00:00",
+      "type": "Ride",
+      "name": "sanitized",
+      "moving_time": 5207,
+      "elapsed_time": 5217,
+      "icu_training_load": 21.2,
+      "icu_intensity": 78.97436,
+      "average_heartrate": 142,
+      "icu_zone_times": [
+        {
+          "id": "Z1",
+          "secs": 608
+        },
+        {
+          "id": "Z2",
+          "secs": 2361
+        },
+        {
+          "id": "Z3",
+          "secs": 1321
+        },
+        {
+          "id": "Z4",
+          "secs": 561
+        },
+        {
+          "id": "Z5",
+          "secs": 196
+        },
+        {
+          "id": "Z6",
+          "secs": 107
+        },
+        {
+          "id": "Z7",
+          "secs": 53
+        },
+        {
+          "id": "SS",
+          "secs": 780
+        }
+      ],
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "decoupling": -4.7151833,
+      "icu_efficiency_factor": 1.084507,
+      "fitnessAtEnd": 28.78709,
+      "fatigueAtEnd": 53.354916
+    },
+    {
+      "id": "bm1",
+      "start_date_local": "2026-05-05T08:00:00",
+      "type": "Ride",
+      "name": "sanitized",
+      "moving_time": 5207,
+      "elapsed_time": 5217,
+      "icu_training_load": 154.3,
+      "icu_intensity": 78.97436,
+      "average_heartrate": 142,
+      "icu_zone_times": [
+        {
+          "id": "Z1",
+          "secs": 608
+        },
+        {
+          "id": "Z2",
+          "secs": 2361
+        },
+        {
+          "id": "Z3",
+          "secs": 1321
+        },
+        {
+          "id": "Z4",
+          "secs": 561
+        },
+        {
+          "id": "Z5",
+          "secs": 196
+        },
+        {
+          "id": "Z6",
+          "secs": 107
+        },
+        {
+          "id": "Z7",
+          "secs": 53
+        },
+        {
+          "id": "SS",
+          "secs": 780
+        }
+      ],
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "decoupling": -4.7151833,
+      "icu_efficiency_factor": 1.084507,
+      "fitnessAtEnd": 28.78709,
+      "fatigueAtEnd": 53.354916
+    },
+    {
+      "id": "bm2",
+      "start_date_local": "2026-05-06T08:00:00",
+      "type": "Ride",
+      "name": "sanitized",
+      "moving_time": 5207,
+      "elapsed_time": 5217,
+      "icu_training_load": 268.1,
+      "icu_intensity": 78.97436,
+      "average_heartrate": 142,
+      "icu_zone_times": [
+        {
+          "id": "Z1",
+          "secs": 608
+        },
+        {
+          "id": "Z2",
+          "secs": 2361
+        },
+        {
+          "id": "Z3",
+          "secs": 1321
+        },
+        {
+          "id": "Z4",
+          "secs": 561
+        },
+        {
+          "id": "Z5",
+          "secs": 196
+        },
+        {
+          "id": "Z6",
+          "secs": 107
+        },
+        {
+          "id": "Z7",
+          "secs": 53
+        },
+        {
+          "id": "SS",
+          "secs": 780
+        }
+      ],
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "decoupling": -4.7151833,
+      "icu_efficiency_factor": 1.084507,
+      "fitnessAtEnd": 28.78709,
+      "fatigueAtEnd": 53.354916
+    },
+    {
+      "id": "bm3",
+      "start_date_local": "2026-05-07T08:00:00",
+      "type": "Ride",
+      "name": "sanitized",
+      "moving_time": 5207,
+      "elapsed_time": 5217,
+      "icu_training_load": 122,
+      "icu_intensity": 78.97436,
+      "average_heartrate": 142,
+      "icu_zone_times": [
+        {
+          "id": "Z1",
+          "secs": 608
+        },
+        {
+          "id": "Z2",
+          "secs": 2361
+        },
+        {
+          "id": "Z3",
+          "secs": 1321
+        },
+        {
+          "id": "Z4",
+          "secs": 561
+        },
+        {
+          "id": "Z5",
+          "secs": 196
+        },
+        {
+          "id": "Z6",
+          "secs": 107
+        },
+        {
+          "id": "Z7",
+          "secs": 53
+        },
+        {
+          "id": "SS",
+          "secs": 780
+        }
+      ],
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "decoupling": -4.7151833,
+      "icu_efficiency_factor": 1.084507,
+      "fitnessAtEnd": 28.78709,
+      "fatigueAtEnd": 53.354916
+    },
+    {
+      "id": "bm4",
+      "start_date_local": "2026-05-08T08:00:00",
+      "type": "Ride",
+      "name": "sanitized",
+      "moving_time": 5207,
+      "elapsed_time": 5217,
+      "icu_training_load": 34.6,
+      "icu_intensity": 78.97436,
+      "average_heartrate": 142,
+      "icu_zone_times": [
+        {
+          "id": "Z1",
+          "secs": 608
+        },
+        {
+          "id": "Z2",
+          "secs": 2361
+        },
+        {
+          "id": "Z3",
+          "secs": 1321
+        },
+        {
+          "id": "Z4",
+          "secs": 561
+        },
+        {
+          "id": "Z5",
+          "secs": 196
+        },
+        {
+          "id": "Z6",
+          "secs": 107
+        },
+        {
+          "id": "Z7",
+          "secs": 53
+        },
+        {
+          "id": "SS",
+          "secs": 780
+        }
+      ],
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "decoupling": -4.7151833,
+      "icu_efficiency_factor": 1.084507,
+      "fitnessAtEnd": 28.78709,
+      "fatigueAtEnd": 53.354916
+    },
+    {
+      "id": "bm5",
+      "start_date_local": "2026-05-09T08:00:00",
+      "type": "Ride",
+      "name": "sanitized",
+      "moving_time": 5207,
+      "elapsed_time": 5217,
+      "icu_training_load": 33.1,
+      "icu_intensity": 78.97436,
+      "average_heartrate": 142,
+      "icu_zone_times": [
+        {
+          "id": "Z1",
+          "secs": 608
+        },
+        {
+          "id": "Z2",
+          "secs": 2361
+        },
+        {
+          "id": "Z3",
+          "secs": 1321
+        },
+        {
+          "id": "Z4",
+          "secs": 561
+        },
+        {
+          "id": "Z5",
+          "secs": 196
+        },
+        {
+          "id": "Z6",
+          "secs": 107
+        },
+        {
+          "id": "Z7",
+          "secs": 53
+        },
+        {
+          "id": "SS",
+          "secs": 780
+        }
+      ],
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "decoupling": -4.7151833,
+      "icu_efficiency_factor": 1.084507,
+      "fitnessAtEnd": 28.78709,
+      "fatigueAtEnd": 53.354916
+    },
+    {
+      "id": "bm6",
+      "start_date_local": "2026-05-10T08:00:00",
+      "type": "Ride",
+      "name": "sanitized",
+      "moving_time": 5207,
+      "elapsed_time": 5217,
+      "icu_training_load": 231.2,
+      "icu_intensity": 78.97436,
+      "average_heartrate": 142,
+      "icu_zone_times": [
+        {
+          "id": "Z1",
+          "secs": 608
+        },
+        {
+          "id": "Z2",
+          "secs": 2361
+        },
+        {
+          "id": "Z3",
+          "secs": 1321
+        },
+        {
+          "id": "Z4",
+          "secs": 561
+        },
+        {
+          "id": "Z5",
+          "secs": 196
+        },
+        {
+          "id": "Z6",
+          "secs": 107
+        },
+        {
+          "id": "Z7",
+          "secs": 53
+        },
+        {
+          "id": "SS",
+          "secs": 780
+        }
+      ],
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "decoupling": -4.7151833,
+      "icu_efficiency_factor": 1.084507,
+      "fitnessAtEnd": 28.78709,
+      "fatigueAtEnd": 53.354916
+    }
+  ],
+  "wellness": [],
+  "ftp_history": []
+}

--- a/packages/core/tests/fixtures/golden/boundary-sum-strain.json
+++ b/packages/core/tests/fixtures/golden/boundary-sum-strain.json
@@ -1,0 +1,210 @@
+{
+  "activities": [
+    {
+      "id": "bs0",
+      "start_date_local": "2026-05-06T08:00:00",
+      "type": "Ride",
+      "name": "sanitized",
+      "moving_time": 5207,
+      "elapsed_time": 5217,
+      "icu_training_load": 9.7,
+      "icu_intensity": 78.97436,
+      "average_heartrate": 142,
+      "icu_zone_times": [
+        {
+          "id": "Z1",
+          "secs": 608
+        },
+        {
+          "id": "Z2",
+          "secs": 2361
+        },
+        {
+          "id": "Z3",
+          "secs": 1321
+        },
+        {
+          "id": "Z4",
+          "secs": 561
+        },
+        {
+          "id": "Z5",
+          "secs": 196
+        },
+        {
+          "id": "Z6",
+          "secs": 107
+        },
+        {
+          "id": "Z7",
+          "secs": 53
+        },
+        {
+          "id": "SS",
+          "secs": 780
+        }
+      ],
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "decoupling": -4.7151833,
+      "icu_efficiency_factor": 1.084507,
+      "fitnessAtEnd": 28.78709,
+      "fatigueAtEnd": 53.354916
+    },
+    {
+      "id": "bs1",
+      "start_date_local": "2026-05-07T08:00:00",
+      "type": "Ride",
+      "name": "sanitized",
+      "moving_time": 5207,
+      "elapsed_time": 5217,
+      "icu_training_load": 266.4,
+      "icu_intensity": 78.97436,
+      "average_heartrate": 142,
+      "icu_zone_times": [
+        {
+          "id": "Z1",
+          "secs": 608
+        },
+        {
+          "id": "Z2",
+          "secs": 2361
+        },
+        {
+          "id": "Z3",
+          "secs": 1321
+        },
+        {
+          "id": "Z4",
+          "secs": 561
+        },
+        {
+          "id": "Z5",
+          "secs": 196
+        },
+        {
+          "id": "Z6",
+          "secs": 107
+        },
+        {
+          "id": "Z7",
+          "secs": 53
+        },
+        {
+          "id": "SS",
+          "secs": 780
+        }
+      ],
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "decoupling": -4.7151833,
+      "icu_efficiency_factor": 1.084507,
+      "fitnessAtEnd": 28.78709,
+      "fatigueAtEnd": 53.354916
+    },
+    {
+      "id": "bs2",
+      "start_date_local": "2026-05-08T08:00:00",
+      "type": "Ride",
+      "name": "sanitized",
+      "moving_time": 5207,
+      "elapsed_time": 5217,
+      "icu_training_load": 239.5,
+      "icu_intensity": 78.97436,
+      "average_heartrate": 142,
+      "icu_zone_times": [
+        {
+          "id": "Z1",
+          "secs": 608
+        },
+        {
+          "id": "Z2",
+          "secs": 2361
+        },
+        {
+          "id": "Z3",
+          "secs": 1321
+        },
+        {
+          "id": "Z4",
+          "secs": 561
+        },
+        {
+          "id": "Z5",
+          "secs": 196
+        },
+        {
+          "id": "Z6",
+          "secs": 107
+        },
+        {
+          "id": "Z7",
+          "secs": 53
+        },
+        {
+          "id": "SS",
+          "secs": 780
+        }
+      ],
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "decoupling": -4.7151833,
+      "icu_efficiency_factor": 1.084507,
+      "fitnessAtEnd": 28.78709,
+      "fatigueAtEnd": 53.354916
+    },
+    {
+      "id": "bs3",
+      "start_date_local": "2026-05-09T08:00:00",
+      "type": "Ride",
+      "name": "sanitized",
+      "moving_time": 5207,
+      "elapsed_time": 5217,
+      "icu_training_load": 9.4,
+      "icu_intensity": 78.97436,
+      "average_heartrate": 142,
+      "icu_zone_times": [
+        {
+          "id": "Z1",
+          "secs": 608
+        },
+        {
+          "id": "Z2",
+          "secs": 2361
+        },
+        {
+          "id": "Z3",
+          "secs": 1321
+        },
+        {
+          "id": "Z4",
+          "secs": 561
+        },
+        {
+          "id": "Z5",
+          "secs": 196
+        },
+        {
+          "id": "Z6",
+          "secs": 107
+        },
+        {
+          "id": "Z7",
+          "secs": 53
+        },
+        {
+          "id": "SS",
+          "secs": 780
+        }
+      ],
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "decoupling": -4.7151833,
+      "icu_efficiency_factor": 1.084507,
+      "fitnessAtEnd": 28.78709,
+      "fatigueAtEnd": 53.354916
+    }
+  ],
+  "wellness": [],
+  "ftp_history": []
+}

--- a/packages/core/tests/fixtures/golden/boundary-zone-total-secs.json
+++ b/packages/core/tests/fixtures/golden/boundary-zone-total-secs.json
@@ -1,0 +1,84 @@
+{
+  "activities": [
+    {
+      "id": "bz0",
+      "start_date_local": "2026-05-08T08:00:00",
+      "type": "Ride",
+      "name": "sanitized",
+      "moving_time": 15215,
+      "elapsed_time": 15225,
+      "icu_training_load": 80.0,
+      "icu_intensity": 78.97436,
+      "average_heartrate": 142,
+      "icu_zone_times": [
+        { "id": "Z1", "secs": 2628.8 },
+        { "id": "Z2", "secs": 1557.8 },
+        { "id": "Z3", "secs": 1075.8 },
+        { "id": "Z4", "secs": 3037.5 },
+        { "id": "Z5", "secs": 1497.4 },
+        { "id": "Z6", "secs": 2199.4 },
+        { "id": "Z7", "secs": 3218.5 }
+      ],
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "decoupling": -4.7151833,
+      "icu_efficiency_factor": 1.084507,
+      "fitnessAtEnd": 28.78709,
+      "fatigueAtEnd": 53.354916
+    },
+    {
+      "id": "bz1",
+      "start_date_local": "2026-05-09T08:00:00",
+      "type": "Ride",
+      "name": "sanitized",
+      "moving_time": 12933,
+      "elapsed_time": 12943,
+      "icu_training_load": 90.0,
+      "icu_intensity": 78.97436,
+      "average_heartrate": 142,
+      "icu_zone_times": [
+        { "id": "Z1", "secs": 102.1 },
+        { "id": "Z2", "secs": 2302.3 },
+        { "id": "Z3", "secs": 2861 },
+        { "id": "Z4", "secs": 1620.1 },
+        { "id": "Z5", "secs": 904.1 },
+        { "id": "Z6", "secs": 2212.4 },
+        { "id": "Z7", "secs": 2930.6 }
+      ],
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "decoupling": -4.7151833,
+      "icu_efficiency_factor": 1.084507,
+      "fitnessAtEnd": 28.78709,
+      "fatigueAtEnd": 53.354916
+    },
+    {
+      "id": "bz2",
+      "start_date_local": "2026-05-10T08:00:00",
+      "type": "Ride",
+      "name": "sanitized",
+      "moving_time": 8446,
+      "elapsed_time": 8456,
+      "icu_training_load": 70.0,
+      "icu_intensity": 78.97436,
+      "average_heartrate": 142,
+      "icu_zone_times": [
+        { "id": "Z1", "secs": 113.4 },
+        { "id": "Z2", "secs": 642.4 },
+        { "id": "Z3", "secs": 2296.9 },
+        { "id": "Z4", "secs": 951.6 },
+        { "id": "Z5", "secs": 1762.6 },
+        { "id": "Z6", "secs": 459.5 },
+        { "id": "Z7", "secs": 2219.8 }
+      ],
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "decoupling": -4.7151833,
+      "icu_efficiency_factor": 1.084507,
+      "fitnessAtEnd": 28.78709,
+      "fatigueAtEnd": 53.354916
+    }
+  ],
+  "wellness": [],
+  "ftp_history": []
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-monotony/acwr.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-monotony/acwr.json
@@ -1,0 +1,8 @@
+{
+  "metric": "acwr",
+  "athlete": "boundary-monotony",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 4
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-monotony/acwr_interpretation.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-monotony/acwr_interpretation.json
@@ -1,0 +1,8 @@
+{
+  "metric": "acwr_interpretation",
+  "athlete": "boundary-monotony",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": "danger"
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-monotony/benchmark_indoor.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-monotony/benchmark_indoor.json
@@ -1,0 +1,14 @@
+{
+  "metric": "benchmark_indoor",
+  "athlete": "boundary-monotony",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "benchmark_index": null,
+    "benchmark_percentage": null,
+    "current_ftp": null,
+    "ftp_8_weeks_ago": null,
+    "seasonal_expected": null
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-monotony/benchmark_outdoor.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-monotony/benchmark_outdoor.json
@@ -1,0 +1,14 @@
+{
+  "metric": "benchmark_outdoor",
+  "athlete": "boundary-monotony",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "benchmark_index": null,
+    "benchmark_percentage": null,
+    "current_ftp": null,
+    "ftp_8_weeks_ago": null,
+    "seasonal_expected": null
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-monotony/calculation_timestamp.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-monotony/calculation_timestamp.json
@@ -1,0 +1,8 @@
+{
+  "metric": "calculation_timestamp",
+  "athlete": "boundary-monotony",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": "2026-05-10T12:00:00"
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-monotony/capability.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-monotony/capability.json
@@ -1,0 +1,62 @@
+{
+  "metric": "capability",
+  "athlete": "boundary-monotony",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "dfa_a1_profile": null,
+    "durability": {
+      "high_drift_count_28d": 0,
+      "high_drift_count_7d": 0,
+      "mean_decoupling_28d": null,
+      "mean_decoupling_7d": null,
+      "note": "Steady-state power sessions only (VI <= 1.05, VI > 0, >= 90min, power data). Negative decoupling = strong durability. Trend compares 7d vs 28d mean (+/-1% = stable). Alerts require N28>=5 (alarm) or N7>=3 AND N28>=5 (declining warning) for statistical reliability.",
+      "qualifying_sessions_28d": 0,
+      "qualifying_sessions_7d": 0,
+      "reliability_limited": true,
+      "reliability_note": "insufficient qualifying sessions for alert evaluation: 7d N=0 (min 3), 28d N=0 (min 5)",
+      "trend": null
+    },
+    "efficiency_factor": {
+      "mean_ef_28d": null,
+      "mean_ef_7d": null,
+      "note": "Steady-state cycling sessions only (VI <= 1.05, VI > 0, >= 20min, power+HR data). Rising EF = improving aerobic efficiency. Compare like-for-like sessions only — EF varies with intensity. Trend compares 7d vs 28d mean (+/-0.03 = stable).",
+      "qualifying_sessions_28d": 0,
+      "qualifying_sessions_7d": 0,
+      "trend": null
+    },
+    "hr_curve_delta": {
+      "anchors": null,
+      "note": "Insufficient HR data in one or both windows.",
+      "rotation_index": null,
+      "window_days": 28
+    },
+    "hrrc": {
+      "mean_hrrc_28d": null,
+      "mean_hrrc_7d": null,
+      "note": "HRRc = heart rate recovery (largest 60s HR drop in bpm after exceeding threshold HR for >1 min). Higher = better parasympathetic recovery. Null when threshold not reached, recording stopped before cooldown, or no HR data. Trend: 7d mean vs 28d mean, >10% = meaningful (min 1 session/7d, 3 sessions/28d). Display only — not wired into readiness_decision signals.",
+      "qualifying_sessions_28d": 0,
+      "qualifying_sessions_7d": 0,
+      "trend": null
+    },
+    "power_curve_delta": {
+      "anchors": null,
+      "note": "Insufficient power data in one or both windows.",
+      "rotation_index": null,
+      "window_days": 28
+    },
+    "sustainability_profile": {
+      "note": "No sustainability data available."
+    },
+    "tid_comparison": {
+      "classification_28d": "Pyramidal",
+      "classification_7d": "Pyramidal",
+      "drift": "consistent",
+      "note": "Compares 7d vs 28d Seiler TID to detect distribution shifts. pi_delta positive = more polarized acutely.",
+      "pi_28d": null,
+      "pi_7d": null,
+      "pi_delta": null
+    }
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-monotony/consistency_details.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-monotony/consistency_details.json
@@ -1,0 +1,13 @@
+{
+  "metric": "consistency_details",
+  "athlete": "boundary-monotony",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "completed_days": 7,
+    "matched_days": 0,
+    "note": "No planned workouts in period",
+    "planned_days": 0
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-monotony/consistency_index.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-monotony/consistency_index.json
@@ -1,0 +1,8 @@
+{
+  "metric": "consistency_index",
+  "athlete": "boundary-monotony",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-monotony/data_quality.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-monotony/data_quality.json
@@ -1,0 +1,18 @@
+{
+  "metric": "data_quality",
+  "athlete": "boundary-monotony",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "activities_28d": 7,
+    "activities_7d": 7,
+    "ftp_history_days": {
+      "indoor": 0,
+      "outdoor": 0
+    },
+    "hrv_data_points": 0,
+    "planned_workouts_7d": 0,
+    "rhr_data_points": 0
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-monotony/easy_time_ratio.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-monotony/easy_time_ratio.json
@@ -1,0 +1,8 @@
+{
+  "metric": "easy_time_ratio",
+  "athlete": "boundary-monotony",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 0.57
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-monotony/easy_time_ratio_note.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-monotony/easy_time_ratio_note.json
@@ -1,0 +1,8 @@
+{
+  "metric": "easy_time_ratio_note",
+  "athlete": "boundary-monotony",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": "Easy time (Z1+Z2) / Total - target ~80% in polarized training"
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-monotony/effective_monotony.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-monotony/effective_monotony.json
@@ -1,0 +1,8 @@
+{
+  "metric": "effective_monotony",
+  "athlete": "boundary-monotony",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 1.24
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-monotony/eftp.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-monotony/eftp.json
@@ -1,0 +1,8 @@
+{
+  "metric": "eftp",
+  "athlete": "boundary-monotony",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-monotony/grey_zone_note.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-monotony/grey_zone_note.json
@@ -1,0 +1,8 @@
+{
+  "metric": "grey_zone_note",
+  "athlete": "boundary-monotony",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": "Gray Zone % (Z3/tempo) - minimize in polarized training"
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-monotony/grey_zone_percentage.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-monotony/grey_zone_percentage.json
@@ -1,0 +1,8 @@
+{
+  "metric": "grey_zone_percentage",
+  "athlete": "boundary-monotony",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 25.4
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-monotony/hard_days_note.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-monotony/hard_days_note.json
@@ -1,0 +1,8 @@
+{
+  "metric": "hard_days_note",
+  "athlete": "boundary-monotony",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": "Power ladder: z3+ >= 30min, z4+ >= 10min, z5+ >= 5min, z6+ >= 2min, z7 >= 1min. HR fallback (when no power): z4+ >= 10min, z5+ >= 5min. Per Seiler 3-zone model + Foster. HR-based days flagged with intensity_basis: hr"
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-monotony/hard_days_this_week.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-monotony/hard_days_this_week.json
@@ -1,0 +1,8 @@
+{
+  "metric": "hard_days_this_week",
+  "athlete": "boundary-monotony",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 7
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-monotony/hrv_baseline_28d.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-monotony/hrv_baseline_28d.json
@@ -1,0 +1,8 @@
+{
+  "metric": "hrv_baseline_28d",
+  "athlete": "boundary-monotony",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-monotony/hrv_baseline_7d.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-monotony/hrv_baseline_7d.json
@@ -1,0 +1,8 @@
+{
+  "metric": "hrv_baseline_7d",
+  "athlete": "boundary-monotony",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-monotony/latest_hrv.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-monotony/latest_hrv.json
@@ -1,0 +1,8 @@
+{
+  "metric": "latest_hrv",
+  "athlete": "boundary-monotony",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-monotony/latest_rhr.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-monotony/latest_rhr.json
@@ -1,0 +1,8 @@
+{
+  "metric": "latest_rhr",
+  "athlete": "boundary-monotony",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-monotony/load_recovery_ratio.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-monotony/load_recovery_ratio.json
@@ -1,0 +1,8 @@
+{
+  "metric": "load_recovery_ratio",
+  "athlete": "boundary-monotony",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-monotony/monotony.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-monotony/monotony.json
@@ -1,0 +1,8 @@
+{
+  "metric": "monotony",
+  "athlete": "boundary-monotony",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 1.24
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-monotony/monotony_interpretation.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-monotony/monotony_interpretation.json
@@ -1,0 +1,8 @@
+{
+  "metric": "monotony_interpretation",
+  "athlete": "boundary-monotony",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": "normal"
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-monotony/multi_sport_detected.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-monotony/multi_sport_detected.json
@@ -1,0 +1,8 @@
+{
+  "metric": "multi_sport_detected",
+  "athlete": "boundary-monotony",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": false
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-monotony/p_max.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-monotony/p_max.json
@@ -1,0 +1,8 @@
+{
+  "metric": "p_max",
+  "athlete": "boundary-monotony",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-monotony/phase_detected.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-monotony/phase_detected.json
@@ -1,0 +1,8 @@
+{
+  "metric": "phase_detected",
+  "athlete": "boundary-monotony",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": "Base"
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-monotony/phase_detection.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-monotony/phase_detection.json
@@ -1,0 +1,38 @@
+{
+  "metric": "phase_detection",
+  "athlete": "boundary-monotony",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "basis": {
+      "data_quality": "good",
+      "stream_1": {
+        "acwr_trend": null,
+        "ctl_slope": null,
+        "hard_day_pattern": 0,
+        "weeks_available": 4
+      },
+      "stream_2": {
+        "current_week_hard_days_completed": 0,
+        "current_week_hard_days_total": 0,
+        "hard_sessions_planned": 0,
+        "next_week_load": null,
+        "plan_coverage_current_week": 0,
+        "plan_coverage_next_week": 0,
+        "planned_tss_delta": null,
+        "race_proximity": null
+      },
+      "stream_agreement": null
+    },
+    "confidence": "medium",
+    "dossier_agreement": null,
+    "dossier_declared": null,
+    "phase": "Base",
+    "phase_duration_weeks": 1,
+    "previous_phase": null,
+    "reason_codes": [
+      "NO_PLANNED_WORKOUTS"
+    ]
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-monotony/phase_triggers.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-monotony/phase_triggers.json
@@ -1,0 +1,10 @@
+{
+  "metric": "phase_triggers",
+  "athlete": "boundary-monotony",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": [
+    "NO_PLANNED_WORKOUTS"
+  ]
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-monotony/power_model_source.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-monotony/power_model_source.json
@@ -1,0 +1,8 @@
+{
+  "metric": "power_model_source",
+  "athlete": "boundary-monotony",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-monotony/primary_sport.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-monotony/primary_sport.json
@@ -1,0 +1,8 @@
+{
+  "metric": "primary_sport",
+  "athlete": "boundary-monotony",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": "cycling"
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-monotony/primary_sport_monotony.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-monotony/primary_sport_monotony.json
@@ -1,0 +1,8 @@
+{
+  "metric": "primary_sport_monotony",
+  "athlete": "boundary-monotony",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 1.24
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-monotony/primary_sport_tss_7d.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-monotony/primary_sport_tss_7d.json
@@ -1,0 +1,8 @@
+{
+  "metric": "primary_sport_tss_7d",
+  "athlete": "boundary-monotony",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 864
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-monotony/quality_intensity_note.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-monotony/quality_intensity_note.json
@@ -1,0 +1,8 @@
+{
+  "metric": "quality_intensity_note",
+  "athlete": "boundary-monotony",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": "Quality Intensity % (Z4+/threshold+) - target ~20% in polarized training"
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-monotony/quality_intensity_percentage.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-monotony/quality_intensity_percentage.json
@@ -1,0 +1,8 @@
+{
+  "metric": "quality_intensity_percentage",
+  "athlete": "boundary-monotony",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 17.6
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-monotony/recovery_index.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-monotony/recovery_index.json
@@ -1,0 +1,8 @@
+{
+  "metric": "recovery_index",
+  "athlete": "boundary-monotony",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-monotony/recovery_index_yesterday.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-monotony/recovery_index_yesterday.json
@@ -1,0 +1,8 @@
+{
+  "metric": "recovery_index_yesterday",
+  "athlete": "boundary-monotony",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-monotony/rhr_baseline_28d.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-monotony/rhr_baseline_28d.json
@@ -1,0 +1,8 @@
+{
+  "metric": "rhr_baseline_28d",
+  "athlete": "boundary-monotony",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-monotony/rhr_baseline_7d.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-monotony/rhr_baseline_7d.json
@@ -1,0 +1,8 @@
+{
+  "metric": "rhr_baseline_7d",
+  "athlete": "boundary-monotony",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-monotony/seasonal_context.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-monotony/seasonal_context.json
@@ -1,0 +1,8 @@
+{
+  "metric": "seasonal_context",
+  "athlete": "boundary-monotony",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": "Build / Early Race Season"
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-monotony/seiler_tid_28d.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-monotony/seiler_tid_28d.json
@@ -1,0 +1,18 @@
+{
+  "metric": "seiler_tid_28d",
+  "athlete": "boundary-monotony",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "classification": "Pyramidal",
+    "polarization_index": null,
+    "z1_pct": 57,
+    "z1_seconds": 20783,
+    "z2_pct": 25.4,
+    "z2_seconds": 9247,
+    "z3_pct": 17.6,
+    "z3_seconds": 6419,
+    "zone_basis": "power"
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-monotony/seiler_tid_28d_primary.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-monotony/seiler_tid_28d_primary.json
@@ -1,0 +1,19 @@
+{
+  "metric": "seiler_tid_28d_primary",
+  "athlete": "boundary-monotony",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "classification": "Pyramidal",
+    "polarization_index": null,
+    "sport": "cycling",
+    "z1_pct": 57,
+    "z1_seconds": 20783,
+    "z2_pct": 25.4,
+    "z2_seconds": 9247,
+    "z3_pct": 17.6,
+    "z3_seconds": 6419,
+    "zone_basis": "power"
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-monotony/seiler_tid_7d.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-monotony/seiler_tid_7d.json
@@ -1,0 +1,18 @@
+{
+  "metric": "seiler_tid_7d",
+  "athlete": "boundary-monotony",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "classification": "Pyramidal",
+    "polarization_index": null,
+    "z1_pct": 57,
+    "z1_seconds": 20783,
+    "z2_pct": 25.4,
+    "z2_seconds": 9247,
+    "z3_pct": 17.6,
+    "z3_seconds": 6419,
+    "zone_basis": "power"
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-monotony/seiler_tid_7d_primary.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-monotony/seiler_tid_7d_primary.json
@@ -1,0 +1,19 @@
+{
+  "metric": "seiler_tid_7d_primary",
+  "athlete": "boundary-monotony",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "classification": "Pyramidal",
+    "polarization_index": null,
+    "sport": "cycling",
+    "z1_pct": 57,
+    "z1_seconds": 20783,
+    "z2_pct": 25.4,
+    "z2_seconds": 9247,
+    "z3_pct": 17.6,
+    "z3_seconds": 6419,
+    "zone_basis": "power"
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-monotony/strain.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-monotony/strain.json
@@ -1,0 +1,8 @@
+{
+  "metric": "strain",
+  "athlete": "boundary-monotony",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 1072
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-monotony/stress_tolerance.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-monotony/stress_tolerance.json
@@ -1,0 +1,8 @@
+{
+  "metric": "stress_tolerance",
+  "athlete": "boundary-monotony",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 8.6
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-monotony/tss_28d_total.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-monotony/tss_28d_total.json
@@ -1,0 +1,8 @@
+{
+  "metric": "tss_28d_total",
+  "athlete": "boundary-monotony",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 864
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-monotony/tss_7d_total.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-monotony/tss_7d_total.json
@@ -1,0 +1,8 @@
+{
+  "metric": "tss_7d_total",
+  "athlete": "boundary-monotony",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 864
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-monotony/vo2max.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-monotony/vo2max.json
@@ -1,0 +1,8 @@
+{
+  "metric": "vo2max",
+  "athlete": "boundary-monotony",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-monotony/w_prime.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-monotony/w_prime.json
@@ -1,0 +1,8 @@
+{
+  "metric": "w_prime",
+  "athlete": "boundary-monotony",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-monotony/w_prime_kj.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-monotony/w_prime_kj.json
@@ -1,0 +1,8 @@
+{
+  "metric": "w_prime_kj",
+  "athlete": "boundary-monotony",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-monotony/zone_distribution_7d.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-monotony/zone_distribution_7d.json
@@ -1,0 +1,15 @@
+{
+  "metric": "zone_distribution_7d",
+  "athlete": "boundary-monotony",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "total_hours": 10.12,
+    "z1_hours": 1.18,
+    "z2_hours": 4.59,
+    "z3_hours": 2.57,
+    "z4_plus_hours": 1.78,
+    "zone_basis": "power"
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-sum-strain/acwr.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-sum-strain/acwr.json
@@ -1,0 +1,8 @@
+{
+  "metric": "acwr",
+  "athlete": "boundary-sum-strain",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 4
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-sum-strain/acwr_interpretation.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-sum-strain/acwr_interpretation.json
@@ -1,0 +1,8 @@
+{
+  "metric": "acwr_interpretation",
+  "athlete": "boundary-sum-strain",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": "danger"
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-sum-strain/benchmark_indoor.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-sum-strain/benchmark_indoor.json
@@ -1,0 +1,14 @@
+{
+  "metric": "benchmark_indoor",
+  "athlete": "boundary-sum-strain",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "benchmark_index": null,
+    "benchmark_percentage": null,
+    "current_ftp": null,
+    "ftp_8_weeks_ago": null,
+    "seasonal_expected": null
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-sum-strain/benchmark_outdoor.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-sum-strain/benchmark_outdoor.json
@@ -1,0 +1,14 @@
+{
+  "metric": "benchmark_outdoor",
+  "athlete": "boundary-sum-strain",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "benchmark_index": null,
+    "benchmark_percentage": null,
+    "current_ftp": null,
+    "ftp_8_weeks_ago": null,
+    "seasonal_expected": null
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-sum-strain/calculation_timestamp.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-sum-strain/calculation_timestamp.json
@@ -1,0 +1,8 @@
+{
+  "metric": "calculation_timestamp",
+  "athlete": "boundary-sum-strain",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": "2026-05-10T12:00:00"
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-sum-strain/capability.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-sum-strain/capability.json
@@ -1,0 +1,62 @@
+{
+  "metric": "capability",
+  "athlete": "boundary-sum-strain",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "dfa_a1_profile": null,
+    "durability": {
+      "high_drift_count_28d": 0,
+      "high_drift_count_7d": 0,
+      "mean_decoupling_28d": null,
+      "mean_decoupling_7d": null,
+      "note": "Steady-state power sessions only (VI <= 1.05, VI > 0, >= 90min, power data). Negative decoupling = strong durability. Trend compares 7d vs 28d mean (+/-1% = stable). Alerts require N28>=5 (alarm) or N7>=3 AND N28>=5 (declining warning) for statistical reliability.",
+      "qualifying_sessions_28d": 0,
+      "qualifying_sessions_7d": 0,
+      "reliability_limited": true,
+      "reliability_note": "insufficient qualifying sessions for alert evaluation: 7d N=0 (min 3), 28d N=0 (min 5)",
+      "trend": null
+    },
+    "efficiency_factor": {
+      "mean_ef_28d": null,
+      "mean_ef_7d": null,
+      "note": "Steady-state cycling sessions only (VI <= 1.05, VI > 0, >= 20min, power+HR data). Rising EF = improving aerobic efficiency. Compare like-for-like sessions only — EF varies with intensity. Trend compares 7d vs 28d mean (+/-0.03 = stable).",
+      "qualifying_sessions_28d": 0,
+      "qualifying_sessions_7d": 0,
+      "trend": null
+    },
+    "hr_curve_delta": {
+      "anchors": null,
+      "note": "Insufficient HR data in one or both windows.",
+      "rotation_index": null,
+      "window_days": 28
+    },
+    "hrrc": {
+      "mean_hrrc_28d": null,
+      "mean_hrrc_7d": null,
+      "note": "HRRc = heart rate recovery (largest 60s HR drop in bpm after exceeding threshold HR for >1 min). Higher = better parasympathetic recovery. Null when threshold not reached, recording stopped before cooldown, or no HR data. Trend: 7d mean vs 28d mean, >10% = meaningful (min 1 session/7d, 3 sessions/28d). Display only — not wired into readiness_decision signals.",
+      "qualifying_sessions_28d": 0,
+      "qualifying_sessions_7d": 0,
+      "trend": null
+    },
+    "power_curve_delta": {
+      "anchors": null,
+      "note": "Insufficient power data in one or both windows.",
+      "rotation_index": null,
+      "window_days": 28
+    },
+    "sustainability_profile": {
+      "note": "No sustainability data available."
+    },
+    "tid_comparison": {
+      "classification_28d": "Pyramidal",
+      "classification_7d": "Pyramidal",
+      "drift": "consistent",
+      "note": "Compares 7d vs 28d Seiler TID to detect distribution shifts. pi_delta positive = more polarized acutely.",
+      "pi_28d": null,
+      "pi_7d": null,
+      "pi_delta": null
+    }
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-sum-strain/consistency_details.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-sum-strain/consistency_details.json
@@ -1,0 +1,13 @@
+{
+  "metric": "consistency_details",
+  "athlete": "boundary-sum-strain",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "completed_days": 4,
+    "matched_days": 0,
+    "note": "No planned workouts in period",
+    "planned_days": 0
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-sum-strain/consistency_index.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-sum-strain/consistency_index.json
@@ -1,0 +1,8 @@
+{
+  "metric": "consistency_index",
+  "athlete": "boundary-sum-strain",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-sum-strain/data_quality.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-sum-strain/data_quality.json
@@ -1,0 +1,18 @@
+{
+  "metric": "data_quality",
+  "athlete": "boundary-sum-strain",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "activities_28d": 4,
+    "activities_7d": 4,
+    "ftp_history_days": {
+      "indoor": 0,
+      "outdoor": 0
+    },
+    "hrv_data_points": 0,
+    "planned_workouts_7d": 0,
+    "rhr_data_points": 0
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-sum-strain/easy_time_ratio.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-sum-strain/easy_time_ratio.json
@@ -1,0 +1,8 @@
+{
+  "metric": "easy_time_ratio",
+  "athlete": "boundary-sum-strain",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 0.57
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-sum-strain/easy_time_ratio_note.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-sum-strain/easy_time_ratio_note.json
@@ -1,0 +1,8 @@
+{
+  "metric": "easy_time_ratio_note",
+  "athlete": "boundary-sum-strain",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": "Easy time (Z1+Z2) / Total - target ~80% in polarized training"
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-sum-strain/effective_monotony.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-sum-strain/effective_monotony.json
@@ -1,0 +1,8 @@
+{
+  "metric": "effective_monotony",
+  "athlete": "boundary-sum-strain",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 0.62
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-sum-strain/eftp.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-sum-strain/eftp.json
@@ -1,0 +1,8 @@
+{
+  "metric": "eftp",
+  "athlete": "boundary-sum-strain",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-sum-strain/grey_zone_note.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-sum-strain/grey_zone_note.json
@@ -1,0 +1,8 @@
+{
+  "metric": "grey_zone_note",
+  "athlete": "boundary-sum-strain",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": "Gray Zone % (Z3/tempo) - minimize in polarized training"
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-sum-strain/grey_zone_percentage.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-sum-strain/grey_zone_percentage.json
@@ -1,0 +1,8 @@
+{
+  "metric": "grey_zone_percentage",
+  "athlete": "boundary-sum-strain",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 25.4
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-sum-strain/hard_days_note.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-sum-strain/hard_days_note.json
@@ -1,0 +1,8 @@
+{
+  "metric": "hard_days_note",
+  "athlete": "boundary-sum-strain",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": "Power ladder: z3+ >= 30min, z4+ >= 10min, z5+ >= 5min, z6+ >= 2min, z7 >= 1min. HR fallback (when no power): z4+ >= 10min, z5+ >= 5min. Per Seiler 3-zone model + Foster. HR-based days flagged with intensity_basis: hr"
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-sum-strain/hard_days_this_week.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-sum-strain/hard_days_this_week.json
@@ -1,0 +1,8 @@
+{
+  "metric": "hard_days_this_week",
+  "athlete": "boundary-sum-strain",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 4
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-sum-strain/hrv_baseline_28d.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-sum-strain/hrv_baseline_28d.json
@@ -1,0 +1,8 @@
+{
+  "metric": "hrv_baseline_28d",
+  "athlete": "boundary-sum-strain",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-sum-strain/hrv_baseline_7d.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-sum-strain/hrv_baseline_7d.json
@@ -1,0 +1,8 @@
+{
+  "metric": "hrv_baseline_7d",
+  "athlete": "boundary-sum-strain",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-sum-strain/latest_hrv.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-sum-strain/latest_hrv.json
@@ -1,0 +1,8 @@
+{
+  "metric": "latest_hrv",
+  "athlete": "boundary-sum-strain",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-sum-strain/latest_rhr.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-sum-strain/latest_rhr.json
@@ -1,0 +1,8 @@
+{
+  "metric": "latest_rhr",
+  "athlete": "boundary-sum-strain",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-sum-strain/load_recovery_ratio.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-sum-strain/load_recovery_ratio.json
@@ -1,0 +1,8 @@
+{
+  "metric": "load_recovery_ratio",
+  "athlete": "boundary-sum-strain",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-sum-strain/monotony.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-sum-strain/monotony.json
@@ -1,0 +1,8 @@
+{
+  "metric": "monotony",
+  "athlete": "boundary-sum-strain",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 0.62
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-sum-strain/monotony_interpretation.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-sum-strain/monotony_interpretation.json
@@ -1,0 +1,8 @@
+{
+  "metric": "monotony_interpretation",
+  "athlete": "boundary-sum-strain",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": "normal"
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-sum-strain/multi_sport_detected.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-sum-strain/multi_sport_detected.json
@@ -1,0 +1,8 @@
+{
+  "metric": "multi_sport_detected",
+  "athlete": "boundary-sum-strain",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": false
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-sum-strain/p_max.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-sum-strain/p_max.json
@@ -1,0 +1,8 @@
+{
+  "metric": "p_max",
+  "athlete": "boundary-sum-strain",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-sum-strain/phase_detected.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-sum-strain/phase_detected.json
@@ -1,0 +1,8 @@
+{
+  "metric": "phase_detected",
+  "athlete": "boundary-sum-strain",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": "Base"
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-sum-strain/phase_detection.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-sum-strain/phase_detection.json
@@ -1,0 +1,38 @@
+{
+  "metric": "phase_detection",
+  "athlete": "boundary-sum-strain",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "basis": {
+      "data_quality": "good",
+      "stream_1": {
+        "acwr_trend": null,
+        "ctl_slope": null,
+        "hard_day_pattern": 0,
+        "weeks_available": 4
+      },
+      "stream_2": {
+        "current_week_hard_days_completed": 0,
+        "current_week_hard_days_total": 0,
+        "hard_sessions_planned": 0,
+        "next_week_load": null,
+        "plan_coverage_current_week": 0,
+        "plan_coverage_next_week": 0,
+        "planned_tss_delta": null,
+        "race_proximity": null
+      },
+      "stream_agreement": null
+    },
+    "confidence": "medium",
+    "dossier_agreement": null,
+    "dossier_declared": null,
+    "phase": "Base",
+    "phase_duration_weeks": 1,
+    "previous_phase": null,
+    "reason_codes": [
+      "NO_PLANNED_WORKOUTS"
+    ]
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-sum-strain/phase_triggers.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-sum-strain/phase_triggers.json
@@ -1,0 +1,10 @@
+{
+  "metric": "phase_triggers",
+  "athlete": "boundary-sum-strain",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": [
+    "NO_PLANNED_WORKOUTS"
+  ]
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-sum-strain/power_model_source.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-sum-strain/power_model_source.json
@@ -1,0 +1,8 @@
+{
+  "metric": "power_model_source",
+  "athlete": "boundary-sum-strain",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-sum-strain/primary_sport.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-sum-strain/primary_sport.json
@@ -1,0 +1,8 @@
+{
+  "metric": "primary_sport",
+  "athlete": "boundary-sum-strain",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": "cycling"
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-sum-strain/primary_sport_monotony.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-sum-strain/primary_sport_monotony.json
@@ -1,0 +1,8 @@
+{
+  "metric": "primary_sport_monotony",
+  "athlete": "boundary-sum-strain",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 0.62
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-sum-strain/primary_sport_tss_7d.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-sum-strain/primary_sport_tss_7d.json
@@ -1,0 +1,8 @@
+{
+  "metric": "primary_sport_tss_7d",
+  "athlete": "boundary-sum-strain",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 525
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-sum-strain/quality_intensity_note.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-sum-strain/quality_intensity_note.json
@@ -1,0 +1,8 @@
+{
+  "metric": "quality_intensity_note",
+  "athlete": "boundary-sum-strain",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": "Quality Intensity % (Z4+/threshold+) - target ~20% in polarized training"
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-sum-strain/quality_intensity_percentage.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-sum-strain/quality_intensity_percentage.json
@@ -1,0 +1,8 @@
+{
+  "metric": "quality_intensity_percentage",
+  "athlete": "boundary-sum-strain",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 17.6
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-sum-strain/recovery_index.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-sum-strain/recovery_index.json
@@ -1,0 +1,8 @@
+{
+  "metric": "recovery_index",
+  "athlete": "boundary-sum-strain",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-sum-strain/recovery_index_yesterday.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-sum-strain/recovery_index_yesterday.json
@@ -1,0 +1,8 @@
+{
+  "metric": "recovery_index_yesterday",
+  "athlete": "boundary-sum-strain",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-sum-strain/rhr_baseline_28d.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-sum-strain/rhr_baseline_28d.json
@@ -1,0 +1,8 @@
+{
+  "metric": "rhr_baseline_28d",
+  "athlete": "boundary-sum-strain",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-sum-strain/rhr_baseline_7d.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-sum-strain/rhr_baseline_7d.json
@@ -1,0 +1,8 @@
+{
+  "metric": "rhr_baseline_7d",
+  "athlete": "boundary-sum-strain",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-sum-strain/seasonal_context.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-sum-strain/seasonal_context.json
@@ -1,0 +1,8 @@
+{
+  "metric": "seasonal_context",
+  "athlete": "boundary-sum-strain",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": "Build / Early Race Season"
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-sum-strain/seiler_tid_28d.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-sum-strain/seiler_tid_28d.json
@@ -1,0 +1,18 @@
+{
+  "metric": "seiler_tid_28d",
+  "athlete": "boundary-sum-strain",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "classification": "Pyramidal",
+    "polarization_index": null,
+    "z1_pct": 57,
+    "z1_seconds": 11876,
+    "z2_pct": 25.4,
+    "z2_seconds": 5284,
+    "z3_pct": 17.6,
+    "z3_seconds": 3668,
+    "zone_basis": "power"
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-sum-strain/seiler_tid_28d_primary.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-sum-strain/seiler_tid_28d_primary.json
@@ -1,0 +1,19 @@
+{
+  "metric": "seiler_tid_28d_primary",
+  "athlete": "boundary-sum-strain",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "classification": "Pyramidal",
+    "polarization_index": null,
+    "sport": "cycling",
+    "z1_pct": 57,
+    "z1_seconds": 11876,
+    "z2_pct": 25.4,
+    "z2_seconds": 5284,
+    "z3_pct": 17.6,
+    "z3_seconds": 3668,
+    "zone_basis": "power"
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-sum-strain/seiler_tid_7d.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-sum-strain/seiler_tid_7d.json
@@ -1,0 +1,18 @@
+{
+  "metric": "seiler_tid_7d",
+  "athlete": "boundary-sum-strain",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "classification": "Pyramidal",
+    "polarization_index": null,
+    "z1_pct": 57,
+    "z1_seconds": 11876,
+    "z2_pct": 25.4,
+    "z2_seconds": 5284,
+    "z3_pct": 17.6,
+    "z3_seconds": 3668,
+    "zone_basis": "power"
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-sum-strain/seiler_tid_7d_primary.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-sum-strain/seiler_tid_7d_primary.json
@@ -1,0 +1,19 @@
+{
+  "metric": "seiler_tid_7d_primary",
+  "athlete": "boundary-sum-strain",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "classification": "Pyramidal",
+    "polarization_index": null,
+    "sport": "cycling",
+    "z1_pct": 57,
+    "z1_seconds": 11876,
+    "z2_pct": 25.4,
+    "z2_seconds": 5284,
+    "z3_pct": 17.6,
+    "z3_seconds": 3668,
+    "zone_basis": "power"
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-sum-strain/strain.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-sum-strain/strain.json
@@ -1,0 +1,8 @@
+{
+  "metric": "strain",
+  "athlete": "boundary-sum-strain",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 326
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-sum-strain/stress_tolerance.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-sum-strain/stress_tolerance.json
@@ -1,0 +1,8 @@
+{
+  "metric": "stress_tolerance",
+  "athlete": "boundary-sum-strain",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 5.3
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-sum-strain/tss_28d_total.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-sum-strain/tss_28d_total.json
@@ -1,0 +1,8 @@
+{
+  "metric": "tss_28d_total",
+  "athlete": "boundary-sum-strain",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 525
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-sum-strain/tss_7d_total.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-sum-strain/tss_7d_total.json
@@ -1,0 +1,8 @@
+{
+  "metric": "tss_7d_total",
+  "athlete": "boundary-sum-strain",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 525
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-sum-strain/vo2max.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-sum-strain/vo2max.json
@@ -1,0 +1,8 @@
+{
+  "metric": "vo2max",
+  "athlete": "boundary-sum-strain",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-sum-strain/w_prime.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-sum-strain/w_prime.json
@@ -1,0 +1,8 @@
+{
+  "metric": "w_prime",
+  "athlete": "boundary-sum-strain",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-sum-strain/w_prime_kj.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-sum-strain/w_prime_kj.json
@@ -1,0 +1,8 @@
+{
+  "metric": "w_prime_kj",
+  "athlete": "boundary-sum-strain",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-sum-strain/zone_distribution_7d.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-sum-strain/zone_distribution_7d.json
@@ -1,0 +1,15 @@
+{
+  "metric": "zone_distribution_7d",
+  "athlete": "boundary-sum-strain",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "total_hours": 5.79,
+    "z1_hours": 0.68,
+    "z2_hours": 2.62,
+    "z3_hours": 1.47,
+    "z4_plus_hours": 1.02,
+    "zone_basis": "power"
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/acwr.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/acwr.json
@@ -1,0 +1,8 @@
+{
+  "metric": "acwr",
+  "athlete": "boundary-zone-total-secs",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 4
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/acwr_interpretation.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/acwr_interpretation.json
@@ -1,0 +1,8 @@
+{
+  "metric": "acwr_interpretation",
+  "athlete": "boundary-zone-total-secs",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": "danger"
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/benchmark_indoor.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/benchmark_indoor.json
@@ -1,0 +1,14 @@
+{
+  "metric": "benchmark_indoor",
+  "athlete": "boundary-zone-total-secs",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "benchmark_index": null,
+    "benchmark_percentage": null,
+    "current_ftp": null,
+    "ftp_8_weeks_ago": null,
+    "seasonal_expected": null
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/benchmark_outdoor.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/benchmark_outdoor.json
@@ -1,0 +1,14 @@
+{
+  "metric": "benchmark_outdoor",
+  "athlete": "boundary-zone-total-secs",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "benchmark_index": null,
+    "benchmark_percentage": null,
+    "current_ftp": null,
+    "ftp_8_weeks_ago": null,
+    "seasonal_expected": null
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/calculation_timestamp.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/calculation_timestamp.json
@@ -1,0 +1,8 @@
+{
+  "metric": "calculation_timestamp",
+  "athlete": "boundary-zone-total-secs",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": "2026-05-10T12:00:00"
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/capability.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/capability.json
@@ -1,0 +1,62 @@
+{
+  "metric": "capability",
+  "athlete": "boundary-zone-total-secs",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "dfa_a1_profile": null,
+    "durability": {
+      "high_drift_count_28d": 0,
+      "high_drift_count_7d": 0,
+      "mean_decoupling_28d": null,
+      "mean_decoupling_7d": null,
+      "note": "Steady-state power sessions only (VI <= 1.05, VI > 0, >= 90min, power data). Negative decoupling = strong durability. Trend compares 7d vs 28d mean (+/-1% = stable). Alerts require N28>=5 (alarm) or N7>=3 AND N28>=5 (declining warning) for statistical reliability.",
+      "qualifying_sessions_28d": 0,
+      "qualifying_sessions_7d": 0,
+      "reliability_limited": true,
+      "reliability_note": "insufficient qualifying sessions for alert evaluation: 7d N=0 (min 3), 28d N=0 (min 5)",
+      "trend": null
+    },
+    "efficiency_factor": {
+      "mean_ef_28d": null,
+      "mean_ef_7d": null,
+      "note": "Steady-state cycling sessions only (VI <= 1.05, VI > 0, >= 20min, power+HR data). Rising EF = improving aerobic efficiency. Compare like-for-like sessions only — EF varies with intensity. Trend compares 7d vs 28d mean (+/-0.03 = stable).",
+      "qualifying_sessions_28d": 0,
+      "qualifying_sessions_7d": 0,
+      "trend": null
+    },
+    "hr_curve_delta": {
+      "anchors": null,
+      "note": "Insufficient HR data in one or both windows.",
+      "rotation_index": null,
+      "window_days": 28
+    },
+    "hrrc": {
+      "mean_hrrc_28d": null,
+      "mean_hrrc_7d": null,
+      "note": "HRRc = heart rate recovery (largest 60s HR drop in bpm after exceeding threshold HR for >1 min). Higher = better parasympathetic recovery. Null when threshold not reached, recording stopped before cooldown, or no HR data. Trend: 7d mean vs 28d mean, >10% = meaningful (min 1 session/7d, 3 sessions/28d). Display only — not wired into readiness_decision signals.",
+      "qualifying_sessions_28d": 0,
+      "qualifying_sessions_7d": 0,
+      "trend": null
+    },
+    "power_curve_delta": {
+      "anchors": null,
+      "note": "Insufficient power data in one or both windows.",
+      "rotation_index": null,
+      "window_days": 28
+    },
+    "sustainability_profile": {
+      "note": "No sustainability data available."
+    },
+    "tid_comparison": {
+      "classification_28d": "High Intensity",
+      "classification_7d": "High Intensity",
+      "drift": "consistent",
+      "note": "Compares 7d vs 28d Seiler TID to detect distribution shifts. pi_delta positive = more polarized acutely.",
+      "pi_28d": null,
+      "pi_7d": null,
+      "pi_delta": null
+    }
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/consistency_details.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/consistency_details.json
@@ -1,0 +1,13 @@
+{
+  "metric": "consistency_details",
+  "athlete": "boundary-zone-total-secs",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "completed_days": 3,
+    "matched_days": 0,
+    "note": "No planned workouts in period",
+    "planned_days": 0
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/consistency_index.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/consistency_index.json
@@ -1,0 +1,8 @@
+{
+  "metric": "consistency_index",
+  "athlete": "boundary-zone-total-secs",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/data_quality.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/data_quality.json
@@ -1,0 +1,18 @@
+{
+  "metric": "data_quality",
+  "athlete": "boundary-zone-total-secs",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "activities_28d": 3,
+    "activities_7d": 3,
+    "ftp_history_days": {
+      "indoor": 0,
+      "outdoor": 0
+    },
+    "hrv_data_points": 0,
+    "planned_workouts_7d": 0,
+    "rhr_data_points": 0
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/easy_time_ratio.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/easy_time_ratio.json
@@ -1,0 +1,8 @@
+{
+  "metric": "easy_time_ratio",
+  "athlete": "boundary-zone-total-secs",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 0.2
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/easy_time_ratio_note.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/easy_time_ratio_note.json
@@ -1,0 +1,8 @@
+{
+  "metric": "easy_time_ratio_note",
+  "athlete": "boundary-zone-total-secs",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": "Easy time (Z1+Z2) / Total - target ~80% in polarized training"
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/effective_monotony.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/effective_monotony.json
@@ -1,0 +1,8 @@
+{
+  "metric": "effective_monotony",
+  "athlete": "boundary-zone-total-secs",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 0.79
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/eftp.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/eftp.json
@@ -1,0 +1,8 @@
+{
+  "metric": "eftp",
+  "athlete": "boundary-zone-total-secs",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/grey_zone_note.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/grey_zone_note.json
@@ -1,0 +1,8 @@
+{
+  "metric": "grey_zone_note",
+  "athlete": "boundary-zone-total-secs",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": "Gray Zone % (Z3/tempo) - minimize in polarized training"
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/grey_zone_percentage.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/grey_zone_percentage.json
@@ -1,0 +1,8 @@
+{
+  "metric": "grey_zone_percentage",
+  "athlete": "boundary-zone-total-secs",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 17
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/hard_days_note.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/hard_days_note.json
@@ -1,0 +1,8 @@
+{
+  "metric": "hard_days_note",
+  "athlete": "boundary-zone-total-secs",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": "Power ladder: z3+ >= 30min, z4+ >= 10min, z5+ >= 5min, z6+ >= 2min, z7 >= 1min. HR fallback (when no power): z4+ >= 10min, z5+ >= 5min. Per Seiler 3-zone model + Foster. HR-based days flagged with intensity_basis: hr"
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/hard_days_this_week.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/hard_days_this_week.json
@@ -1,0 +1,8 @@
+{
+  "metric": "hard_days_this_week",
+  "athlete": "boundary-zone-total-secs",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 3
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/hrv_baseline_28d.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/hrv_baseline_28d.json
@@ -1,0 +1,8 @@
+{
+  "metric": "hrv_baseline_28d",
+  "athlete": "boundary-zone-total-secs",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/hrv_baseline_7d.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/hrv_baseline_7d.json
@@ -1,0 +1,8 @@
+{
+  "metric": "hrv_baseline_7d",
+  "athlete": "boundary-zone-total-secs",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/latest_hrv.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/latest_hrv.json
@@ -1,0 +1,8 @@
+{
+  "metric": "latest_hrv",
+  "athlete": "boundary-zone-total-secs",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/latest_rhr.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/latest_rhr.json
@@ -1,0 +1,8 @@
+{
+  "metric": "latest_rhr",
+  "athlete": "boundary-zone-total-secs",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/load_recovery_ratio.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/load_recovery_ratio.json
@@ -1,0 +1,8 @@
+{
+  "metric": "load_recovery_ratio",
+  "athlete": "boundary-zone-total-secs",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/monotony.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/monotony.json
@@ -1,0 +1,8 @@
+{
+  "metric": "monotony",
+  "athlete": "boundary-zone-total-secs",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 0.79
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/monotony_interpretation.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/monotony_interpretation.json
@@ -1,0 +1,8 @@
+{
+  "metric": "monotony_interpretation",
+  "athlete": "boundary-zone-total-secs",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": "normal"
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/multi_sport_detected.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/multi_sport_detected.json
@@ -1,0 +1,8 @@
+{
+  "metric": "multi_sport_detected",
+  "athlete": "boundary-zone-total-secs",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": false
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/p_max.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/p_max.json
@@ -1,0 +1,8 @@
+{
+  "metric": "p_max",
+  "athlete": "boundary-zone-total-secs",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/phase_detected.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/phase_detected.json
@@ -1,0 +1,8 @@
+{
+  "metric": "phase_detected",
+  "athlete": "boundary-zone-total-secs",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": "Base"
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/phase_detection.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/phase_detection.json
@@ -1,0 +1,38 @@
+{
+  "metric": "phase_detection",
+  "athlete": "boundary-zone-total-secs",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "basis": {
+      "data_quality": "good",
+      "stream_1": {
+        "acwr_trend": null,
+        "ctl_slope": null,
+        "hard_day_pattern": 0,
+        "weeks_available": 4
+      },
+      "stream_2": {
+        "current_week_hard_days_completed": 0,
+        "current_week_hard_days_total": 0,
+        "hard_sessions_planned": 0,
+        "next_week_load": null,
+        "plan_coverage_current_week": 0,
+        "plan_coverage_next_week": 0,
+        "planned_tss_delta": null,
+        "race_proximity": null
+      },
+      "stream_agreement": null
+    },
+    "confidence": "medium",
+    "dossier_agreement": null,
+    "dossier_declared": null,
+    "phase": "Base",
+    "phase_duration_weeks": 1,
+    "previous_phase": null,
+    "reason_codes": [
+      "NO_PLANNED_WORKOUTS"
+    ]
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/phase_triggers.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/phase_triggers.json
@@ -1,0 +1,10 @@
+{
+  "metric": "phase_triggers",
+  "athlete": "boundary-zone-total-secs",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": [
+    "NO_PLANNED_WORKOUTS"
+  ]
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/power_model_source.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/power_model_source.json
@@ -1,0 +1,8 @@
+{
+  "metric": "power_model_source",
+  "athlete": "boundary-zone-total-secs",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/primary_sport.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/primary_sport.json
@@ -1,0 +1,8 @@
+{
+  "metric": "primary_sport",
+  "athlete": "boundary-zone-total-secs",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": "cycling"
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/primary_sport_monotony.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/primary_sport_monotony.json
@@ -1,0 +1,8 @@
+{
+  "metric": "primary_sport_monotony",
+  "athlete": "boundary-zone-total-secs",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 0.79
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/primary_sport_tss_7d.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/primary_sport_tss_7d.json
@@ -1,0 +1,8 @@
+{
+  "metric": "primary_sport_tss_7d",
+  "athlete": "boundary-zone-total-secs",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 240
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/quality_intensity_note.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/quality_intensity_note.json
@@ -1,0 +1,8 @@
+{
+  "metric": "quality_intensity_note",
+  "athlete": "boundary-zone-total-secs",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": "Quality Intensity % (Z4+/threshold+) - target ~20% in polarized training"
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/quality_intensity_percentage.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/quality_intensity_percentage.json
@@ -1,0 +1,8 @@
+{
+  "metric": "quality_intensity_percentage",
+  "athlete": "boundary-zone-total-secs",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 62.9
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/recovery_index.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/recovery_index.json
@@ -1,0 +1,8 @@
+{
+  "metric": "recovery_index",
+  "athlete": "boundary-zone-total-secs",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/recovery_index_yesterday.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/recovery_index_yesterday.json
@@ -1,0 +1,8 @@
+{
+  "metric": "recovery_index_yesterday",
+  "athlete": "boundary-zone-total-secs",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/rhr_baseline_28d.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/rhr_baseline_28d.json
@@ -1,0 +1,8 @@
+{
+  "metric": "rhr_baseline_28d",
+  "athlete": "boundary-zone-total-secs",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/rhr_baseline_7d.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/rhr_baseline_7d.json
@@ -1,0 +1,8 @@
+{
+  "metric": "rhr_baseline_7d",
+  "athlete": "boundary-zone-total-secs",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/seasonal_context.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/seasonal_context.json
@@ -1,0 +1,8 @@
+{
+  "metric": "seasonal_context",
+  "athlete": "boundary-zone-total-secs",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": "Build / Early Race Season"
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/seiler_tid_28d.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/seiler_tid_28d.json
@@ -1,0 +1,18 @@
+{
+  "metric": "seiler_tid_28d",
+  "athlete": "boundary-zone-total-secs",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "classification": "High Intensity",
+    "polarization_index": null,
+    "z1_pct": 20.1,
+    "z1_seconds": 7346.8,
+    "z2_pct": 17,
+    "z2_seconds": 6233.700000000001,
+    "z3_pct": 62.9,
+    "z3_seconds": 23013.5,
+    "zone_basis": "power"
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/seiler_tid_28d_primary.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/seiler_tid_28d_primary.json
@@ -1,0 +1,19 @@
+{
+  "metric": "seiler_tid_28d_primary",
+  "athlete": "boundary-zone-total-secs",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "classification": "High Intensity",
+    "polarization_index": null,
+    "sport": "cycling",
+    "z1_pct": 20.1,
+    "z1_seconds": 7346.8,
+    "z2_pct": 17,
+    "z2_seconds": 6233.700000000001,
+    "z3_pct": 62.9,
+    "z3_seconds": 23013.5,
+    "zone_basis": "power"
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/seiler_tid_7d.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/seiler_tid_7d.json
@@ -1,0 +1,18 @@
+{
+  "metric": "seiler_tid_7d",
+  "athlete": "boundary-zone-total-secs",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "classification": "High Intensity",
+    "polarization_index": null,
+    "z1_pct": 20.1,
+    "z1_seconds": 7346.8,
+    "z2_pct": 17,
+    "z2_seconds": 6233.700000000001,
+    "z3_pct": 62.9,
+    "z3_seconds": 23013.5,
+    "zone_basis": "power"
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/seiler_tid_7d_primary.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/seiler_tid_7d_primary.json
@@ -1,0 +1,19 @@
+{
+  "metric": "seiler_tid_7d_primary",
+  "athlete": "boundary-zone-total-secs",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "classification": "High Intensity",
+    "polarization_index": null,
+    "sport": "cycling",
+    "z1_pct": 20.1,
+    "z1_seconds": 7346.8,
+    "z2_pct": 17,
+    "z2_seconds": 6233.700000000001,
+    "z3_pct": 62.9,
+    "z3_seconds": 23013.5,
+    "zone_basis": "power"
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/strain.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/strain.json
@@ -1,0 +1,8 @@
+{
+  "metric": "strain",
+  "athlete": "boundary-zone-total-secs",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 190
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/stress_tolerance.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/stress_tolerance.json
@@ -1,0 +1,8 @@
+{
+  "metric": "stress_tolerance",
+  "athlete": "boundary-zone-total-secs",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 2.4
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/tss_28d_total.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/tss_28d_total.json
@@ -1,0 +1,8 @@
+{
+  "metric": "tss_28d_total",
+  "athlete": "boundary-zone-total-secs",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 240
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/tss_7d_total.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/tss_7d_total.json
@@ -1,0 +1,8 @@
+{
+  "metric": "tss_7d_total",
+  "athlete": "boundary-zone-total-secs",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 240
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/vo2max.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/vo2max.json
@@ -1,0 +1,8 @@
+{
+  "metric": "vo2max",
+  "athlete": "boundary-zone-total-secs",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/w_prime.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/w_prime.json
@@ -1,0 +1,8 @@
+{
+  "metric": "w_prime",
+  "athlete": "boundary-zone-total-secs",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/w_prime_kj.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/w_prime_kj.json
@@ -1,0 +1,8 @@
+{
+  "metric": "w_prime_kj",
+  "athlete": "boundary-zone-total-secs",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/zone_distribution_7d.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/zone_distribution_7d.json
@@ -1,0 +1,15 @@
+{
+  "metric": "zone_distribution_7d",
+  "athlete": "boundary-zone-total-secs",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "total_hours": 10.16,
+    "z1_hours": 0.79,
+    "z2_hours": 1.25,
+    "z3_hours": 1.73,
+    "z4_plus_hours": 6.39,
+    "zone_basis": "power"
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/manifest.json
+++ b/packages/core/tests/fixtures/snapshots/manifest.json
@@ -5,6 +5,7 @@
   "fixtures": [
     "boundary-monotony",
     "boundary-sum-strain",
+    "boundary-zone-total-secs",
     "data-gap-mid-history",
     "new-athlete-empty",
     "realistic-athlete"

--- a/packages/core/tests/fixtures/snapshots/manifest.json
+++ b/packages/core/tests/fixtures/snapshots/manifest.json
@@ -3,6 +3,8 @@
   "section_11_protocol_version": "3.112",
   "section_11_commit_date": "2026-04-30T21:50:59+02:00",
   "fixtures": [
+    "boundary-monotony",
+    "boundary-sum-strain",
     "data-gap-mid-history",
     "new-athlete-empty",
     "realistic-athlete"

--- a/packages/core/tests/helpers/reference-arbitraries.ts
+++ b/packages/core/tests/helpers/reference-arbitraries.ts
@@ -55,11 +55,11 @@ export const arbitraryIcuIntervalRep: fc.Arbitrary<IcuIntervalRep> = fc.record({
   average_heartrate: nullableOptional(fc.float({ min: 60, max: 200, noNaN: true })),
 });
 
-/** Zone-time entry — intervals.icu returns the object form `{id, secs}` for
- *  native bins and the bare-number form for pre-flattened payloads. The
- *  schema accepts both per ZoneTimeEntrySchema; this arbitrary exercises
- *  both forms so read-side normalization (metrics/README.md Rule 3) sees
- *  both branches under property tests. */
+/** Zone-time entry for the pace/HR fields — those can appear as the object
+ *  form `{id, secs}` or a bare-number form (pre-flattened payloads), and
+ *  ZoneTimeEntrySchema accepts both; this arbitrary exercises both branches
+ *  under property tests. NOTE: `icu_zone_times` is object-form ONLY — use
+ *  `icuZoneTimeEntry` for it, not this one. */
 const zoneTimeEntry: fc.Arbitrary<number | { id: string; secs: number }> = fc.oneof(
   fc.float({ min: 0, max: 3600, noNaN: true }),
   fc.record({
@@ -69,6 +69,17 @@ const zoneTimeEntry: fc.Arbitrary<number | { id: string; secs: number }> = fc.on
 );
 
 const sevenZoneTimes = fc.array(zoneTimeEntry, { minLength: 7, maxLength: 7 });
+
+/** `icu_zone_times` entry — object form only, matching IcuZoneTimeEntrySchema.
+ *  The upstream reads `zone.get("id")` and raises on a bare number, so the
+ *  schema rejects bare numbers for this field; the arbitrary must not produce
+ *  shapes the schema rejects. */
+const icuZoneTimeEntry: fc.Arbitrary<{ id: string; secs: number }> = fc.record({
+  id: fc.constantFrom("Z1", "Z2", "Z3", "Z4", "Z5", "Z6", "Z7", "SS"),
+  secs: fc.float({ min: 0, max: 3600, noNaN: true }),
+});
+
+const sevenIcuZoneTimes = fc.array(icuZoneTimeEntry, { minLength: 7, maxLength: 7 });
 
 const arbitraryActivityRaw: fc.Arbitrary<Activity> = fc.record({
   // Identity + timing — the API uses both the string form ("i146622609",
@@ -98,7 +109,7 @@ const arbitraryActivityRaw: fc.Arbitrary<Activity> = fc.record({
   average_heartrate: fc.option(fc.float({ min: 60, max: 200, noNaN: true }), { nil: null }),
 
   // Zone-time breakdowns (optional)
-  icu_zone_times: fc.option(sevenZoneTimes, { nil: undefined }),
+  icu_zone_times: fc.option(sevenIcuZoneTimes, { nil: undefined }),
   pace_zone_times: fc.option(sevenZoneTimes, { nil: undefined }),
   hr_zone_times: fc.option(sevenZoneTimes, { nil: undefined }),
 

--- a/packages/core/tests/reference-arbitraries.test.ts
+++ b/packages/core/tests/reference-arbitraries.test.ts
@@ -272,24 +272,22 @@ describe("schema-union coverage (id form, zone-times form, rename-layer fields)"
     expect(numberForm).toBeGreaterThan(40);
   });
 
-  it("arbitraryActivity sometimes produces icu_zone_times in the object form {id, secs} and sometimes the bare-number form", () => {
-    let withObjectEntry = 0;
-    let withNumberEntry = 0;
+  it("arbitraryActivity produces icu_zone_times only in the object form {id, secs} — never a bare number (IcuZoneTimeEntrySchema rejects those)", () => {
+    let withZones = 0;
     fc.assert(
       fc.property(arbitraryActivity, (a) => {
         const zones = a.icu_zone_times;
         if (!Array.isArray(zones) || zones.length === 0) return true;
-        if (zones.some((z) => typeof z === "object" && z !== null)) withObjectEntry++;
-        if (zones.some((z) => typeof z === "number")) withNumberEntry++;
-        return true;
+        withZones++;
+        // The upstream reads `zone.get("id")` and raises on a bare number, so
+        // the schema (and this arbitrary) must keep icu_zone_times object-form.
+        return zones.every((z) => typeof z === "object" && z !== null);
       }),
       { numRuns: 500 },
     );
-    // Each of the 7 entries is ~50/50; an activity with zone-times set will
-    // almost always have at least one of each. ~90% of activities have
-    // zone-times set, so 500 runs → ~450 with both forms present.
-    expect(withObjectEntry).toBeGreaterThan(100);
-    expect(withNumberEntry).toBeGreaterThan(100);
+    // ~90% of generated activities have zone-times set, so 500 runs covers the
+    // object-only invariant on a large sample rather than vacuously.
+    expect(withZones).toBeGreaterThan(100);
   });
 
   it("arbitraryActivity sometimes produces a numeric fitnessAtEnd (rename-layer field — metric tests must exercise the populated branch)", () => {

--- a/packages/core/tests/reference-input-schemas.test.ts
+++ b/packages/core/tests/reference-input-schemas.test.ts
@@ -36,8 +36,16 @@ describe("ActivitySchema (z.looseObject)", () => {
       average_watts: 218,
       average_heartrate: 148,
 
-      // Zone-time breakdowns (named, optional)
-      icu_zone_times: [600, 1800, 2400, 540, 60, 0, 0],
+      // Zone-time breakdowns (named, optional). icu_zone_times is the API's
+      // native object-form bins; hr_zone_times exercises the still-permissive
+      // bare-number union arm.
+      icu_zone_times: [
+        { id: "Z1", secs: 600 },
+        { id: "Z2", secs: 1800 },
+        { id: "Z3", secs: 2400 },
+        { id: "Z4", secs: 540 },
+        { id: "Z5", secs: 60 },
+      ],
       pace_zone_times: undefined,
       hr_zone_times: [500, 1700, 2600, 540, 60, 0, 0],
 
@@ -130,6 +138,18 @@ describe("ActivitySchema (z.looseObject)", () => {
       hr_zone_times: [{ id: "Z1", secs: 500 }, { id: "Z2", secs: 1700 }],
     };
     expect(ActivitySchema.parse(objectFormActivity)).toEqual(objectFormActivity);
+  });
+
+  it("rejects an Activity whose icu_zone_times carries a bare-number entry (the upstream reads zone.get('id') and raises on an int, so bare-number bins are unportable and must not reach the read side)", () => {
+    const bareNumberZoneActivity = {
+      id: 17654324,
+      start_date_local: "2026-04-15T07:30:00",
+      type: "Ride",
+      moving_time: 5400,
+      elapsed_time: 5650,
+      icu_zone_times: [600, 1800, 2400, 540, 60, 0, 0],
+    };
+    expect(ActivitySchema.safeParse(bareNumberZoneActivity).success).toBe(false);
   });
 });
 

--- a/packages/core/tests/reference-input-schemas.test.ts
+++ b/packages/core/tests/reference-input-schemas.test.ts
@@ -151,6 +151,18 @@ describe("ActivitySchema (z.looseObject)", () => {
     };
     expect(ActivitySchema.safeParse(bareNumberZoneActivity).success).toBe(false);
   });
+
+  it("accepts an icu_zone_times object bin without `secs` (the oracle defaults a missing secs to 0 via zone.get('secs', 0), so the bin is processable, not a parse failure)", () => {
+    const missingSecsActivity = {
+      id: 17654325,
+      start_date_local: "2026-04-15T07:30:00",
+      type: "Ride",
+      moving_time: 5400,
+      elapsed_time: 5650,
+      icu_zone_times: [{ id: "Z1", secs: 600 }, { id: "Z2" }],
+    };
+    expect(ActivitySchema.safeParse(missingSecsActivity).success).toBe(true);
+  });
 });
 
 describe("WellnessDaySchema (z.looseObject)", () => {

--- a/tools/fuzz-parity-verdict.test.ts
+++ b/tools/fuzz-parity-verdict.test.ts
@@ -4,55 +4,108 @@ import { decideVerdict } from "./fuzz-parity-verdict";
 
 describe("decideVerdict — the harness must never report a vacuous pass", () => {
   it("passes ONLY when the differential ran clean on real inputs", () => {
-    expect(decideVerdict({ compared: 5000, oracleErrors: 0, mismatchTotal: 0 })).toEqual({
-      code: 0,
-      status: "ok",
-    });
+    expect(
+      decideVerdict({ compared: 5000, oracleErrors: 0, contractViolations: 0, mismatchTotal: 0 }),
+    ).toEqual({ code: 0, status: "ok" });
   });
 
   it("fails when the oracle threw on every input (the reported false-green: 0 compared → exit 0)", () => {
-    const v = decideVerdict({ compared: 0, oracleErrors: 5000, mismatchTotal: 0 });
+    const v = decideVerdict({
+      compared: 0,
+      oracleErrors: 5000,
+      contractViolations: 0,
+      mismatchTotal: 0,
+    });
     expect(v.status).toBe("oracle-error");
     expect(v.code).not.toBe(0);
   });
 
   it("fails on a partial-error run that previously printed OK across a handful of fixtures", () => {
-    const v = decideVerdict({ compared: 10, oracleErrors: 4990, mismatchTotal: 0 });
+    const v = decideVerdict({
+      compared: 10,
+      oracleErrors: 4990,
+      contractViolations: 0,
+      mismatchTotal: 0,
+    });
     expect(v.status).toBe("oracle-error");
     expect(v.code).not.toBe(0);
   });
 
   it("fails on even a single oracle error (strict any-error-fails)", () => {
-    expect(decideVerdict({ compared: 4999, oracleErrors: 1, mismatchTotal: 0 }).code).not.toBe(0);
+    expect(
+      decideVerdict({ compared: 4999, oracleErrors: 1, contractViolations: 0, mismatchTotal: 0 })
+        .code,
+    ).not.toBe(0);
+  });
+
+  it("fails on a contract violation — a silent-None input gives a false parity, not a clean pass", () => {
+    const v = decideVerdict({
+      compared: 4999,
+      oracleErrors: 0,
+      contractViolations: 1,
+      mismatchTotal: 0,
+    });
+    expect(v).toEqual({ code: 2, status: "contract-violation" });
+  });
+
+  it("lets an oracle error outrank a contract violation — fix the broken oracle first", () => {
+    expect(
+      decideVerdict({ compared: 100, oracleErrors: 1, contractViolations: 1, mismatchTotal: 0 })
+        .status,
+    ).toBe("oracle-error");
+  });
+
+  it("lets a contract violation outrank a mismatch — a mismatch on an untrustworthy input is meaningless", () => {
+    expect(
+      decideVerdict({ compared: 100, oracleErrors: 0, contractViolations: 1, mismatchTotal: 5 })
+        .status,
+    ).toBe("contract-violation");
   });
 
   it("fails on an empty run (e.g. --n=0) — nothing proven is not a pass", () => {
-    expect(decideVerdict({ compared: 0, oracleErrors: 0, mismatchTotal: 0 })).toEqual({
-      code: 2,
-      status: "empty",
-    });
+    expect(
+      decideVerdict({ compared: 0, oracleErrors: 0, contractViolations: 0, mismatchTotal: 0 }),
+    ).toEqual({ code: 2, status: "empty" });
   });
 
   it("reports metric mismatches as a divergence (exit 1)", () => {
-    expect(decideVerdict({ compared: 5000, oracleErrors: 0, mismatchTotal: 3 })).toEqual({
-      code: 1,
-      status: "mismatch",
-    });
+    expect(
+      decideVerdict({ compared: 5000, oracleErrors: 0, contractViolations: 0, mismatchTotal: 3 }),
+    ).toEqual({ code: 1, status: "mismatch" });
   });
 
   it("lets an oracle error mask mismatches — a broken oracle invalidates the whole run", () => {
-    expect(decideVerdict({ compared: 4000, oracleErrors: 1000, mismatchTotal: 7 }).status).toBe(
-      "oracle-error",
-    );
+    expect(
+      decideVerdict({ compared: 4000, oracleErrors: 1000, contractViolations: 0, mismatchTotal: 7 })
+        .status,
+    ).toBe("oracle-error");
   });
 
-  it("invariant: code 0 IFF oracleErrors===0 && mismatchTotal===0 && compared>0", () => {
+  it("invariant: code 0 IFF every failure counter is clear and at least one fixture compared", () => {
     for (const compared of [0, 1, 100]) {
       for (const oracleErrors of [0, 1, 50]) {
-        for (const mismatchTotal of [0, 1, 9]) {
-          const v = decideVerdict({ compared, oracleErrors, mismatchTotal });
-          const shouldPass = oracleErrors === 0 && mismatchTotal === 0 && compared > 0;
-          expect(v.code === 0).toBe(shouldPass);
+        for (const contractViolations of [0, 1, 50]) {
+          for (const mismatchTotal of [0, 1, 9]) {
+            const v = decideVerdict({ compared, oracleErrors, contractViolations, mismatchTotal });
+            const shouldPass =
+              oracleErrors === 0 &&
+              contractViolations === 0 &&
+              mismatchTotal === 0 &&
+              compared > 0;
+            expect(v.code === 0).toBe(shouldPass);
+            // Precedence: oracle-error > contract-violation > mismatch > empty > ok.
+            const expectedStatus =
+              oracleErrors > 0
+                ? "oracle-error"
+                : contractViolations > 0
+                  ? "contract-violation"
+                  : mismatchTotal > 0
+                    ? "mismatch"
+                    : compared === 0
+                      ? "empty"
+                      : "ok";
+            expect(v.status).toBe(expectedStatus);
+          }
         }
       }
     }

--- a/tools/fuzz-parity-verdict.test.ts
+++ b/tools/fuzz-parity-verdict.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import { decideVerdict } from "./fuzz-parity-verdict";
+
+describe("decideVerdict — the harness must never report a vacuous pass", () => {
+  it("passes ONLY when the differential ran clean on real inputs", () => {
+    expect(decideVerdict({ compared: 5000, oracleErrors: 0, mismatchTotal: 0 })).toEqual({
+      code: 0,
+      status: "ok",
+    });
+  });
+
+  it("fails when the oracle threw on every input (the reported false-green: 0 compared → exit 0)", () => {
+    const v = decideVerdict({ compared: 0, oracleErrors: 5000, mismatchTotal: 0 });
+    expect(v.status).toBe("oracle-error");
+    expect(v.code).not.toBe(0);
+  });
+
+  it("fails on a partial-error run that previously printed OK across a handful of fixtures", () => {
+    const v = decideVerdict({ compared: 10, oracleErrors: 4990, mismatchTotal: 0 });
+    expect(v.status).toBe("oracle-error");
+    expect(v.code).not.toBe(0);
+  });
+
+  it("fails on even a single oracle error (strict any-error-fails)", () => {
+    expect(decideVerdict({ compared: 4999, oracleErrors: 1, mismatchTotal: 0 }).code).not.toBe(0);
+  });
+
+  it("fails on an empty run (e.g. --n=0) — nothing proven is not a pass", () => {
+    expect(decideVerdict({ compared: 0, oracleErrors: 0, mismatchTotal: 0 })).toEqual({
+      code: 2,
+      status: "empty",
+    });
+  });
+
+  it("reports metric mismatches as a divergence (exit 1)", () => {
+    expect(decideVerdict({ compared: 5000, oracleErrors: 0, mismatchTotal: 3 })).toEqual({
+      code: 1,
+      status: "mismatch",
+    });
+  });
+
+  it("lets an oracle error mask mismatches — a broken oracle invalidates the whole run", () => {
+    expect(decideVerdict({ compared: 4000, oracleErrors: 1000, mismatchTotal: 7 }).status).toBe(
+      "oracle-error",
+    );
+  });
+
+  it("invariant: code 0 IFF oracleErrors===0 && mismatchTotal===0 && compared>0", () => {
+    for (const compared of [0, 1, 100]) {
+      for (const oracleErrors of [0, 1, 50]) {
+        for (const mismatchTotal of [0, 1, 9]) {
+          const v = decideVerdict({ compared, oracleErrors, mismatchTotal });
+          const shouldPass = oracleErrors === 0 && mismatchTotal === 0 && compared > 0;
+          expect(v.code === 0).toBe(shouldPass);
+        }
+      }
+    }
+  });
+});

--- a/tools/fuzz-parity-verdict.ts
+++ b/tools/fuzz-parity-verdict.ts
@@ -1,0 +1,42 @@
+/**
+ * Verdict logic for the differential fuzz-parity harness, split into a pure,
+ * side-effect-free module so the "never report a vacuous pass" invariant can be
+ * unit-tested without spinning up Pyodide (importing the harness itself would
+ * trigger its top-level `main()`).
+ *
+ * The harness earns a pass ONLY by actually running the differential clean on
+ * real inputs. A run that proved nothing — the oracle threw on everything, or
+ * nothing was fuzzed at all — must never look like success.
+ */
+
+export type VerdictStatus = "ok" | "mismatch" | "oracle-error" | "empty";
+
+export interface Verdict {
+  /** Process exit code: 0 pass · 1 metric divergence · 2 broken/empty run. */
+  code: 0 | 1 | 2;
+  status: VerdictStatus;
+}
+
+export interface RunCounts {
+  /** Fixtures on which the full TS-vs-oracle comparison actually ran. */
+  compared: number;
+  /** Fixtures the oracle threw on (returned `__error__`) and were skipped. */
+  oracleErrors: number;
+  /** Total metric mismatches summed across every compared fixture. */
+  mismatchTotal: number;
+}
+
+/**
+ * Strict gate: `code` is 0 IFF the run compared at least one fixture, the oracle
+ * never threw, and no metric diverged. Any oracle error fails — a broken oracle
+ * (e.g. an upstream signature drift on a SHA bump) invalidates the run, and a
+ * partial-error run is just as vacuous as a total one. Oracle errors take
+ * precedence over mismatches: fix the oracle first, then re-run for a clean
+ * mismatch signal.
+ */
+export function decideVerdict({ compared, oracleErrors, mismatchTotal }: RunCounts): Verdict {
+  if (oracleErrors > 0) return { code: 2, status: "oracle-error" };
+  if (mismatchTotal > 0) return { code: 1, status: "mismatch" };
+  if (compared === 0) return { code: 2, status: "empty" };
+  return { code: 0, status: "ok" };
+}

--- a/tools/fuzz-parity-verdict.ts
+++ b/tools/fuzz-parity-verdict.ts
@@ -9,7 +9,7 @@
  * nothing was fuzzed at all — must never look like success.
  */
 
-export type VerdictStatus = "ok" | "mismatch" | "oracle-error" | "empty";
+export type VerdictStatus = "ok" | "mismatch" | "oracle-error" | "contract-violation" | "empty";
 
 export interface Verdict {
   /** Process exit code: 0 pass · 1 metric divergence · 2 broken/empty run. */
@@ -22,20 +22,34 @@ export interface RunCounts {
   compared: number;
   /** Fixtures the oracle threw on (returned `__error__`) and were skipped. */
   oracleErrors: number;
+  /**
+   * Fixtures the oracle read a silently-missing fixture key on (returned
+   * `__contract_violation__`) and were skipped. Both sides reading the same
+   * silent None would report a false parity, so these are not trustworthy.
+   */
+  contractViolations: number;
   /** Total metric mismatches summed across every compared fixture. */
   mismatchTotal: number;
 }
 
 /**
  * Strict gate: `code` is 0 IFF the run compared at least one fixture, the oracle
- * never threw, and no metric diverged. Any oracle error fails — a broken oracle
- * (e.g. an upstream signature drift on a SHA bump) invalidates the run, and a
- * partial-error run is just as vacuous as a total one. Oracle errors take
- * precedence over mismatches: fix the oracle first, then re-run for a clean
- * mismatch signal.
+ * never threw, no contract violation occurred, and no metric diverged. Any
+ * oracle error or contract violation fails — a broken oracle (e.g. an upstream
+ * signature drift on a SHA bump) or an input read through a silent-None path
+ * invalidates the run, and a partial failure is just as vacuous as a total one.
+ * Oracle errors take precedence over contract violations, which take precedence
+ * over mismatches: a mismatch computed on an untrustworthy input is meaningless,
+ * so fix the oracle and the input contract first, then re-run for a clean signal.
  */
-export function decideVerdict({ compared, oracleErrors, mismatchTotal }: RunCounts): Verdict {
+export function decideVerdict({
+  compared,
+  oracleErrors,
+  contractViolations,
+  mismatchTotal,
+}: RunCounts): Verdict {
   if (oracleErrors > 0) return { code: 2, status: "oracle-error" };
+  if (contractViolations > 0) return { code: 2, status: "contract-violation" };
   if (mismatchTotal > 0) return { code: 1, status: "mismatch" };
   if (compared === 0) return { code: 2, status: "empty" };
   return { code: 0, status: "ok" };

--- a/tools/fuzz-parity.ts
+++ b/tools/fuzz-parity.ts
@@ -36,6 +36,7 @@ import { join, resolve } from "node:path";
 import { loadPyodide } from "pyodide";
 
 import { deepCompare, METRIC_REGISTRY, REPO_ROOT } from "./check-metric-parity";
+import { decideVerdict } from "./fuzz-parity-verdict";
 
 const SECTION_11_REPO = process.env.SECTION_11_REPO ?? resolve(REPO_ROOT, "../section-11");
 const SYNC_PY_PATH = join(SECTION_11_REPO, "examples/sync.py");
@@ -192,6 +193,8 @@ async function main(): Promise<number> {
   const metrics = Object.keys(METRIC_REGISTRY);
   const mismatch: Record<string, number> = Object.fromEntries(metrics.map((m) => [m, 0]));
   let oracleErrors = 0;
+  let firstOracleError: string | null = null;
+  let firstOracleErrorPath: string | null = null;
   let compared = 0;
   let firstFailPath: string | null = null;
 
@@ -201,6 +204,11 @@ async function main(): Promise<number> {
     const derived = JSON.parse(py.runPython("compute(FIXJSON)") as string) as Record<string, unknown>;
     if ("__error__" in derived) {
       oracleErrors++;
+      if (!firstOracleError) {
+        firstOracleError = String(derived.__error__);
+        firstOracleErrorPath = join(FAIL_DIR, `_fuzz-oracle-error-seed${args.seed}-i${i}.json`);
+        writeFileSync(firstOracleErrorPath, `${JSON.stringify(fixture, null, 2)}\n`);
+      }
       continue;
     }
     compared++;
@@ -230,13 +238,29 @@ async function main(): Promise<number> {
   for (const m of metrics) {
     if (mismatch[m]! > 0) console.log(`[fuzz-parity]   MISMATCH ${m}: ${mismatch[m]}`);
   }
-  if (total === 0) {
-    console.log(`[fuzz-parity] OK — all ${metrics.length} metrics bit-identical across ${compared} fixtures`);
-    return 0;
+  // OK is reported ONLY on a run that proved bit-identity: a non-zero fixture
+  // count, every one compared clean, zero oracle throws. Any `__error__` means
+  // the differential silently skipped that input (the signature-drift-on-a-SHA-
+  // bump failure that used to slip through as a green "OK across 0 fixtures").
+  const verdict = decideVerdict({ compared, oracleErrors, mismatchTotal: total });
+  switch (verdict.status) {
+    case "oracle-error":
+      console.error(`[fuzz-parity] FAIL — oracle threw on ${oracleErrors}/${args.n} input(s); the differential never ran on them, so this is NOT a pass.`);
+      console.error(`[fuzz-parity]   first oracle error: ${firstOracleError}`);
+      console.error(`[fuzz-parity]   erroring fixture written to:\n  ${firstOracleErrorPath}`);
+      break;
+    case "mismatch":
+      console.error(`[fuzz-parity] FAIL — ${total} metric mismatch(es). First failing fixture written to:\n  ${firstFailPath}`);
+      console.error(`[fuzz-parity] Freeze it as a golden fixture (add to HARNESS_FIXTURES in tools/snapshot-section-11.ts, then \`pnpm snapshot:section-11\`) so the gate defends it.`);
+      break;
+    case "empty":
+      console.error(`[fuzz-parity] FAIL — 0 fixtures compared (n=${args.n}); refusing to report OK on a run that proved nothing.`);
+      break;
+    case "ok":
+      console.log(`[fuzz-parity] OK — all ${metrics.length} metrics bit-identical across ${compared}/${args.n} fixtures`);
+      break;
   }
-  console.log(`[fuzz-parity] FAIL — ${total} metric mismatch(es). First failing fixture written to:\n  ${firstFailPath}`);
-  console.log(`[fuzz-parity] Freeze it as a golden fixture (add to HARNESS_FIXTURES in tools/snapshot-section-11.ts, then \`pnpm snapshot:section-11\`) so the gate defends it.`);
-  return 1;
+  return verdict.code;
 }
 
 main().then(

--- a/tools/fuzz-parity.ts
+++ b/tools/fuzz-parity.ts
@@ -118,9 +118,52 @@ _ns = {"__name__": "upstream_under_test", "__file__": "sync.py"}
 exec(SYNC_PY_SOURCE, _ns)
 IntervalsSync = _ns["IntervalsSync"]
 
+# Fixture contract validation — mirrors the snapshot harness so the fuzzer's
+# differential is as strong as the gate's. sync.py reads fixture
+# fields via dict.get(), which silently returns None on a missing key; a
+# perturbation that introduced an untracked silent-None path (or a typo'd
+# field) would be read the same way by both sides and report a false parity.
+# _TrackedDict logs every .get() of an absent key; compute() checks the log
+# (minus the allowlist) after each run and fails loud on anything unexpected.
+import re as _re
+_TRACKED_MISSING = []
+# Allowlist ported from the snapshot harness, plus icu_zone_times: perturb
+# deletes it on ~30% of activities. The golden fixtures always include it, so
+# the snapshot allowlist omits it — but here it is a legitimate optionality.
+_ALLOWED_OPTIONAL_PATHS = {
+    "FIXTURE.activities[*].icu_hr_decoupling",
+    "FIXTURE.activities[*].icu_hr_zone_times",
+    "FIXTURE.activities[*].icu_hrr",
+    "FIXTURE.activities[*].icu_variability_index",
+    "FIXTURE.activities[*].icu_zone_times",
+    "FIXTURE.wellness[*].atl",
+    "FIXTURE.wellness[*].ctl",
+}
+def _normalize_path(path):
+    return _re.sub(r"\\[\\d+\\]", "[*]", path)
+class _TrackedDict(dict):
+    def __init__(self, data, path):
+        super().__init__()
+        self._path = path
+        for k, v in data.items():
+            super().__setitem__(k, _wrap_tracked(v, f"{path}.{k}"))
+    def get(self, key, default=None):
+        if dict.__contains__(self, key):
+            return dict.__getitem__(self, key)
+        _TRACKED_MISSING.append(f"{self._path}.{key}")
+        return default
+def _wrap_tracked(value, path):
+    if isinstance(value, dict):
+        return _TrackedDict(value, path)
+    if isinstance(value, list):
+        return [_wrap_tracked(item, f"{path}[{i}]") for i, item in enumerate(value)]
+    return value
+
 def compute(fixture_json):
     try:
-        FIX = json.loads(fixture_json)
+        # Reset the tracker each call — the loop reuses this module after one exec.
+        _TRACKED_MISSING.clear()
+        FIX = _TrackedDict(json.loads(fixture_json), "FIXTURE")
         acts = FIX.get("activities", []) or []
         well = FIX.get("wellness", []) or []
         def within(items, key, oldest, newest):
@@ -151,6 +194,12 @@ def compute(fixture_json):
             vo2max=None, formatted_planned_workouts=[], race_calendar=None, power_curve_data=None,
             power_curve_dates=None, hr_curve_data=None, sustainability_curves={}, sustainability_window=None,
             sport_settings={}, icu_weight=lw.get("weight"))
+        unallowed = sorted({
+            p for p in _TRACKED_MISSING
+            if _normalize_path(p) not in _ALLOWED_OPTIONAL_PATHS
+        })
+        if unallowed:
+            return json.dumps({"__contract_violation__": {"missing_keys": unallowed}})
         return json.dumps(derived, default=str, sort_keys=True)
     except Exception as e:
         return json.dumps({"__error__": f"{type(e).__name__}: {e}"})
@@ -224,6 +273,9 @@ async function main(): Promise<number> {
   let oracleErrors = 0;
   let firstOracleError: string | null = null;
   let firstOracleErrorPath: string | null = null;
+  let contractViolations = 0;
+  let firstViolation: string | null = null;
+  let firstViolationPath: string | null = null;
   let compared = 0;
   // One reproducing fixture per diverging metric. A single global capture would
   // discard every metric that isn't the first to diverge — defeating the
@@ -240,6 +292,16 @@ async function main(): Promise<number> {
         firstOracleError = String(derived.__error__);
         firstOracleErrorPath = join(FAIL_DIR, `_fuzz-oracle-error-seed${args.seed}-i${i}.json`);
         writeCapture(firstOracleErrorPath, fixture);
+      }
+      continue;
+    }
+    if ("__contract_violation__" in derived) {
+      contractViolations++;
+      if (!firstViolation) {
+        const v = derived.__contract_violation__ as { missing_keys?: string[] };
+        firstViolation = (v.missing_keys ?? []).join(", ");
+        firstViolationPath = join(FAIL_DIR, `_fuzz-contract-violation-seed${args.seed}-i${i}.json`);
+        writeCapture(firstViolationPath, fixture);
       }
       continue;
     }
@@ -273,7 +335,7 @@ async function main(): Promise<number> {
   }
 
   const total = Object.values(mismatch).reduce((s, x) => s + x, 0);
-  console.log(`[fuzz-parity] oracle: Python ${pyVersion} (Pyodide) · seed ${args.seed} · fixtures ${compared}/${args.n} (oracle errors: ${oracleErrors})`);
+  console.log(`[fuzz-parity] oracle: Python ${pyVersion} (Pyodide) · seed ${args.seed} · fixtures ${compared}/${args.n} (oracle errors: ${oracleErrors}, contract violations: ${contractViolations})`);
   for (const m of metrics) {
     if (mismatch[m]! > 0) console.log(`[fuzz-parity]   MISMATCH ${m}: ${mismatch[m]}`);
   }
@@ -301,12 +363,17 @@ async function main(): Promise<number> {
   // count, every one compared clean, zero oracle throws. Any `__error__` means
   // the differential silently skipped that input (the signature-drift-on-a-SHA-
   // bump failure that used to slip through as a green "OK across 0 fixtures").
-  const verdict = decideVerdict({ compared, oracleErrors, mismatchTotal: total });
+  const verdict = decideVerdict({ compared, oracleErrors, contractViolations, mismatchTotal: total });
   switch (verdict.status) {
     case "oracle-error":
       console.error(`[fuzz-parity] FAIL — oracle threw on ${oracleErrors}/${args.n} input(s); the differential never ran on them, so this is NOT a pass.`);
       console.error(`[fuzz-parity]   first oracle error: ${firstOracleError}`);
       console.error(`[fuzz-parity]   erroring fixture written to:\n  ${firstOracleErrorPath}`);
+      break;
+    case "contract-violation":
+      console.error(`[fuzz-parity] FAIL — oracle read a silently-missing fixture key on ${contractViolations}/${args.n} input(s); both sides reading the same None would report a false parity, so this is NOT a pass.`);
+      console.error(`[fuzz-parity]   first missing key(s): ${firstViolation}`);
+      console.error(`[fuzz-parity]   If it is a legitimate schema optionality, add the path to _ALLOWED_OPTIONAL_PATHS in the prologue; otherwise fix perturb so it stops generating it. Fixture written to:\n  ${firstViolationPath}`);
       break;
     case "mismatch": {
       const captured = Object.values(failPaths);

--- a/tools/fuzz-parity.ts
+++ b/tools/fuzz-parity.ts
@@ -164,11 +164,11 @@ function perturb(base: { activities: Record<string, unknown>[]; wellness: Record
     a.type = pick(SPORT_TYPES);
     a.icu_training_load = rnd() < 0.1 ? 0 : dec1(300);
     if (rnd() < 0.7) {
-      a.icu_zone_times = ZONE_IDS.map((id) => ({ id, secs: Math.floor(rnd() * 3600) }));
+      a.icu_zone_times = ZONE_IDS.map((id) => ({ id, secs: dec1(3600) }));
     } else {
       delete a.icu_zone_times;
     }
-    if (rnd() < 0.4) a.icu_hr_zone_times = Array.from({ length: 5 }, () => Math.floor(rnd() * 3000));
+    if (rnd() < 0.4) a.icu_hr_zone_times = Array.from({ length: 5 }, () => dec1(3000));
   }
   for (const w of f.wellness) {
     w.hrv = rnd() < 0.05 ? null : Math.round((10 + rnd() * 240) * 10) / 10;

--- a/tools/fuzz-parity.ts
+++ b/tools/fuzz-parity.ts
@@ -50,14 +50,27 @@ interface Args {
   frozenNow: string;
 }
 
+// Reject typo'd numeric flags fast and loudly, before the expensive Pyodide
+// boot. Without this, `--n=5k` (→ NaN) or `--n=-1` runs the loop zero times:
+// the compared===0 guard still fails the run, but only after loading the oracle
+// and with a generic message. This points straight at the bad flag.
+function intArg(flag: string, raw: string, min: number): number {
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n < min) {
+    console.error(`[fuzz-parity] invalid ${flag}=${raw}: expected an integer >= ${min}`);
+    process.exit(2);
+  }
+  return n;
+}
+
 function parseArgs(argv: string[]): Args {
   const out: Args = { n: 5000, seed: 20260525, fixture: "realistic-athlete", frozenNow: "2026-05-10T12:00:00" };
   for (const a of argv) {
     const m = /^--([a-zA-Z]+)=(.+)$/.exec(a);
     if (!m) continue;
     const [, k, v] = m;
-    if (k === "n") out.n = Number(v);
-    else if (k === "seed") out.seed = Number(v);
+    if (k === "n") out.n = intArg("--n", v!, 1);
+    else if (k === "seed") out.seed = intArg("--seed", v!, 0);
     else if (k === "fixture") out.fixture = v!;
     else if (k === "frozen") out.frozenNow = v!;
   }

--- a/tools/fuzz-parity.ts
+++ b/tools/fuzz-parity.ts
@@ -1,0 +1,248 @@
+/**
+ * Differential fuzz-parity harness.
+ *
+ * The parity gate (`check-metric-parity`) asserts the TS Reference metrics
+ * are bit-identical to the upstream Python protocol — but only on a handful
+ * of hand-authored golden fixtures whose tidy numbers never land on a
+ * rounding boundary. That blind spot let a string of float-precision
+ * deviations ship green (base-10 rounding, float mean/stdev, naive `sum()`),
+ * each invisible until an input lands within a ULP of a `round()` boundary.
+ *
+ * This tool closes the blind spot the durable way: it generates many
+ * randomized fixtures (seeded → reproducible), runs each through BOTH the
+ * Python oracle (sync.py under Pyodide) and the TS `METRIC_REGISTRY`, and
+ * asserts bit-identity across every metric. Inputs are biased toward the
+ * boundary-hitting regime (one-decimal loads / HRV / RHR — integers never
+ * expose the drift). A divergence is written to disk so it can be frozen as
+ * a golden fixture (see `tools/snapshot-section-11.ts` allowlist).
+ *
+ * It is a dev-time / manual tool, NOT part of `pnpm test`: it needs Pyodide
+ * and the upstream checkout, which CI doesn't provision (same constraint as
+ * `diff-pyodide-vs-cpython.ts`). Run by hand during porting, on an upstream
+ * SHA bump, or before a wave that adds float-heavy metrics.
+ *
+ * IMPORTANT — the oracle's Python version is load-bearing. Pyodide currently
+ * bundles CPython 3.13, whose `sum()` (Neumaier compensated, 3.12+) and
+ * `statistics.stdev` (correctly-rounded sqrt, 3.12+) differ from 3.10/3.11.
+ * The TS helpers in `metrics/statistics.ts` reproduce the 3.12+ semantics;
+ * if Pyodide's bundled Python changes, re-confirm them here.
+ *
+ *   Usage: pnpm fuzz-parity [--n=5000] [--seed=20260525] [--fixture=realistic-athlete]
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+import { loadPyodide } from "pyodide";
+
+import { deepCompare, METRIC_REGISTRY, REPO_ROOT } from "./check-metric-parity";
+
+const SECTION_11_REPO = process.env.SECTION_11_REPO ?? resolve(REPO_ROOT, "../section-11");
+const SYNC_PY_PATH = join(SECTION_11_REPO, "examples/sync.py");
+const GOLDEN_DIR = resolve(REPO_ROOT, "packages/core/tests/fixtures/golden");
+const FAIL_DIR = resolve(REPO_ROOT, "packages/core/tests/fixtures/golden");
+
+interface Args {
+  n: number;
+  seed: number;
+  fixture: string;
+  frozenNow: string;
+}
+
+function parseArgs(argv: string[]): Args {
+  const out: Args = { n: 5000, seed: 20260525, fixture: "realistic-athlete", frozenNow: "2026-05-10T12:00:00" };
+  for (const a of argv) {
+    const m = /^--([a-zA-Z]+)=(.+)$/.exec(a);
+    if (!m) continue;
+    const [, k, v] = m;
+    if (k === "n") out.n = Number(v);
+    else if (k === "seed") out.seed = Number(v);
+    else if (k === "fixture") out.fixture = v!;
+    else if (k === "frozen") out.frozenNow = v!;
+  }
+  return out;
+}
+
+// The Pyodide prologue: stub `requests`, freeze `datetime` to the anchor,
+// exec the upstream source, then expose `compute(fixture_json)` returning the
+// full derived-metrics dict. Mirrors the setup in `tools/snapshot-section-11.ts`
+// (kept inline so the loop can call `compute` thousands of times after a
+// single `exec`).
+const ORACLE_PROLOGUE = `
+import sys, json, types
+from datetime import datetime, timedelta
+
+class _StubResponse:
+    def __init__(self, payload=None, status=200):
+        self._payload = payload or {}; self.status_code = status
+    def json(self): return self._payload
+    def raise_for_status(self):
+        if self.status_code >= 400: raise Exception("HTTP")
+class _StubExceptions:
+    Timeout=Exception; RequestException=Exception; ConnectionError=Exception; HTTPError=Exception
+_rs = types.ModuleType("requests")
+def _c(*a, **k): return _StubResponse({})
+_rs.get=_rs.post=_rs.put=_rs.delete=_rs.head=_c
+_rs.exceptions=_StubExceptions
+sys.modules["requests"]=_rs
+
+_FN = datetime.fromisoformat(FROZEN_NOW)
+class _FrozenDateTime(datetime):
+    @classmethod
+    def now(cls, tz=None): return _FN if tz is None else _FN.replace(tzinfo=tz)
+    @classmethod
+    def utcnow(cls): return _FN
+    @classmethod
+    def today(cls): return _FN
+import datetime as _dtm
+_dtm.datetime = _FrozenDateTime
+
+_ns = {"__name__": "upstream_under_test", "__file__": "sync.py"}
+exec(SYNC_PY_SOURCE, _ns)
+IntervalsSync = _ns["IntervalsSync"]
+
+def compute(fixture_json):
+    try:
+        FIX = json.loads(fixture_json)
+        acts = FIX.get("activities", []) or []
+        well = FIX.get("wellness", []) or []
+        def within(items, key, oldest, newest):
+            out = []
+            for it in items:
+                if not isinstance(it, dict): continue
+                d = it.get(key, "")
+                if not isinstance(d, str): continue
+                if oldest <= d[:10] <= newest: out.append(it)
+            return out
+        today = _FN.strftime("%Y-%m-%d")
+        o7 = (_FN - timedelta(days=6)).strftime("%Y-%m-%d")
+        o28 = (_FN - timedelta(days=27)).strftime("%Y-%m-%d")
+        a7 = within(acts, "start_date_local", o7, today)
+        a28 = within(acts, "start_date_local", o28, today)
+        w7 = within(well, "id", o7, today)
+        w28 = within(well, "id", o28, today)
+        lw = (sorted(w28, key=lambda r: r.get("id",""), reverse=True)[0] if w28 else {}) or {}
+        cctl = lw.get("ctl") or 0.0; catl = lw.get("atl") or 0.0
+        ctsb = (cctl - catl) if (cctl is not None and catl is not None) else 0.0
+        sync = IntervalsSync(athlete_id="s", intervals_api_key="k", github_token=None, debug=False)
+        sync._intervals_data = {}
+        BN = (None, None, None)
+        derived = sync._calculate_derived_metrics(
+            activities_7d=a7, activities_28d=a28, wellness_7d=w7, wellness_extended=w28,
+            current_ctl=cctl, current_atl=catl, current_tsb=ctsb, past_events=[],
+            activities_for_consistency=a7, power_model={}, benchmark_indoor=BN, benchmark_outdoor=BN,
+            vo2max=None, formatted_planned_workouts=[], race_calendar=None, power_curve_data=None,
+            power_curve_dates=None, hr_curve_data=None, sustainability_curves={}, sustainability_window=None,
+            sport_settings={}, icu_weight=lw.get("weight"))
+        return json.dumps(derived, default=str, sort_keys=True)
+    except Exception as e:
+        return json.dumps({"__error__": f"{type(e).__name__}: {e}"})
+`;
+
+// A small linear-congruential PRNG so runs are reproducible from --seed.
+function makeRng(seed: number): () => number {
+  let s = seed >>> 0;
+  return () => {
+    s = (Math.imul(s, 1664525) + 1013904223) >>> 0;
+    return s / 0x1_0000_0000;
+  };
+}
+
+const SPORT_TYPES = ["Ride", "VirtualRide", "Run", "VirtualRun", "TrailRun", "NordicSki",
+  "Swim", "Rowing", "WeightTraining", "Walk", "Hike", "Yoga", "Workout"];
+const ZONE_IDS = ["Z1", "Z2", "Z3", "Z4", "Z5", "Z6", "Z7"];
+
+// Perturb the base fixture's numeric inputs into the boundary-hitting regime:
+// one-decimal loads/HRV/RHR (integers never expose the float drift), varied
+// sport families, and a mix of power / HR zone arrays to exercise the basis
+// and primary-sport logic.
+function perturb(base: { activities: Record<string, unknown>[]; wellness: Record<string, unknown>[] }, rnd: () => number): unknown {
+  const pick = <T>(a: T[]): T => a[Math.floor(rnd() * a.length)]!;
+  const dec1 = (hi: number) => Math.round(rnd() * hi * 10) / 10;
+  const f = structuredClone(base);
+  for (const a of f.activities) {
+    a.type = pick(SPORT_TYPES);
+    a.icu_training_load = rnd() < 0.1 ? 0 : dec1(300);
+    if (rnd() < 0.7) {
+      a.icu_zone_times = ZONE_IDS.map((id) => ({ id, secs: Math.floor(rnd() * 3600) }));
+    } else {
+      delete a.icu_zone_times;
+    }
+    if (rnd() < 0.4) a.icu_hr_zone_times = Array.from({ length: 5 }, () => Math.floor(rnd() * 3000));
+  }
+  for (const w of f.wellness) {
+    w.hrv = rnd() < 0.05 ? null : Math.round((10 + rnd() * 240) * 10) / 10;
+    w.restingHR = rnd() < 0.05 ? 0 : Math.round((35 + rnd() * 60) * 10) / 10;
+  }
+  return f;
+}
+
+async function main(): Promise<number> {
+  const args = parseArgs(process.argv.slice(2));
+  const base = JSON.parse(readFileSync(join(GOLDEN_DIR, `${args.fixture}.json`), "utf8"));
+  const syncSource = readFileSync(SYNC_PY_PATH, "utf8");
+
+  const py = await loadPyodide({ indexURL: resolve(REPO_ROOT, "node_modules/pyodide") });
+  py.globals.set("FROZEN_NOW", args.frozenNow);
+  py.globals.set("SYNC_PY_SOURCE", syncSource);
+  py.runPython(ORACLE_PROLOGUE);
+  const pyVersion = py.runPython("__import__('sys').version.split()[0]") as string;
+
+  const rnd = makeRng(args.seed);
+  const metrics = Object.keys(METRIC_REGISTRY);
+  const mismatch: Record<string, number> = Object.fromEntries(metrics.map((m) => [m, 0]));
+  let oracleErrors = 0;
+  let compared = 0;
+  let firstFailPath: string | null = null;
+
+  for (let i = 0; i < args.n; i++) {
+    const fixture = perturb(base, rnd);
+    py.globals.set("FIXJSON", JSON.stringify(fixture));
+    const derived = JSON.parse(py.runPython("compute(FIXJSON)") as string) as Record<string, unknown>;
+    if ("__error__" in derived) {
+      oracleErrors++;
+      continue;
+    }
+    compared++;
+    for (const m of metrics) {
+      let tsVal: unknown;
+      try {
+        tsVal = METRIC_REGISTRY[m]!.compute({ fixture, frozenNow: args.frozenNow });
+      } catch (e) {
+        tsVal = `__ts_threw__:${(e as Error).message}`;
+      }
+      // The oracle emits absent metrics as missing keys; the registry emits
+      // explicit null. Normalize both to null before the bit-identity check.
+      const expected = derived[m] ?? null;
+      const actual = tsVal === undefined ? null : tsVal;
+      if (deepCompare(expected, actual).length > 0) {
+        mismatch[m]!++;
+        if (!firstFailPath) {
+          firstFailPath = join(FAIL_DIR, `_fuzz-fail-${m}-seed${args.seed}-i${i}.json`);
+          writeFileSync(firstFailPath, `${JSON.stringify(fixture, null, 2)}\n`);
+        }
+      }
+    }
+  }
+
+  const total = Object.values(mismatch).reduce((s, x) => s + x, 0);
+  console.log(`[fuzz-parity] oracle: Python ${pyVersion} (Pyodide) · seed ${args.seed} · fixtures ${compared}/${args.n} (oracle errors: ${oracleErrors})`);
+  for (const m of metrics) {
+    if (mismatch[m]! > 0) console.log(`[fuzz-parity]   MISMATCH ${m}: ${mismatch[m]}`);
+  }
+  if (total === 0) {
+    console.log(`[fuzz-parity] OK — all ${metrics.length} metrics bit-identical across ${compared} fixtures`);
+    return 0;
+  }
+  console.log(`[fuzz-parity] FAIL — ${total} metric mismatch(es). First failing fixture written to:\n  ${firstFailPath}`);
+  console.log(`[fuzz-parity] Freeze it as a golden fixture (add to HARNESS_FIXTURES in tools/snapshot-section-11.ts, then \`pnpm snapshot:section-11\`) so the gate defends it.`);
+  return 1;
+}
+
+main().then(
+  (code) => process.exit(code),
+  (err) => {
+    console.error(err);
+    process.exit(2);
+  },
+);

--- a/tools/fuzz-parity.ts
+++ b/tools/fuzz-parity.ts
@@ -30,7 +30,7 @@
  *   Usage: pnpm fuzz-parity [--n=5000] [--seed=20260525] [--fixture=realistic-athlete]
  */
 
-import { readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 
 import { loadPyodide } from "pyodide";
@@ -41,7 +41,10 @@ import { decideVerdict } from "./fuzz-parity-verdict";
 const SECTION_11_REPO = process.env.SECTION_11_REPO ?? resolve(REPO_ROOT, "../section-11");
 const SYNC_PY_PATH = join(SECTION_11_REPO, "examples/sync.py");
 const GOLDEN_DIR = resolve(REPO_ROOT, "packages/core/tests/fixtures/golden");
-const FAIL_DIR = resolve(REPO_ROOT, "packages/core/tests/fixtures/golden");
+// Divergence + oracle-error captures are random, oversized dumps — NOT curated
+// fixtures. They land in a gitignored sibling dir so a stray `git add -A` can't
+// sweep them into the committed golden corpus the gate and snapshot harness trust.
+const FAIL_DIR = resolve(REPO_ROOT, "packages/core/tests/fixtures/_fuzz-fail");
 
 interface Args {
   n: number;
@@ -191,6 +194,13 @@ function perturb(base: { activities: Record<string, unknown>[]; wellness: Record
   return f;
 }
 
+// Lazily create FAIL_DIR so a clean run leaves no empty dir behind, then write
+// the capture. Both the divergence and oracle-error paths funnel through here.
+function writeCapture(filePath: string, fixture: unknown): void {
+  mkdirSync(FAIL_DIR, { recursive: true });
+  writeFileSync(filePath, `${JSON.stringify(fixture, null, 2)}\n`);
+}
+
 async function main(): Promise<number> {
   const args = parseArgs(process.argv.slice(2));
   const base = JSON.parse(readFileSync(join(GOLDEN_DIR, `${args.fixture}.json`), "utf8"));
@@ -205,11 +215,20 @@ async function main(): Promise<number> {
   const rnd = makeRng(args.seed);
   const metrics = Object.keys(METRIC_REGISTRY);
   const mismatch: Record<string, number> = Object.fromEntries(metrics.map((m) => [m, 0]));
+  // Per-metric coverage: `?? null` (below) masks an absent oracle key as null,
+  // so a metric the oracle never emits — or emits only null — would ride the
+  // green headline without ever being compared against a real value. Track both
+  // so the verdict can disclose anything we never actually exercised.
+  const oraclePresent: Record<string, number> = Object.fromEntries(metrics.map((m) => [m, 0]));
+  const oracleNonNull: Record<string, number> = Object.fromEntries(metrics.map((m) => [m, 0]));
   let oracleErrors = 0;
   let firstOracleError: string | null = null;
   let firstOracleErrorPath: string | null = null;
   let compared = 0;
-  let firstFailPath: string | null = null;
+  // One reproducing fixture per diverging metric. A single global capture would
+  // discard every metric that isn't the first to diverge — defeating the
+  // capture-and-defend purpose for all the rest.
+  const failPaths: Record<string, string> = {};
 
   for (let i = 0; i < args.n; i++) {
     const fixture = perturb(base, rnd);
@@ -220,27 +239,34 @@ async function main(): Promise<number> {
       if (!firstOracleError) {
         firstOracleError = String(derived.__error__);
         firstOracleErrorPath = join(FAIL_DIR, `_fuzz-oracle-error-seed${args.seed}-i${i}.json`);
-        writeFileSync(firstOracleErrorPath, `${JSON.stringify(fixture, null, 2)}\n`);
+        writeCapture(firstOracleErrorPath, fixture);
       }
       continue;
     }
     compared++;
     for (const m of metrics) {
+      // The oracle emits absent metrics as missing keys; the registry emits
+      // explicit null. Normalize both to null before the bit-identity check —
+      // but first record whether the oracle genuinely exercised this metric
+      // (emitted the key, with a non-null value) so the mask can't hide a
+      // never-compared metric.
+      if (m in derived) oraclePresent[m]!++;
+      const expected = derived[m] ?? null;
+      if (expected !== null) oracleNonNull[m]!++;
+
       let tsVal: unknown;
       try {
         tsVal = METRIC_REGISTRY[m]!.compute({ fixture, frozenNow: args.frozenNow });
       } catch (e) {
         tsVal = `__ts_threw__:${(e as Error).message}`;
       }
-      // The oracle emits absent metrics as missing keys; the registry emits
-      // explicit null. Normalize both to null before the bit-identity check.
-      const expected = derived[m] ?? null;
       const actual = tsVal === undefined ? null : tsVal;
       if (deepCompare(expected, actual).length > 0) {
         mismatch[m]!++;
-        if (!firstFailPath) {
-          firstFailPath = join(FAIL_DIR, `_fuzz-fail-${m}-seed${args.seed}-i${i}.json`);
-          writeFileSync(firstFailPath, `${JSON.stringify(fixture, null, 2)}\n`);
+        if (!(m in failPaths)) {
+          const failPath = join(FAIL_DIR, `_fuzz-fail-${m}-seed${args.seed}-i${i}.json`);
+          writeCapture(failPath, fixture);
+          failPaths[m] = failPath;
         }
       }
     }
@@ -251,6 +277,26 @@ async function main(): Promise<number> {
   for (const m of metrics) {
     if (mismatch[m]! > 0) console.log(`[fuzz-parity]   MISMATCH ${m}: ${mismatch[m]}`);
   }
+
+  // Coverage disclosure: a metric the oracle never emitted (likely a registry/
+  // oracle name mismatch) or emitted only null was never compared against a real
+  // value — `?? null` would otherwise let it pass silently. Surface both so a
+  // green run can't overstate what it proved.
+  const neverPresent = metrics.filter((m) => oraclePresent[m] === 0);
+  const presentButAlwaysNull = metrics.filter(
+    (m) => oraclePresent[m]! > 0 && oracleNonNull[m] === 0,
+  );
+  const neverExercised = neverPresent.length + presentButAlwaysNull.length;
+  if (compared > 0 && neverExercised > 0) {
+    console.log(`[fuzz-parity]   NOTE — ${neverExercised}/${metrics.length} metric(s) never exercised on a real value:`);
+    for (const m of neverPresent) {
+      console.log(`[fuzz-parity]     ${m}: oracle never emitted this key (registry/oracle name mismatch?)`);
+    }
+    for (const m of presentButAlwaysNull) {
+      console.log(`[fuzz-parity]     ${m}: oracle emitted only null across all ${compared} fixtures`);
+    }
+  }
+
   // OK is reported ONLY on a run that proved bit-identity: a non-zero fixture
   // count, every one compared clean, zero oracle throws. Any `__error__` means
   // the differential silently skipped that input (the signature-drift-on-a-SHA-
@@ -262,16 +308,21 @@ async function main(): Promise<number> {
       console.error(`[fuzz-parity]   first oracle error: ${firstOracleError}`);
       console.error(`[fuzz-parity]   erroring fixture written to:\n  ${firstOracleErrorPath}`);
       break;
-    case "mismatch":
-      console.error(`[fuzz-parity] FAIL — ${total} metric mismatch(es). First failing fixture written to:\n  ${firstFailPath}`);
-      console.error(`[fuzz-parity] Freeze it as a golden fixture (add to HARNESS_FIXTURES in tools/snapshot-section-11.ts, then \`pnpm snapshot:section-11\`) so the gate defends it.`);
+    case "mismatch": {
+      const captured = Object.values(failPaths);
+      console.error(`[fuzz-parity] FAIL — ${total} metric mismatch(es) across ${captured.length} metric(s). Reproducing fixture(s) written to:`);
+      for (const p of captured) console.error(`  ${p}`);
+      console.error(`[fuzz-parity] Freeze each as a golden fixture (add to HARNESS_FIXTURES in tools/snapshot-section-11.ts, then \`pnpm snapshot:section-11\`) so the gate defends it.`);
       break;
+    }
     case "empty":
       console.error(`[fuzz-parity] FAIL — 0 fixtures compared (n=${args.n}); refusing to report OK on a run that proved nothing.`);
       break;
-    case "ok":
-      console.log(`[fuzz-parity] OK — all ${metrics.length} metrics bit-identical across ${compared}/${args.n} fixtures`);
+    case "ok": {
+      const caveat = neverExercised > 0 ? ` (${neverExercised} never exercised — see NOTE above)` : "";
+      console.log(`[fuzz-parity] OK — all ${metrics.length} metrics bit-identical across ${compared}/${args.n} fixtures${caveat}`);
       break;
+    }
   }
   return verdict.code;
 }

--- a/tools/snapshot-section-11.ts
+++ b/tools/snapshot-section-11.ts
@@ -77,6 +77,18 @@ const HARNESS_FIXTURES: HarnessFixtureConfig[] = [
     description:
       "21 activities split by a 28-day gap (14 days 2026-04-01..04-14, gap 04-15..05-12, 7 days resumed 05-13..05-19). Exercises EWMA decay through the gap, ACWR chronic window seeing zeros, monotony on the resumed week. Anchor 2026-05-20 catches the resumed week in the 7d acute window.",
   },
+  {
+    slug: "boundary-monotony",
+    frozenNow: DEFAULT_FROZEN_NOW,
+    description:
+      "Boundary-seeking fixture (fuzz-derived). Daily loads [21.2,154.3,268.1,122.0,34.6,33.1,231.2] over 05-04..05-10 put monotony's mean/stdev ratio exactly on the 2-dp boundary: the correctly-rounded statistics path gives 1.24, a naive float stdev gives 1.23. Defends the exact-rational mean/stdev port at the gate. Load-only (no wellness/ftp).",
+  },
+  {
+    slug: "boundary-sum-strain",
+    frozenNow: DEFAULT_FROZEN_NOW,
+    description:
+      "Boundary-seeking fixture (fuzz-derived). Daily loads 9.7/266.4/239.5/9.4 over 05-06..05-09 sum to exactly 525.0 under compensated (Neumaier) summation but 524.999…9 naively; with monotony 0.62 the product 325.5 rounds to strain 326 where a naive sum gives 325. Defends the compensated-sum port at the gate. Load-only (no wellness/ftp).",
+  },
 ];
 
 function readPyodideVersion(): string {

--- a/tools/snapshot-section-11.ts
+++ b/tools/snapshot-section-11.ts
@@ -89,6 +89,12 @@ const HARNESS_FIXTURES: HarnessFixtureConfig[] = [
     description:
       "Boundary-seeking fixture (fuzz-derived). Daily loads 9.7/266.4/239.5/9.4 over 05-06..05-09 sum to exactly 525.0 under compensated (Neumaier) summation but 524.999…9 naively; with monotony 0.62 the product 325.5 rounds to strain 326 where a naive sum gives 325. Defends the compensated-sum port at the gate. Load-only (no wellness/ftp).",
   },
+  {
+    slug: "boundary-zone-total-secs",
+    frozenNow: DEFAULT_FROZEN_NOW,
+    description:
+      "Boundary-seeking fixture (fuzz-derived). Three activities (05-08..05-10) whose z1–z7 one-decimal-second bins sum, per-activity-compensated, to exactly 36594s, but accumulate to 36594.00000000001s under a single flat naive sum across every activity's bins; that 1-ULP drift pushes total_hours across the 10.165 boundary (compensated 10.16 vs naive 10.17). Defends the per-activity compensated zone-total summation in the zone-distribution port. Zone-only (empty wellness/ftp).",
+  },
 ];
 
 function readPyodideVersion(): string {


### PR DESCRIPTION
## Summary

Ports the Reference layer's training-intensity distribution metrics into TypeScript and hardens the load + distribution metrics to bit-identical parity with the oracle.

## Metrics (faithful transliterations, registered in the parity gate)

- **Zone distribution (7d)** — per-zone hours with the z4+ fold, power/HR basis selection with sport-family preference, and mixed-basis handling.
- **Grey-zone %, quality-intensity %, easy-time ratio** — plus their polarized-training notes.
- **Seiler 3-zone TID** — `seiler_tid` (7d), `seiler_tid_primary`, `seiler_tid_28d`, `seiler_tid_28d_primary`, each carrying the Treff polarization index and a polarized / pyramidal / threshold classification.

Line-by-line ports of `_get_activity_zones`, `_aggregate_zones`, `_aggregate_seiler_zones`, `_build_seiler_tid`, `_calculate_polarization_index`, and `_classify_tid`. Seiler 2010 for the 3-zone intensity model.

## Bit-identity hardening

Review of the distribution wave surfaced eight latent parity risks; all resolved on-branch:

- **Rounding** — `roundHalfEven` rewritten as an exact dyadic-rational round (matches CPython `round()` on every boundary) and hoisted into one shared `metrics/rounding.ts`. The prior scale-then-round diverged on ~1.3% of integer second-totals.
- **Summation order** — `total_time` and `selectPrimarySport` now reproduce the oracle's grouped, Neumaier-compensated order, so a fractional `secs` can't drift a rounding boundary.
- **Schema** — `icu_zone_times` constrained to object-form only (the read side can't process a bare-number bin); the HR-zone reader guards a non-numeric bin so a malformed array can't poison the zone sums.
- **Fuzz-parity harness** — new `tools/fuzz-parity.ts` runs randomized fixtures through both the oracle and the TS registry, failing on any divergence, vacuous run, oracle error, or contract violation (closes the false-green paths).
- **statistics.ts** — corrected the `floatSqrtOfFrac` invariant comment and documented the empty-input return contract.

No deviations registered — every metric is a faithful transliteration.

## Coverage follow-ups (prior architect reviews)

- **Primary-sport tiebreak** — a constructed Load tie pins the strict `total > maxTotal` insertion-order tiebreak (first family in fixture order wins).
- **`effective_monotony` fallback** — a multi-sport window whose highest-Load family has <3 active days pins the selector's primary-null → total-monotony branch.
- **Registry inverse-coverage** — a test asserts every `compute*` export is registered in `METRIC_REGISTRY`, so a ported-but-unregistered metric can't ship green.

## Test plan

- `pnpm --filter @enduragent/core test` → **883 passed, 2 skipped** (73 files).
- `pnpm check-parity --all` → **exit 0**, 120 bit-identical results across 6 fixtures, zero mismatches.
