### PR TITLE
feat(kernel): numbered-migration runner with user_version tracking and downgrade refusal

### DIFF
--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -7,7 +7,8 @@
   "files": ["dist"],
   "exports": {
     "./ports": "./dist/ports.js",
-    "./store/migrations": "./dist/store/migrations.js"
+    "./store/migrations": "./dist/store/migrations.js",
+    "./store": "./dist/store.js"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/kernel/src/store/index.ts
+++ b/packages/kernel/src/store/index.ts
@@ -1,0 +1,1 @@
+export * from "./migrator.js";

--- a/packages/kernel/src/store/migrator.ts
+++ b/packages/kernel/src/store/migrator.ts
@@ -58,7 +58,7 @@ export async function runMigrations(
   migrations: readonly Migration[],
 ): Promise<MigrationResult> {
   const sorted = validateAndSort(migrations);
-  const appMaxVersion = sorted.length === 0 ? 0 : sorted[sorted.length - 1]!.version;
+  const appMaxVersion = sorted.at(-1)?.version ?? 0;
 
   const current = await store.getUserVersion();
   if (current > appMaxVersion) {

--- a/packages/kernel/src/store/migrator.ts
+++ b/packages/kernel/src/store/migrator.ts
@@ -1,0 +1,85 @@
+export interface Migration {
+  readonly version: number;
+  readonly sql: string;
+}
+
+export interface MigratorStore {
+  getUserVersion(): Promise<number>;
+  setUserVersion(version: number): Promise<void>;
+  exec(sql: string): Promise<void>;
+  transaction<T>(fn: () => Promise<T>): Promise<T>;
+}
+
+export interface MigrationResult {
+  readonly fromVersion: number;
+  readonly toVersion: number;
+  readonly applied: readonly number[];
+}
+
+export class StoreNewerThanAppError extends Error {
+  readonly storeVersion: number;
+  readonly appMaxVersion: number;
+  constructor(storeVersion: number, appMaxVersion: number) {
+    super("store is newer than this app");
+    this.name = "StoreNewerThanAppError";
+    this.storeVersion = storeVersion;
+    this.appMaxVersion = appMaxVersion;
+  }
+}
+
+export class InvalidMigrationSetError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "InvalidMigrationSetError";
+  }
+}
+
+function validateAndSort(migrations: readonly Migration[]): Migration[] {
+  const seen = new Set<number>();
+  for (const m of migrations) {
+    if (!Number.isInteger(m.version) || m.version <= 0) {
+      throw new InvalidMigrationSetError(
+        `migration version must be a positive integer, got ${String(m.version)}`,
+      );
+    }
+    if (seen.has(m.version)) {
+      throw new InvalidMigrationSetError(`duplicate migration version ${m.version}`);
+    }
+    seen.add(m.version);
+  }
+  return [...migrations].sort((a, b) => a.version - b.version);
+}
+
+// Startup order is acquire-lock -> migrate -> open store RW; the lock is a
+// separate concern. A thrown StoreNewerThanAppError must abort startup before
+// any read-write use of the store.
+export async function runMigrations(
+  store: MigratorStore,
+  migrations: readonly Migration[],
+): Promise<MigrationResult> {
+  const sorted = validateAndSort(migrations);
+  const appMaxVersion = sorted.length === 0 ? 0 : sorted[sorted.length - 1]!.version;
+
+  const current = await store.getUserVersion();
+  if (current > appMaxVersion) {
+    throw new StoreNewerThanAppError(current, appMaxVersion);
+  }
+
+  // Connection/store state, set outside any transaction (SQLite ignores these
+  // PRAGMAs inside a transaction). Ordered AFTER the downgrade refusal so a
+  // newer store is never written (journal_mode=WAL mutates the DB header).
+  await store.exec("PRAGMA journal_mode = WAL");
+  await store.exec("PRAGMA foreign_keys = ON");
+
+  const pending = sorted.filter((m) => m.version > current);
+  const applied: number[] = [];
+  for (const m of pending) {
+    await store.transaction(async () => {
+      await store.exec(m.sql);
+      await store.setUserVersion(m.version);
+    });
+    applied.push(m.version);
+  }
+
+  return { fromVersion: current, toVersion: appMaxVersion, applied };
+}

--- a/packages/kernel/tests/migrator.test.ts
+++ b/packages/kernel/tests/migrator.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect } from "vitest";
+import {
+  runMigrations,
+  StoreNewerThanAppError,
+  InvalidMigrationSetError,
+  type Migration,
+  type MigratorStore,
+} from "../src/store/migrator.js";
+
+interface FakeStore extends MigratorStore {
+  userVersion: number;
+  readonly execLog: string[];
+}
+
+// A synchronous in-memory MigratorStore. `transaction` snapshots userVersion +
+// execLog length and restores them if `fn` throws, modeling atomic rollback.
+// `failOn` makes a chosen SQL string throw, to exercise the rollback path.
+function makeFakeStore(initialVersion = 0, failOn?: string): FakeStore {
+  const execLog: string[] = [];
+  const store: FakeStore = {
+    userVersion: initialVersion,
+    execLog,
+    async getUserVersion() {
+      return store.userVersion;
+    },
+    async setUserVersion(v: number) {
+      store.userVersion = v;
+    },
+    async exec(sql: string) {
+      if (failOn !== undefined && sql === failOn) throw new Error(`exec failed: ${sql}`);
+      execLog.push(sql);
+    },
+    async transaction<T>(fn: () => Promise<T>): Promise<T> {
+      const snapVersion = store.userVersion;
+      const snapLen = execLog.length;
+      try {
+        return await fn();
+      } catch (e) {
+        store.userVersion = snapVersion;
+        execLog.length = snapLen;
+        throw e;
+      }
+    },
+  };
+  return store;
+}
+
+const PRAGMAS = ["PRAGMA journal_mode = WAL", "PRAGMA foreign_keys = ON"];
+
+function ddlPortion(execLog: readonly string[]): string[] {
+  return execLog.filter((s) => !PRAGMAS.includes(s));
+}
+
+describe("runMigrations", () => {
+  it("applies pending in ascending order", async () => {
+    const store = makeFakeStore(0);
+    const migrations: Migration[] = [
+      { version: 2, sql: "B" },
+      { version: 1, sql: "A" },
+      { version: 3, sql: "C" },
+    ];
+    const result = await runMigrations(store, migrations);
+    expect(result).toEqual({ fromVersion: 0, toVersion: 3, applied: [1, 2, 3] });
+    expect(store.userVersion).toBe(3);
+    expect(ddlPortion(store.execLog)).toEqual(["A", "B", "C"]);
+  });
+
+  it("partial apply from a non-zero current", async () => {
+    const store = makeFakeStore(1);
+    const migrations: Migration[] = [
+      { version: 1, sql: "A" },
+      { version: 2, sql: "B" },
+      { version: 3, sql: "C" },
+    ];
+    const result = await runMigrations(store, migrations);
+    expect(result).toEqual({ fromVersion: 1, toVersion: 3, applied: [2, 3] });
+    expect(store.userVersion).toBe(3);
+    expect(ddlPortion(store.execLog)).toEqual(["B", "C"]);
+  });
+
+  it("idempotence (apply twice = no-op)", async () => {
+    const store = makeFakeStore(0);
+    const migrations: Migration[] = [{ version: 1, sql: "A" }];
+    const first = await runMigrations(store, migrations);
+    expect(first).toEqual({ fromVersion: 0, toVersion: 1, applied: [1] });
+    const second = await runMigrations(store, migrations);
+    expect(second).toEqual({ fromVersion: 1, toVersion: 1, applied: [] });
+    expect(store.userVersion).toBe(1);
+    expect(store.execLog.filter((s) => s === "A").length).toBe(1);
+  });
+
+  it("issues the two connection pragmas, outside/ahead of DDL", async () => {
+    const store = makeFakeStore(0);
+    const migrations: Migration[] = [{ version: 1, sql: "A" }];
+    await runMigrations(store, migrations);
+    expect(store.execLog[0]).toBe("PRAGMA journal_mode = WAL");
+    expect(store.execLog[1]).toBe("PRAGMA foreign_keys = ON");
+    const firstDdlIndex = store.execLog.indexOf("A");
+    expect(firstDdlIndex).toBeGreaterThan(1);
+  });
+
+  it("refuses a store newer than the app (exact named error)", async () => {
+    const store = makeFakeStore(2);
+    const migrations: Migration[] = [{ version: 1, sql: "A" }];
+    let caught: unknown;
+    await expect(
+      runMigrations(store, migrations).catch((e) => {
+        caught = e;
+        throw e;
+      }),
+    ).rejects.toBeInstanceOf(StoreNewerThanAppError);
+    expect(caught).toBeInstanceOf(StoreNewerThanAppError);
+    const err = caught as StoreNewerThanAppError;
+    expect(err.message).toBe("store is newer than this app");
+    expect(err.name).toBe("StoreNewerThanAppError");
+    expect(err.storeVersion).toBe(2);
+    expect(err.appMaxVersion).toBe(1);
+    expect(store.execLog).toEqual([]);
+    expect(store.userVersion).toBe(2);
+  });
+
+  it("rolls back a failing migration's transaction", async () => {
+    const store = makeFakeStore(0, "BAD");
+    const migrations: Migration[] = [
+      { version: 1, sql: "A" },
+      { version: 2, sql: "BAD" },
+      { version: 3, sql: "C" },
+    ];
+    await expect(runMigrations(store, migrations)).rejects.toThrow("exec failed: BAD");
+    expect(store.userVersion).toBe(1);
+    const ddl = ddlPortion(store.execLog);
+    expect(ddl).toContain("A");
+    expect(ddl).not.toContain("BAD");
+    expect(ddl).not.toContain("C");
+  });
+
+  it("handles an empty migration set", async () => {
+    const store = makeFakeStore(0);
+    const result = await runMigrations(store, []);
+    expect(result).toEqual({ fromVersion: 0, toVersion: 0, applied: [] });
+    expect(store.execLog).toEqual(PRAGMAS);
+    expect(ddlPortion(store.execLog)).toEqual([]);
+  });
+
+  it("rejects a malformed set with a duplicate version", async () => {
+    const store = makeFakeStore(0);
+    const migrations: Migration[] = [
+      { version: 1, sql: "A" },
+      { version: 1, sql: "B" },
+    ];
+    await expect(runMigrations(store, migrations)).rejects.toBeInstanceOf(
+      InvalidMigrationSetError,
+    );
+    expect(store.execLog).toEqual([]);
+    expect(store.userVersion).toBe(0);
+  });
+
+  it("rejects a non-positive or non-integer version", async () => {
+    const zeroStore = makeFakeStore(0);
+    await expect(
+      runMigrations(zeroStore, [{ version: 0, sql: "A" }]),
+    ).rejects.toBeInstanceOf(InvalidMigrationSetError);
+
+    const fracStore = makeFakeStore(0);
+    await expect(
+      runMigrations(fracStore, [{ version: 1.5, sql: "A" }]),
+    ).rejects.toBeInstanceOf(InvalidMigrationSetError);
+  });
+});

