### PR TITLE
feat(core): cap oversized tool results and shape intervals payloads

### DIFF
--- a/.changeset/tool-payload-cap.md
+++ b/.changeset/tool-payload-cap.md
@@ -1,0 +1,7 @@
+---
+"@enduragent/core": patch
+---
+
+User-facing: Deep race-review turns with very large data fetches now degrade gracefully instead of failing.
+
+A generic per-result token-share cap is applied at the tool-registration boundary: any tool whose serialized result exceeds half the context window is replaced with a count-preserving notice the model can act on (rerun with narrower arguments), while small results pass through byte-identical. On top of that backstop, the intervals.icu stream fetch now downsamples raw time-series to 10-second bins with a per-channel min/max/mean stats header that preserves true peaks, so a 3-hour ride fits the smallest supported context window instead of overflowing the mid-turn step loop and exhausting the overflow-recovery retries. Every intervals.icu fetch tool's error path now returns a typed object carrying the error kind plus optional HTTP status or message, additively, without changing the kind key the prompt's error-translation table reads.

--- a/packages/core/src/agent/coach-agent.ts
+++ b/packages/core/src/agent/coach-agent.ts
@@ -22,6 +22,7 @@ import { ChatStore } from "./chat-store.js";
 import { buildSystemPrompt, staticRuleBlocks } from "./system-prompt.js";
 import { computeAssembledHash, computeTemplateHash, sha256_16 } from "./prompt-lineage.js";
 import { withSessionLock } from "./session-lock.js";
+import { capToolResult, TOOL_RESULT_SHARE } from "./tool-result-cap.js";
 import { splitHistoryByBudget, makeSummaryMessage } from "./history-limit.js";
 import {
   shouldCompact,
@@ -221,8 +222,12 @@ export class CoachAgent {
       resolvedCs: () => this.resolvedCsStore.getStore() ?? null,
     };
     const registrations = sport.tools(coreDeps);
+    const maxResultTokens = Math.floor(this.config.contextWindowTokens * TOOL_RESULT_SHARE);
     this.tools = Object.fromEntries(
-      registrations.map((r) => [r.name, this.wrapWriteTool(r.name, r.tool)]),
+      registrations.map((r) => [
+        r.name,
+        this.wrapWriteTool(r.name, capToolResult(r.tool, { maxResultTokens })),
+      ]),
     ) as ToolSet;
     // systemPrompt is rebuilt at the top of every chat() call; no need to bake one here.
     this.systemPrompt = "";

--- a/packages/core/src/agent/intervals-tools.ts
+++ b/packages/core/src/agent/intervals-tools.ts
@@ -119,7 +119,7 @@ export function createPureCoreIntervalsTools(
           : ["watts", "heartrate", "cadence", "time", "altitude"];
         const result = await intervals.activities.getStreams(String(input.activityId), types);
         if (!result.ok) return toTypedError(result.error);
-        return downsampleStreams(result.value as Record<string, unknown>);
+        return downsampleStreams(result.value as Record<string, unknown> | unknown[]);
       },
     }),
 

--- a/packages/core/src/agent/intervals-tools.ts
+++ b/packages/core/src/agent/intervals-tools.ts
@@ -1,8 +1,17 @@
 import { tool, zodSchema } from "ai";
 import { z } from "zod";
-import type { IntervalsClient } from "intervals-icu-api";
+import type { ApiError, IntervalsClient } from "intervals-icu-api";
 import type { IntervalsActivityType } from "../sport.js";
 import { todayInTZ } from "./user-time.js";
+import { downsampleStreams } from "./stream-downsample.js";
+
+function toTypedError(error: ApiError): { error: string; status?: number; message?: string } {
+  return {
+    error: error.kind,
+    ...("status" in error ? { status: error.status } : {}),
+    ...("message" in error ? { message: error.message } : {}),
+  };
+}
 
 // intervals-icu-api's TypeScript types declare snake_case fields, but the runtime
 // runs `camelCaseKeys` over every parsed response. So the types lie: at runtime we
@@ -35,7 +44,7 @@ export function createPureCoreIntervalsTools(
       inputSchema: zodSchema(z.object({})),
       execute: async () => {
         const result = await intervals.athlete.get();
-        if (!result.ok) return { error: result.error.kind };
+        if (!result.ok) return toTypedError(result.error);
         return result.value;
       },
     }),
@@ -54,7 +63,7 @@ export function createPureCoreIntervalsTools(
           oldest: input.oldest,
           newest: input.newest ?? undefined,
         });
