### PR TITLE
feat(core): port power-curve delta — MMP rotation across 28d windows

### DIFF
--- a/.changeset/reference-power-curve-delta.md
+++ b/.changeset/reference-power-curve-delta.md
@@ -1,0 +1,11 @@
+---
+"@enduragent/core": patch
+---
+
+Port the Reference layer's `capability.power_curve_delta` — the shift in mean-maximal power at five anchor durations (5s, 60s, 300s, 1200s, 3600s) across two adjacent 28-day windows, with a `rotation_index` summarising whether gains are sprint-biased (positive) or endurance-biased (negative).
+
+- Added `computePowerCurveDelta` to `packages/core/src/reference/metrics/capability.ts` — a line-by-line transliteration of `_calculate_power_curve_delta` (sync.py:4297-4439). Curves are matched by the `r.{start}.{end}` id string (never by list index); a missing id is a silent-null branch. Per-anchor `pct_change` rounds via the exact `roundHalfEven` half-to-even helper; the rotation mean uses the compensated `pythonSum` for parity with the oracle's CPython 3.12+ `sum()`.
+- The window dates are derived from the snapshot's frozen clock ONLY when the fixture carries `power_curves` (mirroring the upstream's fetch gate), so the 12 fixtures without curves reproduce the dateless null block byte-for-byte while the curve-equipped fixture populates `rotation_index` 5.3 with non-null per-anchor entries.
+- Registered `capability.power_curve_delta` in `METRIC_REGISTRY`; the parity matrix asserts bit-identical match across all 13 fixtures. No deviation registered — faithful port. Discipline: `docs/adr/0016-metric-porting-discipline.md`.
+
+Pure derived-metric compute — surfaces as coaching context, no athlete-facing command change.

--- a/packages/core/src/reference/metrics/capability.test.ts
+++ b/packages/core/src/reference/metrics/capability.test.ts
@@ -5,9 +5,11 @@ import {
   computeDurability,
   computeEfficiencyFactor,
   computeHrrc,
+  computePowerCurveDelta,
   computeTidComparison,
 } from "./capability.js";
 import type { MetricInput } from "./metric-input.js";
