### PR TITLE
feat(core): date memory facts with update stamps and source dating discipline

### DIFF
--- a/.changeset/memory-fact-dating.md
+++ b/.changeset/memory-fact-dating.md
@@ -1,0 +1,11 @@
+---
+"@enduragent/core": patch
+"cycling-coach": patch
+---
+
+User-facing: The coach now records when each remembered fact was last confirmed and flags facts older than six months for re-confirmation.
+
+Every memory section write stamps an "_updated: YYYY-MM-DD" first body line
+(athlete-timezone date, idempotent restamp), and the memory-extraction prompt
+now requires a source and as-of date on durable facts, keeps existing dates
+on unchanged facts, and appends "(re-confirm)" to facts older than six months.

--- a/packages/core/src/agent/memory-flush.ts
+++ b/packages/core/src/agent/memory-flush.ts
@@ -71,6 +71,17 @@ For each section you write, include ALL current facts for that section
 (both from memory and from the conversation). This fully replaces the
 section content — omitted facts will be lost.
 
+Dating discipline for durable facts:
+- Append "(<source>, <YYYY-MM-DD>)" to each material fact — who stated it
+  (athlete, coach, intervals.icu) and the date it was last confirmed.
+  Example: "- FTP 252W (athlete, 2026-06-08)".
+- When carrying an unchanged fact forward, keep its existing source and date;
+  re-date a fact only when this conversation re-confirmed it.
+- If a fact's date is more than 6 months before today, keep the fact and
+  append "(re-confirm)" so it can be verified with the athlete.
+- Never write "_updated:" lines yourself; the system stamps each section's
+  update date automatically.
+
 Note (transitional, post-migration): if \`cycling-profile\` contains weight,
 age, or available training days, move them to \`person\`. If \`cycling-history\`
 contains chronic conditions or long-term medications (hypertension, lisinopril,

--- a/packages/core/src/memory/store.ts
+++ b/packages/core/src/memory/store.ts
@@ -14,6 +14,24 @@ const SECTION_SPLIT = /(?=^## )/m;
 const markerOf = (section: string) => `## ${section}`;
 const bodyOf = (block: string) => block.slice(block.indexOf("\n") + 1);
 
