### PR TITLE
feat(tools): add Reference stream/curve fetch tool

### DIFF
--- a/.changeset/reference-stream-fetch-tool.md
+++ b/.changeset/reference-stream-fetch-tool.md
@@ -1,0 +1,7 @@
+---
+"@enduragent/core": patch
+---
+
+Add `tools/fetch-streams.ts` — a dev-time fetcher for the per-activity raw streams and per-athlete power/HR/sustainability curve sets used to author the Reference layer's curve- and stream-driven fixtures. Reads the secondary intervals.icu account, caches each raw response under `referenceDataDir("cycling-coach")/streams/`, is idempotent (skip-if-cached), and throttles requests serially. The snapshot harness never reads this cache — it is operator scratch only.
+
+Pure dev-time infra — athletes don't notice.

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@enduragent/core": "workspace:*",
     "@enduragent/sport-cycling": "workspace:*",
     "@types/node": "^25.6.0",
+    "intervals-icu-api": "0.1.2",
     "msw": "^2.13.3",
     "oxfmt": "^0.45.0",
     "oxlint": "^1.60.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@types/node':
         specifier: ^25.6.0
         version: 25.6.0
+      intervals-icu-api:
+        specifier: 0.1.2
+        version: 0.1.2(typescript@6.0.3)
       msw:
         specifier: ^2.13.3
         version: 2.14.2(@types/node@25.6.0)(typescript@6.0.3)

--- a/tools/fetch-streams.test.ts
+++ b/tools/fetch-streams.test.ts
@@ -1,0 +1,134 @@
+// Tests for the cache-path / skip-if-cached / CLI-window logic of
+// `tools/fetch-streams.ts`. The network is mocked; only the pure helpers and
+// the idempotent caching loop are exercised.
+
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  basicAuthHeader,
+  cacheActivityStreams,
+  parseArgs,
+  resolveWindow,
+  STREAM_TYPES,
+  streamCachePath,
+} from "./fetch-streams.js";
+
+describe("parseArgs", () => {
+  it("defaults to a 42-day window with no limit", () => {
+    expect(parseArgs([])).toEqual({ days: 42 });
+  });
+
+  it("parses the window + limit flags", () => {
+    expect(parseArgs(["--days", "14", "--limit", "3"])).toEqual({
+      days: 14,
+      limit: 3,
+    });
+    expect(parseArgs(["--oldest", "2026-01-01", "--newest", "2026-02-01"])).toEqual({
+      days: 42,
+      oldest: "2026-01-01",
+      newest: "2026-02-01",
+    });
+  });
+
+  it("rejects unknown flags and missing values", () => {
+    expect(() => parseArgs(["--nope"])).toThrow(/unknown flag/);
+    expect(() => parseArgs(["--days"])).toThrow(/requires a value/);
+    expect(() => parseArgs(["--days", "--limit"])).toThrow(/requires a value/);
+  });
+});
+
+describe("resolveWindow", () => {
+  it("honors explicit oldest/newest verbatim", () => {
+    expect(resolveWindow({ days: 42, oldest: "2026-03-01", newest: "2026-03-31" })).toEqual({
+      oldest: "2026-03-01",
+      newest: "2026-03-31",
+    });
+  });
+
+  it("derives a trailing window from --days when bounds are absent", () => {
+    const { oldest, newest } = resolveWindow({ days: 7 });
+    expect(oldest).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(newest).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    const span =
+      (Date.parse(`${newest}T00:00:00Z`) - Date.parse(`${oldest}T00:00:00Z`)) /
+      (24 * 60 * 60 * 1000);
+    expect(span).toBe(7);
+  });
+});
+
+describe("basicAuthHeader", () => {
+  it("matches the intervals.icu API_KEY-as-username Basic scheme", () => {
+    // base64("API_KEY:secret") — the key value is never logged, only encoded.
+    expect(basicAuthHeader("secret")).toBe(
+      `Basic ${Buffer.from("API_KEY:secret").toString("base64")}`,
+    );
+    expect(basicAuthHeader("secret")).toMatch(/^Basic /);
+  });
+});
+
+describe("cacheActivityStreams", () => {
+  let cacheRoot: string;
+
+  beforeEach(() => {
+    cacheRoot = mkdtempSync(join(tmpdir(), "fetch-streams-"));
+  });
+
+  afterEach(() => {
+    rmSync(cacheRoot, { recursive: true, force: true });
+  });
+
+  it("writes one cache file per activity and requests the documented channels", async () => {
+    const requested: string[][] = [];
+    const counts = await cacheActivityStreams(
+      cacheRoot,
+      ["111", "222"],
+      async (_id, types) => {
+        requested.push([...types]);
+        return { ok: true, value: [{ type: "watts", data: [1, 2, 3] }] };
+      },
+      { throttleMs: 0 },
+    );
+
+    expect(counts).toEqual({ fetched: 2, skipped: 0 });
+    expect(existsSync(streamCachePath(cacheRoot, "111"))).toBe(true);
+    expect(existsSync(streamCachePath(cacheRoot, "222"))).toBe(true);
+    expect(requested[0]).toEqual([...STREAM_TYPES]);
+    const written = JSON.parse(readFileSync(streamCachePath(cacheRoot, "111"), "utf-8"));
+    expect(written).toEqual([{ type: "watts", data: [1, 2, 3] }]);
+  });
+
+  it("skips activities whose cache file already exists (idempotent)", async () => {
+    writeFileSync(streamCachePath(cacheRoot, "111"), "[]");
+    let calls = 0;
+    const counts = await cacheActivityStreams(
+      cacheRoot,
+      ["111", "222"],
+      async () => {
+        calls++;
+        return { ok: true, value: [] };
+      },
+      { throttleMs: 0 },
+    );
+
+    expect(counts).toEqual({ fetched: 1, skipped: 1 });
+    expect(calls).toBe(1);
+  });
+
+  it("does not write a cache file when the fetch fails", async () => {
+    const logs: string[] = [];
+    const counts = await cacheActivityStreams(
+      cacheRoot,
+      ["333"],
+      async () => ({ ok: false, error: "boom" }),
+      { throttleMs: 0, log: (m) => logs.push(m) },
+    );
+
+    expect(counts).toEqual({ fetched: 0, skipped: 0 });
+    expect(existsSync(streamCachePath(cacheRoot, "333"))).toBe(false);
+    expect(logs.join("\n")).toMatch(/failed/);
+  });
+});

