### PR TITLE
refactor(tools): extract harness lockstep surface into one contract file

### DIFF
--- a/.changeset/harness-lockstep-contract.md
+++ b/.changeset/harness-lockstep-contract.md
@@ -1,0 +1,22 @@
+---
+"@enduragent/core": patch
+---
+
+Extract the snapshot harness's four-way lockstep surface into one
+language-neutral contract file (`tools/harness-contract.json`). The
+optional-path allowlist (previously duplicated across the pyodide harness,
+the fuzz-parity differential, and the README — three copies that had already
+diverged), the fixture-key → derived-kwarg conditions, and the power/HR
+delta-window day-offsets now live in a single source of truth that the two
+TypeScript files read through `tools/harness-contract.ts` and the two Python
+twins `json.load` relative to their own path. Each file keeps its own logic —
+only the literal data moves — so the twins stay independent reimplementations
+and the cross-interpreter diff remains a real check. The README's allowlist
+block is now test-asserted against the contract rather than hand-synced, and
+`packages/core/tests/harness-contract.test.ts` adds source-level drift
+tripwires that fail if any harness file re-grows an inline copy of the
+extracted literals. Pure refactor: snapshot regeneration is byte-identical,
+the native diff is 0 divergences on the realistic / curve / dfa fixtures, and
+the fuzz-parity failure set is unchanged.
+
+Pure dev-time + oracle infra — athletes don't notice.

