### PR TITLE
feat(kernel): node:sqlite storage driver, repository ports, INV-2 dump harness

### DIFF
--- a/.changeset/kernel-sqlite-adapter.md
+++ b/.changeset/kernel-sqlite-adapter.md
@@ -1,0 +1,9 @@
+---
+"@enduragent/kernel": patch
+"@enduragent/kernel-node": patch
+---
+
+Add the node:sqlite Storage-port driver, the pure repository-port layer
+(anchor-history insert-if-absent / read-current, raw_file and source_record
+upserts), and the INV-2 canonical ordered-logical-dump harness with an
+engine-stable float serializer.

--- a/packages/kernel-node/package.json
+++ b/packages/kernel-node/package.json
@@ -5,11 +5,16 @@
   "description": "Node host adapter for the pure kernel — node:sqlite / node:fs / WebCrypto drivers behind the kernel's ports (scaffold, no content yet).",
   "type": "module",
   "files": ["dist"],
-  "exports": {},
+  "exports": {
+    "./sqlite": "./dist/sqlite.js"
+  },
+  "engines": {
+    "node": ">=24"
+  },
   "scripts": {
     "build": "tsup",
     "check": "tsc --noEmit",
-    "test": "vitest run --passWithNoTests"
+    "test": "vitest run"
   },
   "dependencies": {
     "@enduragent/kernel": "workspace:*"

--- a/packages/kernel-node/src/sqlite/database.ts
+++ b/packages/kernel-node/src/sqlite/database.ts
@@ -1,0 +1,53 @@
+// node:sqlite is a Node built-in (no npm dependency). Runtime floor is Node >=24
+// (the bundled SQLite gains FTS5 there; JSON1 is present everywhere). The recorded
+// fallback to a native driver is triggered ONLY by (a) missing FTS5/JSON1 in the
+// bundled build or (b) a measured >2x backfill regression; adopting it would require
+// a dual-ABI build step in the same change and is out of scope for this change.
+import { DatabaseSync } from "node:sqlite";
+import type { MigratorStore, Row, SqlStore, SqlValue } from "@enduragent/kernel/store";
+
+export function openSqliteStorage(path: string): SqlStore & MigratorStore {
+  const db = new DatabaseSync(path);
+  db.exec("PRAGMA journal_mode = WAL;");
+  db.exec("PRAGMA foreign_keys = ON;");
+  const bind = (params?: readonly SqlValue[]): SqlValue[] => (params ? [...params] : []);
+  return {
+    async exec(sql) {
+      db.exec(sql);
+    },
+    async run(sql, params) {
+      db.prepare(sql).run(...bind(params));
+    },
+    async get(sql, params) {
+      const r = db.prepare(sql).get(...bind(params));
+      return r === undefined || r === null ? undefined : ({ ...r } as Row);
+    },
+    async all(sql, params) {
+      return db.prepare(sql).all(...bind(params)).map((r) => ({ ...r }) as Row);
+    },
+    async close() {
+      db.close();
+    },
+    async getUserVersion() {
+      const r = db.prepare("PRAGMA user_version").get() as { user_version: number };
+      return Number(r.user_version);
+    },
+    async setUserVersion(version) {
+      if (!Number.isSafeInteger(version) || version < 0) {
+        throw new RangeError(`user_version must be a non-negative integer, got ${String(version)}`);
+      }
+      db.exec(`PRAGMA user_version = ${version}`);
+    },
+    async transaction(fn) {
+      db.exec("BEGIN IMMEDIATE");
+      try {
+        const result = await fn();
+        db.exec("COMMIT");
+        return result;
+      } catch (err) {
+        db.exec("ROLLBACK");
+        throw err;
+      }
+    },
+  };
+}

--- a/packages/kernel-node/src/sqlite/database.ts
+++ b/packages/kernel-node/src/sqlite/database.ts
@@ -4,26 +4,25 @@
 // bundled build or (b) a measured >2x backfill regression; adopting it would require
 // a dual-ABI build step in the same change and is out of scope for this change.
 import { DatabaseSync } from "node:sqlite";
-import type { MigratorStore, Row, SqlStore, SqlValue } from "@enduragent/kernel/store";
+import type { MigratorStore, Row, SqlStore } from "@enduragent/kernel/store";
 
 export function openSqliteStorage(path: string): SqlStore & MigratorStore {
   const db = new DatabaseSync(path);
   db.exec("PRAGMA journal_mode = WAL;");
   db.exec("PRAGMA foreign_keys = ON;");
-  const bind = (params?: readonly SqlValue[]): SqlValue[] => (params ? [...params] : []);
   return {
     async exec(sql) {
       db.exec(sql);
     },
     async run(sql, params) {
-      db.prepare(sql).run(...bind(params));
+      db.prepare(sql).run(...(params ?? []));
     },
     async get(sql, params) {
-      const r = db.prepare(sql).get(...bind(params));
+      const r = db.prepare(sql).get(...(params ?? []));
       return r === undefined || r === null ? undefined : ({ ...r } as Row);
     },
     async all(sql, params) {
-      return db.prepare(sql).all(...bind(params)).map((r) => ({ ...r }) as Row);
+      return db.prepare(sql).all(...(params ?? [])).map((r) => ({ ...r }) as Row);
     },
     async close() {
       db.close();

--- a/packages/kernel-node/src/sqlite/index.ts
+++ b/packages/kernel-node/src/sqlite/index.ts
@@ -1,0 +1,1 @@
+export { openSqliteStorage } from "./database.js";

--- a/packages/kernel-node/tests/migrator-e2e.test.ts
+++ b/packages/kernel-node/tests/migrator-e2e.test.ts
@@ -1,0 +1,84 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  DUMP_TABLES,
+  createAnchorRepository,
+  dumpStore,
+  runMigrations,
+  type AnchorHistoryRow,
+  type MigratorStore,
+  type SqlStore,
+} from "@enduragent/kernel/store";
+import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
+import { openSqliteStorage } from "../src/sqlite/index.js";
+
+describe("migrator end-to-end over node:sqlite", () => {
+  let dir: string;
+  let store: SqlStore & MigratorStore;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "kn-"));
+    store = openSqliteStorage(join(dir, "store.db"));
+  });
+
+  afterEach(async () => {
+    await store.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("applies 001_init.sql and advances user_version to 1", async () => {
+    await runMigrations(store, MIGRATIONS);
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 1 });
+
+    const tables = await store.all("SELECT name FROM sqlite_master WHERE type='table'");
+    const names = new Set(tables.map((r) => r.name as string));
+    for (const { table } of DUMP_TABLES) {
+      expect(names.has(table)).toBe(true);
+    }
+
+    expect(await store.all("PRAGMA foreign_key_check")).toEqual([]);
+    expect(await store.get("PRAGMA journal_mode")).toEqual({ journal_mode: "wal" });
+  });
+
+  it("produces a deterministic INV-2 dump of a fixed state", async () => {
+    await runMigrations(store, MIGRATIONS);
+    const repo = createAnchorRepository(store);
+    const row: AnchorHistoryRow = {
+      id: "anchor-e2e",
+      sport: "cycling",
+      anchor_type: "ftp",
+      value: 250.5,
+      unit: "W",
+      valid_from: 1000,
+      source: "manual",
+      confidence: "manual",
+      note: null,
+      provenance: "manual",
+      device_id: null,
+      hlc_physical_ms: null,
+      hlc_counter: null,
+    };
+    await repo.insertIfAbsent(row);
+
+    const dump = await dumpStore(store);
+    expect(dump).toContain("# anchor_history");
+    expect(dump).toContain("anchor-e2e");
+    expect(await dumpStore(store)).toBe(dump);
+  });
+
+  it("shares one real transaction for exec + version bump (atomic rollback)", async () => {
+    const migrations = [
+      { version: 1, sql: "CREATE TABLE first_ok (a TEXT);" },
+      { version: 2, sql: "CREATE TABLE second_partial (a TEXT); INSERT INTO nonexistent VALUES (1);" },
+    ];
+    await expect(runMigrations(store, migrations)).rejects.toThrow();
+
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 1 });
+    const tables = await store.all("SELECT name FROM sqlite_master WHERE type='table'");
+    const names = new Set(tables.map((r) => r.name as string));
+    expect(names.has("first_ok")).toBe(true);
+    expect(names.has("second_partial")).toBe(false);
+  });
+});