--- a/tools/fetch-streams.ts
+++ b/tools/fetch-streams.ts
@@ -1,0 +1,303 @@
+// Dev-time fetcher for the per-activity raw streams and per-athlete
+// power/HR/sustainability curve sets needed to assemble the Reference layer's
+// curve- and stream-driven fixtures. Reads the secondary intervals.icu account
+// (INTERVALS_ATHLETE_ID_2 / INTERVALS_API_KEY_2) and caches each raw response
+// under `referenceDataDir("cycling-coach")/streams/`. The snapshot harness
+// never reads this cache — it is operator scratch for fixture authoring only.
+//
+// Usage (run from repo root for module resolution; credentials live in .env):
+//   pnpm exec tsx --env-file=.env tools/fetch-streams.ts [--days N] [--oldest YYYY-MM-DD] [--newest YYYY-MM-DD] [--limit N]
+//
+// The activities listing endpoint 422s without oldest/newest, so a window is
+// always sent: --oldest/--newest override the default trailing --days window.
+// --limit caps the number of activities processed (smoke runs).
+
+import { mkdir } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+import { IntervalsClient, snakeCaseKeys } from "intervals-icu-api";
+
+import { atomicWriteJson } from "../packages/core/src/io/atomic-write-json.js";
+import { referenceDataDir } from "../packages/core/src/reference/paths.js";
+
+const BINARY_NAME = "cycling-coach";
+const INTERVALS_BASE_URL = "https://intervals.icu/api/v1";
+
+const DEFAULT_WINDOW_DAYS = 42;
+const THROTTLE_MS = 250;
+
+// Per-activity stream channels. dfa_a1 + artifacts are requested explicitly so
+// the cache records their absence for accounts that don't surface them (the
+// AlphaHRV recording fields); the endpoint simply omits absent channels.
+export const STREAM_TYPES: readonly string[] = [
+  "time",
+  "watts",
+  "heartrate",
+  "dfa_a1",
+  "artifacts",
+];
+
+const CYCLING_SPORT_TYPES: readonly string[] = ["Ride", "VirtualRide"];
+
+export interface Window {
+  oldest: string;
+  newest: string;
+}
+
+export interface CliArgs {
+  days: number;
+  oldest?: string;
+  newest?: string;
+  limit?: number;
+}
+
+type StreamFetcher = (
+  activityId: string,
+  types: readonly string[],
+) => Promise<{ ok: true; value: unknown } | { ok: false; error: unknown }>;
+
+function ymd(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export function streamCachePath(cacheRoot: string, activityId: string): string {
+  return join(cacheRoot, `${activityId}.json`);
+}
+
+export function parseArgs(argv: readonly string[]): CliArgs {
+  const args: CliArgs = { days: DEFAULT_WINDOW_DAYS };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    const next = (): string => {
+      const v = argv[i + 1];
+      if (v === undefined || v.startsWith("--")) {
+        throw new Error(`flag ${arg} requires a value`);
+      }
+      i++;
+      return v;
+    };
+    switch (arg) {
+      case "--days":
+        args.days = Number(next());
+        break;
+      case "--oldest":
+        args.oldest = next();
+        break;
+      case "--newest":
+        args.newest = next();
+        break;
+      case "--limit":
+        args.limit = Number(next());
+        break;
+      default:
+        throw new Error(`unknown flag: ${arg}`);
+    }
+  }
+  return args;
+}
+
+export function resolveWindow(args: CliArgs): Window {
+  const newest = args.newest ?? ymd(new Date());
+  const oldest = args.oldest ?? ymd(new Date(Date.now() - args.days * 24 * 60 * 60 * 1000));
+  return { oldest, newest };
+}
+
+export function basicAuthHeader(apiKey: string): string {
+  // Same convention the intervals.icu client uses: HTTP Basic with the literal
+  // username "API_KEY" and the key as the password.
+  const encoded = Buffer.from(`API_KEY:${apiKey}`).toString("base64");
+  return `Basic ${encoded}`;
+}
+
+async function rawGet(
+  athleteId: string,
+  apiKey: string,
+  endpoint: string,
+  query: Record<string, string>,
+): Promise<unknown> {
+  const url = new URL(`${INTERVALS_BASE_URL}/athlete/${athleteId}/${endpoint}`);
+  for (const [key, value] of Object.entries(query)) {
+    url.searchParams.set(key, value);
+  }
+  const response = await fetch(url, {
+    headers: {
+      Authorization: basicAuthHeader(apiKey),
+      Accept: "application/json",
+    },
+  });
+  if (!response.ok) {
+    throw new Error(`${endpoint} → HTTP ${response.status}`);
+  }
+  return response.json();
+}
+
+async function writeCache(path: string, value: unknown): Promise<void> {
+  await mkdir(join(path, ".."), { recursive: true });
+  await atomicWriteJson(path, value);
+}
+
+/**
+ * Cache each activity's streams under `cacheRoot`, skipping any activity whose
+ * file already exists (idempotent re-runs). `getStreams` is injected so the
+ * loop is exercised without a live network in tests. Returns the fetched /
+ * skipped counts.
+ */
+export async function cacheActivityStreams(
+  cacheRoot: string,
+  activityIds: readonly string[],
+  getStreams: StreamFetcher,
+  options?: { throttleMs?: number; log?: (msg: string) => void },
+): Promise<{ fetched: number; skipped: number }> {
+  const throttleMs = options?.throttleMs ?? THROTTLE_MS;
+  const log = options?.log ?? ((msg: string) => console.error(msg));
+  let fetched = 0;
+  let skipped = 0;
+  for (const id of activityIds) {
+    const cachePath = streamCachePath(cacheRoot, id);
+    if (existsSync(cachePath)) {
+      skipped++;
+      continue;
+    }
+    const result = await getStreams(id, STREAM_TYPES);
+    if (!result.ok) {
+      log(`  streams for activity failed: ${result.error}`);
+      continue;
+    }
+    await writeCache(cachePath, result.value);
+    fetched++;
+    if (throttleMs > 0) await sleep(throttleMs);
+  }
+  return { fetched, skipped };
+}
+
+async function main(): Promise<void> {
+  const athleteId = process.env.INTERVALS_ATHLETE_ID_2;
+  const apiKey = process.env.INTERVALS_API_KEY_2;
+  if (!athleteId || !apiKey) {
+    console.error(
+      "Missing credentials. Set INTERVALS_ATHLETE_ID_2 and INTERVALS_API_KEY_2 " +
+        "(e.g. run with `pnpm exec tsx --env-file=.env tools/fetch-streams.ts`). " +
+        "These are the secondary-account vars, distinct from INTERVALS_API_KEY.",
+    );
+    process.exit(1);
+  }
+
+  let args: CliArgs;
+  try {
+    args = parseArgs(process.argv.slice(2));
+  } catch (err) {
+    console.error((err as Error).message);
+    console.error(
+      "usage: tsx tools/fetch-streams.ts [--days N] [--oldest YYYY-MM-DD] [--newest YYYY-MM-DD] [--limit N]",
+    );
+    process.exit(2);
+    return;
+  }
+
+  const { oldest, newest } = resolveWindow(args);
+  const cacheRoot = join(referenceDataDir(BINARY_NAME), "streams");
+  const curvesRoot = join(cacheRoot, "curves");
+
+  const client = new IntervalsClient({
+    apiKey,
+    athleteId,
+    retry: { maxAttempts: 1 },
+  });
+
+  console.error(`Listing activities ${oldest} → ${newest}…`);
+  const listResult = await client.activities.list({ oldest, newest });
+  if (!listResult.ok) {
+    console.error("activities.list failed:", listResult.error);
+    process.exit(2);
+    return;
+  }
+  let activities = snakeCaseKeys(listResult.value) as Array<Record<string, unknown>>;
+  if (args.limit !== undefined) {
+    activities = activities.slice(0, args.limit);
+  }
+  console.error(`  → ${activities.length} activities in scope`);
+
+  const activityIds = activities.map((a) => String(a.id));
+  const streamCounts = await cacheActivityStreams(cacheRoot, activityIds, (id, types) =>
+    client.activities.getStreams(id, [...types]),
+  );
+  console.error(
+    `Streams: ${streamCounts.fetched} fetched, ${streamCounts.skipped} cached (skipped)`,
+  );
+
+  await fetchCurves(athleteId, apiKey, curvesRoot, { oldest, newest });
+}
+
+async function fetchCurves(
+  athleteId: string,
+  apiKey: string,
+  curvesRoot: string,
+  window: Window,
+): Promise<void> {
+  const curvesParam = `r.${window.oldest}.${window.newest}`;
+
+  const jobs: Array<{ name: string; endpoint: string; query: Record<string, string> }> = [
+    {
+      name: "power-curves-ride",
+      endpoint: "power-curves",
+      query: { type: "Ride", curves: curvesParam },
+    },
+    {
+      name: "hr-curves",
+      endpoint: "hr-curves",
+      query: { curves: curvesParam },
+    },
+  ];
+
+  // Per-sport-type sustainability curve sets — one power + one hr fetch per
+  // cycling sport type, mirroring the upstream's sport-filtered fetch loop.
+  for (const type of CYCLING_SPORT_TYPES) {
+    jobs.push({
+      name: `sustainability-power-${type}`,
+      endpoint: "power-curves",
+      query: { type, curves: curvesParam },
+    });
+    jobs.push({
+      name: `sustainability-hr-${type}`,
+      endpoint: "hr-curves",
+      query: { type, curves: curvesParam },
+    });
+  }
+
+  let fetched = 0;
+  let skipped = 0;
+  for (const job of jobs) {
+    const cachePath = join(curvesRoot, `${job.name}.json`);
+    if (existsSync(cachePath)) {
+      skipped++;
+      continue;
+    }
+    try {
+      const data = await rawGet(athleteId, apiKey, job.endpoint, job.query);
+      await writeCache(cachePath, data);
+      fetched++;
+    } catch (err) {
+      console.error(`  curve fetch ${job.name} failed: ${(err as Error).message}`);
+    }
+    await sleep(THROTTLE_MS);
+  }
+  console.error(`Curves: ${fetched} fetched, ${skipped} cached (skipped)`);
+  console.error(`Cache root: ${curvesRoot.replace(/\/curves$/, "")}`);
+}
+
+const isCli =
+  typeof process !== "undefined" &&
+  process.argv[1] !== undefined &&
+  import.meta.url === `file://${process.argv[1]}`;
+
+if (isCli) {
+  main().catch((err) => {
+    console.error("fatal:", err);
+    process.exit(2);
+  });
+}


