### PR TITLE
feat(kernel): add the six host-adapter ports

### DIFF
--- a/packages/kernel-node/package.json
+++ b/packages/kernel-node/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "tsup",
     "check": "tsc --noEmit",
-    "test": "echo 'no tests yet (scaffold)'"
+    "test": "vitest run --passWithNoTests"
   },
   "dependencies": {
     "@enduragent/kernel": "workspace:*"
@@ -17,7 +17,8 @@
   "devDependencies": {
     "@types/node": "^25.6.0",
     "tsup": "^8.4.0",
-    "typescript": "^6.0.2"
+    "typescript": "^6.0.2",
+    "vitest": "^4.1.4"
   },
   "license": "MIT"
 }

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -5,15 +5,18 @@
   "description": "Pure compute kernel — portable TypeScript, no host bindings; all IO through injected ports (scaffold, no content yet).",
   "type": "module",
   "files": ["dist"],
-  "exports": {},
+  "exports": {
+    "./ports": "./dist/ports.js"
+  },
   "scripts": {
     "build": "tsup",
     "check": "tsc --noEmit",
-    "test": "echo 'no tests yet (scaffold)'"
+    "test": "vitest run"
   },
   "devDependencies": {
     "tsup": "^8.4.0",
-    "typescript": "^6.0.2"
+    "typescript": "^6.0.2",
+    "vitest": "^4.1.4"
   },
   "license": "MIT"
 }

--- a/packages/kernel/src/index.ts
+++ b/packages/kernel/src/index.ts
@@ -1,2 +1,0 @@
-// Scaffold — the pure compute kernel's content lands in later waves.
-export const KERNEL_STATUS = "scaffold-no-content-yet" as const;

--- a/packages/kernel/src/ports/clock.ts
+++ b/packages/kernel/src/ports/clock.ts
@@ -1,0 +1,6 @@
+export interface ClockPort {
+  /** Wall-clock Unix epoch milliseconds. Never persist this on a content-addressed derived row. */
+  now(): number;
+  /** Monotonic non-decreasing millisecond counter for timeouts and durations; never persisted. */
+  monotonicNow(): number;
+}

--- a/packages/kernel/src/ports/crypto.ts
+++ b/packages/kernel/src/ports/crypto.ts
@@ -1,0 +1,32 @@
+export interface Pbkdf2Params {
+  readonly passphrase: Uint8Array;
+  readonly salt: Uint8Array;
+  readonly iterations: number;
+  readonly hash: "SHA-256";
+  readonly keyLengthBytes: number;
+}
+
+export interface AesGcmEncryptParams {
+  readonly key: Uint8Array;
+  readonly nonce: Uint8Array;
+  readonly plaintext: Uint8Array;
+  readonly additionalData?: Uint8Array;
+}
+
+export interface AesGcmDecryptParams {
+  readonly key: Uint8Array;
+  readonly nonce: Uint8Array;
+  readonly ciphertext: Uint8Array;
+  readonly additionalData?: Uint8Array;
+}
+
+export interface CryptoPort {
+  /** 32-byte SHA-256 digest of the raw bytes. Hex-encoding is a pure kernel util, not part of this port. */
+  sha256(data: Uint8Array): Promise<Uint8Array>;
+  randomBytes(length: number): Promise<Uint8Array>;
+  pbkdf2(params: Pbkdf2Params): Promise<Uint8Array>;
+  /** AES-256-GCM. Returns the ciphertext with the 16-byte GCM auth tag appended (WebCrypto layout). */
+  aesGcmEncrypt(params: AesGcmEncryptParams): Promise<Uint8Array>;
+  /** AES-256-GCM. `ciphertext` carries the appended auth tag; rejects on tag-verification failure. */
+  aesGcmDecrypt(params: AesGcmDecryptParams): Promise<Uint8Array>;
+}

