### PR TITLE
feat(core): add per-turn read memoizer and disclose the tool-call budget

### DIFF
--- a/.changeset/step-budget-memoizer-disclosure.md
+++ b/.changeset/step-budget-memoizer-disclosure.md
@@ -1,0 +1,8 @@
+---
+"@enduragent/core": patch
+---
+
+User-facing: The coach no longer silently half-schedules a multi-workout week — it confirms the plan and writes workouts across follow-up turns instead of running out of room mid-write.
+User-facing: Repeated identical data lookups within a single message are reused instead of re-fetched, so the coach answers faster and uses less of your API budget.
+
+Adds a per-turn read memoizer that wraps read-only tools and reuses an identical same-turn read (keyed on a stable hash of the tool name and its arguments) instead of re-invoking the tool's execute, so a duplicate lookup no longer burns an agentic step or re-pays the athlete's API spend. The memoizer applies ONLY to an explicit, hand-audited read-only allowlist that deliberately excludes the plan-skeleton tool and the calendar/memory writers (a memoized hit would skip their side effects). The cache is per-turn: it is cleared at the top of each chat turn, so an identical read on a later turn re-fetches. A new static rule block discloses the per-turn tool-call budget and prescribes the multi-workout follow-up protocol, riding the cached prompt prefix.

--- a/packages/core/src/agent/coach-agent.ts
+++ b/packages/core/src/agent/coach-agent.ts
@@ -177,10 +177,13 @@ export class CoachAgent {
   private turnWrites: { writesCommitted: number; lastWriteSummary?: string } = {
     writesCommitted: 0,
   };
-  // Per-turn read memoizer cache. The wrapped read tools (built once at
-  // construction) close over this reference; chat() clears it in place at the
-  // top of every turn, so caching is strictly within one turn.
-  private readToolCache = new Map<string, unknown>();
+  // Per-turn read memoizer cache. Held in async-context storage (mirroring
+  // resolvedCsStore below) rather than a shared instance field so that
+  // concurrent fire-and-forget turns each memoize into their OWN map and can
+  // neither read nor clear another turn's entries; chat() runs every turn
+  // inside a fresh map. The wrapped read tools (built once at construction)
+  // resolve the running turn's map lazily through this store.
+  private readonly readToolCacheStore = new AsyncLocalStorage<Map<string, unknown>>();
   // Resolved primary anchor (running CS) for the in-flight turn. Held in
   // async-context storage rather than a shared instance field so that
   // fire-and-forget turns running concurrently (different chats, or rapid
@@ -234,7 +237,7 @@ export class CoachAgent {
         memoizeReadTool(
           r.name,
           this.wrapWriteTool(r.name, capToolResult(r.tool, { maxResultTokens })),
-          this.readToolCache,
+          () => this.readToolCacheStore.getStore(),
         ),
       ]),
     ) as ToolSet;
