### PR TITLE
feat(core): compute derived metrics from live intervals.icu data in the Reference sync

### DIFF
--- a/.changeset/reference-live-data-bridge.md
+++ b/.changeset/reference-live-data-bridge.md
@@ -1,0 +1,32 @@
+---
+"@enduragent/core": patch
+---
+
+Wire live intervals.icu data into the Reference sync. The production fetcher now
+pulls the athlete profile, a trailing window of activities and wellness, and a
+bounded, best-effort set of per-activity HRV/power streams, runs them through the
+ADR-0012 rename anti-corruption layer, bridges the result to the metric-compute
+input shape (`FetchedReference` → `MetricInput`), and runs the full metric
+registry — so `latest.json` carries real `recent_activities` and a computed
+`derived_metrics` block instead of empty stubs.
+
+New modules: `fixture-bridge.ts` (pure bundle → `FixtureShape`/`MetricInput`
+assembly), `compute-derived-metrics.ts` (registry runner with per-metric failure
+isolation), and `fetch-live-bundle.ts` (the abort-aware, bounded live fetch +
+rename boundary). The stream loop is capped, cycling-only, and bounded by a
+wall-clock sub-budget so a slow account cannot exhaust the sync timeout; a
+malformed row or failed stream is skipped with a warning rather than failing the
+whole sync. Stream responses are normalized from the API's array-of-channels
+(and camelCased keys) into the channel-keyed shape the DFA-α1 block consumes, and
+the metric date-window anchor uses naive local time so it lines up with
+intervals.icu's local-time activity dates. A hard fetch/assembly failure (or a
+surviving trademark-named key) is converted into a failed sync that writes
+`error_state.json` for the curator, rather than escaping the sync uncaught.
+
+`derived_metrics` keeps its `z.unknown()` typing and the per-window
+power/HR/sustainability curve fetch is not yet wired (those capability metrics
+reproduce their null blocks until it lands); both are tracked as follow-ups. The
+`history`/`intervals`/`routes`/`ftp_history` retention cache files keep their
+stubs. Metric math is untouched — parity stays green (559/559).
+
+Internal sync-plumbing change; no athlete-facing output change yet.

--- a/packages/core/src/reference/sync/compute-derived-metrics.ts
+++ b/packages/core/src/reference/sync/compute-derived-metrics.ts
@@ -1,0 +1,42 @@
+// Runs the metric registry over a `MetricInput` to produce the flat
+// `derived_metrics` object the sync persists into `latest.json`. Keys mirror
+// the registry's own keys exactly (including dotted `capability.*` keys), so a
+// downstream reader sees the same metric names the parity gate asserts.
+//
+// Per-metric isolation: a single compute that throws on real (sparser than
+// fixture) data must not sink the whole sync — it is recorded as `null` and a
+// warning is logged, leaving every other metric intact. The parity gate proves
+// the computes are bit-identical on valid fixtures; this guard only covers the
+// production tail where live data is shaped more loosely than a golden fixture.
+
+import { METRIC_REGISTRY, type MetricRegistryEntry } from "../metrics/registry.js";
+import type { MetricInput } from "../metrics/metric-input.js";
+
+/** Shared between the runner + its test so the warn string stays in sync. */
+export const METRIC_COMPUTE_FAILED_LOG_PREFIX = "Reference: metric compute failed";
+
+export interface ComputeDerivedMetricsOptions {
+  /** Sink for per-metric failures; defaults to console.warn. */
+  readonly log?: (msg: string) => void;
+  /** Registry override — defaults to the canonical `METRIC_REGISTRY`. Exposed
+   *  for tests of the per-metric isolation path. */
+  readonly registry?: Record<string, MetricRegistryEntry>;
+}
+
+export function computeDerivedMetrics(
+  input: MetricInput,
+  opts: ComputeDerivedMetricsOptions = {},
+): Record<string, unknown> {
+  const log = opts.log ?? ((m: string) => console.warn(m));
+  const registry = opts.registry ?? METRIC_REGISTRY;
+  const out: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(registry)) {
+    try {
+      out[key] = entry.compute(input);
+    } catch (err) {
+      log(`${METRIC_COMPUTE_FAILED_LOG_PREFIX} '${key}': ${err instanceof Error ? err.message : String(err)}`);
+      out[key] = null;
+    }
+  }
+  return out;
+}