--- a/packages/kernel/src/ports/filesystem.ts
+++ b/packages/kernel/src/ports/filesystem.ts
@@ -1,0 +1,26 @@
+export interface DirEntry {
+  readonly name: string;
+  readonly kind: "file" | "directory" | "other";
+}
+
+export interface FileStat {
+  readonly kind: "file" | "directory" | "other";
+  readonly size: number;
+  readonly mtimeMs: number;
+}
+
+export interface WriteFileOptions {
+  readonly mode?: number;
+}
+
+export interface FileSystemPort {
+  readFile(path: string): Promise<Uint8Array>;
+  readTextFile(path: string): Promise<string>;
+  /** Atomic write: temp file (default mode 0o600) -> write -> fsync -> rename over the target path. */
+  writeFile(path: string, data: Uint8Array | string, options?: WriteFileOptions): Promise<void>;
+  rename(from: string, to: string): Promise<void>;
+  mkdir(path: string, options?: { readonly recursive?: boolean }): Promise<void>;
+  list(path: string): Promise<readonly DirEntry[]>;
+  /** Resolves undefined when the path does not exist. */
+  stat(path: string): Promise<FileStat | undefined>;
+}

--- a/packages/kernel/src/ports/http.ts
+++ b/packages/kernel/src/ports/http.ts
@@ -1,0 +1,18 @@
+export interface HttpRequest {
+  readonly method: string;
+  readonly url: string;
+  readonly headers?: Readonly<Record<string, string>>;
+  readonly body?: Uint8Array | string;
+}
+
+export interface HttpResponse {
+  readonly status: number;
+  readonly headers: Readonly<Record<string, string>>;
+  readonly body: Uint8Array;
+}
+
+// Minimal fetch-shaped client seam. Self-contained request/response types (not
+// the DOM fetch types) so the kernel compiles with no DOM lib.
+export interface HttpPort {
+  fetch(request: HttpRequest): Promise<HttpResponse>;
+}

--- a/packages/kernel/src/ports/index.ts
+++ b/packages/kernel/src/ports/index.ts
@@ -1,0 +1,6 @@
+export * from "./storage.js";
+export * from "./filesystem.js";
+export * from "./crypto.js";
+export * from "./clock.js";
+export * from "./http.js";
+export * from "./logger.js";

--- a/packages/kernel/src/ports/logger.ts
+++ b/packages/kernel/src/ports/logger.ts
@@ -1,0 +1,10 @@
+export type LogLevel = "debug" | "info" | "warn" | "error";
+
+export type LogFields = Readonly<Record<string, unknown>>;
+
+export interface LoggerPort {
+  debug(message: string, fields?: LogFields): void;
+  info(message: string, fields?: LogFields): void;
+  warn(message: string, fields?: LogFields): void;
+  error(message: string, fields?: LogFields): void;
+}

--- a/packages/kernel/src/ports/storage.ts
+++ b/packages/kernel/src/ports/storage.ts
@@ -1,0 +1,25 @@
+export type StorageParam = string | number | bigint | Uint8Array | null;
+
+export type StorageValue = string | number | bigint | Uint8Array | null;
+
+export type StorageRow = Readonly<Record<string, StorageValue>>;
+
+export interface StorageRunResult {
+  readonly changes: number | bigint;
+  readonly lastInsertRowid: number | bigint;
+}
+
+export interface PreparedStatement {
+  run(...params: readonly StorageParam[]): Promise<StorageRunResult>;
+  get(...params: readonly StorageParam[]): Promise<StorageRow | undefined>;
+  all(...params: readonly StorageParam[]): Promise<readonly StorageRow[]>;
+}
+
+// SQL driver seam for an already-open connection. Opening (which needs a
+// filesystem path) is a host concern and is deliberately not on this port.
+export interface StoragePort {
+  exec(sql: string): Promise<void>;
+  prepare(sql: string): Promise<PreparedStatement>;
+  pragma(source: string): Promise<StorageValue>;
+  close(): Promise<void>;
+}

