### PR TITLE
feat(core): journal destructive memory writes to an append-only history log

### DIFF
--- a/.changeset/memory-write-journal.md
+++ b/.changeset/memory-write-journal.md
@@ -1,0 +1,11 @@
+---
+"@enduragent/core": patch
+"@enduragent/sport-cycling": patch
+---
+
+Every destructive memory write (section replace, plan overwrite, section
+rename) now appends a journal line to memory/MEMORY.history.jsonl before
+mutating: {ts, op, section, oldBody, newBody, source}. The journal is
+append-only, 0600, best-effort (a journal failure warns and never blocks
+the write), and makes silent fact loss reconstructible by replay. Write
+paths now declare their source (chat-tool, flush, sport-tool, migration).

--- a/packages/core/src/agent/memory-flush.ts
+++ b/packages/core/src/agent/memory-flush.ts
@@ -63,7 +63,7 @@ function createFlushMemoryWriteTool(memory: MemoryStore, sections: readonly Memo
       }),
     ),
     execute: async (input: { section: string; content: string }) => {
-      memory.writeSection(input.section, input.content);
+      memory.writeSection(input.section, input.content, "flush");
       return { saved: true };
     },
   });

--- a/packages/core/src/agent/tools.ts
+++ b/packages/core/src/agent/tools.ts
@@ -52,7 +52,7 @@ export function createMemoryTools(
       execute: async (input: { type: "memory" | "daily"; section?: string; content: string }) => {
         if (input.type === "memory") {
           // "notes" is a CORE_SHARED_SECTIONS catch-all — safe default when the LLM forgets to pick a section.
-          memory.writeSection(input.section ?? "notes", input.content);
+          memory.writeSection(input.section ?? "notes", input.content, "chat-tool");
         } else {
           memory.appendDailyNote(input.content);
         }
@@ -68,7 +68,7 @@ export function createMemoryTools(
         }),
       ),
       execute: async (input: { plan: Record<string, unknown> }) => {
-        memory.savePlan(input.plan);
+        memory.savePlan(input.plan, "chat-tool");
         return { saved: true };
       },
     }),

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -34,8 +34,9 @@ export { LLM } from "./llm.js";
 export type { GenerateOpts, GenerateResult } from "./llm-types.js";
 
 // ─── Memory ───────────────────────────────────────────────────────────
-export type { MemorySnapshot, MemoryStore } from "./memory.js";
+export type { MemorySnapshot, MemoryStore, MemoryWriteSource } from "./memory.js";
 export { Memory } from "./memory/store.js";
