### PR TITLE
feat(core): wire block_coaching so the coach declines numbers from unvalidated data

### DIFF
--- a/.changeset/coach-declines-stale-numbers.md
+++ b/.changeset/coach-declines-stale-numbers.md
@@ -1,0 +1,7 @@
+---
+"@enduragent/core": patch
+---
+
+User-facing: The coach now declines to quote numbers from stale data and tells you so, instead of fabricating from a stale cache.
+
+When the latest sync fails validation, the gate records a block-coaching mitigation and the chat turn degrades to general, qualitative guidance with a one-line disclosure of how long since the data last synced. The validation-failure signal flows through an already-present on-disk mitigation channel (no schema change): a HARD sync-gate rejection stamps the error state, and the turn reads it once at start, failing open if that state file is itself unreadable. The degrade block renders in the volatile prompt tail so prompt caching is preserved.

--- a/packages/core/CONTEXT.md
+++ b/packages/core/CONTEXT.md
@@ -76,6 +76,16 @@ The turn-invariant head of the system prompt — SOUL, the joined skill prompts,
 
 `getCoachHome(binaryName)` (exported from `@enduragent/core`) is the single helper that resolves a binary's data directory using the three-tier fallback codified in ADR-0006: env-var override (`<BINARY>_HOME`, with `~`/`~/...` expansion) → legacy `~/.cycling-coach/` (only for the `cycling-coach` binary, only when that directory exists on disk) → fresh-install canonical `~/.enduragent/<dataSubdir>/` (subdir derived by stripping `-coach` from the binary name). All persisted state — Core config, Memory, Reference cache files (per the Reference layer's upstream protocol) — routes through this helper. Pure function; callers create the directory when they need it.
 
+## Fail-mode policy
+
+Each subsystem's behavior under failure is a recorded fail-open / fail-closed decision (full table + rationale in the project's fail-mode policy ADR; only this one-line-per-row mirror ships):
+
+- **Coaching from stale/corrupt cache** → **CLOSED** (degrade-and-disclose). A HARD sync-gate rejection stamps `mitigation: "block_coaching"`; the chat turn reads it and declines to quote numbers from unvalidated data, telling the athlete the data is stale instead. The one row wired in code.
+- **Audit-write** (append throws) → **OPEN**. Audit is observability, not the reply path; never break coaching to record a log line.
+- **`error_state.json` unreadable** (missing / unparseable / schema-invalid) → **OPEN** on the read. A broken error-state file must not brick chat — absent/unreadable yields no block, coach normally.
+- **Sender-allowlist lock contention** → **CLOSED**. Access control is a security boundary; deny on uncertainty rather than admit an unverified sender.
+- **Secrets backend unavailable** → **CLOSED**. No credential ⇒ no upstream call; fail loudly rather than proceed with an empty/guessed secret.
+
 ## Reference test substrate (property-based + golden fixtures)
 
 Property-based generators wrapping the Reference input schemas live at

--- a/packages/core/src/agent/coach-agent.ts
+++ b/packages/core/src/agent/coach-agent.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { join } from "node:path";
 import { stepCountIs } from "ai";
 import type { ModelMessage, Tool, ToolSet } from "ai";
 import { makeChatClient } from "../reference/sync/intervals-client-factory.js";
@@ -8,6 +9,13 @@ import type { ResolvedCs } from "../reference/cs-resolution.js";
 import type { SecretsResolver } from "../secrets/types.js";
 import type { Config } from "../config.js";
 import { resolveSecretRef } from "../secrets/resolve.js";
+import { safeReadJson } from "../io/safe-read-json.js";
+import {
+  ErrorStateSchema,
+  type ErrorState,
+  LatestJsonSchema,
+  type LatestJson,
+} from "../reference/index.js";
 import { Memory } from "../memory/store.js";
 import { ChatStore } from "./chat-store.js";
 import { buildSystemPrompt, staticRuleBlocks } from "./system-prompt.js";
@@ -234,6 +242,44 @@ export class CoachAgent {
     } as Tool;
   }
 
