### PR TITLE
fix(core): classify overflow and cap effective context estimates

### DIFF
--- a/.changeset/overflow-estimation-cap.md
+++ b/.changeset/overflow-estimation-cap.md
@@ -1,0 +1,7 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Long chats that hit the model's context limit now compact and retry to produce a complete answer instead of returning a cut-off reply.
+
+Harden context-overflow classification, token estimation, and effective-window caps. Context-overflow classification now recognizes structured provider signals (Codex-normalized `ContextOverflowError`, and 400 responses whose body carries a known overflow code or message) on top of the existing message fallbacks, without treating every 400 as overflow. A successful `length` finish whose prompt already filled the real provider window is routed through the existing compaction rescue rather than persisting the truncated text; plain output-length truncation keeps the earlier empty-reply recovery. Token estimation counts part-array/structured message content instead of dropping it to zero and can anchor budget math to the provider's reported token usage. History budget, preemptive compaction, and compaction chunk sizing use a 200,000-token effective estimator window (`min(providerWindow, 200k)`) so a million-token provider window no longer expands the planning target.

--- a/packages/core/src/agent/coach-agent.ts
+++ b/packages/core/src/agent/coach-agent.ts
@@ -28,7 +28,9 @@ import { splitHistoryByBudget, makeSummaryMessage } from "./history-limit.js";
 import {
   shouldCompact,
   computeHistoryTokenBudget,
+  effectiveEstimatorWindowTokens,
   isContextOverflowError,
+  isWindowExceededFinish,
   isTimeoutError,
   isRateLimitError,
   classifyFailure,
@@ -209,6 +211,12 @@ export class CoachAgent {
   private tz: string;
   private archiveDeferred = new Set<string>();
   private lastFlushMessageCount = new Map<string, number>();
+  // Per-chat provider usage anchor from the last successful turn: the real token
+  // count the model reported plus the message count it saw. Used only to make the
+  // next turn's preemptive budget check safer (see estimatePromptTokens); it is
+  // never a provider-truth substitute and is cleared whenever we compact so a
+  // stale anchor cannot force a redundant compaction on an already-small prompt.
+  private usageAnchor = new Map<string, { promptTokens: number; messageCount: number }>();
   // A committed tool write makes the turn non-replayable: the retry loop re-sends
   // the pre-turn messages, so a second generate could re-run the write. Keep it
   // in async-local turn state so concurrent chats cannot reset each other.
@@ -414,7 +422,9 @@ export class CoachAgent {
       caller: "compact" as const,
       mustPreserveTokens: this.sport.mustPreserveTokens,
       memory: createMemorySnapshot(this.memory),
-      contextWindowTokens: this.config.contextWindowTokens,
+      // Chunk sizing off the effective (capped) window so a 1M provider window
+      // does not scale summary chunks past the estimator ceiling.
+      contextWindowTokens: effectiveEstimatorWindowTokens(this.config.contextWindowTokens),
       budget,
     };
   }
@@ -499,6 +509,7 @@ export class CoachAgent {
           this.archiveDeferred.delete(chatId);
           this.chatStore.archiveAndReset(chatId);
           this.lastFlushMessageCount.delete(chatId);
+          this.usageAnchor.delete(chatId);
           history = [];
           archivedAt = new Date().toISOString();
         }
@@ -628,8 +639,21 @@ export class CoachAgent {
           turnBudget.chargeAttempt();
           turnBudget.checkDeadline();
 
-          // Preemptive: compact before sending if over budget
-          if (shouldCompact({ messages, systemPrompt: this.systemPrompt, contextWindowTokens: this.config.contextWindowTokens })) {
+          // Preemptive: compact before sending if over budget. The usage anchor
+          // (last turn's final prompt token count) makes the estimate safer for
+          // non-Latin text; slicing past the anchored message count yields the
+          // messages appended since, and estimatePromptTokens floors at the char
+          // estimate so a misaligned slice can never lower the estimate.
+          const anchor = this.usageAnchor.get(chatId);
+          if (
+            shouldCompact({
+              messages,
+              systemPrompt: this.systemPrompt,
+              contextWindowTokens: this.config.contextWindowTokens,
+              lastUsageTokens: anchor?.promptTokens,
+              messagesSinceUsageAnchor: anchor ? messages.slice(anchor.messageCount) : undefined,
+            })
+          ) {
             if (!flushedThisTurn) {
               flushedThisTurn = true;
               try {
@@ -641,6 +665,7 @@ export class CoachAgent {
             messages = await summarizeInStages({ messages, ...this.compactionParams(turnBudget) });
             compactions++;
             this.memory.reload();
+            this.usageAnchor.delete(chatId);
           }
 
           try {
@@ -658,6 +683,27 @@ export class CoachAgent {
               deadlineMs: turnBudget.remainingMs(),
             });
             const { text, finishReason } = result;
+
+            // A successful "length" finish whose prompt already filled the real
+            // provider window is a context overflow, not a long answer. Route it
+            // through the existing reactive overflow rescue (compact + retry) and
+            // never persist the truncated text — throw a normalized overflow so
+            // the catch block below handles it exactly like a thrown overflow.
+            // Plain output-length truncation (input below the window) falls
+            // through to recoverStepExhaustedText's existing empty-reply handling.
+            if (
+              isWindowExceededFinish({
+                finishReason,
+                usage: result.usage,
+                contextWindowTokens: this.config.contextWindowTokens,
+              })
+            ) {
+              const overflow = new Error(
+                "Provider reported the context window was exceeded on a successful finish",
+              );
+              overflow.name = "ContextOverflowError";
+              throw overflow;
+            }
 
             // Recovery runs only on this success path (before the catch below).
             const effectiveText = await this.recoverStepExhaustedText(
@@ -722,6 +768,18 @@ export class CoachAgent {
               compactions,
             });
 
+            // Anchor the next turn's budget check to the FINAL step's prompt
+            // token count — the context the model actually saw, system prompt
+            // included. Never the cross-step aggregate (totalUsage), which
+            // overstates a multi-step tool turn several-fold and would force
+            // needless compactions. messages.length is the prompt count the
+            // model saw; the next turn char-estimates only messages appended
+            // beyond it.
+            const anchorTokens = result.usage?.inputTokens;
+            if (typeof anchorTokens === "number" && Number.isFinite(anchorTokens)) {
+              this.usageAnchor.set(chatId, { promptTokens: anchorTokens, messageCount: messages.length });
+            }
+
             // Prefix the one-time post-reset notice onto the first reply after
             // an automatic archive. Not persisted to history — it is a channel
             // disclosure, not conversation content.
@@ -772,6 +830,7 @@ export class CoachAgent {
                 messages = await summarizeInStages({ messages, ...this.compactionParams(turnBudget) });
                 compactions++;
                 this.memory.reload();
+                this.usageAnchor.delete(chatId);
               } catch (rescueErr) {
                 this.log.warn("Compaction rescue failed; rethrowing the original turn error", rescueErr);
                 if (err instanceof Error && err.cause === undefined) {
@@ -790,6 +849,7 @@ export class CoachAgent {
                   messages = await summarizeInStages({ messages, ...this.compactionParams(turnBudget) });
                   compactions++;
                   this.memory.reload();
+                  this.usageAnchor.delete(chatId);
                 } catch (rescueErr) {
                   this.log.warn("Compaction rescue failed; rethrowing the original turn error", rescueErr);
                   if (err instanceof Error && err.cause === undefined) {
@@ -930,6 +990,7 @@ export class CoachAgent {
       this.archiveDeferred.delete(chatId);
       this.chatStore.archiveAndReset(chatId);
       this.lastFlushMessageCount.delete(chatId);
+      this.usageAnchor.delete(chatId);
       return { memoryFlushed };
     });
   }

--- a/packages/core/src/agent/token-utils.ts
+++ b/packages/core/src/agent/token-utils.ts
@@ -1,4 +1,4 @@
-import type { ModelMessage } from "ai";
+import type { FinishReason, LanguageModelUsage, ModelMessage } from "ai";
 import { APICallError } from "@ai-sdk/provider";
 
 export const CHARS_PER_TOKEN = 4;
@@ -8,8 +8,34 @@ export const MIN_PROMPT_BUDGET_TOKENS = 8000;
 export const TIMEOUT_COMPACTION_THRESHOLD = 0.65;
 export const SUMMARIZATION_OVERHEAD_TOKENS = 4096;
 
+// The provider context window can be 1M+ tokens, which would let history budget
+// math build enormous prompts even when product cost/latency want earlier
+// compaction. Cap the ESTIMATOR window (never the provider truth) so budget math
+// uses min(providerWindow, 200k). Smaller provider windows apply unchanged.
+export const MAX_EFFECTIVE_WINDOW_ESTIMATOR_TOKENS = 200_000;
+
+export function effectiveEstimatorWindowTokens(contextWindowTokens: number): number {
+  return Math.min(contextWindowTokens, MAX_EFFECTIVE_WINDOW_ESTIMATOR_TOKENS);
+}
+
 export function messageText(m: ModelMessage): string {
-  return typeof m.content === "string" ? m.content : "";
+  const content = m.content;
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  // Non-string content used to estimate as zero, silently undercounting a
+  // part-array message (tool outputs, structured parts) toward the context
+  // budget. Take text parts verbatim and JSON-serialize other structured parts
+  // so their size is counted rather than dropped.
+  let out = "";
+  for (const part of content) {
+    if (typeof part === "string") {
+      out += part;
+    } else if (part !== null && typeof part === "object") {
+      const text = (part as { text?: unknown }).text;
+      out += typeof text === "string" ? text : JSON.stringify(part);
+    }
+  }
+  return out;
 }
 
 export function estimateTokens(text: string): number {
@@ -20,13 +46,37 @@ export function estimateMessagesTokens(messages: ModelMessage[]): number {
   return messages.reduce((sum, m) => sum + estimateTokens(messageText(m)), 0);
 }
 
+// Budget-check token estimate. When a provider usage anchor is available, the
+// tokens the model already saw are anchored to the provider's real count (which
+// tokenizes non-Latin text far more accurately than chars/4) and only messages
+// appended since the anchor are char-estimated. The result is a safer,
+// never-lower floor than the pure char estimate; it never replaces the raw
+// provider context truth.
+export function estimatePromptTokens(params: {
+  messages: ModelMessage[];
+  systemPrompt: string;
+  // Final-step prompt token count from the provider — already includes the
+  // system prompt, so the anchored branch must not add it again.
+  lastUsageTokens?: number;
+  messagesSinceUsageAnchor?: ModelMessage[];
+}): number {
+  const charEstimate =
+    estimateMessagesTokens(params.messages) + estimateTokens(params.systemPrompt);
+  if (params.lastUsageTokens === undefined || params.messagesSinceUsageAnchor === undefined) {
+    return charEstimate;
+  }
+  const anchored =
+    params.lastUsageTokens + estimateMessagesTokens(params.messagesSinceUsageAnchor);
+  return Math.max(charEstimate, anchored);
+}
+
 export function computeHistoryTokenBudget(params: {
   contextWindowTokens: number;
   systemPrompt: string;
   budgetRatio: number;
 }): number {
   const raw =
-    Math.floor(params.contextWindowTokens * params.budgetRatio) -
+    Math.floor(effectiveEstimatorWindowTokens(params.contextWindowTokens) * params.budgetRatio) -
     estimateTokens(params.systemPrompt) -
     RESERVE_TOKENS;
   return Math.max(raw, MIN_PROMPT_BUDGET_TOKENS);
@@ -36,24 +86,75 @@ export function shouldCompact(params: {
   messages: ModelMessage[];
   systemPrompt: string;
   contextWindowTokens: number;
+  lastUsageTokens?: number;
+  messagesSinceUsageAnchor?: ModelMessage[];
 }): boolean {
-  const estimated =
-    estimateMessagesTokens(params.messages) + estimateTokens(params.systemPrompt);
-  const budget = params.contextWindowTokens - RESERVE_TOKENS;
+  const estimated = estimatePromptTokens(params);
+  const budget = effectiveEstimatorWindowTokens(params.contextWindowTokens) - RESERVE_TOKENS;
   return estimated > budget;
 }
 
+const OVERFLOW_MESSAGE_PATTERNS = [
+  "context_length",
+  "context window",
+  "maximum context",
+  "token limit",
+  "too many tokens",
+  "content_too_large",
+  "prompt is too long",
+  "exceeds the maximum",
+  "input token count",
+] as const;
+
+// A single OpenAI-family structured code; other providers signal overflow only
+// in the message text, handled by the pattern list above.
+const OVERFLOW_ERROR_CODES = new Set(["context_length_exceeded"]);
+
+function matchesOverflowText(text: string): boolean {
+  const lower = text.toLowerCase();
+  return OVERFLOW_MESSAGE_PATTERNS.some((p) => lower.includes(p));
+}
+
+// A 400 is the only status that can carry a context-overflow invalid request;
+// a generic 400 must stay invalid_request, so read the structured body rather
+// than treating every 400 as overflow.
+function apiCallOverflowSignal(err: APICallError): boolean {
+  if (err.statusCode !== 400) return false;
+  const data = err.data as
+    | { error?: { code?: unknown; message?: unknown } }
+    | undefined;
+  const code = data?.error?.code;
+  if (typeof code === "string" && OVERFLOW_ERROR_CODES.has(code)) return true;
+  const bodyMessage = data?.error?.message;
+  if (typeof bodyMessage === "string" && matchesOverflowText(bodyMessage)) return true;
+  if (typeof err.responseBody === "string" && matchesOverflowText(err.responseBody)) return true;
+  return false;
+}
+
 export function isContextOverflowError(err: unknown): boolean {
+  // Codex-normalized overflow is authoritative (the bridge sets this name).
+  if (err instanceof Error && err.name === "ContextOverflowError") return true;
+  if (APICallError.isInstance(err) && apiCallOverflowSignal(err)) return true;
   if (!(err instanceof Error)) return false;
-  const msg = err.message.toLowerCase();
-  return (
-    msg.includes("context_length") ||
-    msg.includes("context window") ||
-    msg.includes("maximum context") ||
-    msg.includes("token limit") ||
-    msg.includes("too many tokens") ||
-    msg.includes("content_too_large")
-  );
+  return matchesOverflowText(err.message);
+}
+
+// A successful generation whose finishReason is "length" is normally plain
+// output-length truncation. But when the prompt alone already filled (or
+// exceeded) the real provider window, that same "length" stop means the context
+// window was exhausted, not that the model wrote a long answer. Detect the
+// latter from usage so it can be routed to compaction rescue instead of being
+// persisted as a truncated reply. Uses the RAW provider window (truth), not the
+// estimator cap.
+export function isWindowExceededFinish(params: {
+  finishReason: FinishReason;
+  usage: LanguageModelUsage | undefined;
+  contextWindowTokens: number;
+}): boolean {
+  if (params.finishReason !== "length") return false;
+  const inputTokens = params.usage?.inputTokens;
+  if (typeof inputTokens !== "number" || !Number.isFinite(inputTokens)) return false;
+  return inputTokens >= params.contextWindowTokens;
 }
 
 export function isTimeoutError(err: unknown): boolean {

--- a/packages/core/tests/coach-agent-empty-reply.test.ts
+++ b/packages/core/tests/coach-agent-empty-reply.test.ts
@@ -136,6 +136,37 @@ describe("coach-agent empty-reply guards", () => {
     expect(assistants[0].content).toBe(reply);
   });
 
+  it("routes a successful window-exceeded finish through compaction/retry without persisting the truncated text", async () => {
+    let mainCalls = 0;
+    const complete = vi.fn(async (params: { system?: string; tools?: unknown }) => {
+      const sys = params.system ?? "";
+      if (sys.includes(FLUSH_MARKER)) return mkAssistant("facts noted");
+      if (sys.length === 0) return mkAssistant("summary");
+      mainCalls++;
+      if (mainCalls === 1) {
+        // A successful "length" finish whose input already filled the 272k window.
+        return {
+          ...mkAssistant("truncated partial answer", "toolUse"),
+          toolCalls: [] as Array<{ id: string; name: string; arguments: Record<string, unknown> }>,
+          usage: { input: 300_000, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 300_000 },
+          stopReason: "length" as const,
+        };
+      }
+      return mkAssistant("Full recovered answer after compaction.");
+    });
+    const { agent } = await setupAgent(complete);
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const reply = await agent.chat("window-exceeded-chat", "deep review please");
+
+    expect(reply).toBe("Full recovered answer after compaction.");
+    expect(mainCalls).toBe(2); // window-exceeded finish forced a retry
+    const assistants = assistantLines("window-exceeded-chat");
+    expect(assistants).toHaveLength(1);
+    expect(assistants[0].content).toBe("Full recovered answer after compaction.");
+    expect(assistants.some((l) => l.content.includes("truncated partial"))).toBe(false);
+  });
+
   it("leaves a normal non-exhausted turn unaffected", async () => {
     const complete = vi.fn(async (params: { system?: string }) => {
       const sys = params.system ?? "";

--- a/packages/core/tests/token-utils.test.ts
+++ b/packages/core/tests/token-utils.test.ts
@@ -1,13 +1,18 @@
 import { describe, it, expect } from "vitest";
 import { APICallError } from "@ai-sdk/provider";
-import type { ModelMessage } from "ai";
+import type { LanguageModelUsage, ModelMessage } from "ai";
 import {
   messageText,
   estimateTokens,
   estimateMessagesTokens,
+  estimatePromptTokens,
   computeHistoryTokenBudget,
   shouldCompact,
   classifyFailure,
+  isContextOverflowError,
+  isWindowExceededFinish,
+  effectiveEstimatorWindowTokens,
+  MAX_EFFECTIVE_WINDOW_ESTIMATOR_TOKENS,
   formatRateLimitWait,
 } from "../src/agent/token-utils.js";
 
@@ -42,21 +47,46 @@ describe("estimateTokens", () => {
 });
 
 describe("messageText", () => {
-  it("returns string content verbatim and \"\" for part-array content", () => {
+  it("returns string content verbatim and concatenates text parts", () => {
     expect(messageText({ role: "user", content: "hello" })).toBe("hello");
-    expect(messageText({ role: "user", content: [{ type: "text", text: "hi" }] })).toBe("");
+    expect(
+      messageText({
+        role: "user",
+        content: [
+          { type: "text", text: "hi" },
+          { type: "text", text: " there" },
+        ],
+      }),
+    ).toBe("hi there");
+  });
+
+  it("serializes non-text structured parts instead of dropping them to zero", () => {
+    const toolMsg = {
+      role: "tool",
+      content: [
+        {
+          type: "tool-result",
+          toolCallId: "c1",
+          toolName: "intervals_get",
+          output: { type: "text", value: "a big structured payload" },
+        },
+      ],
+    } as unknown as ModelMessage;
+    const text = messageText(toolMsg);
+    expect(text.length).toBeGreaterThan(0);
+    expect(text).toContain("tool-result");
   });
 });
 
 describe("estimateMessagesTokens", () => {
-  it("sums per-message estimates, with part-array messages contributing 0", () => {
+  it("counts text-part content instead of dropping it to zero", () => {
     expect(estimateMessagesTokens([msg(400), msg(400)])).toBe(240);
     expect(
       estimateMessagesTokens([
         msg(400),
         { role: "user", content: [{ type: "text", text: "x".repeat(400) }] },
       ]),
-    ).toBe(120);
+    ).toBe(240);
   });
 });
 
@@ -165,5 +195,200 @@ describe("shouldCompact", () => {
     expect(
       shouldCompact({ messages: [msg(4000)], systemPrompt: "xxxx", contextWindowTokens: 21_200 }),
     ).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Effective estimator-window cap
+// ---------------------------------------------------------------------------
+
+describe("effectiveEstimatorWindowTokens", () => {
+  it("caps at 200k and leaves smaller windows unchanged", () => {
+    expect(MAX_EFFECTIVE_WINDOW_ESTIMATOR_TOKENS).toBe(200_000);
+    expect(effectiveEstimatorWindowTokens(1_000_000)).toBe(200_000);
+    expect(effectiveEstimatorWindowTokens(200_000)).toBe(200_000);
+    expect(effectiveEstimatorWindowTokens(128_000)).toBe(128_000);
+  });
+});
+
+describe("history budget / preemptive compaction use min(window, 200k)", () => {
+  it("computeHistoryTokenBudget caps a 1M window at the 200k effective window", () => {
+    const capped = computeHistoryTokenBudget({
+      contextWindowTokens: 1_000_000,
+      systemPrompt: "",
+      budgetRatio: 0.3,
+    });
+    const atCap = computeHistoryTokenBudget({
+      contextWindowTokens: 200_000,
+      systemPrompt: "",
+      budgetRatio: 0.3,
+    });
+    // 200_000 * 0.3 - 0 - 20_000 = 40_000, not 1M * 0.3.
+    expect(capped).toBe(40_000);
+    expect(capped).toBe(atCap);
+  });
+
+  it("computeHistoryTokenBudget leaves a sub-200k window unchanged", () => {
+    expect(
+      computeHistoryTokenBudget({ contextWindowTokens: 128_000, systemPrompt: "", budgetRatio: 0.3 }),
+    ).toBe(128_000 * 0.3 - 20_000);
+  });
+
+  it("shouldCompact treats a 1M window as the 200k effective window", () => {
+    // 210k estimator-tokens: over the 200k-20k budget, but well under a raw 1M window.
+    const big = [msg(700_000)];
+    expect(estimateMessagesTokens(big)).toBe(210_000);
+    expect(
+      shouldCompact({ messages: big, systemPrompt: "", contextWindowTokens: 1_000_000 }),
+    ).toBe(true);
+    expect(
+      shouldCompact({ messages: big, systemPrompt: "", contextWindowTokens: 200_000 }),
+    ).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Usage-anchored estimator
+// ---------------------------------------------------------------------------
+
+describe("estimatePromptTokens usage anchor", () => {
+  it("falls back to the pure char estimate when no anchor is supplied", () => {
+    expect(estimatePromptTokens({ messages: [msg(400)], systemPrompt: "" })).toBe(120);
+  });
+
+  it("anchors to the provider token count for messages the model already saw", () => {
+    // Non-Latin content is tokenized far denser than chars/4; the provider anchor
+    // (12_000 real tokens) yields a safer estimate than the char estimate alone.
+    const seen = [msg(400), msg(400)]; // char estimate 240
+    const sinceAnchor = [msg(400)]; // 120
+    const anchored = estimatePromptTokens({
+      messages: [...seen, ...sinceAnchor],
+      systemPrompt: "",
+      lastUsageTokens: 12_000,
+      messagesSinceUsageAnchor: sinceAnchor,
+    });
+    expect(anchored).toBe(12_000 + 120);
+  });
+
+  it("never drops below the char estimate even when the anchor is smaller", () => {
+    const messages = [msg(400), msg(400)]; // char estimate 240
+    expect(
+      estimatePromptTokens({
+        messages,
+        systemPrompt: "",
+        lastUsageTokens: 10,
+        messagesSinceUsageAnchor: [],
+      }),
+    ).toBe(240);
+  });
+
+  it("makes shouldCompact fire earlier once a large provider anchor is known", () => {
+    const messages = [msg(400)]; // char estimate 120 — nowhere near a 200k budget
+    expect(
+      shouldCompact({ messages, systemPrompt: "", contextWindowTokens: 200_000 }),
+    ).toBe(false);
+    expect(
+      shouldCompact({
+        messages,
+        systemPrompt: "",
+        contextWindowTokens: 200_000,
+        lastUsageTokens: 190_000,
+        messagesSinceUsageAnchor: messages,
+      }),
+    ).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Context-overflow classification
+// ---------------------------------------------------------------------------
+
+function overflowApiError(data: unknown, statusCode = 400): APICallError {
+  return new APICallError({
+    message: "invalid request",
+    url: "https://example.test",
+    requestBodyValues: {},
+    statusCode,
+    data,
+  });
+}
+
+const usage = (inputTokens: number): LanguageModelUsage =>
+  ({ inputTokens, outputTokens: 0, totalTokens: inputTokens }) as unknown as LanguageModelUsage;
+
+describe("isContextOverflowError", () => {
+  it("treats a Codex-normalized ContextOverflowError name as authoritative", () => {
+    const e = new Error("Context overflow: exceeds the maximum context length");
+    e.name = "ContextOverflowError";
+    expect(isContextOverflowError(e)).toBe(true);
+  });
+
+  it("classifies an OpenAI 400 context_length_exceeded body as overflow", () => {
+    const err = overflowApiError({
+      error: {
+        message: "This model's maximum context length is 128000 tokens. However your messages resulted in 140000 tokens.",
+        type: "invalid_request_error",
+        code: "context_length_exceeded",
+      },
+    });
+    expect(isContextOverflowError(err)).toBe(true);
+    expect(classifyFailure(err)).toBe("overflow");
+  });
+
+  it("classifies an Anthropic 400 'prompt is too long' body as overflow", () => {
+    const err = overflowApiError({
+      type: "error",
+      error: { type: "invalid_request_error", message: "prompt is too long: 250000 tokens > 200000 maximum" },
+    });
+    expect(isContextOverflowError(err)).toBe(true);
+    expect(classifyFailure(err)).toBe("overflow");
+  });
+
+  it("classifies a Google 400 'input token count exceeds the maximum' body as overflow", () => {
+    const err = overflowApiError({
+      error: {
+        code: 400,
+        message: "The input token count (1050000) exceeds the maximum number of tokens allowed (1048576).",
+        status: "INVALID_ARGUMENT",
+      },
+    });
+    expect(isContextOverflowError(err)).toBe(true);
+    expect(classifyFailure(err)).toBe("overflow");
+  });
+
+  it("does NOT classify a generic 400 invalid request as overflow", () => {
+    const err = overflowApiError({
+      error: { type: "invalid_request_error", message: "Invalid value for 'temperature': must be <= 2." },
+    });
+    expect(isContextOverflowError(err)).toBe(false);
+    expect(classifyFailure(err)).toBe("invalid_request");
+  });
+
+  it("preserves plain message-substring classification for non-SDK errors", () => {
+    expect(isContextOverflowError(new Error("maximum context length exceeded"))).toBe(true);
+    expect(isContextOverflowError(new Error("something unrelated"))).toBe(false);
+  });
+});
+
+describe("isWindowExceededFinish", () => {
+  it("flags a length finish whose input tokens fill the real window", () => {
+    expect(
+      isWindowExceededFinish({ finishReason: "length", usage: usage(272_000), contextWindowTokens: 272_000 }),
+    ).toBe(true);
+  });
+
+  it("does not flag a plain length finish with room left in the window", () => {
+    expect(
+      isWindowExceededFinish({ finishReason: "length", usage: usage(5_000), contextWindowTokens: 272_000 }),
+    ).toBe(false);
+  });
+
+  it("only fires on a length finish, and never without usage", () => {
+    expect(
+      isWindowExceededFinish({ finishReason: "stop", usage: usage(999_999), contextWindowTokens: 272_000 }),
+    ).toBe(false);
+    expect(
+      isWindowExceededFinish({ finishReason: "length", usage: undefined, contextWindowTokens: 272_000 }),
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
Hardens three related seams in `@cycling-coach/core`'s agent turn loop so long chats that hit the model's context limit compact and retry instead of returning a cut-off answer.

## What changed, by surface

- **Context-overflow classification (`token-utils.ts`, `coach-agent.ts`).** Classification now recognizes structured provider signals — the Codex-normalized `ContextOverflowError`, plus 400 responses whose body carries a known overflow code or message — on top of the existing message-string fallbacks, without treating every 400 as an overflow.

- **Window-exceeded success routing (`coach-agent.ts`).** A successful `length` finish whose prompt already filled the real provider window is routed through the existing compaction rescue rather than persisting the truncated text. Plain output-length truncation keeps the earlier empty-reply recovery. A turn that already committed a tool write short-circuits to the existing tainted-by-writes guard and does not compact, retry, or re-run the tool.

- **Token estimation (`token-utils.ts`).** The estimator counts part-array / structured message content instead of dropping it to zero, and can anchor budget math to the provider's reported token usage.

- **Effective-window cap (`token-utils.ts`, `coach-agent.ts`).** History budget, preemptive compaction, and compaction chunk sizing use a 200,000-token effective estimator window (min(providerWindow, 200k)) so a million-token provider window no longer expands the planning target.

## Test plan

- `pnpm vitest run packages/core/tests/token-utils.test.ts packages/core/tests/coach-agent-empty-reply.test.ts` — estimation, classification, and empty-reply routing.
- `pnpm check` — full typecheck, lint, and test sweep across the workspace.

New coverage: structured/tool-output estimation no longer undercounts; provider-reported window exhaustion triggers compaction rescue; plain length finishes keep the prior empty-answer handling; no history budget can expand to a raw million-token planning target.

A changeset is included with a user-facing note.
