### PR TITLE
feat(core): account whole-turn usage and add a local usage/timing ledger

### DIFF
--- a/packages/core/src/agent/coach-agent.ts
+++ b/packages/core/src/agent/coach-agent.ts
@@ -26,6 +26,7 @@ import { runMemoryFlush, FLUSH_ZERO_WRITE_MIN_MESSAGES, shouldRunMemoryFlush } f
 import type { MemoryFlushOutcome } from "./memory-flush.js";
 import { evaluateSessionFreshness } from "./session-freshness.js";
 import { LLM } from "../llm.js";
+import { appendUsageLine } from "../usage-ledger.js";
 import { createMemorySnapshot } from "../memory/snapshot.js";
 import { resolveUserTimezone, appendCurrentTimeLine } from "./user-time.js";
 
@@ -136,6 +137,7 @@ export class CoachAgent {
 
   async chat(chatId: string, userMessage: string): Promise<string> {
     return withSessionLock(chatId, async () => {
+      const turnStart = Date.now();
       // Single file read: load history + last message time together
       let { messages: history, lastMessageTime } = this.chatStore.load(chatId);
 
@@ -276,11 +278,29 @@ export class CoachAgent {
             tools: this.tools,
             stopWhen: stepCountIs(10),
             maxSteps: 10,
+            caller: "chat",
           });
 
           // Append BOTH after success — JSONL unchanged on failure
           this.chatStore.appendMessage(chatId, "user", userMessage);
           this.chatStore.appendMessage(chatId, "assistant", text);
+
+          appendUsageLine(this.config.dataDir, {
+            ts: Date.now(),
+            kind: "turn",
+            caller: "chat",
+            provider: this.config.llm.provider,
+            model: this.config.llm.model,
+            durationMs: Date.now() - turnStart,
+            steps: undefined,
+            inputTokens: undefined,
+            outputTokens: undefined,
+            totalTokens: undefined,
+            cacheReadTokens: undefined,
+            cacheWriteTokens: undefined,
+            cost: undefined,
+            stopReason: undefined,
+          });
 
           return text;
         } catch (err) {

--- a/packages/core/src/agent/codex-bridge.ts
+++ b/packages/core/src/agent/codex-bridge.ts
@@ -226,6 +226,23 @@ function mapStopReason(reason: StopReason): FinishReason {
   }
 }
 
+function addUsage(acc: PiUsage, u: PiUsage): PiUsage {
+  return {
+    input: acc.input + u.input,
+    output: acc.output + u.output,
+    cacheRead: acc.cacheRead + u.cacheRead,
+    cacheWrite: acc.cacheWrite + u.cacheWrite,
+    totalTokens: acc.totalTokens + u.totalTokens,
+    cost: {
+      input: acc.cost.input + u.cost.input,
+      output: acc.cost.output + u.cost.output,
+      cacheRead: acc.cost.cacheRead + u.cost.cacheRead,
+      cacheWrite: acc.cost.cacheWrite + u.cost.cacheWrite,
+      total: acc.cost.total + u.cost.total,
+    },
+  };
+}
+
 function mapUsage(u: PiUsage): LanguageModelUsage {
   return {
     inputTokens: u.input,
@@ -351,6 +368,8 @@ export async function codexGenerateText(
   const apiKey = await getFreshToken(profileName);
 
   let lastAssistant: AssistantMessage | undefined;
+  let accumulated = emptyUsage();
+  let stepCount = 0;
 
   for (let step = 0; step < limit; step++) {
     const context: Context = {
@@ -375,6 +394,8 @@ export async function codexGenerateText(
     }
 
     lastAssistant = assistant;
+    accumulated = addUsage(accumulated, assistant.usage);
+    stepCount++;
     piMessages.push(assistant);
 
     const calls = collectToolCalls(assistant);
@@ -408,6 +429,9 @@ export async function codexGenerateText(
     toolCalls: toolCalls as GenerateResult["toolCalls"],
     finishReason: mapStopReason(lastAssistant.stopReason),
     usage: mapUsage(lastAssistant.usage),
+    totalUsage: mapUsage(accumulated),
+    steps: stepCount,
+    cost: accumulated.cost,
   };
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -33,6 +33,8 @@ export * from "./reference/index.js";
 // ─── LLM ──────────────────────────────────────────────────────────────
 export { LLM } from "./llm.js";
 export type { GenerateOpts, GenerateResult } from "./llm-types.js";
+export { appendUsageLine, USAGE_LEDGER_FILE, USAGE_LEDGER_MAX_BYTES } from "./usage-ledger.js";
+export type { UsageLedgerLine } from "./usage-ledger.js";
 
 // ─── Memory ───────────────────────────────────────────────────────────
 export type { MemorySnapshot, MemoryStore, MemoryWriteSource } from "./memory.js";

--- a/packages/core/src/llm-types.ts
+++ b/packages/core/src/llm-types.ts
@@ -14,6 +14,7 @@ export interface GenerateOpts {
   stopWhen?: StopCondition<any> | Array<StopCondition<any>>;
   maxSteps?: number;
   maxOutputTokens?: number;
+  caller?: "chat" | "flush" | "compact";
 }
 
 export interface GenerateResult {
@@ -26,4 +27,7 @@ export interface GenerateResult {
   }>;
   finishReason: FinishReason;
   usage: LanguageModelUsage;
+  totalUsage?: LanguageModelUsage;
+  steps?: number;
+  cost?: { input: number; output: number; cacheRead: number; cacheWrite: number; total: number };
 }

--- a/packages/core/src/llm.ts
+++ b/packages/core/src/llm.ts
@@ -7,6 +7,7 @@ import type { LanguageModel } from "ai";
 import type { Config } from "./config.js";
 import { codexGenerateText } from "./agent/codex-bridge.js";
 import type { GenerateOpts, GenerateResult } from "./llm-types.js";
+import { appendUsageLine } from "./usage-ledger.js";
 
 export type { GenerateOpts, GenerateResult } from "./llm-types.js";
 
@@ -24,6 +25,14 @@ export class LLM {
   }
 
   async generate(opts: GenerateOpts): Promise<GenerateResult> {
+    const start = Date.now();
+    const result = await this.dispatch(opts);
+    const durationMs = Date.now() - start;
+    this.recordGenerate(opts, result, durationMs);
+    return result;
+  }
+
+  private async dispatch(opts: GenerateOpts): Promise<GenerateResult> {
     if (this.config.llm.provider === "openai-codex") {
       return await codexGenerateText({
         ...opts,
@@ -67,7 +76,32 @@ export class LLM {
       toolCalls: result.toolCalls as GenerateResult["toolCalls"],
       finishReason: result.finishReason,
       usage: result.usage,
+      totalUsage: result.totalUsage,
+      steps: result.steps.length,
     };
+  }
+
+  private recordGenerate(opts: GenerateOpts, result: GenerateResult, durationMs: number): void {
+    const usage = result.totalUsage;
+    const details = usage?.inputTokenDetails as
+      | { cacheReadTokens?: number; cacheWriteTokens?: number }
+      | undefined;
+    appendUsageLine(this.config.dataDir, {
+      ts: Date.now(),
+      kind: "generate",
+      caller: opts.caller,
+      provider: this.config.llm.provider,
+      model: this.config.llm.model,
+      durationMs,
+      steps: result.steps,
+      inputTokens: usage?.inputTokens,
+      outputTokens: usage?.outputTokens,
+      totalTokens: usage?.totalTokens,
+      cacheReadTokens: details?.cacheReadTokens,
+      cacheWriteTokens: details?.cacheWriteTokens,
+      cost: result.cost,
+      stopReason: result.finishReason,
+    });
   }
 }
 

--- a/packages/core/src/run-binary.ts
+++ b/packages/core/src/run-binary.ts
@@ -4,6 +4,7 @@ import type { Sport } from "./sport.js";
 import type { BinaryConfig } from "./binary.js";
 import type { Memory } from "./memory/store.js";
 import { CONFIG_DIR, envInt } from "./config.js";
+import { appendUsageLine } from "./usage-ledger.js";
 import {
   addSender,
   removeSender,
@@ -277,6 +278,7 @@ export async function runBinary(
     process.exit(1);
   }
 
+  const bootStart = Date.now();
   const { CoachAgent } = await import("./agent/coach-agent.js");
   const agent = new CoachAgent(sport, config);
 
@@ -290,6 +292,23 @@ export async function runBinary(
     dataDir: config.dataDir,
     intervals: config.intervals,
     sport,
+  });
+
+  appendUsageLine(config.dataDir, {
+    ts: Date.now(),
+    kind: "boot",
+    caller: undefined,
+    provider: config.llm.provider,
+    model: config.llm.model,
+    durationMs: Date.now() - bootStart,
+    steps: undefined,
+    inputTokens: undefined,
+    outputTokens: undefined,
+    totalTokens: undefined,
+    cacheReadTokens: undefined,
+    cacheWriteTokens: undefined,
+    cost: undefined,
+    stopReason: undefined,
   });
 
   if (config.telegram.botToken) {

--- a/packages/core/src/usage-ledger.ts
+++ b/packages/core/src/usage-ledger.ts
@@ -1,0 +1,40 @@
+import { appendFileSync, renameSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+export const USAGE_LEDGER_FILE = "usage-ledger.jsonl";
+export const USAGE_LEDGER_MAX_BYTES = 10 * 1024 * 1024;
+
+export interface UsageLedgerLine {
+  ts: number;
+  kind: "generate" | "turn" | "boot";
+  caller: "chat" | "flush" | "compact" | undefined;
+  provider: string;
+  model: string;
+  durationMs: number;
+  steps: number | undefined;
+  inputTokens: number | undefined;
+  outputTokens: number | undefined;
+  totalTokens: number | undefined;
+  cacheReadTokens: number | undefined;
+  cacheWriteTokens: number | undefined;
+  cost: { input: number; output: number; cacheRead: number; cacheWrite: number; total: number } | undefined;
+  stopReason: string | undefined;
+}
+
+export function appendUsageLine(dataDir: string, line: UsageLedgerLine): void {
+  // Best-effort observability sink: a ledger write must never break a chat
+  // turn, so every filesystem call is swallowed on failure.
+  try {
+    const path = join(dataDir, USAGE_LEDGER_FILE);
+    try {
+      if (statSync(path).size >= USAGE_LEDGER_MAX_BYTES) {
+        renameSync(path, `${path}.1`);
+      }
+    } catch {
+      // File absent or unstat-able — nothing to rotate.
+    }
+    appendFileSync(path, JSON.stringify(line) + "\n", { encoding: "utf-8", mode: 0o600 });
+  } catch {
+    // Swallow: observability failure is not a turn failure.
+  }
+}

--- a/packages/core/tests/llm-cache-control.test.ts
+++ b/packages/core/tests/llm-cache-control.test.ts
@@ -24,7 +24,7 @@ function codexConfig(): Config {
   };
 }
 
-const MINIMAL_RESULT = { text: "ok", toolCalls: [], finishReason: "stop", usage: {} };
+const MINIMAL_RESULT = { text: "ok", toolCalls: [], finishReason: "stop", usage: {}, totalUsage: {}, steps: [] };
 
 beforeEach(() => {
   vi.resetModules();

--- a/packages/core/tests/usage-ledger.test.ts
+++ b/packages/core/tests/usage-ledger.test.ts
@@ -1,0 +1,276 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync, statSync, readFileSync, writeFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type { Config } from "../src/config.js";
+import type { UsageLedgerLine } from "../src/usage-ledger.js";
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "cc-ledger-"));
+  vi.resetModules();
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+function ledgerLine(overrides: Partial<UsageLedgerLine> = {}): UsageLedgerLine {
+  return {
+    ts: 1,
+    kind: "generate",
+    caller: undefined,
+    provider: "anthropic",
+    model: "claude-test",
+    durationMs: 12,
+    steps: 1,
+    inputTokens: 5,
+    outputTokens: 3,
+    totalTokens: 8,
+    cacheReadTokens: undefined,
+    cacheWriteTokens: undefined,
+    cost: undefined,
+    stopReason: "stop",
+    ...overrides,
+  };
+}
+
+function anthropicConfig(dataDir: string): Config {
+  return {
+    llm: { provider: "anthropic", model: "claude-test", apiKey: "sk-test" },
+    intervals: { apiKey: "", athleteId: "0" },
+    telegram: { botToken: "" },
+    session: { historyTokenBudgetRatio: 0.3, idleMinutes: 0, dailyResetHour: 4, resetArchiveRetentionDays: 0, timezone: "" },
+    contextWindowTokens: 272_000,
+    dataDir,
+  };
+}
+
+function codexConfig(dataDir: string): Config {
+  return {
+    llm: { provider: "openai-codex", model: "gpt-5.4", apiKey: "", authProfile: "openai-codex" },
+    intervals: { apiKey: "", athleteId: "0" },
+    telegram: { botToken: "" },
+    session: { historyTokenBudgetRatio: 0.3, idleMinutes: 0, dailyResetHour: 4, resetArchiveRetentionDays: 0, timezone: "" },
+    contextWindowTokens: 272_000,
+    dataDir,
+  };
+}
+
+function readLines(dataDir: string, file = "usage-ledger.jsonl"): string[] {
+  return readFileSync(join(dataDir, file), "utf-8").split("\n").filter((l) => l.length > 0);
+}
+
+describe("appendUsageLine", () => {
+  it("writes one JSON line per call to <dataDir>/usage-ledger.jsonl", async () => {
+    const { appendUsageLine } = await import("../src/usage-ledger.js");
+    appendUsageLine(dir, ledgerLine({ kind: "generate" }));
+    appendUsageLine(dir, ledgerLine({ kind: "turn" }));
+
+    const lines = readLines(dir);
+    expect(lines).toHaveLength(2);
+    for (const line of lines) {
+      const parsed = JSON.parse(line) as UsageLedgerLine;
+      expect(parsed.kind).toBeDefined();
+      expect(parsed.durationMs).toBeDefined();
+      expect(parsed.provider).toBe("anthropic");
+    }
+  });
+
+  it("rotates the ledger to .jsonl.1 once it crosses 10 MB", async () => {
+    const { appendUsageLine } = await import("../src/usage-ledger.js");
+    const path = join(dir, "usage-ledger.jsonl");
+    writeFileSync(path, "x".repeat(10.5 * 1024 * 1024));
+
+    appendUsageLine(dir, ledgerLine());
+
+    expect(existsSync(join(dir, "usage-ledger.jsonl.1"))).toBe(true);
+    expect(readLines(dir)).toHaveLength(1);
+    expect(statSync(path).size).toBeLessThan(1024);
+  });
+
+  it("never throws when the ledger write fails", async () => {
+    const { appendUsageLine } = await import("../src/usage-ledger.js");
+    const badDir = "/nonexistent/dir/that/cannot/be/created/\0bad";
+    expect(() => appendUsageLine(badDir, ledgerLine())).not.toThrow();
+  });
+});
+
+describe("LLM.generate — AI-SDK path", () => {
+  async function loadLLMWithGenerateText(stub: Record<string, unknown>) {
+    const generateText = vi.fn(async () => stub);
+    vi.doMock("ai", async () => {
+      const actual = await vi.importActual<typeof import("ai")>("ai");
+      return { ...actual, generateText };
+    });
+    const { LLM } = await import("../src/llm.js");
+    return { LLM, generateText };
+  }
+
+  it("returns whole-turn totalUsage and the step count from the SDK result", async () => {
+    const { LLM } = await loadLLMWithGenerateText({
+      text: "ok",
+      toolCalls: [],
+      finishReason: "stop",
+      usage: { inputTokens: 3, outputTokens: 2, totalTokens: 5 },
+      totalUsage: { inputTokens: 30, outputTokens: 20, totalTokens: 50 },
+      steps: [{ s: "a" }, { s: "b" }, { s: "c" }],
+    });
+    const llm = new LLM(anthropicConfig(dir));
+
+    const result = await llm.generate({ prompt: "hi" });
+
+    expect(result.totalUsage?.inputTokens).toBe(30);
+    expect(result.steps).toBe(3);
+    expect(result.usage.inputTokens).toBe(3);
+  });
+
+  it("writes a caller-tagged generate ledger line reading from totalUsage", async () => {
+    const { LLM } = await loadLLMWithGenerateText({
+      text: "ok",
+      toolCalls: [],
+      finishReason: "stop",
+      usage: { inputTokens: 3, outputTokens: 2, totalTokens: 5 },
+      totalUsage: {
+        inputTokens: 30,
+        outputTokens: 20,
+        totalTokens: 50,
+        inputTokenDetails: { cacheReadTokens: 7, cacheWriteTokens: 4 },
+      },
+      steps: [{ s: "a" }, { s: "b" }],
+    });
+    const llm = new LLM(anthropicConfig(dir));
+
+    await llm.generate({ prompt: "hi", caller: "flush" });
+
+    const lines = readLines(dir);
+    expect(lines).toHaveLength(1);
+    const parsed = JSON.parse(lines[0]) as UsageLedgerLine;
+    expect(parsed.kind).toBe("generate");
+    expect(parsed.caller).toBe("flush");
+    expect(parsed.totalTokens).toBe(50);
+    expect(parsed.cacheReadTokens).toBe(7);
+    expect(parsed.cacheWriteTokens).toBe(4);
+    expect(parsed.steps).toBe(2);
+  });
+});
+
+describe("codex bridge — usage accumulation across the loop", () => {
+  function piUsage(input: number, output: number, cost = 0) {
+    return {
+      input,
+      output,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: input + output,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: cost },
+    };
+  }
+
+  function asstMsg(overrides: Record<string, unknown> = {}) {
+    return {
+      role: "assistant" as const,
+      content: [{ type: "text" as const, text: "hi" }],
+      api: "openai-codex-responses",
+      provider: "openai-codex",
+      model: "gpt-5.4",
+      usage: piUsage(10, 5),
+      stopReason: "stop" as const,
+      timestamp: 1,
+      ...overrides,
+    };
+  }
+
+  async function loadBridge(complete: ReturnType<typeof vi.fn>) {
+    vi.doMock("@mariozechner/pi-ai", () => ({
+      complete,
+      getModel: vi.fn(() => ({
+        id: "gpt-5.4",
+        name: "gpt-5.4",
+        api: "openai-codex-responses",
+        provider: "openai-codex",
+        baseUrl: "https://chatgpt.com/backend-api",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 272_000,
+        maxTokens: 128_000,
+      })),
+    }));
+    vi.doMock("../src/auth/profiles.js", () => ({
+      getFreshToken: vi.fn(async () => "test-access-token"),
+    }));
+    const { codexGenerateText } = await import("../src/agent/codex-bridge.js");
+    return codexGenerateText;
+  }
+
+  it("sums usage across a multi-step loop and keeps last-step usage for back-compat", async () => {
+    const calls = [
+      asstMsg({
+        stopReason: "toolUse",
+        usage: piUsage(10, 5),
+        content: [{ type: "toolCall", id: "c1", name: "noop", arguments: {} }],
+      }),
+      asstMsg({ stopReason: "stop", usage: piUsage(20, 7) }),
+    ];
+    let i = 0;
+    const complete = vi.fn(async () => calls[i++]);
+    const codexGenerateText = await loadBridge(complete);
+
+    const result = await codexGenerateText({
+      messages: [{ role: "user", content: "hi" }],
+      tools: { noop: {} } as never,
+      modelId: "gpt-5.4",
+      profileName: "openai-codex",
+    });
+
+    expect(result.totalUsage?.inputTokens).toBe(30);
+    expect(result.steps).toBe(2);
+    expect(result.usage.inputTokens).toBe(20);
+  });
+
+  it("carries pi-ai's per-call cost object on the result", async () => {
+    const complete = vi.fn(async () => asstMsg({ usage: piUsage(10, 5, 0.03) }));
+    const codexGenerateText = await loadBridge(complete);
+
+    const result = await codexGenerateText({
+      messages: [{ role: "user", content: "hi" }],
+      modelId: "gpt-5.4",
+      profileName: "openai-codex",
+    });
+
+    expect(result.cost?.total).toBe(0.03);
+  });
+});
+
+describe("LLM.generate — codex path writes a ledger line", () => {
+  it("appends a generate line via the chokepoint after the bridge returns", async () => {
+    vi.doMock("../src/agent/codex-bridge.js", () => ({
+      codexGenerateText: vi.fn(async () => ({
+        text: "ok",
+        toolCalls: [],
+        finishReason: "stop",
+        usage: { inputTokens: 20, outputTokens: 7, totalTokens: 27 },
+        totalUsage: { inputTokens: 30, outputTokens: 12, totalTokens: 42 },
+        steps: 2,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0.03 },
+      })),
+    }));
+    const { LLM } = await import("../src/llm.js");
+    const llm = new LLM(codexConfig(dir));
+
+    await llm.generate({ prompt: "hi", caller: "chat" });
+
+    const lines = readLines(dir);
+    expect(lines).toHaveLength(1);
+    const parsed = JSON.parse(lines[0]) as UsageLedgerLine;
+    expect(parsed.kind).toBe("generate");
+    expect(parsed.caller).toBe("chat");
+    expect(parsed.provider).toBe("openai-codex");
+    expect(parsed.totalTokens).toBe(42);
+    expect(parsed.cost?.total).toBe(0.03);
+  });
+});


### PR DESCRIPTION
Returns whole-turn usage from the single LLM dispatch chokepoint instead of the SDK's last-step usage, so a multi-step tool turn now reports the summed token counts rather than only its final step.

The codex bridge now accumulates usage across its own multi-step loop and stops discarding the provider-computed cost object, so codex turns carry the same whole-turn totals and per-call cost as the direct path.

Adds a local-only, rotation-capped JSONL usage/timing ledger written at the dispatch chokepoint: one caller-tagged line per generation (with cache-read/cache-write token counts, duration, step count, and stop reason), plus a per-turn stage line and a boot timer. The ledger lives under the data directory at mode 0600, rotates at 10 MB, is best-effort (a failed write never breaks a chat turn), makes no network calls, and never leaves the machine.

GenerateResult gains optional totalUsage / steps / cost fields (the existing usage stays required); GenerateOpts gains an optional caller tag so call sites can label their lines. A sibling unit test's minimal result mock was aligned to the SDK's actual result shape — which always includes a steps array — so it keeps passing now that the dispatch path reads the step count.

Local-only operator observability with no athlete-facing change, so no changeset.
