### PR TITLE
chore(core): change scheduled sync cadence from 30 min to 6 h

### DIFF
--- a/.changeset/sync-cadence-6h.md
+++ b/.changeset/sync-cadence-6h.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/core": patch
+---
+
+Change the in-process scheduled sync cadence from every 30 minutes to every 6 hours (`SCHEDULED_SYNC_INTERVAL_MS`). The boot sync is unchanged; this only lengthens the recurring in-process refresh timer, reducing intervals.icu API load. Data stays within the 24h "fresh" band between refreshes.

--- a/packages/core/src/reference/freshness.ts
+++ b/packages/core/src/reference/freshness.ts
@@ -49,7 +49,7 @@ export const SYNC_COOLDOWN_MS = 30_000;
 /** Mutex acquire time over this threshold logs a WARN — operator signal. */
 export const MUTEX_HOT_WARN_MS = 10_000;
 /** Scheduled refresh cadence (in-process timer). */
-export const SCHEDULED_SYNC_INTERVAL_MS = 30 * 60 * 1000;
+export const SCHEDULED_SYNC_INTERVAL_MS = 6 * 60 * 60 * 1000;
 /**
  * Per-request HTTP timeout chained with the orchestrator-level signal so a
  * single hung endpoint cannot consume the full SYNC_OPERATION_TIMEOUT_MS


### PR DESCRIPTION
## Summary

Changes the in-process scheduled sync cadence from **every 30 minutes** to **every 6 hours**.

- `SCHEDULED_SYNC_INTERVAL_MS`: `30 * 60 * 1000` → `6 * 60 * 60 * 1000` (21,600,000 ms) in `packages/core/src/reference/freshness.ts`.
- The boot sync is unchanged — the binary still runs one sync at startup; only the recurring in-process refresh timer is lengthened.
- Reduces intervals.icu API load. Data refreshed every 6h stays comfortably inside the 24h `FRESH_MS` band, so no new staleness signalling.

## Why

The 30-minute cadence polls intervals.icu far more often than training data actually changes. Six hours is plenty for a once-or-twice-daily training signal while cutting background API calls ~12×.

## Behavior note

While the process runs, training data can now be up to ~6h stale between automatic refreshes (was ~30 min). A just-uploaded activity is picked up on the next 6-hour tick or on restart. The on-demand `maybeRefreshIfStale` path is still a stub, so there is no faster fallback yet.

## Test plan

- `reference-run-sync.test.ts` imports `SCHEDULED_SYNC_INTERVAL_MS` and derives `next_sync_at` as `now + SCHEDULED_SYNC_INTERVAL_MS` dynamically — it asserts the new 6h value automatically, no hardcoded `30` to update.
- No freshness-band conflict: `FRESH_MS` (24h) > 6h, so the cache is still classified `fresh` between refreshes.

Changeset: `.changeset/sync-cadence-6h.md` (`@enduragent/core` patch).