+export type { MemoryJournalEntry } from "./memory/journal.js";
 export { createMemorySnapshot } from "./memory/snapshot.js";
 export { CORE_SHARED_SECTIONS } from "./memory/shared-sections.js";
 export {

--- a/packages/core/src/memory.ts
+++ b/packages/core/src/memory.ts
@@ -7,12 +7,20 @@
  * (e.g. "FTP 247W") from current memory state.
  */
 
+/** Who performed a destructive memory write — recorded on every journal line. */
+export type MemoryWriteSource =
+  | "chat-tool"
+  | "flush"
+  | "sport-tool"
+  | "migration"
+  | "unattributed";
+
 export interface MemoryStore {
   /** Returns full MEMORY.md contents, or "" if absent. */
   readMemory(): string;
 
   /** Replaces the named section's content; appends if section is missing. */
-  writeSection(section: string, content: string): void;
+  writeSection(section: string, content: string, source?: MemoryWriteSource): void;
 
   /** Returns the named section's body, or null if file or section is absent. */
   readSection(section: string): string | null;
@@ -24,7 +32,11 @@ export interface MemoryStore {
    * - "merged":  both `from` and `to` exist — bodies concatenated under `to`,
    *              `from` block removed.
    */
-  renameSection(from: string, to: string): "renamed" | "noop" | "merged";
+  renameSection(
+    from: string,
+    to: string,
+    source?: MemoryWriteSource,
+  ): "renamed" | "noop" | "merged";
 
   /**
    * Apply multiple renames as a single read + single atomic write. Returns
@@ -34,6 +46,7 @@ export interface MemoryStore {
    */
   renameSections(
     renames: ReadonlyArray<readonly [string, string]>,
+    source?: MemoryWriteSource,
   ): Array<"renamed" | "noop" | "merged">;
 
   /** Reads today's daily-notes file (or for `date` when supplied). */
@@ -43,7 +56,7 @@ export interface MemoryStore {
   appendDailyNote(note: string, date?: string): void;
 
   /** Persists the active training plan as JSON. */
-  savePlan(plan: unknown): void;
+  savePlan(plan: unknown, source?: MemoryWriteSource): void;
 
   /** Loads the active training plan, or null if none. */
   loadPlan(): unknown | null;

--- a/packages/core/src/memory/journal.ts
+++ b/packages/core/src/memory/journal.ts
@@ -1,0 +1,45 @@
+/**
+ * Append-only journal of destructive memory writes.
+ *
+ * One JSON line per write, appended BEFORE the mutation (a crash between
+ * journal and write leaves a harmless extra line, never an unjournaled
+ * destruction). Best-effort: a journal failure warns and never throws, so
+ * a full disk or permission error cannot break the memory write itself.
+ * Mode 0600 — entries carry athlete medical data.
+ */
+import { closeSync, openSync, writeSync } from "node:fs";
+import { join } from "node:path";
+import type { MemoryWriteSource } from "../memory.js";
+
+export const JOURNAL_FILENAME = "MEMORY.history.jsonl";
+
+export type MemoryJournalOp = "write-section" | "save-plan" | "rename-sections";
+
+export interface MemoryJournalEntry {
+  ts: string;
+  op: MemoryJournalOp;
+  section: string | null;
+  oldBody: string | null;
+  newBody: string;
+  source: MemoryWriteSource;
+}
+
+export function appendJournalEntry(memoryDir: string, entry: MemoryJournalEntry): void {
+  let fd: number | null = null;
+  try {
+    fd = openSync(join(memoryDir, JOURNAL_FILENAME), "a", 0o600);
+    writeSync(fd, JSON.stringify(entry) + "\n", null, "utf-8");
+  } catch (err) {
+    console.warn(
+      `memory journal append failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  } finally {
+    if (fd !== null) {
+      try {
+        closeSync(fd);
+      } catch {
+        // ignore — best-effort journal; the memory write itself must proceed.
+      }
+    }
+  }
+}

--- a/packages/core/src/memory/store.ts
+++ b/packages/core/src/memory/store.ts
@@ -1,8 +1,9 @@
 import { readFileSync, mkdirSync, existsSync } from "node:fs";
 import { join } from "node:path";
-import type { MemoryStore } from "../memory.js";
+import type { MemoryStore, MemoryWriteSource } from "../memory.js";
 import { todayInTZ } from "../agent/user-time.js";
 import { atomicWriteFileSync } from "../io/atomic-write-file-sync.js";
+import { appendJournalEntry } from "./journal.js";
 
 // ============================================================================
 // MEMORY SYSTEM
@@ -63,11 +64,20 @@ export class Memory implements MemoryStore {
     return readFileSync(path, "utf-8").replace(/\r\n/g, "\n");
   }
 
-  writeSection(section: string, content: string): void {
+  writeSection(section: string, content: string, source: MemoryWriteSource = "unattributed"): void {
     const path = join(this.memoryDir, "MEMORY.md");
     const existing = this.readMemory();
     const marker = markerOf(section);
     const newBlock = `${marker}\n${content}\n`;
+
+    appendJournalEntry(this.memoryDir, {
+      ts: new Date().toISOString(),
+      op: "write-section",
+      section,
+      oldBody: this.readSection(section),
+      newBody: content,
+      source,
+    });
 
     if (!existing) {
       atomicWriteFileSync(path, newBlock);
@@ -97,7 +107,7 @@ export class Memory implements MemoryStore {
     return body.endsWith("\n") ? body.slice(0, -1) : body;
   }
 
-  renameSection(from: string, to: string): RenameOutcome {
+  renameSection(from: string, to: string, source: MemoryWriteSource = "unattributed"): RenameOutcome {
     const path = join(this.memoryDir, "MEMORY.md");
     const content = this.readMemory();
     if (!content) return "noop";
@@ -106,7 +116,16 @@ export class Memory implements MemoryStore {
     const outcome = applyRename(parts, from, to);
     if (outcome === "noop") return outcome;
 
-    atomicWriteFileSync(path, parts.join(""));
+    const updated = parts.join("");
+    appendJournalEntry(this.memoryDir, {
+      ts: new Date().toISOString(),
+      op: "rename-sections",
+      section: null,
+      oldBody: content,
+      newBody: updated,
+      source,
+    });
+    atomicWriteFileSync(path, updated);
     return outcome;
   }
 
@@ -118,6 +137,7 @@ export class Memory implements MemoryStore {
    */
   renameSections(
     renames: ReadonlyArray<readonly [string, string]>,
+    source: MemoryWriteSource = "unattributed",
   ): RenameOutcome[] {
     const path = join(this.memoryDir, "MEMORY.md");
     const content = this.readMemory();
@@ -132,7 +152,18 @@ export class Memory implements MemoryStore {
       if (outcome !== "noop") mutated = true;
     }
 
-    if (mutated) atomicWriteFileSync(path, parts.join(""));
+    if (mutated) {
+      const updated = parts.join("");
+      appendJournalEntry(this.memoryDir, {
+        ts: new Date().toISOString(),
+        op: "rename-sections",
+        section: null,
+        oldBody: content,
+        newBody: updated,
+        source,
+      });
+      atomicWriteFileSync(path, updated);
+    }
     return outcomes;
   }
 
@@ -163,9 +194,18 @@ export class Memory implements MemoryStore {
 
   // ── Plans ──────────────────────────────────────────────────────────────
 
-  savePlan(plan: unknown): void {
+  savePlan(plan: unknown, source: MemoryWriteSource = "unattributed"): void {
     const path = join(this.plansDir, "current-plan.json");
-    atomicWriteFileSync(path, JSON.stringify(plan, null, 2));
+    const newBody = JSON.stringify(plan, null, 2);
+    appendJournalEntry(this.memoryDir, {
+      ts: new Date().toISOString(),
+      op: "save-plan",
+      section: null,
+      oldBody: existsSync(path) ? readFileSync(path, "utf-8") : null,
+      newBody,
+      source,
+    });
+    atomicWriteFileSync(path, newBody);
   }
 
   loadPlan(): unknown | null {

--- a/packages/core/tests/memory-journal.test.ts
+++ b/packages/core/tests/memory-journal.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync, readFileSync, statSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Memory } from "../src/memory/store.js";
+import { JOURNAL_FILENAME } from "../src/memory/journal.js";
+import { createMemoryTools } from "../src/agent/tools.js";
+import { runMemoryFlush } from "../src/agent/memory-flush.js";
+import { createFakeLLM } from "./helpers/fake-llm.js";
+
+const journalPathOf = (dataDir: string) => join(dataDir, "memory", JOURNAL_FILENAME);
+
+const readJournal = (dataDir: string) =>
+  readFileSync(journalPathOf(dataDir), "utf-8")
+    .trimEnd()
+    .split("\n")
+    .map((l) => JSON.parse(l));
+
+const memoryFilePath = (dataDir: string) => join(dataDir, "memory", "MEMORY.md");
+
+describe("memory journal", () => {
+  let dataDir: string;
+
+  beforeEach(() => {
+    dataDir = mkdtempSync(join(tmpdir(), "cc-journal-"));
+  });
+
+  afterEach(() => {
+    rmSync(dataDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it("first write journals oldBody null", () => {
+    const memory = new Memory(dataDir);
+    memory.writeSection("goals", "Sub-3:30 century", "chat-tool");
+
+    const lines = readJournal(dataDir);
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toMatchObject({
+      op: "write-section",
+      section: "goals",
+      oldBody: null,
+      newBody: "Sub-3:30 century",
+      source: "chat-tool",
+    });
+    expect(lines[0].ts).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+  });
+
+  it("destructive replace journals the prior body and the lost fact is replay-recoverable", () => {
+    const memory = new Memory(dataDir);
+    memory.writeSection("medical-history", "Hypertension; lisinopril 10mg", "flush");
+    memory.writeSection("medical-history", "Asthma, mild", "flush");
+
+    expect(readFileSync(memoryFilePath(dataDir), "utf-8")).not.toContain("lisinopril");
+
+    const lines = readJournal(dataDir);
+    expect(lines).toHaveLength(2);
+    expect(lines[1].oldBody).toBe("Hypertension; lisinopril 10mg");
+
+    const replayDir = mkdtempSync(join(tmpdir(), "cc-journal-replay-"));
+    const replayMemory = new Memory(replayDir);
+    for (const entry of lines.slice(0, lines.length - 1)) {
+      replayMemory.writeSection(entry.section, entry.newBody);
+    }
+    expect(replayMemory.readSection("medical-history")).toContain("lisinopril 10mg");
+    rmSync(replayDir, { recursive: true, force: true });
+  });
+
+  it("appends are byte-stable so earlier lines are never rewritten", () => {
+    const memory = new Memory(dataDir);
+    memory.writeSection("medical-history", "Hypertension; lisinopril 10mg", "flush");
+    const before = readFileSync(journalPathOf(dataDir), "utf-8");
+
+    memory.writeSection("medical-history", "Asthma, mild", "flush");
+    const after = readFileSync(journalPathOf(dataDir), "utf-8");
+
+    expect(after.startsWith(before)).toBe(true);
+  });
+
+  it("savePlan overwrite journals the old plan JSON", () => {
+    const memory = new Memory(dataDir);
+    memory.savePlan({ name: "Base 1" }, "sport-tool");
+    memory.savePlan({ name: "Build 1" }, "chat-tool");
+
+    const lines = readJournal(dataDir);
+    expect(lines).toHaveLength(2);
+    expect(lines[1]).toMatchObject({
+      op: "save-plan",
+      section: null,
+      oldBody: JSON.stringify({ name: "Base 1" }, null, 2),
+      newBody: JSON.stringify({ name: "Build 1" }, null, 2),
+      source: "chat-tool",
+    });
+  });
+
+  it("renameSections journals one full-file entry and noops journal nothing", () => {
+    const memory = new Memory(dataDir);
+    memory.writeSection("profile", "FTP 247W, 72kg");
+    memory.writeSection("schedule", "Mon, Wed, Fri");
+
+    const before = readFileSync(memoryFilePath(dataDir), "utf-8");
+    memory.renameSections(
+      [
+        ["profile", "cycling-profile"],
+        ["missing", "x"],
+      ],
+      "migration",
+    );
+
+    let lines = readJournal(dataDir);
+    expect(lines).toHaveLength(3);
+    expect(lines[2]).toMatchObject({
+      op: "rename-sections",
+      section: null,
+      oldBody: before,
+      newBody: readFileSync(memoryFilePath(dataDir), "utf-8"),
+      source: "migration",
+    });
+
+    memory.renameSections([["missing", "x"]]);
+    lines = readJournal(dataDir);
+    expect(lines).toHaveLength(3);
+  });
+
+  it("omitted source defaults to unattributed", () => {
+    const memory = new Memory(dataDir);
+    memory.writeSection("goals", "x");
+
+    const lines = readJournal(dataDir);
+    expect(lines[0].source).toBe("unattributed");
+  });
+
+  it("journal failure warns and the memory write still succeeds", () => {
+    const memory = new Memory(dataDir);
+    mkdirSync(join(dataDir, "memory", JOURNAL_FILENAME));
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    expect(() => memory.writeSection("goals", "Sub-3:30 century")).not.toThrow();
+    expect(memory.readSection("goals")).toBe("Sub-3:30 century");
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("memory journal append failed"),
+    );
+  });
+
+  it("creates the journal file with 0600 mode", () => {
+    const memory = new Memory(dataDir);
+    memory.writeSection("goals", "Sub-3:30 century");
+
+    expect(statSync(journalPathOf(dataDir)).mode & 0o777).toBe(0o600);
+  });
+
+  it("chat memory_write tool threads chat-tool", async () => {
+    const memory = new Memory(dataDir);
+    const tools = createMemoryTools(memory, [{ name: "goals", description: "Athlete goals" }]);
+
+    await tools.memory_write.execute!(
+      { type: "memory", section: "goals", content: "Sub-3:30 century" },
+      {} as never,
+    );
+
+    const lines = readJournal(dataDir);
+    expect(lines[lines.length - 1]).toMatchObject({ op: "write-section", source: "chat-tool" });
+  });
+
+  it("chat plan_save tool threads chat-tool", async () => {
+    const memory = new Memory(dataDir);
+    const tools = createMemoryTools(memory, [{ name: "goals", description: "Athlete goals" }]);
+
+    await tools.plan_save.execute!({ plan: { name: "Base 1" } }, {} as never);
+
+    const lines = readJournal(dataDir);
+    expect(lines[lines.length - 1]).toMatchObject({ op: "save-plan", source: "chat-tool" });
+  });
+
+  it("flush path threads flush", async () => {
+    const memory = new Memory(dataDir);
+    const llm = createFakeLLM([""]);
+
+    await runMemoryFlush({
+      llm,
+      messages: [{ role: "user", content: "I want FTP 280W by August" }],
+      memory,
+      memorySections: [{ name: "goals", description: "Athlete goals" }],
+    });
+
+    const flushTools = llm.capturedOpts[0]?.tools;
+    expect(flushTools).toBeDefined();
+    expect(flushTools).toHaveProperty("memory_write");
+    await flushTools!.memory_write.execute!(
+      { section: "goals", content: "Target FTP 280W by August" },
+      {} as never,
+    );
+
+    const lines = readJournal(dataDir);
+    expect(lines[lines.length - 1]).toMatchObject({
+      op: "write-section",
+      section: "goals",
+      source: "flush",
+    });
+  });
+});

--- a/packages/sport-cycling/src/migrate.ts
+++ b/packages/sport-cycling/src/migrate.ts
@@ -16,7 +16,7 @@ const LEGACY_RENAMES = [
 export function migrateCyclingLegacySections(memory: MemoryStore): void {
   let outcomes: Array<"renamed" | "noop" | "merged">;
   try {
-    outcomes = memory.renameSections(LEGACY_RENAMES);
+    outcomes = memory.renameSections(LEGACY_RENAMES, "migration");
   } catch (err) {
     console.warn(
       JSON.stringify({

--- a/packages/sport-cycling/src/tools.ts
+++ b/packages/sport-cycling/src/tools.ts
@@ -86,7 +86,7 @@ export function createCyclingTools(
       }) => {
         const profile: AthleteProfile = { ...params, needsExtraRecovery: false };
         const plan = buildPlanSkeleton(profile, tz);
-        memory.savePlan(plan);
+        memory.savePlan(plan, "sport-tool");
         return plan;
       },
     }),


### PR DESCRIPTION
Every destructive memory write now appends a line to an append-only history log (`memory/MEMORY.history.jsonl`) **before** it mutates state, so a fact that gets overwritten or renamed away is reconstructible by replaying the log.

## What it records

One JSON line per destructive write, written before the mutation:

```
{ ts, op, section, oldBody, newBody, source }
```

- `op` is one of `write-section`, `save-plan`, `rename-sections`.
- `oldBody` captures what was there before the write (the fact at risk of loss); `newBody` captures what replaces it.
- `source` attributes the write to the path that made it: `chat-tool`, `flush`, `sport-tool`, `migration`, or `unattributed` when a caller omits it.

## Stance

- **Append-only.** Existing lines are never rewritten; each write only ever appends, so the history is a stable byte-prefix of its later self.
- **Never blocks the write.** Journaling is best-effort: if the append fails, it warns and the memory write still proceeds. Durability of the journal must never come at the cost of the write the user asked for.
- **`0600`** on creation — same posture as the rest of the memory directory.

The four destructive write paths (chat memory tool, the flush memory writer, the sport plan-save tool, and the legacy section-rename migration) now declare their source so the log says who did what. This is plumbing under the memory store — no athlete-facing surface changes.