--- a/packages/kernel-node/tests/repositories.test.ts
+++ b/packages/kernel-node/tests/repositories.test.ts
@@ -1,0 +1,122 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  createAnchorRepository,
+  createRawFileRepository,
+  createSourceRecordRepository,
+  runMigrations,
+  type AnchorHistoryRow,
+  type MigratorStore,
+  type RawFileRow,
+  type SourceRecordRow,
+  type SqlStore,
+} from "@enduragent/kernel/store";
+import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
+import { openSqliteStorage } from "../src/sqlite/index.js";
+
+function anchorRow(overrides: Partial<AnchorHistoryRow> = {}): AnchorHistoryRow {
+  return {
+    id: "anchor-1",
+    sport: "cycling",
+    anchor_type: "ftp",
+    value: 250,
+    unit: "W",
+    valid_from: 1000,
+    source: "manual",
+    confidence: "manual",
+    note: null,
+    provenance: "manual",
+    device_id: null,
+    hlc_physical_ms: null,
+    hlc_counter: null,
+    ...overrides,
+  };
+}
+
+describe("repository ports over real node:sqlite", () => {
+  let dir: string;
+  let store: SqlStore & MigratorStore;
+
+  beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), "kn-"));
+    store = openSqliteStorage(join(dir, "store.db"));
+    await runMigrations(store, MIGRATIONS);
+  });
+
+  afterEach(async () => {
+    await store.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  describe("createAnchorRepository", () => {
+    it("inserts once and is idempotent on the 3-column key", async () => {
+      const repo = createAnchorRepository(store);
+      expect(await repo.insertIfAbsent(anchorRow())).toBe(true);
+      expect(await repo.insertIfAbsent(anchorRow({ id: "anchor-1-dup", value: 999 }))).toBe(false);
+      const count = await store.get("SELECT count(*) AS c FROM anchor_history");
+      expect(count?.c).toBe(1);
+    });
+
+    it("reads the effective-dated current row", async () => {
+      const repo = createAnchorRepository(store);
+      await repo.insertIfAbsent(anchorRow({ id: "v1", valid_from: 1000, value: 250 }));
+      const asOf1 = await repo.readCurrent("cycling", "ftp", 1500);
+      expect(asOf1?.value).toBe(250);
+      await repo.insertIfAbsent(anchorRow({ id: "v2", valid_from: 2000, value: 260 }));
+      const asOf2 = await repo.readCurrent("cycling", "ftp", 2500);
+      expect(asOf2?.value).toBe(260);
+    });
+
+    it("applies confidence precedence for same valid_from (manual > platform)", async () => {
+      const repo = createAnchorRepository(store);
+      await repo.insertIfAbsent(
+        anchorRow({ id: "plat", valid_from: 1000, value: 240, confidence: "platform", provenance: "sync", source: "connector" }),
+      );
+      await store.run(
+        "INSERT INTO anchor_history (id, sport, anchor_type, value, unit, valid_from, source, confidence, note, provenance, device_id, hlc_physical_ms, hlc_counter) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)",
+        ["man", "cycling", "ftp", 250, "W", 1000, "manual", "manual", null, "manual", null, null, null],
+      );
+      const current = await repo.readCurrent("cycling", "ftp", 1500);
+      expect(current?.confidence).toBe("manual");
+      expect(current?.value).toBe(250);
+    });
+  });
+
+  it("upserts raw_file idempotently by sha256", async () => {
+    const repo = createRawFileRepository(store);
+    const row: RawFileRow = {
+      sha256: "abc",
+      path: "/x.fit",
+      ext: "fit",
+      bytes: 100,
+      file_id_serial: 1,
+      file_id_time_created_utc: 1000,
+      manufacturer: "garmin",
+      product: "edge",
+    };
+    await repo.upsert(row);
+    await repo.upsert({ ...row, bytes: 999 });
+    const count = await store.get("SELECT count(*) AS c FROM raw_file");
+    expect(count?.c).toBe(1);
+  });
+
+  it("upserts source_record idempotently by (source, external_id)", async () => {
+    const repo = createSourceRecordRepository(store);
+    const row: SourceRecordRow = {
+      id: "sr-1",
+      workout_key: null,
+      session_key: null,
+      source: "intervals",
+      external_id: "ext-1",
+      raw_sha256: null,
+      quality_rank: 1,
+      payload_json: "{}",
+    };
+    await repo.upsert(row);
+    await repo.upsert({ ...row, id: "sr-2", quality_rank: 5 });
+    const count = await store.get("SELECT count(*) AS c FROM source_record");
+    expect(count?.c).toBe(1);
+  });
+});

