### PR TITLE
refactor(core): route usage-ledger lines through one shared field mapper

### DIFF
--- a/.changeset/usage-line-from-result.md
+++ b/.changeset/usage-line-from-result.md
@@ -1,0 +1,5 @@
+---
+"cycling-coach": patch
+---
+
+Internal refactor: route the per-generation and per-turn usage-ledger lines through one shared `usageFieldsFromResult` mapper, and assert the AI-SDK `inputTokenDetails` cache-token shape in a single `cacheTokenDetails` helper, instead of copying the field-by-field block and cast across `llm.ts` and `coach-agent.ts`. Behavior-neutral.

--- a/packages/core/src/agent/coach-agent.ts
+++ b/packages/core/src/agent/coach-agent.ts
@@ -27,7 +27,7 @@ import { runMemoryFlush, FLUSH_ZERO_WRITE_MIN_MESSAGES, shouldRunMemoryFlush } f
 import type { MemoryFlushOutcome } from "./memory-flush.js";
 import { evaluateSessionFreshness } from "./session-freshness.js";
 import { LLM } from "../llm.js";
-import { appendUsageLine } from "../usage-ledger.js";
+import { appendUsageLine, usageFieldsFromResult } from "../usage-ledger.js";
 import { createMemorySnapshot } from "../memory/snapshot.js";
 import { resolveUserTimezone, appendCurrentTimeLine } from "./user-time.js";
 
