### PR TITLE
refactor(core): dedup wave-1 provenance helpers and extract a shared fixture-builder util

### DIFF
--- a/packages/core/src/reference/schemas/latest.ts
+++ b/packages/core/src/reference/schemas/latest.ts
@@ -79,3 +79,11 @@ export const LatestJsonSchema = z
   .strict();
 
 export type LatestJson = z.infer<typeof LatestJsonSchema>;
+
+/**
+ * Single source of truth for the emit-time provenance tag's shape. Derived from
+ * the schema (the `derived_metrics_meta` field minus its optionality) so the
+ * producer, the `FetchedReference` envelope, and any test all reference one type
+ * instead of re-declaring the literal three times.
+ */
+export type DerivedMetricsMeta = NonNullable<LatestJson["derived_metrics_meta"]>;

--- a/packages/core/src/reference/sport-adapter-dispatcher.ts
+++ b/packages/core/src/reference/sport-adapter-dispatcher.ts
@@ -15,7 +15,7 @@ export function adapterIdentity(adapter: ReferenceSportAdapter): string {
  * in as its own family — per the SPORT_FAMILIES convention that each caller owns
  * its default rather than folding one into the table.
  */
-function familyOf<F extends string | undefined>(type: string, fallback: F): string | F {
+export function familyOf<F extends string | undefined>(type: string, fallback: F): string | F {
   return Object.hasOwn(SPORT_FAMILIES, type) ? SPORT_FAMILIES[type] : fallback;
 }
 

--- a/packages/core/src/reference/sync/fetch-reference-data.ts
+++ b/packages/core/src/reference/sync/fetch-reference-data.ts
@@ -7,35 +7,42 @@ import { buildMetricInput } from "./fixture-bridge.js";
 import { computeDerivedMetrics } from "./compute-derived-metrics.js";
 import {
   runAdaptersForActivities,
+  familyOf,
   type AdapterRun,
 } from "../sport-adapter-dispatcher.js";
 import type { ReferenceSportAdapter } from "../sport-adapter.js";
 import type { IntervalsActivityType } from "../../sport.js";
-import { SPORT_FAMILIES } from "../metrics/sport-families.js";
-
-interface DerivedMetricsMeta {
-  readonly sportFamily: string;
-  readonly basis: "power" | "pace" | "hr";
-  readonly anchorType: "critical-speed" | "ftp";
-}
+import type { DerivedMetricsMeta } from "../schemas/latest.js";
 
 /**
- * Derive the emit-time provenance tag from the covering adapters. Prefers a
- * power-basis adapter when one is present so a mixed bundle (a duathlete's
- * Ride+Run) tags as its kept power family, matching the omission decision;
- * otherwise the first covering adapter wins. Returns `undefined` for an
- * empty-coverage bundle (no adapter to attribute), leaving the optional tag off.
+ * Resolve, in a single scan of `runs`, both the watts-fence decision and the
+ * emit-time provenance tag from one representative covering adapter:
+ *
+ *   - The representative is the power-basis covering adapter when one is present
+ *     (so a mixed bundle — a duathlete's Ride+Run — keeps its power family and
+ *     tags as cycling/power), else the first covering adapter.
+ *   - `omitPowerFamily` is a positive pace-sport assertion: at least one
+ *     activity is covered AND the representative is not power-basis. An
+ *     empty-coverage bundle keeps the full family (no positive signal).
+ *   - `meta` is `undefined` for an empty-coverage bundle (no adapter to
+ *     attribute); otherwise it carries the representative's family + basis +
+ *     anchor. The family falls back to `"other"` for an unmapped or missing
+ *     first activity type.
  */
-function deriveMeta(runs: readonly AdapterRun[]): DerivedMetricsMeta | undefined {
-  if (runs.length === 0) return undefined;
+export function composeProvenance(runs: readonly AdapterRun[]): {
+  omitPowerFamily: boolean;
+  meta: DerivedMetricsMeta | undefined;
+} {
+  if (runs.length === 0) return { omitPowerFamily: false, meta: undefined };
   const covering =
     runs.find((r) => r.adapter.zoneBasis === "power")?.adapter ?? runs[0].adapter;
+  const omitPowerFamily = covering.zoneBasis !== "power";
   const firstType = covering.activityTypes[0];
-  const sportFamily =
-    firstType !== undefined && Object.hasOwn(SPORT_FAMILIES, firstType)
-      ? SPORT_FAMILIES[firstType]
-      : "other";
-  return { sportFamily, basis: covering.zoneBasis, anchorType: covering.anchorType };
+  const sportFamily = firstType !== undefined ? familyOf(firstType, "other") : "other";
+  return {
+    omitPowerFamily,
+    meta: { sportFamily, basis: covering.zoneBasis, anchorType: covering.anchorType },
+  };
 }
 
 /**
@@ -83,16 +90,11 @@ async function fetchOnce(
     sportTypes,
     live.bundle.activities,
   );
-  // Omit the power family only on a positive pace-sport assertion: at least one
-  // activity is covered AND no covering adapter is power-basis. An
-  // empty-coverage bundle keeps the full family (no positive signal).
-  const coveredPowerBasis = runs.some((r) => r.adapter.zoneBasis === "power");
-  const omitPowerFamily = runs.length > 0 && !coveredPowerBasis;
+  const { omitPowerFamily, meta } = composeProvenance(runs);
   const derivedMetrics = computeDerivedMetrics(
     buildMetricInput(live.bundle, live.frozenNow),
     { omitPowerFamily },
   );
-  const meta = deriveMeta(runs);
 
   return {
     latest: {

--- a/packages/core/src/reference/sync/run-sync.ts
+++ b/packages/core/src/reference/sync/run-sync.ts
@@ -6,7 +6,7 @@ import {
   SYNC_OPERATION_TIMEOUT_MS,
 } from "../freshness.js";
 import { atomicWriteJson } from "../../io/atomic-write-json.js";
-import { LATEST_SCHEMA_VERSION } from "../schemas/latest.js";
+import { LATEST_SCHEMA_VERSION, type DerivedMetricsMeta } from "../schemas/latest.js";
 import { HISTORY_SCHEMA_VERSION } from "../schemas/history.js";
 import { INTERVALS_SCHEMA_VERSION } from "../schemas/intervals.js";
 import { ROUTES_SCHEMA_VERSION } from "../schemas/routes.js";
@@ -77,11 +77,7 @@ export interface FetchedReference {
     readonly derived_metrics: unknown;
     /** Emit-time provenance tag — a sibling of `derived_metrics`, never inside
      *  it. Optional: an empty-coverage bundle attaches no tag. */
-    readonly derived_metrics_meta?: {
-      readonly sportFamily: string;
-      readonly basis: "power" | "pace" | "hr";
-      readonly anchorType: "critical-speed" | "ftp";
-    };
+    readonly derived_metrics_meta?: DerivedMetricsMeta;
     readonly recent_activities: readonly unknown[];
     readonly planned_workouts: readonly unknown[];
     readonly wellness_data: unknown;

--- a/packages/core/tests/reference-compute-derived-metrics.test.ts
+++ b/packages/core/tests/reference-compute-derived-metrics.test.ts
@@ -21,6 +21,7 @@ import {
   type ReferenceBundle,
 } from "../src/reference/sync/fixture-bridge.js";
 import { runAdaptersForActivities } from "../src/reference/sport-adapter-dispatcher.js";
+import { composeProvenance } from "../src/reference/sync/fetch-reference-data.js";
 import type { ReferenceSportAdapter } from "../src/reference/sport-adapter.js";
 import type { IntervalsActivityType } from "../src/sport.js";
 import { GoldenFixtureSchema, loadFixture } from "./helpers/load-fixture.js";
@@ -157,10 +158,10 @@ function inputFor(activities: readonly TestActivity[]): MetricInput {
 }
 
 /**
- * Mirror the production `fetchOnce` predicate + emit-time tag without exporting
- * the private function: dispatch the activities, derive `omitPowerFamily`, run
- * the registry, and attach the sibling provenance tag exactly as the producer
- * does. The tag is layered OUTSIDE the derived map.
+ * Drive the production provenance helper end-to-end: dispatch the activities,
+ * derive `omitPowerFamily` + the sibling tag via `composeProvenance`, then run
+ * the registry under that fence. The tag is layered OUTSIDE the derived map,
+ * exactly as the producer does.
  */
 function composeLikeFetchOnce(
   adapters: readonly ReferenceSportAdapter[],
@@ -172,21 +173,9 @@ function composeLikeFetchOnce(
   omitPowerFamily: boolean;
 } {
   const runs = runAdaptersForActivities(adapters, sportTypes, activities as unknown as readonly Activity[]);
-  const coveredPowerBasis = runs.some((r) => r.adapter.zoneBasis === "power");
-  const omitPowerFamily = runs.length > 0 && !coveredPowerBasis;
+  const { omitPowerFamily, meta } = composeProvenance(runs);
   const derived_metrics = computeDerivedMetrics(inputFor(activities), { omitPowerFamily });
-  let derived_metrics_meta: { sportFamily: string; basis: string; anchorType: string } | undefined;
-  if (runs.length > 0) {
-    const covering =
-      runs.find((r) => r.adapter.zoneBasis === "power")?.adapter ?? runs[0].adapter;
-    const families: Record<string, string> = { Ride: "cycling", VirtualRide: "cycling", Run: "run", TrailRun: "run" };
-    derived_metrics_meta = {
-      sportFamily: families[covering.activityTypes[0]] ?? "other",
-      basis: covering.zoneBasis,
-      anchorType: covering.anchorType,
-    };
-  }
-  return { derived_metrics, derived_metrics_meta, omitPowerFamily };
+  return { derived_metrics, derived_metrics_meta: meta, omitPowerFamily };
 }
 
 describe("computeDerivedMetrics power-family omission", () => {

--- a/packages/core/tests/reference-live-sync-integration.test.ts
+++ b/packages/core/tests/reference-live-sync-integration.test.ts
@@ -14,13 +14,13 @@ import { fetchLiveBundle, type BundleFetchClient } from "../src/reference/sync/f
 import { buildMetricInput } from "../src/reference/sync/fixture-bridge.js";
 import { computeDerivedMetrics } from "../src/reference/sync/compute-derived-metrics.js";
 import { runAdaptersForActivities } from "../src/reference/sport-adapter-dispatcher.js";
+import { composeProvenance } from "../src/reference/sync/fetch-reference-data.js";
 import type { ReferenceSportAdapter } from "../src/reference/sport-adapter.js";
 import type { IntervalsActivityType } from "../src/sport.js";
 import type { FetchedReference } from "../src/reference/sync/run-sync.js";
 import { gateLatestJson } from "../src/reference/validation/sync-gate.js";
 import { LatestJsonSchema, LATEST_SCHEMA_VERSION, type LatestJson } from "../src/reference/schemas/latest.js";
 import { METRIC_REGISTRY } from "../src/reference/metrics/registry.js";
-import { SPORT_FAMILIES } from "../src/reference/metrics/sport-families.js";
 import { safeReadJson } from "../src/io/safe-read-json.js";
 
 const NOW = new Date("2026-06-09T12:00:00.000Z");
@@ -76,16 +76,13 @@ function fakeClient(): BundleFetchClient {
   };
 }
 
-type DerivedMetricsMeta = NonNullable<LatestJson["derived_metrics_meta"]>;
-
-/** Compose exactly as the production `fetchOnce` does. */
+/** Compose exactly as the production `fetchOnce` does — through the shared
+ *  `composeProvenance` helper, so the test exercises the production logic. */
 async function composeFetched(): Promise<FetchedReference> {
   const live = await fetchLiveBundle({ client: fakeClient(), signal: new AbortController().signal, now: NOW, throttleMs: 0 });
   const runs = runAdaptersForActivities([CYCLING_ADAPTER], SPORT_TYPES, live.bundle.activities);
-  const coveredPowerBasis = runs.some((r) => r.adapter.zoneBasis === "power");
-  const omitPowerFamily = runs.length > 0 && !coveredPowerBasis;
+  const { omitPowerFamily, meta } = composeProvenance(runs);
   const derived_metrics = computeDerivedMetrics(buildMetricInput(live.bundle, live.frozenNow), { omitPowerFamily });
-  const meta = deriveMeta(runs);
   return {
     latest: {
       athlete_profile: live.athleteProfile,
@@ -101,24 +98,6 @@ async function composeFetched(): Promise<FetchedReference> {
     routes: { routes: [] },
     ftp_history: { entries: [] },
   };
-}
-
-/**
- * Local reconstruction of `fetchOnce`'s private `deriveMeta`: pick the covering
- * adapter (power-basis preferred), then attribute its sport family + basis +
- * anchor. Returns undefined for empty coverage so the optional tag stays off.
- */
-function deriveMeta(
-  runs: ReturnType<typeof runAdaptersForActivities>,
-): DerivedMetricsMeta | undefined {
-  if (runs.length === 0) return undefined;
-  const covering = runs.find((r) => r.adapter.zoneBasis === "power")?.adapter ?? runs[0].adapter;
-  const firstType = covering.activityTypes[0];
-  const sportFamily =
-    firstType !== undefined && Object.hasOwn(SPORT_FAMILIES, firstType)
-      ? SPORT_FAMILIES[firstType]
-      : "other";
-  return { sportFamily, basis: covering.zoneBasis, anchorType: covering.anchorType };
 }
 
 describe("live-data bridge integration", () => {

--- a/tools/build-dfa-fixture.ts
+++ b/tools/build-dfa-fixture.ts
@@ -25,10 +25,15 @@
 // Usage (operator, dev-time):
 //   pnpm exec tsx tools/build-dfa-fixture.ts [--frozen-now 1998-06-04T12:00:00] [--out <path>]
 
-import { createHash } from "node:crypto";
-import { writeFileSync } from "node:fs";
-import { basename, dirname, resolve } from "node:path";
+import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+
+import {
+  parseFixtureArgs,
+  runFixtureCli,
+  writeFixtureWithChecksum,
+  ymdMinus,
+} from "./fixture-builder-util.js";
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const DEFAULT_OUT = resolve(REPO_ROOT, "packages/core/tests/fixtures/golden/dfa-equipped.json");
@@ -66,45 +71,6 @@ const SESSION_SECS = SEGMENT_SECS * 3;
 const DFA_LT1_SEGMENT = 1.0;
 const DFA_MID_SEGMENT = 0.75;
 const DFA_LT2_SEGMENT = 0.5;
-
-interface Args {
-  frozenNow: string;
-  out: string;
-}
-
-function parseArgs(argv: string[]): Args {
-  const out: Args = { frozenNow: DEFAULT_FROZEN_NOW, out: DEFAULT_OUT };
-  for (let i = 0; i < argv.length; i++) {
-    const arg = argv[i];
-    const next = (): string => {
-      const v = argv[i + 1];
-      if (v === undefined || v.startsWith("--")) {
-        throw new Error(`flag ${arg} requires a value`);
-      }
-      i++;
-      return v;
-    };
-    switch (arg) {
-      case "--frozen-now":
-        out.frozenNow = next();
-        break;
-      case "--out":
-        out.out = resolve(next());
-        break;
-      default:
-        throw new Error(`unknown flag: ${arg}`);
-    }
-  }
-  return out;
-}
-
-// Python-equivalent calendar math: parse the anchor as a UTC date, subtract
-// whole days, format %Y-%m-%d. Matches `datetime - timedelta(days=n)` exactly.
-function ymdMinus(frozenNow: string, days: number): string {
-  const base = new Date(`${frozenNow.slice(0, 10)}T00:00:00Z`);
-  base.setUTCDate(base.getUTCDate() - days);
-  return base.toISOString().slice(0, 10);
-}
 
 interface StreamChannels {
   dfa_a1: number[];
@@ -278,31 +244,12 @@ function assertNonVacuous(fixture: BuiltFixture): void {
 }
 
 function main(argv: string[]): void {
-  const args = parseArgs(argv);
+  const args = parseFixtureArgs(argv, { frozenNow: DEFAULT_FROZEN_NOW, out: DEFAULT_OUT });
   const fixture = buildFixture(args.frozenNow);
   assertNonVacuous(fixture);
-
-  const json = `${JSON.stringify(fixture, null, 2)}\n`;
-  writeFileSync(args.out, json);
-  const hash = createHash("sha256").update(json).digest("hex");
-  writeFileSync(`${args.out}.sha256`, `${hash}  ${basename(args.out)}\n`);
-  // eslint-disable-next-line no-console
-  console.error(`Wrote ${args.out} (${json.length} bytes), checksum ${args.out}.sha256`);
+  writeFixtureWithChecksum(args.out, fixture);
 }
 
-const isCli =
-  typeof process !== "undefined" &&
-  process.argv[1] !== undefined &&
-  import.meta.url === `file://${process.argv[1]}`;
-
-if (isCli) {
-  try {
-    main(process.argv.slice(2));
-  } catch (err) {
-    // eslint-disable-next-line no-console
-    console.error((err as Error).message);
-    process.exit(1);
-  }
-}
+runFixtureCli(import.meta.url, main);
 
 export { buildFixture, ymdMinus };

--- a/tools/build-running-fixture.ts
+++ b/tools/build-running-fixture.ts
@@ -26,10 +26,15 @@
 // Usage (operator, dev-time):
 //   pnpm exec tsx tools/build-running-fixture.ts [--frozen-now 1998-06-04T12:00:00] [--out <path>]
 
-import { createHash } from "node:crypto";
-import { writeFileSync } from "node:fs";
-import { basename, dirname, resolve } from "node:path";
+import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+
+import {
+  parseFixtureArgs,
+  runFixtureCli,
+  writeFixtureWithChecksum,
+  ymdMinus,
+} from "./fixture-builder-util.js";
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const DEFAULT_OUT = resolve(REPO_ROOT, "packages/core/tests/fixtures/golden/running-only.json");
@@ -54,45 +59,6 @@ const Z1_FRAC = 0.5;
 const Z2_FRAC = 0.3;
 const Z3_FRAC = 0.05;
 const Z4_FRAC = 0.15;
-
-interface Args {
-  frozenNow: string;
-  out: string;
-}
-
-function parseArgs(argv: string[]): Args {
-  const out: Args = { frozenNow: DEFAULT_FROZEN_NOW, out: DEFAULT_OUT };
-  for (let i = 0; i < argv.length; i++) {
-    const arg = argv[i];
-    const next = (): string => {
-      const v = argv[i + 1];
-      if (v === undefined || v.startsWith("--")) {
-        throw new Error(`flag ${arg} requires a value`);
-      }
-      i++;
-      return v;
-    };
-    switch (arg) {
-      case "--frozen-now":
-        out.frozenNow = next();
-        break;
-      case "--out":
-        out.out = resolve(next());
-        break;
-      default:
-        throw new Error(`unknown flag: ${arg}`);
-    }
-  }
-  return out;
-}
-
-// Python-equivalent calendar math: parse the anchor as a UTC date, subtract
-// whole days, format %Y-%m-%d. Matches `datetime - timedelta(days=n)` exactly.
-function ymdMinus(frozenNow: string, days: number): string {
-  const base = new Date(`${frozenNow.slice(0, 10)}T00:00:00Z`);
-  base.setUTCDate(base.getUTCDate() - days);
-  return base.toISOString().slice(0, 10);
-}
 
 // Flat HR-zone seconds array [z1,z2,z3,z4,z5,z6,z7] for a run of `movingSecs`,
 // split by the fixed low-intensity-dominant fractions. The trailing three hard
@@ -298,31 +264,12 @@ function assertNonVacuous(fixture: BuiltFixture, frozenNow: string): void {
 }
 
 function main(argv: string[]): void {
-  const args = parseArgs(argv);
+  const args = parseFixtureArgs(argv, { frozenNow: DEFAULT_FROZEN_NOW, out: DEFAULT_OUT });
   const fixture = buildFixture(args.frozenNow);
   assertNonVacuous(fixture, args.frozenNow);
-
-  const json = `${JSON.stringify(fixture, null, 2)}\n`;
-  writeFileSync(args.out, json);
-  const hash = createHash("sha256").update(json).digest("hex");
-  writeFileSync(`${args.out}.sha256`, `${hash}  ${basename(args.out)}\n`);
-  // eslint-disable-next-line no-console
-  console.error(`Wrote ${args.out} (${json.length} bytes), checksum ${args.out}.sha256`);
+  writeFixtureWithChecksum(args.out, fixture);
 }
 
-const isCli =
-  typeof process !== "undefined" &&
-  process.argv[1] !== undefined &&
-  import.meta.url === `file://${process.argv[1]}`;
-
-if (isCli) {
-  try {
-    main(process.argv.slice(2));
-  } catch (err) {
-    // eslint-disable-next-line no-console
-    console.error((err as Error).message);
-    process.exit(1);
-  }
-}
+runFixtureCli(import.meta.url, main);
 
 export { buildFixture, ymdMinus };

--- a/tools/fixture-builder-util.ts
+++ b/tools/fixture-builder-util.ts
@@ -1,0 +1,95 @@
+// Shared scaffolding for the fully-synthetic golden-fixture builders. The
+// blocks here are byte-identical across the builders that import them; folding
+// them into one place keeps the calendar math, CLI plumbing, and checksum-write
+// in lockstep. Every helper is pure / deterministic — no Math.random, no
+// Date.now — so a fixture regenerated through these is reproducible byte for
+// byte from its frozen anchor alone.
+
+import { createHash } from "node:crypto";
+import { writeFileSync } from "node:fs";
+import { basename, resolve } from "node:path";
+
+/** The two-flag CLI surface every synthetic builder shares. */
+export interface FixtureArgs {
+  frozenNow: string;
+  out: string;
+}
+
+/**
+ * Parse the shared `--frozen-now` / `--out` flags, defaulting from the caller's
+ * own anchor + output path. `--out` is resolved against cwd; an unknown flag or
+ * a flag missing its value throws.
+ */
+export function parseFixtureArgs(
+  argv: string[],
+  defaults: FixtureArgs,
+): FixtureArgs {
+  const out: FixtureArgs = { frozenNow: defaults.frozenNow, out: defaults.out };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    const next = (): string => {
+      const v = argv[i + 1];
+      if (v === undefined || v.startsWith("--")) {
+        throw new Error(`flag ${arg} requires a value`);
+      }
+      i++;
+      return v;
+    };
+    switch (arg) {
+      case "--frozen-now":
+        out.frozenNow = next();
+        break;
+      case "--out":
+        out.out = resolve(next());
+        break;
+      default:
+        throw new Error(`unknown flag: ${arg}`);
+    }
+  }
+  return out;
+}
+
+/**
+ * Python-equivalent calendar math: parse the anchor's date prefix as a UTC date,
+ * subtract whole days, format `%Y-%m-%d`. Matches `datetime - timedelta(days=n)`
+ * exactly for any anchor (no JS local-time drift).
+ */
+export function ymdMinus(frozenNow: string, days: number): string {
+  const base = new Date(`${frozenNow.slice(0, 10)}T00:00:00Z`);
+  base.setUTCDate(base.getUTCDate() - days);
+  return base.toISOString().slice(0, 10);
+}
+
+/**
+ * Serialize a fixture to pretty JSON with a trailing newline, write it to `out`,
+ * and write the sha256 integrity sidecar (`<hex>  <basename>\n`) alongside it.
+ * Logs the byte count + checksum path to stderr.
+ */
+export function writeFixtureWithChecksum(out: string, fixture: unknown): void {
+  const json = `${JSON.stringify(fixture, null, 2)}\n`;
+  writeFileSync(out, json);
+  const hash = createHash("sha256").update(json).digest("hex");
+  writeFileSync(`${out}.sha256`, `${hash}  ${basename(out)}\n`);
+  // eslint-disable-next-line no-console
+  console.error(`Wrote ${out} (${json.length} bytes), checksum ${out}.sha256`);
+}
+
+/**
+ * Run `main` only when this module is the process entry point (`tsx tools/...`),
+ * not when it is imported by a test. On a thrown error, print the message and
+ * exit 1.
+ */
+export function runFixtureCli(importMetaUrl: string, main: (argv: string[]) => void): void {
+  const isCli =
+    typeof process !== "undefined" &&
+    process.argv[1] !== undefined &&
+    importMetaUrl === `file://${process.argv[1]}`;
+  if (!isCli) return;
+  try {
+    main(process.argv.slice(2));
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error((err as Error).message);
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
## What

`/simplify` quality cleanup over the merged running-analyze wave-1 stack (#246/#248/#249/#251). Pure, behavior-preserving deduplication — no runtime output, metric value, or generated fixture byte changes.

Four reviewers (reuse / simplification / efficiency / altitude) ran fresh-context over the wave-1 diff; the surviving findings were adjudicated and applied, then a fresh read-only verify confirmed each landed correctly.

## Fixes applied

- **One provenance helper, one home.** `fetchOnce` derived `omitPowerFamily` and the `derived_metrics_meta` tag in separate steps that scanned `runs` more than once, and inlined the sport-family lookup. These collapse into a single exported pure `composeProvenance(runs) → { omitPowerFamily, meta }` that resolves the covering adapter once (power-basis preferred, else first) and reuses the dispatcher's `familyOf` (now exported) with the same `'other'` fallback and undefined-guard. Semantically identical across empty / pure-pace / pure-power / mixed Ride+Run inputs.
- **Tests exercise production, not a copy.** Both `reference-live-sync-integration.test.ts` and `reference-compute-derived-metrics.test.ts` had hand-copied reconstructions of the private provenance logic (including a 4-entry inline `Ride→cycling` family map) — so production could drift without failing them. They now import `composeProvenance`; the local copies and the inline map are deleted.
- **One `DerivedMetricsMeta` type.** The `{ sportFamily, basis, anchorType }` shape was declared three times (a local interface, an inline `run-sync.ts` literal, and the zod schema). A single `export type DerivedMetricsMeta = NonNullable<LatestJson['derived_metrics_meta']>` in `schemas/latest.ts` is now the source of truth; the other two sites import it. Type-only — the schema runtime shape and the top-level-sibling placement are unchanged.
- **Shared fixture-builder util.** `build-running-fixture.ts` had introduced a third byte-identical copy of the frozen-anchor calendar helper, the CLI arg parser, the sha256-sidecar writer, and the CLI-entry guard. These move to `tools/fixture-builder-util.ts`; the two fully-synthetic builders (`build-dfa-fixture.ts`, `build-running-fixture.ts`) import them.

## Deliberately skipped

- **Did not** replace the enumerated `DerivedMetricsSchema` in `latest.ts` with `z.record` — that enumeration is the intentional contract #249 just established, and the swap would change the inferred type.
- **Did not** relocate/generalize `readLatestVersioned` — its placement is a deliberate anti-bypass seam, and a generic-across-all-cache-schemas version is speculative infra for readers that don't exist yet.
- **`build-curve-fixture.ts` / `build-capability-fixture.ts` not migrated** onto the shared util: their fixtures need external raw inputs that aren't available here, so byte-identity can't be proven. Their blocks are byte-identical and remain safe future candidates — left in place rather than migrated blind (correctness over completeness).

## Test plan

- `pnpm -r build` — clean
- `pnpm check` — types (0 errors), lint, trademarks, fixture-privacy, registry-isolation all clean
- `pnpm check-parity --all` — **602** OK, exit 0 (unchanged)
- `pnpm test` — full suite green (2625 passed / 5 skipped)
- Builder byte-identity — the refactored `dfa` + `running` builders regenerate their fixtures byte-identically to the pre-refactor output (verified at the same frozen anchor); no committed fixture/snapshot byte changes appear in the diff.
