### PR TITLE
feat(core): fail fast on /sync when a sync is already running

### DIFF
--- a/.changeset/sync-fail-fast-held-mutex.md
+++ b/.changeset/sync-fail-fast-held-mutex.md
@@ -1,0 +1,7 @@
+---
+"@enduragent/core": patch
+---
+
+User-facing: /sync now replies instantly when a sync is already running, instead of appearing to hang.
+
+The interactive /sync path consults the sync mutex and returns the "already running" reply immediately rather than blocking the full acquire timeout; the background scheduler's queue-and-wait behavior is unchanged. The /sync reply also no longer renders a dangling "Refreshed:" line on a no-op cycle — it now says the data was already up to date.

--- a/packages/core/src/reference/sync/format-sync-reply.ts
+++ b/packages/core/src/reference/sync/format-sync-reply.ts
@@ -20,7 +20,7 @@ export function formatSyncReply(result: SyncResult, now: Date = new Date()): str
         case "cooldown":
           return `Just synced — please wait ${Math.ceil((result.retryAfterMs ?? 0) / 1000)}s before forcing another refresh.`;
         case "mutex_held":
-          return "Another sync in progress — please retry in a moment.";
+          return "A sync is already running — it'll finish within about 2 minutes; your data will be fresh then.";
         default: {
           const _exhaustive: never = result;
           throw new Error(`formatSyncReply: unhandled skipped reason ${String(_exhaustive)}`);
@@ -42,8 +42,14 @@ export function formatSyncReply(result: SyncResult, now: Date = new Date()): str
       }
     case "ran": {
       const lastLine = `Last sync: ${formatTimestamp(result.lastSyncAt, now)}`;
-      const refreshedLine = `Refreshed: ${result.refreshed.join(", ")}`;
-      return `Sync ✅\n${lastLine}\n${refreshedLine}`;
+      // The content-hash short-circuit returns `refreshed: []` on a genuine
+      // no-op cycle; rendering a bare "Refreshed: " label would be a dangling
+      // line, so say nothing-changed instead.
+      const detailLine =
+        result.refreshed.length === 0
+          ? "Already up to date — nothing changed since the last sync."
+          : `Refreshed: ${result.refreshed.join(", ")}`;
+      return `Sync ✅\n${lastLine}\n${detailLine}`;
     }
     default: {
       const _exhaustive: never = result;

--- a/packages/core/src/reference/sync/run-sync.ts
+++ b/packages/core/src/reference/sync/run-sync.ts
@@ -231,6 +231,15 @@ export function createRunSync(
       }
     }
 