--- a/packages/kernel-node/tests/sqlite-adapter.test.ts
+++ b/packages/kernel-node/tests/sqlite-adapter.test.ts
@@ -1,0 +1,83 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { SqlStore, MigratorStore } from "@enduragent/kernel/store";
+import { openSqliteStorage } from "../src/sqlite/index.js";
+
+describe("openSqliteStorage adapter", () => {
+  let dir: string;
+  let store: SqlStore & MigratorStore;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "kn-"));
+    store = openSqliteStorage(join(dir, "store.db"));
+  });
+
+  afterEach(async () => {
+    await store.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("opens with WAL journal mode and foreign_keys enabled", async () => {
+    const jm = await store.get("PRAGMA journal_mode");
+    expect(jm).toEqual({ journal_mode: "wal" });
+    const fk = await store.get("PRAGMA foreign_keys");
+    expect(fk).toEqual({ foreign_keys: 1 });
+  });
+
+  it("round-trips TEXT, REAL, and BLOB values through run/get/all", async () => {
+    await store.exec("CREATE TABLE t(a TEXT, n REAL, b BLOB)");
+    await store.run("INSERT INTO t(a, n, b) VALUES (?,?,?)", ["x", 1.5, new Uint8Array([9])]);
+    const got = await store.get("SELECT a, n, b FROM t");
+    expect(got?.a).toBe("x");
+    expect(got?.n).toBe(1.5);
+    expect(got?.b).toBeInstanceOf(Uint8Array);
+    expect([...(got?.b as Uint8Array)]).toEqual([9]);
+    const all = await store.all("SELECT a FROM t");
+    expect(all).toHaveLength(1);
+    const none = await store.get("SELECT a FROM t WHERE a = ?", ["nope"]);
+    expect(none).toBeUndefined();
+  });
+
+  it("reads and writes PRAGMA user_version via exec/get", async () => {
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 0 });
+    await store.exec("PRAGMA user_version = 3");
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 3 });
+  });
+
+  it("returns [] from foreign_key_check on a clean DB", async () => {
+    expect(await store.all("PRAGMA foreign_key_check")).toEqual([]);
+  });
+
+  it("exposes the migrator-port surface on the same connection", async () => {
+    expect(await store.getUserVersion()).toBe(0);
+    await store.setUserVersion(3);
+    expect(await store.getUserVersion()).toBe(3);
+  });
+
+  it("rejects non-integer and negative user_version without changing state", async () => {
+    await store.setUserVersion(3);
+    await expect(store.setUserVersion(1.5)).rejects.toBeInstanceOf(RangeError);
+    await expect(store.setUserVersion(-1)).rejects.toBeInstanceOf(RangeError);
+    expect(await store.getUserVersion()).toBe(3);
+  });
+
+  it("rolls back a failing transaction and returns the result of a passing one", async () => {
+    await store.exec("CREATE TABLE t(a TEXT)");
+    await expect(
+      store.transaction(async () => {
+        await store.run("INSERT INTO t(a) VALUES (?)", ["boom"]);
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+    expect(await store.all("SELECT a FROM t")).toEqual([]);
+
+    const result = await store.transaction(async () => {
+      await store.run("INSERT INTO t(a) VALUES (?)", ["ok"]);
+      return 42;
+    });
+    expect(result).toBe(42);
+    expect(await store.all("SELECT a FROM t")).toEqual([{ a: "ok" }]);
+  });
+});

--- a/packages/kernel-node/tsup.config.ts
+++ b/packages/kernel-node/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: ["src/index.ts"],
+  entry: { index: "src/index.ts", sqlite: "src/sqlite/index.ts" },
   format: ["esm"],
   dts: true,
   sourcemap: true,

--- a/packages/kernel/src/store/anchor-repository.ts
+++ b/packages/kernel/src/store/anchor-repository.ts
@@ -1,0 +1,61 @@
+import type { AnchorHistoryRow, AnchorRepository, Row, SqlStore } from "./ports.js";
+
+function toAnchorHistoryRow(r: Row): AnchorHistoryRow {
+  return {
+    id: r.id as string,
+    sport: r.sport as string,
+    anchor_type: r.anchor_type as string,
+    value: r.value as number,
+    unit: r.unit as string,
+    valid_from: r.valid_from as number,
+    source: r.source as string,
+    confidence: r.confidence as string,
+    note: r.note as string | null,
+    provenance: r.provenance as string,
+    device_id: r.device_id as string | null,
+    hlc_physical_ms: r.hlc_physical_ms as number | null,
+    hlc_counter: r.hlc_counter as number | null,
+  };
+}
+
+export function createAnchorRepository(store: SqlStore): AnchorRepository {
+  return {
+    async insertIfAbsent(row: AnchorHistoryRow): Promise<boolean> {
+      const existing = await store.get(
+        "SELECT 1 AS x FROM anchor_history WHERE sport = ? AND anchor_type = ? AND valid_from = ?",
+        [row.sport, row.anchor_type, row.valid_from],
+      );
+      if (existing) return false;
+      await store.run(
+        "INSERT INTO anchor_history (id, sport, anchor_type, value, unit, valid_from, source, confidence, note, provenance, device_id, hlc_physical_ms, hlc_counter) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)",
+        [
+          row.id,
+          row.sport,
+          row.anchor_type,
+          row.value,
+          row.unit,
+          row.valid_from,
+          row.source,
+          row.confidence,
+          row.note,
+          row.provenance,
+          row.device_id,
+          row.hlc_physical_ms,
+          row.hlc_counter,
+        ],
+      );
+      return true;
+    },
+    async readCurrent(
+      sport: string,
+      anchorType: string,
+      asOfEpochS: number,
+    ): Promise<AnchorHistoryRow | undefined> {
+      const r = await store.get(
+        "SELECT * FROM anchor_history WHERE sport = ? AND anchor_type = ? AND valid_from <= ? ORDER BY valid_from DESC, CASE confidence WHEN 'manual' THEN 0 WHEN 'platform' THEN 1 WHEN 'fit' THEN 2 ELSE 3 END ASC LIMIT 1",
+        [sport, anchorType, asOfEpochS],
+      );
+      return r === undefined ? undefined : toAnchorHistoryRow(r);
+    },
+  };
+}

--- a/packages/kernel/src/store/anchor-repository.ts
+++ b/packages/kernel/src/store/anchor-repository.ts
@@ -1,22 +1,4 @@
-import type { AnchorHistoryRow, AnchorRepository, Row, SqlStore } from "./ports.js";
-
-function toAnchorHistoryRow(r: Row): AnchorHistoryRow {
-  return {
-    id: r.id as string,
-    sport: r.sport as string,
-    anchor_type: r.anchor_type as string,
-    value: r.value as number,
-    unit: r.unit as string,
-    valid_from: r.valid_from as number,
-    source: r.source as string,
-    confidence: r.confidence as string,
-    note: r.note as string | null,
-    provenance: r.provenance as string,
-    device_id: r.device_id as string | null,
-    hlc_physical_ms: r.hlc_physical_ms as number | null,
-    hlc_counter: r.hlc_counter as number | null,
-  };
-}
+import type { AnchorHistoryRow, AnchorRepository, SqlStore } from "./ports.js";
 
 export function createAnchorRepository(store: SqlStore): AnchorRepository {
   return {
@@ -55,7 +37,7 @@ export function createAnchorRepository(store: SqlStore): AnchorRepository {
         "SELECT * FROM anchor_history WHERE sport = ? AND anchor_type = ? AND valid_from <= ? ORDER BY valid_from DESC, CASE confidence WHEN 'manual' THEN 0 WHEN 'platform' THEN 1 WHEN 'fit' THEN 2 ELSE 3 END ASC LIMIT 1",
         [sport, anchorType, asOfEpochS],
       );
-      return r === undefined ? undefined : toAnchorHistoryRow(r);
+      return r === undefined ? undefined : (r as unknown as AnchorHistoryRow);
     },
   };
 }

