### PR TITLE
fix(tools): mirror benchmark/event kwarg surface in fuzz-parity oracle twin

### DIFF
--- a/.changeset/fuzz-oracle-benchmark-kwargs.md
+++ b/.changeset/fuzz-oracle-benchmark-kwargs.md
@@ -1,0 +1,21 @@
+---
+"@enduragent/core": patch
+---
+
+Mirror the snapshot harness's event/benchmark kwarg surface into the fuzz-parity
+oracle twin. The twin hardcoded `past_events=[]` and `benchmark_indoor` /
+`benchmark_outdoor` to the `(None, None, None)` insufficient-history stub, which
+is false for the populated-benchmark-and-consistency fixture: that fixture
+carries indoor/outdoor FTP history, so the twin's stub fed the null branch while
+the real TS path computed the populated branch, producing a guaranteed false
+MISMATCH on `benchmark_indoor`, `benchmark_outdoor`, `consistency_index`, and
+`consistency_details`. The twin now reads the five optional fixture keys
+(`past_events`, `current_ftp_indoor`/`outdoor`, `ftp_history_indoor`/`outdoor`)
+through the contract tracker — all allowlisted in `optionalFixturePaths` — and
+hands the FTP data to the upstream's own `_calculate_benchmark_index`, matching
+the snapshot harness line-for-line. Absent keys reproduce the prior stub so the
+fixtures carrying none stay byte-identical; the populated branch now actually
+runs. The three harness twins stay independent reimplementations of the same
+logic shape.
+
+Pure dev-time oracle infra — athletes don't notice.

--- a/tools/fuzz-parity.ts
+++ b/tools/fuzz-parity.ts
@@ -195,10 +195,32 @@ def compute(fixture_json):
         sync = IntervalsSync(athlete_id="s", intervals_api_key="k", github_token=None, debug=False)
         sync._intervals_data = {}
         BN = (None, None, None)
+        # Event / benchmark kwargs — mirror the snapshot harness. The fixture is
+        # the boundary: past_events and the indoor/outdoor FTP keys are optional
+        # on every committed fixture (allowlisted in optionalFixturePaths), so an
+        # absent key reproduces the prior stub (past_events=[] / BN) while a
+        # populated fixture hands its FTP data to sync's own
+        # _calculate_benchmark_index. Absent keys keep existing snapshots
+        # byte-identical; populated branches now actually run.
+        _past_events = FIX.get("past_events", []) or []
+        _current_ftp_indoor = FIX.get("current_ftp_indoor")
+        _ftp_history_indoor = FIX.get("ftp_history_indoor") or {}
+        _current_ftp_outdoor = FIX.get("current_ftp_outdoor")
+        _ftp_history_outdoor = FIX.get("ftp_history_outdoor") or {}
+        if _current_ftp_indoor and _ftp_history_indoor:
+            _idx_in, _ftp8_in = sync._calculate_benchmark_index(_current_ftp_indoor, _ftp_history_indoor)
+            _benchmark_indoor = (_idx_in, _ftp8_in, _current_ftp_indoor)
+        else:
+            _benchmark_indoor = BN
+        if _current_ftp_outdoor and _ftp_history_outdoor:
+            _idx_out, _ftp8_out = sync._calculate_benchmark_index(_current_ftp_outdoor, _ftp_history_outdoor)
+            _benchmark_outdoor = (_idx_out, _ftp8_out, _current_ftp_outdoor)
+        else:
+            _benchmark_outdoor = BN
         # Conditional curve / athlete kwargs — mirror the snapshot harness. The
-        # fuzzer perturbs only activities/wellness, so these source keys are
-        # always absent here and every derived kwarg falls back to the stub;
-        # the parallel structure keeps the three stub sites in lockstep.
+        # fuzzer perturbs only activities/wellness, so these curve/athlete source
+        # keys are absent on the perturbed fixtures and every derived kwarg falls
+        # back to the stub; the parallel structure keeps the stub sites in lockstep.
         _pcurves = FIX.get("power_curves")
         _hcurves = FIX.get("hr_curves")
         _scurves = FIX.get("sustainability_curves")
@@ -240,8 +262,8 @@ def compute(fixture_json):
                 sync._intervals_data = {"activities": _dfa_acts}
         derived = sync._calculate_derived_metrics(
             activities_7d=a7, activities_28d=a28, wellness_7d=w7, wellness_extended=w28,
-            current_ctl=cctl, current_atl=catl, current_tsb=ctsb, past_events=[],
-            activities_for_consistency=a7, power_model=_pm, benchmark_indoor=BN, benchmark_outdoor=BN,
+            current_ctl=cctl, current_atl=catl, current_tsb=ctsb, past_events=_past_events,
+            activities_for_consistency=a7, power_model=_pm, benchmark_indoor=_benchmark_indoor, benchmark_outdoor=_benchmark_outdoor,
             vo2max=_vo2, formatted_planned_workouts=[], race_calendar=None, power_curve_data=_pcurves,
             power_curve_dates=_pcd, hr_curve_data=_hcurves, sustainability_curves=_scurves or {}, sustainability_window=_sw,
             sport_settings=_ss, icu_weight=lw.get("weight"))


### PR DESCRIPTION
## Summary

The fuzz-parity oracle twin hardcoded its event/benchmark kwargs to the stub
values: `past_events=[]` and `benchmark_indoor` / `benchmark_outdoor` pinned to
the `(None, None, None)` insufficient-FTP-history path. That assumption is false
for the `populated-benchmark-and-consistency` fixture, which carries indoor and
outdoor FTP history. The twin's stub fed the null branch while the real TS path
computed the populated branch, so the differential reported a **guaranteed false
MISMATCH** on `benchmark_indoor`, `benchmark_outdoor`, `consistency_index`, and
`consistency_details` on every run against that fixture.

This mirrors the conditional block the snapshot harness already ships: the twin
now reads the five optional fixture keys (`past_events`,
`current_ftp_indoor`/`outdoor`, `ftp_history_indoor`/`outdoor`) through the
contract tracker — all allowlisted in `optionalFixturePaths`, so absent-key
reads stay allowlisted — and hands the FTP data to the upstream's own
`_calculate_benchmark_index` to build the benchmark tuples. Absent keys
reproduce the prior stub, so the fixtures carrying none stay byte-identical;
the populated branch now actually runs. No `WORKOUT` pre-filter is added at the
kwarg site — that filtering lives downstream in the upstream code. The stale
"always absent here" comment is updated to reflect that the curve/athlete keys
(not the benchmark keys) are the ones absent on perturbed fixtures.

> Note: the `populated-benchmark-and-consistency` fixture is authored for a
> 2026 frozen-now anchor and must be exercised with `--frozen=2026-05-10T12:00:00`;
> the bare default anchor moves every activity date outside the rolling windows
> and degenerates the populated branch to all-null (still matching, but vacuous).

## Test plan

- `pnpm tsx tools/fuzz-parity.ts --fixture=populated-benchmark-and-consistency --n=20 --seed=7 --frozen=2026-05-10T12:00:00` → OK, all 43 metrics bit-identical (the populated branch now actually runs)
- same WITHOUT `--frozen` (default anchor) → OK, degenerate-but-matching
- `pnpm tsx tools/fuzz-parity.ts --n=5000 --seed=20260525` (committed default n) → OK, all 43 metrics bit-identical across 5000/5000 perturbed fixtures
- `pnpm vitest run tools/` → 109 tests green (verdict tests included)
- `pnpm check` → green (build, lint, trademarks, fixture-privacy)
