### PR TITLE
feat(core): derive AI-SDK provider cost from the model-pricing catalog

### DIFF
--- a/.changeset/ai-sdk-cost-derivation.md
+++ b/.changeset/ai-sdk-cost-derivation.md
@@ -1,0 +1,5 @@
+---
+"cycling-coach": patch
+---
+
+Derive per-call cost for the AI-SDK providers (anthropic/openai/google) in the LLM dispatch chokepoint, so the local usage ledger's cost column is populated for them — previously only the codex path carried a cost. Cost is computed from the maintained model-pricing catalog (`pi-ai`'s `calculateCost`), the same catalog the codex path already prices against. The codex path keeps its own provider-reported cost and is never re-priced, and an uncatalogued model leaves cost undefined rather than fabricating a figure.

--- a/packages/core/src/llm.ts
+++ b/packages/core/src/llm.ts
@@ -5,6 +5,7 @@ import { createGoogleGenerativeAI } from "@ai-sdk/google";
 import type { LanguageModel } from "ai";
 
 import { calculateCost, getModels } from "@mariozechner/pi-ai";
+import type { Api, Model } from "@mariozechner/pi-ai";
 
 import type { Config } from "./config.js";
 import { codexGenerateText } from "./agent/codex-bridge.js";
@@ -20,10 +21,18 @@ export type { GenerateOpts, GenerateResult } from "./llm-types.js";
 export class LLM {
   private config: Config;
   private aiSdkModel: LanguageModel | null;
+  // Provider + model are fixed for the instance, so resolve the pricing model
+  // once here. getModels() allocates a fresh array per call, so doing this in
+  // generate() would re-scan the catalog on every LLM round-trip.
+  private pricingModel: Model<Api> | null;
 
   constructor(config: Config) {
     this.config = config;
     this.aiSdkModel = config.llm.provider === "openai-codex" ? null : buildAiSdkModel(config);
+    this.pricingModel =
+      config.llm.provider === "openai-codex"
+        ? null
+        : (getModels(config.llm.provider).find((m) => m.id === config.llm.model) ?? null);
   }
 
   async generate(opts: GenerateOpts): Promise<GenerateResult> {
@@ -83,15 +92,13 @@ export class LLM {
       usage: result.usage,
       totalUsage: result.totalUsage,
       steps: result.steps.length,
-      cost: priceAiSdkUsage(this.config.llm.provider, this.config.llm.model, result.totalUsage),
+      cost: priceAiSdkUsage(this.pricingModel, result.totalUsage),
     };
   }
 
   private recordGenerate(opts: GenerateOpts, result: GenerateResult, durationMs: number): void {
     const usage = result.totalUsage;
-    const details = usage?.inputTokenDetails as
-      | { cacheReadTokens?: number; cacheWriteTokens?: number }
-      | undefined;
+    const details = cacheTokenDetails(usage);
     appendUsageLine(this.config.dataDir, {
       ts: Date.now(),
       kind: "generate",
@@ -111,21 +118,27 @@ export class LLM {
   }
 }
 
-// The AI SDK reports token usage but no cost, so derive it from the same
-// maintained model catalog the codex path already prices against. Codex carries
-// its own provider-reported cost and is never re-priced here. An uncatalogued
-// model yields undefined rather than a fabricated figure (best-effort ledger).
-function priceAiSdkUsage(
-  provider: Config["llm"]["provider"],
-  modelId: string,
-  totalUsage: GenerateResult["totalUsage"],
-): GenerateResult["cost"] | undefined {
-  if (!totalUsage) return undefined;
-  const model = getModels(provider).find((m) => m.id === modelId);
-  if (!model) return undefined;
-  const details = totalUsage.inputTokenDetails as
+// The AI SDK leaves `inputTokenDetails` loosely typed; this is the single point
+// where its cache-token shape is asserted, so every consumer reads it the same way.
+function cacheTokenDetails(
+  usage: GenerateResult["totalUsage"],
+): { cacheReadTokens?: number; cacheWriteTokens?: number } | undefined {
+  return usage?.inputTokenDetails as
     | { cacheReadTokens?: number; cacheWriteTokens?: number }
     | undefined;
+}
+
+// The AI SDK reports token usage but no cost, so derive it from the same
+// maintained model catalog the codex path already prices against. The model is
+// resolved once at construction; codex carries its own provider-reported cost
+// and is never re-priced here. An uncatalogued (null) model yields undefined
+// rather than a fabricated figure (best-effort ledger).
+function priceAiSdkUsage(
+  model: Model<Api> | null,
+  totalUsage: GenerateResult["totalUsage"],
+): GenerateResult["cost"] | undefined {
+  if (!model || !totalUsage) return undefined;
+  const details = cacheTokenDetails(totalUsage);
   return calculateCost(model, {
     input: totalUsage.inputTokens ?? 0,
     output: totalUsage.outputTokens ?? 0,

--- a/packages/core/src/llm.ts
+++ b/packages/core/src/llm.ts
@@ -4,6 +4,8 @@ import { createOpenAI } from "@ai-sdk/openai";
 import { createGoogleGenerativeAI } from "@ai-sdk/google";
 import type { LanguageModel } from "ai";
 
+import { calculateCost, getModels } from "@mariozechner/pi-ai";
+
 import type { Config } from "./config.js";
 import { codexGenerateText } from "./agent/codex-bridge.js";
 import type { GenerateOpts, GenerateResult } from "./llm-types.js";
@@ -81,6 +83,7 @@ export class LLM {
       usage: result.usage,
       totalUsage: result.totalUsage,
       steps: result.steps.length,
+      cost: priceAiSdkUsage(this.config.llm.provider, this.config.llm.model, result.totalUsage),
     };
   }
 
@@ -106,6 +109,31 @@ export class LLM {
       stopReason: result.finishReason,
     });
   }
+}
+
+// The AI SDK reports token usage but no cost, so derive it from the same
+// maintained model catalog the codex path already prices against. Codex carries
+// its own provider-reported cost and is never re-priced here. An uncatalogued
+// model yields undefined rather than a fabricated figure (best-effort ledger).
+function priceAiSdkUsage(
+  provider: Config["llm"]["provider"],
+  modelId: string,
+  totalUsage: GenerateResult["totalUsage"],
+): GenerateResult["cost"] | undefined {
+  if (!totalUsage) return undefined;
+  const model = getModels(provider).find((m) => m.id === modelId);
+  if (!model) return undefined;
+  const details = totalUsage.inputTokenDetails as
+    | { cacheReadTokens?: number; cacheWriteTokens?: number }
+    | undefined;
+  return calculateCost(model, {
+    input: totalUsage.inputTokens ?? 0,
+    output: totalUsage.outputTokens ?? 0,
+    cacheRead: details?.cacheReadTokens ?? 0,
+    cacheWrite: details?.cacheWriteTokens ?? 0,
+    totalTokens: totalUsage.totalTokens ?? 0,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+  });
 }
 
 // ============================================================================

--- a/packages/core/tests/usage-ledger.test.ts
+++ b/packages/core/tests/usage-ledger.test.ts
@@ -156,6 +156,48 @@ describe("LLM.generate — AI-SDK path", () => {
     expect(parsed.cacheWriteTokens).toBe(4);
     expect(parsed.steps).toBe(2);
   });
+
+  it("prices the generate line from the model catalog when the model is catalogued", async () => {
+    const { getModels } = await import("@mariozechner/pi-ai");
+    const known = getModels("anthropic").find((m) => m.cost.input > 0);
+    if (!known) throw new Error("expected at least one priced anthropic model in the catalog");
+
+    const { LLM } = await loadLLMWithGenerateText({
+      text: "ok",
+      toolCalls: [],
+      finishReason: "stop",
+      usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+      totalUsage: { inputTokens: 1_000_000, outputTokens: 0, totalTokens: 1_000_000 },
+      steps: [{ s: "a" }],
+    });
+    const config: Config = { ...anthropicConfig(dir), llm: { provider: "anthropic", model: known.id, apiKey: "sk-test" } };
+    const llm = new LLM(config);
+
+    await llm.generate({ prompt: "hi", caller: "chat" });
+
+    const parsed = JSON.parse(readLines(dir)[0]) as UsageLedgerLine;
+    expect(parsed.cost).toBeDefined();
+    // 1,000,000 input tokens at a per-million-token rate equals exactly that rate.
+    expect(parsed.cost?.input).toBeCloseTo(known.cost.input, 10);
+    expect(parsed.cost?.total).toBeCloseTo(known.cost.input, 10);
+  });
+
+  it("leaves cost undefined when the model is not in the catalog", async () => {
+    const { LLM } = await loadLLMWithGenerateText({
+      text: "ok",
+      toolCalls: [],
+      finishReason: "stop",
+      usage: { inputTokens: 3, outputTokens: 2, totalTokens: 5 },
+      totalUsage: { inputTokens: 30, outputTokens: 20, totalTokens: 50 },
+      steps: [{ s: "a" }],
+    });
+    const llm = new LLM(anthropicConfig(dir)); // model "claude-test" — not catalogued
+
+    await llm.generate({ prompt: "hi", caller: "chat" });
+
+    const parsed = JSON.parse(readLines(dir)[0]) as UsageLedgerLine;
+    expect(parsed.cost).toBeUndefined();
+  });
 });
 
 describe("codex bridge — usage accumulation across the loop", () => {


### PR DESCRIPTION
## What

Derives per-call cost for the AI-SDK providers (anthropic / openai / google) in the LLM dispatch chokepoint. Previously the AI-SDK dispatch return omitted `cost`, so `recordGenerate` wrote `cost: undefined` on every anthropic/openai/google ledger line — only the codex path carried a cost. Now the AI-SDK arm prices `result.totalUsage` against the maintained model-pricing catalog (`pi-ai`'s `calculateCost`) — the same catalog the codex path already prices against — so the local usage ledger's cost column is populated for all providers.

## Contract

- **Provider-reported cost stays authoritative.** The codex path keeps feeding its own pre-priced `cost` and is **never re-priced** at the seam (the codex arm returns before the new pricing). Baking catalog-vs-billed reconciliation into codex lines would produce a populated-but-wrong column, worse than the status quo.
- **Catalog is the fallback only**, used where the provider reports none (the AI SDK reports no cost).
- **Uncatalogued model → `undefined`**, not a fabricated figure (`getModels(provider).find(id)` returns nothing → best-effort ledger contract, no crash at the chokepoint).

No hand-rolled price table — the repo already depends on `pi-ai`, whose catalog is the only maintenance surface, and it's the same one already in use.

## Why

Addresses issue 160 GAP 1 (usage-ledger cost completeness). This is the change that **unblocks issue 158's cost baseline** — the cost column is structurally null until this ships. Composes with the turn-line roll-up (#217): once both land, the turn line also carries AI-SDK cost (it reads `result.cost`).

## Test plan

- New `usage-ledger.test.ts` case: a catalogued model prices the generate line — asserted against `pi-ai`'s live per-million-token rate (1,000,000 input tokens ⇒ cost equals the rate), so it stays robust across catalog updates rather than pinning a dollar figure.
- New case: an uncatalogued model (`claude-test`) leaves `cost` undefined.
- Codex cost-accumulation test unchanged (codex path not re-priced).
- Full core suite green (131 files, 2034 passed, 2 skipped); `tsc --noEmit` clean.
