### PR TITLE
feat(core): port capability.efficiency_factor

### DIFF
--- a/packages/core/src/reference/metrics/capability.test.ts
+++ b/packages/core/src/reference/metrics/capability.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { computeDurability } from "./capability.js";
+import { computeDurability, computeEfficiencyFactor } from "./capability.js";
 import type { MetricInput } from "./metric-input.js";
 
 interface SyntheticActivity {
@@ -11,6 +11,7 @@ interface SyntheticActivity {
   icu_variability_index?: number | null;
   icu_hr_decoupling?: number | null;
   decoupling?: number | null;
+  icu_efficiency_factor?: number | null;
 }
 
 function input(activities: SyntheticActivity[], frozenNow = "2026-05-10T12:00:00"): MetricInput {
@@ -106,5 +107,120 @@ describe("computeDurability", () => {
     expect(result.qualifying_sessions_7d).toBe(1);
     expect(result.mean_decoupling_7d).toBeNull(); // needs >= 2
     expect(result.reliability_limited).toBe(true);
+  });
+});
+
+const EF_NOTE =
+  "Steady-state cycling sessions only (VI <= 1.05, VI > 0, >= 20min, power+HR data). " +
+  "Rising EF = improving aerobic efficiency. Compare like-for-like sessions only — " +
+  "EF varies with intensity. Trend compares 7d vs 28d mean (+/-0.03 = stable).";
+
+// A steady-state cycling session that passes the EF _filter_qualifying: EF
+// present, a cycling type, 0 < VI <= 1.05, moving_time >= 1200s. `ef` is the
+// efficiency-factor value.
+function qualifyingEf(date: string, ef: number, type = "Ride"): SyntheticActivity {
+  return {
+    id: `ef-${date}-${ef}`,
+    start_date_local: `${date}T09:00:00`,
+    type,
+    moving_time: 1800,
+    icu_variability_index: 1.0,
+    icu_efficiency_factor: ef,
+  };
+}
+
+describe("computeEfficiencyFactor", () => {
+  it("returns the insufficient-sessions shape when no activity qualifies (golden-fixture branch)", () => {
+    const result = computeEfficiencyFactor(input([]));
+    expect(result).toEqual({
+      mean_ef_7d: null,
+      mean_ef_28d: null,
+      qualifying_sessions_7d: 0,
+      qualifying_sessions_28d: 0,
+      trend: null,
+      note: EF_NOTE,
+    });
+  });
+
+  it("rejects non-qualifying sessions: non-cycling type, VI out of range, too short, or missing EF", () => {
+    const result = computeEfficiencyFactor(
+      input([
+        { id: 1, start_date_local: "2026-05-08T09:00:00", type: "Run", moving_time: 1800, icu_variability_index: 1.0, icu_efficiency_factor: 2.0 }, // not a cycling type
+        { id: 2, start_date_local: "2026-05-08T09:00:00", type: "Ride", moving_time: 1800, icu_variability_index: 1.06, icu_efficiency_factor: 2.0 }, // VI > 1.05
+        { id: 3, start_date_local: "2026-05-08T09:00:00", type: "Ride", moving_time: 1800, icu_variability_index: 0, icu_efficiency_factor: 2.0 }, // VI not > 0
+        { id: 4, start_date_local: "2026-05-08T09:00:00", type: "Ride", moving_time: 1199, icu_variability_index: 1.0, icu_efficiency_factor: 2.0 }, // < 20 min
+        { id: 5, start_date_local: "2026-05-08T09:00:00", type: "Ride", moving_time: 1800, icu_variability_index: 1.0 }, // missing EF
+      ]),
+    );
+    expect(result.qualifying_sessions_7d).toBe(0);
+    expect(result.qualifying_sessions_28d).toBe(0);
+  });
+
+  it("accepts all four cycling types and rejects other sports", () => {
+    const result = computeEfficiencyFactor(
+      input([
+        qualifyingEf("2026-05-07", 2.0, "Ride"),
+        qualifyingEf("2026-05-08", 2.0, "VirtualRide"),
+        qualifyingEf("2026-05-09", 2.0, "MountainBikeRide"),
+        qualifyingEf("2026-05-10", 2.0, "GravelRide"),
+        qualifyingEf("2026-05-10", 9.0, "Swim"), // rejected — not a cycling type
+      ]),
+    );
+    expect(result.qualifying_sessions_7d).toBe(4);
+  });
+
+  it("computes means and an improving trend when both windows have >= 2 qualifying sessions", () => {
+    const result = computeEfficiencyFactor(
+      input([
+        // 3 in the 7d window (05-04..05-10)
+        qualifyingEf("2026-05-08", 2.5),
+        qualifyingEf("2026-05-09", 2.5),
+        qualifyingEf("2026-05-10", 2.5),
+        // 2 more in 28d-only (04-13..05-03)
+        qualifyingEf("2026-04-20", 2.0),
+        qualifyingEf("2026-04-25", 2.0),
+      ]),
+    );
+    expect(result.qualifying_sessions_7d).toBe(3);
+    expect(result.qualifying_sessions_28d).toBe(5);
+    expect(result.mean_ef_7d).toBe(2.5);
+    expect(result.mean_ef_28d).toBe(2.3); // (2.5*3 + 2.0*2) / 5 = 11.5 / 5
+    expect(result.trend).toBe("improving"); // 2.5 - 2.3 = 0.2 > 0.03
+  });
+
+  it("reports a declining trend when the 7d mean drops below the 28d mean by more than 0.03", () => {
+    const result = computeEfficiencyFactor(
+      input([
+        qualifyingEf("2026-05-08", 2.0),
+        qualifyingEf("2026-05-09", 2.0),
+        qualifyingEf("2026-05-10", 2.0),
+        qualifyingEf("2026-04-20", 2.5),
+        qualifyingEf("2026-04-25", 2.5),
+      ]),
+    );
+    expect(result.mean_ef_7d).toBe(2.0);
+    expect(result.mean_ef_28d).toBe(2.2); // (2.0*3 + 2.5*2) / 5 = 11 / 5
+    expect(result.trend).toBe("declining"); // 2.0 - 2.2 = -0.2 < -0.03
+  });
+
+  it("reports a stable trend when the 7d and 28d means sit inside the +/-0.03 dead-band", () => {
+    const result = computeEfficiencyFactor(
+      input([
+        qualifyingEf("2026-05-08", 2.0),
+        qualifyingEf("2026-05-09", 2.0),
+        qualifyingEf("2026-04-20", 2.0),
+        qualifyingEf("2026-04-25", 2.0),
+      ]),
+    );
+    expect(result.mean_ef_7d).toBe(2.0);
+    expect(result.mean_ef_28d).toBe(2.0);
+    expect(result.trend).toBe("stable");
+  });
+
+  it("leaves the mean null but counts the session when only one qualifies", () => {
+    const result = computeEfficiencyFactor(input([qualifyingEf("2026-05-08", 2.0)]));
+    expect(result.qualifying_sessions_7d).toBe(1);
+    expect(result.mean_ef_7d).toBeNull(); // needs >= 2
+    expect(result.trend).toBeNull();
   });
 });

