### PR TITLE
fix(core): raise LLM call deadlines and turn wall-clock

### DIFF
--- a/.changeset/raise-llm-deadlines.md
+++ b/.changeset/raise-llm-deadlines.md
@@ -1,0 +1,7 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Coach replies now get more time to finish on complex requests before timing out.
+
+Raise the owned model-call deadlines and the per-turn wall-clock so a legitimately-slow reasoning turn is not cut off prematurely: flush/compact 3->5 min, chat 5->10 min, per-turn wall-clock 5->10 min. The chat per-call deadline is clipped by the turn's remaining wall-clock budget, so raising the chat cap is only effective alongside the matching wall-clock raise.

--- a/packages/core/src/agent/turn-budget.ts
+++ b/packages/core/src/agent/turn-budget.ts
@@ -1,6 +1,6 @@
 export const MAX_TURN_MODEL_CALLS = 40;
 export const MAX_TURN_GENERATE_ATTEMPTS = 4;
-export const TURN_WALL_CLOCK_MS = 5 * 60_000;
+export const TURN_WALL_CLOCK_MS = 10 * 60_000;
 
 export type BudgetExceededKind = "model_calls" | "generate_attempts" | "wall_clock";
 

--- a/packages/core/src/llm.ts
+++ b/packages/core/src/llm.ts
@@ -17,8 +17,8 @@ import type { GenerateOpts, GenerateResult } from "./llm-types.js";
 import { appendUsageLine, cacheTokenDetails, usageFieldsFromResult } from "./usage-ledger.js";
 
 export type { GenerateOpts, GenerateResult } from "./llm-types.js";
-export const LLM_CALL_DEADLINE_MS = 180_000;
-export const CHAT_LLM_CALL_DEADLINE_MS = 300_000;
+export const LLM_CALL_DEADLINE_MS = 300_000;
+export const CHAT_LLM_CALL_DEADLINE_MS = 600_000;
 
 // ============================================================================
 // LLM DISPATCH

--- a/packages/core/tests/turn-budget.test.ts
+++ b/packages/core/tests/turn-budget.test.ts
@@ -192,8 +192,9 @@ describe("per-turn budget through chat() (behavioral)", () => {
 
   it("a retry after an early timeout gets only the budget left, capping total chat time", async () => {
     // Each chat generate mints its per-call deadline from the turn's remaining
-    // wall-clock budget. A timeout 100s into the 300s turn must leave the retry
-    // only ~200s — not a fresh full window (the ~600s double-window bug).
+    // wall-clock budget. A timeout 100s into the 600s turn must leave the retry
+    // only ~500s — not a fresh full window (which would let a turn run ~1200s,
+    // the double-window bug).
     let clock = 0;
     const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => clock);
     const deadlines: number[] = [];
@@ -234,7 +235,7 @@ describe("per-turn budget through chat() (behavioral)", () => {
 
   it("a between-attempts wall-clock overrun stops with a wall_clock error and lets the in-flight call complete", async () => {
     // Inject a clock that stays at turnStart through the first attempt and jumps
-    // past the 5-minute deadline once the first attempt's generate has thrown
+    // past the 10-minute deadline once the first attempt's generate has thrown
     // (a rate-limit error the loop would normally retry). The first attempt's
     // generate runs to completion (its throw is observed), proving the deadline
     // never aborted the in-flight call; the between-attempts check then stops it.


### PR DESCRIPTION
## Summary

Follow-up tuning to #281: raises the owned LLM call deadlines and the per-turn wall-clock so a legitimately-slow reasoning turn isn't cut off prematurely.

- `LLM_CALL_DEADLINE_MS` (flush/compact): 180s → 300s
- `CHAT_LLM_CALL_DEADLINE_MS` (chat): 300s → 600s
- `TURN_WALL_CLOCK_MS`: 5 min → 10 min

`CHAT_LLM_CALL_DEADLINE_MS` is clipped by `turnBudget.remainingMs()` (bounded by `TURN_WALL_CLOCK_MS`), so the chat raise is only effective alongside the matching wall-clock raise — both are raised together here.

## Tests

- `corepack pnpm vitest run packages/core` — 2439 passed / 3 skipped / 0 failed
- `packages/core` typecheck (`tsc --noEmit`) — clean
