### PR TITLE
fix(tests): rebuild capability-qualifying base via new committed builder

### DIFF
--- a/.changeset/capability-fixture-builder.md
+++ b/.changeset/capability-fixture-builder.md
@@ -1,0 +1,18 @@
+---
+"@enduragent/core": patch
+---
+
+Add a committed builder for the `capability-qualifying` Reference test fixture
+and rebuild it from the refreshed realistic-athlete golden. `tools/build-capability-fixture.ts`
+reads the sanitized realistic-athlete base (already id-redacted and shifted to
+the synthetic epoch) and appends the five steady-state qualifying Rides at the
+tail, mirroring the sibling builders: deterministic plain `JSON.stringify`
+output, a committed `.sha256` sidecar, and a non-vacuity guard that recomputes
+the durability reliability gate (>= 3 qualifying Rides in the 7d window, >= 5 in
+the 28d window) so a vacuous capture fails the build. The rebuild brings the
+fixture's 38 base activities onto the current sanitizer field surface (adds the
+`icu_hrr` / `icu_variability_index` fields the refresh introduced) while keeping
+the appended Rides byte-identical. Folds the fixture into the checksum integrity
+test and the PII allowlist scan alongside the other builder-produced goldens.
+
+Internal test-fixture + dev-tooling change; no runtime behavior change.

--- a/packages/core/tests/fixtures/README.md
+++ b/packages/core/tests/fixtures/README.md
@@ -43,7 +43,7 @@ one newly covers (the justification the harness fixture registry records).
 | `golden/multisport-thin-primary.json` | synthetic | `effective_monotony` fallback when primary-sport monotony is null (<3 active days) |
 | `golden/populated-benchmark-and-consistency.json` | synthetic | populated `consistency_index` + `benchmark_indoor`/`benchmark_outdoor` (the +/-7d FTP nearest-match window) |
 | `golden/rest-week-with-baseline.json` | synthetic | monotony `stdev<=0 → null` cascade (strain/stress_tolerance null) + flat HRV/RHR baseline block |
-| `golden/capability-qualifying.json` | synthetic | `_calculate_durability` reliability gate (N7>=3, N28>=5) + efficiency_factor + HRRc means/trends |
+| `golden/capability-qualifying.json` | real-derived hybrid | `_calculate_durability` reliability gate (N7>=3, N28>=5) + efficiency_factor + HRRc means/trends — sanitized realistic-athlete base + 5 synthetic qualifying Rides appended at the tail |
 | `golden/dfa-equipped.json` | synthetic | `_compute_dfa_block` + `_calculate_dfa_a1_profile` populated branch: 7 Ride sessions with per-second `dfa_a1`/`artifacts`/`heartrate`/`watts` streams clearing valid_secs>=1200 ∧ valid_pct>=70 and >=60s dwell in BOTH crossing bands → cycling trailing window at confidence=high with non-null lt1/lt2 estimates |
 | `synthetic/has-intervals-placeholder.json` | synthetic | upstream v3.106 bug: a `RECOVERY`-only `icu_intervals` placeholder must NOT be flagged as a structured workout |
 
@@ -63,11 +63,14 @@ The CLI emits a summary listing dropped TP-trademark + PII keys so you can
 confirm the default-deny transform ran, and writes a `.sha256` checksum
 alongside the JSON.
 
-For a new **real-derived hybrid** (curve/stream fixture), use the dedicated
-builder so the curve blocks bypass the sanitizer correctly:
+For a new **real-derived hybrid**, use a dedicated builder so the synthetic
+blocks bypass the sanitizer correctly. `tools/build-curve-fixture.ts` attaches
+synthetic curve blocks to sanitized real rows; `tools/build-capability-fixture.ts`
+appends synthetic qualifying Rides to the sanitized realistic-athlete base.
 
 ```bash
 pnpm exec tsx tools/build-curve-fixture.ts --raw-bundle <bundle.json> --raw-curves <curves.json>
+pnpm exec tsx tools/build-capability-fixture.ts
 ```
 
 For a new **synthetic** fixture, add the file by hand, include a `_comment` key
@@ -82,8 +85,8 @@ vacuous.
 
 ## Integrity + privacy guards
 
-- **`.sha256` checksum** — `realistic-athlete`, `curve-equipped`, and
-  `dfa-equipped` each carry a committed checksum;
+- **`.sha256` checksum** — `realistic-athlete`, `curve-equipped`,
+  `dfa-equipped`, and `capability-qualifying` each carry a committed checksum;
   `realistic-athlete-fixture-checksum.test.ts` re-hashes the bytes on every CI
   run, catching in-place mutation (bad merge, editor save).
 - **PII allowlist scan** — `reference-load-fixture.test.ts` walks the
@@ -91,9 +94,11 @@ vacuous.
   `ALLOWED_FIXTURE_KEYS` (real rows) or the enumerated synthetic-block key set
   (curve-equipped curve/athlete blocks; dfa-equipped stream channels), and that
   every numeric `id`/`*_id` is the redacted sentinel (12345) or a synthetic
-  fixture id (curve >= 90101, dfa >= 90201) — never a real-shaped account id.
-  `dfa-equipped` is fully synthetic, so its only out-of-allowlist keys are the
-  structural stream-channel names + the `String(id)` record keys (>= 90201).
+  fixture id (curve >= 90101, dfa >= 90201, capability-qualifying Rides >= 90001)
+  — never a real-shaped account id. `dfa-equipped` is fully synthetic, so its
+  only out-of-allowlist keys are the structural stream-channel names + the
+  `String(id)` record keys (>= 90201); `capability-qualifying` adds no
+  out-of-allowlist keys (its appended Rides carry only ActivitySchema fields).
 
 ## Privacy callout
 

--- a/packages/core/tests/fixtures/golden/capability-qualifying.json
+++ b/packages/core/tests/fixtures/golden/capability-qualifying.json
@@ -46,9 +46,13 @@
       ],
       "paired_event_id": null,
       "pace_zone_times": null,
+      "icu_hrr": {
+        "average_watts": null
+      },
       "icu_rpe": null,
       "decoupling": -4.7151833,
       "icu_efficiency_factor": 1.084507,
+      "icu_variability_index": 1.0694444,
       "fitnessAtEnd": 28.78709,
       "fatigueAtEnd": 53.354916
     },
@@ -65,9 +69,11 @@
       "icu_zone_times": null,
       "paired_event_id": null,
       "pace_zone_times": null,
