### PR TITLE
feat(core): persist compaction summaries into the day's note

### DIFF
--- a/.changeset/compaction-summary-durability.md
+++ b/.changeset/compaction-summary-durability.md
@@ -1,0 +1,5 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Conversation summaries created during long sessions are now saved into the coach's dated memory notes, so they survive session resets and stay searchable later.

--- a/packages/core/CONTEXT.md
+++ b/packages/core/CONTEXT.md
@@ -38,6 +38,9 @@ The persistent compaction path. At session load, when history exceeds the token 
 **In-Turn Compaction**:
 The ephemeral compaction path (`summarizeInStages`). Reshapes only the in-memory message array, from three sites in the chat loop (preemptive over-budget, context-overflow recovery, timeout recovery); the session JSONL keeps the full history and the reshaped array is discarded at end of turn.
 
+**Compaction Summary Durability**:
+Every freshly generated compaction summary (all four sites: trim, preemptive, overflow recovery, timeout recovery) is also mirrored into the day's note under the fixed marker `### Compaction summary`, heading-demoted, with an exact-block duplicate-skip. This makes the summary recoverable via `memory_read` after a session reset destroys the live JSONL and its archives.
+
 **CoreDeps**:
 The runtime services Core supplies to a Sport's tool factory: `LLM`, `IntervalsClient`, `MemoryStore`, `SecretsResolver`.
 

--- a/packages/core/src/agent/coach-agent.ts
+++ b/packages/core/src/agent/coach-agent.ts
@@ -18,6 +18,7 @@ import {
   type LatestJson,
 } from "../reference/index.js";
 import { Memory } from "../memory/store.js";
+import { persistCompactionSummary } from "../memory/compaction-note.js";
 import { ChatStore } from "./chat-store.js";
 import { buildSystemPrompt, staticRuleBlocks } from "./system-prompt.js";
 import { computeAssembledHash, computeTemplateHash, sha256_16 } from "./prompt-lineage.js";
@@ -463,6 +464,14 @@ export class CoachAgent {
     };
   }
 
+  private persistSummaryToDailyNote(summary: string): void {
+    try {
+      persistCompactionSummary(this.memory, summary);
+    } catch (err) {
+      this.log.warn("Failed to persist compaction summary to daily note", err);
+    }
+  }
+
   private emitTurnOutcome(outcome: TurnOutcome): void {
     // An observability write must never break a turn: a failed outcome emit is
     // swallowed exactly like the usage-ledger and substrate writes.
@@ -588,6 +597,7 @@ export class CoachAgent {
             ...this.compactionParams(turnBudget),
           });
           compactions++;
+          this.persistSummaryToDailyNote(summary);
           summaryMsg = makeSummaryMessage(summary);
           requeued = unsummarized;
           if (flushed) {
@@ -697,7 +707,9 @@ export class CoachAgent {
                 this.log.warn("In-turn memory flush failed; compacting without flush", err);
               }
             }
-            messages = await summarizeInStages({ messages, ...this.compactionParams(turnBudget) });
+            const compacted = await summarizeInStages({ messages, ...this.compactionParams(turnBudget) });
+            messages = compacted.messages;
+            if (compacted.summary) this.persistSummaryToDailyNote(compacted.summary);
             compactions++;
             this.memory.reload();
             this.usageAnchor.delete(chatId);
@@ -862,7 +874,9 @@ export class CoachAgent {
                     this.log.warn("In-turn memory flush failed; compacting without flush", flushErr);
                   }
                 }
-                messages = await summarizeInStages({ messages, ...this.compactionParams(turnBudget) });
+                const compacted = await summarizeInStages({ messages, ...this.compactionParams(turnBudget) });
+                messages = compacted.messages;
+                if (compacted.summary) this.persistSummaryToDailyNote(compacted.summary);
                 compactions++;
                 this.memory.reload();
                 this.usageAnchor.delete(chatId);
