### PR TITLE
test(core): pin the compaction substrate with unit and round-trip coverage

### DIFF
--- a/packages/core/CONTEXT.md
+++ b/packages/core/CONTEXT.md
@@ -32,6 +32,12 @@ Sport-specific sections declared by a Sport package, with the sport id as prefix
 **Must-Preserve Tokens**:
 Per-Sport list of literal phrases the LLM is forbidden to drop during compaction (e.g., `FTP`, `VDOT`).
 
+**Trim Compaction**:
+The persistent compaction path. At session load, when history exceeds the token budget, the oldest messages are summarized and the session JSONL is rewritten as `[summary, ...unsummarized, ...kept]` — after a pre-overwrite memory flush and a `.precompact` archive copy of the original file; the rewrite is skipped entirely when the flush fails. The only compaction that mutates the on-disk record.
+
+**In-Turn Compaction**:
+The ephemeral compaction path (`summarizeInStages`). Reshapes only the in-memory message array, from three sites in the chat loop (preemptive over-budget, context-overflow recovery, timeout recovery); the session JSONL keeps the full history and the reshaped array is discarded at end of turn.
+
 **CoreDeps**:
 The runtime services Core supplies to a Sport's tool factory: `LLM`, `IntervalsClient`, `MemoryStore`, `SecretsResolver`.
 