+      "icu_hrr": null,
       "icu_rpe": null,
       "decoupling": null,
       "icu_efficiency_factor": null,
+      "icu_variability_index": null,
       "fitnessAtEnd": 27.312151,
       "fatigueAtEnd": 47.727512
     },
@@ -117,9 +123,11 @@
       ],
       "paired_event_id": 12345,
       "pace_zone_times": null,
+      "icu_hrr": null,
       "icu_rpe": null,
       "decoupling": -5.1646986,
       "icu_efficiency_factor": 1.0882353,
+      "icu_variability_index": 1.0496454,
       "fitnessAtEnd": 27.970243,
       "fatigueAtEnd": 49.37488
     },
@@ -169,9 +177,11 @@
       ],
       "paired_event_id": null,
       "pace_zone_times": null,
+      "icu_hrr": null,
       "icu_rpe": null,
       "decoupling": -3.520694,
       "icu_efficiency_factor": 1,
+      "icu_variability_index": 1.0465117,
       "fitnessAtEnd": 27.198479,
       "fatigueAtEnd": 47.743237
     },
@@ -221,9 +231,13 @@
       ],
       "paired_event_id": null,
       "pace_zone_times": null,
+      "icu_hrr": {
+        "average_watts": null
+      },
       "icu_rpe": null,
       "decoupling": -5.401834,
       "icu_efficiency_factor": 1.0344827,
+      "icu_variability_index": 1.0563381,
       "fitnessAtEnd": 27.443367,
       "fatigueAtEnd": 58.98432
     },
@@ -273,9 +287,13 @@
       ],
       "paired_event_id": null,
       "pace_zone_times": null,
+      "icu_hrr": {
+        "average_watts": null
+      },
       "icu_rpe": null,
       "decoupling": -14.990025,
       "icu_efficiency_factor": 1.0138888,
+      "icu_variability_index": 1.0656934,
       "fitnessAtEnd": 24.389515,
       "fatigueAtEnd": 46.958954
     },
@@ -292,9 +310,11 @@
       "icu_zone_times": null,
       "paired_event_id": null,
       "pace_zone_times": null,
+      "icu_hrr": null,
       "icu_rpe": null,
       "decoupling": null,
       "icu_efficiency_factor": null,
+      "icu_variability_index": null,
       "fitnessAtEnd": 23.025473,
       "fatigueAtEnd": 41.73144
     },
@@ -344,9 +364,13 @@
       ],
       "paired_event_id": 12345,
       "pace_zone_times": null,
+      "icu_hrr": {
+        "average_watts": null
+      },
       "icu_rpe": null,
       "decoupling": -4.877258,
       "icu_efficiency_factor": 1.028777,
+      "icu_variability_index": 1.0592593,
       "fitnessAtEnd": 23.580276,
       "fatigueAtEnd": 43.532978
     },
@@ -396,9 +420,13 @@
       ],
       "paired_event_id": 12345,
       "pace_zone_times": null,
+      "icu_hrr": {
+        "average_watts": null
+      },
       "icu_rpe": null,
       "decoupling": 2.8127115,
       "icu_efficiency_factor": 0.9929078,
+      "icu_variability_index": 1.0447761,
       "fitnessAtEnd": 22.805597,
       "fatigueAtEnd": 44.112385
     },
@@ -448,9 +476,11 @@
       ],
       "paired_event_id": null,
       "pace_zone_times": null,
+      "icu_hrr": null,
       "icu_rpe": null,
       "decoupling": -4.818208,
       "icu_efficiency_factor": 1.0212766,
+      "icu_variability_index": 1.0510949,
       "fitnessAtEnd": 21.537523,
       "fatigueAtEnd": 43.806248
     },
@@ -467,9 +497,11 @@
       "icu_zone_times": null,
       "paired_event_id": null,
       "pace_zone_times": null,
+      "icu_hrr": null,
       "icu_rpe": null,
       "decoupling": null,
       "icu_efficiency_factor": null,
+      "icu_variability_index": null,
       "fitnessAtEnd": 20.128857,
       "fatigueAtEnd": 38.248154
     },
@@ -519,9 +551,13 @@
       ],
       "paired_event_id": 12345,
       "pace_zone_times": null,
+      "icu_hrr": {
+        "average_watts": null
+      },
       "icu_rpe": null,
       "decoupling": -0.509351,
       "icu_efficiency_factor": 1.0070423,
+      "icu_variability_index": 1.0437956,
       "fitnessAtEnd": 20.613867,
       "fatigueAtEnd": 41.357563
     },
@@ -538,9 +574,11 @@
       "icu_zone_times": null,
       "paired_event_id": null,
       "pace_zone_times": null,
+      "icu_hrr": null,
       "icu_rpe": 1,
       "decoupling": null,
       "icu_efficiency_factor": null,
+      "icu_variability_index": null,
       "fitnessAtEnd": 19.25523,
       "fatigueAtEnd": 35.884132
     },
@@ -590,9 +628,11 @@
       ],
       "paired_event_id": null,
       "pace_zone_times": null,
+      "icu_hrr": null,
       "icu_rpe": null,
       "decoupling": 1.5639164,
       "icu_efficiency_factor": 0.8196721,
+      "icu_variability_index": 1.010101,
       "fitnessAtEnd": 19.092712,
       "fatigueAtEnd": 37.40199
     },
@@ -609,9 +649,11 @@
       "icu_zone_times": null,
       "paired_event_id": null,
       "pace_zone_times": null,
+      "icu_hrr": null,
       "icu_rpe": 1,
       "decoupling": null,
       "icu_efficiency_factor": null,
+      "icu_variability_index": null,
       "fitnessAtEnd": 19.191328,
       "fatigueAtEnd": 40.84215
     },
@@ -661,9 +703,13 @@
       ],
       "paired_event_id": null,
       "pace_zone_times": null,
+      "icu_hrr": {
+        "average_watts": null
+      },
       "icu_rpe": 1,
       "decoupling": -0.9092801,
       "icu_efficiency_factor": 1.04,
+      "icu_variability_index": 1.0833334,
       "fitnessAtEnd": 18.400795,
       "fatigueAtEnd": 39.128696
     },
@@ -680,9 +726,11 @@
       "icu_zone_times": null,
       "paired_event_id": null,
       "pace_zone_times": null,
+      "icu_hrr": null,
       "icu_rpe": 1,
       "decoupling": null,
       "icu_efficiency_factor": null,