+  /**
+   * Read the sync error-state once at turn start and, when the last sync was
+   * rejected for a corruption-class (HARD) failure, return a degrade-and-disclose
+   * instruction block for the volatile prompt tail. The READ itself fails OPEN:
+   * a missing, unparseable, or schema-invalid error-state file must never brick
+   * a chat turn, so `safeReadJson` returning null yields no block.
+   */
+  private buildDegradeBlock(): string | undefined {
+    const referenceDir = join(this.config.dataDir, "data");
+    const errorState = safeReadJson<ErrorState>(
+      join(referenceDir, "error_state.json"),
+      ErrorStateSchema,
+    );
+    if (errorState?.mitigation !== "block_coaching") return undefined;
+
+    // Prefer the cache's last successful-sync stamp as the "last synced" anchor;
+    // fall back to the failure timestamp when the cache is unavailable.
+    const latest = safeReadJson<LatestJson>(
+      join(referenceDir, "latest.json"),
+      LatestJsonSchema,
+    );
+    const lastSynced = latest?.metadata?.last_updated ?? errorState.ts;
+
+    return (
+      "# Data Freshness — DEGRADED\n\n" +
+      "The latest training data could not be validated, so the on-disk cache " +
+      "may be stale or corrupt. You MUST NOT quote specific numbers (paces, " +
+      "power, Load, Fitness, Fatigue, Form, heart rate, durations) from that " +
+      "data — they cannot be trusted. Give general, qualitative guidance only. " +
+      "Open your reply by disclosing the staleness to the athlete, in your own " +
+      `voice, matching this posture: "Your training data hasn't synced since ` +
+      `${lastSynced}, so I won't base numbers on it — here's general guidance ` +
+      `only." State the last-synced time in natural language (e.g. a date or "a ` +
+      `few days ago"); do not echo the raw timestamp verbatim. Then help as best ` +
+      `you can without fabricating figures.`
+    );
+  }
+
   private async flushMemory(
     messages: ModelMessage[],
     trigger: MemoryFlushTrigger,
@@ -349,7 +395,12 @@ export class CoachAgent {
         }
       }
 
