### PR TITLE
refactor(core): move show-numbers review structure into the system-prompt builder and sport-prefix skill keys

### DIFF
--- a/packages/core/CONTEXT.md
+++ b/packages/core/CONTEXT.md
@@ -56,6 +56,9 @@ One user's chat state with one Binary, persisted to disk and locked against conc
 **Channel**:
 A delivery surface (currently only Telegram); sport-agnostic.
 
+**Static Prefix**:
+The turn-invariant head of the system prompt — SOUL, the joined skill prompts, the rule blocks (untrusted-data, recall, workout-review, data-grounding) — that forms one frozen cache prefix; only the Athlete Context block is volatile and renders last. **Boundary policy:** SOUL and always-needed rules stay preloaded in this prefix. Future skill growth that is not needed every turn (e.g., nutrition depth, race-prep depth) ships tool-retrievable rather than preloaded — but never via per-turn conditional injection, which would reshape the prefix and defeat the cache. A guardrail test fails if the prefix's estimated token count exceeds its ceiling, forcing a conscious preload-vs-retrieve decision instead of silent bloat.
+
 ## Relationships
 
 - A **Binary** wraps exactly one **Sport** plus deployment config.

--- a/packages/core/src/agent/system-prompt.ts
+++ b/packages/core/src/agent/system-prompt.ts
@@ -83,8 +83,22 @@ Plus a 4th when concerning: **Is the bigger picture still on track?** (Form / we
 
 ## Output style
 - **Prose-only.** No tables, no metric-list dumps in the default review.
-- **Numbers on demand.** When the athlete replies "show numbers" (or similar), emit the Tier B / Tier C numeric breakdown as a compact table.
+- **Numbers on demand.** When the athlete asks for numbers, emit the breakdown — see the show-numbers format below.
 - One Telegram message — don't split into multi-message walls.
+
+### Show-numbers follow-up format
+When the athlete replies "show numbers" (or "give me the table", "the data", "details", etc.):
+- After Tier A → emit the Tier B numeric breakdown.
+- After Tier B / C → emit a compact markdown table.
+
+The table is a two-column skeleton:
+
+| Metric | Value |
+|---|---|
+
+with one row per headline metric the sport reports. When per-rep interval data is present, follow the headline table with a per-rep table (one row per rep). The sport's review skill names which rows and columns fill these tables.
+
+Keep it compact. The athlete asked for numbers — no prose around the table.
 
 ### Footer (mandatory)
 - **Tier A and Tier B**: end the review with TWO lines:
@@ -119,7 +133,9 @@ export function buildSystemPrompt(
   memory: Memory,
   tz: string = "UTC",
 ): string {
-  const skillsContent = Object.values(persona.skills).join("\n\n---\n\n");
+  const skillsContent = Object.entries(persona.skills)
+    .map(([name, content]) => `## Skill: ${name}\n\n${content}`)
+    .join("\n\n---\n\n");
   const context = memory.getContext();
 
   // Static rule blocks form the cached prefix; the volatile Athlete Context and

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -21,6 +21,7 @@ export type {
   SportPersona,
   ToolRegistration,
 } from "./sport.js";
+export { mergeSportSkills } from "./sport.js";
 
 // ─── Reference layer (see NOTICE.md for upstream attribution) ────────
 // Per-sport seam types, freshness/timing constants, path resolver, I/O

--- a/packages/core/src/sport.ts
+++ b/packages/core/src/sport.ts
@@ -122,3 +122,29 @@ export type SportPersona = Pick<Sport, "soul" | "skills">;
 /** Slice consumed by the memory store factory and the compaction module. */
 export type SportMemoryShape = Pick<Sport, "memorySections" | "mustPreserveTokens">;
 
+/**
+ * Composes multiple sports' skill records into one, throwing on any colliding
+ * key. The bare-spread alternative silently drops the earlier sport's skill;
+ * a skill block is large enough that a silent loss is worse than a hard failure
+ * at boot. Sports keep their keys sport-prefixed (e.g. `cycling-periodization`)
+ * so collisions are structurally unreachable; this guard is the backstop if a
+ * prefix is ever forgotten.
+ */
+export function mergeSportSkills(
+  ...records: ReadonlyArray<Readonly<Record<string, string>>>
+): Record<string, string> {
+  const merged: Record<string, string> = {};
+  for (const record of records) {
+    for (const [key, value] of Object.entries(record)) {
+      if (key in merged) {
+        throw new Error(
+          `Duplicate skill key "${key}" while composing sports. ` +
+            `Skill keys must be sport-prefixed (e.g. "cycling-${key}") to compose.`,
+        );
+      }
+      merged[key] = value;
+    }
+  }
+  return merged;
+}
+

--- a/packages/core/tests/prefix-token-ceiling.test.ts
+++ b/packages/core/tests/prefix-token-ceiling.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { buildSystemPrompt } from "../src/agent/system-prompt.js";
+import { estimateTokens } from "../src/agent/token-utils.js";
+import { cyclingSport } from "@enduragent/sport-cycling";
+import type { Memory } from "../src/memory/store.js";
+import type { SportPersona } from "../src/sport.js";
+
+const emptyMemory = { getContext: () => "" } as unknown as Memory;
+
+const STATIC_PREFIX_TOKEN_CEILING = 12_000;
+
+describe("static system-prompt prefix token ceiling", () => {
+  it("keeps the real cycling static prefix under the ceiling", () => {
+    const prompt = buildSystemPrompt(cyclingSport, emptyMemory, "UTC");
+    expect(estimateTokens(prompt)).toBeLessThan(STATIC_PREFIX_TOKEN_CEILING);
+  });
+
+  it("measures a non-trivial prefix (reads the full corpus)", () => {
+    expect(
+      estimateTokens(buildSystemPrompt(cyclingSport, emptyMemory, "UTC")),
+    ).toBeGreaterThan(5000);
+  });
+
+  it("emits a ## Skill: header once per skill", () => {
+    const persona: SportPersona = {
+      soul: "# Coach",
+      skills: { periodization: "P content", recovery: "R content" },
+    };
+    const prompt = buildSystemPrompt(persona, emptyMemory);
+    expect(prompt).toContain("## Skill: periodization");
+    expect(prompt).toContain("## Skill: recovery");
+    expect(prompt.split("## Skill: periodization").length).toBe(2);
+    expect(prompt.split("## Skill: recovery").length).toBe(2);
+  });
+
+  it("keeps the static prefix byte-stable across consecutive builds", () => {
+    expect(buildSystemPrompt(cyclingSport, emptyMemory, "UTC")).toBe(
+      buildSystemPrompt(cyclingSport, emptyMemory, "UTC"),
+    );
+  });
+});

--- a/packages/core/tests/system-prompt-review-rules.test.ts
+++ b/packages/core/tests/system-prompt-review-rules.test.ts
@@ -170,4 +170,24 @@ describe("WORKOUT_REVIEW_RULES content", () => {
   it("contains the natural-language scoping clause", () => {
     expect(prompt).toMatch(/remaining text as a scoping hint/);
   });
+
+  it("carries the show-numbers escalation ladder in Core", () => {
+    expect(prompt).toContain("After Tier A");
+    expect(prompt).toContain("compact markdown table");
+    expect(prompt).toContain("give me the table");
+  });
+
+  it("carries the generic show-numbers table skeleton in Core", () => {
+    expect(prompt).toContain("| Metric | Value |");
+    expect(prompt).toContain("no prose around the table");
+  });
+
+  it("keeps cycling metric rows out of Core's WORKOUT_REVIEW_RULES", () => {
+    const reviewSection = prompt
+      .split("\n\n---\n\n")
+      .find((s) => s.startsWith("# Workout Review"));
+    expect(reviewSection).toBeDefined();
+    expect(reviewSection).not.toContain("Avg cadence");
+    expect(reviewSection).not.toContain("Target W");
+  });
 });

--- a/packages/sport-cycling/CONTEXT.md
+++ b/packages/sport-cycling/CONTEXT.md
@@ -24,6 +24,7 @@ A single training session (cycling discipline) — name, duration, structured in
 
 - Implements the **Sport** contract from `@enduragent/core` (declared `cyclingSport: Sport`).
 - Owns Memory sections: `cycling-profile`, `cycling-equipment`, `cycling-history` (all sport-prefixed per ADR-0003).
+- Skill keys are sport-prefixed (`cycling-periodization`, `cycling-recovery`, …) so duathlon composition (ADR-0002) can merge sports' skills without collision; Core's `mergeSportSkills` guard throws on a duplicate key.
 - Declares `intervalsActivityTypes: ["Ride", "VirtualRide"]` for intervals.icu sync.
 - `mustPreserveTokens` is function-form; reads `cycling-profile` to extract current FTP value.
 - `tools()` composes four buckets per ADR-0004: `createMemoryTools` + `createPureCoreIntervalsTools` + `createCoreToolsWithSportConfig` + sport-specific `createCyclingTools`.

--- a/packages/sport-cycling/skills/review.md
+++ b/packages/sport-cycling/skills/review.md
@@ -70,14 +70,13 @@ Reviewing differs by venue:
   athlete for high VI on outdoor rides; only flag if a structured interval session
   shows VI > 1.10 (suggesting they didn't hold steady on what should have been steady).
 
-## Show numbers follow-up format
+## Show numbers — the cycling rows
 
-When the athlete replies "show numbers" (or "give me the table", "the data", "details",
-etc.):
-- After Tier A → emit the Tier B numeric breakdown.
-- After Tier B / C → emit a compact markdown table.
+Core's review-rules block owns the show-numbers trigger, the tier-escalation ladder,
+the `| Metric | Value |` skeleton, and the compact-table formatting rule. This
+section names the cycling rows that fill that skeleton.
 
-Tier B / C "show numbers" table shape:
+Headline table rows:
 
 | Metric | Value |
 |---|---|
@@ -90,8 +89,6 @@ Tier B / C "show numbers" table shape:
 | Avg cadence | rpm |
 | Fitness / Fatigue / Form | n / n / n |
 
-If `icu_intervals` present, follow the headline table with a per-rep table:
+When `icu_intervals` is present, the per-rep table columns are:
 
 | Rep | Target W | Actual avg W | Avg HR | Time |
-
-Keep it compact. The athlete asked for numbers — no prose around the table.

--- a/packages/sport-cycling/src/sport.ts
+++ b/packages/sport-cycling/src/sport.ts
@@ -18,7 +18,9 @@ import { cyclingReferenceAdapter } from "./reference/index.js";
 import { athleteProfileSchema } from "./schemas.js";
 
 function loadSkills(): Record<string, string> {
-  return Object.fromEntries(skillEntries.map(({ name, content }) => [name, content]));
+  return Object.fromEntries(
+    skillEntries.map(({ name, content }) => [`cycling-${name}`, content]),
+  );
 }
 
 export const CYCLING_VOCABULARY: readonly string[] = [

--- a/packages/sport-cycling/tests/skill-keyspace.test.ts
+++ b/packages/sport-cycling/tests/skill-keyspace.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { buildSystemPrompt, mergeSportSkills } from "@enduragent/core";
+import type { Memory, SportPersona } from "@enduragent/core";
+import { cyclingSport } from "../src/sport.js";
+
+const fakeMemory = { getContext: () => "" } as unknown as Memory;
+
+describe("cycling skill keyspace", () => {
+  it("prefixes every cycling skill key with cycling-", () => {
+    const keys = Object.keys(cyclingSport.skills);
+    expect(keys.length).toBe(7);
+    expect(keys.every((k) => k.startsWith("cycling-"))).toBe(true);
+    expect(keys.slice().sort()).toEqual(
+      [
+        "cycling-intervals-icu",
+        "cycling-periodization",
+        "cycling-race-prep",
+        "cycling-recovery",
+        "cycling-review",
+        "cycling-workout-design",
+        "cycling-zone-reference",
+      ].sort(),
+    );
+  });
+
+  it("renders the prefixed cycling persona byte-stably across consecutive builds", () => {
+    const persona: SportPersona = {
+      soul: cyclingSport.soul,
+      skills: cyclingSport.skills,
+    };
+    expect(buildSystemPrompt(persona, fakeMemory)).toBe(
+      buildSystemPrompt(persona, fakeMemory),
+    );
+  });
+
+  it("merges disjoint skill records", () => {
+    expect(
+      mergeSportSkills({ "cycling-recovery": "C" }, { "running-recovery": "R" }),
+    ).toEqual({ "cycling-recovery": "C", "running-recovery": "R" });
+  });
+
+  it("throws on a colliding skill key", () => {
+    expect(() => mergeSportSkills({ recovery: "C" }, { recovery: "R" })).toThrow(
+      /Duplicate skill key "recovery"/,
+    );
+  });
+
+  it("composes the real cycling skills with a prefixed peer without throwing", () => {
+    let merged: Record<string, string> = {};
+    expect(() => {
+      merged = mergeSportSkills(cyclingSport.skills, { "running-periodization": "RP" });
+    }).not.toThrow();
+    expect(Object.keys(merged).length).toBe(8);
+  });
+});


### PR DESCRIPTION
## Summary

Three layering changes that ride on the static-above-volatile system-prompt reorder, all behaviour-preserving for the assembled cycling prompt:

- **Show-numbers structure moves into Core.** The show-numbers trigger phrases, the escalation ladder, the generic `| Metric | Value |` table skeleton, the per-rep-table convention, and the "no prose around the table" rule now live in the system-prompt builder's workout-review rules block. The cycling-specific metric rows (Duration, Distance, Load, Intensity, average/weighted-average power, heart-rate, cadence, Fitness/Fatigue/Form, and the per-rep column vocabulary) stay in the cycling review skill. The assembled cycling prompt carries every behaviour it did before — structure and rows both present.

- **Skill keys gain a sport prefix with a duplicate-key guard.** The cycling skill keys are now sport-prefixed, and a new Core merge helper throws on a colliding key so a future composed sport can merge two sports' skills without one silently overwriting the other. Because the builder joins skill values, not keys, the rendered prompt is byte-identical. One line in the cycling package context documents the convention.

- **Static-prefix token ceiling guardrail.** A test fails if the turn-invariant static prefix exceeds a 12,000-estimator-token ceiling. Per-skill headers are now emitted so a dropped or renamed skill is visible in the assembled prompt, and a boundary-policy entry in the Core package context records what stays preloaded versus what future growth ships tool-retrievable.

## Testing

- `pnpm test` — 0 failures
- `pnpm check` — passes

No changeset: all three changes are behaviour-preserving (a layering move with an identical assembled prompt), internal (key strings plus a guard, byte-identical rendered prompt), or doc/guardrail (a structural relabel plus a context entry and a test).
