### PR TITLE
refactor(core): replace ambient turn state with an explicit TurnContext

### DIFF
--- a/packages/core/src/agent/coach-agent.ts
+++ b/packages/core/src/agent/coach-agent.ts
@@ -1,4 +1,3 @@
-import { AsyncLocalStorage } from "node:async_hooks";
 import { randomUUID } from "node:crypto";
 import { join } from "node:path";
 import { stepCountIs } from "ai";
@@ -25,6 +24,7 @@ import { computeAssembledHash, computeTemplateHash, sha256_16 } from "./prompt-l
 import { withSessionLock } from "./session-lock.js";
 import { capToolResult, TOOL_RESULT_SHARE } from "./tool-result-cap.js";
 import { memoizeReadTool } from "./read-memoizer.js";
+import { createTurnContext, getTurnContext } from "./turn-context.js";
 import { splitHistoryByBudget, makeSummaryMessage } from "./history-limit.js";
 import {
   shouldCompact,
@@ -136,11 +136,6 @@ interface TurnOutcome {
   compactions: number;
 }
 
-interface TurnWriteRecord {
-  writesCommitted: number;
-  lastWriteSummary?: string;
-}
-
 function classifyError(err: unknown): string {
   // TurnBudgetExceededError crosses a dynamic-import boundary in tests, so match
   // on the structural name rather than instanceof.
@@ -199,27 +194,6 @@ export class CoachAgent {
   private tz: string;
   private archiveDeferred = new Set<string>();
   private lastFlushMessageCount = new Map<string, number>();
-  // A committed tool write makes the turn non-replayable: the retry loop re-sends
-  // the pre-turn messages, so a second generate could re-run the write. Keep it
-  // in async-local turn state so concurrent chats cannot reset each other.
-  private readonly turnWritesStore = new AsyncLocalStorage<TurnWriteRecord>();
-  // Per-turn read memoizer cache. Held in async-context storage (mirroring
-  // resolvedCsStore below) rather than a shared instance field so that
-  // concurrent fire-and-forget turns each memoize into their OWN map and can
-  // neither read nor clear another turn's entries; chat() runs every turn
-  // inside a fresh map. The wrapped read tools (built once at construction)
-  // resolve the running turn's map lazily through this store.
-  private readonly readToolCacheStore = new AsyncLocalStorage<Map<string, unknown>>();
-  // Resolved primary anchor (running CS) for the in-flight turn. Held in
-  // async-context storage rather than a shared instance field so that
-  // fire-and-forget turns running concurrently (different chats, or rapid
-  // same-chat sends whose synchronous prologues interleave before each turn's
-  // lock body resumes) each read their OWN anchor — a shared field would let a
-  // later turn's value clobber an in-flight turn's and compute zones from the
-  // wrong athlete's critical speed. The getter (read lazily by sport tools via
-  // the `coreDeps.resolvedCs` closure) resolves against the running turn's
-  // context, so the tool set and cached template hash still never rebuild.
-  private readonly resolvedCsStore = new AsyncLocalStorage<ResolvedCs | null>();
   // The prompt-template hash is derived from constructor-stable inputs (soul,
   // skills, tool schemas, model, and the compile-time rule-block set), so it is
   // computed once on first use and reused for every turn of the process.
@@ -266,7 +240,7 @@ export class CoachAgent {
       memory: this.memory,
       secrets,
       tz: this.tz,
-      resolvedCs: () => this.resolvedCsStore.getStore() ?? null,
+      resolvedCs: (options: unknown) => getTurnContext(options)?.resolvedCs ?? null,
     };
     const registrations = sport.tools(coreDeps);
     const maxResultTokens = Math.floor(this.config.contextWindowTokens * TOOL_RESULT_SHARE);
@@ -276,7 +250,7 @@ export class CoachAgent {
         memoizeReadTool(
           r.name,
           this.wrapWriteTool(r.name, capToolResult(r.tool, { maxResultTokens })),
-          () => this.readToolCacheStore.getStore(),
+          (options: unknown) => getTurnContext(options)?.readToolCache,
         ),
       ]),
     ) as ToolSet;
@@ -297,7 +271,7 @@ export class CoachAgent {
       execute: async (input: unknown, options: unknown) => {
         const result = await (inner as (i: unknown, o: unknown) => unknown)(input, options);
         const summary = committedWriteSummary(name, result);
-        const record = this.turnWritesStore.getStore();
+        const record = getTurnContext(options)?.turnWrites;
         if (record !== undefined && summary !== undefined) {
           record.writesCommitted++;
           record.lastWriteSummary = summary;
@@ -437,16 +411,13 @@ export class CoachAgent {
     userMessage: string,
     turn?: { resolvedCs?: ResolvedCs | null },
   ): Promise<string> {
-    // Per-turn anchor, read lazily by sport tools through the coreDeps getter.
-    // Scoped to this turn's async context (not a shared field) so concurrent
-    // fire-and-forget turns never clobber each other's anchor. null when the
-    // channel supplies nothing (CLI path, no sync data).
-    const resolvedCs = turn?.resolvedCs ?? null;
-    const turnWrites: TurnWriteRecord = { writesCommitted: 0 };
-    return this.resolvedCsStore.run(resolvedCs, () =>
-      this.readToolCacheStore.run(new Map<string, unknown>(), () =>
-        this.turnWritesStore.run(turnWrites, () =>
-          withSessionLock(chatId, async () => {
+    // One explicit context per turn, created synchronously before the session
+    // lock is queued so rapid same-chat sends can never share turn state. Tool
+    // wrappers and sport tools reach it through the tool-execution options, so
+    // the tool set and cached template hash never rebuild. resolvedCs is null
+    // when the channel supplies nothing (CLI path, no sync data).
+    const ctx = createTurnContext(turn?.resolvedCs ?? null);
+    return withSessionLock(chatId, async () => {
       const turnStart = Date.now();
       const turnId = randomUUID();
       let compactions = 0;
@@ -625,6 +596,7 @@ export class CoachAgent {
               stopWhen: stepCountIs(10),
               maxSteps: 10,
               caller: "chat",
+              context: ctx,
               cacheKey,
               // Cap this call by the turn's remaining wall-clock budget so a retry
               // after an early timeout inherits only the time the turn has left.
@@ -702,7 +674,7 @@ export class CoachAgent {
             if (err instanceof TurnBudgetExceededError) throw err;
             // A committed tool write makes this turn non-replayable: retrying
             // would re-send the pre-turn messages and could re-run the write.
-            const committedWrites = this.turnWritesStore.getStore() ?? turnWrites;
+            const committedWrites = ctx.turnWrites;
             if (committedWrites.writesCommitted > 0) {
               console.warn(
                 JSON.stringify({
@@ -855,10 +827,7 @@ export class CoachAgent {
         });
         throw terminalErr;
       }
-      }),
-        ),
-      ),
-    );
+    });
   }
 
   hasSession(chatId: string): boolean {

--- a/packages/core/src/agent/codex-bridge.ts
+++ b/packages/core/src/agent/codex-bridge.ts
@@ -154,6 +154,7 @@ async function executeToolCall(
   tools: ToolSet,
   messages: ModelMessage[],
   abortSignal?: AbortSignal,
+  context?: unknown,
 ): Promise<ToolResultPart> {
   const tool = tools[call.name];
   if (!tool || typeof tool.execute !== "function") {
@@ -173,6 +174,7 @@ async function executeToolCall(
       toolCallId: call.id,
       messages,
       abortSignal,
+      experimental_context: context,
     });
     return {
       type: "tool-result",
@@ -201,7 +203,7 @@ function errorResult(call: CodexToolCall, message: string): ToolResultPart {
 export async function codexGenerateText(
   opts: GenerateOpts & { modelId: string; profileName: string; stepLimit?: number },
 ): Promise<GenerateResult> {
-  const { system, messages, prompt, tools, modelId, profileName, stepLimit, cacheKey, signal } = opts;
+  const { system, messages, prompt, tools, modelId, profileName, stepLimit, cacheKey, signal, context } = opts;
 
   const initialMessages: ModelMessage[] = prompt
     ? [{ role: "user", content: prompt }]
@@ -266,7 +268,7 @@ export async function codexGenerateText(
     // Run tool calls in parallel to match AI SDK behavior; Promise.all preserves
     // order so the conversation stays aligned.
     const results = await Promise.all(
-      calls.map((call) => executeToolCall(call, tools, initialMessages, signal)),
+      calls.map((call) => executeToolCall(call, tools, initialMessages, signal, context)),
     );
     convo.push({ role: "tool", content: results } as ModelMessage);
   }

--- a/packages/core/src/agent/read-memoizer.ts
+++ b/packages/core/src/agent/read-memoizer.ts
@@ -47,12 +47,13 @@ export function memoizeKey(toolName: string, args: unknown): string {
 }
 
 // A per-turn cache, supplied either directly (the unit-test path) or via a
-// resolver that reads the running turn's cache from async-context storage (the
-// agent path) so concurrent turns never share or clear each other's entries. A
-// resolver returning undefined means "no turn in scope" — the read runs unmemoized.
+// resolver that reads the running turn's cache from the tool-execution options
+// (the agent path) so concurrent turns never share or clear each other's
+// entries. A resolver returning undefined means "no turn in scope" — the read
+// runs unmemoized.
 export type ReadCacheSource =
   | Map<string, unknown>
-  | (() => Map<string, unknown> | undefined);
+  | ((options: unknown) => Map<string, unknown> | undefined);
 
 export function memoizeReadTool(name: string, tool: Tool, cache: ReadCacheSource): Tool {
   if (!READ_ONLY_TOOL_NAMES.has(name)) return tool;
@@ -62,7 +63,7 @@ export function memoizeReadTool(name: string, tool: Tool, cache: ReadCacheSource
   return {
     ...tool,
     execute: async (input: unknown, options: unknown) => {
-      const store = resolveCache();
+      const store = resolveCache(options);
       const run = () => (inner as (i: unknown, o: unknown) => unknown)(input, options);
       if (store === undefined) return run();
       const key = memoizeKey(name, input);

--- a/packages/core/src/agent/turn-context.ts
+++ b/packages/core/src/agent/turn-context.ts
@@ -1,0 +1,53 @@
+import type { ResolvedCs } from "../reference/cs-resolution.js";
+
+export interface TurnWriteRecord {
+  writesCommitted: number;
+  lastWriteSummary?: string;
+}
+
+// Explicit per-turn state, threaded to tool execution through the
+// tool-execution options instead of an ambient per-process store: chat()
+// creates one TurnContext per turn and attaches it to the generate call; the
+// model SDK delivers it to each tool execute's options, and the codex bridge
+// mirrors the same key. Concurrent turns — different chats, or rapid same-chat
+// sends whose synchronous prologues interleave before each turn's lock body
+// resumes — each carry their OWN object, so no turn can read or clobber
+// another's anchor, read cache, or write record, while the tool set (built
+// once at construction) and the cached template hash never rebuild.
+export interface TurnContext {
+  /** Resolved primary anchor (running critical speed) for this turn; null when the channel supplies none. */
+  readonly resolvedCs: ResolvedCs | null;
+  /** Per-turn read-tool memoizer cache. */
+  readonly readToolCache: Map<string, unknown>;
+  /** Committed-write record; a committed write makes the turn non-replayable. */
+  readonly turnWrites: TurnWriteRecord;
+}
+
+const TURN_CONTEXT_BRAND = Symbol("turn-context");
+
+interface BrandedTurnContext extends TurnContext {
+  readonly [TURN_CONTEXT_BRAND]: true;
+}
+
+export function createTurnContext(resolvedCs: ResolvedCs | null): TurnContext {
+  const ctx: BrandedTurnContext = {
+    [TURN_CONTEXT_BRAND]: true,
+    resolvedCs,
+    readToolCache: new Map<string, unknown>(),
+    turnWrites: { writesCommitted: 0 },
+  };
+  return ctx;
+}
+
+// Tool-execution options are `unknown` at the wrapper seams. A tool executing
+// with no turn in scope (e.g. the memory flush during an explicit session
+// reset) resolves to undefined, and every consumer fails open: reads run
+// unmemoized, writes go unrecorded, the anchor reads null.
+export function getTurnContext(options: unknown): TurnContext | undefined {
+  if (options === null || typeof options !== "object") return undefined;
+  const candidate = (options as { experimental_context?: unknown }).experimental_context;
+  if (candidate === null || typeof candidate !== "object") return undefined;
+  return (candidate as Partial<BrandedTurnContext>)[TURN_CONTEXT_BRAND] === true
+    ? (candidate as TurnContext)
+    : undefined;
+}

--- a/packages/core/src/llm-types.ts
+++ b/packages/core/src/llm-types.ts
@@ -22,6 +22,11 @@ export interface GenerateOpts {
   /** Codex-only: forwarded to the codex bridge as its session id. The AI-SDK providers never read it. */
   cacheKey?: string;
   caller?: CallerRole;
+  /** Opaque per-call context delivered verbatim to tool execute options via
+   * the SDK's experimental context channel (the codex bridge mirrors the same
+   * key; `agent/turn-context.ts` owns the extraction). Never serialized into
+   * the request payload; providers ignore it. */
+  context?: unknown;
 }
 
 export interface GenerateResult {

--- a/packages/core/src/llm.ts
+++ b/packages/core/src/llm.ts
@@ -145,6 +145,7 @@ export class LLM {
       maxOutputTokens: opts.maxOutputTokens,
       maxRetries: 0,
       abortSignal: opts.signal,
+      experimental_context: opts.context,
     };
     const result = opts.prompt !== undefined
       ? await generateText({ ...base, prompt: opts.prompt })

--- a/packages/core/src/sport.ts
+++ b/packages/core/src/sport.ts
@@ -77,8 +77,12 @@ export interface CoreDeps {
    * whereas this is a runtime value re-resolved every turn — the adapter seam
    * can't carry it. Running-specific for now; generalize to a discriminated
    * anchor (e.g. swim CSS, cycling auto-FTP) under the rule of three.
+   *
+   * Takes the tool-execution options object the calling tool's `execute`
+   * received — the per-turn context rides those options; pass them through
+   * opaquely.
    */
-  resolvedCs?: () => ResolvedCs | null;
+  resolvedCs?: (options: unknown) => ResolvedCs | null;
 }
 
 // ─── Sport: the plug-point ─────────────────────────────────────────────

--- a/packages/core/tests/coach-agent-anchor-isolation.test.ts
+++ b/packages/core/tests/coach-agent-anchor-isolation.test.ts
@@ -39,7 +39,7 @@ const sections: readonly MemorySectionSpec[] = [
 
 // A barrier that lets the test interleave the two in-flight turns: the first
 // tool to read its anchor parks on `gate`; the second tool reads ITS anchor and
-// then releases the gate. With AsyncLocalStorage each tool sees its own anchor;
+// then releases the gate. With per-turn context threading each tool sees its own anchor;
 // with a shared instance field the second chat()'s value would have overwritten
 // the first's before the first tool reads — which is exactly what this catches.
 function makeBarrier(): {
@@ -89,11 +89,11 @@ function makeStubRunningSport(): Sport {
           tool: tool({
             description: "Reads the per-turn resolved CS anchor.",
             inputSchema,
-            execute: async ({ label }: { label: string }) => {
+            execute: async ({ label }: { label: string }, options: unknown) => {
               // Read THIS turn's anchor first, then sync at the barrier so both
               // turns are in flight when each reads — a shared field would be
               // clobbered by the later turn before the earlier reads.
-              const anchor = deps.resolvedCs?.() ?? null;
+              const anchor = deps.resolvedCs?.(options) ?? null;
               await barrier.arrive();
               readAnchors[label] = anchor;
               return JSON.stringify(anchor);
@@ -141,7 +141,7 @@ async function setupAgent(complete: ReturnType<typeof vi.fn>) {
   return new CoachAgent(makeStubRunningSport(), baseAgentConfig(dataDir));
 }
 
-describe("per-turn anchor isolation (AsyncLocalStorage, not a shared field)", () => {
+describe("per-turn anchor isolation (turn context, not a shared field)", () => {
   it("two interleaved turns each read their OWN resolvedCs through the tool", async () => {
     barrier.reset();
     delete readAnchors.A;

--- a/packages/core/tests/llm-dispatch.test.ts
+++ b/packages/core/tests/llm-dispatch.test.ts
@@ -55,6 +55,7 @@ type AiSdkCaptured = {
   maxRetries: number | undefined;
   prompt: string | undefined;
   messages: unknown;
+  experimentalContext: unknown;
   called: number;
 };
 
@@ -64,14 +65,16 @@ async function runAiSdk(opts: Parameters<import("../src/llm.js").LLM["generate"]
     maxRetries: undefined,
     prompt: undefined,
     messages: undefined,
+    experimentalContext: undefined,
     called: 0,
   };
   vi.doMock("ai", () => ({
-    generateText: vi.fn(async (o: { abortSignal?: AbortSignal; maxRetries?: number; prompt?: string; messages?: unknown }) => {
+    generateText: vi.fn(async (o: { abortSignal?: AbortSignal; maxRetries?: number; prompt?: string; messages?: unknown; experimental_context?: unknown }) => {
       captured.abortSignal = o.abortSignal;
       captured.maxRetries = o.maxRetries;
       captured.prompt = o.prompt;
       captured.messages = o.messages;
+      captured.experimentalContext = o.experimental_context;
       captured.called++;
       return MINIMAL_RESULT;
     }),
@@ -169,6 +172,17 @@ describe("LLM dispatch — AI SDK path forwards abort signals", () => {
     expect(captured.abortSignal).toBe(timeoutController.signal);
     expect(captured.prompt).toBe("summarize this");
     expect(captured.maxRetries).toBe(0);
+  });
+
+  it("forwards opts.context to generateText by identity as the experimental context", async () => {
+    const turnContext = { marker: "turn-context" };
+
+    const captured = await runAiSdk({
+      messages: [{ role: "user", content: "hi" }],
+      context: turnContext,
+    });
+
+    expect(captured.experimentalContext).toBe(turnContext);
   });
 });
 

--- a/packages/core/tests/turn-context-flush-isolation.test.ts
+++ b/packages/core/tests/turn-context-flush-isolation.test.ts
@@ -1,0 +1,296 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { z } from "zod";
+import { tool } from "ai";
+import { baseAgentConfig } from "./helpers/base-agent-config.js";
+import type { CoreDeps, MemorySectionSpec, Sport, ToolRegistration } from "../src/index.js";
+import type { ResolvedCs } from "../src/reference/cs-resolution.js";
+import { TAINTED_BY_WRITES_MESSAGE } from "../src/agent/coach-agent-copy.js";
+
+const FLUSH_MARKER = "reviewing a conversation to extract and save important athlete";
+
+let tempHome: string;
+let origHome: string | undefined;
+let dataDir: string;
+
+// Reset per test: the stub tools close over these module-level records so the
+// test can observe what each turn's tool actually saw.
+const readAnchors: Record<string, ResolvedCs | null> = {};
+const counters = { zones: 0 };
+
+beforeEach(() => {
+  tempHome = mkdtempSync(join(tmpdir(), "cc-flush-iso-"));
+  origHome = process.env.HOME;
+  process.env.HOME = tempHome;
+  dataDir = join(tempHome, ".cycling-coach");
+  mkdirSync(dataDir, { recursive: true });
+  mkdirSync(join(dataDir, "memory"), { recursive: true });
+  delete readAnchors.A;
+  delete readAnchors.B;
+  counters.zones = 0;
+  vi.resetModules();
+});
+
+afterEach(() => {
+  process.env.HOME = origHome;
+  rmSync(tempHome, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+const sections: readonly MemorySectionSpec[] = [
+  { name: "running-profile", description: "VDOT, easy pace, recent race times" },
+];
+
+function mkAssistant(opts: {
+  text?: string;
+  toolCalls?: Array<{ id: string; name: string; arguments: Record<string, unknown> }>;
+  stopReason?: "stop" | "toolUse";
+}) {
+  const toolCalls = opts.toolCalls ?? [];
+  return {
+    text: toolCalls.length > 0 ? "" : opts.text ?? "",
+    toolCalls,
+    usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0 },
+    stopReason: opts.stopReason ?? "stop",
+  };
+}
+
+// Two lines keeps history below the zero-write archive-deferral threshold while
+// making the session stale under dailyResetHour:4, so the turn awaits the
+// stale-reset flush before its main generate.
+function seedStaleSession(chatId: string): void {
+  const sessionsDir = join(dataDir, "sessions");
+  mkdirSync(sessionsDir, { recursive: true });
+  const ts = new Date(Date.now() - 2 * 86_400_000).toISOString();
+  const lines = [
+    JSON.stringify({ role: "user", content: "earlier question", ts }),
+    JSON.stringify({ role: "assistant", content: "earlier answer", ts }),
+  ].join("\n");
+  writeFileSync(join(sessionsDir, `${chatId}.jsonl`), lines + "\n");
+}
+
+function makeStubRunningSport(): Sport {
+  return {
+    id: "running",
+    soul: "",
+    skills: {},
+    sessionClusterGapMinutes: 60,
+    memorySections: sections,
+    mustPreserveTokens: () => ["VDOT"],
+    intervalsActivityTypes: ["Run", "TrailRun"],
+    athleteProfileSchema: z.object({}),
+    tools: (deps: CoreDeps): readonly ToolRegistration[] => {
+      const anchorSchema = z.object({ label: z.string() });
+      const emptySchema = z.object({});
+      return [
+        {
+          name: "read_anchor",
+          description: "Reads the per-turn resolved CS anchor.",
+          inputSchema: anchorSchema,
+          tool: tool({
+            description: "Reads the per-turn resolved CS anchor.",
+            inputSchema: anchorSchema,
+            execute: async ({ label }: { label: string }, options: unknown) => {
+              readAnchors[label] = deps.resolvedCs?.(options) ?? null;
+              return JSON.stringify(readAnchors[label]);
+            },
+          }),
+        },
+        {
+          name: "calculate_zones",
+          description: "Computes training zones.",
+          inputSchema: emptySchema,
+          tool: tool({
+            description: "Computes training zones.",
+            inputSchema: emptySchema,
+            execute: async () => {
+              counters.zones++;
+              return { execution: counters.zones };
+            },
+          }),
+        },
+        {
+          name: "memory_write",
+          description: "Saves an athlete memory.",
+          inputSchema: emptySchema,
+          tool: tool({
+            description: "Saves an athlete memory.",
+            inputSchema: emptySchema,
+            execute: async () => ({ saved: true }),
+          }),
+        },
+      ];
+    },
+  };
+}
+
+async function setupAgent(complete: ReturnType<typeof vi.fn>) {
+  vi.doMock("../src/agent/codex/responses.js", () => ({
+    codexResponses: complete,
+  }));
+  vi.doMock("../src/agent/codex/oauth.js", () => ({
+    refreshCodexToken: vi.fn(),
+    loginCodex: vi.fn(),
+  }));
+  vi.doMock("../src/auth/profiles.js", () => ({
+    getFreshToken: vi.fn(async () => "token"),
+    loadProfile: vi.fn(),
+    saveProfile: vi.fn(),
+    RefreshTokenReusedError: class extends Error {},
+  }));
+
+  const { CoachAgent } = await import("../src/agent/coach-agent.js");
+  return new CoachAgent(makeStubRunningSport(), baseAgentConfig(dataDir));
+}
+
+function latestUserLabel(messages: { role: string; content?: unknown }[] | undefined): "A" | "B" {
+  const lastUser = [...(messages ?? [])].reverse().find((m) => m.role === "user");
+  const content = (lastUser as { content?: unknown } | undefined)?.content;
+  return typeof content === "string" && content.startsWith("B") ? "B" : "A";
+}
+
+function makeFlushGate() {
+  let releaseFlush!: () => void;
+  const flushReleased = new Promise<void>((r) => {
+    releaseFlush = r;
+  });
+  let flushStarted!: () => void;
+  const flushStartedP = new Promise<void>((r) => {
+    flushStarted = r;
+  });
+  const prologue = async (sys: string): Promise<ReturnType<typeof mkAssistant> | undefined> => {
+    if (sys.includes(FLUSH_MARKER)) {
+      flushStarted();
+      await flushReleased;
+      return mkAssistant({ text: "facts noted" });
+    }
+    if (sys.length === 0) return mkAssistant({ text: "summary" });
+    return undefined;
+  };
+  return { flushStartedP, releaseFlush, prologue };
+}
+
+describe("per-turn state does not bleed across a parked memory flush", () => {
+  it("a turn parked in a memory flush keeps its own resolved anchor while another turn completes", async () => {
+    seedStaleSession("flush-anchor-a");
+    const gate = makeFlushGate();
+
+    const complete = vi.fn(
+      async (params: { system?: string; messages?: { role: string; content?: unknown }[] }) => {
+        const parked = await gate.prologue(params.system ?? "");
+        if (parked !== undefined) return parked;
+        const hasToolResult = (params.messages ?? []).some((m) => m.role === "tool");
+        if (hasToolResult) return mkAssistant({ text: "done" });
+        const label = latestUserLabel(params.messages);
+        return mkAssistant({
+          toolCalls: [{ id: `call-${label}`, name: "read_anchor", arguments: { label } }],
+          stopReason: "toolUse",
+        });
+      },
+    );
+
+    const agent = await setupAgent(complete);
+    const anchorA: ResolvedCs = { criticalSpeedMps: 4.0, source: "platform", confidence: "high" };
+    const anchorB: ResolvedCs = { criticalSpeedMps: 5.0, source: "platform", confidence: "high" };
+
+    const aPromise = agent.chat("flush-anchor-a", "A: how's my pace?", { resolvedCs: anchorA });
+    await gate.flushStartedP;
+    const resB = await agent.chat("flush-anchor-b", "B: how's my pace?", { resolvedCs: anchorB });
+    gate.releaseFlush();
+    const resA = await aPromise;
+
+    expect(resA).toBe("done");
+    expect(resB).toBe("done");
+    // Shared-field regression: B's 5.0 would have clobbered A's before A's tool ran.
+    expect(readAnchors.A?.criticalSpeedMps).toBe(4.0);
+    expect(readAnchors.B?.criticalSpeedMps).toBe(5.0);
+  });
+
+  it("a turn parked in a memory flush does not share the read-tool memoizer cache with another turn", async () => {
+    seedStaleSession("flush-cache-a");
+    const gate = makeFlushGate();
+
+    const complete = vi.fn(
+      async (params: { system?: string; messages?: { role: string; content?: unknown }[] }) => {
+        const parked = await gate.prologue(params.system ?? "");
+        if (parked !== undefined) return parked;
+        const hasToolResult = (params.messages ?? []).some((m) => m.role === "tool");
+        if (hasToolResult) return mkAssistant({ text: "done" });
+        const label = latestUserLabel(params.messages);
+        return mkAssistant({
+          toolCalls: [
+            { id: `${label}-1`, name: "calculate_zones", arguments: {} },
+            { id: `${label}-2`, name: "calculate_zones", arguments: {} },
+          ],
+          stopReason: "toolUse",
+        });
+      },
+    );
+
+    const agent = await setupAgent(complete);
+
+    const aPromise = agent.chat("flush-cache-a", "A: zones please");
+    await gate.flushStartedP;
+    const resB = await agent.chat("flush-cache-b", "B: zones please");
+    gate.releaseFlush();
+    const resA = await aPromise;
+
+    expect(resA).toBe("done");
+    expect(resB).toBe("done");
+    // One underlying execution per turn: the two identical calls WITHIN a turn
+    // share one memoized execution, and the second turn is NOT served from the
+    // first turn's cache. Shared cross-turn cache would yield 1; per-turn
+    // memoization lost entirely would yield 4.
+    expect(counters.zones).toBe(2);
+  });
+
+  it("write taint recorded by one turn does not leak into a turn parked in a memory flush", async () => {
+    seedStaleSession("flush-taint-a");
+    const gate = makeFlushGate();
+    let aMainCalls = 0;
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const complete = vi.fn(
+      async (params: { system?: string; messages?: { role: string; content?: unknown }[] }) => {
+        const parked = await gate.prologue(params.system ?? "");
+        if (parked !== undefined) return parked;
+        const messages = params.messages ?? [];
+        const hasToolResult = messages.some((m) => m.role === "tool");
+        if (latestUserLabel(messages) === "B") {
+          if (!hasToolResult) {
+            return mkAssistant({
+              toolCalls: [{ id: "b-write", name: "memory_write", arguments: {} }],
+              stopReason: "toolUse",
+            });
+          }
+          const err = new Error("deadline exceeded");
+          err.name = "TimeoutError";
+          throw err;
+        }
+        aMainCalls++;
+        if (aMainCalls === 1) {
+          const err = new Error("deadline exceeded");
+          err.name = "TimeoutError";
+          throw err;
+        }
+        return mkAssistant({ text: "A ok" });
+      },
+    );
+
+    const agent = await setupAgent(complete);
+
+    const aPromise = agent.chat("flush-taint-a", "A: how's my form?");
+    await gate.flushStartedP;
+    const resB = await agent.chat("flush-taint-b", "B: note this");
+    gate.releaseFlush();
+    const resA = await aPromise;
+
+    expect(resB).toBe(TAINTED_BY_WRITES_MESSAGE);
+    // Load-bearing: with a shared/bled write record, A's first (timeout) error
+    // would observe writesCommitted > 0 and refuse instead of retrying.
+    expect(resA).toBe("A ok");
+    expect(aMainCalls).toBe(2);
+  });
+});

--- a/packages/sport-running/src/tools.ts
+++ b/packages/sport-running/src/tools.ts
@@ -42,7 +42,7 @@ export function createRunningTools(
   _memory: MemoryStore,
   intervals: IntervalsClient | null,
   _tz: string = "UTC",
-  resolvedCs?: () => ResolvedCs | null,
+  resolvedCs?: (options: unknown) => ResolvedCs | null,
 ) {
   return {
     calculate_zones: tool({
@@ -97,8 +97,8 @@ export function createRunningTools(
         paceUnits?: "MINS_KM" | "MINS_MILE" | null;
         lowerFractionOverride?: number;
         csSource?: "platform" | "athlete_manual";
-      }) => {
-        const resolved = resolvedCs?.() ?? null;
+      }, options: unknown) => {
+        const resolved = resolvedCs?.(options) ?? null;
         // Explicit value (already band-checked by the input schema) outranks the
         // synced anchor (band-checked by resolveRunningCs); whichever we use is
         // therefore guaranteed in [CS_SANITY_MPS.min, max].
@@ -176,12 +176,12 @@ export function createRunningTools(
                 ),
               }),
             ),
-            execute: async (input: { date: string; workout: RunningWorkoutInput }) => {
+            execute: async (input: { date: string; workout: RunningWorkoutInput }, options: unknown) => {
               // The serializer stays pure: pass OUR resolved CS in so distance steps
               // with relative targets can derive their planned time.
               let serialized: ReturnType<typeof serializeRunningWorkout>;
               try {
-                serialized = serializeRunningWorkout(input.workout, resolvedCs?.()?.criticalSpeedMps);
+                serialized = serializeRunningWorkout(input.workout, resolvedCs?.(options)?.criticalSpeedMps);
               } catch (err) {
                 if (err instanceof InvalidWorkoutError) {
                   return { error: "invalid_workout", details: err.message };

--- a/tools/s8a/lib/patch-llm.ts
+++ b/tools/s8a/lib/patch-llm.ts
@@ -36,6 +36,7 @@ export interface GenerateOptsLike {
   maxOutputTokens?: number;
   cacheKey?: string;
   caller?: "chat" | "flush" | "compact";
+  context?: unknown;
   [key: string]: unknown;
 }
 
@@ -442,6 +443,7 @@ async function executeRecordedTools(
       liveResult = await tool.execute(exec.input, {
         toolCallId: `s8a-replay-${ordinal}-${k}`,
         messages: [],
+        experimental_context: opts.context,
       });
     } catch (err) {
       fail(


### PR DESCRIPTION
## Summary

Replaces the three ambient per-turn stores (turn-write records, read-tool cache, and resolved critical-speed) that were held in `AsyncLocalStorage` with a single explicit `TurnContext` value created once per turn and threaded through tool execution. The context rides the tool-execution options channel (`experimental_context` on the AI-SDK path, mirrored by the codex bridge) rather than an ambient async-context store, so per-turn state is passed explicitly instead of inferred from the call stack.

This is a behavior-preserving refactor: no user-visible change.

## Surfaces touched

- **New `turn-context.ts`** — defines `TurnContext` (resolved critical-speed, read-tool cache, turn-write records), `createTurnContext`, and a `getTurnContext(options)` accessor. Not re-exported from the core index; internal to the agent.
- **coach-agent** — drops the async-context import, the three store fields, and the nested `.run()` wrapping. The turn context is created synchronously before the session lock is queued, and passed only on the main chat generate call.
- **llm / llm-types** — `GenerateOpts` gains an optional `context`; the base generate path forwards it as `experimental_context`.
- **codex-bridge** — mirrors the identical context key into the tool-call execution options so the codex path sees the same per-turn state.
- **read-memoizer** — the resolver form now reads the context out of the execute options.
- **sport / sport-running** — the shared dependency for resolved critical-speed now takes the opaque execute options and extracts the context internally; sport tools thread options through without spelling the transport key.
- **s8a replay** — forwards the context into replay options (no-op relative to the existing path).

## Invariants preserved

- Tools are built once; no new enumerable tool fields (template-hash stability).
- Fail-open "no turn in scope" semantics are bit-identical.
- The system prompt is untouched.

## Test plan

- `pnpm check` — green.
- `pnpm vitest run` — green.
- New `turn-context-flush-isolation.test.ts` — three tests park turn A inside its stale-reset flush await while turn B completes, asserting no bleed of anchor, read cache, or write record across the parked flush.
- Existing anchor-isolation, turn-tainted-by-writes, and read-memoizer suites — green.
- `pnpm s8a` — zero diffs, no supersession consulted.
- `pnpm s8a --self-test` — green.
- Repo-wide grep for the async-context store under `packages` (non-dist) — empty.

No changeset: internal refactor, no user-visible change.
