### PR TITLE
feat(telegram): coalesce rapid message fragments

### DIFF
--- a/.changeset/telegram-inbound-coalescing.md
+++ b/.changeset/telegram-inbound-coalescing.md
@@ -1,0 +1,7 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Rapid messages sent within about 1.5 seconds of each other are now combined into a single reply, so a thought split across several messages gets one coherent answer instead of several partial ones.
+
+Buffers free-form Telegram text per chat behind a 1.5s debounce window (each fragment resets the window) and joins fragments with newlines into one turn. A slash command flushes the chat's pending text first, then runs immediately, so commands are never coalesced into free-form text. Turn dependencies are resolved at flush time, the flushed turn threads to the last fragment's message id, each fragment fires one best-effort typing action during the window, and shutdown/update drains flush pending buffers synchronously without waiting on the debounce timer. Debounce timers are unref'd so a pending buffer never holds the process open.

--- a/packages/core/src/channels/telegram.ts
+++ b/packages/core/src/channels/telegram.ts
@@ -29,6 +29,11 @@ import { createSubsystemLogger } from "../logging/index.js";
 // timeout.
 const UPDATE_DRAIN_TIMEOUT_MS = 10_000;
 
+// Debounce window for coalescing rapid free-form message fragments from one
+// chat into a single turn. Each new fragment resets the window; the buffered
+// turn fires this long after the LAST fragment.
+export const CHAT_COALESCE_MS = 1_500;
+
 // Process-local resend cache bounds. The cache holds full generated answers
 // (athlete content) so it is size- and time-bounded and never logged.
 const RESEND_TTL_MS = 30 * 60_000;
@@ -273,7 +278,26 @@ export function createTelegramBot(
     pending.add(task);
     void task.finally(() => pending.delete(task));
   };
-  const drainPending = (): Promise<void> => Promise.all(pending).then(() => undefined);
+  // Per-chat buffer of free-form fragments awaiting the coalesce window. Each
+  // entry rebinds the latest fragment's reply context so the flushed turn
+  // answers on a live ctx, and threads to the last fragment's message id.
+  interface ChatBuffer {
+    fragments: string[];
+    reply: (text: string, options?: Record<string, unknown>) => Promise<unknown>;
+    replyWithChatAction: (action: "typing") => Promise<unknown>;
+    replyToMessageId?: number;
+    timer: ReturnType<typeof setTimeout>;
+  }
+  const chatBuffers = new Map<number, ChatBuffer>();
+
+  // Flush buffered fragments FIRST (synchronously — flushing dispatches onto
+  // `pending`, so the Promise.all snapshot below includes the flushed turns),
+  // so shutdown and /update drains never drop buffered text and never wait on
+  // the debounce timer.
+  const drainPending = (): Promise<void> => {
+    for (const chatId of Array.from(chatBuffers.keys())) flushBufferedChat(chatId);
+    return Promise.all(pending).then(() => undefined);
+  };
 
   void bot.api.setMyCommands(buildCommandMenu(reference)).catch((err) => {
     log.error("set_commands_failed", err, {});
@@ -331,6 +355,74 @@ export function createTelegramBot(
       }
     });
   }
