### PR TITLE
feat(telegram): persist update offsets and preserve session edges

### DIFF
--- a/.changeset/telegram-offset-session-edge.md
+++ b/.changeset/telegram-offset-session-edge.md
@@ -1,0 +1,7 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Messages you send while the bot is offline are no longer dropped when it restarts, and when a new daily session starts the bot now tells you your earlier conversation is archived and your key details are still remembered.
+
+Normal startup no longer drops pending updates; a durable, owner-only offset store (keyed by a short token fingerprint, never the raw token) dedupes anything a previous run already handled and stops `/update` from re-triggering itself after a self-update restart. Operator-capture startup still intentionally drops prior updates. A daily session reset is deferred for one turn when the last exchange is still recent (within 30 minutes), so a conversation that crosses the daily boundary isn't archived mid-thread; malformed timestamps and idle resets are never deferred. On an automatic reset the first reply is prefixed once with a plain-language notice and the model sees a one-turn archive marker so it discloses the fresh session. The athlete's message is now made durable before generation and a failed turn is recorded with a terminal marker, so a mid-turn crash no longer silently erases the message. Compaction now preserves surviving messages' original timestamps.

--- a/packages/core/CONTEXT.md
+++ b/packages/core/CONTEXT.md
@@ -51,7 +51,7 @@ Core's shared entry-point dispatcher. `runBinary(sport, binary, hooks?)` parses 
 Changesets-generated PR aggregating pending `.changeset/*.md` entries across packages into version bumps + CHANGELOG entries. Merging the Version PR triggers the publish job (which runs `pnpm exec changeset version`, `tools/bump-binaries-to-calver.ts` to override binary CalVer, then `pnpm publish -r`).
 
 **Session**:
-One user's chat state with one Binary, persisted to disk and locked against concurrent processes.
+One user's chat state with one Binary, persisted to disk and locked in-process per chat. The process model is one process per dataDir; there is no cross-process lock.
 
 **Channel**:
 A delivery surface (currently only Telegram); sport-agnostic.

--- a/packages/core/src/agent/chat-store.ts
+++ b/packages/core/src/agent/chat-store.ts
@@ -15,6 +15,12 @@ import { messageText } from "./token-utils.js";
 
 const MS_PER_DAY = 86_400_000;
 
