### PR TITLE
refactor(core): gate the anthropic cache-control directive behind the anthropic provider

### DIFF
--- a/.changeset/guard-anthropic-cache-directive.md
+++ b/.changeset/guard-anthropic-cache-directive.md
@@ -1,0 +1,5 @@
+---
+"cycling-coach": patch
+---
+
+Gate the Anthropic ephemeral cache-control directive behind the anthropic provider in the LLM dispatch chokepoint, so openai/google requests carry the plain system string instead of an Anthropic-only `providerOptions` block. Document `GenerateOpts.cacheKey` as codex-only (the AI-SDK arm never reads it; it is forwarded to the codex bridge as its session id). Adds a guardrail test pinning that non-Anthropic AI-SDK providers carry no `cacheControl`/`providerOptions`.

--- a/packages/core/src/llm-types.ts
+++ b/packages/core/src/llm-types.ts
@@ -14,6 +14,7 @@ export interface GenerateOpts {
   stopWhen?: StopCondition<any> | Array<StopCondition<any>>;
   maxSteps?: number;
   maxOutputTokens?: number;
+  /** Codex-only: forwarded to the codex bridge as its session id. The AI-SDK providers never read it. */
   cacheKey?: string;
   caller?: "chat" | "flush" | "compact";
 }

--- a/packages/core/src/llm.ts
+++ b/packages/core/src/llm.ts
@@ -47,17 +47,20 @@ export class LLM {
     }
 
     // Breakpoint on the last (only) stable system block; the provider renders
-    // tools before system, so the marker caches tools + system together.
+    // tools before system, so the marker caches tools + system together. The
+    // cacheControl directive is Anthropic-specific — openai/google get the plain
+    // system string. A second AI-SDK provider that needs prompt caching adds its
+    // own branch here rather than extending this Anthropic-only one.
     const cachedSystem =
-      opts.system === undefined
-        ? undefined
-        : [
+      this.config.llm.provider === "anthropic" && opts.system !== undefined
+        ? [
             {
               role: "system" as const,
               content: opts.system,
               providerOptions: { anthropic: { cacheControl: { type: "ephemeral" } } },
             },
-          ];
+          ]
+        : undefined;
 
     const base = {
       model: this.aiSdkModel,

--- a/packages/core/tests/llm-cache-control.test.ts
+++ b/packages/core/tests/llm-cache-control.test.ts
@@ -24,6 +24,17 @@ function codexConfig(): Config {
   };
 }
 
+function aiSdkConfig(provider: "openai" | "google", model: string): Config {
+  return {
+    llm: { provider, model, apiKey: "test-key" },
+    intervals: { apiKey: "", athleteId: "0" },
+    telegram: { botToken: "" },
+    session: { historyTokenBudgetRatio: 0.3, idleMinutes: 0, dailyResetHour: 4, resetArchiveRetentionDays: 0, timezone: "" },
+    contextWindowTokens: 272_000,
+    dataDir: "/tmp/cc-cache-control-test",
+  };
+}
+
 const MINIMAL_RESULT = { text: "ok", toolCalls: [], finishReason: "stop", usage: {}, totalUsage: {}, steps: [] };
 
 beforeEach(() => {
@@ -85,4 +96,34 @@ describe("LLM cache control — Anthropic system breakpoint", () => {
     expect(typeof captured?.system).toBe("string");
     expect(captured?.system).toBe("STABLE SYSTEM PROMPT");
   });
+});
+
+describe("LLM cache control — non-Anthropic AI-SDK providers carry no Anthropic directive", () => {
+  for (const { provider, model, mockPath, mockFactory } of [
+    { provider: "openai" as const, model: "gpt-4o", mockPath: "@ai-sdk/openai", mockFactory: () => ({ createOpenAI: () => () => ({ provider: "openai-stub" }) }) },
+    { provider: "google" as const, model: "gemini-2.0-flash", mockPath: "@ai-sdk/google", mockFactory: () => ({ createGoogleGenerativeAI: () => () => ({ provider: "google-stub" }) }) },
+  ]) {
+    it(`passes the system as a plain string with no providerOptions on the ${provider} path`, async () => {
+      let captured: { system?: unknown } | undefined;
+      vi.doMock("ai", () => ({
+        generateText: vi.fn(async (arg: { system?: unknown }) => {
+          captured = arg;
+          return MINIMAL_RESULT;
+        }),
+      }));
+      vi.doMock(mockPath, mockFactory);
+
+      const { LLM } = await import("../src/llm.js");
+      const llm = new LLM(aiSdkConfig(provider, model));
+      await llm.generate({
+        system: "STABLE SYSTEM PROMPT",
+        messages: [{ role: "user", content: "hi" }],
+      });
+
+      expect(typeof captured?.system).toBe("string");
+      expect(captured?.system).toBe("STABLE SYSTEM PROMPT");
+      expect(JSON.stringify(captured)).not.toContain("cacheControl");
+      expect(JSON.stringify(captured)).not.toContain("providerOptions");
+    });
+  }
 });


### PR DESCRIPTION
## What

Gates the Anthropic ephemeral `cacheControl` directive in the LLM dispatch chokepoint behind `provider === "anthropic"`. Previously the directive rode onto every AI-SDK provider whenever a system prompt was present, so openai/google requests carried an Anthropic-only `providerOptions` block — inert for those providers today, but a latent correctness hazard. openai/google now receive the plain system string.

Also documents `GenerateOpts.cacheKey` as codex-only: it is forwarded to the codex bridge as its session id and is never read on the AI-SDK arm.

## Why

Addresses the provider cache-strategy seam (issue 159). The cache directive and the `cacheKey` field were both unscoped, making the seam read as if every provider participated in prompt caching when only Anthropic (directive) and codex (`cacheKey`) actually do.

Deliberately minimal per the architecture review — no strategy object, no provider-discriminated `GenerateOpts`. The comment marks the extension point; a second AI-SDK provider that needs caching adds its own branch there.

## Test plan

- New guardrail cases in `llm-cache-control.test.ts`: openai and google paths carry a plain-string system with no `cacheControl`/`providerOptions`.
- Existing anthropic (block array + `cacheControl`) and codex (plain string) cases unchanged.
- Full core suite green (131 files, 2032 passed, 2 skipped); `tsc --noEmit` clean.
