### PR TITLE
refactor(core): simplify prompt-lineage hashing and usage-ledger line shape

### DIFF
--- a/packages/core/src/agent/coach-agent.ts
+++ b/packages/core/src/agent/coach-agent.ts
@@ -1,4 +1,3 @@
-import { createHash } from "node:crypto";
 import { stepCountIs } from "ai";
 import type { ModelMessage, ToolSet } from "ai";
 import { makeChatClient } from "../reference/sync/intervals-client-factory.js";
@@ -10,7 +9,7 @@ import { resolveSecretRef } from "../secrets/resolve.js";
 import { Memory } from "../memory/store.js";
 import { ChatStore } from "./chat-store.js";
 import { buildSystemPrompt, staticRuleBlocks } from "./system-prompt.js";
-import { computePromptLineage } from "./prompt-lineage.js";
+import { computeAssembledHash, computeTemplateHash, sha256_16 } from "./prompt-lineage.js";
 import { withSessionLock } from "./session-lock.js";
 import { splitHistoryByBudget, makeSummaryMessage } from "./history-limit.js";
 import {
@@ -53,10 +52,6 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function cacheKeyForChat(chatId: string): string {
-  return createHash("sha256").update(chatId).digest("hex").slice(0, 16);
-}
-
 // ============================================================================
 // AGENT
 // ============================================================================
@@ -73,6 +68,10 @@ export class CoachAgent {
   private tz: string;
   private archiveDeferred = new Set<string>();
   private lastFlushMessageCount = new Map<string, number>();
+  // The prompt-template hash is derived from constructor-stable inputs (soul,
+  // skills, tool schemas, model, and the compile-time rule-block set), so it is
+  // computed once on first use and reused for every turn of the process.
+  private templateHash?: string;
 
   constructor(sport: Sport, config: Config) {
     this.sport = sport;
@@ -305,24 +304,23 @@ export class CoachAgent {
             stopWhen: stepCountIs(10),
             maxSteps: 10,
             caller: "chat",
-            cacheKey: cacheKeyForChat(chatId),
+            cacheKey: sha256_16(chatId),
           });
 
-          const lineage = computePromptLineage({
+          const templateHash = (this.templateHash ??= computeTemplateHash({
             soul: this.sport.soul,
             skills: this.sport.skills,
             ruleBlocks: staticRuleBlocks(),
             toolSchemas: this.tools,
             model: this.config.llm.model,
-            systemPrompt: this.systemPrompt,
-            messages,
-          });
+          }));
+          const assembledHash = computeAssembledHash(this.systemPrompt, messages);
 
           // Append BOTH after success — JSONL unchanged on failure
           this.chatStore.appendMessage(chatId, "user", userMessage);
           this.chatStore.appendMessage(chatId, "assistant", text, {
-            templateHash: lineage.templateHash,
-            assembledHash: lineage.assembledHash,
+            templateHash,
+            assembledHash,
             provider: this.config.llm.provider,
             model: this.config.llm.model,
           });
@@ -334,14 +332,6 @@ export class CoachAgent {
             provider: this.config.llm.provider,
             model: this.config.llm.model,
             durationMs: Date.now() - turnStart,
-            steps: undefined,
-            inputTokens: undefined,
-            outputTokens: undefined,
-            totalTokens: undefined,
-            cacheReadTokens: undefined,
-            cacheWriteTokens: undefined,
-            cost: undefined,
-            stopReason: undefined,
           });
 
           return text;

--- a/packages/core/src/agent/prompt-lineage.ts
+++ b/packages/core/src/agent/prompt-lineage.ts
@@ -1,16 +1,19 @@
 import { createHash } from "node:crypto";
 import type { ModelMessage } from "ai";
 
-function sha256_16(input: string): string {
+export function sha256_16(input: string): string {
   return createHash("sha256").update(input).digest("hex").slice(0, 16);
 }
 
-export interface PromptLineageInput {
+export interface PromptTemplateInput {
   soul: string;
   skills: Record<string, string>;
   ruleBlocks: string[];
   toolSchemas: unknown;
   model: string;
+}
+
+export interface PromptLineageInput extends PromptTemplateInput {
   systemPrompt: string;
   messages: ModelMessage[];
 }
@@ -35,7 +38,7 @@ function stableSerialize(value: unknown): unknown {
   return value;
 }
 
-export function computePromptLineage(input: PromptLineageInput): PromptLineage {
+export function computeTemplateHash(input: PromptTemplateInput): string {
   const templateBasis = JSON.stringify({
     soul: input.soul,
     skills: stableSerialize(input.skills),
@@ -43,12 +46,17 @@ export function computePromptLineage(input: PromptLineageInput): PromptLineage {
     toolSchemas: stableSerialize(input.toolSchemas),
     model: input.model,
   });
-  const assembledBasis = JSON.stringify({
-    system: input.systemPrompt,
-    messages: input.messages,
-  });
+  return sha256_16(templateBasis);
+}
+
+export function computeAssembledHash(systemPrompt: string, messages: ModelMessage[]): string {
+  const assembledBasis = JSON.stringify({ system: systemPrompt, messages });
+  return sha256_16(assembledBasis);
+}
+
+export function computePromptLineage(input: PromptLineageInput): PromptLineage {
   return {
-    templateHash: sha256_16(templateBasis),
-    assembledHash: sha256_16(assembledBasis),
+    templateHash: computeTemplateHash(input),
+    assembledHash: computeAssembledHash(input.systemPrompt, input.messages),
   };
 }

--- a/packages/core/src/agent/system-prompt.ts
+++ b/packages/core/src/agent/system-prompt.ts
@@ -161,12 +161,7 @@ export function buildSystemPrompt(
     parts.push("# Domain Knowledge\n\n" + skillsContent);
   }
 
-  parts.push(UNTRUSTED_DATA_RULES);
-  parts.push(MEMORY_RECALL_RULES);
-  parts.push(WORKOUT_REVIEW_RULES);
-  if (LAYER_3_GROUNDING_ENABLED) {
-    parts.push(LAYER_3_PROMPT_RULES);
-  }
+  parts.push(...staticRuleBlocks());
 
   // Strip the marker's leading separator so the join adds exactly one.
   parts.push(SYSTEM_PROMPT_CACHE_BOUNDARY.replace(/^\n\n---\n\n/, ""));

--- a/packages/core/src/run-binary.ts
+++ b/packages/core/src/run-binary.ts
@@ -297,18 +297,9 @@ export async function runBinary(
   appendUsageLine(config.dataDir, {
     ts: Date.now(),
     kind: "boot",
-    caller: undefined,
     provider: config.llm.provider,
     model: config.llm.model,
     durationMs: Date.now() - bootStart,
-    steps: undefined,
-    inputTokens: undefined,
-    outputTokens: undefined,
-    totalTokens: undefined,
-    cacheReadTokens: undefined,
-    cacheWriteTokens: undefined,
-    cost: undefined,
-    stopReason: undefined,
   });
 
   if (config.telegram.botToken) {

--- a/packages/core/src/usage-ledger.ts
+++ b/packages/core/src/usage-ledger.ts
@@ -7,18 +7,19 @@ export const USAGE_LEDGER_MAX_BYTES = 10 * 1024 * 1024;
 export interface UsageLedgerLine {
   ts: number;
   kind: "generate" | "turn" | "boot";
-  caller: "chat" | "flush" | "compact" | undefined;
   provider: string;
   model: string;
   durationMs: number;
-  steps: number | undefined;
-  inputTokens: number | undefined;
-  outputTokens: number | undefined;
-  totalTokens: number | undefined;
-  cacheReadTokens: number | undefined;
-  cacheWriteTokens: number | undefined;
-  cost: { input: number; output: number; cacheRead: number; cacheWrite: number; total: number } | undefined;
-  stopReason: string | undefined;
+  // Populated on per-generation lines; absent on the whole-turn and boot lines.
+  caller?: "chat" | "flush" | "compact";
+  steps?: number;
+  inputTokens?: number;
+  outputTokens?: number;
+  totalTokens?: number;
+  cacheReadTokens?: number;
+  cacheWriteTokens?: number;
+  cost?: { input: number; output: number; cacheRead: number; cacheWrite: number; total: number };
+  stopReason?: string;
 }
 
 export function appendUsageLine(dataDir: string, line: UsageLedgerLine): void {

--- a/packages/core/tests/system-prompt-review-rules.test.ts
+++ b/packages/core/tests/system-prompt-review-rules.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   buildSystemPrompt,
+  staticRuleBlocks,
   ATHLETE_CONTEXT_FENCE_OPEN,
   ATHLETE_CONTEXT_FENCE_CLOSE,
   SYSTEM_PROMPT_CACHE_BOUNDARY,
@@ -69,6 +70,19 @@ describe("buildSystemPrompt — review + data-grounding placement", () => {
     expect(
       prompt.includes("Numeric claims MUST come from the current JSON snapshot you read this turn"),
     ).toBe(LAYER_3_GROUNDING_ENABLED);
+  });
+
+  it("assembles exactly the blocks staticRuleBlocks() returns, contiguously and in order", () => {
+    // The builder and the prompt-lineage template hash must read the same
+    // rule-block set; the builder consumes staticRuleBlocks() directly so the
+    // two cannot drift. This pins that contract: every accessor block appears in
+    // the assembled prompt, contiguous and in order.
+    const prompt = buildSystemPrompt(persona, makeFakeMemory("ctx"));
+    const sections = prompt.split("\n\n---\n\n");
+    const blocks = staticRuleBlocks();
+    const start = sections.indexOf(blocks[0]);
+    expect(start).toBeGreaterThan(-1);
+    expect(sections.slice(start, start + blocks.length)).toEqual(blocks);
   });
 });
 


### PR DESCRIPTION
A behavior-preserving cleanup pass over the prompt/caching/cost code, from a four-angle review (reuse, simplification, efficiency, altitude). No user-visible change: assembled prompts stay byte-identical, prompt-lineage hashes and the usage-ledger JSONL are unchanged.

## What changed

**One sha256-16 helper instead of two.** `cacheKeyForChat` re-implemented the exact `createHash(...).digest("hex").slice(0,16)` idiom already living in the prompt-lineage module as `sha256_16`. Exported the one helper, called it from both sites, and dropped the now-unused `node:crypto` import in the agent.

**The rule-block list has a single source again.** `buildSystemPrompt` re-listed the three static rule blocks and re-evaluated the grounding gate inline, in parallel with the `staticRuleBlocks()` accessor that the prompt-template hash reads. The two agreed only by hand-maintained duplication — one edit from the template hash silently attesting a prompt that was never assembled. The builder now spreads `staticRuleBlocks()` directly, so builder and hash basis cannot drift, and a new test pins that the assembled prompt's static-block sequence equals the accessor's output.

**Template hash is computed once, not every turn.** Split the lineage hashing into `computeTemplateHash` + `computeAssembledHash` (keeping `computePromptLineage` as a thin wrapper for the public API). The template hash is derived from constructor-stable inputs — soul, skills, tool schemas, model, and the compile-time rule-block set — so it is now memoized on first use instead of re-stringifying the full tool-schema set on every turn. The assembled hash still recomputes per turn, as it must.

**Honest usage-ledger line shape.** The whole-turn and boot ledger lines spelled out nine fields as literal `undefined`; the interface forced those fields to `T | undefined` to accommodate rows that never populate them. Made the generation-only fields optional and omitted them at the turn/boot call sites — `JSON.stringify` already dropped the undefined keys, so the written JSONL is byte-identical.

## Verification

- `pnpm check` clean (types, trademarks, fixture-privacy, registry-isolation).
- Full core suite green: 131 files, 2030 passed / 2 skipped.
- Byte-stability and prefix-token-ceiling suites confirm the prompt assembly is byte-identical; the prompt-lineage suite confirms the hash values are unchanged; the usage-ledger suite confirms the line shape round-trips.

## Deliberately out of scope (noted, not done here)

- Deriving a `cost` value for the AI-SDK providers (today only the codex path populates it) — that adds behavior/pricing, not cleanup.
- Moving the ledger write off the reply path / dropping the per-append `statSync` — the synchronous write is relied on by tests that read the file immediately; a fire-and-forget change is a behavior change, tracked separately.
- Collapsing the repeated once-per-turn flush guard into a single helper — correct today, but the refactor touches the latch's ordering invariant, so it is left for its own change.
