### PR TITLE
fix(core): quarantine corrupt session lines and surface reset failures

### DIFF
--- a/.changeset/session-corrupt-tolerance.md
+++ b/.changeset/session-corrupt-tolerance.md
@@ -1,0 +1,15 @@
+---
+"@enduragent/core": patch
+"cycling-coach": patch
+---
+
+User-facing: A damaged conversation file no longer blocks the chat — unreadable lines are set aside and the rest of your conversation loads normally.
+
+User-facing: /start now tells you when a session reset fails instead of replying with the usual welcome as if it had succeeded.
+
+The session JSONL loader tolerates torn or malformed lines: invalid lines
+are quarantined verbatim to a timestamped .corrupt sidecar next to the
+session file, the session file is rewritten with only the valid lines, and
+loading never throws on corruption. The pre-reset session read is now
+best-effort (warn and archive anyway), so the reset path can no longer be
+gated behind a successful read of the state it exists to discard.

--- a/packages/core/src/agent/chat-store.ts
+++ b/packages/core/src/agent/chat-store.ts
@@ -28,6 +28,22 @@ interface JsonlLine {
   ts: string;
 }
 
+const VALID_ROLES = new Set(["user", "assistant", "system"]);
+
+function parseSessionLine(line: string): JsonlLine | null {
+  let value: unknown;
+  try {
+    value = JSON.parse(line);
+  } catch {
+    return null;
+  }
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  const v = value as Record<string, unknown>;
+  if (typeof v.role !== "string" || !VALID_ROLES.has(v.role)) return null;
+  if (typeof v.content !== "string" || typeof v.ts !== "string") return null;
+  return value as JsonlLine;
+}
+
 export class ChatStore {
   private sessionsDir: string;
   private resetArchiveRetentionDays: number;
@@ -50,10 +66,30 @@ export class ChatStore {
     const path = this.filePath(chatId);
     if (!existsSync(path)) return { messages: [], lastMessageTime: null };
 
-    const raw = readFileSync(path, "utf-8").trim();
-    if (!raw) return { messages: [], lastMessageTime: null };
+    const lines = readFileSync(path, "utf-8")
+      .split("\n")
+      .filter((line) => line.trim() !== "");
+    const good: string[] = [];
+    const corrupt: string[] = [];
+    const parsed: JsonlLine[] = [];
+    for (const line of lines) {
+      const entry = parseSessionLine(line);
+      if (entry === null) {
+        corrupt.push(line);
+      } else {
+        good.push(line);
+        parsed.push(entry);
+      }
+    }
 
-    const parsed = raw.split("\n").map((line) => JSON.parse(line) as JsonlLine);
+    if (corrupt.length > 0) {
+      try {
+        this.quarantineCorruptLines(chatId, good, corrupt);
+      } catch (err) {
+        console.warn("Failed to quarantine corrupt session lines; continuing with parseable lines", err);
+      }
+    }
+
     const messages = parsed.map(
       (p) => ({ role: p.role, content: p.content }) as ModelMessage,
     );
@@ -110,6 +146,26 @@ export class ChatStore {
     const ts = new Date().toISOString().replace(/:/g, "-");
     copyFileSync(path, `${path}.precompact.${ts}`);
     this.pruneArchives(chatId, "precompact");
+  }
+
+  private quarantineCorruptLines(chatId: string, good: string[], corrupt: string[]): void {
+    const path = this.filePath(chatId);
+    const ts = new Date().toISOString().replace(/:/g, "-");
+    const sidecarPath = `${path}.corrupt.${ts}`;
+    appendFileSync(sidecarPath, corrupt.join("\n") + "\n", { encoding: "utf-8", mode: 0o600 });
+    if (good.length === 0) {
+      unlinkSync(path);
+      console.warn(
+        `Quarantined ${corrupt.length} corrupt session line(s) to ${sidecarPath}; removed empty session`,
+      );
+      return;
+    }
+    const tmpPath = `${path}.tmp`;
+    writeFileSync(tmpPath, good.join("\n") + "\n", { encoding: "utf-8", mode: 0o600 });
+    renameSync(tmpPath, path);
+    console.warn(
+      `Quarantined ${corrupt.length} corrupt session line(s) to ${sidecarPath}; kept ${good.length} valid line(s)`,
+    );
   }
 
   private pruneArchives(chatId: string, suffix: "reset" | "precompact"): void {

--- a/packages/core/src/agent/coach-agent.ts
+++ b/packages/core/src/agent/coach-agent.ts
@@ -260,7 +260,12 @@ export class CoachAgent {
 
   async resetSession(chatId: string): Promise<void> {
     // Flush before reset to avoid losing un-persisted context
-    const { messages: history } = this.chatStore.load(chatId);
+    let history: ModelMessage[] = [];
+    try {
+      ({ messages: history } = this.chatStore.load(chatId));
+    } catch (err) {
+      console.warn("Pre-reset session load failed; archiving session anyway", err);
+    }
     if (history.length > 0) {
       try {
         await this.flushMemory(history);

--- a/packages/core/src/channels/telegram.ts
+++ b/packages/core/src/channels/telegram.ts
@@ -118,6 +118,10 @@ export function createTelegramBot(
       await agent.resetSession(`telegram:${ctx.chat.id}`);
     } catch (err) {
       console.error("Error resetting session:", err);
+      await ctx.reply(
+        "Something went wrong resetting your session — your history is untouched. Please try /start again.",
+      );
+      return;
     }
     await ctx.reply(WELCOME_MESSAGE);
   });

--- a/packages/core/tests/chat-store-corrupt-tolerance.test.ts
+++ b/packages/core/tests/chat-store-corrupt-tolerance.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ChatStore } from "../src/agent/chat-store.js";
+
+let dataDir: string;
+let sessionsDir: string;
+
+beforeEach(() => {
+  dataDir = mkdtempSync(join(tmpdir(), "cc-corrupt-store-"));
+  sessionsDir = join(dataDir, "sessions");
+});
+
+afterEach(() => {
+  rmSync(dataDir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+const VALID_A = JSON.stringify({ role: "user", content: "we agreed: hold volume", ts: "2020-01-01T10:00:00.000Z" });
+const VALID_B = JSON.stringify({ role: "assistant", content: "yes - recheck Friday", ts: "2020-01-01T10:00:05.000Z" });
+const TORN = '{"role":"user","content":"torn mid-wri';
+
+function seedRaw(chatId: string, content: string): void {
+  writeFileSync(join(sessionsDir, `${chatId}.jsonl`), content, "utf-8");
+}
+function sidecars(chatId: string): string[] {
+  return readdirSync(sessionsDir).filter((f) => f.startsWith(`${chatId}.jsonl.corrupt.`)).sort();
+}
+
+describe("ChatStore.load corrupt-line tolerance", () => {
+  it("torn trailing line: survivors load, sidecar holds the torn bytes, file heals", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const store = new ChatStore(dataDir);
+    seedRaw("123", `${VALID_A}\n${VALID_B}\n${TORN}`);
+
+    const { messages, lastMessageTime } = store.load("123");
+
+    expect(messages).toEqual([
+      { role: "user", content: "we agreed: hold volume" },
+      { role: "assistant", content: "yes - recheck Friday" },
+    ]);
+    expect(lastMessageTime).toBe("2020-01-01T10:00:05.000Z");
+
+    const side = sidecars("123");
+    expect(side).toHaveLength(1);
+    expect(readFileSync(join(sessionsDir, side[0]), "utf-8")).toBe(TORN + "\n");
+
+    expect(readFileSync(join(sessionsDir, "123.jsonl"), "utf-8")).toBe(`${VALID_A}\n${VALID_B}\n`);
+
+    expect(
+      warnSpy.mock.calls.some((c) => String(c[0]).includes("corrupt session line")),
+    ).toBe(true);
+  });
+
+  it("corrupt middle line: order preserved", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const store = new ChatStore(dataDir);
+    seedRaw("123", `${VALID_A}\nnot json at all\n${VALID_B}\n`);
+
+    const { messages, lastMessageTime } = store.load("123");
+
+    expect(messages).toEqual([
+      { role: "user", content: "we agreed: hold volume" },
+      { role: "assistant", content: "yes - recheck Friday" },
+    ]);
+    expect(lastMessageTime).toBe("2020-01-01T10:00:05.000Z");
+
+    const side = sidecars("123");
+    expect(side).toHaveLength(1);
+    expect(readFileSync(join(sessionsDir, side[0]), "utf-8")).toBe("not json at all\n");
+  });
+
+  it("shape-invalid JSON is quarantined too", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const store = new ChatStore(dataDir);
+    const invalidRole = '{"role":"tool","content":"x","ts":"2020-01-01T10:00:01.000Z"}';
+    const numericContent = '{"role":"user","content":42,"ts":"2020-01-01T10:00:02.000Z"}';
+    const noTs = '{"role":"user","content":"no ts"}';
+    const arr = "[1,2]";
+    const bareStr = '"just a string"';
+    seedRaw(
+      "123",
+      `${VALID_A}\n${invalidRole}\n${numericContent}\n${noTs}\n${arr}\n${bareStr}`,
+    );
+
+    const { messages } = store.load("123");
+
+    expect(messages).toEqual([{ role: "user", content: "we agreed: hold volume" }]);
+
+    const side = sidecars("123");
+    expect(side).toHaveLength(1);
+    const sideContent = readFileSync(join(sessionsDir, side[0]), "utf-8");
+    expect(sideContent).toContain(invalidRole);
+    expect(sideContent).toContain(numericContent);
+    expect(sideContent).toContain(noTs);
+    expect(sideContent).toContain(arr);
+    expect(sideContent).toContain(bareStr);
+    expect(sideContent).not.toContain(VALID_A);
+  });
+
+  it("all lines corrupt: empty result, session file removed, nothing lost", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const store = new ChatStore(dataDir);
+    seedRaw("123", `${TORN}\ngarbage\n`);
+
+    const result = store.load("123");
+
+    expect(result).toEqual({ messages: [], lastMessageTime: null });
+    expect(store.hasSession("123")).toBe(false);
+
+    const side = sidecars("123");
+    expect(side).toHaveLength(1);
+    const sideContent = readFileSync(join(sessionsDir, side[0]), "utf-8");
+    expect(sideContent).toContain(TORN);
+    expect(sideContent).toContain("garbage");
+  });
+
+  it("clean file: untouched, no sidecar", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const store = new ChatStore(dataDir);
+    seedRaw("123", `${VALID_A}\n${VALID_B}\n`);
+    const before = readFileSync(join(sessionsDir, "123.jsonl"), "utf-8");
+
+    const { messages } = store.load("123");
+
+    expect(messages).toEqual([
+      { role: "user", content: "we agreed: hold volume" },
+      { role: "assistant", content: "yes - recheck Friday" },
+    ]);
+    expect(readFileSync(join(sessionsDir, "123.jsonl"), "utf-8")).toBe(before);
+    expect(sidecars("123")).toEqual([]);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("healing is byte-verbatim — unknown fields survive", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const store = new ChatStore(dataDir);
+    const withExtra = JSON.stringify({ role: "user", content: "hi", ts: "2020-01-01T10:00:00.000Z", extra: 1 });
+    seedRaw("123", `${withExtra}\n${TORN}`);
+
+    store.load("123");
+
+    expect(readFileSync(join(sessionsDir, "123.jsonl"), "utf-8")).toBe(withExtra + "\n");
+  });
+
+  it("blank interior lines are dropped silently, not quarantined", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const store = new ChatStore(dataDir);
+    seedRaw("123", `${VALID_A}\n\n   \n${VALID_B}\n`);
+
+    const { messages } = store.load("123");
+
+    expect(messages).toEqual([
+      { role: "user", content: "we agreed: hold volume" },
+      { role: "assistant", content: "yes - recheck Friday" },
+    ]);
+    expect(sidecars("123")).toEqual([]);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("modes: sidecar and healed file are 0o600", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const store = new ChatStore(dataDir);
+    seedRaw("123", `${VALID_A}\n${VALID_B}\n${TORN}`);
+
+    store.load("123");
+
+    const p = join(sessionsDir, sidecars("123")[0]);
+    expect(statSync(p).mode & 0o777).toBe(0o600);
+    expect(statSync(join(sessionsDir, "123.jsonl")).mode & 0o777).toBe(0o600);
+  });
+
+  it("idempotent: a second load after healing creates no second sidecar", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const store = new ChatStore(dataDir);
+    seedRaw("123", `${VALID_A}\n${VALID_B}\n${TORN}`);
+
+    store.load("123");
+    const afterFirst = readFileSync(join(sessionsDir, "123.jsonl"), "utf-8");
+    store.load("123");
+    const afterSecond = readFileSync(join(sessionsDir, "123.jsonl"), "utf-8");
+
+    expect(sidecars("123")).toHaveLength(1);
+    expect(afterSecond).toBe(afterFirst);
+  });
+
+  it("quarantine failure is best-effort: load still returns the parseable messages", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const store = new ChatStore(dataDir);
+    seedRaw("123", `${VALID_A}\n${VALID_B}\n${TORN}`);
+    mkdirSync(join(sessionsDir, "123.jsonl.tmp"));
+
+    const { messages, lastMessageTime } = store.load("123");
+
+    expect(messages).toEqual([
+      { role: "user", content: "we agreed: hold volume" },
+      { role: "assistant", content: "yes - recheck Friday" },
+    ]);
+    expect(lastMessageTime).toBe("2020-01-01T10:00:05.000Z");
+    expect(readFileSync(join(sessionsDir, "123.jsonl"), "utf-8")).toBe(
+      `${VALID_A}\n${VALID_B}\n${TORN}`,
+    );
+    expect(
+      warnSpy.mock.calls.some((c) => String(c[0]).includes("Failed to quarantine")),
+    ).toBe(true);
+  });
+});

--- a/packages/core/tests/session-corrupt-recovery.test.ts
+++ b/packages/core/tests/session-corrupt-recovery.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  mkdtempSync,
+  rmSync,
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  readdirSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { baseAgentConfig } from "./helpers/base-agent-config.js";
+import { cyclingSport } from "@enduragent/sport-cycling";
+import type { Sport } from "../src/sport.js";
+
+let tempHome: string;
+let origHome: string | undefined;
+let dataDir: string;
+
+beforeEach(() => {
+  tempHome = mkdtempSync(join(tmpdir(), "cc-corrupt-recovery-"));
+  origHome = process.env.HOME;
+  process.env.HOME = tempHome;
+  dataDir = join(tempHome, ".cycling-coach");
+  mkdirSync(dataDir, { recursive: true });
+  mkdirSync(join(dataDir, "memory"), { recursive: true });
+  vi.resetModules();
+});
+
+afterEach(() => {
+  process.env.HOME = origHome;
+  rmSync(tempHome, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+async function setupAgent(complete: ReturnType<typeof vi.fn>) {
+  const model = {
+    id: "gpt-5.4",
+    name: "gpt-5.4",
+    api: "openai-codex-responses",
+    provider: "openai-codex",
+    baseUrl: "https://chatgpt.com/backend-api",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 272_000,
+    maxTokens: 128_000,
+  };
+
+  vi.doMock("@mariozechner/pi-ai", () => ({
+    complete,
+    getModel: vi.fn(() => model),
+  }));
+  vi.doMock("@mariozechner/pi-ai/oauth", () => ({
+    refreshOpenAICodexToken: vi.fn(),
+    loginOpenAICodex: vi.fn(),
+  }));
+  vi.doMock("../src/auth/profiles.js", () => ({
+    getFreshToken: vi.fn(async () => "token"),
+    loadProfile: vi.fn(),
+    saveProfile: vi.fn(),
+    RefreshTokenReusedError: class extends Error {},
+  }));
+
+  const { CoachAgent } = await import("../src/agent/coach-agent.js");
+  return new CoachAgent(cyclingSport as unknown as Sport, baseAgentConfig(dataDir));
+}
+
+function mkAssistant(text: string, stopReason: "stop" | "length" = "stop") {
+  return {
+    role: "assistant" as const,
+    content: [{ type: "text" as const, text }],
+    api: "openai-codex-responses",
+    provider: "openai-codex",
+    model: "gpt-5.4",
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason,
+    timestamp: Date.now(),
+  };
+}
+
+const STALE_TS = "2020-01-01T00:00:00.000Z";
+
+function seedRaw(chatId: string, content: string): void {
+  const sessionsDir = join(dataDir, "sessions");
+  mkdirSync(sessionsDir, { recursive: true });
+  writeFileSync(join(sessionsDir, `${chatId}.jsonl`), content, "utf-8");
+}
+
+function listArchives(chatId: string): string[] {
+  return readdirSync(join(dataDir, "sessions")).filter((f) =>
+    f.startsWith(`${chatId}.jsonl.reset.`),
+  );
+}
+
+function listSidecars(chatId: string): string[] {
+  return readdirSync(join(dataDir, "sessions")).filter((f) =>
+    f.startsWith(`${chatId}.jsonl.corrupt.`),
+  );
+}
+
+describe("CoachAgent corrupt-session recovery", () => {
+  it("resetSession recovers a corrupt session: archive + sidecar, no throw", async () => {
+    const complete = vi.fn(async () => mkAssistant("noted"));
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const agent = await setupAgent(complete);
+    const valid = JSON.stringify({ role: "user", content: "we agreed: hold volume", ts: STALE_TS });
+    seedRaw("corrupt-reset", `${valid}\n{"role":"assistant","content":"torn mid-wri`);
+
+    await expect(agent.resetSession("corrupt-reset")).resolves.toBeUndefined();
+
+    expect(complete).toHaveBeenCalledTimes(1);
+    expect(agent.hasSession("corrupt-reset")).toBe(false);
+
+    const archives = listArchives("corrupt-reset");
+    expect(archives).toHaveLength(1);
+    expect(readFileSync(join(dataDir, "sessions", archives[0]), "utf-8")).toContain("hold volume");
+
+    const side = listSidecars("corrupt-reset");
+    expect(side).toHaveLength(1);
+    expect(readFileSync(join(dataDir, "sessions", side[0]), "utf-8")).toContain("torn mid-wri");
+  });
+
+  it("chat() continues over a corrupt fresh session", async () => {
+    const complete = vi.fn(async () => mkAssistant("recovered-reply"));
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const agent = await setupAgent(complete);
+    const fresh = JSON.stringify({ role: "user", content: "earlier turn", ts: new Date().toISOString() });
+    seedRaw("corrupt-chat", `${fresh}\n{"role":"assistant","content":"torn mid-wri`);
+
+    const text = await agent.chat("corrupt-chat", "hello");
+
+    expect(text).toBe("recovered-reply");
+    expect(complete).toHaveBeenCalledTimes(1);
+    expect(listSidecars("corrupt-chat")).toHaveLength(1);
+
+    const session = readFileSync(join(dataDir, "sessions", "corrupt-chat.jsonl"), "utf-8");
+    expect(session).toContain("earlier turn");
+    expect(session).toContain("hello");
+    expect(session).toContain("recovered-reply");
+    expect(session).not.toContain("torn mid-wri");
+  });
+
+  it("resetSession archives even when the session read itself fails (load guard)", async () => {
+    const complete = vi.fn();
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const agent = await setupAgent(complete);
+    mkdirSync(join(dataDir, "sessions", "unreadable.jsonl"), { recursive: true });
+
+    await expect(agent.resetSession("unreadable")).resolves.toBeUndefined();
+
+    expect(
+      warnSpy.mock.calls.some((c) => String(c[0]).includes("Pre-reset session load failed")),
+    ).toBe(true);
+    expect(complete).not.toHaveBeenCalled();
+    expect(agent.hasSession("unreadable")).toBe(false);
+  });
+});

--- a/packages/core/tests/telegram-start-reset-failure.test.ts
+++ b/packages/core/tests/telegram-start-reset-failure.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { cyclingBinary } from "./helpers/cycling-binary-fixture.js";
+
+let dataDir: string;
+
+beforeEach(() => {
+  dataDir = mkdtempSync(join(tmpdir(), "cc-tg-start-"));
+  mkdirSync(join(dataDir, "sessions"), { recursive: true });
+  vi.resetModules();
+});
+
+afterEach(() => {
+  rmSync(dataDir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+  vi.doUnmock("grammy");
+});
+
+const RESET_FAILURE_REPLY =
+  "Something went wrong resetting your session — your history is untouched. Please try /start again.";
+
+async function buildStartHandler(resetSession: ReturnType<typeof vi.fn>) {
+  const bot = { api: { sendMessage: vi.fn() }, use: vi.fn(), command: vi.fn(), on: vi.fn() };
+  vi.doMock("grammy", () => ({
+    Bot: function FakeBot() {
+      return bot;
+    },
+    InputFile: class {},
+  }));
+  vi.spyOn(console, "error").mockImplementation(() => {});
+  const agent = { resetSession, chat: vi.fn(), hasSession: vi.fn() };
+
+  const { createTelegramBot } = await import("../src/channels/telegram.js");
+  createTelegramBot(
+    "FAKE_TOKEN",
+    agent as unknown as Parameters<typeof createTelegramBot>[1],
+    cyclingBinary,
+    dataDir,
+  );
+
+  const start = bot.command.mock.calls.find((c: unknown[]) => c[0] === "start")![1];
+  return start;
+}
+
+describe("/start reset-failure reply", () => {
+  it("reset rejection → exact failure reply, no Welcome", async () => {
+    const resetSession = vi.fn(async () => {
+      throw new Error("boom");
+    });
+    const start = await buildStartHandler(resetSession);
+    const ctx = { chat: { id: 777 }, reply: vi.fn(async () => undefined) };
+
+    await start(ctx);
+
+    expect(ctx.reply).toHaveBeenCalledTimes(1);
+    expect(ctx.reply).toHaveBeenCalledWith(RESET_FAILURE_REPLY);
+    expect(
+      ctx.reply.mock.calls.some((c: unknown[]) => String(c[0]).includes("Welcome to Cycling Coach")),
+    ).toBe(false);
+  });
+
+  it("reset success → Welcome, no failure copy", async () => {
+    const resetSession = vi.fn(async () => undefined);
+    const start = await buildStartHandler(resetSession);
+    const ctx = { chat: { id: 777 }, reply: vi.fn(async () => undefined) };
+
+    await start(ctx);
+
+    expect(ctx.reply).toHaveBeenCalledTimes(1);
+    expect(
+      ctx.reply.mock.calls.some((c: unknown[]) =>
+        String(c[0]).startsWith("Welcome to Cycling Coach!"),
+      ),
+    ).toBe(true);
+    expect(
+      ctx.reply.mock.calls.some((c: unknown[]) =>
+        String(c[0]).includes("Something went wrong resetting"),
+      ),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
A single torn or malformed line in a per-chat session JSONL file used to brick the product end to end: the loader ran a zero-tolerance JSON.parse on every line, so one bad line threw before any reply could be produced, every reset path threw the same way (the reset read the very state it exists to discard), and /start caught the failure but still replied with the full Welcome message as if the reset had succeeded. A non-atomic two-append-per-turn write, an out-of-space condition, a crash mid-write, or a hand-edit of this user-accessible file all produce such a partial line, making the loss permanent and unrecoverable from inside the product.

This change adds three small, read-side fixes:

- Per-line corrupt tolerance in the loader. Each line that fails to parse, or parses to the wrong shape (role not one of user/assistant/system, non-string content, or missing ts), is quarantined verbatim into a timestamped .corrupt sidecar next to the session file. The session file is then rewritten with only the valid lines using an atomic temp-file-plus-rename, byte-verbatim so original timestamps and any unknown fields survive. Loading never throws on corruption; nothing is silently deleted. If every line is corrupt the session file is removed and the athlete is treated as a fresh session, with every original byte preserved in the sidecar. The quarantine step is itself best-effort: if the heal cannot land it warns and still returns the parseable messages. Sidecars are never pruned.

- The pre-reset session read is now best-effort. A read failure no longer prevents the archive: the reset warns, proceeds with empty history, and always archives. This composes with the existing best-effort pre-reset memory flush guard.

- /start now reports the truth. When a reset actually fails, the handler replies with an honest failure message instead of the Welcome message.

Three new test files cover the tolerant loader (including byte-verbatim healing, 0600 file modes, idempotence, and best-effort behavior under a disk fault), the honest /start failure reply, and agent-layer recovery over a corrupt session.

This is the read-side quarantine only. The write-side persistence guard and the flush retry/observability follow-up are separate, later work.
