### PR TITLE
test(core): add capability-qualifying fixture for populated-branch coverage

### DIFF
--- a/packages/core/tests/fixtures/golden/capability-qualifying.json
+++ b/packages/core/tests/fixtures/golden/capability-qualifying.json
@@ -1,0 +1,3263 @@
+{
+  "activities": [
+    {
+      "id": 12345,
+      "start_date_local": "2026-05-09T07:52:37",
+      "type": "Ride",
+      "name": "sanitized",
+      "moving_time": 5207,
+      "elapsed_time": 5217,
+      "icu_training_load": 90,
+      "icu_intensity": 78.97436,
+      "average_heartrate": 142,
+      "icu_zone_times": [
+        {
+          "id": "Z1",
+          "secs": 608
+        },
+        {
+          "id": "Z2",
+          "secs": 2361
+        },
+        {
+          "id": "Z3",
+          "secs": 1321
+        },
+        {
+          "id": "Z4",
+          "secs": 561
+        },
+        {
+          "id": "Z5",
+          "secs": 196
+        },
+        {
+          "id": "Z6",
+          "secs": 107
+        },
+        {
+          "id": "Z7",
+          "secs": 53
+        },
+        {
+          "id": "SS",
+          "secs": 780
+        }
+      ],
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "icu_rpe": null,
+      "decoupling": -4.7151833,
+      "icu_efficiency_factor": 1.084507,
+      "fitnessAtEnd": 28.78709,
+      "fatigueAtEnd": 53.354916
+    },
+    {
+      "id": 12345,
+      "start_date_local": "2026-05-08T11:25:33",
+      "type": "WeightTraining",
+      "name": "sanitized",
+      "moving_time": 5338,
+      "elapsed_time": 5338,
+      "icu_training_load": 37,
+      "icu_intensity": 49.981243,
+      "average_heartrate": 116,
+      "icu_zone_times": null,
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "icu_rpe": null,
+      "decoupling": null,
+      "icu_efficiency_factor": null,
+      "fitnessAtEnd": 27.312151,
+      "fatigueAtEnd": 47.727512
+    },
+    {
+      "id": 12345,
+      "start_date_local": "2026-05-07T07:40:34",
+      "type": "Ride",
+      "name": "sanitized",
+      "moving_time": 3769,
+      "elapsed_time": 3769,
+      "icu_training_load": 60,
+      "icu_intensity": 75.89744,
+      "average_heartrate": 136,
+      "icu_zone_times": [
+        {
+          "id": "Z1",
+          "secs": 454
+        },
+        {
+          "id": "Z2",
+          "secs": 1940
+        },
+        {
+          "id": "Z3",
+          "secs": 877
+        },
+        {
+          "id": "Z4",
+          "secs": 304
+        },
+        {
+          "id": "Z5",
+          "secs": 103
+        },
+        {
+          "id": "Z6",
+          "secs": 60
+        },
+        {
+          "id": "Z7",
+          "secs": 32
+        },
+        {
+          "id": "SS",
+          "secs": 475
+        }
+      ],
+      "paired_event_id": 12345,
+      "pace_zone_times": null,
+      "icu_rpe": null,
+      "decoupling": -5.1646986,
+      "icu_efficiency_factor": 1.0882353,
+      "fitnessAtEnd": 27.970243,
+      "fatigueAtEnd": 49.37488
+    },
+    {
+      "id": 12345,
+      "start_date_local": "2026-05-06T07:28:50",
+      "type": "Ride",
+      "name": "sanitized",
+      "moving_time": 5236,
+      "elapsed_time": 5248,
+      "icu_training_load": 70,
+      "icu_intensity": 69.23077,
+      "average_heartrate": 135,
+      "icu_zone_times": [
+        {
+          "id": "Z1",
+          "secs": 1082
+        },
+        {
+          "id": "Z2",
+          "secs": 2836
+        },
+        {
+          "id": "Z3",
+          "secs": 914
+        },
+        {
+          "id": "Z4",
+          "secs": 268
+        },
+        {
+          "id": "Z5",
+          "secs": 69
+        },
+        {
+          "id": "Z6",
+          "secs": 47
+        },
+        {
+          "id": "Z7",
+          "secs": 20
+        },
+        {
+          "id": "SS",
+          "secs": 476
+        }
+      ],
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "icu_rpe": null,
+      "decoupling": -3.520694,
+      "icu_efficiency_factor": 1,
+      "fitnessAtEnd": 27.198479,
+      "fatigueAtEnd": 47.743237
+    },
+    {
+      "id": 12345,
+      "start_date_local": "2026-05-03T06:19:03",
+      "type": "Ride",
+      "name": "sanitized",
+      "moving_time": 10803,
+      "elapsed_time": 11067,
+      "icu_training_load": 178,
+      "icu_intensity": 76.92308,
+      "average_heartrate": 145,
+      "icu_zone_times": [
+        {
+          "id": "Z1",
+          "secs": 1260
+        },
+        {
+          "id": "Z2",
+          "secs": 4820
+        },
+        {
+          "id": "Z3",
+          "secs": 3069
+        },
+        {
+          "id": "Z4",
+          "secs": 1081
+        },
+        {
+          "id": "Z5",
+          "secs": 344
+        },
+        {
+          "id": "Z6",
+          "secs": 160
+        },
+        {
+          "id": "Z7",
+          "secs": 69
+        },
+        {
+          "id": "SS",
+          "secs": 1717
+        }
+      ],
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "icu_rpe": null,
+      "decoupling": -5.401834,
+      "icu_efficiency_factor": 1.0344827,
+      "fitnessAtEnd": 27.443367,
+      "fatigueAtEnd": 58.98432
+    },
+    {
+      "id": 12345,
+      "start_date_local": "2026-05-01T07:25:58",
+      "type": "Ride",
+      "name": "sanitized",
+      "moving_time": 5232,
+      "elapsed_time": 5262,
+      "icu_training_load": 81,
+      "icu_intensity": 74.871796,
+      "average_heartrate": 144,
+      "icu_zone_times": [
+        {
+          "id": "Z1",
+          "secs": 898
+        },
+        {
+          "id": "Z2",
+          "secs": 2382
+        },
+        {
+          "id": "Z3",
+          "secs": 1238
+        },
+        {
+          "id": "Z4",
+          "secs": 455
+        },
+        {
+          "id": "Z5",
+          "secs": 180
+        },
+        {
+          "id": "Z6",
+          "secs": 68
+        },
+        {
+          "id": "Z7",
+          "secs": 11
+        },
+        {
+          "id": "SS",
+          "secs": 740
+        }
+      ],
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "icu_rpe": null,
+      "decoupling": -14.990025,
+      "icu_efficiency_factor": 1.0138888,
+      "fitnessAtEnd": 24.389515,
+      "fatigueAtEnd": 46.958954
+    },
+    {
+      "id": 12345,
+      "start_date_local": "2026-04-30T12:10:20",
+      "type": "WeightTraining",
+      "name": "sanitized",
+      "moving_time": 4696,
+      "elapsed_time": 4696,
+      "icu_training_load": 30,
+      "icu_intensity": 47.961647,
+      "average_heartrate": 114,
+      "icu_zone_times": null,
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "icu_rpe": null,
+      "decoupling": null,
+      "icu_efficiency_factor": null,
+      "fitnessAtEnd": 23.025473,
+      "fatigueAtEnd": 41.73144
+    },
+    {
+      "id": 12345,
+      "start_date_local": "2026-04-29T08:08:07",
+      "type": "Ride",
+      "name": "sanitized",
+      "moving_time": 5248,
+      "elapsed_time": 5314,
+      "icu_training_load": 78,
+      "icu_intensity": 73.333336,
+      "average_heartrate": 139,
+      "icu_zone_times": [
+        {
+          "id": "Z1",
+          "secs": 874
+        },
+        {
+          "id": "Z2",
+          "secs": 2691
+        },
+        {
+          "id": "Z3",
+          "secs": 1139
+        },
+        {
+          "id": "Z4",
+          "secs": 312
+        },
+        {
+          "id": "Z5",
+          "secs": 143
+        },
+        {
+          "id": "Z6",
+          "secs": 74
+        },
+        {
+          "id": "Z7",
+          "secs": 15
+        },
+        {
+          "id": "SS",
+          "secs": 552
+        }
+      ],
+      "paired_event_id": 12345,
+      "pace_zone_times": null,
+      "icu_rpe": null,
+      "decoupling": -4.877258,
+      "icu_efficiency_factor": 1.028777,
+      "fitnessAtEnd": 23.580276,
+      "fatigueAtEnd": 43.532978
+    },
+    {
+      "id": 12345,
+      "start_date_local": "2026-04-27T10:01:13",
+      "type": "Ride",
+      "name": "sanitized",
+      "moving_time": 8157,
+      "elapsed_time": 8370,
+      "icu_training_load": 117,
+      "icu_intensity": 71.79487,
+      "average_heartrate": 141,
+      "icu_zone_times": [
+        {
+          "id": "Z1",
+          "secs": 1116
+        },
+        {
+          "id": "Z2",
+          "secs": 4417
+        },
+        {
+          "id": "Z3",
+          "secs": 2020
+        },
+        {
+          "id": "Z4",
+          "secs": 401
+        },
+        {
+          "id": "Z5",
+          "secs": 95
+        },
+        {
+          "id": "Z6",
+          "secs": 64
+        },
+        {
+          "id": "Z7",
+          "secs": 44
+        },
+        {
+          "id": "SS",
+          "secs": 827
+        }
+      ],
+      "paired_event_id": 12345,
+      "pace_zone_times": null,
+      "icu_rpe": null,
+      "decoupling": 2.8127115,
+      "icu_efficiency_factor": 0.9929078,
+      "fitnessAtEnd": 22.805597,
+      "fatigueAtEnd": 44.112385
+    },
+    {
+      "id": 12345,
+      "start_date_local": "2026-04-24T07:26:18",
+      "type": "Ride",
+      "name": "sanitized",
+      "moving_time": 5267,
+      "elapsed_time": 5267,
+      "icu_training_load": 80,
+      "icu_intensity": 73.84615,
+      "average_heartrate": 141,
+      "icu_zone_times": [
+        {
+          "id": "Z1",
+          "secs": 588
+        },
+        {
+          "id": "Z2",
+          "secs": 2923
+        },
+        {
+          "id": "Z3",
+          "secs": 1268
+        },
+        {
+          "id": "Z4",
+          "secs": 268
+        },
+        {
+          "id": "Z5",
+          "secs": 118
+        },
+        {
+          "id": "Z6",
+          "secs": 93
+        },
+        {
+          "id": "Z7",
+          "secs": 9
+        },
+        {
+          "id": "SS",
+          "secs": 515
+        }
+      ],
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "icu_rpe": null,
+      "decoupling": -4.818208,
+      "icu_efficiency_factor": 1.0212766,
+      "fitnessAtEnd": 21.537523,
+      "fatigueAtEnd": 43.806248
+    },
+    {
+      "id": 12345,
+      "start_date_local": "2026-04-23T10:24:06",
+      "type": "WeightTraining",
+      "name": "sanitized",
+      "moving_time": 3303,
+      "elapsed_time": 3303,
+      "icu_training_load": 18,
+      "icu_intensity": 44.306225,
+      "average_heartrate": 109,
+      "icu_zone_times": null,
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "icu_rpe": null,
+      "decoupling": null,
+      "icu_efficiency_factor": null,
+      "fitnessAtEnd": 20.128857,
+      "fatigueAtEnd": 38.248154
+    },
+    {
+      "id": 12345,
+      "start_date_local": "2026-04-22T08:41:28",
+      "type": "Ride",
+      "name": "sanitized",
+      "moving_time": 5164,
+      "elapsed_time": 5216,
+      "icu_training_load": 77,
+      "icu_intensity": 73.333336,
+      "average_heartrate": 142,
+      "icu_zone_times": [
+        {
+          "id": "Z1",
+          "secs": 696
+        },
+        {
+          "id": "Z2",
+          "secs": 2511
+        },
+        {
+          "id": "Z3",
+          "secs": 1328
+        },
+        {
+          "id": "Z4",
+          "secs": 511
+        },
+        {
+          "id": "Z5",
+          "secs": 95
+        },
+        {
+          "id": "Z6",
+          "secs": 18
+        },
+        {
+          "id": "Z7",
+          "secs": 5
+        },
+        {
+          "id": "SS",
+          "secs": 816
+        }
+      ],
+      "paired_event_id": 12345,
+      "pace_zone_times": null,
+      "icu_rpe": null,
+      "decoupling": -0.509351,
+      "icu_efficiency_factor": 1.0070423,
+      "fitnessAtEnd": 20.613867,
+      "fatigueAtEnd": 41.357563
+    },
+    {
+      "id": 12345,
+      "start_date_local": "2026-04-21T15:36:12",
+      "type": "VirtualRun",
+      "name": "sanitized",
+      "moving_time": 2383,
+      "elapsed_time": 2441,
+      "icu_training_load": 26,
+      "icu_intensity": 62.398003,
+      "average_heartrate": 135,
+      "icu_zone_times": null,
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "icu_rpe": 1,
+      "decoupling": null,
+      "icu_efficiency_factor": null,
+      "fitnessAtEnd": 19.25523,
+      "fatigueAtEnd": 35.884132
+    },
+    {
+      "id": 12345,
+      "start_date_local": "2026-04-20T11:43:02",
+      "type": "VirtualRide",
+      "name": "sanitized",
+      "moving_time": 1922,
+      "elapsed_time": 1922,
+      "icu_training_load": 15,
+      "icu_intensity": 52.63158,
+      "average_heartrate": 122,
+      "icu_zone_times": [
+        {
+          "id": "Z1",
+          "secs": 1661
+        },
+        {
+          "id": "Z2",
+          "secs": 262
+        },
+        {
+          "id": "Z3",
+          "secs": 0
+        },
+        {
+          "id": "Z4",
+          "secs": 0
+        },
+        {
+          "id": "Z5",
+          "secs": 0
+        },
+        {
+          "id": "Z6",
+          "secs": 0
+        },
+        {
+          "id": "Z7",
+          "secs": 0
+        },
+        {
+          "id": "SS",
+          "secs": 0
+        }
+      ],
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "icu_rpe": null,
+      "decoupling": 1.5639164,
+      "icu_efficiency_factor": 0.8196721,
+      "fitnessAtEnd": 19.092712,
+      "fatigueAtEnd": 37.40199
+    },
+    {
+      "id": 12345,
+      "start_date_local": "2026-04-19T06:59:28",
+      "type": "Run",
+      "name": "sanitized",
+      "moving_time": 3597,
+      "elapsed_time": 3602,
+      "icu_training_load": 52,
+      "icu_intensity": 72.10101,
+      "average_heartrate": 145,
+      "icu_zone_times": null,
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "icu_rpe": 1,
+      "decoupling": null,
+      "icu_efficiency_factor": null,
+      "fitnessAtEnd": 19.191328,
+      "fatigueAtEnd": 40.84215
+    },
+    {
+      "id": 12345,
+      "start_date_local": "2026-04-18T09:02:18",
+      "type": "Ride",
+      "name": "sanitized",
+      "moving_time": 5445,
+      "elapsed_time": 5445,
+      "icu_training_load": 97,
+      "icu_intensity": 80,
+      "average_heartrate": 150,
+      "icu_zone_times": [
+        {
+          "id": "Z1",
+          "secs": 713
+        },
+        {
+          "id": "Z2",
+          "secs": 2310
+        },
+        {
+          "id": "Z3",
+          "secs": 1425
+        },
+        {
+          "id": "Z4",
+          "secs": 555
+        },
+        {
+          "id": "Z5",
+          "secs": 236
+        },
+        {
+          "id": "Z6",
+          "secs": 145
+        },
+        {
+          "id": "Z7",
+          "secs": 62
+        },
+        {
+          "id": "SS",
+          "secs": 791
+        }
+      ],
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "icu_rpe": 1,
+      "decoupling": -0.9092801,
+      "icu_efficiency_factor": 1.04,
+      "fitnessAtEnd": 18.400795,
+      "fatigueAtEnd": 39.128696
+    },
+    {
+      "id": 12345,
+      "start_date_local": "2026-04-17T14:49:06",
+      "type": "VirtualRun",
+      "name": "sanitized",
+      "moving_time": 2428,
+      "elapsed_time": 2432,
+      "icu_training_load": 28,
+      "icu_intensity": 64.39287,
+      "average_heartrate": 136,
+      "icu_zone_times": null,
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "icu_rpe": 1,
+      "decoupling": null,
+      "icu_efficiency_factor": null,
+      "fitnessAtEnd": 16.50693,
+      "fatigueAtEnd": 30.24169
+    },
+    {
+      "id": 12345,
+      "start_date_local": "2026-04-15T10:22:28",
+      "type": "Run",
+      "name": "sanitized",
+      "moving_time": 2380,
+      "elapsed_time": 2400,
+      "icu_training_load": 29,
+      "icu_intensity": 65.96828,
+      "average_heartrate": 138,
+      "icu_zone_times": null,
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "icu_rpe": null,
+      "decoupling": null,
+      "icu_efficiency_factor": null,
+      "fitnessAtEnd": 16.621067,
+      "fatigueAtEnd": 35.282864
+    },
+    {
+      "id": 12345,
+      "start_date_local": "2026-04-14T10:59:58",
+      "type": "Ride",
+      "name": "sanitized",
+      "moving_time": 5614,
+      "elapsed_time": 5689,
+      "icu_training_load": 85,
+      "icu_intensity": 73.84615,
+      "average_heartrate": 142,
+      "icu_zone_times": [
+        {
+          "id": "Z1",
+          "secs": 1079
+        },
+        {
+          "id": "Z2",
+          "secs": 2628
+        },
+        {
+          "id": "Z3",
+          "secs": 1172
+        },
+        {
+          "id": "Z4",
+          "secs": 456
+        },
+        {
+          "id": "Z5",
+          "secs": 180
+        },
+        {
+          "id": "Z6",
+          "secs": 77
+        },
+        {
+          "id": "Z7",
+          "secs": 22
+        },
+        {
+          "id": "SS",
+          "secs": 694
+        }
+      ],
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "icu_rpe": null,
+      "decoupling": -8.35423,
+      "icu_efficiency_factor": 1.0140845,
+      "fitnessAtEnd": 16.322794,
+      "fatigueAtEnd": 36.247692
+    },
+    {
+      "id": 12345,
+      "start_date_local": "2026-04-13T12:02:43",
+      "type": "WeightTraining",
+      "name": "sanitized",
+      "moving_time": 2735,
+      "elapsed_time": 2735,
+      "icu_training_load": 14,
+      "icu_intensity": 42.935448,
+      "average_heartrate": 107,
+      "icu_zone_times": null,
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "icu_rpe": null,
+      "decoupling": null,
+      "icu_efficiency_factor": null,
+      "fitnessAtEnd": 14.668,
+      "fatigueAtEnd": 28.761044
+    },
+    {
+      "id": 12345,
+      "start_date_local": "2026-04-12T05:59:50",
+      "type": "Run",
+      "name": "sanitized",
+      "moving_time": 1792,
+      "elapsed_time": 1802,
+      "icu_training_load": 30,
+      "icu_intensity": 77.438156,
+      "average_heartrate": 148,
+      "icu_zone_times": null,
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "icu_rpe": 1,
+      "decoupling": null,
+      "icu_efficiency_factor": null,
+      "fitnessAtEnd": 15.021429,
+      "fatigueAtEnd": 31.027822
+    },
+    {
+      "id": 12345,
+      "start_date_local": "2026-04-11T07:30:53",
+      "type": "Ride",
+      "name": "sanitized",
+      "moving_time": 5961,
+      "elapsed_time": 6007,
+      "icu_training_load": 98,
+      "icu_intensity": 76.92308,
+      "average_heartrate": 152,
+      "icu_zone_times": [
+        {
+          "id": "Z1",
+          "secs": 817
+        },
+        {
+          "id": "Z2",
+          "secs": 2956
+        },
+        {
+          "id": "Z3",
+          "secs": 1341
+        },
+        {
+          "id": "Z4",
+          "secs": 527
+        },
+        {
+          "id": "Z5",
+          "secs": 159
+        },
+        {
+          "id": "Z6",
+          "secs": 88
+        },
+        {
+          "id": "Z7",
+          "secs": 73
+        },
+        {
+          "id": "SS",
+          "secs": 805
+        }
+      ],
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "icu_rpe": null,
+      "decoupling": -5.821107,
+      "icu_efficiency_factor": 0.9868421,
+      "fitnessAtEnd": 14.660517,
+      "fatigueAtEnd": 31.18566
+    },
+    {
+      "id": 12345,
+      "start_date_local": "2026-04-09T11:30:57",
+      "type": "WeightTraining",
+      "name": "sanitized",
+      "moving_time": 2746,
+      "elapsed_time": 2746,
+      "icu_training_load": 17,
+      "icu_intensity": 47.217667,
+      "average_heartrate": 112,
+      "icu_zone_times": null,
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "icu_rpe": null,
+      "decoupling": null,
+      "icu_efficiency_factor": null,
+      "fitnessAtEnd": 12.957295,
+      "fatigueAtEnd": 24.138712
+    },
+    {
+      "id": 12345,
+      "start_date_local": "2026-04-08T09:18:15",
+      "type": "Ride",
+      "name": "sanitized",
+      "moving_time": 5709,
+      "elapsed_time": 5746,
+      "icu_training_load": 89,
+      "icu_intensity": 74.871796,
+      "average_heartrate": 146,
+      "icu_zone_times": [
+        {
+          "id": "Z1",
+          "secs": 1385
+        },
+        {
+          "id": "Z2",
+          "secs": 2836
+        },
+        {
+          "id": "Z3",
+          "secs": 1013
+        },
+        {
+          "id": "Z4",
+          "secs": 284
+        },
+        {
+          "id": "Z5",
+          "secs": 66
+        },
+        {
+          "id": "Z6",
+          "secs": 54
+        },
+        {
+          "id": "Z7",
+          "secs": 71
+        },
+        {
+          "id": "SS",
+          "secs": 536
+        }
+      ],
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "icu_rpe": null,
+      "decoupling": -2.744324,
+      "icu_efficiency_factor": 1,
+      "fitnessAtEnd": 13.269505,
+      "fatigueAtEnd": 25.234968
+    },
+    {
+      "id": 12345,
+      "start_date_local": "2026-04-06T10:04:51",
+      "type": "Ride",
+      "name": "sanitized",
+      "moving_time": 5637,
+      "elapsed_time": 5704,
+      "icu_training_load": 66,
+      "icu_intensity": 65.128204,
+      "average_heartrate": 143,
+      "icu_zone_times": [
+        {
+          "id": "Z1",
+          "secs": 1562
+        },
+        {
+          "id": "Z2",
+          "secs": 3040
+        },
+        {
+          "id": "Z3",
+          "secs": 819
+        },
+        {
+          "id": "Z4",
+          "secs": 140
+        },
+        {
+          "id": "Z5",
+          "secs": 47
+        },
+        {
+          "id": "Z6",
+          "secs": 27
+        },
+        {
+          "id": "Z7",
+          "secs": 2
+        },
+        {
+          "id": "SS",
+          "secs": 286
+        }
+      ],
+      "paired_event_id": 12345,
+      "pace_zone_times": null,
+      "icu_rpe": null,
+      "decoupling": -7.1944137,
+      "icu_efficiency_factor": 0.8881119,
+      "fitnessAtEnd": 11.720525,
+      "fatigueAtEnd": 17.814379
+    },
+    {
+      "id": 12345,
+      "start_date_local": "2026-04-03T11:57:27",
+      "type": "Ride",
+      "name": "sanitized",
+      "moving_time": 4163,
+      "elapsed_time": 4163,
+      "icu_training_load": 60,
+      "icu_intensity": 72.30769,
+      "average_heartrate": 152,
+      "icu_zone_times": [
+        {
+          "id": "Z1",
+          "secs": 991
+        },
+        {
+          "id": "Z2",
+          "secs": 1832
+        },
+        {
+          "id": "Z3",
+          "secs": 780
+        },
+        {
+          "id": "Z4",
+          "secs": 270
+        },
+        {
+          "id": "Z5",
+          "secs": 114
+        },
+        {
+          "id": "Z6",
+          "secs": 121
+        },
+        {
+          "id": "Z7",
+          "secs": 56
+        },
+        {
+          "id": "SS",
+          "secs": 435
+        }
+      ],
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "icu_rpe": null,
+      "decoupling": -3.015162,
+      "icu_efficiency_factor": 0.92763156,
+      "fitnessAtEnd": 10.920485,
+      "fatigueAtEnd": 13.859039
+    },
+    {
+      "id": 12345,
+      "start_date_local": "2026-03-31T06:44:10",
+      "type": "Run",
+      "name": "sanitized",
+      "moving_time": 2076,
+      "elapsed_time": 2101,
+      "icu_training_load": 36,
+      "icu_intensity": 78.55844,
+      "average_heartrate": 148,
+      "icu_zone_times": null,
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "icu_rpe": 1,
+      "decoupling": null,
+      "icu_efficiency_factor": null,
+      "fitnessAtEnd": 10.21283,
+      "fatigueAtEnd": 9.01345
+    },
+    {
+      "id": 12345,
+      "start_date_local": "2026-03-23T17:18:29",
+      "type": "WeightTraining",
+      "name": "sanitized",
+      "moving_time": 3689,
+      "elapsed_time": 3689,
+      "icu_training_load": 31,
+      "icu_intensity": 55.016827,
+      "average_heartrate": 124,
+      "icu_zone_times": null,
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "icu_rpe": null,
+      "decoupling": null,
+      "icu_efficiency_factor": null,
+      "fitnessAtEnd": 11.3309965,
+      "fatigueAtEnd": 13.236021
+    },
+    {
+      "id": 12345,
+      "start_date_local": "2026-03-20T16:17:31",
+      "type": "VirtualRun",
+      "name": "sanitized",
+      "moving_time": 2394,
+      "elapsed_time": 2402,
+      "icu_training_load": 29,
+      "icu_intensity": 65.940796,
+      "average_heartrate": 137,
+      "icu_zone_times": null,
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "icu_rpe": 1,
+      "decoupling": null,
+      "icu_efficiency_factor": null,
+      "fitnessAtEnd": 12.169959,
+      "fatigueAtEnd": 13.983252
+    },
+    {
+      "id": 12345,
+      "start_date_local": "2026-03-17T12:36:50",
+      "type": "WeightTraining",
+      "name": "sanitized",
+      "moving_time": 2707,
+      "elapsed_time": 2707,
+      "icu_training_load": 25,
+      "icu_intensity": 57.681644,
+      "average_heartrate": 127,
+      "icu_zone_times": null,
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "icu_rpe": null,
+      "decoupling": null,
+      "icu_efficiency_factor": null,
+      "fitnessAtEnd": 12.338198,
+      "fatigueAtEnd": 15.539
+    },
+    {
+      "id": 12345,
+      "start_date_local": "2026-03-16T09:22:31",
+      "type": "VirtualRun",
+      "name": "sanitized",
+      "moving_time": 1791,
+      "elapsed_time": 1807,
+      "icu_training_load": 26,
+      "icu_intensity": 71.99114,
+      "average_heartrate": 145,
+      "icu_zone_times": null,
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "icu_rpe": 1,
+      "decoupling": null,
+      "icu_efficiency_factor": null,
+      "fitnessAtEnd": 12.635489,
+      "fatigueAtEnd": 14.086121
+    },
+    {
+      "id": 12345,
+      "start_date_local": "2026-03-15T13:24:47",
+      "type": "VirtualRun",
+      "name": "sanitized",
+      "moving_time": 2400,
+      "elapsed_time": 2411,
+      "icu_training_load": 30,
+      "icu_intensity": 66.94272,
+      "average_heartrate": 139,
+      "icu_zone_times": null,
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "icu_rpe": 1,
+      "decoupling": null,
+      "icu_efficiency_factor": null,
+      "fitnessAtEnd": 12.313469,
+      "fatigueAtEnd": 12.256566
+    },
+    {
+      "id": 12345,
+      "start_date_local": "2026-03-14T13:18:48",
+      "type": "VirtualRun",
+      "name": "sanitized",
+      "moving_time": 2395,
+      "elapsed_time": 2401,
+      "icu_training_load": 33,
+      "icu_intensity": 70.35624,
+      "average_heartrate": 144,
+      "icu_zone_times": null,
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "icu_rpe": 1,
+      "decoupling": null,
+      "icu_efficiency_factor": null,
+      "fitnessAtEnd": 11.887308,
+      "fatigueAtEnd": 9.5317955
+    },
+    {
+      "id": 12345,
+      "start_date_local": "2026-03-11T19:13:34",
+      "type": "VirtualRun",
+      "name": "sanitized",
+      "moving_time": 2389,
+      "elapsed_time": 2405,
+      "icu_training_load": 41,
+      "icu_intensity": 78.35667,
+      "average_heartrate": 151,
+      "icu_zone_times": null,
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "icu_rpe": 1,
+      "decoupling": null,
+      "icu_efficiency_factor": null,
+      "fitnessAtEnd": 11.933538,
+      "fatigueAtEnd": 7.888329
+    },
+    {
+      "id": 12345,
+      "start_date_local": "2026-03-01T18:07:56",
+      "type": "VirtualRun",
+      "name": "sanitized",
+      "moving_time": 2992,
+      "elapsed_time": 3002,
+      "icu_training_load": 43,
+      "icu_intensity": 71.82117,
+      "average_heartrate": 143,
+      "icu_zone_times": null,
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "icu_rpe": 1,
+      "decoupling": null,
+      "icu_efficiency_factor": null,
+      "fitnessAtEnd": 13.917642,
+      "fatigueAtEnd": 10.14109
+    },
+    {
+      "id": 12345,
+      "start_date_local": "2026-02-23T12:08:32",
+      "type": "VirtualRun",
+      "name": "sanitized",
+      "moving_time": 2405,
+      "elapsed_time": 2412,
+      "icu_training_load": 33,
+      "icu_intensity": 70.19556,
+      "average_heartrate": 143,
+      "icu_zone_times": null,
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "icu_rpe": 1,
+      "decoupling": null,
+      "icu_efficiency_factor": null,
+      "fitnessAtEnd": 14.887822,
+      "fatigueAtEnd": 10.407923
+    },
+    {
+      "id": 12345,
+      "start_date_local": "2026-02-20T17:35:56",
+      "type": "VirtualRun",
+      "name": "sanitized",
+      "moving_time": 2403,
+      "elapsed_time": 2410,
+      "icu_training_load": 30,
+      "icu_intensity": 66.95661,
+      "average_heartrate": 138,
+      "icu_zone_times": null,
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "icu_rpe": 1,
+      "decoupling": null,
+      "icu_efficiency_factor": null,
+      "fitnessAtEnd": 15.156215,
+      "fatigueAtEnd": 9.233241
+    },
+    {
+      "id": 12345,
+      "start_date_local": "2026-02-17T12:29:58",
+      "type": "VirtualRun",
+      "name": "sanitized",
+      "moving_time": 2419,
+      "elapsed_time": 2426,
+      "icu_training_load": 31,
+      "icu_intensity": 67.8385,
+      "average_heartrate": 140,
+      "icu_zone_times": null,
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "icu_rpe": 1,
+      "decoupling": null,
+      "icu_efficiency_factor": null,
+      "fitnessAtEnd": 15.520292,
+      "fatigueAtEnd": 8.043082
+    },
+    {
+      "id": 90001,
+      "start_date_local": "2026-05-06T09:00:00",
+      "type": "Ride",
+      "name": "Capability qualifier",
+      "moving_time": 6000,
+      "elapsed_time": 6100,
+      "icu_training_load": 90,
+      "icu_intensity": 79,
+      "average_heartrate": 140,
+      "icu_zone_times": [{"id":"Z1","secs":600},{"id":"Z2","secs":3000},{"id":"Z3","secs":1500},{"id":"Z4","secs":500},{"id":"Z5","secs":200},{"id":"Z6","secs":120},{"id":"Z7","secs":80},{"id":"SS","secs":600}],
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "icu_rpe": null,
+      "icu_variability_index": 1.0,
+      "icu_hr_decoupling": 1.0,
+      "icu_efficiency_factor": 2.5,
+      "icu_hrr": 40
+    },
+    {
+      "id": 90002,
+      "start_date_local": "2026-05-08T09:00:00",
+      "type": "Ride",
+      "name": "Capability qualifier",
+      "moving_time": 6000,
+      "elapsed_time": 6100,
+      "icu_training_load": 90,
+      "icu_intensity": 79,
+      "average_heartrate": 140,
+      "icu_zone_times": [{"id":"Z1","secs":600},{"id":"Z2","secs":3000},{"id":"Z3","secs":1500},{"id":"Z4","secs":500},{"id":"Z5","secs":200},{"id":"Z6","secs":120},{"id":"Z7","secs":80},{"id":"SS","secs":600}],
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "icu_rpe": null,
+      "icu_variability_index": 1.0,
+      "icu_hr_decoupling": 2.0,
+      "icu_efficiency_factor": 2.5,
+      "icu_hrr": 40
+    },
+    {
+      "id": 90003,
+      "start_date_local": "2026-05-10T09:00:00",
+      "type": "Ride",
+      "name": "Capability qualifier",
+      "moving_time": 6000,
+      "elapsed_time": 6100,
+      "icu_training_load": 90,
+      "icu_intensity": 79,
+      "average_heartrate": 140,
+      "icu_zone_times": [{"id":"Z1","secs":600},{"id":"Z2","secs":3000},{"id":"Z3","secs":1500},{"id":"Z4","secs":500},{"id":"Z5","secs":200},{"id":"Z6","secs":120},{"id":"Z7","secs":80},{"id":"SS","secs":600}],
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "icu_rpe": null,
+      "icu_variability_index": 1.0,
+      "icu_hr_decoupling": 3.0,
+      "icu_efficiency_factor": 2.5,
+      "icu_hrr": 40
+    },
+    {
+      "id": 90004,
+      "start_date_local": "2026-04-18T09:00:00",
+      "type": "Ride",
+      "name": "Capability qualifier",
+      "moving_time": 6000,
+      "elapsed_time": 6100,
+      "icu_training_load": 90,
+      "icu_intensity": 79,
+      "average_heartrate": 140,
+      "icu_zone_times": [{"id":"Z1","secs":600},{"id":"Z2","secs":3000},{"id":"Z3","secs":1500},{"id":"Z4","secs":500},{"id":"Z5","secs":200},{"id":"Z6","secs":120},{"id":"Z7","secs":80},{"id":"SS","secs":600}],
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "icu_rpe": null,
+      "icu_variability_index": 1.0,
+      "icu_hr_decoupling": 6.0,
+      "icu_efficiency_factor": 2.0,
+      "icu_hrr": 30
+    },
+    {
+      "id": 90005,
+      "start_date_local": "2026-04-24T09:00:00",
+      "type": "Ride",
+      "name": "Capability qualifier",
+      "moving_time": 6000,
+      "elapsed_time": 6100,
+      "icu_training_load": 90,
+      "icu_intensity": 79,
+      "average_heartrate": 140,
+      "icu_zone_times": [{"id":"Z1","secs":600},{"id":"Z2","secs":3000},{"id":"Z3","secs":1500},{"id":"Z4","secs":500},{"id":"Z5","secs":200},{"id":"Z6","secs":120},{"id":"Z7","secs":80},{"id":"SS","secs":600}],
+      "paired_event_id": null,
+      "pace_zone_times": null,
+      "icu_rpe": null,
+      "icu_variability_index": 1.0,
+      "icu_hr_decoupling": 7.0,
+      "icu_efficiency_factor": 2.0,
+      "icu_hrr": 30
+    }
+  ],
+  "wellness": [
+    {
+      "id": "2026-02-16",
+      "weight": null,
+      "restingHR": 57,
+      "hrv": 45,
+      "sleepSecs": 26640,
+      "sleepQuality": 2,
+      "soreness": null,
+      "fatigue": 4.5177035,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 178.25348
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 15.1473055,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": -2.217063
+    },
+    {
+      "id": "2026-02-17",
+      "weight": null,
+      "restingHR": 56,
+      "hrv": 42,
+      "sleepSecs": 22980,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": 8.043082,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 178.07523
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 15.520292,
+      "fitnessContribution": 31,
+      "fatigueContribution": 31,
+      "weeklyFitnessChange": -1.4355221
+    },
+    {
+      "id": "2026-02-18",
+      "weight": null,
+      "restingHR": 56,
+      "hrv": 45,
+      "sleepSecs": 23400,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": 6.97237,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 177.89716
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 15.155126,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": -1.4017477
+    },
+    {
+      "id": "2026-02-19",
+      "weight": null,
+      "restingHR": 57,
+      "hrv": 43,
+      "sleepSecs": 22380,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": 6.0441937,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 177.71925
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 14.798551,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": -1.3687677
+    },
+    {
+      "id": "2026-02-20",
+      "weight": null,
+      "restingHR": 55,
+      "hrv": 44,
+      "sleepSecs": 22800,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": 9.233241,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 177.54153
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 15.156215,
+      "fitnessContribution": 30,
+      "fatigueContribution": 30,
+      "weeklyFitnessChange": -0.63071346
+    },
+    {
+      "id": "2026-02-21",
+      "weight": null,
+      "restingHR": 54,
+      "hrv": 43,
+      "sleepSecs": 19200,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": 8.004092,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 177.364
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 14.799615,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": -1.0864401
+    },
+    {
+      "id": "2026-02-22",
+      "weight": null,
+      "restingHR": 56,
+      "hrv": 33,
+      "sleepSecs": 27575,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": 6.9385705,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 177.18663
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 14.451405,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": -1.0608788
+    },
+    {
+      "id": "2026-02-23",
+      "weight": null,
+      "restingHR": 54,
+      "hrv": 46,
+      "sleepSecs": 24120,
+      "sleepQuality": 2,
+      "soreness": null,
+      "fatigue": 10.407923,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 177.00945
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 14.887822,
+      "fitnessContribution": 33,
+      "fatigueContribution": 33,
+      "weeklyFitnessChange": -0.25948334
+    },
+    {
+      "id": "2026-02-24",
+      "weight": null,
+      "restingHR": 56,
+      "hrv": 41,
+      "sleepSecs": 23400,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": 9.022398,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 176.83244
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 14.537537,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": -0.98275566
+    },
+    {
+      "id": "2026-02-25",
+      "weight": null,
+      "restingHR": 50,
+      "hrv": 58,
+      "sleepSecs": 20580,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": 7.821317,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 176.65561
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 14.195493,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": -0.9596329
+    },
+    {
+      "id": "2026-02-26",
+      "weight": null,
+      "restingHR": 55,
+      "hrv": 44,
+      "sleepSecs": 18660,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": 6.780127,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 176.47896
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 13.861497,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": -0.9370537
+    },
+    {
+      "id": "2026-02-27",
+      "weight": null,
+      "restingHR": 58,
+      "hrv": 37,
+      "sleepSecs": 16020,
+      "sleepQuality": 4,
+      "soreness": null,
+      "fatigue": 5.8775425,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 176.30247
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 13.535359,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": -1.6208553
+    },
+    {
+      "id": "2026-02-28",
+      "weight": null,
+      "restingHR": 62,
+      "hrv": 31,
+      "sleepSecs": 10560,
+      "sleepQuality": 4,
+      "soreness": null,
+      "fatigue": 5.095112,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 176.12617
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 13.216895,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": -1.5827198
+    },
+    {
+      "id": "2026-03-01",
+      "weight": null,
+      "restingHR": 60,
+      "hrv": 31,
+      "sleepSecs": 25524,
+      "sleepQuality": 4,
+      "soreness": null,
+      "fatigue": 10.14109,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 175.95006
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 13.917642,
+      "fitnessContribution": 43,
+      "fatigueContribution": 43,
+      "weeklyFitnessChange": -0.53376293
+    },
+    {
+      "id": "2026-03-02",
+      "weight": null,
+      "restingHR": 59,
+      "hrv": 36,
+      "sleepSecs": 20789,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": 8.791087,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 175.77411
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 13.590183,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": -1.2976389
+    },
+    {
+      "id": "2026-03-03",
+      "weight": null,
+      "restingHR": 58,
+      "hrv": 36,
+      "sleepSecs": 19980,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": 7.620799,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 175.59834
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 13.27043,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": -1.267107
+    },
+    {
+      "id": "2026-03-04",
+      "weight": null,
+      "restingHR": 63,
+      "hrv": 30,
+      "sleepSecs": 19680,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": 6.6063023,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 175.42274
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 12.958199,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": -1.2372942
+    },
+    {
+      "id": "2026-03-05",
+      "weight": null,
+      "restingHR": 60,
+      "hrv": 33,
+      "sleepSecs": 22440,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": 5.7268577,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 175.24733
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 12.653314,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": -1.2081833
+    },
+    {
+      "id": "2026-03-06",
+      "weight": null,
+      "restingHR": 61,
+      "hrv": 32,
+      "sleepSecs": 20242,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": 4.964486,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 175.07208
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 12.355602,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": -1.1797571
+    },
+    {
+      "id": "2026-03-07",
+      "weight": null,
+      "restingHR": 65,
+      "hrv": 29,
+      "sleepSecs": 6822,
+      "sleepQuality": 4,
+      "soreness": null,
+      "fatigue": 4.303603,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 174.89702
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 12.064896,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": -1.1519995
+    },
+    {
+      "id": "2026-03-08",
+      "weight": null,
+      "restingHR": 55,
+      "hrv": 37,
+      "sleepSecs": 30658,
+      "sleepQuality": 2,
+      "soreness": null,
+      "fatigue": 3.7306986,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 174.72212
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 11.781029,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": -2.136613
+    },
+    {
+      "id": "2026-03-09",
+      "weight": null,
+      "restingHR": 60,
+      "hrv": 32,
+      "sleepSecs": 23040,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": 3.23406,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 174.54741
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 11.503841,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": -2.0863419
+    },
+    {
+      "id": "2026-03-10",
+      "weight": null,
+      "restingHR": 61,
+      "hrv": 34,
+      "sleepSecs": 21780,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": 2.8035352,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 174.37286
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 11.233175,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": -2.0372543
+    },
+    {
+      "id": "2026-03-11",
+      "weight": null,
+      "restingHR": 56,
+      "hrv": 41,
+      "sleepSecs": 21929,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": 7.888329,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 174.19849
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 11.933538,
+      "fitnessContribution": 41,
+      "fatigueContribution": 41,
+      "weeklyFitnessChange": -1.0246601
+    },
+    {
+      "id": "2026-03-12",
+      "weight": null,
+      "restingHR": 60,
+      "hrv": 34,
+      "sleepSecs": 16920,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": 6.838218,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 174.02429
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 11.652762,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": -1.0005512
+    },
+    {
+      "id": "2026-03-13",
+      "weight": null,
+      "restingHR": 51,
+      "hrv": 47,
+      "sleepSecs": 27567,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": 5.9279003,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 173.85027
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 11.3785925,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": -0.9770098
+    },
+    {
+      "id": "2026-03-14",
+      "weight": null,
+      "restingHR": 61,
+      "hrv": 34,
+      "sleepSecs": 22260,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": 9.5317955,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 173.67642
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 11.887308,
+      "fitnessContribution": 33,
+      "fatigueContribution": 33,
+      "weeklyFitnessChange": -0.17758751
+    },
+    {
+      "id": "2026-03-15",
+      "weight": null,
+      "restingHR": 55,
+      "hrv": 42,
+      "sleepSecs": 22920,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": 12.256566,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 173.67642
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 12.313469,
+      "fitnessContribution": 30,
+      "fatigueContribution": 30,
+      "weeklyFitnessChange": 0.5324402
+    },
+    {
+      "id": "2026-03-16",
+      "weight": null,
+      "restingHR": 59,
+      "hrv": 36,
+      "sleepSecs": 30120,
+      "sleepQuality": 2,
+      "soreness": null,
+      "fatigue": 14.086121,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 173.67642
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 12.635489,
+      "fitnessContribution": 26,
+      "fatigueContribution": 26,
+      "weeklyFitnessChange": 1.1316481
+    },
+    {
+      "id": "2026-03-17",
+      "weight": null,
+      "restingHR": 61,
+      "hrv": null,
+      "sleepSecs": null,
+      "sleepQuality": null,
+      "soreness": null,
+      "fatigue": 15.539,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 173.67642
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 12.338198,
+      "fitnessContribution": 0,
+      "fatigueContribution": 25,
+      "weeklyFitnessChange": 1.1050224
+    },
+    {
+      "id": "2026-03-18",
+      "weight": null,
+      "restingHR": 60,
+      "hrv": 34,
+      "sleepSecs": 15240,
+      "sleepQuality": 4,
+      "soreness": null,
+      "fatigue": 13.470415,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 173.67642
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 12.047901,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0.11436272
+    },
+    {
+      "id": "2026-03-19",
+      "weight": null,
+      "restingHR": 57,
+      "hrv": 39,
+      "sleepSecs": 20340,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": 11.677205,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 173.67642
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 11.764435,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0.1116724
+    },
+    {
+      "id": "2026-03-20",
+      "weight": null,
+      "restingHR": 53,
+      "hrv": 46,
+      "sleepSecs": 16980,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": 13.983252,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 173.67642
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 12.169959,
+      "fitnessContribution": 29,
+      "fatigueContribution": 29,
+      "weeklyFitnessChange": 0.7913666
+    },
+    {
+      "id": "2026-03-21",
+      "weight": null,
+      "restingHR": 57,
+      "hrv": 40,
+      "sleepSecs": 22500,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": 12.121772,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 173.50275
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 11.88362,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": -0.0036878586
+    },
+    {
+      "id": "2026-03-22",
+      "weight": null,
+      "restingHR": 55,
+      "hrv": 45,
+      "sleepSecs": 19500,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": 10.508096,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 173.32924
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 11.604019,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": -0.70944977
+    },
+    {
+      "id": "2026-03-23",
+      "weight": null,
+      "restingHR": 59,
+      "hrv": 37,
+      "sleepSecs": 21780,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": 13.236021,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 173.15591
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 11.3309965,
+      "fitnessContribution": 0,
+      "fatigueContribution": 31,
+      "weeklyFitnessChange": -1.304493
+    },
+    {
+      "id": "2026-03-24",
+      "weight": null,
+      "restingHR": 57,
+      "hrv": 36,
+      "sleepSecs": 20040,
+      "sleepQuality": 4,
+      "soreness": null,
+      "fatigue": 11.474014,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 172.98276
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 11.064397,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": -1.2738008
+    },
+    {
+      "id": "2026-03-25",
+      "weight": null,
+      "restingHR": 53,
+      "hrv": 46,
+      "sleepSecs": 22560,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": 9.946569,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 172.80978
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 10.80407,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": -1.2438307
+    },
+    {
+      "id": "2026-03-26",
+      "weight": null,
+      "restingHR": 60,
+      "hrv": 30,
+      "sleepSecs": 13320,
+      "sleepQuality": 4,
+      "soreness": null,
+      "fatigue": 8.622461,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 172.63698
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 10.549869,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": -1.2145662
+    },
+    {
+      "id": "2026-03-27",
+      "weight": null,
+      "restingHR": 57,
+      "hrv": 35,
+      "sleepSecs": 12540,
+      "sleepQuality": 4,
+      "soreness": null,
+      "fatigue": 7.4746213,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 172.46434
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 10.301648,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": -1.8683109
+    },
+    {
+      "id": "2026-03-28",
+      "weight": null,
+      "restingHR": 54,
+      "hrv": 44,
+      "sleepSecs": 32820,
+      "sleepQuality": 1,
+      "soreness": null,
+      "fatigue": 6.479584,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 172.29189
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 10.059268,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": -1.8243523
+    },
+    {
+      "id": "2026-03-29",
+      "weight": null,
+      "restingHR": 56,
+      "hrv": 40,
+      "sleepSecs": 27561,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": 5.617008,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 172.1196
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 9.822591,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": -1.7814283
+    },
+    {
+      "id": "2026-03-30",
+      "weight": null,
+      "restingHR": 53,
+      "hrv": 42,
+      "sleepSecs": 22680,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": 4.8692603,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 171.94748
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 9.591482,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": -1.7395144
+    },
+    {
+      "id": "2026-03-31",
+      "weight": null,
+      "restingHR": 48,
+      "hrv": 58,
+      "sleepSecs": 22980,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": 9.01345,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 171.77553
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": 42,
+      "fitness": 10.21283,
+      "fitnessContribution": 36,
+      "fatigueContribution": 36,
+      "weeklyFitnessChange": -0.85156727
+    },
+    {
+      "id": "2026-04-01",
+      "weight": null,
+      "restingHR": 51,
+      "hrv": 49,
+      "sleepSecs": 18780,
+      "sleepQuality": 4,
+      "soreness": null,
+      "fatigue": 7.8135605,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 171.60376
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 9.972539,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": -0.8315315
+    },
+    {
+      "id": "2026-04-02",
+      "weight": null,
+      "restingHR": 57,
+      "hrv": 43,
+      "sleepSecs": 14880,
+      "sleepQuality": 4,
+      "soreness": null,
+      "fatigue": 6.7734027,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 171.43216
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 9.737902,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": -0.8119669
+    },
+    {
+      "id": "2026-04-03",
+      "weight": 87,
+      "restingHR": 51,
+      "hrv": 51,
+      "sleepSecs": 26040,
+      "sleepQuality": 2,
+      "soreness": null,
+      "fatigue": 13.859039,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 171.43216
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 10.920485,
+      "fitnessContribution": 60,
+      "fatigueContribution": 60,
+      "weeklyFitnessChange": 0.6188364
+    },
+    {
+      "id": "2026-04-04",
+      "weight": null,
+      "restingHR": 57,
+      "hrv": 37,
+      "sleepSecs": 24060,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": 12.014095,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 171.43216
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 10.663544,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0.6042757
+    },
+    {
+      "id": "2026-04-05",
+      "weight": null,
+      "restingHR": 57,
+      "hrv": 30,
+      "sleepSecs": 13500,
+      "sleepQuality": 4,
+      "soreness": null,
+      "fatigue": 10.414754,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 171.43216
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 10.412648,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0.5900574
+    },
+    {
+      "id": "2026-04-06",
+      "weight": null,
+      "restingHR": 55,
+      "hrv": 42,
+      "sleepSecs": 27540,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": 17.814379,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 171.43216
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 11.720525,
+      "fitnessContribution": 66,
+      "fatigueContribution": 66,
+      "weeklyFitnessChange": 2.1290426
+    },
+    {
+      "id": "2026-04-07",
+      "weight": null,
+      "restingHR": 57,
+      "hrv": 44,
+      "sleepSecs": 21240,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": 15.442891,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 171.43216
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 11.44476,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 1.2319307
+    },
+    {
+      "id": "2026-04-08",
+      "weight": null,
+      "restingHR": 57,
+      "hrv": 41,
+      "sleepSecs": 10920,
+      "sleepQuality": 4,
+      "soreness": null,
+      "fatigue": 25.234968,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 171.43216
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 13.269505,
+      "fitnessContribution": 89,
+      "fatigueContribution": 89,
+      "weeklyFitnessChange": 3.2969656
+    },
+    {
+      "id": "2026-04-09",
+      "weight": null,
+      "restingHR": 57,
+      "hrv": 37,
+      "sleepSecs": 25500,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": 24.138712,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 171.43216
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 12.957295,
+      "fitnessContribution": 0,
+      "fatigueContribution": 17,
+      "weeklyFitnessChange": 3.2193937
+    },
+    {
+      "id": "2026-04-10",
+      "weight": null,
+      "restingHR": 55,
+      "hrv": 47,
+      "sleepSecs": 23880,
+      "sleepQuality": 2,
+      "soreness": null,
+      "fatigue": 20.925316,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 171.43216
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 12.652432,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 1.7319479
+    },
+    {
+      "id": "2026-04-11",
+      "weight": null,
+      "restingHR": 51,
+      "hrv": 57,
+      "sleepSecs": 21540,
+      "sleepQuality": 4,
+      "soreness": null,
+      "fatigue": 31.18566,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 171.43216
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 14.660517,
+      "fitnessContribution": 98,
+      "fatigueContribution": 98,
+      "weeklyFitnessChange": 3.996973
+    },
+    {
+      "id": "2026-04-12",
+      "weight": null,
+      "restingHR": 57,
+      "hrv": 33,
+      "sleepSecs": 22080,
+      "sleepQuality": 4,
+      "soreness": null,
+      "fatigue": 31.027822,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 171.43216
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": 42,
+      "fitness": 15.021429,
+      "fitnessContribution": 30,
+      "fatigueContribution": 30,
+      "weeklyFitnessChange": 4.608781
+    },
+    {
+      "id": "2026-04-13",
+      "weight": null,
+      "restingHR": 55,
+      "hrv": 44,
+      "sleepSecs": 21480,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": 28.761044,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 171.43216
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 14.668,
+      "fitnessContribution": 0,
+      "fatigueContribution": 14,
+      "weeklyFitnessChange": 2.9474754
+    },
+    {
+      "id": "2026-04-14",
+      "weight": null,
+      "restingHR": 54,
+      "hrv": 46,
+      "sleepSecs": 18416,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": 36.247692,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 171.43216
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 16.322794,
+      "fitnessContribution": 85,
+      "fatigueContribution": 85,
+      "weeklyFitnessChange": 4.8780336
+    },
+    {
+      "id": "2026-04-15",
+      "weight": null,
+      "restingHR": 55,
+      "hrv": 40,
+      "sleepSecs": 24060,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": 35.282864,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 171.43216
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 16.621067,
+      "fitnessContribution": 29,
+      "fatigueContribution": 29,
+      "weeklyFitnessChange": 3.3515625
+    },
+    {
+      "id": "2026-04-16",
+      "weight": null,
+      "restingHR": 54,
+      "hrv": 52,
+      "sleepSecs": 22800,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": 30.585936,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 171.43216
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 16.230001,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 3.272706
+    },
+    {
+      "id": "2026-04-17",
+      "weight": null,
+      "restingHR": 56,
+      "hrv": 44,
+      "sleepSecs": 17361,
+      "sleepQuality": 4,
+      "soreness": null,
+      "fatigue": 30.24169,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 171.43216
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 16.50693,
+      "fitnessContribution": 28,
+      "fatigueContribution": 28,
+      "weeklyFitnessChange": 3.854497
+    },
+    {
+      "id": "2026-04-18",
+      "weight": null,
+      "restingHR": 54,
+      "hrv": 49,
+      "sleepSecs": 22140,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": 39.128696,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 171.43216
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 18.400795,
+      "fitnessContribution": 97,
+      "fatigueContribution": 97,
+      "weeklyFitnessChange": 3.7402782
+    },
+    {
+      "id": "2026-04-19",
+      "weight": null,
+      "restingHR": 58,
+      "hrv": 34,
+      "sleepSecs": 22200,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": 40.84215,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 171.43216
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": 42,
+      "fitness": 19.191328,
+      "fitnessContribution": 52,
+      "fatigueContribution": 52,
+      "weeklyFitnessChange": 4.169899
+    },
+    {
+      "id": "2026-04-20",
+      "weight": null,
+      "restingHR": 55,
+      "hrv": 43,
+      "sleepSecs": 24180,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": 37.40199,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 171.43216
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 19.092712,
+      "fitnessContribution": 15,
+      "fatigueContribution": 15,
+      "weeklyFitnessChange": 4.424712
+    },
+    {
+      "id": "2026-04-21",
+      "weight": null,
+      "restingHR": 57,
+      "hrv": 38,
+      "sleepSecs": 28980,
+      "sleepQuality": 2,
+      "soreness": null,
+      "fatigue": 35.884132,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 171.43216
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 19.25523,
+      "fitnessContribution": 26,
+      "fatigueContribution": 26,
+      "weeklyFitnessChange": 2.932436
+    },
+    {
+      "id": "2026-04-22",
+      "weight": null,
+      "restingHR": 58,
+      "hrv": 40,
+      "sleepSecs": 24960,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": 41.357563,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 171.43216
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 20.613867,
+      "fitnessContribution": 77,
+      "fatigueContribution": 77,
+      "weeklyFitnessChange": 3.9927998
+    },
+    {
+      "id": "2026-04-23",
+      "weight": null,
+      "restingHR": 53,
+      "hrv": 45,
+      "sleepSecs": 20514,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": 38.248154,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 171.43216
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 20.128857,
+      "fitnessContribution": 0,
+      "fatigueContribution": 18,
+      "weeklyFitnessChange": 3.8988552
+    },
+    {
+      "id": "2026-04-24",
+      "weight": null,
+      "restingHR": 58,
+      "hrv": 40,
+      "sleepSecs": 22260,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": 43.806248,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 171.43216
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 21.537523,
+      "fitnessContribution": 80,
+      "fatigueContribution": 80,
+      "weeklyFitnessChange": 5.030594
+    },
+    {
+      "id": "2026-04-25",
+      "weight": null,
+      "restingHR": 58,
+      "hrv": 35,
+      "sleepSecs": 22080,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": 37.974667,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 171.43216
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 21.03078,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 2.6299858
+    },
+    {
+      "id": "2026-04-26",
+      "weight": null,
+      "restingHR": 53,
+      "hrv": 47,
+      "sleepSecs": 22740,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": 32.9194,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 171.43216
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 20.535961,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 1.3446331
+    },
+    {
+      "id": "2026-04-27",
+      "weight": null,
+      "restingHR": 57,
+      "hrv": 35,
+      "sleepSecs": 21360,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": 44.112385,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 171.43216
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 22.805597,
+      "fitnessContribution": 117,
+      "fatigueContribution": 117,
+      "weeklyFitnessChange": 3.712885
+    },
+    {
+      "id": "2026-04-28",
+      "weight": null,
+      "restingHR": 55,
+      "hrv": 37,
+      "sleepSecs": 24120,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": 38.24005,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 171.43216
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 22.26902,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 3.0137901
+    },
+    {
+      "id": "2026-04-29",
+      "weight": null,
+      "restingHR": 54,
+      "hrv": 53,
+      "sleepSecs": 19560,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": 43.532978,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 171.43216
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 23.580276,
+      "fitnessContribution": 78,
+      "fatigueContribution": 78,
+      "weeklyFitnessChange": 2.9664097
+    },
+    {
+      "id": "2026-04-30",
+      "weight": null,
+      "restingHR": 58,
+      "hrv": 43,
+      "sleepSecs": 21660,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": 41.73144,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 171.43216
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 23.025473,
+      "fitnessContribution": 0,
+      "fatigueContribution": 30,
+      "weeklyFitnessChange": 2.896616
+    },
+    {
+      "id": "2026-05-01",
+      "weight": null,
+      "restingHR": 55,
+      "hrv": 45,
+      "sleepSecs": 23799,
+      "sleepQuality": 4,
+      "soreness": null,
+      "fatigue": 46.958954,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 171.43216
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 24.389515,
+      "fitnessContribution": 81,
+      "fatigueContribution": 81,
+      "weeklyFitnessChange": 2.8519917
+    },
+    {
+      "id": "2026-05-02",
+      "weight": null,
+      "restingHR": 58,
+      "hrv": 38,
+      "sleepSecs": 17700,
+      "sleepQuality": 4,
+      "soreness": null,
+      "fatigue": 40.70768,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 171.43216
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 23.81567,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 2.7848892
+    },
+    {
+      "id": "2026-05-03",
+      "weight": null,
+      "restingHR": 55,
+      "hrv": 51,
+      "sleepSecs": 23782,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": 58.98432,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 171.43216
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 27.443367,
+      "fitnessContribution": 178,
+      "fatigueContribution": 178,
+      "weeklyFitnessChange": 6.907406
+    },
+    {
+      "id": "2026-05-04",
+      "weight": null,
+      "restingHR": 61,
+      "hrv": 35,
+      "sleepSecs": 23580,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": 51.132206,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 171.43216
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 26.79767,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 3.992073
+    },
+    {
+      "id": "2026-05-05",
+      "weight": null,
+      "restingHR": 58,
+      "hrv": 45,
+      "sleepSecs": 19800,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": 44.32538,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 171.43216
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 26.167166,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 3.8981457
+    },
+    {
+      "id": "2026-05-06",
+      "weight": null,
+      "restingHR": 54,
+      "hrv": 43,
+      "sleepSecs": 25316,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": 47.743237,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 171.43216
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 27.198479,
+      "fitnessContribution": 70,
+      "fatigueContribution": 70,
+      "weeklyFitnessChange": 3.6182022
+    },
+    {
+      "id": "2026-05-07",
+      "weight": null,
+      "restingHR": 58,
+      "hrv": 39,
+      "sleepSecs": 19726,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": 49.37488,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 171.43216
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 27.970243,
+      "fitnessContribution": 60,
+      "fatigueContribution": 60,
+      "weeklyFitnessChange": 4.944771
+    },
+    {
+      "id": "2026-05-08",
+      "weight": null,
+      "restingHR": 56,
+      "hrv": 44,
+      "sleepSecs": 26520,
+      "sleepQuality": 2,
+      "soreness": null,
+      "fatigue": 47.727512,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 171.43216
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 27.312151,
+      "fitnessContribution": 0,
+      "fatigueContribution": 37,
+      "weeklyFitnessChange": 2.922636
+    },
+    {
+      "id": "2026-05-09",
+      "weight": null,
+      "restingHR": 58,
+      "hrv": 39,
+      "sleepSecs": 18120,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": 53.354916,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 171.43216
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 28.78709,
+      "fitnessContribution": 90,
+      "fatigueContribution": 90,
+      "weeklyFitnessChange": 4.9714203
+    },
+    {
+      "id": "2026-05-10",
+      "weight": null,
+      "restingHR": 58,
+      "hrv": 37,
+      "sleepSecs": 26807,
+      "sleepQuality": 3,
+      "soreness": null,
+      "fatigue": 46.252197,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 171.43216
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 28.10978,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0.66641235
+    },
+    {
+      "id": "2026-05-11",
+      "weight": null,
+      "restingHR": 54,
+      "hrv": 44,
+      "sleepSecs": 26580,
+      "sleepQuality": 2,
+      "soreness": null,
+      "fatigue": 40.09501,
+      "sportInfo": [
+        {
+          "type": "Ride",
+          "eftp": 171.43216
+        }
+      ],
+      "bodyFat": null,
+      "vo2max": null,
+      "fitness": 27.448404,
+      "fitnessContribution": 0,
+      "fatigueContribution": 0,
+      "weeklyFitnessChange": 0.65073395
+    }
+  ],
+  "ftp_history": [
+    {
+      "date": "2026-02-16",
+      "ftp": 178,
+      "source": "estimate"
+    },
+    {
+      "date": "2026-02-21",
+      "ftp": 177,
+      "source": "estimate"
+    },
+    {
+      "date": "2026-02-26",
+      "ftp": 176,
+      "source": "estimate"
+    },
+    {
+      "date": "2026-03-04",
+      "ftp": 175,
+      "source": "estimate"
+    },
+    {
+      "date": "2026-03-10",
+      "ftp": 174,
+      "source": "estimate"
+    },
+    {
+      "date": "2026-03-22",
+      "ftp": 173,
+      "source": "estimate"
+    },
+    {
+      "date": "2026-03-27",
+      "ftp": 172,
+      "source": "estimate"
+    },
+    {
+      "date": "2026-04-02",
+      "ftp": 171,
+      "source": "estimate"
+    }
+  ]
+}