--- a/packages/core/tests/harness-contract.test.ts
+++ b/packages/core/tests/harness-contract.test.ts
@@ -1,0 +1,181 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { REPO_ROOT } from "./helpers/snapshot-harness";
+
+/**
+ * The snapshot harness has four implementations that must agree on the same
+ * literal data — the pyodide harness, its native CPython twin, the fuzz-parity
+ * differential, and the coverage probe. That data lives in one language-neutral
+ * file (`tools/harness-contract.json`) because two of the four are Python and
+ * cannot import the TypeScript loader. This suite is the drift tripwire: it
+ * pins the contract's shape, asserts the README's documented allowlist matches
+ * it, and asserts no harness file has re-grown an inline copy of the literals.
+ */
+
+const CONTRACT_PATH = join(REPO_ROOT, "tools/harness-contract.json");
+const README_PATH = join(REPO_ROOT, "tools/snapshot-section-11.README.md");
+
+const HARNESS_FILES = [
+  "tools/snapshot-section-11.ts",
+  "tools/snapshot-section-11-native.py",
+  "tools/fuzz-parity.ts",
+  "tools/measure-reference-coverage-native.py",
+];
+
+function readContractRaw(): Record<string, unknown> {
+  return JSON.parse(readFileSync(CONTRACT_PATH, "utf8")) as Record<
+    string,
+    unknown
+  >;
+}
+
+/** Drop the `$comment` documentation keys the contract carries inline. */
+function stripComments(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(stripComments);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value)
+        .filter(([k]) => k !== "$comment")
+        .map(([k, v]) => [k, stripComments(v)]),
+    );
+  }
+  return value;
+}
+
+/**
+ * Parse the JSON array that follows a ```json fence in the README's
+ * "Contract validation" section — the human-readable mirror of the
+ * allowlist. The block is fenced exactly once in that section.
+ */
+function readmeAllowlist(readme: string): string[] {
+  const match = readme.match(/```json\n(\[[\s\S]*?\])\n```/);
+  if (!match) throw new Error("README has no fenced JSON allowlist block");
+  return JSON.parse(match[1]!) as string[];
+}
+
+describe("harness-contract.json schema shape", () => {
+  it("parses and exposes exactly the expected top-level keys", () => {
+    const raw = stripComments(readContractRaw()) as Record<string, unknown>;
+    expect(Object.keys(raw).sort()).toEqual([
+      "conditionalKwargs",
+      "fuzzOnlyOptionalPaths",
+      "optionalFixturePaths",
+      "powerCurveDeltaWindowDaysAgo",
+    ]);
+  });
+
+  it("optionalFixturePaths and fuzzOnlyOptionalPaths are non-empty string arrays with no overlap", () => {
+    const raw = stripComments(readContractRaw()) as {
+      optionalFixturePaths: unknown;
+      fuzzOnlyOptionalPaths: unknown;
+    };
+    expect(Array.isArray(raw.optionalFixturePaths)).toBe(true);
+    expect(Array.isArray(raw.fuzzOnlyOptionalPaths)).toBe(true);
+    const canonical = raw.optionalFixturePaths as string[];
+    const fuzzOnly = raw.fuzzOnlyOptionalPaths as string[];
+    expect(canonical.length).toBeGreaterThan(0);
+    expect(fuzzOnly.length).toBeGreaterThan(0);
+    for (const p of [...canonical, ...fuzzOnly]) {
+      expect(typeof p).toBe("string");
+      expect(p.startsWith("FIXTURE.")).toBe(true);
+    }
+    // No path is both canonical and fuzz-only.
+    const overlap = fuzzOnly.filter((p) => canonical.includes(p));
+    expect(overlap).toEqual([]);
+    // No duplicates within either list.
+    expect(new Set(canonical).size).toBe(canonical.length);
+    expect(new Set(fuzzOnly).size).toBe(fuzzOnly.length);
+  });
+
+  it("conditionalKwargs maps every derived kwarg to a gating fixture key", () => {
+    const raw = stripComments(readContractRaw()) as {
+      conditionalKwargs: Record<string, string>;
+    };
+    const map = raw.conditionalKwargs;
+    expect(Object.keys(map).length).toBeGreaterThan(0);
+    for (const [kwarg, sourceKey] of Object.entries(map)) {
+      expect(typeof kwarg).toBe("string");
+      expect(typeof sourceKey).toBe("string");
+      expect(sourceKey.length).toBeGreaterThan(0);
+    }
+    // The gating source keys are a subset of the fixture's optional top-level
+    // keys (each conditional kwarg is derived only when its key is present).
+    const optionalTopLevel = new Set(
+      (raw as unknown as { optionalFixturePaths: string[] }).optionalFixturePaths
+        .filter((p) => !p.includes("[*]") && !p.slice("FIXTURE.".length).includes("."))
+        .map((p) => p.slice("FIXTURE.".length)),
+    );
+    for (const sourceKey of Object.values(map)) {
+      expect(optionalTopLevel.has(sourceKey)).toBe(true);
+    }
+  });
+
+  it("powerCurveDeltaWindowDaysAgo carries the three integer day-offsets", () => {
+    const raw = stripComments(readContractRaw()) as {
+      powerCurveDeltaWindowDaysAgo: Record<string, unknown>;
+    };
+    const w = raw.powerCurveDeltaWindowDaysAgo;
+    expect(Object.keys(w).sort()).toEqual([
+      "win1StartDaysAgo",
+      "win2EndDaysAgo",
+      "win2StartDaysAgo",
+    ]);
+    for (const v of Object.values(w)) {
+      expect(Number.isInteger(v)).toBe(true);
+    }
+  });
+});
+
+describe("README allowlist matches the contract", () => {
+  it("the fenced JSON allowlist block equals optionalFixturePaths exactly", () => {
+    const raw = stripComments(readContractRaw()) as {
+      optionalFixturePaths: string[];
+    };
+    const fromReadme = readmeAllowlist(readFileSync(README_PATH, "utf8"));
+    expect(fromReadme).toEqual(raw.optionalFixturePaths);
+  });
+});
+
+describe("no harness file carries a residual inline copy of the extracted literals", () => {
+  const sources = HARNESS_FILES.map((rel) => ({
+    rel,
+    text: readFileSync(join(REPO_ROOT, rel), "utf8"),
+  }));
+
+  it("no file declares an inline _ALLOWED_OPTIONAL_PATHS set literal", () => {
+    // The allowlist must be built from the injected contract data
+    // (`set(json.loads(...))`), never re-listed as a `{ "FIXTURE..." }` set.
+    for (const { rel, text } of sources) {
+      const inlineSet = /_ALLOWED_OPTIONAL_PATHS\s*=\s*\{[^}]*"FIXTURE\./.test(
+        text,
+      );
+      expect(inlineSet, `${rel} re-grew an inline allowlist set`).toBe(false);
+    }
+  });
+
+  it("no file re-lists the power-curve delta-window day-offsets as inline magic numbers", () => {
+    // The win2 offsets (55 / 28) are unique to the curve delta-window and must
+    // come from the contract; a literal `timedelta(days=55|28)` is drift. The
+    // 27 offset is NOT tested here — it is shared with the base 28-day activity
+    // slice (`days=27`, an inclusive-window off-by-one) that stays inline.
+    const offending = /timedelta\(days=(?:28|55)\)/;
+    for (const { rel, text } of sources) {
+      expect(
+        offending.test(text),
+        `${rel} re-listed a delta-window offset as a magic number`,
+      ).toBe(false);
+    }
+  });
+
+  it("every harness file references the shared contract", () => {
+    for (const { rel, text } of sources) {
+      expect(
+        text.includes("harness-contract"),
+        `${rel} does not read the shared contract`,
+      ).toBe(true);
+    }
+  });
+});

--- a/tools/fuzz-parity.ts
+++ b/tools/fuzz-parity.ts
@@ -36,6 +36,10 @@ import { join, resolve } from "node:path";
 import { loadPyodide } from "pyodide";
 
 import { deepCompare, METRIC_REGISTRY, REPO_ROOT } from "./check-metric-parity";
+import {
+  FUZZ_OPTIONAL_FIXTURE_PATHS,
+  HARNESS_CONTRACT,
+} from "./harness-contract.js";
 import { decideVerdict } from "./fuzz-parity-verdict";
 
 const SECTION_11_REPO = process.env.SECTION_11_REPO ?? resolve(REPO_ROOT, "../section-11");
