### PR TITLE
fix(core): resilient Telegram delivery + shared error classification (Batch 9 G1)

### DIFF
--- a/.changeset/g1-delivery-resilience.md
+++ b/.changeset/g1-delivery-resilience.md
@@ -1,0 +1,7 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Telegram now retries failed message delivery, threads replies to your message, and shows clearer error messages; the CLI no longer prints raw error objects.
+
+Splits generation from delivery in the Telegram turn so a post-generation delivery failure is no longer shown generation copy, installs a bounded API-level retry transformer, adds a process-local resend cache (send "resend" to re-emit the last answer), threads final replies to the inbound message, moves the auth `next()` outside its guarded block so downstream handler errors are no longer mislabeled as security errors, registers a last-resort `bot.catch`, and routes both the Telegram channel and the CLI through one shared error classifier.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,6 +25,7 @@
     "@ai-sdk/provider": "^3.0.9",
     "@ai-sdk/provider-utils": "^4.0.24",
     "@clack/prompts": "^1.2.0",
+    "@grammyjs/auto-retry": "^2.0.2",
     "@openrouter/ai-sdk-provider": "^2.9.1",
     "ai": "^6.0.158",
     "grammy": "^1.42.0",

--- a/packages/core/src/agent/error-classify.ts
+++ b/packages/core/src/agent/error-classify.ts
@@ -8,29 +8,33 @@ export type AgentErrorKind =
   | "intervals"
   | "unknown";
 
-const INTERVALS_API_ERROR_KINDS: ReadonlySet<string> = new Set([
-  "Unauthorized",
-  "Forbidden",
-  "NotFound",
-  "RateLimit",
-  "Validation",
-  "Http",
-  "Timeout",
-  "Network",
-  "Unknown",
-]);
+// Routing for intervals' ApiError, whose `kind` is a type-only discriminated
+// union (no importable class) we mirror here. The `satisfies Record<ApiError
+// ["kind"], …>` tie makes `pnpm check` fail if the upstream union gains or
+// renames a kind, forcing a routing decision instead of silently degrading to
+// the generic apology.
+const INTERVALS_KIND_ROUTING = {
+  Unauthorized: "intervals",
+  Forbidden: "intervals",
+  NotFound: "intervals",
+  Validation: "intervals",
+  Http: "intervals",
+  Unknown: "intervals",
+  RateLimit: "rate_limit",
+  Timeout: "provider-down",
+  Network: "provider-down",
+} satisfies Record<ApiError["kind"], AgentErrorKind>;
 
-// Narrow guard: intervals' ApiError is a type-only discriminated union (no
-// importable class), so match on its specific `kind` literals rather than any
-// object that happens to carry a string `kind`, which would misclassify
-// unrelated errors.
+// Narrow guard: match only objects whose string `kind` is one the upstream
+// union actually defines, so unrelated errors that happen to carry a `kind`
+// are not misclassified as intervals failures.
 function isIntervalsApiError(err: unknown): err is ApiError {
   return (
     typeof err === "object" &&
     err !== null &&
     "kind" in err &&
     typeof (err as { kind: unknown }).kind === "string" &&
-    INTERVALS_API_ERROR_KINDS.has((err as { kind: string }).kind)
+    (err as { kind: string }).kind in INTERVALS_KIND_ROUTING
   );
 }
 
