### PR TITLE
fix(tools): merge-patch the snapshot manifest on the debug regen path

### DIFF
--- a/.changeset/snapshot-debug-regen-manifest-merge.md
+++ b/.changeset/snapshot-debug-regen-manifest-merge.md
@@ -1,0 +1,24 @@
+---
+"@enduragent/core": patch
+---
+
+Stop the single-fixture debug snapshot regen from clobbering the manifest. The
+`SNAPSHOT_FIXTURE_PATH` debug path processes one fixture but used to rewrite
+`manifest.json` from that single slug — silently dropping every other fixture
+from the index (their snapshot files on disk untouched, only the manifest lied)
+and collapsing the metric union down to the one fixture's metrics. The debug
+path now MERGE-patches instead: it unions the processed slug into the existing
+fixtures + metrics lists and preserves the rest, leaving a manifest byte-identical
+to a full regen. It refuses loudly (non-zero exit) when no manifest exists yet
+(a debug regen presumes an initialized snapshot tree) or when the existing
+manifest's oracle coordinates — upstream sha / protocol version / commit date /
+pyodide version — diverge from the current toolchain, so a stale-coordinate
+partial manifest can't land. The manifest builders are extracted into their own
+module and unit-tested, including a hermetic byte-identity gate that reconstructs
+the committed manifest from the on-disk snapshot tree without booting the WASM
+oracle; the full-regen path's manifest output is preserved byte-identical. The
+snapshot-index smoke test now asserts the full fixture allowlist rather than a
+single slug, closing the asymmetric hole where a debug regen of that one named
+slug would corrupt the index unasserted.
+
+Pure dev-time + oracle infra — athletes don't notice.

