### PR TITLE
fix(core): disable HTTP-layer retries on the chat intervals client

### DIFF
--- a/.changeset/chat-client-no-http-retry.md
+++ b/.changeset/chat-client-no-http-retry.md
@@ -1,0 +1,7 @@
+---
+"@enduragent/core": patch
+---
+
+User-facing: Fixed a bug where a flaky intervals.icu connection while saving a workout could create duplicate workouts on your calendar.
+
+The chat-path client now constructs through the intervals client factory with lib-side retry disabled (`maxAttempts: 1`), mirroring the sync path, so non-idempotent calendar writes are never replayed by the HTTP layer.

--- a/packages/core/src/agent/coach-agent.ts
+++ b/packages/core/src/agent/coach-agent.ts
@@ -1,6 +1,6 @@
 import { stepCountIs } from "ai";
 import type { ModelMessage, ToolSet } from "ai";
-import { IntervalsClient } from "intervals-icu-api";
+import { makeChatClient } from "../reference/sync/intervals-client-factory.js";
 import { getEffectiveSections } from "../memory/effective-sections.js";
 import type { CoreDeps, Sport } from "../sport.js";
 import type { SecretsResolver } from "../secrets/types.js";
@@ -63,7 +63,7 @@ export class CoachAgent {
     this.chatStore = new ChatStore(config.dataDir);
 
     const intervals = config.intervals.apiKey
-      ? new IntervalsClient({
+      ? makeChatClient({
           apiKey: config.intervals.apiKey,
           athleteId: config.intervals.athleteId,
         })

--- a/packages/core/src/reference/sync/intervals-client-factory.ts
+++ b/packages/core/src/reference/sync/intervals-client-factory.ts
@@ -49,3 +49,23 @@ export function makeAbortableClient(opts: {
     retry: { maxAttempts: 1 },
   });
 }
+
+/**
+ * Chat-path IntervalsClient. Lib-side retry is disabled (`maxAttempts: 1`) so
+ * non-idempotent calendar writes (POST/PUT/DELETE) are never replayed by the
+ * HTTP layer; transient-failure handling belongs to the caller. `fetch` is
+ * injectable for tests — the constructor's `fetch` option is the lib's only
+ * injection point (see the note on `makeAbortableClient`).
+ */
+export function makeChatClient(opts: {
+  apiKey: string;
+  athleteId?: string;
+  fetch?: typeof globalThis.fetch;
+}): IntervalsClient {
+  return new IntervalsClient({
+    apiKey: opts.apiKey,
+    athleteId: opts.athleteId,
+    fetch: opts.fetch,
+    retry: { maxAttempts: 1 },
+  });
+}

--- a/packages/core/tests/reference-intervals-client-factory.test.ts
+++ b/packages/core/tests/reference-intervals-client-factory.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { IntervalsClient } from "intervals-icu-api";
 import {
   makeAbortableClient,
+  makeChatClient,
   wrapFetchWithSignal,
 } from "../src/reference/sync/intervals-client-factory.js";
 
@@ -98,5 +99,54 @@ describe("makeAbortableClient", () => {
       perRequestMs: 30_000,
     });
     expect(client).toBeInstanceOf(IntervalsClient);
+  });
+});
+
+describe("makeChatClient", () => {
+  it("returns an IntervalsClient instance", () => {
+    const client = makeChatClient({ apiKey: "test-key" });
+    expect(client).toBeInstanceOf(IntervalsClient);
+  });
+
+  it("does not retry a POST that fails with HTTP 500", async () => {
+    const stub = vi.fn(async () => new Response("boom", { status: 500 }));
+    const client = makeChatClient({
+      apiKey: "test-key",
+      athleteId: "i1",
+      fetch: stub as unknown as typeof globalThis.fetch,
+    });
+
+    const result = await client.events.create({
+      start_date_local: "1998-01-05T00:00:00",
+      category: "WORKOUT",
+      name: "Test workout",
+    });
+
+    expect(stub).toHaveBeenCalledTimes(1);
+    expect(result.ok).toBe(false);
+  });
+
+  it("does not honor Retry-After on a 429 at the HTTP layer", async () => {
+    const stub = vi.fn(
+      async () =>
+        new Response("slow down", {
+          status: 429,
+          headers: { "Retry-After": "120" },
+        }),
+    );
+    const client = makeChatClient({
+      apiKey: "test-key",
+      athleteId: "i1",
+      fetch: stub as unknown as typeof globalThis.fetch,
+    });
+
+    const result = await client.events.create({
+      start_date_local: "1998-01-05T00:00:00",
+      category: "WORKOUT",
+      name: "Test workout",
+    });
+
+    expect(stub).toHaveBeenCalledTimes(1);
+    expect(result.ok).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

The chat path built a raw `IntervalsClient` with no retry override, so the library's default HTTP executor silently auto-retried every request — including POST/PUT/DELETE — up to 3 attempts on 429/500/502/503/504, honoring `Retry-After` verbatim and uncapped. The chat path has two write-class calls (workout create, event delete); the create is a POST with no idempotency key. A gateway 502 racing a committed create could therefore double-create the workout with no app involvement: the phantom workout auto-syncs to the athlete's head unit, and duplicates skew planned-Load and Form projections.

The sync path already solved this by constructing its client through a factory with `retry: { maxAttempts: 1 }`. This change gives the chat path the same posture:

- New `makeChatClient` export in the intervals client factory, constructing the client with lib-side retry disabled and an injectable `fetch` for tests.
- `CoachAgent` now constructs its intervals client through the factory; the direct lib import is removed.
- Three new tests prove non-retry behavior: instance shape, a stubbed HTTP 500 POST observed exactly once, and a stubbed 429 with `Retry-After: 120` observed exactly once with no sleep.

Trade-off (accepted): `maxAttempts: 1` also disables HTTP-layer retries on chat reads; reads are idempotent and the model re-calls failed tools naturally, mirroring the sync path's posture where retry policy lives at the caller layer.

## Test plan

- `pnpm test packages/core/tests/reference-intervals-client-factory.test.ts` — 7 passed (4 existing + 3 new)
- `pnpm test` — 111 files, 1949 passed | 2 skipped (delta vs merge-base: +3, all in the factory test file)
- `pnpm check` — exits 0
