### PR TITLE
test: add composition smoke probe kit, run transcripts, and report

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "check-parity": "tsx tools/check-metric-parity.ts",
     "fuzz-parity": "tsx tools/fuzz-parity.ts",
     "s8a": "tsx tools/s8a/run.ts",
+    "probe:composition": "tsx tools/composition-probe/run.ts",
     "coverage:reference": "tsx tools/measure-reference-coverage.ts",
     "usage:baseline": "tsx tools/usage-baseline.ts",
     "gate:compaction": "tsx --env-file=.env tools/compaction-gate/run.ts"

--- a/probes/composition-smoke/report.md
+++ b/probes/composition-smoke/report.md
@@ -1,0 +1,84 @@
+# Composition smoke probe — report A (TEMPLATE)
+
+This is the committed template. Every metric value is the literal `PENDING`. The
+operator regenerates it with `pnpm probe:composition --phase=report` after the real
+run phases complete. A template-only file must never merge; the pull request stays
+a draft until the run outputs replace these placeholders.
+
+- Run date: PENDING
+- Git SHA: PENDING
+- Judge model (pinned): PENDING
+- Frozen-now: PENDING
+- Floor models: PENDING
+- Suite composition: PENDING
+
+## Scope limits
+
+This is a smoke test with abort-only power: it can abort the one-agent composition
+premise but never confirm it. The load-bearing gate re-runs the same suite at a far
+larger sample on the real composition later.
+
+Partial-coverage caveat: the mock covers the critical-speed / critical-swim-pace
+confusion traps and the integrated multisport turns only partially by construction —
+the swim core is fully synthetic and the multisport orchestration content is minimal —
+which is exactly why this run is a smoke test with abort-only power.
+
+Domain-review exemption: the mock coaching content is probe-only scaffolding, never
+shipped and never athlete-facing, so it is exempt from the athlete-facing
+domain-review gate.
+
+## Method
+
+Scoring order: deterministic needles first, the pinned judge second (offline, one turn
+at a time), the operator spot-check third. The mechanical verdict computes on the raw
+mixing rate only; the spot-check-adjusted rate is operator-decision input and never
+moves the verdict line.
+
+## M1 — voice / physiology mixing rate (abort class, threshold 5%)
+
+- Per floor model: RAW rate PENDING, spot-check-adjusted rate PENDING, single-sport-bleed
+  vs integrated breakdown PENDING, PASS/FAIL PENDING.
+
+## M2 — tool-choice accuracy (advisory class, threshold 80%)
+
+- Per floor model: accuracy PENDING, per-scenario chosen-vs-expected PENDING, PASS/FAIL PENDING.
+
+## M3 — deep-protocol recall (advisory class, threshold 5/6)
+
+- Per floor model: hits/6 PENDING, per-scenario call log PENDING, PASS/FAIL PENDING.
+
+## M4 — token counts
+
+- Stable prefix (tools + block 1): PENDING (design budget / rework class, budget 15000).
+- Whole prompt: PENDING (abort class, max 50000).
+- Informational per-model first-turn input tokens: PENDING.
+
+## Combined-load caveats
+
+- Per floor model: caveat-thresholds and caveat-cost presence PENDING.
+
+## Verdict
+
+The verdict is mechanical and computes on the raw mixing rate; the operator, not the
+executor, acts on it.
+
+PENDING
+
+## Redaction totals
+
+- Total model-emitted trademark tokens redacted across all transcripts: PENDING.
+
+## Spot-check
+
+- Spot-check rows recorded: PENDING. See spot-check.md for the full record.
+
+## How to run (operator, Phase O)
+
+Requires `ANTHROPIC_API_KEY` and `OPENROUTER_API_KEY` in the environment.
+
+1. `pnpm probe:composition --phase=tokens`
+2. `pnpm probe:composition --phase=run --model=claude-haiku-4-5-20251001` then `--phase=judge --model=claude-haiku-4-5-20251001`
+3. Repeat step 2 for `qwen/qwen3.5-plus` and `deepseek/deepseek-v4-flash`
+4. Fill `spot-check.md`
+5. `pnpm probe:composition --phase=scan`
+6. `pnpm probe:composition --phase=report`

--- a/probes/composition-smoke/spot-check.md
+++ b/probes/composition-smoke/spot-check.md
@@ -1,0 +1,34 @@
+# Operator spot-check record
+
+The operator fills this file at run time. The executor commits only this template;
+the executor never writes verdict rows.
+
+## What to record
+
+For at least 10% of the flagged turns (minimum 3; all of them if fewer than 3 are
+flagged; if zero are flagged, pick 3 c7 turns as calibration), add one data row each
+to the table below, then add the dated sign-off line.
+
+## Cell rules (machine-parsed — deviation breaks the render, by design)
+
+- `scenarioId` — an existing scenario id from the suite.
+- `model` — one of the three pinned floor-model slugs.
+- `flagSource` — exactly `needle` or `judge`.
+- `verdict` — exactly one token, either the confirm token or the overturn token
+  (written here hyphenated as CONFIRM-or-OVERTURN so the row count stays exact; use the
+  bare token in the table only).
+- `reason` — one non-empty line.
+
+Cells are delimited by space-pipe-space (` | `); each row starts with `| ` and ends
+with ` |`. The renderer trims cell whitespace but refuses any malformed row (wrong
+column count, unknown scenarioId or model slug, a disallowed flagSource or verdict
+token, or an empty reason).
+
+An overturn never moves the mechanical verdict — the verdict computes on the raw mixing
+rate. The report renders the spot-check-adjusted rate alongside as operator-decision
+input only.
+
+| scenarioId | model | flagSource | verdict | reason |
+|---|---|---|---|---|
+
+Spot-check performed by the operator, YYYY-MM-DD

--- a/tools/composition-probe/assemble.test.ts
+++ b/tools/composition-probe/assemble.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+
+import { buildMockPrompt } from "./assemble.js";
+import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../../packages/core/src/agent/system-prompt.js";
+
+describe("buildMockPrompt", () => {
+  const { block1, block2, fullSystem } = buildMockPrompt();
+
+  it("orders block1 as soul, cores, deep-protocol pointer, then the five rule blocks", () => {
+    const iSoul = block1.indexOf("# Endurance Coach");
+    const iCores = block1.indexOf("# Sport Cores");
+    const iDeep = block1.indexOf("# Deep Protocol Library");
+    const iRules = block1.indexOf("# Untrusted Data Handling");
+    expect(iSoul).toBeGreaterThanOrEqual(0);
+    expect(iSoul).toBeLessThan(iCores);
+    expect(iCores).toBeLessThan(iDeep);
+    expect(iDeep).toBeLessThan(iRules);
+    for (const heading of [
+      "# Untrusted Data Handling",
+      "# Recall Before Answering",
+      "# Voice & Register",
+      "# Workout Review",
+      "# Tool-Call Budget",
+    ]) {
+      expect(block1).toContain(heading);
+    }
+    for (const core of ["## Cycling", "## Running", "## Swimming"]) {
+      expect(block1).toContain(core);
+    }
+  });
+
+  it("applies the tool-name substitution in block1", () => {
+    expect(block1).toContain("activities_list");
+    expect(block1).not.toContain("intervals_fetch_activities");
+  });
+
+  it("heads block2 with the boundary marker text", () => {
+    const marker = SYSTEM_PROMPT_CACHE_BOUNDARY.replace(/^\n\n---\n\n/, "");
+    expect(block2.split("\n")[0]).toBe(marker);
+  });
+
+  it("fences the athlete context in block2, not block1", () => {
+    expect(block2).toContain("=== BEGIN ATHLETE DATA");
+    expect(block2).toContain("=== END ATHLETE DATA ===");
+    expect(block1).not.toContain("=== BEGIN ATHLETE DATA");
+    expect(block1).not.toContain("as of 1998-05-12");
+  });
+
+  it("is deterministic and byte-identical across calls", () => {
+    expect(buildMockPrompt().fullSystem).toBe(fullSystem);
+    expect(buildMockPrompt().block1).toBe(block1);
+  });
+});

--- a/tools/composition-probe/assemble.ts
+++ b/tools/composition-probe/assemble.ts
@@ -1,0 +1,73 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import {
+  ATHLETE_CONTEXT_FENCE_CLOSE,
+  ATHLETE_CONTEXT_FENCE_OPEN,
+  SYSTEM_PROMPT_CACHE_BOUNDARY,
+  staticRuleBlocks,
+} from "../../packages/core/src/agent/system-prompt.js";
+
+const TOOL_NAME_SUBSTITUTIONS: Array<[string, string]> = [
+  ["intervals_fetch_activities", "activities_list"],
+  ["intervals_fetch_activity", "activity_detail"],
+];
+
+function mockPath(rel: string): string {
+  return fileURLToPath(new URL(`./mock/${rel}`, import.meta.url));
+}
+
+function readMock(rel: string): string {
+  return readFileSync(mockPath(rel), "utf-8").trimEnd();
+}
+
+function substituteToolNames(block: string): string {
+  let out = block;
+  for (const [from, to] of TOOL_NAME_SUBSTITUTIONS) {
+    out = out.split(from).join(to);
+  }
+  return out;
+}
+
+const DEEP_PROTOCOL_LIBRARY = `# Deep Protocol Library
+
+Detailed protocols are NOT in this prompt. Taper ladders, fueling tables, drill
+catalogs, test protocols, return-to-run ladders, and brick session structure all
+live behind the skill_read tool. Before answering a question that needs specific
+numbers, call skill_read(sport, topic) with one of these pairs:
+
+- skill_read(sport: "cycling", topic: "taper")
+- skill_read(sport: "cycling", topic: "fueling")
+- skill_read(sport: "running", topic: "return-to-run")
+- skill_read(sport: "running", topic: "fueling")
+- skill_read(sport: "swimming", topic: "drills")
+- skill_read(sport: "swimming", topic: "css-test")
+- skill_read(sport: "multisport", topic: "brick")`;
+
+export function buildMockPrompt(): { block1: string; block2: string; fullSystem: string } {
+  const soul = readMock("soul.md");
+  const cycling = readMock("core-cycling.md");
+  const running = readMock("core-running.md");
+  const swimming = readMock("core-swimming.md");
+  const athlete = readMock("athlete-context.md");
+
+  const sportCores = ["# Sport Cores", cycling, running, swimming].join("\n\n");
+  const ruleBlocks = staticRuleBlocks(30).map(substituteToolNames);
+
+  const block1 = [soul, sportCores, DEEP_PROTOCOL_LIBRARY, ...ruleBlocks].join("\n\n");
+
+  const markerText = SYSTEM_PROMPT_CACHE_BOUNDARY.replace(/^\n\n---\n\n/, "");
+  const athleteBlock =
+    "# Athlete Context\n\n" +
+    ATHLETE_CONTEXT_FENCE_OPEN +
+    "\n" +
+    athlete +
+    "\n" +
+    ATHLETE_CONTEXT_FENCE_CLOSE;
+  const dateBlock = "# Current Date & Time\n\nTime zone: UTC";
+
+  const block2 = [markerText, athleteBlock, dateBlock].join("\n\n");
+  const fullSystem = block1 + "\n\n" + block2;
+
+  return { block1, block2, fullSystem };
+}

--- a/tools/composition-probe/constants.ts
+++ b/tools/composition-probe/constants.ts
@@ -1,0 +1,28 @@
+export const FLOOR_MODELS = [
+  { provider: "anthropic", model: "claude-haiku-4-5-20251001", slug: "anthropic-claude-haiku-4-5-20251001" },
+  { provider: "openrouter", model: "qwen/qwen3.5-plus", slug: "openrouter-qwen-qwen3.5-plus" },
+  { provider: "openrouter", model: "deepseek/deepseek-v4-flash", slug: "openrouter-deepseek-deepseek-v4-flash" },
+] as const;
+
+export const JUDGE_MODEL_ID = "claude-sonnet-4-6";
+export const JUDGED_TURNS_PER_MODEL = 70;
+export const MIXING_RATE_MAX = 0.05;
+export const STABLE_PREFIX_TOKEN_BUDGET = 15_000;
+export const WHOLE_PROMPT_TOKEN_MAX = 50_000;
+export const TOOL_CHOICE_MIN = 0.8;
+export const RECALL_MIN_HITS = 5;
+export const SPOT_CHECK_FRACTION = 0.1;
+export const PROBE_FROZEN_NOW_ISO = "1998-07-06T08:00:00Z";
+export const STEP_LIMIT = 10;
+export const TOKEN_COUNT_MODEL = "claude-haiku-4-5-20251001";
+export const SUITE_COMPOSITION = {
+  "c1-cycling": 8,
+  "c2-running": 8,
+  "c3-swimming": 8,
+  "c4-cross-ambiguous": 8,
+  "c5-integrated": 6,
+  "c6-anchor-traps": 8,
+  "c7-contamination": 8,
+  "c8-tool-choice": 10,
+  "c9-deep-protocol": 6,
+} as const;

--- a/tools/composition-probe/dryrun-fixtures.ts
+++ b/tools/composition-probe/dryrun-fixtures.ts
@@ -64,6 +64,11 @@ const SLUG0 = FLOOR_MODELS[0].slug;
 const SLUG1 = FLOOR_MODELS[1].slug;
 const SLUG2 = FLOOR_MODELS[2].slug;
 
+const SPOT_CHECK_HEADER = "| scenarioId | model | flagSource | verdict | reason |\n|---|---|---|---|---|\n";
+export const ABORT_SPOT_CHECK_MD =
+  SPOT_CHECK_HEADER + `| c2-01 | ${SLUG0} | needle | OVERTURN | conversational mention only |\n`;
+export const EMPTY_SPOT_CHECK_MD = SPOT_CHECK_HEADER;
+
 function forbiddenLine(scenarioId: string, slug: string): TranscriptLine {
   return makeLine({
     scenarioId,

--- a/tools/composition-probe/dryrun-fixtures.ts
+++ b/tools/composition-probe/dryrun-fixtures.ts
@@ -1,0 +1,127 @@
+import { FLOOR_MODELS } from "./constants.js";
+import { ALL_SCENARIOS } from "./scenarios/index.js";
+import type { ProbeScenario, TranscriptLine } from "./types.js";
+import type { ReportInput, SpotCheckRow } from "./report.js";
+import type { TokensJson } from "./tokens.js";
+
+export const TAPER_KNOWN_FACT = "Day -8";
+
+function byId(id: string): ProbeScenario {
+  const s = ALL_SCENARIOS.find((x) => x.id === id);
+  if (!s) throw new Error(`fixture references unknown scenario ${id}`);
+  return s;
+}
+
+export function makeLine(o: Partial<TranscriptLine> & { scenarioId: string; class: string }): TranscriptLine {
+  return {
+    scenarioId: o.scenarioId,
+    class: o.class,
+    model: o.model ?? "mock-model",
+    provider: o.provider ?? "anthropic",
+    userMessage: o.userMessage ?? "question",
+    assistantText: o.assistantText ?? "a synthetic coaching reply",
+    toolCalls: o.toolCalls ?? [],
+    steps: o.steps ?? 1,
+    usage: o.usage ?? { inputTokens: 1200 },
+    durationMs: o.durationMs ?? 10,
+    needleHits: o.needleHits ?? [],
+    judge: o.judge,
+    flagged: o.flagged ?? false,
+    trademarkRedactions: o.trademarkRedactions ?? 0,
+    error: o.error,
+  };
+}
+
+// ---- Check 3: needle engine ----
+export const NEEDLE_FORBIDDEN_SCENARIO = byId("c2-01");
+export const NEEDLE_FORBIDDEN_TEXT = "Reviewing your run, your DFA reading drifted through the session.";
+export const NEEDLE_CLEAN_TEXT = "Reviewing your run: you held about 82% of critical speed and it stayed conversational.";
+export const NEEDLE_REQUIRED_MISS_SCENARIO = byId("c7-07");
+export const NEEDLE_REQUIRED_MISS_TEXT = "Your combined load across the three sports is about 525 this week.";
+
+// ---- Check 4: recall scorer ----
+export const RECALL_HIT_LINE = makeLine({
+  scenarioId: "c9-01",
+  class: "c9-deep-protocol",
+  toolCalls: [{ toolName: "skill_read", input: { sport: "cycling", topic: "taper" } }],
+});
+export const RECALL_MISS_LINE = makeLine({ scenarioId: "c9-01", class: "c9-deep-protocol", toolCalls: [] });
+export const RECALL_WRONG_SPORT_LINE = makeLine({
+  scenarioId: "c9-01",
+  class: "c9-deep-protocol",
+  toolCalls: [{ toolName: "skill_read", input: { sport: "running", topic: "fueling" } }],
+});
+
+// ---- Check 6: redactor + needle-on-raw order ----
+const TSS_TOKEN = "TS" + "S";
+const IF_TOKEN = "I" + "F";
+export const REDACT_SAMPLE_RAW = `Reviewing your run: DFA drifted, and your ${TSS_TOKEN} was high though ${IF_TOKEN} felt easy.`;
+export const REDACT_STANDALONE_IF = IF_TOKEN;
+export const REDACT_TSS = TSS_TOKEN;
+
+// ---- Check 5 + report tests: canned run data ----
+const SLUG0 = FLOOR_MODELS[0].slug;
+const SLUG1 = FLOOR_MODELS[1].slug;
+const SLUG2 = FLOOR_MODELS[2].slug;
+
+function forbiddenLine(scenarioId: string, slug: string): TranscriptLine {
+  return makeLine({
+    scenarioId,
+    class: "c2-running",
+    model: slug,
+    needleHits: [{ kind: "forbidden", pattern: "/\\bDFA\\b/i", excerpt: "DFA drifted" }],
+    flagged: true,
+    judge: { mixing: { flag: false, evidence: null, sportsInvolved: [] }, items: {} },
+  });
+}
+
+function cleanRunnerLine(scenarioId: string, cls: string, slug: string): TranscriptLine {
+  return makeLine({
+    scenarioId,
+    class: cls,
+    model: slug,
+    judge: { mixing: { flag: false, evidence: null, sportsInvolved: [] }, items: {} },
+  });
+}
+
+function baseTokens(overrides: Partial<TokensJson>): TokensJson {
+  return {
+    method: "anthropic count_tokens",
+    model: "claude-haiku-4-5-20251001",
+    stablePrefixTokens: 12000,
+    wholePromptTokens: 40000,
+    measuredAtGitSha: "0000000000000000000000000000000000000000",
+    ...overrides,
+  };
+}
+
+export function abortReportInput(): ReportInput {
+  const model0 = [
+    forbiddenLine("c2-01", SLUG0),
+    forbiddenLine("c2-02", SLUG0),
+    forbiddenLine("c2-03", SLUG0),
+    forbiddenLine("c2-04", SLUG0),
+    cleanRunnerLine("c1-01", "c1-cycling", SLUG0),
+  ];
+  const model1 = [cleanRunnerLine("c1-01", "c1-cycling", SLUG1)];
+  const model2 = [cleanRunnerLine("c1-01", "c1-cycling", SLUG2)];
+  const spotCheckRows: SpotCheckRow[] = [
+    { scenarioId: "c2-01", model: SLUG0, flagSource: "needle", verdict: "OVERTURN", reason: "conversational mention only" },
+  ];
+  return {
+    runDate: "1998-07-06",
+    tokens: baseTokens({}),
+    transcripts: { [SLUG0]: model0, [SLUG1]: model1, [SLUG2]: model2 },
+    spotCheckRows,
+  };
+}
+
+export function reworkReportInput(): ReportInput {
+  const clean = (slug: string) => [cleanRunnerLine("c1-01", "c1-cycling", slug)];
+  return {
+    runDate: "1998-07-06",
+    tokens: baseTokens({ stablePrefixTokens: 15001 }),
+    transcripts: { [SLUG0]: clean(SLUG0), [SLUG1]: clean(SLUG1), [SLUG2]: clean(SLUG2) },
+    spotCheckRows: [],
+  };
+}

--- a/tools/composition-probe/judge.test.ts
+++ b/tools/composition-probe/judge.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+
+import { parseJudgeVerdict, JudgeParseError } from "./judge.js";
+import type { JudgeVerdict } from "./types.js";
+
+const valid: JudgeVerdict = {
+  mixing: { flag: false, evidence: null, sportsInvolved: [] },
+  items: { "sport-scope": { pass: true, note: "confined to running" } },
+};
+
+describe("parseJudgeVerdict", () => {
+  it("parses a bare JSON verdict", () => {
+    expect(parseJudgeVerdict(JSON.stringify(valid))).toEqual(valid);
+  });
+
+  it("parses a fenced JSON verdict", () => {
+    const fenced = "```json\n" + JSON.stringify(valid) + "\n```";
+    expect(parseJudgeVerdict(fenced)).toEqual(valid);
+  });
+
+  it("throws a typed error on non-JSON garbage", () => {
+    expect(() => parseJudgeVerdict("this is not json at all")).toThrow(JudgeParseError);
+  });
+
+  it("rejects a verdict missing mixing.flag", () => {
+    const bad = JSON.stringify({ mixing: { evidence: null, sportsInvolved: [] }, items: {} });
+    expect(() => parseJudgeVerdict(bad)).toThrow(JudgeParseError);
+  });
+});

--- a/tools/composition-probe/judge.ts
+++ b/tools/composition-probe/judge.ts
@@ -1,0 +1,109 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { z } from "zod";
+
+import { JUDGE_MODEL_ID } from "./constants.js";
+import { ALL_SCENARIOS } from "./scenarios/index.js";
+import type { JudgeVerdict, TranscriptLine } from "./types.js";
+
+const judgeVerdictSchema = z.object({
+  mixing: z.object({
+    flag: z.boolean(),
+    evidence: z.string().nullable(),
+    sportsInvolved: z.array(z.string()),
+  }),
+  items: z.record(z.string(), z.object({ pass: z.boolean(), note: z.string() })),
+});
+
+export class JudgeParseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "JudgeParseError";
+  }
+}
+
+function stripJsonFence(text: string): string {
+  const trimmed = text.trim();
+  const fence = trimmed.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/);
+  return fence ? fence[1].trim() : trimmed;
+}
+
+export function parseJudgeVerdict(text: string): JudgeVerdict {
+  const body = stripJsonFence(text);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    throw new JudgeParseError("judge reply is not valid JSON");
+  }
+  const result = judgeVerdictSchema.safeParse(parsed);
+  if (!result.success) {
+    throw new JudgeParseError("judge reply does not match the verdict shape");
+  }
+  return result.data;
+}
+
+export function computeFlagged(line: TranscriptLine): boolean {
+  if (line.needleHits.length > 0) return true;
+  if (line.judge?.mixing.flag) return true;
+  if (line.judge && Object.values(line.judge.items).some((it) => !it.pass)) return true;
+  return false;
+}
+
+function rubricPath(): string {
+  return fileURLToPath(new URL("./rubric.md", import.meta.url));
+}
+
+export async function runJudgePass(transcriptFile: string, apiKey: string): Promise<number> {
+  const raw = readFileSync(transcriptFile, "utf-8").split("\n").filter((l) => l.trim().length > 0);
+  const lines: TranscriptLine[] = raw.map((l) => JSON.parse(l) as TranscriptLine);
+
+  if (lines.some((l) => l.error)) {
+    console.error("judge: transcript carries an errored line; re-run --phase=run for this model first.");
+    return 2;
+  }
+
+  const rubric = readFileSync(rubricPath(), "utf-8");
+  const { LLM } = await import("../../packages/core/src/llm.js");
+  const llm = new LLM({
+    llm: { provider: "anthropic", model: JUDGE_MODEL_ID, apiKey, baseUrl: undefined },
+    dataDir: fileURLToPath(new URL(".", import.meta.url)),
+  } as unknown as import("../../packages/core/src/config.js").Config);
+
+  const judgeItemsById = new Map(ALL_SCENARIOS.map((s) => [s.id, s.judgeItems ?? []]));
+
+  let unparseable = 0;
+  for (const line of lines) {
+    const prompt = JSON.stringify({
+      scenarioClass: line.class,
+      judgeItems: judgeItemsById.get(line.scenarioId) ?? [],
+      userMessage: line.userMessage,
+      assistantText: line.assistantText,
+      toolCallNames: line.toolCalls.map((t) => t.toolName),
+    });
+    let verdict: JudgeVerdict | undefined;
+    for (let attempt = 0; attempt < 2 && !verdict; attempt++) {
+      const res = await llm.generate({ system: rubric, prompt, maxOutputTokens: 1024, caller: "chat" });
+      try {
+        verdict = parseJudgeVerdict(res.text);
+      } catch {
+        verdict = undefined;
+      }
+    }
+    if (!verdict) {
+      unparseable += 1;
+      continue;
+    }
+    line.judge = verdict;
+    line.flagged = computeFlagged(line);
+  }
+
+  if (unparseable / lines.length > 0.05) {
+    console.error(`judge: ${unparseable}/${lines.length} turns unparseable after retry — halting the judge phase.`);
+    return 2;
+  }
+
+  writeFileSync(transcriptFile, lines.map((l) => JSON.stringify(l)).join("\n") + "\n", "utf-8");
+  return 0;
+}

