### PR TITLE
fix(core): bound LLM calls and retry plain timeouts once

### DIFF
--- a/.changeset/bounded-llm-timeouts.md
+++ b/.changeset/bounded-llm-timeouts.md
@@ -1,0 +1,7 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Coach replies now get a bounded model-call deadline and one safe retry for plain timeouts instead of hanging indefinitely.
+
+Bound owned LLM calls with an abort deadline and guard timeout retries from replaying committed tool writes.

--- a/.changeset/bounded-llm-timeouts.md
+++ b/.changeset/bounded-llm-timeouts.md
@@ -3,5 +3,9 @@
 ---
 
 User-facing: Coach replies now get a bounded model-call deadline and one safe retry for plain timeouts instead of hanging indefinitely.
+User-facing: Training plans are no longer at risk of being duplicated when a request times out or context overflows.
+User-facing: Long chat turns are now bounded so they can't run roughly twice the intended time.
 
 Bound owned LLM calls with an abort deadline and guard timeout retries from replaying committed tool writes.
+
+When a turn has already committed a memory or plan write and then fails (overflow/timeout), it now returns the canned "couldn't finish" message instead of self-healing via replay — deliberately preventing a re-run of the non-idempotent write. The committed write is preserved; only the in-turn answer is sacrificed.

--- a/packages/core/src/agent/coach-agent.ts
+++ b/packages/core/src/agent/coach-agent.ts
@@ -78,6 +78,9 @@ const REPLAY_UNSAFE_TOOL_NAMES = new Set([
   "intervals_delete_workout",
   "memory_write",
   "plan_save",
+  // Commits a plan via memory.savePlan — the same non-idempotent side effect as
+  // plan_save — so a retry must not replay it. Recognized in committedWriteSummary.
+  "build_plan_skeleton",
 ]);
 
 // A turn that spent its whole step budget on tool calls (or hit the output-token
@@ -165,11 +168,14 @@ function backoffWithSentinelError(
 
 function committedWriteSummary(name: string, result: unknown): string | undefined {
   if (result === null || typeof result !== "object") return undefined;
-  const out = result as { created?: unknown; deleted?: unknown; saved?: unknown };
+  const out = result as { created?: unknown; deleted?: unknown; saved?: unknown; phases?: unknown };
   if (out.created === true) return "created a workout on the calendar";
   if (out.deleted === true) return "deleted a scheduled workout";
   if (out.saved === true && name === "memory_write") return "saved athlete memory";
   if (out.saved === true && name === "plan_save") return "saved the training plan";
+  // build_plan_skeleton returns the saved plan itself (a phases-bearing object),
+  // not a {saved:true} ack, so recognize its success by the plan shape.
+  if (name === "build_plan_skeleton" && Array.isArray(out.phases)) return "built training plan";
   return undefined;
 }
 
@@ -380,6 +386,7 @@ export class CoachAgent {
         tools: undefined,
         caller: "chat",
         cacheKey,
+        deadlineMs: turnBudget.remainingMs(),
       });
       return recovery.text.trim() !== "" ? recovery.text : STEP_LIMIT_TRUNCATION_MESSAGE;
     } catch (recoveryErr) {
@@ -603,6 +610,9 @@ export class CoachAgent {
               maxSteps: 10,
               caller: "chat",
               cacheKey,
+              // Cap this call by the turn's remaining wall-clock budget so a retry
+              // after an early timeout inherits only the time the turn has left.
+              deadlineMs: turnBudget.remainingMs(),
             });
             const { text, finishReason } = result;
 

--- a/packages/core/src/agent/coach-agent.ts
+++ b/packages/core/src/agent/coach-agent.ts
@@ -132,6 +132,11 @@ interface TurnOutcome {
   compactions: number;
 }
 