+      "icu_variability_index": null,
       "fitnessAtEnd": 16.50693,
       "fatigueAtEnd": 30.24169
     },
@@ -699,9 +747,11 @@
       "icu_zone_times": null,
       "paired_event_id": null,
       "pace_zone_times": null,
+      "icu_hrr": null,
       "icu_rpe": null,
       "decoupling": null,
       "icu_efficiency_factor": null,
+      "icu_variability_index": null,
       "fitnessAtEnd": 16.621067,
       "fatigueAtEnd": 35.282864
     },
@@ -751,9 +801,13 @@
       ],
       "paired_event_id": null,
       "pace_zone_times": null,
+      "icu_hrr": {
+        "average_watts": null
+      },
       "icu_rpe": null,
       "decoupling": -8.35423,
       "icu_efficiency_factor": 1.0140845,
+      "icu_variability_index": 1.0746269,
       "fitnessAtEnd": 16.322794,
       "fatigueAtEnd": 36.247692
     },
@@ -770,9 +824,11 @@
       "icu_zone_times": null,
       "paired_event_id": null,
       "pace_zone_times": null,
+      "icu_hrr": null,
       "icu_rpe": null,
       "decoupling": null,
       "icu_efficiency_factor": null,
+      "icu_variability_index": null,
       "fitnessAtEnd": 14.668,
       "fatigueAtEnd": 28.761044
     },
@@ -789,9 +845,11 @@
       "icu_zone_times": null,
       "paired_event_id": null,
       "pace_zone_times": null,
+      "icu_hrr": null,
       "icu_rpe": 1,
       "decoupling": null,
       "icu_efficiency_factor": null,
+      "icu_variability_index": null,
       "fitnessAtEnd": 15.021429,
       "fatigueAtEnd": 31.027822
     },
@@ -841,9 +899,13 @@
       ],
       "paired_event_id": null,
       "pace_zone_times": null,
+      "icu_hrr": {
+        "average_watts": null
+      },
       "icu_rpe": null,
       "decoupling": -5.821107,
       "icu_efficiency_factor": 0.9868421,
+      "icu_variability_index": 1.0638298,
       "fitnessAtEnd": 14.660517,
       "fatigueAtEnd": 31.18566
     },
@@ -860,9 +922,11 @@
       "icu_zone_times": null,
       "paired_event_id": null,
       "pace_zone_times": null,
+      "icu_hrr": null,
       "icu_rpe": null,
       "decoupling": null,
       "icu_efficiency_factor": null,
+      "icu_variability_index": null,
       "fitnessAtEnd": 12.957295,
       "fatigueAtEnd": 24.138712
     },
@@ -912,9 +976,13 @@
       ],
       "paired_event_id": null,
       "pace_zone_times": null,
+      "icu_hrr": {
+        "average_watts": null
+      },
       "icu_rpe": null,
       "decoupling": -2.744324,
       "icu_efficiency_factor": 1,
+      "icu_variability_index": 1.1230769,
       "fitnessAtEnd": 13.269505,
       "fatigueAtEnd": 25.234968
     },
@@ -964,9 +1032,11 @@
       ],
       "paired_event_id": 12345,
       "pace_zone_times": null,
+      "icu_hrr": null,
       "icu_rpe": null,
       "decoupling": -7.1944137,
       "icu_efficiency_factor": 0.8881119,
+      "icu_variability_index": 1.0409836,
       "fitnessAtEnd": 11.720525,
       "fatigueAtEnd": 17.814379
     },
@@ -1016,9 +1086,13 @@
       ],
       "paired_event_id": null,
       "pace_zone_times": null,
+      "icu_hrr": {
+        "average_watts": null
+      },
       "icu_rpe": null,
       "decoupling": -3.015162,
       "icu_efficiency_factor": 0.92763156,
+      "icu_variability_index": 1.0681819,
       "fitnessAtEnd": 10.920485,
       "fatigueAtEnd": 13.859039
     },
@@ -1035,9 +1109,11 @@
       "icu_zone_times": null,
       "paired_event_id": null,
       "pace_zone_times": null,
+      "icu_hrr": null,
       "icu_rpe": 1,
       "decoupling": null,
       "icu_efficiency_factor": null,
+      "icu_variability_index": null,
       "fitnessAtEnd": 10.21283,
       "fatigueAtEnd": 9.01345
     },
@@ -1054,9 +1130,11 @@
       "icu_zone_times": null,
       "paired_event_id": null,
       "pace_zone_times": null,
+      "icu_hrr": null,
       "icu_rpe": null,
       "decoupling": null,
       "icu_efficiency_factor": null,
+      "icu_variability_index": null,
       "fitnessAtEnd": 11.3309965,
       "fatigueAtEnd": 13.236021
     },
@@ -1073,9 +1151,11 @@
       "icu_zone_times": null,
       "paired_event_id": null,
       "pace_zone_times": null,
+      "icu_hrr": null,
       "icu_rpe": 1,
       "decoupling": null,
       "icu_efficiency_factor": null,
+      "icu_variability_index": null,
       "fitnessAtEnd": 12.169959,
       "fatigueAtEnd": 13.983252
     },
@@ -1092,9 +1172,11 @@
       "icu_zone_times": null,
       "paired_event_id": null,
       "pace_zone_times": null,
+      "icu_hrr": null,
       "icu_rpe": null,
       "decoupling": null,
       "icu_efficiency_factor": null,
+      "icu_variability_index": null,
       "fitnessAtEnd": 12.338198,
       "fatigueAtEnd": 15.539
     },
@@ -1111,9 +1193,11 @@
       "icu_zone_times": null,
       "paired_event_id": null,
       "pace_zone_times": null,
+      "icu_hrr": null,
       "icu_rpe": 1,
       "decoupling": null,
       "icu_efficiency_factor": null,
+      "icu_variability_index": null,
       "fitnessAtEnd": 12.635489,
       "fatigueAtEnd": 14.086121
     },
@@ -1130,9 +1214,11 @@
       "icu_zone_times": null,
       "paired_event_id": null,
       "pace_zone_times": null,
+      "icu_hrr": null,
       "icu_rpe": 1,
       "decoupling": null,
       "icu_efficiency_factor": null,
+      "icu_variability_index": null,
       "fitnessAtEnd": 12.313469,
       "fatigueAtEnd": 12.256566
     },