--- a/packages/kernel/src/store/canonical-json.ts
+++ b/packages/kernel/src/store/canonical-json.ts
@@ -1,0 +1,41 @@
+import type { Row, SqlValue } from "./ports.js";
+
+/** ECMAScript Number::toString (shortest round-trip, engine-stable). Rejects non-finite; normalizes -0. */
+export function canonicalNumber(n: number): string {
+  if (!Number.isFinite(n)) throw new Error(`canonical dump: non-finite number ${n}`);
+  return Object.is(n, -0) ? "0" : `${n}`;
+}
+
+function toHex(bytes: Uint8Array): string {
+  let out = "";
+  for (const b of bytes) out += b.toString(16).padStart(2, "0");
+  return out;
+}
+
+/** Tag every scalar so TEXT/INTEGER/REAL/BLOB/NULL can never alias in the dump. */
+export function canonicalScalar(v: SqlValue): [string, string | null] {
+  if (v === null) return ["z", null];
+  if (typeof v === "string") return ["s", v];
+  if (typeof v === "number") return ["n", canonicalNumber(v)];
+  if (typeof v === "bigint") return ["i", v.toString()];
+  return ["b", toHex(v)];
+}
+
+/** Recursive alphabetical key-sort (re-implements tools/s8a/lib/canonical.ts stableSerialize). */
+export function sortKeys(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortKeys);
+  if (value !== null && typeof value === "object") {
+    const rec = value as Record<string, unknown>;
+    const sorted: Record<string, unknown> = {};
+    for (const k of Object.keys(rec).sort()) sorted[k] = sortKeys(rec[k]);
+    return sorted;
+  }
+  return value;
+}
+
+/** One row → a single canonical JSON line (keys sorted, values tagged). */
+export function canonicalRowJson(row: Row): string {
+  const tagged: Record<string, [string, string | null]> = {};
+  for (const key of Object.keys(row)) tagged[key] = canonicalScalar(row[key]);
+  return JSON.stringify(sortKeys(tagged));
+}

