### PR TITLE
feat(core): cap per-turn model calls and guard retries against replayed writes

### DIFF
--- a/.changeset/per-turn-budget-and-write-guard.md
+++ b/.changeset/per-turn-budget-and-write-guard.md
@@ -1,0 +1,8 @@
+---
+"@enduragent/core": patch
+---
+
+User-facing: Added a per-turn safety cap so a flaky provider connection can never run up a large surprise bill on your API key in a single message.
+User-facing: Fixed a bug where retrying after a hiccup could create a duplicate workout on your calendar; the coach now tells you honestly if a change was saved but the reply didn't finish.
+
+A single per-turn budget now caps total model calls and total generate attempts across every error class and the flush and compaction ladders, with a five-minute wall-clock checked only between attempts that never aborts an in-flight call, so a brownout turn stops with a classified budget error instead of spending the athlete's pay-as-you-go budget. The agent also records each committed calendar write within a turn and refuses to silently retry once a write has committed, returning an honest message that a change was saved but the reply failed rather than replaying a non-idempotent create into a duplicate workout.

--- a/packages/core/src/agent/coach-agent-copy.ts
+++ b/packages/core/src/agent/coach-agent-copy.ts
@@ -1,0 +1,4 @@
+export const TAINTED_BY_WRITES_MESSAGE =
+  "I made a change to your calendar, but then ran into a problem finishing my reply. " +
+  "Your change is saved — please open your calendar to confirm it looks right, " +
+  "and tell me if you'd like me to adjust it.";

--- a/packages/core/src/agent/coach-agent.ts
+++ b/packages/core/src/agent/coach-agent.ts
@@ -1,5 +1,5 @@
 import { stepCountIs } from "ai";
-import type { ModelMessage, ToolSet } from "ai";
+import type { ModelMessage, Tool, ToolSet } from "ai";
 import { makeChatClient } from "../reference/sync/intervals-client-factory.js";
 import { getEffectiveSections } from "../memory/effective-sections.js";
 import type { CoreDeps, Sport } from "../sport.js";
@@ -33,6 +33,8 @@ import { createMemorySnapshot } from "../memory/snapshot.js";
 import { resolveUserTimezone, appendCurrentTimeLine } from "./user-time.js";
 import { createSubsystemLogger, type SubsystemLogger } from "../logging/index.js";
 import { retryWithBackoff } from "../concurrency/retry.js";
+import { createTurnBudget, TurnBudgetExceededError, type TurnBudget } from "./turn-budget.js";
+import { TAINTED_BY_WRITES_MESSAGE } from "./coach-agent-copy.js";
 
 const MAX_OVERFLOW_ATTEMPTS = 3;
 const MAX_TIMEOUT_ATTEMPTS = 2;
@@ -42,6 +44,10 @@ const RATE_LIMIT_FALLBACK_MULTIPLIER = 2;
 const RATE_LIMIT_FALLBACK_MAX_MS = 30_000;
 const RATE_LIMIT_MAX_WAIT_MS = 120_000;
 const MAX_FLUSH_ATTEMPTS = 2;
+
+// Calendar write tools whose committed success makes a turn non-replayable.
+// Kept here so the taint set can't drift from the actual tool names.
+const WRITE_TOOL_NAMES = new Set(["intervals_create_workout", "intervals_delete_workout"]);
 
 type MemoryFlushTrigger =
   | "stale-reset"
