### PR TITLE
refactor(core): extract shared date helpers — eliminate triplication

### DIFF
--- a/packages/core/src/reference/metrics/compliance-and-body.ts
+++ b/packages/core/src/reference/metrics/compliance-and-body.ts
@@ -7,6 +7,11 @@
 
 import type { Activity } from "../schemas/inputs.js";
 
+import {
+  isoDateDaysBefore,
+  isoToMs,
+  parseIsoMs,
+} from "./date-helpers.js";
 import { roundHalfEven } from "./rounding.js";
 import {
   getActivities,
@@ -19,6 +24,10 @@ import {
 } from "./metric-input.js";
 import { computeSeasonalContext, type SeasonalContext } from "./seasonal-context.js";
 
+// Upstream sync.py:3553 hardcodes this 4-element subset; e-bike rides are
+// deliberately excluded from consistency tracking even though they appear in
+// SPORT_FAMILIES as cycling. Don't derive from SPORT_FAMILIES — the
+// divergence is upstream-faithful.
 const CYCLING_TYPES = new Set([
   "Ride",
   "VirtualRide",
@@ -158,20 +167,6 @@ function sliceTrailing7d(activities: Activity[], frozenNow: string): Activity[] 
   });
 }
 
-function isoDateDaysBefore(isoNow: string, daysBefore: number): string {
-  const [y, m, d] = isoNow.slice(0, 10).split("-").map(Number) as [
-    number,
-    number,
-    number,
-  ];
-  const utc = new Date(Date.UTC(y, m - 1, d));
-  utc.setUTCDate(utc.getUTCDate() - daysBefore);
-  const yy = utc.getUTCFullYear();
-  const mm = String(utc.getUTCMonth() + 1).padStart(2, "0");
-  const dd = String(utc.getUTCDate()).padStart(2, "0");
-  return `${yy}-${mm}-${dd}`;
-}
-
 export interface BenchmarkEmission {
   current_ftp: number | null;
   ftp_8_weeks_ago: number | null;
@@ -238,7 +233,7 @@ export function calculateBenchmarkIndex(
   let bestDiff = Number.POSITIVE_INFINITY;
 
   for (const dateStr of Object.keys(ftpHistory)) {
-    const entryMs = parseIsoDateMidnightMs(dateStr);
+    const entryMs = parseIsoMs(dateStr);
     if (entryMs === null) continue;
     if (entryMs < earliestMs || entryMs > latestMs) continue;
     const diff = Math.abs(Math.floor((entryMs - targetMs) / MS_PER_DAY));
@@ -358,51 +353,3 @@ export function computeBenchmarkOutdoor(input: MetricInput): BenchmarkEmission {
   };
 }
 
-function isoToMs(iso: string): number {
-  // Parse 'YYYY-MM-DDTHH:MM:SS' (or 'YYYY-MM-DD') as a UTC instant. Both
-  // sides of the window comparison go through this helper, so the choice
-  // of zone is internal — what matters is that the wall-clock offset
-  // between a frozenNow datetime and a date-only history entry mirrors
-  // Python's naive-datetime subtraction.
-  const datePart = iso.slice(0, 10);
-  const timePart = iso.length >= 19 ? iso.slice(11, 19) : "00:00:00";
-  const [y, m, d] = datePart.split("-").map(Number) as [
-    number,
-    number,
-    number,
-  ];
-  const [hh, mm, ss] = timePart.split(":").map(Number) as [
-    number,
-    number,
-    number,
-  ];
-  return Date.UTC(y, m - 1, d, hh, mm, ss);
-}
-
-function parseIsoDateMidnightMs(dateStr: string): number | null {
-  // sync.py:2221 wraps the strptime in try/except; malformed entries are
-  // skipped silently. Mirror that here — anything that isn't strict
-  // YYYY-MM-DD with a calendar-real month/day is dropped. The round-trip
-  // check is load-bearing: `Date.UTC(2026, 1, 30)` silently normalises to
-  // 2026-03-02, but `datetime.strptime("2026-02-30", "%Y-%m-%d")` raises
-  // and the upstream `except` skips the entry. Without the check, a
-  // calendar-invalid history key would slip into the ±7d window with the
-  // wrong timestamp and break parity.
-  if (typeof dateStr !== "string") return null;
-  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dateStr);
-  if (!match) return null;
-  const y = Number(match[1]);
-  const mo = Number(match[2]);
-  const d = Number(match[3]);
-  if (mo < 1 || mo > 12 || d < 1 || d > 31) return null;
-  const ms = Date.UTC(y, mo - 1, d);
-  const back = new Date(ms);
-  if (
-    back.getUTCFullYear() !== y ||
-    back.getUTCMonth() + 1 !== mo ||
-    back.getUTCDate() !== d
-  ) {
-    return null;
-  }
-  return ms;
-}

--- a/packages/core/src/reference/metrics/date-helpers.test.ts
+++ b/packages/core/src/reference/metrics/date-helpers.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  formatYmd,
+  isoDateDaysBefore,
+  isoToMs,
+  parseIsoMs,
+} from "./date-helpers.js";
+
+describe("isoToMs", () => {
+  it("treats a date-only input as midnight UTC", () => {
+    expect(isoToMs("2026-05-10")).toBe(Date.UTC(2026, 4, 10));
+  });
+
+  it("uses the time component when present", () => {
+    expect(isoToMs("2026-05-10T12:00:00")).toBe(Date.UTC(2026, 4, 10, 12, 0, 0));
+    expect(isoToMs("2026-05-10T23:59:59")).toBe(
+      Date.UTC(2026, 4, 10, 23, 59, 59),
+    );
+  });
+});
+
+describe("parseIsoMs", () => {
+  it("parses a valid YYYY-MM-DD to midnight UTC ms", () => {
+    expect(parseIsoMs("2026-05-10")).toBe(Date.UTC(2026, 4, 10));
+    expect(parseIsoMs("1900-01-01")).toBe(Date.UTC(1900, 0, 1));
+  });
+
+  it("returns null for malformed strings", () => {
+    expect(parseIsoMs("not-a-date")).toBeNull();
+    expect(parseIsoMs("2026-5-10")).toBeNull(); // non-zero-padded
+    expect(parseIsoMs("2026/05/10")).toBeNull(); // wrong separator
+    expect(parseIsoMs("")).toBeNull();
+    expect(parseIsoMs("2026-05-10T00:00:00")).toBeNull(); // datetime, not date
+  });
+
+  it("returns null for out-of-range months and days", () => {
+    expect(parseIsoMs("2026-00-01")).toBeNull();
+    expect(parseIsoMs("2026-13-01")).toBeNull();
+    expect(parseIsoMs("2026-05-00")).toBeNull();
+    expect(parseIsoMs("2026-05-32")).toBeNull();
+  });
+
+  it("returns null for calendar-invalid days the JS Date constructor silently normalises", () => {
+    // Date.UTC(2026, 1, 30) rolls to 2026-03-02; the round-trip check
+    // catches that and returns null. Python's strptime would also reject
+    // these — this is the parity-critical case.
+    expect(parseIsoMs("2026-02-30")).toBeNull();
+    expect(parseIsoMs("2026-02-29")).toBeNull(); // 2026 is not a leap year
+    expect(parseIsoMs("2026-04-31")).toBeNull();
+    expect(parseIsoMs("2026-06-31")).toBeNull();
+    expect(parseIsoMs("2026-09-31")).toBeNull();
+    expect(parseIsoMs("2026-11-31")).toBeNull();
+  });
+
+  it("accepts Feb 29 in actual leap years", () => {
+    expect(parseIsoMs("2024-02-29")).toBe(Date.UTC(2024, 1, 29));
+    expect(parseIsoMs("2000-02-29")).toBe(Date.UTC(2000, 1, 29));
+    // Century non-leap (not divisible by 400)
+    expect(parseIsoMs("1900-02-29")).toBeNull();
+  });
+});
+
+describe("formatYmd", () => {
+  it("formats an arbitrary midnight-UTC timestamp", () => {
+    expect(formatYmd(Date.UTC(2026, 4, 10))).toBe("2026-05-10");
+  });
+
+  it("pads single-digit month and day to two digits", () => {
+    expect(formatYmd(Date.UTC(2026, 0, 5))).toBe("2026-01-05");
+    expect(formatYmd(Date.UTC(2026, 8, 9))).toBe("2026-09-09");
+  });
+});
+
+describe("isoDateDaysBefore", () => {
+  it("steps back the requested number of calendar days", () => {
+    expect(isoDateDaysBefore("2026-05-10T12:00:00", 0)).toBe("2026-05-10");
+    expect(isoDateDaysBefore("2026-05-10T12:00:00", 6)).toBe("2026-05-04");
+    expect(isoDateDaysBefore("2026-05-10T12:00:00", 27)).toBe("2026-04-13");
+  });
+
+  it("handles month rollover", () => {
+    expect(isoDateDaysBefore("2026-03-05T12:00:00", 10)).toBe("2026-02-23");
+  });
+
+  it("handles year rollover", () => {
+    expect(isoDateDaysBefore("2026-01-03T12:00:00", 5)).toBe("2025-12-29");
+  });
+
+  it("handles leap-year February boundary", () => {
+    expect(isoDateDaysBefore("2024-03-01T12:00:00", 1)).toBe("2024-02-29");
+    expect(isoDateDaysBefore("2025-03-01T12:00:00", 1)).toBe("2025-02-28");
+  });
+
+  it("ignores the time component of isoNow (only the date prefix matters)", () => {
+    expect(isoDateDaysBefore("2026-05-10T00:00:00", 6)).toBe(
+      isoDateDaysBefore("2026-05-10T23:59:59", 6),
+    );
+  });
+});

