### PR TITLE
feat(core): port capability.hrrc — HRRc recovery-quality trend

### DIFF
--- a/packages/core/src/reference/metrics/capability.test.ts
+++ b/packages/core/src/reference/metrics/capability.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { computeDurability, computeEfficiencyFactor } from "./capability.js";
+import { computeDurability, computeEfficiencyFactor, computeHrrc } from "./capability.js";
 import type { MetricInput } from "./metric-input.js";
 
 interface SyntheticActivity {
@@ -12,6 +12,7 @@ interface SyntheticActivity {
   icu_hr_decoupling?: number | null;
   decoupling?: number | null;
   icu_efficiency_factor?: number | null;
+  icu_hrr?: number | { value?: number | null; hrr?: number | null } | null;
 }
 
 function input(activities: SyntheticActivity[], frozenNow = "2026-05-10T12:00:00"): MetricInput {
@@ -222,5 +223,110 @@ describe("computeEfficiencyFactor", () => {
     expect(result.qualifying_sessions_7d).toBe(1);
     expect(result.mean_ef_7d).toBeNull(); // needs >= 2
     expect(result.trend).toBeNull();
+  });
+});
+
+const HRRC_NOTE =
+  "HRRc = heart rate recovery (largest 60s HR drop in bpm after exceeding threshold HR for >1 min). " +
+  "Higher = better parasympathetic recovery. Null when threshold not reached, recording stopped " +
+  "before cooldown, or no HR data. Trend: 7d mean vs 28d mean, >10% = meaningful " +
+  "(min 1 session/7d, 3 sessions/28d). Display only — not wired into readiness_decision signals.";
+
+// A session that passes the HRRc _filter_qualifying: HRRc present and > 0.
+function qualifyingHrrc(date: string, hrr: number): SyntheticActivity {
+  return {
+    id: `hrrc-${date}-${hrr}`,
+    start_date_local: `${date}T09:00:00`,
+    type: "Ride",
+    moving_time: 3600,
+    icu_hrr: hrr,
+  };
+}
+
+describe("computeHrrc", () => {
+  it("empty → insufficient shape (golden-fixture branch)", () => {
+    const result = computeHrrc(input([]));
+    expect(result).toEqual({
+      mean_hrrc_7d: null,
+      mean_hrrc_28d: null,
+      qualifying_sessions_7d: 0,
+      qualifying_sessions_28d: 0,
+      trend: null,
+      note: HRRC_NOTE,
+    });
+  });
+
+  it("dict-form extraction + value/hrr fallback + banker rounding", () => {
+    const result = computeHrrc(
+      input([
+        { start_date_local: "2026-05-08T09:00:00", type: "Ride", moving_time: 3600, icu_hrr: { value: 34 } },
+        { start_date_local: "2026-04-20T09:00:00", type: "Ride", moving_time: 3600, icu_hrr: { hrr: 30 } },
+        { start_date_local: "2026-04-25T09:00:00", type: "Ride", moving_time: 3600, icu_hrr: { value: null, hrr: 28 } },
+      ]),
+    );
+    expect(result.qualifying_sessions_7d).toBe(1);
+    expect(result.qualifying_sessions_28d).toBe(3);
+    expect(result.mean_hrrc_7d).toBe(34.0);
+    expect(result.mean_hrrc_28d).toBe(30.7);
+  });
+
+  it("filter rejects icu_hrr <= 0 and missing", () => {
+    const result = computeHrrc(
+      input([
+        { start_date_local: "2026-05-08T09:00:00", type: "Ride", moving_time: 3600, icu_hrr: 0 },
+        { start_date_local: "2026-05-08T09:00:00", type: "Ride", moving_time: 3600, icu_hrr: -5 },
+        { start_date_local: "2026-05-08T09:00:00", type: "Ride", moving_time: 3600 },
+        qualifyingHrrc("2026-05-08", 25),
+      ]),
+    );
+    expect(result.qualifying_sessions_28d).toBe(1);
+  });
+
+  it("7d>=1 emits a mean but 28d<3 stays null", () => {
+    const result = computeHrrc(input([qualifyingHrrc("2026-05-08", 35)]));
+    expect(result.qualifying_sessions_7d).toBe(1);
+    expect(result.mean_hrrc_7d).toBe(35.0);
+    expect(result.mean_hrrc_28d).toBeNull();
+    expect(result.qualifying_sessions_28d).toBe(1);
+    expect(result.trend).toBeNull();
+  });
+
+  it("improving trend", () => {
+    const result = computeHrrc(
+      input([
+        qualifyingHrrc("2026-05-08", 40),
+        qualifyingHrrc("2026-04-20", 30),
+        qualifyingHrrc("2026-04-25", 20),
+      ]),
+    );
+    expect(result.mean_hrrc_7d).toBe(40.0);
+    expect(result.mean_hrrc_28d).toBe(30.0);
+    expect(result.trend).toBe("improving");
+  });
+
+  it("declining trend", () => {
+    const result = computeHrrc(
+      input([
+        qualifyingHrrc("2026-05-08", 26),
+        qualifyingHrrc("2026-04-20", 32),
+        qualifyingHrrc("2026-04-25", 32),
+      ]),
+    );
+    expect(result.mean_hrrc_7d).toBe(26.0);
+    expect(result.mean_hrrc_28d).toBe(30.0);
+    expect(result.trend).toBe("declining");
+  });
+
+  it("stable trend (inside ±10%)", () => {
+    const result = computeHrrc(
+      input([
+        qualifyingHrrc("2026-05-08", 31),
+        qualifyingHrrc("2026-04-20", 30),
+        qualifyingHrrc("2026-04-25", 29),
+      ]),
+    );
+    expect(result.mean_hrrc_7d).toBe(31.0);
+    expect(result.mean_hrrc_28d).toBe(30.0);
+    expect(result.trend).toBe("stable");
   });
 });

