### PR TITLE
feat(core): tag the usage-ledger turn line with the prompt template hash

### DIFF
--- a/.changeset/usage-ledger-template-hash.md
+++ b/.changeset/usage-ledger-template-hash.md
@@ -1,5 +1,5 @@
 ---
-"cycling-coach": patch
+"@enduragent/core": patch
 ---
 
 Tag the local usage-ledger turn line with the prompt template hash. The turn line now carries an optional `templateHash` so a recorded latency/timing sample is attributable to the exact prompt revision that produced it, without a timestamp join against the chat-store. The value is already computed at the append site; only the turn line carries it (the per-generation line stays as-is). Additive and optional — existing ledger lines and readers are unaffected.

--- a/.changeset/usage-ledger-template-hash.md
+++ b/.changeset/usage-ledger-template-hash.md
@@ -1,0 +1,5 @@
+---
+"cycling-coach": patch
+---
+
+Tag the local usage-ledger turn line with the prompt template hash. The turn line now carries an optional `templateHash` so a recorded latency/timing sample is attributable to the exact prompt revision that produced it, without a timestamp join against the chat-store. The value is already computed at the append site; only the turn line carries it (the per-generation line stays as-is). Additive and optional — existing ledger lines and readers are unaffected.

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "snapshot:section-11": "tsx tools/snapshot-section-11.ts",
     "check-parity": "tsx tools/check-metric-parity.ts",
     "fuzz-parity": "tsx tools/fuzz-parity.ts",
-    "coverage:reference": "tsx tools/measure-reference-coverage.ts"
+    "coverage:reference": "tsx tools/measure-reference-coverage.ts",
+    "usage:baseline": "tsx tools/usage-baseline.ts"
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.0",

--- a/packages/core/src/agent/coach-agent.ts
+++ b/packages/core/src/agent/coach-agent.ts
@@ -354,6 +354,7 @@ export class CoachAgent {
             provider: this.config.llm.provider,
             model: this.config.llm.model,
             durationMs: Date.now() - turnStart,
+            templateHash,
             ...usageFieldsFromResult(result),
           });
 

--- a/packages/core/src/coach-home.ts
+++ b/packages/core/src/coach-home.ts
@@ -25,7 +25,7 @@ import { join } from "node:path";
 
 const LEGACY_CYCLING_COACH_BASENAME = ".cycling-coach";
 
