### PR TITLE
refactor(core): route error_state writes through the injectable abort-aware seam and pin the intra-cycle block_coaching race

### DIFF
--- a/packages/core/src/reference/sync/error-state-writer.ts
+++ b/packages/core/src/reference/sync/error-state-writer.ts
@@ -9,12 +9,22 @@ import { atomicWriteJson } from "../../io/atomic-write-json.js";
 
 export type { ErrorPhase };
 
+export type ErrorStateWrite = (
+  path: string,
+  value: unknown,
+  opts?: { signal?: AbortSignal },
+) => Promise<void>;
+
 /**
  * Atomic-write `error_state.json` to the data dir. Called by `runSync()`
  * when the outer 2-min timeout fires (with `phase` set per ADR-0011's
  * commit-marker-last write order), when the Layer-1 gate rejects a fetch
  * (with `phase` omitted), or on the soft-warn path (with
  * `mitigation: "warn_only"`). Cleared on the next fully-clean sync.
+ *
+ * The write is injectable (defaults to `atomicWriteJson`) and threads an
+ * optional abort signal so a late body write skips its rename after the outer
+ * timeout force-releases the mutex.
  */
 export async function writeErrorState(
   dataDir: string,
@@ -24,15 +34,21 @@ export async function writeErrorState(
     phase?: ErrorPhase;
     mitigation?: ErrorMitigation;
   },
+  opts?: { write?: ErrorStateWrite; signal?: AbortSignal },
 ): Promise<void> {
-  await atomicWriteJson(join(dataDir, "error_state.json"), {
-    schema_version: ERROR_STATE_SCHEMA_VERSION,
-    step: payload.step,
-    detail: payload.detail,
-    ts: new Date().toISOString(),
-    ...(payload.phase !== undefined ? { phase: payload.phase } : {}),
-    ...(payload.mitigation !== undefined ? { mitigation: payload.mitigation } : {}),
-  });
+  const write = opts?.write ?? atomicWriteJson;
+  await write(
+    join(dataDir, "error_state.json"),
+    {
+      schema_version: ERROR_STATE_SCHEMA_VERSION,
+      step: payload.step,
+      detail: payload.detail,
+      ts: new Date().toISOString(),
+      ...(payload.phase !== undefined ? { phase: payload.phase } : {}),
+      ...(payload.mitigation !== undefined ? { mitigation: payload.mitigation } : {}),
+    },
+    { signal: opts?.signal },
+  );
 }
 
 /**
@@ -42,7 +58,11 @@ export async function writeErrorState(
  * stale-error_state interleave. Swallows ENOENT — a missing file is the
  * desired post-state.
  */
