### PR TITLE
feat(core): port capability.dfa_a1_profile — DFA-alpha1 LT1/LT2 estimation

### DIFF
--- a/.changeset/port-dfa-a1-profile.md
+++ b/.changeset/port-dfa-a1-profile.md
@@ -1,0 +1,7 @@
+---
+"@enduragent/core": patch
+---
+
+Port the Reference layer's `capability.dfa_a1_profile` metric — DFA-alpha1 LT1/LT2 threshold estimation from per-second AlphaHRV streams. The full pipeline is transliterated line-by-line: the streams-assembly path joins each fixture `streams` record (keyed by `String(activity.id)`) back to the activities array, runs each record carrying a `dfa_a1` channel through the per-session DFA block builder (sentinel-zero + artifact filtering, validity gate, percentile/TIZ-band rollups, first-vs-last-third drift, LT1/LT2 crossing-band HR/watts estimates), and feeds the qualifying sessions into the profile aggregator (latest sufficient session + per-sport-family trailing window with confidence tiers and indoor/outdoor watts split for cycling). The 12 stream-free fixtures reproduce the null profile byte-for-byte; the stream-equipped fixture populates the full cycling block bit-identically against the oracle snapshot (confidence high, lt1 {hr 141, watts_outdoor 181}, lt2 {hr 169, watts_outdoor 261}). Numerically faithful: every `round()` site uses banker's rounding on the exact double (including Python's no-arg `round(x)` integer form), and float `sum()` sites use compensated summation to match CPython 3.12+.
+
+Pure Reference-layer + oracle parity work — athletes don't notice yet.

--- a/packages/core/src/reference/metrics/capability.test.ts
+++ b/packages/core/src/reference/metrics/capability.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  buildDfaBlock,
   compareTid,
+  computeDfaA1Profile,
   computeDurability,
   computeEfficiencyFactor,
   computeHrrc,
@@ -11,6 +13,7 @@ import {
 } from "./capability.js";
 import type { MetricInput } from "./metric-input.js";
 import type {
+  ActivityStreams,
   PowerCurveData,
   SustainabilityFamilyCurves,
 } from "../schemas/inputs.js";
@@ -898,5 +901,240 @@ describe("computeSustainabilityProfile", () => {
       note: "No sport families produced valid sustainability data.",
       window: { days: 42, start: "2026-04-24", end: "2026-06-04" },
     });
+  });
+});
+
+// ─── DFA a1 profile ─────────────────────────────────────────────────────────
+
+interface DfaActivityIn {
+  id: number;
+  start_date_local: string;
+  type?: string;
+  name?: string;
+  moving_time?: number;
+  elapsed_time?: number;
+}
+
+function dfaInput(opts: {
+  activities: DfaActivityIn[];
+  streams?: Record<string, ActivityStreams>;
+  frozenNow?: string;
+}): MetricInput {
+  const { activities, streams, frozenNow = "2026-06-04T12:00:00" } = opts;
+  return {
+    fixture: {
+      activities: activities.map((a) => ({
+        moving_time: 1800,
+        elapsed_time: 1800,
+        type: "Ride",
+        ...a,
+      })),
+      wellness: [],
+      ftp_history: [],
+      ...(streams ? { streams } : {}),
+    },
+    frozenNow,
+  } as unknown as MetricInput;
+}
+
+// Reproduces one synthetic dfa-equipped stream: 1800 samples split 600/600/600
+// across dfa_a1 = 1.0 / 0.75 / 0.5, with matching HR (138/152/166) and watts
+// (175/218/255) plateaus and zero artifacts — a sufficient, steady cycling
+// session. The 1.0 plateau lands in the LT1 crossing band (0.95-1.05), the 0.5
+// plateau in the LT2 band (0.45-0.55), each well past the 60s dwell gate.
+function syntheticDfaStream(): ActivityStreams {
+  const rep = (v: number, n: number): number[] => Array.from({ length: n }, () => v);
+  return {
+    dfa_a1: [...rep(1.0, 600), ...rep(0.75, 600), ...rep(0.5, 600)],
+    artifacts: rep(0, 1800),
+    heartrate: [...rep(138, 600), ...rep(152, 600), ...rep(166, 600)],
+    watts: [...rep(175, 600), ...rep(218, 600), ...rep(255, 600)],
+  };
+}
+
+describe("buildDfaBlock", () => {
+  it("absent dfa_a1 channel → null (no AlphaHRV recording)", () => {
+    expect(buildDfaBlock({ heartrate: [140, 141], watts: [200, 201] })).toBeNull();
+    expect(buildDfaBlock({ dfa_a1: [] })).toBeNull();
+  });
+
+  it("too short → block with quality.sufficient=false and all-null rollups", () => {
+    // 100 valid seconds < DFA_MIN_DURATION_SECS (1200).
+    const block = buildDfaBlock({
+      dfa_a1: Array.from({ length: 100 }, () => 0.8),
+      artifacts: Array.from({ length: 100 }, () => 0),
+    });
+    expect(block).not.toBeNull();
+    expect(block!.quality.sufficient).toBe(false);
+    expect(block!.quality.valid_secs).toBe(100);
+    expect(block!.avg).toBeNull();
+    expect(block!.tiz_lt1_transition).toBeNull();
+    expect(block!.lt1_crossing).toBeNull();
+  });
+
+  it("sentinel zeros (<0.01) and high-artifact seconds are filtered jointly", () => {
+    const block = buildDfaBlock({
+      dfa_a1: [0.0, 0.8, 0.8, 0.8],
+      artifacts: [0, 0, 99, 0], // 3rd second dropped on artifact gate
+    });
+    // 2 valid of 4 → valid_pct round(100*2/4,1)=50.0; artifact_rate_avg
+    // round((0+0+99+0)/4,2)=24.75 over all 4 (artifact sum counts every second).
+    expect(block!.quality.valid_secs).toBe(2);
+    expect(block!.quality.valid_pct).toBe(50);
+    expect(block!.quality.artifact_rate_avg).toBe(24.75);
+  });
+
+  it("sufficient steady session → avg + band/crossing rollups (banker's rounding)", () => {
+    const block = buildDfaBlock(syntheticDfaStream());
+    expect(block!.quality.sufficient).toBe(true);
+    expect(block!.quality.valid_pct).toBe(100);
+    // avg = round((600·1 + 600·0.75 + 600·0.5)/1800, 3) = round(0.75, 3)
+    expect(block!.avg).toBe(0.75);
+    // tiz bands: 1.0 → below_lt1 is d>1.0 (none); 1.0 falls in lt1_transition
+    // (0.75<=d<=1.0) along with the 0.75 plateau → 1200/1800 = 66.7%.
+    expect(block!.tiz_below_lt1).toBeNull();
+    expect(block!.tiz_lt1_transition!.pct).toBe(66.7);
+    expect(block!.tiz_transition_lt2!.pct).toBe(33.3); // the 0.5 plateau
+    expect(block!.tiz_above_lt2).toBeNull();
+    // LT1 crossing band 0.95-1.05 catches the 1.0 plateau (600s ≥ 60 dwell).
+    expect(block!.lt1_crossing).toEqual({ secs_in_band: 600, avg_hr: 138, avg_watts: 175 });
+    // LT2 crossing band 0.45-0.55 catches the 0.5 plateau.
+    expect(block!.lt2_crossing).toEqual({ secs_in_band: 600, avg_hr: 166, avg_watts: 255 });
+  });
+});
+
+describe("computeDfaA1Profile", () => {
+  it("no streams → null profile (the 12-fixture branch)", () => {
+    expect(
+      computeDfaA1Profile(
+        dfaInput({ activities: [{ id: 1, start_date_local: "2026-06-03T07:00:00" }] }),
+      ),
+    ).toBeNull();
+  });
+
+  it("streams present but no dfa_a1 channel anywhere → null", () => {
+    expect(
+      computeDfaA1Profile(
+        dfaInput({
+          activities: [{ id: 1, start_date_local: "2026-06-03T07:00:00" }],
+          streams: { "1": { heartrate: [140], watts: [200] } },
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it("seven sufficient cycling sessions → high confidence, watts split outdoor", () => {
+    const dates = [
+      "2026-05-28",
+      "2026-05-29",
+      "2026-05-30",
+      "2026-05-31",
+      "2026-06-01",
+      "2026-06-02",
+      "2026-06-03",
+    ];
+    const ids = [90201, 90202, 90203, 90204, 90205, 90206, 90207];
+    const activities = ids.map((id, i) => ({
+      id,
+      start_date_local: `${dates[i]}T07:00:00`,
+      type: "Ride",
+      name: "synthetic-dfa-ride",
+    }));
+    const streams: Record<string, ActivityStreams> = {};
+    for (const id of ids) streams[String(id)] = syntheticDfaStream();
+
+    const profile = computeDfaA1Profile(dfaInput({ activities, streams }))!;
+
+    expect(profile.latest_session).toMatchObject({
+      activity_id: 90207,
+      date: "2026-06-03",
+      sport: "Ride",
+      validated: true,
+      avg: 0.75,
+      drift_delta: -0.5,
+      drift_interpretable: true,
+      quality_pct: 100,
+      sufficient: true,
+      tiz_split_pct: { below_lt1: 0, lt1_transition: 66.7, transition_lt2: 33.3, above_lt2: 0 },
+    });
+
+    const cycling = profile.trailing_by_sport.cycling!;
+    expect(cycling.confidence).toBe("high");
+    expect(cycling.n_sessions).toBe(7);
+    expect(cycling.avg_dfa_a1).toBe(0.75);
+    expect(cycling.date_range).toEqual(["2026-05-28", "2026-06-03"]);
+    expect(cycling.validated).toBe(true);
+    expect(cycling).not.toHaveProperty("note");
+    expect(cycling.lt1_estimate).toEqual({
+      hr: 138,
+      watts_outdoor: 175,
+      watts_indoor: null,
+      n_sessions: 7,
+      n_sessions_outdoor: 7,
+      n_sessions_indoor: 0,
+    });
+    expect(cycling.lt2_estimate).toEqual({
+      hr: 166,
+      watts_outdoor: 255,
+      watts_indoor: null,
+      n_sessions: 7,
+      n_sessions_outdoor: 7,
+      n_sessions_indoor: 0,
+    });
+  });
+
+  it("non-cycling family → pooled watts + validated=false with the informational note", () => {
+    const dates = [
+      "2026-05-28",
+      "2026-05-29",
+      "2026-05-30",
+      "2026-05-31",
+      "2026-06-01",
+      "2026-06-02",
+    ];
+    const activities = dates.map((d, i) => ({
+      id: 70001 + i,
+      start_date_local: `${d}T07:00:00`,
+      type: "Rowing",
+      name: "synthetic-dfa-row",
+    }));
+    const streams: Record<string, ActivityStreams> = {};
+    for (const a of activities) streams[String(a.id)] = syntheticDfaStream();
+
+    const profile = computeDfaA1Profile(dfaInput({ activities, streams }))!;
+    const rowing = profile.trailing_by_sport.rowing!;
+    expect(rowing.validated).toBe(false);
+    expect(rowing.confidence).toBe("high"); // 6 crossing sessions
+    const lt1 = rowing.lt1_estimate as { hr: number; watts: number; n_sessions: number };
+    expect(lt1).toEqual({ hr: 138, watts: 175, n_sessions: 6 });
+    expect(rowing.note).toContain("cycling-validated");
+    // latest_session for a non-cycling sport is validated=false too.
+    expect(profile.latest_session.validated).toBe(false);
+  });
+
+  it("only insufficient sessions → latest_session sufficient=false, no trailing block", () => {
+    // 100 valid seconds is below the 1200s sufficiency floor.
+    const shortStream: ActivityStreams = {
+      dfa_a1: Array.from({ length: 100 }, () => 0.8),
+      artifacts: Array.from({ length: 100 }, () => 0),
+      heartrate: Array.from({ length: 100 }, () => 140),
+      watts: Array.from({ length: 100 }, () => 200),
+    };
+    const profile = computeDfaA1Profile(
+      dfaInput({
+        activities: [
+          { id: 1, start_date_local: "2026-06-01T07:00:00", name: "short-a" },
+          { id: 2, start_date_local: "2026-06-03T07:00:00", name: "short-b" },
+        ],
+        streams: { "1": shortStream, "2": shortStream },
+      }),
+    )!;
+    expect(profile.latest_session).toMatchObject({
+      activity_id: 2, // most recent
+      sufficient: false,
+      avg: null,
+      tiz_split_pct: null,
+    });
+    expect(profile.trailing_by_sport).toEqual({});
   });
 });

--- a/packages/core/src/reference/metrics/capability.ts
+++ b/packages/core/src/reference/metrics/capability.ts
@@ -18,6 +18,7 @@ import {
   getAthlete,
   getHrCurves,
   getPowerCurves,
+  getStreams,
   getSustainabilityCurves,
   getWellness,
   type MetricInput,
@@ -28,6 +29,7 @@ import { mean, pythonSum } from "./statistics.js";
 import { roundHalfEven } from "./rounding.js";
 import type {
   Activity,
+  ActivityStreams,
   AthleteSettings,
   HrCurveData,
   PowerCurveData,
@@ -1202,4 +1204,636 @@ function hrCurveById(
     if (c.id === curveId) match = c;
   }
   return match;
+}
+
+// ─── DFA a1 profile ────────────────────────────────────────────────────────
+
+// Per-session DFA a1 interpretation thresholds (sync.py:273-284). The 1.0/0.5
+// mapping is cycling-validated; other sports get rollups but validated=false.
+const DFA_LT1 = 1.0;
+const DFA_LT2 = 0.5;
+const DFA_LT1_BAND = 0.05;
+const DFA_LT2_BAND = 0.05;
+const DFA_MIN_CROSSING_DWELL_SECS = 60;
+const DFA_ARTIFACT_MAX_PCT = 5.0;
+const DFA_MIN_VALID_VALUE = 0.01;
+const DFA_MIN_DURATION_SECS = 1200;
+const DFA_SUFFICIENT_MIN_VALID_PCT = 70.0;
+const DFA_DRIFT_INTERPRETABLE_MAX_LT2_PCT = 15.0;
+const DFA_TRAILING_WINDOW_N = 7;
+const DFA_VALIDATED_SPORTS = new Set(["cycling"]);
+
+interface DfaBandStats {
+  secs: number;
+  pct: number;
+  avg_hr: number | null;
+  avg_watts: number | null;
+}
+
+interface DfaDrift {
+  first_third_avg: number;
+  last_third_avg: number;
+  delta: number;
+  interpretable: boolean;
+}
+
+interface DfaCrossing {
+  secs_in_band: number;
+  avg_hr: number | null;
+  avg_watts: number | null;
+}
+
+interface DfaQuality {
+  valid_secs: number;
+  total_secs: number;
+  valid_pct: number;
+  artifact_rate_avg: number | null;
+  sufficient: boolean;
+}
+
+interface DfaBlock {
+  avg: number | null;
+  p25: number | null;
+  p50: number | null;
+  p75: number | null;
+  tiz_below_lt1: DfaBandStats | null;
+  tiz_lt1_transition: DfaBandStats | null;
+  tiz_transition_lt2: DfaBandStats | null;
+  tiz_above_lt2: DfaBandStats | null;
+  drift: DfaDrift | null;
+  lt1_crossing: DfaCrossing | null;
+  lt2_crossing: DfaCrossing | null;
+  quality: DfaQuality;
+}
+
+// Per-interval DFA activity entry, the shape the snapshot harness assembles
+// into the upstream's `_intervals_data['activities']` before
+// `_calculate_dfa_a1_profile` reads it. `dfa` is the block from
+// `_compute_dfa_block`.
+interface DfaActivity {
+  activity_id: number | string | null;
+  date: string;
+  type: string;
+  name: string;
+  dfa: DfaBlock;
+}
+
+// Indoor cycling activity types (sync.py:315) and the resolver (sync.py:317-320).
+// A second copy of the sustainability-profile constant lives above; kept local
+// to each metric to mirror the single upstream class method without coupling the
+// two ports.
+const DFA_INDOOR_CYCLING_TYPES = new Set(["VirtualRide"]);
+function dfaIsIndoorCycling(activityType: string): boolean {
+  return DFA_INDOOR_CYCLING_TYPES.has(activityType);
+}
+
+/**
+ * Per-session DFA a1 rollup from raw streams. Mirrors `_compute_dfa_block`
+ * (sync.py:944-1124) line-by-line.
+ *
+ * Returns null when the `dfa_a1` channel is absent entirely (AlphaHRV did not
+ * record). When present but insufficient (too short, too noisy) returns a block
+ * with `quality.sufficient=false` and all-null rollups so the caller can tell
+ * "no AlphaHRV" (null) from "ran but unusable" (block, sufficient=false).
+ *
+ * Filtering (in order): drop seconds where dfa_a1 < 0.01 (AlphaHRV sentinel
+ * zeros), then drop seconds where artifacts % > 5 (Altini convention). Both
+ * filters apply jointly to dfa_a1/hr/watts so they stay index-aligned.
+ *
+ * Numerically sensitive: every `round()` site mirrors Python banker's rounding
+ * via `roundHalfEven`; `sum()` over the float dfa values uses the compensated
+ * `pythonSum` to match CPython 3.12+. See `NOTICE.md` for upstream attribution.
+ */
+export function buildDfaBlock(streams: ActivityStreams): DfaBlock | null {
+  const dfaStream = streams.dfa_a1;
+  if (!dfaStream || dfaStream.length === 0) {
+    return null; // no AlphaHRV recording on this activity
+  }
+
+  const n = dfaStream.length;
+  const filled = <T>(value: T): T[] => Array.from({ length: n }, () => value);
+  let artifactsStream: (number | null)[] = streams.artifacts ?? filled<number | null>(0.0);
+  let hrStream: (number | null)[] = streams.heartrate ?? filled<number | null>(null);
+  let wattsStream: (number | null)[] = streams.watts ?? filled<number | null>(null);
+
+  // Align all streams to dfa_a1 length (defensive — should already match).
+  if (artifactsStream.length !== n) {
+    artifactsStream = artifactsStream.concat(filled<number | null>(0.0)).slice(0, n);
+  }
+  if (hrStream.length !== n) {
+    hrStream = hrStream.concat(filled<number | null>(null)).slice(0, n);
+  }
+  if (wattsStream.length !== n) {
+    wattsStream = wattsStream.concat(filled<number | null>(null)).slice(0, n);
+  }
+
+  const validDfa: number[] = [];
+  const validHr: (number | null)[] = [];
+  const validWatts: (number | null)[] = [];
+  let artifactSum = 0.0;
+  let artifactCount = 0;
+  for (let i = 0; i < n; i++) {
+    const d = dfaStream[i]!;
+    const a = artifactsStream[i]!;
+    if (a !== null) {
+      artifactSum += a;
+      artifactCount += 1;
+    }
+    if (d === null || d < DFA_MIN_VALID_VALUE) continue;
+    if (a !== null && a > DFA_ARTIFACT_MAX_PCT) continue;
+    validDfa.push(d);
+    validHr.push(hrStream[i]!);
+    validWatts.push(wattsStream[i]!);
+  }
+
+  const validSecs = validDfa.length;
+  const totalSecs = n;
+  const validPct = totalSecs ? roundHalfEven((100.0 * validSecs) / totalSecs, 1) : 0.0;
+  const artifactRateAvg = artifactCount
+    ? roundHalfEven(artifactSum / artifactCount, 2)
+    : null;
+  const sufficient =
+    validSecs >= DFA_MIN_DURATION_SECS && validPct >= DFA_SUFFICIENT_MIN_VALID_PCT;
+
+  const quality: DfaQuality = {
+    valid_secs: validSecs,
+    total_secs: totalSecs,
+    valid_pct: validPct,
+    artifact_rate_avg: artifactRateAvg,
+    sufficient,
+  };
+
+  if (!sufficient) {
+    return {
+      avg: null,
+      p25: null,
+      p50: null,
+      p75: null,
+      tiz_below_lt1: null,
+      tiz_lt1_transition: null,
+      tiz_transition_lt2: null,
+      tiz_above_lt2: null,
+      drift: null,
+      lt1_crossing: null,
+      lt2_crossing: null,
+      quality,
+    };
+  }
+
+  const sortedDfa = [...validDfa].sort((x, y) => x - y);
+  const avg = roundHalfEven(pythonSum(validDfa) / validSecs, 3);
+  const p25 = roundHalfEven(sortedDfa[Math.floor(validSecs / 4)]!, 3);
+  const p50 = roundHalfEven(sortedDfa[Math.floor(validSecs / 2)]!, 3);
+  const p75 = roundHalfEven(sortedDfa[Math.floor((validSecs * 3) / 4)]!, 3);
+
+  const bandStats = (predicate: (d: number) => boolean): DfaBandStats | null => {
+    let secs = 0;
+    let hrSum = 0;
+    let hrN = 0;
+    let wSum = 0;
+    let wN = 0;
+    for (let i = 0; i < validSecs; i++) {
+      if (predicate(validDfa[i]!)) {
+        secs += 1;
+        if (validHr[i] !== null) {
+          hrSum += validHr[i]!;
+          hrN += 1;
+        }
+        if (validWatts[i] !== null) {
+          wSum += validWatts[i]!;
+          wN += 1;
+        }
+      }
+    }
+    if (secs === 0) return null;
+    return {
+      secs,
+      pct: roundHalfEven((100.0 * secs) / validSecs, 1),
+      avg_hr: hrN ? roundHalfEven(hrSum / hrN, 0) : null,
+      avg_watts: wN ? roundHalfEven(wSum / wN, 0) : null,
+    };
+  };
+
+  const tizBelowLt1 = bandStats((d) => d > DFA_LT1);
+  const tizLt1Transition = bandStats((d) => 0.75 <= d && d <= DFA_LT1);
+  const tizTransitionLt2 = bandStats((d) => DFA_LT2 <= d && d < 0.75);
+  const tizAboveLt2 = bandStats((d) => d < DFA_LT2);
+
+  // Drift: first-third vs last-third of valid data.
+  const third = Math.floor(validSecs / 3);
+  let drift: DfaDrift | null;
+  if (third >= 60) {
+    const firstThird = validDfa.slice(0, third);
+    const lastThird = validDfa.slice(validSecs - third);
+    const firstAvg = roundHalfEven(pythonSum(firstThird) / firstThird.length, 3);
+    const lastAvg = roundHalfEven(pythonSum(lastThird) / lastThird.length, 3);
+    const driftDelta = roundHalfEven(lastAvg - firstAvg, 3);
+    const aboveLt2Pct = tizAboveLt2 ? tizAboveLt2.pct : 0.0;
+    const interpretable = aboveLt2Pct <= DFA_DRIFT_INTERPRETABLE_MAX_LT2_PCT;
+    drift = {
+      first_third_avg: firstAvg,
+      last_third_avg: lastAvg,
+      delta: driftDelta,
+      interpretable,
+    };
+  } else {
+    drift = null;
+  }
+
+  // LT1 / LT2 crossing-band estimates.
+  const crossingStats = (center: number, band: number): DfaCrossing => {
+    const lo = center - band;
+    const hi = center + band;
+    let secs = 0;
+    let hrSum = 0;
+    let hrN = 0;
+    let wSum = 0;
+    let wN = 0;
+    for (let i = 0; i < validSecs; i++) {
+      if (lo <= validDfa[i]! && validDfa[i]! <= hi) {
+        secs += 1;
+        if (validHr[i] !== null) {
+          hrSum += validHr[i]!;
+          hrN += 1;
+        }
+        if (validWatts[i] !== null) {
+          wSum += validWatts[i]!;
+          wN += 1;
+        }
+      }
+    }
+    if (secs < DFA_MIN_CROSSING_DWELL_SECS) {
+      return { secs_in_band: secs, avg_hr: null, avg_watts: null };
+    }
+    return {
+      secs_in_band: secs,
+      avg_hr: hrN ? roundHalfEven(hrSum / hrN, 0) : null,
+      avg_watts: wN ? roundHalfEven(wSum / wN, 0) : null,
+    };
+  };
+
+  const lt1Crossing = crossingStats(DFA_LT1, DFA_LT1_BAND);
+  const lt2Crossing = crossingStats(DFA_LT2, DFA_LT2_BAND);
+
+  return {
+    avg,
+    p25,
+    p50,
+    p75,
+    tiz_below_lt1: tizBelowLt1,
+    tiz_lt1_transition: tizLt1Transition,
+    tiz_transition_lt2: tizTransitionLt2,
+    tiz_above_lt2: tizAboveLt2,
+    drift,
+    lt1_crossing: lt1Crossing,
+    lt2_crossing: lt2Crossing,
+    quality,
+  };
+}
+
+// Streams-assembly path the snapshot harness runs before
+// `_calculate_dfa_a1_profile`: join each activity to its stream record by
+// `String(id)`, keep records that carry a `dfa_a1` channel, run each through
+// `buildDfaBlock`, and collect the per-interval activity entries the profile
+// reads. The upstream stores these on `_intervals_data`; here they are passed
+// directly. Absent streams (or no qualifying record) yield an empty list, which
+// the profile maps to null.
+function assembleDfaActivities(input: MetricInput): DfaActivity[] {
+  const streams = getStreams(input);
+  if (Object.keys(streams).length === 0) return [];
+
+  const out: DfaActivity[] = [];
+  for (const act of getActivities(input)) {
+    const rec = streams[String(act.id)];
+    if (!rec || !rec.dfa_a1 || rec.dfa_a1.length === 0) continue;
+    const block = buildDfaBlock(rec);
+    if (block === null) continue;
+    // `name` is a loose ride-through field (not in ActivitySchema's typed
+    // surface). Mirror the harness's `_sact.get("name", "")` default.
+    const name = (act as { name?: string }).name ?? "";
+    out.push({
+      activity_id: act.id,
+      date: act.start_date_local.slice(0, 10),
+      type: act.type,
+      name,
+      dfa: block,
+    });
+  }
+  return out;
+}
+
+interface DfaLatestSession {
+  activity_id: number | string | null;
+  date: string;
+  name: string;
+  sport: string;
+  validated: boolean;
+  avg: number | null;
+  tiz_split_pct: Record<string, number> | null;
+  drift_delta: number | null;
+  drift_interpretable: boolean | null;
+  quality_pct: number | null;
+  sufficient: boolean;
+}
+
+interface DfaThresholdEstimateCycling {
+  hr: number | null;
+  watts_outdoor: number | null;
+  watts_indoor: number | null;
+  n_sessions: number;
+  n_sessions_outdoor: number;
+  n_sessions_indoor: number;
+}
+
+interface DfaThresholdEstimatePooled {
+  hr: number | null;
+  watts: number | null;
+  n_sessions: number;
+}
+
+interface DfaSportBlock {
+  n_sessions: number;
+  date_range: [string | null, string | null];
+  avg_dfa_a1: number | null;
+  drift_delta_mean: number | null;
+  lt1_crossing_sessions: number;
+  lt2_crossing_sessions: number;
+  lt1_estimate: DfaThresholdEstimateCycling | DfaThresholdEstimatePooled | null;
+  lt2_estimate: DfaThresholdEstimateCycling | DfaThresholdEstimatePooled | null;
+  quality_avg_pct: number;
+  validated: boolean;
+  confidence: "high" | "moderate" | "low" | null;
+  note?: string;
+}
+
+export interface DfaA1Profile {
+  latest_session: DfaLatestSession;
+  trailing_by_sport: Record<string, DfaSportBlock>;
+}
+
+/**
+ * DFA a1 profile for the capability block. Mirrors `_calculate_dfa_a1_profile`
+ * (sync.py:4588-4802) line-by-line, fed by the streams-assembly path the harness
+ * runs before the call (`assembleDfaActivities`).
+ *
+ * Returns:
+ *   - latest_session: most recent activity with a sufficient dfa block (any
+ *     sport); falls back to the most recent insufficient one so the caller sees
+ *     "AlphaHRV ran but unusable" instead of "no data".
+ *   - trailing_by_sport: per sport family, aggregated rollups across the latest
+ *     DFA_TRAILING_WINDOW_N sufficient sessions, with confidence + validated
+ *     flags and crossing-band LT1/LT2 estimates (cycling splits watts by
+ *     indoor/outdoor environment; other sports keep pooled watts).
+ *
+ * Returns null when no stream record carries a dfa_a1 channel — mirroring the
+ * upstream's "no intervals data / no DFA-equipped sessions" null return.
+ *
+ * Numerically sensitive: every `round()` mirrors Python banker's rounding via
+ * `roundHalfEven` (including the no-arg `round(x)` int form ported as
+ * `roundHalfEven(x, 0)`); float `sum()` over avg/drift values uses the
+ * compensated `pythonSum`. Integer floor division `//` is `Math.floor` (all
+ * operands non-negative). See `NOTICE.md` for upstream attribution.
+ *
+ * @see Rowlands, D. S. et al. (2017); Gronwald, T. & Hoos, O. (2020);
+ *      Mateo-March, M. et al. (2023) — cycling DFA a1 threshold validation.
+ */
+export function computeDfaA1Profile(input: MetricInput): DfaA1Profile | null {
+  const activities = assembleDfaActivities(input);
+  // Keep only activities with a dfa block, most recent first.
+  const dfaActivities = activities.filter((a) => a.dfa !== null);
+  if (dfaActivities.length === 0) return null;
+  // Stable descending sort by date, mirroring Python's stable list.sort.
+  const ordered = [...dfaActivities]
+    .map((a, i) => ({ a, i }))
+    .sort((x, y) => {
+      const dx = x.a.date ?? "";
+      const dy = y.a.date ?? "";
+      if (dx < dy) return 1;
+      if (dx > dy) return -1;
+      return x.i - y.i;
+    })
+    .map((e) => e.a);
+
+  // --- latest_session: most recent SUFFICIENT session ---
+  let latestSession: DfaLatestSession | null = null;
+  for (const a of ordered) {
+    const block = a.dfa;
+    const quality = block.quality;
+    if (quality.sufficient) {
+      const tizSplit: Record<string, number> = {};
+      const tizPairs: [keyof DfaBlock, string][] = [
+        ["tiz_below_lt1", "below_lt1"],
+        ["tiz_lt1_transition", "lt1_transition"],
+        ["tiz_transition_lt2", "transition_lt2"],
+        ["tiz_above_lt2", "above_lt2"],
+      ];
+      for (const [key, label] of tizPairs) {
+        const band = block[key] as DfaBandStats | null;
+        tizSplit[label] = band ? band.pct : 0.0;
+      }
+      const drift = block.drift ?? null;
+      latestSession = {
+        activity_id: a.activity_id,
+        date: a.date,
+        name: a.name,
+        sport: a.type,
+        validated: DFA_VALIDATED_SPORTS.has(SPORT_FAMILIES[a.type] ?? ""),
+        avg: block.avg,
+        tiz_split_pct: tizSplit,
+        drift_delta: drift ? drift.delta : null,
+        drift_interpretable: drift ? drift.interpretable : null,
+        quality_pct: quality.valid_pct,
+        sufficient: true,
+      };
+      break;
+    }
+  }
+
+  if (latestSession === null) {
+    const a = ordered[0]!;
+    latestSession = {
+      activity_id: a.activity_id,
+      date: a.date,
+      name: a.name,
+      sport: a.type,
+      validated: DFA_VALIDATED_SPORTS.has(SPORT_FAMILIES[a.type] ?? ""),
+      avg: null,
+      tiz_split_pct: null,
+      drift_delta: null,
+      drift_interpretable: null,
+      quality_pct: a.dfa.quality.valid_pct,
+      sufficient: false,
+    };
+  }
+
+  // --- trailing_by_sport: per-sport aggregation across last N sufficient sessions ---
+  const trailingBySport: Record<string, DfaSportBlock> = {};
+  const byFamily = new Map<string, DfaActivity[]>();
+  for (const a of ordered) {
+    if (!a.dfa.quality.sufficient) continue;
+    const family = SPORT_FAMILIES[a.type] ?? "other";
+    if (!byFamily.has(family)) byFamily.set(family, []);
+    byFamily.get(family)!.push(a);
+  }
+
+  for (const [family, acts] of byFamily) {
+    const window = acts.slice(0, DFA_TRAILING_WINDOW_N);
+    const n = window.length;
+    if (n === 0) continue;
+
+    const avgDfaValues = window
+      .map((a) => a.dfa.avg)
+      .filter((v): v is number => v !== null && v !== undefined);
+    const avgDfa = avgDfaValues.length
+      ? roundHalfEven(pythonSum(avgDfaValues) / avgDfaValues.length, 3)
+      : null;
+    const driftValues = window
+      .filter(
+        (a) =>
+          a.dfa.drift &&
+          a.dfa.drift.interpretable &&
+          a.dfa.drift.delta !== null &&
+          a.dfa.drift.delta !== undefined,
+      )
+      .map((a) => a.dfa.drift!.delta);
+    const driftMean = driftValues.length
+      ? roundHalfEven(pythonSum(driftValues) / driftValues.length, 3)
+      : null;
+
+    // Threshold estimates from crossing bands — only sessions with sufficient dwell.
+    const avgCrossing = (
+      key: "lt1_crossing" | "lt2_crossing",
+      field: "avg_hr" | "avg_watts",
+      subset?: DfaActivity[],
+    ): [number | null, number] => {
+      const source = subset ?? window;
+      const vals: number[] = [];
+      for (const a of source) {
+        const cb = a.dfa[key];
+        if (cb && cb.secs_in_band >= DFA_MIN_CROSSING_DWELL_SECS) {
+          const v = cb[field];
+          if (v !== null && v !== undefined) vals.push(v);
+        }
+      }
+      if (vals.length === 0) return [null, 0];
+      return [roundHalfEven(pythonSum(vals) / vals.length, 0), vals.length];
+    };
+
+    // HR estimates — pooled across all sessions.
+    const [lt1Hr, lt1NHr] = avgCrossing("lt1_crossing", "avg_hr");
+    const [lt2Hr, lt2NHr] = avgCrossing("lt2_crossing", "avg_hr");
+
+    const isCycling = family === "cycling";
+    let lt1Watts: number | null = null;
+    let lt2Watts: number | null = null;
+    let lt1NW = 0;
+    let lt2NW = 0;
+    let lt1WattsOut: number | null = null;
+    let lt1WattsIn: number | null = null;
+    let lt2WattsOut: number | null = null;
+    let lt2WattsIn: number | null = null;
+    let lt1NWOut = 0;
+    let lt1NWIn = 0;
+    let lt2NWOut = 0;
+    let lt2NWIn = 0;
+    if (isCycling) {
+      const indoor = window.filter((a) => dfaIsIndoorCycling(a.type));
+      const outdoor = window.filter((a) => !dfaIsIndoorCycling(a.type));
+      [lt1WattsOut, lt1NWOut] = avgCrossing("lt1_crossing", "avg_watts", outdoor);
+      [lt1WattsIn, lt1NWIn] = avgCrossing("lt1_crossing", "avg_watts", indoor);
+      [lt2WattsOut, lt2NWOut] = avgCrossing("lt2_crossing", "avg_watts", outdoor);
+      [lt2WattsIn, lt2NWIn] = avgCrossing("lt2_crossing", "avg_watts", indoor);
+      lt1NW = lt1NWOut + lt1NWIn;
+      lt2NW = lt2NWOut + lt2NWIn;
+    } else {
+      [lt1Watts, lt1NW] = avgCrossing("lt1_crossing", "avg_watts");
+      [lt2Watts, lt2NW] = avgCrossing("lt2_crossing", "avg_watts");
+    }
+
+    const lt1CrossingSessions = window.filter(
+      (a) => (a.dfa.lt1_crossing?.secs_in_band ?? 0) >= DFA_MIN_CROSSING_DWELL_SECS,
+    ).length;
+    const lt2CrossingSessions = window.filter(
+      (a) => (a.dfa.lt2_crossing?.secs_in_band ?? 0) >= DFA_MIN_CROSSING_DWELL_SECS,
+    ).length;
+
+    const crossingN = Math.max(lt1NHr, lt1NW, lt2NHr, lt2NW);
+    let confidence: "high" | "moderate" | "low" | null;
+    if (crossingN >= 6) confidence = "high";
+    else if (crossingN >= 4) confidence = "moderate";
+    else if (crossingN >= 3) confidence = "low";
+    else confidence = null;
+
+    const qualityAvg = roundHalfEven(
+      pythonSum(window.map((a) => a.dfa.quality.valid_pct)) / n,
+      1,
+    );
+
+    const validated = DFA_VALIDATED_SPORTS.has(family);
+
+    let lt1Est: DfaThresholdEstimateCycling | DfaThresholdEstimatePooled | null;
+    let lt2Est: DfaThresholdEstimateCycling | DfaThresholdEstimatePooled | null;
+    if (isCycling) {
+      lt1Est = confidence
+        ? {
+            hr: lt1Hr,
+            watts_outdoor: lt1WattsOut,
+            watts_indoor: lt1WattsIn,
+            n_sessions: Math.max(lt1NHr, lt1NW),
+            n_sessions_outdoor: lt1NWOut,
+            n_sessions_indoor: lt1NWIn,
+          }
+        : null;
+      lt2Est = confidence
+        ? {
+            hr: lt2Hr,
+            watts_outdoor: lt2WattsOut,
+            watts_indoor: lt2WattsIn,
+            n_sessions: Math.max(lt2NHr, lt2NW),
+            n_sessions_outdoor: lt2NWOut,
+            n_sessions_indoor: lt2NWIn,
+          }
+        : null;
+    } else {
+      lt1Est = confidence
+        ? {
+            hr: lt1Hr,
+            watts: lt1Watts,
+            n_sessions: Math.max(lt1NHr, lt1NW),
+          }
+        : null;
+      lt2Est = confidence
+        ? {
+            hr: lt2Hr,
+            watts: lt2Watts,
+            n_sessions: Math.max(lt2NHr, lt2NW),
+          }
+        : null;
+    }
+
+    const sportBlock: DfaSportBlock = {
+      n_sessions: n,
+      date_range: [window[n - 1]!.date ?? null, window[0]!.date ?? null],
+      avg_dfa_a1: avgDfa,
+      drift_delta_mean: driftMean,
+      lt1_crossing_sessions: lt1CrossingSessions,
+      lt2_crossing_sessions: lt2CrossingSessions,
+      lt1_estimate: lt1Est,
+      lt2_estimate: lt2Est,
+      quality_avg_pct: qualityAvg,
+      validated,
+      confidence,
+    };
+    if (!validated) {
+      sportBlock.note =
+        `DFA a1 threshold mapping (1.0/0.5) is cycling-validated. ` +
+        `${family} thresholds may differ — treat estimates as informational only.`;
+    }
+    trailingBySport[family] = sportBlock;
+  }
+
+  return {
+    latest_session: latestSession,
+    trailing_by_sport: trailingBySport,
+  };
 }

--- a/packages/core/src/reference/metrics/metric-input.ts
+++ b/packages/core/src/reference/metrics/metric-input.ts
@@ -1,5 +1,6 @@
 import type {
   Activity,
+  ActivityStreams,
   AthleteSettings,
   FixtureShape,
   HrCurveData,
@@ -146,4 +147,15 @@ export function getSustainabilityCurves(
   input: MetricInput,
 ): Record<string, SustainabilityFamilyCurves> {
   return input.fixture.sustainability_curves ?? {};
+}
+
+// The per-second stream record bundle, keyed by `String(activity.id)`. The
+// dfa-profile path joins this back to the activities array (both sides coerce
+// id to string), runs each qualifying record through the per-session DFA block,
+// and reads the result as the trailing-window source. Its presence gates the
+// whole profile — the harness leaves the upstream's `_intervals_data` empty when
+// no stream record carries a `dfa_a1` channel, so absent streams reproduce the
+// null profile byte-for-byte. Returns the empty record when absent.
+export function getStreams(input: MetricInput): Record<string, ActivityStreams> {
+  return input.fixture.streams ?? {};
 }

--- a/packages/core/src/reference/metrics/registry.ts
+++ b/packages/core/src/reference/metrics/registry.ts
@@ -10,6 +10,7 @@
 
 import { computeWeightSignal } from "./bodycomp.js";
 import {
+  computeDfaA1Profile,
   computeDurability,
   computeEfficiencyFactor,
   computeHrCurveDelta,
@@ -103,6 +104,7 @@ export const METRIC_REGISTRY: Record<string, MetricRegistryEntry> = {
   "capability.power_curve_delta": { compute: computePowerCurveDelta },
   "capability.hr_curve_delta": { compute: computeHrCurveDelta },
   "capability.sustainability_profile": { compute: computeSustainabilityProfile },
+  "capability.dfa_a1_profile": { compute: computeDfaA1Profile },
   eftp: { compute: computeEftp },
   w_prime: { compute: computeWPrime },
   w_prime_kj: { compute: computeWPrimeKj },


### PR DESCRIPTION
## Summary

Ports `capability.dfa_a1_profile` — DFA-alpha1 LT1/LT2 threshold estimation from per-second activity streams — into the Reference layer. **Tenth and final Wave-2 curve/stream-gated oracle key.**

- `buildDfaBlock`: per-session DFA block from raw streams — sentinel/artifact filtering, validity gate, percentile + 4-band time-in-zone rollups, first-vs-last-third drift, LT1/LT2 crossing-band HR/watts estimates
- `computeDfaA1Profile`: latest-sufficient-session selection, per-sport-family trailing window with confidence tiers, indoor/outdoor watts split for cycling
- `assembleDfaActivities` mirrors the harness's streams-assembly path; new `getStreams` accessor; registry entry for the sub-key (parent `capability` stays unregistered, Group A pattern)
- Populated on `dfa-equipped` (confidence "high", LT1 141 bpm / 181 W outdoor, LT2 169 bpm / 261 W outdoor); null block on the other 12 fixtures

## Numerical discipline

Stdlib-only upstream (no numpy). Every `round()` site uses `roundHalfEven` (including the no-arg integer form → `roundHalfEven(x, 0)`); all float `sum()` sites use compensated `pythonSum`; floor division → `Math.floor` (non-negative operands); stable descending date sort reproduces Python sort stability via index tie-breaker; conditional key emission matched exactly (cycling block omits `note`, emits `watts_outdoor`/`watts_indoor`; non-cycling emits `note` + pooled `watts`).

## Parity

- `pnpm check-parity --metric=capability.dfa_a1_profile --fixture=all` → 13/13 OK, bit-identical
- Zero snapshot changes
- Full suite: 1679 passed | 5 skipped (pre-existing)

## Faithfulness

Line-by-line transliteration; no deviation-registry entries needed.
