### PR TITLE
fix(core): clamp rate-limit retry-after backoff to 120s

### DIFF
--- a/.changeset/rate-limit-backoff-clamp.md
+++ b/.changeset/rate-limit-backoff-clamp.md
@@ -1,0 +1,8 @@
+---
+"@enduragent/core": patch
+"cycling-coach": patch
+---
+
+User-facing: When the model provider asks the coach to back off, waits are now capped at 2 minutes — a huge provider-requested delay can no longer freeze the chat for hours.
+
+Clamps the header-derived retry wait in the chat retry loop to a named 120 s ceiling at the existing backoff site (the 30 s cap previously bound only the locally computed fallback). The existing rate-limit warn line now reports the provider-requested value when clamping occurs.

--- a/packages/core/src/agent/coach-agent.ts
+++ b/packages/core/src/agent/coach-agent.ts
@@ -34,6 +34,7 @@ const MAX_RATE_LIMIT_ATTEMPTS = 3;
 const RATE_LIMIT_FALLBACK_BASE_MS = 5_000;
 const RATE_LIMIT_FALLBACK_MULTIPLIER = 2;
 const RATE_LIMIT_FALLBACK_MAX_MS = 30_000;
+const RATE_LIMIT_MAX_WAIT_MS = 120_000;
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -215,12 +216,16 @@ export class CoachAgent {
           if (isRateLimitError(err) && rateLimitAttempts < MAX_RATE_LIMIT_ATTEMPTS) {
             rateLimitAttempts++;
             const retryAfter = extractRetryAfterMs(err);
-            const backoff = retryAfter
+            const requestedMs = retryAfter
               ?? Math.min(
                    RATE_LIMIT_FALLBACK_BASE_MS * Math.pow(RATE_LIMIT_FALLBACK_MULTIPLIER, rateLimitAttempts - 1),
                    RATE_LIMIT_FALLBACK_MAX_MS,
                  );
-            console.warn(`Rate limited (attempt ${rateLimitAttempts}/${MAX_RATE_LIMIT_ATTEMPTS}), waiting ${backoff}ms`);
+            const backoff = Math.min(requestedMs, RATE_LIMIT_MAX_WAIT_MS);
+            const clampNote = requestedMs > RATE_LIMIT_MAX_WAIT_MS
+              ? ` (provider requested ${requestedMs}ms, clamped to ${RATE_LIMIT_MAX_WAIT_MS}ms)`
+              : "";
+            console.warn(`Rate limited (attempt ${rateLimitAttempts}/${MAX_RATE_LIMIT_ATTEMPTS}), waiting ${backoff}ms${clampNote}`);
             await sleep(backoff);
             continue;
           }

--- a/packages/core/tests/retry-loop-codex.test.ts
+++ b/packages/core/tests/retry-loop-codex.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { APICallError } from "@ai-sdk/provider";
 import { mkdtempSync, rmSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -146,5 +147,79 @@ describe("retry loop on Codex path", () => {
     expect(text).toBe("recovered-after-compaction");
     // 1 overflow + 1 memory flush during compaction + 1 retry success = 3
     expect(complete).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe("rate-limit backoff clamp", () => {
+  it("clamps a header-derived retry-after above the cap to RATE_LIMIT_MAX_WAIT_MS", async () => {
+    let n = 0;
+    const complete = vi.fn(async () => {
+      n++;
+      if (n === 1) {
+        // Message must not match codex-bridge normalizeError patterns, or the
+        // headers are stripped before reaching the retry loop.
+        throw new APICallError({
+          message: "quota exhausted",
+          url: "https://chatgpt.com/backend-api",
+          requestBodyValues: {},
+          statusCode: 429,
+          responseHeaders: { "retry-after": "3600" },
+        });
+      }
+      return mkAssistant("recovered-after-clamp");
+    });
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.useFakeTimers();
+    const agent = await setupAgent(complete);
+
+    const chatPromise = agent.chat("test-chat-clamp", "hello");
+    await vi.advanceTimersByTimeAsync(120_000);
+    const text = await chatPromise;
+
+    expect(text).toBe("recovered-after-clamp");
+    expect(complete).toHaveBeenCalledTimes(2);
+    const warnLine = warnSpy.mock.calls
+      .map((c) => String(c[0]))
+      .find((s) => s.includes("Rate limited"));
+    expect(warnLine).toContain("waiting 120000ms");
+    expect(warnLine).toContain("provider requested 3600000ms");
+
+    vi.useRealTimers();
+  });
+
+  it("honors a sub-cap header-derived retry-after unchanged", async () => {
+    let n = 0;
+    const complete = vi.fn(async () => {
+      n++;
+      if (n === 1) {
+        throw new APICallError({
+          message: "quota exhausted",
+          url: "https://chatgpt.com/backend-api",
+          requestBodyValues: {},
+          statusCode: 429,
+          responseHeaders: { "retry-after": "10" },
+        });
+      }
+      return mkAssistant("recovered-fast");
+    });
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.useFakeTimers();
+    const agent = await setupAgent(complete);
+
+    const chatPromise = agent.chat("test-chat-subcap", "hello");
+    await vi.advanceTimersByTimeAsync(10_000);
+    const text = await chatPromise;
+
+    expect(text).toBe("recovered-fast");
+    expect(complete).toHaveBeenCalledTimes(2);
+    const warnLine = warnSpy.mock.calls
+      .map((c) => String(c[0]))
+      .find((s) => s.includes("Rate limited"));
+    expect(warnLine).toContain("waiting 10000ms");
+    expect(warnLine).not.toContain("clamped");
+
+    vi.useRealTimers();
   });
 });


### PR DESCRIPTION
## Summary

When the chat retry loop honored a provider-supplied Retry-After header, the value passed through unbounded: a `retry-after: 3600` response slept a full hour per attempt (up to ~3 hours across attempts) while the per-chat session lock was held, queueing every subsequent athlete message behind it. The existing 30 s cap bound only the locally computed exponential fallback, never the header value.

## Changes

- New module-level constant `RATE_LIMIT_MAX_WAIT_MS = 120_000` in `coach-agent.ts`, applied via `Math.min` to the combined header-or-fallback wait. Fallback behavior is unchanged (it already maxed at 30 s).
- The existing rate-limit `console.warn` line now appends `(provider requested <N>ms, clamped to 120000ms)` when clamping occurs; the non-clamped line is byte-identical to before.
- Two new fake-timer tests in `retry-loop-codex.test.ts`: a 3600 s header releases after a 120 000 ms advance with the clamped warn line, and a sub-cap 10 s header passes through unclamped.
- Changeset bumping `@enduragent/core` and `cycling-coach` with a `User-facing:` line.

This mirrors the precedent already in the snapshot sender, which hard-caps provider `retry_after` values; the chat LLM layer was the one surface without a cap.

## Testing

- `pnpm test packages/core/tests/retry-loop-codex.test.ts` — 5 passed (3 existing + 2 new)
- `pnpm test` — 111 files, 1946 passed / 2 skipped, 0 failures
- `pnpm lint` — 0 warnings, 0 errors