### PR TITLE
fix(telegram): harden markdown->HTML rendering and parse-failure fallback

### DIFF
--- a/.changeset/telegram-rendering-pipeline.md
+++ b/.changeset/telegram-rendering-pipeline.md
@@ -1,0 +1,7 @@
+---
+"@enduragent/core": patch
+---
+
+User-facing: Workout prescriptions and code blocks now render exactly as written, links are clickable, and formatting errors fall back to clean readable text.
+
+The Telegram markdown→HTML converter now extracts fenced code blocks from the raw source before escaping (mirroring the table path), so a fenced workout like `- 4x8min @ 105%` survives byte-for-byte instead of having its bullets, headers, and italics mangled inside the `<pre>`. The italic regex is tightened so spaced asterisks in interval math (`do 3 * 8 reps`) keep their literal `*`. An http/https-only `[text](url)` rule renders clickable links with attribute-escaped hrefs and no double-escaped `&` in multi-param query strings. The long-message hard split no longer bisects an HTML tag, entity, or surrogate pair. When Telegram rejects a chunk, the fallback now delivers human-readable source text rather than resending raw tag soup. Finally, the `/snapshot` debug dump rides the same HTML path, dropping the lone legacy Markdown parse mode.

--- a/packages/core/src/channels/telegram.ts
+++ b/packages/core/src/channels/telegram.ts
@@ -310,7 +310,7 @@ export function createTelegramBot(
         const output = formatSnapshotRaw(latest, section);
         try {
           await sendSnapshotOutput(output, {
-            reply: (text) => ctx.reply(text, { parse_mode: "Markdown" }) as Promise<unknown>,
+            reply: (text) => sendLongMessage(ctx, text) as Promise<unknown>,
             sendDocument: (buffer, filename) =>
               ctx.replyWithDocument(new InputFile(buffer, filename)) as Promise<unknown>,
           });
@@ -433,12 +433,20 @@ export function createTelegramBot(
 export function markdownToTelegramHtml(md: string): string {
   // Telegram has no table primitive. Extract tables first so the bullet-point
   // regex below doesn't mangle their leading `|`, then restore as <pre> blocks.
-  const { text, tables } = extractTables(md);
+  const { text: noTables, tables } = extractTables(md);
+
+  // Extract fenced code blocks from the RAW (table-stripped) markdown BEFORE
+  // escaping, exactly as extractTables does. This preserves the fence body
+  // byte-for-byte through the regex passes (no header/bold/italic/bullet
+  // transform reaches inside) and restores it as an escaped <pre> at the end,
+  // keeping the escape-first security property intact.
+  const { text, fences } = extractFences(noTables);
 
   // Escape the raw source BEFORE any markdown conversion so the only real tags
   // in the output are the ones this converter emits. Literal HTML in the LLM
   // output (which can echo attacker-influenced intervals.icu text) must render
-  // as text, never as markup. Table cells are escaped inside renderTableAsPre.
+  // as text, never as markup. Table cells are escaped inside renderTableAsPre;
+  // fence bodies are escaped on restore below.
   let html = escapeHtmlText(text);
 
   // Headers: ### Title → <b>Title</b>
@@ -447,13 +455,21 @@ export function markdownToTelegramHtml(md: string): string {
   // Bold: **text** → <b>text</b>
   html = html.replace(/\*\*(.+?)\*\*/g, "<b>$1</b>");
 
-  // Italic: *text* or _text_ → <i>text</i>
-  html = html.replace(/(?<!\w)\*([^*]+?)\*(?!\w)/g, "<i>$1</i>");
+  // Italic: *text* or _text_ → <i>text</i>. A space (or another `*`) adjacent to
+  // either delimiter disqualifies the match, so interval math like
+  // `do 3 * 8 reps then 2 * 20min` keeps its literal `*` and emits no <i>.
+  html = html.replace(/(?<![\w*])\*(?![\s*])([^*\n]+?)(?<![\s*])\*(?![\w*])/g, "<i>$1</i>");
   html = html.replace(/(?<!\w)_([^_]+?)_(?!\w)/g, "<i>$1</i>");
 
-  // Code blocks: ```...``` → <pre>...</pre> (must run before inline-code, otherwise the
-  // single-backtick regex eats pairs of fence backticks and breaks the block).
-  html = html.replace(/```[\w]*\n?([\s\S]*?)```/g, "<pre>$1</pre>");
+  // Links: [text](http(s)://url) → <a href="url">text</a>. Runs on the
+  // post-escape html string, so the link text is already escaped; the url is
+  // captured from this same (escaped) string and only attribute-quote-escaped —
+  // re-running escapeHtmlText would double-escape an already-escaped `&` in a
+  // multi-param query string. http/https only; other schemes stay literal.
+  html = html.replace(
+    /\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g,
+    (_, label: string, url: string) => `<a href="${escapeHtmlAttrPreEscaped(url)}">${label}</a>`,
+  );
 
   // Inline code: `text` → <code>text</code>
   html = html.replace(/`([^`]+?)`/g, "<code>$1</code>");
@@ -464,7 +480,34 @@ export function markdownToTelegramHtml(md: string): string {
   // Bullet points: - item → • item
   html = html.replace(/^[-*]\s+/gm, "• ");
 
-  return html.replace(/\[\[__TBL_(\d+)__\]\]/g, (_, idx) => tables[Number(idx)] ?? "");
+  html = html.replace(/\[\[__TBL_(\d+)__\]\]/g, (_, idx) => tables[Number(idx)] ?? "");
+  return html.replace(
+    /\[\[__FENCE_(\d+)__\]\]/g,
+    (_, idx) => `<pre>${escapeHtmlText(fences[Number(idx)] ?? "")}</pre>`,
+  );
+}
+
+// Quote/apostrophe-escape a URL that has ALREADY passed through escapeHtmlText
+// (so `&`/`<`/`>` are entities). Only `"` and `'` remain to neutralize for an
+// attribute context; escapeHtmlAttr would re-escape the entities' `&`.
+function escapeHtmlAttrPreEscaped(s: string): string {
+  return s.replace(/"/g, "&quot;").replace(/'/g, "&#39;");
+}
+
+const FENCE_RE = /```[^\n]*\n?([\s\S]*?)```/g;
+
+// Mirror extractTables: walk the RAW markdown, replace each fenced code block
+// with an inert placeholder (no `* _ ` # -` or leading `[-*]`, so no regex
+// between extraction and restore touches it), and collect the raw fence body
+// for escaped-<pre> restore at the end of markdownToTelegramHtml.
+function extractFences(md: string): { text: string; fences: string[] } {
+  const fences: string[] = [];
+  const text = md.replace(FENCE_RE, (_, body: string) => {
+    const idx = fences.length;
+    fences.push(body);
+    return `[[__FENCE_${idx}__]]`;
+  });
+  return { text, fences };
 }
 
 const TABLE_SEPARATOR_RE = /^\s*\|?\s*:?-{2,}:?\s*(\|\s*:?-{2,}:?\s*)+\|?\s*$/;
@@ -620,14 +663,58 @@ export function chunkHtml(html: string, maxLen: number = TELEGRAM_MAX_LENGTH): s
     if (unit.kind === "pre") {
       chunks.push(...splitPreBlock(text, maxLen));
     } else {
-      for (let i = 0; i < text.length; i += maxLen) {
-        chunks.push(text.slice(i, i + maxLen));
-      }
+      chunks.push(...hardSplit(text, maxLen));
     }
   }
 
   flush();
   return chunks;
+}
+
+// Hard-split a single oversized line at a boundary that never bisects an HTML
+// tag (`<…>`), an entity (`&…;`), or a UTF-16 surrogate pair. Scans back from
+// the fixed offset to the last safe cut; if none exists below maxLen the line is
+// pathological (e.g. one >maxLen tag) and we fall back to the raw slice for that
+// one piece to guarantee forward progress.
+function hardSplit(text: string, maxLen: number): string[] {
+  const out: string[] = [];
+  let start = 0;
+  while (text.length - start > maxLen) {
+    let cut = start + maxLen;
+    while (cut > start && !isSafeCut(text, cut)) cut--;
+    if (cut === start) cut = start + maxLen; // pathological: no safe boundary
+    out.push(text.slice(start, cut));
+    start = cut;
+  }
+  out.push(text.slice(start));
+  return out;
+}
+
+// A cut at index `i` (split into [..i) and [i..]) is safe when it does not land
+// inside an open `<…>` tag, inside an unterminated `&…;` entity, or between the
+// two halves of a surrogate pair.
+function isSafeCut(text: string, i: number): boolean {
+  const prev = text.charCodeAt(i - 1);
+  if (prev >= 0xd800 && prev <= 0xdbff) return false; // high surrogate before cut
+
+  // Inside a tag if the nearest unescaped `<`/`>` scanning back is a `<`.
+  const lt = text.lastIndexOf("<", i - 1);
+  const gt = text.lastIndexOf(">", i - 1);
+  if (lt > gt) return false;
+
+  // Inside an entity if the nearest `&` scanning back has no terminating `;`
+  // before the cut and is close enough to still be an open entity run.
+  const amp = text.lastIndexOf("&", i - 1);
+  if (amp >= 0) {
+    const semi = text.indexOf(";", amp);
+    if (semi < 0 || semi >= i) {
+      // No `;` yet; only treat as an open entity if the run so far is entity-ish
+      // (no whitespace/`<`/`&`), otherwise a bare `&` is just literal text.
+      const run = text.slice(amp + 1, i);
+      if (/^[a-zA-Z0-9#]*$/.test(run)) return false;
+    }
+  }
+  return true;
 }
 
 function isTelegramParseError(err: unknown): boolean {
@@ -655,9 +742,30 @@ export async function sendLongMessage(
         "Telegram rejected HTML chunk; resending as plain text:",
         err instanceof Error ? err.message : String(err),
       );
-      await ctx.reply(chunk);
+      // Resend human-readable source, not the rejected HTML. Strip the converter
+      // tags and invert the (trivially invertible) HTML escape so the athlete
+      // sees clean text — never tag soup or double-escaped entities.
+      const plain = htmlChunkToPlainText(chunk);
+      if (plain.trim() === "") continue;
+      await ctx.reply(plain);
     }
   }
+}
+
+// Turn a rejected HTML chunk back into readable plain text for the no-parse-mode
+// fallback: drop the converter tags this module emits, then invert escapeHtmlText
+// (`&lt;`→`<`, `&gt;`→`>`, and `&amp;`→`&` LAST so `&amp;lt;` round-trips to
+// `&lt;`). The output carries no tags and no double-escaped entities.
+function htmlChunkToPlainText(chunk: string): string {
+  return chunk
+    .replace(/<\/?(?:b|i|s|u|pre|code)>/g, "")
+    .replace(/<a href="[^"]*">/g, "")
+    .replace(/<\/a>/g, "")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&amp;/g, "&");
 }
 
 // ============================================================================

--- a/packages/core/src/channels/telegram.ts
+++ b/packages/core/src/channels/telegram.ts
@@ -465,9 +465,11 @@ export function markdownToTelegramHtml(md: string): string {
   // post-escape html string, so the link text is already escaped; the url is
   // captured from this same (escaped) string and only attribute-quote-escaped —
   // re-running escapeHtmlText would double-escape an already-escaped `&` in a
-  // multi-param query string. http/https only; other schemes stay literal.
+  // multi-param query string. http/https only; other schemes stay literal. The
+  // URL allows one level of balanced parens so Wikipedia-style URLs like
+  // `…/Foo_(bar)` keep their closing paren instead of truncating at it.
   html = html.replace(
-    /\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g,
+    /\[([^\]]+)\]\((https?:\/\/(?:[^\s()]|\([^\s()]*\))+)\)/g,
     (_, label: string, url: string) => `<a href="${escapeHtmlAttrPreEscaped(url)}">${label}</a>`,
   );
 
@@ -672,16 +674,19 @@ export function chunkHtml(html: string, maxLen: number = TELEGRAM_MAX_LENGTH): s
 }
 
 // Hard-split a single oversized line at a boundary that never bisects an HTML
-// tag (`<…>`), an entity (`&…;`), or a UTF-16 surrogate pair. Scans back from
-// the fixed offset to the last safe cut; if none exists below maxLen the line is
-// pathological (e.g. one >maxLen tag) and we fall back to the raw slice for that
-// one piece to guarantee forward progress.
+// tag (`<…>`), an entity (`&…;`), or a UTF-16 surrogate pair, and never lands
+// BETWEEN a converter tag's open and its close (which would leave a chunk with
+// an unbalanced `<b>`/`<a>`/… — Telegram rejects it and forces the plain-text
+// fallback). Scans back from the fixed offset to the last such safe cut; if none
+// exists below maxLen the line is pathological (e.g. one >maxLen tag) and we fall
+// back to the raw slice for that one piece to guarantee forward progress.
+// (`<pre>` blocks never reach here; they are split by splitPreBlock.)
 function hardSplit(text: string, maxLen: number): string[] {
   const out: string[] = [];
   let start = 0;
   while (text.length - start > maxLen) {
     let cut = start + maxLen;
-    while (cut > start && !isSafeCut(text, cut)) cut--;
+    while (cut > start && !isSafeCut(text, start, cut)) cut--;
     if (cut === start) cut = start + maxLen; // pathological: no safe boundary
     out.push(text.slice(start, cut));
     start = cut;
@@ -690,10 +695,28 @@ function hardSplit(text: string, maxLen: number): string[] {
   return out;
 }
 
-// A cut at index `i` (split into [..i) and [i..]) is safe when it does not land
-// inside an open `<…>` tag, inside an unterminated `&…;` entity, or between the
-// two halves of a surrogate pair.
-function isSafeCut(text: string, i: number): boolean {
+const INLINE_TAG_RE = /<(\/?)(b|i|s|u|code|a)\b[^>]*>/g;
+
+// True when cutting at `i` would leave an inline converter tag opened within
+// [start, i) still unclosed at `i` — i.e. the cut falls between an open tag and
+// its matching close, which yields an unbalanced chunk.
+function cutSplitsOpenTag(text: string, start: number, i: number): boolean {
+  const stack: string[] = [];
+  for (const m of text.slice(start, i).matchAll(INLINE_TAG_RE)) {
+    if (m[1] === "/") {
+      const k = stack.lastIndexOf(m[2]);
+      if (k >= 0) stack.splice(k, 1);
+    } else {
+      stack.push(m[2]);
+    }
+  }
+  return stack.length > 0;
+}
+
+// A cut at index `i` (split into [start..i) and [i..]) is safe when it does not
+// land inside an open `<…>` tag, inside an unterminated `&…;` entity, between the
+// two halves of a surrogate pair, or between a converter tag's open and close.
+function isSafeCut(text: string, start: number, i: number): boolean {
   const prev = text.charCodeAt(i - 1);
   if (prev >= 0xd800 && prev <= 0xdbff) return false; // high surrogate before cut
 
@@ -714,6 +737,8 @@ function isSafeCut(text: string, i: number): boolean {
       if (/^[a-zA-Z0-9#]*$/.test(run)) return false;
     }
   }
+
+  if (cutSplitsOpenTag(text, start, i)) return false;
   return true;
 }
 

--- a/packages/core/src/reference/sync/snapshot-debug.ts
+++ b/packages/core/src/reference/sync/snapshot-debug.ts
@@ -1,3 +1,4 @@
+import { escapeHtmlText } from "../../channels/html-escape.js";
 import {
   SNAPSHOT_DOCUMENT_THRESHOLD_BYTES,
   SNAPSHOT_DOCUMENT_THRESHOLD_CHUNKS,
@@ -7,13 +8,10 @@ import type { LatestJson } from "../schemas/latest.js";
 const TELEGRAM_MAX_CHUNK = 4096;
 // Each chunk is a code fence the Telegram HTML path renders as an escaped
 // <pre> block (the snapshot reply runs every chunk through markdownToTelegramHtml).
-// Reserve overhead for the fence + the <pre>…</pre> the converter adds so the
-// rendered chunk still fits Telegram's 4096-char limit.
 const FENCE_OPEN = "```\n";
 const FENCE_CLOSE = "\n```";
-const FENCE_OVERHEAD = FENCE_OPEN.length + FENCE_CLOSE.length;
-const PRE_RENDER_OVERHEAD = "<pre></pre>".length;
-const BODY_BUDGET = TELEGRAM_MAX_CHUNK - FENCE_OVERHEAD - PRE_RENDER_OVERHEAD;
+// Room the rendered `<pre>${escapeHtmlText(body)}</pre>` leaves for the body.
+const RENDERED_BUDGET = TELEGRAM_MAX_CHUNK - "<pre></pre>".length;
 
 const VALID_SECTIONS: readonly (keyof LatestJson)[] = [
   "athlete_profile",
@@ -92,11 +90,34 @@ function wrap(body: string): SnapshotOutput {
   return { kind: "chunks", chunks };
 }
 
+function isHighSurrogate(code: number): boolean {
+  return code >= 0xd800 && code <= 0xdbff;
+}
+
+// Each emitted chunk is a code fence the HTML path restores as
+// `<pre>${escapeHtmlText(body)}</pre>`. Budget by the RENDERED length, not the
+// raw length: a slice dense with `& < >` expands under escaping (`&`→`&amp;` is
+// +4), so a raw-length budget could render a <pre> past Telegram's 4096 limit,
+// and the converter's own chunker would then re-split it — breaking the 1:1
+// raw→sent mapping the snapshot retry relies on. Growing the slice until the
+// rendered <pre> would overflow guarantees one sub-chunk out per raw chunk.
 function splitIntoChunks(body: string): readonly string[] {
   const out: string[] = [];
-  for (let i = 0; i < body.length; i += BODY_BUDGET) {
-    const slice = body.slice(i, i + BODY_BUDGET);
-    out.push(`${FENCE_OPEN}${slice}${FENCE_CLOSE}`);
+  let i = 0;
+  while (i < body.length) {
+    let rendered = 0;
+    let j = i;
+    while (j < body.length) {
+      const next = escapeHtmlText(body[j]).length;
+      if (rendered + next > RENDERED_BUDGET) break;
+      rendered += next;
+      j++;
+    }
+    // Don't cut between the halves of a surrogate pair (but always make progress).
+    if (j > i + 1 && j < body.length && isHighSurrogate(body.charCodeAt(j - 1))) j--;
+    // A single char can never exceed the budget, so j always advances past i.
+    out.push(`${FENCE_OPEN}${body.slice(i, j)}${FENCE_CLOSE}`);
+    i = j;
   }
   return out;
 }

--- a/packages/core/src/reference/sync/snapshot-debug.ts
+++ b/packages/core/src/reference/sync/snapshot-debug.ts
@@ -11,7 +11,10 @@ const TELEGRAM_MAX_CHUNK = 4096;
 const FENCE_OPEN = "```\n";
 const FENCE_CLOSE = "\n```";
 // Room the rendered `<pre>${escapeHtmlText(body)}</pre>` leaves for the body.
-const RENDERED_BUDGET = TELEGRAM_MAX_CHUNK - "<pre></pre>".length;
+// The trailing `-1` reserves the leading `\n` of FENCE_CLOSE: FENCE_RE captures
+// `slice + "\n"` as the fence body, so the restored <pre> carries one extra char
+// the `<pre></pre>` overhead alone doesn't account for.
+const RENDERED_BUDGET = TELEGRAM_MAX_CHUNK - "<pre></pre>".length - 1;
 
 const VALID_SECTIONS: readonly (keyof LatestJson)[] = [
   "athlete_profile",

--- a/packages/core/src/reference/sync/snapshot-debug.ts
+++ b/packages/core/src/reference/sync/snapshot-debug.ts
@@ -5,12 +5,15 @@ import {
 import type { LatestJson } from "../schemas/latest.js";
 
 const TELEGRAM_MAX_CHUNK = 4096;
-// Wrap inside ```json ... ``` fences for readability; reserve overhead for the
-// fences themselves so the body fits.
-const FENCE_OPEN = "```json\n";
+// Each chunk is a code fence the Telegram HTML path renders as an escaped
+// <pre> block (the snapshot reply runs every chunk through markdownToTelegramHtml).
+// Reserve overhead for the fence + the <pre>…</pre> the converter adds so the
+// rendered chunk still fits Telegram's 4096-char limit.
+const FENCE_OPEN = "```\n";
 const FENCE_CLOSE = "\n```";
 const FENCE_OVERHEAD = FENCE_OPEN.length + FENCE_CLOSE.length;
-const BODY_BUDGET = TELEGRAM_MAX_CHUNK - FENCE_OVERHEAD;
+const PRE_RENDER_OVERHEAD = "<pre></pre>".length;
+const BODY_BUDGET = TELEGRAM_MAX_CHUNK - FENCE_OVERHEAD - PRE_RENDER_OVERHEAD;
 
 const VALID_SECTIONS: readonly (keyof LatestJson)[] = [
   "athlete_profile",

--- a/packages/core/tests/reference-snapshot-debug.test.ts
+++ b/packages/core/tests/reference-snapshot-debug.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { formatSnapshotRaw } from "../src/reference/sync/snapshot-debug.js";
+import { markdownToTelegramHtml, chunkHtml } from "../src/channels/telegram.js";
 import type { LatestJson } from "../src/reference/schemas/latest.js";
 
 const tinyLatest: LatestJson = {
@@ -43,6 +44,28 @@ describe("formatSnapshotRaw", () => {
       // The serialized data should appear somewhere in the chunks.
       expect(out.chunks.join("")).toContain("\"id\": \"test\"");
       expect(out.chunks.join("")).toContain("\"sleep_hours\": 7.5");
+    }
+  });
+
+  it("renders every chunk to a single <pre> within Telegram's limit even when the body is escape-dense", () => {
+    // intervals.icu activity names/descriptions are Strava-mirrored and can be
+    // dense with `& < >`, which expand under HTML escaping (`&`→`&amp;` is +4).
+    // If the chunk budget ignored that expansion, a rendered <pre> would overflow
+    // 4096 and the converter's chunker would re-split it — breaking the 1:1
+    // raw→sent mapping the snapshot retry relies on.
+    const escapeDense: LatestJson = {
+      ...tinyLatest,
+      recent_activities: [{ id: 1, name: "<&>".repeat(1000) }],
+    };
+    const out = formatSnapshotRaw(escapeDense);
+    expect(out.kind).toBe("chunks");
+    if (out.kind === "chunks") {
+      expect(out.chunks.length).toBeGreaterThan(1);
+      for (const chunk of out.chunks) {
+        const rendered = markdownToTelegramHtml(chunk);
+        expect(rendered.length).toBeLessThanOrEqual(4096);
+        expect(chunkHtml(rendered)).toHaveLength(1);
+      }
     }
   });
 

--- a/packages/core/tests/reference-snapshot-debug.test.ts
+++ b/packages/core/tests/reference-snapshot-debug.test.ts
@@ -27,15 +27,18 @@ describe("formatSnapshotRaw", () => {
     }
   });
 
-  it("returns chunked markdown for a small full dump (each chunk ≤4096 chars)", () => {
+  it("returns HTML-path-renderable chunks for a small full dump (each chunk ≤4096 chars)", () => {
     const out = formatSnapshotRaw(tinyLatest);
     expect(out.kind).toBe("chunks");
     if (out.kind === "chunks") {
       expect(out.chunks.length).toBeGreaterThanOrEqual(1);
       for (const chunk of out.chunks) {
         expect(chunk.length).toBeLessThanOrEqual(4096);
-        expect(chunk.startsWith("```json")).toBe(true);
-        expect(chunk.endsWith("```")).toBe(true);
+        // Each chunk is a plain code fence the HTML path renders as an escaped
+        // <pre> block (no language tag, no legacy ```json wrapper).
+        expect(chunk.startsWith("```\n")).toBe(true);
+        expect(chunk.endsWith("\n```")).toBe(true);
+        expect(chunk.startsWith("```json")).toBe(false);
       }
       // The serialized data should appear somewhere in the chunks.
       expect(out.chunks.join("")).toContain("\"id\": \"test\"");

--- a/packages/core/tests/reference-snapshot-debug.test.ts
+++ b/packages/core/tests/reference-snapshot-debug.test.ts
@@ -69,6 +69,37 @@ describe("formatSnapshotRaw", () => {
     }
   });
 
+  it("keeps a budget-filling plain-ASCII chunk inside Telegram's limit (1:1 raw→sent)", () => {
+    // The COMMON case: JSON snapshots are predominantly ASCII, where each char
+    // escapes to length 1, so a full-size chunk fills the rendered budget exactly.
+    // FENCE_RE captures `slice + "\n"` (the leading newline of the closing fence)
+    // as the <pre> body, so the restored block carries one char the `<pre></pre>`
+    // overhead alone never reserves. Sizing the section so a slice lands on the
+    // budget boundary exercises that path: without the trailing -1 in
+    // RENDERED_BUDGET the rendered <pre> would be 4097, defeating the 1:1
+    // raw→sent invariant this chunker exists to guarantee.
+    const asciiHeavy: LatestJson = {
+      ...tinyLatest,
+      derived_metrics: { note: "z".repeat(9000) },
+    };
+    const out = formatSnapshotRaw(asciiHeavy);
+    expect(out.kind).toBe("chunks");
+    if (out.kind === "chunks") {
+      expect(out.chunks.length).toBeGreaterThan(1);
+      // At least one chunk must actually fill the budget — otherwise the test
+      // never exercises the boundary it's meant to guard.
+      const maxRendered = Math.max(
+        ...out.chunks.map((chunk) => markdownToTelegramHtml(chunk).length),
+      );
+      expect(maxRendered).toBe(4096);
+      for (const chunk of out.chunks) {
+        const rendered = markdownToTelegramHtml(chunk);
+        expect(rendered.length).toBeLessThanOrEqual(4096);
+        expect(chunkHtml(rendered)).toHaveLength(1);
+      }
+    }
+  });
+
   it("returns just the requested section when a valid name is passed", () => {
     const out = formatSnapshotRaw(tinyLatest, "wellness_data");
     expect(out.kind).toBe("chunks");

--- a/packages/core/tests/telegram-md.test.ts
+++ b/packages/core/tests/telegram-md.test.ts
@@ -123,6 +123,60 @@ describe("markdownToTelegramHtml", () => {
     const out = markdownToTelegramHtml("a &amp; b");
     expect(out).toContain("a &amp;amp; b");
   });
+
+  it("preserves fenced content byte-for-byte (modulo escaping) with no transform injection", () => {
+    const out = markdownToTelegramHtml("```\n- 4x8min @ 105%\n# main set\ndo 3 * 8\n```");
+    const pre = out.match(/<pre>([\s\S]*?)<\/pre>/);
+    expect(pre).not.toBeNull();
+    const body = pre![1];
+    expect(body).toContain("- 4x8min @ 105%");
+    expect(body).toContain("# main set");
+    expect(body).toContain("do 3 * 8");
+    expect(out).not.toContain("•");
+    expect(out).not.toContain("<b>main set</b>");
+    expect(out).not.toContain("<i>");
+  });
+
+  it("does not italicize spaced asterisks in interval math", () => {
+    const out = markdownToTelegramHtml("do 3 * 8 reps then 2 * 20min");
+    expect(out).toContain("3 * 8");
+    expect(out).toContain("2 * 20min");
+    expect(out).not.toContain("<i>");
+  });
+
+  it("still italicizes genuine emphasis with no internal spaces", () => {
+    const out = markdownToTelegramHtml("this is *important*");
+    expect(out).toContain("<i>important</i>");
+  });
+
+  it("renders an https link as an escaped <a href>", () => {
+    const out = markdownToTelegramHtml("see [the plan](https://example.com)");
+    expect(out).toContain('<a href="https://example.com">the plan</a>');
+  });
+
+  it("renders an http link as an escaped <a href>", () => {
+    const out = markdownToTelegramHtml("[x](http://a.b)");
+    expect(out).toContain('<a href="http://a.b">x</a>');
+  });
+
+  it("leaves a non-http(s) link as literal text", () => {
+    const out = markdownToTelegramHtml("[x](javascript:alert(1))");
+    expect(out).not.toContain("<a");
+    expect(out).toContain("[x](javascript:alert(1))");
+  });
+
+  it("attribute-escapes a quote in the link href", () => {
+    const out = markdownToTelegramHtml('[x](https://a.b/?q="hi")');
+    const href = out.match(/href="([^"]*)"/);
+    expect(href).not.toBeNull();
+    expect(out).toContain("&quot;");
+  });
+
+  it("does not double-escape an ampersand in a multi-param link href", () => {
+    const out = markdownToTelegramHtml("[plan](https://example.com/?a=1&b=2)");
+    expect(out).toContain('href="https://example.com/?a=1&amp;b=2"');
+    expect(out).not.toContain("&amp;amp;");
+  });
 });
 
 describe("sendLongMessage", () => {
@@ -130,7 +184,7 @@ describe("sendLongMessage", () => {
     return { reply: vi.fn(replyImpl) };
   }
 
-  it("retries a chunk as plain text when Telegram rejects the HTML parse", async () => {
+  it("falls back to human-readable source text when Telegram rejects the HTML parse", async () => {
     const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const ctx = makeCtx(async (_text, options) => {
       if (options?.parse_mode === "HTML") {
@@ -140,12 +194,21 @@ describe("sendLongMessage", () => {
       }
       return undefined;
     });
-    await expect(sendLongMessage(ctx, "hello **world**")).resolves.toBeUndefined();
+    await expect(
+      sendLongMessage(ctx, "**Week 1** a & b [link](https://x.y)"),
+    ).resolves.toBeUndefined();
     expect(ctx.reply).toHaveBeenCalledTimes(2);
     const [firstCall, secondCall] = ctx.reply.mock.calls;
     expect(firstCall[1]).toEqual({ parse_mode: "HTML" });
     expect(secondCall[1]).toBeUndefined();
-    expect(secondCall[0]).toBe(firstCall[0]);
+    const fallback = String(secondCall[0]);
+    expect(fallback).not.toContain("<b>");
+    expect(fallback).not.toContain("<i>");
+    expect(fallback).not.toContain("<pre>");
+    expect(fallback).not.toContain("<a");
+    expect(fallback).not.toContain("&amp;amp;");
+    expect(fallback).toContain("Week 1");
+    expect(fallback).toContain("a & b");
     errSpy.mockRestore();
   });
 
@@ -248,6 +311,23 @@ describe("chunkHtml", () => {
       expect(opens).toBe(closes);
       expect(c.length).toBeLessThanOrEqual(MAX);
     }
+  });
+
+  it("hard-splits without cutting a tag, entity, or surrogate pair", () => {
+    const unit = "<b>x</b> &amp; ";
+    const line = unit.repeat(Math.ceil((MAX + 1000) / unit.length));
+    const chunks = chunkHtml(line);
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const c of chunks) {
+      expect(c.length).toBeLessThanOrEqual(MAX);
+      expect(c.match(/<[^>]*$/)).toBeNull(); // no chunk ends mid-tag
+      expect(c.match(/&[^;]*$/)).toBeNull(); // no chunk ends mid-entity
+      const last = c.charCodeAt(c.length - 1);
+      expect(last >= 0xd800 && last <= 0xdbff).toBe(false); // no lone high surrogate
+      const first = c.charCodeAt(0);
+      expect(first >= 0xdc00 && first <= 0xdfff).toBe(false); // no lone low surrogate
+    }
+    expect(chunks.join("")).toBe(line);
   });
 
   it("preserves consecutive multi-line <pre> blocks across chunking", () => {

--- a/packages/core/tests/telegram-md.test.ts
+++ b/packages/core/tests/telegram-md.test.ts
@@ -177,6 +177,12 @@ describe("markdownToTelegramHtml", () => {
     expect(out).toContain('href="https://example.com/?a=1&amp;b=2"');
     expect(out).not.toContain("&amp;amp;");
   });
+
+  it("keeps a balanced closing paren inside the link URL", () => {
+    const out = markdownToTelegramHtml("see [Foo](https://en.wikipedia.org/wiki/Foo_(bar))");
+    expect(out).toContain('<a href="https://en.wikipedia.org/wiki/Foo_(bar)">Foo</a>');
+    expect(out).not.toContain(">)"); // no stray dangling paren after the link
+  });
 });
 
 describe("sendLongMessage", () => {
@@ -328,6 +334,18 @@ describe("chunkHtml", () => {
       expect(first >= 0xdc00 && first <= 0xdfff).toBe(false); // no lone low surrogate
     }
     expect(chunks.join("")).toBe(line);
+  });
+
+  it("keeps inline tags balanced when hard-splitting a long formatted line", () => {
+    const unit = "<b>workout</b> ";
+    const line = unit.repeat(Math.ceil((MAX + 1000) / unit.length));
+    const chunks = chunkHtml(line);
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const c of chunks) {
+      expect(c.length).toBeLessThanOrEqual(MAX);
+      expect((c.match(/<b>/g) ?? []).length).toBe((c.match(/<\/b>/g) ?? []).length);
+      expect(c.match(/<[^>]*$/)).toBeNull(); // no chunk ends mid-tag
+    }
   });
 
   it("preserves consecutive multi-line <pre> blocks across chunking", () => {


### PR DESCRIPTION
Hardens the Telegram markdown-to-HTML rendering pipeline so workout prescriptions, code blocks, and links render correctly, and so a parse failure degrades to readable text instead of tag soup.

## What changed (by surface)

- **Fenced code blocks** (`channels/telegram.ts`): fence extraction now runs on the raw markdown *before* escaping, mirroring the existing table-extraction path. Each fence is swapped for an inert placeholder, then restored at the end as an escaped `<pre>` block. This preserves the escape-first security property while keeping fenced content byte-identical (no bullet/header/italic injection inside the block). The old inline fence-to-`<pre>` regex is removed.
- **Italic regex** (`channels/telegram.ts`): tightened so a space adjacent to either asterisk disqualifies the match, so interval math like `do 3 * 8` keeps its literal asterisks while `*emphasis*` still italicizes.
- **Links** (`channels/telegram.ts`): an http/https-only `[text](url)` rule renders an attribute-escaped `<a href>` on the post-escape string, with no double-escaped `&` on multi-param query URLs; non-http(s) targets stay literal.
- **Hard split** (`channels/telegram.ts`): the long-message chunker's fixed-offset split is replaced with an entity/tag/surrogate-safe split that preserves the `<pre>`-integrity invariants.
- **Parse-failure fallback** (`channels/telegram.ts`): when Telegram rejects a chunk, the fallback now delivers human-readable markdown source rather than resending the HTML chunk, keeping the message-only PII discipline.
- **`/snapshot` debug dump** (`reference/sync/snapshot-debug.ts`): routed through the HTML path, dropping the lone legacy Markdown parse mode; chunk-shape assertions updated in lockstep.

## Test plan

- `pnpm vitest run packages/core/tests/telegram-md.test.ts` — fence preservation, spaced-asterisk round-trip, link escaping, hard-split integrity, fallback content, and the escape-first security suite stay green.
- `pnpm vitest run packages/core/tests/reference-snapshot-debug.test.ts packages/core/tests/reference-send-snapshot.test.ts` — `/snapshot` HTML migration; the send-snapshot surface is unedited.
- `pnpm test && pnpm check` — full suite and typecheck green.

Stacked on top of the prior CLI-exit-paths task's branch (base is that branch, not main); the operator merges bottom-up and retargets.