### PR TITLE
feat(core): flush memory proactively when history nears its token budget

### DIFF
--- a/.changeset/soft-threshold-memory-flush.md
+++ b/.changeset/soft-threshold-memory-flush.md
@@ -1,0 +1,13 @@
+---
+"@enduragent/core": patch
+"cycling-coach": patch
+---
+
+User-facing: The coach now saves important details to long-term memory proactively as a long conversation approaches its condensing point, instead of waiting until older messages are about to be dropped.
+
+When the loaded history exceeds 80% of its token budget and at least five
+messages have arrived since the last proactive save, the agent runs a
+memory flush before building the turn, so facts reach durable memory while
+the full raw history still exists. A per-chat in-memory cooldown prevents
+repeated flushes; trim-time flushes count toward it and session resets
+clear it. A flush failure warns and never blocks the turn.

--- a/packages/core/src/agent/coach-agent.ts
+++ b/packages/core/src/agent/coach-agent.ts
@@ -22,7 +22,7 @@ import {
   TIMEOUT_COMPACTION_THRESHOLD,
 } from "./token-utils.js";
 import { summarizeInStages, summarizeDroppedMessages } from "./compaction.js";
-import { runMemoryFlush, FLUSH_ZERO_WRITE_MIN_MESSAGES } from "./memory-flush.js";
+import { runMemoryFlush, FLUSH_ZERO_WRITE_MIN_MESSAGES, shouldRunMemoryFlush } from "./memory-flush.js";
 import type { MemoryFlushOutcome } from "./memory-flush.js";
 import { evaluateSessionFreshness } from "./session-freshness.js";
 import { LLM } from "../llm.js";
@@ -43,7 +43,8 @@ type MemoryFlushTrigger =
   | "explicit-reset"
   | "trim"
   | "pre-compaction"
