### PR TITLE
test(core): add rest-week-with-baseline golden fixture

### DIFF
--- a/packages/core/tests/fixtures/golden/rest-week-with-baseline.json
+++ b/packages/core/tests/fixtures/golden/rest-week-with-baseline.json
@@ -1,0 +1,846 @@
+{
+  "activities": [
+    {
+      "id": "rwb0",
+      "start_date_local": "2026-05-04T09:00:00",
+      "type": "Ride",
+      "name": "recovery ride",
+      "moving_time": 2700,
+      "elapsed_time": 2730,
+      "icu_training_load": 35.0,
+      "icu_intensity": 65.5,
+      "average_heartrate": 125,
+      "icu_zone_times": [
+        {
+          "id": "Z1",
+          "secs": 600
+        },
+        {
+          "id": "Z2",
+          "secs": 1500
+        },
+        {
+          "id": "Z3",
+          "secs": 600
+        }
+      ],
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "decoupling": -2.1,
+      "icu_efficiency_factor": 1.05,
+      "fitnessAtEnd": 30.0,
+      "fatigueAtEnd": 24.0
+    },
+    {
+      "id": "rwb1",
+      "start_date_local": "2026-05-05T09:00:00",
+      "type": "Ride",
+      "name": "recovery ride",
+      "moving_time": 2700,
+      "elapsed_time": 2730,
+      "icu_training_load": 35.0,
+      "icu_intensity": 65.5,
+      "average_heartrate": 125,
+      "icu_zone_times": [
+        {
+          "id": "Z1",
+          "secs": 600
+        },
+        {
+          "id": "Z2",
+          "secs": 1500
+        },
+        {
+          "id": "Z3",
+          "secs": 600
+        }
+      ],
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "decoupling": -2.1,
+      "icu_efficiency_factor": 1.05,
+      "fitnessAtEnd": 30.0,
+      "fatigueAtEnd": 24.0
+    },
+    {
+      "id": "rwb2",
+      "start_date_local": "2026-05-06T09:00:00",
+      "type": "Ride",
+      "name": "recovery ride",
+      "moving_time": 2700,
+      "elapsed_time": 2730,
+      "icu_training_load": 35.0,
+      "icu_intensity": 65.5,
+      "average_heartrate": 125,
+      "icu_zone_times": [
+        {
+          "id": "Z1",
+          "secs": 600
+        },
+        {
+          "id": "Z2",
+          "secs": 1500
+        },
+        {
+          "id": "Z3",
+          "secs": 600
+        }
+      ],
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "decoupling": -2.1,
+      "icu_efficiency_factor": 1.05,
+      "fitnessAtEnd": 30.0,
+      "fatigueAtEnd": 24.0
+    },
+    {
+      "id": "rwb3",
+      "start_date_local": "2026-05-07T09:00:00",
+      "type": "Ride",
+      "name": "recovery ride",
+      "moving_time": 2700,
+      "elapsed_time": 2730,
+      "icu_training_load": 35.0,
+      "icu_intensity": 65.5,
+      "average_heartrate": 125,
+      "icu_zone_times": [
+        {
+          "id": "Z1",
+          "secs": 600
+        },
+        {
+          "id": "Z2",
+          "secs": 1500
+        },
+        {
+          "id": "Z3",
+          "secs": 600
+        }
+      ],
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "decoupling": -2.1,
+      "icu_efficiency_factor": 1.05,
+      "fitnessAtEnd": 30.0,
+      "fatigueAtEnd": 24.0
+    },
+    {
+      "id": "rwb4",
+      "start_date_local": "2026-05-08T09:00:00",
+      "type": "Ride",
+      "name": "recovery ride",
+      "moving_time": 2700,
+      "elapsed_time": 2730,
+      "icu_training_load": 35.0,
+      "icu_intensity": 65.5,
+      "average_heartrate": 125,
+      "icu_zone_times": [
+        {
+          "id": "Z1",
+          "secs": 600
+        },
+        {
+          "id": "Z2",
+          "secs": 1500
+        },
+        {
+          "id": "Z3",
+          "secs": 600
+        }
+      ],
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "decoupling": -2.1,
+      "icu_efficiency_factor": 1.05,
+      "fitnessAtEnd": 30.0,
+      "fatigueAtEnd": 24.0
+    },
+    {
+      "id": "rwb5",
+      "start_date_local": "2026-05-09T09:00:00",
+      "type": "Ride",
+      "name": "recovery ride",
+      "moving_time": 2700,
+      "elapsed_time": 2730,
+      "icu_training_load": 35.0,
+      "icu_intensity": 65.5,
+      "average_heartrate": 125,
+      "icu_zone_times": [
+        {
+          "id": "Z1",
+          "secs": 600
+        },
+        {
+          "id": "Z2",
+          "secs": 1500
+        },
+        {
+          "id": "Z3",
+          "secs": 600
+        }
+      ],
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "decoupling": -2.1,
+      "icu_efficiency_factor": 1.05,
+      "fitnessAtEnd": 30.0,
+      "fatigueAtEnd": 24.0
+    },
+    {
+      "id": "rwb6",
+      "start_date_local": "2026-05-10T09:00:00",
+      "type": "Ride",
+      "name": "recovery ride",
+      "moving_time": 2700,
+      "elapsed_time": 2730,
+      "icu_training_load": 35.0,
+      "icu_intensity": 65.5,
+      "average_heartrate": 125,
+      "icu_zone_times": [
+        {
+          "id": "Z1",
+          "secs": 600
+        },
+        {
+          "id": "Z2",
+          "secs": 1500
+        },
+        {
+          "id": "Z3",
+          "secs": 600
+        }
+      ],
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "decoupling": -2.1,
+      "icu_efficiency_factor": 1.05,
+      "fitnessAtEnd": 30.0,
+      "fatigueAtEnd": 24.0
+    }
+  ],
+  "wellness": [
+    {
+      "id": "2026-04-13",
+      "weight": null,
+      "restingHR": 58,
+      "hrv": 52,
+      "sleepSecs": 28800,
+      "sleepQuality": 4,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 240
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 32.0,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-04-14",
+      "weight": null,
+      "restingHR": 58,
+      "hrv": 52,
+      "sleepSecs": 28800,
+      "sleepQuality": 4,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 240
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 31.9,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-04-15",
+      "weight": null,
+      "restingHR": 58,
+      "hrv": 52,
+      "sleepSecs": 28800,
+      "sleepQuality": 4,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 240
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 31.7,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-04-16",
+      "weight": null,
+      "restingHR": 58,
+      "hrv": 52,
+      "sleepSecs": 28800,
+      "sleepQuality": 4,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 240
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 31.6,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-04-17",
+      "weight": null,
+      "restingHR": 58,
+      "hrv": 52,
+      "sleepSecs": 28800,
+      "sleepQuality": 4,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 240
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 31.5,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-04-18",
+      "weight": null,
+      "restingHR": 58,
+      "hrv": 52,
+      "sleepSecs": 28800,
+      "sleepQuality": 4,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 240
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 31.3,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-04-19",
+      "weight": null,
+      "restingHR": 58,
+      "hrv": 52,
+      "sleepSecs": 28800,
+      "sleepQuality": 4,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 240
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 31.2,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-04-20",
+      "weight": null,
+      "restingHR": 58,
+      "hrv": 52,
+      "sleepSecs": 28800,
+      "sleepQuality": 4,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 240
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 31.0,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-04-21",
+      "weight": null,
+      "restingHR": 58,
+      "hrv": 52,
+      "sleepSecs": 28800,
+      "sleepQuality": 4,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 240
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 30.9,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-04-22",
+      "weight": null,
+      "restingHR": 58,
+      "hrv": 52,
+      "sleepSecs": 28800,
+      "sleepQuality": 4,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 240
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 30.8,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-04-23",
+      "weight": null,
+      "restingHR": 58,
+      "hrv": 52,
+      "sleepSecs": 28800,
+      "sleepQuality": 4,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 240
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 30.6,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-04-24",
+      "weight": null,
+      "restingHR": 58,
+      "hrv": 52,
+      "sleepSecs": 28800,
+      "sleepQuality": 4,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 240
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 30.5,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-04-25",
+      "weight": null,
+      "restingHR": 58,
+      "hrv": 52,
+      "sleepSecs": 28800,
+      "sleepQuality": 4,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 240
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 30.4,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-04-26",
+      "weight": null,
+      "restingHR": 58,
+      "hrv": 52,
+      "sleepSecs": 28800,
+      "sleepQuality": 4,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 240
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 30.2,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-04-27",
+      "weight": null,
+      "restingHR": 58,
+      "hrv": 52,
+      "sleepSecs": 28800,
+      "sleepQuality": 4,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 240
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 30.1,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-04-28",
+      "weight": null,
+      "restingHR": 58,
+      "hrv": 52,
+      "sleepSecs": 28800,
+      "sleepQuality": 4,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 240
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 29.9,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-04-29",
+      "weight": null,
+      "restingHR": 58,
+      "hrv": 52,
+      "sleepSecs": 28800,
+      "sleepQuality": 4,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 240
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 29.8,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-04-30",
+      "weight": null,
+      "restingHR": 58,
+      "hrv": 52,
+      "sleepSecs": 28800,
+      "sleepQuality": 4,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 240
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 29.7,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-05-01",
+      "weight": null,
+      "restingHR": 58,
+      "hrv": 52,
+      "sleepSecs": 28800,
+      "sleepQuality": 4,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 240
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 29.5,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-05-02",
+      "weight": null,
+      "restingHR": 58,
+      "hrv": 52,
+      "sleepSecs": 28800,
+      "sleepQuality": 4,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 240
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 29.4,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-05-03",
+      "weight": null,
+      "restingHR": 58,
+      "hrv": 52,
+      "sleepSecs": 28800,
+      "sleepQuality": 4,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 240
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 29.3,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-05-04",
+      "weight": null,
+      "restingHR": 58,
+      "hrv": 52,
+      "sleepSecs": 28800,
+      "sleepQuality": 4,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 240
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 29.1,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-05-05",
+      "weight": null,
+      "restingHR": 58,
+      "hrv": 52,
+      "sleepSecs": 28800,
+      "sleepQuality": 4,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 240
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 29.0,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-05-06",
+      "weight": null,
+      "restingHR": 58,
+      "hrv": 52,
+      "sleepSecs": 28800,
+      "sleepQuality": 4,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 240
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 28.8,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-05-07",
+      "weight": null,
+      "restingHR": 58,
+      "hrv": 52,
+      "sleepSecs": 28800,
+      "sleepQuality": 4,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 240
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 28.7,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-05-08",
+      "weight": null,
+      "restingHR": 58,
+      "hrv": 52,
+      "sleepSecs": 28800,
+      "sleepQuality": 4,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 240
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 28.6,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-05-09",
+      "weight": null,
+      "restingHR": 58,
+      "hrv": 52,
+      "sleepSecs": 28800,
+      "sleepQuality": 4,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 240
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 28.4,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    },
+    {
+      "id": "2026-05-10",
+      "weight": null,
+      "restingHR": 58,
+      "hrv": 52,
+      "sleepSecs": 28800,
+      "sleepQuality": 4,
+      "soreness": null,
+      "fatigue": null,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 240
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 28.3,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0
+    }
+  ],
+  "ftp_history": [
+    {
+      "date": "2026-03-15",
+      "ftp": 280,
+      "source": "test"
+    }
+  ]
+}