--- a/packages/core/src/reference/metrics/capability.ts
+++ b/packages/core/src/reference/metrics/capability.ts
@@ -201,3 +201,75 @@ export function computeEfficiencyFactor(input: MetricInput): EfficiencyFactorSig
       "EF varies with intensity. Trend compares 7d vs 28d mean (+/-0.03 = stable).",
   };
 }
+
+export interface HrrcSignal {
+  mean_hrrc_7d: number | null;
+  mean_hrrc_28d: number | null;
+  qualifying_sessions_7d: number;
+  qualifying_sessions_28d: number;
+  trend: "improving" | "declining" | "stable" | null;
+  note: string;
+}
+
+// Heart-rate-recovery values from a window. Qualifying = HRRc present, plain
+// number or object value/hrr payload, and > 0. Mirrors the nested
+// _filter_qualifying at sync.py:4217-4232.
+function filterQualifyingHrrc(activities: Activity[]): number[] {
+  const qualifying: number[] = [];
+  for (const act of activities) {
+    let hrrc = act.icu_hrr;
+    if (hrrc === null || hrrc === undefined) continue;
+    if (typeof hrrc === "object") {
+      let v = hrrc.value;
+      if (v === null || v === undefined) v = hrrc.hrr;
+      hrrc = v;
+    }
+    if (typeof hrrc === "number" && hrrc > 0) {
+      qualifying.push(hrrc);
+    }
+  }
+  return qualifying;
+}
+
+/**
+ * HRRc — aggregate heart-rate recovery across qualifying sessions, as a
+ * 7d-vs-28d trend.
+ *
+ * The 7d mean needs >= 1 qualifying session; the 28d mean needs >= 3
+ * qualifying sessions. The trend needs both windows and uses a +/-10%
+ * dead-band around the proportional 7d-vs-28d difference.
+ *
+ * Upstream source mirrored line-by-line: sync.py:4216-4295
+ * (_calculate_hrrc_trend) plus the nested _filter_qualifying helper at
+ * sync.py:4217-4232. The 7d/28d activity windows mirror the harness
+ * slice_window calls. See NOTICE.md for upstream attribution.
+ */
+export function computeHrrc(input: MetricInput): HrrcSignal {
+  const activities = getActivities(input);
+  const vals7d = filterQualifyingHrrc(getActivitiesInWindow(activities, 7, input.frozenNow));
+  const vals28d = filterQualifyingHrrc(getActivitiesInWindow(activities, 28, input.frozenNow));
+
+  const mean7d = vals7d.length >= 1 ? roundHalfEven(mean(vals7d), 1) : null;
+  const mean28d = vals28d.length >= 3 ? roundHalfEven(mean(vals28d), 1) : null;
+
+  let trend: HrrcSignal["trend"] = null;
+  if (mean7d !== null && mean28d !== null && mean28d > 0) {
+    const pctChange = (mean7d - mean28d) / mean28d;
+    if (pctChange > 0.10) trend = "improving";
+    else if (pctChange < -0.10) trend = "declining";
+    else trend = "stable";
+  }
+
+  return {
+    mean_hrrc_7d: mean7d,
+    mean_hrrc_28d: mean28d,
+    qualifying_sessions_7d: vals7d.length,
+    qualifying_sessions_28d: vals28d.length,
+    trend,
+    note:
+      "HRRc = heart rate recovery (largest 60s HR drop in bpm after exceeding threshold HR for >1 min). " +
+      "Higher = better parasympathetic recovery. Null when threshold not reached, recording stopped " +
+      "before cooldown, or no HR data. Trend: 7d mean vs 28d mean, >10% = meaningful " +
+      "(min 1 session/7d, 3 sessions/28d). Display only — not wired into readiness_decision signals.",
+  };
+}