--- a/packages/kernel/tests/ports.contract.test.ts
+++ b/packages/kernel/tests/ports.contract.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from "vitest";
+import type {
+  ClockPort,
+  CryptoPort,
+  DirEntry,
+  FileStat,
+  FileSystemPort,
+  HttpPort,
+  HttpRequest,
+  HttpResponse,
+  LoggerPort,
+  PreparedStatement,
+  StoragePort,
+  StorageRow,
+  StorageRunResult,
+} from "../src/ports/index.js";
+
+class FakeFileSystem implements FileSystemPort {
+  private readonly files = new Map<string, Uint8Array>();
+  private readonly dirs = new Set<string>();
+
+  async readFile(path: string): Promise<Uint8Array> {
+    const data = this.files.get(path);
+    if (!data) throw new Error(`no such file: ${path}`);
+    return data;
+  }
+  async readTextFile(path: string): Promise<string> {
+    return new TextDecoder().decode(await this.readFile(path));
+  }
+  async writeFile(path: string, data: Uint8Array | string): Promise<void> {
+    this.files.set(path, typeof data === "string" ? new TextEncoder().encode(data) : data);
+  }
+  async rename(from: string, to: string): Promise<void> {
+    this.files.set(to, await this.readFile(from));
+    this.files.delete(from);
+  }
+  async mkdir(path: string): Promise<void> {
+    this.dirs.add(path);
+  }
+  async list(path: string): Promise<readonly DirEntry[]> {
+    return [...this.files.keys()]
+      .filter((p) => p.startsWith(`${path}/`))
+      .map((p) => ({ name: p.slice(path.length + 1), kind: "file" as const }));
+  }
+  async stat(path: string): Promise<FileStat | undefined> {
+    const data = this.files.get(path);
+    if (data) return { kind: "file", size: data.byteLength, mtimeMs: 0 };
+    if (this.dirs.has(path)) return { kind: "directory", size: 0, mtimeMs: 0 };
+    return undefined;
+  }
+}
+
+class FakeClock implements ClockPort {
+  private mono = 0;
+  constructor(private readonly epochMs: number) {}
+  now(): number {
+    return this.epochMs;
+  }
+  monotonicNow(): number {
+    this.mono += 1;
+    return this.mono;
+  }
+}
+
+class CapturingLogger implements LoggerPort {
+  readonly lines: Array<{ level: string; message: string }> = [];
+  debug(message: string): void {
+    this.lines.push({ level: "debug", message });
+  }
+  info(message: string): void {
+    this.lines.push({ level: "info", message });
+  }
+  warn(message: string): void {
+    this.lines.push({ level: "warn", message });
+  }
+  error(message: string): void {
+    this.lines.push({ level: "error", message });
+  }
+}
+
+class FakeStorage implements StoragePort {
+  readonly execed: string[] = [];
+  private userVersion = 0;
+  async exec(sql: string): Promise<void> {
+    this.execed.push(sql);
+    const match = /PRAGMA\s+user_version\s*=\s*(\d+)/i.exec(sql);
+    if (match) this.userVersion = Number(match[1]);
+  }
+  async prepare(sql: string): Promise<PreparedStatement> {
+    const uv = this.userVersion;
+    return {
+      async run(): Promise<StorageRunResult> {
+        return { changes: 0, lastInsertRowid: 0 };
+      },
+      async get(): Promise<StorageRow | undefined> {
+        return /user_version/i.test(sql) ? { user_version: uv } : undefined;
+      },
+      async all(): Promise<readonly StorageRow[]> {
+        return [];
+      },
+    };
+  }
+  async pragma(source: string): Promise<number | null> {
+    return /user_version/i.test(source) ? this.userVersion : null;
+  }
+  async close(): Promise<void> {}
+}
+
+class StubCrypto implements CryptoPort {
+  async sha256(data: Uint8Array): Promise<Uint8Array> {
+    return new Uint8Array(32).fill(data.byteLength & 0xff);
+  }
+  async randomBytes(length: number): Promise<Uint8Array> {
+    return new Uint8Array(length);
+  }
+  async pbkdf2(): Promise<Uint8Array> {
+    return new Uint8Array(32);
+  }
+  async aesGcmEncrypt(): Promise<Uint8Array> {
+    return new Uint8Array(0);
+  }
+  async aesGcmDecrypt(): Promise<Uint8Array> {
+    return new Uint8Array(0);
+  }
+}
+
+class StubHttp implements HttpPort {
+  async fetch(request: HttpRequest): Promise<HttpResponse> {
+    return {
+      status: 200,
+      headers: { "x-echo": request.method },
+      body: new TextEncoder().encode(request.url),
+    };
+  }
+}
+
+describe("kernel ports", () => {
+  it("FileSystemPort round-trips text and resolves undefined for an absent path", async () => {
+    const fs: FileSystemPort = new FakeFileSystem();
+    await fs.mkdir("/store");
+    await fs.writeFile("/store/a.txt", "hello");
+    expect(await fs.readTextFile("/store/a.txt")).toBe("hello");
+    expect(await fs.stat("/store/missing")).toBeUndefined();
+    expect((await fs.list("/store")).map((e) => e.name)).toContain("a.txt");
+  });
+
+  it("ClockPort exposes wall-clock and a monotonic counter", () => {
+    const clock: ClockPort = new FakeClock(1_700_000_000_000);
+    expect(clock.now()).toBe(1_700_000_000_000);
+    const first = clock.monotonicNow();
+    const second = clock.monotonicNow();
+    expect(first).toBeLessThan(second);
+  });
+
+  it("LoggerPort captures leveled lines", () => {
+    const logger = new CapturingLogger();
+    logger.info("up");
+    logger.error("down");
+    expect(logger.lines).toEqual([
+      { level: "info", message: "up" },
+      { level: "error", message: "down" },
+    ]);
+  });
+
+  it("StoragePort exec/prepare/pragma express the user_version read/apply flow", async () => {
+    const storage: StoragePort = new FakeStorage();
+    expect(await storage.pragma("user_version")).toBe(0);
+    await storage.exec("PRAGMA user_version = 1");
+    expect(await storage.pragma("user_version")).toBe(1);
+    const stmt = await storage.prepare("PRAGMA user_version");
+    expect(await stmt.get()).toEqual({ user_version: 1 });
+    await storage.close();
+  });
+
+  it("CryptoPort and HttpPort are implementable with the WebCrypto-subset / fetch-shaped surface", async () => {
+    const crypto: CryptoPort = new StubCrypto();
+    expect((await crypto.sha256(new Uint8Array([1, 2, 3]))).byteLength).toBe(32);
+    expect((await crypto.randomBytes(12)).byteLength).toBe(12);
+    const http: HttpPort = new StubHttp();
+    const res = await http.fetch({ method: "GET", url: "http://127.0.0.1/healthz" });
+    expect(res.status).toBe(200);
+  });
+});

