### PR TITLE
Link survey in update notices

### DIFF
--- a/.changeset/survey-feedback-cta.md
+++ b/.changeset/survey-feedback-cta.md
@@ -1,0 +1,7 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Update notifications now link to a short customer discovery survey so you can help prioritize mobile app, 24/7 bot, Railway template, and setup/payment work.
+
+Replace the X.com feedback prompt in the Telegram update-available broadcast with the Tally survey call-to-action.

--- a/packages/core/src/channels/telegram.ts
+++ b/packages/core/src/channels/telegram.ts
@@ -822,7 +822,7 @@ export async function notifyUpdate(bot: Bot, dataDir: string, binary: BinaryConf
     const updateInstruction = isManagedDeploy()
       ? `Send /whatsnew to see what changed. ${MANAGED_DEPLOY_UPDATE_NOTICE}`
       : "Send /whatsnew to see what changed, /update to install.";
-    const message = `Update available: ${info.current} → ${info.latest}\n${updateInstruction}\n\nWant the bot running 24/7 without keeping your computer on? Deploy the Railway template: https://railway.com/deploy/cycling-coach\n\nTag or DM me at x.com/yerzhansa with feedback, feature requests, or bugs — help shape what's next.`;
+    const message = `Update available: ${info.current} → ${info.latest}\n${updateInstruction}\n\nWant the bot running 24/7 without keeping your computer on? Deploy the Railway template: https://railway.com/deploy/cycling-coach\n\nHelp shape what Cycling Coach builds next: please take 3 minutes to answer this short survey so the mobile app, 24/7 bot, Railway template, and setup/payment options are prioritized around what would actually help you: https://tally.so/r/b5Dv4g`;
 
     for (const chatId of chatIds) {
       try {

--- a/packages/core/src/channels/telegram.ts
+++ b/packages/core/src/channels/telegram.ts
@@ -822,7 +822,7 @@ export async function notifyUpdate(bot: Bot, dataDir: string, binary: BinaryConf
     const updateInstruction = isManagedDeploy()
       ? `Send /whatsnew to see what changed. ${MANAGED_DEPLOY_UPDATE_NOTICE}`
       : "Send /whatsnew to see what changed, /update to install.";
-    const message = `Update available: ${info.current} → ${info.latest}\n${updateInstruction}\n\nWant the bot running 24/7 without keeping your computer on? Deploy the Railway template: https://railway.com/deploy/cycling-coach\n\nHelp shape what Cycling Coach builds next: please take 3 minutes to answer this short survey so the mobile app, 24/7 bot, Railway template, and setup/payment options are prioritized around what would actually help you: https://tally.so/r/b5Dv4g`;
+    const message = `Update available: ${info.current} → ${info.latest}\n${updateInstruction}\n\nHelp shape what Cycling Coach builds next: please take 3 minutes to answer this short survey so the mobile app, 24/7 bot, Railway template, and setup/payment options are prioritized around what would actually help you: https://tally.so/r/b5Dv4g\n\nWant the bot running 24/7 without keeping your computer on? Deploy the Railway template: https://railway.com/deploy/cycling-coach`;
 
     for (const chatId of chatIds) {
       try {

--- a/packages/core/tests/telegram-bot.test.ts
+++ b/packages/core/tests/telegram-bot.test.ts
@@ -204,9 +204,11 @@ describe("notifyUpdate — broadcast filtering (L3)", () => {
     expect(message).toContain(
       "Want the bot running 24/7 without keeping your computer on? Deploy the Railway template: https://railway.com/deploy/cycling-coach",
     );
-    expect(message).toContain("x.com/yerzhansa");
+    expect(message).toContain("https://tally.so/r/b5Dv4g");
+    expect(message).toContain("Help shape what Cycling Coach builds next");
+    expect(message).not.toContain("x.com/yerzhansa");
     expect(message.indexOf("railway.com/deploy/cycling-coach")).toBeLessThan(
-      message.indexOf("x.com/yerzhansa"),
+      message.indexOf("https://tally.so/r/b5Dv4g"),
     );
   });
 });

--- a/packages/core/tests/telegram-bot.test.ts
+++ b/packages/core/tests/telegram-bot.test.ts
@@ -207,8 +207,8 @@ describe("notifyUpdate — broadcast filtering (L3)", () => {
     expect(message).toContain("https://tally.so/r/b5Dv4g");
     expect(message).toContain("Help shape what Cycling Coach builds next");
     expect(message).not.toContain("x.com/yerzhansa");
-    expect(message.indexOf("railway.com/deploy/cycling-coach")).toBeLessThan(
-      message.indexOf("https://tally.so/r/b5Dv4g"),
+    expect(message.indexOf("https://tally.so/r/b5Dv4g")).toBeLessThan(
+      message.indexOf("railway.com/deploy/cycling-coach"),
     );
   });
 });


### PR DESCRIPTION
## Summary
- Replace the X.com feedback prompt in Telegram update-available broadcasts with the Tally customer discovery survey link.
- Keep the Railway template prompt ahead of the new survey CTA.
- Add a user-facing changeset so the release notes mention the survey path.

## Test plan
- [x] Vitest Telegram bot test
- [x] Changeset user-facing check