+import type { PowerCurveData } from "../schemas/inputs.js";
 
 interface SyntheticActivity {
   id?: string | number;
@@ -489,5 +491,157 @@ describe("compareTid", () => {
       drift: null,
       note: TID_NOTE_INSUFFICIENT,
     });
+  });
+});
+
+const PCD_NOTE =
+  "Compares MMP at 5 anchor durations (5s neuromuscular, 60s anaerobic, " +
+  "300s MAP, 1200s threshold, 3600s endurance) across two 28d windows. " +
+  "rotation_index = mean(5s,60s pct_change) - mean(1200s,3600s pct_change). " +
+  "Positive = sprint-biased gains, negative = endurance-biased. " +
+  "300s excluded from rotation (transitional). " +
+  "Null when either window has fewer than 3 valid anchor durations.";
+
+// frozenNow=2026-06-04 → current window r.2026-05-08.2026-06-04 (now-27..today),
+// previous window r.2026-04-10.2026-05-07 (now-55..now-28). Matches the
+// curve-equipped oracle snapshot's window math.
+const PCD_FROZEN_NOW = "2026-06-04T12:00:00";
+const PCD_CURRENT_ID = "r.2026-05-08.2026-06-04";
+const PCD_PREVIOUS_ID = "r.2026-04-10.2026-05-07";
+
+function powerInput(
+  powerCurves: PowerCurveData | undefined,
+  frozenNow = PCD_FROZEN_NOW,
+): MetricInput {
+  return {
+    fixture: { activities: [], ...(powerCurves ? { power_curves: powerCurves } : {}) },
+    frozenNow,
+  } as unknown as MetricInput;
+}
+
+describe("computePowerCurveDelta", () => {
+  it("absent power_curves → dateless null block (the 12-fixture branch)", () => {
+    expect(computePowerCurveDelta(powerInput(undefined))).toEqual({
+      window_days: 28,
+      anchors: null,
+      rotation_index: null,
+      note: "Insufficient power data in one or both windows.",
+    });
+  });
+
+  it("empty list → null block but WITH window keys (curves present gates the dates)", () => {
+    expect(computePowerCurveDelta(powerInput({ list: [] }))).toEqual({
+      window_days: 28,
+      current_window: { start: "2026-05-08", end: "2026-06-04" },
+      previous_window: { start: "2026-04-10", end: "2026-05-07" },
+      anchors: null,
+      rotation_index: null,
+      note: "Insufficient power data in one or both windows.",
+    });
+  });
+
+  it("missing-id curve is a silent null branch, named per which window is absent", () => {
+    const result = computePowerCurveDelta(
+      powerInput({
+        list: [{ id: PCD_CURRENT_ID, secs: [5, 60, 1200, 3600], watts: [600, 300, 190, 170] }],
+      }),
+    );
+    expect(result.anchors).toBeNull();
+    expect(result.rotation_index).toBeNull();
+    expect(result.note).toBe("No power data in previous window(s).");
+    expect(result.current_window).toEqual({ start: "2026-05-08", end: "2026-06-04" });
+  });
+
+  it("populated: per-anchor pct_change + rotation_index match the curve-equipped oracle", () => {
+    const result = computePowerCurveDelta(
+      powerInput({
+        list: [
+          {
+            id: PCD_CURRENT_ID,
+            secs: [5, 60, 300, 1200, 3600],
+            watts: [637, 310, 218, 191, 169],
+          },
+          {
+            id: PCD_PREVIOUS_ID,
+            secs: [5, 60, 300, 1200, 3600],
+            watts: [564, 259, 195, 167, 157],
+          },
+        ],
+      }),
+    );
+    expect(result).toEqual({
+      window_days: 28,
+      current_window: { start: "2026-05-08", end: "2026-06-04" },
+      previous_window: { start: "2026-04-10", end: "2026-05-07" },
+      anchors: {
+        "5s": { current_watts: 637, previous_watts: 564, pct_change: 12.9 },
+        "60s": { current_watts: 310, previous_watts: 259, pct_change: 19.7 },
+        "300s": { current_watts: 218, previous_watts: 195, pct_change: 11.8 },
+        "1200s": { current_watts: 191, previous_watts: 167, pct_change: 14.4 },
+        "3600s": { current_watts: 169, previous_watts: 157, pct_change: 7.6 },
+      },
+      // short mean(12.9,19.7)=16.3, long mean(14.4,7.6)=11.0 → 5.3
+      rotation_index: 5.3,
+      note: PCD_NOTE,
+    });
+  });
+
+  it("zero/null watts → anchor null; pct_change null when either side null", () => {
+    const result = computePowerCurveDelta(
+      powerInput({
+        list: [
+          { id: PCD_CURRENT_ID, secs: [5, 60, 300, 1200, 3600], watts: [600, 0, 218, 191, 169] },
+          { id: PCD_PREVIOUS_ID, secs: [5, 60, 300, 1200, 3600], watts: [564, 259, null, 167, 157] },
+        ],
+      }),
+    );
+    // 60s current=0 → not > 0 → current_watts null → pct_change null
+    expect(result.anchors?.["60s"]).toEqual({
+      current_watts: null,
+      previous_watts: 259,
+      pct_change: null,
+    });
+    // 300s previous=null → previous_watts null → pct_change null
+    expect(result.anchors?.["300s"]).toEqual({
+      current_watts: 218,
+      previous_watts: null,
+      pct_change: null,
+    });
+    // current valid = {5s,300s,1200s,3600s}=4, previous valid = {5s,60s,1200s,3600s}=4 → block survives
+    // but rotation needs 5s,60s,1200s,3600s all non-null; 60s pct_change null → rotation null
+    expect(result.rotation_index).toBeNull();
+  });
+
+  it("block guard: < 3 valid anchors in a window → null block with the count message", () => {
+    const result = computePowerCurveDelta(
+      powerInput({
+        list: [
+          // current window: only 5s and 60s carry watts → 2 valid (< 3)
+          { id: PCD_CURRENT_ID, secs: [5, 60], watts: [600, 300] },
+          { id: PCD_PREVIOUS_ID, secs: [5, 60, 300, 1200, 3600], watts: [564, 259, 195, 167, 157] },
+        ],
+      }),
+    );
+    expect(result.anchors).toBeNull();
+    expect(result.rotation_index).toBeNull();
+    expect(result.note).toBe(
+      "Too few valid anchors (current: 2, previous: 5, need 3+).",
+    );
+  });
+
+  it("anchor absent from secs array → that anchor null, others computed", () => {
+    const result = computePowerCurveDelta(
+      powerInput({
+        list: [
+          // 60s omitted from secs entirely (not a zero, just not present)
+          { id: PCD_CURRENT_ID, secs: [5, 300, 1200, 3600], watts: [637, 218, 191, 169] },
+          { id: PCD_PREVIOUS_ID, secs: [5, 60, 300, 1200, 3600], watts: [564, 259, 195, 167, 157] },
+        ],
+      }),
+    );
+    expect(result.anchors?.["60s"].current_watts).toBeNull();
+    expect(result.anchors?.["5s"].current_watts).toBe(637);
+    // 60s pct_change null → rotation null even though block guard (4 valid each) passes
+    expect(result.rotation_index).toBeNull();
   });
 });

