### PR TITLE
fix(core): give the sync fetch a per-endpoint error channel and content-hash short-circuit

### DIFF
--- a/.changeset/sync-fetch-error-channel.md
+++ b/.changeset/sync-fetch-error-channel.md
@@ -1,0 +1,7 @@
+---
+"@enduragent/core": patch
+---
+
+User-facing: A sync hiccup no longer silently blanks your data behind a "fresh" stamp — if a data source errors, the coach keeps the last good snapshot and records the failure instead of overwriting it with empties.
+
+Per-endpoint fetch failures (athlete-profile, wellness) now ride a Result-shaped error channel into the Reference layer's data-fetch gate; the gate's data-fetch precondition hard-fails naming the endpoint, so the failed sync routes through the existing gate-rejection path — the prior cache file is preserved, the freshness stamp is not advanced, and the error state records the failure. The same pass adds a content-hash short-circuit to the sync write loop: a no-op cycle (re-fetched data identical modulo metadata) now skips the cache writes entirely, leaving the files byte-identical instead of re-stamping a fresh timestamp every cycle; the sidecar commit marker still advances each cycle.

--- a/packages/core/src/reference/sync/fetch-live-bundle.ts
+++ b/packages/core/src/reference/sync/fetch-live-bundle.ts
@@ -96,6 +96,14 @@ export interface BundleFetchClient {
   };
 }
 
+/** One per-endpoint fetch failure: which source envelope returned an error and
+ *  a human-readable reason. A present, non-empty list is "errored" — distinct
+ *  from a successful fetch that legitimately returned empty data. */
+export interface FetchEndpointError {
+  readonly endpoint: string;
+  readonly detail: string;
+}
+
 export interface LiveFetchResult {
   /** Raw athlete object — cached verbatim as `latest.athlete_profile`. */
   readonly athleteProfile: unknown;
@@ -107,6 +115,12 @@ export interface LiveFetchResult {
   readonly bundle: ReferenceBundle;
   /** Sync wall-clock as an ISO string — the metric date-window anchor. */
   readonly frozenNow: string;
+  /** Endpoints that returned an error (athlete-profile, wellness) and were
+   *  filled with empty fallbacks to keep the bundle well-typed. The gate turns
+   *  a non-empty list into a hard-fail so a swallowed failure can no longer
+   *  commit empty data behind a fresh stamp. Omitted when every endpoint was
+   *  reachable. */
+  readonly fetchErrors?: readonly FetchEndpointError[];
 }
 
 function ymd(date: Date): string {
@@ -240,8 +254,14 @@ export async function fetchLiveBundle(deps: LiveFetchDeps): Promise<LiveFetchRes
   const newest = ymd(now);
   const oldest = ymd(new Date(now.getTime() - FETCH_WINDOW_DAYS * 24 * 60 * 60 * 1000));
 
+  const fetchErrors: FetchEndpointError[] = [];
+
   const athleteResult = await client.athlete.get();
-  if (!athleteResult.ok) log(`Reference: athlete.get failed: ${String(athleteResult.error)}`);
+  if (!athleteResult.ok) {
+    const detail = String(athleteResult.error);
+    log(`Reference: athlete.get failed: ${detail}`);
+    fetchErrors.push({ endpoint: "athlete", detail });
+  }
   const athleteProfile = athleteResult.ok ? athleteResult.value : {};
 
   const actResult = await client.activities.list({ oldest, newest });
@@ -260,7 +280,11 @@ export async function fetchLiveBundle(deps: LiveFetchDeps): Promise<LiveFetchRes
   }
 
   const wellResult = await client.wellness.list({ oldest, newest });
-  if (!wellResult.ok) log(`Reference: wellness.list failed: ${String(wellResult.error)}`);
+  if (!wellResult.ok) {
+    const detail = String(wellResult.error);
+    log(`Reference: wellness.list failed: ${detail}`);
+    fetchErrors.push({ endpoint: "wellness", detail });
+  }
   const rawWellness: Array<Record<string, unknown>> =
     wellResult.ok && Array.isArray(wellResult.value)
       ? (wellResult.value as Array<Record<string, unknown>>)
@@ -309,7 +333,14 @@ export async function fetchLiveBundle(deps: LiveFetchDeps): Promise<LiveFetchRes
     return Number.isFinite(ms) && ms >= retentionCutoffMs;
   });
 
