### PR TITLE
refactor(core): stamp a forward-compatible schema_version on sync-history outcome lines

### DIFF
--- a/packages/core/src/reference/sync/run-sync.ts
+++ b/packages/core/src/reference/sync/run-sync.ts
@@ -18,7 +18,11 @@ import { ErrorStateSchema } from "../schemas/error-state.js";
 import type { ErrorPhase, ErrorCaller, ErrorState } from "../schemas/error-state.js";
 import { gateLatestJson } from "../validation/sync-gate.js";
 import { writeErrorState, clearErrorState } from "./error-state-writer.js";
-import { createSyncHistoryWriter, type SyncOutcomeLine } from "./sync-history.js";
+import {
+  createSyncHistoryWriter,
+  SYNC_HISTORY_SCHEMA_VERSION,
+  type SyncOutcomeLine,
+} from "./sync-history.js";
 import type { AsyncMutex } from "../../concurrency/mutex.js";
 import type { Cooldown } from "../../concurrency/cooldown.js";
 import type { Clock } from "../../concurrency/clock.js";
@@ -255,6 +259,7 @@ export function createRunSync(
     const emit = (kind: SyncResult["kind"], reason: string | undefined): void => {
       try {
         syncHistory({
+          schema_version: SYNC_HISTORY_SCHEMA_VERSION,
           ts: now().toISOString(),
           caller: opts.caller ?? "scheduled",
           kind,

--- a/packages/core/src/reference/sync/sync-history.ts
+++ b/packages/core/src/reference/sync/sync-history.ts
@@ -6,6 +6,13 @@ import type { ErrorCaller } from "../schemas/error-state.js";
 export const SYNC_HISTORY_FILE = "sync-history.jsonl";
 
 /**
+ * Forward-compatibility primitive: stamped on every outcome line so a later
+ * reader can version-discriminate the trail. It can never be retrofitted onto
+ * lines already written to disk, so it must lead every line from the first write.
+ */
+export const SYNC_HISTORY_SCHEMA_VERSION = "1";
+
+/**
  * Size-only cap. Outcome lines are ~80–120 bytes each, so 1 MB holds tens of
  * thousands of ticks — far more than a month of frequent syncs. The history
  * file deliberately has NO age cap (unlike the rolling logger's 14-day prune):
@@ -16,6 +23,7 @@ export const SYNC_HISTORY_FILE = "sync-history.jsonl";
 export const SYNC_HISTORY_MAX_BYTES = 1 * 1024 * 1024;
 
 export interface SyncOutcomeLine {
+  readonly schema_version: string;
   readonly ts: string;
   readonly caller: ErrorCaller;
   readonly kind: "ran" | "skipped" | "failed";

--- a/packages/core/tests/reference-run-sync.test.ts
+++ b/packages/core/tests/reference-run-sync.test.ts
@@ -1119,6 +1119,7 @@ describe("createRunSync sync-history emit", () => {
     expect(result.kind).toBe("ran");
     expect(syncHistory).toHaveBeenCalledOnce();
     const line = syncHistory.mock.calls[0]![0];
+    expect(line.schema_version).toBe("1");
     expect(line.kind).toBe("ran");
     expect(line.caller).toBe("scheduled");
     expect(line.reason).toBeUndefined();

--- a/packages/core/tests/sync-history.test.ts
+++ b/packages/core/tests/sync-history.test.ts
@@ -34,6 +34,7 @@ describe("createSyncHistoryWriter", () => {
     const writer = createSyncHistoryWriter(dir);
 
     const line: SyncOutcomeLine = {
+      schema_version: "1",
       ts: "1998-05-09T14:00:00.000Z",
       caller: "scheduled",
       kind: "failed",
@@ -41,7 +42,13 @@ describe("createSyncHistoryWriter", () => {
       duration_ms: 1234,
     };
     writer(line);
-    writer({ ts: "1998-05-09T14:01:00.000Z", caller: "lazy", kind: "ran", duration_ms: 5 });
+    writer({
+      schema_version: "1",
+      ts: "1998-05-09T14:01:00.000Z",
+      caller: "lazy",
+      kind: "ran",
+      duration_ms: 5,
+    });
 
     // The file lives beside error_state.json — NOT under logs/, NOT log.jsonl.
     expect(existsSync(path)).toBe(true);
@@ -50,6 +57,7 @@ describe("createSyncHistoryWriter", () => {
     const lines = readFileSync(path, "utf-8").trim().split("\n");
     expect(lines).toHaveLength(2);
     expect(JSON.parse(lines[0])).toEqual({
+      schema_version: "1",
       ts: "1998-05-09T14:00:00.000Z",
       caller: "scheduled",
       kind: "failed",
@@ -66,6 +74,7 @@ describe("createSyncHistoryWriter", () => {
 
     // Seed the live file above the (tiny, injected) cap with an ANCIENT line.
     const ancient: SyncOutcomeLine = {
+      schema_version: "1",
       ts: "1990-01-01T00:00:00.000Z",
       caller: "scheduled",
       kind: "ran",
@@ -77,7 +86,13 @@ describe("createSyncHistoryWriter", () => {
 
     // The next write trips the size rotate: the seeded content moves to `.1`,
     // the live file holds only the fresh line.
-    writer({ ts: "1998-05-09T14:00:00.000Z", caller: "lazy", kind: "ran", duration_ms: 9 });
+    writer({
+      schema_version: "1",
+      ts: "1998-05-09T14:00:00.000Z",
+      caller: "lazy",
+      kind: "ran",
+      duration_ms: 9,
+    });
 
     expect(existsSync(`${path}.1`)).toBe(true);
     const live = readFileSync(path, "utf-8").trim().split("\n");
@@ -99,6 +114,7 @@ describe("createSyncHistoryWriter", () => {
     const writer = createSyncHistoryWriter(join(blocker, "nested"));
 
     const line: SyncOutcomeLine = {
+      schema_version: "1",
       ts: "1998-05-09T14:00:00.000Z",
       caller: "scheduled",
       kind: "ran",


### PR DESCRIPTION
## What

Adds a stable `schema_version` to every sync-history outcome line so a future reader can version-discriminate the JSONL trail.

- New `SYNC_HISTORY_SCHEMA_VERSION = "1"`, mirroring the existing error-state / scheduler schema-version house pattern.
- A required `schema_version` field leading every `SyncOutcomeLine`, stamped at the single emit site so all `ran` / `skipped` / `failed` lines (and the catch-path line) carry it.

## Why

This is the one element of the trail's governance that **cannot** be retrofitted: lines written without a version key are permanently un-discriminable, so the field must lead from the first write. The writer stays best-effort and never-throws — no validation was added to the write path.

Promoting `reason` from a free-form string to a documented union and adding a read-side schema remain **deferred** until a first consumer reads the trail (a curator read, a diagnostics command, or ops tooling), where the open-vs-closed decision can be made against real requirements.

## Scope / testing

Pure-infra on a write-only, zero-consumer diagnostics trail — no athlete-visible change, so no changeset. Lint, typecheck, the trademark gate, and the sync-history + run-sync test suites are all green.
