### PR TITLE
refactor(core,tools): post-merge cleanup of the capability + coverage work

### DIFF
--- a/packages/core/src/reference/metrics/capability.ts
+++ b/packages/core/src/reference/metrics/capability.ts
@@ -11,8 +11,7 @@
  * See `NOTICE.md` for upstream attribution.
  */
 
-import { getActivitiesInWindow } from "./distribution.js";
-import { getActivities, type MetricInput } from "./metric-input.js";
+import { getActivities, getActivitiesInWindow, type MetricInput } from "./metric-input.js";
 import { mean } from "./statistics.js";
 import { roundHalfEven } from "./rounding.js";
 import type { Activity } from "../schemas/inputs.js";

--- a/packages/core/src/reference/metrics/distribution.ts
+++ b/packages/core/src/reference/metrics/distribution.ts
@@ -10,8 +10,7 @@
 
 import type { Activity } from "../schemas/inputs.js";
 
-import { isoDateDaysBefore } from "./date-helpers.js";
-import { getActivities, type MetricInput } from "./metric-input.js";
+import { getActivities, getActivitiesInWindow, type MetricInput } from "./metric-input.js";
 import { roundHalfEven } from "./rounding.js";
 import { SPORT_FAMILIES } from "./sport-families.js";
 import { pythonSum } from "./statistics.js";
@@ -618,24 +617,5 @@ function selectPrimarySport(activities: Activity[]): string | null {
     }
   }
   return primary;
-}
-
-// The trailing 7-day activity window the upstream reads as `activities_7d`:
-// rows whose `start_date_local` date falls in [frozenNow-(days-1),
-// frozenNow], inclusive, in fixture order. Mirrors the harness
-// `_within(_activities_all, "start_date_local", ...)` slice — an inclusive
-// lexicographic date comparison over the YYYY-MM-DD prefix.
-export function getActivitiesInWindow(
-  activities: Activity[],
-  days: number,
-  frozenNow: string,
-): Activity[] {
-  const oldest = isoDateDaysBefore(frozenNow, days - 1);
-  const today = frozenNow.slice(0, 10);
-  return activities.filter((a) => {
-    if (typeof a.start_date_local !== "string") return false;
-    const d = a.start_date_local.slice(0, 10);
-    return oldest <= d && d <= today;
-  });
 }
 

--- a/packages/core/src/reference/metrics/metric-input.ts
+++ b/packages/core/src/reference/metrics/metric-input.ts
@@ -4,6 +4,7 @@ import type {
   PlannedEvent,
   WellnessDay,
 } from "../schemas/inputs.js";
