### PR TITLE
fix(core): replace retired google default model with gemini-2.5-flash

### DIFF
--- a/.changeset/google-default-model.md
+++ b/.changeset/google-default-model.md
@@ -1,0 +1,11 @@
+---
+"@enduragent/core": patch
+"cycling-coach": patch
+---
+
+User-facing: Fixed the default Google model: setups that never chose a model now use gemini-2.5-flash, replacing the retired gemini-2.0-flash that made the coach fail to respond.
+
+The google provider's hardcoded default pointed at gemini-2.0-flash, retired
+by Google on 2026-06-01, so env-only deployments hard-errored on every call.
+CONTEXT_WINDOWS gains a gemini-2.5-flash entry (1,000,000) so the model
+resolves its real window instead of the 200,000-token fallback.

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -60,6 +60,7 @@ const CONTEXT_WINDOWS: Record<string, number> = {
   "claude-haiku-4-5-20251001": 200_000,
   "gpt-4o": 128_000,
   "gemini-2.0-flash": 1_000_000,
+  "gemini-2.5-flash": 1_000_000,
   "gpt-5.4": 272_000,
   "gpt-5.4-mini": 272_000,
   "gpt-5.4-pro": 272_000,
@@ -183,7 +184,7 @@ export function loadConfig(): Config {
   const defaultModelMap: Record<string, string> = {
     anthropic: "claude-sonnet-4-6",
     openai: "gpt-4o",
-    google: "gemini-2.0-flash",
+    google: "gemini-2.5-flash",
     "openai-codex": "gpt-5.4",
   };
 

--- a/packages/core/tests/config.default-models.test.ts
+++ b/packages/core/tests/config.default-models.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const MANAGED_ENV = [
+  "ANTHROPIC_API_KEY",
+  "OPENAI_API_KEY",
+  "GOOGLE_GENERATIVE_AI_API_KEY",
+  "INTERVALS_API_KEY",
+  "INTERVALS_ATHLETE_ID",
+  "TELEGRAM_BOT_TOKEN",
+  "LLM_PROVIDER",
+  "LLM_MODEL",
+  "CONTEXT_WINDOW_TOKENS",
+];
+
+let tempHome: string;
+let origHome: string | undefined;
+let origCcHome: string | undefined;
+const savedEnv: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  tempHome = mkdtempSync(join(tmpdir(), "cc-defaultmodels-"));
+  origHome = process.env.HOME;
+  origCcHome = process.env.CYCLING_COACH_HOME;
+  process.env.HOME = tempHome;
+  delete process.env.CYCLING_COACH_HOME;
+  mkdirSync(join(tempHome, ".cycling-coach"), { recursive: true });
+  for (const k of MANAGED_ENV) {
+    savedEnv[k] = process.env[k];
+    delete process.env[k];
+  }
+  vi.resetModules();
+});
+
+afterEach(() => {
+  process.env.HOME = origHome;
+  if (origCcHome !== undefined) process.env.CYCLING_COACH_HOME = origCcHome;
+  else delete process.env.CYCLING_COACH_HOME;
+  for (const k of MANAGED_ENV) {
+    if (savedEnv[k] !== undefined) process.env[k] = savedEnv[k];
+    else delete process.env[k];
+  }
+  rmSync(tempHome, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+describe("config — default model and context-window resolution", () => {
+  it("google provider with no model defaults to gemini-2.5-flash with a 1M window", async () => {
+    process.env.LLM_PROVIDER = "google";
+    const { loadConfig } = await import("../src/config.js");
+    const cfg = loadConfig();
+    expect(cfg.llm.model).toBe("gemini-2.5-flash");
+    expect(cfg.contextWindowTokens).toBe(1_000_000);
+  });
+
+  it("explicit gemini-2.5-flash model resolves the 1M window regardless of provider", async () => {
+    process.env.LLM_PROVIDER = "anthropic";
+    process.env.LLM_MODEL = "gemini-2.5-flash";
+    const { loadConfig } = await import("../src/config.js");
+    const cfg = loadConfig();
+    expect(cfg.contextWindowTokens).toBe(1_000_000);
+  });
+
+  it("openai provider with no model stays pinned to gpt-4o with a 128k window", async () => {
+    process.env.LLM_PROVIDER = "openai";
+    const { loadConfig } = await import("../src/config.js");
+    const cfg = loadConfig();
+    expect(cfg.llm.model).toBe("gpt-4o");
+    expect(cfg.contextWindowTokens).toBe(128_000);
+  });
+});


### PR DESCRIPTION
## Summary

- The google provider's hardcoded default model pointed at `gemini-2.0-flash`, retired by Google on 2026-06-01, so env-only deployments (`LLM_PROVIDER=google` with no model configured) hard-errored on every LLM call. The default now resolves `gemini-2.5-flash`, matching the setup wizard's existing recommendation.
- `CONTEXT_WINDOWS` gains a `gemini-2.5-flash` entry (1,000,000 tokens) so the model resolves its real context window instead of the 200,000-token unknown-model fallback.
- New test file `packages/core/tests/config.default-models.test.ts` covers the google default + window, the explicit-model window lookup, and pins the openai default (`gpt-4o`) so an accidental bump fails loudly. Verified red against the unmodified source.

The openai default bump is intentionally deferred to a follow-up (lineage: token-economics audit). The `gemini-2.0-flash` window entry stays for now; catalog unification is a later concern.

## Test plan

- `pnpm vitest run packages/core/tests/config.default-models.test.ts` — 3 passed
- Non-vacuity: with `config.ts` stashed, the new tests fail (2 failed | 1 passed)
- `pnpm test` — 111 files, 1944 passed | 2 skipped
- `pnpm --filter @enduragent/core build` — ESM + DTS build success
