### PR TITLE
feat(core): structure the latest derived_metrics schema and version-gate the read

### DIFF
--- a/packages/core/src/reference/io/read-latest-versioned.ts
+++ b/packages/core/src/reference/io/read-latest-versioned.ts
@@ -1,0 +1,29 @@
+import { safeReadJson } from "../../io/safe-read-json.js";
+import {
+  LATEST_SCHEMA_VERSION,
+  LatestJsonSchema,
+  type LatestJson,
+} from "../schemas/latest.js";
+
+/**
+ * Read the latest-cache envelope and version-gate it.
+ *
+ * Returns the parsed envelope only when its `metadata.schema_version` matches
+ * the current `LATEST_SCHEMA_VERSION`. A version mismatch returns null so the
+ * caller treats it as a cache miss and re-syncs — discard-and-resync, no
+ * migration map (mirrors the safe-read-json doctrine).
+ *
+ * The equality gate runs AFTER safeReadJson because safeReadJson types
+ * `schema_version` only as `z.string()`; a stale-but-shape-valid v1 file would
+ * otherwise parse clean.
+ */
+export function readLatestVersioned(path: string): LatestJson | null {
+  const result = safeReadJson<LatestJson>(path, LatestJsonSchema);
+  if (result === null) {
+    return null;
+  }
+  if (result.metadata.schema_version !== LATEST_SCHEMA_VERSION) {
+    return null;
+  }
+  return result;
+}

--- a/packages/core/src/reference/runtime.ts
+++ b/packages/core/src/reference/runtime.ts
@@ -5,8 +5,8 @@ import { Cooldown } from "../concurrency/cooldown.js";
 import { createRunSync } from "./sync/run-sync.js";
 import { Scheduler } from "./sync/scheduler.js";
 import { makeProductionFetcher } from "./sync/fetch-reference-data.js";