+import { isoDateDaysBefore } from "./date-helpers.js";
 
 /** Per-activity intervals entry projected to the fields the Reference layer
  *  consumes. Mirrors the upstream's intervals.json row shape (a distinct API
@@ -35,6 +36,25 @@ export interface MetricInput {
 
 export function getActivities(input: MetricInput): Activity[] {
   return input.fixture.activities;
+}
+
+// The trailing activity window the upstream reads as `activities_7d` /
+// `activities_28d`: rows whose `start_date_local` date falls in
+// [frozenNow-(days-1), frozenNow], inclusive, in fixture order. Mirrors the
+// harness `slice_window(_activities_all, "start_date_local", ...)` — an
+// inclusive lexicographic date comparison over the YYYY-MM-DD prefix.
+export function getActivitiesInWindow(
+  activities: Activity[],
+  days: number,
+  frozenNow: string,
+): Activity[] {
+  const oldest = isoDateDaysBefore(frozenNow, days - 1);
+  const today = frozenNow.slice(0, 10);
+  return activities.filter((a) => {
+    if (typeof a.start_date_local !== "string") return false;
+    const d = a.start_date_local.slice(0, 10);
+    return oldest <= d && d <= today;
+  });
 }
 
 export function getPastEvents(input: MetricInput): PlannedEvent[] {

--- a/tools/harness-fixtures.ts
+++ b/tools/harness-fixtures.ts
@@ -1,0 +1,87 @@
+/**
+ * The golden-fixture allowlist the snapshot harness processes, each with its
+ * frozen-now anchor. Single source of truth shared by the snapshot harness
+ * (tools/snapshot-section-11.ts) and the coverage probe
+ * (tools/measure-reference-coverage.ts), so the per-fixture anchors can't
+ * drift between the two.
+ *
+ * Adding a fixture is an explicit edit here — the golden dir also holds
+ * fixtures owned by other tests (the F7 reference substrate's
+ * `post-break-resume`, `zero-activities`) that don't conform to sync.py's
+ * contract and must not be run through the harness. Each entry's `description`
+ * carries the rationale for the slug + the anchor it chose.
+ */
+
+// Default anchor. The manifest's `frozen_now` field also takes this value as
+// the default; per-fixture overrides ride through each per-snapshot wrapper's
+// `frozen_now` field.
+export const DEFAULT_FROZEN_NOW = "2026-05-10T12:00:00";
+
+export interface HarnessFixtureConfig {
+  slug: string;
+  frozenNow: string;
+  description: string;
+}
+
+export const HARNESS_FIXTURES: HarnessFixtureConfig[] = [
+  {
+    slug: "realistic-athlete",
+    frozenNow: DEFAULT_FROZEN_NOW,
+    description:
+      "Happy-path baseline — sanitized real athlete bundle. Exercises the populated branches of every metric. Anchor 2026-05-10 sits one day after the fixture's last activity.",
+  },
+  {
+    slug: "new-athlete-empty",
+    frozenNow: DEFAULT_FROZEN_NOW,
+    description:
+      "Zero activities, zero wellness, zero ftp_history. Forces every 'no data' branch — ACWR div-by-zero, monotony of empty week, recovery_index no-contributors. Anchor doesn't matter; reuses the default.",
+  },
+  {
+    slug: "data-gap-mid-history",
+    frozenNow: "2026-05-20T12:00:00",
+    description:
+      "21 activities split by a 28-day gap (14 days 2026-04-01..04-14, gap 04-15..05-12, 7 days resumed 05-13..05-19). Exercises EWMA decay through the gap, ACWR chronic window seeing zeros, monotony on the resumed week. Anchor 2026-05-20 catches the resumed week in the 7d acute window.",
+  },
+  {
+    slug: "boundary-monotony",
+    frozenNow: DEFAULT_FROZEN_NOW,
+    description:
+      "Boundary-seeking fixture (fuzz-derived). Daily loads [21.2,154.3,268.1,122.0,34.6,33.1,231.2] over 05-04..05-10 put monotony's mean/stdev ratio exactly on the 2-dp boundary: the correctly-rounded statistics path gives 1.24, a naive float stdev gives 1.23. Defends the exact-rational mean/stdev port at the gate. Load-only (no wellness/ftp).",
+  },
+  {
+    slug: "boundary-sum-strain",
+    frozenNow: DEFAULT_FROZEN_NOW,
+    description:
+      "Boundary-seeking fixture (fuzz-derived). Daily loads 9.7/266.4/239.5/9.4 over 05-06..05-09 sum to exactly 525.0 under compensated (Neumaier) summation but 524.999…9 naively; with monotony 0.62 the product 325.5 rounds to strain 326 where a naive sum gives 325. Defends the compensated-sum port at the gate. Load-only (no wellness/ftp).",
+  },
+  {
+    slug: "boundary-zone-total-secs",
+    frozenNow: DEFAULT_FROZEN_NOW,
+    description:
+      "Boundary-seeking fixture (fuzz-derived). Three activities (05-08..05-10) whose z1–z7 one-decimal-second bins sum, per-activity-compensated, to exactly 36594s, but accumulate to 36594.00000000001s under a single flat naive sum across every activity's bins; that 1-ULP drift pushes total_hours across the 10.165 boundary (compensated 10.16 vs naive 10.17). Defends the per-activity compensated zone-total summation in the zone-distribution port. Zone-only (empty wellness/ftp).",
+  },
+  {
+    slug: "multisport-tie",
+    frozenNow: DEFAULT_FROZEN_NOW,
+    description:
+      "Primary-sport tiebreak fixture. Cycling [100,80,60] on 05-04..06 and run [60,60,60,60] on 05-07..10 each total exactly 240 over the 7d window; cycling is encountered first, so the `total > maxTotal` strict tiebreak (mirroring Python `max(dict, key=dict.get)` insertion order) must pick cycling. The two sports' daily distributions differ, so a tiebreak regression flips primary_sport_monotony to run's value — caught at the gate. Load+zones only (empty wellness/ftp).",
+  },
+  {
+    slug: "multisport-thin-primary",
+    frozenNow: DEFAULT_FROZEN_NOW,
+    description:
+      "effective_monotony selector branch B (multi-sport, primary=null → fall back to total). Cycling [80,80,80] on 05-04..06 (total 240, 3 days) and run [150,150] on 05-09..10 (total 300, 2 days): run wins primary on total but has <3 active days, so primary_sport_monotony is null while total monotony is non-null. The selector's `!== null` gate does load-bearing work here — inverting it regresses with no other fixture defense. Load+zones only (empty wellness/ftp).",
+  },
+  {
+    slug: "populated-benchmark-and-consistency",
+    frozenNow: DEFAULT_FROZEN_NOW,
+    description:
+      "Populated-branch coverage for consistency_index + benchmark_indoor + benchmark_outdoor — the F11 metrics whose previous fixtures all collapsed to the null branch. 4 WORKOUT events on 05-05/07/09/10 paired with cycling activities on 05-05/07/09 give matched=3, planned=4, consistency_index=0.75. FTP history has a 2026-03-15 entry sitting exactly at (frozenNow - 56d), exercising the +/-7d nearest-match window: indoor 280/270-1=0.037 in seasonal range [0.01,0.04] → seasonal_expected=true; outdoor 270/260-1=0.038 same range true. Without this fixture the parity gate is theatre for those three metrics.",
+  },
+  {
+    slug: "rest-week-with-baseline",
+    frozenNow: DEFAULT_FROZEN_NOW,
+    description:
+      "Constant-Load coverage for the monotony stdev=0 branch. 7 recovery rides on 05-04..05-10 at an IDENTICAL daily Load of 35.0 give the 7d series [35,35,35,35,35,35,35] — non-zero mean, sample stdev exactly 0 — so monotony hits the `stdevLoad <= 0 -> null` guard (a path the all-zero fixtures reach via a different branch). That null cascades: strain -> null, stress_tolerance -> null. Single-sport, so primary_sport_monotony hits its own stdev=0 null too. The 28-day wellness baseline (stable RHR 58 / HRV 52) populates recovery_index + HRV/RHR baselines through the flat block. Anchor 2026-05-10 puts the constant week in the 7d acute window.",
+  },
+];

