### PR TITLE
feat(kernel): raw-archive manager (content-addressed writes, snapshots, quarantine)

### DIFF
--- a/.changeset/kernel-raw-archive.md
+++ b/.changeset/kernel-raw-archive.md
@@ -1,0 +1,10 @@
+---
+"@enduragent/kernel": patch
+"@enduragent/kernel-node": patch
+---
+
+Add the content-addressed raw-archive manager to the pure kernel and its Node
+host adapter: content-addressed artifact writes, gzipped canonical-JSON payload
+snapshots, quarantine routing for unparseable inputs, and a structurally
+never-delete, archive-first write surface behind the injected Crypto and
+FileSystem ports.

--- a/packages/kernel-node/package.json
+++ b/packages/kernel-node/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "files": ["dist"],
   "exports": {
-    "./sqlite": "./dist/sqlite.js"
+    "./sqlite": "./dist/sqlite.js",
+    "./archive": "./dist/archive/index.js"
   },
   "engines": {
     "node": ">=24"

--- a/packages/kernel-node/src/archive/index.ts
+++ b/packages/kernel-node/src/archive/index.ts
@@ -1,0 +1,7 @@
+export { createArchiveManager, ARCHIVE_GZIP_LEVEL } from "./manager.js";
+export type { ArchiveManagerDeps } from "./manager.js";
+export type {
+  ArchiveManager,
+  ArchiveInstant,
+  ArchiveWriteResult,
+} from "@enduragent/kernel/archive";

--- a/packages/kernel-node/src/archive/manager.ts
+++ b/packages/kernel-node/src/archive/manager.ts
@@ -1,0 +1,112 @@
+import { dirname, join } from "node:path";
+import { gunzipSync, gzipSync } from "node:zlib";
+import type { CryptoPort, FileSystemPort } from "@enduragent/kernel/ports";
+import {
+  artifactRelPath,
+  canonicalJson,
+  quarantineRelPath,
+  snapshotRelPath,
+  type ArchiveInstant,
+  type ArchiveManager,
+  type ArchiveWriteResult,
+} from "@enduragent/kernel/archive";
+
+export const ARCHIVE_GZIP_LEVEL = 6;
+
+export interface ArchiveManagerDeps {
+  /** Absolute path to the archive root. NEVER derived from the store/DB dir. */
+  readonly archiveRoot: string;
+  readonly crypto: CryptoPort;
+  readonly fs: FileSystemPort;
+}
+
+function toHex(bytes: Uint8Array): string {
+  let hex = "";
+  for (const byte of bytes) {
+    hex += byte.toString(16).padStart(2, "0");
+  }
+  return hex;
+}
+
+export function createArchiveManager(deps: ArchiveManagerDeps): ArchiveManager {
+  const { archiveRoot, crypto, fs } = deps;
+
+  async function addressOf(bytes: Uint8Array): Promise<string> {
+    return toHex(await crypto.sha256(bytes));
+  }
+
+  async function exists(full: string): Promise<boolean> {
+    return (await fs.stat(full)) !== undefined;
+  }
+
+  // Durable write through the injected FileSystem port: its writeFile is the
+  // atomic temp->fsync->rename seam, so a mid-write kill leaves the old file or
+  // nothing, never a truncated artifact. The manager holds no deletion path
+  // over committed archive content.
+  async function writeDurable(full: string, bytes: Uint8Array): Promise<void> {
+    await fs.mkdir(dirname(full), { recursive: true });
+    await fs.writeFile(full, bytes);
+  }
+
+  return {
+    async writeArtifact(
+      bytes: Uint8Array,
+      ext: string,
+      when: ArchiveInstant,
+    ): Promise<ArchiveWriteResult> {
+      const address = await addressOf(bytes);
+      const relPath = artifactRelPath(address, ext, when);
+      const full = join(archiveRoot, relPath);
+      if (await exists(full)) {
+        return { address, relPath, deduped: true };
+      }
+      await writeDurable(full, bytes);
+      return { address, relPath, deduped: false };
+    },
+
+    async writeSnapshot(payload: unknown, when: ArchiveInstant): Promise<ArchiveWriteResult> {
+      const raw = Buffer.from(canonicalJson(payload), "utf8");
+      const gz = gzipSync(raw, { level: ARCHIVE_GZIP_LEVEL });
+      const address = await addressOf(gz);
+      const relPath = snapshotRelPath(address, when);
+      const full = join(archiveRoot, relPath);
+      if (await exists(full)) {
+        return { address, relPath, deduped: true };
+      }
+      await writeDurable(full, gz);
+      return { address, relPath, deduped: false };
+    },
+
+    async quarantine(
+      bytes: Uint8Array,
+      ext: string,
+      reason: string,
+    ): Promise<ArchiveWriteResult> {
+      const address = await addressOf(bytes);
+      const relPath = quarantineRelPath(address, ext);
+      const full = join(archiveRoot, relPath);
+      await fs.mkdir(dirname(full), { recursive: true });
+      const deduped = await exists(full);
+      if (!deduped) {
+        await fs.writeFile(full, bytes);
+      }
+      // Durable reason sidecar: an unparseable payload is never silently
+      // dropped — the why is persisted beside the bytes, not merely logged.
+      await fs.writeFile(`${full}.reason.txt`, reason);
+      return { address, relPath, deduped };
+    },
+
+    async readArtifact(relPath: string): Promise<Uint8Array> {
+      return fs.readFile(join(archiveRoot, relPath));
+    },
+
+    async readSnapshot(relPath: string): Promise<unknown> {
+      const gz = await fs.readFile(join(archiveRoot, relPath));
+      return JSON.parse(gunzipSync(gz).toString("utf8"));
+    },
+
+    async has(relPath: string): Promise<boolean> {
+      return exists(join(archiveRoot, relPath));
+    },
+  };
+}

--- a/packages/kernel-node/src/archive/manager.ts
+++ b/packages/kernel-node/src/archive/manager.ts
@@ -4,8 +4,10 @@ import type { CryptoPort, FileSystemPort } from "@enduragent/kernel/ports";
 import {
   artifactRelPath,
   canonicalJson,
+  quarantineReasonRelPath,
   quarantineRelPath,
   snapshotRelPath,
+  toHex,
   type ArchiveInstant,
   type ArchiveManager,
   type ArchiveWriteResult,
@@ -18,14 +20,6 @@ export interface ArchiveManagerDeps {
   readonly archiveRoot: string;
   readonly crypto: CryptoPort;
   readonly fs: FileSystemPort;
-}
-
-function toHex(bytes: Uint8Array): string {
-  let hex = "";
-  for (const byte of bytes) {
-    hex += byte.toString(16).padStart(2, "0");
-  }
-  return hex;
 }
 
 export function createArchiveManager(deps: ArchiveManagerDeps): ArchiveManager {
@@ -43,9 +37,22 @@ export function createArchiveManager(deps: ArchiveManagerDeps): ArchiveManager {
   // atomic temp->fsync->rename seam, so a mid-write kill leaves the old file or
   // nothing, never a truncated artifact. The manager holds no deletion path
   // over committed archive content.
-  async function writeDurable(full: string, bytes: Uint8Array): Promise<void> {
+  async function writeDurable(full: string, data: Uint8Array | string): Promise<void> {
     await fs.mkdir(dirname(full), { recursive: true });
-    await fs.writeFile(full, bytes);
+    await fs.writeFile(full, data);
+  }
+
+  async function commit(
+    address: string,
+    relPath: string,
+    bytes: Uint8Array,
+  ): Promise<ArchiveWriteResult> {
+    const full = join(archiveRoot, relPath);
+    if (await exists(full)) {
+      return { address, relPath, deduped: true };
+    }
+    await writeDurable(full, bytes);
+    return { address, relPath, deduped: false };
   }
 
   return {
@@ -55,26 +62,14 @@ export function createArchiveManager(deps: ArchiveManagerDeps): ArchiveManager {
       when: ArchiveInstant,
     ): Promise<ArchiveWriteResult> {
       const address = await addressOf(bytes);
-      const relPath = artifactRelPath(address, ext, when);
-      const full = join(archiveRoot, relPath);
-      if (await exists(full)) {
-        return { address, relPath, deduped: true };
-      }
-      await writeDurable(full, bytes);
-      return { address, relPath, deduped: false };
+      return commit(address, artifactRelPath(address, ext, when), bytes);
     },
 
     async writeSnapshot(payload: unknown, when: ArchiveInstant): Promise<ArchiveWriteResult> {
       const raw = Buffer.from(canonicalJson(payload), "utf8");
       const gz = gzipSync(raw, { level: ARCHIVE_GZIP_LEVEL });
       const address = await addressOf(gz);
-      const relPath = snapshotRelPath(address, when);
-      const full = join(archiveRoot, relPath);
-      if (await exists(full)) {
-        return { address, relPath, deduped: true };
-      }
-      await writeDurable(full, gz);
-      return { address, relPath, deduped: false };
+      return commit(address, snapshotRelPath(address, when), gz);
     },
 
     async quarantine(
@@ -83,17 +78,15 @@ export function createArchiveManager(deps: ArchiveManagerDeps): ArchiveManager {
       reason: string,
     ): Promise<ArchiveWriteResult> {
       const address = await addressOf(bytes);
-      const relPath = quarantineRelPath(address, ext);
-      const full = join(archiveRoot, relPath);
-      await fs.mkdir(dirname(full), { recursive: true });
-      const deduped = await exists(full);
-      if (!deduped) {
-        await fs.writeFile(full, bytes);
-      }
+      const result = await commit(address, quarantineRelPath(address, ext), bytes);
       // Durable reason sidecar: an unparseable payload is never silently
       // dropped — the why is persisted beside the bytes, not merely logged.
-      await fs.writeFile(`${full}.reason.txt`, reason);
-      return { address, relPath, deduped };
+      // First reason wins: committed archive-adjacent content is never rewritten.
+      const reasonFull = join(archiveRoot, quarantineReasonRelPath(address, ext));
+      if (!(await exists(reasonFull))) {
+        await writeDurable(reasonFull, reason);
+      }
+      return result;
     },
 
     async readArtifact(relPath: string): Promise<Uint8Array> {

--- a/packages/kernel-node/tests/archive-manager.test.ts
+++ b/packages/kernel-node/tests/archive-manager.test.ts
@@ -1,5 +1,6 @@
 import { createHash, randomBytes } from "node:crypto";
 import { mkdtempSync, readdirSync, rmSync } from "node:fs";
+import { gunzipSync } from "node:zlib";
 import { open, mkdir, readFile, rename, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { isAbsolute, join, relative, resolve } from "node:path";
@@ -128,14 +129,36 @@ describe("archive manager", () => {
     expect(yearDirs).toEqual([]);
   });
 
+  it("preserves the first quarantine reason — a re-quarantine never rewrites the sidecar", async () => {
+    const manager = makeManager();
+    const bytes = new Uint8Array([255, 0, 128]);
+    const first = await manager.quarantine(bytes, "bin", "original diagnosis");
+    const second = await manager.quarantine(bytes, "bin", "later different reason");
+
+    expect(second.deduped).toBe(true);
+    expect(second.relPath).toBe(first.relPath);
+    const full = join(archiveRoot, first.relPath);
+    expect(await readFile(`${full}.reason.txt`, "utf8")).toBe("original diagnosis");
+  });
+
   it("round-trips a snapshot through gzip and canonical JSON", async () => {
     const manager = makeManager();
     const payload = { b: 1, a: { d: 4, c: 3 }, list: [3, 1, 2] };
     const result = await manager.writeSnapshot(payload, WHEN);
 
     expect(result.relPath.endsWith(".json.gz")).toBe(true);
+    const onDisk = gunzipSync(await readFile(join(archiveRoot, result.relPath))).toString("utf8");
+    expect(onDisk).toBe(canonicalJson(payload));
     const readBack = await manager.readSnapshot(result.relPath);
     expect(canonicalJson(readBack)).toBe(canonicalJson(payload));
+  });
+
+  it("addresses key-order-insensitively — reordered keys hit the same snapshot", async () => {
+    const manager = makeManager();
+    const first = await manager.writeSnapshot({ b: 1, a: { d: 4, c: 3 } }, WHEN);
+    const second = await manager.writeSnapshot({ a: { c: 3, d: 4 }, b: 1 }, WHEN);
+    expect(second.address).toBe(first.address);
+    expect(second.deduped).toBe(true);
   });
 
   it("addresses the compressed bytes and dedups a repeated snapshot", async () => {

--- a/packages/kernel-node/tests/archive-manager.test.ts
+++ b/packages/kernel-node/tests/archive-manager.test.ts
@@ -1,0 +1,171 @@
+import { createHash, randomBytes } from "node:crypto";
+import { mkdtempSync, readdirSync, rmSync } from "node:fs";
+import { open, mkdir, readFile, rename, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { isAbsolute, join, relative, resolve } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { CryptoPort, FileSystemPort } from "@enduragent/kernel/ports";
+import { canonicalJson } from "@enduragent/kernel/archive";
+import { createArchiveManager } from "../src/archive/index.js";
+
+function makeCrypto(): CryptoPort {
+  return {
+    async sha256(data) {
+      return new Uint8Array(createHash("sha256").update(data).digest());
+    },
+    async randomBytes(length) {
+      return new Uint8Array(randomBytes(length));
+    },
+    async pbkdf2() {
+      throw new Error("unused in archive tests");
+    },
+    async aesGcmEncrypt() {
+      throw new Error("unused in archive tests");
+    },
+    async aesGcmDecrypt() {
+      throw new Error("unused in archive tests");
+    },
+  };
+}
+
+function makeFs(): FileSystemPort {
+  return {
+    async readFile(path) {
+      return new Uint8Array(await readFile(path));
+    },
+    async readTextFile(path) {
+      return readFile(path, "utf8");
+    },
+    async writeFile(path, data, options) {
+      const tmp = `${path}.tmp.${randomBytes(4).toString("hex")}`;
+      const fh = await open(tmp, "w", options?.mode ?? 0o600);
+      try {
+        await fh.writeFile(typeof data === "string" ? Buffer.from(data, "utf8") : Buffer.from(data));
+        await fh.sync();
+      } finally {
+        await fh.close();
+      }
+      await rename(tmp, path);
+    },
+    async rename(from, to) {
+      await rename(from, to);
+    },
+    async mkdir(path, options) {
+      await mkdir(path, { recursive: options?.recursive ?? false });
+    },
+    async list() {
+      throw new Error("unused in archive tests");
+    },
+    async stat(path) {
+      try {
+        const s = await stat(path);
+        return {
+          kind: s.isFile() ? "file" : s.isDirectory() ? "directory" : "other",
+          size: s.size,
+          mtimeMs: s.mtimeMs,
+        };
+      } catch {
+        return undefined;
+      }
+    },
+  };
+}
+
+const WHEN = { epochSeconds: 1615766400 }; // 2021-03-15T00:00:00Z
+
+let archiveRoot: string;
+
+beforeEach(() => {
+  archiveRoot = mkdtempSync(join(tmpdir(), "archive-mgr-"));
+});
+
+afterEach(() => {
+  rmSync(archiveRoot, { recursive: true, force: true });
+});
+
+function makeManager() {
+  return createArchiveManager({ archiveRoot, crypto: makeCrypto(), fs: makeFs() });
+}
+
+describe("archive manager", () => {
+  it("produces a stable content address for identical bytes", async () => {
+    const manager = makeManager();
+    const bytes = new Uint8Array([1, 2, 3, 4]);
+    const first = await manager.writeArtifact(bytes, "fit", WHEN);
+    const second = await manager.writeArtifact(new Uint8Array([1, 2, 3, 4]), "fit", WHEN);
+    expect(first.address).toBe(second.address);
+    expect(first.relPath).toBe(second.relPath);
+    expect(first.relPath).toBe(`2021/03/${first.address}.fit`);
+  });
+
+  it("is idempotent — the second write is a skipped no-op, not a rewrite", async () => {
+    const manager = makeManager();
+    const bytes = new Uint8Array([9, 8, 7]);
+    const first = await manager.writeArtifact(bytes, "fit", WHEN);
+    expect(first.deduped).toBe(false);
+
+    const full = join(archiveRoot, first.relPath);
+    // Overwrite the committed file with a sentinel; a dedup no-op must leave it.
+    await writeFile(full, Buffer.from([42]));
+
+    const second = await manager.writeArtifact(bytes, "fit", WHEN);
+    expect(second.deduped).toBe(true);
+    expect(new Uint8Array(await readFile(full))).toEqual(new Uint8Array([42]));
+  });
+
+  it("routes unparseable bytes to quarantine with a durable reason sidecar", async () => {
+    const manager = makeManager();
+    const bytes = new Uint8Array([255, 0, 128]);
+    const result = await manager.quarantine(bytes, "bin", "unparseable payload");
+
+    expect(result.relPath).toBe(`quarantine/${result.address}.bin`);
+    const full = join(archiveRoot, result.relPath);
+    expect(new Uint8Array(await readFile(full))).toEqual(bytes);
+    expect(await readFile(`${full}.reason.txt`, "utf8")).toBe("unparseable payload");
+
+    // Nothing landed under a yyyy/mm shard.
+    const yearDirs = readdirSync(archiveRoot).filter((name) => /^\d{4}$/.test(name));
+    expect(yearDirs).toEqual([]);
+  });
+
+  it("round-trips a snapshot through gzip and canonical JSON", async () => {
+    const manager = makeManager();
+    const payload = { b: 1, a: { d: 4, c: 3 }, list: [3, 1, 2] };
+    const result = await manager.writeSnapshot(payload, WHEN);
+
+    expect(result.relPath.endsWith(".json.gz")).toBe(true);
+    const readBack = await manager.readSnapshot(result.relPath);
+    expect(canonicalJson(readBack)).toBe(canonicalJson(payload));
+  });
+
+  it("addresses the compressed bytes and dedups a repeated snapshot", async () => {
+    const manager = makeManager();
+    const payload = { alpha: [1, 2, 3], beta: "x" };
+    const first = await manager.writeSnapshot(payload, WHEN);
+    const second = await manager.writeSnapshot(payload, WHEN);
+    expect(first.address).toBe(second.address);
+    expect(first.deduped).toBe(false);
+    expect(second.deduped).toBe(true);
+  });
+
+  it("exposes no deletion or mutation surface (never-delete is structural)", () => {
+    const manager = makeManager();
+    for (const forbidden of ["delete", "remove", "unlink", "prune", "update", "rm"]) {
+      expect(forbidden in manager).toBe(false);
+    }
+  });
+
+  it("confines every written path under archiveRoot", async () => {
+    const manager = makeManager();
+    const artifact = await manager.writeArtifact(new Uint8Array([1]), "fit", WHEN);
+    const snapshot = await manager.writeSnapshot({ k: 1 }, WHEN);
+    const quarantined = await manager.quarantine(new Uint8Array([2]), "bin", "why");
+    const rootReal = resolve(archiveRoot);
+    for (const rel of [artifact.relPath, snapshot.relPath, quarantined.relPath]) {
+      const full = resolve(join(archiveRoot, rel));
+      const rel2 = relative(rootReal, full);
+      expect(rel2.startsWith("..")).toBe(false);
+      expect(isAbsolute(rel2)).toBe(false);
+    }
+  });
+});

--- a/packages/kernel-node/tsup.config.ts
+++ b/packages/kernel-node/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: { index: "src/index.ts", sqlite: "src/sqlite/index.ts" },
+  entry: { index: "src/index.ts", sqlite: "src/sqlite/index.ts", "archive/index": "src/archive/index.ts" },
   format: ["esm"],
   dts: true,
   sourcemap: true,

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -8,7 +8,8 @@
   "exports": {
     "./ports": "./dist/ports.js",
     "./store/migrations": "./dist/store/migrations.js",
-    "./store": "./dist/store.js"
+    "./store": "./dist/store.js",
+    "./archive": "./dist/archive/index.js"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/kernel/src/archive/canonical.ts
+++ b/packages/kernel/src/archive/canonical.ts
@@ -1,0 +1,18 @@
+export function stableSerialize(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(stableSerialize);
+  }
+  if (value !== null && typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    const sorted: Record<string, unknown> = {};
+    for (const key of Object.keys(record).sort()) {
+      sorted[key] = stableSerialize(record[key]);
+    }
+    return sorted;
+  }
+  return value;
+}
+
+export function canonicalJson(value: unknown): string {
+  return JSON.stringify(stableSerialize(value), null, 2);
+}

--- a/packages/kernel/src/archive/canonical.ts
+++ b/packages/kernel/src/archive/canonical.ts
@@ -1,18 +1,5 @@
-export function stableSerialize(value: unknown): unknown {
-  if (Array.isArray(value)) {
-    return value.map(stableSerialize);
-  }
-  if (value !== null && typeof value === "object") {
-    const record = value as Record<string, unknown>;
-    const sorted: Record<string, unknown> = {};
-    for (const key of Object.keys(record).sort()) {
-      sorted[key] = stableSerialize(record[key]);
-    }
-    return sorted;
-  }
-  return value;
-}
+import { sortKeys } from "../store/canonical-json.js";
 
 export function canonicalJson(value: unknown): string {
-  return JSON.stringify(stableSerialize(value), null, 2);
+  return JSON.stringify(sortKeys(value), null, 2);
 }

--- a/packages/kernel/src/archive/index.ts
+++ b/packages/kernel/src/archive/index.ts
@@ -1,0 +1,3 @@
+export * from "./types.js";
+export * from "./paths.js";
+export * from "./canonical.js";

--- a/packages/kernel/src/archive/paths.ts
+++ b/packages/kernel/src/archive/paths.ts
@@ -1,0 +1,59 @@
+import type { ArchiveInstant } from "./types.js";
+
+export const ADDRESS_HEX_LEN = 64;
+
+export class InvalidArtifactExtensionError extends Error {}
+export class InvalidContentAddressError extends Error {}
+
+/** Lowercase, strip a single leading dot, reject anything not /^[a-z0-9]+$/.
+ *  Guards against path traversal and multi-segment extensions (snapshots use
+ *  the fixed `.json.gz` suffix via snapshotRelPath, not this). */
+export function normalizeExt(ext: string): string {
+  let normalized = ext.toLowerCase();
+  if (normalized.startsWith(".")) {
+    normalized = normalized.slice(1);
+  }
+  if (!/^[a-z0-9]+$/.test(normalized)) {
+    throw new InvalidArtifactExtensionError(`invalid artifact extension: ${ext}`);
+  }
+  return normalized;
+}
+
+/** Throw InvalidContentAddressError unless `address` matches /^[0-9a-f]{64}$/. */
+export function assertValidAddress(address: string): void {
+  if (!/^[0-9a-f]{64}$/.test(address)) {
+    throw new InvalidContentAddressError(`invalid content address: ${address}`);
+  }
+}
+
+/** UTC year (4-digit) + zero-padded 2-digit month from an ArchiveInstant. */
+export function shardFromInstant(
+  when: ArchiveInstant,
+): { readonly year: string; readonly month: string } {
+  const date = new Date(when.epochSeconds * 1000);
+  const year = String(date.getUTCFullYear());
+  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+  return { year, month };
+}
+
+/** `<yyyy>/<mm>/<address>.<normalizedExt>` (validates address + ext). */
+export function artifactRelPath(address: string, ext: string, when: ArchiveInstant): string {
+  assertValidAddress(address);
+  const normalizedExt = normalizeExt(ext);
+  const { year, month } = shardFromInstant(when);
+  return `${year}/${month}/${address}.${normalizedExt}`;
+}
+
+/** `<yyyy>/<mm>/<address>.json.gz` (validates address). */
+export function snapshotRelPath(address: string, when: ArchiveInstant): string {
+  assertValidAddress(address);
+  const { year, month } = shardFromInstant(when);
+  return `${year}/${month}/${address}.json.gz`;
+}
+
+/** `quarantine/<address>.<normalizedExt>` — flat, no shard (validates address + ext). */
+export function quarantineRelPath(address: string, ext: string): string {
+  assertValidAddress(address);
+  const normalizedExt = normalizeExt(ext);
+  return `quarantine/${address}.${normalizedExt}`;
+}

--- a/packages/kernel/src/archive/paths.ts
+++ b/packages/kernel/src/archive/paths.ts
@@ -2,8 +2,17 @@ import type { ArchiveInstant } from "./types.js";
 
 export const ADDRESS_HEX_LEN = 64;
 
+const ADDRESS_RE = new RegExp(`^[0-9a-f]{${ADDRESS_HEX_LEN}}$`);
+
 export class InvalidArtifactExtensionError extends Error {}
 export class InvalidContentAddressError extends Error {}
+
+/** Lowercase hex of a digest — the canonical content-address form ADDRESS_RE validates. */
+export function toHex(bytes: Uint8Array): string {
+  let out = "";
+  for (const b of bytes) out += b.toString(16).padStart(2, "0");
+  return out;
+}
 
 /** Lowercase, strip a single leading dot, reject anything not /^[a-z0-9]+$/.
  *  Guards against path traversal and multi-segment extensions (snapshots use
@@ -19,9 +28,9 @@ export function normalizeExt(ext: string): string {
   return normalized;
 }
 
-/** Throw InvalidContentAddressError unless `address` matches /^[0-9a-f]{64}$/. */
+/** Throw InvalidContentAddressError unless `address` is ADDRESS_HEX_LEN lowercase hex chars. */
 export function assertValidAddress(address: string): void {
-  if (!/^[0-9a-f]{64}$/.test(address)) {
+  if (!ADDRESS_RE.test(address)) {
     throw new InvalidContentAddressError(`invalid content address: ${address}`);
   }
 }
@@ -56,4 +65,9 @@ export function quarantineRelPath(address: string, ext: string): string {
   assertValidAddress(address);
   const normalizedExt = normalizeExt(ext);
   return `quarantine/${address}.${normalizedExt}`;
+}
+
+/** `quarantine/<address>.<normalizedExt>.reason.txt` — the durable reason sidecar beside the bytes. */
+export function quarantineReasonRelPath(address: string, ext: string): string {
+  return `${quarantineRelPath(address, ext)}.reason.txt`;
 }

--- a/packages/kernel/src/archive/types.ts
+++ b/packages/kernel/src/archive/types.ts
@@ -1,0 +1,61 @@
+/**
+ * A logical instant supplied by the CALLER (the artifact's own time — an
+ * activity start, a file's creation time, or a payload's snapshot time),
+ * NEVER wall-clock. The archive path shard derives from this, so archiving the
+ * same content is a pure, idempotent function of (bytes, instant): re-archiving
+ * always maps to the same directory and the same content address. Reading
+ * wall-clock here would let the same artifact land under two shards over time
+ * and break content dedup.
+ */
+export interface ArchiveInstant {
+  /** Epoch SECONDS, UTC. The yyyy/mm shard is derived in UTC from this. */
+  readonly epochSeconds: number;
+}
+
+export interface ArchiveWriteResult {
+  /** Lowercase-hex SHA-256 content address (64 chars). */
+  readonly address: string;
+  /** archiveRoot-relative POSIX path the artifact occupies. */
+  readonly relPath: string;
+  /** True when the content was already present and the write was skipped. */
+  readonly deduped: boolean;
+}
+
+/**
+ * The immutable, content-addressed raw archive — the athlete's source of
+ * truth. Its write methods are the FIRST sink in any ingest path: every pull
+ * MUST write its payload here before any derived store row is written
+ * (archive-first is a hard ordering invariant, a direct dependency of
+ * deterministic rebuild). The archive is append-only and content-addressed:
+ * this interface exposes NO deletion, mutation, prune, or update method by
+ * design. Do not add one.
+ */
+export interface ArchiveManager {
+  /**
+   * Archive raw artifact bytes (FIT/TCX/GPX/…), content-addressed on the raw
+   * bytes, at `<yyyy>/<mm>/<address>.<ext>`. Archive-first sink; idempotent by
+   * content address.
+   */
+  writeArtifact(
+    bytes: Uint8Array,
+    ext: string,
+    when: ArchiveInstant,
+  ): Promise<ArchiveWriteResult>;
+  /**
+   * Archive an API sync payload as a gzipped canonical-JSON snapshot,
+   * content-addressed on the COMPRESSED bytes, at `<yyyy>/<mm>/<address>.json.gz`.
+   * Archive-first sink; idempotent by content address.
+   */
+  writeSnapshot(payload: unknown, when: ArchiveInstant): Promise<ArchiveWriteResult>;
+  /**
+   * Route bytes an ingest path could not parse into `quarantine/<address>.<ext>`
+   * with a durable reason sidecar. Never silently dropped.
+   */
+  quarantine(bytes: Uint8Array, ext: string, reason: string): Promise<ArchiveWriteResult>;
+  /** Read raw artifact bytes back by archiveRoot-relative path. */
+  readArtifact(relPath: string): Promise<Uint8Array>;
+  /** Read + gunzip + parse a snapshot back to its value by archiveRoot-relative path. */
+  readSnapshot(relPath: string): Promise<unknown>;
+  /** True when an archiveRoot-relative path exists on disk. */
+  has(relPath: string): Promise<boolean>;
+}

--- a/packages/kernel/tests/archive-canonical.test.ts
+++ b/packages/kernel/tests/archive-canonical.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { canonicalJson } from "../src/archive/index.js";
+
+describe("canonicalJson", () => {
+  it("is insertion-order independent", () => {
+    const a = { b: 1, a: 2, c: 3 };
+    const b = { c: 3, a: 2, b: 1 };
+    expect(canonicalJson(a)).toBe(canonicalJson(b));
+  });
+
+  it("sorts keys at every depth while preserving array order", () => {
+    const value = {
+      z: { y: 2, x: 1 },
+      a: [3, 1, 2],
+    };
+    expect(canonicalJson(value)).toBe(
+      JSON.stringify({ a: [3, 1, 2], z: { x: 1, y: 2 } }, null, 2),
+    );
+  });
+
+  it("passes scalars and null through unchanged", () => {
+    expect(canonicalJson(null)).toBe("null");
+    expect(canonicalJson(42)).toBe("42");
+    expect(canonicalJson("hi")).toBe('"hi"');
+    expect(canonicalJson({ n: null, s: "x", i: 1 })).toBe(
+      JSON.stringify({ i: 1, n: null, s: "x" }, null, 2),
+    );
+  });
+});

--- a/packages/kernel/tests/archive-paths.test.ts
+++ b/packages/kernel/tests/archive-paths.test.ts
@@ -5,9 +5,11 @@ import {
   InvalidArtifactExtensionError,
   InvalidContentAddressError,
   normalizeExt,
+  quarantineReasonRelPath,
   quarantineRelPath,
   shardFromInstant,
   snapshotRelPath,
+  toHex,
 } from "../src/archive/index.js";
 
 const ADDR = "a".repeat(64);
@@ -30,9 +32,13 @@ describe("shardFromInstant", () => {
   });
 
   it("derives from UTC, not local time", () => {
-    // 2021-01-01T00:30:00Z is 2020-12-31 in any negative-offset local zone.
-    const when = { epochSeconds: Date.UTC(2021, 0, 1, 0, 30, 0) / 1000 };
-    expect(shardFromInstant(when)).toEqual({ year: "2021", month: "01" });
+    // Both sides of the year boundary: 00:30Z catches negative-offset local
+    // zones, 23:30Z catches positive-offset ones — one of the two always
+    // discriminates UTC from local regardless of the host's offset sign.
+    const justAfter = { epochSeconds: Date.UTC(2021, 0, 1, 0, 30, 0) / 1000 };
+    expect(shardFromInstant(justAfter)).toEqual({ year: "2021", month: "01" });
+    const justBefore = { epochSeconds: Date.UTC(2020, 11, 31, 23, 30, 0) / 1000 };
+    expect(shardFromInstant(justBefore)).toEqual({ year: "2020", month: "12" });
   });
 });
 
@@ -80,6 +86,8 @@ describe("rel-path builders", () => {
     expect(artifactRelPath(ADDR, "fit", WHEN)).toBe(`2021/03/${ADDR}.fit`);
     expect(snapshotRelPath(ADDR, WHEN)).toBe(`2021/03/${ADDR}.json.gz`);
     expect(quarantineRelPath(ADDR, "fit")).toBe(`quarantine/${ADDR}.fit`);
+    expect(quarantineReasonRelPath(ADDR, "fit")).toBe(`quarantine/${ADDR}.fit.reason.txt`);
+    expect(toHex(new Uint8Array([0, 15, 255]))).toBe("000fff");
   });
 
   it("rejects a bad address in every builder", () => {

--- a/packages/kernel/tests/archive-paths.test.ts
+++ b/packages/kernel/tests/archive-paths.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import {
+  artifactRelPath,
+  assertValidAddress,
+  InvalidArtifactExtensionError,
+  InvalidContentAddressError,
+  normalizeExt,
+  quarantineRelPath,
+  shardFromInstant,
+  snapshotRelPath,
+} from "../src/archive/index.js";
+
+const ADDR = "a".repeat(64);
+const BAD_ADDR = "z".repeat(64);
+const WHEN = { epochSeconds: 1615766400 }; // 2021-03-15T00:00:00Z
+
+describe("shardFromInstant", () => {
+  it("derives the UTC year and zero-padded month", () => {
+    expect(shardFromInstant(WHEN)).toEqual({ year: "2021", month: "03" });
+  });
+
+  it("zero-pads a January month to 01", () => {
+    const when = { epochSeconds: Date.UTC(2021, 0, 15) / 1000 };
+    expect(shardFromInstant(when).month).toBe("01");
+  });
+
+  it("renders December as 12", () => {
+    const when = { epochSeconds: Date.UTC(2021, 11, 20) / 1000 };
+    expect(shardFromInstant(when).month).toBe("12");
+  });
+
+  it("derives from UTC, not local time", () => {
+    // 2021-01-01T00:30:00Z is 2020-12-31 in any negative-offset local zone.
+    const when = { epochSeconds: Date.UTC(2021, 0, 1, 0, 30, 0) / 1000 };
+    expect(shardFromInstant(when)).toEqual({ year: "2021", month: "01" });
+  });
+});
+
+describe("normalizeExt", () => {
+  it("lowercases and strips a single leading dot", () => {
+    expect(normalizeExt("FIT")).toBe("fit");
+    expect(normalizeExt(".tcx")).toBe("tcx");
+    expect(normalizeExt("gpx")).toBe("gpx");
+  });
+
+  it("rejects invalid extensions echoing the original input", () => {
+    for (const bad of ["", "fi t", "json.gz", "../etc", "a/b"]) {
+      let caught: unknown;
+      try {
+        normalizeExt(bad);
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(InvalidArtifactExtensionError);
+      expect((caught as Error).message).toBe(`invalid artifact extension: ${bad}`);
+    }
+  });
+});
+
+describe("assertValidAddress", () => {
+  it("passes a 64-char lowercase hex string", () => {
+    expect(() => assertValidAddress(ADDR)).not.toThrow();
+  });
+
+  it("throws on a 63-char string", () => {
+    expect(() => assertValidAddress("a".repeat(63))).toThrow(InvalidContentAddressError);
+  });
+
+  it("throws on an uppercase hex digit", () => {
+    expect(() => assertValidAddress("A" + "a".repeat(63))).toThrow(InvalidContentAddressError);
+  });
+
+  it("throws on a non-hex char", () => {
+    expect(() => assertValidAddress("g" + "a".repeat(63))).toThrow(InvalidContentAddressError);
+  });
+});
+
+describe("rel-path builders", () => {
+  it("builds artifact / snapshot / quarantine paths", () => {
+    expect(artifactRelPath(ADDR, "fit", WHEN)).toBe(`2021/03/${ADDR}.fit`);
+    expect(snapshotRelPath(ADDR, WHEN)).toBe(`2021/03/${ADDR}.json.gz`);
+    expect(quarantineRelPath(ADDR, "fit")).toBe(`quarantine/${ADDR}.fit`);
+  });
+
+  it("rejects a bad address in every builder", () => {
+    expect(() => artifactRelPath(BAD_ADDR, "fit", WHEN)).toThrow(InvalidContentAddressError);
+    expect(() => snapshotRelPath(BAD_ADDR, WHEN)).toThrow(InvalidContentAddressError);
+    expect(() => quarantineRelPath(BAD_ADDR, "fit")).toThrow(InvalidContentAddressError);
+  });
+});

--- a/packages/kernel/tsup.config.ts
+++ b/packages/kernel/tsup.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     ports: "src/ports/index.ts",
     "store/migrations": "src/store/migrations/index.ts",
     store: "src/store/index.ts",
+    "archive/index": "src/archive/index.ts",
   },
   loader: { ".sql": "text" },
   format: ["esm"],


### PR DESCRIPTION
## What

Adds the content-addressed raw-archive manager as the athlete's immutable source of truth, split across the two private kernel packages.

**Pure decision logic (`@enduragent/kernel/archive`)** — a new leaf subpath exposing:

- `types.ts` — the `ArchiveManager` interface (with no deletion, mutation, prune, or update method by design), `ArchiveInstant` (a caller-supplied logical instant, never wall-clock), and `ArchiveWriteResult`.
- `paths.ts` — extension normalization, content-address validation, and UTC year/month shard derivation, producing `<yyyy>/<mm>/<address>.<ext>` layout. Validation rejects path traversal and malformed addresses.
- `canonical.ts` — canonical-JSON serialization for deterministic snapshot payloads.

**Host implementation (`@enduragent/kernel-node/archive`)** — `createArchiveManager`, which wires the pure path/address logic to the injected Crypto and FileSystem ports:

- `writeArtifact` — content-addressed raw artifact writes (FIT/TCX/GPX and similar), addressed on the raw bytes.
- `writeSnapshot` — API sync payloads stored as gzipped canonical-JSON, addressed on the compressed bytes.
- `quarantine` — routes unparseable inputs to a quarantine location with a durable reason sidecar, never silently dropped.
- Read-back helpers (`readArtifact`, `readSnapshot`, `has`).

Writes are atomic (temp → fsync → rename), idempotent by content address (re-archiving the same content dedups), and structurally never-delete. Archive-first ordering (payload lands here before any derived row) is documented as a hard ingest invariant.

Both packages remain private and unpublished; a changeset is included naming only the two private packages, with no user-facing line.

## Test plan

- New pure unit tests for path/shard/extension/address validation and canonical-JSON serialization in the kernel package.
- New host tests exercising content-addressed writes, dedup idempotence, gzip snapshot round-trip, and quarantine routing through in-memory port fakes.
- `pnpm check` green end-to-end (build, typecheck, lints, trademark, fixture-privacy, package-deps, kernel-discipline).
- `pnpm test` green; `pnpm s8a` exit 0 with zero diffs; `pnpm check-parity --all` all pairs green with zero snapshot regeneration.
- Kernel purity intact: no `node:*` or workspace imports in the pure `packages/kernel/src` archive surface.