--- a/packages/core/src/reference/metrics/date-helpers.ts
+++ b/packages/core/src/reference/metrics/date-helpers.ts
@@ -1,0 +1,101 @@
+/**
+ * Reference layer — pure date arithmetic primitives shared across metric
+ * modules. Operates on ISO date strings (`YYYY-MM-DD` or
+ * `YYYY-MM-DDThh:mm:ss`); conversion to/from millisecond timestamps is
+ * hidden inside.
+ *
+ * Extracted from three near-identical local copies after the F11 batch
+ * surfaced the duplication and a divergence in the formatter
+ * implementation (two sites used `toISOString().slice(0, 10)`, one
+ * used manual `padStart`). The manual formatter is canonical here: it
+ * keeps a YYYY-prefixed shape for all years in `[0, 9999]` and never
+ * emits the leading `+` that `toISOString` does for year ≥ 10000.
+ */
+
+/**
+ * Parse an ISO date or datetime string to its UTC ms timestamp. Handles
+ * both `YYYY-MM-DD` (treated as midnight UTC) and
+ * `YYYY-MM-DDThh:mm:ss` (the time component is used as-is). Used at the
+ * benchmark-index date-diff seam where the harness emits a fixture-pinned
+ * frozenNow with a time component but FTP history keys are date-only.
+ */
+export function isoToMs(iso: string): number {
+  const datePart = iso.slice(0, 10);
+  const timePart = iso.length >= 19 ? iso.slice(11, 19) : "00:00:00";
+  const [y, m, d] = datePart.split("-").map(Number) as [
+    number,
+    number,
+    number,
+  ];
+  const [hh, mm, ss] = timePart.split(":").map(Number) as [
+    number,
+    number,
+    number,
+  ];
+  return Date.UTC(y, m - 1, d, hh, mm, ss);
+}
+
+/**
+ * Parse a strict `YYYY-MM-DD` string to its midnight-UTC ms timestamp,
+ * returning `null` on any deviation from the strict shape, including
+ * calendar-invalid dates (Feb 30, Apr 31, etc.) that `Date.UTC` would
+ * silently normalise into the following month.
+ *
+ * Mirrors the upstream Python's `strptime("%Y-%m-%d")` plus `try/except`
+ * pattern: malformed entries are dropped, not crashed on. The round-trip
+ * check is load-bearing for parity — without it, a fixture key like
+ * `"2026-02-30"` would slip into a benchmark window with a March
+ * timestamp and bind the wrong FTP value.
+ */
+export function parseIsoMs(dateStr: string): number | null {
+  if (typeof dateStr !== "string") return null;
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dateStr);
+  if (!match) return null;
+  const y = Number(match[1]);
+  const mo = Number(match[2]);
+  const d = Number(match[3]);
+  if (mo < 1 || mo > 12 || d < 1 || d > 31) return null;
+  const ms = Date.UTC(y, mo - 1, d);
+  const back = new Date(ms);
+  if (
+    back.getUTCFullYear() !== y ||
+    back.getUTCMonth() + 1 !== mo ||
+    back.getUTCDate() !== d
+  ) {
+    return null;
+  }
+  return ms;
+}
+
+/**
+ * Format a UTC ms timestamp as `YYYY-MM-DD`. Year is padded to 4 digits
+ * for the conventional ISO shape; years outside `[0, 9999]` retain their
+ * natural width (no `+`/`-` prefix). Month and day are always 2 digits.
+ */
+export function formatYmd(ms: number): string {
+  const utc = new Date(ms);
+  const y = String(utc.getUTCFullYear()).padStart(4, "0");
+  const m = String(utc.getUTCMonth() + 1).padStart(2, "0");
+  const d = String(utc.getUTCDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+/**
+ * Return the `YYYY-MM-DD` that is `daysBefore` calendar days earlier than
+ * `isoNow`'s date prefix. Uses `setUTCDate(-N)` so month and year
+ * rollovers are calendar-correct (including leap years).
+ */
+export function isoDateDaysBefore(
+  isoNow: string,
+  daysBefore: number,
+): string {
+  const datePart = isoNow.slice(0, 10);
+  const [y, m, d] = datePart.split("-").map(Number) as [
+    number,
+    number,
+    number,
+  ];
+  const utc = new Date(Date.UTC(y, m - 1, d));
+  utc.setUTCDate(utc.getUTCDate() - daysBefore);
+  return formatYmd(utc.getTime());
+}

--- a/packages/core/src/reference/metrics/distribution.ts
+++ b/packages/core/src/reference/metrics/distribution.ts
@@ -10,6 +10,7 @@
 
 import type { Activity } from "../schemas/inputs.js";
 
+import { isoDateDaysBefore } from "./date-helpers.js";
 import { getActivities, type MetricInput } from "./metric-input.js";
 import { roundHalfEven } from "./rounding.js";
 import { SPORT_FAMILIES } from "./sport-families.js";
@@ -638,10 +639,3 @@ function getActivitiesInWindow(
   });
 }
 
