### PR TITLE
feat(running): serialize structured workouts and add the calendar-create tool

### DIFF
--- a/.changeset/running-workout-serializer.md
+++ b/.changeset/running-workout-serializer.md
@@ -1,0 +1,8 @@
+---
+"@enduragent/sport-running": minor
+"@enduragent/core": patch
+---
+
+Serialize structured running workouts and add the calendar-create running tool.
+
+`@enduragent/sport-running` now ships `serializeRunningWorkout` (pace-based steps → intervals.icu native step syntax) plus a gated `intervals_create_workout` tool that writes the workout to the intervals.icu calendar. Steps carry zone, critical-speed-fraction, or absolute-pace targets over time or distance, rendered so the server parses them into a structured workout (distances emit as km/mi so they are never misread as minutes); running Pace Load stays server-authoritative, so no client load is sent. `@enduragent/core` re-exports the critical-speed sanity band (`CS_MIN_MPS` / `CS_MAX_MPS`) as a single constant the running package now derives its band from.

--- a/packages/core/src/reference/cs-resolution.ts
+++ b/packages/core/src/reference/cs-resolution.ts
@@ -17,8 +17,9 @@ export const RUN_FAMILY_TYPES = new Set<string>(["Run", "TrailRun"]);
 
 // Hard-refusal CS band in m/s: a value outside is unit-confused or corrupt, not a
 // real CS. Typical recreational-to-trained range (~2.5–6.0 m/s, ≈6:40–2:47/km)
-// sits inside; [2.0, 6.5] adds headroom before refusing. Kept in sync with the
-// sport-running CS_SANITY_MPS constant.
+// sits inside; [2.0, 6.5] adds headroom before refusing. Single source of truth:
+// sport-running derives its CS_SANITY_MPS from these via the core barrel re-export
+// (compiler-enforced), so the two bands cannot drift.
 export const CS_MIN_MPS = 2.0;
 export const CS_MAX_MPS = 6.5;
 

--- a/packages/core/src/reference/index.ts
+++ b/packages/core/src/reference/index.ts
@@ -23,7 +23,7 @@ export type { ReferenceServices } from "./services.js";
 // ─── Running CS-anchor resolution (Tier 2) ────────────────────────────
 // `resolveRunningCs` reads the latest synced profile; channels call it per turn.
 // `ResolvedCs` is the anchor shape sport tools receive via `CoreDeps.resolvedCs`.
-export { resolveRunningCs, collectRunCsRows } from "./cs-resolution.js";
+export { resolveRunningCs, collectRunCsRows, CS_MIN_MPS, CS_MAX_MPS } from "./cs-resolution.js";
 export type { ResolvedCs, RunCsRow, CsConfidence } from "./cs-resolution.js";
 
 // ─── Constants ────────────────────────────────────────────────────────

--- a/packages/sport-running/src/index.ts
+++ b/packages/sport-running/src/index.ts
@@ -12,6 +12,13 @@ export type { RunningZoneDisplay } from "./zones.js";
 
 export * from "./schemas.js";
 
+export {
+  serializeRunningWorkout,
+  runningWorkoutInputSchema,
+  InvalidWorkoutError,
+  type RunningWorkoutInput,
+} from "./intervals-serializer.js";
+
 export { runningSport, RUNNING_VOCABULARY } from "./sport.js";
 export { createRunningTools } from "./tools.js";
 export { runningReferenceAdapter } from "./reference/index.js";

