### PR TITLE
feat(core): port capability.tid_comparison — 7d-vs-28d TID drift

### DIFF
--- a/packages/core/src/reference/metrics/capability.test.ts
+++ b/packages/core/src/reference/metrics/capability.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 
-import { computeDurability, computeEfficiencyFactor, computeHrrc } from "./capability.js";
+import {
+  compareTid,
+  computeDurability,
+  computeEfficiencyFactor,
+  computeHrrc,
+  computeTidComparison,
+} from "./capability.js";
 import type { MetricInput } from "./metric-input.js";
 
 interface SyntheticActivity {
@@ -328,5 +334,160 @@ describe("computeHrrc", () => {
     expect(result.mean_hrrc_7d).toBe(31.0);
     expect(result.mean_hrrc_28d).toBe(30.0);
     expect(result.trend).toBe("stable");
+  });
+});
+
+const TID_NOTE_INSUFFICIENT =
+  "Compares 7d vs 28d Seiler TID to detect distribution shifts. Insufficient data in one or both windows.";
+const TID_NOTE_FULL =
+  "Compares 7d vs 28d Seiler TID to detect distribution shifts. pi_delta positive = more polarized acutely.";
+
+describe("compareTid", () => {
+  it("insufficient (cls_7d null)", () => {
+    expect(
+      compareTid(
+        { classification: null, polarization_index: null },
+        { classification: "Base", polarization_index: 1.5 },
+      ),
+    ).toEqual({
+      classification_7d: null,
+      classification_28d: "Base",
+      pi_7d: null,
+      pi_28d: 1.5,
+      pi_delta: null,
+      drift: null,
+      note: TID_NOTE_INSUFFICIENT,
+    });
+  });
+
+  it("consistent (cls equal, pi null)", () => {
+    expect(
+      compareTid(
+        { classification: "Pyramidal", polarization_index: null },
+        { classification: "Pyramidal", polarization_index: null },
+      ),
+    ).toEqual({
+      classification_7d: "Pyramidal",
+      classification_28d: "Pyramidal",
+      pi_7d: null,
+      pi_28d: null,
+      pi_delta: null,
+      drift: "consistent",
+      note: TID_NOTE_FULL,
+    });
+  });
+
+  it("shifting (cls differ, pi null)", () => {
+    expect(
+      compareTid(
+        { classification: "Polarized", polarization_index: null },
+        { classification: "Pyramidal", polarization_index: null },
+      ),
+    ).toEqual({
+      classification_7d: "Polarized",
+      classification_28d: "Pyramidal",
+      pi_7d: null,
+      pi_28d: null,
+      pi_delta: null,
+      drift: "shifting",
+      note: TID_NOTE_FULL,
+    });
+  });
+
+  it("acute_depolarization beats shifting", () => {
+    expect(
+      compareTid(
+        { classification: "Polarized", polarization_index: 1.5 },
+        { classification: "Pyramidal", polarization_index: 2.5 },
+      ),
+    ).toEqual({
+      classification_7d: "Polarized",
+      classification_28d: "Pyramidal",
+      pi_7d: 1.5,
+      pi_28d: 2.5,
+      pi_delta: -1.0,
+      drift: "acute_depolarization",
+      note: TID_NOTE_FULL,
+    });
+  });
+
+  it("acute_depolarization boundary (>= 2.0) beats consistent", () => {
+    expect(
+      compareTid(
+        { classification: "Pyramidal", polarization_index: 1.99 },
+        { classification: "Pyramidal", polarization_index: 2.0 },
+      ),
+    ).toEqual({
+      classification_7d: "Pyramidal",
+      classification_28d: "Pyramidal",
+      pi_7d: 1.99,
+      pi_28d: 2.0,
+      pi_delta: -0.01,
+      drift: "acute_depolarization",
+      note: TID_NOTE_FULL,
+    });
+  });
+
+  it("NOT acute when pi_28d < 2.0", () => {
+    expect(
+      compareTid(
+        { classification: "Base", polarization_index: 1.5 },
+        { classification: "Base", polarization_index: 1.8 },
+      ),
+    ).toEqual({
+      classification_7d: "Base",
+      classification_28d: "Base",
+      pi_7d: 1.5,
+      pi_28d: 1.8,
+      pi_delta: -0.3,
+      drift: "consistent",
+      note: TID_NOTE_FULL,
+    });
+  });
+
+  it("pi_delta banker's tie", () => {
+    expect(
+      compareTid(
+        { classification: "Base", polarization_index: 2.125 },
+        { classification: "Base", polarization_index: 2.0 },
+      ),
+    ).toEqual({
+      classification_7d: "Base",
+      classification_28d: "Base",
+      pi_7d: 2.125,
+      pi_28d: 2.0,
+      pi_delta: 0.12,
+      drift: "consistent",
+      note: TID_NOTE_FULL,
+    });
+  });
+
+  it("pi_delta null when one pi null (cls present)", () => {
+    expect(
+      compareTid(
+        { classification: "Base", polarization_index: 2.0 },
+        { classification: "Base", polarization_index: null },
+      ),
+    ).toEqual({
+      classification_7d: "Base",
+      classification_28d: "Base",
+      pi_7d: 2.0,
+      pi_28d: null,
+      pi_delta: null,
+      drift: "consistent",
+      note: TID_NOTE_FULL,
+    });
+  });
+
+  it("integration", () => {
+    expect(computeTidComparison(input([]))).toEqual({
+      classification_7d: null,
+      classification_28d: null,
+      pi_7d: null,
+      pi_28d: null,
+      pi_delta: null,
+      drift: null,
+      note: TID_NOTE_INSUFFICIENT,
+    });
   });
 });