@@ -127,35 +131,18 @@ IntervalsSync = _ns["IntervalsSync"]
 # (minus the allowlist) after each run and fails loud on anything unexpected.
 import re as _re
 _TRACKED_MISSING = []
-# Allowlist ported from the snapshot harness, plus icu_zone_times: perturb
-# deletes it on ~30% of activities. The golden fixtures always include it, so
-# the snapshot allowlist omits it — but here it is a legitimate optionality.
-_ALLOWED_OPTIONAL_PATHS = {
-    "FIXTURE.activities[*].icu_hr_decoupling",
-    "FIXTURE.activities[*].icu_hr_zone_times",
-    "FIXTURE.activities[*].icu_hrr",
-    "FIXTURE.activities[*].icu_hrr.value",
-    "FIXTURE.activities[*].icu_hrr.hrr",
-    "FIXTURE.activities[*].icu_variability_index",
-    "FIXTURE.activities[*].icu_zone_times",
-    "FIXTURE.wellness[*].atl",
-    "FIXTURE.wellness[*].ctl",
-    # Top-level fixture extensions — reconciled with the snapshot harness's
-    # allowlist so the fuzzer's contract check is as strong as the gate's.
-    # The fuzzer perturbs only activities/wellness, so these are always absent
-    # here; the entries keep the two allowlists in lockstep.
-    "FIXTURE.past_events",
-    "FIXTURE.current_ftp_indoor",
-    "FIXTURE.current_ftp_outdoor",
-    "FIXTURE.ftp_history_indoor",
-    "FIXTURE.ftp_history_outdoor",
-    "FIXTURE.intervals",
-    "FIXTURE.power_curves",
-    "FIXTURE.hr_curves",
-    "FIXTURE.sustainability_curves",
-    "FIXTURE.streams",
-    "FIXTURE.athlete",
-}
+# Allowlist shared with the snapshot harness via tools/harness-contract.json,
+# injected here as ALLOWED_OPTIONAL_PATHS_JSON. The fuzz copy is the canonical
+# set PLUS the fuzz-only extras (icu_zone_times — perturb deletes it on ~30% of
+# activities; golden fixtures always include it, so the snapshot allowlist omits
+# it). The TS side unions the two contract lists before injecting them here.
+_ALLOWED_OPTIONAL_PATHS = set(json.loads(ALLOWED_OPTIONAL_PATHS_JSON))
+# Power/HR delta-window day-offsets — shared literal data from the contract,
+# injected as PC_DELTA_WINDOW_JSON. compute() closes over these module globals.
+_PC_WINDOW = json.loads(PC_DELTA_WINDOW_JSON)
+_PC_WIN1_START = _PC_WINDOW["win1StartDaysAgo"]
+_PC_WIN2_START = _PC_WINDOW["win2StartDaysAgo"]
+_PC_WIN2_END = _PC_WINDOW["win2EndDaysAgo"]
 def _normalize_path(path):
     return _re.sub(r"\\[\\d+\\]", "[*]", path)
 class _TrackedDict(dict):
@@ -213,9 +200,9 @@ def compute(fixture_json):
         _scurves = FIX.get("sustainability_curves")
         _athlete = FIX.get("athlete")
         if _pcurves:
-            _pcd = ((_FN - timedelta(days=27)).strftime("%Y-%m-%d"), today,
-                    (_FN - timedelta(days=55)).strftime("%Y-%m-%d"),
-                    (_FN - timedelta(days=28)).strftime("%Y-%m-%d"))
+            _pcd = ((_FN - timedelta(days=_PC_WIN1_START)).strftime("%Y-%m-%d"), today,
+                    (_FN - timedelta(days=_PC_WIN2_START)).strftime("%Y-%m-%d"),
+                    (_FN - timedelta(days=_PC_WIN2_END)).strftime("%Y-%m-%d"))
         else:
             _pcd = None
         if _scurves:
