### PR TITLE
refactor(core): type fixture envelope at parity-gate boundary (ADR-0017)

### DIFF
--- a/packages/core/src/reference/index.ts
+++ b/packages/core/src/reference/index.ts
@@ -75,6 +75,8 @@ export {
   type FtpHistoryPoint,
   PlannedEventSchema,
   type PlannedEvent,
+  FixtureSchema,
+  type FixtureShape,
   IcuIntervalRepSchema,
   type IcuIntervalRep,
   ZoneTimesSchema,

--- a/packages/core/src/reference/metrics/compliance-and-body.ts
+++ b/packages/core/src/reference/metrics/compliance-and-body.ts
@@ -7,6 +7,11 @@
 
 import type { Activity } from "../schemas/inputs.js";
 
+import {
+  isoDateDaysBefore,
+  isoToMs,
+  parseIsoMs,
+} from "./date-helpers.js";
 import { roundHalfEven } from "./rounding.js";
 import {
   getActivities,
@@ -19,6 +24,10 @@ import {
 } from "./metric-input.js";
 import { computeSeasonalContext, type SeasonalContext } from "./seasonal-context.js";
 
+// Upstream sync.py:3553 hardcodes this 4-element subset; e-bike rides are
+// deliberately excluded from consistency tracking even though they appear in
+// SPORT_FAMILIES as cycling. Don't derive from SPORT_FAMILIES — the
+// divergence is upstream-faithful.
 const CYCLING_TYPES = new Set([
   "Ride",
   "VirtualRide",
@@ -158,20 +167,6 @@ function sliceTrailing7d(activities: Activity[], frozenNow: string): Activity[] 
   });
 }
 
-function isoDateDaysBefore(isoNow: string, daysBefore: number): string {
-  const [y, m, d] = isoNow.slice(0, 10).split("-").map(Number) as [
-    number,
-    number,
-    number,
-  ];
-  const utc = new Date(Date.UTC(y, m - 1, d));
-  utc.setUTCDate(utc.getUTCDate() - daysBefore);
-  const yy = utc.getUTCFullYear();
-  const mm = String(utc.getUTCMonth() + 1).padStart(2, "0");
-  const dd = String(utc.getUTCDate()).padStart(2, "0");
-  return `${yy}-${mm}-${dd}`;
-}
-
 export interface BenchmarkEmission {
   current_ftp: number | null;
   ftp_8_weeks_ago: number | null;
@@ -238,7 +233,7 @@ export function calculateBenchmarkIndex(
   let bestDiff = Number.POSITIVE_INFINITY;
 
   for (const dateStr of Object.keys(ftpHistory)) {
-    const entryMs = parseIsoDateMidnightMs(dateStr);
+    const entryMs = parseIsoMs(dateStr);
     if (entryMs === null) continue;
     if (entryMs < earliestMs || entryMs > latestMs) continue;
     const diff = Math.abs(Math.floor((entryMs - targetMs) / MS_PER_DAY));
@@ -358,51 +353,3 @@ export function computeBenchmarkOutdoor(input: MetricInput): BenchmarkEmission {
   };
 }
 
-function isoToMs(iso: string): number {
-  // Parse 'YYYY-MM-DDTHH:MM:SS' (or 'YYYY-MM-DD') as a UTC instant. Both
-  // sides of the window comparison go through this helper, so the choice
-  // of zone is internal — what matters is that the wall-clock offset
-  // between a frozenNow datetime and a date-only history entry mirrors
-  // Python's naive-datetime subtraction.
-  const datePart = iso.slice(0, 10);
-  const timePart = iso.length >= 19 ? iso.slice(11, 19) : "00:00:00";
-  const [y, m, d] = datePart.split("-").map(Number) as [
-    number,
-    number,
-    number,
-  ];
-  const [hh, mm, ss] = timePart.split(":").map(Number) as [
-    number,
-    number,
-    number,
-  ];
-  return Date.UTC(y, m - 1, d, hh, mm, ss);
-}
-
-function parseIsoDateMidnightMs(dateStr: string): number | null {
-  // sync.py:2221 wraps the strptime in try/except; malformed entries are
-  // skipped silently. Mirror that here — anything that isn't strict
-  // YYYY-MM-DD with a calendar-real month/day is dropped. The round-trip
-  // check is load-bearing: `Date.UTC(2026, 1, 30)` silently normalises to
-  // 2026-03-02, but `datetime.strptime("2026-02-30", "%Y-%m-%d")` raises
-  // and the upstream `except` skips the entry. Without the check, a
-  // calendar-invalid history key would slip into the ±7d window with the
-  // wrong timestamp and break parity.
-  if (typeof dateStr !== "string") return null;
-  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dateStr);
-  if (!match) return null;
-  const y = Number(match[1]);
-  const mo = Number(match[2]);
-  const d = Number(match[3]);
-  if (mo < 1 || mo > 12 || d < 1 || d > 31) return null;
-  const ms = Date.UTC(y, mo - 1, d);
-  const back = new Date(ms);
-  if (
-    back.getUTCFullYear() !== y ||
-    back.getUTCMonth() + 1 !== mo ||
-    back.getUTCDate() !== d
-  ) {
-    return null;
-  }
-  return ms;
-}

--- a/packages/core/src/reference/metrics/date-helpers.test.ts
+++ b/packages/core/src/reference/metrics/date-helpers.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  formatYmd,
+  isoDateDaysBefore,
+  isoToMs,
+  parseIsoMs,
+} from "./date-helpers.js";
+
+describe("isoToMs", () => {
+  it("treats a date-only input as midnight UTC", () => {
+    expect(isoToMs("2026-05-10")).toBe(Date.UTC(2026, 4, 10));
+  });
+
+  it("uses the time component when present", () => {
+    expect(isoToMs("2026-05-10T12:00:00")).toBe(Date.UTC(2026, 4, 10, 12, 0, 0));
+    expect(isoToMs("2026-05-10T23:59:59")).toBe(
+      Date.UTC(2026, 4, 10, 23, 59, 59),
+    );
+  });
+});
+
+describe("parseIsoMs", () => {
+  it("parses a valid YYYY-MM-DD to midnight UTC ms", () => {
+    expect(parseIsoMs("2026-05-10")).toBe(Date.UTC(2026, 4, 10));
+    expect(parseIsoMs("1900-01-01")).toBe(Date.UTC(1900, 0, 1));
+  });
+
+  it("returns null for malformed strings", () => {
+    expect(parseIsoMs("not-a-date")).toBeNull();
+    expect(parseIsoMs("2026-5-10")).toBeNull(); // non-zero-padded
+    expect(parseIsoMs("2026/05/10")).toBeNull(); // wrong separator
+    expect(parseIsoMs("")).toBeNull();
+    expect(parseIsoMs("2026-05-10T00:00:00")).toBeNull(); // datetime, not date
+  });
+
+  it("returns null for out-of-range months and days", () => {
+    expect(parseIsoMs("2026-00-01")).toBeNull();
+    expect(parseIsoMs("2026-13-01")).toBeNull();
+    expect(parseIsoMs("2026-05-00")).toBeNull();
+    expect(parseIsoMs("2026-05-32")).toBeNull();
+  });
+
+  it("returns null for calendar-invalid days the JS Date constructor silently normalises", () => {
+    // Date.UTC(2026, 1, 30) rolls to 2026-03-02; the round-trip check
+    // catches that and returns null. Python's strptime would also reject
+    // these — this is the parity-critical case.
+    expect(parseIsoMs("2026-02-30")).toBeNull();
+    expect(parseIsoMs("2026-02-29")).toBeNull(); // 2026 is not a leap year
+    expect(parseIsoMs("2026-04-31")).toBeNull();
+    expect(parseIsoMs("2026-06-31")).toBeNull();
+    expect(parseIsoMs("2026-09-31")).toBeNull();
+    expect(parseIsoMs("2026-11-31")).toBeNull();
+  });
+
+  it("accepts Feb 29 in actual leap years", () => {
+    expect(parseIsoMs("2024-02-29")).toBe(Date.UTC(2024, 1, 29));
+    expect(parseIsoMs("2000-02-29")).toBe(Date.UTC(2000, 1, 29));
+    // Century non-leap (not divisible by 400)
+    expect(parseIsoMs("1900-02-29")).toBeNull();
+  });
+});
+
+describe("formatYmd", () => {
+  it("formats an arbitrary midnight-UTC timestamp", () => {
+    expect(formatYmd(Date.UTC(2026, 4, 10))).toBe("2026-05-10");
+  });
+
+  it("pads single-digit month and day to two digits", () => {
+    expect(formatYmd(Date.UTC(2026, 0, 5))).toBe("2026-01-05");
+    expect(formatYmd(Date.UTC(2026, 8, 9))).toBe("2026-09-09");
+  });
+});
+
+describe("isoDateDaysBefore", () => {
+  it("steps back the requested number of calendar days", () => {
+    expect(isoDateDaysBefore("2026-05-10T12:00:00", 0)).toBe("2026-05-10");
+    expect(isoDateDaysBefore("2026-05-10T12:00:00", 6)).toBe("2026-05-04");
+    expect(isoDateDaysBefore("2026-05-10T12:00:00", 27)).toBe("2026-04-13");
+  });
+
+  it("handles month rollover", () => {
+    expect(isoDateDaysBefore("2026-03-05T12:00:00", 10)).toBe("2026-02-23");
+  });
+
+  it("handles year rollover", () => {
+    expect(isoDateDaysBefore("2026-01-03T12:00:00", 5)).toBe("2025-12-29");
+  });
+
+  it("handles leap-year February boundary", () => {
+    expect(isoDateDaysBefore("2024-03-01T12:00:00", 1)).toBe("2024-02-29");
+    expect(isoDateDaysBefore("2025-03-01T12:00:00", 1)).toBe("2025-02-28");
+  });
+
+  it("ignores the time component of isoNow (only the date prefix matters)", () => {
+    expect(isoDateDaysBefore("2026-05-10T00:00:00", 6)).toBe(
+      isoDateDaysBefore("2026-05-10T23:59:59", 6),
+    );
+  });
+});

--- a/packages/core/src/reference/metrics/date-helpers.ts
+++ b/packages/core/src/reference/metrics/date-helpers.ts
@@ -1,0 +1,101 @@
+/**
+ * Reference layer — pure date arithmetic primitives shared across metric
+ * modules. Operates on ISO date strings (`YYYY-MM-DD` or
+ * `YYYY-MM-DDThh:mm:ss`); conversion to/from millisecond timestamps is
+ * hidden inside.
+ *
+ * Extracted from three near-identical local copies after the F11 batch
+ * surfaced the duplication and a divergence in the formatter
+ * implementation (two sites used `toISOString().slice(0, 10)`, one
+ * used manual `padStart`). The manual formatter is canonical here: it
+ * keeps a YYYY-prefixed shape for all years in `[0, 9999]` and never
+ * emits the leading `+` that `toISOString` does for year ≥ 10000.
+ */
+
+/**
+ * Parse an ISO date or datetime string to its UTC ms timestamp. Handles
+ * both `YYYY-MM-DD` (treated as midnight UTC) and
+ * `YYYY-MM-DDThh:mm:ss` (the time component is used as-is). Used at the
+ * benchmark-index date-diff seam where the harness emits a fixture-pinned
+ * frozenNow with a time component but FTP history keys are date-only.
+ */
+export function isoToMs(iso: string): number {
+  const datePart = iso.slice(0, 10);
+  const timePart = iso.length >= 19 ? iso.slice(11, 19) : "00:00:00";
+  const [y, m, d] = datePart.split("-").map(Number) as [
+    number,
+    number,
+    number,
+  ];
+  const [hh, mm, ss] = timePart.split(":").map(Number) as [
+    number,
+    number,
+    number,
+  ];
+  return Date.UTC(y, m - 1, d, hh, mm, ss);
+}
+
+/**
+ * Parse a strict `YYYY-MM-DD` string to its midnight-UTC ms timestamp,
+ * returning `null` on any deviation from the strict shape, including
+ * calendar-invalid dates (Feb 30, Apr 31, etc.) that `Date.UTC` would
+ * silently normalise into the following month.
+ *
+ * Mirrors the upstream Python's `strptime("%Y-%m-%d")` plus `try/except`
+ * pattern: malformed entries are dropped, not crashed on. The round-trip
+ * check is load-bearing for parity — without it, a fixture key like
+ * `"2026-02-30"` would slip into a benchmark window with a March
+ * timestamp and bind the wrong FTP value.
+ */
+export function parseIsoMs(dateStr: string): number | null {
+  if (typeof dateStr !== "string") return null;
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dateStr);
+  if (!match) return null;
+  const y = Number(match[1]);
+  const mo = Number(match[2]);
+  const d = Number(match[3]);
+  if (mo < 1 || mo > 12 || d < 1 || d > 31) return null;
+  const ms = Date.UTC(y, mo - 1, d);
+  const back = new Date(ms);
+  if (
+    back.getUTCFullYear() !== y ||
+    back.getUTCMonth() + 1 !== mo ||
+    back.getUTCDate() !== d
+  ) {
+    return null;
+  }
+  return ms;
+}
+
+/**
+ * Format a UTC ms timestamp as `YYYY-MM-DD`. Year is padded to 4 digits
+ * for the conventional ISO shape; years outside `[0, 9999]` retain their
+ * natural width (no `+`/`-` prefix). Month and day are always 2 digits.
+ */
+export function formatYmd(ms: number): string {
+  const utc = new Date(ms);
+  const y = String(utc.getUTCFullYear()).padStart(4, "0");
+  const m = String(utc.getUTCMonth() + 1).padStart(2, "0");
+  const d = String(utc.getUTCDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+/**
+ * Return the `YYYY-MM-DD` that is `daysBefore` calendar days earlier than
+ * `isoNow`'s date prefix. Uses `setUTCDate(-N)` so month and year
+ * rollovers are calendar-correct (including leap years).
+ */
+export function isoDateDaysBefore(
+  isoNow: string,
+  daysBefore: number,
+): string {
+  const datePart = isoNow.slice(0, 10);
+  const [y, m, d] = datePart.split("-").map(Number) as [
+    number,
+    number,
+    number,
+  ];
+  const utc = new Date(Date.UTC(y, m - 1, d));
+  utc.setUTCDate(utc.getUTCDate() - daysBefore);
+  return formatYmd(utc.getTime());
+}

--- a/packages/core/src/reference/metrics/distribution.ts
+++ b/packages/core/src/reference/metrics/distribution.ts
@@ -10,6 +10,7 @@
 
 import type { Activity } from "../schemas/inputs.js";
 
+import { isoDateDaysBefore } from "./date-helpers.js";
 import { getActivities, type MetricInput } from "./metric-input.js";
 import { roundHalfEven } from "./rounding.js";
 import { SPORT_FAMILIES } from "./sport-families.js";
@@ -638,10 +639,3 @@ function getActivitiesInWindow(
   });
 }
 
