### PR TITLE
feat(core): port weight_signal — gated W/kg block trajectory + weekly weight stats

### DIFF
--- a/packages/core/src/reference/metrics/bodycomp.test.ts
+++ b/packages/core/src/reference/metrics/bodycomp.test.ts
@@ -1,0 +1,476 @@
+import { describe, expect, it } from "vitest";
+
+import type { FixtureShape, WellnessDay } from "../schemas/inputs.js";
+import { computeWeightSignal } from "./bodycomp.js";
+import type { MetricInput } from "./metric-input.js";
+
+const FROZEN_NOW = "2026-05-10T12:00:00";
+const TODAY = "2026-05-10";
+
+function ymdDaysBefore(daysBefore: number): string {
+  const [y, m, d] = TODAY.split("-").map(Number) as [number, number, number];
+  const ms = Date.UTC(y, m - 1, d) - daysBefore * 86_400_000;
+  const dt = new Date(ms);
+  const yy = String(dt.getUTCFullYear()).padStart(4, "0");
+  const mm = String(dt.getUTCMonth() + 1).padStart(2, "0");
+  const dd = String(dt.getUTCDate()).padStart(2, "0");
+  return `${yy}-${mm}-${dd}`;
+}
+
+function wellness(rows: { date: string; weight: number | null }[]): WellnessDay[] {
+  return rows.map((r) => ({
+    id: r.date,
+    weight: r.weight,
+    restingHR: null,
+    hrv: null,
+    sleepSecs: null,
+    sleepQuality: null,
+  })) as WellnessDay[];
+}
+
+function fixture(
+  partial: Partial<FixtureShape> & { eftp?: number },
+): FixtureShape {
+  return {
+    activities: [],
+    wellness: [],
+    ftp_history: [],
+    ...partial,
+  } as unknown as FixtureShape;
+}
+
+function input(f: FixtureShape, frozenNow = FROZEN_NOW): MetricInput {
+  return { fixture: f, frozenNow };
+}
+
+describe("computeWeightSignal", () => {
+  it("returns null when no weight entries exist", () => {
+    expect(
+      computeWeightSignal(
+        input(fixture({ wellness: wellness([]) })),
+      ),
+    ).toBeNull();
+  });
+
+  it("returns null when all weight entries are null or zero", () => {
+    expect(
+      computeWeightSignal(
+        input(
+          fixture({
+            wellness: wellness([
+              { date: TODAY, weight: null },
+              { date: ymdDaysBefore(1), weight: 0 },
+            ]),
+          }),
+        ),
+      ),
+    ).toBeNull();
+  });
+
+  it("skips entries with malformed dates", () => {
+    const f = fixture({
+      wellness: [
+        { id: "garbage", weight: 70 } as WellnessDay,
+        { id: "2026-02-30", weight: 70 } as WellnessDay, // calendar-invalid
+      ],
+    });
+    expect(computeWeightSignal(input(f))).toBeNull();
+  });
+
+  describe("weight_latest", () => {
+    it("emits both fields when latest is within 14 days", () => {
+      const r = computeWeightSignal(
+        input(
+          fixture({
+            wellness: wellness([{ date: ymdDaysBefore(14), weight: 71.5 }]),
+          }),
+        ),
+      );
+      expect(r?.weight_latest_kg).toBe(71.5);
+      expect(r?.weight_latest_date).toBe(ymdDaysBefore(14));
+    });
+
+    it("omits weight_latest_kg when staleness exceeds 14 days", () => {
+      const r = computeWeightSignal(
+        input(
+          fixture({
+            wellness: wellness([{ date: ymdDaysBefore(15), weight: 71.5 }]),
+          }),
+        ),
+      );
+      expect(r).toBeNull(); // no other gates passed → whole block null
+    });
+
+    it("rounds to 1dp via banker's rounding", () => {
+      // 71.25 → half-to-even → 71.2
+      const r = computeWeightSignal(
+        input(
+          fixture({
+            wellness: wellness([{ date: TODAY, weight: 71.25 }]),
+          }),
+        ),
+      );
+      expect(r?.weight_latest_kg).toBe(71.2);
+    });
+  });
+
+  describe("wkg_current — FTP source resolution", () => {
+    it("uses tested FTP when current_ftp_outdoor is set", () => {
+      const r = computeWeightSignal(
+        input(
+          fixture({
+            wellness: wellness([{ date: TODAY, weight: 70.0 }]),
+            current_ftp_outdoor: 280,
+          }),
+        ),
+      );
+      expect(r?.wkg_current).toBe(4);
+      expect(r?.wkg_ftp_source).toBe("tested");
+    });
+
+    it("falls back to eftp when tested FTP is absent", () => {
+      const r = computeWeightSignal(
+        input(
+          fixture({
+            wellness: wellness([{ date: TODAY, weight: 70.0 }]),
+            eftp: 245,
+          }),
+        ),
+      );
+      expect(r?.wkg_current).toBe(3.5);
+      expect(r?.wkg_ftp_source).toBe("eftp");
+    });
+
+    it("falls back to eftp when tested FTP is zero", () => {
+      const r = computeWeightSignal(
+        input(
+          fixture({
+            wellness: wellness([{ date: TODAY, weight: 70.0 }]),
+            current_ftp_outdoor: 0,
+            eftp: 245,
+          }),
+        ),
+      );
+      expect(r?.wkg_ftp_source).toBe("eftp");
+    });
+
+    it("does NOT cross-read indoor FTP for the tested source", () => {
+      // Only current_ftp_indoor present → tested branch should NOT fire.
+      const r = computeWeightSignal(
+        input(
+          fixture({
+            wellness: wellness([{ date: TODAY, weight: 70.0 }]),
+            current_ftp_indoor: 280,
+          }),
+        ),
+      );
+      expect(r?.wkg_current).toBeUndefined();
+      expect(r?.wkg_ftp_source).toBeUndefined();
+    });
+
+    it("emits ftp_setting_date from outdoor history newest entry", () => {
+      const r = computeWeightSignal(
+        input(
+          fixture({
+            wellness: wellness([{ date: TODAY, weight: 70.0 }]),
+            current_ftp_outdoor: 280,
+            ftp_history_outdoor: {
+              "2026-01-01": 250,
+              "2026-04-15": 280,
+              "2026-03-15": 270,
+            },
+          }),
+        ),
+      );
+      expect(r?.ftp_setting_date).toBe("2026-04-15");
+    });
+
+    it("falls back to indoor history when outdoor is empty", () => {
+      const r = computeWeightSignal(
+        input(
+          fixture({
+            wellness: wellness([{ date: TODAY, weight: 70.0 }]),
+            current_ftp_outdoor: 280,
+            ftp_history_indoor: {
+              "2026-02-01": 270,
+              "2026-04-01": 280,
+            },
+          }),
+        ),
+      );
+      expect(r?.ftp_setting_date).toBe("2026-04-01");
+    });
+
+    it("omits ftp_setting_date when neither history is populated", () => {
+      const r = computeWeightSignal(
+        input(
+          fixture({
+            wellness: wellness([{ date: TODAY, weight: 70.0 }]),
+            current_ftp_outdoor: 280,
+          }),
+        ),
+      );
+      expect(r?.wkg_current).toBe(4);
+      expect(r?.ftp_setting_date).toBeUndefined();
+    });
+
+    it("omits wkg_current when no FTP source resolves", () => {
+      const r = computeWeightSignal(
+        input(
+          fixture({
+            wellness: wellness([{ date: TODAY, weight: 70.0 }]),
+          }),
+        ),
+      );
+      expect(r?.weight_latest_kg).toBe(70);
+      expect(r?.wkg_current).toBeUndefined();
+    });
+  });
+
+  describe("wkg_block_* — boundary windows", () => {
+    it("emits the block trio when both boundary windows are populated", () => {
+      const r = computeWeightSignal(
+        input(
+          fixture({
+            wellness: wellness([
+              // First-4 window [today-27, today-24]
+              { date: ymdDaysBefore(25), weight: 72.0 },
+              // Last-4 window [today-3, today]
+              { date: TODAY, weight: 70.0 },
+            ]),
+            current_ftp_outdoor: 280,
+          }),
+        ),
+      );
+      expect(r?.wkg_block_start).toBe(3.89); // 280/72.0
+      expect(r?.wkg_block_end).toBe(4); // 280/70.0
+      expect(r?.wkg_block_delta).toBe(0.11);
+    });
+
+    it("omits block trio when first-4 window is empty", () => {
+      const r = computeWeightSignal(
+        input(
+          fixture({
+            wellness: wellness([
+              { date: ymdDaysBefore(20), weight: 72.0 }, // OUTSIDE first-4
+              { date: TODAY, weight: 70.0 },
+            ]),
+            current_ftp_outdoor: 280,
+          }),
+        ),
+      );
+      expect(r?.wkg_block_start).toBeUndefined();
+      expect(r?.wkg_block_end).toBeUndefined();
+    });
+
+    it("omits block trio when last-4 window is empty", () => {
+      const r = computeWeightSignal(
+        input(
+          fixture({
+            wellness: wellness([
+              { date: ymdDaysBefore(25), weight: 72.0 },
+              { date: ymdDaysBefore(5), weight: 70.0 }, // OUTSIDE last-4
+            ]),
+            current_ftp_outdoor: 280,
+          }),
+        ),
+      );
+      expect(r?.wkg_block_start).toBeUndefined();
+    });
+
+    it("nearestInRange picks newest on a tied distance (newest-first iteration)", () => {
+      // Anchor for last-4 is today (offset 0). Same distance both directions
+      // is impossible inside [today-3, today] because today itself is the anchor.
+      // Construct a tie within first-4: anchor is today-27. Days today-26 and
+      // today-25 are both distance 1 and 2 — different distances. To force a
+      // tie we need symmetric distances. Use anchor today-25 (mid of [today-27,
+      // today-24]): days today-27 and today-23 would be ±2 — but today-23 is
+      // outside the range. Instead test that on a tied window with two entries
+      // newest-first iteration picks the newer.
+      //
+      // Setup: first-4 window [today-27, today-24], anchor today-27.
+      //   today-26 (dist 1) and today-26 (dist 1) — same date can't tie.
+      //   today-25 (dist 2) and today-24 (dist 3) — different.
+      // The newest-first tiebreak is exercised when distances are equal.
+      // We force a tie by constructing two entries at SAME distance via
+      // distinct dates: today-27 (dist 0) and today-25 (dist 2) — different.
+      // The strict `< bestDist` (not `<=`) tiebreak means the FIRST seen wins,
+      // which on newest-first means the most-recent entry. Verify with two
+      // entries at distance 2 from anchor today-27: today-25 (dist 2) is the
+      // only such day (today-29 would be out-of-range). So no real tie exists
+      // in the first-4 anchor=today-27 config.
+      //
+      // Construct an artificial tie via the last-4 window with anchor=today:
+      // today-1 (dist 1), today-1 again is impossible. Tie requires equidistant
+      // dates from anchor; only achievable when the window straddles the anchor.
+      // For the last-4 window [today-3, today], anchor=today, no two distinct
+      // dates can tie. For the first-4 window [today-27, today-24], anchor=
+      // today-27, no two dates can tie either (each date is uniquely distant).
+      //
+      // Conclusion: the upstream's _nearest_in_range cannot produce a tie under
+      // the calling convention (both anchors are at window boundaries). The
+      // newest-first iteration is still the documented protocol; we mirror it
+      // and rely on parity-gate bit-identity for tiebreak ordering rather than
+      // a unit-level forced tie.
+      expect(true).toBe(true);
+    });
+  });
+
+  describe("weight_7d_avg_kg", () => {
+    it("emits when ≥4 weigh-ins in trailing 7d", () => {
+      const r = computeWeightSignal(
+        input(
+          fixture({
+            wellness: wellness([
+              { date: TODAY, weight: 70.0 },
+              { date: ymdDaysBefore(1), weight: 70.5 },
+              { date: ymdDaysBefore(2), weight: 71.0 },
+              { date: ymdDaysBefore(3), weight: 71.5 },
+            ]),
+          }),
+        ),
+      );
+      expect(r?.weight_7d_avg_kg).toBe(70.8); // (70+70.5+71+71.5)/4 = 70.75 → 70.8 (half-to-even)
+    });
+
+    it("omits when <4 weigh-ins in trailing 7d", () => {
+      const r = computeWeightSignal(
+        input(
+          fixture({
+            wellness: wellness([
+              { date: TODAY, weight: 70.0 },
+              { date: ymdDaysBefore(1), weight: 70.5 },
+              { date: ymdDaysBefore(2), weight: 71.0 },
+            ]),
+          }),
+        ),
+      );
+      expect(r?.weight_7d_avg_kg).toBeUndefined();
+    });
+
+    it("excludes entries outside the trailing-7d window", () => {
+      const r = computeWeightSignal(
+        input(
+          fixture({
+            wellness: wellness([
+              { date: TODAY, weight: 70.0 },
+              { date: ymdDaysBefore(1), weight: 70.5 },
+              { date: ymdDaysBefore(2), weight: 71.0 },
+              // today-7 is outside [today-6, today]
+              { date: ymdDaysBefore(7), weight: 71.5 },
+            ]),
+          }),
+        ),
+      );
+      expect(r?.weight_7d_avg_kg).toBeUndefined();
+    });
+  });
+
+  describe("weight_28d_slope_kg_per_week", () => {
+    it("emits when ≥14 weigh-ins in trailing 28d", () => {
+      const rows: { date: string; weight: number }[] = [];
+      for (let i = 0; i < 14; i++) {
+        rows.push({
+          date: ymdDaysBefore(i * 2),
+          weight: 70 + i * 0.1, // increases as i increases (older dates)
+        });
+      }
+      const r = computeWeightSignal(input(fixture({ wellness: wellness(rows) })));
+      // Newer dates have lower weight → negative slope (weight decreasing over time).
+      expect(r?.weight_28d_slope_kg_per_week).toBeLessThan(0);
+    });
+
+    it("omits when <14 weigh-ins in trailing 28d", () => {
+      const rows: { date: string; weight: number }[] = [];
+      for (let i = 0; i < 13; i++) {
+        rows.push({ date: ymdDaysBefore(i * 2), weight: 70 + i * 0.1 });
+      }
+      const r = computeWeightSignal(input(fixture({ wellness: wellness(rows) })));
+      expect(r?.weight_28d_slope_kg_per_week).toBeUndefined();
+    });
+
+    it("guards against the all-same-day degenerate case (den === 0)", () => {
+      // Construct 14 entries all on the same day. den = Σ(x − mean)² = 0
+      // because every x is the same. Slope should be omitted.
+      // Wellness dedup happens upstream typically, but synthesise distinct
+      // ids with the same date prefix to exercise the gate.
+      const rows: WellnessDay[] = [];
+      for (let i = 0; i < 14; i++) {
+        rows.push({
+          id: `${TODAY}#${i}`, // .slice(0,10) → all "2026-05-10"
+          weight: 70 + i * 0.1,
+          restingHR: null,
+          hrv: null,
+          sleepSecs: null,
+          sleepQuality: null,
+        } as WellnessDay);
+      }
+      const r = computeWeightSignal(input(fixture({ wellness: rows })));
+      expect(r?.weight_28d_slope_kg_per_week).toBeUndefined();
+    });
+
+    it("rounds slope to 3dp via banker's rounding", () => {
+      const rows: { date: string; weight: number }[] = [];
+      for (let i = 0; i < 14; i++) {
+        rows.push({ date: ymdDaysBefore(i * 2), weight: 70 + i * 0.01 });
+      }
+      const r = computeWeightSignal(
+        input(fixture({ wellness: wellness(rows) })),
+      );
+      expect(r?.weight_28d_slope_kg_per_week).toBeDefined();
+      // 3-decimal precision verified by parity fixture; here we just assert
+      // it lands at 3dp and not 1dp.
+      const s = r!.weight_28d_slope_kg_per_week!;
+      const stringified = s.toString();
+      // It must be a finite number, three or fewer decimal places.
+      expect(Number.isFinite(s)).toBe(true);
+      expect(stringified).toMatch(/^-?\d+(\.\d{1,3})?$/);
+    });
+  });
+
+  describe("populated-branch parity fixture", () => {
+    it("emits all four gated groups when the populated fixture's gates fire", () => {
+      // Mirror the populated-benchmark-and-consistency fixture's weight signal
+      // (gates exercised: latest ≤14d, FTP=tested, wkg_block trio, 7d-avg,
+      // 28d-slope). The exact values are pinned by the parity gate; here we
+      // just verify the SET of keys present.
+      const rows: { date: string; weight: number }[] = [
+        { date: "2026-05-10", weight: 72.0 },
+        { date: "2026-05-09", weight: 72.1 },
+        { date: "2026-05-08", weight: 72.2 },
+        { date: "2026-05-07", weight: 72.0 },
+        { date: "2026-05-06", weight: 71.9 },
+        { date: "2026-05-05", weight: 72.0 },
+        { date: "2026-05-04", weight: 72.1 },
+        { date: "2026-05-02", weight: 72.3 },
+        { date: "2026-04-30", weight: 72.4 },
+        { date: "2026-04-28", weight: 72.5 },
+        { date: "2026-04-25", weight: 72.6 },
+        { date: "2026-04-22", weight: 72.7 },
+        { date: "2026-04-19", weight: 72.8 },
+        { date: "2026-04-15", weight: 72.9 },
+      ];
+      const r = computeWeightSignal(
+        input(
+          fixture({
+            wellness: wellness(rows),
+            current_ftp_outdoor: 270,
+            ftp_history_outdoor: { "2026-04-15": 265 },
+          }),
+        ),
+      );
+      expect(r).toEqual({
+        weight_latest_kg: 72,
+        weight_latest_date: "2026-05-10",
+        wkg_current: 3.75,
+        wkg_ftp_source: "tested",
+        ftp_setting_date: "2026-04-15",
+        wkg_block_start: 3.7,
+        wkg_block_end: 3.75,
+        wkg_block_delta: 0.05,
+        weight_7d_avg_kg: 72,
+        weight_28d_slope_kg_per_week: -0.279,
+      });
+    });
+  });
+});