@@ -68,6 +74,12 @@ export class CoachAgent {
   private tz: string;
   private archiveDeferred = new Set<string>();
   private lastFlushMessageCount = new Map<string, number>();
+  // Per-turn record of committed calendar writes, reset at the top of chat().
+  // A committed write makes the turn non-replayable: the retry loop re-sends the
+  // pre-turn messages, so a second generate could re-run a non-idempotent create.
+  private turnWrites: { writesCommitted: number; lastWriteSummary?: string } = {
+    writesCommitted: 0,
+  };
   // Resolved primary anchor (running CS) for the in-flight turn. Set at the top
   // of chat() from the channel's per-turn value and read lazily by sport tools
   // via the `coreDeps.resolvedCs` getter, so the tool set (and the cached
@@ -109,14 +121,47 @@ export class CoachAgent {
       resolvedCs: () => this.currentResolvedCs,
     };
     const registrations = sport.tools(coreDeps);
-    this.tools = Object.fromEntries(registrations.map((r) => [r.name, r.tool])) as ToolSet;
+    this.tools = Object.fromEntries(
+      registrations.map((r) => [r.name, this.wrapWriteTool(r.name, r.tool)]),
+    ) as ToolSet;
     // systemPrompt is rebuilt at the top of every chat() call; no need to bake one here.
     this.systemPrompt = "";
+  }
+
+  // Agent-owned wrapper that records a committed calendar write the moment its
+  // tool executes — at the execution boundary, not from the generate result,
+  // because result.toolCalls carries only the last agentic step and would miss
+  // a write committed on an earlier step. Non-write tools pass through untouched.
+  private wrapWriteTool(name: string, tool: Tool): Tool {
+    if (!WRITE_TOOL_NAMES.has(name)) return tool;
+    const inner = tool.execute;
+    if (typeof inner !== "function") return tool;
+    const record = this.turnWrites;
+    return {
+      ...tool,
+      execute: async (input: unknown, options: unknown) => {
+        const result = await (inner as (i: unknown, o: unknown) => unknown)(input, options);
+        if (
+          result !== null &&
+          typeof result === "object" &&
+          ((result as { created?: unknown }).created === true ||
+            (result as { deleted?: unknown }).deleted === true)
+        ) {
+          record.writesCommitted++;
+          record.lastWriteSummary =
+            (result as { created?: unknown }).created === true
+              ? "created a workout on the calendar"
+              : "deleted a scheduled workout";
+        }
+        return result;
+      },
+    } as Tool;
   }
 
   private async flushMemory(
     messages: ModelMessage[],
     trigger: MemoryFlushTrigger,
+    budget?: Pick<TurnBudget, "chargeModelCall">,
   ): Promise<MemoryFlushOutcome> {
     let lastError: unknown;
     for (let attempt = 1; attempt <= MAX_FLUSH_ATTEMPTS; attempt++) {
@@ -127,6 +172,7 @@ export class CoachAgent {
           memory: this.memory,
           memorySections: getEffectiveSections(this.sport),
           tz: this.tz,
+          budget,
         });
       } catch (err) {
         lastError = err;
@@ -144,13 +190,14 @@ export class CoachAgent {
     throw lastError;
   }
 
-  private compactionParams() {
+  private compactionParams(budget?: Pick<TurnBudget, "chargeModelCall">) {
     return {
       llm: this.llm,
       caller: "compact" as const,
       mustPreserveTokens: this.sport.mustPreserveTokens,
       memory: createMemorySnapshot(this.memory),
       contextWindowTokens: this.config.contextWindowTokens,
+      budget,
     };
   }
 
@@ -164,6 +211,11 @@ export class CoachAgent {
     this.currentResolvedCs = turn?.resolvedCs ?? null;
     return withSessionLock(chatId, async () => {
       const turnStart = Date.now();
+      const turnBudget = createTurnBudget(() => Date.now());
+      // Reset the per-turn write record in place (the wrapped write tools hold a
+      // reference to this object, captured once at construction).
+      this.turnWrites.writesCommitted = 0;
+      this.turnWrites.lastWriteSummary = undefined;
       // One flush per turn: the latch flips on entry (before the await
       // resolves) so a thrown flush still consumes the turn's single flush.
       let flushedThisTurn = false;
@@ -183,7 +235,7 @@ export class CoachAgent {
         if (history.length > 0 && !flushedThisTurn) {
           flushedThisTurn = true;
           try {
-            outcome = await this.flushMemory(history, "stale-reset");
+            outcome = await this.flushMemory(history, "stale-reset", turnBudget);
           } catch (err) {
             this.log.warn("Pre-reset memory flush failed; archiving session anyway", err);
           }
@@ -229,7 +281,7 @@ export class CoachAgent {
         if (!flushedThisTurn) {
           flushedThisTurn = true;
           try {
-            await this.flushMemory(history, "trim");
+            await this.flushMemory(history, "trim", turnBudget);
           } catch (err) {
             flushed = false;
             this.log.warn("Pre-compaction memory flush failed; keeping session file unchanged", err);
@@ -239,7 +291,7 @@ export class CoachAgent {
           const { summary, unsummarized } = await summarizeDroppedMessages({
             dropped,
             previousSummary,
-            ...this.compactionParams(),
+            ...this.compactionParams(turnBudget),
           });
           summaryMsg = makeSummaryMessage(summary);
           requeued = unsummarized;
@@ -270,7 +322,7 @@ export class CoachAgent {
         if (!flushedThisTurn) {
           flushedThisTurn = true;
           try {
-            await this.flushMemory(history, "soft-threshold");
+            await this.flushMemory(history, "soft-threshold", turnBudget);
           } catch (err) {
             this.log.warn("Soft-threshold memory flush failed; continuing turn", err);
           }
@@ -299,21 +351,28 @@ export class CoachAgent {
       const cacheKey = sha256_16(chatId);
 
       while (true) {
+        // Between-attempt budget gates: the attempt charge and the wall-clock
+        // check run at the loop top so the deadline stops the NEXT attempt and
+        // never aborts a generate/compaction already in flight.
+        turnBudget.chargeAttempt();
+        turnBudget.checkDeadline();
+
         // Preemptive: compact before sending if over budget
         if (shouldCompact({ messages, systemPrompt: this.systemPrompt, contextWindowTokens: this.config.contextWindowTokens })) {
           if (!flushedThisTurn) {
             flushedThisTurn = true;
             try {
-              await this.flushMemory(messages, "pre-compaction");
+              await this.flushMemory(messages, "pre-compaction", turnBudget);
             } catch (err) {
               this.log.warn("In-turn memory flush failed; compacting without flush", err);
             }
           }
-          messages = await summarizeInStages({ messages, ...this.compactionParams() });
+          messages = await summarizeInStages({ messages, ...this.compactionParams(turnBudget) });
           this.memory.reload();
         }
 
         try {
+          turnBudget.chargeModelCall();
           const result = await this.llm.generate({
             system: this.systemPrompt,
             messages,
@@ -360,6 +419,24 @@ export class CoachAgent {
 
           return text;
         } catch (err) {
+          // The classified budget error is terminal: re-throw it before any
+          // retry branch so a future reordering can never mistake it for one of
+          // the retryable classes and swallow it.
+          if (err instanceof TurnBudgetExceededError) throw err;
+          // A committed calendar write makes this turn non-replayable: retrying
+          // would re-send the pre-turn messages and could re-run a
+          // non-idempotent create. Refuse honestly instead of looping.
+          if (this.turnWrites.writesCommitted > 0) {
+            console.warn(
+              JSON.stringify({
+                event: "turn_failed_after_write",
+                writesCommitted: this.turnWrites.writesCommitted,
+                lastWriteSummary: this.turnWrites.lastWriteSummary,
+                error: (err instanceof Error ? err.message : String(err)).slice(0, 200),
+              }),
+            );
+            return TAINTED_BY_WRITES_MESSAGE;
+          }
           // Reactive: context overflow → flush + compact + retry
           if (isContextOverflowError(err) && overflowAttempts < MAX_OVERFLOW_ATTEMPTS) {
             overflowAttempts++;
@@ -367,12 +444,12 @@ export class CoachAgent {
               if (!flushedThisTurn) {
                 flushedThisTurn = true;
                 try {
-                  await this.flushMemory(messages, "overflow-recovery");
+                  await this.flushMemory(messages, "overflow-recovery", turnBudget);
                 } catch (flushErr) {
                   this.log.warn("In-turn memory flush failed; compacting without flush", flushErr);
                 }
               }
-              messages = await summarizeInStages({ messages, ...this.compactionParams() });
+              messages = await summarizeInStages({ messages, ...this.compactionParams(turnBudget) });
               this.memory.reload();
             } catch (rescueErr) {
               this.log.warn("Compaction rescue failed; rethrowing the original turn error", rescueErr);
@@ -389,7 +466,7 @@ export class CoachAgent {
             if (ratio > TIMEOUT_COMPACTION_THRESHOLD) {
               timeoutAttempts++;
               try {
-                messages = await summarizeInStages({ messages, ...this.compactionParams() });
+                messages = await summarizeInStages({ messages, ...this.compactionParams(turnBudget) });
                 this.memory.reload();
               } catch (rescueErr) {
                 this.log.warn("Compaction rescue failed; rethrowing the original turn error", rescueErr);
@@ -436,6 +513,10 @@ export class CoachAgent {
                 },
               },
             );
+            // The backoff sleep is the one place a turn can silently burn
+            // minutes; converting a long Retry-After wait into a clean budget
+            // stop here means the deadline never wedges the session lock.
+            turnBudget.checkDeadline();
             continue;
           }
           // Rate limit retries exhausted → throw to caller (skip compaction — API is rate limited)

--- a/packages/core/src/agent/compaction.ts
+++ b/packages/core/src/agent/compaction.ts
@@ -12,6 +12,9 @@ import {
 import { makeSummaryMessage, SUMMARY_PREFIX } from "./history-limit.js";
 import type { LLM } from "../llm.js";
 import type { GenerateOpts } from "../llm-types.js";
+import type { TurnBudget } from "./turn-budget.js";
+
+type ModelCallCharger = Pick<TurnBudget, "chargeModelCall">;
 
 // ============================================================================
 // CONSTANTS
@@ -121,8 +124,10 @@ function capSummary(summary: string): string {
 
 async function generateSummaryWithTimeout(
   llm: LLM,
-  opts: { prompt: string; maxOutputTokens: number; caller?: GenerateOpts["caller"] },
+  opts: { prompt: string; maxOutputTokens: number; caller?: GenerateOpts["caller"]; budget?: ModelCallCharger },
 ): Promise<string> {
+  const { budget, ...generateOpts } = opts;
+  budget?.chargeModelCall();
   let timer: ReturnType<typeof setTimeout> | undefined;
   const deadline = new Promise<never>((_, reject) => {
     timer = setTimeout(
@@ -130,7 +135,7 @@ async function generateSummaryWithTimeout(
       SUMMARIZATION_TIMEOUT_MS,
     );
   });
-  const call = llm.generate(opts);
+  const call = llm.generate(generateOpts);
   try {
     const { text } = await Promise.race([call, deadline]);
     return text;
@@ -223,8 +228,9 @@ async function finalizeSummary(params: {
   mustPreserveBlock: string;
   maxRetries: number;
   caller?: GenerateOpts["caller"];
+  budget?: ModelCallCharger;
 }): Promise<string> {
-  const { llm, mustPreserveBlock, maxRetries, caller } = params;
+  const { llm, mustPreserveBlock, maxRetries, caller, budget } = params;
   let best = capSummary(params.summary);
   const audit = auditSummaryQuality(best);
   if (audit.ok) return best;
@@ -235,6 +241,7 @@ async function finalizeSummary(params: {
         prompt: `Restructure the following summary to include ALL required section headings: ${audit.missing.join(", ")}.\n\n${best}\n\n${mustPreserveBlock}`,
         maxOutputTokens: MAX_SUMMARY_TOKENS,
         caller,
+        budget,
       });
       const capped = capSummary(text);
       if (auditSummaryQuality(capped).ok) return capped;
@@ -260,8 +267,9 @@ export async function summarizeDroppedMessages(params: {
   maxRetries?: number;
   contextWindowTokens?: number;
   caller?: GenerateOpts["caller"];
+  budget?: ModelCallCharger;
 }): Promise<{ summary: string; unsummarized: ModelMessage[] }> {
-  const { dropped, llm, mustPreserveTokens, memory, previousSummary, maxRetries = 1, contextWindowTokens, caller } = params;
+  const { dropped, llm, mustPreserveTokens, memory, previousSummary, maxRetries = 1, contextWindowTokens, caller, budget } = params;
 
   if (dropped.length === 0) return { summary: previousSummary ?? "", unsummarized: [] };
 
@@ -291,6 +299,7 @@ export async function summarizeDroppedMessages(params: {
         prompt,
         maxOutputTokens: MAX_SUMMARY_TOKENS,
         caller,
+        budget,
       });
       summary = text;
     } catch (err) {
@@ -307,7 +316,7 @@ export async function summarizeDroppedMessages(params: {
   }
 
   return {
-    summary: await finalizeSummary({ summary, llm, mustPreserveBlock, maxRetries, caller }),
+    summary: await finalizeSummary({ summary, llm, mustPreserveBlock, maxRetries, caller, budget }),
     unsummarized,
   };
 }
@@ -325,8 +334,9 @@ export async function summarizeInStages(params: {
   previousSummary?: string;
   contextWindowTokens?: number;
   caller?: GenerateOpts["caller"];
+  budget?: ModelCallCharger;
 }): Promise<ModelMessage[]> {
-  const { llm, mustPreserveTokens, memory, recentToKeep = 4, contextWindowTokens, caller } = params;
+  const { llm, mustPreserveTokens, memory, recentToKeep = 4, contextWindowTokens, caller, budget } = params;
 
   let messages = params.messages;
   let previousSummary = params.previousSummary;
@@ -370,6 +380,7 @@ export async function summarizeInStages(params: {
         prompt: `${summarizePrompt}${contextPrefix}\n\n${transcript}`,
         maxOutputTokens: MAX_SUMMARY_TOKENS,
         caller,
+        budget,
       });
       summary = text;
     } catch (err) {
@@ -388,6 +399,7 @@ export async function summarizeInStages(params: {
     mustPreserveBlock,
     maxRetries: 1,
     caller,
+    budget,
   });
   return [makeSummaryMessage(finalSummary), ...recent];
 }

--- a/packages/core/src/agent/memory-flush.ts
+++ b/packages/core/src/agent/memory-flush.ts
@@ -6,6 +6,7 @@ import type { MemoryStore } from "../memory.js";
 import { createMemoryReadTool } from "./tools.js";
 import type { LLM } from "../llm.js";
 import type { GenerateResult } from "../llm-types.js";
+import type { TurnBudget } from "./turn-budget.js";
 import { LEDGER_EVENT_KINDS, LEDGER_DATE_PATTERN, type LedgerEventKind } from "../memory/event-ledger.js";
 import { todayInTZ } from "./user-time.js";
 
@@ -201,6 +202,7 @@ export async function runMemoryFlush(params: {
   memory: MemoryStore;
   memorySections: readonly MemorySectionSpec[];
   tz?: string;
+  budget?: Pick<TurnBudget, "chargeModelCall">;
 }): Promise<MemoryFlushOutcome> {
   if (params.memorySections.length === 0) {
     throw new Error(
@@ -223,6 +225,7 @@ export async function runMemoryFlush(params: {
     }),
   };
 
+  params.budget?.chargeModelCall();
   const result = await params.llm.generate({
     system: MEMORY_FLUSH_SYSTEM_PROMPT,
     messages: [

--- a/packages/core/src/agent/turn-budget.ts
+++ b/packages/core/src/agent/turn-budget.ts
@@ -1,0 +1,57 @@
+export const MAX_TURN_MODEL_CALLS = 40;
+export const MAX_TURN_GENERATE_ATTEMPTS = 4;
+export const TURN_WALL_CLOCK_MS = 5 * 60_000;
+
+export type BudgetExceededKind = "model_calls" | "generate_attempts" | "wall_clock";
+
+export class TurnBudgetExceededError extends Error {
+  readonly kind: BudgetExceededKind;
+  constructor(kind: BudgetExceededKind, detail: string) {
+    super(detail);
+    this.name = "TurnBudgetExceededError";
+    this.kind = kind;
+  }
+}
+
+export interface TurnBudget {
+  /** Throws TurnBudgetExceededError("model_calls") if a model call would exceed the cap. Call BEFORE every llm.generate. */
+  chargeModelCall(): void;
+  /** Charge one outer generate attempt. Throws "generate_attempts" past the attempt cap. */
+  chargeAttempt(): void;
+  /** Between-attempt deadline check (never mid-attempt). Throws "wall_clock" on overrun. */
+  checkDeadline(): void;
+}
+
+export function createTurnBudget(now: () => number): TurnBudget {
+  const turnStart = now();
+  let modelCalls = 0;
+  let attempts = 0;
+  return {
+    chargeModelCall() {
+      modelCalls++;
+      if (modelCalls > MAX_TURN_MODEL_CALLS) {
+        throw new TurnBudgetExceededError(
+          "model_calls",
+          `Per-turn model-call budget exceeded (${MAX_TURN_MODEL_CALLS}).`,
+        );
+      }
+    },
+    chargeAttempt() {
+      attempts++;
+      if (attempts > MAX_TURN_GENERATE_ATTEMPTS) {
+        throw new TurnBudgetExceededError(
+          "generate_attempts",
+          `Per-turn generate-attempt budget exceeded (${MAX_TURN_GENERATE_ATTEMPTS}).`,
+        );
+      }
+    },
+    checkDeadline() {
+      if (now() - turnStart >= TURN_WALL_CLOCK_MS) {
+        throw new TurnBudgetExceededError(
+          "wall_clock",
+          `Per-turn wall-clock deadline exceeded (${TURN_WALL_CLOCK_MS}ms).`,
+        );
+      }
+    },
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -105,6 +105,14 @@ export type { IntervalsClient } from "./intervals.js";
 
 // ─── Agent ────────────────────────────────────────────────────────────
 export { CoachAgent } from "./agent/coach-agent.js";
+export {
+  TurnBudgetExceededError,
+  MAX_TURN_MODEL_CALLS,
+  MAX_TURN_GENERATE_ATTEMPTS,
+  TURN_WALL_CLOCK_MS,
+} from "./agent/turn-budget.js";
+export type { BudgetExceededKind, TurnBudget } from "./agent/turn-budget.js";
+export { TAINTED_BY_WRITES_MESSAGE } from "./agent/coach-agent-copy.js";
 export { ChatStore } from "./agent/chat-store.js";
 export { buildSystemPrompt, SYSTEM_PROMPT_CACHE_BOUNDARY } from "./agent/system-prompt.js";
 export { computePromptLineage } from "./agent/prompt-lineage.js";

--- a/packages/core/tests/turn-budget.test.ts
+++ b/packages/core/tests/turn-budget.test.ts
@@ -1,0 +1,250 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { baseAgentConfig } from "./helpers/base-agent-config.js";
+import { cyclingSport } from "@enduragent/sport-cycling";
+import type { Sport } from "../src/sport.js";
+import {
+  createTurnBudget,
+  TurnBudgetExceededError,
+  MAX_TURN_MODEL_CALLS,
+  MAX_TURN_GENERATE_ATTEMPTS,
+  TURN_WALL_CLOCK_MS,
+} from "../src/agent/turn-budget.js";
+
+let tempHome: string;
+let origHome: string | undefined;
+let dataDir: string;
+
+beforeEach(() => {
+  tempHome = mkdtempSync(join(tmpdir(), "cc-budget-"));
+  origHome = process.env.HOME;
+  process.env.HOME = tempHome;
+  dataDir = join(tempHome, ".cycling-coach");
+  mkdirSync(dataDir, { recursive: true });
+  mkdirSync(join(dataDir, "memory"), { recursive: true });
+  vi.resetModules();
+});
+
+afterEach(() => {
+  process.env.HOME = origHome;
+  rmSync(tempHome, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+const FLUSH_MARKER = "reviewing a conversation to extract and save important athlete";
+
+function mkAssistant(text: string, stopReason: "stop" | "length" = "stop") {
+  return {
+    role: "assistant" as const,
+    content: [{ type: "text" as const, text }],
+    api: "openai-codex-responses",
+    provider: "openai-codex",
+    model: "gpt-5.4",
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason,
+    timestamp: Date.now(),
+  };
+}
+
+async function setupAgent(complete: ReturnType<typeof vi.fn>) {
+  const model = {
+    id: "gpt-5.4",
+    name: "gpt-5.4",
+    api: "openai-codex-responses",
+    provider: "openai-codex",
+    baseUrl: "https://chatgpt.com/backend-api",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 272_000,
+    maxTokens: 128_000,
+  };
+
+  vi.doMock("@mariozechner/pi-ai", () => ({
+    complete,
+    getModel: vi.fn(() => model),
+  }));
+  vi.doMock("@mariozechner/pi-ai/oauth", () => ({
+    refreshOpenAICodexToken: vi.fn(),
+    loginOpenAICodex: vi.fn(),
+  }));
+  vi.doMock("../src/auth/profiles.js", () => ({
+    getFreshToken: vi.fn(async () => "token"),
+    loadProfile: vi.fn(),
+    saveProfile: vi.fn(),
+    RefreshTokenReusedError: class extends Error {},
+  }));
+
+  const { CoachAgent } = await import("../src/agent/coach-agent.js");
+  return new CoachAgent(cyclingSport as unknown as Sport, baseAgentConfig(dataDir));
+}
+
+function isMainTurn(call: unknown[]): boolean {
+  const sys = (call[1] as { systemPrompt?: string } | undefined)?.systemPrompt ?? "";
+  return sys.length > 0 && !sys.includes(FLUSH_MARKER);
+}
+
+function countMainTurns(complete: ReturnType<typeof vi.fn>): number {
+  return complete.mock.calls.filter(isMainTurn).length;
+}
+
+async function settle<T>(p: Promise<T>): Promise<{ ok: true; value: T } | { ok: false; error: unknown }> {
+  return p.then(
+    (value) => ({ ok: true as const, value }),
+    (error: unknown) => ({ ok: false as const, error }),
+  );
+}
+
+describe("createTurnBudget (unit)", () => {
+  it("charges model calls up to the cap then throws a classified model_calls error", () => {
+    const budget = createTurnBudget(() => 0);
+    for (let i = 0; i < MAX_TURN_MODEL_CALLS; i++) budget.chargeModelCall();
+    let thrown: unknown;
+    try {
+      budget.chargeModelCall();
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(TurnBudgetExceededError);
+    expect((thrown as TurnBudgetExceededError).kind).toBe("model_calls");
+  });
+
+  it("charges attempts up to the cap then throws a classified generate_attempts error", () => {
+    const budget = createTurnBudget(() => 0);
+    for (let i = 0; i < MAX_TURN_GENERATE_ATTEMPTS; i++) budget.chargeAttempt();
+    let thrown: unknown;
+    try {
+      budget.chargeAttempt();
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(TurnBudgetExceededError);
+    expect((thrown as TurnBudgetExceededError).kind).toBe("generate_attempts");
+  });
+
+  it("checkDeadline throws wall_clock only once the injected clock crosses the deadline", () => {
+    let clock = 1_000;
+    const budget = createTurnBudget(() => clock);
+    expect(() => budget.checkDeadline()).not.toThrow();
+    clock += TURN_WALL_CLOCK_MS - 1;
+    expect(() => budget.checkDeadline()).not.toThrow();
+    clock += 1;
+    let thrown: unknown;
+    try {
+      budget.checkDeadline();
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(TurnBudgetExceededError);
+    expect((thrown as TurnBudgetExceededError).kind).toBe("wall_clock");
+  });
+});
+
+describe("per-turn budget through chat() (behavioral)", () => {
+  it("stops a brownout turn at the attempt cap with a classified generate_attempts error and <= 40 model calls", async () => {
+    // Mix error classes so the per-class caps (3 overflow / 2 timeout / 3
+    // rate-limit) never exhaust before the total attempt cap of 4 fires: three
+    // overflows then rate-limits. Attempt 5's charge throws before any spend.
+    const complete = vi.fn(async (_model: unknown, context: { systemPrompt?: string }) => {
+      const sys = context.systemPrompt ?? "";
+      if (sys.includes(FLUSH_MARKER)) return mkAssistant("facts noted");
+      if (sys.length === 0) return mkAssistant("summary"); // compaction prompt-only call
+      const mainTurns = countMainTurns(complete);
+      if (mainTurns <= 3) {
+        throw new Error("Request exceeds the maximum context length of 272000 tokens");
+      }
+      throw new Error("You have hit your rate limit. Try again later.");
+    });
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.useFakeTimers();
+    const agent = await setupAgent(complete);
+
+    const outcomeP = settle(agent.chat("brownout", "hello"));
+    await vi.advanceTimersByTimeAsync(600_000);
+    const outcome = await outcomeP;
+    vi.useRealTimers();
+
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok) {
+      // Module identity differs across vi.resetModules() + dynamic import, so
+      // assert on the structural fields (name + kind) rather than instanceof.
+      expect((outcome.error as Error).name).toBe("TurnBudgetExceededError");
+      expect((outcome.error as TurnBudgetExceededError).kind).toBe("generate_attempts");
+    }
+    expect(countMainTurns(complete)).toBeLessThanOrEqual(MAX_TURN_GENERATE_ATTEMPTS);
+    expect(complete.mock.calls.length).toBeLessThanOrEqual(MAX_TURN_MODEL_CALLS);
+  });
+
+  it("a normal turn under budget returns its text and charges exactly one model call", async () => {
+    const complete = vi.fn(async (_model: unknown, context: { systemPrompt?: string }) => {
+      const sys = context.systemPrompt ?? "";
+      if (sys.includes(FLUSH_MARKER)) return mkAssistant("facts noted");
+      if (sys.length === 0) return mkAssistant("summary");
+      return mkAssistant("all good");
+    });
+    const agent = await setupAgent(complete);
+
+    const text = await agent.chat("happy", "hello");
+
+    expect(text).toBe("all good");
+    expect(countMainTurns(complete)).toBe(1);
+  });
+
+  it("a between-attempts wall-clock overrun stops with a wall_clock error and lets the in-flight call complete", async () => {
+    // Inject a clock that stays at turnStart through the first attempt and jumps
+    // past the 5-minute deadline once the first attempt's generate has thrown
+    // (a rate-limit error the loop would normally retry). The first attempt's
+    // generate runs to completion (its throw is observed), proving the deadline
+    // never aborted the in-flight call; the between-attempts check then stops it.
+    const base = 1_000_000;
+    let crossed = false;
+    const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => {
+      return crossed ? base + TURN_WALL_CLOCK_MS + 1 : base;
+    });
+
+    let mainCalls = 0;
+    let firstAttemptCompleted = false;
+    const complete = vi.fn(async (_model: unknown, context: { systemPrompt?: string }) => {
+      const sys = context.systemPrompt ?? "";
+      if (sys.includes(FLUSH_MARKER)) return mkAssistant("facts noted");
+      if (sys.length === 0) return mkAssistant("summary");
+      mainCalls++;
+      if (mainCalls === 1) {
+        firstAttemptCompleted = true;
+        crossed = true;
+        throw new Error("You have hit your rate limit. Try again later.");
+      }
+      return mkAssistant("should-not-reach");
+    });
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    // Fake only the timer functions, not Date, so the explicit Date.now spy
+    // above controls the budget clock while the rate-limit backoff sleep is
+    // still driven synchronously by advanceTimersByTimeAsync.
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "setInterval", "clearInterval"] });
+    const agent = await setupAgent(complete);
+
+    const outcomeP = settle(agent.chat("walls", "hello"));
+    await vi.advanceTimersByTimeAsync(600_000);
+    const outcome = await outcomeP;
+    vi.useRealTimers();
+    nowSpy.mockRestore();
+
+    expect(firstAttemptCompleted).toBe(true);
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok) {
+      expect((outcome.error as Error).name).toBe("TurnBudgetExceededError");
+      expect((outcome.error as TurnBudgetExceededError).kind).toBe("wall_clock");
+    }
+    // The second main generate never ran — the deadline stopped the next attempt.
+    expect(mainCalls).toBe(1);
+  });
+});

--- a/packages/core/tests/turn-tainted-by-writes.test.ts
+++ b/packages/core/tests/turn-tainted-by-writes.test.ts
@@ -1,0 +1,282 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { http, HttpResponse } from "msw";
+import { baseAgentConfig } from "./helpers/base-agent-config.js";
+import { createMockIntervalsServer } from "./helpers/mock-intervals.js";
+import { cyclingSport } from "@enduragent/sport-cycling";
+import type { Sport } from "../src/sport.js";
+import { TAINTED_BY_WRITES_MESSAGE } from "../src/agent/coach-agent-copy.js";
+
+let tempHome: string;
+let origHome: string | undefined;
+let dataDir: string;
+
+beforeEach(() => {
+  tempHome = mkdtempSync(join(tmpdir(), "cc-taint-"));
+  origHome = process.env.HOME;
+  process.env.HOME = tempHome;
+  dataDir = join(tempHome, ".cycling-coach");
+  mkdirSync(dataDir, { recursive: true });
+  mkdirSync(join(dataDir, "memory"), { recursive: true });
+  vi.resetModules();
+});
+
+afterEach(() => {
+  process.env.HOME = origHome;
+  rmSync(tempHome, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+function mkAssistant(opts: {
+  text?: string;
+  toolCall?: { id: string; name: string; arguments: Record<string, unknown> };
+  stopReason?: "stop" | "toolUse";
+}) {
+  const content = opts.toolCall
+    ? [{ type: "toolCall" as const, id: opts.toolCall.id, name: opts.toolCall.name, arguments: opts.toolCall.arguments }]
+    : [{ type: "text" as const, text: opts.text ?? "" }];
+  return {
+    role: "assistant" as const,
+    content,
+    api: "openai-codex-responses",
+    provider: "openai-codex",
+    model: "gpt-5.4",
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: opts.stopReason ?? "stop",
+    timestamp: Date.now(),
+  };
+}
+
+function intervalsConfig() {
+  return {
+    ...baseAgentConfig(dataDir),
+    intervals: { apiKey: "test-key", athleteId: "i1" },
+  };
+}
+
+async function setupAgent(complete: ReturnType<typeof vi.fn>) {
+  const model = {
+    id: "gpt-5.4",
+    name: "gpt-5.4",
+    api: "openai-codex-responses",
+    provider: "openai-codex",
+    baseUrl: "https://chatgpt.com/backend-api",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 272_000,
+    maxTokens: 128_000,
+  };
+
+  vi.doMock("@mariozechner/pi-ai", () => ({
+    complete,
+    getModel: vi.fn(() => model),
+  }));
+  vi.doMock("@mariozechner/pi-ai/oauth", () => ({
+    refreshOpenAICodexToken: vi.fn(),
+    loginOpenAICodex: vi.fn(),
+  }));
+  vi.doMock("../src/auth/profiles.js", () => ({
+    getFreshToken: vi.fn(async () => "token"),
+    loadProfile: vi.fn(),
+    saveProfile: vi.fn(),
+    RefreshTokenReusedError: class extends Error {},
+  }));
+
+  const { CoachAgent } = await import("../src/agent/coach-agent.js");
+  return new CoachAgent(cyclingSport as unknown as Sport, intervalsConfig());
+}
+
+const FLUSH_MARKER = "reviewing a conversation to extract and save important athlete";
+
+function tomorrowISODate(): string {
+  const d = new Date();
+  d.setDate(d.getDate() + 1);
+  return d.toISOString().slice(0, 10);
+}
+
+describe("tainted-by-writes refusal", () => {
+  it("a write on a non-final step then a brownout refuses without replaying the write", async () => {
+    const { server, createdWorkouts } = createMockIntervalsServer();
+    server.listen({ onUnhandledRequest: "bypass" });
+    try {
+      let mainTurns = 0;
+      let secondMainAfterWrite = false;
+      const complete = vi.fn(async (_model: unknown, context: { systemPrompt?: string }, _opts: unknown) => {
+        const sys = context.systemPrompt ?? "";
+        if (sys.includes(FLUSH_MARKER)) return mkAssistant({ text: "facts noted" });
+        if (sys.length === 0) return mkAssistant({ text: "summary" });
+        mainTurns++;
+        // Within attempt 1: step 1 emits the create tool-call (non-final), the
+        // bridge executes it (write commits via MSW), then step 2 throws — so
+        // the write lands on a non-final step that the final-step result misses.
+        const ctx = context as { messages?: { role: string }[] };
+        const hasToolResult = (ctx.messages ?? []).some((m) => m.role === "toolResult");
+        if (mainTurns === 1 && !hasToolResult) {
+          return mkAssistant({
+            toolCall: {
+              id: "call-1",
+              name: "intervals_create_workout",
+              arguments: {
+                date: tomorrowISODate(),
+                workout: {
+                  name: "Threshold 2x20",
+                  steps: [
+                    { type: "warmup", duration: { value: 10, unit: "minutes" }, power: { kind: "percent_ftp", value: 50 } },
+                    { type: "steady", duration: { value: 20, unit: "minutes" }, power: { kind: "percent_ftp", value: 95 } },
+                  ],
+                },
+              },
+            },
+            stopReason: "toolUse",
+          });
+        }
+        // The step after the write throws a retryable error.
+        secondMainAfterWrite = true;
+        throw new Error("You have hit your rate limit. Try again later.");
+      });
+      vi.spyOn(console, "warn").mockImplementation(() => {});
+      const agent = await setupAgent(complete);
+
+      const result = await agent.chat("taint", "create a threshold workout for tomorrow");
+
+      expect(result).toBe(TAINTED_BY_WRITES_MESSAGE);
+      // The write committed exactly once and was never replayed on a retry.
+      expect(createdWorkouts.length).toBe(1);
+      expect(secondMainAfterWrite).toBe(true);
+    } finally {
+      server.close();
+    }
+  });
+
+  it("a delete on a turn that then errors also taints", async () => {
+    const { server, createdWorkouts, deletedEventIds } = createMockIntervalsServer();
+    // Seed an upcoming workout so the delete tool's get-before-delete succeeds.
+    createdWorkouts.push({
+      id: 7777,
+      start_date_local: `${tomorrowISODate()}T00:00:00`,
+      category: "WORKOUT",
+      name: "To delete",
+      type: "Ride",
+      moving_time: 3600,
+    });
+    server.listen({ onUnhandledRequest: "bypass" });
+    try {
+      let mainTurns = 0;
+      const complete = vi.fn(async (_model: unknown, context: { systemPrompt?: string }) => {
+        const sys = context.systemPrompt ?? "";
+        if (sys.includes(FLUSH_MARKER)) return mkAssistant({ text: "facts noted" });
+        if (sys.length === 0) return mkAssistant({ text: "summary" });
+        mainTurns++;
+        const ctx = context as { messages?: { role: string }[] };
+        const hasToolResult = (ctx.messages ?? []).some((m) => m.role === "toolResult");
+        if (mainTurns === 1 && !hasToolResult) {
+          return mkAssistant({
+            toolCall: { id: "call-d", name: "intervals_delete_workout", arguments: { eventId: 7777 } },
+            stopReason: "toolUse",
+          });
+        }
+        throw new Error("You have hit your rate limit. Try again later.");
+      });
+      vi.spyOn(console, "warn").mockImplementation(() => {});
+      const agent = await setupAgent(complete);
+
+      const result = await agent.chat("taint-del", "delete tomorrow's workout");
+
+      expect(result).toBe(TAINTED_BY_WRITES_MESSAGE);
+      expect(deletedEventIds).toEqual([7777]);
+    } finally {
+      server.close();
+    }
+  });
+
+  it("a no-write brownout still retries normally and the guard does not over-fire", async () => {
+    let mainTurns = 0;
+    const complete = vi.fn(async (_model: unknown, context: { systemPrompt?: string }) => {
+      const sys = context.systemPrompt ?? "";
+      if (sys.includes(FLUSH_MARKER)) return mkAssistant({ text: "facts noted" });
+      if (sys.length === 0) return mkAssistant({ text: "summary" });
+      mainTurns++;
+      if (mainTurns === 1) throw new Error("You have hit your rate limit. Try again later.");
+      return mkAssistant({ text: "recovered after retry" });
+    });
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.useFakeTimers();
+    const agent = await setupAgent(complete);
+
+    const chatPromise = agent.chat("nowrite", "hello");
+    await vi.advanceTimersByTimeAsync(60_000);
+    const result = await chatPromise;
+    vi.useRealTimers();
+
+    expect(result).toBe("recovered after retry");
+    expect(result).not.toBe(TAINTED_BY_WRITES_MESSAGE);
+    expect(mainTurns).toBe(2);
+  });
+
+  it("an errored (uncommitted) write does not taint and the loop still retries", async () => {
+    const { server, createdWorkouts } = createMockIntervalsServer();
+    // The POST fails server-side, so the create tool returns { error: ... }
+    // rather than { created: true } — no committed write, no taint.
+    server.use(
+      http.post("https://intervals.icu/api/v1/athlete/:id/events", () =>
+        HttpResponse.json({ error: "server_error" }, { status: 500 }),
+      ),
+    );
+    server.listen({ onUnhandledRequest: "bypass" });
+    try {
+      let mainTurns = 0;
+      const complete = vi.fn(async (_model: unknown, context: { systemPrompt?: string }) => {
+        const sys = context.systemPrompt ?? "";
+        if (sys.includes(FLUSH_MARKER)) return mkAssistant({ text: "facts noted" });
+        if (sys.length === 0) return mkAssistant({ text: "summary" });
+        mainTurns++;
+        const ctx = context as { messages?: { role: string }[] };
+        const hasToolResult = (ctx.messages ?? []).some((m) => m.role === "toolResult");
+        if (mainTurns === 1 && !hasToolResult) {
+          return mkAssistant({
+            toolCall: {
+              id: "call-bad",
+              name: "intervals_create_workout",
+              arguments: {
+                date: tomorrowISODate(),
+                workout: {
+                  name: "Threshold",
+                  steps: [
+                    { type: "steady", duration: { value: 20, unit: "minutes" }, power: { kind: "percent_ftp", value: 90 } },
+                  ],
+                },
+              },
+            },
+            stopReason: "toolUse",
+          });
+        }
+        if (mainTurns === 1) throw new Error("You have hit your rate limit. Try again later.");
+        return mkAssistant({ text: "recovered, nothing saved" });
+      });
+      vi.spyOn(console, "warn").mockImplementation(() => {});
+      vi.useFakeTimers();
+      const agent = await setupAgent(complete);
+
+      const chatPromise = agent.chat("errwrite", "create a workout");
+      await vi.advanceTimersByTimeAsync(60_000);
+      const result = await chatPromise;
+      vi.useRealTimers();
+
+      expect(result).not.toBe(TAINTED_BY_WRITES_MESSAGE);
+      expect(result).toBe("recovered, nothing saved");
+      expect(createdWorkouts.length).toBe(0);
+    } finally {
+      server.close();
+    }
+  });
+});


### PR DESCRIPTION
Caps per-turn spend and stops a retried turn from silently replaying a write tool (e.g. creating a workout twice).

- New `packages/core/src/agent/turn-budget.ts`: a hardcoded per-turn budget — 40 total model calls, 4 generate attempts, a 5-minute wall-clock deadline — charged before every model call across the whole turn (including the compaction and memory-flush ladders), with the deadline checked only between attempts so an in-flight call is never aborted. An overrun raises a classified error the loop never swallows.
- Write-replay guard: the agent records executed write-tool calls per turn; on a mid-turn retry it refuses with an honest "a change was made but the turn failed" message instead of re-running a non-idempotent create/delete.

Stacked on the previous PR (base `refactor/shared-retry-primitive`).

Changeset: yes (runaway-spend stop + duplicate-workout fix are athlete-visible).

## Test plan
`pnpm check` / `pnpm test` green (new `turn-budget.test.ts` + `turn-tainted-by-writes.test.ts`; both behavioral guards verified required-red).
