### PR TITLE
fix(core): add memory-flush outcome detection, retry, and reset-failure disclosure

### DIFF
--- a/.changeset/flush-observability-retry.md
+++ b/.changeset/flush-observability-retry.md
@@ -1,0 +1,14 @@
+---
+"@enduragent/core": patch
+"cycling-coach": patch
+---
+
+User-facing: If the coach can't fully reset your previous session, it now says so ("some earlier context may still apply") instead of failing silently.
+
+Memory flushes now return a structured outcome ({writes, ledgerAppends,
+finishReason, usage, shrunkSections}) instead of discarding the model
+result. A flush that writes nothing on a non-trivial conversation, or
+that shrinks a memory section by more than 30%, emits a structured warn
+event (char counts only — never section content). The flush trigger
+paths gain bounded retry and a degradation policy that defers the
+session archive when extraction visibly failed.

--- a/packages/core/src/agent/coach-agent.ts
+++ b/packages/core/src/agent/coach-agent.ts
@@ -22,7 +22,8 @@ import {
   TIMEOUT_COMPACTION_THRESHOLD,
 } from "./token-utils.js";
 import { summarizeInStages, summarizeDroppedMessages } from "./compaction.js";
-import { runMemoryFlush } from "./memory-flush.js";
+import { runMemoryFlush, FLUSH_ZERO_WRITE_MIN_MESSAGES } from "./memory-flush.js";
+import type { MemoryFlushOutcome } from "./memory-flush.js";
 import { evaluateSessionFreshness } from "./session-freshness.js";
 import { LLM } from "../llm.js";
 import { createMemorySnapshot } from "../memory/snapshot.js";
@@ -35,6 +36,14 @@ const RATE_LIMIT_FALLBACK_BASE_MS = 5_000;
 const RATE_LIMIT_FALLBACK_MULTIPLIER = 2;
 const RATE_LIMIT_FALLBACK_MAX_MS = 30_000;
 const RATE_LIMIT_MAX_WAIT_MS = 120_000;