--- a/packages/core/src/reference/metrics/capability.ts
+++ b/packages/core/src/reference/metrics/capability.ts
@@ -12,6 +12,7 @@
  */
 
 import { getActivities, getActivitiesInWindow, type MetricInput } from "./metric-input.js";
+import { computeSeilerTid, computeSeilerTid28d, type SeilerTid } from "./distribution.js";
 import { mean } from "./statistics.js";
 import { roundHalfEven } from "./rounding.js";
 import type { Activity } from "../schemas/inputs.js";
@@ -272,4 +273,76 @@ export function computeHrrc(input: MetricInput): HrrcSignal {
       "before cooldown, or no HR data. Trend: 7d mean vs 28d mean, >10% = meaningful " +
       "(min 1 session/7d, 3 sessions/28d). Display only — not wired into readiness_decision signals.",
   };
+}
+
+export interface TidComparisonSignal {
+  classification_7d: string | null;
+  classification_28d: string | null;
+  pi_7d: number | null;
+  pi_28d: number | null;
+  pi_delta: number | null;
+  drift: "consistent" | "shifting" | "acute_depolarization" | null;
+  note: string;
+}
+
+const TID_COMPARISON_NOTE_INSUFFICIENT =
+  "Compares 7d vs 28d Seiler TID to detect distribution shifts. Insufficient data in one or both windows.";
+const TID_COMPARISON_NOTE_FULL =
+  "Compares 7d vs 28d Seiler TID to detect distribution shifts. pi_delta positive = more polarized acutely.";
+
+export function compareTid(
+  seiler7d: Pick<SeilerTid, "classification" | "polarization_index">,
+  seiler28d: Pick<SeilerTid, "classification" | "polarization_index">,
+): TidComparisonSignal {
+  const cls7d = seiler7d.classification;
+  const cls28d = seiler28d.classification;
+  const pi7d = seiler7d.polarization_index;
+  const pi28d = seiler28d.polarization_index;
+
+  if (cls7d === null || cls28d === null) {
+    return {
+      classification_7d: cls7d,
+      classification_28d: cls28d,
+      pi_7d: pi7d,
+      pi_28d: pi28d,
+      pi_delta: null,
+      drift: null,
+      note: TID_COMPARISON_NOTE_INSUFFICIENT,
+    };
+  }
+
+  let piDelta: number | null = null;
+  if (pi7d !== null && pi28d !== null) {
+    piDelta = roundHalfEven(pi7d - pi28d, 2);
+  }
+
+  let drift: TidComparisonSignal["drift"];
+  if (pi7d !== null && pi28d !== null && pi7d < 2.0 && pi28d >= 2.0) {
+    drift = "acute_depolarization";
+  } else if (cls7d !== cls28d) {
+    drift = "shifting";
+  } else {
+    drift = "consistent";
+  }
+
+  return {
+    classification_7d: cls7d,
+    classification_28d: cls28d,
+    pi_7d: pi7d,
+    pi_28d: pi28d,
+    pi_delta: piDelta,
+    drift,
+    note: TID_COMPARISON_NOTE_FULL,
+  };
+}
+
+/**
+ * TID comparison — acute-vs-chronic Seiler distribution drift.
+ *
+ * Purely composes the all-sport 7d and 28d Seiler outputs and mirrors the
+ * upstream call site at `sync.py:3199` into the comparator ported from
+ * `sync.py:5094-5154`. See `NOTICE.md` for upstream attribution.
+ */
+export function computeTidComparison(input: MetricInput): TidComparisonSignal {
+  return compareTid(computeSeilerTid(input), computeSeilerTid28d(input));
 }