+    // Fail fast for the interactive caller: if a sync is already running, the
+    // athlete's /sync would otherwise enqueue a waiter and block the full
+    // acquire timeout before skipping. Reply immediately instead. The scheduled
+    // caller deliberately keeps queue-and-wait semantics (it has no one waiting
+    // on a reply), so this branch is /sync-only.
+    if (opts.caller === "/sync" && deps.mutex.isHeld()) {
+      return { kind: "skipped", reason: "mutex_held" };
+    }
+
     const mutexResult = await deps.mutex.runExclusive(
       async (): Promise<SyncResult> => {
         const controller = new AbortController();

--- a/packages/core/tests/reference-format-sync-reply.test.ts
+++ b/packages/core/tests/reference-format-sync-reply.test.ts
@@ -19,6 +19,19 @@ describe("formatSyncReply", () => {
     expect(text).toContain("history");
   });
 
+  it("renders a no-op ran result (empty refreshed) without a dangling 'Refreshed:' line", () => {
+    const r: SyncResult = {
+      kind: "ran",
+      lastSyncAt: "2026-05-09T14:23:00Z",
+      refreshed: [],
+    };
+    const text = formatSyncReply(r, fixedNow);
+    expect(text).toContain("Sync");
+    expect(text).toContain("Last sync:");
+    expect(text).not.toContain("Refreshed:");
+    expect(text.toLowerCase()).toContain("nothing changed");
+  });
+
   it("formats the cooldown skip with a per-second retryAfter countdown", () => {
     const r: SyncResult = {
       kind: "skipped",
@@ -30,13 +43,14 @@ describe("formatSyncReply", () => {
     expect(text).toContain("18s");
   });
 
-  it("formats the mutex_held skip as 'sync in progress, please retry shortly'", () => {
+  it("formats the mutex_held skip as the static 'already running' reply", () => {
     const r: SyncResult = {
       kind: "skipped",
       reason: "mutex_held",
     };
     const text = formatSyncReply(r, fixedNow);
-    expect(text.toLowerCase()).toContain("sync in progress");
+    expect(text.toLowerCase()).toContain("already running");
+    expect(text.toLowerCase()).not.toContain("sync in progress");
   });
 
   it("formats an outer-timeout failure as 'I can't reach intervals.icu'", () => {

--- a/packages/core/tests/reference-run-sync.test.ts
+++ b/packages/core/tests/reference-run-sync.test.ts
@@ -149,6 +149,103 @@ describe("createRunSync", () => {
     expect(slowFetch).toHaveBeenCalledOnce();
   });
 
+  it("interactive /sync fails fast on a held mutex: returns mutex_held promptly without fetching or waiting the acquire timeout", async () => {
+    const mutex = new AsyncMutex();
+    const cooldown = new Cooldown();
+    const now = new Date("2026-05-09T14:00:00Z");
+
+    let resolveSlow!: () => void;
+    const slowFetch = vi.fn(async () => {
+      await new Promise<void>((resolve) => {
+        resolveSlow = resolve;
+      });
+      return emptyFetched;
+    });
+    const fastFetch = vi.fn().mockResolvedValue(emptyFetched);
+
+    const runSyncSlow = createRunSync({
+      dataDir: dir,
+      mutex,
+      cooldown,
+      cooldownWindowMs: 30_000,
+      fetchReferenceData: slowFetch,
+      now: () => now,
+      timing: { acquireTimeoutMs: 5_000, hotWarnMs: 1_000 },
+    });
+    const runSyncInteractive = createRunSync({
+      dataDir: dir,
+      mutex,
+      cooldown,
+      cooldownWindowMs: 30_000,
+      fetchReferenceData: fastFetch,
+      now: () => now,
+      // A LONG acquire timeout: if the fast-path did not short-circuit, the
+      // interactive call would hang here, so a prompt resolution proves the
+      // `isHeld()` guard fired before the blocking acquire.
+      timing: { acquireTimeoutMs: 60_000, hotWarnMs: 1_000 },
+    });
+
+    const p1 = runSyncSlow({ caller: "scheduled" });
+    // Let the slow sync acquire and start holding the mutex.
+    await Promise.resolve();
+    expect(mutex.isHeld()).toBe(true);
+
+    const r2 = await runSyncInteractive({ caller: "/sync", chatId: "telegram:1" });
+    expect(r2).toEqual({ kind: "skipped", reason: "mutex_held" });
+    expect(fastFetch).not.toHaveBeenCalled();
+
+    resolveSlow();
+    const r1 = await p1;
+    expect(r1.kind).toBe("ran");
+  });
+
+  it("scheduled caller does NOT short-circuit on a held mutex: it reaches the blocking acquire and waits", async () => {
+    const mutex = new AsyncMutex();
+    const cooldown = new Cooldown();
+    const now = new Date("2026-05-09T14:00:00Z");
+
+    let resolveSlow!: () => void;
+    const slowFetch = vi.fn(async () => {
+      await new Promise<void>((resolve) => {
+        resolveSlow = resolve;
+      });
+      return emptyFetched;
+    });
+    const fastFetch = vi.fn().mockResolvedValue(emptyFetched);
+
+    const runSyncSlow = createRunSync({
+      dataDir: dir,
+      mutex,
+      cooldown,
+      cooldownWindowMs: 30_000,
+      fetchReferenceData: slowFetch,
+      now: () => now,
+      timing: { acquireTimeoutMs: 5_000, hotWarnMs: 1_000 },
+    });
+    const runSyncScheduled = createRunSync({
+      dataDir: dir,
+      mutex,
+      cooldown,
+      cooldownWindowMs: 30_000,
+      fetchReferenceData: fastFetch,
+      now: () => now,
+      timing: { acquireTimeoutMs: 30, hotWarnMs: 10 },
+    });
+
+    const p1 = runSyncSlow({ caller: "scheduled" });
+    await Promise.resolve();
+    expect(mutex.isHeld()).toBe(true);
+
+    // The scheduled caller queue-waits and times out (kind:skipped after the
+    // acquire timeout), proving the fast-path guard did not fire for it.
+    const r2 = await runSyncScheduled({ caller: "scheduled" });
+    expect(r2).toEqual({ kind: "skipped", reason: "mutex_held" });
+    expect(fastFetch).not.toHaveBeenCalled();
+
+    resolveSlow();
+    await p1;
+  });
+
   it("times out at outerTimeoutMs: aborts the controller, writes error_state.json with phase, releases mutex, returns kind:failed", async () => {
     const mutex = new AsyncMutex();
     const cooldown = new Cooldown();


### PR DESCRIPTION
## Summary

An interactive `/sync` previously queued behind the full 30-second mutex acquire timeout when a sync was already running, so the user saw the command appear to hang. This change makes the interactive path fail fast: when `caller === '/sync'` and the sync mutex is already held, `/sync` replies immediately with the static "already running" message instead of waiting on the acquire. The background scheduler's non-interactive queue-and-wait behavior and the 30-second timeout value are unchanged.

This task also adds a small reply-formatting guard: a no-op cycle now returns an empty refreshed list, which previously rendered a dangling "Refreshed:" line in the `/sync` reply. The formatter now omits that line and states the data was already up to date.

## Surfaces touched

- `packages/core/src/reference/sync/run-sync.ts` — interactive fast-path: consult the mutex's held state for the `/sync` caller and short-circuit with the static reply before the long acquire.
- `packages/core/src/reference/sync/format-sync-reply.ts` — suppress the empty "Refreshed:" line on a no-op cycle.
- `packages/core/tests/reference-run-sync.test.ts`, `packages/core/tests/reference-format-sync-reply.test.ts` — coverage for the fast-path reply and the empty-refresh rendering.

## Test plan

- `pnpm check && pnpm test` green.
- Interactive `/sync` during a held mutex replies immediately with the static message and never queues the acquire.
- The scheduler's non-interactive queue-wait is unchanged.
- A no-op cycle renders no dangling "Refreshed:" line.

## Stacking

This PR stacks on the sync fetch error-channel work; its base is `feature/sync-fetch-error-channel`, not `main`. Merge bottom-up and retarget to `main` before merging this one.