-      this.systemPrompt = buildSystemPrompt(this.sport, this.memory, this.tz);
+      this.systemPrompt = buildSystemPrompt(
+        this.sport,
+        this.memory,
+        this.tz,
+        this.buildDegradeBlock(),
+      );
 
       const budget = computeHistoryTokenBudget({
         contextWindowTokens: this.config.contextWindowTokens,

--- a/packages/core/src/agent/system-prompt.ts
+++ b/packages/core/src/agent/system-prompt.ts
@@ -146,6 +146,7 @@ export function buildSystemPrompt(
   persona: SportPersona,
   memory: Memory,
   tz: string = "UTC",
+  degradeBlock?: string,
 ): string {
   const skillsContent = Object.entries(persona.skills)
     .map(([name, content]) => `## Skill: ${name}\n\n${content}`)
@@ -181,6 +182,13 @@ export function buildSystemPrompt(
   // appendCurrentTimeLine() so it stays fresh across long sessions and
   // doesn't go stale crossing local midnight. See user-time.ts.
   parts.push(`# Current Date & Time\n\nTime zone: ${tz}`);
+
+  // Volatile per-turn block: rendered AFTER the cache boundary because it
+  // depends on disk state (whether the last sync failed validation) and would
+  // reshape the cached prefix every turn if it rode above the boundary.
+  if (degradeBlock) {
+    parts.push(degradeBlock);
+  }
 
   return parts.join("\n\n---\n\n");
 }

--- a/packages/core/src/reference/sync/run-sync.ts
+++ b/packages/core/src/reference/sync/run-sync.ts
@@ -14,7 +14,8 @@ import { INTERVALS_SCHEMA_VERSION, IntervalsJsonSchema } from "../schemas/interv
 import { ROUTES_SCHEMA_VERSION, RoutesJsonSchema } from "../schemas/routes.js";
 import { FTP_HISTORY_SCHEMA_VERSION, FtpHistoryJsonSchema } from "../schemas/ftp-history.js";
 import { SCHEDULER_SCHEMA_VERSION } from "../schemas/scheduler.js";
-import type { ErrorPhase, ErrorCaller } from "../schemas/error-state.js";
+import { ErrorStateSchema } from "../schemas/error-state.js";
+import type { ErrorPhase, ErrorCaller, ErrorState } from "../schemas/error-state.js";
 import { gateLatestJson } from "../validation/sync-gate.js";
 import { writeErrorState, clearErrorState } from "./error-state-writer.js";
 import { createSyncHistoryWriter, type SyncOutcomeLine } from "./sync-history.js";
@@ -177,6 +178,18 @@ function readPriorCache(path: string, file: CacheFile): Record<string, unknown> 
   return safeReadJson<Record<string, unknown>>(path, CACHE_SCHEMAS[file]);
 }
 
+/** Carry forward an active `block_coaching` mitigation onto a subsequent
+ *  failure-path write. `error_state.json` is single-slot/last-writer-wins, so a
+ *  transient timeout or fetch failure following a HARD gate rejection would
+ *  otherwise overwrite the corruption-class block with a mitigation-less record
+ *  and silently re-open coaching while the cache is still unvalidated. A
+ *  timeout/fetch failure is an unknown outcome, not proof the cache became
+ *  trustworthy — only the clean-sync `clearError` path removes the block. */
+function priorBlockCoaching(dataDir: string): { mitigation: "block_coaching" } | undefined {
+  const prior = safeReadJson<ErrorState>(join(dataDir, "error_state.json"), ErrorStateSchema);
+  return prior?.mitigation === "block_coaching" ? { mitigation: prior.mitigation } : undefined;
+}
+
 /** Recursively rebuild an object/array with every object's keys in sorted
  *  order, so two structurally-equal payloads serialize identically regardless
  *  of key insertion order. `priorPayloadEquals` reads the prior payload back
@@ -283,6 +296,12 @@ export function createRunSync(
         async (): Promise<SyncResult> => {
         const controller = new AbortController();
         let phase: ErrorPhase = "fetching";
+        // Set synchronously the instant this cycle classifies the bundle as
+        // unusable, before the (async) error_state write. The outer-timeout path
+        // races the body's write and cannot re-read error_state.json reliably
+        // (the body's rename may not have landed yet), so it ORs this flag in
+        // rather than demote a same-cycle HARD rejection to a mitigation-less record.
+        let cycleBlockCoaching = false;
 
         // Returned at any phase boundary where `controller.signal.aborted` is
         // true after an `await` resolves. Prevents body from doing the next
@@ -305,7 +324,12 @@ export function createRunSync(
             // scheduled tick logging-only and the curator blind to the failure.
             if (controller.signal.aborted) return abortedResult();
             const detail = err instanceof Error ? err.message : String(err);
-            await writeErrorState(deps.dataDir, { step: "fetch_failed", phase, detail });
+            await writeErrorState(deps.dataDir, {
+              step: "fetch_failed",
+              phase,
+              detail,
+              ...priorBlockCoaching(deps.dataDir),
+            });
             return {
               kind: "failed",
               reason: "fetch_failed",
@@ -319,9 +343,16 @@ export function createRunSync(
           // on-disk LatestJson, so prior-vs-incoming comparison is not yet wired.
           const gateResult = gate(fetched, null, now());
           if (!gateResult.ok) {
+            // A HARD gate failure means the freshly-fetched bundle could not be
+            // validated — the cache is unvalidated/corrupt. Mark the failure
+            // block-coaching so the chat path degrades to general guidance
+            // instead of quoting numbers from data we could not trust. The soft
+            // path below keeps its non-blocking warn-only mitigation.
+            cycleBlockCoaching = true;
             await writeErrorState(deps.dataDir, {
               step: "gate_rejected",
               detail: gateResult.failures.map((f) => `${f.step}: ${f.detail}`).join("; "),
+              mitigation: "block_coaching",
             });
             return {
               kind: "failed",
@@ -467,6 +498,9 @@ export function createRunSync(
             step: "outer_timeout",
             phase,
             detail: `runSync exceeded ${outerTimeoutMs}ms during ${phase} phase`,
+            ...(cycleBlockCoaching
+              ? ({ mitigation: "block_coaching" } as const)
+              : priorBlockCoaching(deps.dataDir)),
           });
           return { kind: "failed", reason: "outer_timeout", failures: [] };
         }

--- a/packages/core/tests/coach-agent-block-coaching.test.ts
+++ b/packages/core/tests/coach-agent-block-coaching.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { baseAgentConfig } from "./helpers/base-agent-config.js";
+import { cyclingSport } from "@enduragent/sport-cycling";
+import type { Sport } from "../src/sport.js";
+import {
+  SYSTEM_PROMPT_CACHE_BOUNDARY,
+} from "../src/agent/system-prompt.js";
+
+let tempHome: string;
+let origHome: string | undefined;
+let dataDir: string;
+
+beforeEach(() => {
+  tempHome = mkdtempSync(join(tmpdir(), "cc-blockcoaching-"));
+  origHome = process.env.HOME;
+  process.env.HOME = tempHome;
+  dataDir = join(tempHome, ".cycling-coach");
+  mkdirSync(join(dataDir, "memory"), { recursive: true });
+  mkdirSync(join(dataDir, "data"), { recursive: true });
+  vi.resetModules();
+});
+
+afterEach(() => {
+  process.env.HOME = origHome;
+  rmSync(tempHome, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+const FLUSH_MARKER = "reviewing a conversation to extract and save important athlete";
+const DISCLOSE_MARKER = "won't base numbers on it";
+
+function mkAssistant(text: string) {
+  return {
+    text,
+    toolCalls: [],
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+    },
+    stopReason: "stop" as const,
+  };
+}
+
+/** Capture the main-turn system prompt (the one that is NOT the flush/summary call). */
+function captureMainPrompt() {
+  const seen: string[] = [];
+  const complete = vi.fn(async (params: { system?: string }) => {
+    const sys = params.system ?? "";
+    if (sys.includes(FLUSH_MARKER)) return mkAssistant("facts noted");
+    if (sys.length === 0) return mkAssistant("summary");
+    seen.push(sys);
+    return mkAssistant("all good");
+  });
+  return { complete, seen };
+}
+
+function writeErrorStateFile(mitigation: string | undefined): void {
+  const payload: Record<string, unknown> = {
+    schema_version: "1",
+    step: "gate_rejected",
+    detail: "step1_ftp_source: FTP source missing",
+    ts: "2026-05-09T14:00:00.000Z",
+  };
+  if (mitigation !== undefined) payload.mitigation = mitigation;
+  writeFileSync(join(dataDir, "data", "error_state.json"), JSON.stringify(payload));
+}
+
+async function setupAgent(complete: ReturnType<typeof vi.fn>) {
+  vi.doMock("../src/agent/codex/responses.js", () => ({
+    codexResponses: complete,
+  }));
+  vi.doMock("../src/agent/codex/oauth.js", () => ({
+    refreshCodexToken: vi.fn(),
+    loginCodex: vi.fn(),
+  }));
+  vi.doMock("../src/auth/profiles.js", () => ({
+    getFreshToken: vi.fn(async () => "token"),
+    loadProfile: vi.fn(),
+    saveProfile: vi.fn(),
+    RefreshTokenReusedError: class extends Error {},
+  }));
+
+  const { CoachAgent } = await import("../src/agent/coach-agent.js");
+  return new CoachAgent(cyclingSport as unknown as Sport, baseAgentConfig(dataDir));
+}
+
+describe("block_coaching consume side (degrade-and-disclose prompt block)", () => {
+  it("block_coaching on disk ⇒ a degrade-and-disclose block in the volatile prompt tail", async () => {
+    writeErrorStateFile("block_coaching");
+    const { complete, seen } = captureMainPrompt();
+    const agent = await setupAgent(complete);
+
+    const text = await agent.chat("blk-chat", "how's my training?");
+    expect(text).toBe("all good");
+
+    const prompt = seen.at(-1) ?? "";
+    expect(prompt).toContain(DISCLOSE_MARKER);
+    // The block renders AFTER the cache boundary (volatile tail), not in the prefix.
+    const boundaryIdx = prompt.indexOf(SYSTEM_PROMPT_CACHE_BOUNDARY.replace(/^\n\n---\n\n/, ""));
+    const blockIdx = prompt.indexOf(DISCLOSE_MARKER);
+    expect(boundaryIdx).toBeGreaterThanOrEqual(0);
+    expect(blockIdx).toBeGreaterThan(boundaryIdx);
+  });
+
+  it("no error_state.json ⇒ no degrade block; coach answers normally", async () => {
+    const { complete, seen } = captureMainPrompt();
+    const agent = await setupAgent(complete);
+
+    const text = await agent.chat("clean-chat", "how's my training?");
+    expect(text).toBe("all good");
+    expect(seen.at(-1) ?? "").not.toContain(DISCLOSE_MARKER);
+  });
+
+  it("warn_only ⇒ no degrade block (only block_coaching triggers it)", async () => {
+    writeErrorStateFile("warn_only");
+    const { complete, seen } = captureMainPrompt();
+    const agent = await setupAgent(complete);
+
+    const text = await agent.chat("warn-chat", "how's my training?");
+    expect(text).toBe("all good");
+    expect(seen.at(-1) ?? "").not.toContain(DISCLOSE_MARKER);
+  });
+
+  it("unreadable / garbage error_state.json ⇒ no block, no throw (fail-open on the read)", async () => {
+    writeFileSync(join(dataDir, "data", "error_state.json"), "{ not valid json ::");
+    const { complete, seen } = captureMainPrompt();
+    const agent = await setupAgent(complete);
+
+    // Required-red: a read that throws on bad JSON instead of safeReadJson breaks this.
+    const text = await agent.chat("garbage-chat", "how's my training?");
+    expect(text).toBe("all good");
+    expect(seen.at(-1) ?? "").not.toContain(DISCLOSE_MARKER);
+  });
+});

--- a/packages/core/tests/sync-gate-block-coaching.test.ts
+++ b/packages/core/tests/sync-gate-block-coaching.test.ts
@@ -1,0 +1,182 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AsyncMutex } from "../src/concurrency/mutex.js";
+import { Cooldown } from "../src/concurrency/cooldown.js";
+import { createRunSync } from "../src/reference/sync/run-sync.js";
+import { writeErrorState } from "../src/reference/sync/error-state-writer.js";
+import { emptyFetched } from "./helpers/reference-fixtures.js";
+
+describe("block_coaching write side (gate-reject mitigation)", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "block-coaching-write-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  function readErrorState(): Record<string, unknown> {
+    return JSON.parse(readFileSync(join(dir, "error_state.json"), "utf-8"));
+  }
+
+  it("a HARD gate rejection stamps mitigation:block_coaching on error_state.json", async () => {
+    const now = new Date("2026-05-09T14:00:00Z");
+    const fetchSpy = vi.fn().mockResolvedValue(emptyFetched);
+    const rejectingGate = vi.fn().mockReturnValue({
+      ok: false,
+      failures: [{ step: "step1_ftp_source", detail: "FTP source missing on athlete profile" }],
+      warnings: [],
+    });
+
+    const runSync = createRunSync({
+      dataDir: dir,
+      mutex: new AsyncMutex(),
+      cooldown: new Cooldown(),
+      cooldownWindowMs: 30_000,
+      fetchReferenceData: fetchSpy,
+      gate: rejectingGate,
+      now: () => now,
+    });
+
+    const result = await runSync({ caller: "scheduled" });
+
+    expect(result.kind).toBe("failed");
+    if (result.kind === "failed") expect(result.reason).toBe("gate_rejected");
+
+    const errorState = readErrorState();
+    // Required-red: without the S3 write the field is absent / undefined here.
+    expect(errorState.mitigation).toBe("block_coaching");
+    expect(errorState.step).toBe("gate_rejected");
+  });
+
+  it("soft warnings still write mitigation:warn_only, never block_coaching", async () => {
+    const now = new Date("2026-05-09T14:00:00Z");
+    const fetchSpy = vi.fn().mockResolvedValue(emptyFetched);
+    const warningGate = vi.fn().mockReturnValue({
+      ok: true,
+      failures: [],
+      warnings: [{ step: "step6_freshness_24h", detail: "data freshness=stale" }],
+      freshness: "stale",
+    });
+
+    const runSync = createRunSync({
+      dataDir: dir,
+      mutex: new AsyncMutex(),
+      cooldown: new Cooldown(),
+      cooldownWindowMs: 30_000,
+      fetchReferenceData: fetchSpy,
+      gate: warningGate,
+      now: () => now,
+    });
+
+    const result = await runSync({ caller: "scheduled" });
+    expect(result.kind).toBe("ran");
+
+    const errorState = readErrorState();
+    expect(errorState.mitigation).toBe("warn_only");
+    expect(errorState.mitigation).not.toBe("block_coaching");
+  });
+
+  it("a later outer_timeout cycle preserves a prior block_coaching (does not re-open coaching while the cache is still unvalidated)", async () => {
+    const now = new Date("2026-05-09T14:00:00Z");
+
+    // Cycle 1: a HARD gate rejection stamps block_coaching.
+    const rejectingSync = createRunSync({
+      dataDir: dir,
+      mutex: new AsyncMutex(),
+      cooldown: new Cooldown(),
+      cooldownWindowMs: 30_000,
+      fetchReferenceData: vi.fn().mockResolvedValue(emptyFetched),
+      gate: vi.fn().mockReturnValue({
+        ok: false,
+        failures: [{ step: "step1_ftp_source", detail: "FTP source missing" }],
+        warnings: [],
+      }),
+      now: () => now,
+    });
+    await rejectingSync({ caller: "scheduled" });
+    expect(readErrorState().mitigation).toBe("block_coaching");
+
+    // Cycle 2: a transient outer timeout — the cache was never re-validated, so
+    // the corruption-class block must survive the mitigation-less timeout write.
+    const timingOutSync = createRunSync({
+      dataDir: dir,
+      mutex: new AsyncMutex(),
+      cooldown: new Cooldown(),
+      cooldownWindowMs: 30_000,
+      fetchReferenceData: vi.fn(() => new Promise<never>(() => {})),
+      now: () => now,
+      timing: { outerTimeoutMs: 30 },
+    });
+    const result = await timingOutSync({ caller: "scheduled" });
+    expect(result.kind).toBe("failed");
+    if (result.kind === "failed") expect(result.reason).toBe("outer_timeout");
+
+    const errorState = readErrorState();
+    expect(errorState.step).toBe("outer_timeout");
+    expect(errorState.mitigation).toBe("block_coaching");
+  });
+
+  it("a pre-existing block_coaching survives an outer_timeout cycle: the timeout-path record still carries the block (carry-forward)", async () => {
+    const now = new Date("2026-05-09T14:00:00Z");
+
+    // Pre-seed a corruption-class block from an earlier HARD gate rejection.
+    await writeErrorState(dir, {
+      step: "gate_rejected",
+      detail: "FTP source missing",
+      mitigation: "block_coaching",
+    });
+    expect(readErrorState().mitigation).toBe("block_coaching");
+
+    // A later tick times out (hanging fetch). The cache was never re-validated,
+    // so the mitigation-less timeout write must NOT demote the block — the
+    // timeout path carries the prior block_coaching forward off disk.
+    const runSync = createRunSync({
+      dataDir: dir,
+      mutex: new AsyncMutex(),
+      cooldown: new Cooldown(),
+      cooldownWindowMs: 30_000,
+      fetchReferenceData: vi.fn(() => new Promise<never>(() => {})),
+      now: () => now,
+      timing: { outerTimeoutMs: 30 },
+    });
+
+    const result = await runSync({ caller: "scheduled" });
+    expect(result.kind).toBe("failed");
+    if (result.kind === "failed") expect(result.reason).toBe("outer_timeout");
+
+    const errorState = readErrorState();
+    expect(errorState.step).toBe("outer_timeout");
+    expect(errorState.mitigation).toBe("block_coaching");
+  });
+
+  it("a clean sync leaves no error_state.json (the block write never leaks onto the happy path)", async () => {
+    const now = new Date("2026-05-09T14:00:00Z");
+    const fetchSpy = vi.fn().mockResolvedValue(emptyFetched);
+    const cleanGate = vi.fn().mockReturnValue({
+      ok: true,
+      failures: [],
+      warnings: [],
+      freshness: "fresh",
+    });
+
+    const runSync = createRunSync({
+      dataDir: dir,
+      mutex: new AsyncMutex(),
+      cooldown: new Cooldown(),
+      cooldownWindowMs: 30_000,
+      fetchReferenceData: fetchSpy,
+      gate: cleanGate,
+      now: () => now,
+    });
+
+    const result = await runSync({ caller: "scheduled" });
+    expect(result.kind).toBe("ran");
+    expect(existsSync(join(dir, "error_state.json"))).toBe(false);
+  });
+});