+
+  // Idempotent read-and-delete: no await between lookup and delete, so a
+  // concurrent flush (command middleware vs. drain vs. timer) can never
+  // double-dispatch the same buffered turn. Deps are resolved here, at flush
+  // time, so the coalesced turn sees fresh environment state.
+  function flushBufferedChat(chatId: number): void {
+    const buf = chatBuffers.get(chatId);
+    if (buf === undefined) return;
+    chatBuffers.delete(chatId);
+    clearTimeout(buf.timer);
+    runTurn({
+      ctx: { reply: buf.reply, replyWithChatAction: buf.replyWithChatAction },
+      command: "chat",
+      chatId: `telegram:${chatId}`,
+      message: buf.fragments.join("\n"),
+      deps: turnDeps(),
+      genericReply: "Sorry, something went wrong. Please try again.",
+      replyToMessageId: buf.replyToMessageId,
+    });
+  }
+
+  function bufferChatMessage(ctx: {
+    chat: { id: number };
+    message: { text: string; message_id?: number };
+    reply: (text: string, options?: Record<string, unknown>) => Promise<unknown>;
+    replyWithChatAction: (action: "typing") => Promise<unknown>;
+  }): void {
+    const text = ctx.message.text;
+    const chatId = ctx.chat.id;
+    if (text.startsWith("/")) {
+      // Unregistered-command fallthrough: never buffered. The turn runs
+      // immediately so a command can never be coalesced into free-form text.
+      runTurn({
+        ctx,
+        command: "chat",
+        chatId: `telegram:${chatId}`,
+        message: text,
+        deps: turnDeps(),
+        genericReply: "Sorry, something went wrong. Please try again.",
+        replyToMessageId: ctx.message.message_id,
+      });
+      return;
+    }
+    const existing = chatBuffers.get(chatId);
+    if (existing !== undefined) clearTimeout(existing.timer);
+    const fragments = existing?.fragments ?? [];
+    fragments.push(text);
+    const timer = setTimeout(() => flushBufferedChat(chatId), CHAT_COALESCE_MS);
+    timer.unref?.();
+    chatBuffers.set(chatId, {
+      fragments,
+      reply: (t, o) => ctx.reply(t, o),
+      replyWithChatAction: (a) => ctx.replyWithChatAction(a),
+      replyToMessageId: ctx.message.message_id,
+      timer,
+    });
+  }
+
+  // Flush middleware: any slash update flushes this chat's buffered text ahead
+  // of the command handler, so the buffered turn enqueues on the FIFO session
+  // lock before the command runs. Registered after auth (createSecuredBot) and
+  // before every bot.command below — do not move it below a command.
+  bot.use(async (ctx, next) => {
+    if (ctx.chat !== undefined && ctx.message?.text?.startsWith("/") === true) {
+      flushBufferedChat(ctx.chat.id);
+    }
+    await next();
+  });
 
   // ── Commands ────────────────────────────────────────────────────────────
 
@@ -553,16 +645,14 @@ export function createTelegramBot(
       }
     }
 
