### PR TITLE
refactor(core): hoist the loop-invariant prompt cache key out of the retry loop

### DIFF
--- a/packages/core/src/agent/coach-agent.ts
+++ b/packages/core/src/agent/coach-agent.ts
@@ -281,6 +281,9 @@ export class CoachAgent {
       let timeoutAttempts = 0;
       let rateLimitAttempts = 0;
 
+      // Loop-invariant: the prompt cache key derives only from the chat id.
+      const cacheKey = sha256_16(chatId);
+
       while (true) {
         // Preemptive: compact before sending if over budget
         if (shouldCompact({ messages, systemPrompt: this.systemPrompt, contextWindowTokens: this.config.contextWindowTokens })) {
@@ -304,7 +307,7 @@ export class CoachAgent {
             stopWhen: stepCountIs(10),
             maxSteps: 10,
             caller: "chat",
-            cacheKey: sha256_16(chatId),
+            cacheKey,
           });
 
           const templateHash = (this.templateHash ??= computeTemplateHash({


### PR DESCRIPTION
A tiny behavior-preserving cleanup surfaced by a second-pass review of the prompt/caching/cost code.

The `chat()` prompt cache key is a pure function of the chat id, but it was built inside the per-turn retry/compaction `while (true)` loop — so it re-hashed on every overflow retry and read as if it could vary per iteration when it cannot. Hoisted the `const cacheKey = sha256_16(chatId)` above the loop.

No behavior change: the value passed to `generate` is identical; only the redundant per-iteration recompute (and the false implication of per-iteration variance) is removed.

## Verification

- `pnpm check` clean (types, trademarks, fixture-privacy, registry-isolation).
- Full core suite green: 131 files, 2030 passed / 2 skipped.
