### PR TITLE
Ignore Codex override instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ scripts/
 .claude
 .codex/
 CLAUDE.local.md
+AGENTS.override.md
 .tests/
 .agents/
 .ralph/


### PR DESCRIPTION
## Summary
- Add AGENTS.override.md to shared ignore rules so local Codex project instructions stay out of commits.

## Test plan
- [x] Verified AGENTS.override.md and CLAUDE.local.md are ignored with git check-ignore.