### PR TITLE
test(core): harness pass-through + populated-branch fixture for F11 metrics

### DIFF
--- a/packages/core/src/reference/index.ts
+++ b/packages/core/src/reference/index.ts
@@ -75,6 +75,8 @@ export {
   type FtpHistoryPoint,
   PlannedEventSchema,
   type PlannedEvent,
+  FixtureSchema,
+  type FixtureShape,
   IcuIntervalRepSchema,
   type IcuIntervalRep,
   ZoneTimesSchema,

--- a/packages/core/src/reference/metrics/compliance-and-body.ts
+++ b/packages/core/src/reference/metrics/compliance-and-body.ts
@@ -7,6 +7,11 @@
 
 import type { Activity } from "../schemas/inputs.js";
 
+import {
+  isoDateDaysBefore,
+  isoToMs,
+  parseIsoMs,
+} from "./date-helpers.js";
 import { roundHalfEven } from "./rounding.js";
 import {
   getActivities,
@@ -19,6 +24,10 @@ import {
 } from "./metric-input.js";
 import { computeSeasonalContext, type SeasonalContext } from "./seasonal-context.js";
 
+// Upstream sync.py:3553 hardcodes this 4-element subset; e-bike rides are
+// deliberately excluded from consistency tracking even though they appear in
+// SPORT_FAMILIES as cycling. Don't derive from SPORT_FAMILIES — the
+// divergence is upstream-faithful.
 const CYCLING_TYPES = new Set([
   "Ride",
   "VirtualRide",
@@ -158,20 +167,6 @@ function sliceTrailing7d(activities: Activity[], frozenNow: string): Activity[] 
   });
 }
 
-function isoDateDaysBefore(isoNow: string, daysBefore: number): string {
-  const [y, m, d] = isoNow.slice(0, 10).split("-").map(Number) as [
-    number,
-    number,
-    number,
-  ];
-  const utc = new Date(Date.UTC(y, m - 1, d));
-  utc.setUTCDate(utc.getUTCDate() - daysBefore);
-  const yy = utc.getUTCFullYear();
-  const mm = String(utc.getUTCMonth() + 1).padStart(2, "0");
-  const dd = String(utc.getUTCDate()).padStart(2, "0");
-  return `${yy}-${mm}-${dd}`;
-}
-
 export interface BenchmarkEmission {
   current_ftp: number | null;
   ftp_8_weeks_ago: number | null;
@@ -238,7 +233,7 @@ export function calculateBenchmarkIndex(
   let bestDiff = Number.POSITIVE_INFINITY;
 
   for (const dateStr of Object.keys(ftpHistory)) {
-    const entryMs = parseIsoDateMidnightMs(dateStr);
+    const entryMs = parseIsoMs(dateStr);
     if (entryMs === null) continue;
     if (entryMs < earliestMs || entryMs > latestMs) continue;
     const diff = Math.abs(Math.floor((entryMs - targetMs) / MS_PER_DAY));
@@ -358,51 +353,3 @@ export function computeBenchmarkOutdoor(input: MetricInput): BenchmarkEmission {
   };
 }
 
-function isoToMs(iso: string): number {
-  // Parse 'YYYY-MM-DDTHH:MM:SS' (or 'YYYY-MM-DD') as a UTC instant. Both
-  // sides of the window comparison go through this helper, so the choice
-  // of zone is internal — what matters is that the wall-clock offset
-  // between a frozenNow datetime and a date-only history entry mirrors
-  // Python's naive-datetime subtraction.
-  const datePart = iso.slice(0, 10);
-  const timePart = iso.length >= 19 ? iso.slice(11, 19) : "00:00:00";
-  const [y, m, d] = datePart.split("-").map(Number) as [
-    number,
-    number,
-    number,
-  ];
-  const [hh, mm, ss] = timePart.split(":").map(Number) as [
-    number,
-    number,
-    number,
-  ];
-  return Date.UTC(y, m - 1, d, hh, mm, ss);
-}
-
-function parseIsoDateMidnightMs(dateStr: string): number | null {
-  // sync.py:2221 wraps the strptime in try/except; malformed entries are
-  // skipped silently. Mirror that here — anything that isn't strict
-  // YYYY-MM-DD with a calendar-real month/day is dropped. The round-trip
-  // check is load-bearing: `Date.UTC(2026, 1, 30)` silently normalises to
-  // 2026-03-02, but `datetime.strptime("2026-02-30", "%Y-%m-%d")` raises
-  // and the upstream `except` skips the entry. Without the check, a
-  // calendar-invalid history key would slip into the ±7d window with the
-  // wrong timestamp and break parity.
-  if (typeof dateStr !== "string") return null;
-  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dateStr);
-  if (!match) return null;
-  const y = Number(match[1]);
-  const mo = Number(match[2]);
-  const d = Number(match[3]);
-  if (mo < 1 || mo > 12 || d < 1 || d > 31) return null;
-  const ms = Date.UTC(y, mo - 1, d);
-  const back = new Date(ms);
-  if (
-    back.getUTCFullYear() !== y ||
-    back.getUTCMonth() + 1 !== mo ||
-    back.getUTCDate() !== d
-  ) {
-    return null;
-  }
-  return ms;
-}

--- a/packages/core/src/reference/metrics/date-helpers.test.ts
+++ b/packages/core/src/reference/metrics/date-helpers.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  formatYmd,
+  isoDateDaysBefore,
+  isoToMs,
+  parseIsoMs,
+} from "./date-helpers.js";
+
+describe("isoToMs", () => {
+  it("treats a date-only input as midnight UTC", () => {
+    expect(isoToMs("2026-05-10")).toBe(Date.UTC(2026, 4, 10));
+  });
+
+  it("uses the time component when present", () => {
+    expect(isoToMs("2026-05-10T12:00:00")).toBe(Date.UTC(2026, 4, 10, 12, 0, 0));
+    expect(isoToMs("2026-05-10T23:59:59")).toBe(
+      Date.UTC(2026, 4, 10, 23, 59, 59),
+    );
+  });
+});
+
+describe("parseIsoMs", () => {
+  it("parses a valid YYYY-MM-DD to midnight UTC ms", () => {
+    expect(parseIsoMs("2026-05-10")).toBe(Date.UTC(2026, 4, 10));
+    expect(parseIsoMs("1900-01-01")).toBe(Date.UTC(1900, 0, 1));
+  });
+
+  it("returns null for malformed strings", () => {
+    expect(parseIsoMs("not-a-date")).toBeNull();
+    expect(parseIsoMs("2026-5-10")).toBeNull(); // non-zero-padded
+    expect(parseIsoMs("2026/05/10")).toBeNull(); // wrong separator
+    expect(parseIsoMs("")).toBeNull();
+    expect(parseIsoMs("2026-05-10T00:00:00")).toBeNull(); // datetime, not date
+  });
+
+  it("returns null for out-of-range months and days", () => {
+    expect(parseIsoMs("2026-00-01")).toBeNull();
+    expect(parseIsoMs("2026-13-01")).toBeNull();
+    expect(parseIsoMs("2026-05-00")).toBeNull();
+    expect(parseIsoMs("2026-05-32")).toBeNull();
+  });
+
+  it("returns null for calendar-invalid days the JS Date constructor silently normalises", () => {
+    // Date.UTC(2026, 1, 30) rolls to 2026-03-02; the round-trip check
+    // catches that and returns null. Python's strptime would also reject
+    // these — this is the parity-critical case.
+    expect(parseIsoMs("2026-02-30")).toBeNull();
+    expect(parseIsoMs("2026-02-29")).toBeNull(); // 2026 is not a leap year
+    expect(parseIsoMs("2026-04-31")).toBeNull();
+    expect(parseIsoMs("2026-06-31")).toBeNull();
+    expect(parseIsoMs("2026-09-31")).toBeNull();
+    expect(parseIsoMs("2026-11-31")).toBeNull();
+  });
+
+  it("accepts Feb 29 in actual leap years", () => {
+    expect(parseIsoMs("2024-02-29")).toBe(Date.UTC(2024, 1, 29));
+    expect(parseIsoMs("2000-02-29")).toBe(Date.UTC(2000, 1, 29));
+    // Century non-leap (not divisible by 400)
+    expect(parseIsoMs("1900-02-29")).toBeNull();
+  });
+});
+
+describe("formatYmd", () => {
+  it("formats an arbitrary midnight-UTC timestamp", () => {
+    expect(formatYmd(Date.UTC(2026, 4, 10))).toBe("2026-05-10");
+  });
+
+  it("pads single-digit month and day to two digits", () => {
+    expect(formatYmd(Date.UTC(2026, 0, 5))).toBe("2026-01-05");
+    expect(formatYmd(Date.UTC(2026, 8, 9))).toBe("2026-09-09");
+  });
+});
+
+describe("isoDateDaysBefore", () => {
+  it("steps back the requested number of calendar days", () => {
+    expect(isoDateDaysBefore("2026-05-10T12:00:00", 0)).toBe("2026-05-10");
+    expect(isoDateDaysBefore("2026-05-10T12:00:00", 6)).toBe("2026-05-04");
+    expect(isoDateDaysBefore("2026-05-10T12:00:00", 27)).toBe("2026-04-13");
+  });
+
+  it("handles month rollover", () => {
+    expect(isoDateDaysBefore("2026-03-05T12:00:00", 10)).toBe("2026-02-23");
+  });
+
+  it("handles year rollover", () => {
+    expect(isoDateDaysBefore("2026-01-03T12:00:00", 5)).toBe("2025-12-29");
+  });
+
+  it("handles leap-year February boundary", () => {
+    expect(isoDateDaysBefore("2024-03-01T12:00:00", 1)).toBe("2024-02-29");
+    expect(isoDateDaysBefore("2025-03-01T12:00:00", 1)).toBe("2025-02-28");
+  });
+
+  it("ignores the time component of isoNow (only the date prefix matters)", () => {
+    expect(isoDateDaysBefore("2026-05-10T00:00:00", 6)).toBe(
+      isoDateDaysBefore("2026-05-10T23:59:59", 6),
+    );
+  });
+});

--- a/packages/core/src/reference/metrics/date-helpers.ts
+++ b/packages/core/src/reference/metrics/date-helpers.ts
@@ -1,0 +1,101 @@
+/**
+ * Reference layer — pure date arithmetic primitives shared across metric
+ * modules. Operates on ISO date strings (`YYYY-MM-DD` or
+ * `YYYY-MM-DDThh:mm:ss`); conversion to/from millisecond timestamps is
+ * hidden inside.
+ *
+ * Extracted from three near-identical local copies after the F11 batch
+ * surfaced the duplication and a divergence in the formatter
+ * implementation (two sites used `toISOString().slice(0, 10)`, one
+ * used manual `padStart`). The manual formatter is canonical here: it
+ * keeps a YYYY-prefixed shape for all years in `[0, 9999]` and never
+ * emits the leading `+` that `toISOString` does for year ≥ 10000.
+ */
+
+/**
+ * Parse an ISO date or datetime string to its UTC ms timestamp. Handles
+ * both `YYYY-MM-DD` (treated as midnight UTC) and
+ * `YYYY-MM-DDThh:mm:ss` (the time component is used as-is). Used at the
+ * benchmark-index date-diff seam where the harness emits a fixture-pinned
+ * frozenNow with a time component but FTP history keys are date-only.
+ */
+export function isoToMs(iso: string): number {
+  const datePart = iso.slice(0, 10);
+  const timePart = iso.length >= 19 ? iso.slice(11, 19) : "00:00:00";
+  const [y, m, d] = datePart.split("-").map(Number) as [
+    number,
+    number,
+    number,
+  ];
+  const [hh, mm, ss] = timePart.split(":").map(Number) as [
+    number,
+    number,
+    number,
+  ];
+  return Date.UTC(y, m - 1, d, hh, mm, ss);
+}
+
+/**
+ * Parse a strict `YYYY-MM-DD` string to its midnight-UTC ms timestamp,
+ * returning `null` on any deviation from the strict shape, including
+ * calendar-invalid dates (Feb 30, Apr 31, etc.) that `Date.UTC` would
+ * silently normalise into the following month.
+ *
+ * Mirrors the upstream Python's `strptime("%Y-%m-%d")` plus `try/except`
+ * pattern: malformed entries are dropped, not crashed on. The round-trip
+ * check is load-bearing for parity — without it, a fixture key like
+ * `"2026-02-30"` would slip into a benchmark window with a March
+ * timestamp and bind the wrong FTP value.
+ */
+export function parseIsoMs(dateStr: string): number | null {
+  if (typeof dateStr !== "string") return null;
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dateStr);
+  if (!match) return null;
+  const y = Number(match[1]);
+  const mo = Number(match[2]);
+  const d = Number(match[3]);
+  if (mo < 1 || mo > 12 || d < 1 || d > 31) return null;
+  const ms = Date.UTC(y, mo - 1, d);
+  const back = new Date(ms);
+  if (
+    back.getUTCFullYear() !== y ||
+    back.getUTCMonth() + 1 !== mo ||
+    back.getUTCDate() !== d
+  ) {
+    return null;
+  }
+  return ms;
+}
+
+/**
+ * Format a UTC ms timestamp as `YYYY-MM-DD`. Year is padded to 4 digits
+ * for the conventional ISO shape; years outside `[0, 9999]` retain their
+ * natural width (no `+`/`-` prefix). Month and day are always 2 digits.
+ */
+export function formatYmd(ms: number): string {
+  const utc = new Date(ms);
+  const y = String(utc.getUTCFullYear()).padStart(4, "0");
+  const m = String(utc.getUTCMonth() + 1).padStart(2, "0");
+  const d = String(utc.getUTCDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+/**
+ * Return the `YYYY-MM-DD` that is `daysBefore` calendar days earlier than
+ * `isoNow`'s date prefix. Uses `setUTCDate(-N)` so month and year
+ * rollovers are calendar-correct (including leap years).
+ */
+export function isoDateDaysBefore(
+  isoNow: string,
+  daysBefore: number,
+): string {
+  const datePart = isoNow.slice(0, 10);
+  const [y, m, d] = datePart.split("-").map(Number) as [
+    number,
+    number,
+    number,
+  ];
+  const utc = new Date(Date.UTC(y, m - 1, d));
+  utc.setUTCDate(utc.getUTCDate() - daysBefore);
+  return formatYmd(utc.getTime());
+}

--- a/packages/core/src/reference/metrics/distribution.ts
+++ b/packages/core/src/reference/metrics/distribution.ts
@@ -10,6 +10,7 @@
 
 import type { Activity } from "../schemas/inputs.js";
 
+import { isoDateDaysBefore } from "./date-helpers.js";
 import { getActivities, type MetricInput } from "./metric-input.js";
 import { roundHalfEven } from "./rounding.js";
 import { SPORT_FAMILIES } from "./sport-families.js";
@@ -638,10 +639,3 @@ function getActivitiesInWindow(
   });
 }
 
