### PR TITLE
feat(core): append a per-tick sync outcome line to a durable history file

### DIFF
--- a/packages/core/src/reference/sync/run-sync.ts
+++ b/packages/core/src/reference/sync/run-sync.ts
@@ -17,6 +17,7 @@ import { SCHEDULER_SCHEMA_VERSION } from "../schemas/scheduler.js";
 import type { ErrorPhase, ErrorCaller } from "../schemas/error-state.js";
 import { gateLatestJson } from "../validation/sync-gate.js";
 import { writeErrorState, clearErrorState } from "./error-state-writer.js";
+import { createSyncHistoryWriter, type SyncOutcomeLine } from "./sync-history.js";
 import type { AsyncMutex } from "../../concurrency/mutex.js";
 import type { Cooldown } from "../../concurrency/cooldown.js";
 import type { Clock } from "../../concurrency/clock.js";
@@ -138,6 +139,12 @@ export interface RunSyncDeps {
   ) => Promise<void>;
   /** Override error_state.json removal for tests; defaults to `clearErrorState`. */
   readonly clearError?: (dataDir: string) => Promise<void>;
+  /**
+   * Override the per-tick outcome writer for tests; defaults to
+   * `createSyncHistoryWriter(deps.dataDir)`. Best-effort and never throws, so it
+   * can never alter or break the `SyncResult` it records.
+   */
+  readonly syncHistory?: (line: SyncOutcomeLine) => void;
 }
 
 interface CacheWriteSpec {
@@ -222,16 +229,42 @@ export function createRunSync(
   const gate = deps.gate ?? gateLatestJson;
   const writeJson = deps.atomicWrite ?? atomicWriteJson;
   const clearError = deps.clearError ?? clearErrorState;
+  const syncHistory = deps.syncHistory ?? createSyncHistoryWriter(deps.dataDir);
 
   return async (opts = {}) => {
+    const startedAt = now();
+    // The outcome line is a best-effort diagnostics trail: a write (or a
+    // misbehaving injected writer) must never alter or break the tick it
+    // records. The default writer already swallows; this guard also fences a
+    // throwing test seam from escaping the tick. A backward wall-clock step
+    // between `startedAt` and the emit must never write a negative duration, so
+    // the delta is clamped non-negative.
+    const emit = (kind: SyncResult["kind"], reason: string | undefined): void => {
+      try {
+        syncHistory({
+          ts: now().toISOString(),
+          caller: opts.caller ?? "scheduled",
+          kind,
+          reason,
+          duration_ms: Math.max(0, now().getTime() - startedAt.getTime()),
+        });
+      } catch {
+        // Swallowed — see comment above.
+      }
+    };
+    const emitOutcome = (result: SyncResult): SyncResult => {
+      emit(result.kind, "reason" in result ? result.reason : undefined);
+      return result;
+    };
+
     if (opts.caller === "/sync" && opts.chatId !== undefined) {
       const c = deps.cooldown.check(opts.chatId, deps.cooldownWindowMs);
       if (!c.ok) {
-        return {
+        return emitOutcome({
           kind: "skipped",
           reason: "cooldown",
           retryAfterMs: c.retryAfterMs,
-        };
+        });
       }
     }
 
@@ -241,11 +274,13 @@ export function createRunSync(
     // caller deliberately keeps queue-and-wait semantics (it has no one waiting
     // on a reply), so this branch is /sync-only.
     if (opts.caller === "/sync" && deps.mutex.isHeld()) {
-      return { kind: "skipped", reason: "mutex_held" };
+      return emitOutcome({ kind: "skipped", reason: "mutex_held" });
     }
 
-    const mutexResult = await deps.mutex.runExclusive(
-      async (): Promise<SyncResult> => {
+    let mutexResult;
+    try {
+      mutexResult = await deps.mutex.runExclusive(
+        async (): Promise<SyncResult> => {
         const controller = new AbortController();
         let phase: ErrorPhase = "fetching";
 
@@ -438,22 +473,31 @@ export function createRunSync(
 
         if (bodyError !== undefined) throw bodyError;
         return bodyResult!;
-      },
-      {
-        acquireTimeoutMs,
-        hotWarnMs,
-        caller: opts.caller ?? "scheduled",
-      },
-    );
+        },
+        {
+          acquireTimeoutMs,
+          hotWarnMs,
+          caller: opts.caller ?? "scheduled",
+        },
+      );
+    } catch (err) {
+      // The mutex body re-throws an unguarded error (e.g. a gate or cache-write
+      // throw) out of `runExclusive`. The ticket's invariant is that EVERY tick
+      // leaves exactly one history line, so stamp a `failed` line before letting
+      // the throw propagate — otherwise a disk error mid-write would erase its
+      // own evidence, the exact failure mode this trail exists to capture.
+      emit("failed", "unexpected_error");
+      throw err;
+    }
 
     if (mutexResult.kind === "timeout") {
-      return { kind: "skipped", reason: "mutex_held" };
+      return emitOutcome({ kind: "skipped", reason: "mutex_held" });
     }
 
     const result = mutexResult.value;
     if (result.kind === "ran" && opts.caller === "/sync" && opts.chatId !== undefined) {
       deps.cooldown.record(opts.chatId);
     }
-    return result;
+    return emitOutcome(result);
   };
 }

--- a/packages/core/src/reference/sync/sync-history.ts
+++ b/packages/core/src/reference/sync/sync-history.ts
@@ -1,0 +1,81 @@
+import { appendFileSync, mkdirSync, renameSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+import type { ErrorCaller } from "../schemas/error-state.js";
+
+export const SYNC_HISTORY_FILE = "sync-history.jsonl";
+
+/**
+ * Size-only cap. Outcome lines are ~80–120 bytes each, so 1 MB holds tens of
+ * thousands of ticks — far more than a month of frequent syncs. The history
+ * file deliberately has NO age cap (unlike the rolling logger's 14-day prune):
+ * answering "how often did sync fail last month, and why?" needs ~30-day
+ * retention, which a coupled age cap cannot guarantee. A separate file with a
+ * size-only cap is the only shape that holds the full month.
+ */
+export const SYNC_HISTORY_MAX_BYTES = 1 * 1024 * 1024;
+
+export interface SyncOutcomeLine {
+  readonly ts: string;
+  readonly caller: ErrorCaller;
+  readonly kind: "ran" | "skipped" | "failed";
+  readonly reason?: string;
+  readonly duration_ms: number;
+}
+
+let escalatedOnce = false;
+
+/**
+ * Reset the once-per-process escalation latch. Test-only seam: the latch is
+ * module-level so a single warning fires per process in production, but unit
+ * tests that assert the latch behavior need to reset it between cases.
+ */
+export function resetSyncHistoryEscalation(): void {
+  escalatedOnce = false;
+}
+
+/**
+ * Build the per-tick sync outcome writer. Each call appends exactly one JSONL
+ * line to `<dataDir>/sync-history.jsonl`, rotating to `.1` on size overflow.
+ *
+ * The write is best-effort and NEVER throws: this is a diagnostics trail, and a
+ * full disk or permission error must never break the sync tick it observes — a
+ * writer that crashes the thing it records is worse than none. A once-per-
+ * process `console.warn` surfaces the writer's own failure without spamming.
+ */
+export function createSyncHistoryWriter(
+  dataDir: string,
+  options: { maxBytes?: number } = {},
+): (line: SyncOutcomeLine) => void {
+  const maxBytes = options.maxBytes ?? SYNC_HISTORY_MAX_BYTES;
+  const path = join(dataDir, SYNC_HISTORY_FILE);
+
+  function rotateIfNeeded(): void {
+    try {
+      if (statSync(path).size >= maxBytes) {
+        renameSync(path, `${path}.1`);
+      }
+    } catch {
+      // File absent or unstat-able — nothing to rotate.
+    }
+  }
+
+  return (line: SyncOutcomeLine): void => {
+    try {
+      mkdirSync(dataDir, { recursive: true, mode: 0o700 });
+      rotateIfNeeded();
+      appendFileSync(path, JSON.stringify(line) + "\n", { encoding: "utf-8", mode: 0o600 });
+    } catch {
+      if (!escalatedOnce) {
+        escalatedOnce = true;
+        try {
+          console.warn(
+            "[sync-history] outcome write failed — the sync history trail is not being persisted.",
+          );
+        } catch {
+          // Even the escalation warning is best-effort.
+        }
+      }
+    }
+  };
+}

--- a/packages/core/tests/reference-run-sync.test.ts
+++ b/packages/core/tests/reference-run-sync.test.ts
@@ -1056,3 +1056,282 @@ describe("latest derived_metrics structured schema + version gate", () => {
     expect(runtime.services.loadLatest()).toBeNull();
   });
 });
+
+describe("createRunSync sync-history emit", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "reference-run-sync-history-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  const okGate = vi.fn().mockReturnValue({ ok: true, failures: [], warnings: [] });
+
+  it("clean ran: emits exactly one line with kind:ran, no reason, finite duration ≥ 0", async () => {
+    const syncHistory = vi.fn();
+    // Advancing clock so duration is a positive measured delta, not zero.
+    let t = Date.parse("2026-05-09T14:00:00.000Z");
+    const runSync = createRunSync({
+      dataDir: dir,
+      mutex: new AsyncMutex(),
+      cooldown: new Cooldown(),
+      cooldownWindowMs: 30_000,
+      fetchReferenceData: vi.fn().mockResolvedValue({
+        ...emptyFetched,
+        latest: { ...emptyFetched.latest, athlete_profile: { id: "a" } },
+      }),
+      gate: okGate,
+      syncHistory,
+      now: () => new Date((t += 5)),
+    });
+
+    const result = await runSync({ caller: "scheduled" });
+
+    expect(result.kind).toBe("ran");
+    expect(syncHistory).toHaveBeenCalledOnce();
+    const line = syncHistory.mock.calls[0]![0];
+    expect(line.kind).toBe("ran");
+    expect(line.caller).toBe("scheduled");
+    expect(line.reason).toBeUndefined();
+    expect(typeof line.duration_ms).toBe("number");
+    expect(Number.isFinite(line.duration_ms)).toBe(true);
+    expect(line.duration_ms).toBeGreaterThanOrEqual(0);
+    expect(typeof line.ts).toBe("string");
+  });
+
+  it("clamps duration_ms to 0 when the wall clock steps backward mid-tick", async () => {
+    const syncHistory = vi.fn();
+    // Clock steps backward between startedAt and the emit (a backward NTP step):
+    // the recorded duration must clamp to 0, never a negative number.
+    const times = [
+      Date.parse("2026-05-09T14:00:10.000Z"),
+      Date.parse("2026-05-09T14:00:00.000Z"),
+      Date.parse("2026-05-09T14:00:00.000Z"),
+    ];
+    let i = 0;
+    const runSync = createRunSync({
+      dataDir: dir,
+      mutex: new AsyncMutex(),
+      cooldown: new Cooldown(),
+      cooldownWindowMs: 30_000,
+      fetchReferenceData: vi.fn().mockResolvedValue(emptyFetched),
+      gate: okGate,
+      syncHistory,
+      now: () => new Date(times[Math.min(i++, times.length - 1)]!),
+    });
+
+    await runSync({ caller: "scheduled" });
+
+    expect(syncHistory).toHaveBeenCalledOnce();
+    expect(syncHistory.mock.calls[0]![0].duration_ms).toBe(0);
+  });
+
+  it("gate_rejected: emits one line with kind:failed reason:gate_rejected", async () => {
+    const syncHistory = vi.fn();
+    const now = new Date("2026-05-09T14:00:00Z");
+    const runSync = createRunSync({
+      dataDir: dir,
+      mutex: new AsyncMutex(),
+      cooldown: new Cooldown(),
+      cooldownWindowMs: 30_000,
+      fetchReferenceData: vi.fn().mockResolvedValue(emptyFetched),
+      gate: vi.fn().mockReturnValue({
+        ok: false,
+        failures: [{ step: "ftp_source_check", detail: "missing" }],
+        warnings: [],
+      }),
+      syncHistory,
+      now: () => now,
+    });
+
+    await runSync({ caller: "lazy" });
+
+    expect(syncHistory).toHaveBeenCalledOnce();
+    const line = syncHistory.mock.calls[0]![0];
+    expect(line.kind).toBe("failed");
+    expect(line.reason).toBe("gate_rejected");
+    expect(line.caller).toBe("lazy");
+  });
+
+  it("fetch_failed (fetcher rejects): emits one line with kind:failed reason:fetch_failed", async () => {
+    const syncHistory = vi.fn();
+    const now = new Date("2026-05-09T14:00:00Z");
+    const runSync = createRunSync({
+      dataDir: dir,
+      mutex: new AsyncMutex(),
+      cooldown: new Cooldown(),
+      cooldownWindowMs: 30_000,
+      fetchReferenceData: vi.fn().mockRejectedValue(new Error("net down")),
+      syncHistory,
+      now: () => now,
+    });
+
+    const result = await runSync({ caller: "scheduled" });
+
+    expect(result.kind).toBe("failed");
+    expect(syncHistory).toHaveBeenCalledOnce();
+    const line = syncHistory.mock.calls[0]![0];
+    expect(line.kind).toBe("failed");
+    expect(line.reason).toBe("fetch_failed");
+  });
+
+  it("outer_timeout: emits one line with kind:failed reason:outer_timeout", async () => {
+    const syncHistory = vi.fn();
+    const now = new Date("2026-05-09T14:00:00Z");
+    const runSync = createRunSync({
+      dataDir: dir,
+      mutex: new AsyncMutex(),
+      cooldown: new Cooldown(),
+      cooldownWindowMs: 30_000,
+      fetchReferenceData: vi.fn(
+        async (): Promise<FetchedReference> => await new Promise<FetchedReference>(() => {}),
+      ),
+      syncHistory,
+      now: () => now,
+      timing: { outerTimeoutMs: 30 },
+    });
+
+    await runSync({ caller: "scheduled" });
+
+    expect(syncHistory).toHaveBeenCalledOnce();
+    const line = syncHistory.mock.calls[0]![0];
+    expect(line.kind).toBe("failed");
+    expect(line.reason).toBe("outer_timeout");
+  });
+
+  it("mutex_held skip: a contended scheduled tick emits one line with kind:skipped reason:mutex_held", async () => {
+    const mutex = new AsyncMutex();
+    const cooldown = new Cooldown();
+    const now = new Date("2026-05-09T14:00:00Z");
+    const syncHistory = vi.fn();
+
+    let resolveSlow!: () => void;
+    const slowFetch = vi.fn(async () => {
+      await new Promise<void>((resolve) => {
+        resolveSlow = resolve;
+      });
+      return emptyFetched;
+    });
+
+    const runSyncSlow = createRunSync({
+      dataDir: dir,
+      mutex,
+      cooldown,
+      cooldownWindowMs: 30_000,
+      fetchReferenceData: slowFetch,
+      gate: okGate,
+      now: () => now,
+      timing: { acquireTimeoutMs: 5_000, hotWarnMs: 1_000 },
+    });
+    const runSyncFast = createRunSync({
+      dataDir: dir,
+      mutex,
+      cooldown,
+      cooldownWindowMs: 30_000,
+      fetchReferenceData: vi.fn().mockResolvedValue(emptyFetched),
+      gate: okGate,
+      syncHistory,
+      now: () => now,
+      timing: { acquireTimeoutMs: 30, hotWarnMs: 10 },
+    });
+
+    const p1 = runSyncSlow({ caller: "scheduled" });
+    const r2 = await runSyncFast({ caller: "scheduled" });
+
+    expect(r2).toEqual({ kind: "skipped", reason: "mutex_held" });
+    expect(syncHistory).toHaveBeenCalledOnce();
+    expect(syncHistory.mock.calls[0]![0].kind).toBe("skipped");
+    expect(syncHistory.mock.calls[0]![0].reason).toBe("mutex_held");
+
+    resolveSlow();
+    await p1;
+  });
+
+  it("/sync cooldown skip: emits one line with kind:skipped reason:cooldown (early-return path)", async () => {
+    let now = 1_000_000;
+    const cooldown = new Cooldown(() => now);
+    cooldown.record("telegram:123");
+    now += 5_000;
+    const syncHistory = vi.fn();
+
+    const runSync = createRunSync({
+      dataDir: dir,
+      mutex: new AsyncMutex(),
+      cooldown,
+      cooldownWindowMs: 30_000,
+      fetchReferenceData: vi.fn(),
+      syncHistory,
+      now: () => new Date(now),
+    });
+
+    const result = await runSync({ caller: "/sync", chatId: "telegram:123" });
+
+    expect(result.kind).toBe("skipped");
+    expect(syncHistory).toHaveBeenCalledOnce();
+    const line = syncHistory.mock.calls[0]![0];
+    expect(line.kind).toBe("skipped");
+    expect(line.reason).toBe("cooldown");
+    expect(line.caller).toBe("/sync");
+  });
+
+  it("a body that throws still leaves exactly one failed line before the throw propagates", async () => {
+    const syncHistory = vi.fn();
+    const now = new Date("2026-05-09T14:00:00Z");
+    const runSync = createRunSync({
+      dataDir: dir,
+      mutex: new AsyncMutex(),
+      cooldown: new Cooldown(),
+      cooldownWindowMs: 30_000,
+      fetchReferenceData: vi.fn().mockResolvedValue(emptyFetched),
+      // An unguarded throw from inside the mutex body (here the gate) re-throws
+      // out of runExclusive — the path that previously bypassed the emit.
+      gate: vi.fn(() => {
+        throw new Error("gate blew up");
+      }),
+      syncHistory,
+      now: () => now,
+    });
+
+    await expect(runSync({ caller: "scheduled" })).rejects.toThrow("gate blew up");
+
+    expect(syncHistory).toHaveBeenCalledOnce();
+    const line = syncHistory.mock.calls[0]![0];
+    expect(line.kind).toBe("failed");
+    expect(line.reason).toBe("unexpected_error");
+    expect(line.caller).toBe("scheduled");
+    expect(line.duration_ms).toBeGreaterThanOrEqual(0);
+  });
+
+  it("a throwing syncHistory spy cannot break the tick: runSync still resolves to the correct result", async () => {
+    const throwingHistory = vi.fn(() => {
+      throw new Error("history write blew up");
+    });
+    const now = new Date("2026-05-09T14:00:00Z");
+    const runSync = createRunSync({
+      dataDir: dir,
+      mutex: new AsyncMutex(),
+      cooldown: new Cooldown(),
+      cooldownWindowMs: 30_000,
+      fetchReferenceData: vi.fn().mockResolvedValue(emptyFetched),
+      gate: vi.fn().mockReturnValue({
+        ok: false,
+        failures: [{ step: "ftp_source_check", detail: "missing" }],
+        warnings: [],
+      }),
+      syncHistory: throwingHistory,
+      now: () => now,
+    });
+
+    // The wiring positions the emit so its throw cannot escape the tick: the
+    // real writer never throws, but a defensive guard keeps a misbehaving
+    // injected writer from corrupting the SyncResult.
+    await expect(runSync({ caller: "scheduled" })).resolves.toMatchObject({
+      kind: "failed",
+      reason: "gate_rejected",
+    });
+  });
+});

--- a/packages/core/tests/sync-history.test.ts
+++ b/packages/core/tests/sync-history.test.ts
@@ -1,0 +1,115 @@
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  SYNC_HISTORY_FILE,
+  createSyncHistoryWriter,
+  resetSyncHistoryEscalation,
+  type SyncOutcomeLine,
+} from "../src/reference/sync/sync-history.js";
+
+describe("createSyncHistoryWriter", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "sync-history-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    resetSyncHistoryEscalation();
+    vi.restoreAllMocks();
+  });
+
+  it("appends exactly one JSONL line per call, with the full outcome shape, to sync-history.jsonl", () => {
+    const path = join(dir, SYNC_HISTORY_FILE);
+    const writer = createSyncHistoryWriter(dir);
+
+    const line: SyncOutcomeLine = {
+      ts: "1998-05-09T14:00:00.000Z",
+      caller: "scheduled",
+      kind: "failed",
+      reason: "gate_rejected",
+      duration_ms: 1234,
+    };
+    writer(line);
+    writer({ ts: "1998-05-09T14:01:00.000Z", caller: "lazy", kind: "ran", duration_ms: 5 });
+
+    // The file lives beside error_state.json — NOT under logs/, NOT log.jsonl.
+    expect(existsSync(path)).toBe(true);
+    expect(existsSync(join(dir, "logs", "log.jsonl"))).toBe(false);
+
+    const lines = readFileSync(path, "utf-8").trim().split("\n");
+    expect(lines).toHaveLength(2);
+    expect(JSON.parse(lines[0])).toEqual({
+      ts: "1998-05-09T14:00:00.000Z",
+      caller: "scheduled",
+      kind: "failed",
+      reason: "gate_rejected",
+      duration_ms: 1234,
+    });
+    // A `ran` line carries no reason.
+    expect(JSON.parse(lines[1]).reason).toBeUndefined();
+  });
+
+  it("rotates to .1 on size overflow and applies NO age-based pruning (size-only cap, ~30-day retention)", () => {
+    const path = join(dir, SYNC_HISTORY_FILE);
+    const writer = createSyncHistoryWriter(dir, { maxBytes: 256 });
+
+    // Seed the live file above the (tiny, injected) cap with an ANCIENT line.
+    const ancient: SyncOutcomeLine = {
+      ts: "1990-01-01T00:00:00.000Z",
+      caller: "scheduled",
+      kind: "ran",
+      reason: undefined,
+      duration_ms: 1,
+    };
+    writeFileSync(path, JSON.stringify({ ...ancient, filler: "x".repeat(512) }) + "\n");
+    expect(statSync(path).size).toBeGreaterThan(256);
+
+    // The next write trips the size rotate: the seeded content moves to `.1`,
+    // the live file holds only the fresh line.
+    writer({ ts: "1998-05-09T14:00:00.000Z", caller: "lazy", kind: "ran", duration_ms: 9 });
+
+    expect(existsSync(`${path}.1`)).toBe(true);
+    const live = readFileSync(path, "utf-8").trim().split("\n");
+    expect(live).toHaveLength(1);
+    expect(JSON.parse(live[0]).caller).toBe("lazy");
+
+    // The ancient line is NOT dropped — it survives in `.1`. A size-only cap has
+    // no age prune, so ~30-day-old lines persist until rotated out by SIZE.
+    const rotated = readFileSync(`${path}.1`, "utf-8");
+    expect(rotated).toContain("1990-01-01T00:00:00.000Z");
+  });
+
+  it("never throws when the append target is unwritable; warns once per process and swallows", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    // Point dataDir at a path whose parent is a regular file, so mkdir/append
+    // fails — mirrors the rolling logger's unwritable-target test.
+    const blocker = join(dir, "block");
+    writeFileSync(blocker, "i am a file, not a dir");
+    const writer = createSyncHistoryWriter(join(blocker, "nested"));
+
+    const line: SyncOutcomeLine = {
+      ts: "1998-05-09T14:00:00.000Z",
+      caller: "scheduled",
+      kind: "ran",
+      duration_ms: 7,
+    };
+
+    expect(() => writer(line)).not.toThrow();
+    expect(warnSpy).toHaveBeenCalledOnce();
+
+    // The once-per-process latch holds: a second failing write does not re-warn.
+    expect(() => writer(line)).not.toThrow();
+    expect(warnSpy).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
Adds a durable, standalone per-tick sync outcome trail so a multi-tick sync outage leaves evidence that survives until an operator can read it.

## What changed

- New module `packages/core/src/reference/sync/sync-history.ts`: a best-effort JSONL writer that appends exactly one outcome line per sync tick — `{ ts, caller, kind, reason?, step?, duration_ms }` — to a standalone `sync-history.jsonl` under the data dir. The file is size-capped at ~1 MB (rotating to `.1` on overflow) with deliberately no age cap, so roughly a month of ticks is retained and "how often did sync fail last month, and why?" stays answerable. The writer never throws: a full disk or permission error must never break the tick it observes, and it escalates its own failure with a once-per-process warning.
- `run-sync.ts` calls the writer at every tick exit path — successes, skips, and failures alike, including the scheduler path that previously discarded its result. A throwing sync body still stamps a `failed` line, with the recorded duration clamped to be non-negative.

The single-slot error-state lifecycle is untouched; the doctor-side reader that surfaces this history is intentionally out of scope.

This is a standalone diagnostics surface — no athlete-visible behavior changes, so no changeset rides this PR.

## Test plan

- New `packages/core/tests/sync-history.test.ts`: one line per write, JSONL shape, size-cap rotation, the no-throw guarantee under write failure, and the once-per-process escalation latch.
- `packages/core/tests/reference-run-sync.test.ts`: extended to assert every tick exit path (ran / skipped / failed, scheduler and interactive callers) emits exactly one history line and that a thrown sync body still stamps a failed line.
- `pnpm check && pnpm test` green.

This PR stacks on the abort-aware atomic-write branch; its base is that branch, not main.
