### PR TITLE
refactor(tools): extract shared file-system gate helper

### DIFF
--- a/tools/check-fixture-privacy.ts
+++ b/tools/check-fixture-privacy.ts
@@ -38,8 +38,8 @@
  */
 
 import * as ts from "typescript";
-import { readFileSync, readdirSync, statSync } from "node:fs";
-import { join } from "node:path";
+import { readFileSync } from "node:fs";
+import { TS_EXTS, ext, collectFiles, makeSkipCheck, nonFlagArgs, runGateCli } from "./lint-fs.js";
 
 export type PrivacyRule = "intervals-id" | "current-era-date";
 
@@ -91,7 +91,6 @@ export const SYNTHETIC_FIXTURE_ALLOWLIST: ReadonlySet<string> = new Set([
   "zero-activities.json",
 ]);
 
-const TS_EXTS = new Set([".ts", ".tsx", ".cts", ".mts"]);
 const MD_EXTS = new Set([".md", ".mdx"]);
 const JSON_EXTS = new Set([".json"]);
 
@@ -99,19 +98,12 @@ const SKIP_DIRECTIVE = "fixture-privacy-lint:skip-file";
 
 const GOLDEN_FIXTURE_DIR = "packages/core/tests/fixtures/golden";
 
-function getExt(file: string): string {
-  const i = file.lastIndexOf(".");
-  return i === -1 ? "" : file.slice(i);
-}
-
 function basenameOf(file: string): string {
   const i = Math.max(file.lastIndexOf("/"), file.lastIndexOf("\\"));
   return i === -1 ? file : file.slice(i + 1);
 }
 
