### PR TITLE
feat(kernel-node): single-writer store lock (port-bind singleton + advisory lockfile)

### DIFF
--- a/packages/kernel-node/package.json
+++ b/packages/kernel-node/package.json
@@ -7,7 +7,8 @@
   "files": ["dist"],
   "exports": {
     "./sqlite": "./dist/sqlite.js",
-    "./archive": "./dist/archive/index.js"
+    "./archive": "./dist/archive/index.js",
+    "./lock": "./dist/lock/index.js"
   },
   "engines": {
     "node": ">=24"

--- a/packages/kernel-node/src/lock/acquire.ts
+++ b/packages/kernel-node/src/lock/acquire.ts
@@ -1,8 +1,8 @@
 import { createServer, type Server, type AddressInfo } from "node:net";
-import { closeSync, openSync, existsSync, mkdirSync, chmodSync, statSync, constants as fsConstants } from "node:fs";
+import { existsSync, mkdirSync, chmodSync, statSync } from "node:fs";
 import { unlink } from "node:fs/promises";
 import { join } from "node:path";
-import { readLockfile, writeLockfile } from "./lockfile-body.js";
+import { claimLockfile, readLockfile } from "./lockfile-body.js";
 import { readPortFile, writePortFile } from "./port-file.js";
 import { defaultHealthzProbe, isPortBound, type HealthzProbe } from "./healthz-probe.js";
 
@@ -40,20 +40,6 @@ export type AcquireWriteLockResult = WriteLockHandle | PeerHealthyOutcome;
 
 export const LOCKFILE_NAME = "store-writer.lock" as const;
 export const PORT_FILE_NAME = "store-writer.port" as const;
-
-const CLAIM_FILL_GRACE_MS = 150;
-
-function sleep(ms: number): Promise<void> {
-  return new Promise<void>((resolve) => setTimeout(resolve, ms));
-}
-
-function claimAgeMs(path: string): number | null {
-  try {
-    return Date.now() - statSync(path).mtimeMs;
-  } catch {
-    return null;
-  }
-}
 
 function ensureConfigDirSecure(configDir: string): void {
   if (existsSync(configDir)) {
@@ -123,19 +109,13 @@ export async function acquireWriteLock(opts: AcquireWriteLockOptions): Promise<A
   const actualPort = (server.address() as AddressInfo).port;
 
   const claimAndFill = async (): Promise<WriteLockHandle> => {
-    const fd = openSync(
-      lockfilePath,
-      fsConstants.O_CREAT | fsConstants.O_EXCL | fsConstants.O_WRONLY,
-      0o600,
-    );
-    closeSync(fd);
-    await writePortFile(portFilePath, actualPort);
-    await writeLockfile(lockfilePath, {
+    await claimLockfile(lockfilePath, {
       pid: process.pid,
       port: actualPort,
       version: opts.version,
       athleteHome: opts.athleteHome,
     });
+    await writePortFile(portFilePath, actualPort);
     return {
       status: "acquired",
       port: actualPort,
@@ -157,24 +137,20 @@ export async function acquireWriteLock(opts: AcquireWriteLockOptions): Promise<A
         await closeServer(server);
         throw err;
       }
-      let other = readLockfile(lockfilePath);
-      let otherPort = other?.port ?? readPortFile(portFilePath);
+      const other = readLockfile(lockfilePath);
+      const otherPort = other?.port ?? readPortFile(portFilePath);
       if (otherPort === null) {
-        await sleep(CLAIM_FILL_GRACE_MS);
-        other = readLockfile(lockfilePath);
-        otherPort = other?.port ?? readPortFile(portFilePath);
-        if (otherPort === null) {
-          const age = claimAgeMs(lockfilePath);
-          if (age !== null && age < CLAIM_FILL_GRACE_MS) {
-            await closeServer(server);
-            throw new WriteLockContentionError(
-              `Another writer won arbitration for this store; stop that process or wait, then retry.`,
-              3,
-            );
-          }
-        }
+        // Corruption backstop — no process ordering produces a claim without a
+        // readable port (claims are born with their body via claimLockfile).
+        // An unreadable claim is not proven stale, and no timer may prove it:
+        // never unlink, never wait.
+        await closeServer(server);
+        throw new WriteLockContentionError(
+          `The lockfile at ${lockfilePath} is unreadable; remove it and retry.`,
+          3,
+        );
       }
-      if (otherPort !== null && (await isPortBound(otherPort))) {
+      if (await isPortBound(otherPort)) {
         await closeServer(server);
         return contentionAgainstBound(other?.pid, otherPort, portFilePath, probe);
       }

--- a/packages/kernel-node/src/lock/acquire.ts
+++ b/packages/kernel-node/src/lock/acquire.ts
@@ -1,0 +1,191 @@
+import { createServer, type Server, type AddressInfo } from "node:net";
+import { closeSync, openSync, existsSync, mkdirSync, chmodSync, statSync, constants as fsConstants } from "node:fs";
+import { unlink } from "node:fs/promises";
+import { join } from "node:path";
+import { readLockfile, writeLockfile } from "./lockfile-body.js";
+import { readPortFile, writePortFile } from "./port-file.js";
+import { defaultHealthzProbe, isPortBound, type HealthzProbe } from "./healthz-probe.js";
+
+export class WriteLockContentionError extends Error {
+  readonly exitCode: number;
+  constructor(message: string, exitCode: number) {
+    super(message);
+    this.name = "WriteLockContentionError";
+    this.exitCode = exitCode;
+  }
+}
+
+export interface AcquireWriteLockOptions {
+  readonly configDir: string;
+  readonly athleteHome: string;
+  readonly version: string;
+  readonly probeHealthz?: HealthzProbe;
+}
+
+export interface WriteLockHandle {
+  readonly status: "acquired";
+  readonly port: number;
+  readonly lockfilePath: string;
+  readonly portFilePath: string;
+  release(): Promise<void>;
+}
+
+export interface PeerHealthyOutcome {
+  readonly status: "peer-healthy";
+  readonly port: number;
+  readonly peerVersion: string;
+}
+
+export type AcquireWriteLockResult = WriteLockHandle | PeerHealthyOutcome;
+
+export const LOCKFILE_NAME = "store-writer.lock" as const;
+export const PORT_FILE_NAME = "store-writer.port" as const;
+
+const CLAIM_FILL_GRACE_MS = 150;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise<void>((resolve) => setTimeout(resolve, ms));
+}
+
+function claimAgeMs(path: string): number | null {
+  try {
+    return Date.now() - statSync(path).mtimeMs;
+  } catch {
+    return null;
+  }
+}
+
+function ensureConfigDirSecure(configDir: string): void {
+  if (existsSync(configDir)) {
+    const mode = statSync(configDir).mode & 0o777;
+    if (mode !== 0o700) chmodSync(configDir, 0o700);
+  } else {
+    mkdirSync(configDir, { recursive: true, mode: 0o700 });
+  }
+}
+
+function bindWriterSocket(): Promise<Server> {
+  return new Promise<Server>((resolve, reject) => {
+    const server = createServer();
+    server.on("error", reject);
+    server.listen({ host: "127.0.0.1", port: 0 }, () => resolve(server));
+  });
+}
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise<void>((resolve) => server.close(() => resolve()));
+}
+
+async function bestEffortUnlink(path: string): Promise<void> {
+  try {
+    await unlink(path);
+  } catch {
+    /* already gone */
+  }
+}
+
+function contentionAgainstBound(
+  bodyPid: number | undefined,
+  boundPort: number,
+  portFilePath: string,
+  probe: HealthzProbe,
+): Promise<PeerHealthyOutcome | never> {
+  return probe(boundPort).then((verdict) => {
+    if (verdict.kind === "healthy") {
+      return { status: "peer-healthy", port: boundPort, peerVersion: verdict.version };
+    }
+    if (verdict.kind === "unresponsive") {
+      throw new WriteLockContentionError(
+        `Another writer already holds this store (pid ${bodyPid ?? "unknown"}); stop that process or wait, then retry.`,
+        3,
+      );
+    }
+    throw new WriteLockContentionError(
+      `127.0.0.1:${boundPort} is held by a foreign process; change or remove the port file at ${portFilePath} and retry.`,
+      3,
+    );
+  });
+}
+
+export async function acquireWriteLock(opts: AcquireWriteLockOptions): Promise<AcquireWriteLockResult> {
+  const probe = opts.probeHealthz ?? defaultHealthzProbe;
+  ensureConfigDirSecure(opts.configDir);
+  const lockfilePath = join(opts.configDir, LOCKFILE_NAME);
+  const portFilePath = join(opts.configDir, PORT_FILE_NAME);
+
+  const recordedPort = readPortFile(portFilePath);
+  if (recordedPort !== null && (await isPortBound(recordedPort))) {
+    const body = readLockfile(lockfilePath);
+    return contentionAgainstBound(body?.pid, recordedPort, portFilePath, probe);
+  }
+
+  const server = await bindWriterSocket();
+  const actualPort = (server.address() as AddressInfo).port;
+
+  const claimAndFill = async (): Promise<WriteLockHandle> => {
+    const fd = openSync(
+      lockfilePath,
+      fsConstants.O_CREAT | fsConstants.O_EXCL | fsConstants.O_WRONLY,
+      0o600,
+    );
+    closeSync(fd);
+    await writePortFile(portFilePath, actualPort);
+    await writeLockfile(lockfilePath, {
+      pid: process.pid,
+      port: actualPort,
+      version: opts.version,
+      athleteHome: opts.athleteHome,
+    });
+    return {
+      status: "acquired",
+      port: actualPort,
+      lockfilePath,
+      portFilePath,
+      release: async (): Promise<void> => {
+        await closeServer(server);
+        await bestEffortUnlink(lockfilePath);
+        await bestEffortUnlink(portFilePath);
+      },
+    };
+  };
+
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      return await claimAndFill();
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "EEXIST") {
+        await closeServer(server);
+        throw err;
+      }
+      let other = readLockfile(lockfilePath);
+      let otherPort = other?.port ?? readPortFile(portFilePath);
+      if (otherPort === null) {
+        await sleep(CLAIM_FILL_GRACE_MS);
+        other = readLockfile(lockfilePath);
+        otherPort = other?.port ?? readPortFile(portFilePath);
+        if (otherPort === null) {
+          const age = claimAgeMs(lockfilePath);
+          if (age !== null && age < CLAIM_FILL_GRACE_MS) {
+            await closeServer(server);
+            throw new WriteLockContentionError(
+              `Another writer won arbitration for this store; stop that process or wait, then retry.`,
+              3,
+            );
+          }
+        }
+      }
+      if (otherPort !== null && (await isPortBound(otherPort))) {
+        await closeServer(server);
+        return contentionAgainstBound(other?.pid, otherPort, portFilePath, probe);
+      }
+      await bestEffortUnlink(lockfilePath);
+      await bestEffortUnlink(portFilePath);
+    }
+  }
+
+  await closeServer(server);
+  throw new WriteLockContentionError(
+    `Another writer won arbitration for this store; stop that process or wait, then retry.`,
+    3,
+  );
+}

--- a/packages/kernel-node/src/lock/healthz-probe.ts
+++ b/packages/kernel-node/src/lock/healthz-probe.ts
@@ -1,0 +1,78 @@
+import { get } from "node:http";
+import { createConnection } from "node:net";
+
+export type HealthzVerdict =
+  | { readonly kind: "healthy"; readonly version: string }
+  | { readonly kind: "unresponsive" }
+  | { readonly kind: "foreign" };
+
+export type HealthzProbe = (port: number) => Promise<HealthzVerdict>;
+
+export const HEALTHZ_SERVICE_MARKER = "enduragent-store-writer" as const;
+
+const PROBE_TIMEOUT_MS = 1000;
+
+export function classifyHealthzResponse(status: number, body: string): HealthzVerdict {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    return { kind: "foreign" };
+  }
+  if (typeof parsed === "object" && parsed !== null) {
+    const obj = parsed as Record<string, unknown>;
+    if (obj.service === HEALTHZ_SERVICE_MARKER && typeof obj.version === "string" && obj.version.length > 0) {
+      return { kind: "healthy", version: obj.version };
+    }
+  }
+  void status;
+  return { kind: "foreign" };
+}
+
+export const defaultHealthzProbe: HealthzProbe = (port: number): Promise<HealthzVerdict> =>
+  new Promise<HealthzVerdict>((resolve) => {
+    let settled = false;
+    const done = (verdict: HealthzVerdict): void => {
+      if (settled) return;
+      settled = true;
+      resolve(verdict);
+    };
+
+    const req = get(
+      { host: "127.0.0.1", port, path: "/healthz", timeout: PROBE_TIMEOUT_MS },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (chunk: Buffer) => chunks.push(chunk));
+        res.on("end", () => {
+          const body = Buffer.concat(chunks).toString("utf-8");
+          done(classifyHealthzResponse(res.statusCode ?? 0, body));
+        });
+        res.on("error", () => done({ kind: "unresponsive" }));
+      },
+    );
+    req.on("timeout", () => {
+      req.destroy();
+      done({ kind: "unresponsive" });
+    });
+    req.on("error", () => done({ kind: "unresponsive" }));
+  });
+
+export async function isPortBound(port: number): Promise<boolean> {
+  return new Promise<boolean>((resolve) => {
+    let settled = false;
+    const done = (bound: boolean): void => {
+      if (settled) return;
+      settled = true;
+      socket.destroy();
+      resolve(bound);
+    };
+
+    const socket = createConnection({ host: "127.0.0.1", port });
+    socket.setTimeout(PROBE_TIMEOUT_MS);
+    socket.on("connect", () => done(true));
+    socket.on("timeout", () => done(true));
+    socket.on("error", (err: NodeJS.ErrnoException) => {
+      done(err.code !== "ECONNREFUSED");
+    });
+  });
+}

