### PR TITLE
feat(core): add append-only athlete event ledger with flush extraction

### DIFF
--- a/.changeset/memory-event-ledger.md
+++ b/.changeset/memory-event-ledger.md
@@ -1,0 +1,10 @@
+---
+"@enduragent/core": patch
+"cycling-coach": patch
+---
+
+Adds an append-only event ledger (memory/events.jsonl) recording dated
+athlete events — decisions, overrides, illness, experiments, outcomes —
+with a closed kind enum and host-stamped timestamps. The memory flush
+gains a ledger_append tool and an event-extraction prompt clause so these
+events are captured durably instead of being lost at extraction time.

--- a/packages/core/src/agent/coach-agent.ts
+++ b/packages/core/src/agent/coach-agent.ts
@@ -89,6 +89,7 @@ export class CoachAgent {
       messages,
       memory: this.memory,
       memorySections: getEffectiveSections(this.sport),
+      tz: this.tz,
     });
   }
 

--- a/packages/core/src/agent/memory-flush.ts
+++ b/packages/core/src/agent/memory-flush.ts
@@ -5,6 +5,8 @@ import type { MemorySectionSpec } from "../sport.js";
 import type { MemoryStore } from "../memory.js";
 import { createMemoryReadTool } from "./tools.js";
 import type { LLM } from "../llm.js";
+import { LEDGER_EVENT_KINDS, LEDGER_DATE_PATTERN, type LedgerEventKind } from "../memory/event-ledger.js";
+import { todayInTZ } from "./user-time.js";
 
 // ============================================================================
 // CONSTANTS
@@ -19,9 +21,11 @@ export const SOFT_THRESHOLD_RATIO = 0.8;
 const MEMORY_FLUSH_SYSTEM_PROMPT = `You are reviewing a conversation to extract and save important athlete
 information before it is summarized. Use the memory_write tool to save
 details into the appropriate section. Each section is fully replaced on
-write, so include ALL current facts for that section, not just new ones.`;
+write, so include ALL current facts for that section, not just new ones.
+Use the ledger_append tool to record dated events (decisions, overrides,
+illness, experiment outcomes); ledger entries are appended, never replaced.`;
 
-function buildFlushUserPrompt(sections: readonly MemorySectionSpec[]): string {
+function buildFlushUserPrompt(sections: readonly MemorySectionSpec[], today: string): string {
   const sectionList = sections.map((s) => `- "${s.name}": ${s.description}`).join("\n");
   // The transitional migration clause helps the LLM redistribute legacy
   // content (chronic facts in cycling-history, body data in cycling-profile)
@@ -45,6 +49,17 @@ age, or available training days, move them to \`person\`. If \`cycling-history\`
 contains chronic conditions or long-term medications (hypertension, lisinopril,
 diabetes), move them to \`medical-history\`.
 
+Today is ${today}.
+
+Also record dated events in the permanent event ledger using ledger_append:
+- decisions made with the athlete, with the rationale
+- times the athlete overrode, declined, or changed a recommendation
+- illness, injury, or pain mentions (acute ones count — they need no memory section)
+- experiment outcomes (what was tried, what happened)
+Date each event (YYYY-MM-DD) with the day it happened, which may be earlier
+than today. Record only events from this conversation; never re-record
+events that earlier reviews already saved.
+
 Only write sections that have new or changed information.`;
 }
 
@@ -65,6 +80,30 @@ function createFlushMemoryWriteTool(memory: MemoryStore, sections: readonly Memo
     execute: async (input: { section: string; content: string }) => {
       memory.writeSection(input.section, input.content, "flush");
       return { saved: true };
+    },
+  });
+}
+
+function createLedgerAppendTool(memory: MemoryStore) {
+  return tool({
+    description:
+      "Record a dated athlete event (decision, override, illness, experiment, outcome) in the permanent event ledger. Entries are appended, never replaced.",
+    inputSchema: zodSchema(
+      z.object({
+        date: z
+          .string()
+          .regex(LEDGER_DATE_PATTERN)
+          .describe("Date the event happened (YYYY-MM-DD, athlete-local)"),
+        kind: z.enum(LEDGER_EVENT_KINDS).describe("Event category"),
+        text: z
+          .string()
+          .min(1)
+          .describe("What happened, in one or two sentences, including rationale or outcome when stated"),
+      }),
+    ),
+    execute: async (input: { date: string; kind: LedgerEventKind; text: string }) => {
+      memory.appendEvent({ ...input, source: "flush" });
+      return { recorded: true };
     },
   });
 }