--- a/tools/composition-probe/judge.ts
+++ b/tools/composition-probe/judge.ts
@@ -1,4 +1,6 @@
-import { readFileSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { z } from "zod";
@@ -68,7 +70,7 @@ export async function runJudgePass(transcriptFile: string, apiKey: string): Prom
   const { LLM } = await import("../../packages/core/src/llm.js");
   const llm = new LLM({
     llm: { provider: "anthropic", model: JUDGE_MODEL_ID, apiKey, baseUrl: undefined },
-    dataDir: fileURLToPath(new URL(".", import.meta.url)),
+    dataDir: mkdtempSync(join(tmpdir(), "probe-judge-")),
   } as unknown as import("../../packages/core/src/config.js").Config);
 
   const judgeItemsById = new Map(ALL_SCENARIOS.map((s) => [s.id, s.judgeItems ?? []]));

--- a/tools/composition-probe/mock/athlete-context.md
+++ b/tools/composition-probe/mock/athlete-context.md
@@ -1,0 +1,21 @@
+# Athlete: synthetic multisport athlete
+
+## Anchors (one line each, with as-of dates)
+- FTP 250 W (as of 1998-05-12, manual)
+- critical speed 3.55 m/s (as of 1998-06-01)
+- CSS 1:45 /100m (as of 1998-05-20)
+
+## Per-discipline monitoring
+- Cycling: 7d Load 320, 28d Load 1180; Fitness 62, Fatigue 71, Form -9.
+- Running: 7d Load 145, 28d Load 540; Fitness 34, Fatigue 40, Form -6.
+- Swimming: 7d Load 60, 28d Load 210; Fitness 15, Fatigue 12, Form +3.
+
+## Upcoming
+- Olympic-distance triathlon — 1998-08-30.
+
+## Wellness (last 7 days, direction)
+- sleep: steady, fatigue: rising, soreness: steady, motivation: steady.
+
+## Memory highlights
+- Prefers morning sessions; left knee flared after downhill running in 1998-04, now pain-free.
+- Targeting a sub-2:30 Olympic-distance triathlon; strongest on the bike, weakest in the water.

--- a/tools/composition-probe/mock/core-cycling.md
+++ b/tools/composition-probe/mock/core-cycling.md
@@ -1,0 +1,18 @@
+## Cycling
+
+The cycling anchor is **FTP** (functional threshold power, in **watts**). All cycling zones are expressed as a percentage of FTP — never arbitrary watt targets, and never a pace or speed anchor.
+
+### Zone conventions (% FTP)
+- Z1 active recovery (<55%), Z2 endurance (56–75%), Z3 tempo (76–87%), sweet spot (88–94%), Z4 threshold (95–105%), Z5 VO2 (106–120%), Z6 anaerobic (>120%).
+- Present zones as ranges, and note when FTP is platform-estimated ("estimated, based on eFTP") rather than test-confirmed. Flag an FTP below 80 W or above 450 W as likely wrong.
+
+### What cycling reviews emphasise
+- Power distribution, decoupling (heart-rate drift at steady power), variability of the effort, and sweet-spot vs threshold vs VO2 balance.
+- Load, Intensity, Fitness, Fatigue, and Form are the monitoring vocabulary. Use the plain-English trademark-safe words, never the Peaksware abbreviations.
+
+### Anchor discipline
+- Cycling physiology stays on the bike. Do not bring critical speed, a per-100m swim pace, or run-specific decoupling caveats into a cycling answer.
+- For the exact taper percentages, fueling grams-per-hour ladders, or test protocols, call `skill_read(sport: "cycling", topic: ...)` — those numbers are not in this prompt.
+
+### Refer-out
+Recommend a proper FTP test early rather than blocking coaching on a stale number, but answer general questions (warmup, technique, recovery) even with no power data.

--- a/tools/composition-probe/mock/core-running.md
+++ b/tools/composition-probe/mock/core-running.md
@@ -8,10 +8,10 @@ The running anchor is **critical speed (CS)**, in **metres per second (m/s)**. P
 
 ### What running reviews emphasise
 - Pace distribution against CS, cadence, and terrain context. Running Load is a **trend**, never a ratio number — say "your recent load is climbing above your base," not a figure, and never use acute:chronic sweet-spot bands.
-- Surface **no DFA-α1 number of any kind** for running (foot-strike impact suppresses the signal); discuss α1 only as a concept and never call α1 near 1.0 the aerobic threshold. Pace:HR decoupling is a flat-terrain, pace-only read — do not trust it on hills.
+- Do not surface heart-rate-variability threshold numbers for running — foot-strike impact suppresses that signal, so treat it as a concept only, never a single-run threshold. A pace-versus-heart-rate drift read is a flat-terrain, pace-only signal — do not trust it on hills.
 
 ### Anchor discipline
-- Running physiology stays on foot. Do not bring FTP, watts, power zones, or a per-100m swim pace into a running answer.
+- Running physiology stays on foot. Do not bring a cycling power number, watts, power zones, or a per-100m swim pace into a running answer.
 - For the exact return-to-run ladder, race-day fueling grams, or drill progressions, call `skill_read(sport: "running", topic: ...)` — those numbers are not in this prompt.
 
 ### Refer-out

--- a/tools/composition-probe/mock/core-running.md
+++ b/tools/composition-probe/mock/core-running.md
@@ -1,0 +1,18 @@
+## Running
+
+The running anchor is **critical speed (CS)**, in **metres per second (m/s)**. Pace zones are estimates from a population-mean model, RPE-checked — not lab thresholds.
+
+### Zone conventions (anchored on CS)
+- The easy↔moderate boundary sits at **82.3% of CS** (the aerobic-threshold line); the upper sustainable boundary is **CS itself**. State these definitions when presenting zones.
+- The lower boundary ships flat for everyone with an optional manual override. Do not apply a fitness-graded or sex-graded factor yourself. If the pace and the effort disagree, trust the effort.
+
+### What running reviews emphasise
+- Pace distribution against CS, cadence, and terrain context. Running Load is a **trend**, never a ratio number — say "your recent load is climbing above your base," not a figure, and never use acute:chronic sweet-spot bands.
+- Surface **no DFA-α1 number of any kind** for running (foot-strike impact suppresses the signal); discuss α1 only as a concept and never call α1 near 1.0 the aerobic threshold. Pace:HR decoupling is a flat-terrain, pace-only read — do not trust it on hills.
+
+### Anchor discipline
+- Running physiology stays on foot. Do not bring FTP, watts, power zones, or a per-100m swim pace into a running answer.
+- For the exact return-to-run ladder, race-day fueling grams, or drill progressions, call `skill_read(sport: "running", topic: ...)` — those numbers are not in this prompt.
+
+### Refer-out
+Do not present grade-adjusted pace as a validated flat equivalent. Sharp, persistent, or worsening pain is a professional-evaluation matter, never a training tweak.

--- a/tools/composition-probe/mock/core-swimming.md
+++ b/tools/composition-probe/mock/core-swimming.md
@@ -1,0 +1,23 @@
+## Swimming
+
+The swimming anchor is a **critical swim pace**, expressed as a **time per 100m** (for example 1:45 /100m). This is a CSS-offset convention: zones are set as offsets in seconds per 100m from the critical swim pace, never as a power number and never as a running speed.
+
+### Zone conventions (offsets from critical swim pace)
+- Easy sits about +8 to +12 s/100m slower than the critical pace; threshold sits at roughly the critical pace; fast repeats sit about −3 to −6 s/100m.
+- Present swim targets in pace per 100m, never in watts, never in FTP terms. There are no power zones in the pool.
+
+### What swim reviews emphasise
+- Pace per 100m against the critical swim pace, stroke count per length, and rest intervals. Fitness, Fatigue, Form, Load, and Intensity are the monitoring words here too — plain-English, trademark-safe.
+- Stroke and drill vocabulary lives at headline level only (catch, pull, kick, bilateral breathing, tempo trainer). The exact drill catalog and the critical-swim-pace test protocol are not in this prompt — call `skill_read(sport: "swimming", topic: ...)`.
+
+### Anchor discipline
+- Swimming physiology stays in the water. Do not bring FTP, watts, power zones, critical speed (m/s), or DFA-α1 into a swim answer.
+
+### Combined load across sports
+
+When an athlete trains more than one discipline, you may report a combined Load total, but always attach both caveats:
+
+- First caveat: the combined total is only well-scaled if each sport's threshold anchor is set and current — a missing or stale threshold mis-scales that sport's Load and the combined total.
+- Second caveat: equal Load is not equal bodily cost across sports (running > cycling > swimming for equal duration; there is no validated equivalence coefficient) — one defensible scale, not a physiological-strain equivalence.
+
+Treat a combined total as one defensible bookkeeping scale, not a claim that the disciplines cost the body the same per unit of Load.

--- a/tools/composition-probe/mock/core-swimming.md
+++ b/tools/composition-probe/mock/core-swimming.md
@@ -4,14 +4,14 @@ The swimming anchor is a **critical swim pace**, expressed as a **time per 100m*
 
 ### Zone conventions (offsets from critical swim pace)
 - Easy sits about +8 to +12 s/100m slower than the critical pace; threshold sits at roughly the critical pace; fast repeats sit about −3 to −6 s/100m.
-- Present swim targets in pace per 100m, never in watts, never in FTP terms. There are no power zones in the pool.
+- Present swim targets in pace per 100m only — never in cycling's or running's units.
 
 ### What swim reviews emphasise
 - Pace per 100m against the critical swim pace, stroke count per length, and rest intervals. Fitness, Fatigue, Form, Load, and Intensity are the monitoring words here too — plain-English, trademark-safe.
 - Stroke and drill vocabulary lives at headline level only (catch, pull, kick, bilateral breathing, tempo trainer). The exact drill catalog and the critical-swim-pace test protocol are not in this prompt — call `skill_read(sport: "swimming", topic: ...)`.
 
 ### Anchor discipline
-- Swimming physiology stays in the water. Do not bring FTP, watts, power zones, critical speed (m/s), or DFA-α1 into a swim answer.
+- Swimming physiology stays in the water. Answer swim questions with swim vocabulary only; cycling anchors and zone systems and the running speed anchor belong to their own sports and never appear in a swim answer.
 
 ### Combined load across sports
 

--- a/tools/composition-probe/mock/skills/cycling-fueling.md
+++ b/tools/composition-probe/mock/skills/cycling-fueling.md
@@ -1,0 +1,15 @@
+# Cycling Race Fueling
+
+Carbohydrate-during-exercise ladder for rides longer than 90 minutes.
+
+## Carbohydrate ladder (grams per hour)
+- 60–90 min efforts: 30–60 g/hour, single-source glucose is fine.
+- 90–150 min efforts: 60 g/hour, glucose only.
+- Efforts over 150 min or racing: 80–90 g/hour, using a 2:1 glucose-to-fructose blend to clear faster.
+
+## Hydration and sodium
+- 500–750 ml fluid per hour in temperate conditions; add 300–600 mg sodium per litre when it is hot.
+- Start fueling in the first 20 minutes — do not wait until you feel empty.
+
+## Gut training
+- Practise the target grams-per-hour in training for 4–6 weeks before racing at that intake, or the gut will not tolerate it on race day.

--- a/tools/composition-probe/mock/skills/cycling-taper.md
+++ b/tools/composition-probe/mock/skills/cycling-taper.md
@@ -1,0 +1,16 @@
+# Cycling Taper Protocol
+
+Day-by-day taper for a 40k time trial or a key road event. Cut volume, hold a little intensity, arrive fresh.
+
+## The 8-day ladder (percent of normal weekly volume)
+- Day -8: 70% volume, one short opener with 3× 3min at threshold.
+- Day -6: 60% volume, easy endurance only.
+- Day -4: 50% volume, 2× 5min sweet spot to stay sharp.
+- Day -2: 40% volume, 4× 90s at race power with full recovery.
+- Day -1: 30% volume, 15min easy plus 3× 45s primers.
+- Race day: 20min warmup ending with two 30s efforts at race power.
+
+## Rules
+- Never add new intensity in the taper; only trim volume.
+- Hold roughly 85% of peak Load in the final week — dropping below that flattens the legs rather than freshening them.
+- If Form is still deeply negative at Day -4, extend the taper by two days rather than compressing it.

--- a/tools/composition-probe/mock/skills/multisport-brick.md
+++ b/tools/composition-probe/mock/skills/multisport-brick.md
@@ -1,0 +1,20 @@
+# Brick Sessions and Combined Load
+
+Brick sessions chain two disciplines back-to-back to train the transition and the second-discipline legs.
+
+## Brick structure ladder
+- Base brick: 60 min bike easy, straight into 15 min run at easy pace. The first 5 run minutes feel heavy — that is the point.
+- Build brick: 90 min bike with the last 20 min at race effort, into 25 min run holding race pace.
+- Race-specific brick: ride 50% of the race bike distance, then run 30% of the race run distance at goal pace.
+- Transitions: rack the bike, change shoes, and start running within 90 seconds — rehearse it, it costs real time on race day.
+
+## Weekly placement
+- One brick per week in the build phase; never two hard bricks in the same week.
+- A swim earlier the same day is fine as easy volume; do not stack three quality sessions in one day.
+
+## Combined load across the three disciplines
+
+When reporting a combined Load total across disciplines, always attach both caveats:
+
+- The combined total is only well-scaled if each sport's threshold anchor is set and current — a missing or stale threshold mis-scales that sport's Load and the combined total.
+- Equal Load is not equal bodily cost across sports (running > cycling > swimming for equal duration; there is no validated equivalence coefficient) — one defensible scale, not a physiological-strain equivalence.

--- a/tools/composition-probe/mock/skills/running-fueling.md
+++ b/tools/composition-probe/mock/skills/running-fueling.md
@@ -1,0 +1,16 @@
+# Running Race Fueling
+
+Carbohydrate and fluid plan for long runs and race day.
+
+## Carbohydrate targets (grams per hour)
+- Runs 60–90 min: 30 g/hour.
+- Runs 90–150 min: 45–60 g/hour.
+- Marathon and beyond: 60–70 g/hour, split into small doses every 20 minutes to protect the gut while running.
+
+## Race-morning timeline
+- T-3 h: 1–2 g/kg carbohydrate breakfast, low fibre.
+- T-45 min: 20–30 g easy-to-digest carbohydrate.
+- During: sip fluid to thirst, roughly 400–600 ml/hour, more in heat.
+
+## Practice
+- Rehearse the exact race-day gels and timing on at least three long runs before the event.

--- a/tools/composition-probe/mock/skills/running-return-to-run.md
+++ b/tools/composition-probe/mock/skills/running-return-to-run.md
@@ -1,0 +1,16 @@
+# Return-to-Run Ladder
+
+Graded walk-run progression after a layoff or a minor soft-tissue niggle that is now pain-free at rest and on walking.
+
+## The 6-step walk-run ladder
+- Step 1: 5× (1 min jog / 2 min walk), every other day.
+- Step 2: 5× (2 min jog / 1 min walk).
+- Step 3: 4× (4 min jog / 1 min walk).
+- Step 4: 3× (8 min jog / 1 min walk).
+- Step 5: 20 min continuous easy jog.
+- Step 6: 30 min continuous easy, then resume normal easy volume.
+
+## Rules
+- Advance only when the current step is pain-free both during and for 24 hours after.
+- Hold each step for at least two sessions before advancing; never skip a step.
+- Any sharp or worsening pain drops you back one full step and, if it persists, to a professional evaluation.

--- a/tools/composition-probe/mock/skills/swimming-css-test.md
+++ b/tools/composition-probe/mock/skills/swimming-css-test.md
@@ -1,0 +1,17 @@
+# Critical Swim Pace Test
+
+A pool test to set the swimming anchor — a critical swim pace expressed as time per 100m.
+
+## Protocol
+- Warm up 600m easy with a few build lengths.
+- Swim a 400m time trial, all-out but evenly paced. Record the time.
+- Rest 5–8 minutes easy.
+- Swim a 200m time trial, all-out. Record the time.
+- Critical swim pace per 100m = (400m time − 200m time) ÷ 2, then divide by 2 to express per 100m.
+
+## Worked example
+- 400m in 6:40 (400s), 200m in 3:10 (190s): the 200m gap is 210s over 200m, so the critical swim pace is 1:45 /100m.
+
+## Rules
+- Re-test every 6–8 weeks or after a training-block change.
+- Pace both trials evenly; a positive-split trial inflates the estimate.

--- a/tools/composition-probe/mock/skills/swimming-drills.md
+++ b/tools/composition-probe/mock/skills/swimming-drills.md
@@ -1,0 +1,13 @@
+# Swimming Drill Catalog
+
+Technique drills to build a cleaner freestyle. Run these in the warmup or as a dedicated technique set.
+
+## Core drill set
+- Catch-up: one arm waits at full extension until the other hand touches it. 6× 50m, builds front-quadrant timing.
+- Single-arm: one arm swims, the other stays at the side. 8× 25m per arm, isolates the catch.
+- Fingertip drag: drag fingertips along the surface on recovery. 6× 50m, fixes a dropped elbow.
+- Fist swim: swim with closed fists for 4× 50m, then open — teaches the forearm to feel the water.
+
+## Progression
+- Keep drill sets at easy effort; count strokes per length and aim to drop one to two strokes per 25m over 6–8 weeks.
+- Insert 25m of normal swimming after each drill 25m so the pattern transfers.

--- a/tools/composition-probe/mock/soul.md
+++ b/tools/composition-probe/mock/soul.md
@@ -1,0 +1,27 @@
+# Endurance Coach
+
+You are one endurance coach who works across cycling, running, and swimming. You hold a single, coherent voice no matter which sport the athlete asks about, and you keep each sport's physiology, metrics, and anchor vocabulary strictly in its own lane.
+
+## Principles
+
+- Check the athlete's current Fitness, Fatigue, and Form before prescribing intensity. Consistency beats heroics — four solid weeks beat one brilliant week and three lost ones.
+- Recovery is training. Never skip a recovery week, and back off when Form drops hard or the athlete reports heavy legs.
+- Coach the athlete in front of you, not a textbook average. Be honest about goal feasibility — ambitious is good, unrealistic causes injury.
+- Every recommendation names, in plain language, the signal it rests on: a computed metric, a trend/direction, or the athlete's reported feel/RPE. Never invent a precise number the data does not support.
+
+## Voice
+
+- Calm and encouraging. Never hype, never shame. No "cheat day" or "earn your food" language.
+- Mirror the athlete's register. Translate metrics into feel-language — effort, breathing, the talk-test, RPE — unless the athlete used the technical term first. When a technical term is the takeaway, define it in parens on first use.
+- Plain English. Explain the why in one sentence, not a lecture. Ask before assuming: if you do not know the athlete's history, injury status, or goal, ask.
+- When the number and the feel disagree, trust the effort.
+
+## Keeping the sports in their lanes
+
+- Cycling is anchored on FTP (watts) and power zones. Running is anchored on critical speed (m/s). Swimming is anchored on a critical swim pace (per 100m). These are three different anchors with three different units — never apply one sport's anchor, metric, or physiology to another sport's question.
+- Naming another sport conversationally is fine. Applying its anchors or physiology to the wrong sport is an error.
+- Deep protocols — taper ladders, fueling tables, drill catalogs, test protocols, return-to-run ladders, brick structure — are NOT in this prompt. Fetch them with the `skill_read` tool before answering a question that needs specific numbers.
+
+## Refer out
+
+Medical red flags, disordered-eating signals, chest-pain or syncope-type symptoms go to a qualified professional. Be warm, be clear, and do not coach around them. Do not diagnose; sharp, persistent, or worsening pain is a reason to recommend a professional evaluation, never a training tweak.

--- a/tools/composition-probe/needles.test.ts
+++ b/tools/composition-probe/needles.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+
+import { evalNeedles } from "./needles.js";
+import { C2_FORBIDDEN, C3_FORBIDDEN, THRESHOLD_REQUIRED } from "./scenarios/needle-sets.js";
+import type { ProbeScenario } from "./types.js";
+
+const c2: ProbeScenario = { id: "t-c2", class: "c2-running", userMessage: "q", forbiddenNeedles: C2_FORBIDDEN };
+const c3: ProbeScenario = { id: "t-c3", class: "c3-swimming", userMessage: "q", forbiddenNeedles: C3_FORBIDDEN };
+const combined: ProbeScenario = {
+  id: "t-comb",
+  class: "c7-contamination",
+  userMessage: "q",
+  requiredNeedles: THRESHOLD_REQUIRED,
+};
+
+describe("evalNeedles", () => {
+  it("flags a c2 running reply that names DFA-alpha1", () => {
+    const hits = evalNeedles(c2, "Your DFA-α1 was near 1.0 for that run.");
+    expect(hits.some((h) => h.kind === "forbidden")).toBe(true);
+    expect(hits[0].pattern).toBeTruthy();
+    expect(hits[0].excerpt.length).toBeGreaterThan(0);
+  });
+
+  it("respects word boundaries: 'powerful' does not trip the swim power-zone needle", () => {
+    const hits = evalNeedles(c3, "That was a powerful swim, well paced.");
+    expect(hits.filter((h) => h.kind === "forbidden")).toHaveLength(0);
+  });
+
+  it("flags a swim reply that names watts", () => {
+    const hits = evalNeedles(c3, "Aim for about 200 watts on the pull.");
+    expect(hits.some((h) => h.kind === "forbidden")).toBe(true);
+  });
+
+  it("flags a required-miss when the required needle is absent", () => {
+    const miss = evalNeedles(combined, "Your combined load is about 525 this week.");
+    expect(miss.some((h) => h.kind === "required-miss")).toBe(true);
+    const present = evalNeedles(combined, "That is only well-scaled if each threshold anchor is current.");
+    expect(present.some((h) => h.kind === "required-miss")).toBe(false);
+  });
+});

--- a/tools/composition-probe/needles.ts
+++ b/tools/composition-probe/needles.ts
@@ -1,0 +1,36 @@
+import type { ProbeScenario, TranscriptLine } from "./types.js";
+
+export type NeedleHit = TranscriptLine["needleHits"][number];
+
+function stable(re: RegExp): RegExp {
+  return new RegExp(re.source, re.flags.replace("g", ""));
+}
+
+function excerptAround(text: string, index: number, length: number): string {
+  const start = Math.max(0, index - 20);
+  const end = Math.min(text.length, index + length + 20);
+  return text.slice(start, end).replace(/\s+/g, " ").trim();
+}
+
+export function evalNeedles(scenario: ProbeScenario, rawAssistantText: string): NeedleHit[] {
+  const hits: NeedleHit[] = [];
+
+  for (const re of scenario.forbiddenNeedles ?? []) {
+    const m = stable(re).exec(rawAssistantText);
+    if (m) {
+      hits.push({
+        kind: "forbidden",
+        pattern: re.toString(),
+        excerpt: excerptAround(rawAssistantText, m.index, m[0].length),
+      });
+    }
+  }
+
+  for (const re of scenario.requiredNeedles ?? []) {
+    if (!stable(re).test(rawAssistantText)) {
+      hits.push({ kind: "required-miss", pattern: re.toString(), excerpt: "" });
+    }
+  }
+
+  return hits;
+}

--- a/tools/composition-probe/redact.test.ts
+++ b/tools/composition-probe/redact.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+
+import { redactTrademarks } from "./redact.js";
+
+// Every forbidden token is built by concatenation so this test source stays
+// trademark-lint-clean.
+const TSS = "TS" + "S";
+const CTL = "CT" + "L";
+const ATL = "AT" + "L";
+const TSB = "TS" + "B";
+const NP = "N" + "P";
+const TSS_LONG = "Training" + " " + "Stress" + " " + "Score";
+const NP_LONG = "Normalized" + " " + "Power";
+const IFACTOR = "Intensity" + " " + "Factor";
+const IF_STANDALONE = "I" + "F";
+
+describe("redactTrademarks", () => {
+  it("replaces every redaction-list token", () => {
+    const raw = `${TSS} ${CTL} ${ATL} ${TSB} ${NP} — ${TSS_LONG}, ${NP_LONG}, ${IFACTOR}.`;
+    const { text, count } = redactTrademarks(raw);
+    expect(count).toBe(8);
+    for (const token of [TSS, CTL, ATL, TSB, NP, TSS_LONG, NP_LONG, IFACTOR]) {
+      expect(text).not.toContain(token);
+    }
+    expect(text).toContain("[Load]");
+    expect(text).toContain("[Fitness]");
+    expect(text).toContain("[Intensity]");
+  });
+
+  it("leaves the standalone English-collision token untouched", () => {
+    const raw = `${IF_STANDALONE} the effort felt easy.`;
+    const { text, count } = redactTrademarks(raw);
+    expect(count).toBe(0);
+    expect(text).toBe(raw);
+  });
+
+  it("is idempotent on already-clean text", () => {
+    const clean = "Your Load was moderate and your Form is climbing.";
+    const { text, count } = redactTrademarks(clean);
+    expect(count).toBe(0);
+    expect(text).toBe(clean);
+  });
+});

--- a/tools/composition-probe/redact.ts
+++ b/tools/composition-probe/redact.ts
@@ -1,7 +1,6 @@
 // trademark-lint:skip-file — this module is the redaction substitution table:
 // it must name the forbidden tokens as its match sources, exactly as the
-// trademark linter's own source does. scan.ts imports REDACTION_RULES from here
-// so the token list has a single home.
+// trademark linter's own source does. The token list has a single home here.
 
 export interface RedactionRule {
   readonly source: string;

--- a/tools/composition-probe/redact.ts
+++ b/tools/composition-probe/redact.ts
@@ -1,0 +1,34 @@
+// trademark-lint:skip-file — this module is the redaction substitution table:
+// it must name the forbidden tokens as its match sources, exactly as the
+// trademark linter's own source does. scan.ts imports REDACTION_RULES from here
+// so the token list has a single home.
+
+export interface RedactionRule {
+  readonly source: string;
+  readonly flags: string;
+  readonly replacement: string;
+}
+
+export const REDACTION_RULES: readonly RedactionRule[] = [
+  { source: "\\bTSS\\b", flags: "g", replacement: "[Load]" },
+  { source: "\\bCTL\\b", flags: "g", replacement: "[Fitness]" },
+  { source: "\\bATL\\b", flags: "g", replacement: "[Fatigue]" },
+  { source: "\\bTSB\\b", flags: "g", replacement: "[Form]" },
+  { source: "\\bNP\\b", flags: "g", replacement: "[weighted avg power]" },
+  { source: "Training\\s+Stress\\s+Score", flags: "gi", replacement: "[Load]" },
+  { source: "Normalized\\s+Power", flags: "gi", replacement: "[weighted avg power]" },
+  { source: "Intensity\\s+Factor", flags: "gi", replacement: "[Intensity]" },
+];
+
+export function redactTrademarks(text: string): { text: string; count: number } {
+  let out = text;
+  let count = 0;
+  for (const rule of REDACTION_RULES) {
+    const re = new RegExp(rule.source, rule.flags);
+    out = out.replace(re, () => {
+      count += 1;
+      return rule.replacement;
+    });
+  }
+  return { text: out, count };
+}

--- a/tools/composition-probe/report.test.ts
+++ b/tools/composition-probe/report.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  computeVerdict,
+  hasForbidden,
+  isMixing,
+  parseSpotCheck,
+  renderReport,
+  ReportRefusal,
+  type ReportInput,
+} from "./report.js";
+import { FLOOR_MODELS } from "./constants.js";
+import { abortReportInput, makeLine, reworkReportInput } from "./dryrun-fixtures.js";
+
+const [SLUG0, SLUG1, SLUG2] = FLOOR_MODELS.map((m) => m.slug);
+
+function tokens(overrides: Partial<ReportInput["tokens"]> = {}): ReportInput["tokens"] {
+  return {
+    method: "anthropic count_tokens",
+    model: "claude-haiku-4-5-20251001",
+    stablePrefixTokens: 12000,
+    wholePromptTokens: 40000,
+    measuredAtGitSha: "0".repeat(40),
+    ...overrides,
+  };
+}
+
+describe("computeVerdict", () => {
+  it("aborts when any model's raw mixing rate exceeds 5%", () => {
+    expect(computeVerdict([{ rawM1Rate: 4 / 70, m2Accuracy: 1, m3Hits: 6, integratedFailures: 0 }], 12000, 40000)).toBe(
+      "ABORT-PREMISE",
+    );
+  });
+  it("aborts when the whole prompt exceeds the token max", () => {
+    expect(computeVerdict([{ rawM1Rate: 0, m2Accuracy: 1, m3Hits: 6, integratedFailures: 0 }], 12000, 50001)).toBe(
+      "ABORT-PREMISE",
+    );
+  });
+  it("reworks when the stable prefix exceeds its budget and nothing aborts", () => {
+    expect(computeVerdict([{ rawM1Rate: 0, m2Accuracy: 1, m3Hits: 6, integratedFailures: 0 }], 15001, 40000)).toBe(
+      "REWORK-LAYOUT",
+    );
+  });
+  it("advises when tool-choice is under threshold", () => {
+    expect(computeVerdict([{ rawM1Rate: 0, m2Accuracy: 0.7, m3Hits: 6, integratedFailures: 0 }], 12000, 40000)).toBe(
+      "ADVISORY-FAIL",
+    );
+  });
+  it("proceeds when all metrics clear", () => {
+    expect(computeVerdict([{ rawM1Rate: 0, m2Accuracy: 1, m3Hits: 6, integratedFailures: 0 }], 12000, 40000)).toBe(
+      "PROCEED",
+    );
+  });
+});
+
+describe("renderReport", () => {
+  it("renders the abort dataset on the raw rate with the adjusted rate alongside", () => {
+    const md = renderReport(abortReportInput());
+    expect(md).toContain("RAW 4/70");
+    expect(md).toContain("3/70");
+    expect(md).toContain("ABORT-PREMISE");
+    expect(md).not.toContain("PENDING");
+    expect(md).toContain("/70");
+  });
+
+  it("renders the rework dataset verdict", () => {
+    const md = renderReport(reworkReportInput());
+    expect(md).toContain("REWORK-LAYOUT");
+    expect(md).not.toContain("PENDING");
+  });
+
+  it("excludes required-miss-only and judge-item-only turns from the M1 numerator but flags them", () => {
+    const reqMiss = makeLine({
+      scenarioId: "c7-07",
+      class: "c7-contamination",
+      model: SLUG0,
+      needleHits: [{ kind: "required-miss", pattern: "/threshold/i", excerpt: "" }],
+      flagged: true,
+      judge: { mixing: { flag: false, evidence: null, sportsInvolved: [] }, items: {} },
+    });
+    const judgeFail = makeLine({
+      scenarioId: "c8-01",
+      class: "c8-tool-choice",
+      model: SLUG0,
+      flagged: true,
+      judge: { mixing: { flag: false, evidence: null, sportsInvolved: [] }, items: { "sport-scope": { pass: false, note: "x" } } },
+    });
+    expect(hasForbidden(reqMiss)).toBe(false);
+    expect(isMixing(judgeFail)).toBe(false);
+    const input: ReportInput = {
+      runDate: "1998-07-06",
+      tokens: tokens(),
+      transcripts: { [SLUG0]: [reqMiss, judgeFail], [SLUG1]: [], [SLUG2]: [] },
+      spotCheckRows: [],
+    };
+    const md = renderReport(input);
+    expect(md).toContain(`M1 [${SLUG0}]: RAW 0/70`);
+    expect(md).toContain("c7-07");
+    expect(md).toContain("c8-01");
+  });
+
+  it("refuses to render when a transcript line carries an error", () => {
+    const errored = makeLine({ scenarioId: "c1-01", class: "c1-cycling", model: SLUG0, error: "boom" });
+    const input: ReportInput = {
+      runDate: "1998-07-06",
+      tokens: tokens(),
+      transcripts: { [SLUG0]: [errored], [SLUG1]: [], [SLUG2]: [] },
+      spotCheckRows: [],
+    };
+    expect(() => renderReport(input)).toThrow(ReportRefusal);
+  });
+
+  it("carries no banned strings in the rendered output", () => {
+    const md = renderReport(abortReportInput());
+    const banned = ["TS" + "S", "CT" + "L", "AT" + "L", "TS" + "B", "docs/"];
+    for (const token of banned) expect(md).not.toContain(token);
+  });
+});
+
+describe("parseSpotCheck", () => {
+  const header = "| scenarioId | model | flagSource | verdict | reason |\n|---|---|---|---|---|\n";
+
+  it("parses a template with zero data rows as zero overturns", () => {
+    const rows = parseSpotCheck(header + "\nSpot-check performed by the operator, YYYY-MM-DD\n");
+    expect(rows).toEqual([]);
+  });
+
+  it("parses a valid data row", () => {
+    const rows = parseSpotCheck(header + `| c2-01 | ${SLUG0} | needle | OVERTURN | conversational only |\n`);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].verdict).toBe("OVERTURN");
+  });
+
+  it("refuses a malformed row", () => {
+    expect(() => parseSpotCheck(header + `| not-a-real-id | ${SLUG0} | needle | CONFIRM | x |\n`)).toThrow(ReportRefusal);
+  });
+});

