### PR TITLE
refactor(core): rename thin adapter PowerCurveDelta to PowerCurveDeltaSummary

### DIFF
--- a/.changeset/reference-adapter-powercurvedelta-rename.md
+++ b/.changeset/reference-adapter-powercurvedelta-rename.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/core": patch
+---
+
+Rename the Reference layer's thin per-sport projection type `PowerCurveDelta` to `PowerCurveDeltaSummary` on the `ReferenceSportAdapter` seam. This is a type-only rename with zero behavior change; it disambiguates the thin public projection shape returned by `computePowerCurve` from the rich internal compute type of the same name, so a single projection module can import both without a name collision.

--- a/packages/core/src/reference/CONTEXT.md
+++ b/packages/core/src/reference/CONTEXT.md
@@ -14,7 +14,7 @@ reference/
 ├── index.ts            (public barrel — wired into packages/core/src/index.ts)
 ├── services.ts         (ReferenceServices — service-aggregate exposed to channels per ADR-0010)
 ├── runtime.ts          (ReferenceRuntime + bootstrapReference — pins ADR-0011 two-phase init)
-├── sport-adapter.ts    (the per-sport seam type — ReferenceSportAdapter + DfaSummary + PowerCurveDelta)
+├── sport-adapter.ts    (the per-sport seam type — ReferenceSportAdapter + DfaSummary + PowerCurveDeltaSummary)
 ├── freshness.ts        (single-source-of-truth constants: freshness, retention, mutex/cooldown timings)
 ├── paths.ts            (referenceDataDir(binaryName) — composes via getCoachHome)
 ├── preserve-tokens.ts  (REFERENCE_PRESERVE_TOKENS — populated alongside the curator; sports spread)

--- a/packages/core/src/reference/index.ts
+++ b/packages/core/src/reference/index.ts
@@ -1,7 +1,7 @@
 // ─── Per-sport seam type (ADR-0010) ───────────────────────────────────
 export type {
   DfaSummary,
-  PowerCurveDelta,
+  PowerCurveDeltaSummary,
   ReferenceSportAdapter,
 } from "./sport-adapter.js";
 

--- a/packages/core/src/reference/sport-adapter.ts
+++ b/packages/core/src/reference/sport-adapter.ts
@@ -45,7 +45,7 @@ export interface ReferenceSportAdapter {
   computeDfa?(activity: Activity): DfaSummary | null;
 
   /** Optional. Sports without a power-equivalent curve omit this hook. */
-  computePowerCurve?(activities: readonly Activity[]): PowerCurveDelta | null;
+  computePowerCurve?(activities: readonly Activity[]): PowerCurveDeltaSummary | null;
 }
 
 export interface DfaSummary {
@@ -59,7 +59,12 @@ export interface DfaSummary {
   readonly value?: number;
 }
 
-export interface PowerCurveDelta {
+/**
+ * Thin public projection shape returned by `computePowerCurve`. Distinct from
+ * the rich internal compute type so a projection module can import both in one
+ * scope without a name collision.
+ */
+export interface PowerCurveDeltaSummary {
   readonly anchorsCovered: number;
   readonly trend?: "up" | "down" | "flat";
 }

--- a/packages/core/tests/reference-sport-adapter.test.ts
+++ b/packages/core/tests/reference-sport-adapter.test.ts
@@ -21,7 +21,7 @@
 import { describe, it, expect } from "vitest";
 import type {
   DfaSummary,
-  PowerCurveDelta,
+  PowerCurveDeltaSummary,
   ReferenceSportAdapter,
   Sport,
 } from "../src/index.js";
@@ -41,7 +41,7 @@ describe("ReferenceSportAdapter type surface", () => {
 
   it("ReferenceSportAdapter accepts optional algorithm hooks", () => {
     const fakeDfa: DfaSummary = { sufficient: true, value: 0.78 };
-    const fakeCurveDelta: PowerCurveDelta = { anchorsCovered: 5, trend: "up" };
+    const fakeCurveDelta: PowerCurveDeltaSummary = { anchorsCovered: 5, trend: "up" };
 
     const withHooks: ReferenceSportAdapter = {
       activityTypes: ["Ride"] as const,
@@ -59,10 +59,10 @@ describe("ReferenceSportAdapter type surface", () => {
     expect(delta?.anchorsCovered).toBe(5);
   });
 
-  it("DfaSummary and PowerCurveDelta are exported and usable", () => {
+  it("DfaSummary and PowerCurveDeltaSummary are exported and usable", () => {
     const noisy: DfaSummary = { sufficient: false };
     expect(noisy.sufficient).toBe(false);
-    const flat: PowerCurveDelta = { anchorsCovered: 0, trend: "flat" };
+    const flat: PowerCurveDeltaSummary = { anchorsCovered: 0, trend: "flat" };
     expect(flat.trend).toBe("flat");
   });
 });


### PR DESCRIPTION
Renames the thin per-sport projection type `PowerCurveDelta` to `PowerCurveDeltaSummary` on the `ReferenceSportAdapter` seam (type-only, zero behavior). Disambiguates the thin public projection returned by `computePowerCurve` from the rich internal compute type of the same name, so one projection module can import both without a name collision.

Base `main`. First of a 7-PR stack landing the Reference per-sport adapter seam.