### PR TITLE
feat(cycling-coach): add Railway one-click deploy template

### DIFF
--- a/.changeset/railway-deploy-template.md
+++ b/.changeset/railway-deploy-template.md
@@ -1,0 +1,8 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Added a one-click Railway deploy template so you can spin up your own private, single-tenant instance — your own bot, your own keys, your own data — in a few clicks.
+User-facing: In managed container deploys, /update now explains that the bot updates by redeploying the image instead of attempting an install that can't succeed there.
+
+Ships the Railway distribution channel: a `railway.toml` (Dockerfile builder, crash-restart policy, no inbound healthcheck for the long-polling worker) and a Deploy button in the README. Gates the self-update path behind a `CYCLING_COACH_MANAGED_DEPLOY` flag baked into the runtime image so `/update` and the startup broadcast give redeploy guidance instead of running `npm install -g` (guaranteed EACCES in an image-baked container). Also ships the MIT license + attribution inside both the published npm tarball and the runtime image, and adds a test guarding that every Dockerfile base image stays digest-pinned.

--- a/.dockerignore
+++ b/.dockerignore
@@ -30,7 +30,10 @@ CLAUDE.local.md
 coverage
 .vitest-cache
 
-# Repo metadata not needed in image
-README.md
-CONTRIBUTING.md
-LICENSE
+# Repo metadata not needed in image — exclude the root copies only. The
+# package-level LICENSE / NOTICE.md / README.md must reach the runtime image
+# (they ride into the pnpm-deploy runtime bundle) so the shipped image carries
+# the MIT attribution the upstream license requires.
+/README.md
+/CONTRIBUTING.md
+/LICENSE

--- a/README.md
+++ b/README.md
@@ -388,6 +388,14 @@ telegram:
 
 ### Railway
 
+**One-click deploy** — provisions a single-tenant instance you own end to end (your own @BotFather bot, your intervals.icu key, your LLM key — BYOK, no shared service):
+
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/new/template/TEMPLATE_ID?utm_medium=integration&utm_source=button&utm_campaign=cycling-coach)
+
+<!-- Replace TEMPLATE_ID above with the real id after publishing the Railway template (Project Settings → Generate Template from Project). Until then the button links to a placeholder; the manual steps below always work. -->
+
+Or set it up manually:
+
 Railway autodetects the `Dockerfile` and deploys with no extra config files. Steps:
 
 1. Push this repo to GitHub.

--- a/packages/core/src/channels/telegram.ts
+++ b/packages/core/src/channels/telegram.ts
@@ -9,6 +9,8 @@ import {
   getCurrentVersion,
   getLastNotifiedVersion,
   setLastNotifiedVersion,
+  isManagedDeploy,
+  MANAGED_DEPLOY_UPDATE_NOTICE,
 } from "../updater.js";
 import { buildWhatsNewMessage } from "../release-notes.js";
 import { createAuthMiddleware } from "./telegram-access.js";
