### PR TITLE
feat(core): evaluate all validation checks and bump the audit schema to v2

### DIFF
--- a/packages/core/src/agent/coach-agent.ts
+++ b/packages/core/src/agent/coach-agent.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { stepCountIs } from "ai";
 import type { ModelMessage, Tool, ToolSet } from "ai";
 import { makeChatClient } from "../reference/sync/intervals-client-factory.js";
@@ -56,6 +57,31 @@ type MemoryFlushTrigger =
   | "pre-compaction"
   | "overflow-recovery"
   | "soft-threshold";
+
+// The per-turn terminal record. Field names are frozen by the operator spec:
+// error_class and duration_ms are snake_case, and the three *Attempts mirror the
+// in-scope retry counters exactly.
+interface TurnOutcome {
+  turnId: string;
+  chatId: string;
+  ok: boolean;
+  error_class?: string;
+  overflowAttempts: number;
+  timeoutAttempts: number;
+  rateLimitAttempts: number;
+  duration_ms: number;
+  compactions: number;
+}
+
+function classifyError(err: unknown): string {
+  // TurnBudgetExceededError crosses a dynamic-import boundary in tests, so match
+  // on the structural name rather than instanceof.
+  if (err instanceof Error && err.name === "TurnBudgetExceededError") return "budget";
+  if (isContextOverflowError(err)) return "overflow";
+  if (isTimeoutError(err)) return "timeout";
+  if (isRateLimitError(err)) return "rate_limit";
+  return "unknown";
+}
 
 // ============================================================================
 // AGENT
@@ -201,6 +227,16 @@ export class CoachAgent {
     };
   }
 