-function isoDateDaysBefore(isoNow: string, daysBefore: number): string {
-  const datePart = isoNow.slice(0, 10);
-  const [y, m, d] = datePart.split("-").map(Number) as [number, number, number];
-  const utc = new Date(Date.UTC(y, m - 1, d));
-  utc.setUTCDate(utc.getUTCDate() - daysBefore);
-  return utc.toISOString().slice(0, 10);
-}

--- a/packages/core/src/reference/metrics/load-management.ts
+++ b/packages/core/src/reference/metrics/load-management.ts
@@ -7,6 +7,7 @@
 
 import type { Activity, WellnessDay } from "../schemas/inputs.js";
 
+import { isoDateDaysBefore } from "./date-helpers.js";
 import { getActivities, type MetricInput } from "./metric-input.js";
 import { roundHalfEven } from "./rounding.js";
 import { SPORT_FAMILIES } from "./sport-families.js";
@@ -569,10 +570,3 @@ function getDailyLoadBySport(
   return result;
 }
 
-function isoDateDaysBefore(isoNow: string, daysBefore: number): string {
-  const datePart = isoNow.slice(0, 10);
-  const [y, m, d] = datePart.split("-").map(Number) as [number, number, number];
-  const utc = new Date(Date.UTC(y, m - 1, d));
-  utc.setUTCDate(utc.getUTCDate() - daysBefore);
-  return utc.toISOString().slice(0, 10);
-}