--- a/packages/core/tests/fixtures/snapshots/capability-qualifying/acwr.json
+++ b/packages/core/tests/fixtures/snapshots/capability-qualifying/acwr.json
@@ -1,0 +1,8 @@
+{
+  "metric": "acwr",
+  "athlete": "capability-qualifying",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 1.23
+}

--- a/packages/core/tests/fixtures/snapshots/capability-qualifying/acwr_interpretation.json
+++ b/packages/core/tests/fixtures/snapshots/capability-qualifying/acwr_interpretation.json
@@ -1,0 +1,8 @@
+{
+  "metric": "acwr_interpretation",
+  "athlete": "capability-qualifying",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": "optimal"
+}

--- a/packages/core/tests/fixtures/snapshots/capability-qualifying/benchmark_indoor.json
+++ b/packages/core/tests/fixtures/snapshots/capability-qualifying/benchmark_indoor.json
@@ -1,0 +1,14 @@
+{
+  "metric": "benchmark_indoor",
+  "athlete": "capability-qualifying",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "benchmark_index": null,
+    "benchmark_percentage": null,
+    "current_ftp": null,
+    "ftp_8_weeks_ago": null,
+    "seasonal_expected": null
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/capability-qualifying/benchmark_outdoor.json
+++ b/packages/core/tests/fixtures/snapshots/capability-qualifying/benchmark_outdoor.json
@@ -1,0 +1,14 @@
+{
+  "metric": "benchmark_outdoor",
+  "athlete": "capability-qualifying",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "benchmark_index": null,
+    "benchmark_percentage": null,
+    "current_ftp": null,
+    "ftp_8_weeks_ago": null,
+    "seasonal_expected": null
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/capability-qualifying/calculation_timestamp.json
+++ b/packages/core/tests/fixtures/snapshots/capability-qualifying/calculation_timestamp.json
@@ -1,0 +1,8 @@
+{
+  "metric": "calculation_timestamp",
+  "athlete": "capability-qualifying",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": "2026-05-10T12:00:00"
+}

--- a/packages/core/tests/fixtures/snapshots/capability-qualifying/capability.dfa_a1_profile.json
+++ b/packages/core/tests/fixtures/snapshots/capability-qualifying/capability.dfa_a1_profile.json
@@ -1,0 +1,8 @@
+{
+  "metric": "capability.dfa_a1_profile",
+  "athlete": "capability-qualifying",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/capability-qualifying/capability.durability.json
+++ b/packages/core/tests/fixtures/snapshots/capability-qualifying/capability.durability.json
@@ -1,0 +1,19 @@
+{
+  "metric": "capability.durability",
+  "athlete": "capability-qualifying",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "high_drift_count_28d": 2,
+    "high_drift_count_7d": 0,
+    "mean_decoupling_28d": 3.8,
+    "mean_decoupling_7d": 2,
+    "note": "Steady-state power sessions only (VI <= 1.05, VI > 0, >= 90min, power data). Negative decoupling = strong durability. Trend compares 7d vs 28d mean (+/-1% = stable). Alerts require N28>=5 (alarm) or N7>=3 AND N28>=5 (declining warning) for statistical reliability.",
+    "qualifying_sessions_28d": 5,
+    "qualifying_sessions_7d": 3,
+    "reliability_limited": false,
+    "reliability_note": null,
+    "trend": "improving"
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/capability-qualifying/capability.efficiency_factor.json
+++ b/packages/core/tests/fixtures/snapshots/capability-qualifying/capability.efficiency_factor.json
@@ -1,0 +1,15 @@
+{
+  "metric": "capability.efficiency_factor",
+  "athlete": "capability-qualifying",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "mean_ef_28d": 2.3,
+    "mean_ef_7d": 2.5,
+    "note": "Steady-state cycling sessions only (VI <= 1.05, VI > 0, >= 20min, power+HR data). Rising EF = improving aerobic efficiency. Compare like-for-like sessions only — EF varies with intensity. Trend compares 7d vs 28d mean (+/-0.03 = stable).",
+    "qualifying_sessions_28d": 5,
+    "qualifying_sessions_7d": 3,
+    "trend": "improving"
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/capability-qualifying/capability.hr_curve_delta.json
+++ b/packages/core/tests/fixtures/snapshots/capability-qualifying/capability.hr_curve_delta.json
@@ -1,0 +1,13 @@
+{
+  "metric": "capability.hr_curve_delta",
+  "athlete": "capability-qualifying",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "anchors": null,
+    "note": "Insufficient HR data in one or both windows.",
+    "rotation_index": null,
+    "window_days": 28
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/capability-qualifying/capability.hrrc.json
+++ b/packages/core/tests/fixtures/snapshots/capability-qualifying/capability.hrrc.json
@@ -1,0 +1,15 @@
+{
+  "metric": "capability.hrrc",
+  "athlete": "capability-qualifying",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "mean_hrrc_28d": 36,
+    "mean_hrrc_7d": 40,
+    "note": "HRRc = heart rate recovery (largest 60s HR drop in bpm after exceeding threshold HR for >1 min). Higher = better parasympathetic recovery. Null when threshold not reached, recording stopped before cooldown, or no HR data. Trend: 7d mean vs 28d mean, >10% = meaningful (min 1 session/7d, 3 sessions/28d). Display only — not wired into readiness_decision signals.",
+    "qualifying_sessions_28d": 5,
+    "qualifying_sessions_7d": 3,
+    "trend": "improving"
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/capability-qualifying/capability.json
+++ b/packages/core/tests/fixtures/snapshots/capability-qualifying/capability.json
@@ -1,0 +1,62 @@
+{
+  "metric": "capability",
+  "athlete": "capability-qualifying",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "dfa_a1_profile": null,
+    "durability": {
+      "high_drift_count_28d": 2,
+      "high_drift_count_7d": 0,
+      "mean_decoupling_28d": 3.8,
+      "mean_decoupling_7d": 2,
+      "note": "Steady-state power sessions only (VI <= 1.05, VI > 0, >= 90min, power data). Negative decoupling = strong durability. Trend compares 7d vs 28d mean (+/-1% = stable). Alerts require N28>=5 (alarm) or N7>=3 AND N28>=5 (declining warning) for statistical reliability.",
+      "qualifying_sessions_28d": 5,
+      "qualifying_sessions_7d": 3,
+      "reliability_limited": false,
+      "reliability_note": null,
+      "trend": "improving"
+    },
+    "efficiency_factor": {
+      "mean_ef_28d": 2.3,
+      "mean_ef_7d": 2.5,
+      "note": "Steady-state cycling sessions only (VI <= 1.05, VI > 0, >= 20min, power+HR data). Rising EF = improving aerobic efficiency. Compare like-for-like sessions only — EF varies with intensity. Trend compares 7d vs 28d mean (+/-0.03 = stable).",
+      "qualifying_sessions_28d": 5,
+      "qualifying_sessions_7d": 3,
+      "trend": "improving"
+    },
+    "hr_curve_delta": {
+      "anchors": null,
+      "note": "Insufficient HR data in one or both windows.",
+      "rotation_index": null,
+      "window_days": 28
+    },
+    "hrrc": {
+      "mean_hrrc_28d": 36,
+      "mean_hrrc_7d": 40,
+      "note": "HRRc = heart rate recovery (largest 60s HR drop in bpm after exceeding threshold HR for >1 min). Higher = better parasympathetic recovery. Null when threshold not reached, recording stopped before cooldown, or no HR data. Trend: 7d mean vs 28d mean, >10% = meaningful (min 1 session/7d, 3 sessions/28d). Display only — not wired into readiness_decision signals.",
+      "qualifying_sessions_28d": 5,
+      "qualifying_sessions_7d": 3,
+      "trend": "improving"
+    },
+    "power_curve_delta": {
+      "anchors": null,
+      "note": "Insufficient power data in one or both windows.",
+      "rotation_index": null,
+      "window_days": 28
+    },
+    "sustainability_profile": {
+      "note": "No sustainability data available."
+    },
+    "tid_comparison": {
+      "classification_28d": "Pyramidal",
+      "classification_7d": "Pyramidal",
+      "drift": "consistent",
+      "note": "Compares 7d vs 28d Seiler TID to detect distribution shifts. pi_delta positive = more polarized acutely.",
+      "pi_28d": null,
+      "pi_7d": null,
+      "pi_delta": null
+    }
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/capability-qualifying/capability.power_curve_delta.json
+++ b/packages/core/tests/fixtures/snapshots/capability-qualifying/capability.power_curve_delta.json
@@ -1,0 +1,13 @@
+{
+  "metric": "capability.power_curve_delta",
+  "athlete": "capability-qualifying",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "anchors": null,
+    "note": "Insufficient power data in one or both windows.",
+    "rotation_index": null,
+    "window_days": 28
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/capability-qualifying/capability.sustainability_profile.json
+++ b/packages/core/tests/fixtures/snapshots/capability-qualifying/capability.sustainability_profile.json
@@ -1,0 +1,10 @@
+{
+  "metric": "capability.sustainability_profile",
+  "athlete": "capability-qualifying",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "note": "No sustainability data available."
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/capability-qualifying/capability.tid_comparison.json
+++ b/packages/core/tests/fixtures/snapshots/capability-qualifying/capability.tid_comparison.json
@@ -1,0 +1,16 @@
+{
+  "metric": "capability.tid_comparison",
+  "athlete": "capability-qualifying",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "classification_28d": "Pyramidal",
+    "classification_7d": "Pyramidal",
+    "drift": "consistent",
+    "note": "Compares 7d vs 28d Seiler TID to detect distribution shifts. pi_delta positive = more polarized acutely.",
+    "pi_28d": null,
+    "pi_7d": null,
+    "pi_delta": null
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/capability-qualifying/consistency_details.json
+++ b/packages/core/tests/fixtures/snapshots/capability-qualifying/consistency_details.json
@@ -1,0 +1,13 @@
+{
+  "metric": "consistency_details",
+  "athlete": "capability-qualifying",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "completed_days": 5,
+    "matched_days": 0,
+    "note": "No planned workouts in period",
+    "planned_days": 0
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/capability-qualifying/consistency_index.json
+++ b/packages/core/tests/fixtures/snapshots/capability-qualifying/consistency_index.json
@@ -1,0 +1,8 @@
+{
+  "metric": "consistency_index",
+  "athlete": "capability-qualifying",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/capability-qualifying/data_quality.json
+++ b/packages/core/tests/fixtures/snapshots/capability-qualifying/data_quality.json
@@ -1,0 +1,18 @@
+{
+  "metric": "data_quality",
+  "athlete": "capability-qualifying",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "activities_28d": 25,
+    "activities_7d": 7,
+    "ftp_history_days": {
+      "indoor": 0,
+      "outdoor": 0
+    },
+    "hrv_data_points": 7,
+    "planned_workouts_7d": 0,
+    "rhr_data_points": 7
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/capability-qualifying/easy_time_ratio.json
+++ b/packages/core/tests/fixtures/snapshots/capability-qualifying/easy_time_ratio.json
@@ -1,0 +1,8 @@
+{
+  "metric": "easy_time_ratio",
+  "athlete": "capability-qualifying",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 0.62
+}

--- a/packages/core/tests/fixtures/snapshots/capability-qualifying/easy_time_ratio_note.json
+++ b/packages/core/tests/fixtures/snapshots/capability-qualifying/easy_time_ratio_note.json
@@ -1,0 +1,8 @@
+{
+  "metric": "easy_time_ratio_note",
+  "athlete": "capability-qualifying",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": "Easy time (Z1+Z2) / Total - target ~80% in polarized training"
+}

--- a/packages/core/tests/fixtures/snapshots/capability-qualifying/effective_monotony.json
+++ b/packages/core/tests/fixtures/snapshots/capability-qualifying/effective_monotony.json
@@ -1,0 +1,8 @@
+{
+  "metric": "effective_monotony",
+  "athlete": "capability-qualifying",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 1.24
+}

--- a/packages/core/tests/fixtures/snapshots/capability-qualifying/effort_response_signal.json
+++ b/packages/core/tests/fixtures/snapshots/capability-qualifying/effort_response_signal.json
@@ -1,0 +1,15 @@
+{
+  "metric": "effort_response_signal",
+  "athlete": "capability-qualifying",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "12345": "positive",
+    "90001": null,
+    "90002": null,
+    "90003": null,
+    "90004": null,
+    "90005": null
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/capability-qualifying/eftp.json
+++ b/packages/core/tests/fixtures/snapshots/capability-qualifying/eftp.json
@@ -1,0 +1,8 @@
+{
+  "metric": "eftp",
+  "athlete": "capability-qualifying",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/capability-qualifying/grey_zone_note.json
+++ b/packages/core/tests/fixtures/snapshots/capability-qualifying/grey_zone_note.json
@@ -1,0 +1,8 @@
+{
+  "metric": "grey_zone_note",
+  "athlete": "capability-qualifying",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": "Gray Zone % (Z3/tempo) - minimize in polarized training"
+}

--- a/packages/core/tests/fixtures/snapshots/capability-qualifying/grey_zone_percentage.json
+++ b/packages/core/tests/fixtures/snapshots/capability-qualifying/grey_zone_percentage.json
@@ -1,0 +1,8 @@
+{
+  "metric": "grey_zone_percentage",
+  "athlete": "capability-qualifying",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 23.6
+}

--- a/packages/core/tests/fixtures/snapshots/capability-qualifying/hard_days_note.json
+++ b/packages/core/tests/fixtures/snapshots/capability-qualifying/hard_days_note.json
@@ -1,0 +1,8 @@
+{
+  "metric": "hard_days_note",
+  "athlete": "capability-qualifying",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": "Power ladder: z3+ >= 30min, z4+ >= 10min, z5+ >= 5min, z6+ >= 2min, z7 >= 1min. HR fallback (when no power): z4+ >= 10min, z5+ >= 5min. Per Seiler 3-zone model + Foster. HR-based days flagged with intensity_basis: hr"
+}

--- a/packages/core/tests/fixtures/snapshots/capability-qualifying/hard_days_this_week.json
+++ b/packages/core/tests/fixtures/snapshots/capability-qualifying/hard_days_this_week.json
@@ -1,0 +1,8 @@
+{
+  "metric": "hard_days_this_week",
+  "athlete": "capability-qualifying",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 4
+}

--- a/packages/core/tests/fixtures/snapshots/capability-qualifying/has_intervals.json
+++ b/packages/core/tests/fixtures/snapshots/capability-qualifying/has_intervals.json
@@ -1,0 +1,15 @@
+{
+  "metric": "has_intervals",
+  "athlete": "capability-qualifying",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "12345": false,
+    "90001": false,
+    "90002": false,
+    "90003": false,
+    "90004": false,
+    "90005": false
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/capability-qualifying/hrv_baseline_28d.json
+++ b/packages/core/tests/fixtures/snapshots/capability-qualifying/hrv_baseline_28d.json
@@ -1,0 +1,8 @@
+{
+  "metric": "hrv_baseline_28d",
+  "athlete": "capability-qualifying",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 42.2
+}

--- a/packages/core/tests/fixtures/snapshots/capability-qualifying/hrv_baseline_7d.json
+++ b/packages/core/tests/fixtures/snapshots/capability-qualifying/hrv_baseline_7d.json
@@ -1,0 +1,8 @@
+{
+  "metric": "hrv_baseline_7d",
+  "athlete": "capability-qualifying",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 40.3
+}

--- a/packages/core/tests/fixtures/snapshots/capability-qualifying/latest_hrv.json
+++ b/packages/core/tests/fixtures/snapshots/capability-qualifying/latest_hrv.json
@@ -1,0 +1,8 @@
+{
+  "metric": "latest_hrv",
+  "athlete": "capability-qualifying",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 37
+}

--- a/packages/core/tests/fixtures/snapshots/capability-qualifying/latest_rhr.json
+++ b/packages/core/tests/fixtures/snapshots/capability-qualifying/latest_rhr.json
@@ -1,0 +1,8 @@
+{
+  "metric": "latest_rhr",
+  "athlete": "capability-qualifying",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 58
+}

--- a/packages/core/tests/fixtures/snapshots/capability-qualifying/load_recovery_ratio.json
+++ b/packages/core/tests/fixtures/snapshots/capability-qualifying/load_recovery_ratio.json
@@ -1,0 +1,8 @@
+{
+  "metric": "load_recovery_ratio",
+  "athlete": "capability-qualifying",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 5.8
+}

--- a/packages/core/tests/fixtures/snapshots/capability-qualifying/monotony.json
+++ b/packages/core/tests/fixtures/snapshots/capability-qualifying/monotony.json
@@ -1,0 +1,8 @@
+{
+  "metric": "monotony",
+  "athlete": "capability-qualifying",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 1.25
+}

--- a/packages/core/tests/fixtures/snapshots/capability-qualifying/monotony_interpretation.json
+++ b/packages/core/tests/fixtures/snapshots/capability-qualifying/monotony_interpretation.json
@@ -1,0 +1,8 @@
+{
+  "metric": "monotony_interpretation",
+  "athlete": "capability-qualifying",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": "normal (primary sport 1.24, total 1.25 inflated by multi-sport)"
+}

--- a/packages/core/tests/fixtures/snapshots/capability-qualifying/multi_sport_detected.json
+++ b/packages/core/tests/fixtures/snapshots/capability-qualifying/multi_sport_detected.json
@@ -1,0 +1,8 @@
+{
+  "metric": "multi_sport_detected",
+  "athlete": "capability-qualifying",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": true
+}

--- a/packages/core/tests/fixtures/snapshots/capability-qualifying/p_max.json
+++ b/packages/core/tests/fixtures/snapshots/capability-qualifying/p_max.json
@@ -1,0 +1,8 @@
+{
+  "metric": "p_max",
+  "athlete": "capability-qualifying",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/capability-qualifying/phase_detected.json
+++ b/packages/core/tests/fixtures/snapshots/capability-qualifying/phase_detected.json
@@ -1,0 +1,8 @@
+{
+  "metric": "phase_detected",
+  "athlete": "capability-qualifying",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": "Build"
+}

--- a/packages/core/tests/fixtures/snapshots/capability-qualifying/phase_detection.json
+++ b/packages/core/tests/fixtures/snapshots/capability-qualifying/phase_detection.json
@@ -1,0 +1,38 @@
+{
+  "metric": "phase_detection",
+  "athlete": "capability-qualifying",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "basis": {
+      "data_quality": "good",
+      "stream_1": {
+        "acwr_trend": null,
+        "ctl_slope": null,
+        "hard_day_pattern": 2.3,
+        "weeks_available": 4
+      },
+      "stream_2": {
+        "current_week_hard_days_completed": 0,
+        "current_week_hard_days_total": 0,
+        "hard_sessions_planned": 0,
+        "next_week_load": null,
+        "plan_coverage_current_week": 0,
+        "plan_coverage_next_week": 0,
+        "planned_tss_delta": null,
+        "race_proximity": null
+      },
+      "stream_agreement": null
+    },
+    "confidence": "medium",
+    "dossier_agreement": null,
+    "dossier_declared": null,
+    "phase": "Build",
+    "phase_duration_weeks": 1,
+    "previous_phase": null,
+    "reason_codes": [
+      "NO_PLANNED_WORKOUTS"
+    ]
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/capability-qualifying/phase_triggers.json
+++ b/packages/core/tests/fixtures/snapshots/capability-qualifying/phase_triggers.json
@@ -1,0 +1,10 @@
+{
+  "metric": "phase_triggers",
+  "athlete": "capability-qualifying",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": [
+    "NO_PLANNED_WORKOUTS"
+  ]
+}

--- a/packages/core/tests/fixtures/snapshots/capability-qualifying/power_model_source.json
+++ b/packages/core/tests/fixtures/snapshots/capability-qualifying/power_model_source.json
@@ -1,0 +1,8 @@
+{
+  "metric": "power_model_source",
+  "athlete": "capability-qualifying",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/capability-qualifying/primary_sport.json
+++ b/packages/core/tests/fixtures/snapshots/capability-qualifying/primary_sport.json
@@ -1,0 +1,8 @@
+{
+  "metric": "primary_sport",
+  "athlete": "capability-qualifying",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": "cycling"
+}

--- a/packages/core/tests/fixtures/snapshots/capability-qualifying/primary_sport_monotony.json
+++ b/packages/core/tests/fixtures/snapshots/capability-qualifying/primary_sport_monotony.json
@@ -1,0 +1,8 @@
+{
+  "metric": "primary_sport_monotony",
+  "athlete": "capability-qualifying",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 1.24
+}

--- a/packages/core/tests/fixtures/snapshots/capability-qualifying/primary_sport_tss_7d.json
+++ b/packages/core/tests/fixtures/snapshots/capability-qualifying/primary_sport_tss_7d.json
@@ -1,0 +1,8 @@
+{
+  "metric": "primary_sport_tss_7d",
+  "athlete": "capability-qualifying",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 490
+}

--- a/packages/core/tests/fixtures/snapshots/capability-qualifying/quality_intensity_note.json
+++ b/packages/core/tests/fixtures/snapshots/capability-qualifying/quality_intensity_note.json
@@ -1,0 +1,8 @@
+{
+  "metric": "quality_intensity_note",
+  "athlete": "capability-qualifying",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": "Quality Intensity % (Z4+/threshold+) - target ~20% in polarized training"
+}

--- a/packages/core/tests/fixtures/snapshots/capability-qualifying/quality_intensity_percentage.json
+++ b/packages/core/tests/fixtures/snapshots/capability-qualifying/quality_intensity_percentage.json
@@ -1,0 +1,8 @@
+{
+  "metric": "quality_intensity_percentage",
+  "athlete": "capability-qualifying",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 14
+}

--- a/packages/core/tests/fixtures/snapshots/capability-qualifying/recovery_index.json
+++ b/packages/core/tests/fixtures/snapshots/capability-qualifying/recovery_index.json
@@ -1,0 +1,8 @@
+{
+  "metric": "recovery_index",
+  "athlete": "capability-qualifying",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 0.91
+}

--- a/packages/core/tests/fixtures/snapshots/capability-qualifying/recovery_index_yesterday.json
+++ b/packages/core/tests/fixtures/snapshots/capability-qualifying/recovery_index_yesterday.json
@@ -1,0 +1,8 @@
+{
+  "metric": "recovery_index_yesterday",
+  "athlete": "capability-qualifying",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 0.96
+}

--- a/packages/core/tests/fixtures/snapshots/capability-qualifying/rhr_baseline_28d.json
+++ b/packages/core/tests/fixtures/snapshots/capability-qualifying/rhr_baseline_28d.json
@@ -1,0 +1,8 @@
+{
+  "metric": "rhr_baseline_28d",
+  "athlete": "capability-qualifying",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 56.2
+}

--- a/packages/core/tests/fixtures/snapshots/capability-qualifying/rhr_baseline_7d.json
+++ b/packages/core/tests/fixtures/snapshots/capability-qualifying/rhr_baseline_7d.json
@@ -1,0 +1,8 @@
+{
+  "metric": "rhr_baseline_7d",
+  "athlete": "capability-qualifying",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 57.6
+}

--- a/packages/core/tests/fixtures/snapshots/capability-qualifying/seasonal_context.json
+++ b/packages/core/tests/fixtures/snapshots/capability-qualifying/seasonal_context.json
@@ -1,0 +1,8 @@
+{
+  "metric": "seasonal_context",
+  "athlete": "capability-qualifying",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": "Build / Early Race Season"
+}

--- a/packages/core/tests/fixtures/snapshots/capability-qualifying/seiler_tid_28d.json
+++ b/packages/core/tests/fixtures/snapshots/capability-qualifying/seiler_tid_28d.json
@@ -1,0 +1,18 @@
+{
+  "metric": "seiler_tid_28d",
+  "athlete": "capability-qualifying",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "classification": "Pyramidal",
+    "polarization_index": null,
+    "z1_pct": 63,
+    "z1_seconds": 61110,
+    "z2_pct": 24,
+    "z2_seconds": 23271,
+    "z3_pct": 13.1,
+    "z3_seconds": 12686,
+    "zone_basis": "power"
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/capability-qualifying/seiler_tid_28d_primary.json
+++ b/packages/core/tests/fixtures/snapshots/capability-qualifying/seiler_tid_28d_primary.json
@@ -1,0 +1,19 @@
+{
+  "metric": "seiler_tid_28d_primary",
+  "athlete": "capability-qualifying",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "classification": "Pyramidal",
+    "polarization_index": null,
+    "sport": "cycling",
+    "z1_pct": 63,
+    "z1_seconds": 61110,
+    "z2_pct": 24,
+    "z2_seconds": 23271,
+    "z3_pct": 13.1,
+    "z3_seconds": 12686,
+    "zone_basis": "power"
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/capability-qualifying/seiler_tid_7d.json
+++ b/packages/core/tests/fixtures/snapshots/capability-qualifying/seiler_tid_7d.json
@@ -1,0 +1,18 @@
+{
+  "metric": "seiler_tid_7d",
+  "athlete": "capability-qualifying",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "classification": "Pyramidal",
+    "polarization_index": null,
+    "z1_pct": 62.3,
+    "z1_seconds": 20081,
+    "z2_pct": 23.6,
+    "z2_seconds": 7612,
+    "z3_pct": 14,
+    "z3_seconds": 4520,
+    "zone_basis": "power"
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/capability-qualifying/seiler_tid_7d_primary.json
+++ b/packages/core/tests/fixtures/snapshots/capability-qualifying/seiler_tid_7d_primary.json
@@ -1,0 +1,19 @@
+{
+  "metric": "seiler_tid_7d_primary",
+  "athlete": "capability-qualifying",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "classification": "Pyramidal",
+    "polarization_index": null,
+    "sport": "cycling",
+    "z1_pct": 62.3,
+    "z1_seconds": 20081,
+    "z2_pct": 23.6,
+    "z2_seconds": 7612,
+    "z3_pct": 14,
+    "z3_seconds": 4520,
+    "zone_basis": "power"
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/capability-qualifying/strain.json
+++ b/packages/core/tests/fixtures/snapshots/capability-qualifying/strain.json
@@ -1,0 +1,8 @@
+{
+  "metric": "strain",
+  "athlete": "capability-qualifying",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 659
+}

--- a/packages/core/tests/fixtures/snapshots/capability-qualifying/stress_tolerance.json
+++ b/packages/core/tests/fixtures/snapshots/capability-qualifying/stress_tolerance.json
@@ -1,0 +1,8 @@
+{
+  "metric": "stress_tolerance",
+  "athlete": "capability-qualifying",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 5.3
+}

--- a/packages/core/tests/fixtures/snapshots/capability-qualifying/tss_28d_total.json
+++ b/packages/core/tests/fixtures/snapshots/capability-qualifying/tss_28d_total.json
@@ -1,0 +1,8 @@
+{
+  "metric": "tss_28d_total",
+  "athlete": "capability-qualifying",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 1712
+}

--- a/packages/core/tests/fixtures/snapshots/capability-qualifying/tss_7d_total.json
+++ b/packages/core/tests/fixtures/snapshots/capability-qualifying/tss_7d_total.json
@@ -1,0 +1,8 @@
+{
+  "metric": "tss_7d_total",
+  "athlete": "capability-qualifying",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": 527
+}

--- a/packages/core/tests/fixtures/snapshots/capability-qualifying/vo2max.json
+++ b/packages/core/tests/fixtures/snapshots/capability-qualifying/vo2max.json
@@ -1,0 +1,8 @@
+{
+  "metric": "vo2max",
+  "athlete": "capability-qualifying",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/capability-qualifying/w_prime.json
+++ b/packages/core/tests/fixtures/snapshots/capability-qualifying/w_prime.json
@@ -1,0 +1,8 @@
+{
+  "metric": "w_prime",
+  "athlete": "capability-qualifying",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/capability-qualifying/w_prime_kj.json
+++ b/packages/core/tests/fixtures/snapshots/capability-qualifying/w_prime_kj.json
@@ -1,0 +1,8 @@
+{
+  "metric": "w_prime_kj",
+  "athlete": "capability-qualifying",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/capability-qualifying/weight_signal.json
+++ b/packages/core/tests/fixtures/snapshots/capability-qualifying/weight_signal.json
@@ -1,0 +1,8 @@
+{
+  "metric": "weight_signal",
+  "athlete": "capability-qualifying",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/capability-qualifying/zone_distribution_7d.json
+++ b/packages/core/tests/fixtures/snapshots/capability-qualifying/zone_distribution_7d.json
@@ -1,0 +1,15 @@
+{
+  "metric": "zone_distribution_7d",
+  "athlete": "capability-qualifying",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "2026-05-10T12:00:00",
+  "value": {
+    "total_hours": 8.95,
+    "z1_hours": 1.1,
+    "z2_hours": 4.48,
+    "z3_hours": 2.11,
+    "z4_plus_hours": 1.26,
+    "zone_basis": "power"
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/manifest.json
+++ b/packages/core/tests/fixtures/snapshots/manifest.json
@@ -6,6 +6,7 @@
     "boundary-monotony",
     "boundary-sum-strain",
     "boundary-zone-total-secs",
+    "capability-qualifying",
     "data-gap-mid-history",
     "multisport-thin-primary",
     "multisport-tie",

--- a/tools/harness-fixtures.ts
+++ b/tools/harness-fixtures.ts
@@ -84,4 +84,10 @@ export const HARNESS_FIXTURES: HarnessFixtureConfig[] = [
     description:
       "Constant-Load coverage for the monotony stdev=0 branch. 7 recovery rides on 05-04..05-10 at an IDENTICAL daily Load of 35.0 give the 7d series [35,35,35,35,35,35,35] — non-zero mean, sample stdev exactly 0 — so monotony hits the `stdevLoad <= 0 -> null` guard (a path the all-zero fixtures reach via a different branch). That null cascades: strain -> null, stress_tolerance -> null. Single-sport, so primary_sport_monotony hits its own stdev=0 null too. The 28-day wellness baseline (stable RHR 58 / HRV 52) populates recovery_index + HRV/RHR baselines through the flat block. Anchor 2026-05-10 puts the constant week in the 7d acute window.",
   },
+  {
+    slug: "capability-qualifying",
+    frozenNow: DEFAULT_FROZEN_NOW,
+    description:
+      "Populated-branch coverage for the capability sub-keys (durability, efficiency_factor, hrrc). Appends 5 steady-state qualifying Rides (VI 1.0, moving_time 6000s, decoupling/EF/hrr present) to the realistic-athlete base — 3 in the 7d window, 5 in the 28d window — clearing durability's reliability gate (N7>=3, N28>=5) and exercising the means + trends the all-null fixtures never reach.",
+  },
 ];


### PR DESCRIPTION
Adds a dedicated golden fixture so the parity gate exercises the **populated** branches of the capability sub-keys, which every existing fixture left null.

## What
- New `golden/capability-qualifying.json`: the realistic-athlete base plus 5 appended steady-state qualifying Rides (`icu_variability_index` 1.0, `moving_time` 6000s, `icu_hr_decoupling`/`icu_efficiency_factor`/`icu_hrr` present), dated 3 in the 7d window and 5 in the 28d window. Distinct synthetic ids (90001–90005) so they don't collide with the base's sanitized-id sentinel.
- New allowlist entry in `harness-fixtures.ts` + regenerated oracle snapshots (`snapshots/capability-qualifying/`, 63 files) + the manifest line.

## Why
The Rides clear durability's reliability gate (N7≥3, N28≥5) and give EF/hrrc their qualifying counts, so the oracle now produces real values instead of the empty-branch shape:
- `durability`: 7d mean 2.0, 28d mean 3.8, high-drift 2/28d, reliability cleared, trend improving
- `efficiency_factor`: 7d 2.5, 28d 2.3, trend improving
- `hrrc`: 7d 40, 28d 36, trend improving

These match the algorithms' hand-derived expectations exactly — so the gate now **oracle-verifies** the populated arithmetic that was previously only unit-tested.

## Verification
- **Purely additive** — `git status` confirms only the new golden file, the new snapshot dir, the manifest line, and the allowlist entry changed; no existing snapshot modified (upstream pinned at the same SHA → deterministic regen).
- Full parity matrix green: **374 assertions** (every registered metric × every fixture, including the new one).

No changeset — internal test fixture.