### PR DESCRIPTION
Wires the previously schema-only block-coaching mitigation into a working degrade-and-disclose path for stale and corruption-class sync failures.

## What changed by surface

- Sync orchestration (run-sync.ts): a HARD sync-gate rejection now records a block-coaching mitigation in the existing on-disk error-state channel — no schema change, the field already existed and was never written or consumed. A transient failure preserves the prior mitigation rather than clobbering it.
- Chat path (coach-agent.ts, system-prompt.ts): the turn reads the mitigation once at start and, when set, degrades to general qualitative guidance with a one-line disclosure of how long since the data last synced. The degrade block renders in the volatile prompt tail so prompt caching upstream stays intact. If the error-state file is itself unreadable, the turn fails open.
- CONTEXT.md: one-line mirror of the fail-open/fail-closed decision so the shipped surface documents the policy.
- Changeset: user-facing entry describing the decline-and-disclose behavior.

## Test plan

- pnpm check && pnpm test green.
- New tests assert the gate stamps the mitigation on a hard rejection, that a transient failure preserves a prior mitigation, that the chat turn degrades and discloses when the mitigation is set, and that an unreadable state file fails open (coaching proceeds normally).

This PR stacks on the prior task's branch; its base is that feature branch, not main. Operator merges the stack bottom-up and retargets.
