### PR TITLE
ci: gate every PR on the pnpm check aggregator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,5 @@ jobs:
           node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - run: pnpm -r build
-      - run: pnpm exec oxlint packages/
-      - run: pnpm check:fixture-privacy
+      - run: pnpm check
       - run: pnpm test


### PR DESCRIPTION
## Summary

Rewrites the CI `test` job's run steps to `pnpm install --frozen-lockfile` → `pnpm check` → `pnpm test`, replacing the three individually replicated steps (`pnpm -r build`, oxlint, fixture-privacy lint). CI now runs the root `check` aggregator directly, so it can never again silently diverge from it — notably, the trademark-substitution lint (`check:trademarks`) was missing from CI and now gates every PR. Any future addition to the aggregator is gated automatically with zero workflow edits.

Packaging note: shipped as a standalone PR (operator decision 2026-06-12) so this one-line gate flip stays reviewable, sequenced after the merge-gate flip and the typecheck-gate paydown.

Formatting (`fmt:check`) is intentionally NOT wired in: it is red on main (212/1159 files, no oxfmt config) and is deferred to a separate style follow-up so the reformat doesn't bury this change.

## Test plan

- `pnpm check && pnpm test` green locally (110 files, 1941 passed / 2 skipped).
- Red path verified locally with a transient probe file containing a banned token (deleted before commit): the lint exits 1 and names the file; clean run exits 0 afterward. The lint's red path is also pinned in the existing vitest suite.
- `test` job id and `uses:` action pins untouched; required-check naming unaffected.