--- a/packages/core/src/reference/metrics/capability.ts
+++ b/packages/core/src/reference/metrics/capability.ts
@@ -29,6 +29,15 @@ export interface DurabilitySignal {
   note: string;
 }
 
+export interface EfficiencyFactorSignal {
+  mean_ef_7d: number | null;
+  mean_ef_28d: number | null;
+  qualifying_sessions_7d: number;
+  qualifying_sessions_28d: number;
+  trend: "improving" | "declining" | "stable" | null;
+  note: string;
+}
+
 // Steady-state-session decoupling values from a window. Qualifying =
 // decoupling present, variability index in (0, 1.05], moving_time ≥ 90 min.
 // Mirrors the nested `_filter_qualifying` at sync.py:4061-4078. The raw API
@@ -51,6 +60,36 @@ function filterQualifying(activities: Activity[]): number[] {
       mt >= 5400
     ) {
       qualifying.push(dec);
+    }
+  }
+  return qualifying;
+}
+
+// Cycling activity types EF is restricted to. Mirrors the CYCLING_TYPES set
+// at sync.py:4161.
+const CYCLING_TYPES = new Set(["Ride", "VirtualRide", "MountainBikeRide", "GravelRide"]);
+
+// Steady-state-session efficiency-factor values from a window. Qualifying =
+// EF present, a cycling type, variability index in (0, 1.05], moving_time >=
+// 20 min. Mirrors the nested _filter_qualifying at sync.py:4163-4179.
+function filterQualifyingEf(activities: Activity[]): number[] {
+  const qualifying: number[] = [];
+  for (const act of activities) {
+    const ef = act.icu_efficiency_factor;
+    const vi = act.icu_variability_index;
+    const mt = act.moving_time || 0;
+
+    if (
+      ef !== null &&
+      ef !== undefined &&
+      CYCLING_TYPES.has(act.type) &&
+      vi !== null &&
+      vi !== undefined &&
+      vi > 0 &&
+      vi <= 1.05 &&
+      mt >= 1200
+    ) {
+      qualifying.push(ef);
     }
   }
   return qualifying;
@@ -116,5 +155,49 @@ export function computeDurability(input: MetricInput): DurabilitySignal {
       "Negative decoupling = strong durability. Trend compares 7d vs 28d mean " +
       "(+/-1% = stable). Alerts require N28>=5 (alarm) or N7>=3 AND N28>=5 " +
       "(declining warning) for statistical reliability.",
+  };
+}
+
+/**
+ * Efficiency Factor — aggregate EF across qualifying steady-state cycling
+ * sessions, as a 7d-vs-28d trend. EF is a power-to-heart-rate efficiency
+ * ratio (intervals.icu supplies it per activity as icu_efficiency_factor);
+ * rising EF at a given intensity indicates improving aerobic fitness, and
+ * because EF varies with intensity the trend compares like-for-like windows.
+ *
+ * Means need >= 2 qualifying sessions; the trend needs both windows and uses
+ * a +/-0.03 dead-band around the 7d-minus-28d delta.
+ *
+ * Upstream source mirrored line-by-line: sync.py:4138-4214
+ * (_calculate_efficiency_factor) plus the nested _filter_qualifying helper at
+ * sync.py:4163-4179. The 7d/28d activity windows mirror the harness
+ * slice_window calls. See NOTICE.md for upstream attribution.
+ */
+export function computeEfficiencyFactor(input: MetricInput): EfficiencyFactorSignal {
+  const activities = getActivities(input);
+  const vals7d = filterQualifyingEf(getActivitiesInWindow(activities, 7, input.frozenNow));
+  const vals28d = filterQualifyingEf(getActivitiesInWindow(activities, 28, input.frozenNow));
+
+  const mean7d = vals7d.length >= 2 ? roundHalfEven(mean(vals7d), 2) : null;
+  const mean28d = vals28d.length >= 2 ? roundHalfEven(mean(vals28d), 2) : null;
+
+  let trend: EfficiencyFactorSignal["trend"] = null;
+  if (mean7d !== null && mean28d !== null) {
+    const delta = mean7d - mean28d;
+    if (delta > 0.03) trend = "improving";
+    else if (delta < -0.03) trend = "declining";
+    else trend = "stable";
+  }
+
+  return {
+    mean_ef_7d: mean7d,
+    mean_ef_28d: mean28d,
+    qualifying_sessions_7d: vals7d.length,
+    qualifying_sessions_28d: vals28d.length,
+    trend,
+    note:
+      "Steady-state cycling sessions only (VI <= 1.05, VI > 0, >= 20min, power+HR data). " +
+      "Rising EF = improving aerobic efficiency. Compare like-for-like sessions only — " +
+      "EF varies with intensity. Trend compares 7d vs 28d mean (+/-0.03 = stable).",
   };
 }