@@ -318,6 +305,14 @@ async function main(): Promise<number> {
   const py = await loadPyodide({ indexURL: resolve(REPO_ROOT, "node_modules/pyodide") });
   py.globals.set("FROZEN_NOW", args.frozenNow);
   py.globals.set("SYNC_PY_SOURCE", syncSource);
+  py.globals.set(
+    "ALLOWED_OPTIONAL_PATHS_JSON",
+    JSON.stringify(FUZZ_OPTIONAL_FIXTURE_PATHS),
+  );
+  py.globals.set(
+    "PC_DELTA_WINDOW_JSON",
+    JSON.stringify(HARNESS_CONTRACT.powerCurveDeltaWindowDaysAgo),
+  );
   py.runPython(ORACLE_PROLOGUE);
   const pyVersion = py.runPython("__import__('sys').version.split()[0]") as string;
 
@@ -433,7 +428,7 @@ async function main(): Promise<number> {
     case "contract-violation":
       console.error(`[fuzz-parity] FAIL — oracle read a silently-missing fixture key on ${contractViolations}/${args.n} input(s); both sides reading the same None would report a false parity, so this is NOT a pass.`);
       console.error(`[fuzz-parity]   first missing key(s): ${firstViolation}`);
-      console.error(`[fuzz-parity]   If it is a legitimate schema optionality, add the path to _ALLOWED_OPTIONAL_PATHS in the prologue; otherwise fix perturb so it stops generating it. Fixture written to:\n  ${firstViolationPath}`);
+      console.error(`[fuzz-parity]   If it is a legitimate schema optionality, add the path to optionalFixturePaths (or fuzzOnlyOptionalPaths) in tools/harness-contract.json; otherwise fix perturb so it stops generating it. Fixture written to:\n  ${firstViolationPath}`);
       break;
     case "mismatch": {
       const captured = Object.values(failPaths);

--- a/tools/harness-contract.json
+++ b/tools/harness-contract.json
@@ -1,0 +1,45 @@
+{
+  "$comment": "Language-neutral lockstep contract for the Reference layer's snapshot harness and its three twins (the pyodide harness, the native-CPython twin, the fuzz-parity differential, and the coverage probe). PURE DATA ONLY: literal values that must be identical across all four files. Each file keeps its own logic and reads these values (TypeScript via readFileSync+JSON.parse, Python via json.load). NEVER add expressions, templates, or per-file logic here — the twins are intentionally independent reimplementations, and that independence is what makes the cross-interpreter diff a real check. See the harness README's 'Harness contract' section.",
+  "optionalFixturePaths": [
+    "FIXTURE.activities[*].icu_hr_decoupling",
+    "FIXTURE.activities[*].icu_hr_zone_times",
+    "FIXTURE.activities[*].icu_hrr",
+    "FIXTURE.activities[*].icu_hrr.value",
+    "FIXTURE.activities[*].icu_hrr.hrr",
+    "FIXTURE.activities[*].icu_variability_index",
+    "FIXTURE.wellness[*].atl",
+    "FIXTURE.wellness[*].ctl",
+    "FIXTURE.past_events",
+    "FIXTURE.current_ftp_indoor",
+    "FIXTURE.current_ftp_outdoor",
+    "FIXTURE.ftp_history_indoor",
+    "FIXTURE.ftp_history_outdoor",
+    "FIXTURE.intervals",
+    "FIXTURE.power_curves",
+    "FIXTURE.hr_curves",
+    "FIXTURE.sustainability_curves",
+    "FIXTURE.streams",
+    "FIXTURE.athlete"
+  ],
+  "fuzzOnlyOptionalPaths": [
+    "FIXTURE.activities[*].icu_zone_times"
+  ],
+  "conditionalKwargs": {
+    "$comment": "Derived-kwarg name -> the fixture key whose presence gates it. Each twin derives the kwarg ONLY when the source key is present; absent keys reproduce the prior stub so fixtures carrying none stay byte-identical (including the absence of the upstream null-blocks' window keys). The map encodes that 'derive only when the key exists' rule as data; the per-kwarg derivation arithmetic stays as logic in each file.",
+    "power_curve_data": "power_curves",
+    "power_curve_dates": "power_curves",
+    "hr_curve_data": "hr_curves",
+    "sustainability_curves": "sustainability_curves",
+    "sustainability_window": "sustainability_curves",
+    "sport_settings": "athlete",
+    "power_model": "athlete",
+    "vo2max": "athlete",
+    "dfa_intervals_data": "streams"
+  },
+  "powerCurveDeltaWindowDaysAgo": {
+    "$comment": "Integer day-offsets-from-frozen-now for the two power/HR delta windows the upstream derives in pc_dates (sync.py:2465-2469). Each twin still does its own `frozen_now - timedelta(days=N)` calendar arithmetic; only the integers N live here. win1 = (now - win1StartDaysAgo)..today; win2 = (now - win2StartDaysAgo)..(now - win2EndDaysAgo).",
+    "win1StartDaysAgo": 27,
+    "win2StartDaysAgo": 55,
+    "win2EndDaysAgo": 28
+  }
+}

--- a/tools/harness-contract.ts
+++ b/tools/harness-contract.ts
@@ -1,0 +1,60 @@
+/**
+ * TypeScript loader for the language-neutral harness contract
+ * (`tools/harness-contract.json`). The JSON is the single source of truth for
+ * the literal data the snapshot harness and its three twins must share; the
+ * two Python twins read the same file via `json.load`. Keeping the read here
+ * (resolved relative to this file, not cwd) means both TS call sites — the
+ * pyodide harness and the fuzz-parity differential — agree on one parse.
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export interface HarnessContract {
+  optionalFixturePaths: string[];
+  fuzzOnlyOptionalPaths: string[];
+  conditionalKwargs: Record<string, string>;
+  powerCurveDeltaWindowDaysAgo: {
+    win1StartDaysAgo: number;
+    win2StartDaysAgo: number;
+    win2EndDaysAgo: number;
+  };
+}
+
+const CONTRACT_PATH = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "harness-contract.json",
+);
+
+function stripComments<T>(value: T): T {
+  if (Array.isArray(value)) {
+    return value.map((v) => stripComments(v)) as T;
+  }
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value)) {
+      if (k === "$comment") continue;
+      out[k] = stripComments(v);
+    }
+    return out as T;
+  }
+  return value;
+}
+
+export const HARNESS_CONTRACT: HarnessContract = stripComments(
+  JSON.parse(readFileSync(CONTRACT_PATH, "utf8")) as HarnessContract,
+);
+
+/** Allowlist the snapshot harness enforces (no fuzz-only extras). */
+export const OPTIONAL_FIXTURE_PATHS: readonly string[] =
+  HARNESS_CONTRACT.optionalFixturePaths;
+
+/**
+ * Allowlist the fuzz differential enforces — the canonical set plus the
+ * fuzz-only optionalities its perturbation legitimately produces.
+ */
+export const FUZZ_OPTIONAL_FIXTURE_PATHS: readonly string[] = [
+  ...HARNESS_CONTRACT.optionalFixturePaths,
+  ...HARNESS_CONTRACT.fuzzOnlyOptionalPaths,
+];

--- a/tools/measure-reference-coverage-native.py
+++ b/tools/measure-reference-coverage-native.py
@@ -132,7 +132,17 @@ def latest_wellness(rows):
     return sorted(rows, key=lambda r: r.get("id", ""), reverse=True)[0]
 
 
-def run_one_fixture(IntervalsSync, fixture: dict, frozen_now: datetime) -> None:
+def load_harness_contract() -> dict:
+    """Read the language-neutral lockstep contract shared with the pyodide
+    harness (tools/harness-contract.json), resolved relative to this file —
+    not cwd — so the probe reads the same literal data from any working dir."""
+    contract_path = Path(__file__).resolve().parent / "harness-contract.json"
+    return json.loads(contract_path.read_text(encoding="utf-8"))
+
+
+def run_one_fixture(
+    IntervalsSync, fixture: dict, frozen_now: datetime, pc_window: dict
+) -> None:
     """Drive _calculate_derived_metrics for a single fixture. Mirrors the
     arg-marshalling of tools/snapshot-section-11-native.py exactly so the
     code paths under coverage match the oracle the parity gate snapshots."""
@@ -171,10 +181,10 @@ def run_one_fixture(IntervalsSync, fixture: dict, frozen_now: datetime) -> None:
 
     if power_curves:
         pc_dates = (
-            (frozen_now - timedelta(days=27)).strftime("%Y-%m-%d"),
+            (frozen_now - timedelta(days=pc_window["win1StartDaysAgo"])).strftime("%Y-%m-%d"),
             today,
-            (frozen_now - timedelta(days=55)).strftime("%Y-%m-%d"),
-            (frozen_now - timedelta(days=28)).strftime("%Y-%m-%d"),
+            (frozen_now - timedelta(days=pc_window["win2StartDaysAgo"])).strftime("%Y-%m-%d"),
+            (frozen_now - timedelta(days=pc_window["win2EndDaysAgo"])).strftime("%Y-%m-%d"),
         )
     else:
         pc_dates = None
@@ -294,6 +304,7 @@ def main() -> int:
         print(f"upstream sync.py not found at {sync_py_path}", file=sys.stderr)
         return 2
     manifest = json.loads(args.manifest.read_text(encoding="utf-8"))
+    pc_window = load_harness_contract()["powerCurveDeltaWindowDaysAgo"]
 
     stub_requests()
     install_frozen_datetime()
@@ -317,7 +328,7 @@ def main() -> int:
         frozen = datetime.fromisoformat(entry["frozen_now"])
         try:
             fixture = json.loads(fx_path.read_text(encoding="utf-8"))
-            run_one_fixture(IntervalsSync, fixture, frozen)
+            run_one_fixture(IntervalsSync, fixture, frozen, pc_window)
             ran.append(fx_path.name)
         except Exception as e:  # noqa: BLE001 — record, keep measuring the rest
             errors.append({"fixture": fx_path.name, "type": type(e).__name__, "message": str(e),

--- a/tools/snapshot-section-11-native.py
+++ b/tools/snapshot-section-11-native.py
@@ -161,6 +161,14 @@ def latest_wellness(rows):
     return sorted(rows, key=lambda r: r.get("id", ""), reverse=True)[0]
 
 
+def load_harness_contract() -> dict:
+    """Read the language-neutral lockstep contract shared with the pyodide
+    harness (tools/harness-contract.json), resolved relative to this file —
+    not cwd — so the twin reads the same literal data from any working dir."""
+    contract_path = Path(__file__).resolve().parent / "harness-contract.json"
+    return json.loads(contract_path.read_text(encoding="utf-8"))
+
+
 def main() -> int:
     args = parse_args()
     sync_py_path = args.section_11_repo / "examples/sync.py"
@@ -172,6 +180,9 @@ def main() -> int:
         return 2
 
     stub_requests()
+
+    contract = load_harness_contract()
+    pc_window = contract["powerCurveDeltaWindowDaysAgo"]
 
     frozen_now = datetime.fromisoformat(args.frozen_now)
     install_frozen_datetime(frozen_now)
@@ -224,9 +235,9 @@ def main() -> int:
 
     if power_curves:
         pc_end1 = today
-        pc_start1 = (frozen_now - timedelta(days=27)).strftime("%Y-%m-%d")
-        pc_end2 = (frozen_now - timedelta(days=28)).strftime("%Y-%m-%d")
-        pc_start2 = (frozen_now - timedelta(days=55)).strftime("%Y-%m-%d")
+        pc_start1 = (frozen_now - timedelta(days=pc_window["win1StartDaysAgo"])).strftime("%Y-%m-%d")
+        pc_end2 = (frozen_now - timedelta(days=pc_window["win2EndDaysAgo"])).strftime("%Y-%m-%d")
+        pc_start2 = (frozen_now - timedelta(days=pc_window["win2StartDaysAgo"])).strftime("%Y-%m-%d")
         pc_dates = (pc_start1, pc_end1, pc_start2, pc_end2)
     else:
         pc_dates = None

--- a/tools/snapshot-section-11.README.md
+++ b/tools/snapshot-section-11.README.md
@@ -272,9 +272,9 @@ read silently as None (1 total .get() accesses):
 
 sync.py read None silently from fixture paths that don't exist.
 Either fix the fixture to include the keys, or — if a key is
-intentionally optional in the schema — extend the contract
-allowlist in tools/snapshot-section-11.ts. See the README's
-'Contract validation' section.
+intentionally optional in the schema — add the path to
+optionalFixturePaths in tools/harness-contract.json. See the
+README's 'Contract validation' section.
 ```
 
 Allowlist semantics:
@@ -288,51 +288,74 @@ Allowlist semantics:
 - A missing key not in the allowlist is a contract violation and
   fails the run.
 
-Initial allowlist (intervals.icu fields that may legitimately be
+Allowlist (intervals.icu fields that may legitimately be
 absent on a per-record basis — old activities computed before the
 field existed, rest-day wellness entries with no Fitness/Fatigue,
 etc.):
 
-```python
-_ALLOWED_OPTIONAL_PATHS = {
-    # Per-record intervals.icu fields that may legitimately be absent.
-    "FIXTURE.activities[*].icu_hr_decoupling",
-    "FIXTURE.activities[*].icu_hr_zone_times",
-    "FIXTURE.activities[*].icu_hrr",
-    "FIXTURE.activities[*].icu_hrr.value",
-    "FIXTURE.activities[*].icu_hrr.hrr",
-    "FIXTURE.activities[*].icu_variability_index",
-    "FIXTURE.wellness[*].atl",
-    "FIXTURE.wellness[*].ctl",
-    # Top-level fixture extensions — present only on the fixtures that exercise
-    # the corresponding populated branch; absent (and pass-through) on the rest.
-    "FIXTURE.past_events",
-    "FIXTURE.current_ftp_indoor",
-    "FIXTURE.current_ftp_outdoor",
-    "FIXTURE.ftp_history_indoor",
-    "FIXTURE.ftp_history_outdoor",
-    "FIXTURE.intervals",
-    "FIXTURE.power_curves",
-    "FIXTURE.hr_curves",
-    "FIXTURE.sustainability_curves",
-    "FIXTURE.streams",
-    "FIXTURE.athlete",
-}
+```json
+[
+  "FIXTURE.activities[*].icu_hr_decoupling",
+  "FIXTURE.activities[*].icu_hr_zone_times",
+  "FIXTURE.activities[*].icu_hrr",
+  "FIXTURE.activities[*].icu_hrr.value",
+  "FIXTURE.activities[*].icu_hrr.hrr",
+  "FIXTURE.activities[*].icu_variability_index",
+  "FIXTURE.wellness[*].atl",
+  "FIXTURE.wellness[*].ctl",
+  "FIXTURE.past_events",
+  "FIXTURE.current_ftp_indoor",
+  "FIXTURE.current_ftp_outdoor",
+  "FIXTURE.ftp_history_indoor",
+  "FIXTURE.ftp_history_outdoor",
+  "FIXTURE.intervals",
+  "FIXTURE.power_curves",
+  "FIXTURE.hr_curves",
+  "FIXTURE.sustainability_curves",
+  "FIXTURE.streams",
+  "FIXTURE.athlete"
+]
 ```
 
-The same allowlist is duplicated in three places that must stay in lockstep:
-`tools/snapshot-section-11.ts` (the canonical copy the harness uses),
-`tools/fuzz-parity.ts` (so the fuzzer's contract check is as strong as the
-gate's), and this README block. Extending it means editing all three.
+This list is the `optionalFixturePaths` array of the shared harness
+contract (`tools/harness-contract.json`) — the single source of truth
+the harness and its twins read at runtime. The block above is NOT a
+separate copy to hand-sync; `packages/core/tests/harness-contract.test.ts`
+parses it and asserts it equals the contract's `optionalFixturePaths`
+exactly, so the two cannot drift. The fuzz-parity differential adds one
+fuzz-only optionality (`FIXTURE.activities[*].icu_zone_times`, which its
+perturbation deletes on ~30% of activities) via the contract's
+`fuzzOnlyOptionalPaths` array; the harness, the native twin, and the
+coverage probe use the canonical list only.
 
-Extending the allowlist requires a README update in this section so
-the reviewer can trace why a particular field is treated as
-schema-optional.
+Extending the allowlist means editing `tools/harness-contract.json` and
+this README block (the test keeps them aligned) so a reviewer can trace
+why a particular field is treated as schema-optional.
 
 Tested by `packages/core/tests/snapshot-contract.test.ts`, which
 deliberately renames `"activities"` to `"activitiez"` in a temp
 fixture, runs the harness against it, and asserts the structured
 failure surfaces the renamed path.
+
+## Harness contract
+
+This harness has four implementations that must agree on the same literal
+data: the pyodide harness (`tools/snapshot-section-11.ts`), its native
+CPython twin (`tools/snapshot-section-11-native.py`), the fuzz-parity
+differential (`tools/fuzz-parity.ts`), and the branch-coverage probe
+(`tools/measure-reference-coverage-native.py`). Because two of them are
+Python and cannot import the TypeScript module, that shared data lives in
+a language-neutral file, `tools/harness-contract.json`: the optional-path
+allowlist (`optionalFixturePaths` + `fuzzOnlyOptionalPaths`), the
+fixture-key → derived-kwarg conditions (`conditionalKwargs`), and the
+power/HR delta-window day-offsets (`powerCurveDeltaWindowDaysAgo`). The
+TypeScript files read it through `tools/harness-contract.ts`; the Python
+twins `json.load` it relative to their own path. Each file keeps its own
+logic — only the literal values are shared, so the twins stay independent
+reimplementations and the cross-interpreter diff remains a real check.
+`packages/core/tests/harness-contract.test.ts` asserts the contract's
+schema shape, that this README's allowlist block matches it, and that no
+file carries a residual inline copy of the extracted literals.
 
 ## Null / absent audit (against F8 metric scope)
 

--- a/tools/snapshot-section-11.ts
+++ b/tools/snapshot-section-11.ts
@@ -27,6 +27,10 @@ import { fileURLToPath } from "node:url";
 import { loadPyodide } from "pyodide";
 
 import type { Manifest, Snapshot } from "./check-metric-parity";
+import {
+  HARNESS_CONTRACT,
+  OPTIONAL_FIXTURE_PATHS,
+} from "./harness-contract.js";
 import { DEFAULT_FROZEN_NOW, HARNESS_FIXTURES } from "./harness-fixtures.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -189,36 +193,19 @@ IntervalsSync = _sync_ns["IntervalsSync"]
 import re as _re
 _TRACKED_MISSING = []
 
-_ALLOWED_OPTIONAL_PATHS = {
-    "FIXTURE.activities[*].icu_hr_decoupling",
-    "FIXTURE.activities[*].icu_hr_zone_times",
-    "FIXTURE.activities[*].icu_hrr",
-    # icu_hrr may arrive as a dict; the upstream reads .value then .hrr,
-    # defaulting both to None (see _calculate_hrrc_trend's _filter_qualifying).
-    "FIXTURE.activities[*].icu_hrr.value",
-    "FIXTURE.activities[*].icu_hrr.hrr",
-    "FIXTURE.activities[*].icu_variability_index",
-    "FIXTURE.wellness[*].atl",
-    "FIXTURE.wellness[*].ctl",
-    # F11 fixture extensions — absent on every fixture that doesn't exercise
-    # the populated benchmark / consistency branches; present on fixtures that
-    # do. The harness reads them pass-through (no hardcoded overrides) per
-    # ADR-0017's boundary contract.
-    "FIXTURE.past_events",
-    "FIXTURE.current_ftp_indoor",
-    "FIXTURE.current_ftp_outdoor",
-    "FIXTURE.ftp_history_indoor",
-    "FIXTURE.ftp_history_outdoor",
-    "FIXTURE.intervals",
-    # Curve + stream extensions — present only on the curve/stream fixtures.
-    # The harness derives the date/window kwargs ONLY when the matching key
-    # is present, so absent keys reproduce the prior null-block snapshots.
-    "FIXTURE.power_curves",
-    "FIXTURE.hr_curves",
-    "FIXTURE.sustainability_curves",
-    "FIXTURE.streams",
-    "FIXTURE.athlete",
-}
+# The allowlist of legitimately-optional fixture paths is shared literal data
+# across the harness twins; it lives in tools/harness-contract.json and is
+# injected here as ALLOWED_OPTIONAL_PATHS_JSON (see the README's "Harness
+# contract" section). [*] is the array-index wildcard.
+_ALLOWED_OPTIONAL_PATHS = set(json.loads(ALLOWED_OPTIONAL_PATHS_JSON))
+
+# Power/HR delta-window day-offsets — shared literal data from
+# tools/harness-contract.json (injected as PC_DELTA_WINDOW_JSON). Each twin
+# keeps its own timedelta arithmetic; only the integers come from the contract.
+_PC_WINDOW = json.loads(PC_DELTA_WINDOW_JSON)
+_PC_WIN1_START = _PC_WINDOW["win1StartDaysAgo"]
+_PC_WIN2_START = _PC_WINDOW["win2StartDaysAgo"]
+_PC_WIN2_END = _PC_WINDOW["win2EndDaysAgo"]
 
 def _normalize_path(path):
     return _re.sub(r"\\[\\d+\\]", "[*]", path)
@@ -353,9 +340,9 @@ _raw_latest_wellness = _pick_latest_wellness(
 # when it fetched power curves; both delta metrics read this same tuple.
 if _power_curves:
     _pc_end1 = _TODAY
-    _pc_start1 = (_FROZEN_NOW - timedelta(days=27)).strftime("%Y-%m-%d")
-    _pc_end2 = (_FROZEN_NOW - timedelta(days=28)).strftime("%Y-%m-%d")
-    _pc_start2 = (_FROZEN_NOW - timedelta(days=55)).strftime("%Y-%m-%d")
+    _pc_start1 = (_FROZEN_NOW - timedelta(days=_PC_WIN1_START)).strftime("%Y-%m-%d")
+    _pc_end2 = (_FROZEN_NOW - timedelta(days=_PC_WIN2_END)).strftime("%Y-%m-%d")
+    _pc_start2 = (_FROZEN_NOW - timedelta(days=_PC_WIN2_START)).strftime("%Y-%m-%d")
     _pc_dates = (_pc_start1, _pc_end1, _pc_start2, _pc_end2)
 else:
     _pc_dates = None
@@ -554,9 +541,9 @@ if "__error__" not in derived:
                 "message": (
                     "sync.py read None silently from fixture paths that don't exist. "
                     "Either fix the fixture to include the keys, or — if a key is "
-                    "intentionally optional in the schema — extend the contract "
-                    "allowlist in tools/snapshot-section-11.ts. See the README's "
-                    "'Contract validation' section."
+                    "intentionally optional in the schema — add the path to "
+                    "optionalFixturePaths in tools/harness-contract.json. See the "
+                    "README's 'Contract validation' section."
                 ),
             }
         }
@@ -697,6 +684,14 @@ async function main(): Promise<void> {
 
   pyodide.globals.set("SYNC_PY_PATH", SYNC_PY_PATH);
   pyodide.globals.set("SYNC_PY_SOURCE", syncPySource);
+  pyodide.globals.set(
+    "ALLOWED_OPTIONAL_PATHS_JSON",
+    JSON.stringify(OPTIONAL_FIXTURE_PATHS),
+  );
+  pyodide.globals.set(
+    "PC_DELTA_WINDOW_JSON",
+    JSON.stringify(HARNESS_CONTRACT.powerCurveDeltaWindowDaysAgo),
+  );
 
   const results: { slug: string; metrics: string[] }[] = [];
   for (const fixture of fixtures) {


### PR DESCRIPTION
## Summary

Extracts the harness lockstep surface — duplicated across the snapshot harness, its native twin, the fuzz harness, and the coverage probe — into one language-neutral data file, `tools/harness-contract.json`. This is the structural fix for the drift class behind two real bugs (the native twin missing the F11 hoists; the fuzz harness's stale allowlist).

- **`tools/harness-contract.json`** — pure data: `optionalFixturePaths` (19 entries, the canonical allowlist), `fuzzOnlyOptionalPaths` (1 entry — the fuzz harness's deliberate `icu_zone_times` perturbation, previously an unexplained inline extra), `conditionalKwargs` (9-entry derived-kwarg → gating-fixture-key map), and the curve-delta window offsets.
- **Consumers**: both TS harnesses read it via a typed loader (`tools/harness-contract.ts`); both Python twins `json.load()` it resolved relative to `__file__`. Only literal data moved — each file keeps its own logic, so the pyodide/CPython twins stay independent implementations and the cross-runtime diff remains a real check.
- **`packages/core/tests/harness-contract.test.ts`** — asserts contract shape, README↔contract agreement, and source-level tripwires against residual inline copies.

## Verification

- Pure refactor: full snapshot regen across all 13 fixtures → zero byte changes (`git status` over the snapshot tree empty)
- Cross-runtime diff: realistic-athlete, curve-equipped, dfa-equipped all `63 metrics bit-identical`, 0 divergences
- `pnpm test`: 1506 passed | 5 skipped; `pnpm check:trademarks` clean; oxlint 0/0; both Python twins AST-parse clean
- fuzz-parity failure set unchanged (the documented pre-existing six) — no new failures
