### PR TITLE
fix(config): copy patches dir into Docker image before pnpm install

### DIFF
--- a/packages/cycling-coach/Dockerfile
+++ b/packages/cycling-coach/Dockerfile
@@ -20,6 +20,10 @@ COPY packages/core/package.json ./packages/core/
 COPY packages/sport-cycling/package.json ./packages/sport-cycling/
 COPY packages/cycling-coach/package.json ./packages/cycling-coach/
 
+# pnpm.patchedDependencies in the root manifest references patches/*.patch;
+# `pnpm install` reads them during resolution, so they must exist before install.
+COPY patches ./patches
+
 RUN pnpm install --filter cycling-coach... --frozen-lockfile
 
 # Source after deps for cache reuse.


### PR DESCRIPTION
## Problem

The Railway build fails at `pnpm install --filter cycling-coach... --frozen-lockfile` with:

```
ENOENT: no such file or directory, open '/app/patches/@mariozechner__pi-ai@0.67.6.patch'
```

The root `package.json` declares a `pnpm.patchedDependencies` entry pointing at `patches/@mariozechner__pi-ai@0.67.6.patch`. pnpm reads patch files during resolution, so they must exist in the image before `pnpm install` runs. The Dockerfile copied the workspace manifests and lockfile but never copied `patches/`, so the install aborted (exit 254).

## Fix

Add `COPY patches ./patches` after the manifest copies and before `pnpm install`. The patch is git-tracked and not in `.dockerignore`, so it's already in the build context — it just needed to land in the image layer. Placed before install to keep the cache-friendly ordering (patches change rarely).

## Verification

- Lockfile patch hash matches the tracked file, so `--frozen-lockfile` has what it needs.
- Could not run a local Docker build (no daemon on this machine); the failure was unambiguously the missing file.