### PR TITLE
feat(running): auto-resolve the critical-speed anchor from synced data

### DIFF
--- a/.changeset/running-cs-autofeed.md
+++ b/.changeset/running-cs-autofeed.md
@@ -1,0 +1,9 @@
+---
+"@enduragent/core": minor
+"@enduragent/sport-running": minor
+"running-coach": patch
+---
+
+Auto-resolve the running critical-speed anchor from synced intervals.icu data so `calculate_zones` no longer depends on the LLM supplying it.
+
+Core gains `resolveRunningCs(latest)` (sharing one row-walk with the step-5 CS-source gate so the two cannot drift) and a per-turn `CoreDeps.resolvedCs` getter; the Telegram channel resolves the anchor from the latest synced profile each turn and passes it into `chat()`. The running `calculate_zones` tool makes `criticalSpeedMps` optional — it falls back to the synced anchor (manual `critical_speed` outranking platform `threshold_pace`), reports real provenance (`csSource` / `anchorOrigin` / `platformConfidence`), and returns a `no_cs_anchor` error rather than guessing when neither is present. The per-turn value is read lazily through a closure, so the prompt-template hash and cache prefix stay stable; non-running sports and the CLI path are unaffected.

--- a/packages/core/src/agent/coach-agent.ts
+++ b/packages/core/src/agent/coach-agent.ts
@@ -3,6 +3,7 @@ import type { ModelMessage, ToolSet } from "ai";
 import { makeChatClient } from "../reference/sync/intervals-client-factory.js";
 import { getEffectiveSections } from "../memory/effective-sections.js";
 import type { CoreDeps, Sport } from "../sport.js";
+import type { ResolvedCs } from "../reference/cs-resolution.js";
 import type { SecretsResolver } from "../secrets/types.js";
 import type { Config } from "../config.js";
 import { resolveSecretRef } from "../secrets/resolve.js";
@@ -68,6 +69,11 @@ export class CoachAgent {
   private tz: string;
   private archiveDeferred = new Set<string>();
   private lastFlushMessageCount = new Map<string, number>();
+  // Resolved primary anchor (running CS) for the in-flight turn. Set at the top
+  // of chat() from the channel's per-turn value and read lazily by sport tools
+  // via the `coreDeps.resolvedCs` getter, so the tool set (and the cached
+  // template hash) never has to be rebuilt per turn.
+  private currentResolvedCs: ResolvedCs | null = null;
   // The prompt-template hash is derived from constructor-stable inputs (soul,
   // skills, tool schemas, model, and the compile-time rule-block set), so it is
   // computed once on first use and reused for every turn of the process.
@@ -100,6 +106,7 @@ export class CoachAgent {
       memory: this.memory,
       secrets,
       tz: this.tz,
+      resolvedCs: () => this.currentResolvedCs,
     };
     const registrations = sport.tools(coreDeps);
     this.tools = Object.fromEntries(registrations.map((r) => [r.name, r.tool])) as ToolSet;
@@ -147,7 +154,14 @@ export class CoachAgent {
     };
   }
 
