### PR TITLE
docs(core): note CHAT_LLM_CALL_DEADLINE_MS lockstep with turn wall-clock

### DIFF
--- a/packages/core/src/llm.ts
+++ b/packages/core/src/llm.ts
@@ -18,6 +18,8 @@ import { appendUsageLine, cacheTokenDetails, usageFieldsFromResult } from "./usa
 
 export type { GenerateOpts, GenerateResult } from "./llm-types.js";
 export const LLM_CALL_DEADLINE_MS = 300_000;
+// Chat calls clip this by the turn's remaining wall-clock (TURN_WALL_CLOCK_MS
+// in ./agent/turn-budget.ts), so any value above it never binds — keep <= it.
 export const CHAT_LLM_CALL_DEADLINE_MS = 600_000;
 
 // ============================================================================


### PR DESCRIPTION
## What

Adds a two-line invariant comment above `CHAT_LLM_CALL_DEADLINE_MS` in `packages/core/src/llm.ts`. Comment-only — no behavior change.

```ts
export const LLM_CALL_DEADLINE_MS = 300_000;
// Chat calls clip this by the turn's remaining wall-clock (TURN_WALL_CLOCK_MS
// in ./agent/turn-budget.ts), so any value above it never binds — keep <= it.
export const CHAT_LLM_CALL_DEADLINE_MS = 600_000;
```

## Why

Follow-up cleanup surfaced by a `/simplify` pass over #286. After that change, `CHAT_LLM_CALL_DEADLINE_MS` (600k) exactly equals `TURN_WALL_CLOCK_MS` (10 × 60k) and is silently coupled to it: every chat call's effective deadline is `min(CHAT_LLM_CALL_DEADLINE_MS, turnBudget.remainingMs())`, and `remainingMs()` is always `<= TURN_WALL_CLOCK_MS`. So the chat cap only binds while `CHAT_LLM_CALL_DEADLINE_MS <= TURN_WALL_CLOCK_MS` — raise it above the wall-clock and the bump is inert; drop the wall-clock below it and chat is silently shortened.

That invariant previously lived only in #286's commit message and changeset body (the changeset is consumed/deleted at the next version-bump), leaving no in-code record for a future maintainer editing either constant.

Deliberately a cross-reference comment, not a code coupling: importing `TURN_WALL_CLOCK_MS` into `llm.ts` (to derive or assert) would add a wrong-direction dependency edge from LLM dispatch into the agent turn-budget for a rarely-changing constants pair.

## Test plan

No behavior change (comment only). Mechanism verified by reading the dispatch site (`llm.ts` `generate()` `Math.min` clip), both chat call sites in `coach-agent.ts`, and `remainingMs()` in `agent/turn-budget.ts`.