### PR TITLE
feat(core): fence the power-metric family out of pure-pace syncs

### DIFF
--- a/packages/core/src/reference/schemas/latest.ts
+++ b/packages/core/src/reference/schemas/latest.ts
@@ -16,6 +16,14 @@ export const LatestJsonSchema = z
     athlete_profile: z.unknown(),
     current_status: z.unknown(),
     derived_metrics: z.unknown(),
+    derived_metrics_meta: z
+      .object({
+        sportFamily: z.string(),
+        basis: z.enum(["power", "pace", "hr"]),
+        anchorType: z.enum(["critical-speed", "ftp"]),
+      })
+      .strict()
+      .optional(),
     recent_activities: z.array(z.unknown()),
     planned_workouts: z.array(z.unknown()),
     wellness_data: z.unknown(),

--- a/packages/core/src/reference/sport-adapter.ts
+++ b/packages/core/src/reference/sport-adapter.ts
@@ -39,6 +39,15 @@ export interface ReferenceSportAdapter {
   readonly dfaValidated: boolean;
 
   /**
+   * The training-intensity anchor the sport's zones derive from:
+   * `"critical-speed"` for pace sports, `"ftp"` for power sports. Net-new
+   * declarative metadata — it is NOT derivable from `zoneBasis` (a future pace
+   * sport could anchor on something other than critical speed), so it is stated
+   * explicitly rather than inferred.
+   */
+  readonly anchorType: "critical-speed" | "ftp";
+
+  /**
    * Optional. When absent OR when `dfaValidated === false`, Reference's
    * curator records `{ sufficient: false }` and skips the metric.
    */

--- a/packages/core/src/reference/sync/compute-derived-metrics.ts
+++ b/packages/core/src/reference/sync/compute-derived-metrics.ts
@@ -15,12 +15,43 @@ import type { MetricInput } from "../metrics/metric-input.js";
 /** Shared between the runner + its test so the warn string stays in sync. */
 export const METRIC_COMPUTE_FAILED_LOG_PREFIX = "Reference: metric compute failed";
 
+/**
+ * Registry keys omitted from a pure-pace sync when `omitPowerFamily` is set —
+ * the watts-fence. Matched by EXACT STRING, never by prefix: the set mixes bare
+ * keys (`eftp`) with dotted ones (`capability.power_curve_delta`), and prefix
+ * matching would wrongly catch `capability.sustainability_profile` /
+ * `capability.efficiency_factor`, which MUST ride through (they are
+ * multi-family / tag-fenced, not omitted).
+ *
+ * `vo2max` is an intentional conservative over-omission — it reads a
+ * sport-ambiguous wellness scalar, not a watt — so a cycling-derived value is
+ * not leaked into a runner's map; a future running VO2max path will need it
+ * removed from this set.
+ *
+ * Hand-maintained: a future power-derived registry metric must be added here or
+ * it leaks a watt into a pure-pace map. There is no key-shape shortcut.
+ */
+export const POWER_FAMILY_OMIT_KEYS: ReadonlySet<string> = new Set([
+  "eftp",
+  "w_prime",
+  "w_prime_kj",
+  "p_max",
+  "power_model_source",
+  "vo2max",
+  "capability.power_curve_delta",
+  "capability.hr_curve_delta",
+  "capability.dfa_a1_profile",
+]);
+
 export interface ComputeDerivedMetricsOptions {
   /** Sink for per-metric failures; defaults to console.warn. */
   readonly log?: (msg: string) => void;
   /** Registry override — defaults to the canonical `METRIC_REGISTRY`. Exposed
    *  for tests of the per-metric isolation path. */
   readonly registry?: Record<string, MetricRegistryEntry>;
+  /** When `true`, skip the {@link POWER_FAMILY_OMIT_KEYS} — the pure-pace
+   *  watts-fence. Defaults to `false`, leaving output byte-identical. */
+  readonly omitPowerFamily?: boolean;
 }
 
 export function computeDerivedMetrics(
@@ -31,6 +62,7 @@ export function computeDerivedMetrics(
   const registry = opts.registry ?? METRIC_REGISTRY;
   const out: Record<string, unknown> = {};
   for (const [key, entry] of Object.entries(registry)) {
+    if (opts.omitPowerFamily === true && POWER_FAMILY_OMIT_KEYS.has(key)) continue;
     try {
       out[key] = entry.compute(input);
     } catch (err) {

--- a/packages/core/src/reference/sync/fetch-reference-data.ts
+++ b/packages/core/src/reference/sync/fetch-reference-data.ts
@@ -11,6 +11,32 @@ import {
 } from "../sport-adapter-dispatcher.js";
 import type { ReferenceSportAdapter } from "../sport-adapter.js";
 import type { IntervalsActivityType } from "../../sport.js";
+import { SPORT_FAMILIES } from "../metrics/sport-families.js";
+
+interface DerivedMetricsMeta {
+  readonly sportFamily: string;
+  readonly basis: "power" | "pace" | "hr";
+  readonly anchorType: "critical-speed" | "ftp";
+}
+
+/**
+ * Derive the emit-time provenance tag from the covering adapters. Prefers a
+ * power-basis adapter when one is present so a mixed bundle (a duathlete's
+ * Ride+Run) tags as its kept power family, matching the omission decision;
+ * otherwise the first covering adapter wins. Returns `undefined` for an
+ * empty-coverage bundle (no adapter to attribute), leaving the optional tag off.
+ */
+function deriveMeta(runs: readonly AdapterRun[]): DerivedMetricsMeta | undefined {
+  if (runs.length === 0) return undefined;
+  const covering =
+    runs.find((r) => r.adapter.zoneBasis === "power")?.adapter ?? runs[0].adapter;
+  const firstType = covering.activityTypes[0];
+  const sportFamily =
+    firstType !== undefined && Object.hasOwn(SPORT_FAMILIES, firstType)
+      ? SPORT_FAMILIES[firstType]
+      : "other";
+  return { sportFamily, basis: covering.zoneBasis, anchorType: covering.anchorType };
+}
 
 /**
  * Production fetcher. Pulls the live intervals.icu bundle (athlete profile,
@@ -58,16 +84,25 @@ async function fetchOnce(
     sportTypes,
     live.bundle.activities,
   );
-  void runs;
+  // Omit the power family only on a positive pace-sport assertion: at least one
+  // activity is covered AND no covering adapter is power-basis. An
+  // empty-coverage bundle keeps the full family (no positive signal).
+  const coveredPowerBasis = runs.some((r) => r.adapter.zoneBasis === "power");
+  const omitPowerFamily = runs.length > 0 && !coveredPowerBasis;
   const derivedMetrics = computeDerivedMetrics(
     buildMetricInput(live.bundle, live.frozenNow),
+    { omitPowerFamily },
   );
+  const meta = deriveMeta(runs);
 
   return {
     latest: {
       athlete_profile: live.athleteProfile,
       current_status: {},
       derived_metrics: derivedMetrics,
+      // Sibling of `derived_metrics`, NEVER a key inside it — the parity gate's
+      // key-union deepCompare runs over the map only, so the tag must stay out.
+      ...(meta ? { derived_metrics_meta: meta } : {}),
       recent_activities: live.recentActivities,
       planned_workouts: [],
       wellness_data: live.wellnessData,

--- a/packages/core/src/reference/sync/run-sync.ts
+++ b/packages/core/src/reference/sync/run-sync.ts
@@ -75,6 +75,13 @@ export interface FetchedReference {
     readonly athlete_profile: unknown;
     readonly current_status: unknown;
     readonly derived_metrics: unknown;
+    /** Emit-time provenance tag — a sibling of `derived_metrics`, never inside
+     *  it. Optional: an empty-coverage bundle attaches no tag. */
+    readonly derived_metrics_meta?: {
+      readonly sportFamily: string;
+      readonly basis: "power" | "pace" | "hr";
+      readonly anchorType: "critical-speed" | "ftp";
+    };
     readonly recent_activities: readonly unknown[];
     readonly planned_workouts: readonly unknown[];
     readonly wellness_data: unknown;

--- a/packages/core/tests/reference-compute-derived-metrics.test.ts
+++ b/packages/core/tests/reference-compute-derived-metrics.test.ts
@@ -5,15 +5,23 @@
 // single throwing metric is isolated to `null` + a warning, never sinking the
 // rest.
 
+import type { Activity } from "intervals-icu-api";
 import { describe, expect, it, vi } from "vitest";
 
 import {
   computeDerivedMetrics,
   METRIC_COMPUTE_FAILED_LOG_PREFIX,
+  POWER_FAMILY_OMIT_KEYS,
 } from "../src/reference/sync/compute-derived-metrics.js";
 import { METRIC_REGISTRY } from "../src/reference/metrics/registry.js";
 import type { MetricInput } from "../src/reference/metrics/metric-input.js";
-import { buildFixtureShape } from "../src/reference/sync/fixture-bridge.js";
+import {
+  buildFixtureShape,
+  type ReferenceBundle,
+} from "../src/reference/sync/fixture-bridge.js";
+import { runAdaptersForActivities } from "../src/reference/sport-adapter-dispatcher.js";
+import type { ReferenceSportAdapter } from "../src/reference/sport-adapter.js";
+import type { IntervalsActivityType } from "../src/sport.js";
 import { GoldenFixtureSchema, loadFixture } from "./helpers/load-fixture.js";
 
 function dfaEquippedInput(): MetricInput {
@@ -93,5 +101,225 @@ describe("computeDerivedMetrics", () => {
     expect(log.mock.calls[0]?.[0]).toContain(METRIC_COMPUTE_FAILED_LOG_PREFIX);
     expect(log.mock.calls[0]?.[0]).toContain("bad");
     expect(log.mock.calls[0]?.[0]).toContain("boom");
+  });
+});
+
+// ─── Power-family watts-fence (pure-pace omission) ──────────────────────────
+
+const RUNNING_ADAPTER: ReferenceSportAdapter = {
+  activityTypes: ["Run", "TrailRun"],
+  zoneBasis: "pace",
+  decouplingBasis: "pace",
+  sustainabilityAnchors: [],
+  dfaValidated: false,
+  anchorType: "critical-speed",
+};
+
+const CYCLING_ADAPTER: ReferenceSportAdapter = {
+  activityTypes: ["Ride", "VirtualRide"],
+  zoneBasis: "power",
+  decouplingBasis: "power",
+  sustainabilityAnchors: [300, 1200, 3600],
+  dfaValidated: true,
+  anchorType: "ftp",
+};
+
+const EXCLUDE_FROM_OMISSION = [
+  "capability.sustainability_profile",
+  "capability.efficiency_factor",
+] as const;
+
+// A renamed row carrying the required numeric fields the bridge schema demands
+// plus an index signature so it also satisfies the dispatcher's `Activity`.
+type TestActivity = ReferenceBundle["activities"][number];
+
+function activity(id: number, type: string, daysAgo: number): TestActivity {
+  // Anchor relative to the shared frozenNow so the load windows see the rows.
+  const day = String(4 - daysAgo).padStart(2, "0");
+  return {
+    id,
+    start_date_local: `2026-06-${day}T07:00:00`,
+    type,
+    moving_time: 3600,
+    elapsed_time: 3700,
+    icu_training_load: 60,
+  };
+}
+
+function inputFor(activities: readonly TestActivity[]): MetricInput {
+  const bundle: ReferenceBundle = {
+    activities,
+    wellness: [],
+    ftpHistory: [],
+  };
+  return { fixture: buildFixtureShape(bundle), frozenNow: "2026-06-04T12:00:00" };
+}
+
+/**
+ * Mirror the production `fetchOnce` predicate + emit-time tag without exporting
+ * the private function: dispatch the activities, derive `omitPowerFamily`, run
+ * the registry, and attach the sibling provenance tag exactly as the producer
+ * does. The tag is layered OUTSIDE the derived map.
+ */
+function composeLikeFetchOnce(
+  adapters: readonly ReferenceSportAdapter[],
+  sportTypes: readonly IntervalsActivityType[],
+  activities: readonly TestActivity[],
+): {
+  derived_metrics: Record<string, unknown>;
+  derived_metrics_meta?: { sportFamily: string; basis: string; anchorType: string };
+  omitPowerFamily: boolean;
+} {
+  const runs = runAdaptersForActivities(adapters, sportTypes, activities as unknown as readonly Activity[]);
+  const coveredPowerBasis = runs.some((r) => r.adapter.zoneBasis === "power");
+  const omitPowerFamily = runs.length > 0 && !coveredPowerBasis;
+  const derived_metrics = computeDerivedMetrics(inputFor(activities), { omitPowerFamily });
+  let derived_metrics_meta: { sportFamily: string; basis: string; anchorType: string } | undefined;
+  if (runs.length > 0) {
+    const covering =
+      runs.find((r) => r.adapter.zoneBasis === "power")?.adapter ?? runs[0].adapter;
+    const families: Record<string, string> = { Ride: "cycling", VirtualRide: "cycling", Run: "run", TrailRun: "run" };
+    derived_metrics_meta = {
+      sportFamily: families[covering.activityTypes[0]] ?? "other",
+      basis: covering.zoneBasis,
+      anchorType: covering.anchorType,
+    };
+  }
+  return { derived_metrics, derived_metrics_meta, omitPowerFamily };
+}
+
+describe("computeDerivedMetrics power-family omission", () => {
+  it("omits exactly the 9 power-family keys when omitPowerFamily is true", () => {
+    const out = computeDerivedMetrics(inputFor([activity(1, "Run", 1)]), { omitPowerFamily: true });
+    for (const key of POWER_FAMILY_OMIT_KEYS) {
+      expect(out).not.toHaveProperty(key);
+    }
+    const expected = Object.keys(METRIC_REGISTRY).filter((k) => !POWER_FAMILY_OMIT_KEYS.has(k));
+    expect(Object.keys(out).sort()).toEqual(expected.sort());
+  });
+
+  it("keeps the EXCLUDE-SET (sustainability_profile + efficiency_factor) even when omitting", () => {
+    const out = computeDerivedMetrics(inputFor([activity(1, "Run", 1)]), { omitPowerFamily: true });
+    for (const key of EXCLUDE_FROM_OMISSION) {
+      expect(out).toHaveProperty(key);
+    }
+  });
+
+  it("DEFAULT (omitPowerFamily unset/false) returns the full registry key-set, byte-identical", () => {
+    const noOpts = computeDerivedMetrics(inputFor([activity(1, "Run", 1)]));
+    const explicitFalse = computeDerivedMetrics(inputFor([activity(1, "Run", 1)]), { omitPowerFamily: false });
+    expect(Object.keys(noOpts).sort()).toEqual(Object.keys(METRIC_REGISTRY).sort());
+    expect(Object.keys(explicitFalse).sort()).toEqual(Object.keys(METRIC_REGISTRY).sort());
+    expect(explicitFalse).toEqual(noOpts);
+  });
+
+  it("POWER_FAMILY_OMIT_KEYS has exactly 9 members, excludes the EXCLUDE-SET, and is a registry subset", () => {
+    expect(POWER_FAMILY_OMIT_KEYS.size).toBe(9);
+    for (const key of EXCLUDE_FROM_OMISSION) {
+      expect(POWER_FAMILY_OMIT_KEYS.has(key)).toBe(false);
+    }
+    for (const key of POWER_FAMILY_OMIT_KEYS) {
+      expect(Object.hasOwn(METRIC_REGISTRY, key)).toBe(true);
+    }
+  });
+});
+
+describe("fetchOnce-shaped power-family fence + provenance tag", () => {
+  const RUN_TYPES: readonly IntervalsActivityType[] = ["Run", "TrailRun"];
+  const RIDE_TYPES: readonly IntervalsActivityType[] = ["Ride", "VirtualRide"];
+  const DUATHLON_TYPES: readonly IntervalsActivityType[] = ["Ride", "VirtualRide", "Run", "TrailRun"];
+
+  it("pure-Run bundle: omits power keys from derived_metrics and tags run/pace/critical-speed", () => {
+    const { derived_metrics, derived_metrics_meta, omitPowerFamily } = composeLikeFetchOnce(
+      [RUNNING_ADAPTER],
+      RUN_TYPES,
+      [activity(1, "Run", 1), activity(2, "TrailRun", 2)],
+    );
+    expect(omitPowerFamily).toBe(true);
+    for (const key of POWER_FAMILY_OMIT_KEYS) {
+      expect(derived_metrics).not.toHaveProperty(key);
+    }
+    // The tag is a SIBLING — no provenance key leaked into the map.
+    expect(derived_metrics).not.toHaveProperty("sportFamily");
+    expect(derived_metrics).not.toHaveProperty("basis");
+    expect(derived_metrics).not.toHaveProperty("anchorType");
+    expect(derived_metrics_meta).toEqual({ sportFamily: "run", basis: "pace", anchorType: "critical-speed" });
+  });
+
+  it("cycling-only bundle: keeps the full power family and tags cycling/power/ftp", () => {
+    const { derived_metrics, derived_metrics_meta, omitPowerFamily } = composeLikeFetchOnce(
+      [CYCLING_ADAPTER],
+      RIDE_TYPES,
+      [activity(1, "Ride", 1)],
+    );
+    expect(omitPowerFamily).toBe(false);
+    expect(Object.keys(derived_metrics).sort()).toEqual(Object.keys(METRIC_REGISTRY).sort());
+    expect(derived_metrics_meta).toEqual({ sportFamily: "cycling", basis: "power", anchorType: "ftp" });
+  });
+
+  it("mixed Ride+Run bundle: keeps the full power family (duathlete keeps cycling power) and tags", () => {
+    const { derived_metrics, derived_metrics_meta, omitPowerFamily } = composeLikeFetchOnce(
+      [CYCLING_ADAPTER, RUNNING_ADAPTER],
+      DUATHLON_TYPES,
+      [activity(1, "Ride", 1), activity(2, "Run", 2)],
+    );
+    expect(omitPowerFamily).toBe(false);
+    expect(Object.keys(derived_metrics).sort()).toEqual(Object.keys(METRIC_REGISTRY).sort());
+    for (const key of POWER_FAMILY_OMIT_KEYS) {
+      expect(derived_metrics).toHaveProperty(key);
+    }
+    expect(derived_metrics_meta?.basis).toBe("power");
+    expect(derived_metrics_meta?.anchorType).toBe("ftp");
+  });
+
+  it("empty-coverage bundle: omitPowerFamily false, full family, no tag", () => {
+    const { derived_metrics, derived_metrics_meta, omitPowerFamily } = composeLikeFetchOnce(
+      [RUNNING_ADAPTER],
+      RUN_TYPES,
+      [],
+    );
+    expect(omitPowerFamily).toBe(false);
+    expect(Object.keys(derived_metrics).sort()).toEqual(Object.keys(METRIC_REGISTRY).sort());
+    expect(derived_metrics_meta).toBeUndefined();
+  });
+
+  it("out-of-sport-only bundle (no covering adapter): omitPowerFamily false, full family", () => {
+    const { derived_metrics, omitPowerFamily } = composeLikeFetchOnce(
+      [RUNNING_ADAPTER],
+      RUN_TYPES,
+      [activity(1, "Ride", 1)], // Ride is not covered by the running-only adapter set
+    );
+    expect(omitPowerFamily).toBe(false);
+    expect(Object.keys(derived_metrics).sort()).toEqual(Object.keys(METRIC_REGISTRY).sort());
+  });
+});
+
+describe("cycling-shaped survivors on a pure-Run bundle (intentional, wave-3 reader handles)", () => {
+  it("consistency_index reads completed=0 / matched=0 via the CYCLING_TYPES gate", () => {
+    const out = computeDerivedMetrics(inputFor([activity(1, "Run", 1), activity(2, "Run", 2)]), {
+      omitPowerFamily: true,
+    });
+    const details = out["consistency_details"] as {
+      completed_days?: number;
+      matched_days?: number;
+    } | null;
+    expect(details).not.toBeNull();
+    expect(details?.completed_days).toBe(0);
+    expect(details?.matched_days).toBe(0);
+  });
+
+  it("capability.durability survives with null means + the 'power sessions only' note", () => {
+    const out = computeDerivedMetrics(inputFor([activity(1, "Run", 1), activity(2, "Run", 2)]), {
+      omitPowerFamily: true,
+    });
+    const durability = out["capability.durability"] as {
+      mean_decoupling_7d: number | null;
+      mean_decoupling_28d: number | null;
+      note: string;
+    } | null;
+    expect(durability).not.toBeNull();
+    expect(durability?.mean_decoupling_7d).toBeNull();
+    expect(durability?.mean_decoupling_28d).toBeNull();
+    expect(durability?.note).toContain("power sessions only");
   });
 });

--- a/packages/core/tests/reference-live-sync-integration.test.ts
+++ b/packages/core/tests/reference-live-sync-integration.test.ts
@@ -25,6 +25,7 @@ const CYCLING_ADAPTER: ReferenceSportAdapter = {
   decouplingBasis: "power",
   sustainabilityAnchors: [300, 1200, 3600],
   dfaValidated: true,
+  anchorType: "ftp",
 };
 
 const SPORT_TYPES: readonly IntervalsActivityType[] = ["Ride", "VirtualRide"];

--- a/packages/core/tests/reference-live-sync-integration.test.ts
+++ b/packages/core/tests/reference-live-sync-integration.test.ts
@@ -4,6 +4,10 @@
 // shape `runSync` commits to `latest.json`. This is the "real adapter output on
 // disk stays valid" guarantee behind AC3.
 
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
 import { describe, expect, it } from "vitest";
 
 import { fetchLiveBundle, type BundleFetchClient } from "../src/reference/sync/fetch-live-bundle.js";
@@ -14,8 +18,10 @@ import type { ReferenceSportAdapter } from "../src/reference/sport-adapter.js";
 import type { IntervalsActivityType } from "../src/sport.js";
 import type { FetchedReference } from "../src/reference/sync/run-sync.js";
 import { gateLatestJson } from "../src/reference/validation/sync-gate.js";
-import { LatestJsonSchema } from "../src/reference/schemas/latest.js";
+import { LatestJsonSchema, type LatestJson } from "../src/reference/schemas/latest.js";
 import { METRIC_REGISTRY } from "../src/reference/metrics/registry.js";
+import { SPORT_FAMILIES } from "../src/reference/metrics/sport-families.js";
+import { safeReadJson } from "../src/io/safe-read-json.js";
 
 const NOW = new Date("2026-06-09T12:00:00.000Z");
 
@@ -70,16 +76,22 @@ function fakeClient(): BundleFetchClient {
   };
 }
 
+type DerivedMetricsMeta = NonNullable<LatestJson["derived_metrics_meta"]>;
+
 /** Compose exactly as the production `fetchOnce` does. */
 async function composeFetched(): Promise<FetchedReference> {
   const live = await fetchLiveBundle({ client: fakeClient(), signal: new AbortController().signal, now: NOW, throttleMs: 0 });
-  runAdaptersForActivities([CYCLING_ADAPTER], SPORT_TYPES, live.bundle.activities);
-  const derived_metrics = computeDerivedMetrics(buildMetricInput(live.bundle, live.frozenNow));
+  const runs = runAdaptersForActivities([CYCLING_ADAPTER], SPORT_TYPES, live.bundle.activities);
+  const coveredPowerBasis = runs.some((r) => r.adapter.zoneBasis === "power");
+  const omitPowerFamily = runs.length > 0 && !coveredPowerBasis;
+  const derived_metrics = computeDerivedMetrics(buildMetricInput(live.bundle, live.frozenNow), { omitPowerFamily });
+  const meta = deriveMeta(runs);
   return {
     latest: {
       athlete_profile: live.athleteProfile,
       current_status: {},
       derived_metrics,
+      ...(meta ? { derived_metrics_meta: meta } : {}),
       recent_activities: live.recentActivities,
       planned_workouts: [],
       wellness_data: live.wellnessData,
@@ -89,6 +101,24 @@ async function composeFetched(): Promise<FetchedReference> {
     routes: { routes: [] },
     ftp_history: { entries: [] },
   };
+}
+
+/**
+ * Local reconstruction of `fetchOnce`'s private `deriveMeta`: pick the covering
+ * adapter (power-basis preferred), then attribute its sport family + basis +
+ * anchor. Returns undefined for empty coverage so the optional tag stays off.
+ */
+function deriveMeta(
+  runs: ReturnType<typeof runAdaptersForActivities>,
+): DerivedMetricsMeta | undefined {
+  if (runs.length === 0) return undefined;
+  const covering = runs.find((r) => r.adapter.zoneBasis === "power")?.adapter ?? runs[0].adapter;
+  const firstType = covering.activityTypes[0];
+  const sportFamily =
+    firstType !== undefined && Object.hasOwn(SPORT_FAMILIES, firstType)
+      ? SPORT_FAMILIES[firstType]
+      : "other";
+  return { sportFamily, basis: covering.zoneBasis, anchorType: covering.anchorType };
 }
 
 describe("live-data bridge integration", () => {
@@ -106,6 +136,24 @@ describe("live-data bridge integration", () => {
       ...fetched.latest,
     };
     expect(() => LatestJsonSchema.parse(onDisk)).not.toThrow();
+  });
+
+  it("round-trips the derived_metrics_meta tag through the real strict read path (no cache-miss loop)", async () => {
+    const fetched = await composeFetched();
+    const tag = { sportFamily: "cycling", basis: "power", anchorType: "ftp" };
+    expect(fetched.latest.derived_metrics_meta).toEqual(tag);
+
+    const onDisk = {
+      metadata: { schema_version: "1", last_updated: NOW.toISOString(), freshness: "fresh" as const },
+      ...fetched.latest,
+    };
+    const dir = mkdtempSync(join(tmpdir(), "reference-latest-"));
+    const path = join(dir, "latest.json");
+    writeFileSync(path, JSON.stringify(onDisk), "utf-8");
+
+    const readBack = safeReadJson<LatestJson>(path, LatestJsonSchema);
+    expect(readBack).not.toBeNull();
+    expect(readBack?.derived_metrics_meta).toEqual(tag);
   });
 
   it("writes a populated, full-registry derived_metrics block", async () => {

--- a/packages/core/tests/reference-runtime.test.ts
+++ b/packages/core/tests/reference-runtime.test.ts
@@ -250,6 +250,7 @@ describe("bootstrapReference (fail-fast on misconfigured adapters)", () => {
     decouplingBasis: "power",
     sustainabilityAnchors: [],
     dfaValidated: true,
+    anchorType: "ftp",
   });
 
   it("rejects with ReferenceConfigError when two adapters overlap, before any IO", async () => {

--- a/packages/core/tests/reference-sport-adapter-dispatcher.test.ts
+++ b/packages/core/tests/reference-sport-adapter-dispatcher.test.ts
@@ -13,6 +13,7 @@ const cyclingAdapter: ReferenceSportAdapter = {
   decouplingBasis: "power",
   sustainabilityAnchors: [300, 1200, 3600],
   dfaValidated: true,
+  anchorType: "ftp",
 };
 
 const runningAdapter: ReferenceSportAdapter = {
@@ -21,6 +22,7 @@ const runningAdapter: ReferenceSportAdapter = {
   decouplingBasis: "pace",
   sustainabilityAnchors: [60, 300],
   dfaValidated: false,
+  anchorType: "critical-speed",
 };
 
 function activity(type: string): Activity {

--- a/packages/core/tests/reference-sport-adapter-invariants.test.ts
+++ b/packages/core/tests/reference-sport-adapter-invariants.test.ts
@@ -14,6 +14,7 @@ const cyclingAdapter: ReferenceSportAdapter = {
   decouplingBasis: "power",
   sustainabilityAnchors: [300, 1200, 3600],
   dfaValidated: true,
+  anchorType: "ftp",
 };
 
 const runningAdapter: ReferenceSportAdapter = {
@@ -22,6 +23,7 @@ const runningAdapter: ReferenceSportAdapter = {
   decouplingBasis: "pace",
   sustainabilityAnchors: [60, 300],
   dfaValidated: false,
+  anchorType: "critical-speed",
 };
 
 describe("ReferenceConfigError", () => {
@@ -50,6 +52,7 @@ describe("assertDisjointCoverage", () => {
       decouplingBasis: "power",
       sustainabilityAnchors: [300],
       dfaValidated: true,
+      anchorType: "ftp",
     };
     const overlapB: ReferenceSportAdapter = {
       activityTypes: ["Ride", "VirtualRide"],
@@ -57,6 +60,7 @@ describe("assertDisjointCoverage", () => {
       decouplingBasis: "power",
       sustainabilityAnchors: [600],
       dfaValidated: true,
+      anchorType: "ftp",
     };
     let caught: unknown;
     try {
@@ -90,6 +94,7 @@ describe("assertSubsetCoverage", () => {
       decouplingBasis: "power",
       sustainabilityAnchors: [300],
       dfaValidated: true,
+      anchorType: "ftp",
     };
     let caught: unknown;
     try {

--- a/packages/core/tests/reference-sport-adapter.test.ts
+++ b/packages/core/tests/reference-sport-adapter.test.ts
@@ -34,6 +34,7 @@ describe("ReferenceSportAdapter type surface", () => {
       decouplingBasis: "power",
       sustainabilityAnchors: [60, 90, 120, 180, 240],
       dfaValidated: true,
+      anchorType: "ftp",
     };
     expect(declarativeOnly.activityTypes.length).toBeGreaterThan(0);
     expect(declarativeOnly.zoneBasis).toBe("power");
@@ -49,6 +50,7 @@ describe("ReferenceSportAdapter type surface", () => {
       decouplingBasis: "power",
       sustainabilityAnchors: [60],
       dfaValidated: true,
+      anchorType: "ftp",
       computeDfa: () => fakeDfa,
       computePowerCurve: () => fakeCurveDelta,
     };
@@ -85,6 +87,7 @@ describe("Sport.referenceAdapters?() integration", () => {
       decouplingBasis: "power",
       sustainabilityAnchors: [60],
       dfaValidated: true,
+      anchorType: "ftp",
     };
     const sliceWithMethod: Pick<Sport, "id" | "referenceAdapters"> = {
       id: "cycling",
@@ -102,6 +105,7 @@ describe("Sport.referenceAdapters?() integration", () => {
       decouplingBasis: "power",
       sustainabilityAnchors: [60, 120],
       dfaValidated: true,
+      anchorType: "ftp",
     };
     const runningAdapter: ReferenceSportAdapter = {
       activityTypes: ["Run", "TrailRun"] as const,
@@ -109,6 +113,7 @@ describe("Sport.referenceAdapters?() integration", () => {
       decouplingBasis: "pace",
       sustainabilityAnchors: [30, 60],
       dfaValidated: false,
+      anchorType: "critical-speed",
     };
 
     const cycling: Pick<Sport, "id" | "referenceAdapters"> = {

--- a/packages/core/tests/reference/fixtures/sport-shapes/overlap-adapter-shape.ts
+++ b/packages/core/tests/reference/fixtures/sport-shapes/overlap-adapter-shape.ts
@@ -17,6 +17,7 @@ export const overlapAdapterShape: Pick<
       decouplingBasis: "power",
       sustainabilityAnchors: [],
       dfaValidated: true,
+      anchorType: "ftp",
     },
     {
       activityTypes: ["Ride"],
@@ -24,6 +25,7 @@ export const overlapAdapterShape: Pick<
       decouplingBasis: "power",
       sustainabilityAnchors: [],
       dfaValidated: true,
+      anchorType: "ftp",
     },
   ],
 };

--- a/packages/core/tests/reference/fixtures/sport-shapes/two-adapter-duathlon-shape.ts
+++ b/packages/core/tests/reference/fixtures/sport-shapes/two-adapter-duathlon-shape.ts
@@ -11,6 +11,7 @@ const cyclingAdapter: ReferenceSportAdapter = {
   decouplingBasis: "power",
   sustainabilityAnchors: [300, 600, 1200, 1800, 3600, 5400, 7200],
   dfaValidated: true,
+  anchorType: "ftp",
 };
 
 const runningAdapter: ReferenceSportAdapter = {
@@ -19,6 +20,7 @@ const runningAdapter: ReferenceSportAdapter = {
   decouplingBasis: "pace",
   sustainabilityAnchors: [],
   dfaValidated: false,
+  anchorType: "critical-speed",
 };
 
 export const twoAdapterDuathlonShape: Pick<

--- a/packages/sport-cycling/src/reference/cycling-adapter.ts
+++ b/packages/sport-cycling/src/reference/cycling-adapter.ts
@@ -17,4 +17,5 @@ export const cyclingReferenceAdapter: ReferenceSportAdapter = {
   decouplingBasis: "power",
   sustainabilityAnchors: CYCLING_SUSTAINABILITY_ANCHORS,
   dfaValidated: true,
+  anchorType: "ftp",
 };

--- a/packages/sport-running/src/reference/running-adapter.ts
+++ b/packages/sport-running/src/reference/running-adapter.ts
@@ -10,4 +10,5 @@ export const runningReferenceAdapter: ReferenceSportAdapter = {
   decouplingBasis: "pace",
   sustainabilityAnchors: [],
   dfaValidated: false,
+  anchorType: "critical-speed",
 };


### PR DESCRIPTION
## What

Second wave-1 work item for the running analyze path: a **compute-time power-metric fence** so a pace-only (running) sync never surfaces cycling power numbers in an athlete's derived metrics.

- **`anchorType` on the sport adapter** — a new required declarative field (`"critical-speed" | "ftp"`), set on the two production adapters (cycling = `ftp`, running = `critical-speed`). Not derivable from `zoneBasis`, so it is declared explicitly.
- **Positive, basis-driven omission** — `computeDerivedMetrics` gains an `omitPowerFamily` option. When set, it skips exactly the 9-key power family (`POWER_FAMILY_OMIT_KEYS`, exact-string match — no prefix matching) and lets the two pace-relevant capability keys (`sustainability_profile`, `efficiency_factor`) ride through.
- **The fire condition is a positive pace-sport assertion** — omission fires only when at least one activity is covered *and* no covering adapter is power-basis. A mixed Ride+Run bundle (duathlete) keeps the full power family; an empty-coverage bundle keeps it too.
- **Provenance tag as a sibling** — the producer attaches `{ sportFamily, basis, anchorType }` as a top-level `derived_metrics_meta` sibling of `derived_metrics`, never a key *inside* it.

## Why a sibling tag (parity invariant)

The bit-identity parity gate deep-compares each metric's `compute` output against per-metric snapshots via a key-union walk — any new key *inside* `derived_metrics` reads as drift. Keeping the tag a sibling leaves the gate blind to it: `pnpm check-parity --all` stays **559/559** green, byte-identical, because default `computeDerivedMetrics` output is unchanged (the option defaults off) and the gate calls `entry.compute` directly.

## Read-path fix (second commit)

The producer writes `derived_metrics_meta` on every covered sync (cycling included), but the strict read validator (`LatestJsonSchema`) did not yet know the key — so on read it would reject the envelope, the caller would treat it as a cache miss, re-sync, and re-write the same rejected file: a permanent re-sync loop for every athlete. The fix teaches the read validator the **optional** sibling key (no schema-version bump, `derived_metrics` stays `z.unknown()` — the structured rewrite is a later item), and makes the integration round-trip test honest so it now exercises a *tagged* envelope through the real `safeReadJson` read path.

## Test plan

- `pnpm -r build` — clean across all packages
- `pnpm test` — full suite green (2572 passed / 5 skipped), incl. 11 new omission/tag tests + a tmp-file round-trip test through the strict read path
- `pnpm check-parity --all` — 559/559 OK, zero mismatches, zero snapshot drift
- `pnpm check` — types, lint, trademark, fixture-privacy, registry-isolation all clean

Stacked on #246 (base = `feature/reference-dispatcher-live-consumer`). Merge #246 first, then retarget this to `main`.
