### PR TITLE
fix(core): kill the process group on secrets spawn timeout

### DIFF
--- a/packages/core/src/secrets/backends/_spawn.ts
+++ b/packages/core/src/secrets/backends/_spawn.ts
@@ -40,6 +40,7 @@ function runSpawn(
       stdio: [stdinData === null ? "ignore" : "pipe", "pipe", "pipe"],
       windowsHide: true,
       env: process.env,
+      detached: true,
     });
 
     let stdout = "";
@@ -49,7 +50,17 @@ function runSpawn(
 
     const timer = setTimeout(() => {
       timedOut = true;
-      child.kill("SIGKILL");
+      // Kill the whole process group, not just the direct child, so a forked
+      // grandchild can't keep the inherited stdio pipes open and stall "close".
+      if (process.platform !== "win32" && child.pid !== undefined) {
+        try {
+          process.kill(-child.pid, "SIGKILL");
+        } catch {
+          child.kill("SIGKILL");
+        }
+      } else {
+        child.kill("SIGKILL");
+      }
     }, opts.timeoutMs);
 
     child.stdout?.on("data", (chunk: Buffer) => {

--- a/packages/core/tests/secrets/backends/detect.test.ts
+++ b/packages/core/tests/secrets/backends/detect.test.ts
@@ -105,9 +105,8 @@ exit 2
   });
 
   it("returns unavailable/other with detail 'timeout' when op hangs past timeoutMs", async () => {
-    // sleep 2 (not 5) — _spawn.ts waits for `close` which only fires once the
-    // sleep child exits; under vitest's 5s default testTimeout, `sleep 5` is
-    // right on the edge and CI's Linux scheduler pushes it over.
+    // Resolves at ~timeoutMs, not at the sleep child's exit: _spawn.ts kills the
+    // child's process group on timeout, so the grandchild can't hold `close` open.
     const opPath = await makeOpStub(`sleep 2`);
     const result = await _detectBackendsWithOverrides({
       opPath,

--- a/packages/core/tests/secrets/backends/spawn-timeout.test.ts
+++ b/packages/core/tests/secrets/backends/spawn-timeout.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnCapture, spawnStdin } from "../../../src/secrets/backends/_spawn.js";
+
+const stubDirs: string[] = [];
+
+async function makeSleepStub(script: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "spawn-timeout-"));
+  stubDirs.push(dir);
+  const path = join(dir, "stub");
+  await writeFile(path, `#!/bin/sh\n${script}\n`, { mode: 0o755 });
+  return path;
+}
+
+afterEach(async () => {
+  while (stubDirs.length > 0) {
+    const dir = stubDirs.pop();
+    if (dir) await rm(dir, { recursive: true, force: true });
+  }
+});
+
+describe("spawn timeout group-kill", () => {
+  it("resolves at ~timeoutMs even when a grandchild outlives the kill", async () => {
+    const stub = await makeSleepStub("sleep 5");
+    const start = Date.now();
+    const res = await spawnCapture(stub, [], { timeoutMs: 200 });
+    const elapsed = Date.now() - start;
+    expect(res.timedOut).toBe(true);
+    expect(res.exitCode).toBe(null);
+    // The fix resolves at ~205 ms; unfixed it waits for the sleep 5 grandchild
+    // (~5000 ms). 2000 ms cleanly separates the two and absorbs CI jitter.
+    expect(elapsed).toBeLessThan(2000);
+  });
+
+  it("times out the stdin entry point the same way", async () => {
+    const stub = await makeSleepStub("sleep 5");
+    const start = Date.now();
+    const res = await spawnStdin(stub, [], "payload", { timeoutMs: 200 });
+    expect(res.timedOut).toBe(true);
+    expect(Date.now() - start).toBeLessThan(2000);
+  });
+
+  it("lets a fast stub resolve normally well under the timeout", async () => {
+    const stub = await makeSleepStub("printf 'hello'");
+    const res = await spawnCapture(stub, [], { timeoutMs: 5000 });
+    expect(res.timedOut).toBe(false);
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toBe("hello");
+  });
+});


### PR DESCRIPTION
## What

The secrets-spawn helper that backs the credential backends (the `spawnCapture` and `spawnStdin` entry points, both routed through the shared `runSpawn`) now spawns its child process detached, making the child the leader of its own process group. On timeout, the helper kills the entire process group via the negative pid on POSIX rather than only the direct child.

## Why

Previously, when a helper invocation exceeded its timeout budget, the helper sent `SIGKILL` to the direct child only. If that child had forked a grandchild, the grandchild inherited the stdio pipes and kept them open, so the `close` event never fired and the operation stalled well past the configured `timeoutMs` — resolving only when the grandchild itself exited. Killing the whole group reaps the grandchild too, so the inherited pipes close and the timeout resolves at the configured budget.

This fixes both the production timeout-contract wart and a set of secrets timeout tests that were flaky by construction (they waited on grandchild exit rather than on the timeout).

## How

- In `runSpawn`, the spawn options gain `detached: true` so the child becomes a process-group leader and any grandchildren join the group.
- The timeout handler group-kills on POSIX: `process.kill(-pid, "SIGKILL")`, guarded behind a platform check and a pid-defined null guard, wrapped in a try/catch that falls back to a direct `child.kill("SIGKILL")` for the already-exited-child race (negative-pid kill throws `ESRCH`). On Windows, or when the pid is undefined, it falls back to the direct child kill.

Caller semantics are unchanged — `timedOut` resolution behaves identically from the callers' perspective; only the kill mechanism changed.

## Tests

- Adds a helper-layer wall-time regression test for the spawn helper: a stub that sleeps past the timeout now resolves at roughly the timeout budget (under two seconds) instead of at grandchild exit (~five seconds), and the SIGKILL'd child reports a null exit code. Both `spawnCapture` and `spawnStdin` are exercised to confirm they share the group-kill path. A fast-exiting stub still resolves normally with intact stdout, confirming the detached spawn did not break the happy path.
- Refreshes a now-stale stub comment in the backend-detection test that justified its sleep on the old grandchild-stall behavior.

This is an internal-reliability change with no athlete-facing surface, so it ships without a changeset.
