### PR TITLE
chore(core): clarify multi-sport predicate JSDoc, consolidate test fixture casts

### DIFF
--- a/packages/core/src/reference/metrics/load-management.test.ts
+++ b/packages/core/src/reference/metrics/load-management.test.ts
@@ -13,11 +13,20 @@ import {
 } from "./load-management.js";
 import type { MetricInput } from "./metric-input.js";
 
+// The synthetic rows in this file are intentionally minimal — only the fields
+// each formula reads — so they don't satisfy the full parsed Activity /
+// WellnessDay shape. asFixture casts them through the gate-boundary fixture
+// type at one local seam; the full shape is exercised by the parity matrix
+// against captured fixtures.
+function asFixture(rows: {
+  activities?: unknown[];
+  wellness?: unknown[];
+}): MetricInput["fixture"] {
+  return rows as unknown as MetricInput["fixture"];
+}
+
 // These computers read only start_date_local, icu_training_load, and (for
-// the per-sport split) type through the shared daily-Load aggregators; the
-// full Activity shape is exercised by the parity matrix against captured
-// fixtures. These synthetic rows isolate the formulae and cast through the
-// parsed fixture shape at the local unit-test boundary.
+// the per-sport split) type through the shared daily-Load aggregators.
 function input(
   activities: {
     start_date_local: string;
@@ -26,10 +35,7 @@ function input(
   }[],
   frozenNow: string,
 ): MetricInput {
-  return {
-    fixture: { activities } as unknown as MetricInput["fixture"],
-    frozenNow,
-  };
+  return { fixture: asFixture({ activities }), frozenNow };
 }
 
 describe("computeMonotony", () => {
@@ -239,10 +245,7 @@ function wellnessInput(
   wellness: { id: string; hrv: number | null; restingHR: number | null }[],
   frozenNow: string,
 ): MetricInput {
-  return {
-    fixture: { wellness } as unknown as MetricInput["fixture"],
-    frozenNow,
-  };
+  return { fixture: asFixture({ wellness }), frozenNow };
 }
 
 describe("computeRecoveryIndex", () => {
@@ -311,10 +314,7 @@ function loadRecoveryInput(
   wellness: { id: string; hrv: number | null; restingHR: number | null }[],
   frozenNow: string,
 ): MetricInput {
-  return {
-    fixture: { activities, wellness } as unknown as MetricInput["fixture"],
-    frozenNow,
-  };
+  return { fixture: asFixture({ activities, wellness }), frozenNow };
 }
 
 describe("computeLoadRecoveryRatio", () => {
@@ -370,10 +370,7 @@ describe("load aggregators — malformed start_date_local is dropped, not thrown
   ];
 
   function fixtureOf(activities: unknown[]): MetricInput {
-    return {
-      fixture: { activities } as unknown as MetricInput["fixture"],
-      frozenNow: FROZEN,
-    };
+    return { fixture: asFixture({ activities }), frozenNow: FROZEN };
   }
 
   it("computeMonotony drops a null-date row (getDailyLoad)", () => {

--- a/packages/core/src/reference/metrics/load-management.ts
+++ b/packages/core/src/reference/metrics/load-management.ts
@@ -181,10 +181,10 @@ export function computePrimarySportMonotony(input: MetricInput): number | null {
  *
  * Pure composition — no new math. Calls the sibling compute functions
  * for the two candidate values and the shared per-sport aggregator for
- * the multi-sport check. The `isMultiSport` branch selector shares the
- * same derivation as `computeMultiSportDetected`. The duplicate
- * aggregation work (getDailyLoad runs three times across this call's
- * transitive helpers) is intentional:
+ * the multi-sport check. The `isMultiSport` branch selector re-derives the
+ * same `getDailyLoadBySport(...).size > 1` predicate emitted standalone as
+ * `multi_sport_detected`. The duplicate aggregation work (getDailyLoad runs
+ * three times across this call's transitive helpers) is intentional:
  * the discipline rewards line-by-line transliteration over optimization,
  * and the snapshot gate would catch any drift from a structural rewrite.
  *
@@ -214,10 +214,12 @@ export function computeEffectiveMonotony(input: MetricInput): number | null {
 
 /**
  * `multi_sport_detected` — whether the trailing-7-day window spans more than
- * one sport family by accumulated Load. This is the SAME `is_multi_sport`
- * derivation `computeEffectiveMonotony` uses for its branch selector
- * (`getDailyLoadBySport(...).size > 1`); the two share one definition so the
- * runtime indicator and the monotony selector can never disagree.
+ * one sport family by accumulated Load. Computes the same
+ * `getDailyLoadBySport(...).size > 1` predicate that the monotony selectors
+ * (`computeEffectiveMonotony`, `computeMonotonyInterpretation`) apply inline.
+ * Each site re-derives it to mirror the single upstream `is_multi_sport` local
+ * line-by-line rather than sharing a TS symbol; the snapshot gate is what
+ * guards them against drifting apart.
  *
  * Upstream source mirrored line-by-line: `sync.py:3081`
  * (`is_multi_sport = len(daily_tss_by_sport) > 1`), emitted at `sync.py:3368`.


### PR DESCRIPTION
## Summary
- Rewords the JSDoc on `computeEffectiveMonotony` and `computeMultiSportDetected` to describe the `is_multi_sport` predicate as re-derived inline at each call site, mirroring the single upstream definition line-by-line (follow-up wording cleanup to #137).
- Consolidates the repeated `as unknown as MetricInput["fixture"]` casts in the test file behind a single local `asFixture()` helper. No new test cases, no behavior change.

## Test plan
- Comment/test-refactor only — no compute-function body changed; parity matrix unaffected.
- `pnpm test` (vitest parity suite) covers the touched module.