### PR TITLE
chore(tools): exclude stale agent worktrees from test collection

### DIFF
--- a/.changeset/vitest-exclude-stale-worktrees.md
+++ b/.changeset/vitest-exclude-stale-worktrees.md
@@ -1,0 +1,12 @@
+---
+"@enduragent/core": patch
+---
+
+Scope the root test runner's collection to the project tree so stale agent
+worktrees under `.claude/` are no longer crawled. The root vitest config now
+extends vitest's default `exclude` with `**/.claude/**`, so the throwaway copies
+of the suite that live in agent scratch worktrees stop being collected — they had
+been amplifying a known load-dependent flake and adding spurious failures (one
+worktree also carried a missing build artifact). The real suite is unchanged.
+
+Pure dev-tooling change — athletes don't notice.

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "vitest/config";
+import { configDefaults, defineConfig } from "vitest/config";
 
 /**
  * Vite (which vitest is built on) doesn't natively handle `import x from "*.md"`
@@ -8,6 +8,9 @@ import { defineConfig } from "vitest/config";
  * markdown imports resolve to inline default-export strings during vitest runs.
  */
 export default defineConfig({
+  test: {
+    exclude: [...configDefaults.exclude, "**/.claude/**"],
+  },
   plugins: [
     {
       name: "raw-md",


### PR DESCRIPTION
## Summary

The root `vitest.config.ts` had no `test.exclude`, so the runner fell back to vitest's default exclude (`**/node_modules/**`, `**/.git/**` only). That meant throwaway copies of the suite living in agent scratch worktrees under `.claude/worktrees/` were being crawled and collected — 388 stale test files. Those stale copies amplified a known load-dependent flake (the secrets-backend detect test) and contributed spurious failures, including one worktree carrying a missing build artifact.

This extends vitest's default exclude with `**/.claude/**`, following the config's existing TypeScript / `defineConfig` style, so only the project tree is collected. The worktrees themselves are left untouched.

```ts
test: {
  exclude: [...configDefaults.exclude, "**/.claude/**"],
},
```

Single concern: test-collection scope only. No runtime or source behavior changes.

## Test plan

- `pnpm vitest list | grep -c .claude/worktrees` → `0` (was 388 stale files collected before).
- Full run: `pnpm vitest run` → `95` test files, `1708` passed, `2` skipped, and the only failure is the pre-existing `sanitize-cli-fixture-stability.test.ts` stale-golden drift being addressed in a separate lane. The secrets-backend detect test passed (no flake this run).

Note: `--reporter=basic` is not a valid reporter in vitest 4 (it errors `Failed to load url basic`); the default reporter was used for the verification run, which reports the same file/test summary.