--- a/packages/kernel/src/store/dump.ts
+++ b/packages/kernel/src/store/dump.ts
@@ -1,0 +1,41 @@
+import { canonicalRowJson } from "./canonical-json.js";
+import type { Row, SqlStore } from "./ports.js";
+
+/** Every table in 001_init.sql, alphabetical, with its content-derived order key (DDL-SPEC §4/§8). */
+export const DUMP_TABLES: readonly { readonly table: string; readonly orderBy: string }[] = [
+  { table: "anchor_history", orderBy: "id" },
+  { table: "athlete", orderBy: "id" },
+  { table: "field_merge_override_overlay", orderBy: "id" },
+  { table: "intake_flags", orderBy: "id" },
+  { table: "lap", orderBy: "lap_key" },
+  { table: "mean_max_cache", orderBy: "mmax_key" },
+  { table: "metric_snapshot", orderBy: "snapshot_key" },
+  { table: "planned_workout", orderBy: "id" },
+  { table: "pool_size_correction_overlay", orderBy: "id" },
+  { table: "race_goal", orderBy: "id" },
+  { table: "raw_file", orderBy: "sha256" },
+  { table: "session", orderBy: "session_key" },
+  { table: "source_record", orderBy: "id" },
+  { table: "sport_settings", orderBy: "id" },
+  { table: "stream", orderBy: "stream_key" },
+  { table: "stroke_correction_overlay", orderBy: "id" },
+  { table: "swim_length", orderBy: "length_key" },
+  { table: "wellness", orderBy: "id" },
+  { table: "workout", orderBy: "workout_key" },
+  { table: "zone_set_history", orderBy: "id" },
+];
+
+/** Pure: already-ordered rows → the canonical section for one table (header line + one line per row). */
+export function canonicalizeTable(table: string, rows: readonly Row[]): string {
+  return [`# ${table}`, ...rows.map(canonicalRowJson)].join("\n");
+}
+
+/** Async: SELECT * ORDER BY <key> per table, canonicalize, concatenate. */
+export async function dumpStore(store: SqlStore): Promise<string> {
+  const sections: string[] = [];
+  for (const { table, orderBy } of DUMP_TABLES) {
+    const rows = await store.all(`SELECT * FROM ${table} ORDER BY ${orderBy} ASC`);
+    sections.push(canonicalizeTable(table, rows));
+  }
+  return sections.join("\n");
+}