--- a/packages/kernel/tsup.config.ts
+++ b/packages/kernel/tsup.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   entry: {
     ports: "src/ports/index.ts",
     "store/migrations": "src/store/migrations/index.ts",
+    store: "src/store/index.ts",
   },
   loader: { ".sql": "text" },
   format: ["esm"],


### PR DESCRIPTION
## Summary

Adds the pure-compute migration runner to the local-first athlete store's kernel package. This is the piece that decides which schema migrations to apply and applies them safely, with no host or filesystem dependencies.

## What changed, by surface

- **`packages/kernel/src/store/migrator.ts`** (new) — an exported async `runMigrations(store, migrations)` plus the `Migration` and `MigratorStore` capability interfaces, a `MigrationResult` shape, and two named errors (`StoreNewerThanAppError`, `InvalidMigrationSetError`). The runner:
  - validates the migration set (positive-integer versions, no duplicates) and sorts it ascending;
  - reads the store's tracked `user_version`;
  - refuses to run against a store newer than the app, throwing `StoreNewerThanAppError` **before** any write so a newer store is never mutated;
  - sets `journal_mode = WAL` and `foreign_keys = ON` outside any transaction;
  - applies each pending migration inside its own transaction (schema exec + version bump atomic), making re-runs idempotent.
- **`packages/kernel/src/store/index.ts`** (new) — re-exports the migrator on a new `./store` subpath.
- **`packages/kernel/tests/migrator.test.ts`** (new) — pure in-memory fake store covering ascending order, partial apply, idempotence, the two pragmas running ahead of DDL, downgrade refusal (exact error, empty exec log), per-migration transaction rollback, and the malformed-set cases (empty set, duplicate version, non-positive / non-integer version).
- **`packages/kernel/tsup.config.ts`** / **`packages/kernel/package.json`** — wire the new `./store` build entry and export subpath. No `.` barrel is introduced.

The runner imports nothing — no host modules, no workspace packages — and consumes an injected `MigratorStore` capability, so it stays a leaf of the pure compute kernel. No schema file is created, edited, or imported here.

## Test plan

- `pnpm build` — kernel emits `dist/store.js` + `dist/store.d.ts`.
- `pnpm vitest run packages/kernel/tests/migrator.test.ts` — green (ordering, idempotence, downgrade refusal, rollback, pragma ordering, malformed-set cases).
- `pnpm check` — passes end-to-end (build, typecheck, lints, package-deps, kernel-discipline).
- `pnpm test` — green.
- `pnpm s8a` and `pnpm s8a --self-test` — exit 0, zero diffs.
- `pnpm check-parity --all` — all pairs green, zero snapshot regeneration.