-  | "overflow-recovery";
+  | "overflow-recovery"
+  | "soft-threshold";
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -63,6 +64,7 @@ export class CoachAgent {
   private systemPrompt: string;
   private tz: string;
   private archiveDeferred = new Set<string>();
+  private lastFlushMessageCount = new Map<string, number>();
 
   constructor(sport: Sport, config: Config) {
     this.sport = sport;
@@ -170,6 +172,7 @@ export class CoachAgent {
         } else {
           this.archiveDeferred.delete(chatId);
           this.chatStore.archiveAndReset(chatId);
+          this.lastFlushMessageCount.delete(chatId);
           history = [];
         }
       }
@@ -189,6 +192,7 @@ export class CoachAgent {
       let summaryMsg: ModelMessage | undefined;
       let requeued: ModelMessage[] = [];
       if (dropped.length > 0) {
+        this.lastFlushMessageCount.set(chatId, history.length);
         let flushed = true;
         try {
           await this.flushMemory(history, "trim");
@@ -216,6 +220,23 @@ export class CoachAgent {
         }
       } else if (previousSummary) {
         summaryMsg = makeSummaryMessage(previousSummary);
+      }
+
+      if (
+        dropped.length === 0 &&
+        shouldRunMemoryFlush({
+          estimatedTokens: estimateMessagesTokens(history),
+          tokenBudget: budget,
+          lastFlushMessageCount: this.lastFlushMessageCount.get(chatId) ?? 0,
+          currentMessageCount: history.length,
+        })
+      ) {
+        this.lastFlushMessageCount.set(chatId, history.length);
+        try {
+          await this.flushMemory(history, "soft-threshold");
+        } catch (err) {
+          console.warn("Soft-threshold memory flush failed; continuing turn", err);
+        }
       }
 
       // Append a fresh "Current time:" line to the user message so the LLM
@@ -349,6 +370,7 @@ export class CoachAgent {
     }
     this.archiveDeferred.delete(chatId);
     this.chatStore.archiveAndReset(chatId);
+    this.lastFlushMessageCount.delete(chatId);
     return { memoryFlushed };
   }
 

--- a/packages/core/src/agent/memory-flush.ts
+++ b/packages/core/src/agent/memory-flush.ts
@@ -15,6 +15,20 @@ import { todayInTZ } from "./user-time.js";
 
 export const SOFT_THRESHOLD_RATIO = 0.8;
 
+export const FLUSH_COOLDOWN_MESSAGES = 5;
+
+export function shouldRunMemoryFlush(params: {
+  estimatedTokens: number;
+  tokenBudget: number;
+  lastFlushMessageCount: number;
+  currentMessageCount: number;
+}): boolean {
+  if (params.currentMessageCount - params.lastFlushMessageCount < FLUSH_COOLDOWN_MESSAGES) {
+    return false;
+  }
+  return params.estimatedTokens > params.tokenBudget * SOFT_THRESHOLD_RATIO;
+}
+
 export const FLUSH_ZERO_WRITE_MIN_MESSAGES = 4;
 export const FLUSH_SHRINK_MIN_CHARS = 200;
 export const FLUSH_SHRINK_RATIO = 0.7;

--- a/packages/core/tests/soft-threshold-flush.test.ts
+++ b/packages/core/tests/soft-threshold-flush.test.ts
@@ -1,0 +1,304 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  mkdtempSync,
+  rmSync,
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  readdirSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { baseAgentConfig } from "./helpers/base-agent-config.js";
+import { cyclingSport } from "@enduragent/sport-cycling";
+import type { Sport } from "../src/sport.js";
+import { shouldRunMemoryFlush } from "../src/agent/memory-flush.js";
+
+const FIVE_SECTION_SUMMARY = [
+  "## Athlete Profile",
+  "- FTP 247W, 72kg, training Mon/Wed/Fri",
+  "## Training Status",
+  "- Build phase, target FTP 280W",
+  "## Coach Stance",
+  "- Hold volume this week (prior knee issue); athlete has not pushed back",
+  "## Discussion Context",
+  "- Goal-setting and equipment review",
+  "## Pending Questions",
+  "- None outstanding",
+].join("\n");
+
+describe("shouldRunMemoryFlush", () => {
+  it("cooldown suppresses even far over threshold", () => {
+    expect(
+      shouldRunMemoryFlush({
+        estimatedTokens: 9_999,
+        tokenBudget: 10_000,
+        lastFlushMessageCount: 10,
+        currentMessageCount: 14,
+      }),
+    ).toBe(false);
+  });
+
+  it("exactly 5 new messages over threshold fires", () => {
+    expect(
+      shouldRunMemoryFlush({
+        estimatedTokens: 9_000,
+        tokenBudget: 10_000,
+        lastFlushMessageCount: 10,
+        currentMessageCount: 15,
+      }),
+    ).toBe(true);
+  });
+
+  it("exactly 80% does not fire (strict >)", () => {
+    expect(
+      shouldRunMemoryFlush({
+        estimatedTokens: 8_000,
+        tokenBudget: 10_000,
+        lastFlushMessageCount: 0,
+        currentMessageCount: 20,
+      }),
+    ).toBe(false);
+  });
+
+  it("just above 80% fires", () => {
+    expect(
+      shouldRunMemoryFlush({
+        estimatedTokens: 8_001,
+        tokenBudget: 10_000,
+        lastFlushMessageCount: 0,
+        currentMessageCount: 20,
+      }),
+    ).toBe(true);
+  });
+
+  it("never-flushed short session is suppressed", () => {
+    expect(
+      shouldRunMemoryFlush({
+        estimatedTokens: 9_000,
+        tokenBudget: 10_000,
+        lastFlushMessageCount: 0,
+        currentMessageCount: 4,
+      }),
+    ).toBe(false);
+  });
+
+  it("never-flushed session at 5 messages fires", () => {
+    expect(
+      shouldRunMemoryFlush({
+        estimatedTokens: 9_000,
+        tokenBudget: 10_000,
+        lastFlushMessageCount: 0,
+        currentMessageCount: 5,
+      }),
+    ).toBe(true);
+  });
+});
+
+let tempHome: string;
+let origHome: string | undefined;
+let dataDir: string;
+
+beforeEach(() => {
+  tempHome = mkdtempSync(join(tmpdir(), "cc-softflush-"));
+  origHome = process.env.HOME;
+  process.env.HOME = tempHome;
+  dataDir = join(tempHome, ".cycling-coach");
+  mkdirSync(dataDir, { recursive: true });
+  mkdirSync(join(dataDir, "memory"), { recursive: true });
+  vi.resetModules();
+});
+
+afterEach(() => {
+  process.env.HOME = origHome;
+  rmSync(tempHome, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+async function setupAgent(complete: ReturnType<typeof vi.fn>) {
+  const model = {
+    id: "gpt-5.4",
+    name: "gpt-5.4",
+    api: "openai-codex-responses",
+    provider: "openai-codex",
+    baseUrl: "https://chatgpt.com/backend-api",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 272_000,
+    maxTokens: 128_000,
+  };
+
+  vi.doMock("@mariozechner/pi-ai", () => ({
+    complete,
+    getModel: vi.fn(() => model),
+  }));
+  vi.doMock("@mariozechner/pi-ai/oauth", () => ({
+    refreshOpenAICodexToken: vi.fn(),
+    loginOpenAICodex: vi.fn(),
+  }));
+  vi.doMock("../src/auth/profiles.js", () => ({
+    getFreshToken: vi.fn(async () => "token"),
+    loadProfile: vi.fn(),
+    saveProfile: vi.fn(),
+    RefreshTokenReusedError: class extends Error {},
+  }));
+
+  const { CoachAgent } = await import("../src/agent/coach-agent.js");
+  return new CoachAgent(cyclingSport as unknown as Sport, {
+    ...baseAgentConfig(dataDir),
+    contextWindowTokens: 80_000,
+  });
+}
+
+function mkAssistant(text: string, stopReason: "stop" | "length" = "stop") {
+  return {
+    role: "assistant" as const,
+    content: [{ type: "text" as const, text }],
+    api: "openai-codex-responses",
+    provider: "openai-codex",
+    model: "gpt-5.4",
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason,
+    timestamp: Date.now(),
+  };
+}
+
+const FRESH_TS = new Date().toISOString();
+
+function seedSession(chatId: string, lines: Array<{ role: string; content: string; ts: string }>) {
+  const sessionsDir = join(dataDir, "sessions");
+  mkdirSync(sessionsDir, { recursive: true });
+  writeFileSync(
+    join(sessionsDir, `${chatId}.jsonl`),
+    lines.map((l) => JSON.stringify(l)).join("\n") + "\n",
+    "utf-8",
+  );
+}
+
+function overThresholdLines(): Array<{ role: string; content: string; ts: string }> {
+  return Array.from({ length: 10 }, (_, i) => ({
+    role: i % 2 === 0 ? "user" : "assistant",
+    content: `SOFT-MARK-${i} ` + "x".repeat(2_400 - 11 - String(i).length),
+    ts: FRESH_TS,
+  }));
+}
+
+function underThresholdLines(): Array<{ role: string; content: string; ts: string }> {
+  return Array.from({ length: 6 }, (_, i) => ({
+    role: i % 2 === 0 ? "user" : "assistant",
+    content: "x".repeat(800),
+    ts: FRESH_TS,
+  }));
+}
+
+function trimLines(): Array<{ role: string; content: string; ts: string }> {
+  return Array.from({ length: 13 }, (_, i) => ({
+    role: i % 2 === 0 ? "user" : "assistant",
+    content: "x".repeat(2_400),
+    ts: FRESH_TS,
+  }));
+}
+
+function readSession(chatId: string): string {
+  return readFileSync(join(dataDir, "sessions", `${chatId}.jsonl`), "utf-8");
+}
+
+describe("soft-threshold flush in chat()", () => {
+  it("fires past 80% and cools down for 5 messages", async () => {
+    let n = 0;
+    const complete = vi.fn(async () => {
+      n++;
+      if (n === 1) return mkAssistant("facts noted");
+      return mkAssistant("main-reply");
+    });
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const agent = await setupAgent(complete);
+    seedSession("soft", overThresholdLines());
+
+    const text = await agent.chat("soft", "hello");
+
+    expect(text).toBe("main-reply");
+    expect(complete).toHaveBeenCalledTimes(2);
+    const warnSpy = console.warn as unknown as ReturnType<typeof vi.fn>;
+    expect(warnSpy.mock.calls.some((c) => String(c[0]).includes("flush failed"))).toBe(false);
+    const session = readSession("soft");
+    expect(session).toContain("SOFT-MARK-0");
+    expect(session).toContain("SOFT-MARK-9");
+    expect(session).toContain("hello");
+    expect(session).toContain("main-reply");
+
+    await agent.chat("soft", "again");
+    expect(complete).toHaveBeenCalledTimes(3);
+  });
+
+  it("below threshold never flushes", async () => {
+    const complete = vi.fn(async () => mkAssistant("reply"));
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const agent = await setupAgent(complete);
+    seedSession("low", underThresholdLines());
+
+    await agent.chat("low", "hi");
+
+    expect(complete).toHaveBeenCalledTimes(1);
+  });
+
+  it("flush failure warns, the turn completes, the cooldown still advances", async () => {
+    let n = 0;
+    const complete = vi.fn(async () => {
+      n++;
+      if (n <= 2) throw new Error("boom");
+      return mkAssistant("ok-reply");
+    });
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const agent = await setupAgent(complete);
+    seedSession("fail", overThresholdLines());
+
+    const text = await agent.chat("fail", "hello");
+
+    expect(text).toBe("ok-reply");
+    expect(
+      warnSpy.mock.calls.some((c) => String(c[0]).includes("Soft-threshold memory flush failed")),
+    ).toBe(true);
+    expect(complete.mock.calls.length).toBeGreaterThanOrEqual(2);
+    const session = readSession("fail");
+    expect(session).toContain("hello");
+    expect(session).toContain("ok-reply");
+
+    const before = complete.mock.calls.length;
+    await agent.chat("fail", "again");
+    expect(complete.mock.calls.length).toBe(before + 1);
+  });
+
+  it("a trim turn does not double-flush", async () => {
+    let n = 0;
+    const complete = vi.fn(async () => {
+      n++;
+      if (n === 1) return mkAssistant("facts noted");
+      if (n === 2) return mkAssistant(FIVE_SECTION_SUMMARY);
+      return mkAssistant("trim-reply");
+    });
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const agent = await setupAgent(complete);
+    seedSession("trim", trimLines());
+
+    const text = await agent.chat("trim", "hello");
+
+    expect(text).toBe("trim-reply");
+    expect(complete).toHaveBeenCalledTimes(3);
+    const archives = readdirSync(join(dataDir, "sessions")).filter((f) =>
+      f.startsWith("trim.jsonl.precompact."),
+    );
+    expect(archives).toHaveLength(1);
+    expect(
+      warnSpy.mock.calls.some((c) => String(c[0]).includes("Soft-threshold")),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
Adds a proactive memory flush so durable athlete facts get extracted while a long conversation is merely approaching its condensing point, rather than only at the moment older messages are about to be dropped.

## What changed

`memory-flush.ts` gains a pure `shouldRunMemoryFlush` trigger (and an exported `FLUSH_COOLDOWN_MESSAGES = 5`) built on the existing `SOFT_THRESHOLD_RATIO = 0.8` constant, which until now had no consumer. The trigger fires when the estimated history tokens exceed 80% of the computed history token budget, but only after at least five new messages have arrived since the last proactive flush. The cooldown is checked first, with a strict less-than on the message gap and a strict greater-than on the threshold.

`coach-agent.ts` consults the trigger once per turn inside `chat()`, on the no-trim path (gated on `dropped.length === 0`). When it fires, the agent records the attempt in a per-chat in-memory cooldown map and then runs a guarded flush. The flush is wrapped so a failure warns and never blocks the turn. Trim-time flushes also record into the same cooldown so the soft path cannot fire a redundant second flush on the next turn, and both session-reset paths clear the cooldown so a fresh session starts a fresh count.

## Why

This narrows the exposure window of the trim-path compaction flush, which fires only at 100% of the budget when messages are already being dropped. Flushing at 80% means facts reach durable memory while the full raw history still exists, so the trim-time flush becomes a second chance rather than the only chance.

## Notes

The cooldown is process-lifetime only with no persistence and no config surface. Retry and degradation policy stay owned by the flush-observability work; this site only adds the warn-and-continue guard.

## Tests

A new suite covers the pure trigger's boundary table (strict 80% and 5-message edges) plus four agent-integration tests: fires past 80% and then cools down, stays quiet below threshold, warns and still completes the turn (cooldown advancing) when the flush throws, and confirms a trim turn does not double-flush.