--- a/packages/kernel/src/store/index.ts
+++ b/packages/kernel/src/store/index.ts
@@ -1,1 +1,6 @@
 export * from "./migrator.js";
+export * from "./ports.js";
+export * from "./canonical-json.js";
+export * from "./dump.js";
+export * from "./anchor-repository.js";
+export * from "./source-repository.js";

--- a/packages/kernel/src/store/ports.ts
+++ b/packages/kernel/src/store/ports.ts
@@ -1,0 +1,68 @@
+export type SqlValue = string | number | bigint | Uint8Array | null;
+export type Row = Record<string, SqlValue>;
+
+/**
+ * Low-level async SQL-exec port. The SQLite driver in kernel-node implements it
+ * (wrapping the synchronous DatabaseSync in resolved promises, per the
+ * async-first port rule). No driver types cross this boundary.
+ */
+export interface SqlStore {
+  exec(sql: string): Promise<void>;
+  run(sql: string, params?: readonly SqlValue[]): Promise<void>;
+  get(sql: string, params?: readonly SqlValue[]): Promise<Row | undefined>;
+  all(sql: string, params?: readonly SqlValue[]): Promise<Row[]>;
+  close(): Promise<void>;
+}
+
+export interface AnchorHistoryRow {
+  id: string;
+  sport: string;
+  anchor_type: string;
+  value: number;
+  unit: string;
+  valid_from: number;
+  source: string;
+  confidence: string;
+  note: string | null;
+  provenance: string;
+  device_id: string | null;
+  hlc_physical_ms: number | null;
+  hlc_counter: number | null;
+}
+
+export interface RawFileRow {
+  sha256: string;
+  path: string | null;
+  ext: string | null;
+  bytes: number | null;
+  file_id_serial: number | null;
+  file_id_time_created_utc: number | null;
+  manufacturer: string | null;
+  product: string | null;
+}
+
+export interface SourceRecordRow {
+  id: string;
+  workout_key: string | null;
+  session_key: string | null;
+  source: string;
+  external_id: string;
+  raw_sha256: string | null;
+  quality_rank: number;
+  payload_json: string;
+}
+
+export interface AnchorRepository {
+  /** Insert iff no row exists for (sport, anchor_type, valid_from). Returns true if inserted. */
+  insertIfAbsent(row: AnchorHistoryRow): Promise<boolean>;
+  /** Effective-dated current row: max valid_from ≤ asOfEpochS, tie-broken by confidence precedence. */
+  readCurrent(sport: string, anchorType: string, asOfEpochS: number): Promise<AnchorHistoryRow | undefined>;
+}
+
+export interface RawFileRepository {
+  upsert(row: RawFileRow): Promise<void>;
+}
+
+export interface SourceRecordRepository {
+  upsert(row: SourceRecordRow): Promise<void>;
+}