--- a/packages/kernel-node/src/lock/index.ts
+++ b/packages/kernel-node/src/lock/index.ts
@@ -1,0 +1,16 @@
+export {
+  acquireWriteLock,
+  WriteLockContentionError,
+  LOCKFILE_NAME,
+  PORT_FILE_NAME,
+} from "./acquire.js";
+export type {
+  AcquireWriteLockOptions,
+  AcquireWriteLockResult,
+  WriteLockHandle,
+  PeerHealthyOutcome,
+} from "./acquire.js";
+export type { LockfileBody } from "./lockfile-body.js";
+export { readLockfile } from "./lockfile-body.js";
+export type { HealthzVerdict, HealthzProbe } from "./healthz-probe.js";
+export { classifyHealthzResponse, HEALTHZ_SERVICE_MARKER } from "./healthz-probe.js";

--- a/packages/kernel-node/src/lock/lockfile-body.ts
+++ b/packages/kernel-node/src/lock/lockfile-body.ts
@@ -1,4 +1,4 @@
-import { open, rename, unlink } from "node:fs/promises";
+import { link, open, unlink } from "node:fs/promises";
 import { readFileSync } from "node:fs";
 import { randomBytes } from "node:crypto";
 
@@ -9,7 +9,12 @@ export interface LockfileBody {
   readonly athleteHome: string;
 }
 