-function isSkippedFile(source: string): boolean {
-  return source.slice(0, 1024).includes(SKIP_DIRECTIVE);
-}
+const isSkippedFile = makeSkipCheck(SKIP_DIRECTIVE);
 
 function* matchIntervalsId(
   text: string,
@@ -300,10 +292,10 @@ function findDateHitsInGoldenFixture(file: string): PrivacyHit[] {
 export function findIdHits(files: readonly string[]): PrivacyHit[] {
   const out: PrivacyHit[] = [];
   for (const file of files) {
-    const ext = getExt(file);
-    if (TS_EXTS.has(ext)) out.push(...findIdHitsInTsFile(file));
-    else if (JSON_EXTS.has(ext)) out.push(...findIdHitsInJsonFile(file));
-    else if (MD_EXTS.has(ext)) out.push(...findIdHitsInMdFile(file));
+    const fileExt = ext(file);
+    if (TS_EXTS.has(fileExt)) out.push(...findIdHitsInTsFile(file));
+    else if (JSON_EXTS.has(fileExt)) out.push(...findIdHitsInJsonFile(file));
+    else if (MD_EXTS.has(fileExt)) out.push(...findIdHitsInMdFile(file));
   }
   return out;
 }
@@ -312,7 +304,7 @@ export function findIdHits(files: readonly string[]): PrivacyHit[] {
 export function findDateHits(goldenFiles: readonly string[]): PrivacyHit[] {
   const out: PrivacyHit[] = [];
   for (const file of goldenFiles) {
-    if (getExt(file) === ".json") out.push(...findDateHitsInGoldenFixture(file));
+    if (ext(file) === ".json") out.push(...findDateHitsInGoldenFixture(file));
   }
   return out;
 }
@@ -321,24 +313,6 @@ export function findDateHits(goldenFiles: readonly string[]): PrivacyHit[] {
 export function findFixturePrivacyHits(files: readonly string[]): PrivacyHit[] {
   const golden = files.filter((f) => f.includes(GOLDEN_FIXTURE_DIR));
   return [...findIdHits(files), ...findDateHits(golden)];
-}
-
-function collectFiles(path: string, out: string[]): void {
-  let st;
-  try {
-    st = statSync(path);
-  } catch {
-    return;
-  }
-  if (st.isFile()) {
-    out.push(path);
-    return;
-  }
-  if (!st.isDirectory()) return;
-  for (const entry of readdirSync(path)) {
-    if (entry === "node_modules" || entry === "dist" || entry.startsWith(".")) continue;
-    collectFiles(join(path, entry), out);
-  }
 }
 
 // Top-level args are statSync'd directly, so the dot-entry skip inside
@@ -360,7 +334,7 @@ function formatHit(hit: PrivacyHit): string {
 }
 
 export function main(argv: readonly string[]): number {
-  const args = argv.filter((a) => !a.startsWith("-"));
+  const args = nonFlagArgs(argv);
   const inputPaths = args.length > 0 ? args : DEFAULT_SCAN_PATHS;
 
   const files: string[] = [];
@@ -391,11 +365,4 @@ export function main(argv: readonly string[]): number {
   return 1;
 }
 
-const isCli =
-  typeof process !== "undefined" &&
-  process.argv[1] !== undefined &&
-  import.meta.url === `file://${process.argv[1]}`;
-
-if (isCli) {
-  process.exit(main(process.argv.slice(2)));
-}
+runGateCli(import.meta.url, main);

--- a/tools/check-registry-isolation.test.ts
+++ b/tools/check-registry-isolation.test.ts
@@ -135,16 +135,6 @@ describe("main", () => {
     expect(main([join(tempDir, "packages")])).toBe(0);
   });
 
-  it("skips node_modules, dist, and dotfile dirs while walking a package tree", () => {
-    // Each excluded dir carries a violation that MUST NOT be reported; only the
-    // src file is in scope and it is clean. Pins the load-bearing exclusion.
-    write("packages/sport-x/node_modules/dep/bad.ts", `export const k = METRIC_REGISTRY;\n`);
-    write("packages/sport-x/dist/out.ts", `export const k = METRIC_REGISTRY;\n`);
-    write("packages/sport-x/.cache/hidden.ts", `export const k = METRIC_REGISTRY;\n`);
-    write("packages/sport-x/src/ok.ts", `export const clean = 1;\n`);
-    expect(main([join(tempDir, "packages")])).toBe(0);
-  });
-
   it("treats an empty or nonexistent scope as a clean pass", () => {
     expect(main([join(tempDir, "does-not-exist")])).toBe(0);
   });

--- a/tools/check-registry-isolation.ts
+++ b/tools/check-registry-isolation.ts
@@ -43,6 +43,7 @@
 import * as ts from "typescript";
 import { readFileSync, readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
+import { TS_EXTS, ext, collectFiles, makeSkipCheck, nonFlagArgs, runGateCli } from "./lint-fs.js";
 
 export interface RegistryReferenceHit {
   readonly file: string;
@@ -53,18 +54,9 @@ export interface RegistryReferenceHit {
 /** The registry export sport packages must never reference. */
 const TARGET_IDENTIFIER = "METRIC_REGISTRY";
 
-const TS_EXTS = new Set([".ts", ".tsx", ".cts", ".mts"]);
-
-function getExt(file: string): string {
-  const i = file.lastIndexOf(".");
-  return i === -1 ? "" : file.slice(i);
-}
-
 const SKIP_DIRECTIVE = "registry-isolation-lint:skip-file";
 
-function isSkippedFile(source: string): boolean {
-  return source.slice(0, 1024).includes(SKIP_DIRECTIVE);
-}
+const isSkippedFile = makeSkipCheck(SKIP_DIRECTIVE);
 
 function findHitsInTsFile(file: string): RegistryReferenceHit[] {
   const source = readFileSync(file, "utf-8");
@@ -93,28 +85,9 @@ function findHitsInTsFile(file: string): RegistryReferenceHit[] {
 export function findRegistryReferences(files: readonly string[]): RegistryReferenceHit[] {
   const out: RegistryReferenceHit[] = [];
   for (const file of files) {
-    if (TS_EXTS.has(getExt(file))) out.push(...findHitsInTsFile(file));
+    if (TS_EXTS.has(ext(file))) out.push(...findHitsInTsFile(file));
   }
   return out;
-}
-
-/** Recursively collect scannable files under a directory. */
-function collectFiles(path: string, out: string[]): void {
-  let st;
-  try {
-    st = statSync(path);
-  } catch {
-    return;
-  }
-  if (st.isFile()) {
-    out.push(path);
-    return;
-  }
-  if (!st.isDirectory()) return;
-  for (const entry of readdirSync(path)) {
-    if (entry === "node_modules" || entry === "dist" || entry.startsWith(".")) continue;
-    collectFiles(join(path, entry), out);
-  }
 }
 
 const PACKAGES_DIR = "packages";
@@ -149,7 +122,7 @@ function formatHit(hit: RegistryReferenceHit): string {
 }
 
 export function main(argv: readonly string[]): number {
-  const args = argv.filter((a) => !a.startsWith("-"));
+  const args = nonFlagArgs(argv);
   const inputPaths = args.length > 0 ? args : discoverSportPackageDirs();
   const files: string[] = [];
   for (const p of inputPaths) collectFiles(p, files);
@@ -176,12 +149,4 @@ export function main(argv: readonly string[]): number {
   return 1;
 }
 
-// CLI entrypoint when invoked directly via `tsx tools/check-registry-isolation.ts`.
-const isCli =
-  typeof process !== "undefined" &&
-  process.argv[1] !== undefined &&
-  import.meta.url === `file://${process.argv[1]}`;
-
-if (isCli) {
-  process.exit(main(process.argv.slice(2)));
-}
+runGateCli(import.meta.url, main);

--- a/tools/check-trademarks.ts
+++ b/tools/check-trademarks.ts
@@ -24,8 +24,8 @@
  */
 
 import * as ts from "typescript";
-import { readFileSync, readdirSync, statSync } from "node:fs";
-import { join } from "node:path";
+import { readFileSync } from "node:fs";
+import { TS_EXTS, ext, collectFiles, makeSkipCheck, nonFlagArgs, runGateCli } from "./lint-fs.js";
 
 export interface TrademarkHit {
   readonly file: string;
@@ -48,13 +48,7 @@ export const FORBIDDEN_TOKENS: Readonly<Record<string, string>> = Object.freeze(
   "Normalized Power": "weighted average power",
 });
 
-const TS_EXTS = new Set([".ts", ".tsx", ".cts", ".mts"]);
 const MD_EXTS = new Set([".md", ".mdx"]);
-
-function getExt(file: string): string {
-  const i = file.lastIndexOf(".");
-  return i === -1 ? "" : file.slice(i);
-}
 
 /**
  * Build a regex that matches each forbidden token with proper word boundaries.
@@ -93,9 +87,7 @@ function* matchInText(
  */
 const SKIP_DIRECTIVE = "trademark-lint:skip-file";
 
-function isSkippedFile(source: string): boolean {
-  return source.slice(0, 1024).includes(SKIP_DIRECTIVE);
-}
+const isSkippedFile = makeSkipCheck(SKIP_DIRECTIVE);
 
 function findHitsInTsFile(file: string): TrademarkHit[] {
   const source = readFileSync(file, "utf-8");
@@ -204,33 +196,14 @@ function findHitsInMdFile(file: string): TrademarkHit[] {
 export function findTrademarkHits(files: readonly string[]): TrademarkHit[] {
   const out: TrademarkHit[] = [];
   for (const file of files) {
-    const ext = getExt(file);
-    if (TS_EXTS.has(ext)) {
+    const fileExt = ext(file);
+    if (TS_EXTS.has(fileExt)) {
       out.push(...findHitsInTsFile(file));
-    } else if (MD_EXTS.has(ext)) {
+    } else if (MD_EXTS.has(fileExt)) {
       out.push(...findHitsInMdFile(file));
     }
   }
   return out;
-}
-
-/** Recursively collect lintable files under a directory. */
-function collectFiles(path: string, out: string[]): void {
-  let st;
-  try {
-    st = statSync(path);
-  } catch {
-    return; // missing path — caller decides whether that's an error
-  }
-  if (st.isFile()) {
-    out.push(path);
-    return;
-  }
-  if (!st.isDirectory()) return;
-  for (const entry of readdirSync(path)) {
-    if (entry === "node_modules" || entry === "dist" || entry.startsWith(".")) continue;
-    collectFiles(join(path, entry), out);
-  }
 }
 
 function formatHit(hit: TrademarkHit): string {
@@ -255,7 +228,7 @@ const DEFAULT_SCAN_PATHS: readonly string[] = [
 ];
 
 export function main(argv: readonly string[]): number {
-  const args = argv.filter((a) => !a.startsWith("-"));
+  const args = nonFlagArgs(argv);
   const inputPaths = args.length > 0 ? args : DEFAULT_SCAN_PATHS;
   const files: string[] = [];
   for (const p of inputPaths) collectFiles(p, files);
@@ -280,13 +253,4 @@ export function main(argv: readonly string[]): number {
   return 1;
 }
 
-// CLI entrypoint when invoked directly via `tsx tools/check-trademarks.ts <files>`.
-// Detect via import.meta.url instead of require.main; this file is ESM.
-const isCli =
-  typeof process !== "undefined" &&
-  process.argv[1] !== undefined &&
-  import.meta.url === `file://${process.argv[1]}`;
-
-if (isCli) {
-  process.exit(main(process.argv.slice(2)));
-}
+runGateCli(import.meta.url, main);

--- a/tools/lint-fs.test.ts
+++ b/tools/lint-fs.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { collectFiles, ext, TS_EXTS, makeSkipCheck, isCliEntry, nonFlagArgs } from "./lint-fs.js";
+
+let tempDir: string;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "lint-fs-"));
+});
+
+afterEach(() => {
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+function write(rel: string, contents: string): string {
+  const p = join(tempDir, rel);
+  mkdirSync(join(p, ".."), { recursive: true });
+  writeFileSync(p, contents, "utf-8");
+  return p;
+}
+
+describe("collectFiles", () => {
+  it("collects nested files, skipping node_modules / dist / dotfile dirs while recursing", () => {
+    write("pkg/src/a.ts", "export const a = 1;\n");
+    write("pkg/src/sub/b.ts", "export const b = 2;\n");
+    write("pkg/node_modules/dep/c.ts", "export const c = 3;\n");
+    write("pkg/dist/d.ts", "export const d = 4;\n");
+    write("pkg/.cache/e.ts", "export const e = 5;\n");
+
+    const out: string[] = [];
+    collectFiles(join(tempDir, "pkg"), out);
+
+    expect(out.some((p) => p.endsWith("a.ts"))).toBe(true);
+    expect(out.some((p) => p.endsWith("b.ts"))).toBe(true);
+    expect(out.some((p) => p.endsWith("c.ts"))).toBe(false);
+    expect(out.some((p) => p.endsWith("d.ts"))).toBe(false);
+    expect(out.some((p) => p.endsWith("e.ts"))).toBe(false);
+  });
+
+  it("collects a single file passed directly (top-level stat, not a dir walk)", () => {
+    const file = write("pkg/src/a.ts", "export const a = 1;\n");
+    const out: string[] = [];
+    collectFiles(file, out);
+    expect(out).toEqual([file]);
+  });
+
+  it("silently ignores a missing path", () => {
+    const out: string[] = [];
+    expect(() => collectFiles(join(tempDir, "nope"), out)).not.toThrow();
+    expect(out).toEqual([]);
+  });
+
+  it("walks a dotfile dir passed as an explicit top-level arg (the .changeset contract)", () => {
+    write(".changeset/x.ts", "export const x = 1;\n");
+    const out: string[] = [];
+    collectFiles(join(tempDir, ".changeset"), out);
+    expect(out.some((p) => p.endsWith("x.ts"))).toBe(true);
+  });
+});
+
+describe("ext", () => {
+  it("returns the dotted extension for normal files and '' for none", () => {
+    expect(ext("foo.ts")).toBe(".ts");
+    expect(ext("a/b/c.tsx")).toBe(".tsx");
+    expect(ext("Makefile")).toBe("");
+    expect(ext("a.b.json")).toBe(".json");
+  });
+
+  it("treats a leading-dot basename as having no extension (extname semantics)", () => {
+    expect(ext(".bashrc")).toBe("");
+    expect(ext("dir/.config")).toBe("");
+  });
+});
+
+describe("TS_EXTS", () => {
+  it("carries exactly the four TypeScript source extensions", () => {
+    expect([...TS_EXTS].sort()).toEqual([".cts", ".mts", ".ts", ".tsx"]);
+  });
+});
+
+describe("makeSkipCheck", () => {
+  it("detects the directive within the first 1 KB, in any comment style", () => {
+    const skip = makeSkipCheck("my-lint:skip-file");
+    expect(skip("// my-lint:skip-file\ncode")).toBe(true);
+    expect(skip("<!-- my-lint:skip-file -->")).toBe(true);
+    expect(skip("clean source")).toBe(false);
+  });
+
+  it("does NOT detect a directive past the 1 KB header window", () => {
+    const skip = makeSkipCheck("my-lint:skip-file");
+    expect(skip("a".repeat(1100) + "\nmy-lint:skip-file")).toBe(false);
+  });
+});
+
+describe("nonFlagArgs", () => {
+  it("strips --flag / -x args and keeps paths", () => {
+    expect(nonFlagArgs(["--strict", "packages", "-q", "tools"])).toEqual(["packages", "tools"]);
+  });
+});
+
+describe("isCliEntry", () => {
+  it("returns false for a non-matching meta URL", () => {
+    expect(isCliEntry("file:///definitely/not/the/entry.ts")).toBe(false);
+  });
+});
+
+describe("shared module is token-clean (AC-5)", () => {
+  it("carries no gate domain tokens", () => {
+    const src = readFileSync(new URL("./lint-fs.ts", import.meta.url), "utf-8");
+    expect(src).not.toContain("METRIC_REGISTRY");
+    expect(src).not.toMatch(/\bi\d{8,9}\b/);
+    expect(src).not.toContain("skip-file");
+  });
+});

--- a/tools/lint-fs.ts
+++ b/tools/lint-fs.ts
@@ -1,0 +1,75 @@
+/**
+ * Shared file-system / CLI plumbing for the repo's shape-based static gates.
+ *
+ * Each gate (`tools/check-*.ts`) keeps its own domain logic — the token regex,
+ * the id-shape regex + date walk, the identifier AST walk — and imports the
+ * generic, domain-free pieces from here: the recursive file walk with its
+ * directory-exclusion contract, the TypeScript source-extension set, the
+ * extension helper, the skip-directive factory, and the ESM-entry CLI runner.
+ *
+ * This module is deliberately free of any gate's domain vocabulary so it can be
+ * imported by every gate without itself becoming a surface any gate must scan.
+ */
+
+import { readdirSync, statSync } from "node:fs";
+import { join, extname } from "node:path";
+
+/** The TypeScript source extensions every gate AST-walks. */
+export const TS_EXTS: ReadonlySet<string> = new Set([".ts", ".tsx", ".cts", ".mts"]);
+
+/** File extension including the leading dot, or "" if none. */
+export function ext(file: string): string {
+  return extname(file);
+}
+
+/**
+ * Recursively collect files under `path` into `out`. Top-level args are
+ * statSync'd directly; while RECURSING, node_modules/dist/dotfile entries are
+ * skipped (so a dotfile dir passed as an explicit arg — e.g. `.changeset` — is
+ * still walked, but a `.cache` dir found inside a tree is not). Missing paths
+ * are silently ignored; the caller decides whether empty scope is an error.
+ */
+export function collectFiles(path: string, out: string[]): void {
+  let st;
+  try {
+    st = statSync(path);
+  } catch {
+    return;
+  }
+  if (st.isFile()) {
+    out.push(path);
+    return;
+  }
+  if (!st.isDirectory()) return;
+  for (const entry of readdirSync(path)) {
+    if (entry === "node_modules" || entry === "dist" || entry.startsWith(".")) continue;
+    collectFiles(join(path, entry), out);
+  }
+}
+
+/**
+ * Build a per-gate "is this file opted out?" predicate. A file opts out by
+ * placing the gate's skip directive within its first 1 KB, in any comment style.
+ */
+export function makeSkipCheck(directive: string): (source: string) => boolean {
+  return (source: string) => source.slice(0, 1024).includes(directive);
+}
+
+/** True when this module's gate file was invoked directly as the ESM entrypoint. */
+export function isCliEntry(metaUrl: string): boolean {
+  return (
+    typeof process !== "undefined" &&
+    process.argv[1] !== undefined &&
+    metaUrl === `file://${process.argv[1]}`
+  );
+}
+
+/** Strip flag-style args (`--strict`, `-x`) from an argv list. */
+export function nonFlagArgs(argv: readonly string[]): string[] {
+  return argv.filter((a) => !a.startsWith("-"));
+}
+
+/** Run a gate's `main` and exit with its code when invoked as the CLI entry. */
+export function runGateCli(metaUrl: string, main: (argv: readonly string[]) => number): void {
+  if (isCliEntry(metaUrl)) process.exit(main(process.argv.slice(2)));
+}


### PR DESCRIPTION
Three shape-based static gates each carried a near-identical copy of the same file-system and CLI plumbing: a recursive directory walk that collects source files while skipping `node_modules`, `dist`, and dotfile directories; the set of TypeScript extensions; an extension helper; a first-1KB skip-directive check; and the ESM-entry guard plus argument-filter and exit-code contract for running the gate as a CLI.

This change lifts that shared plumbing into a single token-clean `tools/lint-fs.ts` that all three gates import, so a future fourth gate starts from the shared module instead of cloning a fourth copy.

What moved into `tools/lint-fs.ts`:

- `collectFiles` — the recursive walk (stats the top-level arguments directly, skips dotfile entries only while recursing, silently ignores missing paths).
- `TS_EXTS` — the read-only set of TypeScript file extensions.
- `ext` — the extension primitive, now built on Node's `extname`. This folds in the one intentional micro-change (the previous hand-rolled extractor is replaced by `extname`), proven behavior-neutral because dotfiles are never extension-routed.
- `makeSkipCheck` — the skip-directive factory returning a first-1024-character substring predicate.
- `isCliEntry` / `runGateCli` — the ESM-entry guard and CLI runner.
- `nonFlagArgs` — the positional-argument filter.

Each gate keeps its own domain logic: the trademark gate keeps its token regex and finders, the fixture-privacy gate keeps its id-shape regex, date walk, and synthetic allowlists (including its two-pass scan over the golden-fixture directory), and the registry-isolation gate keeps its identifier AST walk and sport-package discovery. The shared module deliberately contains none of those domain tokens.

Testing: the single directory-exclusion assertion that previously lived in the registry-isolation gate test now runs once against the shared `collectFiles` in a new `tools/lint-fs.test.ts`, alongside coverage for the extension helper, the extension set, the skip-directive factory, the argument filter, the CLI-entry guard, and a cleanliness case that pins the shared module free of domain-specific tokens. No per-gate exclusion test remains.

Behavior is preserved: all three gates produce identical hit sets, exit codes, and report strings as before. This is a build/tooling refactor with no user-facing change, so it ships no changeset.

This lands alongside the package-exports-map change and the earlier registry-isolation gate work.