--- a/packages/core/tests/fixtures/snapshots/manifest.json
+++ b/packages/core/tests/fixtures/snapshots/manifest.json
@@ -11,7 +11,8 @@
     "multisport-tie",
     "new-athlete-empty",
     "populated-benchmark-and-consistency",
-    "realistic-athlete"
+    "realistic-athlete",
+    "rest-week-with-baseline"
   ],
   "metrics": [
     "acwr",

--- a/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/acwr.json
+++ b/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/acwr.json
@@ -1,0 +1,8 @@
+{
+  "metric": "acwr",
+  "athlete": "rest-week-with-baseline",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 4
+}

--- a/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/acwr_interpretation.json
+++ b/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/acwr_interpretation.json
@@ -1,0 +1,8 @@
+{
+  "metric": "acwr_interpretation",
+  "athlete": "rest-week-with-baseline",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": "danger"
+}

--- a/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/benchmark_indoor.json
+++ b/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/benchmark_indoor.json
@@ -1,0 +1,14 @@
+{
+  "metric": "benchmark_indoor",
+  "athlete": "rest-week-with-baseline",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "benchmark_index": null,
+    "benchmark_percentage": null,
+    "current_ftp": null,
+    "ftp_8_weeks_ago": null,
+    "seasonal_expected": null
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/benchmark_outdoor.json
+++ b/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/benchmark_outdoor.json
@@ -1,0 +1,14 @@
+{
+  "metric": "benchmark_outdoor",
+  "athlete": "rest-week-with-baseline",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "benchmark_index": null,
+    "benchmark_percentage": null,
+    "current_ftp": null,
+    "ftp_8_weeks_ago": null,
+    "seasonal_expected": null
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/calculation_timestamp.json
+++ b/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/calculation_timestamp.json
@@ -1,0 +1,8 @@
+{
+  "metric": "calculation_timestamp",
+  "athlete": "rest-week-with-baseline",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": "2026-05-10T12:00:00"
+}

--- a/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/capability.json
+++ b/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/capability.json
@@ -1,0 +1,62 @@
+{
+  "metric": "capability",
+  "athlete": "rest-week-with-baseline",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "dfa_a1_profile": null,
+    "durability": {
+      "high_drift_count_28d": 0,
+      "high_drift_count_7d": 0,
+      "mean_decoupling_28d": null,
+      "mean_decoupling_7d": null,
+      "note": "Steady-state power sessions only (VI <= 1.05, VI > 0, >= 90min, power data). Negative decoupling = strong durability. Trend compares 7d vs 28d mean (+/-1% = stable). Alerts require N28>=5 (alarm) or N7>=3 AND N28>=5 (declining warning) for statistical reliability.",
+      "qualifying_sessions_28d": 0,
+      "qualifying_sessions_7d": 0,
+      "reliability_limited": true,
+      "reliability_note": "insufficient qualifying sessions for alert evaluation: 7d N=0 (min 3), 28d N=0 (min 5)",
+      "trend": null
+    },
+    "efficiency_factor": {
+      "mean_ef_28d": null,
+      "mean_ef_7d": null,
+      "note": "Steady-state cycling sessions only (VI <= 1.05, VI > 0, >= 20min, power+HR data). Rising EF = improving aerobic efficiency. Compare like-for-like sessions only — EF varies with intensity. Trend compares 7d vs 28d mean (+/-0.03 = stable).",
+      "qualifying_sessions_28d": 0,
+      "qualifying_sessions_7d": 0,
+      "trend": null
+    },
+    "hr_curve_delta": {
+      "anchors": null,
+      "note": "Insufficient HR data in one or both windows.",
+      "rotation_index": null,
+      "window_days": 28
+    },
+    "hrrc": {
+      "mean_hrrc_28d": null,
+      "mean_hrrc_7d": null,
+      "note": "HRRc = heart rate recovery (largest 60s HR drop in bpm after exceeding threshold HR for >1 min). Higher = better parasympathetic recovery. Null when threshold not reached, recording stopped before cooldown, or no HR data. Trend: 7d mean vs 28d mean, >10% = meaningful (min 1 session/7d, 3 sessions/28d). Display only — not wired into readiness_decision signals.",
+      "qualifying_sessions_28d": 0,
+      "qualifying_sessions_7d": 0,
+      "trend": null
+    },
+    "power_curve_delta": {
+      "anchors": null,
+      "note": "Insufficient power data in one or both windows.",
+      "rotation_index": null,
+      "window_days": 28
+    },
+    "sustainability_profile": {
+      "note": "No sustainability data available."
+    },
+    "tid_comparison": {
+      "classification_28d": "Base",
+      "classification_7d": "Base",
+      "drift": "consistent",
+      "note": "Compares 7d vs 28d Seiler TID to detect distribution shifts. pi_delta positive = more polarized acutely.",
+      "pi_28d": null,
+      "pi_7d": null,
+      "pi_delta": null
+    }
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/consistency_details.json
+++ b/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/consistency_details.json
@@ -1,0 +1,13 @@
+{
+  "metric": "consistency_details",
+  "athlete": "rest-week-with-baseline",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "completed_days": 7,
+    "matched_days": 0,
+    "note": "No planned workouts in period",
+    "planned_days": 0
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/consistency_index.json
+++ b/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/consistency_index.json
@@ -1,0 +1,8 @@
+{
+  "metric": "consistency_index",
+  "athlete": "rest-week-with-baseline",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/data_quality.json
+++ b/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/data_quality.json
@@ -1,0 +1,18 @@
+{
+  "metric": "data_quality",
+  "athlete": "rest-week-with-baseline",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "activities_28d": 7,
+    "activities_7d": 7,
+    "ftp_history_days": {
+      "indoor": 0,
+      "outdoor": 0
+    },
+    "hrv_data_points": 7,
+    "planned_workouts_7d": 0,
+    "rhr_data_points": 7
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/easy_time_ratio.json
+++ b/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/easy_time_ratio.json
@@ -1,0 +1,8 @@
+{
+  "metric": "easy_time_ratio",
+  "athlete": "rest-week-with-baseline",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 0.78
+}

--- a/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/easy_time_ratio_note.json
+++ b/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/easy_time_ratio_note.json
@@ -1,0 +1,8 @@
+{
+  "metric": "easy_time_ratio_note",
+  "athlete": "rest-week-with-baseline",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": "Easy time (Z1+Z2) / Total - target ~80% in polarized training"
+}

--- a/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/effective_monotony.json
+++ b/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/effective_monotony.json
@@ -1,0 +1,8 @@
+{
+  "metric": "effective_monotony",
+  "athlete": "rest-week-with-baseline",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/effort_response_signal.json
+++ b/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/effort_response_signal.json
@@ -1,0 +1,16 @@
+{
+  "metric": "effort_response_signal",
+  "athlete": "rest-week-with-baseline",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "rwb0": null,
+    "rwb1": null,
+    "rwb2": null,
+    "rwb3": null,
+    "rwb4": null,
+    "rwb5": null,
+    "rwb6": null
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/eftp.json
+++ b/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/eftp.json
@@ -1,0 +1,8 @@
+{
+  "metric": "eftp",
+  "athlete": "rest-week-with-baseline",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/grey_zone_note.json
+++ b/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/grey_zone_note.json
@@ -1,0 +1,8 @@
+{
+  "metric": "grey_zone_note",
+  "athlete": "rest-week-with-baseline",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": "Gray Zone % (Z3/tempo) - minimize in polarized training"
+}

--- a/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/grey_zone_percentage.json
+++ b/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/grey_zone_percentage.json
@@ -1,0 +1,8 @@
+{
+  "metric": "grey_zone_percentage",
+  "athlete": "rest-week-with-baseline",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 22.2
+}

--- a/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/hard_days_note.json
+++ b/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/hard_days_note.json
@@ -1,0 +1,8 @@
+{
+  "metric": "hard_days_note",
+  "athlete": "rest-week-with-baseline",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": "Power ladder: z3+ >= 30min, z4+ >= 10min, z5+ >= 5min, z6+ >= 2min, z7 >= 1min. HR fallback (when no power): z4+ >= 10min, z5+ >= 5min. Per Seiler 3-zone model + Foster. HR-based days flagged with intensity_basis: hr"
+}

--- a/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/hard_days_this_week.json
+++ b/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/hard_days_this_week.json
@@ -1,0 +1,8 @@
+{
+  "metric": "hard_days_this_week",
+  "athlete": "rest-week-with-baseline",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 0
+}

--- a/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/has_intervals.json
+++ b/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/has_intervals.json
@@ -1,0 +1,16 @@
+{
+  "metric": "has_intervals",
+  "athlete": "rest-week-with-baseline",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "rwb0": false,
+    "rwb1": false,
+    "rwb2": false,
+    "rwb3": false,
+    "rwb4": false,
+    "rwb5": false,
+    "rwb6": false
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/hrv_baseline_28d.json
+++ b/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/hrv_baseline_28d.json
@@ -1,0 +1,8 @@
+{
+  "metric": "hrv_baseline_28d",
+  "athlete": "rest-week-with-baseline",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 52
+}

--- a/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/hrv_baseline_7d.json
+++ b/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/hrv_baseline_7d.json
@@ -1,0 +1,8 @@
+{
+  "metric": "hrv_baseline_7d",
+  "athlete": "rest-week-with-baseline",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 52
+}

--- a/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/latest_hrv.json
+++ b/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/latest_hrv.json
@@ -1,0 +1,8 @@
+{
+  "metric": "latest_hrv",
+  "athlete": "rest-week-with-baseline",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 52
+}

--- a/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/latest_rhr.json
+++ b/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/latest_rhr.json
@@ -1,0 +1,8 @@
+{
+  "metric": "latest_rhr",
+  "athlete": "rest-week-with-baseline",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 58
+}

--- a/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/load_recovery_ratio.json
+++ b/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/load_recovery_ratio.json
@@ -1,0 +1,8 @@
+{
+  "metric": "load_recovery_ratio",
+  "athlete": "rest-week-with-baseline",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 2.5
+}

--- a/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/monotony.json
+++ b/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/monotony.json
@@ -1,0 +1,8 @@
+{
+  "metric": "monotony",
+  "athlete": "rest-week-with-baseline",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/monotony_interpretation.json
+++ b/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/monotony_interpretation.json
@@ -1,0 +1,8 @@
+{
+  "metric": "monotony_interpretation",
+  "athlete": "rest-week-with-baseline",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/multi_sport_detected.json
+++ b/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/multi_sport_detected.json
@@ -1,0 +1,8 @@
+{
+  "metric": "multi_sport_detected",
+  "athlete": "rest-week-with-baseline",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": false
+}

--- a/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/p_max.json
+++ b/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/p_max.json
@@ -1,0 +1,8 @@
+{
+  "metric": "p_max",
+  "athlete": "rest-week-with-baseline",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/phase_detected.json
+++ b/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/phase_detected.json
@@ -1,0 +1,8 @@
+{
+  "metric": "phase_detected",
+  "athlete": "rest-week-with-baseline",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": "Base"
+}

--- a/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/phase_detection.json
+++ b/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/phase_detection.json
@@ -1,0 +1,38 @@
+{
+  "metric": "phase_detection",
+  "athlete": "rest-week-with-baseline",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "basis": {
+      "data_quality": "good",
+      "stream_1": {
+        "acwr_trend": null,
+        "ctl_slope": null,
+        "hard_day_pattern": 0,
+        "weeks_available": 4
+      },
+      "stream_2": {
+        "current_week_hard_days_completed": 0,
+        "current_week_hard_days_total": 0,
+        "hard_sessions_planned": 0,
+        "next_week_load": null,
+        "plan_coverage_current_week": 0,
+        "plan_coverage_next_week": 0,
+        "planned_tss_delta": null,
+        "race_proximity": null
+      },
+      "stream_agreement": null
+    },
+    "confidence": "medium",
+    "dossier_agreement": null,
+    "dossier_declared": null,
+    "phase": "Base",
+    "phase_duration_weeks": 1,
+    "previous_phase": null,
+    "reason_codes": [
+      "NO_PLANNED_WORKOUTS"
+    ]
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/phase_triggers.json
+++ b/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/phase_triggers.json
@@ -1,0 +1,10 @@
+{
+  "metric": "phase_triggers",
+  "athlete": "rest-week-with-baseline",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": [
+    "NO_PLANNED_WORKOUTS"
+  ]
+}

--- a/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/power_model_source.json
+++ b/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/power_model_source.json
@@ -1,0 +1,8 @@
+{
+  "metric": "power_model_source",
+  "athlete": "rest-week-with-baseline",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/primary_sport.json
+++ b/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/primary_sport.json
@@ -1,0 +1,8 @@
+{
+  "metric": "primary_sport",
+  "athlete": "rest-week-with-baseline",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": "cycling"
+}

--- a/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/primary_sport_monotony.json
+++ b/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/primary_sport_monotony.json
@@ -1,0 +1,8 @@
+{
+  "metric": "primary_sport_monotony",
+  "athlete": "rest-week-with-baseline",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/primary_sport_tss_7d.json
+++ b/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/primary_sport_tss_7d.json
@@ -1,0 +1,8 @@
+{
+  "metric": "primary_sport_tss_7d",
+  "athlete": "rest-week-with-baseline",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 245
+}

--- a/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/quality_intensity_note.json
+++ b/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/quality_intensity_note.json
@@ -1,0 +1,8 @@
+{
+  "metric": "quality_intensity_note",
+  "athlete": "rest-week-with-baseline",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": "Quality Intensity % (Z4+/threshold+) - target ~20% in polarized training"
+}

--- a/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/quality_intensity_percentage.json
+++ b/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/quality_intensity_percentage.json
@@ -1,0 +1,8 @@
+{
+  "metric": "quality_intensity_percentage",
+  "athlete": "rest-week-with-baseline",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 0
+}

--- a/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/recovery_index.json
+++ b/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/recovery_index.json
@@ -1,0 +1,8 @@
+{
+  "metric": "recovery_index",
+  "athlete": "rest-week-with-baseline",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 1
+}

--- a/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/recovery_index_yesterday.json
+++ b/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/recovery_index_yesterday.json
@@ -1,0 +1,8 @@
+{
+  "metric": "recovery_index_yesterday",
+  "athlete": "rest-week-with-baseline",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 1
+}

--- a/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/rhr_baseline_28d.json
+++ b/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/rhr_baseline_28d.json
@@ -1,0 +1,8 @@
+{
+  "metric": "rhr_baseline_28d",
+  "athlete": "rest-week-with-baseline",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 58
+}

--- a/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/rhr_baseline_7d.json
+++ b/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/rhr_baseline_7d.json
@@ -1,0 +1,8 @@
+{
+  "metric": "rhr_baseline_7d",
+  "athlete": "rest-week-with-baseline",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 58
+}

--- a/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/seasonal_context.json
+++ b/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/seasonal_context.json
@@ -1,0 +1,8 @@
+{
+  "metric": "seasonal_context",
+  "athlete": "rest-week-with-baseline",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": "Build / Early Race Season"
+}

--- a/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/seiler_tid_28d.json
+++ b/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/seiler_tid_28d.json
@@ -1,0 +1,18 @@
+{
+  "metric": "seiler_tid_28d",
+  "athlete": "rest-week-with-baseline",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "classification": "Base",
+    "polarization_index": null,
+    "z1_pct": 77.8,
+    "z1_seconds": 14700,
+    "z2_pct": 22.2,
+    "z2_seconds": 4200,
+    "z3_pct": 0,
+    "z3_seconds": 0,
+    "zone_basis": "power"
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/seiler_tid_28d_primary.json
+++ b/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/seiler_tid_28d_primary.json
@@ -1,0 +1,19 @@
+{
+  "metric": "seiler_tid_28d_primary",
+  "athlete": "rest-week-with-baseline",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "classification": "Base",
+    "polarization_index": null,
+    "sport": "cycling",
+    "z1_pct": 77.8,
+    "z1_seconds": 14700,
+    "z2_pct": 22.2,
+    "z2_seconds": 4200,
+    "z3_pct": 0,
+    "z3_seconds": 0,
+    "zone_basis": "power"
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/seiler_tid_7d.json
+++ b/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/seiler_tid_7d.json
@@ -1,0 +1,18 @@
+{
+  "metric": "seiler_tid_7d",
+  "athlete": "rest-week-with-baseline",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "classification": "Base",
+    "polarization_index": null,
+    "z1_pct": 77.8,
+    "z1_seconds": 14700,
+    "z2_pct": 22.2,
+    "z2_seconds": 4200,
+    "z3_pct": 0,
+    "z3_seconds": 0,
+    "zone_basis": "power"
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/seiler_tid_7d_primary.json
+++ b/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/seiler_tid_7d_primary.json
@@ -1,0 +1,19 @@
+{
+  "metric": "seiler_tid_7d_primary",
+  "athlete": "rest-week-with-baseline",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "classification": "Base",
+    "polarization_index": null,
+    "sport": "cycling",
+    "z1_pct": 77.8,
+    "z1_seconds": 14700,
+    "z2_pct": 22.2,
+    "z2_seconds": 4200,
+    "z3_pct": 0,
+    "z3_seconds": 0,
+    "zone_basis": "power"
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/strain.json
+++ b/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/strain.json
@@ -1,0 +1,8 @@
+{
+  "metric": "strain",
+  "athlete": "rest-week-with-baseline",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/stress_tolerance.json
+++ b/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/stress_tolerance.json
@@ -1,0 +1,8 @@
+{
+  "metric": "stress_tolerance",
+  "athlete": "rest-week-with-baseline",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/tss_28d_total.json
+++ b/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/tss_28d_total.json
@@ -1,0 +1,8 @@
+{
+  "metric": "tss_28d_total",
+  "athlete": "rest-week-with-baseline",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 245
+}

--- a/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/tss_7d_total.json
+++ b/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/tss_7d_total.json
@@ -1,0 +1,8 @@
+{
+  "metric": "tss_7d_total",
+  "athlete": "rest-week-with-baseline",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 245
+}

--- a/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/vo2max.json
+++ b/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/vo2max.json
@@ -1,0 +1,8 @@
+{
+  "metric": "vo2max",
+  "athlete": "rest-week-with-baseline",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/w_prime.json
+++ b/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/w_prime.json
@@ -1,0 +1,8 @@
+{
+  "metric": "w_prime",
+  "athlete": "rest-week-with-baseline",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/w_prime_kj.json
+++ b/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/w_prime_kj.json
@@ -1,0 +1,8 @@
+{
+  "metric": "w_prime_kj",
+  "athlete": "rest-week-with-baseline",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/weight_signal.json
+++ b/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/weight_signal.json
@@ -1,0 +1,8 @@
+{
+  "metric": "weight_signal",
+  "athlete": "rest-week-with-baseline",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/zone_distribution_7d.json
+++ b/packages/core/tests/fixtures/snapshots/rest-week-with-baseline/zone_distribution_7d.json
@@ -1,0 +1,15 @@
+{
+  "metric": "zone_distribution_7d",
+  "athlete": "rest-week-with-baseline",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "total_hours": 5.25,
+    "z1_hours": 1.17,
+    "z2_hours": 2.92,
+    "z3_hours": 1.17,
+    "z4_plus_hours": 0,
+    "zone_basis": "power"
+  }
+}

--- a/tools/snapshot-section-11.ts
+++ b/tools/snapshot-section-11.ts
@@ -113,6 +113,12 @@ const HARNESS_FIXTURES: HarnessFixtureConfig[] = [
     description:
       "Populated-branch coverage for consistency_index + benchmark_indoor + benchmark_outdoor — the F11 metrics whose previous fixtures all collapsed to the null branch. 4 WORKOUT events on 05-05/07/09/10 paired with cycling activities on 05-05/07/09 give matched=3, planned=4, consistency_index=0.75. FTP history has a 2026-03-15 entry sitting exactly at (frozenNow - 56d), exercising the +/-7d nearest-match window: indoor 280/270-1=0.037 in seasonal range [0.01,0.04] → seasonal_expected=true; outdoor 270/260-1=0.038 same range true. Without this fixture the parity gate is theatre for those three metrics.",
   },
+  {
+    slug: "rest-week-with-baseline",
+    frozenNow: DEFAULT_FROZEN_NOW,
+    description:
+      "Constant-Load coverage for the monotony stdev=0 branch. 7 recovery rides on 05-04..05-10 at an IDENTICAL daily Load of 35.0 give the 7d series [35,35,35,35,35,35,35] — non-zero mean, sample stdev exactly 0 — so monotony hits the `stdevLoad <= 0 -> null` guard (a path the all-zero fixtures reach via a different branch). That null cascades: strain -> null, stress_tolerance -> null. Single-sport, so primary_sport_monotony hits its own stdev=0 null too. The 28-day wellness baseline (stable RHR 58 / HRV 52) populates recovery_index + HRV/RHR baselines through the flat block. Anchor 2026-05-10 puts the constant week in the 7d acute window.",
+  },
 ];
 
 function readPyodideVersion(): string {


### PR DESCRIPTION
## What

Adds the 4th hand-authored golden fixture, `rest-week-with-baseline`, to close a branch-coverage gap: the **monotony stdev=0** path.

## Why

No existing fixture exercises `computeMonotony`'s `stdevLoad <= 0 → null` guard (`load-management.ts:99`). The all-zero fixtures (`new-athlete-empty`, `zero-activities`) reach a *null* monotony via a different branch (line 93's empty/single-day guard), so the stdev=0 branch — and the cascade it triggers — was untested.

Seven recovery rides on 2026-05-04…05-10 at an **identical** daily Load of 35.0 produce the trailing-7 series `[35,35,35,35,35,35,35]` (non-zero mean, sample stdev exactly 0). That hits the target branch and cascades:

| metric | value | branch |
|---|---|---|
| `monotony` | `null` | stdev=0 guard (line 99) |
| `primary_sport_monotony` | `null` | single-sport stdev=0 (line 166) |
| `effective_monotony` | `null` | selector → total (null) |
| `strain` | `null` | `!monotony` cascade (line 244) |
| `stress_tolerance` | `null` | `!strain \|\| !monotony` (line 292) |
| `monotony_interpretation` | `null` | `effectiveMonotony === null` (line 336) |

A 28-day wellness baseline (stable RHR 58 / HRV 52) keeps `recovery_index` and the HRV/RHR baselines populated through the flat block, so the fixture is non-degenerate (`acwr=4`, `recovery_index` non-null, zones populated) rather than collapsing every metric to null.

## Discipline

- Activity field set mirrors `boundary-monotony`; wellness field set mirrors `data-gap-mid-history` — both stay inside the snapshot harness contract allowlist (no `__contract_violation__`).
- Registered in the `HARNESS_FIXTURES` allowlist with rationale.
- Synthetic data, distinct `rwb0..rwb6` ids — no privacy/PII surface.

## Tests

- `pnpm check-parity --all` → **280 OK cells, 0 mismatches** (28 new cells for this fixture, all OK).
- `reference-parity` + `reference-load-fixture` vitest → **311 passed**.
- Snapshot regeneration touches only the new fixture's dir + `manifest.json` — no churn in other fixtures.