### PR TITLE
fix(core): flush, archive, and audit trim-path compaction summaries

### DIFF
--- a/.changeset/compaction-trim-flush-audit.md
+++ b/.changeset/compaction-trim-flush-audit.md
@@ -1,0 +1,16 @@
+---
+"@enduragent/core": patch
+"cycling-coach": patch
+---
+
+User-facing: Long conversations are now condensed safely — the coach saves durable facts to memory and keeps a local archive of the full transcript before condensing older messages, leaves your history untouched if anything fails along the way, and completeness-checks every condensed summary.
+
+The trim-path compaction now flushes memory before rewriting the session
+file and skips the rewrite when the flush fails; every successful trim
+archives the pre-rewrite transcript to a .precompact sidecar governed by
+the existing opt-in retention knob. Summarization of dropped messages
+returns failed chunks to the caller instead of discarding them and throws
+on total failure so history is never replaced by an empty summary. The
+summary-quality audit is extracted into a shared post-step applied by
+both compaction pipelines, with output bounded at generation time and the
+audit running after any final truncation.

--- a/packages/core/src/agent/chat-store.ts
+++ b/packages/core/src/agent/chat-store.ts
@@ -3,6 +3,7 @@ import {
   writeFileSync,
   appendFileSync,
   renameSync,
+  copyFileSync,
   existsSync,
   mkdirSync,
   readdirSync,
@@ -99,12 +100,21 @@ export class ChatStore {
     const ts = new Date().toISOString().replace(/:/g, "-");
     const archivePath = `${path}.reset.${ts}`;
     renameSync(path, archivePath);
-    this.pruneArchives(chatId);
+    this.pruneArchives(chatId, "reset");
   }
 
-  private pruneArchives(chatId: string): void {
+  archivePreCompact(chatId: string): void {
+    const path = this.filePath(chatId);
+    if (!existsSync(path)) return;
+
+    const ts = new Date().toISOString().replace(/:/g, "-");
+    copyFileSync(path, `${path}.precompact.${ts}`);
+    this.pruneArchives(chatId, "precompact");
+  }
+
+  private pruneArchives(chatId: string, suffix: "reset" | "precompact"): void {
     if (this.resetArchiveRetentionDays <= 0) return;
-    const prefix = `${chatId}.jsonl.reset.`;
+    const prefix = `${chatId}.jsonl.${suffix}.`;
     const cutoffMs = Date.now() - this.resetArchiveRetentionDays * MS_PER_DAY;
     for (const name of readdirSync(this.sessionsDir)) {
       if (!name.startsWith(prefix)) continue;

--- a/packages/core/src/agent/coach-agent.ts
+++ b/packages/core/src/agent/coach-agent.ts
@@ -140,15 +140,27 @@ export class CoachAgent {
       });
 
       let summaryMsg: ModelMessage | undefined;
+      let requeued: ModelMessage[] = [];
       if (dropped.length > 0) {
+        let flushed = true;
         try {
-          const summary = await summarizeDroppedMessages({
+          await this.flushMemory(history);
+        } catch (err) {
+          flushed = false;
+          console.warn("Pre-compaction memory flush failed; keeping session file unchanged", err);
+        }
+        try {
+          const { summary, unsummarized } = await summarizeDroppedMessages({
             dropped,
             previousSummary,
             ...this.compactionParams(),
           });
           summaryMsg = makeSummaryMessage(summary);
-          this.chatStore.overwriteHistory(chatId, [summaryMsg, ...kept]);
+          requeued = unsummarized;
+          if (flushed) {
+            this.chatStore.archivePreCompact(chatId);
+            this.chatStore.overwriteHistory(chatId, [summaryMsg, ...requeued, ...kept]);
+          }
         } catch (err) {
           console.warn("Dropped message summarization failed, continuing without summary", err);
           if (previousSummary) {
@@ -168,6 +180,7 @@ export class CoachAgent {
       // Build messages array with new user message
       let messages: ModelMessage[] = [
         ...(summaryMsg ? [summaryMsg] : []),
+        ...requeued,
         ...kept,
         { role: "user", content: userMessageWithTime },
       ];

--- a/packages/core/src/agent/compaction.ts
+++ b/packages/core/src/agent/compaction.ts
@@ -9,7 +9,7 @@ import {
   MIN_PROMPT_BUDGET_TOKENS,
   SUMMARIZATION_OVERHEAD_TOKENS,
 } from "./token-utils.js";
-import { makeSummaryMessage } from "./history-limit.js";
+import { makeSummaryMessage, SUMMARY_PREFIX } from "./history-limit.js";
 import type { LLM } from "../llm.js";
 
 // ============================================================================
@@ -18,7 +18,7 @@ import type { LLM } from "../llm.js";
 
 const MAX_SUMMARY_CHARS = 4_000;
 const SUMMARY_TRUNCATED_MARKER = "\n\n[Summary truncated]";
-const MAX_SUMMARY_TOKENS = 2048;
+const MAX_SUMMARY_TOKENS = 1000;
 const BASE_CHUNK_RATIO = 0.4;
 const MIN_CHUNK_RATIO = 0.15;
 
@@ -74,6 +74,8 @@ function buildSummarizePrompt(tokens: readonly string[]): string {
   return `Summarize the following conversation concisely — aim for 300-500 words total.
 Use bullet points, not paragraphs. Omit generic advice that can be re-derived.
 
+If an existing summary of earlier context is provided, PRESERVE every fact in it unless a newer message directly supersedes it — do not drop a fact merely because it is old.
+
 Use these exact section headings:
 ## Athlete Profile
 ## Training Status
@@ -89,6 +91,8 @@ function buildDroppedMessagesPrompt(tokens: readonly string[]): string {
 
 Produce a compact, factual summary — aim for 300-500 words total.
 Use bullet points, not paragraphs. Omit generic advice that can be re-derived.
+
+If an existing summary of earlier context is provided, PRESERVE every fact in it unless a newer message directly supersedes it — do not drop a fact merely because it is old.
 
 Use these exact section headings:
 ## Athlete Profile
@@ -188,6 +192,34 @@ export function auditSummaryQuality(summary: string): { ok: boolean; missing: st
   return missing.length === 0 ? { ok: true, missing: [] } : { ok: false, missing };
 }
 
+async function finalizeSummary(params: {
+  summary: string;
+  llm: LLM;
+  mustPreserveBlock: string;
+  maxRetries: number;
+}): Promise<string> {
+  const { llm, mustPreserveBlock, maxRetries } = params;
+  let best = capSummary(params.summary);
+  const audit = auditSummaryQuality(best);
+  if (audit.ok) return best;
+
+  for (let attempt = 0; attempt < maxRetries; attempt++) {
+    try {
+      const { text } = await llm.generate({
+        prompt: `Restructure the following summary to include ALL required section headings: ${audit.missing.join(", ")}.\n\n${best}\n\n${mustPreserveBlock}`,
+        maxOutputTokens: MAX_SUMMARY_TOKENS,
+      });
+      const capped = capSummary(text);
+      if (auditSummaryQuality(capped).ok) return capped;
+      best = capped;
+    } catch (err) {
+      console.warn("Summary audit retry failed", err);
+    }
+  }
+
+  return best;
+}
+
 // ============================================================================
 // DROPPED MESSAGE SUMMARIZATION
 // ============================================================================
@@ -245,26 +277,10 @@ export async function summarizeDroppedMessages(params: {
     });
   }
 
-  // Quality guard with retry
-  const audit = auditSummaryQuality(summary);
-  if (audit.ok) return { summary: capSummary(summary), unsummarized };
-
-  let best: string = summary;
-  for (let attempt = 0; attempt < maxRetries; attempt++) {
-    try {
-      const { text } = await llm.generate({
-        prompt: `Restructure the following summary to include ALL required section headings: ${audit.missing.join(", ")}.\n\n${best}\n\n${mustPreserveBlock}`,
-        maxOutputTokens: MAX_SUMMARY_TOKENS,
-      });
-      const retryAudit = auditSummaryQuality(text);
-      if (retryAudit.ok) return { summary: capSummary(text), unsummarized };
-      best = text;
-    } catch (err) {
-      console.warn("Dropped message summarization retry failed", err);
-    }
-  }
-
-  return { summary: capSummary(best), unsummarized };
+  return {
+    summary: await finalizeSummary({ summary, llm, mustPreserveBlock, maxRetries }),
+    unsummarized,
+  };
 }
 
 // ============================================================================
@@ -280,18 +296,33 @@ export async function summarizeInStages(params: {
   previousSummary?: string;
   contextWindowTokens?: number;
 }): Promise<ModelMessage[]> {
-  const { messages, llm, mustPreserveTokens, memory, recentToKeep = 4, previousSummary, contextWindowTokens } = params;
+  const { llm, mustPreserveTokens, memory, recentToKeep = 4, contextWindowTokens } = params;
+
+  let messages = params.messages;
+  let previousSummary = params.previousSummary;
+  const first = messages[0];
+  if (
+    previousSummary === undefined &&
+    first !== undefined &&
+    first.role === "system" &&
+    typeof first.content === "string" &&
+    first.content.startsWith(SUMMARY_PREFIX)
+  ) {
+    previousSummary = first.content.slice(SUMMARY_PREFIX.length + 1);
+    messages = messages.slice(1);
+  }
 
   const keepCount = Math.min(recentToKeep, messages.length);
   const toSummarize = messages.slice(0, messages.length - keepCount);
   const recent = messages.slice(messages.length - keepCount);
 
   if (toSummarize.length === 0) {
-    return messages;
+    return params.messages;
   }
 
   const tokens = resolveTokens(mustPreserveTokens, memory);
   const summarizePrompt = buildSummarizePrompt(tokens);
+  const mustPreserveBlock = buildMustPreserveBlock(tokens);
 
   const chunks = computeAdaptiveChunks(toSummarize, contextWindowTokens);
 
@@ -308,8 +339,14 @@ export async function summarizeInStages(params: {
       prompt: `${summarizePrompt}${contextPrefix}\n\n${transcript}`,
       maxOutputTokens: MAX_SUMMARY_TOKENS,
     });
-    summary = capSummary(text);
+    summary = text;
   }
 
-  return [makeSummaryMessage(summary!), ...recent];
+  const finalSummary = await finalizeSummary({
+    summary: summary ?? "",
+    llm,
+    mustPreserveBlock,
+    maxRetries: 1,
+  });
+  return [makeSummaryMessage(finalSummary), ...recent];
 }

--- a/packages/core/src/agent/compaction.ts
+++ b/packages/core/src/agent/compaction.ts
@@ -200,10 +200,10 @@ export async function summarizeDroppedMessages(params: {
   previousSummary?: string;
   maxRetries?: number;
   contextWindowTokens?: number;
-}): Promise<string> {
+}): Promise<{ summary: string; unsummarized: ModelMessage[] }> {
   const { dropped, llm, mustPreserveTokens, memory, previousSummary, maxRetries = 1, contextWindowTokens } = params;
 
-  if (dropped.length === 0) return previousSummary ?? "";
+  if (dropped.length === 0) return { summary: previousSummary ?? "", unsummarized: [] };
 
   const tokens = resolveTokens(mustPreserveTokens, memory);
   const droppedPrompt = buildDroppedMessagesPrompt(tokens);
@@ -214,6 +214,8 @@ export async function summarizeDroppedMessages(params: {
   if (chunks.length === 0) chunks.push(dropped);
 
   let summary: string | undefined;
+  const unsummarized: ModelMessage[] = [];
+  let lastError: unknown;
 
   for (const chunk of chunks) {
     const transcript = formatTranscript(chunk);
@@ -231,15 +233,21 @@ export async function summarizeDroppedMessages(params: {
       });
       summary = text;
     } catch (err) {
+      lastError = err;
+      unsummarized.push(...chunk);
       console.warn("Dropped message summarization LLM call failed, using fallback", err);
     }
   }
 
-  if (summary === undefined) return capSummary(previousSummary ?? "");
+  if (summary === undefined) {
+    throw new Error("Dropped message summarization failed for every chunk", {
+      cause: lastError,
+    });
+  }
 
   // Quality guard with retry
   const audit = auditSummaryQuality(summary);
-  if (audit.ok) return capSummary(summary);
+  if (audit.ok) return { summary: capSummary(summary), unsummarized };
 
   let best: string = summary;
   for (let attempt = 0; attempt < maxRetries; attempt++) {
@@ -249,14 +257,14 @@ export async function summarizeDroppedMessages(params: {
         maxOutputTokens: MAX_SUMMARY_TOKENS,
       });
       const retryAudit = auditSummaryQuality(text);
-      if (retryAudit.ok) return capSummary(text);
+      if (retryAudit.ok) return { summary: capSummary(text), unsummarized };
       best = text;
     } catch (err) {
       console.warn("Dropped message summarization retry failed", err);
     }
   }
 
-  return capSummary(best);
+  return { summary: capSummary(best), unsummarized };
 }
 
 // ============================================================================

--- a/packages/core/tests/chat-store.test.ts
+++ b/packages/core/tests/chat-store.test.ts
@@ -3,6 +3,7 @@ import {
   existsSync,
   mkdtempSync,
   readdirSync,
+  readFileSync,
   rmSync,
   statSync,
   writeFileSync,
@@ -29,10 +30,16 @@ function listArchives(chatId: string): string[] {
     .sort();
 }
 
+function listPrecompactArchives(chatId: string): string[] {
+  return readdirSync(sessionsDir)
+    .filter((f) => f.startsWith(`${chatId}.jsonl.precompact.`))
+    .sort();
+}
+
 const MS_PER_DAY = 86_400_000;
 
-function plantArchive(chatId: string, date: Date): string {
-  const name = `${chatId}.jsonl.reset.${date.toISOString().replace(/:/g, "-")}`;
+function plantArchive(chatId: string, date: Date, suffix = "reset"): string {
+  const name = `${chatId}.jsonl.${suffix}.${date.toISOString().replace(/:/g, "-")}`;
   writeFileSync(join(sessionsDir, name), "{}\n", "utf-8");
   return name;
 }
@@ -143,5 +150,67 @@ describe("ChatStore.archiveAndReset — opt-in age-based retention", () => {
     store.archiveAndReset("123");
 
     expect(listArchives("123")).toContain(ancient);
+  });
+});
+
+describe("ChatStore.archivePreCompact — pre-compaction archives", () => {
+  it("copies the session file, leaving the original intact", () => {
+    const store = new ChatStore(dataDir);
+    store.appendMessage("123", "user", "precious context");
+
+    store.archivePreCompact("123");
+
+    expect(store.hasSession("123")).toBe(true);
+    expect(readFileSync(join(sessionsDir, "123.jsonl"), "utf-8")).toContain("precious context");
+    const archives = listPrecompactArchives("123");
+    expect(archives).toHaveLength(1);
+    expect(readFileSync(join(sessionsDir, archives[0]), "utf-8")).toContain("precious context");
+  });
+
+  it("writes the archive with owner-only 0o600", () => {
+    const store = new ChatStore(dataDir);
+    store.appendMessage("123", "user", "precious context");
+
+    store.archivePreCompact("123");
+
+    const archives = listPrecompactArchives("123");
+    expect(statSync(join(sessionsDir, archives[0])).mode & 0o777).toBe(0o600);
+  });
+
+  it("is a no-op when no live session exists", () => {
+    const store = new ChatStore(dataDir);
+
+    store.archivePreCompact("ghost");
+
+    expect(existsSync(join(sessionsDir, "ghost.jsonl"))).toBe(false);
+    expect(listPrecompactArchives("ghost")).toHaveLength(0);
+  });
+
+  it("never prunes pre-compaction archives when retention is disabled", () => {
+    const store = new ChatStore(dataDir);
+    const old = plantArchive("123", new Date(Date.now() - 40 * MS_PER_DAY), "precompact");
+
+    store.appendMessage("123", "user", "hello");
+    store.archivePreCompact("123");
+
+    expect(listPrecompactArchives("123")).toContain(old);
+  });
+
+  it("prunes only its own suffix when opt-in retention is active", () => {
+    const store = new ChatStore(dataDir, 30);
+    const oldPrecompact = plantArchive("123", new Date(Date.now() - 40 * MS_PER_DAY), "precompact");
+    const oldReset = plantArchive("123", new Date(Date.now() - 40 * MS_PER_DAY), "reset");
+
+    store.appendMessage("123", "user", "hello");
+    store.archivePreCompact("123");
+
+    expect(listPrecompactArchives("123")).not.toContain(oldPrecompact);
+    expect(listPrecompactArchives("123")).toHaveLength(1);
+    expect(listArchives("123")).toContain(oldReset);
+
+    store.archiveAndReset("123");
+
+    expect(listArchives("123")).not.toContain(oldReset);
+    expect(listPrecompactArchives("123")).toHaveLength(1);
   });
 });

--- a/packages/core/tests/compaction.test.ts
+++ b/packages/core/tests/compaction.test.ts
@@ -6,6 +6,7 @@ import {
   summarizeDroppedMessages,
   summarizeInStages,
 } from "../src/agent/compaction.js";
+import { makeSummaryMessage, SUMMARY_PREFIX } from "../src/agent/history-limit.js";
 import { createFakeLLM } from "./helpers/fake-llm.js";
 
 // ─── Test helpers ─────────────────────────────────────────────────────
@@ -217,5 +218,120 @@ describe("summarizeDroppedMessages failure containment", () => {
 
     expect(result).toEqual({ summary: "prior", unsummarized: [] });
     expect(llm.capturedPrompts).toHaveLength(0);
+  });
+});
+
+describe("shared audit post-step (cap-before-audit)", () => {
+  const PREVIOUS_SUMMARY = "## Athlete Profile\n- FTP 247W baseline established";
+
+  it("staged summarization retries a sectionless summary and returns the restructured one", async () => {
+    const spy = createFakeLLM(["just some unstructured text", VALID_FIVE_SECTION_SUMMARY]);
+
+    const result = await summarizeInStages({
+      messages: REPRESENTATIVE_CONVERSATION,
+      llm: spy,
+      mustPreserveTokens: CYCLING_VOCABULARY,
+      memory: EMPTY_SNAPSHOT,
+      recentToKeep: 2,
+    });
+
+    expect(spy.capturedPrompts).toHaveLength(2);
+    expect(spy.capturedPrompts[1]).toContain("Restructure the following summary");
+    for (const opts of spy.capturedOpts) {
+      expect(opts.maxOutputTokens).toBe(1000);
+    }
+    expect(result[0].content).toContain("## Coach Stance");
+    expect(result[0].content).toContain("## Pending Questions");
+    expect(result).toHaveLength(3);
+  });
+
+  it("staged summarization that stays sectionless degrades to the capped text instead of throwing", async () => {
+    const spy = createFakeLLM(["no sections here", "still no sections"]);
+
+    const result = await summarizeInStages({
+      messages: REPRESENTATIVE_CONVERSATION,
+      llm: spy,
+      mustPreserveTokens: CYCLING_VOCABULARY,
+      memory: EMPTY_SNAPSHOT,
+      recentToKeep: 2,
+    });
+
+    expect(spy.capturedPrompts).toHaveLength(2);
+    expect(result[0].content).toContain("still no sections");
+    expect(result).toHaveLength(3);
+  });
+
+  it("audits the capped text, not the pre-cap text: tail-amputated sections trigger the retry", async () => {
+    const tailBeyondCap =
+      "## Athlete Profile\n- FTP 247W\n" +
+      "x".repeat(4100) +
+      "\n## Training Status\n## Coach Stance\n## Discussion Context\n## Pending Questions";
+    const spy = createFakeLLM([tailBeyondCap, VALID_FIVE_SECTION_SUMMARY]);
+
+    const { summary, unsummarized } = await summarizeDroppedMessages({
+      dropped: REPRESENTATIVE_CONVERSATION,
+      llm: spy,
+      mustPreserveTokens: CYCLING_VOCABULARY,
+      memory: EMPTY_SNAPSHOT,
+    });
+
+    expect(spy.capturedPrompts).toHaveLength(2);
+    expect(summary).toBe(VALID_FIVE_SECTION_SUMMARY);
+    expect(unsummarized).toEqual([]);
+  });
+
+  it("every summarization call carries the 1000-token generation bound", async () => {
+    const spy = createFakeLLM(["sectionless", "still sectionless"]);
+
+    await summarizeDroppedMessages({
+      dropped: REPRESENTATIVE_CONVERSATION,
+      llm: spy,
+      mustPreserveTokens: CYCLING_VOCABULARY,
+      memory: EMPTY_SNAPSHOT,
+    });
+
+    expect(spy.capturedOpts.length).toBeGreaterThanOrEqual(2);
+    for (const opts of spy.capturedOpts) {
+      expect(opts.maxOutputTokens).toBe(1000);
+    }
+  });
+
+  it("a leading summary message reaches summarizeInStages as previousSummary, not as a transcript line", async () => {
+    const spy = createFakeLLM([VALID_FIVE_SECTION_SUMMARY]);
+
+    await summarizeInStages({
+      messages: [makeSummaryMessage(PREVIOUS_SUMMARY), ...REPRESENTATIVE_CONVERSATION],
+      llm: spy,
+      mustPreserveTokens: CYCLING_VOCABULARY,
+      memory: EMPTY_SNAPSHOT,
+      recentToKeep: 2,
+    });
+
+    const prompt = spy.capturedPrompts[0];
+    expect(prompt).toContain("Existing summary of earlier context:");
+    expect(prompt).toContain("FTP 247W baseline established");
+    expect(prompt).not.toContain(`system: ${SUMMARY_PREFIX}`);
+  });
+
+  it("both update prompts carry the PRESERVE-prior-summary rule", async () => {
+    const spy = createFakeLLM([VALID_FIVE_SECTION_SUMMARY, VALID_FIVE_SECTION_SUMMARY]);
+
+    await summarizeDroppedMessages({
+      dropped: REPRESENTATIVE_CONVERSATION,
+      llm: spy,
+      mustPreserveTokens: CYCLING_VOCABULARY,
+      memory: EMPTY_SNAPSHOT,
+      previousSummary: PREVIOUS_SUMMARY,
+    });
+    await summarizeInStages({
+      messages: REPRESENTATIVE_CONVERSATION,
+      llm: spy,
+      mustPreserveTokens: CYCLING_VOCABULARY,
+      memory: EMPTY_SNAPSHOT,
+      recentToKeep: 2,
+    });
+
+    expect(spy.capturedPrompts[0]).toContain("PRESERVE every fact in it");
+    expect(spy.capturedPrompts[1]).toContain("PRESERVE every fact in it");
   });
 });

--- a/packages/core/tests/compaction.test.ts
+++ b/packages/core/tests/compaction.test.ts
@@ -158,3 +158,64 @@ describe("compaction (sport-parameterized)", () => {
     expect(audit.missing).toEqual(["## Coach Stance"]);
   });
 });
+
+describe("summarizeDroppedMessages failure containment", () => {
+  it("throws when every chunk fails", async () => {
+    const llm = createFakeLLM([{ error: new Error("boom") }], { repeatLast: true });
+
+    await expect(
+      summarizeDroppedMessages({
+        dropped: REPRESENTATIVE_CONVERSATION,
+        llm,
+        mustPreserveTokens: [],
+        memory: EMPTY_SNAPSHOT,
+      }),
+    ).rejects.toThrow("Dropped message summarization failed for every chunk");
+  });
+
+  it("requeues the failed chunk's messages when one chunk fails", async () => {
+    const firstMessage: ModelMessage = { role: "user", content: "CHUNK-A " + "a".repeat(20_000) };
+    const secondMessage: ModelMessage = { role: "user", content: "CHUNK-B " + "b".repeat(20_000) };
+    const llm = createFakeLLM([{ error: new Error("boom") }, VALID_FIVE_SECTION_SUMMARY]);
+
+    const result = await summarizeDroppedMessages({
+      dropped: [firstMessage, secondMessage],
+      llm,
+      mustPreserveTokens: [],
+      memory: EMPTY_SNAPSHOT,
+      contextWindowTokens: 30_000,
+    });
+
+    expect(result.unsummarized).toEqual([firstMessage]);
+    expect(result.summary).toContain("## Coach Stance");
+  });
+
+  it("returns an empty requeue on success", async () => {
+    const llm = createFakeLLM([VALID_FIVE_SECTION_SUMMARY]);
+
+    const result = await summarizeDroppedMessages({
+      dropped: REPRESENTATIVE_CONVERSATION,
+      llm,
+      mustPreserveTokens: [],
+      memory: EMPTY_SNAPSHOT,
+    });
+
+    expect(result.unsummarized).toEqual([]);
+    expect(result.summary).toContain("## Coach Stance");
+  });
+
+  it("short-circuits empty dropped without an LLM call", async () => {
+    const llm = createFakeLLM([VALID_FIVE_SECTION_SUMMARY]);
+
+    const result = await summarizeDroppedMessages({
+      dropped: [],
+      llm,
+      mustPreserveTokens: [],
+      memory: EMPTY_SNAPSHOT,
+      previousSummary: "prior",
+    });
+
+    expect(result).toEqual({ summary: "prior", unsummarized: [] });
+    expect(llm.capturedPrompts).toHaveLength(0);
+  });
+});

--- a/packages/core/tests/trim-compaction-guard.test.ts
+++ b/packages/core/tests/trim-compaction-guard.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  mkdtempSync,
+  rmSync,
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  readdirSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { baseAgentConfig } from "./helpers/base-agent-config.js";
+import { cyclingSport } from "@enduragent/sport-cycling";
+import type { Sport } from "../src/sport.js";
+
+let tempHome: string;
+let origHome: string | undefined;
+let dataDir: string;
+
+beforeEach(() => {
+  tempHome = mkdtempSync(join(tmpdir(), "cc-trimguard-"));
+  origHome = process.env.HOME;
+  process.env.HOME = tempHome;
+  dataDir = join(tempHome, ".cycling-coach");
+  mkdirSync(dataDir, { recursive: true });
+  mkdirSync(join(dataDir, "memory"), { recursive: true });
+  vi.resetModules();
+});
+
+afterEach(() => {
+  process.env.HOME = origHome;
+  rmSync(tempHome, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+async function setupAgent(complete: ReturnType<typeof vi.fn>) {
+  const model = {
+    id: "gpt-5.4",
+    name: "gpt-5.4",
+    api: "openai-codex-responses",
+    provider: "openai-codex",
+    baseUrl: "https://chatgpt.com/backend-api",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 272_000,
+    maxTokens: 128_000,
+  };
+
+  vi.doMock("@mariozechner/pi-ai", () => ({
+    complete,
+    getModel: vi.fn(() => model),
+  }));
+  vi.doMock("@mariozechner/pi-ai/oauth", () => ({
+    refreshOpenAICodexToken: vi.fn(),
+    loginOpenAICodex: vi.fn(),
+  }));
+  vi.doMock("../src/auth/profiles.js", () => ({
+    getFreshToken: vi.fn(async () => "token"),
+    loadProfile: vi.fn(),
+    saveProfile: vi.fn(),
+    RefreshTokenReusedError: class extends Error {},
+  }));
+
+  const { CoachAgent } = await import("../src/agent/coach-agent.js");
+  return new CoachAgent(cyclingSport as unknown as Sport, {
+    ...baseAgentConfig(dataDir),
+    contextWindowTokens: 120_000,
+  });
+}
+
+function mkAssistant(text: string, stopReason: "stop" | "length" = "stop") {
+  return {
+    role: "assistant" as const,
+    content: [{ type: "text" as const, text }],
+    api: "openai-codex-responses",
+    provider: "openai-codex",
+    model: "gpt-5.4",
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason,
+    timestamp: Date.now(),
+  };
+}
+
+function seedSession(chatId: string, lines: Array<{ role: string; content: string; ts: string }>) {
+  const sessionsDir = join(dataDir, "sessions");
+  mkdirSync(sessionsDir, { recursive: true });
+  writeFileSync(
+    join(sessionsDir, `${chatId}.jsonl`),
+    lines.map((l) => JSON.stringify(l)).join("\n") + "\n",
+    "utf-8",
+  );
+}
+
+function listPrecompact(chatId: string): string[] {
+  return readdirSync(join(dataDir, "sessions")).filter((f) =>
+    f.startsWith(`${chatId}.jsonl.precompact.`),
+  );
+}
+
+const FIVE_SECTION_SUMMARY = [
+  "## Athlete Profile",
+  "- FTP 247W, 72kg",
+  "## Training Status",
+  "- Build phase",
+  "## Coach Stance",
+  "- Hold volume this week",
+  "## Discussion Context",
+  "- Goal review",
+  "## Pending Questions",
+  "- None outstanding",
+].join("\n");
+
+const FRESH_TS = new Date().toISOString();
+const seeded = Array.from({ length: 30 }, (_, i) => ({
+  role: i % 2 === 0 ? "user" : "assistant",
+  content: `TRIM-MARK-${i} ` + "x".repeat(2_400),
+  ts: FRESH_TS,
+}));
+
+describe("trim-path compaction guard", () => {
+  it("flushes, archives, then overwrites on a successful trim", async () => {
+    let n = 0;
+    const complete = vi.fn(async () => {
+      n++;
+      if (n === 1) return mkAssistant("facts noted");
+      if (n === 2) return mkAssistant(FIVE_SECTION_SUMMARY);
+      return mkAssistant("final-reply");
+    });
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const agent = await setupAgent(complete);
+    seedSession("trim-ok", seeded);
+
+    const text = await agent.chat("trim-ok", "hello");
+
+    expect(text).toBe("final-reply");
+    expect(complete).toHaveBeenCalledTimes(3);
+
+    const archives = listPrecompact("trim-ok");
+    expect(archives).toHaveLength(1);
+    const archived = readFileSync(join(dataDir, "sessions", archives[0]), "utf-8");
+    expect(archived).toContain("TRIM-MARK-0");
+    expect(archived).toContain("TRIM-MARK-29");
+
+    const session = readFileSync(join(dataDir, "sessions", "trim-ok.jsonl"), "utf-8");
+    expect(session).toContain("## Coach Stance");
+    expect(session).toContain("TRIM-MARK-29");
+    expect(session).toContain("hello");
+    expect(session).toContain("final-reply");
+    expect(session).not.toContain("TRIM-MARK-0 ");
+
+    expect(warnSpy.mock.calls.some((c) => String(c[0]).includes("flush failed"))).toBe(false);
+  });
+
+  it("skips archive and overwrite when the flush fails; the turn still completes", async () => {
+    let n = 0;
+    const complete = vi.fn(async () => {
+      n++;
+      if (n === 1) throw new Error("boom");
+      if (n === 2) return mkAssistant(FIVE_SECTION_SUMMARY);
+      return mkAssistant("final-reply");
+    });
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const agent = await setupAgent(complete);
+    seedSession("trim-flush-fail", seeded);
+
+    const text = await agent.chat("trim-flush-fail", "hello");
+
+    expect(text).toBe("final-reply");
+    expect(complete).toHaveBeenCalledTimes(3);
+    expect(listPrecompact("trim-flush-fail")).toHaveLength(0);
+
+    const session = readFileSync(join(dataDir, "sessions", "trim-flush-fail.jsonl"), "utf-8");
+    expect(session).toContain("TRIM-MARK-0 ");
+    expect(session).not.toContain("## Coach Stance");
+
+    expect(
+      warnSpy.mock.calls.some((c) => String(c[0]).includes("Pre-compaction memory flush failed")),
+    ).toBe(true);
+  });
+
+  it("leaves history untouched when summarization fails entirely", async () => {
+    let n = 0;
+    const complete = vi.fn(async () => {
+      n++;
+      if (n === 1) return mkAssistant("facts noted");
+      if (n === 2) throw new Error("boom");
+      return mkAssistant("final-reply");
+    });
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const agent = await setupAgent(complete);
+    seedSession("trim-summary-fail", seeded);
+
+    const text = await agent.chat("trim-summary-fail", "hello");
+
+    expect(text).toBe("final-reply");
+    expect(listPrecompact("trim-summary-fail")).toHaveLength(0);
+
+    const session = readFileSync(join(dataDir, "sessions", "trim-summary-fail.jsonl"), "utf-8");
+    expect(session).toContain("TRIM-MARK-0 ");
+    expect(session).not.toContain("## Coach Stance");
+
+    expect(
+      warnSpy.mock.calls.some((c) => String(c[0]).includes("Dropped message summarization failed")),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
This change closes the data-loss holes on the most frequent compaction path — the per-turn trim that rewrites a long conversation's session file in place — and strengthens the only quality gate that guards condensed summaries.

Trim-path flush, archive, and skip-on-failure:

- Before the trim rewrites the session file, durable facts are now flushed to memory (warn-and-proceed), mirroring the session-reset flush guards. If that flush fails, the rewrite is skipped entirely so the untouched file is retried naturally on the next turn.
- Every successful trim copies the pre-rewrite transcript to a `.precompact` sidecar before overwriting, reusing the existing per-suffix archive retention machinery. Pruning stays disabled until the operator activates the opt-in retention knob, and each suffix prunes only its own archives.
- Summarization of dropped messages now returns the failed chunks' messages to the caller (persisted between the summary and the kept tail, in chronological order) instead of silently discarding them, and throws when every chunk fails so history is never replaced by an empty or partial summary. The caller's keep-history-untouched path is now actually reachable.

Shared summary-quality audit:

- The audit-and-retry is extracted into one module-private post-step used by both the trim path and the staged in-turn summarizer. The summary generation bound now matches the character cap, the audit always runs on already-capped text (so a passing summary is never amputated afterward), and the staged summarizer drops its compounding per-chunk capping.
- A leading summary message reaching the staged summarizer is now extracted into previous-summary context rather than rendered as a literal transcript line, and both summarization prompts carry a preserve-prior-summary rule so older facts are not dropped merely for being old.

Coverage: new pre-compaction-archive unit cases, dropped-message failure-containment cases, three end-to-end trim-guard tests (successful trim flushes/archives/overwrites; flush failure skips both and the turn still completes; total summarization failure leaves history untouched), and six cap-before-audit cases across both pipelines. Full suite green; the failure-path tests are red against the pre-change source.