+const UPDATED_STAMP_PREFIX = "_updated: ";
+
+/**
+ * Stamp a section body's first line with its write date. Idempotent: an
+ * existing leading stamp (e.g. echoed back by the LLM from memory_read)
+ * is replaced, never stacked — a body carries at most one leading stamp.
+ */
+function stampUpdated(content: string, date: string): string {
+  let body = content;
+  if (body.startsWith(UPDATED_STAMP_PREFIX)) {
+    const nl = body.indexOf("\n");
+    body = nl === -1 ? "" : body.slice(nl + 1);
+  }
+  return body === ""
+    ? `${UPDATED_STAMP_PREFIX}${date}`
+    : `${UPDATED_STAMP_PREFIX}${date}\n${body}`;
+}
+
 type RenameOutcome = "renamed" | "noop" | "merged";
 
 /**
@@ -69,14 +87,15 @@ export class Memory implements MemoryStore {
     const path = join(this.memoryDir, "MEMORY.md");
     const existing = this.readMemory();
     const marker = markerOf(section);
-    const newBlock = `${marker}\n${content}\n`;
+    const stamped = stampUpdated(content, todayInTZ(this.tz));
+    const newBlock = `${marker}\n${stamped}\n`;
 
     appendJournalEntry(this.memoryDir, {
       ts: new Date().toISOString(),
       op: "write-section",
       section,
       oldBody: this.readSection(section),
-      newBody: content,
+      newBody: stamped,
       source,
     });
 

--- a/packages/core/tests/memory-fact-dating.test.ts
+++ b/packages/core/tests/memory-fact-dating.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Memory } from "../src/memory/store.js";
+import { createMemorySnapshot } from "../src/memory/snapshot.js";
+import { JOURNAL_FILENAME } from "../src/memory/journal.js";
+import { runMemoryFlush } from "../src/agent/memory-flush.js";
+import { createFakeLLM } from "./helpers/fake-llm.js";
+
+let dataDir: string;
+
+beforeEach(() => {
+  dataDir = mkdtempSync(join(tmpdir(), "cc-factdating-"));
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-06-11T08:00:00.000Z"));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+describe("writeSection _updated stamp", () => {
+  it("stamps the first body line with today's date", () => {
+    const memory = new Memory(dataDir);
+    memory.writeSection("goals", "FTP 252W (athlete, 2026-06-08)", "chat-tool");
+
+    expect(memory.readSection("goals")).toBe(
+      "_updated: 2026-06-11\nFTP 252W (athlete, 2026-06-08)",
+    );
+  });
+
+  it("uses the store's timezone for the stamp date", () => {
+    vi.setSystemTime(new Date("2026-06-11T23:30:00.000Z"));
+    const memory = new Memory(dataDir, "Pacific/Auckland");
+    memory.writeSection("goals", "race in October");
+
+    expect(memory.readSection("goals")).toBe("_updated: 2026-06-12\nrace in October");
+  });
+
+  it("replaces an echoed stale stamp instead of stacking a second one", () => {
+    const memory = new Memory(dataDir);
+    memory.writeSection("goals", "_updated: 2026-01-05\nFTP 255W", "flush");
+
+    const body = memory.readSection("goals");
+    expect(body).toBe("_updated: 2026-06-11\nFTP 255W");
+    expect(body!.match(/_updated:/g)).toHaveLength(1);
+  });
+
+  it("re-stamps content that is only a stale stamp line", () => {
+    const memory = new Memory(dataDir);
+    memory.writeSection("notes", "_updated: 2026-01-05");
+
+    expect(memory.readSection("notes")).toBe("_updated: 2026-06-11");
+  });
+
+  it("stamps empty content as a bare stamp line", () => {
+    const memory = new Memory(dataDir);
+    memory.writeSection("notes", "");
+
+    expect(memory.readSection("notes")).toBe("_updated: 2026-06-11");
+  });
+
+  it("does not fragment section parsing or the snapshot view", () => {
+    const memory = new Memory(dataDir);
+    memory.writeSection("goals", "sub-3:30 century");
+    memory.writeSection("schedule", "Mon, Wed, Fri");
+
+    const snapshot = createMemorySnapshot(memory);
+    expect(snapshot.listSections()).toEqual(["goals", "schedule"]);
+    expect(snapshot.read("schedule")).toContain("Mon, Wed, Fri");
+    expect(memory.readSection("goals")).toBe("_updated: 2026-06-11\nsub-3:30 century\n");
+  });
+
+  it("journals the stamped body so the journal mirrors written bytes", () => {
+    const memory = new Memory(dataDir);
+    memory.writeSection("goals", "FTP 252W", "flush");
+
+    const lines = readFileSync(join(dataDir, "memory", JOURNAL_FILENAME), "utf-8")
+      .trimEnd()
+      .split("\n")
+      .map((l) => JSON.parse(l));
+    expect(lines[0].newBody).toBe("_updated: 2026-06-11\nFTP 252W");
+    expect(lines[0].newBody).toBe(memory.readSection("goals"));
+  });
+
+  it("renames preserve the original stamp untouched", () => {
+    const memory = new Memory(dataDir);
+    memory.writeSection("profile", "FTP 247W");
+    vi.setSystemTime(new Date("2026-09-01T08:00:00.000Z"));
+    memory.renameSection("profile", "cycling-profile", "migration");
+
+    expect(memory.readSection("cycling-profile")).toBe("_updated: 2026-06-11\nFTP 247W");
+  });
+});
+
+describe("flush prompt dating discipline", () => {
+  it("carries the source-and-date rule, the 6-month re-confirm flag, and the stamp prohibition", async () => {
+    const memory = new Memory(dataDir);
+    const llm = createFakeLLM([""]);
+
+    await runMemoryFlush({
+      llm,
+      messages: [{ role: "user", content: "My FTP is 252 as of last week" }],
+      memory,
+      memorySections: [{ name: "goals", description: "Athlete goals" }],
+      tz: "UTC",
+    });
+
+    const messages = llm.capturedMessages[0] ?? [];
+    const content = String(messages[messages.length - 1]?.content ?? "");
+    expect(content).toContain('Example: "- FTP 252W (athlete, 2026-06-08)"');
+    expect(content).toContain("6 months");
+    expect(content).toContain("(re-confirm)");
+    expect(content).toContain('Never write "_updated:" lines yourself');
+    expect(content).toContain("Today is 2026-06-11");
+    expect(content.indexOf("omitted facts will be lost")).toBeLessThan(
+      content.indexOf("Dating discipline"),
+    );
+    expect(content.indexOf("Dating discipline")).toBeLessThan(
+      content.indexOf("Note (transitional"),
+    );
+  });
+
+  it("the flush memory_write tool produces a stamped section", async () => {
+    const memory = new Memory(dataDir);
+    const llm = createFakeLLM([""]);
+
+    await runMemoryFlush({
+      llm,
+      messages: [{ role: "user", content: "I want FTP 280W by August" }],
+      memory,
+      memorySections: [{ name: "goals", description: "Athlete goals" }],
+      tz: "UTC",
+    });
+
+    const flushTools = llm.capturedOpts[0]?.tools;
+    expect(flushTools).toBeDefined();
+    await flushTools!.memory_write.execute!(
+      { section: "goals", content: "FTP 280W target (athlete, 2026-06-11)" },
+      {} as never,
+    );
+
+    expect(memory.readSection("goals")).toBe(
+      "_updated: 2026-06-11\nFTP 280W target (athlete, 2026-06-11)",
+    );
+  });
+});

--- a/packages/core/tests/memory-flush-outcome.test.ts
+++ b/packages/core/tests/memory-flush-outcome.test.ts
@@ -161,10 +161,14 @@ describe("runMemoryFlush outcome detection", () => {
     expect(shrunk).toHaveLength(1);
     expect(shrunk[0].section).toBe("medical-history");
     expect(shrunk[0].beforeChars).toBe(body.length);
-    expect(shrunk[0].afterChars).toBe("Asthma, mild".length);
+    expect(shrunk[0].afterChars).toBe("_updated: 0000-00-00\n".length + "Asthma, mild".length);
     expect(JSON.stringify(shrunk[0]).toLowerCase()).not.toContain("lisinopril");
     expect(outcome.shrunkSections).toEqual([
-      { section: "medical-history", beforeChars: body.length, afterChars: "Asthma, mild".length },
+      {
+        section: "medical-history",
+        beforeChars: body.length,
+        afterChars: "_updated: 0000-00-00\n".length + "Asthma, mild".length,
+      },
     ]);
   });
 

--- a/packages/core/tests/memory-journal.test.ts
+++ b/packages/core/tests/memory-journal.test.ts
@@ -40,9 +40,9 @@ describe("memory journal", () => {
       op: "write-section",
       section: "goals",
       oldBody: null,
-      newBody: "Sub-3:30 century",
       source: "chat-tool",
     });
+    expect(lines[0].newBody).toMatch(/^_updated: \d{4}-\d{2}-\d{2}\nSub-3:30 century$/);
     expect(lines[0].ts).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
   });
 
@@ -55,7 +55,7 @@ describe("memory journal", () => {
 
     const lines = readJournal(dataDir);
     expect(lines).toHaveLength(2);
-    expect(lines[1].oldBody).toBe("Hypertension; lisinopril 10mg");
+    expect(lines[1].oldBody).toMatch(/^_updated: \d{4}-\d{2}-\d{2}\nHypertension; lisinopril 10mg$/);
 
     const replayDir = mkdtempSync(join(tmpdir(), "cc-journal-replay-"));
     const replayMemory = new Memory(replayDir);
@@ -136,7 +136,7 @@ describe("memory journal", () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
     expect(() => memory.writeSection("goals", "Sub-3:30 century")).not.toThrow();
-    expect(memory.readSection("goals")).toBe("Sub-3:30 century");
+    expect(memory.readSection("goals")).toMatch(/^_updated: \d{4}-\d{2}-\d{2}\nSub-3:30 century$/);
     expect(warnSpy).toHaveBeenCalledWith(
       expect.stringContaining("memory journal append failed"),
     );

--- a/packages/core/tests/memory-rename-section.test.ts
+++ b/packages/core/tests/memory-rename-section.test.ts
@@ -87,13 +87,13 @@ describe("Memory.renameSection", () => {
     memory.writeSection("schedule", "Mon, Wed, Fri");
     memory.writeSection("health", "Knee twinge resolved");
     const beforeRename = readFileSync(path, "utf-8");
-    expect(beforeRename.endsWith("## health\nKnee twinge resolved\n")).toBe(true);
+    expect(beforeRename).toMatch(/## health\n_updated: \d{4}-\d{2}-\d{2}\nKnee twinge resolved\n$/);
 
     expect(memory.renameSection("health", "cycling-history")).toBe("renamed");
     const after = readFileSync(path, "utf-8");
-    expect(after.endsWith("## cycling-history\nKnee twinge resolved\n")).toBe(true);
+    expect(after).toMatch(/## cycling-history\n_updated: \d{4}-\d{2}-\d{2}\nKnee twinge resolved\n$/);
     // schedule (the prior section) should be untouched
-    expect(after.includes("## schedule\nMon, Wed, Fri\n")).toBe(true);
+    expect(after).toMatch(/## schedule\n_updated: \d{4}-\d{2}-\d{2}\nMon, Wed, Fri\n/);
   });
 
   it('merges bodies under `to` when both sections exist; `from` block removed', () => {


### PR DESCRIPTION
Long-term athlete memory is a sectioned markdown file that the chat and memory-flush surfaces rewrite wholesale, but nothing recorded when a fact was last true or who asserted it. An undated "FTP 252W" or a months-old injury note gets injected into every system prompt as if it were current, and a hallucinated or injected fact quietly acquires permanent unattributed authority.

This change adds two layers of dating to that file.

Structural (deterministic): `Memory.writeSection` now stamps every section body's first line with `_updated: YYYY-MM-DD`, dated in the athlete's timezone. The stamp is idempotent — an echoed stale stamp on incoming content is replaced rather than stacked — and it is a body line, so it does not fragment the `## `-based section parsing, the snapshot view, or the write journal. Every writer (chat tool, flush tool, sport tools) inherits it for free because they all funnel through `writeSection`, and the journal now mirrors the exact bytes written.

Prompt (probabilistic): the memory-extraction prompt gains a dating discipline. It asks the model to append `(<source>, <YYYY-MM-DD>)` to each material fact, to keep existing dates when carrying unchanged facts forward, and to append `(re-confirm)` to any fact whose date is more than six months old so the coach can verify it with the athlete. Stale facts are flagged and kept, never dropped. The prompt also instructs the model never to write `_updated:` lines itself, since the system stamps those automatically.

This is the substrate any future staleness sweep, athlete review surface, or poisoning audit would build on; none of those are in scope here.

Tests: a new suite covers the stamp (today's date, athlete timezone, idempotent restamp, empty/stamp-only content, snapshot non-fragmentation, journal mirroring, rename preservation) and the two flush behaviors (the prompt carries the rules in the enforced position, and the flush write tool produces a stamped section). Existing journal, rename, and flush-outcome assertions that pinned the un-stamped body shape are re-pinned to the stamped shape.

Builds on the memory write journal and the flush observability work already on main.