-export async function clearErrorState(dataDir: string): Promise<void> {
+export async function clearErrorState(
+  dataDir: string,
+  opts?: { signal?: AbortSignal },
+): Promise<void> {
+  if (opts?.signal?.aborted === true) return;
   try {
     await unlink(join(dataDir, "error_state.json"));
   } catch (err) {

--- a/packages/core/src/reference/sync/run-sync.ts
+++ b/packages/core/src/reference/sync/run-sync.ts
@@ -139,7 +139,7 @@ export interface RunSyncDeps {
     opts?: { signal?: AbortSignal },
   ) => Promise<void>;
   /** Override error_state.json removal for tests; defaults to `clearErrorState`. */
-  readonly clearError?: (dataDir: string) => Promise<void>;
+  readonly clearError?: (dataDir: string, opts?: { signal?: AbortSignal }) => Promise<void>;
   /**
    * Override the per-tick outcome writer for tests; defaults to
    * `createSyncHistoryWriter(deps.dataDir)`. Best-effort and never throws, so it
@@ -324,12 +324,17 @@ export function createRunSync(
             // scheduled tick logging-only and the curator blind to the failure.
             if (controller.signal.aborted) return abortedResult();
             const detail = err instanceof Error ? err.message : String(err);
-            await writeErrorState(deps.dataDir, {
-              step: "fetch_failed",
-              phase,
-              detail,
-              ...priorBlockCoaching(deps.dataDir),
-            });
+            // Route through the injectable abort-aware seam so a late body write skips its rename if the outer timeout already force-released the mutex.
+            await writeErrorState(
+              deps.dataDir,
+              {
+                step: "fetch_failed",
+                phase,
+                detail,
+                ...priorBlockCoaching(deps.dataDir),
+              },
+              { write: writeJson, signal: controller.signal },
+            );
             return {
               kind: "failed",
               reason: "fetch_failed",
@@ -349,11 +354,15 @@ export function createRunSync(
             // instead of quoting numbers from data we could not trust. The soft
             // path below keeps its non-blocking warn-only mitigation.
             cycleBlockCoaching = true;
-            await writeErrorState(deps.dataDir, {
-              step: "gate_rejected",
-              detail: gateResult.failures.map((f) => `${f.step}: ${f.detail}`).join("; "),
-              mitigation: "block_coaching",
-            });
+            await writeErrorState(
+              deps.dataDir,
+              {
+                step: "gate_rejected",
+                detail: gateResult.failures.map((f) => `${f.step}: ${f.detail}`).join("; "),
+                mitigation: "block_coaching",
+              },
+              { write: writeJson, signal: controller.signal },
+            );
             return {
               kind: "failed",
               reason: "gate_rejected",
@@ -439,13 +448,17 @@ export function createRunSync(
           // record a non-blocking warn_only state; a fully-clean sync clears
           // any error_state left by a prior failed/soft run.
           if (gateResult.warnings.length > 0) {
-            await writeErrorState(deps.dataDir, {
-              step: "gate_warnings",
-              detail: gateResult.warnings.map((w) => `${w.step}: ${w.detail}`).join("; "),
-              mitigation: "warn_only",
-            });
+            await writeErrorState(
+              deps.dataDir,
+              {
+                step: "gate_warnings",
+                detail: gateResult.warnings.map((w) => `${w.step}: ${w.detail}`).join("; "),
+                mitigation: "warn_only",
+              },
+              { write: writeJson, signal: controller.signal },
+            );
           } else {
-            await clearError(deps.dataDir);
+            await clearError(deps.dataDir, { signal: controller.signal });
           }
 
           return {
@@ -494,14 +507,19 @@ export function createRunSync(
               );
             }
           });
-          await writeErrorState(deps.dataDir, {
-            step: "outer_timeout",
-            phase,
-            detail: `runSync exceeded ${outerTimeoutMs}ms during ${phase} phase`,
-            ...(cycleBlockCoaching
-              ? ({ mitigation: "block_coaching" } as const)
-              : priorBlockCoaching(deps.dataDir)),
-          });
+          // No signal here: this write runs AFTER controller.abort() and is the authoritative timeout record. Threading the (already-aborted) signal would make the abort-aware helper skip its rename and drop the record entirely.
+          await writeErrorState(
+            deps.dataDir,
+            {
+              step: "outer_timeout",
+              phase,
+              detail: `runSync exceeded ${outerTimeoutMs}ms during ${phase} phase`,
+              ...(cycleBlockCoaching
+                ? ({ mitigation: "block_coaching" } as const)
+                : priorBlockCoaching(deps.dataDir)),
+            },
+            { write: writeJson },
+          );
           return { kind: "failed", reason: "outer_timeout", failures: [] };
         }
 

--- a/packages/core/tests/reference-error-state-writer.test.ts
+++ b/packages/core/tests/reference-error-state-writer.test.ts
@@ -1,12 +1,15 @@
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   ERROR_STATE_SCHEMA_VERSION,
   ErrorStateSchema,
 } from "../src/reference/schemas/error-state.js";
-import { writeErrorState } from "../src/reference/sync/error-state-writer.js";
+import {
+  clearErrorState,
+  writeErrorState,
+} from "../src/reference/sync/error-state-writer.js";
 
 describe("writeErrorState", () => {
   let dir: string;
@@ -45,6 +48,69 @@ describe("writeErrorState", () => {
     const parsed = ErrorStateSchema.parse(JSON.parse(raw));
     expect(parsed.step).toBe("gate_rejected");
     expect(parsed.phase).toBeUndefined();
+  });
+
+  it("routes through an injected write and threads the signal (B1)", async () => {
+    const spy = vi.fn().mockResolvedValue(undefined);
+    const controller = new AbortController();
+
+    await writeErrorState(
+      dir,
+      { step: "gate_rejected", detail: "x", mitigation: "block_coaching" },
+      { write: spy, signal: controller.signal },
+    );
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect((spy.mock.calls[0][0] as string).endsWith("error_state.json")).toBe(true);
+    const value = spy.mock.calls[0][1] as Record<string, unknown>;
+    expect(value.step).toBe("gate_rejected");
+    expect(value.detail).toBe("x");
+    expect(value.mitigation).toBe("block_coaching");
+    expect(value.schema_version).toBe(ERROR_STATE_SCHEMA_VERSION);
+    expect(typeof value.ts).toBe("string");
+    expect(spy.mock.calls[0][2]).toEqual({ signal: controller.signal });
+  });
+
+  it("default write honours an already-aborted signal — no file lands (B2)", async () => {
+    const aborted = new AbortController();
+    aborted.abort();
+
+    await writeErrorState(
+      dir,
+      { step: "gate_rejected", detail: "x" },
+      { signal: aborted.signal },
+    );
+    expect(existsSync(join(dir, "error_state.json"))).toBe(false);
+
+    // A fresh, non-aborted write lands the file — proving the seam threads the
+    // signal into the real abort-aware atomicWriteJson rather than swallowing it.
+    await writeErrorState(dir, { step: "gate_rejected", detail: "x" });
+    expect(existsSync(join(dir, "error_state.json"))).toBe(true);
+  });
+});
+
+describe("clearErrorState", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "reference-error-state-clear-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("skips the unlink when the signal is aborted (B3)", async () => {
+    await writeErrorState(dir, { step: "gate_rejected", detail: "x" });
+    expect(existsSync(join(dir, "error_state.json"))).toBe(true);
+
+    const aborted = new AbortController();
+    aborted.abort();
+    await clearErrorState(dir, { signal: aborted.signal });
+    expect(existsSync(join(dir, "error_state.json"))).toBe(true);
+
+    await clearErrorState(dir);
+    expect(existsSync(join(dir, "error_state.json"))).toBe(false);
   });
 });
 

--- a/packages/core/tests/reference-run-sync.test.ts
+++ b/packages/core/tests/reference-run-sync.test.ts
@@ -340,7 +340,17 @@ describe("createRunSync", () => {
       ...emptyFetched,
       fetch_errors: [{ endpoint: "athlete", detail: "timeout" }],
     });
-    const writeSpy = vi.fn(async (_path: string, _value: unknown): Promise<void> => {});
+    const { atomicWriteJson: realAtomicWrite } = await import(
+      "../src/io/atomic-write-json.js"
+    );
+    // The gate-reject error_state write now routes through the injectable seam
+    // (deps.atomicWrite), so forward it to the real writer for the on-disk
+    // assertion below; cache/scheduler writes are still recorded as spy calls.
+    const writeSpy = vi.fn(
+      async (path: string, value: unknown, opts?: { signal?: AbortSignal }): Promise<void> => {
+        await realAtomicWrite(path, value, opts);
+      },
+    );
 
     const runSync = createRunSync({
       dataDir: dir,
@@ -628,7 +638,10 @@ describe("createRunSync", () => {
         value: unknown,
         opts?: { signal?: AbortSignal },
       ): Promise<void> => {
-        if (!path.endsWith(".scheduler.json")) {
+        // Park only the cache writes; the post-timeout error_state record (which
+        // now routes through this same seam, signal-less) must pass straight
+        // through so the orchestrator can land the authoritative timeout record.
+        if (!path.endsWith(".scheduler.json") && !path.endsWith("error_state.json")) {
           if (signalArrived !== null) {
             signalArrived();
             signalArrived = null;
@@ -734,14 +747,26 @@ describe("createRunSync", () => {
     const fetchSpy = vi.fn().mockResolvedValue(emptyFetched);
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
+    const { atomicWriteJson: realAtomicWrite } = await import(
+      "../src/io/atomic-write-json.js"
+    );
     // atomicWrite that throws (simulating disk-full or fs error) AFTER a 200ms
     // delay. With outerTimeoutMs: 20, the outer race wins ("timeout") at ~20ms;
     // the body's await of this write rejects at ~200ms. The 10× gap keeps the
-    // test deterministic on slow CI runners.
-    const failingWrite = vi.fn(async (): Promise<void> => {
-      await new Promise((resolve) => setTimeout(resolve, 200));
-      throw new Error("simulated disk-full mid-write");
-    });
+    // test deterministic on slow CI runners. The timeout-path error_state write
+    // now routes through this same seam — forward it to the real writer so the
+    // authoritative timeout record still lands and only the body's cache write
+    // simulates the disk failure under test.
+    const failingWrite = vi.fn(
+      async (path: string, value: unknown, opts?: { signal?: AbortSignal }): Promise<void> => {
+        if (path.endsWith("error_state.json")) {
+          await realAtomicWrite(path, value, opts);
+          return;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 200));
+        throw new Error("simulated disk-full mid-write");
+      },
+    );
 
     const runSync = createRunSync({
       dataDir: dir,

--- a/packages/core/tests/sync-gate-block-coaching.test.ts
+++ b/packages/core/tests/sync-gate-block-coaching.test.ts
@@ -155,6 +155,123 @@ describe("block_coaching write side (gate-reject mitigation)", () => {
     expect(errorState.mitigation).toBe("block_coaching");
   });
 
+  it("intra-cycle: a same-cycle gate-reject + outer-timeout keeps mitigation:block_coaching on the timeout record (and the abort-skipped gate write never clobbers it)", async () => {
+    const now = new Date("2026-05-09T14:00:00Z");
+    const mutex = new AsyncMutex();
+    const fetchSpy = vi.fn().mockResolvedValue(emptyFetched);
+    const rejectingGate = vi.fn().mockReturnValue({
+      ok: false,
+      failures: [{ step: "step1_ftp_source", detail: "FTP source missing on athlete profile" }],
+      warnings: [],
+    });
+
+    const { atomicWriteJson: realAtomicWrite } = await import(
+      "../src/io/atomic-write-json.js"
+    );
+
+    // Park the FIRST error_state.json write (the gate-reject write) on a gate so
+    // the outer timer can fire while it is still in flight; later writes (the
+    // timeout-path record) pass straight through.
+    let releaseGate!: () => void;
+    const gateLatch = new Promise<void>((resolve) => {
+      releaseGate = resolve;
+    });
+    let signalArrived: (() => void) | null = () => {};
+    const arrivedAtGate = new Promise<void>((resolve) => {
+      signalArrived = resolve;
+    });
+    const pendingWrites: Array<Promise<unknown>> = [];
+    const writes: Array<{ path: string; value: unknown }> = [];
+    let parkedFirst = false;
+    const latchedWrite = vi.fn(
+      async (
+        path: string,
+        value: unknown,
+        opts?: { signal?: AbortSignal },
+      ): Promise<void> => {
+        writes.push({ path, value });
+        if (path.endsWith("error_state.json") && !parkedFirst) {
+          parkedFirst = true;
+          if (signalArrived !== null) {
+            signalArrived();
+            signalArrived = null;
+          }
+          await gateLatch;
+        }
+        // Forward the threaded opts so the released gate-reject write honours the
+        // abort (rename-skip) exactly as production does.
+        const w = realAtomicWrite(path, value, opts);
+        pendingWrites.push(w);
+        await w;
+      },
+    );
+
+    let capturedTimeoutFn!: () => void;
+    const setTimeoutFn = vi.fn((fn: () => void) => {
+      capturedTimeoutFn = fn;
+      return 1;
+    });
+    const clearTimeoutFn = vi.fn();
+
+    const runSync = createRunSync({
+      dataDir: dir,
+      mutex,
+      cooldown: new Cooldown(),
+      cooldownWindowMs: 30_000,
+      fetchReferenceData: fetchSpy,
+      gate: rejectingGate,
+      atomicWrite: latchedWrite,
+      clock: { setTimeout: setTimeoutFn, clearTimeout: clearTimeoutFn },
+      now: () => now,
+      timing: { outerTimeoutMs: 300 },
+    });
+
+    const p = runSync({ caller: "scheduled" });
+
+    await arrivedAtGate;
+    await Promise.resolve();
+
+    // Fire the outer timeout while the gate-reject write is STILL parked.
+    capturedTimeoutFn();
+    const result = await p;
+
+    // (1) The cycle fails on the outer timeout.
+    expect(result.kind).toBe("failed");
+    if (result.kind === "failed") expect(result.reason).toBe("outer_timeout");
+
+    // (2) The timeout-path record carries block_coaching from the synchronous
+    // in-cycle cycleBlockCoaching flag. Without the flag the timeout path would
+    // read priorBlockCoaching off disk, but the gate-reject write is still parked
+    // / never landed, so it would be undefined — which is exactly why this
+    // assertion fails if the flag is neutralised.
+    const timeoutRecord = writes.find(
+      (w) =>
+        w.path.endsWith("error_state.json") &&
+        (w.value as { step?: string }).step === "outer_timeout",
+    );
+    expect(timeoutRecord).toBeDefined();
+    expect((timeoutRecord!.value as { mitigation?: string }).mitigation).toBe(
+      "block_coaching",
+    );
+
+    // (3) The timeout force-released the mutex.
+    expect(mutex.isHeld()).toBe(false);
+
+    // (4) Release the parked gate-reject write and drain. Its threaded (aborted)
+    // signal makes the abort-aware helper skip its rename, so it never clobbers
+    // the already-landed timeout record on disk.
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    releaseGate();
+    await Promise.allSettled(pendingWrites);
+    await Promise.resolve();
+    await Promise.resolve();
+    warnSpy.mockRestore();
+
+    const onDisk = readErrorState();
+    expect(onDisk.step).toBe("outer_timeout");
+    expect(onDisk.mitigation).toBe("block_coaching");
+  });
+
   it("a clean sync leaves no error_state.json (the block write never leaks onto the happy path)", async () => {
     const now = new Date("2026-05-09T14:00:00Z");
     const fetchSpy = vi.fn().mockResolvedValue(emptyFetched);


### PR DESCRIPTION
## What

A follow-up to the same-cycle `block_coaching` race fix landed in #243 (commit `d8d265e`). That fix is correct-by-construction (a synchronous in-cycle flag), but it shipped **without an executable intra-cycle test** because the gate-reject `error_state.json` write was not injectable — it went through the module-level writer, so a test could not latch it to deterministically force the gate-reject + outer-timeout interleaving.

This PR closes that gap and a related late-write window:

1. **One injectable + abort-aware seam.** `writeErrorState` / `clearErrorState` gain an optional opts arg (`{ write?, signal? }`), defaulting to `atomicWriteJson`. `error_state.json` writes now go through the **same** injectable abort-aware path the cache/scheduler writes already use (`deps.atomicWrite ?? atomicWriteJson`).

2. **Abort-signal threading (the related late-write window).** The three **body** `error_state` writes (`fetch_failed`, `gate_rejected`, `gate_warnings`) and the success-path `clearError` now thread `controller.signal`. If the outer timeout fired and force-released the mutex to a successor cycle, a late body write now skips its rename instead of clobbering a fresh record the successor wrote — consistent with the abort-aware cache writes.

3. **Load-bearing invariant — the timeout-path write stays signal-less.** The post-timeout `outer_timeout` record write runs **after** `controller.abort()` and is the authoritative timeout record; threading the (already-aborted) signal there would make the abort-aware helper skip its rename and drop the record. It deliberately passes `{ write: writeJson }` only, with a `WHY` comment.

4. **Deterministic intra-cycle guard.** A new test parks the gate-reject `error_state` write, hand-fires the captured outer timer while it is parked, and asserts the timeout record carries `mitigation: "block_coaching"` — proving it comes from the synchronous in-cycle flag, **not** from disk (the parked write never landed). It is mutation-distinguishing: neutralise the flag and the timeout record falls back to a disk read that returns nothing, so the assertion fails. The test also confirms the released gate-reject write is abort-skipped and never clobbers the timeout record.

## Files

- `error-state-writer.ts` — the seam (injectable write + abort-skip on `clearErrorState`).
- `run-sync.ts` — wire the 5 call sites (3 body writes + clear get the signal; timeout write stays signal-less).
- `sync-gate-block-coaching.test.ts` — the deterministic intra-cycle guard.
- `reference-error-state-writer.test.ts` — seam unit tests (signal threading, abort-skip on write and clear).
- `reference-run-sync.test.ts` — three pre-existing tests updated so their injected write-spies forward `error_state.json` writes to the real writer (the seam now intercepts them). Intent-preserving, no assertions changed; stash-isolation confirmed these were the only three affected.

## Verification

- Built and reviewed via fresh-context agents: 3 correctness lenses (seam, guard, wiring) + 2 independent adversarial skeptics. Both skeptics could not reach either failure mode (timeout record losing `block_coaching`, or failing to land) — confirmed unreachable from first-principles event-loop analysis.
- Full suite green: **2587 passing** (+2 skipped); `pnpm check` exit 0 (types, trademarks, fixture-privacy, registry-isolation all clean).

## Notes

- Stacked on the freshness PR (#244), the current top of the sync-reliability stack. Merge bottom-up.
- Touches `reference/sync/` and `io/` test surfaces only — no metrics/validation/curator, so no porting-discipline gate.
- No changeset: pure infra/test reliability, no athlete-visible behavior change (the `block_coaching` behavior already shipped in #243).
