### PR TITLE
feat(core): port power-model scalar passthroughs

### DIFF
--- a/.changeset/reference-power-model-scalars.md
+++ b/.changeset/reference-power-model-scalars.md
@@ -1,0 +1,7 @@
+---
+"@enduragent/core": patch
+---
+
+Port the Reference layer's six power-model scalar passthroughs — `eftp`, `w_prime`, `w_prime_kj`, `p_max`, `power_model_source`, and `vo2max`. These are a single passthrough family: the upstream extracts the live cycling estimates from today's wellness row (the latest row in the 28-day window) via `_extract_power_model_from_wellness`, finding the first `type == "Ride"` sportInfo dict and reading camelCase `eftp`/`wPrime`/`pMax` with Python-`round` semantics (1-decimal eFTP and W'-kJ, integer W' and P-max, all guarded by Python truthiness), plus `vo2max` straight off the row. No computation. New `packages/core/src/reference/metrics/power-model.ts` mirrors the extraction line-by-line and the harness's `athlete`-key gate (absent athlete → the empty-power-model state, every key null); the six compute functions register in the metrics registry. Bit-identical against the committed oracle across all 13 fixtures (curve-equipped populated, the other twelve null). Unit tests cover the populated paths the oracles can't reach — the Ride-selection loop, the truthiness gates, the round boundaries, and the latest-in-window row selection.
+
+Internal Reference-layer + oracle work — athletes don't notice.