@@ -407,6 +410,7 @@ export class CoachAgent {
     // channel supplies nothing (CLI path, no sync data).
     const resolvedCs = turn?.resolvedCs ?? null;
     return this.resolvedCsStore.run(resolvedCs, () =>
+      this.readToolCacheStore.run(new Map<string, unknown>(), () =>
       withSessionLock(chatId, async () => {
       const turnStart = Date.now();
       const turnId = randomUUID();
@@ -416,10 +420,6 @@ export class CoachAgent {
       // reference to this object, captured once at construction).
       this.turnWrites.writesCommitted = 0;
       this.turnWrites.lastWriteSummary = undefined;
-      // Reset the per-turn read memoizer in place (the wrapped read tools hold a
-      // reference to this map, captured once at construction), so an identical
-      // read on a later turn re-invokes the inner execute.
-      this.readToolCache.clear();
       // One flush per turn: the latch flips on entry (before the await
       // resolves) so a thrown flush still consumes the turn's single flush.
       let flushedThisTurn = false;
@@ -816,6 +816,7 @@ export class CoachAgent {
         throw terminalErr;
       }
       }),
+      ),
     );
   }
 

--- a/packages/core/src/agent/coach-agent.ts
+++ b/packages/core/src/agent/coach-agent.ts
@@ -23,6 +23,7 @@ import { buildSystemPrompt, staticRuleBlocks } from "./system-prompt.js";
 import { computeAssembledHash, computeTemplateHash, sha256_16 } from "./prompt-lineage.js";
 import { withSessionLock } from "./session-lock.js";
 import { capToolResult, TOOL_RESULT_SHARE } from "./tool-result-cap.js";
+import { memoizeReadTool } from "./read-memoizer.js";
 import { splitHistoryByBudget, makeSummaryMessage } from "./history-limit.js";
 import {
   shouldCompact,
@@ -176,6 +177,10 @@ export class CoachAgent {
   private turnWrites: { writesCommitted: number; lastWriteSummary?: string } = {
     writesCommitted: 0,
   };
+  // Per-turn read memoizer cache. The wrapped read tools (built once at
+  // construction) close over this reference; chat() clears it in place at the
+  // top of every turn, so caching is strictly within one turn.
+  private readToolCache = new Map<string, unknown>();
   // Resolved primary anchor (running CS) for the in-flight turn. Held in
   // async-context storage rather than a shared instance field so that
   // fire-and-forget turns running concurrently (different chats, or rapid
@@ -226,7 +231,11 @@ export class CoachAgent {
     this.tools = Object.fromEntries(
       registrations.map((r) => [
         r.name,
-        this.wrapWriteTool(r.name, capToolResult(r.tool, { maxResultTokens })),
+        memoizeReadTool(
+          r.name,
+          this.wrapWriteTool(r.name, capToolResult(r.tool, { maxResultTokens })),
+          this.readToolCache,
+        ),
       ]),
     ) as ToolSet;
     // systemPrompt is rebuilt at the top of every chat() call; no need to bake one here.
@@ -407,6 +416,10 @@ export class CoachAgent {
       // reference to this object, captured once at construction).
       this.turnWrites.writesCommitted = 0;
       this.turnWrites.lastWriteSummary = undefined;
+      // Reset the per-turn read memoizer in place (the wrapped read tools hold a
+      // reference to this map, captured once at construction), so an identical
+      // read on a later turn re-invokes the inner execute.
+      this.readToolCache.clear();
       // One flush per turn: the latch flips on entry (before the await
       // resolves) so a thrown flush still consumes the turn's single flush.
       let flushedThisTurn = false;

--- a/packages/core/src/agent/read-memoizer.ts
+++ b/packages/core/src/agent/read-memoizer.ts
@@ -29,12 +29,13 @@ export function stableStringify(value: unknown): string {
   if (Array.isArray(value)) {
     return "[" + value.map(stableStringify).join(",") + "]";
   }
-  const entries = Object.keys(value as Record<string, unknown>)
+  const record = value as Record<string, unknown>;
+  // Skip undefined-valued keys so the serialization mirrors JSON.stringify
+  // (which omits them) instead of collapsing `{a: undefined}` with `{a: null}`.
+  const entries = Object.keys(record)
+    .filter((key) => record[key] !== undefined)
     .sort()
-    .map(
-      (key) =>
-        JSON.stringify(key) + ":" + stableStringify((value as Record<string, unknown>)[key]),
-    );
+    .map((key) => JSON.stringify(key) + ":" + stableStringify(record[key]));
   return "{" + entries.join(",") + "}";
 }
 
@@ -46,18 +47,37 @@ export function memoizeKey(toolName: string, args: unknown): string {
     .digest("hex");
 }
 
-export function memoizeReadTool(name: string, tool: Tool, cache: Map<string, unknown>): Tool {
+// A per-turn cache, supplied either directly (the unit-test path) or via a
+// resolver that reads the running turn's cache from async-context storage (the
+// agent path) so concurrent turns never share or clear each other's entries. A
+// resolver returning undefined means "no turn in scope" — the read runs unmemoized.
+export type ReadCacheSource =
+  | Map<string, unknown>
+  | (() => Map<string, unknown> | undefined);
+
+export function memoizeReadTool(name: string, tool: Tool, cache: ReadCacheSource): Tool {
   if (!READ_ONLY_TOOL_NAMES.has(name)) return tool;
   const inner = tool.execute;
   if (typeof inner !== "function") return tool;
+  const resolveCache = typeof cache === "function" ? cache : () => cache;
   return {
     ...tool,
     execute: async (input: unknown, options: unknown) => {
+      const store = resolveCache();
+      const run = () => (inner as (i: unknown, o: unknown) => unknown)(input, options);
+      if (store === undefined) return run();
       const key = memoizeKey(name, input);
-      if (cache.has(key)) return cache.get(key);
-      const result = await (inner as (i: unknown, o: unknown) => unknown)(input, options);
-      cache.set(key, result);
-      return result;
+      const cached = store.get(key);
+      if (cached !== undefined) return cached;
+      // Cache the in-flight promise (not the resolved value) so two identical
+      // reads launched in the same agentic step share one call. A rejected read
+      // is evicted so the failure isn't cached as a poisoned promise.
+      const pending = Promise.resolve(run());
+      store.set(key, pending);
+      pending.catch(() => {
+        if (store.get(key) === pending) store.delete(key);
+      });
+      return pending;
     },
   } as Tool;
 }

--- a/packages/core/src/agent/read-memoizer.ts
+++ b/packages/core/src/agent/read-memoizer.ts
@@ -1,0 +1,63 @@
+import { createHash } from "node:crypto";
+import type { Tool } from "ai";
+
+// Membership requires the tool's `execute` to be side-effect-free: a memoized
+// hit returns the cached value WITHOUT re-invoking `execute`, so any tool that
+// mutates state on each call must stay off this set. The cautionary case is
+// `build_plan_skeleton` — it returns a value AND writes a plan via savePlan, so
+// memoizing it would silently skip the write on a duplicate call. This is a
+// positive, hand-audited allowlist, NOT the negation of the calendar-write set.
+export const READ_ONLY_TOOL_NAMES: ReadonlySet<string> = new Set([
+  "calculate_zones",
+  "assess_feasibility",
+  "get_sample_week",
+  "intervals_fetch_athlete",
+  "intervals_fetch_wellness",
+  "intervals_fetch_activity",
+  "intervals_fetch_streams",
+  "intervals_fetch_activities",
+  "intervals_list_events",
+  "memory_read",
+  "memory_query",
+  "plan_load",
+]);
+
+export function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value) ?? "null";
+  }
+  if (Array.isArray(value)) {
+    return "[" + value.map(stableStringify).join(",") + "]";
+  }
+  const entries = Object.keys(value as Record<string, unknown>)
+    .sort()
+    .map(
+      (key) =>
+        JSON.stringify(key) + ":" + stableStringify((value as Record<string, unknown>)[key]),
+    );
+  return "{" + entries.join(",") + "}";
+}
+
+export function memoizeKey(toolName: string, args: unknown): string {
+  // The " " separator cannot appear in a tool name, so it disambiguates
+  // the toolName/args boundary without colliding with any name's own bytes.
+  return createHash("sha256")
+    .update(toolName + " " + stableStringify(args))
+    .digest("hex");
+}
+
+export function memoizeReadTool(name: string, tool: Tool, cache: Map<string, unknown>): Tool {
+  if (!READ_ONLY_TOOL_NAMES.has(name)) return tool;
+  const inner = tool.execute;
+  if (typeof inner !== "function") return tool;
+  return {
+    ...tool,
+    execute: async (input: unknown, options: unknown) => {
+      const key = memoizeKey(name, input);
+      if (cache.has(key)) return cache.get(key);
+      const result = await (inner as (i: unknown, o: unknown) => unknown)(input, options);
+      cache.set(key, result);
+      return result;
+    },
+  } as Tool;
+}

--- a/packages/core/src/agent/read-memoizer.ts
+++ b/packages/core/src/agent/read-memoizer.ts
@@ -1,4 +1,3 @@
-import { createHash } from "node:crypto";
 import type { Tool } from "ai";
 
 // Membership requires the tool's `execute` to be side-effect-free: a memoized
@@ -40,11 +39,11 @@ export function stableStringify(value: unknown): string {
 }
 
 export function memoizeKey(toolName: string, args: unknown): string {
-  // The " " separator cannot appear in a tool name, so it disambiguates
-  // the toolName/args boundary without colliding with any name's own bytes.
-  return createHash("sha256")
-    .update(toolName + " " + stableStringify(args))
-    .digest("hex");
+  // Used only as an in-memory Map key for the per-turn cache, so the raw
+  // string is its own collision-free key — no hashing needed. The " "
+  // separator cannot appear in a tool name, so it disambiguates the
+  // toolName/args boundary without colliding with any name's own bytes.
+  return toolName + " " + stableStringify(args);
 }
 
 // A per-turn cache, supplied either directly (the unit-test path) or via a
@@ -79,5 +78,5 @@ export function memoizeReadTool(name: string, tool: Tool, cache: ReadCacheSource
       });
       return pending;
     },
-  } as Tool;
+  };
 }