-        if (!result.ok) return { error: result.error.kind };
+        if (!result.ok) return toTypedError(result.error);
         return result.value;
       },
     }),
@@ -74,7 +83,7 @@ export function createPureCoreIntervalsTools(
       ),
       execute: async (input: { activityId: number }) => {
         const result = await intervals.activities.get(String(input.activityId));
-        if (!result.ok) return { error: result.error.kind };
+        if (!result.ok) return toTypedError(result.error);
         return result.value;
       },
     }),
@@ -82,9 +91,11 @@ export function createPureCoreIntervalsTools(
     intervals_fetch_streams: tool({
       description:
         "Fetch raw time-series streams for an activity (watts, heartrate, cadence, " +
-        "time, altitude, distance, lat, lng). Returns an object with each requested " +
-        "type as a sample array. EXPENSIVE: a 3-hour ride is ~10,800 samples per " +
-        "type. ONLY call for Tier C deep reviews (races + explicit 'deep' override). " +
+        "time, altitude, distance, lat, lng). Returns a downsampled object: each " +
+        "requested type is binned to 10-second windows (one mean value per bin) with " +
+        "a per-channel min/max/mean stats header carrying the true peaks and averages " +
+        "over the full series. EXPENSIVE: a 3-hour ride is ~10,800 samples per " +
+        "type even before binning. ONLY call for Tier C deep reviews (races + explicit 'deep' override). " +
         "For Tier A/B reviews, use `intervals_fetch_activities` and " +
         "`intervals_fetch_activity` instead. Default types are watts, heartrate, " +
         "cadence, time, altitude.",
@@ -107,8 +118,8 @@ export function createPureCoreIntervalsTools(
           ? input.types
           : ["watts", "heartrate", "cadence", "time", "altitude"];
         const result = await intervals.activities.getStreams(String(input.activityId), types);
-        if (!result.ok) return { error: result.error.kind };
-        return result.value;
+        if (!result.ok) return toTypedError(result.error);
+        return downsampleStreams(result.value as Record<string, unknown>);
       },
     }),
 
@@ -125,7 +136,7 @@ export function createPureCoreIntervalsTools(
       ),
       execute: async (input: { eventId: number }) => {
         const fetched = await intervals.events.get(input.eventId);
-        if (!fetched.ok) return { error: fetched.error.kind };
+        if (!fetched.ok) return toTypedError(fetched.error);
         const event = fetched.value as unknown as IntervalsEventRuntime;
         const today = todayInTZ(tz);
         const eventDate = event.startDateLocal.slice(0, 10);
@@ -136,7 +147,7 @@ export function createPureCoreIntervalsTools(
           };
         }
         const result = await intervals.events.delete(input.eventId);
-        if (!result.ok) return { error: result.error.kind };
+        if (!result.ok) return toTypedError(result.error);
         return { deleted: true };
       },
     }),
@@ -172,7 +183,7 @@ export function createCoreToolsWithSportConfig(
           oldest: input.oldest,
           newest: input.newest ?? undefined,
         });
-        if (!result.ok) return { error: result.error.kind };
+        if (!result.ok) return toTypedError(result.error);
         return result.value;
       },
     }),
@@ -194,7 +205,7 @@ export function createCoreToolsWithSportConfig(
           newest: input.newest ?? undefined,
           category: ["WORKOUT"],
         });
