### PR TITLE
fix(core): deliver the reply before persistence and append history atomically

### DIFF
--- a/.changeset/deliver-reply-before-persist.md
+++ b/.changeset/deliver-reply-before-persist.md
@@ -1,0 +1,7 @@
+---
+"@enduragent/core": patch
+---
+
+User-facing: Fixed a bug where a full disk could discard a reply you'd already received — the coach now always shows the reply and tells you once if it couldn't save it to your history.
+
+The chat turn now delivers the generated reply even when the session append throws, so a full disk or permission error never discards a reply you already paid for. Both session lines are written as a single atomic append, so a partial half-turn can never land, and a disk-full condition is surfaced to you once per process. The fix lives in Core, so both the CLI and the Telegram channel are fixed without a channel edit — mirroring the audit writer's never-break-the-reply-path discipline.

--- a/packages/core/src/agent/chat-store.ts
+++ b/packages/core/src/agent/chat-store.ts
@@ -123,6 +123,22 @@ export class ChatStore {
     appendFileSync(path, JSON.stringify(line) + "\n", { encoding: "utf-8", mode: 0o600 });
   }
 
+  appendTurn(
+    chatId: string,
+    userContent: string,
+    assistantContent: string,
+    lineage: { templateHash: string; assembledHash: string; provider: string; model: string },
+  ): void {
+    const path = this.filePath(chatId);
+    const ts = new Date().toISOString();
+    const userLine: JsonlLine = { role: "user", content: userContent, ts };
+    const assistantLine: JsonlLine = { role: "assistant", content: assistantContent, ts, ...lineage };
+    // Both lines in one buffer and one write so the pair lands together or not
+    // at all — a partial write can never leave a dangling user line.
+    const buffer = JSON.stringify(userLine) + "\n" + JSON.stringify(assistantLine) + "\n";
+    appendFileSync(path, buffer, { encoding: "utf-8", mode: 0o600 });
+  }
+
   overwriteHistory(chatId: string, messages: ModelMessage[]): void {
     const path = this.filePath(chatId);
     const tmpPath = `${path}.tmp`;

--- a/packages/core/src/agent/coach-agent.ts
+++ b/packages/core/src/agent/coach-agent.ts
@@ -117,6 +117,22 @@ function classifyError(err: unknown): string {
   return "unknown";
 }
 
+// Replays a pre-captured error to retryWithBackoff exactly once so it performs a
+// single capped backoff sleep: the first invocation rethrows `err`, the second
+// resolves. All scheduling (jitter, retry-after floor, onRetry) stays in opts.
+function backoffWithSentinelError(
+  err: unknown,
+  opts: Parameters<typeof retryWithBackoff>[1],
+): Promise<void> {
+  let retried = false;
+  return retryWithBackoff(async () => {
+    if (!retried) {
+      retried = true;
+      throw err;
+    }
+  }, opts);
+}
+
 // ============================================================================
 // AGENT
 // ============================================================================
@@ -602,26 +618,17 @@ export class CoachAgent {
               const clampNote = requestedMs > RATE_LIMIT_MAX_WAIT_MS
                 ? ` (provider requested ${requestedMs}ms, clamped to ${RATE_LIMIT_MAX_WAIT_MS}ms)`
                 : "";
-              let retried = false;
-              await retryWithBackoff(
-                async () => {
-                  if (!retried) {
-                    retried = true;
-                    throw err;
-                  }
+              await backoffWithSentinelError(err, {
+                attempts: 2,
+                baseMs: requestedMs,
+                capMs: RATE_LIMIT_MAX_WAIT_MS,
+                shouldRetry: () => true,
+                retryAfterMs: () => requestedMs,
+                random: () => 0,
+                onRetry: ({ delayMs }) => {
+                  console.warn(`Rate limited (attempt ${attemptNo}/${MAX_RATE_LIMIT_ATTEMPTS}), waiting ${delayMs}ms${clampNote}`);
                 },
-                {
-                  attempts: 2,
-                  baseMs: requestedMs,
-                  capMs: RATE_LIMIT_MAX_WAIT_MS,
-                  shouldRetry: () => true,
-                  retryAfterMs: () => requestedMs,
-                  random: () => 0,
-                  onRetry: ({ delayMs }) => {
-                    console.warn(`Rate limited (attempt ${attemptNo}/${MAX_RATE_LIMIT_ATTEMPTS}), waiting ${delayMs}ms${clampNote}`);
-                  },
-                },
-              );
+              });
               // The backoff sleep is the one place a turn can silently burn
               // minutes; converting a long Retry-After wait into a clean budget
               // stop here means the deadline never wedges the session lock.
@@ -646,22 +653,13 @@ export class CoachAgent {
             ) {
               serverErrorAttempts++;
               const retryAfterFloor = retryAfterFloorMs(err);
-              let retried = false;
-              await retryWithBackoff(
-                async () => {
-                  if (!retried) {
-                    retried = true;
-                    throw err;
-                  }
-                },
-                {
-                  attempts: 2,
-                  baseMs: retryAfterFloor ?? SERVER_ERROR_BACKOFF_BASE_MS,
-                  capMs: SERVER_ERROR_BACKOFF_MAX_MS,
-                  shouldRetry: () => true,
-                  retryAfterMs: () => retryAfterFloor,
-                },
-              );
+              await backoffWithSentinelError(err, {
+                attempts: 2,
+                baseMs: retryAfterFloor ?? SERVER_ERROR_BACKOFF_BASE_MS,
+                capMs: SERVER_ERROR_BACKOFF_MAX_MS,
+                shouldRetry: () => true,
+                retryAfterMs: () => retryAfterFloor,
+              });
               turnBudget.checkDeadline();
               continue;
             }

--- a/packages/core/src/agent/coach-agent.ts
+++ b/packages/core/src/agent/coach-agent.ts
@@ -54,6 +54,25 @@ const MAX_FLUSH_ATTEMPTS = 2;
 // Kept here so the taint set can't drift from the actual tool names.
 const WRITE_TOOL_NAMES = new Set(["intervals_create_workout", "intervals_delete_workout"]);
 
+const DISK_FULL_NOTE =
+  "\n\n(Heads up: my disk is full, so I couldn't save this to our history — but your message went through. Please free up some space when you can.)";
+
+// Disk-full is a host condition, not a per-chat one, so the athlete is told
+// once for the whole process rather than every turn the disk stays full.
+let persistenceNoticeShown = false;
+
+function noteForPersistenceFailure(err: unknown): string {
+  const code = (err as NodeJS.ErrnoException | undefined)?.code;
+  if (code !== "ENOSPC") return "";
+  if (persistenceNoticeShown) return "";
+  persistenceNoticeShown = true;
+  return DISK_FULL_NOTE;
+}
+
+export function __resetPersistenceNoticeState(): void {
+  persistenceNoticeShown = false;
+}
+
 type MemoryFlushTrigger =
   | "stale-reset"
   | "explicit-reset"
@@ -439,14 +458,23 @@ export class CoachAgent {
             }));
             const assembledHash = computeAssembledHash(this.systemPrompt, messages);
 
-            // Append BOTH after success — JSONL unchanged on failure
-            this.chatStore.appendMessage(chatId, "user", userMessage);
-            this.chatStore.appendMessage(chatId, "assistant", text, {
-              templateHash,
-              assembledHash,
-              provider: this.config.llm.provider,
-              model: this.config.llm.model,
-            });
+            // Append BOTH after success as one atomic write — JSONL unchanged
+            // on failure, no dangling user line on a partial write.
+            let persistenceNote = "";
+            try {
+              this.chatStore.appendTurn(chatId, userMessage, text, {
+                templateHash,
+                assembledHash,
+                provider: this.config.llm.provider,
+                model: this.config.llm.model,
+              });
+            } catch (persistErr) {
+              // Deliver-first: a full disk or permission error must never
+              // discard a reply the athlete already paid for. Swallow the
+              // persistence throw, warn once, and still return the reply.
+              console.warn("Session persistence failed; delivering reply unsaved", persistErr);
+              persistenceNote = noteForPersistenceFailure(persistErr);
+            }
 
             // A turn can run several generations (retry/compaction/overflow
             // recovery); these usage/cost figures are the FINAL successful
@@ -474,7 +502,7 @@ export class CoachAgent {
               compactions,
             });
 