-  return { athleteProfile, recentActivities, wellnessData: wellness, bundle, frozenNow };
+  return {
+    athleteProfile,
+    recentActivities,
+    wellnessData: wellness,
+    bundle,
+    frozenNow,
+    ...(fetchErrors.length > 0 ? { fetchErrors } : {}),
+  };
 }
 
 async function fetchStreams(

--- a/packages/core/src/reference/sync/fetch-reference-data.ts
+++ b/packages/core/src/reference/sync/fetch-reference-data.ts
@@ -59,5 +59,8 @@ async function fetchOnce(
     intervals: { by_activity: {} },
     routes: { routes: [] },
     ftp_history: { entries: [] },
+    ...(live.fetchErrors && live.fetchErrors.length > 0
+      ? { fetch_errors: live.fetchErrors }
+      : {}),
   };
 }

--- a/packages/core/src/reference/sync/run-sync.ts
+++ b/packages/core/src/reference/sync/run-sync.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import {
   MUTEX_ACQUIRE_TIMEOUT_MS,
@@ -89,6 +90,12 @@ export interface FetchedReference {
   };
   readonly routes: { readonly routes: readonly unknown[] };
   readonly ftp_history: { readonly entries: readonly unknown[] };
+  /** Source endpoints that errored during the fetch (athlete-profile, wellness).
+   *  Present + non-empty means a fetch failed and was filled with empty data;
+   *  step0 hard-fails on it so the swallowed failure can no longer commit empties
+   *  behind a fresh stamp. Omitted when every endpoint was reachable, so a
+   *  fully-successful fetch is shape-identical to a genuinely-empty account. */
+  readonly fetch_errors?: readonly { readonly endpoint: string; readonly detail: string }[];
 }
 
 export interface RunSyncDeps {
@@ -130,6 +137,41 @@ interface CacheWriteSpec {
 
 /** Shared between runtime + tests so the warn-after-timeout string stays in sync. */
 export const BODY_AFTER_TIMEOUT_LOG_PREFIX = "Reference: body threw after outer timeout";
+
+/** Read a prior on-disk cache file as a parsed object, or `null` when it is
+ *  absent / unreadable / not an object — any of which means "no comparable
+ *  prior, must write". */
+function readPriorCache(path: string): Record<string, unknown> | null {
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf-8");
+  } catch {
+    return null;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  return typeof parsed === "object" && parsed !== null
+    ? (parsed as Record<string, unknown>)
+    : null;
+}
+
+/** True when the prior file's payload (everything except the churning
+ *  `metadata` envelope) serializes identically to the new payload, using the
+ *  same serializer settings `atomicWriteJson` writes with — so a no-op cycle
+ *  skips the write and leaves the file byte-identical. */
+function priorPayloadEquals(
+  prior: Record<string, unknown>,
+  payload: Readonly<Record<string, unknown>>,
+): boolean {
+  const { metadata: _metadata, ...priorPayload } = prior;
+  return (
+    JSON.stringify(priorPayload, null, 2) === JSON.stringify(payload, null, 2)
+  );
+}
 
 export function createRunSync(
   deps: RunSyncDeps,
@@ -239,14 +281,28 @@ export function createRunSync(
               payload: fetched.ftp_history,
             },
           ];
-          await Promise.all(
-            cacheWrites.map(({ file, version, payload, extras }) =>
-              writeJson(join(deps.dataDir, `${file}.json`), {
-                metadata: { schema_version: version, last_updated: lastUpdated, ...extras },
-                ...payload,
+          // Content-hash short-circuit: re-stamping `last_updated` every cycle
+          // makes each cache file byte-different even when the underlying data
+          // is unchanged. The `metadata` envelope (which carries the churning
+          // `last_updated`) is excluded from the comparison so a no-op cycle
+          // leaves the file — old timestamp and all — byte-identical, and only
+          // a genuine data change rewrites the file with a fresh stamp.
+          const refreshed = (
+            await Promise.all(
+              cacheWrites.map(async ({ file, version, payload, extras }) => {
+                const path = join(deps.dataDir, `${file}.json`);
+                const prior = readPriorCache(path);
+                if (prior !== null && priorPayloadEquals(prior, payload)) {
+                  return null;
+                }
+                await writeJson(path, {
+                  metadata: { schema_version: version, last_updated: lastUpdated, ...extras },
+                  ...payload,
+                });
+                return file;
               }),
-            ),
-          );
+            )
+          ).filter((f): f is CacheFile => f !== null);
           // A1 fix: if the outer timeout fired during the cache writes,
           // bail before writing the commit marker. Without this guard the
           // scheduler.json could land after error_state.json was written,
@@ -279,7 +335,7 @@ export function createRunSync(
           return {
             kind: "ran",
             lastSyncAt: lastUpdated,
-            refreshed: cacheWrites.map((w) => w.file),
+            refreshed,
           };
         };
 

--- a/packages/core/src/reference/sync/run-sync.ts
+++ b/packages/core/src/reference/sync/run-sync.ts
@@ -1,5 +1,5 @@
-import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import type { ZodTypeAny } from "zod";
 import {
   MUTEX_ACQUIRE_TIMEOUT_MS,
   MUTEX_HOT_WARN_MS,
@@ -7,11 +7,12 @@ import {
   SYNC_OPERATION_TIMEOUT_MS,
 } from "../freshness.js";
 import { atomicWriteJson } from "../../io/atomic-write-json.js";
-import { LATEST_SCHEMA_VERSION } from "../schemas/latest.js";
-import { HISTORY_SCHEMA_VERSION } from "../schemas/history.js";
-import { INTERVALS_SCHEMA_VERSION } from "../schemas/intervals.js";
-import { ROUTES_SCHEMA_VERSION } from "../schemas/routes.js";
-import { FTP_HISTORY_SCHEMA_VERSION } from "../schemas/ftp-history.js";
+import { safeReadJson } from "../../io/safe-read-json.js";
+import { LATEST_SCHEMA_VERSION, LatestJsonSchema } from "../schemas/latest.js";
+import { HISTORY_SCHEMA_VERSION, HistoryJsonSchema } from "../schemas/history.js";
+import { INTERVALS_SCHEMA_VERSION, IntervalsJsonSchema } from "../schemas/intervals.js";
+import { ROUTES_SCHEMA_VERSION, RoutesJsonSchema } from "../schemas/routes.js";
+import { FTP_HISTORY_SCHEMA_VERSION, FtpHistoryJsonSchema } from "../schemas/ftp-history.js";
 import { SCHEDULER_SCHEMA_VERSION } from "../schemas/scheduler.js";
 import type { ErrorPhase, ErrorCaller } from "../schemas/error-state.js";
 import { gateLatestJson } from "../validation/sync-gate.js";
@@ -138,25 +139,24 @@ interface CacheWriteSpec {
 /** Shared between runtime + tests so the warn-after-timeout string stays in sync. */
 export const BODY_AFTER_TIMEOUT_LOG_PREFIX = "Reference: body threw after outer timeout";
 
+/** Per-cache-file Zod schema, so the prior-read routes through the same
+ *  `safeReadJson` boundary every other Reference read uses (CONTEXT.md: Reference
+ *  NEVER calls `JSON.parse(readFileSync(...))` directly). A schema mismatch or an
+ *  unreadable file yields `null` — which `readPriorCache` already treats as "no
+ *  comparable prior, must write". */
+const CACHE_SCHEMAS: Readonly<Record<CacheFile, ZodTypeAny>> = {
+  latest: LatestJsonSchema,
+  history: HistoryJsonSchema,
+  intervals: IntervalsJsonSchema,
+  routes: RoutesJsonSchema,
+  ftp_history: FtpHistoryJsonSchema,
+};
+
 /** Read a prior on-disk cache file as a parsed object, or `null` when it is
- *  absent / unreadable / not an object — any of which means "no comparable
+ *  absent / unreadable / schema-invalid — any of which means "no comparable
  *  prior, must write". */
-function readPriorCache(path: string): Record<string, unknown> | null {
-  let raw: string;
-  try {
-    raw = readFileSync(path, "utf-8");
-  } catch {
-    return null;
-  }
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch {
-    return null;
-  }
-  return typeof parsed === "object" && parsed !== null
-    ? (parsed as Record<string, unknown>)
-    : null;
+function readPriorCache(path: string, file: CacheFile): Record<string, unknown> | null {
+  return safeReadJson<Record<string, unknown>>(path, CACHE_SCHEMAS[file]);
 }
 
 /** True when the prior file's payload (everything except the churning
@@ -291,7 +291,7 @@ export function createRunSync(
             await Promise.all(
               cacheWrites.map(async ({ file, version, payload, extras }) => {
                 const path = join(deps.dataDir, `${file}.json`);
-                const prior = readPriorCache(path);
+                const prior = readPriorCache(path, file);
                 if (prior !== null && priorPayloadEquals(prior, payload)) {
                   return null;
                 }

--- a/packages/core/src/reference/sync/run-sync.ts
+++ b/packages/core/src/reference/sync/run-sync.ts
@@ -159,17 +159,39 @@ function readPriorCache(path: string, file: CacheFile): Record<string, unknown> 
   return safeReadJson<Record<string, unknown>>(path, CACHE_SCHEMAS[file]);
 }
 
+/** Recursively rebuild an object/array with every object's keys in sorted
+ *  order, so two structurally-equal payloads serialize identically regardless
+ *  of key insertion order. `priorPayloadEquals` reads the prior payload back
+ *  through a Zod re-parse, which rebuilds objects in schema-declaration order
+ *  rather than the producer's insertion order; canonicalizing both sides makes
+ *  the no-op short-circuit immune to that reordering (and to any future
+ *  producer that emits the same data in a different key order). */
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (value !== null && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(value).sort()) {
+      out[key] = canonicalize((value as Record<string, unknown>)[key]);
+    }
+    return out;
+  }
+  return value;
+}
+
 /** True when the prior file's payload (everything except the churning
- *  `metadata` envelope) serializes identically to the new payload, using the
- *  same serializer settings `atomicWriteJson` writes with — so a no-op cycle
- *  skips the write and leaves the file byte-identical. */
+ *  `metadata` envelope) is structurally equal to the new payload — so a no-op
+ *  cycle skips the write and leaves the file byte-identical. The comparison is
+ *  key-order-insensitive (see `canonicalize`): the no-op guarantee must not
+ *  hinge on the producer emitting keys in the same order the cache schema
+ *  declares them. */
 function priorPayloadEquals(
   prior: Record<string, unknown>,
   payload: Readonly<Record<string, unknown>>,
 ): boolean {
   const { metadata: _metadata, ...priorPayload } = prior;
   return (
-    JSON.stringify(priorPayload, null, 2) === JSON.stringify(payload, null, 2)
+    JSON.stringify(canonicalize(priorPayload)) ===
+    JSON.stringify(canonicalize(payload))
   );
 }
 

--- a/packages/core/src/reference/validation/checks/step0-data-fetch.ts
+++ b/packages/core/src/reference/validation/checks/step0-data-fetch.ts
@@ -31,5 +31,17 @@ export function checkDataFetch(fetched: FetchedReference): CheckResult {
     }
   }
 
+  // A present-but-errored envelope (a fetch that failed and was filled with an
+  // empty fallback) is distinct from a present-but-legitimately-empty one: the
+  // presence null-check above passes both, but the data-fetch precondition is
+  // "every source envelope was fetched", so an errored endpoint must hard-fail
+  // rather than commit empty data behind a fresh stamp.
+  for (const e of fetched.fetch_errors ?? []) {
+    failures.push({
+      step: "step0_data_fetch",
+      detail: `source endpoint errored: ${e.endpoint} (${e.detail})`,
+    });
+  }
+
   return { failures, warnings: [] };
 }

--- a/packages/core/tests/reference-fetch-live-bundle.test.ts
+++ b/packages/core/tests/reference-fetch-live-bundle.test.ts
@@ -251,6 +251,19 @@ describe("fetchLiveBundle — real lib stream shapes + edge cases", () => {
     expect(logs.some((l) => l.includes("athlete.get failed"))).toBe(true);
   });
 
+  it("records a fetchErrors entry naming the athlete endpoint when athlete.get fails (still a usable bundle)", async () => {
+    const client: BundleFetchClient = {
+      athlete: { get: async () => ({ ok: false, error: "unauthorized" }) },
+      activities: { list: async () => ({ ok: true, value: [] }), getStreams: async () => STREAM_OK },
+      wellness: { list: async () => ({ ok: true, value: [] }) },
+    };
+    const res = await fetchLiveBundle({ client, signal: new AbortController().signal, now: NOW, throttleMs: 0, log: () => {} });
+    expect(res.fetchErrors).toBeDefined();
+    expect(res.fetchErrors?.some((e) => e.endpoint === "athlete")).toBe(true);
+    // Bundle is still well-typed: the athlete fallback is `{}`, no crash.
+    expect(res.bundle.athlete).toBeUndefined();
+  });
+
   it("resolves with empty wellness + a warning when wellness.list fails", async () => {
     const logs: string[] = [];
     const client: BundleFetchClient = {
@@ -262,6 +275,24 @@ describe("fetchLiveBundle — real lib stream shapes + edge cases", () => {
     expect(res.bundle.wellness).toEqual([]);
     expect(res.bundle.ftpHistory).toEqual([]);
     expect(logs.some((l) => l.includes("wellness.list failed"))).toBe(true);
+  });
+
+  it("records a fetchErrors entry naming the wellness endpoint when wellness.list fails (still a usable bundle)", async () => {
+    const client: BundleFetchClient = {
+      athlete: { get: async () => ({ ok: true, value: {} }) },
+      activities: { list: async () => ({ ok: true, value: [] }), getStreams: async () => STREAM_OK },
+      wellness: { list: async () => ({ ok: false, error: "timeout" }) },
+    };
+    const res = await fetchLiveBundle({ client, signal: new AbortController().signal, now: NOW, throttleMs: 0, log: () => {} });
+    expect(res.fetchErrors).toBeDefined();
+    expect(res.fetchErrors?.some((e) => e.endpoint === "wellness")).toBe(true);
+    expect(res.bundle.wellness).toEqual([]);
+  });
+
+  it("omits fetchErrors entirely when every endpoint succeeds", async () => {
+    const { client } = fakeClient({ activities: [], wellness: [], athlete: {} });
+    const res = await fetchLiveBundle({ client, signal: new AbortController().signal, now: NOW, throttleMs: 0 });
+    expect(res.fetchErrors).toBeUndefined();
   });
 
   it("treats a non-array activities body as empty (ok:true, malformed) without crashing", async () => {

--- a/packages/core/tests/reference-run-sync.test.ts
+++ b/packages/core/tests/reference-run-sync.test.ts
@@ -228,6 +228,130 @@ describe("createRunSync", () => {
     expect(mutex.isHeld()).toBe(false);
   });
 
+  it("a fetched bundle carrying fetch_errors hard-fails the gate, writes error_state, and never writes latest.json", async () => {
+    const mutex = new AsyncMutex();
+    const cooldown = new Cooldown();
+    const now = new Date("2026-05-09T14:00:00Z");
+
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ...emptyFetched,
+      fetch_errors: [{ endpoint: "athlete", detail: "timeout" }],
+    });
+    const writeSpy = vi.fn(async (_path: string, _value: unknown): Promise<void> => {});
+
+    const runSync = createRunSync({
+      dataDir: dir,
+      mutex,
+      cooldown,
+      cooldownWindowMs: 30_000,
+      fetchReferenceData: fetchSpy,
+      atomicWrite: writeSpy,
+      now: () => now,
+    });
+
+    const result = await runSync({ caller: "scheduled" });
+
+    expect(result.kind).toBe("failed");
+    if (result.kind === "failed") {
+      expect(result.reason).toBe("gate_rejected");
+      expect(result.failures.some((f) => f.reason.includes("athlete"))).toBe(true);
+    }
+
+    // The prior cache is preserved: no latest.json (or any cache file) write fired.
+    const wrotePaths = writeSpy.mock.calls.map((c) => c[0]);
+    expect(wrotePaths.some((p) => p.endsWith("latest.json"))).toBe(false);
+    expect(wrotePaths.some((p) => p.endsWith(".scheduler.json"))).toBe(false);
+
+    // error_state.json names the failed endpoint (real write, gate-rejection path).
+    const errorState = JSON.parse(readFileSync(join(dir, "error_state.json"), "utf-8"));
+    expect(errorState.step).toBe("gate_rejected");
+    expect(errorState.detail).toContain("athlete");
+
+    expect(mutex.isHeld()).toBe(false);
+  });
+
+  it("no-op cycle: a re-fetch with byte-identical data leaves all 5 cache files byte-identical (frozen last_updated)", async () => {
+    const mutex = new AsyncMutex();
+    const cooldown = new Cooldown();
+    const first = new Date("2026-05-09T14:00:00Z");
+    const second = new Date("2026-05-09T14:30:00Z");
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ...emptyFetched,
+      latest: { ...emptyFetched.latest, athlete_profile: { id: "test-athlete" } },
+    });
+
+    const makeRunSync = (now: Date) =>
+      createRunSync({
+        dataDir: dir,
+        mutex,
+        cooldown,
+        cooldownWindowMs: 30_000,
+        fetchReferenceData: fetchSpy,
+        now: () => now,
+      });
+
+    const files = ["latest", "history", "intervals", "routes", "ftp_history"];
+
+    const r1 = await makeRunSync(first)({ caller: "scheduled" });
+    expect(r1.kind).toBe("ran");
+    const afterFirst = files.map((f) => readFileSync(join(dir, `${f}.json`), "utf-8"));
+
+    const r2 = await makeRunSync(second)({ caller: "scheduled" });
+    expect(r2.kind).toBe("ran");
+    const afterSecond = files.map((f) => readFileSync(join(dir, `${f}.json`), "utf-8"));
+
+    expect(afterSecond).toEqual(afterFirst);
+    if (r2.kind === "ran") expect(r2.refreshed).toEqual([]);
+
+    // The commit marker still advanced even though no cache file was rewritten.
+    const scheduler = JSON.parse(readFileSync(join(dir, ".scheduler.json"), "utf-8"));
+    expect(scheduler.last_sync_at).toBe(second.toISOString());
+    // latest.json kept the FIRST run's timestamp (skipped, not rewritten).
+    const latest = JSON.parse(readFileSync(join(dir, "latest.json"), "utf-8"));
+    expect(latest.metadata.last_updated).toBe(first.toISOString());
+  });
+
+  it("changed-file-only: a second fetch that changes intervals rewrites only intervals.json; siblings keep their bytes", async () => {
+    const mutex = new AsyncMutex();
+    const cooldown = new Cooldown();
+    const first = new Date("2026-05-09T14:00:00Z");
+    const second = new Date("2026-05-09T14:30:00Z");
+
+    const base = {
+      ...emptyFetched,
+      latest: { ...emptyFetched.latest, athlete_profile: { id: "test-athlete" } },
+    };
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValueOnce(base)
+      .mockResolvedValueOnce({
+        ...base,
+        intervals: { by_activity: { a1: [{ id: "i1" }] } },
+      });
+
+    const makeRunSync = (now: Date) =>
+      createRunSync({
+        dataDir: dir,
+        mutex,
+        cooldown,
+        cooldownWindowMs: 30_000,
+        fetchReferenceData: fetchSpy,
+        now: () => now,
+      });
+
+    await makeRunSync(first)({ caller: "scheduled" });
+    const latestBefore = readFileSync(join(dir, "latest.json"), "utf-8");
+
+    const r2 = await makeRunSync(second)({ caller: "scheduled" });
+    if (r2.kind === "ran") expect(r2.refreshed).toEqual(["intervals"]);
+
+    const intervals = JSON.parse(readFileSync(join(dir, "intervals.json"), "utf-8"));
+    expect(intervals.metadata.last_updated).toBe(second.toISOString());
+    expect(intervals.by_activity).toEqual({ a1: [{ id: "i1" }] });
+    // latest.json untouched (no data change) — bytes + timestamp frozen at run 1.
+    expect(readFileSync(join(dir, "latest.json"), "utf-8")).toBe(latestBefore);
+  });
+
   it("when outer timeout fires during writing_scheduler phase, error_state.phase reflects it and caches survive", async () => {
     const mutex = new AsyncMutex();
     const cooldown = new Cooldown();

--- a/packages/core/tests/reference-run-sync.test.ts
+++ b/packages/core/tests/reference-run-sync.test.ts
@@ -311,6 +311,48 @@ describe("createRunSync", () => {
     expect(latest.metadata.last_updated).toBe(first.toISOString());
   });
 
+  it("no-op cycle: a re-fetch with the same data but a different top-level key order still short-circuits", async () => {
+    const mutex = new AsyncMutex();
+    const cooldown = new Cooldown();
+    const first = new Date("2026-05-09T14:00:00Z");
+    const second = new Date("2026-05-09T14:30:00Z");
+
+    // The on-disk file is read back through a Zod re-parse, which rebuilds the
+    // payload in schema-declaration order; the live producer emits it in
+    // insertion order. A future producer (or a re-ordered nested object) can
+    // legitimately differ in key order while carrying identical data — the
+    // short-circuit must not be defeated by that.
+    const profile = { name: "test", id: "test-athlete", ftp: 250 };
+    const reordered = { ftp: 250, id: "test-athlete", name: "test" };
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ...emptyFetched,
+        latest: { ...emptyFetched.latest, athlete_profile: profile },
+      })
+      .mockResolvedValueOnce({
+        ...emptyFetched,
+        latest: { ...emptyFetched.latest, athlete_profile: reordered },
+      });
+
+    const makeRunSync = (now: Date) =>
+      createRunSync({
+        dataDir: dir,
+        mutex,
+        cooldown,
+        cooldownWindowMs: 30_000,
+        fetchReferenceData: fetchSpy,
+        now: () => now,
+      });
+
+    await makeRunSync(first)({ caller: "scheduled" });
+    const latestBefore = readFileSync(join(dir, "latest.json"), "utf-8");
+
+    const r2 = await makeRunSync(second)({ caller: "scheduled" });
+    if (r2.kind === "ran") expect(r2.refreshed).toEqual([]);
+    expect(readFileSync(join(dir, "latest.json"), "utf-8")).toBe(latestBefore);
+  });
+
   it("changed-file-only: a second fetch that changes intervals rewrites only intervals.json; siblings keep their bytes", async () => {
     const mutex = new AsyncMutex();
     const cooldown = new Cooldown();

--- a/packages/core/tests/reference-sync-gate.test.ts
+++ b/packages/core/tests/reference-sync-gate.test.ts
@@ -35,6 +35,26 @@ describe("gateLatestJson", () => {
     expect(result.failures.map((f) => f.step)).toContain("step0_data_fetch");
   });
 
+  it("step0 FAIL: a non-empty fetch_errors channel → ok:false, step0 failure names the endpoint", () => {
+    const fetched: FetchedReference = {
+      ...emptyFetched,
+      fetch_errors: [{ endpoint: "wellness", detail: "429" }],
+    };
+    const result = gateLatestJson(fetched, null, NOW);
+    expect(result.ok).toBe(false);
+    const step0 = result.failures.find((f) => f.step === "step0_data_fetch");
+    expect(step0).toBeDefined();
+    expect(step0!.detail).toContain("wellness");
+  });
+
+  it("step0 PASS: empty-but-error-free envelope (no fetch_errors) stays green", () => {
+    // Guards the errored-vs-empty distinction: a genuinely-empty account must
+    // still pass step0 clean. (Same invariant as the :19-22 empty-stub test.)
+    const result = gateLatestJson(emptyFetched, null, NOW);
+    expect(result.ok).toBe(true);
+    expect(result.failures.map((f) => f.step)).not.toContain("step0_data_fetch");
+  });
+
   // ── step1: FTP source (HARD) ──────────────────────────────────────────
 
   it("step1 PASS: sportSettings ftp:247 → no step1 failure", () => {


### PR DESCRIPTION
## What

Two coupled correctness fixes in the Reference layer's sync pipeline.

**Per-endpoint error channel (errored != empty).** Today the live-data bundle swallows `athlete.get()` / `wellness.list()` failures with empty catch blocks, so a transient source outage produces an empty-but-valid bundle that sails through the gate and stamps blank data over the athlete's last good snapshot as if it were fresh. This change threads a `Result`-shaped error channel: `FetchedReference` gains an optional `fetch_errors` field, `fetch-live-bundle` records the previously-swallowed per-endpoint failures into it, and the data-fetch precondition gate hard-fails (naming the endpoint) when the channel is non-empty. The failed sync then routes through the existing gate-rejection path, which already skips the cache-write loop — so the prior cache file is preserved untouched, the freshness stamp is not advanced, and the failure is recorded instead of being silently overwritten. No new write branch and no error-state schema bump.

**Content-hash short-circuit.** The write loop now compares the serialized payload (modulo metadata) against the prior cycle and skips the cache writes when they are identical, so a no-op cycle leaves the cache files byte-identical rather than re-stamping a fresh timestamp every run. The per-cycle commit marker in the scheduler sidecar still advances.

## Surfaces touched

- `reference/sync/fetch-live-bundle.ts`, `fetch-reference-data.ts` — record per-endpoint failures into the new error channel instead of swallowing them.
- `reference/sync/run-sync.ts` — content-hash short-circuit on the write loop; prior-cache read routed through the `safeReadJson` I/O boundary.
- `reference/validation/checks/step0-data-fetch.ts` — the data-fetch precondition hard-fails on a non-empty error channel. This restores the upstream data-fetch precondition (additive faithfulness restore, not a deviation).

## Test plan

- `pnpm check && pnpm test` green.
- New coverage in `reference-fetch-live-bundle.test.ts` asserts per-endpoint failures land in the error channel.
- `reference-run-sync.test.ts` asserts a failed-envelope cycle preserves the prior cache (no empty-fresh commit) and a no-op cycle leaves the cache byte-identical with only the sidecar marker advancing.
- The load-bearing `reference-sync-gate.test.ts` empty-stub invariant stays `ok: true`.

This is the base of a stacked series; later PRs in the series build on this branch and rebase onto main as it lands.