### PR TITLE
test(core): add shared queue-backed fake-LLM helper

### DIFF
--- a/packages/core/tests/chronic-keyword-scan.test.ts
+++ b/packages/core/tests/chronic-keyword-scan.test.ts
@@ -5,24 +5,8 @@ import { join } from "node:path";
 import type { ModelMessage } from "ai";
 import { Memory } from "../src/memory/store.js";
 import { runMemoryFlush, CHRONIC_KEYWORDS } from "../src/agent/memory-flush.js";
-import type { LLM } from "../src/llm.js";
 import type { MemorySectionSpec } from "../src/sport.js";
-
-// LLM stub that produces no tool calls — runMemoryFlush completes quickly,
-// then the post-flush scan runs. Lets us assert scan behavior without the
-// real LLM rewriting the file.
-function noopLLM(): LLM {
-  return {
-    async generate() {
-      return {
-        text: "",
-        toolCalls: [],
-        finishReason: "stop" as const,
-        usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
-      };
-    },
-  } as unknown as LLM;
-}
+import { createFakeLLM } from "./helpers/fake-llm.js";
 
 const SECTIONS: readonly MemorySectionSpec[] = [
   { name: "cycling-history", description: "cycling-specific history" },
@@ -108,7 +92,7 @@ describe("post-flush chronic-keyword scan", () => {
   it("does not warn when cycling-history is absent", async () => {
     const memory = new Memory(dataDir);
     await runMemoryFlush({
-      llm: noopLLM(),
+      llm: createFakeLLM(),
       messages: NO_MESSAGES,
       memory,
       memorySections: SECTIONS,
@@ -122,7 +106,7 @@ describe("post-flush chronic-keyword scan", () => {
     writeFileSync(memoryFile, "## cycling-history\nKnee twinge resolved\n", "utf-8");
     const memory = new Memory(dataDir);
     await runMemoryFlush({
-      llm: noopLLM(),
+      llm: createFakeLLM(),
       messages: NO_MESSAGES,
       memory,
       memorySections: SECTIONS,
@@ -140,7 +124,7 @@ describe("post-flush chronic-keyword scan", () => {
     );
     const memory = new Memory(dataDir);
     await runMemoryFlush({
-      llm: noopLLM(),
+      llm: createFakeLLM(),
       messages: NO_MESSAGES,
       memory,
       memorySections: SECTIONS,
@@ -161,7 +145,7 @@ describe("post-flush chronic-keyword scan", () => {
     );
     const memory = new Memory(dataDir);
     await runMemoryFlush({
-      llm: noopLLM(),
+      llm: createFakeLLM(),
       messages: NO_MESSAGES,
       memory,
       memorySections: SECTIONS,
@@ -181,7 +165,7 @@ describe("post-flush chronic-keyword scan", () => {
     );
     const memory = new Memory(dataDir);
     await runMemoryFlush({
-      llm: noopLLM(),
+      llm: createFakeLLM(),
       messages: NO_MESSAGES,
       memory,
       memorySections: SECTIONS,
@@ -197,7 +181,7 @@ describe("post-flush chronic-keyword scan", () => {
     writeFileSync(memoryFile, "## cycling-history\nDIABETES diagnosis 2020.\n", "utf-8");
     const memory = new Memory(dataDir);
     await runMemoryFlush({
-      llm: noopLLM(),
+      llm: createFakeLLM(),
       messages: NO_MESSAGES,
       memory,
       memorySections: SECTIONS,
@@ -214,7 +198,7 @@ describe("post-flush chronic-keyword scan", () => {
     writeFileSync(memoryFile, `## cycling-history\n${body}\n`, "utf-8");
     const memory = new Memory(dataDir);
     await runMemoryFlush({
-      llm: noopLLM(),
+      llm: createFakeLLM(),
       messages: NO_MESSAGES,
       memory,
       memorySections: SECTIONS,

--- a/packages/core/tests/compaction.test.ts
+++ b/packages/core/tests/compaction.test.ts
@@ -6,34 +6,9 @@ import {
   summarizeDroppedMessages,
   summarizeInStages,
 } from "../src/agent/compaction.js";
-import type { LLM } from "../src/llm.js";
+import { createFakeLLM } from "./helpers/fake-llm.js";
 
 // ─── Test helpers ─────────────────────────────────────────────────────
-
-interface SpyLLM extends LLM {
-  capturedPrompts: string[];
-  capturedMessages: ModelMessage[][];
-}
-
-function createSpyLLM(response: string): SpyLLM {
-  const capturedPrompts: string[] = [];
-  const capturedMessages: ModelMessage[][] = [];
-  const spy = {
-    capturedPrompts,
-    capturedMessages,
-    async generate(opts: { prompt?: string; messages?: ModelMessage[] }) {
-      if (opts.prompt !== undefined) capturedPrompts.push(opts.prompt);
-      if (opts.messages !== undefined) capturedMessages.push(opts.messages);
-      return {
-        text: response,
-        toolCalls: [],
-        finishReason: "stop" as const,
-        usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
-      };
-    },
-  };
-  return spy as unknown as SpyLLM;
-}
 
 const REPRESENTATIVE_CONVERSATION: ModelMessage[] = [
   { role: "user", content: "My FTP is 247W and I weigh 72kg." },
@@ -76,7 +51,7 @@ const EMPTY_SNAPSHOT: MemorySnapshot = {
 
 describe("compaction (sport-parameterized)", () => {
   it("summarizeDroppedMessages prompt carries MUST-PRESERVE + sport tokens + transcript data", async () => {
-    const spy = createSpyLLM(VALID_FOUR_SECTION_SUMMARY);
+    const spy = createFakeLLM([VALID_FOUR_SECTION_SUMMARY], { repeatLast: true });
 
     await summarizeDroppedMessages({
       dropped: REPRESENTATIVE_CONVERSATION,
@@ -103,7 +78,7 @@ describe("compaction (sport-parameterized)", () => {
   });
 
   it("summarizeDroppedMessages with function-form tokens calls the function with the snapshot", async () => {
-    const spy = createSpyLLM(VALID_FOUR_SECTION_SUMMARY);
+    const spy = createFakeLLM([VALID_FOUR_SECTION_SUMMARY], { repeatLast: true });
     const calls: MemorySnapshot[] = [];
 
     await summarizeDroppedMessages({
@@ -123,7 +98,7 @@ describe("compaction (sport-parameterized)", () => {
   });
 
   it("summarizeInStages prompt also carries the MUST-PRESERVE instruction and tokens", async () => {
-    const spy = createSpyLLM(VALID_FOUR_SECTION_SUMMARY);
+    const spy = createFakeLLM([VALID_FOUR_SECTION_SUMMARY], { repeatLast: true });
 
     await summarizeInStages({
       messages: REPRESENTATIVE_CONVERSATION,

--- a/packages/core/tests/empty-section-guards.test.ts
+++ b/packages/core/tests/empty-section-guards.test.ts
@@ -6,24 +6,11 @@ import type { ModelMessage } from "ai";
 import { createMemoryTools } from "../src/agent/tools.js";
 import { runMemoryFlush } from "../src/agent/memory-flush.js";
 import { Memory } from "../src/memory/store.js";
-import type { LLM } from "../src/llm.js";
+import { createFakeLLM } from "./helpers/fake-llm.js";
 
 // Both consumers convert the section list into a non-empty Zod enum
 // (`z.enum([...] as [string, ...string[]])`). An empty list crashes Zod
 // with an opaque message; the explicit guard surfaces a real diagnostic.
-
-function noopLLM(): LLM {
-  return {
-    async generate() {
-      return {
-        text: "",
-        toolCalls: [],
-        finishReason: "stop" as const,
-        usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
-      };
-    },
-  } as unknown as LLM;
-}
 
 describe("createMemoryTools — empty-section guard", () => {
   let dataDir: string;
@@ -55,7 +42,7 @@ describe("runMemoryFlush — empty-section guard", () => {
     const memory = new Memory(dataDir);
     await expect(
       runMemoryFlush({
-        llm: noopLLM(),
+        llm: createFakeLLM(),
         messages: [] as ModelMessage[],
         memory,
         memorySections: [],

--- a/packages/core/tests/fake-llm.test.ts
+++ b/packages/core/tests/fake-llm.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import type { ModelMessage } from "ai";
+import { createFakeLLM } from "./helpers/fake-llm.js";
+
+describe("createFakeLLM", () => {
+  it("serves queued turns in order, with string shorthand defaults", async () => {
+    const llm = createFakeLLM(["first", { text: "second", finishReason: "length" }]);
+    const a = await llm.generate({ prompt: "p1" });
+    const b = await llm.generate({ prompt: "p2" });
+    expect(a.text).toBe("first");
+    expect(a.finishReason).toBe("stop");
+    expect(a.toolCalls).toEqual([]);
+    expect(a.usage.totalTokens).toBe(0);
+    expect(b.text).toBe("second");
+    expect(b.finishReason).toBe("length");
+  });
+
+  it("serves the empty turn once the queue is exhausted", async () => {
+    const llm = createFakeLLM(["only"]);
+    await llm.generate({ prompt: "p1" });
+    const out = await llm.generate({ prompt: "p2" });
+    expect(out.text).toBe("");
+    expect(out.toolCalls).toEqual([]);
+    expect(out.finishReason).toBe("stop");
+  });
+
+  it("repeatLast replays the final turn after exhaustion", async () => {
+    const llm = createFakeLLM(["a", "b"], { repeatLast: true });
+    await llm.generate({ prompt: "1" });
+    await llm.generate({ prompt: "2" });
+    const third = await llm.generate({ prompt: "3" });
+    expect(third.text).toBe("b");
+  });
+
+  it("scripts per-turn toolCalls and usage overrides", async () => {
+    const llm = createFakeLLM([
+      {
+        toolCalls: [{ type: "tool-call", toolCallId: "t1", toolName: "memory_write", input: {} }],
+        usage: { inputTokens: 11, outputTokens: 5, totalTokens: 16 },
+      },
+    ]);
+    const out = await llm.generate({ prompt: "p" });
+    expect(out.toolCalls).toHaveLength(1);
+    expect(out.toolCalls[0]?.toolName).toBe("memory_write");
+    expect(out.usage.inputTokens).toBe(11);
+    expect(out.usage.totalTokens).toBe(16);
+  });
+
+  it("rejects when the turn scripts an error, then serves the next turn", async () => {
+    const boom = new Error("provider down");
+    const llm = createFakeLLM([{ error: boom }, "recovered"]);
+    await expect(llm.generate({ prompt: "p1" })).rejects.toThrow("provider down");
+    const out = await llm.generate({ prompt: "p2" });
+    expect(out.text).toBe("recovered");
+  });
+
+  it("captures prompts, messages, and full opts", async () => {
+    const llm = createFakeLLM();
+    const messages: ModelMessage[] = [{ role: "user", content: "hi" }];
+    await llm.generate({ prompt: "a prompt", system: "sys" });
+    await llm.generate({ messages });
+    expect(llm.capturedPrompts).toEqual(["a prompt"]);
+    expect(llm.capturedMessages).toEqual([messages]);
+    expect(llm.capturedOpts).toHaveLength(2);
+    expect(llm.capturedOpts[0]?.system).toBe("sys");
+  });
+});

--- a/packages/core/tests/helpers/fake-llm.ts
+++ b/packages/core/tests/helpers/fake-llm.ts
@@ -1,0 +1,77 @@
+import type { ModelMessage } from "ai";
+import type { LLM } from "../../src/llm.js";
+import type { GenerateOpts, GenerateResult } from "../../src/llm-types.js";
+
+export interface FakeTurn {
+  text?: string;
+  toolCalls?: GenerateResult["toolCalls"];
+  finishReason?: GenerateResult["finishReason"];
+  usage?: Partial<GenerateResult["usage"]>;
+  error?: Error;
+}
+
+export type QueuedTurn = string | FakeTurn;
+
+export interface FakeLLMOptions {
+  /** Replay the final queued turn forever once the queue is exhausted. */
+  repeatLast?: boolean;
+}
+
+export interface FakeLLM extends LLM {
+  capturedPrompts: string[];
+  capturedMessages: ModelMessage[][];
+  capturedOpts: GenerateOpts[];
+}
+
+function zeroUsage(): GenerateResult["usage"] {
+  return {
+    inputTokens: 0,
+    inputTokenDetails: { noCacheTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 },
+    outputTokens: 0,
+    outputTokenDetails: { textTokens: 0, reasoningTokens: 0 },
+    totalTokens: 0,
+  };
+}
+
+/**
+ * Queue-backed in-process LLM fake. Each generate() call consumes the next
+ * queued turn (string shorthand = text-only turn); an exhausted queue serves
+ * an empty no-tool-call turn unless repeatLast is set. Turns may script
+ * toolCalls / finishReason / usage per call, or reject via `error`. Every
+ * call is recorded in capturedOpts; prompt/messages calls additionally land
+ * in capturedPrompts/capturedMessages. The fake never executes opts.tools.
+ */
+export function createFakeLLM(
+  turns: QueuedTurn[] = [],
+  options: FakeLLMOptions = {},
+): FakeLLM {
+  const capturedPrompts: string[] = [];
+  const capturedMessages: ModelMessage[][] = [];
+  const capturedOpts: GenerateOpts[] = [];
+  let next = 0;
+  const fake = {
+    capturedPrompts,
+    capturedMessages,
+    capturedOpts,
+    async generate(opts: GenerateOpts): Promise<GenerateResult> {
+      capturedOpts.push(opts);
+      if (opts.prompt !== undefined) capturedPrompts.push(opts.prompt);
+      if (opts.messages !== undefined) capturedMessages.push(opts.messages);
+      const queued =
+        next < turns.length
+          ? turns[next++]
+          : options.repeatLast && turns.length > 0
+            ? turns[turns.length - 1]
+            : {};
+      const turn: FakeTurn = typeof queued === "string" ? { text: queued } : queued;
+      if (turn.error) throw turn.error;
+      return {
+        text: turn.text ?? "",
+        toolCalls: turn.toolCalls ?? [],
+        finishReason: turn.finishReason ?? "stop",
+        usage: { ...zeroUsage(), ...turn.usage },
+      };
+    },
+  };
+  return fake as unknown as FakeLLM;
+}

--- a/packages/core/tests/reference-retry-with-feedback.test.ts
+++ b/packages/core/tests/reference-retry-with-feedback.test.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect } from "vitest";
-import type { ModelMessage } from "ai";
 import { validateAndRetry } from "../src/reference/validation/retry-with-feedback.js";
 import type { LatestJson } from "../src/reference/schemas/latest.js";
-import type { LLM } from "../src/llm.js";
+import { createFakeLLM } from "./helpers/fake-llm.js";
 
 function makeSnapshot(currentStatus: unknown): LatestJson {
   return {
@@ -36,36 +35,11 @@ function withMeta(prose: string, value: unknown): string {
   return `${prose}\n---meta---\n${JSON.stringify(makeMetadata(value))}`;
 }
 
-interface SpyLLM {
-  generate: LLM["generate"];
-  capturedPrompts: string[];
-}
-
-/** Queue-backed LLM stub mirroring tests/compaction.test.ts:18-36. */
-function createQueueLLM(queue: string[]): SpyLLM {
-  const capturedPrompts: string[] = [];
-  let i = 0;
-  const spy = {
-    capturedPrompts,
-    async generate(opts: { prompt?: string; messages?: ModelMessage[] }) {
-      if (opts.prompt !== undefined) capturedPrompts.push(opts.prompt);
-      const text = queue[i++] ?? "";
-      return {
-        text,
-        toolCalls: [],
-        finishReason: "stop" as const,
-        usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
-      };
-    },
-  };
-  return spy as unknown as SpyLLM;
-}
-
 const SNAPSHOT = makeSnapshot({ acwr: { value: 1.42 } });
 
 describe("validateAndRetry — enforce mode", () => {
   it("does not call the LLM when the first attempt validates", async () => {
-    const llm = createQueueLLM([]);
+    const llm = createFakeLLM([]);
     const result = await validateAndRetry(
       llm,
       "how am I doing?",
@@ -81,7 +55,7 @@ describe("validateAndRetry — enforce mode", () => {
 
   it("retries exactly once with feedback and succeeds on the corrected reply", async () => {
     const corrected = withMeta("corrected coaching", 1.42);
-    const llm = createQueueLLM([corrected]);
+    const llm = createFakeLLM([corrected]);
     const result = await validateAndRetry(
       llm,
       "how am I doing?",
@@ -102,7 +76,7 @@ describe("validateAndRetry — enforce mode", () => {
 
   it("returns the second response with validation_warning on a double failure", async () => {
     const stillWrong = withMeta("still wrong", 1.99);
-    const llm = createQueueLLM([stillWrong]);
+    const llm = createFakeLLM([stillWrong]);
     const result = await validateAndRetry(
       llm,
       "how am I doing?",
@@ -117,7 +91,7 @@ describe("validateAndRetry — enforce mode", () => {
 
   it("never makes a third call even when the retry is also wrong", async () => {
     const stillWrong = withMeta("still wrong", 1.99);
-    const llm = createQueueLLM([stillWrong, withMeta("third", 1.42)]);
+    const llm = createFakeLLM([stillWrong, withMeta("third", 1.42)]);
     await validateAndRetry(
       llm,
       "how am I doing?",
@@ -131,7 +105,7 @@ describe("validateAndRetry — enforce mode", () => {
 
 describe("validateAndRetry — observe mode", () => {
   it("flags would_have_retried on a mismatch without calling the LLM", async () => {
-    const llm = createQueueLLM([]);
+    const llm = createFakeLLM([]);
     const result = await validateAndRetry(
       llm,
       "how am I doing?",
@@ -146,7 +120,7 @@ describe("validateAndRetry — observe mode", () => {
   });
 
   it("does not flag would_have_retried on a match", async () => {
-    const llm = createQueueLLM([]);
+    const llm = createFakeLLM([]);
     const result = await validateAndRetry(
       llm,
       "how am I doing?",
@@ -161,7 +135,7 @@ describe("validateAndRetry — observe mode", () => {
 
 describe("validateAndRetry — off mode", () => {
   it("returns the original response untouched with no validation or retry", async () => {
-    const llm = createQueueLLM([]);
+    const llm = createFakeLLM([]);
     const result = await validateAndRetry(
       llm,
       "how am I doing?",


### PR DESCRIPTION
## What

Four test suites each carried their own hand-rolled in-process LLM fake stubbing the same `LLM.generate()` surface: a one-response spy that captured prompts, a queue-backed stub, and two byte-identical empty-response stubs. The shapes had already drifted (one captured messages, one only prompts, two captured nothing), and every upcoming memory and compaction test suite needed yet another variant.

This replaces all four with one canonical, queue-backed factory — `createFakeLLM` — in the test helpers directory:

- String-shorthand or full-turn queue entries; an exhausted queue serves an empty no-tool-call turn unless `repeatLast` is set.
- Per-turn scripting of `toolCalls`, `finishReason`, `usage`, or an `error` to reject with.
- Three capture arrays: `capturedPrompts`, `capturedMessages`, `capturedOpts`.
- Builds the full installed `LanguageModelUsage` shape, so it is assignable wherever a real `LLM` is expected without `as unknown as` casts at the call site.

A dedicated contract suite pins the semantics (queue order, exhaustion, `repeatLast` replay, scripted tool-calls/usage, error-then-recover, and capture contents).

## Migration

The compaction, retry-with-feedback (Reference layer validation), chronic-keyword-scan, and empty-section-guard suites now import the helper; their local fakes are deleted. No assertions, fixtures, or describe blocks changed and every test count is unchanged (25 across the four files). Upcoming memory and compaction test suites consume the same factory by its exported name.

## Test plan

- `pnpm vitest run` over the contract suite + four migrated files → 5 files, 31 tests pass.
- `pnpm test` → 117 files, 2013 passed | 2 skipped.
- `pnpm check` → exit 0.

Test-only change; no changeset.