--- a/packages/kernel/tests/ports.contract.test.ts
+++ b/packages/kernel/tests/ports.contract.test.ts
@@ -15,6 +15,9 @@ import type {
   StorageRunResult,
 } from "../src/ports/index.js";
 
+const utf8Encoder = new TextEncoder();
+const utf8Decoder = new TextDecoder();
+
 class FakeFileSystem implements FileSystemPort {
   private readonly files = new Map<string, Uint8Array>();
   private readonly dirs = new Set<string>();
@@ -25,10 +28,10 @@ class FakeFileSystem implements FileSystemPort {
     return data;
   }
   async readTextFile(path: string): Promise<string> {
-    return new TextDecoder().decode(await this.readFile(path));
+    return utf8Decoder.decode(await this.readFile(path));
   }
   async writeFile(path: string, data: Uint8Array | string): Promise<void> {
-    this.files.set(path, typeof data === "string" ? new TextEncoder().encode(data) : data);
+    this.files.set(path, typeof data === "string" ? utf8Encoder.encode(data) : data);
   }
   async rename(from: string, to: string): Promise<void> {
     this.files.set(to, await this.readFile(from));
@@ -79,10 +82,8 @@ class CapturingLogger implements LoggerPort {
 }
 
 class FakeStorage implements StoragePort {
-  readonly execed: string[] = [];
   private userVersion = 0;
   async exec(sql: string): Promise<void> {
-    this.execed.push(sql);
     const match = /PRAGMA\s+user_version\s*=\s*(\d+)/i.exec(sql);
     if (match) this.userVersion = Number(match[1]);
   }
@@ -107,8 +108,8 @@ class FakeStorage implements StoragePort {
 }
 
 class StubCrypto implements CryptoPort {
-  async sha256(data: Uint8Array): Promise<Uint8Array> {
-    return new Uint8Array(32).fill(data.byteLength & 0xff);
+  async sha256(): Promise<Uint8Array> {
+    return new Uint8Array(32);
   }
   async randomBytes(length: number): Promise<Uint8Array> {
     return new Uint8Array(length);
@@ -129,7 +130,7 @@ class StubHttp implements HttpPort {
     return {
       status: 200,
       headers: { "x-echo": request.method },
-      body: new TextEncoder().encode(request.url),
+      body: utf8Encoder.encode(request.url),
     };
   }
 }
@@ -179,5 +180,7 @@ describe("kernel ports", () => {
     const http: HttpPort = new StubHttp();
     const res = await http.fetch({ method: "GET", url: "http://127.0.0.1/healthz" });
     expect(res.status).toBe(200);
+    expect(res.headers["x-echo"]).toBe("GET");
+    expect(utf8Decoder.decode(res.body)).toBe("http://127.0.0.1/healthz");
   });
 });

--- a/packages/kernel/tsup.config.ts
+++ b/packages/kernel/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: ["src/index.ts"],
+  entry: { ports: "src/ports/index.ts" },
   format: ["esm"],
   dts: true,
   sourcemap: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -225,6 +225,9 @@ importers:
       typescript:
         specifier: ^6.0.2
         version: 6.0.3
+      vitest:
+        specifier: ^4.1.4
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.8(vitest@4.1.5))(msw@2.14.2(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/kernel-node:
     dependencies:
@@ -241,6 +244,9 @@ importers:
       typescript:
         specifier: ^6.0.2
         version: 6.0.3
+      vitest:
+        specifier: ^4.1.4
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.8(vitest@4.1.5))(msw@2.14.2(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/running-coach:
     dependencies:


### PR DESCRIPTION
## Summary

Adds the six host-adapter ports to the pure compute kernel: `Storage`, `FileSystem`, `Crypto`, `Clock`, `Http`, and `Logger`. Each is defined as an interface plus its supporting type aliases only — zero runtime logic, no platform imports, no workspace or third-party dependencies. The four IO ports (`Storage`, `FileSystem`, `Crypto`, `Http`) are async-first; `Clock` and `Logger` are synchronous. All binary payloads are modeled as `Uint8Array`, and the `Http`/`Crypto` ports declare their own request, response, and parameter shapes rather than leaning on any DOM or platform nominal types, keeping the kernel free of ambient platform lib dependencies.

The ports are consumable through a single `./ports` subpath — there is no `.` barrel. The previous `KERNEL_STATUS` placeholder module is removed, the build entry is repointed to the ports barrel, and the package exposes exactly one export key. A pure in-memory contract smoke test exercises the port shapes with hand-written fakes.

The host-driver scaffold package gains a real test script only; its exports, sources, and config are untouched. Both packages remain private and unpublished, so no changeset accompanies this change.

## Changed surfaces

- New port interface modules and their barrel under the kernel's `ports` directory.
- Kernel package manifest: single `./ports` export, real test script, test-runner dev dependency.
- Kernel build config: entry repointed to the ports barrel.
- Host-driver scaffold manifest: test script and test-runner dev dependency only.
- Pure in-memory contract test for the port surfaces.

## Test plan

- `pnpm build` — kernel emits the ports bundle and its declarations.
- `pnpm check` — full gate chain green end-to-end (DOM-free typecheck over the port sources, lint governance, trademark, fixture-privacy, contract-deps, registry-isolation).
- `pnpm vitest run packages/kernel/tests/ports.contract.test.ts` — five contract cases pass.
- `pnpm test` — green suite.
- `pnpm s8a` — exit 0, zero diffs.
- `pnpm check-parity --all` — all pairs green, zero snapshot regeneration.
- Purity check: no platform-builtin imports under the kernel sources.
