### PR TITLE
docs: point X follow link to @yerzhansa

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 AI cycling coaching agent. Bring your own LLM API key **or sign in with a ChatGPT Plus subscription**, connect [intervals.icu](https://intervals.icu) for real athlete data, chat via Telegram or CLI.
 
-Follow [@enduragent](https://x.com/enduragent) on X for updates, or drop a question/feedback anytime.
+Follow [@yerzhansa](https://x.com/yerzhansa) on X for updates, or drop a question/feedback anytime.
 
 ## What it does
 

--- a/packages/cycling-coach/README.md
+++ b/packages/cycling-coach/README.md
@@ -82,7 +82,7 @@ npx cycling-coach
 
 ## More
 
-- Follow [@enduragent](https://x.com/enduragent) on X for updates, or drop a question/feedback anytime.
+- Follow [@yerzhansa](https://x.com/yerzhansa) on X for updates, or drop a question/feedback anytime.
 - **Secrets backends** (1Password, macOS Keychain, Vault, AWS/GCP Secret Manager, age, env), **architecture diagram**, and **development setup** — see the [GitHub repo](https://github.com/yerzhansa/cycling-coach#readme).
 - **Issues**: <https://github.com/yerzhansa/cycling-coach/issues>
 - **License**: MIT


### PR DESCRIPTION
Updates the "Follow on X" link in both READMEs from `@enduragent` (https://x.com/enduragent) to `@yerzhansa` (https://x.com/yerzhansa).

Both the handle text and the URL are updated so the label matches its target.

- `README.md`
- `packages/cycling-coach/README.md`

Internal `@enduragent/*` package names and `~/.enduragent/` data dirs are intentionally left untouched.