### PR TITLE
fix(core): make derived_metrics_meta provenance honest with prescriptionBasis + analysisBasis

### DIFF
--- a/.changeset/derived-metrics-meta-analysis-basis.md
+++ b/.changeset/derived-metrics-meta-analysis-basis.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/core": patch
+---
+
+Make the `derived_metrics_meta` provenance honest. Rename `basis` to `prescriptionBasis` (the adapter's declared prescription anchor — `power`/`pace`) and add a separate `analysisBasis` carrying the substrate the distribution numbers were actually computed off (`power`/`hr`/`mixed`/`null`, read from the already-computed `zone_distribution_7d.zone_basis`). For a power-less run these diverge: prescription `pace`, analysis `hr`. `latest.json` schema bumps v2 -> v3 (discard-and-resync). No ported metric math changes.

--- a/packages/core/src/reference/schemas/latest.ts
+++ b/packages/core/src/reference/schemas/latest.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 // Bump this only when THIS file's shape changes — never in lockstep with
 // sibling schemas. See CONTRIBUTING.md "Reference schema-version policy."
-export const LATEST_SCHEMA_VERSION = "2";
+export const LATEST_SCHEMA_VERSION = "3";
 
 const DerivedMetricsSchema = z
   .object({
@@ -67,8 +67,9 @@ export const LatestJsonSchema = z
     derived_metrics_meta: z
       .object({
         sportFamily: z.string(),
-        basis: z.enum(["power", "pace", "hr"]),
+        prescriptionBasis: z.enum(["power", "pace"]),
         anchorType: z.enum(["critical-speed", "ftp"]),
+        analysisBasis: z.enum(["power", "hr", "mixed"]).nullable(),
       })
       .strict()
       .optional(),

--- a/packages/core/src/reference/sync/fetch-reference-data.ts
+++ b/packages/core/src/reference/sync/fetch-reference-data.ts
@@ -15,8 +15,9 @@ import { SPORT_FAMILIES } from "../metrics/sport-families.js";
 
 interface DerivedMetricsMeta {
   readonly sportFamily: string;
-  readonly basis: "power" | "pace" | "hr";
+  readonly prescriptionBasis: "power" | "pace";
   readonly anchorType: "critical-speed" | "ftp";
+  readonly analysisBasis: "power" | "hr" | "mixed" | null;
 }
 
 /**
@@ -25,8 +26,17 @@ interface DerivedMetricsMeta {
  * Ride+Run) tags as its kept power family, matching the omission decision;
  * otherwise the first covering adapter wins. Returns `undefined` for an
  * empty-coverage bundle (no adapter to attribute), leaving the optional tag off.
+ *
+ * `prescriptionBasis` is the adapter's declared prescription anchor
+ * (`zoneBasis`) — what zones we'd write a workout against. `analysisBasis` is
+ * the substrate the distribution numbers were ACTUALLY computed off (the
+ * registry's `zone_distribution_7d.zone_basis`: power|hr|mixed|null) — for a
+ * power-less run these diverge (prescription `pace`, analysis `hr`).
  */
-function deriveMeta(runs: readonly AdapterRun[]): DerivedMetricsMeta | undefined {
+function deriveMeta(
+  runs: readonly AdapterRun[],
+  analysisBasis: "power" | "hr" | "mixed" | null,
+): DerivedMetricsMeta | undefined {
   if (runs.length === 0) return undefined;
   const covering =
     runs.find((r) => r.adapter.zoneBasis === "power")?.adapter ?? runs[0].adapter;
@@ -35,7 +45,14 @@ function deriveMeta(runs: readonly AdapterRun[]): DerivedMetricsMeta | undefined
     firstType !== undefined && Object.hasOwn(SPORT_FAMILIES, firstType)
       ? SPORT_FAMILIES[firstType]
       : "other";
-  return { sportFamily, basis: covering.zoneBasis, anchorType: covering.anchorType };
+  return {
+    sportFamily,
+    // No shipped adapter declares a 'hr' prescription anchor; only power/pace
+    // are instantiated, so narrowing off the wider interface type is safe.
+    prescriptionBasis: covering.zoneBasis as "power" | "pace",
+    anchorType: covering.anchorType,
+    analysisBasis,
+  };
 }
 
 /**
@@ -92,7 +109,17 @@ async function fetchOnce(
     buildMetricInput(live.bundle, live.frozenNow),
     { omitPowerFamily },
   );
-  const meta = deriveMeta(runs);
+  // Read the actual analysis substrate off the already-computed window metric —
+  // never recompute it. `zone_distribution_7d.zone_basis` is the canonical
+  // window-level substrate (distribution.ts emits it). Default to null when the
+  // metric is absent or not an object (defensive — the omitPowerFamily fence
+  // does NOT strip zone_distribution_7d today, but guard anyway).
+  const zoneDist = derivedMetrics["zone_distribution_7d"];
+  const analysisBasis =
+    zoneDist !== null && typeof zoneDist === "object" && "zone_basis" in zoneDist
+      ? ((zoneDist as { zone_basis: "power" | "hr" | "mixed" | null }).zone_basis ?? null)
+      : null;
+  const meta = deriveMeta(runs, analysisBasis);
 
   return {
     latest: {

--- a/packages/core/src/reference/sync/run-sync.ts
+++ b/packages/core/src/reference/sync/run-sync.ts
@@ -80,11 +80,14 @@ export interface FetchedReference {
     readonly current_status: unknown;
     readonly derived_metrics: unknown;
     /** Emit-time provenance tag — a sibling of `derived_metrics`, never inside
-     *  it. Optional: an empty-coverage bundle attaches no tag. */
+     *  it. Optional: an empty-coverage bundle attaches no tag. `prescriptionBasis`
+     *  is the adapter's declared prescription anchor; `analysisBasis` is the
+     *  substrate the distribution numbers were actually computed off. */
     readonly derived_metrics_meta?: {
       readonly sportFamily: string;
-      readonly basis: "power" | "pace" | "hr";
+      readonly prescriptionBasis: "power" | "pace";
       readonly anchorType: "critical-speed" | "ftp";
+      readonly analysisBasis: "power" | "hr" | "mixed" | null;
     };
     readonly recent_activities: readonly unknown[];
     readonly planned_workouts: readonly unknown[];

--- a/packages/core/tests/reference-compute-derived-metrics.test.ts
+++ b/packages/core/tests/reference-compute-derived-metrics.test.ts
@@ -168,22 +168,35 @@ function composeLikeFetchOnce(
   activities: readonly TestActivity[],
 ): {
   derived_metrics: Record<string, unknown>;
-  derived_metrics_meta?: { sportFamily: string; basis: string; anchorType: string };
+  derived_metrics_meta?: {
+    sportFamily: string;
+    prescriptionBasis: string;
+    anchorType: string;
+    analysisBasis: "power" | "hr" | "mixed" | null;
+  };
   omitPowerFamily: boolean;
 } {
   const runs = runAdaptersForActivities(adapters, sportTypes, activities as unknown as readonly Activity[]);
   const coveredPowerBasis = runs.some((r) => r.adapter.zoneBasis === "power");
   const omitPowerFamily = runs.length > 0 && !coveredPowerBasis;
   const derived_metrics = computeDerivedMetrics(inputFor(activities), { omitPowerFamily });
-  let derived_metrics_meta: { sportFamily: string; basis: string; anchorType: string } | undefined;
+  const zoneDist = derived_metrics["zone_distribution_7d"];
+  const analysisBasis: "power" | "hr" | "mixed" | null =
+    zoneDist !== null && typeof zoneDist === "object" && "zone_basis" in zoneDist
+      ? ((zoneDist as { zone_basis: "power" | "hr" | "mixed" | null }).zone_basis ?? null)
+      : null;
+  let derived_metrics_meta:
+    | { sportFamily: string; prescriptionBasis: string; anchorType: string; analysisBasis: "power" | "hr" | "mixed" | null }
+    | undefined;
   if (runs.length > 0) {
     const covering =
       runs.find((r) => r.adapter.zoneBasis === "power")?.adapter ?? runs[0].adapter;
     const families: Record<string, string> = { Ride: "cycling", VirtualRide: "cycling", Run: "run", TrailRun: "run" };
     derived_metrics_meta = {
       sportFamily: families[covering.activityTypes[0]] ?? "other",
-      basis: covering.zoneBasis,
+      prescriptionBasis: covering.zoneBasis,
       anchorType: covering.anchorType,
+      analysisBasis,
     };
   }
   return { derived_metrics, derived_metrics_meta, omitPowerFamily };
@@ -242,9 +255,14 @@ describe("fetchOnce-shaped power-family fence + provenance tag", () => {
     }
     // The tag is a SIBLING — no provenance key leaked into the map.
     expect(derived_metrics).not.toHaveProperty("sportFamily");
-    expect(derived_metrics).not.toHaveProperty("basis");
+    expect(derived_metrics).not.toHaveProperty("prescriptionBasis");
     expect(derived_metrics).not.toHaveProperty("anchorType");
-    expect(derived_metrics_meta).toEqual({ sportFamily: "run", basis: "pace", anchorType: "critical-speed" });
+    expect(derived_metrics_meta).toEqual({
+      sportFamily: "run",
+      prescriptionBasis: "pace",
+      anchorType: "critical-speed",
+      analysisBasis: null,
+    });
   });
 
   it("cycling-only bundle: keeps the full power family and tags cycling/power/ftp", () => {
@@ -255,7 +273,12 @@ describe("fetchOnce-shaped power-family fence + provenance tag", () => {
     );
     expect(omitPowerFamily).toBe(false);
     expect(Object.keys(derived_metrics).sort()).toEqual(Object.keys(METRIC_REGISTRY).sort());
-    expect(derived_metrics_meta).toEqual({ sportFamily: "cycling", basis: "power", anchorType: "ftp" });
+    expect(derived_metrics_meta).toEqual({
+      sportFamily: "cycling",
+      prescriptionBasis: "power",
+      anchorType: "ftp",
+      analysisBasis: null,
+    });
   });
 
   it("mixed Ride+Run bundle: keeps the full power family (duathlete keeps cycling power) and tags", () => {
@@ -269,7 +292,7 @@ describe("fetchOnce-shaped power-family fence + provenance tag", () => {
     for (const key of POWER_FAMILY_OMIT_KEYS) {
       expect(derived_metrics).toHaveProperty(key);
     }
-    expect(derived_metrics_meta?.basis).toBe("power");
+    expect(derived_metrics_meta?.prescriptionBasis).toBe("power");
     expect(derived_metrics_meta?.anchorType).toBe("ftp");
   });
 
@@ -380,5 +403,26 @@ describe("running-only golden fixture (pure-pace production path)", () => {
     // Low-intensity-dominant by construction (~0.80).
     expect(easyRatio).toBeGreaterThanOrEqual(0.7);
     expect(easyRatio).toBeLessThanOrEqual(0.9);
+  });
+
+  it("provenance tag diverges: prescriptionBasis is pace, analysisBasis is the HR substrate the numbers were computed off", () => {
+    // A power-less running bundle is PRESCRIBED off pace/critical-speed but the
+    // distribution numbers are ANALYZED off HR zones — the exact mislabel this
+    // fix corrects. Derive the tag the production way: run the pace adapter and
+    // read the already-computed zone_distribution_7d.zone_basis as the substrate.
+    const out = computeDerivedMetrics(runningOnlyInput(), { omitPowerFamily: true });
+    const zoneDist = out["zone_distribution_7d"] as { zone_basis: string | null } | null;
+    const analysisBasis = zoneDist?.zone_basis ?? null;
+
+    const fixture = loadFixture("golden/running-only", GoldenFixtureSchema);
+    const runs = runAdaptersForActivities(
+      [RUNNING_ADAPTER],
+      ["Run", "TrailRun"],
+      fixture.activities as unknown as readonly Activity[],
+    );
+    const covering = runs.find((r) => r.adapter.zoneBasis === "power")?.adapter ?? runs[0].adapter;
+
+    expect(covering.zoneBasis).toBe("pace");
+    expect(analysisBasis).toBe("hr");
   });
 });

--- a/packages/core/tests/reference-live-sync-integration.test.ts
+++ b/packages/core/tests/reference-live-sync-integration.test.ts
@@ -85,7 +85,12 @@ async function composeFetched(): Promise<FetchedReference> {
   const coveredPowerBasis = runs.some((r) => r.adapter.zoneBasis === "power");
   const omitPowerFamily = runs.length > 0 && !coveredPowerBasis;
   const derived_metrics = computeDerivedMetrics(buildMetricInput(live.bundle, live.frozenNow), { omitPowerFamily });
-  const meta = deriveMeta(runs);
+  const zoneDist = derived_metrics["zone_distribution_7d"];
+  const analysisBasis: "power" | "hr" | "mixed" | null =
+    zoneDist !== null && typeof zoneDist === "object" && "zone_basis" in zoneDist
+      ? ((zoneDist as { zone_basis: "power" | "hr" | "mixed" | null }).zone_basis ?? null)
+      : null;
+  const meta = deriveMeta(runs, analysisBasis);
   return {
     latest: {
       athlete_profile: live.athleteProfile,
@@ -110,6 +115,7 @@ async function composeFetched(): Promise<FetchedReference> {
  */
 function deriveMeta(
   runs: ReturnType<typeof runAdaptersForActivities>,
+  analysisBasis: "power" | "hr" | "mixed" | null,
 ): DerivedMetricsMeta | undefined {
   if (runs.length === 0) return undefined;
   const covering = runs.find((r) => r.adapter.zoneBasis === "power")?.adapter ?? runs[0].adapter;
@@ -118,7 +124,12 @@ function deriveMeta(
     firstType !== undefined && Object.hasOwn(SPORT_FAMILIES, firstType)
       ? SPORT_FAMILIES[firstType]
       : "other";
-  return { sportFamily, basis: covering.zoneBasis, anchorType: covering.anchorType };
+  return {
+    sportFamily,
+    prescriptionBasis: covering.zoneBasis as "power" | "pace",
+    anchorType: covering.anchorType,
+    analysisBasis,
+  };
 }
 
 describe("live-data bridge integration", () => {
@@ -140,7 +151,15 @@ describe("live-data bridge integration", () => {
 
   it("round-trips the derived_metrics_meta tag through the real strict read path (no cache-miss loop)", async () => {
     const fetched = await composeFetched();
-    const tag = { sportFamily: "cycling", basis: "power", anchorType: "ftp" };
+    // The fakeClient activities carry no zone-time blocks, so the window-level
+    // zone_distribution_7d.zone_basis is null — analysisBasis tracks it (null),
+    // distinct from the power prescriptionBasis.
+    const tag = {
+      sportFamily: "cycling",
+      prescriptionBasis: "power",
+      anchorType: "ftp",
+      analysisBasis: null,
+    };
     expect(fetched.latest.derived_metrics_meta).toEqual(tag);
 
     const onDisk = {

--- a/packages/core/tests/reference-run-sync.test.ts
+++ b/packages/core/tests/reference-run-sync.test.ts
@@ -997,8 +997,8 @@ describe("latest derived_metrics structured schema + version gate", () => {
     vi.restoreAllMocks();
   });
 
-  it("the current cache schema version is \"2\"", () => {
-    expect(LATEST_SCHEMA_VERSION).toBe("2");
+  it("the current cache schema version is \"3\"", () => {
+    expect(LATEST_SCHEMA_VERSION).toBe("3");
   });
 
   it("a sparse running derived_metrics map (power keys absent, others null) parses clean", () => {


### PR DESCRIPTION
## What

Splits the `derived_metrics_meta` provenance tag's single, conflated `basis` field into two honest fields:

- `prescriptionBasis` (`power` | `pace`) — the anchor the athlete's zones are prescribed from.
- `analysisBasis` (`power` | `hr` | `mixed` | `null`) — what the derived metrics were actually computed from.

Bumps `LATEST_SCHEMA_VERSION` 2 → 3.

## Why

For an athlete with no power meter, a run is *prescribed* off pace but *analyzed* off heart rate. The old single `basis` field reported the analysis substrate (`hr`) in the slot a consumer reads as the prescription anchor — silently mislabeling the run. The two genuinely diverge, so they need two fields. No consumer reads the tag yet, so the mislabel is latent today; this lands the honest contract before the first consumer (the running analyze reader) is built.

## Notes

- The tag is a sibling of `derived_metrics`, outside the parity gate's key-union — so the v2→v3 bump touches no computed metric value and needs no parity-deviation entry. Verified: metric parity unchanged.
- v2→v3 is a discard-and-resync (no migration map); a stale on-disk cache is simply re-fetched.
- This is the sequencing predecessor for the running analyze Layer-3 reader: the reader must bind to `prescriptionBasis`/`analysisBasis`, never the old `basis`. Merge this first.