--- a/packages/sport-running/src/intervals-serializer.ts
+++ b/packages/sport-running/src/intervals-serializer.ts
@@ -1,0 +1,407 @@
+import { z } from "zod";
+import { ZONE_INTENSITY_MIDPOINTS } from "./zones.js";
+
+export class InvalidWorkoutError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "InvalidWorkoutError";
+  }
+}
+
+// Pace target. Three kinds, all rendered to intervals.icu native "Pace" syntax:
+//  - 'zone'        → "Z3 Pace" / "Z2-Z3 Pace"      (server resolves vs athlete threshold pace)
+//  - 'cs_fraction' → "100% Pace" / "72-100% Pace"  (fraction-of-CS-SPEED == %-of-threshold-pace, zero inversion)
+//  - 'pace'        → "5:00/km Pace" / "7:15-7:00/km Pace" (absolute M:SS, slower-first; escape hatch)
+const paceKindSchema = z.enum(["zone", "cs_fraction", "pace"]);
+
+const paceTargetSchema = z.object({
+  kind: paceKindSchema,
+  // zone: integer 1-6 | cs_fraction: ~0.5-1.3 | pace: "M:SS" string
+  value: z.union([z.number().positive(), z.string()]).optional(),
+  low: z.union([z.number().positive(), z.string()]).optional(),
+  high: z.union([z.number().positive(), z.string()]).optional(),
+  unit: z.enum(["km", "mi"]).optional(), // only meaningful for kind:'pace'
+});
+
+const durationSchema = z.object({
+  value: z.number().positive(),
+  // 'meters' is the natural form for 400m/800m reps; distance_km/distance_mi
+  // mirror the codebase's existing durationUnitSchema vocabulary.
+  unit: z.enum(["seconds", "minutes", "meters", "distance_km", "distance_mi"]),
+});
+
+const runningStepTypeSchema = z.enum([
+  "warmup",
+  "steady",
+  "tempo",
+  "threshold",
+  "interval",
+  "repetition",
+  "strides",
+  "ramp",
+  "recovery",
+  "rest",
+  "cooldown",
+]); // NOTE: no 'freeride' (cycling-only); adds running-idiomatic tempo/threshold/strides/repetition
+
+const runningSimpleStepSchema = z
+  .object({
+    type: runningStepTypeSchema,
+    duration: durationSchema,
+    pace: paceTargetSchema.optional(),
+    label: z.string().max(120).optional(),
+  })
+  // A distance-duration step MUST carry a pace target, so its planned time can be
+  // derived. Turns the runtime InvalidWorkoutError into a schema-level correction
+  // the LLM gets immediately.
+  .superRefine((step, ctx) => {
+    const isDistance =
+      step.duration.unit === "meters" ||
+      step.duration.unit === "distance_km" ||
+      step.duration.unit === "distance_mi";
+    if (isDistance && step.pace === undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "a distance-duration step requires a pace target so its planned time can be derived",
+        path: ["pace"],
+      });
+    }
+    // 'strides' is a neuromuscular drill, NOT a CS-zone prescription. Reject a
+    // CS-anchored target on strides; allow duration-only or an absolute-pace
+    // escape hatch + label.
+    if (step.type === "strides" && step.pace !== undefined && step.pace.kind !== "pace") {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "strides are a neuromuscular drill — use a duration-only step or kind:'pace', not a CS zone/fraction",
+        path: ["pace", "kind"],
+      });
+    }
+  });
+
+const runningSetStepSchema = z.object({
+  type: z.literal("set"),
+  repeat: z.number().int().min(1).max(20),
+  interval: runningSimpleStepSchema,
+  recovery: runningSimpleStepSchema,
+});
+
+export const runningWorkoutInputSchema = z.object({
+  name: z.string().min(1).max(120),
+  steps: z.array(z.union([runningSimpleStepSchema, runningSetStepSchema])).min(1).max(40),
+});
+
+export type RunningWorkoutInput = z.infer<typeof runningWorkoutInputSchema>;
+
+type SimpleStep = z.infer<typeof runningSimpleStepSchema>;
+type SetStep = z.infer<typeof runningSetStepSchema>;
+type PaceTarget = z.infer<typeof paceTargetSchema>;
+type AnyStep = SimpleStep | SetStep;
+type DurationInput = z.infer<typeof durationSchema>;
+
+const MAX_ZONE = 6;
+const MIN_ZONE = 1;
+const MAX_CS_FRACTION = 1.3;
+
+const KM_METERS = 1000;
+const MILE_METERS = 1609.344;
+const MMSS_RE = /^(\d{1,2}):([0-5]\d)$/;
+
+function isDistanceUnit(unit: DurationInput["unit"]): boolean {
+  return unit === "meters" || unit === "distance_km" || unit === "distance_mi";
+}
+
+/** A distance step's length in metres; time steps return undefined. */
+function distanceMeters(d: DurationInput): number | undefined {
+  if (d.unit === "meters") return d.value;
+  if (d.unit === "distance_km") return d.value * KM_METERS;
+  if (d.unit === "distance_mi") return d.value * MILE_METERS;
+  return undefined;
+}
+
+function timeSeconds(d: DurationInput): number | undefined {
+  if (d.unit === "seconds") return d.value;
+  if (d.unit === "minutes") return d.value * 60;
+  return undefined;
+}
+
+function mid(a: number | undefined, b: number | undefined): number | undefined {
+  return a !== undefined && b !== undefined ? (a + b) / 2 : undefined;
+}
+
+/** Parse an "M:SS" pace string to total seconds; throws on a malformed shape. */
+function paceStringToSeconds(s: string, path: string): number {
+  const m = MMSS_RE.exec(s);
+  if (m === null) {
+    throw new InvalidWorkoutError(`${path}: pace "${s}" must be "M:SS" (e.g. 5:00)`);
+  }
+  return Number(m[1]) * 60 + Number(m[2]);
+}
+
+function asNumber(v: number | string | undefined): number | undefined {
+  return typeof v === "number" ? v : undefined;
+}
+
+function asString(v: number | string | undefined): string | undefined {
+  return typeof v === "string" ? v : undefined;
+}
+
+function assertZone(n: number, path: string): void {
+  if (!Number.isInteger(n) || n < MIN_ZONE || n > MAX_ZONE) {
+    throw new InvalidWorkoutError(`${path}: zone must be an integer ${MIN_ZONE}-${MAX_ZONE}, got ${n}`);
+  }
+}
+
+function formatDuration(d: DurationInput): string {
+  if (isDistanceUnit(d.unit)) {
+    // intervals.icu native syntax: a bare "m" means MINUTES, so a distance must
+    // NEVER emit a bare-"m" token — render every distance as km/mi instead.
+    if (d.unit === "distance_mi") return `${d.value}mi`;
+    if (d.unit === "distance_km") return `${d.value}km`;
+    // 'meters' → decimal km (400m → "0.4km"), sidestepping the "m"=minutes trap.
+    return `${d.value / KM_METERS}km`;
+  }
+  const total = Math.round(timeSeconds(d) ?? 0);
+  if (total < 60) return `${total}s`;
+  const minutes = Math.floor(total / 60);
+  const seconds = total % 60;
+  return seconds === 0 ? `${minutes}m` : `${minutes}m${seconds}`;
+}
+
+/**
+ * Resolve the m/s a pace target prescribes, for deriving a distance step's planned
+ * time. Returns undefined when no relative anchor is available (relative kind but
+ * no csMps) — the caller decides whether that is fatal.
+ */
+function paceTargetMps(p: PaceTarget, csMps: number | undefined): number | undefined {
+  if (p.kind === "cs_fraction") {
+    if (csMps === undefined) return undefined;
+    const f = asNumber(p.value) ?? mid(asNumber(p.low), asNumber(p.high));
+    return f === undefined ? undefined : f * csMps;
+  }
+  if (p.kind === "zone") {
+    if (csMps === undefined) return undefined;
+    const z = asNumber(p.value) ?? mid(asNumber(p.low), asNumber(p.high));
+    if (z === undefined) return undefined;
+    const lo = ZONE_INTENSITY_MIDPOINTS[Math.floor(z)];
+    const hi = ZONE_INTENSITY_MIDPOINTS[Math.ceil(z)];
+    if (lo === undefined || hi === undefined) return undefined;
+    return ((lo + hi) / 2) * csMps;
+  }
+  // absolute 'pace': invert the M:SS to m/s (midpoint of a range).
+  const meters = p.unit === "mi" ? MILE_METERS : KM_METERS;
+  const seconds =
+    asString(p.value) !== undefined
+      ? paceStringToSeconds(asString(p.value)!, "pace.value")
+      : mid(
+          asString(p.low) !== undefined ? paceStringToSeconds(asString(p.low)!, "pace.low") : undefined,
+          asString(p.high) !== undefined ? paceStringToSeconds(asString(p.high)!, "pace.high") : undefined,
+        );
+  if (seconds === undefined || seconds <= 0) return undefined;
+  return meters / seconds;
+}
+
+function formatPace(p: PaceTarget, isRamp: boolean, path: string): string {
+  const prefix = isRamp ? "ramp " : "";
+  const hasRange = p.low !== undefined && p.high !== undefined;
+  if (isRamp && !hasRange) {
+    throw new InvalidWorkoutError(`${path}: ramp requires pace.low and pace.high`);
+  }
+
+  if (p.kind === "zone") {
+    if (hasRange) {
+      const lo = asNumber(p.low);
+      const hi = asNumber(p.high);
+      if (lo === undefined || hi === undefined) {
+        throw new InvalidWorkoutError(`${path}: zone range requires numeric pace.low and pace.high`);
+      }
+      assertZone(lo, `${path}.pace.low`);
+      assertZone(hi, `${path}.pace.high`);
+      if (lo > hi) {
+        throw new InvalidWorkoutError(`${path}: pace.low (Z${lo}) must be a slower/equal zone than pace.high (Z${hi})`);
+      }
+      return `${prefix}Z${lo}-Z${hi} Pace`;
+    }
+    const z = asNumber(p.value);
+    if (z === undefined) throw new InvalidWorkoutError(`${path}: zone target requires a numeric 'value' or 'low'+'high'`);
+    assertZone(z, `${path}.pace.value`);
+    return `Z${z} Pace`;
+  }
+
+  if (p.kind === "cs_fraction") {
+    const checkFraction = (f: number, name: string): void => {
+      if (f > MAX_CS_FRACTION) {
+        throw new InvalidWorkoutError(`${path}.pace.${name}: cs_fraction ${f} exceeds sanity bound ${MAX_CS_FRACTION}`);
+      }
+    };
+    if (hasRange) {
+      const lo = asNumber(p.low);
+      const hi = asNumber(p.high);
+      if (lo === undefined || hi === undefined) {
+        throw new InvalidWorkoutError(`${path}: cs_fraction range requires numeric pace.low and pace.high`);
+      }
+      checkFraction(lo, "low");
+      checkFraction(hi, "high");
+      if (lo > hi) {
+        throw new InvalidWorkoutError(`${path}: pace.low (${lo}) must be a slower/equal fraction than pace.high (${hi})`);
+      }
+      return `${prefix}${Math.round(lo * 100)}-${Math.round(hi * 100)}% Pace`;
+    }
+    const f = asNumber(p.value);
+    if (f === undefined) throw new InvalidWorkoutError(`${path}: cs_fraction target requires a numeric 'value' or 'low'+'high'`);
+    checkFraction(f, "value");
+    return `${Math.round(f * 100)}% Pace`;
+  }
+
+  // absolute 'pace' escape hatch — low/high are M:SS strings; emit slower-first.
+  const unit = p.unit === "mi" ? "/mi" : "/km";
+  if (hasRange) {
+    const loStr = asString(p.low);
+    const hiStr = asString(p.high);
+    if (loStr === undefined || hiStr === undefined) {
+      throw new InvalidWorkoutError(`${path}: absolute pace range requires "M:SS" strings for low and high`);
+    }
+    const loSec = paceStringToSeconds(loStr, `${path}.pace.low`);
+    const hiSec = paceStringToSeconds(hiStr, `${path}.pace.high`);
+    // Slower pace = LARGER total seconds; the low/first value must be the slower one.
+    if (loSec < hiSec) {
+      throw new InvalidWorkoutError(
+        `${path}: absolute pace range must be slower-first — pace.low (${loStr}) is faster than pace.high (${hiStr})`,
+      );
+    }
+    return `${prefix}${loStr}-${hiStr}${unit} Pace`;
+  }
+  const valStr = asString(p.value);
+  if (valStr === undefined) {
+    throw new InvalidWorkoutError(`${path}: absolute pace target requires an "M:SS" 'value' or 'low'+'high'`);
+  }
+  paceStringToSeconds(valStr, `${path}.pace.value`);
+  return `${valStr}${unit} Pace`;
+}
+
+function formatStepLine(step: SimpleStep, path: string): string {
+  const parts: string[] = [formatDuration(step.duration)];
+  if (step.pace) {
+    parts.push(formatPace(step.pace, step.type === "ramp", path));
+  }
+  const body = parts.join(" ");
+  return step.label ? `- ${body} ${step.label}` : `- ${body}`;
+}
+
+function sectionLabelFor(type: SimpleStep["type"] | "set"): string {
+  if (type === "warmup") return "Warmup";
+  if (type === "cooldown") return "Cooldown";
+  return "Main set";
+}
+
+function preValidate(step: AnyStep, path: string): void {
+  if (step.type === "set") {
+    preValidate(step.interval, `${path}.interval`);
+    preValidate(step.recovery, `${path}.recovery`);
+    return;
+  }
+  if (step.type === "ramp" && !step.pace) {
+    throw new InvalidWorkoutError(`${path}: ramp step requires a pace target`);
+  }
+  // formatPace carries the per-kind bound + range-ordering checks; calling it here
+  // surfaces those failures up front, before any line is emitted.
+  if (step.pace) formatPace(step.pace, step.type === "ramp", path);
+}
+
+function walkSimpleSteps(
+  steps: AnyStep[],
+  visit: (step: SimpleStep, multiplier: number) => void,
+): void {
+  const go = (step: AnyStep, multiplier: number): void => {
+    if (step.type === "set") {
+      go(step.interval, multiplier * step.repeat);
+      go(step.recovery, multiplier * step.repeat);
+      return;
+    }
+    visit(step, multiplier);
+  };
+  for (const s of steps) go(s, 1);
+}
+
+/** Planned seconds for one simple step. Distance steps derive time from pace→m/s. */
+function stepSeconds(step: SimpleStep, csMps: number | undefined, path: string): number {
+  const timeSec = timeSeconds(step.duration);
+  if (timeSec !== undefined) return timeSec;
+
+  const meters = distanceMeters(step.duration);
+  if (meters === undefined) return 0;
+  // movingTime is the only client-supplied time signal; we will not fabricate it.
+  if (!step.pace) {
+    throw new InvalidWorkoutError(`${path}: distance step has no pace target — cannot derive planned time`);
+  }
+  const mps = paceTargetMps(step.pace, csMps);
+  if (mps === undefined || mps <= 0) {
+    throw new InvalidWorkoutError(
+      `${path}: distance step pace cannot resolve to m/s (relative target needs a critical speed) — cannot derive planned time`,
+    );
+  }
+  return meters / mps;
+}
+
+function totalSeconds(steps: AnyStep[], csMps: number | undefined): number {
+  let total = 0;
+  walkSimpleSteps(steps, (step, multiplier) => {
+    total += stepSeconds(step, csMps, "step") * multiplier;
+  });
+  return Math.round(total);
+}
+
+/**
+ * Serialize a CS-anchored running workout to intervals.icu native description syntax.
+ *
+ * @param input  Parsed running workout (name + ordered pace steps).
+ * @param csMps  The resolved critical speed (m/s). REQUIRED whenever any DISTANCE
+ *               step carries a relative pace target (kind:'zone' or 'cs_fraction'),
+ *               because movingTime for a distance step is derived from pace→m/s.
+ *               Absence in that case throws InvalidWorkoutError (we will not
+ *               fabricate a planned duration — SOUL no-invented-precision).
+ *               Mirrors cycling's optional ftpWatts.
+ * @returns      { description, movingTime } — NO trainingLoad (running load is
+ *               server-authoritative; the server derives Pace Load from the
+ *               parsed steps against the athlete's own threshold pace).
+ * @throws InvalidWorkoutError on schema failure, structural violation, or a
+ *               distance step whose pace cannot resolve to m/s.
+ */
+export function serializeRunningWorkout(
+  input: RunningWorkoutInput,
+  csMps?: number,
+): { description: string; movingTime: number } {
+  // Defense in depth: tool callers already pass a parsed object via zodSchema(),
+  // but direct callers (tests, future library use) may not. Wrap ZodError so
+  // both paths surface as InvalidWorkoutError to consumers.
+  const parsed = runningWorkoutInputSchema.safeParse(input);
+  if (!parsed.success) {
+    throw new InvalidWorkoutError(parsed.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join("; "));
+  }
+  const checked = parsed.data;
+  checked.steps.forEach((s, i) => preValidate(s, `steps[${i}]`));
+
+  const lines: string[] = [];
+  let currentLabel: string | null = null;
+
+  checked.steps.forEach((step, i) => {
+    const label = sectionLabelFor(step.type);
+    if (label !== currentLabel) {
+      if (lines.length > 0) lines.push("");
+      lines.push(label);
+      currentLabel = label;
+    }
+    const path = `steps[${i}]`;
+    if (step.type === "set") {
+      lines.push(`${step.repeat}x`);
+      lines.push(formatStepLine(step.interval, `${path}.interval`));
+      lines.push(formatStepLine(step.recovery, `${path}.recovery`));
+    } else {
+      lines.push(formatStepLine(step, path));
+    }
+  });
+
+  return {
+    description: lines.join("\n"),
+    movingTime: totalSeconds(checked.steps, csMps),
+  };
+}

