### PR TITLE
feat(core): add Reference sport-adapter dispatcher and coverage invariants

### DIFF
--- a/.changeset/reference-adapter-powercurvedelta-rename.md
+++ b/.changeset/reference-adapter-powercurvedelta-rename.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/core": patch
+---
+
+Rename the Reference layer's thin per-sport projection type `PowerCurveDelta` to `PowerCurveDeltaSummary` on the `ReferenceSportAdapter` seam. This is a type-only rename with zero behavior change; it disambiguates the thin public projection shape returned by `computePowerCurve` from the rich internal compute type of the same name, so a single projection module can import both without a name collision.

--- a/packages/core/src/reference/CONTEXT.md
+++ b/packages/core/src/reference/CONTEXT.md
@@ -84,7 +84,12 @@ Two functions + a defensive walker + two type-gated parsers live in `sync/rename
 
 ## Sport seam (per ADR-0010)
 
-Sports plug into Reference via the optional `Sport.referenceAdapters?(): readonly ReferenceSportAdapter[]` method (type-only seam; sport implementations register adapters as they come online). Each adapter declares activity types it handles, plus declarative metadata (zone basis, decoupling basis, sustainability anchors, DFA-validated flag) and optional algorithm hooks (`computeDfa`, `computePowerCurve`). Two startup invariants — disjoint coverage + subset coverage of `sport.intervalsActivityTypes` — are enforced by Reference's dispatcher.
+Sports plug into Reference via the optional `Sport.referenceAdapters?(): readonly ReferenceSportAdapter[]` method (sport implementations register adapters as they come online). Each adapter declares activity types it handles, plus declarative metadata (zone basis, decoupling basis, sustainability anchors, DFA-validated flag) and optional algorithm hooks (`computeDfa`, `computePowerCurve`).
+
+The dispatch + invariant kernel lives in `sport-adapter-dispatcher.ts` and `sport-adapter-invariants.ts`:
+
+- **Routing.** `findAdapterForActivity` resolves one activity to its covering adapter; `runAdaptersForActivities` pairs a batch of activities with their adapters (selections only — it invokes no hooks; the live `Activity → MetricInput` bridge that feeds the hooks is deferred). Routing is family-aware: an adapter listing only `Ride`/`VirtualRide` also covers gravel/mountain-bike/e-bike rides because the registry counts those under the same family. Out-of-sport activities are skipped silently; an in-sport activity with no covering adapter warns once per distinct type per call.
+- **Invariants.** `assertDisjointCoverage` (no two adapters claim the same activity type) and `assertSubsetCoverage` (every declared type ⊆ `sport.intervalsActivityTypes`) run at boot, throwing `ReferenceConfigError` and naming offenders by stable identity. Only `ReferenceConfigError` is re-exported from the Reference barrel; the dispatcher and invariant functions are imported from their own module paths.
 
 ## Channel seam (`services.ts`)
 

--- a/packages/core/src/reference/CONTEXT.md
+++ b/packages/core/src/reference/CONTEXT.md
@@ -14,7 +14,7 @@ reference/
 ├── index.ts            (public barrel — wired into packages/core/src/index.ts)
 ├── services.ts         (ReferenceServices — service-aggregate exposed to channels per ADR-0010)
 ├── runtime.ts          (ReferenceRuntime + bootstrapReference — pins ADR-0011 two-phase init)
-├── sport-adapter.ts    (the per-sport seam type — ReferenceSportAdapter + DfaSummary + PowerCurveDelta)
+├── sport-adapter.ts    (the per-sport seam type — ReferenceSportAdapter + DfaSummary + PowerCurveDeltaSummary)
 ├── freshness.ts        (single-source-of-truth constants: freshness, retention, mutex/cooldown timings)
 ├── paths.ts            (referenceDataDir(binaryName) — composes via getCoachHome)
 ├── preserve-tokens.ts  (REFERENCE_PRESERVE_TOKENS — populated alongside the curator; sports spread)

--- a/packages/core/src/reference/errors.ts
+++ b/packages/core/src/reference/errors.ts
@@ -1,0 +1,6 @@
+export class ReferenceConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ReferenceConfigError";
+  }
+}

--- a/packages/core/src/reference/index.ts
+++ b/packages/core/src/reference/index.ts
@@ -5,6 +5,9 @@ export type {
   ReferenceSportAdapter,
 } from "./sport-adapter.js";
 
+// ─── Per-sport seam boot-config error ─────────────────────────────────
+export { ReferenceConfigError } from "./errors.js";
+
 // ─── Service-aggregate type for downstream channels ───────────────────
 export type { ReferenceServices } from "./services.js";
 

--- a/packages/core/src/reference/index.ts
+++ b/packages/core/src/reference/index.ts
@@ -1,7 +1,7 @@
 // ─── Per-sport seam type (ADR-0010) ───────────────────────────────────
 export type {
   DfaSummary,
-  PowerCurveDelta,
+  PowerCurveDeltaSummary,
   ReferenceSportAdapter,
 } from "./sport-adapter.js";
 

--- a/packages/core/src/reference/sport-adapter-dispatcher.ts
+++ b/packages/core/src/reference/sport-adapter-dispatcher.ts
@@ -1,0 +1,85 @@
+import type { Activity } from "intervals-icu-api";
+import type { ReferenceSportAdapter } from "./sport-adapter.js";
+import type { IntervalsActivityType } from "../sport.js";
+import { SPORT_FAMILIES } from "./metrics/sport-families.js";
+
+/** Stable, index-free identity for error and warn messages. */
+export function adapterIdentity(adapter: ReferenceSportAdapter): string {
+  return `adapter[${[...adapter.activityTypes].join(",")}]`;
+}
+
+/**
+ * Resolve an activity type to its sport family, or `fallback` when the type is
+ * unmapped. Callers choose the fallback that fits their question — `undefined`
+ * when an unmapped type means "no family", or the raw type when it should stand
+ * in as its own family — per the SPORT_FAMILIES convention that each caller owns
+ * its default rather than folding one into the table.
+ */
+function familyOf<F extends string | undefined>(type: string, fallback: F): string | F {
+  return Object.hasOwn(SPORT_FAMILIES, type) ? SPORT_FAMILIES[type] : fallback;
+}
+
+/**
+ * Route by sport family rather than by the strict cycling-only set: an adapter
+ * listing only `Ride`/`VirtualRide` still covers gravel/mountain-bike/e-bike
+ * rides because the registry already counts those under the same family. The
+ * narrower per-metric gates re-narrow internally, so dispatch must match the
+ * registry's wider family grouping or the projection would disagree with the
+ * authoritative counts.
+ */
+function adapterCoversType(adapter: ReferenceSportAdapter, type: string): boolean {
+  if (adapter.activityTypes.some((t) => t === type)) return true;
+  const family = familyOf(type, undefined);
+  if (family === undefined) return false;
+  return adapter.activityTypes.some((t) => SPORT_FAMILIES[t] === family);
+}
+
+export function findAdapterForActivity(
+  adapters: readonly ReferenceSportAdapter[],
+  activity: Activity,
+): ReferenceSportAdapter | null {
+  const type = activity.type;
+  // `Activity.type` is typed as a required string, but a malformed upstream row
+  // can still arrive without it at runtime — so this guard is load-bearing, not
+  // dead code; don't strip it. A gap here is silent (never a warn).
+  if (type === undefined) return null;
+  return adapters.find((a) => adapterCoversType(a, type)) ?? null;
+}
+
+export interface AdapterRun {
+  readonly activity: Activity;
+  readonly adapter: ReferenceSportAdapter;
+}
+
+/**
+ * Returns selections only — it pairs activities with their covering adapter and
+ * does not invoke any adapter hook. Out-of-sport types are skipped silently; an
+ * in-sport type with no covering adapter warns once per distinct type per call
+ * so a misconfigured adapter array is visible without flooding the log.
+ */
+export function runAdaptersForActivities(
+  adapters: readonly ReferenceSportAdapter[],
+  sportTypes: readonly IntervalsActivityType[],
+  activities: readonly Activity[],
+): readonly AdapterRun[] {
+  const runs: AdapterRun[] = [];
+  const warned = new Set<string>();
+  const sportFamilies = new Set(sportTypes.map((t) => familyOf(t, t)));
+  for (const activity of activities) {
+    const type = activity.type;
+    if (type === undefined) continue;
+    const family = familyOf(type, type);
+    const adapter = findAdapterForActivity(adapters, activity);
+    if (adapter) {
+      runs.push({ activity, adapter });
+      continue;
+    }
+    if (sportFamilies.has(family) && !warned.has(type)) {
+      warned.add(type);
+      console.warn(
+        `Reference: in-sport activity type "${type}" has no covering adapter; skipping its sport-specific metrics.`,
+      );
+    }
+  }
+  return runs;
+}

--- a/packages/core/src/reference/sport-adapter-invariants.ts
+++ b/packages/core/src/reference/sport-adapter-invariants.ts
@@ -1,0 +1,51 @@
+import type { ReferenceSportAdapter } from "./sport-adapter.js";
+import type { IntervalsActivityType } from "../sport.js";
+import { ReferenceConfigError } from "./errors.js";
+import { adapterIdentity } from "./sport-adapter-dispatcher.js";
+
+/**
+ * No two adapters in a sport's array may claim the same activity type, so each
+ * activity routes to exactly one adapter. Offenders are named by their stable
+ * identity, never by array position — positions shift as adapters are spread
+ * for composing sports.
+ */
+export function assertDisjointCoverage(adapters: readonly ReferenceSportAdapter[]): void {
+  const owner = new Map<string, ReferenceSportAdapter>();
+  for (const adapter of adapters) {
+    for (const type of adapter.activityTypes) {
+      const prior = owner.get(type);
+      if (prior !== undefined && prior !== adapter) {
+        throw new ReferenceConfigError(
+          `Reference adapter coverage overlaps on "${type}": ${adapterIdentity(prior)} and ${adapterIdentity(adapter)} both claim it.`,
+        );
+      }
+      owner.set(type, adapter);
+    }
+  }
+}
+
+/**
+ * Every activity type an adapter literally declares must be one the sport reads;
+ * an adapter claiming a type outside `sport.intervalsActivityTypes` is a
+ * misconfiguration. This checks the raw declared types, deliberately distinct
+ * from the family-aware dispatch membership.
+ */
+export function assertSubsetCoverage(
+  adapters: readonly ReferenceSportAdapter[],
+  sportTypes: readonly IntervalsActivityType[],
+): void {
+  const declared = new Set<string>(sportTypes as readonly string[]);
+  const strays: string[] = [];
+  for (const adapter of adapters) {
+    for (const type of adapter.activityTypes) {
+      if (!declared.has(type)) {
+        strays.push(`"${type}" (${adapterIdentity(adapter)})`);
+      }
+    }
+  }
+  if (strays.length > 0) {
+    throw new ReferenceConfigError(
+      `Reference adapter declares activity types outside the sport's set: ${strays.join(", ")}.`,
+    );
+  }
+}