@@ -881,7 +895,9 @@ export class CoachAgent {
               if (ratio > TIMEOUT_COMPACTION_THRESHOLD) {
                 timeoutAttempts++;
                 try {
-                  messages = await summarizeInStages({ messages, ...this.compactionParams(turnBudget) });
+                  const compacted = await summarizeInStages({ messages, ...this.compactionParams(turnBudget) });
+                  messages = compacted.messages;
+                  if (compacted.summary) this.persistSummaryToDailyNote(compacted.summary);
                   compactions++;
                   this.memory.reload();
                   this.usageAnchor.delete(chatId);

--- a/packages/core/src/agent/coach-agent.ts
+++ b/packages/core/src/agent/coach-agent.ts
@@ -673,6 +673,15 @@ export class CoachAgent {
       let rateLimitAttempts = 0;
       let serverErrorAttempts = 0;
 
+      const compactInTurn = async () => {
+        const compacted = await summarizeInStages({ messages, ...this.compactionParams(turnBudget) });
+        messages = compacted.messages;
+        if (compacted.summary) this.persistSummaryToDailyNote(compacted.summary);
+        compactions++;
+        this.memory.reload();
+        this.usageAnchor.delete(chatId);
+      };
+
       // Loop-invariant: the prompt cache key derives only from the chat id.
       const cacheKey = sha256_16(chatId);
 
@@ -707,12 +716,7 @@ export class CoachAgent {
                 this.log.warn("In-turn memory flush failed; compacting without flush", err);
               }
             }
-            const compacted = await summarizeInStages({ messages, ...this.compactionParams(turnBudget) });
-            messages = compacted.messages;
-            if (compacted.summary) this.persistSummaryToDailyNote(compacted.summary);
-            compactions++;
-            this.memory.reload();
-            this.usageAnchor.delete(chatId);
+            await compactInTurn();
           }
 
           try {
@@ -874,12 +878,7 @@ export class CoachAgent {
                     this.log.warn("In-turn memory flush failed; compacting without flush", flushErr);
                   }
                 }
-                const compacted = await summarizeInStages({ messages, ...this.compactionParams(turnBudget) });
-                messages = compacted.messages;
-                if (compacted.summary) this.persistSummaryToDailyNote(compacted.summary);
-                compactions++;
-                this.memory.reload();
-                this.usageAnchor.delete(chatId);
+                await compactInTurn();
               } catch (rescueErr) {
                 this.log.warn("Compaction rescue failed; rethrowing the original turn error", rescueErr);
                 if (err instanceof Error && err.cause === undefined) {
@@ -895,12 +894,7 @@ export class CoachAgent {
               if (ratio > TIMEOUT_COMPACTION_THRESHOLD) {
                 timeoutAttempts++;
                 try {
-                  const compacted = await summarizeInStages({ messages, ...this.compactionParams(turnBudget) });
-                  messages = compacted.messages;
-                  if (compacted.summary) this.persistSummaryToDailyNote(compacted.summary);
-                  compactions++;
-                  this.memory.reload();
-                  this.usageAnchor.delete(chatId);
+                  await compactInTurn();
                 } catch (rescueErr) {
                   this.log.warn("Compaction rescue failed; rethrowing the original turn error", rescueErr);
                   if (err instanceof Error && err.cause === undefined) {

--- a/packages/core/src/agent/compaction.ts
+++ b/packages/core/src/agent/compaction.ts
@@ -336,7 +336,7 @@ export async function summarizeInStages(params: {
   contextWindowTokens?: number;
   caller?: GenerateOpts["caller"];
   budget?: ModelCallCharger;
-}): Promise<ModelMessage[]> {
+}): Promise<{ messages: ModelMessage[]; summary?: string }> {
   const { llm, mustPreserveTokens, memory, recentToKeep = 4, contextWindowTokens, caller, budget } = params;
 
   let messages = params.messages;
@@ -358,7 +358,7 @@ export async function summarizeInStages(params: {
   const recent = messages.slice(messages.length - keepCount);
 
   if (toSummarize.length === 0) {
-    return params.messages;
+    return { messages: params.messages };
   }
 
   const tokens = resolveTokens(mustPreserveTokens, memory);
@@ -391,7 +391,7 @@ export async function summarizeInStages(params: {
 
   if (summary === undefined) {
     console.warn("Staged summarization produced no summary; dropping oldest messages without one");
-    return [...recent];
+    return { messages: [...recent] };
   }
 
   const finalSummary = await finalizeSummary({
@@ -402,5 +402,5 @@ export async function summarizeInStages(params: {
     caller,
     budget,
   });
-  return [makeSummaryMessage(finalSummary), ...recent];
+  return { messages: [makeSummaryMessage(finalSummary), ...recent], summary: finalSummary };
 }

--- a/packages/core/src/memory/compaction-note.ts
+++ b/packages/core/src/memory/compaction-note.ts
@@ -11,12 +11,9 @@ export function formatCompactionNote(summary: string): string {
 }
 
 export function persistCompactionSummary(
-  memory: Pick<MemoryStore, "appendDailyNote" | "readDailyNotes">,
+  memory: Pick<MemoryStore, "appendDailyNote">,
   summary: string,
-): boolean {
-  if (summary.trim() === "") return false;
-  const block = formatCompactionNote(summary);
-  if (memory.readDailyNotes().includes(block)) return false;
-  memory.appendDailyNote(block);
-  return true;
+): void {
+  if (summary.trim() === "") return;
+  memory.appendDailyNote(formatCompactionNote(summary));
 }

--- a/packages/core/src/memory/compaction-note.ts
+++ b/packages/core/src/memory/compaction-note.ts
@@ -1,0 +1,22 @@
+import type { MemoryStore } from "../memory.js";
+
+export const COMPACTION_SUMMARY_MARKER = "### Compaction summary";
+
+export function demoteSummaryHeadings(summary: string): string {
+  return summary.replace(/^## (?!#)/gm, "#### ");
+}
+
+export function formatCompactionNote(summary: string): string {
+  return `${COMPACTION_SUMMARY_MARKER}\n\n${demoteSummaryHeadings(summary)}`;
+}
+
+export function persistCompactionSummary(
+  memory: Pick<MemoryStore, "appendDailyNote" | "readDailyNotes">,
+  summary: string,
+): boolean {
+  if (summary.trim() === "") return false;
+  const block = formatCompactionNote(summary);
+  if (memory.readDailyNotes().includes(block)) return false;
+  memory.appendDailyNote(block);
+  return true;
+}

--- a/packages/core/tests/coach-agent-summary-durability.test.ts
+++ b/packages/core/tests/coach-agent-summary-durability.test.ts
@@ -167,7 +167,7 @@ describe("compaction summary durability into daily notes", () => {
     expect(markerCount(note)).toBe(1);
   });
 
-  it("AC4: a persisted summary survives a session reset and is found via the dated read path", async () => {
+  it("a persisted summary survives a session reset and is found via the dated read path", async () => {
     let n = 0;
     const complete = vi.fn(async () => {
       n++;
@@ -189,7 +189,7 @@ describe("compaction summary durability into daily notes", () => {
     expect(recovered[0].text).toContain("#### Coach Stance");
   });
 
-  it("AC5: a daily-note write failure is swallowed and never fails the turn", async () => {
+  it("a daily-note write failure is swallowed and never fails the turn", async () => {
     let n = 0;
     const complete = vi.fn(async () => {
       n++;

--- a/packages/core/tests/coach-agent-summary-durability.test.ts
+++ b/packages/core/tests/coach-agent-summary-durability.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readdirSync } from "node:fs";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readdirSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { baseAgentConfig } from "./helpers/base-agent-config.js";
@@ -209,5 +209,7 @@ describe("compaction summary durability into daily notes", () => {
 
     expect(text).toBe("final-reply");
     expect(agent.getMemory().readDailyNotes()).not.toContain(COMPACTION_SUMMARY_MARKER);
+    const logged = readFileSync(join(dataDir, "logs", "log.jsonl"), "utf-8");
+    expect(logged).toContain("Failed to persist compaction summary to daily note");
   });
 });

--- a/packages/core/tests/coach-agent-summary-durability.test.ts
+++ b/packages/core/tests/coach-agent-summary-durability.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { baseAgentConfig } from "./helpers/base-agent-config.js";
+import { cyclingSport } from "@enduragent/sport-cycling";
+import { COMPACTION_SUMMARY_MARKER } from "../src/memory/compaction-note.js";
+import type { Sport } from "../src/sport.js";
+
+let tempHome: string;
+let origHome: string | undefined;
+let dataDir: string;
+
+beforeEach(() => {
+  tempHome = mkdtempSync(join(tmpdir(), "cc-summary-durability-"));
+  origHome = process.env.HOME;
+  process.env.HOME = tempHome;
+  dataDir = join(tempHome, ".cycling-coach");
+  mkdirSync(dataDir, { recursive: true });
+  mkdirSync(join(dataDir, "memory"), { recursive: true });
+  vi.resetModules();
+});
+
+afterEach(() => {
+  process.env.HOME = origHome;
+  rmSync(tempHome, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+async function setupAgent(complete: ReturnType<typeof vi.fn>) {
+  vi.doMock("../src/agent/codex/responses.js", () => ({
+    codexResponses: complete,
+  }));
+  vi.doMock("../src/agent/codex/oauth.js", () => ({
+    refreshCodexToken: vi.fn(),
+    loginCodex: vi.fn(),
+  }));
+  vi.doMock("../src/auth/profiles.js", () => ({
+    getFreshToken: vi.fn(async () => "token"),
+    loadProfile: vi.fn(),
+    saveProfile: vi.fn(),
+    RefreshTokenReusedError: class extends Error {},
+  }));
+
+  const { CoachAgent } = await import("../src/agent/coach-agent.js");
+  return new CoachAgent(cyclingSport as unknown as Sport, {
+    ...baseAgentConfig(dataDir),
+    contextWindowTokens: 120_000,
+  });
+}
+
+function mkAssistant(text: string, stopReason: "stop" | "length" = "stop") {
+  return {
+    text,
+    toolCalls: [],
+    usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0 },
+    stopReason,
+  };
+}
+
+function seedSession(chatId: string, lines: Array<{ role: string; content: string; ts: string }>) {
+  const sessionsDir = join(dataDir, "sessions");
+  mkdirSync(sessionsDir, { recursive: true });
+  writeFileSync(
+    join(sessionsDir, `${chatId}.jsonl`),
+    lines.map((l) => JSON.stringify(l)).join("\n") + "\n",
+    "utf-8",
+  );
+}
+
+const FIVE_SECTION_SUMMARY = [
+  "## Athlete Profile",
+  "- FTP 247W, 72kg",
+  "## Training Status",
+  "- Build phase",
+  "## Coach Stance",
+  "- Hold volume this week",
+  "## Discussion Context",
+  "- Goal review",
+  "## Pending Questions",
+  "- None outstanding",
+].join("\n");
+
+const FRESH_TS = new Date().toISOString();
+const bigHistory = Array.from({ length: 30 }, (_, i) => ({
+  role: i % 2 === 0 ? "user" : "assistant",
+  content: `MARK-${i} ` + "x".repeat(2_400),
+  ts: FRESH_TS,
+}));
+
+const smallHistory = Array.from({ length: 4 }, (_, i) => ({
+  role: i % 2 === 0 ? "user" : "assistant",
+  content: `hi-${i}`,
+  ts: FRESH_TS,
+}));
+
+function markerCount(note: string): number {
+  return note.split(COMPACTION_SUMMARY_MARKER).length - 1;
+}
+
+function dateKeyForToday(): string {
+  const files = readdirSync(join(dataDir, "memory")).filter((f) => /^\d{4}-\d{2}-\d{2}\.md$/.test(f));
+  expect(files).toHaveLength(1);
+  return files[0].replace(/\.md$/, "");
+}
+
+describe("compaction summary durability into daily notes", () => {
+  it("site 1 (trim path): the dropped-message summary lands in the day's note, heading-demoted", async () => {
+    let n = 0;
+    const complete = vi.fn(async () => {
+      n++;
+      if (n === 1) return mkAssistant("facts noted");
+      if (n === 2) return mkAssistant(FIVE_SECTION_SUMMARY);
+      return mkAssistant("final-reply");
+    });
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const agent = await setupAgent(complete);
+    seedSession("trim", bigHistory);
+
+    const text = await agent.chat("trim", "hello");
+
+    expect(text).toBe("final-reply");
+    const note = agent.getMemory().readDailyNotes();
+    expect(note).toContain(COMPACTION_SUMMARY_MARKER);
+    expect(note).toContain("#### Coach Stance");
+    expect(note).not.toMatch(/^## Coach Stance/m);
+  });
+
+  it("site 3 (overflow rescue): the rescue summary persists and the turn still replies", async () => {
+    let n = 0;
+    const complete = vi.fn(async () => {
+      n++;
+      if (n === 1) {
+        throw new Error("Request exceeds the maximum context length of 272000 tokens");
+      }
+      if (n === 3) return mkAssistant(FIVE_SECTION_SUMMARY);
+      return mkAssistant("final-reply");
+    });
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const agent = await setupAgent(complete);
+    seedSession("overflow", smallHistory);
+
+    const text = await agent.chat("overflow", "hello");
+
+    expect(text).toBe("final-reply");
+    const note = agent.getMemory().readDailyNotes();
+    expect(note).toContain(COMPACTION_SUMMARY_MARKER);
+    expect(note).toContain("#### Coach Stance");
+  });
+
+  it("duplicate-skip: two compactions with identical summary text produce exactly one block", async () => {
+    let n = 0;
+    const complete = vi.fn(async () => {
+      n++;
+      if (n === 2 || n === 5) return mkAssistant(FIVE_SECTION_SUMMARY);
+      return mkAssistant("final-reply");
+    });
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const agent = await setupAgent(complete);
+
+    seedSession("dup", bigHistory);
+    await agent.chat("dup", "first");
+    seedSession("dup", bigHistory);
+    await agent.chat("dup", "second");
+
+    const note = agent.getMemory().readDailyNotes();
+    expect(markerCount(note)).toBe(1);
+  });
+
+  it("AC4: a persisted summary survives a session reset and is found via the dated read path", async () => {
+    let n = 0;
+    const complete = vi.fn(async () => {
+      n++;
+      if (n === 2) return mkAssistant(FIVE_SECTION_SUMMARY);
+      return mkAssistant("final-reply");
+    });
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const agent = await setupAgent(complete);
+    seedSession("reset", bigHistory);
+
+    await agent.chat("reset", "hello");
+    const dateKey = dateKeyForToday();
+
+    await agent.resetSession("reset");
+
+    const recovered = agent.getMemory().readDailyNotesInRange(dateKey, dateKey);
+    expect(recovered).toHaveLength(1);
+    expect(recovered[0].text).toContain(COMPACTION_SUMMARY_MARKER);
+    expect(recovered[0].text).toContain("#### Coach Stance");
+  });
+
+  it("AC5: a daily-note write failure is swallowed and never fails the turn", async () => {
+    let n = 0;
+    const complete = vi.fn(async () => {
+      n++;
+      if (n === 1) return mkAssistant("facts noted");
+      if (n === 2) return mkAssistant(FIVE_SECTION_SUMMARY);
+      return mkAssistant("final-reply");
+    });
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { Memory } = await import("../src/memory/store.js");
+    vi.spyOn(Memory.prototype, "appendDailyNote").mockImplementation(() => {
+      throw new Error("disk full");
+    });
+    const agent = await setupAgent(complete);
+    seedSession("ac5", bigHistory);
+
+    const text = await agent.chat("ac5", "hello");
+
+    expect(text).toBe("final-reply");
+    expect(agent.getMemory().readDailyNotes()).not.toContain(COMPACTION_SUMMARY_MARKER);
+  });
+});

--- a/packages/core/tests/compaction-note.test.ts
+++ b/packages/core/tests/compaction-note.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  COMPACTION_SUMMARY_MARKER,
+  demoteSummaryHeadings,
+  formatCompactionNote,
+  persistCompactionSummary,
+} from "../src/memory/compaction-note.js";
+
+const FIVE_SECTION_SUMMARY = [
+  "## Athlete Profile",
+  "- FTP 247W, 72kg",
+  "## Training Status",
+  "- Build phase",
+  "## Coach Stance",
+  "- Hold volume this week",
+  "## Discussion Context",
+  "- Goal review",
+  "## Pending Questions",
+  "- None outstanding",
+].join("\n");
+
+function stubMemory() {
+  let note = "";
+  return {
+    readDailyNotes: () => note,
+    appendDailyNote: (n: string) => {
+      note = note ? `${note}\n${n}` : n;
+    },
+    get: () => note,
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("demoteSummaryHeadings", () => {
+  it("demotes each of the five real section headings from H2 to H4", () => {
+    const out = demoteSummaryHeadings(FIVE_SECTION_SUMMARY);
+    expect(out).toContain("#### Athlete Profile");
+    expect(out).toContain("#### Training Status");
+    expect(out).toContain("#### Coach Stance");
+    expect(out).toContain("#### Discussion Context");
+    expect(out).toContain("#### Pending Questions");
+    expect(out).not.toMatch(/^## Athlete Profile/m);
+  });
+
+  it("leaves H3 and H4 lines untouched", () => {
+    const body = "### Already H3\n#### Already H4\n- bullet";
+    expect(demoteSummaryHeadings(body)).toBe(body);
+  });
+
+  it("leaves mid-line ## untouched", () => {
+    const body = "- a value like ## in prose stays";
+    expect(demoteSummaryHeadings(body)).toBe(body);
+  });
+});
+
+describe("formatCompactionNote", () => {
+  it("starts with the exact marker constant followed by a blank line", () => {
+    const block = formatCompactionNote(FIVE_SECTION_SUMMARY);
+    expect(block.startsWith(`${COMPACTION_SUMMARY_MARKER}\n\n`)).toBe(true);
+    expect(block).toContain("#### Athlete Profile");
+  });
+});
+
+describe("persistCompactionSummary", () => {
+  it("writes on first call and returns true", () => {
+    const mem = stubMemory();
+    expect(persistCompactionSummary(mem, FIVE_SECTION_SUMMARY)).toBe(true);
+    expect(mem.get()).toContain(COMPACTION_SUMMARY_MARKER);
+    expect(mem.get()).toContain("#### Coach Stance");
+  });
+
+  it("skips an identical summary on the same day and returns false", () => {
+    const mem = stubMemory();
+    persistCompactionSummary(mem, FIVE_SECTION_SUMMARY);
+    const before = mem.get();
+    expect(persistCompactionSummary(mem, FIVE_SECTION_SUMMARY)).toBe(false);
+    expect(mem.get()).toBe(before);
+    expect(mem.get().split(COMPACTION_SUMMARY_MARKER).length - 1).toBe(1);
+  });
+
+  it("appends a distinct summary as a second block", () => {
+    const mem = stubMemory();
+    persistCompactionSummary(mem, FIVE_SECTION_SUMMARY);
+    expect(persistCompactionSummary(mem, "## Athlete Profile\n- FTP now 260W")).toBe(true);
+    expect(mem.get().split(COMPACTION_SUMMARY_MARKER).length - 1).toBe(2);
+  });
+
+  it("writes nothing for an empty or whitespace-only summary", () => {
+    const mem = stubMemory();
+    expect(persistCompactionSummary(mem, "")).toBe(false);
+    expect(persistCompactionSummary(mem, "   \n  ")).toBe(false);
+    expect(mem.get()).toBe("");
+  });
+
+  it("dedupes correctly even when the body itself contains the marker line", () => {
+    const mem = stubMemory();
+    const withMarker = `## Athlete Profile\n- note mentioning ${COMPACTION_SUMMARY_MARKER} inline`;
+    expect(persistCompactionSummary(mem, withMarker)).toBe(true);
+    expect(persistCompactionSummary(mem, withMarker)).toBe(false);
+  });
+
+  it("demotes an adversarial H2 heading so it cannot masquerade as a memory section", () => {
+    const mem = stubMemory();
+    const adversarial = "## Today's Notes\n- injected\n## person\n- injected";
+    persistCompactionSummary(mem, adversarial);
+    expect(mem.get()).toContain("#### Today's Notes");
+    expect(mem.get()).toContain("#### person");
+    expect(mem.get()).not.toMatch(/^## Today's Notes/m);
+    expect(mem.get()).not.toMatch(/^## person/m);
+  });
+});

--- a/packages/core/tests/compaction-note.test.ts
+++ b/packages/core/tests/compaction-note.test.ts
@@ -22,7 +22,6 @@ const FIVE_SECTION_SUMMARY = [
 function stubMemory() {
   let note = "";
   return {
-    readDailyNotes: () => note,
     appendDailyNote: (n: string) => {
       note = note ? `${note}\n${n}` : n;
     },
@@ -65,41 +64,25 @@ describe("formatCompactionNote", () => {
 });
 
 describe("persistCompactionSummary", () => {
-  it("writes on first call and returns true", () => {
-    const mem = stubMemory();
-    expect(persistCompactionSummary(mem, FIVE_SECTION_SUMMARY)).toBe(true);
-    expect(mem.get()).toContain(COMPACTION_SUMMARY_MARKER);
-    expect(mem.get()).toContain("#### Coach Stance");
-  });
-
-  it("skips an identical summary on the same day and returns false", () => {
+  it("writes the marker block with demoted headings", () => {
     const mem = stubMemory();
     persistCompactionSummary(mem, FIVE_SECTION_SUMMARY);
-    const before = mem.get();
-    expect(persistCompactionSummary(mem, FIVE_SECTION_SUMMARY)).toBe(false);
-    expect(mem.get()).toBe(before);
-    expect(mem.get().split(COMPACTION_SUMMARY_MARKER).length - 1).toBe(1);
+    expect(mem.get()).toContain(COMPACTION_SUMMARY_MARKER);
+    expect(mem.get()).toContain("#### Coach Stance");
   });
 
   it("appends a distinct summary as a second block", () => {
     const mem = stubMemory();
     persistCompactionSummary(mem, FIVE_SECTION_SUMMARY);
-    expect(persistCompactionSummary(mem, "## Athlete Profile\n- FTP now 260W")).toBe(true);
+    persistCompactionSummary(mem, "## Athlete Profile\n- FTP now 260W");
     expect(mem.get().split(COMPACTION_SUMMARY_MARKER).length - 1).toBe(2);
   });
 
   it("writes nothing for an empty or whitespace-only summary", () => {
     const mem = stubMemory();
-    expect(persistCompactionSummary(mem, "")).toBe(false);
-    expect(persistCompactionSummary(mem, "   \n  ")).toBe(false);
+    persistCompactionSummary(mem, "");
+    persistCompactionSummary(mem, "   \n  ");
     expect(mem.get()).toBe("");
-  });
-
-  it("dedupes correctly even when the body itself contains the marker line", () => {
-    const mem = stubMemory();
-    const withMarker = `## Athlete Profile\n- note mentioning ${COMPACTION_SUMMARY_MARKER} inline`;
-    expect(persistCompactionSummary(mem, withMarker)).toBe(true);
-    expect(persistCompactionSummary(mem, withMarker)).toBe(false);
   });
 
   it("demotes an adversarial H2 heading so it cannot masquerade as a memory section", () => {

--- a/packages/core/tests/compaction-substrate.test.ts
+++ b/packages/core/tests/compaction-substrate.test.ts
@@ -168,8 +168,9 @@ describe("coach-stance round-trip (mechanical path)", () => {
 
     expect(llm.capturedPrompts).toHaveLength(1);
     expect(llm.capturedPrompts[0]).toContain(STANCE_FACT);
-    expect(result).toHaveLength(3);
-    expect(result[0].role).toBe("system");
-    expect(String(result[0].content)).toContain(STANCE_FACT);
+    expect(result.messages).toHaveLength(3);
+    expect(result.messages[0].role).toBe("system");
+    expect(String(result.messages[0].content)).toContain(STANCE_FACT);
+    expect(result.summary).toContain(STANCE_FACT);
   });
 });

--- a/packages/core/tests/compaction.test.ts
+++ b/packages/core/tests/compaction.test.ts
@@ -240,9 +240,10 @@ describe("shared audit post-step (cap-before-audit)", () => {
     for (const opts of spy.capturedOpts) {
       expect(opts.maxOutputTokens).toBe(1000);
     }
-    expect(result[0].content).toContain("## Coach Stance");
-    expect(result[0].content).toContain("## Pending Questions");
-    expect(result).toHaveLength(3);
+    expect(result.messages[0].content).toContain("## Coach Stance");
+    expect(result.messages[0].content).toContain("## Pending Questions");
+    expect(result.messages).toHaveLength(3);
+    expect(result.summary).toContain("## Coach Stance");
   });
 
   it("staged summarization that stays sectionless degrades to the capped text instead of throwing", async () => {
@@ -257,8 +258,9 @@ describe("shared audit post-step (cap-before-audit)", () => {
     });
 
     expect(spy.capturedPrompts).toHaveLength(2);
-    expect(result[0].content).toContain("still no sections");
-    expect(result).toHaveLength(3);
+    expect(result.messages[0].content).toContain("still no sections");
+    expect(result.messages).toHaveLength(3);
+    expect(result.summary).toContain("still no sections");
   });
 
   it("audits the capped text, not the pre-cap text: tail-amputated sections trigger the retry", async () => {

--- a/packages/core/tests/summarize-stages-guards.test.ts
+++ b/packages/core/tests/summarize-stages-guards.test.ts
@@ -63,10 +63,10 @@ describe("summarizeInStages guards", () => {
     await vi.advanceTimersByTimeAsync(120_000);
     const result = await p;
 
-    expect(result[0].role).toBe("system");
-    expect(String(result[0].content)).toContain("FTP 247W");
-    expect(String(result[0].content)).toContain("## Coach Stance");
-    expect(result.length).toBe(5);
+    expect(result.messages[0].role).toBe("system");
+    expect(String(result.messages[0].content)).toContain("FTP 247W");
+    expect(String(result.messages[0].content)).toContain("## Coach Stance");
+    expect(result.messages.length).toBe(5);
 
     const chunkWarn = warnSpy.mock.calls.find(
       (call) => typeof call[0] === "string" && call[0].includes("Staged summarization chunk failed"),
@@ -87,8 +87,8 @@ describe("summarizeInStages guards", () => {
       previousSummary: VALID_FIVE_SECTION_SUMMARY,
     });
 
-    expect(result[0].role).toBe("system");
-    expect(String(result[0].content)).toContain("FTP 247W");
+    expect(result.messages[0].role).toBe("system");
+    expect(String(result.messages[0].content)).toContain("FTP 247W");
     expect(spy.capturedPrompts.length).toBe(1);
 
     const chunkWarn = warnSpy.mock.calls.find(
@@ -108,8 +108,9 @@ describe("summarizeInStages guards", () => {
       memory: EMPTY_SNAPSHOT,
     });
 
-    expect(result).toEqual(REPRESENTATIVE_CONVERSATION.slice(-4));
-    for (const msg of result) {
+    expect(result.messages).toEqual(REPRESENTATIVE_CONVERSATION.slice(-4));
+    expect(result.summary).toBeUndefined();
+    for (const msg of result.messages) {
       expect(String(msg.content).startsWith(SUMMARY_PREFIX)).toBe(false);
     }
 
@@ -134,9 +135,9 @@ describe("summarizeInStages guards", () => {
     });
 
     expect(spy.capturedPrompts.length).toBe(2);
-    expect(result[0].role).toBe("system");
-    expect(String(result[0].content)).toContain("## Coach Stance");
-    expect(String(result[0].content)).toContain("FTP 247W");
+    expect(result.messages[0].role).toBe("system");
+    expect(String(result.messages[0].content)).toContain("## Coach Stance");
+    expect(String(result.messages[0].content)).toContain("FTP 247W");
 
     const chunkWarns = warnSpy.mock.calls.filter(
       (call) => typeof call[0] === "string" && call[0].includes("Staged summarization chunk failed"),
@@ -155,9 +156,10 @@ describe("summarizeInStages guards", () => {
       memory: EMPTY_SNAPSHOT,
     });
 
-    expect(result[0].role).toBe("system");
-    expect(String(result[0].content)).toContain("## Athlete Profile");
-    expect(result.length).toBe(5);
+    expect(result.messages[0].role).toBe("system");
+    expect(String(result.messages[0].content)).toContain("## Athlete Profile");
+    expect(result.messages.length).toBe(5);
+    expect(result.summary).toContain("## Athlete Profile");
 
     const guardWarn = warnSpy.mock.calls.find(
       (call) =>

--- a/packages/core/tests/summarize-stages-guards.test.ts
+++ b/packages/core/tests/summarize-stages-guards.test.ts
@@ -120,6 +120,22 @@ describe("summarizeInStages guards", () => {
     expect(dropWarn).toBeDefined();
   });
 
+  it("returns the input unchanged with no summary when there is nothing to summarize", async () => {
+    const spy = createFakeLLM([]);
+    const short = REPRESENTATIVE_CONVERSATION.slice(-3);
+
+    const result = await summarizeInStages({
+      messages: short,
+      llm: spy,
+      mustPreserveTokens: CYCLING_VOCABULARY,
+      memory: EMPTY_SNAPSHOT,
+    });
+
+    expect(result.messages).toEqual(short);
+    expect(result.summary).toBeUndefined();
+    expect(spy.capturedPrompts.length).toBe(0);
+  });
+
   it("carries the last successful chunk summary across a failed chunk", async () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const spy = createFakeLLM([VALID_FIVE_SECTION_SUMMARY, { error: new Error("boom") }]);


### PR DESCRIPTION
Compaction summaries are expensive multi-call LLM output that previously lived only inside the live session JSONL. A session reset archives that file into paths no code ever reads, and archive retention eventually prunes them — so athlete-profile deltas, coach stance, and pending questions captured in a summary were lost after the daily reset. This PR gives every compaction summary a durable home in the day's memory note, recoverable through the dated `memory_read` path.

## What changed

- `summarizeInStages` now returns `{ messages, summary? }`, with `summary` set only when a fresh summary was actually generated. Call sites no longer need to sniff the messages array, and the two summary-less return paths (nothing to summarize; total chunk failure) leave `summary` undefined.
- New pure module `packages/core/src/memory/compaction-note.ts`: a fixed marker constant (`### Compaction summary`), heading demotion (`## ` at line starts becomes `#### ` so a summary body can never masquerade as a top-level memory section in the daily-note render), block formatting, and `persistCompactionSummary` with an exact-block duplicate-skip so re-running the same compaction never appends twice.
- `CoachAgent` persists the fresh summary at all four compaction sites — session-start history trim, preemptive compaction, overflow rescue, and timeout rescue — through a private helper whose try/catch guarantees a note-write failure (full disk, permissions) only logs a warning and never fails the compaction or the turn. The trim site persists even when the pre-compaction flush failed, since the summary was already generated and used. Carried previous summaries are not re-persisted; only fresh output is.
- The messages array each site feeds back into the loop is unchanged — persistence is a side channel only. The event ledger is untouched; the daily note is the durable surface.
- One-line `packages/core/CONTEXT.md` addition documenting the mirror-into-daily-note behavior, plus a patch changeset with a `User-facing:` line.

## Test plan

- New `packages/core/tests/compaction-note.test.ts` — unit coverage for heading demotion (all five real section headings, `###`/`####` and mid-line `##` left alone), marker formatting, and duplicate-skip semantics (identical summary skips, distinct summary appends, empty/whitespace writes nothing, a body containing the marker line still dedupes).
- New `packages/core/tests/coach-agent-summary-durability.test.ts` — integration through `CoachAgent` with a stub LLM: trim-path persistence, overflow-rescue persistence with the turn still replying, end-to-end duplicate-skip across two identical compactions, reset survival (summary readable via the dated read path after `archiveAndReset` destroys the live JSONL), and a throwing `appendDailyNote` completing the turn with only a warning.
- Updated existing compaction tests for the new return shape, including assertions that only the fresh-summary path sets `summary`.
- Verified locally: `pnpm vitest run packages/core/tests/coach-agent-summary-durability.test.ts packages/core/tests/compaction-note.test.ts packages/core/tests/compaction.test.ts` and `pnpm check` both green.
