### PR TITLE
chore(core): remove unimplemented MemorySectionSpec.schema field

### DIFF
--- a/.changeset/memory-section-spec-schema-delete.md
+++ b/.changeset/memory-section-spec-schema-delete.md
@@ -1,0 +1,7 @@
+---
+"@enduragent/core": patch
+---
+
+Remove the unimplemented `schema` field from `MemorySectionSpec`. No code ever
+read it; section-name validation at the memory_write seams (Zod enum of
+declared section names) is the actual enforcement surface.

--- a/packages/core/src/sport.ts
+++ b/packages/core/src/sport.ts
@@ -37,8 +37,6 @@ export interface MemorySectionSpec {
   name: string;
   /** Description shown to the LLM in section headers + memory_write tool docs. */
   description: string;
-  /** Optional Zod schema; when present, Core validates writes. */
-  schema?: z.ZodTypeAny;
 }
 
 // ─── Tool registration (ADR-0004) ──────────────────────────────────────

--- a/packages/core/tests/effective-sections.test.ts
+++ b/packages/core/tests/effective-sections.test.ts
@@ -22,6 +22,16 @@ function makeSport(id: SportId, sections: readonly MemorySectionSpec[]): Sport {
   };
 }
 
+// MemorySectionSpec deliberately has no validation schema; a schema field is a
+// promise Core does not keep.
+const _rejectsSchemaField: MemorySectionSpec = {
+  name: "notes",
+  description: "misc",
+  // @ts-expect-error — 'schema' is not a member of MemorySectionSpec
+  schema: undefined,
+};
+void _rejectsSchemaField;
+
 describe("getEffectiveSections", () => {
   let warnSpy: ReturnType<typeof vi.spyOn>;
 


### PR DESCRIPTION
## Summary

Removes the unimplemented `schema` field (and its "Core validates writes" doc-comment) from the exported `MemorySectionSpec` interface in the core package.

The field was a false contract: no write path ever read it, no sport package set it, and no test exercised it. A sport author could set `schema` expecting per-section validated writes and silently get none. The real enforcement surface at the `memory_write` seams is the Zod section-name enum built from the declared section names — that is unchanged.

## Changes by surface

- `packages/core/src/sport.ts` — delete the optional `schema` member and its doc-comment from `MemorySectionSpec`.
- `packages/core/tests/effective-sections.test.ts` — add a compile-time regression guard (`@ts-expect-error` on a spec literal carrying `schema`) so the field cannot be silently re-added.
- changeset — patch release note for the core package.

## Test plan

- `pnpm vitest run packages/core/tests/effective-sections.test.ts` — section-spec tests pass, guard compiles as expected.
- `pnpm check` — typecheck, lint, and full build green across the workspace.