+interface TurnWriteRecord {
+  writesCommitted: number;
+  lastWriteSummary?: string;
+}
+
 function classifyError(err: unknown): string {
   // TurnBudgetExceededError crosses a dynamic-import boundary in tests, so match
   // on the structural name rather than instanceof.
@@ -186,10 +191,9 @@ export class CoachAgent {
   private archiveDeferred = new Set<string>();
   private lastFlushMessageCount = new Map<string, number>();
   // A committed tool write makes the turn non-replayable: the retry loop re-sends
-  // the pre-turn messages, so a second generate could re-run the write.
-  private turnWrites: { writesCommitted: number; lastWriteSummary?: string } = {
-    writesCommitted: 0,
-  };
+  // the pre-turn messages, so a second generate could re-run the write. Keep it
+  // in async-local turn state so concurrent chats cannot reset each other.
+  private readonly turnWritesStore = new AsyncLocalStorage<TurnWriteRecord>();
   // Per-turn read memoizer cache. Held in async-context storage (mirroring
   // resolvedCsStore below) rather than a shared instance field so that
   // concurrent fire-and-forget turns each memoize into their OWN map and can
@@ -266,13 +270,13 @@ export class CoachAgent {
     if (!REPLAY_UNSAFE_TOOL_NAMES.has(name)) return tool;
     const inner = tool.execute;
     if (typeof inner !== "function") return tool;
-    const record = this.turnWrites;
     return {
       ...tool,
       execute: async (input: unknown, options: unknown) => {
         const result = await (inner as (i: unknown, o: unknown) => unknown)(input, options);
         const summary = committedWriteSummary(name, result);
-        if (summary !== undefined) {
+        const record = this.turnWritesStore.getStore();
+        if (record !== undefined && summary !== undefined) {
           record.writesCommitted++;
           record.lastWriteSummary = summary;
         }
@@ -415,17 +419,15 @@ export class CoachAgent {
     // fire-and-forget turns never clobber each other's anchor. null when the
     // channel supplies nothing (CLI path, no sync data).
     const resolvedCs = turn?.resolvedCs ?? null;
+    const turnWrites: TurnWriteRecord = { writesCommitted: 0 };
     return this.resolvedCsStore.run(resolvedCs, () =>
       this.readToolCacheStore.run(new Map<string, unknown>(), () =>
-      withSessionLock(chatId, async () => {
+        this.turnWritesStore.run(turnWrites, () =>
+          withSessionLock(chatId, async () => {
       const turnStart = Date.now();
       const turnId = randomUUID();
       let compactions = 0;
       const turnBudget = createTurnBudget(() => Date.now());
-      // Reset the per-turn write record in place (the wrapped write tools hold a
-      // reference to this object, captured once at construction).
-      this.turnWrites.writesCommitted = 0;
-      this.turnWrites.lastWriteSummary = undefined;
       // One flush per turn: the latch flips on entry (before the await
       // resolves) so a thrown flush still consumes the turn's single flush.
       let flushedThisTurn = false;
@@ -674,12 +676,13 @@ export class CoachAgent {
             if (err instanceof TurnBudgetExceededError) throw err;
             // A committed tool write makes this turn non-replayable: retrying
             // would re-send the pre-turn messages and could re-run the write.
-            if (this.turnWrites.writesCommitted > 0) {
+            const committedWrites = this.turnWritesStore.getStore() ?? turnWrites;
+            if (committedWrites.writesCommitted > 0) {
               console.warn(
                 JSON.stringify({
                   event: "turn_failed_after_write",
-                  writesCommitted: this.turnWrites.writesCommitted,
-                  lastWriteSummary: this.turnWrites.lastWriteSummary,
+                  writesCommitted: committedWrites.writesCommitted,
+                  lastWriteSummary: committedWrites.lastWriteSummary,
                   error: (err instanceof Error ? err.message : String(err)).slice(0, 200),
                 }),
               );
@@ -827,6 +830,7 @@ export class CoachAgent {
         throw terminalErr;
       }
       }),
+        ),
       ),
     );
   }

--- a/packages/core/src/agent/coach-agent.ts
+++ b/packages/core/src/agent/coach-agent.ts
@@ -51,6 +51,7 @@ import { TAINTED_BY_WRITES_MESSAGE, STEP_LIMIT_TRUNCATION_MESSAGE } from "./coac
 
 const MAX_OVERFLOW_ATTEMPTS = 3;
 const MAX_TIMEOUT_ATTEMPTS = 2;
+const MAX_PLAIN_TIMEOUT_ATTEMPTS = 1;
 const MAX_RATE_LIMIT_ATTEMPTS = 3;
 const MAX_SERVER_ERROR_ATTEMPTS = 2;
 const SERVER_ERROR_BACKOFF_BASE_MS = 500;
@@ -72,9 +73,12 @@ const RATE_LIMIT_FALLBACK_MAX_MS = 30_000;
 const RATE_LIMIT_MAX_WAIT_MS = 120_000;
 const MAX_FLUSH_ATTEMPTS = 2;
 
-// Calendar write tools whose committed success makes a turn non-replayable.
-// Kept here so the taint set can't drift from the actual tool names.
-const WRITE_TOOL_NAMES = new Set(["intervals_create_workout", "intervals_delete_workout"]);
+const REPLAY_UNSAFE_TOOL_NAMES = new Set([
+  "intervals_create_workout",
+  "intervals_delete_workout",
+  "memory_write",
+  "plan_save",
+]);
 
 // A turn that spent its whole step budget on tool calls (or hit the output-token
 // cap) and never emitted final text. Kept a single named predicate so the future
@@ -154,6 +158,16 @@ function backoffWithSentinelError(
   }, opts);
 }
 
+function committedWriteSummary(name: string, result: unknown): string | undefined {
+  if (result === null || typeof result !== "object") return undefined;
+  const out = result as { created?: unknown; deleted?: unknown; saved?: unknown };
+  if (out.created === true) return "created a workout on the calendar";
+  if (out.deleted === true) return "deleted a scheduled workout";
+  if (out.saved === true && name === "memory_write") return "saved athlete memory";
+  if (out.saved === true && name === "plan_save") return "saved the training plan";
+  return undefined;
+}
+
 // ============================================================================
 // AGENT
 // ============================================================================
@@ -171,9 +185,8 @@ export class CoachAgent {
   private tz: string;
   private archiveDeferred = new Set<string>();
   private lastFlushMessageCount = new Map<string, number>();
-  // Per-turn record of committed calendar writes, reset at the top of chat().
-  // A committed write makes the turn non-replayable: the retry loop re-sends the
-  // pre-turn messages, so a second generate could re-run a non-idempotent create.
+  // A committed tool write makes the turn non-replayable: the retry loop re-sends
+  // the pre-turn messages, so a second generate could re-run the write.
   private turnWrites: { writesCommitted: number; lastWriteSummary?: string } = {
     writesCommitted: 0,
   };
@@ -245,12 +258,12 @@ export class CoachAgent {
     this.systemPrompt = "";
   }
 
-  // Agent-owned wrapper that records a committed calendar write the moment its
+  // Agent-owned wrapper that records a committed tool write the moment its
   // tool executes — at the execution boundary, not from the generate result,
   // because result.toolCalls carries only the last agentic step and would miss
   // a write committed on an earlier step. Non-write tools pass through untouched.
   private wrapWriteTool(name: string, tool: Tool): Tool {
-    if (!WRITE_TOOL_NAMES.has(name)) return tool;
+    if (!REPLAY_UNSAFE_TOOL_NAMES.has(name)) return tool;
     const inner = tool.execute;
     if (typeof inner !== "function") return tool;
     const record = this.turnWrites;
@@ -258,17 +271,10 @@ export class CoachAgent {
       ...tool,
       execute: async (input: unknown, options: unknown) => {
         const result = await (inner as (i: unknown, o: unknown) => unknown)(input, options);
-        if (
-          result !== null &&
-          typeof result === "object" &&
-          ((result as { created?: unknown }).created === true ||
-            (result as { deleted?: unknown }).deleted === true)
-        ) {
+        const summary = committedWriteSummary(name, result);
+        if (summary !== undefined) {
           record.writesCommitted++;
-          record.lastWriteSummary =
-            (result as { created?: unknown }).created === true
-              ? "created a workout on the calendar"
-              : "deleted a scheduled workout";
+          record.lastWriteSummary = summary;
         }
         return result;
       },
@@ -555,6 +561,7 @@ export class CoachAgent {
 
       let overflowAttempts = 0;
       let timeoutAttempts = 0;
+      let plainTimeoutAttempts = 0;
       let rateLimitAttempts = 0;
       let serverErrorAttempts = 0;
 
@@ -665,9 +672,8 @@ export class CoachAgent {
             // retry branch so a future reordering can never mistake it for one of
             // the retryable classes and swallow it.
             if (err instanceof TurnBudgetExceededError) throw err;
-            // A committed calendar write makes this turn non-replayable: retrying
-            // would re-send the pre-turn messages and could re-run a
-            // non-idempotent create. Refuse honestly instead of looping.
+            // A committed tool write makes this turn non-replayable: retrying
+            // would re-send the pre-turn messages and could re-run the write.
             if (this.turnWrites.writesCommitted > 0) {
               console.warn(
                 JSON.stringify({
@@ -730,6 +736,11 @@ export class CoachAgent {
                   }
                   throw err;
                 }
+                continue;
+              }
+              if (plainTimeoutAttempts < MAX_PLAIN_TIMEOUT_ATTEMPTS) {
+                plainTimeoutAttempts++;
+                timeoutAttempts++;
                 continue;
               }
             }

--- a/packages/core/src/agent/codex-bridge.ts
+++ b/packages/core/src/agent/codex-bridge.ts
@@ -201,7 +201,7 @@ function errorResult(call: CodexToolCall, message: string): ToolResultPart {
 export async function codexGenerateText(
   opts: GenerateOpts & { modelId: string; profileName: string; stepLimit?: number },
 ): Promise<GenerateResult> {
-  const { system, messages, prompt, tools, modelId, profileName, stepLimit, cacheKey } = opts;
+  const { system, messages, prompt, tools, modelId, profileName, stepLimit, cacheKey, signal } = opts;
 
   const initialMessages: ModelMessage[] = prompt
     ? [{ role: "user", content: prompt }]
@@ -235,6 +235,7 @@ export async function codexGenerateText(
         tools,
         accessToken,
         sessionId: cacheKey,
+        signal,
       });
     } catch (err) {
       throw normalizeError(err);
@@ -263,7 +264,7 @@ export async function codexGenerateText(
     // Run tool calls in parallel to match AI SDK behavior; Promise.all preserves
     // order so the conversation stays aligned.
     const results = await Promise.all(
-      calls.map((call) => executeToolCall(call, tools, initialMessages)),
+      calls.map((call) => executeToolCall(call, tools, initialMessages, signal)),
     );
     convo.push({ role: "tool", content: results } as ModelMessage);
   }

--- a/packages/core/src/agent/codex-bridge.ts
+++ b/packages/core/src/agent/codex-bridge.ts
@@ -211,7 +211,9 @@ export async function codexGenerateText(
 
   // Fetch the token once per request. The step loop runs well within the
   // 5-minute refresh threshold, so a refresh mid-loop is not a concern.
-  const accessToken = await getFreshToken(profileName);
+  // Thread the per-call signal so a stalled token endpoint is bounded by the
+  // same deadline as the request rather than hanging the turn.
+  const accessToken = await getFreshToken(profileName, signal);
 
   const toToolCallPart = (tc: CodexToolCall) => ({
     type: "tool-call" as const,

--- a/packages/core/src/agent/codex/oauth.ts
+++ b/packages/core/src/agent/codex/oauth.ts
@@ -252,6 +252,12 @@ async function exchangeAuthorizationCode(
   };
 }
 
+function isAbortShaped(error: unknown): boolean {
+  if (error === null || typeof error !== "object") return false;
+  const name = (error as { name?: unknown }).name;
+  return name === "AbortError" || name === "TimeoutError";
+}
+
 async function refreshAccessToken(
   refreshToken: string,
   signal?: AbortSignal,
@@ -295,6 +301,10 @@ async function refreshAccessToken(
       expires: Date.now() + json.expires_in * 1000,
     };
   } catch (error) {
+    // A deadline or 30s-backstop abort is not a credential failure -- propagate it
+    // with its real shape so the retry/deny path is skipped and the surfaced error
+    // is the abort, not a misleading "re-run setup".
+    if (isAbortShaped(error) || signal?.aborted) throw error;
     console.error("[codex-oauth] Token refresh error:", error);
     return { type: "failed" };
   }

--- a/packages/core/src/agent/codex/oauth.ts
+++ b/packages/core/src/agent/codex/oauth.ts
@@ -11,6 +11,7 @@ const SCOPE = "openid profile email offline_access";
 const CALLBACK_PORT = 1455;
 const CALLBACK_HOST = "127.0.0.1";
 const CALLBACK_PATH = "/auth/callback";
+const TOKEN_REFRESH_TIMEOUT_MS = 30_000;
 
 export interface CodexCredentials {
   access: string;
@@ -251,8 +252,15 @@ async function exchangeAuthorizationCode(
   };
 }
 
-async function refreshAccessToken(refreshToken: string): Promise<TokenResult> {
+async function refreshAccessToken(
+  refreshToken: string,
+  signal?: AbortSignal,
+): Promise<TokenResult> {
   try {
+    // The token endpoint should respond quickly; bound it with a short timeout
+    // combined with the caller's deadline so a stall can't hang the turn.
+    const timeout = AbortSignal.timeout(TOKEN_REFRESH_TIMEOUT_MS);
+    const fetchSignal = signal ? AbortSignal.any([signal, timeout]) : timeout;
     const response = await fetch(TOKEN_URL, {
       method: "POST",
       headers: { "Content-Type": "application/x-www-form-urlencoded" },
@@ -261,6 +269,7 @@ async function refreshAccessToken(refreshToken: string): Promise<TokenResult> {
         refresh_token: refreshToken,
         client_id: CLIENT_ID,
       }),
+      signal: fetchSignal,
     });
     if (!response.ok) {
       console.error("[codex-oauth] Token refresh failed:", response.status);
@@ -366,8 +375,11 @@ export async function loginCodex(options: CodexLoginOptions): Promise<CodexCrede
   }
 }
 
-export async function refreshCodexToken(refreshToken: string): Promise<CodexCredentials> {
-  const result = await refreshAccessToken(refreshToken);
+export async function refreshCodexToken(
+  refreshToken: string,
+  signal?: AbortSignal,
+): Promise<CodexCredentials> {
+  const result = await refreshAccessToken(refreshToken, signal);
   if (result.type !== "success") {
     throw new Error("Failed to refresh OpenAI Codex token");
   }

--- a/packages/core/src/agent/codex/responses.ts
+++ b/packages/core/src/agent/codex/responses.ts
@@ -593,7 +593,13 @@ function abortError(signal: AbortSignal | undefined, fallback?: unknown): Error 
   const reason = signal?.reason;
   if (reason instanceof Error) return reason;
   if (fallback instanceof Error) return fallback;
-  return new Error(reason === undefined ? "Request was aborted" : String(reason));
+  if (reason === undefined) return new Error("Request was aborted");
+  if (typeof reason === "string") return new Error(reason);
+  try {
+    return new Error(JSON.stringify(reason));
+  } catch {
+    return new Error("Request was aborted");
+  }
 }
 
 // ============================================================================
@@ -657,7 +663,7 @@ export async function codexResponses(params: CodexResponsesParams): Promise<Code
     throw err;
   }
 
-  if (params.signal?.aborted) throw abortError(params.signal);
-
+  // A fully-accumulated result is already paid for; return it even if the signal
+  // races the boundary and flips to aborted after accumulation has resolved.
   return result;
 }

--- a/packages/core/src/agent/codex/responses.ts
+++ b/packages/core/src/agent/codex/responses.ts
@@ -596,7 +596,8 @@ function abortError(signal: AbortSignal | undefined, fallback?: unknown): Error 
   if (reason === undefined) return new Error("Request was aborted");
   if (typeof reason === "string") return new Error(reason);
   try {
-    return new Error(JSON.stringify(reason));
+    const serialized = JSON.stringify(reason);
+    return new Error(serialized ?? "Request was aborted");
   } catch {
     return new Error("Request was aborted");
   }

--- a/packages/core/src/agent/codex/responses.ts
+++ b/packages/core/src/agent/codex/responses.ts
@@ -575,12 +575,33 @@ function parseRetryAfterMs(headers: Headers): number | undefined {
   return undefined;
 }
 
+function isTimeoutAbort(signal: AbortSignal | undefined): boolean {
+  if (!signal?.aborted) return false;
+  const reason = signal.reason;
+  if (reason instanceof Error && /timeout|deadline/i.test(`${reason.name} ${reason.message}`)) {
+    return true;
+  }
+  if (reason && typeof reason === "object") {
+    const { name, message } = reason as { name?: unknown; message?: unknown };
+    return /timeout|deadline/i.test(`${String(name ?? "")} ${String(message ?? "")}`);
+  }
+  return false;
+}
+
+function abortError(signal: AbortSignal | undefined, fallback?: unknown): Error {
+  if (isTimeoutAbort(signal)) return new Error("Request was aborted");
+  const reason = signal?.reason;
+  if (reason instanceof Error) return reason;
+  if (fallback instanceof Error) return fallback;
+  return new Error(reason === undefined ? "Request was aborted" : String(reason));
+}
+
 // ============================================================================
 // Main entrypoint — one round-trip, no internal retry loop
 // ============================================================================
 
 export async function codexResponses(params: CodexResponsesParams): Promise<CodexResponsesResult> {
-  if (params.signal?.aborted) throw new Error("Request was aborted");
+  if (params.signal?.aborted) throw abortError(params.signal);
 
   const accountId = extractAccountId(params.accessToken);
   const headers = buildSSEHeaders(accountId, params.accessToken, params.sessionId);
@@ -600,7 +621,7 @@ export async function codexResponses(params: CodexResponsesParams): Promise<Code
     // the outer classifier reads the errno via the cause chain. Abort surfaces
     // as the verbatim string the timeout classifier matches.
     if (err instanceof Error && (err.name === "AbortError" || params.signal?.aborted)) {
-      throw new Error("Request was aborted");
+      throw abortError(params.signal, err);
     }
     throw err;
   }
@@ -626,9 +647,17 @@ export async function codexResponses(params: CodexResponsesParams): Promise<Code
 
   if (!response.body) throw new Error("No response body");
 
-  const result = await accumulate(mapCodexEvents(parseSSE(response)));
+  let result: CodexResponsesResult;
+  try {
+    result = await accumulate(mapCodexEvents(parseSSE(response)));
+  } catch (err) {
+    if (err instanceof Error && (err.name === "AbortError" || params.signal?.aborted)) {
+      throw abortError(params.signal, err);
+    }
+    throw err;
+  }
 
-  if (params.signal?.aborted) throw new Error("Request was aborted");
+  if (params.signal?.aborted) throw abortError(params.signal);
 
   return result;
 }

--- a/packages/core/src/agent/turn-budget.ts
+++ b/packages/core/src/agent/turn-budget.ts
@@ -20,6 +20,8 @@ export interface TurnBudget {
   chargeAttempt(): void;
   /** Between-attempt deadline check (never mid-attempt). Throws "wall_clock" on overrun. */
   checkDeadline(): void;
+  /** Milliseconds left in the turn's wall-clock budget (never negative). Lets a per-call LLM deadline be bounded by the budget the next attempt still has. */
+  remainingMs(): number;
 }
 
 export function createTurnBudget(now: () => number): TurnBudget {
@@ -52,6 +54,9 @@ export function createTurnBudget(now: () => number): TurnBudget {
           `Per-turn wall-clock deadline exceeded (${TURN_WALL_CLOCK_MS}ms).`,
         );
       }
+    },
+    remainingMs() {
+      return Math.max(0, TURN_WALL_CLOCK_MS - (now() - turnStart));
     },
   };
 }

--- a/packages/core/src/auth/profiles.ts
+++ b/packages/core/src/auth/profiles.ts
@@ -106,6 +106,9 @@ async function refreshWithRetry(name: string, cred: OAuthCredential, signal?: Ab
   try {
     return await refreshCodexToken(cred.refresh, signal);
   } catch (err) {
+    // A caller-deadline abort is not a denied refresh -- skip the 2s retry/deny path
+    // and propagate it so the surfaced error is not a misleading "re-run setup".
+    if (signal?.aborted) throw err;
     if (!isRefreshDenied(err)) throw err;
     // pi-ai reports invalid_grant, 5xx, and network failures with one generic
     // message; retry once with the on-disk token before declaring the

--- a/packages/core/src/auth/profiles.ts
+++ b/packages/core/src/auth/profiles.ts
@@ -102,9 +102,9 @@ function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-async function refreshWithRetry(name: string, cred: OAuthCredential) {
+async function refreshWithRetry(name: string, cred: OAuthCredential, signal?: AbortSignal) {
   try {
-    return await refreshCodexToken(cred.refresh);
+    return await refreshCodexToken(cred.refresh, signal);
   } catch (err) {
     if (!isRefreshDenied(err)) throw err;
     // pi-ai reports invalid_grant, 5xx, and network failures with one generic
@@ -113,7 +113,7 @@ async function refreshWithRetry(name: string, cred: OAuthCredential) {
     await delay(REFRESH_RETRY_DELAY_MS);
     const onDisk = loadProfile(name) ?? cred;
     try {
-      return await refreshCodexToken(onDisk.refresh);
+      return await refreshCodexToken(onDisk.refresh, signal);
     } catch (retryErr) {
       if (isRefreshDenied(retryErr)) {
         throw new RefreshTokenReusedError(name, retryErr);
@@ -125,11 +125,11 @@ async function refreshWithRetry(name: string, cred: OAuthCredential) {
 
 const refreshQueues = new Map<string, Promise<unknown>>();
 
-export async function getFreshToken(name: string): Promise<string> {
+export async function getFreshToken(name: string, signal?: AbortSignal): Promise<string> {
   const prev = refreshQueues.get(name) ?? Promise.resolve();
   const run = prev.then(
-    () => getFreshTokenExclusive(name),
-    () => getFreshTokenExclusive(name),
+    () => getFreshTokenExclusive(name, signal),
+    () => getFreshTokenExclusive(name, signal),
   );
   refreshQueues.set(name, run);
   try {
@@ -141,7 +141,7 @@ export async function getFreshToken(name: string): Promise<string> {
   }
 }
 
-async function getFreshTokenExclusive(name: string): Promise<string> {
+async function getFreshTokenExclusive(name: string, signal?: AbortSignal): Promise<string> {
   const cred = loadProfile(name);
   if (!cred) {
     throw new Error(`No OAuth profile "${name}". Run \`cycling-coach setup\` to create one.`);
@@ -155,7 +155,7 @@ async function getFreshTokenExclusive(name: string): Promise<string> {
     throw new Error(`Refresh not implemented for profile "${name}"`);
   }
 
-  const refreshed = await refreshWithRetry(name, cred);
+  const refreshed = await refreshWithRetry(name, cred, signal);
 
   const next: OAuthCredential = {
     type: "oauth",

--- a/packages/core/src/llm-types.ts
+++ b/packages/core/src/llm-types.ts
@@ -15,6 +15,8 @@ export interface GenerateOpts {
   maxSteps?: number;
   maxOutputTokens?: number;
   signal?: AbortSignal;
+  /** Upper bound (ms) on this single call, intersected with the caller's per-call deadline. Lets the agent loop cap a call by the turn's remaining wall-clock budget so a retry after an early timeout cannot open a fresh full deadline window. */
+  deadlineMs?: number;
   /** Codex-only: forwarded to the codex bridge as its session id. The AI-SDK providers never read it. */
   cacheKey?: string;
   caller?: "chat" | "flush" | "compact";

--- a/packages/core/src/llm-types.ts
+++ b/packages/core/src/llm-types.ts
@@ -14,6 +14,7 @@ export interface GenerateOpts {
   stopWhen?: StopCondition<any> | Array<StopCondition<any>>;
   maxSteps?: number;
   maxOutputTokens?: number;
+  signal?: AbortSignal;
   /** Codex-only: forwarded to the codex bridge as its session id. The AI-SDK providers never read it. */
   cacheKey?: string;
   caller?: "chat" | "flush" | "compact";

--- a/packages/core/src/llm.ts
+++ b/packages/core/src/llm.ts
@@ -15,7 +15,6 @@ import { PROVIDER_BASE_URLS } from "./config.js";
 import { codexGenerateText } from "./agent/codex-bridge.js";
 import type { GenerateOpts, GenerateResult } from "./llm-types.js";
 import { appendUsageLine, cacheTokenDetails, usageFieldsFromResult } from "./usage-ledger.js";
-import { chainedSignal } from "./concurrency/abort-budget.js";
 
 export type { GenerateOpts, GenerateResult } from "./llm-types.js";
 export const LLM_CALL_DEADLINE_MS = 180_000;
@@ -64,12 +63,23 @@ export class LLM {
 
   async generate(opts: GenerateOpts): Promise<GenerateResult> {
     const start = Date.now();
-    const signal = withLLMDeadline(opts.signal, deadlineMsForCaller(opts.caller));
+    // The per-call deadline is the caller's class budget intersected with any
+    // turn-remaining bound the agent loop passes, so a retry after an early
+    // timeout inherits only the time the turn has left — never a fresh window.
+    const deadlineMs = Math.min(
+      deadlineMsForCaller(opts.caller),
+      opts.deadlineMs ?? Number.POSITIVE_INFINITY,
+    );
+    const { signal, deadline } = withLLMDeadline(opts.signal, deadlineMs);
     let result: GenerateResult;
     try {
       result = await this.dispatch({ ...opts, signal });
     } catch (err) {
-      if (isDeadlineAbort(signal)) throw toTimeoutError(err);
+      // Relabel to TimeoutError only when OUR per-call timer fired AND the error
+      // is abort-shaped: a 5xx/429/network thrown while the timer happens to be
+      // aborted must keep its own class, and an outer caller cancellation that
+      // never tripped our timer is not our deadline.
+      if (deadline.aborted && isAbortError(err, deadline)) throw toTimeoutError(err);
       throw err;
     }
     const durationMs = Date.now() - start;
@@ -169,21 +179,29 @@ function deadlineMsForCaller(caller: GenerateOpts["caller"]): number {
   return caller === "chat" ? CHAT_LLM_CALL_DEADLINE_MS : LLM_CALL_DEADLINE_MS;
 }
 
-function withLLMDeadline(signal: AbortSignal | undefined, deadlineMs: number): AbortSignal {
-  return signal === undefined
-    ? AbortSignal.timeout(deadlineMs)
-    : chainedSignal({ outer: signal, perRequestMs: deadlineMs });
+// Returns BOTH the per-call timer (so the catch can ask "did our timer fire?")
+// and the signal actually handed to the provider — the timer alone when there is
+// no outer signal, else the union of the two.
+function withLLMDeadline(
+  signal: AbortSignal | undefined,
+  deadlineMs: number,
+): { signal: AbortSignal; deadline: AbortSignal } {
+  const deadline = AbortSignal.timeout(deadlineMs);
+  return {
+    deadline,
+    signal: signal === undefined ? deadline : AbortSignal.any([signal, deadline]),
+  };
 }
 
-function isDeadlineAbort(signal: AbortSignal): boolean {
-  if (!signal.aborted) return false;
-  const reason = signal.reason;
-  if (reason instanceof Error && /timeout|deadline/i.test(`${reason.name} ${reason.message}`)) {
-    return true;
-  }
-  if (reason && typeof reason === "object") {
-    const { name, message } = reason as { name?: unknown; message?: unknown };
-    return /timeout|deadline/i.test(`${String(name ?? "")} ${String(message ?? "")}`);
+// True when the caught error is the shape an aborted request produces — an
+// AbortError/TimeoutError, or the timer's own reason. A 5xx/429/network error
+// (APICallError, ServerError/RateLimitError/NetworkError) carries a different
+// name and is NOT matched, so it keeps its own retry class.
+function isAbortError(err: unknown, deadline: AbortSignal): boolean {
+  if (err === deadline.reason) return true;
+  if (err !== null && typeof err === "object") {
+    const name = (err as { name?: unknown }).name;
+    return name === "AbortError" || name === "TimeoutError";
   }
   return false;
 }

--- a/packages/core/src/llm.ts
+++ b/packages/core/src/llm.ts
@@ -15,8 +15,10 @@ import { PROVIDER_BASE_URLS } from "./config.js";
 import { codexGenerateText } from "./agent/codex-bridge.js";
 import type { GenerateOpts, GenerateResult } from "./llm-types.js";
 import { appendUsageLine, cacheTokenDetails, usageFieldsFromResult } from "./usage-ledger.js";
+import { chainedSignal } from "./concurrency/abort-budget.js";
 
 export type { GenerateOpts, GenerateResult } from "./llm-types.js";
+export const LLM_CALL_DEADLINE_MS = 180_000;
 
 // ============================================================================
 // LLM DISPATCH
@@ -61,7 +63,14 @@ export class LLM {
 
   async generate(opts: GenerateOpts): Promise<GenerateResult> {
     const start = Date.now();
-    const result = await this.dispatch(opts);
+    const signal = withLLMDeadline(opts.signal);
+    let result: GenerateResult;
+    try {
+      result = await this.dispatch({ ...opts, signal });
+    } catch (err) {
+      if (isDeadlineAbort(signal)) throw toTimeoutError(err);
+      throw err;
+    }
     const durationMs = Date.now() - start;
     this.recordGenerate(opts, result, durationMs);
     return result;
@@ -103,6 +112,7 @@ export class LLM {
       stopWhen: opts.stopWhen,
       maxOutputTokens: opts.maxOutputTokens,
       maxRetries: 0,
+      abortSignal: opts.signal,
     };
     const result = opts.prompt !== undefined
       ? await generateText({ ...base, prompt: opts.prompt })
@@ -152,6 +162,34 @@ function priceAiSdkUsage(
     cacheRead: details?.cacheReadTokens ?? 0,
     cacheWrite: details?.cacheWriteTokens ?? 0,
   });
+}
+
+function withLLMDeadline(signal: AbortSignal | undefined): AbortSignal {
+  return signal === undefined
+    ? AbortSignal.timeout(LLM_CALL_DEADLINE_MS)
+    : chainedSignal({ outer: signal, perRequestMs: LLM_CALL_DEADLINE_MS });
+}
+
+function isDeadlineAbort(signal: AbortSignal): boolean {
+  if (!signal.aborted) return false;
+  const reason = signal.reason;
+  if (reason instanceof Error && /timeout|deadline/i.test(`${reason.name} ${reason.message}`)) {
+    return true;
+  }
+  if (reason && typeof reason === "object") {
+    const { name, message } = reason as { name?: unknown; message?: unknown };
+    return /timeout|deadline/i.test(`${String(name ?? "")} ${String(message ?? "")}`);
+  }
+  return false;
+}
+
+function toTimeoutError(err: unknown): Error {
+  if (err instanceof Error && err.name === "TimeoutError") return err;
+  const message = err instanceof Error ? err.message : String(err);
+  const out = new Error(`Request timeout: ${message}`) as Error & { cause?: unknown };
+  out.name = "TimeoutError";
+  if (err instanceof Error) out.cause = err;
+  return out;
 }
 
 // ============================================================================

--- a/packages/core/src/llm.ts
+++ b/packages/core/src/llm.ts
@@ -193,15 +193,20 @@ function withLLMDeadline(
   };
 }
 
-// True when the caught error is the shape an aborted request produces — an
-// AbortError/TimeoutError, or the timer's own reason. A 5xx/429/network error
-// (APICallError, ServerError/RateLimitError/NetworkError) carries a different
-// name and is NOT matched, so it keeps its own retry class.
+// True when the caught error is the shape an aborted request produces -- the
+// timer's own reason, or an AbortError/TimeoutError anywhere in its cause chain
+// (some providers wrap the abort under a non-standard name). A 5xx/429/network
+// error carries no such cause and is NOT matched, so it keeps its own retry
+// class. Only consulted when OUR timer fired (deadline.aborted), so widening to
+// the cause chain cannot mislabel an unrelated failure.
 function isAbortError(err: unknown, deadline: AbortSignal): boolean {
-  if (err === deadline.reason) return true;
-  if (err !== null && typeof err === "object") {
-    const name = (err as { name?: unknown }).name;
-    return name === "AbortError" || name === "TimeoutError";
+  let current: unknown = err;
+  for (let depth = 0; depth < 5 && current != null; depth++) {
+    if (current === deadline.reason) return true;
+    if (typeof current !== "object") return false;
+    const name = (current as { name?: unknown }).name;
+    if (name === "AbortError" || name === "TimeoutError") return true;
+    current = (current as { cause?: unknown }).cause;
   }
   return false;
 }

--- a/packages/core/src/llm.ts
+++ b/packages/core/src/llm.ts
@@ -19,6 +19,7 @@ import { chainedSignal } from "./concurrency/abort-budget.js";
 
 export type { GenerateOpts, GenerateResult } from "./llm-types.js";
 export const LLM_CALL_DEADLINE_MS = 180_000;
+export const CHAT_LLM_CALL_DEADLINE_MS = 300_000;
 
 // ============================================================================
 // LLM DISPATCH
@@ -63,7 +64,7 @@ export class LLM {
 
   async generate(opts: GenerateOpts): Promise<GenerateResult> {
     const start = Date.now();
-    const signal = withLLMDeadline(opts.signal);
+    const signal = withLLMDeadline(opts.signal, deadlineMsForCaller(opts.caller));
     let result: GenerateResult;
     try {
       result = await this.dispatch({ ...opts, signal });
@@ -164,10 +165,14 @@ function priceAiSdkUsage(
   });
 }
 
-function withLLMDeadline(signal: AbortSignal | undefined): AbortSignal {
+function deadlineMsForCaller(caller: GenerateOpts["caller"]): number {
+  return caller === "chat" ? CHAT_LLM_CALL_DEADLINE_MS : LLM_CALL_DEADLINE_MS;
+}
+
+function withLLMDeadline(signal: AbortSignal | undefined, deadlineMs: number): AbortSignal {
   return signal === undefined
-    ? AbortSignal.timeout(LLM_CALL_DEADLINE_MS)
-    : chainedSignal({ outer: signal, perRequestMs: LLM_CALL_DEADLINE_MS });
+    ? AbortSignal.timeout(deadlineMs)
+    : chainedSignal({ outer: signal, perRequestMs: deadlineMs });
 }
 
 function isDeadlineAbort(signal: AbortSignal): boolean {

--- a/packages/core/tests/coach-agent-turn-outcome.test.ts
+++ b/packages/core/tests/coach-agent-turn-outcome.test.ts
@@ -185,6 +185,63 @@ describe("per-turn outcome line", () => {
     expect(lines[0].compactions).toBeGreaterThanOrEqual(1);
   });
 
+  it("a small-context timeout retries once without compaction and can recover", async () => {
+    let mainCalls = 0;
+    const complete = vi.fn(async (params: { system?: string }) => {
+      const sys = params.system ?? "";
+      if (sys.includes(FLUSH_MARKER)) return mkAssistant("facts noted");
+      if (sys.length === 0) return mkAssistant("summary");
+      mainCalls++;
+      if (mainCalls === 1) {
+        const err = new Error("deadline exceeded");
+        err.name = "TimeoutError";
+        throw err;
+      }
+      return mkAssistant("recovered timeout reply");
+    });
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const agent = await setupAgent(complete);
+
+    const text = await agent.chat("timeout-recover-chat", "hello");
+
+    expect(text).toBe("recovered timeout reply");
+    expect(mainCalls).toBe(2);
+    const lines = readOutcomeLines();
+    expect(lines).toHaveLength(1);
+    expect(lines[0].ok).toBe(true);
+    expect(lines[0].timeoutAttempts).toBe(1);
+    expect(lines[0].compactions).toBe(0);
+  });
+
+  it("a persistent small-context timeout makes exactly one plain retry", async () => {
+    let mainCalls = 0;
+    const complete = vi.fn(async (params: { system?: string }) => {
+      const sys = params.system ?? "";
+      if (sys.includes(FLUSH_MARKER)) return mkAssistant("facts noted");
+      if (sys.length === 0) return mkAssistant("summary");
+      mainCalls++;
+      const err = new Error("deadline exceeded");
+      err.name = "TimeoutError";
+      throw err;
+    });
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const agent = await setupAgent(complete);
+
+    const outcome = await agent.chat("timeout-fail-chat", "hello").then(
+      () => ({ ok: true as const }),
+      (error: unknown) => ({ ok: false as const, error }),
+    );
+
+    expect(outcome.ok).toBe(false);
+    expect(mainCalls).toBe(2);
+    const lines = readOutcomeLines();
+    expect(lines).toHaveLength(1);
+    expect(lines[0].ok).toBe(false);
+    expect(lines[0].error_class).toBe("timeout");
+    expect(lines[0].timeoutAttempts).toBe(1);
+    expect(lines[0].compactions).toBe(0);
+  });
+
   it("leaves the session JSONL byte-identical on a failed turn", async () => {
     const complete = vi.fn(async (params: { system?: string }) => {
       const sys = params.system ?? "";

--- a/packages/core/tests/codex-bridge.test.ts
+++ b/packages/core/tests/codex-bridge.test.ts
@@ -184,6 +184,23 @@ describe("codex-bridge", () => {
     );
   });
 
+  it("forwards opts.signal to the codex response request", async () => {
+    const complete = vi.fn(async () => asstMsg());
+    const { codexGenerateText } = await loadBridgeWithMocks({ complete });
+    const signal = new AbortController().signal;
+
+    await codexGenerateText({
+      messages: [{ role: "user", content: "hi" }],
+      modelId: "gpt-5.4",
+      profileName: "openai-codex",
+      signal,
+    });
+
+    expect(complete).toHaveBeenCalledWith(
+      expect.objectContaining({ signal }),
+    );
+  });
+
   it("surfaces finishReason=length so isContextOverflowError can catch it upstream via retry", async () => {
     const complete = vi.fn(async () => asstMsg({ stopReason: "length", text: "truncated" }));
     const { codexGenerateText } = await loadBridgeWithMocks({ complete });
@@ -291,6 +308,44 @@ describe("codex-bridge", () => {
     const toolMsg = conversations[1].messages.find((m) => m.role === "tool");
     expect(toolMsg).toBeDefined();
     expect(JSON.stringify(toolMsg!.content)).toContain("logged 60");
+  });
+
+  it("forwards opts.signal to codex tool execution", async () => {
+    let toolOptions: { abortSignal?: AbortSignal } | undefined;
+    const execute = vi.fn(async (_input: { minutes: number }, options: { abortSignal?: AbortSignal }) => {
+      toolOptions = options;
+      return "logged";
+    });
+    const tools = {
+      log_ride: {
+        description: "log a ride",
+        inputSchema: zodSchema(z.object({ minutes: z.number() })),
+        execute,
+      },
+    };
+    const complete = vi.fn(async (params: { messages: Array<Record<string, unknown>> }) => {
+      const hasToolResult = params.messages.some((m) => m.role === "tool");
+      if (!hasToolResult) {
+        return asstMsg({
+          stopReason: "toolUse",
+          toolCalls: [{ id: "c1", name: "log_ride", arguments: { minutes: 60 } }],
+        });
+      }
+      return asstMsg();
+    });
+    const { codexGenerateText } = await loadBridgeWithMocks({ complete });
+    const signal = new AbortController().signal;
+
+    await codexGenerateText({
+      messages: [{ role: "user", content: "hi" }],
+      tools: tools as never,
+      modelId: "gpt-5.4",
+      profileName: "openai-codex",
+      signal,
+    });
+
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(toolOptions?.abortSignal).toBe(signal);
   });
 
   it("does not leak fake tokens via console.warn/error", async () => {

--- a/packages/core/tests/codex-bridge.test.ts
+++ b/packages/core/tests/codex-bridge.test.ts
@@ -148,10 +148,26 @@ describe("codex-bridge", () => {
       profileName: "openai-codex",
     });
 
-    expect(freshToken).toHaveBeenCalledWith("openai-codex");
+    expect(freshToken).toHaveBeenCalledWith("openai-codex", undefined);
     expect(complete).toHaveBeenCalledWith(
       expect.objectContaining({ accessToken: "fresh-token-abc", modelId: "gpt-5.4" }),
     );
+  });
+
+  it("threads the per-call abort signal into getFreshToken so the token refresh shares the deadline", async () => {
+    const complete = vi.fn(async () => asstMsg());
+    const freshToken = vi.fn(async () => "fresh-token-abc");
+    const { codexGenerateText } = await loadBridgeWithMocks({ complete, freshToken });
+    const controller = new AbortController();
+
+    await codexGenerateText({
+      messages: [{ role: "user", content: "hi" }],
+      modelId: "gpt-5.4",
+      profileName: "openai-codex",
+      signal: controller.signal,
+    });
+
+    expect(freshToken).toHaveBeenCalledWith("openai-codex", controller.signal);
   });
 
   it("forwards opts.cacheKey as the request sessionId; omits it when absent", async () => {

--- a/packages/core/tests/codex/oauth.test.ts
+++ b/packages/core/tests/codex/oauth.test.ts
@@ -74,6 +74,32 @@ describe("refreshCodexToken", () => {
     await expect(refreshCodexToken("rt")).rejects.toThrow("Failed to extract accountId from token");
   });
 
+  it("aborts a stalled token fetch when the caller's signal fires instead of hanging", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    // A token endpoint that never responds on its own; the only way the promise
+    // settles is the passed-in abort signal firing.
+    vi.spyOn(globalThis, "fetch").mockImplementation((_url, init?: RequestInit) => {
+      return new Promise((_resolve, reject) => {
+        const sig = init?.signal;
+        if (!sig) return; // never settles without a signal -> proves we thread one
+        if (sig.aborted) {
+          reject(new DOMException("Aborted", "AbortError"));
+          return;
+        }
+        sig.addEventListener("abort", () => {
+          reject(new DOMException("Aborted", "AbortError"));
+        });
+      });
+    });
+
+    const controller = new AbortController();
+    const pending = refreshCodexToken("rt", controller.signal);
+    // Fire the deadline; the in-flight token refresh must unwind, not hang.
+    controller.abort();
+
+    await expect(pending).rejects.toThrow("Failed to refresh OpenAI Codex token");
+  });
+
   it("never logs the refresh token or response body on failure (redaction)", async () => {
     const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     vi.spyOn(globalThis, "fetch").mockResolvedValue(

--- a/packages/core/tests/codex/oauth.test.ts
+++ b/packages/core/tests/codex/oauth.test.ts
@@ -74,7 +74,7 @@ describe("refreshCodexToken", () => {
     await expect(refreshCodexToken("rt")).rejects.toThrow("Failed to extract accountId from token");
   });
 
-  it("aborts a stalled token fetch when the caller's signal fires instead of hanging", async () => {
+  it("propagates the abort instead of relabeling when the caller signal fires", async () => {
     vi.spyOn(console, "error").mockImplementation(() => {});
     // A token endpoint that never responds on its own; the only way the promise
     // settles is the passed-in abort signal firing.
@@ -97,7 +97,20 @@ describe("refreshCodexToken", () => {
     // Fire the deadline; the in-flight token refresh must unwind, not hang.
     controller.abort();
 
-    await expect(pending).rejects.toThrow("Failed to refresh OpenAI Codex token");
+    const err = await pending.catch((e) => e);
+    expect((err as Error).name).toBe("AbortError");
+    expect((err as Error).message).not.toMatch(/Failed to refresh/);
+  });
+
+  it("propagates the 30s backstop TimeoutError instead of relabeling", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+      throw new DOMException("The operation timed out", "TimeoutError");
+    });
+
+    const err = await refreshCodexToken("rt").catch((e) => e);
+    expect((err as Error).name).toBe("TimeoutError");
+    expect((err as Error).message).not.toMatch(/Failed to refresh/);
   });
 
   it("never logs the refresh token or response body on failure (redaction)", async () => {

--- a/packages/core/tests/codex/responses.test.ts
+++ b/packages/core/tests/codex/responses.test.ts
@@ -335,6 +335,19 @@ describe("codexResponses error surface (single attempt, no retry loop)", () => {
     expect(result.stopReason).toBe("stop");
   });
 
+  it("falls back to 'Request was aborted' when the abort reason serializes to undefined", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const controller = new AbortController();
+    controller.abort(() => {});
+
+    const err = (await codexResponses(baseParams({ signal: controller.signal })).catch(
+      (e) => e,
+    )) as Error;
+
+    expect(err.message).toBe("Request was aborted");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
   it("serializes a non-string, non-Error abort reason without producing '[object Object]'", async () => {
     const fetchSpy = vi.spyOn(globalThis, "fetch");
     const controller = new AbortController();

--- a/packages/core/tests/codex/responses.test.ts
+++ b/packages/core/tests/codex/responses.test.ts
@@ -301,4 +301,51 @@ describe("codexResponses error surface (single attempt, no retry loop)", () => {
     const err = (await codexResponses(baseParams()).catch((e) => e)) as Error;
     expect(err.message).toContain("stream blew up");
   });
+
+  it("returns a fully-accumulated result even if the signal aborts right after accumulation resolves", async () => {
+    const controller = new AbortController();
+    // The stream completes cleanly, then the signal flips to aborted as the
+    // boundary check would run — the already-paid-for result must still return.
+    // The abort must fire while the stream is being READ (not at construction:
+    // ReadableStream.start runs eagerly, which would abort before codexResponses
+    // is even called and trip the entry guard). pull() runs lazily per read, so
+    // the first pull delivers the body and the second aborts after it.
+    let pulls = 0;
+    const stream = new ReadableStream<Uint8Array>({
+      pull(c) {
+        if (pulls === 0) {
+          const enc = new TextEncoder();
+          const body =
+            TEXT_EVENTS.map((e) => `data: ${JSON.stringify(e)}\n\n`).join("") + "data: [DONE]\n\n";
+          c.enqueue(enc.encode(body));
+          pulls++;
+        } else {
+          controller.abort(new Error("aborted after accumulate"));
+          c.close();
+        }
+      },
+    });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(stream, { status: 200, headers: { "content-type": "text/event-stream" } }),
+    );
+
+    const result = await codexResponses(baseParams({ signal: controller.signal }));
+
+    expect(result.text).toBe("Hello world");
+    expect(result.stopReason).toBe("stop");
+  });
+
+  it("serializes a non-string, non-Error abort reason without producing '[object Object]'", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const controller = new AbortController();
+    controller.abort({ code: "cancel" });
+
+    const err = (await codexResponses(baseParams({ signal: controller.signal })).catch(
+      (e) => e,
+    )) as Error;
+
+    expect(err.message).toContain("cancel");
+    expect(err.message).not.toContain("[object Object]");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
 });

--- a/packages/core/tests/codex/responses.test.ts
+++ b/packages/core/tests/codex/responses.test.ts
@@ -245,15 +245,53 @@ describe("codexResponses error surface (single attempt, no retry loop)", () => {
     expect(isNetworkError(normalizeError(err))).toBe(true);
   });
 
-  it("throws 'Request was aborted' when the signal is already aborted, without fetching", async () => {
+  it("preserves a non-timeout abort reason when the signal is already aborted, without fetching", async () => {
     const fetchSpy = vi.spyOn(globalThis, "fetch");
     const controller = new AbortController();
-    controller.abort();
+    controller.abort(new Error("operator cancelled"));
+
+    const err = (await codexResponses(baseParams({ signal: controller.signal })).catch((e) => e)) as Error;
+
+    expect(err.message).toBe("operator cancelled");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("throws 'Request was aborted' for a timeout abort reason, without fetching", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const controller = new AbortController();
+    const reason = new Error("deadline exceeded");
+    reason.name = "TimeoutError";
+    controller.abort(reason);
 
     const err = (await codexResponses(baseParams({ signal: controller.signal })).catch((e) => e)) as Error;
 
     expect(err.message).toBe("Request was aborted");
     expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("maps a timeout abort during stream reading to 'Request was aborted'", async () => {
+    const controller = new AbortController();
+    const reason = new Error("deadline exceeded");
+    reason.name = "TimeoutError";
+    const stream = new ReadableStream<Uint8Array>({
+      start(c) {
+        c.enqueue(new TextEncoder().encode(`data: ${JSON.stringify({ type: "response.created" })}\n\n`));
+        controller.abort(reason);
+        const abortErr = new Error("stream aborted");
+        abortErr.name = "AbortError";
+        c.error(abortErr);
+      },
+    });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(stream, {
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+      }),
+    );
+
+    const err = (await codexResponses(baseParams({ signal: controller.signal })).catch((e) => e)) as Error;
+
+    expect(err.message).toBe("Request was aborted");
   });
 
   it("throws the codex error message on a stream error event", async () => {

--- a/packages/core/tests/llm-dispatch.test.ts
+++ b/packages/core/tests/llm-dispatch.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 
 import type { Config } from "../src/config.js";
 
+const MINIMAL_RESULT = { text: "ok", toolCalls: [], finishReason: "stop", usage: {}, totalUsage: {}, steps: [] };
+
 function codexConfig(): Config {
   return {
     llm: { provider: "openai-codex", model: "gpt-5.4", apiKey: "", authProfile: "openai-codex" },
@@ -13,20 +15,73 @@ function codexConfig(): Config {
   };
 }
 
-type Captured = { stepLimit: number | undefined; cacheKey: string | undefined; called: number };
+function anthropicConfig(): Config {
+  return {
+    llm: { provider: "anthropic", model: "claude-test", apiKey: "test-key" },
+    intervals: { apiKey: "", athleteId: "0" },
+    telegram: { botToken: "" },
+    session: { historyTokenBudgetRatio: 0.3, idleMinutes: 0, dailyResetHour: 4, resetArchiveRetentionDays: 0, timezone: "" },
+    contextWindowTokens: 272_000,
+    dataDir: "/tmp/cc-dispatch-test",
+  };
+}
+
+type Captured = {
+  stepLimit: number | undefined;
+  cacheKey: string | undefined;
+  signal: AbortSignal | undefined;
+  called: number;
+};
 
 async function runCodex(opts: Parameters<import("../src/llm.js").LLM["generate"]>[0]): Promise<Captured> {
-  const captured: Captured = { stepLimit: undefined, cacheKey: undefined, called: 0 };
+  const captured: Captured = { stepLimit: undefined, cacheKey: undefined, signal: undefined, called: 0 };
   vi.doMock("../src/agent/codex-bridge.js", () => ({
-    codexGenerateText: vi.fn(async (o: { stepLimit?: number; cacheKey?: string }) => {
+    codexGenerateText: vi.fn(async (o: { stepLimit?: number; cacheKey?: string; signal?: AbortSignal }) => {
       captured.stepLimit = o.stepLimit;
       captured.cacheKey = o.cacheKey;
+      captured.signal = o.signal;
       captured.called++;
-      return { text: "ok", toolCalls: [], finishReason: "stop", usage: {} };
+      return MINIMAL_RESULT;
     }),
   }));
   const { LLM } = await import("../src/llm.js");
   const llm = new LLM(codexConfig());
+  await llm.generate(opts);
+  return captured;
+}
+
+type AiSdkCaptured = {
+  abortSignal: AbortSignal | undefined;
+  maxRetries: number | undefined;
+  prompt: string | undefined;
+  messages: unknown;
+  called: number;
+};
+
+async function runAiSdk(opts: Parameters<import("../src/llm.js").LLM["generate"]>[0]): Promise<AiSdkCaptured> {
+  const captured: AiSdkCaptured = {
+    abortSignal: undefined,
+    maxRetries: undefined,
+    prompt: undefined,
+    messages: undefined,
+    called: 0,
+  };
+  vi.doMock("ai", () => ({
+    generateText: vi.fn(async (o: { abortSignal?: AbortSignal; maxRetries?: number; prompt?: string; messages?: unknown }) => {
+      captured.abortSignal = o.abortSignal;
+      captured.maxRetries = o.maxRetries;
+      captured.prompt = o.prompt;
+      captured.messages = o.messages;
+      captured.called++;
+      return MINIMAL_RESULT;
+    }),
+    stepCountIs: vi.fn((count: number) => ({ type: "step-count", count })),
+  }));
+  vi.doMock("@ai-sdk/anthropic", () => ({
+    createAnthropic: () => () => ({ provider: "anthropic-stub" }),
+  }));
+  const { LLM } = await import("../src/llm.js");
+  const llm = new LLM(anthropicConfig());
   await llm.generate(opts);
   return captured;
 }
@@ -60,5 +115,42 @@ describe("LLM dispatch — codex path forwards maxSteps to bridge", () => {
       cacheKey: "deadbeefdeadbeef",
     });
     expect(captured.cacheKey).toBe("deadbeefdeadbeef");
+  });
+
+  it("creates the default deadline signal and forwards it to the bridge", async () => {
+    const timeoutController = new AbortController();
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockReturnValue(timeoutController.signal);
+
+    const captured = await runCodex({ messages: [{ role: "user", content: "hi" }] });
+    const { LLM_CALL_DEADLINE_MS } = await import("../src/llm.js");
+
+    expect(timeoutSpy).toHaveBeenCalledWith(LLM_CALL_DEADLINE_MS);
+    expect(captured.signal).toBe(timeoutController.signal);
+  });
+});
+
+describe("LLM dispatch — AI SDK path forwards abort signals", () => {
+  it("passes a default deadline signal and keeps SDK retries disabled on messages calls", async () => {
+    const timeoutController = new AbortController();
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockReturnValue(timeoutController.signal);
+
+    const captured = await runAiSdk({ messages: [{ role: "user", content: "hi" }] });
+    const { LLM_CALL_DEADLINE_MS } = await import("../src/llm.js");
+
+    expect(timeoutSpy).toHaveBeenCalledWith(LLM_CALL_DEADLINE_MS);
+    expect(captured.abortSignal).toBe(timeoutController.signal);
+    expect(captured.maxRetries).toBe(0);
+    expect(captured.messages).toEqual([{ role: "user", content: "hi" }]);
+  });
+
+  it("passes the deadline signal on prompt-only calls too", async () => {
+    const timeoutController = new AbortController();
+    vi.spyOn(AbortSignal, "timeout").mockReturnValue(timeoutController.signal);
+
+    const captured = await runAiSdk({ prompt: "summarize this" });
+
+    expect(captured.abortSignal).toBe(timeoutController.signal);
+    expect(captured.prompt).toBe("summarize this");
+    expect(captured.maxRetries).toBe(0);
   });
 });

--- a/packages/core/tests/llm-dispatch.test.ts
+++ b/packages/core/tests/llm-dispatch.test.ts
@@ -165,3 +165,76 @@ describe("LLM dispatch — AI SDK path forwards abort signals", () => {
     expect(captured.maxRetries).toBe(0);
   });
 });
+
+describe("LLM generate — per-call deadline bounded by opts.deadlineMs", () => {
+  it("uses the smaller of the caller deadline and opts.deadlineMs", async () => {
+    const timeoutSpy = vi
+      .spyOn(AbortSignal, "timeout")
+      .mockReturnValue(new AbortController().signal);
+
+    await runAiSdk({ messages: [{ role: "user", content: "hi" }], caller: "chat", deadlineMs: 120_000 });
+
+    expect(timeoutSpy).toHaveBeenCalledWith(120_000);
+  });
+
+  it("ignores opts.deadlineMs when it exceeds the caller deadline", async () => {
+    const timeoutSpy = vi
+      .spyOn(AbortSignal, "timeout")
+      .mockReturnValue(new AbortController().signal);
+
+    await runAiSdk({ messages: [{ role: "user", content: "hi" }], caller: "chat", deadlineMs: 999_999 });
+    const { CHAT_LLM_CALL_DEADLINE_MS } = await import("../src/llm.js");
+
+    expect(timeoutSpy).toHaveBeenCalledWith(CHAT_LLM_CALL_DEADLINE_MS);
+  });
+});
+
+describe("LLM generate — timeout reclassification gated on our timer + abort shape", () => {
+  function abortedTimeoutSignal(): AbortSignal {
+    const ac = new AbortController();
+    ac.abort(new DOMException("The operation timed out.", "TimeoutError"));
+    return ac.signal;
+  }
+
+  async function generateThrowing(thrown: unknown): Promise<unknown> {
+    vi.doMock("ai", () => ({
+      generateText: vi.fn(async () => {
+        throw thrown;
+      }),
+      stepCountIs: vi.fn((count: number) => ({ type: "step-count", count })),
+    }));
+    vi.doMock("@ai-sdk/anthropic", () => ({
+      createAnthropic: () => () => ({ provider: "anthropic-stub" }),
+    }));
+    // The per-call timer has already fired by the time dispatch throws.
+    vi.spyOn(AbortSignal, "timeout").mockReturnValue(abortedTimeoutSignal());
+
+    const { LLM } = await import("../src/llm.js");
+    const llm = new LLM(anthropicConfig());
+    let rejected = false;
+    let caught: unknown;
+    try {
+      await llm.generate({ messages: [{ role: "user", content: "hi" }] });
+    } catch (err) {
+      rejected = true;
+      caught = err;
+    }
+    expect(rejected).toBe(true);
+    return caught;
+  }
+
+  it("does NOT relabel a 5xx thrown while the deadline signal is aborted", async () => {
+    const serverErr = Object.assign(new Error("upstream 500"), { httpStatus: 500 });
+    const caught = await generateThrowing(serverErr);
+    expect(caught).toBe(serverErr);
+    expect((caught as Error).name).not.toBe("TimeoutError");
+    expect((caught as { httpStatus?: number }).httpStatus).toBe(500);
+  });
+
+  it("surfaces a genuine per-call abort as a TimeoutError", async () => {
+    const abortErr = new Error("The operation was aborted");
+    abortErr.name = "AbortError";
+    const caught = await generateThrowing(abortErr);
+    expect((caught as Error).name).toBe("TimeoutError");
+  });
+});

--- a/packages/core/tests/llm-dispatch.test.ts
+++ b/packages/core/tests/llm-dispatch.test.ts
@@ -237,4 +237,56 @@ describe("LLM generate — timeout reclassification gated on our timer + abort s
     const caught = await generateThrowing(abortErr);
     expect((caught as Error).name).toBe("TimeoutError");
   });
+
+  // Sibling of generateThrowing: our timer never fires (AbortSignal.timeout
+  // returns a non-aborted signal), and opts.signal is threaded through so an
+  // OUTER caller cancellation can be exercised.
+  async function generateThrowingWithSignal(
+    thrown: unknown,
+    signal: AbortSignal,
+  ): Promise<unknown> {
+    vi.doMock("ai", () => ({
+      generateText: vi.fn(async () => {
+        throw thrown;
+      }),
+      stepCountIs: vi.fn((count: number) => ({ type: "step-count", count })),
+    }));
+    vi.doMock("@ai-sdk/anthropic", () => ({
+      createAnthropic: () => () => ({ provider: "anthropic-stub" }),
+    }));
+    // Our per-call timer never fires: deadline.aborted stays false.
+    vi.spyOn(AbortSignal, "timeout").mockReturnValue(new AbortController().signal);
+
+    const { LLM } = await import("../src/llm.js");
+    const llm = new LLM(anthropicConfig());
+    let rejected = false;
+    let caught: unknown;
+    try {
+      await llm.generate({ messages: [{ role: "user", content: "hi" }], signal });
+    } catch (err) {
+      rejected = true;
+      caught = err;
+    }
+    expect(rejected).toBe(true);
+    return caught;
+  }
+
+  it("does NOT relabel an outer-signal abort when our timer never fired", async () => {
+    const outer = new AbortController();
+    outer.abort(new DOMException("The operation was aborted.", "AbortError"));
+    const abortErr = new Error("The operation was aborted");
+    abortErr.name = "AbortError";
+    const caught = await generateThrowingWithSignal(abortErr, outer.signal);
+    expect((caught as Error).name).toBe("AbortError");
+    expect((caught as Error).name).not.toBe("TimeoutError");
+  });
+
+  it("relabels a genuine deadline abort wrapped under a non-standard name", async () => {
+    const wrapped = Object.assign(new Error("api call failed"), {
+      name: "AI_APICallError",
+      cause: Object.assign(new Error("aborted"), { name: "AbortError" }),
+    });
+    const caught = await generateThrowing(wrapped);
+    expect((caught as Error).name).toBe("TimeoutError");
+  });
 });

--- a/packages/core/tests/llm-dispatch.test.ts
+++ b/packages/core/tests/llm-dispatch.test.ts
@@ -127,6 +127,17 @@ describe("LLM dispatch — codex path forwards maxSteps to bridge", () => {
     expect(timeoutSpy).toHaveBeenCalledWith(LLM_CALL_DEADLINE_MS);
     expect(captured.signal).toBe(timeoutController.signal);
   });
+
+  it("uses the longer chat deadline for chat calls", async () => {
+    const timeoutController = new AbortController();
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockReturnValue(timeoutController.signal);
+
+    const captured = await runCodex({ messages: [{ role: "user", content: "hi" }], caller: "chat" });
+    const { CHAT_LLM_CALL_DEADLINE_MS } = await import("../src/llm.js");
+
+    expect(timeoutSpy).toHaveBeenCalledWith(CHAT_LLM_CALL_DEADLINE_MS);
+    expect(captured.signal).toBe(timeoutController.signal);
+  });
 });
 
 describe("LLM dispatch — AI SDK path forwards abort signals", () => {

--- a/packages/core/tests/turn-budget.test.ts
+++ b/packages/core/tests/turn-budget.test.ts
@@ -112,6 +112,16 @@ describe("createTurnBudget (unit)", () => {
     expect((thrown as TurnBudgetExceededError).kind).toBe("generate_attempts");
   });
 
+  it("remainingMs returns the budget left and clamps to zero past the deadline", () => {
+    let clock = 5_000;
+    const budget = createTurnBudget(() => clock);
+    expect(budget.remainingMs()).toBe(TURN_WALL_CLOCK_MS);
+    clock += 100_000;
+    expect(budget.remainingMs()).toBe(TURN_WALL_CLOCK_MS - 100_000);
+    clock += TURN_WALL_CLOCK_MS;
+    expect(budget.remainingMs()).toBe(0);
+  });
+
   it("checkDeadline throws wall_clock only once the injected clock crosses the deadline", () => {
     let clock = 1_000;
     const budget = createTurnBudget(() => clock);
@@ -178,6 +188,48 @@ describe("per-turn budget through chat() (behavioral)", () => {
 
     expect(text).toBe("all good");
     expect(countMainTurns(complete)).toBe(1);
+  });
+
+  it("a retry after an early timeout gets only the budget left, capping total chat time", async () => {
+    // Each chat generate mints its per-call deadline from the turn's remaining
+    // wall-clock budget. A timeout 100s into the 300s turn must leave the retry
+    // only ~200s — not a fresh full window (the ~600s double-window bug).
+    let clock = 0;
+    const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => clock);
+    const deadlines: number[] = [];
+    vi.spyOn(AbortSignal, "timeout").mockImplementation((ms) => {
+      deadlines.push(ms);
+      return new AbortController().signal;
+    });
+
+    let mainCalls = 0;
+    const complete = vi.fn(async (params: { system?: string }) => {
+      const sys = params.system ?? "";
+      if (sys.includes(FLUSH_MARKER)) return mkAssistant("facts noted");
+      if (sys.length === 0) return mkAssistant("summary");
+      mainCalls++;
+      if (mainCalls === 1) {
+        clock += 100_000;
+        const err = new Error("deadline exceeded");
+        err.name = "TimeoutError";
+        throw err;
+      }
+      return mkAssistant("done");
+    });
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const agent = await setupAgent(complete);
+
+    const text = await agent.chat("budget-deadline", "hello");
+    nowSpy.mockRestore();
+
+    expect(text).toBe("done");
+    expect(mainCalls).toBe(2);
+    expect(deadlines.length).toBe(2);
+    // First call: full budget. Retry: only the ~200s the turn has left.
+    expect(deadlines[0]).toBe(TURN_WALL_CLOCK_MS);
+    expect(deadlines[1]).toBe(TURN_WALL_CLOCK_MS - 100_000);
+    // Total chat time stays bounded by the wall-clock budget.
+    expect(100_000 + deadlines[1]).toBeLessThanOrEqual(TURN_WALL_CLOCK_MS);
   });
 
   it("a between-attempts wall-clock overrun stops with a wall_clock error and lets the in-flight call complete", async () => {

--- a/packages/core/tests/turn-tainted-by-writes.test.ts
+++ b/packages/core/tests/turn-tainted-by-writes.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { mkdtempSync, rmSync, mkdirSync } from "node:fs";
+import { mkdtempSync, rmSync, mkdirSync, readdirSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { http, HttpResponse } from "msw";
@@ -136,6 +136,96 @@ describe("tainted-by-writes refusal", () => {
     } finally {
       server.close();
     }
+  });
+
+  it("a write on a non-final step then a timeout refuses without replaying the write", async () => {
+    const { server, createdWorkouts } = createMockIntervalsServer();
+    server.listen({ onUnhandledRequest: "bypass" });
+    try {
+      let mainTurns = 0;
+      let secondMainAfterWrite = false;
+      const complete = vi.fn(async (params: { system?: string }) => {
+        const sys = params.system ?? "";
+        if (sys.includes(FLUSH_MARKER)) return mkAssistant({ text: "facts noted" });
+        if (sys.length === 0) return mkAssistant({ text: "summary" });
+        mainTurns++;
+        const ctx = params as { messages?: { role: string }[] };
+        const hasToolResult = (ctx.messages ?? []).some((m) => m.role === "tool");
+        if (mainTurns === 1 && !hasToolResult) {
+          return mkAssistant({
+            toolCall: {
+              id: "call-timeout",
+              name: "intervals_create_workout",
+              arguments: {
+                date: tomorrowISODate(),
+                workout: {
+                  name: "Endurance 45",
+                  steps: [
+                    { type: "warmup", duration: { value: 10, unit: "minutes" }, power: { kind: "percent_ftp", value: 50 } },
+                    { type: "steady", duration: { value: 35, unit: "minutes" }, power: { kind: "percent_ftp", value: 70 } },
+                  ],
+                },
+              },
+            },
+            stopReason: "toolUse",
+          });
+        }
+        secondMainAfterWrite = true;
+        const err = new Error("deadline exceeded");
+        err.name = "TimeoutError";
+        throw err;
+      });
+      vi.spyOn(console, "warn").mockImplementation(() => {});
+      const agent = await setupAgent(complete);
+
+      const result = await agent.chat("taint-timeout", "create an endurance workout for tomorrow");
+
+      expect(result).toBe(TAINTED_BY_WRITES_MESSAGE);
+      expect(createdWorkouts.length).toBe(1);
+      expect(secondMainAfterWrite).toBe(true);
+      expect(mainTurns).toBe(2);
+    } finally {
+      server.close();
+    }
+  });
+
+  it("a memory write then timeout refuses without replaying the memory append", async () => {
+    let mainTurns = 0;
+    const note = "felt unusually fresh after breakfast";
+    const complete = vi.fn(async (params: { system?: string }) => {
+      const sys = params.system ?? "";
+      if (sys.includes(FLUSH_MARKER)) return mkAssistant({ text: "facts noted" });
+      if (sys.length === 0) return mkAssistant({ text: "summary" });
+      mainTurns++;
+      const ctx = params as { messages?: { role: string }[] };
+      const hasToolResult = (ctx.messages ?? []).some((m) => m.role === "tool");
+      if (mainTurns === 1 && !hasToolResult) {
+        return mkAssistant({
+          toolCall: {
+            id: "call-memory",
+            name: "memory_write",
+            arguments: { type: "daily", content: note },
+          },
+          stopReason: "toolUse",
+        });
+      }
+      const err = new Error("deadline exceeded");
+      err.name = "TimeoutError";
+      throw err;
+    });
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const agent = await setupAgent(complete);
+
+    const result = await agent.chat("taint-memory", "remember that breakfast helped");
+
+    expect(result).toBe(TAINTED_BY_WRITES_MESSAGE);
+    expect(mainTurns).toBe(2);
+    const memoryDir = join(dataDir, "memory");
+    const dailyNotes = readdirSync(memoryDir)
+      .filter((name) => name.endsWith(".md") && name !== "MEMORY.md")
+      .map((name) => readFileSync(join(memoryDir, name), "utf-8"))
+      .join("\n");
+    expect((dailyNotes.match(new RegExp(note, "g")) ?? []).length).toBe(1);
   });
 
   it("a delete on a turn that then errors also taints", async () => {

--- a/packages/core/tests/turn-tainted-by-writes.test.ts
+++ b/packages/core/tests/turn-tainted-by-writes.test.ts
@@ -231,6 +231,53 @@ describe("tainted-by-writes refusal", () => {
     expect((dailyMemoryText().match(new RegExp(note, "g")) ?? []).length).toBe(1);
   });
 
+  it("a plan-skeleton build then a timeout refuses without replaying the plan save", async () => {
+    let mainTurns = 0;
+    const complete = vi.fn(async (params: { system?: string }) => {
+      const sys = params.system ?? "";
+      if (sys.includes(FLUSH_MARKER)) return mkAssistant({ text: "facts noted" });
+      if (sys.length === 0) return mkAssistant({ text: "summary" });
+      mainTurns++;
+      const ctx = params as { messages?: { role: string }[] };
+      const hasToolResult = (ctx.messages ?? []).some((m) => m.role === "tool");
+      if (mainTurns === 1 && !hasToolResult) {
+        return mkAssistant({
+          toolCall: {
+            id: "call-plan",
+            name: "build_plan_skeleton",
+            arguments: {
+              experienceLevel: "intermediate",
+              ftpWatts: 250,
+              volumeTier: "medium",
+              scheduleType: "flexible",
+              goalType: "general",
+              generalGoal: "build aerobic base",
+            },
+          },
+          stopReason: "toolUse",
+        });
+      }
+      const err = new Error("deadline exceeded");
+      err.name = "TimeoutError";
+      throw err;
+    });
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const agent = await setupAgent(complete);
+
+    const result = await agent.chat("taint-plan", "build me a training plan");
+
+    expect(result).toBe(TAINTED_BY_WRITES_MESSAGE);
+    expect(mainTurns).toBe(2);
+    // The plan committed exactly once and was never replayed on the retry.
+    const journal = join(dataDir, "memory", "MEMORY.history.jsonl");
+    const planSaves = readFileSync(journal, "utf-8")
+      .split("\n")
+      .filter((line) => line.trim() !== "")
+      .map((line) => JSON.parse(line) as { op?: string })
+      .filter((entry) => entry.op === "save-plan");
+    expect(planSaves.length).toBe(1);
+  });
+
   it("keeps write taint scoped when different chats run concurrently", async () => {
     const note = "freshness note scoped to the first chat";
     let firstMainCalls = 0;

--- a/packages/core/tests/turn-tainted-by-writes.test.ts
+++ b/packages/core/tests/turn-tainted-by-writes.test.ts
@@ -84,6 +84,14 @@ function tomorrowISODate(): string {
   return d.toISOString().slice(0, 10);
 }
 
+function dailyMemoryText(): string {
+  const memoryDir = join(dataDir, "memory");
+  return readdirSync(memoryDir)
+    .filter((name) => name.endsWith(".md") && name !== "MEMORY.md")
+    .map((name) => readFileSync(join(memoryDir, name), "utf-8"))
+    .join("\n");
+}
+
 describe("tainted-by-writes refusal", () => {
   it("a write on a non-final step then a brownout refuses without replaying the write", async () => {
     const { server, createdWorkouts } = createMockIntervalsServer();
@@ -220,12 +228,69 @@ describe("tainted-by-writes refusal", () => {
 
     expect(result).toBe(TAINTED_BY_WRITES_MESSAGE);
     expect(mainTurns).toBe(2);
-    const memoryDir = join(dataDir, "memory");
-    const dailyNotes = readdirSync(memoryDir)
-      .filter((name) => name.endsWith(".md") && name !== "MEMORY.md")
-      .map((name) => readFileSync(join(memoryDir, name), "utf-8"))
-      .join("\n");
-    expect((dailyNotes.match(new RegExp(note, "g")) ?? []).length).toBe(1);
+    expect((dailyMemoryText().match(new RegExp(note, "g")) ?? []).length).toBe(1);
+  });
+
+  it("keeps write taint scoped when different chats run concurrently", async () => {
+    const note = "freshness note scoped to the first chat";
+    let firstMainCalls = 0;
+    let secondMainCalls = 0;
+    let releaseFirstAfterWrite = () => {};
+    const firstAfterWrite = new Promise<void>((resolve) => {
+      releaseFirstAfterWrite = resolve;
+    });
+    let markFirstPostWrite = () => {};
+    const firstPostWrite = new Promise<void>((resolve) => {
+      markFirstPostWrite = resolve;
+    });
+    const complete = vi.fn(async (params: { system?: string; messages?: { role: string; content?: unknown }[] }) => {
+      const sys = params.system ?? "";
+      if (sys.includes(FLUSH_MARKER)) return mkAssistant({ text: "facts noted" });
+      if (sys.length === 0) return mkAssistant({ text: "summary" });
+
+      const messages = params.messages ?? [];
+      const transcript = JSON.stringify(messages);
+      const hasToolResult = messages.some((m) => m.role === "tool");
+      if (transcript.includes("first memory note")) {
+        firstMainCalls++;
+        if (!hasToolResult) {
+          return mkAssistant({
+            toolCall: {
+              id: "call-concurrent-memory",
+              name: "memory_write",
+              arguments: { type: "daily", content: note },
+            },
+            stopReason: "toolUse",
+          });
+        }
+        markFirstPostWrite();
+        await firstAfterWrite;
+        const err = new Error("deadline exceeded");
+        err.name = "TimeoutError";
+        throw err;
+      }
+
+      if (transcript.includes("second normal turn")) {
+        secondMainCalls++;
+        return mkAssistant({ text: "second ok" });
+      }
+
+      throw new Error(`unexpected messages: ${transcript}`);
+    });
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const agent = await setupAgent(complete);
+
+    const firstResultPromise = agent.chat("taint-concurrent-a", "first memory note");
+    await firstPostWrite;
+    const secondResult = await agent.chat("taint-concurrent-b", "second normal turn");
+    releaseFirstAfterWrite();
+    const firstResult = await firstResultPromise;
+
+    expect(secondResult).toBe("second ok");
+    expect(firstResult).toBe(TAINTED_BY_WRITES_MESSAGE);
+    expect(firstMainCalls).toBe(2);
+    expect(secondMainCalls).toBe(1);
+    expect((dailyMemoryText().match(new RegExp(note, "g")) ?? []).length).toBe(1);
   });
 
   it("a delete on a turn that then errors also taints", async () => {


### PR DESCRIPTION
## Summary
- add a GenerateOpts signal seam with a 180s owned LLM-call deadline
- forward cancellation through AI SDK and Codex request/tool execution paths
- retry one small-context plain timeout only before committed tool writes make the turn non-replayable

## Tests
- corepack pnpm vitest run packages/core/tests/llm-dispatch.test.ts packages/core/tests/codex-bridge.test.ts packages/core/tests/coach-agent-turn-outcome.test.ts packages/core/tests/turn-tainted-by-writes.test.ts
- corepack pnpm vitest run packages/core/tests/codex/responses.test.ts
- PATH=/Users/yerzhansagyt/Library/pnpm:$PATH pnpm check