-import { safeReadJson } from "../io/safe-read-json.js";
-import { LatestJsonSchema, type LatestJson } from "./schemas/latest.js";
+import { readLatestVersioned } from "./io/read-latest-versioned.js";
+import { type LatestJson } from "./schemas/latest.js";
 import { SYNC_COOLDOWN_MS, SCHEDULED_SYNC_INTERVAL_MS } from "./freshness.js";
 import {
   assertDisjointCoverage,
@@ -106,7 +106,7 @@ export async function bootstrapReference(
   const services: ReferenceServices = {
     runSync: (req) => runSyncInternal({ caller: "/sync", chatId: req.chatId }),
     loadLatest: (): LatestJson | null =>
-      safeReadJson<LatestJson>(join(referenceDataPath, "latest.json"), LatestJsonSchema),
+      readLatestVersioned(join(referenceDataPath, "latest.json")),
     // Stub; the curator fills this (see ReferenceServices.maybeRefreshIfStale).
     maybeRefreshIfStale: () => Promise.resolve({ kind: "fresh" }),
   };

--- a/packages/core/src/reference/schemas/latest.ts
+++ b/packages/core/src/reference/schemas/latest.ts
@@ -2,7 +2,55 @@ import { z } from "zod";
 
 // Bump this only when THIS file's shape changes — never in lockstep with
 // sibling schemas. See CONTRIBUTING.md "Reference schema-version policy."
-export const LATEST_SCHEMA_VERSION = "1";
+export const LATEST_SCHEMA_VERSION = "2";
+
+const DerivedMetricsSchema = z
+  .object({
+    acwr: z.number().nullable().optional(),
+    monotony: z.number().nullable().optional(),
+    primary_sport_monotony: z.number().nullable().optional(),
+    effective_monotony: z.number().nullable().optional(),
+    monotony_interpretation: z.string().nullable().optional(),
+    multi_sport_detected: z.unknown().nullable().optional(),
+    strain: z.number().nullable().optional(),
+    recovery_index: z.number().nullable().optional(),
+    stress_tolerance: z.number().nullable().optional(),
+    load_recovery_ratio: z.number().nullable().optional(),
+    zone_distribution_7d: z.unknown().nullable().optional(),
+    grey_zone_percentage: z.number().nullable().optional(),
+    grey_zone_note: z.string().nullable().optional(),
+    quality_intensity_percentage: z.number().nullable().optional(),
+    quality_intensity_note: z.string().nullable().optional(),
+    easy_time_ratio: z.number().nullable().optional(),
+    easy_time_ratio_note: z.string().nullable().optional(),
+    seiler_tid_7d: z.unknown().nullable().optional(),
+    seiler_tid_7d_primary: z.unknown().nullable().optional(),
+    seiler_tid_28d: z.unknown().nullable().optional(),
+    seiler_tid_28d_primary: z.unknown().nullable().optional(),
+    consistency_index: z.number().nullable().optional(),
+    consistency_details: z.unknown().nullable().optional(),
+    seasonal_context: z.unknown().nullable().optional(),
+    benchmark_indoor: z.unknown().nullable().optional(),
+    benchmark_outdoor: z.unknown().nullable().optional(),
+    has_intervals: z.unknown().nullable().optional(),
+    effort_response_signal: z.unknown().nullable().optional(),
+    weight_signal: z.unknown().nullable().optional(),
+    "capability.durability": z.unknown().nullable().optional(),
+    "capability.efficiency_factor": z.unknown().nullable().optional(),
+    "capability.hrrc": z.unknown().nullable().optional(),
+    "capability.tid_comparison": z.unknown().nullable().optional(),
+    "capability.power_curve_delta": z.unknown().nullable().optional(),
+    "capability.hr_curve_delta": z.unknown().nullable().optional(),
+    "capability.sustainability_profile": z.unknown().nullable().optional(),
+    "capability.dfa_a1_profile": z.unknown().nullable().optional(),
+    eftp: z.number().nullable().optional(),
+    w_prime: z.number().nullable().optional(),
+    w_prime_kj: z.number().nullable().optional(),
+    p_max: z.number().nullable().optional(),
+    power_model_source: z.string().nullable().optional(),
+    vo2max: z.number().nullable().optional(),
+  })
+  .passthrough();
 
 export const LatestJsonSchema = z
   .object({
@@ -15,7 +63,7 @@ export const LatestJsonSchema = z
       .strict(),
     athlete_profile: z.unknown(),
     current_status: z.unknown(),
-    derived_metrics: z.unknown(),
+    derived_metrics: DerivedMetricsSchema,
     derived_metrics_meta: z
       .object({
         sportFamily: z.string(),

--- a/packages/core/src/reference/sync/fetch-reference-data.ts
+++ b/packages/core/src/reference/sync/fetch-reference-data.ts
@@ -50,8 +50,7 @@ function deriveMeta(runs: readonly AdapterRun[]): DerivedMetricsMeta | undefined
  *
  * Out of scope (separate deferred tickets): the per-window power/HR/
  * sustainability curve fetch (the curve-delta capability metrics reproduce
- * their null blocks until it lands), and the structured `derived_metrics`
- * schema + cache version bump (the field stays `z.unknown()` for now). The
+ * their null blocks until it lands). The
  * `history`/`intervals`/`routes`/`ftp_history` retention cache files keep their
  * empty stubs — they are populated by their own retention pipeline, not here.
  */

--- a/packages/core/tests/reference-live-sync-integration.test.ts
+++ b/packages/core/tests/reference-live-sync-integration.test.ts
@@ -18,7 +18,7 @@ import type { ReferenceSportAdapter } from "../src/reference/sport-adapter.js";
 import type { IntervalsActivityType } from "../src/sport.js";
 import type { FetchedReference } from "../src/reference/sync/run-sync.js";
 import { gateLatestJson } from "../src/reference/validation/sync-gate.js";
-import { LatestJsonSchema, type LatestJson } from "../src/reference/schemas/latest.js";
+import { LatestJsonSchema, LATEST_SCHEMA_VERSION, type LatestJson } from "../src/reference/schemas/latest.js";
 import { METRIC_REGISTRY } from "../src/reference/metrics/registry.js";
 import { SPORT_FAMILIES } from "../src/reference/metrics/sport-families.js";
 import { safeReadJson } from "../src/io/safe-read-json.js";
@@ -132,7 +132,7 @@ describe("live-data bridge integration", () => {
   it("produces a latest envelope that parses against LatestJsonSchema", async () => {
     const fetched = await composeFetched();
     const onDisk = {
-      metadata: { schema_version: "1", last_updated: NOW.toISOString(), freshness: "fresh" as const },
+      metadata: { schema_version: LATEST_SCHEMA_VERSION, last_updated: NOW.toISOString(), freshness: "fresh" as const },
       ...fetched.latest,
     };
     expect(() => LatestJsonSchema.parse(onDisk)).not.toThrow();
@@ -144,7 +144,7 @@ describe("live-data bridge integration", () => {
     expect(fetched.latest.derived_metrics_meta).toEqual(tag);
 
     const onDisk = {
-      metadata: { schema_version: "1", last_updated: NOW.toISOString(), freshness: "fresh" as const },
+      metadata: { schema_version: LATEST_SCHEMA_VERSION, last_updated: NOW.toISOString(), freshness: "fresh" as const },
       ...fetched.latest,
     };
     const dir = mkdtempSync(join(tmpdir(), "reference-latest-"));

--- a/packages/core/tests/reference-run-sync.test.ts
+++ b/packages/core/tests/reference-run-sync.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -10,7 +10,13 @@ import {
   BODY_AFTER_TIMEOUT_LOG_PREFIX,
 } from "../src/reference/sync/run-sync.js";
 import { SCHEDULED_SYNC_INTERVAL_MS } from "../src/reference/freshness.js";
-import { LATEST_SCHEMA_VERSION } from "../src/reference/schemas/latest.js";
+import {
+  LATEST_SCHEMA_VERSION,
+  LatestJsonSchema,
+} from "../src/reference/schemas/latest.js";
+import { readLatestVersioned } from "../src/reference/io/read-latest-versioned.js";
+import { bootstrapReference } from "../src/reference/runtime.js";
+import type { Sport } from "../src/sport.js";
 import { emptyFetched } from "./helpers/reference-fixtures.js";
 
 describe("createRunSync", () => {
@@ -630,5 +636,129 @@ describe("createRunSync", () => {
     // clearTimeoutFn must receive the handle that setTimeoutFn returned.
     const expectedHandle = setSpy.mock.results[0]?.value;
     expect(clearSpy).toHaveBeenCalledWith(expectedHandle);
+  });
+});
+
+const fakeSport = (): Sport =>
+  ({
+    intervalsActivityTypes: [],
+    referenceAdapters: undefined,
+  }) as unknown as Sport;
+
+// A v2-shaped body the schema accepts on its own merits — used to prove the
+// version-equality gate runs AFTER safeReadJson (safeReadJson types
+// schema_version only as z.string(), so a shape-valid stale file parses clean).
+const v2BodyShapeValid = {
+  athlete_profile: { id: "test-athlete" },
+  current_status: {},
+  derived_metrics: { acwr: null, monotony: 1.2 },
+  recent_activities: [],
+  planned_workouts: [],
+  wellness_data: {},
+};
+
+const onDiskWithVersion = (version: string) => ({
+  metadata: {
+    schema_version: version,
+    last_updated: "1998-06-20T00:00:00.000Z",
+    freshness: "fresh" as const,
+  },
+  ...v2BodyShapeValid,
+});
+
+describe("latest derived_metrics structured schema + version gate", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "reference-run-schema-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it("the current cache schema version is \"2\"", () => {
+    expect(LATEST_SCHEMA_VERSION).toBe("2");
+  });
+
+  it("a sparse running derived_metrics map (power keys absent, others null) parses clean", () => {
+    const sparse = {
+      ...onDiskWithVersion(LATEST_SCHEMA_VERSION),
+      derived_metrics: {
+        acwr: null,
+        monotony: null,
+        strain: null,
+        easy_time_ratio: null,
+        consistency_index: null,
+        seiler_tid_7d: null,
+        seasonal_context: null,
+        "capability.durability": null,
+        "capability.efficiency_factor": null,
+      },
+    };
+    expect(() => LatestJsonSchema.parse(sparse)).not.toThrow();
+  });
+
+  it("the 8 dotted capability.* keys round-trip verbatim as FLAT properties", () => {
+    const withCapabilities = {
+      ...onDiskWithVersion(LATEST_SCHEMA_VERSION),
+      derived_metrics: {
+        "capability.durability": { score: 1 },
+        "capability.efficiency_factor": { ef: 2 },
+        "capability.hrrc": { v: 3 },
+        "capability.tid_comparison": { v: 4 },
+        "capability.power_curve_delta": null,
+        "capability.hr_curve_delta": null,
+        "capability.sustainability_profile": { v: 7 },
+        "capability.dfa_a1_profile": { v: 8 },
+      },
+    };
+    const parsed = LatestJsonSchema.parse(withCapabilities);
+    expect(parsed.derived_metrics["capability.durability"]).toEqual({ score: 1 });
+    expect(parsed.derived_metrics["capability.dfa_a1_profile"]).toEqual({ v: 8 });
+    // The flat dotted key is NOT a nested capability object.
+    expect(
+      (parsed.derived_metrics as Record<string, unknown>).capability,
+    ).toBeUndefined();
+  });
+
+  it("readLatestVersioned returns the parsed envelope for a current-v2 file", () => {
+    const path = join(dir, "latest.json");
+    writeFileSync(path, JSON.stringify(onDiskWithVersion(LATEST_SCHEMA_VERSION)), "utf-8");
+    const result = readLatestVersioned(path);
+    expect(result).not.toBeNull();
+    expect(result?.metadata.schema_version).toBe(LATEST_SCHEMA_VERSION);
+  });
+
+  it("readLatestVersioned routes a stale v1 file to discard-and-resync (null) even when its body fits v2", () => {
+    const path = join(dir, "latest.json");
+    // Deliberately schema_version "1" — do NOT bump this literal.
+    writeFileSync(path, JSON.stringify(onDiskWithVersion("1")), "utf-8");
+    expect(readLatestVersioned(path)).toBeNull();
+  });
+
+  it("readLatestVersioned returns null for a missing or corrupt file (safeReadJson behavior preserved)", () => {
+    expect(readLatestVersioned(join(dir, "does-not-exist.json"))).toBeNull();
+    const corrupt = join(dir, "corrupt.json");
+    writeFileSync(corrupt, "{ not valid json", "utf-8");
+    expect(readLatestVersioned(corrupt)).toBeNull();
+  });
+
+  it("runtime loadLatest (delegating to readLatestVersioned) returns null for a stale v1 cache that fits v2", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(emptyFetched);
+    const runtime = await bootstrapReference({
+      dataDir: dir,
+      intervals: { apiKey: "test-key" },
+      sport: fakeSport(),
+      fetchReferenceData: fetchSpy,
+    });
+    runtime.scheduler.stop();
+
+    // Overwrite the freshly-synced cache with a stale v1 file whose body is
+    // otherwise v2-shape-valid. loadLatest must treat it as a cache miss.
+    const latestPath = join(dir, "data", "latest.json");
+    writeFileSync(latestPath, JSON.stringify(onDiskWithVersion("1")), "utf-8");
+    expect(runtime.services.loadLatest()).toBeNull();
   });
 });


### PR DESCRIPTION
## What

Third wave-1 work item: harden the persisted `latest.json` cache so its `derived_metrics` block has a real shape and a stale cache is re-synced instead of silently read.

- **Structured `derived_metrics`** — replaces the `z.unknown()` escape hatch with an object schema enumerating the exact 43 registry metric keys (29 flat + the 8 dotted `capability.*` keys as flat quoted properties, matching what the compute runner actually emits + 6 power-model keys). Every value is `.nullable().optional()` and the object is `.passthrough()`, so a sparse running map (which drops the 9 power keys) and existing golden fixtures (some of which carry `derived_metrics: {}`) all parse, while a newly-registered metric doesn't force a same-PR schema edit.
- **Version bump `1` → `2`** — the persisted-shape changed, so `LATEST_SCHEMA_VERSION` bumps. The write path stamps it automatically.
- **Version-gated read** — a new exported `readLatestVersioned` helper wraps `safeReadJson` and discards (returns null → cache miss → re-sync) any file whose `metadata.schema_version` isn't current. The equality check runs *after* the parse, so it catches a `v1` file whose body coincidentally fits `v2` (the schema types `schema_version` only as a string). `runtime.ts` `loadLatest` now delegates to it — a single locality-correct home so a future curator reuses the gate instead of re-deriving a discard path.

## Why a helper, not an inline gate

The version-equality discard belongs with the read, not with one caller. Inlining it at the `loadLatest` closure would let a later cache-refresh path read `latest.json` directly and bypass the gate (a silent-stale read). The exported helper closes that door.

## Test plan

- `pnpm -r build` + `pnpm check:types` — clean; the widened `LatestJson` type still compiles at `runtime.ts` and the telegram readers
- `pnpm test` — full suite green (2579 passed / 5 skipped), incl. new tests: version === `2`, sparse running map parses, dotted `capability.*` keys round-trip as flat properties, `readLatestVersioned` returns null for a stale `v1` file (even one that fits `v2`) and the envelope for a current file, and `loadLatest` delegates correctly
- `pnpm check-parity --all` — 559/559 OK (the schema asserts the persisted shape; parity calls `compute` directly and is unaffected)
- `pnpm check` — types, lint, trademark, fixture-privacy, registry-isolation all clean

Stacked on #248 (base = `feature/reference-power-family-fence`). Merge order: #246 → #248 → this, retargeting each to `main` after the one below it merges.
