### PR TITLE
feat(core): route update checks through ping endpoint and re-check daily

### DIFF
--- a/.changeset/version-ping-telemetry.md
+++ b/.changeset/version-ping-telemetry.md
@@ -1,0 +1,7 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Long-running deployments now check for updates daily, not only at restart.
+
+Route the existing startup version check through an update endpoint that returns the latest published version and records an anonymous per-instance count. A daily re-check runs alongside the startup check so long-running deployments learn about new releases without a restart; both automatic checks respect `CYCLING_COACH_NO_UPDATE_CHECK`. Dev/test and any endpoint outage fall back to `registry.npmjs.org`, so update checks and notifications keep working.

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules/
 .pnpm-store/
 dist/
 docs/
+workers/
 .env
 *.tgz
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -125,9 +125,13 @@ Free-form chat works too — ask anything about training, report an injury, requ
 
 Cycling Coach restricts Telegram interactions to a configured allowlist of user IDs. Only senders in `~/.cycling-coach/allowed-senders.json` (or set via the `CYCLING_COACH_OPERATOR_ID` env var, single ID) can interact with the bot. Random Telegram users who discover your bot's username are dropped at the middleware layer.
 
-### No telemetry, one update check
+### Update checks & usage counting
 
-Cycling Coach collects no analytics and sends no telemetry. The one background network call it makes on its own: on Telegram-mode startup, a single HTTPS request to `registry.npmjs.org` to check whether a newer version exists. It carries no athlete data and no credentials — the only thing disclosed is the request itself. Set `CYCLING_COACH_NO_UPDATE_CHECK=1` to disable it. The operator-initiated `/update` and `/whatsnew` commands still reach the registry (and, for `/whatsnew`, the GitHub Releases API for release notes) — those are explicit requests, not background checks. In managed container deploys, `/update` does not run npm; image hosts update by redeploying the container image.
+To check whether a newer version exists, Cycling Coach makes one background HTTPS request to `ping.enduragent.icu`. That endpoint returns the latest published version (the same answer `registry.npmjs.org` gives) and records an anonymous usage count so the project can see roughly how many instances are running across install channels. The count contains no personal information.
+
+The check runs on Telegram-mode startup and again every 24 hours (so a long-running deployment learns about new releases without a restart). The same request powers the "update available" notification and the `/whatsnew` and `/update` commands. In development and test the bot talks to `registry.npmjs.org` directly instead; if the `ping.enduragent.icu` endpoint is ever unreachable, the bot silently falls back to `registry.npmjs.org`, so update checks keep working either way.
+
+Set `CYCLING_COACH_NO_UPDATE_CHECK=1` to disable the automatic background checks (both the startup check and the daily re-check). The operator-initiated `/update` and `/whatsnew` commands still query the endpoint — those are explicit requests, not background checks (and `/whatsnew` also reaches the GitHub Releases API for release notes). In managed container deploys, `/update` does not run npm; image hosts update by redeploying the container image.
 
 ### First-time setup
 