--- a/packages/core/src/reference/metrics/bodycomp.test.ts
+++ b/packages/core/src/reference/metrics/bodycomp.test.ts
@@ -277,43 +277,6 @@ describe("computeWeightSignal", () => {
       );
       expect(r?.wkg_block_start).toBeUndefined();
     });
-
-    it("nearestInRange picks newest on a tied distance (newest-first iteration)", () => {
-      // Anchor for last-4 is today (offset 0). Same distance both directions
-      // is impossible inside [today-3, today] because today itself is the anchor.
-      // Construct a tie within first-4: anchor is today-27. Days today-26 and
-      // today-25 are both distance 1 and 2 — different distances. To force a
-      // tie we need symmetric distances. Use anchor today-25 (mid of [today-27,
-      // today-24]): days today-27 and today-23 would be ±2 — but today-23 is
-      // outside the range. Instead test that on a tied window with two entries
-      // newest-first iteration picks the newer.
-      //
-      // Setup: first-4 window [today-27, today-24], anchor today-27.
-      //   today-26 (dist 1) and today-26 (dist 1) — same date can't tie.
-      //   today-25 (dist 2) and today-24 (dist 3) — different.
-      // The newest-first tiebreak is exercised when distances are equal.
-      // We force a tie by constructing two entries at SAME distance via
-      // distinct dates: today-27 (dist 0) and today-25 (dist 2) — different.
-      // The strict `< bestDist` (not `<=`) tiebreak means the FIRST seen wins,
-      // which on newest-first means the most-recent entry. Verify with two
-      // entries at distance 2 from anchor today-27: today-25 (dist 2) is the
-      // only such day (today-29 would be out-of-range). So no real tie exists
-      // in the first-4 anchor=today-27 config.
-      //
-      // Construct an artificial tie via the last-4 window with anchor=today:
-      // today-1 (dist 1), today-1 again is impossible. Tie requires equidistant
-      // dates from anchor; only achievable when the window straddles the anchor.
-      // For the last-4 window [today-3, today], anchor=today, no two distinct
-      // dates can tie. For the first-4 window [today-27, today-24], anchor=
-      // today-27, no two dates can tie either (each date is uniquely distant).
-      //
-      // Conclusion: the upstream's _nearest_in_range cannot produce a tie under
-      // the calling convention (both anchors are at window boundaries). The
-      // newest-first iteration is still the documented protocol; we mirror it
-      // and rely on parity-gate bit-identity for tiebreak ordering rather than
-      // a unit-level forced tie.
-      expect(true).toBe(true);
-    });
   });
 
   describe("weight_7d_avg_kg", () => {

--- a/packages/core/src/reference/metrics/bodycomp.ts
+++ b/packages/core/src/reference/metrics/bodycomp.ts
@@ -1,0 +1,239 @@
+/**
+ * Reference layer — body-composition signals derived from the wellness
+ * stream and the cycling FTP source.
+ *
+ * Currently houses `computeWeightSignal` only: a multi-field gated
+ * emission summarising the trailing 28-day weight series. Each output
+ * sub-field is independently gated (latest-14d, first-4/last-4 boundary
+ * windows for the block trajectory, ≥4-in-7d average, ≥14-in-28d
+ * least-squares slope) and **absent from the returned dict** when its
+ * gate fails — `null` is reserved for the all-fail case where every
+ * sub-field would be absent.
+ *
+ * The module is sized for the broader body-composition class (a future
+ * lean-mass signal would land alongside) rather than just the W/kg block;
+ * if no sibling metric materialises before another touch-up, rename to
+ * `weight-signal.ts`.
+ */
+
+import {
+  getCurrentFtpOutdoor,
+  getEftp,
+  getFtpHistoryIndoor,
+  getFtpHistoryOutdoor,
+  getWellnessExtendedWeight,
+  type MetricInput,
+} from "./metric-input.js";
+import { isoToMs, parseIsoMs } from "./date-helpers.js";
+import { pythonSum } from "./statistics.js";
+import { roundHalfEven } from "./rounding.js";
+
+const MS_PER_DAY = 86_400_000;
+const BLOCK_WINDOW_DAYS = 28;
+const BOUNDARY_WIDTH_DAYS = 4;
+
+export type FtpSource = "tested" | "eftp";
+
+/**
+ * Trailing W/kg block trajectory plus weekly weight stats. Every field is
+ * optional: a failed gate REMOVES the key (never writes `null`), so the
+ * downstream layer treats absence as the "omit this section" signal.
+ * The whole object is `null` when no gate fired.
+ */
+export interface WeightSignal {
+  weight_latest_kg?: number;
+  weight_latest_date?: string;
+  wkg_current?: number;
+  wkg_ftp_source?: FtpSource;
+  ftp_setting_date?: string;
+  wkg_block_start?: number;
+  wkg_block_end?: number;
+  wkg_block_delta?: number;
+  weight_7d_avg_kg?: number;
+  weight_28d_slope_kg_per_week?: number;
+}
+
+interface DatedWeight {
+  dateMs: number;
+  dateStr: string;
+  weight: number;
+}
+
+// Pick the weigh-in whose date falls within [lowMs, highMs] and is closest
+// to anchorMs (in calendar-day distance). Iterates newest-first with a
+// strictly-less-than tiebreak so the first-seen (newest) row wins on a
+// tied calendar distance — mirrors the upstream's `entries` ordering.
+function nearestInRange(
+  newestFirst: readonly DatedWeight[],
+  lowMs: number,
+  highMs: number,
+  anchorMs: number,
+): number | null {
+  let best: number | null = null;
+  let bestDist: number | null = null;
+  for (const e of newestFirst) {
+    if (e.dateMs < lowMs || e.dateMs > highMs) continue;
+    const dist = Math.abs(Math.floor((e.dateMs - anchorMs) / MS_PER_DAY));
+    if (bestDist === null || dist < bestDist) {
+      best = e.weight;
+      bestDist = dist;
+    }
+  }
+  return best;
+}
+
+export function computeWeightSignal(
+  input: MetricInput,
+): WeightSignal | null {
+  const wellness = getWellnessExtendedWeight(input);
+
+  const todayStr = input.frozenNow.slice(0, 10);
+  const todayMs = isoToMs(todayStr);
+
+  // Collect dated weight entries — drop nulls, zeros, missing/malformed dates.
+  const entries: DatedWeight[] = [];
+  for (const w of wellness) {
+    const wt = w.weight;
+    if (wt === null || wt === undefined || wt === 0) continue;
+    const dateStr = (w.id ?? "").slice(0, 10);
+    if (!dateStr) continue;
+    const ms = parseIsoMs(dateStr);
+    if (ms === null) continue;
+    entries.push({ dateMs: ms, dateStr, weight: wt });
+  }
+
+  if (entries.length === 0) return null;
+
+  // Newest-first
+  entries.sort((a, b) => b.dateMs - a.dateMs);
+
+  const block: WeightSignal = {};
+
+  // weight_latest_kg / weight_latest_date — latest weigh-in within 14 days.
+  const latest = entries[0]!;
+  const latestAgeDays = Math.floor((todayMs - latest.dateMs) / MS_PER_DAY);
+  if (latestAgeDays >= 0 && latestAgeDays <= 14) {
+    block.weight_latest_kg = roundHalfEven(latest.weight, 1);
+    block.weight_latest_date = latest.dateStr;
+  }
+
+  // FTP source — tested cycling.ftp preferred, eFTP fallback. Indoor FTP
+  // is unused in this metric per the upstream protocol (sync.py:2871
+  // reads cycling.ftp = outdoor only). ftp_setting_date still falls back
+  // to the indoor history newest entry when outdoor history is empty
+  // (sync.py:2882-2890).
+  const testedFtp = getCurrentFtpOutdoor(input);
+  const eftp = getEftp(input);
+
+  let ftpUsed: number | null = null;
+  let ftpSource: FtpSource | null = null;
+  let ftpSettingDate: string | null = null;
+
+  if (testedFtp !== null && testedFtp !== 0) {
+    ftpUsed = testedFtp;
+    ftpSource = "tested";
+    const outdoorDates = Object.keys(getFtpHistoryOutdoor(input))
+      .slice()
+      .sort()
+      .reverse();
+    const indoorDates = Object.keys(getFtpHistoryIndoor(input))
+      .slice()
+      .sort()
+      .reverse();
+    if (outdoorDates.length > 0) {
+      ftpSettingDate = outdoorDates[0]!;
+    } else if (indoorDates.length > 0) {
+      ftpSettingDate = indoorDates[0]!;
+    }
+  } else if (eftp !== null && eftp !== 0) {
+    ftpUsed = eftp;
+    ftpSource = "eftp";
+  }
+
+  // wkg_current — needs weight_latest + an FTP source.
+  if (
+    block.weight_latest_kg !== undefined &&
+    ftpUsed !== null &&
+    block.weight_latest_kg > 0
+  ) {
+    block.wkg_current = roundHalfEven(ftpUsed / block.weight_latest_kg, 2);
+    block.wkg_ftp_source = ftpSource!;
+    if (ftpSettingDate !== null) {
+      block.ftp_setting_date = ftpSettingDate;
+    }
+  }
+
+  // Block trajectory: first-4 days of the trailing 28d window (anchored at
+  // day -27) and last-4 days (anchored at today). Both endpoints use the
+  // CURRENT FTP, so the delta isolates weight change across the window.
+  const first4HighMs =
+    todayMs - (BLOCK_WINDOW_DAYS - BOUNDARY_WIDTH_DAYS) * MS_PER_DAY;
+  const first4LowMs = todayMs - (BLOCK_WINDOW_DAYS - 1) * MS_PER_DAY;
+  const last4LowMs = todayMs - (BOUNDARY_WIDTH_DAYS - 1) * MS_PER_DAY;
+  const last4HighMs = todayMs;
+
+  const weightAtStart = nearestInRange(
+    entries,
+    first4LowMs,
+    first4HighMs,
+    first4LowMs,
+  );
+  const weightAtEnd = nearestInRange(
+    entries,
+    last4LowMs,
+    last4HighMs,
+    todayMs,
+  );
+
+  if (weightAtStart !== null && weightAtEnd !== null && ftpUsed !== null) {
+    block.wkg_block_start = roundHalfEven(ftpUsed / weightAtStart, 2);
+    block.wkg_block_end = roundHalfEven(ftpUsed / weightAtEnd, 2);
+    block.wkg_block_delta = roundHalfEven(
+      block.wkg_block_end - block.wkg_block_start,
+      2,
+    );
+  }
+
+  // weight_7d_avg_kg — ≥4 weigh-ins in the trailing 7 days.
+  const sevenDCutoffMs = todayMs - 6 * MS_PER_DAY;
+  const sevenDWeights = entries
+    .filter((e) => e.dateMs >= sevenDCutoffMs)
+    .map((e) => e.weight);
+  if (sevenDWeights.length >= 4) {
+    const avgKg = pythonSum(sevenDWeights) / sevenDWeights.length;
+    block.weight_7d_avg_kg = roundHalfEven(avgKg, 1);
+  }
+
+  // weight_28d_slope_kg_per_week — least-squares slope over the trailing 28d,
+  // multiplied by 7 to convert per-day → per-week. ≥14 weigh-ins required.
+  // Mirrors sync.py:2942-2960's denom > 0 gate, which protects against the
+  // degenerate case of all weigh-ins on a single day.
+  const twentyEightDCutoffMs = todayMs - (BLOCK_WINDOW_DAYS - 1) * MS_PER_DAY;
+  const slopePairs = entries.filter((e) => e.dateMs >= twentyEightDCutoffMs);
+  if (slopePairs.length >= 14) {
+    const n = slopePairs.length;
+    const xs = slopePairs.map((e) =>
+      Math.floor((e.dateMs - twentyEightDCutoffMs) / MS_PER_DAY),
+    );
+    const ys = slopePairs.map((e) => e.weight);
+    const meanX = pythonSum(xs) / n;
+    const meanY = pythonSum(ys) / n;
+    const numTerms: number[] = [];
+    const denTerms: number[] = [];
+    for (let i = 0; i < n; i++) {
+      const dx = xs[i]! - meanX;
+      const dy = ys[i]! - meanY;
+      numTerms.push(dx * dy);
+      denTerms.push(dx * dx);
+    }
+    const num = pythonSum(numTerms);
+    const den = pythonSum(denTerms);
+    if (den > 0) {
+      const slopeKgPerWeek = (num / den) * 7;
+      block.weight_28d_slope_kg_per_week = roundHalfEven(slopeKgPerWeek, 3);
+    }
+  }
+
+  if (Object.keys(block).length === 0) return null;
+  return block;
+}

--- a/packages/core/src/reference/metrics/metric-input.ts
+++ b/packages/core/src/reference/metrics/metric-input.ts
@@ -73,13 +73,8 @@ export function getWellnessExtendedWeight(input: MetricInput): WellnessDay[] {
   return input.fixture.wellness;
 }
 
-// Optional top-level fixture field surfacing the eFTP fallback for
-// `_build_weight_signal`'s FTP source resolution. Not declared on
-// FixtureSchema (the populated fixture exercises the tested-FTP branch;
-// the eFTP path is covered by unit tests that synthesise MetricInput
-// directly), so this accessor reads via the loose-object ride-through.
+// Top-level eFTP fallback for `_build_weight_signal`'s FTP source
+// resolution when tested outdoor FTP is null. See FixtureSchema.eftp.
 export function getEftp(input: MetricInput): number | null {
-  const raw = (input.fixture as Record<string, unknown>).eftp;
-  if (typeof raw === "number") return raw;
-  return null;
+  return input.fixture.eftp ?? null;
 }

--- a/packages/core/src/reference/metrics/metric-input.ts
+++ b/packages/core/src/reference/metrics/metric-input.ts
@@ -2,6 +2,7 @@ import type {
   Activity,
   FixtureShape,
   PlannedEvent,
+  WellnessDay,
 } from "../schemas/inputs.js";
 
 /** Per-activity intervals entry projected to the fields the Reference layer
@@ -64,4 +65,21 @@ export function getFtpHistoryOutdoor(
 // IntervalsEntry surface; the schema already validates the shape.
 export function getIntervalsLookup(input: MetricInput): IntervalsLookup {
   return (input.fixture.intervals ?? {}) as IntervalsLookup;
+}
+
+/** Trailing-28d wellness rows in fixture order. Weight-signal callers
+ *  filter by date internally — no slicing happens here. */
+export function getWellnessExtendedWeight(input: MetricInput): WellnessDay[] {
+  return input.fixture.wellness;
+}
+
+// Optional top-level fixture field surfacing the eFTP fallback for
+// `_build_weight_signal`'s FTP source resolution. Not declared on
+// FixtureSchema (the populated fixture exercises the tested-FTP branch;
+// the eFTP path is covered by unit tests that synthesise MetricInput
+// directly), so this accessor reads via the loose-object ride-through.
+export function getEftp(input: MetricInput): number | null {
+  const raw = (input.fixture as Record<string, unknown>).eftp;
+  if (typeof raw === "number") return raw;
+  return null;
 }

--- a/packages/core/src/reference/metrics/registry.ts
+++ b/packages/core/src/reference/metrics/registry.ts
@@ -8,6 +8,7 @@
  * `packages/core/tests/reference-parity.test.ts` picks it up automatically.
  */
 
+import { computeWeightSignal } from "./bodycomp.js";
 import {
   computeBenchmarkIndoor,
   computeBenchmarkOutdoor,
@@ -75,4 +76,5 @@ export const METRIC_REGISTRY: Record<string, MetricRegistryEntry> = {
   benchmark_outdoor: { compute: computeBenchmarkOutdoor },
   has_intervals: { compute: computeHasIntervals },
   effort_response_signal: { compute: computeEffortResponseSignal },
+  weight_signal: { compute: computeWeightSignal },
 };

--- a/packages/core/src/reference/schemas/inputs.ts
+++ b/packages/core/src/reference/schemas/inputs.ts
@@ -225,6 +225,13 @@ export const FixtureSchema = z
     ftp_history_indoor: z.record(z.string(), z.number()).optional(),
     ftp_history_outdoor: z.record(z.string(), z.number()).optional(),
 
+    // Top-level eFTP fallback consumed by `_build_weight_signal`'s FTP
+    // source resolution when tested outdoor FTP is null. Distinct from
+    // `sportInfo[].eftp` (inner field, used by tools/fetch-real-athlete.ts
+    // to derive ftp_history). Optional — current golden fixtures don't
+    // populate this branch; the eFTP path is exercised by unit tests.
+    eftp: z.number().nullable().optional(),
+
     // Per-activity intervals lookup, mirroring upstream's intervals.json
     // surface (a distinct API endpoint from activities). Keyed by activity
     // id as a string. Optional so existing fixtures without the key still

--- a/packages/core/tests/fixtures/golden/populated-benchmark-and-consistency.json
+++ b/packages/core/tests/fixtures/golden/populated-benchmark-and-consistency.json
@@ -139,6 +139,62 @@
       "hrv": 65,
       "sleepSecs": 24300,
       "sleepQuality": 75
+    },
+    {
+      "id": "2026-05-02",
+      "weight": 72.3,
+      "restingHR": null,
+      "hrv": null,
+      "sleepSecs": null,
+      "sleepQuality": null
+    },
+    {
+      "id": "2026-04-30",
+      "weight": 72.4,
+      "restingHR": null,
+      "hrv": null,
+      "sleepSecs": null,
+      "sleepQuality": null
+    },
+    {
+      "id": "2026-04-28",
+      "weight": 72.5,
+      "restingHR": null,
+      "hrv": null,
+      "sleepSecs": null,
+      "sleepQuality": null
+    },
+    {
+      "id": "2026-04-25",
+      "weight": 72.6,
+      "restingHR": null,
+      "hrv": null,
+      "sleepSecs": null,
+      "sleepQuality": null
+    },
+    {
+      "id": "2026-04-22",
+      "weight": 72.7,
+      "restingHR": null,
+      "hrv": null,
+      "sleepSecs": null,
+      "sleepQuality": null
+    },
+    {
+      "id": "2026-04-19",
+      "weight": 72.8,
+      "restingHR": null,
+      "hrv": null,
+      "sleepSecs": null,
+      "sleepQuality": null
+    },
+    {
+      "id": "2026-04-15",
+      "weight": 72.9,
+      "restingHR": null,
+      "hrv": null,
+      "sleepSecs": null,
+      "sleepQuality": null
     }
   ],
   "ftp_history": [],

--- a/packages/core/tests/fixtures/snapshots/boundary-monotony/weight_signal.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-monotony/weight_signal.json
@@ -1,0 +1,8 @@
+{
+  "metric": "weight_signal",
+  "athlete": "boundary-monotony",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-sum-strain/weight_signal.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-sum-strain/weight_signal.json
@@ -1,0 +1,8 @@
+{
+  "metric": "weight_signal",
+  "athlete": "boundary-sum-strain",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/weight_signal.json
+++ b/packages/core/tests/fixtures/snapshots/boundary-zone-total-secs/weight_signal.json
@@ -1,0 +1,8 @@
+{
+  "metric": "weight_signal",
+  "athlete": "boundary-zone-total-secs",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/data-gap-mid-history/weight_signal.json
+++ b/packages/core/tests/fixtures/snapshots/data-gap-mid-history/weight_signal.json
@@ -1,0 +1,8 @@
+{
+  "metric": "weight_signal",
+  "athlete": "data-gap-mid-history",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-20T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/manifest.json
+++ b/packages/core/tests/fixtures/snapshots/manifest.json
@@ -67,6 +67,7 @@
     "vo2max",
     "w_prime",
     "w_prime_kj",
+    "weight_signal",
     "zone_distribution_7d"
   ],
   "pyodide_version": "0.29.4",

--- a/packages/core/tests/fixtures/snapshots/multisport-thin-primary/weight_signal.json
+++ b/packages/core/tests/fixtures/snapshots/multisport-thin-primary/weight_signal.json
@@ -1,0 +1,8 @@
+{
+  "metric": "weight_signal",
+  "athlete": "multisport-thin-primary",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/multisport-tie/weight_signal.json
+++ b/packages/core/tests/fixtures/snapshots/multisport-tie/weight_signal.json
@@ -1,0 +1,8 @@
+{
+  "metric": "weight_signal",
+  "athlete": "multisport-tie",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/new-athlete-empty/weight_signal.json
+++ b/packages/core/tests/fixtures/snapshots/new-athlete-empty/weight_signal.json
@@ -1,0 +1,8 @@
+{
+  "metric": "weight_signal",
+  "athlete": "new-athlete-empty",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/weight_signal.json
+++ b/packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/weight_signal.json
@@ -1,0 +1,19 @@
+{
+  "metric": "weight_signal",
+  "athlete": "populated-benchmark-and-consistency",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "ftp_setting_date": "2026-04-15",
+    "weight_28d_slope_kg_per_week": -0.279,
+    "weight_7d_avg_kg": 72,
+    "weight_latest_date": "2026-05-10",
+    "weight_latest_kg": 72,
+    "wkg_block_delta": 0.05,
+    "wkg_block_end": 3.75,
+    "wkg_block_start": 3.7,
+    "wkg_current": 3.75,
+    "wkg_ftp_source": "tested"
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/realistic-athlete/weight_signal.json
+++ b/packages/core/tests/fixtures/snapshots/realistic-athlete/weight_signal.json
@@ -1,0 +1,8 @@
+{
+  "metric": "weight_signal",
+  "athlete": "realistic-athlete",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/tools/snapshot-section-11.ts
+++ b/tools/snapshot-section-11.ts
@@ -481,6 +481,43 @@ if "__error__" not in derived:
         k: _effort_response[k] for k in sorted(_effort_response.keys())
     }
 
+    # === weight_signal (v3.112) ===
+    # Hoisted from sync.py:2746-2752 outside _calculate_derived_metrics.
+    # The upstream assigns the result to data["current_status"]["weight"];
+    # we surface it as a top-level derived key for the parity gate.
+    #
+    # _load_ftp_history is monkey-patched to read from the fixture's
+    # ftp_history_indoor / ftp_history_outdoor records instead of disk —
+    # the production helper reads ftp_history.json from cwd, which is
+    # neither portable nor reproducible in the harness. _raw_fixture
+    # bypasses _TrackedDict so empty / absent history dicts don't log
+    # spurious missing-key events on the dict.get accesses inside
+    # _build_weight_signal.
+    _raw_ftp_indoor = _raw_fixture.get("ftp_history_indoor") or {}
+    _raw_ftp_outdoor = _raw_fixture.get("ftp_history_outdoor") or {}
+    sync._load_ftp_history = lambda: {
+        "indoor": _raw_ftp_indoor,
+        "outdoor": _raw_ftp_outdoor,
+    }
+    _raw_current_ftp_outdoor = _raw_fixture.get("current_ftp_outdoor")
+    _raw_eftp = _raw_fixture.get("eftp")
+    _weight_sport_settings = {
+        "cycling": {"ftp": _raw_current_ftp_outdoor},
+    } if _raw_current_ftp_outdoor else {}
+    _weight_power_model = {"eftp": _raw_eftp} if _raw_eftp else {}
+    _raw_wellness = _raw_fixture.get("wellness") or []
+    _weight_signal_value = sync._build_weight_signal(
+        _raw_wellness,
+        _weight_sport_settings,
+        _weight_power_model,
+        None,
+    )
+    # Display sub-dict is out of scope per Wave 6 deferral — strip before
+    # snapshotting so the parity gate doesn't pin a contract we don't ship.
+    if _weight_signal_value and "display" in _weight_signal_value:
+        del _weight_signal_value["display"]
+    derived["weight_signal"] = _weight_signal_value
+
     _unallowed = sorted({
         p for p in _TRACKED_MISSING
         if _normalize_path(p) not in _ALLOWED_OPTIONAL_PATHS


### PR DESCRIPTION
## Summary


- New `computeWeightSignal(input)` in
  `packages/core/src/reference/metrics/bodycomp.ts` mirrors the
  Reference v3.112 protocol at `sync.py:2790-2975` line-by-line:
  collect dated weigh-ins (drop nulls, zeros, malformed dates,
  calendar-invalid dates via the existing `parseIsoMs` round-trip
  check), sort newest-first, then independently gate up to seven
  emission keys — (1) `weight_latest_kg` + `weight_latest_date`
  (latest ≤14d), (2) `wkg_current` + `wkg_ftp_source` + optional
  `ftp_setting_date` (weight_latest present AND FTP source resolved,
  tested cycling.ftp = outdoor FTP per `sync.py:2871/2422-2423`
  preferred, eFTP fallback per sync.py:2891-2893, ftp_setting_date
  tries outdoor history newest first then indoor per sync.py:2882-2890),
  (3) `wkg_block_start/end/delta` (≥1 weigh-in in both first-4
  `[today-27, today-24]` and last-4 `[today-3, today]` windows;
  `nearestInRange` mirrors sync.py:2910-2920 newest-first with
  `dist < bestDist` strict-less-than tiebreak), (4) `weight_7d_avg_kg`
  (≥4 in trailing 7d, naive mean via `pythonSum`), (5)
  `weight_28d_slope_kg_per_week` (≥14 in trailing 28d, linear
  least-squares mirroring sync.py:2942-2960 with `den > 0` guard,
  ×7 day→week conversion). Failed gates remove the key from the dict;
  all-fail collapses to `null`. Roundings per sync.py: weight_latest
  1dp, wkg_* 2dp, weight_7d_avg 1dp, slope 3dp — all via
  `roundHalfEven` (banker's). [842d804]
- Snapshot harness extended at `tools/snapshot-section-11.ts` with a
  `weight_signal` block (hoisted from outside `_calculate_derived_metrics`
  per sync.py:2746-2752). Reads `wellness` / `current_ftp_outdoor` /
  `eftp` / `ftp_history_*` from `_raw_fixture` (bypassing _TrackedDict
  so empty / absent history dicts don't log spurious missing-key
  events on the function's internal `.get` calls) and monkey-patches
  `sync._load_ftp_history` to return fixture-provided history rather
  than reading `ftp_history.json` from disk. Strips the `display`
  sub-dict before emission — display units are a Wave 6 deferral. The
  metric is `null` on every fixture that doesn't carry weigh-ins;
  populated-fixture exercises all four gated groups. [842d804]
- Architect Q6 push-back verified: after running
  `pnpm snapshot:section-11`, `git status` confirms
  `packages/core/tests/fixtures/snapshots/populated-benchmark-and-consistency/`
  touches ONLY `weight_signal.json`. No other metric drifts on the
  7 added wellness rows because every other wellness consumer
  (HRV/RHR baselines, latest_hrv, latest_rhr, data_quality counts,
  icu_weight pass-through) filters on non-null `hrv`/`restingHR`
  values, and the added rows carry `null` for both. [842d804]
- Architect Q5 push-back verified: the parity gate's `formatHumanDiff`
  at `tools/check-metric-parity.ts:432-447` already produces
  per-field path identification via `deepCompare`'s leaf-path tree.
  Forced field-level corruption test (`wkg_current` → 99.99 in the
  snapshot, restore after) showed: `$.wkg_current: expected 99.99 |
  got 3.75` — exact field named, no raw JSON dump. No gate changes
  required.
- `populated-benchmark-and-consistency.json` extended in-place with
  7 additional trailing-28d wellness rows (2026-05-02, 04-30, 04-28,
  04-25, 04-22, 04-19, 04-15) with `weight` populated and all other
  fields `null`. Covers — (i) latest ≤14d (latest 05-10 unchanged),
  (ii) first-4 window [04-13, 04-16] gets one entry at 04-15,
  (iii) 4-in-7d window unchanged (still 7 entries in [05-04, 05-10]),
  (iv) 14-in-28d threshold exactly met (7 existing + 7 added = 14),
  (v) FTP-source tested path via the populated fixture's
  `current_ftp_outdoor: 270` (eFTP fallback path covered by unit
  tests). The populated-fixture snapshot value:
  `{weight_latest_kg: 72, weight_latest_date: "2026-05-10",
  wkg_current: 3.75, wkg_ftp_source: "tested",
  ftp_setting_date: "2026-04-15", wkg_block_start: 3.7,
  wkg_block_end: 3.75, wkg_block_delta: 0.05, weight_7d_avg_kg: 72,
  weight_28d_slope_kg_per_week: -0.279}`. [842d804]
- New accessors `getWellnessExtendedWeight(input)` and `getEftp(input)`
  in `metric-input.ts`. `getWellnessExtendedWeight` returns the full
  fixture wellness array (date filtering happens internally in the
  metric — the largest window is 28d, identical to the harness's
  wellness slice). `FixtureSchema` is extended with
  `eftp: z.number().nullable().optional()` (in `inputs.ts`, follow-up
  commit e383b54 per ADR-0017) so `getEftp(input)` reads
  `input.fixture.eftp ?? null` through the typed schema rather than a
  loose-object cast — small, well-defined, and worth the schema
  extension. No committed fixture currently populates `eftp`; unit
  tests synthesise `MetricInput` directly to hit the eFTP fallback
  branch. [842d804, e383b54]
- 26 focused unit tests in `bodycomp.test.ts` (25 after the
  architect-review test-cleanup pass that dropped a no-op
  `expect(true).toBe(true)` placeholder whose 30-line analysis
  duplicated the existing comment on `nearestInRange`): null-input
  and malformed-date guards; weight_latest dp-1 banker's rounding
  edge (71.25 → 71.2); FTP source matrix (tested / eFTP /
  0-tested-→-eFTP / indoor-FTP-isolation / outdoor-history-newest /
  indoor-history-fallback / no-history-emits-wkg-without-date);
  block-trio boundary windows (both populated / first-4 empty /
  last-4 empty); 7d-avg ≥4 gate + window-edge exclusion; 28d-slope
  ≥14 gate + den=0 degenerate-day guard + 3dp emission; one
  parity-mirror test that reconstructs the populated fixture's full
  expected shape.


## Test plan

- [x] Task `Verify:` commands exit 0 (per Phase 1 critique)
- [x] `.ralph/smoke.sh` (full, including parity gate) exits 0 — defense-in-depth re-run
- [x] Fresh-context critic verdict: SHIPPED (see `.ralph/iters/weight_signal/critique.md` locally)
- [x] No rubric dimension scored < 3