--- a/packages/core/tests/compaction-substrate.test.ts
+++ b/packages/core/tests/compaction-substrate.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ModelMessage } from "ai";
+import type { MemorySnapshot } from "@enduragent/core";
+import {
+  summarizeDroppedMessages,
+  summarizeInStages,
+  chunkMessagesByMaxTokens,
+  computeAdaptiveChunkRatio,
+} from "../src/agent/compaction.js";
+import {
+  makeSummaryMessage,
+  splitHistoryByBudget,
+} from "../src/agent/history-limit.js";
+import { ChatStore } from "../src/agent/chat-store.js";
+import { createFakeLLM } from "./helpers/fake-llm.js";
+import { CYCLING_VOCABULARY } from "@enduragent/sport-cycling";
+
+let dataDir: string;
+
+beforeEach(() => {
+  dataDir = mkdtempSync(join(tmpdir(), "cc-substrate-"));
+});
+
+afterEach(() => {
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+const EMPTY_SNAPSHOT: MemorySnapshot = {
+  read: () => null,
+  has: () => false,
+  listSections: () => [],
+};
+
+const CONVERSATION: ModelMessage[] = [
+  { role: "user", content: "My FTP is 247W and I weigh 72kg." },
+  { role: "assistant", content: "Got it. Logging FTP=247W, weight=72kg." },
+  { role: "user", content: "I train Monday, Wednesday, and Friday." },
+  { role: "assistant", content: "Schedule noted: Mon/Wed/Fri." },
+  { role: "user", content: "Goal: lift FTP to 280W by August for the Gran Fondo." },
+  { role: "assistant", content: "Target: FTP 280W, race type gran_fondo." },
+  { role: "user", content: "Bike is Trek Madone, power meter is Quarq DZero." },
+  { role: "assistant", content: "Equipment logged." },
+  { role: "user", content: "I had a knee issue last winter; it flares with high volume." },
+  { role: "assistant", content: "Health note: prior knee issue, watch high-volume blocks." },
+];
+
+const STANCE_FACT = "holding weekly volume at 8h; athlete disputes and asked for 12h";
+
+const STANCE_SUMMARY = [
+  "## Athlete Profile",
+  "- FTP 247W, 72kg, Mon/Wed/Fri schedule. " + "Long-standing base notes. ".repeat(20),
+  "## Training Status",
+  "- Build phase, target FTP 280W by August",
+  "## Coach Stance",
+  `- ${STANCE_FACT}`,
+  "## Discussion Context",
+  "- Weekly volume negotiation",
+  "## Pending Questions",
+  "- Athlete to confirm available hours on Friday",
+].join("\n");
+
+const msg = (chars: number): ModelMessage => ({ role: "user", content: "x".repeat(chars) });
+
+describe("chunkMessagesByMaxTokens", () => {
+  it("returns no chunks for an empty message list", () => {
+    expect(chunkMessagesByMaxTokens([], 300)).toEqual([]);
+  });
+
+  it("packs greedily under the safety-margin budget and preserves order", () => {
+    const messages = [msg(400), msg(400), msg(400), msg(400), msg(400)];
+    const chunks = chunkMessagesByMaxTokens(messages, 300);
+    expect(chunks.map((c) => c.length)).toEqual([2, 2, 1]);
+    expect(chunks.flat()).toEqual(messages);
+  });
+
+  it("gives an oversized message its own chunk instead of dropping it", () => {
+    const messages = [msg(400), msg(400)];
+    const chunks = chunkMessagesByMaxTokens(messages, 60);
+    expect(chunks.map((c) => c.length)).toEqual([1, 1]);
+    expect(chunks.flat()).toEqual(messages);
+  });
+});
+
+describe("computeAdaptiveChunkRatio", () => {
+  it("returns the 0.4 base ratio for empty input and for small messages", () => {
+    expect(computeAdaptiveChunkRatio([], 200_000)).toBe(0.4);
+    expect(computeAdaptiveChunkRatio([msg(40)], 200_000)).toBe(0.4);
+  });
+
+  it("reduces the ratio once the average message dominates the window", () => {
+    expect(computeAdaptiveChunkRatio([msg(4000)], 12_000)).toBeCloseTo(0.16, 10);
+  });
+
+  it("never drops below the 0.15 floor", () => {
+    expect(computeAdaptiveChunkRatio([msg(4000)], 10_000)).toBeCloseTo(0.15, 10);
+  });
+});
+
+describe("summary capping through the trim pipeline", () => {
+  it("caps an oversized summary at 4000 chars with the truncation marker", async () => {
+    const headings =
+      "## Athlete Profile\n- FTP 247W\n## Training Status\n- Build\n## Coach Stance\n- Hold volume\n## Discussion Context\n- Goals\n## Pending Questions\n- None\n";
+    const oversized = headings + "z".repeat(8000);
+    const llm = createFakeLLM([oversized]);
+
+    const { summary, unsummarized } = await summarizeDroppedMessages({
+      dropped: CONVERSATION,
+      llm,
+      mustPreserveTokens: CYCLING_VOCABULARY,
+      memory: EMPTY_SNAPSHOT,
+    });
+
+    expect(unsummarized).toEqual([]);
+    expect(llm.capturedPrompts).toHaveLength(1);
+    expect(summary.length).toBe(4000 + "\n\n[Summary truncated]".length);
+    expect(summary.endsWith("[Summary truncated]")).toBe(true);
+    expect(summary).toContain("## Pending Questions");
+  });
+});
+
+describe("coach-stance round-trip (mechanical path)", () => {
+  it("a stance fact survives trim, persistence, extraction, and re-entry into the next prompt", async () => {
+    const llm1 = createFakeLLM([STANCE_SUMMARY]);
+    const { summary, unsummarized } = await summarizeDroppedMessages({
+      dropped: CONVERSATION,
+      llm: llm1,
+      mustPreserveTokens: CYCLING_VOCABULARY,
+      memory: EMPTY_SNAPSHOT,
+    });
+
+    expect(unsummarized).toEqual([]);
+    expect(summary).toContain(STANCE_FACT);
+
+    const store = new ChatStore(dataDir);
+    store.overwriteHistory("rt", [
+      makeSummaryMessage(summary),
+      { role: "user", content: "kept tail message" },
+    ]);
+    const { messages } = store.load("rt");
+    const split = splitHistoryByBudget({ messages, tokenBudget: 100_000 });
+    expect(split.previousSummary).toBe(summary);
+    expect(split.kept).toEqual([{ role: "user", content: "kept tail message" }]);
+
+    const llm2 = createFakeLLM([STANCE_SUMMARY]);
+    await summarizeDroppedMessages({
+      dropped: [{ role: "user", content: "another old message about cadence" }],
+      previousSummary: split.previousSummary,
+      llm: llm2,
+      mustPreserveTokens: CYCLING_VOCABULARY,
+      memory: EMPTY_SNAPSHOT,
+    });
+    expect(llm2.capturedPrompts[0]).toContain("Existing summary of earlier context:");
+    expect(llm2.capturedPrompts[0]).toContain(STANCE_FACT);
+  });
+
+  it("a stance fact in a leading summary survives the in-turn pipeline into the carried summary", async () => {
+    const llm = createFakeLLM([STANCE_SUMMARY]);
+    const result = await summarizeInStages({
+      messages: [makeSummaryMessage(STANCE_SUMMARY), ...CONVERSATION],
+      llm,
+      mustPreserveTokens: CYCLING_VOCABULARY,
+      memory: EMPTY_SNAPSHOT,
+      recentToKeep: 2,
+    });
+
+    expect(llm.capturedPrompts).toHaveLength(1);
+    expect(llm.capturedPrompts[0]).toContain(STANCE_FACT);
+    expect(result).toHaveLength(3);
+    expect(result[0].role).toBe("system");
+    expect(String(result[0].content)).toContain(STANCE_FACT);
+  });
+});

--- a/packages/core/tests/history-limit.test.ts
+++ b/packages/core/tests/history-limit.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ModelMessage } from "ai";
+import {
+  splitHistoryByBudget,
+  makeSummaryMessage,
+  SUMMARY_PREFIX,
+} from "../src/agent/history-limit.js";
+import { ChatStore } from "../src/agent/chat-store.js";
+
+let dataDir: string;
+
+beforeEach(() => {
+  dataDir = mkdtempSync(join(tmpdir(), "cc-histlimit-"));
+});
+
+afterEach(() => {
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+const msg = (chars: number): ModelMessage => ({ role: "user", content: "x".repeat(chars) });
+
+describe("splitHistoryByBudget", () => {
+  it("returns empty kept/dropped and no summary for empty input", () => {
+    expect(splitHistoryByBudget({ messages: [], tokenBudget: 100 })).toEqual({
+      kept: [],
+      dropped: [],
+      previousSummary: undefined,
+    });
+  });
+
+  it("extracts a summary at index 0 byte-exactly, including multi-line text", () => {
+    const text = "line one\nline two";
+    const result = splitHistoryByBudget({
+      messages: [makeSummaryMessage(text), { role: "user", content: "hello" }],
+      tokenBudget: 100_000,
+    });
+    expect(result.previousSummary).toBe(text);
+    expect(result.kept).toEqual([{ role: "user", content: "hello" }]);
+    expect(result.dropped).toEqual([]);
+  });
+
+  it("treats non-summary first messages as conversation, not summary", () => {
+    const systemRoleWrongPrefix = splitHistoryByBudget({
+      messages: [
+        { role: "system", content: "You are a coach" },
+        { role: "user", content: "hi" },
+      ],
+      tokenBudget: 100_000,
+    });
+    expect(systemRoleWrongPrefix.previousSummary).toBe(undefined);
+    expect(systemRoleWrongPrefix.kept[0]).toEqual({ role: "system", content: "You are a coach" });
+
+    const rightPrefixWrongRole = splitHistoryByBudget({
+      messages: [{ role: "user", content: `${SUMMARY_PREFIX}\nfake` }],
+      tokenBudget: 100_000,
+    });
+    expect(rightPrefixWrongRole.previousSummary).toBe(undefined);
+    expect(rightPrefixWrongRole.kept[0]).toEqual({
+      role: "user",
+      content: `${SUMMARY_PREFIX}\nfake`,
+    });
+  });
+
+  it("drops the oldest messages until within budget", () => {
+    const messages = Array.from({ length: 5 }, () => msg(400));
+    const result = splitHistoryByBudget({ messages, tokenBudget: 300 });
+    expect(result.dropped).toEqual(messages.slice(0, 3));
+    expect(result.kept).toEqual(messages.slice(3));
+  });
+
+  it("never empties kept even when the survivor exceeds the budget", () => {
+    const messages = Array.from({ length: 5 }, () => msg(400));
+    const result = splitHistoryByBudget({ messages, tokenBudget: 0 });
+    expect(result.kept).toHaveLength(1);
+    expect(result.kept).toEqual([messages[4]]);
+    expect(result.dropped).toEqual(messages.slice(0, 4));
+  });
+
+  it("excludes the extracted summary's size from the budget", () => {
+    const result = splitHistoryByBudget({
+      messages: [makeSummaryMessage("x".repeat(4000)), msg(400), msg(400)],
+      tokenBudget: 240,
+    });
+    expect(result.dropped).toEqual([]);
+    expect(result.kept).toHaveLength(2);
+  });
+});
+
+describe("SUMMARY_PREFIX and makeSummaryMessage", () => {
+  it("pins the persisted prefix string and the summary-message shape", () => {
+    expect(SUMMARY_PREFIX).toBe("[Previous conversation summary]");
+    expect(makeSummaryMessage("S")).toEqual({
+      role: "system",
+      content: "[Previous conversation summary]\nS",
+    });
+  });
+});
+
+describe("system-message round-trip through write/load", () => {
+  it("survives ChatStore.overwriteHistory, load, and extraction losslessly", () => {
+    const store = new ChatStore(dataDir);
+    const text = "alpha\nbeta";
+    store.overwriteHistory("rt", [makeSummaryMessage(text), { role: "user", content: "tail" }]);
+    const { messages } = store.load("rt");
+    expect(messages).toHaveLength(2);
+    expect(messages[0].role).toBe("system");
+    const split = splitHistoryByBudget({ messages, tokenBudget: 100_000 });
+    expect(split.previousSummary).toBe(text);
+    expect(split.kept).toEqual([{ role: "user", content: "tail" }]);
+  });
+});

--- a/packages/core/tests/token-utils.test.ts
+++ b/packages/core/tests/token-utils.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import type { ModelMessage } from "ai";
+import {
+  messageText,
+  estimateTokens,
+  estimateMessagesTokens,
+  computeHistoryTokenBudget,
+  shouldCompact,
+} from "../src/agent/token-utils.js";
+
+const msg = (chars: number): ModelMessage => ({ role: "user", content: "x".repeat(chars) });
+
+describe("estimateTokens", () => {
+  it("pins the chars/4 x 1.2 formula", () => {
+    expect(estimateTokens("")).toBe(0);
+    expect(estimateTokens("abcd")).toBe(2);
+    expect(estimateTokens("x".repeat(40))).toBe(12);
+    expect(estimateTokens("x".repeat(400))).toBe(120);
+  });
+});
+
+describe("messageText", () => {
+  it("returns string content verbatim and \"\" for part-array content", () => {
+    expect(messageText({ role: "user", content: "hello" })).toBe("hello");
+    expect(messageText({ role: "user", content: [{ type: "text", text: "hi" }] })).toBe("");
+  });
+});
+
+describe("estimateMessagesTokens", () => {
+  it("sums per-message estimates, with part-array messages contributing 0", () => {
+    expect(estimateMessagesTokens([msg(400), msg(400)])).toBe(240);
+    expect(
+      estimateMessagesTokens([
+        msg(400),
+        { role: "user", content: [{ type: "text", text: "x".repeat(400) }] },
+      ]),
+    ).toBe(120);
+  });
+});
+
+describe("computeHistoryTokenBudget", () => {
+  it("computes window x ratio minus system-prompt tokens minus the reserve", () => {
+    expect(
+      computeHistoryTokenBudget({
+        contextWindowTokens: 200_000,
+        systemPrompt: "x".repeat(4000),
+        budgetRatio: 0.3,
+      }),
+    ).toBe(38_800);
+  });
+
+  it("floors at 8,000 tokens", () => {
+    expect(
+      computeHistoryTokenBudget({
+        contextWindowTokens: 100_000,
+        systemPrompt: "x".repeat(8000),
+        budgetRatio: 0.3,
+      }),
+    ).toBe(8000);
+    expect(
+      computeHistoryTokenBudget({
+        contextWindowTokens: 10_000,
+        systemPrompt: "",
+        budgetRatio: 0.3,
+      }),
+    ).toBe(8000);
+  });
+});
+
+describe("shouldCompact", () => {
+  it("is strict at the boundary and counts the system prompt", () => {
+    expect(
+      shouldCompact({ messages: [msg(4000)], systemPrompt: "", contextWindowTokens: 21_200 }),
+    ).toBe(false);
+    expect(
+      shouldCompact({ messages: [msg(4000)], systemPrompt: "", contextWindowTokens: 21_199 }),
+    ).toBe(true);
+    expect(
+      shouldCompact({ messages: [msg(4000)], systemPrompt: "xxxx", contextWindowTokens: 21_200 }),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
Adds the first unit coverage for the compaction substrate — the pure functions that decide what survives a long conversation. This is a pinning suite: it asserts the current shapes so that future estimator and budget changes (the planned estimation rework) must consciously update a red test instead of silently drifting.

Three new test files (23 tests, no source changes):

- `token-utils.test.ts` (6 tests) — pins the token estimator (chars/4 x 1.2), `messageText`'s string-vs-part-array handling, the message-sum, the history budget arithmetic and its 8,000-token floor, and the strict `shouldCompact` boundary (equality does not compact; the system prompt is counted).
- `history-limit.test.ts` (8 tests) — pins `splitHistoryByBudget`: empty input, byte-exact summary-at-index-0 extraction (including multi-line text), non-summary first messages treated as conversation, the drop-loop boundary math, the minimum-kept edge (the loop never empties the survivors), and the summary being excluded from the budget. Also pins the persisted prefix string and `makeSummaryMessage` shape, plus the system-message round-trip through `ChatStore.overwriteHistory` and `load` — the loop the entire trim design rests on.
- `compaction-substrate.test.ts` (9 tests) — pins greedy chunking and the oversized-message-own-chunk rule, the adaptive chunk ratio (base, reduction, and floor), the oversized-summary cap with its truncation marker, and the coach-stance round-trip: a stance fact placed in a summary survives capping, persistence, extraction, and re-entry into the next summarization prompt — both through the persistent trim pipeline and through the ephemeral in-turn pipeline. Uses the shared fake-LLM helper as the only model seam; no integration scaffolding.

Non-vacuity is proven by three targeted source mutations (extraction off-by-one, cap shrink, compaction-boundary flip), each of which forces the expected tests red; the source is restored byte-identical and is untouched in this diff.

Also adds two glossary entries to `packages/core/CONTEXT.md` distinguishing the two compaction paths: Trim Compaction (persistent — the only path that rewrites the on-disk session record, after a pre-overwrite flush and an archive copy, and skipped entirely if the flush fails) versus In-Turn Compaction (ephemeral — reshapes only the in-memory array and is discarded at end of turn). This sits alongside the trim-path flush work and the staged-summarization guards already on main.

No changeset: tests and a glossary entry change no shipped behavior.
