### PR TITLE
feat(core): add sport-agnostic pace formatter (m/s to M:SS)

### DIFF
--- a/.changeset/core-pace-formatter.md
+++ b/.changeset/core-pace-formatter.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/core": patch
+---
+
+Add a sport-agnostic pace formatter that renders an SI speed (metres per second) to an athlete-facing M:SS pace, keyed on the `pace_units` display preference (per-mile for `MINS_MILE`, per-kilometre otherwise). Distance is parameterised so a per-100 pace can reuse it. Additive presentation helper with no caller yet.

--- a/packages/core/src/agent/pace-format.test.ts
+++ b/packages/core/src/agent/pace-format.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { formatPaceFromMps, renderPaceMMSS, PACE_UNAVAILABLE } from "./pace-format.js";
+
+describe("formatPaceFromMps", () => {
+  it("renders /mi at the mile divisor for MINS_MILE", () => {
+    // 1609.344 / 4.0 = 402.336 → round 402 → 6:42
+    expect(formatPaceFromMps(4.0, "MINS_MILE")).toBe("6:42/mi");
+  });
+
+  it("renders /km at the km divisor for MINS_KM", () => {
+    // 1000 / 4.0 = 250 → 4:10
+    expect(formatPaceFromMps(4.0, "MINS_KM")).toBe("4:10/km");
+  });
+
+  it("falls through to /km for null", () => {
+    expect(formatPaceFromMps(4.0, null)).toBe("4:10/km");
+  });
+
+  it("falls through to /km for undefined", () => {
+    expect(formatPaceFromMps(4.0, undefined)).toBe("4:10/km");
+    expect(formatPaceFromMps(4.0)).toBe("4:10/km");
+  });
+
+  it("falls through to /km for NONE", () => {
+    expect(formatPaceFromMps(4.0, "NONE")).toBe("4:10/km");
+  });
+
+  it("falls through to /km for an unrecognized string", () => {
+    expect(formatPaceFromMps(4.0, "SECS_KM")).toBe("4:10/km");
+    expect(formatPaceFromMps(4.0, "totally-bogus")).toBe("4:10/km");
+  });
+
+  it("rounds on rendered seconds, matching the zones paceMMSS contract", () => {
+    // zones paceMMSS: Math.round(1000 / 4.0) = 250 → 4:10. Identical here.
+    expect(formatPaceFromMps(4.0, "MINS_KM")).toBe("4:10/km");
+    // A speed that forces a non-trivial round: 1000 / 3.7 = 270.27 → 270 → 4:30
+    expect(formatPaceFromMps(3.7, "MINS_KM")).toBe("4:30/km");
+  });
+
+  it("returns the sentinel for a non-positive speed, never Infinity:00", () => {
+    expect(formatPaceFromMps(0, "MINS_KM")).toBe(PACE_UNAVAILABLE);
+    expect(formatPaceFromMps(-2, "MINS_KM")).toBe(PACE_UNAVAILABLE);
+    expect(formatPaceFromMps(0, "MINS_KM")).not.toContain("Infinity");
+  });
+
+  it("returns the sentinel for a non-finite speed, never NaN", () => {
+    expect(formatPaceFromMps(Number.NaN, "MINS_KM")).toBe(PACE_UNAVAILABLE);
+    expect(formatPaceFromMps(Number.POSITIVE_INFINITY, "MINS_KM")).toBe(PACE_UNAVAILABLE);
+    expect(formatPaceFromMps(Number.NaN, "MINS_KM")).not.toContain("NaN");
+  });
+});
+
+describe("renderPaceMMSS", () => {
+  it("renders pace-per-100m for swimming reuse", () => {
+    // 100 / 1.25 = 80 → 1:20
+    expect(renderPaceMMSS(1.25, 100)).toBe("1:20");
+  });
+
+  it("rounds on the rendered total seconds", () => {
+    // 1000 / 4.0 = 250 → 4:10
+    expect(renderPaceMMSS(4.0, 1000)).toBe("4:10");
+  });
+
+  it("returns the sentinel for non-positive / non-finite speeds", () => {
+    expect(renderPaceMMSS(0, 100)).toBe(PACE_UNAVAILABLE);
+    expect(renderPaceMMSS(Number.NaN, 100)).toBe(PACE_UNAVAILABLE);
+    expect(renderPaceMMSS(Number.POSITIVE_INFINITY, 100)).toBe(PACE_UNAVAILABLE);
+  });
+});

--- a/packages/core/src/agent/pace-format.ts
+++ b/packages/core/src/agent/pace-format.ts
@@ -1,0 +1,17 @@
+export const PACE_UNAVAILABLE = "—";
+
+export function renderPaceMMSS(speedMps: number, meters: number): string {
+  if (!Number.isFinite(speedMps) || speedMps <= 0) return PACE_UNAVAILABLE;
+  const totalSec = Math.round(meters / speedMps);
+  const minutes = Math.floor(totalSec / 60);
+  const seconds = totalSec % 60;
+  return `${minutes}:${String(seconds).padStart(2, "0")}`;
+}
+
+export function formatPaceFromMps(speedMps: number, paceUnits?: string | null): string {
+  const meters = paceUnits === "MINS_MILE" ? 1609.344 : 1000;
+  const suffix = paceUnits === "MINS_MILE" ? "/mi" : "/km";
+  const pace = renderPaceMMSS(speedMps, meters);
+  if (pace === PACE_UNAVAILABLE) return pace;
+  return `${pace}${suffix}`;
+}


### PR DESCRIPTION
## What

Adds `packages/core/src/agent/pace-format.ts` — a sport-agnostic presentation helper that renders a Reference-layer SI speed (metres per second) to an athlete-facing `M:SS` pace, keyed solely on the `pace_units` display preference (`/mi` for `MINS_MILE`, `/km` otherwise). Distance is a parameter so a per-100 pace can reuse it.

## Why

The running analyze surface needs to render an analyzed pace, and that value is a Reference-layer (Core) number in SI. This keeps unit ownership in Core — the number's owner — instead of borrowing a prescription-private renderer. Purely additive: no caller yet (the running analyze reader wires it in a later change), and the prescription-side zone renderer is untouched and byte-identical.

## Tests

12 unit tests covering: mile/km divisor selection, fall-through for `MINS_KM` / `NONE` / null / absent / unrecognized, rounding on the rendered total seconds (matching the prescription renderer's contract), a defined sentinel for non-positive / non-finite speeds (never `Infinity:00` / `NaN`), and the parameterised per-100 path. `tsc` clean.