+const MAX_FLUSH_ATTEMPTS = 2;
+
+type MemoryFlushTrigger =
+  | "stale-reset"
+  | "explicit-reset"
+  | "trim"
+  | "pre-compaction"
+  | "overflow-recovery";
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -53,6 +62,7 @@ export class CoachAgent {
   private tools: ToolSet;
   private systemPrompt: string;
   private tz: string;
+  private archiveDeferred = new Set<string>();
 
   constructor(sport: Sport, config: Config) {
     this.sport = sport;
@@ -83,14 +93,34 @@ export class CoachAgent {
     this.systemPrompt = "";
   }
 
-  private async flushMemory(messages: ModelMessage[]): Promise<void> {
-    await runMemoryFlush({
-      llm: this.llm,
-      messages,
-      memory: this.memory,
-      memorySections: getEffectiveSections(this.sport),
-      tz: this.tz,
-    });
+  private async flushMemory(
+    messages: ModelMessage[],
+    trigger: MemoryFlushTrigger,
+  ): Promise<MemoryFlushOutcome> {
+    let lastError: unknown;
+    for (let attempt = 1; attempt <= MAX_FLUSH_ATTEMPTS; attempt++) {
+      try {
+        return await runMemoryFlush({
+          llm: this.llm,
+          messages,
+          memory: this.memory,
+          memorySections: getEffectiveSections(this.sport),
+          tz: this.tz,
+        });
+      } catch (err) {
+        lastError = err;
+        console.warn(
+          JSON.stringify({
+            event: "memory_flush_failed",
+            trigger,
+            attempt,
+            maxAttempts: MAX_FLUSH_ATTEMPTS,
+            error: (err instanceof Error ? err.message : String(err)).slice(0, 200),
+          }),
+        );
+      }
+    }
+    throw lastError;
   }
 
   private compactionParams() {
@@ -116,15 +146,32 @@ export class CoachAgent {
 
       if (!fresh) {
         // Flush memory before reset, then archive
+        let outcome: MemoryFlushOutcome | null = null;
         if (history.length > 0) {
           try {
-            await this.flushMemory(history);
+            outcome = await this.flushMemory(history, "stale-reset");
           } catch (err) {
             console.warn("Pre-reset memory flush failed; archiving session anyway", err);
           }
         }
-        this.chatStore.archiveAndReset(chatId);
-        history = [];
+        const zeroWrite =
+          outcome !== null &&
+          outcome.writes === 0 &&
+          outcome.ledgerAppends === 0 &&
+          history.length >= FLUSH_ZERO_WRITE_MIN_MESSAGES;
+        if (zeroWrite && !this.archiveDeferred.has(chatId)) {
+          this.archiveDeferred.add(chatId);
+          console.warn(
+            JSON.stringify({
+              event: "memory_flush_archive_deferred",
+              messageCount: history.length,
+            }),
+          );
+        } else {
+          this.archiveDeferred.delete(chatId);
+          this.chatStore.archiveAndReset(chatId);
+          history = [];
+        }
       }
 
       this.systemPrompt = buildSystemPrompt(this.sport, this.memory, this.tz);
@@ -144,7 +191,7 @@ export class CoachAgent {
       if (dropped.length > 0) {
         let flushed = true;
         try {
-          await this.flushMemory(history);
+          await this.flushMemory(history, "trim");
         } catch (err) {
           flushed = false;
           console.warn("Pre-compaction memory flush failed; keeping session file unchanged", err);
@@ -192,7 +239,11 @@ export class CoachAgent {
       while (true) {
         // Preemptive: compact before sending if over budget
         if (shouldCompact({ messages, systemPrompt: this.systemPrompt, contextWindowTokens: this.config.contextWindowTokens })) {
-          await this.flushMemory(messages);
+          try {
+            await this.flushMemory(messages, "pre-compaction");
+          } catch (err) {
+            console.warn("In-turn memory flush failed; compacting without flush", err);
+          }
           messages = await summarizeInStages({ messages, ...this.compactionParams() });
           this.memory.reload();
         }
@@ -215,7 +266,11 @@ export class CoachAgent {
           // Reactive: context overflow → flush + compact + retry
           if (isContextOverflowError(err) && overflowAttempts < MAX_OVERFLOW_ATTEMPTS) {
             overflowAttempts++;
-            await this.flushMemory(messages);
+            try {
+              await this.flushMemory(messages, "overflow-recovery");
+            } catch (flushErr) {
+              console.warn("In-turn memory flush failed; compacting without flush", flushErr);
+            }
             messages = await summarizeInStages({ messages, ...this.compactionParams() });
             this.memory.reload();
             continue;
@@ -258,22 +313,27 @@ export class CoachAgent {
     return this.chatStore.hasSession(chatId);
   }
 
-  async resetSession(chatId: string): Promise<void> {
+  async resetSession(chatId: string): Promise<{ memoryFlushed: boolean }> {
     // Flush before reset to avoid losing un-persisted context
+    let memoryFlushed = true;
     let history: ModelMessage[] = [];
     try {
       ({ messages: history } = this.chatStore.load(chatId));
     } catch (err) {
+      memoryFlushed = false;
       console.warn("Pre-reset session load failed; archiving session anyway", err);
     }
     if (history.length > 0) {
       try {
-        await this.flushMemory(history);
+        await this.flushMemory(history, "explicit-reset");
       } catch (err) {
+        memoryFlushed = false;
         console.warn("Pre-reset memory flush failed; archiving session anyway", err);
       }
     }
+    this.archiveDeferred.delete(chatId);
     this.chatStore.archiveAndReset(chatId);
+    return { memoryFlushed };
   }
 
   getMemory(): Memory {

--- a/packages/core/src/agent/memory-flush.ts
+++ b/packages/core/src/agent/memory-flush.ts
@@ -5,6 +5,7 @@ import type { MemorySectionSpec } from "../sport.js";
 import type { MemoryStore } from "../memory.js";
 import { createMemoryReadTool } from "./tools.js";
 import type { LLM } from "../llm.js";
+import type { GenerateResult } from "../llm-types.js";
 import { LEDGER_EVENT_KINDS, LEDGER_DATE_PATTERN, type LedgerEventKind } from "../memory/event-ledger.js";
 import { todayInTZ } from "./user-time.js";
 
@@ -13,6 +14,18 @@ import { todayInTZ } from "./user-time.js";
 // ============================================================================
 
 export const SOFT_THRESHOLD_RATIO = 0.8;
+
+export const FLUSH_ZERO_WRITE_MIN_MESSAGES = 4;
+export const FLUSH_SHRINK_MIN_CHARS = 200;
+export const FLUSH_SHRINK_RATIO = 0.7;
+
+export interface MemoryFlushOutcome {
+  writes: number;
+  ledgerAppends: number;
+  finishReason: GenerateResult["finishReason"];
+  usage: GenerateResult["usage"];
+  shrunkSections: Array<{ section: string; beforeChars: number; afterChars: number }>;
+}
 
 // ============================================================================
 // PROMPTS
@@ -67,7 +80,11 @@ Only write sections that have new or changed information.`;
 // APPEND-ONLY MEMORY WRITE TOOL
 // ============================================================================
 
-function createFlushMemoryWriteTool(memory: MemoryStore, sections: readonly MemorySectionSpec[]) {
+function createFlushMemoryWriteTool(
+  memory: MemoryStore,
+  sections: readonly MemorySectionSpec[],
+  onWrite: () => void,
+) {
   const sectionNames = sections.map((s) => s.name) as [string, ...string[]];
   return tool({
     description: "Write to a memory section (replaces entire section content)",
@@ -79,12 +96,13 @@ function createFlushMemoryWriteTool(memory: MemoryStore, sections: readonly Memo
     ),
     execute: async (input: { section: string; content: string }) => {
       memory.writeSection(input.section, input.content, "flush");
+      onWrite();
       return { saved: true };
     },
   });
 }
 
-function createLedgerAppendTool(memory: MemoryStore) {
+function createLedgerAppendTool(memory: MemoryStore, onAppend: () => void) {
   return tool({
     description:
       "Record a dated athlete event (decision, override, illness, experiment, outcome) in the permanent event ledger. Entries are appended, never replaced.",
@@ -103,6 +121,7 @@ function createLedgerAppendTool(memory: MemoryStore) {
     ),
     execute: async (input: { date: string; kind: LedgerEventKind; text: string }) => {
       memory.appendEvent({ ...input, source: "flush" });
+      onAppend();
       return { recorded: true };
     },
   });
@@ -157,20 +176,29 @@ export async function runMemoryFlush(params: {
   memory: MemoryStore;
   memorySections: readonly MemorySectionSpec[];
   tz?: string;
-}): Promise<void> {
+}): Promise<MemoryFlushOutcome> {
   if (params.memorySections.length === 0) {
     throw new Error(
       "runMemoryFlush requires at least one memory section. " +
         "Pass getEffectiveSections(sport) — Core's shared sections guarantee non-empty.",
     );
   }
+  let writes = 0;
+  let ledgerAppends = 0;
+  const beforeChars = new Map(
+    params.memorySections.map((s) => [s.name, (params.memory.readSection(s.name) ?? "").length]),
+  );
   const flushTools = {
-    memory_write: createFlushMemoryWriteTool(params.memory, params.memorySections),
+    memory_write: createFlushMemoryWriteTool(params.memory, params.memorySections, () => {
+      writes++;
+    }),
     memory_read: createMemoryReadTool(params.memory),
-    ledger_append: createLedgerAppendTool(params.memory),
+    ledger_append: createLedgerAppendTool(params.memory, () => {
+      ledgerAppends++;
+    }),
   };
 
-  await params.llm.generate({
+  const result = await params.llm.generate({
     system: MEMORY_FLUSH_SYSTEM_PROMPT,
     messages: [
       ...params.messages,
@@ -186,4 +214,45 @@ export async function runMemoryFlush(params: {
 
   params.memory.reload();
   scanForStuckChronic(params.memory);
+
+  const shrunkSections: MemoryFlushOutcome["shrunkSections"] = [];
+  for (const spec of params.memorySections) {
+    const before = beforeChars.get(spec.name) ?? 0;
+    const after = (params.memory.readSection(spec.name) ?? "").length;
+    if (before >= FLUSH_SHRINK_MIN_CHARS && after < before * FLUSH_SHRINK_RATIO) {
+      shrunkSections.push({ section: spec.name, beforeChars: before, afterChars: after });
+      // Char counts only — section bodies are athlete data and must not land in logs.
+      console.warn(
+        JSON.stringify({
+          event: "memory_flush_section_shrunk",
+          section: spec.name,
+          beforeChars: before,
+          afterChars: after,
+        }),
+      );
+    }
+  }
+
+  if (
+    writes === 0 &&
+    ledgerAppends === 0 &&
+    params.messages.length >= FLUSH_ZERO_WRITE_MIN_MESSAGES
+  ) {
+    console.warn(
+      JSON.stringify({
+        event: "memory_flush_zero_writes",
+        messageCount: params.messages.length,
+        finishReason: result.finishReason,
+        outputTokens: result.usage.outputTokens ?? null,
+      }),
+    );
+  }
+
+  return {
+    writes,
+    ledgerAppends,
+    finishReason: result.finishReason,
+    usage: result.usage,
+    shrunkSections,
+  };
 }

--- a/packages/core/src/channels/telegram.ts
+++ b/packages/core/src/channels/telegram.ts
@@ -46,6 +46,9 @@ const WELCOME_MESSAGE =
   "/update — Check for and install updates\n\n" +
   "Or just chat with me about your training!";
 
+const RESET_CAVEAT_NOTE =
+  "Note: I couldn't fully reset our previous session, so some earlier context may still apply.";
+
 const SNAPSHOT_HELP =
   "/snapshot raw [section]    — dump pre-curation latest.json (or one section)\n" +
   "/snapshot help             — show this list\n\n" +
@@ -114,8 +117,9 @@ export function createTelegramBot(
 
   bot.command("start", async (ctx) => {
     greeted.add(ctx.chat.id);
+    let memoryFlushed = true;
     try {
-      await agent.resetSession(`telegram:${ctx.chat.id}`);
+      ({ memoryFlushed } = await agent.resetSession(`telegram:${ctx.chat.id}`));
     } catch (err) {
       console.error("Error resetting session:", err);
       await ctx.reply(
@@ -123,7 +127,9 @@ export function createTelegramBot(
       );
       return;
     }
-    await ctx.reply(WELCOME_MESSAGE);
+    await ctx.reply(
+      memoryFlushed ? WELCOME_MESSAGE : `${WELCOME_MESSAGE}\n\n${RESET_CAVEAT_NOTE}`,
+    );
   });
 
   bot.command("plan", async (ctx) => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -124,6 +124,7 @@ export {
   summarizeInStages,
 } from "./agent/compaction.js";
 export { runMemoryFlush } from "./agent/memory-flush.js";
+export type { MemoryFlushOutcome } from "./agent/memory-flush.js";
 export {
   evaluateSessionFreshness,
   resolveDailyResetAtMs,

--- a/packages/core/tests/flush-retry-degradation.test.ts
+++ b/packages/core/tests/flush-retry-degradation.test.ts
@@ -1,0 +1,251 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  mkdtempSync,
+  rmSync,
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  readdirSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { baseAgentConfig } from "./helpers/base-agent-config.js";
+import { cyclingSport } from "@enduragent/sport-cycling";
+import type { Sport } from "../src/sport.js";
+
+let tempHome: string;
+let origHome: string | undefined;
+let dataDir: string;
+
+beforeEach(() => {
+  tempHome = mkdtempSync(join(tmpdir(), "cc-flushretry-"));
+  origHome = process.env.HOME;
+  process.env.HOME = tempHome;
+  dataDir = join(tempHome, ".cycling-coach");
+  mkdirSync(dataDir, { recursive: true });
+  mkdirSync(join(dataDir, "memory"), { recursive: true });
+  vi.resetModules();
+});
+
+afterEach(() => {
+  process.env.HOME = origHome;
+  rmSync(tempHome, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+async function setupAgent(complete: ReturnType<typeof vi.fn>) {
+  const model = {
+    id: "gpt-5.4",
+    name: "gpt-5.4",
+    api: "openai-codex-responses",
+    provider: "openai-codex",
+    baseUrl: "https://chatgpt.com/backend-api",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 272_000,
+    maxTokens: 128_000,
+  };
+
+  vi.doMock("@mariozechner/pi-ai", () => ({
+    complete,
+    getModel: vi.fn(() => model),
+  }));
+  vi.doMock("@mariozechner/pi-ai/oauth", () => ({
+    refreshOpenAICodexToken: vi.fn(),
+    loginOpenAICodex: vi.fn(),
+  }));
+  vi.doMock("../src/auth/profiles.js", () => ({
+    getFreshToken: vi.fn(async () => "token"),
+    loadProfile: vi.fn(),
+    saveProfile: vi.fn(),
+    RefreshTokenReusedError: class extends Error {},
+  }));
+
+  const { CoachAgent } = await import("../src/agent/coach-agent.js");
+  return new CoachAgent(cyclingSport as unknown as Sport, baseAgentConfig(dataDir));
+}
+
+function mkAssistant(text: string, stopReason: "stop" | "length" = "stop") {
+  return {
+    role: "assistant" as const,
+    content: [{ type: "text" as const, text }],
+    api: "openai-codex-responses",
+    provider: "openai-codex",
+    model: "gpt-5.4",
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason,
+    timestamp: Date.now(),
+  };
+}
+
+function seedSession(chatId: string, lines: Array<{ role: string; content: string; ts: string }>) {
+  const sessionsDir = join(dataDir, "sessions");
+  mkdirSync(sessionsDir, { recursive: true });
+  writeFileSync(
+    join(sessionsDir, `${chatId}.jsonl`),
+    lines.map((l) => JSON.stringify(l)).join("\n") + "\n",
+    "utf-8",
+  );
+}
+
+function listArchives(chatId: string): string[] {
+  return readdirSync(join(dataDir, "sessions")).filter((f) =>
+    f.startsWith(`${chatId}.jsonl.reset.`),
+  );
+}
+
+const STALE_TS = "2020-01-01T00:00:00.000Z";
+
+const STALE_FOUR = [
+  { role: "user", content: "old-fact-1: knee niggle on long rides", ts: STALE_TS },
+  { role: "assistant", content: "old-fact-2: keep rides under two hours", ts: STALE_TS },
+  { role: "user", content: "old-fact-3: agreed to recheck next week", ts: STALE_TS },
+  { role: "assistant", content: "old-fact-4: noted, plan adjusted", ts: STALE_TS },
+];
+
+function warnEvents(warnSpy: ReturnType<typeof vi.spyOn>): Array<Record<string, unknown>> {
+  return warnSpy.mock.calls
+    .map((args: unknown[]) => {
+      try {
+        return JSON.parse(String(args[0]));
+      } catch {
+        return null;
+      }
+    })
+    .filter((e: unknown): e is Record<string, unknown> => e !== null);
+}
+
+function eventsNamed(warnSpy: ReturnType<typeof vi.spyOn>, name: string) {
+  return warnEvents(warnSpy).filter((e) => e.event === name);
+}
+
+describe("flush retry and degradation", () => {
+  it("a transient flush failure recovers via retry on resetSession", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    let n = 0;
+    const complete = vi.fn(async () => {
+      n++;
+      if (n === 1) throw new Error("boom");
+      return mkAssistant("noted");
+    });
+    const agent = await setupAgent(complete);
+    seedSession("retry-ok", STALE_FOUR.slice(0, 2));
+
+    await expect(agent.resetSession("retry-ok")).resolves.toEqual({ memoryFlushed: true });
+
+    expect(complete).toHaveBeenCalledTimes(2);
+    expect(agent.hasSession("retry-ok")).toBe(false);
+    expect(listArchives("retry-ok")).toHaveLength(1);
+
+    const failed = eventsNamed(warnSpy, "memory_flush_failed");
+    expect(failed).toHaveLength(1);
+    expect(failed[0].trigger).toBe("explicit-reset");
+    expect(failed[0].attempt).toBe(1);
+    expect(failed[0].maxAttempts).toBe(2);
+    expect(failed[0].error).toBe("boom");
+    expect(
+      warnSpy.mock.calls.some((c) => String(c[0]).includes("Pre-reset memory flush failed")),
+    ).toBe(false);
+  });
+
+  it("a persistent flush failure on resetSession degrades but still archives", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const complete = vi.fn(async () => {
+      throw new Error("boom");
+    });
+    const agent = await setupAgent(complete);
+    seedSession("retry-dead", STALE_FOUR.slice(0, 2));
+
+    await expect(agent.resetSession("retry-dead")).resolves.toEqual({ memoryFlushed: false });
+
+    expect(complete).toHaveBeenCalledTimes(2);
+    expect(listArchives("retry-dead")).toHaveLength(1);
+    expect(agent.hasSession("retry-dead")).toBe(false);
+
+    const failed = eventsNamed(warnSpy, "memory_flush_failed");
+    expect(failed).toHaveLength(2);
+    expect(failed.every((e) => e.trigger === "explicit-reset")).toBe(true);
+    expect(
+      warnSpy.mock.calls.some((c) => String(c[0]).includes("Pre-reset memory flush failed")),
+    ).toBe(true);
+  });
+
+  it("a zero-write stale flush defers the archive exactly once", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    let n = 0;
+    const complete = vi.fn(async () => {
+      n++;
+      return mkAssistant(`turn-${n}`);
+    });
+    const agent = await setupAgent(complete);
+    seedSession("defer", STALE_FOUR);
+
+    const t1 = await agent.chat("defer", "hello");
+    expect(t1).toBe("turn-2");
+    expect(listArchives("defer")).toHaveLength(0);
+    expect(eventsNamed(warnSpy, "memory_flush_archive_deferred")).toHaveLength(1);
+    expect(eventsNamed(warnSpy, "memory_flush_archive_deferred")[0].messageCount).toBe(4);
+    const afterT1 = readFileSync(join(dataDir, "sessions", "defer.jsonl"), "utf-8");
+    expect(afterT1).toContain("old-fact-1");
+    expect(afterT1).toContain("hello");
+
+    seedSession("defer", STALE_FOUR);
+
+    const t2 = await agent.chat("defer", "hello again");
+    expect(t2).toBe("turn-4");
+    const archives = listArchives("defer");
+    expect(archives).toHaveLength(1);
+    expect(readFileSync(join(dataDir, "sessions", archives[0]), "utf-8")).toContain("old-fact-1");
+    const afterT2 = readFileSync(join(dataDir, "sessions", "defer.jsonl"), "utf-8");
+    expect(afterT2).toContain("hello again");
+    expect(afterT2).not.toContain("old-fact-1");
+    expect(eventsNamed(warnSpy, "memory_flush_archive_deferred")).toHaveLength(1);
+  });
+
+  it("a zero-write flush on a short stale session archives normally", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    let n = 0;
+    const complete = vi.fn(async () => {
+      n++;
+      return mkAssistant(`turn-${n}`);
+    });
+    const agent = await setupAgent(complete);
+    seedSession("short", STALE_FOUR.slice(0, 2));
+
+    const text = await agent.chat("short", "hello");
+    expect(text).toBe("turn-2");
+    expect(listArchives("short")).toHaveLength(1);
+    expect(eventsNamed(warnSpy, "memory_flush_archive_deferred")).toHaveLength(0);
+  });
+
+  it("an overflow-recovery flush failure no longer kills the turn", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    let n = 0;
+    const complete = vi.fn(async () => {
+      n++;
+      if (n === 1) throw new Error("Request exceeds the maximum context length of 272000 tokens");
+      if (n <= 3) throw new Error("boom");
+      return mkAssistant("recovered");
+    });
+    const agent = await setupAgent(complete);
+
+    const text = await agent.chat("overflow-degrade", "hello");
+    expect(text).toBe("recovered");
+    expect(complete).toHaveBeenCalledTimes(4);
+
+    const failed = eventsNamed(warnSpy, "memory_flush_failed");
+    expect(failed).toHaveLength(2);
+    expect(failed.every((e) => e.trigger === "overflow-recovery")).toBe(true);
+    expect(
+      warnSpy.mock.calls.some((c) => String(c[0]).includes("In-turn memory flush failed")),
+    ).toBe(true);
+  });
+});

--- a/packages/core/tests/memory-flush-outcome.test.ts
+++ b/packages/core/tests/memory-flush-outcome.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ModelMessage, ToolSet } from "ai";
+import { Memory } from "../src/memory/store.js";
+import {
+  runMemoryFlush,
+  FLUSH_ZERO_WRITE_MIN_MESSAGES,
+  FLUSH_SHRINK_MIN_CHARS,
+} from "../src/agent/memory-flush.js";
+import type { MemorySectionSpec } from "../src/sport.js";
+import type { GenerateOpts } from "../src/llm-types.js";
+import { createFakeLLM, type FakeLLM, type QueuedTurn } from "./helpers/fake-llm.js";
+
+const SECTIONS: readonly MemorySectionSpec[] = [
+  { name: "goals", description: "Athlete goals" },
+  { name: "medical-history", description: "chronic conditions" },
+];
+
+const NON_TRIVIAL: ModelMessage[] = [
+  { role: "user", content: "Did 3x12 at threshold today, knee felt fine" },
+  { role: "assistant", content: "Good - keep the volume, recheck Friday" },
+  { role: "user", content: "Also switching to morning rides from next week" },
+  { role: "assistant", content: "Noted - I will plan intensity for mornings" },
+];
+
+const TRIVIAL: ModelMessage[] = [{ role: "user", content: "thanks" }];
+
+function drivenLLM(turns: QueuedTurn[], drive: (tools: ToolSet) => Promise<void>): FakeLLM {
+  const inner = createFakeLLM(turns);
+  return {
+    ...inner,
+    async generate(opts: GenerateOpts) {
+      if (opts.tools) await drive(opts.tools);
+      return inner.generate(opts);
+    },
+  } as FakeLLM;
+}
+
+describe("runMemoryFlush outcome detection", () => {
+  let dataDir: string;
+  let memoryFile: string;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    dataDir = mkdtempSync(join(tmpdir(), "cc-flushout-"));
+    mkdirSync(join(dataDir, "memory"), { recursive: true });
+    memoryFile = join(dataDir, "memory", "MEMORY.md");
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    rmSync(dataDir, { recursive: true, force: true });
+    warnSpy.mockRestore();
+  });
+
+  function warnEvents(): Array<Record<string, unknown>> {
+    return warnSpy.mock.calls
+      .map((args: unknown[]) => {
+        try {
+          return JSON.parse(String(args[0]));
+        } catch {
+          return null;
+        }
+      })
+      .filter((e: unknown): e is Record<string, unknown> => e !== null);
+  }
+
+  function eventsNamed(name: string): Array<Record<string, unknown>> {
+    return warnEvents().filter((e) => e.event === name);
+  }
+
+  it("zero-write flush on a non-trivial conversation warns and reports writes: 0", async () => {
+    const memory = new Memory(dataDir);
+    const outcome = await runMemoryFlush({
+      llm: createFakeLLM([""]),
+      messages: NON_TRIVIAL,
+      memory,
+      memorySections: SECTIONS,
+    });
+    expect(outcome.writes).toBe(0);
+    expect(outcome.ledgerAppends).toBe(0);
+    expect(outcome.finishReason).toBe("stop");
+    const zero = eventsNamed("memory_flush_zero_writes");
+    expect(zero).toHaveLength(1);
+    expect(zero[0].messageCount).toBe(NON_TRIVIAL.length);
+    expect(NON_TRIVIAL.length).toBeGreaterThanOrEqual(FLUSH_ZERO_WRITE_MIN_MESSAGES);
+  });
+
+  it("zero-write flush on a trivial conversation stays silent", async () => {
+    const memory = new Memory(dataDir);
+    const outcome = await runMemoryFlush({
+      llm: createFakeLLM([""]),
+      messages: TRIVIAL,
+      memory,
+      memorySections: SECTIONS,
+    });
+    expect(outcome.writes).toBe(0);
+    expect(eventsNamed("memory_flush_zero_writes")).toHaveLength(0);
+  });
+
+  it("ledger-append-only flush counts the append and does not warn", async () => {
+    const memory = new Memory(dataDir);
+    const llm = drivenLLM([""], async (tools) => {
+      await tools.ledger_append.execute!(
+        { date: "2026-06-01", kind: "decision", text: "hold volume this week" },
+        {} as never,
+      );
+    });
+    const outcome = await runMemoryFlush({
+      llm,
+      messages: NON_TRIVIAL,
+      memory,
+      memorySections: SECTIONS,
+    });
+    expect(outcome.writes).toBe(0);
+    expect(outcome.ledgerAppends).toBe(1);
+    expect(eventsNamed("memory_flush_zero_writes")).toHaveLength(0);
+  });
+
+  it("counts executed memory_write calls in the outcome", async () => {
+    const memory = new Memory(dataDir);
+    const llm = drivenLLM([""], async (tools) => {
+      await tools.memory_write.execute!(
+        { section: "goals", content: "Target FTP 280W by August" },
+        {} as never,
+      );
+      await tools.memory_write.execute!(
+        { section: "medical-history", content: "Asthma, mild" },
+        {} as never,
+      );
+    });
+    const outcome = await runMemoryFlush({
+      llm,
+      messages: NON_TRIVIAL,
+      memory,
+      memorySections: SECTIONS,
+    });
+    expect(outcome.writes).toBe(2);
+    expect(eventsNamed("memory_flush_zero_writes")).toHaveLength(0);
+  });
+
+  it("warns with char counts only when a section shrinks past the ratio", async () => {
+    const body = "hypertension; lisinopril 10mg; ".repeat(20);
+    writeFileSync(memoryFile, `## medical-history\n${body}\n`, "utf-8");
+    const memory = new Memory(dataDir);
+    const llm = drivenLLM([""], async (tools) => {
+      await tools.memory_write.execute!(
+        { section: "medical-history", content: "Asthma, mild" },
+        {} as never,
+      );
+    });
+    const outcome = await runMemoryFlush({
+      llm,
+      messages: NON_TRIVIAL,
+      memory,
+      memorySections: SECTIONS,
+    });
+    const shrunk = eventsNamed("memory_flush_section_shrunk");
+    expect(shrunk).toHaveLength(1);
+    expect(shrunk[0].section).toBe("medical-history");
+    expect(shrunk[0].beforeChars).toBe(body.length);
+    expect(shrunk[0].afterChars).toBe("Asthma, mild".length);
+    expect(JSON.stringify(shrunk[0]).toLowerCase()).not.toContain("lisinopril");
+    expect(outcome.shrunkSections).toEqual([
+      { section: "medical-history", beforeChars: body.length, afterChars: "Asthma, mild".length },
+    ]);
+  });
+
+  it("does not warn when the shrinking section is below the size floor", async () => {
+    const body = "a".repeat(FLUSH_SHRINK_MIN_CHARS - 100);
+    writeFileSync(memoryFile, `## goals\n${body}\n`, "utf-8");
+    const memory = new Memory(dataDir);
+    const llm = drivenLLM([""], async (tools) => {
+      await tools.memory_write.execute!({ section: "goals", content: "short" }, {} as never);
+    });
+    const outcome = await runMemoryFlush({
+      llm,
+      messages: NON_TRIVIAL,
+      memory,
+      memorySections: SECTIONS,
+    });
+    expect(eventsNamed("memory_flush_section_shrunk")).toHaveLength(0);
+    expect(outcome.shrunkSections).toEqual([]);
+  });
+
+  it("does not warn on a modest shrink within the ratio", async () => {
+    writeFileSync(memoryFile, `## goals\n${"a".repeat(400)}\n`, "utf-8");
+    const memory = new Memory(dataDir);
+    const llm = drivenLLM([""], async (tools) => {
+      await tools.memory_write.execute!(
+        { section: "goals", content: "b".repeat(300) },
+        {} as never,
+      );
+    });
+    const outcome = await runMemoryFlush({
+      llm,
+      messages: NON_TRIVIAL,
+      memory,
+      memorySections: SECTIONS,
+    });
+    expect(eventsNamed("memory_flush_section_shrunk")).toHaveLength(0);
+    expect(outcome.shrunkSections).toEqual([]);
+  });
+
+  it("passes finishReason and usage through from the generate result", async () => {
+    const memory = new Memory(dataDir);
+    const outcome = await runMemoryFlush({
+      llm: createFakeLLM([{ text: "", finishReason: "length", usage: { outputTokens: 7 } }]),
+      messages: TRIVIAL,
+      memory,
+      memorySections: SECTIONS,
+    });
+    expect(outcome.finishReason).toBe("length");
+    expect(outcome.usage.outputTokens).toBe(7);
+  });
+
+  it("flushing twice with a deterministic writer leaves MEMORY.md byte-identical", async () => {
+    const memory = new Memory(dataDir);
+    const content = "Target FTP 280W by August";
+    const drive = async (tools: ToolSet) => {
+      await tools.memory_write.execute!({ section: "goals", content }, {} as never);
+    };
+    const first = await runMemoryFlush({
+      llm: drivenLLM([""], drive),
+      messages: NON_TRIVIAL,
+      memory,
+      memorySections: SECTIONS,
+    });
+    const afterFirst = readFileSync(memoryFile, "utf-8");
+    const second = await runMemoryFlush({
+      llm: drivenLLM([""], drive),
+      messages: NON_TRIVIAL,
+      memory,
+      memorySections: SECTIONS,
+    });
+    const afterSecond = readFileSync(memoryFile, "utf-8");
+    expect(first.writes).toBe(1);
+    expect(second.writes).toBe(1);
+    expect(afterSecond).toBe(afterFirst);
+  });
+
+  it("an LLM error still propagates and emits no detection events", async () => {
+    const memory = new Memory(dataDir);
+    await expect(
+      runMemoryFlush({
+        llm: createFakeLLM([{ error: new Error("boom") }]),
+        messages: NON_TRIVIAL,
+        memory,
+        memorySections: SECTIONS,
+      }),
+    ).rejects.toThrow("boom");
+    expect(eventsNamed("memory_flush_zero_writes")).toHaveLength(0);
+    expect(eventsNamed("memory_flush_section_shrunk")).toHaveLength(0);
+  });
+});

--- a/packages/core/tests/reset-flush-guard.test.ts
+++ b/packages/core/tests/reset-flush-guard.test.ts
@@ -116,9 +116,9 @@ describe("reset-path flush guards", () => {
       { role: "assistant", content: "yes - hold volume, recheck Friday", ts: STALE_TS },
     ]);
 
-    await expect(agent.resetSession("reset-guard")).resolves.toBeUndefined();
+    await expect(agent.resetSession("reset-guard")).resolves.toEqual({ memoryFlushed: false });
 
-    expect(complete).toHaveBeenCalledTimes(1);
+    expect(complete).toHaveBeenCalledTimes(2);
     expect(agent.hasSession("reset-guard")).toBe(false);
     const archives = listArchives("reset-guard");
     expect(archives).toHaveLength(1);
@@ -134,7 +134,7 @@ describe("reset-path flush guards", () => {
     let n = 0;
     const complete = vi.fn(async () => {
       n++;
-      if (n === 1) throw new Error("boom");
+      if (n <= 2) throw new Error("boom");
       return mkAssistant("fresh-start");
     });
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
@@ -147,7 +147,7 @@ describe("reset-path flush guards", () => {
     const text = await agent.chat("stale-guard", "hello");
 
     expect(text).toBe("fresh-start");
-    expect(complete).toHaveBeenCalledTimes(2);
+    expect(complete).toHaveBeenCalledTimes(3);
     const archives = listArchives("stale-guard");
     expect(archives).toHaveLength(1);
     const archived = readFileSync(join(dataDir, "sessions", archives[0]), "utf-8");
@@ -169,7 +169,7 @@ describe("reset-path flush guards", () => {
       { role: "user", content: "remember my FTP is 247", ts: STALE_TS },
     ]);
 
-    await agent.resetSession("healthy-reset");
+    await expect(agent.resetSession("healthy-reset")).resolves.toEqual({ memoryFlushed: true });
 
     expect(complete).toHaveBeenCalledTimes(1);
     expect(agent.hasSession("healthy-reset")).toBe(false);

--- a/packages/core/tests/session-corrupt-recovery.test.ts
+++ b/packages/core/tests/session-corrupt-recovery.test.ts
@@ -114,7 +114,7 @@ describe("CoachAgent corrupt-session recovery", () => {
     const valid = JSON.stringify({ role: "user", content: "we agreed: hold volume", ts: STALE_TS });
     seedRaw("corrupt-reset", `${valid}\n{"role":"assistant","content":"torn mid-wri`);
 
-    await expect(agent.resetSession("corrupt-reset")).resolves.toBeUndefined();
+    await expect(agent.resetSession("corrupt-reset")).resolves.toEqual({ memoryFlushed: true });
 
     expect(complete).toHaveBeenCalledTimes(1);
     expect(agent.hasSession("corrupt-reset")).toBe(false);
@@ -154,7 +154,7 @@ describe("CoachAgent corrupt-session recovery", () => {
     const agent = await setupAgent(complete);
     mkdirSync(join(dataDir, "sessions", "unreadable.jsonl"), { recursive: true });
 
-    await expect(agent.resetSession("unreadable")).resolves.toBeUndefined();
+    await expect(agent.resetSession("unreadable")).resolves.toEqual({ memoryFlushed: false });
 
     expect(
       warnSpy.mock.calls.some((c) => String(c[0]).includes("Pre-reset session load failed")),

--- a/packages/core/tests/telegram-start-reset-failure.test.ts
+++ b/packages/core/tests/telegram-start-reset-failure.test.ts
@@ -21,6 +21,9 @@ afterEach(() => {
 const RESET_FAILURE_REPLY =
   "Something went wrong resetting your session — your history is untouched. Please try /start again.";
 
+const RESET_CAVEAT =
+  "Note: I couldn't fully reset our previous session, so some earlier context may still apply.";
+
 async function buildStartHandler(resetSession: ReturnType<typeof vi.fn>) {
   const bot = { api: { sendMessage: vi.fn() }, use: vi.fn(), command: vi.fn(), on: vi.fn() };
   vi.doMock("grammy", () => ({
@@ -62,7 +65,7 @@ describe("/start reset-failure reply", () => {
   });
 
   it("reset success → Welcome, no failure copy", async () => {
-    const resetSession = vi.fn(async () => undefined);
+    const resetSession = vi.fn(async () => ({ memoryFlushed: true }));
     const start = await buildStartHandler(resetSession);
     const ctx = { chat: { id: 777 }, reply: vi.fn(async () => undefined) };
 
@@ -73,6 +76,32 @@ describe("/start reset-failure reply", () => {
       ctx.reply.mock.calls.some((c: unknown[]) =>
         String(c[0]).startsWith("Welcome to Cycling Coach!"),
       ),
+    ).toBe(true);
+    expect(
+      ctx.reply.mock.calls.some((c: unknown[]) =>
+        String(c[0]).includes("Something went wrong resetting"),
+      ),
+    ).toBe(false);
+    expect(
+      ctx.reply.mock.calls.some((c: unknown[]) => String(c[0]).includes(RESET_CAVEAT)),
+    ).toBe(false);
+  });
+
+  it("degraded reset → Welcome plus the caveat line", async () => {
+    const resetSession = vi.fn(async () => ({ memoryFlushed: false }));
+    const start = await buildStartHandler(resetSession);
+    const ctx = { chat: { id: 777 }, reply: vi.fn(async () => undefined) };
+
+    await start(ctx);
+
+    expect(ctx.reply).toHaveBeenCalledTimes(1);
+    expect(
+      ctx.reply.mock.calls.some((c: unknown[]) =>
+        String(c[0]).startsWith("Welcome to Cycling Coach!"),
+      ),
+    ).toBe(true);
+    expect(
+      ctx.reply.mock.calls.some((c: unknown[]) => String(c[0]).includes(RESET_CAVEAT)),
     ).toBe(true);
     expect(
       ctx.reply.mock.calls.some((c: unknown[]) =>

--- a/packages/core/tests/trim-compaction-guard.test.ts
+++ b/packages/core/tests/trim-compaction-guard.test.ts
@@ -163,8 +163,8 @@ describe("trim-path compaction guard", () => {
     let n = 0;
     const complete = vi.fn(async () => {
       n++;
-      if (n === 1) throw new Error("boom");
-      if (n === 2) return mkAssistant(FIVE_SECTION_SUMMARY);
+      if (n <= 2) throw new Error("boom");
+      if (n === 3) return mkAssistant(FIVE_SECTION_SUMMARY);
       return mkAssistant("final-reply");
     });
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
@@ -174,7 +174,7 @@ describe("trim-path compaction guard", () => {
     const text = await agent.chat("trim-flush-fail", "hello");
 
     expect(text).toBe("final-reply");
-    expect(complete).toHaveBeenCalledTimes(3);
+    expect(complete).toHaveBeenCalledTimes(4);
     expect(listPrecompact("trim-flush-fail")).toHaveLength(0);
 
     const session = readFileSync(join(dataDir, "sessions", "trim-flush-fail.jsonl"), "utf-8");


### PR DESCRIPTION
Before a session is reset or compacted, the coach runs one LLM call to extract durable athlete facts into long-term memory. Until now that call discarded its result, ran with no retry, and could succeed while writing nothing — a systematic extraction failure was invisible, and a degraded reset still greeted the athlete as if nothing had gone wrong. This change makes the flush observable and gives the trigger paths a real failure policy.

Outcome detection (inside the memory-flush module):

- The flush now returns a structured outcome — writes, ledger appends, finish reason, usage, and any shrunk sections — instead of returning nothing. Per-flush counters increment only after each store call succeeds.
- A flush that writes nothing on a non-trivial conversation emits a structured warn event, and a memory section that shrinks past a ratio threshold emits another. Both carry character counts only; section bodies never reach the logs.
- Control flow is unchanged: an LLM error still propagates exactly as before, with no new try/catch around the model call.

Trigger-path policy (across the chat agent and the Telegram channel):

- Every flush now routes through one chokepoint that retries once and logs a trigger-tagged failure event per failed attempt, so a transient blip no longer permanently skips an extraction increment.
- The two in-turn compaction sites gain warn-and-proceed guards: a flush failure there no longer kills the athlete's turn, since the session file still holds the full history for a later flush.
- When a stale, non-trivial session flushes but writes nothing, the session archive is deferred once so the history stays on disk for the next reset boundary to retry over.
- The explicit reset now reports whether memory was flushed, and /start discloses a degraded reset with a single caveat line appended to the welcome message instead of pretending the reset fully succeeded. The existing hard-failure reply is untouched.

This builds on the reset-path flush guards and the corrupt-session tolerance landed earlier and composes with them rather than replacing them.

Testing: added a flush outcome-detection suite and a retry/degradation suite, and re-pinned the affected sibling suites to the new contract. pnpm check exits 0 and the full pnpm test run passes with zero failures locally.