+// Recorded in history when a turn fails before producing a reply, so the
+// athlete's (durably persisted) message is visibly unanswered rather than
+// silently dangling.
+export const TURN_FAILURE_MARKER =
+  "[This turn did not complete — the message above was not answered.]";
+
 function parseArchiveTimestampMs(suffix: string): number | null {
   // archiveAndReset writes toISOString() with ":" replaced by "-"; reverse
   // only the time-part dashes before parsing.
@@ -157,18 +163,56 @@ export class ChatStore {
     const path = this.filePath(chatId);
     const tmpPath = `${path}.tmp`;
     const now = new Date().toISOString();
+
+    // Preserve the original timestamp of a message that survives the rewrite so
+    // freshness/idle math keeps working across a compaction. Timestamps are read
+    // back from the existing file by (role, content); a summary/system line is a
+    // freshly-generated artifact and always gets `now`. Build a per-key queue so
+    // duplicate lines each keep their own original stamp in order.
+    const tsByKey = new Map<string, string[]>();
+    if (existsSync(path)) {
+      for (const line of readFileSync(path, "utf-8").split("\n")) {
+        if (line.trim() === "") continue;
+        const entry = parseSessionLine(line);
+        if (entry === null || entry.role === "system") continue;
+        const key = `${entry.role}\n${entry.content}`;
+        const queue = tsByKey.get(key);
+        if (queue) queue.push(entry.ts);
+        else tsByKey.set(key, [entry.ts]);
+      }
+    }
+
     const content = messages
       .map((m) => {
-        const line: JsonlLine = {
-          role: m.role as JsonlLine["role"],
-          content: messageText(m),
-          ts: now,
-        };
+        const role = m.role as JsonlLine["role"];
+        const text = messageText(m);
+        let ts = now;
+        if (role !== "system") {
+          const queue = tsByKey.get(`${role}\n${text}`);
+          const preserved = queue?.shift();
+          if (preserved !== undefined) ts = preserved;
+        }
+        const line: JsonlLine = { role, content: text, ts };
         return JSON.stringify(line);
       })
       .join("\n") + "\n";
     writeFileSync(tmpPath, content, { encoding: "utf-8", mode: 0o600 });
     renameSync(tmpPath, path);
+  }
+
+  // Terminal failure marker: makes a turn that died before producing a reply
+  // visible in history instead of leaving a bare user line with no answer. The
+  // athlete's message stays durable (it was appended before generation); this
+  // records that the turn did not complete. No-op when no session file exists.
+  appendFailureMarker(chatId: string): void {
+    const path = this.filePath(chatId);
+    if (!existsSync(path)) return;
+    const line: JsonlLine = {
+      role: "system",
+      content: TURN_FAILURE_MARKER,
+      ts: new Date().toISOString(),
+    };
+    appendFileSync(path, JSON.stringify(line) + "\n", { encoding: "utf-8", mode: 0o600 });
   }
 
   archiveAndReset(chatId: string): void {

--- a/packages/core/src/agent/coach-agent.ts
+++ b/packages/core/src/agent/coach-agent.ts
@@ -39,7 +39,7 @@ import {
 import { summarizeInStages, summarizeDroppedMessages } from "./compaction.js";
 import { runMemoryFlush, FLUSH_ZERO_WRITE_MIN_MESSAGES, shouldRunMemoryFlush } from "./memory-flush.js";
 import type { MemoryFlushOutcome } from "./memory-flush.js";
-import { evaluateSessionFreshness } from "./session-freshness.js";
+import { evaluateSessionFreshness, shouldDeferDailyReset } from "./session-freshness.js";
 import { LLM } from "../llm.js";
 import { appendUsageLine, usageFieldsFromResult } from "../usage-ledger.js";
 import { createMemorySnapshot } from "../memory/snapshot.js";
@@ -92,6 +92,19 @@ function isStepExhaustedEmpty(text: string, finishReason: FinishReason): boolean
 }
 
 const RECOVERY_PROMPT = "summarize what you did and what's left";
+
+// Prefixed once onto the first reply after an automatic session reset so the
+// athlete is told, in plain language, that the earlier conversation is archived
+// and their durable memory survives. Frozen copy — do not reword.
+const POST_RESET_NOTICE =
+  "Started a fresh session - earlier conversation is archived, and I still have your key details in memory.";
+
+// One-turn, model-visible system line injected after an automatic archive so the
+// model discloses the fresh session itself. Not relied on as the athlete-facing
+// disclosure (that is POST_RESET_NOTICE).
+function archiveMarker(archivedAt: string): string {
+  return `Previous session archived at ${archivedAt}. Briefly disclose this before answering.`;
+}
 
 const DISK_FULL_NOTE =
   "\n\n(Heads up: my disk is full, so I couldn't save this to our history — but your message went through. Please free up some space when you can.)";
@@ -441,14 +454,24 @@ export class CoachAgent {
       // Single file read: load history + last message time together
       let { messages: history, lastMessageTime } = this.chatStore.load(chatId);
 
-      const { fresh } = evaluateSessionFreshness({
+      const { fresh, reason } = evaluateSessionFreshness({
         lastMessageTime,
         dailyResetHour: this.config.session.dailyResetHour,
         idleMinutes: this.config.session.idleMinutes,
         tz: this.tz,
       });
 
-      if (!fresh) {
+      // Defer a daily reset for one turn when the last exchange is still recent,
+      // so an athlete mid-conversation across the daily boundary isn't archived
+      // out from under them. Malformed timestamps (reason "daily", unparseable)
+      // and idle resets are never deferred.
+      const deferDaily = !fresh && reason === "daily" && shouldDeferDailyReset(lastMessageTime);
+
+      // Set only when an automatic archive actually runs this turn — drives the
+      // one-turn model marker and the one-time post-reset athlete notice.
+      let archivedAt: string | undefined;
+
+      if (!fresh && !deferDaily) {
         // Flush memory before reset, then archive
         let outcome: MemoryFlushOutcome | null = null;
         if (history.length > 0 && !flushedThisTurn) {
@@ -477,6 +500,7 @@ export class CoachAgent {
           this.chatStore.archiveAndReset(chatId);
           this.lastFlushMessageCount.delete(chatId);
           history = [];
+          archivedAt = new Date().toISOString();
         }
       }
 
@@ -560,13 +584,32 @@ export class CoachAgent {
       // across the retry/compaction loop below.
       const userMessageWithTime = appendCurrentTimeLine(userMessage, this.tz);
 
+      // One-turn model-visible archive marker: after an automatic reset, tell
+      // the model to disclose the fresh session. Not persisted (it is rebuilt
+      // per turn and only emitted on the reset turn).
+      const archiveMarkerMsg: ModelMessage | undefined =
+        archivedAt !== undefined
+          ? { role: "system", content: archiveMarker(archivedAt) }
+          : undefined;
+
       // Build messages array with new user message
       let messages: ModelMessage[] = [
         ...(summaryMsg ? [summaryMsg] : []),
+        ...(archiveMarkerMsg ? [archiveMarkerMsg] : []),
         ...requeued,
         ...kept,
         { role: "user", content: userMessageWithTime },
       ];
+
+      // Make the athlete's message durable BEFORE generation so a process death
+      // mid-turn leaves it visible in history instead of erasing it. Deliver-
+      // first: a persistence failure here (full disk, permissions) must never
+      // block the turn, so swallow and continue — the reply still runs.
+      try {
+        this.chatStore.appendMessage(chatId, "user", userMessage);
+      } catch (persistErr) {
+        console.warn("Pre-generation user append failed; continuing turn", persistErr);
+      }
 
       let overflowAttempts = 0;
       let timeoutAttempts = 0;
@@ -634,11 +677,12 @@ export class CoachAgent {
             }));
             const assembledHash = computeAssembledHash(this.systemPrompt, messages);
 
-            // Append BOTH after success as one atomic write — JSONL unchanged
-            // on failure, no dangling user line on a partial write.
+            // The user line was appended before generation; append the assistant
+            // reply now. The empty-assistant guard inside appendMessage keeps a
+            // blank reply from polluting history.
             let persistenceNote = "";
             try {
-              this.chatStore.appendTurn(chatId, userMessage, effectiveText, {
+              this.chatStore.appendMessage(chatId, "assistant", effectiveText, {
                 templateHash,
                 assembledHash,
                 provider: this.config.llm.provider,
@@ -678,7 +722,11 @@ export class CoachAgent {
               compactions,
             });
 
-            return effectiveText + persistenceNote;
+            // Prefix the one-time post-reset notice onto the first reply after
+            // an automatic archive. Not persisted to history — it is a channel
+            // disclosure, not conversation content.
+            const resetPrefix = archivedAt !== undefined ? `${POST_RESET_NOTICE}\n\n` : "";
+            return resetPrefix + effectiveText + persistenceNote;
           } catch (err) {
             // The classified budget error is terminal: re-throw it before any
             // retry branch so a future reordering can never mistake it for one of
@@ -824,6 +872,14 @@ export class CoachAgent {
           }
         }
       } catch (terminalErr) {
+        // Record a terminal failure marker so the durably-appended user line is
+        // visibly unanswered rather than a bare dangling message. Best-effort:
+        // a marker write failure must never mask the original error.
+        try {
+          this.chatStore.appendFailureMarker(chatId);
+        } catch (markerErr) {
+          console.warn("Failed to append terminal failure marker", markerErr);
+        }
         // Single failure-emit point: every terminal throw out of the loop is one
         // failed turn, so the outcome line fires exactly once before the rethrow.
         this.emitTurnOutcome({

--- a/packages/core/src/agent/session-freshness.ts
+++ b/packages/core/src/agent/session-freshness.ts
@@ -87,3 +87,24 @@ export function evaluateSessionFreshness(params: {
 
   return { fresh: true };
 }
+
+// Grace window: a daily reset is deferred for one turn when the last exchange is
+// this recent, so an athlete mid-conversation across the daily boundary doesn't
+// have their session archived out from under them.
+export const DAILY_RESET_DEFER_MS = 30 * 60_000;
+
+/**
+ * Whether a daily (not idle) reset should be deferred for this turn because the
+ * last exchange is still recent. Malformed timestamps are NEVER deferred (they
+ * signal a corrupt session that should reset); a null timestamp means no history
+ * to defer.
+ */
+export function shouldDeferDailyReset(
+  lastMessageTime: string | null,
+  now: number = Date.now(),
+): boolean {
+  if (!lastMessageTime) return false;
+  const ms = new Date(lastMessageTime).getTime();
+  if (Number.isNaN(ms)) return false;
+  return now - ms < DAILY_RESET_DEFER_MS;
+}

--- a/packages/core/src/channels/telegram-update-offsets.ts
+++ b/packages/core/src/channels/telegram-update-offsets.ts
@@ -1,0 +1,136 @@
+import {
+  createHash,
+} from "node:crypto";
+import { existsSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+// Durable Telegram update-offset / dedupe store. Normal polling no longer drops
+// pending updates on startup (so a message sent while the bot was down is still
+// delivered on restart); this store is the safety that keeps a restart from
+// re-processing an update the previous run already handled, and keeps a
+// self-update `/update` from re-triggering itself after the restart.
+//
+// The store is owner-only JSON under dataDir, keyed by a short SHA-256 of the
+// bot token so two bots sharing a dataDir never share a dedupe log. The raw
+// token is NEVER written — only its fingerprint appears (in the filename).
+
+// Bounded ring of recently dispatched update ids. Guards exact-replay dedupe
+// (a crash mid-turn re-delivers an update whose id was already recorded).
+export const MAX_DISPATCHED_IDS = 200;
+
+const STORE_VERSION = 1 as const;
+
+export interface SelfUpdateMarker {
+  updateId: number | null;
+  chatId: number;
+  ts: string;
+  targetVersion: string;
+}
+
+export interface UpdateOffsetState {
+  version: typeof STORE_VERSION;
+  lastUpdateId: number;
+  dispatchedUpdateIds: number[];
+  selfUpdate?: SelfUpdateMarker;
+}
+
+// Short, non-reversible fingerprint of the bot token. Only the first 16 hex
+// chars are used — enough to disambiguate co-located bots, not enough to be a
+// credential.
+export function tokenFingerprint(token: string): string {
+  return createHash("sha256").update(token).digest("hex").slice(0, 16);
+}
+
+function emptyState(): UpdateOffsetState {
+  return { version: STORE_VERSION, lastUpdateId: 0, dispatchedUpdateIds: [] };
+}
+
+export class TelegramUpdateOffsetStore {
+  private readonly path: string;
+
+  constructor(dataDir: string, token: string) {
+    this.path = join(dataDir, `telegram-offsets.${tokenFingerprint(token)}.json`);
+  }
+
+  load(): UpdateOffsetState {
+    if (!existsSync(this.path)) return emptyState();
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(readFileSync(this.path, "utf-8"));
+    } catch {
+      return emptyState();
+    }
+    if (typeof parsed !== "object" || parsed === null) return emptyState();
+    const v = parsed as Record<string, unknown>;
+    const lastUpdateId = typeof v.lastUpdateId === "number" ? v.lastUpdateId : 0;
+    const dispatchedUpdateIds = Array.isArray(v.dispatchedUpdateIds)
+      ? v.dispatchedUpdateIds.filter((n): n is number => typeof n === "number")
+      : [];
+    const state: UpdateOffsetState = {
+      version: STORE_VERSION,
+      lastUpdateId,
+      dispatchedUpdateIds,
+    };
+    const marker = v.selfUpdate;
+    if (typeof marker === "object" && marker !== null) {
+      const m = marker as Record<string, unknown>;
+      if (
+        typeof m.chatId === "number" &&
+        typeof m.ts === "string" &&
+        typeof m.targetVersion === "string"
+      ) {
+        state.selfUpdate = {
+          updateId: typeof m.updateId === "number" ? m.updateId : null,
+          chatId: m.chatId,
+          ts: m.ts,
+          targetVersion: m.targetVersion,
+        };
+      }
+    }
+    return state;
+  }
+
+  private save(state: UpdateOffsetState): void {
+    const tmp = `${this.path}.tmp`;
+    writeFileSync(tmp, JSON.stringify(state), { encoding: "utf-8", mode: 0o600 });
+    renameSync(tmp, this.path);
+  }
+
+  // Record an update id as dispatched, advancing the offset and the bounded ring.
+  private record(state: UpdateOffsetState, updateId: number): void {
+    if (!state.dispatchedUpdateIds.includes(updateId)) {
+      state.dispatchedUpdateIds.push(updateId);
+    }
+    if (state.dispatchedUpdateIds.length > MAX_DISPATCHED_IDS) {
+      state.dispatchedUpdateIds = state.dispatchedUpdateIds.slice(-MAX_DISPATCHED_IDS);
+    }
+    if (updateId > state.lastUpdateId) state.lastUpdateId = updateId;
+  }
+
+  // Returns true if this update should be dispatched, recording it first —
+  // record before dispatch so a crash-mid-turn re-delivery dedupes safely.
+  // Fails OPEN: a corrupt or unwritable store must never silence the athlete, so
+  // any error means "dispatch it" rather than dropping the message.
+  shouldDispatch(updateId: number): boolean {
+    try {
+      const state = this.load();
+      if (updateId <= state.lastUpdateId) return false;
+      if (state.dispatchedUpdateIds.includes(updateId)) return false;
+      this.record(state, updateId);
+      this.save(state);
+      return true;
+    } catch {
+      return true;
+    }
+  }
+
+  // Persist a self-update marker before `/update` stops the bot. The marker id
+  // is recorded as dispatched so the re-delivered `/update` is deduped after the
+  // restart. Throws on write failure so the caller can decline to stop.
+  recordSelfUpdate(marker: SelfUpdateMarker): void {
+    const state = this.load();
+    state.selfUpdate = marker;
+    if (typeof marker.updateId === "number") this.record(state, marker.updateId);
+    this.save(state);
+  }
+}

--- a/packages/core/src/channels/telegram.ts
+++ b/packages/core/src/channels/telegram.ts
@@ -15,6 +15,7 @@ import {
 } from "../updater.js";
 import { buildWhatsNewMessage } from "../release-notes.js";
 import { createAuthMiddleware } from "./telegram-access.js";
+import { TelegramUpdateOffsetStore } from "./telegram-update-offsets.js";
 import { loadAllowedSenders, loadAllowedSendersWithSource } from "./allowed-senders.js";
 import { escapeHtmlText } from "./html-escape.js";
 import type { ReferenceServices } from "../reference/services.js";
@@ -51,6 +52,12 @@ const DELIVERY_FAILURE_HINT = `I generated the answer, but Telegram had trouble 
 // bot.catch — those are Telegram transport errors, not LLM/tool errors, so they
 // must not be dressed in provider-specific vocabulary.
 const GENERIC_TRANSPORT_APOLOGY = "Sorry, something went wrong. Please try again.";
+
+// Shown when /update can't durably record the self-update marker. Without that
+// marker a restart could re-trigger /update in a loop, so we decline to stop and
+// tell the athlete to retry rather than risk the loop.
+const SELF_UPDATE_MARKER_FAILURE =
+  "Couldn't safely prepare the update just now. Please try /update again in a moment.";
 
 // How often to re-emit Telegram's native "typing" indicator while a turn is in
 // flight. Telegram auto-clears the indicator ~5s after each sendChatAction, so we
@@ -232,6 +239,12 @@ export function createTelegramBot(
   const bot = createSecuredBot({ token, binary, dataDir });
   const log = createSubsystemLogger("telegram", dataDir);
   const greeted = new Set<number>();
+
+  // Durable update-offset store. Normal polling processes pending updates (so a
+  // message sent while the bot was down still arrives); the guard below dedupes
+  // anything a previous run already dispatched or acknowledged before a crash /
+  // self-update restart.
+  const offsets = new TelegramUpdateOffsetStore(dataDir, token);
 
   // Process-local per-chat cache of the last generated answer, so an athlete can
   // ask for it again after a Telegram delivery failure without re-running the LLM
@@ -424,6 +437,15 @@ export function createTelegramBot(
     await next();
   });
 
+  // Update-offset dedupe guard. Runs after the flush middleware and before every
+  // handler: an update already dispatched — or acknowledged before a crash /
+  // self-update restart — is skipped so its work never re-runs.
+  bot.use(async (ctx, next) => {
+    const updateId = ctx.update?.update_id;
+    if (typeof updateId === "number" && !offsets.shouldDispatch(updateId)) return;
+    await next();
+  });
+
   // ── Commands ────────────────────────────────────────────────────────────
 
   bot.command("start", async (ctx) => {
@@ -591,6 +613,24 @@ export function createTelegramBot(
         return;
       }
       latest = info.latest;
+      // Persist a durable self-update marker BEFORE stopping. It records the
+      // /update's own update id as dispatched so the restart doesn't re-trigger
+      // /update. If the marker can't be written we must NOT stop — a
+      // restart could otherwise loop on /update — so surface a safe retry copy.
+      try {
+        offsets.recordSelfUpdate({
+          updateId: typeof ctx.update?.update_id === "number" ? ctx.update.update_id : null,
+          chatId: ctx.chat.id,
+          ts: new Date().toISOString(),
+          targetVersion: info.latest,
+        });
+      } catch (markerErr) {
+        log.error("self_update_marker_failed", markerErr, {
+          chatId: `telegram:${ctx.chat.id}`,
+        });
+        await ctx.reply(SELF_UPDATE_MARKER_FAILURE);
+        return;
+      }
       await ctx.reply(`Updating ${info.current} → ${info.latest}...\nThe bot will stop after installation. Run \`${binary.binaryName}\` to start it again.`);
       // Stop polling first so Telegram commits the /update offset — otherwise
       // Telegram re-sends /update on next startup and we loop forever — then let

--- a/packages/core/src/run-binary.ts
+++ b/packages/core/src/run-binary.ts
@@ -399,7 +399,11 @@ export async function runBinary(
     // handler's clean exit(0). A genuine startup failure (bad token, pre-signal
     // crash) leaves shuttingDown false and still fatals.
     let shuttingDown = false;
-    bot.start({ drop_pending_updates: true }).catch(async (err) => {
+    // Normal startup does NOT drop pending updates: a message sent while the bot
+    // was down must still be delivered on restart. The durable update-offset
+    // guard inside createTelegramBot dedupes anything the previous run already
+    // handled. (Operator-capture startup keeps drop_pending_updates on purpose.)
+    bot.start().catch(async (err) => {
       if (shuttingDown) return;
       const { reportFatal } = await import("./process-guard.js");
       reportFatal(err, { dataDir: config.dataDir });

--- a/packages/core/tests/chat-store.test.ts
+++ b/packages/core/tests/chat-store.test.ts
@@ -10,7 +10,8 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { ChatStore } from "../src/agent/chat-store.js";
+import { ChatStore, TURN_FAILURE_MARKER } from "../src/agent/chat-store.js";
+import { makeSummaryMessage } from "../src/agent/history-limit.js";
 
 // ESM module namespaces are non-configurable, so vi.spyOn cannot intercept a
 // named fs import. Mock the module up front: appendFileSync is a spy that
@@ -305,5 +306,74 @@ describe("ChatStore — empty assistant guard", () => {
     vi.spyOn(console, "warn").mockImplementation(() => {});
     store.appendMessage("g3", "assistant", "");
     expect(assistantCount(store, "g3")).toBe(0);
+  });
+});
+
+describe("ChatStore.overwriteHistory — timestamp preservation", () => {
+  const OLD_TS = "1998-03-01T10:00:00.000Z";
+
+  function rawLines(chatId: string): Array<{ role: string; content: string; ts: string }> {
+    return readFileSync(join(sessionsDir, `${chatId}.jsonl`), "utf-8")
+      .split("\n")
+      .filter((l) => l.trim() !== "")
+      .map((l) => JSON.parse(l) as { role: string; content: string; ts: string });
+  }
+
+  it("keeps a surviving message's original ts and stamps summary lines fresh", () => {
+    const store = new ChatStore(dataDir);
+    writeFileSync(
+      join(sessionsDir, "ts.jsonl"),
+      JSON.stringify({ role: "user", content: "keep me", ts: OLD_TS }) +
+        "\n" +
+        JSON.stringify({ role: "assistant", content: "kept reply", ts: OLD_TS }) +
+        "\n",
+      "utf-8",
+    );
+
+    const before = Date.now();
+    store.overwriteHistory("ts", [
+      makeSummaryMessage("older stuff summarized"),
+      { role: "user", content: "keep me" },
+      { role: "assistant", content: "kept reply" },
+    ]);
+
+    const lines = rawLines("ts");
+    const summary = lines.find((l) => l.role === "system")!;
+    const user = lines.find((l) => l.role === "user")!;
+    const assistant = lines.find((l) => l.role === "assistant")!;
+    expect(user.ts).toBe(OLD_TS);
+    expect(assistant.ts).toBe(OLD_TS);
+    expect(Date.parse(summary.ts)).toBeGreaterThanOrEqual(before);
+  });
+
+  it("stamps a brand-new (non-surviving) message with a fresh ts", () => {
+    const store = new ChatStore(dataDir);
+    writeFileSync(
+      join(sessionsDir, "ts2.jsonl"),
+      JSON.stringify({ role: "user", content: "original", ts: OLD_TS }) + "\n",
+      "utf-8",
+    );
+    const before = Date.now();
+    store.overwriteHistory("ts2", [{ role: "assistant", content: "totally new" }]);
+    expect(Date.parse(rawLines("ts2")[0].ts)).toBeGreaterThanOrEqual(before);
+  });
+});
+
+describe("ChatStore.appendFailureMarker", () => {
+  it("appends a system failure marker after a durable user line", () => {
+    const store = new ChatStore(dataDir);
+    store.appendMessage("f1", "user", "remember I hate hills");
+    store.appendFailureMarker("f1");
+    const { messages } = store.load("f1");
+    expect(messages).toEqual([
+      { role: "user", content: "remember I hate hills" },
+      { role: "system", content: TURN_FAILURE_MARKER },
+    ]);
+  });
+
+  it("is a no-op when no session file exists", () => {
+    const store = new ChatStore(dataDir);
+    store.appendFailureMarker("ghost");
+    expect(existsSync(join(sessionsDir, "ghost.jsonl"))).toBe(false);
   });
 });

--- a/packages/core/tests/coach-agent-deliver-first.test.ts
+++ b/packages/core/tests/coach-agent-deliver-first.test.ts
@@ -4,6 +4,7 @@ import {
   rmSync,
   mkdirSync,
   readFileSync,
+  writeFileSync,
   existsSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -99,7 +100,10 @@ describe("coach-agent deliver-first persistence", () => {
     );
     resetNotice = __resetPersistenceNoticeState;
     resetNotice();
-    vi.spyOn(ChatStore.prototype, "appendTurn").mockImplementation(() => {
+    // The user line is appended before generation and the assistant line after;
+    // both go through appendMessage now. Throwing on it exercises deliver-first
+    // on the reply-persist path (the disk-full note rides the assistant append).
+    vi.spyOn(ChatStore.prototype, "appendMessage").mockImplementation(() => {
       throw errored("ENOSPC");
     });
     vi.spyOn(console, "warn").mockImplementation(() => {});
@@ -119,7 +123,7 @@ describe("coach-agent deliver-first persistence", () => {
     );
     resetNotice = __resetPersistenceNoticeState;
     resetNotice();
-    vi.spyOn(ChatStore.prototype, "appendTurn").mockImplementation(() => {
+    vi.spyOn(ChatStore.prototype, "appendMessage").mockImplementation(() => {
       throw errored("EACCES");
     });
     vi.spyOn(console, "warn").mockImplementation(() => {});
@@ -146,5 +150,72 @@ describe("coach-agent deliver-first persistence", () => {
       .filter((l) => l.length > 0);
     expect(lines.some((l) => l.includes('"role":"user"'))).toBe(true);
     expect(lines.some((l) => l.includes('"role":"assistant"'))).toBe(true);
+  });
+
+  it("leaves the athlete message and a failure marker in history when the turn throws", async () => {
+    const complete = vi.fn(async (params: { system?: string }) => {
+      const sys = params.system ?? "";
+      if (sys.includes(FLUSH_MARKER)) return mkAssistant("facts noted");
+      if (sys.length === 0) return mkAssistant("summary");
+      throw new Error("provider exploded");
+    });
+    const { agent, __resetPersistenceNoticeState } = await setupAgent(complete);
+    resetNotice = __resetPersistenceNoticeState;
+    resetNotice();
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await expect(agent.chat("fail-chat", "remember I hate hills")).rejects.toThrow();
+
+    const lines = readFileSync(sessionFile("fail-chat"), "utf-8")
+      .split("\n")
+      .filter((l) => l.length > 0)
+      .map((l) => JSON.parse(l) as { role: string; content: string });
+    expect(lines.some((l) => l.role === "user" && l.content === "remember I hate hills")).toBe(true);
+    expect(lines.some((l) => l.role === "system" && l.content.includes("did not complete"))).toBe(true);
+  });
+
+  it("prefixes the post-reset notice and shows the model a one-turn archive marker", async () => {
+    const POST_RESET_NOTICE =
+      "Started a fresh session - earlier conversation is archived, and I still have your key details in memory.";
+    const complete = happyComplete("here is the answer");
+    const { agent, __resetPersistenceNoticeState } = await setupAgent(complete);
+    resetNotice = __resetPersistenceNoticeState;
+    resetNotice();
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    // Seed a session last touched long before today's daily reset hour so the
+    // automatic daily reset fires (and is NOT deferred).
+    const oldTs = "1998-01-01T00:00:00.000Z";
+    writeFileSync(
+      sessionFile("reset-chat"),
+      JSON.stringify({ role: "user", content: "old q", ts: oldTs }) +
+        "\n" +
+        JSON.stringify({ role: "assistant", content: "old a", ts: oldTs }) +
+        "\n",
+      "utf-8",
+    );
+
+    const reply = await agent.chat("reset-chat", "how's my form?");
+
+    expect(reply.startsWith(POST_RESET_NOTICE)).toBe(true);
+    expect(reply).toContain("here is the answer");
+
+    const sawMarker = complete.mock.calls.some((call) => {
+      const params = call[0] as { messages?: Array<{ role: string; content: unknown }> };
+      return (
+        Array.isArray(params.messages) &&
+        params.messages.some(
+          (m) =>
+            m.role === "system" &&
+            typeof m.content === "string" &&
+            m.content.includes("Previous session archived at"),
+        )
+      );
+    });
+    expect(sawMarker).toBe(true);
+
+    // The prior transcript was archived (renamed away).
+    const archives = readFileSync(sessionFile("reset-chat"), "utf-8");
+    expect(archives).not.toContain("old q");
   });
 });

--- a/packages/core/tests/coach-agent-turn-outcome.test.ts
+++ b/packages/core/tests/coach-agent-turn-outcome.test.ts
@@ -242,7 +242,7 @@ describe("per-turn outcome line", () => {
     expect(lines[0].compactions).toBe(0);
   });
 
-  it("leaves the session JSONL byte-identical on a failed turn", async () => {
+  it("keeps the athlete message durable and marks the failed turn in history", async () => {
     const complete = vi.fn(async (params: { system?: string }) => {
       const sys = params.system ?? "";
       if (sys.includes(FLUSH_MARKER)) return mkAssistant("facts noted");
@@ -253,8 +253,6 @@ describe("per-turn outcome line", () => {
     vi.useFakeTimers();
     const agent = await setupAgent(complete);
 
-    const before = readSession("fail-chat");
-
     const p = agent.chat("fail-chat", "hello");
     const settled = p.then(
       () => undefined,
@@ -264,8 +262,16 @@ describe("per-turn outcome line", () => {
     await settled;
     vi.useRealTimers();
 
+    // The athlete message is appended before generation and survives the
+    // failure; a terminal failure marker records that the turn did not complete
+    // (instead of silently erasing the message).
     const after = readSession("fail-chat");
-    expect(after).toBe(before);
+    expect(after).not.toBeNull();
+    expect(after).toContain('"role":"user"');
+    expect(after).toContain("hello");
+    expect(after).toContain("did not complete");
+    // No assistant reply persisted for a failed turn.
+    expect(after).not.toContain('"role":"assistant"');
   });
 
   it("does not reject when the outcome sink throws", async () => {

--- a/packages/core/tests/flush-retry-degradation.test.ts
+++ b/packages/core/tests/flush-retry-degradation.test.ts
@@ -181,7 +181,10 @@ describe("flush retry and degradation", () => {
     seedSession("defer", STALE_FOUR);
 
     const t2 = await agent.chat("defer", "hello again");
-    expect(t2).toBe("turn-4");
+    // This turn archives (deferral is one-shot), so the reply carries the
+    // one-time post-reset notice prefix ahead of the model text.
+    expect(t2.startsWith("Started a fresh session")).toBe(true);
+    expect(t2).toContain("turn-4");
     const archives = listArchives("defer");
     expect(archives).toHaveLength(1);
     expect(readFileSync(join(dataDir, "sessions", archives[0]), "utf-8")).toContain("old-fact-1");
@@ -202,7 +205,9 @@ describe("flush retry and degradation", () => {
     seedSession("short", STALE_FOUR.slice(0, 2));
 
     const text = await agent.chat("short", "hello");
-    expect(text).toBe("turn-2");
+    // Archiving turn → reply prefixed with the one-time post-reset notice.
+    expect(text.startsWith("Started a fresh session")).toBe(true);
+    expect(text).toContain("turn-2");
     expect(listArchives("short")).toHaveLength(1);
     expect(eventsNamed(warnSpy, "memory_flush_archive_deferred")).toHaveLength(0);
   });

--- a/packages/core/tests/reset-flush-guard.test.ts
+++ b/packages/core/tests/reset-flush-guard.test.ts
@@ -127,7 +127,9 @@ describe("reset-path flush guards", () => {
 
     const text = await agent.chat("stale-guard", "hello");
 
-    expect(text).toBe("fresh-start");
+    // A reset turn now prefixes the one-time post-reset notice before the reply.
+    expect(text.startsWith("Started a fresh session")).toBe(true);
+    expect(text).toContain("fresh-start");
     expect(complete).toHaveBeenCalledTimes(3);
     const archives = listArchives("stale-guard");
     expect(archives).toHaveLength(1);

--- a/packages/core/tests/run-binary-allowlist.test.ts
+++ b/packages/core/tests/run-binary-allowlist.test.ts
@@ -379,6 +379,8 @@ describe("startup-capture predicate (T3)", () => {
     await runBinary(stubSport as never, cyclingBinary);
     expect(captureFn).toHaveBeenCalledTimes(1);
     expect(startSpy).toHaveBeenCalledTimes(1); // bot started despite getme-failed
-    expect(startSpy).toHaveBeenCalledWith({ drop_pending_updates: true });
+    // Normal startup no longer drops pending updates (offline messages survive a
+    // restart); the update-offset guard dedupes replays instead.
+    expect(startSpy).toHaveBeenCalledWith();
   });
 });

--- a/packages/core/tests/session-freshness.test.ts
+++ b/packages/core/tests/session-freshness.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
   evaluateSessionFreshness,
   resolveDailyResetAtMs,
+  shouldDeferDailyReset,
+  DAILY_RESET_DEFER_MS,
 } from "../src/agent/session-freshness.js";
 
 describe("evaluateSessionFreshness", () => {
@@ -110,5 +112,27 @@ describe("evaluateSessionFreshness", () => {
   it("resolveDailyResetAtMs falls back to yesterday's reset before the hour", () => {
     vi.setSystemTime(new Date("2026-06-11T02:00:00.000Z"));
     expect(resolveDailyResetAtMs(4, "UTC")).toBe(Date.UTC(2026, 5, 10, 4, 0, 0));
+  });
+});
+
+describe("shouldDeferDailyReset", () => {
+  const now = Date.parse("2026-06-11T04:05:00.000Z");
+
+  it("defers when the last exchange is within the grace window", () => {
+    const recent = new Date(now - (DAILY_RESET_DEFER_MS - 60_000)).toISOString();
+    expect(shouldDeferDailyReset(recent, now)).toBe(true);
+  });
+
+  it("does not defer once the last exchange is older than the grace window", () => {
+    const old = new Date(now - (DAILY_RESET_DEFER_MS + 60_000)).toISOString();
+    expect(shouldDeferDailyReset(old, now)).toBe(false);
+  });
+
+  it("never defers a malformed timestamp", () => {
+    expect(shouldDeferDailyReset("not-a-date", now)).toBe(false);
+  });
+
+  it("never defers when there is no history", () => {
+    expect(shouldDeferDailyReset(null, now)).toBe(false);
   });
 });

--- a/packages/core/tests/telegram-coalescing.test.ts
+++ b/packages/core/tests/telegram-coalescing.test.ts
@@ -214,15 +214,18 @@ describe("inbound coalescing (fake timers)", () => {
     expect(agent.chat).toHaveBeenCalledTimes(1);
   });
 
-  it("registration order: auth use → flush middleware use → every command", async () => {
+  it("registration order: auth use → flush middleware use → update guard → every command", async () => {
     const { bot } = await buildBot();
-    expect(bot.use).toHaveBeenCalledTimes(2);
+    // auth (createSecuredBot) → flush middleware → update-offset dedupe guard.
+    expect(bot.use).toHaveBeenCalledTimes(3);
     const authOrder = bot.use.mock.invocationCallOrder[0];
     const flushOrder = bot.use.mock.invocationCallOrder[1];
+    const guardOrder = bot.use.mock.invocationCallOrder[2];
     expect(authOrder).toBeLessThan(flushOrder);
+    expect(flushOrder).toBeLessThan(guardOrder);
     expect(bot.command.mock.invocationCallOrder.length).toBeGreaterThan(0);
     for (const commandOrder of bot.command.mock.invocationCallOrder) {
-      expect(flushOrder).toBeLessThan(commandOrder);
+      expect(guardOrder).toBeLessThan(commandOrder);
     }
   });
 

--- a/packages/core/tests/telegram-dispatch.test.ts
+++ b/packages/core/tests/telegram-dispatch.test.ts
@@ -21,6 +21,7 @@ afterEach(() => {
   vi.unstubAllEnvs();
   vi.doUnmock("grammy");
   vi.doUnmock("../src/updater.js");
+  vi.doUnmock("../src/channels/telegram-update-offsets.js");
 });
 
 interface FakeBot {
@@ -784,6 +785,40 @@ describe("/update — ordering invariant", () => {
     const ctx = makeCtx();
     await getCommand(bot, "update")(ctx);
     expect(someReply(ctx, "Could not check for updates. Try again later.")).toBe(true);
+    expect(selfUpdate).not.toHaveBeenCalled();
+  });
+
+  it("self-update marker write failure → safe retry copy, does NOT stop or self-update", async () => {
+    const selfUpdate = vi.fn();
+    vi.doMock("../src/updater.js", async () => {
+      const real = await vi.importActual<typeof import("../src/updater.js")>("../src/updater.js");
+      return {
+        ...real,
+        checkForUpdate: vi.fn(async () => ({
+          current: "2026.5.5",
+          latest: "2026.5.10",
+          updateAvailable: true,
+        })),
+        selfUpdate,
+      };
+    });
+    vi.doMock("../src/channels/telegram-update-offsets.js", () => ({
+      TelegramUpdateOffsetStore: class {
+        shouldDispatch() {
+          return true;
+        }
+        recordSelfUpdate() {
+          throw new Error("marker write failed");
+        }
+      },
+    }));
+
+    const { bot } = await buildBot();
+    const ctx = makeCtx();
+    await getCommand(bot, "update")(ctx);
+
+    expect(someReply(ctx, "Couldn't safely prepare the update just now")).toBe(true);
+    expect(bot.stop).not.toHaveBeenCalled();
     expect(selfUpdate).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/tests/telegram-update-offsets.test.ts
+++ b/packages/core/tests/telegram-update-offsets.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, readFileSync, readdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  TelegramUpdateOffsetStore,
+  tokenFingerprint,
+  MAX_DISPATCHED_IDS,
+} from "../src/channels/telegram-update-offsets.js";
+
+const TOKEN = "123456:ABC-DEF-super-secret-bot-token";
+
+let dataDir: string;
+
+beforeEach(() => {
+  dataDir = mkdtempSync(join(tmpdir(), "cc-tg-offsets-"));
+});
+
+afterEach(() => {
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+describe("tokenFingerprint", () => {
+  it("is a deterministic 16-hex-char digest that is not the raw token", () => {
+    const fp = tokenFingerprint(TOKEN);
+    expect(fp).toMatch(/^[0-9a-f]{16}$/);
+    expect(fp).toBe(tokenFingerprint(TOKEN));
+    expect(fp).not.toContain(TOKEN);
+    expect(tokenFingerprint("other")).not.toBe(fp);
+  });
+});
+
+describe("TelegramUpdateOffsetStore — dispatch dedupe", () => {
+  it("dispatches a new update once and skips an exact replay", () => {
+    const store = new TelegramUpdateOffsetStore(dataDir, TOKEN);
+    expect(store.shouldDispatch(10)).toBe(true);
+    expect(store.shouldDispatch(10)).toBe(false);
+  });
+
+  it("skips any update id at or below the persisted offset", () => {
+    const store = new TelegramUpdateOffsetStore(dataDir, TOKEN);
+    expect(store.shouldDispatch(20)).toBe(true);
+    expect(store.shouldDispatch(15)).toBe(false);
+    expect(store.shouldDispatch(20)).toBe(false);
+    expect(store.shouldDispatch(21)).toBe(true);
+  });
+
+  it("persists the dedupe log across store instances (restart)", () => {
+    new TelegramUpdateOffsetStore(dataDir, TOKEN).shouldDispatch(42);
+    const afterRestart = new TelegramUpdateOffsetStore(dataDir, TOKEN);
+    expect(afterRestart.shouldDispatch(42)).toBe(false);
+    expect(afterRestart.shouldDispatch(43)).toBe(true);
+  });
+
+  it("bounds the dispatched-id ring around the configured cap", () => {
+    const store = new TelegramUpdateOffsetStore(dataDir, TOKEN);
+    for (let id = 1; id <= MAX_DISPATCHED_IDS + 50; id++) store.shouldDispatch(id);
+    const state = store.load();
+    expect(state.dispatchedUpdateIds.length).toBeLessThanOrEqual(MAX_DISPATCHED_IDS);
+    // The offset high-water mark still dedupes ids evicted from the ring.
+    expect(store.shouldDispatch(1)).toBe(false);
+    expect(state.lastUpdateId).toBe(MAX_DISPATCHED_IDS + 50);
+  });
+
+  it("stores no raw bot token — only its fingerprint appears (in the filename)", () => {
+    const store = new TelegramUpdateOffsetStore(dataDir, TOKEN);
+    store.shouldDispatch(7);
+    const files = readdirSync(dataDir);
+    const offsetFile = files.find((f) => f.startsWith("telegram-offsets."));
+    expect(offsetFile).toBeDefined();
+    expect(offsetFile).toContain(tokenFingerprint(TOKEN));
+    expect(offsetFile).not.toContain(TOKEN);
+    const raw = readFileSync(join(dataDir, offsetFile!), "utf-8");
+    expect(raw).not.toContain(TOKEN);
+  });
+
+  it("fails open — dispatches when the store cannot be persisted", () => {
+    const store = new TelegramUpdateOffsetStore(join(dataDir, "does", "not", "exist"), TOKEN);
+    expect(store.shouldDispatch(5)).toBe(true);
+  });
+});
+
+describe("TelegramUpdateOffsetStore — self-update marker", () => {
+  it("persists the marker and dedupes the /update's own update id after restart", () => {
+    const store = new TelegramUpdateOffsetStore(dataDir, TOKEN);
+    store.recordSelfUpdate({
+      updateId: 99,
+      chatId: 777,
+      ts: "1998-06-01T00:00:00.000Z",
+      targetVersion: "2026.6.1",
+    });
+    const restarted = new TelegramUpdateOffsetStore(dataDir, TOKEN);
+    expect(restarted.load().selfUpdate).toEqual({
+      updateId: 99,
+      chatId: 777,
+      ts: "1998-06-01T00:00:00.000Z",
+      targetVersion: "2026.6.1",
+    });
+    // The re-delivered /update after the restart is deduped.
+    expect(restarted.shouldDispatch(99)).toBe(false);
+  });
+
+  it("accepts a marker with a null update id (direct handler invocation)", () => {
+    const store = new TelegramUpdateOffsetStore(dataDir, TOKEN);
+    expect(() =>
+      store.recordSelfUpdate({
+        updateId: null,
+        chatId: 1,
+        ts: "1998-06-01T00:00:00.000Z",
+        targetVersion: "2026.6.1",
+      }),
+    ).not.toThrow();
+    expect(store.load().selfUpdate?.updateId).toBeNull();
+  });
+
+  it("throws when the marker cannot be written (so /update can decline to stop)", () => {
+    const store = new TelegramUpdateOffsetStore(join(dataDir, "missing"), TOKEN);
+    expect(() =>
+      store.recordSelfUpdate({
+        updateId: 1,
+        chatId: 1,
+        ts: "1998-06-01T00:00:00.000Z",
+        targetVersion: "2026.6.1",
+      }),
+    ).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Hardens Telegram update handling and daily-session boundaries so messages are no longer silently lost across restarts and session rollovers.

- **Update offsets are now durable.** Normal startup no longer drops pending updates. A durable, owner-only offset store keyed by a short token fingerprint (never the raw token) dedupes anything a previous run already handled, and stops `/update` from re-triggering itself after a self-update restart. Operator-capture startup still intentionally drops prior updates.
- **Session edges are preserved.** A daily session reset is deferred for one turn when the last exchange is still recent (within 30 minutes), so a conversation that crosses the daily boundary isn't archived mid-thread. Malformed timestamps and idle resets are never deferred.
- **Fresh-session disclosure.** On an automatic reset the first reply is prefixed once with a plain-language notice, and the model sees a one-turn archive marker so it discloses that a new session has started while your key details are still remembered.
- **Durable athlete messages.** The athlete's message is made durable before generation and a failed turn is recorded with a terminal marker, so a mid-turn crash no longer silently erases the message.
- **Compaction fidelity.** Compaction now preserves surviving messages' original timestamps.

## Test plan

- `pnpm vitest run` over the core package: new/updated suites for the offset store, session freshness, dispatch/coalescing, chat-store, deliver-first and turn-outcome paths, flush-retry degradation, reset-flush guard, and the run-binary allowlist.
- Verified typecheck and lint pass across the changed surfaces.