-function expandTilde(p: string): string {
+export function expandTilde(p: string): string {
   if (p === "~") return homedir();
   if (p.startsWith("~/")) return join(homedir(), p.slice(2));
   return p;

--- a/packages/core/src/usage-ledger.ts
+++ b/packages/core/src/usage-ledger.ts
@@ -16,6 +16,10 @@ export interface UsageLedgerLine {
   // boot line. On a turn line the token/cost figures are the final successful
   // generation's, not a sum across retry/compaction attempts.
   caller?: "chat" | "flush" | "compact";
+  // Prompt-template lineage of the turn (computeTemplateHash). Present only on
+  // kind:"turn" lines, where it makes a latency/usage sample self-attributable
+  // to a prompt revision without a timestamp join against the chat-store JSONL.
+  templateHash?: string;
   steps?: number;
   inputTokens?: number;
   outputTokens?: number;

--- a/packages/core/tests/usage-ledger.test.ts
+++ b/packages/core/tests/usage-ledger.test.ts
@@ -29,6 +29,7 @@ function ledgerLine(overrides: Partial<UsageLedgerLine> = {}): UsageLedgerLine {
     provider: "anthropic",
     model: "claude-test",
     durationMs: 12,
+    templateHash: undefined,
     steps: 1,
     inputTokens: 5,
     outputTokens: 3,
@@ -136,6 +137,7 @@ describe("appendUsageLine", () => {
       dir,
       ledgerLine({
         kind: "turn",
+        templateHash: "0123456789abcdef",
         inputTokens: 30,
         outputTokens: 12,
         totalTokens: 42,
@@ -153,6 +155,19 @@ describe("appendUsageLine", () => {
     expect(parsed.cacheReadTokens).toBe(7);
     expect(parsed.cacheWriteTokens).toBe(4);
     expect(parsed.cost?.total).toBe(0.03);
+    expect(parsed.templateHash).toBe("0123456789abcdef");
+  });
+
+  it("omits templateHash on a generate line and round-trips it on a turn line", async () => {
+    const { appendUsageLine } = await import("../src/usage-ledger.js");
+    appendUsageLine(dir, ledgerLine({ kind: "generate" }));
+    appendUsageLine(dir, ledgerLine({ kind: "turn", templateHash: "abcdef0123456789" }));
+
+    const [gen, turn] = readLines(dir).map((l) => JSON.parse(l) as UsageLedgerLine);
+    expect(gen.kind).toBe("generate");
+    expect(gen.templateHash).toBeUndefined();
+    expect(turn.kind).toBe("turn");
+    expect(turn.templateHash).toBe("abcdef0123456789");
   });
 
   it("rotates the ledger to .jsonl.1 once it crosses 10 MB", async () => {
@@ -496,5 +511,6 @@ describe("turn line — winning generation usage and cost", () => {
     expect(turnLine?.outputTokens).toBe(12);
     expect(turnLine?.totalTokens).toBe(42);
     expect(turnLine?.cost?.total).toBe(0.03);
+    expect(turnLine?.templateHash).toMatch(/^[0-9a-f]{16}$/);
   });
 });

--- a/tools/seed-usage-ledger.ts
+++ b/tools/seed-usage-ledger.ts
@@ -1,0 +1,144 @@
+/**
+ * Seeds an ISOLATED usage-ledger.jsonl with a handful of real chat turns so the
+ * `usage:baseline` summarizer can be demonstrated without a multi-day wait.
+ * Turns run on the operator's configured provider (codex = subscription, no
+ * marginal cost; anthropic is cost-guarded to the cheap Haiku model). The
+ * provider's auth must be reachable from the isolated home — for codex, copy
+ * `auth-profiles.json` into it first (see the run sequence at the bottom).
+ *
+ * SAFETY INVARIANT: this tool refuses to run unless CYCLING_COACH_HOME points
+ * at a non-default, isolated directory. It must be impossible to write
+ * synthetic turns into the operator's real ledger (the one that will hold the
+ * genuine >=3-day baseline).
+ *
+ * CAVEAT (read before trusting numbers): these turns fire back-to-back within
+ * seconds, so every turn after the first hits a warm prompt cache (~5-minute
+ * provider-side TTL). Real athlete usage is spaced hours/days apart and almost
+ * never reuses the cache. This sample therefore shows an inflated cache-read
+ * ratio and is a TOOL SMOKE-TEST, not a faithful baseline.
+ */
+import { homedir } from "node:os";
+import { resolve, join } from "node:path";
+
+import { loadConfig, resolveConfigSecrets, CoachAgent, USAGE_LEDGER_FILE } from "@enduragent/core";
+import { cyclingSport } from "@enduragent/sport-cycling";
+
+// Respect the operator's configured provider (their real auth runs the turns).
+// The cheap-model cost guard for the metered anthropic path is applied AFTER
+// loadConfig (in main), where the provider is resolved from env AND config.yaml
+// — resolving it from the LLM_PROVIDER env var alone would mis-fire for a
+// yaml-configured codex operator and force a Claude model onto the codex bridge.
+const HAIKU = "claude-haiku-4-5-20251001";
+
+function expandTilde(p: string): string {
+  if (p === "~") return homedir();
+  if (p.startsWith("~/")) return join(homedir(), p.slice(2));
+  return p;
+}
+
+// --- Hard safety guard --------------------------------------------------------
+const rawHome = process.env.CYCLING_COACH_HOME;
+if (rawHome === undefined || rawHome.trim() === "") {
+  console.error(
+    "REFUSING TO RUN: CYCLING_COACH_HOME is not set.\n" +
+      "This tool writes synthetic turns and must target an isolated dir.\n" +
+      "Set CYCLING_COACH_HOME to a throwaway absolute path, e.g.:\n" +
+      "  CYCLING_COACH_HOME=$(mktemp -d) pnpm exec tsx --env-file=.env tools/seed-usage-ledger.ts",
+  );
+  process.exit(1);
+}
+const isolatedHome = resolve(expandTilde(rawHome.trim()));
+const FORBIDDEN = [
+  resolve(join(homedir(), ".cycling-coach")), // tier-2 legacy default
+  resolve(join(homedir(), ".enduragent", "cycling")), // tier-3 canonical default
+];
+if (FORBIDDEN.includes(isolatedHome)) {
+  console.error(
+    `REFUSING TO RUN: CYCLING_COACH_HOME resolves to a DEFAULT data dir (${isolatedHome}).\n` +
+      "That is the operator's real ledger location. Point it at a throwaway dir instead.",
+  );
+  process.exit(1);
+}
+
+const MESSAGES = [
+  "Hey coach, did 90 minutes endurance this morning, legs felt good.",
+  "What should tomorrow look like if I want to keep building base?",
+  "I'm a bit sore in the quads, normal?",
+  "My FTP is 247W. Is that something I should retest soon?",
+  "Slept badly last night, only 5 hours. Should I still ride hard today?",
+  "Planning a 4-hour gravel ride Saturday — how do I fuel it?",
+  "Felt flat on the bike all week. Overtraining or just life?",
+  "Quick one: zone 2 power range for me?",
+];
+
+async function main(): Promise<void> {
+  // loadConfig() reads CYCLING_COACH_HOME (via getCoachHome) for dataDir and
+  // resolves the provider from env + config.yaml. Cost guard: only the metered
+  // anthropic path — if anthropic is the resolved provider and the operator
+  // pinned no model via env, force the cheap Haiku model so the smoke run stays
+  // cheap. Codex/others run untouched (codex = subscription, no marginal cost).
+  const loaded = loadConfig();
+  if (loaded.llm.provider === "anthropic" && !process.env.LLM_MODEL) {
+    loaded.llm.model = HAIKU;
+    if (!process.env.LLM_FLUSH_MODEL) loaded.llm.flushModel = HAIKU;
+  }
+  const config = await resolveConfigSecrets(loaded);
+
+  if (resolve(config.dataDir) !== isolatedHome) {
+    console.error(
+      `REFUSING TO RUN: resolved config.dataDir (${config.dataDir}) != isolated home (${isolatedHome}).\n` +
+        "loadConfig did not honor CYCLING_COACH_HOME as expected — aborting to avoid touching the real ledger.\n" +
+        "Pass an ABSOLUTE path (mktemp -d gives one).",
+    );
+    process.exit(1);
+  }
+  // Auth is provider-specific: the metered providers need an apiKey; codex
+  // authenticates via the auth profile copied into the isolated home. Don't
+  // hard-gate on apiKey — let a real auth failure surface per-turn below.
+  if (config.llm.provider !== "openai-codex" && !config.llm.apiKey) {
+    console.error(
+      `No API key for provider '${config.llm.provider}'. Set the provider's key in .env, ` +
+        "or use the codex auth profile. Aborting.",
+    );
+    process.exit(1);
+  }
+  console.log(`Provider: ${config.llm.provider}  model: ${config.llm.model}`);
+
+  const agent = new CoachAgent(cyclingSport, config);
+  const chatId = "seed-smoke";
+
+  console.log(`Seeding ${MESSAGES.length} Haiku turns into ${config.dataDir} ...`);
+  for (let i = 0; i < MESSAGES.length; i++) {
+    const msg = MESSAGES[i];
+    process.stdout.write(`  [${i + 1}/${MESSAGES.length}] `);
+    try {
+      const reply = await agent.chat(chatId, msg);
+      console.log(`ok (${reply.length} chars)`);
+    } catch (err) {
+      console.log(`FAILED: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  const ledgerPath = join(config.dataDir, USAGE_LEDGER_FILE);
+  console.log("\nDone. Isolated ledger written to:");
+  console.log(`  ${ledgerPath}`);
+  console.log(
+    "\nCAVEAT: back-to-back turns share a warm prompt cache (~5-min TTL), so the\n" +
+      "cache-read ratio here is inflated vs real spaced usage. Smoke-test, not a baseline.\n" +
+      `Summarize it with: pnpm usage:baseline --data-dir ${config.dataDir}`,
+  );
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});
+
+// Run sequence (isolates the ledger; never touches the real ~/.cycling-coach):
+//
+//   export CYCLING_COACH_HOME="$(mktemp -d -t cc-ledger-smoke)"
+//   # codex auth lives in the data dir — copy the profile into the isolated home:
+//   cp ~/.cycling-coach/auth-profiles.json "$CYCLING_COACH_HOME"/ 2>/dev/null || true
+//   pnpm exec tsx --env-file=.env tools/seed-usage-ledger.ts
+//   pnpm usage:baseline --data-dir "$CYCLING_COACH_HOME"
+//   rm -rf "$CYCLING_COACH_HOME"   # disposable

--- a/tools/seed-usage-ledger.ts
+++ b/tools/seed-usage-ledger.ts
@@ -21,6 +21,7 @@ import { homedir } from "node:os";
 import { resolve, join } from "node:path";
 
 import { loadConfig, resolveConfigSecrets, CoachAgent, USAGE_LEDGER_FILE } from "@enduragent/core";
+import { expandTilde } from "../packages/core/src/coach-home.js";
 import { cyclingSport } from "@enduragent/sport-cycling";
 
 // Respect the operator's configured provider (their real auth runs the turns).
@@ -29,12 +30,6 @@ import { cyclingSport } from "@enduragent/sport-cycling";
 // — resolving it from the LLM_PROVIDER env var alone would mis-fire for a
 // yaml-configured codex operator and force a Claude model onto the codex bridge.
 const HAIKU = "claude-haiku-4-5-20251001";
-
-function expandTilde(p: string): string {
-  if (p === "~") return homedir();
-  if (p.startsWith("~/")) return join(homedir(), p.slice(2));
-  return p;
-}
 
 // --- Hard safety guard --------------------------------------------------------
 const rawHome = process.env.CYCLING_COACH_HOME;

--- a/tools/usage-baseline.test.ts
+++ b/tools/usage-baseline.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  parseCli,
+  resolveDataDir,
+  parseLedger,
+  selectLines,
+  percentile,
+  mean,
+  safeDiv,
+  buildReport,
+  type LedgerLineWithLineage,
+} from "./usage-baseline.js";
+
+const DAY = 24 * 60 * 60 * 1000;
+const T0 = 1_700_000_000_000; // fixed anchor; the tool never reads wall-clock
+
+function line(over: Partial<LedgerLineWithLineage>): LedgerLineWithLineage {
+  return {
+    ts: T0,
+    kind: "turn",
+    provider: "anthropic",
+    model: "claude",
+    durationMs: 1000,
+    caller: "chat",
+    ...over,
+  };
+}
+function jsonl(lines: LedgerLineWithLineage[]): string {
+  return lines.map((l) => JSON.stringify(l)).join("\n") + "\n";
+}
+
+describe("percentile — nearest-rank, deterministic", () => {
+  it("returns null on an empty sample", () => {
+    expect(percentile([], 50)).toBeNull();
+  });
+  it("p50 of [1,2,3,4] is 2 (rank ceil(0.5*4)=2)", () => {
+    expect(percentile([1, 2, 3, 4], 50)).toBe(2);
+  });
+  it("p95 of 1..100 is 95", () => {
+    const vals = Array.from({ length: 100 }, (_, i) => i + 1);
+    expect(percentile(vals, 95)).toBe(95);
+  });
+  it("p0 is the min, p100 is the max", () => {
+    expect(percentile([5, 1, 9, 3], 0)).toBe(1);
+    expect(percentile([5, 1, 9, 3], 100)).toBe(9);
+  });
+  it("single element returns that element at every percentile", () => {
+    expect(percentile([42], 50)).toBe(42);
+    expect(percentile([42], 95)).toBe(42);
+  });
+  it("does not mutate the input array", () => {
+    const input = [3, 1, 2];
+    percentile(input, 50);
+    expect(input).toEqual([3, 1, 2]);
+  });
+});
+
+describe("mean / safeDiv guards", () => {
+  it("mean of empty is null", () => {
+    expect(mean([])).toBeNull();
+  });
+  it("safeDiv guards zero / negative / NaN denominators", () => {
+    expect(safeDiv(5, 0)).toBeNull();
+    expect(safeDiv(5, -1)).toBeNull();
+    expect(safeDiv(5, NaN)).toBeNull();
+    expect(safeDiv(4, 2)).toBe(2);
+  });
+});
+
+describe("parseLedger", () => {
+  it("skips blank and malformed lines, keeps well-formed ones", () => {
+    const raw = [JSON.stringify(line({})), "", "{ not json", "null", JSON.stringify({ foo: 1 })].join(
+      "\n",
+    );
+    expect(parseLedger(raw)).toHaveLength(1);
+  });
+});
+
+describe("selectLines — kind + caller filter", () => {
+  const lines = [
+    line({ kind: "turn", caller: "chat" }),
+    line({ kind: "turn", caller: "flush" }),
+    line({ kind: "generate", caller: "chat" }),
+    line({ kind: "boot", caller: undefined }),
+  ];
+  it("defaults to kind=turn caller=chat", () => {
+    expect(selectLines(lines, "turn", "chat")).toHaveLength(1);
+  });
+  it("--kind generate selects the generate line", () => {
+    expect(selectLines(lines, "generate", "chat")).toHaveLength(1);
+  });
+  it("caller=all keeps every line of the kind", () => {
+    expect(selectLines(lines, "turn", "all")).toHaveLength(2);
+  });
+  it("--kind boot ignores the caller filter (boot lines carry no caller)", () => {
+    expect(selectLines(lines, "boot", "chat")).toHaveLength(1);
+  });
+});
+
+describe("parseCli", () => {
+  it("defaults to kind=turn caller=chat json=false", () => {
+    expect(parseCli([])).toEqual({ kind: "turn", caller: "chat", json: false });
+  });
+  it("accepts --flag value and --flag=value spellings", () => {
+    expect(parseCli(["--data-dir", "/tmp/x", "--kind", "generate"])).toMatchObject({
+      dataDir: "/tmp/x",
+      kind: "generate",
+    });
+    expect(parseCli(["--data-dir=/tmp/y", "--caller=all", "--json"])).toMatchObject({
+      dataDir: "/tmp/y",
+      caller: "all",
+      json: true,
+    });
+  });
+  it("rejects unknown flags and bad enum values", () => {
+    expect(() => parseCli(["--nope"])).toThrow(/unknown flag/);
+    expect(() => parseCli(["--kind", "bogus"])).toThrow(/--kind/);
+  });
+  it("rejects an empty required value (avoids silent fallback to the real home)", () => {
+    expect(() => parseCli(["--data-dir="])).toThrow(/non-empty value/);
+    expect(() => parseCli(["--data-dir", ""])).toThrow(/non-empty value/);
+  });
+  it("rejects an inline value on the boolean --json flag", () => {
+    expect(() => parseCli(["--json=false"])).toThrow(/--json takes no value/);
+  });
+});
+
+describe("resolveDataDir precedence", () => {
+  it("--data-dir wins over env", () => {
+    const prev = process.env.CYCLING_COACH_HOME;
+    process.env.CYCLING_COACH_HOME = "/env/path";
+    try {
+      expect(resolveDataDir("/flag/path")).toEqual({ dir: "/flag/path", source: "--data-dir" });
+    } finally {
+      if (prev === undefined) delete process.env.CYCLING_COACH_HOME;
+      else process.env.CYCLING_COACH_HOME = prev;
+    }
+  });
+  it("env is used when no flag is given", () => {
+    const prev = process.env.CYCLING_COACH_HOME;
+    process.env.CYCLING_COACH_HOME = "/env/path";
+    try {
+      expect(resolveDataDir(undefined)).toEqual({
+        dir: "/env/path",
+        source: "CYCLING_COACH_HOME",
+      });
+    } finally {
+      if (prev === undefined) delete process.env.CYCLING_COACH_HOME;
+      else process.env.CYCLING_COACH_HOME = prev;
+    }
+  });
+});
+
+describe("buildReport", () => {
+  it("groups by templateHash; absent => 'unknown'", () => {
+    const raw = jsonl([
+      line({ ts: T0, templateHash: "aaa" }),
+      line({ ts: T0 + DAY, templateHash: "aaa" }),
+      line({ ts: T0 + 2 * DAY }), // no templateHash
+    ]);
+    const r = buildReport({ ledgerPath: "/p", dataDirSource: "--data-dir", raw, kind: "turn", caller: "chat" });
+    const hashes = r.groups.map((g) => g.templateHash);
+    expect(hashes).toEqual(["aaa", "unknown"]); // sorted
+    expect(r.groups.find((g) => g.templateHash === "aaa")!.count).toBe(2);
+  });
+
+  it("computes a >=3-day span without a warning, <3 days warns", () => {
+    const wide = buildReport({
+      ledgerPath: "/p",
+      dataDirSource: "x",
+      raw: jsonl([line({ ts: T0 }), line({ ts: T0 + 4 * DAY })]),
+      kind: "turn",
+      caller: "chat",
+    });
+    expect(wide.window.spanDays).toBeCloseTo(4);
+    expect(wide.window.spanWarning).toBeNull();
+
+    const narrow = buildReport({
+      ledgerPath: "/p",
+      dataDirSource: "x",
+      raw: jsonl([line({ ts: T0 }), line({ ts: T0 + DAY })]),
+      kind: "turn",
+      caller: "chat",
+    });
+    expect(narrow.window.spanWarning).toMatch(/below the 3-day minimum/);
+  });
+
+  it("cache-read: per-line mean/p50 + overall ratio, divide-by-zero safe", () => {
+    const raw = jsonl([
+      line({ inputTokens: 100, cacheReadTokens: 50 }), // ratio 0.5
+      line({ inputTokens: 200, cacheReadTokens: 200 }), // ratio 1.0
+      line({ inputTokens: 0, cacheReadTokens: 0 }), // excluded (no positive input)
+      line({ inputTokens: undefined, cacheReadTokens: 10 }), // excluded
+    ]);
+    const g = buildReport({ ledgerPath: "/p", dataDirSource: "x", raw, kind: "turn", caller: "chat" }).groups[0];
+    expect(g.cacheRead.ratioSampleSize).toBe(2);
+    expect(g.cacheRead.perLineRatioMean).toBeCloseTo(0.75);
+    expect(g.cacheRead.perLineRatioP50).toBe(0.5); // nearest-rank p50 of [0.5,1.0] -> rank ceil(0.5*2)=1 -> sorted[0]=0.5
+    expect(g.cacheRead.overallRatio).toBeCloseTo(250 / 300); // sum-based
+  });
+
+  it("an all-zero-input group yields null ratios, never NaN", () => {
+    const raw = jsonl([line({ inputTokens: 0, cacheReadTokens: 0 })]);
+    const g = buildReport({ ledgerPath: "/p", dataDirSource: "x", raw, kind: "turn", caller: "chat" }).groups[0];
+    expect(g.cacheRead.perLineRatioMean).toBeNull();
+    expect(g.cacheRead.overallRatio).toBeNull();
+  });
+
+  it("cost: sums + means only lines carrying a cost object", () => {
+    const raw = jsonl([
+      line({ cost: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, total: 0.02 } }),
+      line({ cost: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, total: 0.04 } }),
+      line({}), // no cost — skipped, NOT counted as 0
+    ]);
+    const g = buildReport({ ledgerPath: "/p", dataDirSource: "x", raw, kind: "turn", caller: "chat" }).groups[0];
+    expect(g.cost.costedLines).toBe(2);
+    expect(g.cost.total).toBeCloseTo(0.06);
+    expect(g.cost.meanPerTurn).toBeCloseTo(0.03); // mean over costed lines only
+  });
+
+  it("latency percentiles use durationMs", () => {
+    const raw = jsonl([1, 2, 3, 4].map((d) => line({ durationMs: d * 1000 })));
+    const g = buildReport({ ledgerPath: "/p", dataDirSource: "x", raw, kind: "turn", caller: "chat" }).groups[0];
+    expect(g.latencyMs.p50).toBe(2000);
+    expect(g.latencyMs.min).toBe(1000);
+    expect(g.latencyMs.max).toBe(4000);
+  });
+
+  it("empty selection: no groups, span null, warning set", () => {
+    const r = buildReport({ ledgerPath: "/p", dataDirSource: "x", raw: "", kind: "turn", caller: "chat" });
+    expect(r.groups).toHaveLength(0);
+    expect(r.window.spanDays).toBeNull();
+    expect(r.window.spanWarning).toMatch(/no selected lines/);
+  });
+});

--- a/tools/usage-baseline.test.ts
+++ b/tools/usage-baseline.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 
+import type { UsageLedgerLine } from "../packages/core/src/usage-ledger.js";
 import {
   parseCli,
   resolveDataDir,
@@ -9,13 +10,12 @@ import {
   mean,
   safeDiv,
   buildReport,
-  type LedgerLineWithLineage,
 } from "./usage-baseline.js";
 
 const DAY = 24 * 60 * 60 * 1000;
 const T0 = 1_700_000_000_000; // fixed anchor; the tool never reads wall-clock
 
-function line(over: Partial<LedgerLineWithLineage>): LedgerLineWithLineage {
+function line(over: Partial<UsageLedgerLine>): UsageLedgerLine {
   return {
     ts: T0,
     kind: "turn",
@@ -26,7 +26,7 @@ function line(over: Partial<LedgerLineWithLineage>): LedgerLineWithLineage {
     ...over,
   };
 }
-function jsonl(lines: LedgerLineWithLineage[]): string {
+function jsonl(lines: UsageLedgerLine[]): string {
   return lines.map((l) => JSON.stringify(l)).join("\n") + "\n";
 }
 

--- a/tools/usage-baseline.ts
+++ b/tools/usage-baseline.ts
@@ -1,0 +1,399 @@
+/**
+ * usage:baseline — latency + cache-read + cost baseline over the usage ledger.
+ *
+ * Reads `<dataDir>/usage-ledger.jsonl` and prints a per-templateHash baseline
+ * summary so a real >=3-day snapshot is one command. The ledger line shape is
+ * owned by packages/core/src/usage-ledger.ts (UsageLedgerLine).
+ *
+ * Data-dir resolution (first match wins):
+ *   1. --data-dir <path>
+ *   2. CYCLING_COACH_HOME env-var
+ *   3. getCoachHome("cycling-coach")   (its own legacy ~/.cycling-coach fallback)
+ *
+ * Percentile method: NEAREST-RANK (no interpolation). For a sorted ascending
+ * sample of n values and p in [0,100], rank = clamp(ceil(p/100 * n), 1, n) and
+ * the result is sorted[rank-1]. Deterministic and exactly reproducible; chosen
+ * over linear interpolation so the baseline numbers are stable values drawn
+ * from the observed sample rather than synthetic in-between values.
+ *
+ * Per-turn token/cost figures are the FINAL successful generation's, not a sum
+ * across retry/compaction attempts (see usage-ledger.ts). This tool only reads
+ * the live ledger; data rotated to usage-ledger.jsonl.1 at 10 MB is not read.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { USAGE_LEDGER_FILE, type UsageLedgerLine } from "../packages/core/src/usage-ledger.js";
+import { getCoachHome } from "../packages/core/src/coach-home.js";
+
+// `templateHash` lands on the ledger turn line via the lineage change; widen
+// defensively so the tool also handles older lines that predate it (bucketed
+// under "unknown").
+export type LedgerLineWithLineage = UsageLedgerLine & { templateHash?: string };
+
+const UNKNOWN_TEMPLATE = "unknown";
+const MIN_SPAN_DAYS = 3;
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+// ─── CLI ────────────────────────────────────────────────────────────────
+
+export interface CliArgs {
+  dataDir?: string;
+  kind: UsageLedgerLine["kind"];
+  caller?: UsageLedgerLine["caller"] | "all";
+  json: boolean;
+}
+
+const KIND_VALUES = new Set(["generate", "turn", "boot"]);
+const CALLER_VALUES = new Set(["chat", "flush", "compact", "all"]);
+
+// Accepts both `--flag=value` and `--flag value`. Flags: --data-dir, --kind,
+// --caller, --json.
+export function parseCli(argv: readonly string[]): CliArgs {
+  const out: CliArgs = { kind: "turn", caller: "chat", json: false };
+  for (let i = 0; i < argv.length; i++) {
+    const tok = argv[i];
+    if (!tok.startsWith("--")) throw new Error(`unexpected positional arg: ${tok}`);
+    const eq = tok.indexOf("=");
+    const key = eq === -1 ? tok.slice(2) : tok.slice(2, eq);
+    const inlineVal = eq === -1 ? undefined : tok.slice(eq + 1);
+    const takeValue = (): string => {
+      const fromNext = inlineVal === undefined;
+      const val = fromNext ? argv[i + 1] : inlineVal;
+      if (val === undefined || val.length === 0 || (fromNext && val.startsWith("--"))) {
+        throw new Error(`flag --${key} requires a non-empty value`);
+      }
+      if (fromNext) i += 1;
+      return val;
+    };
+    switch (key) {
+      case "data-dir":
+        out.dataDir = takeValue();
+        break;
+      case "kind": {
+        const v = takeValue();
+        if (!KIND_VALUES.has(v)) {
+          throw new Error(`--kind must be one of generate|turn|boot (got '${v}')`);
+        }
+        out.kind = v as UsageLedgerLine["kind"];
+        break;
+      }
+      case "caller": {
+        const v = takeValue();
+        if (!CALLER_VALUES.has(v)) {
+          throw new Error(`--caller must be one of chat|flush|compact|all (got '${v}')`);
+        }
+        out.caller = v as CliArgs["caller"];
+        break;
+      }
+      case "json":
+        if (inlineVal !== undefined) throw new Error("flag --json takes no value");
+        out.json = true;
+        break;
+      default:
+        throw new Error(`unknown flag: ${tok}`);
+    }
+  }
+  return out;
+}
+
+export function resolveDataDir(dataDirFlag: string | undefined): { dir: string; source: string } {
+  if (dataDirFlag !== undefined && dataDirFlag.length > 0) {
+    return { dir: dataDirFlag, source: "--data-dir" };
+  }
+  const env = process.env.CYCLING_COACH_HOME;
+  if (env !== undefined && env.length > 0) {
+    return { dir: env, source: "CYCLING_COACH_HOME" };
+  }
+  return { dir: getCoachHome("cycling-coach"), source: 'getCoachHome("cycling-coach")' };
+}
+
+// ─── Parsing ──────────────────────────────────────────────────────────────
+
+// Parses JSONL, skipping blank lines and any line that fails to parse or lacks
+// a numeric ts / string kind (defensive: the ledger is a best-effort sink).
+export function parseLedger(raw: string): LedgerLineWithLineage[] {
+  const out: LedgerLineWithLineage[] = [];
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed.length === 0) continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch {
+      continue;
+    }
+    if (
+      parsed !== null &&
+      typeof parsed === "object" &&
+      typeof (parsed as { ts?: unknown }).ts === "number" &&
+      typeof (parsed as { kind?: unknown }).kind === "string"
+    ) {
+      out.push(parsed as LedgerLineWithLineage);
+    }
+  }
+  return out;
+}
+
+export function selectLines(
+  lines: readonly LedgerLineWithLineage[],
+  kind: UsageLedgerLine["kind"],
+  caller: CliArgs["caller"],
+): LedgerLineWithLineage[] {
+  // Boot lines never carry a caller, so the caller filter is skipped for them;
+  // otherwise `--kind boot` with the default `--caller chat` would select none.
+  return lines.filter(
+    (l) =>
+      l.kind === kind &&
+      (kind === "boot" || caller === "all" || caller === undefined || l.caller === caller),
+  );
+}
+
+// ─── Statistics ─────────────────────────────────────────────────────────
+
+// Nearest-rank percentile. p in [0,100]. Returns null for an empty sample.
+// Does NOT mutate the input. See the module header for the exact definition.
+export function percentile(values: readonly number[], p: number): number | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const rank = Math.min(Math.max(Math.ceil((p / 100) * sorted.length), 1), sorted.length);
+  return sorted[rank - 1];
+}
+
+export function mean(values: readonly number[]): number | null {
+  if (values.length === 0) return null;
+  return values.reduce((a, b) => a + b, 0) / values.length;
+}
+
+// Guarded division: a zero/negative/NaN denominator yields null, never NaN/Inf.
+export function safeDiv(numerator: number, denominator: number): number | null {
+  if (!Number.isFinite(denominator) || denominator <= 0) return null;
+  const r = numerator / denominator;
+  return Number.isFinite(r) ? r : null;
+}
+
+// ─── Aggregation ──────────────────────────────────────────────────────────
+
+export interface GroupSummary {
+  templateHash: string;
+  count: number;
+  latencyMs: {
+    p50: number | null;
+    p95: number | null;
+    mean: number | null;
+    min: number | null;
+    max: number | null;
+  };
+  cacheRead: {
+    // mean / p50 of per-line cacheReadTokens/inputTokens (lines without a
+    // positive inputTokens are excluded — they cannot form a ratio).
+    perLineRatioMean: number | null;
+    perLineRatioP50: number | null;
+    // overall sum(cacheRead)/sum(input) across the group.
+    overallRatio: number | null;
+    ratioSampleSize: number;
+  };
+  cost: {
+    // Only lines carrying a cost object contribute; lines lacking cost are
+    // skipped, NOT counted as 0.
+    total: number;
+    meanPerTurn: number | null;
+    costedLines: number;
+  };
+}
+
+export interface Report {
+  ledgerPath: string;
+  dataDirSource: string;
+  linesRead: number;
+  linesSelected: number;
+  kind: string;
+  caller: string;
+  window: {
+    oldestTs: number | null;
+    newestTs: number | null;
+    spanDays: number | null;
+    spanWarning: string | null;
+  };
+  groups: GroupSummary[];
+}
+
+function summarizeGroup(
+  templateHash: string,
+  lines: readonly LedgerLineWithLineage[],
+): GroupSummary {
+  const durations = lines.map((l) => l.durationMs).filter((d): d is number => Number.isFinite(d));
+
+  const perLineRatios: number[] = [];
+  let sumCacheRead = 0;
+  let sumInput = 0;
+  for (const l of lines) {
+    const input = l.inputTokens;
+    const cacheRead = l.cacheReadTokens ?? 0;
+    if (typeof input === "number" && input > 0) {
+      perLineRatios.push(cacheRead / input);
+      sumInput += input;
+      sumCacheRead += cacheRead;
+    }
+  }
+
+  const costTotals = lines
+    .map((l) => l.cost?.total)
+    .filter((c): c is number => Number.isFinite(c));
+
+  return {
+    templateHash,
+    count: lines.length,
+    latencyMs: {
+      p50: percentile(durations, 50),
+      p95: percentile(durations, 95),
+      mean: mean(durations),
+      min: durations.length > 0 ? Math.min(...durations) : null,
+      max: durations.length > 0 ? Math.max(...durations) : null,
+    },
+    cacheRead: {
+      perLineRatioMean: mean(perLineRatios),
+      perLineRatioP50: percentile(perLineRatios, 50),
+      overallRatio: safeDiv(sumCacheRead, sumInput),
+      ratioSampleSize: perLineRatios.length,
+    },
+    cost: {
+      total: costTotals.reduce((a, b) => a + b, 0),
+      meanPerTurn: mean(costTotals),
+      costedLines: costTotals.length,
+    },
+  };
+}
+
+export function buildReport(args: {
+  ledgerPath: string;
+  dataDirSource: string;
+  raw: string;
+  kind: UsageLedgerLine["kind"];
+  caller: CliArgs["caller"];
+}): Report {
+  const all = parseLedger(args.raw);
+  const selected = selectLines(all, args.kind, args.caller);
+
+  const tsValues = selected.map((l) => l.ts);
+  const oldestTs = tsValues.length > 0 ? Math.min(...tsValues) : null;
+  const newestTs = tsValues.length > 0 ? Math.max(...tsValues) : null;
+  const spanDays =
+    oldestTs !== null && newestTs !== null ? (newestTs - oldestTs) / MS_PER_DAY : null;
+  const spanWarning =
+    selected.length === 0
+      ? "no selected lines — nothing to summarize"
+      : spanDays !== null && spanDays < MIN_SPAN_DAYS
+        ? `window spans ${spanDays.toFixed(2)} day(s) — below the ${MIN_SPAN_DAYS}-day minimum a real baseline needs`
+        : null;
+
+  const byHash = new Map<string, LedgerLineWithLineage[]>();
+  for (const l of selected) {
+    const key = l.templateHash ?? UNKNOWN_TEMPLATE;
+    const bucket = byHash.get(key);
+    if (bucket) bucket.push(l);
+    else byHash.set(key, [l]);
+  }
+
+  const groups = [...byHash.keys()].sort().map((hash) => summarizeGroup(hash, byHash.get(hash)!));
+
+  return {
+    ledgerPath: args.ledgerPath,
+    dataDirSource: args.dataDirSource,
+    linesRead: all.length,
+    linesSelected: selected.length,
+    kind: args.kind,
+    caller: args.caller ?? "all",
+    window: { oldestTs, newestTs, spanDays, spanWarning },
+    groups,
+  };
+}
+
+// ─── Formatting ───────────────────────────────────────────────────────────
+
+function fmtNum(v: number | null, digits = 0): string {
+  return v === null ? "—" : v.toFixed(digits);
+}
+
+function fmtRatio(v: number | null): string {
+  return v === null ? "—" : `${(v * 100).toFixed(1)}%`;
+}
+
+function fmtIso(ts: number | null): string {
+  return ts === null ? "—" : new Date(ts).toISOString();
+}
+
+export function formatHuman(report: Report): string {
+  const out: string[] = [];
+  out.push(`usage:baseline`);
+  out.push(`  ledger: ${report.ledgerPath}  (via ${report.dataDirSource})`);
+  out.push(`  lines read: ${report.linesRead}  selected: ${report.linesSelected}`);
+  out.push(`  filter: kind=${report.kind} caller=${report.caller}`);
+  out.push(
+    `  window: ${fmtIso(report.window.oldestTs)} .. ${fmtIso(report.window.newestTs)} ` +
+      `(${report.window.spanDays === null ? "—" : report.window.spanDays.toFixed(2)} days)`,
+  );
+  if (report.window.spanWarning) out.push(`  WARNING: ${report.window.spanWarning}`);
+  out.push("");
+
+  for (const g of report.groups) {
+    out.push(`templateHash ${g.templateHash}  (n=${g.count})`);
+    out.push(
+      `  latency ms : p50 ${fmtNum(g.latencyMs.p50)}  p95 ${fmtNum(g.latencyMs.p95)}  ` +
+        `mean ${fmtNum(g.latencyMs.mean)}  min ${fmtNum(g.latencyMs.min)}  max ${fmtNum(g.latencyMs.max)}`,
+    );
+    out.push(
+      `  cache-read : per-line mean ${fmtRatio(g.cacheRead.perLineRatioMean)}  ` +
+        `p50 ${fmtRatio(g.cacheRead.perLineRatioP50)}  overall ${fmtRatio(g.cacheRead.overallRatio)}  ` +
+        `(n=${g.cacheRead.ratioSampleSize})`,
+    );
+    out.push(
+      `  cost       : total ${fmtNum(g.cost.total, 4)}  mean/turn ${fmtNum(g.cost.meanPerTurn, 4)}  ` +
+        `(costed lines=${g.cost.costedLines})`,
+    );
+    out.push("");
+  }
+  if (report.groups.length === 0) out.push("(no groups)");
+  return out.join("\n");
+}
+
+// ─── Entry ────────────────────────────────────────────────────────────────
+
+export function run(argv: readonly string[]): number {
+  const args = parseCli(argv);
+  const { dir, source } = resolveDataDir(args.dataDir);
+  const ledgerPath = join(dir, USAGE_LEDGER_FILE);
+
+  let raw: string;
+  try {
+    raw = readFileSync(ledgerPath, "utf-8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      console.error(`usage:baseline: no ledger at ${ledgerPath} (via ${source})`);
+      return 1;
+    }
+    throw err;
+  }
+
+  const report = buildReport({
+    ledgerPath,
+    dataDirSource: source,
+    raw,
+    kind: args.kind,
+    caller: args.caller,
+  });
+
+  if (args.json) {
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  } else {
+    console.log(formatHuman(report));
+  }
+  return 0;
+}
+
+const invokedAsScript =
+  process.argv[1] !== undefined && import.meta.url === `file://${process.argv[1]}`;
+if (invokedAsScript) {
+  process.exit(run(process.argv.slice(2)));
+}

--- a/tools/usage-baseline.ts
+++ b/tools/usage-baseline.ts
@@ -25,16 +25,11 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { USAGE_LEDGER_FILE, type UsageLedgerLine } from "../packages/core/src/usage-ledger.js";
-import { getCoachHome } from "../packages/core/src/coach-home.js";
-
-// `templateHash` lands on the ledger turn line via the lineage change; widen
-// defensively so the tool also handles older lines that predate it (bucketed
-// under "unknown").
-export type LedgerLineWithLineage = UsageLedgerLine & { templateHash?: string };
+import { getCoachHome, expandTilde } from "../packages/core/src/coach-home.js";
+import { MS_PER_DAY } from "../packages/core/src/io/date-keys.js";
 
 const UNKNOWN_TEMPLATE = "unknown";
 const MIN_SPAN_DAYS = 3;
-const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
 // ─── CLI ────────────────────────────────────────────────────────────────
 
@@ -100,11 +95,11 @@ export function parseCli(argv: readonly string[]): CliArgs {
 
 export function resolveDataDir(dataDirFlag: string | undefined): { dir: string; source: string } {
   if (dataDirFlag !== undefined && dataDirFlag.length > 0) {
-    return { dir: dataDirFlag, source: "--data-dir" };
+    return { dir: expandTilde(dataDirFlag), source: "--data-dir" };
   }
   const env = process.env.CYCLING_COACH_HOME;
   if (env !== undefined && env.length > 0) {
-    return { dir: env, source: "CYCLING_COACH_HOME" };
+    return { dir: expandTilde(env), source: "CYCLING_COACH_HOME" };
   }
   return { dir: getCoachHome("cycling-coach"), source: 'getCoachHome("cycling-coach")' };
 }
@@ -113,8 +108,8 @@ export function resolveDataDir(dataDirFlag: string | undefined): { dir: string; 
 
 // Parses JSONL, skipping blank lines and any line that fails to parse or lacks
 // a numeric ts / string kind (defensive: the ledger is a best-effort sink).
-export function parseLedger(raw: string): LedgerLineWithLineage[] {
-  const out: LedgerLineWithLineage[] = [];
+export function parseLedger(raw: string): UsageLedgerLine[] {
+  const out: UsageLedgerLine[] = [];
   for (const line of raw.split("\n")) {
     const trimmed = line.trim();
     if (trimmed.length === 0) continue;
@@ -130,17 +125,17 @@ export function parseLedger(raw: string): LedgerLineWithLineage[] {
       typeof (parsed as { ts?: unknown }).ts === "number" &&
       typeof (parsed as { kind?: unknown }).kind === "string"
     ) {
-      out.push(parsed as LedgerLineWithLineage);
+      out.push(parsed as UsageLedgerLine);
     }
   }
   return out;
 }
 
 export function selectLines(
-  lines: readonly LedgerLineWithLineage[],
+  lines: readonly UsageLedgerLine[],
   kind: UsageLedgerLine["kind"],
   caller: CliArgs["caller"],
-): LedgerLineWithLineage[] {
+): UsageLedgerLine[] {
   // Boot lines never carry a caller, so the caller filter is skipped for them;
   // otherwise `--kind boot` with the default `--caller chat` would select none.
   return lines.filter(
@@ -221,7 +216,7 @@ export interface Report {
 
 function summarizeGroup(
   templateHash: string,
-  lines: readonly LedgerLineWithLineage[],
+  lines: readonly UsageLedgerLine[],
 ): GroupSummary {
   const durations = lines.map((l) => l.durationMs).filter((d): d is number => Number.isFinite(d));
 
@@ -249,8 +244,8 @@ function summarizeGroup(
       p50: percentile(durations, 50),
       p95: percentile(durations, 95),
       mean: mean(durations),
-      min: durations.length > 0 ? Math.min(...durations) : null,
-      max: durations.length > 0 ? Math.max(...durations) : null,
+      min: percentile(durations, 0),
+      max: percentile(durations, 100),
     },
     cacheRead: {
       perLineRatioMean: mean(perLineRatios),
@@ -288,7 +283,7 @@ export function buildReport(args: {
         ? `window spans ${spanDays.toFixed(2)} day(s) — below the ${MIN_SPAN_DAYS}-day minimum a real baseline needs`
         : null;
 
-  const byHash = new Map<string, LedgerLineWithLineage[]>();
+  const byHash = new Map<string, UsageLedgerLine[]>();
   for (const l of selected) {
     const key = l.templateHash ?? UNKNOWN_TEMPLATE;
     const bucket = byHash.get(key);


### PR DESCRIPTION
## Summary

Tags the local usage/timing ledger's per-turn line with the prompt **template hash**, and lands the `usage:baseline` tooling that summarizes the ledger. This makes a recorded latency/timing sample attributable to the exact prompt revision that produced it, so a future cutover that grows the stable prompt prefix can be measured against a real before-state.

This is the **tooling** half of the latency-baseline work item — it does *not* collect the baseline itself (that's operator activity: the bot must run for ≥3 days with caching active to populate the ledger, then `pnpm usage:baseline`).

## What lands

- **`UsageLedgerLine.templateHash?`** — the turn-kind ledger line now carries the already-computed per-turn template hash. Additive and optional; existing ledger lines and readers are unaffected. The per-generation line is unchanged.
- **`tools/usage-baseline.ts`** (`pnpm usage:baseline`) — summarizes per-turn duration (p50/p95/mean/min/max) and cache-read ratio + cost from `<dataDir>/usage-ledger.jsonl` over a window, grouped by template hash, and **warns when the window is under 3 days**.
- **`tools/seed-usage-ledger.ts`** — exercises the summarizer against an isolated dir without waiting for real turns; refuses to run unless pointed at a throwaway `CYCLING_COACH_HOME`.

## Why

The whole point of the ledger seam is to make spend and latency attributable. Threading the template hash onto the line lets a latency sample be tied to the exact prompt revision **without a timestamp join** against the chat-store. The summarizer turns the raw JSONL into the p50/p95 + cache-ratio numbers the baseline needs.

## Testing

- Repo-wide typecheck (`pnpm check:types`, covers `tools/`): clean
- `packages/core/tests/usage-ledger.test.ts`: **15 pass**
- `tools/usage-baseline.test.ts`: **27 pass**
- Full `pnpm -r build` green; trademark + fixture-privacy gates clean

## Follow-up (not in this PR)

Capturing the actual **≥3-day** baseline is operator activity, not a code change: run the bot on `main` for ≥3 days with caching active (the ledger has had no real turns since 2026-05-09, so it is empty — it must be actively used), then `pnpm usage:baseline`. This must complete **before** the prompt-prefix cutover lands. Tracked as a deferred ticket in the progress dashboard.