-export async function writeLockfile(lockfilePath: string, body: LockfileBody): Promise<void> {
+// claimLockfile IS the mutex: link(2) fails EEXIST iff the target exists — the
+// same kernel-atomic exclusive-create arbitration as O_CREAT|O_EXCL, but the
+// claim is born carrying its full body, so no observer can ever read an empty
+// or partial claim. A body is never rewritten in place: a stale claim is
+// unlinked and a fresh claim published.
+export async function claimLockfile(lockfilePath: string, body: LockfileBody): Promise<void> {
   const serialized = JSON.stringify(body, null, 2) + "\n";
   const suffix = randomBytes(4).toString("hex");
   const tempPath = `${lockfilePath}.tmp.${suffix}`;
@@ -21,8 +26,8 @@ export async function writeLockfile(lockfilePath: string, body: LockfileBody): P
     await fh.sync();
     await fh.close();
     fh = null;
-    await rename(tempPath, lockfilePath);
-  } catch (err) {
+    await link(tempPath, lockfilePath);
+  } finally {
     if (fh !== null) {
       try {
         await fh.close();
@@ -35,7 +40,6 @@ export async function writeLockfile(lockfilePath: string, body: LockfileBody): P
     } catch {
       /* temp sibling may not exist */
     }
-    throw err;
   }
 }
 

--- a/packages/kernel-node/src/lock/lockfile-body.ts
+++ b/packages/kernel-node/src/lock/lockfile-body.ts
@@ -1,0 +1,68 @@
+import { open, rename, unlink } from "node:fs/promises";
+import { readFileSync } from "node:fs";
+import { randomBytes } from "node:crypto";
+
+export interface LockfileBody {
+  readonly pid: number;
+  readonly port: number;
+  readonly version: string;
+  readonly athleteHome: string;
+}
+
+export async function writeLockfile(lockfilePath: string, body: LockfileBody): Promise<void> {
+  const serialized = JSON.stringify(body, null, 2) + "\n";
+  const suffix = randomBytes(4).toString("hex");
+  const tempPath = `${lockfilePath}.tmp.${suffix}`;
+
+  let fh: Awaited<ReturnType<typeof open>> | null = null;
+  try {
+    fh = await open(tempPath, "w", 0o600);
+    await fh.writeFile(serialized, "utf-8");
+    await fh.sync();
+    await fh.close();
+    fh = null;
+    await rename(tempPath, lockfilePath);
+  } catch (err) {
+    if (fh !== null) {
+      try {
+        await fh.close();
+      } catch {
+        /* already in the error path */
+      }
+    }
+    try {
+      await unlink(tempPath);
+    } catch {
+      /* temp sibling may not exist */
+    }
+    throw err;
+  }
+}
+
+export function readLockfile(lockfilePath: string): LockfileBody | null {
+  let raw: string;
+  try {
+    raw = readFileSync(lockfilePath, "utf-8");
+  } catch {
+    return null;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null) return null;
+  const body = parsed as Record<string, unknown>;
+  const { pid, port, version, athleteHome } = body;
+  if (!Number.isInteger(pid) || (pid as number) <= 0) return null;
+  if (!Number.isInteger(port) || (port as number) <= 0) return null;
+  if (typeof version !== "string" || version.length === 0) return null;
+  if (typeof athleteHome !== "string" || athleteHome.length === 0) return null;
+  return {
+    pid: pid as number,
+    port: port as number,
+    version,
+    athleteHome,
+  };
+}

--- a/packages/kernel-node/src/lock/port-file.ts
+++ b/packages/kernel-node/src/lock/port-file.ts
@@ -1,0 +1,45 @@
+import { open, rename, unlink } from "node:fs/promises";
+import { readFileSync } from "node:fs";
+import { randomBytes } from "node:crypto";
+
+export async function writePortFile(portFilePath: string, port: number): Promise<void> {
+  const serialized = `${port}\n`;
+  const suffix = randomBytes(4).toString("hex");
+  const tempPath = `${portFilePath}.tmp.${suffix}`;
+
+  let fh: Awaited<ReturnType<typeof open>> | null = null;
+  try {
+    fh = await open(tempPath, "w", 0o600);
+    await fh.writeFile(serialized, "utf-8");
+    await fh.sync();
+    await fh.close();
+    fh = null;
+    await rename(tempPath, portFilePath);
+  } catch (err) {
+    if (fh !== null) {
+      try {
+        await fh.close();
+      } catch {
+        /* already in the error path */
+      }
+    }
+    try {
+      await unlink(tempPath);
+    } catch {
+      /* temp sibling may not exist */
+    }
+    throw err;
+  }
+}
+
+export function readPortFile(portFilePath: string): number | null {
+  let raw: string;
+  try {
+    raw = readFileSync(portFilePath, "utf-8");
+  } catch {
+    return null;
+  }
+  const port = Number(raw.trim());
+  if (!Number.isInteger(port) || port < 1 || port > 65535) return null;
+  return port;
+}

--- a/packages/kernel-node/tests/lock.test.ts
+++ b/packages/kernel-node/tests/lock.test.ts
@@ -3,7 +3,7 @@
 // are proven by branch selection against an injected /healthz test double; the full
 // four-case matrix against a real daemon /healthz responder arms at W8.
 
-import { mkdtempSync, rmSync, readFileSync } from "node:fs";
+import { mkdtempSync, rmSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createServer, type Server } from "node:net";
@@ -21,7 +21,7 @@ import {
   type AcquireWriteLockResult,
 } from "../src/lock/index.js";
 import { writePortFile, readPortFile } from "../src/lock/port-file.js";
-import { writeLockfile } from "../src/lock/lockfile-body.js";
+import { claimLockfile } from "../src/lock/lockfile-body.js";
 import { defaultHealthzProbe, classifyHealthzResponse } from "../src/lock/healthz-probe.js";
 
 const tempDirs: string[] = [];
@@ -149,7 +149,7 @@ describe("acquireWriteLock", () => {
     const configDir = freshDir();
     const { port } = await occupyPort();
     await writePortFile(join(configDir, PORT_FILE_NAME), port);
-    await writeLockfile(join(configDir, LOCKFILE_NAME), {
+    await claimLockfile(join(configDir, LOCKFILE_NAME), {
       pid: 777,
       port,
       version: "8.8.8",
@@ -172,7 +172,7 @@ describe("acquireWriteLock", () => {
     const configDir = freshDir();
     const freePort = await knownFreePort();
     await writePortFile(join(configDir, PORT_FILE_NAME), freePort);
-    await writeLockfile(join(configDir, LOCKFILE_NAME), {
+    await claimLockfile(join(configDir, LOCKFILE_NAME), {
       pid: process.pid,
       port: freePort,
       version: "0.0.1",
@@ -203,7 +203,7 @@ describe("acquireWriteLock", () => {
     const configDir = freshDir();
     const { port } = await occupyPort();
     await writePortFile(join(configDir, PORT_FILE_NAME), port);
-    await writeLockfile(join(configDir, LOCKFILE_NAME), {
+    await claimLockfile(join(configDir, LOCKFILE_NAME), {
       pid: 424242,
       port,
       version: "0.0.1",
@@ -287,23 +287,98 @@ describe("acquireWriteLock", () => {
     expect((caught as WriteLockContentionError).exitCode).toBe(3);
   });
 
-  it("(same-dir) two concurrent acquirers on one fresh configDir yield exactly one winner", async () => {
-    const configDir = freshDir();
+  it("(race) two concurrent acquirers on one fresh configDir yield exactly one winner, every time", async () => {
     const probe: HealthzProbe = async () => ({ kind: "unresponsive" });
-    const opts = { configDir, athleteHome: "/home/a", version: "1.0.0", probeHealthz: probe };
+    for (let i = 0; i < 25; i++) {
+      const configDir = freshDir();
+      const opts = { configDir, athleteHome: "/home/a", version: "1.0.0", probeHealthz: probe };
 
-    const settled = await Promise.allSettled([acquireWriteLock(opts), acquireWriteLock(opts)]);
+      const settled = await Promise.allSettled([acquireWriteLock(opts), acquireWriteLock(opts)]);
 
-    const winners = settled.filter(
-      (s): s is PromiseFulfilledResult<AcquireWriteLockResult> =>
-        s.status === "fulfilled" && s.value.status === "acquired",
+      const winners = settled.filter(
+        (s): s is PromiseFulfilledResult<AcquireWriteLockResult> =>
+          s.status === "fulfilled" && s.value.status === "acquired",
+      );
+      const losers = settled.filter((s): s is PromiseRejectedResult => s.status === "rejected");
+      expect(winners).toHaveLength(1);
+      expect(losers).toHaveLength(1);
+      expect(losers[0].reason).toBeInstanceOf(WriteLockContentionError);
+      expect((losers[0].reason as WriteLockContentionError).exitCode).toBe(3);
+      await trackHandle(winners[0].value).release();
+      heldHandles.length = 0;
+    }
+  });
+
+  it("(race, mid-fill) a live claim without a port file is never unlinked", async () => {
+    const configDir = freshDir();
+    const { port } = await occupyPort();
+    const lockfilePath = join(configDir, LOCKFILE_NAME);
+    await claimLockfile(lockfilePath, {
+      pid: 555001,
+      port,
+      version: "1.0.0",
+      athleteHome: "/home/a",
+    });
+    const lockBefore = readFileSync(lockfilePath, "utf-8");
+
+    const probe: HealthzProbe = async () => ({ kind: "unresponsive" });
+    let caught: unknown;
+    try {
+      await acquireWriteLock({ configDir, athleteHome: "/home/a", version: "1.0.0", probeHealthz: probe });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(WriteLockContentionError);
+    expect((caught as WriteLockContentionError).exitCode).toBe(3);
+    expect((caught as WriteLockContentionError).message).toContain("555001");
+    expect(readFileSync(lockfilePath, "utf-8")).toBe(lockBefore);
+    expect(readdirSync(configDir).filter((n) => n.includes(".tmp."))).toEqual([]);
+  });
+
+  it("(b-variant) a crash artifact claim naming a free port is reclaimed without probing", async () => {
+    const configDir = freshDir();
+    const freePort = await knownFreePort();
+    await claimLockfile(join(configDir, LOCKFILE_NAME), {
+      pid: 555002,
+      port: freePort,
+      version: "0.0.1",
+      athleteHome: "/home/a",
+    });
+
+    const throwingProbe: HealthzProbe = async () => {
+      throw new Error("probe must not be consulted for a free-port artifact");
+    };
+    const result = trackHandle(
+      await acquireWriteLock({
+        configDir,
+        athleteHome: "/home/a",
+        version: "1.0.0",
+        probeHealthz: throwingProbe,
+      }),
     );
-    const losers = settled.filter((s): s is PromiseRejectedResult => s.status === "rejected");
-    expect(winners).toHaveLength(1);
-    expect(losers).toHaveLength(1);
-    trackHandle(winners[0].value);
-    expect(losers[0].reason).toBeInstanceOf(WriteLockContentionError);
-    expect((losers[0].reason as WriteLockContentionError).exitCode).toBe(3);
+    expect(result.status).toBe("acquired");
+    const replaced = readLockfile(join(configDir, LOCKFILE_NAME));
+    expect(replaced?.pid).toBe(process.pid);
+    expect(replaced?.port).toBe(result.port);
+  });
+
+  it("(corrupt-claim) an unreadable claim refuses exit 3 naming the file, never unlinks it", async () => {
+    for (const garbage of ["", "not json {{{"]) {
+      const configDir = freshDir();
+      const lockfilePath = join(configDir, LOCKFILE_NAME);
+      writeFileSync(lockfilePath, garbage);
+
+      let caught: unknown;
+      try {
+        await acquireWriteLock({ configDir, athleteHome: "/home/a", version: "1.0.0" });
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(WriteLockContentionError);
+      expect((caught as WriteLockContentionError).exitCode).toBe(3);
+      expect((caught as WriteLockContentionError).message).toContain(lockfilePath);
+      expect(readFileSync(lockfilePath, "utf-8")).toBe(garbage);
+    }
   });
 
   it("(default-probe) the real probe classifier resolves healthy/foreign/unresponsive", async () => {

--- a/packages/kernel-node/tests/lock.test.ts
+++ b/packages/kernel-node/tests/lock.test.ts
@@ -1,0 +1,331 @@
+// W1 scope: the port bind, lockfile write/read-back, per-home port file, case (b)
+// reclaim, and RO-open are real behavior tested here end-to-end. Cases (a)/(c)/(d)
+// are proven by branch selection against an injected /healthz test double; the full
+// four-case matrix against a real daemon /healthz responder arms at W8.
+
+import { mkdtempSync, rmSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createServer, type Server } from "node:net";
+import { createServer as createHttpServer, type Server as HttpServer } from "node:http";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  acquireWriteLock,
+  WriteLockContentionError,
+  readLockfile,
+  LOCKFILE_NAME,
+  PORT_FILE_NAME,
+  type HealthzProbe,
+  type WriteLockHandle,
+  type AcquireWriteLockResult,
+} from "../src/lock/index.js";
+import { writePortFile, readPortFile } from "../src/lock/port-file.js";
+import { writeLockfile } from "../src/lock/lockfile-body.js";
+import { defaultHealthzProbe, classifyHealthzResponse } from "../src/lock/healthz-probe.js";
+
+const tempDirs: string[] = [];
+const heldHandles: WriteLockHandle[] = [];
+const netServers: Server[] = [];
+const httpServers: HttpServer[] = [];
+
+function freshDir(prefix = "lock-"): string {
+  const d = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(d);
+  return d;
+}
+
+function isHandle(r: AcquireWriteLockResult): r is WriteLockHandle {
+  return r.status === "acquired";
+}
+
+function trackHandle(r: AcquireWriteLockResult): WriteLockHandle {
+  if (!isHandle(r)) throw new Error(`expected acquired, got ${r.status}`);
+  heldHandles.push(r);
+  return r;
+}
+
+function occupyPort(): Promise<{ port: number; server: Server }> {
+  return new Promise((resolve) => {
+    const server = createServer();
+    netServers.push(server);
+    server.listen({ host: "127.0.0.1", port: 0 }, () => {
+      const addr = server.address();
+      if (addr === null || typeof addr === "string") throw new Error("no addr");
+      resolve({ port: addr.port, server });
+    });
+  });
+}
+
+function knownFreePort(): Promise<number> {
+  return new Promise((resolve) => {
+    const server = createServer();
+    server.listen({ host: "127.0.0.1", port: 0 }, () => {
+      const addr = server.address();
+      if (addr === null || typeof addr === "string") throw new Error("no addr");
+      const port = addr.port;
+      server.close(() => resolve(port));
+    });
+  });
+}
+
+function httpResponder(body: string): Promise<{ port: number; server: HttpServer }> {
+  return new Promise((resolve) => {
+    const server = createHttpServer((_req, res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(body);
+    });
+    httpServers.push(server);
+    server.listen({ host: "127.0.0.1", port: 0 }, () => {
+      const addr = server.address();
+      if (addr === null || typeof addr === "string") throw new Error("no addr");
+      resolve({ port: addr.port, server });
+    });
+  });
+}
+
+afterEach(async () => {
+  for (const h of heldHandles.splice(0)) {
+    try {
+      await h.release();
+    } catch {
+      /* best effort */
+    }
+  }
+  for (const s of netServers.splice(0)) {
+    await new Promise<void>((resolve) => s.close(() => resolve()));
+  }
+  for (const s of httpServers.splice(0)) {
+    await new Promise<void>((resolve) => s.close(() => resolve()));
+  }
+  for (const d of tempDirs.splice(0)) {
+    rmSync(d, { recursive: true, force: true });
+  }
+});
+
+describe("acquireWriteLock", () => {
+  it("(bind) port-bind singleton is authoritative", async () => {
+    const configDir = freshDir();
+    const result = trackHandle(
+      await acquireWriteLock({ configDir, athleteHome: "/home/a", version: "1.0.0" }),
+    );
+    expect(result.status).toBe("acquired");
+
+    const onDisk = readLockfile(join(configDir, LOCKFILE_NAME));
+    expect(onDisk).toEqual({
+      pid: process.pid,
+      port: result.port,
+      version: "1.0.0",
+      athleteHome: "/home/a",
+    });
+    expect(readPortFile(join(configDir, PORT_FILE_NAME))).toBe(result.port);
+
+    await expect(
+      new Promise((_resolve, reject) => {
+        const s = createServer();
+        s.on("error", reject);
+        s.listen({ host: "127.0.0.1", port: result.port });
+      }),
+    ).rejects.toMatchObject({ code: "EADDRINUSE" });
+
+    await result.release();
+    heldHandles.length = 0;
+    expect(readLockfile(join(configDir, LOCKFILE_NAME))).toBeNull();
+    expect(readPortFile(join(configDir, PORT_FILE_NAME))).toBeNull();
+    const rebound = await new Promise<Server>((resolve, reject) => {
+      const s = createServer();
+      s.on("error", reject);
+      s.listen({ host: "127.0.0.1", port: result.port }, () => resolve(s));
+    });
+    netServers.push(rebound);
+    await new Promise<void>((resolve) => rebound.close(() => resolve()));
+    netServers.pop();
+    const rebind = await acquireWriteLock({ configDir, athleteHome: "/home/a", version: "1.0.0" });
+    trackHandle(rebind);
+    expect(rebind.status).toBe("acquired");
+  });
+
+  it("(a) healthy peer returns peer-healthy without binding", async () => {
+    const configDir = freshDir();
+    const { port } = await occupyPort();
+    await writePortFile(join(configDir, PORT_FILE_NAME), port);
+    await writeLockfile(join(configDir, LOCKFILE_NAME), {
+      pid: 777,
+      port,
+      version: "8.8.8",
+      athleteHome: "/home/a",
+    });
+    const lockBefore = readFileSync(join(configDir, LOCKFILE_NAME), "utf-8");
+
+    const probe: HealthzProbe = async () => ({ kind: "healthy", version: "9.9.9" });
+    const result = await acquireWriteLock({
+      configDir,
+      athleteHome: "/home/a",
+      version: "1.0.0",
+      probeHealthz: probe,
+    });
+    expect(result).toEqual({ status: "peer-healthy", port, peerVersion: "9.9.9" });
+    expect(readFileSync(join(configDir, LOCKFILE_NAME), "utf-8")).toBe(lockBefore);
+  });
+
+  it("(b) stale lockfile with free port reclaims without probing", async () => {
+    const configDir = freshDir();
+    const freePort = await knownFreePort();
+    await writePortFile(join(configDir, PORT_FILE_NAME), freePort);
+    await writeLockfile(join(configDir, LOCKFILE_NAME), {
+      pid: process.pid,
+      port: freePort,
+      version: "0.0.1",
+      athleteHome: "/home/a",
+    });
+
+    const throwingProbe: HealthzProbe = async () => {
+      throw new Error("probe must not be consulted on case (b)");
+    };
+    const result = trackHandle(
+      await acquireWriteLock({
+        configDir,
+        athleteHome: "/home/a",
+        version: "1.0.0",
+        probeHealthz: throwingProbe,
+      }),
+    );
+    expect(result.status).toBe("acquired");
+    expect(result.port).not.toBe(freePort);
+
+    const reclaimed = readLockfile(join(configDir, LOCKFILE_NAME));
+    expect(reclaimed?.pid).toBe(process.pid);
+    expect(reclaimed?.port).toBe(result.port);
+    expect(readPortFile(join(configDir, PORT_FILE_NAME))).toBe(result.port);
+  });
+
+  it("(c) bound port + unresponsive /healthz refuses exit 3 naming the pid", async () => {
+    const configDir = freshDir();
+    const { port } = await occupyPort();
+    await writePortFile(join(configDir, PORT_FILE_NAME), port);
+    await writeLockfile(join(configDir, LOCKFILE_NAME), {
+      pid: 424242,
+      port,
+      version: "0.0.1",
+      athleteHome: "/home/a",
+    });
+
+    const probe: HealthzProbe = async () => ({ kind: "unresponsive" });
+    let caught: unknown;
+    try {
+      await acquireWriteLock({ configDir, athleteHome: "/home/a", version: "1.0.0", probeHealthz: probe });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(WriteLockContentionError);
+    expect((caught as WriteLockContentionError).exitCode).toBe(3);
+    expect((caught as WriteLockContentionError).message).toContain("424242");
+  });
+
+  it("(d) foreign process refuses exit 3 naming the port file", async () => {
+    const configDir = freshDir();
+    const { port } = await occupyPort();
+    const portFilePath = join(configDir, PORT_FILE_NAME);
+    await writePortFile(portFilePath, port);
+
+    const probe: HealthzProbe = async () => ({ kind: "foreign" });
+    let caught: unknown;
+    try {
+      await acquireWriteLock({ configDir, athleteHome: "/home/a", version: "1.0.0", probeHealthz: probe });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(WriteLockContentionError);
+    expect((caught as WriteLockContentionError).exitCode).toBe(3);
+    expect((caught as WriteLockContentionError).message).toContain(portFilePath);
+  });
+
+  it("(RO-open) read-only open works beside the write-lock holder over WAL", async () => {
+    const dbDir = freshDir("db-");
+    const dbPath = join(dbDir, "store.db");
+    const seed = new DatabaseSync(dbPath);
+    seed.exec("PRAGMA journal_mode = WAL");
+    seed.exec("CREATE TABLE t(x INTEGER)");
+    seed.exec("INSERT INTO t VALUES (42)");
+    seed.close();
+
+    const configDir = freshDir();
+    trackHandle(await acquireWriteLock({ configDir, athleteHome: "/home/a", version: "1.0.0" }));
+
+    const ro = new DatabaseSync(dbPath, { readOnly: true });
+    const row = ro.prepare("SELECT x FROM t").get() as { x: number };
+    expect(row.x).toBe(42);
+    ro.close();
+  });
+
+  it("(two-homes) two athlete homes acquire distinct ports without collision", async () => {
+    const configDirA = freshDir();
+    const configDirB = freshDir();
+    const a = trackHandle(
+      await acquireWriteLock({ configDir: configDirA, athleteHome: "/home/a", version: "1.0.0" }),
+    );
+    const b = trackHandle(
+      await acquireWriteLock({ configDir: configDirB, athleteHome: "/home/b", version: "1.0.0" }),
+    );
+    expect(a.port).not.toBe(b.port);
+    expect(readPortFile(join(configDirA, PORT_FILE_NAME))).toBe(a.port);
+    expect(readPortFile(join(configDirB, PORT_FILE_NAME))).toBe(b.port);
+  });
+
+  it("(same-dir) two acquirers on one configDir yield exactly one winner", async () => {
+    const configDir = freshDir();
+    trackHandle(await acquireWriteLock({ configDir, athleteHome: "/home/a", version: "1.0.0" }));
+
+    const probe: HealthzProbe = async () => ({ kind: "unresponsive" });
+    let caught: unknown;
+    try {
+      await acquireWriteLock({ configDir, athleteHome: "/home/a", version: "1.0.0", probeHealthz: probe });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(WriteLockContentionError);
+    expect((caught as WriteLockContentionError).exitCode).toBe(3);
+  });
+
+  it("(same-dir) two concurrent acquirers on one fresh configDir yield exactly one winner", async () => {
+    const configDir = freshDir();
+    const probe: HealthzProbe = async () => ({ kind: "unresponsive" });
+    const opts = { configDir, athleteHome: "/home/a", version: "1.0.0", probeHealthz: probe };
+
+    const settled = await Promise.allSettled([acquireWriteLock(opts), acquireWriteLock(opts)]);
+
+    const winners = settled.filter(
+      (s): s is PromiseFulfilledResult<AcquireWriteLockResult> =>
+        s.status === "fulfilled" && s.value.status === "acquired",
+    );
+    const losers = settled.filter((s): s is PromiseRejectedResult => s.status === "rejected");
+    expect(winners).toHaveLength(1);
+    expect(losers).toHaveLength(1);
+    trackHandle(winners[0].value);
+    expect(losers[0].reason).toBeInstanceOf(WriteLockContentionError);
+    expect((losers[0].reason as WriteLockContentionError).exitCode).toBe(3);
+  });
+
+  it("(default-probe) the real probe classifier resolves healthy/foreign/unresponsive", async () => {
+    const coach = await httpResponder(
+      JSON.stringify({ service: "enduragent-store-writer", version: "1.2.3" }),
+    );
+    expect(await defaultHealthzProbe(coach.port)).toEqual({ kind: "healthy", version: "1.2.3" });
+
+    const foreign = await httpResponder("hello");
+    expect(await defaultHealthzProbe(foreign.port)).toEqual({ kind: "foreign" });
+
+    const freePort = await knownFreePort();
+    expect(await defaultHealthzProbe(freePort)).toEqual({ kind: "unresponsive" });
+  });
+
+  it("(classify) classifyHealthzResponse maps coach/foreign/garbage bodies", () => {
+    expect(
+      classifyHealthzResponse(200, JSON.stringify({ service: "enduragent-store-writer", version: "2.0.0" })),
+    ).toEqual({ kind: "healthy", version: "2.0.0" });
+    expect(classifyHealthzResponse(200, JSON.stringify({ service: "other", version: "2.0.0" }))).toEqual({
+      kind: "foreign",
+    });
+    expect(classifyHealthzResponse(200, "not-json-garbage")).toEqual({ kind: "foreign" });
+  });
+});

--- a/packages/kernel-node/tsup.config.ts
+++ b/packages/kernel-node/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: { index: "src/index.ts", sqlite: "src/sqlite/index.ts", "archive/index": "src/archive/index.ts" },
+  entry: { index: "src/index.ts", sqlite: "src/sqlite/index.ts", "archive/index": "src/archive/index.ts", "lock/index": "src/lock/index.ts" },
   format: ["esm"],
   dts: true,
   sourcemap: true,


### PR DESCRIPTION
## Summary

Adds a single-writer store lock to `@enduragent/kernel-node`, exposed on a new `./lock` subpath. Only host-driver code in `packages/kernel-node` is touched; the pure compute kernel (`packages/kernel`) gains nothing.

The lock enforces that at most one process holds the read-write role for a given athlete home:

- A bound `127.0.0.1` loopback socket is the sole authority for the single-writer role — a process holds the role iff it holds the bound socket.
- The lockfile (`{ pid, port, version, athleteHome }`, atomically written) is advisory metadata only. It names the current holder for human-facing refusal messages; it never grants the role, and a stale lockfile can never wrongly block a start.
- The lockfile and the per-athlete-home port file both live under an injected, app-private, never-synced config directory. The lock module resolves no home itself — `configDir` is passed in as a parameter, keeping these files out of the archive root.

Four contention behaviors resolve deterministically:

- Healthy peer already holding the lock → returns a peer-healthy outcome the caller maps to a deferential exit 0.
- Stale lockfile with the recorded port free → reclaim (bind, replace lockfile + port file, start).
- Lockfile present, port bound, health probe unresponsive → refuse with a contention error carrying exit code 3 and the holder pid.
- Port bound by a foreign process (health probe returns non-coach output) → refuse with exit code 3, naming the port file.

Staleness is decided purely by "the recorded port is free" — no pid-liveness probe and no freshness window. A bound port already proves liveness, and a recycled pid would read as falsely alive. Read-only opens continue to work beside the write holder (WAL) and are covered by a test.

## Surfaces

- `packages/kernel-node/src/lock/lockfile-body.ts` — advisory lockfile shape plus atomic reader/writer.
- `packages/kernel-node/src/lock/port-file.ts` — per-athlete-home port file reader/writer.
- `packages/kernel-node/src/lock/healthz-probe.ts` — default health-probe classifier plus an injectable probe seam.
- `packages/kernel-node/src/lock/acquire.ts` — the acquire flow resolving the four contention behaviors.
- `packages/kernel-node/src/lock/index.ts` — the `./lock` subpath barrel.
- `packages/kernel-node/tests/lock.test.ts` — covers the port-bind singleton, lockfile write/read-back, per-home port file, stale-reclaim, read-only-open-beside-holder, and the probe classifier via an injected stub plus one minimal loopback responder.
- `packages/kernel-node/package.json`, `packages/kernel-node/tsup.config.ts` — add the `./lock` export key and the matching build entry.

## Test plan

- `pnpm build` — kernel-node emits the `lock/index` bundle.
- `pnpm check` — green end-to-end (build, typecheck, lints, trademark, fixture-privacy, registry-isolation, changeset, package-deps, kernel-discipline).
- `pnpm vitest run packages/kernel-node/tests/lock.test.ts` — the lock suite passes.
- `pnpm test` — full suite green (the known `detect.test.ts` load flake passes on isolated re-run).
- `pnpm s8a` and `pnpm s8a --self-test` — exit 0, zero diffs.
- `pnpm check-parity --all` — all pairs green, zero snapshot regeneration.

No changeset: `@enduragent/kernel-node` is private and nothing here is user-visible.