--- a/packages/kernel/src/store/source-repository.ts
+++ b/packages/kernel/src/store/source-repository.ts
@@ -1,0 +1,47 @@
+import type {
+  RawFileRepository,
+  RawFileRow,
+  SourceRecordRepository,
+  SourceRecordRow,
+  SqlStore,
+} from "./ports.js";
+
+export function createRawFileRepository(store: SqlStore): RawFileRepository {
+  return {
+    async upsert(row: RawFileRow): Promise<void> {
+      await store.run(
+        "INSERT INTO raw_file (sha256, path, ext, bytes, file_id_serial, file_id_time_created_utc, manufacturer, product) VALUES (?,?,?,?,?,?,?,?) ON CONFLICT DO NOTHING",
+        [
+          row.sha256,
+          row.path,
+          row.ext,
+          row.bytes,
+          row.file_id_serial,
+          row.file_id_time_created_utc,
+          row.manufacturer,
+          row.product,
+        ],
+      );
+    },
+  };
+}
+
+export function createSourceRecordRepository(store: SqlStore): SourceRecordRepository {
+  return {
+    async upsert(row: SourceRecordRow): Promise<void> {
+      await store.run(
+        "INSERT INTO source_record (id, workout_key, session_key, source, external_id, raw_sha256, quality_rank, payload_json) VALUES (?,?,?,?,?,?,?,?) ON CONFLICT DO NOTHING",
+        [
+          row.id,
+          row.workout_key,
+          row.session_key,
+          row.source,
+          row.external_id,
+          row.raw_sha256,
+          row.quality_rank,
+          row.payload_json,
+        ],
+      );
+    },
+  };
+}

--- a/packages/kernel/tests/canonical-json.test.ts
+++ b/packages/kernel/tests/canonical-json.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import {
+  canonicalNumber,
+  canonicalRowJson,
+  canonicalScalar,
+  sortKeys,
+} from "../src/store/canonical-json.js";
+import type { Row } from "../src/store/ports.js";
+
+describe("canonicalNumber", () => {
+  it("renders shortest decimal strings", () => {
+    expect(canonicalNumber(1.5)).toBe("1.5");
+    expect(canonicalNumber(1)).toBe("1");
+    expect(canonicalNumber(250.5)).toBe("250.5");
+    expect(canonicalNumber(-2.5)).toBe("-2.5");
+  });
+
+  it("normalizes -0 and 0 to '0'", () => {
+    expect(canonicalNumber(-0)).toBe("0");
+    expect(canonicalNumber(0)).toBe("0");
+  });
+
+  it("throws on non-finite values", () => {
+    expect(() => canonicalNumber(NaN)).toThrow();
+    expect(() => canonicalNumber(Infinity)).toThrow();
+    expect(() => canonicalNumber(-Infinity)).toThrow();
+  });
+});
+
+describe("canonicalScalar", () => {
+  it("tags each scalar type distinctly", () => {
+    expect(canonicalScalar(null)).toEqual(["z", null]);
+    expect(canonicalScalar("x")).toEqual(["s", "x"]);
+    expect(canonicalScalar(7)).toEqual(["n", "7"]);
+    expect(canonicalScalar(10n)).toEqual(["i", "10"]);
+    expect(canonicalScalar(new Uint8Array([0, 255, 16]))).toEqual(["b", "00ff10"]);
+  });
+});
+
+describe("sortKeys", () => {
+  it("sorts object keys ascending, recursively", () => {
+    const input = { b: 2, a: 1, nested: { z: 26, y: 25 } };
+    const sorted = sortKeys(input);
+    expect(JSON.stringify(sorted)).toBe(JSON.stringify({ a: 1, b: 2, nested: { y: 25, z: 26 } }));
+  });
+});
+
+describe("canonicalRowJson", () => {
+  it("produces byte-identical output regardless of key insertion order", () => {
+    const rowA: Row = { a: "x", b: 250.5, c: null };
+    const rowB: Row = { c: null, b: 250.5, a: "x" };
+    expect(canonicalRowJson(rowA)).toBe(canonicalRowJson(rowB));
+  });
+
+  it("renders a REAL value with the ['n', ...] tag", () => {
+    const row: Row = { value: 250.5 };
+    expect(canonicalRowJson(row)).toBe(JSON.stringify({ value: ["n", "250.5"] }));
+  });
+});

