### PR TITLE
feat(core): port has_intervals classifier with per-activity snapshot pattern

### DIFF
--- a/packages/core/src/reference/metrics/compliance-and-body.test.ts
+++ b/packages/core/src/reference/metrics/compliance-and-body.test.ts
@@ -637,7 +637,7 @@ describe("computeHasIntervals", () => {
     expect(computeHasIntervals(env)).toEqual({ "12345": true });
   });
 
-  it("emits the per-activity map with keys sorted ascending as strings (architect Q1+Q9 push-back)", () => {
+  it("emits the per-activity map with keys sorted ascending as strings", () => {
     // The harness sorts via `sorted(d.keys())` before emit. The TS port also
     // sorts so call-site iteration order is locked across Pyodide / CPython /
     // Node. Non-integer-like keys are used here because V8 / SpiderMonkey
@@ -682,9 +682,8 @@ describe("computeHasIntervals", () => {
   });
 
   it("treats a missing intervals top-level key as an empty lookup (FixtureSchema .optional() compatibility)", () => {
-    // ADR-0017 + architect Q8 push-back: existing fixtures without an
-    // `intervals` top-level key must still classify cleanly; every
-    // activity falls into branch (d).
+    // ADR-0017: existing fixtures without an `intervals` top-level key
+    // must still classify cleanly; every activity falls into branch (d).
     const env: MetricInput = {
       fixture: {
         activities: [

--- a/packages/core/src/reference/metrics/compliance-and-body.test.ts
+++ b/packages/core/src/reference/metrics/compliance-and-body.test.ts
@@ -6,6 +6,7 @@ import {
   computeBenchmarkOutdoor,
   computeConsistencyDetails,
   computeConsistencyIndex,
+  computeHasIntervals,
   formatBenchmarkPercentage,
   isBenchmarkExpected,
 } from "./compliance-and-body.js";
@@ -543,5 +544,161 @@ describe("computeBenchmarkOutdoor", () => {
       benchmark_percentage: "+1.8%",
       seasonal_expected: true,
     });
+  });
+});
+
+describe("computeHasIntervals", () => {
+  // The v3.106 fix narrows the predicate to WORK segments only — a non-empty
+  // intervals list is no longer sufficient. The five branches at
+  // `sync.py:7866-7873` are exercised here at unit scope; the populated
+  // fixture exercises the same five at the parity gate.
+  interface IntervalEntry {
+    intervals?: { type: string }[];
+    [k: string]: unknown;
+  }
+
+  function withIntervals(
+    activities: { id: string | number }[],
+    intervals: Record<string, IntervalEntry>,
+  ): MetricInput {
+    return {
+      fixture: {
+        activities: activities.map((a) => ({
+          id: a.id,
+          start_date_local: "2026-05-10T07:00:00",
+          type: "Ride",
+          moving_time: 1800,
+          elapsed_time: 1900,
+        })),
+        intervals,
+      } as MetricInput["fixture"],
+      frozenNow: "2026-05-10T12:00:00",
+    };
+  }
+
+  it("flags an activity true when its lookup entry has a WORK segment (branch a)", () => {
+    const env = withIntervals(
+      [{ id: "a1" }],
+      { a1: { intervals: [{ type: "WORK" }] } },
+    );
+    expect(computeHasIntervals(env)).toEqual({ a1: true });
+  });
+
+  it("flags an activity false when its lookup entry has only RECOVERY segments (branch b, v3.106 regression test)", () => {
+    // Pre-v3.106 this returned true (non-empty intervals list). The fix at
+    // sync.py:133 narrowed the predicate; whole-session RECOVERY placeholders
+    // on unstructured endurance rides now classify as false.
+    const env = withIntervals(
+      [{ id: "a2" }],
+      { a2: { intervals: [{ type: "RECOVERY" }] } },
+    );
+    expect(computeHasIntervals(env)).toEqual({ a2: false });
+  });
+
+  it("flags an activity false when its lookup entry has an empty intervals list (branch c)", () => {
+    const env = withIntervals(
+      [{ id: "a3" }],
+      { a3: { intervals: [] } },
+    );
+    expect(computeHasIntervals(env)).toEqual({ a3: false });
+  });
+
+  it("flags an activity false when it is NOT in the intervals lookup (branch d, default)", () => {
+    // No entry for a4 in the lookup. Upstream's `intervals_by_id.get(id)`
+    // returns None; the `if _entry:` gate short-circuits.
+    const env = withIntervals([{ id: "a4" }], {});
+    expect(computeHasIntervals(env)).toEqual({ a4: false });
+  });
+
+  it("flags an activity false when its lookup entry is missing the intervals key (branch e, `or []` short-circuit)", () => {
+    // Mirrors sync.py:7872 — `(_entry.get("intervals") or [])` coerces a
+    // missing or falsy `intervals` to an empty iterable; the WORK check
+    // then has nothing to match.
+    const env = withIntervals(
+      [{ id: "a5" }],
+      { a5: { dfa: { quality: { sufficient: false } } } },
+    );
+    expect(computeHasIntervals(env)).toEqual({ a5: false });
+  });
+
+  it("returns an empty map when there are no activities", () => {
+    const env = withIntervals([], {});
+    expect(computeHasIntervals(env)).toEqual({});
+  });
+
+  it("stringifies numeric activity ids for the lookup (mirrors `str(act.get('id'))` at sync.py:7870)", () => {
+    // Real intervals.icu activity ids round-trip as numbers on some endpoints.
+    // The upstream's lookup key is `str(activity_id)`, so the TS port must
+    // stringify too.
+    const env = withIntervals(
+      [{ id: 12345 }],
+      { "12345": { intervals: [{ type: "WORK" }] } },
+    );
+    expect(computeHasIntervals(env)).toEqual({ "12345": true });
+  });
+
+  it("emits the per-activity map with keys sorted ascending as strings (architect Q1+Q9 push-back)", () => {
+    // The harness sorts via `sorted(d.keys())` before emit. The TS port also
+    // sorts so call-site iteration order is locked across Pyodide / CPython /
+    // Node. Non-integer-like keys are used here because V8 / SpiderMonkey
+    // / JSC iterate integer-like string keys ('1','2','10') in numeric
+    // ascending order regardless of insertion order — a quirk of the
+    // ECMAScript Object key-ordering spec that masks insertion-order bugs
+    // on numeric-id activities (the parity gate's deepCompare is order-
+    // insensitive, so this matters for downstream LLM iteration only).
+    // Real intervals.icu ids carry the 'i' prefix (e.g. 'i146622609'),
+    // which stays non-integer-like.
+    const env = withIntervals(
+      [{ id: "i20" }, { id: "i03" }, { id: "i10" }],
+      {
+        i20: { intervals: [{ type: "WORK" }] },
+        i03: { intervals: [{ type: "WORK" }] },
+        i10: { intervals: [{ type: "RECOVERY" }] },
+      },
+    );
+    expect(Object.keys(computeHasIntervals(env))).toEqual([
+      "i03",
+      "i10",
+      "i20",
+    ]);
+  });
+
+  it("returns true when any segment is WORK (mixed list with RECOVERY + WORK)", () => {
+    // Defends against an over-narrow predicate that requires ALL segments
+    // to be WORK. Upstream uses `any(...)` semantics.
+    const env = withIntervals(
+      [{ id: "mix" }],
+      {
+        mix: {
+          intervals: [
+            { type: "RECOVERY" },
+            { type: "WORK" },
+            { type: "RECOVERY" },
+          ],
+        },
+      },
+    );
+    expect(computeHasIntervals(env)).toEqual({ mix: true });
+  });
+
+  it("treats a missing intervals top-level key as an empty lookup (FixtureSchema .optional() compatibility)", () => {
+    // ADR-0017 + architect Q8 push-back: existing fixtures without an
+    // `intervals` top-level key must still classify cleanly; every
+    // activity falls into branch (d).
+    const env: MetricInput = {
+      fixture: {
+        activities: [
+          {
+            id: "a1",
+            start_date_local: "2026-05-10T07:00:00",
+            type: "Ride",
+            moving_time: 1800,
+            elapsed_time: 1900,
+          },
+        ],
+      } as MetricInput["fixture"],
+      frozenNow: "2026-05-10T12:00:00",
+    };
+    expect(computeHasIntervals(env)).toEqual({ a1: false });
   });
 });

--- a/packages/core/src/reference/metrics/compliance-and-body.ts
+++ b/packages/core/src/reference/metrics/compliance-and-body.ts
@@ -334,8 +334,7 @@ export function computeBenchmarkIndoor(input: MetricInput): BenchmarkEmission {
  *
  * Keys are stringified `activity.id` (mirroring `str(act.get("id"))` at
  * `sync.py:7870`) and sorted ascending as strings to lock JSON key-order
- * across Pyodide / CPython / Node (architect Q1+Q9 push-back on the
- * snapshot harness).
+ * across Pyodide / CPython / Node.
  *
  * Upstream source mirrored line-by-line: `sync.py:7866-7873` inside
  * `_format_activities`; v3.106 changelog entry at `sync.py:133` documents

--- a/packages/core/src/reference/metrics/compliance-and-body.ts
+++ b/packages/core/src/reference/metrics/compliance-and-body.ts
@@ -19,7 +19,10 @@ import {
   getCurrentFtpOutdoor,
   getFtpHistoryIndoor,
   getFtpHistoryOutdoor,
+  getIntervalsLookup,
   getPastEvents,
+  type IntervalsEntry,
+  type IntervalsLookup,
   type MetricInput,
 } from "./metric-input.js";
 import { computeSeasonalContext, type SeasonalContext } from "./seasonal-context.js";
@@ -319,6 +322,64 @@ export function computeBenchmarkIndoor(input: MetricInput): BenchmarkEmission {
         : formatBenchmarkPercentage(benchmarkIndex),
     seasonal_expected: seasonalExpected,
   };
+}
+
+/**
+ * v3.106 has-intervals classifier. Per-activity flag — `true` only when the
+ * activity's lookup entry exists AND carries at least one segment with
+ * `type === "WORK"`. RECOVERY-only placeholders, empty interval lists,
+ * activities absent from the lookup, and lookup entries missing the
+ * `intervals` key all return `false`. The v3.105 implementation flagged
+ * any non-empty intervals list as structured; the v3.106 fix narrows the
+ * predicate to WORK segments only so that intervals.icu's whole-session
+ * RECOVERY placeholder on unstructured endurance rides no longer
+ * misclassifies them.
+ *
+ * Upstream source mirrored line-by-line: `sync.py:7866-7873`. v3.106
+ * changelog entry at `sync.py:133` documents the regression fix.
+ */
+function hasIntervalsForActivity(
+  activity: Activity,
+  intervalsLookup: IntervalsLookup,
+): boolean {
+  const entry: IntervalsEntry | undefined = intervalsLookup[String(activity.id)];
+  if (!entry) return false;
+  const segments = entry.intervals ?? [];
+  for (const segment of segments) {
+    if (segment.type === "WORK") return true;
+  }
+  return false;
+}
+
+/**
+ * Per-activity has-intervals emission. Returns a map keyed by stringified
+ * `activity.id` (mirroring upstream's `str(act.get("id"))` lookup at
+ * `sync.py:7870`). Keys are sorted ascending as strings to lock JSON
+ * key-order across Pyodide / CPython / Node (architect Q1+Q9 push-back
+ * on the snapshot harness).
+ *
+ * Upstream source: per-activity loop at `sync.py:7866-7873` inside
+ * `_format_activities`; this Reference-port hoists the predicate into a
+ * standalone derived map so the parity gate can assert it without
+ * exposing the whole formatted-activity dict.
+ */
+export function computeHasIntervals(
+  input: MetricInput,
+): Record<string, boolean> {
+  const intervalsLookup = getIntervalsLookup(input);
+  const activities = getActivities(input);
+
+  const flagByActivityId: Record<string, boolean> = {};
+  for (const activity of activities) {
+    const key = String(activity.id);
+    flagByActivityId[key] = hasIntervalsForActivity(activity, intervalsLookup);
+  }
+
+  const sorted: Record<string, boolean> = {};
+  for (const key of Object.keys(flagByActivityId).sort()) {
+    sorted[key] = flagByActivityId[key]!;
+  }
+  return sorted;
 }
 
 /**

--- a/packages/core/src/reference/metrics/compliance-and-body.ts
+++ b/packages/core/src/reference/metrics/compliance-and-body.ts
@@ -21,8 +21,6 @@ import {
   getFtpHistoryOutdoor,
   getIntervalsLookup,
   getPastEvents,
-  type IntervalsEntry,
-  type IntervalsLookup,
   type MetricInput,
 } from "./metric-input.js";
 import { computeSeasonalContext, type SeasonalContext } from "./seasonal-context.js";
@@ -325,41 +323,23 @@ export function computeBenchmarkIndoor(input: MetricInput): BenchmarkEmission {
 }
 
 /**
- * v3.106 has-intervals classifier. Per-activity flag — `true` only when the
- * activity's lookup entry exists AND carries at least one segment with
+ * Per-activity v3.106 has-intervals emission. Each entry is `true` only when
+ * the activity's lookup entry exists AND carries at least one segment with
  * `type === "WORK"`. RECOVERY-only placeholders, empty interval lists,
  * activities absent from the lookup, and lookup entries missing the
- * `intervals` key all return `false`. The v3.105 implementation flagged
- * any non-empty intervals list as structured; the v3.106 fix narrows the
- * predicate to WORK segments only so that intervals.icu's whole-session
- * RECOVERY placeholder on unstructured endurance rides no longer
- * misclassifies them.
+ * `intervals` key all return `false`. v3.105 flagged any non-empty intervals
+ * list as structured; the v3.106 fix narrows to WORK segments so
+ * intervals.icu's whole-session RECOVERY placeholder on unstructured
+ * endurance rides no longer misclassifies them.
  *
- * Upstream source mirrored line-by-line: `sync.py:7866-7873`. v3.106
- * changelog entry at `sync.py:133` documents the regression fix.
- */
-function hasIntervalsForActivity(
-  activity: Activity,
-  intervalsLookup: IntervalsLookup,
-): boolean {
-  const entry: IntervalsEntry | undefined = intervalsLookup[String(activity.id)];
-  if (!entry) return false;
-  const segments = entry.intervals ?? [];
-  for (const segment of segments) {
-    if (segment.type === "WORK") return true;
-  }
-  return false;
-}
-
-/**
- * Per-activity has-intervals emission. Returns a map keyed by stringified
- * `activity.id` (mirroring upstream's `str(act.get("id"))` lookup at
- * `sync.py:7870`). Keys are sorted ascending as strings to lock JSON
- * key-order across Pyodide / CPython / Node (architect Q1+Q9 push-back
- * on the snapshot harness).
+ * Keys are stringified `activity.id` (mirroring `str(act.get("id"))` at
+ * `sync.py:7870`) and sorted ascending as strings to lock JSON key-order
+ * across Pyodide / CPython / Node (architect Q1+Q9 push-back on the
+ * snapshot harness).
  *
- * Upstream source: per-activity loop at `sync.py:7866-7873` inside
- * `_format_activities`; this Reference-port hoists the predicate into a
+ * Upstream source mirrored line-by-line: `sync.py:7866-7873` inside
+ * `_format_activities`; v3.106 changelog entry at `sync.py:133` documents
+ * the regression fix. This Reference-port hoists the predicate into a
  * standalone derived map so the parity gate can assert it without
  * exposing the whole formatted-activity dict.
  */
@@ -372,7 +352,8 @@ export function computeHasIntervals(
   const flagByActivityId: Record<string, boolean> = {};
   for (const activity of activities) {
     const key = String(activity.id);
-    flagByActivityId[key] = hasIntervalsForActivity(activity, intervalsLookup);
+    const segments = intervalsLookup[key]?.intervals ?? [];
+    flagByActivityId[key] = segments.some((s) => s.type === "WORK");
   }
 
   const sorted: Record<string, boolean> = {};

--- a/packages/core/src/reference/metrics/metric-input.ts
+++ b/packages/core/src/reference/metrics/metric-input.ts
@@ -4,6 +4,15 @@ import type {
   PlannedEvent,
 } from "../schemas/inputs.js";
 
+/** Per-activity intervals entry projected to the fields the Reference layer
+ *  consumes. Mirrors the upstream's intervals.json row shape (a distinct API
+ *  surface from `activities`). The `intervals` sub-array can be absent, empty,
+ *  or carry segments with `type` strings like `"WORK"` / `"RECOVERY"`. */
+export interface IntervalsEntry {
+  intervals?: { type: string }[];
+}
+export type IntervalsLookup = Record<string, IntervalsEntry>;
+
 /**
  * The contract between a metric port and the parity gate.
  *
@@ -49,4 +58,8 @@ export function getFtpHistoryOutdoor(
   input: MetricInput,
 ): Record<string, number> {
   return input.fixture.ftp_history_outdoor ?? {};
+}
+
+export function getIntervalsLookup(input: MetricInput): IntervalsLookup {
+  return (input.fixture.intervals ?? {}) as IntervalsLookup;
 }

--- a/packages/core/src/reference/metrics/metric-input.ts
+++ b/packages/core/src/reference/metrics/metric-input.ts
@@ -60,6 +60,8 @@ export function getFtpHistoryOutdoor(
   return input.fixture.ftp_history_outdoor ?? {};
 }
 
+// Cast narrows Zod's looseObject ride-through inference to the named
+// IntervalsEntry surface; the schema already validates the shape.
 export function getIntervalsLookup(input: MetricInput): IntervalsLookup {
   return (input.fixture.intervals ?? {}) as IntervalsLookup;
 }

--- a/packages/core/src/reference/metrics/registry.ts
+++ b/packages/core/src/reference/metrics/registry.ts
@@ -13,6 +13,7 @@ import {
   computeBenchmarkOutdoor,
   computeConsistencyDetails,
   computeConsistencyIndex,
+  computeHasIntervals,
 } from "./compliance-and-body.js";
 import {
   computeEasyTimeRatio,
@@ -71,4 +72,5 @@ export const METRIC_REGISTRY: Record<string, MetricRegistryEntry> = {
   seasonal_context: { compute: computeSeasonalContext },
   benchmark_indoor: { compute: computeBenchmarkIndoor },
   benchmark_outdoor: { compute: computeBenchmarkOutdoor },
+  has_intervals: { compute: computeHasIntervals },
 };

--- a/packages/core/src/reference/schemas/inputs.ts
+++ b/packages/core/src/reference/schemas/inputs.ts
@@ -223,6 +223,23 @@ export const FixtureSchema = z
     current_ftp_outdoor: z.number().nullable().optional(),
     ftp_history_indoor: z.record(z.string(), z.number()).optional(),
     ftp_history_outdoor: z.record(z.string(), z.number()).optional(),
+
+    // Per-activity intervals lookup, mirroring upstream's intervals.json
+    // surface (a distinct API endpoint from activities). Keyed by activity
+    // id as a string. Optional so existing fixtures without the key still
+    // validate. Only the `intervals[].type` field is consumed by the
+    // current Reference port (`has_intervals` WORK-segment classifier);
+    // other fields ride through via the loose row schemas. See ADR-0017.
+    intervals: z
+      .record(
+        z.string(),
+        z.looseObject({
+          intervals: z
+            .array(z.looseObject({ type: z.string() }))
+            .optional(),
+        }),
+      )
+      .optional(),
   })
   .strict();
 export type FixtureShape = z.infer<typeof FixtureSchema>;

--- a/packages/core/tests/fixtures/golden/populated-benchmark-and-consistency.json
+++ b/packages/core/tests/fixtures/golden/populated-benchmark-and-consistency.json
@@ -65,6 +65,22 @@
       ],
       "decoupling": -3.8,
       "icu_efficiency_factor": 1.10
+    },
+    {
+      "id": "pbc4",
+      "start_date_local": "2026-04-05T07:00:00",
+      "type": "Ride",
+      "name": "out-of-28d-window",
+      "moving_time": 1800,
+      "elapsed_time": 1900
+    },
+    {
+      "id": "pbc5",
+      "start_date_local": "2026-04-01T07:00:00",
+      "type": "Ride",
+      "name": "out-of-28d-window",
+      "moving_time": 1800,
+      "elapsed_time": 1900
     }
   ],
   "wellness": [
@@ -161,5 +177,11 @@
     "2026-02-01": 255,
     "2026-03-15": 260,
     "2026-04-15": 265
+  },
+  "intervals": {
+    "pbc1": { "intervals": [{ "type": "WORK", "duration": 300 }] },
+    "pbc2": { "intervals": [{ "type": "RECOVERY", "duration": 600 }] },
+    "pbc4": { "intervals": [] },
+    "pbc5": { "dfa": { "quality": { "sufficient": false } } }
   }
 }

--- a/packages/core/tests/fixtures/snapshots/boundary-monotony/has_intervals.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-monotony/has_intervals.json
@@ -1,0 +1,16 @@
+{
+  "metric": "has_intervals",
+  "athlete": "boundary-monotony",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "bm0": false,
+    "bm1": false,
+    "bm2": false,
+    "bm3": false,
+    "bm4": false,
+    "bm5": false,
+    "bm6": false
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-sum-strain/has_intervals.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-sum-strain/has_intervals.json
@@ -1,0 +1,13 @@
+{
+  "metric": "has_intervals",
+  "athlete": "boundary-sum-strain",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "bs0": false,
+    "bs1": false,
+    "bs2": false,
+    "bs3": false
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/has_intervals.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/has_intervals.json
@@ -1,0 +1,12 @@
+{
+  "metric": "has_intervals",
+  "athlete": "boundary-zone-total-secs",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "bz0": false,
+    "bz1": false,
+    "bz2": false
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/data-gap-mid-history/has_intervals.json
+++ b/packages/core/tests/fixtures/snapshots/data-gap-mid-history/has_intervals.json
@@ -1,0 +1,30 @@
+{
+  "metric": "has_intervals",
+  "athlete": "data-gap-mid-history",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-20T12:00:00",
+  "value": {
+    "100000": false,
+    "100001": false,
+    "100002": false,
+    "100003": false,
+    "100004": false,
+    "100005": false,
+    "100006": false,
+    "100007": false,
+    "100008": false,
+    "100009": false,
+    "100010": false,
+    "100011": false,
+    "100012": false,
+    "100013": false,
+    "100014": false,
+    "100015": false,
+    "100016": false,
+    "100017": false,
+    "100018": false,
+    "100019": false,
+    "100020": false
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/manifest.json
+++ b/packages/core/tests/fixtures/snapshots/manifest.json
@@ -31,6 +31,7 @@
     "grey_zone_percentage",
     "hard_days_note",
     "hard_days_this_week",
+    "has_intervals",
     "hrv_baseline_28d",
     "hrv_baseline_7d",
     "latest_hrv",

--- a/packages/core/tests/fixtures/snapshots/multisport-thin-primary/has_intervals.json
+++ b/packages/core/tests/fixtures/snapshots/multisport-thin-primary/has_intervals.json
@@ -1,0 +1,14 @@
+{
+  "metric": "has_intervals",
+  "athlete": "multisport-thin-primary",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "tp0": false,
+    "tp1": false,
+    "tp2": false,
+    "tp3": false,
+    "tp4": false
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/multisport-tie/has_intervals.json
+++ b/packages/core/tests/fixtures/snapshots/multisport-tie/has_intervals.json
@@ -1,0 +1,16 @@
+{
+  "metric": "has_intervals",
+  "athlete": "multisport-tie",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "mt0": false,
+    "mt1": false,
+    "mt2": false,
+    "mt3": false,
+    "mt4": false,
+    "mt5": false,
+    "mt6": false
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/new-athlete-empty/has_intervals.json
+++ b/packages/core/tests/fixtures/snapshots/new-athlete-empty/has_intervals.json
@@ -1,0 +1,8 @@
+{
+  "metric": "has_intervals",
+  "athlete": "new-athlete-empty",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {}
+}

--- a/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/has_intervals.json
+++ b/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/has_intervals.json
@@ -1,0 +1,14 @@
+{
+  "metric": "has_intervals",
+  "athlete": "populated-benchmark-and-consistency",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "pbc1": true,
+    "pbc2": false,
+    "pbc3": false,
+    "pbc4": false,
+    "pbc5": false
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/realistic-athlete/has_intervals.json
+++ b/packages/core/tests/fixtures/snapshots/realistic-athlete/has_intervals.json
@@ -1,0 +1,10 @@
+{
+  "metric": "has_intervals",
+  "athlete": "realistic-athlete",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "12345": false
+  }
+}

--- a/tools/snapshot-section-11.ts
+++ b/tools/snapshot-section-11.ts
@@ -455,9 +455,9 @@ if "__error__" not in derived:
                     break
         _has_intervals[_act_id] = _flag
     # Explicit sort defends per-activity-map key order across Pyodide /
-    # CPython / Node (architect Q1+Q9). json.dumps(sort_keys=True) below
-    # already sorts globally; the explicit pre-sort keeps the convention
-    # legible at the point the map is constructed.
+    # CPython / Node. json.dumps(sort_keys=True) below already sorts
+    # globally; the explicit pre-sort keeps the convention legible at
+    # the point the map is constructed.
     derived["has_intervals"] = {
         k: _has_intervals[k] for k in sorted(_has_intervals.keys())
     }

--- a/tools/snapshot-section-11.ts
+++ b/tools/snapshot-section-11.ts
@@ -280,6 +280,7 @@ _ALLOWED_OPTIONAL_PATHS = {
     "FIXTURE.current_ftp_outdoor",
     "FIXTURE.ftp_history_indoor",
     "FIXTURE.ftp_history_outdoor",
+    "FIXTURE.intervals",
 }
 
 def _normalize_path(path):
@@ -425,6 +426,42 @@ except Exception as e:
     }
 
 if "__error__" not in derived:
+    # === has_intervals per-activity classifier (v3.106) ===
+    # Hoisted from sync.py:7866-7873 inside _format_activities. The upstream
+    # emits has_intervals per activity in the formatted activity dict; we
+    # surface it as a top-level derived key so the parity gate can assert
+    # it without ingesting the full per-activity display block (which mixes
+    # protocol output with formatting orthogonal to the predicate).
+    #
+    # Bypass _TrackedDict on the intervals lookup by reparsing FIXTURE_JSON:
+    # (a) the upstream's intervals_by_id is built from self._intervals_data
+    #     (a separate API surface), so the contract tracker has nothing to
+    #     assert on it; (b) branch (e) of the predicate — entry present
+    #     without an 'intervals' key — would otherwise raise a spurious
+    #     missing-key event on _entry.get('intervals').
+    _raw_fixture = json.loads(FIXTURE_JSON)
+    _intervals_raw = _raw_fixture.get("intervals") or {}
+    _has_intervals = {}
+    for _act in _activities_all:
+        if not isinstance(_act, dict):
+            continue
+        _act_id = str(_act.get("id"))
+        _entry = _intervals_raw.get(_act_id)
+        _flag = False
+        if _entry:
+            for _seg in (_entry.get("intervals") or []):
+                if isinstance(_seg, dict) and _seg.get("type") == "WORK":
+                    _flag = True
+                    break
+        _has_intervals[_act_id] = _flag
+    # Explicit sort defends per-activity-map key order across Pyodide /
+    # CPython / Node (architect Q1+Q9). json.dumps(sort_keys=True) below
+    # already sorts globally; the explicit pre-sort keeps the convention
+    # legible at the point the map is constructed.
+    derived["has_intervals"] = {
+        k: _has_intervals[k] for k in sorted(_has_intervals.keys())
+    }
+
     _unallowed = sorted({
         p for p in _TRACKED_MISSING
         if _normalize_path(p) not in _ALLOWED_OPTIONAL_PATHS


### PR DESCRIPTION
## Summary


- New `computeHasIntervals(input)` in
  `packages/core/src/reference/metrics/compliance-and-body.ts` ports the
  v3.106 WORK-segment classifier from `sync.py:7866-7873`. The function
  returns a per-activity map (`Record<string, boolean>`) keyed by
  stringified `activity.id`; a value is `true` only when the lookup
  entry carries at least one segment with `type === "WORK"`. The
  per-activity helper `hasIntervalsForActivity(activity, intervalsLookup)`
  is module-private (non-`compute*` name) so the registry's inverse-
  coverage check stays happy. Output keys are explicitly sorted
  ascending as strings before emission, matching the harness's
  `sorted(d.keys())` discipline. [a93734a]
- `has_intervals: { compute: computeHasIntervals }` registered in
  `METRIC_REGISTRY`. [a93734a]
- New accessor `getIntervalsLookup(input)` in
  `packages/core/src/reference/metrics/metric-input.ts` follows the
  `getActivities` convention; returns `input.fixture.intervals ?? {}`.
  Companion type exports `IntervalsEntry` and `IntervalsLookup` so
  callers consume a typed shape, not `unknown`. [a93734a]
- `FixtureSchema` extended with an `intervals` top-level key per
  ADR-0017 (Q8 decision):

  ```ts
  intervals: z.record(z.string(), z.looseObject({
    intervals: z.array(z.looseObject({ type: z.string() })).optional(),
  })).optional(),
  ```

  `.optional()` is load-bearing — existing fixtures without the key
  still validate (regression test covers this branch). Inner row uses
  `z.looseObject` so segment fields beyond `type` (e.g. `duration`,
  `average_watts`) ride through without a schema bump. [a93734a]
- Snapshot harness (`tools/snapshot-section-11.ts`) emits
  `derived["has_intervals"] = { "<activity_id>": true|false, ... }` with
  keys sorted ascending via `sorted(d.keys())` before `json.dump`. The
  predicate is implemented in the harness prologue line-by-line from
  `sync.py:7866-7873`. The intervals slice is reparsed from
  `FIXTURE_JSON` to bypass `_TrackedDict` instrumentation — otherwise
  branch (e) (entry present but no `intervals` key) would trip a
  spurious missing-key event on the inner `_entry.get("intervals")`
  call. `FIXTURE.intervals` is added to `_ALLOWED_OPTIONAL_PATHS` so
  fixtures without the key don't blow the contract gate. [a93734a]
- `populated-benchmark-and-consistency.json` extended with two
  out-of-28d-window activities (`pbc4` on 2026-04-05, `pbc5` on
  2026-04-01) plus a 4-entry `intervals` lookup covering all 5
  branches:

  | Activity | Lookup entry | Branch |
  |---|---|---|
  | pbc1 (in 7d window) | `{ intervals: [{ type: "WORK" }] }` | (a) WORK → true |
  | pbc2 (in 7d window) | `{ intervals: [{ type: "RECOVERY" }] }` | (b) RECOVERY-only → false (v3.106 regression test) |
  | pbc3 (in 7d window) | (not in lookup) | (d) absent → false (default) |
  | pbc4 (outside 28d) | `{ intervals: [] }` | (c) empty list → false |
  | pbc5 (outside 28d) | `{ dfa: { quality: ... } }` | (e) entry without `intervals` key → false |

  The two new activities sit **before** the 28d window (frozenNow's
  28d slice is `[2026-04-13, 2026-05-10]`); they never enter the 7d
  or 28d activity slices and therefore don't drift any existing
  metric's snapshot. Verified via `git diff` after `pnpm
  snapshot:section-11`: only `manifest.json` (one new metric in the
  list) and the 9 new `has_intervals.json` files appear — no other
  snapshot file changed. [a93734a]
- 11 focused unit tests in `compliance-and-body.test.ts` for
  `computeHasIntervals`: each of the 5 branches (a)–(e), empty-
  activities edge case, numeric-id stringification (mirrors
  `str(act.get('id'))` at sync.py:7870), key sort ordering (uses
  non-integer-like keys because V8 iterates integer-like string keys
  in numeric order regardless of insertion order), mixed-segment list
  with both WORK and RECOVERY (defends `any()` semantics), and the
  `FixtureSchema.intervals` `.optional()` regression (fixture without
  `intervals` classifies cleanly). [a93734a]


## Test plan

- [x] Task `Verify:` commands exit 0 (per Phase 1 critique)
- [x] `.ralph/smoke.sh` (full, including parity gate) exits 0 — defense-in-depth re-run
- [x] Fresh-context critic verdict: SHIPPED (see `.ralph/iters/has_intervals/critique.md` locally)
- [x] No rubric dimension scored < 3
