### PR TITLE
fix(core): add compaction stance carrier and guard reset-path flushes

### DIFF
--- a/.changeset/compaction-stance-flush-guards.md
+++ b/.changeset/compaction-stance-flush-guards.md
@@ -1,0 +1,15 @@
+---
+"@enduragent/core": patch
+"cycling-coach": patch
+---
+
+User-facing: The coach now carries its current training recommendation (and any pushback you've raised) across long conversations instead of sometimes losing it when older messages are condensed.
+
+User-facing: Session resets no longer get stuck when saving memory fails — the coach archives the conversation and starts fresh anyway.
+
+Compaction summaries gain a required Coach Stance section (enforced by the
+headings audit) and the MUST-PRESERVE block gains stance, dispute, illness,
+and agreed-action bullets, so the summarizer can no longer file the coach's
+own recommendation under omittable generic advice. Both reset-path memory
+flushes are now wrapped in warn-and-proceed guards so a flush failure cannot
+block the session archive.

--- a/packages/core/src/agent/coach-agent.ts
+++ b/packages/core/src/agent/coach-agent.ts
@@ -117,7 +117,11 @@ export class CoachAgent {
       if (!fresh) {
         // Flush memory before reset, then archive
         if (history.length > 0) {
-          await this.flushMemory(history);
+          try {
+            await this.flushMemory(history);
+          } catch (err) {
+            console.warn("Pre-reset memory flush failed; archiving session anyway", err);
+          }
         }
         this.chatStore.archiveAndReset(chatId);
         history = [];
@@ -245,7 +249,11 @@ export class CoachAgent {
     // Flush before reset to avoid losing un-persisted context
     const { messages: history } = this.chatStore.load(chatId);
     if (history.length > 0) {
-      await this.flushMemory(history);
+      try {
+        await this.flushMemory(history);
+      } catch (err) {
+        console.warn("Pre-reset memory flush failed; archiving session anyway", err);
+      }
     }
     this.chatStore.archiveAndReset(chatId);
   }

--- a/packages/core/src/agent/compaction.ts
+++ b/packages/core/src/agent/compaction.ts
@@ -25,6 +25,7 @@ const MIN_CHUNK_RATIO = 0.15;
 const REQUIRED_SUMMARY_SECTIONS = [
   "## Athlete Profile",
   "## Training Status",
+  "## Coach Stance",
   "## Discussion Context",
   "## Pending Questions",
 ] as const;
@@ -55,6 +56,10 @@ function buildMustPreserveBlock(tokens: readonly string[]): string {
 - Current training plan status and phase
 - Recent workout feedback and performance trends
 - Decisions made about training approach
+- The coach's most recent stance per axis ({volume, intensity} in increase/hold/reduce/none plus rest/refer_out flags) and the receipt it was grounded in
+- Any coach recommendation the athlete is currently disputing
+- Any illness or symptoms mentioned
+- Actions agreed but not yet executed
 - Any injuries, constraints, or preferences mentioned
 - The last thing the athlete asked and what was being discussed
 
@@ -72,6 +77,7 @@ Use bullet points, not paragraphs. Omit generic advice that can be re-derived.
 Use these exact section headings:
 ## Athlete Profile
 ## Training Status
+## Coach Stance
 ## Discussion Context
 ## Pending Questions
 
@@ -87,6 +93,7 @@ Use bullet points, not paragraphs. Omit generic advice that can be re-derived.
 Use these exact section headings:
 ## Athlete Profile
 ## Training Status
+## Coach Stance
 ## Discussion Context
 ## Pending Questions
 

--- a/packages/core/tests/compaction.test.ts
+++ b/packages/core/tests/compaction.test.ts
@@ -23,11 +23,13 @@ const REPRESENTATIVE_CONVERSATION: ModelMessage[] = [
   { role: "assistant", content: "Health note: prior knee issue, watch high-volume blocks." },
 ];
 
-const VALID_FOUR_SECTION_SUMMARY = [
+const VALID_FIVE_SECTION_SUMMARY = [
   "## Athlete Profile",
   "- FTP 247W, 72kg, training Mon/Wed/Fri",
   "## Training Status",
   "- Build phase, target FTP 280W",
+  "## Coach Stance",
+  "- Hold volume this week (prior knee issue); athlete has not pushed back",
   "## Discussion Context",
   "- Goal-setting and equipment review",
   "## Pending Questions",
@@ -51,7 +53,7 @@ const EMPTY_SNAPSHOT: MemorySnapshot = {
 
 describe("compaction (sport-parameterized)", () => {
   it("summarizeDroppedMessages prompt carries MUST-PRESERVE + sport tokens + transcript data", async () => {
-    const spy = createFakeLLM([VALID_FOUR_SECTION_SUMMARY], { repeatLast: true });
+    const spy = createFakeLLM([VALID_FIVE_SECTION_SUMMARY], { repeatLast: true });
 
     await summarizeDroppedMessages({
       dropped: REPRESENTATIVE_CONVERSATION,
@@ -75,10 +77,16 @@ describe("compaction (sport-parameterized)", () => {
     // Transcript data is included verbatim.
     expect(prompt).toContain("247W");
     expect(prompt).toContain("72kg");
+
+    expect(prompt).toContain("## Coach Stance");
+    expect(prompt).toContain("stance per axis");
+    expect(prompt).toContain("currently disputing");
+    expect(prompt).toContain("illness or symptoms");
+    expect(prompt).toContain("agreed but not yet executed");
   });
 
   it("summarizeDroppedMessages with function-form tokens calls the function with the snapshot", async () => {
-    const spy = createFakeLLM([VALID_FOUR_SECTION_SUMMARY], { repeatLast: true });
+    const spy = createFakeLLM([VALID_FIVE_SECTION_SUMMARY], { repeatLast: true });
     const calls: MemorySnapshot[] = [];
 
     await summarizeDroppedMessages({
@@ -98,7 +106,7 @@ describe("compaction (sport-parameterized)", () => {
   });
 
   it("summarizeInStages prompt also carries the MUST-PRESERVE instruction and tokens", async () => {
-    const spy = createFakeLLM([VALID_FOUR_SECTION_SUMMARY], { repeatLast: true });
+    const spy = createFakeLLM([VALID_FIVE_SECTION_SUMMARY], { repeatLast: true });
 
     await summarizeInStages({
       messages: REPRESENTATIVE_CONVERSATION,
@@ -111,10 +119,16 @@ describe("compaction (sport-parameterized)", () => {
     expect(spy.capturedPrompts.length).toBeGreaterThan(0);
     expect(spy.capturedPrompts[0]).toContain("MUST PRESERVE");
     expect(spy.capturedPrompts[0]).toContain("FTP");
+
+    expect(spy.capturedPrompts[0]).toContain("## Coach Stance");
+    expect(spy.capturedPrompts[0]).toContain("stance per axis");
+    expect(spy.capturedPrompts[0]).toContain("currently disputing");
+    expect(spy.capturedPrompts[0]).toContain("illness or symptoms");
+    expect(spy.capturedPrompts[0]).toContain("agreed but not yet executed");
   });
 
-  it("auditSummaryQuality accepts a summary with all four required sections", () => {
-    const audit = auditSummaryQuality(VALID_FOUR_SECTION_SUMMARY);
+  it("auditSummaryQuality accepts a summary with all five required sections", () => {
+    const audit = auditSummaryQuality(VALID_FIVE_SECTION_SUMMARY);
     expect(audit.ok).toBe(true);
     expect(audit.missing).toEqual([]);
   });
@@ -124,6 +138,23 @@ describe("compaction (sport-parameterized)", () => {
     const audit = auditSummaryQuality(partial);
     expect(audit.ok).toBe(false);
     expect(audit.missing).toContain("## Training Status");
+    expect(audit.missing).toContain("## Coach Stance");
     expect(audit.missing).toContain("## Pending Questions");
+  });
+
+  it("auditSummaryQuality flags a summary missing only ## Coach Stance", () => {
+    const fourSection = [
+      "## Athlete Profile",
+      "- FTP 247W",
+      "## Training Status",
+      "- Build phase",
+      "## Discussion Context",
+      "- Goal review",
+      "## Pending Questions",
+      "- None",
+    ].join("\n");
+    const audit = auditSummaryQuality(fourSection);
+    expect(audit.ok).toBe(false);
+    expect(audit.missing).toEqual(["## Coach Stance"]);
   });
 });

--- a/packages/core/tests/reset-flush-guard.test.ts
+++ b/packages/core/tests/reset-flush-guard.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  mkdtempSync,
+  rmSync,
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  readdirSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { baseAgentConfig } from "./helpers/base-agent-config.js";
+import { cyclingSport } from "@enduragent/sport-cycling";
+import type { Sport } from "../src/sport.js";
+
+let tempHome: string;
+let origHome: string | undefined;
+let dataDir: string;
+
+beforeEach(() => {
+  tempHome = mkdtempSync(join(tmpdir(), "cc-resetflush-"));
+  origHome = process.env.HOME;
+  process.env.HOME = tempHome;
+  dataDir = join(tempHome, ".cycling-coach");
+  mkdirSync(dataDir, { recursive: true });
+  mkdirSync(join(dataDir, "memory"), { recursive: true });
+  vi.resetModules();
+});
+
+afterEach(() => {
+  process.env.HOME = origHome;
+  rmSync(tempHome, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+async function setupAgent(complete: ReturnType<typeof vi.fn>) {
+  const model = {
+    id: "gpt-5.4",
+    name: "gpt-5.4",
+    api: "openai-codex-responses",
+    provider: "openai-codex",
+    baseUrl: "https://chatgpt.com/backend-api",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 272_000,
+    maxTokens: 128_000,
+  };
+
+  vi.doMock("@mariozechner/pi-ai", () => ({
+    complete,
+    getModel: vi.fn(() => model),
+  }));
+  vi.doMock("@mariozechner/pi-ai/oauth", () => ({
+    refreshOpenAICodexToken: vi.fn(),
+    loginOpenAICodex: vi.fn(),
+  }));
+  vi.doMock("../src/auth/profiles.js", () => ({
+    getFreshToken: vi.fn(async () => "token"),
+    loadProfile: vi.fn(),
+    saveProfile: vi.fn(),
+    RefreshTokenReusedError: class extends Error {},
+  }));
+
+  const { CoachAgent } = await import("../src/agent/coach-agent.js");
+  return new CoachAgent(cyclingSport as unknown as Sport, baseAgentConfig(dataDir));
+}
+
+function mkAssistant(text: string, stopReason: "stop" | "length" = "stop") {
+  return {
+    role: "assistant" as const,
+    content: [{ type: "text" as const, text }],
+    api: "openai-codex-responses",
+    provider: "openai-codex",
+    model: "gpt-5.4",
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason,
+    timestamp: Date.now(),
+  };
+}
+
+const STALE_TS = "2020-01-01T00:00:00.000Z";
+
+function seedSession(chatId: string, lines: Array<{ role: string; content: string; ts: string }>) {
+  const sessionsDir = join(dataDir, "sessions");
+  mkdirSync(sessionsDir, { recursive: true });
+  writeFileSync(
+    join(sessionsDir, `${chatId}.jsonl`),
+    lines.map((l) => JSON.stringify(l)).join("\n") + "\n",
+    "utf-8",
+  );
+}
+
+function listArchives(chatId: string): string[] {
+  return readdirSync(join(dataDir, "sessions")).filter((f) =>
+    f.startsWith(`${chatId}.jsonl.reset.`),
+  );
+}
+
+describe("reset-path flush guards", () => {
+  it("resetSession archives the session even when the memory flush throws", async () => {
+    const complete = vi.fn(async () => {
+      throw new Error("boom");
+    });
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const agent = await setupAgent(complete);
+    seedSession("reset-guard", [
+      { role: "user", content: "we agreed: hold volume this week", ts: STALE_TS },
+      { role: "assistant", content: "yes - hold volume, recheck Friday", ts: STALE_TS },
+    ]);
+
+    await expect(agent.resetSession("reset-guard")).resolves.toBeUndefined();
+
+    expect(complete).toHaveBeenCalledTimes(1);
+    expect(agent.hasSession("reset-guard")).toBe(false);
+    const archives = listArchives("reset-guard");
+    expect(archives).toHaveLength(1);
+    const archived = readFileSync(join(dataDir, "sessions", archives[0]), "utf-8");
+    expect(archived).toContain("hold volume this week");
+    expect(archived).toContain("recheck Friday");
+    expect(
+      warnSpy.mock.calls.some((c) => String(c[0]).includes("Pre-reset memory flush failed")),
+    ).toBe(true);
+  });
+
+  it("freshness-expiry reset archives and the chat continues when the flush throws", async () => {
+    let n = 0;
+    const complete = vi.fn(async () => {
+      n++;
+      if (n === 1) throw new Error("boom");
+      return mkAssistant("fresh-start");
+    });
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const agent = await setupAgent(complete);
+    seedSession("stale-guard", [
+      { role: "user", content: "old turn from a previous day", ts: STALE_TS },
+      { role: "assistant", content: "old reply", ts: STALE_TS },
+    ]);
+
+    const text = await agent.chat("stale-guard", "hello");
+
+    expect(text).toBe("fresh-start");
+    expect(complete).toHaveBeenCalledTimes(2);
+    const archives = listArchives("stale-guard");
+    expect(archives).toHaveLength(1);
+    const archived = readFileSync(join(dataDir, "sessions", archives[0]), "utf-8");
+    expect(archived).toContain("old turn from a previous day");
+    const freshSession = readFileSync(join(dataDir, "sessions", "stale-guard.jsonl"), "utf-8");
+    expect(freshSession).toContain("hello");
+    expect(freshSession).toContain("fresh-start");
+    expect(freshSession).not.toContain("old turn from a previous day");
+    expect(
+      warnSpy.mock.calls.some((c) => String(c[0]).includes("Pre-reset memory flush failed")),
+    ).toBe(true);
+  });
+
+  it("resetSession flushes and archives without a failure warn when the LLM is healthy", async () => {
+    const complete = vi.fn(async () => mkAssistant("noted"));
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const agent = await setupAgent(complete);
+    seedSession("healthy-reset", [
+      { role: "user", content: "remember my FTP is 247", ts: STALE_TS },
+    ]);
+
+    await agent.resetSession("healthy-reset");
+
+    expect(complete).toHaveBeenCalledTimes(1);
+    expect(agent.hasSession("healthy-reset")).toBe(false);
+    expect(listArchives("healthy-reset")).toHaveLength(1);
+    expect(
+      warnSpy.mock.calls.some((c) => String(c[0]).includes("Pre-reset memory flush failed")),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
Two small, related memory data-loss stop-losses for long conversations and session resets, shipped together as one change.

## Compaction stance carrier

When a conversation outgrows its token budget, the coach condenses older messages into a structured summary. That summary preserved the athlete's profile, plan status, feedback, and last question — but had no home for **what the coach itself most recently recommended** ("hold volume this week"), nor for an athlete actively pushing back on it. Worse, the summarizer was told to "omit generic advice that can be re-derived" — exactly the bucket a recommendation gets filed under. Across a compaction boundary the coach could innocently forget its own stance and capitulate to pressure it would otherwise hold against.

This adds a required `## Coach Stance` section to the summary heading list (positioned ahead of the blind tail-truncation point) so the summary-quality audit now structurally enforces its presence, and adds four MUST-PRESERVE bullets covering the coach's current stance per axis, any recommendation under dispute, illness/symptom mentions, and agreed-but-unexecuted actions. The bullet wording deliberately uses the field names a future deterministic carrier will consume, so that later work slots in without prompt churn.

## Reset-path flush guards

Before a session reset, the coach extracts durable facts from the dying conversation into memory via one LLM call. Both reset paths — the daily-freshness expiry inside the chat loop and the explicit reset command — `await` that flush **unguarded**, directly ahead of the archive step. The flush has no provider-level retry, so a single transient error would escape: on the freshness path the archive never happened and the same stale history re-triggered the same failing flush on every subsequent message, bricking the athlete's entire chat surface until the flush happened to succeed.

Both flush calls are now wrapped in warn-and-proceed guards: on failure the coach logs a warning and **always** proceeds to archive and start fresh. The archive file preserves the full raw history for later salvage, so a failed flush loses at most one increment of memory extraction instead of the whole conversation. The archive and reset stay outside the guard so a flush failure can never mask an archive failure.

## Tests

- The compaction summary suite gains stance-content assertions on both summarizer prompts, an audit case proving a summary missing only the stance section is rejected, and the shared fixture updated to the five-section shape (5 → 6 tests).
- A new reset-path guard suite (3 tests) proves both reset paths archive and continue when the flush throws, that the archive retains the pre-reset history, and that a healthy flush still runs without a spurious warning.
- Full `pnpm check` and `pnpm test` green; no regressions.
