### PR TITLE
feat(core): widen sport and activity-type unions

### DIFF
--- a/.changeset/sport-union-widen.md
+++ b/.changeset/sport-union-widen.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/core": patch
+---
+
+Widen the sport identity unions: `SportId` gains `swimming` and `triathlon`; `IntervalsActivityType` gains `Swim`, `OpenWaterSwim`, and `VirtualRun`. Type-level only — no sport declares the new activity types yet and no runtime behavior changes.

--- a/packages/core/src/reference/cs-resolution.ts
+++ b/packages/core/src/reference/cs-resolution.ts
@@ -9,10 +9,12 @@
  */
 import type { LatestJson } from "./schemas/latest.js";
 
-// intervals.icu running-family activity types. Kept to the set the running sport
-// declares (Run, TrailRun); VirtualRun is intentionally excluded — not in core's
-// IntervalsActivityType union this wave. Shared by the resolver and the step-5
-// gate (validation/checks/step5-cs-source.ts) so the two cannot diverge.
+// intervals.icu running-family activity types. Kept to the set the running
+// sport declares (Run, TrailRun); VirtualRun is deliberately excluded — no
+// running sport declares it, and adding it here would change which
+// sportSettings rows feed CS resolution. Shared by the resolver and the
+// step-5 gate (validation/checks/step5-cs-source.ts) so the two cannot
+// diverge.
 export const RUN_FAMILY_TYPES = new Set<string>(["Run", "TrailRun"]);
 
 // Hard-refusal CS band in m/s: a value outside is unit-confused or corrupt, not a

--- a/packages/core/src/sport.ts
+++ b/packages/core/src/sport.ts
@@ -9,7 +9,7 @@ import type { SecretsResolver } from "./secrets/types.js";
 
 // ─── Identity ──────────────────────────────────────────────────────────
 /** Closed literal union — adding a sport requires a Core bump. Intentional. */
-export type SportId = "cycling" | "running" | "duathlon";
+export type SportId = "cycling" | "running" | "duathlon" | "swimming" | "triathlon";
 
 /** intervals.icu activity-type filter values. */
 export type IntervalsActivityType =
@@ -21,7 +21,12 @@ export type IntervalsActivityType =
   // route to the cycling adapter and reconcile with its sport-family counts.
   | "MountainBikeRide"
   | "GravelRide"
-  | "EBikeRide";
+  | "EBikeRide"
+  // Reserved: no sport's intervalsActivityTypes declares these yet, so they
+  // stay inert until one does.
+  | "Swim"
+  | "OpenWaterSwim"
+  | "VirtualRun";
 
 // ─── Shared kernel ─────────────────────────────────────────────────────
 /** Every sport's profile schema must extend this. */

--- a/packages/core/tests/sport-id-union.test.ts
+++ b/packages/core/tests/sport-id-union.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import type { IntervalsActivityType, SportId } from "@enduragent/core";
+
+describe("sport identity unions", () => {
+  it("accepts every declared sport id", () => {
+    const ids: readonly SportId[] = ["cycling", "running", "duathlon", "swimming", "triathlon"];
+    expect(ids).toHaveLength(5);
+  });
+
+  it("accepts every declared intervals.icu activity type", () => {
+    const types: readonly IntervalsActivityType[] = [
+      "Ride",
+      "Run",
+      "VirtualRide",
+      "TrailRun",
+      "MountainBikeRide",
+      "GravelRide",
+      "EBikeRide",
+      "Swim",
+      "OpenWaterSwim",
+      "VirtualRun",
+    ];
+    expect(types).toHaveLength(10);
+  });
+});


### PR DESCRIPTION
Widens two closed literal unions in the Core sport-identity module so future waves can introduce swimming and triathlon adapters. This is a type-level-only change: every new identifier is inert because no sport declares it yet, and there are no runtime set, table, or schema edits.

## What changed by surface

- `packages/core/src/sport.ts` — `SportId` gains `swimming` and `triathlon`; `IntervalsActivityType` gains `Swim`, `OpenWaterSwim`, and `VirtualRun`. The existing members and the cycling-family comment are byte-preserved; the three new activity types carry a short "Reserved" comment noting they stay inert until a sport declares them.
- `packages/core/src/reference/cs-resolution.ts` — comment-only reword. The union bump falsifies the old justification for excluding `VirtualRun` from `RUN_FAMILY_TYPES` ("not in the union"), so the comment now explains the real reason (no running sport declares it, and adding it would change which sportSettings rows feed critical-speed resolution). The `RUN_FAMILY_TYPES` set and every code line stay byte-identical.
- `packages/core/tests/sport-id-union.test.ts` — new compile-time membership pin: typed literal arrays enumerate all five `SportId` members and all ten `IntervalsActivityType` values, so any future accidental narrowing of either union fails to compile.
- `.changeset/sport-union-widen.md` — `@enduragent/core` patch changeset. No user-facing line: the package is private and a type-level widening is invisible to athletes.

No sport-family table, sport package, or schema is touched. No `Set<string>` constant is retyped to the union, and no Zod enum is introduced.

## Test plan

- `pnpm check` — green (per-package tsc, root type check, lints, trademark / fixture-privacy / registry-isolation / changeset gates).
- `pnpm vitest run packages/core/tests/sport-id-union.test.ts` — green (the new membership pin).
- `pnpm test` — full suite green with no test edits beyond the one new file. The known `secrets/backends/detect.test.ts` flake, which can go red only under full-suite load and passes in isolation, is unrelated to this diff.
- `pnpm s8a` — zero diffs (behavior baseline unchanged).
- `pnpm check-parity --all` — all pairs green with zero snapshot regeneration.
