### PR TITLE
chore: gitignore specs/ — Spec Kit feature-folder output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ CLAUDE.local.md
 .agents/
 .ralph/
 .specify/
+specs/
 skills-lock.json
 # fuzz-parity divergence / oracle-error captures (dev-time only, never committed)
 packages/core/tests/fixtures/_fuzz-fail/


### PR DESCRIPTION
## Summary

- Adds `specs/` to `.gitignore`. Spec Kit's `create-new-feature.sh` produces a `specs/NNN-<slug>/` folder per feature with local-only design artifacts (spec, research, data model, contracts, quickstart). Treating them like `docs/` — local-only, not shipped — matches the existing `docs/` gitignore line and the project's "design artifacts stay local" convention (per CLAUDE.local.md §Repository Hygiene).
- Cherry-picked from `feature/f11-remaining-trio` so it lands as its own chore commit on `main` rather than riding along inside an unrelated feature PR.

## Test plan

- [x] `git check-ignore -v specs/` returns the .gitignore match on any branch off main after merge
- [x] Existing checked-in files unaffected (the line is additive)