--- a/packages/core/tests/reference-metrics-snapshot-loop.test.ts
+++ b/packages/core/tests/reference-metrics-snapshot-loop.test.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 import type { Manifest, Snapshot } from "../../../tools/check-metric-parity";
+import { HARNESS_FIXTURES } from "../../../tools/harness-fixtures";
 
 /**
  * Smoke test for the section-11 snapshot harness oracle.
@@ -29,7 +30,13 @@ describe("section-11 snapshot loop", () => {
     expect(manifest.section_11_sha).toMatch(/^[0-9a-f]{40}$/);
     expect(manifest.section_11_protocol_version).toMatch(/^\d+\.\d+$/);
     expect(manifest.section_11_commit_date).toMatch(/^\d{4}-\d{2}-\d{2}T/);
-    expect(manifest.fixtures).toContain("realistic-athlete");
+    // Assert the FULL allowlist, not just one slug: a single-fixture debug
+    // regen that clobbered the manifest down to its own slug would slip past a
+    // `toContain("realistic-athlete")` check whenever that slug is the one
+    // debugged. Pinned to HARNESS_FIXTURES, the single source of truth.
+    expect([...manifest.fixtures].sort()).toEqual(
+      HARNESS_FIXTURES.map((f) => f.slug).sort(),
+    );
     expect(manifest.metrics.length).toBeGreaterThan(0);
     expect(manifest.frozen_now).toBe("2026-05-10T12:00:00");
   });

--- a/tools/snapshot-manifest.test.ts
+++ b/tools/snapshot-manifest.test.ts
@@ -1,0 +1,213 @@
+import {
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import type { Manifest } from "./check-metric-parity";
+import { DEFAULT_FROZEN_NOW } from "./harness-fixtures.js";
+import {
+  buildManifest,
+  loadManifestForDebugOrThrow,
+  type ManifestCoordinates,
+  mergeManifestForDebug,
+} from "./snapshot-manifest.js";
+
+/**
+ * Tests for the snapshot oracle's manifest builders. The full-regen path
+ * (`buildManifest`) must stay byte-identical to the committed manifest; the
+ * debug path (`mergeManifestForDebug`) must patch one fixture into the index
+ * without dropping the others — the defect issue #015 documents.
+ */
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SNAPSHOTS_ROOT = resolve(
+  __dirname,
+  "../packages/core/tests/fixtures/snapshots",
+);
+
+const COORDS: ManifestCoordinates = {
+  sha: "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  protocolVersion: "3.112",
+  commitDate: "2026-04-30T21:50:59+02:00",
+  pyodideVersion: "0.29.4",
+};
+
+function manifestWith(overrides: Partial<Manifest>): Manifest {
+  return {
+    section_11_sha: COORDS.sha,
+    section_11_protocol_version: COORDS.protocolVersion,
+    section_11_commit_date: COORDS.commitDate,
+    fixtures: ["alpha", "beta"],
+    metrics: ["acwr", "monotony", "strain"],
+    pyodide_version: COORDS.pyodideVersion,
+    frozen_now: DEFAULT_FROZEN_NOW,
+    offline_mode: "A_stub_requests_plus_monkey_patch",
+    ...overrides,
+  };
+}
+
+describe("buildManifest", () => {
+  it("sorts + dedupes fixtures and metrics with the canonical field order", () => {
+    const manifest = buildManifest(
+      [
+        { slug: "beta", metrics: ["monotony", "acwr"] },
+        { slug: "alpha", metrics: ["acwr", "strain"] },
+      ],
+      COORDS,
+    );
+    expect(manifest.fixtures).toEqual(["alpha", "beta"]);
+    expect(manifest.metrics).toEqual(["acwr", "monotony", "strain"]);
+    expect(Object.keys(manifest)).toEqual([
+      "section_11_sha",
+      "section_11_protocol_version",
+      "section_11_commit_date",
+      "fixtures",
+      "metrics",
+      "pyodide_version",
+      "frozen_now",
+      "offline_mode",
+    ]);
+    expect(manifest.frozen_now).toBe(DEFAULT_FROZEN_NOW);
+    expect(manifest.offline_mode).toBe("A_stub_requests_plus_monkey_patch");
+  });
+
+  it("reconstructs the committed manifest byte-identically from the on-disk snapshot tree", () => {
+    // The hermetic byte-identity gate: prove the extraction matches the
+    // committed full-regen manifest WITHOUT booting Pyodide. If buildManifest
+    // ever drifts from the inline construction this catches it.
+    const committedBytes = readFileSync(
+      join(SNAPSHOTS_ROOT, "manifest.json"),
+      "utf8",
+    );
+    const committed = JSON.parse(committedBytes) as Manifest;
+
+    const slugs = readdirSync(SNAPSHOTS_ROOT).filter((entry) =>
+      statSync(join(SNAPSHOTS_ROOT, entry)).isDirectory(),
+    );
+    const results = slugs.map((slug) => ({
+      slug,
+      metrics: readdirSync(join(SNAPSHOTS_ROOT, slug))
+        .filter((f) => f.endsWith(".json"))
+        .map((f) => f.replace(/\.json$/, "")),
+    }));
+
+    const rebuilt = buildManifest(results, {
+      sha: committed.section_11_sha,
+      protocolVersion: committed.section_11_protocol_version,
+      commitDate: committed.section_11_commit_date,
+      pyodideVersion: committed.pyodide_version,
+    });
+    expect(`${JSON.stringify(rebuilt, null, 2)}\n`).toBe(committedBytes);
+  });
+});
+
+describe("mergeManifestForDebug", () => {
+  it("patches one fixture into the index, preserving every other entry", () => {
+    const existing = manifestWith({
+      fixtures: ["alpha", "beta", "gamma"],
+      metrics: ["acwr", "monotony", "strain"],
+    });
+    const merged = mergeManifestForDebug(
+      existing,
+      [{ slug: "beta", metrics: ["acwr", "monotony"] }],
+      COORDS,
+    );
+    expect(merged.fixtures).toEqual(["alpha", "beta", "gamma"]);
+    expect(merged.metrics).toEqual(["acwr", "monotony", "strain"]);
+  });
+
+  it("is a no-op (byte-identical) when re-merging an already-indexed fixture", () => {
+    const existing = manifestWith({
+      fixtures: ["alpha", "beta", "gamma"],
+      metrics: ["acwr", "monotony", "strain"],
+    });
+    const merged = mergeManifestForDebug(
+      existing,
+      [{ slug: "beta", metrics: ["acwr", "monotony", "strain"] }],
+      COORDS,
+    );
+    expect(JSON.stringify(merged)).toBe(JSON.stringify(existing));
+  });
+
+  it("adds a new fixture's slug + any new metrics to the union", () => {
+    const existing = manifestWith({
+      fixtures: ["alpha", "beta"],
+      metrics: ["acwr", "monotony"],
+    });
+    const merged = mergeManifestForDebug(
+      existing,
+      [{ slug: "delta", metrics: ["monotony", "vo2max"] }],
+      COORDS,
+    );
+    expect(merged.fixtures).toEqual(["alpha", "beta", "delta"]);
+    expect(merged.metrics).toEqual(["acwr", "monotony", "vo2max"]);
+  });
+
+  it("keeps a metric the debugged fixture no longer emits (union, not replace)", () => {
+    // Other fixtures may still emit it; the global metric list is a union, so
+    // a single fixture dropping a metric must not prune it from the index.
+    const existing = manifestWith({
+      fixtures: ["alpha"],
+      metrics: ["acwr", "monotony", "strain"],
+    });
+    const merged = mergeManifestForDebug(
+      existing,
+      [{ slug: "alpha", metrics: ["acwr"] }],
+      COORDS,
+    );
+    expect(merged.metrics).toEqual(["acwr", "monotony", "strain"]);
+  });
+
+  it.each([
+    ["sha", { section_11_sha: "0".repeat(40) }],
+    ["protocol_version", { section_11_protocol_version: "3.999" }],
+    ["commit_date", { section_11_commit_date: "1999-01-01T00:00:00+00:00" }],
+    ["pyodide_version", { pyodide_version: "0.0.1" }],
+  ])("throws on a %s mismatch against the current toolchain", (_field, drift) => {
+    const existing = manifestWith(drift as Partial<Manifest>);
+    expect(() =>
+      mergeManifestForDebug(
+        existing,
+        [{ slug: "alpha", metrics: ["acwr"] }],
+        COORDS,
+      ),
+    ).toThrow(/pnpm snapshot:section-11/);
+  });
+});
+
+describe("loadManifestForDebugOrThrow", () => {
+  function withTempDir(fn: (dir: string) => void): void {
+    const dir = mkdtempSync(join(tmpdir(), "snapshot-manifest-test-"));
+    try {
+      fn(dir);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
+  it("reads and parses an existing manifest", () => {
+    withTempDir((dir) => {
+      const path = join(dir, "manifest.json");
+      const manifest = manifestWith({});
+      writeFileSync(path, JSON.stringify(manifest));
+      expect(loadManifestForDebugOrThrow(path)).toEqual(manifest);
+    });
+  });
+
+  it("throws instructively when no manifest exists", () => {
+    withTempDir((dir) => {
+      expect(() =>
+        loadManifestForDebugOrThrow(join(dir, "manifest.json")),
+      ).toThrow(/requires an existing manifest/);
+    });
+  });
+});

--- a/tools/snapshot-manifest.ts
+++ b/tools/snapshot-manifest.ts
@@ -1,0 +1,127 @@
+/**
+ * Pure builders for the snapshot oracle's `manifest.json`, split out of
+ * the harness CLI so they're unit-testable without booting Pyodide
+ * (snapshot-section-11.ts runs `main()` at module load).
+ *
+ * Two construction paths:
+ *  - `buildManifest` — the full-regen path: the manifest is the index of
+ *    every fixture the run just processed.
+ *  - `mergeManifestForDebug` — the single-fixture debug path
+ *    (SNAPSHOT_FIXTURE_PATH): the run only touched one fixture, so the
+ *    manifest must be PATCHED into the existing index, not rebuilt from
+ *    the one slug — otherwise the other fixtures silently vanish from the
+ *    index while their snapshot files stay on disk (a lying manifest).
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+
+import type { Manifest } from "./check-metric-parity";
+import { DEFAULT_FROZEN_NOW } from "./harness-fixtures.js";
+
+export interface FixtureResult {
+  slug: string;
+  metrics: string[];
+}
+
+export interface ManifestCoordinates {
+  sha: string;
+  protocolVersion: string;
+  commitDate: string;
+  pyodideVersion: string;
+}
+
+const OFFLINE_MODE = "A_stub_requests_plus_monkey_patch" as const;
+
+function dedupeSorted(values: string[]): string[] {
+  return [...new Set(values)].sort();
+}
+
+function composeManifest(
+  coords: ManifestCoordinates,
+  fixtures: string[],
+  metrics: string[],
+): Manifest {
+  // Field order is load-bearing: JSON.stringify preserves insertion order,
+  // and the determinism test asserts byte-identical manifests across runs.
+  return {
+    section_11_sha: coords.sha,
+    section_11_protocol_version: coords.protocolVersion,
+    section_11_commit_date: coords.commitDate,
+    fixtures,
+    metrics,
+    pyodide_version: coords.pyodideVersion,
+    frozen_now: DEFAULT_FROZEN_NOW,
+    offline_mode: OFFLINE_MODE,
+  };
+}
+
+export function buildManifest(
+  results: FixtureResult[],
+  coords: ManifestCoordinates,
+): Manifest {
+  return composeManifest(
+    coords,
+    dedupeSorted(results.map((r) => r.slug)),
+    dedupeSorted(results.flatMap((r) => r.metrics)),
+  );
+}
+
+export function mergeManifestForDebug(
+  existing: Manifest,
+  results: FixtureResult[],
+  coords: ManifestCoordinates,
+): Manifest {
+  assertCoordinatesMatch(existing, coords);
+  return composeManifest(
+    coords,
+    dedupeSorted([...existing.fixtures, ...results.map((r) => r.slug)]),
+    dedupeSorted([...existing.metrics, ...results.flatMap((r) => r.metrics)]),
+  );
+}
+
+function assertCoordinatesMatch(
+  existing: Manifest,
+  coords: ManifestCoordinates,
+): void {
+  const drift: string[] = [];
+  if (existing.section_11_sha !== coords.sha) {
+    drift.push(`sha: ${existing.section_11_sha} -> ${coords.sha}`);
+  }
+  if (existing.section_11_protocol_version !== coords.protocolVersion) {
+    drift.push(
+      `protocol_version: ${existing.section_11_protocol_version} -> ${coords.protocolVersion}`,
+    );
+  }
+  if (existing.section_11_commit_date !== coords.commitDate) {
+    drift.push(
+      `commit_date: ${existing.section_11_commit_date} -> ${coords.commitDate}`,
+    );
+  }
+  if (existing.pyodide_version !== coords.pyodideVersion) {
+    drift.push(
+      `pyodide_version: ${existing.pyodide_version} -> ${coords.pyodideVersion}`,
+    );
+  }
+  if (drift.length > 0) {
+    throw new Error(
+      `Debug regen (SNAPSHOT_FIXTURE_PATH) refused: the existing manifest's ` +
+        `oracle coordinates differ from the current toolchain:\n  ${drift.join("\n  ")}\n` +
+        `Merging one fixture would leave the other fixtures' entries pinned to ` +
+        `stale coordinates. Run a full \`pnpm snapshot:section-11\` to regenerate ` +
+        `every fixture against the current toolchain.`,
+    );
+  }
+}
+
+export function loadManifestForDebugOrThrow(manifestPath: string): Manifest {
+  if (!existsSync(manifestPath)) {
+    throw new Error(
+      `Debug regen (SNAPSHOT_FIXTURE_PATH) requires an existing manifest at ` +
+        `${manifestPath}, but none was found. A debug regen patches one fixture ` +
+        `into an already-initialized snapshot tree; run a full ` +
+        `\`pnpm snapshot:section-11\` once to initialize it before iterating on a ` +
+        `single fixture.`,
+    );
+  }
+  return JSON.parse(readFileSync(manifestPath, "utf8")) as Manifest;
+}

--- a/tools/snapshot-section-11.ts
+++ b/tools/snapshot-section-11.ts
@@ -26,17 +26,22 @@ import { fileURLToPath } from "node:url";
 
 import { loadPyodide } from "pyodide";
 
-import type { Manifest, Snapshot } from "./check-metric-parity";
+import type { Snapshot } from "./check-metric-parity";
 import {
   HARNESS_CONTRACT,
   OPTIONAL_FIXTURE_PATHS,
 } from "./harness-contract.js";
 import {
-  DEFAULT_FROZEN_NOW,
   HARNESS_FIXTURES,
   resolveFixtureAnchor,
 } from "./harness-fixtures.js";
 import { runNativeCheckGate } from "./native-check-gate.js";
+import {
+  buildManifest,
+  loadManifestForDebugOrThrow,
+  mergeManifestForDebug,
+  type ManifestCoordinates,
+} from "./snapshot-manifest.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, "..");
@@ -641,9 +646,11 @@ async function main(): Promise<void> {
   const goldenDir = resolve(REPO_ROOT, GOLDEN_DIR_REL);
   const manifestPath = join(snapshotRoot, "manifest.json");
 
+  const debugFixturePath = process.env.SNAPSHOT_FIXTURE_PATH;
+  const isDebug = Boolean(debugFixturePath);
   let fixtures: FixtureEntry[];
-  if (process.env.SNAPSHOT_FIXTURE_PATH) {
-    const path = resolve(process.env.SNAPSHOT_FIXTURE_PATH);
+  if (debugFixturePath) {
+    const path = resolve(debugFixturePath);
     if (!existsSync(path)) {
       throw new Error(`Fixture not found: ${path}`);
     }
@@ -711,19 +718,23 @@ async function main(): Promise<void> {
     results.push({ slug: fixture.slug, metrics });
   }
 
-  const fixtureSlugs = results.map((r) => r.slug).sort();
-  const allMetrics = [...new Set(results.flatMap((r) => r.metrics))].sort();
-
-  const manifest: Manifest = {
-    section_11_sha: sha,
-    section_11_protocol_version: protocolVersion,
-    section_11_commit_date: commitDate,
-    fixtures: fixtureSlugs,
-    metrics: allMetrics,
-    pyodide_version: pyodideVersion,
-    frozen_now: DEFAULT_FROZEN_NOW,
-    offline_mode: "A_stub_requests_plus_monkey_patch",
+  const coords: ManifestCoordinates = {
+    sha,
+    protocolVersion,
+    commitDate,
+    pyodideVersion,
   };
+  // The debug path processed a single fixture; patch it into the existing
+  // index instead of rebuilding from one slug (which would drop the rest).
+  // Built AFTER the fixture loop so a contract violation in processFixture
+  // surfaces first and the merge never runs on a corrupt fixture.
+  const manifest = isDebug
+    ? mergeManifestForDebug(
+        loadManifestForDebugOrThrow(manifestPath),
+        results,
+        coords,
+      )
+    : buildManifest(results, coords);
   writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
 
   for (const { slug, metrics } of results) {
@@ -734,7 +745,7 @@ async function main(): Promise<void> {
   }
   // eslint-disable-next-line no-console
   console.log(
-    `[snapshot] manifest pins ${fixtureSlugs.length} fixture(s) + ${allMetrics.length} metric(s)`,
+    `[snapshot] manifest pins ${manifest.fixtures.length} fixture(s) + ${manifest.metrics.length} metric(s)`,
   );
 
   // Gate the regen on a green native runtime-parity diff: re-run the just-


### PR DESCRIPTION
## What

Fixes the single-fixture debug snapshot regen clobbering the snapshot index.

The `SNAPSHOT_FIXTURE_PATH` debug path processes one fixture but rebuilt
`manifest.json` from that single slug — silently dropping every other fixture
from the index (their snapshot files on disk untouched, only the manifest lied)
and collapsing the metric union down to the one fixture's metrics. The
asymmetric index smoke test missed the corruption whenever the debugged slug was
the one the test named.

## Changes

- **New `tools/snapshot-manifest.ts`** — three pure, unit-testable manifest
  builders, split out so they're testable without booting the WASM oracle:
  - `buildManifest` — full-regen path, extracted byte-identical from the old
    inline construction (field order preserved).
  - `mergeManifestForDebug` — debug path: unions the processed slug into the
    existing `fixtures` + `metrics` and preserves the rest; throws when the
    existing manifest's oracle coordinates (sha / protocol / commit-date /
    pyodide) diverge from the current toolchain, so a stale-coordinate partial
    manifest can't land.
  - `loadManifestForDebugOrThrow` — throws loudly when no manifest exists (a
    debug regen presumes an initialized snapshot tree).
- **`tools/snapshot-section-11.ts`** — `main()` branches at manifest-write time,
  *after* the fixture loop, so a contract violation in `processFixture` still
  surfaces first.
- **`reference-metrics-snapshot-loop.test.ts`** — asserts `manifest.fixtures`
  equals the full `HARNESS_FIXTURES` allowlist, closing the asymmetric hole.
- **`tools/snapshot-manifest.test.ts`** — unit tests for the merge, including a
  hermetic byte-identity gate that reconstructs the committed manifest from the
  on-disk snapshot tree.

## Test plan

- Full suite green: 1734 passed / 2 skipped.
- Full-regen determinism + debug-path contract tests confirmed executed (not
  skipped) and passing.
- End-to-end: a real single-fixture debug regen now reports
  `manifest pins 13 fixture(s) + 63 metric(s)` and leaves the working tree
  byte-stable (committable-and-correct manifest).
- `pnpm -r build`, oxlint, `check:fixture-privacy`, `check:trademarks` clean.
