### PR TITLE
fix(core): make reset-archive pruning opt-in and age-based

### DIFF
--- a/.changeset/reset-archive-retention.md
+++ b/.changeset/reset-archive-retention.md
@@ -1,0 +1,13 @@
+---
+"@enduragent/core": patch
+"cycling-coach": patch
+---
+
+User-facing: Archived chat sessions are now kept indefinitely by default — previously only the 20 most recent were kept; a new retention setting lets you opt into age-based cleanup.
+
+Session reset archives were pruned to the newest 20 per chat, silently
+deleting the only copy of older conversations before any extraction
+substrate exists. The count-based prune is removed; a new
+session.resetArchiveRetentionDays config knob (env:
+SESSION_RESET_ARCHIVE_RETENTION_DAYS, default 0 = keep forever) provides
+opt-in age-based pruning instead. Archive file permissions are unchanged.

--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@ File-based at `~/.cycling-coach/`:
 
 The agent reads memory at the start of each conversation and writes to it when significant decisions are made (new goal, plan change, injury).
 
+Conversation transcripts live at `~/.cycling-coach/sessions/<chatId>.jsonl`. A session reset renames the transcript to a timestamped archive (`<chatId>.jsonl.reset.<timestamp>`) rather than deleting it, and archives are kept indefinitely by default. To opt into age-based cleanup, set `session.resetArchiveRetentionDays` in `config.yaml` (or the `SESSION_RESET_ARCHIVE_RETENTION_DAYS` env var) to the number of days to keep archives; `0` — the default — keeps them forever. Archive files are owner-readable only (mode `0600`).
+
 ## Alternative config: YAML
 
 Instead of env vars, you can create `~/.cycling-coach/config.yaml`:

--- a/packages/core/src/agent/chat-store.ts
+++ b/packages/core/src/agent/chat-store.ts
@@ -12,7 +12,14 @@ import { join } from "node:path";
 import type { ModelMessage } from "ai";
 import { messageText } from "./token-utils.js";
 
