### PR TITLE
fix(config): chown mounted data volume before dropping to non-root user

### DIFF
--- a/packages/cycling-coach/Dockerfile
+++ b/packages/cycling-coach/Dockerfile
@@ -53,10 +53,15 @@ WORKDIR /app
 ENV NODE_ENV=production
 ENV CYCLING_COACH_HOME=/data
 
+# su-exec drops root to `node` in the entrypoint after the mounted volume's
+# ownership is fixed (managed-platform volumes mount as root).
+RUN apk add --no-cache su-exec
+
 COPY --from=builder --chown=root:root /app/runtime-bundle ./
+COPY packages/cycling-coach/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh && mkdir -p /data
 
-RUN mkdir -p /data && chown node:node /data && chmod 700 /data
-
-USER node
-
+# Intentionally NOT `USER node`: the container starts as root so the entrypoint
+# can chown the runtime-mounted volume, then execs the process as `node`.
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 CMD ["node", "dist/index.js"]

--- a/packages/cycling-coach/docker-entrypoint.sh
+++ b/packages/cycling-coach/docker-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -e
+
+# Platforms like Railway mount the persistent volume at $CYCLING_COACH_HOME owned
+# by root, overlaying the build-time directory. The app runs as the non-root
+# `node` user and locks the data dir to 0700, so it must own it. Start as root,
+# hand the volume to `node`, then drop privileges for the actual process.
+DATA_DIR="${CYCLING_COACH_HOME:-/data}"
+
+if [ "$(id -u)" = "0" ]; then
+  mkdir -p "$DATA_DIR"
+  chown -R node:node "$DATA_DIR"
+  exec su-exec node "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
## Problem

The build now succeeds, but the container crash-loops on startup:

```
Error: EPERM: operation not permitted, chmod '/data'
    at ensureDataDirSecure (file:///app/dist/index.js:739:7)
```

Managed platforms (Railway) mount the persistent volume at `/data` **owned by root**, overlaying the build-time directory. The image runs as the non-root `node` user (`USER node`), so:

1. `ensureDataDirSecure` calls `chmod('/data')` → `EPERM` (node doesn't own the root-owned mount) → crash loop.
2. Even past that, `node` couldn't *write* to the root-owned volume, so it would fail on the first data write regardless.

Fixing only the chmod is insufficient — the volume ownership itself is wrong.

## Fix

Use the canonical non-root-with-volume pattern: start the container as root, fix the volume ownership in an entrypoint, then drop privileges.

- Add `docker-entrypoint.sh`: as root, `chown -R node:node $CYCLING_COACH_HOME`, then `exec su-exec node "$@"`.
- Install `su-exec`; replace `USER node` with the entrypoint (container starts as root, process runs as node).

The 0700 data-dir security invariant is preserved: `node` ends up owning the dir, so `ensureDataDirSecure` succeeds as designed and the final process is non-root. `exec` keeps signal propagation intact for graceful shutdown.

## Verification

- Could not run a local Docker build (no daemon on this machine). Logic verified: entrypoint runs as root first, hands the volume to node, execs as node; `su-exec` is in the alpine package repo; entrypoint is in the build context and made executable.