### PR TITLE
fix(core): wire CLI exit paths and a cold-start sync banner

### DIFF
--- a/.changeset/cli-exit-paths-and-cold-start-banner.md
+++ b/.changeset/cli-exit-paths-and-cold-start-banner.md
@@ -1,0 +1,7 @@
+---
+"@enduragent/core": patch
+---
+
+User-facing: /quit, /exit, and Ctrl-D now exit cleanly, and startup shows a "syncing training data" line (with an explanation if the first sync fails).
+
+The CLI readline loop registers a single close handler that stops the periodic Reference sync scheduler and exits with code 0, so /quit, /exit, Ctrl-D, and a single Ctrl-C at the prompt all return the athlete to their shell instead of leaving a zombie process syncing under their API key. A verbatim banner prints before the awaited boot sync (in both CLI and Telegram modes) so the previously blank up-to-120s cold start is visible. A first sync that resolves failed (rather than throwing) is now surfaced with a one-line explanation from the Reference bootstrap. As defense-in-depth, the periodic scheduler timer is unref'd behind a guard so it cannot keep the process alive on its own.

--- a/packages/core/src/reference/runtime.ts
+++ b/packages/core/src/reference/runtime.ts
@@ -94,7 +94,12 @@ export async function bootstrapReference(
   // continue with whatever cache (if any) is on disk; the scheduler's next
   // tick will retry.
   try {
-    await runSyncInternal({ caller: "scheduled" });
+    const firstSync = await runSyncInternal({ caller: "scheduled" });
+    if (firstSync.kind === "failed") {
+      console.warn(
+        `${INITIAL_SYNC_FAILED_LOG_PREFIX} (${firstSync.reason}). Continuing with cached data if available; the next scheduled sync will retry.`,
+      );
+    }
   } catch (err) {
     console.warn(
       `${INITIAL_SYNC_FAILED_LOG_PREFIX} (${err instanceof Error ? err.message : String(err)}). Continuing with empty cache; lazy fallback will retry.`,

--- a/packages/core/src/reference/sync/scheduler.ts
+++ b/packages/core/src/reference/sync/scheduler.ts
@@ -94,5 +94,12 @@ export class Scheduler {
         this.scheduleNext();
       }
     }, this.nextDelay);
+
+    // Defense-in-depth: don't let the periodic timer keep the process alive on
+    // its own. A test-injected fake handle may not expose `unref`, so guard it.
+    const handle = this.timerHandle as { unref?: () => void } | null;
+    if (handle !== null && typeof handle.unref === "function") {
+      handle.unref();
+    }
   }
 }