@@ -333,10 +333,6 @@ export class CoachAgent {
           // recovery); these usage/cost figures are the FINAL successful
           // generation's only — not a turn-wide sum across attempts. A true
           // accumulator over all attempts is deferred.
-          const turnUsage = result.totalUsage;
-          const turnCacheDetails = turnUsage?.inputTokenDetails as
-            | { cacheReadTokens?: number; cacheWriteTokens?: number }
-            | undefined;
           appendUsageLine(this.config.dataDir, {
             ts: Date.now(),
             kind: "turn",
@@ -344,12 +340,7 @@ export class CoachAgent {
             provider: this.config.llm.provider,
             model: this.config.llm.model,
             durationMs: Date.now() - turnStart,
-            inputTokens: turnUsage?.inputTokens,
-            outputTokens: turnUsage?.outputTokens,
-            totalTokens: turnUsage?.totalTokens,
-            cacheReadTokens: turnCacheDetails?.cacheReadTokens,
-            cacheWriteTokens: turnCacheDetails?.cacheWriteTokens,
-            cost: result.cost,
+            ...usageFieldsFromResult(result),
           });
 
           return text;

--- a/packages/core/src/llm.ts
+++ b/packages/core/src/llm.ts
@@ -10,7 +10,7 @@ import type { Api, Model } from "@mariozechner/pi-ai";
 import type { Config } from "./config.js";
 import { codexGenerateText } from "./agent/codex-bridge.js";
 import type { GenerateOpts, GenerateResult } from "./llm-types.js";
-import { appendUsageLine } from "./usage-ledger.js";
+import { appendUsageLine, cacheTokenDetails, usageFieldsFromResult } from "./usage-ledger.js";
 
 export type { GenerateOpts, GenerateResult } from "./llm-types.js";
 
@@ -97,8 +97,6 @@ export class LLM {
   }
 
   private recordGenerate(opts: GenerateOpts, result: GenerateResult, durationMs: number): void {
-    const usage = result.totalUsage;
-    const details = cacheTokenDetails(usage);
     appendUsageLine(this.config.dataDir, {
       ts: Date.now(),
       kind: "generate",
@@ -107,25 +105,10 @@ export class LLM {
       model: this.config.llm.model,
       durationMs,
       steps: result.steps,
-      inputTokens: usage?.inputTokens,
-      outputTokens: usage?.outputTokens,
-      totalTokens: usage?.totalTokens,
-      cacheReadTokens: details?.cacheReadTokens,
-      cacheWriteTokens: details?.cacheWriteTokens,
-      cost: result.cost,
+      ...usageFieldsFromResult(result),
       stopReason: result.finishReason,
     });
   }
-}
-
-// The AI SDK leaves `inputTokenDetails` loosely typed; this is the single point
-// where its cache-token shape is asserted, so every consumer reads it the same way.
-function cacheTokenDetails(
-  usage: GenerateResult["totalUsage"],
-): { cacheReadTokens?: number; cacheWriteTokens?: number } | undefined {
-  return usage?.inputTokenDetails as
-    | { cacheReadTokens?: number; cacheWriteTokens?: number }
-    | undefined;
 }
 
 // The AI SDK reports token usage but no cost, so derive it from the same

--- a/packages/core/src/usage-ledger.ts
+++ b/packages/core/src/usage-ledger.ts
@@ -1,6 +1,8 @@
 import { appendFileSync, renameSync, statSync } from "node:fs";
 import { join } from "node:path";
 
+import type { GenerateResult } from "./llm-types.js";
+
 export const USAGE_LEDGER_FILE = "usage-ledger.jsonl";
 export const USAGE_LEDGER_MAX_BYTES = 10 * 1024 * 1024;
 
@@ -22,6 +24,37 @@ export interface UsageLedgerLine {
   cacheWriteTokens?: number;
   cost?: { input: number; output: number; cacheRead: number; cacheWrite: number; total: number };
   stopReason?: string;
+}
+
+// The AI SDK leaves `inputTokenDetails` loosely typed; this is the single point
+// where its cache-token shape is asserted, so every consumer reads it the same way.
+export function cacheTokenDetails(
+  usage: GenerateResult["totalUsage"],
+): { cacheReadTokens?: number; cacheWriteTokens?: number } | undefined {
+  return usage?.inputTokenDetails as
+    | { cacheReadTokens?: number; cacheWriteTokens?: number }
+    | undefined;
+}
+
+// Maps a completed generation's whole-turn usage and derived cost onto the
+// ledger's token/cost fields. The per-generation line and the per-turn line
+// carry the same shape, so both build it through this one mapper.
+export function usageFieldsFromResult(
+  result: GenerateResult,
+): Pick<
+  UsageLedgerLine,
+  "inputTokens" | "outputTokens" | "totalTokens" | "cacheReadTokens" | "cacheWriteTokens" | "cost"
+> {
+  const usage = result.totalUsage;
+  const details = cacheTokenDetails(usage);
+  return {
+    inputTokens: usage?.inputTokens,
+    outputTokens: usage?.outputTokens,
+    totalTokens: usage?.totalTokens,
+    cacheReadTokens: details?.cacheReadTokens,
+    cacheWriteTokens: details?.cacheWriteTokens,
+    cost: result.cost,
+  };
 }
 
 export function appendUsageLine(dataDir: string, line: UsageLedgerLine): void {

--- a/packages/core/tests/usage-ledger.test.ts
+++ b/packages/core/tests/usage-ledger.test.ts
@@ -67,6 +67,53 @@ function readLines(dataDir: string, file = "usage-ledger.jsonl"): string[] {
   return readFileSync(join(dataDir, file), "utf-8").split("\n").filter((l) => l.length > 0);
 }
 
+describe("usageFieldsFromResult", () => {
+  it("maps whole-turn usage, cache details, and cost onto the ledger fields", async () => {
+    const { usageFieldsFromResult } = await import("../src/usage-ledger.js");
+    const fields = usageFieldsFromResult({
+      text: "ok",
+      toolCalls: [],
+      finishReason: "stop",
+      usage: { inputTokens: 3, outputTokens: 2, totalTokens: 5 },
+      totalUsage: {
+        inputTokens: 30,
+        outputTokens: 12,
+        totalTokens: 42,
+        inputTokenDetails: { cacheReadTokens: 7, cacheWriteTokens: 4 },
+      },
+      steps: 1,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0.03 },
+    } as unknown as import("../src/llm-types.js").GenerateResult);
+
+    expect(fields).toEqual({
+      inputTokens: 30,
+      outputTokens: 12,
+      totalTokens: 42,
+      cacheReadTokens: 7,
+      cacheWriteTokens: 4,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0.03 },
+    });
+  });
+
+  it("leaves token fields undefined when totalUsage is absent", async () => {
+    const { usageFieldsFromResult } = await import("../src/usage-ledger.js");
+    const fields = usageFieldsFromResult({
+      text: "ok",
+      toolCalls: [],
+      finishReason: "stop",
+      usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+      totalUsage: undefined,
+      cost: undefined,
+    } as unknown as import("../src/llm-types.js").GenerateResult);
+
+    expect(fields.inputTokens).toBeUndefined();
+    expect(fields.totalTokens).toBeUndefined();
+    expect(fields.cacheReadTokens).toBeUndefined();
+    expect(fields.cacheWriteTokens).toBeUndefined();
+    expect(fields.cost).toBeUndefined();
+  });
+});
+
 describe("appendUsageLine", () => {
   it("writes one JSON line per call to <dataDir>/usage-ledger.jsonl", async () => {
     const { appendUsageLine } = await import("../src/usage-ledger.js");


### PR DESCRIPTION
Both the per-generation ledger line (`llm.ts` `recordGenerate`) and the per-turn line (`coach-agent.ts`) independently copied the same six token/cost fields out of a `GenerateResult` and each re-asserted the loosely-typed `inputTokenDetails` cache-token shape by hand. This collapses all of it behind two shared helpers in `usage-ledger.ts`:

- `cacheTokenDetails(usage)` — the single point asserting the SDK's cache-token shape.
- `usageFieldsFromResult(result)` — maps the whole-turn usage + derived cost onto the ledger's token/cost fields.

Both call sites now spread the mapper; `priceAiSdkUsage` imports the shared cast. The mapper returns the six fields in the same order the inline copies used, so the serialized JSONL key order is unchanged — behavior-neutral.

Verification: `tsc --noEmit` clean; full core suite 2038 pass / 2 skipped (added a direct unit test for the mapper). Confirmed byte-equivalent output, complete dedup (cast now appears exactly once), and no new import cycle (the new `usage-ledger -> llm-types` edge is type-only into a leaf module).