@@ -265,6 +267,10 @@ export function createTelegramBot(
   });
 
   bot.command("update", async (ctx) => {
+    if (isManagedDeploy()) {
+      await ctx.reply(MANAGED_DEPLOY_UPDATE_NOTICE);
+      return;
+    }
     await ctx.reply("Checking for updates...");
     let latest: string | undefined;
     try {
@@ -573,7 +579,9 @@ export async function notifyUpdate(bot: Bot, dataDir: string, binary: BinaryConf
     const knownChats = getKnownTelegramChatIds(dataDir);
     const chatIds =
       allowed.dmPolicy === "open" ? knownChats : knownChats.filter((id) => allowSet.has(id));
-    const message = `Update available: ${info.current} → ${info.latest}\nSend /whatsnew to see what changed, /update to install.`;
+    const message = isManagedDeploy()
+      ? `Update available: ${info.current} → ${info.latest}\nSend /whatsnew to see what changed. ${MANAGED_DEPLOY_UPDATE_NOTICE}`
+      : `Update available: ${info.current} → ${info.latest}\nSend /whatsnew to see what changed, /update to install.`;
 
     for (const chatId of chatIds) {
       try {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -181,7 +181,9 @@ export {
   getCurrentVersion,
   getKnownTelegramChatIds,
   getLastNotifiedVersion,
+  isManagedDeploy,
   isUpdateAvailable,
+  MANAGED_DEPLOY_UPDATE_NOTICE,
   selfUpdate,
   setLastNotifiedVersion,
 } from "./updater.js";

--- a/packages/core/src/updater.ts
+++ b/packages/core/src/updater.ts
@@ -120,6 +120,22 @@ export function selfUpdate(binaryName: string, version?: string): void {
   process.exit(0);
 }
 
+/**
+ * True in a platform-managed container deploy (Railway, Fly, PikaPods, …) where
+ * the code is image-baked and `npm install -g` is guaranteed to fail with
+ * EACCES. The Dockerfile bakes `CYCLING_COACH_MANAGED_DEPLOY=1` into the runtime
+ * stage. In this mode the bot must not offer or attempt a self-update — the
+ * platform updates by rebuilding the image from a newer commit.
+ */
+export function isManagedDeploy(): boolean {
+  const flag = process.env.CYCLING_COACH_MANAGED_DEPLOY;
+  return flag === "1" || flag?.toLowerCase() === "true";
+}
+
+/** Operator-facing guidance shown instead of a self-update in managed deploys. */
+export const MANAGED_DEPLOY_UPDATE_NOTICE =
+  "This deployment updates by redeploying the image, not via /update — your hosting platform rebuilds the bot from the latest version when you redeploy.";
+
 export function getKnownTelegramChatIds(dataDir: string): string[] {
   return enumerateTelegramSessions(dataDir).map((s) => s.chatId);
 }

--- a/packages/core/tests/telegram-bot.test.ts
+++ b/packages/core/tests/telegram-bot.test.ts
@@ -124,6 +124,49 @@ describe("notifyUpdate — broadcast filtering (L3)", () => {
     expect(calledIds).toEqual(["11111", "99999"]);
   });
 
+  it("managed-deploy broadcast swaps the /update call-to-action for redeploy guidance", async () => {
+    vi.stubEnv("CYCLING_COACH_MANAGED_DEPLOY", "1");
+    seedSession("11111");
+    saveAllowedSenders(dataDir, () => ({
+      ...defaultPairingState(),
+      dmPolicy: "allowlist",
+      allowFrom: ["11111"],
+      primaryOperator: "11111",
+    }));
+
+    vi.doMock("../src/updater.js", async () => {
+      const real = await vi.importActual<typeof import("../src/updater.js")>(
+        "../src/updater.js",
+      );
+      return {
+        ...real,
+        checkForUpdate: vi.fn(async () => ({
+          current: "2026.5.5",
+          latest: "2026.5.10",
+          updateAvailable: true,
+        })),
+        getKnownTelegramChatIds: vi.fn(() => ["11111"]),
+        getLastNotifiedVersion: vi.fn(() => null),
+        setLastNotifiedVersion: vi.fn(),
+      };
+    });
+
+    const sendMessage = vi.fn(async () => undefined);
+    const fakeBot = { api: { sendMessage } } as unknown as Parameters<
+      typeof import("../src/channels/telegram.js")["notifyUpdate"]
+    >[0];
+
+    const { notifyUpdate } = await import("../src/channels/telegram.js");
+    await notifyUpdate(fakeBot, dataDir, cyclingBinary);
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    const text = String(sendMessage.mock.calls[0][1]);
+    expect(text).toContain("redeploying the image");
+    expect(text).not.toContain("/update to install");
+
+    vi.unstubAllEnvs();
+  });
+
   it("does NOT broadcast in default-pairing mode (no allowed senders → empty filter)", async () => {
     seedSession("99999");
 

--- a/packages/core/tests/updater.test.ts
+++ b/packages/core/tests/updater.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { buildSelfUpdateCommand, checkForUpdate, isUpdateAvailable } from "../src/updater.js";
+import {
+  buildSelfUpdateCommand,
+  checkForUpdate,
+  isManagedDeploy,
+  isUpdateAvailable,
+} from "../src/updater.js";
 
 // Regression: the original `data.version !== current` returned true for ANY
 // inequality, including the case where the running bot is ahead of npm — a
@@ -93,5 +98,31 @@ describe("checkForUpdate", () => {
     } finally {
       vi.unstubAllEnvs();
     }
+  });
+});
+
+describe("isManagedDeploy", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('is true when CYCLING_COACH_MANAGED_DEPLOY="1"', () => {
+    vi.stubEnv("CYCLING_COACH_MANAGED_DEPLOY", "1");
+    expect(isManagedDeploy()).toBe(true);
+  });
+
+  it('is true when the flag is "true" (any case)', () => {
+    vi.stubEnv("CYCLING_COACH_MANAGED_DEPLOY", "TRUE");
+    expect(isManagedDeploy()).toBe(true);
+  });
+
+  it("is false when the flag is unset", () => {
+    vi.stubEnv("CYCLING_COACH_MANAGED_DEPLOY", "");
+    expect(isManagedDeploy()).toBe(false);
+  });
+
+  it('is false when the flag is "0"', () => {
+    vi.stubEnv("CYCLING_COACH_MANAGED_DEPLOY", "0");
+    expect(isManagedDeploy()).toBe(false);
   });
 });

--- a/packages/cycling-coach/Dockerfile
+++ b/packages/cycling-coach/Dockerfile
@@ -53,6 +53,10 @@ WORKDIR /app
 ENV NODE_ENV=production
 ENV CYCLING_COACH_HOME=/data
 
+# Image-baked deploys can't self-update via `npm install -g` (EACCES). This
+# flag makes /update tell the operator to redeploy instead of execing npm.
+ENV CYCLING_COACH_MANAGED_DEPLOY=1
+
 # su-exec drops root to `node` in the entrypoint after the mounted volume's
 # ownership is fixed (managed-platform volumes mount as root).
 RUN apk add --no-cache su-exec

--- a/packages/cycling-coach/LICENSE
+++ b/packages/cycling-coach/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Yerzhan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/cycling-coach/NOTICE.md
+++ b/packages/cycling-coach/NOTICE.md
@@ -1,0 +1,83 @@
+# Notices and Attributions
+
+This file lists upstream projects whose code or design Cycling Coach (and the
+broader `enduragent` workspace) carries, along with the licenses they were
+distributed under and the modifications introduced during the port.
+
+---
+
+## section-11
+
+Cycling Coach's **Reference** submodule (the data + sport-aware adapter
+substrate that grounds coaching in verified athlete numerics) is a port of
+[section-11](https://github.com/CrankAddict/section-11) by CrankAddict,
+specifically protocol v11.43, released under the MIT License.
+
+### Original license (verbatim)
+
+```
+MIT License
+
+Copyright (c) 2026 CrankAddict
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+### Modifications introduced in this port
+
+The Reference submodule (`packages/core/src/reference/`) is not a verbatim
+copy; the following modifications were applied during the port:
+
+- **Trademark substitution.** Section-11 was authored against TrainingPeaks
+  vocabulary. This codebase uses intervals.icu's plain-English alternatives
+  throughout — the substitution is enforced by `pnpm check:trademarks` and
+  documented in [`CONTRIBUTING.md`](./CONTRIBUTING.md#trademark-hygiene).
+- **Multi-sport adapter pattern.** Per ADR-0010, the Reference layer gains a
+  per-sport seam — sports plug in via an optional `referenceAdapters?()`
+  method on the `Sport` interface, returning an array of layer-owned adapters
+  with declarative metadata plus optional algorithm hooks (e.g.,
+  `computeDfa`, `computePowerCurve`). Section-11's single-sport design is
+  preserved as the cycling adapter; running and duathlon compose via the
+  same seam.
+- **Zod-strict schemas as drift gate.** Every cache file (`latest.json`,
+  `history.json`, `intervals.json`, `routes.json`, `ftp_history.json`,
+  `.scheduler.json`, `error_state.json`) is parsed through a `.strict()` Zod
+  schema. Forgotten-field drift fails loudly instead of silently dropping
+  data; a unit test enumerates every schema and asserts strictness.
+- **Mutex / cooldown discipline for sync.** A single mutex-protected
+  `runSync()` orchestrates scheduled, lazy-fallback, and `/sync`-triggered
+  refreshes with a 30 s acquire timeout, 2 min outer timeout, and 30 s
+  per-chat cooldown. The orchestrator lives at
+  `packages/core/src/reference/sync/run-sync.ts`; the underlying
+  primitives (`AsyncMutex`, `chainedSignal`, `Cooldown`) live in
+  `packages/core/src/concurrency/` and are reused unchanged by future
+  horizontal layers (Decision Layer, Heartbeat, Coaching Loop) per
+  ADR-0011.
+- **Three-layer validation.** Layer 1 sync gate (mechanical), Layer 2
+  Zod-validated LLM output with one retry on citation mismatch, Layer 3
+  prompt rules.
+- **Display-units conversion at prompt-injection time.** Canonical metric on
+  disk; `formatQuantity(quantity, athleteUnits)` renders to the athlete's
+  preferred system. Section-11's mixed-units assumptions are removed.
+
+### Canonical attribution surfaces
+
+This file (`NOTICE.md`) and the [`README.md` Credits section](./README.md#credits)
+are the canonical attribution surfaces. The full upstream repository is at
+https://github.com/CrankAddict/section-11.

--- a/packages/cycling-coach/README.md
+++ b/packages/cycling-coach/README.md
@@ -85,4 +85,11 @@ npx cycling-coach
 - Follow [@enduragent](https://x.com/enduragent) on X for updates, or drop a question/feedback anytime.
 - **Secrets backends** (1Password, macOS Keychain, Vault, AWS/GCP Secret Manager, age, env), **architecture diagram**, and **development setup** — see the [GitHub repo](https://github.com/yerzhansa/cycling-coach#readme).
 - **Issues**: <https://github.com/yerzhansa/cycling-coach/issues>
-- **License**: MIT
+
+## Credits
+
+Cycling Coach's data substrate (the "Reference" submodule that grounds coaching in verified athlete numerics) is a port of [section-11](https://github.com/CrankAddict/section-11) (CrankAddict, MIT-licensed). See the bundled `NOTICE.md` for the full attribution and the list of modifications introduced during the port.
+
+## License
+
+MIT

--- a/packages/cycling-coach/package.json
+++ b/packages/cycling-coach/package.json
@@ -8,7 +8,8 @@
     "cycling-coach": "dist/index.js"
   },
   "files": [
-    "dist"
+    "dist",
+    "NOTICE.md"
   ],
   "license": "MIT",
   "repository": {

--- a/packages/cycling-coach/railway.toml
+++ b/packages/cycling-coach/railway.toml
@@ -1,0 +1,12 @@
+# https://docs.railway.com/config-as-code/reference
+[build]
+builder = "DOCKERFILE"
+dockerfilePath = "packages/cycling-coach/Dockerfile"
+
+[deploy]
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 10
+# No healthcheckPath: this is a long-polling Telegram worker with no inbound
+# port, so a port-probe healthcheck would never pass and would kill the bot.
+# No startCommand: the Dockerfile ENTRYPOINT runs docker-entrypoint.sh, which
+# chowns the volume, drops to the node user, then runs `node dist/index.js`.

--- a/packages/cycling-coach/tests/dockerfile-pin-guard.test.ts
+++ b/packages/cycling-coach/tests/dockerfile-pin-guard.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parse } from "yaml";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+describe("Dockerfile base-image pin guard", () => {
+  it("every FROM pins an image digest", () => {
+    const dockerfile = readFileSync(resolve(HERE, "../Dockerfile"), "utf-8");
+    const fromLines = dockerfile.split("\n").filter((line) => /^FROM\s/i.test(line));
+    expect(fromLines.length).toBeGreaterThan(0);
+    for (const line of fromLines) {
+      expect(
+        /@sha256:[0-9a-f]{64}(?:\s|$)/i.test(line),
+        `Unpinned base image in Dockerfile:\n  ${line}\n` +
+          `Pin the image to a digest using the \`image:tag@sha256:...\` form so a ` +
+          `mutable tag can't silently change the build.`,
+      ).toBe(true);
+    }
+  });
+
+  it("dependabot tracks the Dockerfile directory", () => {
+    const yaml = readFileSync(resolve(HERE, "../../../.github/dependabot.yml"), "utf-8");
+    const config = parse(yaml) as {
+      updates?: Array<{ "package-ecosystem"?: string; directory?: string }>;
+    };
+    const tracked = (config.updates ?? []).some(
+      (entry) =>
+        entry["package-ecosystem"] === "docker" && entry.directory === "/packages/cycling-coach",
+    );
+    expect(
+      tracked,
+      `dependabot.yml has no \`docker\` update entry for directory ` +
+        `\`/packages/cycling-coach\`. Without it, the pinned base-image digest ` +
+        `won't receive automated security bumps.`,
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Why

We want a credit-card-free, one-click way for athletes to run their **own** single-tenant Cycling Coach — their bot, their keys, their data — without us ever hosting a multi-tenant service. Railway's deploy templates fit that exactly: it builds the in-repo Dockerfile from a pinned commit, attaches a volume, and runs a env-var wizard. This PR makes the repo deployable as that template and clears the prerequisites that would otherwise break a managed deploy.

## What changed

- **Self-update gating** — in an image-baked container, `npm install -g` is guaranteed to fail with EACCES, but `/update` still offered it and the startup broadcast still said "/update to install", so a managed deploy told users to run a command that stops the bot (the supervisor then silently restarts the old image). A `CYCLING_COACH_MANAGED_DEPLOY` flag, baked into the runtime image, now makes `/update` and the broadcast give redeploy guidance and never exec npm.
- **`railway.toml`** — Dockerfile builder (build context stays at the repo root so the workspace COPY paths resolve), on-failure restart policy, no healthcheck (long-polling worker, no inbound port). Plus a Deploy button + single-tenant/BYOK framing in the README.
- **License in the shipped artifacts** — the published tarball and the runtime image carried the Reference layer code with no license text, breaking the MIT notice condition. `LICENSE` + `NOTICE.md` now ride into both, and the shipped README has a Credits section.
- **Docker pin guard** — a test asserts every `FROM` keeps an `@sha256` digest and that dependabot tracks the Dockerfile, so a bare-tag bump fails CI.

## Verification

`pnpm -r build`, `pnpm -r check` (typecheck, 7 packages), `oxlint`, and the full `pnpm test` (2305 passing) are green. `npm pack --dry-run` lists `LICENSE` + `NOTICE.md`.

## Not in this PR (operator steps / follow-ups)

Publishing the template (deploy once → Generate Template → enroll the kickback) and replacing the `TEMPLATE_ID` placeholder in the README are manual operator steps. PikaPods is deferred (architecturally blocked: no inbound port, curated catalog with no self-serve images) and the GHCR multi-arch image-publish job is optional/later — both will be filed as tracked tickets.
