### PR TITLE
chore(telegram): link to x.com/yerzhansa in update notification

### DIFF
--- a/packages/core/src/channels/telegram.ts
+++ b/packages/core/src/channels/telegram.ts
@@ -812,7 +812,7 @@ export async function notifyUpdate(bot: Bot, dataDir: string, binary: BinaryConf
     const knownChats = getKnownTelegramChatIds(dataDir);
     const chatIds =
       allowed.dmPolicy === "open" ? knownChats : knownChats.filter((id) => allowSet.has(id));
-    const message = `Update available: ${info.current} → ${info.latest}\nSend /whatsnew to see what changed, /update to install.\n\nTag or DM @yerzhansa on X.com with feedback, feature requests, or bugs — help shape what's next.`;
+    const message = `Update available: ${info.current} → ${info.latest}\nSend /whatsnew to see what changed, /update to install.\n\nTag or DM me at x.com/yerzhansa with feedback, feature requests, or bugs — help shape what's next.`;
 
     for (const chatId of chatIds) {
       try {


### PR DESCRIPTION
## What

The "update available" notification mentioned `@yerzhansa` as plain text. The message is sent with no `parse_mode`, so the handle wasn't clickable. Switch it to the bare URL `x.com/yerzhansa`, which Telegram auto-links.

## Change

`packages/core/src/channels/telegram.ts` — `@yerzhansa on X.com` → `me at x.com/yerzhansa`.

No changeset (minor link tweak). No tests assert the message text — `notifyUpdate` tests only cover broadcast filtering.