--- a/packages/core/src/reference/metrics/load-management.ts
+++ b/packages/core/src/reference/metrics/load-management.ts
@@ -468,8 +468,7 @@ function isValidHrv(value: number | null | undefined): value is number {
 // latest. Fixtures are trusted at the gate boundary (Zod ran upstream
 // of snapshot capture), matching the `getActivities` cast.
 function getWellnessWindow(input: MetricInput, days: number): WellnessDay[] {
-  const fixture = input.fixture as { wellness?: WellnessDay[] };
-  const wellness = fixture.wellness ?? [];
+  const wellness = input.fixture.wellness;
   const oldest = isoDateDaysBefore(input.frozenNow, days - 1);
   const today = input.frozenNow.slice(0, 10);
   return wellness.filter((w) => {

--- a/packages/core/src/reference/metrics/metric-input.ts
+++ b/packages/core/src/reference/metrics/metric-input.ts
@@ -1,57 +1,52 @@
-import type { Activity, PlannedEvent } from "../schemas/inputs.js";
+import type {
+  Activity,
+  FixtureShape,
+  PlannedEvent,
+} from "../schemas/inputs.js";
 
 /**
  * The contract between a metric port and the parity gate.
  *
- * The gate (`tools/check-metric-parity.ts`) loads each metric's snapshot,
- * resolves the registry entry to a function in this directory, and calls
- * it with this input shape. `frozenNow` matches the snapshot's
- * `frozen_now` field so the metric can derive date-relative windows that
- * line up with the captured oracle.
+ * `fixture` is typed via `FixtureSchema` (parsed at the gate boundary
+ * in `tools/check-metric-parity.ts`), so metrics receive a validated
+ * shape instead of `unknown`. Accessors here are typed dot-access
+ * thin wrappers — kept as named exports so call sites remain readable
+ * (`getActivities(input)` over `input.fixture.activities`) and to give
+ * a stable surface to mock in unit tests.
+ *
+ * `frozenNow` matches the snapshot's `frozen_now` field so the metric
+ * can derive date-relative windows that line up with the captured
+ * oracle.
  */
 export interface MetricInput {
-  fixture: unknown;
+  fixture: FixtureShape;
   frozenNow: string;
 }
 
-// Fixtures are trusted at the gate boundary; this helper does not
-// re-validate (Zod ran upstream of the snapshot capture). When a wellness
-// metric joins the port (e.g. recovery_index), add a sibling
-// `getWellness(input)` the same way rather than widening this one.
 export function getActivities(input: MetricInput): Activity[] {
-  const fixture = input.fixture as { activities?: Activity[] };
-  return fixture.activities ?? [];
+  return input.fixture.activities;
 }
 
 export function getPastEvents(input: MetricInput): PlannedEvent[] {
-  const fixture = input.fixture as { past_events?: PlannedEvent[] };
-  return fixture.past_events ?? [];
+  return input.fixture.past_events ?? [];
 }
 
 export function getCurrentFtpIndoor(input: MetricInput): number | null {
-  const fixture = input.fixture as { current_ftp_indoor?: number | null };
-  return fixture.current_ftp_indoor ?? null;
+  return input.fixture.current_ftp_indoor ?? null;
 }
 
 export function getFtpHistoryIndoor(
   input: MetricInput,
 ): Record<string, number> {
-  const fixture = input.fixture as {
-    ftp_history_indoor?: Record<string, number>;
-  };
-  return fixture.ftp_history_indoor ?? {};
+  return input.fixture.ftp_history_indoor ?? {};
 }
 
 export function getCurrentFtpOutdoor(input: MetricInput): number | null {
-  const fixture = input.fixture as { current_ftp_outdoor?: number | null };
-  return fixture.current_ftp_outdoor ?? null;
+  return input.fixture.current_ftp_outdoor ?? null;
 }
 
 export function getFtpHistoryOutdoor(
   input: MetricInput,
 ): Record<string, number> {
-  const fixture = input.fixture as {
-    ftp_history_outdoor?: Record<string, number>;
-  };
-  return fixture.ftp_history_outdoor ?? {};
+  return input.fixture.ftp_history_outdoor ?? {};
 }

--- a/packages/core/src/reference/schemas/inputs.ts
+++ b/packages/core/src/reference/schemas/inputs.ts
@@ -183,3 +183,46 @@ export const PlannedEventSchema = z.looseObject({
   name: z.string().optional(),
 });
 export type PlannedEvent = z.infer<typeof PlannedEventSchema>;
+
+/**
+ * Top-level envelope for a golden fixture. The shape every parity-gate
+ * metric receives. Strict at the envelope level (rogue top-level keys
+ * fail the parse — typos can't masquerade as silently-present optional
+ * fields); per-row schemas remain `z.looseObject()` so real upstream
+ * shape rides through (see the file header on the trademark-hygiene
+ * justification for that decision).
+ *
+ * Adding a new field is an explicit schema change: a new fixture key
+ * that isn't here fails parse at the gate boundary, forcing the
+ * accessor + schema to land in lockstep. That friction is the point —
+ * it's what stops a sixth-or-seventh ad-hoc `as { ... }` cast from
+ * accreting in metric files when an author judges the schema-update
+ * tax to be higher than an inline cast (the pattern that proliferated
+ * before this seam landed).
+ *
+ * Used by:
+ *   - `tools/check-metric-parity.ts` — parses every fixture at the
+ *     gate boundary; metric implementations see a typed shape, never
+ *     `unknown`.
+ *   - `packages/core/tests/helpers/load-fixture.ts` — the test loader
+ *     re-uses this schema as its validation surface (no duplicate
+ *     definition).
+ */
+export const FixtureSchema = z
+  .object({
+    activities: z.array(ActivitySchema),
+    wellness: z.array(WellnessDaySchema),
+    ftp_history: z.array(FtpHistoryPointSchema),
+
+    // Optional fixture extensions for the compliance + benchmark batch.
+    // None of the current committed fixtures populate these; the schema
+    // declares them so future populated-branch fixtures can land
+    // without a rogue-key parse failure.
+    past_events: z.array(PlannedEventSchema).optional(),
+    current_ftp_indoor: z.number().nullable().optional(),
+    current_ftp_outdoor: z.number().nullable().optional(),
+    ftp_history_indoor: z.record(z.string(), z.number()).optional(),
+    ftp_history_outdoor: z.record(z.string(), z.number()).optional(),
+  })
+  .strict();
+export type FixtureShape = z.infer<typeof FixtureSchema>;

--- a/packages/core/tests/helpers/load-fixture.ts
+++ b/packages/core/tests/helpers/load-fixture.ts
@@ -6,26 +6,19 @@
 import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { z, type ZodTypeAny } from "zod";
+import { type ZodTypeAny, type z } from "zod";
 
 import {
-  ActivitySchema,
-  FtpHistoryPointSchema,
-  WellnessDaySchema,
+  FixtureSchema,
+  type FixtureShape,
 } from "../../src/reference/schemas/inputs.js";
 
-/** Aggregate envelope for committed golden fixtures. Top-level `.strict()`
- *  ensures the envelope has exactly the 3 named arrays — no rogue keys
- *  masquerading as fixture data. Per-row schemas are `z.looseObject()` so
- *  real intervals.icu shape rides through without losing TP-trademark fields. */
-export const GoldenFixtureSchema = z
-  .object({
-    activities: z.array(ActivitySchema),
-    wellness: z.array(WellnessDaySchema),
-    ftp_history: z.array(FtpHistoryPointSchema),
-  })
-  .strict();
-export type GoldenFixture = z.infer<typeof GoldenFixtureSchema>;
+/** Re-export the canonical fixture schema for in-package test callers.
+ *  Single source of truth for the envelope shape lives in
+ *  `reference/schemas/inputs.ts` (ADR-0017); both this helper and the
+ *  parity gate at `tools/check-metric-parity.ts` consume it from there. */
+export const GoldenFixtureSchema = FixtureSchema;
+export type GoldenFixture = FixtureShape;
 
 const DEFAULT_FIXTURES_ROOT = resolve(
   dirname(fileURLToPath(import.meta.url)),

--- a/tools/check-metric-parity.ts
+++ b/tools/check-metric-parity.ts
@@ -27,6 +27,10 @@ import {
   METRIC_REGISTRY,
   type MetricRegistryEntry,
 } from "../packages/core/src/reference/metrics/registry.js";
+import {
+  FixtureSchema,
+  type FixtureShape,
+} from "../packages/core/src/reference/schemas/inputs.js";
 
 export type { MetricInput, MetricRegistryEntry };
 export { METRIC_REGISTRY };
@@ -248,13 +252,22 @@ export function loadSnapshot(athlete: string, metric: string): Snapshot {
   return JSON.parse(readFileSync(path, "utf8")) as Snapshot;
 }
 
-// Returns the parsed JSON as `unknown`. The gate intentionally does not
-// Zod-validate fixtures here — that's a metric-function entry concern.
-// (`packages/core/tests/helpers/load-fixture.ts` is the validating loader
-// for in-package tests.)
-export function loadGoldenFixture(athlete: string): unknown {
+// Validates the fixture against `FixtureSchema` at the gate boundary
+// (ADR-0017). Failures throw with the fixture path and the Zod issue
+// tree so a malformed fixture surfaces here, not deep inside a metric.
+// Top-level keys are strict — a rogue field (typo, undeclared addition)
+// fails the parse; per-row schemas stay loose so real upstream shape
+// rides through.
+export function loadGoldenFixture(athlete: string): FixtureShape {
   const path = join(FIXTURES_ROOT, `${athlete}.json`);
-  return JSON.parse(readFileSync(path, "utf8"));
+  const raw = JSON.parse(readFileSync(path, "utf8"));
+  const result = FixtureSchema.safeParse(raw);
+  if (!result.success) {
+    throw new Error(
+      `fixture ${athlete}.json failed schema parse:\n${result.error.message}`,
+    );
+  }
+  return result.data;
 }
 
 // ─── Discovery ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Defines a single canonical `FixtureSchema` in `reference/schemas/inputs.ts` and routes every fixture load through it. The parity gate parses fixtures with `FixtureSchema.safeParse` at the boundary; the in-package test loader re-exports the same schema; `MetricInput.fixture` is typed `FixtureShape` instead of `unknown`. Every `as { ... }` cast in metric code disappears, including the inline wellness cast in `load-management.ts` that signaled the prior convention was already breaking.

This is **stacked on #121** (date-helpers extraction). Merge #121 first, then this. Architect review of the F11 batch flagged this as P0 cleanup to land before F10.

## What changes

- **New: `FixtureSchema` + `FixtureShape`** in `packages/core/src/reference/schemas/inputs.ts`. Strict envelope (rogue top-level keys fail parse), loose rows (per-row schemas stay `z.looseObject()` so real upstream shape rides through). Three required arrays (`activities`, `wellness`, `ftp_history`), five optional fields the F11 batch introduced (`past_events`, `current_ftp_indoor`/`outdoor`, `ftp_history_indoor`/`outdoor`).
- **Parity gate validates at the boundary.** `tools/check-metric-parity.ts:loadGoldenFixture` now returns `FixtureShape`, throws with the fixture path + Zod issue tree on parse failure. Removed the prior \"intentionally does not Zod-validate\" comment.
- **`MetricInput.fixture: FixtureShape`** (not `unknown`). All accessors in `metric-input.ts` collapse to typed dot-access — no more `(input.fixture as { key?: T }).key ?? default` casts.
- **Inline cast removed.** `load-management.ts:469`'s `input.fixture as { wellness?: WellnessDay[] }` becomes `input.fixture.wellness`. This was the canary — the convention had already broken in main.
- **Single source of truth.** `packages/core/tests/helpers/load-fixture.ts`'s `GoldenFixtureSchema` now re-exports `FixtureSchema` from the canonical location.

## Why strict + loose hybrid

The envelope is project-owned (we know what top-level keys mean — typos here are bugs). The rows are upstream-owned (intervals.icu can add fields to individual activities; per-row schemas stay loose to tolerate that). A typo at the envelope level fails the parse; an upstream addition at the row level passes through.

Adding a new fixture field becomes a two-step explicit change: (a) add to `FixtureSchema`, (b) add the metric that reads it — both in the same PR. The friction is intentional — it's what stops the inline-cast pattern from re-accreting on F10.

## Test plan

- [x] `pnpm test reference-load-fixture compliance-and-body load-management distribution date-helpers metric-input` — 130/130 pass
- [x] `pnpm check-parity --all` — 176/176 OK, zero behavioural change
- [x] `pnpm -r build` — clean typecheck
- [x] Full suite minus the known flaky secrets test (`detect.test.ts` flakes only under full-suite load; unrelated to this diff)
- [x] The 6 metric-input accessors + the wellness window now access `input.fixture.<key>` directly; if any caller had a typo, the build would fail at the accessor body (it doesn't)

## Architectural decision

Captured as ADR-0017 locally (gitignored per the repo's `docs/` convention). The decision: validation lives at the gate boundary, not in metric code; one schema; strict envelope + loose rows; required core + optional extensions.