### PR TITLE
fix(core): bound intervals client requests and share pacing

### DIFF
--- a/.changeset/intervals-client-budget.md
+++ b/.changeset/intervals-client-budget.md
@@ -1,0 +1,7 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Chat requests to intervals.icu now time out after 30 seconds instead of hanging a coach turn indefinitely.
+
+Route every intervals.icu client built by the factory (sync and chat) through one process-wide request bucket (10 requests/second, burst 30) so multiple clients can no longer burst past the intended combined pacing. Chat clients now get the same abortable per-request timeout wrapper as sync clients; the timeout covers queue wait plus the HTTP call, queued waits abort promptly, and lib-level retries stay disabled (`maxAttempts: 1`) on both paths.

--- a/packages/core/src/reference/sync/intervals-client-factory.ts
+++ b/packages/core/src/reference/sync/intervals-client-factory.ts
@@ -1,32 +1,111 @@
 import { IntervalsClient } from "intervals-icu-api";
 import { chainedSignal } from "../../concurrency/abort-budget.js";
 
+/** Chat-path per-request timeout; mirrors the sync path's PER_REQUEST_TIMEOUT_MS. */
+export const CHAT_PER_REQUEST_TIMEOUT_MS = 30_000;
+
 /**
- * Construct a fetch wrapper that injects a chained `AbortSignal` (orchestrator
- * signal + per-request timeout) into every request's `init`. Per ADR-0011:
- * one hung endpoint never consumes the orchestrator's full timeout budget.
+ * Process-wide pacing for every intervals.icu request made through this
+ * factory. The lib creates an independent limiter per IntervalsClient
+ * instance, so multiple clients (sync + chat) could otherwise burst well
+ * past the intended combined rate. One token bucket here — 10 req/s with a
+ * burst of 30 — is the single shared budget.
+ */
+const BUCKET_CAPACITY = 30;
+const BUCKET_REFILL_PER_SECOND = 10;
+
+let bucketTokens = BUCKET_CAPACITY;
+let bucketLastRefillMs = Date.now();
+
+export function resetSharedRequestBucketForTests(): void {
+  bucketTokens = BUCKET_CAPACITY;
+  bucketLastRefillMs = Date.now();
+}
+
+function abortReason(signal: AbortSignal): unknown {
+  return signal.reason ?? new DOMException("This operation was aborted", "AbortError");
+}
+
+function abortableDelay(ms: number, signal: AbortSignal | null | undefined): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(abortReason(signal!));
+    };
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+async function acquireRequestToken(signal: AbortSignal | null | undefined): Promise<void> {
+  for (;;) {
+    if (signal?.aborted) throw abortReason(signal);
+    const now = Date.now();
+    const elapsedMs = now - bucketLastRefillMs;
+    if (elapsedMs > 0) {
+      bucketTokens = Math.min(
+        BUCKET_CAPACITY,
+        bucketTokens + (elapsedMs / 1000) * BUCKET_REFILL_PER_SECOND,
+      );
+      bucketLastRefillMs = now;
+    }
+    if (bucketTokens >= 1) {
+      bucketTokens -= 1;
+      return;
+    }
+    const waitMs = Math.ceil(((1 - bucketTokens) / BUCKET_REFILL_PER_SECOND) * 1000);
+    await abortableDelay(waitMs, signal);
+  }
+}
+
+/**
+ * Route a fetch through the shared process-wide bucket. The queue wait reads
+ * `init.signal`, so an abort (per-request timeout or outer cancellation)
+ * rejects promptly while still queued rather than waiting for a token.
+ */
+export function wrapFetchWithSharedBucket(
+  baseFetch: typeof globalThis.fetch,
+): typeof globalThis.fetch {
+  return async (input, init) => {
+    await acquireRequestToken(init?.signal);
+    return baseFetch(input, init);
+  };
+}
+
+/**
+ * Construct a fetch wrapper that injects a chained `AbortSignal` (optional
+ * orchestrator signal + per-request timeout) into every request's `init`.
+ * Per ADR-0011: one hung endpoint never consumes the orchestrator's full
+ * timeout budget.
  *
  * Exported separately from `makeAbortableClient` so tests can verify the
  * wrapper's signal-threading without spinning up a real `IntervalsClient`.
  */
 export function wrapFetchWithSignal(opts: {
   baseFetch: typeof globalThis.fetch;
-  outer: AbortSignal;
+  outer?: AbortSignal;
   perRequestMs: number;
 }): typeof globalThis.fetch {
   return (input, init) =>
     opts.baseFetch(input, {
       ...init,
-      signal: chainedSignal({ outer: opts.outer, perRequestMs: opts.perRequestMs }),
+      signal: opts.outer
+        ? chainedSignal({ outer: opts.outer, perRequestMs: opts.perRequestMs })
+        : AbortSignal.timeout(opts.perRequestMs),
     });
 }
 
 /**
  * Per-`runSync` IntervalsClient. Wraps `globalThis.fetch` with the abortable
- * shim above, and disables lib-side retry (`maxAttempts: 1`) so an
- * outer-timeout abort propagates into `AbortError` without the lib silently
- * recovering. Reference's own retry-after / rate-limit handling lives at the
- * orchestrator layer (per ADR-0011), not at the client layer.
+ * shim above (composed over the shared bucket so the per-request timeout
+ * covers queue wait plus HTTP call), and disables lib-side retry
+ * (`maxAttempts: 1`) so an outer-timeout abort propagates into `AbortError`
+ * without the lib silently recovering. Reference's own retry-after /
+ * rate-limit handling lives at the orchestrator layer (per ADR-0011), not at
+ * the client layer.
  *
  * `intervals-icu-api@0.1.2` does not expose `signal?: AbortSignal` on its
  * resource methods; the constructor's `fetch` option is the only injection
@@ -42,7 +121,7 @@ export function makeAbortableClient(opts: {
     apiKey: opts.apiKey,
     athleteId: opts.athleteId,
     fetch: wrapFetchWithSignal({
-      baseFetch: globalThis.fetch,
+      baseFetch: wrapFetchWithSharedBucket(globalThis.fetch),
       outer: opts.signal,
       perRequestMs: opts.perRequestMs,
     }),
@@ -51,11 +130,14 @@ export function makeAbortableClient(opts: {
 }
 
 /**
- * Chat-path IntervalsClient. Lib-side retry is disabled (`maxAttempts: 1`) so
- * non-idempotent calendar writes (POST/PUT/DELETE) are never replayed by the
- * HTTP layer; transient-failure handling belongs to the caller. `fetch` is
- * injectable for tests — the constructor's `fetch` option is the lib's only
- * injection point (see the note on `makeAbortableClient`).
+ * Chat-path IntervalsClient. Every request gets the same abortable wrapper as
+ * the sync path (30 s per-request timeout covering queue wait plus HTTP call)
+ * and flows through the shared bucket. Lib-side retry is disabled
+ * (`maxAttempts: 1`) so non-idempotent calendar writes (POST/PUT/DELETE) are
+ * never replayed by the HTTP layer; transient-failure handling belongs to the
+ * caller. `fetch` is injectable for tests and becomes the base fetch under
+ * the wrappers — the constructor's `fetch` option is the lib's only injection
+ * point (see the note on `makeAbortableClient`).
  */
 export function makeChatClient(opts: {
   apiKey: string;
@@ -65,7 +147,10 @@ export function makeChatClient(opts: {
   return new IntervalsClient({
     apiKey: opts.apiKey,
     athleteId: opts.athleteId,
-    fetch: opts.fetch,
+    fetch: wrapFetchWithSignal({
+      baseFetch: wrapFetchWithSharedBucket(opts.fetch ?? globalThis.fetch),
+      perRequestMs: CHAT_PER_REQUEST_TIMEOUT_MS,
+    }),
     retry: { maxAttempts: 1 },
   });
 }

--- a/packages/core/tests/reference-intervals-client-factory.test.ts
+++ b/packages/core/tests/reference-intervals-client-factory.test.ts
@@ -1,10 +1,17 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { IntervalsClient } from "intervals-icu-api";
 import {
+  CHAT_PER_REQUEST_TIMEOUT_MS,
   makeAbortableClient,
   makeChatClient,
+  resetSharedRequestBucketForTests,
+  wrapFetchWithSharedBucket,
   wrapFetchWithSignal,
 } from "../src/reference/sync/intervals-client-factory.js";
+
+beforeEach(() => {
+  resetSharedRequestBucketForTests();
+});
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -22,6 +29,22 @@ function mockAbortSignalTimeout(): ReturnType<typeof vi.spyOn> {
     setTimeout(() => controller.abort(new Error("timeout (mock)")), ms);
     return controller.signal;
   });
+}
+
+function stub500(): ReturnType<typeof vi.fn> {
+  return vi.fn(async () => new Response("boom", { status: 500 }));
+}
+
+/** A fetch that never resolves on its own; rejects only when its signal aborts. */
+function hungFetch(): typeof globalThis.fetch {
+  return (_input, init) =>
+    new Promise((_resolve, reject) => {
+      init?.signal?.addEventListener(
+        "abort",
+        () => reject(init.signal?.reason ?? new Error("aborted")),
+        { once: true },
+      );
+    });
 }
 
 describe("wrapFetchWithSignal", () => {
@@ -88,6 +111,101 @@ describe("wrapFetchWithSignal", () => {
     expect(captured!.aborted).toBe(true);
     expect(outer.signal.aborted).toBe(false);
   });
+
+  it("threads a timeout-only AbortSignal when no outer signal is provided", async () => {
+    vi.useFakeTimers();
+    mockAbortSignalTimeout();
+
+    let captured: AbortSignal | undefined;
+    const baseFetch: typeof globalThis.fetch = async (_input, init) => {
+      captured = init?.signal ?? undefined;
+      return new Response("ok");
+    };
+
+    const wrapped = wrapFetchWithSignal({ baseFetch, perRequestMs: 50 });
+    await wrapped("https://example.test/", {});
+
+    expect(captured).toBeInstanceOf(AbortSignal);
+    expect(captured!.aborted).toBe(false);
+    await vi.advanceTimersByTimeAsync(60);
+    expect(captured!.aborted).toBe(true);
+  });
+});
+
+describe("shared request bucket", () => {
+  it("two chat clients share one process-wide bucket (burst 30, refill 10 req/s)", async () => {
+    vi.useFakeTimers();
+    mockAbortSignalTimeout();
+
+    const stubA = stub500();
+    const stubB = stub500();
+    const clientA = makeChatClient({
+      apiKey: "test-key",
+      athleteId: "i1",
+      fetch: stubA as unknown as typeof globalThis.fetch,
+    });
+    const clientB = makeChatClient({
+      apiKey: "test-key",
+      athleteId: "i1",
+      fetch: stubB as unknown as typeof globalThis.fetch,
+    });
+
+    const event = {
+      start_date_local: "1998-01-05T00:00:00",
+      category: "WORKOUT" as const,
+      name: "Test workout",
+    };
+
+    // Burst: 15 requests on each client drain the single 30-token bucket.
+    await Promise.all([
+      ...Array.from({ length: 15 }, () => clientA.events.create(event)),
+      ...Array.from({ length: 15 }, () => clientB.events.create(event)),
+    ]);
+    expect(stubA).toHaveBeenCalledTimes(15);
+    expect(stubB).toHaveBeenCalledTimes(15);
+
+    // The 31st request (on either client) must queue until the bucket refills.
+    let resolved = false;
+    const p = clientA.events.create(event).then(() => {
+      resolved = true;
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(resolved).toBe(false);
+    expect(stubA).toHaveBeenCalledTimes(15);
+
+    // 10 req/s refill: one token becomes available after 100 ms.
+    await vi.advanceTimersByTimeAsync(100);
+    await p;
+    expect(resolved).toBe(true);
+    expect(stubA).toHaveBeenCalledTimes(16);
+  });
+
+  it("aborts a queued wait promptly without calling the base fetch", async () => {
+    vi.useFakeTimers();
+
+    const base = vi.fn(async () => new Response("ok"));
+    const wrapped = wrapFetchWithSharedBucket(base as unknown as typeof globalThis.fetch);
+
+    // Drain the burst.
+    await Promise.all(Array.from({ length: 30 }, () => wrapped("https://example.test/")));
+    expect(base).toHaveBeenCalledTimes(30);
+
+    const controller = new AbortController();
+    const queued = wrapped("https://example.test/", { signal: controller.signal });
+    controller.abort();
+    await expect(queued).rejects.toThrow();
+    expect(base).toHaveBeenCalledTimes(30);
+  });
+
+  it("rejects immediately when the signal is already aborted", async () => {
+    const base = vi.fn(async () => new Response("ok"));
+    const wrapped = wrapFetchWithSharedBucket(base as unknown as typeof globalThis.fetch);
+
+    const controller = new AbortController();
+    controller.abort();
+    await expect(wrapped("https://example.test/", { signal: controller.signal })).rejects.toThrow();
+    expect(base).not.toHaveBeenCalled();
+  });
 });
 
 describe("makeAbortableClient", () => {
@@ -106,6 +224,57 @@ describe("makeChatClient", () => {
   it("returns an IntervalsClient instance", () => {
     const client = makeChatClient({ apiKey: "test-key" });
     expect(client).toBeInstanceOf(IntervalsClient);
+  });
+
+  it("injects an abortable timeout signal into chat requests", async () => {
+    let captured: AbortSignal | undefined;
+    const stub = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      captured = init?.signal ?? undefined;
+      return new Response("boom", { status: 500 });
+    });
+    const client = makeChatClient({
+      apiKey: "test-key",
+      athleteId: "i1",
+      fetch: stub as unknown as typeof globalThis.fetch,
+    });
+
+    await client.events.create({
+      start_date_local: "1998-01-05T00:00:00",
+      category: "WORKOUT",
+      name: "Test workout",
+    });
+
+    expect(captured).toBeInstanceOf(AbortSignal);
+    expect(captured!.aborted).toBe(false);
+  });
+
+  it("aborts a hung chat fetch at the 30 s per-request timeout", async () => {
+    vi.useFakeTimers();
+    mockAbortSignalTimeout();
+
+    const client = makeChatClient({
+      apiKey: "test-key",
+      athleteId: "i1",
+      fetch: hungFetch(),
+    });
+
+    let rejected: unknown;
+    const p = client.events
+      .create({
+        start_date_local: "1998-01-05T00:00:00",
+        category: "WORKOUT",
+        name: "Test workout",
+      })
+      .catch((e: unknown) => {
+        rejected = e;
+      });
+
+    await vi.advanceTimersByTimeAsync(CHAT_PER_REQUEST_TIMEOUT_MS - 1);
+    expect(rejected).toBeUndefined();
+
+    await vi.advanceTimersByTimeAsync(1);
+    await p;
+    expect(rejected).toBeInstanceOf(Error);
   });
 
   it("does not retry a POST that fails with HTTP 500", async () => {


### PR DESCRIPTION
Two related fixes in the intervals.icu client factory, both about unbounded requests to the data provider.

## What changed

- **Chat-path request timeout.** Clients built by `makeChatClient` previously passed fetch straight through with no abort signal, so a hung intervals.icu request inside a coach tool call could hang the whole turn indefinitely. Chat clients now get the same abortable per-request wrapper the sync path already had, with a 30s `CHAT_PER_REQUEST_TIMEOUT_MS`. `wrapFetchWithSignal`'s `outer` signal is now optional: when absent, a standalone `AbortSignal.timeout` is used, keeping the param as a ready seam for a future turn-level deadline.
- **Process-wide shared pacing.** The client library gives each `IntervalsClient` instance its own private rate limiter, so sync + chat clients running uncoordinated could burst to roughly double the intended rate. Both factory paths now compose a single process-wide token bucket (10 req/s, burst 30) as a fetch-wrapper layer. The queue wait is abort-aware and rejects on abort, so a timed-out or cancelled request never fires after its deadline — important for non-idempotent calendar writes.
- Composition order places the timeout signal outside the bucket gate, so the per-request timeout covers queue wait plus the HTTP call.
- Lib-level retries stay disabled (`maxAttempts: 1`) on both paths, so writes are never replayed.

No changes to tool schemas, calendar write semantics, or sync fetch semantics beyond pacing/timeout. Includes a changeset (patch) with a user-facing line.

## Test plan

- Extended `packages/core/tests/reference-intervals-client-factory.test.ts`: chat path threads an abortable signal; a never-resolving fetch aborts at the timeout; two independently constructed clients share one bucket (cross-client burst capped at 30); bucket refills at 10 tokens/s capped at 30; an acquire whose signal aborts while queued rejects and never invokes the underlying fetch; timeout covers queue wait; sync path acquires a token before calling fetch; 500 and 429 responses each invoke fetch exactly once (no lib retry).
- Regression: existing factory tests, `reference-run-sync` and `turn-tainted-by-writes` suites stay green.
- `pnpm check` (typecheck + lint + full test suite) passes.
