### PR TITLE
fix(cycling-coach): inject createRequire into ESM bundle to fix startup crash

### DIFF
--- a/.changeset/fix-esm-dynamic-require.md
+++ b/.changeset/fix-esm-dynamic-require.md
@@ -1,0 +1,7 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Fixed a startup crash that stopped the bot from launching on the latest release.
+
+The published binary bundles workspace packages inline, which pulls in transitive CommonJS dependencies whose `require()` of Node builtins hit esbuild's ESM dynamic-require shim and threw at startup. A `createRequire` banner in the bundle gives that shim a real `require` to delegate to, so the builtins resolve normally.

--- a/packages/cycling-coach/tsup.config.ts
+++ b/packages/cycling-coach/tsup.config.ts
@@ -11,5 +11,15 @@ export default defineConfig({
   // self-contained. See ADR-0010.
   noExternal: [/^@enduragent\//],
   // Shebang for the bin field — npm preserves bin permissions on publish.
-  banner: { js: "#!/usr/bin/env node" },
+  // createRequire shim: bundling @enduragent/* pulls transitive CJS deps
+  // (e.g. @grammyjs/auto-retry → debug) inline, and their `require()` of Node
+  // builtins hits esbuild's ESM `__require`, which throws without a real
+  // `require` in scope. Defining one makes that shim delegate instead of throw.
+  banner: {
+    js: [
+      "#!/usr/bin/env node",
+      'import { createRequire as __createRequire } from "node:module";',
+      "const require = __createRequire(import.meta.url);",
+    ].join("\n"),
+  },
 });


### PR DESCRIPTION
The deployable was crash-looping on startup and the release `Pack and smoke` gate was failing, both with the same error:

```
Error: Dynamic require of "tty" is not supported
  at .../debug/src/node.js
  at .../@grammyjs/auto-retry/out/platform.node.js
```

## Root cause

`packages/cycling-coach` builds with `format: ["esm"]` and `noExternal: [/^@enduragent\//]`, so it bundles the workspace packages inline. That pulls in **transitive** CommonJS deps that are not listed in cycling-coach's own `dependencies` — `@grammyjs/auto-retry` → `debug` — so tsup inlines them rather than externalizing them. `debug` does `require("tty")` at module-eval time, which hits esbuild's ESM `__require` shim. With no real `require` in ESM scope, that shim throws, killing the process before any CLI logic runs.

The sibling binaries (`running-coach`, `duathlon-coach`) use `external: [/^@enduragent\//]`, never inline `debug`, and are unaffected.

## Fix

Add a `createRequire` banner to the bundle. esbuild's shim already checks `typeof require !== "undefined"` and delegates to a real `require` when present, so this resolves **all** dynamically-required builtins at once. This keeps the self-contained-tarball contract (ADR-0010) intact — unlike externalizing the dep.

## Verification

- `node dist/index.js --help` and `version` run cleanly; zero `Dynamic require` occurrences.
- Replicated the release gate locally (`npm pack` → install into clean consumer → `--help`): **exit 0**.
- Typecheck passes.