### PR TITLE
Add GHCR-backed Railway deploy path

### DIFF
--- a/.changeset/ghcr-railway-template.md
+++ b/.changeset/ghcr-railway-template.md
@@ -1,0 +1,7 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Managed container deploys now explain that updates happen by redeploying the image instead of trying to run npm self-update inside the bot.
+
+Publish and document the official GHCR image path for Railway image-backed templates.

--- a/.dockerignore
+++ b/.dockerignore
@@ -33,4 +33,3 @@ coverage
 # Repo metadata not needed in image
 README.md
 CONTRIBUTING.md
-LICENSE

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,0 +1,81 @@
+name: Publish Docker image
+
+# First run creates the GHCR package. Before publishing the Railway marketplace
+# template, confirm the package visibility is Public in GitHub Packages.
+
+on:
+  push:
+    branches: [main]
+    tags:
+      - 'cycling-coach@*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE_NAME: ghcr.io/yerzhansa/cycling-coach
+
+jobs:
+  image:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    concurrency:
+      group: publish-image-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        name: Derive image tags
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          short_sha="${GITHUB_SHA::12}"
+          version=""
+          if [[ "${GITHUB_REF_TYPE}" == "tag" && "${GITHUB_REF_NAME}" == cycling-coach@* ]]; then
+            version="${GITHUB_REF_NAME#cycling-coach@}"
+          fi
+
+          {
+            echo "tags<<EOF"
+            echo "${IMAGE_NAME}:stable"
+            echo "${IMAGE_NAME}:main-${short_sha}"
+            if [[ -n "$version" ]]; then
+              echo "${IMAGE_NAME}:${version}"
+            fi
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            echo "labels<<EOF"
+            echo "org.opencontainers.image.title=Cycling Coach"
+            echo "org.opencontainers.image.description=Single-tenant AI cycling coach for Telegram and intervals.icu"
+            echo "org.opencontainers.image.source=https://github.com/yerzhansa/cycling-coach"
+            echo "org.opencontainers.image.revision=${GITHUB_SHA}"
+            if [[ -n "$version" ]]; then
+              echo "org.opencontainers.image.version=${version}"
+            fi
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: .
+          file: packages/cycling-coach/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,12 @@
 node_modules/
+.pnpm-store/
 dist/
 docs/
 .env
 *.tgz
 .DS_Store
 .idea/
+.obsidian/
 scripts/
 .claude
 .codex/

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Note: `npm run dev` runs TypeScript directly (via tsx). `npm run build` produces
 | `/status` | Shows fitness, fatigue, form, and coaching notes |
 | `/sync` | Pushes next 1-2 weeks of planned workouts to intervals.icu calendar |
 | `/whatsnew` | Shows what changed in the latest release |
-| `/update` | Updates the bot — installs the exact version it verified against the npm registry, with lifecycle scripts disabled (`npm install -g --ignore-scripts`) |
+| `/update` | npm installs: updates the bot to the exact verified registry version. Managed container deploys: explains that updates happen by image redeploy. |
 
 Free-form chat works too — ask anything about training, report an injury, request plan adjustments.
 
@@ -119,7 +119,7 @@ Cycling Coach restricts Telegram interactions to a configured allowlist of user 
 
 ### No telemetry, one update check
 
-Cycling Coach collects no analytics and sends no telemetry. The one background network call it makes on its own: on Telegram-mode startup, a single HTTPS request to `registry.npmjs.org` to check whether a newer version exists. It carries no athlete data and no credentials — the only thing disclosed is the request itself. Set `CYCLING_COACH_NO_UPDATE_CHECK=1` to disable it. The operator-initiated `/update` and `/whatsnew` commands still reach the registry (and, for `/whatsnew`, the GitHub Releases API for release notes) — those are explicit requests, not background checks.
+Cycling Coach collects no analytics and sends no telemetry. The one background network call it makes on its own: on Telegram-mode startup, a single HTTPS request to `registry.npmjs.org` to check whether a newer version exists. It carries no athlete data and no credentials — the only thing disclosed is the request itself. Set `CYCLING_COACH_NO_UPDATE_CHECK=1` to disable it. The operator-initiated `/update` and `/whatsnew` commands still reach the registry (and, for `/whatsnew`, the GitHub Releases API for release notes) — those are explicit requests, not background checks. In managed container deploys, `/update` does not run npm; image hosts update by redeploying the container image.
 
 ### First-time setup
 
@@ -350,20 +350,30 @@ Cycling Coach is a single Node process holding a long-polling connection to Tele
 
 ### Docker
 
-A `Dockerfile` is included. Build and run locally:
+The official image is published to GHCR:
 
 ```bash
-docker build -t cycling-coach .
+docker pull ghcr.io/yerzhansa/cycling-coach:stable
+```
 
+Run it with a persistent `/data` volume:
+
+```bash
 docker run -d --name cycling-coach \
   -v cycling-coach-data:/data \
   --env-file .env \
-  cycling-coach
+  ghcr.io/yerzhansa/cycling-coach:stable
 ```
 
-Use `--env-file` rather than inline `-e KEY=value` flags — inline values land in shell history and are visible to other users via `ps`. Your `.env` should contain `ANTHROPIC_API_KEY` (or `OPENAI_API_KEY` / `GOOGLE_GENERATIVE_AI_API_KEY`), `INTERVALS_API_KEY`, `INTERVALS_ATHLETE_ID`, and `TELEGRAM_BOT_TOKEN`. Restrict the file to the user that invokes `docker`: `chmod 600 .env`. Note that env vars passed to a container remain visible via `docker inspect` to anything with Docker-socket access — where available, prefer Docker Compose `secrets:` or podman secrets instead. For non-container installs, the config-based secret backends (macOS Keychain, 1Password SecretRef — see [Storing secrets outside config.yaml](#storing-secrets-outside-configyaml)) keep keys out of the environment entirely.
+Or build the same image locally from this repo:
 
-The image mounts `/data` for state and reads `/data/config.yaml` if present. The container runs as the non-root `node` user (uid 1000), and `/data` inside the image is owned by it. A volume mounted over `/data` carries its own ownership — managed PaaS platforms (Railway, Fly) typically mount fresh volumes as root-owned, so the bot can't write state until ownership is fixed. Configure the mount's ownership where the platform supports it, or fix it once with `docker run --rm --user root -v cycling-coach-data:/data cycling-coach chown -R node:node /data`; for host bind-mounts, `docker run --user "$(id -u):$(id -g)"` also works. With the env vars above, no `config.yaml` is required — the legacy env-var fallback (`ANTHROPIC_API_KEY` etc.) covers the three secret fields.
+```bash
+docker build -f packages/cycling-coach/Dockerfile -t cycling-coach .
+```
+
+Use `--env-file` rather than inline `-e KEY=value` flags — inline values land in shell history and are visible to other users via `ps`. Your `.env` should contain `ANTHROPIC_API_KEY` (or `OPENAI_API_KEY` / `GOOGLE_GENERATIVE_AI_API_KEY`), `INTERVALS_API_KEY`, `INTERVALS_ATHLETE_ID`, `TELEGRAM_BOT_TOKEN`, and `CYCLING_COACH_OPERATOR_ID` for unattended cloud/container starts. Restrict the file to the user that invokes `docker`: `chmod 600 .env`. Note that env vars passed to a container remain visible via `docker inspect` to anything with Docker-socket access — where available, prefer Docker Compose `secrets:` or podman secrets instead. For non-container installs, the config-based secret backends (macOS Keychain, 1Password SecretRef — see [Storing secrets outside config.yaml](#storing-secrets-outside-configyaml)) keep keys out of the environment entirely.
+
+The image mounts `/data` for state and reads `/data/config.yaml` if present. The image sets `CYCLING_COACH_MANAGED_DEPLOY=1`, so `/update` is disabled and updates happen by pulling/redeploying a newer image. The container starts as root only long enough to fix managed-platform volume ownership, then drops to the non-root `node` user (uid 1000). With the env vars above, no `config.yaml` is required — the legacy env-var fallback (`ANTHROPIC_API_KEY` etc.) covers the three secret fields.
 
 For finer control (custom model, idle timeout, etc.) drop a `config.yaml` into the volume:
 
@@ -388,15 +398,21 @@ telegram:
 
 ### Railway
 
-Railway autodetects the `Dockerfile` and deploys with no extra config files. Steps:
+The Railway distribution path is an image-backed marketplace template, not a GitHub fork or source build.
 
-1. Push this repo to GitHub.
-2. In Railway, **New Project → Deploy from GitHub repo**.
-3. Add a **Volume** mounted at `/data`.
-4. Add the env vars in **Variables**: `ANTHROPIC_API_KEY` (or `OPENAI_API_KEY` / `GOOGLE_GENERATIVE_AI_API_KEY`), `INTERVALS_API_KEY`, `INTERVALS_ATHLETE_ID`, `TELEGRAM_BOT_TOKEN`.
-5. Deploy. Railway shows logs; `Telegram bot started` confirms it's polling.
+Template link placeholder: `https://railway.com/new/template/TEMPLATE_ID`
 
-Railway does not scale services with attached volumes to zero, so the bot stays connected.
+Replace `TEMPLATE_ID` only after the GHCR package is public and the template is published in Railway's marketplace. The template service should use:
+
+- Docker image: `ghcr.io/yerzhansa/cycling-coach:stable`.
+- Volume: mount a persistent Railway volume at `/data`.
+- Variables: `ANTHROPIC_API_KEY` (or `OPENAI_API_KEY` / `GOOGLE_GENERATIVE_AI_API_KEY`), `INTERVALS_API_KEY`, `INTERVALS_ATHLETE_ID`, `TELEGRAM_BOT_TOKEN`, `CYCLING_COACH_OPERATOR_ID`.
+- Instances: exactly one replica, no autoscaling.
+- Networking: no public domain/gateway is required; Telegram uses outbound long polling.
+- Restart policy: restart on failure so the bot reconnects after crashes or Railway maintenance.
+- Updates: enable Railway image auto-updates for the GHCR image/tag and choose a maintenance window. Railway will redeploy the updated `stable` image; `/update` inside the bot stays disabled for managed deploys.
+
+Each deployment is single-tenant: the user's secrets and `/data` volume stay inside their Railway project, and Cycling Coach has no shared backend or telemetry.
 
 ### Other platforms
 

--- a/packages/core/src/channels/telegram.ts
+++ b/packages/core/src/channels/telegram.ts
@@ -8,6 +8,8 @@ import {
   getKnownTelegramChatIds,
   getCurrentVersion,
   getLastNotifiedVersion,
+  isManagedDeploy,
+  MANAGED_DEPLOY_UPDATE_NOTICE,
   setLastNotifiedVersion,
 } from "../updater.js";
 import { buildWhatsNewMessage } from "../release-notes.js";
@@ -364,6 +366,11 @@ export function createTelegramBot(
   });
 
   bot.command("update", async (ctx) => {
+    if (isManagedDeploy()) {
+      await ctx.reply(MANAGED_DEPLOY_UPDATE_NOTICE);
+      return;
+    }
+
     await ctx.reply("Checking for updates...");
     let latest: string | undefined;
     try {
@@ -812,7 +819,10 @@ export async function notifyUpdate(bot: Bot, dataDir: string, binary: BinaryConf
     const knownChats = getKnownTelegramChatIds(dataDir);
     const chatIds =
       allowed.dmPolicy === "open" ? knownChats : knownChats.filter((id) => allowSet.has(id));
-    const message = `Update available: ${info.current} → ${info.latest}\nSend /whatsnew to see what changed, /update to install.\n\nTag or DM me at x.com/yerzhansa with feedback, feature requests, or bugs — help shape what's next.`;
+    const updateInstruction = isManagedDeploy()
+      ? `Send /whatsnew to see what changed. ${MANAGED_DEPLOY_UPDATE_NOTICE}`
+      : "Send /whatsnew to see what changed, /update to install.";
+    const message = `Update available: ${info.current} → ${info.latest}\n${updateInstruction}\n\nTag or DM me at x.com/yerzhansa with feedback, feature requests, or bugs — help shape what's next.`;
 
     for (const chatId of chatIds) {
       try {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -217,7 +217,9 @@ export {
   getCurrentVersion,
   getKnownTelegramChatIds,
   getLastNotifiedVersion,
+  isManagedDeploy,
   isUpdateAvailable,
+  MANAGED_DEPLOY_UPDATE_NOTICE,
   selfUpdate,
   setLastNotifiedVersion,
 } from "./updater.js";

--- a/packages/core/src/updater.ts
+++ b/packages/core/src/updater.ts
@@ -10,6 +10,14 @@ export interface UpdateInfo {
   updateAvailable: boolean;
 }
 
+export const MANAGED_DEPLOY_UPDATE_NOTICE =
+  "This deployment updates through its container image. If Railway image auto-updates are enabled, Railway redeploys the latest GHCR image during the configured maintenance window; otherwise redeploy the service from the latest image in Railway.";
+
+export function isManagedDeploy(env: Record<string, string | undefined> = process.env): boolean {
+  const value = env.CYCLING_COACH_MANAGED_DEPLOY?.trim().toLowerCase();
+  return value === "1" || value === "true";
+}
+
 /**
  * Parse a CalVer string `YYYY.M.D` (with optional same-day re-release suffix
  * `-N`) into a comparable 4-tuple. Returns null for unparseable input —

--- a/packages/core/tests/telegram-bot.test.ts
+++ b/packages/core/tests/telegram-bot.test.ts
@@ -9,7 +9,11 @@ import {
 } from "../src/channels/allowed-senders.js";
 
 let dataDir: string;
-const ENV_KEYS = ["CYCLING_COACH_OPERATOR_ID", "CYCLING_COACH_DM_POLICY"];
+const ENV_KEYS = [
+  "CYCLING_COACH_OPERATOR_ID",
+  "CYCLING_COACH_DM_POLICY",
+  "CYCLING_COACH_MANAGED_DEPLOY",
+];
 let savedEnv: Record<string, string | undefined>;
 
 beforeEach(() => {
@@ -71,7 +75,7 @@ describe("notifyUpdate — broadcast filtering (L3)", () => {
       };
     });
 
-    const sendMessage = vi.fn(async () => undefined);
+    const sendMessage = vi.fn(async (_chatId: string, _message: string) => undefined);
     const fakeBot = { api: { sendMessage } } as unknown as Parameters<
       typeof import("../src/channels/telegram.js")["notifyUpdate"]
     >[0];
@@ -112,7 +116,7 @@ describe("notifyUpdate — broadcast filtering (L3)", () => {
       };
     });
 
-    const sendMessage = vi.fn(async () => undefined);
+    const sendMessage = vi.fn(async (_chatId: string, _message: string) => undefined);
     const fakeBot = { api: { sendMessage } } as unknown as Parameters<
       typeof import("../src/channels/telegram.js")["notifyUpdate"]
     >[0];
@@ -144,7 +148,7 @@ describe("notifyUpdate — broadcast filtering (L3)", () => {
       };
     });
 
-    const sendMessage = vi.fn(async () => undefined);
+    const sendMessage = vi.fn(async (_chatId: string, _message: string) => undefined);
     const fakeBot = { api: { sendMessage } } as unknown as Parameters<
       typeof import("../src/channels/telegram.js")["notifyUpdate"]
     >[0];
@@ -153,6 +157,51 @@ describe("notifyUpdate — broadcast filtering (L3)", () => {
     await notifyUpdate(fakeBot, dataDir, cyclingBinary);
 
     expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("managed deploy broadcast points at image redeploys instead of /update", async () => {
+    seedSession("11111");
+    saveAllowedSenders(dataDir, () => ({
+      ...defaultPairingState(),
+      dmPolicy: "allowlist",
+      allowFrom: ["11111"],
+      primaryOperator: "11111",
+    }));
+    process.env.CYCLING_COACH_MANAGED_DEPLOY = "1";
+
+    vi.doMock("../src/updater.js", async () => {
+      const real = await vi.importActual<typeof import("../src/updater.js")>(
+        "../src/updater.js",
+      );
+      return {
+        ...real,
+        checkForUpdate: vi.fn(async () => ({
+          current: "2026.5.5",
+          latest: "2026.5.10",
+          updateAvailable: true,
+        })),
+        getKnownTelegramChatIds: vi.fn(() => ["11111"]),
+        getLastNotifiedVersion: vi.fn(() => null),
+        setLastNotifiedVersion: vi.fn(),
+      };
+    });
+
+    const sendMessage = vi.fn(async (_chatId: string, _message: string) => undefined);
+    const fakeBot = { api: { sendMessage } } as unknown as Parameters<
+      typeof import("../src/channels/telegram.js")["notifyUpdate"]
+    >[0];
+
+    const { notifyUpdate } = await import("../src/channels/telegram.js");
+    await notifyUpdate(fakeBot, dataDir, cyclingBinary);
+
+    const message = sendMessage.mock.calls[0]?.[1] ?? "";
+    expect(message).toContain("Update available: 2026.5.5");
+    expect(message).toContain("Send /whatsnew to see what changed.");
+    expect(message).toContain("container image");
+    expect(message).toContain("GHCR image");
+    expect(message).toContain("Railway");
+    expect(message).not.toContain("/update to install");
+    expect(message).toContain("x.com/yerzhansa");
   });
 });
 

--- a/packages/core/tests/telegram-dispatch.test.ts
+++ b/packages/core/tests/telegram-dispatch.test.ts
@@ -17,6 +17,7 @@ beforeEach(() => {
 afterEach(() => {
   rmSync(dataDir, { recursive: true, force: true });
   vi.restoreAllMocks();
+  vi.unstubAllEnvs();
   vi.doUnmock("grammy");
   vi.doUnmock("../src/updater.js");
 });
@@ -355,6 +356,34 @@ describe("/snapshot — arg fallback", () => {
 });
 
 describe("/update — ordering invariant", () => {
+  it("managed deploys reply with image-update guidance and skip npm self-update", async () => {
+    vi.stubEnv("CYCLING_COACH_MANAGED_DEPLOY", "1");
+    const checkForUpdate = vi.fn(async () => ({
+      current: "2026.5.5",
+      latest: "2026.5.10",
+      updateAvailable: true,
+    }));
+    const selfUpdate = vi.fn();
+    vi.doMock("../src/updater.js", async () => {
+      const real = await vi.importActual<typeof import("../src/updater.js")>("../src/updater.js");
+      return {
+        ...real,
+        checkForUpdate,
+        selfUpdate,
+      };
+    });
+
+    const { bot } = await buildBot();
+    const ctx = makeCtx();
+    await getCommand(bot, "update")(ctx);
+
+    expect(someReply(ctx, "container image")).toBe(true);
+    expect(someReply(ctx, "GHCR image")).toBe(true);
+    expect(checkForUpdate).not.toHaveBeenCalled();
+    expect(bot.stop).not.toHaveBeenCalled();
+    expect(selfUpdate).not.toHaveBeenCalled();
+  });
+
   it("REGRESSION: /update calls bot.stop() BEFORE selfUpdate (no infinite re-send loop)", async () => {
     const selfUpdate = vi.fn();
     vi.doMock("../src/updater.js", async () => {

--- a/packages/core/tests/updater.test.ts
+++ b/packages/core/tests/updater.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { buildSelfUpdateCommand, checkForUpdate, isUpdateAvailable } from "../src/updater.js";
+import {
+  buildSelfUpdateCommand,
+  checkForUpdate,
+  isManagedDeploy,
+  isUpdateAvailable,
+} from "../src/updater.js";
 
 // Regression: the original `data.version !== current` returned true for ANY
 // inequality, including the case where the running bot is ahead of npm — a
@@ -68,6 +73,20 @@ describe("buildSelfUpdateCommand", () => {
     const cmd = buildSelfUpdateCommand("cycling-coach", "1.0.0; touch /tmp/pwned");
     expect(cmd).toContain("cycling-coach@latest");
     expect(cmd).not.toContain(";");
+  });
+});
+
+describe("isManagedDeploy", () => {
+  it("treats 1 and true as managed deploy signals", () => {
+    expect(isManagedDeploy({ CYCLING_COACH_MANAGED_DEPLOY: "1" })).toBe(true);
+    expect(isManagedDeploy({ CYCLING_COACH_MANAGED_DEPLOY: "true" })).toBe(true);
+    expect(isManagedDeploy({ CYCLING_COACH_MANAGED_DEPLOY: " TRUE " })).toBe(true);
+  });
+
+  it("treats absent or non-true values as unmanaged installs", () => {
+    expect(isManagedDeploy({})).toBe(false);
+    expect(isManagedDeploy({ CYCLING_COACH_MANAGED_DEPLOY: "0" })).toBe(false);
+    expect(isManagedDeploy({ CYCLING_COACH_MANAGED_DEPLOY: "false" })).toBe(false);
   });
 });
 

--- a/packages/cycling-coach/CONTEXT.md
+++ b/packages/cycling-coach/CONTEXT.md
@@ -11,7 +11,7 @@ Bundled via tsup with `@enduragent/*` **inlined** (`noExternal`). The published 
 - `src/index.ts` — the bin shim (`runBinary(cyclingSport, cyclingBinary, { onStartup })`).
 - `src/binary.ts` — `cyclingBinary: BinaryConfig` (binaryName: "cycling-coach", displayName: "Cycling Coach", dataSubdir: "cycling", keychainPrefix: "cycling-coach", homeEnvVar: "CYCLING_COACH_HOME").
 - `tests/migration-integration.test.ts` — end-to-end check that the legacy-section migration runs through `agent.getMemory()` exactly as `runBinary`'s onStartup does.
-- `Dockerfile` — multi-stage workspace build via `pnpm deploy --prod`. Railway picks this up.
+- `Dockerfile` — multi-stage workspace build via `pnpm deploy --prod`. The published GHCR image sets `CYCLING_COACH_MANAGED_DEPLOY=1` so image-backed hosts update by redeploying the container, not by `/update`.
 
 ## Not here (intentionally)
 

--- a/packages/cycling-coach/Dockerfile
+++ b/packages/cycling-coach/Dockerfile
@@ -48,12 +48,16 @@ WORKDIR /app
 
 ENV NODE_ENV=production
 ENV CYCLING_COACH_HOME=/data
+# Image-backed hosts update by pulling/redeploying the container, not by npm
+# self-update inside the running process.
+ENV CYCLING_COACH_MANAGED_DEPLOY=1
 
 # su-exec drops root to `node` in the entrypoint after the mounted volume's
 # ownership is fixed (managed-platform volumes mount as root).
 RUN apk add --no-cache su-exec
 
 COPY --from=builder --chown=root:root /app/runtime-bundle ./
+COPY --chown=root:root LICENSE NOTICE.md ./
 COPY packages/cycling-coach/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh && mkdir -p /data
 

--- a/packages/cycling-coach/tests/dockerfile-pin-guard.test.ts
+++ b/packages/cycling-coach/tests/dockerfile-pin-guard.test.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import YAML from "yaml";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+
+describe("Docker image supply-chain guards", () => {
+  it("pins every Dockerfile base image by digest", () => {
+    const dockerfile = readFileSync(
+      resolve(repoRoot, "packages/cycling-coach/Dockerfile"),
+      "utf8",
+    );
+    const fromLines = dockerfile
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line.startsWith("FROM "));
+
+    expect(fromLines.length).toBeGreaterThan(0);
+    for (const line of fromLines) {
+      expect(line).toMatch(/^FROM\s+\S+@sha256:[a-f0-9]{64}(?:\s+AS\s+\S+)?$/);
+    }
+  });
+
+  it("keeps Dependabot watching the cycling-coach Dockerfile", () => {
+    const dependabot = YAML.parse(
+      readFileSync(resolve(repoRoot, ".github/dependabot.yml"), "utf8"),
+    ) as { updates?: Array<Record<string, unknown>> };
+
+    expect(
+      dependabot.updates?.some(
+        (entry) =>
+          entry["package-ecosystem"] === "docker" &&
+          entry.directory === "/packages/cycling-coach",
+      ),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Publish a SHA-pinned GitHub Actions workflow for `ghcr.io/yerzhansa/cycling-coach:stable` plus release/sha image tags.
- Mark container deploys as managed so `/update` explains image redeploys instead of trying npm self-update.
- Document the GHCR-backed Railway template shape: `/data` volume, required vars, single replica, no public gateway/shared backend, and image auto-updates.

## Test plan
- [x] `env CI=true corepack pnpm --filter @enduragent/core exec vitest run tests/updater.test.ts tests/telegram-bot.test.ts tests/telegram-dispatch.test.ts`
- [x] `env CI=true corepack pnpm --filter cycling-coach exec vitest run tests/dockerfile-pin-guard.test.ts`
- [x] `env CI=true corepack pnpm -r build`
- [x] `env CI=true corepack pnpm -r check`
- [x] `env CI=true corepack pnpm exec tsc -p tsconfig.check.json`
- [x] `env CI=true corepack pnpm exec oxlint packages/`
- [x] `env CI=true corepack pnpm exec tsx tools/check-trademarks.ts`
- [x] `env CI=true corepack pnpm exec tsx tools/check-fixture-privacy.ts`
- [x] `env CI=true corepack pnpm exec tsx tools/check-registry-isolation.ts`
- [x] `env CI=true corepack pnpm exec tsx tools/check-changeset-user-facing.ts`
- [x] Workflow YAML parses via `node --input-type=module ... YAML.parse(...)`
- [x] `git diff --check`

Not run locally: `docker build -f packages/cycling-coach/Dockerfile ...` because the Docker daemon is not running on this machine.