### PR TITLE
feat(telegram): invite feedback on X.com in update notification

### DIFF
--- a/.changeset/update-notice-feedback-cta.md
+++ b/.changeset/update-notice-feedback-cta.md
@@ -1,0 +1,7 @@
+---
+"@enduragent/core": patch
+---
+
+User-facing: The "update available" notification now invites you to tag or DM @yerzhansa on X.com with feedback, feature requests, or bugs.
+
+Appends a one-line feedback call-to-action to the startup update-available broadcast in the Telegram channel. Plain-text only (the broadcast sends without a parse mode), so no markdown/HTML escaping concerns. Broadcast filtering and once-per-version dedupe are unchanged.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 AI cycling coaching agent. Bring your own LLM API key **or sign in with a ChatGPT Plus subscription**, connect [intervals.icu](https://intervals.icu) for real athlete data, chat via Telegram or CLI.
 
-Follow [@yerzhansa](https://x.com/yerzhansa) on X for updates, or drop a question/feedback anytime.
+Follow [@yerzhansa](https://x.com/yerzhansa) on X.com for updates, or drop a question/feedback anytime.
 
 ## What it does
 

--- a/packages/core/src/channels/telegram.ts
+++ b/packages/core/src/channels/telegram.ts
@@ -812,7 +812,7 @@ export async function notifyUpdate(bot: Bot, dataDir: string, binary: BinaryConf
     const knownChats = getKnownTelegramChatIds(dataDir);
     const chatIds =
       allowed.dmPolicy === "open" ? knownChats : knownChats.filter((id) => allowSet.has(id));
-    const message = `Update available: ${info.current} → ${info.latest}\nSend /whatsnew to see what changed, /update to install.`;
+    const message = `Update available: ${info.current} → ${info.latest}\nSend /whatsnew to see what changed, /update to install.\n\nTag or DM @yerzhansa on X.com with feedback, feature requests, or bugs — help shape what's next.`;
 
     for (const chatId of chatIds) {
       try {

--- a/packages/cycling-coach/README.md
+++ b/packages/cycling-coach/README.md
@@ -82,7 +82,7 @@ npx cycling-coach
 
 ## More
 
-- Follow [@yerzhansa](https://x.com/yerzhansa) on X for updates, or drop a question/feedback anytime.
+- Follow [@yerzhansa](https://x.com/yerzhansa) on X.com for updates, or drop a question/feedback anytime.
 - **Secrets backends** (1Password, macOS Keychain, Vault, AWS/GCP Secret Manager, age, env), **architecture diagram**, and **development setup** — see the [GitHub repo](https://github.com/yerzhansa/cycling-coach#readme).
 - **Issues**: <https://github.com/yerzhansa/cycling-coach/issues>
 - **License**: MIT


### PR DESCRIPTION
Adds a feedback call-to-action to the startup "update available" Telegram broadcast and tidies the X follow-link label.

## Changes
- `packages/core/src/channels/telegram.ts` — the update-available notification now ends with: _"Tag or DM @yerzhansa on X.com with feedback, feature requests, or bugs — help shape what's next."_ Plain-text only (broadcast sends with no parse mode); broadcast filtering and once-per-version dedupe are unchanged.
- `README.md`, `packages/cycling-coach/README.md` — relabel the X follow link as `X.com` (URL unchanged).
- Changeset with a `User-facing:` line so it surfaces in `/whatsnew`.

## Test
- `vitest run tests/telegram-bot.test.ts` — 5/5 pass (broadcast filtering unaffected).
- `tsc --noEmit` on core — clean.