### PR TITLE
refactor(core): extract shared UTC date-key util and rewire call sites

### DIFF
--- a/.changeset/shared-date-key-util.md
+++ b/.changeset/shared-date-key-util.md
@@ -1,0 +1,12 @@
+---
+"@enduragent/core": patch
+---
+
+Consolidate the pure-UTC `YYYY-MM-DD` date-key arithmetic into one shared
+`io/` leaf util. The midnight-UTC parse, the milliseconds-per-day constant,
+the epoch-ms-to-key format, the calendar-validity round-trip, and the
+inclusive-range convention were hand-inlined across the dated-recall tool and
+the daily-notes range reader; they now live in a single internal module so the
+two call sites can no longer drift on the inclusivity convention or the
+midnight-UTC suffix. Behavior-neutral: every pre-existing test stays green with
+no assertion changes.

--- a/packages/core/src/agent/tools.ts
+++ b/packages/core/src/agent/tools.ts
@@ -2,6 +2,7 @@ import { tool, zodSchema } from "ai";
 import { z } from "zod";
 import type { MemorySectionSpec } from "../sport.js";
 import type { MemoryStore } from "../memory.js";
+import { isRealDateKey, parseDateKeyMs, MS_PER_DAY } from "../io/date-keys.js";
 
 function buildMemoryWriteDescription(sections: readonly MemorySectionSpec[]): string {
   const sectionList = sections.map((s) => `${s.name} (${s.description})`).join("; ");
@@ -22,11 +23,6 @@ export function createMemoryReadTool(memory: MemoryStore) {
 const MEMORY_QUERY_MAX_RANGE_DAYS = 366;
 const MEMORY_QUERY_MAX_RESULT_CHARS = 20_000;
 const MEMORY_QUERY_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
-
-function isRealDate(d: string): boolean {
-  const ms = Date.parse(`${d}T00:00:00Z`);
-  return Number.isFinite(ms) && new Date(ms).toISOString().slice(0, 10) === d;
-}
 
 export function createMemoryQueryTool(memory: MemoryStore) {
   return tool({
@@ -52,14 +48,13 @@ export function createMemoryQueryTool(memory: MemoryStore) {
     ),
     execute: async (input: { from: string; to: string; query?: string }) => {
       const { from, to, query } = input;
-      if (!isRealDate(from) || !isRealDate(to)) {
+      if (!isRealDateKey(from) || !isRealDateKey(to)) {
         return `Error: ${from}..${to} contains an invalid calendar date. Use real YYYY-MM-DD dates.`;
       }
       if (from > to) {
         return `Error: 'from' (${from}) is after 'to' (${to}). Swap the bounds.`;
       }
-      const rangeDays =
-        (Date.parse(`${to}T00:00:00Z`) - Date.parse(`${from}T00:00:00Z`)) / 86_400_000 + 1;
+      const rangeDays = (parseDateKeyMs(to) - parseDateKeyMs(from)) / MS_PER_DAY + 1;
       if (rangeDays > MEMORY_QUERY_MAX_RANGE_DAYS) {
         return `Error: range is ${rangeDays} days; the maximum is ${MEMORY_QUERY_MAX_RANGE_DAYS}. Query a narrower range.`;
       }

--- a/packages/core/src/io/date-keys.ts
+++ b/packages/core/src/io/date-keys.ts
@@ -1,0 +1,38 @@
+export const MS_PER_DAY = 86_400_000;
+
+/**
+ * Parse a `YYYY-MM-DD` date key to its midnight-UTC epoch-ms.
+ * The `T00:00:00Z` suffix is load-bearing: it pins the parse to UTC
+ * so the result is timezone-independent. Returns a non-finite value
+ * (NaN) for malformed input — callers that need calendar validity use
+ * isRealDateKey.
+ */
+export function parseDateKeyMs(dateKey: string): number {
+  return Date.parse(`${dateKey}T00:00:00Z`);
+}
+
+/**
+ * True iff `dateKey` is a real calendar date in `YYYY-MM-DD` shape.
+ * parse → re-format → compare round-trip rejects calendar-invalid dates
+ * (e.g. 2026-02-30) that Date.parse would silently normalise.
+ */
+export function isRealDateKey(dateKey: string): boolean {
+  const ms = parseDateKeyMs(dateKey);
+  return Number.isFinite(ms) && new Date(ms).toISOString().slice(0, 10) === dateKey;
+}
+
+/**
+ * Inclusive forward iteration over every `YYYY-MM-DD` key in `[from, to]`.
+ * Inclusive of BOTH endpoints (mirrors the `+ 1` range-day count). Returns
+ * `[]` if either bound is unparseable; assumes `from <= to` lexicographically.
+ */
+export function eachDateKeyInRange(from: string, to: string): string[] {
+  const fromMs = parseDateKeyMs(from);
+  const toMs = parseDateKeyMs(to);
+  if (!Number.isFinite(fromMs) || !Number.isFinite(toMs)) return [];
+  const out: string[] = [];
+  for (let t = fromMs; t <= toMs; t += MS_PER_DAY) {
+    out.push(new Date(t).toISOString().slice(0, 10));
+  }
+  return out;
+}

--- a/packages/core/src/memory/store.ts
+++ b/packages/core/src/memory/store.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import type { MemoryStore, MemoryWriteSource } from "../memory.js";
 import { todayInTZ } from "../agent/user-time.js";
 import { atomicWriteFileSync } from "../io/atomic-write-file-sync.js";
+import { eachDateKeyInRange } from "../io/date-keys.js";
 import { appendJournalEntry } from "./journal.js";
 import { appendLedgerEvent, LEDGER_FILENAME, type LedgerEventInput } from "./event-ledger.js";
 
@@ -213,12 +214,8 @@ export class Memory implements MemoryStore {
   }
 
   readDailyNotesInRange(from: string, to: string): Array<{ date: string; text: string }> {
-    const fromMs = Date.parse(`${from}T00:00:00Z`);
-    const toMs = Date.parse(`${to}T00:00:00Z`);
-    if (!Number.isFinite(fromMs) || !Number.isFinite(toMs)) return [];
     const out: Array<{ date: string; text: string }> = [];
-    for (let t = fromMs; t <= toMs; t += 86_400_000) {
-      const date = new Date(t).toISOString().slice(0, 10);
+    for (const date of eachDateKeyInRange(from, to)) {
       const text = this.readDailyNotes(date);
       if (text) out.push({ date, text });
     }

--- a/packages/core/tests/io-date-keys.test.ts
+++ b/packages/core/tests/io-date-keys.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  MS_PER_DAY,
+  parseDateKeyMs,
+  isRealDateKey,
+  eachDateKeyInRange,
+} from "../src/io/date-keys.js";
+
+describe("parseDateKeyMs", () => {
+  it("returns the midnight-UTC epoch-ms for a valid key", () => {
+    expect(parseDateKeyMs("1998-03-01")).toBe(Date.UTC(1998, 2, 1));
+  });
+
+  it("returns a non-finite value for garbage", () => {
+    expect(Number.isFinite(parseDateKeyMs("nope"))).toBe(false);
+  });
+});
+
+describe("isRealDateKey", () => {
+  it("is true for a real date", () => {
+    expect(isRealDateKey("1998-03-01")).toBe(true);
+  });
+
+  it("is false for calendar-invalid dates Date.parse would normalise", () => {
+    expect(isRealDateKey("2026-02-30")).toBe(false);
+    expect(isRealDateKey("2026-13-01")).toBe(false);
+    expect(isRealDateKey("2026-04-31")).toBe(false);
+  });
+
+  it("is false for wrong shape", () => {
+    expect(isRealDateKey("2026-3-1")).toBe(false);
+    expect(isRealDateKey("2026/03/01")).toBe(false);
+    expect(isRealDateKey("")).toBe(false);
+  });
+});
+
+describe("eachDateKeyInRange", () => {
+  it("is inclusive of both endpoints", () => {
+    expect(eachDateKeyInRange("1998-03-01", "1998-03-03")).toEqual([
+      "1998-03-01",
+      "1998-03-02",
+      "1998-03-03",
+    ]);
+  });
+
+  it("returns exactly [from] for a single-day range", () => {
+    expect(eachDateKeyInRange("1998-03-01", "1998-03-01")).toEqual(["1998-03-01"]);
+  });
+
+  it("crosses a month boundary correctly", () => {
+    const days = eachDateKeyInRange("1998-02-28", "1998-03-01");
+    expect(days).toEqual(["1998-02-28", "1998-03-01"]);
+  });
+
+  it("returns [] when either bound is malformed", () => {
+    expect(eachDateKeyInRange("nope", "1998-03-01")).toEqual([]);
+    expect(eachDateKeyInRange("1998-03-01", "nope")).toEqual([]);
+  });
+});
+
+describe("inclusivity consistency (anti-drift)", () => {
+  it("pins the loop-bound convention to the +1 range-day count", () => {
+    const from = "1998-03-01";
+    const to = "1998-03-31";
+    expect(eachDateKeyInRange(from, to).length).toBe(
+      (parseDateKeyMs(to) - parseDateKeyMs(from)) / MS_PER_DAY + 1,
+    );
+  });
+});


### PR DESCRIPTION
Consolidates the pure-UTC YYYY-MM-DD date-key arithmetic that was hand-inlined across two surfaces into one small shared leaf module under the io/ layer.

Before this change, the midnight-UTC parse (the T00:00:00Z suffix that pins Date.parse to UTC), the milliseconds-per-day constant, the epoch-ms-to-key format (toISOString().slice(0, 10)), and the calendar-validity round-trip were each duplicated. The two consumers could silently drift on the inclusivity convention or on the midnight-UTC suffix, which is a latent maintainability bug: touch one site and the others diverge.

What changed:

- New internal module packages/core/src/io/date-keys.ts exporting parseDateKeyMs, isRealDateKey, eachDateKeyInRange, and the MS_PER_DAY constant. It is pure UTC, timezone-free, depends only on Date globals, and imports nothing from inside the package. It is not re-exported from the package barrel, matching the existing io/ precedent.
- The dated-recall tool now imports isRealDateKey for both bound checks and computes its range-day count via parseDateKeyMs and MS_PER_DAY, replacing the inline math. The module-private calendar-validity helper is gone. No wall-clock read is introduced, so the tool stays a pure function of its inputs.
- The daily-notes range reader now iterates eachDateKeyInRange, preserving its empty-on-malformed and only-push-rows-with-text behavior exactly.
- The reset-archive retention path keeps its own local constant untouched; its timestamp parsing is a different primitive (a full demangled datetime, not a bare date key) and stays as-is.

This is a behavior-neutral refactor: every pre-existing test stays green with zero assertion edits, and a new focused unit test pins the new util including an inclusivity-consistency assertion that ties the loop bound and the +1 range-day count to the same number. The full build and test gates pass locally.