--- a/tools/measure-reference-coverage-native.py
+++ b/tools/measure-reference-coverage-native.py
@@ -264,28 +264,34 @@ def main() -> int:
     data = cov.get_data()
     executed_lines = set(data.lines(str(sync_py_path)) or [])
 
-    # Missing lines + branch arcs via coverage's analysis. analysis2 is the
-    # public surface for missing lines; _analyze exposes branch arcs (kept
-    # in a try/except so a coverage-API shift degrades to line-only).
+    # Missing lines come from analysis2 (public API). One _analyze pass
+    # (private API — hence the noqa + guard) then yields both the missing
+    # branch arcs and the branch totals; a coverage-API shift degrades to the
+    # line-only coverage above.
     _f, statements, _excl, missing, _fmt = cov.analysis2(str(sync_py_path))
     missing_set = set(missing)
     missing_branch_arcs: dict[int, list[int]] = {}
+    total_branches = 0
+    covered_branches = 0
     try:
         analysis = cov._analyze(str(sync_py_path))  # noqa: SLF001
         for src, dsts in analysis.missing_branch_arcs().items():
             missing_branch_arcs[int(src)] = sorted(int(d) for d in dsts)
+        total_branches = analysis.numbers.n_branches
+        covered_branches = total_branches - analysis.numbers.n_missing_branches
     except Exception:  # noqa: BLE001
-        missing_branch_arcs = {}
+        pass
 
+    # A function ran iff a BODY line executed — the def line alone executes at
+    # module-load for every function and is not evidence of a call. Compute the
+    # entered set once; the report loop and the summary count both reuse it.
     def entered(fn: dict) -> bool:
-        # A function ran iff a BODY line executed — the def line alone executes
-        # at module-load for every function and is not evidence of a call.
         return any(ln in executed_lines for ln in range(fn["body_start"], fn["end"] + 1))
 
+    entered_fns = [fn for fn in fns if entered(fn)]
+
     report_fns = []
-    for fn in fns:
-        if not entered(fn):
-            continue  # function never ran on the metrics path — not a callee
+    for fn in entered_fns:
         rng = range(fn["start"], fn["end"] + 1)
         fn_missing_lines = sorted(ln for ln in missing_set if ln in rng)
         fn_missing_branches = {
@@ -302,16 +308,6 @@ def main() -> int:
             "missing_branch_arcs": [{"from": s, "to": d} for s, dsts in fn_missing_branches.items() for d in dsts],
         })
 