-  async chat(chatId: string, userMessage: string): Promise<string> {
+  async chat(
+    chatId: string,
+    userMessage: string,
+    turn?: { resolvedCs?: ResolvedCs | null },
+  ): Promise<string> {
+    // Per-turn anchor, read lazily by sport tools through the coreDeps getter.
+    // Cleared to null when the channel supplies nothing (CLI path, no sync data).
+    this.currentResolvedCs = turn?.resolvedCs ?? null;
     return withSessionLock(chatId, async () => {
       const turnStart = Date.now();
       // One flush per turn: the latch flips on entry (before the await

--- a/packages/core/src/channels/telegram.ts
+++ b/packages/core/src/channels/telegram.ts
@@ -15,6 +15,7 @@ import { createAuthMiddleware } from "./telegram-access.js";
 import { loadAllowedSenders, loadAllowedSendersWithSource } from "./allowed-senders.js";
 import { escapeHtmlText } from "./html-escape.js";
 import type { ReferenceServices } from "../reference/services.js";
+import { resolveRunningCs, type ResolvedCs } from "../reference/cs-resolution.js";
 import { formatSyncReply } from "../reference/sync/format-sync-reply.js";
 import { formatSnapshotRaw } from "../reference/sync/snapshot-debug.js";
 import { sendSnapshotOutput } from "../reference/sync/send-snapshot.js";
@@ -113,6 +114,14 @@ export function createTelegramBot(
   const bot = createSecuredBot({ token, binary, dataDir });
   const greeted = new Set<number>();
 
+  // Resolve the running CS anchor once per turn from the latest synced profile so
+  // calculate_zones reads the athlete's real critical speed instead of an LLM
+  // guess. Returns undefined — leaving the tool on its LLM-supplied param — when no
+  // reference sync is wired; resolveRunningCs itself returns null for cycling,
+  // pre-sync, or a profile with no run-family row.
+  const turnDeps = (): { resolvedCs: ResolvedCs | null } | undefined =>
+    reference !== undefined ? { resolvedCs: resolveRunningCs(reference.loadLatest()) } : undefined;
+
   // ── Commands ────────────────────────────────────────────────────────────
 
   bot.command("start", async (ctx) => {
@@ -136,7 +145,7 @@ export function createTelegramBot(
     await ctx.reply("Analyzing your data and building a plan...");
     const chatId = `telegram:${ctx.chat.id}`;
     try {
-      const response = await agent.chat(chatId, "/plan");
+      const response = await agent.chat(chatId, "/plan", turnDeps());
       await sendLongMessage(ctx, response);
     } catch (err) {
       console.error("Error in /plan:", err);
@@ -152,7 +161,7 @@ export function createTelegramBot(
     await ctx.reply("Checking your form and plan...");
     const chatId = `telegram:${ctx.chat.id}`;
     try {
-      const response = await agent.chat(chatId, "/workout");
+      const response = await agent.chat(chatId, "/workout", turnDeps());
       await sendLongMessage(ctx, response);
     } catch (err) {
       console.error("Error in /workout:", err);
@@ -168,7 +177,7 @@ export function createTelegramBot(
     await ctx.reply("Fetching your fitness data...");
     const chatId = `telegram:${ctx.chat.id}`;
     try {
-      const response = await agent.chat(chatId, "/status");
+      const response = await agent.chat(chatId, "/status", turnDeps());
       await sendLongMessage(ctx, response);
     } catch (err) {
       console.error("Error in /status:", err);
@@ -232,7 +241,7 @@ export function createTelegramBot(
     const chatId = `telegram:${ctx.chat.id}`;
     try {
       const message = args ? `/review ${args}` : "/review";
-      const response = await agent.chat(chatId, message);
+      const response = await agent.chat(chatId, message, turnDeps());
       await sendLongMessage(ctx, response);
     } catch (err) {
       console.error("Error in /review:", err);
@@ -306,7 +315,7 @@ export function createTelegramBot(
     }
 
     try {
-      const response = await agent.chat(chatId, ctx.message.text);
+      const response = await agent.chat(chatId, ctx.message.text, turnDeps());
       await sendLongMessage(ctx, response);
     } catch (err) {
       console.error("Error in chat:", err);

--- a/packages/core/src/reference/cs-resolution.ts
+++ b/packages/core/src/reference/cs-resolution.ts
@@ -1,0 +1,112 @@
+/**
+ * Resolve the running critical-speed (CS) anchor from synced reference data so
+ * the `calculate_zones` tool no longer depends on the LLM supplying it. The
+ * resolver and the step-5 CS-source sync gate share ONE row-walk
+ * (`collectRunCsRows`) so what gets validated at sync and what gets read back at
+ * a turn cannot drift. Manual `critical_speed` outranks platform `threshold_pace`;
+ * both are SI metres-per-second. Compute-our-own (best-efforts CS fit) is
+ * deferred — this reads only the two locked sources off the raw `sportSettings`.
+ */
+import type { LatestJson } from "./schemas/latest.js";
+
+// intervals.icu running-family activity types. Kept to the set the running sport
+// declares (Run, TrailRun); VirtualRun is intentionally excluded — not in core's
+// IntervalsActivityType union this wave. Shared by the resolver and the step-5
+// gate (validation/checks/step5-cs-source.ts) so the two cannot diverge.
+export const RUN_FAMILY_TYPES = new Set<string>(["Run", "TrailRun"]);
+
+// Hard-refusal CS band in m/s: a value outside is unit-confused or corrupt, not a
+// real CS. Typical recreational-to-trained range (~2.5–6.0 m/s, ≈6:40–2:47/km)
+// sits inside; [2.0, 6.5] adds headroom before refusing. Kept in sync with the
+// sport-running CS_SANITY_MPS constant.
+export const CS_MIN_MPS = 2.0;
+export const CS_MAX_MPS = 6.5;
+
+export type CsConfidence = "high" | "medium" | "low";
+
+/** One run-family `sportSettings` row's CS-relevant fields. */
+export interface RunCsRow {
+  /** Manual override (`critical_speed`), m/s. Outranks `thresholdPace`. */
+  criticalSpeed: number | null;
+  /** Platform-supplied anchor (`threshold_pace`), m/s. */
+  thresholdPace: number | null;
+  /** Platform reliability label (`cs_confidence`); disclosure-only. */
+  confidence: CsConfidence | null;
+}
+
+/** The resolved primary anchor handed to the running zone tool per turn. */
+export interface ResolvedCs {
+  criticalSpeedMps: number;
+  source: "platform" | "athlete_manual";
+  confidence: CsConfidence | null;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function asConfidence(value: unknown): CsConfidence | null {
+  return value === "high" || value === "medium" || value === "low" ? value : null;
+}
+
+/**
+ * Walk an athlete profile's `sportSettings` for run-family rows and return their
+ * CS-relevant fields. Operates on the raw profile object (`athlete_profile` is
+ * `unknown` on `LatestJson`, and `FetchedReference.latest.athlete_profile` is the
+ * same shape), narrowing defensively. Returns `[]` when no profile / no run row
+ * is present (RESOLVE-OR-SKIP — a cyclist with no Run activity is not an error).
+ */
+export function collectRunCsRows(athleteProfile: unknown): RunCsRow[] {
+  const profile = asRecord(athleteProfile);
+  if (profile === null) return [];
+
+  const sportSettings = profile.sportSettings;
+  if (!Array.isArray(sportSettings)) return [];
+
+  return sportSettings.flatMap((row) => {
+    const r = asRecord(row);
+    if (r === null) return [];
+    const types = r.types;
+    if (!Array.isArray(types)) return [];
+    const isRun = types.some((t) => typeof t === "string" && RUN_FAMILY_TYPES.has(t));
+    if (!isRun) return [];
+    return [
+      {
+        criticalSpeed: typeof r.critical_speed === "number" ? r.critical_speed : null,
+        thresholdPace: typeof r.threshold_pace === "number" ? r.threshold_pace : null,
+        confidence: asConfidence(r.cs_confidence),
+      },
+    ];
+  });
+}
+
+function inBand(value: number): boolean {
+  return Number.isFinite(value) && value >= CS_MIN_MPS && value <= CS_MAX_MPS;
+}
+
+/**
+ * Resolve the running CS anchor from `latest.json`. Manual `critical_speed`
+ * outranks platform `threshold_pace` (mirrors the step-5 gate's precedence). Each
+ * value is band-checked defensively (the gate refuses out-of-band CS at sync, but
+ * a manual override could in principle reach `latest.json` un-gated) — an
+ * out-of-band value is skipped, never returned. Returns `null` when no in-band
+ * anchor is present, so a pre-sync or non-running athlete falls back to the tool's
+ * LLM-supplied param rather than minting a corrupt zone table.
+ */
+export function resolveRunningCs(latest: LatestJson | null): ResolvedCs | null {
+  const rows = collectRunCsRows(latest?.athlete_profile);
+
+  for (const row of rows) {
+    if (row.criticalSpeed !== null && inBand(row.criticalSpeed)) {
+      return { criticalSpeedMps: row.criticalSpeed, source: "athlete_manual", confidence: row.confidence };
+    }
+  }
+  for (const row of rows) {
+    if (row.thresholdPace !== null && inBand(row.thresholdPace)) {
+      return { criticalSpeedMps: row.thresholdPace, source: "platform", confidence: row.confidence };
+    }
+  }
+  return null;
+}

--- a/packages/core/src/reference/index.ts
+++ b/packages/core/src/reference/index.ts
@@ -20,6 +20,12 @@ export { ReferenceConfigError } from "./errors.js";
 // ─── Service-aggregate type for downstream channels ───────────────────
 export type { ReferenceServices } from "./services.js";
 
+// ─── Running CS-anchor resolution (Tier 2) ────────────────────────────
+// `resolveRunningCs` reads the latest synced profile; channels call it per turn.
+// `ResolvedCs` is the anchor shape sport tools receive via `CoreDeps.resolvedCs`.
+export { resolveRunningCs, collectRunCsRows } from "./cs-resolution.js";
+export type { ResolvedCs, RunCsRow, CsConfidence } from "./cs-resolution.js";
+
 // ─── Constants ────────────────────────────────────────────────────────
 export {
   FRESH_MS,

--- a/packages/core/src/reference/validation/checks/step5-cs-source.ts
+++ b/packages/core/src/reference/validation/checks/step5-cs-source.ts
@@ -7,59 +7,24 @@
  */
 import type { FetchedReference } from "../../sync/run-sync.js";
 import type { CheckResult, GateFailure } from "../sync-gate.js";
-
-// intervals.icu running-family activity types. Kept to the set the running sport
-// actually declares (Run, TrailRun); VirtualRun is intentionally excluded — it is
-// not in core's IntervalsActivityType union this wave, so admitting it would
-// validate rows the sport never claims to handle. Inlined (not imported from the
-// metrics layer's module-private SPORT_FAMILIES) so the gate stays self-contained,
-// mirroring how collectFtpValues walks rows directly.
-const RUN_FAMILY_TYPES = new Set(["Run", "TrailRun"]);
-
-// Hard-refusal CS band in m/s: a value outside is unit-confused or corrupt, not a
-// real CS. The typical recreational-to-trained range (~2.5–6.0 m/s, ≈6:40–2:47/km)
-// sits inside; the [2.0, 6.5] edges add headroom before refusing. Kept in sync
-// with the sport-running CS_SANITY_MPS constant.
-const CS_MIN_MPS = 2.0;
-const CS_MAX_MPS = 6.5;
-
-function asRecord(value: unknown): Record<string, unknown> | null {
-  return typeof value === "object" && value !== null
-    ? (value as Record<string, unknown>)
-    : null;
-}
+import { collectRunCsRows, CS_MIN_MPS, CS_MAX_MPS } from "../../cs-resolution.js";
 
 /**
  * Collect the running CS anchors the athlete profile exposes, split by source:
- * `manual` from `sportSettings[*].critical_speed`, `platform` from
- * `.threshold_pace`, for rows whose `types` intersect the running family.
- * Returns empty lists when no running row (or no CS field) is present
- * (RESOLVE-OR-SKIP: a cyclist with no Run activity must not hard-fail).
+ * `manual` from `sportSettings[*].critical_speed`, `platform` from `.threshold_pace`,
+ * for rows whose `types` intersect the running family. Reuses the shared row-walk
+ * (`collectRunCsRows`) so this gate validates exactly the fields the runtime
+ * resolver (`resolveRunningCs`) reads back — the two cannot drift. Returns empty
+ * lists when no running row (or no CS field) is present (RESOLVE-OR-SKIP: a
+ * cyclist with no Run activity must not hard-fail).
  */
 export function collectCsValues(fetched: FetchedReference): {
   manual: number[];
   platform: number[];
 } {
-  const manual: number[] = [];
-  const platform: number[] = [];
-
-  const profile = asRecord(fetched?.latest?.athlete_profile);
-  if (profile === null) return { manual, platform };
-
-  const sportSettings = profile.sportSettings;
-  if (Array.isArray(sportSettings)) {
-    for (const row of sportSettings) {
-      const r = asRecord(row);
-      if (r === null) continue;
-      const types = r.types;
-      if (!Array.isArray(types)) continue;
-      const isRun = types.some((t) => typeof t === "string" && RUN_FAMILY_TYPES.has(t));
-      if (!isRun) continue;
-      if (typeof r.critical_speed === "number") manual.push(r.critical_speed);
-      if (typeof r.threshold_pace === "number") platform.push(r.threshold_pace);
-    }
-  }
-
+  const rows = collectRunCsRows(fetched?.latest?.athlete_profile);
+  const manual = rows.map((r) => r.criticalSpeed).filter((v): v is number => v !== null);
+  const platform = rows.map((r) => r.thresholdPace).filter((v): v is number => v !== null);
   return { manual, platform };
 }
 

--- a/packages/core/src/sport.ts
+++ b/packages/core/src/sport.ts
@@ -3,6 +3,7 @@ import type { z } from "zod";
 import type { IntervalsClient } from "./intervals.js";
 import type { LLM } from "./llm.js";
 import type { MemorySnapshot, MemoryStore } from "./memory.js";
+import type { ResolvedCs } from "./reference/cs-resolution.js";
 import type { ReferenceSportAdapter } from "./reference/sport-adapter.js";
 import type { SecretsResolver } from "./secrets/types.js";
 
@@ -62,6 +63,22 @@ export interface CoreDeps {
   /** Athlete IANA timezone, resolved by Core. Used so tools see the same
    * "today" the system prompt references. */
   tz: string;
+  /**
+   * Per-turn getter for the resolved primary anchor (running critical speed),
+   * sourced from the latest synced reference data just before the turn. A getter
+   * (not a value) because tools are built once at construction while the anchor
+   * changes per turn — reading it lazily keeps the tool SCHEMA, and thus the
+   * prompt-template hash, stable. Returns `null` when no sync data / no run-family
+   * row / a non-running sport / the CLI path; sports that don't anchor on CS
+   * ignore it.
+   *
+   * Why this rides `CoreDeps` rather than the ADR-0010 Reference adapter: the
+   * adapter is built once at boot (declarative metadata + pure compute hooks),
+   * whereas this is a runtime value re-resolved every turn — the adapter seam
+   * can't carry it. Running-specific for now; generalize to a discriminated
+   * anchor (e.g. swim CSS, cycling auto-FTP) under the rule of three.
+   */
+  resolvedCs?: () => ResolvedCs | null;
 }
 
 // ─── Sport: the plug-point ─────────────────────────────────────────────

--- a/packages/core/tests/cs-resolution.test.ts
+++ b/packages/core/tests/cs-resolution.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import type { LatestJson } from "../src/reference/schemas/latest.js";
+import { resolveRunningCs, collectRunCsRows } from "../src/reference/cs-resolution.js";
+
+// Same sportSettings row shape the step-5 CS-source gate validates — both read it
+// through the shared collectRunCsRows walk, so a schema change breaks both.
+function latestWith(sportSettings: unknown): LatestJson {
+  return { athlete_profile: { sportSettings } } as unknown as LatestJson;
+}
+
+describe("resolveRunningCs", () => {
+  it("resolves a platform threshold_pace for a Run row", () => {
+    const r = resolveRunningCs(latestWith([{ types: ["Run"], threshold_pace: 4.0 }]));
+    expect(r).toEqual({ criticalSpeedMps: 4.0, source: "platform", confidence: null });
+  });
+
+  it("matches TrailRun rows too", () => {
+    const r = resolveRunningCs(latestWith([{ types: ["TrailRun"], threshold_pace: 3.5 }]));
+    expect(r?.criticalSpeedMps).toBe(3.5);
+  });
+
+  it("manual critical_speed outranks platform threshold_pace (the locked precedence)", () => {
+    const r = resolveRunningCs(latestWith([{ types: ["Run"], critical_speed: 3.8, threshold_pace: 4.0 }]));
+    expect(r).toEqual({ criticalSpeedMps: 3.8, source: "athlete_manual", confidence: null });
+  });
+
+  it("threads cs_confidence through as disclosure-only", () => {
+    const r = resolveRunningCs(latestWith([{ types: ["Run"], threshold_pace: 4.0, cs_confidence: "high" }]));
+    expect(r?.confidence).toBe("high");
+  });
+
+  it("returns null for a non-running profile (resolve-or-skip)", () => {
+    expect(resolveRunningCs(latestWith([{ types: ["Ride"], ftp: 247 }]))).toBeNull();
+  });
+
+  it("skips an out-of-band value rather than emitting a corrupt anchor", () => {
+    expect(resolveRunningCs(latestWith([{ types: ["Run"], threshold_pace: 7.5 }]))).toBeNull();
+    expect(resolveRunningCs(latestWith([{ types: ["Run"], critical_speed: -1 }]))).toBeNull();
+  });
+
+  it("falls back to a valid platform value when a manual override is out of band", () => {
+    const r = resolveRunningCs(latestWith([{ types: ["Run"], critical_speed: 9.9, threshold_pace: 4.0 }]));
+    expect(r).toEqual({ criticalSpeedMps: 4.0, source: "platform", confidence: null });
+  });
+
+  it("returns null on null / empty / malformed input", () => {
+    expect(resolveRunningCs(null)).toBeNull();
+    expect(resolveRunningCs(latestWith([]))).toBeNull();
+    expect(resolveRunningCs({} as unknown as LatestJson)).toBeNull();
+  });
+});
+
+describe("collectRunCsRows (shared with the step-5 gate)", () => {
+  it("yields only run-family rows' CS fields", () => {
+    const rows = collectRunCsRows({
+      sportSettings: [
+        { types: ["Run"], critical_speed: 3.8, threshold_pace: 4.0, cs_confidence: "medium" },
+        { types: ["Ride"], ftp: 247 },
+      ],
+    });
+    expect(rows).toEqual([{ criticalSpeed: 3.8, thresholdPace: 4.0, confidence: "medium" }]);
+  });
+
+  it("returns [] for a malformed profile", () => {
+    expect(collectRunCsRows(null)).toEqual([]);
+    expect(collectRunCsRows({ sportSettings: "nope" })).toEqual([]);
+    expect(collectRunCsRows(42)).toEqual([]);
+  });
+});

--- a/packages/core/tests/telegram-dispatch.test.ts
+++ b/packages/core/tests/telegram-dispatch.test.ts
@@ -184,7 +184,8 @@ describe("agent-backed commands", () => {
       agent.chat.mockResolvedValue("ok");
       const ctx = makeCtx();
       await getCommand(bot, name)(ctx);
-      expect(agent.chat).toHaveBeenCalledWith("telegram:777", messageFor[name]);
+      // No reference wired in this buildBot() → no per-turn anchor passed.
+      expect(agent.chat).toHaveBeenCalledWith("telegram:777", messageFor[name], undefined);
       const htmlReply = ctx.reply.mock.calls.find(
         (c: unknown[]) =>
           String(c[0]).includes("ok") &&
@@ -222,8 +223,26 @@ describe("agent-backed commands", () => {
     agent.chat.mockResolvedValue("ok");
     const ctx = makeCtx({ match: "2026-05-01" });
     await getCommand(bot, "review")(ctx);
-    expect(agent.chat).toHaveBeenCalledWith("telegram:777", "/review 2026-05-01");
+    expect(agent.chat).toHaveBeenCalledWith("telegram:777", "/review 2026-05-01", undefined);
     expect(someReply(ctx, "Reviewing your last session (2026-05-01)...")).toBe(true);
+  });
+
+  it("resolves the running CS anchor from a synced profile and passes it into chat", async () => {
+    const reference: StubReference = {
+      runSync: vi.fn(),
+      loadLatest: vi.fn(() => ({
+        athlete_profile: {
+          sportSettings: [{ types: ["Run"], threshold_pace: 4.0, cs_confidence: "high" }],
+        },
+      })),
+    };
+    const { bot, agent } = await buildBot({ reference });
+    agent.chat.mockResolvedValue("ok");
+    const ctx = makeCtx();
+    await getCommand(bot, "plan")(ctx);
+    expect(agent.chat).toHaveBeenCalledWith("telegram:777", "/plan", {
+      resolvedCs: { criticalSpeedMps: 4.0, source: "platform", confidence: "high" },
+    });
   });
 });
 

--- a/packages/sport-running/src/sport.ts
+++ b/packages/sport-running/src/sport.ts
@@ -79,7 +79,7 @@ export const runningSport: Sport = {
       ...createMemoryTools(deps.memory, sections),
       ...createPureCoreIntervalsTools(deps.intervals, deps.tz),
       ...createCoreToolsWithSportConfig(deps.intervals, runningSport.intervalsActivityTypes),
-      ...createRunningTools(deps.memory, deps.intervals, deps.tz),
+      ...createRunningTools(deps.memory, deps.intervals, deps.tz, deps.resolvedCs),
     };
     return Object.entries(toolset).map(([name, t]) => ({
       name,

--- a/packages/sport-running/src/tools.ts
+++ b/packages/sport-running/src/tools.ts
@@ -1,6 +1,6 @@
 import { tool, zodSchema } from "ai";
 import { z } from "zod";
-import type { MemoryStore } from "@enduragent/core";
+import type { MemoryStore, ResolvedCs } from "@enduragent/core";
 import type { IntervalsClient } from "intervals-icu-api";
 import {
   calculateRunningZones,
@@ -15,6 +15,10 @@ import {
  * `calculate_zones` tool only; the intervals.icu workout creator is deferred
  * until a running workout serializer exists (Pure-Core + Core-with-sport-config
  * intervals tools still compose in via `runningSport.tools`).
+ *
+ * The athlete's critical speed is resolved automatically from synced
+ * intervals.icu data when available (`resolvedCs` getter, fed per turn by Core);
+ * the LLM-supplied `criticalSpeedMps` is now an override, not a requirement.
  */
 
 const RPE_FRAMING =
@@ -32,24 +36,32 @@ export function createRunningTools(
   _memory: MemoryStore,
   _intervals: IntervalsClient | null,
   _tz: string = "UTC",
+  resolvedCs?: () => ResolvedCs | null,
 ) {
   return {
     calculate_zones: tool({
       description:
-        "Calculate 6 critical-speed-anchored running pace zones. Pass the athlete's " +
-        "critical speed in m/s (intervals.icu stores threshold_pace in SI m/s, e.g. " +
-        "4.0 m/s ≈ 4:10/km). The manual override outranks the platform value; an " +
-        "out-of-range lower-boundary override is clamped and the clamp is disclosed. " +
-        "Returns zones plus a real confidence/source field — surface the RPE-checked " +
-        "estimate framing to the athlete; never present these as lab-measured thresholds.",
+        "Calculate 6 critical-speed-anchored running pace zones. When the athlete's " +
+        "critical speed is synced from intervals.icu, OMIT criticalSpeedMps — the tool " +
+        "uses the synced anchor automatically and reports its provenance. Pass " +
+        "criticalSpeedMps (in m/s; intervals.icu stores threshold_pace in SI m/s, e.g. " +
+        "4.0 m/s ≈ 4:10/km) only to override the synced value — a coach-entered number " +
+        "or a hypothetical. An explicit value outranks the synced anchor; a manual " +
+        "lower-boundary override is clamped and the clamp is disclosed. Returns zones " +
+        "plus real source/confidence fields — surface the RPE-checked estimate framing " +
+        "to the athlete; never present these as lab-measured thresholds. If no critical " +
+        "speed is synced or supplied, the tool returns a no_cs_anchor error — ask the " +
+        "athlete for a recent CS / threshold test rather than guessing.",
       inputSchema: zodSchema(
         z.object({
           criticalSpeedMps: z
             .number()
             .min(CS_SANITY_MPS.min)
             .max(CS_SANITY_MPS.max)
+            .optional()
             .describe(
-              "Critical speed in m/s (intervals.icu threshold_pace is already m/s). " +
+              "Override critical speed in m/s (intervals.icu threshold_pace is already m/s). " +
+                "Omit to use the synced anchor when one exists. " +
                 `Sane band [${CS_SANITY_MPS.min}, ${CS_SANITY_MPS.max}].`,
             ),
           paceUnits: z
@@ -67,16 +79,34 @@ export function createRunningTools(
           csSource: z
             .enum(["platform", "athlete_manual"])
             .default("platform")
-            .describe("Where the CS value came from; 'athlete_manual' = coach/athlete-entered."),
+            .describe(
+              "Provenance of an EXPLICIT criticalSpeedMps; ignored when the synced " +
+                "anchor is used (its provenance is reported instead). 'athlete_manual' = " +
+                "coach/athlete-entered.",
+            ),
         }),
       ),
       execute: async (input: {
-        criticalSpeedMps: number;
+        criticalSpeedMps?: number;
         paceUnits?: "MINS_KM" | "MINS_MILE" | null;
         lowerFractionOverride?: number;
         csSource?: "platform" | "athlete_manual";
       }) => {
-        const csSource = input.csSource ?? "platform";
+        const resolved = resolvedCs?.() ?? null;
+        // Explicit value (already band-checked by the input schema) outranks the
+        // synced anchor (band-checked by resolveRunningCs); whichever we use is
+        // therefore guaranteed in [CS_SANITY_MPS.min, max].
+        const autoResolved = input.criticalSpeedMps === undefined && resolved !== null;
+        const cs = input.criticalSpeedMps ?? resolved?.criticalSpeedMps;
+        if (cs === undefined) {
+          return {
+            error: "no_cs_anchor",
+            details:
+              "No critical speed is synced from intervals.icu or supplied. Ask the athlete " +
+              "for a recent critical-speed / threshold-pace test (or have them set threshold " +
+              "pace in intervals.icu), then retry — do not invent a value.",
+          };
+        }
 
         let lowerFraction: number | undefined;
         let clampApplied: { requested: number; clamped: number } | undefined;
@@ -87,17 +117,22 @@ export function createRunningTools(
         }
 
         const zones: RunningZoneDisplay[] = calculateRunningZones(
-          input.criticalSpeedMps,
+          cs,
           input.paceUnits ?? null,
           lowerFraction,
         );
 
+        const csSource = autoResolved ? resolved.source : input.csSource ?? "platform";
+
         return {
           zones,
+          criticalSpeedMps: cs,
           thresholdDefinition: THRESHOLD_DEFINITION,
           framing: RPE_FRAMING,
           csSource,
+          anchorOrigin: autoResolved ? "auto-resolved" : "supplied",
           confidence: csSource === "athlete_manual" ? "coach-entered" : "platform-reported",
+          ...(autoResolved && resolved.confidence ? { platformConfidence: resolved.confidence } : {}),
           ...(clampApplied ? { clampApplied } : {}),
         };
       },

--- a/packages/sport-running/tests/tools.test.ts
+++ b/packages/sport-running/tests/tools.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import type { MemoryStore } from "@enduragent/core";
+import type { MemoryStore, ResolvedCs } from "@enduragent/core";
 import { createRunningTools } from "../src/tools.js";
 
 // The Vercel AI SDK wraps execute; call it directly with a stub options arg
@@ -48,5 +48,70 @@ describe("calculate_zones tool", () => {
   it("does NOT disclose a clamp for an in-range override", async () => {
     const out = await execZones({ criticalSpeedMps: 4.0, lowerFractionOverride: 0.85 });
     expect(out.clampApplied).toBeUndefined();
+  });
+});
+
+// Auto-resolution path: CS comes from the synced anchor (the resolvedCs getter Core
+// feeds per turn) when the LLM omits criticalSpeedMps.
+function execZonesResolved(
+  input: Record<string, unknown>,
+  resolved: ResolvedCs | null,
+): Promise<{
+  zones?: unknown[];
+  criticalSpeedMps?: number;
+  csSource?: string;
+  confidence?: string;
+  anchorOrigin?: string;
+  platformConfidence?: string;
+  error?: string;
+}> {
+  const tools = createRunningTools({} as MemoryStore, null, "UTC", () => resolved);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (tools.calculate_zones as any).execute(input, {});
+}
+
+describe("calculate_zones CS auto-resolution", () => {
+  it("uses the synced platform anchor when criticalSpeedMps is omitted", async () => {
+    const out = await execZonesResolved(
+      { paceUnits: "MINS_KM" },
+      { criticalSpeedMps: 4.2, source: "platform", confidence: "high" },
+    );
+    expect(out.zones).toHaveLength(6);
+    expect(out.criticalSpeedMps).toBe(4.2);
+    expect(out.anchorOrigin).toBe("auto-resolved");
+    expect(out.csSource).toBe("platform");
+    expect(out.confidence).toBe("platform-reported");
+    expect(out.platformConfidence).toBe("high");
+  });
+
+  it("reports manual provenance when the synced anchor is a manual override", async () => {
+    const out = await execZonesResolved({}, { criticalSpeedMps: 3.8, source: "athlete_manual", confidence: null });
+    expect(out.anchorOrigin).toBe("auto-resolved");
+    expect(out.csSource).toBe("athlete_manual");
+    expect(out.confidence).toBe("coach-entered");
+    expect(out.platformConfidence).toBeUndefined();
+  });
+
+  it("lets an explicit criticalSpeedMps override the synced anchor", async () => {
+    const out = await execZonesResolved(
+      { criticalSpeedMps: 5.0, csSource: "athlete_manual" },
+      { criticalSpeedMps: 4.0, source: "platform", confidence: "high" },
+    );
+    expect(out.criticalSpeedMps).toBe(5.0);
+    expect(out.anchorOrigin).toBe("supplied");
+    expect(out.csSource).toBe("athlete_manual");
+  });
+
+  it("returns a no_cs_anchor error when neither synced nor supplied", async () => {
+    const out = await execZonesResolved({}, null);
+    expect(out.error).toBe("no_cs_anchor");
+    expect(out.zones).toBeUndefined();
+  });
+
+  it("returns no_cs_anchor when no resolver is wired and no value supplied", async () => {
+    const tools = createRunningTools({} as MemoryStore, null, "UTC");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const out = await (tools.calculate_zones as any).execute({}, {});
+    expect(out.error).toBe("no_cs_anchor");
   });
 });


### PR DESCRIPTION
> Stacked on #225 (Tier 1). Base is `feature/running-pace-zones`; review/merge that first, then this retargets to `main`.

## Why

Tier 1 landed the running pace zones, but `calculate_zones` still relied on the LLM passing the athlete's critical speed (CS) by hand — the coach could guess the anchor every zone table is built from. This makes the anchor real: it's resolved automatically from the athlete's synced intervals.icu data.

## What changed

- **`resolveRunningCs(latest)`** (new, Core) reads the run-family `threshold_pace` / `critical_speed` off the latest synced profile, manual outranking platform, band-checked. It shares one row-walk (`collectRunCsRows`) with the step-5 CS-source sync gate, so what's validated at sync and what's read back at a turn can't drift.
- **Per-turn injection**: the Telegram channel resolves the anchor from `loadLatest()` each turn and passes it into `chat()`; Core exposes it to tools via a `CoreDeps.resolvedCs` getter read lazily inside the tool's `execute`. Because the value never enters the tool schema, the cached prompt-template hash and cache prefix stay stable (verified by the architect review).
- **`calculate_zones`**: `criticalSpeedMps` is now optional — it falls back to the synced anchor, reports real provenance (`csSource` / `anchorOrigin` / `platformConfidence`), and returns a `no_cs_anchor` error (ask the athlete, don't guess) when neither a synced nor supplied value exists.
- Non-running sports and the CLI path are inert (resolver returns `null`).

## Review

Architect (structural) + endurance-expert (disclosure) both returned **approve-with-notes**, no blocking findings; the prompt-hash stability was the architect's focus and it holds. Non-blocking notes (seam-recording, anchor-staleness disclosure, constant unification) are tracked as follow-ups.

## Verification

`pnpm check` clean. `pnpm test`: 2346 passed, 2 skipped (+16 Tier 2 tests — resolver precedence/band/resolve-or-skip, tool fallback/provenance, channel wiring).
