### PR TITLE
feat(core): route codex requests to a stable per-chat prompt cache key

### DIFF
--- a/.changeset/codex-prompt-cache-key.md
+++ b/.changeset/codex-prompt-cache-key.md
@@ -1,0 +1,7 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: On the ChatGPT/Codex subscription, your conversation's static context is now served from the model's prompt cache, easing usage-limit pressure during long chats.
+
+Threads a stable per-chat cache-routing key (sha256 prefix of the chat id, never the raw id) from the chat entry point through the codex bridge into the Responses prompt cache key. The non-codex provider path ignores the field by construction.

--- a/packages/core/src/agent/coach-agent.ts
+++ b/packages/core/src/agent/coach-agent.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { stepCountIs } from "ai";
 import type { ModelMessage, ToolSet } from "ai";
 import { makeChatClient } from "../reference/sync/intervals-client-factory.js";
@@ -50,6 +51,10 @@ type MemoryFlushTrigger =
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function cacheKeyForChat(chatId: string): string {
+  return createHash("sha256").update(chatId).digest("hex").slice(0, 16);
 }
 
 // ============================================================================
@@ -280,6 +285,7 @@ export class CoachAgent {
             stopWhen: stepCountIs(10),
             maxSteps: 10,
             caller: "chat",
+            cacheKey: cacheKeyForChat(chatId),
           });
 
           const lineage = computePromptLineage({

--- a/packages/core/src/agent/codex-bridge.ts
+++ b/packages/core/src/agent/codex-bridge.ts
@@ -349,7 +349,7 @@ async function executeToolCall(
 export async function codexGenerateText(
   opts: GenerateOpts & { modelId: string; profileName: string; stepLimit?: number },
 ): Promise<GenerateResult> {
-  const { system, messages, prompt, tools, modelId, profileName, maxOutputTokens, stepLimit } = opts;
+  const { system, messages, prompt, tools, modelId, profileName, maxOutputTokens, stepLimit, cacheKey } = opts;
 
   const initialMessages: ModelMessage[] = prompt
     ? [{ role: "user", content: prompt }]
@@ -384,6 +384,7 @@ export async function codexGenerateText(
         apiKey,
         maxTokens: maxOutputTokens,
         onResponse: onCodexResponse,
+        sessionId: cacheKey,
       });
     } catch (err) {
       throw normalizeError(err);

--- a/packages/core/src/llm-types.ts
+++ b/packages/core/src/llm-types.ts
@@ -14,6 +14,7 @@ export interface GenerateOpts {
   stopWhen?: StopCondition<any> | Array<StopCondition<any>>;
   maxSteps?: number;
   maxOutputTokens?: number;
+  cacheKey?: string;
   caller?: "chat" | "flush" | "compact";
 }
 

--- a/packages/core/tests/codex-bridge.test.ts
+++ b/packages/core/tests/codex-bridge.test.ts
@@ -177,6 +177,40 @@ describe("codex-bridge", () => {
     );
   });
 
+  it("forwards opts.cacheKey to pi-ai's complete as sessionId; omits it when absent", async () => {
+    const completeWithKey = vi.fn(async () => asstMsg());
+    const { codexGenerateText: genWithKey } = await loadBridgeWithMocks({ complete: completeWithKey });
+
+    await genWithKey({
+      messages: [{ role: "user", content: "hi" }],
+      modelId: "gpt-5.4",
+      profileName: "openai-codex",
+      cacheKey: "abc123def456",
+    });
+
+    expect(completeWithKey).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.any(Object),
+      expect.objectContaining({ sessionId: "abc123def456" }),
+    );
+
+    vi.resetModules();
+    const completeNoKey = vi.fn(async () => asstMsg());
+    const { codexGenerateText: genNoKey } = await loadBridgeWithMocks({ complete: completeNoKey });
+
+    await genNoKey({
+      messages: [{ role: "user", content: "hi" }],
+      modelId: "gpt-5.4",
+      profileName: "openai-codex",
+    });
+
+    expect(completeNoKey).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.any(Object),
+      expect.objectContaining({ sessionId: undefined }),
+    );
+  });
+
   it("surfaces finishReason=length so isContextOverflowError can catch it upstream via retry", async () => {
     const complete = vi.fn(async () =>
       asstMsg({ stopReason: "length", content: [{ type: "text", text: "truncated" }] }),

--- a/packages/core/tests/llm-dispatch.test.ts
+++ b/packages/core/tests/llm-dispatch.test.ts
@@ -13,13 +13,14 @@ function codexConfig(): Config {
   };
 }
 
-type Captured = { stepLimit: number | undefined; called: number };
+type Captured = { stepLimit: number | undefined; cacheKey: string | undefined; called: number };
 
 async function runCodex(opts: Parameters<import("../src/llm.js").LLM["generate"]>[0]): Promise<Captured> {
-  const captured: Captured = { stepLimit: undefined, called: 0 };
+  const captured: Captured = { stepLimit: undefined, cacheKey: undefined, called: 0 };
   vi.doMock("../src/agent/codex-bridge.js", () => ({
-    codexGenerateText: vi.fn(async (o: { stepLimit?: number }) => {
+    codexGenerateText: vi.fn(async (o: { stepLimit?: number; cacheKey?: string }) => {
       captured.stepLimit = o.stepLimit;
+      captured.cacheKey = o.cacheKey;
       captured.called++;
       return { text: "ok", toolCalls: [], finishReason: "stop", usage: {} };
     }),
@@ -51,5 +52,13 @@ describe("LLM dispatch — codex path forwards maxSteps to bridge", () => {
   it("forwards undefined when maxSteps is not provided (bridge applies its own default)", async () => {
     const captured = await runCodex({ messages: [{ role: "user", content: "hi" }] });
     expect(captured.stepLimit).toBeUndefined();
+  });
+
+  it("forwards opts.cacheKey to the bridge", async () => {
+    const captured = await runCodex({
+      messages: [{ role: "user", content: "hi" }],
+      cacheKey: "deadbeefdeadbeef",
+    });
+    expect(captured.cacheKey).toBe("deadbeefdeadbeef");
   });
 });


### PR DESCRIPTION
Adds an optional `cacheKey` to the generate options and forwards it, on the Codex provider path only, to the underlying client as its session identifier — which the client maps to the Responses prompt cache key. The coaching turn derives the key as a 16-character sha256 prefix of the chat id (never the raw id), so each chat's byte-stable static context is routed to the same prompt cache entry across turns. On a ChatGPT/Codex subscription this serves the unchanging prefix from cache at a fraction of the per-request quota weight, easing usage-limit pressure during long conversations.

## What changed

- `GenerateOpts` gains an optional `cacheKey` string. The codex bridge destructures it and passes it through as the session identifier (`undefined` when the caller omits it, which the client treats as no cache key).
- The chat entry point derives the per-chat key with a module-private sha256-prefix helper and threads it onto the single coaching-turn generate call. The raw chat id is never used as the key.
- The non-codex provider path ignores the field by construction — the base request object does not spread the options through, so the field is a deliberate no-op there.

## Tests

- A bridge passthrough test asserts the key reaches the client as the session identifier and that omitting it leaves the identifier undefined.
- A dispatch flow-through test asserts the generate chokepoint forwards the key to the bridge.

## Scope notes

This change touches only the codex passthrough. It leaves the provider prefix-caching work, the usage/cache-read accounting seam, and the flush/compaction cost-routing changes untouched — those ship on their own branches. Ships with a changeset carrying a user-facing line on the subscription quota relief.