--- a/packages/kernel/tests/store-dump.test.ts
+++ b/packages/kernel/tests/store-dump.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { canonicalizeTable } from "../src/store/dump.js";
+import type { Row } from "../src/store/ports.js";
+
+describe("INV-2 canonical dump (armed with real ingest at W2)", () => {
+  const rowA: Row = {
+    id: "a1",
+    sport: "cycling",
+    anchor_type: "ftp",
+    value: 250.5,
+    unit: "W",
+    valid_from: 1000,
+    source: "manual",
+    confidence: "manual",
+    note: null,
+    provenance: "manual",
+    device_id: null,
+    hlc_physical_ms: null,
+    hlc_counter: null,
+  };
+  const rowB: Row = {
+    id: "a2",
+    sport: "cycling",
+    anchor_type: "ftp",
+    value: 260,
+    unit: "W",
+    valid_from: 2000,
+    source: "manual",
+    confidence: "manual",
+    note: null,
+    provenance: "manual",
+    device_id: null,
+    hlc_physical_ms: null,
+    hlc_counter: null,
+  };
+
+  it("emits a table header and one line per row, stable across calls", () => {
+    const out = canonicalizeTable("anchor_history", [rowA, rowB]);
+    expect(out.startsWith("# anchor_history")).toBe(true);
+    expect(out.split("\n")).toHaveLength(3);
+    expect(canonicalizeTable("anchor_history", [rowA, rowB])).toBe(out);
+  });
+
+  it("normalizes column key order inside a row", () => {
+    const scrambled: Row = {
+      value: 250.5,
+      id: "a1",
+      sport: "cycling",
+      anchor_type: "ftp",
+      unit: "W",
+      valid_from: 1000,
+      source: "manual",
+      confidence: "manual",
+      note: null,
+      provenance: "manual",
+      device_id: null,
+      hlc_physical_ms: null,
+      hlc_counter: null,
+    };
+    expect(canonicalizeTable("anchor_history", [scrambled])).toBe(
+      canonicalizeTable("anchor_history", [rowA]),
+    );
+  });
+
+  it("renders a BLOB column via the ['b', ...] tag", () => {
+    const row: Row = { data: new Uint8Array([1, 2, 3]) };
+    const out = canonicalizeTable("raw_file", [row]);
+    expect(out).toContain(`"data":["b","010203"]`);
+  });
+});


### PR DESCRIPTION
## Summary

Adds the storage layer for the pure compute kernel and its Node driver.

- **`@enduragent/kernel` `./store` subpath** — a pure repository layer with no runtime dependencies:
  - `ports.ts` defines the `SqlStore` port plus the anchor / raw-file / source-record row and repository interfaces.
  - `canonical-json.ts` re-implements an engine-stable float serializer and key-sorted row canonicalizer from scratch (no import from the tooling layer).
  - `dump.ts` produces the canonical, ordered logical dump (`SELECT *` ordered by a content-derived key) used to assert dump-identity.
  - `anchor-repository.ts` does insert-if-absent on the three-column key plus an effective-dated read-current with manual > platform > fit precedence.
  - `source-repository.ts` upserts raw-file and source-record rows via `INSERT ... ON CONFLICT DO NOTHING`.
- **`@enduragent/kernel-node` `./sqlite` subpath** — the driver that wraps Node's built-in `node:sqlite` `DatabaseSync` behind the pure `SqlStore` port on a single connection object (WAL mode, `foreign_keys=ON`, null-prototype row normalization). The same connection object also satisfies the migrator port from the preceding change, so the migrator runs against it directly with no wrapper.
- **Package wiring** — both packages gain their new subpath in `tsup.config.ts` and `package.json` exports (no `.` barrel). `kernel-node` declares `engines.node >= 24`.

## Test plan

- `pnpm build` — emits `dist/store.js` (+ types) for the kernel and `dist/sqlite.js` (+ types) for the node package.
- `pnpm check` — passes end-to-end, including package-dependency and kernel-purity lints (the kernel store layer stays free of `node:*` and workspace imports; the driver types never cross the port).
- `pnpm vitest run packages/kernel/tests packages/kernel-node/tests` — covers the canonical-JSON serializer, the store dump, the sqlite adapter, the repositories, and an end-to-end migrator run against a real temp-file database.
- `pnpm test`, `pnpm s8a`, and `pnpm check-parity --all` — all green with zero snapshot regeneration.

The `node:sqlite` ExperimentalWarning is accepted as-is and never globally suppressed.