@@ -1149,9 +1235,11 @@
       "icu_zone_times": null,
       "paired_event_id": null,
       "pace_zone_times": null,
+      "icu_hrr": null,
       "icu_rpe": 1,
       "decoupling": null,
       "icu_efficiency_factor": null,
+      "icu_variability_index": null,
       "fitnessAtEnd": 11.887308,
       "fatigueAtEnd": 9.5317955
     },
@@ -1168,9 +1256,11 @@
       "icu_zone_times": null,
       "paired_event_id": null,
       "pace_zone_times": null,
+      "icu_hrr": null,
       "icu_rpe": 1,
       "decoupling": null,
       "icu_efficiency_factor": null,
+      "icu_variability_index": null,
       "fitnessAtEnd": 11.933538,
       "fatigueAtEnd": 7.888329
     },
@@ -1187,9 +1277,11 @@
       "icu_zone_times": null,
       "paired_event_id": null,
       "pace_zone_times": null,
+      "icu_hrr": null,
       "icu_rpe": 1,
       "decoupling": null,
       "icu_efficiency_factor": null,
+      "icu_variability_index": null,
       "fitnessAtEnd": 13.917642,
       "fatigueAtEnd": 10.14109
     },
@@ -1206,9 +1298,11 @@
       "icu_zone_times": null,
       "paired_event_id": null,
       "pace_zone_times": null,
+      "icu_hrr": null,
       "icu_rpe": 1,
       "decoupling": null,
       "icu_efficiency_factor": null,
+      "icu_variability_index": null,
       "fitnessAtEnd": 14.887822,
       "fatigueAtEnd": 10.407923
     },
@@ -1225,9 +1319,11 @@
       "icu_zone_times": null,
       "paired_event_id": null,
       "pace_zone_times": null,
+      "icu_hrr": null,
       "icu_rpe": 1,
       "decoupling": null,
       "icu_efficiency_factor": null,
+      "icu_variability_index": null,
       "fitnessAtEnd": 15.156215,
       "fatigueAtEnd": 9.233241
     },
@@ -1244,9 +1340,11 @@
       "icu_zone_times": null,
       "paired_event_id": null,
       "pace_zone_times": null,
+      "icu_hrr": null,
       "icu_rpe": 1,
       "decoupling": null,
       "icu_efficiency_factor": null,
+      "icu_variability_index": null,
       "fitnessAtEnd": 15.520292,
       "fatigueAtEnd": 8.043082
     },
@@ -1260,12 +1358,45 @@
       "icu_training_load": 90,
       "icu_intensity": 79,
       "average_heartrate": 140,
-      "icu_zone_times": [{"id":"Z1","secs":600},{"id":"Z2","secs":3000},{"id":"Z3","secs":1500},{"id":"Z4","secs":500},{"id":"Z5","secs":200},{"id":"Z6","secs":120},{"id":"Z7","secs":80},{"id":"SS","secs":600}],
+      "icu_zone_times": [
+        {
+          "id": "Z1",
+          "secs": 600
+        },
+        {
+          "id": "Z2",
+          "secs": 3000
+        },
+        {
+          "id": "Z3",
+          "secs": 1500
+        },
+        {
+          "id": "Z4",
+          "secs": 500
+        },
+        {
+          "id": "Z5",
+          "secs": 200
+        },
+        {
+          "id": "Z6",
+          "secs": 120
+        },
+        {
+          "id": "Z7",
+          "secs": 80
+        },
+        {
+          "id": "SS",
+          "secs": 600
+        }
+      ],
       "paired_event_id": null,
       "pace_zone_times": null,
       "icu_rpe": null,
-      "icu_variability_index": 1.0,
-      "icu_hr_decoupling": 1.0,
+      "icu_variability_index": 1,
+      "icu_hr_decoupling": 1,
       "icu_efficiency_factor": 2.5,
       "icu_hrr": 40
     },
@@ -1279,12 +1410,45 @@
       "icu_training_load": 90,
       "icu_intensity": 79,
       "average_heartrate": 140,
-      "icu_zone_times": [{"id":"Z1","secs":600},{"id":"Z2","secs":3000},{"id":"Z3","secs":1500},{"id":"Z4","secs":500},{"id":"Z5","secs":200},{"id":"Z6","secs":120},{"id":"Z7","secs":80},{"id":"SS","secs":600}],
+      "icu_zone_times": [
+        {
+          "id": "Z1",
+          "secs": 600
+        },
+        {
+          "id": "Z2",
+          "secs": 3000
+        },
+        {
+          "id": "Z3",
+          "secs": 1500
+        },
+        {
+          "id": "Z4",
+          "secs": 500
+        },
+        {
+          "id": "Z5",
+          "secs": 200
+        },
+        {
+          "id": "Z6",
+          "secs": 120
+        },
+        {
+          "id": "Z7",
+          "secs": 80
+        },
+        {
+          "id": "SS",
+          "secs": 600
+        }
+      ],
       "paired_event_id": null,
       "pace_zone_times": null,
       "icu_rpe": null,
-      "icu_variability_index": 1.0,
-      "icu_hr_decoupling": 2.0,
+      "icu_variability_index": 1,
+      "icu_hr_decoupling": 2,
       "icu_efficiency_factor": 2.5,
       "icu_hrr": 40
     },
@@ -1298,12 +1462,45 @@
       "icu_training_load": 90,
       "icu_intensity": 79,
       "average_heartrate": 140,
-      "icu_zone_times": [{"id":"Z1","secs":600},{"id":"Z2","secs":3000},{"id":"Z3","secs":1500},{"id":"Z4","secs":500},{"id":"Z5","secs":200},{"id":"Z6","secs":120},{"id":"Z7","secs":80},{"id":"SS","secs":600}],
+      "icu_zone_times": [
+        {
+          "id": "Z1",
+          "secs": 600
+        },
+        {
+          "id": "Z2",
+          "secs": 3000
+        },
+        {
+          "id": "Z3",
+          "secs": 1500
+        },
+        {
+          "id": "Z4",
+          "secs": 500
+        },
+        {
+          "id": "Z5",
+          "secs": 200
+        },
+        {
+          "id": "Z6",
+          "secs": 120
+        },
+        {
+          "id": "Z7",
+          "secs": 80
+        },
+        {
+          "id": "SS",
+          "secs": 600
+        }
+      ],
       "paired_event_id": null,
       "pace_zone_times": null,
       "icu_rpe": null,
