### PR TITLE
feat(core): add a rolling redacted local log substrate

### DIFF
--- a/packages/core/src/agent/coach-agent.ts
+++ b/packages/core/src/agent/coach-agent.ts
@@ -31,6 +31,7 @@ import { LLM } from "../llm.js";
 import { appendUsageLine, usageFieldsFromResult } from "../usage-ledger.js";
 import { createMemorySnapshot } from "../memory/snapshot.js";
 import { resolveUserTimezone, appendCurrentTimeLine } from "./user-time.js";
+import { createSubsystemLogger, type SubsystemLogger } from "../logging/index.js";
 
 const MAX_OVERFLOW_ATTEMPTS = 3;
 const MAX_TIMEOUT_ATTEMPTS = 2;
@@ -64,6 +65,7 @@ export class CoachAgent {
   private config: Config;
   private memory: Memory;
   private chatStore: ChatStore;
+  private log: SubsystemLogger;
   private tools: ToolSet;
   private systemPrompt: string;
   private tz: string;
@@ -91,6 +93,7 @@ export class CoachAgent {
     this.tz = resolveUserTimezone(config.session.timezone);
     this.memory = new Memory(config.dataDir, this.tz);
     this.chatStore = new ChatStore(config.dataDir, config.session.resetArchiveRetentionDays);
+    this.log = createSubsystemLogger("agent", config.dataDir);
 
     const intervals = config.intervals.apiKey
       ? makeChatClient({
@@ -185,7 +188,7 @@ export class CoachAgent {
           try {
             outcome = await this.flushMemory(history, "stale-reset");
           } catch (err) {
-            console.warn("Pre-reset memory flush failed; archiving session anyway", err);
+            this.log.warn("Pre-reset memory flush failed; archiving session anyway", err);
           }
         }
         const zeroWrite =
@@ -232,7 +235,7 @@ export class CoachAgent {
             await this.flushMemory(history, "trim");
           } catch (err) {
             flushed = false;
-            console.warn("Pre-compaction memory flush failed; keeping session file unchanged", err);
+            this.log.warn("Pre-compaction memory flush failed; keeping session file unchanged", err);
           }
         }
         try {
@@ -248,7 +251,7 @@ export class CoachAgent {
             this.chatStore.overwriteHistory(chatId, [summaryMsg, ...requeued, ...kept]);
           }
         } catch (err) {
-          console.warn("Dropped message summarization failed, continuing without summary", err);
+          this.log.warn("Dropped message summarization failed, continuing without summary", err);
           if (previousSummary) {
             summaryMsg = makeSummaryMessage(previousSummary);
           }
@@ -272,7 +275,7 @@ export class CoachAgent {
           try {
             await this.flushMemory(history, "soft-threshold");
           } catch (err) {
-            console.warn("Soft-threshold memory flush failed; continuing turn", err);
+            this.log.warn("Soft-threshold memory flush failed; continuing turn", err);
           }
         }
       }
@@ -306,7 +309,7 @@ export class CoachAgent {
             try {
               await this.flushMemory(messages, "pre-compaction");
             } catch (err) {
-              console.warn("In-turn memory flush failed; compacting without flush", err);
+              this.log.warn("In-turn memory flush failed; compacting without flush", err);
             }
           }
           messages = await summarizeInStages({ messages, ...this.compactionParams() });
@@ -368,13 +371,13 @@ export class CoachAgent {
                 try {
                   await this.flushMemory(messages, "overflow-recovery");
                 } catch (flushErr) {
-                  console.warn("In-turn memory flush failed; compacting without flush", flushErr);
+                  this.log.warn("In-turn memory flush failed; compacting without flush", flushErr);
                 }
               }
               messages = await summarizeInStages({ messages, ...this.compactionParams() });
               this.memory.reload();
             } catch (rescueErr) {
-              console.warn("Compaction rescue failed; rethrowing the original turn error", rescueErr);
+              this.log.warn("Compaction rescue failed; rethrowing the original turn error", rescueErr);
               if (err instanceof Error && err.cause === undefined) {
                 (err as Error & { cause?: unknown }).cause = rescueErr;
               }
@@ -391,7 +394,7 @@ export class CoachAgent {
                 messages = await summarizeInStages({ messages, ...this.compactionParams() });
                 this.memory.reload();
               } catch (rescueErr) {
-                console.warn("Compaction rescue failed; rethrowing the original turn error", rescueErr);
+                this.log.warn("Compaction rescue failed; rethrowing the original turn error", rescueErr);
                 if (err instanceof Error && err.cause === undefined) {
                   (err as Error & { cause?: unknown }).cause = rescueErr;
                 }
@@ -436,14 +439,14 @@ export class CoachAgent {
       ({ messages: history } = this.chatStore.load(chatId));
     } catch (err) {
       memoryFlushed = false;
-      console.warn("Pre-reset session load failed; archiving session anyway", err);
+      this.log.warn("Pre-reset session load failed; archiving session anyway", err);
     }
     if (history.length > 0) {
       try {
         await this.flushMemory(history, "explicit-reset");
       } catch (err) {
         memoryFlushed = false;
-        console.warn("Pre-reset memory flush failed; archiving session anyway", err);
+        this.log.warn("Pre-reset memory flush failed; archiving session anyway", err);
       }
     }
     this.archiveDeferred.delete(chatId);

--- a/packages/core/src/channels/telegram.ts
+++ b/packages/core/src/channels/telegram.ts
@@ -19,6 +19,7 @@ import { resolveRunningCs, type ResolvedCs } from "../reference/cs-resolution.js
 import { formatSyncReply } from "../reference/sync/format-sync-reply.js";
 import { formatSnapshotRaw } from "../reference/sync/snapshot-debug.js";
 import { sendSnapshotOutput } from "../reference/sync/send-snapshot.js";
+import { createSubsystemLogger } from "../logging/index.js";
 
 function formatRateLimitWait(err: unknown): string {
   const ms = extractRetryAfterMs(err);
@@ -112,6 +113,7 @@ export function createTelegramBot(
 ): Bot {
   logSecurityStartup(dataDir, binary.binaryName);
   const bot = createSecuredBot({ token, binary, dataDir });
+  const log = createSubsystemLogger("telegram", dataDir);
   const greeted = new Set<number>();
 
   // Resolve the running CS anchor once per turn from the latest synced profile so
@@ -130,7 +132,7 @@ export function createTelegramBot(
     try {
       ({ memoryFlushed } = await agent.resetSession(`telegram:${ctx.chat.id}`));
     } catch (err) {
-      console.error("Error resetting session:", err);
+      log.error("command_failed", err, { command: "start", chatId: `telegram:${ctx.chat.id}` });
       await ctx.reply(
         "Something went wrong resetting your session — your history is untouched. Please try /start again.",
       );
@@ -148,7 +150,7 @@ export function createTelegramBot(
       const response = await agent.chat(chatId, "/plan", turnDeps());
       await sendLongMessage(ctx, response);
     } catch (err) {
-      console.error("Error in /plan:", err);
+      log.error("command_failed", err, { command: "plan", chatId });
       if (isRateLimitError(err)) {
         await ctx.reply(`Rate limited — please try again in ${formatRateLimitWait(err)}.`);
       } else {
@@ -164,7 +166,7 @@ export function createTelegramBot(
       const response = await agent.chat(chatId, "/workout", turnDeps());
       await sendLongMessage(ctx, response);
     } catch (err) {
-      console.error("Error in /workout:", err);
+      log.error("command_failed", err, { command: "workout", chatId });
       if (isRateLimitError(err)) {
         await ctx.reply(`Rate limited — please try again in ${formatRateLimitWait(err)}.`);
       } else {
@@ -180,7 +182,7 @@ export function createTelegramBot(
       const response = await agent.chat(chatId, "/status", turnDeps());
       await sendLongMessage(ctx, response);
     } catch (err) {
-      console.error("Error in /status:", err);
+      log.error("command_failed", err, { command: "status", chatId });
       if (isRateLimitError(err)) {
         await ctx.reply(`Rate limited — please try again in ${formatRateLimitWait(err)}.`);
       } else {
@@ -198,7 +200,7 @@ export function createTelegramBot(
         });
         await ctx.reply(formatSyncReply(result));
       } catch (err) {
-        console.error("Error in /sync:", err);
+        log.error("command_failed", err, { command: "sync", chatId: `telegram:${ctx.chat.id}` });
         await ctx.reply("Sorry, something went wrong syncing. Please try again.");
       }
     });
@@ -223,7 +225,7 @@ export function createTelegramBot(
               ctx.replyWithDocument(new InputFile(buffer, filename)) as Promise<unknown>,
           });
         } catch (err) {
-          console.error("Error in /snapshot raw:", err);
+          log.error("command_failed", err, { command: "snapshot", chatId: `telegram:${ctx.chat.id}` });
           await ctx.reply("Sorry, something went wrong rendering the snapshot.");
         }
         return;
@@ -244,7 +246,7 @@ export function createTelegramBot(
       const response = await agent.chat(chatId, message, turnDeps());
       await sendLongMessage(ctx, response);
     } catch (err) {
-      console.error("Error in /review:", err);
+      log.error("command_failed", err, { command: "review", chatId });
       if (isRateLimitError(err)) {
         await ctx.reply(`Rate limited — please try again in ${formatRateLimitWait(err)}.`);
       } else {
@@ -268,7 +270,7 @@ export function createTelegramBot(
       const message = await buildWhatsNewMessage(binary.binaryName, info);
       await sendLongMessage(ctx, message);
     } catch (err) {
-      console.error("Error in /whatsnew:", err);
+      log.error("command_failed", err, { command: "whatsnew", chatId: `telegram:${ctx.chat.id}` });
       await ctx.reply("Sorry, couldn't fetch release notes. Please try again.");
     }
   });
@@ -292,7 +294,7 @@ export function createTelegramBot(
       // Telegram re-sends /update on next startup and we loop forever.
       void bot.stop().then(() => selfUpdate(binary.binaryName, info.latest));
     } catch (err) {
-      console.error("Error in /update:", err);
+      log.error("command_failed", err, { command: "update", chatId: `telegram:${ctx.chat.id}` });
       await ctx.reply(
         `Update failed. Please run \`npm install -g ${binary.binaryName}@${latest ?? "latest"} --ignore-scripts\` manually.`,
       );
@@ -318,7 +320,7 @@ export function createTelegramBot(
       const response = await agent.chat(chatId, ctx.message.text, turnDeps());
       await sendLongMessage(ctx, response);
     } catch (err) {
-      console.error("Error in chat:", err);
+      log.error("command_failed", err, { command: "chat", chatId });
       if (isRateLimitError(err)) {
         const wait = formatRateLimitWait(err);
         await ctx.reply(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -36,6 +36,16 @@ export type { GenerateOpts, GenerateResult } from "./llm-types.js";
 export { appendUsageLine, USAGE_LEDGER_FILE, USAGE_LEDGER_MAX_BYTES } from "./usage-ledger.js";
 export type { UsageLedgerLine } from "./usage-ledger.js";
 
+// ─── Logging substrate ────────────────────────────────────────────────
+export {
+  createSubsystemLogger,
+  createSubsystemLoggers,
+  serializeError,
+  LOG_LEVELS,
+  normalizeLogLevel,
+} from "./logging/index.js";
+export type { LogLine, LogLevel, SubsystemLogger, Subsystem } from "./logging/index.js";
+
 // ─── Memory ───────────────────────────────────────────────────────────
 export type { MemorySnapshot, MemoryStore, MemoryWriteSource } from "./memory.js";
 export { Memory } from "./memory/store.js";

--- a/packages/core/src/logging/index.ts
+++ b/packages/core/src/logging/index.ts
@@ -1,0 +1,17 @@
+export { LOG_LEVELS, normalizeLogLevel } from "./levels.js";
+export type { LogLevel } from "./levels.js";
+export { serializeError } from "./serialize-error.js";
+export { redactObject, REDACTION_SENTINEL } from "./redact.js";
+export {
+  createRootLogger,
+  pruneFileByAge,
+  LOG_FILE,
+  LOG_MAX_BYTES,
+  LOG_MAX_AGE_MS,
+} from "./logger.js";
+export type { LogLine, LogInput, RootLogger, RootLoggerOptions } from "./logger.js";
+export {
+  createSubsystemLogger,
+  createSubsystemLoggers,
+} from "./subsystem.js";
+export type { SubsystemLogger, Subsystem } from "./subsystem.js";

--- a/packages/core/src/logging/levels.ts
+++ b/packages/core/src/logging/levels.ts
@@ -1,0 +1,29 @@
+export const LOG_LEVELS = ["silent", "error", "warn", "info", "debug"] as const;
+
+export type LogLevel = (typeof LOG_LEVELS)[number];
+
+const LEVEL_ORDER: Record<LogLevel, number> = {
+  silent: 0,
+  error: 1,
+  warn: 2,
+  info: 3,
+  debug: 4,
+};
+
+export function normalizeLogLevel(s?: string): LogLevel {
+  const candidate = (s ?? "").trim().toLowerCase();
+  return (LOG_LEVELS as readonly string[]).includes(candidate)
+    ? (candidate as LogLevel)
+    : "info";
+}
+
+export function logLevelRank(level: LogLevel): number {
+  return LEVEL_ORDER[level];
+}
+
+// A line at `lineLevel` is emitted when the configured threshold is at least as
+// verbose. `silent` emits nothing; `debug` lets everything through.
+export function isLevelEnabled(lineLevel: LogLevel, threshold: LogLevel): boolean {
+  if (threshold === "silent") return false;
+  return LEVEL_ORDER[lineLevel] <= LEVEL_ORDER[threshold];
+}

--- a/packages/core/src/logging/logger.ts
+++ b/packages/core/src/logging/logger.ts
@@ -1,0 +1,156 @@
+import { appendFileSync, mkdirSync, renameSync, statSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { type LogLevel, normalizeLogLevel, isLevelEnabled } from "./levels.js";
+
+export const LOG_FILE = "log.jsonl";
+export const LOG_MAX_BYTES = 10 * 1024 * 1024;
+export const LOG_MAX_AGE_MS = 14 * 24 * 60 * 60 * 1000;
+
+export interface LogLine {
+  ts: string;
+  level: LogLevel;
+  component: string;
+  event: string;
+  chatId?: string;
+  turnId?: string;
+  syncTickId?: string;
+  [field: string]: unknown;
+}
+
+// The emit payload: the caller supplies component + event and any extra fields;
+// the logger stamps ts + level. Declared separately from LogLine (rather than
+// `Omit<LogLine, "ts" | "level">`) because an Omit over an index-signature
+// interface widens every named field to `unknown`.
+export interface LogInput {
+  component: string;
+  event: string;
+  [field: string]: unknown;
+}
+
+export interface RootLogger {
+  emit(level: LogLevel, line: LogInput): void;
+}
+
+export interface RootLoggerOptions {
+  // Test seams; production callers pass none.
+  maxBytes?: number;
+  maxAgeMs?: number;
+  now?: () => number;
+  threshold?: LogLevel;
+}
+
+let escalatedOnce = false;
+
+function consoleSink(level: LogLevel): (msg: string) => void {
+  if (level === "error") return console.error;
+  if (level === "warn") return console.warn;
+  return console.log;
+}
+
+// Drops file lines whose `ts` is older than the age cap. Returns the surviving
+// lines, or null when nothing needed pruning (so the caller can skip the
+// rewrite). Best-effort: an unparseable line is kept rather than dropped.
+function pruneAgedLines(raw: string, cutoffMs: number): string | null {
+  const lines = raw.split("\n").filter((l) => l.length > 0);
+  const kept: string[] = [];
+  let dropped = false;
+  for (const line of lines) {
+    let ts: number | undefined;
+    try {
+      const parsed = JSON.parse(line) as { ts?: string };
+      ts = parsed.ts !== undefined ? Date.parse(parsed.ts) : undefined;
+    } catch {
+      ts = undefined;
+    }
+    if (ts !== undefined && !Number.isNaN(ts) && ts < cutoffMs) {
+      dropped = true;
+      continue;
+    }
+    kept.push(line);
+  }
+  if (!dropped) return null;
+  return kept.length > 0 ? kept.join("\n") + "\n" : "";
+}
+
+export function pruneFileByAge(path: string, cutoffMs: number): void {
+  // Exported for unit-testing the age-cap prune with an injected timestamp.
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf-8");
+  } catch {
+    return;
+  }
+  const pruned = pruneAgedLines(raw, cutoffMs);
+  if (pruned === null) return;
+  try {
+    writeFileSync(path, pruned, { encoding: "utf-8", mode: 0o600 });
+  } catch {
+    // Swallow: an observability prune failure is not a turn failure.
+  }
+}
+
+export function createRootLogger(dataDir: string, options: RootLoggerOptions = {}): RootLogger {
+  const maxBytes = options.maxBytes ?? LOG_MAX_BYTES;
+  const maxAgeMs = options.maxAgeMs ?? LOG_MAX_AGE_MS;
+  const now = options.now ?? Date.now;
+  const threshold = options.threshold ?? normalizeLogLevel(process.env.CYCLING_COACH_LOG_LEVEL);
+  const dir = join(dataDir, "logs");
+  const path = join(dir, LOG_FILE);
+
+  function rotateIfNeeded(): void {
+    try {
+      if (statSync(path).size >= maxBytes) {
+        renameSync(path, `${path}.1`);
+        return;
+      }
+    } catch {
+      // File absent or unstat-able — nothing to rotate.
+      return;
+    }
+    pruneFileByAge(path, now() - maxAgeMs);
+  }
+
+  return {
+    emit(level, line) {
+      const record: LogLine = {
+        ...line,
+        ts: new Date(now()).toISOString(),
+        level,
+        component: line.component,
+        event: line.event,
+      };
+
+      if (isLevelEnabled(level, threshold)) {
+        const sink = consoleSink(level);
+        try {
+          sink(`[${record.component}] ${record.event}`);
+        } catch {
+          // Console may be closed in some run modes; never let it break a turn.
+        }
+      }
+
+      // The file is the durable channel and must NEVER throw — a full disk, a
+      // permission error, or an EROFS volume can never break a chat turn, a
+      // sync tick, or process startup.
+      try {
+        mkdirSync(dir, { recursive: true, mode: 0o700 });
+        rotateIfNeeded();
+        appendFileSync(path, JSON.stringify(record) + "\n", { encoding: "utf-8", mode: 0o600 });
+      } catch {
+        if (!escalatedOnce) {
+          escalatedOnce = true;
+          try {
+            console.warn("[logging] local log write failed — diagnostics are not being persisted.");
+          } catch {
+            // Even the escalation warning is best-effort.
+          }
+        }
+      }
+    },
+  };
+}
+
+export function __resetLoggingEscalationForTesting(): void {
+  escalatedOnce = false;
+}

--- a/packages/core/src/logging/redact.ts
+++ b/packages/core/src/logging/redact.ts
@@ -1,0 +1,38 @@
+export const REDACTION_SENTINEL = "[redacted]";
+
+// Substring, case-insensitive: a key like `x-api-key` or `Authorization` matches.
+const DENYLIST_KEY_SUBSTRINGS = ["authorization", "api_key", "apikey", "token", "cookie"];
+
+// Bounded so a hostile or cyclic object can never hang the logger.
+const MAX_REDACT_DEPTH = 6;
+
+function keyIsDenied(key: string): boolean {
+  const lower = key.toLowerCase();
+  return DENYLIST_KEY_SUBSTRINGS.some((needle) => lower.includes(needle));
+}
+
+// Walks an object/array, replacing the value of any denylisted key with a
+// sentinel (kept, not deleted, so the shape stays legible). Cycles are tracked
+// via a seen-set and depth is capped; both yield a sentinel rather than recurse
+// forever. Primitives pass through untouched — the key denylist is the contract,
+// not a value-shape scanner.
+export function redactObject(value: unknown): unknown {
+  return redactAt(value, 0, new WeakSet<object>());
+}
+
+function redactAt(value: unknown, depth: number, seen: WeakSet<object>): unknown {
+  if (value === null || typeof value !== "object") return value;
+  if (depth >= MAX_REDACT_DEPTH) return REDACTION_SENTINEL;
+  if (seen.has(value)) return REDACTION_SENTINEL;
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    return value.map((item) => redactAt(item, depth + 1, seen));
+  }
+
+  const out: Record<string, unknown> = {};
+  for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+    out[key] = keyIsDenied(key) ? REDACTION_SENTINEL : redactAt(child, depth + 1, seen);
+  }
+  return out;
+}

--- a/packages/core/src/logging/serialize-error.ts
+++ b/packages/core/src/logging/serialize-error.ts
@@ -1,0 +1,72 @@
+import { redactObject, REDACTION_SENTINEL } from "./redact.js";
+
+// Fields on a provider/SDK error that carry the outbound prompt or response
+// body — the conversation, the memory-bearing system prompt, the athlete's
+// reply text. They are NEVER copied onto the serialized output; this is what
+// makes the log file born redacted rather than redacted by a later follow-up.
+const DROP_FIELDS = new Set([
+  "requestBodyValues",
+  "responseBody",
+  "payload",
+  "body",
+  "data",
+]);
+
+// Provider/SDK error fields that are safe to keep for diagnosis.
+const KEEP_FIELDS = ["statusCode", "url", "provider"] as const;
+
+const MAX_STACK_CHARS = 1000;
+
+function trimStack(stack: unknown): string | undefined {
+  if (typeof stack !== "string") return undefined;
+  return stack.length > MAX_STACK_CHARS ? stack.slice(0, MAX_STACK_CHARS) : stack;
+}
+
+export function serializeError(err: unknown): Record<string, unknown> {
+  // Never throw: a circular or exotic error must yield a sentinel object, not
+  // crash the logger and so break a chat turn, a sync tick, or startup.
+  try {
+    if (!(err instanceof Error)) {
+      return { value: String(err) };
+    }
+
+    const out: Record<string, unknown> = {
+      name: err.name,
+      message: err.message,
+    };
+
+    const stack = trimStack(err.stack);
+    if (stack !== undefined) out.stack = stack;
+
+    const record = err as unknown as Record<string, unknown>;
+    for (const field of KEEP_FIELDS) {
+      const v = record[field];
+      if (v !== undefined) out[field] = v;
+    }
+
+    // Surviving own-enumerable fields (not the dropped payload class) are run
+    // through the recursive key denylist so a nested authorization/token/cookie
+    // never lands in the file.
+    for (const [key, value] of Object.entries(record)) {
+      if (DROP_FIELDS.has(key)) continue;
+      if (key === "name" || key === "message" || key === "stack") continue;
+      if ((KEEP_FIELDS as readonly string[]).includes(key)) continue;
+      const lower = key.toLowerCase();
+      if (
+        lower.includes("authorization") ||
+        lower.includes("api_key") ||
+        lower.includes("apikey") ||
+        lower.includes("token") ||
+        lower.includes("cookie")
+      ) {
+        out[key] = REDACTION_SENTINEL;
+        continue;
+      }
+      out[key] = redactObject(value);
+    }
+
+    return out;
+  } catch {
+    return { name: "UnserializableError" };
+  }
+}

--- a/packages/core/src/logging/subsystem.ts
+++ b/packages/core/src/logging/subsystem.ts
@@ -1,0 +1,64 @@
+import { type LogLevel } from "./levels.js";
+import { createRootLogger, type RootLogger, type RootLoggerOptions } from "./logger.js";
+import { serializeError } from "./serialize-error.js";
+
+type Fields = Record<string, unknown>;
+
+export interface SubsystemLogger {
+  debug(event: string, fields?: Fields): void;
+  info(event: string, fields?: Fields): void;
+  warn(event: string, err?: unknown, fields?: Fields): void;
+  error(event: string, err?: unknown, fields?: Fields): void;
+}
+
+const SUBSYSTEMS = ["sync", "telegram", "agent", "compaction", "memory", "audit"] as const;
+
+export type Subsystem = (typeof SUBSYSTEMS)[number];
+
+function emitErrBearing(
+  root: RootLogger,
+  level: LogLevel,
+  component: string,
+  event: string,
+  err?: unknown,
+  fields?: Fields,
+): void {
+  const errFields = err === undefined ? {} : { err: serializeError(err) };
+  root.emit(level, { component, event, ...errFields, ...fields });
+}
+
+export function createSubsystemLogger(
+  component: string,
+  dataDir: string,
+  options?: RootLoggerOptions,
+): SubsystemLogger {
+  const root = createRootLogger(dataDir, options);
+  return {
+    debug(event, fields) {
+      root.emit("debug", { component, event, ...fields });
+    },
+    info(event, fields) {
+      root.emit("info", { component, event, ...fields });
+    },
+    warn(event, err, fields) {
+      emitErrBearing(root, "warn", component, event, err, fields);
+    },
+    error(event, err, fields) {
+      emitErrBearing(root, "error", component, event, err, fields);
+    },
+  };
+}
+
+// The launch set of subsystem child loggers. More tags can be added cheaply by
+// calling createSubsystemLogger directly; these are the components the batch's
+// consumers tag against.
+export function createSubsystemLoggers(
+  dataDir: string,
+  options?: RootLoggerOptions,
+): Record<Subsystem, SubsystemLogger> {
+  const out = {} as Record<Subsystem, SubsystemLogger>;
+  for (const name of SUBSYSTEMS) {
+    out[name] = createSubsystemLogger(name, dataDir, options);
+  }
+  return out;
+}

--- a/packages/core/tests/logging.test.ts
+++ b/packages/core/tests/logging.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  mkdtempSync,
+  rmSync,
+  statSync,
+  readFileSync,
+  writeFileSync,
+  existsSync,
+  utimesSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  createSubsystemLogger,
+  createRootLogger,
+  serializeError,
+  pruneFileByAge,
+  LOG_FILE,
+  LOG_MAX_AGE_MS,
+} from "../src/logging/index.js";
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "cc-log-"));
+  vi.resetModules();
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+function logFilePath(dataDir: string): string {
+  return join(dataDir, "logs", LOG_FILE);
+}
+
+function readLines(dataDir: string): string[] {
+  return readFileSync(logFilePath(dataDir), "utf-8")
+    .split("\n")
+    .filter((l) => l.length > 0);
+}
+
+describe("subsystem logger — file sink", () => {
+  it("writes a JSONL line carrying ts, level, component, event", () => {
+    const log = createSubsystemLogger("agent", dir);
+    log.info("turn_started", { chatId: "telegram:i1" });
+
+    const lines = readLines(dir);
+    expect(lines).toHaveLength(1);
+    const parsed = JSON.parse(lines[lines.length - 1]) as Record<string, unknown>;
+    expect(parsed.ts).toBeTypeOf("string");
+    expect(parsed.level).toBe("info");
+    expect(parsed.component).toBe("agent");
+    expect(parsed.event).toBe("turn_started");
+    expect(parsed.chatId).toBe("telegram:i1");
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "writes the file at mode 0600 inside a 0700 logs dir",
+    () => {
+      const log = createSubsystemLogger("sync", dir);
+      log.info("tick");
+
+      const fileMode = statSync(logFilePath(dir)).mode & 0o777;
+      const dirMode = statSync(join(dir, "logs")).mode & 0o777;
+      expect(fileMode).toBe(0o600);
+      expect(dirMode).toBe(0o700);
+    },
+  );
+});
+
+describe("born-redacted invariant", () => {
+  it("redacts payload/requestBodyValues/responseBody and denylisted keys while keeping name/message/statusCode", () => {
+    const err = Object.assign(new Error("upstream blew up"), {
+      name: "APICallError",
+      statusCode: 429,
+      payload: { text: "ATHLETE HEALTH SECRET" },
+      requestBodyValues: { messages: ["SECRET PROMPT"] },
+      responseBody: "SECRET BODY",
+      headers: {
+        authorization: "Bearer SECRET",
+        api_key: "sk-SECRET",
+        token: "SECRET",
+        cookie: "SECRET",
+      },
+    });
+
+    const log = createSubsystemLogger("telegram", dir);
+    log.error("command_failed", err, { chatId: "telegram:i1" });
+
+    const raw = readLines(dir).join("\n");
+    expect(raw).not.toContain("ATHLETE HEALTH SECRET");
+    expect(raw).not.toContain("SECRET PROMPT");
+    expect(raw).not.toContain("SECRET BODY");
+    expect(raw).not.toContain("Bearer SECRET");
+    expect(raw).not.toContain("sk-SECRET");
+
+    expect(raw).toContain("APICallError");
+    expect(raw).toContain("upstream blew up");
+    expect(raw).toContain("429");
+  });
+});
+
+describe("size-cap rotation", () => {
+  it("rotates the live file to .jsonl.1 once it crosses the byte cap", () => {
+    const path = logFilePath(dir);
+    const root = createRootLogger(dir, { maxBytes: 256 });
+    // Seed the live file above the (tiny, injected) cap, then emit once.
+    root.emit("info", { component: "agent", event: "seed", filler: "x".repeat(512) });
+    expect(statSync(path).size).toBeGreaterThan(256);
+
+    root.emit("info", { component: "agent", event: "after_rotate" });
+
+    expect(existsSync(`${path}.1`)).toBe(true);
+    const live = readLines(dir);
+    expect(live).toHaveLength(1);
+    expect(JSON.parse(live[0]).event).toBe("after_rotate");
+  });
+});
+
+describe("age-cap retention", () => {
+  it("prunes lines older than the cap and keeps fresh ones", () => {
+    const now = Date.UTC(2000, 0, 15);
+    const oldTs = new Date(now - LOG_MAX_AGE_MS - 1000).toISOString();
+    const freshTs = new Date(now - 1000).toISOString();
+    const path = logFilePath(dir);
+    const root = createRootLogger(dir, { now: () => now });
+    // Prime the dir, then overwrite with a mixed-age file.
+    root.emit("info", { component: "agent", event: "prime" });
+    writeFileSync(
+      path,
+      [
+        JSON.stringify({ ts: oldTs, level: "info", component: "agent", event: "STALE_LINE" }),
+        JSON.stringify({ ts: freshTs, level: "info", component: "agent", event: "FRESH_LINE" }),
+      ].join("\n") + "\n",
+    );
+
+    pruneFileByAge(path, now - LOG_MAX_AGE_MS);
+
+    const raw = readFileSync(path, "utf-8");
+    expect(raw).not.toContain("STALE_LINE");
+    expect(raw).toContain("FRESH_LINE");
+  });
+
+  it("rolls aged content on the next emit when the file is under the size cap", () => {
+    const now = Date.UTC(2000, 0, 15);
+    const path = logFilePath(dir);
+    const root = createRootLogger(dir, { now: () => now });
+    root.emit("info", { component: "agent", event: "prime" });
+    writeFileSync(
+      path,
+      JSON.stringify({
+        ts: new Date(now - LOG_MAX_AGE_MS - 1000).toISOString(),
+        level: "info",
+        component: "agent",
+        event: "STALE_LINE",
+      }) + "\n",
+    );
+    // Touch back-date so the file modtime cannot mask the in-line age check.
+    const old = (now - LOG_MAX_AGE_MS - 1000) / 1000;
+    utimesSync(path, old, old);
+
+    root.emit("info", { component: "agent", event: "FRESH_EMIT" });
+
+    const raw = readFileSync(path, "utf-8");
+    expect(raw).not.toContain("STALE_LINE");
+    expect(raw).toContain("FRESH_EMIT");
+  });
+});
+
+describe("never throws on an unwritable target", () => {
+  it("does not throw when the parent of the logs dir is a regular file", () => {
+    // Point dataDir at a path whose parent is a file, so mkdir/open fails.
+    const blocker = join(dir, "block");
+    writeFileSync(blocker, "i am a file, not a dir");
+    const log = createSubsystemLogger("agent", join(blocker, "nested"));
+
+    expect(() => log.error("boom", new Error("x"))).not.toThrow();
+    expect(() => log.info("ok")).not.toThrow();
+  });
+});
+
+describe("serializeError unit cases", () => {
+  it("keeps name and message for a plain Error", () => {
+    const out = serializeError(new Error("plain failure"));
+    expect(out.name).toBe("Error");
+    expect(out.message).toBe("plain failure");
+  });
+
+  it("returns { value } for a non-Error without deep inspection", () => {
+    const out = serializeError({ not: "an error" });
+    expect(out).toEqual({ value: "[object Object]" });
+  });
+
+  it("does not throw and yields a sentinel for a circular error", () => {
+    const err = new Error("cyclic") as Error & { self?: unknown };
+    err.self = err;
+    let out: Record<string, unknown> = {};
+    expect(() => {
+      out = serializeError(err);
+    }).not.toThrow();
+    expect(out.name).toBe("Error");
+    expect(out.message).toBe("cyclic");
+    // The circular field is replaced by a sentinel, never recursed into.
+    expect(JSON.stringify(out)).toContain("[redacted]");
+  });
+
+  it("drops requestBodyValues/responseBody/payload entirely", () => {
+    const err = Object.assign(new Error("leak vector"), {
+      requestBodyValues: { messages: ["SECRET PROMPT"] },
+      responseBody: "SECRET BODY",
+      payload: { text: "SECRET REPLY" },
+    });
+    const out = serializeError(err);
+    const serialized = JSON.stringify(out);
+    expect(serialized).not.toContain("SECRET PROMPT");
+    expect(serialized).not.toContain("SECRET BODY");
+    expect(serialized).not.toContain("SECRET REPLY");
+    expect(out).not.toHaveProperty("requestBodyValues");
+    expect(out).not.toHaveProperty("responseBody");
+    expect(out).not.toHaveProperty("payload");
+  });
+});


### PR DESCRIPTION
Adds a rolling, born-redacted local diagnostic log so runtime failures are no longer console-only (and lost in unattended run modes), and so error dumps stop leaking athlete content into stdout.

- New `packages/core/src/logging/`: a JSONL sink under the per-binary data dir with a 10 MB size cap and a 14-day age cap, six subsystem child loggers, console kept as a secondary transport, and a logger that never throws (every fs call best-effort).
- A shared `serializeError` + a case-insensitive recursive key denylist (authorization / api_key / token / cookie) that drops request/response payload fields, so the file is redacted from the first byte.
- Routes the privacy-critical error-bearing console sites — the Telegram per-command catch dumps and the coach-agent raw-error warns — through the redactor; the interactive CLI prints stay console-first.

First in a stacked series of error-resilience changes; base `main`.

Changeset: none (operator-facing infra, no athlete-visible behavior change).

## Test plan
`pnpm check` and `pnpm test` green (new `logging.test.ts`: born-redacted invariant verified required-red against an identity serializer, plus rotation, age-cap, never-throws).
