### PR TITLE
fix(config): drop dead patches COPY from Dockerfile

### DIFF
--- a/packages/cycling-coach/Dockerfile
+++ b/packages/cycling-coach/Dockerfile
@@ -20,10 +20,6 @@ COPY packages/core/package.json ./packages/core/
 COPY packages/sport-cycling/package.json ./packages/sport-cycling/
 COPY packages/cycling-coach/package.json ./packages/cycling-coach/
 
-# pnpm.patchedDependencies in the root manifest references patches/*.patch;
-# `pnpm install` reads them during resolution, so they must exist before install.
-COPY patches ./patches
-
 RUN pnpm install --filter cycling-coach... --frozen-lockfile
 
 # Source after deps for cache reuse.


### PR DESCRIPTION
## Problem

The image build fails at the `COPY patches ./patches` step:

```
Build Failed: failed to compute cache key: failed to calculate checksum of ref ...: "/patches": not found
```

## Root cause

#245 vendored the patched dependency in-house and removed both the `patches/` directory and the `pnpm.patchedDependencies` block from the root manifest. The Dockerfile's `COPY patches ./patches` step — added in #206 *for that specific patch* — was left dangling. With no `patches/` in the build context, every image build since #245 fails at that step.

## Fix

Remove the dead `COPY patches ./patches` step (and its now-false comment). There are zero patched dependencies, so nothing needs copying before `pnpm install`; the install no longer reads any patch during resolution.

## Validation

Static: `patches/` is absent and untracked, and `patchedDependencies` is absent from both `package.json` and `pnpm-workspace.yaml` on `main` — the COPY can only fail, never succeed. Removing it restores the pre-#206 build path (which built cleanly). The image build itself is the integration test and re-validates on the next deploy from `main`. (Local Docker daemon was unavailable to build here.)