-      "icu_variability_index": 1.0,
-      "icu_hr_decoupling": 3.0,
+      "icu_variability_index": 1,
+      "icu_hr_decoupling": 3,
       "icu_efficiency_factor": 2.5,
       "icu_hrr": 40
     },
@@ -1317,13 +1514,46 @@
       "icu_training_load": 90,
       "icu_intensity": 79,
       "average_heartrate": 140,
-      "icu_zone_times": [{"id":"Z1","secs":600},{"id":"Z2","secs":3000},{"id":"Z3","secs":1500},{"id":"Z4","secs":500},{"id":"Z5","secs":200},{"id":"Z6","secs":120},{"id":"Z7","secs":80},{"id":"SS","secs":600}],
+      "icu_zone_times": [
+        {
+          "id": "Z1",
+          "secs": 600
+        },
+        {
+          "id": "Z2",
+          "secs": 3000
+        },
+        {
+          "id": "Z3",
+          "secs": 1500
+        },
+        {
+          "id": "Z4",
+          "secs": 500
+        },
+        {
+          "id": "Z5",
+          "secs": 200
+        },
+        {
+          "id": "Z6",
+          "secs": 120
+        },
+        {
+          "id": "Z7",
+          "secs": 80
+        },
+        {
+          "id": "SS",
+          "secs": 600
+        }
+      ],
       "paired_event_id": null,
       "pace_zone_times": null,
       "icu_rpe": null,
-      "icu_variability_index": 1.0,
-      "icu_hr_decoupling": 6.0,
-      "icu_efficiency_factor": 2.0,
+      "icu_variability_index": 1,
+      "icu_hr_decoupling": 6,
+      "icu_efficiency_factor": 2,
       "icu_hrr": 30
     },
     {
@@ -1336,13 +1566,46 @@
       "icu_training_load": 90,
       "icu_intensity": 79,
       "average_heartrate": 140,
-      "icu_zone_times": [{"id":"Z1","secs":600},{"id":"Z2","secs":3000},{"id":"Z3","secs":1500},{"id":"Z4","secs":500},{"id":"Z5","secs":200},{"id":"Z6","secs":120},{"id":"Z7","secs":80},{"id":"SS","secs":600}],
+      "icu_zone_times": [
+        {
+          "id": "Z1",
+          "secs": 600
+        },
+        {
+          "id": "Z2",
+          "secs": 3000
+        },
+        {
+          "id": "Z3",
+          "secs": 1500
+        },
+        {
+          "id": "Z4",
+          "secs": 500
+        },
+        {
+          "id": "Z5",
+          "secs": 200
+        },
+        {
+          "id": "Z6",
+          "secs": 120
+        },
+        {
+          "id": "Z7",
+          "secs": 80
+        },
+        {
+          "id": "SS",
+          "secs": 600
+        }
+      ],
       "paired_event_id": null,
       "pace_zone_times": null,
       "icu_rpe": null,
-      "icu_variability_index": 1.0,
-      "icu_hr_decoupling": 7.0,
-      "icu_efficiency_factor": 2.0,
+      "icu_variability_index": 1,
+      "icu_hr_decoupling": 7,
+      "icu_efficiency_factor": 2,
       "icu_hrr": 30
     }
   ],

--- a/packages/core/tests/fixtures/golden/capability-qualifying.json.sha256
+++ b/packages/core/tests/fixtures/golden/capability-qualifying.json.sha256
@@ -1,0 +1,1 @@
+2460c41fb30e959b0513428af16b4aa2a4242264d47664b6f4e0983cd4241fa8  capability-qualifying.json

--- a/packages/core/tests/fixtures/snapshots/capability-qualifying/capability.durability.json
+++ b/packages/core/tests/fixtures/snapshots/capability-qualifying/capability.durability.json
@@ -7,10 +7,10 @@
   "value": {
     "high_drift_count_28d": 2,
     "high_drift_count_7d": 0,
-    "mean_decoupling_28d": 3.8,
+    "mean_decoupling_28d": 3.64,
     "mean_decoupling_7d": 2,
     "note": "Steady-state power sessions only (VI <= 1.05, VI > 0, >= 90min, power data). Negative decoupling = strong durability. Trend compares 7d vs 28d mean (+/-1% = stable). Alerts require N28>=5 (alarm) or N7>=3 AND N28>=5 (declining warning) for statistical reliability.",
-    "qualifying_sessions_28d": 5,
+    "qualifying_sessions_28d": 6,
     "qualifying_sessions_7d": 3,
     "reliability_limited": false,
     "reliability_note": null,

--- a/packages/core/tests/fixtures/snapshots/capability-qualifying/capability.efficiency_factor.json
+++ b/packages/core/tests/fixtures/snapshots/capability-qualifying/capability.efficiency_factor.json
@@ -5,11 +5,11 @@
   "section_11_protocol_version": "3.112",
   "frozen_now": "1998-05-10T12:00:00",
   "value": {
-    "mean_ef_28d": 2.3,
-    "mean_ef_7d": 2.5,
+    "mean_ef_28d": 1.64,
+    "mean_ef_7d": 1.92,
     "note": "Steady-state cycling sessions only (VI <= 1.05, VI > 0, >= 20min, power+HR data). Rising EF = improving aerobic efficiency. Compare like-for-like sessions only — EF varies with intensity. Trend compares 7d vs 28d mean (+/-0.03 = stable).",
-    "qualifying_sessions_28d": 5,
-    "qualifying_sessions_7d": 3,
+    "qualifying_sessions_28d": 10,
+    "qualifying_sessions_7d": 5,
     "trend": "improving"
   }
 }