--- a/packages/core/src/reference/metrics/registry.ts
+++ b/packages/core/src/reference/metrics/registry.ts
@@ -9,7 +9,7 @@
  */
 
 import { computeWeightSignal } from "./bodycomp.js";
-import { computeDurability } from "./capability.js";
+import { computeDurability, computeEfficiencyFactor } from "./capability.js";
 import {
   computeBenchmarkIndoor,
   computeBenchmarkOutdoor,
@@ -79,4 +79,5 @@ export const METRIC_REGISTRY: Record<string, MetricRegistryEntry> = {
   effort_response_signal: { compute: computeEffortResponseSignal },
   weight_signal: { compute: computeWeightSignal },
   "capability.durability": { compute: computeDurability },
+  "capability.efficiency_factor": { compute: computeEfficiencyFactor },
 };


### PR DESCRIPTION
## What

Ports `capability.efficiency_factor`, the second of the eight capability sub-keys the upstream emits under the `capability` dict (after `capability.durability` in #132).

`computeEfficiencyFactor` is a line-by-line transliteration of `sync.py:4138-4214` (`_calculate_efficiency_factor`, plus the nested `_filter_qualifying` at `sync.py:4163-4179`):

- **Qualifying session** = a cycling type (`Ride`, `VirtualRide`, `MountainBikeRide`, `GravelRide`) with an efficiency factor present, variability index in `(0, 1.05]`, and `moving_time >= 1200s` (20 min).
- **Means** — `round(mean, 2)` over the 7d / 28d windows, computed only when ≥ 2 sessions qualify.
- **Trend** — `improving` / `declining` / `stable` from the 7d-minus-28d delta with a ±0.03 dead-band; `null` unless both windows have a mean.
- No reliability gate — that field group is durability-specific.

`icu_efficiency_factor` was already added to `ActivitySchema` in #132, so there is no schema change here.

## Verification

- **Bit-identical parity** across all 10 fixtures (`check-parity --metric=capability.efficiency_factor`). The committed oracles all hit the insufficient-sessions branch, so the populated paths (cycling-type filter, VI/duration gating, the ≥ 2-session mean rule, all three trend branches) are covered by 7 new unit tests.
- `check-parity --all`: 0 failures; the unregistered-snapshot warning drops from 7 → 6 capability sub-keys.
- `pnpm check` (build + lint + trademarks) clean; reference-parity matrix 311 passing; capability unit tests 12 passing.

## Discipline

Faithful transliteration — no algorithmic deviation, so no `tools/intentional-deviations.yaml` entry is needed. Reviewed across three lenses (transliteration fidelity, project voice/trademark, unit-test arithmetic).
