### PR TITLE
refactor(core): route REPL and Telegram through the in-process engine seam

### DIFF
--- a/.changeset/engine-seam-wrap.md
+++ b/.changeset/engine-seam-wrap.md
@@ -1,0 +1,8 @@
+---
+"@enduragent/core": patch
+---
+
+Route the CLI REPL and the Telegram channel through an in-process engine seam
+(createCoachEngine) that delegates verbatim to the coaching agent. Pure
+wiring refactor: no behavior change, proven by the replay gate's zero-diff
+baseline and the untouched channel test suites.

--- a/packages/core/src/agent/coach-engine.ts
+++ b/packages/core/src/agent/coach-engine.ts
@@ -1,0 +1,46 @@
+import type { Config } from "../config.js";
+import type { Sport } from "../sport.js";
+import type { Memory } from "../memory/store.js";
+import type { ResolvedCs } from "../reference/cs-resolution.js";
+import { CoachAgent } from "./coach-agent.js";
+
+/**
+ * The subset of the agent's public surface the in-process channels consume.
+ * A verbatim transcription of the corresponding CoachAgent signatures; the
+ * conformance test asserts exact type equality, so the two cannot drift
+ * silently.
+ */
+export interface CoachEngineSeam {
+  chat(
+    chatId: string,
+    userMessage: string,
+    turn?: { resolvedCs?: ResolvedCs | null },
+  ): Promise<string>;
+  hasSession(chatId: string): boolean;
+  resetSession(chatId: string): Promise<{ memoryFlushed: boolean }>;
+}
+
+/**
+ * In-process engine handle: the seam plus the one composition-root
+ * accessor that cannot cross a wire boundary — the Memory instance the
+ * startup hook mutates before any channel is reachable.
+ */
+export interface LocalCoachEngine extends CoachEngineSeam {
+  getMemory(): Memory;
+}
+
+/**
+ * Pure delegation: the engine holds no state beyond the wrapped agent and
+ * every method forwards verbatim, so reverting to direct CoachAgent
+ * construction is a mechanical substitution.
+ */
+export function createCoachEngine(sport: Sport, config: Config): LocalCoachEngine {
+  const agent = new CoachAgent(sport, config);
+  return {
+    chat: (chatId: string, userMessage: string, turn?: { resolvedCs?: ResolvedCs | null }) =>
+      agent.chat(chatId, userMessage, turn),
+    hasSession: (chatId: string) => agent.hasSession(chatId),
+    resetSession: (chatId: string) => agent.resetSession(chatId),
+    getMemory: () => agent.getMemory(),
+  };
+}

--- a/packages/core/src/channels/telegram.ts
+++ b/packages/core/src/channels/telegram.ts
@@ -1,6 +1,6 @@
 import { Bot, InputFile } from "grammy";
 import { autoRetry } from "@grammyjs/auto-retry";