@@ -50,10 +54,11 @@ export function classifyAgentError(err: unknown): {
   }
 
   if (isIntervalsApiError(err)) {
-    if (err.kind === "RateLimit") {
+    const routed = INTERVALS_KIND_ROUTING[err.kind];
+    if (routed === "rate_limit") {
       return rateLimited(err);
     }
-    if (err.kind === "Timeout" || err.kind === "Network") {
+    if (routed === "provider-down") {
       return {
         kind: "provider-down",
         athleteMessage: "The model provider is having trouble — try again in a few minutes.",

--- a/packages/core/src/agent/error-classify.ts
+++ b/packages/core/src/agent/error-classify.ts
@@ -1,0 +1,87 @@
+import type { ApiError } from "intervals-icu-api";
+import { classifyFailure, formatRateLimitWait, isRateLimitError } from "./token-utils.js";
+
+export type AgentErrorKind =
+  | "rate_limit"
+  | "provider-auth"
+  | "provider-down"
+  | "intervals"
+  | "unknown";
+
+const INTERVALS_API_ERROR_KINDS: ReadonlySet<string> = new Set([
+  "Unauthorized",
+  "Forbidden",
+  "NotFound",
+  "RateLimit",
+  "Validation",
+  "Http",
+  "Timeout",
+  "Network",
+  "Unknown",
+]);
+
+// Narrow guard: intervals' ApiError is a type-only discriminated union (no
+// importable class), so match on its specific `kind` literals rather than any
+// object that happens to carry a string `kind`, which would misclassify
+// unrelated errors.
+function isIntervalsApiError(err: unknown): err is ApiError {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "kind" in err &&
+    typeof (err as { kind: unknown }).kind === "string" &&
+    INTERVALS_API_ERROR_KINDS.has((err as { kind: string }).kind)
+  );
+}
+
+export function classifyAgentError(err: unknown): {
+  kind: AgentErrorKind;
+  athleteMessage: string;
+} {
+  if (isRateLimitError(err)) {
+    return {
+      kind: "rate_limit",
+      athleteMessage: `Rate limited — please try again in ${formatRateLimitWait(err)}.`,
+    };
+  }
+
+  if (isIntervalsApiError(err)) {
+    if (err.kind === "RateLimit") {
+      return {
+        kind: "rate_limit",
+        athleteMessage: `Rate limited — please try again in ${formatRateLimitWait(err)}.`,
+      };
+    }
+    if (err.kind === "Timeout" || err.kind === "Network") {
+      return {
+        kind: "provider-down",
+        athleteMessage: "The model provider is having trouble — try again in a few minutes.",
+      };
+    }
+    return {
+      kind: "intervals",
+      athleteMessage: "Couldn't reach intervals.icu right now — try again shortly.",
+    };
+  }
+
+  switch (classifyFailure(err)) {
+    case "auth":
+      return {
+        kind: "provider-auth",
+        athleteMessage:
+          "The model provider rejected the API key — check your provider credentials.",
+      };
+    case "server_error":
+    case "network":
+    case "timeout":
+      return {
+        kind: "provider-down",
+        athleteMessage: "The model provider is having trouble — try again in a few minutes.",
+      };
+    default:
+      return {
+        kind: "unknown",
+        athleteMessage: "Sorry, something went wrong. Please try again.",
+      };
+  }
+}

--- a/packages/core/src/agent/error-classify.ts
+++ b/packages/core/src/agent/error-classify.ts
@@ -34,23 +34,24 @@ function isIntervalsApiError(err: unknown): err is ApiError {
   );
 }
 
+function rateLimited(err: unknown): { kind: AgentErrorKind; athleteMessage: string } {
+  return {
+    kind: "rate_limit",
+    athleteMessage: `Rate limited — please try again in ${formatRateLimitWait(err)}.`,
+  };
+}
+
 export function classifyAgentError(err: unknown): {
   kind: AgentErrorKind;
   athleteMessage: string;
 } {
   if (isRateLimitError(err)) {
-    return {
-      kind: "rate_limit",
-      athleteMessage: `Rate limited — please try again in ${formatRateLimitWait(err)}.`,
-    };
+    return rateLimited(err);
   }
 
   if (isIntervalsApiError(err)) {
     if (err.kind === "RateLimit") {
-      return {
-        kind: "rate_limit",
-        athleteMessage: `Rate limited — please try again in ${formatRateLimitWait(err)}.`,
-      };
+      return rateLimited(err);
     }
     if (err.kind === "Timeout" || err.kind === "Network") {
       return {

--- a/packages/core/src/agent/error-classify.ts
+++ b/packages/core/src/agent/error-classify.ts
@@ -1,5 +1,10 @@
 import type { ApiError } from "intervals-icu-api";
-import { classifyFailure, formatRateLimitWait, isRateLimitError } from "./token-utils.js";
+import {
+  classifyFailure,
+  extractRetryAfterMs,
+  formatRateLimitWaitMs,
+  isRateLimitError,
+} from "./token-utils.js";
 
 export type AgentErrorKind =
   | "rate_limit"
@@ -7,6 +12,13 @@ export type AgentErrorKind =
   | "provider-down"
   | "intervals"
   | "unknown";
+
+const PROVIDER_DOWN_MESSAGE =
+  "The model provider is having trouble — try again in a few minutes.";
+const INTERVALS_TRANSIENT_MESSAGE =
+  "Couldn't reach intervals.icu right now — try again shortly.";
+const INTERVALS_CREDENTIALS_MESSAGE =
+  "intervals.icu rejected the request — check your intervals.icu connection or API key.";
 
 // Routing for intervals' ApiError, whose `kind` is a type-only discriminated
 // union (no importable class) we mirror here. The `satisfies Record<ApiError
@@ -21,8 +33,8 @@ const INTERVALS_KIND_ROUTING = {
   Http: "intervals",
   Unknown: "intervals",
   RateLimit: "rate_limit",
-  Timeout: "provider-down",
-  Network: "provider-down",
+  Timeout: "intervals",
+  Network: "intervals",
 } satisfies Record<ApiError["kind"], AgentErrorKind>;
 
 // Narrow guard: match only objects whose string `kind` is one the upstream
@@ -38,10 +50,16 @@ function isIntervalsApiError(err: unknown): err is ApiError {
   );
 }
 
+function carriedRetryAfterMs(err: unknown): number | null {
+  const carried = (err as { retryAfterMs?: unknown }).retryAfterMs;
+  return typeof carried === "number" && Number.isFinite(carried) && carried > 0 ? carried : null;
+}
+
 function rateLimited(err: unknown): { kind: AgentErrorKind; athleteMessage: string } {
+  const ms = extractRetryAfterMs(err) ?? carriedRetryAfterMs(err);
   return {
     kind: "rate_limit",
-    athleteMessage: `Rate limited — please try again in ${formatRateLimitWait(err)}.`,
+    athleteMessage: `Rate limited — please try again in ${formatRateLimitWaitMs(ms)}.`,
   };
 }
 
@@ -54,19 +72,18 @@ export function classifyAgentError(err: unknown): {
   }
 
   if (isIntervalsApiError(err)) {
-    const routed = INTERVALS_KIND_ROUTING[err.kind];
-    if (routed === "rate_limit") {
+    if (INTERVALS_KIND_ROUTING[err.kind] === "rate_limit") {
       return rateLimited(err);
     }
-    if (routed === "provider-down") {
+    if (err.kind === "Unauthorized" || err.kind === "Forbidden") {
       return {
-        kind: "provider-down",
-        athleteMessage: "The model provider is having trouble — try again in a few minutes.",
+        kind: "intervals",
+        athleteMessage: INTERVALS_CREDENTIALS_MESSAGE,
       };
     }
     return {
       kind: "intervals",
-      athleteMessage: "Couldn't reach intervals.icu right now — try again shortly.",
+      athleteMessage: INTERVALS_TRANSIENT_MESSAGE,
     };
   }
 
@@ -82,7 +99,7 @@ export function classifyAgentError(err: unknown): {
     case "timeout":
       return {
         kind: "provider-down",
-        athleteMessage: "The model provider is having trouble — try again in a few minutes.",
+        athleteMessage: PROVIDER_DOWN_MESSAGE,
       };
     default:
       return {

--- a/packages/core/src/agent/token-utils.ts
+++ b/packages/core/src/agent/token-utils.ts
@@ -155,3 +155,11 @@ export function extractRetryAfterMs(err: unknown): number | null {
 
   return null;
 }
+
+export function formatRateLimitWait(err: unknown): string {
+  const ms = extractRetryAfterMs(err);
+  if (!ms) return "about a minute";
+  const secs = Math.ceil(ms / 1000);
+  if (secs < 60) return `~${secs} seconds`;
+  return `~${Math.ceil(secs / 60)} minute${Math.ceil(secs / 60) > 1 ? "s" : ""}`;
+}

--- a/packages/core/src/agent/token-utils.ts
+++ b/packages/core/src/agent/token-utils.ts
@@ -156,10 +156,13 @@ export function extractRetryAfterMs(err: unknown): number | null {
   return null;
 }
 
-export function formatRateLimitWait(err: unknown): string {
-  const ms = extractRetryAfterMs(err);
+export function formatRateLimitWaitMs(ms: number | null): string {
   if (!ms) return "about a minute";
   const secs = Math.ceil(ms / 1000);
   if (secs < 60) return `~${secs} seconds`;
   return `~${Math.ceil(secs / 60)} minute${Math.ceil(secs / 60) > 1 ? "s" : ""}`;
+}
+
+export function formatRateLimitWait(err: unknown): string {
+  return formatRateLimitWaitMs(extractRetryAfterMs(err));
 }

--- a/packages/core/src/channels/telegram-access.ts
+++ b/packages/core/src/channels/telegram-access.ts
@@ -88,16 +88,19 @@ function warnOpenPolicyServe(warned: Set<string>, fromId: number | undefined): v
 export function createAuthMiddleware(opts: CreateAuthMiddlewareOpts): MiddlewareFn<Context> {
   const openPolicyWarned = new Set<string>();
   return async (ctx, next) => {
+    // Auth decision (allowlist load, evaluateAccess, pairing-challenge reply) is
+    // the only logic guarded here, and it fails CLOSED. next() runs OUTSIDE the
+    // guard so a downstream handler throw propagates to bot.catch instead of
+    // being mislabeled a security error and silently dropped.
+    let granted = false;
     try {
       const allowed = loadAllowedSenders(opts.dataDir);
       const decision = evaluateAccess(ctx, allowed);
       if (decision.allow) {
         if (decision.viaOpenPolicy) warnOpenPolicyServe(openPolicyWarned, ctx.from?.id);
-        await next();
-        return;
-      }
-      // Drop. Optionally reply with pairing-challenge (rate-limited per-sender).
-      if (decision.pairingChallenge) {
+        granted = true;
+      } else if (decision.pairingChallenge) {
+        // Drop. Optionally reply with pairing-challenge (rate-limited per-sender).
         const senderId = decision.pairingChallenge;
         const now = Date.now();
         const last = opts.challengeRateLimit.get(senderId) ?? 0;
@@ -115,6 +118,8 @@ export function createAuthMiddleware(opts: CreateAuthMiddlewareOpts): Middleware
       console.error(
         `[security] middleware error: ${err instanceof Error ? err.message : String(err)}`,
       );
+      return;
     }
+    if (granted) await next();
   };
 }

--- a/packages/core/src/channels/telegram.ts
+++ b/packages/core/src/channels/telegram.ts
@@ -1,7 +1,8 @@
 import { Bot, InputFile } from "grammy";
+import { autoRetry } from "@grammyjs/auto-retry";
 import type { CoachAgent } from "../agent/coach-agent.js";
 import type { BinaryConfig } from "../binary.js";
-import { isRateLimitError, extractRetryAfterMs } from "../agent/token-utils.js";
+import { classifyAgentError } from "../agent/error-classify.js";
 import {
   checkForUpdate,
   selfUpdate,
@@ -23,18 +24,15 @@ import { formatSnapshotRaw } from "../reference/sync/snapshot-debug.js";
 import { sendSnapshotOutput } from "../reference/sync/send-snapshot.js";
 import { createSubsystemLogger } from "../logging/index.js";
 
-function formatRateLimitWait(err: unknown): string {
-  const ms = extractRetryAfterMs(err);
-  if (!ms) return "about a minute";
-  const secs = Math.ceil(ms / 1000);
-  if (secs < 60) return `~${secs} seconds`;
-  return `~${Math.ceil(secs / 60)} minute${Math.ceil(secs / 60) > 1 ? "s" : ""}`;
-}
-
 // Upper bound on how long /update waits for in-flight turns to finish before
 // self-updating. A hung turn must never wedge the update, so the drain races a
 // timeout.
 const UPDATE_DRAIN_TIMEOUT_MS = 10_000;
+
+// Process-local resend cache bounds. The cache holds full generated answers
+// (athlete content) so it is size- and time-bounded and never logged.
+const RESEND_TTL_MS = 30 * 60_000;
+const RESEND_MAX_ENTRIES = 1000;
 
 function drainBounded(drain: () => Promise<void>, timeoutMs: number): Promise<void> {
   return Promise.race([
@@ -106,6 +104,21 @@ function createSecuredBot(opts: {
 }): Bot {
   const bot = new Bot(opts.token);
 
+  // Bounded API-level retry restricted to a Telegram 429 carrying a `retry_after`
+  // (the one failure class where the original send provably did NOT land).
+  // rethrowInternalServerErrors / rethrowHttpErrors disable this plugin's default
+  // 5xx and network retries, which would risk a duplicate send on an ambiguous
+  // failure whose original request may already have been delivered server-side.
+  // maxDelaySeconds caps how long we'll wait out a flood.
+  bot.api.config.use(
+    autoRetry({
+      maxRetryAttempts: 1,
+      maxDelaySeconds: 300,
+      rethrowInternalServerErrors: true,
+      rethrowHttpErrors: true,
+    }),
+  );
+
   // Per-sender pairing-challenge rate-limit map (process-lifetime; LRU-bounded).
   const challengeRateLimit = new Map<string, number>();
   bot.use(
@@ -158,6 +171,33 @@ export function createTelegramBot(
   const log = createSubsystemLogger("telegram", dataDir);
   const greeted = new Set<number>();
 
+  // Process-local per-chat cache of the last generated answer, so an athlete can
+  // ask for it again after a Telegram delivery failure without re-running the LLM
+  // turn. Bounded + TTL'd; contents (athlete text) are never logged.
+  const resendCache = new Map<string, { answer: string; expires: number }>();
+  const writeResend = (chatId: string, answer: string): void => {
+    const now = Date.now();
+    for (const [key, entry] of resendCache) {
+      if (entry.expires <= now) resendCache.delete(key);
+    }
+    if (resendCache.has(chatId)) resendCache.delete(chatId); // bump to MRU position
+    resendCache.set(chatId, { answer, expires: now + RESEND_TTL_MS });
+    while (resendCache.size > RESEND_MAX_ENTRIES) {
+      const oldest = resendCache.keys().next().value;
+      if (oldest === undefined) break;
+      resendCache.delete(oldest);
+    }
+  };
+  const readResend = (chatId: string): string | undefined => {
+    const entry = resendCache.get(chatId);
+    if (!entry) return undefined;
+    if (entry.expires <= Date.now()) {
+      resendCache.delete(chatId);
+      return undefined;
+    }
+    return entry.answer;
+  };
+
   // Fire-and-forget turn dispatch. Telegram handlers spawn the LLM turn on a
   // tracked task and return immediately so grammY's sequential update loop is
   // never blocked by a long turn. The task owns its user-facing error reply; the
@@ -192,9 +232,10 @@ export function createTelegramBot(
 
   // Shared turn skeleton: every chat-bearing handler captures its deps/message
   // synchronously, then hands the LLM turn here to run on the fire-and-forget
-  // task. The only per-handler differences are the user-facing strings, the log
-  // command name, and (for the text chat handler) the rate-limited reply wording,
-  // all passed in rather than re-templated so the handlers stay byte-identical.
+  // task. Generation and delivery are split into separate try blocks so a
+  // post-generation Telegram delivery failure is never shown generation copy and
+  // vice versa. The only per-handler differences (genericReply text, log command
+  // name, reply-to id) are passed in rather than re-templated.
   function runTurn(opts: {
     ctx: { reply: (text: string, options?: Record<string, unknown>) => Promise<unknown> };
     command: string;
@@ -202,22 +243,26 @@ export function createTelegramBot(
     message: string;
     deps: ReturnType<typeof turnDeps>;
     genericReply: string;
-    rateLimitReply?: (err: unknown) => string;
+    replyToMessageId?: number;
   }): void {
     dispatch(async () => {
+      let response: string;
       try {
-        const response = await agent.chat(opts.chatId, opts.message, opts.deps);
-        await sendLongMessage(opts.ctx, response);
+        response = await agent.chat(opts.chatId, opts.message, opts.deps);
       } catch (err) {
         log.error("command_failed", err, { command: opts.command, chatId: opts.chatId });
-        if (isRateLimitError(err)) {
-          const reply = opts.rateLimitReply
-            ? opts.rateLimitReply(err)
-            : `Rate limited — please try again in ${formatRateLimitWait(err)}.`;
-          await opts.ctx.reply(reply);
-        } else {
-          await opts.ctx.reply(opts.genericReply);
-        }
+        const { kind, athleteMessage } = classifyAgentError(err);
+        await opts.ctx.reply(kind === "unknown" ? opts.genericReply : athleteMessage);
+        return;
+      }
+      writeResend(opts.chatId, response);
+      try {
+        await sendLongMessage(opts.ctx, response, opts.replyToMessageId);
+      } catch (err) {
+        log.error("delivery_failed", err, { command: opts.command, chatId: opts.chatId });
+        await opts.ctx.reply(
+          'I generated the answer, but Telegram had trouble delivering it. Send "resend" and I\'ll send the same answer again.',
+        );
       }
     });
   }
@@ -252,6 +297,7 @@ export function createTelegramBot(
       message: "/plan",
       deps,
       genericReply: "Sorry, something went wrong generating your plan. Please try again.",
+      replyToMessageId: ctx.message?.message_id,
     });
   });
 
@@ -266,6 +312,7 @@ export function createTelegramBot(
       message: "/workout",
       deps,
       genericReply: "Sorry, something went wrong. Please try again.",
+      replyToMessageId: ctx.message?.message_id,
     });
   });
 
@@ -280,6 +327,7 @@ export function createTelegramBot(
       message: "/status",
       deps,
       genericReply: "Sorry, something went wrong. Please try again.",
+      replyToMessageId: ctx.message?.message_id,
     });
   });
 
@@ -342,6 +390,7 @@ export function createTelegramBot(
       message,
       deps,
       genericReply: "Sorry, something went wrong reviewing your session. Please try again.",
+      replyToMessageId: ctx.message?.message_id,
     });
   });
 
@@ -405,6 +454,16 @@ export function createTelegramBot(
 
   bot.on("message:text", async (ctx) => {
     const chatId = `telegram:${ctx.chat.id}`;
+    const text = ctx.message.text;
+
+    // Resend the last cached answer without re-running the LLM turn. Short-circuit
+    // BEFORE any greeting/dispatch so it never reaches agent.chat.
+    if (text.trim().toLowerCase() === "resend") {
+      const cached = readResend(chatId);
+      if (cached !== undefined) await sendLongMessage(ctx, cached);
+      else await ctx.reply("I don't have a recent answer to resend.");
+      return;
+    }
 
     // Welcome newcomers on their very first message. `greeted` is in-memory,
     // so after a process restart we consult the on-disk session to tell
@@ -416,7 +475,6 @@ export function createTelegramBot(
       }
     }
 
-    const text = ctx.message.text;
     const deps = turnDeps();
     runTurn({
       ctx,
@@ -425,9 +483,22 @@ export function createTelegramBot(
       message: text,
       deps,
       genericReply: "Sorry, something went wrong. Please try again.",
-      rateLimitReply: (err) =>
-        `Your message was not processed (rate limited). Please wait ${formatRateLimitWait(err)} and resend:\n\n"${text.slice(0, 200)}"`,
+      replyToMessageId: ctx.message?.message_id,
     });
+  });
+
+  bot.catch(async (botError) => {
+    // Real surface: synchronous handler/ack reply failures NOT on a dispatched
+    // turn (dispatched-turn errors are already swallowed by the dispatch wrapper).
+    // The classified-reply attempt is itself guarded so a reply throw cannot
+    // re-enter bot.catch or escape as an unhandled rejection.
+    log.error("bot_catch", botError.error, {});
+    const c = botError.ctx;
+    try {
+      if (c?.chat) await c.reply(classifyAgentError(botError.error).athleteMessage);
+    } catch (replyErr) {
+      log.error("bot_catch_reply_failed", replyErr, {});
+    }
   });
 
   return { bot, drainPending };
@@ -757,15 +828,25 @@ function isTelegramParseError(err: unknown): boolean {
 export async function sendLongMessage(
   ctx: { reply: (text: string, options?: Record<string, unknown>) => Promise<unknown> },
   text: string,
+  replyToMessageId?: number,
 ): Promise<void> {
   const html = markdownToTelegramHtml(text);
+  // Thread the FIRST delivered chunk to the inbound message; later chunks stay
+  // unthreaded. allow_sending_without_reply keeps the send working even if the
+  // inbound message was deleted (otherwise reply-to-deleted is a new failure).
+  let pendingThread =
+    replyToMessageId !== undefined
+      ? { reply_parameters: { message_id: replyToMessageId, allow_sending_without_reply: true } }
+      : undefined;
   for (const chunk of chunkHtml(html)) {
     // Telegram rejects an empty message (400: message text is empty), and an
     // empty chunk carries nothing for the athlete anyway — skip it so ctx.reply
     // is never called with empty/whitespace-only text.
     if (chunk.trim() === "") continue;
+    const thread = pendingThread;
     try {
-      await ctx.reply(chunk, { parse_mode: "HTML" });
+      await ctx.reply(chunk, { parse_mode: "HTML", ...thread });
+      pendingThread = undefined;
     } catch (err) {
       if (!isTelegramParseError(err)) throw err;
       // Log the message only — a grammY error object carries the request
@@ -779,7 +860,8 @@ export async function sendLongMessage(
       // sees clean text — never tag soup or double-escaped entities.
       const plain = htmlChunkToPlainText(chunk);
       if (plain.trim() === "") continue;
-      await ctx.reply(plain);
+      await ctx.reply(plain, thread);
+      pendingThread = undefined;
     }
   }
 }

--- a/packages/core/src/channels/telegram.ts
+++ b/packages/core/src/channels/telegram.ts
@@ -37,6 +37,16 @@ const RESEND_MAX_ENTRIES = 1000;
 // matcher and the delivery-failure hint so the two can never drift apart.
 const RESEND_KEYWORD = "resend";
 
+// Shown when generation succeeded but Telegram couldn't deliver the answer.
+// Used by both the runTurn delivery catch and the resend-dispatch catch so the
+// two delivery-failure paths can never drift apart.
+const DELIVERY_FAILURE_HINT = `I generated the answer, but Telegram had trouble delivering it. Send "${RESEND_KEYWORD}" and I'll send the same answer again.`;
+
+// Neutral apology for synchronous handler/ack failures surfaced through
+// bot.catch — those are Telegram transport errors, not LLM/tool errors, so they
+// must not be dressed in provider-specific vocabulary.
+const GENERIC_TRANSPORT_APOLOGY = "Sorry, something went wrong. Please try again.";
+
 function drainBounded(drain: () => Promise<void>, timeoutMs: number): Promise<void> {
   return Promise.race([
     drain(),
@@ -112,11 +122,17 @@ function createSecuredBot(opts: {
   // rethrowInternalServerErrors / rethrowHttpErrors disable this plugin's default
   // 5xx and network retries, which would risk a duplicate send on an ambiguous
   // failure whose original request may already have been delivered server-side.
-  // maxDelaySeconds caps how long we'll wait out a flood.
+  // Deliberately a separate retry policy from the shared primitive in
+  // concurrency/retry.ts: this is a grammY API-transformer seam handling
+  // bot-transport 429s, not an LLM/tool retry.
+  // The only calls that can block grammY's sequential update loop are the
+  // synchronous command acks, so maxDelaySeconds is a small bound: a 429 whose
+  // retry_after exceeds it must fail fast rather than freeze every chat. The
+  // fire-and-forget delivery path and the resend cache are the backstops.
   bot.api.config.use(
     autoRetry({
       maxRetryAttempts: 1,
-      maxDelaySeconds: 300,
+      maxDelaySeconds: 5,
       rethrowInternalServerErrors: true,
       rethrowHttpErrors: true,
     }),
@@ -263,9 +279,7 @@ export function createTelegramBot(
         await sendLongMessage(opts.ctx, response, opts.replyToMessageId);
       } catch (err) {
         log.error("delivery_failed", err, { command: opts.command, chatId: opts.chatId });
-        await opts.ctx.reply(
-          `I generated the answer, but Telegram had trouble delivering it. Send "${RESEND_KEYWORD}" and I'll send the same answer again.`,
-        );
+        await opts.ctx.reply(DELIVERY_FAILURE_HINT);
       }
     });
   }
@@ -277,6 +291,7 @@ export function createTelegramBot(
     let memoryFlushed = true;
     try {
       ({ memoryFlushed } = await agent.resetSession(`telegram:${ctx.chat.id}`));
+      resendCache.delete(`telegram:${ctx.chat.id}`);
     } catch (err) {
       log.error("command_failed", err, { command: "start", chatId: `telegram:${ctx.chat.id}` });
       await ctx.reply(
@@ -463,8 +478,20 @@ export function createTelegramBot(
     // BEFORE any greeting/dispatch so it never reaches agent.chat.
     if (text.trim().toLowerCase() === RESEND_KEYWORD) {
       const cached = readResend(chatId);
-      if (cached !== undefined) await sendLongMessage(ctx, cached);
-      else await ctx.reply("I don't have a recent answer to resend.");
+      if (cached !== undefined) {
+        // Route through dispatch so re-emitting a long multi-chunk answer runs on
+        // the fire-and-forget task instead of blocking the sequential update loop,
+        // and a delivery failure gets the same hint runTurn uses rather than
+        // escaping to bot.catch as generic classified copy.
+        dispatch(async () => {
+          try {
+            await sendLongMessage(ctx, cached);
+          } catch (err) {
+            log.error("delivery_failed", err, { command: "resend", chatId });
+            await ctx.reply(DELIVERY_FAILURE_HINT);
+          }
+        });
+      } else await ctx.reply("I don't have a recent answer to resend.");
       return;
     }
 
@@ -498,7 +525,7 @@ export function createTelegramBot(
     log.error("bot_catch", botError.error, {});
     const c = botError.ctx;
     try {
-      if (c?.chat) await c.reply(classifyAgentError(botError.error).athleteMessage);
+      if (c?.chat) await c.reply(GENERIC_TRANSPORT_APOLOGY);
     } catch (replyErr) {
       log.error("bot_catch_reply_failed", replyErr, {});
     }

--- a/packages/core/src/channels/telegram.ts
+++ b/packages/core/src/channels/telegram.ts
@@ -33,6 +33,9 @@ const UPDATE_DRAIN_TIMEOUT_MS = 10_000;
 // (athlete content) so it is size- and time-bounded and never logged.
 const RESEND_TTL_MS = 30 * 60_000;
 const RESEND_MAX_ENTRIES = 1000;
+// The bare word an athlete types to re-emit the last answer. Shared by the
+// matcher and the delivery-failure hint so the two can never drift apart.
+const RESEND_KEYWORD = "resend";
 
 function drainBounded(drain: () => Promise<void>, timeoutMs: number): Promise<void> {
   return Promise.race([
@@ -180,7 +183,7 @@ export function createTelegramBot(
     for (const [key, entry] of resendCache) {
       if (entry.expires <= now) resendCache.delete(key);
     }
-    if (resendCache.has(chatId)) resendCache.delete(chatId); // bump to MRU position
+    resendCache.delete(chatId); // bump to MRU position (no-op if absent)
     resendCache.set(chatId, { answer, expires: now + RESEND_TTL_MS });
     while (resendCache.size > RESEND_MAX_ENTRIES) {
       const oldest = resendCache.keys().next().value;
@@ -261,7 +264,7 @@ export function createTelegramBot(
       } catch (err) {
         log.error("delivery_failed", err, { command: opts.command, chatId: opts.chatId });
         await opts.ctx.reply(
-          'I generated the answer, but Telegram had trouble delivering it. Send "resend" and I\'ll send the same answer again.',
+          `I generated the answer, but Telegram had trouble delivering it. Send "${RESEND_KEYWORD}" and I'll send the same answer again.`,
         );
       }
     });
@@ -458,7 +461,7 @@ export function createTelegramBot(
 
     // Resend the last cached answer without re-running the LLM turn. Short-circuit
     // BEFORE any greeting/dispatch so it never reaches agent.chat.
-    if (text.trim().toLowerCase() === "resend") {
+    if (text.trim().toLowerCase() === RESEND_KEYWORD) {
       const cached = readResend(chatId);
       if (cached !== undefined) await sendLongMessage(ctx, cached);
       else await ctx.reply("I don't have a recent answer to resend.");

--- a/packages/core/src/run-binary.ts
+++ b/packages/core/src/run-binary.ts
@@ -13,6 +13,14 @@ import {
   loadAllowedSenders,
   ensureDataDirSecure,
 } from "./channels/allowed-senders.js";
+import { classifyAgentError } from "./agent/error-classify.js";
+
+// Shared error classifier output as the CLI's athlete-facing reply, so the CLI
+// and the Telegram channel speak the same error vocabulary and never dump a raw
+// error object in the reply position.
+export function formatCliReply(err: unknown): string {
+  return classifyAgentError(err).athleteMessage;
+}
 
 export interface RunBinaryHooks {
   /** Called once per process at startup, after Memory exists, before any chat handler is reachable. */
@@ -448,7 +456,11 @@ export async function runBinary(
         const response = await agent.chat("cli", input);
         console.log("\n" + response + "\n");
       } catch (err) {
-        console.error("Error:", err);
+        // Full detail (stack, provider payload) → stderr; a friendly classified
+        // reply → stdout in the reply position. The raw err never lands as the
+        // coach reply.
+        console.error("Error detail:", err);
+        console.log("\n" + formatCliReply(err) + "\n");
       }
       rl.prompt();
     });

--- a/packages/core/tests/error-classify.test.ts
+++ b/packages/core/tests/error-classify.test.ts
@@ -57,27 +57,42 @@ describe("classifyAgentError", () => {
     );
   });
 
-  it("classifies an intervals ApiError (Unauthorized/NotFound) as intervals", () => {
+  it("classifies intervals Unauthorized/Forbidden as intervals with the credentials copy, NotFound as intervals transient", () => {
     const unauthorized: ApiError = { kind: "Unauthorized", status: 401, body: {} };
-    const notFound: ApiError = { kind: "NotFound", status: 404, body: {} };
-    for (const err of [unauthorized, notFound]) {
+    const forbidden: ApiError = { kind: "Forbidden", status: 403, body: {} };
+    for (const err of [unauthorized, forbidden]) {
       const result = classifyAgentError(err);
       expect(result.kind).toBe("intervals");
       expect(result.athleteMessage).toBe(
-        "Couldn't reach intervals.icu right now — try again shortly.",
+        "intervals.icu rejected the request — check your intervals.icu connection or API key.",
       );
     }
+
+    const notFound: ApiError = { kind: "NotFound", status: 404, body: {} };
+    const notFoundResult = classifyAgentError(notFound);
+    expect(notFoundResult.kind).toBe("intervals");
+    expect(notFoundResult.athleteMessage).toBe(
+      "Couldn't reach intervals.icu right now — try again shortly.",
+    );
   });
 
-  it("routes intervals RateLimit to rate_limit and Timeout/Network to provider-down", () => {
+  it("routes intervals RateLimit to rate_limit and Timeout/Network to the intervals transient classification", () => {
     const rateLimit: ApiError = { kind: "RateLimit", status: 429, retryAfterMs: 1000, body: {} };
     expect(classifyAgentError(rateLimit).kind).toBe("rate_limit");
 
     const timeout: ApiError = { kind: "Timeout", message: "slow" };
-    expect(classifyAgentError(timeout).kind).toBe("provider-down");
+    const timeoutResult = classifyAgentError(timeout);
+    expect(timeoutResult.kind).toBe("intervals");
+    expect(timeoutResult.athleteMessage).toBe(
+      "Couldn't reach intervals.icu right now — try again shortly.",
+    );
 
     const network: ApiError = { kind: "Network", message: "down" };
-    expect(classifyAgentError(network).kind).toBe("provider-down");
+    const networkResult = classifyAgentError(network);
+    expect(networkResult.kind).toBe("intervals");
+    expect(networkResult.athleteMessage).toBe(
+      "Couldn't reach intervals.icu right now — try again shortly.",
+    );
   });
 
   it("does NOT classify an unrelated object carrying a string kind as intervals", () => {

--- a/packages/core/tests/error-classify.test.ts
+++ b/packages/core/tests/error-classify.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from "vitest";
+import { APICallError } from "@ai-sdk/provider";
+import type { ApiError } from "intervals-icu-api";
+import { classifyAgentError } from "../src/agent/error-classify.js";
+import { formatRateLimitWait } from "../src/agent/token-utils.js";
+
+function apiError(statusCode: number): APICallError {
+  return new APICallError({
+    message: "api error",
+    url: "https://example.test",
+    requestBodyValues: {},
+    statusCode,
+  });
+}
+
+describe("classifyAgentError", () => {
+  it("classifies 401/403 as provider-auth with provider-neutral copy", () => {
+    for (const status of [401, 403]) {
+      const result = classifyAgentError(apiError(status));
+      expect(result.kind).toBe("provider-auth");
+      expect(result.athleteMessage).toBe(
+        "The model provider rejected the API key — check your provider credentials.",
+      );
+      expect(result.athleteMessage).not.toContain("Anthropic");
+    }
+  });
+
+  it("classifies 5xx as provider-down", () => {
+    for (const status of [500, 502, 503, 504, 529]) {
+      const result = classifyAgentError(apiError(status));
+      expect(result.kind).toBe("provider-down");
+      expect(result.athleteMessage).toBe(
+        "The model provider is having trouble — try again in a few minutes.",
+      );
+    }
+  });
+
+  it("classifies a network error (ECONNRESET via cause chain) as provider-down", () => {
+    const e = new TypeError("fetch failed");
+    (e as Error & { cause?: unknown }).cause = { code: "ECONNRESET" };
+    expect(classifyAgentError(e).kind).toBe("provider-down");
+  });
+
+  it("classifies a TimeoutError as provider-down", () => {
+    const e = new Error("boom");
+    e.name = "TimeoutError";
+    expect(classifyAgentError(e).kind).toBe("provider-down");
+  });
+
+  it("classifies 429 as rate_limit with the formatRateLimitWait copy", () => {
+    const err = apiError(429);
+    const result = classifyAgentError(err);
+    expect(result.kind).toBe("rate_limit");
+    expect(result.athleteMessage).toContain(formatRateLimitWait(err));
+    expect(result.athleteMessage).toBe(
+      "Rate limited — please try again in about a minute.",
+    );
+  });
+
+  it("classifies an intervals ApiError (Unauthorized/NotFound) as intervals", () => {
+    const unauthorized: ApiError = { kind: "Unauthorized", status: 401, body: {} };
+    const notFound: ApiError = { kind: "NotFound", status: 404, body: {} };
+    for (const err of [unauthorized, notFound]) {
+      const result = classifyAgentError(err);
+      expect(result.kind).toBe("intervals");
+      expect(result.athleteMessage).toBe(
+        "Couldn't reach intervals.icu right now — try again shortly.",
+      );
+    }
+  });
+
+  it("routes intervals RateLimit to rate_limit and Timeout/Network to provider-down", () => {
+    const rateLimit: ApiError = { kind: "RateLimit", status: 429, retryAfterMs: 1000, body: {} };
+    expect(classifyAgentError(rateLimit).kind).toBe("rate_limit");
+
+    const timeout: ApiError = { kind: "Timeout", message: "slow" };
+    expect(classifyAgentError(timeout).kind).toBe("provider-down");
+
+    const network: ApiError = { kind: "Network", message: "down" };
+    expect(classifyAgentError(network).kind).toBe("provider-down");
+  });
+
+  it("does NOT classify an unrelated object carrying a string kind as intervals", () => {
+    const result = classifyAgentError({ kind: "whatever" });
+    expect(result.kind).toBe("unknown");
+  });
+
+  it("classifies unknown / overflow / invalid_request as unknown with a single-line apology", () => {
+    const cases: unknown[] = [
+      new Error("???"),
+      new Error("maximum context length exceeded"),
+      apiError(400),
+    ];
+    for (const err of cases) {
+      const result = classifyAgentError(err);
+      expect(result.kind).toBe("unknown");
+      expect(result.athleteMessage).toBe("Sorry, something went wrong. Please try again.");
+      expect(result.athleteMessage).not.toContain("\n");
+    }
+  });
+
+  it("never leaks the raw error message or a stack trace into athleteMessage", () => {
+    const err = new Error("SENSITIVE provider payload at /secret/path");
+    const result = classifyAgentError(err);
+    expect(result.athleteMessage).not.toContain("SENSITIVE");
+    expect(result.athleteMessage).not.toContain("/secret/path");
+    expect(result.athleteMessage).not.toContain("Error:");
+  });
+});

--- a/packages/core/tests/run-binary.test.ts
+++ b/packages/core/tests/run-binary.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, rmSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { z } from "zod";
+import { APICallError } from "@ai-sdk/provider";
 import type {
   BinaryConfig,
   CoreDeps,
@@ -150,5 +151,53 @@ describe("runBinary CLI routing", () => {
     await expect(runBinary(stubRunningSport, stubRunningBinary)).rejects.toThrow("__exit_1");
 
     expect(errSpy.mock.calls.some((c) => String(c[0]).includes("Unknown command: bogus"))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatCliReply — shared classified copy for the CLI reply position
+// ---------------------------------------------------------------------------
+
+describe("formatCliReply", () => {
+  function apiError(statusCode: number, retryAfterSec?: number): APICallError {
+    return new APICallError({
+      message: "api error",
+      url: "https://example.invalid/api",
+      requestBodyValues: {},
+      statusCode,
+      responseHeaders:
+        retryAfterSec === undefined ? undefined : { "retry-after": String(retryAfterSec) },
+    });
+  }
+
+  it("on a 429 returns the friendly wait copy (no stack)", async () => {
+    const { formatCliReply } = await import("../src/run-binary.js");
+    const reply = formatCliReply(apiError(429, 30));
+    expect(reply).toBe("Rate limited — please try again in ~30 seconds.");
+    expect(reply).not.toContain("APICallError");
+    expect(reply).not.toContain("\n");
+  });
+
+  it("on a provider-auth error returns the provider-neutral one-liner (no payload)", async () => {
+    const { formatCliReply } = await import("../src/run-binary.js");
+    const reply = formatCliReply(apiError(401));
+    expect(reply).toBe("The model provider rejected the API key — check your provider credentials.");
+    expect(reply).not.toContain("Anthropic");
+    expect(reply).not.toContain("example.invalid");
+  });
+
+  it("on a provider-down error returns the one-line classified copy", async () => {
+    const { formatCliReply } = await import("../src/run-binary.js");
+    expect(formatCliReply(apiError(503))).toBe(
+      "The model provider is having trouble — try again in a few minutes.",
+    );
+  });
+
+  it("on an unknown error returns the single-line apology with no raw message", async () => {
+    const { formatCliReply } = await import("../src/run-binary.js");
+    const reply = formatCliReply(new Error("SENSITIVE provider payload at /secret/path"));
+    expect(reply).toBe("Sorry, something went wrong. Please try again.");
+    expect(reply).not.toContain("SENSITIVE");
+    expect(reply).not.toContain("/secret/path");
   });
 });

--- a/packages/core/tests/telegram-access.test.ts
+++ b/packages/core/tests/telegram-access.test.ts
@@ -378,4 +378,92 @@ describe("createAuthMiddleware — gating", () => {
     expect(errSpy).toHaveBeenCalledWith(expect.stringContaining("[security] middleware error"));
     errSpy.mockRestore();
   });
+
+  // ── AC8: next() runs OUTSIDE the auth guard ─────────────────────────────
+  it("AC8: a downstream next() throw propagates and is NOT logged as a security error", async () => {
+    saveAllowedSenders(dataDir, () => ({
+      ...defaultPairingState(),
+      dmPolicy: "allowlist",
+      allowFrom: ["12345"],
+      primaryOperator: "12345",
+    }));
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const mw = createAuthMiddleware({
+      dataDir,
+      binaryName: "cycling-coach",
+      challengeRateLimit: new Map(),
+      challengeMinIntervalMs: 60_000,
+    });
+    const ctx = makeMwCtx({ chatType: "private", fromId: 12345 });
+    const next = vi.fn(async () => {
+      throw new Error("downstream handler boom");
+    });
+    await expect(mw(ctx, next)).rejects.toThrow("downstream handler boom");
+    const securityLogs = errSpy.mock.calls.filter((c) =>
+      String(c[0]).includes("[security] middleware error"),
+    );
+    expect(securityLogs.length).toBe(0);
+    errSpy.mockRestore();
+  });
+
+  it("AC8: an allowlist-load throw is caught fail-closed (logged, no next(), no rethrow)", async () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    // A throwing challengeRateLimit.get forces a throw on the pairing path,
+    // exercising the guarded auth-logic catch (default-pairing dataDir).
+    const throwingMap = new Proxy(new Map<string, number>(), {
+      get(target, prop) {
+        if (prop === "get") {
+          return () => {
+            throw new Error("synthetic auth boom");
+          };
+        }
+        return Reflect.get(target, prop);
+      },
+    }) as Map<string, number>;
+    const mw = createAuthMiddleware({
+      dataDir,
+      binaryName: "cycling-coach",
+      challengeRateLimit: throwingMap,
+      challengeMinIntervalMs: 60_000,
+    });
+    const ctx = makeMwCtx({ chatType: "private", fromId: 99999 });
+    const next = vi.fn(async () => undefined);
+    await expect(mw(ctx, next)).resolves.toBeUndefined();
+    expect(next).not.toHaveBeenCalled();
+    expect(errSpy).toHaveBeenCalledWith(expect.stringContaining("[security] middleware error"));
+    errSpy.mockRestore();
+  });
+
+  it("AC8: a granted (allowlisted) sender runs next() exactly once", async () => {
+    saveAllowedSenders(dataDir, () => ({
+      ...defaultPairingState(),
+      dmPolicy: "allowlist",
+      allowFrom: ["12345"],
+      primaryOperator: "12345",
+    }));
+    const mw = createAuthMiddleware({
+      dataDir,
+      binaryName: "cycling-coach",
+      challengeRateLimit: new Map(),
+      challengeMinIntervalMs: 60_000,
+    });
+    const ctx = makeMwCtx({ chatType: "private", fromId: 12345 });
+    const next = vi.fn(async () => undefined);
+    await mw(ctx, next);
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it("AC8: a non-allowlisted pairing sender gets the challenge and next() is NOT called", async () => {
+    const mw = createAuthMiddleware({
+      dataDir,
+      binaryName: "cycling-coach",
+      challengeRateLimit: new Map(),
+      challengeMinIntervalMs: 60_000,
+    });
+    const ctx = makeMwCtx({ chatType: "private", fromId: 99999, fromFirstName: "Stranger" });
+    const next = vi.fn(async () => undefined);
+    await mw(ctx, next);
+    expect(ctx.reply).toHaveBeenCalledTimes(1);
+    expect(next).not.toHaveBeenCalled();
+  });
 });

--- a/packages/core/tests/telegram-access.test.ts
+++ b/packages/core/tests/telegram-access.test.ts
@@ -99,7 +99,7 @@ describe("evaluateAccess — allowlist matching", () => {
 });
 
 describe("buildPairingChallenge — HTML body", () => {
-  it("includes sender's user-ID, owner CLI command, and 'ask the bot owner' fallback (S5)", () => {
+  it("includes sender's user-ID, owner CLI command, and 'ask the bot owner' fallback", () => {
     const html = buildPairingChallenge("99999", "Stranger", "cycling-coach");
     expect(html).toContain("99999");
     expect(html).toContain("cycling-coach add-sender 99999");
@@ -221,7 +221,7 @@ describe("createAuthMiddleware — gating", () => {
     expect(ctx.reply).not.toHaveBeenCalled();
   });
 
-  it("rate-limit (H2): same sender messaging twice within window → only one reply", async () => {
+  it("rate-limit: same sender messaging twice within window → only one reply", async () => {
     const map = new Map<string, number>();
     const mw = createAuthMiddleware({
       dataDir,
@@ -379,8 +379,8 @@ describe("createAuthMiddleware — gating", () => {
     errSpy.mockRestore();
   });
 
-  // ── AC8: next() runs OUTSIDE the auth guard ─────────────────────────────
-  it("AC8: a downstream next() throw propagates and is NOT logged as a security error", async () => {
+  // ── next() runs OUTSIDE the auth guard ─────────────────────────────
+  it("a downstream next() throw propagates and is NOT logged as a security error", async () => {
     saveAllowedSenders(dataDir, () => ({
       ...defaultPairingState(),
       dmPolicy: "allowlist",
@@ -406,7 +406,7 @@ describe("createAuthMiddleware — gating", () => {
     errSpy.mockRestore();
   });
 
-  it("AC8: an allowlist-load throw is caught fail-closed (logged, no next(), no rethrow)", async () => {
+  it("an allowlist-load throw is caught fail-closed (logged, no next(), no rethrow)", async () => {
     const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     // A throwing challengeRateLimit.get forces a throw on the pairing path,
     // exercising the guarded auth-logic catch (default-pairing dataDir).
@@ -434,7 +434,7 @@ describe("createAuthMiddleware — gating", () => {
     errSpy.mockRestore();
   });
 
-  it("AC8: a granted (allowlisted) sender runs next() exactly once", async () => {
+  it("a granted (allowlisted) sender runs next() exactly once", async () => {
     saveAllowedSenders(dataDir, () => ({
       ...defaultPairingState(),
       dmPolicy: "allowlist",
@@ -453,7 +453,7 @@ describe("createAuthMiddleware — gating", () => {
     expect(next).toHaveBeenCalledTimes(1);
   });
 
-  it("AC8: a non-allowlisted pairing sender gets the challenge and next() is NOT called", async () => {
+  it("a non-allowlisted pairing sender gets the challenge and next() is NOT called", async () => {
     const mw = createAuthMiddleware({
       dataDir,
       binaryName: "cycling-coach",

--- a/packages/core/tests/telegram-bot.test.ts
+++ b/packages/core/tests/telegram-bot.test.ts
@@ -220,7 +220,13 @@ describe("createTelegramBot — startup diagnostic + no security broadcast", () 
     const use = vi.fn();
     const command = vi.fn();
     const on = vi.fn();
-    const bot = { api: { sendMessage, setMyCommands: vi.fn(async () => true) }, use, command, on };
+    const bot = {
+      api: { sendMessage, setMyCommands: vi.fn(async () => true), config: { use: vi.fn() } },
+      use,
+      command,
+      on,
+      catch: vi.fn(),
+    };
 
     vi.doMock("grammy", () => ({
       Bot: function FakeBot() {
@@ -265,10 +271,11 @@ describe("createTelegramBot — startup diagnostic + no security broadcast", () 
 
     const sendMessage = vi.fn(async () => undefined);
     const bot = {
-      api: { sendMessage, setMyCommands: vi.fn(async () => true) },
+      api: { sendMessage, setMyCommands: vi.fn(async () => true), config: { use: vi.fn() } },
       use: vi.fn(),
       command: vi.fn(),
       on: vi.fn(),
+      catch: vi.fn(),
     };
     vi.doMock("grammy", () => ({
       Bot: function FakeBot() {

--- a/packages/core/tests/telegram-dispatch.test.ts
+++ b/packages/core/tests/telegram-dispatch.test.ts
@@ -23,11 +23,16 @@ afterEach(() => {
 });
 
 interface FakeBot {
-  api: { sendMessage: ReturnType<typeof vi.fn>; setMyCommands: ReturnType<typeof vi.fn> };
+  api: {
+    sendMessage: ReturnType<typeof vi.fn>;
+    setMyCommands: ReturnType<typeof vi.fn>;
+    config: { use: ReturnType<typeof vi.fn> };
+  };
   use: ReturnType<typeof vi.fn>;
   command: ReturnType<typeof vi.fn>;
   on: ReturnType<typeof vi.fn>;
   stop: ReturnType<typeof vi.fn>;
+  catch: ReturnType<typeof vi.fn>;
 }
 
 interface StubAgent {
@@ -57,11 +62,13 @@ async function buildBot(opts?: {
     api: {
       sendMessage: vi.fn(async () => undefined),
       setMyCommands: vi.fn(opts?.setMyCommands ?? (async () => true)),
+      config: { use: vi.fn() },
     },
     use: vi.fn(),
     command: vi.fn(),
     on: vi.fn(),
     stop: vi.fn(opts?.stop ?? (async () => undefined)),
+    catch: vi.fn(),
   };
   vi.doMock("grammy", () => ({
     Bot: function FakeBot() {
@@ -102,10 +109,16 @@ function getMessageText(bot: FakeBot) {
   return call[1] as (ctx: unknown) => Promise<void>;
 }
 
+function getBotCatch(bot: FakeBot) {
+  const call = bot.catch.mock.calls[0];
+  if (!call) throw new Error("bot.catch handler not registered");
+  return call[0] as (botError: { error: unknown; ctx?: unknown }) => Promise<void>;
+}
+
 interface FakeCtx {
   chat: { id: number };
   match: string;
-  message: { text: string };
+  message: { text: string; message_id?: number };
   reply: ReturnType<typeof vi.fn>;
   replyWithDocument: ReturnType<typeof vi.fn>;
 }
@@ -132,6 +145,15 @@ function rateLimitError(retryAfterSec?: number): unknown {
     });
   }
   return new Error("rate limit");
+}
+
+function apiError(statusCode: number): unknown {
+  return new APICallError({
+    message: "api error",
+    url: "https://example.invalid/api",
+    requestBodyValues: {},
+    statusCode,
+  });
 }
 
 function replyTexts(ctx: FakeCtx): string[] {
@@ -269,15 +291,15 @@ describe("message:text — apology vs rate-limit fork", () => {
     expect(ctx.reply.mock.calls.length).toBeGreaterThanOrEqual(1);
   });
 
-  it("rate-limit with retry-after header → precise wait echoing the user text", async () => {
+  it("rate-limit with retry-after header → classified wait copy, no stale 'not processed' line", async () => {
     const { bot, agent, drainPending } = await buildBot();
     agent.hasSession.mockReturnValue(true);
     agent.chat.mockRejectedValue(rateLimitError(45));
     const ctx = makeCtx({ message: { text: "plan my week" } });
     await getMessageText(bot)(ctx);
     await drainPending();
-    expect(someReply(ctx, "Please wait ~45 seconds and resend:")).toBe(true);
-    expect(someReply(ctx, "plan my week")).toBe(true);
+    expect(someReply(ctx, "Rate limited — please try again in ~45 seconds.")).toBe(true);
+    expect(someReply(ctx, "was not processed")).toBe(false);
   });
 
   it("rate-limit without header → default 'about a minute' wait", async () => {
@@ -288,6 +310,141 @@ describe("message:text — apology vs rate-limit fork", () => {
     await getMessageText(bot)(ctx);
     await drainPending();
     expect(someReply(ctx, "about a minute")).toBe(true);
+  });
+});
+
+describe("G1 — retry transformer / classified errors / delivery split", () => {
+  it("createSecuredBot installs the auto-retry transformer exactly once", async () => {
+    const { bot } = await buildBot();
+    expect(bot.api.config.use).toHaveBeenCalledTimes(1);
+  });
+
+  it("generation provider-auth error → provider-auth copy (NOT delivery copy, NOT genericReply)", async () => {
+    const { bot, agent, drainPending } = await buildBot();
+    agent.chat.mockRejectedValue(apiError(401));
+    const ctx = makeCtx();
+    await getCommand(bot, "plan")(ctx);
+    await drainPending();
+    expect(
+      someReply(ctx, "The model provider rejected the API key — check your provider credentials."),
+    ).toBe(true);
+    expect(someReply(ctx, "Telegram had trouble delivering")).toBe(false);
+    expect(someReply(ctx, "Sorry, something went wrong generating your plan")).toBe(false);
+  });
+
+  it("generation unknown-kind error → caller genericReply (fallback only on unknown)", async () => {
+    const { bot, agent, drainPending } = await buildBot();
+    agent.chat.mockRejectedValue(new Error("???"));
+    const ctx = makeCtx();
+    await getCommand(bot, "plan")(ctx);
+    await drainPending();
+    expect(someReply(ctx, "Sorry, something went wrong generating your plan. Please try again.")).toBe(
+      true,
+    );
+  });
+
+  it("generation succeeds but delivery rejects (non-parse) → D1 delivery copy AND the answer is resendable", async () => {
+    const { bot, agent, drainPending } = await buildBot();
+    agent.hasSession.mockReturnValue(true);
+    agent.chat.mockResolvedValue("the generated answer");
+    const ctx = makeCtx({ message: { text: "how's my form?" } });
+    ctx.reply.mockImplementation(async (_text: string, options?: Record<string, unknown>) => {
+      if (options?.parse_mode === "HTML") {
+        throw new Error("Call to 'sendMessage' failed! (403: Forbidden: bot was blocked by the user)");
+      }
+      return undefined;
+    });
+    await getMessageText(bot)(ctx);
+    await drainPending();
+    expect(someReply(ctx, "I generated the answer, but Telegram had trouble delivering it.")).toBe(true);
+
+    // The resend cache was written before delivery, so a follow-up resend re-emits it.
+    const ctx2 = makeCtx({ message: { text: "resend" } });
+    await getMessageText(bot)(ctx2);
+    await drainPending();
+    expect(someReply(ctx2, "the generated answer")).toBe(true);
+  });
+
+  it("after a successful turn, 'resend' (and '  RESEND  ') re-emit the same answer without re-running agent.chat", async () => {
+    const { bot, agent, drainPending } = await buildBot();
+    agent.hasSession.mockReturnValue(true);
+    agent.chat.mockResolvedValue("cached answer body");
+    const handler = getMessageText(bot);
+
+    await handler(makeCtx({ message: { text: "how's my form?" } }));
+    await drainPending();
+
+    const ctx2 = makeCtx({ message: { text: "resend" } });
+    await handler(ctx2);
+    await drainPending();
+    expect(someReply(ctx2, "cached answer body")).toBe(true);
+
+    const ctx3 = makeCtx({ message: { text: "  RESEND  " } });
+    await handler(ctx3);
+    await drainPending();
+    expect(someReply(ctx3, "cached answer body")).toBe(true);
+
+    expect(agent.chat).toHaveBeenCalledTimes(1);
+  });
+
+  it("'resend' with no cached answer → guidance reply and NO agent.chat", async () => {
+    const { bot, agent } = await buildBot();
+    agent.hasSession.mockReturnValue(true);
+    const ctx = makeCtx({ message: { text: "resend" } });
+    await getMessageText(bot)(ctx);
+    expect(someReply(ctx, "I don't have a recent answer to resend.")).toBe(true);
+    expect(agent.chat).not.toHaveBeenCalled();
+  });
+
+  it("threads the first delivered chunk to ctx.message.message_id; later chunks are unthreaded", async () => {
+    const { bot, agent, drainPending } = await buildBot();
+    agent.hasSession.mockReturnValue(true);
+    agent.chat.mockResolvedValue("x".repeat(9000));
+    const ctx = makeCtx({ message: { text: "long please", message_id: 4242 } });
+    await getMessageText(bot)(ctx);
+    await drainPending();
+    const htmlCalls = ctx.reply.mock.calls.filter(
+      (c: unknown[]) => (c[1] as { parse_mode?: string } | undefined)?.parse_mode === "HTML",
+    );
+    expect(htmlCalls.length).toBeGreaterThan(1);
+    expect((htmlCalls[0][1] as { reply_parameters?: unknown }).reply_parameters).toEqual({
+      message_id: 4242,
+      allow_sending_without_reply: true,
+    });
+    for (const c of htmlCalls.slice(1)) {
+      expect((c[1] as { reply_parameters?: unknown }).reply_parameters).toBeUndefined();
+    }
+  });
+
+  it("the stale 'was not processed (rate limited)… resend:' copy never appears", async () => {
+    const { bot, agent, drainPending } = await buildBot();
+    agent.hasSession.mockReturnValue(true);
+    agent.chat.mockRejectedValue(rateLimitError(30));
+    const ctx = makeCtx({ message: { text: "plan my week" } });
+    await getMessageText(bot)(ctx);
+    await drainPending();
+    expect(replyTexts(ctx).some((t) => t.includes("was not processed"))).toBe(false);
+    expect(replyTexts(ctx).some((t) => t.includes("and resend:"))).toBe(false);
+  });
+
+  it("the captured bot.catch handler replies classified copy; a reply throw does not escape", async () => {
+    const { bot } = await buildBot();
+    const handler = getBotCatch(bot);
+
+    const reply = vi.fn(async () => undefined);
+    await expect(
+      handler({ error: apiError(401), ctx: { chat: { id: 1 }, reply } }),
+    ).resolves.toBeUndefined();
+    expect(reply).toHaveBeenCalledWith(
+      "The model provider rejected the API key — check your provider credentials.",
+    );
+
+    const throwingReply = vi.fn(async () => {
+      throw new Error("cannot reply");
+    });
+    await expect(
+      handler({ error: new Error("boom"), ctx: { chat: { id: 1 }, reply: throwingReply } }),
+    ).resolves.toBeUndefined();
   });
 });
 

--- a/packages/core/tests/telegram-dispatch.test.ts
+++ b/packages/core/tests/telegram-dispatch.test.ts
@@ -313,7 +313,7 @@ describe("message:text — apology vs rate-limit fork", () => {
   });
 });
 
-describe("G1 — retry transformer / classified errors / delivery split", () => {
+describe("retry transformer / classified errors / delivery split", () => {
   it("createSecuredBot installs the auto-retry transformer exactly once", async () => {
     const { bot } = await buildBot();
     expect(bot.api.config.use).toHaveBeenCalledTimes(1);
@@ -343,7 +343,7 @@ describe("G1 — retry transformer / classified errors / delivery split", () => 
     );
   });
 
-  it("generation succeeds but delivery rejects (non-parse) → D1 delivery copy AND the answer is resendable", async () => {
+  it("generation succeeds but delivery rejects (non-parse) → delivery copy AND the answer is resendable", async () => {
     const { bot, agent, drainPending } = await buildBot();
     agent.hasSession.mockReturnValue(true);
     agent.chat.mockResolvedValue("the generated answer");
@@ -427,7 +427,7 @@ describe("G1 — retry transformer / classified errors / delivery split", () => 
     expect(replyTexts(ctx).some((t) => t.includes("and resend:"))).toBe(false);
   });
 
-  it("the captured bot.catch handler replies classified copy; a reply throw does not escape", async () => {
+  it("the captured bot.catch handler replies a neutral apology; a reply throw does not escape", async () => {
     const { bot } = await buildBot();
     const handler = getBotCatch(bot);
 
@@ -435,9 +435,7 @@ describe("G1 — retry transformer / classified errors / delivery split", () => 
     await expect(
       handler({ error: apiError(401), ctx: { chat: { id: 1 }, reply } }),
     ).resolves.toBeUndefined();
-    expect(reply).toHaveBeenCalledWith(
-      "The model provider rejected the API key — check your provider credentials.",
-    );
+    expect(reply).toHaveBeenCalledWith("Sorry, something went wrong. Please try again.");
 
     const throwingReply = vi.fn(async () => {
       throw new Error("cannot reply");

--- a/packages/core/tests/telegram-nonblocking.test.ts
+++ b/packages/core/tests/telegram-nonblocking.test.ts
@@ -20,11 +20,16 @@ afterEach(() => {
 });
 
 interface FakeBot {
-  api: { sendMessage: ReturnType<typeof vi.fn>; setMyCommands: ReturnType<typeof vi.fn> };
+  api: {
+    sendMessage: ReturnType<typeof vi.fn>;
+    setMyCommands: ReturnType<typeof vi.fn>;
+    config: { use: ReturnType<typeof vi.fn> };
+  };
   use: ReturnType<typeof vi.fn>;
   command: ReturnType<typeof vi.fn>;
   on: ReturnType<typeof vi.fn>;
   stop: ReturnType<typeof vi.fn>;
+  catch: ReturnType<typeof vi.fn>;
 }
 
 interface StubAgent {
@@ -49,11 +54,13 @@ async function buildBot(opts?: { reference?: StubReference }): Promise<BuildBotR
     api: {
       sendMessage: vi.fn(async () => undefined),
       setMyCommands: vi.fn(async () => true),
+      config: { use: vi.fn() },
     },
     use: vi.fn(),
     command: vi.fn(),
     on: vi.fn(),
     stop: vi.fn(async () => undefined),
+    catch: vi.fn(),
   };
   vi.doMock("grammy", () => ({
     Bot: function FakeBot() {

--- a/packages/core/tests/telegram-start-reset-failure.test.ts
+++ b/packages/core/tests/telegram-start-reset-failure.test.ts
@@ -26,10 +26,11 @@ const RESET_CAVEAT =
 
 async function buildStartHandler(resetSession: ReturnType<typeof vi.fn>) {
   const bot = {
-    api: { sendMessage: vi.fn(), setMyCommands: vi.fn(async () => true) },
+    api: { sendMessage: vi.fn(), setMyCommands: vi.fn(async () => true), config: { use: vi.fn() } },
     use: vi.fn(),
     command: vi.fn(),
     on: vi.fn(),
+    catch: vi.fn(),
   };
   vi.doMock("grammy", () => ({
     Bot: function FakeBot() {

--- a/packages/core/tests/token-utils.test.ts
+++ b/packages/core/tests/token-utils.test.ts
@@ -8,6 +8,7 @@ import {
   computeHistoryTokenBudget,
   shouldCompact,
   classifyFailure,
+  formatRateLimitWait,
 } from "../src/agent/token-utils.js";
 
 function apiError(statusCode: number): APICallError {
@@ -16,6 +17,16 @@ function apiError(statusCode: number): APICallError {
     url: "https://example.test",
     requestBodyValues: {},
     statusCode,
+  });
+}
+
+function rateLimitError(retryAfterSeconds: number): APICallError {
+  return new APICallError({
+    message: "rate limited",
+    url: "https://example.test",
+    requestBodyValues: {},
+    statusCode: 429,
+    responseHeaders: { "retry-after": String(retryAfterSeconds) },
   });
 }
 
@@ -120,6 +131,26 @@ describe("classifyFailure", () => {
 
   it("classifies an unmatched error as unknown", () => {
     expect(classifyFailure(new Error("???"))).toBe("unknown");
+  });
+});
+
+describe("formatRateLimitWait", () => {
+  it("returns 'about a minute' when no retry-after header is present", () => {
+    expect(formatRateLimitWait(new Error("rate limited"))).toBe("about a minute");
+    expect(formatRateLimitWait(apiError(429))).toBe("about a minute");
+  });
+
+  it("returns '~Ns' for a sub-minute retry-after", () => {
+    expect(formatRateLimitWait(rateLimitError(30))).toBe("~30 seconds");
+  });
+
+  it("returns '~N minute(s)' for a >=60s retry-after", () => {
+    expect(formatRateLimitWait(rateLimitError(90))).toBe("~2 minutes");
+    expect(formatRateLimitWait(rateLimitError(60))).toBe("~1 minute");
+  });
+
+  it("is importable from token-utils.js", () => {
+    expect(typeof formatRateLimitWait).toBe("function");
   });
 });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,6 +83,9 @@ importers:
       '@clack/prompts':
         specifier: ^1.2.0
         version: 1.3.0
+      '@grammyjs/auto-retry':
+        specifier: ^2.0.2
+        version: 2.0.2(grammy@1.42.0)
       '@openrouter/ai-sdk-provider':
         specifier: ^2.9.1
         version: 2.9.1(ai@6.0.170(zod@4.4.1))(zod@4.4.1)
@@ -614,6 +617,12 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@grammyjs/auto-retry@2.0.2':
+    resolution: {integrity: sha512-b4A4p5jlYDiQtW0c0FXYe11WMkYoiW+5rvOaDMCOk1h7Pu2SDl7B7gmFF8cthWCx2+M2nWLOsBxAgbBG4kKWYg==}
+    engines: {node: '>=12.20.0 || >=14.13.1'}
+    peerDependencies:
+      grammy: ^1.10.0
 
   '@grammyjs/types@3.26.0':
     resolution: {integrity: sha512-jlnyfxfev/2o68HlvAGRocAXgdPPX5QabG7jZlbqC2r9DZyWBfzTlg+nu3O3Fy4EhgLWu28hZ/8wr7DsNamP9A==}
@@ -2588,6 +2597,13 @@ snapshots:
 
   '@esbuild/win32-x64@0.27.7':
     optional: true
+
+  '@grammyjs/auto-retry@2.0.2(grammy@1.42.0)':
+    dependencies:
+      debug: 4.4.3
+      grammy: 1.42.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@grammyjs/types@3.26.0': {}
 


### PR DESCRIPTION
## Batch 9 · G1 — Delivery resilience + shared error copy

Folds tickets **041**, **042**, **048**. All about how the chat surface behaves when something fails *after* or *around* generating a reply.

### What changed
- **Generation vs delivery split** (`runTurn`): `agent.chat` and `sendLongMessage` now sit in separate `try` blocks. A post-generation Telegram delivery failure shows delivery copy ("I generated the answer, but Telegram had trouble delivering it…") instead of generation copy, and vice versa.
- **Bounded API-level retry** (`@grammyjs/auto-retry`, `maxRetryAttempts: 1`): restricted to a Telegram 429 carrying `retry_after`. `rethrowInternalServerErrors` + `rethrowHttpErrors` are set so arbitrary 5xx / network errors are **not** retried — that avoids a duplicate send when the original request may already have landed server-side.
- **Resend cache**: process-local per-chat cache (30-min TTL, ~1000-entry bound, never logged). Sending `resend` re-emits the last answer **without** re-running the model.
- **Reply threading**: final replies thread to the inbound message (`reply_parameters` on the first chunk only, `allow_sending_without_reply: true`).
- **Auth boundary** (`telegram-access.ts`): `await next()` moved **outside** the guarded `try`, gated on the grant decision — downstream handler errors propagate instead of being mislabeled `[security] middleware error`. The granted path is the only path that calls `next()` (fail-closed preserved).
- **`bot.catch`**: last-resort handler for synchronous ack/handler reply failures (dispatched-turn errors are already handled by the Batch-8 dispatch wrapper); its own reply attempt is guarded.
- **Shared classifier** (`error-classify.ts`): one pure `classifyAgentError(err) → { kind, athleteMessage }` consumed by both the Telegram channel and the CLI. Provider-auth copy is provider-neutral (seven providers ship). The CLI now writes classified copy to **stdout** and keeps raw error detail on **stderr** only.

### Notable correction during build
The spec assumed `auto-retry` only retries `429+retry_after` by default; the installed `auto-retry@2.0.2` actually retries 5xx by default. A verify pass caught this (AC2 double-send risk) and the fix sets the two rethrow flags. No other findings survived re-verification.

### Tests / gate
- New: `error-classify.test.ts`; expanded `token-utils`, `telegram-dispatch`, `telegram-access`, `run-binary` test files (+ FakeBot `api.config.use`/`catch` shims in three more telegram test files).
- `pnpm check` green (build · typecheck · oxlint 0/0 · trademarks · fixture-privacy · registry-isolation · changeset).
- Full core suite: **2471 passed / 2 skipped**.

### Scope guard (AC13)
No durable resend store, no update-offset store, no `CoachAgent.chat` persistence change, no remote logging/telemetry — those belong to later Batch 9 groups.

https://claude.ai/code/session_01DqCsUjhtfMiTtnH4CyySZM
