### PR TITLE
fix(core): treat future-dated cache timestamps as stale and report them honestly

### DIFF
--- a/.changeset/clock-skew-freshness-honesty.md
+++ b/.changeset/clock-skew-freshness-honesty.md
@@ -1,0 +1,7 @@
+---
+"@enduragent/core": patch
+---
+
+User-facing: A backward or frozen system clock no longer makes stale training data appear fresh.
+
+The freshness band now treats a cache timestamp more than five minutes in the future as stale (raising a freshness warning) instead of fresh, and the `/sync` reply words a future timestamp honestly instead of clamping it to "0s ago".

--- a/packages/core/src/reference/freshness.ts
+++ b/packages/core/src/reference/freshness.ts
@@ -10,6 +10,12 @@ export const FRESH_MS = 24 * 60 * 60 * 1000;
 export const STALE_MS = 48 * 60 * 60 * 1000;
 /** >7 d: data is critical; force a fresh sync before answering. */
 export const CRITICAL_MS = 7 * 24 * 60 * 60 * 1000;
+/**
+ * Tolerance for a `last_updated` timestamp in the future. A few minutes of
+ * clock skew (NTP correction, VM time-sync) is benign; beyond this the
+ * timestamp is impossible and the cache is treated as stale rather than fresh.
+ */
+export const FUTURE_TOLERANCE_MS = 5 * 60 * 1000;
 
 // ─── Retention windows ─────────────────────────────────────────────────
 /** Days of history retained at "latest" granularity (recent activities + wellness). */

--- a/packages/core/src/reference/sync/format-sync-reply.ts
+++ b/packages/core/src/reference/sync/format-sync-reply.ts
@@ -58,16 +58,27 @@ export function formatSyncReply(result: SyncResult, now: Date = new Date()): str
   }
 }
 
+// Display flags any meaningful future-dating of the cache stamp. Deliberately
+// tighter than freshness.ts's FUTURE_TOLERANCE_MS (5 min): the staleness
+// classifier tolerates benign sub-tolerance skew, but the human-facing line
+// should surface even a small clock disagreement rather than print "0s ago".
+const FUTURE_DISPLAY_THRESHOLD_MS = 1000;
+
 function formatTimestamp(iso: string, now: Date): string {
   const d = new Date(iso);
-  const diffMs = Math.max(0, now.getTime() - d.getTime());
-  const diffSec = Math.round(diffMs / 1000);
+  const deltaMs = now.getTime() - d.getTime();
+  const utc = `${d.toISOString().slice(0, 16).replace("T", " ")} UTC`;
+  if (deltaMs < -FUTURE_DISPLAY_THRESHOLD_MS) {
+    // A future timestamp means the cache stamp is ahead of the wall clock —
+    // almost always clock skew. Word it honestly instead of clamping to "0s ago".
+    return `${utc} (in the future — check system clock)`;
+  }
+  const diffSec = Math.round(Math.max(0, deltaMs) / 1000);
   const ago =
     diffSec < 60
       ? `${diffSec}s ago`
       : diffSec < 3600
         ? `${Math.round(diffSec / 60)} min ago`
         : `${Math.round(diffSec / 3600)} h ago`;
-  const utc = `${d.toISOString().slice(0, 16).replace("T", " ")} UTC`;
   return `${utc} (${ago})`;
 }

--- a/packages/core/src/reference/sync/freshness-check.ts
+++ b/packages/core/src/reference/sync/freshness-check.ts
@@ -1,4 +1,4 @@
-import { CRITICAL_MS, FRESH_MS, STALE_MS } from "../freshness.js";
+import { CRITICAL_MS, FRESH_MS, FUTURE_TOLERANCE_MS, STALE_MS } from "../freshness.js";
 
 export type Freshness = "fresh" | "flag" | "stale" | "critical";
 