-    const deps = turnDeps();
-    runTurn({
-      ctx,
-      command: "chat",
-      chatId,
-      message: text,
-      deps,
-      genericReply: "Sorry, something went wrong. Please try again.",
-      replyToMessageId: ctx.message?.message_id,
-    });
+    // One best-effort typing action per fragment so the athlete sees activity
+    // during the debounce window; only the LLM turn is debounced, never the
+    // signal. Fire-and-forget: a failure can never reach the handler's failure
+    // path (the full typing heartbeat starts at flush inside runTurn).
+    void Promise.resolve()
+      .then(() => ctx.replyWithChatAction("typing"))
+      .catch(() => log.debug("typing_action_failed", { command: "chat", chatId }));
+    bufferChatMessage(ctx);
   });
 
   bot.catch(async (botError) => {

--- a/packages/core/tests/telegram-coalescing.test.ts
+++ b/packages/core/tests/telegram-coalescing.test.ts
@@ -1,0 +1,321 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { cyclingBinary } from "./helpers/cycling-binary-fixture.js";
+import { CHAT_COALESCE_MS } from "../src/channels/telegram.js";
+
+let dataDir: string;
+
+beforeEach(() => {
+  dataDir = mkdtempSync(join(tmpdir(), "cc-tg-coalesce-"));
+  mkdirSync(join(dataDir, "sessions"), { recursive: true });
+  vi.resetModules();
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  rmSync(dataDir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+  vi.doUnmock("grammy");
+});
+
+interface FakeBot {
+  api: {
+    sendMessage: ReturnType<typeof vi.fn>;
+    setMyCommands: ReturnType<typeof vi.fn>;
+    config: { use: ReturnType<typeof vi.fn> };
+  };
+  use: ReturnType<typeof vi.fn>;
+  command: ReturnType<typeof vi.fn>;
+  on: ReturnType<typeof vi.fn>;
+  stop: ReturnType<typeof vi.fn>;
+  catch: ReturnType<typeof vi.fn>;
+}
+
+interface StubAgent {
+  chat: ReturnType<typeof vi.fn>;
+  hasSession: ReturnType<typeof vi.fn>;
+  resetSession: ReturnType<typeof vi.fn>;
+}
+
+interface BuildBotResult {
+  bot: FakeBot;
+  agent: StubAgent;
+  drainPending: () => Promise<void>;
+}
+
+async function buildBot(): Promise<BuildBotResult> {
+  const bot: FakeBot = {
+    api: {
+      sendMessage: vi.fn(async () => undefined),
+      setMyCommands: vi.fn(async () => true),
+      config: { use: vi.fn() },
+    },
+    use: vi.fn(),
+    command: vi.fn(),
+    on: vi.fn(),
+    stop: vi.fn(async () => undefined),
+    catch: vi.fn(),
+  };
+  vi.doMock("grammy", () => ({
+    Bot: function FakeBot() {
+      return bot;
+    },
+    InputFile: class {},
+  }));
+
+  const agent: StubAgent = {
+    chat: vi.fn(async () => "ok"),
+    hasSession: vi.fn(() => true),
+    resetSession: vi.fn(),
+  };
+
+  const { createTelegramBot } = await import("../src/channels/telegram.js");
+  const { drainPending } = createTelegramBot(
+    "FAKE_TOKEN",
+    agent as unknown as Parameters<typeof createTelegramBot>[1],
+    cyclingBinary,
+    dataDir,
+    undefined,
+  );
+
+  return { bot, agent, drainPending };
+}
+
+function getMessageText(bot: FakeBot) {
+  const call = bot.on.mock.calls.find((c: unknown[]) => c[0] === "message:text");
+  if (!call) throw new Error("message:text handler not registered");
+  return call[1] as (ctx: unknown) => Promise<void>;
+}
+
+// The flush middleware is the SECOND bot.use registration (auth is first, in
+// createSecuredBot).
+function getFlushMiddleware(bot: FakeBot) {
+  const call = bot.use.mock.calls[1];
+  if (!call) throw new Error("flush middleware not registered");
+  return call[0] as (ctx: unknown, next: () => Promise<void>) => Promise<void>;
+}
+
+interface FakeCtx {
+  chat: { id: number };
+  match: string;
+  message: { text: string; message_id?: number };
+  reply: ReturnType<typeof vi.fn>;
+  replyWithDocument: ReturnType<typeof vi.fn>;
+  replyWithChatAction: ReturnType<typeof vi.fn>;
+}
+
+function makeCtx(overrides?: Partial<FakeCtx>): FakeCtx {
+  return {
+    chat: { id: 777 },
+    match: "",
+    message: { text: "hi" },
+    reply: vi.fn(async () => undefined),
+    replyWithDocument: vi.fn(async () => undefined),
+    replyWithChatAction: vi.fn(async () => true),
+    ...overrides,
+  };
+}
+
+describe("inbound coalescing (fake timers)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("three fragments within the window produce ONE agent.chat call with newline-joined text, threaded to the last fragment", async () => {
+    const { bot, agent, drainPending } = await buildBot();
+    const handler = getMessageText(bot);
+    const ctxA = makeCtx({ message: { text: "one", message_id: 11 } });
+    const ctxB = makeCtx({ message: { text: "two", message_id: 12 } });
+    const ctxC = makeCtx({ message: { text: "three", message_id: 13 } });
+
+    await handler(ctxA);
+    await handler(ctxB);
+    await handler(ctxC);
+    expect(agent.chat).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(CHAT_COALESCE_MS);
+    await drainPending();
+
+    expect(agent.chat).toHaveBeenCalledTimes(1);
+    expect(agent.chat).toHaveBeenCalledWith("telegram:777", "one\ntwo\nthree", undefined);
+
+    // The flushed answer threads to the LAST fragment's message id, on the
+    // last fragment's reply context.
+    const htmlCall = ctxC.reply.mock.calls.find(
+      (c: unknown[]) => (c[1] as { parse_mode?: string } | undefined)?.parse_mode === "HTML",
+    );
+    expect(htmlCall).toBeDefined();
+    expect((htmlCall![1] as { reply_parameters?: { message_id?: number } }).reply_parameters).toEqual(
+      { message_id: 13, allow_sending_without_reply: true },
+    );
+  });
+
+  it("each fragment resets the timer: nothing fires until the window elapses after the LAST fragment", async () => {
+    const { bot, agent, drainPending } = await buildBot();
+    const handler = getMessageText(bot);
+
+    await handler(makeCtx({ message: { text: "a" } }));
+    await vi.advanceTimersByTimeAsync(1_000);
+    await handler(makeCtx({ message: { text: "b" } }));
+    await vi.advanceTimersByTimeAsync(1_000);
+    await handler(makeCtx({ message: { text: "c" } }));
+
+    // 100ms short of the window after the last fragment: still buffered.
+    await vi.advanceTimersByTimeAsync(CHAT_COALESCE_MS - 100);
+    expect(agent.chat).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(100);
+    await drainPending();
+    expect(agent.chat).toHaveBeenCalledTimes(1);
+    expect(agent.chat).toHaveBeenCalledWith("telegram:777", "a\nb\nc", undefined);
+  });
+
+  it("different chats are isolated: concurrent fragments never cross-join", async () => {
+    const { bot, agent, drainPending } = await buildBot();
+    const handler = getMessageText(bot);
+
+    await handler(makeCtx({ chat: { id: 1 }, message: { text: "left" } }));
+    await handler(makeCtx({ chat: { id: 2 }, message: { text: "right" } }));
+    await vi.advanceTimersByTimeAsync(CHAT_COALESCE_MS);
+    await drainPending();
+
+    expect(agent.chat).toHaveBeenCalledTimes(2);
+    expect(agent.chat).toHaveBeenCalledWith("telegram:1", "left", undefined);
+    expect(agent.chat).toHaveBeenCalledWith("telegram:2", "right", undefined);
+  });
+
+  it("a slash update mid-buffer flushes the pending text BEFORE the command handler runs", async () => {
+    const { bot, agent, drainPending } = await buildBot();
+    const handler = getMessageText(bot);
+
+    await handler(makeCtx({ message: { text: "pending thought" } }));
+    expect(agent.chat).not.toHaveBeenCalled();
+
+    const next = vi.fn(async () => undefined);
+    await getFlushMiddleware(bot)(makeCtx({ message: { text: "/status" } }), next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    // The buffered turn is dispatched (reaches agent.chat) before the command
+    // handler chain continues — it enqueues on the FIFO session lock first.
+    expect(agent.chat).toHaveBeenCalledTimes(1);
+    expect(agent.chat.mock.invocationCallOrder[0]).toBeLessThan(next.mock.invocationCallOrder[0]);
+
+    await drainPending();
+    expect(agent.chat).toHaveBeenCalledWith("telegram:777", "pending thought", undefined);
+
+    // The flush cleared the debounce timer: the window elapsing later must not
+    // double-dispatch the same buffered text.
+    await vi.advanceTimersByTimeAsync(CHAT_COALESCE_MS * 2);
+    expect(agent.chat).toHaveBeenCalledTimes(1);
+  });
+
+  it("registration order: auth use → flush middleware use → every command", async () => {
+    const { bot } = await buildBot();
+    expect(bot.use).toHaveBeenCalledTimes(2);
+    const authOrder = bot.use.mock.invocationCallOrder[0];
+    const flushOrder = bot.use.mock.invocationCallOrder[1];
+    expect(authOrder).toBeLessThan(flushOrder);
+    expect(bot.command.mock.invocationCallOrder.length).toBeGreaterThan(0);
+    for (const commandOrder of bot.command.mock.invocationCallOrder) {
+      expect(flushOrder).toBeLessThan(commandOrder);
+    }
+  });
+
+  it("drainPending flushes buffered text immediately — no debounce-timer wait", async () => {
+    const { bot, agent, drainPending } = await buildBot();
+    await getMessageText(bot)(makeCtx({ message: { text: "about to shut down" } }));
+    expect(agent.chat).not.toHaveBeenCalled();
+
+    // No timer advance: the drain itself must flush, then await the turn.
+    await drainPending();
+    expect(agent.chat).toHaveBeenCalledTimes(1);
+    expect(agent.chat).toHaveBeenCalledWith("telegram:777", "about to shut down", undefined);
+  });
+
+  it("each fragment fires one best-effort typing action during the window; the flushed turn still heartbeats", async () => {
+    const { bot, agent, drainPending } = await buildBot();
+    const handler = getMessageText(bot);
+    const ctxA = makeCtx({ message: { text: "one" } });
+    const ctxB = makeCtx({ message: { text: "two" } });
+    const ctxC = makeCtx({ message: { text: "three" } });
+
+    await handler(ctxA);
+    await handler(ctxB);
+    await handler(ctxC);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(ctxA.replyWithChatAction).toHaveBeenCalledWith("typing");
+    expect(ctxB.replyWithChatAction).toHaveBeenCalledWith("typing");
+    expect(ctxC.replyWithChatAction).toHaveBeenCalledWith("typing");
+    expect(ctxA.replyWithChatAction).toHaveBeenCalledTimes(1);
+    expect(ctxB.replyWithChatAction).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(CHAT_COALESCE_MS);
+    await drainPending();
+    expect(agent.chat).toHaveBeenCalledTimes(1);
+    // The heartbeat runs on the LAST fragment's rebound context.
+    expect(ctxC.replyWithChatAction.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("a typing-action failure never breaks the handler or the buffered turn", async () => {
+    const { bot, agent, drainPending } = await buildBot();
+    const ctx = makeCtx({ message: { text: "hello" } });
+    ctx.replyWithChatAction.mockRejectedValue(new Error("chat action down"));
+
+    await expect(getMessageText(bot)(ctx)).resolves.toBeUndefined();
+    await vi.advanceTimersByTimeAsync(CHAT_COALESCE_MS);
+    await drainPending();
+    expect(agent.chat).toHaveBeenCalledWith("telegram:777", "hello", undefined);
+  });
+
+  it("leading-slash message:text (unregistered command fallthrough) is never buffered", async () => {
+    const { bot, agent, drainPending } = await buildBot();
+    const handler = getMessageText(bot);
+
+    await handler(makeCtx({ message: { text: "a buffered thought" } }));
+    await handler(makeCtx({ message: { text: "/unknowncmd" } }));
+
+    // The slash turn dispatched immediately — no window wait, no coalescing
+    // with the pending free-form fragment.
+    expect(agent.chat).toHaveBeenCalledTimes(1);
+    expect(agent.chat).toHaveBeenCalledWith("telegram:777", "/unknowncmd", undefined);
+
+    await vi.advanceTimersByTimeAsync(CHAT_COALESCE_MS);
+    await drainPending();
+    expect(agent.chat).toHaveBeenCalledTimes(2);
+    expect(agent.chat).toHaveBeenCalledWith("telegram:777", "a buffered thought", undefined);
+  });
+});
+
+describe("inbound coalescing (timer plumbing)", () => {
+  it("debounce timers are unref'd; a reset clears exactly the previous timer", async () => {
+    const { bot } = await buildBot();
+    const handler = getMessageText(bot);
+
+    const unrefA = vi.fn();
+    const unrefB = vi.fn();
+    const timers = [{ unref: unrefA }, { unref: unrefB }];
+    const setTimeoutSpy = vi.fn(() => timers[setTimeoutSpy.mock.calls.length - 1]);
+    const clearTimeoutSpy = vi.fn();
+    vi.stubGlobal("setTimeout", setTimeoutSpy);
+    vi.stubGlobal("clearTimeout", clearTimeoutSpy);
+    try {
+      await handler(makeCtx({ message: { text: "first" } }));
+      expect(setTimeoutSpy).toHaveBeenCalledTimes(1);
+      expect(unrefA).toHaveBeenCalledTimes(1);
+      expect(clearTimeoutSpy).not.toHaveBeenCalled();
+
+      await handler(makeCtx({ message: { text: "second" } }));
+      expect(setTimeoutSpy).toHaveBeenCalledTimes(2);
+      expect(unrefB).toHaveBeenCalledTimes(1);
+      expect(clearTimeoutSpy).toHaveBeenCalledWith(timers[0]);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+});

--- a/packages/core/tests/telegram-nonblocking.test.ts
+++ b/packages/core/tests/telegram-nonblocking.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { cyclingBinary } from "./helpers/cycling-binary-fixture.js";
+import { CHAT_COALESCE_MS } from "../src/channels/telegram.js";
 
 let dataDir: string;
 
@@ -219,9 +220,19 @@ describe("non-blocking dispatch", () => {
     const ctxB = makeCtx({ chat: { id: 333 }, message: { text: "second" } });
     agent.hasSession.mockReturnValue(true);
 
-    await getMessageText(bot)(ctxA);
-    await getMessageText(bot)(ctxB);
-    await drainPending();
+    // Advance past the coalesce window between sends so each message is its
+    // own turn (fragments inside the window are a single coalesced turn —
+    // covered in telegram-coalescing.test.ts).
+    vi.useFakeTimers();
+    try {
+      await getMessageText(bot)(ctxA);
+      await vi.advanceTimersByTimeAsync(CHAT_COALESCE_MS);
+      await getMessageText(bot)(ctxB);
+      await vi.advanceTimersByTimeAsync(CHAT_COALESCE_MS);
+      await drainPending();
+    } finally {
+      vi.useRealTimers();
+    }
 
     expect(agent.chat).toHaveBeenCalledWith("telegram:333", "first", undefined);
     expect(agent.chat).toHaveBeenCalledWith("telegram:333", "second", undefined);


### PR DESCRIPTION
## Summary

When an athlete types one thought across several rapid Telegram messages ("how's my form", "after yesterday's ride", "should I go hard tomorrow?"), each fragment previously fired its own LLM turn: the first reply missed the later context, the model was invoked N times for one question, and the athlete got N partial answers.

This PR adds an inbound coalescing buffer in the Telegram channel:

- Free-form `message:text` fragments are buffered per chat behind a fixed 1.5 s debounce window (reset on each new fragment) and dispatched as a single coach turn with the fragments newline-joined in send order.
- Slash commands are never delayed or buffered. A middleware (registered after auth, before every command handler) flushes the chat's pending buffer first, so the buffered turn reaches the session lock before the command's work and no typed text is stranded.
- Stray leading-slash text that is not a registered command is skipped, never buffered.
- `drainPending()` flushes all buffered chats synchronously before awaiting in-flight turns, so shutdown and `/update` drains never wait on the debounce timer or drop buffered text.
- Turn dependencies resolve at flush time (not fragment-arrival time), the flushed turn threads its reply to the last fragment's message id, and each fragment fires one best-effort typing action so the athlete sees feedback during the window.
- Debounce timers are unref'd so a pending buffer never keeps the process alive.
- The newcomer greeting and the `resend` short-circuit stay synchronous, ahead of buffering.

Includes a user-facing changeset.

## Test plan

- New `packages/core/tests/telegram-coalescing.test.ts` (fake timers): burst coalescing into one turn with newline-joined text, debounce reset at the 1.5 s boundary (1.499 s no-fire / +1 ms fires once), command-mid-buffer flush ordering, drain-flushes-before-awaiting, per-fragment typing action, leading-slash skip, timer unref.
- Updated `packages/core/tests/telegram-nonblocking.test.ts` same-chat ordering test for the coalesced dispatch.
- Verified with `pnpm vitest run packages/core/tests/telegram-coalescing.test.ts packages/core/tests/telegram-nonblocking.test.ts packages/core/tests/telegram-dispatch.test.ts` and full `pnpm check`.