-const MAX_RESET_ARCHIVES = 20;
+const MS_PER_DAY = 86_400_000;
+
+function parseArchiveTimestampMs(suffix: string): number | null {
+  // archiveAndReset writes toISOString() with ":" replaced by "-"; reverse
+  // only the time-part dashes before parsing.
+  const ms = Date.parse(suffix.replace(/T(\d{2})-(\d{2})-(\d{2})/, "T$1:$2:$3"));
+  return Number.isNaN(ms) ? null : ms;
+}
 
 interface JsonlLine {
   role: "user" | "assistant" | "system";
@@ -22,9 +29,11 @@ interface JsonlLine {
 
 export class ChatStore {
   private sessionsDir: string;
+  private resetArchiveRetentionDays: number;
 
-  constructor(dataDir: string) {
+  constructor(dataDir: string, resetArchiveRetentionDays = 0) {
     this.sessionsDir = join(dataDir, "sessions");
+    this.resetArchiveRetentionDays = resetArchiveRetentionDays;
     mkdirSync(this.sessionsDir, { recursive: true, mode: 0o700 });
   }
 
@@ -94,14 +103,17 @@ export class ChatStore {
   }
 
   private pruneArchives(chatId: string): void {
+    if (this.resetArchiveRetentionDays <= 0) return;
     const prefix = `${chatId}.jsonl.reset.`;
-    // Archive names embed a fixed-width ISO timestamp, so a lexicographic
-    // sort is chronological — the oldest archives sort first.
-    const archives = readdirSync(this.sessionsDir)
-      .filter((f) => f.startsWith(prefix))
-      .sort();
-    for (const stale of archives.slice(0, Math.max(0, archives.length - MAX_RESET_ARCHIVES))) {
-      unlinkSync(join(this.sessionsDir, stale));
+    const cutoffMs = Date.now() - this.resetArchiveRetentionDays * MS_PER_DAY;
+    for (const name of readdirSync(this.sessionsDir)) {
+      if (!name.startsWith(prefix)) continue;
+      const archivedAtMs = parseArchiveTimestampMs(name.slice(prefix.length));
+      // Unparseable timestamps are kept: never delete an archive that
+      // cannot be dated.
+      if (archivedAtMs !== null && archivedAtMs < cutoffMs) {
+        unlinkSync(join(this.sessionsDir, name));
+      }
     }
   }
 }

--- a/packages/core/src/agent/coach-agent.ts
+++ b/packages/core/src/agent/coach-agent.ts
@@ -60,7 +60,7 @@ export class CoachAgent {
     this.llm = new LLM(config);
     this.tz = resolveUserTimezone(config.session.timezone);
     this.memory = new Memory(config.dataDir, this.tz);
-    this.chatStore = new ChatStore(config.dataDir);
+    this.chatStore = new ChatStore(config.dataDir, config.session.resetArchiveRetentionDays);
 
     const intervals = config.intervals.apiKey
       ? makeChatClient({

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -27,6 +27,8 @@ export interface Config {
     historyTokenBudgetRatio: number;
     idleMinutes: number;
     dailyResetHour: number;
+    /** Days to keep session reset archives; 0 = keep forever (pruning disabled). */
+    resetArchiveRetentionDays: number;
     /** Athlete IANA timezone (e.g. "Europe/Berlin"). Empty = resolver picks host TZ. */
     timezone: string;
   };
@@ -220,6 +222,10 @@ export function loadConfig(): Config {
         envInt("SESSION_IDLE_MINUTES") ?? (sessionYaml.idleMinutes as number) ?? 0,
       dailyResetHour:
         envInt("SESSION_DAILY_RESET_HOUR") ?? (sessionYaml.dailyResetHour as number) ?? 4,
+      resetArchiveRetentionDays:
+        envInt("SESSION_RESET_ARCHIVE_RETENTION_DAYS") ??
+        (sessionYaml.resetArchiveRetentionDays as number) ??
+        0,
       timezone:
         env("COACH_TZ") ?? (sessionYaml.timezone as string | undefined) ?? "",
     },

--- a/packages/core/tests/chat-store.test.ts
+++ b/packages/core/tests/chat-store.test.ts
@@ -29,6 +29,14 @@ function listArchives(chatId: string): string[] {
     .sort();
 }
 
+const MS_PER_DAY = 86_400_000;
+
+function plantArchive(chatId: string, date: Date): string {
+  const name = `${chatId}.jsonl.reset.${date.toISOString().replace(/:/g, "-")}`;
+  writeFileSync(join(sessionsDir, name), "{}\n", "utf-8");
+  return name;
+}
+
 describe("ChatStore — on-disk permissions", () => {
   it("creates the sessions directory with owner-only 0o700", () => {
     new ChatStore(dataDir);
@@ -63,11 +71,8 @@ describe("ChatStore.archiveAndReset — archive retention", () => {
     expect(listArchives("123")).toHaveLength(1);
   });
 
-  it("keeps at most 20 archives per chat, deleting the oldest first", () => {
+  it("keeps every archive by default — count-based pruning is gone", () => {
     const store = new ChatStore(dataDir);
-    // archiveAndReset timestamps have millisecond resolution, so rapid
-    // looped resets would collide on one archive name; plant distinct
-    // pre-existing archives directly instead.
     const planted = Array.from({ length: 25 }, (_, i) => {
       const name = `123.jsonl.reset.2026-06-01T00-00-${String(i).padStart(2, "0")}.000Z`;
       writeFileSync(join(sessionsDir, name), "{}\n", "utf-8");
@@ -78,29 +83,10 @@ describe("ChatStore.archiveAndReset — archive retention", () => {
     store.archiveAndReset("123");
 
     const archives = listArchives("123");
-    expect(archives).toHaveLength(20);
-    // The 6 oldest planted archives are gone (25 planted + 1 new = 26 → 20).
-    for (const stale of planted.slice(0, 6)) {
-      expect(archives).not.toContain(stale);
-    }
-    // The newest planted archives and the fresh one survive.
-    for (const kept of planted.slice(6)) {
+    expect(archives).toHaveLength(26);
+    for (const kept of planted) {
       expect(archives).toContain(kept);
     }
-  });
-
-  it("prunes only the resetting chat's archives, not other chats'", () => {
-    const store = new ChatStore(dataDir);
-    for (let i = 0; i < 25; i++) {
-      const suffix = `2026-06-01T00-00-${String(i).padStart(2, "0")}.000Z`;
-      writeFileSync(join(sessionsDir, `456.jsonl.reset.${suffix}`), "{}\n", "utf-8");
-    }
-
-    store.appendMessage("123", "user", "hello");
-    store.archiveAndReset("123");
-
-    expect(listArchives("456")).toHaveLength(25);
-    expect(listArchives("123")).toHaveLength(1);
   });
 
   it("is a no-op when no live session exists", () => {
@@ -110,5 +96,52 @@ describe("ChatStore.archiveAndReset — archive retention", () => {
 
     expect(existsSync(join(sessionsDir, "123.jsonl"))).toBe(false);
     expect(listArchives("123")).toHaveLength(0);
+  });
+});
+
+describe("ChatStore.archiveAndReset — opt-in age-based retention", () => {
+  it("deletes archives older than the horizon and keeps newer ones", () => {
+    const store = new ChatStore(dataDir, 365);
+    const old = plantArchive("123", new Date(Date.now() - 366 * MS_PER_DAY));
+    const recent = plantArchive("123", new Date(Date.now() - 1 * MS_PER_DAY));
+
+    store.appendMessage("123", "user", "hello");
+    store.archiveAndReset("123");
+
+    const archives = listArchives("123");
+    expect(archives).not.toContain(old);
+    expect(archives).toContain(recent);
+    expect(archives).toHaveLength(2);
+  });
+
+  it("never deletes an archive whose timestamp suffix cannot be parsed", () => {
+    const store = new ChatStore(dataDir, 1);
+    const odd = "123.jsonl.reset.not-a-timestamp";
+    writeFileSync(join(sessionsDir, odd), "{}\n", "utf-8");
+
+    store.appendMessage("123", "user", "hello");
+    store.archiveAndReset("123");
+
+    expect(listArchives("123")).toContain(odd);
+  });
+
+  it("prunes only the resetting chat's archives", () => {
+    const store = new ChatStore(dataDir, 1);
+    const otherOld = plantArchive("456", new Date(Date.now() - 400 * MS_PER_DAY));
+
+    store.appendMessage("123", "user", "hello");
+    store.archiveAndReset("123");
+
+    expect(listArchives("456")).toContain(otherOld);
+  });
+
+  it("does not prune even ancient archives when retention is disabled", () => {
+    const store = new ChatStore(dataDir);
+    const ancient = plantArchive("123", new Date(Date.now() - 4000 * MS_PER_DAY));
+
+    store.appendMessage("123", "user", "hello");
+    store.archiveAndReset("123");
+
+    expect(listArchives("123")).toContain(ancient);
   });
 });

--- a/packages/core/tests/config.session-retention.test.ts
+++ b/packages/core/tests/config.session-retention.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { stringify as toYaml } from "yaml";
+import { setupConfigEnvSandbox } from "./helpers/config-env-sandbox.js";
+
+const getTempHome = setupConfigEnvSandbox("cc-sessionretention-");
+
+const CONFIG = () => join(getTempHome(), ".cycling-coach", "config.yaml");
+
+describe("config — session.resetArchiveRetentionDays", () => {
+  it("defaults to 0 (archives kept forever)", async () => {
+    const { loadConfig } = await import("../src/config.js");
+    expect(loadConfig().session.resetArchiveRetentionDays).toBe(0);
+  });
+
+  it("resolves the SESSION_RESET_ARCHIVE_RETENTION_DAYS env var", async () => {
+    process.env.SESSION_RESET_ARCHIVE_RETENTION_DAYS = "365";
+    const { loadConfig } = await import("../src/config.js");
+    expect(loadConfig().session.resetArchiveRetentionDays).toBe(365);
+  });
+
+  it("resolves the yaml session.resetArchiveRetentionDays key", async () => {
+    writeFileSync(CONFIG(), toYaml({ session: { resetArchiveRetentionDays: 30 } }), {
+      mode: 0o600,
+    });
+    const { loadConfig } = await import("../src/config.js");
+    expect(loadConfig().session.resetArchiveRetentionDays).toBe(30);
+  });
+});

--- a/packages/core/tests/helpers/base-agent-config.ts
+++ b/packages/core/tests/helpers/base-agent-config.ts
@@ -16,6 +16,7 @@ export function baseAgentConfig(dataDir: string) {
       historyTokenBudgetRatio: 0.3,
       idleMinutes: 0,
       dailyResetHour: 4,
+      resetArchiveRetentionDays: 0,
       timezone: "",
     },
     contextWindowTokens: 272_000,

--- a/packages/core/tests/helpers/config-env-sandbox.ts
+++ b/packages/core/tests/helpers/config-env-sandbox.ts
@@ -1,0 +1,58 @@
+import { beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const MANAGED_ENV = [
+  "ANTHROPIC_API_KEY",
+  "OPENAI_API_KEY",
+  "GOOGLE_GENERATIVE_AI_API_KEY",
+  "INTERVALS_API_KEY",
+  "INTERVALS_ATHLETE_ID",
+  "TELEGRAM_BOT_TOKEN",
+  "LLM_PROVIDER",
+  "LLM_MODEL",
+  "CONTEXT_WINDOW_TOKENS",
+  "SESSION_RESET_ARCHIVE_RETENTION_DAYS",
+];
+
+/**
+ * Registers beforeEach/afterEach hooks that point HOME at a fresh temp dir
+ * (with `.cycling-coach/` created), clear `CYCLING_COACH_HOME` and every
+ * managed env var, and restore everything afterward. Returns a getter for
+ * the current temp HOME.
+ */
+export function setupConfigEnvSandbox(prefix: string): () => string {
+  let tempHome: string;
+  let origHome: string | undefined;
+  let origCcHome: string | undefined;
+  const savedEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    tempHome = mkdtempSync(join(tmpdir(), prefix));
+    origHome = process.env.HOME;
+    origCcHome = process.env.CYCLING_COACH_HOME;
+    process.env.HOME = tempHome;
+    delete process.env.CYCLING_COACH_HOME;
+    mkdirSync(join(tempHome, ".cycling-coach"), { recursive: true });
+    for (const k of MANAGED_ENV) {
+      savedEnv[k] = process.env[k];
+      delete process.env[k];
+    }
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    process.env.HOME = origHome;
+    if (origCcHome !== undefined) process.env.CYCLING_COACH_HOME = origCcHome;
+    else delete process.env.CYCLING_COACH_HOME;
+    for (const k of MANAGED_ENV) {
+      if (savedEnv[k] !== undefined) process.env[k] = savedEnv[k];
+      else delete process.env[k];
+    }
+    rmSync(tempHome, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  return () => tempHome;
+}

--- a/packages/core/tests/llm-dispatch.test.ts
+++ b/packages/core/tests/llm-dispatch.test.ts
@@ -7,7 +7,7 @@ function codexConfig(): Config {
     llm: { provider: "openai-codex", model: "gpt-5.4", apiKey: "", authProfile: "openai-codex" },
     intervals: { apiKey: "", athleteId: "0" },
     telegram: { botToken: "" },
-    session: { historyTokenBudgetRatio: 0.3, idleMinutes: 0, dailyResetHour: 4, timezone: "" },
+    session: { historyTokenBudgetRatio: 0.3, idleMinutes: 0, dailyResetHour: 4, resetArchiveRetentionDays: 0, timezone: "" },
     contextWindowTokens: 272_000,
     dataDir: "/tmp/cc-dispatch-test",
   };


### PR DESCRIPTION
## What

Session reset archives were pruned to the newest 20 per chat. Once a 21st reset happened, the oldest archive — the only copy of that conversation — was deleted, before any extraction or memory substrate exists to recover its content. That silent, count-based deletion is the data-loss path this change closes.

The count-based prune is removed. Archives are now kept indefinitely by default. A new `session.resetArchiveRetentionDays` knob (env `SESSION_RESET_ARCHIVE_RETENTION_DAYS`, default `0` = keep forever) opts into **age-based** pruning instead: with a positive value, only archives older than that many days are removed, and an archive whose timestamp can't be parsed is never deleted.

## Why

The archive-on-reset behavior shipped in #171 as a safety net, but the count cap quietly defeated it for any athlete who reset more than 20 times. Keeping everything by default makes the safety net actually hold; age-based retention gives operators a bounded-growth option without resurrecting the silent-loss behavior. A later default flip from `0` toward a finite window is deliberately deferred until a durable extraction path exists.

## Changes

- `ChatStore` pruning rewritten from count-based to opt-in age-based; unparseable archive timestamps are preserved.
- New `session.resetArchiveRetentionDays` config field, threaded from `loadConfig` (env + yaml) into `ChatStore`.
- Test coverage: archives kept by default, age-based deletion when configured, unparseable-timestamp preservation, and config resolution (default / env / yaml).
- README memory section documents the new knob.