@@ -13,6 +13,11 @@ export function freshnessOf(
   now: Date = new Date(),
 ): Freshness {
   const elapsed = now.getTime() - new Date(metadata.last_updated).getTime();
+  // A `last_updated` in the future beyond a small skew tolerance is impossible;
+  // a backward/frozen clock would otherwise leave `elapsed` negative forever and
+  // mask arbitrarily old data as fresh. Treat it as stale so the freshness
+  // annotator raises a warning instead of silently trusting it.
+  if (elapsed < -FUTURE_TOLERANCE_MS) return "stale";
   if (elapsed >= CRITICAL_MS) return "critical";
   if (elapsed >= STALE_MS) return "stale";
   if (elapsed >= FRESH_MS) return "flag";

--- a/packages/core/tests/reference-format-sync-reply.test.ts
+++ b/packages/core/tests/reference-format-sync-reply.test.ts
@@ -32,6 +32,27 @@ describe("formatSyncReply", () => {
     expect(text.toLowerCase()).toContain("nothing changed");
   });
 
+  it("words a future lastSyncAt honestly instead of clamping it to '0s ago'", () => {
+    const r: SyncResult = {
+      kind: "ran",
+      lastSyncAt: new Date(fixedNow.getTime() + 10 * 60 * 1000).toISOString(),
+      refreshed: ["latest"],
+    };
+    const text = formatSyncReply(r, fixedNow);
+    expect(text).not.toContain("0s ago");
+    expect(text.toLowerCase()).toMatch(/future|clock/);
+  });
+
+  it("renders a normal past lastSyncAt as 'Xs ago' (ladder unchanged)", () => {
+    const r: SyncResult = {
+      kind: "ran",
+      lastSyncAt: "2026-05-09T14:23:00Z",
+      refreshed: ["latest"],
+    };
+    const text = formatSyncReply(r, fixedNow);
+    expect(text).toContain("32s ago");
+  });
+
   it("formats the cooldown skip with a per-second retryAfter countdown", () => {
     const r: SyncResult = {
       kind: "skipped",

--- a/packages/core/tests/reference-freshness-check.test.ts
+++ b/packages/core/tests/reference-freshness-check.test.ts
@@ -27,4 +27,14 @@ describe("freshnessOf", () => {
     expect(freshnessOf({ last_updated: ago(7 * DAY) }, fixedNow)).toBe("critical");
     expect(freshnessOf({ last_updated: ago(30 * DAY) }, fixedNow)).toBe("critical");
   });
+
+  it("returns 'stale' when last_updated is in the future beyond the skew tolerance", () => {
+    const thirtyMinAhead = new Date(fixedNow.getTime() + 30 * 60 * 1000).toISOString();
+    expect(freshnessOf({ last_updated: thirtyMinAhead }, fixedNow)).toBe("stale");
+  });
+
+  it("stays 'fresh' when last_updated is in the future within the skew tolerance", () => {
+    const oneMinAhead = new Date(fixedNow.getTime() + 60 * 1000).toISOString();
+    expect(freshnessOf({ last_updated: oneMinAhead }, fixedNow)).toBe("fresh");
+  });
 });


### PR DESCRIPTION
Fixes a clock-skew freshness gap in the sync data-freshness path (pure-function legs only).

Today a `last_updated` timestamp that sits in the future (a backward or frozen system clock, a daylight-saving edge) produces a negative elapsed interval, which the freshness band ladder maps to "fresh forever" — stale data reads as current. The `/sync` reply compounds this by clamping a future timestamp to "0s ago", which reads as a perfectly-fresh sync.

Changes by surface:

- `reference/freshness.ts` — adds a future-timestamp tolerance constant (~5 minutes) to the freshness band definitions, so a small benign skew is absorbed but a real future-dated timestamp is not.
- `reference/sync/freshness-check.ts` — a cache timestamp more than the tolerance into the future is now classified stale and surfaces a freshness warning, instead of falling through to fresh.
- `reference/sync/format-sync-reply.ts` — a future timestamp is rendered with honest future wording rather than being masked as "0s ago".

The doctor-report clock-skew line is intentionally out of scope here and is tracked for a later batch.

Test plan:

- `reference-freshness-check.test.ts` — covers a within-tolerance future timestamp (still fresh), a beyond-tolerance future timestamp (now stale + warning), and the existing past-timestamp band behavior (unchanged).
- `reference-format-sync-reply.test.ts` — asserts the future-timestamp wording and that ordinary past timestamps still render their elapsed string.
- `pnpm check && pnpm test` green.

Stacked PR: this branch is based on the prior task's branch, not main. The operator merges the stack bottom-up and retargets each PR to main before merge.