--- a/packages/sport-running/src/schemas.ts
+++ b/packages/sport-running/src/schemas.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { CS_MIN_MPS, CS_MAX_MPS } from "@enduragent/core";
 
 // ============================================================================
 // SHARED ENUMS
@@ -28,7 +29,7 @@ export const csConfidenceSchema = z.enum(["high", "medium", "low"]);
 export const athleteProfileSchema = z.object({
   experienceLevel: experienceLevelSchema.optional(),
   weightKg: z.number().positive().optional(),
-  criticalSpeedMps: z.number().min(2.0).max(6.5).nullable().optional(),
+  criticalSpeedMps: z.number().min(CS_MIN_MPS).max(CS_MAX_MPS).nullable().optional(),
   paceUnits: paceUnitsSchema.nullable().optional(),
   csSource: csSourceSchema.nullable().optional(),
   csConfidence: csConfidenceSchema.nullable().optional(),

--- a/packages/sport-running/src/tools.ts
+++ b/packages/sport-running/src/tools.ts
@@ -9,12 +9,18 @@ import {
   THRESHOLD_DEFINITION,
   type RunningZoneDisplay,
 } from "./zones.js";
+import {
+  serializeRunningWorkout,
+  runningWorkoutInputSchema,
+  InvalidWorkoutError,
+  type RunningWorkoutInput,
+} from "./intervals-serializer.js";
 
 /**
- * Pure-Sport running tools per ADR-0004. This wave ships the CS-anchored
- * `calculate_zones` tool only; the intervals.icu workout creator is deferred
- * until a running workout serializer exists (Pure-Core + Core-with-sport-config
- * intervals tools still compose in via `runningSport.tools`).
+ * Pure-Sport running tools per ADR-0004 — the CS-anchored `calculate_zones` tool
+ * plus the running-flavored intervals.icu workout creator (hardcoded
+ * `type: "Run"`, gated on a configured intervals client). Pure-Core and
+ * Core-with-sport-config intervals tools still compose in via `runningSport.tools`.
  *
  * The athlete's critical speed is resolved automatically from synced
  * intervals.icu data when available (`resolvedCs` getter, fed per turn by Core);
@@ -34,7 +40,7 @@ function clampLowerFraction(requested: number): { value: number; clamped: boolea
 
 export function createRunningTools(
   _memory: MemoryStore,
-  _intervals: IntervalsClient | null,
+  intervals: IntervalsClient | null,
   _tz: string = "UTC",
   resolvedCs?: () => ResolvedCs | null,
 ) {
@@ -137,5 +143,66 @@ export function createRunningTools(
         };
       },
     }),
+
+    ...(intervals
+      ? {
+          intervals_create_workout: tool({
+            description:
+              "Create a structured running workout on the intervals.icu calendar (auto-syncs to " +
+              "Garmin/Wahoo). Supply the workout as structured steps — the tool serializes them into " +
+              "intervals.icu's native pace syntax so the pace chart renders and the server computes load " +
+              "against the athlete's own threshold pace. Anchor pace targets on the critical-speed zones " +
+              "(kind:'zone' 1-6, or kind:'cs_fraction') — these are RPE-checked estimates from a " +
+              "population-mean model, not lab-measured thresholds. If the athlete's critical speed is a " +
+              "manual/coach-entered override, prefer absolute kind:'pace' targets so the prescription " +
+              "matches the zone table you showed them. Strides are a neuromuscular drill — prescribe them " +
+              "as a duration-only step (or with a relaxed-fast kind:'pace'), never a CS zone. Do not invent " +
+              "a pace the resolved CS doesn't support. Durations may be time (seconds/minutes) or distance " +
+              "(meters/km/mi); a distance step needs a pace target so its planned time can be derived. For " +
+              "every pushed workout, put the RPE-check + provenance framing, plus athlete-facing coaching " +
+              "narrative (feel, RPE cues, target spm, hydration), in your chat reply — the calendar entry " +
+              "cannot carry it.",
+            inputSchema: zodSchema(
+              z.object({
+                date: z.string().describe("Workout date (YYYY-MM-DD)"),
+                workout: runningWorkoutInputSchema.describe(
+                  "Structured workout: name + ordered steps. Top-level steps can be simple " +
+                    "(warmup/steady/tempo/threshold/interval/repetition/strides/ramp/recovery/rest/cooldown) " +
+                    "or a set {type:'set', repeat, interval, recovery}. Durations use time (seconds/minutes) " +
+                    "or distance (meters/distance_km/distance_mi); a distance step needs a pace target. Pace " +
+                    "targets: {kind:'zone'|'cs_fraction'|'pace', value} or {kind, low, high} for ranges. " +
+                    "cs_fraction is a fraction of critical speed (1.0 = threshold). Absolute 'pace' is M:SS " +
+                    "strings, slower-first for ranges. Ramps require low+high.",
+                ),
+              }),
+            ),
+            execute: async (input: { date: string; workout: RunningWorkoutInput }) => {
+              // The serializer stays pure: pass OUR resolved CS in so distance steps
+              // with relative targets can derive their planned time.
+              let serialized: ReturnType<typeof serializeRunningWorkout>;
+              try {
+                serialized = serializeRunningWorkout(input.workout, resolvedCs?.()?.criticalSpeedMps);
+              } catch (err) {
+                if (err instanceof InvalidWorkoutError) {
+                  return { error: "invalid_workout", details: err.message };
+                }
+                throw err;
+              }
+              const result = await intervals.events.create({
+                start_date_local: `${input.date}T00:00:00`,
+                category: "WORKOUT",
+                name: input.workout.name,
+                type: "Run",
+                moving_time: serialized.movingTime,
+                // No icu_training_load — the server derives running Pace Load from the
+                // parsed steps against the athlete's own threshold pace.
+                description: serialized.description,
+              });
+              if (!result.ok) return { error: result.error.kind };
+              return { created: true, event: result.value };
+            },
+          }),
+        }
+      : {}),
   };
 }

--- a/packages/sport-running/src/zones.ts
+++ b/packages/sport-running/src/zones.ts
@@ -7,6 +7,8 @@
 // convention. CS and all band speeds are SI metres-per-second — intervals.icu
 // stores threshold_pace in m/s and uses pace_units only as a display preference.
 
+import { CS_MIN_MPS, CS_MAX_MPS } from "@enduragent/core";
+
 export interface RunningZoneDisplay {
   label: string;
   value: string;
@@ -31,10 +33,10 @@ export const LOWER_FRACTION_CLAMP = { min: 0.78, max: 0.88 } as const;
 /**
  * Hard-refusal CS band in m/s: a value outside is unit-confused or corrupt, not a
  * real CS. The typical recreational-to-trained range (~2.5–6.0 m/s, ≈6:40–2:47/km)
- * sits inside; the [2.0, 6.5] edges add headroom before refusing. Kept in sync
- * with the core CS-source gate.
+ * sits inside; the edges add headroom before refusing. Derived from core
+ * (compiler-enforced) so the band cannot drift from the CS-source gate.
  */
-export const CS_SANITY_MPS = { min: 2.0, max: 6.5 } as const;
+export const CS_SANITY_MPS = { min: CS_MIN_MPS, max: CS_MAX_MPS } as const;
 
 /** One-sentence disclosure of the threshold definitions the table assumes. */
 export const THRESHOLD_DEFINITION =
@@ -130,7 +132,11 @@ export const ZONE_DESCRIPTIONS: Record<string, string> = {
 /**
  * Zone-number → representative fraction-of-CS midpoint (open-ended Z1/Z6 use an
  * interior point). Parallels cycling's ZONE_INTENSITY_MIDPOINTS; assumes the flat
- * 0.823 LT1 edge.
+ * 0.823 LT1 edge. The open-ended Z1=0.66 / Z6=1.2 midpoints are
+ * representative-not-prescribed interior points: any duration derived from them
+ * (e.g. seeding a distance step's planned time) is a coarse seed only, consistent
+ * with the server's per-athlete recompute — do not harden it into a precise pace
+ * claim.
  */
 export const ZONE_INTENSITY_MIDPOINTS: Record<number, number> = {
   1: 0.66,

--- a/packages/sport-running/tests/intervals-serializer.test.ts
+++ b/packages/sport-running/tests/intervals-serializer.test.ts
@@ -1,0 +1,646 @@
+import { describe, it, expect } from "vitest";
+import {
+  serializeRunningWorkout,
+  runningWorkoutInputSchema,
+  InvalidWorkoutError,
+  type RunningWorkoutInput,
+} from "../src/intervals-serializer.js";
+
+describe("serializeRunningWorkout — description output", () => {
+  it("emits a Z2 easy run as a cs_fraction range", () => {
+    const input: RunningWorkoutInput = {
+      name: "Z2 Easy 50min",
+      steps: [
+        {
+          type: "warmup",
+          duration: { value: 10, unit: "minutes" },
+          pace: { kind: "cs_fraction", low: 0.72, high: 0.82 },
+        },
+        {
+          type: "steady",
+          duration: { value: 30, unit: "minutes" },
+          pace: { kind: "cs_fraction", low: 0.72, high: 0.82 },
+        },
+        {
+          type: "cooldown",
+          duration: { value: 10, unit: "minutes" },
+          pace: { kind: "cs_fraction", value: 0.7 },
+        },
+      ],
+    };
+
+    const { description } = serializeRunningWorkout(input);
+
+    expect(description).toContain("Warmup");
+    expect(description).toContain("- 10m 72-82% Pace");
+    expect(description).toContain("Main set");
+    expect(description).toContain("Cooldown");
+    expect(description).toContain("- 10m 70% Pace");
+  });
+
+  it("emits a threshold set with Nx line and interval+recovery lines", () => {
+    const input: RunningWorkoutInput = {
+      name: "Threshold 3x1km",
+      steps: [
+        {
+          type: "warmup",
+          duration: { value: 12, unit: "minutes" },
+          pace: { kind: "cs_fraction", low: 0.7, high: 0.8 },
+        },
+        {
+          type: "set",
+          repeat: 3,
+          interval: {
+            type: "threshold",
+            duration: { value: 1, unit: "distance_km" },
+            pace: { kind: "cs_fraction", value: 1.0 },
+            label: "Threshold",
+          },
+          recovery: {
+            type: "recovery",
+            duration: { value: 90, unit: "seconds" },
+            pace: { kind: "cs_fraction", value: 0.65 },
+          },
+        },
+        {
+          type: "cooldown",
+          duration: { value: 10, unit: "minutes" },
+          pace: { kind: "cs_fraction", value: 0.65 },
+        },
+      ],
+    };
+
+    // csMps required: the 1km interval is a distance step with a relative target,
+    // so its planned time is derived from pace→m/s.
+    const { description } = serializeRunningWorkout(input, 4.0);
+
+    expect(description).toMatch(/^Warmup$/m);
+    expect(description).toContain("Main set");
+    expect(description).toMatch(/^3x$/m);
+    expect(description).toContain("- 1km 100% Pace Threshold");
+    expect(description).toContain("- 1m30 65% Pace");
+    expect(description).toContain("Cooldown");
+  });
+
+  it("emits a single zone target", () => {
+    const input: RunningWorkoutInput = {
+      name: "Zone target",
+      steps: [
+        {
+          type: "steady",
+          duration: { value: 60, unit: "minutes" },
+          pace: { kind: "zone", value: 2 },
+        },
+      ],
+    };
+
+    const { description } = serializeRunningWorkout(input);
+    expect(description).toContain("- 60m Z2 Pace");
+  });
+
+  it("emits a zone range over a distance step", () => {
+    const input: RunningWorkoutInput = {
+      name: "Zone range",
+      steps: [
+        {
+          type: "interval",
+          duration: { value: 1, unit: "distance_mi" },
+          pace: { kind: "zone", low: 4, high: 5 },
+        },
+      ],
+    };
+
+    const { description } = serializeRunningWorkout(input, 4.0);
+    expect(description).toContain("- 1mi Z4-Z5 Pace");
+  });
+
+  it("emits an absolute pace escape hatch", () => {
+    const input: RunningWorkoutInput = {
+      name: "Absolute pace",
+      steps: [
+        {
+          type: "steady",
+          duration: { value: 10, unit: "minutes" },
+          pace: { kind: "pace", value: "5:00" },
+        },
+      ],
+    };
+
+    const { description } = serializeRunningWorkout(input);
+    expect(description).toContain("- 10m 5:00/km Pace");
+  });
+
+  it("emits a ramp step with the 'ramp' keyword and bounds", () => {
+    const input: RunningWorkoutInput = {
+      name: "Ramp warmup",
+      steps: [
+        {
+          type: "ramp",
+          duration: { value: 10, unit: "minutes" },
+          pace: { kind: "cs_fraction", low: 0.6, high: 0.8 },
+        },
+      ],
+    };
+
+    const { description } = serializeRunningWorkout(input);
+    expect(description).toContain("- 10m ramp 60-80% Pace");
+  });
+
+  it("files new running step types under Main set with no extra header", () => {
+    const input: RunningWorkoutInput = {
+      name: "Mixed mains",
+      steps: [
+        { type: "tempo", duration: { value: 10, unit: "minutes" }, pace: { kind: "zone", value: 3 } },
+        { type: "threshold", duration: { value: 10, unit: "minutes" }, pace: { kind: "zone", value: 4 } },
+        { type: "repetition", duration: { value: 5, unit: "minutes" }, pace: { kind: "zone", value: 5 } },
+      ],
+    };
+
+    const { description } = serializeRunningWorkout(input);
+    const mainCount = (description.match(/^Main set$/gm) ?? []).length;
+    expect(mainCount).toBe(1);
+  });
+
+  it("formats sub-minute durations as seconds", () => {
+    const input: RunningWorkoutInput = {
+      name: "Short reps",
+      steps: [
+        {
+          type: "interval",
+          duration: { value: 30, unit: "seconds" },
+          pace: { kind: "cs_fraction", value: 1.1 },
+        },
+      ],
+    };
+
+    const { description } = serializeRunningWorkout(input);
+    expect(description).toContain("- 30s 110% Pace");
+  });
+
+  it("formats 90-second durations as 1m30", () => {
+    const input: RunningWorkoutInput = {
+      name: "90s effort",
+      steps: [
+        {
+          type: "interval",
+          duration: { value: 90, unit: "seconds" },
+          pace: { kind: "cs_fraction", value: 1.05 },
+        },
+      ],
+    };
+
+    const { description } = serializeRunningWorkout(input);
+    expect(description).toContain("- 1m30 105% Pace");
+  });
+
+  it("does not repeat the section label for consecutive same-section steps", () => {
+    const input: RunningWorkoutInput = {
+      name: "Two warmup steps",
+      steps: [
+        { type: "warmup", duration: { value: 5, unit: "minutes" }, pace: { kind: "cs_fraction", value: 0.6 } },
+        { type: "warmup", duration: { value: 5, unit: "minutes" }, pace: { kind: "cs_fraction", value: 0.7 } },
+      ],
+    };
+
+    const { description } = serializeRunningWorkout(input);
+    const warmupCount = (description.match(/^Warmup$/gm) ?? []).length;
+    expect(warmupCount).toBe(1);
+  });
+});
+
+describe("serializeRunningWorkout — distance & units (the m≠meters gate)", () => {
+  it("renders a 400m rep as 0.4km, never bare 400m", () => {
+    const input: RunningWorkoutInput = {
+      name: "400s",
+      steps: [
+        {
+          type: "interval",
+          duration: { value: 400, unit: "meters" },
+          pace: { kind: "cs_fraction", value: 1.06 },
+        },
+      ],
+    };
+
+    const { description } = serializeRunningWorkout(input, 4.0);
+    expect(description).toContain("- 0.4km");
+    expect(description).not.toContain("400m");
+  });
+
+  it("never emits a distance token ending in a bare 'm'", () => {
+    const input: RunningWorkoutInput = {
+      name: "Distance mix",
+      steps: [
+        { type: "interval", duration: { value: 400, unit: "meters" }, pace: { kind: "cs_fraction", value: 1.06 } },
+        { type: "interval", duration: { value: 800, unit: "meters" }, pace: { kind: "cs_fraction", value: 1.0 } },
+        { type: "steady", duration: { value: 5, unit: "distance_km" }, pace: { kind: "cs_fraction", value: 0.8 } },
+        { type: "steady", duration: { value: 3, unit: "distance_mi" }, pace: { kind: "cs_fraction", value: 0.8 } },
+      ],
+    };
+
+    const { description } = serializeRunningWorkout(input, 4.0);
+    // The first token of every step line is the duration token; assert none of the
+    // distance ones end in a bare 'm' (which intervals.icu reads as MINUTES).
+    for (const line of description.split("\n")) {
+      if (!line.startsWith("- ")) continue;
+      const token = line.slice(2).split(" ")[0];
+      expect(token).not.toMatch(/\d+m$/);
+    }
+  });
+
+  it("renders distance_km and distance_mi units", () => {
+    const input: RunningWorkoutInput = {
+      name: "km and mi",
+      steps: [
+        { type: "steady", duration: { value: 1, unit: "distance_km" }, pace: { kind: "cs_fraction", value: 0.8 } },
+        { type: "steady", duration: { value: 1, unit: "distance_mi" }, pace: { kind: "cs_fraction", value: 0.8 } },
+      ],
+    };
+
+    const { description } = serializeRunningWorkout(input, 4.0);
+    expect(description).toContain("- 1km 80% Pace");
+    expect(description).toContain("- 1mi 80% Pace");
+  });
+
+  it("uses /km by default and /mi when unit is mi for absolute pace", () => {
+    const km: RunningWorkoutInput = {
+      name: "km pace",
+      steps: [{ type: "steady", duration: { value: 5, unit: "minutes" }, pace: { kind: "pace", value: "5:00" } }],
+    };
+    const mi: RunningWorkoutInput = {
+      name: "mi pace",
+      steps: [{ type: "steady", duration: { value: 5, unit: "minutes" }, pace: { kind: "pace", value: "8:00", unit: "mi" } }],
+    };
+
+    expect(serializeRunningWorkout(km).description).toContain("5:00/km Pace");
+    expect(serializeRunningWorkout(mi).description).toContain("8:00/mi Pace");
+  });
+});
+
+describe("serializeRunningWorkout — movingTime", () => {
+  it("sums simple time steps", () => {
+    const input: RunningWorkoutInput = {
+      name: "Time sum",
+      steps: [
+        { type: "warmup", duration: { value: 10, unit: "minutes" }, pace: { kind: "cs_fraction", value: 0.7 } },
+        { type: "steady", duration: { value: 30, unit: "minutes" }, pace: { kind: "cs_fraction", value: 0.8 } },
+        { type: "cooldown", duration: { value: 5, unit: "minutes" }, pace: { kind: "cs_fraction", value: 0.65 } },
+      ],
+    };
+
+    const { movingTime } = serializeRunningWorkout(input);
+    expect(movingTime).toBe(45 * 60);
+  });
+
+  it("multiplies set durations by repeat count", () => {
+    const input: RunningWorkoutInput = {
+      name: "Set sum",
+      steps: [
+        { type: "warmup", duration: { value: 10, unit: "minutes" }, pace: { kind: "cs_fraction", value: 0.7 } },
+        {
+          type: "set",
+          repeat: 3,
+          interval: { type: "interval", duration: { value: 3, unit: "minutes" }, pace: { kind: "cs_fraction", value: 1.05 } },
+          recovery: { type: "recovery", duration: { value: 2, unit: "minutes" }, pace: { kind: "cs_fraction", value: 0.65 } },
+        },
+        { type: "cooldown", duration: { value: 10, unit: "minutes" }, pace: { kind: "cs_fraction", value: 0.65 } },
+      ],
+    };
+
+    // 10 + (3+2)*3 + 10 = 35 min
+    const { movingTime } = serializeRunningWorkout(input);
+    expect(movingTime).toBe(35 * 60);
+  });
+
+  it("handles mixed seconds/minutes", () => {
+    const input: RunningWorkoutInput = {
+      name: "Mixed",
+      steps: [
+        { type: "steady", duration: { value: 90, unit: "seconds" }, pace: { kind: "cs_fraction", value: 0.7 } },
+        { type: "steady", duration: { value: 2, unit: "minutes" }, pace: { kind: "cs_fraction", value: 0.7 } },
+      ],
+    };
+
+    const { movingTime } = serializeRunningWorkout(input);
+    expect(movingTime).toBe(90 + 120);
+  });
+
+  it("derives distance-step seconds from a cs_fraction target and csMps", () => {
+    const input: RunningWorkoutInput = {
+      name: "400m derive",
+      steps: [
+        {
+          type: "interval",
+          duration: { value: 400, unit: "meters" },
+          pace: { kind: "cs_fraction", value: 1.06 },
+        },
+      ],
+    };
+
+    // mps = 1.06 * 4.0 = 4.24; seconds = 400 / 4.24 ≈ 94.3 → rounds to 94.
+    const { movingTime } = serializeRunningWorkout(input, 4.0);
+    expect(movingTime).toBe(94);
+  });
+
+  it("derives distance-step seconds from a zone target via ZONE_INTENSITY_MIDPOINTS", () => {
+    const input: RunningWorkoutInput = {
+      name: "1mi zone4 derive",
+      steps: [
+        {
+          type: "interval",
+          duration: { value: 1, unit: "distance_mi" },
+          pace: { kind: "zone", value: 4 },
+        },
+      ],
+    };
+
+    // zone 4 midpoint = 0.955; mps = 0.955 * 4.0 = 3.82; seconds = 1609.344 / 3.82 ≈ 421.3 → 421.
+    const { movingTime } = serializeRunningWorkout(input, 4.0);
+    expect(movingTime).toBe(421);
+  });
+
+  it("throws when a distance step has a relative target but no csMps", () => {
+    const input: RunningWorkoutInput = {
+      name: "no cs",
+      steps: [
+        {
+          type: "interval",
+          duration: { value: 400, unit: "meters" },
+          pace: { kind: "cs_fraction", value: 1.06 },
+        },
+      ],
+    };
+
+    expect(() => serializeRunningWorkout(input)).toThrow(InvalidWorkoutError);
+  });
+
+  it("rejects a bare-distance step (no pace) at schema parse", () => {
+    const input = {
+      name: "bare distance",
+      steps: [{ type: "interval" as const, duration: { value: 400, unit: "meters" as const } }],
+    };
+
+    expect(() => serializeRunningWorkout(input as RunningWorkoutInput)).toThrow(InvalidWorkoutError);
+  });
+});
+
+describe("serializeRunningWorkout — SPEED↔PACE inversion (the #1 trap)", () => {
+  it("serializes a faster zone to a numerically smaller M:SS than a slower zone", () => {
+    const slow: RunningWorkoutInput = {
+      name: "slow",
+      steps: [{ type: "steady", duration: { value: 1, unit: "distance_km" }, pace: { kind: "pace", value: "6:00" } }],
+    };
+    const fast: RunningWorkoutInput = {
+      name: "fast",
+      steps: [{ type: "steady", duration: { value: 1, unit: "distance_km" }, pace: { kind: "pace", value: "4:00" } }],
+    };
+
+    // Z2-ish (slow) carries a larger M:SS than a Z5-ish (fast) effort.
+    const slowTime = serializeRunningWorkout(slow).movingTime;
+    const fastTime = serializeRunningWorkout(fast).movingTime;
+    expect(slowTime).toBeGreaterThan(fastTime);
+  });
+
+  it("preserves direction for cs_fraction percent emission", () => {
+    const vo2: RunningWorkoutInput = {
+      name: "vo2",
+      steps: [{ type: "interval", duration: { value: 3, unit: "minutes" }, pace: { kind: "cs_fraction", value: 1.12 } }],
+    };
+    const easy: RunningWorkoutInput = {
+      name: "easy",
+      steps: [{ type: "steady", duration: { value: 30, unit: "minutes" }, pace: { kind: "cs_fraction", value: 0.72 } }],
+    };
+
+    expect(serializeRunningWorkout(vo2).description).toContain("112% Pace");
+    expect(serializeRunningWorkout(easy).description).toContain("72% Pace");
+  });
+});
+
+describe("serializeRunningWorkout — range ordering by pace kind (the #2 trap)", () => {
+  it("emits a cs_fraction range ascending (slow→fast percent)", () => {
+    const input: RunningWorkoutInput = {
+      name: "frac range",
+      steps: [{ type: "steady", duration: { value: 20, unit: "minutes" }, pace: { kind: "cs_fraction", low: 0.72, high: 0.82 } }],
+    };
+
+    expect(serializeRunningWorkout(input).description).toContain("72-82% Pace");
+  });
+
+  it("emits a zone range ascending", () => {
+    const input: RunningWorkoutInput = {
+      name: "zone range",
+      steps: [{ type: "interval", duration: { value: 5, unit: "minutes" }, pace: { kind: "zone", low: 4, high: 5 } }],
+    };
+
+    expect(serializeRunningWorkout(input).description).toContain("Z4-Z5 Pace");
+  });
+
+  it("emits an absolute pace range slower-first when supplied slower-first", () => {
+    const input: RunningWorkoutInput = {
+      name: "abs range",
+      steps: [{ type: "steady", duration: { value: 10, unit: "minutes" }, pace: { kind: "pace", low: "7:15", high: "7:00" } }],
+    };
+
+    expect(serializeRunningWorkout(input).description).toContain("7:15-7:00/km Pace");
+  });
+
+  it("throws on a faster-first absolute pace range", () => {
+    const input: RunningWorkoutInput = {
+      name: "abs range bad",
+      steps: [{ type: "steady", duration: { value: 10, unit: "minutes" }, pace: { kind: "pace", low: "7:00", high: "7:15" } }],
+    };
+
+    expect(() => serializeRunningWorkout(input)).toThrow(InvalidWorkoutError);
+  });
+
+  it("throws on a descending cs_fraction range", () => {
+    const input: RunningWorkoutInput = {
+      name: "frac range bad",
+      steps: [{ type: "steady", duration: { value: 10, unit: "minutes" }, pace: { kind: "cs_fraction", low: 0.82, high: 0.72 } }],
+    };
+
+    expect(() => serializeRunningWorkout(input)).toThrow(InvalidWorkoutError);
+  });
+});
+
+describe("serializeRunningWorkout — validation / InvalidWorkoutError", () => {
+  it("rejects empty steps array at schema level", () => {
+    const bad = { name: "Empty", steps: [] };
+    expect(() => serializeRunningWorkout(bad as RunningWorkoutInput)).toThrow();
+  });
+
+  it("rejects missing name", () => {
+    const bad = {
+      steps: [{ type: "steady", duration: { value: 10, unit: "minutes" }, pace: { kind: "cs_fraction", value: 0.7 } }],
+    };
+    expect(() => serializeRunningWorkout(bad as unknown as RunningWorkoutInput)).toThrow();
+  });
+
+  it("rejects ramp without pace.low and pace.high", () => {
+    const input = {
+      name: "Bad ramp",
+      steps: [
+        {
+          type: "ramp" as const,
+          duration: { value: 10, unit: "minutes" as const },
+          pace: { kind: "cs_fraction" as const, value: 0.7 },
+        },
+      ],
+    };
+
+    expect(() => serializeRunningWorkout(input)).toThrow(InvalidWorkoutError);
+    expect(() => serializeRunningWorkout(input)).toThrow(/ramp requires pace\.low and pace\.high/);
+  });
+
+  it("rejects ramp with no pace target at all", () => {
+    const input = {
+      name: "Bad ramp",
+      steps: [{ type: "ramp" as const, duration: { value: 10, unit: "minutes" as const } }],
+    };
+
+    expect(() => serializeRunningWorkout(input)).toThrow(InvalidWorkoutError);
+  });
+
+  it("rejects zone 7 (running MAX_ZONE is 6, unlike cycling's 7)", () => {
+    const input = {
+      name: "Bad zone",
+      steps: [
+        {
+          type: "interval" as const,
+          duration: { value: 5, unit: "minutes" as const },
+          pace: { kind: "zone" as const, value: 7 },
+        },
+      ],
+    };
+
+    expect(() => serializeRunningWorkout(input)).toThrow(InvalidWorkoutError);
+    expect(() => serializeRunningWorkout(input)).toThrow(/zone must be an integer/);
+  });
+
+  it("rejects a cs_fraction above the sanity bound", () => {
+    const input = {
+      name: "Absurd fraction",
+      steps: [
+        {
+          type: "interval" as const,
+          duration: { value: 30, unit: "seconds" as const },
+          pace: { kind: "cs_fraction" as const, value: 1.5 },
+        },
+      ],
+    };
+
+    expect(() => serializeRunningWorkout(input)).toThrow(InvalidWorkoutError);
+    expect(() => serializeRunningWorkout(input)).toThrow(/exceeds sanity bound/);
+  });
+
+  it("rejects a set with repeat > 20 at schema level", () => {
+    const input = {
+      name: "Too many repeats",
+      steps: [
+        {
+          type: "set" as const,
+          repeat: 21,
+          interval: {
+            type: "interval" as const,
+            duration: { value: 1, unit: "minutes" as const },
+            pace: { kind: "cs_fraction" as const, value: 1.05 },
+          },
+          recovery: {
+            type: "recovery" as const,
+            duration: { value: 1, unit: "minutes" as const },
+            pace: { kind: "cs_fraction" as const, value: 0.65 },
+          },
+        },
+      ],
+    };
+
+    expect(() => serializeRunningWorkout(input)).toThrow();
+  });
+
+  it("rejects a top-level steps array longer than 40", () => {
+    const step = {
+      type: "steady" as const,
+      duration: { value: 1, unit: "minutes" as const },
+      pace: { kind: "cs_fraction" as const, value: 0.7 },
+    };
+    const input = { name: "Too many steps", steps: Array.from({ length: 41 }, () => step) };
+
+    expect(() => serializeRunningWorkout(input)).toThrow();
+  });
+
+  it("rejects a distance step with a non-resolvable pace", () => {
+    const input: RunningWorkoutInput = {
+      name: "no cs distance",
+      steps: [{ type: "interval", duration: { value: 400, unit: "meters" }, pace: { kind: "zone", value: 4 } }],
+    };
+
+    expect(() => serializeRunningWorkout(input)).toThrow(InvalidWorkoutError);
+  });
+
+  it("rejects strides carrying a cs_fraction target", () => {
+    const input = {
+      name: "Strides zone",
+      steps: [
+        {
+          type: "strides" as const,
+          duration: { value: 20, unit: "seconds" as const },
+          pace: { kind: "cs_fraction" as const, value: 1.2 },
+        },
+      ],
+    };
+
+    expect(() => serializeRunningWorkout(input)).toThrow(InvalidWorkoutError);
+  });
+
+  it("rejects strides carrying a zone target", () => {
+    const input = {
+      name: "Strides zone",
+      steps: [
+        {
+          type: "strides" as const,
+          duration: { value: 20, unit: "seconds" as const },
+          pace: { kind: "zone" as const, value: 6 },
+        },
+      ],
+    };
+
+    expect(() => serializeRunningWorkout(input)).toThrow(InvalidWorkoutError);
+  });
+
+  it("accepts strides as a duration-only step", () => {
+    const input: RunningWorkoutInput = {
+      name: "Strides plain",
+      steps: [{ type: "strides", duration: { value: 20, unit: "seconds" }, label: "relaxed-fast" }],
+    };
+
+    const { description } = serializeRunningWorkout(input);
+    expect(description).toContain("- 20s relaxed-fast");
+  });
+
+  it("accepts strides with an absolute pace escape hatch", () => {
+    const input: RunningWorkoutInput = {
+      name: "Strides pace",
+      steps: [{ type: "strides", duration: { value: 20, unit: "seconds" }, pace: { kind: "pace", value: "3:30" } }],
+    };
+
+    const { description } = serializeRunningWorkout(input);
+    expect(description).toContain("3:30/km Pace");
+  });
+});
+
+describe("runningWorkoutInputSchema", () => {
+  it("rejects the cycling-only freeride step type", () => {
+    const result = runningWorkoutInputSchema.safeParse({
+      name: "Freeride",
+      steps: [{ type: "freeride", duration: { value: 60, unit: "minutes" } }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts distance-based durations (the inverse of the cycling schema)", () => {
+    const result = runningWorkoutInputSchema.safeParse({
+      name: "Distance",
+      steps: [{ type: "interval", duration: { value: 5, unit: "distance_km" }, pace: { kind: "cs_fraction", value: 0.8 } }],
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/packages/sport-running/tests/tools.test.ts
+++ b/packages/sport-running/tests/tools.test.ts
@@ -115,3 +115,144 @@ describe("calculate_zones CS auto-resolution", () => {
     expect(out.error).toBe("no_cs_anchor");
   });
 });
+
+// ---------------------------------------------------------------------------
+// intervals_create_workout — gated on a configured intervals client.
+// ---------------------------------------------------------------------------
+
+type CreateResult =
+  | { ok: true; value: { id: number } }
+  | { ok: false; error: { kind: string } };
+
+interface FakeIntervals {
+  events: { create: (payload: Record<string, unknown>) => Promise<CreateResult> };
+}
+
+function fakeIntervals(
+  result: CreateResult,
+): { client: FakeIntervals; calls: Record<string, unknown>[] } {
+  const calls: Record<string, unknown>[] = [];
+  const client: FakeIntervals = {
+    events: {
+      create: async (payload) => {
+        calls.push(payload);
+        return result;
+      },
+    },
+  };
+  return { client, calls };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function createWorkoutTool(intervals: any, resolved: ResolvedCs | null = null) {
+  const tools = createRunningTools(
+    {} as MemoryStore,
+    intervals,
+    "UTC",
+    resolved === null ? undefined : () => resolved,
+  );
+  return (tools as Record<string, unknown>).intervals_create_workout as
+    | { execute: (input: unknown, opts: unknown) => Promise<Record<string, unknown>> }
+    | undefined;
+}
+
+describe("intervals_create_workout tool", () => {
+  it("is absent when no intervals client is configured", () => {
+    const tools = createRunningTools({} as MemoryStore, null, "UTC");
+    expect("intervals_create_workout" in tools).toBe(false);
+  });
+
+  it("is present when an intervals client is configured", () => {
+    const { client } = fakeIntervals({ ok: true, value: { id: 1 } });
+    const tool = createWorkoutTool(client);
+    expect(tool).toBeDefined();
+  });
+
+  it("posts type:'Run', WORKOUT, the serialized description, no icu_training_load", async () => {
+    const { client, calls } = fakeIntervals({ ok: true, value: { id: 42 } });
+    const tool = createWorkoutTool(client)!;
+
+    const out = await tool.execute(
+      {
+        date: "2026-06-21",
+        workout: {
+          name: "Easy 30",
+          steps: [{ type: "steady", duration: { value: 30, unit: "minutes" }, pace: { kind: "cs_fraction", value: 0.75 } }],
+        },
+      },
+      {},
+    );
+
+    expect(out).toEqual({ created: true, event: { id: 42 } });
+    expect(calls).toHaveLength(1);
+    const payload = calls[0];
+    expect(payload.type).toBe("Run");
+    expect(payload.category).toBe("WORKOUT");
+    expect(payload.name).toBe("Easy 30");
+    expect(typeof payload.description).toBe("string");
+    expect(payload.description).toContain("75% Pace");
+    expect("icu_training_load" in payload).toBe(false);
+  });
+
+  it("passes a manual-source resolved CS through and still serializes (DOM-1)", async () => {
+    const { client, calls } = fakeIntervals({ ok: true, value: { id: 7 } });
+    const tool = createWorkoutTool(client, {
+      criticalSpeedMps: 4.0,
+      source: "athlete_manual",
+      confidence: null,
+    })!;
+
+    const out = await tool.execute(
+      {
+        date: "2026-06-21",
+        workout: {
+          name: "Manual CS 400s",
+          steps: [{ type: "interval", duration: { value: 400, unit: "meters" }, pace: { kind: "cs_fraction", value: 1.06 } }],
+        },
+      },
+      {},
+    );
+
+    expect(out).toEqual({ created: true, event: { id: 7 } });
+    // The distance step's planned time resolved via the passed-through CS.
+    expect(calls[0].moving_time).toBe(94);
+  });
+
+  it("returns invalid_workout and does NOT call events.create on a serialization failure", async () => {
+    const { client, calls } = fakeIntervals({ ok: true, value: { id: 1 } });
+    const tool = createWorkoutTool(client)!;
+
+    const out = await tool.execute(
+      {
+        date: "2026-06-21",
+        workout: {
+          name: "Bad",
+          steps: [{ type: "ramp", duration: { value: 10, unit: "minutes" }, pace: { kind: "cs_fraction", value: 0.7 } }],
+        },
+      },
+      {},
+    );
+
+    expect(out.error).toBe("invalid_workout");
+    expect(typeof out.details).toBe("string");
+    expect(calls).toHaveLength(0);
+  });
+
+  it("surfaces the API error kind when events.create fails", async () => {
+    const { client } = fakeIntervals({ ok: false, error: { kind: "rate_limited" } });
+    const tool = createWorkoutTool(client)!;
+
+    const out = await tool.execute(
+      {
+        date: "2026-06-21",
+        workout: {
+          name: "Easy 30",
+          steps: [{ type: "steady", duration: { value: 30, unit: "minutes" }, pace: { kind: "cs_fraction", value: 0.75 } }],
+        },
+      },
+      {},
+    );
+
+    expect(out.error).toBe("rate_limited");
+  });
+});


### PR DESCRIPTION
## What

Adds the running coach's first workout-creation capability: a pace-based workout serializer and a gated intervals.icu calendar-create tool, mirroring the cycling serializer's shape (ADR-0004/0005).

- `serializeRunningWorkout(input, csMps?)` → `{ description, movingTime }`, emitting intervals.icu native step syntax over a **pace** axis.
- Steps support three pace-target kinds — `zone` (1–6), `cs_fraction` (fraction of critical speed), and absolute `pace` (M:SS) — over time **or** distance.
- Gated `intervals_create_workout` tool (present only when an intervals client is wired): posts `type:"Run"` / `category:"WORKOUT"` and **omits** `icu_training_load`, leaving running Pace Load server-authoritative.
- Freebie: the critical-speed sanity band `[2.0, 6.5]` is now a single `@enduragent/core` constant (`CS_MIN_MPS` / `CS_MAX_MPS`); sport-running derives its band from it instead of hardcoding.

## Server-verified wire format

A live round-trip against intervals.icu (create → read → delete) confirmed the server parses every emitted form into a structured workout:

| emitted | server `workoutDoc.steps[0].pace` |
|---|---|
| `5:00/km Pace` | `{units:"secs/km", value:300}` |
| `7:15-7:00/km Pace` | `{start:435, end:420, units:"secs/km"}` |
| `95% Pace` | `{units:"%pace", value:95}` |

Client `moving_time` is honored (1200 → 1200). Distances emit as `km`/`mi` — never a bare `m`, which intervals.icu reads as *minutes*. (Note for future readers: the create body is snake_case, but the GET response is camelCase — `workoutDoc` / `movingTime` / `icuTrainingLoad`.)

## Conscious divergence

This tool ships under the generic name `intervals_create_workout` rather than the per-sport `intervals_create_run_workout` prescribed by ADR-0004/0005 — a conscious choice while running is the only sport with a workout creator, with the rename obligation tracked against the composed-Sport factory work, where the cross-sport tool-registry union first surfaces the name collision.

## Tests

- sport-running: **73 passing** (serializer suite + gated-tool coverage); build + typecheck clean
- core typecheck clean; cycling regression **134 passing** (no drift)

## Follow-ups (tracked)

- `cs_fraction` lower sanity bound (the fraction is bounded above only) — filed against the safe-envelope work
- a test asserting the zone midpoint table stays within its band edges
- the `intervals_create_workout` → `intervals_create_run_workout` rename, due when the composed-Sport factory unions per-sport registries