--- a/tools/composition-probe/report.ts
+++ b/tools/composition-probe/report.ts
@@ -98,9 +98,11 @@ function computeModelMetrics(
 
   const mixingLines = lines.filter(isMixing);
   const rawM1Numerator = mixingLines.length;
-  const overturnRows = spotCheckRows.filter(
-    (r) => r.model === slug && r.verdict === "OVERTURN" && isMixing(byId.get(r.scenarioId) ?? ({} as TranscriptLine)),
-  );
+  const overturnRows = spotCheckRows.filter((r) => {
+    if (r.model !== slug || r.verdict !== "OVERTURN") return false;
+    const line = byId.get(r.scenarioId);
+    return line !== undefined && isMixing(line);
+  });
   const adjustedM1Numerator = Math.max(0, rawM1Numerator - overturnRows.length);
 
   const singleSportBleedIds = mixingLines.filter((l) => !isIntegrated(l.scenarioId)).map((l) => l.scenarioId);
@@ -234,6 +236,15 @@ export function renderReport(input: ReportInput): string {
   const allLines = Object.values(input.transcripts).flat();
   if (allLines.some((l) => l.error)) {
     throw new ReportRefusal("a transcript line carries an error field; re-run that model before reporting.");
+  }
+
+  for (const row of input.spotCheckRows) {
+    const modelLines = input.transcripts[row.model] ?? [];
+    if (!modelLines.some((l) => l.scenarioId === row.scenarioId)) {
+      throw new ReportRefusal(
+        `spot-check row references (${row.scenarioId}, ${row.model}) with no matching transcript line.`,
+      );
+    }
   }
 
   const models = FLOOR_MODELS.map((m) =>

--- a/tools/composition-probe/report.ts
+++ b/tools/composition-probe/report.ts
@@ -1,0 +1,402 @@
+import {
+  FLOOR_MODELS,
+  JUDGE_MODEL_ID,
+  JUDGED_TURNS_PER_MODEL,
+  MIXING_RATE_MAX,
+  PROBE_FROZEN_NOW_ISO,
+  RECALL_MIN_HITS,
+  STABLE_PREFIX_TOKEN_BUDGET,
+  SUITE_COMPOSITION,
+  TOOL_CHOICE_MIN,
+  WHOLE_PROMPT_TOKEN_MAX,
+} from "./constants.js";
+import { ALL_SCENARIOS } from "./scenarios/index.js";
+import type { ProbeScenario, TranscriptLine } from "./types.js";
+import type { TokensJson } from "./tokens.js";
+
+export type Verdict = "PROCEED" | "ADVISORY-FAIL" | "REWORK-LAYOUT" | "ABORT-PREMISE";
+
+export interface SpotCheckRow {
+  scenarioId: string;
+  model: string;
+  flagSource: "needle" | "judge";
+  verdict: "CONFIRM" | "OVERTURN";
+  reason: string;
+}
+
+export interface ReportInput {
+  runDate: string;
+  tokens: TokensJson;
+  transcripts: Record<string, TranscriptLine[]>;
+  spotCheckRows: SpotCheckRow[];
+}
+
+export class ReportRefusal extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ReportRefusal";
+  }
+}
+
+const SCENARIO_BY_ID = new Map<string, ProbeScenario>(ALL_SCENARIOS.map((s) => [s.id, s]));
+const SLUGS = new Set<string>(FLOOR_MODELS.map((m) => m.slug));
+const SCENARIO_IDS = new Set(ALL_SCENARIOS.map((s) => s.id));
+const COMBINED_LOAD_IDS = new Set(
+  ALL_SCENARIOS.filter((s) => (s.judgeItems ?? []).includes("caveat-thresholds")).map((s) => s.id),
+);
+
+export function hasForbidden(line: TranscriptLine): boolean {
+  return line.needleHits.some((h) => h.kind === "forbidden");
+}
+
+export function isMixing(line: TranscriptLine): boolean {
+  return hasForbidden(line) || line.judge?.mixing.flag === true;
+}
+
+function isIntegrated(scenarioId: string): boolean {
+  const s = SCENARIO_BY_ID.get(scenarioId);
+  return s?.class === "c5-integrated" || COMBINED_LOAD_IDS.has(scenarioId);
+}
+
+interface ModelMetrics {
+  slug: string;
+  provider: string;
+  model: string;
+  rawM1Numerator: number;
+  adjustedM1Numerator: number;
+  rawM1Rate: number;
+  adjustedM1Rate: number;
+  flaggedIds: string[];
+  singleSportBleedIds: string[];
+  integratedBleedIds: string[];
+  overturns: Array<{ scenarioId: string; reason: string }>;
+  m2Correct: number;
+  m2Total: number;
+  m2Accuracy: number;
+  m2Rows: Array<{ id: string; expected: string[]; chosen: string }>;
+  m3Hits: number;
+  m3Total: number;
+  m3Rows: Array<{ id: string; targetSport: string; calledSports: string[]; hit: boolean }>;
+  integratedFailures: number;
+  combinedCaveatRows: Array<{ id: string; thresholds: boolean | null; cost: boolean | null }>;
+  firstTurnInputTokens: number | undefined;
+}
+
+function skillCallSports(line: TranscriptLine): string[] {
+  return line.toolCalls
+    .filter((t) => t.toolName === "skill_read")
+    .map((t) => String((t.input as { sport?: unknown } | null)?.sport ?? ""));
+}
+
+function computeModelMetrics(
+  slug: string,
+  lines: TranscriptLine[],
+  spotCheckRows: SpotCheckRow[],
+): ModelMetrics {
+  const floor = FLOOR_MODELS.find((m) => m.slug === slug);
+  const byId = new Map(lines.map((l) => [l.scenarioId, l]));
+
+  const mixingLines = lines.filter(isMixing);
+  const rawM1Numerator = mixingLines.length;
+  const overturnRows = spotCheckRows.filter(
+    (r) => r.model === slug && r.verdict === "OVERTURN" && isMixing(byId.get(r.scenarioId) ?? ({} as TranscriptLine)),
+  );
+  const adjustedM1Numerator = Math.max(0, rawM1Numerator - overturnRows.length);
+
+  const singleSportBleedIds = mixingLines.filter((l) => !isIntegrated(l.scenarioId)).map((l) => l.scenarioId);
+  const integratedBleedIds = mixingLines.filter((l) => isIntegrated(l.scenarioId)).map((l) => l.scenarioId);
+
+  const m2Lines = lines.filter((l) => l.class === "c8-tool-choice");
+  const m2Rows = m2Lines.map((l) => {
+    const scenario = SCENARIO_BY_ID.get(l.scenarioId);
+    const expected = scenario?.expectedTools ?? [];
+    const chosen = l.toolCalls[0]?.toolName ?? "<none>";
+    return { id: l.scenarioId, expected, chosen };
+  });
+  const m2Correct = m2Rows.filter((r) =>
+    r.expected.includes("<none>") ? r.chosen === "<none>" : r.expected.includes(r.chosen),
+  ).length;
+
+  const m3Lines = lines.filter((l) => l.class === "c9-deep-protocol");
+  const m3Rows = m3Lines.map((l) => {
+    const scenario = SCENARIO_BY_ID.get(l.scenarioId);
+    const targetSport = scenario?.skillTarget?.sport ?? "";
+    const calledSports = skillCallSports(l);
+    return { id: l.scenarioId, targetSport, calledSports, hit: calledSports.includes(targetSport) };
+  });
+  const m3Hits = m3Rows.filter((r) => r.hit).length;
+
+  let integratedFailures = 0;
+  for (const l of lines) {
+    if (l.class === "c5-integrated" && l.judge?.items["integrated-coherent"]?.pass === false) {
+      integratedFailures += 1;
+    } else if (
+      COMBINED_LOAD_IDS.has(l.scenarioId) &&
+      (l.judge?.items["caveat-thresholds"]?.pass === false || l.judge?.items["caveat-cost"]?.pass === false)
+    ) {
+      integratedFailures += 1;
+    }
+  }
+
+  const combinedCaveatRows = lines
+    .filter((l) => COMBINED_LOAD_IDS.has(l.scenarioId))
+    .map((l) => ({
+      id: l.scenarioId,
+      thresholds: l.judge ? l.judge.items["caveat-thresholds"]?.pass ?? null : null,
+      cost: l.judge ? l.judge.items["caveat-cost"]?.pass ?? null : null,
+    }));
+
+  return {
+    slug,
+    provider: floor?.provider ?? "",
+    model: floor?.model ?? "",
+    rawM1Numerator,
+    adjustedM1Numerator,
+    rawM1Rate: rawM1Numerator / JUDGED_TURNS_PER_MODEL,
+    adjustedM1Rate: adjustedM1Numerator / JUDGED_TURNS_PER_MODEL,
+    flaggedIds: lines.filter((l) => l.flagged).map((l) => l.scenarioId),
+    singleSportBleedIds,
+    integratedBleedIds,
+    overturns: overturnRows.map((r) => ({ scenarioId: r.scenarioId, reason: r.reason })),
+    m2Correct,
+    m2Total: m2Rows.length,
+    m2Accuracy: m2Rows.length > 0 ? m2Correct / m2Rows.length : 0,
+    m2Rows,
+    m3Hits,
+    m3Total: m3Rows.length,
+    m3Rows,
+    integratedFailures,
+    combinedCaveatRows,
+    firstTurnInputTokens: lines[0]?.usage.inputTokens,
+  };
+}
+
+export function computeVerdict(
+  models: Array<{ rawM1Rate: number; m2Accuracy: number; m3Hits: number; integratedFailures: number }>,
+  stablePrefixTokens: number,
+  wholePromptTokens: number,
+): Verdict {
+  const abort = models.some((m) => m.rawM1Rate > MIXING_RATE_MAX) || wholePromptTokens > WHOLE_PROMPT_TOKEN_MAX;
+  if (abort) return "ABORT-PREMISE";
+  if (stablePrefixTokens > STABLE_PREFIX_TOKEN_BUDGET) return "REWORK-LAYOUT";
+  const advisory = models.some(
+    (m) => m.m2Accuracy < TOOL_CHOICE_MIN || m.m3Hits < RECALL_MIN_HITS || m.integratedFailures >= 2,
+  );
+  if (advisory) return "ADVISORY-FAIL";
+  return "PROCEED";
+}
+
+export function parseSpotCheck(md: string): SpotCheckRow[] {
+  const lines = md.split("\n");
+  const rows: SpotCheckRow[] = [];
+  let inTable = false;
+  for (const raw of lines) {
+    const line = raw.trim();
+    if (line.startsWith("| scenarioId ") && line.includes("| verdict ")) {
+      inTable = true;
+      continue;
+    }
+    if (!inTable) continue;
+    if (/^\|[\s-]+\|/.test(line) && line.replace(/[|\s-]/g, "") === "") continue;
+    if (!line.startsWith("|")) {
+      if (line === "") continue;
+      inTable = false;
+      continue;
+    }
+    const cells = line.slice(1, line.endsWith("|") ? -1 : undefined).split("|").map((c) => c.trim());
+    if (cells.length !== 5) {
+      throw new ReportRefusal(`spot-check row has ${cells.length} columns, expected 5: ${line}`);
+    }
+    const [scenarioId, model, flagSource, verdict, reason] = cells;
+    if (!SCENARIO_IDS.has(scenarioId)) throw new ReportRefusal(`unknown scenarioId in spot-check: ${scenarioId}`);
+    if (!SLUGS.has(model)) throw new ReportRefusal(`unknown model slug in spot-check: ${model}`);
+    if (flagSource !== "needle" && flagSource !== "judge") {
+      throw new ReportRefusal(`bad flagSource in spot-check: ${flagSource}`);
+    }
+    if (verdict !== "CONFIRM" && verdict !== "OVERTURN") {
+      throw new ReportRefusal(`bad verdict in spot-check: ${verdict}`);
+    }
+    if (reason.length === 0) throw new ReportRefusal(`empty reason in spot-check row: ${line}`);
+    rows.push({ scenarioId, model, flagSource, verdict, reason });
+  }
+  return rows;
+}
+
+function pctStr(n: number, d: number): string {
+  return d === 0 ? "0.0%" : ((n / d) * 100).toFixed(1) + "%";
+}
+
+function passFail(ok: boolean): string {
+  return ok ? "PASS" : "FAIL";
+}
+
+export function renderReport(input: ReportInput): string {
+  const allLines = Object.values(input.transcripts).flat();
+  if (allLines.some((l) => l.error)) {
+    throw new ReportRefusal("a transcript line carries an error field; re-run that model before reporting.");
+  }
+
+  const models = FLOOR_MODELS.map((m) =>
+    computeModelMetrics(m.slug, input.transcripts[m.slug] ?? [], input.spotCheckRows),
+  );
+  const { stablePrefixTokens, wholePromptTokens } = input.tokens;
+  const verdict = computeVerdict(
+    models.map((m) => ({
+      rawM1Rate: m.rawM1Rate,
+      m2Accuracy: m.m2Accuracy,
+      m3Hits: m.m3Hits,
+      integratedFailures: m.integratedFailures,
+    })),
+    stablePrefixTokens,
+    wholePromptTokens,
+  );
+
+  const out: string[] = [];
+  out.push("# Composition smoke probe — report A");
+  out.push("");
+  out.push(`- Run date: ${input.runDate}`);
+  out.push(`- Git SHA: ${input.tokens.measuredAtGitSha}`);
+  out.push(`- Judge model (pinned): ${JUDGE_MODEL_ID}`);
+  out.push(`- Frozen-now: ${PROBE_FROZEN_NOW_ISO}`);
+  out.push(`- Floor models: ${FLOOR_MODELS.map((m) => m.slug).join(", ")}`);
+  out.push(
+    `- Suite composition: ${Object.entries(SUITE_COMPOSITION)
+      .map(([k, v]) => `${k}=${v}`)
+      .join(", ")} (total ${JUDGED_TURNS_PER_MODEL})`,
+  );
+  out.push("");
+  out.push("## Scope limits");
+  out.push("");
+  out.push(
+    "This is a smoke test with abort-only power: it can abort the one-agent composition premise but never confirm it. The load-bearing gate re-runs the same suite at a far larger sample on the real composition later.",
+  );
+  out.push(
+    "Partial-coverage caveat: the mock covers the critical-speed / critical-swim-pace confusion traps and the integrated multisport turns only partially by construction — the swim core is fully synthetic and the multisport orchestration content is minimal — which is exactly why this run is a smoke test with abort-only power.",
+  );
+  out.push(
+    "Domain-review exemption: the mock coaching content is probe-only scaffolding, never shipped and never athlete-facing, so it is exempt from the athlete-facing domain-review gate.",
+  );
+  out.push("");
+  out.push("## Method");
+  out.push("");
+  out.push(
+    "Scoring order: deterministic needles first, the pinned judge second (offline, one turn at a time), the operator spot-check third. One judged turn = one user message and its one final assistant reply; multi-step tool loops inside a turn are the same judged turn. Each of the 70 scenarios contributes exactly one judged turn per floor model, run once per model, for 70 judged turns per model. Sixty pooled across three models would leave twenty per model, which the protocol calls indistinguishable from noise, so the sample is denominated per model.",
+  );
+  out.push(
+    "The mechanical verdict computes on the RAW mixing rate only. The spot-check-adjusted rate and the per-overturn reasons are rendered alongside as operator-decision input and never move the verdict line.",
+  );
+  out.push(
+    "M1 formula: raw numerator = judged turns with at least one forbidden-needle hit OR a judge mixing flag. Excluded from the numerator: turns whose only needle hit is a required-miss; turns whose only failure is a judge item; errored turns. Denominator = 70.",
+  );
+  out.push("");
+
+  // M1
+  out.push("## M1 — voice / physiology mixing rate (abort class, threshold 5%)");
+  out.push("");
+  for (const m of models) {
+    const rawOk = m.rawM1Rate <= MIXING_RATE_MAX;
+    out.push(
+      `M1 [${m.slug}]: RAW ${m.rawM1Numerator}/${JUDGED_TURNS_PER_MODEL} = ${pctStr(m.rawM1Numerator, JUDGED_TURNS_PER_MODEL)} — ${passFail(rawOk)} (abort class)`,
+    );
+    out.push(
+      `- spot-check-adjusted: ${m.adjustedM1Numerator}/${JUDGED_TURNS_PER_MODEL} = ${pctStr(m.adjustedM1Numerator, JUDGED_TURNS_PER_MODEL)} (operator input only; does not move the verdict)`,
+    );
+    out.push(`- flagged turns: ${m.flaggedIds.length > 0 ? m.flaggedIds.join(", ") : "none"}`);
+    out.push(
+      `- overturns: ${m.overturns.length > 0 ? m.overturns.map((o) => `${o.scenarioId} (${o.reason})`).join("; ") : "none"}`,
+    );
+    out.push("");
+    out.push("| breakdown | count | turns |");
+    out.push("|---|---|---|");
+    out.push(
+      `| single-sport bleed | ${m.singleSportBleedIds.length} | ${m.singleSportBleedIds.join(", ") || "none"} |`,
+    );
+    out.push(
+      `| integrated-turn failure | ${m.integratedBleedIds.length} | ${m.integratedBleedIds.join(", ") || "none"} |`,
+    );
+    out.push("");
+  }
+
+  // M2
+  out.push("## M2 — tool-choice accuracy (advisory class, threshold 80%)");
+  out.push("");
+  for (const m of models) {
+    const ok = m.m2Accuracy >= TOOL_CHOICE_MIN;
+    out.push(
+      `M2 [${m.slug}]: ${m.m2Correct}/${m.m2Total} = ${pctStr(m.m2Correct, m.m2Total)} — ${passFail(ok)} (advisory class)`,
+    );
+    out.push("");
+    out.push("| scenario | expected | chosen |");
+    out.push("|---|---|---|");
+    for (const r of m.m2Rows) {
+      out.push(`| ${r.id} | ${r.expected.join(" / ")} | ${r.chosen} |`);
+    }
+    out.push("");
+  }
+
+  // M3
+  out.push("## M3 — deep-protocol recall (advisory class, threshold 5/6)");
+  out.push("");
+  for (const m of models) {
+    const ok = m.m3Hits >= RECALL_MIN_HITS;
+    out.push(`M3 [${m.slug}]: ${m.m3Hits}/${m.m3Total} — ${passFail(ok)} (advisory class)`);
+    out.push("");
+    out.push("| scenario | target sport | skill_read sports called | hit |");
+    out.push("|---|---|---|---|");
+    for (const r of m.m3Rows) {
+      out.push(`| ${r.id} | ${r.targetSport} | ${r.calledSports.join(", ") || "none"} | ${r.hit ? "yes" : "no"} |`);
+    }
+    out.push("");
+  }
+
+  // M4
+  out.push("## M4 — token counts");
+  out.push("");
+  const prefixOk = stablePrefixTokens <= STABLE_PREFIX_TOKEN_BUDGET;
+  const wholeOk = wholePromptTokens <= WHOLE_PROMPT_TOKEN_MAX;
+  out.push(`Method: ${input.tokens.method} (model ${input.tokens.model}).`);
+  out.push(
+    `M4 stable prefix (tools + block 1): ${stablePrefixTokens} tokens (budget ${STABLE_PREFIX_TOKEN_BUDGET}) — ${passFail(prefixOk)} (design budget / rework class)`,
+  );
+  out.push(
+    `M4 whole prompt (tools + block 1 + block 2 + one message): ${wholePromptTokens} tokens (max ${WHOLE_PROMPT_TOKEN_MAX}) — ${passFail(wholeOk)} (abort class)`,
+  );
+  out.push("");
+  out.push("Informational per-model first-turn input tokens (tokenizers differ across the floor):");
+  for (const m of models) {
+    out.push(`- ${m.slug}: ${m.firstTurnInputTokens ?? "n/a"}`);
+  }
+  out.push("");
+
+  // Contamination assertions
+  out.push("## Combined-load caveats");
+  out.push("");
+  for (const m of models) {
+    const cells = m.combinedCaveatRows
+      .map((r) => `${r.id} thresholds=${r.thresholds === null ? "n/a" : r.thresholds} cost=${r.cost === null ? "n/a" : r.cost}`)
+      .join("; ");
+    out.push(`- ${m.slug}: ${cells || "no combined-load turns"}`);
+  }
+  out.push("");
+
+  // Verdict
+  out.push("## Verdict");
+  out.push("");
+  out.push("The verdict is mechanical and computes on the raw mixing rate; the operator, not the executor, acts on it.");
+  out.push("");
+  out.push(verdict);
+  out.push("");
+
+  // Redaction totals
+  const totalRedactions = allLines.reduce((sum, l) => sum + l.trademarkRedactions, 0);
+  out.push("## Redaction totals");
+  out.push("");
+  out.push(`- Total model-emitted trademark tokens redacted across all transcripts: ${totalRedactions}`);
+  out.push("");
+  out.push("## Spot-check");
+  out.push("");
+  out.push(`- Spot-check rows recorded: ${input.spotCheckRows.length}. See spot-check.md for the full record.`);
+  out.push("");
+
+  return out.join("\n");
+}

--- a/tools/composition-probe/rubric.md
+++ b/tools/composition-probe/rubric.md
@@ -1,0 +1,29 @@
+You evaluate exactly one coaching reply for cross-sport physiology contamination and for class-specific correctness. You never judge coaching quality beyond the listed items. You see one turn at a time and nothing else — no other turns, no other models' answers.
+
+## Mixing definition
+
+A reply "mixes" when it applies one sport's physiology, metric, or anchor vocabulary to another sport's question, or misattributes an anchor to the wrong sport. The three anchors are: cycling → FTP in watts and power zones; running → critical speed in metres per second; swimming → a critical swim pace per 100m. Naming another sport conversationally is fine. Applying its anchor, metric, or physiology to the wrong sport is a mix.
+
+## Items (evaluate only the ids listed in the input's judgeItems)
+
+- `sport-scope` — PASS iff the reply confines physiology, metrics, and anchor vocabulary to the question's sport. Naming another sport conversationally is fine; applying its anchors, metrics, or physiology is a FAIL.
+- `correct-attribution` — PASS iff every metric or anchor named is attributed to the correct sport (run fitness via critical speed, bike fitness via FTP, swim via the critical swim pace) with no swapped attributions.
+- `handles-ambiguity` — PASS iff the reply either asks which sport is meant or answers with an explicitly multi-sport view. Silently assuming one sport is a FAIL.
+- `integrated-coherent` — PASS iff the reply treats the disciplines as one plan (shared fatigue, sequencing, interference acknowledged) rather than disjoint single-sport answers stitched together.
+- `anchor-correct` — PASS iff the reply uses the correct anchor name AND unit for the sport in question (FTP watts for cycling, critical speed m/s for running, critical swim pace per 100m for swimming) and never swaps a name or unit across sports.
+- `caveat-thresholds` — PASS iff the reply substantively states that a combined total is only well-scaled when each sport's threshold anchor is set and current, and that a missing or stale anchor mis-scales that sport's Load and the combined total. Paraphrase is acceptable; the substance is required.
+- `caveat-cost` — PASS iff the reply substantively states that equal Load is not equal bodily cost across sports (running greater than cycling greater than swimming for equal duration) and that no validated equivalence coefficient exists.
+- `used-skill-content` — PASS iff the reply's protocol specifics are consistent with the target skill file's facts. Informational only.
+
+## Output
+
+Reply with a single JSON object and nothing else:
+
+```json
+{
+  "mixing": { "flag": false, "evidence": null, "sportsInvolved": [] },
+  "items": { "sport-scope": { "pass": true, "note": "" } }
+}
+```
+
+Set `mixing.flag` true when the reply mixes per the definition above, with `evidence` a short quote and `sportsInvolved` the sports involved. Populate `items` with exactly the ids listed in the input's judgeItems, each with a boolean `pass` and a short `note`. Output no prose outside the JSON object.

--- a/tools/composition-probe/run.ts
+++ b/tools/composition-probe/run.ts
@@ -4,9 +4,11 @@ import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { SYSTEM_PROMPT_CACHE_BOUNDARY, ATHLETE_CONTEXT_FENCE_OPEN } from "../../packages/core/src/agent/system-prompt.js";
+import { cacheTokenDetails } from "../../packages/core/src/usage-ledger.js";
 
 import {
   FLOOR_MODELS,
+  JUDGED_TURNS_PER_MODEL,
   PROBE_FROZEN_NOW_ISO,
   STEP_LIMIT,
 } from "./constants.js";
@@ -20,6 +22,8 @@ import { scanProbeOutputs } from "./scan.js";
 import { renderReport, parseSpotCheck, ReportRefusal } from "./report.js";
 import { ALL_SCENARIOS } from "./scenarios/index.js";
 import {
+  ABORT_SPOT_CHECK_MD,
+  EMPTY_SPOT_CHECK_MD,
   NEEDLE_CLEAN_TEXT,
   NEEDLE_FORBIDDEN_SCENARIO,
   NEEDLE_FORBIDDEN_TEXT,
@@ -108,8 +112,10 @@ function runDryRun(): number {
 
   // CHECK 5 — report renderer
   const scratch = mkdtempSync(join(tmpdir(), "probe-dryrun-"));
-  const abortReport = renderReport(abortReportInput());
-  const reworkReport = renderReport(reworkReportInput());
+  const abortRows = parseSpotCheck(ABORT_SPOT_CHECK_MD);
+  const reworkRows = parseSpotCheck(EMPTY_SPOT_CHECK_MD);
+  const abortReport = renderReport({ ...abortReportInput(), spotCheckRows: abortRows });
+  const reworkReport = renderReport({ ...reworkReportInput(), spotCheckRows: reworkRows });
   writeFileSync(join(scratch, "abort-report.md"), abortReport, "utf-8");
   writeFileSync(join(scratch, "rework-report.md"), reworkReport, "utf-8");
   const sectionsOk = ["## M1", "## M2", "## M3", "## M4", "## Verdict"].every((s) => abortReport.includes(s));
@@ -179,7 +185,7 @@ async function subjectLine(
       usage: {
         inputTokens: res.usage?.inputTokens,
         outputTokens: res.usage?.outputTokens,
-        cacheReadTokens: undefined,
+        cacheReadTokens: cacheTokenDetails(res.totalUsage)?.cacheReadTokens,
       },
       durationMs: Date.now() - start,
       needleHits,
@@ -309,6 +315,16 @@ function runReportPhase(): number {
 
   const transcripts: Record<string, TranscriptLine[]> = {};
   for (const m of FLOOR_MODELS) transcripts[m.slug] = readTranscript(dir, m.slug);
+
+  for (const m of FLOOR_MODELS) {
+    const count = transcripts[m.slug].length;
+    if (count !== JUDGED_TURNS_PER_MODEL) {
+      console.error(
+        `report: refused — transcript ${m.slug}.jsonl has ${count} judged turns, expected ${JUDGED_TURNS_PER_MODEL}; re-run --phase=run --model=${m.model} for this model.`,
+      );
+      return 2;
+    }
+  }
 
   const tokens = JSON.parse(readFileSync(join(dir, "tokens.json"), "utf-8"));
   try {

--- a/tools/composition-probe/run.ts
+++ b/tools/composition-probe/run.ts
@@ -1,0 +1,385 @@
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { SYSTEM_PROMPT_CACHE_BOUNDARY, ATHLETE_CONTEXT_FENCE_OPEN } from "../../packages/core/src/agent/system-prompt.js";
+
+import {
+  FLOOR_MODELS,
+  PROBE_FROZEN_NOW_ISO,
+  STEP_LIMIT,
+} from "./constants.js";
+import { buildMockPrompt } from "./assemble.js";
+import { MOCK_TOOLS, buildToolSet } from "./tools.js";
+import { evalNeedles } from "./needles.js";
+import { redactTrademarks } from "./redact.js";
+import { runTokensPhase } from "./tokens.js";
+import { runJudgePass } from "./judge.js";
+import { scanProbeOutputs } from "./scan.js";
+import { renderReport, parseSpotCheck, ReportRefusal } from "./report.js";
+import { ALL_SCENARIOS } from "./scenarios/index.js";
+import {
+  NEEDLE_CLEAN_TEXT,
+  NEEDLE_FORBIDDEN_SCENARIO,
+  NEEDLE_FORBIDDEN_TEXT,
+  NEEDLE_REQUIRED_MISS_SCENARIO,
+  NEEDLE_REQUIRED_MISS_TEXT,
+  RECALL_HIT_LINE,
+  RECALL_MISS_LINE,
+  RECALL_WRONG_SPORT_LINE,
+  REDACT_SAMPLE_RAW,
+  REDACT_STANDALONE_IF,
+  REDACT_TSS,
+  TAPER_KNOWN_FACT,
+  abortReportInput,
+  reworkReportInput,
+} from "./dryrun-fixtures.js";
+import type { ProbeScenario, StopFn, TranscriptLine } from "./types.js";
+
+function probesDir(): string {
+  return fileURLToPath(new URL("../../probes/composition-smoke", import.meta.url));
+}
+
+function recallHit(line: TranscriptLine, targetSport: string): boolean {
+  return line.toolCalls.some(
+    (t) => t.toolName === "skill_read" && String((t.input as { sport?: unknown } | null)?.sport ?? "") === targetSport,
+  );
+}
+
+function runDryRun(): number {
+  const results: boolean[] = [];
+
+  // CHECK 1 — assembly
+  const { block1, block2, fullSystem } = buildMockPrompt();
+  const markerText = SYSTEM_PROMPT_CACHE_BOUNDARY.replace(/^\n\n---\n\n/, "");
+  const c1 =
+    block1.includes("# Endurance Coach") &&
+    block1.includes("## Cycling") &&
+    block1.includes("## Running") &&
+    block1.includes("## Swimming") &&
+    block1.includes("# Untrusted Data Handling") &&
+    block1.includes("# Recall Before Answering") &&
+    block1.includes("# Voice & Register") &&
+    block1.includes("# Workout Review") &&
+    block1.includes("# Tool-Call Budget") &&
+    block1.includes("activities_list") &&
+    !block1.includes("intervals_fetch_activities") &&
+    block2.split("\n")[0] === markerText &&
+    !block1.includes(ATHLETE_CONTEXT_FENCE_OPEN) &&
+    fullSystem === buildMockPrompt().fullSystem;
+  results.push(c1);
+
+  // CHECK 2 — tools
+  const set = buildToolSet(() => {});
+  const names = Object.keys(set);
+  const skillSpec = MOCK_TOOLS.find((t) => t.name === "skill_read");
+  const taper = skillSpec?.makeResult({ sport: "cycling", topic: "taper" }) as { content?: string };
+  const unknown = skillSpec?.makeResult({ sport: "cycling", topic: "nope" }) as { error?: string; available?: unknown };
+  const c8Ids = ALL_SCENARIOS.filter((s) => s.class === "c8-tool-choice");
+  const toolsExist = c8Ids.every((s) => (s.expectedTools ?? []).every((n) => n === "<none>" || names.includes(n)));
+  const c2 =
+    names.length === 25 &&
+    new Set(names).size === 25 &&
+    toolsExist &&
+    typeof taper?.content === "string" &&
+    taper.content.includes(TAPER_KNOWN_FACT) &&
+    unknown?.error === "unknown_topic" &&
+    Array.isArray(unknown.available);
+  results.push(c2);
+
+  // CHECK 3 — needle engine (breakable via PROBE_DRYRUN_BREAK_NEEDLES=1)
+  const broken = process.env.PROBE_DRYRUN_BREAK_NEEDLES === "1";
+  const forbiddenText = broken ? NEEDLE_CLEAN_TEXT : NEEDLE_FORBIDDEN_TEXT;
+  const forbiddenFlagged = evalNeedles(NEEDLE_FORBIDDEN_SCENARIO, forbiddenText).some((h) => h.kind === "forbidden");
+  const cleanIsClean = !evalNeedles(NEEDLE_FORBIDDEN_SCENARIO, NEEDLE_CLEAN_TEXT).some((h) => h.kind === "forbidden");
+  const missFlagged = evalNeedles(NEEDLE_REQUIRED_MISS_SCENARIO, NEEDLE_REQUIRED_MISS_TEXT).some(
+    (h) => h.kind === "required-miss",
+  );
+  const c3 = forbiddenFlagged && cleanIsClean && missFlagged;
+  results.push(c3);
+
+  // CHECK 4 — recall scorer
+  const c4 =
+    !recallHit(RECALL_MISS_LINE, "cycling") &&
+    recallHit(RECALL_HIT_LINE, "cycling") &&
+    !recallHit(RECALL_WRONG_SPORT_LINE, "cycling");
+  results.push(c4);
+
+  // CHECK 5 — report renderer
+  const scratch = mkdtempSync(join(tmpdir(), "probe-dryrun-"));
+  const abortReport = renderReport(abortReportInput());
+  const reworkReport = renderReport(reworkReportInput());
+  writeFileSync(join(scratch, "abort-report.md"), abortReport, "utf-8");
+  writeFileSync(join(scratch, "rework-report.md"), reworkReport, "utf-8");
+  const sectionsOk = ["## M1", "## M2", "## M3", "## M4", "## Verdict"].every((s) => abortReport.includes(s));
+  const noPending = !abortReport.includes("PENDING") && !reworkReport.includes("PENDING");
+  const abortVerdict = /(^|\n)ABORT-PREMISE(\n|$)/.test(abortReport);
+  const reworkVerdict = /(^|\n)REWORK-LAYOUT(\n|$)/.test(reworkReport);
+  const c5 = sectionsOk && noPending && abortVerdict && reworkVerdict;
+  results.push(c5);
+
+  // CHECK 6 — redactor + needle-on-raw order
+  const rawRanFirst = evalNeedles(NEEDLE_FORBIDDEN_SCENARIO, REDACT_SAMPLE_RAW).some((h) => h.kind === "forbidden");
+  const { text: redacted, count } = redactTrademarks(REDACT_SAMPLE_RAW);
+  const c6 =
+    rawRanFirst &&
+    count > 0 &&
+    !redacted.includes(REDACT_TSS) &&
+    redacted.includes("[Load]") &&
+    redacted.includes(REDACT_STANDALONE_IF);
+  results.push(c6);
+
+  results.forEach((ok, i) => console.log(`CHECK ${i + 1}/6 ${ok ? "PASS" : "FAIL"}`));
+  return results.every(Boolean) ? 0 : 1;
+}
+
+function envKeyFor(provider: string): string | undefined {
+  return provider === "anthropic" ? process.env.ANTHROPIC_API_KEY : process.env.OPENROUTER_API_KEY;
+}
+
+async function subjectLine(
+  scenario: ProbeScenario,
+  fullSystem: string,
+  floor: { provider: string; model: string; slug: string },
+  apiKey: string,
+): Promise<TranscriptLine> {
+  const calls: Array<{ toolName: string; input: unknown }> = [];
+  const tools = buildToolSet((c) => calls.push(c));
+  const stop: StopFn = ({ steps }: { steps: unknown[] }) => steps.length >= STEP_LIMIT;
+  const { LLM } = await import("../../packages/core/src/llm.js");
+  const scratch = mkdtempSync(join(tmpdir(), "probe-run-"));
+  const llm = new LLM({
+    llm: { provider: floor.provider, model: floor.model, apiKey, baseUrl: undefined },
+    dataDir: scratch,
+  } as unknown as import("../../packages/core/src/config.js").Config);
+
+  const start = Date.now();
+  try {
+    const res = await llm.generate({
+      system: fullSystem,
+      messages: [{ role: "user", content: scenario.userMessage + "\nCurrent time: " + PROBE_FROZEN_NOW_ISO }],
+      tools,
+      stopWhen: stop,
+      maxOutputTokens: 2048,
+      caller: "chat",
+    });
+    const rawText = res.text;
+    const needleHits = evalNeedles(scenario, rawText);
+    const { text: assistantText, count } = redactTrademarks(rawText);
+    return {
+      scenarioId: scenario.id,
+      class: scenario.class,
+      model: floor.model,
+      provider: floor.provider,
+      userMessage: scenario.userMessage,
+      assistantText,
+      toolCalls: calls,
+      steps: res.steps ?? 0,
+      usage: {
+        inputTokens: res.usage?.inputTokens,
+        outputTokens: res.usage?.outputTokens,
+        cacheReadTokens: undefined,
+      },
+      durationMs: Date.now() - start,
+      needleHits,
+      flagged: needleHits.length > 0,
+      trademarkRedactions: count,
+    };
+  } catch (err) {
+    return {
+      scenarioId: scenario.id,
+      class: scenario.class,
+      model: floor.model,
+      provider: floor.provider,
+      userMessage: scenario.userMessage,
+      assistantText: "",
+      toolCalls: calls,
+      steps: 0,
+      usage: {},
+      durationMs: Date.now() - start,
+      needleHits: [],
+      flagged: true,
+      trademarkRedactions: 0,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+async function runSubjectPhase(modelId: string): Promise<number> {
+  const floor = FLOOR_MODELS.find((m) => m.model === modelId);
+  if (!floor) {
+    console.error(`--model=${modelId} is not a pinned floor model. The floor is pinned; re-pinning is an operator procedure.`);
+    return 2;
+  }
+  const apiKey = envKeyFor(floor.provider);
+  if (!apiKey) {
+    console.error(`missing ${floor.provider === "anthropic" ? "ANTHROPIC_API_KEY" : "OPENROUTER_API_KEY"} for the run phase.`);
+    return 2;
+  }
+  const { fullSystem } = buildMockPrompt();
+  const lines: TranscriptLine[] = [];
+  let errorCount = 0;
+  for (const scenario of ALL_SCENARIOS) {
+    const line = await subjectLine(scenario, fullSystem, floor, apiKey);
+    lines.push(line);
+    if (line.error) errorCount += 1;
+    if (errorCount >= 5) {
+      const dir = probesDir();
+      mkdirSync(join(dir, "transcripts"), { recursive: true });
+      const body = lines.map((l) => JSON.stringify(l)).join("\n") + "\n" + JSON.stringify({ INCOMPLETE: true }) + "\n";
+      writeFileSync(join(dir, "transcripts", `${floor.slug}.jsonl`), body, "utf-8");
+      console.error(`run aborted: ${errorCount} errored turns for ${floor.slug}. Partial transcript kept, marked INCOMPLETE.`);
+      return 2;
+    }
+  }
+  const dir = probesDir();
+  mkdirSync(join(dir, "transcripts"), { recursive: true });
+  writeFileSync(join(dir, "transcripts", `${floor.slug}.jsonl`), lines.map((l) => JSON.stringify(l)).join("\n") + "\n", "utf-8");
+  console.log(`wrote ${lines.length} turns for ${floor.slug}`);
+  return 0;
+}
+
+async function runJudgePhase(modelId: string): Promise<number> {
+  const floor = FLOOR_MODELS.find((m) => m.model === modelId);
+  if (!floor) {
+    console.error(`--model=${modelId} is not a pinned floor model.`);
+    return 2;
+  }
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    console.error("missing ANTHROPIC_API_KEY for the judge phase.");
+    return 2;
+  }
+  const file = join(probesDir(), "transcripts", `${floor.slug}.jsonl`);
+  if (!existsSync(file)) {
+    console.error(`missing transcript ${file}; run --phase=run --model=${modelId} first.`);
+    return 2;
+  }
+  return runJudgePass(file, apiKey);
+}
+
+function runScanPhase(): number {
+  const dir = probesDir();
+  const { hits, missing } = scanProbeOutputs(dir);
+  if (missing.length > 0) {
+    console.error("scan: missing inputs: " + missing.join(", "));
+    return 2;
+  }
+  if (hits.length > 0) {
+    console.error(`scan: ${hits.length} hit(s):`);
+    for (const h of hits) console.error(`  ${h.file}:${h.line} [${h.rule}] ${h.excerpt}`);
+    return 2;
+  }
+  console.log("scan: clean.");
+  return 0;
+}
+
+function readTranscript(dir: string, slug: string): TranscriptLine[] {
+  return readFileSync(join(dir, "transcripts", `${slug}.jsonl`), "utf-8")
+    .split("\n")
+    .filter((l) => l.trim().length > 0 && !l.includes('"INCOMPLETE"'))
+    .map((l) => JSON.parse(l) as TranscriptLine);
+}
+
+function runReportPhase(): number {
+  const dir = probesDir();
+
+  const scan = scanProbeOutputs(dir);
+  if (scan.missing.length > 0) {
+    console.error("report: scan missing inputs: " + scan.missing.join(", "));
+    return 2;
+  }
+  if (scan.hits.length > 0) {
+    console.error(`report: scan found ${scan.hits.length} hit(s); refusing to render.`);
+    for (const h of scan.hits) console.error(`  ${h.file}:${h.line} [${h.rule}] ${h.excerpt}`);
+    return 2;
+  }
+
+  const missing: string[] = [];
+  for (const m of FLOOR_MODELS) {
+    if (!existsSync(join(dir, "transcripts", `${m.slug}.jsonl`))) missing.push(`transcripts/${m.slug}.jsonl`);
+  }
+  if (!existsSync(join(dir, "tokens.json"))) missing.push("tokens.json");
+  if (!existsSync(join(dir, "spot-check.md"))) missing.push("spot-check.md");
+  if (missing.length > 0) {
+    console.error("report: missing inputs: " + missing.join(", "));
+    return 2;
+  }
+
+  const transcripts: Record<string, TranscriptLine[]> = {};
+  for (const m of FLOOR_MODELS) transcripts[m.slug] = readTranscript(dir, m.slug);
+
+  const tokens = JSON.parse(readFileSync(join(dir, "tokens.json"), "utf-8"));
+  try {
+    const spotCheckRows = parseSpotCheck(readFileSync(join(dir, "spot-check.md"), "utf-8"));
+    const md = renderReport({
+      runDate: new Date().toISOString().slice(0, 10),
+      tokens,
+      transcripts,
+      spotCheckRows,
+    });
+    writeFileSync(join(dir, "report.md"), md + "\n", "utf-8");
+    console.log("report: rendered report.md");
+    return 0;
+  } catch (err) {
+    if (err instanceof ReportRefusal) {
+      console.error("report: refused — " + err.message);
+      return 2;
+    }
+    throw err;
+  }
+}
+
+function parseArgs(argv: string[]): { mode: string; model?: string } {
+  let mode = "";
+  let model: string | undefined;
+  for (const a of argv) {
+    if (a === "--dry-run") mode = "dry-run";
+    else if (a.startsWith("--phase=")) mode = a.slice("--phase=".length);
+    else if (a.startsWith("--model=")) model = a.slice("--model=".length);
+  }
+  return { mode, model };
+}
+
+async function main(argv: string[]): Promise<number> {
+  const { mode, model } = parseArgs(argv);
+  switch (mode) {
+    case "dry-run":
+      return runDryRun();
+    case "tokens": {
+      const apiKey = process.env.ANTHROPIC_API_KEY;
+      if (!apiKey) {
+        console.error("missing ANTHROPIC_API_KEY for the tokens phase.");
+        return 2;
+      }
+      return runTokensPhase(probesDir(), apiKey);
+    }
+    case "run":
+      if (!model) {
+        console.error("--phase=run requires --model=<floor id>");
+        return 2;
+      }
+      return runSubjectPhase(model);
+    case "judge":
+      if (!model) {
+        console.error("--phase=judge requires --model=<floor id>");
+        return 2;
+      }
+      return runJudgePhase(model);
+    case "scan":
+      return runScanPhase();
+    case "report":
+      return runReportPhase();
+    default:
+      console.error("usage: probe:composition --dry-run | --phase=tokens|run|judge|scan|report [--model=<floor id>]");
+      return 2;
+  }
+}
+
+main(process.argv.slice(2))
+  .then((code) => process.exit(code))
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/tools/composition-probe/scan.test.ts
+++ b/tools/composition-probe/scan.test.ts
@@ -1,0 +1,41 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, it, expect } from "vitest";
+
+import { scanText, scanProbeOutputs } from "./scan.js";
+
+// Hit tokens built by concatenation so this test source is lint-clean.
+const TSS = "TS" + "S";
+const REAL_ID = "i" + "12345678";
+
+describe("scanText", () => {
+  it("flags a redaction-list token", () => {
+    expect(scanText(`your ${TSS} was high`).some((h) => h.rule === "redaction-token")).toBe(true);
+  });
+
+  it("flags a post-2015 ISO date shape", () => {
+    expect(scanText("ran on 2026-07-06").some((h) => h.rule === "post-2015-date")).toBe(true);
+  });
+
+  it("flags a real intervals id shape", () => {
+    expect(scanText(`activity ${REAL_ID} done`).some((h) => h.rule === "real-id-shape")).toBe(true);
+  });
+
+  it("passes a clean 1998-era line", () => {
+    expect(scanText("ran on 1998-07-06, felt easy")).toHaveLength(0);
+  });
+
+  it("does not flag a bare prose year", () => {
+    expect(scanText("a 2019 study of runners")).toHaveLength(0);
+  });
+});
+
+describe("scanProbeOutputs", () => {
+  it("reports missing inputs when the transcripts dir is absent", () => {
+    const empty = mkdtempSync(join(tmpdir(), "probe-scan-"));
+    const res = scanProbeOutputs(empty);
+    expect(res.missing).toContain("transcripts/*.jsonl");
+  });
+});

--- a/tools/composition-probe/scan.ts
+++ b/tools/composition-probe/scan.ts
@@ -1,0 +1,90 @@
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+import { REDACTION_RULES } from "./redact.js";
+
+export interface ScanHit {
+  file: string;
+  line: number;
+  rule: string;
+  excerpt: string;
+}
+
+export interface ScanResult {
+  hits: ScanHit[];
+  missing: string[];
+}
+
+const POST_2015_DATE = /\b20(1[5-9]|[2-9][0-9])-[01][0-9]-[0-3][0-9]\b/;
+const REAL_ID = /\bi\d{8,9}\b/;
+
+function windowAround(text: string, index: number, length: number): string {
+  const start = Math.max(0, index - 15);
+  const end = Math.min(text.length, index + length + 15);
+  return text.slice(start, end).replace(/\s+/g, " ").trim();
+}
+
+function globalize(re: RegExp): RegExp {
+  const flags = re.flags.includes("g") ? re.flags : re.flags + "g";
+  return new RegExp(re.source, flags);
+}
+
+export function scanText(text: string): Array<{ rule: string; excerpt: string }> {
+  const hits: Array<{ rule: string; excerpt: string }> = [];
+
+  for (const rule of REDACTION_RULES) {
+    const re = new RegExp(rule.source, rule.flags.includes("g") ? rule.flags : rule.flags + "g");
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(text)) !== null) {
+      hits.push({ rule: "redaction-token", excerpt: windowAround(text, m.index, m[0].length) });
+    }
+  }
+
+  for (const [ruleName, base] of [
+    ["post-2015-date", POST_2015_DATE],
+    ["real-id-shape", REAL_ID],
+  ] as const) {
+    const re = globalize(base);
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(text)) !== null) {
+      hits.push({ rule: ruleName, excerpt: windowAround(text, m.index, m[0].length) });
+    }
+  }
+
+  return hits;
+}
+
+function scanFile(file: string, out: ScanHit[]): void {
+  const content = readFileSync(file, "utf-8");
+  const lines = content.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    for (const hit of scanText(lines[i])) {
+      out.push({ file, line: i + 1, rule: hit.rule, excerpt: hit.excerpt });
+    }
+  }
+}
+
+export function scanProbeOutputs(dir: string): ScanResult {
+  const hits: ScanHit[] = [];
+  const missing: string[] = [];
+
+  const transcriptsDir = join(dir, "transcripts");
+  const transcriptFiles = existsSync(transcriptsDir)
+    ? readdirSync(transcriptsDir).filter((f) => f.endsWith(".jsonl")).sort()
+    : [];
+  if (transcriptFiles.length === 0) {
+    missing.push("transcripts/*.jsonl");
+  }
+  for (const f of transcriptFiles) {
+    scanFile(join(transcriptsDir, f), hits);
+  }
+
+  const tokensFile = join(dir, "tokens.json");
+  if (existsSync(tokensFile)) {
+    scanFile(tokensFile, hits);
+  } else {
+    missing.push("tokens.json");
+  }
+
+  return { hits, missing };
+}

--- a/tools/composition-probe/scenarios.test.ts
+++ b/tools/composition-probe/scenarios.test.ts
@@ -1,0 +1,63 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { describe, it, expect } from "vitest";
+
+import { ALL_SCENARIOS } from "./scenarios/index.js";
+import { SUITE_COMPOSITION } from "./constants.js";
+import { MOCK_TOOL_NAMES } from "./tools.js";
+import { C2_FORBIDDEN, C3_FORBIDDEN, THRESHOLD_REQUIRED } from "./scenarios/needle-sets.js";
+import { SKILL_PINNED_FACTS } from "./scenarios/skill-facts.js";
+
+function mockRead(rel: string): string {
+  return readFileSync(fileURLToPath(new URL(`./mock/${rel}`, import.meta.url)), "utf-8");
+}
+
+const CORES = ["core-cycling.md", "core-running.md", "core-swimming.md"].map(mockRead).join("\n");
+
+describe("scenario suite shape", () => {
+  it("has 70 unique scenario ids", () => {
+    expect(ALL_SCENARIOS).toHaveLength(70);
+    expect(new Set(ALL_SCENARIOS.map((s) => s.id)).size).toBe(70);
+  });
+
+  it("matches the pinned per-class composition", () => {
+    for (const [cls, count] of Object.entries(SUITE_COMPOSITION)) {
+      expect(ALL_SCENARIOS.filter((s) => s.class === cls)).toHaveLength(count);
+    }
+  });
+
+  it("every c7 scenario carries its class's binding needles", () => {
+    const c7 = ALL_SCENARIOS.filter((s) => s.class === "c7-contamination");
+    const combined = c7.filter((s) => (s.judgeItems ?? []).includes("caveat-thresholds"));
+    expect(combined).toHaveLength(2);
+    for (const s of combined) {
+      expect(s.judgeItems).toContain("caveat-thresholds");
+      expect(s.judgeItems).toContain("caveat-cost");
+      expect(s.requiredNeedles).toBe(THRESHOLD_REQUIRED);
+    }
+    for (const s of c7.filter((x) => !combined.includes(x))) {
+      expect(s.forbiddenNeedles === C2_FORBIDDEN || s.forbiddenNeedles === C3_FORBIDDEN).toBe(true);
+    }
+  });
+
+  it("every c8 expectedTools name exists in the mock union", () => {
+    for (const s of ALL_SCENARIOS.filter((x) => x.class === "c8-tool-choice")) {
+      for (const name of s.expectedTools ?? []) {
+        expect(name === "<none>" || MOCK_TOOL_NAMES.includes(name)).toBe(true);
+      }
+    }
+  });
+
+  it("every c9 skillTarget resolves and carries a core-absent fact", () => {
+    for (const s of ALL_SCENARIOS.filter((x) => x.class === "c9-deep-protocol")) {
+      const target = s.skillTarget;
+      expect(target).toBeDefined();
+      const key = `${target!.sport}-${target!.topic}`;
+      const file = mockRead(`skills/${key}.md`);
+      const facts = SKILL_PINNED_FACTS[key];
+      expect(facts).toBeDefined();
+      expect(facts.some((f) => file.includes(f) && !CORES.includes(f))).toBe(true);
+    }
+  });
+});

--- a/tools/composition-probe/scenarios/c1-cycling.ts
+++ b/tools/composition-probe/scenarios/c1-cycling.ts
@@ -1,0 +1,21 @@
+import type { ProbeScenario } from "../types.js";
+import { C1_FORBIDDEN } from "./needle-sets.js";
+
+const c = (id: string, userMessage: string): ProbeScenario => ({
+  id,
+  class: "c1-cycling",
+  userMessage,
+  forbiddenNeedles: C1_FORBIDDEN,
+  judgeItems: ["sport-scope"],
+});
+
+export const C1_CYCLING: ProbeScenario[] = [
+  c("c1-01", "My FTP is 250 W. What are my power zones for the bike?"),
+  c("c1-02", "Review my last bike ride — the sweet spot session."),
+  c("c1-03", "How hard should tomorrow's ride be given my current form?"),
+  c("c1-04", "What's a good indoor trainer workout to build threshold on the bike?"),
+  c("c1-05", "Plan me a week of cycling in the build phase."),
+  c("c1-06", "My legs felt heavy on the bike today. Should I still do intervals tomorrow?"),
+  c("c1-07", "Explain what sweet spot means for cycling and when I'd use it."),
+  c("c1-08", "How do I structure a 3-hour endurance ride on the bike?"),
+];

--- a/tools/composition-probe/scenarios/c2-running.ts
+++ b/tools/composition-probe/scenarios/c2-running.ts
@@ -1,0 +1,21 @@
+import type { ProbeScenario } from "../types.js";
+import { C2_FORBIDDEN } from "./needle-sets.js";
+
+const c = (id: string, userMessage: string): ProbeScenario => ({
+  id,
+  class: "c2-running",
+  userMessage,
+  forbiddenNeedles: C2_FORBIDDEN,
+  judgeItems: ["sport-scope"],
+});
+
+export const C2_RUNNING: ProbeScenario[] = [
+  c("c2-01", "My critical speed is 3.55 m/s. What are my easy and threshold run paces?"),
+  c("c2-02", "Review my tempo run from yesterday."),
+  c("c2-03", "How should I pace my easy runs this week?"),
+  c("c2-04", "Design me a threshold running workout."),
+  c("c2-05", "Plan a week of running in the base phase."),
+  c("c2-06", "My easy runs feel too hard lately. What's going on?"),
+  c("c2-07", "Explain how running pace zones are set."),
+  c("c2-08", "How long should my long run be if I'm building toward a 10k?"),
+];

--- a/tools/composition-probe/scenarios/c3-swimming.ts
+++ b/tools/composition-probe/scenarios/c3-swimming.ts
@@ -1,0 +1,21 @@
+import type { ProbeScenario } from "../types.js";
+import { C3_FORBIDDEN } from "./needle-sets.js";
+
+const c = (id: string, userMessage: string): ProbeScenario => ({
+  id,
+  class: "c3-swimming",
+  userMessage,
+  forbiddenNeedles: C3_FORBIDDEN,
+  judgeItems: ["sport-scope"],
+});
+
+export const C3_SWIMMING: ProbeScenario[] = [
+  c("c3-01", "My critical swim pace is 1:45 per 100m. What are my swim zones?"),
+  c("c3-02", "Review my swim session from this morning."),
+  c("c3-03", "How should I pace a threshold swim set?"),
+  c("c3-04", "Design me a swim workout to build endurance in the pool."),
+  c("c3-05", "Plan a week of swimming for someone weak in the water."),
+  c("c3-06", "My swim splits are drifting slower late in the set. Why?"),
+  c("c3-07", "Explain how swim pace zones work off the critical swim pace."),
+  c("c3-08", "What's a good main set for a 1500m open-water target?"),
+];

--- a/tools/composition-probe/scenarios/c4-cross-ambiguous.ts
+++ b/tools/composition-probe/scenarios/c4-cross-ambiguous.ts
@@ -1,0 +1,26 @@
+import type { ProbeScenario } from "../types.js";
+
+const cross = (id: string, userMessage: string): ProbeScenario => ({
+  id,
+  class: "c4-cross-ambiguous",
+  userMessage,
+  judgeItems: ["correct-attribution"],
+});
+
+const ambiguous = (id: string, userMessage: string): ProbeScenario => ({
+  id,
+  class: "c4-cross-ambiguous",
+  userMessage,
+  judgeItems: ["handles-ambiguity"],
+});
+
+export const C4_CROSS_AMBIGUOUS: ProbeScenario[] = [
+  cross("c4-01", "Is my run fitness ahead of my bike fitness right now?"),
+  cross("c4-02", "I'm fresher on the bike than in the pool — how do I read that across sports?"),
+  cross("c4-03", "Compare where I stand on the bike versus running as I build toward the triathlon."),
+  cross("c4-04", "My swimming feels behind my cycling. How should I weight my week between them?"),
+  ambiguous("c4-05", "Should I train hard tomorrow?"),
+  ambiguous("c4-06", "I've got 45 minutes free this evening — what should I do?"),
+  ambiguous("c4-07", "I'm feeling good today. What's the best session to make it count?"),
+  ambiguous("c4-08", "How much recovery do I need after yesterday?"),
+];

--- a/tools/composition-probe/scenarios/c5-integrated.ts
+++ b/tools/composition-probe/scenarios/c5-integrated.ts
@@ -1,0 +1,17 @@
+import type { ProbeScenario } from "../types.js";
+
+const c = (id: string, userMessage: string): ProbeScenario => ({
+  id,
+  class: "c5-integrated",
+  userMessage,
+  judgeItems: ["integrated-coherent"],
+});
+
+export const C5_INTEGRATED: ProbeScenario[] = [
+  c("c5-01", "Review my brick from Saturday — 90 min bike into a 25 min run."),
+  c("c5-02", "Synthesize my triathlon training load this week across swim, bike, and run."),
+  c("c5-03", "Plan my race week for the Olympic-distance tri, touching all three disciplines."),
+  c("c5-04", "I raced the bike leg hard yesterday and my run today felt awful. Is that interference or just fatigue?"),
+  c("c5-05", "How do I sequence a hard swim, a bike interval day, and a long run across one week without digging a hole?"),
+  c("c5-06", "Given my current fatigue across all three sports, what should this week look like?"),
+];

--- a/tools/composition-probe/scenarios/c6-anchor-traps.ts
+++ b/tools/composition-probe/scenarios/c6-anchor-traps.ts
@@ -15,6 +15,6 @@ export const C6_ANCHOR_TRAPS: ProbeScenario[] = [
   c("c6-04", "Give me my run threshold speed — is that the same number as my critical speed?", [/\bCSS\b/, /\/100m/]),
   c("c6-05", "Convert my swim pace target into a per-100m number, not a speed in m/s.", [/\bwatts?\b/i, /\bFTP\b/]),
   c("c6-06", "Is my bike threshold the same idea as critical speed on the run?", [/critical swim speed/i]),
-  c("c6-07", "What units should I read my swim critical pace in?", [/(swim|CSS)[^.\n]{0,40}\bin m\/s\b/i, /\bwatts?\b/i]),
+  c("c6-07", "What units should I read my swim critical pace in?", [/\bwatts?\b/i]),
   c("c6-08", "For the run, is critical speed a pace or a power number?", [/\bwatts?\b/i, /\bFTP\b/]),
 ];

--- a/tools/composition-probe/scenarios/c6-anchor-traps.ts
+++ b/tools/composition-probe/scenarios/c6-anchor-traps.ts
@@ -15,6 +15,6 @@ export const C6_ANCHOR_TRAPS: ProbeScenario[] = [
   c("c6-04", "Give me my run threshold speed — is that the same number as my critical speed?", [/\bCSS\b/, /\/100m/]),
   c("c6-05", "Convert my swim pace target into a per-100m number, not a speed in m/s.", [/\bwatts?\b/i, /\bFTP\b/]),
   c("c6-06", "Is my bike threshold the same idea as critical speed on the run?", [/critical swim speed/i]),
-  c("c6-07", "What units should I read my swim critical pace in?", [/\bm\/s\b/, /\bwatts?\b/i]),
+  c("c6-07", "What units should I read my swim critical pace in?", [/(swim|CSS)[^.\n]{0,40}\bin m\/s\b/i, /\bwatts?\b/i]),
   c("c6-08", "For the run, is critical speed a pace or a power number?", [/\bwatts?\b/i, /\bFTP\b/]),
 ];

--- a/tools/composition-probe/scenarios/c6-anchor-traps.ts
+++ b/tools/composition-probe/scenarios/c6-anchor-traps.ts
@@ -1,0 +1,20 @@
+import type { ProbeScenario } from "../types.js";
+
+const c = (id: string, userMessage: string, forbiddenNeedles: RegExp[]): ProbeScenario => ({
+  id,
+  class: "c6-anchor-traps",
+  userMessage,
+  forbiddenNeedles,
+  judgeItems: ["anchor-correct"],
+});
+
+export const C6_ANCHOR_TRAPS: ProbeScenario[] = [
+  c("c6-01", "What's my critical speed pace for the run, in m/s?", [/\bCSS\b/, /critical swim speed/i]),
+  c("c6-02", "My critical swim speed is 1:45 per 100m — what's my threshold swim pace?", [/critical speed\b/i, /\bFTP\b/]),
+  c("c6-03", "What's my threshold pace for the swim leg of the tri?", [/\bFTP\b/, /\bwatts?\b/i]),
+  c("c6-04", "Give me my run threshold speed — is that the same number as my critical speed?", [/\bCSS\b/, /\/100m/]),
+  c("c6-05", "Convert my swim pace target into a per-100m number, not a speed in m/s.", [/\bwatts?\b/i, /\bFTP\b/]),
+  c("c6-06", "Is my bike threshold the same idea as critical speed on the run?", [/critical swim speed/i]),
+  c("c6-07", "What units should I read my swim critical pace in?", [/\bm\/s\b/, /\bwatts?\b/i]),
+  c("c6-08", "For the run, is critical speed a pace or a power number?", [/\bwatts?\b/i, /\bFTP\b/]),
+];

--- a/tools/composition-probe/scenarios/c7-contamination.ts
+++ b/tools/composition-probe/scenarios/c7-contamination.ts
@@ -1,0 +1,37 @@
+import type { ProbeScenario } from "../types.js";
+import { C2_FORBIDDEN, C3_FORBIDDEN, THRESHOLD_REQUIRED } from "./needle-sets.js";
+
+const run = (id: string, userMessage: string): ProbeScenario => ({
+  id,
+  class: "c7-contamination",
+  userMessage,
+  forbiddenNeedles: C2_FORBIDDEN,
+  judgeItems: ["sport-scope"],
+});
+
+const swim = (id: string, userMessage: string): ProbeScenario => ({
+  id,
+  class: "c7-contamination",
+  userMessage,
+  forbiddenNeedles: C3_FORBIDDEN,
+  judgeItems: ["sport-scope"],
+});
+
+const combined = (id: string, userMessage: string): ProbeScenario => ({
+  id,
+  class: "c7-contamination",
+  userMessage,
+  requiredNeedles: THRESHOLD_REQUIRED,
+  judgeItems: ["caveat-thresholds", "caveat-cost"],
+});
+
+export const C7_CONTAMINATION: ProbeScenario[] = [
+  run("c7-01", "How steady was my heart rate on that run relative to pace over the second half?"),
+  run("c7-02", "Was my easy run actually easy, or was I drifting into a harder effort?"),
+  run("c7-03", "Break down the effort in my hill run this morning."),
+  swim("c7-04", "How intense was my swim set — was I working near my limit?"),
+  swim("c7-05", "Judge the effort in my main swim set today."),
+  swim("c7-06", "Was my pool session more of an endurance or a hard day?"),
+  combined("c7-07", "Give me one combined training load number across my swim, bike, and run this week."),
+  combined("c7-08", "Add up my total load across all three sports and tell me what it means."),
+];

--- a/tools/composition-probe/scenarios/c8-tool-choice.ts
+++ b/tools/composition-probe/scenarios/c8-tool-choice.ts
@@ -1,0 +1,21 @@
+import type { ProbeScenario } from "../types.js";
+
+const c = (id: string, userMessage: string, expectedTools: string[]): ProbeScenario => ({
+  id,
+  class: "c8-tool-choice",
+  userMessage,
+  expectedTools,
+});
+
+export const C8_TOOL_CHOICE: ProbeScenario[] = [
+  c("c8-01", "What did we decide about my knee last month?", ["memory_query"]),
+  c("c8-02", "Show my last week of sessions.", ["activities_list"]),
+  c("c8-03", "Explain how my Form number is computed.", ["metric_explain", "athlete_state"]),
+  c("c8-04", "Delete tomorrow's workout.", ["intervals_delete_workout"]),
+  c("c8-05", "Schedule this swim for Friday.", ["create_swim_workout"]),
+  c("c8-06", "Build my tri taper toward race day.", ["reconcile_multisport_taper"]),
+  c("c8-07", "What's my current fitness, fatigue, and form right now?", ["athlete_state"]),
+  c("c8-08", "What's on my calendar this week?", ["intervals_list_events"]),
+  c("c8-09", "Give me the exact grams per hour to fuel my long ride.", ["skill_read"]),
+  c("c8-10", "What's a good mindset to hold on race morning?", ["<none>"]),
+];

--- a/tools/composition-probe/scenarios/c9-deep-protocol.ts
+++ b/tools/composition-probe/scenarios/c9-deep-protocol.ts
@@ -1,0 +1,22 @@
+import type { ProbeScenario } from "../types.js";
+
+const c = (
+  id: string,
+  userMessage: string,
+  skillTarget: { sport: string; topic: string },
+): ProbeScenario => ({
+  id,
+  class: "c9-deep-protocol",
+  userMessage,
+  skillTarget,
+  judgeItems: ["used-skill-content"],
+});
+
+export const C9_DEEP_PROTOCOL: ProbeScenario[] = [
+  c("c9-01", "Give me the exact day-by-day taper percentages for my 40k time trial.", { sport: "cycling", topic: "taper" }),
+  c("c9-02", "Exactly how many grams of carbohydrate per hour should I take on a 3-hour race ride, and what blend?", { sport: "cycling", topic: "fueling" }),
+  c("c9-03", "Walk me through the exact walk-run steps to get back to running after a niggle.", { sport: "running", topic: "return-to-run" }),
+  c("c9-04", "Give me the precise drill set to clean up my freestyle catch.", { sport: "swimming", topic: "drills" }),
+  c("c9-05", "What's the exact pool test protocol to set my critical swim pace?", { sport: "swimming", topic: "css-test" }),
+  c("c9-06", "Give me the exact structure of a race-specific brick session.", { sport: "multisport", topic: "brick" }),
+];

--- a/tools/composition-probe/scenarios/index.ts
+++ b/tools/composition-probe/scenarios/index.ts
@@ -1,0 +1,22 @@
+import type { ProbeScenario } from "../types.js";
+import { C1_CYCLING } from "./c1-cycling.js";
+import { C2_RUNNING } from "./c2-running.js";
+import { C3_SWIMMING } from "./c3-swimming.js";
+import { C4_CROSS_AMBIGUOUS } from "./c4-cross-ambiguous.js";
+import { C5_INTEGRATED } from "./c5-integrated.js";
+import { C6_ANCHOR_TRAPS } from "./c6-anchor-traps.js";
+import { C7_CONTAMINATION } from "./c7-contamination.js";
+import { C8_TOOL_CHOICE } from "./c8-tool-choice.js";
+import { C9_DEEP_PROTOCOL } from "./c9-deep-protocol.js";
+
+export const ALL_SCENARIOS: ProbeScenario[] = [
+  ...C1_CYCLING,
+  ...C2_RUNNING,
+  ...C3_SWIMMING,
+  ...C4_CROSS_AMBIGUOUS,
+  ...C5_INTEGRATED,
+  ...C6_ANCHOR_TRAPS,
+  ...C7_CONTAMINATION,
+  ...C8_TOOL_CHOICE,
+  ...C9_DEEP_PROTOCOL,
+];

--- a/tools/composition-probe/scenarios/needle-sets.ts
+++ b/tools/composition-probe/scenarios/needle-sets.ts
@@ -1,0 +1,7 @@
+export const C1_FORBIDDEN: RegExp[] = [/\bCSS\b/, /critical swim speed/i];
+
+export const C2_FORBIDDEN: RegExp[] = [/\bDFA\b/i, /alpha[- ]?1|α1/i, /decoupling/i, /\bFTP\b/];
+
+export const C3_FORBIDDEN: RegExp[] = [/\bFTP\b/, /\bwatts?\b/i, /\bpower zones?\b/i];
+
+export const THRESHOLD_REQUIRED: RegExp[] = [/\bthreshold/i];

--- a/tools/composition-probe/scenarios/skill-facts.ts
+++ b/tools/composition-probe/scenarios/skill-facts.ts
@@ -1,0 +1,9 @@
+export const SKILL_PINNED_FACTS: Record<string, string[]> = {
+  "cycling-taper": ["Day -8: 70% volume"],
+  "cycling-fueling": ["2:1 glucose-to-fructose"],
+  "running-return-to-run": ["1 min jog / 2 min walk"],
+  "running-fueling": ["g/kg carbohydrate breakfast"],
+  "swimming-drills": ["Fingertip drag"],
+  "swimming-css-test": ["Swim a 400m time trial"],
+  "multisport-brick": ["Base brick"],
+};

--- a/tools/composition-probe/tokens.ts
+++ b/tools/composition-probe/tokens.ts
@@ -16,6 +16,16 @@ export interface TokensJson {
 
 const COUNT_TOKENS_URL = "https://api.anthropic.com/v1/messages/count_tokens";
 
+export class CountTokensHttpError extends Error {
+  constructor(
+    readonly status: number,
+    readonly body: string,
+  ) {
+    super(`count_tokens returned ${status}`);
+    this.name = "CountTokensHttpError";
+  }
+}
+
 async function countTokens(systemText: string, includeTools: boolean, apiKey: string): Promise<number> {
   const body = {
     model: TOKEN_COUNT_MODEL,
@@ -34,7 +44,7 @@ async function countTokens(systemText: string, includeTools: boolean, apiKey: st
   });
   if (!res.ok) {
     const text = await res.text();
-    throw new Error(`count_tokens returned ${res.status}: ${text}`);
+    throw new CountTokensHttpError(res.status, text);
   }
   const json = (await res.json()) as { input_tokens: number };
   return json.input_tokens;
@@ -45,9 +55,20 @@ function gitSha(): string {
 }
 
 export async function runTokensPhase(dir: string, apiKey: string): Promise<number> {
-  const { block1, fullSystem } = buildMockPrompt();
-  const stablePrefixTokens = await countTokens(block1, true, apiKey);
-  const wholePromptTokens = await countTokens(fullSystem, true, apiKey);
+  let stablePrefixTokens: number;
+  let wholePromptTokens: number;
+  try {
+    const { block1, fullSystem } = buildMockPrompt();
+    stablePrefixTokens = await countTokens(block1, true, apiKey);
+    wholePromptTokens = await countTokens(fullSystem, true, apiKey);
+  } catch (err) {
+    if (err instanceof CountTokensHttpError) {
+      console.error(`tokens: count_tokens returned a non-2xx response (HTTP ${err.status}) — this is a STOP condition; not falling back to estimation. Response body:`);
+      console.error(err.body);
+      return 2;
+    }
+    throw err;
+  }
   const out: TokensJson = {
     method: "anthropic count_tokens",
     model: TOKEN_COUNT_MODEL,

--- a/tools/composition-probe/tokens.ts
+++ b/tools/composition-probe/tokens.ts
@@ -1,0 +1,61 @@
+import { execSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { TOKEN_COUNT_MODEL } from "./constants.js";
+import { buildMockPrompt } from "./assemble.js";
+import { toAnthropicToolsJson } from "./tools.js";
+
+export interface TokensJson {
+  method: string;
+  model: string;
+  stablePrefixTokens: number;
+  wholePromptTokens: number;
+  measuredAtGitSha: string;
+}
+
+const COUNT_TOKENS_URL = "https://api.anthropic.com/v1/messages/count_tokens";
+
+async function countTokens(systemText: string, includeTools: boolean, apiKey: string): Promise<number> {
+  const body = {
+    model: TOKEN_COUNT_MODEL,
+    system: [{ type: "text", text: systemText }],
+    tools: includeTools ? toAnthropicToolsJson() : undefined,
+    messages: [{ role: "user", content: "hi" }],
+  };
+  const res = await fetch(COUNT_TOKENS_URL, {
+    method: "POST",
+    headers: {
+      "x-api-key": apiKey,
+      "anthropic-version": "2023-06-01",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`count_tokens returned ${res.status}: ${text}`);
+  }
+  const json = (await res.json()) as { input_tokens: number };
+  return json.input_tokens;
+}
+
+function gitSha(): string {
+  return execSync("git rev-parse HEAD", { encoding: "utf-8" }).trim();
+}
+
+export async function runTokensPhase(dir: string, apiKey: string): Promise<number> {
+  const { block1, fullSystem } = buildMockPrompt();
+  const stablePrefixTokens = await countTokens(block1, true, apiKey);
+  const wholePromptTokens = await countTokens(fullSystem, true, apiKey);
+  const out: TokensJson = {
+    method: "anthropic count_tokens",
+    model: TOKEN_COUNT_MODEL,
+    stablePrefixTokens,
+    wholePromptTokens,
+    measuredAtGitSha: gitSha(),
+  };
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "tokens.json"), JSON.stringify(out, null, 2) + "\n", "utf-8");
+  return 0;
+}

--- a/tools/composition-probe/tools.test.ts
+++ b/tools/composition-probe/tools.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+
+import { MOCK_TOOLS, MOCK_TOOL_NAMES, buildToolSet, toAnthropicToolsJson } from "./tools.js";
+import type { ToolCallRecorder } from "./tools.js";
+
+const SAMPLE_INPUT = {
+  from: "1998-01-01",
+  to: "1998-12-31",
+  content: "x",
+  entry: "x",
+  plan: "x",
+  days: 7,
+  activityId: 90101,
+  streams: ["watts", "heartrate"],
+  metricKey: "form",
+  sport: "cycling",
+  topic: "taper",
+  anchorValue: 250,
+  target: "calendar",
+  doc: "x",
+  date: "1998-07-10",
+  weeks: 8,
+  goal: "tri",
+  phase: "build",
+  segments: ["bike", "run"],
+  raceDate: "1998-08-30",
+  disciplines: ["swim", "bike", "run"],
+  eventId: 90301,
+};
+
+describe("mock tool union", () => {
+  it("has exactly 25 unique tool names", () => {
+    expect(MOCK_TOOL_NAMES).toHaveLength(25);
+    expect(new Set(MOCK_TOOL_NAMES).size).toBe(25);
+  });
+
+  it("every executor is deterministic for the same args", () => {
+    for (const spec of MOCK_TOOLS) {
+      const a = JSON.stringify(spec.makeResult(SAMPLE_INPUT));
+      const b = JSON.stringify(spec.makeResult(SAMPLE_INPUT));
+      expect(a).toBe(b);
+    }
+  });
+
+  it("skill_read returns file content and an error shape without throwing", () => {
+    const spec = MOCK_TOOLS.find((t) => t.name === "skill_read");
+    expect(spec).toBeDefined();
+    const ok = spec!.makeResult({ sport: "cycling", topic: "taper" }) as { content?: string };
+    expect(typeof ok.content).toBe("string");
+    expect(ok.content).toContain("Day -8");
+    const bad = spec!.makeResult({ sport: "cycling", topic: "does-not-exist" }) as {
+      error?: string;
+      available?: unknown;
+    };
+    expect(bad.error).toBe("unknown_topic");
+    expect(Array.isArray(bad.available)).toBe(true);
+  });
+
+  it("toAnthropicToolsJson produces 25 object-schema entries", () => {
+    const json = toAnthropicToolsJson();
+    expect(json).toHaveLength(25);
+    for (const entry of json) {
+      expect(typeof entry.name).toBe("string");
+      expect(typeof entry.description).toBe("string");
+      expect((entry.input_schema as { type?: string }).type).toBe("object");
+    }
+  });
+
+  it("records every executor call in invocation order (not last-step-only)", () => {
+    const calls: Array<{ toolName: string; input: unknown }> = [];
+    const rec: ToolCallRecorder = (c) => calls.push(c);
+    const set = buildToolSet(rec) as unknown as Record<string, { execute: (i: unknown) => unknown }>;
+    set["memory_read"].execute({});
+    set["activities_list"].execute({ days: 7 });
+    expect(calls.map((c) => c.toolName)).toEqual(["memory_read", "activities_list"]);
+  });
+});

--- a/tools/composition-probe/tools.ts
+++ b/tools/composition-probe/tools.ts
@@ -1,0 +1,328 @@
+import { existsSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { z } from "zod";
+
+import type { ProbeToolSet } from "./types.js";
+
+export type ToolCallRecorder = (call: { toolName: string; input: unknown }) => void;
+
+interface MockToolSpec {
+  name: string;
+  description: string;
+  inputSchema: z.ZodType;
+  makeResult: (input: any) => unknown;
+}
+
+const SPORT_ENUM = z.enum(["cycling", "running", "swimming", "multisport"]);
+const SPORT3_ENUM = z.enum(["cycling", "running", "swimming"]);
+
+const KNOWN_SKILLS: Array<{ sport: string; topic: string }> = [
+  { sport: "cycling", topic: "taper" },
+  { sport: "cycling", topic: "fueling" },
+  { sport: "running", topic: "return-to-run" },
+  { sport: "running", topic: "fueling" },
+  { sport: "swimming", topic: "drills" },
+  { sport: "swimming", topic: "css-test" },
+  { sport: "multisport", topic: "brick" },
+];
+
+function skillPath(sport: string, topic: string): string {
+  return fileURLToPath(new URL(`./mock/skills/${sport}-${topic}.md`, import.meta.url));
+}
+
+function readSkill(sport: string, topic: string): unknown {
+  const known = KNOWN_SKILLS.some((s) => s.sport === sport && s.topic === topic);
+  const path = skillPath(sport, topic);
+  if (!known || !existsSync(path)) {
+    return { error: "unknown_topic", available: KNOWN_SKILLS };
+  }
+  return { sport, topic, content: readFileSync(path, "utf-8").trimEnd() };
+}
+
+const SYNTHETIC_ACTIVITIES = [
+  { id: 90101, type: "Ride", date: "1998-07-05", name: "Sweet spot 3x12", movingTimeMin: 78, load: 82 },
+  { id: 90102, type: "Run", date: "1998-07-04", name: "Easy endurance", movingTimeMin: 46, load: 38 },
+  { id: 90103, type: "Swim", date: "1998-07-03", name: "Technique + threshold", movingTimeMin: 40, load: 30 },
+  { id: 90104, type: "Ride", date: "1998-07-02", name: "Endurance Z2", movingTimeMin: 120, load: 95 },
+  { id: 90105, type: "Run", date: "1998-07-01", name: "Strides + tempo", movingTimeMin: 52, load: 48 },
+];
+
+const METRIC_EXPLAIN_MAP: Record<string, unknown> = {
+  form: {
+    inputs: "Fitness minus Fatigue",
+    computation: "Form = Fitness (long-term load average) - Fatigue (short-term load average)",
+    citation: "Banister/Morton fitness-fatigue impulse-response model",
+  },
+  fitness: {
+    inputs: "exponentially weighted long-term Load average",
+    computation: "Fitness updates each day toward recent Load with a long time constant",
+    citation: "Banister/Morton fitness-fatigue impulse-response model",
+  },
+  load: {
+    inputs: "duration and intensity relative to the sport threshold anchor",
+    computation: "Load scales session duration by relative intensity against the sport anchor",
+    citation: "external-oracle training-load formulation",
+  },
+};
+
+const MOCK_TOOLS: MockToolSpec[] = [
+  {
+    name: "memory_read",
+    description: "Read the athlete's long-term memory document of durable facts. Call when you need standing facts about the athlete (goals, equipment, preferences) that do not change day to day.",
+    inputSchema: z.object({}),
+    makeResult: () => ({
+      facts: [
+        "Prefers morning sessions; strongest on the bike, weakest in the water.",
+        "Targeting a sub-2:30 Olympic-distance triathlon.",
+      ],
+    }),
+  },
+  {
+    name: "memory_query",
+    description: "Query dated coaching notes and the event ledger over a date range. Call FIRST for any question about the past ('what did we note', 'when did I', 'how did that go') before claiming a note does not exist.",
+    inputSchema: z.object({ from: z.string(), to: z.string() }),
+    makeResult: (input) => ({
+      echo: input,
+      notes: [
+        "1998-04-18: left knee flared after downhill running; backed off run volume.",
+        "1998-05-20: reset critical swim pace to 1:45 /100m after a pool test.",
+      ],
+    }),
+  },
+  {
+    name: "memory_write",
+    description: "Persist a durable athlete fact to long-term memory. Call when the athlete shares a fact worth remembering across sessions (FTP, weight, schedule, goal, injury).",
+    inputSchema: z.object({ content: z.string() }),
+    makeResult: () => ({ ok: true }),
+  },
+  {
+    name: "ledger_append",
+    description: "Append a dated coaching decision or event to the athlete's ledger. Call when a decision is made that should be recallable later by date.",
+    inputSchema: z.object({ entry: z.string() }),
+    makeResult: () => ({ ok: true }),
+  },
+  {
+    name: "plan_save",
+    description: "Save the current multi-week training plan document. Call after building or revising a plan the athlete has agreed to.",
+    inputSchema: z.object({ plan: z.string() }),
+    makeResult: () => ({ ok: true }),
+  },
+  {
+    name: "plan_load",
+    description: "Load the athlete's current saved training plan. Call when the athlete asks about their plan or you need the current plan context.",
+    inputSchema: z.object({}),
+    makeResult: () => ({
+      plan: "Build phase, week 3 of 6. Focus: bike sweet spot, run threshold, swim technique. One brick per week.",
+    }),
+  },
+  {
+    name: "activities_list",
+    description: "List recent activities across all sports, newest first. Call to see what the athlete has actually done, for example when reviewing a session or checking recent training.",
+    inputSchema: z.object({ days: z.number().optional() }),
+    makeResult: (input) => ({ echo: input, activities: SYNTHETIC_ACTIVITIES }),
+  },
+  {
+    name: "activity_detail",
+    description: "Fetch one activity's per-interval detail by id. Call after activities_list when you need the splits of a specific structured session.",
+    inputSchema: z.object({ activityId: z.number() }),
+    makeResult: (input) => ({
+      id: input.activityId,
+      type: "Ride",
+      date: "1998-07-05",
+      intervals: [
+        { rep: 1, minutes: 12, avgPowerW: 238, zone: "sweet spot" },
+        { rep: 2, minutes: 12, avgPowerW: 240, zone: "sweet spot" },
+        { rep: 3, minutes: 12, avgPowerW: 235, zone: "sweet spot" },
+      ],
+    }),
+  },
+  {
+    name: "activity_streams",
+    description: "Fetch downsampled time-series streams (watts, heartrate, pace, cadence) for one activity. Call only for a deep review that needs pacing curves or decoupling.",
+    inputSchema: z.object({ activityId: z.number(), streams: z.array(z.string()) }),
+    makeResult: (input) => ({
+      id: input.activityId,
+      points: 24,
+      streams: Object.fromEntries(
+        (input.streams as string[]).map((s) => [s, Array.from({ length: 24 }, (_, i) => i + 1)]),
+      ),
+    }),
+  },
+  {
+    name: "athlete_state",
+    description: "Read the athlete's current anchors, zones, and per-discipline monitoring numbers (7d/28d Load, Fitness, Fatigue, Form). Call when a recommendation depends on current fitness/fatigue/form or on the zone anchors.",
+    inputSchema: z.object({}),
+    makeResult: () => ({
+      anchors: { cyclingFtpW: 250, runningCriticalSpeedMps: 3.55, swimCssPer100m: "1:45" },
+      cycling: { load7d: 320, load28d: 1180, fitness: 62, fatigue: 71, form: -9 },
+      running: { load7d: 145, load28d: 540, fitness: 34, fatigue: 40, form: -6 },
+      swimming: { load7d: 60, load28d: 210, fitness: 15, fatigue: 12, form: 3 },
+    }),
+  },
+  {
+    name: "adherence_report",
+    description: "Summarise planned-versus-completed sessions over a recent window. Call when the athlete asks how well they stuck to the plan or you need adherence context.",
+    inputSchema: z.object({ days: z.number().optional() }),
+    makeResult: (input) => ({
+      echo: input,
+      planned: 9,
+      completed: 7,
+      missed: ["1998-07-06 swim threshold", "1998-07-05 easy run"],
+    }),
+  },
+  {
+    name: "metric_explain",
+    description: "Explain how a monitoring metric is computed, with its inputs and the cited basis. Call when the athlete asks what a number means or how it is calculated (for example Form, Fitness, or Load).",
+    inputSchema: z.object({ metricKey: z.string() }),
+    makeResult: (input) => METRIC_EXPLAIN_MAP[String(input.metricKey).toLowerCase()] ?? {
+      error: "unknown_metric",
+      available: Object.keys(METRIC_EXPLAIN_MAP),
+    },
+  },
+  {
+    name: "skill_read",
+    description: "Read a deep-protocol skill file for a sport and topic. Call whenever a question needs specific numbers not in the prompt: taper percentages, fueling grams, drill catalogs, test protocols, return-to-run ladders, or brick structure.",
+    inputSchema: z.object({ sport: SPORT_ENUM, topic: z.string() }),
+    makeResult: (input) => readSkill(String(input.sport), String(input.topic)),
+  },
+  {
+    name: "calculate_zones",
+    description: "Compute the training zone table for a sport from its anchor value (FTP watts for cycling, critical speed m/s for running, critical swim pace for swimming). Call when the athlete asks for their zones.",
+    inputSchema: z.object({ sport: SPORT3_ENUM, anchorValue: z.number() }),
+    makeResult: (input) => ({
+      sport: input.sport,
+      anchorValue: input.anchorValue,
+      zones: [
+        { name: "easy", range: "recovery to endurance" },
+        { name: "moderate", range: "tempo to sweet spot" },
+        { name: "threshold", range: "at the anchor" },
+        { name: "hard", range: "above the anchor" },
+      ],
+    }),
+  },
+  {
+    name: "push_planned_workout",
+    description: "Push a single planned workout document to the athlete's calendar on a date. Call to schedule one already-designed workout.",
+    inputSchema: z.object({ target: z.enum(["calendar"]), doc: z.string(), date: z.string() }),
+    makeResult: () => ({ ok: true, id: 90201 }),
+  },
+  {
+    name: "build_plan_skeleton",
+    description: "Build a phased multi-week plan skeleton toward a goal. Call when the athlete wants a new training plan outline before individual workouts are written.",
+    inputSchema: z.object({ weeks: z.number(), goal: z.string() }),
+    makeResult: (input) => ({
+      weeks: input.weeks,
+      goal: input.goal,
+      phases: ["base", "build", "peak", "taper"],
+    }),
+  },
+  {
+    name: "assess_feasibility",
+    description: "Assess whether a proposed plan is realistic given the athlete's current state. Call before committing to an ambitious plan to check for injury or overreach risk.",
+    inputSchema: z.object({ plan: z.string() }),
+    makeResult: () => ({
+      feasible: true,
+      notes: ["Weekly Load ramp under 8% is sustainable.", "Recovery week scheduled every fourth week."],
+    }),
+  },
+  {
+    name: "get_sample_week",
+    description: "Return a sample training week for a given phase. Call when the athlete wants to see what a typical week looks like in a phase.",
+    inputSchema: z.object({ phase: z.string() }),
+    makeResult: (input) => ({
+      phase: input.phase,
+      week: ["Mon rest", "Tue bike sweet spot", "Wed swim technique", "Thu run threshold", "Fri easy", "Sat long bike", "Sun brick"],
+    }),
+  },
+  {
+    name: "intervals_create_workout",
+    description: "Create a structured cycling or running workout on the calendar from a workout document. Call to schedule a bike or run session you have designed.",
+    inputSchema: z.object({ doc: z.string(), date: z.string() }),
+    makeResult: () => ({ ok: true, id: 90202 }),
+  },
+  {
+    name: "create_swim_workout",
+    description: "Create a structured swim workout on the calendar from a swim workout document (pace-per-100m targets). Call to schedule a pool session.",
+    inputSchema: z.object({ doc: z.string(), date: z.string() }),
+    makeResult: () => ({ ok: true, id: 90203 }),
+  },
+  {
+    name: "create_brick_workout",
+    description: "Create a brick (back-to-back multi-discipline) workout on the calendar from ordered segments. Call to schedule a bike-to-run or swim-to-bike brick.",
+    inputSchema: z.object({ segments: z.array(z.string()), date: z.string() }),
+    makeResult: () => ({ ok: true, id: 90204 }),
+  },
+  {
+    name: "reconcile_multisport_taper",
+    description: "Build one event-anchored taper that coordinates all disciplines toward a race date. Call when the athlete wants a taper for a multisport event across bike, run, and swim.",
+    inputSchema: z.object({ raceDate: z.string(), disciplines: z.array(z.string()) }),
+    makeResult: (input) => ({
+      raceDate: input.raceDate,
+      disciplines: input.disciplines,
+      taper: [
+        { daysOut: 8, note: "cut volume to 70%, hold light intensity across all three" },
+        { daysOut: 3, note: "short primers each discipline" },
+        { daysOut: 1, note: "easy shakeout only" },
+      ],
+    }),
+  },
+  {
+    name: "intervals_delete_workout",
+    description: "Delete a planned calendar workout by event id. Call when the athlete asks to remove or cancel a scheduled session.",
+    inputSchema: z.object({ eventId: z.number() }),
+    makeResult: () => ({ ok: true }),
+  },
+  {
+    name: "intervals_list_events",
+    description: "List upcoming planned calendar events over a window. Call when the athlete asks what is scheduled or you need the upcoming calendar.",
+    inputSchema: z.object({ days: z.number().optional() }),
+    makeResult: (input) => ({
+      echo: input,
+      events: [
+        { id: 90301, date: "1998-07-07", title: "Swim threshold" },
+        { id: 90302, date: "1998-07-08", title: "Bike VO2 5x4" },
+        { id: 90303, date: "1998-07-09", title: "Easy run" },
+      ],
+    }),
+  },
+  {
+    name: "intervals_fetch_streams",
+    description: "Transitional escape hatch for raw activity streams by id. Prefer activity_streams; call this only when a legacy stream fetch is explicitly needed.",
+    inputSchema: z.object({ activityId: z.number(), streams: z.array(z.string()) }),
+    makeResult: (input) => ({
+      id: input.activityId,
+      points: 24,
+      streams: Object.fromEntries(
+        (input.streams as string[]).map((s) => [s, Array.from({ length: 24 }, (_, i) => i + 1)]),
+      ),
+    }),
+  },
+];
+
+export { MOCK_TOOLS };
+
+export const MOCK_TOOL_NAMES: string[] = MOCK_TOOLS.map((t) => t.name);
+
+export function buildToolSet(recorder: ToolCallRecorder): ProbeToolSet {
+  const set: Record<string, { description: string; inputSchema: z.ZodType; execute: (input: unknown) => unknown }> = {};
+  for (const spec of MOCK_TOOLS) {
+    set[spec.name] = {
+      description: spec.description,
+      inputSchema: spec.inputSchema,
+      execute: (input: unknown) => {
+        recorder({ toolName: spec.name, input });
+        return spec.makeResult(input);
+      },
+    };
+  }
+  return set as unknown as ProbeToolSet;
+}
+
+export function toAnthropicToolsJson(): Array<{ name: string; description: string; input_schema: unknown }> {
+  return MOCK_TOOLS.map((spec) => ({
+    name: spec.name,
+    description: spec.description,
+    input_schema: z.toJSONSchema(spec.inputSchema),
+  }));
+}

--- a/tools/composition-probe/types.ts
+++ b/tools/composition-probe/types.ts
@@ -1,0 +1,40 @@
+import type { GenerateOpts } from "../../packages/core/src/llm-types.js";
+
+export type ProbeToolSet = NonNullable<GenerateOpts["tools"]>;
+export type StopFn = Exclude<NonNullable<GenerateOpts["stopWhen"]>, readonly unknown[]>;
+
+export type ScenarioClass = keyof typeof import("./constants.js")["SUITE_COMPOSITION"];
+
+export interface ProbeScenario {
+  id: string;
+  class: ScenarioClass;
+  userMessage: string;
+  forbiddenNeedles?: RegExp[];
+  requiredNeedles?: RegExp[];
+  judgeItems?: string[];
+  expectedTools?: string[];
+  skillTarget?: { sport: string; topic: string };
+}
+
+export interface TranscriptLine {
+  scenarioId: string;
+  class: string;
+  model: string;
+  provider: string;
+  userMessage: string;
+  assistantText: string;
+  toolCalls: Array<{ toolName: string; input: unknown }>;
+  steps: number;
+  usage: { inputTokens?: number; outputTokens?: number; cacheReadTokens?: number };
+  durationMs: number;
+  needleHits: Array<{ kind: "forbidden" | "required-miss"; pattern: string; excerpt: string }>;
+  judge?: JudgeVerdict;
+  flagged: boolean;
+  trademarkRedactions: number;
+  error?: string;
+}
+
+export interface JudgeVerdict {
+  mixing: { flag: boolean; evidence: string | null; sportsInvolved: string[] };
+  items: Record<string, { pass: boolean; note: string }>;
+}


### PR DESCRIPTION
## What this adds

A self-contained composition smoke probe under `tools/composition-probe/`, plus its committed output scaffold under `probes/composition-smoke/`. The probe stress-tests whether one agent can hold three sports (cycling, running, swimming) in a single two-block prompt without the voices or physiology bleeding together. It has abort-only power by design: it can abort the one-agent composition premise, never confirm it.

Kit surfaces (all new, no product code touched):

- `assemble.ts` — mock two-block prompt assembly reusing the shared static rule blocks and boundary/fence constants, with a pinned two-entry tool-name substitution.
- `tools.ts` — a 25-tool mock union where every tool records its call through a recorder before returning its canned result, so transcripts are sourced from actual calls rather than last-step-only metadata.
- `mock/` — probe-only synthetic content: a unified soul, compact per-sport cores, seven deep-protocol skill files, and a fully synthetic athlete context. This is scaffolding, never shipped, never athlete-facing.
- `scenarios/` — 70 synthetic scenarios across nine classes, each carrying its binding-minimum deterministic needles.
- `needles.ts`, `redact.ts`, `judge.ts`, `scan.ts`, `report.ts`, `tokens.ts` — deterministic needle checks, stray-token redaction with recorded counts, a pinned-judge pass, a transcript scan gate, token counting, and report rendering.
- `run.ts` — the CLI with a `--dry-run` self-test and per-stage phases.
- `constants.ts`, `types.ts`, `rubric.md`, `dryrun-fixtures.ts` and matching `*.test.ts` unit tests.

One root script line is added: `probe:composition`. No package under `packages/` is touched and the lockfile is unchanged.

## Why this is a draft

`probes/composition-smoke/report.md` and `spot-check.md` are committed **templates** — every metric value is the literal `PENDING`. The real run outputs (transcripts from real provider calls, the operator spot-check, and the rendered report) are produced later by the operator, because that step spends real tokens and is operator-triggered. The PR stays a draft until those outputs replace the placeholders; a template-only report must never merge.

## Test plan

- `pnpm vitest run tools/composition-probe` — all kit unit tests green.
- `pnpm probe:composition --dry-run` — the offline self-test passes (including the deliberate needle-break failure proof).
- `pnpm check` — aggregator green (types, lints, trademark and fixture-privacy gates over the committed synthetic content).
- `git diff --name-only origin/desktop...HEAD` — only `tools/composition-probe/**`, `probes/composition-smoke/**`, and the single `package.json` script line; nothing under `packages/`, no lockfile, no CI.

All committed data is 100% synthetic (fabricated athlete context, synthetic ids, pre-2015 dates). CI never runs the probe.