--- a/packages/core/src/run-binary.ts
+++ b/packages/core/src/run-binary.ts
@@ -342,6 +342,7 @@ export async function runBinary(
   await runStartupHook(agent.getMemory(), hooks.onStartup);
 
   const { bootstrapReference } = await import("./reference/runtime.js");
+  console.log("syncing training data from intervals.icu…");
   const reference = await bootstrapReference({
     dataDir: config.dataDir,
     intervals: config.intervals,
@@ -424,6 +425,11 @@ export async function runBinary(
       input: process.stdin,
       output: process.stdout,
       prompt: "> ",
+    });
+
+    rl.on("close", () => {
+      reference.scheduler.stop();
+      process.exit(0);
     });
 
     rl.prompt();

--- a/packages/core/tests/reference-runtime.test.ts
+++ b/packages/core/tests/reference-runtime.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, rmSync, existsSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { bootstrapReference } from "../src/reference/runtime.js";
+import { bootstrapReference, INITIAL_SYNC_FAILED_LOG_PREFIX } from "../src/reference/runtime.js";
 import { ReferenceConfigError } from "../src/reference/errors.js";
 import type { ReferenceSportAdapter } from "../src/reference/sport-adapter.js";
 import type { Sport } from "../src/sport.js";
@@ -106,6 +106,27 @@ describe("bootstrapReference (behavioral)", () => {
     // The fetch rejection is now handled inside runSync (converted to a failed
     // sync + error_state.json) rather than rethrown, so bootstrap continues and
     // the curator can see the failure on disk.
+    expect(existsSync(join(dataDir, "data", "error_state.json"))).toBe(true);
+    runtime.scheduler.stop();
+  });
+
+  it("warns when the initial sync RESOLVES failed (errored endpoints, not a thrown fetch)", async () => {
+    const failedFetch = vi.fn().mockResolvedValue({
+      ...emptyFetched,
+      fetch_errors: [{ endpoint: "athlete-profile", detail: "503 from intervals.icu" }],
+    });
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const runtime = await bootstrapReference({
+      dataDir,
+      intervals: { apiKey: "test-key" },
+      sport: fakeSport(),
+      fetchReferenceData: failedFetch,
+    });
+
+    expect(runtime).toBeDefined();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining(INITIAL_SYNC_FAILED_LOG_PREFIX));
+    // The gate rejection still records the curator's error_state on disk.
     expect(existsSync(join(dataDir, "data", "error_state.json"))).toBe(true);
     runtime.scheduler.stop();
   });

--- a/packages/core/tests/reference-scheduler.test.ts
+++ b/packages/core/tests/reference-scheduler.test.ts
@@ -108,6 +108,26 @@ describe("Scheduler", () => {
     expect(runSyncSpy).toHaveBeenCalledOnce();
   });
 
+  it("unref's the production timer handle when it exposes unref (defense-in-depth)", () => {
+    const fixedNow = new Date("2026-05-09T14:00:00Z");
+    const fakeHandle = { unref: vi.fn() };
+    const runSyncSpy = vi.fn();
+
+    const scheduler = new Scheduler({
+      dataDir: dir,
+      runSync: runSyncSpy,
+      intervalMs: 30 * 60_000,
+      clock: {
+        now: () => fixedNow,
+        setTimeout: () => fakeHandle,
+        clearTimeout: () => {},
+      },
+    });
+    scheduler.start();
+
+    expect(fakeHandle.unref).toHaveBeenCalledOnce();
+  });
+
   it("stop() cancels the pending timer; subsequent ticks do not fire", async () => {
     const fixedNow = new Date("2026-05-09T14:00:00Z");
     vi.setSystemTime(fixedNow);

--- a/packages/core/tests/run-binary-init-order.test.ts
+++ b/packages/core/tests/run-binary-init-order.test.ts
@@ -88,6 +88,32 @@ describe("run-binary shutdown-window latch", () => {
   });
 });
 
+describe("run-binary CLI exit + cold-start banner", () => {
+  const SOURCE_PATH = join(__dirname, "..", "src", "run-binary.ts");
+  const src = readFileSync(SOURCE_PATH, "utf-8");
+
+  it("prints the verbatim cold-start banner before the awaited bootstrap", () => {
+    const banner = "syncing training data from intervals.icu…";
+    expect(countOccurrences(src, banner)).toBe(1);
+    expect(src.indexOf(banner)).toBeLessThan(src.indexOf("await bootstrapReference("));
+  });
+
+  it("registers a close handler that stops the scheduler and exits 0", () => {
+    expect(src).toContain('rl.on("close"');
+    expect(src).toContain("reference.scheduler.stop()");
+    expect(src).toContain("process.exit(0)");
+  });
+
+  it("keeps /quit and /exit routing to rl.close()", () => {
+    expect(countOccurrences(src, 'input === "/quit" || input === "/exit"')).toBe(1);
+    expect(src).toContain("rl.close()");
+  });
+
+  it("does not smuggle in a mid-turn abort (AbortController is the LLM-deadline work's)", () => {
+    expect(src).not.toContain("AbortController");
+  });
+});
+
 function countOccurrences(haystack: string, needle: string): number {
   let count = 0;
   let idx = 0;


### PR DESCRIPTION
Stacked on the empty-reply-guards branch (merge that one first, then this retargets to main).

## What this changes

**CLI exit paths (run-binary.ts).** The interactive chat readline now registers a single `close` handler that stops the periodic Reference sync scheduler and then exits with code 0. That close event is the convergence point for `/quit`, `/exit`, Ctrl-D, and a single Ctrl-C at the prompt, so all four routes now return the athlete to their shell cleanly instead of leaving a zombie process that keeps syncing under their API key. The bare `rl.close()` in the `/quit` / `/exit` guard stays put and lets the close handler do the teardown rather than duplicating it inline. No mid-turn abort handling is introduced.

**Cold-start banner (run-binary.ts).** A verbatim "syncing training data from intervals.icu" line prints immediately before the awaited boot sync, in both CLI and Telegram modes, above the mode split. This makes the previously blank up-to-two-minute cold start visible. It is the only run-binary.ts edit and is anchored by name (above the awaited bootstrap call), not by line number.

**Resolved-but-failed first sync (reference/runtime.ts).** The bootstrap now binds the first sync result and, when it resolves to a failed kind (rather than throwing), surfaces a one-line explanation via the existing initial-sync-failed log prefix. This is purely additive: it does not throw, does not reorder scheduler start, and does not change the documented init order.

**Scheduler timer guard (reference/sync/scheduler.ts).** As defense-in-depth, the periodic scheduler timer is `unref()`'d behind a typeof-function guard so it cannot keep the process alive on its own, while the clock-injected fake-timer tests keep passing.

## Test plan

- New / extended cases in `reference-runtime.test.ts` (resolved-but-failed first sync surfaced), `reference-scheduler.test.ts` (timer unref guard), and `run-binary-init-order.test.ts` (banner source-anchor + exit path).
- `pnpm vitest run packages/core/tests/reference-runtime.test.ts packages/core/tests/reference-scheduler.test.ts packages/core/tests/run-binary-init-order.test.ts`
- `pnpm test && pnpm check` green.

User-facing changeset included.