--- a/packages/core/src/reference/metrics/registry.ts
+++ b/packages/core/src/reference/metrics/registry.ts
@@ -9,7 +9,12 @@
  */
 
 import { computeWeightSignal } from "./bodycomp.js";
-import { computeDurability, computeEfficiencyFactor, computeHrrc } from "./capability.js";
+import {
+  computeDurability,
+  computeEfficiencyFactor,
+  computeHrrc,
+  computeTidComparison,
+} from "./capability.js";
 import {
   computeBenchmarkIndoor,
   computeBenchmarkOutdoor,
@@ -81,4 +86,5 @@ export const METRIC_REGISTRY: Record<string, MetricRegistryEntry> = {
   "capability.durability": { compute: computeDurability },
   "capability.efficiency_factor": { compute: computeEfficiencyFactor },
   "capability.hrrc": { compute: computeHrrc },
+  "capability.tid_comparison": { compute: computeTidComparison },
 };


### PR DESCRIPTION
Ports the TID-comparison metric (7d-vs-28d training-intensity-distribution drift) as a Reference-layer capability sub-key, transliterated line-by-line from `sync.py:5094-5154` (tolerance-0 parity gate).

## What
- Pure `compareTid(seiler7d, seiler28d)` mirrors the upstream signature: compares the two Seiler TID outputs' `classification` + `polarization_index` and classifies drift with the upstream priority — `acute_depolarization` (`pi_7d < 2.0 && pi_28d >= 2.0`) checked **before** `shifting` (classifications differ) and `consistent` — plus a banker's-rounded `pi_delta`.
- `computeTidComparison(input)` composes the already-shipped `computeSeilerTid` / `computeSeilerTid28d` (the all-sports variants), matching the call site at `sync.py:3199`.
- Registers `capability.tid_comparison`. No schema change — it consumes seiler outputs.

## Verification
- Parity gate green across all 10 fixtures, exercising the **insufficient** (empty fixtures → null classification) and **consistent** (populated, equal classifications) branches.
- 9 unit tests cover the branches the oracle can't reach (all fixtures have null PI): `shifting`, `acute_depolarization` priority + the `>= 2.0` boundary, `pi_delta` banker's-rounding ties, and one-PI-null.
- Independent re-derivation of every test expectation from the upstream confirms the arithmetic; typecheck + lint clean.

No changeset — internal Reference-layer metric, not wired into athlete-facing output.