--- a/packages/core/tests/fixtures/snapshots/capability-qualifying/capability.json
+++ b/packages/core/tests/fixtures/snapshots/capability-qualifying/capability.json
@@ -9,21 +9,21 @@
     "durability": {
       "high_drift_count_28d": 2,
       "high_drift_count_7d": 0,
-      "mean_decoupling_28d": 3.8,
+      "mean_decoupling_28d": 3.64,
       "mean_decoupling_7d": 2,
       "note": "Steady-state power sessions only (VI <= 1.05, VI > 0, >= 90min, power data). Negative decoupling = strong durability. Trend compares 7d vs 28d mean (+/-1% = stable). Alerts require N28>=5 (alarm) or N7>=3 AND N28>=5 (declining warning) for statistical reliability.",
-      "qualifying_sessions_28d": 5,
+      "qualifying_sessions_28d": 6,
       "qualifying_sessions_7d": 3,
       "reliability_limited": false,
       "reliability_note": null,
       "trend": "improving"
     },
     "efficiency_factor": {
-      "mean_ef_28d": 2.3,
-      "mean_ef_7d": 2.5,
+      "mean_ef_28d": 1.64,
+      "mean_ef_7d": 1.92,
       "note": "Steady-state cycling sessions only (VI <= 1.05, VI > 0, >= 20min, power+HR data). Rising EF = improving aerobic efficiency. Compare like-for-like sessions only — EF varies with intensity. Trend compares 7d vs 28d mean (+/-0.03 = stable).",
-      "qualifying_sessions_28d": 5,
-      "qualifying_sessions_7d": 3,
+      "qualifying_sessions_28d": 10,
+      "qualifying_sessions_7d": 5,
       "trend": "improving"
     },
     "hr_curve_delta": {

--- a/packages/core/tests/realistic-athlete-fixture-checksum.test.ts
+++ b/packages/core/tests/realistic-athlete-fixture-checksum.test.ts
@@ -31,8 +31,9 @@ const HERE = dirname(fileURLToPath(import.meta.url));
 // Every fixture with a committed `.sha256` integrity guard is checked here.
 // realistic-athlete is fully sanitizer-produced; curve-equipped is a hybrid
 // (sanitized rows + synthetic curve blocks); dfa-equipped is fully synthetic
-// (generated stream blob). Each fixture's regen path writes the checksum
-// alongside the JSON.
+// (generated stream blob); capability-qualifying is a hybrid (the
+// realistic-athlete base + synthetic qualifying Rides appended at the tail).
+// Each fixture's regen path writes the checksum alongside the JSON.
 const FIXTURES: Array<{ slug: string; regen: string }> = [
   {
     slug: "realistic-athlete",
@@ -45,6 +46,10 @@ const FIXTURES: Array<{ slug: string; regen: string }> = [
   {
     slug: "dfa-equipped",
     regen: "tools/build-dfa-fixture.ts",
+  },
+  {
+    slug: "capability-qualifying",
+    regen: "tools/build-capability-fixture.ts",
   },
 ];
 

--- a/packages/core/tests/reference-load-fixture.test.ts
+++ b/packages/core/tests/reference-load-fixture.test.ts
@@ -239,6 +239,16 @@ describe("loadFixture against committed golden fixtures", () => {
       dynamicKeyAllowed: (key, parentPath) =>
         parentPath === "streams" && /^\d+$/.test(key) && Number(key) >= 90201,
     },
+    {
+      slug: "golden/capability-qualifying",
+      // No extra keys: the appended qualifying Rides carry only ActivitySchema
+      // fields (icu_hr_decoupling, icu_hrr, icu_variability_index, …), all
+      // already in ALLOWED_FIXTURE_KEYS.
+      extraKeys: new Set(),
+      // The realistic-athlete base rows keep the 12345 sentinel; the appended
+      // Rides use distinct synthetic ids (>= 90001, below the curve/dfa ranges).
+      idSentinel: (v) => v === 12345 || (typeof v === "number" && v >= 90001),
+    },
   ];
 
   describe.each(piiScanFixtures)("$slug — PII regression scanner (allowlist)", ({ slug, extraKeys, idSentinel, dynamicKeyAllowed }) => {

--- a/tools/build-capability-fixture.ts
+++ b/tools/build-capability-fixture.ts
@@ -1,0 +1,269 @@
+// Builds the `capability-qualifying` golden fixture: the sanitized
+// realistic-athlete base with five steady-state qualifying Rides appended to
+// the tail of `activities`. The base is read from the committed
+// realistic-athlete golden — already sanitized, id-redacted, and shifted to the
+// synthetic epoch — so this builder never re-runs the sanitizer; it only
+// appends. The appended Rides are de-identified at the source (synthetic
+// 90001-90005 ids, 1998-epoch dates) and are attached AFTER / outside any
+// sanitizer walk, exactly as the sibling curve builder attaches its synthetic
+// blocks, so their literals must already sit in the synthetic epoch.
+//
+// The Rides are hardcoded verbatim rather than generated. Each one's field set
+// (icu_hr_decoupling, bare-number icu_hrr, no fitnessAtEnd/fatigueAtEnd) is the
+// raw intervals.icu API surface the durability/EF/HRRc metrics read directly,
+// not the refreshed real-activity surface — copying them literally keeps the
+// committed bytes pinned to the values the populated-branch coverage depends on.
+//
+// The build ends with a non-vacuity guard that independently recomputes the
+// durability reliability gate from the OUTPUT — >= 3 qualifying steady-state
+// Rides in the 7d window and >= 5 in the 28d window before the anchor — and
+// fails the build unless it clears. That turns a "parity-green-but-vacuous"
+// fixture (one that quietly drops below the gate and flips the means to null)
+// into a hard build failure.
+//
+// Determinism: same base bytes -> byte-identical output. No Math.random /
+// Date.now; the base is read from disk and the Rides are literals.
+//
+// Usage (operator, dev-time):
+//   pnpm exec tsx tools/build-capability-fixture.ts \
+//     [--frozen-now 1998-05-10T12:00:00] [--base <path>] [--out <path>]
+
+import { createHash } from "node:crypto";
+import { readFileSync, writeFileSync } from "node:fs";
+import { basename, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const GOLDEN_DIR = resolve(REPO_ROOT, "packages/core/tests/fixtures/golden");
+const DEFAULT_BASE = resolve(GOLDEN_DIR, "realistic-athlete.json");
+const DEFAULT_OUT = resolve(GOLDEN_DIR, "capability-qualifying.json");
+// Shares the realistic-athlete base, whose dates were shifted back one full
+// Gregorian cycle to de-identify the real calendar, so the anchor sits in the
+// synthetic epoch one day after the base's last activity. The durability
+// windows the guard recomputes are taken relative to this clock.
+const DEFAULT_FROZEN_NOW = "1998-05-10T12:00:00";
+
+// Durability qualifying predicate (mirrors capability.ts filterQualifying /
+// sync.py:4061-4078) and reliability gate (capability.ts computeDurability):
+// a Ride qualifies when decoupling is present, VI is in (0, 1.05], and
+// moving_time >= 90 min; the gate needs N7 >= 3 and N28 >= 5.
+const VI_MAX = 1.05;
+const MIN_MOVING_TIME_SECS = 5400;
+const RELIABILITY_MIN_N7 = 3;
+const RELIABILITY_MIN_N28 = 5;
+
+interface Args {
+  base: string;
+  frozenNow: string;
+  out: string;
+}
+
+function parseArgs(argv: string[]): Args {
+  const out: Args = {
+    base: DEFAULT_BASE,
+    frozenNow: DEFAULT_FROZEN_NOW,
+    out: DEFAULT_OUT,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    const next = (): string => {
+      const v = argv[i + 1];
+      if (v === undefined || v.startsWith("--")) {
+        throw new Error(`flag ${arg} requires a value`);
+      }
+      i++;
+      return v;
+    };
+    switch (arg) {
+      case "--base":
+        out.base = resolve(next());
+        break;
+      case "--frozen-now":
+        out.frozenNow = next();
+        break;
+      case "--out":
+        out.out = resolve(next());
+        break;
+      default:
+        throw new Error(`unknown flag: ${arg}`);
+    }
+  }
+  return out;
+}
+
+// Python-equivalent calendar math: parse the anchor as a UTC date, subtract
+// whole days, format %Y-%m-%d. Matches the harness slice_window's inclusive
+// [frozenNow-(days-1), frozenNow] date prefix comparison.
+function ymdMinus(frozenNow: string, days: number): string {
+  const base = new Date(`${frozenNow.slice(0, 10)}T00:00:00Z`);
+  base.setUTCDate(base.getUTCDate() - days);
+  return base.toISOString().slice(0, 10);
+}
+
+// The five qualifying Rides, verbatim. Field set + key order are the raw
+// intervals.icu API surface the durability/EF/HRRc filters read: icu_hr_decoupling
+// (the preferred decoupling field), bare-number icu_hrr, VI exactly 1.0, and a
+// 6000s moving_time clearing the 90-min steady-state floor. Three land in the
+// 7d window (05-06/05-08/05-10), all five in the 28d window. The 09:00:00
+// wall-clock and 1998-epoch dates keep every literal de-identified.
+const ZONE_TIMES = [
+  { id: "Z1", secs: 600 },
+  { id: "Z2", secs: 3000 },
+  { id: "Z3", secs: 1500 },
+  { id: "Z4", secs: 500 },
+  { id: "Z5", secs: 200 },
+  { id: "Z6", secs: 120 },
+  { id: "Z7", secs: 80 },
+  { id: "SS", secs: 600 },
+];
+
+interface QualifyingRide {
+  id: number;
+  start_date_local: string;
+  type: string;
+  name: string;
+  moving_time: number;
+  elapsed_time: number;
+  icu_training_load: number;
+  icu_intensity: number;
+  average_heartrate: number;
+  icu_zone_times: { id: string; secs: number }[];
+  paired_event_id: number | null;
+  pace_zone_times: number | null;
+  icu_rpe: number | null;
+  icu_variability_index: number;
+  icu_hr_decoupling: number;
+  icu_efficiency_factor: number;
+  icu_hrr: number;
+}
+
+function qualifyingRide(
+  id: number,
+  date: string,
+  decoupling: number,
+  efficiencyFactor: number,
+  hrr: number,
+): QualifyingRide {
+  return {
+    id,
+    start_date_local: `${date}T09:00:00`,
+    type: "Ride",
+    name: "Capability qualifier",
+    moving_time: 6000,
+    elapsed_time: 6100,
+    icu_training_load: 90,
+    icu_intensity: 79,
+    average_heartrate: 140,
+    icu_zone_times: ZONE_TIMES.map((z) => ({ ...z })),
+    paired_event_id: null,
+    pace_zone_times: null,
+    icu_rpe: null,
+    icu_variability_index: 1.0,
+    icu_hr_decoupling: decoupling,
+    icu_efficiency_factor: efficiencyFactor,
+    icu_hrr: hrr,
+  };
+}
+
+// Literal id order 90001->90005 (NOT re-sorted into the base's descending
+// calendar). decoupling rises across the window so the 7d-vs-28d trend has
+// signal; EF/HRR step down on the older two so the means differ between windows.
+const QUALIFYING_RIDES: QualifyingRide[] = [
+  qualifyingRide(90001, "1998-05-06", 1.0, 2.5, 40),
+  qualifyingRide(90002, "1998-05-08", 2.0, 2.5, 40),
+  qualifyingRide(90003, "1998-05-10", 3.0, 2.5, 40),
+  qualifyingRide(90004, "1998-04-18", 6.0, 2.0, 30),
+  qualifyingRide(90005, "1998-04-24", 7.0, 2.0, 30),
+];
+
+interface BaseFixture {
+  activities: Record<string, unknown>[];
+  [key: string]: unknown;
+}
+
+function buildFixture(basePath: string): BaseFixture {
+  const base = JSON.parse(readFileSync(basePath, "utf8")) as BaseFixture;
+  if (!Array.isArray(base.activities)) {
+    throw new Error(`base fixture ${basePath} has no activities array`);
+  }
+  // Append the Rides to the tail in literal id order; preserve every other
+  // top-level key (wellness, ftp_history, ...) and its insertion order.
+  return {
+    ...base,
+    activities: [...base.activities, ...QUALIFYING_RIDES.map((r) => ({ ...r }))],
+  };
+}
+
+// ─── Non-vacuity guard ─────────────────────────────────────────────────────
+// Recompute the durability reliability gate from the OUTPUT, mirroring
+// capability.ts: qualifying = decoupling present, VI in (0, 1.05], moving_time
+// >= 5400s; window = inclusive [frozenNow-(days-1), frozenNow] date prefix.
+// Fail unless N7 >= 3 and N28 >= 5 so the durability/EF/HRRc means stay
+// populated (the whole reason this fixture exists).
+function assertNonVacuous(fixture: BaseFixture, frozenNow: string): void {
+  const fail = (msg: string): never => {
+    throw new Error(`[build-capability-fixture] non-vacuity guard failed: ${msg}`);
+  };
+
+  const today = frozenNow.slice(0, 10);
+  const inWindow = (act: Record<string, unknown>, days: number): boolean => {
+    const sd = act.start_date_local;
+    if (typeof sd !== "string") return false;
+    const d = sd.slice(0, 10);
+    return ymdMinus(frozenNow, days - 1) <= d && d <= today;
+  };
+  const isQualifying = (act: Record<string, unknown>): boolean => {
+    let dec = act.icu_hr_decoupling as number | null | undefined;
+    if (dec === null || dec === undefined) dec = act.decoupling as number | null | undefined;
+    const vi = act.icu_variability_index as number | null | undefined;
+    const mt = (act.moving_time as number | undefined) || 0;
+    return (
+      dec !== null &&
+      dec !== undefined &&
+      vi !== null &&
+      vi !== undefined &&
+      vi > 0 &&
+      vi <= VI_MAX &&
+      mt >= MIN_MOVING_TIME_SECS
+    );
+  };
+
+  const n7 = fixture.activities.filter((a) => inWindow(a, 7) && isQualifying(a)).length;
+  const n28 = fixture.activities.filter((a) => inWindow(a, 28) && isQualifying(a)).length;
+  if (n7 < RELIABILITY_MIN_N7) {
+    fail(`only ${n7} qualifying Rides in the 7d window (need >= ${RELIABILITY_MIN_N7})`);
+  }
+  if (n28 < RELIABILITY_MIN_N28) {
+    fail(`only ${n28} qualifying Rides in the 28d window (need >= ${RELIABILITY_MIN_N28})`);
+  }
+}
+
+function main(argv: string[]): void {
+  const args = parseArgs(argv);
+  const fixture = buildFixture(args.base);
+  assertNonVacuous(fixture, args.frozenNow);
+
+  const json = `${JSON.stringify(fixture, null, 2)}\n`;
+  writeFileSync(args.out, json);
+  const hash = createHash("sha256").update(json).digest("hex");
+  writeFileSync(`${args.out}.sha256`, `${hash}  ${basename(args.out)}\n`);
+  // eslint-disable-next-line no-console
+  console.error(`Wrote ${args.out} (${json.length} bytes), checksum ${args.out}.sha256`);
+}
+
+const isCli =
+  typeof process !== "undefined" &&
+  process.argv[1] !== undefined &&
+  import.meta.url === `file://${process.argv[1]}`;
+
+if (isCli) {
+  try {
+    main(process.argv.slice(2));
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error((err as Error).message);
+    process.exit(1);
+  }
+}
+
+export { buildFixture, ymdMinus, QUALIFYING_RIDES };

--- a/tools/harness-fixtures.ts
+++ b/tools/harness-fixtures.ts
@@ -95,7 +95,7 @@ export const HARNESS_FIXTURES: HarnessFixtureConfig[] = [
     // cycle for de-identification, so its anchor moves with them.
     frozenNow: "1998-05-10T12:00:00",
     description:
-      "Populated-branch coverage for the capability sub-keys (durability, efficiency_factor, hrrc). Appends 5 steady-state qualifying Rides (VI 1.0, moving_time 6000s, decoupling/EF/hrr present) to the realistic-athlete base — 3 in the 7d window, 5 in the 28d window — clearing durability's reliability gate (N7>=3, N28>=5) and exercising the means + trends the all-null fixtures never reach.",
+      "Populated-branch coverage for the capability sub-keys (durability, efficiency_factor, hrrc). Appends 5 steady-state qualifying Rides (VI 1.0, moving_time 6000s, decoupling/EF/hrr present) to the realistic-athlete base — 3 in the 7d window, 5 in the 28d window — clearing durability's reliability gate (N7>=3, N28>=5) and exercising the means + trends the all-null fixtures never reach. Built by tools/build-capability-fixture.ts (qualifying Rides appended to the tail AFTER the sanitizer over the realistic-athlete base — they carry the raw icu_hr_decoupling/bare-icu_hrr API surface and de-identified synthetic ids, so they bypass the base's sanitizer walk; the builder's non-vacuity guard recomputes the reliability gate).",
   },
   {
     slug: "curve-equipped",


### PR DESCRIPTION
## Summary

- The `capability-qualifying` golden's 38 base activities were a stale pre-refresh copy of the `realistic-athlete` golden: after #155 brought that golden onto the current sanitizer field surface (`icu_hrr`, `icu_variability_index`), this derived fixture still carried neither field — and no script existed to rebuild it.
- Adds `tools/build-capability-fixture.ts` (sibling of the curve/dfa builders): reads the committed `realistic-athlete` golden, appends the five hardcoded steady-state qualifying Rides verbatim, writes canonical JSON + a `.sha256` sidecar, and ends with a non-vacuity guard that recomputes the durability reliability gate (N7 >= 3, N28 >= 5) from the output and fails the build if the fixture ever goes vacuous.
- Rebuilds the golden: all 38 base activities gain exactly the two refreshed fields (zero other value changes; appended Rides byte-identical in data), and folds the fixture into the checksum-integrity test and the PII allowlist scan alongside the other builder-produced goldens.

## Snapshot deltas (regenerated through the native runtime-parity gate)

Only 3 snapshot files changed, all on this slug; every delta was independently re-derived from the upstream qualifying predicates against both the old and new golden:

| Key | Old → New | Why |
|---|---|---|
| `capability.durability` qualifying_sessions_28d | 5 → 6 | one base Ride (mt 8157s, VI 1.045, decoupling present) now clears the gate; previously rejected only for missing VI |
| `capability.durability` mean_decoupling_28d | 3.8 → 3.64 | the new qualifier joins the 28d pool; 7d values unchanged |
| `capability.efficiency_factor` qualifying_sessions 28d/7d | 5/3 → 10/5 | the EF gate's 20-min floor admits far more base rides than durability's 90-min floor |
| `capability.efficiency_factor` mean_ef 28d/7d | 2.3/2.5 → 1.64/1.92 | added base EF values sit below the synthetic Rides' |

`capability.hrrc` (reads only `icu_hrr`, which is non-numeric on all base rows), `data_quality` (activity counts unchanged), every null-branch sub-key, the manifest, and all 12 other fixtures: byte-identical.

## Verification

- Native runtime-parity gate: **819 metrics × 13 fixtures bit-identical**
- `pnpm check-parity --all`: **520 OK**
- Full suite: **96 files, 1722 passed, 0 failures** (incl. the sanitize-CLI stability guard)
- `pnpm check:fixture-privacy` clean — base stays 1998-epoch with the 12345 sentinel; appended ride ids 90001–90005 sit in their own synthetic range below curve (90101+) / dfa (90201+)
- Builder re-run is byte-identical (deterministic); `.sha256` sidecar verifies; non-vacuity guard proven non-vacuous (a 1998-12-31 anchor fails the build loudly)
