### PR TITLE
ci: add Node 24 test gate and scoped macOS secrets leg, revive dead test gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,17 +12,13 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        node: [22, 24]
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         # Reads `packageManager` from root package.json (corepack-style pin).
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: ${{ matrix.node }}
+          node-version: 24
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,26 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [22, 24]
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        # Reads `packageManager` from root package.json (corepack-style pin).
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: ${{ matrix.node }}
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm check
+      - run: pnpm test
+
+  secrets-macos:
+    runs-on: macos-latest
+    env:
+      CI: macos
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
@@ -21,5 +41,4 @@ jobs:
           node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - run: pnpm check
-      - run: pnpm test
+      - run: pnpm --filter @enduragent/core exec vitest run tests/secrets

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ AI cycling coaching agent. Bring your own LLM API key **or sign in with a ChatGP
 
 Requires [Node.js](https://nodejs.org/) 22+ (comes with npm).
 
+Supported on macOS and Linux. Windows is not supported — the secrets backends and process handling are POSIX-shaped (use WSL2 if you must run on Windows).
+
 Open **Terminal** (Mac/Linux) or **PowerShell** (Windows) and run:
 
 ```bash

--- a/packages/core/tests/fixtures/mocks/synthetic-raw-mock.expected.json
+++ b/packages/core/tests/fixtures/mocks/synthetic-raw-mock.expected.json
@@ -1,0 +1,45 @@
+{
+  "activities": [
+    {
+      "id": 12345,
+      "start_date_local": "1998-03-01T07:00:00",
+      "type": "Ride",
+      "moving_time": 3600,
+      "elapsed_time": 3720,
+      "icu_training_load": 65,
+      "average_watts": 180,
+      "average_heartrate": 142
+    },
+    {
+      "id": 12345,
+      "start_date_local": "1998-03-03T06:30:00",
+      "type": "Ride",
+      "moving_time": 5400,
+      "elapsed_time": 5500,
+      "icu_training_load": 95,
+      "average_watts": 195,
+      "average_heartrate": 150
+    }
+  ],
+  "wellness": [
+    {
+      "id": "1998-03-01",
+      "weight": 72,
+      "restingHR": 48,
+      "hrv": 65
+    },
+    {
+      "id": "1998-03-03",
+      "weight": 71.8,
+      "restingHR": 47,
+      "hrv": 68
+    }
+  ],
+  "ftp_history": [
+    {
+      "date": "1998-02-15",
+      "ftp": 250,
+      "source": "estimate"
+    }
+  ]
+}

--- a/packages/core/tests/fixtures/mocks/synthetic-raw-mock.json
+++ b/packages/core/tests/fixtures/mocks/synthetic-raw-mock.json
@@ -1,0 +1,31 @@
+{
+  "activities": [
+    {
+      "id": 90101,
+      "start_date_local": "2026-03-01T07:00:00",
+      "type": "Ride",
+      "moving_time": 3600,
+      "elapsed_time": 3720,
+      "icu_training_load": 65,
+      "average_watts": 180,
+      "average_heartrate": 142
+    },
+    {
+      "id": 90102,
+      "start_date_local": "2026-03-03T06:30:00",
+      "type": "Ride",
+      "moving_time": 5400,
+      "elapsed_time": 5500,
+      "icu_training_load": 95,
+      "average_watts": 195,
+      "average_heartrate": 150
+    }
+  ],
+  "wellness": [
+    { "id": "2026-03-01", "weight": 72.0, "restingHR": 48, "hrv": 65 },
+    { "id": "2026-03-03", "weight": 71.8, "restingHR": 47, "hrv": 68 }
+  ],
+  "ftp_history": [
+    { "date": "2026-02-15", "ftp": 250, "source": "estimate" }
+  ]
+}

--- a/packages/core/tests/sanitize-cli-fixture-stability.test.ts
+++ b/packages/core/tests/sanitize-cli-fixture-stability.test.ts
@@ -28,6 +28,24 @@ const GOLDEN_PATH = join(
   "golden",
   "realistic-athlete.json",
 );
+const SYNTHETIC_MOCK_PATH = join(
+  REPO_ROOT,
+  "packages",
+  "core",
+  "tests",
+  "fixtures",
+  "mocks",
+  "synthetic-raw-mock.json",
+);
+const SYNTHETIC_EXPECTED_PATH = join(
+  REPO_ROOT,
+  "packages",
+  "core",
+  "tests",
+  "fixtures",
+  "mocks",
+  "synthetic-raw-mock.expected.json",
+);
 
 let dirs: string[] = [];
 afterEach(() => {
@@ -55,4 +73,22 @@ describe("sanitize CLI fixture stability", () => {
       expect(regenerated.equals(committed)).toBe(true);
     },
   );
+});
+
+describe("sanitize CLI fixture stability (synthetic, CI-runnable)", () => {
+  it("running the CLI on the committed synthetic mock is byte-identical to the committed expected output", async () => {
+    const outputDir = mkdtempSync(join(tmpdir(), "sanitize-synth-stability-"));
+    dirs.push(outputDir);
+
+    const exit = await main([SYNTHETIC_MOCK_PATH, "synthetic-raw-mock", "--force"], {
+      outputRoot: outputDir,
+      out: () => {},
+      err: () => {},
+    });
+
+    expect(exit).toBe(0);
+    const regenerated = readFileSync(join(outputDir, "synthetic-raw-mock.json"));
+    const expected = readFileSync(SYNTHETIC_EXPECTED_PATH);
+    expect(regenerated.equals(expected)).toBe(true);
+  });
 });

--- a/packages/core/tests/secrets/backends/keychain.test.ts
+++ b/packages/core/tests/secrets/backends/keychain.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { access, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { execFile } from "node:child_process";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { promisify } from "node:util";
 import {
   KeychainUnsafeValueError,
   KeychainUnsupportedPlatformError,
@@ -390,16 +392,30 @@ describe("keychainSecretRef", () => {
   });
 });
 
-describe("keychain idempotency (CI-only)", () => {
+const execFileAsync = promisify(execFile);
+
+describe("keychain idempotency (CI-only, real keychain)", () => {
   it.skipIf(process.env.CI !== "macos")(
-    "keychainItemUpsert stores the second value when called twice with different values",
+    "upsert twice with different values; find-generic-password returns the second",
     async () => {
-      // Placeholder for the CI-only integration test. Real implementation would:
-      //   1. keychainItemUpsert(field, "v1", realLoginPath)
-      //   2. keychainItemUpsert(field, "v2", realLoginPath)
-      //   3. spawn `security find-generic-password -w ...` and assert stdout === "v2"
-      //   4. keychainItemDelete(field, realLoginPath) for cleanup.
-      expect(true).toBe(true);
+      const field = `cc_citest_${process.pid}_${Math.random().toString(36).slice(2)}`;
+      const loginPath = await keychainLoginPath();
+      try {
+        await keychainItemUpsert(field, "v1", loginPath, { platform: "darwin" });
+        await keychainItemUpsert(field, "v2", loginPath, { platform: "darwin" });
+        const { stdout } = await execFileAsync("/usr/bin/security", [
+          "find-generic-password",
+          "-w",
+          "-s",
+          "cycling-coach",
+          "-a",
+          field,
+          loginPath,
+        ]);
+        expect(stdout.trim()).toBe("v2");
+      } finally {
+        await keychainItemDelete(field, loginPath);
+      }
     },
   );
 });


### PR DESCRIPTION
## What changed

CI grows from a single environment cell into a Node version matrix plus a tightly-scoped macOS secrets leg, and two structurally-dead test gates are revived so they actually run.

### CI workflow

The Linux test job now runs a `fail-fast: false` matrix across Node 22 and 24 — the floor and the release runtime — consuming the raised engines floor that the recent engines-floor change established (the matrix is `[22, 24]` precisely because the floor is now `>=22`; there is deliberately no Node-20 leg). The pinned action SHAs are unchanged. A second `macos-latest` job sets `CI=macos` and runs only the secrets suite (`vitest run tests/secrets`), not the full check/test aggregator, to keep macOS runner minutes tightly bounded.

### Revived keychain integration test

The previous keychain placeholder was a tautology that never exercised the backend. It is now a real macOS-gated integration test (the implemented path, not the delete fallback): it upserts a throwaway login-keychain field twice, reads it back via `security find-generic-password`, asserts the second value won, and deletes the field in a `finally`. It stays skipped everywhere except the macOS leg (and locally when an operator exports `CI=macos`), so it is correct-by-construction on Linux clones.

### Synthetic sanitize-stability gate that runs in CI

A small synthetic raw bundle and its CLI-generated expected output are committed under the test fixtures' `mocks/` directory (outside `golden/`, with reserved-range integer activity ids and fabricated dates so the date-shift transform has a visible, verifiable effect). A new no-skip stability test regenerates the sanitized output into a tmpdir and asserts byte-identity against the committed expected file. Because the input is now committed rather than a gitignored local artifact, this byte-identity gate runs on every CI leg and every clone, catching committed-output drift for the synthetic substrate. The existing real-data stability test is preserved byte-for-byte. Both new fixture files pass the fixture-privacy gate with no allowlist edit.

### README

A short supported-OS note sits near the Node-version requirement: macOS and Linux are supported, Windows is unsupported (the secrets backends and spawn semantics are POSIX-shaped). The existing terminal-instruction line is untouched.

## Sibling work

This builds on the engines-floor change (which raised the floor to `22+`) and the spawn process-group-kill fix already on main.

## Notes

No changeset: this is a CI, test, and README-scope change with no athlete-visible behavior change.
