### PR TITLE
test(core): add the running-only golden fixture, builder, and oracle snapshots

### DIFF
--- a/packages/core/tests/fixtures/golden/running-only.json
+++ b/packages/core/tests/fixtures/golden/running-only.json
@@ -1,0 +1,413 @@
+{
+  "activities": [
+    {
+      "id": 90301,
+      "start_date_local": "1998-05-08T07:00:00",
+      "type": "Run",
+      "name": "synthetic-run",
+      "moving_time": 3600,
+      "elapsed_time": 3660,
+      "icu_training_load": 48,
+      "icu_hr_zone_times": [
+        1800,
+        1080,
+        180,
+        540,
+        0,
+        0,
+        0
+      ],
+      "icu_zone_times": null,
+      "decoupling": null,
+      "icu_efficiency_factor": null
+    },
+    {
+      "id": 90302,
+      "start_date_local": "1998-05-10T07:00:00",
+      "type": "Run",
+      "name": "synthetic-run",
+      "moving_time": 4200,
+      "elapsed_time": 4260,
+      "icu_training_load": 72,
+      "icu_hr_zone_times": [
+        2100,
+        1260,
+        210,
+        630,
+        0,
+        0,
+        0
+      ],
+      "icu_zone_times": null,
+      "decoupling": null,
+      "icu_efficiency_factor": null
+    },
+    {
+      "id": 90303,
+      "start_date_local": "1998-05-12T07:00:00",
+      "type": "TrailRun",
+      "name": "synthetic-trail-run",
+      "moving_time": 6000,
+      "elapsed_time": 6060,
+      "icu_training_load": 90,
+      "icu_hr_zone_times": [
+        3000,
+        1800,
+        300,
+        900,
+        0,
+        0,
+        0
+      ],
+      "icu_zone_times": null,
+      "decoupling": null,
+      "icu_efficiency_factor": null
+    },
+    {
+      "id": 90304,
+      "start_date_local": "1998-05-14T07:00:00",
+      "type": "Run",
+      "name": "synthetic-run",
+      "moving_time": 2400,
+      "elapsed_time": 2460,
+      "icu_training_load": 35,
+      "icu_hr_zone_times": [
+        1200,
+        720,
+        120,
+        360,
+        0,
+        0,
+        0
+      ],
+      "icu_zone_times": null,
+      "decoupling": null,
+      "icu_efficiency_factor": null
+    },
+    {
+      "id": 90305,
+      "start_date_local": "1998-05-17T07:00:00",
+      "type": "Run",
+      "name": "synthetic-run",
+      "moving_time": 3600,
+      "elapsed_time": 3660,
+      "icu_training_load": 55,
+      "icu_hr_zone_times": [
+        1800,
+        1080,
+        180,
+        540,
+        0,
+        0,
+        0
+      ],
+      "icu_zone_times": null,
+      "decoupling": null,
+      "icu_efficiency_factor": null
+    },
+    {
+      "id": 90306,
+      "start_date_local": "1998-05-19T07:00:00",
+      "type": "Run",
+      "name": "synthetic-run",
+      "moving_time": 4800,
+      "elapsed_time": 4860,
+      "icu_training_load": 80,
+      "icu_hr_zone_times": [
+        2400,
+        1440,
+        240,
+        720,
+        0,
+        0,
+        0
+      ],
+      "icu_zone_times": null,
+      "decoupling": null,
+      "icu_efficiency_factor": null
+    },
+    {
+      "id": 90307,
+      "start_date_local": "1998-05-21T07:00:00",
+      "type": "Run",
+      "name": "synthetic-run",
+      "moving_time": 3000,
+      "elapsed_time": 3060,
+      "icu_training_load": 42,
+      "icu_hr_zone_times": [
+        1500,
+        900,
+        150,
+        450,
+        0,
+        0,
+        0
+      ],
+      "icu_zone_times": null,
+      "decoupling": null,
+      "icu_efficiency_factor": null
+    },
+    {
+      "id": 90308,
+      "start_date_local": "1998-05-24T07:00:00",
+      "type": "Run",
+      "name": "synthetic-run",
+      "moving_time": 3600,
+      "elapsed_time": 3660,
+      "icu_training_load": 60,
+      "icu_hr_zone_times": [
+        1800,
+        1080,
+        180,
+        540,
+        0,
+        0,
+        0
+      ],
+      "icu_zone_times": null,
+      "decoupling": null,
+      "icu_efficiency_factor": null
+    },
+    {
+      "id": 90309,
+      "start_date_local": "1998-05-26T07:00:00",
+      "type": "Run",
+      "name": "synthetic-run",
+      "moving_time": 3000,
+      "elapsed_time": 3060,
+      "icu_training_load": 50,
+      "icu_hr_zone_times": [
+        1500,
+        900,
+        150,
+        450,
+        0,
+        0,
+        0
+      ],
+      "icu_zone_times": null,
+      "decoupling": null,
+      "icu_efficiency_factor": null
+    },
+    {
+      "id": 90310,
+      "start_date_local": "1998-05-29T07:00:00",
+      "type": "Run",
+      "name": "synthetic-run",
+      "moving_time": 3600,
+      "elapsed_time": 3660,
+      "icu_training_load": 45,
+      "icu_hr_zone_times": [
+        1800,
+        1080,
+        180,
+        540,
+        0,
+        0,
+        0
+      ],
+      "icu_zone_times": null,
+      "decoupling": null,
+      "icu_efficiency_factor": null
+    },
+    {
+      "id": 90311,
+      "start_date_local": "1998-05-31T07:00:00",
+      "type": "Run",
+      "name": "synthetic-run",
+      "moving_time": 4200,
+      "elapsed_time": 4260,
+      "icu_training_load": 70,
+      "icu_hr_zone_times": [
+        2100,
+        1260,
+        210,
+        630,
+        0,
+        0,
+        0
+      ],
+      "icu_zone_times": null,
+      "decoupling": null,
+      "icu_efficiency_factor": null
+    },
+    {
+      "id": 90312,
+      "start_date_local": "1998-06-01T07:00:00",
+      "type": "Run",
+      "name": "synthetic-run",
+      "moving_time": 2400,
+      "elapsed_time": 2460,
+      "icu_training_load": 38,
+      "icu_hr_zone_times": [
+        1200,
+        720,
+        120,
+        360,
+        0,
+        0,
+        0
+      ],
+      "icu_zone_times": null,
+      "decoupling": null,
+      "icu_efficiency_factor": null
+    },
+    {
+      "id": 90313,
+      "start_date_local": "1998-06-02T07:00:00",
+      "type": "TrailRun",
+      "name": "synthetic-trail-run",
+      "moving_time": 6000,
+      "elapsed_time": 6060,
+      "icu_training_load": 85,
+      "icu_hr_zone_times": [
+        3000,
+        1800,
+        300,
+        900,
+        0,
+        0,
+        0
+      ],
+      "icu_zone_times": null,
+      "decoupling": null,
+      "icu_efficiency_factor": null
+    },
+    {
+      "id": 90314,
+      "start_date_local": "1998-06-04T07:00:00",
+      "type": "Run",
+      "name": "synthetic-run",
+      "moving_time": 3600,
+      "elapsed_time": 3660,
+      "icu_training_load": 52,
+      "icu_hr_zone_times": [
+        1800,
+        1080,
+        180,
+        540,
+        0,
+        0,
+        0
+      ],
+      "icu_zone_times": null,
+      "decoupling": null,
+      "icu_efficiency_factor": null
+    }
+  ],
+  "wellness": [
+    {
+      "id": "1998-05-08",
+      "weight": null,
+      "restingHR": 50,
+      "hrv": 70,
+      "sleepSecs": null,
+      "sleepQuality": null
+    },
+    {
+      "id": "1998-05-10",
+      "weight": null,
+      "restingHR": 50,
+      "hrv": 70,
+      "sleepSecs": null,
+      "sleepQuality": null
+    },
+    {
+      "id": "1998-05-12",
+      "weight": null,
+      "restingHR": 50,
+      "hrv": 70,
+      "sleepSecs": null,
+      "sleepQuality": null
+    },
+    {
+      "id": "1998-05-14",
+      "weight": null,
+      "restingHR": 50,
+      "hrv": 70,
+      "sleepSecs": null,
+      "sleepQuality": null
+    },
+    {
+      "id": "1998-05-17",
+      "weight": null,
+      "restingHR": 50,
+      "hrv": 70,
+      "sleepSecs": null,
+      "sleepQuality": null
+    },
+    {
+      "id": "1998-05-19",
+      "weight": null,
+      "restingHR": 50,
+      "hrv": 70,
+      "sleepSecs": null,
+      "sleepQuality": null
+    },
+    {
+      "id": "1998-05-21",
+      "weight": null,
+      "restingHR": 50,
+      "hrv": 70,
+      "sleepSecs": null,
+      "sleepQuality": null
+    },
+    {
+      "id": "1998-05-24",
+      "weight": null,
+      "restingHR": 50,
+      "hrv": 70,
+      "sleepSecs": null,
+      "sleepQuality": null
+    },
+    {
+      "id": "1998-05-26",
+      "weight": null,
+      "restingHR": 50,
+      "hrv": 70,
+      "sleepSecs": null,
+      "sleepQuality": null
+    },
+    {
+      "id": "1998-05-29",
+      "weight": null,
+      "restingHR": 50,
+      "hrv": 70,
+      "sleepSecs": null,
+      "sleepQuality": null
+    },
+    {
+      "id": "1998-05-31",
+      "weight": null,
+      "restingHR": 50,
+      "hrv": 70,
+      "sleepSecs": null,
+      "sleepQuality": null
+    },
+    {
+      "id": "1998-06-01",
+      "weight": null,
+      "restingHR": 50,
+      "hrv": 70,
+      "sleepSecs": null,
+      "sleepQuality": null
+    },
+    {
+      "id": "1998-06-02",
+      "weight": null,
+      "restingHR": 50,
+      "hrv": 70,
+      "sleepSecs": null,
+      "sleepQuality": null
+    },
+    {
+      "id": "1998-06-04",
+      "weight": null,
+      "restingHR": 50,
+      "hrv": 70,
+      "sleepSecs": null,
+      "sleepQuality": null
+    }
+  ],
+  "ftp_history": []
+}