-            return text;
+            return text + persistenceNote;
           } catch (err) {
             // The classified budget error is terminal: re-throw it before any
             // retry branch so a future reordering can never mistake it for one of

--- a/packages/core/src/agent/coach-agent.ts
+++ b/packages/core/src/agent/coach-agent.ts
@@ -44,6 +44,17 @@ const MAX_RATE_LIMIT_ATTEMPTS = 3;
 const MAX_SERVER_ERROR_ATTEMPTS = 2;
 const SERVER_ERROR_BACKOFF_BASE_MS = 500;
 const SERVER_ERROR_BACKOFF_MAX_MS = 5_000;
+
+// The AI-SDK path exposes Retry-After via APICallError response headers
+// (extractRetryAfterMs). Codex-normalized ServerError/RateLimitError instead
+// carry the parsed hint as a numeric `retryAfterMs` property, so honor that too;
+// otherwise the bridge parses a header the retry loop never reads.
+function retryAfterFloorMs(err: unknown): number | null {
+  const fromHeaders = extractRetryAfterMs(err);
+  if (fromHeaders !== null) return fromHeaders;
+  const carried = (err as { retryAfterMs?: unknown }).retryAfterMs;
+  return typeof carried === "number" && Number.isFinite(carried) && carried > 0 ? carried : null;
+}
 const RATE_LIMIT_FALLBACK_BASE_MS = 5_000;
 const RATE_LIMIT_FALLBACK_MULTIPLIER = 2;
 const RATE_LIMIT_FALLBACK_MAX_MS = 30_000;
@@ -583,7 +594,7 @@ export class CoachAgent {
               // The server hint (if any) is a lower bound; absent one, fall back to a
               // capped exponential. Either feeds the primitive as the Retry-After
               // floor so the 120s ceiling and the clamp note are honored bit-for-bit.
-              const requestedMs = extractRetryAfterMs(err)
+              const requestedMs = retryAfterFloorMs(err)
                 ?? Math.min(
                      RATE_LIMIT_FALLBACK_BASE_MS * RATE_LIMIT_FALLBACK_MULTIPLIER ** (attemptNo - 1),
                      RATE_LIMIT_FALLBACK_MAX_MS,
@@ -634,7 +645,7 @@ export class CoachAgent {
               serverErrorAttempts < MAX_SERVER_ERROR_ATTEMPTS
             ) {
               serverErrorAttempts++;
-              const retryAfterFloor = extractRetryAfterMs(err);
+              const retryAfterFloor = retryAfterFloorMs(err);
               let retried = false;
               await retryWithBackoff(
                 async () => {

--- a/packages/core/src/logging/levels.ts
+++ b/packages/core/src/logging/levels.ts
@@ -17,10 +17,6 @@ export function normalizeLogLevel(s?: string): LogLevel {
     : "info";
 }
 
-export function logLevelRank(level: LogLevel): number {
-  return LEVEL_ORDER[level];
-}
-
 // A line at `lineLevel` is emitted when the configured threshold is at least as
 // verbose. `silent` emits nothing; `debug` lets everything through.
 export function isLevelEnabled(lineLevel: LogLevel, threshold: LogLevel): boolean {

--- a/packages/core/src/logging/logger.ts
+++ b/packages/core/src/logging/logger.ts
@@ -150,7 +150,3 @@ export function createRootLogger(dataDir: string, options: RootLoggerOptions = {
     },
   };
 }
-
-export function __resetLoggingEscalationForTesting(): void {
-  escalatedOnce = false;
-}

--- a/packages/core/src/logging/redact.ts
+++ b/packages/core/src/logging/redact.ts
@@ -6,7 +6,7 @@ const DENYLIST_KEY_SUBSTRINGS = ["authorization", "api_key", "apikey", "token", 
 // Bounded so a hostile or cyclic object can never hang the logger.
 const MAX_REDACT_DEPTH = 6;
 
-function keyIsDenied(key: string): boolean {
+export function keyIsDenied(key: string): boolean {
   const lower = key.toLowerCase();
   return DENYLIST_KEY_SUBSTRINGS.some((needle) => lower.includes(needle));
 }

--- a/packages/core/src/logging/serialize-error.ts
+++ b/packages/core/src/logging/serialize-error.ts
@@ -1,4 +1,4 @@
-import { redactObject, REDACTION_SENTINEL } from "./redact.js";
+import { redactObject, REDACTION_SENTINEL, keyIsDenied } from "./redact.js";
 
 // Fields on a provider/SDK error that carry the outbound prompt or response
 // body — the conversation, the memory-bearing system prompt, the athlete's
@@ -51,14 +51,7 @@ export function serializeError(err: unknown): Record<string, unknown> {
       if (DROP_FIELDS.has(key)) continue;
       if (key === "name" || key === "message" || key === "stack") continue;
       if ((KEEP_FIELDS as readonly string[]).includes(key)) continue;
-      const lower = key.toLowerCase();
-      if (
-        lower.includes("authorization") ||
-        lower.includes("api_key") ||
-        lower.includes("apikey") ||
-        lower.includes("token") ||
-        lower.includes("cookie")
-      ) {
+      if (keyIsDenied(key)) {
         out[key] = REDACTION_SENTINEL;
         continue;
       }

--- a/packages/core/src/process-guard.ts
+++ b/packages/core/src/process-guard.ts
@@ -84,10 +84,17 @@ export function logBootLine(opts: { dataDir: string }): void {
   const log = createSubsystemLogger("agent", opts.dataDir);
   try {
     log.info("boot", { pid: process.pid });
-    if (prior !== undefined && prior.status !== "unclean") {
-      // A breadcrumb left in `running` state at the next boot means the prior
-      // run died without a clean shutdown.
-      log.warn("previous_run_unclean", undefined, { startedAt: prior.startedAt });
+    if (prior !== undefined) {
+      // Any breadcrumb still present at boot means the prior run never reached a
+      // clean shutdown (which deletes it): `unclean` = a crash handler fired and
+      // recorded the death; `running` = a hard death (SIGKILL / power loss) with
+      // no handler. Both must surface, and a handler-recorded `uncleanAt` must
+      // carry into this durable line before the file is re-armed below.
+      log.warn("previous_run_unclean", undefined, {
+        startedAt: prior.startedAt,
+        priorStatus: prior.status,
+        ...(prior.uncleanAt !== undefined ? { uncleanAt: prior.uncleanAt } : {}),
+      });
     }
   } catch {
     // The logger never throws by contract; stay defensive at startup.

--- a/packages/core/tests/chat-store.test.ts
+++ b/packages/core/tests/chat-store.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
   existsSync,
   mkdtempSync,
@@ -12,6 +12,25 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { ChatStore } from "../src/agent/chat-store.js";
 
+// ESM module namespaces are non-configurable, so vi.spyOn cannot intercept a
+// named fs import. Mock the module up front: appendFileSync is a spy that
+// delegates to the real implementation (captured inside the factory so it is
+// not itself the mock) unless a test flips throwState.shouldThrow. vi.hoisted
+// makes the spy + flag available to the hoisted vi.mock factory.
+const { appendFileSyncSpy, throwState } = vi.hoisted(() => ({
+  appendFileSyncSpy: vi.fn(),
+  throwState: { shouldThrow: null as (() => never) | null },
+}));
+vi.mock("node:fs", async () => {
+  const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+  const realAppend = actual.appendFileSync;
+  appendFileSyncSpy.mockImplementation((path: string, data: string, opts?: unknown) => {
+    if (throwState.shouldThrow) throwState.shouldThrow();
+    return realAppend(path, data, opts as Parameters<typeof realAppend>[2]);
+  });
+  return { ...actual, appendFileSync: (...args: [string, string, unknown?]) => appendFileSyncSpy(...args) };
+});
+
 let dataDir: string;
 let sessionsDir: string;
 
@@ -22,7 +41,11 @@ beforeEach(() => {
 
 afterEach(() => {
   rmSync(dataDir, { recursive: true, force: true });
+  throwState.shouldThrow = null;
+  appendFileSyncSpy.mockClear();
 });
+
+const LINEAGE = { templateHash: "t", assembledHash: "h", provider: "p", model: "m" };
 
 function listArchives(chatId: string): string[] {
   return readdirSync(sessionsDir)
@@ -212,5 +235,40 @@ describe("ChatStore.archivePreCompact — pre-compaction archives", () => {
 
     expect(listArchives("123")).not.toContain(oldReset);
     expect(listPrecompactArchives("123")).toHaveLength(1);
+  });
+});
+
+describe("ChatStore.appendTurn — single-buffer atomic two-line append", () => {
+  it("issues exactly one appendFileSync writing both the user and assistant line", () => {
+    const store = new ChatStore(dataDir);
+    appendFileSyncSpy.mockClear();
+
+    store.appendTurn("c1", "u", "a", LINEAGE);
+
+    // The ChatStore constructor's mkdir does not append, so the only append in
+    // this turn is appendTurn's single write.
+    expect(appendFileSyncSpy).toHaveBeenCalledTimes(1);
+    const buffer = appendFileSyncSpy.mock.calls[0][1] as string;
+    expect(buffer).toContain('"role":"user"');
+    expect(buffer).toContain('"role":"assistant"');
+
+    const { messages } = store.load("c1");
+    expect(messages).toEqual([
+      { role: "user", content: "u" },
+      { role: "assistant", content: "a" },
+    ]);
+  });
+
+  it("throws on an fs error and leaves no dangling user line", () => {
+    const store = new ChatStore(dataDir);
+    throwState.shouldThrow = () => {
+      throw Object.assign(new Error("ENOSPC: no space left"), { code: "ENOSPC" });
+    };
+
+    expect(() => store.appendTurn("c1", "u", "a", LINEAGE)).toThrow();
+
+    throwState.shouldThrow = null;
+    expect(existsSync(join(sessionsDir, "c1.jsonl"))).toBe(false);
+    expect(store.load("c1").messages).toEqual([]);
   });
 });

--- a/packages/core/tests/coach-agent-deliver-first.test.ts
+++ b/packages/core/tests/coach-agent-deliver-first.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  mkdtempSync,
+  rmSync,
+  mkdirSync,
+  readFileSync,
+  existsSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { baseAgentConfig } from "./helpers/base-agent-config.js";
+import { cyclingSport } from "@enduragent/sport-cycling";
+import type { Sport } from "../src/sport.js";
+
+let tempHome: string;
+let origHome: string | undefined;
+let dataDir: string;
+
+beforeEach(() => {
+  tempHome = mkdtempSync(join(tmpdir(), "cc-deliver-first-"));
+  origHome = process.env.HOME;
+  process.env.HOME = tempHome;
+  dataDir = join(tempHome, ".cycling-coach");
+  mkdirSync(dataDir, { recursive: true });
+  mkdirSync(join(dataDir, "memory"), { recursive: true });
+  vi.resetModules();
+});
+
+const FLUSH_MARKER = "reviewing a conversation to extract and save important athlete";
+
+function mkAssistant(text: string) {
+  return {
+    role: "assistant" as const,
+    content: [{ type: "text" as const, text }],
+    api: "openai-codex-responses",
+    provider: "openai-codex",
+    model: "gpt-5.4",
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: "stop" as const,
+    timestamp: Date.now(),
+  };
+}
+
+function errored(code: string): NodeJS.ErrnoException {
+  return Object.assign(new Error(`${code}: append failed`), { code });
+}
+
+async function setupAgent(complete: ReturnType<typeof vi.fn>) {
+  const model = {
+    id: "gpt-5.4",
+    name: "gpt-5.4",
+    api: "openai-codex-responses",
+    provider: "openai-codex",
+    baseUrl: "https://chatgpt.com/backend-api",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 272_000,
+    maxTokens: 128_000,
+  };
+
+  vi.doMock("@mariozechner/pi-ai", () => ({
+    complete,
+    getModel: vi.fn(() => model),
+  }));
+  vi.doMock("@mariozechner/pi-ai/oauth", () => ({
+    refreshOpenAICodexToken: vi.fn(),
+    loginOpenAICodex: vi.fn(),
+  }));
+  vi.doMock("../src/auth/profiles.js", () => ({
+    getFreshToken: vi.fn(async () => "token"),
+    loadProfile: vi.fn(),
+    saveProfile: vi.fn(),
+    RefreshTokenReusedError: class extends Error {},
+  }));
+
+  const { CoachAgent, __resetPersistenceNoticeState } = await import("../src/agent/coach-agent.js");
+  const { ChatStore } = await import("../src/agent/chat-store.js");
+  const agent = new CoachAgent(cyclingSport as unknown as Sport, baseAgentConfig(dataDir));
+  return { agent, ChatStore, __resetPersistenceNoticeState };
+}
+
+function happyComplete(reply: string) {
+  return vi.fn(async (_model: unknown, context: { systemPrompt?: string }) => {
+    const sys = context.systemPrompt ?? "";
+    if (sys.includes(FLUSH_MARKER)) return mkAssistant("facts noted");
+    if (sys.length === 0) return mkAssistant("summary");
+    return mkAssistant(reply);
+  });
+}
+
+function sessionFile(chatId: string): string {
+  return join(dataDir, "sessions", `${chatId}.jsonl`);
+}
+
+const DISK_FULL_FRAGMENT = "disk is full";
+
+describe("coach-agent deliver-first persistence", () => {
+  let resetNotice: () => void;
+
+  afterEach(() => {
+    resetNotice?.();
+    process.env.HOME = origHome;
+    rmSync(tempHome, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it("delivers the reply on an ENOSPC append and appends the disk-full note only once", async () => {
+    const { agent, ChatStore, __resetPersistenceNoticeState } = await setupAgent(
+      happyComplete("here is your reply"),
+    );
+    resetNotice = __resetPersistenceNoticeState;
+    resetNotice();
+    vi.spyOn(ChatStore.prototype, "appendTurn").mockImplementation(() => {
+      throw errored("ENOSPC");
+    });
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const first = await agent.chat("disk-chat", "hello");
+    expect(first).toContain("here is your reply");
+    expect(first).toContain(DISK_FULL_FRAGMENT);
+
+    const second = await agent.chat("disk-chat", "again");
+    expect(second).toContain("here is your reply");
+    expect(second).not.toContain(DISK_FULL_FRAGMENT);
+  });
+
+  it("delivers the reply on a non-ENOSPC append with no athlete note", async () => {
+    const { agent, ChatStore, __resetPersistenceNoticeState } = await setupAgent(
+      happyComplete("eacces reply"),
+    );
+    resetNotice = __resetPersistenceNoticeState;
+    resetNotice();
+    vi.spyOn(ChatStore.prototype, "appendTurn").mockImplementation(() => {
+      throw errored("EACCES");
+    });
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const text = await agent.chat("eacces-chat", "hello");
+    expect(text).toBe("eacces reply");
+    expect(text).not.toContain(DISK_FULL_FRAGMENT);
+  });
+
+  it("happy path returns the reply with no note and persists the turn", async () => {
+    const { agent, __resetPersistenceNoticeState } = await setupAgent(
+      happyComplete("persisted reply"),
+    );
+    resetNotice = __resetPersistenceNoticeState;
+    resetNotice();
+
+    const text = await agent.chat("happy-chat", "hello");
+    expect(text).toBe("persisted reply");
+    expect(text).not.toContain(DISK_FULL_FRAGMENT);
+
+    expect(existsSync(sessionFile("happy-chat"))).toBe(true);
+    const lines = readFileSync(sessionFile("happy-chat"), "utf-8")
+      .split("\n")
+      .filter((l) => l.length > 0);
+    expect(lines.some((l) => l.includes('"role":"user"'))).toBe(true);
+    expect(lines.some((l) => l.includes('"role":"assistant"'))).toBe(true);
+  });
+});

--- a/packages/core/tests/codex-bridge.test.ts
+++ b/packages/core/tests/codex-bridge.test.ts
@@ -501,10 +501,13 @@ describe("codex-bridge network-error escape", () => {
     expect(out.status).toBe(500);
   });
 
-  it("installs the wrapper around complete() so a single fetch throw surfaces marked, once", async () => {
-    // Drive the real bridge wrapper: complete() makes ONE fetch call, which the
-    // installed wrapper has swapped to throw-and-mark. The library would retry a
-    // raw network throw up to 4x; the marker short-circuits it to one attempt.
+  it("installs the wrapper so the library retry loop short-circuits a network throw to one fetch", async () => {
+    // The wrapper the bridge installs around complete() rethrows a network throw
+    // carrying PI_AI_NO_RETRY_MARKER. `complete` models pi-ai's real predicate —
+    // retry up to 4x UNLESS the error message carries that marker — so this test
+    // actually exercises the short-circuit: with the marker, fetch runs once;
+    // remove the marker rethrow and the loop runs the inner fetch 4 times.
+    const PI_AI_MAX_RETRIES = 4;
     const fetchSpy = vi.fn(async () => {
       // Undici buries the connection code on .cause.code of a "fetch failed".
       const e = new TypeError("fetch failed");
@@ -512,9 +515,19 @@ describe("codex-bridge network-error escape", () => {
       throw e;
     });
     const complete = vi.fn(async () => {
-      // Exactly one fetch attempt, mirroring the marker-short-circuited loop.
-      await (globalThis.fetch as unknown as typeof fetchSpy)();
-      return asstMsg();
+      let lastError: unknown;
+      for (let attempt = 0; attempt < PI_AI_MAX_RETRIES; attempt++) {
+        try {
+          await (globalThis.fetch as unknown as typeof fetchSpy)();
+          return asstMsg();
+        } catch (e) {
+          lastError = e;
+          // pi-ai 0.67.x retries a network throw unless its message carries the
+          // no-retry marker; the installed wrapper is what stamps that marker.
+          if (e instanceof Error && e.message.includes(PI_AI_NO_RETRY_MARKER)) throw e;
+        }
+      }
+      throw lastError;
     });
     const { codexGenerateText } = await loadBridgeWithMocks({ complete });
     vi.spyOn(globalThis, "fetch").mockImplementation(fetchSpy as unknown as typeof fetch);
@@ -530,6 +543,7 @@ describe("codex-bridge network-error escape", () => {
       thrown = err;
     }
 
+    // The marker stopped pi-ai's loop after the first attempt (not 4).
     expect(fetchSpy).toHaveBeenCalledTimes(1);
     expect(thrown).toBeInstanceOf(Error);
     // The surfaced (normalized) error is a network error, never rate-limit.

--- a/packages/core/tests/process-guard.test.ts
+++ b/packages/core/tests/process-guard.test.ts
@@ -165,6 +165,23 @@ describe("logBootLine + breadcrumb lifecycle", () => {
 
     expect(captured.some((c) => c.event === "previous_run_unclean")).toBe(false);
   });
+
+  it("flags a handler-written `unclean` breadcrumb at the next boot and carries uncleanAt", async () => {
+    const { logBootLine } = await loadGuard();
+    const uncleanAt = 1_700_000_000_000;
+    // Simulate a prior run whose crash handler fired and recorded the death.
+    writeFileSync(
+      breadcrumb(),
+      JSON.stringify({ startedAt: uncleanAt - 5_000, status: "unclean", uncleanAt }),
+    );
+    captured.length = 0;
+    logBootLine({ dataDir: tempHome });
+
+    const warn = captured.find((c) => c.event === "previous_run_unclean");
+    expect(warn).toBeDefined();
+    expect(warn!.line.priorStatus).toBe("unclean");
+    expect(warn!.line.uncleanAt).toBe(uncleanAt);
+  });
 });
 
 describe("reportFatal", () => {


### PR DESCRIPTION
Delivers the generated reply even when persistence fails, appends history atomically — and carries the series' post-review cleanup.

- `chat-store` gains an atomic two-line `appendTurn`; the coach-agent sends the reply before persisting and, on a persistence throw, warns once (a single ENOSPC "disk full — history not saved" notice) instead of discarding a paid-for reply. Write-side only.
- Folds in the series' two post-review commits: the review-fix commit (crash-breadcrumb `unclean`-state surfacing, codex `Retry-After` consumption, a non-vacuous marker test) and a simplification pass (shared key-denylist reuse, a hoisted backoff helper, two dead symbols removed). These span several of the earlier files, so they ride at the tip of the stack rather than inside one task's PR.

Stacked on the previous PR (base `feature/provider-error-taxonomy`); the tip of the series.

Changeset: yes (deliver-first persistence guard is athlete-visible).

## Test plan
`pnpm check` exit 0; `pnpm test` 167 files / 2449 passed on current `main`.
