### PR TITLE
fix(core): skip the atomic rename when the sync cycle was aborted

### DIFF
--- a/packages/core/src/io/atomic-write-json.ts
+++ b/packages/core/src/io/atomic-write-json.ts
@@ -12,7 +12,11 @@ import { randomBytes } from "node:crypto";
  * rethrown. The on-disk target at `path` is untouched on every failure path
  * because rename is the last step.
  */
-export async function atomicWriteJson(path: string, value: unknown): Promise<void> {
+export async function atomicWriteJson(
+  path: string,
+  value: unknown,
+  opts?: { signal?: AbortSignal },
+): Promise<void> {
   // Serialize FIRST so circular-reference / BigInt failures don't leave a
   // half-baked temp file on disk.
   const body = JSON.stringify(value, null, 2) + "\n";
@@ -27,6 +31,20 @@ export async function atomicWriteJson(path: string, value: unknown): Promise<voi
     await fh.sync();
     await fh.close();
     fh = null;
+    // Check the abort signal at the LAST instant before commit. A sync cycle
+    // whose outer timeout fired has already force-released the mutex to its
+    // successor; renaming this dead cycle's payload in now would replace the
+    // live file mid-successor-cycle. So if aborted, drop the temp sibling and
+    // return cleanly — the skip is a successful no-op, not an error. Checking
+    // earlier would race the abort against the in-flight writeFile/sync.
+    if (opts?.signal?.aborted === true) {
+      try {
+        await unlink(tempPath);
+      } catch {
+        // Temp file may already be gone; best-effort cleanup.
+      }
+      return;
+    }
     await rename(tempPath, path);
   } catch (err) {
     if (fh !== null) {

--- a/packages/core/src/reference/sync/run-sync.ts
+++ b/packages/core/src/reference/sync/run-sync.ts
@@ -131,7 +131,11 @@ export interface RunSyncDeps {
   /** Override Layer-1 gate for tests; defaults to `gateLatestJson`. */
   readonly gate?: typeof gateLatestJson;
   /** Override atomic write for tests; defaults to `atomicWriteJson`. */
-  readonly atomicWrite?: (path: string, value: unknown) => Promise<void>;
+  readonly atomicWrite?: (
+    path: string,
+    value: unknown,
+    opts?: { signal?: AbortSignal },
+  ) => Promise<void>;
   /** Override error_state.json removal for tests; defaults to `clearErrorState`. */
   readonly clearError?: (dataDir: string) => Promise<void>;
 }
@@ -333,10 +337,14 @@ export function createRunSync(
                 if (prior !== null && priorPayloadEquals(prior, payload)) {
                   return null;
                 }
-                await writeJson(path, {
-                  metadata: { schema_version: version, last_updated: lastUpdated, ...extras },
-                  ...payload,
-                });
+                await writeJson(
+                  path,
+                  {
+                    metadata: { schema_version: version, last_updated: lastUpdated, ...extras },
+                    ...payload,
+                  },
+                  { signal: controller.signal },
+                );
                 return file;
               }),
             )
@@ -349,11 +357,15 @@ export function createRunSync(
 
           // Commit-marker LAST per ADR-0011.
           phase = "writing_scheduler";
-          await writeJson(join(deps.dataDir, ".scheduler.json"), {
-            schema_version: SCHEDULER_SCHEMA_VERSION,
-            last_sync_at: lastUpdated,
-            next_sync_at: new Date(now().getTime() + scheduledIntervalMs).toISOString(),
-          });
+          await writeJson(
+            join(deps.dataDir, ".scheduler.json"),
+            {
+              schema_version: SCHEDULER_SCHEMA_VERSION,
+              last_sync_at: lastUpdated,
+              next_sync_at: new Date(now().getTime() + scheduledIntervalMs).toISOString(),
+            },
+            { signal: controller.signal },
+          );
 
           // error_state.json lifecycle, AFTER the commit marker (ADR-0011
           // commit-marker-last) so a curator reading mid-sync never observes a

--- a/packages/core/tests/io-atomic-write-json.test.ts
+++ b/packages/core/tests/io-atomic-write-json.test.ts
@@ -124,3 +124,36 @@ describe("atomicWriteJson — atomicity invariant", () => {
     expect(onDisk).toEqual(original);
   });
 });
+
+describe("atomicWriteJson — abort semantics", () => {
+  it("skips the rename when the signal is already aborted and leaves the target untouched", async () => {
+    const target = join(tempDir, "guarded.json");
+    await atomicWriteJson(target, { old: true });
+
+    const controller = new AbortController();
+    controller.abort();
+
+    // The aborted-skip is a clean no-op, not a rejection.
+    await expect(
+      atomicWriteJson(target, { fresh: 1 }, { signal: controller.signal }),
+    ).resolves.toBeUndefined();
+
+    // Rename was skipped — the live file still holds the prior payload.
+    const onDisk = JSON.parse(readFileSync(target, "utf-8"));
+    expect(onDisk).toEqual({ old: true });
+
+    // The aborted branch unlinked its temp sibling — none should linger.
+    const orphans = readdirSync(tempDir).filter((e) => e.includes(".tmp."));
+    expect(orphans).toEqual([]);
+  });
+
+  it("renames normally when the signal is present but not aborted", async () => {
+    const target = join(tempDir, "live.json");
+    const controller = new AbortController();
+
+    await atomicWriteJson(target, { fresh: 1 }, { signal: controller.signal });
+
+    const onDisk = JSON.parse(readFileSync(target, "utf-8"));
+    expect(onDisk).toEqual({ fresh: 1 });
+  });
+});