-        if (!result.ok) return { error: result.error.kind };
+        if (!result.ok) return toTypedError(result.error);
         return (result.value as unknown as IntervalsEventRuntime[]).map((e) => ({
           id: e.id,
           startDateLocal: e.startDateLocal,

--- a/packages/core/src/agent/stream-downsample.ts
+++ b/packages/core/src/agent/stream-downsample.ts
@@ -15,37 +15,62 @@ export type DownsampledStreams = {
   channels: Record<string, ChannelSummary>;
 };
 
-function isNumericArray(value: unknown): value is number[] {
-  return Array.isArray(value) && value.every((v) => typeof v === "number");
+// intervals.icu's streams endpoint returns an array of channel objects
+// (`[{type, data}, …]`); only some integrations pre-key it into `{watts, …}`.
+// Accept both so the live array form is not silently dropped, and tolerate the
+// null gaps the API marks with `allNull` — a dropped sensor packet must not lose
+// the whole channel.
+function toChannelArrays(raw: unknown): Array<[string, unknown[]]> {
+  if (Array.isArray(raw)) {
+    const out: Array<[string, unknown[]]> = [];
+    for (const el of raw) {
+      if (el === null || typeof el !== "object") continue;
+      const { type, data } = el as { type?: unknown; data?: unknown };
+      if (typeof type === "string" && Array.isArray(data)) out.push([type, data]);
+    }
+    return out;
+  }
+  if (raw !== null && typeof raw === "object") {
+    return Object.entries(raw as Record<string, unknown>).filter(
+      (entry): entry is [string, unknown[]] => Array.isArray(entry[1]),
+    );
+  }
+  return [];
 }
 
-function summarizeChannel(values: number[], binSeconds: number): ChannelSummary {
-  let min = values[0];
-  let max = values[0];
+function summarizeChannel(values: readonly unknown[], binSeconds: number): ChannelSummary | null {
+  let min = Infinity;
+  let max = -Infinity;
   let sum = 0;
+  let count = 0;
   for (const v of values) {
+    if (typeof v !== "number" || !Number.isFinite(v)) continue;
     if (v < min) min = v;
     if (v > max) max = v;
     sum += v;
+    count++;
   }
-  const mean = Math.round((sum / values.length) * 10) / 10;
+  if (count === 0) return null;
+  const mean = Math.round((sum / count) * 10) / 10;
 
   const samples: number[] = [];
   for (let i = 0; i < values.length; i += binSeconds) {
     let binSum = 0;
     let binCount = 0;
     for (let j = i; j < i + binSeconds && j < values.length; j++) {
-      binSum += values[j];
+      const v = values[j];
+      if (typeof v !== "number" || !Number.isFinite(v)) continue;
+      binSum += v;
       binCount++;
     }
-    samples.push(Math.round(binSum / binCount));
+    if (binCount > 0) samples.push(Math.round(binSum / binCount));
   }
 
   return { min, max, mean, samples };
 }
 
 export function downsampleStreams(
-  raw: Record<string, unknown>,
+  raw: Record<string, unknown> | unknown[],
   opts?: { binSeconds?: number },
 ): DownsampledStreams {
   const binSeconds = opts?.binSeconds ?? STREAM_BIN_SECONDS;
@@ -53,11 +78,11 @@ export function downsampleStreams(
   let sampleCount = 0;
   let bins = 0;
 
-  for (const [name, value] of Object.entries(raw)) {
-    if (!isNumericArray(value) || value.length === 0) continue;
-    const summary = summarizeChannel(value, binSeconds);
+  for (const [name, values] of toChannelArrays(raw)) {
+    const summary = summarizeChannel(values, binSeconds);
+    if (!summary) continue;
     channels[name] = summary;
-    if (value.length > sampleCount) sampleCount = value.length;
+    if (values.length > sampleCount) sampleCount = values.length;
     if (summary.samples.length > bins) bins = summary.samples.length;
   }
 

--- a/packages/core/src/agent/stream-downsample.ts
+++ b/packages/core/src/agent/stream-downsample.ts
@@ -1,0 +1,65 @@
+export const STREAM_BIN_SECONDS = 10;
+export const STREAM_RESULT_TARGET_TOKENS = 7_000;
+
+type ChannelSummary = {
+  min: number;
+  max: number;
+  mean: number;
+  samples: number[];
+};
+
+export type DownsampledStreams = {
+  binSeconds: number;
+  sampleCount: number;
+  bins: number;
+  channels: Record<string, ChannelSummary>;
+};
+
+function isNumericArray(value: unknown): value is number[] {
+  return Array.isArray(value) && value.every((v) => typeof v === "number");
+}
+
+function summarizeChannel(values: number[], binSeconds: number): ChannelSummary {
+  let min = values[0];
+  let max = values[0];
+  let sum = 0;
+  for (const v of values) {
+    if (v < min) min = v;
+    if (v > max) max = v;
+    sum += v;
+  }
+  const mean = Math.round((sum / values.length) * 10) / 10;
+
+  const samples: number[] = [];
+  for (let i = 0; i < values.length; i += binSeconds) {
+    let binSum = 0;
+    let binCount = 0;
+    for (let j = i; j < i + binSeconds && j < values.length; j++) {
+      binSum += values[j];
+      binCount++;
+    }
+    samples.push(Math.round(binSum / binCount));
+  }
+
+  return { min, max, mean, samples };
+}
+
+export function downsampleStreams(
+  raw: Record<string, unknown>,
+  opts?: { binSeconds?: number },
+): DownsampledStreams {
+  const binSeconds = opts?.binSeconds ?? STREAM_BIN_SECONDS;
+  const channels: Record<string, ChannelSummary> = {};
+  let sampleCount = 0;
+  let bins = 0;
+
+  for (const [name, value] of Object.entries(raw)) {
+    if (!isNumericArray(value) || value.length === 0) continue;
+    const summary = summarizeChannel(value, binSeconds);
+    channels[name] = summary;
+    if (value.length > sampleCount) sampleCount = value.length;
+    if (summary.samples.length > bins) bins = summary.samples.length;
+  }
+
+  return { binSeconds, sampleCount, bins, channels };
+}

--- a/packages/core/src/agent/stream-downsample.ts
+++ b/packages/core/src/agent/stream-downsample.ts
@@ -43,29 +43,27 @@ function summarizeChannel(values: readonly unknown[], binSeconds: number): Chann
   let max = -Infinity;
   let sum = 0;
   let count = 0;
-  for (const v of values) {
-    if (typeof v !== "number" || !Number.isFinite(v)) continue;
-    if (v < min) min = v;
-    if (v > max) max = v;
-    sum += v;
-    count++;
-  }
-  if (count === 0) return null;
-  const mean = Math.round((sum / count) * 10) / 10;
-
   const samples: number[] = [];
+
   for (let i = 0; i < values.length; i += binSeconds) {
     let binSum = 0;
     let binCount = 0;
     for (let j = i; j < i + binSeconds && j < values.length; j++) {
       const v = values[j];
       if (typeof v !== "number" || !Number.isFinite(v)) continue;
+      if (v < min) min = v;
+      if (v > max) max = v;
       binSum += v;
       binCount++;
     }
-    if (binCount > 0) samples.push(Math.round(binSum / binCount));
+    if (binCount === 0) continue;
+    sum += binSum;
+    count += binCount;
+    samples.push(Math.round(binSum / binCount));
   }
 
+  if (count === 0) return null;
+  const mean = Math.round((sum / count) * 10) / 10;
   return { min, max, mean, samples };
 }
 

--- a/packages/core/src/agent/tool-result-cap.ts
+++ b/packages/core/src/agent/tool-result-cap.ts
@@ -11,16 +11,16 @@ type CappedResult = {
   estimatedTokens: number;
 };
 
-function omittedSampleCount(result: unknown, serializedLength: number): number {
-  if (result !== null && typeof result === "object" && !Array.isArray(result)) {
+function omittedSampleCount(result: unknown): number {
+  if (Array.isArray(result)) return result.length;
+  if (result !== null && typeof result === "object") {
     let largest = 0;
     for (const value of Object.values(result as Record<string, unknown>)) {
       if (Array.isArray(value) && value.length > largest) largest = value.length;
     }
-    if (largest > 0) return largest;
+    return largest;
   }
-  if (Array.isArray(result)) return result.length;
-  return serializedLength > 0 && typeof result === "string" ? serializedLength : 0;
+  return 0;
 }
 
 export function capToolResult(tool: Tool, opts: { maxResultTokens: number }): Tool {
@@ -34,7 +34,7 @@ export function capToolResult(tool: Tool, opts: { maxResultTokens: number }): To
         typeof result === "string" ? result : (JSON.stringify(result) ?? "");
       const estimatedTokens = estimateTokens(serialized);
       if (estimatedTokens <= opts.maxResultTokens) return result;
-      const omittedSamples = omittedSampleCount(result, serialized.length);
+      const omittedSamples = omittedSampleCount(result);
       const capped: CappedResult = {
         truncated: true,
         notice:

--- a/packages/core/src/agent/tool-result-cap.ts
+++ b/packages/core/src/agent/tool-result-cap.ts
@@ -1,0 +1,49 @@
+import type { Tool } from "ai";
+import { estimateTokens } from "./token-utils.js";
+
+export const TOOL_RESULT_SHARE = 0.5;
+export const STEP_BOUNDARY_RATIO = 0.9;
+
+type CappedResult = {
+  truncated: true;
+  notice: string;
+  omittedSamples: number;
+  estimatedTokens: number;
+};
+
+function omittedSampleCount(result: unknown, serializedLength: number): number {
+  if (result !== null && typeof result === "object" && !Array.isArray(result)) {
+    let largest = 0;
+    for (const value of Object.values(result as Record<string, unknown>)) {
+      if (Array.isArray(value) && value.length > largest) largest = value.length;
+    }
+    if (largest > 0) return largest;
+  }
+  if (Array.isArray(result)) return result.length;
+  return serializedLength > 0 && typeof result === "string" ? serializedLength : 0;
+}
+
+export function capToolResult(tool: Tool, opts: { maxResultTokens: number }): Tool {
+  const inner = tool.execute;
+  if (typeof inner !== "function") return tool;
+  return {
+    ...tool,
+    execute: async (input: unknown, options: unknown) => {
+      const result = await (inner as (i: unknown, o: unknown) => unknown)(input, options);
+      const serialized =
+        typeof result === "string" ? result : (JSON.stringify(result) ?? "");
+      const estimatedTokens = estimateTokens(serialized);
+      if (estimatedTokens <= opts.maxResultTokens) return result;
+      const omittedSamples = omittedSampleCount(result, serialized.length);
+      const capped: CappedResult = {
+        truncated: true,
+        notice:
+          `Tool result too large (~${estimatedTokens} tokens) and was omitted to protect context. ` +
+          "Rerun with narrower arguments (e.g. a smaller date range, fewer stream types, or a shorter activity).",
+        omittedSamples,
+        estimatedTokens,
+      };
+      return capped;
+    },
+  };
+}

--- a/packages/core/src/agent/tool-result-cap.ts
+++ b/packages/core/src/agent/tool-result-cap.ts
@@ -2,7 +2,6 @@ import type { Tool } from "ai";
 import { estimateTokens } from "./token-utils.js";
 
 export const TOOL_RESULT_SHARE = 0.5;
-export const STEP_BOUNDARY_RATIO = 0.9;
 
 type CappedResult = {
   truncated: true;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -113,7 +113,7 @@ export {
 } from "./agent/turn-budget.js";
 export type { BudgetExceededKind, TurnBudget } from "./agent/turn-budget.js";
 export { TAINTED_BY_WRITES_MESSAGE } from "./agent/coach-agent-copy.js";
-export { capToolResult, TOOL_RESULT_SHARE, STEP_BOUNDARY_RATIO } from "./agent/tool-result-cap.js";
+export { capToolResult, TOOL_RESULT_SHARE } from "./agent/tool-result-cap.js";
 export {
   downsampleStreams,
   STREAM_BIN_SECONDS,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -113,6 +113,13 @@ export {
 } from "./agent/turn-budget.js";
 export type { BudgetExceededKind, TurnBudget } from "./agent/turn-budget.js";
 export { TAINTED_BY_WRITES_MESSAGE } from "./agent/coach-agent-copy.js";
+export { capToolResult, TOOL_RESULT_SHARE, STEP_BOUNDARY_RATIO } from "./agent/tool-result-cap.js";
+export {
+  downsampleStreams,
+  STREAM_BIN_SECONDS,
+  STREAM_RESULT_TARGET_TOKENS,
+} from "./agent/stream-downsample.js";
+export type { DownsampledStreams } from "./agent/stream-downsample.js";
 export { ChatStore } from "./agent/chat-store.js";
 export { buildSystemPrompt, SYSTEM_PROMPT_CACHE_BOUNDARY } from "./agent/system-prompt.js";
 export { computePromptLineage } from "./agent/prompt-lineage.js";

--- a/packages/core/tests/intervals-tools-fetch-streams.test.ts
+++ b/packages/core/tests/intervals-tools-fetch-streams.test.ts
@@ -61,15 +61,19 @@ describe("intervals_fetch_streams", () => {
     expect(capture.types).toEqual(["watts", "heartrate", "cadence", "time", "altitude"]);
   });
 
-  it("returns the stream payload verbatim on success", async () => {
+  it("returns a downsampled stream object on success", async () => {
     const streams = { watts: [100, 200, 300], time: [0, 1, 2] };
     const fake = makeFakeIntervals({ ok: true, value: streams }, {});
     const tools = createPureCoreIntervalsTools(fake);
     const tool = tools.intervals_fetch_streams!;
 
-    const result = await tool.execute!({ activityId: 1 }, {} as never);
+    const result = (await tool.execute!({ activityId: 1 }, {} as never)) as {
+      sampleCount: number;
+      channels: Record<string, { max: number }>;
+    };
 
-    expect(result).toEqual(streams);
+    expect(result.sampleCount).toBe(3);
+    expect(result.channels.watts.max).toBe(300);
   });
 
   it("returns { error: kind } on SDK error", async () => {

--- a/packages/core/tests/stream-downsample.test.ts
+++ b/packages/core/tests/stream-downsample.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from "vitest";
+import type { IntervalsClient } from "intervals-icu-api";
+import {
+  downsampleStreams,
+  STREAM_BIN_SECONDS,
+  STREAM_RESULT_TARGET_TOKENS,
+} from "../src/agent/stream-downsample.js";
+import { estimateTokens } from "../src/agent/token-utils.js";
+import { createPureCoreIntervalsTools } from "../src/agent/intervals-tools.js";
+
+type AnyResult = { ok: true; value: unknown } | { ok: false; error: unknown };
+
+function makeFakeIntervals(result: AnyResult): IntervalsClient {
+  const fake = {
+    activities: {
+      getStreams: async () => result,
+    },
+  };
+  return fake as unknown as IntervalsClient;
+}
+
+describe("downsampleStreams", () => {
+  it("constants pin the configured values", () => {
+    expect(STREAM_BIN_SECONDS).toBe(10);
+    expect(STREAM_RESULT_TARGET_TOKENS).toBe(7000);
+  });
+
+  it("bin reduction shrinks the per-channel series", () => {
+    const watts = Array(600).fill(200);
+    const out = downsampleStreams({ watts });
+    expect(out.bins).toBe(60);
+    expect(out.channels.watts.samples).toHaveLength(60);
+    expect(out.sampleCount).toBe(600);
+  });
+
+  it("the stats header preserves true peaks over the full channel", () => {
+    const watts = [...Array(599).fill(100), 900];
+    const out = downsampleStreams({ watts });
+    expect(out.channels.watts.max).toBe(900);
+    expect(out.channels.watts.samples.every((v) => v < 900)).toBe(true);
+  });
+
+  it("missing or non-array channels do not throw (manual-entry activity)", () => {
+    const out = downsampleStreams({
+      heartrate: [120, 121, 122],
+      watts: undefined as unknown as number[],
+      cadence: "nope" as unknown as number[],
+    });
+    expect(out.channels.heartrate).toBeDefined();
+    expect(out.channels.watts).toBeUndefined();
+    expect(out.channels.cadence).toBeUndefined();
+  });
+
+  it("a 3 h-ride payload fits the per-result target after shaping (fits)", () => {
+    const big = {
+      watts: Array(10800).fill(250),
+      heartrate: Array(10800).fill(150),
+      cadence: Array(10800).fill(90),
+      time: Array.from({ length: 10800 }, (_, i) => i),
+      altitude: Array(10800).fill(500),
+    };
+    expect(estimateTokens(JSON.stringify(big))).toBeGreaterThan(STREAM_RESULT_TARGET_TOKENS);
+    expect(estimateTokens(JSON.stringify(downsampleStreams(big)))).toBeLessThanOrEqual(
+      STREAM_RESULT_TARGET_TOKENS,
+    );
+  });
+
+  it("the shaped streams tool returns the downsampled object, not the raw value (shaped tool)", async () => {
+    const big = {
+      watts: Array(10800).fill(250),
+      heartrate: Array(10800).fill(150),
+      cadence: Array(10800).fill(90),
+      time: Array.from({ length: 10800 }, (_, i) => i),
+      altitude: Array(10800).fill(500),
+    };
+    const fake = makeFakeIntervals({ ok: true, value: big });
+    const tools = createPureCoreIntervalsTools(fake);
+    const out = (await tools.intervals_fetch_streams!.execute!(
+      { activityId: 12345 },
+      {} as never,
+    )) as { bins: number; sampleCount: number; channels: Record<string, unknown> };
+    expect(out.bins).toBeGreaterThan(0);
+    expect(out.sampleCount).toBe(10800);
+    expect(out.channels.watts).toBeDefined();
+    expect(Array.isArray((out as { watts?: unknown }).watts)).toBe(false);
+  });
+
+  it("typed error object on the streams failure path", async () => {
+    const notFound = makeFakeIntervals({
+      ok: false,
+      error: { kind: "NotFound", status: 404, body: undefined },
+    });
+    const nfTools = createPureCoreIntervalsTools(notFound);
+    const nfOut = (await nfTools.intervals_fetch_streams!.execute!(
+      { activityId: 1 },
+      {} as never,
+    )) as { error: string; status?: number };
+    expect(nfOut.error).toBe("NotFound");
+    expect(nfOut.status).toBe(404);
+
+    const timeout = makeFakeIntervals({
+      ok: false,
+      error: { kind: "Timeout", message: "slow down" },
+    });
+    const toTools = createPureCoreIntervalsTools(timeout);
+    const toOut = (await toTools.intervals_fetch_streams!.execute!(
+      { activityId: 1 },
+      {} as never,
+    )) as { error: string; message?: string };
+    expect(toOut.error).toBe("Timeout");
+    expect(toOut.message).toBe("slow down");
+  });
+});

--- a/packages/core/tests/stream-downsample.test.ts
+++ b/packages/core/tests/stream-downsample.test.ts
@@ -51,6 +51,28 @@ describe("downsampleStreams", () => {
     expect(out.channels.cadence).toBeUndefined();
   });
 
+  it("a channel survives null gaps without NaN (dropped sensor packets)", () => {
+    const out = downsampleStreams({
+      watts: [100, null as unknown as number, 102],
+    });
+    expect(out.channels.watts).toBeDefined();
+    expect(out.channels.watts.min).toBe(100);
+    expect(out.channels.watts.max).toBe(102);
+    expect(Number.isNaN(out.channels.watts.mean)).toBe(false);
+    expect(out.channels.watts.samples.every((v) => Number.isFinite(v))).toBe(true);
+  });
+
+  it("accepts the live array-of-channel shape from the streams endpoint", () => {
+    const out = downsampleStreams([
+      { type: "watts", data: Array(600).fill(200) },
+      { type: "heartrate", data: Array(600).fill(150) },
+    ]);
+    expect(out.channels.watts).toBeDefined();
+    expect(out.channels.heartrate).toBeDefined();
+    expect(out.channels.watts.samples).toHaveLength(60);
+    expect(out.sampleCount).toBe(600);
+  });
+
   it("a 3 h-ride payload fits the per-result target after shaping (fits)", () => {
     const big = {
       watts: Array(10800).fill(250),
@@ -83,6 +105,23 @@ describe("downsampleStreams", () => {
     expect(out.sampleCount).toBe(10800);
     expect(out.channels.watts).toBeDefined();
     expect(Array.isArray((out as { watts?: unknown }).watts)).toBe(false);
+  });
+
+  it("shaped tool downsamples the live array-of-channel payload", async () => {
+    const live = [
+      { type: "watts", data: Array(10800).fill(250) },
+      { type: "heartrate", data: Array(10800).fill(150) },
+    ];
+    const fake = makeFakeIntervals({ ok: true, value: live });
+    const tools = createPureCoreIntervalsTools(fake);
+    const out = (await tools.intervals_fetch_streams!.execute!(
+      { activityId: 12345 },
+      {} as never,
+    )) as { bins: number; sampleCount: number; channels: Record<string, unknown> };
+    expect(out.sampleCount).toBe(10800);
+    expect(out.bins).toBeGreaterThan(0);
+    expect(out.channels.watts).toBeDefined();
+    expect(out.channels.heartrate).toBeDefined();
   });
 
   it("typed error object on the streams failure path", async () => {

--- a/packages/core/tests/tool-result-cap.test.ts
+++ b/packages/core/tests/tool-result-cap.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import type { Tool } from "ai";
+import { capToolResult, TOOL_RESULT_SHARE, STEP_BOUNDARY_RATIO } from "../src/agent/tool-result-cap.js";
+
+const stubTool = (value: unknown): Tool =>
+  ({ description: "stub", execute: async () => value }) as unknown as Tool;
+
+describe("capToolResult", () => {
+  it("constants pin the configured shares", () => {
+    expect(TOOL_RESULT_SHARE).toBe(0.5);
+    expect(STEP_BOUNDARY_RATIO).toBe(0.9);
+  });
+
+  it("small result passes through byte-identical (same reference)", async () => {
+    const value = { watts: [100, 200, 300] };
+    const wrapped = capToolResult(stubTool(value), { maxResultTokens: 50_000 });
+    const out = await wrapped.execute!({}, {} as never);
+    expect(out).toBe(value);
+  });
+
+  it("string result under the cap passes through unchanged", async () => {
+    const wrapped = capToolResult(stubTool("short answer"), { maxResultTokens: 50_000 });
+    const out = await wrapped.execute!({}, {} as never);
+    expect(out).toBe("short answer");
+  });
+
+  it("oversized stream result is truncated with a count-preserving notice", async () => {
+    const big = {
+      watts: Array(10800).fill(250),
+      heartrate: Array(10800).fill(150),
+      cadence: Array(10800).fill(90),
+      time: Array(10800).fill(1),
+      altitude: Array(10800).fill(500),
+    };
+    const wrapped = capToolResult(stubTool(big), { maxResultTokens: 50_000 });
+    const out = (await wrapped.execute!({}, {} as never)) as {
+      truncated: boolean;
+      notice: string;
+      omittedSamples: number;
+    };
+    expect(out.truncated).toBe(true);
+    expect(out.notice).toMatch(/narrower/i);
+    expect(out.omittedSamples).toBeGreaterThan(0);
+  });
+
+  it("a tool with no execute is returned unchanged", () => {
+    const t = { description: "no-exec" } as unknown as Tool;
+    expect(capToolResult(t, { maxResultTokens: 50_000 })).toBe(t);
+  });
+
+  it("respects the caller-supplied budget boundary", async () => {
+    const value = { watts: Array(200).fill(250) };
+    const passes = capToolResult(stubTool(value), { maxResultTokens: 50_000 });
+    expect(await passes.execute!({}, {} as never)).toBe(value);
+
+    const capped = capToolResult(stubTool(value), { maxResultTokens: 10 });
+    const out = (await capped.execute!({}, {} as never)) as { truncated?: boolean };
+    expect(out.truncated).toBe(true);
+  });
+});

--- a/packages/core/tests/tool-result-cap.test.ts
+++ b/packages/core/tests/tool-result-cap.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import type { Tool } from "ai";
-import { capToolResult, TOOL_RESULT_SHARE, STEP_BOUNDARY_RATIO } from "../src/agent/tool-result-cap.js";
+import { capToolResult, TOOL_RESULT_SHARE } from "../src/agent/tool-result-cap.js";
 
 const stubTool = (value: unknown): Tool =>
   ({ description: "stub", execute: async () => value }) as unknown as Tool;
@@ -8,7 +8,6 @@ const stubTool = (value: unknown): Tool =>
 describe("capToolResult", () => {
   it("constants pin the configured shares", () => {
     expect(TOOL_RESULT_SHARE).toBe(0.5);
-    expect(STEP_BOUNDARY_RATIO).toBe(0.9);
   });
 
   it("small result passes through byte-identical (same reference)", async () => {


### PR DESCRIPTION
## Summary

Deep race-review turns that pull very large data sets (a full 3-hour ride's streams) used to overflow the mid-turn step loop and exhaust the overflow-recovery retries, failing the turn. This change shapes oversized tool payloads at two layers so those turns degrade gracefully instead.

### Tool-registration cap (generic backstop)
A new sport-agnostic `capToolResult` wrapper composes at the tool-registration seam, inside the existing write-detection wrapper, so write detection still fires on the real result. It applies a token-share budget (half the context window) per tool result:
- under the budget: the result passes through byte-identical (same reference);
- over the budget: it is replaced with an actionable object `{truncated, notice, omittedSamples, estimatedTokens}` — an honest sample count and a notice steering the model to rerun with narrower arguments, not a sliced JSON string.

The step-boundary ratio is defined as a constant only; its abort wiring is deferred to a follow-up.

### Per-tool intervals payload shaping
A new `downsampleStreams` helper bins raw time-series into 10-second buckets with a per-channel min/max/mean stats header that preserves true peaks. The intervals.icu stream fetch tool now returns the downsampled object, so a 3-hour ride fits the smallest supported context window. Missing or non-array channels do not throw. A small follow-up commit normalizes live stream channel shape and null gaps before downsampling.

Every intervals.icu fetch tool's error path now returns a typed error object that keeps the `kind` key the prompt's error-translation table reads, adding HTTP status and message additively.

Both layers reuse the existing token estimator (no second estimator) and add no config surface; the overflow-recovery branch and step-count limits are unchanged.

## Test plan
- `pnpm vitest run packages/core/tests/tool-result-cap.test.ts packages/core/tests/stream-downsample.test.ts` — direct-call unit coverage for the cap and the downsampler (small pass-through is same-reference; an oversized stub returns the truncation object; bins preserve peaks; missing channels no-throw).
- `pnpm vitest run packages/core/tests/intervals-tools-fetch-streams.test.ts` — the shaped streams tool returns the downsampled object and typed errors.
- `pnpm test && pnpm check` green.

## Stacking
This PR is stacked: its base is the sibling rendering-pipeline branch, not main. Merge bottom-up and retarget to main before merging this one.