-function isoDateDaysBefore(isoNow: string, daysBefore: number): string {
-  const datePart = isoNow.slice(0, 10);
-  const [y, m, d] = datePart.split("-").map(Number) as [number, number, number];
-  const utc = new Date(Date.UTC(y, m - 1, d));
-  utc.setUTCDate(utc.getUTCDate() - daysBefore);
-  return utc.toISOString().slice(0, 10);
-}

--- a/packages/core/src/reference/metrics/load-management.ts
+++ b/packages/core/src/reference/metrics/load-management.ts
@@ -7,6 +7,7 @@
 
 import type { Activity, WellnessDay } from "../schemas/inputs.js";
 
+import { isoDateDaysBefore } from "./date-helpers.js";
 import { getActivities, type MetricInput } from "./metric-input.js";
 import { roundHalfEven } from "./rounding.js";
 import { SPORT_FAMILIES } from "./sport-families.js";
@@ -569,10 +570,3 @@ function getDailyLoadBySport(
   return result;
 }
 
-function isoDateDaysBefore(isoNow: string, daysBefore: number): string {
-  const datePart = isoNow.slice(0, 10);
-  const [y, m, d] = datePart.split("-").map(Number) as [number, number, number];
-  const utc = new Date(Date.UTC(y, m - 1, d));
-  utc.setUTCDate(utc.getUTCDate() - daysBefore);
-  return utc.toISOString().slice(0, 10);
-}


