### PR TITLE
chore(core): add an exports map to block deep subpath imports

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -6,6 +6,9 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": "./dist/index.js"
+  },
   "license": "MIT",
   "scripts": {
     "build": "tsup",

--- a/packages/core/tests/reference-adapter-delegation-surface.test.ts
+++ b/packages/core/tests/reference-adapter-delegation-surface.test.ts
@@ -16,6 +16,9 @@
  */
 
 import { describe, it, expect, expectTypeOf } from "vitest";
+import { execFileSync } from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import {
   computeDfaA1Profile,
   computePowerCurveDelta,
@@ -86,5 +89,21 @@ describe("registry stays the sole writer of the capability metrics (OP1)", () =>
 
   it("does not leak the registry through the public barrel", () => {
     expect("METRIC_REGISTRY" in corePublicApi).toBe(false);
+  });
+
+  it("blocks deep package-specifier imports into core internals", () => {
+    // vitest resolves through Vite, which ignores Node's package `exports`
+    // field, so the boundary is asserted under Node's own loader via a child.
+    const corePkgRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+    const probe =
+      "import('@enduragent/core/dist/reference/metrics/registry.js')" +
+      ".then(() => process.stdout.write('RESOLVED'))" +
+      ".catch((err) => process.stdout.write(String(err?.code)));";
+    const reported = execFileSync(
+      process.execPath,
+      ["--input-type=module", "-e", probe],
+      { cwd: corePkgRoot, encoding: "utf8" },
+    );
+    expect(reported).toBe("ERR_PACKAGE_PATH_NOT_EXPORTED");
   });
 });

--- a/tools/check-registry-isolation.ts
+++ b/tools/check-registry-isolation.ts
@@ -27,12 +27,14 @@
  * import, member access, mutation) is a violation. Every realistic import/use
  * form surfaces the identifier by name, so this covers them all.
  *
- * One adversarial form is an accepted residual gap, NOT caught here: a dynamic
+ * The one adversarial form this lint cannot see by construction — a dynamic
  * string-keyed access (`ns["METRIC_REGISTRY"]`) reached via a deep import of
- * core internals. The public `@enduragent/core` barrel does not export the
- * registry (pinned in `reference-adapter-delegation-surface`), but deep
- * subpath/relative imports into core are not yet mechanically blocked, so that
- * exotic path is left to reviewer discipline rather than this lint.
+ * core internals — is now closed structurally rather than by this lint. The
+ * public `@enduragent/core` barrel does not export the registry (pinned in
+ * `reference-adapter-delegation-surface`), AND `@enduragent/core`'s package
+ * `exports` map exposes only the public entry, so any package-specifier deep
+ * import into core internals fails to resolve (`ERR_PACKAGE_PATH_NOT_EXPORTED`).
+ * The exotic path therefore cannot be reached from a sport package at all.
  *
  * Files that legitimately name the identifier (this linter, its test) opt out
  * via a `registry-isolation-lint:skip-file` marker in the first 1 KB.


### PR DESCRIPTION
## Summary

Adds a package `exports` map to `@enduragent/core` so that Node and every exports-honoring bundler reject deep subpath imports into the package's internals at resolution time. The map exposes only the public entry (`"."` → `./dist/index.js`); the existing `main` and `types` top-level fields are retained alongside it so legacy resolvers continue to work. No other `package.json` field is touched, and no public subpath is declared — only the barrel is reachable.

This brings core to the same encapsulation posture the sport packages already ship, and closes a structural escape hatch that the registry-isolation gate cannot see: a string-keyed access to the metric registry reached through a deep package-specifier import. The public barrel never exported the registry, but until now a deep subpath import could still reach core internals. With the exports map in place, any such package-specifier deep import fails to resolve with `ERR_PACKAGE_PATH_NOT_EXPORTED`, so that path cannot be reached from a sport package at all.

This addresses the architect-review finding on core's package boundary surfaced during the registry-isolation review.

## Changes by surface

- **Package boundary** (`packages/core/package.json`): adds the minimal `exports` map (`{ ".": "./dist/index.js" }`) directly after `types`, mirroring the sibling sport package's shape. `main` and `types` are kept top-level; no `./package.json` entry and no nested `types` condition are added.
- **Registry-isolation gate JSDoc** (`tools/check-registry-isolation.ts`): tightens the residual-gap paragraph to state that the deep-import path is now closed structurally by the package exports map (citing the `ERR_PACKAGE_PATH_NOT_EXPORTED` resolution failure) rather than describing it as an open gap left to reviewer discipline. The skip-file marker, target identifier, AST-walk logic, and CLI behavior are untouched.
- **Encapsulation test** (`packages/core/tests/reference-adapter-delegation-surface.test.ts`): adds one co-located case that pins the new guarantee as the structural complement of the existing barrel-leak guard. Because vitest resolves through Vite — which ignores Node's `exports` field — the case exercises the boundary under Node's own ESM loader via a short-lived child process and asserts the deep package-specifier import rejects with `ERR_PACKAGE_PATH_NOT_EXPORTED`.

## Notes

- No changeset: this is an internal packaging change to a private workspace package with no athlete-visible behavior.
- This is the structural mechanism for the boundary; the follow-up shared-FS-helper extraction ships separately.

## Test plan

- `pnpm -r build` — clean full build of every workspace package succeeds; build entry and cross-package imports still resolve.
- `pnpm check` — full aggregator green (build, per-package typecheck, lint, trademark / fixture-privacy / registry-isolation gates).
- `pnpm test` — full suite green, including the new deep-import case and the unchanged barrel-leak guard.
- Verified the new test fails on main-before-the-change (deep import resolves differently) and passes after, proving it pins the new guarantee rather than a pre-existing condition.