--- a/packages/core/src/reference/metrics/capability.ts
+++ b/packages/core/src/reference/metrics/capability.ts
@@ -11,11 +11,17 @@
  * See `NOTICE.md` for upstream attribution.
  */
 
-import { getActivities, getActivitiesInWindow, type MetricInput } from "./metric-input.js";
+import { isoDateDaysBefore } from "./date-helpers.js";
+import {
+  getActivities,
+  getActivitiesInWindow,
+  getPowerCurves,
+  type MetricInput,
+} from "./metric-input.js";
 import { computeSeilerTid, computeSeilerTid28d, type SeilerTid } from "./distribution.js";
-import { mean } from "./statistics.js";
+import { mean, pythonSum } from "./statistics.js";
 import { roundHalfEven } from "./rounding.js";
-import type { Activity } from "../schemas/inputs.js";
+import type { Activity, PowerCurveData } from "../schemas/inputs.js";
 
 export interface DurabilitySignal {
   mean_decoupling_7d: number | null;
@@ -345,4 +351,190 @@ export function compareTid(
  */
 export function computeTidComparison(input: MetricInput): TidComparisonSignal {
   return compareTid(computeSeilerTid(input), computeSeilerTid28d(input));
+}
+
+export interface PowerCurveAnchor {
+  current_watts: number | null;
+  previous_watts: number | null;
+  pct_change: number | null;
+}
+
+export interface PowerCurveWindow {
+  start: string;
+  end: string;
+}
+
+export interface PowerCurveDelta {
+  window_days: 28;
+  current_window?: PowerCurveWindow;
+  previous_window?: PowerCurveWindow;
+  anchors: Record<string, PowerCurveAnchor> | null;
+  rotation_index: number | null;
+  note: string;
+}
+
+const POWER_CURVE_ANCHORS: Record<string, number> = {
+  "5s": 5,
+  "60s": 60,
+  "300s": 300,
+  "1200s": 1200,
+  "3600s": 3600,
+};
+
+const POWER_CURVE_DELTA_NOTE =
+  "Compares MMP at 5 anchor durations (5s neuromuscular, 60s anaerobic, " +
+  "300s MAP, 1200s threshold, 3600s endurance) across two 28d windows. " +
+  "rotation_index = mean(5s,60s pct_change) - mean(1200s,3600s pct_change). " +
+  "Positive = sprint-biased gains, negative = endurance-biased. " +
+  "300s excluded from rotation (transitional). " +
+  "Null when either window has fewer than 3 valid anchor durations.";
+
+/**
+ * Power curve delta — the shift in mean-maximal power at anchor durations
+ * across two adjacent 28-day windows, plus a `rotation_index` summarising
+ * whether the gains are sprint- (positive) or endurance-biased (negative).
+ *
+ * The upstream derives `power_curve_dates` from the frozen clock ONLY when it
+ * fetched power curves (the snapshot harness mirrors that gate), so
+ * `powerCurveDates` here stays null whenever the fixture omits `power_curves`
+ * — reproducing the dateless null block byte-for-byte. Curves are matched by
+ * the `r.{start}.{end}` id string, never by list position; a missing id is a
+ * silent null branch, not an error.
+ *
+ * Upstream source mirrored line-by-line: `sync.py:4297-4439`
+ * (`_calculate_power_curve_delta`) with the window math wired by the harness
+ * at `sync.py:2465-2469` (win1 = now-27..today, win2 = now-55..now-28).
+ * See `NOTICE.md` for upstream attribution.
+ *
+ * @see Pinot, J., & Grappe, F. (2011). The record power profile to assess
+ *      performance in elite cyclists. Int J Sports Med 32(11):839-844.
+ */
+export function computePowerCurveDelta(input: MetricInput): PowerCurveDelta {
+  const powerCurveData = getPowerCurves(input);
+  const powerCurveDates = powerCurveDatesFrom(input.frozenNow, powerCurveData);
+
+  const nullBlock = (note = "Insufficient power data in one or both windows."): PowerCurveDelta => {
+    const dates: Pick<PowerCurveDelta, "current_window" | "previous_window"> = {};
+    if (powerCurveDates) {
+      dates.current_window = { start: powerCurveDates[0], end: powerCurveDates[1] };
+      dates.previous_window = { start: powerCurveDates[2], end: powerCurveDates[3] };
+    }
+    return {
+      window_days: 28,
+      ...dates,
+      anchors: null,
+      rotation_index: null,
+      note,
+    };
+  };
+
+  if (!powerCurveData || !powerCurveDates) {
+    return nullBlock();
+  }
+
+  const curvesList = powerCurveData.list ?? [];
+  if (curvesList.length === 0) {
+    return nullBlock();
+  }
+
+  const [pcStart1, pcEnd1, pcStart2, pcEnd2] = powerCurveDates;
+  const currentId = `r.${pcStart1}.${pcEnd1}`;
+  const previousId = `r.${pcStart2}.${pcEnd2}`;
+
+  const curvesById = new Map<string, PowerCurveData["list"][number]>();
+  for (const c of curvesList) {
+    if (!curvesById.has(c.id)) curvesById.set(c.id, c);
+  }
+  const currentCurve = curvesById.get(currentId);
+  const previousCurve = curvesById.get(previousId);
+
+  if (!currentCurve || !previousCurve) {
+    const missing: string[] = [];
+    if (!currentCurve) missing.push("current");
+    if (!previousCurve) missing.push("previous");
+    return nullBlock(`No power data in ${missing.join(" and ")} window(s).`);
+  }
+
+  const anchors: Record<string, PowerCurveAnchor> = {};
+  for (const [label, durationSecs] of Object.entries(POWER_CURVE_ANCHORS)) {
+    const curSecs = currentCurve.secs ?? [];
+    const curWatts = currentCurve.watts ?? [];
+    const prevSecs = previousCurve.secs ?? [];
+    const prevWatts = previousCurve.watts ?? [];
+
+    let curW: number | null = null;
+    if (curSecs.includes(durationSecs)) {
+      const idx = curSecs.indexOf(durationSecs);
+      const val = idx < curWatts.length ? curWatts[idx] : null;
+      if (val !== null && val !== undefined && val > 0) {
+        curW = val;
+      }
+    }
+
+    let prevW: number | null = null;
+    if (prevSecs.includes(durationSecs)) {
+      const idx = prevSecs.indexOf(durationSecs);
+      const val = idx < prevWatts.length ? prevWatts[idx] : null;
+      if (val !== null && val !== undefined && val > 0) {
+        prevW = val;
+      }
+    }
+
+    let pctChange: number | null = null;
+    if (curW !== null && prevW !== null) {
+      pctChange = roundHalfEven(((curW - prevW) / prevW) * 100, 1);
+    }
+
+    anchors[label] = {
+      current_watts: curW,
+      previous_watts: prevW,
+      pct_change: pctChange,
+    };
+  }
+
+  const currentValid = Object.values(anchors).filter((a) => a.current_watts !== null).length;
+  const previousValid = Object.values(anchors).filter((a) => a.previous_watts !== null).length;
+
+  if (currentValid < 3 || previousValid < 3) {
+    return nullBlock(
+      `Too few valid anchors (current: ${currentValid}, previous: ${previousValid}, need 3+).`,
+    );
+  }
+
+  const shortChanges = [anchors["5s"].pct_change, anchors["60s"].pct_change];
+  const longChanges = [anchors["1200s"].pct_change, anchors["3600s"].pct_change];
+
+  let rotationIndex: number | null = null;
+  if ([...shortChanges, ...longChanges].every((v) => v !== null)) {
+    const shortMean = pythonSum(shortChanges as number[]) / shortChanges.length;
+    const longMean = pythonSum(longChanges as number[]) / longChanges.length;
+    rotationIndex = roundHalfEven(shortMean - longMean, 1);
+  }
+
+  return {
+    window_days: 28,
+    current_window: { start: pcStart1, end: pcEnd1 },
+    previous_window: { start: pcStart2, end: pcEnd2 },
+    anchors,
+    rotation_index: rotationIndex,
+    note: POWER_CURVE_DELTA_NOTE,
+  };
+}
+
+// The four-date window tuple the harness passes as `power_curve_dates`,
+// derived from the frozen clock — present only when the fixture carried
+// `power_curves` (the upstream fetch gate, `sync.py:2465-2469`):
+// current = [now-27, today], previous = [now-55, now-28].
+function powerCurveDatesFrom(
+  frozenNow: string,
+  powerCurveData: PowerCurveData | null,
+): [string, string, string, string] | null {
+  if (!powerCurveData) return null;
+  const today = frozenNow.slice(0, 10);
+  return [
+    isoDateDaysBefore(frozenNow, 27),
+    today,
+    isoDateDaysBefore(frozenNow, 55),
+    isoDateDaysBefore(frozenNow, 28),
+  ];
 }

--- a/packages/core/src/reference/metrics/metric-input.ts
+++ b/packages/core/src/reference/metrics/metric-input.ts
@@ -3,6 +3,7 @@ import type {
   AthleteSettings,
   FixtureShape,
   PlannedEvent,
+  PowerCurveData,
   WellnessDay,
 } from "../schemas/inputs.js";
 import { isoDateDaysBefore } from "./date-helpers.js";
@@ -114,4 +115,12 @@ export function getAthlete(input: MetricInput): AthleteSettings | null {
 // the latest row within the 28-day window from this surface.
 export function getWellness(input: MetricInput): WellnessDay[] {
   return input.fixture.wellness;
+}
+
+// The `{list}` power mean-max curve envelope the upstream fetches and passes
+// as the `power_curve_data` kwarg. Its presence gates the delta window math:
+// the harness derives `power_curve_dates` from frozenNow ONLY when this key
+// is present, so absent curves reproduce the null block without window keys.
+export function getPowerCurves(input: MetricInput): PowerCurveData | null {
+  return input.fixture.power_curves ?? null;
 }

--- a/packages/core/src/reference/metrics/registry.ts
+++ b/packages/core/src/reference/metrics/registry.ts
@@ -13,6 +13,7 @@ import {
   computeDurability,
   computeEfficiencyFactor,
   computeHrrc,
+  computePowerCurveDelta,
   computeTidComparison,
 } from "./capability.js";
 import {
@@ -97,6 +98,7 @@ export const METRIC_REGISTRY: Record<string, MetricRegistryEntry> = {
   "capability.efficiency_factor": { compute: computeEfficiencyFactor },
   "capability.hrrc": { compute: computeHrrc },
   "capability.tid_comparison": { compute: computeTidComparison },
+  "capability.power_curve_delta": { compute: computePowerCurveDelta },
   eftp: { compute: computeEftp },
   w_prime: { compute: computeWPrime },
   w_prime_kj: { compute: computeWPrimeKj },


### PR DESCRIPTION
## Summary

Ports `capability.power_curve_delta` into the Reference layer: best-power comparison at anchor durations across two 28-day windows, with per-anchor pct_change and the rotation index.

- `computePowerCurveDelta` in `capability.ts` — line-by-line transliteration of the upstream calculation, including the silent-null branches the curve-id matching implies (a missing `r.{start}.{end}` id yields null, not an error), the ≥3-of-5-anchors block guard, and the stricter all-4-of-{5s,60s,1200s,3600s}-in-both-windows requirement for `rotation_index`.
- Exact-arithmetic helpers throughout: `roundHalfEven` for pct_change/rotation, `pythonSum` for the rotation halves.
- Window-tuple derivation (`powerCurveDatesFrom`) gated on the `power_curves` fixture key, matching the harness, so the 12 curveless fixtures keep the dateless null block bit-identically.
- Registered as a capability sub-key per the established Group A pattern; `getPowerCurves` accessor added at the gate boundary; 8 unit tests for branches the oracle fixtures don't reach.

## Verification

- Parity gate: 13/13 fixtures bit-identical, exit 0 — populated on curve-equipped (rotation_index 5.3, 5 non-null anchors), null blocks elsewhere
- `pnpm test`: 1614 passed | 5 skipped (+20 vs main, incl. 13 auto-picked parity assertions)
- Zero snapshot/fixture changes; `pnpm check:trademarks` clean; oxlint 0/0
- No deviation-registry changes (faithful transliteration, no Phase 4 events)