--- a/packages/core/src/reference/metrics/metric-input.ts
+++ b/packages/core/src/reference/metrics/metric-input.ts
@@ -1,5 +1,6 @@
 import type {
   Activity,
+  AthleteSettings,
   FixtureShape,
   PlannedEvent,
   WellnessDay,
@@ -97,4 +98,20 @@ export function getWellnessExtendedWeight(input: MetricInput): WellnessDay[] {
 // resolution when tested outdoor FTP is null. See FixtureSchema.eftp.
 export function getEftp(input: MetricInput): number | null {
   return input.fixture.eftp ?? null;
+}
+
+// The athlete-settings carrier. In the snapshot harness this key's
+// presence gates the live power-model pipeline: only when the fixture
+// carries `athlete` does the harness run `_extract_power_model_from_wellness`
+// against the latest wellness row and read its `vo2max`; absent athlete →
+// empty power model + null vo2max (the prior stub). Mirror that gate by
+// keying the power-model passthroughs on this accessor returning non-null.
+export function getAthlete(input: MetricInput): AthleteSettings | null {
+  return input.fixture.athlete ?? null;
+}
+
+// Full wellness array, in fixture order. Power-model passthroughs select
+// the latest row within the 28-day window from this surface.
+export function getWellness(input: MetricInput): WellnessDay[] {
+  return input.fixture.wellness;
 }

--- a/packages/core/src/reference/metrics/power-model.test.ts
+++ b/packages/core/src/reference/metrics/power-model.test.ts
@@ -1,0 +1,310 @@
+import { describe, expect, it } from "vitest";
+
+import type { FixtureShape, WellnessDay } from "../schemas/inputs.js";
+import type { MetricInput } from "./metric-input.js";
+import {
+  computeEftp,
+  computePMax,
+  computePowerModelSource,
+  computeVo2max,
+  computeWPrime,
+  computeWPrimeKj,
+} from "./power-model.js";
+
+const FROZEN_NOW = "2026-06-04T12:00:00";
+
+interface SportInfoRow {
+  type: string;
+  eftp?: number | null;
+  wPrime?: number | null;
+  pMax?: number | null;
+}
+
+interface WellnessRowInput {
+  date: string;
+  sportInfo?: SportInfoRow[];
+  vo2max?: number | null;
+}
+
+function wellness(rows: WellnessRowInput[]): WellnessDay[] {
+  return rows.map((r) => ({
+    id: r.date,
+    weight: null,
+    restingHR: null,
+    hrv: null,
+    sleepSecs: null,
+    sleepQuality: null,
+    ...(r.sportInfo !== undefined ? { sportInfo: r.sportInfo } : {}),
+    ...(r.vo2max !== undefined ? { vo2max: r.vo2max } : {}),
+  })) as WellnessDay[];
+}
+
+function fixture(partial: Partial<FixtureShape>): FixtureShape {
+  return {
+    activities: [],
+    wellness: [],
+    ftp_history: [],
+    ...partial,
+  } as unknown as FixtureShape;
+}
+
+function input(f: FixtureShape, frozenNow = FROZEN_NOW): MetricInput {
+  return { fixture: f, frozenNow };
+}
+
+// The athlete-key carrier the harness gates the live power-model pipeline on.
+const ATHLETE = { sportSettings: [] } as unknown as FixtureShape["athlete"];
+
+describe("power-model passthroughs — athlete gate", () => {
+  it("returns null for every key when the fixture carries no athlete", () => {
+    const f = fixture({
+      athlete: undefined,
+      wellness: wellness([
+        {
+          date: "2026-06-04",
+          sportInfo: [{ type: "Ride", eftp: 200, wPrime: 13882, pMax: 727 }],
+          vo2max: 58,
+        },
+      ]),
+    });
+    expect(computeEftp(input(f))).toBeNull();
+    expect(computeWPrime(input(f))).toBeNull();
+    expect(computeWPrimeKj(input(f))).toBeNull();
+    expect(computePMax(input(f))).toBeNull();
+    expect(computePowerModelSource(input(f))).toBeNull();
+    expect(computeVo2max(input(f))).toBeNull();
+  });
+
+  it("activates the pipeline when athlete is present", () => {
+    const f = fixture({
+      athlete: ATHLETE,
+      wellness: wellness([
+        {
+          date: "2026-06-04",
+          sportInfo: [{ type: "Ride", eftp: 200, wPrime: 13882, pMax: 727 }],
+          vo2max: 58,
+        },
+      ]),
+    });
+    expect(computeEftp(input(f))).toBe(200);
+    expect(computeWPrime(input(f))).toBe(13882);
+    expect(computeWPrimeKj(input(f))).toBe(13.9);
+    expect(computePMax(input(f))).toBe(727);
+    expect(computePowerModelSource(input(f))).toBe("wellness.sportInfo");
+    expect(computeVo2max(input(f))).toBe(58);
+  });
+});
+
+describe("power-model passthroughs — sportInfo Ride selection", () => {
+  it("finds the first Ride dict, skipping non-Ride sports", () => {
+    const f = fixture({
+      athlete: ATHLETE,
+      wellness: wellness([
+        {
+          date: "2026-06-04",
+          sportInfo: [
+            { type: "Run", eftp: 999 },
+            { type: "Ride", eftp: 250, wPrime: 20000, pMax: 900 },
+            { type: "Ride", eftp: 111 },
+          ],
+        },
+      ]),
+    });
+    expect(computeEftp(input(f))).toBe(250);
+    expect(computePMax(input(f))).toBe(900);
+    expect(computePowerModelSource(input(f))).toBe("wellness.sportInfo");
+  });
+
+  it("reports source 'unavailable' when no Ride dict is present", () => {
+    const f = fixture({
+      athlete: ATHLETE,
+      wellness: wellness([
+        { date: "2026-06-04", sportInfo: [{ type: "Run", eftp: 250 }] },
+      ]),
+    });
+    expect(computePowerModelSource(input(f))).toBe("unavailable");
+    expect(computeEftp(input(f))).toBeNull();
+    expect(computeWPrime(input(f))).toBeNull();
+  });
+
+  it("reports source 'unavailable' when sportInfo is empty", () => {
+    const f = fixture({
+      athlete: ATHLETE,
+      wellness: wellness([{ date: "2026-06-04", sportInfo: [] }]),
+    });
+    expect(computePowerModelSource(input(f))).toBe("unavailable");
+  });
+
+  it("reports source 'unavailable' when the row has no sportInfo key", () => {
+    const f = fixture({
+      athlete: ATHLETE,
+      wellness: wellness([{ date: "2026-06-04" }]),
+    });
+    expect(computePowerModelSource(input(f))).toBe("unavailable");
+    expect(computeEftp(input(f))).toBeNull();
+  });
+});
+
+describe("power-model passthroughs — truthiness gates", () => {
+  it("maps a 0 scalar to null (Python falsy), keeping source populated", () => {
+    const f = fixture({
+      athlete: ATHLETE,
+      wellness: wellness([
+        {
+          date: "2026-06-04",
+          sportInfo: [{ type: "Ride", eftp: 0, wPrime: 0, pMax: 0 }],
+        },
+      ]),
+    });
+    expect(computeEftp(input(f))).toBeNull();
+    expect(computeWPrime(input(f))).toBeNull();
+    expect(computeWPrimeKj(input(f))).toBeNull();
+    expect(computePMax(input(f))).toBeNull();
+    expect(computePowerModelSource(input(f))).toBe("wellness.sportInfo");
+  });
+
+  it("maps an absent/null scalar to null independently per field", () => {
+    const f = fixture({
+      athlete: ATHLETE,
+      wellness: wellness([
+        {
+          date: "2026-06-04",
+          sportInfo: [{ type: "Ride", eftp: 240, wPrime: null }],
+        },
+      ]),
+    });
+    expect(computeEftp(input(f))).toBe(240);
+    expect(computeWPrime(input(f))).toBeNull();
+    expect(computeWPrimeKj(input(f))).toBeNull();
+    expect(computePMax(input(f))).toBeNull();
+  });
+});
+
+describe("power-model passthroughs — Python round semantics", () => {
+  it("rounds eftp to one decimal with banker's rounding", () => {
+    // round(240.25, 1) → 240.2 (tie to even); round(240.35, 1) → 240.3 on the
+    // true double (240.35 stored just below). Matches Python's round().
+    const mk = (e: number) =>
+      fixture({
+        athlete: ATHLETE,
+        wellness: wellness([
+          { date: "2026-06-04", sportInfo: [{ type: "Ride", eftp: e }] },
+        ]),
+      });
+    expect(computeEftp(input(mk(240.25)))).toBe(240.2);
+    expect(computeEftp(input(mk(173.67642)))).toBe(173.7);
+  });
+
+  it("rounds w_prime to the nearest integer (single-arg round)", () => {
+    const mk = (w: number) =>
+      fixture({
+        athlete: ATHLETE,
+        wellness: wellness([
+          { date: "2026-06-04", sportInfo: [{ type: "Ride", wPrime: w }] },
+        ]),
+      });
+    // round(13882.4) → 13882; round(13882.5) → 13882 (tie to even).
+    expect(computeWPrime(input(mk(13882.4)))).toBe(13882);
+    expect(computeWPrime(input(mk(13882.5)))).toBe(13882);
+    expect(computeWPrime(input(mk(13883.5)))).toBe(13884);
+  });
+
+  it("derives w_prime_kj as round(w_prime / 1000, 1)", () => {
+    const mk = (w: number) =>
+      fixture({
+        athlete: ATHLETE,
+        wellness: wellness([
+          { date: "2026-06-04", sportInfo: [{ type: "Ride", wPrime: w }] },
+        ]),
+      });
+    expect(computeWPrimeKj(input(mk(13882)))).toBe(13.9);
+    expect(computeWPrimeKj(input(mk(20000)))).toBe(20);
+    // 12450/1000 = 12.45 stored just below 12.45, so round(_, 1) → 12.4.
+    expect(computeWPrimeKj(input(mk(12450)))).toBe(12.4);
+  });
+
+  it("rounds p_max to the nearest integer", () => {
+    const f = fixture({
+      athlete: ATHLETE,
+      wellness: wellness([
+        { date: "2026-06-04", sportInfo: [{ type: "Ride", pMax: 726.6 }] },
+      ]),
+    });
+    expect(computePMax(input(f))).toBe(727);
+  });
+});
+
+describe("power-model passthroughs — today_wellness selection", () => {
+  it("uses the latest in-window wellness row, not fixture order", () => {
+    const f = fixture({
+      athlete: ATHLETE,
+      wellness: wellness([
+        { date: "2026-06-04", sportInfo: [{ type: "Ride", eftp: 200 }], vo2max: 58 },
+        { date: "2026-05-20", sportInfo: [{ type: "Ride", eftp: 182 }], vo2max: 46 },
+      ]),
+    });
+    expect(computeEftp(input(f))).toBe(200);
+    expect(computeVo2max(input(f))).toBe(58);
+  });
+
+  it("picks the max id even when rows are out of order", () => {
+    const f = fixture({
+      athlete: ATHLETE,
+      wellness: wellness([
+        { date: "2026-05-20", sportInfo: [{ type: "Ride", eftp: 182 }] },
+        { date: "2026-06-04", sportInfo: [{ type: "Ride", eftp: 200 }] },
+        { date: "2026-05-30", sportInfo: [{ type: "Ride", eftp: 185 }] },
+      ]),
+    });
+    expect(computeEftp(input(f))).toBe(200);
+  });
+
+  it("excludes rows outside the 28-day window", () => {
+    // frozenNow 2026-06-04 → window oldest is 2026-05-08. A 2026-05-01 row
+    // (with a higher eftp) must be excluded; the in-window 2026-05-10 row wins.
+    const f = fixture({
+      athlete: ATHLETE,
+      wellness: wellness([
+        { date: "2026-05-01", sportInfo: [{ type: "Ride", eftp: 999 }] },
+        { date: "2026-05-10", sportInfo: [{ type: "Ride", eftp: 190 }] },
+      ]),
+    });
+    expect(computeEftp(input(f))).toBe(190);
+  });
+
+  it("reports 'unavailable' source when no row falls in the window", () => {
+    const f = fixture({
+      athlete: ATHLETE,
+      wellness: wellness([
+        { date: "2026-05-01", sportInfo: [{ type: "Ride", eftp: 200 }], vo2max: 58 },
+      ]),
+    });
+    expect(computePowerModelSource(input(f))).toBe("unavailable");
+    expect(computeEftp(input(f))).toBeNull();
+    expect(computeVo2max(input(f))).toBeNull();
+  });
+});
+
+describe("power-model passthroughs — vo2max", () => {
+  it("passes through vo2max from the latest row", () => {
+    const f = fixture({
+      athlete: ATHLETE,
+      wellness: wellness([
+        { date: "2026-06-04", sportInfo: [{ type: "Ride", eftp: 200 }], vo2max: 58 },
+      ]),
+    });
+    expect(computeVo2max(input(f))).toBe(58);
+  });
+
+  it("is null when the latest row has no vo2max — independent of sportInfo", () => {
+    const f = fixture({
+      athlete: ATHLETE,
+      wellness: wellness([
+        { date: "2026-06-04", sportInfo: [{ type: "Ride", eftp: 200 }] },
+      ]),
+    });
+    expect(computeVo2max(input(f))).toBeNull();
+    // sportInfo still resolves — vo2max gating is independent.
+    expect(computeEftp(input(f))).toBe(200);
+  });
+});

--- a/packages/core/src/reference/metrics/power-model.ts
+++ b/packages/core/src/reference/metrics/power-model.ts
@@ -1,0 +1,178 @@
+/**
+ * Reference layer — power-model scalar passthroughs.
+ *
+ * The upstream carries six live power-model estimates straight from
+ * today's wellness row: eFTP, W', W'-in-kJ, P-max, the source label, and
+ * VO2max. They are not computed from the activity stream — they are the
+ * accurate live estimates the API already publishes (matching the
+ * intervals.icu UI). The upstream extracts them via
+ * `_extract_power_model_from_wellness(today_wellness)` and reads
+ * `vo2max = today_wellness.get("vo2max")` (sync.py extraction +
+ * the `_calculate_derived_metrics` output keys).
+ *
+ * `today_wellness` is the LATEST wellness row inside the 28-day window
+ * (the same row the harness designates as `today_wellness`). The harness
+ * gates the whole live-power-model pipeline on the fixture's `athlete`
+ * key: absent athlete → empty power model + null vo2max. This module
+ * mirrors that gate, then mirrors the extraction's truthiness +
+ * rounding line-by-line.
+ *
+ * Each scalar ports as its own compute function (one-metric-one-file
+ * oracle), all delegating to the shared extraction so the truthiness and
+ * rounding live in one place.
+ *
+ * See `NOTICE.md` for upstream attribution.
+ */
+
+import {
+  getAthlete,
+  getWellness,
+  type MetricInput,
+} from "./metric-input.js";
+import { isoDateDaysBefore } from "./date-helpers.js";
+import { roundHalfEven } from "./rounding.js";
+import type { WellnessDay } from "../schemas/inputs.js";
+
+/** The dict shape `_extract_power_model_from_wellness` returns. Source is
+ *  `"wellness.sportInfo"` when a Ride sportInfo row is found, `"unavailable"`
+ *  otherwise; the harness designates an absent-athlete fixture's power model
+ *  as `{}`, so the consumed `.get(...)` keys resolve to null for those. */
+export interface PowerModel {
+  eftp: number | null;
+  w_prime: number | null;
+  w_prime_kj: number | null;
+  p_max: number | null;
+  source: string;
+}
+
+// One per-sport entry in a wellness row's `sportInfo` array. The rows ride
+// through the loose WellnessDay schema, so the field is read off the row's
+// index signature and narrowed here.
+interface SportInfoEntry {
+  type?: unknown;
+  eftp?: unknown;
+  wPrime?: unknown;
+  pMax?: unknown;
+}
+
+// Python truthiness over the value `round(...)` guards on: 0 and None (here
+// null/undefined/NaN) are falsy, every other finite number is truthy.
+function isTruthyNumber(v: unknown): v is number {
+  return typeof v === "number" && v !== 0 && !Number.isNaN(v);
+}
+
+// `_extract_power_model_from_wellness(wellness_data)` (sync.py). Finds the
+// first `type == "Ride"` sportInfo dict, reads camelCase eftp/wPrime/pMax,
+// and rounds each under Python's `round`: `round(eftp, 1)` (1 decimal),
+// `round(w_prime)` / `round(p_max)` (single-arg → nearest integer),
+// `round(w_prime / 1000, 1)` (1 decimal). The `if <value>` guards mirror
+// Python truthiness, so a 0 or absent value yields null.
+function extractPowerModelFromWellness(row: WellnessDay): PowerModel {
+  const sportInfo = ((row as { sportInfo?: unknown }).sportInfo ?? []) as
+    | SportInfoEntry[];
+
+  let cyclingInfo: SportInfoEntry | null = null;
+  for (const sport of Array.isArray(sportInfo) ? sportInfo : []) {
+    if (sport && typeof sport === "object" && sport.type === "Ride") {
+      cyclingInfo = sport;
+      break;
+    }
+  }
+
+  if (!cyclingInfo) {
+    return {
+      eftp: null,
+      w_prime: null,
+      w_prime_kj: null,
+      p_max: null,
+      source: "unavailable",
+    };
+  }
+
+  const eftp = cyclingInfo.eftp;
+  const wPrime = cyclingInfo.wPrime;
+  const pMax = cyclingInfo.pMax;
+
+  return {
+    eftp: isTruthyNumber(eftp) ? roundHalfEven(eftp, 1) : null,
+    w_prime: isTruthyNumber(wPrime) ? roundHalfEven(wPrime, 0) : null,
+    w_prime_kj: isTruthyNumber(wPrime) ? roundHalfEven(wPrime / 1000, 1) : null,
+    p_max: isTruthyNumber(pMax) ? roundHalfEven(pMax, 0) : null,
+    source: "wellness.sportInfo",
+  };
+}
+
+// The harness's `today_wellness`: the latest wellness row whose `id[:10]`
+// falls in the 28-day window [frozenNow-27, frozenNow], chosen by sorting
+// the in-window rows by `id` string descending and taking the first. Returns
+// null when no row qualifies — the harness's `_pick_latest_wellness(...) or {}`
+// empty case, which `_extract_power_model_from_wellness` then sees as a row
+// with no sportInfo (source "unavailable") and `vo2max` as null.
+function selectTodayWellness(input: MetricInput): WellnessDay | null {
+  const today = input.frozenNow.slice(0, 10);
+  const oldest = isoDateDaysBefore(input.frozenNow, 27);
+
+  const inWindow = getWellness(input).filter((row) => {
+    if (typeof row.id !== "string") return false;
+    const d = row.id.slice(0, 10);
+    return oldest <= d && d <= today;
+  });
+  if (inWindow.length === 0) return null;
+
+  let latest = inWindow[0]!;
+  for (const row of inWindow) {
+    if ((row.id ?? "") > (latest.id ?? "")) latest = row;
+  }
+  return latest;
+}
+
+// The power model the upstream consumes for this fixture, or null to signal
+// the harness's empty-dict (`power_model = {}`) state. Mirrors the harness
+// gate: only when the fixture carries `athlete` does the live pipeline run.
+// Absent athlete → null (so every consumed `.get(...)` key resolves to null).
+// Present athlete but no in-window wellness → the empty-row extraction
+// (source "unavailable", scalars null), matching `_extract_power_model_from_wellness({})`.
+function resolvePowerModel(input: MetricInput): PowerModel | null {
+  if (getAthlete(input) === null) return null;
+  const today = selectTodayWellness(input);
+  if (today === null) {
+    return {
+      eftp: null,
+      w_prime: null,
+      w_prime_kj: null,
+      p_max: null,
+      source: "unavailable",
+    };
+  }
+  return extractPowerModelFromWellness(today);
+}
+
+export function computeEftp(input: MetricInput): number | null {
+  return resolvePowerModel(input)?.eftp ?? null;
+}
+
+export function computeWPrime(input: MetricInput): number | null {
+  return resolvePowerModel(input)?.w_prime ?? null;
+}
+
+export function computeWPrimeKj(input: MetricInput): number | null {
+  return resolvePowerModel(input)?.w_prime_kj ?? null;
+}
+
+export function computePMax(input: MetricInput): number | null {
+  return resolvePowerModel(input)?.p_max ?? null;
+}
+
+export function computePowerModelSource(input: MetricInput): string | null {
+  return resolvePowerModel(input)?.source ?? null;
+}
+
+// `vo2max = today_wellness.get("vo2max")`, gated on the same `athlete` key as
+// the power model (absent athlete → null in the harness). Read off the loose
+// wellness row; an absent/null field passes through as null.
+export function computeVo2max(input: MetricInput): number | null {
+  if (getAthlete(input) === null) return null;
+  const today = selectTodayWellness(input);
+  if (today === null) return null;
+  return today.vo2max ?? null;
+}

--- a/packages/core/src/reference/metrics/registry.ts
+++ b/packages/core/src/reference/metrics/registry.ts
@@ -49,6 +49,14 @@ import {
   computeStressTolerance,
 } from "./load-management.js";
 import type { MetricInput } from "./metric-input.js";
+import {
+  computeEftp,
+  computePMax,
+  computePowerModelSource,
+  computeVo2max,
+  computeWPrime,
+  computeWPrimeKj,
+} from "./power-model.js";
 import { computeSeasonalContext } from "./seasonal-context.js";
 
 export interface MetricRegistryEntry {
@@ -89,4 +97,10 @@ export const METRIC_REGISTRY: Record<string, MetricRegistryEntry> = {
   "capability.efficiency_factor": { compute: computeEfficiencyFactor },
   "capability.hrrc": { compute: computeHrrc },
   "capability.tid_comparison": { compute: computeTidComparison },
+  eftp: { compute: computeEftp },
+  w_prime: { compute: computeWPrime },
+  w_prime_kj: { compute: computeWPrimeKj },
+  p_max: { compute: computePMax },
+  power_model_source: { compute: computePowerModelSource },
+  vo2max: { compute: computeVo2max },
 };


### PR DESCRIPTION
## Summary

Ports the six power-model scalar passthroughs into the Reference layer: `eftp`, `w_prime`, `w_prime_kj`, `p_max`, `power_model_source`, `vo2max`.

- **New module** `packages/core/src/reference/metrics/power-model.ts` — the family is a single passthrough chain (latest in-window wellness row → first `type=="Ride"` sportInfo dict → camelCase `eftp`/`wPrime`/`pMax`), so it ships as one module: shared extraction helpers + six thin compute functions, registered via `registry.ts` (78 new parity-matrix assertions).
- **Fidelity details mirrored exactly**: Python truthiness on each scalar (0/None falsy), `round(eftp,1)` / single-arg integer `round(w_prime)` / `round(w_prime/1000,1)` / `round(p_max)` via the exact `roundHalfEven` helper, `source` `"wellness.sportInfo"` vs `"unavailable"`, and the harness's athlete-presence gate (absent `athlete` key → all six null — which is why the 12 non-curve fixtures emit null, not `"unavailable"`).
- **Accessors**: `getAthlete` / `getWellness` added to `metric-input.ts` per the established gate-boundary pattern.

## Verification

- Parity gate: 13 fixtures × 6 keys, all bit-identical, exit 0 — populated values on the curve-equipped fixture (`eftp 200`, `w_prime 13882`, `w_prime_kj 13.9`, `p_max 727`, `source "wellness.sportInfo"`, `vo2max 58`), null on the other 12
- `pnpm test`: 1594 passed | 5 skipped (+96 vs main); `pnpm check:trademarks`: clean; oxlint: 0 warnings/errors
- Zero snapshot changes (ports never regenerate); no deviation-registry changes (faithful transliteration, no Phase 4 events)
