### PR TITLE
feat(core): wire the live activity dispatcher into the reference fetch path

### DIFF
--- a/packages/core/src/reference/runtime.ts
+++ b/packages/core/src/reference/runtime.ts
@@ -71,6 +71,8 @@ export async function bootstrapReference(
     makeProductionFetcher({
       apiKey: deps.intervals.apiKey,
       athleteId: deps.intervals.athleteId,
+      adapters,
+      sportTypes: deps.sport.intervalsActivityTypes,
     });
 
   const mutex = new AsyncMutex();

--- a/packages/core/src/reference/sync/fetch-reference-data.ts
+++ b/packages/core/src/reference/sync/fetch-reference-data.ts
@@ -5,13 +5,20 @@ import { PER_REQUEST_TIMEOUT_MS } from "../freshness.js";
 import { fetchLiveBundle } from "./fetch-live-bundle.js";
 import { buildMetricInput } from "./fixture-bridge.js";
 import { computeDerivedMetrics } from "./compute-derived-metrics.js";
+import {
+  runAdaptersForActivities,
+  type AdapterRun,
+} from "../sport-adapter-dispatcher.js";
+import type { ReferenceSportAdapter } from "../sport-adapter.js";
+import type { IntervalsActivityType } from "../../sport.js";
 
 /**
  * Production fetcher. Pulls the live intervals.icu bundle (athlete profile,
  * trailing activities/wellness, bounded HRV/power streams), bridges it to the
- * metric-compute input shape, and runs the metric registry so `latest.json`
- * carries real `recent_activities` + computed `derived_metrics`. Constructs a
- * per-runSync `IntervalsClient` (per ADR-0011) so the orchestrator's outer
+ * metric-compute input shape, fans the live activities out to their covering
+ * sport adapters, and runs the metric registry so `latest.json` carries real
+ * `recent_activities` + computed `derived_metrics`. Constructs a per-runSync
+ * `IntervalsClient` (per ADR-0011) so the orchestrator's outer
  * `AbortController` propagates into in-flight requests; the stream loop is
  * additionally abort-aware so a slow account cannot exhaust the sync budget.
  *
@@ -25,6 +32,8 @@ import { computeDerivedMetrics } from "./compute-derived-metrics.js";
 export function makeProductionFetcher(deps: {
   apiKey: string;
   athleteId?: string;
+  adapters: readonly ReferenceSportAdapter[];
+  sportTypes: readonly IntervalsActivityType[];
 }): (signal: AbortSignal) => Promise<FetchedReference> {
   return async (signal) => {
     const client = makeAbortableClient({
@@ -33,15 +42,23 @@ export function makeProductionFetcher(deps: {
       signal,
       perRequestMs: PER_REQUEST_TIMEOUT_MS,
     });
-    return await fetchOnce(client, signal);
+    return await fetchOnce(client, signal, deps.adapters, deps.sportTypes);
   };
 }
 
 async function fetchOnce(
   client: IntervalsClient,
   signal: AbortSignal,
+  adapters: readonly ReferenceSportAdapter[],
+  sportTypes: readonly IntervalsActivityType[],
 ): Promise<FetchedReference> {
   const live = await fetchLiveBundle({ client, signal, now: new Date() });
+  const runs: readonly AdapterRun[] = runAdaptersForActivities(
+    adapters,
+    sportTypes,
+    live.bundle.activities,
+  );
+  void runs;
   const derivedMetrics = computeDerivedMetrics(
     buildMetricInput(live.bundle, live.frozenNow),
   );

--- a/packages/core/tests/reference-live-sync-integration.test.ts
+++ b/packages/core/tests/reference-live-sync-integration.test.ts
@@ -9,12 +9,25 @@ import { describe, expect, it } from "vitest";
 import { fetchLiveBundle, type BundleFetchClient } from "../src/reference/sync/fetch-live-bundle.js";
 import { buildMetricInput } from "../src/reference/sync/fixture-bridge.js";
 import { computeDerivedMetrics } from "../src/reference/sync/compute-derived-metrics.js";
+import { runAdaptersForActivities } from "../src/reference/sport-adapter-dispatcher.js";
+import type { ReferenceSportAdapter } from "../src/reference/sport-adapter.js";
+import type { IntervalsActivityType } from "../src/sport.js";
 import type { FetchedReference } from "../src/reference/sync/run-sync.js";
 import { gateLatestJson } from "../src/reference/validation/sync-gate.js";
 import { LatestJsonSchema } from "../src/reference/schemas/latest.js";
 import { METRIC_REGISTRY } from "../src/reference/metrics/registry.js";
 
 const NOW = new Date("2026-06-09T12:00:00.000Z");
+
+const CYCLING_ADAPTER: ReferenceSportAdapter = {
+  activityTypes: ["Ride", "VirtualRide"],
+  zoneBasis: "power",
+  decouplingBasis: "power",
+  sustainabilityAnchors: [300, 1200, 3600],
+  dfaValidated: true,
+};
+
+const SPORT_TYPES: readonly IntervalsActivityType[] = ["Ride", "VirtualRide"];
 
 function daysAgo(n: number): string {
   return new Date(NOW.getTime() - n * 24 * 60 * 60 * 1000).toISOString();
@@ -59,6 +72,7 @@ function fakeClient(): BundleFetchClient {
 /** Compose exactly as the production `fetchOnce` does. */
 async function composeFetched(): Promise<FetchedReference> {
   const live = await fetchLiveBundle({ client: fakeClient(), signal: new AbortController().signal, now: NOW, throttleMs: 0 });
+  runAdaptersForActivities([CYCLING_ADAPTER], SPORT_TYPES, live.bundle.activities);
   const derived_metrics = computeDerivedMetrics(buildMetricInput(live.bundle, live.frozenNow));
   return {
     latest: {
@@ -107,6 +121,7 @@ describe("live-data bridge integration", () => {
       wellness: { list: async () => ({ ok: true, value: [] }) },
     };
     const live = await fetchLiveBundle({ client: emptyClient, signal: new AbortController().signal, now: NOW, throttleMs: 0 });
+    runAdaptersForActivities([CYCLING_ADAPTER], SPORT_TYPES, live.bundle.activities);
     const derived_metrics = computeDerivedMetrics(buildMetricInput(live.bundle, live.frozenNow));
     const fetched: FetchedReference = {
       latest: {


### PR DESCRIPTION
## Summary

Wires the Reference layer's live activity→adapter dispatcher (`runAdaptersForActivities`) into the production fetch path as its first real caller. This is **producer-side, additive plumbing**: the dispatch result is computed but not yet consumed (`void runs;`), so output is **byte-identical** for cycling-only, mixed, and empty bundles. It establishes the seam the next change consumes to fence per-sport metric output.

First of the producer-side series that lets the Reference layer analyze completed runs.

## Changes

- `fetch-reference-data.ts` — widen `makeProductionFetcher` deps to carry `{ adapters, sportTypes }`; widen `fetchOnce`; call `runAdaptersForActivities` once on the live activities (result intentionally unused this change). `computeDerivedMetrics` call left untouched.
- `runtime.ts` — pass the already-resolved adapters + `sport.intervalsActivityTypes` into the production fetcher; injected-fetcher branch unchanged.
- `reference-live-sync-integration.test.ts` — mirror the new `fetchOnce` in `composeFetched` + the empty-bundle analog so the test helper stays faithful; full-key-set assertions unchanged and green.

## Test plan

- `pnpm -r build` ✅
- `pnpm check:types` ✅ (independently re-run post-rebase scope)
- scoped vitest (live-sync integration, dispatcher, run-sync, compute-derived-metrics, runtime) ✅
- `pnpm check` umbrella (types / oxlint / trademarks / fixture-privacy / registry-isolation) ✅
- Parity unaffected by design (no metric compute touched; `computeDerivedMetrics` byte-identical) — CI runs the full sweep against the rebased base.

No user-facing changeset: this change is internal and produces no observable output change; the user-facing entry ships with the athlete-facing reveal.
