### PR TITLE
ci: run the release pack-and-smoke gate on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,37 @@ jobs:
             echo "::warning::No changeset found for this PR. Behavioral/user-facing changes should ship a .changeset/*.md (see .changeset/README.md). chore:/ci: PRs are exempt."
           fi
 
+  smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm -r build
+      - name: Pack and smoke cycling-coach
+        # Mirrors release.yml's smoke gate: install the packed tarball into a
+        # fresh consumer and run the bundled binary. Runs on every PR (including
+        # the Version PR) and on main, so a broken published bundle — e.g. an ESM
+        # dynamic-require of a Node builtin that only surfaces in the packed
+        # artifact, not in `pnpm test` — is caught before merge, not at release.
+        # cycling-coach is the only publishable binary (ADR-0009); extend when
+        # running-coach / duathlon-coach graduate.
+        run: |
+          set -euo pipefail
+          PACKAGE=cycling-coach
+          cd "packages/$PACKAGE"
+          pnpm pack --pack-destination "/tmp/smoke-pack-$PACKAGE"
+          mkdir -p "/tmp/smoke-consumer-$PACKAGE"
+          cd "/tmp/smoke-consumer-$PACKAGE"
+          npm init -y > /dev/null
+          npm install /tmp/smoke-pack-$PACKAGE/*.tgz
+          timeout 30 node "node_modules/$PACKAGE/dist/index.js" --help
+
   secrets-macos:
     runs-on: macos-latest
     env:


### PR DESCRIPTION
The `Dynamic require of "tty"` crash that took down the deploy (fixed in #295) slipped through PR CI and was only caught by the smoke step in `release.yml` — after merge and after the `stable` image had already published and crash-looped on Railway.

Root reason: `pnpm test` runs against source, but the failure only exists in the **packed, bundled** artifact (esbuild inlines transitive CJS deps whose `require()` of builtins hits the ESM dynamic-require shim). Nothing before release exercised the packed tarball.

## Change

Mirror `release.yml`'s `smoke` job into `ci.yml` as a new `smoke` job:

- pack `cycling-coach`, install the tarball into a clean consumer, run `dist/index.js --help`
- runs on every PR (including the Version PR) and on `main`

So a broken bundle now fails a PR check **before merge**, instead of at release time.

Notes:
- No untrusted input in any `run:` block (package name hardcoded) — no injection surface.
- `cycling-coach` is the only publishable binary (ADR-0009); extend when the others graduate.
- `ci:` commit, so the changeset-presence check is intentionally skipped.