### PR TITLE
fix(core): keep fixed-length truncation UTF-16 safe

### DIFF
--- a/.changeset/utf16-safe-truncation.md
+++ b/.changeset/utf16-safe-truncation.md
@@ -1,0 +1,8 @@
+---
+"@enduragent/core": patch
+"cycling-coach": patch
+---
+
+User-facing: Fixed a rare bug where an emoji sitting exactly at a length limit could be sliced in half, producing garbled text in long Telegram code blocks, compaction summaries, and memory query results.
+
+All fixed-length string cuts now route through a shared `truncateUtf16Safe` helper that backs the cut off by one UTF-16 unit when it would bisect a surrogate pair. Fixed sites: `splitPreBlock`'s oversized-row fallback and `hardSplit`'s pathological fallback in the Telegram chunker, `capSummary` in compaction, and the `memory_query` result cap. (docs/issues #171)

--- a/packages/core/src/agent/compaction.ts
+++ b/packages/core/src/agent/compaction.ts
@@ -11,6 +11,7 @@ import {
 } from "./token-utils.js";
 import { makeSummaryMessage, SUMMARY_PREFIX } from "./history-limit.js";
 import type { LLM } from "../llm.js";
+import { truncateUtf16Safe } from "../text-truncate.js";
 import type { GenerateOpts } from "../llm-types.js";
 import type { TurnBudget } from "./turn-budget.js";
 
@@ -119,7 +120,7 @@ function formatTranscript(messages: ModelMessage[]): string {
 
 function capSummary(summary: string): string {
   if (summary.length <= MAX_SUMMARY_CHARS) return summary;
-  return summary.slice(0, MAX_SUMMARY_CHARS) + SUMMARY_TRUNCATED_MARKER;
+  return truncateUtf16Safe(summary, MAX_SUMMARY_CHARS) + SUMMARY_TRUNCATED_MARKER;
 }
 
 async function generateSummaryWithTimeout(

--- a/packages/core/src/agent/tools.ts
+++ b/packages/core/src/agent/tools.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import type { MemorySectionSpec } from "../sport.js";
 import type { MemoryStore } from "../memory.js";
 import { isRealDateKey, parseDateKeyMs, MS_PER_DAY } from "../io/date-keys.js";
+import { truncateUtf16Safe } from "../text-truncate.js";
 
 function buildMemoryWriteDescription(sections: readonly MemorySectionSpec[]): string {
   const sectionList = sections.map((s) => `${s.name} (${s.description})`).join("; ");
@@ -95,7 +96,7 @@ export function createMemoryQueryTool(memory: MemoryStore) {
         .map((d) => `## ${d}\n${byDate.get(d)!.join("\n")}`);
       const result = [header, ...sections].join("\n\n");
       return result.length > MEMORY_QUERY_MAX_RESULT_CHARS
-        ? result.slice(0, MEMORY_QUERY_MAX_RESULT_CHARS) +
+        ? truncateUtf16Safe(result, MEMORY_QUERY_MAX_RESULT_CHARS) +
             "\n[truncated — narrow the date range or add a query term]"
         : result;
     },

--- a/packages/core/src/channels/telegram.ts
+++ b/packages/core/src/channels/telegram.ts
@@ -24,6 +24,7 @@ import { formatSyncReply } from "../reference/sync/format-sync-reply.js";
 import { formatSnapshotRaw } from "../reference/sync/snapshot-debug.js";
 import { sendSnapshotOutput } from "../reference/sync/send-snapshot.js";
 import { createSubsystemLogger } from "../logging/index.js";
+import { truncateUtf16Safe } from "../text-truncate.js";
 
 // Upper bound on how long /update waits for in-flight turns to finish before
 // self-updating. A hung turn must never wedge the update, so the drain races a
@@ -911,8 +912,11 @@ function splitPreBlock(block: string, maxLen: number): string[] {
     }
     // Single row alone exceeds the budget — hard-split, wrap each piece.
     const sliceMax = Math.max(1, maxLen - PRE_OVERHEAD);
-    for (let k = 0; k < row.length; k += sliceMax) {
-      out.push(`${PRE_OPEN}${row.slice(k, k + sliceMax)}${PRE_CLOSE}`);
+    let k = 0;
+    while (k < row.length) {
+      const piece = truncateUtf16Safe(row.slice(k), sliceMax);
+      out.push(`${PRE_OPEN}${piece}${PRE_CLOSE}`);
+      k += piece.length;
     }
     current = "";
   }
@@ -973,7 +977,13 @@ function hardSplit(text: string, maxLen: number): string[] {
   while (text.length - start > maxLen) {
     let cut = start + maxLen;
     while (cut > start && !isSafeCut(text, start, cut)) cut--;
-    if (cut === start) cut = start + maxLen; // pathological: no safe boundary
+    if (cut === start) {
+      // Pathological: no safe boundary below maxLen. Take the raw slice, but
+      // still refuse to bisect a surrogate pair.
+      cut = start + maxLen;
+      const prev = text.charCodeAt(cut - 1);
+      if (prev >= 0xd800 && prev <= 0xdbff && cut - 1 > start) cut--;
+    }
     out.push(text.slice(start, cut));
     start = cut;
   }

--- a/packages/core/src/text-truncate.ts
+++ b/packages/core/src/text-truncate.ts
@@ -1,0 +1,13 @@
+// `String.prototype.slice` counts UTF-16 code units, so a fixed-length cut can
+// land between the two halves of a surrogate pair (emoji, some CJK), leaving a
+// lone surrogate that renders as garbage and that some downstream APIs reject
+// outright. Backing the cut off by one unit keeps the result well-formed.
+export function truncateUtf16Safe(text: string, maxChars: number): string {
+  if (maxChars <= 0) return "";
+  if (text.length <= maxChars) return text;
+  const prev = text.charCodeAt(maxChars - 1);
+  // maxChars === 1 with a leading high surrogate is unsalvageable — return the
+  // lone unit rather than an empty string so callers always make progress.
+  const cut = prev >= 0xd800 && prev <= 0xdbff && maxChars > 1 ? maxChars - 1 : maxChars;
+  return text.slice(0, cut);
+}

--- a/packages/core/tests/text-truncate.test.ts
+++ b/packages/core/tests/text-truncate.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import { truncateUtf16Safe } from "../src/text-truncate.js";
+import { chunkHtml } from "../src/channels/telegram.js";
+
+// Local stand-in for String.prototype.isWellFormed (ES2024, above the repo's
+// TS lib target): true when the string contains no lone surrogates.
+function isWellFormedUtf16(s: string): boolean {
+  for (let i = 0; i < s.length; i++) {
+    const c = s.charCodeAt(i);
+    if (c >= 0xd800 && c <= 0xdbff) {
+      const next = s.charCodeAt(i + 1);
+      if (!(next >= 0xdc00 && next <= 0xdfff)) return false;
+      i++;
+    } else if (c >= 0xdc00 && c <= 0xdfff) {
+      return false;
+    }
+  }
+  return true;
+}
+
+describe("truncateUtf16Safe", () => {
+  it("returns short strings unchanged", () => {
+    expect(truncateUtf16Safe("abc", 10)).toBe("abc");
+    expect(truncateUtf16Safe("", 10)).toBe("");
+  });
+
+  it("cuts at maxChars when the boundary is safe", () => {
+    expect(truncateUtf16Safe("abcdef", 3)).toBe("abc");
+  });
+
+  it("backs off by one when the cut would split a surrogate pair", () => {
+    // "ab" + 🚴 (2 UTF-16 units) — a cut at 3 lands between the halves.
+    const s = "ab\u{1F6B4}cd";
+    const out = truncateUtf16Safe(s, 3);
+    expect(out).toBe("ab");
+    expect(isWellFormedUtf16(out)).toBe(true);
+  });
+
+  it("keeps a full emoji when the cut lands after its low surrogate", () => {
+    const s = "ab\u{1F6B4}cd";
+    const out = truncateUtf16Safe(s, 4);
+    expect(out).toBe("ab\u{1F6B4}");
+    expect(isWellFormedUtf16(out)).toBe(true);
+  });
+
+  it("returns empty for non-positive maxChars", () => {
+    expect(truncateUtf16Safe("abc", 0)).toBe("");
+    expect(truncateUtf16Safe("abc", -1)).toBe("");
+  });
+
+  it("makes forward progress at maxChars 1 even on a leading high surrogate", () => {
+    const s = "\u{1F6B4}x";
+    expect(truncateUtf16Safe(s, 1).length).toBe(1);
+  });
+
+  it("emoji straddling arbitrary cut points always yields well-formed output", () => {
+    const s = "🚴🏔️💪 ride done 🎉".repeat(3);
+    for (let max = 1; max <= s.length; max++) {
+      const out = truncateUtf16Safe(s, max);
+      if (max > 1) expect(isWellFormedUtf16(out)).toBe(true);
+      expect(out.length).toBeLessThanOrEqual(max);
+      expect(out.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("chunkHtml <pre> splitting with boundary emoji", () => {
+  const MAX = 4096;
+
+  it("never emits a pre chunk with a lone surrogate", () => {
+    // One giant single row of emoji forces splitPreBlock's fixed-width
+    // fallback; every fixed-width boundary lands mid-pair without the fix.
+    const row = "\u{1F6B4}".repeat(Math.ceil((MAX + 500) / 2));
+    const pre = `<pre>${row}</pre>`;
+    const chunks = chunkHtml(pre, MAX);
+    expect(chunks.length).toBeGreaterThan(1);
+    let reassembled = "";
+    for (const c of chunks) {
+      expect(c.length).toBeLessThanOrEqual(MAX);
+      expect(isWellFormedUtf16(c)).toBe(true);
+      reassembled += c.replace(/^<pre>/, "").replace(/<\/pre>$/, "");
+    }
+    expect(reassembled).toBe(row);
+  });
+});


### PR DESCRIPTION
## What

JavaScript `.slice()` counts UTF-16 code units, so a fixed-length cut can land between the two halves of a surrogate pair (emoji, some CJK), leaving a lone surrogate that renders as garbage and that some downstream APIs reject outright.

Adds a shared `truncateUtf16Safe(text, maxChars)` helper (`packages/core/src/text-truncate.ts`) that backs the cut off by one unit when it would bisect a pair, and routes every raw fixed-length cut through it:

- **Telegram pre-block splitter** (`splitPreBlock` oversized-row fallback) — a >4096-char single line in a `<pre>` block with an emoji at the boundary produced a chunk Telegram rejects, forcing the plain-text fallback. The fixed-width `for` loop becomes a `while` that advances by the actual (possibly one-shorter) piece length, so no content is dropped.
- **`hardSplit` pathological fallback** — the main path was already surrogate-safe via `isSafeCut`; only the no-safe-boundary raw-slice fallback shared the defect.
- **Compaction summary cap** (`capSummary`, 4000 chars) — the worst one: a split emoji persisted a lone surrogate into the session JSONL and rode every subsequent prompt; some providers 400 on lone surrogates.
- **`memory_query` result cap** (20 000 chars) — a split emoji landed in the tool result sent back to the model the same turn.

## Tests

New `packages/core/tests/text-truncate.test.ts`: unit coverage for the helper (boundary emoji, exhaustive cut-point sweep, forward-progress guarantee at `maxChars === 1`) plus a `chunkHtml` integration test that forces the pre-block fixed-width fallback with an all-emoji row and asserts every chunk is well-formed and content is preserved. Existing chunker tests pass unmodified. Full `pnpm check` green.

Severity is low (needs an emoji exactly at a cut boundary), but the compaction path makes corrupted output durable, so worth closing out.