+  private emitTurnOutcome(outcome: TurnOutcome): void {
+    // An observability write must never break a turn: a failed outcome emit is
+    // swallowed exactly like the usage-ledger and substrate writes.
+    try {
+      this.log.info("turn_outcome", { ...outcome });
+    } catch {
+      // Swallow.
+    }
+  }
+
   async chat(
     chatId: string,
     userMessage: string,
@@ -211,6 +247,8 @@ export class CoachAgent {
     this.currentResolvedCs = turn?.resolvedCs ?? null;
     return withSessionLock(chatId, async () => {
       const turnStart = Date.now();
+      const turnId = randomUUID();
+      let compactions = 0;
       const turnBudget = createTurnBudget(() => Date.now());
       // Reset the per-turn write record in place (the wrapped write tools hold a
       // reference to this object, captured once at construction).
@@ -293,6 +331,7 @@ export class CoachAgent {
             previousSummary,
             ...this.compactionParams(turnBudget),
           });
+          compactions++;
           summaryMsg = makeSummaryMessage(summary);
           requeued = unsummarized;
           if (flushed) {
@@ -350,123 +389,131 @@ export class CoachAgent {
       // Loop-invariant: the prompt cache key derives only from the chat id.
       const cacheKey = sha256_16(chatId);
 
-      while (true) {
-        // Between-attempt budget gates: the attempt charge and the wall-clock
-        // check run at the loop top so the deadline stops the NEXT attempt and
-        // never aborts a generate/compaction already in flight.
-        turnBudget.chargeAttempt();
-        turnBudget.checkDeadline();
+      try {
+        while (true) {
+          // Between-attempt budget gates: the attempt charge and the wall-clock
+          // check run at the loop top so the deadline stops the NEXT attempt and
+          // never aborts a generate/compaction already in flight.
+          turnBudget.chargeAttempt();
+          turnBudget.checkDeadline();
 
-        // Preemptive: compact before sending if over budget
-        if (shouldCompact({ messages, systemPrompt: this.systemPrompt, contextWindowTokens: this.config.contextWindowTokens })) {
-          if (!flushedThisTurn) {
-            flushedThisTurn = true;
-            try {
-              await this.flushMemory(messages, "pre-compaction", turnBudget);
-            } catch (err) {
-              this.log.warn("In-turn memory flush failed; compacting without flush", err);
-            }
-          }
-          messages = await summarizeInStages({ messages, ...this.compactionParams(turnBudget) });
-          this.memory.reload();
-        }
-
-        try {
-          turnBudget.chargeModelCall();
-          const result = await this.llm.generate({
-            system: this.systemPrompt,
-            messages,
-            tools: this.tools,
-            stopWhen: stepCountIs(10),
-            maxSteps: 10,
-            caller: "chat",
-            cacheKey,
-          });
-          const { text } = result;
-
-          const templateHash = (this.templateHash ??= computeTemplateHash({
-            soul: this.sport.soul,
-            skills: this.sport.skills,
-            ruleBlocks: staticRuleBlocks(),
-            toolSchemas: this.tools,
-            model: this.config.llm.model,
-          }));
-          const assembledHash = computeAssembledHash(this.systemPrompt, messages);
-
-          // Append BOTH after success — JSONL unchanged on failure
-          this.chatStore.appendMessage(chatId, "user", userMessage);
-          this.chatStore.appendMessage(chatId, "assistant", text, {
-            templateHash,
-            assembledHash,
-            provider: this.config.llm.provider,
-            model: this.config.llm.model,
-          });
-
-          // A turn can run several generations (retry/compaction/overflow
-          // recovery); these usage/cost figures are the FINAL successful
-          // generation's only — not a turn-wide sum across attempts. A true
-          // accumulator over all attempts is deferred.
-          appendUsageLine(this.config.dataDir, {
-            ts: Date.now(),
-            kind: "turn",
-            caller: "chat",
-            provider: this.config.llm.provider,
-            model: this.config.llm.model,
-            durationMs: Date.now() - turnStart,
-            templateHash,
-            ...usageFieldsFromResult(result),
-          });
-
-          return text;
-        } catch (err) {
-          // The classified budget error is terminal: re-throw it before any
-          // retry branch so a future reordering can never mistake it for one of
-          // the retryable classes and swallow it.
-          if (err instanceof TurnBudgetExceededError) throw err;
-          // A committed calendar write makes this turn non-replayable: retrying
-          // would re-send the pre-turn messages and could re-run a
-          // non-idempotent create. Refuse honestly instead of looping.
-          if (this.turnWrites.writesCommitted > 0) {
-            console.warn(
-              JSON.stringify({
-                event: "turn_failed_after_write",
-                writesCommitted: this.turnWrites.writesCommitted,
-                lastWriteSummary: this.turnWrites.lastWriteSummary,
-                error: (err instanceof Error ? err.message : String(err)).slice(0, 200),
-              }),
-            );
-            return TAINTED_BY_WRITES_MESSAGE;
-          }
-          // Reactive: context overflow → flush + compact + retry
-          if (isContextOverflowError(err) && overflowAttempts < MAX_OVERFLOW_ATTEMPTS) {
-            overflowAttempts++;
-            try {
-              if (!flushedThisTurn) {
-                flushedThisTurn = true;
-                try {
-                  await this.flushMemory(messages, "overflow-recovery", turnBudget);
-                } catch (flushErr) {
-                  this.log.warn("In-turn memory flush failed; compacting without flush", flushErr);
-                }
-              }
-              messages = await summarizeInStages({ messages, ...this.compactionParams(turnBudget) });
-              this.memory.reload();
-            } catch (rescueErr) {
-              this.log.warn("Compaction rescue failed; rethrowing the original turn error", rescueErr);
-              if (err instanceof Error && err.cause === undefined) {
-                (err as Error & { cause?: unknown }).cause = rescueErr;
-              }
-              throw err;
-            }
-            continue;
-          }
-          // Timeout with high context usage → compact + retry (no flush)
-          if (isTimeoutError(err) && timeoutAttempts < MAX_TIMEOUT_ATTEMPTS) {
-            const ratio = estimateMessagesTokens(messages) / this.config.contextWindowTokens;
-            if (ratio > TIMEOUT_COMPACTION_THRESHOLD) {
-              timeoutAttempts++;
+          // Preemptive: compact before sending if over budget
+          if (shouldCompact({ messages, systemPrompt: this.systemPrompt, contextWindowTokens: this.config.contextWindowTokens })) {
+            if (!flushedThisTurn) {
+              flushedThisTurn = true;
               try {
+                await this.flushMemory(messages, "pre-compaction", turnBudget);
+              } catch (err) {
+                this.log.warn("In-turn memory flush failed; compacting without flush", err);
+              }
+            }
+            messages = await summarizeInStages({ messages, ...this.compactionParams(turnBudget) });
+            compactions++;
+            this.memory.reload();
+          }
+
+          try {
+            turnBudget.chargeModelCall();
+            const result = await this.llm.generate({
+              system: this.systemPrompt,
+              messages,
+              tools: this.tools,
+              stopWhen: stepCountIs(10),
+              maxSteps: 10,
+              caller: "chat",
+              cacheKey,
+            });
+            const { text } = result;
+
+            const templateHash = (this.templateHash ??= computeTemplateHash({
+              soul: this.sport.soul,
+              skills: this.sport.skills,
+              ruleBlocks: staticRuleBlocks(),
+              toolSchemas: this.tools,
+              model: this.config.llm.model,
+            }));
+            const assembledHash = computeAssembledHash(this.systemPrompt, messages);
+
+            // Append BOTH after success — JSONL unchanged on failure
+            this.chatStore.appendMessage(chatId, "user", userMessage);
+            this.chatStore.appendMessage(chatId, "assistant", text, {
+              templateHash,
+              assembledHash,
+              provider: this.config.llm.provider,
+              model: this.config.llm.model,
+            });
+
+            // A turn can run several generations (retry/compaction/overflow
+            // recovery); these usage/cost figures are the FINAL successful
+            // generation's only — not a turn-wide sum across attempts. A true
+            // accumulator over all attempts is deferred.
+            appendUsageLine(this.config.dataDir, {
+              ts: Date.now(),
+              kind: "turn",
+              caller: "chat",
+              provider: this.config.llm.provider,
+              model: this.config.llm.model,
+              durationMs: Date.now() - turnStart,
+              templateHash,
+              ...usageFieldsFromResult(result),
+            });
+
+            this.emitTurnOutcome({
+              turnId,
+              chatId,
+              ok: true,
+              overflowAttempts,
+              timeoutAttempts,
+              rateLimitAttempts,
+              duration_ms: Date.now() - turnStart,
+              compactions,
+            });
+
+            return text;
+          } catch (err) {
+            // The classified budget error is terminal: re-throw it before any
+            // retry branch so a future reordering can never mistake it for one of
+            // the retryable classes and swallow it.
+            if (err instanceof TurnBudgetExceededError) throw err;
+            // A committed calendar write makes this turn non-replayable: retrying
+            // would re-send the pre-turn messages and could re-run a
+            // non-idempotent create. Refuse honestly instead of looping.
+            if (this.turnWrites.writesCommitted > 0) {
+              console.warn(
+                JSON.stringify({
+                  event: "turn_failed_after_write",
+                  writesCommitted: this.turnWrites.writesCommitted,
+                  lastWriteSummary: this.turnWrites.lastWriteSummary,
+                  error: (err instanceof Error ? err.message : String(err)).slice(0, 200),
+                }),
+              );
+              this.emitTurnOutcome({
+                turnId,
+                chatId,
+                ok: false,
+                error_class: classifyError(err),
+                overflowAttempts,
+                timeoutAttempts,
+                rateLimitAttempts,
+                duration_ms: Date.now() - turnStart,
+                compactions,
+              });
+              return TAINTED_BY_WRITES_MESSAGE;
+            }
+            // Reactive: context overflow → flush + compact + retry
+            if (isContextOverflowError(err) && overflowAttempts < MAX_OVERFLOW_ATTEMPTS) {
+              overflowAttempts++;
+              try {
+                if (!flushedThisTurn) {
+                  flushedThisTurn = true;
+                  try {
+                    await this.flushMemory(messages, "overflow-recovery", turnBudget);
+                  } catch (flushErr) {
+                    this.log.warn("In-turn memory flush failed; compacting without flush", flushErr);
+                  }
+                }
                 messages = await summarizeInStages({ messages, ...this.compactionParams(turnBudget) });
+                compactions++;
                 this.memory.reload();
               } catch (rescueErr) {
                 this.log.warn("Compaction rescue failed; rethrowing the original turn error", rescueErr);
@@ -477,51 +524,85 @@ export class CoachAgent {
               }
               continue;
             }
-          }
-          // Rate limit → backoff (respect retry-after) + retry
-          if (isRateLimitError(err) && rateLimitAttempts < MAX_RATE_LIMIT_ATTEMPTS) {
-            rateLimitAttempts++;
-            const attemptNo = rateLimitAttempts;
-            // The server hint (if any) is a lower bound; absent one, fall back to a
-            // capped exponential. Either feeds the primitive as the Retry-After
-            // floor so the 120s ceiling and the clamp note are honored bit-for-bit.
-            const requestedMs = extractRetryAfterMs(err)
-              ?? Math.min(
-                   RATE_LIMIT_FALLBACK_BASE_MS * RATE_LIMIT_FALLBACK_MULTIPLIER ** (attemptNo - 1),
-                   RATE_LIMIT_FALLBACK_MAX_MS,
-                 );
-            const clampNote = requestedMs > RATE_LIMIT_MAX_WAIT_MS
-              ? ` (provider requested ${requestedMs}ms, clamped to ${RATE_LIMIT_MAX_WAIT_MS}ms)`
-              : "";
-            let retried = false;
-            await retryWithBackoff(
-              async () => {
-                if (!retried) {
-                  retried = true;
+            // Timeout with high context usage → compact + retry (no flush)
+            if (isTimeoutError(err) && timeoutAttempts < MAX_TIMEOUT_ATTEMPTS) {
+              const ratio = estimateMessagesTokens(messages) / this.config.contextWindowTokens;
+              if (ratio > TIMEOUT_COMPACTION_THRESHOLD) {
+                timeoutAttempts++;
+                try {
+                  messages = await summarizeInStages({ messages, ...this.compactionParams(turnBudget) });
+                  compactions++;
+                  this.memory.reload();
+                } catch (rescueErr) {
+                  this.log.warn("Compaction rescue failed; rethrowing the original turn error", rescueErr);
+                  if (err instanceof Error && err.cause === undefined) {
+                    (err as Error & { cause?: unknown }).cause = rescueErr;
+                  }
                   throw err;
                 }
-              },
-              {
-                attempts: 2,
-                baseMs: requestedMs,
-                capMs: RATE_LIMIT_MAX_WAIT_MS,
-                shouldRetry: () => true,
-                retryAfterMs: () => requestedMs,
-                random: () => 0,
-                onRetry: ({ delayMs }) => {
-                  console.warn(`Rate limited (attempt ${attemptNo}/${MAX_RATE_LIMIT_ATTEMPTS}), waiting ${delayMs}ms${clampNote}`);
+                continue;
+              }
+            }
+            // Rate limit → backoff (respect retry-after) + retry
+            if (isRateLimitError(err) && rateLimitAttempts < MAX_RATE_LIMIT_ATTEMPTS) {
+              rateLimitAttempts++;
+              const attemptNo = rateLimitAttempts;
+              // The server hint (if any) is a lower bound; absent one, fall back to a
+              // capped exponential. Either feeds the primitive as the Retry-After
+              // floor so the 120s ceiling and the clamp note are honored bit-for-bit.
+              const requestedMs = extractRetryAfterMs(err)
+                ?? Math.min(
+                     RATE_LIMIT_FALLBACK_BASE_MS * RATE_LIMIT_FALLBACK_MULTIPLIER ** (attemptNo - 1),
+                     RATE_LIMIT_FALLBACK_MAX_MS,
+                   );
+              const clampNote = requestedMs > RATE_LIMIT_MAX_WAIT_MS
+                ? ` (provider requested ${requestedMs}ms, clamped to ${RATE_LIMIT_MAX_WAIT_MS}ms)`
+                : "";
+              let retried = false;
+              await retryWithBackoff(
+                async () => {
+                  if (!retried) {
+                    retried = true;
+                    throw err;
+                  }
                 },
-              },
-            );
-            // The backoff sleep is the one place a turn can silently burn
-            // minutes; converting a long Retry-After wait into a clean budget
-            // stop here means the deadline never wedges the session lock.
-            turnBudget.checkDeadline();
-            continue;
+                {
+                  attempts: 2,
+                  baseMs: requestedMs,
+                  capMs: RATE_LIMIT_MAX_WAIT_MS,
+                  shouldRetry: () => true,
+                  retryAfterMs: () => requestedMs,
+                  random: () => 0,
+                  onRetry: ({ delayMs }) => {
+                    console.warn(`Rate limited (attempt ${attemptNo}/${MAX_RATE_LIMIT_ATTEMPTS}), waiting ${delayMs}ms${clampNote}`);
+                  },
+                },
+              );
+              // The backoff sleep is the one place a turn can silently burn
+              // minutes; converting a long Retry-After wait into a clean budget
+              // stop here means the deadline never wedges the session lock.
+              turnBudget.checkDeadline();
+              continue;
+            }
+            // Rate limit retries exhausted → throw to caller (skip compaction — API is rate limited)
+            throw err;
           }
-          // Rate limit retries exhausted → throw to caller (skip compaction — API is rate limited)
-          throw err;
         }
+      } catch (terminalErr) {
+        // Single failure-emit point: every terminal throw out of the loop is one
+        // failed turn, so the outcome line fires exactly once before the rethrow.
+        this.emitTurnOutcome({
+          turnId,
+          chatId,
+          ok: false,
+          error_class: classifyError(terminalErr),
+          overflowAttempts,
+          timeoutAttempts,
+          rateLimitAttempts,
+          duration_ms: Date.now() - turnStart,
+          compactions,
+        });
+        throw terminalErr;
       }
     });
   }

--- a/packages/core/src/reference/audit/parse.ts
+++ b/packages/core/src/reference/audit/parse.ts
@@ -19,6 +19,21 @@ import {
   type AuditLogEntry,
 } from "../validation/recommendation-metadata.js";
 
+/**
+ * Maps a v1-shaped line forward to the v2 shape: a v1 reply line is a `reply`
+ * event with no recomputable per-lens verdicts and no template hash, so the
+ * offline gate reads the whole observe window across the bump boundary.
+ */
+function mapV1ToV2(obj: Record<string, unknown>): Record<string, unknown> {
+  return {
+    ...obj,
+    schema_version: "2",
+    event_type: "reply",
+    verdicts: null,
+    prompt_template_hash: null,
+  };
+}
+
 export async function* parseAuditLog(
   binaryName: string,
 ): AsyncGenerator<AuditLogEntry> {
@@ -45,14 +60,19 @@ export async function* parseAuditLog(
     }
 
     const version = (obj as { schema_version?: unknown })?.schema_version;
-    if (version !== AUDIT_SCHEMA_VERSION) {
+    let candidate: unknown;
+    if (version === AUDIT_SCHEMA_VERSION) {
+      candidate = obj;
+    } else if (version === "1") {
+      candidate = mapV1ToV2(obj as Record<string, unknown>);
+    } else {
       console.warn(
         `parseAuditLog: skipping unknown schema_version ${String(version)} (parser supports ${AUDIT_SCHEMA_VERSION})`,
       );
       continue;
     }
 
-    const result = AuditLogEntrySchema.safeParse(obj);
+    const result = AuditLogEntrySchema.safeParse(candidate);
     if (!result.success) {
       console.warn(
         `parseAuditLog: skipping line failing schema: ${result.error.message}`,

--- a/packages/core/src/reference/validation/recommendation-metadata.ts
+++ b/packages/core/src/reference/validation/recommendation-metadata.ts
@@ -9,7 +9,28 @@
  */
 import { z } from "zod";
 
-export const AUDIT_SCHEMA_VERSION = "1";
+export const AUDIT_SCHEMA_VERSION = "2";
+
+/**
+ * Event-type discriminator for an audit entry. `turn_failed` is the reserved
+ * terminal-failure class: a turn that never delivered a reply, so the offline
+ * gate can correct for survivorship rather than modelling delivered replies
+ * only. The per-turn outcome record is emitted to a separate diagnostic sink;
+ * this member reserves the class on the entry for the later chat-path wiring.
+ */
+export const AuditEventType = z.enum([
+  "reply",
+  "tool_gate_block",
+  "input_screen_hit",
+  "refusal",
+  "turn_failed",
+]);
+export type AuditEventType = z.infer<typeof AuditEventType>;
+
+export const LensVerdictSchema = z
+  .object({ lens: z.string(), ok: z.boolean(), detail: z.string().nullable() })
+  .strict();
+export type LensVerdict = z.infer<typeof LensVerdictSchema>;
 
 export const CitationSchema = z
   .object({
@@ -38,6 +59,11 @@ export const AuditLogEntrySchema = z
     responseHash: z.string(),
     metadata: RecommendationMetadataSchema,
     validation_warning: z.boolean().optional(),
+    // v2 fields — all optional/nullable so a v1-shaped line still parses under
+    // .strict() once the parser maps it forward.
+    event_type: AuditEventType.optional(),
+    verdicts: z.array(LensVerdictSchema).nullable().optional(),
+    prompt_template_hash: z.string().nullable().optional(),
   })
   .strict();
 export type AuditLogEntry = z.infer<typeof AuditLogEntrySchema>;

--- a/packages/core/src/reference/validation/retry-with-feedback.ts
+++ b/packages/core/src/reference/validation/retry-with-feedback.ts
@@ -63,8 +63,9 @@ export async function validateAndRetry(
     return { response, metadata: parseMetadata(metadata) };
   }
 
+  const feedback = first.failures.map((f) => f.detail).join("\n- ");
   const retryPrompt = `Your previous response had a citation mismatch:
-- ${first.feedback}
+- ${feedback}
 Please regenerate your reply, citing only values that exist in the latest snapshot. Same coaching content, corrected numbers.`;
 
   const result = await llm.generate({

--- a/packages/core/src/reference/validation/validate-response.ts
+++ b/packages/core/src/reference/validation/validate-response.ts
@@ -22,9 +22,19 @@ export type Layer2Mode = "off" | "observe" | "enforce";
  */
 export const DEFAULT_LAYER_2_MODE: Layer2Mode = "observe";
 
+export type ValidationCheck =
+  | "metadata_schema" // RecommendationMetadataSchema.safeParse failed
+  | "citation_source" // a cited field is absent from the snapshot
+  | "citation_value"; // a cited value mismatches the snapshot (beyond ±0.01)
+
+export interface ValidationFailure {
+  readonly check: ValidationCheck;
+  readonly detail: string;
+}
+
 export interface ValidationResult {
-  ok: boolean;
-  feedback?: string;
+  readonly ok: boolean;
+  readonly failures: readonly ValidationFailure[];
 }
 
 const META_DELIMITER = "---meta---";
@@ -76,8 +86,10 @@ export function getByPath(obj: unknown, path: string): unknown {
 /**
  * Asserts every citation in `metadata` resolves to a matching value in the
  * snapshot. Numbers compare within a ±0.01 tolerance; strings/enums compare
- * strictly. Returns the first failure's feedback string (the exact phrasing the
- * enforce-mode retry prompt quotes back to the LLM).
+ * strictly. Evaluates ALL checks and returns one failure per miss, each tagged
+ * with its check identity, so the offline per-lens gate can read each lens's
+ * verdict. The one short-circuit: a schema-parse failure leaves the citations
+ * unparseable, so the per-citation checks have nothing to run on.
  */
 export function validateRecommendation(
   _response: string,
@@ -88,29 +100,36 @@ export function validateRecommendation(
   if (!parsed.success) {
     return {
       ok: false,
-      feedback: `Metadata failed schema validation: ${parsed.error.message}`,
+      failures: [
+        {
+          check: "metadata_schema",
+          detail: `Metadata failed schema validation: ${parsed.error.message}`,
+        },
+      ],
     };
   }
 
   const meta: RecommendationMetadata = parsed.data;
+  const failures: ValidationFailure[] = [];
   for (const citation of meta.citations) {
     const actual = getByPath(snapshot, citation.field);
     if (actual === undefined) {
-      return {
-        ok: false,
-        feedback: `Citation source missing: ${citation.field} not found in snapshot.`,
-      };
+      failures.push({
+        check: "citation_source",
+        detail: `Citation source missing: ${citation.field} not found in snapshot.`,
+      });
+      continue;
     }
 
     if (!valuesMatch(actual, citation.value)) {
-      return {
-        ok: false,
-        feedback: `Citation mismatch: cited ${citation.field}=${String(citation.value)}, snapshot has ${String(actual)}.`,
-      };
+      failures.push({
+        check: "citation_value",
+        detail: `Citation mismatch: cited ${citation.field}=${String(citation.value)}, snapshot has ${String(actual)}.`,
+      });
     }
   }
 
-  return { ok: true };
+  return { ok: failures.length === 0, failures };
 }
 
 function valuesMatch(actual: unknown, cited: unknown): boolean {

--- a/packages/core/tests/coach-agent-turn-outcome.test.ts
+++ b/packages/core/tests/coach-agent-turn-outcome.test.ts
@@ -1,0 +1,262 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  mkdtempSync,
+  rmSync,
+  mkdirSync,
+  readFileSync,
+  existsSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { baseAgentConfig } from "./helpers/base-agent-config.js";
+import { cyclingSport } from "@enduragent/sport-cycling";
+import type { Sport } from "../src/sport.js";
+
+// The rate-limit retry cap in coach-agent.ts (a module-local const there).
+const MAX_RATE_LIMIT_ATTEMPTS = 3;
+
+let tempHome: string;
+let origHome: string | undefined;
+let dataDir: string;
+
+beforeEach(() => {
+  tempHome = mkdtempSync(join(tmpdir(), "cc-turnoutcome-"));
+  origHome = process.env.HOME;
+  process.env.HOME = tempHome;
+  dataDir = join(tempHome, ".cycling-coach");
+  mkdirSync(dataDir, { recursive: true });
+  mkdirSync(join(dataDir, "memory"), { recursive: true });
+  vi.resetModules();
+});
+
+afterEach(() => {
+  process.env.HOME = origHome;
+  rmSync(tempHome, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+const FLUSH_MARKER = "reviewing a conversation to extract and save important athlete";
+
+function mkAssistant(text: string, stopReason: "stop" | "length" = "stop") {
+  return {
+    role: "assistant" as const,
+    content: [{ type: "text" as const, text }],
+    api: "openai-codex-responses",
+    provider: "openai-codex",
+    model: "gpt-5.4",
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason,
+    timestamp: Date.now(),
+  };
+}
+
+async function setupAgent(complete: ReturnType<typeof vi.fn>) {
+  const model = {
+    id: "gpt-5.4",
+    name: "gpt-5.4",
+    api: "openai-codex-responses",
+    provider: "openai-codex",
+    baseUrl: "https://chatgpt.com/backend-api",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 272_000,
+    maxTokens: 128_000,
+  };
+
+  vi.doMock("@mariozechner/pi-ai", () => ({
+    complete,
+    getModel: vi.fn(() => model),
+  }));
+  vi.doMock("@mariozechner/pi-ai/oauth", () => ({
+    refreshOpenAICodexToken: vi.fn(),
+    loginOpenAICodex: vi.fn(),
+  }));
+  vi.doMock("../src/auth/profiles.js", () => ({
+    getFreshToken: vi.fn(async () => "token"),
+    loadProfile: vi.fn(),
+    saveProfile: vi.fn(),
+    RefreshTokenReusedError: class extends Error {},
+  }));
+
+  const { CoachAgent } = await import("../src/agent/coach-agent.js");
+  return new CoachAgent(cyclingSport as unknown as Sport, baseAgentConfig(dataDir));
+}
+
+interface OutcomeLine {
+  event: string;
+  turnId?: string;
+  chatId?: string;
+  ok?: boolean;
+  error_class?: string;
+  overflowAttempts?: number;
+  timeoutAttempts?: number;
+  rateLimitAttempts?: number;
+  duration_ms?: number;
+  compactions?: number;
+}
+
+function readOutcomeLines(): OutcomeLine[] {
+  const path = join(dataDir, "logs", "log.jsonl");
+  if (!existsSync(path)) return [];
+  return readFileSync(path, "utf-8")
+    .split("\n")
+    .filter((l) => l.length > 0)
+    .map((l) => JSON.parse(l) as OutcomeLine)
+    .filter((l) => l.event === "turn_outcome");
+}
+
+function sessionFile(chatId: string): string {
+  return join(dataDir, "sessions", `${chatId}.jsonl`);
+}
+
+function readSession(chatId: string): string | null {
+  const path = sessionFile(chatId);
+  return existsSync(path) ? readFileSync(path, "utf-8") : null;
+}
+
+describe("per-turn outcome line", () => {
+  it("a successful turn emits exactly one ok:true line", async () => {
+    const complete = vi.fn(async (_model: unknown, context: { systemPrompt?: string }) => {
+      const sys = context.systemPrompt ?? "";
+      if (sys.includes(FLUSH_MARKER)) return mkAssistant("facts noted");
+      if (sys.length === 0) return mkAssistant("summary");
+      return mkAssistant("all good");
+    });
+    const agent = await setupAgent(complete);
+
+    const text = await agent.chat("ok-chat", "hello");
+    expect(text).toBe("all good");
+
+    const lines = readOutcomeLines();
+    expect(lines).toHaveLength(1);
+    const line = lines[0];
+    expect(line.ok).toBe(true);
+    expect(line.error_class).toBeUndefined();
+    expect(typeof line.turnId).toBe("string");
+    expect(line.turnId!.length).toBeGreaterThan(0);
+    expect(line.chatId).toBe("ok-chat");
+    expect(typeof line.duration_ms).toBe("number");
+    expect(line.duration_ms).toBeGreaterThanOrEqual(0);
+    expect(line.overflowAttempts).toBe(0);
+    expect(line.timeoutAttempts).toBe(0);
+    expect(line.rateLimitAttempts).toBe(0);
+  });
+
+  it("a rate-limit retries-exhausted turn emits exactly one ok:false line with error_class rate_limit", async () => {
+    const complete = vi.fn(async (_model: unknown, context: { systemPrompt?: string }) => {
+      const sys = context.systemPrompt ?? "";
+      if (sys.includes(FLUSH_MARKER)) return mkAssistant("facts noted");
+      if (sys.length === 0) return mkAssistant("summary");
+      throw new Error("You have hit your rate limit. Try again later.");
+    });
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.useFakeTimers();
+    const agent = await setupAgent(complete);
+
+    const p = agent.chat("fail-chat", "hello");
+    const settled = p.then(
+      () => ({ ok: true as const }),
+      (error: unknown) => ({ ok: false as const, error }),
+    );
+    await vi.advanceTimersByTimeAsync(600_000);
+    const outcome = await settled;
+    vi.useRealTimers();
+
+    expect(outcome.ok).toBe(false);
+
+    const lines = readOutcomeLines();
+    expect(lines).toHaveLength(1);
+    expect(lines[0].ok).toBe(false);
+    expect(lines[0].error_class).toBe("rate_limit");
+    expect(lines[0].rateLimitAttempts).toBe(MAX_RATE_LIMIT_ATTEMPTS);
+  });
+
+  it("a retried-then-succeeded turn emits one ok:true line with the recovery counters", async () => {
+    let mainCalls = 0;
+    const complete = vi.fn(async (_model: unknown, context: { systemPrompt?: string }) => {
+      const sys = context.systemPrompt ?? "";
+      if (sys.includes(FLUSH_MARKER)) return mkAssistant("facts noted");
+      if (sys.length === 0) return mkAssistant("summary");
+      mainCalls++;
+      if (mainCalls === 1) {
+        throw new Error("Request exceeds the maximum context length of 272000 tokens");
+      }
+      return mkAssistant("recovered reply");
+    });
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const agent = await setupAgent(complete);
+
+    const text = await agent.chat("recover-chat", "hello");
+    expect(text).toBe("recovered reply");
+
+    const lines = readOutcomeLines();
+    expect(lines).toHaveLength(1);
+    expect(lines[0].ok).toBe(true);
+    expect(lines[0].overflowAttempts).toBe(1);
+    expect(lines[0].compactions).toBeGreaterThanOrEqual(1);
+  });
+
+  it("leaves the session JSONL byte-identical on a failed turn", async () => {
+    const complete = vi.fn(async (_model: unknown, context: { systemPrompt?: string }) => {
+      const sys = context.systemPrompt ?? "";
+      if (sys.includes(FLUSH_MARKER)) return mkAssistant("facts noted");
+      if (sys.length === 0) return mkAssistant("summary");
+      throw new Error("You have hit your rate limit. Try again later.");
+    });
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.useFakeTimers();
+    const agent = await setupAgent(complete);
+
+    const before = readSession("fail-chat");
+
+    const p = agent.chat("fail-chat", "hello");
+    const settled = p.then(
+      () => undefined,
+      () => undefined,
+    );
+    await vi.advanceTimersByTimeAsync(600_000);
+    await settled;
+    vi.useRealTimers();
+
+    const after = readSession("fail-chat");
+    expect(after).toBe(before);
+  });
+
+  it("does not reject when the outcome sink throws", async () => {
+    const complete = vi.fn(async (_model: unknown, context: { systemPrompt?: string }) => {
+      const sys = context.systemPrompt ?? "";
+      if (sys.includes(FLUSH_MARKER)) return mkAssistant("facts noted");
+      if (sys.length === 0) return mkAssistant("summary");
+      return mkAssistant("all good");
+    });
+    // Force the child logger's structured emit to throw so emitTurnOutcome's
+    // swallowing try/catch is exercised — the turn must still resolve.
+    vi.doMock("../src/logging/index.js", async () => {
+      const actual = await vi.importActual<typeof import("../src/logging/index.js")>(
+        "../src/logging/index.js",
+      );
+      return {
+        ...actual,
+        createSubsystemLogger: () => ({
+          debug: () => {},
+          info: () => {
+            throw new Error("sink boom");
+          },
+          warn: () => {},
+          error: () => {},
+        }),
+      };
+    });
+    const agent = await setupAgent(complete);
+
+    await expect(agent.chat("sink-chat", "hello")).resolves.toBe("all good");
+  });
+});

--- a/packages/core/tests/reference-audit-parse.test.ts
+++ b/packages/core/tests/reference-audit-parse.test.ts
@@ -84,17 +84,59 @@ describe("parseAuditLog", () => {
     expect(parsed).toEqual([a, b, c]);
   });
 
-  it("skips an unknown schema_version line with a warn", async () => {
+  it("parses a v2 line natively", async () => {
+    const v2 = {
+      schema_version: "2",
+      ts: new Date().toISOString(),
+      chatId: "v2-native",
+      responseHash: "0000000000000010",
+      metadata,
+      event_type: "tool_gate_block",
+      verdicts: [{ lens: "citation", ok: false, detail: "missing source" }],
+      prompt_template_hash: "abc123",
+    };
+    writeRawLog(JSON.stringify(v2) + "\n");
+
+    const parsed = await collect();
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].chatId).toBe("v2-native");
+    expect(parsed[0].event_type).toBe("tool_gate_block");
+    expect(parsed[0].verdicts).toEqual([
+      { lens: "citation", ok: false, detail: "missing source" },
+    ]);
+    expect(parsed[0].prompt_template_hash).toBe("abc123");
+  });
+
+  it("maps a v1 line forward to v2 with null verdicts and event_type reply", async () => {
+    const v1 = {
+      schema_version: "1",
+      ts: new Date().toISOString(),
+      chatId: "v1-line",
+      responseHash: "0000000000000011",
+      metadata,
+    };
+    writeRawLog(JSON.stringify(v1) + "\n");
+
+    const parsed = await collect();
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].chatId).toBe("v1-line");
+    expect(parsed[0].schema_version).toBe("2");
+    expect(parsed[0].event_type).toBe("reply");
+    expect(parsed[0].verdicts).toBeNull();
+    expect(parsed[0].prompt_template_hash).toBeNull();
+  });
+
+  it("still skips a genuinely unknown schema_version with a warn", async () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const valid = makeEntry({ chatId: "v1" });
-    const future = makeEntry({ chatId: "v2", schema_version: "2" });
+    const valid = makeEntry({ chatId: "current" });
+    const future = makeEntry({ chatId: "future", schema_version: "3" });
     writeRawLog(JSON.stringify(valid) + "\n" + JSON.stringify(future) + "\n");
 
     const parsed = await collect();
     expect(parsed).toHaveLength(1);
-    expect(parsed[0].chatId).toBe("v1");
+    expect(parsed[0].chatId).toBe("current");
     expect(warnSpy).toHaveBeenCalledTimes(1);
-    expect(warnSpy.mock.calls[0][0]).toContain("schema_version 2");
+    expect(warnSpy.mock.calls[0][0]).toContain("schema_version 3");
   });
 
   it("skips a malformed JSON line with a warn", async () => {

--- a/packages/core/tests/reference-recommendation-metadata.test.ts
+++ b/packages/core/tests/reference-recommendation-metadata.test.ts
@@ -68,8 +68,8 @@ describe("CitationSchema", () => {
 });
 
 describe("AuditLogEntrySchema", () => {
-  it("exposes AUDIT_SCHEMA_VERSION === '1'", () => {
-    expect(AUDIT_SCHEMA_VERSION).toBe("1");
+  it("exposes AUDIT_SCHEMA_VERSION === '2'", () => {
+    expect(AUDIT_SCHEMA_VERSION).toBe("2");
   });
 
   it("accepts a valid entry and round-trips it", () => {
@@ -95,6 +95,36 @@ describe("AuditLogEntrySchema", () => {
     };
     const parsed = AuditLogEntrySchema.parse(entry);
     expect(parsed.validation_warning).toBe(true);
+  });
+
+  it("accepts the v2 fields and round-trips them", () => {
+    const entry = {
+      schema_version: AUDIT_SCHEMA_VERSION,
+      ts: new Date().toISOString(),
+      chatId: "12345",
+      responseHash: "abcdef0123456789",
+      metadata: validMetadata,
+      event_type: "turn_failed" as const,
+      verdicts: [{ lens: "citation", ok: true, detail: null }],
+      prompt_template_hash: "deadbeefdeadbeef",
+    };
+    const parsed = AuditLogEntrySchema.parse(entry);
+    expect(parsed.event_type).toBe("turn_failed");
+    expect(parsed.verdicts).toEqual([{ lens: "citation", ok: true, detail: null }]);
+    expect(parsed.prompt_template_hash).toBe("deadbeefdeadbeef");
+  });
+
+  it("a minimal (v1-field-set) entry still parses under the v2 schema", () => {
+    // The v2 fields being optional is what keeps the v1->v2 map and the existing
+    // minimal-entry shape valid.
+    const entry = {
+      schema_version: AUDIT_SCHEMA_VERSION,
+      ts: new Date().toISOString(),
+      chatId: "12345",
+      responseHash: "abcdef0123456789",
+      metadata: validMetadata,
+    };
+    expect(() => AuditLogEntrySchema.parse(entry)).not.toThrow();
   });
 
   it("rejects an unknown top-level field (.strict() boundary)", () => {

--- a/packages/core/tests/reference-validate-response.test.ts
+++ b/packages/core/tests/reference-validate-response.test.ts
@@ -35,21 +35,23 @@ describe("validateRecommendation", () => {
   it("returns ok for an exactly-matching numeric citation", () => {
     const snapshot = makeSnapshot({ acwr: { value: 1.42 } });
     const meta = makeMetadata([{ field: "current_status.acwr.value", value: 1.42 }]);
-    expect(validateRecommendation("reply", meta, snapshot)).toEqual({ ok: true });
+    expect(validateRecommendation("reply", meta, snapshot)).toEqual({ ok: true, failures: [] });
   });
 
   it("returns ok for a citation within the ±0.01 tolerance", () => {
     const snapshot = makeSnapshot({ acwr: { value: 1.42 } });
     const meta = makeMetadata([{ field: "current_status.acwr.value", value: 1.425 }]);
-    expect(validateRecommendation("reply", meta, snapshot)).toEqual({ ok: true });
+    expect(validateRecommendation("reply", meta, snapshot)).toEqual({ ok: true, failures: [] });
   });
 
-  it("returns the exact mismatch feedback when off by more than tolerance", () => {
+  it("returns the exact mismatch detail when off by more than tolerance", () => {
     const snapshot = makeSnapshot({ acwr: { value: 1.42 } });
     const meta = makeMetadata([{ field: "current_status.acwr.value", value: 1.45 }]);
     const result = validateRecommendation("reply", meta, snapshot);
     expect(result.ok).toBe(false);
-    expect(result.feedback).toBe(
+    expect(result.failures).toHaveLength(1);
+    expect(result.failures[0].check).toBe("citation_value");
+    expect(result.failures[0].detail).toBe(
       "Citation mismatch: cited current_status.acwr.value=1.45, snapshot has 1.42.",
     );
   });
@@ -61,8 +63,10 @@ describe("validateRecommendation", () => {
     ]);
     const result = validateRecommendation("reply", meta, snapshot);
     expect(result.ok).toBe(false);
-    expect(result.feedback).toContain("current_status.monotony.value");
-    expect(result.feedback).toContain("not found in snapshot");
+    expect(result.failures).toHaveLength(1);
+    expect(result.failures[0].check).toBe("citation_source");
+    expect(result.failures[0].detail).toContain("current_status.monotony.value");
+    expect(result.failures[0].detail).toContain("not found in snapshot");
   });
 
   it("returns a strict mismatch for a string/enum citation", () => {
@@ -70,13 +74,14 @@ describe("validateRecommendation", () => {
     const meta = makeMetadata([{ field: "current_status.phase", value: "build" }]);
     const result = validateRecommendation("reply", meta, snapshot);
     expect(result.ok).toBe(false);
-    expect(result.feedback).toContain("current_status.phase");
+    expect(result.failures[0].check).toBe("citation_value");
+    expect(result.failures[0].detail).toContain("current_status.phase");
   });
 
   it("returns ok for a matching string/enum citation", () => {
     const snapshot = makeSnapshot({ phase: "base" });
     const meta = makeMetadata([{ field: "current_status.phase", value: "base" }]);
-    expect(validateRecommendation("reply", meta, snapshot)).toEqual({ ok: true });
+    expect(validateRecommendation("reply", meta, snapshot)).toEqual({ ok: true, failures: [] });
   });
 
   it("does not let a snapshot false/null/empty-string satisfy a cited 0", () => {
@@ -85,7 +90,7 @@ describe("validateRecommendation", () => {
       const meta = makeMetadata([{ field: "current_status.rest_flag", value: 0 }]);
       const result = validateRecommendation("reply", meta, snapshot);
       expect(result.ok).toBe(false);
-      expect(result.feedback).toContain("current_status.rest_flag");
+      expect(result.failures[0].detail).toContain("current_status.rest_flag");
     }
   });
 
@@ -95,7 +100,7 @@ describe("validateRecommendation", () => {
       const meta = makeMetadata([{ field: "current_status.load", value: citedValue }]);
       const result = validateRecommendation("reply", meta, snapshot);
       expect(result.ok).toBe(false);
-      expect(result.feedback).toContain("current_status.load");
+      expect(result.failures[0].detail).toContain("current_status.load");
     }
   });
 
@@ -111,7 +116,26 @@ describe("validateRecommendation", () => {
     };
     const result = validateRecommendation("reply", badMeta, snapshot);
     expect(result.ok).toBe(false);
-    expect(result.feedback).toContain("Metadata failed schema validation");
+    expect(result.failures).toHaveLength(1);
+    expect(result.failures[0].check).toBe("metadata_schema");
+    expect(result.failures[0].detail).toContain("Metadata failed schema validation");
+  });
+
+  it("collects ALL citation failures, not just the first", () => {
+    const snapshot = makeSnapshot({ acwr: { value: 1.42 } });
+    const meta = makeMetadata([
+      // First citation: a missing source.
+      { field: "current_status.monotony.value", value: 1.1 },
+      // Second citation: a value mismatch on a present field.
+      { field: "current_status.acwr.value", value: 1.99 },
+    ]);
+    const result = validateRecommendation("reply", meta, snapshot);
+    expect(result.ok).toBe(false);
+    expect(result.failures).toHaveLength(2);
+    expect(result.failures.map((f) => f.check)).toEqual([
+      "citation_source",
+      "citation_value",
+    ]);
   });
 });
 


### PR DESCRIPTION
Restructures validation results so all checks are evaluated (not first-failure-return), bumps the audit schema to v2 in one move, and emits a per-turn outcome line so the CLI and Telegram surfaces cannot diverge.

- `ValidationResult` becomes `{ ok, failures: [{ check, detail }] }` with a closed check enum; all checks run.
- A single `AUDIT_SCHEMA_VERSION` v2 bump absorbs the per-lens verdicts, the event-type discriminator, the reserved `turn_failed` class, and the prompt-lineage hash field; the parser becomes multi-version (v1 -> v2-with-nulls).
- The coach-agent emits one per-turn outcome line (turn id, ok, error class, attempt counters, duration, compactions); the session store stays success-only.

Stacked on the previous PR (base `feature/per-turn-budget-and-write-guard`).

Changeset: none (internal / observability surface).

## Test plan
`pnpm check` / `pnpm test` green (validate-response, audit-parse, recommendation-metadata, and a new coach-agent turn-outcome suite; required-reds verified).