--- a/packages/core/src/reference/sync/fetch-live-bundle.ts
+++ b/packages/core/src/reference/sync/fetch-live-bundle.ts
@@ -1,0 +1,367 @@
+// Live intervals.icu fetch for the Reference sync. Pulls the athlete profile,
+// a trailing window of activities + wellness, derives a cycling FTP history,
+// and (best-effort, bounded) the per-activity HRV/power streams the DFA-α1 and
+// per-session capability metrics consume. Returns a `ReferenceBundle` the
+// fixture bridge turns into the metric-compute input shape.
+//
+// ADR-0012: every sync path into Reference MUST pass real rows through the
+// rename anti-corruption layer between API parse and any downstream consumer.
+// This module is that boundary for the production path — `renameTpFieldsOn*`
+// per row, then `assertNoTpKeysRemain` over the assembled rows.
+//
+// Robustness: per-row rename/parse and per-activity stream fetches are
+// best-effort (a bad row or a failed stream is skipped with a warning, never
+// fails the whole sync). The streams loop is bounded (recent cycling rides
+// only, capped) and abort-aware so a slow account cannot consume the whole
+// `SYNC_OPERATION_TIMEOUT_MS` budget.
+
+import { snakeCaseKeys } from "intervals-icu-api";
+
+import {
+  AthleteSchema,
+  ActivityStreamsSchema,
+  type Activity,
+  type ActivityStreams,
+  type AthleteSettings,
+  type FtpHistoryPoint,
+  type WellnessDay,
+} from "../schemas/inputs.js";
+import {
+  assertNoTpKeysRemain,
+  parseRenamedActivity,
+  parseRenamedWellnessRow,
+  renameTpFieldsOnActivity,
+  renameTpFieldsOnWellnessRow,
+  type RenameSummary,
+} from "./rename-tp-fields.js";
+import { LATEST_RETENTION_DAYS } from "../freshness.js";
+import type { ReferenceBundle } from "./fixture-bridge.js";
+
+/** Trailing window pulled for metric computation (covers the widest metric
+ *  window — the 42-day sustainability look-back — with margin). */
+export const FETCH_WINDOW_DAYS = 84;
+/** Only fetch per-activity streams for rides this recent. DFA-α1's trailing
+ *  aggregate reads the last few sufficient sessions, so a short window keeps
+ *  the request count bounded without starving the metric. */
+export const STREAM_WINDOW_DAYS = 21;
+/** Hard cap on per-activity stream fetches per sync, regardless of window. */
+export const MAX_STREAM_ACTIVITIES = 12;
+const STREAM_THROTTLE_MS = 250;
+/** Wall-clock budget for the whole stream phase. Streams are best-effort, so we
+ *  stop fetching once this elapses rather than letting a slow account push the
+ *  sync toward the outer SYNC_OPERATION_TIMEOUT_MS (which would abort with an
+ *  empty-failure and no useful cache). */
+const STREAM_PHASE_BUDGET_MS = 60_000;
+
+/** Per-second channels requested per activity. `dfa_a1` + `artifacts` are the
+ *  HRV channels the DFA-α1 block reads; `watts`/`heartrate` feed the per-session
+ *  capability blocks. `time` is requested for alignment and rides through. */
+export const STREAM_TYPES: readonly string[] = [
+  "time",
+  "watts",
+  "heartrate",
+  "dfa_a1",
+  "artifacts",
+];
+
+/** DFA-α1 is upstream-validated for cycling only; stream fetches target these
+ *  types (the cycling adapter's `activityTypes`). */
+const STREAM_SPORT_TYPES: ReadonlySet<string> = new Set(["Ride", "VirtualRide"]);
+
+/** Cycling sport types whose `sportInfo.eftp` seeds the FTP history series. */
+const CYCLING_TYPES: ReadonlySet<string> = new Set([
+  "Ride",
+  "VirtualRide",
+  "GravelRide",
+  "MountainBikeRide",
+  "EBikeRide",
+  "EMountainBikeRide",
+  "TrackRide",
+  "Cyclocross",
+  "Handcycle",
+]);
+
+type FetchResult<T> = { ok: true; value: T } | { ok: false; error: unknown };
+
+/** Structural subset of `IntervalsClient` the bundle fetch needs — narrow so
+ *  tests can inject a fake without standing up the whole client. */
+export interface BundleFetchClient {
+  readonly athlete: { get(): Promise<FetchResult<unknown>> };
+  readonly activities: {
+    list(query: { oldest: string; newest?: string }): Promise<FetchResult<unknown[]>>;
+    getStreams(activityId: string, types: string[]): Promise<FetchResult<unknown>>;
+  };
+  readonly wellness: {
+    list(query: { oldest?: string; newest?: string }): Promise<FetchResult<unknown[]>>;
+  };
+}
+
+export interface LiveFetchResult {
+  /** Raw athlete object — cached verbatim as `latest.athlete_profile`. */
+  readonly athleteProfile: unknown;
+  /** Trailing 7-day renamed activities for the `latest.recent_activities` cache. */
+  readonly recentActivities: readonly Activity[];
+  /** Renamed wellness rows for the `latest.wellness_data` cache. */
+  readonly wellnessData: readonly WellnessDay[];
+  /** Full-window inputs for metric computation. */
+  readonly bundle: ReferenceBundle;
+  /** Sync wall-clock as an ISO string — the metric date-window anchor. */
+  readonly frozenNow: string;
+}
+
+function ymd(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+// Zone-less local-time ISO (YYYY-MM-DDThh:mm:ss). The metric date-window math
+// compares this anchor's date prefix against activity `start_date_local` values,
+// which intervals.icu emits in the athlete's local time with no zone. A UTC
+// `toISOString()` here would shift the anchor's calendar date near midnight and
+// drop/include a day's activities at the window edge; the naive-local form
+// mirrors the oracle's `datetime.now()` convention so the windows line up.
+function naiveLocalIso(date: Date): string {
+  const p = (n: number): string => String(n).padStart(2, "0");
+  return (
+    `${date.getFullYear()}-${p(date.getMonth() + 1)}-${p(date.getDate())}` +
+    `T${p(date.getHours())}:${p(date.getMinutes())}:${p(date.getSeconds())}`
+  );
+}
+
+// intervals.icu's streams endpoint returns an array of channel objects
+// (`[{type, data}, …]`); the lib also camelCases response keys (so `dfa_a1`
+// becomes `dfaA1` on the object form). Normalize both into the channel-keyed
+// shape the metrics + ActivityStreamsSchema consume (`{dfa_a1, watts, …}`).
+export function normalizeStreams(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    const out: Record<string, unknown> = {};
+    for (const el of value) {
+      if (
+        el !== null &&
+        typeof el === "object" &&
+        typeof (el as Record<string, unknown>).type === "string" &&
+        Array.isArray((el as Record<string, unknown>).data)
+      ) {
+        out[(el as Record<string, unknown>).type as string] = (el as Record<string, unknown>).data;
+      }
+    }
+    return out;
+  }
+  if (value !== null && typeof value === "object") {
+    return snakeCaseKeys(value);
+  }
+  return value;
+}
+
+function isCyclingStreamType(type: unknown): boolean {
+  return typeof type === "string" && STREAM_SPORT_TYPES.has(type);
+}
+
+/** Sparse cycling FTP series from per-day `sportInfo.eftp` — one point per
+ *  change. intervals.icu has no public FTP-history endpoint, so the series is
+ *  synthesized from wellness sportInfo exactly as the fixture builder does. */
+export function deriveFtpHistory(
+  wellness: readonly WellnessDay[],
+): FtpHistoryPoint[] {
+  const points: FtpHistoryPoint[] = [];
+  let lastFtp: number | null = null;
+  const sorted = [...wellness].sort((a, b) => String(a.id).localeCompare(String(b.id)));
+  for (const day of sorted) {
+    const sportInfo =
+      (day as { sportInfo?: Array<Record<string, unknown>> | null }).sportInfo ?? [];
+    let cyclingEftp: number | null = null;
+    for (const si of sportInfo) {
+      if (
+        typeof si.type === "string" &&
+        CYCLING_TYPES.has(si.type) &&
+        typeof si.eftp === "number" &&
+        Number.isFinite(si.eftp)
+      ) {
+        cyclingEftp = Math.round(si.eftp);
+        break;
+      }
+    }
+    if (cyclingEftp === null || cyclingEftp === lastFtp) continue;
+    points.push({ date: String(day.id), ftp: cyclingEftp, source: "estimate" });
+    lastFtp = cyclingEftp;
+  }
+  return points;
+}
+
+function extractAthleteSettings(profile: unknown): AthleteSettings | undefined {
+  if (typeof profile !== "object" || profile === null) return undefined;
+  const sportSettings = (profile as Record<string, unknown>).sportSettings;
+  if (!Array.isArray(sportSettings)) return undefined;
+  // The profile rides through the lib's camelCasing (indoor_ftp -> indoorFtp);
+  // reverse it so AthleteSchema's snake_case fields resolve.
+  const parsed = AthleteSchema.safeParse({ sportSettings: snakeCaseKeys(sportSettings) });
+  return parsed.success ? parsed.data : undefined;
+}
+
+interface LiveFetchDeps {
+  readonly client: BundleFetchClient;
+  readonly signal: AbortSignal;
+  readonly now: Date;
+  /** Override the inter-request throttle (tests pass 0). */
+  readonly throttleMs?: number;
+  /** Sink for non-fatal warnings; defaults to console.warn. */
+  readonly log?: (msg: string) => void;
+}
+
+function sleep(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    if (ms <= 0 || signal.aborted) {
+      resolve();
+      return;
+    }
+    const onAbort = (): void => {
+      clearTimeout(t);
+      resolve();
+    };
+    const t = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+/**
+ * Fetch + assemble the live Reference bundle. Throws only on a hard
+ * precondition failure (activities list unreachable) or a surviving
+ * TP-trademarked key (the anti-corruption contract); every other degradation
+ * is best-effort and logged.
+ */
+export async function fetchLiveBundle(deps: LiveFetchDeps): Promise<LiveFetchResult> {
+  const { client, signal, now } = deps;
+  const log = deps.log ?? ((m: string) => console.warn(m));
+  const throttleMs = deps.throttleMs ?? STREAM_THROTTLE_MS;
+  const frozenNow = naiveLocalIso(now);
+
+  const newest = ymd(now);
+  const oldest = ymd(new Date(now.getTime() - FETCH_WINDOW_DAYS * 24 * 60 * 60 * 1000));
+
+  const athleteResult = await client.athlete.get();
+  if (!athleteResult.ok) log(`Reference: athlete.get failed: ${String(athleteResult.error)}`);
+  const athleteProfile = athleteResult.ok ? athleteResult.value : {};
+
+  const actResult = await client.activities.list({ oldest, newest });
+  if (!actResult.ok) {
+    throw new Error(`activities.list failed: ${String(actResult.error)}`);
+  }
+  // The lib auto-camelCases activity responses; ActivitySchema requires
+  // snake_case (start_date_local, icu_training_load, …). Reverse it here only —
+  // wellness already ships in the camelCase mixed shape the schema agrees on. A
+  // non-array body (ok:true but malformed) is treated as empty, not a crash.
+  let rawActivities: Array<Record<string, unknown>> = [];
+  if (Array.isArray(actResult.value)) {
+    rawActivities = snakeCaseKeys(actResult.value) as Array<Record<string, unknown>>;
+  } else {
+    log("Reference: activities.list returned a non-array body; treating as empty");
+  }
+
+  const wellResult = await client.wellness.list({ oldest, newest });
+  if (!wellResult.ok) log(`Reference: wellness.list failed: ${String(wellResult.error)}`);
+  const rawWellness: Array<Record<string, unknown>> =
+    wellResult.ok && Array.isArray(wellResult.value)
+      ? (wellResult.value as Array<Record<string, unknown>>)
+      : [];
+
+  const actSummary: RenameSummary = { skippedNonNumeric: {} };
+  const wellSummary: RenameSummary = { skippedNonNumeric: {} };
+
+  const activities: Activity[] = [];
+  for (const row of rawActivities) {
+    try {
+      activities.push(parseRenamedActivity(renameTpFieldsOnActivity(row, actSummary)));
+    } catch (err) {
+      log(`Reference: skipped malformed activity row: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+  const wellness: WellnessDay[] = [];
+  for (const row of rawWellness) {
+    try {
+      wellness.push(parseRenamedWellnessRow(renameTpFieldsOnWellnessRow(row, wellSummary)));
+    } catch (err) {
+      log(`Reference: skipped malformed wellness row: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  // ADR-0012 defense-in-depth: no TP-trademarked key may survive rename.
+  assertNoTpKeysRemain({ activities, wellness });
+
+  const streams = await fetchStreams(client, activities, signal, now, throttleMs, log);
+
+  const ftpHistory = deriveFtpHistory(wellness);
+  const athlete = extractAthleteSettings(athleteProfile);
+
+  const bundle: ReferenceBundle = {
+    activities,
+    wellness,
+    ftpHistory,
+    ...(Object.keys(streams).length > 0 ? { streams } : {}),
+    ...(athlete !== undefined ? { athlete } : {}),
+  };
+
+  const retentionCutoffMs = now.getTime() - LATEST_RETENTION_DAYS * 24 * 60 * 60 * 1000;
+  const recentActivities = activities.filter((a) => {
+    if (typeof a.start_date_local !== "string") return false;
+    const ms = Date.parse(a.start_date_local);
+    return Number.isFinite(ms) && ms >= retentionCutoffMs;
+  });
+
+  return { athleteProfile, recentActivities, wellnessData: wellness, bundle, frozenNow };
+}
+
+async function fetchStreams(
+  client: BundleFetchClient,
+  activities: readonly Activity[],
+  signal: AbortSignal,
+  now: Date,
+  throttleMs: number,
+  log: (msg: string) => void,
+): Promise<Record<string, ActivityStreams>> {
+  const streamCutoffMs = now.getTime() - STREAM_WINDOW_DAYS * 24 * 60 * 60 * 1000;
+  const seen = new Set<string>();
+  const candidates = activities
+    .filter((a) => isCyclingStreamType(a.type) && typeof a.start_date_local === "string")
+    .filter((a) => {
+      const ms = Date.parse(a.start_date_local);
+      return Number.isFinite(ms) && ms >= streamCutoffMs;
+    })
+    .sort((a, b) => Date.parse(b.start_date_local) - Date.parse(a.start_date_local))
+    .filter((a) => {
+      // Collapse duplicate ids (the sort keeps the newest first), so a repeated
+      // id can't double-fetch or mis-join the DFA profile.
+      const id = String(a.id);
+      if (seen.has(id)) return false;
+      seen.add(id);
+      return true;
+    })
+    .slice(0, MAX_STREAM_ACTIVITIES);
+
+  const deadline = Date.now() + STREAM_PHASE_BUDGET_MS;
+  const out: Record<string, ActivityStreams> = {};
+  for (const activity of candidates) {
+    if (signal.aborted || Date.now() > deadline) break;
+    const id = String(activity.id);
+    let result: FetchResult<unknown>;
+    try {
+      result = await client.activities.getStreams(id, [...STREAM_TYPES]);
+    } catch (err) {
+      log(`Reference: streams fetch threw for an activity: ${err instanceof Error ? err.message : String(err)}`);
+      continue;
+    }
+    if (!result.ok) {
+      log(`Reference: streams fetch failed for an activity: ${String(result.error)}`);
+      continue;
+    }
+    const parsed = ActivityStreamsSchema.safeParse(normalizeStreams(result.value));
+    if (!parsed.success) {
+      log(`Reference: streams shape rejected for an activity: ${parsed.error.message}`);
+      continue;
+    }
+    out[id] = parsed.data;
+    await sleep(throttleMs, signal);
+  }
+  return out;
+}

--- a/packages/core/src/reference/sync/fetch-reference-data.ts
+++ b/packages/core/src/reference/sync/fetch-reference-data.ts
@@ -2,13 +2,25 @@ import type { IntervalsClient } from "intervals-icu-api";
 import type { FetchedReference } from "./run-sync.js";
 import { makeAbortableClient } from "./intervals-client-factory.js";
 import { PER_REQUEST_TIMEOUT_MS } from "../freshness.js";
+import { fetchLiveBundle } from "./fetch-live-bundle.js";
+import { buildMetricInput } from "./fixture-bridge.js";
+import { computeDerivedMetrics } from "./compute-derived-metrics.js";
 
 /**
- * Production fetcher. Today just proves the orchestration writes a
- * parseable cache for the scheduler-and-snapshot debug surface to read;
- * per-metric population is filled in by upcoming changes. Constructs a
- * per-runSync `IntervalsClient` (per ADR-0011) so the orchestrator's
- * outer `AbortController` propagates into in-flight requests.
+ * Production fetcher. Pulls the live intervals.icu bundle (athlete profile,
+ * trailing activities/wellness, bounded HRV/power streams), bridges it to the
+ * metric-compute input shape, and runs the metric registry so `latest.json`
+ * carries real `recent_activities` + computed `derived_metrics`. Constructs a
+ * per-runSync `IntervalsClient` (per ADR-0011) so the orchestrator's outer
+ * `AbortController` propagates into in-flight requests; the stream loop is
+ * additionally abort-aware so a slow account cannot exhaust the sync budget.
+ *
+ * Out of scope (separate deferred tickets): the per-window power/HR/
+ * sustainability curve fetch (the curve-delta capability metrics reproduce
+ * their null blocks until it lands), and the structured `derived_metrics`
+ * schema + cache version bump (the field stays `z.unknown()` for now). The
+ * `history`/`intervals`/`routes`/`ftp_history` retention cache files keep their
+ * empty stubs — they are populated by their own retention pipeline, not here.
  */
 export function makeProductionFetcher(deps: {
   apiKey: string;
@@ -21,22 +33,27 @@ export function makeProductionFetcher(deps: {
       signal,
       perRequestMs: PER_REQUEST_TIMEOUT_MS,
     });
-    return await fetchOnce(client);
+    return await fetchOnce(client, signal);
   };
 }
 
-async function fetchOnce(client: IntervalsClient): Promise<FetchedReference> {
-  const athleteResult = await client.athlete.get();
-  const athlete = athleteResult.ok ? athleteResult.value : {};
+async function fetchOnce(
+  client: IntervalsClient,
+  signal: AbortSignal,
+): Promise<FetchedReference> {
+  const live = await fetchLiveBundle({ client, signal, now: new Date() });
+  const derivedMetrics = computeDerivedMetrics(
+    buildMetricInput(live.bundle, live.frozenNow),
+  );
 
   return {
     latest: {
-      athlete_profile: athlete,
+      athlete_profile: live.athleteProfile,
       current_status: {},
-      derived_metrics: {},
-      recent_activities: [],
+      derived_metrics: derivedMetrics,
+      recent_activities: live.recentActivities,
       planned_workouts: [],
-      wellness_data: {},
+      wellness_data: live.wellnessData,
     },
     history: { daily: [], weekly: [], monthly: [] },
     intervals: { by_activity: {} },

--- a/packages/core/src/reference/sync/fixture-bridge.ts
+++ b/packages/core/src/reference/sync/fixture-bridge.ts
@@ -1,0 +1,81 @@
+// Bridge between a fetched intervals.icu bundle and the metric-compute input
+// shape. The fetch layer hands this module already-renamed, already-parsed
+// rows (the ADR-0012 anti-corruption rename runs upstream of here, in
+// `fetch-live-bundle.ts`); this module only assembles them into the
+// `FixtureShape` the registry computes consume and wraps it as a `MetricInput`.
+//
+// Kept pure and free of any I/O so the assembly is unit-testable without a
+// network and so the parity gate's `FixtureShape` is the single shape the
+// production sync and the snapshot harness both target.
+
+import {
+  FixtureSchema,
+  type Activity,
+  type ActivityStreams,
+  type AthleteSettings,
+  type FixtureShape,
+  type FtpHistoryPoint,
+  type HrCurveData,
+  type PowerCurveData,
+  type SustainabilityFamilyCurves,
+  type WellnessDay,
+} from "../schemas/inputs.js";
+import type { MetricInput } from "../metrics/metric-input.js";
+
+/**
+ * The fetched, renamed inputs the bridge assembles into a `FixtureShape`.
+ *
+ * `activities` / `wellness` MUST already have passed through the rename layer
+ * (`renameTpFieldsOnActivity` / `renameTpFieldsOnWellnessRow`) — this module
+ * does not re-run it. The curve + stream fields are optional: when absent, the
+ * corresponding capability metrics reproduce their null blocks exactly as the
+ * snapshot harness does for fixtures that omit those keys.
+ */
+export interface ReferenceBundle {
+  readonly activities: readonly Activity[];
+  readonly wellness: readonly WellnessDay[];
+  readonly ftpHistory: readonly FtpHistoryPoint[];
+  readonly streams?: Readonly<Record<string, ActivityStreams>>;
+  readonly powerCurves?: PowerCurveData;
+  readonly hrCurves?: HrCurveData;
+  readonly sustainabilityCurves?: Readonly<Record<string, SustainabilityFamilyCurves>>;
+  readonly athlete?: AthleteSettings;
+  readonly currentFtpIndoor?: number | null;
+  readonly currentFtpOutdoor?: number | null;
+  readonly ftpHistoryIndoor?: Readonly<Record<string, number>>;
+  readonly ftpHistoryOutdoor?: Readonly<Record<string, number>>;
+  readonly eftp?: number | null;
+}
+
+/**
+ * Assemble + validate a `FixtureShape` from a fetched bundle. Optional keys are
+ * attached only when present so the strict envelope reproduces the
+ * absent-key-means-null-block behaviour the snapshot fixtures rely on (an
+ * explicit `key: undefined` would still parse, but omitting keeps the cached
+ * shape identical to a fixture that never carried the key).
+ */
+export function buildFixtureShape(bundle: ReferenceBundle): FixtureShape {
+  const raw: Record<string, unknown> = {
+    activities: [...bundle.activities],
+    wellness: [...bundle.wellness],
+    ftp_history: [...bundle.ftpHistory],
+  };
+  if (bundle.streams !== undefined) raw.streams = bundle.streams;
+  if (bundle.powerCurves !== undefined) raw.power_curves = bundle.powerCurves;
+  if (bundle.hrCurves !== undefined) raw.hr_curves = bundle.hrCurves;
+  if (bundle.sustainabilityCurves !== undefined) {
+    raw.sustainability_curves = bundle.sustainabilityCurves;
+  }
+  if (bundle.athlete !== undefined) raw.athlete = bundle.athlete;
+  if (bundle.currentFtpIndoor !== undefined) raw.current_ftp_indoor = bundle.currentFtpIndoor;
+  if (bundle.currentFtpOutdoor !== undefined) raw.current_ftp_outdoor = bundle.currentFtpOutdoor;
+  if (bundle.ftpHistoryIndoor !== undefined) raw.ftp_history_indoor = bundle.ftpHistoryIndoor;
+  if (bundle.ftpHistoryOutdoor !== undefined) raw.ftp_history_outdoor = bundle.ftpHistoryOutdoor;
+  if (bundle.eftp !== undefined) raw.eftp = bundle.eftp;
+  return FixtureSchema.parse(raw);
+}
+
+/** Wrap a fetched bundle as a `MetricInput` for the registry computes. */
+export function buildMetricInput(bundle: ReferenceBundle, frozenNow: string): MetricInput {
+  return { fixture: buildFixtureShape(bundle), frozenNow };
+}

--- a/packages/core/src/reference/sync/format-sync-reply.ts
+++ b/packages/core/src/reference/sync/format-sync-reply.ts
@@ -27,12 +27,13 @@ export function formatSyncReply(result: SyncResult, now: Date = new Date()): str
         }
       }
     case "failed":
-      // Both `outer_timeout` and `gate_rejected` surface to athletes as the
-      // same "can't reach" message today. The future curator will inspect
-      // `error_state.json` and may inject more specific guidance.
+      // `outer_timeout`, `gate_rejected`, and `fetch_failed` all surface to
+      // athletes as the same "can't reach" message today. The future curator
+      // will inspect `error_state.json` and may inject more specific guidance.
       switch (result.reason) {
         case "outer_timeout":
         case "gate_rejected":
+        case "fetch_failed":
           return "I can't reach intervals.icu right now.";
         default: {
           const _exhaustive: never = result.reason;

--- a/packages/core/src/reference/sync/run-sync.ts
+++ b/packages/core/src/reference/sync/run-sync.ts
@@ -66,7 +66,7 @@ export type SyncResult =
     }
   | {
       readonly kind: "failed";
-      readonly reason: "outer_timeout" | "gate_rejected";
+      readonly reason: "outer_timeout" | "gate_rejected" | "fetch_failed";
       readonly failures: readonly SyncFailure[];
     };
 
@@ -175,7 +175,24 @@ export function createRunSync(
         });
 
         const body = async (): Promise<SyncResult> => {
-          const fetched = await deps.fetchReferenceData(controller.signal);
+          let fetched: FetchedReference;
+          try {
+            fetched = await deps.fetchReferenceData(controller.signal);
+          } catch (err) {
+            // A hard fetch/assembly failure (unreachable list endpoint, a
+            // surviving TP-trademarked key, a malformed bundle) must surface to
+            // the curator like any other failed sync — write error_state and
+            // return `failed`. Letting the rejection escape would leave the
+            // scheduled tick logging-only and the curator blind to the failure.
+            if (controller.signal.aborted) return abortedResult();
+            const detail = err instanceof Error ? err.message : String(err);
+            await writeErrorState(deps.dataDir, { step: "fetch_failed", phase, detail });
+            return {
+              kind: "failed",
+              reason: "fetch_failed",
+              failures: [{ file: "latest", reason: detail }],
+            };
+          }
           if (controller.signal.aborted) return abortedResult();
 
           phase = "gating";

--- a/packages/core/tests/reference-compute-derived-metrics.test.ts
+++ b/packages/core/tests/reference-compute-derived-metrics.test.ts
@@ -1,0 +1,90 @@
+// `computeDerivedMetrics` runs the metric registry over a MetricInput to
+// produce the flat `derived_metrics` object the sync persists. These tests pin
+// that (a) it covers the whole registry key-set, (b) it computes real values —
+// including the stream-driven DFA-α1 profile — off a golden fixture, and (c) a
+// single throwing metric is isolated to `null` + a warning, never sinking the
+// rest.
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  computeDerivedMetrics,
+  METRIC_COMPUTE_FAILED_LOG_PREFIX,
+} from "../src/reference/sync/compute-derived-metrics.js";
+import { METRIC_REGISTRY } from "../src/reference/metrics/registry.js";
+import type { MetricInput } from "../src/reference/metrics/metric-input.js";
+import { buildFixtureShape } from "../src/reference/sync/fixture-bridge.js";
+import { GoldenFixtureSchema, loadFixture } from "./helpers/load-fixture.js";
+
+function dfaEquippedInput(): MetricInput {
+  const fixture = loadFixture("golden/dfa-equipped", GoldenFixtureSchema);
+  // Anchor frozenNow just after the newest session so the trailing DFA window
+  // captures the fixture's sufficient rides (epoch-agnostic).
+  const newest = fixture.activities
+    .map((a) => a.start_date_local.slice(0, 10))
+    .sort()
+    .at(-1)!;
+  return { fixture, frozenNow: `${newest}T12:00:00` };
+}
+
+describe("computeDerivedMetrics", () => {
+  it("covers the full registry key-set", () => {
+    const out = computeDerivedMetrics(dfaEquippedInput());
+    expect(Object.keys(out).sort()).toEqual(Object.keys(METRIC_REGISTRY).sort());
+  });
+
+  it("computes the stream-driven DFA-α1 profile on a real fixture", () => {
+    const out = computeDerivedMetrics(dfaEquippedInput());
+    const profile = out["capability.dfa_a1_profile"] as {
+      latest_session?: { sufficient?: boolean };
+    } | null;
+    expect(profile).not.toBeNull();
+    expect(profile?.latest_session).toBeDefined();
+    expect(profile?.latest_session?.sufficient).toBe(true);
+  });
+
+  it("computes load-management metrics (no throw on real data)", () => {
+    const out = computeDerivedMetrics(dfaEquippedInput());
+    expect(out).toHaveProperty("acwr");
+    expect(out).toHaveProperty("monotony");
+    expect(out).toHaveProperty("strain");
+  });
+
+  it("does not throw any real registry metric on a deliberately sparse (but schema-valid) fixture", () => {
+    // The isolation path should never actually fire for real metrics on thin
+    // live data — each degrades to a legitimate null/empty block. A warning here
+    // means a real metric throws on sparse input (a production risk).
+    const log = vi.fn();
+    const sparse = buildFixtureShape({
+      activities: [
+        { id: 1, start_date_local: "2026-06-01T07:00:00", type: "Ride", moving_time: 3600, elapsed_time: 3700 },
+      ],
+      wellness: [
+        { id: "2026-06-01", weight: null, restingHR: null, hrv: null, sleepSecs: null, sleepQuality: null },
+      ],
+      ftpHistory: [],
+    });
+    computeDerivedMetrics({ fixture: sparse, frozenNow: "2026-06-02T12:00:00" }, { log });
+    expect(log).not.toHaveBeenCalled();
+  });
+
+  it("isolates a throwing metric to null + warning, leaving the rest intact", () => {
+    const log = vi.fn();
+    const out = computeDerivedMetrics({ fixture: {} as never, frozenNow: "x" }, {
+      log,
+      registry: {
+        good: { compute: () => 42 },
+        bad: {
+          compute: () => {
+            throw new Error("boom");
+          },
+        },
+      },
+    });
+    expect(out).toEqual({ good: 42, bad: null });
+    expect(log).toHaveBeenCalledTimes(1);
+    expect(log.mock.calls[0]?.[0]).toContain(METRIC_COMPUTE_FAILED_LOG_PREFIX);
+    expect(log.mock.calls[0]?.[0]).toContain("bad");
+    expect(log.mock.calls[0]?.[0]).toContain("boom");
+  });
+});

--- a/packages/core/tests/reference-fetch-live-bundle.test.ts
+++ b/packages/core/tests/reference-fetch-live-bundle.test.ts
@@ -1,0 +1,330 @@
+// `fetchLiveBundle` is the production sync's intervals.icu fetch + ADR-0012
+// anti-corruption boundary. These tests inject a fake client (no network) and
+// pin: TP-field rename on activities + wellness, activity snake-casing, the
+// bounded/cycling-only/abort-aware stream loop, best-effort degradation, FTP
+// history derivation from sportInfo, and the 7-day recent-activities slice.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  fetchLiveBundle,
+  deriveFtpHistory,
+  normalizeStreams,
+  MAX_STREAM_ACTIVITIES,
+  type BundleFetchClient,
+} from "../src/reference/sync/fetch-live-bundle.js";
+import type { WellnessDay } from "../src/reference/schemas/inputs.js";
+
+const NOW = new Date("2026-06-09T12:00:00.000Z");
+
+function daysAgo(n: number): string {
+  return new Date(NOW.getTime() - n * 24 * 60 * 60 * 1000).toISOString();
+}
+
+/** camelCase activity row as the intervals.icu lib emits it (pre-snakeCase). */
+function camelActivity(over: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 1,
+    startDateLocal: daysAgo(2),
+    type: "Ride",
+    movingTime: 3600,
+    elapsedTime: 3700,
+    icuTrainingLoad: 80,
+    averageHeartrate: 140,
+    icuCtl: 50, // TP source → fitnessAtEnd after rename
+    icuAtl: 60, // TP source → fatigueAtEnd after rename
+    ...over,
+  };
+}
+
+function wellnessRaw(over: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: "2026-06-08",
+    weight: 70,
+    restingHR: 50,
+    hrv: 60,
+    sleepSecs: 28800,
+    sleepQuality: 3,
+    ctl: 40, // → fitness
+    atl: 45, // → fatigue
+    ctlLoad: 5,
+    atlLoad: 6,
+    rampRate: 1,
+    sportInfo: [{ type: "Ride", eftp: 250 }],
+    ...over,
+  };
+}
+
+const STREAM_OK = { ok: true as const, value: { dfa_a1: [1, 0.8], heartrate: [140, 145], watts: [200, 210] } };
+
+interface FakeOpts {
+  activities?: Record<string, unknown>[];
+  wellness?: Record<string, unknown>[];
+  athlete?: unknown;
+  streamFor?: (id: string) => { ok: true; value: unknown } | { ok: false; error: unknown };
+  activitiesFail?: boolean;
+}
+
+function fakeClient(opts: FakeOpts): { client: BundleFetchClient; streamCalls: string[] } {
+  const streamCalls: string[] = [];
+  const client: BundleFetchClient = {
+    athlete: { get: async () => ({ ok: true, value: opts.athlete ?? {} }) },
+    activities: {
+      list: async () =>
+        opts.activitiesFail
+          ? { ok: false, error: "boom" }
+          : { ok: true, value: opts.activities ?? [] },
+      getStreams: async (id: string) => {
+        streamCalls.push(id);
+        return opts.streamFor ? opts.streamFor(id) : STREAM_OK;
+      },
+    },
+    wellness: { list: async () => ({ ok: true, value: opts.wellness ?? [] }) },
+  };
+  return { client, streamCalls };
+}
+
+describe("fetchLiveBundle", () => {
+  it("snake-cases + renames TP fields on activities and wellness", async () => {
+    const { client } = fakeClient({
+      activities: [camelActivity({ id: 7 })],
+      wellness: [wellnessRaw()],
+    });
+    const res = await fetchLiveBundle({ client, signal: new AbortController().signal, now: NOW, throttleMs: 0 });
+
+    const act = res.bundle.activities[0]! as Record<string, unknown>;
+    expect(act.start_date_local).toBeTypeOf("string");
+    expect(act.fitnessAtEnd).toBe(50);
+    expect(act.fatigueAtEnd).toBe(60);
+    expect(act.icu_ctl).toBeUndefined();
+    expect(act.icu_atl).toBeUndefined();
+
+    const well = res.bundle.wellness[0]! as Record<string, unknown>;
+    expect(well.fitness).toBe(40);
+    expect(well.fatigue).toBe(45);
+    expect(well.ctl).toBeUndefined();
+    expect(well.atl).toBeUndefined();
+  });
+
+  it("fetches streams only for cycling rides within the stream window, capped", async () => {
+    const cyclingInWindow = Array.from({ length: MAX_STREAM_ACTIVITIES + 3 }, (_, i) =>
+      camelActivity({ id: 100 + i, startDateLocal: daysAgo(1 + i) }),
+    );
+    const activities = [
+      ...cyclingInWindow,
+      camelActivity({ id: 900, type: "Run", startDateLocal: daysAgo(1) }), // non-cycling
+      camelActivity({ id: 901, startDateLocal: daysAgo(40) }), // outside stream window
+    ];
+    const { client, streamCalls } = fakeClient({ activities });
+    const res = await fetchLiveBundle({ client, signal: new AbortController().signal, now: NOW, throttleMs: 0 });
+
+    expect(streamCalls).toHaveLength(MAX_STREAM_ACTIVITIES);
+    expect(streamCalls).not.toContain("900"); // run excluded
+    expect(streamCalls).not.toContain("901"); // out-of-window excluded
+    expect(Object.keys(res.bundle.streams ?? {})).toHaveLength(MAX_STREAM_ACTIVITIES);
+    // full window still present in the metric-input activities (84-day fetch)
+    expect(res.bundle.activities).toHaveLength(activities.length);
+  });
+
+  it("is best-effort: a failed stream fetch is skipped, others kept", async () => {
+    const activities = [
+      camelActivity({ id: 1, startDateLocal: daysAgo(1) }),
+      camelActivity({ id: 2, startDateLocal: daysAgo(2) }),
+    ];
+    const { client } = fakeClient({
+      activities,
+      streamFor: (id) => (id === "1" ? { ok: false, error: "no streams" } : STREAM_OK),
+    });
+    const res = await fetchLiveBundle({ client, signal: new AbortController().signal, now: NOW, throttleMs: 0, log: () => {} });
+    expect(res.bundle.streams?.["1"]).toBeUndefined();
+    expect(res.bundle.streams?.["2"]).toBeDefined();
+  });
+
+  it("breaks the stream loop when the signal is already aborted", async () => {
+    const ac = new AbortController();
+    ac.abort();
+    const { client, streamCalls } = fakeClient({ activities: [camelActivity({ id: 1, startDateLocal: daysAgo(1) })] });
+    const res = await fetchLiveBundle({ client, signal: ac.signal, now: NOW, throttleMs: 0 });
+    expect(streamCalls).toHaveLength(0);
+    expect(res.bundle.streams).toBeUndefined();
+  });
+
+  it("derives cycling FTP history from sportInfo.eftp (one point per change)", async () => {
+    const { client } = fakeClient({
+      wellness: [
+        wellnessRaw({ id: "2026-05-01", sportInfo: [{ type: "Ride", eftp: 240 }] }),
+        wellnessRaw({ id: "2026-05-08", sportInfo: [{ type: "Ride", eftp: 240 }] }), // no change
+        wellnessRaw({ id: "2026-05-20", sportInfo: [{ type: "Ride", eftp: 250 }] }), // change
+      ],
+    });
+    const res = await fetchLiveBundle({ client, signal: new AbortController().signal, now: NOW, throttleMs: 0 });
+    expect(res.bundle.ftpHistory).toEqual([
+      { date: "2026-05-01", ftp: 240, source: "estimate" },
+      { date: "2026-05-20", ftp: 250, source: "estimate" },
+    ]);
+  });
+
+  it("recentActivities is the 7-day slice; bundle keeps the full window", async () => {
+    const { client } = fakeClient({
+      activities: [
+        camelActivity({ id: 1, startDateLocal: daysAgo(2) }), // within 7d
+        camelActivity({ id: 2, startDateLocal: daysAgo(30) }), // outside 7d, inside 84d
+      ],
+    });
+    const res = await fetchLiveBundle({ client, signal: new AbortController().signal, now: NOW, throttleMs: 0 });
+    expect(res.recentActivities).toHaveLength(1);
+    expect(res.bundle.activities).toHaveLength(2);
+  });
+
+  it("extracts athlete sportSettings when present", async () => {
+    const { client } = fakeClient({
+      athlete: { sportSettings: [{ types: ["Ride"], ftp: 250, indoor_ftp: 240, lthr: 165 }] },
+    });
+    const res = await fetchLiveBundle({ client, signal: new AbortController().signal, now: NOW, throttleMs: 0 });
+    expect(res.bundle.athlete?.sportSettings[0]?.ftp).toBe(250);
+  });
+
+  it("throws when the activities list is unreachable", async () => {
+    const { client } = fakeClient({ activitiesFail: true });
+    await expect(
+      fetchLiveBundle({ client, signal: new AbortController().signal, now: NOW, throttleMs: 0 }),
+    ).rejects.toThrow(/activities\.list failed/);
+  });
+});
+
+describe("fetchLiveBundle — real lib stream shapes + edge cases", () => {
+  it("normalizes the lib's ARRAY stream shape so dfa_a1 lands", async () => {
+    // The real getStreams returns camelCased `[{type, data}, …]`, not a
+    // channel-keyed object — the bug the review caught (DFA never computed).
+    const { client } = fakeClient({
+      activities: [camelActivity({ id: 1, startDateLocal: daysAgo(1) })],
+      streamFor: () => ({
+        ok: true,
+        value: [
+          { type: "dfa_a1", data: [1, 0.8] },
+          { type: "watts", data: [200, 210] },
+          { type: "heartrate", data: [140, 145] },
+          { type: "time", data: [0, 1] },
+        ],
+      }),
+    });
+    const res = await fetchLiveBundle({ client, signal: new AbortController().signal, now: NOW, throttleMs: 0 });
+    expect(res.bundle.streams?.["1"]?.dfa_a1).toEqual([1, 0.8]);
+    expect(res.bundle.streams?.["1"]?.watts).toEqual([200, 210]);
+  });
+
+  it("normalizes the lib's camelCased OBJECT stream shape (dfaA1 -> dfa_a1)", async () => {
+    const { client } = fakeClient({
+      activities: [camelActivity({ id: 1, startDateLocal: daysAgo(1) })],
+      streamFor: () => ({ ok: true, value: { dfaA1: [1, 0.8], watts: [200], heartrate: [140] } }),
+    });
+    const res = await fetchLiveBundle({ client, signal: new AbortController().signal, now: NOW, throttleMs: 0 });
+    expect(res.bundle.streams?.["1"]?.dfa_a1).toEqual([1, 0.8]);
+  });
+
+  it("drops a wrong-shaped stream body (not array-of-channels, not object)", async () => {
+    const { client } = fakeClient({
+      activities: [camelActivity({ id: 1, startDateLocal: daysAgo(1) })],
+      streamFor: () => ({ ok: true, value: "garbage" }),
+    });
+    const res = await fetchLiveBundle({ client, signal: new AbortController().signal, now: NOW, throttleMs: 0, log: () => {} });
+    expect(res.bundle.streams).toBeUndefined();
+  });
+
+  it("recovers indoor_ftp from the lib's camelCased athlete profile", async () => {
+    const { client } = fakeClient({
+      athlete: { sportSettings: [{ types: ["Ride"], ftp: 250, indoorFtp: 240, lthr: 165 }] },
+    });
+    const res = await fetchLiveBundle({ client, signal: new AbortController().signal, now: NOW, throttleMs: 0 });
+    expect(res.bundle.athlete?.sportSettings[0]?.indoor_ftp).toBe(240);
+  });
+
+  it("resolves with a warning when athlete.get fails (no settings, not a crash)", async () => {
+    const logs: string[] = [];
+    const client: BundleFetchClient = {
+      athlete: { get: async () => ({ ok: false, error: "unauthorized" }) },
+      activities: { list: async () => ({ ok: true, value: [] }), getStreams: async () => STREAM_OK },
+      wellness: { list: async () => ({ ok: true, value: [] }) },
+    };
+    const res = await fetchLiveBundle({ client, signal: new AbortController().signal, now: NOW, throttleMs: 0, log: (m) => logs.push(m) });
+    expect(res.bundle.athlete).toBeUndefined();
+    expect(logs.some((l) => l.includes("athlete.get failed"))).toBe(true);
+  });
+
+  it("resolves with empty wellness + a warning when wellness.list fails", async () => {
+    const logs: string[] = [];
+    const client: BundleFetchClient = {
+      athlete: { get: async () => ({ ok: true, value: {} }) },
+      activities: { list: async () => ({ ok: true, value: [] }), getStreams: async () => STREAM_OK },
+      wellness: { list: async () => ({ ok: false, error: "timeout" }) },
+    };
+    const res = await fetchLiveBundle({ client, signal: new AbortController().signal, now: NOW, throttleMs: 0, log: (m) => logs.push(m) });
+    expect(res.bundle.wellness).toEqual([]);
+    expect(res.bundle.ftpHistory).toEqual([]);
+    expect(logs.some((l) => l.includes("wellness.list failed"))).toBe(true);
+  });
+
+  it("treats a non-array activities body as empty (ok:true, malformed) without crashing", async () => {
+    const logs: string[] = [];
+    const client: BundleFetchClient = {
+      athlete: { get: async () => ({ ok: true, value: {} }) },
+      activities: { list: async () => ({ ok: true, value: { not: "an array" } as unknown as unknown[] }), getStreams: async () => STREAM_OK },
+      wellness: { list: async () => ({ ok: true, value: [] }) },
+    };
+    const res = await fetchLiveBundle({ client, signal: new AbortController().signal, now: NOW, throttleMs: 0, log: (m) => logs.push(m) });
+    expect(res.bundle.activities).toEqual([]);
+    expect(logs.some((l) => l.includes("non-array"))).toBe(true);
+  });
+
+  it("breaks the stream loop mid-flight when aborted during a fetch", async () => {
+    const ac = new AbortController();
+    const activities = [
+      camelActivity({ id: 1, startDateLocal: daysAgo(1) }),
+      camelActivity({ id: 2, startDateLocal: daysAgo(2) }),
+      camelActivity({ id: 3, startDateLocal: daysAgo(3) }),
+    ];
+    const { client, streamCalls } = fakeClient({
+      activities,
+      streamFor: () => {
+        ac.abort();
+        return STREAM_OK;
+      },
+    });
+    await fetchLiveBundle({ client, signal: ac.signal, now: NOW, throttleMs: 0 });
+    expect(streamCalls).toHaveLength(1);
+  });
+
+  it("anchors frozenNow to naive local time (no UTC Z/offset suffix)", async () => {
+    const { client } = fakeClient({ activities: [] });
+    const res = await fetchLiveBundle({ client, signal: new AbortController().signal, now: NOW, throttleMs: 0 });
+    expect(res.frozenNow).not.toMatch(/[Z+]/);
+    expect(res.frozenNow).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/);
+  });
+});
+
+describe("normalizeStreams", () => {
+  it("maps an array of {type,data} channels to a channel-keyed object", () => {
+    expect(
+      normalizeStreams([
+        { type: "dfa_a1", data: [1, 0.8] },
+        { type: "watts", data: [200] },
+      ]),
+    ).toEqual({ dfa_a1: [1, 0.8], watts: [200] });
+  });
+  it("snake-cases a camelCased object body", () => {
+    expect(normalizeStreams({ dfaA1: [1], heartrate: [140] })).toEqual({ dfa_a1: [1], heartrate: [140] });
+  });
+  it("passes a scalar through untouched", () => {
+    expect(normalizeStreams("garbage")).toBe("garbage");
+  });
+});
+
+describe("deriveFtpHistory", () => {
+  it("ignores non-cycling sportInfo and rounds eftp", () => {
+    const wellness: WellnessDay[] = [
+      { id: "2026-05-01", weight: null, restingHR: null, hrv: null, sleepSecs: null, sleepQuality: null, sportInfo: [{ type: "Run", eftp: 300 }] } as WellnessDay,
+      { id: "2026-05-02", weight: null, restingHR: null, hrv: null, sleepSecs: null, sleepQuality: null, sportInfo: [{ type: "Ride", eftp: 249.6 }] } as WellnessDay,
+    ];
+    expect(deriveFtpHistory(wellness)).toEqual([{ date: "2026-05-02", ftp: 250, source: "estimate" }]);
+  });
+});

--- a/packages/core/tests/reference-fixture-bridge.test.ts
+++ b/packages/core/tests/reference-fixture-bridge.test.ts
@@ -1,0 +1,95 @@
+// The fixture bridge turns a fetched intervals.icu bundle into the parity
+// gate's `FixtureShape` / `MetricInput`. These tests pin that it assembles the
+// required rows, attaches optional curve/stream keys only when present (so an
+// absent key reproduces the null-block behaviour the snapshot fixtures rely
+// on), and round-trips a real golden fixture's stream-bearing shape.
+
+import { describe, expect, it } from "vitest";
+
+import { buildFixtureShape, buildMetricInput, type ReferenceBundle } from "../src/reference/sync/fixture-bridge.js";
+import type { Activity, FtpHistoryPoint, WellnessDay } from "../src/reference/schemas/inputs.js";
+import { GoldenFixtureSchema, loadFixture } from "./helpers/load-fixture.js";
+
+const activity = (over: Partial<Activity> = {}): Activity => ({
+  id: 1,
+  start_date_local: "2026-06-01T07:00:00",
+  type: "Ride",
+  moving_time: 3600,
+  elapsed_time: 3700,
+  ...over,
+});
+
+const wellnessRow = (over: Partial<WellnessDay> = {}): WellnessDay => ({
+  id: "2026-06-01",
+  weight: 70,
+  restingHR: 50,
+  hrv: 60,
+  sleepSecs: 28800,
+  sleepQuality: 3,
+  ...over,
+});
+
+const ftp: FtpHistoryPoint = { date: "2026-06-01", ftp: 250, source: "estimate" };
+
+describe("buildFixtureShape", () => {
+  it("assembles the required rows and parses against FixtureSchema", () => {
+    const bundle: ReferenceBundle = {
+      activities: [activity()],
+      wellness: [wellnessRow()],
+      ftpHistory: [ftp],
+    };
+    const fixture = buildFixtureShape(bundle);
+    expect(fixture.activities).toHaveLength(1);
+    expect(fixture.wellness).toHaveLength(1);
+    expect(fixture.ftp_history).toEqual([ftp]);
+  });
+
+  it("omits optional curve/stream/athlete keys when the bundle lacks them", () => {
+    const fixture = buildFixtureShape({
+      activities: [activity()],
+      wellness: [wellnessRow()],
+      ftpHistory: [],
+    });
+    expect("streams" in fixture).toBe(false);
+    expect("power_curves" in fixture).toBe(false);
+    expect("hr_curves" in fixture).toBe(false);
+    expect("sustainability_curves" in fixture).toBe(false);
+    expect("athlete" in fixture).toBe(false);
+  });
+
+  it("attaches optional keys when present", () => {
+    const fixture = buildFixtureShape({
+      activities: [activity({ id: "90201" })],
+      wellness: [wellnessRow()],
+      ftpHistory: [],
+      streams: { "90201": { dfa_a1: [1, 0.8], heartrate: [140, 145], watts: [200, 210] } },
+      athlete: { sportSettings: [{ types: ["Ride"], ftp: 250, indoor_ftp: 240, lthr: 165 }] },
+      currentFtpOutdoor: 250,
+    });
+    expect(fixture.streams).toBeDefined();
+    expect(fixture.streams?.["90201"]?.dfa_a1).toEqual([1, 0.8]);
+    expect(fixture.athlete?.sportSettings[0]?.ftp).toBe(250);
+    expect(fixture.current_ftp_outdoor).toBe(250);
+  });
+
+  it("round-trips a real stream-bearing golden fixture", () => {
+    const golden = loadFixture("golden/dfa-equipped", GoldenFixtureSchema);
+    const rebuilt = buildFixtureShape({
+      activities: golden.activities,
+      wellness: golden.wellness,
+      ftpHistory: golden.ftp_history,
+      streams: golden.streams,
+    });
+    expect(rebuilt.activities).toEqual(golden.activities);
+    expect(rebuilt.streams).toEqual(golden.streams);
+  });
+
+  it("buildMetricInput wraps the fixture with frozenNow", () => {
+    const input = buildMetricInput(
+      { activities: [activity()], wellness: [wellnessRow()], ftpHistory: [] },
+      "2026-06-09T12:00:00.000Z",
+    );
+    expect(input.frozenNow).toBe("2026-06-09T12:00:00.000Z");
+    expect(input.fixture.activities).toHaveLength(1);
+  });
+});

--- a/packages/core/tests/reference-live-sync-integration.test.ts
+++ b/packages/core/tests/reference-live-sync-integration.test.ts
@@ -1,0 +1,129 @@
+// Integration check for the live-data bridge: the composed fetch → bridge →
+// registry output (mirroring the production `fetchOnce`) must pass the Layer-1
+// sync gate with no hard failures and parse against `LatestJsonSchema` — the
+// shape `runSync` commits to `latest.json`. This is the "real adapter output on
+// disk stays valid" guarantee behind AC3.
+
+import { describe, expect, it } from "vitest";
+
+import { fetchLiveBundle, type BundleFetchClient } from "../src/reference/sync/fetch-live-bundle.js";
+import { buildMetricInput } from "../src/reference/sync/fixture-bridge.js";
+import { computeDerivedMetrics } from "../src/reference/sync/compute-derived-metrics.js";
+import type { FetchedReference } from "../src/reference/sync/run-sync.js";
+import { gateLatestJson } from "../src/reference/validation/sync-gate.js";
+import { LatestJsonSchema } from "../src/reference/schemas/latest.js";
+import { METRIC_REGISTRY } from "../src/reference/metrics/registry.js";
+
+const NOW = new Date("2026-06-09T12:00:00.000Z");
+
+function daysAgo(n: number): string {
+  return new Date(NOW.getTime() - n * 24 * 60 * 60 * 1000).toISOString();
+}
+
+function fakeClient(): BundleFetchClient {
+  const activities = Array.from({ length: 5 }, (_, i) => ({
+    id: 100 + i,
+    startDateLocal: daysAgo(i + 1),
+    type: "Ride",
+    movingTime: 3600,
+    elapsedTime: 3700,
+    icuTrainingLoad: 80,
+    averageHeartrate: 140,
+    icuCtl: 50,
+    icuAtl: 60,
+  }));
+  const wellness = Array.from({ length: 5 }, (_, i) => ({
+    id: daysAgo(i + 1).slice(0, 10),
+    weight: 70,
+    restingHR: 50,
+    hrv: 60,
+    sleepSecs: 28800,
+    sleepQuality: 3,
+    ctl: 40,
+    atl: 45,
+    ctlLoad: 5,
+    atlLoad: 6,
+    rampRate: 1,
+    sportInfo: [{ type: "Ride", eftp: 250 }],
+  }));
+  return {
+    athlete: { get: async () => ({ ok: true, value: { sportSettings: [{ types: ["Ride"], ftp: 250, indoor_ftp: 240, lthr: 165 }] } }) },
+    activities: {
+      list: async () => ({ ok: true, value: activities }),
+      getStreams: async () => ({ ok: true, value: { dfa_a1: [1, 0.8], heartrate: [140, 145], watts: [200, 210] } }),
+    },
+    wellness: { list: async () => ({ ok: true, value: wellness }) },
+  };
+}
+
+/** Compose exactly as the production `fetchOnce` does. */
+async function composeFetched(): Promise<FetchedReference> {
+  const live = await fetchLiveBundle({ client: fakeClient(), signal: new AbortController().signal, now: NOW, throttleMs: 0 });
+  const derived_metrics = computeDerivedMetrics(buildMetricInput(live.bundle, live.frozenNow));
+  return {
+    latest: {
+      athlete_profile: live.athleteProfile,
+      current_status: {},
+      derived_metrics,
+      recent_activities: live.recentActivities,
+      planned_workouts: [],
+      wellness_data: live.wellnessData,
+    },
+    history: { daily: [], weekly: [], monthly: [] },
+    intervals: { by_activity: {} },
+    routes: { routes: [] },
+    ftp_history: { entries: [] },
+  };
+}
+
+describe("live-data bridge integration", () => {
+  it("passes the Layer-1 sync gate with no hard failures", async () => {
+    const fetched = await composeFetched();
+    const result = gateLatestJson(fetched, null, NOW);
+    expect(result.failures).toEqual([]);
+    expect(result.ok).toBe(true);
+  });
+
+  it("produces a latest envelope that parses against LatestJsonSchema", async () => {
+    const fetched = await composeFetched();
+    const onDisk = {
+      metadata: { schema_version: "1", last_updated: NOW.toISOString(), freshness: "fresh" as const },
+      ...fetched.latest,
+    };
+    expect(() => LatestJsonSchema.parse(onDisk)).not.toThrow();
+  });
+
+  it("writes a populated, full-registry derived_metrics block", async () => {
+    const fetched = await composeFetched();
+    const derived = fetched.latest.derived_metrics as Record<string, unknown>;
+    expect(Object.keys(derived).sort()).toEqual(Object.keys(METRIC_REGISTRY).sort());
+    expect(fetched.latest.recent_activities.length).toBeGreaterThan(0);
+  });
+
+  it("handles an empty bundle (zero activities/wellness): gate passes, full key-set, empty recent_activities", async () => {
+    const emptyClient: BundleFetchClient = {
+      athlete: { get: async () => ({ ok: true, value: {} }) },
+      activities: { list: async () => ({ ok: true, value: [] }), getStreams: async () => ({ ok: true, value: [] }) },
+      wellness: { list: async () => ({ ok: true, value: [] }) },
+    };
+    const live = await fetchLiveBundle({ client: emptyClient, signal: new AbortController().signal, now: NOW, throttleMs: 0 });
+    const derived_metrics = computeDerivedMetrics(buildMetricInput(live.bundle, live.frozenNow));
+    const fetched: FetchedReference = {
+      latest: {
+        athlete_profile: live.athleteProfile,
+        current_status: {},
+        derived_metrics,
+        recent_activities: live.recentActivities,
+        planned_workouts: [],
+        wellness_data: live.wellnessData,
+      },
+      history: { daily: [], weekly: [], monthly: [] },
+      intervals: { by_activity: {} },
+      routes: { routes: [] },
+      ftp_history: { entries: [] },
+    };
+    expect(gateLatestJson(fetched, null, NOW).failures).toEqual([]);
+    expect(Object.keys(derived_metrics).sort()).toEqual(Object.keys(METRIC_REGISTRY).sort());
+    expect(live.recentActivities).toEqual([]);
+  });
+});

--- a/packages/core/tests/reference-runtime.test.ts
+++ b/packages/core/tests/reference-runtime.test.ts
@@ -2,10 +2,7 @@ import { mkdtempSync, rmSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  bootstrapReference,
-  INITIAL_SYNC_FAILED_LOG_PREFIX,
-} from "../src/reference/runtime.js";
+import { bootstrapReference } from "../src/reference/runtime.js";
 import { ReferenceConfigError } from "../src/reference/errors.js";
 import type { ReferenceSportAdapter } from "../src/reference/sport-adapter.js";
 import type { Sport } from "../src/sport.js";
@@ -93,9 +90,9 @@ describe("bootstrapReference (behavioral)", () => {
     runtime.scheduler.stop();
   });
 
-  it("does not throw when the initial fetch fails (best-effort init)", async () => {
+  it("does not throw when the initial fetch fails; writes error_state for the curator (best-effort init)", async () => {
     const failingFetch = vi.fn().mockRejectedValue(new Error("intervals.icu unreachable"));
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
 
     const runtime = await bootstrapReference({
       dataDir,
@@ -105,9 +102,10 @@ describe("bootstrapReference (behavioral)", () => {
     });
 
     expect(runtime).toBeDefined();
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining(INITIAL_SYNC_FAILED_LOG_PREFIX),
-    );
+    // The fetch rejection is now handled inside runSync (converted to a failed
+    // sync + error_state.json) rather than rethrown, so bootstrap continues and
+    // the curator can see the failure on disk.
+    expect(existsSync(join(dataDir, "data", "error_state.json"))).toBe(true);
     runtime.scheduler.stop();
   });
 


### PR DESCRIPTION
## What

Wires live intervals.icu data into the Reference layer's sync. The production
fetcher now pulls the athlete profile, a trailing window of activities and
wellness, and a bounded, best-effort set of per-activity HRV/power streams; runs
them through the ADR-0012 rename anti-corruption layer; bridges the result to the
metric-compute input shape (`FetchedReference` → `MetricInput`); and runs the
full metric registry — so `latest.json` carries real `recent_activities` and a
computed `derived_metrics` block instead of empty stubs.

## How

New modules:
- `fixture-bridge.ts` — pure bundle → `FixtureShape` / `MetricInput` assembly.
- `compute-derived-metrics.ts` — registry runner with per-metric failure
  isolation (a throwing metric degrades to `null` + a warning, never sinking the
  rest).
- `fetch-live-bundle.ts` — the abort-aware, bounded live fetch + rename boundary.
  The stream loop is capped, cycling-only, and bounded by a wall-clock
  sub-budget so a slow account cannot exhaust the sync timeout.

Hardening from review: stream responses are normalized from the API's
array-of-channels (and camelCased keys) into the channel-keyed shape the DFA-α1
block consumes; the metric date-window anchor uses naive local time so it lines
up with intervals.icu's local-time activity dates; a hard fetch/assembly failure
(or a surviving trademark-named key) is converted into a failed sync that writes
`error_state.json` for the curator, rather than escaping uncaught.

## Scope / follow-ups

`derived_metrics` keeps its `z.unknown()` typing and the per-window
power/HR/sustainability curve fetch is not yet wired (those capability metrics
reproduce their null blocks until it lands) — both tracked as follow-ups. The
`history`/`intervals`/`routes`/`ftp_history` retention caches keep their stubs.
Metric math is untouched — parity stays green (559/559).

## Verification

- Full suite green; `check-parity --all` 559/559 (exit 0); lint / trademarks /
  fixture-privacy clean.

Internal sync-plumbing change; no athlete-facing output change yet.