-    total_branches = 0
-    covered_branches = 0
-    try:
-        analysis = cov._analyze(str(sync_py_path))  # noqa: SLF001
-        n_branches, n_partial = analysis.numbers.n_branches, analysis.numbers.n_missing_branches
-        total_branches = n_branches
-        covered_branches = n_branches - n_partial
-    except Exception:  # noqa: BLE001
-        pass
-
     report = {
         "upstream_sync_py": str(sync_py_path),
         "fixtures_run": ran,
@@ -321,7 +317,7 @@ def main() -> int:
             "executed_statements": len(statements) - len(missing_set),
             "total_branches": total_branches,
             "covered_branches": covered_branches,
-            "functions_entered": sum(1 for fn in fns if entered(fn)),
+            "functions_entered": len(entered_fns),
             "functions_with_gaps": len(report_fns),
         },
         # Only functions the metrics path actually entered, that still have gaps.

--- a/tools/measure-reference-coverage.ts
+++ b/tools/measure-reference-coverage.ts
@@ -27,28 +27,12 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
 import { REPO_ROOT } from "./check-metric-parity";
+import { HARNESS_FIXTURES } from "./harness-fixtures.js";
 
 const GOLDEN_DIR = resolve(REPO_ROOT, "packages/core/tests/fixtures/golden");
-const MANIFEST_PATH = resolve(
-  REPO_ROOT,
-  "packages/core/tests/fixtures/snapshots/manifest.json",
-);
 const SECTION_11_REPO =
   process.env.SECTION_11_REPO ?? resolve(REPO_ROOT, "../section-11");
 const NATIVE_SCRIPT = resolve(REPO_ROOT, "tools/measure-reference-coverage-native.py");
-
-// Per-fixture frozen-now anchor. Mirrors the HARNESS_FIXTURES allowlist in
-// tools/snapshot-section-11.ts: every fixture uses the default anchor except
-// data-gap-mid-history, whose 28-day gap needs a later anchor to land the
-// resumed week in the acute window. Keep in step with that allowlist.
-const DEFAULT_FROZEN_NOW = "2026-05-10T12:00:00";
-const FROZEN_NOW_OVERRIDES: Record<string, string> = {
-  "data-gap-mid-history": "2026-05-20T12:00:00",
-};
-
-interface ManifestFile {
-  fixtures: string[];
-}
 
 interface CoverageReport {
   upstream_sync_py: string;
@@ -71,13 +55,12 @@ interface CoverageReport {
   }[];
 }
 
