### PR TITLE
feat(core): route the flush to a cheap model and dedupe it per chat turn

### DIFF
--- a/.changeset/flush-model-and-dedupe.md
+++ b/.changeset/flush-model-and-dedupe.md
@@ -1,0 +1,8 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Added an optional cheaper model for memory tidy-up (config `llm.flush_model` / env `LLM_FLUSH_MODEL`); unset keeps using your chat model.
+User-facing: The first reply of the day and recovery from long conversations are faster — the bot no longer re-runs the memory tidy-up multiple times in one turn.
+
+The memory tidy-up can now run on a configurable cheaper model via a second, lazily-built LLM while the chat reply keeps the default model; when unset it reuses the chat model (no change). A per-turn latch deduplicates the tidy-up to at most once per chat turn — the daily-reset tidy-up counts as the one, and the trim, over-budget, and overflow-recovery paths no longer re-run it. The tidy-up and compaction calls are now tagged in the local-only usage ledger so their cost is visible.

--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ llm:
   provider: anthropic
   model: claude-opus-4-6
   api_key: sk-ant-...
+  flush_model: claude-haiku-4-5-20251001 # optional: cheaper model for memory tidy-up
 
 intervals:
   api_key: your-intervals-api-key
@@ -207,6 +208,10 @@ llm:
 ```
 
 Env vars take precedence over YAML.
+
+### Cheaper model for memory tidy-up
+
+The bot periodically summarizes a conversation into structured memory ("memory tidy-up"). This runs on your chat model by default, but it is a mechanical extract-the-facts task that a cheaper model handles just as well. Set `llm.flush_model` in `config.yaml` (or the `LLM_FLUSH_MODEL` env var) to route only the tidy-up through a cheaper model while your chat replies keep the default model. When unset, the tidy-up reuses your chat model (no change). Suggested cheap models per provider: Anthropic — a haiku-class model such as `claude-haiku-4-5-20251001`; OpenAI — a mini-class model such as `gpt-5.4-mini` or `gpt-4o-mini`; Google — a flash-class model such as `gemini-2.5-flash`.
 
 ## Storing secrets outside config.yaml
 

--- a/packages/core/src/agent/coach-agent.ts
+++ b/packages/core/src/agent/coach-agent.ts
@@ -64,6 +64,7 @@ function cacheKeyForChat(chatId: string): string {
 export class CoachAgent {
   private sport: Sport;
   private llm: LLM;
+  private flushLlm: LLM;
   private config: Config;
   private memory: Memory;
   private chatStore: ChatStore;
@@ -77,6 +78,11 @@ export class CoachAgent {
     this.sport = sport;
     this.config = config;
     this.llm = new LLM(config);
+    const { flushModel } = config.llm;
+    this.flushLlm =
+      flushModel !== undefined && flushModel !== config.llm.model
+        ? new LLM({ ...config, llm: { ...config.llm, model: flushModel } })
+        : this.llm;
     this.tz = resolveUserTimezone(config.session.timezone);
     this.memory = new Memory(config.dataDir, this.tz);
     this.chatStore = new ChatStore(config.dataDir, config.session.resetArchiveRetentionDays);
@@ -110,7 +116,7 @@ export class CoachAgent {
     for (let attempt = 1; attempt <= MAX_FLUSH_ATTEMPTS; attempt++) {
       try {
         return await runMemoryFlush({
-          llm: this.llm,
+          llm: this.flushLlm,
           messages,
           memory: this.memory,
           memorySections: getEffectiveSections(this.sport),
@@ -135,6 +141,7 @@ export class CoachAgent {
   private compactionParams() {
     return {
       llm: this.llm,
+      caller: "compact" as const,
       mustPreserveTokens: this.sport.mustPreserveTokens,
       memory: createMemorySnapshot(this.memory),
       contextWindowTokens: this.config.contextWindowTokens,
@@ -144,6 +151,9 @@ export class CoachAgent {
   async chat(chatId: string, userMessage: string): Promise<string> {
     return withSessionLock(chatId, async () => {
       const turnStart = Date.now();
+      // One flush per turn: the latch flips on entry (before the await
+      // resolves) so a thrown flush still consumes the turn's single flush.
+      let flushedThisTurn = false;
       // Single file read: load history + last message time together
       let { messages: history, lastMessageTime } = this.chatStore.load(chatId);
 
@@ -157,7 +167,8 @@ export class CoachAgent {
       if (!fresh) {
         // Flush memory before reset, then archive
         let outcome: MemoryFlushOutcome | null = null;
-        if (history.length > 0) {
+        if (history.length > 0 && !flushedThisTurn) {
+          flushedThisTurn = true;
           try {
             outcome = await this.flushMemory(history, "stale-reset");
           } catch (err) {
@@ -202,11 +213,14 @@ export class CoachAgent {
       if (dropped.length > 0) {
         this.lastFlushMessageCount.set(chatId, history.length);
         let flushed = true;
-        try {
-          await this.flushMemory(history, "trim");
-        } catch (err) {
-          flushed = false;
-          console.warn("Pre-compaction memory flush failed; keeping session file unchanged", err);
+        if (!flushedThisTurn) {
+          flushedThisTurn = true;
+          try {
+            await this.flushMemory(history, "trim");
+          } catch (err) {
+            flushed = false;
+            console.warn("Pre-compaction memory flush failed; keeping session file unchanged", err);
+          }
         }
         try {
           const { summary, unsummarized } = await summarizeDroppedMessages({
@@ -240,10 +254,13 @@ export class CoachAgent {
         })
       ) {
         this.lastFlushMessageCount.set(chatId, history.length);
-        try {
-          await this.flushMemory(history, "soft-threshold");
-        } catch (err) {
-          console.warn("Soft-threshold memory flush failed; continuing turn", err);
+        if (!flushedThisTurn) {
+          flushedThisTurn = true;
+          try {
+            await this.flushMemory(history, "soft-threshold");
+          } catch (err) {
+            console.warn("Soft-threshold memory flush failed; continuing turn", err);
+          }
         }
       }
 
@@ -268,10 +285,13 @@ export class CoachAgent {
       while (true) {
         // Preemptive: compact before sending if over budget
         if (shouldCompact({ messages, systemPrompt: this.systemPrompt, contextWindowTokens: this.config.contextWindowTokens })) {
-          try {
-            await this.flushMemory(messages, "pre-compaction");
-          } catch (err) {
-            console.warn("In-turn memory flush failed; compacting without flush", err);
+          if (!flushedThisTurn) {
+            flushedThisTurn = true;
+            try {
+              await this.flushMemory(messages, "pre-compaction");
+            } catch (err) {
+              console.warn("In-turn memory flush failed; compacting without flush", err);
+            }
           }
           messages = await summarizeInStages({ messages, ...this.compactionParams() });
           this.memory.reload();
@@ -330,10 +350,13 @@ export class CoachAgent {
           if (isContextOverflowError(err) && overflowAttempts < MAX_OVERFLOW_ATTEMPTS) {
             overflowAttempts++;
             try {
-              try {
-                await this.flushMemory(messages, "overflow-recovery");
-              } catch (flushErr) {
-                console.warn("In-turn memory flush failed; compacting without flush", flushErr);
+              if (!flushedThisTurn) {
+                flushedThisTurn = true;
+                try {
+                  await this.flushMemory(messages, "overflow-recovery");
+                } catch (flushErr) {
+                  console.warn("In-turn memory flush failed; compacting without flush", flushErr);
+                }
               }
               messages = await summarizeInStages({ messages, ...this.compactionParams() });
               this.memory.reload();

--- a/packages/core/src/agent/compaction.ts
+++ b/packages/core/src/agent/compaction.ts
@@ -11,6 +11,7 @@ import {
 } from "./token-utils.js";
 import { makeSummaryMessage, SUMMARY_PREFIX } from "./history-limit.js";
 import type { LLM } from "../llm.js";
+import type { GenerateOpts } from "../llm-types.js";
 
 // ============================================================================
 // CONSTANTS
@@ -120,7 +121,7 @@ function capSummary(summary: string): string {
 
 async function generateSummaryWithTimeout(
   llm: LLM,
-  opts: { prompt: string; maxOutputTokens: number },
+  opts: { prompt: string; maxOutputTokens: number; caller?: GenerateOpts["caller"] },
 ): Promise<string> {
   let timer: ReturnType<typeof setTimeout> | undefined;
   const deadline = new Promise<never>((_, reject) => {
@@ -221,8 +222,9 @@ async function finalizeSummary(params: {
   llm: LLM;
   mustPreserveBlock: string;
   maxRetries: number;
+  caller?: GenerateOpts["caller"];
 }): Promise<string> {
-  const { llm, mustPreserveBlock, maxRetries } = params;
+  const { llm, mustPreserveBlock, maxRetries, caller } = params;
   let best = capSummary(params.summary);
   const audit = auditSummaryQuality(best);
   if (audit.ok) return best;
@@ -232,6 +234,7 @@ async function finalizeSummary(params: {
       const text = await generateSummaryWithTimeout(llm, {
         prompt: `Restructure the following summary to include ALL required section headings: ${audit.missing.join(", ")}.\n\n${best}\n\n${mustPreserveBlock}`,
         maxOutputTokens: MAX_SUMMARY_TOKENS,
+        caller,
       });
       const capped = capSummary(text);
       if (auditSummaryQuality(capped).ok) return capped;
@@ -256,8 +259,9 @@ export async function summarizeDroppedMessages(params: {
   previousSummary?: string;
   maxRetries?: number;
   contextWindowTokens?: number;
+  caller?: GenerateOpts["caller"];
 }): Promise<{ summary: string; unsummarized: ModelMessage[] }> {
-  const { dropped, llm, mustPreserveTokens, memory, previousSummary, maxRetries = 1, contextWindowTokens } = params;
+  const { dropped, llm, mustPreserveTokens, memory, previousSummary, maxRetries = 1, contextWindowTokens, caller } = params;
 
   if (dropped.length === 0) return { summary: previousSummary ?? "", unsummarized: [] };
 
@@ -286,6 +290,7 @@ export async function summarizeDroppedMessages(params: {
       const text = await generateSummaryWithTimeout(llm, {
         prompt,
         maxOutputTokens: MAX_SUMMARY_TOKENS,
+        caller,
       });
       summary = text;
     } catch (err) {
@@ -302,7 +307,7 @@ export async function summarizeDroppedMessages(params: {
   }
 
   return {
-    summary: await finalizeSummary({ summary, llm, mustPreserveBlock, maxRetries }),
+    summary: await finalizeSummary({ summary, llm, mustPreserveBlock, maxRetries, caller }),
     unsummarized,
   };
 }
@@ -319,8 +324,9 @@ export async function summarizeInStages(params: {
   recentToKeep?: number;
   previousSummary?: string;
   contextWindowTokens?: number;
+  caller?: GenerateOpts["caller"];
 }): Promise<ModelMessage[]> {
-  const { llm, mustPreserveTokens, memory, recentToKeep = 4, contextWindowTokens } = params;
+  const { llm, mustPreserveTokens, memory, recentToKeep = 4, contextWindowTokens, caller } = params;
 
   let messages = params.messages;
   let previousSummary = params.previousSummary;
@@ -363,6 +369,7 @@ export async function summarizeInStages(params: {
       const text = await generateSummaryWithTimeout(llm, {
         prompt: `${summarizePrompt}${contextPrefix}\n\n${transcript}`,
         maxOutputTokens: MAX_SUMMARY_TOKENS,
+        caller,
       });
       summary = text;
     } catch (err) {
@@ -380,6 +387,7 @@ export async function summarizeInStages(params: {
     llm,
     mustPreserveBlock,
     maxRetries: 1,
+    caller,
   });
   return [makeSummaryMessage(finalSummary), ...recent];
 }

--- a/packages/core/src/agent/memory-flush.ts
+++ b/packages/core/src/agent/memory-flush.ts
@@ -235,6 +235,7 @@ export async function runMemoryFlush(params: {
     tools: flushTools,
     stopWhen: stepCountIs(5),
     maxSteps: 5,
+    caller: "flush",
   });
 
   params.memory.reload();

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -15,6 +15,8 @@ export interface Config {
     model: string;
     apiKey: string;
     authProfile?: string;
+    /** Cheaper model for the memory flush; unset reuses the chat model. */
+    flushModel?: string;
   };
   intervals: {
     apiKey: string;
@@ -193,6 +195,9 @@ export function loadConfig(): Config {
   const model =
     env("LLM_MODEL") ?? (llmYaml.model as string | undefined) ?? defaultModelMap[provider];
 
+  const flushModel =
+    env("LLM_FLUSH_MODEL") ?? (llmYaml.flush_model as string | undefined);
+
   const config: Config = {
     llm: {
       provider,
@@ -202,6 +207,7 @@ export function loadConfig(): Config {
         provider === "openai-codex"
           ? ((llmYaml.auth_profile as string | undefined) ?? "openai-codex")
           : undefined,
+      flushModel,
     },
     intervals: {
       apiKey: intervalsApiKey,

--- a/packages/core/tests/config.flush-model.test.ts
+++ b/packages/core/tests/config.flush-model.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const MANAGED_ENV = [
+  "ANTHROPIC_API_KEY",
+  "OPENAI_API_KEY",
+  "GOOGLE_GENERATIVE_AI_API_KEY",
+  "INTERVALS_API_KEY",
+  "INTERVALS_ATHLETE_ID",
+  "TELEGRAM_BOT_TOKEN",
+  "LLM_PROVIDER",
+  "LLM_MODEL",
+  "LLM_FLUSH_MODEL",
+  "CONTEXT_WINDOW_TOKENS",
+];
+
+let tempHome: string;
+let origHome: string | undefined;
+let origCcHome: string | undefined;
+const savedEnv: Record<string, string | undefined> = {};
+
+function writeYaml(body: string): void {
+  writeFileSync(join(tempHome, ".cycling-coach", "config.yaml"), body, "utf-8");
+}
+
+beforeEach(() => {
+  tempHome = mkdtempSync(join(tmpdir(), "cc-flushmodel-"));
+  origHome = process.env.HOME;
+  origCcHome = process.env.CYCLING_COACH_HOME;
+  process.env.HOME = tempHome;
+  delete process.env.CYCLING_COACH_HOME;
+  mkdirSync(join(tempHome, ".cycling-coach"), { recursive: true });
+  for (const k of MANAGED_ENV) {
+    savedEnv[k] = process.env[k];
+    delete process.env[k];
+  }
+  vi.resetModules();
+});
+
+afterEach(() => {
+  process.env.HOME = origHome;
+  if (origCcHome !== undefined) process.env.CYCLING_COACH_HOME = origCcHome;
+  else delete process.env.CYCLING_COACH_HOME;
+  for (const k of MANAGED_ENV) {
+    if (savedEnv[k] !== undefined) process.env[k] = savedEnv[k];
+    else delete process.env[k];
+  }
+  rmSync(tempHome, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+describe("config — flush-model resolution", () => {
+  it("env LLM_FLUSH_MODEL resolves into cfg.llm.flushModel", async () => {
+    process.env.LLM_PROVIDER = "anthropic";
+    process.env.LLM_FLUSH_MODEL = "claude-haiku-4-5-20251001";
+    const { loadConfig } = await import("../src/config.js");
+    expect(loadConfig().llm.flushModel).toBe("claude-haiku-4-5-20251001");
+  });
+
+  it("YAML llm.flush_model resolves when the env var is unset", async () => {
+    writeYaml("llm:\n  provider: anthropic\n  flush_model: claude-haiku-4-5-20251001\n");
+    const { loadConfig } = await import("../src/config.js");
+    expect(loadConfig().llm.flushModel).toBe("claude-haiku-4-5-20251001");
+  });
+
+  it("env beats YAML", async () => {
+    writeYaml("llm:\n  provider: anthropic\n  flush_model: yaml-model\n");
+    process.env.LLM_FLUSH_MODEL = "env-model";
+    const { loadConfig } = await import("../src/config.js");
+    expect(loadConfig().llm.flushModel).toBe("env-model");
+  });
+
+  it("unset resolves to undefined (the no-change fallback)", async () => {
+    process.env.LLM_PROVIDER = "anthropic";
+    const { loadConfig } = await import("../src/config.js");
+    expect(loadConfig().llm.flushModel).toBeUndefined();
+  });
+});

--- a/packages/core/tests/flush-dedupe-per-turn.test.ts
+++ b/packages/core/tests/flush-dedupe-per-turn.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { baseAgentConfig } from "./helpers/base-agent-config.js";
+import { cyclingSport } from "@enduragent/sport-cycling";
+import type { Sport } from "../src/sport.js";
+
+const FLUSH_MARKER = "reviewing a conversation to extract and save important athlete";
+const FIVE_SECTION_SUMMARY = [
+  "## Athlete Profile",
+  "- FTP 247W, 72kg, training Mon/Wed/Fri",
+  "## Training Status",
+  "- Build phase, target FTP 280W",
+  "## Coach Stance",
+  "- Hold volume this week; athlete has not pushed back",
+  "## Discussion Context",
+  "- Goal-setting and equipment review",
+  "## Pending Questions",
+  "- None outstanding",
+].join("\n");
+
+let tempHome: string;
+let origHome: string | undefined;
+let dataDir: string;
+
+beforeEach(() => {
+  tempHome = mkdtempSync(join(tmpdir(), "cc-dedupe-"));
+  origHome = process.env.HOME;
+  process.env.HOME = tempHome;
+  dataDir = join(tempHome, ".cycling-coach");
+  mkdirSync(dataDir, { recursive: true });
+  mkdirSync(join(dataDir, "memory"), { recursive: true });
+  vi.resetModules();
+});
+
+afterEach(() => {
+  process.env.HOME = origHome;
+  rmSync(tempHome, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+async function setupAgent(complete: ReturnType<typeof vi.fn>) {
+  const model = {
+    id: "gpt-5.4",
+    name: "gpt-5.4",
+    api: "openai-codex-responses",
+    provider: "openai-codex",
+    baseUrl: "https://chatgpt.com/backend-api",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 272_000,
+    maxTokens: 128_000,
+  };
+
+  vi.doMock("@mariozechner/pi-ai", () => ({
+    complete,
+    getModel: vi.fn(() => model),
+  }));
+  vi.doMock("@mariozechner/pi-ai/oauth", () => ({
+    refreshOpenAICodexToken: vi.fn(),
+    loginOpenAICodex: vi.fn(),
+  }));
+  vi.doMock("../src/auth/profiles.js", () => ({
+    getFreshToken: vi.fn(async () => "token"),
+    loadProfile: vi.fn(),
+    saveProfile: vi.fn(),
+    RefreshTokenReusedError: class extends Error {},
+  }));
+
+  const { CoachAgent } = await import("../src/agent/coach-agent.js");
+  return new CoachAgent(cyclingSport as unknown as Sport, {
+    ...baseAgentConfig(dataDir),
+    contextWindowTokens: 80_000,
+  });
+}
+
+function mkAssistant(text: string, stopReason: "stop" | "length" = "stop") {
+  return {
+    role: "assistant" as const,
+    content: [{ type: "text" as const, text }],
+    api: "openai-codex-responses",
+    provider: "openai-codex",
+    model: "gpt-5.4",
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason,
+    timestamp: Date.now(),
+  };
+}
+
+// A call is a flush iff the codex Context carries the memory-flush system prompt.
+function isFlushCall(call: unknown[]): boolean {
+  const context = call[1] as { systemPrompt?: string } | undefined;
+  return typeof context?.systemPrompt === "string" && context.systemPrompt.includes(FLUSH_MARKER);
+}
+
+function countFlushCalls(complete: ReturnType<typeof vi.fn>): number {
+  return complete.mock.calls.filter((c) => isFlushCall(c)).length;
+}
+
+function seedSession(
+  chatId: string,
+  lines: Array<{ role: string; content: string; ts: string }>,
+) {
+  const sessionsDir = join(dataDir, "sessions");
+  mkdirSync(sessionsDir, { recursive: true });
+  writeFileSync(
+    join(sessionsDir, `${chatId}.jsonl`),
+    lines.map((l) => JSON.stringify(l)).join("\n") + "\n",
+    "utf-8",
+  );
+}
+
+function overBudgetLines(ts: string): Array<{ role: string; content: string; ts: string }> {
+  return Array.from({ length: 13 }, (_, i) => ({
+    role: i % 2 === 0 ? "user" : "assistant",
+    content: "x".repeat(2_400),
+    ts,
+  }));
+}
+
+const FRESH_TS = new Date().toISOString();
+const STALE_TS = "2020-01-01T00:00:00.000Z";
+
+describe("flush dedupe — at most one memory flush per chat() turn", () => {
+  it("an overflow-retry storm flushes at most once", async () => {
+    const complete = vi.fn(async (_model: unknown, context: { systemPrompt?: string }) => {
+      const sys = context.systemPrompt ?? "";
+      if (sys.includes(FLUSH_MARKER)) return mkAssistant("facts noted");
+      if (sys.length === 0) return mkAssistant(FIVE_SECTION_SUMMARY); // compaction (prompt-only)
+      // Main turn: throw overflow twice to drive the retry loop, then recover.
+      const mainTurns = complete.mock.calls.filter((c) => {
+        const s = (c[1] as { systemPrompt?: string } | undefined)?.systemPrompt ?? "";
+        return s.length > 0 && !s.includes(FLUSH_MARKER);
+      }).length;
+      if (mainTurns <= 2) {
+        throw new Error("Request exceeds the maximum context length of 272000 tokens");
+      }
+      return mkAssistant("recovered");
+    });
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const agent = await setupAgent(complete);
+    seedSession("storm", overBudgetLines(FRESH_TS));
+
+    const text = await agent.chat("storm", "hello");
+
+    expect(text).toBe("recovered");
+    expect(countFlushCalls(complete)).toBeLessThanOrEqual(1);
+  });
+
+  it("a daily-reset turn does not also flush on trim or compaction", async () => {
+    const complete = vi.fn(async (_model: unknown, context: { systemPrompt?: string }) => {
+      const sys = context.systemPrompt ?? "";
+      if (sys.includes(FLUSH_MARKER)) return mkAssistant("facts noted");
+      if (sys.length === 0) return mkAssistant(FIVE_SECTION_SUMMARY);
+      return mkAssistant("fresh-day-reply");
+    });
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const agent = await setupAgent(complete);
+    // Stale (predates the daily reset hour) AND over budget.
+    seedSession("daily", overBudgetLines(STALE_TS));
+
+    const text = await agent.chat("daily", "hello");
+
+    expect(text).toBe("fresh-day-reply");
+    expect(countFlushCalls(complete)).toBeLessThanOrEqual(1);
+  });
+
+  it("a normal single-flush trim turn is unchanged (no false suppression)", async () => {
+    const complete = vi.fn(async (_model: unknown, context: { systemPrompt?: string }) => {
+      const sys = context.systemPrompt ?? "";
+      if (sys.includes(FLUSH_MARKER)) return mkAssistant("facts noted");
+      if (sys.length === 0) return mkAssistant(FIVE_SECTION_SUMMARY);
+      return mkAssistant("trim-reply");
+    });
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const agent = await setupAgent(complete);
+    seedSession("trim", overBudgetLines(FRESH_TS));
+
+    const text = await agent.chat("trim", "hello");
+
+    expect(text).toBe("trim-reply");
+    expect(countFlushCalls(complete)).toBe(1);
+  });
+});

--- a/packages/core/tests/flush-dedupe-per-turn.test.ts
+++ b/packages/core/tests/flush-dedupe-per-turn.test.ts
@@ -2,9 +2,13 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { ModelMessage } from "ai";
 import { baseAgentConfig } from "./helpers/base-agent-config.js";
 import { cyclingSport } from "@enduragent/sport-cycling";
 import type { Sport } from "../src/sport.js";
+import type { LLM, GenerateResult, GenerateOpts } from "../src/llm.js";
+import type { MemorySnapshot } from "../src/memory.js";
+import { summarizeInStages, summarizeDroppedMessages } from "../src/agent/compaction.js";
 
 const FLUSH_MARKER = "reviewing a conversation to extract and save important athlete";
 const FIVE_SECTION_SUMMARY = [
@@ -189,5 +193,67 @@ describe("flush dedupe — at most one memory flush per chat() turn", () => {
 
     expect(text).toBe("trim-reply");
     expect(countFlushCalls(complete)).toBe(1);
+  });
+});
+
+describe("compaction caller tag — the compact tag reaches llm.generate end-to-end", () => {
+  const emptyMemory: MemorySnapshot = {
+    read: () => null,
+    has: () => false,
+    listSections: () => [],
+  };
+
+  function makeLlmSpy() {
+    // The compaction path reads only `.text` off the result; the rest of
+    // GenerateResult is supplied via cast so the mock stays minimal.
+    const generate = vi.fn(
+      async (_opts: GenerateOpts): Promise<GenerateResult> =>
+        ({
+          text: FIVE_SECTION_SUMMARY,
+          toolCalls: [],
+          finishReason: "stop" as const,
+        }) as unknown as GenerateResult,
+    );
+    return { llm: { generate } as unknown as LLM, generate };
+  }
+
+  function mkText(text: string): ModelMessage {
+    return { role: "user", content: text };
+  }
+
+  it("summarizeInStages threads caller:'compact' into every llm.generate call", async () => {
+    const { llm, generate } = makeLlmSpy();
+    // recentToKeep defaults to 4, so 6 messages leaves 2 to summarize.
+    const messages = Array.from({ length: 6 }, (_, i) => mkText(`turn ${i}`));
+
+    await summarizeInStages({
+      messages,
+      llm,
+      mustPreserveTokens: [],
+      memory: emptyMemory,
+      caller: "compact",
+    });
+
+    expect(generate).toHaveBeenCalled();
+    for (const call of generate.mock.calls) {
+      expect(call[0]).toMatchObject({ caller: "compact" });
+    }
+  });
+
+  it("summarizeDroppedMessages threads caller:'compact' into every llm.generate call", async () => {
+    const { llm, generate } = makeLlmSpy();
+
+    await summarizeDroppedMessages({
+      dropped: [mkText("older turn a"), mkText("older turn b")],
+      llm,
+      mustPreserveTokens: [],
+      memory: emptyMemory,
+      caller: "compact",
+    });
+
+    expect(generate).toHaveBeenCalled();
+    for (const call of generate.mock.calls) {
+      expect(call[0]).toMatchObject({ caller: "compact" });
+    }
   });
 });


### PR DESCRIPTION
Two flush cost-leak closers.

**A configurable cheaper model for the memory flush.** A new `llm.flush_model` config key (env `LLM_FLUSH_MODEL`) routes the memory flush through a second, lazily-built LLM while the chat turn keeps its own model; unset falls back to the chat model, so there is no behavior change and no new default. The flush now emits a usage line through the local cost ledger, so its spend is finally visible. The README documents the knob with per-provider cheap-model suggestions.

**A per-turn latch so the memory flush runs at most once per chat turn.** The daily-reset flush counts as the one, and the trim, over-budget, and overflow-recovery paths no longer re-run it — closing the up-to-several-times-per-turn flush that was blocking the first reply of the day. The latch is local to the turn and flips on entry, so even a thrown flush still counts as the one; the standalone session-reset flush is untouched.

**Caller-tagged ledger lines.** The flush and compaction model calls are now tagged in the local usage ledger (the flush as a flush call, compaction as a compaction call, the main turn as a chat call), so each kind of spend is attributable. A regression test pins the compaction tag reaching the model call end-to-end.

Local gates green: `pnpm check` and `pnpm test` (0 failures). The four existing flush suites pass unchanged; the new config-resolution and per-turn-dedupe suites cover the routing, the latch, and the caller tags.