-function isoDateDaysBefore(isoNow: string, daysBefore: number): string {
-  const datePart = isoNow.slice(0, 10);
-  const [y, m, d] = datePart.split("-").map(Number) as [number, number, number];
-  const utc = new Date(Date.UTC(y, m - 1, d));
-  utc.setUTCDate(utc.getUTCDate() - daysBefore);
-  return utc.toISOString().slice(0, 10);
-}

--- a/packages/core/src/reference/metrics/load-management.ts
+++ b/packages/core/src/reference/metrics/load-management.ts
@@ -7,6 +7,7 @@
 
 import type { Activity, WellnessDay } from "../schemas/inputs.js";
 
+import { isoDateDaysBefore } from "./date-helpers.js";
 import { getActivities, type MetricInput } from "./metric-input.js";
 import { roundHalfEven } from "./rounding.js";
 import { SPORT_FAMILIES } from "./sport-families.js";
@@ -569,10 +570,3 @@ function getDailyLoadBySport(
   return result;
 }
 
-function isoDateDaysBefore(isoNow: string, daysBefore: number): string {
-  const datePart = isoNow.slice(0, 10);
-  const [y, m, d] = datePart.split("-").map(Number) as [number, number, number];
-  const utc = new Date(Date.UTC(y, m - 1, d));
-  utc.setUTCDate(utc.getUTCDate() - daysBefore);
-  return utc.toISOString().slice(0, 10);
-}