--- a/packages/core/src/reference/sport-adapter.ts
+++ b/packages/core/src/reference/sport-adapter.ts
@@ -45,7 +45,7 @@ export interface ReferenceSportAdapter {
   computeDfa?(activity: Activity): DfaSummary | null;
 
   /** Optional. Sports without a power-equivalent curve omit this hook. */
-  computePowerCurve?(activities: readonly Activity[]): PowerCurveDelta | null;
+  computePowerCurve?(activities: readonly Activity[]): PowerCurveDeltaSummary | null;
 }
 
 export interface DfaSummary {
@@ -59,7 +59,12 @@ export interface DfaSummary {
   readonly value?: number;
 }
 
-export interface PowerCurveDelta {
+/**
+ * Thin public projection shape returned by `computePowerCurve`. Distinct from
+ * the rich internal compute type so a projection module can import both in one
+ * scope without a name collision.
+ */
+export interface PowerCurveDeltaSummary {
   readonly anchorsCovered: number;
   readonly trend?: "up" | "down" | "flat";
 }

--- a/packages/core/tests/reference-sport-adapter-dispatcher.test.ts
+++ b/packages/core/tests/reference-sport-adapter-dispatcher.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import type { Activity } from "intervals-icu-api";
+import type { ReferenceSportAdapter } from "../src/reference/sport-adapter.js";
+import type { IntervalsActivityType } from "../src/sport.js";
+import {
+  findAdapterForActivity,
+  runAdaptersForActivities,
+} from "../src/reference/sport-adapter-dispatcher.js";
+
+const cyclingAdapter: ReferenceSportAdapter = {
+  activityTypes: ["Ride", "VirtualRide"],
+  zoneBasis: "power",
+  decouplingBasis: "power",
+  sustainabilityAnchors: [300, 1200, 3600],
+  dfaValidated: true,
+};
+
+const runningAdapter: ReferenceSportAdapter = {
+  activityTypes: ["Run", "TrailRun"],
+  zoneBasis: "pace",
+  decouplingBasis: "pace",
+  sustainabilityAnchors: [60, 300],
+  dfaValidated: false,
+};
+
+function activity(type: string): Activity {
+  return { id: "12345", start_date_local: "1998-06-04T12:00:00", type } as Activity;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("findAdapterForActivity", () => {
+  it("returns null for an empty adapter array without throwing", () => {
+    expect(findAdapterForActivity([], activity("Ride"))).toBeNull();
+  });
+
+  it("routes Ride and VirtualRide to the single cycling adapter", () => {
+    expect(findAdapterForActivity([cyclingAdapter], activity("Ride"))).toBe(cyclingAdapter);
+    expect(findAdapterForActivity([cyclingAdapter], activity("VirtualRide"))).toBe(
+      cyclingAdapter,
+    );
+  });
+
+  it("returns null for an out-of-sport type the lone cycling adapter does not cover", () => {
+    expect(findAdapterForActivity([cyclingAdapter], activity("Run"))).toBeNull();
+  });
+
+  it("routes each type to its own adapter when two disjoint adapters are present", () => {
+    const adapters = [cyclingAdapter, runningAdapter];
+    expect(findAdapterForActivity(adapters, activity("Ride"))).toBe(cyclingAdapter);
+    expect(findAdapterForActivity(adapters, activity("TrailRun"))).toBe(runningAdapter);
+  });
+
+  it("routes the duathlon spread: Ride to cycling, Run to running", () => {
+    const adapters = [cyclingAdapter, runningAdapter];
+    expect(findAdapterForActivity(adapters, activity("Ride"))).toBe(cyclingAdapter);
+    expect(findAdapterForActivity(adapters, activity("Run"))).toBe(runningAdapter);
+  });
+
+  it("routes GravelRide to the cycling adapter via family even though it is not listed", () => {
+    const adapter = findAdapterForActivity([cyclingAdapter], activity("GravelRide"));
+    expect(adapter).toBe(cyclingAdapter);
+  });
+
+  it("routes EBikeRide to the cycling adapter via the family table", () => {
+    expect(findAdapterForActivity([cyclingAdapter], activity("EBikeRide"))).toBe(cyclingAdapter);
+  });
+
+  it("routes MountainBikeRide to the cycling adapter via the family table", () => {
+    expect(findAdapterForActivity([cyclingAdapter], activity("MountainBikeRide"))).toBe(
+      cyclingAdapter,
+    );
+  });
+
+  it("returns null for a type absent from the family table", () => {
+    expect(findAdapterForActivity([cyclingAdapter, runningAdapter], activity("Skydive"))).toBeNull();
+  });
+
+  it("returns null without warning for a malformed row whose type is missing", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const malformed = { id: "12345", start_date_local: "1998-06-04T12:00:00" } as unknown as Activity;
+    expect(findAdapterForActivity([cyclingAdapter], malformed)).toBeNull();
+    expect(warn).not.toHaveBeenCalled();
+  });
+});
+
+describe("runAdaptersForActivities", () => {
+  const cyclingTypes: readonly IntervalsActivityType[] = ["Ride", "VirtualRide"];
+
+  it("returns one AdapterRun per matched activity and pairs the covering adapter", () => {
+    const runs = runAdaptersForActivities([cyclingAdapter], cyclingTypes, [
+      activity("Ride"),
+      activity("VirtualRide"),
+    ]);
+    expect(runs).toHaveLength(2);
+    expect(runs.every((r) => r.adapter === cyclingAdapter)).toBe(true);
+    expect(runs.map((r) => r.activity.type)).toEqual(["Ride", "VirtualRide"]);
+  });
+
+  it("does not invoke computeDfa or computePowerCurve on the matched adapter", () => {
+    const dfaSpy = vi.fn(() => null);
+    const curveSpy = vi.fn(() => null);
+    const spyAdapter: ReferenceSportAdapter = {
+      ...cyclingAdapter,
+      computeDfa: dfaSpy,
+      computePowerCurve: curveSpy,
+    };
+    runAdaptersForActivities([spyAdapter], cyclingTypes, [activity("Ride")]);
+    expect(dfaSpy).not.toHaveBeenCalled();
+    expect(curveSpy).not.toHaveBeenCalled();
+  });
+
+  it("warns exactly once for repeated in-sport activities with no covering adapter", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const sportTypes: readonly IntervalsActivityType[] = ["Ride", "VirtualRide", "Run"];
+    const activities = Array.from({ length: 5 }, () => activity("Run"));
+    const runs = runAdaptersForActivities([cyclingAdapter], sportTypes, activities);
+    expect(runs).toHaveLength(0);
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it("stays silent for out-of-sport types and warns for the same type when in-sport", () => {
+    const warnSilent = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const outOfSport = runAdaptersForActivities([cyclingAdapter], cyclingTypes, [activity("Run")]);
+    expect(outOfSport).toHaveLength(0);
+    expect(warnSilent).not.toHaveBeenCalled();
+    warnSilent.mockRestore();
+
+    const warnInSport = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const inSport = runAdaptersForActivities(
+      [cyclingAdapter],
+      ["Ride", "VirtualRide", "Run"],
+      [activity("Run")],
+    );
+    expect(inSport).toHaveLength(0);
+    expect(warnInSport).toHaveBeenCalledTimes(1);
+  });
+
+  it("silently skips an out-of-sport type without warning", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const runs = runAdaptersForActivities([cyclingAdapter], cyclingTypes, [activity("Swim")]);
+    expect(runs).toHaveLength(0);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("silently skips a malformed row whose type is missing", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const malformed = { id: "12345", start_date_local: "1998-06-04T12:00:00" } as unknown as Activity;
+    const runs = runAdaptersForActivities([cyclingAdapter], cyclingTypes, [malformed]);
+    expect(runs).toHaveLength(0);
+    expect(warn).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/tests/reference-sport-adapter-invariants.test.ts
+++ b/packages/core/tests/reference-sport-adapter-invariants.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from "vitest";
+import type { ReferenceSportAdapter } from "../src/reference/sport-adapter.js";
+import type { IntervalsActivityType } from "../src/sport.js";
+import {
+  assertDisjointCoverage,
+  assertSubsetCoverage,
+} from "../src/reference/sport-adapter-invariants.js";
+import { ReferenceConfigError } from "../src/reference/errors.js";
+import { ReferenceConfigError as ReferenceConfigErrorFromBarrel } from "../src/index.js";
+
+const cyclingAdapter: ReferenceSportAdapter = {
+  activityTypes: ["Ride", "VirtualRide"],
+  zoneBasis: "power",
+  decouplingBasis: "power",
+  sustainabilityAnchors: [300, 1200, 3600],
+  dfaValidated: true,
+};
+
+const runningAdapter: ReferenceSportAdapter = {
+  activityTypes: ["Run", "TrailRun"],
+  zoneBasis: "pace",
+  decouplingBasis: "pace",
+  sustainabilityAnchors: [60, 300],
+  dfaValidated: false,
+};
+
+describe("ReferenceConfigError", () => {
+  it("is an Error subclass with the expected name, identical at module and barrel", () => {
+    const err = new ReferenceConfigError("boom");
+    expect(err).toBeInstanceOf(ReferenceConfigError);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe("ReferenceConfigError");
+    expect(ReferenceConfigErrorFromBarrel).toBe(ReferenceConfigError);
+  });
+});
+
+describe("assertDisjointCoverage", () => {
+  it("does not throw when adapters claim disjoint types", () => {
+    expect(() => assertDisjointCoverage([cyclingAdapter, runningAdapter])).not.toThrow();
+  });
+
+  it("does not throw for an empty adapter array", () => {
+    expect(() => assertDisjointCoverage([])).not.toThrow();
+  });
+
+  it("throws naming both offending adapters by identity, never by array index", () => {
+    const overlapA: ReferenceSportAdapter = {
+      activityTypes: ["Ride"],
+      zoneBasis: "power",
+      decouplingBasis: "power",
+      sustainabilityAnchors: [300],
+      dfaValidated: true,
+    };
+    const overlapB: ReferenceSportAdapter = {
+      activityTypes: ["Ride", "VirtualRide"],
+      zoneBasis: "power",
+      decouplingBasis: "power",
+      sustainabilityAnchors: [600],
+      dfaValidated: true,
+    };
+    let caught: unknown;
+    try {
+      assertDisjointCoverage([overlapA, overlapB]);
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(ReferenceConfigError);
+    const message = (caught as Error).message;
+    expect(message).toContain("adapter[Ride]");
+    expect(message).toContain("adapter[Ride,VirtualRide]");
+    expect(message).not.toContain("index ");
+  });
+});
+
+describe("assertSubsetCoverage", () => {
+  const cyclingTypes: readonly IntervalsActivityType[] = ["Ride", "VirtualRide"];
+
+  it("does not throw when the union of declared types is a subset", () => {
+    expect(() => assertSubsetCoverage([cyclingAdapter], cyclingTypes)).not.toThrow();
+  });
+
+  it("does not throw for an empty adapter array", () => {
+    expect(() => assertSubsetCoverage([], cyclingTypes)).not.toThrow();
+  });
+
+  it("throws naming the stray type and the owning adapter identity", () => {
+    const strayAdapter: ReferenceSportAdapter = {
+      activityTypes: ["Ride", "GravelRide"] as unknown as readonly IntervalsActivityType[],
+      zoneBasis: "power",
+      decouplingBasis: "power",
+      sustainabilityAnchors: [300],
+      dfaValidated: true,
+    };
+    let caught: unknown;
+    try {
+      assertSubsetCoverage([strayAdapter], cyclingTypes);
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(ReferenceConfigError);
+    const message = (caught as Error).message;
+    expect(message).toContain("GravelRide");
+    expect(message).toContain("adapter[Ride,GravelRide]");
+  });
+});

--- a/packages/core/tests/reference-sport-adapter.test.ts
+++ b/packages/core/tests/reference-sport-adapter.test.ts
@@ -21,7 +21,7 @@
 import { describe, it, expect } from "vitest";
 import type {
   DfaSummary,
-  PowerCurveDelta,
+  PowerCurveDeltaSummary,
   ReferenceSportAdapter,
   Sport,
 } from "../src/index.js";
@@ -41,7 +41,7 @@ describe("ReferenceSportAdapter type surface", () => {
 
   it("ReferenceSportAdapter accepts optional algorithm hooks", () => {
     const fakeDfa: DfaSummary = { sufficient: true, value: 0.78 };
-    const fakeCurveDelta: PowerCurveDelta = { anchorsCovered: 5, trend: "up" };
+    const fakeCurveDelta: PowerCurveDeltaSummary = { anchorsCovered: 5, trend: "up" };
 
     const withHooks: ReferenceSportAdapter = {
       activityTypes: ["Ride"] as const,
@@ -59,10 +59,10 @@ describe("ReferenceSportAdapter type surface", () => {
     expect(delta?.anchorsCovered).toBe(5);
   });
 
-  it("DfaSummary and PowerCurveDelta are exported and usable", () => {
+  it("DfaSummary and PowerCurveDeltaSummary are exported and usable", () => {
     const noisy: DfaSummary = { sufficient: false };
     expect(noisy.sufficient).toBe(false);
-    const flat: PowerCurveDelta = { anchorsCovered: 0, trend: "flat" };
+    const flat: PowerCurveDeltaSummary = { anchorsCovered: 0, trend: "flat" };
     expect(flat.trend).toBe("flat");
   });
 });


### PR DESCRIPTION
Adds the pure dispatch + invariant kernel: `findAdapterForActivity` / `runAdaptersForActivities` (family-aware routing via the shared sport-families table), `assertDisjointCoverage` / `assertSubsetCoverage`, and `ReferenceConfigError`. Selections only — invokes no adapter hooks; adds no metric-registry writer.

Stacked — base branch is the prior step in the seam.