--- a/packages/core/tests/reference-run-sync.test.ts
+++ b/packages/core/tests/reference-run-sync.test.ts
@@ -698,10 +698,19 @@ describe("createRunSync", () => {
     await Promise.resolve();
     await Promise.resolve();
 
-    // The in-flight cache writes were aborted at the rename boundary: each
-    // helper fsync'd its temp file then skipped the rename, so NONE of the
-    // payload files landed. A dead cycle's stale payload must never replace the
-    // live file after the mutex was handed to the successor cycle.
+    // The rename-boundary check skips any cache write that had not yet reached
+    // its rename commit when the abort fired. This test's cacheGate parks all 5
+    // writes BEFORE they delegate to the real helper, so the hand-fired abort
+    // lands while every write is still ahead of its check — deterministically
+    // forcing all 5 into the skip window, so NONE of the payload files land.
+    // Production does NOT gate the writes (run-sync fires them concurrently), so
+    // an abort at an arbitrary instant may leave a PARTIAL subset renamed: any
+    // write already past its check is uncancellable and still commits, while
+    // writes still ahead of the check skip. The guarantee the check delivers is
+    // per-write ("no write renames after observing the abort"), not an
+    // all-or-nothing across the 5 files. Either way, a dead cycle's payload that
+    // had not yet committed never replaces the live file after the mutex was
+    // handed to the successor cycle.
     for (const file of [
       "latest.json",
       "history.json",

--- a/packages/core/tests/reference-run-sync.test.ts
+++ b/packages/core/tests/reference-run-sync.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -623,7 +623,11 @@ describe("createRunSync", () => {
     });
     const pendingWrites: Array<Promise<unknown>> = [];
     const latchedCacheWrite = vi.fn(
-      async (path: string, value: unknown): Promise<void> => {
+      async (
+        path: string,
+        value: unknown,
+        opts?: { signal?: AbortSignal },
+      ): Promise<void> => {
         if (!path.endsWith(".scheduler.json")) {
           if (signalArrived !== null) {
             signalArrived();
@@ -631,7 +635,10 @@ describe("createRunSync", () => {
           }
           await cacheGate;
         }
-        const w = realAtomicWrite(path, value);
+        // Forward the threaded signal so the real abort-aware helper sees the
+        // aborted state once the hand-fired timer ran — the rename-skip fires
+        // exactly as in production.
+        const w = realAtomicWrite(path, value, opts);
         pendingWrites.push(w);
         await w;
       },
@@ -677,10 +684,8 @@ describe("createRunSync", () => {
     expect(errorState.step).toBe("outer_timeout");
     expect(errorState.phase).toBe("writing_cache");
 
-    // The 5 cache files COMPLETED (they were already in flight when abort fired —
-    // filesystem writes aren't cancellable). Without the A1 fix, .scheduler.json
-    // would also have been written, contradicting the error_state.json marker.
-    // With A1: scheduler.json must NOT exist.
+    // With A1 + the abort-aware write helper, .scheduler.json must NOT exist
+    // (the body bailed before the commit-marker write).
     expect(() => readFileSync(join(dir, ".scheduler.json"), "utf-8")).toThrow();
 
     expect(mutex.isHeld()).toBe(false);
@@ -692,6 +697,23 @@ describe("createRunSync", () => {
     await Promise.allSettled(pendingWrites);
     await Promise.resolve();
     await Promise.resolve();
+
+    // The in-flight cache writes were aborted at the rename boundary: each
+    // helper fsync'd its temp file then skipped the rename, so NONE of the
+    // payload files landed. A dead cycle's stale payload must never replace the
+    // live file after the mutex was handed to the successor cycle.
+    for (const file of [
+      "latest.json",
+      "history.json",
+      "intervals.json",
+      "routes.json",
+      "ftp_history.json",
+    ]) {
+      expect(() => readFileSync(join(dir, file), "utf-8")).toThrow();
+    }
+    // No temp siblings linger — the aborted branch unlinked each one.
+    const orphans = readdirSync(dir).filter((e) => e.includes(".tmp."));
+    expect(orphans).toEqual([]);
   });
 
   // ── A2: body throws after timeout — error must NOT be silently swallowed ──


### PR DESCRIPTION
Makes the atomic JSON writer abort-aware so a timed-out, zombie sync cycle can never rename its stale payload into the data directory after a successor cycle has already taken over the mutex.

## Change by surface

- `packages/core/src/io/atomic-write-json.ts` — the helper now accepts an optional `AbortSignal`. The temp file is still written and fsync'd as before, but when the signal is aborted the helper unlinks the temp sibling and returns without performing the final rename. The target file is left untouched and no `.tmp.*` sibling lingers.
- `packages/core/src/reference/sync/run-sync.ts` — threads the cycle's `controller.signal` through the per-cycle `writeJson` seam so all six payload/marker writes inherit it. The error-state writes are intentionally left unsignalled so failure bookkeeping always lands even when the cycle is aborted.

No timeout values change and there is no force-release rework. This is a pure-infra correctness fix with no athlete-visible behavior, so it carries no changeset.

## Test plan

- `pnpm check && pnpm test` green.
- `packages/core/tests/io-atomic-write-json.test.ts` — an aborted write leaves the target untouched and removes the temp sibling; a non-aborted write renames as before.
- `packages/core/tests/reference-run-sync.test.ts` — the six per-cycle writes pass the signal while error-state writes do not; an abort during the cache-write phase lands zero cache files.

This PR stacks on the prior sync-reliability branch; merge bottom-up and retarget to main.