### PR DESCRIPTION
## Summary

Lifts four pure date primitives into a new `packages/core/src/reference/metrics/date-helpers.ts`, eliminating the three near-identical copies of `isoDateDaysBefore` that had accumulated across `compliance-and-body.ts` (F11), `load-management.ts` (F8), and `distribution.ts` (F9) — including a realized formatter divergence (two sites used `toISOString().slice(0, 10)`, one used manual `padStart`).

Architect review of the F11 batch flagged this as P0 cleanup to land before F10 starts; otherwise F10's metrics would inherit a 4th copy.

## What lands

- New `date-helpers.ts` with `parseIsoMs`, `isoToMs`, `formatYmd`, `isoDateDaysBefore`.
- Manual-`padStart` formatter is canonical (no `+` prefix on year ≥10000; predictable shape across the year range).
- `parseIsoMs` carries the calendar-validity round-trip check that the post-/simplify pass added on F11 — rejects `2026-02-30` etc. instead of silently rolling them into March.
- Three call sites updated to import from the shared module; three local copies deleted (~77 lines removed, ~213 added counting the new module + tests).
- One-line documentation comment added to `CYCLING_TYPES` in compliance-and-body explaining why it doesn't derive from `SPORT_FAMILIES` (upstream deliberately excludes `EBikeRide`).

## Test plan

- [x] `pnpm test date-helpers compliance-and-body load-management distribution` — 102/102 pass
- [x] `pnpm check-parity --all` — 176/176 OK, no metric output regressions
- [x] `pnpm -r build` — clean typecheck across the workspace
- [x] New `date-helpers.test.ts` covers regression edges fixture coverage doesn't reach: calendar-invalid days (Feb 30, Apr 31, ...), Feb 29 leap-year vs century-non-leap, month/year rollover for `isoDateDaysBefore`