--- a/packages/core/src/reference/metrics/load-management.ts
+++ b/packages/core/src/reference/metrics/load-management.ts
@@ -468,8 +468,7 @@ function isValidHrv(value: number | null | undefined): value is number {
 // latest. Fixtures are trusted at the gate boundary (Zod ran upstream
 // of snapshot capture), matching the `getActivities` cast.
 function getWellnessWindow(input: MetricInput, days: number): WellnessDay[] {
-  const fixture = input.fixture as { wellness?: WellnessDay[] };
-  const wellness = fixture.wellness ?? [];
+  const wellness = input.fixture.wellness;
   const oldest = isoDateDaysBefore(input.frozenNow, days - 1);
   const today = input.frozenNow.slice(0, 10);
   return wellness.filter((w) => {

--- a/packages/core/src/reference/metrics/metric-input.ts
+++ b/packages/core/src/reference/metrics/metric-input.ts
@@ -1,57 +1,52 @@
-import type { Activity, PlannedEvent } from "../schemas/inputs.js";
+import type {
+  Activity,
+  FixtureShape,
+  PlannedEvent,
+} from "../schemas/inputs.js";
 
 /**
  * The contract between a metric port and the parity gate.
  *
- * The gate (`tools/check-metric-parity.ts`) loads each metric's snapshot,
- * resolves the registry entry to a function in this directory, and calls
- * it with this input shape. `frozenNow` matches the snapshot's
- * `frozen_now` field so the metric can derive date-relative windows that
- * line up with the captured oracle.
+ * `fixture` is typed via `FixtureSchema` (parsed at the gate boundary
+ * in `tools/check-metric-parity.ts`), so metrics receive a validated
+ * shape instead of `unknown`. Accessors here are typed dot-access
+ * thin wrappers — kept as named exports so call sites remain readable
+ * (`getActivities(input)` over `input.fixture.activities`) and to give
+ * a stable surface to mock in unit tests.
+ *
+ * `frozenNow` matches the snapshot's `frozen_now` field so the metric
+ * can derive date-relative windows that line up with the captured
+ * oracle.
  */
 export interface MetricInput {
-  fixture: unknown;
+  fixture: FixtureShape;
   frozenNow: string;
 }
 
-// Fixtures are trusted at the gate boundary; this helper does not
-// re-validate (Zod ran upstream of the snapshot capture). When a wellness
-// metric joins the port (e.g. recovery_index), add a sibling
-// `getWellness(input)` the same way rather than widening this one.
 export function getActivities(input: MetricInput): Activity[] {
-  const fixture = input.fixture as { activities?: Activity[] };
-  return fixture.activities ?? [];
+  return input.fixture.activities;
 }
 
 export function getPastEvents(input: MetricInput): PlannedEvent[] {
-  const fixture = input.fixture as { past_events?: PlannedEvent[] };
-  return fixture.past_events ?? [];
+  return input.fixture.past_events ?? [];
 }
 
 export function getCurrentFtpIndoor(input: MetricInput): number | null {
-  const fixture = input.fixture as { current_ftp_indoor?: number | null };
-  return fixture.current_ftp_indoor ?? null;
+  return input.fixture.current_ftp_indoor ?? null;
 }
 
 export function getFtpHistoryIndoor(
   input: MetricInput,
 ): Record<string, number> {
-  const fixture = input.fixture as {
-    ftp_history_indoor?: Record<string, number>;
-  };
-  return fixture.ftp_history_indoor ?? {};
+  return input.fixture.ftp_history_indoor ?? {};
 }
 
 export function getCurrentFtpOutdoor(input: MetricInput): number | null {
-  const fixture = input.fixture as { current_ftp_outdoor?: number | null };
-  return fixture.current_ftp_outdoor ?? null;
+  return input.fixture.current_ftp_outdoor ?? null;
 }
 
 export function getFtpHistoryOutdoor(
   input: MetricInput,
 ): Record<string, number> {
-  const fixture = input.fixture as {
-    ftp_history_outdoor?: Record<string, number>;
-  };
-  return fixture.ftp_history_outdoor ?? {};
+  return input.fixture.ftp_history_outdoor ?? {};
 }

--- a/packages/core/src/reference/schemas/inputs.ts
+++ b/packages/core/src/reference/schemas/inputs.ts
@@ -183,3 +183,46 @@ export const PlannedEventSchema = z.looseObject({
   name: z.string().optional(),
 });
 export type PlannedEvent = z.infer<typeof PlannedEventSchema>;
+
+/**
+ * Top-level envelope for a golden fixture. The shape every parity-gate
+ * metric receives. Strict at the envelope level (rogue top-level keys
+ * fail the parse — typos can't masquerade as silently-present optional
+ * fields); per-row schemas remain `z.looseObject()` so real upstream
+ * shape rides through (see the file header on the trademark-hygiene
+ * justification for that decision).
+ *
+ * Adding a new field is an explicit schema change: a new fixture key
+ * that isn't here fails parse at the gate boundary, forcing the
+ * accessor + schema to land in lockstep. That friction is the point —
+ * it's what stops a sixth-or-seventh ad-hoc `as { ... }` cast from
+ * accreting in metric files when an author judges the schema-update
+ * tax to be higher than an inline cast (the pattern that proliferated
+ * before this seam landed).
+ *
+ * Used by:
+ *   - `tools/check-metric-parity.ts` — parses every fixture at the
+ *     gate boundary; metric implementations see a typed shape, never
+ *     `unknown`.
+ *   - `packages/core/tests/helpers/load-fixture.ts` — the test loader
+ *     re-uses this schema as its validation surface (no duplicate
+ *     definition).
+ */
+export const FixtureSchema = z
+  .object({
+    activities: z.array(ActivitySchema),
+    wellness: z.array(WellnessDaySchema),
+    ftp_history: z.array(FtpHistoryPointSchema),
+
+    // Optional fixture extensions for the compliance + benchmark batch.
+    // None of the current committed fixtures populate these; the schema
+    // declares them so future populated-branch fixtures can land
+    // without a rogue-key parse failure.
+    past_events: z.array(PlannedEventSchema).optional(),
+    current_ftp_indoor: z.number().nullable().optional(),
+    current_ftp_outdoor: z.number().nullable().optional(),
+    ftp_history_indoor: z.record(z.string(), z.number()).optional(),
+    ftp_history_outdoor: z.record(z.string(), z.number()).optional(),
+  })
+  .strict();
+export type FixtureShape = z.infer<typeof FixtureSchema>;

--- a/packages/core/tests/fixtures/golden/populated-benchmark-and-consistency.json
+++ b/packages/core/tests/fixtures/golden/populated-benchmark-and-consistency.json
@@ -1,0 +1,165 @@
+{
+  "activities": [
+    {
+      "id": "pbc1",
+      "start_date_local": "2026-05-05T07:00:00",
+      "type": "Ride",
+      "name": "sanitized",
+      "moving_time": 3600,
+      "elapsed_time": 3700,
+      "icu_training_load": 60,
+      "icu_intensity": 70.0,
+      "average_heartrate": 142,
+      "icu_zone_times": [
+        { "id": "Z1", "secs": 600 },
+        { "id": "Z2", "secs": 1500 },
+        { "id": "Z3", "secs": 900 },
+        { "id": "Z4", "secs": 400 },
+        { "id": "Z5", "secs": 150 },
+        { "id": "Z6", "secs": 40 },
+        { "id": "Z7", "secs": 10 }
+      ],
+      "decoupling": -3.1,
+      "icu_efficiency_factor": 1.08
+    },
+    {
+      "id": "pbc2",
+      "start_date_local": "2026-05-07T18:00:00",
+      "type": "VirtualRide",
+      "name": "sanitized",
+      "moving_time": 2700,
+      "elapsed_time": 2800,
+      "icu_training_load": 45,
+      "icu_intensity": 65.0,
+      "average_heartrate": 138,
+      "icu_zone_times": [
+        { "id": "Z1", "secs": 500 },
+        { "id": "Z2", "secs": 1200 },
+        { "id": "Z3", "secs": 700 },
+        { "id": "Z4", "secs": 200 },
+        { "id": "Z5", "secs": 80 },
+        { "id": "Z6", "secs": 20 },
+        { "id": "Z7", "secs": 0 }
+      ],
+      "decoupling": -2.4,
+      "icu_efficiency_factor": 1.05
+    },
+    {
+      "id": "pbc3",
+      "start_date_local": "2026-05-09T16:00:00",
+      "type": "GravelRide",
+      "name": "sanitized",
+      "moving_time": 5400,
+      "elapsed_time": 5500,
+      "icu_training_load": 80,
+      "icu_intensity": 75.0,
+      "average_heartrate": 145,
+      "icu_zone_times": [
+        { "id": "Z1", "secs": 900 },
+        { "id": "Z2", "secs": 2200 },
+        { "id": "Z3", "secs": 1200 },
+        { "id": "Z4", "secs": 700 },
+        { "id": "Z5", "secs": 300 },
+        { "id": "Z6", "secs": 80 },
+        { "id": "Z7", "secs": 20 }
+      ],
+      "decoupling": -3.8,
+      "icu_efficiency_factor": 1.10
+    }
+  ],
+  "wellness": [
+    {
+      "id": "2026-05-10",
+      "weight": 72.0,
+      "restingHR": 54,
+      "hrv": 68,
+      "sleepSecs": 25200,
+      "sleepQuality": 80
+    },
+    {
+      "id": "2026-05-09",
+      "weight": 72.1,
+      "restingHR": 55,
+      "hrv": 66,
+      "sleepSecs": 24300,
+      "sleepQuality": 75
+    },
+    {
+      "id": "2026-05-08",
+      "weight": 72.2,
+      "restingHR": 56,
+      "hrv": 64,
+      "sleepSecs": 23400,
+      "sleepQuality": 70
+    },
+    {
+      "id": "2026-05-07",
+      "weight": 72.0,
+      "restingHR": 55,
+      "hrv": 67,
+      "sleepSecs": 25200,
+      "sleepQuality": 80
+    },
+    {
+      "id": "2026-05-06",
+      "weight": 71.9,
+      "restingHR": 54,
+      "hrv": 69,
+      "sleepSecs": 26100,
+      "sleepQuality": 85
+    },
+    {
+      "id": "2026-05-05",
+      "weight": 72.0,
+      "restingHR": 55,
+      "hrv": 66,
+      "sleepSecs": 25200,
+      "sleepQuality": 80
+    },
+    {
+      "id": "2026-05-04",
+      "weight": 72.1,
+      "restingHR": 56,
+      "hrv": 65,
+      "sleepSecs": 24300,
+      "sleepQuality": 75
+    }
+  ],
+  "ftp_history": [],
+  "past_events": [
+    {
+      "id": 1001,
+      "category": "WORKOUT",
+      "start_date_local": "2026-05-05T06:00:00"
+    },
+    {
+      "id": 1002,
+      "category": "WORKOUT",
+      "start_date_local": "2026-05-07T06:00:00"
+    },
+    {
+      "id": 1003,
+      "category": "WORKOUT",
+      "start_date_local": "2026-05-09T06:00:00"
+    },
+    {
+      "id": 1004,
+      "category": "WORKOUT",
+      "start_date_local": "2026-05-10T06:00:00"
+    }
+  ],
+  "current_ftp_indoor": 280,
+  "ftp_history_indoor": {
+    "2026-01-01": 260,
+    "2026-02-01": 265,
+    "2026-03-15": 270,
+    "2026-04-15": 275
+  },
+  "current_ftp_outdoor": 270,
+  "ftp_history_outdoor": {
+    "2026-01-01": 250,
+    "2026-02-01": 255,
+    "2026-03-15": 260,
+    "2026-04-15": 265
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/manifest.json
+++ b/packages/core/tests/fixtures/snapshots/manifest.json
@@ -10,6 +10,7 @@
     "multisport-thin-primary",
     "multisport-tie",
     "new-athlete-empty",
+    "populated-benchmark-and-consistency",
     "realistic-athlete"
   ],
   "metrics": [

--- a/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/acwr.json
+++ b/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/acwr.json
@@ -1,0 +1,8 @@
+{
+  "metric": "acwr",
+  "athlete": "populated-benchmark-and-consistency",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 4
+}

--- a/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/acwr_interpretation.json
+++ b/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/acwr_interpretation.json
@@ -1,0 +1,8 @@
+{
+  "metric": "acwr_interpretation",
+  "athlete": "populated-benchmark-and-consistency",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": "danger"
+}

--- a/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/benchmark_indoor.json
+++ b/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/benchmark_indoor.json
@@ -1,0 +1,14 @@
+{
+  "metric": "benchmark_indoor",
+  "athlete": "populated-benchmark-and-consistency",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "benchmark_index": 0.037,
+    "benchmark_percentage": "+3.7%",
+    "current_ftp": 280,
+    "ftp_8_weeks_ago": 270,
+    "seasonal_expected": true
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/benchmark_outdoor.json
+++ b/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/benchmark_outdoor.json
@@ -1,0 +1,14 @@
+{
+  "metric": "benchmark_outdoor",
+  "athlete": "populated-benchmark-and-consistency",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "benchmark_index": 0.038,
+    "benchmark_percentage": "+3.8%",
+    "current_ftp": 270,
+    "ftp_8_weeks_ago": 260,
+    "seasonal_expected": true
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/calculation_timestamp.json
+++ b/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/calculation_timestamp.json
@@ -1,0 +1,8 @@
+{
+  "metric": "calculation_timestamp",
+  "athlete": "populated-benchmark-and-consistency",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": "2026-05-10T12:00:00"
+}

--- a/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/capability.json
+++ b/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/capability.json
@@ -1,0 +1,62 @@
+{
+  "metric": "capability",
+  "athlete": "populated-benchmark-and-consistency",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "dfa_a1_profile": null,
+    "durability": {
+      "high_drift_count_28d": 0,
+      "high_drift_count_7d": 0,
+      "mean_decoupling_28d": null,
+      "mean_decoupling_7d": null,
+      "note": "Steady-state power sessions only (VI <= 1.05, VI > 0, >= 90min, power data). Negative decoupling = strong durability. Trend compares 7d vs 28d mean (+/-1% = stable). Alerts require N28>=5 (alarm) or N7>=3 AND N28>=5 (declining warning) for statistical reliability.",
+      "qualifying_sessions_28d": 0,
+      "qualifying_sessions_7d": 0,
+      "reliability_limited": true,
+      "reliability_note": "insufficient qualifying sessions for alert evaluation: 7d N=0 (min 3), 28d N=0 (min 5)",
+      "trend": null
+    },
+    "efficiency_factor": {
+      "mean_ef_28d": null,
+      "mean_ef_7d": null,
+      "note": "Steady-state cycling sessions only (VI <= 1.05, VI > 0, >= 20min, power+HR data). Rising EF = improving aerobic efficiency. Compare like-for-like sessions only — EF varies with intensity. Trend compares 7d vs 28d mean (+/-0.03 = stable).",
+      "qualifying_sessions_28d": 0,
+      "qualifying_sessions_7d": 0,
+      "trend": null
+    },
+    "hr_curve_delta": {
+      "anchors": null,
+      "note": "Insufficient HR data in one or both windows.",
+      "rotation_index": null,
+      "window_days": 28
+    },
+    "hrrc": {
+      "mean_hrrc_28d": null,
+      "mean_hrrc_7d": null,
+      "note": "HRRc = heart rate recovery (largest 60s HR drop in bpm after exceeding threshold HR for >1 min). Higher = better parasympathetic recovery. Null when threshold not reached, recording stopped before cooldown, or no HR data. Trend: 7d mean vs 28d mean, >10% = meaningful (min 1 session/7d, 3 sessions/28d). Display only — not wired into readiness_decision signals.",
+      "qualifying_sessions_28d": 0,
+      "qualifying_sessions_7d": 0,
+      "trend": null
+    },
+    "power_curve_delta": {
+      "anchors": null,
+      "note": "Insufficient power data in one or both windows.",
+      "rotation_index": null,
+      "window_days": 28
+    },
+    "sustainability_profile": {
+      "note": "No sustainability data available."
+    },
+    "tid_comparison": {
+      "classification_28d": "Pyramidal",
+      "classification_7d": "Pyramidal",
+      "drift": "consistent",
+      "note": "Compares 7d vs 28d Seiler TID to detect distribution shifts. pi_delta positive = more polarized acutely.",
+      "pi_28d": null,
+      "pi_7d": null,
+      "pi_delta": null
+    }
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/consistency_details.json
+++ b/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/consistency_details.json
@@ -1,0 +1,23 @@
+{
+  "metric": "consistency_details",
+  "athlete": "populated-benchmark-and-consistency",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "completed_dates": [
+      "2026-05-05",
+      "2026-05-07",
+      "2026-05-09"
+    ],
+    "completed_days": 3,
+    "matched_days": 3,
+    "planned_dates": [
+      "2026-05-05",
+      "2026-05-07",
+      "2026-05-09",
+      "2026-05-10"
+    ],
+    "planned_days": 4
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/consistency_index.json
+++ b/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/consistency_index.json
@@ -1,0 +1,8 @@
+{
+  "metric": "consistency_index",
+  "athlete": "populated-benchmark-and-consistency",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 0.75
+}

--- a/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/data_quality.json
+++ b/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/data_quality.json
@@ -1,0 +1,18 @@
+{
+  "metric": "data_quality",
+  "athlete": "populated-benchmark-and-consistency",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "activities_28d": 3,
+    "activities_7d": 3,
+    "ftp_history_days": {
+      "indoor": 0,
+      "outdoor": 0
+    },
+    "hrv_data_points": 7,
+    "planned_workouts_7d": 4,
+    "rhr_data_points": 7
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/easy_time_ratio.json
+++ b/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/easy_time_ratio.json
@@ -1,0 +1,8 @@
+{
+  "metric": "easy_time_ratio",
+  "athlete": "populated-benchmark-and-consistency",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 0.59
+}

--- a/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/easy_time_ratio_note.json
+++ b/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/easy_time_ratio_note.json
@@ -1,0 +1,8 @@
+{
+  "metric": "easy_time_ratio_note",
+  "athlete": "populated-benchmark-and-consistency",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": "Easy time (Z1+Z2) / Total - target ~80% in polarized training"
+}

--- a/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/effective_monotony.json
+++ b/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/effective_monotony.json
@@ -1,0 +1,8 @@
+{
+  "metric": "effective_monotony",
+  "athlete": "populated-benchmark-and-consistency",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 0.77
+}

--- a/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/eftp.json
+++ b/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/eftp.json
@@ -1,0 +1,8 @@
+{
+  "metric": "eftp",
+  "athlete": "populated-benchmark-and-consistency",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/grey_zone_note.json
+++ b/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/grey_zone_note.json
@@ -1,0 +1,8 @@
+{
+  "metric": "grey_zone_note",
+  "athlete": "populated-benchmark-and-consistency",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": "Gray Zone % (Z3/tempo) - minimize in polarized training"
+}

--- a/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/grey_zone_percentage.json
+++ b/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/grey_zone_percentage.json
@@ -1,0 +1,8 @@
+{
+  "metric": "grey_zone_percentage",
+  "athlete": "populated-benchmark-and-consistency",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 23.9
+}

--- a/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/hard_days_note.json
+++ b/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/hard_days_note.json
@@ -1,0 +1,8 @@
+{
+  "metric": "hard_days_note",
+  "athlete": "populated-benchmark-and-consistency",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": "Power ladder: z3+ >= 30min, z4+ >= 10min, z5+ >= 5min, z6+ >= 2min, z7 >= 1min. HR fallback (when no power): z4+ >= 10min, z5+ >= 5min. Per Seiler 3-zone model + Foster. HR-based days flagged with intensity_basis: hr"
+}

--- a/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/hard_days_this_week.json
+++ b/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/hard_days_this_week.json
@@ -1,0 +1,8 @@
+{
+  "metric": "hard_days_this_week",
+  "athlete": "populated-benchmark-and-consistency",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 2
+}

--- a/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/hrv_baseline_28d.json
+++ b/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/hrv_baseline_28d.json
@@ -1,0 +1,8 @@
+{
+  "metric": "hrv_baseline_28d",
+  "athlete": "populated-benchmark-and-consistency",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 66.4
+}

--- a/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/hrv_baseline_7d.json
+++ b/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/hrv_baseline_7d.json
@@ -1,0 +1,8 @@
+{
+  "metric": "hrv_baseline_7d",
+  "athlete": "populated-benchmark-and-consistency",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 66.4
+}

--- a/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/latest_hrv.json
+++ b/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/latest_hrv.json
@@ -1,0 +1,8 @@
+{
+  "metric": "latest_hrv",
+  "athlete": "populated-benchmark-and-consistency",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 65
+}

--- a/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/latest_rhr.json
+++ b/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/latest_rhr.json
@@ -1,0 +1,8 @@
+{
+  "metric": "latest_rhr",
+  "athlete": "populated-benchmark-and-consistency",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 56
+}

--- a/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/load_recovery_ratio.json
+++ b/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/load_recovery_ratio.json
@@ -1,0 +1,8 @@
+{
+  "metric": "load_recovery_ratio",
+  "athlete": "populated-benchmark-and-consistency",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 1.9
+}

--- a/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/monotony.json
+++ b/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/monotony.json
@@ -1,0 +1,8 @@
+{
+  "metric": "monotony",
+  "athlete": "populated-benchmark-and-consistency",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 0.77
+}

--- a/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/monotony_interpretation.json
+++ b/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/monotony_interpretation.json
@@ -1,0 +1,8 @@
+{
+  "metric": "monotony_interpretation",
+  "athlete": "populated-benchmark-and-consistency",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": "normal"
+}

--- a/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/multi_sport_detected.json
+++ b/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/multi_sport_detected.json
@@ -1,0 +1,8 @@
+{
+  "metric": "multi_sport_detected",
+  "athlete": "populated-benchmark-and-consistency",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": false
+}

--- a/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/p_max.json
+++ b/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/p_max.json
@@ -1,0 +1,8 @@
+{
+  "metric": "p_max",
+  "athlete": "populated-benchmark-and-consistency",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/phase_detected.json
+++ b/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/phase_detected.json
@@ -1,0 +1,8 @@
+{
+  "metric": "phase_detected",
+  "athlete": "populated-benchmark-and-consistency",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": "Base"
+}

--- a/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/phase_detection.json
+++ b/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/phase_detection.json
@@ -1,0 +1,38 @@
+{
+  "metric": "phase_detection",
+  "athlete": "populated-benchmark-and-consistency",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "basis": {
+      "data_quality": "good",
+      "stream_1": {
+        "acwr_trend": null,
+        "ctl_slope": null,
+        "hard_day_pattern": 0,
+        "weeks_available": 4
+      },
+      "stream_2": {
+        "current_week_hard_days_completed": 0,
+        "current_week_hard_days_total": 0,
+        "hard_sessions_planned": 0,
+        "next_week_load": null,
+        "plan_coverage_current_week": 0,
+        "plan_coverage_next_week": 0,
+        "planned_tss_delta": null,
+        "race_proximity": null
+      },
+      "stream_agreement": null
+    },
+    "confidence": "medium",
+    "dossier_agreement": null,
+    "dossier_declared": null,
+    "phase": "Base",
+    "phase_duration_weeks": 1,
+    "previous_phase": null,
+    "reason_codes": [
+      "NO_PLANNED_WORKOUTS"
+    ]
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/phase_triggers.json
+++ b/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/phase_triggers.json
@@ -1,0 +1,10 @@
+{
+  "metric": "phase_triggers",
+  "athlete": "populated-benchmark-and-consistency",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": [
+    "NO_PLANNED_WORKOUTS"
+  ]
+}

--- a/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/power_model_source.json
+++ b/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/power_model_source.json
@@ -1,0 +1,8 @@
+{
+  "metric": "power_model_source",
+  "athlete": "populated-benchmark-and-consistency",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/primary_sport.json
+++ b/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/primary_sport.json
@@ -1,0 +1,8 @@
+{
+  "metric": "primary_sport",
+  "athlete": "populated-benchmark-and-consistency",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": "cycling"
+}

--- a/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/primary_sport_monotony.json
+++ b/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/primary_sport_monotony.json
@@ -1,0 +1,8 @@
+{
+  "metric": "primary_sport_monotony",
+  "athlete": "populated-benchmark-and-consistency",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 0.77
+}

--- a/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/primary_sport_tss_7d.json
+++ b/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/primary_sport_tss_7d.json
@@ -1,0 +1,8 @@
+{
+  "metric": "primary_sport_tss_7d",
+  "athlete": "populated-benchmark-and-consistency",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 185
+}

--- a/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/quality_intensity_note.json
+++ b/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/quality_intensity_note.json
@@ -1,0 +1,8 @@
+{
+  "metric": "quality_intensity_note",
+  "athlete": "populated-benchmark-and-consistency",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": "Quality Intensity % (Z4+/threshold+) - target ~20% in polarized training"
+}

--- a/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/quality_intensity_percentage.json
+++ b/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/quality_intensity_percentage.json
@@ -1,0 +1,8 @@
+{
+  "metric": "quality_intensity_percentage",
+  "athlete": "populated-benchmark-and-consistency",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 17.1
+}

--- a/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/recovery_index.json
+++ b/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/recovery_index.json
@@ -1,0 +1,8 @@
+{
+  "metric": "recovery_index",
+  "athlete": "populated-benchmark-and-consistency",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 0.96
+}

--- a/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/recovery_index_yesterday.json
+++ b/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/recovery_index_yesterday.json
@@ -1,0 +1,8 @@
+{
+  "metric": "recovery_index_yesterday",
+  "athlete": "populated-benchmark-and-consistency",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 0.99
+}

--- a/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/rhr_baseline_28d.json
+++ b/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/rhr_baseline_28d.json
@@ -1,0 +1,8 @@
+{
+  "metric": "rhr_baseline_28d",
+  "athlete": "populated-benchmark-and-consistency",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 55
+}

--- a/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/rhr_baseline_7d.json
+++ b/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/rhr_baseline_7d.json
@@ -1,0 +1,8 @@
+{
+  "metric": "rhr_baseline_7d",
+  "athlete": "populated-benchmark-and-consistency",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 55
+}

--- a/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/seasonal_context.json
+++ b/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/seasonal_context.json
@@ -1,0 +1,8 @@
+{
+  "metric": "seasonal_context",
+  "athlete": "populated-benchmark-and-consistency",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": "Build / Early Race Season"
+}

--- a/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/seiler_tid_28d.json
+++ b/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/seiler_tid_28d.json
@@ -1,0 +1,18 @@
+{
+  "metric": "seiler_tid_28d",
+  "athlete": "populated-benchmark-and-consistency",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "classification": "Pyramidal",
+    "polarization_index": null,
+    "z1_pct": 59,
+    "z1_seconds": 6900,
+    "z2_pct": 23.9,
+    "z2_seconds": 2800,
+    "z3_pct": 17.1,
+    "z3_seconds": 2000,
+    "zone_basis": "power"
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/seiler_tid_28d_primary.json
+++ b/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/seiler_tid_28d_primary.json
@@ -1,0 +1,19 @@
+{
+  "metric": "seiler_tid_28d_primary",
+  "athlete": "populated-benchmark-and-consistency",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "classification": "Pyramidal",
+    "polarization_index": null,
+    "sport": "cycling",
+    "z1_pct": 59,
+    "z1_seconds": 6900,
+    "z2_pct": 23.9,
+    "z2_seconds": 2800,
+    "z3_pct": 17.1,
+    "z3_seconds": 2000,
+    "zone_basis": "power"
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/seiler_tid_7d.json
+++ b/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/seiler_tid_7d.json
@@ -1,0 +1,18 @@
+{
+  "metric": "seiler_tid_7d",
+  "athlete": "populated-benchmark-and-consistency",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "classification": "Pyramidal",
+    "polarization_index": null,
+    "z1_pct": 59,
+    "z1_seconds": 6900,
+    "z2_pct": 23.9,
+    "z2_seconds": 2800,
+    "z3_pct": 17.1,
+    "z3_seconds": 2000,
+    "zone_basis": "power"
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/seiler_tid_7d_primary.json
+++ b/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/seiler_tid_7d_primary.json
@@ -1,0 +1,19 @@
+{
+  "metric": "seiler_tid_7d_primary",
+  "athlete": "populated-benchmark-and-consistency",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "classification": "Pyramidal",
+    "polarization_index": null,
+    "sport": "cycling",
+    "z1_pct": 59,
+    "z1_seconds": 6900,
+    "z2_pct": 23.9,
+    "z2_seconds": 2800,
+    "z3_pct": 17.1,
+    "z3_seconds": 2000,
+    "zone_basis": "power"
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/strain.json
+++ b/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/strain.json
@@ -1,0 +1,8 @@
+{
+  "metric": "strain",
+  "athlete": "populated-benchmark-and-consistency",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 142
+}

--- a/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/stress_tolerance.json
+++ b/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/stress_tolerance.json
@@ -1,0 +1,8 @@
+{
+  "metric": "stress_tolerance",
+  "athlete": "populated-benchmark-and-consistency",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 1.8
+}

--- a/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/tss_28d_total.json
+++ b/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/tss_28d_total.json
@@ -1,0 +1,8 @@
+{
+  "metric": "tss_28d_total",
+  "athlete": "populated-benchmark-and-consistency",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 185
+}

--- a/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/tss_7d_total.json
+++ b/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/tss_7d_total.json
@@ -1,0 +1,8 @@
+{
+  "metric": "tss_7d_total",
+  "athlete": "populated-benchmark-and-consistency",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 185
+}

--- a/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/vo2max.json
+++ b/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/vo2max.json
@@ -1,0 +1,8 @@
+{
+  "metric": "vo2max",
+  "athlete": "populated-benchmark-and-consistency",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/w_prime.json
+++ b/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/w_prime.json
@@ -1,0 +1,8 @@
+{
+  "metric": "w_prime",
+  "athlete": "populated-benchmark-and-consistency",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/w_prime_kj.json
+++ b/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/w_prime_kj.json
@@ -1,0 +1,8 @@
+{
+  "metric": "w_prime_kj",
+  "athlete": "populated-benchmark-and-consistency",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/zone_distribution_7d.json
+++ b/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/zone_distribution_7d.json
@@ -1,0 +1,15 @@
+{
+  "metric": "zone_distribution_7d",
+  "athlete": "populated-benchmark-and-consistency",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "total_hours": 3.25,
+    "z1_hours": 0.56,
+    "z2_hours": 1.36,
+    "z3_hours": 0.78,
+    "z4_plus_hours": 0.56,
+    "zone_basis": "power"
+  }
+}

--- a/packages/core/tests/helpers/load-fixture.ts
+++ b/packages/core/tests/helpers/load-fixture.ts
@@ -6,26 +6,19 @@
 import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { z, type ZodTypeAny } from "zod";
+import { type ZodTypeAny, type z } from "zod";
 
 import {
-  ActivitySchema,
-  FtpHistoryPointSchema,
-  WellnessDaySchema,
+  FixtureSchema,
+  type FixtureShape,
 } from "../../src/reference/schemas/inputs.js";
 
-/** Aggregate envelope for committed golden fixtures. Top-level `.strict()`
- *  ensures the envelope has exactly the 3 named arrays — no rogue keys
- *  masquerading as fixture data. Per-row schemas are `z.looseObject()` so
- *  real intervals.icu shape rides through without losing TP-trademark fields. */
-export const GoldenFixtureSchema = z
-  .object({
-    activities: z.array(ActivitySchema),
-    wellness: z.array(WellnessDaySchema),
-    ftp_history: z.array(FtpHistoryPointSchema),
-  })
-  .strict();
-export type GoldenFixture = z.infer<typeof GoldenFixtureSchema>;
+/** Re-export the canonical fixture schema for in-package test callers.
+ *  Single source of truth for the envelope shape lives in
+ *  `reference/schemas/inputs.ts` (ADR-0017); both this helper and the
+ *  parity gate at `tools/check-metric-parity.ts` consume it from there. */
+export const GoldenFixtureSchema = FixtureSchema;
+export type GoldenFixture = FixtureShape;
 
 const DEFAULT_FIXTURES_ROOT = resolve(
   dirname(fileURLToPath(import.meta.url)),

--- a/tools/check-metric-parity.ts
+++ b/tools/check-metric-parity.ts
@@ -27,6 +27,10 @@ import {
   METRIC_REGISTRY,
   type MetricRegistryEntry,
 } from "../packages/core/src/reference/metrics/registry.js";
+import {
+  FixtureSchema,
+  type FixtureShape,
+} from "../packages/core/src/reference/schemas/inputs.js";
 
 export type { MetricInput, MetricRegistryEntry };
 export { METRIC_REGISTRY };
@@ -248,13 +252,22 @@ export function loadSnapshot(athlete: string, metric: string): Snapshot {
   return JSON.parse(readFileSync(path, "utf8")) as Snapshot;
 }
 
-// Returns the parsed JSON as `unknown`. The gate intentionally does not
-// Zod-validate fixtures here — that's a metric-function entry concern.
-// (`packages/core/tests/helpers/load-fixture.ts` is the validating loader
-// for in-package tests.)
-export function loadGoldenFixture(athlete: string): unknown {
+// Validates the fixture against `FixtureSchema` at the gate boundary
+// (ADR-0017). Failures throw with the fixture path and the Zod issue
+// tree so a malformed fixture surfaces here, not deep inside a metric.
+// Top-level keys are strict — a rogue field (typo, undeclared addition)
+// fails the parse; per-row schemas stay loose so real upstream shape
+// rides through.
+export function loadGoldenFixture(athlete: string): FixtureShape {
   const path = join(FIXTURES_ROOT, `${athlete}.json`);
-  return JSON.parse(readFileSync(path, "utf8"));
+  const raw = JSON.parse(readFileSync(path, "utf8"));
+  const result = FixtureSchema.safeParse(raw);
+  if (!result.success) {
+    throw new Error(
+      `fixture ${athlete}.json failed schema parse:\n${result.error.message}`,
+    );
+  }
+  return result.data;
 }
 
 // ─── Discovery ─────────────────────────────────────────────────────────

--- a/tools/snapshot-section-11.ts
+++ b/tools/snapshot-section-11.ts
@@ -107,6 +107,12 @@ const HARNESS_FIXTURES: HarnessFixtureConfig[] = [
     description:
       "effective_monotony selector branch B (multi-sport, primary=null → fall back to total). Cycling [80,80,80] on 05-04..06 (total 240, 3 days) and run [150,150] on 05-09..10 (total 300, 2 days): run wins primary on total but has <3 active days, so primary_sport_monotony is null while total monotony is non-null. The selector's `!== null` gate does load-bearing work here — inverting it regresses with no other fixture defense. Load+zones only (empty wellness/ftp).",
   },
+  {
+    slug: "populated-benchmark-and-consistency",
+    frozenNow: DEFAULT_FROZEN_NOW,
+    description:
+      "Populated-branch coverage for consistency_index + benchmark_indoor + benchmark_outdoor — the F11 metrics whose previous fixtures all collapsed to the null branch. 4 WORKOUT events on 05-05/07/09/10 paired with cycling activities on 05-05/07/09 give matched=3, planned=4, consistency_index=0.75. FTP history has a 2026-03-15 entry sitting exactly at (frozenNow - 56d), exercising the +/-7d nearest-match window: indoor 280/270-1=0.037 in seasonal range [0.01,0.04] → seasonal_expected=true; outdoor 270/260-1=0.038 same range true. Without this fixture the parity gate is theatre for those three metrics.",
+  },
 ];
 
 function readPyodideVersion(): string {
@@ -265,6 +271,15 @@ _ALLOWED_OPTIONAL_PATHS = {
     "FIXTURE.activities[*].icu_variability_index",
     "FIXTURE.wellness[*].atl",
     "FIXTURE.wellness[*].ctl",
+    # F11 fixture extensions — absent on every fixture that doesn't exercise
+    # the populated benchmark / consistency branches; present on fixtures that
+    # do. The harness reads them pass-through (no hardcoded overrides) per
+    # ADR-0017's boundary contract.
+    "FIXTURE.past_events",
+    "FIXTURE.current_ftp_indoor",
+    "FIXTURE.current_ftp_outdoor",
+    "FIXTURE.ftp_history_indoor",
+    "FIXTURE.ftp_history_outdoor",
 }
 
 def _normalize_path(path):
@@ -343,6 +358,37 @@ sync._intervals_data = {}
 # (None, None, None) is the documented "insufficient FTP history" path.
 _BENCH_NONE = (None, None, None)
 
+# Pass-through read of F11 fixture extensions. The harness used to
+# hardcode past_events=[] and benchmark_*=_BENCH_NONE, which made the
+# parity gate vacuous for those metrics (every snapshot collapsed to
+# the null branch). ADR-0017 makes the fixture the boundary — these
+# fields are optional on every committed fixture and the harness
+# computes the benchmark tuples by handing the fixture-provided FTP
+# data to sync.py's own _calculate_benchmark_index. Absent fields
+# produce the same null branches the hardcoded path did, so existing
+# snapshots stay bit-identical; populated branches now actually run.
+_past_events = FIXTURE.get("past_events", []) or []
+_current_ftp_indoor = FIXTURE.get("current_ftp_indoor")
+_ftp_history_indoor = FIXTURE.get("ftp_history_indoor") or {}
+_current_ftp_outdoor = FIXTURE.get("current_ftp_outdoor")
+_ftp_history_outdoor = FIXTURE.get("ftp_history_outdoor") or {}
+
+if _current_ftp_indoor and _ftp_history_indoor:
+    _idx_in, _ftp8_in = sync._calculate_benchmark_index(
+        _current_ftp_indoor, _ftp_history_indoor
+    )
+    _benchmark_indoor = (_idx_in, _ftp8_in, _current_ftp_indoor)
+else:
+    _benchmark_indoor = _BENCH_NONE
+
+if _current_ftp_outdoor and _ftp_history_outdoor:
+    _idx_out, _ftp8_out = sync._calculate_benchmark_index(
+        _current_ftp_outdoor, _ftp_history_outdoor
+    )
+    _benchmark_outdoor = (_idx_out, _ftp8_out, _current_ftp_outdoor)
+else:
+    _benchmark_outdoor = _BENCH_NONE
+
 try:
     derived = sync._calculate_derived_metrics(
         activities_7d=_ACTIVITIES_7D,
@@ -352,11 +398,11 @@ try:
         current_ctl=_CURRENT_CTL,
         current_atl=_CURRENT_ATL,
         current_tsb=_CURRENT_TSB,
-        past_events=[],
+        past_events=_past_events,
         activities_for_consistency=_ACTIVITIES_7D,
         power_model={},
-        benchmark_indoor=_BENCH_NONE,
-        benchmark_outdoor=_BENCH_NONE,
+        benchmark_indoor=_benchmark_indoor,
+        benchmark_outdoor=_benchmark_outdoor,
         vo2max=None,
         formatted_planned_workouts=[],
         race_calendar=None,


### PR DESCRIPTION
## Summary

Resolves the vacuous-parity issue the F11 architect review flagged as concern #5. The snapshot harness used to hardcode `past_events=[]` and the indoor/outdoor benchmark tuples to `(None, None, None)`, which meant the parity gate was theatre for `consistency_index`, `consistency_details`, `benchmark_indoor`, `benchmark_outdoor`, and the `seasonal_expected` branch — every snapshot for those metrics collapsed to null regardless of fixture content.

**This is stacked on #122 → #121.** Merge in order.

## What changes

- **Harness pass-through.** `tools/snapshot-section-11.ts` now reads `past_events`, `current_ftp_indoor`/`outdoor`, and `ftp_history_indoor`/`outdoor` from the fixture, then hands the FTP data to the upstream's own `_calculate_benchmark_index` to derive the benchmark tuples. No more hardcoded overrides.
- **Allowlist extension.** Five new optional top-level paths added to `_ALLOWED_OPTIONAL_PATHS` so existing fixtures (which don't provide the F11 fields) don't fail the contract-validation pass.
- **New populated-branch fixture.** `packages/core/tests/fixtures/golden/populated-benchmark-and-consistency.json` provides 4 WORKOUT past_events paired with 3 cycling activities (matches → `consistency_index: 0.75`, populated `consistency_details`); FTP histories with a `2026-03-15` entry exactly at frozenNow - 56d (indoor `280/270 - 1 = 0.037`, outdoor `270/260 - 1 = 0.038`; both in May's `[0.01, 0.04]` range → `seasonal_expected: true`). Wired into `HARNESS_FIXTURES`.
- **52 new snapshot files** under `packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/`. The 5 F11-relevant snapshots now hold real oracle values, not null.

## Bit-identity safety

The pre/post snapshot diff for the 8 existing fixture directories is **empty** — every existing snapshot regenerated bit-identically because absent F11 fields produce the same null branches the hardcoded overrides did. Existing parity behavior is unchanged; the change is purely additive coverage.

## Test plan

- [x] `pnpm snapshot:section-11` — 9 fixtures × 52 metrics regenerate cleanly; pre-existing snapshots unchanged
- [x] `pnpm check-parity --all` — 198/198 OK (up from 176; new fixture × 22 implemented metrics)
- [x] `pnpm check-parity --fixture=populated-benchmark-and-consistency --metric={consistency_index,consistency_details,benchmark_indoor,benchmark_outdoor,seasonal_context}` — all OK against real oracle values
- [x] `pnpm test compliance-and-body load-management distribution date-helpers reference-load-fixture metric-input registry` — 131/131 pass

## What this closes

| Metric | Before this PR | After this PR |
|---|---|---|
| `consistency_index` | gate sees `null == null` on every fixture | gate sees `0.75` on populated fixture |
| `consistency_details` | always empty-branch shape | populated-branch shape with date lists |
| `benchmark_indoor` | always `{ *: null }` | populated 5-key dict with `+3.7%`, `seasonal_expected: true` |
| `benchmark_outdoor` | always `{ *: null }` | populated 5-key dict with `+3.8%`, `seasonal_expected: true` |
| `seasonal_expected` branch | unreachable | exercised end-to-end via the populated benchmarks |

The remaining seasonal-context coverage gap (May-only fixtures) is a separate fixture-authoring batch — per-season variants would close it but aren't in scope here.