### PR DESCRIPTION
## Summary

Adds `tools/fetch-streams.ts`, the dev-time fetcher that backfills the per-activity raw streams and per-athlete power/HR/sustainability curve sets used to author the Reference layer's upcoming curve- and stream-driven fixtures.

- **Streams** via the `intervals-icu-api` client (`activities.getStreams`, `retry:{maxAttempts:1}`): `time, watts, heartrate, dfa_a1, artifacts` — channels the account doesn't serve are handled without error.
- **Curves** via raw fetch (the library has no curve endpoints): power-curves (Ride), hr-curves, and per-sport-type sustainability sets over the standard windows.
- **Cache**: raw response JSON via `atomicWriteJson` under `referenceDataDir("cycling-coach")/streams/` (+`/curves/`); idempotent skip-if-cached; serial fetch with a fixed 250 ms throttle.
- **Credentials**: secondary-account env pair; clean failure with a clear message when absent; values never logged.
- The snapshot harness **never reads this cache** — it reads only committed fixtures. This tool is operator scratch for fixture authoring.

## Verification

- `tsc --noEmit` clean; `oxlint`/`oxfmt` clean on the new files.
- `pnpm test`: 1417 passed / 5 skipped (9 new unit tests: arg parsing, window resolution, auth-header shape, skip-if-cached loop with mocked fetch + tmpdir).
- Live smoke run (`--limit 3`): 3 stream files + 6 curve files written on first run; `0 fetched, 9 skipped` on second run (idempotency). One sampled activity served only time+heartrate, confirming graceful channel absence.
- `pnpm check:trademarks`: clean.

## Notes

One deviation from the original sketch: cache files are pretty-printed, not compact — the mandated `atomicWriteJson` helper hardcodes 2-space indentation, and a canonical write path beats a stringify preference for dev-time scratch.