-import type { CoachAgent } from "../agent/coach-agent.js";
+import type { CoachEngineSeam } from "../agent/coach-engine.js";
 import type { BinaryConfig } from "../binary.js";
 import { classifyAgentError } from "../agent/error-classify.js";
 import {
@@ -218,7 +218,7 @@ export interface TelegramBotHandle {
 
 export function createTelegramBot(
   token: string,
-  agent: CoachAgent,
+  agent: CoachEngineSeam,
   binary: BinaryConfig,
   dataDir: string,
   reference?: ReferenceServices,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -105,6 +105,8 @@ export type { IntervalsClient } from "./intervals.js";
 
 // ─── Agent ────────────────────────────────────────────────────────────
 export { CoachAgent } from "./agent/coach-agent.js";
+export { createCoachEngine } from "./agent/coach-engine.js";
+export type { CoachEngineSeam, LocalCoachEngine } from "./agent/coach-engine.js";
 export {
   TurnBudgetExceededError,
   MAX_TURN_MODEL_CALLS,

--- a/packages/core/src/run-binary.ts
+++ b/packages/core/src/run-binary.ts
@@ -341,13 +341,13 @@ export async function runBinary(
   }
 
   const bootStart = Date.now();
-  const { CoachAgent } = await import("./agent/coach-agent.js");
-  const agent = new CoachAgent(sport, config);
+  const { createCoachEngine } = await import("./agent/coach-engine.js");
+  const engine = createCoachEngine(sport, config);
 
   // Init order: Memory (above) → startup hook → Reference bootstrap → Telegram.
   // Reference's internal init sequence is pinned inside `bootstrapReference`
   // per ADR-0011 (two-phase scheduler — no timer until first runSync resolves).
-  await runStartupHook(agent.getMemory(), hooks.onStartup);
+  await runStartupHook(engine.getMemory(), hooks.onStartup);
 
   const { bootstrapReference } = await import("./reference/runtime.js");
   console.log("syncing training data from intervals.icu…");
@@ -383,7 +383,7 @@ export async function runBinary(
     const { createTelegramBot, notifyUpdate } = await import("./channels/telegram.js");
     const { bot, drainPending } = createTelegramBot(
       config.telegram.botToken,
-      agent,
+      engine,
       binary,
       config.dataDir,
       reference.services,
@@ -459,7 +459,7 @@ export async function runBinary(
       }
 
       try {
-        const response = await agent.chat("cli", input);
+        const response = await engine.chat("cli", input);
         console.log("\n" + response + "\n");
       } catch (err) {
         // Full detail (stack, provider payload) → stderr; a friendly classified

--- a/packages/core/tests/coach-engine.test.ts
+++ b/packages/core/tests/coach-engine.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, expectTypeOf, it, vi } from "vitest";
+import type { CoachAgent } from "../src/agent/coach-agent.js";
+import type { CoachEngineSeam } from "../src/agent/coach-engine.js";
+
+describe("createCoachEngine delegates verbatim to CoachAgent", () => {
+  afterEach(() => {
+    vi.doUnmock("../src/agent/coach-agent.js");
+    vi.resetModules();
+  });
+
+  async function setup() {
+    const chat = vi.fn(async () => "canned-reply");
+    const hasSession = vi.fn(() => true);
+    const resetSession = vi.fn(async () => ({ memoryFlushed: false }));
+    const memorySentinel = { sentinel: "memory" };
+    const ctorArgs: unknown[][] = [];
+    vi.doMock("../src/agent/coach-agent.js", () => ({
+      CoachAgent: class {
+        chat = chat;
+        hasSession = hasSession;
+        resetSession = resetSession;
+        getMemory = () => memorySentinel;
+        constructor(...args: unknown[]) {
+          ctorArgs.push(args);
+        }
+      },
+    }));
+    const { createCoachEngine } = await import("../src/agent/coach-engine.js");
+    return { createCoachEngine, chat, hasSession, resetSession, memorySentinel, ctorArgs };
+  }
+
+  it("constructs exactly one CoachAgent with verbatim args", async () => {
+    const { createCoachEngine, ctorArgs } = await setup();
+    const sportSentinel = { sentinel: "sport" } as never;
+    const configSentinel = { sentinel: "config" } as never;
+    createCoachEngine(sportSentinel, configSentinel);
+    expect(ctorArgs).toHaveLength(1);
+    expect(ctorArgs[0]).toHaveLength(2);
+    expect(ctorArgs[0]![0]).toBe(sportSentinel);
+    expect(ctorArgs[0]![1]).toBe(configSentinel);
+  });
+
+  it("chat forwards all three args and the result", async () => {
+    const { createCoachEngine, chat } = await setup();
+    const engine = createCoachEngine({} as never, {} as never);
+    const turnSentinel = { resolvedCs: null };
+    const result = await engine.chat("chat-1", "hello", turnSentinel);
+    expect(chat).toHaveBeenCalledTimes(1);
+    expect(chat).toHaveBeenCalledWith("chat-1", "hello", turnSentinel);
+    expect((chat.mock.calls[0] as unknown[])[2]).toBe(turnSentinel);
+    expect(result).toBe("canned-reply");
+  });
+
+  it("chat with the third arg omitted forwards undefined", async () => {
+    const { createCoachEngine, chat } = await setup();
+    const engine = createCoachEngine({} as never, {} as never);
+    await engine.chat("chat-1", "hello");
+    expect(chat).toHaveBeenCalledTimes(1);
+    expect((chat.mock.calls[0] as unknown[])[2]).toBe(undefined);
+  });
+
+  it("hasSession forwards and returns", async () => {
+    const { createCoachEngine, hasSession } = await setup();
+    const engine = createCoachEngine({} as never, {} as never);
+    expect(engine.hasSession("chat-2")).toBe(true);
+    expect(hasSession).toHaveBeenCalledTimes(1);
+    expect(hasSession).toHaveBeenCalledWith("chat-2");
+  });
+
+  it("resetSession forwards and returns the delegate's exact object", async () => {
+    const { createCoachEngine, resetSession } = await setup();
+    const engine = createCoachEngine({} as never, {} as never);
+    const result = await engine.resetSession("chat-3");
+    expect(resetSession).toHaveBeenCalledTimes(1);
+    expect(resetSession).toHaveBeenCalledWith("chat-3");
+    const delegateResult = await resetSession.mock.results[0]!.value;
+    expect(result).toBe(delegateResult);
+  });
+
+  it("getMemory returns the delegate's Memory instance", async () => {
+    const { createCoachEngine, memorySentinel } = await setup();
+    const engine = createCoachEngine({} as never, {} as never);
+    expect(engine.getMemory()).toBe(memorySentinel);
+  });
+
+  it("CoachAgent members exactly equal the seam members (compile-time)", () => {
+    expectTypeOf<CoachAgent["chat"]>().toEqualTypeOf<CoachEngineSeam["chat"]>();
+    expectTypeOf<CoachAgent["hasSession"]>().toEqualTypeOf<CoachEngineSeam["hasSession"]>();
+    expectTypeOf<CoachAgent["resetSession"]>().toEqualTypeOf<CoachEngineSeam["resetSession"]>();
+    const toSeam = (a: CoachAgent): CoachEngineSeam => a;
+    expect(typeof toSeam).toBe("function");
+  });
+});

--- a/packages/core/tests/run-binary-init-order.test.ts
+++ b/packages/core/tests/run-binary-init-order.test.ts
@@ -8,7 +8,7 @@ import { describe, expect, it } from "vitest";
  * verified behaviorally in `reference-runtime.test.ts`. This file guards
  * only the outer sequence the binary orchestrates around it:
  *
- *   1. Memory (CoachAgent constructor)
+ *   1. Memory (engine construction — the CoachAgent constructor runs inside createCoachEngine)
  *   2. Startup hook (binary-specific; cycling-coach's runs the legacy migrate)
  *   3. Reference bootstrap
  *   4. Telegram bot
@@ -23,7 +23,7 @@ describe("run-binary outer init order", () => {
   const src = readFileSync(SOURCE_PATH, "utf-8");
 
   const STEPS: ReadonlyArray<readonly [string, string]> = [
-    ["1: Memory (CoachAgent constructor)", "new CoachAgent("],
+    ["1: Memory (engine construction)", "createCoachEngine("],
     ["2: Startup hook", "await runStartupHook("],
     ["3: Reference bootstrap", "await bootstrapReference("],
     ["4: Telegram bot constructed", "createTelegramBot("],


### PR DESCRIPTION
## Summary

Introduces an in-process engine seam in core and routes both channel consumers through it, with zero behavior change.

- New `packages/core/src/agent/coach-engine.ts` exports `CoachEngineSeam` (the three channel-consumed signatures: `chat`, `hasSession`, `resetSession`), `LocalCoachEngine` (the seam plus `getMemory`), and `createCoachEngine(sport, config)` — a stateless factory that constructs one `CoachAgent` and delegates verbatim, with no wrapping, catching, or logging.
- `run-binary.ts` now constructs the agent exclusively via `createCoachEngine`; the Telegram channel consumes it through the seam type instead of the concrete agent class.
- `index.ts` newly exports `createCoachEngine` and the engine types; `CoachAgent` remains a public export.
- The agent implementation itself is untouched (byte-identical to the base branch).
- Changeset: patch on `@enduragent/core` (infrastructure-only, not athlete-visible).

## Test plan

- New `packages/core/tests/coach-engine.test.ts` (7 tests), including an exact type-equality conformance check (`expectTypeOf(...).toEqualTypeOf`) that rides `pnpm check:types`.
- Updated the two construction-site anchors in `packages/core/tests/run-binary-init-order.test.ts`; the allowlist and all Telegram channel suites pass unmodified.
- `pnpm check` green; `pnpm vitest run` green; scenario replay baseline (`pnpm s8a` and `pnpm s8a --self-test`) green with zero diffs, proving byte-identical runtime behavior; `pnpm check-parity --all` green with zero snapshot regeneration.