--- a/packages/core/src/channels/telegram.ts
+++ b/packages/core/src/channels/telegram.ts
@@ -352,7 +352,7 @@ export function createTelegramBot(
   bot.command("whatsnew", async (ctx) => {
     await ctx.reply("Fetching release notes...");
     try {
-      const info = await checkForUpdate(binary.binaryName);
+      const info = await checkForUpdate(binary.binaryName, dataDir);
       if (!info) {
         await ctx.reply("Couldn't reach npm to check the latest version. Try again later.");
         return;
@@ -374,7 +374,7 @@ export function createTelegramBot(
     await ctx.reply("Checking for updates...");
     let latest: string | undefined;
     try {
-      const info = await checkForUpdate(binary.binaryName);
+      const info = await checkForUpdate(binary.binaryName, dataDir);
       if (!info) {
         await ctx.reply("Could not check for updates. Try again later.");
         return;
@@ -806,7 +806,7 @@ function htmlChunkToPlainText(chunk: string): string {
 
 export async function notifyUpdate(bot: Bot, dataDir: string, binary: BinaryConfig): Promise<void> {
   try {
-    const info = await checkForUpdate(binary.binaryName);
+    const info = await checkForUpdate(binary.binaryName, dataDir);
     if (!info?.updateAvailable) return;
 
     if (getLastNotifiedVersion(dataDir) === info.latest) return;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -213,8 +213,10 @@ export type { Config } from "./config.js";
 
 // ─── Updater ──────────────────────────────────────────────────────────
 export {
+  buildCheckUrl,
   checkForUpdate,
   getCurrentVersion,
+  getInstanceId,
   getKnownTelegramChatIds,
   getLastNotifiedVersion,
   isManagedDeploy,

--- a/packages/core/src/run-binary.ts
+++ b/packages/core/src/run-binary.ts
@@ -417,6 +417,12 @@ export async function runBinary(
 
     if (!process.env.CYCLING_COACH_NO_UPDATE_CHECK) {
       notifyUpdate(bot, config.dataDir, binary).catch(() => {});
+      // A long-running deployment would otherwise never learn about a new
+      // release until it restarts; notifyUpdate dedupes per version so the
+      // re-check broadcasts at most once per release. unref() so the timer
+      // never holds the process open.
+      const DAY_MS = 24 * 60 * 60 * 1000;
+      setInterval(() => void notifyUpdate(bot, config.dataDir, binary), DAY_MS).unref?.();
     }
   } else {
     console.log(`${binary.displayName} (CLI mode). Type your message:`);

--- a/packages/core/src/updater.ts
+++ b/packages/core/src/updater.ts
@@ -1,5 +1,6 @@
 import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { execSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import { createRequire } from "node:module";
 import { join } from "node:path";
 import { enumerateTelegramSessions } from "./channels/telegram-sessions.js";
@@ -90,20 +91,73 @@ export function getCurrentVersion(binaryName: string): string {
 }
 
 const NPM_REGISTRY = "https://registry.npmjs.org";
+const PING_ENDPOINT = "https://ping.enduragent.icu/v1/check";
+const INSTANCE_ID_FILE = "instance-id";
 
-export async function checkForUpdate(binaryName: string): Promise<UpdateInfo | null> {
+function isDevOrTest(): boolean {
+  return process.env.NODE_ENV === "development" || process.env.NODE_ENV === "test";
+}
+
+/** Random anonymous ID, created once and persisted in the data dir. */
+export function getInstanceId(dataDir: string): string {
+  const path = join(dataDir, INSTANCE_ID_FILE);
   try {
-    const res = await fetch(`${NPM_REGISTRY}/${binaryName}/latest`, {
-      signal: AbortSignal.timeout(5000),
-    });
+    const existing = readFileSync(path, "utf-8").trim();
+    if (/^[0-9a-f-]{36}$/.test(existing)) return existing;
+  } catch {
+    // fall through — create it
+  }
+  const id = randomUUID();
+  try {
+    mkdirSync(dataDir, { recursive: true });
+    writeFileSync(path, id);
+  } catch {
+    // Non-critical — an unpersisted ID still identifies this process run
+  }
+  return id;
+}
+
+export function buildCheckUrl(binaryName: string, dataDir?: string): string {
+  if (isDevOrTest()) return `${NPM_REGISTRY}/${binaryName}/latest`;
+  const params = new URLSearchParams({
+    bin: binaryName,
+    version: getCurrentVersion(binaryName),
+    channel: isManagedDeploy() ? "docker" : "npm",
+  });
+  if (dataDir) params.set("instance", getInstanceId(dataDir));
+  return `${PING_ENDPOINT}?${params}`;
+}
+
+export async function checkForUpdate(
+  binaryName: string,
+  dataDir?: string,
+): Promise<UpdateInfo | null> {
+  const current = getCurrentVersion(binaryName);
+  const parse = async (res: Response): Promise<UpdateInfo | null> => {
     if (!res.ok) return null;
     const data = (await res.json()) as { version: string };
-    const current = getCurrentVersion(binaryName);
     return {
       current,
       latest: data.version,
       updateAvailable: isUpdateAvailable(data.version, current),
     };
+  };
+  try {
+    const res = await fetch(buildCheckUrl(binaryName, dataDir), {
+      signal: AbortSignal.timeout(5000),
+    });
+    const info = await parse(res);
+    if (info) return info;
+  } catch {
+    // fall through to npm fallback
+  }
+  // In dev/test the primary request WAS npm — don't retry the same host.
+  if (isDevOrTest()) return null;
+  try {
+    const res = await fetch(`${NPM_REGISTRY}/${binaryName}/latest`, {
+      signal: AbortSignal.timeout(5000),
+    });
+    return await parse(res);
   } catch {
     return null;
   }

--- a/packages/core/tests/telegram-bot.test.ts
+++ b/packages/core/tests/telegram-bot.test.ts
@@ -88,6 +88,48 @@ describe("notifyUpdate — broadcast filtering (L3)", () => {
     expect(calledIds).not.toContain("99999");
   });
 
+  // The daily re-check calls notifyUpdate on a timer; the last-notified-version
+  // guard must make a second firing for the same version a no-op so athletes get
+  // at most one broadcast per release.
+  it("does not re-broadcast an already-notified version on a second firing (idempotent)", async () => {
+    seedSession("11111");
+    saveAllowedSenders(dataDir, () => ({
+      ...defaultPairingState(),
+      dmPolicy: "allowlist",
+      allowFrom: ["11111"],
+      primaryOperator: "11111",
+    }));
+
+    // Keep the REAL getLastNotifiedVersion / setLastNotifiedVersion so the
+    // guard actually persists to (and reads back from) the temp data dir.
+    vi.doMock("../src/updater.js", async () => {
+      const real = await vi.importActual<typeof import("../src/updater.js")>(
+        "../src/updater.js",
+      );
+      return {
+        ...real,
+        checkForUpdate: vi.fn(async () => ({
+          current: "2026.5.5",
+          latest: "2026.5.10",
+          updateAvailable: true,
+        })),
+        getKnownTelegramChatIds: vi.fn(() => ["11111"]),
+      };
+    });
+
+    const sendMessage = vi.fn(async (_chatId: string, _message: string) => undefined);
+    const fakeBot = { api: { sendMessage } } as unknown as Parameters<
+      typeof import("../src/channels/telegram.js")["notifyUpdate"]
+    >[0];
+
+    const { notifyUpdate } = await import("../src/channels/telegram.js");
+    await notifyUpdate(fakeBot, dataDir, cyclingBinary);
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+
+    await notifyUpdate(fakeBot, dataDir, cyclingBinary);
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+  });
+
   it("broadcasts to all known chats when CYCLING_COACH_DM_POLICY=open (env-var-only escape)", async () => {
     seedSession("11111");
     seedSession("99999");

--- a/packages/core/tests/updater.test.ts
+++ b/packages/core/tests/updater.test.ts
@@ -1,7 +1,13 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
+  buildCheckUrl,
   buildSelfUpdateCommand,
   checkForUpdate,
+  getCurrentVersion,
+  getInstanceId,
   isManagedDeploy,
   isUpdateAvailable,
 } from "../src/updater.js";
@@ -90,9 +96,94 @@ describe("isManagedDeploy", () => {
   });
 });
 
+describe("buildCheckUrl", () => {
+  let dataDir: string;
+
+  beforeEach(() => {
+    dataDir = mkdtempSync(join(tmpdir(), "cc-updater-url-"));
+  });
+
+  afterEach(() => {
+    rmSync(dataDir, { recursive: true, force: true });
+    vi.unstubAllEnvs();
+  });
+
+  it("builds the ping URL with exactly bin, version, channel, instance when a dataDir is given (production)", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    const url = new URL(buildCheckUrl("cycling-coach", dataDir));
+    expect(`${url.origin}${url.pathname}`).toBe("https://ping.enduragent.icu/v1/check");
+    expect([...url.searchParams.keys()].sort()).toEqual(["bin", "channel", "instance", "version"]);
+    expect(url.searchParams.get("bin")).toBe("cycling-coach");
+    expect(url.searchParams.get("version")).toBe(getCurrentVersion("cycling-coach"));
+    expect(url.searchParams.get("channel")).toBe("npm");
+    expect(url.searchParams.get("instance")).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  it("omits the instance param when no dataDir is given (production)", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    const url = new URL(buildCheckUrl("cycling-coach"));
+    expect(url.searchParams.has("instance")).toBe(false);
+    expect([...url.searchParams.keys()].sort()).toEqual(["bin", "channel", "version"]);
+  });
+
+  it("channel is docker under CYCLING_COACH_MANAGED_DEPLOY=1 (production)", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("CYCLING_COACH_MANAGED_DEPLOY", "1");
+    expect(new URL(buildCheckUrl("cycling-coach")).searchParams.get("channel")).toBe("docker");
+  });
+
+  it("returns the plain npm registry URL under NODE_ENV=development", () => {
+    vi.stubEnv("NODE_ENV", "development");
+    expect(buildCheckUrl("cycling-coach", dataDir)).toBe(
+      "https://registry.npmjs.org/cycling-coach/latest",
+    );
+  });
+
+  it("returns the plain npm registry URL under NODE_ENV=test", () => {
+    vi.stubEnv("NODE_ENV", "test");
+    expect(buildCheckUrl("cycling-coach", dataDir)).toBe(
+      "https://registry.npmjs.org/cycling-coach/latest",
+    );
+  });
+});
+
+describe("getInstanceId", () => {
+  let base: string;
+
+  beforeEach(() => {
+    base = mkdtempSync(join(tmpdir(), "cc-instance-id-"));
+  });
+
+  afterEach(() => {
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  it("returns the same UUID across calls, creating the dir if missing", () => {
+    const dir = join(base, "not-yet-created");
+    expect(existsSync(dir)).toBe(false);
+    const first = getInstanceId(dir);
+    expect(first).toMatch(/^[0-9a-f-]{36}$/);
+    expect(existsSync(join(dir, "instance-id"))).toBe(true);
+    expect(getInstanceId(dir)).toBe(first);
+  });
+
+  it("returns a fresh valid UUID without throwing when the dir is unwritable", () => {
+    const filePath = join(base, "a-file");
+    writeFileSync(filePath, "x");
+    // A path whose parent is a regular file cannot be created → mkdirSync throws.
+    const unwritable = join(filePath, "nested");
+    let id = "";
+    expect(() => {
+      id = getInstanceId(unwritable);
+    }).not.toThrow();
+    expect(id).toMatch(/^[0-9a-f-]{36}$/);
+  });
+});
+
 describe("checkForUpdate", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
   });
 
   // The CYCLING_COACH_NO_UPDATE_CHECK opt-out gates only the automatic
@@ -112,5 +203,51 @@ describe("checkForUpdate", () => {
     } finally {
       vi.unstubAllEnvs();
     }
+  });
+
+  it("falls back to the npm registry when the ping endpoint fails (production)", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    const urls: string[] = [];
+    const fetchMock = vi.fn(async (input: string) => {
+      urls.push(input);
+      if (urls.length === 1) throw new Error("ping endpoint down");
+      return { ok: true, json: async () => ({ version: "2026.5.10" }) };
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const info = await checkForUpdate("cycling-coach");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(urls[0]).toContain("ping.enduragent.icu");
+    expect(urls[1]).toBe("https://registry.npmjs.org/cycling-coach/latest");
+    expect(info?.latest).toBe("2026.5.10");
+  });
+
+  it("returns null (never throws) when both hosts fail (production)", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    const fetchMock = vi.fn(async () => {
+      throw new Error("network down");
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const info = await checkForUpdate("cycling-coach");
+    expect(info).toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  // vitest sets NODE_ENV=test globally, so no ping.enduragent.icu URL is
+  // ever constructed and the primary (npm) failure does NOT retry the same host.
+  it("never constructs a ping.enduragent.icu URL under NODE_ENV=test", async () => {
+    expect(process.env.NODE_ENV).toBe("test");
+    expect(buildCheckUrl("cycling-coach", "/tmp/does-not-matter")).not.toContain(
+      "ping.enduragent.icu",
+    );
+    const urls: string[] = [];
+    const fetchMock = vi.fn(async (input: string) => {
+      urls.push(input);
+      throw new Error("offline");
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const info = await checkForUpdate("cycling-coach", "/tmp/does-not-matter");
+    expect(info).toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(urls.every((u) => !u.includes("ping.enduragent.icu"))).toBe(true);
   });
 });


### PR DESCRIPTION
## What & why

npm download counts can't measure real usage — every publish gets a bot/mirror burst, and the Railway/container channel never touches npm at all. This repoints the bot's **existing** startup version check at an edge endpoint (`ping.enduragent.icu/v1/check`) that returns npm's latest-version answer unchanged **and** records one anonymous row per request, so real instances can be counted per day, split by install channel. It also adds a 24 h re-check so long-running deployments learn about new releases without a restart (`last-notified-version` already dedupes broadcasts).

The change is strictly additive on resilience: any endpoint failure — or dev/test — falls back to `registry.npmjs.org`, and every path returns `null` rather than throwing, so startup is never blocked and `/update` + `/whatsnew` keep working even if the endpoint is down.

## What's in this PR (client only)

- `packages/core/src/updater.ts` — `getInstanceId`, `buildCheckUrl`, reworked `checkForUpdate(binaryName, dataDir?)` with npm fallback + a dev/test gate that queries npm directly.
- `packages/core/src/channels/telegram.ts` — pass `dataDir` at the three `checkForUpdate` call sites.
- `packages/core/src/run-binary.ts` — 24 h `setInterval(...).unref?.()` re-check, inside the existing `CYCLING_COACH_NO_UPDATE_CHECK` guard (both automatic checks respect the opt-out; CLI mode gets no timer).
- `packages/core/src/index.ts` — export `buildCheckUrl`, `getInstanceId`.
- Tests — `updater.test.ts` (URL building, exact params, dev/test → npm URL, instance-ID persistence + unwritable-dir no-throw, npm fallback, no-throw when both hosts fail, and that no ping URL is ever constructed under `NODE_ENV=test`); `telegram-bot.test.ts` (daily notify is idempotent per version).
- `README.md` — updates the privacy section (the prior "no telemetry" wording is no longer accurate).
- `.changeset/` — patch changeset.
- `.gitignore` — ignore `workers/`: the edge Worker is deployed via `wrangler` as operator-local infra, not shipped product code.

## Behavior & privacy

The endpoint records an anonymous per-instance usage count with no personal data. In development/test, and on any endpoint outage, the bot talks to `registry.npmjs.org` directly. `CYCLING_COACH_NO_UPDATE_CHECK=1` disables the automatic startup + daily checks (operator-initiated `/update` and `/whatsnew` still query, as before).

## Operator: reading the numbers

Cloudflare Analytics Engine SQL API (dashboard → Analytics Engine, or the SQL API):

```sql
SELECT toStartOfInterval(timestamp, INTERVAL '1' DAY) AS day,
       blob3 AS channel,
       COUNT(DISTINCT blob4) AS instances
FROM version_pings
GROUP BY day, channel
ORDER BY day DESC
```

`blob2` is the version for per-version splits. The Worker (deployed out-of-band, kept local) is bound as a Cloudflare **Custom Domain** so it auto-provisions the `ping` DNS record + TLS on deploy; it is already deployed and confirmed recording end-to-end.

## Test plan

- `pnpm check` green — types, oxlint, trademarks, fixture-privacy, registry-isolation, changeset-userfacing.
- `pnpm test` — 2850 passed / 5 skipped.
- Endpoint deployed; a live smoke request returned the latest version and produced a row in the `version_pings` dataset.