@@ -117,6 +156,7 @@ export async function runMemoryFlush(params: {
   messages: ModelMessage[];
   memory: MemoryStore;
   memorySections: readonly MemorySectionSpec[];
+  tz?: string;
 }): Promise<void> {
   if (params.memorySections.length === 0) {
     throw new Error(
@@ -127,13 +167,17 @@ export async function runMemoryFlush(params: {
   const flushTools = {
     memory_write: createFlushMemoryWriteTool(params.memory, params.memorySections),
     memory_read: createMemoryReadTool(params.memory),
+    ledger_append: createLedgerAppendTool(params.memory),
   };
 
   await params.llm.generate({
     system: MEMORY_FLUSH_SYSTEM_PROMPT,
     messages: [
       ...params.messages,
-      { role: "user" as const, content: buildFlushUserPrompt(params.memorySections) },
+      {
+        role: "user" as const,
+        content: buildFlushUserPrompt(params.memorySections, todayInTZ(params.tz ?? "UTC")),
+      },
     ],
     tools: flushTools,
     stopWhen: stepCountIs(5),

--- a/packages/core/src/memory.ts
+++ b/packages/core/src/memory.ts
@@ -7,6 +7,8 @@
  * (e.g. "FTP 247W") from current memory state.
  */
 
+import type { LedgerEventInput } from "./memory/event-ledger.js";
+
 /** Who performed a destructive memory write — recorded on every journal line. */
 export type MemoryWriteSource =
   | "chat-tool"
@@ -54,6 +56,12 @@ export interface MemoryStore {
 
   /** Appends a note to today's daily-notes file. */
   appendDailyNote(note: string, date?: string): void;
+
+  /**
+   * Appends one event to the append-only event ledger
+   * (`memory/events.jsonl`). Entries are never rewritten or pruned.
+   */
+  appendEvent(event: LedgerEventInput): void;
 
   /** Persists the active training plan as JSON. */
   savePlan(plan: unknown, source?: MemoryWriteSource): void;

--- a/packages/core/src/memory/event-ledger.ts
+++ b/packages/core/src/memory/event-ledger.ts
@@ -1,0 +1,41 @@
+import { appendFileSync } from "node:fs";
+import { join } from "node:path";
+import { z } from "zod";
+
+export const LEDGER_EVENT_KINDS = [
+  "decision",
+  "override",
+  "illness",
+  "experiment",
+  "outcome",
+] as const;
+export type LedgerEventKind = (typeof LEDGER_EVENT_KINDS)[number];
+
+export const LEDGER_EVENT_SOURCES = ["flush"] as const;
+export type LedgerEventSource = (typeof LEDGER_EVENT_SOURCES)[number];
+
+export const LEDGER_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+// Append-only invariant: lines are never rewritten or pruned, and the
+// parse-before-append below guarantees every committed line satisfies
+// ledgerEventSchema — readers may parse without a quarantine path.
+export const ledgerEventSchema = z.object({
+  ts: z.string(),
+  date: z.string().regex(LEDGER_DATE_PATTERN),
+  kind: z.enum(LEDGER_EVENT_KINDS),
+  text: z.string().min(1),
+  source: z.enum(LEDGER_EVENT_SOURCES),
+});
+
+export type LedgerEvent = z.infer<typeof ledgerEventSchema>;
+export type LedgerEventInput = Omit<LedgerEvent, "ts">;
+
+export const LEDGER_FILENAME = "events.jsonl";
+
+export function appendLedgerEvent(memoryDir: string, event: LedgerEventInput): void {
+  const line = ledgerEventSchema.parse({ ts: new Date().toISOString(), ...event });
+  appendFileSync(join(memoryDir, LEDGER_FILENAME), JSON.stringify(line) + "\n", {
+    encoding: "utf-8",
+    mode: 0o600,
+  });
+}

--- a/packages/core/src/memory/store.ts
+++ b/packages/core/src/memory/store.ts
@@ -4,6 +4,7 @@ import type { MemoryStore, MemoryWriteSource } from "../memory.js";
 import { todayInTZ } from "../agent/user-time.js";
 import { atomicWriteFileSync } from "../io/atomic-write-file-sync.js";
 import { appendJournalEntry } from "./journal.js";
+import { appendLedgerEvent, type LedgerEventInput } from "./event-ledger.js";
 
 // ============================================================================
 // MEMORY SYSTEM
@@ -190,6 +191,10 @@ export class Memory implements MemoryStore {
     const existing = this.readDailyNotes(d);
     const updated = existing ? `${existing}\n${note}` : note;
     atomicWriteFileSync(path, updated);
+  }
+
+  appendEvent(event: LedgerEventInput): void {
+    appendLedgerEvent(this.memoryDir, event);
   }
 
   // ── Plans ──────────────────────────────────────────────────────────────

--- a/packages/core/tests/memory-event-ledger.test.ts
+++ b/packages/core/tests/memory-event-ledger.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync, readFileSync, statSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ModelMessage } from "ai";
+import { Memory } from "../src/memory/store.js";
+import { ChatStore } from "../src/agent/chat-store.js";
+import { runMemoryFlush } from "../src/agent/memory-flush.js";
+import { ledgerEventSchema } from "../src/memory/event-ledger.js";
+import type { GenerateOpts, GenerateResult } from "../src/llm-types.js";
+import type { LLM } from "../src/llm.js";
+import type { MemorySectionSpec } from "../src/sport.js";
+
+const SECTIONS: readonly MemorySectionSpec[] = [
+  { name: "notes", description: "anything else" },
+  { name: "medical-history", description: "chronic conditions" },
+];
+
+const eventsPathOf = (dataDir: string) => join(dataDir, "memory", "events.jsonl");
+
+const readLines = (dataDir: string) =>
+  readFileSync(eventsPathOf(dataDir), "utf-8")
+    .trimEnd()
+    .split("\n")
+    .map((l) => JSON.parse(l));
+
+type ScriptedToolCall = { tool: string; input: unknown };
+
+function executeToolsLLM(calls: ScriptedToolCall[], captured: GenerateOpts[]): LLM {
+  return {
+    async generate(opts: GenerateOpts): Promise<GenerateResult> {
+      captured.push(opts);
+      for (const call of calls) {
+        const t = (opts.tools ?? {})[call.tool] as
+          | {
+              execute?: (
+                input: unknown,
+                ctx: { toolCallId: string; messages: ModelMessage[] },
+              ) => Promise<unknown>;
+            }
+          | undefined;
+        if (!t?.execute) throw new Error(`tool ${call.tool} not in flush toolset`);
+        await t.execute(call.input, { toolCallId: "test-call", messages: [] });
+      }
+      return {
+        text: "",
+        toolCalls: [],
+        finishReason: "stop" as const,
+        usage: {
+          inputTokens: 0,
+          inputTokenDetails: { noCacheTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 },
+          outputTokens: 0,
+          outputTokenDetails: { textTokens: 0, reasoningTokens: 0 },
+          totalTokens: 0,
+        },
+      };
+    },
+  } as unknown as LLM;
+}
+
+describe("Memory.appendEvent", () => {
+  let dataDir: string;
+
+  beforeEach(() => {
+    dataDir = mkdtempSync(join(tmpdir(), "cc-ledger-"));
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-11T08:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    rmSync(dataDir, { recursive: true, force: true });
+    vi.useRealTimers();
+  });
+
+  it("appends one schema-valid line with a host-stamped ts", () => {
+    const memory = new Memory(dataDir);
+    memory.appendEvent({
+      date: "2026-06-10",
+      kind: "override",
+      text: "Rode hard despite a rest-day recommendation",
+      source: "flush",
+    });
+
+    const lines = readLines(dataDir);
+    expect(lines).toHaveLength(1);
+    expect(() => ledgerEventSchema.parse(lines[0])).not.toThrow();
+    expect(lines[0]).toEqual({
+      ts: "2026-06-11T08:00:00.000Z",
+      date: "2026-06-10",
+      kind: "override",
+      text: "Rode hard despite a rest-day recommendation",
+      source: "flush",
+    });
+  });
+
+  it("appends without rewriting earlier lines", () => {
+    const memory = new Memory(dataDir);
+    memory.appendEvent({ date: "2026-06-09", kind: "decision", text: "Switch to base block", source: "flush" });
+    const before = readFileSync(eventsPathOf(dataDir), "utf-8");
+
+    memory.appendEvent({ date: "2026-06-10", kind: "outcome", text: "FTP test 252W", source: "flush" });
+    const after = readFileSync(eventsPathOf(dataDir), "utf-8");
+
+    expect(readLines(dataDir)).toHaveLength(2);
+    expect(after.startsWith(before)).toBe(true);
+  });
+
+  it("creates the file owner-only", () => {
+    const memory = new Memory(dataDir);
+    memory.appendEvent({ date: "2026-06-10", kind: "illness", text: "Head cold", source: "flush" });
+
+    expect(statSync(eventsPathOf(dataDir)).mode & 0o777).toBe(0o600);
+  });
+
+  it("rejects a malformed date", () => {
+    const memory = new Memory(dataDir);
+    expect(() =>
+      memory.appendEvent({ date: "June 10", kind: "override", text: "x", source: "flush" }),
+    ).toThrow();
+    expect(existsSync(eventsPathOf(dataDir))).toBe(false);
+  });
+
+  it("rejects an unknown kind", () => {
+    const memory = new Memory(dataDir);
+    expect(() =>
+      memory.appendEvent({
+        date: "2026-06-10",
+        // @ts-expect-error — invalid kind, schema must reject at runtime
+        kind: "weather",
+        text: "x",
+        source: "flush",
+      }),
+    ).toThrow();
+    expect(existsSync(eventsPathOf(dataDir))).toBe(false);
+  });
+
+  it("survives section rewrites, plan overwrites, and a session reset", () => {
+    const memory = new Memory(dataDir);
+    memory.appendEvent({ date: "2026-06-10", kind: "experiment", text: "Tried 3x20 SST", source: "flush" });
+    const snapshot = readFileSync(eventsPathOf(dataDir), "utf-8");
+
+    memory.writeSection("notes", "first");
+    memory.writeSection("notes", "second");
+    memory.savePlan({ name: "x" });
+    expect(readFileSync(eventsPathOf(dataDir), "utf-8")).toBe(snapshot);
+
+    const chat = new ChatStore(dataDir);
+    chat.appendMessage("c1", "user", "hi");
+    chat.archiveAndReset("c1");
+    expect(readFileSync(eventsPathOf(dataDir), "utf-8")).toBe(snapshot);
+  });
+});
+
+describe("runMemoryFlush ledger integration", () => {
+  let dataDir: string;
+
+  beforeEach(() => {
+    dataDir = mkdtempSync(join(tmpdir(), "cc-ledger-"));
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-11T08:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    rmSync(dataDir, { recursive: true, force: true });
+    vi.useRealTimers();
+  });
+
+  const OVERRIDE_CONVO: ModelMessage[] = [
+    { role: "assistant", content: "Tomorrow is a rest day — keep it easy." },
+    { role: "user", content: "I rode hard anyway, felt great." },
+  ];
+
+  it("an override exchange produces a ledger line", async () => {
+    const memory = new Memory(dataDir);
+    const captured: GenerateOpts[] = [];
+    const llm = executeToolsLLM(
+      [
+        {
+          tool: "ledger_append",
+          input: {
+            date: "2026-06-10",
+            kind: "override",
+            text: "Rode hard despite a rest-day recommendation",
+          },
+        },
+      ],
+      captured,
+    );
+
+    await runMemoryFlush({ llm, messages: OVERRIDE_CONVO, memory, memorySections: SECTIONS, tz: "UTC" });
+
+    const lines = readLines(dataDir);
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toMatchObject({
+      ts: "2026-06-11T08:00:00.000Z",
+      date: "2026-06-10",
+      kind: "override",
+      source: "flush",
+    });
+  });
+
+  it("the flush toolset exposes exactly the three tools", async () => {
+    const memory = new Memory(dataDir);
+    const captured: GenerateOpts[] = [];
+    const llm = executeToolsLLM([], captured);
+
+    await runMemoryFlush({ llm, messages: OVERRIDE_CONVO, memory, memorySections: SECTIONS, tz: "UTC" });
+
+    expect(Object.keys(captured[0].tools ?? {}).sort()).toEqual([
+      "ledger_append",
+      "memory_read",
+      "memory_write",
+    ]);
+  });
+
+  it("the flush prompt carries the extraction clause and the date anchor", async () => {
+    const memory = new Memory(dataDir);
+    const captured: GenerateOpts[] = [];
+    const llm = executeToolsLLM([], captured);
+
+    await runMemoryFlush({ llm, messages: OVERRIDE_CONVO, memory, memorySections: SECTIONS, tz: "UTC" });
+
+    const messages = captured[0].messages ?? [];
+    const last = messages[messages.length - 1];
+    const content = last.content as string;
+    expect(content).toContain("Today is 2026-06-11");
+    expect(content).toContain("ledger_append");
+    expect(content).toContain("overrode");
+  });
+
+  it("a flush that records no event creates no file", async () => {
+    const memory = new Memory(dataDir);
+    const captured: GenerateOpts[] = [];
+    const llm = executeToolsLLM(
+      [{ tool: "memory_write", input: { section: "notes", content: "x" } }],
+      captured,
+    );
+
+    await runMemoryFlush({ llm, messages: OVERRIDE_CONVO, memory, memorySections: SECTIONS, tz: "UTC" });
+
+    expect(existsSync(eventsPathOf(dataDir))).toBe(false);
+  });
+});

--- a/packages/sport-cycling/tests/migrate-cycling-legacy-sections.test.ts
+++ b/packages/sport-cycling/tests/migrate-cycling-legacy-sections.test.ts
@@ -182,6 +182,7 @@ describe("migrateCyclingLegacySections", () => {
       writeSection: () => {},
       readDailyNotes: () => "",
       appendDailyNote: () => {},
+      appendEvent: () => {},
       savePlan: () => {},
       loadPlan: () => null,
       reload: () => {},


### PR DESCRIPTION
Adds an append-only event ledger in the athlete memory directory (`memory/events.jsonl`). The memory flush now records dated decisions, overrides, illness mentions, and experiment outcomes durably, instead of squeezing them into the undated notes catch-all where the next flush can drop them — or losing them outright when the transcript is archived.

## What it records

Each line is one JSON event with a fixed schema:

```
{ ts, date, kind, text, source }
```

- `ts` — host-stamped UTC instant of the append (never model-supplied).
- `date` — athlete-local `YYYY-MM-DD` the event actually happened, which may precede `ts`.
- `kind` — a closed five-value enum: `decision`, `override`, `illness`, `experiment`, `outcome`.
- `text` — the free-text description, including rationale or outcome.
- `source` — the writer; only `flush` today (the enum names current writers, not aspirations).

## Stance

- **Append-only, never pruned.** Lines are only ever appended; nothing rewrites or rotates the file. Section writes, plan overwrites, flushes, and session resets all leave earlier lines byte-identical.
- **Parse-before-append.** Every line is validated against the schema before it is written, so a malformed date or unknown kind throws and nothing lands — readers can parse the file without a quarantine path. This writer deliberately throws on failure (matching the other memory writes), distinct from the best-effort history journal.
- **`0600`** on creation, consistent with the rest of the memory directory.

## How events get captured

The memory flush gains a `ledger_append` tool (flush toolset only — not the live chat tools) and an event-extraction clause in the flush prompt, anchored with the athlete-local date so the model can date events that happened earlier in the conversation. This is write-side plumbing: there is no read path yet, so nothing is athlete-visible until the dated recall tool lands. The flush now threads the athlete timezone through for that date anchor.