--- a/packages/core/tests/fixtures/golden/running-only.json.sha256
+++ b/packages/core/tests/fixtures/golden/running-only.json.sha256
@@ -1,0 +1,1 @@
+e2b7d5b47245a27764841a7b0dacbc95474aa8f76babec1a00603da34f0dc130  running-only.json

--- a/packages/core/tests/fixtures/snapshots/manifest.json
+++ b/packages/core/tests/fixtures/snapshots/manifest.json
@@ -15,7 +15,8 @@
     "new-athlete-empty",
     "populated-benchmark-and-consistency",
     "realistic-athlete",
-    "rest-week-with-baseline"
+    "rest-week-with-baseline",
+    "running-only"
   ],
   "metrics": [
     "acwr",

--- a/packages/core/tests/fixtures/snapshots/running-only/acwr.json
+++ b/packages/core/tests/fixtures/snapshots/running-only/acwr.json
@@ -1,0 +1,8 @@
+{
+  "metric": "acwr",
+  "athlete": "running-only",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "1998-06-04T12:00:00",
+  "value": 1.41
+}

--- a/packages/core/tests/fixtures/snapshots/running-only/acwr_interpretation.json
+++ b/packages/core/tests/fixtures/snapshots/running-only/acwr_interpretation.json
@@ -1,0 +1,8 @@
+{
+  "metric": "acwr_interpretation",
+  "athlete": "running-only",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "1998-06-04T12:00:00",
+  "value": "caution"
+}

--- a/packages/core/tests/fixtures/snapshots/running-only/benchmark_indoor.json
+++ b/packages/core/tests/fixtures/snapshots/running-only/benchmark_indoor.json
@@ -1,0 +1,14 @@
+{
+  "metric": "benchmark_indoor",
+  "athlete": "running-only",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "1998-06-04T12:00:00",
+  "value": {
+    "benchmark_index": null,
+    "benchmark_percentage": null,
+    "current_ftp": null,
+    "ftp_8_weeks_ago": null,
+    "seasonal_expected": null
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/running-only/benchmark_outdoor.json
+++ b/packages/core/tests/fixtures/snapshots/running-only/benchmark_outdoor.json
@@ -1,0 +1,14 @@
+{
+  "metric": "benchmark_outdoor",
+  "athlete": "running-only",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "1998-06-04T12:00:00",
+  "value": {
+    "benchmark_index": null,
+    "benchmark_percentage": null,
+    "current_ftp": null,
+    "ftp_8_weeks_ago": null,
+    "seasonal_expected": null
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/running-only/calculation_timestamp.json
+++ b/packages/core/tests/fixtures/snapshots/running-only/calculation_timestamp.json
@@ -1,0 +1,8 @@
+{
+  "metric": "calculation_timestamp",
+  "athlete": "running-only",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "1998-06-04T12:00:00",
+  "value": "1998-06-04T12:00:00"
+}

--- a/packages/core/tests/fixtures/snapshots/running-only/capability.dfa_a1_profile.json
+++ b/packages/core/tests/fixtures/snapshots/running-only/capability.dfa_a1_profile.json
@@ -1,0 +1,8 @@
+{
+  "metric": "capability.dfa_a1_profile",
+  "athlete": "running-only",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "1998-06-04T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/running-only/capability.durability.json
+++ b/packages/core/tests/fixtures/snapshots/running-only/capability.durability.json
@@ -1,0 +1,19 @@
+{
+  "metric": "capability.durability",
+  "athlete": "running-only",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "1998-06-04T12:00:00",
+  "value": {
+    "high_drift_count_28d": 0,
+    "high_drift_count_7d": 0,
+    "mean_decoupling_28d": null,
+    "mean_decoupling_7d": null,
+    "note": "Steady-state power sessions only (VI <= 1.05, VI > 0, >= 90min, power data). Negative decoupling = strong durability. Trend compares 7d vs 28d mean (+/-1% = stable). Alerts require N28>=5 (alarm) or N7>=3 AND N28>=5 (declining warning) for statistical reliability.",
+    "qualifying_sessions_28d": 0,
+    "qualifying_sessions_7d": 0,
+    "reliability_limited": true,
+    "reliability_note": "insufficient qualifying sessions for alert evaluation: 7d N=0 (min 3), 28d N=0 (min 5)",
+    "trend": null
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/running-only/capability.efficiency_factor.json
+++ b/packages/core/tests/fixtures/snapshots/running-only/capability.efficiency_factor.json
@@ -1,0 +1,15 @@
+{
+  "metric": "capability.efficiency_factor",
+  "athlete": "running-only",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "1998-06-04T12:00:00",
+  "value": {
+    "mean_ef_28d": null,
+    "mean_ef_7d": null,
+    "note": "Steady-state cycling sessions only (VI <= 1.05, VI > 0, >= 20min, power+HR data). Rising EF = improving aerobic efficiency. Compare like-for-like sessions only — EF varies with intensity. Trend compares 7d vs 28d mean (+/-0.03 = stable).",
+    "qualifying_sessions_28d": 0,
+    "qualifying_sessions_7d": 0,
+    "trend": null
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/running-only/capability.hr_curve_delta.json
+++ b/packages/core/tests/fixtures/snapshots/running-only/capability.hr_curve_delta.json
@@ -1,0 +1,13 @@
+{
+  "metric": "capability.hr_curve_delta",
+  "athlete": "running-only",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "1998-06-04T12:00:00",
+  "value": {
+    "anchors": null,
+    "note": "Insufficient HR data in one or both windows.",
+    "rotation_index": null,
+    "window_days": 28
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/running-only/capability.hrrc.json
+++ b/packages/core/tests/fixtures/snapshots/running-only/capability.hrrc.json
@@ -1,0 +1,15 @@
+{
+  "metric": "capability.hrrc",
+  "athlete": "running-only",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "1998-06-04T12:00:00",
+  "value": {
+    "mean_hrrc_28d": null,
+    "mean_hrrc_7d": null,
+    "note": "HRRc = heart rate recovery (largest 60s HR drop in bpm after exceeding threshold HR for >1 min). Higher = better parasympathetic recovery. Null when threshold not reached, recording stopped before cooldown, or no HR data. Trend: 7d mean vs 28d mean, >10% = meaningful (min 1 session/7d, 3 sessions/28d). Display only — not wired into readiness_decision signals.",
+    "qualifying_sessions_28d": 0,
+    "qualifying_sessions_7d": 0,
+    "trend": null
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/running-only/capability.json
+++ b/packages/core/tests/fixtures/snapshots/running-only/capability.json
@@ -1,0 +1,62 @@
+{
+  "metric": "capability",
+  "athlete": "running-only",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "1998-06-04T12:00:00",
+  "value": {
+    "dfa_a1_profile": null,
+    "durability": {
+      "high_drift_count_28d": 0,
+      "high_drift_count_7d": 0,
+      "mean_decoupling_28d": null,
+      "mean_decoupling_7d": null,
+      "note": "Steady-state power sessions only (VI <= 1.05, VI > 0, >= 90min, power data). Negative decoupling = strong durability. Trend compares 7d vs 28d mean (+/-1% = stable). Alerts require N28>=5 (alarm) or N7>=3 AND N28>=5 (declining warning) for statistical reliability.",
+      "qualifying_sessions_28d": 0,
+      "qualifying_sessions_7d": 0,
+      "reliability_limited": true,
+      "reliability_note": "insufficient qualifying sessions for alert evaluation: 7d N=0 (min 3), 28d N=0 (min 5)",
+      "trend": null
+    },
+    "efficiency_factor": {
+      "mean_ef_28d": null,
+      "mean_ef_7d": null,
+      "note": "Steady-state cycling sessions only (VI <= 1.05, VI > 0, >= 20min, power+HR data). Rising EF = improving aerobic efficiency. Compare like-for-like sessions only — EF varies with intensity. Trend compares 7d vs 28d mean (+/-0.03 = stable).",
+      "qualifying_sessions_28d": 0,
+      "qualifying_sessions_7d": 0,
+      "trend": null
+    },
+    "hr_curve_delta": {
+      "anchors": null,
+      "note": "Insufficient HR data in one or both windows.",
+      "rotation_index": null,
+      "window_days": 28
+    },
+    "hrrc": {
+      "mean_hrrc_28d": null,
+      "mean_hrrc_7d": null,
+      "note": "HRRc = heart rate recovery (largest 60s HR drop in bpm after exceeding threshold HR for >1 min). Higher = better parasympathetic recovery. Null when threshold not reached, recording stopped before cooldown, or no HR data. Trend: 7d mean vs 28d mean, >10% = meaningful (min 1 session/7d, 3 sessions/28d). Display only — not wired into readiness_decision signals.",
+      "qualifying_sessions_28d": 0,
+      "qualifying_sessions_7d": 0,
+      "trend": null
+    },
+    "power_curve_delta": {
+      "anchors": null,
+      "note": "Insufficient power data in one or both windows.",
+      "rotation_index": null,
+      "window_days": 28
+    },
+    "sustainability_profile": {
+      "note": "No sustainability data available."
+    },
+    "tid_comparison": {
+      "classification_28d": "Polarized",
+      "classification_7d": "Polarized",
+      "drift": "consistent",
+      "note": "Compares 7d vs 28d Seiler TID to detect distribution shifts. pi_delta positive = more polarized acutely.",
+      "pi_28d": 2.38,
+      "pi_7d": 2.38,
+      "pi_delta": 0
+    }
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/running-only/capability.power_curve_delta.json
+++ b/packages/core/tests/fixtures/snapshots/running-only/capability.power_curve_delta.json
@@ -1,0 +1,13 @@
+{
+  "metric": "capability.power_curve_delta",
+  "athlete": "running-only",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "1998-06-04T12:00:00",
+  "value": {
+    "anchors": null,
+    "note": "Insufficient power data in one or both windows.",
+    "rotation_index": null,
+    "window_days": 28
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/running-only/capability.sustainability_profile.json
+++ b/packages/core/tests/fixtures/snapshots/running-only/capability.sustainability_profile.json
@@ -1,0 +1,10 @@
+{
+  "metric": "capability.sustainability_profile",
+  "athlete": "running-only",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "1998-06-04T12:00:00",
+  "value": {
+    "note": "No sustainability data available."
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/running-only/capability.tid_comparison.json
+++ b/packages/core/tests/fixtures/snapshots/running-only/capability.tid_comparison.json
@@ -1,0 +1,16 @@
+{
+  "metric": "capability.tid_comparison",
+  "athlete": "running-only",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "1998-06-04T12:00:00",
+  "value": {
+    "classification_28d": "Polarized",
+    "classification_7d": "Polarized",
+    "drift": "consistent",
+    "note": "Compares 7d vs 28d Seiler TID to detect distribution shifts. pi_delta positive = more polarized acutely.",
+    "pi_28d": 2.38,
+    "pi_7d": 2.38,
+    "pi_delta": 0
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/running-only/consistency_details.json
+++ b/packages/core/tests/fixtures/snapshots/running-only/consistency_details.json
@@ -1,0 +1,13 @@
+{
+  "metric": "consistency_details",
+  "athlete": "running-only",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "1998-06-04T12:00:00",
+  "value": {
+    "completed_days": 0,
+    "matched_days": 0,
+    "note": "No planned workouts in period",
+    "planned_days": 0
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/running-only/consistency_index.json
+++ b/packages/core/tests/fixtures/snapshots/running-only/consistency_index.json
@@ -1,0 +1,8 @@
+{
+  "metric": "consistency_index",
+  "athlete": "running-only",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "1998-06-04T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/running-only/data_quality.json
+++ b/packages/core/tests/fixtures/snapshots/running-only/data_quality.json
@@ -1,0 +1,18 @@
+{
+  "metric": "data_quality",
+  "athlete": "running-only",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "1998-06-04T12:00:00",
+  "value": {
+    "activities_28d": 14,
+    "activities_7d": 5,
+    "ftp_history_days": {
+      "indoor": 0,
+      "outdoor": 0
+    },
+    "hrv_data_points": 5,
+    "planned_workouts_7d": 0,
+    "rhr_data_points": 5
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/running-only/easy_time_ratio.json
+++ b/packages/core/tests/fixtures/snapshots/running-only/easy_time_ratio.json
@@ -1,0 +1,8 @@
+{
+  "metric": "easy_time_ratio",
+  "athlete": "running-only",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "1998-06-04T12:00:00",
+  "value": 0.8
+}

--- a/packages/core/tests/fixtures/snapshots/running-only/easy_time_ratio_note.json
+++ b/packages/core/tests/fixtures/snapshots/running-only/easy_time_ratio_note.json
@@ -1,0 +1,8 @@
+{
+  "metric": "easy_time_ratio_note",
+  "athlete": "running-only",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "1998-06-04T12:00:00",
+  "value": "Easy time (Z1+Z2) / Total - target ~80% in polarized training"
+}

--- a/packages/core/tests/fixtures/snapshots/running-only/effective_monotony.json
+++ b/packages/core/tests/fixtures/snapshots/running-only/effective_monotony.json
@@ -1,0 +1,8 @@
+{
+  "metric": "effective_monotony",
+  "athlete": "running-only",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "1998-06-04T12:00:00",
+  "value": 1.28
+}

--- a/packages/core/tests/fixtures/snapshots/running-only/effort_response_signal.json
+++ b/packages/core/tests/fixtures/snapshots/running-only/effort_response_signal.json
@@ -1,0 +1,23 @@
+{
+  "metric": "effort_response_signal",
+  "athlete": "running-only",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "1998-06-04T12:00:00",
+  "value": {
+    "90301": null,
+    "90302": null,
+    "90303": null,
+    "90304": null,
+    "90305": null,
+    "90306": null,
+    "90307": null,
+    "90308": null,
+    "90309": null,
+    "90310": null,
+    "90311": null,
+    "90312": null,
+    "90313": null,
+    "90314": null
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/running-only/eftp.json
+++ b/packages/core/tests/fixtures/snapshots/running-only/eftp.json
@@ -1,0 +1,8 @@
+{
+  "metric": "eftp",
+  "athlete": "running-only",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "1998-06-04T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/running-only/grey_zone_note.json
+++ b/packages/core/tests/fixtures/snapshots/running-only/grey_zone_note.json
@@ -1,0 +1,8 @@
+{
+  "metric": "grey_zone_note",
+  "athlete": "running-only",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "1998-06-04T12:00:00",
+  "value": "Gray Zone % (Z3/tempo) - minimize in polarized training"
+}

--- a/packages/core/tests/fixtures/snapshots/running-only/grey_zone_percentage.json
+++ b/packages/core/tests/fixtures/snapshots/running-only/grey_zone_percentage.json
@@ -1,0 +1,8 @@
+{
+  "metric": "grey_zone_percentage",
+  "athlete": "running-only",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "1998-06-04T12:00:00",
+  "value": 5
+}

--- a/packages/core/tests/fixtures/snapshots/running-only/hard_days_note.json
+++ b/packages/core/tests/fixtures/snapshots/running-only/hard_days_note.json
@@ -1,0 +1,8 @@
+{
+  "metric": "hard_days_note",
+  "athlete": "running-only",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "1998-06-04T12:00:00",
+  "value": "Power ladder: z3+ >= 30min, z4+ >= 10min, z5+ >= 5min, z6+ >= 2min, z7 >= 1min. HR fallback (when no power): z4+ >= 10min, z5+ >= 5min. Per Seiler 3-zone model + Foster. HR-based days flagged with intensity_basis: hr"
+}

--- a/packages/core/tests/fixtures/snapshots/running-only/hard_days_this_week.json
+++ b/packages/core/tests/fixtures/snapshots/running-only/hard_days_this_week.json
@@ -1,0 +1,8 @@
+{
+  "metric": "hard_days_this_week",
+  "athlete": "running-only",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "1998-06-04T12:00:00",
+  "value": 1
+}

--- a/packages/core/tests/fixtures/snapshots/running-only/has_intervals.json
+++ b/packages/core/tests/fixtures/snapshots/running-only/has_intervals.json
@@ -1,0 +1,23 @@
+{
+  "metric": "has_intervals",
+  "athlete": "running-only",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "1998-06-04T12:00:00",
+  "value": {
+    "90301": false,
+    "90302": false,
+    "90303": false,
+    "90304": false,
+    "90305": false,
+    "90306": false,
+    "90307": false,
+    "90308": false,
+    "90309": false,
+    "90310": false,
+    "90311": false,
+    "90312": false,
+    "90313": false,
+    "90314": false
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/running-only/hrv_baseline_28d.json
+++ b/packages/core/tests/fixtures/snapshots/running-only/hrv_baseline_28d.json
@@ -1,0 +1,8 @@
+{
+  "metric": "hrv_baseline_28d",
+  "athlete": "running-only",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "1998-06-04T12:00:00",
+  "value": 70
+}

--- a/packages/core/tests/fixtures/snapshots/running-only/hrv_baseline_7d.json
+++ b/packages/core/tests/fixtures/snapshots/running-only/hrv_baseline_7d.json
@@ -1,0 +1,8 @@
+{
+  "metric": "hrv_baseline_7d",
+  "athlete": "running-only",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "1998-06-04T12:00:00",
+  "value": 70
+}

--- a/packages/core/tests/fixtures/snapshots/running-only/latest_hrv.json
+++ b/packages/core/tests/fixtures/snapshots/running-only/latest_hrv.json
@@ -1,0 +1,8 @@
+{
+  "metric": "latest_hrv",
+  "athlete": "running-only",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "1998-06-04T12:00:00",
+  "value": 70
+}

--- a/packages/core/tests/fixtures/snapshots/running-only/latest_rhr.json
+++ b/packages/core/tests/fixtures/snapshots/running-only/latest_rhr.json
@@ -1,0 +1,8 @@
+{
+  "metric": "latest_rhr",
+  "athlete": "running-only",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "1998-06-04T12:00:00",
+  "value": 50
+}

--- a/packages/core/tests/fixtures/snapshots/running-only/load_recovery_ratio.json
+++ b/packages/core/tests/fixtures/snapshots/running-only/load_recovery_ratio.json
@@ -1,0 +1,8 @@
+{
+  "metric": "load_recovery_ratio",
+  "athlete": "running-only",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "1998-06-04T12:00:00",
+  "value": 2.9
+}

--- a/packages/core/tests/fixtures/snapshots/running-only/monotony.json
+++ b/packages/core/tests/fixtures/snapshots/running-only/monotony.json
@@ -1,0 +1,8 @@
+{
+  "metric": "monotony",
+  "athlete": "running-only",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "1998-06-04T12:00:00",
+  "value": 1.28
+}

--- a/packages/core/tests/fixtures/snapshots/running-only/monotony_interpretation.json
+++ b/packages/core/tests/fixtures/snapshots/running-only/monotony_interpretation.json
@@ -1,0 +1,8 @@
+{
+  "metric": "monotony_interpretation",
+  "athlete": "running-only",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "1998-06-04T12:00:00",
+  "value": "normal"
+}

--- a/packages/core/tests/fixtures/snapshots/running-only/multi_sport_detected.json
+++ b/packages/core/tests/fixtures/snapshots/running-only/multi_sport_detected.json
@@ -1,0 +1,8 @@
+{
+  "metric": "multi_sport_detected",
+  "athlete": "running-only",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "1998-06-04T12:00:00",
+  "value": false
+}

--- a/packages/core/tests/fixtures/snapshots/running-only/p_max.json
+++ b/packages/core/tests/fixtures/snapshots/running-only/p_max.json
@@ -1,0 +1,8 @@
+{
+  "metric": "p_max",
+  "athlete": "running-only",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "1998-06-04T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/running-only/phase_detected.json
+++ b/packages/core/tests/fixtures/snapshots/running-only/phase_detected.json
@@ -1,0 +1,8 @@
+{
+  "metric": "phase_detected",
+  "athlete": "running-only",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "1998-06-04T12:00:00",
+  "value": "Base"
+}

--- a/packages/core/tests/fixtures/snapshots/running-only/phase_detection.json
+++ b/packages/core/tests/fixtures/snapshots/running-only/phase_detection.json
@@ -1,0 +1,38 @@
+{
+  "metric": "phase_detection",
+  "athlete": "running-only",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "1998-06-04T12:00:00",
+  "value": {
+    "basis": {
+      "data_quality": "good",
+      "stream_1": {
+        "acwr_trend": null,
+        "ctl_slope": null,
+        "hard_day_pattern": 1,
+        "weeks_available": 4
+      },
+      "stream_2": {
+        "current_week_hard_days_completed": 0,
+        "current_week_hard_days_total": 0,
+        "hard_sessions_planned": 0,
+        "next_week_load": null,
+        "plan_coverage_current_week": 0,
+        "plan_coverage_next_week": 0,
+        "planned_tss_delta": null,
+        "race_proximity": null
+      },
+      "stream_agreement": null
+    },
+    "confidence": "medium",
+    "dossier_agreement": null,
+    "dossier_declared": null,
+    "phase": "Base",
+    "phase_duration_weeks": 1,
+    "previous_phase": null,
+    "reason_codes": [
+      "NO_PLANNED_WORKOUTS"
+    ]
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/running-only/phase_triggers.json
+++ b/packages/core/tests/fixtures/snapshots/running-only/phase_triggers.json
@@ -1,0 +1,10 @@
+{
+  "metric": "phase_triggers",
+  "athlete": "running-only",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "1998-06-04T12:00:00",
+  "value": [
+    "NO_PLANNED_WORKOUTS"
+  ]
+}

--- a/packages/core/tests/fixtures/snapshots/running-only/power_model_source.json
+++ b/packages/core/tests/fixtures/snapshots/running-only/power_model_source.json
@@ -1,0 +1,8 @@
+{
+  "metric": "power_model_source",
+  "athlete": "running-only",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "1998-06-04T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/running-only/primary_sport.json
+++ b/packages/core/tests/fixtures/snapshots/running-only/primary_sport.json
@@ -1,0 +1,8 @@
+{
+  "metric": "primary_sport",
+  "athlete": "running-only",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "1998-06-04T12:00:00",
+  "value": "run"
+}

--- a/packages/core/tests/fixtures/snapshots/running-only/primary_sport_monotony.json
+++ b/packages/core/tests/fixtures/snapshots/running-only/primary_sport_monotony.json
@@ -1,0 +1,8 @@
+{
+  "metric": "primary_sport_monotony",
+  "athlete": "running-only",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "1998-06-04T12:00:00",
+  "value": 1.28
+}

--- a/packages/core/tests/fixtures/snapshots/running-only/primary_sport_tss_7d.json
+++ b/packages/core/tests/fixtures/snapshots/running-only/primary_sport_tss_7d.json
@@ -1,0 +1,8 @@
+{
+  "metric": "primary_sport_tss_7d",
+  "athlete": "running-only",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "1998-06-04T12:00:00",
+  "value": 290
+}

--- a/packages/core/tests/fixtures/snapshots/running-only/quality_intensity_note.json
+++ b/packages/core/tests/fixtures/snapshots/running-only/quality_intensity_note.json
@@ -1,0 +1,8 @@
+{
+  "metric": "quality_intensity_note",
+  "athlete": "running-only",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "1998-06-04T12:00:00",
+  "value": "Quality Intensity % (Z4+/threshold+) - target ~20% in polarized training"
+}

--- a/packages/core/tests/fixtures/snapshots/running-only/quality_intensity_percentage.json
+++ b/packages/core/tests/fixtures/snapshots/running-only/quality_intensity_percentage.json
@@ -1,0 +1,8 @@
+{
+  "metric": "quality_intensity_percentage",
+  "athlete": "running-only",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "1998-06-04T12:00:00",
+  "value": 15
+}

--- a/packages/core/tests/fixtures/snapshots/running-only/recovery_index.json
+++ b/packages/core/tests/fixtures/snapshots/running-only/recovery_index.json
@@ -1,0 +1,8 @@
+{
+  "metric": "recovery_index",
+  "athlete": "running-only",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "1998-06-04T12:00:00",
+  "value": 1
+}

--- a/packages/core/tests/fixtures/snapshots/running-only/recovery_index_yesterday.json
+++ b/packages/core/tests/fixtures/snapshots/running-only/recovery_index_yesterday.json
@@ -1,0 +1,8 @@
+{
+  "metric": "recovery_index_yesterday",
+  "athlete": "running-only",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "1998-06-04T12:00:00",
+  "value": 1
+}

--- a/packages/core/tests/fixtures/snapshots/running-only/rhr_baseline_28d.json
+++ b/packages/core/tests/fixtures/snapshots/running-only/rhr_baseline_28d.json
@@ -1,0 +1,8 @@
+{
+  "metric": "rhr_baseline_28d",
+  "athlete": "running-only",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "1998-06-04T12:00:00",
+  "value": 50
+}

--- a/packages/core/tests/fixtures/snapshots/running-only/rhr_baseline_7d.json
+++ b/packages/core/tests/fixtures/snapshots/running-only/rhr_baseline_7d.json
@@ -1,0 +1,8 @@
+{
+  "metric": "rhr_baseline_7d",
+  "athlete": "running-only",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "1998-06-04T12:00:00",
+  "value": 50
+}

--- a/packages/core/tests/fixtures/snapshots/running-only/seasonal_context.json
+++ b/packages/core/tests/fixtures/snapshots/running-only/seasonal_context.json
@@ -1,0 +1,8 @@
+{
+  "metric": "seasonal_context",
+  "athlete": "running-only",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "1998-06-04T12:00:00",
+  "value": "Build / Early Race Season"
+}

--- a/packages/core/tests/fixtures/snapshots/running-only/seiler_tid_28d.json
+++ b/packages/core/tests/fixtures/snapshots/running-only/seiler_tid_28d.json
@@ -1,0 +1,18 @@
+{
+  "metric": "seiler_tid_28d",
+  "athlete": "running-only",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "1998-06-04T12:00:00",
+  "value": {
+    "classification": "Polarized",
+    "polarization_index": 2.38,
+    "z1_pct": 80,
+    "z1_seconds": 43200,
+    "z2_pct": 5,
+    "z2_seconds": 2700,
+    "z3_pct": 15,
+    "z3_seconds": 8100,
+    "zone_basis": "hr"
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/running-only/seiler_tid_28d_primary.json
+++ b/packages/core/tests/fixtures/snapshots/running-only/seiler_tid_28d_primary.json
@@ -1,0 +1,19 @@
+{
+  "metric": "seiler_tid_28d_primary",
+  "athlete": "running-only",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "1998-06-04T12:00:00",
+  "value": {
+    "classification": "Polarized",
+    "polarization_index": 2.38,
+    "sport": "run",
+    "z1_pct": 80,
+    "z1_seconds": 43200,
+    "z2_pct": 5,
+    "z2_seconds": 2700,
+    "z3_pct": 15,
+    "z3_seconds": 8100,
+    "zone_basis": "hr"
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/running-only/seiler_tid_7d.json
+++ b/packages/core/tests/fixtures/snapshots/running-only/seiler_tid_7d.json
@@ -1,0 +1,18 @@
+{
+  "metric": "seiler_tid_7d",
+  "athlete": "running-only",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "1998-06-04T12:00:00",
+  "value": {
+    "classification": "Polarized",
+    "polarization_index": 2.38,
+    "z1_pct": 80,
+    "z1_seconds": 15840,
+    "z2_pct": 5,
+    "z2_seconds": 990,
+    "z3_pct": 15,
+    "z3_seconds": 2970,
+    "zone_basis": "hr"
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/running-only/seiler_tid_7d_primary.json
+++ b/packages/core/tests/fixtures/snapshots/running-only/seiler_tid_7d_primary.json
@@ -1,0 +1,19 @@
+{
+  "metric": "seiler_tid_7d_primary",
+  "athlete": "running-only",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "1998-06-04T12:00:00",
+  "value": {
+    "classification": "Polarized",
+    "polarization_index": 2.38,
+    "sport": "run",
+    "z1_pct": 80,
+    "z1_seconds": 15840,
+    "z2_pct": 5,
+    "z2_seconds": 990,
+    "z3_pct": 15,
+    "z3_seconds": 2970,
+    "zone_basis": "hr"
+  }
+}

--- a/packages/core/tests/fixtures/snapshots/running-only/strain.json
+++ b/packages/core/tests/fixtures/snapshots/running-only/strain.json
@@ -1,0 +1,8 @@
+{
+  "metric": "strain",
+  "athlete": "running-only",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "1998-06-04T12:00:00",
+  "value": 371
+}

--- a/packages/core/tests/fixtures/snapshots/running-only/stress_tolerance.json
+++ b/packages/core/tests/fixtures/snapshots/running-only/stress_tolerance.json
@@ -1,0 +1,8 @@
+{
+  "metric": "stress_tolerance",
+  "athlete": "running-only",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "1998-06-04T12:00:00",
+  "value": 2.9
+}

--- a/packages/core/tests/fixtures/snapshots/running-only/tss_28d_total.json
+++ b/packages/core/tests/fixtures/snapshots/running-only/tss_28d_total.json
@@ -1,0 +1,8 @@
+{
+  "metric": "tss_28d_total",
+  "athlete": "running-only",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "1998-06-04T12:00:00",
+  "value": 822
+}

--- a/packages/core/tests/fixtures/snapshots/running-only/tss_7d_total.json
+++ b/packages/core/tests/fixtures/snapshots/running-only/tss_7d_total.json
@@ -1,0 +1,8 @@
+{
+  "metric": "tss_7d_total",
+  "athlete": "running-only",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "1998-06-04T12:00:00",
+  "value": 290
+}

--- a/packages/core/tests/fixtures/snapshots/running-only/vo2max.json
+++ b/packages/core/tests/fixtures/snapshots/running-only/vo2max.json
@@ -1,0 +1,8 @@
+{
+  "metric": "vo2max",
+  "athlete": "running-only",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "1998-06-04T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/running-only/w_prime.json
+++ b/packages/core/tests/fixtures/snapshots/running-only/w_prime.json
@@ -1,0 +1,8 @@
+{
+  "metric": "w_prime",
+  "athlete": "running-only",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "1998-06-04T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/running-only/w_prime_kj.json
+++ b/packages/core/tests/fixtures/snapshots/running-only/w_prime_kj.json
@@ -1,0 +1,8 @@
+{
+  "metric": "w_prime_kj",
+  "athlete": "running-only",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "1998-06-04T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/running-only/weight_signal.json
+++ b/packages/core/tests/fixtures/snapshots/running-only/weight_signal.json
@@ -1,0 +1,8 @@
+{
+  "metric": "weight_signal",
+  "athlete": "running-only",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "1998-06-04T12:00:00",
+  "value": null
+}

--- a/packages/core/tests/fixtures/snapshots/running-only/zone_distribution_7d.json
+++ b/packages/core/tests/fixtures/snapshots/running-only/zone_distribution_7d.json
@@ -1,0 +1,15 @@
+{
+  "metric": "zone_distribution_7d",
+  "athlete": "running-only",
+  "section_11_sha": "224c369d2f14a71725cb9157fc133cf3cff5cd32",
+  "section_11_protocol_version": "3.112",
+  "frozen_now": "1998-06-04T12:00:00",
+  "value": {
+    "total_hours": 5.5,
+    "z1_hours": 2.75,
+    "z2_hours": 1.65,
+    "z3_hours": 0.28,
+    "z4_plus_hours": 0.82,
+    "zone_basis": "hr"
+  }
+}

--- a/packages/core/tests/realistic-athlete-fixture-checksum.test.ts
+++ b/packages/core/tests/realistic-athlete-fixture-checksum.test.ts
@@ -51,6 +51,10 @@ const FIXTURES: Array<{ slug: string; regen: string }> = [
     slug: "capability-qualifying",
     regen: "tools/build-capability-fixture.ts",
   },
+  {
+    slug: "running-only",
+    regen: "tools/build-running-fixture.ts",
+  },
 ];
 
 describe.each(FIXTURES)("$slug fixture checksum", ({ slug, regen }) => {

--- a/packages/core/tests/reference-compute-derived-metrics.test.ts
+++ b/packages/core/tests/reference-compute-derived-metrics.test.ts
@@ -17,6 +17,7 @@ import { METRIC_REGISTRY } from "../src/reference/metrics/registry.js";
 import type { MetricInput } from "../src/reference/metrics/metric-input.js";
 import {
   buildFixtureShape,
+  buildMetricInput,
   type ReferenceBundle,
 } from "../src/reference/sync/fixture-bridge.js";
 import { runAdaptersForActivities } from "../src/reference/sport-adapter-dispatcher.js";
@@ -321,5 +322,63 @@ describe("cycling-shaped survivors on a pure-Run bundle (intentional, wave-3 rea
     expect(durability?.mean_decoupling_7d).toBeNull();
     expect(durability?.mean_decoupling_28d).toBeNull();
     expect(durability?.note).toContain("power sessions only");
+  });
+});
+
+// ─── running-only golden fixture: watts-fence + run-realism at the TS layer ──
+//
+// Distinct from the oracle snapshot set (which asserts bit-identity per metric):
+// this drives the PRODUCTION pure-pace path — buildMetricInput + the
+// `omitPowerFamily: true` watts-fence — over the committed running-only golden
+// fixture, then proves the persisted map (a) omits every power-family key and
+// (b) populates the run-realism survivors non-degenerately off HR zones.
+
+describe("running-only golden fixture (pure-pace production path)", () => {
+  function runningOnlyInput(): MetricInput {
+    const fixture = loadFixture("golden/running-only", GoldenFixtureSchema);
+    // Map the golden FixtureShape back through the production assembly path
+    // (buildMetricInput over a ReferenceBundle) — the same shape the live sync
+    // hands the registry for a pure-pace bundle.
+    const bundle: ReferenceBundle = {
+      activities: fixture.activities,
+      wellness: fixture.wellness,
+      ftpHistory: fixture.ftp_history,
+    };
+    return buildMetricInput(bundle, "1998-06-04T12:00:00");
+  }
+
+  it("omits all 9 power-family keys under the pure-pace watts-fence", () => {
+    const out = computeDerivedMetrics(runningOnlyInput(), { omitPowerFamily: true });
+    for (const key of POWER_FAMILY_OMIT_KEYS) {
+      expect(out).not.toHaveProperty(key);
+    }
+  });
+
+  it("populates the Seiler-TID / zone-distribution / easy-time survivors non-degenerately off HR zones", () => {
+    const out = computeDerivedMetrics(runningOnlyInput(), { omitPowerFamily: true });
+
+    const seiler = out["seiler_tid_7d"] as {
+      classification: string | null;
+      zone_basis: string | null;
+      z1_pct: number | null;
+    } | null;
+    expect(seiler).not.toBeNull();
+    expect(seiler?.classification).not.toBeNull();
+    expect(seiler?.zone_basis).toBe("hr");
+    expect(seiler?.z1_pct).toBeGreaterThan(0);
+
+    const zoneDist = out["zone_distribution_7d"] as {
+      total_hours: number;
+      zone_basis: string | null;
+    } | null;
+    expect(zoneDist).not.toBeNull();
+    expect(zoneDist?.zone_basis).toBe("hr");
+    expect(zoneDist?.total_hours).toBeGreaterThan(0);
+
+    const easyRatio = out["easy_time_ratio"] as number | null;
+    expect(easyRatio).not.toBeNull();
+    // Low-intensity-dominant by construction (~0.80).
+    expect(easyRatio).toBeGreaterThanOrEqual(0.7);
+    expect(easyRatio).toBeLessThanOrEqual(0.9);
   });
 });

--- a/tools/build-running-fixture.ts
+++ b/tools/build-running-fixture.ts
@@ -1,0 +1,328 @@
+// Builds the `running-only` golden fixture: a FULLY SYNTHETIC bundle of Run /
+// TrailRun activities carrying realistic, low-intensity-dominant HR-zone time
+// data and non-zero per-session load. No real data, no sanitizer involvement —
+// every byte is generated from the closed-form patterns here.
+//
+// Why this fixture exists: it is the pure-pace coverage substrate. The runs
+// carry NO watts / power fields of any kind, so the parity gate's power-family
+// snapshots collapse to their null blocks while the load-management survivors
+// (ACWR / monotony / strain / stress_tolerance) and the zone-distribution
+// survivors (Seiler TID, zone_distribution_7d, easy_time_ratio, grey-zone %,
+// quality-intensity %) all compute NON-degenerately off HR zones. Runners are
+// commonly HR-zoned, so every session uses `icu_hr_zone_times` (a flat
+// seconds array indexed to z1..z7) — which also exercises the HR-fallback
+// path (`zone_basis == "hr"`) that the cycling fixtures' power zones never
+// reach.
+//
+// Determinism: no Math.random / Date.now. Every date is derived from the
+// frozen anchor string via ymdMinus (UTC calendar math); the load + zone
+// patterns are explicit constants. Re-running produces byte-identical output.
+// The build ends with a non-vacuity guard that independently recomputes the
+// central claims (acute + chronic load non-zero with a non-constant 7d series;
+// a populated, low-intensity-dominant zone distribution) and fails unless they
+// hold — so a "parity-green-but-vacuous" fixture (load present but zone times
+// starved, or a constant load series that nulls monotony) can never ship.
+//
+// Usage (operator, dev-time):
+//   pnpm exec tsx tools/build-running-fixture.ts [--frozen-now 1998-06-04T12:00:00] [--out <path>]
+
+import { createHash } from "node:crypto";
+import { writeFileSync } from "node:fs";
+import { basename, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const DEFAULT_OUT = resolve(REPO_ROOT, "packages/core/tests/fixtures/golden/running-only.json");
+
+// Synthetic-epoch anchor (one full Gregorian cycle back from the real era).
+// This fixture is fully synthetic — no real PII — but the anchor sits in the
+// synthetic epoch so any future regen lands its dates pre-cutoff, consistent
+// with the fixture-privacy invariant (tools/check-fixture-privacy.ts).
+const DEFAULT_FROZEN_NOW = "1998-06-04T12:00:00";
+
+// Synthetic id base, reserved per-fixture so the synthetic fixtures never
+// collide: 90101 = curve, 90201 = dfa, 90301 = running. Well above the
+// real-data sentinel (12345) and below nothing real.
+const SYNTHETIC_ID_BASE = 90301;
+
+// Seiler-zone split applied to every run: ~80% easy (Z1+Z2), ~5% grey (Z3),
+// ~15% hard (Z4). Co-present with the low-intensity-dominant framing the
+// fixture targets (easy_time_ratio ~0.80, a "Polarized" TID classification).
+// Fractions chosen so each run's seconds split to integers on the moving
+// times below.
+const Z1_FRAC = 0.5;
+const Z2_FRAC = 0.3;
+const Z3_FRAC = 0.05;
+const Z4_FRAC = 0.15;
+
+interface Args {
+  frozenNow: string;
+  out: string;
+}
+
+function parseArgs(argv: string[]): Args {
+  const out: Args = { frozenNow: DEFAULT_FROZEN_NOW, out: DEFAULT_OUT };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    const next = (): string => {
+      const v = argv[i + 1];
+      if (v === undefined || v.startsWith("--")) {
+        throw new Error(`flag ${arg} requires a value`);
+      }
+      i++;
+      return v;
+    };
+    switch (arg) {
+      case "--frozen-now":
+        out.frozenNow = next();
+        break;
+      case "--out":
+        out.out = resolve(next());
+        break;
+      default:
+        throw new Error(`unknown flag: ${arg}`);
+    }
+  }
+  return out;
+}
+
+// Python-equivalent calendar math: parse the anchor as a UTC date, subtract
+// whole days, format %Y-%m-%d. Matches `datetime - timedelta(days=n)` exactly.
+function ymdMinus(frozenNow: string, days: number): string {
+  const base = new Date(`${frozenNow.slice(0, 10)}T00:00:00Z`);
+  base.setUTCDate(base.getUTCDate() - days);
+  return base.toISOString().slice(0, 10);
+}
+
+// Flat HR-zone seconds array [z1,z2,z3,z4,z5,z6,z7] for a run of `movingSecs`,
+// split by the fixed low-intensity-dominant fractions. The trailing three hard
+// zones stay 0 — a runner's hard time folds into Z4 here. Zero bins are
+// skipped by both the oracle and the TS port (the `if secs` guard), so they
+// neither alter the basis nor the totals.
+function hrZoneTimes(movingSecs: number): number[] {
+  return [
+    Math.round(movingSecs * Z1_FRAC),
+    Math.round(movingSecs * Z2_FRAC),
+    Math.round(movingSecs * Z3_FRAC),
+    Math.round(movingSecs * Z4_FRAC),
+    0,
+    0,
+    0,
+  ];
+}
+
+// One run's calendar offset (days before the anchor), type, load, and moving
+// time. The acute window is now-6..now-0; the chronic window is now-27..now-0.
+// The 7d block carries a NON-CONSTANT daily-load series with two rest days, so
+// monotony's sample stdev is > 0 (a constant series nulls monotony) while at
+// least three run days keep primary_sport_monotony populated. The TrailRun in
+// the acute window exercises a second `run`-family activity type.
+interface RunSpec {
+  daysAgo: number;
+  type: "Run" | "TrailRun";
+  load: number;
+  movingSecs: number;
+}
+
+const RUN_SPECS: RunSpec[] = [
+  // ── chronic-only block (now-27 .. now-7): populates the 28d load + 28d TID ──
+  { daysAgo: 27, type: "Run", load: 48, movingSecs: 3600 },
+  { daysAgo: 25, type: "Run", load: 72, movingSecs: 4200 },
+  { daysAgo: 23, type: "TrailRun", load: 90, movingSecs: 6000 },
+  { daysAgo: 21, type: "Run", load: 35, movingSecs: 2400 },
+  { daysAgo: 18, type: "Run", load: 55, movingSecs: 3600 },
+  { daysAgo: 16, type: "Run", load: 80, movingSecs: 4800 },
+  { daysAgo: 14, type: "Run", load: 42, movingSecs: 3000 },
+  { daysAgo: 11, type: "Run", load: 60, movingSecs: 3600 },
+  { daysAgo: 9, type: "Run", load: 50, movingSecs: 3000 },
+  // ── acute block (now-6 .. now-0): the 7d series [45,0,70,38,85,0,52] ──
+  { daysAgo: 6, type: "Run", load: 45, movingSecs: 3600 },
+  // now-5 rest (no activity)
+  { daysAgo: 4, type: "Run", load: 70, movingSecs: 4200 },
+  { daysAgo: 3, type: "Run", load: 38, movingSecs: 2400 },
+  { daysAgo: 2, type: "TrailRun", load: 85, movingSecs: 6000 },
+  // now-1 rest (no activity)
+  { daysAgo: 0, type: "Run", load: 52, movingSecs: 3600 },
+];
+
+interface BuiltFixture {
+  activities: Record<string, unknown>[];
+  wellness: Record<string, unknown>[];
+  ftp_history: unknown[];
+}
+
+function buildFixture(frozenNow: string): BuiltFixture {
+  const activities: Record<string, unknown>[] = [];
+  const wellnessDates = new Set<string>();
+
+  RUN_SPECS.forEach((spec, i) => {
+    const id = SYNTHETIC_ID_BASE + i;
+    const date = ymdMinus(frozenNow, spec.daysAgo);
+    wellnessDates.add(date);
+    activities.push({
+      id,
+      start_date_local: `${date}T07:00:00`,
+      type: spec.type,
+      name: spec.type === "TrailRun" ? "synthetic-trail-run" : "synthetic-run",
+      moving_time: spec.movingSecs,
+      elapsed_time: spec.movingSecs + 60,
+      icu_training_load: spec.load,
+      // Runners are commonly HR-zoned: flat seconds array indexed z1..z7. With
+      // no power fields present this drives the HR-fallback path (zone_basis ==
+      // "hr") in the distribution metrics.
+      icu_hr_zone_times: hrZoneTimes(spec.movingSecs),
+      // Present-but-null nullable fields the upstream reads per-activity via
+      // dict.get(): keeping them present (not absent) keeps the harness's
+      // contract tracker quiet without introducing power/HR-derived signal.
+      // `decoupling` (NOT `icu_hr_decoupling`) is the present key: the upstream
+      // reads `icu_hr_decoupling` first (allowlisted-optional, so its absence
+      // is fine) then falls back to `decoupling`, which must be present so the
+      // fallback read does not log a missing-key contract violation.
+      icu_zone_times: null,
+      decoupling: null,
+      icu_efficiency_factor: null,
+    });
+  });
+
+  // One wellness row per training day (stable RHR/HRV) so the recovery-index
+  // window has rows to read; the central claims do not depend on these, but a
+  // populated baseline keeps the recovery survivors non-degenerate too. No
+  // sportInfo / athlete / curve keys — this fixture targets the load + zone
+  // survivors only.
+  const wellness = [...wellnessDates]
+    .sort()
+    .map((date) => ({
+      id: date,
+      weight: null,
+      restingHR: 50,
+      hrv: 70,
+      sleepSecs: null,
+      sleepQuality: null,
+    }));
+
+  return { activities, wellness, ftp_history: [] };
+}
+
+// ─── Non-vacuity guard ─────────────────────────────────────────────────────
+// Recompute the central claims independently (plain TS arithmetic mirroring the
+// documented thresholds) and fail the build if vacuous:
+//   1. ACWR / strain inputs: chronic (28d) total load > 0 AND acute (7d) total
+//      load > 0.
+//   2. Monotony input: the 7d daily-load series is NON-CONSTANT (sample stdev
+//      > 0) with >= 1 active day — else monotony (and the strain cascade) null.
+//   3. Primary-sport monotony input: >= 3 active run days in the 7d window.
+//   4. Seiler-TID input: the 7d window carries populated, low-intensity-
+//      dominant zone time (total zone secs > 0, easy ratio in [0.70, 0.90]).
+function assertNonVacuous(fixture: BuiltFixture, frozenNow: string): void {
+  const fail = (msg: string): never => {
+    throw new Error(`[build-running-fixture] non-vacuity guard failed: ${msg}`);
+  };
+
+  const acuteDates = new Set<string>();
+  const chronicDates = new Set<string>();
+  for (let d = 0; d < 7; d++) acuteDates.add(ymdMinus(frozenNow, d));
+  for (let d = 0; d < 28; d++) chronicDates.add(ymdMinus(frozenNow, d));
+
+  // Daily load buckets within each window.
+  const acuteDaily = new Map<string, number>();
+  let chronicTotal = 0;
+  let acuteZoneTotal = 0;
+  let acuteEasy = 0;
+  let acuteRunActiveDays = 0;
+  const acuteRunDates = new Set<string>();
+
+  for (const act of fixture.activities) {
+    const date = String(act.start_date_local).slice(0, 10);
+    const load = Number(act.icu_training_load) || 0;
+    const type = String(act.type);
+    if (type !== "Run" && type !== "TrailRun") {
+      fail(`non-run activity type "${type}" leaked into the running-only fixture`);
+    }
+    if (chronicDates.has(date)) chronicTotal += load;
+    if (acuteDates.has(date)) {
+      acuteDaily.set(date, (acuteDaily.get(date) ?? 0) + load);
+      if (load > 0) acuteRunDates.add(date);
+      const z = act.icu_hr_zone_times;
+      if (Array.isArray(z)) {
+        const secs = z.map((v) => (typeof v === "number" ? v : 0));
+        const total = secs.reduce((a, b) => a + b, 0);
+        acuteZoneTotal += total;
+        // Seiler easy = Z1 + Z2 (first two bins).
+        acuteEasy += (secs[0] ?? 0) + (secs[1] ?? 0);
+      }
+    }
+  }
+  acuteRunActiveDays = acuteRunDates.size;
+
+  // 1. Acute + chronic load.
+  if (chronicTotal <= 0) fail(`28d chronic total load is ${chronicTotal} (need > 0 for ACWR)`);
+  const acuteSeries = [...acuteDates].sort().map((d) => acuteDaily.get(d) ?? 0);
+  const acuteTotal = acuteSeries.reduce((a, b) => a + b, 0);
+  if (acuteTotal <= 0) fail(`7d acute total load is ${acuteTotal} (need > 0 for strain)`);
+
+  // 2. Non-constant 7d series (sample stdev > 0).
+  const n = acuteSeries.length;
+  const mean = acuteTotal / n;
+  const variance = acuteSeries.reduce((s, v) => s + (v - mean) ** 2, 0) / (n - 1);
+  if (!(variance > 0)) {
+    fail(`7d daily-load series is constant (stdev 0) → monotony would be null: [${acuteSeries}]`);
+  }
+
+  // 3. Primary-sport (run) active days.
+  if (acuteRunActiveDays < 3) {
+    fail(`only ${acuteRunActiveDays} active run day(s) in the 7d window (need >= 3 for primary_sport_monotony)`);
+  }
+
+  // 4. Populated, low-intensity-dominant zone distribution.
+  if (acuteZoneTotal <= 0) {
+    fail(`7d zone-time total is ${acuteZoneTotal} → Seiler TID would be degenerate`);
+  }
+  const easyRatio = acuteEasy / acuteZoneTotal;
+  if (!(easyRatio >= 0.7 && easyRatio <= 0.9)) {
+    fail(`7d easy_time_ratio is ${easyRatio.toFixed(3)} (expected low-intensity-dominant ~0.80, band [0.70,0.90])`);
+  }
+
+  // Watts-fence self-check: no power field may appear anywhere in an activity.
+  const POWER_KEYS = new Set([
+    "average_watts",
+    "icu_weighted_avg_watts",
+    "watts",
+    "icu_zone_times_watts",
+    "icu_pm_p_max",
+  ]);
+  for (const act of fixture.activities) {
+    for (const k of Object.keys(act)) {
+      if (POWER_KEYS.has(k)) fail(`power field "${k}" present on a running-only activity`);
+    }
+  }
+}
+
+function main(argv: string[]): void {
+  const args = parseArgs(argv);
+  const fixture = buildFixture(args.frozenNow);
+  assertNonVacuous(fixture, args.frozenNow);
+
+  const json = `${JSON.stringify(fixture, null, 2)}\n`;
+  writeFileSync(args.out, json);
+  const hash = createHash("sha256").update(json).digest("hex");
+  writeFileSync(`${args.out}.sha256`, `${hash}  ${basename(args.out)}\n`);
+  // eslint-disable-next-line no-console
+  console.error(`Wrote ${args.out} (${json.length} bytes), checksum ${args.out}.sha256`);
+}
+
+const isCli =
+  typeof process !== "undefined" &&
+  process.argv[1] !== undefined &&
+  import.meta.url === `file://${process.argv[1]}`;
+
+if (isCli) {
+  try {
+    main(process.argv.slice(2));
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error((err as Error).message);
+    process.exit(1);
+  }
+}
+
+export { buildFixture, ymdMinus };

--- a/tools/check-fixture-privacy.ts
+++ b/tools/check-fixture-privacy.ts
@@ -87,6 +87,7 @@ export const SYNTHETIC_FIXTURE_ALLOWLIST: ReadonlySet<string> = new Set([
   "populated-benchmark-and-consistency.json",
   "rest-week-with-baseline.json",
   "dfa-equipped.json",
+  "running-only.json",
   "post-break-resume.json",
   "zero-activities.json",
 ]);

--- a/tools/harness-fixtures.ts
+++ b/tools/harness-fixtures.ts
@@ -109,6 +109,12 @@ export const HARNESS_FIXTURES: HarnessFixtureConfig[] = [
     description:
       "Populated-branch coverage for capability.dfa_a1_profile. Fully synthetic (no sanitizer, no real data): 7 Ride activities (ids 90201-90207) on 2026-05-28..06-03, each carrying a per-second streams record (dfa_a1/artifacts/heartrate/watts, 1800 samples) keyed by String(id) in the top-level `streams` key. Every session is 3×600s segments at dfa_a1 1.0 / 0.75 / 0.5 with artifacts 0 — so valid_secs=1800, valid_pct=100, and each session holds 600s of dwell in BOTH the LT1 band [0.95,1.05] and the LT2 band [0.45,0.55] with co-present heartrate+watts. The 7 qualifying sessions push crossing_n to 7 (>=6), so the cycling trailing window reports confidence=high with non-null lt1_estimate + lt2_estimate. Built by tools/build-dfa-fixture.ts (synthetic stream blob + non-vacuity guard recomputing the sufficiency + crossing-band thresholds). Anchor 2026-06-04 sits one day after the last ride.",
   },
+  {
+    slug: "running-only",
+    frozenNow: "1998-06-04T12:00:00",
+    description:
+      "Pure-pace coverage, fully-synthetic Run/TrailRun bundle (ids 90301+) with non-zero load + realistic low-intensity-dominant zone-time data so run Load flows through ACWR/monotony/strain AND the Seiler-TID/zone-distribution survivors compute non-degenerately; carries NO watts/power fields; built by tools/build-running-fixture.ts, synthetic, ids 90301+.",
+  },
 ];
 
 /**


### PR DESCRIPTION
## What

Final wave-1 work item: a fully-synthetic **running-only golden fixture** that exercises the running analyze path end-to-end against the parity gate, plus its deterministic builder, the three harness registrations, the oracle-generated per-metric snapshot tree, and a run-realism + power-fence unit test.

- **Fixture** (`packages/core/tests/fixtures/golden/running-only.json`) — 14 `Run`/`TrailRun` activities over the 28-day chronic window (ids `90301`–`90314`, anchor `1998-06-04`), each carrying non-zero `icu_training_load` and per-activity `icu_hr_zone_times`, and **no watts/power fields at all**. The acute 7-day daily-load series has two rest days and five active days, so monotony is non-degenerate. Zone distribution is low-intensity-dominant (~80% easy / ~15% hard), which drives the HR-fallback compute path (`zone_basis == "hr"`).
- **Builder** (`tools/build-running-fixture.ts`) — closed-form, deterministic (no `Math.random`, no wall-clock; every date flows from a frozen anchor via a UTC calendar helper). Models the existing synthetic-fixture builder pattern: reserved id base `90301`, non-vacuity guard, `.sha256` sidecar, CLI guard, `buildFixture` export. Two runs produce a byte-identical fixture.
- **Three registrations** — harness fixture list, the fixture-privacy synthetic allowlist, and the checksum byte-guard test.
- **Oracle snapshot tree** (`snapshots/running-only/`, 63 files) — the same uniform per-metric file set as every other fixture dir. The 9 power-family snapshots (`eftp`, `w_prime`, `w_prime_kj`, `p_max`, `power_model_source`, `vo2max`, `capability.power_curve_delta/hr_curve_delta/dfa_a1_profile`) are **present and null-valued**, so `check-parity --all` enumerates them without an ENOENT crash.
- **Unit test** — loads the golden fixture through the production input mapper and asserts (a) all 9 power-family keys are omitted under `omitPowerFamily: true`, and (b) `seiler_tid_7d` / `zone_distribution_7d` (`zone_basis "hr"`) + `easy_time_ratio` (~0.80) populate non-degenerately.

## Why null-valued power snapshots, not absent files

`check-parity --all` has no missing-file guard — an absent per-metric snapshot is an ENOENT that aborts the whole run. The oracle therefore emits the full uniform metric set for every fixture, power family included; for a pace-only bundle those nine files are simply null-valued. Keeping the file set uniform is what lets the gate stay a clean key-union walk.

## Parity

`check-parity --all` is now **602** (43 registered metrics × 14 fixtures), all green, exit 0. **No existing snapshot or golden-fixture bytes changed** — the only modified snapshot file is `manifest.json`, an additive append of `running-only` to its sorted fixtures list. The running-only fixture contributes 43 OK (including the 9 null-valued power-family files).

## Test plan

- `pnpm -r build` — clean across all packages
- `pnpm check:fixture-privacy` — golden fixtures clean; `running-only.json` on the synthetic allowlist, ids below the real id shape, pre-cutoff anchor
- `pnpm check-parity --all` — 602 OK, 0 FAIL, 0 ENOENT/error
- `pnpm test` — full suite green (2625 passed / 5 skipped), incl. the new run-realism + power-fence describe block and the running-only checksum byte-guard
- `pnpm check` — build, types, lint, trademark, fixture-privacy, registry-isolation all clean

Stacked on #249 (base = `feature/reference-latest-schema-v2`). Merge order: #246 → #248 → #249 → this, retargeting each to `main` after the one below it merges.
