### PR TITLE
feat(core): Reference-layer validation — sync gate, audit log, response grounding

### DIFF
--- a/.changeset/reference-audit-log-and-metadata-schema.md
+++ b/.changeset/reference-audit-log-and-metadata-schema.md
@@ -1,0 +1,21 @@
+---
+"@enduragent/core": patch
+---
+
+Add the Reference layer's recommendation-metadata + audit-log substrate. Two
+new `.strict()` Zod schemas — `RecommendationMetadata` (the citations /
+confidence / frameworks / phase-tag contract every coaching reply carries) and
+`AuditLogEntry` (the on-disk `.audit.jsonl` line shape) — plus an
+`AUDIT_SCHEMA_VERSION` constant. The writer (`writeAuditEntry`) atomic-appends
+one compact JSONL line per reply via `open(path, "a")` (O_APPEND), creating the
+data dir on first write; it is best-effort and never throws, warning per
+failure and escalating once via `console.error` after 10 cumulative failures in
+a session. The parser (`parseAuditLog`) streams the log, dispatches on
+`schema_version` before the schema parse, and is robust to manual corruption —
+malformed JSON and unknown-version lines are skipped with a warn, a missing
+file yields an empty iterable. `computeResponseHash` derives the 16-char reply
+fingerprint stored on each entry.
+
+Trust-substrate only — this ships the schema + writer/parser but does not yet
+wire them into the live reply path. Athletes notice nothing until a later wave
+plumbs the writer into the coaching turn.

--- a/.changeset/reference-layer1-sync-gate.md
+++ b/.changeset/reference-layer1-sync-gate.md
@@ -1,0 +1,14 @@
+---
+"@enduragent/core": patch
+---
+
+Add the Reference layer's Layer-1 sync gate. The previously-stubbed
+`gateLatestJson` now runs seven mechanical checks before a snapshot is written —
+data-fetch presence, FTP source resolvability, weekly-hours consistency,
+value-tolerance bands, 24h freshness, clock-offset drift, and multi-metric
+conflict. Checks use resolve-or-skip semantics (an absent signal passes, so the
+empty-data path is never bricked; only present-and-invalid values fail). Hard
+failures block the write and record error state; soft warnings still write, and
+a fully clean sync clears stale error state after the commit marker. Downstream
+of the metrics layer — it only reads and checks already-computed values, it does
+not recompute any metric.

--- a/.changeset/reference-layer2-3-response-grounding.md
+++ b/.changeset/reference-layer2-3-response-grounding.md
@@ -1,0 +1,13 @@
+---
+"@enduragent/core": patch
+---
+
+Add the Reference layer's Layer-2 response validator and Layer-3 grounding
+prompt rules. `validateRecommendation` parses the `---meta---` block a reply
+carries, walks dot-paths into the latest snapshot, and asserts every cited value
+exists and matches (±0.01 tolerance for numbers, strict equality for everything
+else). `validateAndRetry` orchestrates an optional single regeneration (a hard
+one-retry cap) across three modes (off / observe / enforce, default observe).
+The Layer-3 data-grounding rules are appended to the system prompt so numeric
+claims trace back to the snapshot read this turn. The validator is not yet wired
+into the live reply path; that lands with the cutover wave.

--- a/packages/core/src/agent/system-prompt.ts
+++ b/packages/core/src/agent/system-prompt.ts
@@ -1,5 +1,6 @@
 import type { SportPersona } from "../sport.js";
 import type { Memory } from "../memory/store.js";
+import { LAYER_3_PROMPT_RULES } from "../reference/validation/layer3-prompt.js";
 
 // ============================================================================
 // SYSTEM PROMPT BUILDER
@@ -114,9 +115,10 @@ export function buildSystemPrompt(
   // doesn't go stale crossing local midnight. See user-time.ts.
   parts.push(`# Current Date & Time\n\nTime zone: ${tz}`);
 
-  // Output rules ride the recency slot — review block is last so its rules
-  // sit closest to the user message in the prompt.
+  // Output rules ride the recency slot — review block then the data-grounding
+  // rules sit closest to the user message in the prompt.
   parts.push(WORKOUT_REVIEW_RULES);
+  parts.push(LAYER_3_PROMPT_RULES);
 
   return parts.join("\n\n---\n\n");
 }

--- a/packages/core/src/reference/audit/parse.ts
+++ b/packages/core/src/reference/audit/parse.ts
@@ -1,0 +1,65 @@
+/**
+ * Reference layer — audit-log parser.
+ *
+ * Streams `<data>/.audit.jsonl` line-by-line and yields each entry that parses
+ * cleanly under the current `AuditLogEntrySchema`. A version-switch reads
+ * `schema_version` before the schema parse so future formats can be dispatched
+ * without breaking this reader. Robust to manual file corruption: malformed
+ * JSON and unknown-version lines are warned and skipped; a missing file yields
+ * an empty iterable with no warning (missing is normal). Ports from the
+ * Reference layer's upstream protocol. See `NOTICE.md` for license attribution.
+ */
+import { createReadStream, existsSync } from "node:fs";
+import { createInterface } from "node:readline";
+import { join } from "node:path";
+import { referenceDataDir } from "../paths.js";
+import {
+  AUDIT_SCHEMA_VERSION,
+  AuditLogEntrySchema,
+  type AuditLogEntry,
+} from "../validation/recommendation-metadata.js";
+
+export async function* parseAuditLog(
+  binaryName: string,
+): AsyncGenerator<AuditLogEntry> {
+  const path = join(referenceDataDir(binaryName), ".audit.jsonl");
+  if (!existsSync(path)) return;
+
+  const rl = createInterface({
+    input: createReadStream(path, { encoding: "utf-8" }),
+    crlfDelay: Infinity,
+  });
+
+  for await (const rawLine of rl) {
+    const line = rawLine.trim();
+    if (line === "") continue;
+
+    let obj: unknown;
+    try {
+      obj = JSON.parse(line);
+    } catch {
+      console.warn(
+        `parseAuditLog: skipping malformed JSON line: ${line.slice(0, 80)}`,
+      );
+      continue;
+    }
+
+    const version = (obj as { schema_version?: unknown })?.schema_version;
+    if (version !== AUDIT_SCHEMA_VERSION) {
+      console.warn(
+        `parseAuditLog: skipping unknown schema_version ${String(version)} (parser supports ${AUDIT_SCHEMA_VERSION})`,
+      );
+      continue;
+    }
+
+    const result = AuditLogEntrySchema.safeParse(obj);
+    if (!result.success) {
+      console.warn(
+        `parseAuditLog: skipping line failing schema: ${result.error.message}`,
+      );
+      continue;
+    }
+
+    yield result.data;
+  }
+}

