### PR TITLE
fix(core): guard staged summarization with timeout and degradation

### DIFF
--- a/.changeset/summarize-stages-guards.md
+++ b/.changeset/summarize-stages-guards.md
@@ -1,0 +1,15 @@
+---
+"@enduragent/core": patch
+"cycling-coach": patch
+---
+
+User-facing: Condensing a long conversation can no longer hang or fail your message — summarization now times out after two minutes and the coach continues with the best summary it has.
+
+Every staged-summarization LLM call now runs under a 120 s race-only
+deadline (classified as a timeout by the existing error classifier).
+summarizeInStages degrades instead of throwing: a failed chunk falls back
+to the carried summary, and with no summary at all it head-drops the
+oldest messages so the turn can proceed. The overflow/timeout rescue
+paths rethrow the ORIGINAL turn error with any rescue failure attached
+as its cause, so summarization failures can no longer mask the error
+that actually ended the turn.

--- a/packages/core/src/agent/coach-agent.ts
+++ b/packages/core/src/agent/coach-agent.ts
@@ -267,12 +267,20 @@ export class CoachAgent {
           if (isContextOverflowError(err) && overflowAttempts < MAX_OVERFLOW_ATTEMPTS) {
             overflowAttempts++;
             try {
-              await this.flushMemory(messages, "overflow-recovery");
-            } catch (flushErr) {
-              console.warn("In-turn memory flush failed; compacting without flush", flushErr);
+              try {
+                await this.flushMemory(messages, "overflow-recovery");
+              } catch (flushErr) {
+                console.warn("In-turn memory flush failed; compacting without flush", flushErr);
+              }
+              messages = await summarizeInStages({ messages, ...this.compactionParams() });
+              this.memory.reload();
+            } catch (rescueErr) {
+              console.warn("Compaction rescue failed; rethrowing the original turn error", rescueErr);
+              if (err instanceof Error && err.cause === undefined) {
+                (err as Error & { cause?: unknown }).cause = rescueErr;
+              }
+              throw err;
             }
-            messages = await summarizeInStages({ messages, ...this.compactionParams() });
-            this.memory.reload();
             continue;
           }
           // Timeout with high context usage → compact + retry (no flush)
@@ -280,8 +288,16 @@ export class CoachAgent {
             const ratio = estimateMessagesTokens(messages) / this.config.contextWindowTokens;
             if (ratio > TIMEOUT_COMPACTION_THRESHOLD) {
               timeoutAttempts++;
-              messages = await summarizeInStages({ messages, ...this.compactionParams() });
-              this.memory.reload();
+              try {
+                messages = await summarizeInStages({ messages, ...this.compactionParams() });
+                this.memory.reload();
+              } catch (rescueErr) {
+                console.warn("Compaction rescue failed; rethrowing the original turn error", rescueErr);
+                if (err instanceof Error && err.cause === undefined) {
+                  (err as Error & { cause?: unknown }).cause = rescueErr;
+                }
+                throw err;
+              }
               continue;
             }
           }

--- a/packages/core/src/agent/compaction.ts
+++ b/packages/core/src/agent/compaction.ts
@@ -19,6 +19,7 @@ import type { LLM } from "../llm.js";
 const MAX_SUMMARY_CHARS = 4_000;
 const SUMMARY_TRUNCATED_MARKER = "\n\n[Summary truncated]";
 const MAX_SUMMARY_TOKENS = 1000;
+const SUMMARIZATION_TIMEOUT_MS = 120_000;
 const BASE_CHUNK_RATIO = 0.4;
 const MIN_CHUNK_RATIO = 0.15;
 
@@ -117,6 +118,29 @@ function capSummary(summary: string): string {
   return summary.slice(0, MAX_SUMMARY_CHARS) + SUMMARY_TRUNCATED_MARKER;
 }
 
+async function generateSummaryWithTimeout(
+  llm: LLM,
+  opts: { prompt: string; maxOutputTokens: number },
+): Promise<string> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const deadline = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(`Summarization timed out after ${SUMMARIZATION_TIMEOUT_MS}ms`)),
+      SUMMARIZATION_TIMEOUT_MS,
+    );
+  });
+  const call = llm.generate(opts);
+  try {
+    const { text } = await Promise.race([call, deadline]);
+    return text;
+  } finally {
+    clearTimeout(timer);
+    // Race-only deadline: the losing call keeps running; swallow its late
+    // rejection so it cannot surface as an unhandled rejection.
+    call.catch(() => {});
+  }
+}
+
 export function computeAdaptiveChunkRatio(
   messages: ModelMessage[],
   contextWindowTokens: number,
@@ -205,7 +229,7 @@ async function finalizeSummary(params: {
 
   for (let attempt = 0; attempt < maxRetries; attempt++) {
     try {
-      const { text } = await llm.generate({
+      const text = await generateSummaryWithTimeout(llm, {
         prompt: `Restructure the following summary to include ALL required section headings: ${audit.missing.join(", ")}.\n\n${best}\n\n${mustPreserveBlock}`,
         maxOutputTokens: MAX_SUMMARY_TOKENS,
       });
@@ -259,7 +283,7 @@ export async function summarizeDroppedMessages(params: {
     ].join("\n");
 
     try {
-      const { text } = await llm.generate({
+      const text = await generateSummaryWithTimeout(llm, {
         prompt,
         maxOutputTokens: MAX_SUMMARY_TOKENS,
       });
@@ -335,15 +359,24 @@ export async function summarizeInStages(params: {
       ? `\nExisting summary of earlier context:\n${summary}\n\n`
       : "";
 
-    const { text } = await llm.generate({
-      prompt: `${summarizePrompt}${contextPrefix}\n\n${transcript}`,
-      maxOutputTokens: MAX_SUMMARY_TOKENS,
-    });
-    summary = text;
+    try {
+      const text = await generateSummaryWithTimeout(llm, {
+        prompt: `${summarizePrompt}${contextPrefix}\n\n${transcript}`,
+        maxOutputTokens: MAX_SUMMARY_TOKENS,
+      });
+      summary = text;
+    } catch (err) {
+      console.warn("Staged summarization chunk failed; continuing with carried summary", err);
+    }
+  }
+
+  if (summary === undefined) {
+    console.warn("Staged summarization produced no summary; dropping oldest messages without one");
+    return [...recent];
   }
 
   const finalSummary = await finalizeSummary({
-    summary: summary ?? "",
+    summary,
     llm,
     mustPreserveBlock,
     maxRetries: 1,

--- a/packages/core/tests/compaction-rescue-original-error.test.ts
+++ b/packages/core/tests/compaction-rescue-original-error.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { baseAgentConfig } from "./helpers/base-agent-config.js";
+import { cyclingSport } from "@enduragent/sport-cycling";
+import { isContextOverflowError } from "../src/agent/token-utils.js";
+import type { Sport } from "../src/sport.js";
+
+let tempHome: string;
+let origHome: string | undefined;
+let dataDir: string;
+
+beforeEach(() => {
+  tempHome = mkdtempSync(join(tmpdir(), "cc-rescue-"));
+  origHome = process.env.HOME;
+  process.env.HOME = tempHome;
+  dataDir = join(tempHome, ".cycling-coach");
+  mkdirSync(dataDir, { recursive: true });
+  mkdirSync(join(dataDir, "memory"), { recursive: true });
+  vi.resetModules();
+});
+
+afterEach(() => {
+  process.env.HOME = origHome;
+  rmSync(tempHome, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+const rescueBoom = new Error("rescue boom");
+
+async function setupAgent(complete: ReturnType<typeof vi.fn>) {
+  const model = {
+    id: "gpt-5.4",
+    name: "gpt-5.4",
+    api: "openai-codex-responses",
+    provider: "openai-codex",
+    baseUrl: "https://chatgpt.com/backend-api",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 272_000,
+    maxTokens: 128_000,
+  };
+
+  vi.doMock("@mariozechner/pi-ai", () => ({
+    complete,
+    getModel: vi.fn(() => model),
+  }));
+  vi.doMock("@mariozechner/pi-ai/oauth", () => ({
+    refreshOpenAICodexToken: vi.fn(),
+    loginOpenAICodex: vi.fn(),
+  }));
+  vi.doMock("../src/auth/profiles.js", () => ({
+    getFreshToken: vi.fn(async () => "token"),
+    loadProfile: vi.fn(),
+    saveProfile: vi.fn(),
+    RefreshTokenReusedError: class extends Error {},
+  }));
+  vi.doMock("../src/agent/compaction.js", async () => {
+    const actual = await vi.importActual<typeof import("../src/agent/compaction.js")>(
+      "../src/agent/compaction.js",
+    );
+    return { ...actual, summarizeInStages: vi.fn(async () => { throw rescueBoom; }) };
+  });
+
+  const { CoachAgent } = await import("../src/agent/coach-agent.js");
+  return new CoachAgent(cyclingSport as unknown as Sport, baseAgentConfig(dataDir));
+}
+
+function mkAssistant(text: string, stopReason: "stop" | "length" = "stop") {
+  return {
+    role: "assistant" as const,
+    content: [{ type: "text" as const, text }],
+    api: "openai-codex-responses",
+    provider: "openai-codex",
+    model: "gpt-5.4",
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason,
+    timestamp: Date.now(),
+  };
+}
+
+describe("compaction rescue preserves the original turn error", () => {
+  it("overflow rescue failure surfaces the ORIGINAL overflow error with the rescue failure as cause", async () => {
+    let n = 0;
+    const complete = vi.fn(async () => {
+      n++;
+      if (n === 1) {
+        throw new Error("Request exceeds the maximum context length of 272000 tokens");
+      }
+      return mkAssistant("flush ok");
+    });
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const agent = await setupAgent(complete);
+
+    const rejection = await agent.chat("rescue-chat", "hello").then(
+      () => {
+        throw new Error("expected rejection");
+      },
+      (e: unknown) => e as Error,
+    );
+
+    expect(rejection.message).toMatch(/maximum context length/);
+    expect(isContextOverflowError(rejection)).toBe(true);
+    expect(rejection.cause).toBe(rescueBoom);
+
+    const rescueWarn = warnSpy.mock.calls.find(
+      (call) => typeof call[0] === "string" && call[0].includes("Compaction rescue failed"),
+    );
+    expect(rescueWarn).toBeDefined();
+    expect(complete.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/packages/core/tests/summarize-stages-guards.test.ts
+++ b/packages/core/tests/summarize-stages-guards.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import type { ModelMessage } from "ai";
+import type { MemorySnapshot } from "@enduragent/core";
+import { summarizeInStages, summarizeDroppedMessages } from "../src/agent/compaction.js";
+import { isTimeoutError } from "../src/agent/token-utils.js";
+import { SUMMARY_PREFIX } from "../src/agent/history-limit.js";
+import { CYCLING_VOCABULARY } from "@enduragent/sport-cycling";
+import { createFakeLLM } from "./helpers/fake-llm.js";
+import type { LLM } from "../src/llm.js";
+
+const REPRESENTATIVE_CONVERSATION: ModelMessage[] = [
+  { role: "user", content: "My FTP is 247W and I weigh 72kg." },
+  { role: "assistant", content: "Got it. Logging FTP=247W, weight=72kg." },
+  { role: "user", content: "I train Monday, Wednesday, and Friday." },
+  { role: "assistant", content: "Schedule noted: Mon/Wed/Fri." },
+  { role: "user", content: "Goal: lift FTP to 280W by August for the Gran Fondo." },
+  { role: "assistant", content: "Target: FTP 280W by 2026-08, race type gran_fondo." },
+  { role: "user", content: "Bike is Trek Madone, power meter is Quarq DZero." },
+  { role: "assistant", content: "Equipment logged." },
+  { role: "user", content: "I had a knee issue last winter; it flares with high volume." },
+  { role: "assistant", content: "Health note: prior knee issue, watch high-volume blocks." },
+];
+
+const VALID_FIVE_SECTION_SUMMARY = [
+  "## Athlete Profile",
+  "- FTP 247W, 72kg, training Mon/Wed/Fri",
+  "## Training Status",
+  "- Build phase, target FTP 280W",
+  "## Coach Stance",
+  "- Hold volume, recheck Friday",
+  "## Discussion Context",
+  "- Goal-setting and equipment review",
+  "## Pending Questions",
+  "- None outstanding",
+].join("\n");
+
+const EMPTY_SNAPSHOT: MemorySnapshot = {
+  read: () => null,
+  has: () => false,
+  listSections: () => [],
+};
+
+const hangingLLM = { generate: () => new Promise<never>(() => {}) } as unknown as LLM;
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("summarizeInStages guards", () => {
+  it("times out a hung summarization call after 120 s and degrades to the previous summary", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const p = summarizeInStages({
+      messages: REPRESENTATIVE_CONVERSATION,
+      llm: hangingLLM,
+      mustPreserveTokens: CYCLING_VOCABULARY,
+      memory: EMPTY_SNAPSHOT,
+      previousSummary: VALID_FIVE_SECTION_SUMMARY,
+    });
+
+    await vi.advanceTimersByTimeAsync(120_000);
+    const result = await p;
+
+    expect(result[0].role).toBe("system");
+    expect(String(result[0].content)).toContain("FTP 247W");
+    expect(String(result[0].content)).toContain("## Coach Stance");
+    expect(result.length).toBe(5);
+
+    const chunkWarn = warnSpy.mock.calls.find(
+      (call) => typeof call[0] === "string" && call[0].includes("Staged summarization chunk failed"),
+    );
+    expect(chunkWarn).toBeDefined();
+    expect(isTimeoutError(chunkWarn?.[1])).toBe(true);
+  }, 10_000);
+
+  it("falls back to the previous summary when the summarization call rejects", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const spy = createFakeLLM([{ error: new Error("boom") }]);
+
+    const result = await summarizeInStages({
+      messages: REPRESENTATIVE_CONVERSATION,
+      llm: spy,
+      mustPreserveTokens: CYCLING_VOCABULARY,
+      memory: EMPTY_SNAPSHOT,
+      previousSummary: VALID_FIVE_SECTION_SUMMARY,
+    });
+
+    expect(result[0].role).toBe("system");
+    expect(String(result[0].content)).toContain("FTP 247W");
+    expect(spy.capturedPrompts.length).toBe(1);
+
+    const chunkWarn = warnSpy.mock.calls.find(
+      (call) => typeof call[0] === "string" && call[0].includes("Staged summarization chunk failed"),
+    );
+    expect(chunkWarn).toBeDefined();
+  });
+
+  it("head-drops when every call fails and there is no previous summary", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const spy = createFakeLLM([{ error: new Error("boom") }], { repeatLast: true });
+
+    const result = await summarizeInStages({
+      messages: REPRESENTATIVE_CONVERSATION,
+      llm: spy,
+      mustPreserveTokens: CYCLING_VOCABULARY,
+      memory: EMPTY_SNAPSHOT,
+    });
+
+    expect(result).toEqual(REPRESENTATIVE_CONVERSATION.slice(-4));
+    for (const msg of result) {
+      expect(String(msg.content).startsWith(SUMMARY_PREFIX)).toBe(false);
+    }
+
+    const dropWarn = warnSpy.mock.calls.find(
+      (call) => typeof call[0] === "string" && call[0].includes("produced no summary"),
+    );
+    expect(dropWarn).toBeDefined();
+  });
+
+  it("carries the last successful chunk summary across a failed chunk", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const spy = createFakeLLM([VALID_FIVE_SECTION_SUMMARY, { error: new Error("boom") }]);
+    const big = (s: string) => ({ role: "user" as const, content: s.repeat(30_000) });
+    const messages = [big("a"), big("b"), ...REPRESENTATIVE_CONVERSATION.slice(-4)];
+
+    const result = await summarizeInStages({
+      messages,
+      llm: spy,
+      mustPreserveTokens: CYCLING_VOCABULARY,
+      memory: EMPTY_SNAPSHOT,
+      contextWindowTokens: 30_000,
+    });
+
+    expect(spy.capturedPrompts.length).toBe(2);
+    expect(result[0].role).toBe("system");
+    expect(String(result[0].content)).toContain("## Coach Stance");
+    expect(String(result[0].content)).toContain("FTP 247W");
+
+    const chunkWarns = warnSpy.mock.calls.filter(
+      (call) => typeof call[0] === "string" && call[0].includes("Staged summarization chunk failed"),
+    );
+    expect(chunkWarns.length).toBe(1);
+  });
+
+  it("healthy path is unchanged", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const spy = createFakeLLM([VALID_FIVE_SECTION_SUMMARY], { repeatLast: true });
+
+    const result = await summarizeInStages({
+      messages: REPRESENTATIVE_CONVERSATION,
+      llm: spy,
+      mustPreserveTokens: CYCLING_VOCABULARY,
+      memory: EMPTY_SNAPSHOT,
+    });
+
+    expect(result[0].role).toBe("system");
+    expect(String(result[0].content)).toContain("## Athlete Profile");
+    expect(result.length).toBe(5);
+
+    const guardWarn = warnSpy.mock.calls.find(
+      (call) =>
+        typeof call[0] === "string" &&
+        (call[0].includes("Staged summarization chunk failed") || call[0].includes("produced no summary")),
+    );
+    expect(guardWarn).toBeUndefined();
+  });
+
+  it("summarizeDroppedMessages hang times out and surfaces the total-failure throw", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const p = summarizeDroppedMessages({
+      dropped: REPRESENTATIVE_CONVERSATION,
+      llm: hangingLLM,
+      mustPreserveTokens: CYCLING_VOCABULARY,
+      memory: EMPTY_SNAPSHOT,
+      previousSummary: "OLD DROPPED SUMMARY",
+    });
+    const rejection = p.then(
+      () => {
+        throw new Error("expected rejection");
+      },
+      (e: unknown) => e as Error,
+    );
+
+    await vi.advanceTimersByTimeAsync(120_000);
+    const err = await rejection;
+
+    expect(err.message).toContain("failed for every chunk");
+    expect(isTimeoutError((err as Error & { cause?: unknown }).cause)).toBe(true);
+
+    const chunkWarn = warnSpy.mock.calls.find(
+      (call) => typeof call[0] === "string" && call[0].includes("Dropped message summarization LLM call failed"),
+    );
+    expect(chunkWarn).toBeDefined();
+  }, 10_000);
+});


### PR DESCRIPTION
Staged summarization in the compaction layer was completely unguarded: a hung summarization LLM call could block a turn indefinitely while holding the session lock, a single transient failure on one chunk would throw out of the function, and on the reactive rescue paths that thrown summarization error would replace the original overflow or timeout error that actually ended the turn.

This change adds three guards.

Deadline. Every summarization LLM call in the compaction module now runs under a 120 s race-only deadline via a small helper. The losing call keeps running (no cancellation seam exists at this layer yet — that is the per-call LLM deadline follow-up), and its late rejection is swallowed so it cannot surface as an unhandled rejection. The deadline error message is shaped so the existing error classifier treats it as a timeout.

Degradation ladder. summarizeInStages no longer throws on an LLM failure or timeout. A failed chunk warns and continues with the carried summary (the previous summary, or the last successful chunk's output). If no summary exists at all after the loop, it head-drops: it returns only the most recent messages with no summary message. This is not durable data loss — summarizeInStages only reshapes the in-turn message array; the session file keeps the full history, and the trim-path flush work already persists pre-compaction history.

Original-error preservation. At both reactive rescue sites in the chat loop (the context-overflow branch and the high-context timeout branch), any failure during the rescue now rethrows the original turn error with the rescue failure attached as its cause, instead of masking it. Rethrowing the original error keeps upstream classification intact. The landed memory-flush guard statements inside the overflow branch are preserved verbatim inside the new wrap; the preemptive and rate-limit branches are untouched.

New tests cover the deadline, the carried-summary and head-drop ladder, the dropped-messages timeout surfacing the total-failure throw, and a coach-agent integration test proving the original overflow error survives a rescue failure with the rescue error as its cause. Local pnpm check and pnpm test are both green.