+// Drive coverage over the same fixtures + anchors the snapshot harness uses,
+// straight from the shared allowlist — no second copy of the anchor table.
 function buildManifest(tmpDir: string): string {
-  const { fixtures } = JSON.parse(
-    readFileSync(MANIFEST_PATH, "utf8"),
-  ) as ManifestFile;
-  const entries = fixtures.map((slug) => ({
+  const entries = HARNESS_FIXTURES.map(({ slug, frozenNow }) => ({
     path: join(GOLDEN_DIR, `${slug}.json`),
-    frozen_now: FROZEN_NOW_OVERRIDES[slug] ?? DEFAULT_FROZEN_NOW,
+    frozen_now: frozenNow,
   }));
   const manifestPath = join(tmpDir, "coverage-manifest.json");
   writeFileSync(manifestPath, JSON.stringify(entries, null, 2));

--- a/tools/snapshot-section-11.ts
+++ b/tools/snapshot-section-11.ts
@@ -18,7 +18,6 @@ import { execSync } from "node:child_process";
 import {
   existsSync,
   mkdirSync,
-  readdirSync,
   readFileSync,
   writeFileSync,
 } from "node:fs";
@@ -28,6 +27,7 @@ import { fileURLToPath } from "node:url";
 import { loadPyodide } from "pyodide";
 
 import type { Manifest, Snapshot } from "./check-metric-parity";
+import { DEFAULT_FROZEN_NOW, HARNESS_FIXTURES } from "./harness-fixtures.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, "..");
@@ -39,87 +39,6 @@ const SYNC_PY_PATH = join(SECTION_11_REPO, "examples/sync.py");
 
 const GOLDEN_DIR_REL = "packages/core/tests/fixtures/golden";
 const SNAPSHOT_ROOT_REL = "packages/core/tests/fixtures/snapshots";
-
-// Default anchor used when SNAPSHOT_FIXTURE_PATH points at a fixture not
-// in the allowlist (determinism/contract tests). The manifest's
-// `frozen_now` field also takes this value as the default; per-fixture
-// overrides ride through each per-snapshot wrapper's `frozen_now` field.
-const DEFAULT_FROZEN_NOW = "2026-05-10T12:00:00";
-
-// Allowlist of golden fixtures the snapshot harness processes. Adding a
-// fixture is an explicit edit here — the golden dir also holds fixtures
-// owned by other tests (F7 reference substrate's `post-break-resume`,
-// `zero-activities`) that don't conform to sync.py's contract and must
-// not be run through this harness. Each entry's `description` field
-// carries the rationale for the slug + the anchor it chose.
-interface HarnessFixtureConfig {
-  slug: string;
-  frozenNow: string;
-  description: string;
-}
-
-const HARNESS_FIXTURES: HarnessFixtureConfig[] = [
-  {
-    slug: "realistic-athlete",
-    frozenNow: DEFAULT_FROZEN_NOW,
-    description:
-      "Happy-path baseline — sanitized real athlete bundle. Exercises the populated branches of every metric. Anchor 2026-05-10 sits one day after the fixture's last activity.",
-  },
-  {
-    slug: "new-athlete-empty",
-    frozenNow: DEFAULT_FROZEN_NOW,
-    description:
-      "Zero activities, zero wellness, zero ftp_history. Forces every 'no data' branch — ACWR div-by-zero, monotony of empty week, recovery_index no-contributors. Anchor doesn't matter; reuses the default.",
-  },
-  {
-    slug: "data-gap-mid-history",
-    frozenNow: "2026-05-20T12:00:00",
-    description:
-      "21 activities split by a 28-day gap (14 days 2026-04-01..04-14, gap 04-15..05-12, 7 days resumed 05-13..05-19). Exercises EWMA decay through the gap, ACWR chronic window seeing zeros, monotony on the resumed week. Anchor 2026-05-20 catches the resumed week in the 7d acute window.",
-  },
-  {
-    slug: "boundary-monotony",
-    frozenNow: DEFAULT_FROZEN_NOW,
-    description:
-      "Boundary-seeking fixture (fuzz-derived). Daily loads [21.2,154.3,268.1,122.0,34.6,33.1,231.2] over 05-04..05-10 put monotony's mean/stdev ratio exactly on the 2-dp boundary: the correctly-rounded statistics path gives 1.24, a naive float stdev gives 1.23. Defends the exact-rational mean/stdev port at the gate. Load-only (no wellness/ftp).",
-  },
-  {
-    slug: "boundary-sum-strain",
-    frozenNow: DEFAULT_FROZEN_NOW,
-    description:
-      "Boundary-seeking fixture (fuzz-derived). Daily loads 9.7/266.4/239.5/9.4 over 05-06..05-09 sum to exactly 525.0 under compensated (Neumaier) summation but 524.999…9 naively; with monotony 0.62 the product 325.5 rounds to strain 326 where a naive sum gives 325. Defends the compensated-sum port at the gate. Load-only (no wellness/ftp).",
-  },
-  {
-    slug: "boundary-zone-total-secs",
-    frozenNow: DEFAULT_FROZEN_NOW,
-    description:
-      "Boundary-seeking fixture (fuzz-derived). Three activities (05-08..05-10) whose z1–z7 one-decimal-second bins sum, per-activity-compensated, to exactly 36594s, but accumulate to 36594.00000000001s under a single flat naive sum across every activity's bins; that 1-ULP drift pushes total_hours across the 10.165 boundary (compensated 10.16 vs naive 10.17). Defends the per-activity compensated zone-total summation in the zone-distribution port. Zone-only (empty wellness/ftp).",
-  },
-  {
-    slug: "multisport-tie",
-    frozenNow: DEFAULT_FROZEN_NOW,
-    description:
-      "Primary-sport tiebreak fixture. Cycling [100,80,60] on 05-04..06 and run [60,60,60,60] on 05-07..10 each total exactly 240 over the 7d window; cycling is encountered first, so the `total > maxTotal` strict tiebreak (mirroring Python `max(dict, key=dict.get)` insertion order) must pick cycling. The two sports' daily distributions differ, so a tiebreak regression flips primary_sport_monotony to run's value — caught at the gate. Load+zones only (empty wellness/ftp).",
-  },
-  {
-    slug: "multisport-thin-primary",
-    frozenNow: DEFAULT_FROZEN_NOW,
-    description:
-      "effective_monotony selector branch B (multi-sport, primary=null → fall back to total). Cycling [80,80,80] on 05-04..06 (total 240, 3 days) and run [150,150] on 05-09..10 (total 300, 2 days): run wins primary on total but has <3 active days, so primary_sport_monotony is null while total monotony is non-null. The selector's `!== null` gate does load-bearing work here — inverting it regresses with no other fixture defense. Load+zones only (empty wellness/ftp).",
-  },
-  {
-    slug: "populated-benchmark-and-consistency",
-    frozenNow: DEFAULT_FROZEN_NOW,
-    description:
-      "Populated-branch coverage for consistency_index + benchmark_indoor + benchmark_outdoor — the F11 metrics whose previous fixtures all collapsed to the null branch. 4 WORKOUT events on 05-05/07/09/10 paired with cycling activities on 05-05/07/09 give matched=3, planned=4, consistency_index=0.75. FTP history has a 2026-03-15 entry sitting exactly at (frozenNow - 56d), exercising the +/-7d nearest-match window: indoor 280/270-1=0.037 in seasonal range [0.01,0.04] → seasonal_expected=true; outdoor 270/260-1=0.038 same range true. Without this fixture the parity gate is theatre for those three metrics.",
-  },
-  {
-    slug: "rest-week-with-baseline",
-    frozenNow: DEFAULT_FROZEN_NOW,
-    description:
-      "Constant-Load coverage for the monotony stdev=0 branch. 7 recovery rides on 05-04..05-10 at an IDENTICAL daily Load of 35.0 give the 7d series [35,35,35,35,35,35,35] — non-zero mean, sample stdev exactly 0 — so monotony hits the `stdevLoad <= 0 -> null` guard (a path the all-zero fixtures reach via a different branch). That null cascades: strain -> null, stress_tolerance -> null. Single-sport, so primary_sport_monotony hits its own stdev=0 null too. The 28-day wellness baseline (stable RHR 58 / HRV 52) populates recovery_index + HRV/RHR baselines through the flat block. Anchor 2026-05-10 puts the constant week in the 7d acute window.",
-  },
-];
 
 function readPyodideVersion(): string {
   const pkg = JSON.parse(


### PR DESCRIPTION
A `/simplify` quality pass over #130/#131/#132 (reuse, simplification, efficiency, altitude). **No behavior change** — snapshots regenerate byte-identical (0 diff), `check-parity --all` stays at 290 OK / 0 mismatches, the coverage probe emits the same report.

## Fixes

1. **Altitude — move `getActivitiesInWindow` to its proper home.** It was `export`ed from `distribution.ts` so `capability.ts` could import it, creating a `capability → distribution` cross-tier dependency. Moved to `metric-input.ts` (the established home for shared metric accessors, next to `getActivities`); both modules import it from there.

2. **Reuse — single source of truth for the fixture allowlist.** The coverage probe hand-mirrored the per-fixture frozen-now anchor table from `HARNESS_FIXTURES` (with a "keep in step by hand" comment — a standing drift hazard). Extracted `HARNESS_FIXTURES` + `DEFAULT_FROZEN_NOW` into `tools/harness-fixtures.ts`; the snapshot harness and coverage probe both import it, and the probe builds its manifest straight from the shared list (no duplicated anchors, no `manifest.json` read).

3. **Simplification / efficiency — collapse the coverage analysis passes.** `measure-reference-coverage-native.py` called `cov._analyze()` twice plus `analysis2()`. One `_analyze()` pass now yields both branch arcs and totals (`analysis2` stays as the line-only fallback), and the entered-function set is computed once instead of re-scanned for the summary count.

4. **Dead code — drop an unused `readdirSync` import** from `snapshot-section-11.ts` (pre-existing; `tools/` isn't in the CI lint set).

## Skipped (reviewed, judged justified)

Intentional native-twin prologue duplication (the diff *is* the lockstep check), the "explode capability" duplication across the two harnesses + its `list()` micro-nit, the `.gitignore .coverage` entry (idiomatic defense-in-depth), `del derived["capability"]` (monolith kept by design), a dotted-registry-key assertion (YAGNI), and the `capability.ts` null-checks (faithful line-by-line port).

## Verification

- `pnpm snapshot:section-11` → **0 snapshot/golden files changed** (byte-identical).
- `pnpm check-parity --all` → 290 OK, 0 mismatches.
- `pnpm coverage:reference` → same report (10 fixtures, 40 entered, same F10 gaps).
- Core build (DTS) + `oxlint` on touched files → clean. Core metric suite: 351 passed.

_(Pre-existing, out of scope: `sanitize-cli-fixture-stability.test.ts` fails locally on clean `main` too — not touched here, green in CI on the merged PRs. Local-environment artifact.)_