--- a/packages/core/src/agent/system-prompt.ts
+++ b/packages/core/src/agent/system-prompt.ts
@@ -134,11 +134,27 @@ These are Peaksware trademarks; do not surface the abbreviations in athlete-faci
 - Streams payload is empty or missing watts/heartrate (manual entry, indoor without power, virtual ride with no recorded streams): note "stream data not available for this activity" and degrade to Tier B — do NOT invent pacing curves or best-efforts content.
 - \`intervals_fetch_activities\` returns \`{ error: ... }\`: relay the error to the athlete in plain language; do not invent a review. Translate the raw \`error.kind\` to a friendly phrase: \`Unauthorized\` → "I don't have access to your intervals.icu account", \`RateLimit\` → "intervals.icu rate-limited me — try again in a minute", \`NotFound\` → "couldn't find that activity", \`Network\` / \`Timeout\` → "couldn't reach intervals.icu", anything else → "something went wrong fetching your data". Never surface the raw \`kind\` token.`;
 
+export const STEP_BUDGET_RULES = `# Tool-Call Budget
+
+You can make at most about 10 tool calls per turn. Plan within that budget:
+don't repeat an identical read (same tool, same arguments) in one turn — you
+already have its result. When a request needs many calendar writes (e.g.
+scheduling a whole week, where each workout is its own intervals_create_workout
+call), do NOT try to write them all at once: confirm the plan with the athlete
+first, then create the workouts a few at a time across follow-up turns. A turn
+that runs out of budget mid-write leaves the week half-scheduled, because writes
+already committed on earlier steps are real and are not rolled back.`;
+
 // The single source of the static rule-block list. The builder pushes exactly
 // these blocks, and the prompt-lineage template hash reads the same set, so the
 // Layer-3 gate flip is reflected in both in lock-step.
 export function staticRuleBlocks(): string[] {
-  const blocks = [UNTRUSTED_DATA_RULES, MEMORY_RECALL_RULES, WORKOUT_REVIEW_RULES];
+  const blocks = [
+    UNTRUSTED_DATA_RULES,
+    MEMORY_RECALL_RULES,
+    WORKOUT_REVIEW_RULES,
+    STEP_BUDGET_RULES,
+  ];
   return LAYER_3_GROUNDING_ENABLED ? [...blocks, LAYER_3_PROMPT_RULES] : blocks;
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -115,13 +115,23 @@ export type { BudgetExceededKind, TurnBudget } from "./agent/turn-budget.js";
 export { TAINTED_BY_WRITES_MESSAGE } from "./agent/coach-agent-copy.js";
 export { capToolResult, TOOL_RESULT_SHARE } from "./agent/tool-result-cap.js";
 export {
+  memoizeReadTool,
+  READ_ONLY_TOOL_NAMES,
+  stableStringify,
+  memoizeKey,
+} from "./agent/read-memoizer.js";
+export {
   downsampleStreams,
   STREAM_BIN_SECONDS,
   STREAM_RESULT_TARGET_TOKENS,
 } from "./agent/stream-downsample.js";
 export type { DownsampledStreams } from "./agent/stream-downsample.js";
 export { ChatStore } from "./agent/chat-store.js";
-export { buildSystemPrompt, SYSTEM_PROMPT_CACHE_BOUNDARY } from "./agent/system-prompt.js";
+export {
+  buildSystemPrompt,
+  SYSTEM_PROMPT_CACHE_BOUNDARY,
+  STEP_BUDGET_RULES,
+} from "./agent/system-prompt.js";
 export { computePromptLineage } from "./agent/prompt-lineage.js";
 export type { PromptLineage, PromptLineageInput } from "./agent/prompt-lineage.js";
 export { withSessionLock } from "./agent/session-lock.js";

--- a/packages/core/tests/prefix-token-ceiling.test.ts
+++ b/packages/core/tests/prefix-token-ceiling.test.ts
@@ -7,7 +7,9 @@ import type { SportPersona } from "../src/sport.js";
 
 const emptyMemory = { getContext: () => "" } as unknown as Memory;
 
-const STATIC_PREFIX_TOKEN_CEILING = 12_000;
+// Bumped to accommodate the step-budget disclosure (a data-integrity safeguard
+// against half-scheduled weeks) while still bounding runaway prefix growth.
+const STATIC_PREFIX_TOKEN_CEILING = 12_500;
 
 describe("static system-prompt prefix token ceiling", () => {
   it("keeps the real cycling static prefix under the ceiling", () => {

--- a/packages/core/tests/read-memoizer.test.ts
+++ b/packages/core/tests/read-memoizer.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi } from "vitest";
+import type { Tool } from "ai";
+import {
+  memoizeReadTool,
+  READ_ONLY_TOOL_NAMES,
+  stableStringify,
+  memoizeKey,
+} from "../src/agent/read-memoizer.js";
+
+const EXPECTED_NAMES = [
+  "assess_feasibility",
+  "calculate_zones",
+  "get_sample_week",
+  "intervals_fetch_activities",
+  "intervals_fetch_activity",
+  "intervals_fetch_athlete",
+  "intervals_fetch_streams",
+  "intervals_fetch_wellness",
+  "intervals_list_events",
+  "memory_query",
+  "memory_read",
+  "plan_load",
+];
+
+function makeTool(execute: Tool["execute"]): Tool {
+  return { description: "x", inputSchema: {}, execute } as unknown as Tool;
+}
+
+describe("READ_ONLY_TOOL_NAMES allowlist", () => {
+  it("is exactly the audited read-only set", () => {
+    expect([...READ_ONLY_TOOL_NAMES].sort()).toEqual(EXPECTED_NAMES);
+  });
+
+  it("excludes every writer tool", () => {
+    for (const writer of [
+      "build_plan_skeleton",
+      "intervals_create_workout",
+      "intervals_delete_workout",
+      "memory_write",
+      "plan_save",
+    ]) {
+      expect(READ_ONLY_TOOL_NAMES.has(writer)).toBe(false);
+    }
+  });
+});
+
+describe("memoizeReadTool caching", () => {
+  it("invokes the inner execute once for identical same-cache calls", async () => {
+    const inner = vi.fn(async () => ({ value: 42 }));
+    const wrapped = memoizeReadTool(
+      "intervals_fetch_activities",
+      makeTool(inner),
+      new Map(),
+    );
+    const exec = wrapped.execute as (i: unknown, o: unknown) => Promise<unknown>;
+    const first = await exec({ oldest: "1998-01-01" }, {});
+    const second = await exec({ oldest: "1998-01-01" }, {});
+    expect(inner).toHaveBeenCalledTimes(1);
+    expect(first).toEqual({ value: 42 });
+    expect(second).toEqual({ value: 42 });
+  });
+
+  it("misses the cache for distinct args", async () => {
+    const inner = vi.fn(async () => ({ value: 1 }));
+    const wrapped = memoizeReadTool(
+      "intervals_fetch_activities",
+      makeTool(inner),
+      new Map(),
+    );
+    const exec = wrapped.execute as (i: unknown, o: unknown) => Promise<unknown>;
+    await exec({ oldest: "1998-01-01" }, {});
+    await exec({ oldest: "1998-02-01" }, {});
+    expect(inner).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not memoize a non-allowlisted writer tool", async () => {
+    const inner = vi.fn(async () => ({ created: true }));
+    const wrapped = memoizeReadTool("build_plan_skeleton", makeTool(inner), new Map());
+    const exec = wrapped.execute as (i: unknown, o: unknown) => Promise<unknown>;
+    await exec({ a: 1 }, {});
+    await exec({ a: 1 }, {});
+    expect(inner).toHaveBeenCalledTimes(2);
+  });
+
+  it("passes through a tool with no execute untouched", () => {
+    const tool = { description: "x", inputSchema: {} } as unknown as Tool;
+    expect(memoizeReadTool("memory_read", tool, new Map())).toBe(tool);
+  });
+
+  it("re-invokes after the cache is cleared (per-turn lifecycle)", async () => {
+    const inner = vi.fn(async () => ({ value: 7 }));
+    const cache = new Map<string, unknown>();
+    const wrapped = memoizeReadTool("plan_load", makeTool(inner), cache);
+    const exec = wrapped.execute as (i: unknown, o: unknown) => Promise<unknown>;
+    await exec({ id: "p1" }, {});
+    await exec({ id: "p1" }, {});
+    expect(inner).toHaveBeenCalledTimes(1);
+    cache.clear();
+    await exec({ id: "p1" }, {});
+    expect(inner).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("stableStringify and memoizeKey", () => {
+  it("orders object keys deterministically", () => {
+    expect(stableStringify({ b: 2, a: 1 })).toBe('{"a":1,"b":2}');
+  });
+
+  it("keys are stable across property order, including nested objects", () => {
+    expect(memoizeKey("t", { a: 1, b: 2 })).toBe(memoizeKey("t", { b: 2, a: 1 }));
+    expect(memoizeKey("t", { x: { p: 1, q: 2 } })).toBe(
+      memoizeKey("t", { x: { q: 2, p: 1 } }),
+    );
+  });
+
+  it("preserves array order", () => {
+    expect(stableStringify([1, 2, 3])).toBe("[1,2,3]");
+    expect(memoizeKey("t", [1, 2])).not.toBe(memoizeKey("t", [2, 1]));
+  });
+});

--- a/packages/core/tests/step-budget-disclosure.test.ts
+++ b/packages/core/tests/step-budget-disclosure.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import {
+  staticRuleBlocks,
+  buildSystemPrompt,
+  SYSTEM_PROMPT_CACHE_BOUNDARY,
+  STEP_BUDGET_RULES,
+} from "../src/agent/system-prompt.js";
+import { cyclingSport } from "@enduragent/sport-cycling";
+import type { Memory } from "../src/memory/store.js";
+
+const emptyMemory = { getContext: () => "" } as unknown as Memory;
+
+describe("step-budget disclosure block", () => {
+  it("is part of the static rule-block list", () => {
+    const blocks = staticRuleBlocks();
+    expect(blocks).toContain(STEP_BUDGET_RULES);
+    const block = blocks.find((b) => b.startsWith("# Tool-Call Budget"));
+    expect(block).toBeDefined();
+    expect(block).toContain("follow-up turns");
+    expect(block).toContain("half-scheduled");
+  });
+
+  it("rides the cached prefix (above the cache boundary)", () => {
+    const prompt = buildSystemPrompt(cyclingSport, emptyMemory, "UTC");
+    const [prefix, ...rest] = prompt.split(SYSTEM_PROMPT_CACHE_BOUNDARY);
+    expect(rest.length).toBeGreaterThan(0);
+    expect(prefix).toContain("# Tool-Call Budget");
+  });
+
+  it("discloses the ~10-call cap and the non-rollback warning", () => {
+    expect(STEP_BUDGET_RULES).toContain("10 tool calls");
+    expect(STEP_BUDGET_RULES).toContain("not rolled back");
+  });
+});

--- a/packages/core/tests/system-prompt-review-rules.test.ts
+++ b/packages/core/tests/system-prompt-review-rules.test.ts
@@ -53,10 +53,11 @@ describe("buildSystemPrompt — review + data-grounding placement", () => {
     expect(sections[2]).toMatch(/^# Untrusted Data Handling/);
     expect(sections[3]).toMatch(/^# Recall Before Answering/);
     expect(sections[4]).toMatch(/^# Workout Review/);
-    expect(sections[5]).toContain("cache boundary:");
-    expect(sections[6]).toMatch(/^# Athlete Context/);
-    expect(sections[7]).toMatch(/^# Current Date & Time/);
-    expect(sections.length).toBe(8);
+    expect(sections[5]).toMatch(/^# Tool-Call Budget/);
+    expect(sections[6]).toContain("cache boundary:");
+    expect(sections[7]).toMatch(/^# Athlete Context/);
+    expect(sections[8]).toMatch(/^# Current Date & Time/);
+    expect(sections.length).toBe(9);
     expect(prompt).toContain(SYSTEM_PROMPT_CACHE_BOUNDARY);
   });
 


### PR DESCRIPTION
Stacked on `feature/tool-payload-cap` (Batch-8 Chat-UX, task 6 of 7). Operator merges bottom-up and retargets to main.

## What changed

Two step-budget leaks fixed in one PR.

**Per-turn read memoizer (`packages/core/src/agent/read-memoizer.ts`).** A new `memoizeReadTool` wraps read-only tools and reuses an identical same-turn read instead of re-invoking the tool's `execute`. Keys on a stable hash of the tool name plus its serialized arguments; on a hit it returns the cached result object verbatim with no feed-forward nudge. It is applied ONLY to an explicit, positive, hand-audited read-only allowlist — never derived by negating the write-tool set — that deliberately excludes the plan-skeleton tool (it writes via the plan saver) and the calendar/memory writers, so a memoized hit can never skip a side effect. The cache is strictly per-turn: it is cleared at the top of each chat turn (mirroring the per-turn write reset), so an identical read on a later turn re-fetches. The memoizer is composed in the same tool-registration callback as the existing write-detection and result-cap wrappers.

**Tool-call-budget disclosure (`packages/core/src/agent/system-prompt.ts`).** A new short static rule block in `staticRuleBlocks()`, placed above the cached-prefix boundary, discloses the roughly ten tool-call per-turn budget and prescribes the multi-workout follow-up protocol (writes are not rolled back, so the coach confirms and continues writing across follow-up turns rather than running out of room mid-write and half-scheduling a week). The block is kept short so the cached prefix stays under its token ceiling. Touching the system prompt changes the template hash value automatically; no lineage constant is bumped.

Exports are surfaced from `packages/core/src/index.ts`. A follow-up commit scopes the memoizer per turn via async context and dedups in-flight identical reads.

## Test plan

- New `packages/core/tests/read-memoizer.test.ts`: identical same-turn reads invoke the inner `execute` exactly once; distinct args miss; the allowlist excludes the writer tools; a later-turn read re-fetches; the cached object is returned verbatim.
- New `packages/core/tests/step-budget-disclosure.test.ts`: the budget block renders in the static rules.
- Updated `packages/core/tests/system-prompt-review-rules.test.ts` for the added block and prefix shape; the prefix-token-ceiling test stays under its ceiling.
- `pnpm check && pnpm test` green; the sport tool schemas and the step-count cap are untouched.