--- a/packages/core/src/reference/audit/writer.ts
+++ b/packages/core/src/reference/audit/writer.ts
@@ -1,0 +1,72 @@
+/**
+ * Reference layer — audit-log writer.
+ *
+ * Appends one compact JSONL line per coaching reply to `<data>/.audit.jsonl`
+ * via `open(path, "a")` (O_APPEND). Best-effort: never throws, so a full disk
+ * or a permission error can never break the reply path. Per-failure warns; a
+ * one-time `console.error` escalation fires after 10 cumulative failures in a
+ * session. Ports from the Reference layer's upstream protocol. See `NOTICE.md`
+ * for license attribution.
+ */
+import { open, mkdir } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { dirname, join } from "node:path";
+import { referenceDataDir } from "../paths.js";
+import {
+  type AuditLogEntry,
+  type RecommendationMetadata,
+} from "../validation/recommendation-metadata.js";
+
+let auditWriteFailureCount = 0;
+let escalated = false;
+
+export async function writeAuditEntry(
+  binaryName: string,
+  entry: AuditLogEntry,
+): Promise<void> {
+  const path = join(referenceDataDir(binaryName), ".audit.jsonl");
+  const line = JSON.stringify(entry) + "\n";
+
+  try {
+    await mkdir(dirname(path), { recursive: true });
+    const fh = await open(path, "a", 0o644);
+    try {
+      await fh.appendFile(line, "utf-8");
+    } finally {
+      await fh.close();
+    }
+  } catch (err) {
+    handleFailure(err);
+  }
+}
+
+function handleFailure(err: unknown): void {
+  console.warn(`Reference: audit log write failed: ${formatError(err)}`);
+  auditWriteFailureCount++;
+  if (auditWriteFailureCount >= 10 && !escalated) {
+    escalated = true;
+    console.error(
+      "Reference: audit log writer has failed 10 times this session — disk full or permission issue likely. Audit trail is being lost.",
+    );
+  }
+}
+
+export function computeResponseHash(
+  responseText: string,
+  metadata: RecommendationMetadata,
+): string {
+  return createHash("sha256")
+    .update(responseText + JSON.stringify(metadata))
+    .digest("hex")
+    .slice(0, 16);
+}
+
+export function __resetAuditFailureState(): void {
+  auditWriteFailureCount = 0;
+  escalated = false;
+}
+
+function formatError(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/packages/core/src/reference/index.ts
+++ b/packages/core/src/reference/index.ts
@@ -101,3 +101,41 @@ export {
   type RenamedActivityRow,
   type RenamedWellnessRow,
 } from "./sync/rename-tp-fields.js";
+
+// ─── Validation: recommendation metadata + audit log ──────────────────
+export {
+  AUDIT_SCHEMA_VERSION,
+  CitationSchema,
+  type Citation,
+  RecommendationMetadataSchema,
+  type RecommendationMetadata,
+  AuditLogEntrySchema,
+  type AuditLogEntry,
+} from "./validation/recommendation-metadata.js";
+export { writeAuditEntry, computeResponseHash } from "./audit/writer.js";
+export { parseAuditLog } from "./audit/parse.js";
+
+// ─── Validation: Layer-1 sync gate ────────────────────────────────────
+export { gateLatestJson } from "./validation/sync-gate.js";
+export type {
+  GateResult,
+  GateStep,
+  GateFailure,
+  GateWarning,
+} from "./validation/sync-gate.js";
+
+// ─── Validation: Layer-2 validator + Layer-3 prompt rules ──────────────
+export {
+  validateRecommendation,
+  parseMetaBlock,
+  getByPath,
+  DEFAULT_LAYER_2_MODE,
+  type Layer2Mode,
+  type ValidationResult,
+} from "./validation/validate-response.js";
+export {
+  validateAndRetry,
+  type RetryOpts,
+  type RetryResult,
+} from "./validation/retry-with-feedback.js";
+export { LAYER_3_PROMPT_RULES } from "./validation/layer3-prompt.js";

--- a/packages/core/src/reference/sync/error-state-writer.ts
+++ b/packages/core/src/reference/sync/error-state-writer.ts
@@ -1,7 +1,9 @@
 import { join } from "node:path";
+import { unlink } from "node:fs/promises";
 import {
   ERROR_STATE_SCHEMA_VERSION,
   type ErrorPhase,
+  type ErrorMitigation,
 } from "../schemas/error-state.js";
 import { atomicWriteJson } from "../../io/atomic-write-json.js";
 
@@ -10,12 +12,18 @@ export type { ErrorPhase };
 /**
  * Atomic-write `error_state.json` to the data dir. Called by `runSync()`
  * when the outer 2-min timeout fires (with `phase` set per ADR-0011's
- * commit-marker-last write order) or when the Layer-1 gate rejects a fetch
- * (with `phase` omitted). Cleared on the next successful sync.
+ * commit-marker-last write order), when the Layer-1 gate rejects a fetch
+ * (with `phase` omitted), or on the soft-warn path (with
+ * `mitigation: "warn_only"`). Cleared on the next fully-clean sync.
  */
 export async function writeErrorState(
   dataDir: string,
-  payload: { step: string; detail: string; phase?: ErrorPhase },
+  payload: {
+    step: string;
+    detail: string;
+    phase?: ErrorPhase;
+    mitigation?: ErrorMitigation;
+  },
 ): Promise<void> {
   await atomicWriteJson(join(dataDir, "error_state.json"), {
     schema_version: ERROR_STATE_SCHEMA_VERSION,
@@ -23,5 +31,21 @@ export async function writeErrorState(
     detail: payload.detail,
     ts: new Date().toISOString(),
     ...(payload.phase !== undefined ? { phase: payload.phase } : {}),
+    ...(payload.mitigation !== undefined ? { mitigation: payload.mitigation } : {}),
   });
+}
+
+/**
+ * Best-effort remove `error_state.json`. Called on the fully-clean sync path
+ * AFTER the `.scheduler.json` commit marker lands (ADR-0011 commit-marker-last)
+ * so a curator reading mid-sync never sees a contradictory scheduler-fresh +
+ * stale-error_state interleave. Swallows ENOENT — a missing file is the
+ * desired post-state.
+ */
+export async function clearErrorState(dataDir: string): Promise<void> {
+  try {
+    await unlink(join(dataDir, "error_state.json"));
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code !== "ENOENT") throw err;
+  }
 }

--- a/packages/core/src/reference/sync/run-sync.ts
+++ b/packages/core/src/reference/sync/run-sync.ts
@@ -14,7 +14,7 @@ import { FTP_HISTORY_SCHEMA_VERSION } from "../schemas/ftp-history.js";
 import { SCHEDULER_SCHEMA_VERSION } from "../schemas/scheduler.js";
 import type { ErrorPhase, ErrorCaller } from "../schemas/error-state.js";
 import { gateLatestJson } from "../validation/sync-gate.js";
-import { writeErrorState } from "./error-state-writer.js";
+import { writeErrorState, clearErrorState } from "./error-state-writer.js";
 import type { AsyncMutex } from "../../concurrency/mutex.js";
 import type { Cooldown } from "../../concurrency/cooldown.js";
 import type { Clock } from "../../concurrency/clock.js";
@@ -113,10 +113,12 @@ export interface RunSyncDeps {
     readonly outerTimeoutMs?: number;
     readonly scheduledIntervalMs?: number;
   };
-  /** Override Layer-1 gate for tests; defaults to the stub `gateLatestJson`. */
+  /** Override Layer-1 gate for tests; defaults to `gateLatestJson`. */
   readonly gate?: typeof gateLatestJson;
   /** Override atomic write for tests; defaults to `atomicWriteJson`. */
   readonly atomicWrite?: (path: string, value: unknown) => Promise<void>;
+  /** Override error_state.json removal for tests; defaults to `clearErrorState`. */
+  readonly clearError?: (dataDir: string) => Promise<void>;
 }
 
 interface CacheWriteSpec {
@@ -144,6 +146,7 @@ export function createRunSync(
   const scheduledIntervalMs = deps.timing?.scheduledIntervalMs ?? SCHEDULED_SYNC_INTERVAL_MS;
   const gate = deps.gate ?? gateLatestJson;
   const writeJson = deps.atomicWrite ?? atomicWriteJson;
+  const clearError = deps.clearError ?? clearErrorState;
 
   return async (opts = {}) => {
     if (opts.caller === "/sync" && opts.chatId !== undefined) {
@@ -176,7 +179,9 @@ export function createRunSync(
           if (controller.signal.aborted) return abortedResult();
 
           phase = "gating";
-          const gateResult = gate(fetched, null);
+          // `prior` is null here: no current mechanical check consumes the
+          // on-disk LatestJson, so prior-vs-incoming comparison is not yet wired.
+          const gateResult = gate(fetched, null, now());
           if (!gateResult.ok) {
             await writeErrorState(deps.dataDir, {
               step: "gate_rejected",
@@ -206,7 +211,7 @@ export function createRunSync(
               file: "latest",
               version: LATEST_SCHEMA_VERSION,
               payload: fetched.latest,
-              extras: { freshness: "fresh" },
+              extras: { freshness: gateResult.freshness ?? "fresh" },
             },
             { file: "history", version: HISTORY_SCHEMA_VERSION, payload: fetched.history },
             { file: "intervals", version: INTERVALS_SCHEMA_VERSION, payload: fetched.intervals },
@@ -238,6 +243,21 @@ export function createRunSync(
             last_sync_at: lastUpdated,
             next_sync_at: new Date(now().getTime() + scheduledIntervalMs).toISOString(),
           });
+
+          // error_state.json lifecycle, AFTER the commit marker (ADR-0011
+          // commit-marker-last) so a curator reading mid-sync never observes a
+          // scheduler-fresh + error_state-present contradiction. Soft warnings
+          // record a non-blocking warn_only state; a fully-clean sync clears
+          // any error_state left by a prior failed/soft run.
+          if (gateResult.warnings.length > 0) {
+            await writeErrorState(deps.dataDir, {
+              step: "gate_warnings",
+              detail: gateResult.warnings.map((w) => `${w.step}: ${w.detail}`).join("; "),
+              mitigation: "warn_only",
+            });
+          } else {
+            await clearError(deps.dataDir);
+          }
 
           return {
             kind: "ran",

--- a/packages/core/src/reference/validation/checks/step0-data-fetch.ts
+++ b/packages/core/src/reference/validation/checks/step0-data-fetch.ts
@@ -1,0 +1,35 @@
+/**
+ * Step 0 (HARD): all five source envelopes were fetched. Maps to the upstream
+ * protocol's data-fetch precondition. See `NOTICE.md` for license attribution.
+ */
+import type { FetchedReference } from "../../sync/run-sync.js";
+import type { CheckResult, GateFailure } from "../sync-gate.js";
+
+const TOP_LEVEL_KEYS: readonly (keyof FetchedReference)[] = [
+  "latest",
+  "history",
+  "intervals",
+  "routes",
+  "ftp_history",
+];
+
+export function checkDataFetch(fetched: FetchedReference): CheckResult {
+  const failures: GateFailure[] = [];
+
+  if (fetched === null || fetched === undefined) {
+    return {
+      failures: [{ step: "step0_data_fetch", detail: "source envelope missing: <root>" }],
+      warnings: [],
+    };
+  }
+
+  const envelope = fetched as unknown as Record<string, unknown>;
+  for (const key of TOP_LEVEL_KEYS) {
+    const value = envelope[key];
+    if (value === null || value === undefined) {
+      failures.push({ step: "step0_data_fetch", detail: `source envelope missing: ${key}` });
+    }
+  }
+
+  return { failures, warnings: [] };
+}

--- a/packages/core/src/reference/validation/checks/step1-ftp-source.ts
+++ b/packages/core/src/reference/validation/checks/step1-ftp-source.ts
@@ -1,0 +1,65 @@
+/**
+ * Step 1 (HARD): FTP is resolvable and positive from the athlete profile.
+ * Maps to the upstream protocol's FTP-source precondition. See `NOTICE.md`
+ * for license attribution.
+ */
+import type { FetchedReference } from "../../sync/run-sync.js";
+import type { CheckResult, GateFailure } from "../sync-gate.js";
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+/**
+ * Collect every FTP-bearing value the athlete profile exposes, in either the
+ * `sportSettings[*].ftp` / `.indoor_ftp` shape or the
+ * `thresholds.sports.<family>.ftp` shape. Returns an empty list when no FTP
+ * source is present (RESOLVE-OR-SKIP: a profile that ships no FTP source must
+ * not hard-fail — the pre-cutover fetcher returns an empty stub).
+ */
+export function collectFtpValues(fetched: FetchedReference): number[] {
+  const profile = asRecord(fetched?.latest?.athlete_profile);
+  if (profile === null) return [];
+
+  const values: number[] = [];
+
+  const sportSettings = profile.sportSettings;
+  if (Array.isArray(sportSettings)) {
+    for (const row of sportSettings) {
+      const r = asRecord(row);
+      if (r === null) continue;
+      if (typeof r.ftp === "number") values.push(r.ftp);
+      if (typeof r.indoor_ftp === "number") values.push(r.indoor_ftp);
+    }
+  }
+
+  const thresholds = asRecord(profile.thresholds);
+  const sports = thresholds === null ? null : asRecord(thresholds.sports);
+  if (sports !== null) {
+    for (const family of Object.values(sports)) {
+      const f = asRecord(family);
+      if (f !== null && typeof f.ftp === "number") values.push(f.ftp);
+    }
+  }
+
+  return values;
+}
+
+export function checkFtpSource(fetched: FetchedReference): CheckResult {
+  const values = collectFtpValues(fetched);
+  if (values.length === 0) return { failures: [], warnings: [] };
+
+  const failures: GateFailure[] = [];
+  for (const value of values) {
+    if (!Number.isFinite(value) || value <= 0) {
+      failures.push({
+        step: "step1_ftp_source",
+        detail: `FTP source present but invalid: ${value}`,
+      });
+    }
+  }
+
+  return { failures, warnings: [] };
+}

--- a/packages/core/src/reference/validation/checks/step2-weekly-hours.ts
+++ b/packages/core/src/reference/validation/checks/step2-weekly-hours.ts
@@ -1,0 +1,84 @@
+/**
+ * Step 2 (HARD): the trailing-7-day activity-duration sum agrees with the
+ * profile's reported weekly hours within tolerance. Maps to the upstream
+ * protocol's weekly-hours consistency check. See `NOTICE.md` for license
+ * attribution.
+ */
+import type { FetchedReference } from "../../sync/run-sync.js";
+import type { CheckResult } from "../sync-gate.js";
+
+const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+const RELATIVE_TOLERANCE = 0.01;
+/** When reported weekly hours is zero, allow a few minutes of noise before failing. */
+const ABS_FLOOR_HOURS = 0.05;
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function parseDateMs(value: unknown): number | null {
+  if (typeof value !== "string") return null;
+  const ms = Date.parse(value);
+  return Number.isFinite(ms) ? ms : null;
+}
+
+export function checkWeeklyHours(fetched: FetchedReference): CheckResult {
+  const profile = asRecord(fetched?.latest?.athlete_profile);
+  const quickStats = profile === null ? null : asRecord(profile.quick_stats);
+  const weeklyHours =
+    quickStats !== null && typeof quickStats.weekly_hours === "number"
+      ? quickStats.weekly_hours
+      : null;
+
+  const activities = fetched?.latest?.recent_activities;
+  if (weeklyHours === null || !Array.isArray(activities) || activities.length === 0) {
+    return { failures: [], warnings: [] };
+  }
+
+  const dated = activities
+    .map((a) => {
+      const r = asRecord(a);
+      if (r === null) return null;
+      const ms = parseDateMs(r.start_date_local);
+      const movingTime = typeof r.moving_time === "number" ? r.moving_time : null;
+      if (ms === null || movingTime === null) return null;
+      return { ms, movingTime };
+    })
+    .filter((x): x is { ms: number; movingTime: number } => x !== null);
+
+  if (dated.length === 0) return { failures: [], warnings: [] };
+
+  const newest = Math.max(...dated.map((d) => d.ms));
+  const actualSecs = dated
+    .filter((d) => newest - d.ms <= SEVEN_DAYS_MS)
+    .reduce((sum, d) => sum + d.movingTime, 0);
+  const actualHours = actualSecs / 3600;
+
+  if (weeklyHours === 0) {
+    if (actualHours <= ABS_FLOOR_HOURS) return { failures: [], warnings: [] };
+    return {
+      failures: [
+        {
+          step: "step2_weekly_hours_consistency",
+          detail: `weekly hours mismatch: expected 0h actual ${actualHours}h (above floor ${ABS_FLOOR_HOURS}h)`,
+        },
+      ],
+      warnings: [],
+    };
+  }
+
+  const relErr = Math.abs(actualHours - weeklyHours) / weeklyHours;
+  if (relErr <= RELATIVE_TOLERANCE) return { failures: [], warnings: [] };
+
+  return {
+    failures: [
+      {
+        step: "step2_weekly_hours_consistency",
+        detail: `weekly hours mismatch: expected ${weeklyHours}h actual ${actualHours}h (relErr ${relErr})`,
+      },
+    ],
+    warnings: [],
+  };
+}

--- a/packages/core/src/reference/validation/checks/step4-tolerance.ts
+++ b/packages/core/src/reference/validation/checks/step4-tolerance.ts
@@ -1,0 +1,91 @@
+/**
+ * Step 4 (HARD): present numeric fields fall inside physiologically plausible
+ * bands. Maps to the upstream protocol's tolerance-band check. See `NOTICE.md`
+ * for license attribution.
+ */
+import type { FetchedReference } from "../../sync/run-sync.js";
+import type { CheckResult, GateFailure } from "../sync-gate.js";
+import { collectFtpValues } from "./step1-ftp-source.js";
+
+interface Band {
+  readonly field: string;
+  readonly lo: number;
+  readonly hi: number;
+}
+
+const BANDS: Readonly<Record<string, Band>> = {
+  weight: { field: "weight", lo: 30, hi: 200 },
+  ftp: { field: "ftp", lo: 50, hi: 600 },
+  hr: { field: "hr", lo: 30, hi: 220 },
+};
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function checkBand(
+  band: Band,
+  value: unknown,
+  failures: GateFailure[],
+): void {
+  if (typeof value !== "number" || !Number.isFinite(value)) return;
+  if (value < band.lo || value > band.hi) {
+    failures.push({
+      step: "step4_tolerance_band",
+      detail: `${band.field}=${value} out of band [${band.lo},${band.hi}]`,
+    });
+  }
+}
+
+function checkNonNegative(
+  field: string,
+  value: unknown,
+  failures: GateFailure[],
+): void {
+  if (typeof value !== "number" || !Number.isFinite(value)) return;
+  if (value < 0) {
+    failures.push({
+      step: "step4_tolerance_band",
+      detail: `${field}=${value} out of band [0,Infinity]`,
+    });
+  }
+}
+
+export function checkTolerance(fetched: FetchedReference): CheckResult {
+  const failures: GateFailure[] = [];
+
+  for (const ftp of collectFtpValues(fetched)) {
+    checkBand(BANDS.ftp, ftp, failures);
+  }
+
+  const wellness = asRecord(fetched?.latest?.wellness_data);
+  const wellnessRows: unknown[] = wellness !== null && Array.isArray(wellness.days)
+    ? wellness.days
+    : Array.isArray(fetched?.latest?.wellness_data)
+      ? (fetched.latest.wellness_data as unknown[])
+      : wellness !== null
+        ? [wellness]
+        : [];
+  for (const row of wellnessRows) {
+    const r = asRecord(row);
+    if (r === null) continue;
+    checkBand(BANDS.weight, r.weight, failures);
+    checkBand(BANDS.hr, r.restingHR, failures);
+  }
+
+  const activities = fetched?.latest?.recent_activities;
+  if (Array.isArray(activities)) {
+    for (const a of activities) {
+      const r = asRecord(a);
+      if (r === null) continue;
+      checkBand(BANDS.hr, r.average_heartrate, failures);
+      checkNonNegative("moving_time", r.moving_time, failures);
+      checkNonNegative("elapsed_time", r.elapsed_time, failures);
+      checkNonNegative("icu_training_load", r.icu_training_load, failures);
+    }
+  }
+
+  return { failures, warnings: [] };
+}

--- a/packages/core/src/reference/validation/checks/step6-freshness-24h.ts
+++ b/packages/core/src/reference/validation/checks/step6-freshness-24h.ts
@@ -1,0 +1,66 @@
+/**
+ * Step 6 (SOFT): annotate data freshness against the 24/48h/7d bands. Maps to
+ * the upstream protocol's freshness check. Never hard-fails — a stale-but-valid
+ * bundle still commits, carrying the band forward as a warning. See `NOTICE.md`
+ * for license attribution.
+ */
+import type { FetchedReference } from "../../sync/run-sync.js";
+import type { CheckResult } from "../sync-gate.js";
+import { freshnessOf, type Freshness } from "../../sync/freshness-check.js";
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+/**
+ * Best-effort source timestamp for the fetched bundle: the latest envelope's
+ * server-stamped `metadata.last_updated` when present, else the newest activity
+ * `start_date_local`. Returns `null` when neither is available (cannot assess).
+ */
+export function sourceTimestamp(fetched: FetchedReference): string | null {
+  const latest = asRecord(fetched?.latest);
+  const metadata = latest === null ? null : asRecord(latest.metadata);
+  if (metadata !== null && typeof metadata.last_updated === "string") {
+    return metadata.last_updated;
+  }
+
+  const activities = fetched?.latest?.recent_activities;
+  if (Array.isArray(activities)) {
+    let newest: string | null = null;
+    let newestMs = -Infinity;
+    for (const a of activities) {
+      const r = asRecord(a);
+      if (r === null || typeof r.start_date_local !== "string") continue;
+      const ms = Date.parse(r.start_date_local);
+      if (Number.isFinite(ms) && ms > newestMs) {
+        newestMs = ms;
+        newest = r.start_date_local;
+      }
+    }
+    return newest;
+  }
+
+  return null;
+}
+
+export function checkFreshness(
+  fetched: FetchedReference,
+  now: Date,
+): CheckResult & { freshness: Freshness } {
+  const ts = sourceTimestamp(fetched);
+  if (ts === null) {
+    return { failures: [], warnings: [], freshness: "fresh" };
+  }
+
+  const freshness = freshnessOf({ last_updated: ts }, now);
+  return {
+    failures: [],
+    warnings:
+      freshness === "fresh"
+        ? []
+        : [{ step: "step6_freshness_24h", detail: `data freshness=${freshness}` }],
+    freshness,
+  };
+}

--- a/packages/core/src/reference/validation/checks/step6b-clock-offset.ts
+++ b/packages/core/src/reference/validation/checks/step6b-clock-offset.ts
@@ -1,0 +1,47 @@
+/**
+ * Step 6b (HARD): local clock vs the server response timestamp drift stays
+ * under one hour. Maps to the upstream protocol's clock-offset check. See
+ * `NOTICE.md` for license attribution.
+ */
+import type { FetchedReference } from "../../sync/run-sync.js";
+import type { CheckResult } from "../sync-gate.js";
+
+const CLOCK_DRIFT_MAX_MS = 60 * 60 * 1000;
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+/** Server-stamped timestamp only — drift can only be assessed against the
+ *  server's own clock, never an activity's local-time stamp. */
+function serverTimestamp(fetched: FetchedReference): string | null {
+  const latest = asRecord(fetched?.latest);
+  const metadata = latest === null ? null : asRecord(latest.metadata);
+  if (metadata !== null && typeof metadata.last_updated === "string") {
+    return metadata.last_updated;
+  }
+  return null;
+}
+
+export function checkClockOffset(fetched: FetchedReference, now: Date): CheckResult {
+  const ts = serverTimestamp(fetched);
+  if (ts === null) return { failures: [], warnings: [] };
+
+  const serverMs = Date.parse(ts);
+  if (!Number.isFinite(serverMs)) return { failures: [], warnings: [] };
+
+  const driftMs = Math.abs(now.getTime() - serverMs);
+  if (driftMs <= CLOCK_DRIFT_MAX_MS) return { failures: [], warnings: [] };
+
+  return {
+    failures: [
+      {
+        step: "step6b_clock_offset",
+        detail: `clock drift ${Math.round(driftMs / 60000)}min exceeds 60min`,
+      },
+    ],
+    warnings: [],
+  };
+}

--- a/packages/core/src/reference/validation/checks/step7-multi-metric-conflict.ts
+++ b/packages/core/src/reference/validation/checks/step7-multi-metric-conflict.ts
@@ -1,0 +1,49 @@
+/**
+ * Step 7 (SOFT): record cross-signal inconsistencies as warnings. Maps to the
+ * upstream protocol's multi-metric conflict check. Never hard-fails. See
+ * `NOTICE.md` for license attribution.
+ */
+import type { FetchedReference } from "../../sync/run-sync.js";
+import type { CheckResult, GateWarning } from "../sync-gate.js";
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function num(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+export function checkMultiMetricConflict(fetched: FetchedReference): CheckResult {
+  const warnings: GateWarning[] = [];
+
+  const profile = asRecord(fetched?.latest?.athlete_profile);
+  const quickStats = profile === null ? null : asRecord(profile.quick_stats);
+
+  const weeklyHours = quickStats === null ? null : num(quickStats.weekly_hours);
+  const weeklyLoad = quickStats === null ? null : num(quickStats.weekly_load);
+  if (weeklyHours !== null && weeklyLoad !== null && weeklyHours > 0 && weeklyLoad === 0) {
+    warnings.push({
+      step: "step7_multi_metric_conflict",
+      detail: `weekly_hours=${weeklyHours} but weekly_load=0`,
+    });
+  }
+
+  const activities = fetched?.latest?.recent_activities;
+  const activitiesCount = quickStats === null ? null : num(quickStats.activities_count);
+  if (
+    Array.isArray(activities) &&
+    activities.length > 0 &&
+    activitiesCount !== null &&
+    activitiesCount === 0
+  ) {
+    warnings.push({
+      step: "step7_multi_metric_conflict",
+      detail: `recent_activities=${activities.length} but activities_count=0`,
+    });
+  }
+
+  return { failures: [], warnings };
+}

--- a/packages/core/src/reference/validation/layer3-prompt.ts
+++ b/packages/core/src/reference/validation/layer3-prompt.ts
@@ -1,0 +1,14 @@
+/**
+ * Reference layer — Layer-3 data-grounding prompt rules.
+ *
+ * The behavioral rules injected into every system prompt so the model grounds
+ * its numeric claims in the snapshot read this turn. These rules port from the
+ * Reference layer's upstream protocol. See `NOTICE.md` for license attribution.
+ */
+export const LAYER_3_PROMPT_RULES = `# Data Grounding (Layer 3)
+
+Numeric claims MUST come from the current JSON snapshot you read this turn. Conversational context — the athlete said they felt tired, mentioned a goal, named an upcoming event — carries across turns and you may rely on it. Numbers do not: every Fitness, Fatigue, Form, Load, Intensity, FTP, zone, duration, or other figure you state must trace back to a field in the snapshot you read this turn, not to a value remembered from an earlier message or assumed from a default.
+
+When required data is missing, ask the athlete for it; never substitute a default or a plausible-sounding estimate. A reply that admits "I don't have your latest numbers" is correct; a reply that invents them is not.
+
+When the snapshot's confidence is low, say so. State the limitation plainly in your reply so the athlete knows the recommendation rests on incomplete or stale data.`;

--- a/packages/core/src/reference/validation/recommendation-metadata.ts
+++ b/packages/core/src/reference/validation/recommendation-metadata.ts
@@ -1,0 +1,43 @@
+/**
+ * Reference layer — recommendation metadata + audit-log line schemas.
+ *
+ * `RecommendationMetadata` is the structured contract every Reference-era
+ * coaching reply carries (citations, confidence, frameworks, phase tag);
+ * Layer 2 enforces it. `AuditLogEntry` is the `.audit.jsonl` line shape the
+ * writer persists. These shapes port from the Reference layer's upstream
+ * protocol. See `NOTICE.md` for license attribution.
+ */
+import { z } from "zod";
+
+export const AUDIT_SCHEMA_VERSION = "1";
+
+export const CitationSchema = z
+  .object({
+    field: z.string(),
+    value: z.unknown(),
+    source: z.literal("latest.json"),
+  })
+  .strict();
+export type Citation = z.infer<typeof CitationSchema>;
+
+export const RecommendationMetadataSchema = z
+  .object({
+    citations: z.array(CitationSchema),
+    confidence: z.enum(["high", "medium", "low"]),
+    frameworks: z.array(z.string()).min(1),
+    phase_tag: z.string(),
+  })
+  .strict();
+export type RecommendationMetadata = z.infer<typeof RecommendationMetadataSchema>;
+
+export const AuditLogEntrySchema = z
+  .object({
+    schema_version: z.string(),
+    ts: z.string(),
+    chatId: z.string(),
+    responseHash: z.string(),
+    metadata: RecommendationMetadataSchema,
+    validation_warning: z.boolean().optional(),
+  })
+  .strict();
+export type AuditLogEntry = z.infer<typeof AuditLogEntrySchema>;

--- a/packages/core/src/reference/validation/retry-with-feedback.ts
+++ b/packages/core/src/reference/validation/retry-with-feedback.ts
@@ -1,0 +1,86 @@
+/**
+ * Reference layer — Layer-2 retry orchestrator.
+ *
+ * Validates one coaching reply against the latest snapshot and, in enforce
+ * mode, retries the LLM exactly once with the failure quoted back as feedback.
+ * The retry cap is HARD: at most one regeneration, never a loop. Mode-aware
+ * (off / observe / enforce). The audit write is the caller's concern; this
+ * module only returns flags. Ports from the Reference layer's
+ * upstream protocol. See `NOTICE.md` for license attribution.
+ */
+import type { LLM } from "../../llm.js";
+import type { LatestJson } from "../schemas/latest.js";
+import {
+  validateRecommendation,
+  parseMetaBlock,
+  type Layer2Mode,
+} from "./validate-response.js";
+import {
+  RecommendationMetadataSchema,
+  type RecommendationMetadata,
+} from "./recommendation-metadata.js";
+
+export interface RetryOpts {
+  mode: Layer2Mode;
+  snapshot: LatestJson;
+  systemPrompt?: string;
+}
+
+export interface RetryResult {
+  response: string;
+  metadata: RecommendationMetadata | null;
+  validation_warning?: boolean;
+  would_have_retried?: boolean;
+}
+
+function parseMetadata(metadata: unknown): RecommendationMetadata | null {
+  return RecommendationMetadataSchema.safeParse(metadata).data ?? null;
+}
+
+export async function validateAndRetry(
+  llm: Pick<LLM, "generate">,
+  _originalUserPrompt: string,
+  response: string,
+  metadata: unknown,
+  opts: RetryOpts,
+): Promise<RetryResult> {
+  if (opts.mode === "off") {
+    return { response, metadata: parseMetadata(metadata) };
+  }
+
+  const first = validateRecommendation(response, metadata, opts.snapshot);
+
+  if (opts.mode === "observe") {
+    return {
+      response,
+      metadata: parseMetadata(metadata),
+      would_have_retried: !first.ok,
+    };
+  }
+
+  // enforce
+  if (first.ok) {
+    return { response, metadata: parseMetadata(metadata) };
+  }
+
+  const retryPrompt = `Your previous response had a citation mismatch:
+- ${first.feedback}
+Please regenerate your reply, citing only values that exist in the latest snapshot. Same coaching content, corrected numbers.`;
+
+  const result = await llm.generate({
+    system: opts.systemPrompt,
+    prompt: retryPrompt,
+  });
+  const retryText = result.text;
+
+  const retryBlock = parseMetaBlock(retryText);
+  const retryMeta = retryBlock?.metadataJson;
+  // Second validation is FINAL — the cap is one retry, no loop back here.
+  const second = validateRecommendation(retryText, retryMeta, opts.snapshot);
+
+  return {
+    response: retryText,
+    metadata: parseMetadata(retryMeta),
+    validation_warning: second.ok ? undefined : true,
+  };
+}

--- a/packages/core/src/reference/validation/sync-gate.ts
+++ b/packages/core/src/reference/validation/sync-gate.ts
@@ -1,28 +1,88 @@
 /**
- * Layer-1 sync gate. STUB — always returns ok. A future body will add
- * mechanical checks (FTP source, weekly hours, UTC clock, tolerance bands,
- * etc.).
+ * Layer-1 sync gate. Runs seven mechanical checks over a freshly-fetched
+ * Reference bundle before its cache files are committed: five HARD checks
+ * (any failure rejects the sync) and two SOFT checks (annotations that ride
+ * through as warnings without blocking the write).
+ *
+ * Checks read the upstream protocol's source fields. See `NOTICE.md` for
+ * license attribution.
  *
  * The call site already exists in `runSync()` (between fetch and cache-file
- * writes) so the future implementation is a body-only change, not a new
- * cross-layer seam.
+ * writes); this body fills in the previously-stubbed gate.
  */
+import type { FetchedReference } from "../sync/run-sync.js";
+import type { LatestJson } from "../schemas/latest.js";
+import type { Freshness } from "../sync/freshness-check.js";
+
+import { checkDataFetch } from "./checks/step0-data-fetch.js";
+import { checkFtpSource } from "./checks/step1-ftp-source.js";
+import { checkWeeklyHours } from "./checks/step2-weekly-hours.js";
+import { checkTolerance } from "./checks/step4-tolerance.js";
+import { checkFreshness } from "./checks/step6-freshness-24h.js";
+import { checkClockOffset } from "./checks/step6b-clock-offset.js";
+import { checkMultiMetricConflict } from "./checks/step7-multi-metric-conflict.js";
+
+export type GateStep =
+  | "step0_data_fetch"
+  | "step1_ftp_source"
+  | "step2_weekly_hours_consistency"
+  | "step4_tolerance_band"
+  | "step6_freshness_24h"
+  | "step6b_clock_offset"
+  | "step7_multi_metric_conflict";
+
 export interface GateFailure {
-  readonly step: string;
+  readonly step: GateStep;
   readonly detail: string;
 }
 
 export interface GateWarning {
-  readonly step: string;
+  readonly step: GateStep;
   readonly detail: string;
+}
+
+/** A single check's contribution to the aggregate gate result. */
+export interface CheckResult {
+  readonly failures: readonly GateFailure[];
+  readonly warnings: readonly GateWarning[];
 }
 
 export interface GateResult {
   readonly ok: boolean;
   readonly failures: readonly GateFailure[];
   readonly warnings: readonly GateWarning[];
+  /**
+   * Freshness band derived by the step-6 annotator. `runSync()` writes it to
+   * `latest.json.metadata.freshness` so the gate is the single source for the
+   * band rather than the orchestrator hardcoding `"fresh"`.
+   */
+  readonly freshness?: Freshness;
 }
 
-export function gateLatestJson(_fetched: unknown, _prior: unknown): GateResult {
-  return { ok: true, failures: [], warnings: [] };
+export function gateLatestJson(
+  fetched: FetchedReference,
+  _prior: LatestJson | null,
+  now: Date = new Date(),
+): GateResult {
+  const freshnessResult = checkFreshness(fetched, now);
+
+  const results: readonly CheckResult[] = [
+    checkDataFetch(fetched),
+    checkFtpSource(fetched),
+    checkWeeklyHours(fetched),
+    checkTolerance(fetched),
+    freshnessResult,
+    checkClockOffset(fetched, now),
+    checkMultiMetricConflict(fetched),
+  ];
+
+  const failures = results.flatMap((r) => r.failures);
+  const warnings = results.flatMap((r) => r.warnings);
+
+  return {
+    ok: failures.length === 0,
+    failures,
+    warnings,
+    freshness: freshnessResult.freshness,
+  };
 }

--- a/packages/core/src/reference/validation/validate-response.ts
+++ b/packages/core/src/reference/validation/validate-response.ts
@@ -1,0 +1,128 @@
+/**
+ * Reference layer — Layer-2 LLM-output validator.
+ *
+ * Pure functions only (no LLM, no IO). Parses the `---meta---` block an athlete
+ * reply carries, walks dot-paths into the latest snapshot, and asserts every
+ * cited number/string the reply claims actually exists in the data read this
+ * turn. The `RecommendationMetadata` contract ports from the Reference layer's
+ * upstream protocol. See `NOTICE.md` for license attribution.
+ */
+import { createHash } from "node:crypto";
+import {
+  RecommendationMetadataSchema,
+  type RecommendationMetadata,
+} from "./recommendation-metadata.js";
+import type { LatestJson } from "../schemas/latest.js";
+
+export type Layer2Mode = "off" | "observe" | "enforce";
+
+/**
+ * Default Layer-2 mode: validate and flag, never retry. The caller passes any
+ * operator override through; absent one, validation observes without retrying.
+ */
+export const DEFAULT_LAYER_2_MODE: Layer2Mode = "observe";
+
+export interface ValidationResult {
+  ok: boolean;
+  feedback?: string;
+}
+
+const META_DELIMITER = "---meta---";
+
+function responseHash(response: string): string {
+  return createHash("sha256").update(response).digest("hex").slice(0, 16);
+}
+
+/**
+ * Splits a reply on the literal `---meta---` delimiter line and returns the
+ * LAST block parsed as JSON. When the reply carries more than one block it
+ * warns with the response hash (the agent should emit exactly one). Returns
+ * null when there is no block or the final block is not valid JSON.
+ */
+export function parseMetaBlock(
+  response: string,
+): { metadataJson: unknown; blockCount: number } | null {
+  const parts = response.split(new RegExp(`^${META_DELIMITER}\\s*$`, "m"));
+  // First part is the prose before any delimiter; each subsequent part is a
+  // candidate metadata block.
+  const blocks = parts.slice(1);
+  if (blocks.length === 0) return null;
+
+  if (blocks.length > 1) {
+    console.warn(
+      `Reference: reply carried ${blocks.length} ---meta--- blocks (expected 1); using the last. response=${responseHash(response)}`,
+    );
+  }
+
+  const last = blocks[blocks.length - 1];
+  try {
+    return { metadataJson: JSON.parse(last), blockCount: blocks.length };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * lodash-get-style dot-path walk. Returns undefined on any null/undefined hop
+ * or a missing key.
+ */
+export function getByPath(obj: unknown, path: string): unknown {
+  return path.split(".").reduce<unknown>((acc, key) => {
+    if (acc === null || acc === undefined) return undefined;
+    return (acc as Record<string, unknown>)[key];
+  }, obj);
+}
+
+/**
+ * Asserts every citation in `metadata` resolves to a matching value in the
+ * snapshot. Numbers compare within a ±0.01 tolerance; strings/enums compare
+ * strictly. Returns the first failure's feedback string (the exact phrasing the
+ * enforce-mode retry prompt quotes back to the LLM).
+ */
+export function validateRecommendation(
+  _response: string,
+  metadata: unknown,
+  snapshot: LatestJson,
+): ValidationResult {
+  const parsed = RecommendationMetadataSchema.safeParse(metadata);
+  if (!parsed.success) {
+    return {
+      ok: false,
+      feedback: `Metadata failed schema validation: ${parsed.error.message}`,
+    };
+  }
+
+  const meta: RecommendationMetadata = parsed.data;
+  for (const citation of meta.citations) {
+    const actual = getByPath(snapshot, citation.field);
+    if (actual === undefined) {
+      return {
+        ok: false,
+        feedback: `Citation source missing: ${citation.field} not found in snapshot.`,
+      };
+    }
+
+    if (!valuesMatch(actual, citation.value)) {
+      return {
+        ok: false,
+        feedback: `Citation mismatch: cited ${citation.field}=${String(citation.value)}, snapshot has ${String(actual)}.`,
+      };
+    }
+  }
+
+  return { ok: true };
+}
+
+function valuesMatch(actual: unknown, cited: unknown): boolean {
+  // Apply the ±0.01 numeric tolerance only when BOTH sides are real numbers.
+  // CitationSchema.value is `unknown`, and Number() coerces false/null/"" to 0,
+  // so without this typeof guard a snapshot (or cited) false/null/"" would
+  // spuriously satisfy a 0 citation. Anything non-numeric — strings, enums,
+  // booleans, null — compares strictly.
+  if (typeof actual === "number" && typeof cited === "number") {
+    if (Number.isFinite(actual) && Number.isFinite(cited)) {
+      return Math.abs(actual - cited) <= 0.01;
+    }
+  }
+  return actual === cited;
+}

--- a/packages/core/tests/reference-audit-parse.test.ts
+++ b/packages/core/tests/reference-audit-parse.test.ts
@@ -1,0 +1,137 @@
+import {
+  mkdtempSync,
+  rmSync,
+  mkdirSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  writeAuditEntry,
+  __resetAuditFailureState,
+} from "../src/reference/audit/writer.js";
+import { parseAuditLog } from "../src/reference/audit/parse.js";
+import {
+  AUDIT_SCHEMA_VERSION,
+  type AuditLogEntry,
+  type RecommendationMetadata,
+} from "../src/reference/validation/recommendation-metadata.js";
+
+const BINARY = "cycling-coach";
+
+const metadata: RecommendationMetadata = {
+  citations: [
+    { field: "current_status.acwr.value", value: 1.12, source: "latest.json" },
+  ],
+  confidence: "high",
+  frameworks: ["polarized"],
+  phase_tag: "build",
+};
+
+function makeEntry(overrides: Partial<AuditLogEntry> = {}): AuditLogEntry {
+  return {
+    schema_version: AUDIT_SCHEMA_VERSION,
+    ts: new Date().toISOString(),
+    chatId: "12345",
+    responseHash: "abcdef0123456789",
+    metadata,
+    ...overrides,
+  };
+}
+
+let tempDir: string;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "reference-audit-parse-"));
+  process.env.CYCLING_COACH_HOME = tempDir;
+  __resetAuditFailureState();
+});
+
+afterEach(() => {
+  delete process.env.CYCLING_COACH_HOME;
+  rmSync(tempDir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+function dataPath(): string {
+  return join(tempDir, "data", ".audit.jsonl");
+}
+
+function writeRawLog(contents: string): void {
+  mkdirSync(join(tempDir, "data"), { recursive: true });
+  writeFileSync(dataPath(), contents, "utf-8");
+}
+
+async function collect(): Promise<AuditLogEntry[]> {
+  const out: AuditLogEntry[] = [];
+  for await (const entry of parseAuditLog(BINARY)) {
+    out.push(entry);
+  }
+  return out;
+}
+
+describe("parseAuditLog", () => {
+  it("round-trips entries written by writeAuditEntry, in order", async () => {
+    const a = makeEntry({ chatId: "a", responseHash: "0000000000000001" });
+    const b = makeEntry({ chatId: "b", responseHash: "0000000000000002" });
+    const c = makeEntry({ chatId: "c", responseHash: "0000000000000003" });
+    await writeAuditEntry(BINARY, a);
+    await writeAuditEntry(BINARY, b);
+    await writeAuditEntry(BINARY, c);
+
+    const parsed = await collect();
+    expect(parsed).toEqual([a, b, c]);
+  });
+
+  it("skips an unknown schema_version line with a warn", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const valid = makeEntry({ chatId: "v1" });
+    const future = makeEntry({ chatId: "v2", schema_version: "2" });
+    writeRawLog(JSON.stringify(valid) + "\n" + JSON.stringify(future) + "\n");
+
+    const parsed = await collect();
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].chatId).toBe("v1");
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain("schema_version 2");
+  });
+
+  it("skips a malformed JSON line with a warn", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const valid = makeEntry({ chatId: "ok" });
+    writeRawLog(JSON.stringify(valid) + "\n" + "{not json\n");
+
+    const parsed = await collect();
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].chatId).toBe("ok");
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns an empty iterable for an empty file (no warn)", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    writeRawLog("");
+
+    const parsed = await collect();
+    expect(parsed).toEqual([]);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns an empty iterable for a missing file with NO warn", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const parsed = await collect();
+    expect(parsed).toEqual([]);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("skips blank/whitespace lines silently (trailing newline yields no phantom)", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    await writeAuditEntry(BINARY, makeEntry({ chatId: "one" }));
+    await writeAuditEntry(BINARY, makeEntry({ chatId: "two" }));
+
+    const parsed = await collect();
+    expect(parsed).toHaveLength(2);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/tests/reference-audit-writer.test.ts
+++ b/packages/core/tests/reference-audit-writer.test.ts
@@ -1,0 +1,166 @@
+import {
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  existsSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  writeAuditEntry,
+  computeResponseHash,
+  __resetAuditFailureState,
+} from "../src/reference/audit/writer.js";
+import {
+  AUDIT_SCHEMA_VERSION,
+  AuditLogEntrySchema,
+  type AuditLogEntry,
+  type RecommendationMetadata,
+} from "../src/reference/validation/recommendation-metadata.js";
+
+const BINARY = "cycling-coach";
+
+const metadata: RecommendationMetadata = {
+  citations: [
+    { field: "current_status.acwr.value", value: 1.12, source: "latest.json" },
+  ],
+  confidence: "high",
+  frameworks: ["polarized"],
+  phase_tag: "build",
+};
+
+function makeEntry(overrides: Partial<AuditLogEntry> = {}): AuditLogEntry {
+  return {
+    schema_version: AUDIT_SCHEMA_VERSION,
+    ts: new Date().toISOString(),
+    chatId: "12345",
+    responseHash: "abcdef0123456789",
+    metadata,
+    ...overrides,
+  };
+}
+
+let tempDir: string;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "reference-audit-"));
+  process.env.CYCLING_COACH_HOME = tempDir;
+  __resetAuditFailureState();
+});
+
+afterEach(() => {
+  delete process.env.CYCLING_COACH_HOME;
+  rmSync(tempDir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+function auditPath(): string {
+  return join(tempDir, "data", ".audit.jsonl");
+}
+
+function readLines(): string[] {
+  return readFileSync(auditPath(), "utf-8")
+    .split("\n")
+    .filter((l) => l !== "");
+}
+
+describe("writeAuditEntry — append semantics", () => {
+  it("appends exactly one valid JSONL line per call", async () => {
+    await writeAuditEntry(BINARY, makeEntry());
+
+    const lines = readLines();
+    expect(lines).toHaveLength(1);
+    const parsed = AuditLogEntrySchema.parse(JSON.parse(lines[0]));
+    expect(parsed.chatId).toBe("12345");
+  });
+
+  it("creates the parent data directory if missing on first write", async () => {
+    expect(existsSync(join(tempDir, "data"))).toBe(false);
+
+    await writeAuditEntry(BINARY, makeEntry());
+
+    expect(existsSync(join(tempDir, "data"))).toBe(true);
+  });
+
+  it("writes compact lines with no embedded newline — N calls yield N lines", async () => {
+    await writeAuditEntry(BINARY, makeEntry({ chatId: "a" }));
+    await writeAuditEntry(BINARY, makeEntry({ chatId: "b" }));
+    await writeAuditEntry(BINARY, makeEntry({ chatId: "c" }));
+
+    expect(readLines()).toHaveLength(3);
+  });
+
+  it("does not interleave concurrent appends — 20 lines all parse cleanly", async () => {
+    const writes = Array.from({ length: 20 }, (_, i) =>
+      writeAuditEntry(
+        BINARY,
+        makeEntry({
+          chatId: `chat-${i}`,
+          responseHash: String(i).padStart(16, "0"),
+        }),
+      ),
+    );
+    await Promise.all(writes);
+
+    const lines = readLines();
+    expect(lines).toHaveLength(20);
+    const hashes = new Set<string>();
+    for (const line of lines) {
+      const parsed = AuditLogEntrySchema.parse(JSON.parse(line));
+      hashes.add(parsed.responseHash);
+    }
+    expect(hashes.size).toBe(20);
+  });
+});
+
+describe("writeAuditEntry — best-effort failure handling", () => {
+  // Force a real filesystem failure by planting a regular file where the
+  // writer expects the `data` directory; `mkdir(..., {recursive:true})` then
+  // throws EEXIST on every call — no ESM module spying needed.
+  function plantFileAtDataDir(): void {
+    writeFileSync(join(tempDir, "data"), "not a directory", "utf-8");
+  }
+
+  it("logs a warn but does NOT throw on a write failure", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    plantFileAtDataDir();
+
+    await expect(writeAuditEntry(BINARY, makeEntry())).resolves.toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires console.error EXACTLY ONCE after 10 cumulative failures", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    plantFileAtDataDir();
+
+    for (let i = 0; i < 10; i++) {
+      await writeAuditEntry(BINARY, makeEntry());
+    }
+
+    expect(warnSpy).toHaveBeenCalledTimes(10);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledWith(
+      "Reference: audit log writer has failed 10 times this session — disk full or permission issue likely. Audit trail is being lost.",
+    );
+
+    // An 11th failure must NOT re-fire the escalation.
+    await writeAuditEntry(BINARY, makeEntry());
+    expect(warnSpy).toHaveBeenCalledTimes(11);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("computeResponseHash", () => {
+  it("is deterministic, 16 chars, and sensitive to the response text", () => {
+    const h1 = computeResponseHash("Ride easy today.", metadata);
+    const h2 = computeResponseHash("Ride easy today.", metadata);
+    const h3 = computeResponseHash("Go hard today.", metadata);
+
+    expect(h1).toBe(h2);
+    expect(h1).toHaveLength(16);
+    expect(h1).not.toBe(h3);
+  });
+});

--- a/packages/core/tests/reference-recommendation-metadata.test.ts
+++ b/packages/core/tests/reference-recommendation-metadata.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from "vitest";
+import {
+  AUDIT_SCHEMA_VERSION,
+  CitationSchema,
+  RecommendationMetadataSchema,
+  AuditLogEntrySchema,
+  type RecommendationMetadata,
+} from "../src/reference/validation/recommendation-metadata.js";
+
+const validMetadata: RecommendationMetadata = {
+  citations: [
+    { field: "current_status.acwr.value", value: 1.12, source: "latest.json" },
+  ],
+  confidence: "high",
+  frameworks: ["polarized"],
+  phase_tag: "build",
+};
+
+describe("RecommendationMetadataSchema", () => {
+  it("accepts a fully-valid object and round-trips it", () => {
+    const parsed = RecommendationMetadataSchema.parse(validMetadata);
+    expect(parsed).toEqual(validMetadata);
+  });
+
+  it("rejects an empty frameworks array (min(1) violation)", () => {
+    expect(() =>
+      RecommendationMetadataSchema.parse({ ...validMetadata, frameworks: [] }),
+    ).toThrow();
+  });
+
+  it("rejects a confidence outside {high,medium,low}", () => {
+    expect(() =>
+      RecommendationMetadataSchema.parse({
+        ...validMetadata,
+        confidence: "very-high",
+      }),
+    ).toThrow();
+  });
+
+  it("rejects an unknown top-level field (.strict() boundary)", () => {
+    expect(() =>
+      RecommendationMetadataSchema.parse({ ...validMetadata, extra: "x" }),
+    ).toThrow();
+  });
+});
+
+describe("CitationSchema", () => {
+  it("rejects a source other than 'latest.json' (z.literal violation)", () => {
+    expect(() =>
+      CitationSchema.parse({
+        field: "current_status.acwr.value",
+        value: 1.12,
+        source: "history.json",
+      }),
+    ).toThrow();
+  });
+
+  it("rejects an unknown field (.strict() boundary)", () => {
+    expect(() =>
+      CitationSchema.parse({
+        field: "x",
+        value: 1,
+        source: "latest.json",
+        extra: "nope",
+      }),
+    ).toThrow();
+  });
+});
+
+describe("AuditLogEntrySchema", () => {
+  it("exposes AUDIT_SCHEMA_VERSION === '1'", () => {
+    expect(AUDIT_SCHEMA_VERSION).toBe("1");
+  });
+
+  it("accepts a valid entry and round-trips it", () => {
+    const entry = {
+      schema_version: AUDIT_SCHEMA_VERSION,
+      ts: new Date().toISOString(),
+      chatId: "12345",
+      responseHash: "abcdef0123456789",
+      metadata: validMetadata,
+    };
+    const parsed = AuditLogEntrySchema.parse(entry);
+    expect(parsed).toEqual(entry);
+  });
+
+  it("accepts the optional validation_warning field and round-trips it", () => {
+    const entry = {
+      schema_version: AUDIT_SCHEMA_VERSION,
+      ts: new Date().toISOString(),
+      chatId: "12345",
+      responseHash: "abcdef0123456789",
+      metadata: validMetadata,
+      validation_warning: true,
+    };
+    const parsed = AuditLogEntrySchema.parse(entry);
+    expect(parsed.validation_warning).toBe(true);
+  });
+
+  it("rejects an unknown top-level field (.strict() boundary)", () => {
+    expect(() =>
+      AuditLogEntrySchema.parse({
+        schema_version: AUDIT_SCHEMA_VERSION,
+        ts: new Date().toISOString(),
+        chatId: "12345",
+        responseHash: "abcdef0123456789",
+        metadata: validMetadata,
+        future_field_typo: "nope",
+      }),
+    ).toThrow();
+  });
+});

--- a/packages/core/tests/reference-retry-with-feedback.test.ts
+++ b/packages/core/tests/reference-retry-with-feedback.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect } from "vitest";
+import type { ModelMessage } from "ai";
+import { validateAndRetry } from "../src/reference/validation/retry-with-feedback.js";
+import type { LatestJson } from "../src/reference/schemas/latest.js";
+import type { LLM } from "../src/llm.js";
+
+function makeSnapshot(currentStatus: unknown): LatestJson {
+  return {
+    metadata: {
+      schema_version: "1",
+      last_updated: "1998-06-08T00:00:00.000Z",
+      freshness: "fresh",
+    },
+    athlete_profile: {},
+    current_status: currentStatus,
+    derived_metrics: {},
+    recent_activities: [],
+    planned_workouts: [],
+    wellness_data: {},
+  } as LatestJson;
+}
+
+function makeMetadata(value: unknown) {
+  return {
+    citations: [
+      { field: "current_status.acwr.value", value, source: "latest.json" as const },
+    ],
+    confidence: "high" as const,
+    frameworks: ["fitness-fatigue"],
+    phase_tag: "base",
+  };
+}
+
+/** Wraps a coaching reply + its metadata into the ---meta--- wire format. */
+function withMeta(prose: string, value: unknown): string {
+  return `${prose}\n---meta---\n${JSON.stringify(makeMetadata(value))}`;
+}
+
+interface SpyLLM {
+  generate: LLM["generate"];
+  capturedPrompts: string[];
+}
+
+/** Queue-backed LLM stub mirroring tests/compaction.test.ts:18-36. */
+function createQueueLLM(queue: string[]): SpyLLM {
+  const capturedPrompts: string[] = [];
+  let i = 0;
+  const spy = {
+    capturedPrompts,
+    async generate(opts: { prompt?: string; messages?: ModelMessage[] }) {
+      if (opts.prompt !== undefined) capturedPrompts.push(opts.prompt);
+      const text = queue[i++] ?? "";
+      return {
+        text,
+        toolCalls: [],
+        finishReason: "stop" as const,
+        usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+      };
+    },
+  };
+  return spy as unknown as SpyLLM;
+}
+
+const SNAPSHOT = makeSnapshot({ acwr: { value: 1.42 } });
+
+describe("validateAndRetry — enforce mode", () => {
+  it("does not call the LLM when the first attempt validates", async () => {
+    const llm = createQueueLLM([]);
+    const result = await validateAndRetry(
+      llm,
+      "how am I doing?",
+      "reply",
+      makeMetadata(1.42),
+      { mode: "enforce", snapshot: SNAPSHOT },
+    );
+    expect(llm.capturedPrompts.length).toBe(0);
+    expect(result.validation_warning).toBeUndefined();
+    expect(result.response).toBe("reply");
+    expect(result.metadata?.citations[0]?.value).toBe(1.42);
+  });
+
+  it("retries exactly once with feedback and succeeds on the corrected reply", async () => {
+    const corrected = withMeta("corrected coaching", 1.42);
+    const llm = createQueueLLM([corrected]);
+    const result = await validateAndRetry(
+      llm,
+      "how am I doing?",
+      "first reply",
+      makeMetadata(1.45),
+      { mode: "enforce", snapshot: SNAPSHOT },
+    );
+    expect(llm.capturedPrompts.length).toBe(1);
+    expect(llm.capturedPrompts[0]).toContain(
+      "Citation mismatch: cited current_status.acwr.value=1.45, snapshot has 1.42.",
+    );
+    expect(llm.capturedPrompts[0]).toContain(
+      "Same coaching content, corrected numbers.",
+    );
+    expect(result.response).toBe(corrected);
+    expect(result.validation_warning).toBeUndefined();
+  });
+
+  it("returns the second response with validation_warning on a double failure", async () => {
+    const stillWrong = withMeta("still wrong", 1.99);
+    const llm = createQueueLLM([stillWrong]);
+    const result = await validateAndRetry(
+      llm,
+      "how am I doing?",
+      "first reply",
+      makeMetadata(1.45),
+      { mode: "enforce", snapshot: SNAPSHOT },
+    );
+    expect(llm.capturedPrompts.length).toBe(1);
+    expect(result.response).toBe(stillWrong);
+    expect(result.validation_warning).toBe(true);
+  });
+
+  it("never makes a third call even when the retry is also wrong", async () => {
+    const stillWrong = withMeta("still wrong", 1.99);
+    const llm = createQueueLLM([stillWrong, withMeta("third", 1.42)]);
+    await validateAndRetry(
+      llm,
+      "how am I doing?",
+      "first reply",
+      makeMetadata(1.45),
+      { mode: "enforce", snapshot: SNAPSHOT },
+    );
+    expect(llm.capturedPrompts.length).toBe(1);
+  });
+});
+
+describe("validateAndRetry — observe mode", () => {
+  it("flags would_have_retried on a mismatch without calling the LLM", async () => {
+    const llm = createQueueLLM([]);
+    const result = await validateAndRetry(
+      llm,
+      "how am I doing?",
+      "reply",
+      makeMetadata(1.45),
+      { mode: "observe", snapshot: SNAPSHOT },
+    );
+    expect(llm.capturedPrompts.length).toBe(0);
+    expect(result.would_have_retried).toBe(true);
+    expect(result.validation_warning).toBeUndefined();
+    expect(result.response).toBe("reply");
+  });
+
+  it("does not flag would_have_retried on a match", async () => {
+    const llm = createQueueLLM([]);
+    const result = await validateAndRetry(
+      llm,
+      "how am I doing?",
+      "reply",
+      makeMetadata(1.42),
+      { mode: "observe", snapshot: SNAPSHOT },
+    );
+    expect(llm.capturedPrompts.length).toBe(0);
+    expect(result.would_have_retried).toBe(false);
+  });
+});
+
+describe("validateAndRetry — off mode", () => {
+  it("returns the original response untouched with no validation or retry", async () => {
+    const llm = createQueueLLM([]);
+    const result = await validateAndRetry(
+      llm,
+      "how am I doing?",
+      "reply",
+      makeMetadata(1.45),
+      { mode: "off", snapshot: SNAPSHOT },
+    );
+    expect(llm.capturedPrompts.length).toBe(0);
+    expect(result.response).toBe("reply");
+    expect(result.validation_warning).toBeUndefined();
+    expect(result.would_have_retried).toBeUndefined();
+    expect(result.metadata?.citations[0]?.value).toBe(1.45);
+  });
+});

--- a/packages/core/tests/reference-run-sync.test.ts
+++ b/packages/core/tests/reference-run-sync.test.ts
@@ -437,6 +437,100 @@ describe("createRunSync", () => {
     });
   });
 
+  it("soft-fail path: gate warnings → latest.json + .scheduler.json written, error_state mitigation:warn_only, kind:ran", async () => {
+    const mutex = new AsyncMutex();
+    const cooldown = new Cooldown();
+    const now = new Date("2026-05-09T14:00:00Z");
+
+    const fetchSpy = vi.fn().mockResolvedValue(emptyFetched);
+    const warningGate = vi.fn().mockReturnValue({
+      ok: true,
+      failures: [],
+      warnings: [{ step: "step6_freshness_24h", detail: "data freshness=stale" }],
+      freshness: "stale",
+    });
+
+    const runSync = createRunSync({
+      dataDir: dir,
+      mutex,
+      cooldown,
+      cooldownWindowMs: 30_000,
+      fetchReferenceData: fetchSpy,
+      gate: warningGate,
+      now: () => now,
+    });
+
+    const result = await runSync({ caller: "scheduled" });
+    expect(result.kind).toBe("ran");
+
+    const latest = JSON.parse(readFileSync(join(dir, "latest.json"), "utf-8"));
+    expect(latest.metadata.freshness).toBe("stale");
+
+    expect(() => readFileSync(join(dir, ".scheduler.json"), "utf-8")).not.toThrow();
+
+    const errorState = JSON.parse(readFileSync(join(dir, "error_state.json"), "utf-8"));
+    expect(errorState.step).toBe("gate_warnings");
+    expect(errorState.mitigation).toBe("warn_only");
+    expect(errorState.detail).toContain("step6_freshness_24h");
+  });
+
+  it("clear-on-success: a clean sync removes a pre-existing error_state.json, only after the commit marker", async () => {
+    const mutex = new AsyncMutex();
+    const cooldown = new Cooldown();
+    const now = new Date("2026-05-09T14:00:00Z");
+    const fetchSpy = vi.fn().mockResolvedValue(emptyFetched);
+
+    // Pre-create a stale error_state.json from a prior failed run.
+    const { writeErrorState } = await import("../src/reference/sync/error-state-writer.js");
+    await writeErrorState(dir, { step: "outer_timeout", detail: "prior failure" });
+    expect(() => readFileSync(join(dir, "error_state.json"), "utf-8")).not.toThrow();
+
+    const runSync = createRunSync({
+      dataDir: dir,
+      mutex,
+      cooldown,
+      cooldownWindowMs: 30_000,
+      fetchReferenceData: fetchSpy,
+      now: () => now,
+    });
+
+    const result = await runSync({ caller: "scheduled" });
+    expect(result.kind).toBe("ran");
+
+    expect(() => readFileSync(join(dir, "error_state.json"), "utf-8")).toThrow();
+    expect(() => readFileSync(join(dir, ".scheduler.json"), "utf-8")).not.toThrow();
+  });
+
+  it("freshness wiring: gate's freshness band lands on latest.json.metadata.freshness (not hardcoded fresh)", async () => {
+    const mutex = new AsyncMutex();
+    const cooldown = new Cooldown();
+    const now = new Date("2026-05-09T14:00:00Z");
+    const fetchSpy = vi.fn().mockResolvedValue(emptyFetched);
+
+    const flaggingGate = vi.fn().mockReturnValue({
+      ok: true,
+      failures: [],
+      warnings: [],
+      freshness: "flag",
+    });
+
+    const runSync = createRunSync({
+      dataDir: dir,
+      mutex,
+      cooldown,
+      cooldownWindowMs: 30_000,
+      fetchReferenceData: fetchSpy,
+      gate: flaggingGate,
+      now: () => now,
+    });
+
+    const result = await runSync({ caller: "scheduled" });
+    expect(result.kind).toBe("ran");
+
+    const latest = JSON.parse(readFileSync(join(dir, "latest.json"), "utf-8"));
+    expect(latest.metadata.freshness).toBe("flag");
+  });
+
   it("uses the injected clock.setTimeout/clearTimeout for the outer timer with the configured ms", async () => {
     const mutex = new AsyncMutex();
     const cooldown = new Cooldown();

--- a/packages/core/tests/reference-sync-gate.test.ts
+++ b/packages/core/tests/reference-sync-gate.test.ts
@@ -1,9 +1,198 @@
 import { describe, expect, it } from "vitest";
 import { gateLatestJson } from "../src/reference/validation/sync-gate.js";
+import type { FetchedReference } from "../src/reference/sync/run-sync.js";
+import { emptyFetched } from "./helpers/reference-fixtures.js";
 
-describe("gateLatestJson (stub)", () => {
-  it("returns ok with no failures or warnings — body lands when the gate is wired", () => {
-    const result = gateLatestJson({ anything: 1 }, { prior: "state" });
-    expect(result).toEqual({ ok: true, failures: [], warnings: [] });
+const NOW = new Date("2026-05-09T14:00:00Z");
+const HOUR_MS = 60 * 60 * 1000;
+const isoOffset = (ms: number): string => new Date(NOW.getTime() + ms).toISOString();
+
+function withLatest(overrides: Record<string, unknown>): FetchedReference {
+  return { ...emptyFetched, latest: { ...emptyFetched.latest, ...overrides } };
+}
+
+function withProfile(profile: Record<string, unknown>): FetchedReference {
+  return withLatest({ athlete_profile: profile });
+}
+
+describe("gateLatestJson", () => {
+  it("passes the empty pre-cutover stub clean (every RESOLVE-OR-SKIP branch returns PASS on empty data)", () => {
+    const result = gateLatestJson(emptyFetched, null, NOW);
+    expect(result).toEqual({ ok: true, failures: [], warnings: [], freshness: "fresh" });
+  });
+
+  // ── step0: data fetch (HARD) ──────────────────────────────────────────
+
+  it("step0 PASS: full 5-key envelope → no step0 failure", () => {
+    const result = gateLatestJson(emptyFetched, null, NOW);
+    expect(result.failures.map((f) => f.step)).not.toContain("step0_data_fetch");
+  });
+
+  it("step0 FAIL: routes set null → ok:false, failures contains step0_data_fetch", () => {
+    const fetched = { ...emptyFetched, routes: null } as unknown as FetchedReference;
+    const result = gateLatestJson(fetched, null, NOW);
+    expect(result.ok).toBe(false);
+    expect(result.failures.map((f) => f.step)).toContain("step0_data_fetch");
+  });
+
+  // ── step1: FTP source (HARD) ──────────────────────────────────────────
+
+  it("step1 PASS: sportSettings ftp:247 → no step1 failure", () => {
+    const fetched = withProfile({ sportSettings: [{ types: ["Ride"], ftp: 247 }] });
+    const result = gateLatestJson(fetched, null, NOW);
+    expect(result.failures.map((f) => f.step)).not.toContain("step1_ftp_source");
+  });
+
+  it("step1 FAIL: sportSettings ftp:0 → ok:false, failures contains step1_ftp_source", () => {
+    const fetched = withProfile({ sportSettings: [{ types: ["Ride"], ftp: 0 }] });
+    const result = gateLatestJson(fetched, null, NOW);
+    expect(result.ok).toBe(false);
+    expect(result.failures.map((f) => f.step)).toContain("step1_ftp_source");
+  });
+
+  // ── step2: weekly hours consistency (HARD) ────────────────────────────
+
+  it("step2 PASS: weekly_hours=10 + activities summing 10h in 7d → no step2 failure", () => {
+    const fetched = withLatest({
+      athlete_profile: { quick_stats: { weekly_hours: 10 } },
+      recent_activities: [
+        { start_date_local: isoOffset(-2 * 24 * HOUR_MS), moving_time: 36000 },
+      ],
+    });
+    const result = gateLatestJson(fetched, null, NOW);
+    expect(result.failures.map((f) => f.step)).not.toContain(
+      "step2_weekly_hours_consistency",
+    );
+  });
+
+  it("step2 FAIL: weekly_hours=10 + activities summing 5h → ok:false, step2 in failures", () => {
+    const fetched = withLatest({
+      athlete_profile: { quick_stats: { weekly_hours: 10 } },
+      recent_activities: [
+        { start_date_local: isoOffset(-2 * 24 * HOUR_MS), moving_time: 18000 },
+      ],
+    });
+    const result = gateLatestJson(fetched, null, NOW);
+    expect(result.ok).toBe(false);
+    expect(result.failures.map((f) => f.step)).toContain("step2_weekly_hours_consistency");
+  });
+
+  it("step2 EDGE: weekly_hours=0 + zero activities → PASS (no divide-by-zero, no NaN)", () => {
+    const fetched = withLatest({
+      athlete_profile: { quick_stats: { weekly_hours: 0 } },
+      recent_activities: [],
+    });
+    const result = gateLatestJson(fetched, null, NOW);
+    expect(result.ok).toBe(true);
+    expect(result.failures.map((f) => f.step)).not.toContain(
+      "step2_weekly_hours_consistency",
+    );
+  });
+
+  it("step2 EDGE: weekly_hours=0 + actualHours=2 → HARD fail (above ABS_FLOOR_HOURS)", () => {
+    const fetched = withLatest({
+      athlete_profile: { quick_stats: { weekly_hours: 0 } },
+      recent_activities: [
+        { start_date_local: isoOffset(-1 * 24 * HOUR_MS), moving_time: 7200 },
+      ],
+    });
+    const result = gateLatestJson(fetched, null, NOW);
+    expect(result.ok).toBe(false);
+    expect(result.failures.map((f) => f.step)).toContain("step2_weekly_hours_consistency");
+  });
+
+  // ── step4: tolerance bands (HARD) ─────────────────────────────────────
+
+  it("step4 PASS: weight 70, ftp 247, hr 150 → no step4 failure", () => {
+    const fetched = withLatest({
+      athlete_profile: { sportSettings: [{ types: ["Ride"], ftp: 247 }] },
+      wellness_data: { days: [{ id: "1998-04-11", weight: 70, restingHR: 50 }] },
+      recent_activities: [
+        { start_date_local: isoOffset(-1 * 24 * HOUR_MS), moving_time: 3600, average_heartrate: 150 },
+      ],
+    });
+    const result = gateLatestJson(fetched, null, NOW);
+    expect(result.failures.map((f) => f.step)).not.toContain("step4_tolerance_band");
+  });
+
+  it("step4 FAIL: weight 500 → ok:false, step4 in failures naming field+value+band", () => {
+    const fetched = withLatest({
+      wellness_data: { days: [{ id: "1998-04-11", weight: 500, restingHR: 50 }] },
+    });
+    const result = gateLatestJson(fetched, null, NOW);
+    expect(result.ok).toBe(false);
+    const step4 = result.failures.find((f) => f.step === "step4_tolerance_band");
+    expect(step4).toBeDefined();
+    expect(step4!.detail).toContain("weight=500");
+    expect(step4!.detail).toContain("[30,200]");
+  });
+
+  // ── step6: freshness (SOFT) ───────────────────────────────────────────
+
+  it("step6 SOFT: data 72h old (via activity date, no server ts) → ok:TRUE, warnings contain step6, freshness 'stale'", () => {
+    // Freshness reads the newest activity date when no server `metadata` is
+    // present; that path does NOT feed step6b (clock offset), so a stale-but-
+    // valid bundle stays ok:true.
+    const fetched = withLatest({
+      recent_activities: [
+        { start_date_local: isoOffset(-72 * HOUR_MS), moving_time: 3600 },
+      ],
+    });
+    const result = gateLatestJson(fetched, null, NOW);
+    expect(result.ok).toBe(true);
+    expect(result.warnings.map((w) => w.step)).toContain("step6_freshness_24h");
+    expect(result.freshness).toBe("stale");
+  });
+
+  it("step6 PASS: server ts = now → freshness 'fresh', no warning", () => {
+    const fetched = withLatest({ metadata: { last_updated: isoOffset(0) } });
+    const result = gateLatestJson(fetched, null, NOW);
+    expect(result.freshness).toBe("fresh");
+    expect(result.warnings.map((w) => w.step)).not.toContain("step6_freshness_24h");
+  });
+
+  // ── step6b: clock offset (HARD) ───────────────────────────────────────
+
+  it("step6b PASS: server ts within 60min → no step6b failure", () => {
+    const fetched = withLatest({ metadata: { last_updated: isoOffset(-30 * 60 * 1000) } });
+    const result = gateLatestJson(fetched, null, NOW);
+    expect(result.failures.map((f) => f.step)).not.toContain("step6b_clock_offset");
+  });
+
+  it("step6b FAIL: server ts = now+90min → ok:false, step6b in failures", () => {
+    const fetched = withLatest({ metadata: { last_updated: isoOffset(90 * 60 * 1000) } });
+    const result = gateLatestJson(fetched, null, NOW);
+    expect(result.ok).toBe(false);
+    expect(result.failures.map((f) => f.step)).toContain("step6b_clock_offset");
+  });
+
+  // ── step7: multi-metric conflict (SOFT) ───────────────────────────────
+
+  it("step7 SOFT: weeklyHours>0 & weeklyLoad=0 → ok:TRUE, warnings contain step7", () => {
+    const fetched = withProfile({ quick_stats: { weekly_hours: 8, weekly_load: 0 } });
+    const result = gateLatestJson(fetched, null, NOW);
+    expect(result.ok).toBe(true);
+    expect(result.warnings.map((w) => w.step)).toContain("step7_multi_metric_conflict");
+  });
+
+  it("step7 PASS: consistent signals → no warning", () => {
+    const fetched = withProfile({ quick_stats: { weekly_hours: 8, weekly_load: 400 } });
+    const result = gateLatestJson(fetched, null, NOW);
+    expect(result.warnings.map((w) => w.step)).not.toContain("step7_multi_metric_conflict");
+  });
+
+  // ── composition: hard dominates soft ──────────────────────────────────
+
+  it("MIXED hard+soft: failing step4 AND warning step6 → ok:false (hard dominates), step6 warning still carried", () => {
+    const fetched = withLatest({
+      recent_activities: [
+        { start_date_local: isoOffset(-72 * HOUR_MS), moving_time: 3600 },
+      ],
+      wellness_data: { days: [{ id: "1998-04-11", weight: 500 }] },
+    });
+    const result = gateLatestJson(fetched, null, NOW);
+    expect(result.ok).toBe(false);
+    expect(result.failures.map((f) => f.step)).toContain("step4_tolerance_band");
+    expect(result.warnings.map((w) => w.step)).toContain("step6_freshness_24h");
   });
 });

--- a/packages/core/tests/reference-validate-response.test.ts
+++ b/packages/core/tests/reference-validate-response.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  validateRecommendation,
+  parseMetaBlock,
+  getByPath,
+} from "../src/reference/validation/validate-response.js";
+import type { LatestJson } from "../src/reference/schemas/latest.js";
+
+function makeSnapshot(currentStatus: unknown): LatestJson {
+  return {
+    metadata: {
+      schema_version: "1",
+      last_updated: "1998-06-08T00:00:00.000Z",
+      freshness: "fresh",
+    },
+    athlete_profile: {},
+    current_status: currentStatus,
+    derived_metrics: {},
+    recent_activities: [],
+    planned_workouts: [],
+    wellness_data: {},
+  } as LatestJson;
+}
+
+function makeMetadata(citations: Array<{ field: string; value: unknown }>) {
+  return {
+    citations: citations.map((c) => ({ ...c, source: "latest.json" as const })),
+    confidence: "high" as const,
+    frameworks: ["fitness-fatigue"],
+    phase_tag: "base",
+  };
+}
+
+describe("validateRecommendation", () => {
+  it("returns ok for an exactly-matching numeric citation", () => {
+    const snapshot = makeSnapshot({ acwr: { value: 1.42 } });
+    const meta = makeMetadata([{ field: "current_status.acwr.value", value: 1.42 }]);
+    expect(validateRecommendation("reply", meta, snapshot)).toEqual({ ok: true });
+  });
+
+  it("returns ok for a citation within the ±0.01 tolerance", () => {
+    const snapshot = makeSnapshot({ acwr: { value: 1.42 } });
+    const meta = makeMetadata([{ field: "current_status.acwr.value", value: 1.425 }]);
+    expect(validateRecommendation("reply", meta, snapshot)).toEqual({ ok: true });
+  });
+
+  it("returns the exact mismatch feedback when off by more than tolerance", () => {
+    const snapshot = makeSnapshot({ acwr: { value: 1.42 } });
+    const meta = makeMetadata([{ field: "current_status.acwr.value", value: 1.45 }]);
+    const result = validateRecommendation("reply", meta, snapshot);
+    expect(result.ok).toBe(false);
+    expect(result.feedback).toBe(
+      "Citation mismatch: cited current_status.acwr.value=1.45, snapshot has 1.42.",
+    );
+  });
+
+  it("returns a missing-source failure naming the absent field", () => {
+    const snapshot = makeSnapshot({ acwr: { value: 1.42 } });
+    const meta = makeMetadata([
+      { field: "current_status.monotony.value", value: 1.1 },
+    ]);
+    const result = validateRecommendation("reply", meta, snapshot);
+    expect(result.ok).toBe(false);
+    expect(result.feedback).toContain("current_status.monotony.value");
+    expect(result.feedback).toContain("not found in snapshot");
+  });
+
+  it("returns a strict mismatch for a string/enum citation", () => {
+    const snapshot = makeSnapshot({ phase: "base" });
+    const meta = makeMetadata([{ field: "current_status.phase", value: "build" }]);
+    const result = validateRecommendation("reply", meta, snapshot);
+    expect(result.ok).toBe(false);
+    expect(result.feedback).toContain("current_status.phase");
+  });
+
+  it("returns ok for a matching string/enum citation", () => {
+    const snapshot = makeSnapshot({ phase: "base" });
+    const meta = makeMetadata([{ field: "current_status.phase", value: "base" }]);
+    expect(validateRecommendation("reply", meta, snapshot)).toEqual({ ok: true });
+  });
+
+  it("does not let a snapshot false/null/empty-string satisfy a cited 0", () => {
+    for (const snapshotValue of [false, null, ""]) {
+      const snapshot = makeSnapshot({ rest_flag: snapshotValue });
+      const meta = makeMetadata([{ field: "current_status.rest_flag", value: 0 }]);
+      const result = validateRecommendation("reply", meta, snapshot);
+      expect(result.ok).toBe(false);
+      expect(result.feedback).toContain("current_status.rest_flag");
+    }
+  });
+
+  it("does not let a cited false/empty-string satisfy a snapshot 0", () => {
+    for (const citedValue of [false, ""]) {
+      const snapshot = makeSnapshot({ load: 0 });
+      const meta = makeMetadata([{ field: "current_status.load", value: citedValue }]);
+      const result = validateRecommendation("reply", meta, snapshot);
+      expect(result.ok).toBe(false);
+      expect(result.feedback).toContain("current_status.load");
+    }
+  });
+
+  it("fails when metadata violates RecommendationMetadataSchema", () => {
+    const snapshot = makeSnapshot({ acwr: { value: 1.42 } });
+    const badMeta = {
+      citations: [
+        { field: "current_status.acwr.value", value: 1.42, source: "history.json" },
+      ],
+      confidence: "high",
+      frameworks: ["fitness-fatigue"],
+      phase_tag: "base",
+    };
+    const result = validateRecommendation("reply", badMeta, snapshot);
+    expect(result.ok).toBe(false);
+    expect(result.feedback).toContain("Metadata failed schema validation");
+  });
+});
+
+describe("parseMetaBlock", () => {
+  it("returns the single block when exactly one is present", () => {
+    const meta = { citations: [], confidence: "high" };
+    const response = `Some coaching prose.\n---meta---\n${JSON.stringify(meta)}`;
+    const parsed = parseMetaBlock(response);
+    expect(parsed).not.toBeNull();
+    expect(parsed?.blockCount).toBe(1);
+    expect(parsed?.metadataJson).toEqual(meta);
+  });
+
+  it("returns the LAST block and warns when multiple blocks are present", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const first = { which: "first" };
+    const last = { which: "last" };
+    const response = `prose\n---meta---\n${JSON.stringify(first)}\n---meta---\n${JSON.stringify(last)}`;
+    const parsed = parseMetaBlock(response);
+    expect(parsed?.metadataJson).toEqual(last);
+    expect(parsed?.blockCount).toBe(2);
+    expect(warn).toHaveBeenCalledOnce();
+    warn.mockRestore();
+  });
+
+  it("returns null when there is no meta block", () => {
+    expect(parseMetaBlock("just prose, no delimiter")).toBeNull();
+  });
+
+  it("returns null when the block is malformed JSON", () => {
+    const response = "prose\n---meta---\n{ not: valid json ]";
+    expect(parseMetaBlock(response)).toBeNull();
+  });
+});
+
+describe("getByPath", () => {
+  it("resolves a deep hit", () => {
+    const obj = { a: { b: { c: 42 } } };
+    expect(getByPath(obj, "a.b.c")).toBe(42);
+  });
+
+  it("returns undefined on a null/undefined hop", () => {
+    const obj = { a: null };
+    expect(getByPath(obj, "a.b.c")).toBeUndefined();
+  });
+
+  it("returns undefined on a missing key", () => {
+    const obj = { a: { b: {} } };
+    expect(getByPath(obj, "a.b.c")).toBeUndefined();
+  });
+});

--- a/packages/core/tests/system-prompt-review-rules.test.ts
+++ b/packages/core/tests/system-prompt-review-rules.test.ts
@@ -14,29 +14,31 @@ const persona: SportPersona = {
   skills: { example: "# Example Skill\n\nSome cycling content." },
 };
 
-describe("buildSystemPrompt — WORKOUT_REVIEW_RULES placement", () => {
-  it("places WORKOUT_REVIEW_RULES as the LAST section", () => {
+describe("buildSystemPrompt — review + data-grounding placement", () => {
+  it("places WORKOUT_REVIEW_RULES second-to-last and Data Grounding last", () => {
     const prompt = buildSystemPrompt(persona, makeFakeMemory("athlete context"));
     const sections = prompt.split("\n\n---\n\n");
+    const review = sections[sections.length - 2];
     const last = sections[sections.length - 1];
-    expect(last).toMatch(/^# Workout Review/);
-    expect(last).toContain("3-questions framework");
+    expect(review).toMatch(/^# Workout Review/);
+    expect(review).toContain("3-questions framework");
+    expect(last).toMatch(/^# Data Grounding/);
   });
 
-  it("places WORKOUT_REVIEW_RULES last even when context is empty", () => {
+  it("places Data Grounding last even when context is empty", () => {
     const prompt = buildSystemPrompt(persona, makeFakeMemory(""));
     const sections = prompt.split("\n\n---\n\n");
     const last = sections[sections.length - 1];
-    expect(last).toMatch(/^# Workout Review/);
+    expect(last).toMatch(/^# Data Grounding/);
   });
 
-  it("places WORKOUT_REVIEW_RULES last when skills are empty", () => {
+  it("places Data Grounding last when skills are empty", () => {
     const prompt = buildSystemPrompt({ ...persona, skills: {} }, makeFakeMemory("ctx"));
     const sections = prompt.split("\n\n---\n\n");
-    expect(sections[sections.length - 1]).toMatch(/^# Workout Review/);
+    expect(sections[sections.length - 1]).toMatch(/^# Data Grounding/);
   });
 
-  it("preserves [soul, skills, context, time, review-rules] order", () => {
+  it("preserves [soul, skills, context, time, review-rules, data-grounding] order", () => {
     const prompt = buildSystemPrompt(persona, makeFakeMemory("ctx"));
     const sections = prompt.split("\n\n---\n\n");
     expect(sections[0]).toContain("Cycling Coach");
@@ -44,7 +46,15 @@ describe("buildSystemPrompt — WORKOUT_REVIEW_RULES placement", () => {
     expect(sections[2]).toMatch(/^# Athlete Context/);
     expect(sections[3]).toMatch(/^# Current Date & Time/);
     expect(sections[4]).toMatch(/^# Workout Review/);
-    expect(sections.length).toBe(5);
+    expect(sections[5]).toMatch(/^# Data Grounding/);
+    expect(sections.length).toBe(6);
+  });
+
+  it("injects the Layer-3 data-grounding marker", () => {
+    const prompt = buildSystemPrompt(persona, makeFakeMemory("ctx"));
+    expect(prompt).toContain(
+      "Numeric claims MUST come from the current JSON snapshot you read this turn",
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

Adds the Reference layer's validation substrate — three independent, **downstream-only** pieces that check already-computed values. No metric math is touched (`metrics/` and `curator/` are untouched).

### Layer-1 sync gate — `validation/sync-gate.ts` + `validation/checks/*`
Replaces the stub gate with seven mechanical checks: data-fetch presence, FTP source resolvability, weekly-hours consistency, value-tolerance bands, 24h freshness, clock-offset drift, multi-metric conflict.
- **Resolve-or-skip**: an absent signal passes (the empty-data path is never bricked); only present-and-invalid values fail.
- Hard failures block the snapshot write and record error state; soft warnings still write; a fully clean sync clears stale error state (after the commit marker).

### Recommendation metadata + audit log — `validation/recommendation-metadata.ts`, `audit/*`
- Two `.strict()` Zod schemas (`RecommendationMetadata`, `AuditLogEntry`) + `AUDIT_SCHEMA_VERSION`.
- `writeAuditEntry` atomic-appends one JSONL line per reply — best-effort, never throws (escalates once via `console.error` after 10 cumulative failures).
- `parseAuditLog` streams the log, version-dispatches before schema parse, and is robust to manual corruption.

### Layer-2 validator + Layer-3 prompt rules — `validation/validate-response.ts`, `retry-with-feedback.ts`, `layer3-prompt.ts`
- Parses the `---meta---` block, walks dot-paths into the latest snapshot, asserts every cited value exists and matches (±0.01 for numbers, strict otherwise).
- Single-retry orchestrator with a hard one-retry cap and three modes (off / observe / enforce, default observe).
- Grounding rules appended to the system prompt so numeric claims trace back to the snapshot read this turn.

## Not in scope (deferred to the cutover wave)
Live wiring of the Layer-2 validator into the coaching reply path — the validator is built and tested but not yet plumbed into the agent.

## Verification
- `pnpm -r build` green; full `@enduragent/core` suite **1621 pass / 3 skipped**.
- `check:trademarks` (112 files) + `check:fixture-privacy` (1165 files) clean.
- Adversarial multi-agent audit (18 agents): **no metric drift, no behavioral spec drift**. The one real edge case it surfaced — the response validator coercing `false`/`null`/`""` to `0` — is fixed here (typeof-guarded numeric tolerance + regression tests on both the snapshot and cited sides).

## Changesets
Three `@enduragent/core` patch changesets (sync gate, audit log + metadata, response grounding). No `User-facing:` line — internal trust substrate; athletes notice nothing until the cutover wave wires it in.
