### PR TITLE
feat(core): fold per-turn token usage and cost onto the usage-ledger turn line

### DIFF
--- a/.changeset/turn-line-usage-rollup.md
+++ b/.changeset/turn-line-usage-rollup.md
@@ -1,0 +1,5 @@
+---
+"cycling-coach": patch
+---
+
+Record per-turn token usage and cost on the local usage-ledger turn line. The chat turn line previously carried only timing (`durationMs`); it now also folds in the winning generation's input/output/total tokens, cache read/write tokens, and cost, mirroring the per-generation line. v1 records the final successful generation's figures — not a sum across retry/compaction attempts — and a true turn-wide accumulator is deferred.

--- a/packages/core/src/agent/coach-agent.ts
+++ b/packages/core/src/agent/coach-agent.ts
@@ -300,7 +300,7 @@ export class CoachAgent {
         }
 
         try {
-          const { text } = await this.llm.generate({
+          const result = await this.llm.generate({
             system: this.systemPrompt,
             messages,
             tools: this.tools,
@@ -309,6 +309,7 @@ export class CoachAgent {
             caller: "chat",
             cacheKey,
           });
+          const { text } = result;
 
           const templateHash = (this.templateHash ??= computeTemplateHash({
             soul: this.sport.soul,
@@ -328,6 +329,14 @@ export class CoachAgent {
             model: this.config.llm.model,
           });
 
+          // A turn can run several generations (retry/compaction/overflow
+          // recovery); these usage/cost figures are the FINAL successful
+          // generation's only — not a turn-wide sum across attempts. A true
+          // accumulator over all attempts is deferred.
+          const turnUsage = result.totalUsage;
+          const turnCacheDetails = turnUsage?.inputTokenDetails as
+            | { cacheReadTokens?: number; cacheWriteTokens?: number }
+            | undefined;
           appendUsageLine(this.config.dataDir, {
             ts: Date.now(),
             kind: "turn",
@@ -335,6 +344,12 @@ export class CoachAgent {
             provider: this.config.llm.provider,
             model: this.config.llm.model,
             durationMs: Date.now() - turnStart,
+            inputTokens: turnUsage?.inputTokens,
+            outputTokens: turnUsage?.outputTokens,
+            totalTokens: turnUsage?.totalTokens,
+            cacheReadTokens: turnCacheDetails?.cacheReadTokens,
+            cacheWriteTokens: turnCacheDetails?.cacheWriteTokens,
+            cost: result.cost,
           });
 
           return text;

--- a/packages/core/src/usage-ledger.ts
+++ b/packages/core/src/usage-ledger.ts
@@ -10,7 +10,9 @@ export interface UsageLedgerLine {
   provider: string;
   model: string;
   durationMs: number;
-  // Populated on per-generation lines; absent on the whole-turn and boot lines.
+  // Populated on per-generation lines and on the whole-turn line; absent on the
+  // boot line. On a turn line the token/cost figures are the final successful
+  // generation's, not a sum across retry/compaction attempts.
   caller?: "chat" | "flush" | "compact";
   steps?: number;
   inputTokens?: number;

--- a/packages/core/tests/usage-ledger.test.ts
+++ b/packages/core/tests/usage-ledger.test.ts
@@ -1,10 +1,13 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { mkdtempSync, rmSync, statSync, readFileSync, writeFileSync, existsSync } from "node:fs";
+import { mkdtempSync, rmSync, mkdirSync, statSync, readFileSync, writeFileSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import { cyclingSport } from "@enduragent/sport-cycling";
 import type { Config } from "../src/config.js";
+import type { Sport } from "../src/sport.js";
 import type { UsageLedgerLine } from "../src/usage-ledger.js";
+import { baseAgentConfig } from "./helpers/base-agent-config.js";
 
 let dir: string;
 
@@ -78,6 +81,31 @@ describe("appendUsageLine", () => {
       expect(parsed.durationMs).toBeDefined();
       expect(parsed.provider).toBe("anthropic");
     }
+  });
+
+  it("carries the per-turn token usage and cost on a turn line", async () => {
+    const { appendUsageLine } = await import("../src/usage-ledger.js");
+    appendUsageLine(
+      dir,
+      ledgerLine({
+        kind: "turn",
+        inputTokens: 30,
+        outputTokens: 12,
+        totalTokens: 42,
+        cacheReadTokens: 7,
+        cacheWriteTokens: 4,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0.03 },
+      }),
+    );
+
+    const parsed = JSON.parse(readLines(dir)[0]) as UsageLedgerLine;
+    expect(parsed.kind).toBe("turn");
+    expect(parsed.inputTokens).toBe(30);
+    expect(parsed.outputTokens).toBe(12);
+    expect(parsed.totalTokens).toBe(42);
+    expect(parsed.cacheReadTokens).toBe(7);
+    expect(parsed.cacheWriteTokens).toBe(4);
+    expect(parsed.cost?.total).toBe(0.03);
   });
 
   it("rotates the ledger to .jsonl.1 once it crosses 10 MB", async () => {
@@ -272,5 +300,112 @@ describe("LLM.generate — codex path writes a ledger line", () => {
     expect(parsed.provider).toBe("openai-codex");
     expect(parsed.totalTokens).toBe(42);
     expect(parsed.cost?.total).toBe(0.03);
+  });
+});
+
+describe("turn line — winning generation usage and cost", () => {
+  let tempHome: string;
+  let origHome: string | undefined;
+  let agentDataDir: string;
+
+  beforeEach(() => {
+    tempHome = mkdtempSync(join(tmpdir(), "cc-turn-"));
+    origHome = process.env.HOME;
+    process.env.HOME = tempHome;
+    agentDataDir = join(tempHome, ".cycling-coach");
+    mkdirSync(agentDataDir, { recursive: true });
+    mkdirSync(join(agentDataDir, "memory"), { recursive: true });
+    vi.resetModules();
+    // A sibling describe block stubs the codex bridge to a fixed reply; drop
+    // that registration so this block drives the real retry loop.
+    vi.doUnmock("../src/agent/codex-bridge.js");
+  });
+
+  afterEach(() => {
+    process.env.HOME = origHome;
+    rmSync(tempHome, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  function piUsage(input: number, output: number, cost = 0) {
+    return {
+      input,
+      output,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: input + output,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: cost },
+    };
+  }
+
+  function mkAssistant(text: string, usage = piUsage(0, 0)) {
+    return {
+      role: "assistant" as const,
+      content: [{ type: "text" as const, text }],
+      api: "openai-codex-responses",
+      provider: "openai-codex",
+      model: "gpt-5.4",
+      usage,
+      stopReason: "stop" as const,
+      timestamp: Date.now(),
+    };
+  }
+
+  async function setupAgent(complete: ReturnType<typeof vi.fn>) {
+    const model = {
+      id: "gpt-5.4",
+      name: "gpt-5.4",
+      api: "openai-codex-responses",
+      provider: "openai-codex",
+      baseUrl: "https://chatgpt.com/backend-api",
+      reasoning: true,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 272_000,
+      maxTokens: 128_000,
+    };
+    vi.doMock("@mariozechner/pi-ai", () => ({
+      complete,
+      getModel: vi.fn(() => model),
+    }));
+    vi.doMock("@mariozechner/pi-ai/oauth", () => ({
+      refreshOpenAICodexToken: vi.fn(),
+      loginOpenAICodex: vi.fn(),
+    }));
+    vi.doMock("../src/auth/profiles.js", () => ({
+      getFreshToken: vi.fn(async () => "token"),
+      loadProfile: vi.fn(),
+      saveProfile: vi.fn(),
+      RefreshTokenReusedError: class extends Error {},
+    }));
+    const { CoachAgent } = await import("../src/agent/coach-agent.js");
+    return new CoachAgent(cyclingSport as unknown as Sport, baseAgentConfig(agentDataDir));
+  }
+
+  it("records the final successful generation's usage/cost, not a failed attempt's", async () => {
+    let n = 0;
+    const complete = vi.fn(async () => {
+      n++;
+      if (n === 1) {
+        // First attempt overflows: its usage must never reach the turn line.
+        throw new Error("Request exceeds the maximum context length of 272000 tokens");
+      }
+      // The winning retry carries the figures the turn line must report.
+      return mkAssistant("recovered", piUsage(30, 12, 0.03));
+    });
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const agent = await setupAgent(complete);
+
+    const text = await agent.chat("turn-winner", "hello");
+    expect(text).toBe("recovered");
+
+    const turnLine = readLines(agentDataDir)
+      .map((l) => JSON.parse(l) as UsageLedgerLine)
+      .find((l) => l.kind === "turn");
+    expect(turnLine).toBeDefined();
+    expect(turnLine?.inputTokens).toBe(30);
+    expect(turnLine?.outputTokens).toBe(12);
+    expect(turnLine?.totalTokens).toBe(42);
+    expect(turnLine?.cost?.total).toBe(0.03);
   });
 });


### PR DESCRIPTION
## What

Records per-turn token usage and cost on the local usage-ledger **turn** line. The chat turn line previously carried only timing (`durationMs`); the chat generation result was destructured as `const { text } = ...` with `totalUsage`/`cost` discarded. It now captures the full result and folds the winning generation's `inputTokens`/`outputTokens`/`totalTokens`, `cacheReadTokens`/`cacheWriteTokens`, and `cost` onto the turn line, mirroring the existing per-generation line's field names and the nested `cost` shape.

No type change was needed — those fields already existed (optional) on the shared `UsageLedgerLine` interface; the field comment is tightened to document that turn lines now carry them.

## Winning-generation v1 semantics

A turn can run several generations (the `while (true)` retry/compaction/overflow-recovery loop). The turn-line emission sits inside the success branch, reached only after a generation succeeds and immediately before the turn returns — so it records the **final successful generation's** figures, not a sum across attempts and not a failed attempt's. A true turn-wide accumulator is explicitly deferred (documented in a code comment at the emission site).

## Why

Addresses issue 160 GAP 2 (usage-ledger cost completeness). The turn line is the natural roll-up surface for per-turn observability; today it drops usage/cost data the chat call already has in hand.

## Test plan

- New `usage-ledger.test.ts` case: a `kind:"turn"` line round-trips the token/cost fields through the writer.
- New end-to-end case: drives `CoachAgent.chat()` through a context-overflow retry storm and asserts the turn line carries the **winning** retry's figures (30/12/42, `cost.total` 0.03), proving a thrown first attempt's numbers never land.
- Existing turn-line assertions (kind/durationMs/provider) left intact.
- Full core suite green (131 files, 2032 passed, 2 skipped); `tsc --noEmit` clean.

## Note

The AI-SDK dispatch path leaves `cost` undefined today (only the codex path computes it) — consistent with the existing per-generation line. Deriving cost for the AI-SDK providers is the follow-up (issue 160 GAP 1).
