### PR TITLE
chore(deps): move Docker base image to node:24-alpine LTS

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,9 @@ updates:
     directory: /packages/cycling-coach
     schedule:
       interval: weekly
+    # Hold the base image on its current Node LTS line; take digest/minor/patch
+    # security updates automatically but bump the major by hand to the next LTS
+    # (even majors), skipping odd-numbered Current releases.
+    ignore:
+      - dependency-name: "node"
+        update-types: ["version-update:semver-major"]

--- a/packages/cycling-coach/Dockerfile
+++ b/packages/cycling-coach/Dockerfile
@@ -4,7 +4,7 @@
 # strips dev deps, produces a self-contained directory).
 
 # ── builder ────────────────────────────────────────────────────────────────
-FROM node:22-alpine@sha256:968df39aedcea65eeb078fb336ed7191baf48f972b4479711397108be0966920 AS builder
+FROM node:24-alpine@sha256:fb71d01345f11b708a3553c66e7c74074f2d506400ea81973343d915cb64eef0 AS builder
 WORKDIR /app
 
 # Honor the packageManager pin in root package.json.
@@ -43,7 +43,7 @@ RUN pnpm --filter cycling-coach... build
 RUN pnpm --filter cycling-coach --prod --legacy deploy /app/runtime-bundle
 
 # ── runtime ────────────────────────────────────────────────────────────────
-FROM node:22-alpine@sha256:968df39aedcea65eeb078fb336ed7191baf48f972b4479711397108be0966920 AS runtime
+FROM node:24-alpine@sha256:fb71d01345f11b708a3553c66e7c74074f2d506400ea81973343d915cb64eef0 AS runtime
 WORKDIR /app
 
 ENV NODE_ENV=production


### PR DESCRIPTION
## What

Bumps the `cycling-coach` Dockerfile base image (both builder and runtime stages) from `node:22-alpine` to `node:24-alpine`, pinned by digest. Also pins the dependabot docker ecosystem to hold the major at the current LTS line.

## Why this instead of the open node:26 bump (#172)

- **Node 24 is the Active LTS line** and is exactly the Node the release pipeline already runs (`release.yml` / `version-pr.yml` pin `node-version: 24`). Node 26 is a non-LTS Current release, ahead of and out of line with what the code is tested and released against.
- The dependabot pin (`ignore` semver-major for `node`) keeps digest/minor/patch security updates flowing on the 24 line while moving majors by hand to the next even LTS — so the image won't auto-jump onto odd-numbered Current releases again.

## Validation

- CI `test` check gates this PR (set to auto-merge on green).
- Note: no workflow builds the Docker image, and Docker wasn't available locally to build it here. Node 24 is low-risk on that front since the release pipeline already runs on it.

Supersedes #172, which should be closed.