### PR TITLE
docs: add @enduragent X link to READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 AI cycling coaching agent. Bring your own LLM API key **or sign in with a ChatGPT Plus subscription**, connect [intervals.icu](https://intervals.icu) for real athlete data, chat via Telegram or CLI.
 
+Follow [@enduragent](https://x.com/enduragent) on X for updates, or drop a question/feedback anytime.
+
 ## What it does
 
 - Analyzes fitness, fatigue, and form from your real rides

--- a/packages/cycling-coach/README.md
+++ b/packages/cycling-coach/README.md
@@ -82,6 +82,7 @@ npx cycling-coach
 
 ## More
 
+- Follow [@enduragent](https://x.com/enduragent) on X for updates, or drop a question/feedback anytime.
 - **Secrets backends** (1Password, macOS Keychain, Vault, AWS/GCP Secret Manager, age, env), **architecture diagram**, and **development setup** — see the [GitHub repo](https://github.com/yerzhansa/cycling-coach#readme).
 - **Issues**: <https://github.com/yerzhansa/cycling-coach/issues>
 - **License**: MIT


### PR DESCRIPTION
Adds a follow line for the project's X account (@enduragent) to the root README and the cycling-coach package README.

> Follow @enduragent on X for updates, or drop a question/feedback anytime.

- Root `README.md`: line under the tagline.
- `packages/cycling-coach/README.md`: bullet in the "More" list.

Docs-only; no code or behavior changes.