--- a/packages/core/src/reference/metrics/registry.ts
+++ b/packages/core/src/reference/metrics/registry.ts
@@ -9,7 +9,7 @@
  */
 
 import { computeWeightSignal } from "./bodycomp.js";
-import { computeDurability, computeEfficiencyFactor } from "./capability.js";
+import { computeDurability, computeEfficiencyFactor, computeHrrc } from "./capability.js";
 import {
   computeBenchmarkIndoor,
   computeBenchmarkOutdoor,
@@ -80,4 +80,5 @@ export const METRIC_REGISTRY: Record<string, MetricRegistryEntry> = {
   weight_signal: { compute: computeWeightSignal },
   "capability.durability": { compute: computeDurability },
   "capability.efficiency_factor": { compute: computeEfficiencyFactor },
+  "capability.hrrc": { compute: computeHrrc },
 };

--- a/packages/core/src/reference/schemas/inputs.ts
+++ b/packages/core/src/reference/schemas/inputs.ts
@@ -105,6 +105,18 @@ export const ActivitySchema = z.looseObject({
   icu_variability_index: z.number().nullable().optional(),
   pa_hr: z.number().nullable().optional(),
   icu_efficiency_factor: z.number().nullable().optional(),
+  icu_hrr: z
+    .union([
+      z.number(),
+      z
+        .object({
+          value: z.number().nullable().optional(),
+          hrr: z.number().nullable().optional(),
+        })
+        .loose(),
+    ])
+    .nullable()
+    .optional(),
   icu_intervals: z.array(IcuIntervalRepSchema).optional(),
 
   // Compliance


### PR DESCRIPTION
Ports the HRRc (heart-rate recovery) trend as a Reference-layer capability sub-key, transliterated line-by-line from `sync.py:4216-4295` (tolerance-0 parity gate).

## What
- `computeHrrc(input)` → 7d/28d qualifying-session means of `icu_hrr` (present and `> 0`; payload may be a plain number or a `{value,hrr}` object with `value`-then-`hrr` fallback), with the upstream's window minimums (7d ≥ 1, 28d ≥ 3), banker's-rounded to 1dp, and a ±10% proportional dead-band trend.
- Adds an additive, optional `icu_hrr` field to the `Activity` schema (`number | {value,hrr}`), `.nullable().optional()` so existing fixtures still validate.
- Registers `capability.hrrc` in the metric registry.

## Verification
- Parity gate green across all 10 fixtures (every fixture hits the empty branch — no `icu_hrr` data yet).
- 7 unit tests cover the populated branches the oracle can't reach: dict/number extraction + `value→hrr` fallback, the `> 0` filter, the 7d≥1 / 28d≥3 gates, banker's rounding, and improving/declining/stable trend.
- Independent re-derivation of every test expectation from the upstream confirms the arithmetic; typecheck + lint clean.

No changeset — internal Reference-layer metric, not wired into athlete-facing output (the note itself flags it display-only).
