### PR TITLE
feat(kernel): export/import op for the local-first athlete store

### DIFF
--- a/packages/kernel-node/package.json
+++ b/packages/kernel-node/package.json
@@ -8,7 +8,8 @@
   "exports": {
     "./sqlite": "./dist/sqlite.js",
     "./archive": "./dist/archive/index.js",
-    "./lock": "./dist/lock/index.js"
+    "./lock": "./dist/lock/index.js",
+    "./store-export": "./dist/store-export/index.js"
   },
   "engines": {
     "node": ">=24"

--- a/packages/kernel-node/src/store-export/index.ts
+++ b/packages/kernel-node/src/store-export/index.ts
@@ -1,0 +1,1 @@
+export { webCryptoExportCrypto, webCryptoTextCodec, webCryptoExportEnv } from "./web-crypto.js";

--- a/packages/kernel-node/src/store-export/web-crypto.ts
+++ b/packages/kernel-node/src/store-export/web-crypto.ts
@@ -1,0 +1,63 @@
+import type { ExportCryptoPort, TextCodec } from "@enduragent/kernel/store/export";
+import { PBKDF2_HASH, AES_KEY_BITS } from "@enduragent/kernel/store/export";
+
+export const webCryptoTextCodec: TextCodec = {
+  encodeUtf8: (s) => new TextEncoder().encode(s),
+  decodeUtf8: (b) => new TextDecoder().decode(b),
+};
+
+function toBufferSource(view: Uint8Array): Uint8Array<ArrayBuffer> {
+  const copy = new Uint8Array(view.length);
+  copy.set(view);
+  return copy;
+}
+
+async function deriveKey(
+  passphrase: string,
+  salt: Uint8Array,
+  iterations: number,
+  usage: "encrypt" | "decrypt",
+): Promise<CryptoKey> {
+  const base = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(passphrase),
+    "PBKDF2",
+    false,
+    ["deriveKey"],
+  );
+  return crypto.subtle.deriveKey(
+    { name: "PBKDF2", salt: toBufferSource(salt), iterations, hash: PBKDF2_HASH },
+    base,
+    { name: "AES-GCM", length: AES_KEY_BITS },
+    false,
+    [usage],
+  );
+}
+
+export const webCryptoExportCrypto: ExportCryptoPort = {
+  randomBytes(n) {
+    const b = new Uint8Array(n);
+    globalThis.crypto.getRandomValues(b);
+    return b;
+  },
+  async encrypt({ passphrase, salt, iterations, nonce, aad, plaintext }) {
+    const key = await deriveKey(passphrase, salt, iterations, "encrypt");
+    const out = await crypto.subtle.encrypt(
+      { name: "AES-GCM", iv: toBufferSource(nonce), additionalData: toBufferSource(aad) },
+      key,
+      toBufferSource(plaintext),
+    );
+    return new Uint8Array(out);
+  },
+  async decrypt({ passphrase, salt, iterations, nonce, aad, ciphertext }) {
+    const key = await deriveKey(passphrase, salt, iterations, "decrypt");
+    const out = await crypto.subtle.decrypt(
+      { name: "AES-GCM", iv: toBufferSource(nonce), additionalData: toBufferSource(aad) },
+      key,
+      toBufferSource(ciphertext),
+    );
+    return new Uint8Array(out);
+  },
+};
+
+export const webCryptoExportEnv = { crypto: webCryptoExportCrypto, codec: webCryptoTextCodec } as const;

--- a/packages/kernel-node/src/store-export/web-crypto.ts
+++ b/packages/kernel-node/src/store-export/web-crypto.ts
@@ -7,6 +7,13 @@ export const webCryptoTextCodec: TextCodec = {
 };
 
 function toBufferSource(view: Uint8Array): Uint8Array<ArrayBuffer> {
+  if (
+    view.byteOffset === 0 &&
+    view.byteLength === view.buffer.byteLength &&
+    view.buffer instanceof ArrayBuffer
+  ) {
+    return view as Uint8Array<ArrayBuffer>;
+  }
   const copy = new Uint8Array(view.length);
   copy.set(view);
   return copy;

--- a/packages/kernel-node/tests/store-export.test.ts
+++ b/packages/kernel-node/tests/store-export.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildExport,
+  importExport,
+  PBKDF2_ITERATIONS,
+  PURE_AUTHORED_TABLES,
+  MIXED_AUTHORED_TABLES,
+  ExportDecryptionError,
+  type ArchiveArtifact,
+  type AuthoredRow,
+  type ExportSource,
+  type ArchiveManifestReader,
+  type ImportSink,
+  type ArchivePresenceChecker,
+  type RestoreTableResult,
+} from "@enduragent/kernel/store/export";
+import { webCryptoExportEnv } from "@enduragent/kernel-node/store-export";
+
+const { crypto, codec } = webCryptoExportEnv;
+
+interface Populated {
+  readonly userVersion: number;
+  readonly rows: Record<string, readonly AuthoredRow[]>;
+  readonly artifacts: readonly ArchiveArtifact[];
+}
+
+function populated(userVersion = 3): Populated {
+  const rows: Record<string, readonly AuthoredRow[]> = {};
+  for (const t of PURE_AUTHORED_TABLES) rows[t] = [{ id: `${t}-1`, v: 1 }, { id: `${t}-2`, note: "üñïçödé" }];
+  for (const t of MIXED_AUTHORED_TABLES) rows[t] = [{ id: `${t}-m1`, provenance: "manual" }];
+  const artifacts: ArchiveArtifact[] = [
+    { address: "aa", relPath: "archive/2026/06/aa/aa.fit", bytes: 20, kind: "fit" },
+    { address: "bb", relPath: "archive/2026/06/bb/bb.tcx", bytes: 30, kind: "tcx" },
+  ];
+  return { userVersion, rows, artifacts };
+}
+
+function makeSource(data: Populated): ExportSource {
+  return {
+    async readUserVersion() {
+      return data.userVersion;
+    },
+    async readAuthoredTable(table) {
+      return data.rows[table] ?? [];
+    },
+  };
+}
+
+function makeManifest(data: Populated): ArchiveManifestReader {
+  return {
+    async listArtifacts() {
+      return data.artifacts;
+    },
+  };
+}
+
+function makeSink(): ImportSink & { stored: Map<string, AuthoredRow[]> } {
+  const stored = new Map<string, AuthoredRow[]>();
+  return {
+    stored,
+    async restoreAuthoredTable(table, rows): Promise<RestoreTableResult> {
+      let list = stored.get(table);
+      if (!list) {
+        list = [];
+        stored.set(table, list);
+      }
+      let inserted = 0;
+      let skipped = 0;
+      for (const row of rows) {
+        const key = JSON.stringify(row);
+        if (list.some((r) => JSON.stringify(r) === key)) skipped += 1;
+        else {
+          list.push(row);
+          inserted += 1;
+        }
+      }
+      return { table, inserted, skipped };
+    },
+  };
+}
+
+function makePresence(): ArchivePresenceChecker {
+  return {
+    async hasArtifact() {
+      return true;
+    },
+  };
+}
+
+describe("store export op with real WebCrypto", () => {
+  it("(real-roundtrip-nopass) restores every authored row without a passphrase", async () => {
+    const data = populated();
+    const built = await buildExport(
+      { source: makeSource(data), manifest: makeManifest(data), crypto, codec },
+      {},
+    );
+    const sink = makeSink();
+    await importExport(
+      { sink, presence: makePresence(), crypto, codec, targetUserVersion: 5 },
+      { container: built.container },
+    );
+    for (const t of [...PURE_AUTHORED_TABLES, ...MIXED_AUTHORED_TABLES]) {
+      expect(sink.stored.get(t)).toEqual(data.rows[t]);
+    }
+  });
+
+  it("(real-roundtrip-pass) round-trips with a multibyte passphrase", async () => {
+    const data = populated();
+    const built = await buildExport(
+      { source: makeSource(data), manifest: makeManifest(data), crypto, codec },
+      { passphrase: "s3kr3t-üñïçödé" },
+    );
+    const sink = makeSink();
+    await importExport(
+      { sink, presence: makePresence(), crypto, codec, targetUserVersion: 5 },
+      { container: built.container, passphrase: "s3kr3t-üñïçödé" },
+    );
+    for (const t of [...PURE_AUTHORED_TABLES, ...MIXED_AUTHORED_TABLES]) {
+      expect(sink.stored.get(t)).toEqual(data.rows[t]);
+    }
+  });
+
+  it("(wrong-pass) a wrong passphrase rejects with ExportDecryptionError", async () => {
+    const data = populated();
+    const built = await buildExport(
+      { source: makeSource(data), manifest: makeManifest(data), crypto, codec },
+      { passphrase: "right" },
+    );
+    await expect(
+      importExport(
+        { sink: makeSink(), presence: makePresence(), crypto, codec, targetUserVersion: 5 },
+        { container: built.container, passphrase: "wrong" },
+      ),
+    ).rejects.toBeInstanceOf(ExportDecryptionError);
+  });
+
+  it("(tamper-ciphertext) flipping a ciphertext bit rejects with ExportDecryptionError", async () => {
+    const data = populated();
+    const built = await buildExport(
+      { source: makeSource(data), manifest: makeManifest(data), crypto, codec },
+      { passphrase: "pw" },
+    );
+    const tampered = built.container.slice();
+    tampered[tampered.length - 1] ^= 0x01;
+    await expect(
+      importExport(
+        { sink: makeSink(), presence: makePresence(), crypto, codec, targetUserVersion: 5 },
+        { container: tampered, passphrase: "pw" },
+      ),
+    ).rejects.toBeInstanceOf(ExportDecryptionError);
+  });
+
+  it("(tamper-header) flipping a nonce/AAD bit rejects with ExportDecryptionError", async () => {
+    const data = populated();
+    const built = await buildExport(
+      { source: makeSource(data), manifest: makeManifest(data), crypto, codec },
+      { passphrase: "pw" },
+    );
+    const tampered = built.container.slice();
+    tampered[34] ^= 0x01;
+    await expect(
+      importExport(
+        { sink: makeSink(), presence: makePresence(), crypto, codec, targetUserVersion: 5 },
+        { container: tampered, passphrase: "pw" },
+      ),
+    ).rejects.toBeInstanceOf(ExportDecryptionError);
+  });
+
+  it("(iterations-floor) container ITERATIONS field equals PBKDF2_ITERATIONS >= 600000", async () => {
+    const data = populated();
+    const built = await buildExport(
+      { source: makeSource(data), manifest: makeManifest(data), crypto, codec },
+      { passphrase: "pw" },
+    );
+    const iterations = new DataView(
+      built.container.buffer,
+      built.container.byteOffset,
+    ).getUint32(11, false);
+    expect(iterations).toBe(PBKDF2_ITERATIONS);
+    expect(PBKDF2_ITERATIONS).toBeGreaterThanOrEqual(600_000);
+  });
+});

--- a/packages/kernel-node/tsup.config.ts
+++ b/packages/kernel-node/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: { index: "src/index.ts", sqlite: "src/sqlite/index.ts", "archive/index": "src/archive/index.ts", "lock/index": "src/lock/index.ts" },
+  entry: { index: "src/index.ts", sqlite: "src/sqlite/index.ts", "archive/index": "src/archive/index.ts", "lock/index": "src/lock/index.ts", "store-export/index": "src/store-export/index.ts" },
   format: ["esm"],
   dts: true,
   sourcemap: true,

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -9,7 +9,8 @@
     "./ports": "./dist/ports.js",
     "./store/migrations": "./dist/store/migrations.js",
     "./store": "./dist/store.js",
-    "./archive": "./dist/archive/index.js"
+    "./archive": "./dist/archive/index.js",
+    "./store/export": "./dist/store/export/index.js"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/kernel/src/store/export/container.ts
+++ b/packages/kernel/src/store/export/container.ts
@@ -1,0 +1,171 @@
+import {
+  type ExportCryptoPort,
+  type TextCodec,
+  PBKDF2_ITERATIONS,
+  SALT_BYTES,
+  NONCE_BYTES,
+} from "./ports.js";
+
+export function stableSerialize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(stableSerialize);
+  if (value !== null && typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    const sorted: Record<string, unknown> = {};
+    for (const key of Object.keys(record).sort()) sorted[key] = stableSerialize(record[key]);
+    return sorted;
+  }
+  return value;
+}
+export function canonicalJson(value: unknown): string {
+  return JSON.stringify(stableSerialize(value), null, 2);
+}
+
+// ASCII "ENDRXPRT" — the 8 magic bytes identifying an enduragent export file.
+export const CONTAINER_MAGIC = Uint8Array.of(0x45, 0x4e, 0x44, 0x52, 0x58, 0x50, 0x52, 0x54);
+export const EXPORT_FORMAT_VERSION = 1 as const;
+export const MODE_PLAINTEXT = 0x00 as const;
+export const MODE_PASSPHRASE = 0x01 as const;
+export const KDF_PBKDF2_SHA256 = 0x01 as const;
+export const AEAD_AES256_GCM = 0x01 as const;
+
+const PLAINTEXT_HEADER_LEN = 10;
+const PASSPHRASE_HEADER_LEN = 46;
+
+export class ExportFormatError extends Error {
+  constructor(message: string) { super(message); this.name = "ExportFormatError"; }
+}
+export class ExportPassphraseRequiredError extends Error {
+  constructor(message: string) { super(message); this.name = "ExportPassphraseRequiredError"; }
+}
+export class ExportDecryptionError extends Error {
+  constructor(message: string) { super(message); this.name = "ExportDecryptionError"; }
+}
+
+function concatBytes(parts: readonly Uint8Array[]): Uint8Array {
+  let total = 0;
+  for (const p of parts) total += p.length;
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const p of parts) {
+    out.set(p, offset);
+    offset += p.length;
+  }
+  return out;
+}
+
+export async function encodeContainer(
+  document: unknown,
+  deps: { codec: TextCodec; crypto: ExportCryptoPort },
+  opts: { passphrase?: string },
+): Promise<Uint8Array> {
+  const payload = deps.codec.encodeUtf8(canonicalJson(document));
+  if (!opts.passphrase) {
+    return concatBytes([
+      CONTAINER_MAGIC,
+      Uint8Array.of(EXPORT_FORMAT_VERSION, MODE_PLAINTEXT),
+      payload,
+    ]);
+  }
+  const salt = deps.crypto.randomBytes(SALT_BYTES);
+  const nonce = deps.crypto.randomBytes(NONCE_BYTES);
+  const header = new Uint8Array(PASSPHRASE_HEADER_LEN);
+  header.set(CONTAINER_MAGIC, 0);
+  header[8] = EXPORT_FORMAT_VERSION;
+  header[9] = MODE_PASSPHRASE;
+  header[10] = KDF_PBKDF2_SHA256;
+  new DataView(header.buffer, header.byteOffset).setUint32(11, PBKDF2_ITERATIONS, false);
+  header[15] = SALT_BYTES;
+  header.set(salt, 16);
+  header[32] = AEAD_AES256_GCM;
+  header[33] = NONCE_BYTES;
+  header.set(nonce, 34);
+  const ciphertext = await deps.crypto.encrypt({
+    passphrase: opts.passphrase,
+    salt,
+    iterations: PBKDF2_ITERATIONS,
+    nonce,
+    aad: header,
+    plaintext: payload,
+  });
+  return concatBytes([header, ciphertext]);
+}
+
+export async function decodeContainer(
+  container: Uint8Array,
+  deps: { codec: TextCodec; crypto: ExportCryptoPort },
+  opts: { passphrase?: string },
+): Promise<unknown> {
+  if (container.length < PLAINTEXT_HEADER_LEN) {
+    throw new ExportFormatError("This is not an enduragent export file.");
+  }
+  for (let i = 0; i < CONTAINER_MAGIC.length; i++) {
+    if (container[i] !== CONTAINER_MAGIC[i]) {
+      throw new ExportFormatError("This is not an enduragent export file.");
+    }
+  }
+  if (container[8] !== EXPORT_FORMAT_VERSION) {
+    throw new ExportFormatError(
+      `Unsupported export format version ${container[8]}; update the app to read this file.`,
+    );
+  }
+  const mode = container[9];
+  if (mode === MODE_PLAINTEXT) {
+    const text = deps.codec.decodeUtf8(container.subarray(PLAINTEXT_HEADER_LEN));
+    return parseJsonPayload(text);
+  }
+  if (mode === MODE_PASSPHRASE) {
+    if (!opts.passphrase) {
+      throw new ExportPassphraseRequiredError(
+        "This export is passphrase-protected; a passphrase is required to open it.",
+      );
+    }
+    if (container.length < PASSPHRASE_HEADER_LEN) {
+      throw new ExportFormatError("The export file header is corrupt or uses unsupported parameters.");
+    }
+    const kdfId = container[10];
+    const iterations = new DataView(container.buffer, container.byteOffset).getUint32(11, false);
+    const saltLen = container[15];
+    const aeadId = container[32];
+    const nonceLen = container[33];
+    if (
+      kdfId !== KDF_PBKDF2_SHA256 ||
+      aeadId !== AEAD_AES256_GCM ||
+      saltLen !== SALT_BYTES ||
+      nonceLen !== NONCE_BYTES ||
+      iterations < PBKDF2_ITERATIONS
+    ) {
+      throw new ExportFormatError("The export file header is corrupt or uses unsupported parameters.");
+    }
+    const salt = container.subarray(16, 16 + saltLen);
+    const nonce = container.subarray(34, 34 + nonceLen);
+    const ciphertext = container.subarray(PASSPHRASE_HEADER_LEN);
+    const aad = container.subarray(0, PASSPHRASE_HEADER_LEN);
+    // AES-GCM cannot distinguish a wrong passphrase from tampered bytes —
+    // both surface as ExportDecryptionError. Do not attempt to tell them apart.
+    let plaintext: Uint8Array;
+    try {
+      plaintext = await deps.crypto.decrypt({
+        passphrase: opts.passphrase,
+        salt,
+        iterations,
+        nonce,
+        aad,
+        ciphertext,
+      });
+    } catch {
+      throw new ExportDecryptionError(
+        "Could not decrypt the export: wrong passphrase, or the file has been modified.",
+      );
+    }
+    return parseJsonPayload(deps.codec.decodeUtf8(plaintext));
+  }
+  throw new ExportFormatError("The export file header is corrupt or uses unsupported parameters.");
+}
+
+function parseJsonPayload(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new ExportFormatError("The export file is corrupt (payload is not valid JSON).");
+  }
+}

--- a/packages/kernel/src/store/export/container.ts
+++ b/packages/kernel/src/store/export/container.ts
@@ -1,3 +1,4 @@
+import { sortKeys } from "../canonical-json.js";
 import {
   type ExportCryptoPort,
   type TextCodec,
@@ -6,18 +7,9 @@ import {
   NONCE_BYTES,
 } from "./ports.js";
 
-export function stableSerialize(value: unknown): unknown {
-  if (Array.isArray(value)) return value.map(stableSerialize);
-  if (value !== null && typeof value === "object") {
-    const record = value as Record<string, unknown>;
-    const sorted: Record<string, unknown> = {};
-    for (const key of Object.keys(record).sort()) sorted[key] = stableSerialize(record[key]);
-    return sorted;
-  }
-  return value;
-}
+export { sortKeys as stableSerialize };
 export function canonicalJson(value: unknown): string {
-  return JSON.stringify(stableSerialize(value), null, 2);
+  return JSON.stringify(sortKeys(value), null, 2);
 }
 
 // ASCII "ENDRXPRT" — the 8 magic bytes identifying an enduragent export file.

--- a/packages/kernel/src/store/export/export-op.ts
+++ b/packages/kernel/src/store/export/export-op.ts
@@ -1,0 +1,151 @@
+import {
+  type ArchiveArtifact,
+  type ArchiveManifestReader,
+  type ArchivePresenceChecker,
+  type AuthoredRow,
+  type ExportCryptoPort,
+  type ExportSource,
+  type ImportSink,
+  type RestoreTableResult,
+  type TextCodec,
+  PURE_AUTHORED_TABLES,
+  MIXED_AUTHORED_TABLES,
+} from "./ports.js";
+import {
+  encodeContainer,
+  decodeContainer,
+  EXPORT_FORMAT_VERSION,
+  ExportFormatError,
+} from "./container.js";
+
+export const EXPORT_DOCUMENT_KIND = "enduragent-export" as const;
+
+export const EXPORT_WARNING =
+  "Warning: this file contains your full health and chat history. Anyone who can open it — and, if you set one, anyone who has the passphrase — can read everything in it. Store it somewhere private, and only share it over a channel you trust." as const;
+
+export class ExportSchemaMismatchError extends Error {
+  constructor(message: string) { super(message); this.name = "ExportSchemaMismatchError"; }
+}
+
+export interface BuildExportDeps {
+  readonly source: ExportSource;
+  readonly manifest: ArchiveManifestReader;
+  readonly crypto: ExportCryptoPort;
+  readonly codec: TextCodec;
+}
+export interface BuildExportResult {
+  readonly container: Uint8Array;
+  readonly warning: string;
+  readonly encrypted: boolean;
+  readonly tables: readonly { readonly table: string; readonly count: number }[];
+  readonly artifactCount: number;
+}
+
+export interface ImportExportDeps {
+  readonly sink: ImportSink;
+  readonly presence: ArchivePresenceChecker;
+  readonly crypto: ExportCryptoPort;
+  readonly codec: TextCodec;
+  readonly targetUserVersion: number;
+}
+export interface ManifestVerification {
+  readonly total: number;
+  readonly present: number;
+  readonly missing: readonly ArchiveArtifact[];
+}
+export interface ImportResult {
+  readonly restored: readonly RestoreTableResult[];
+  readonly manifest: ManifestVerification;
+}
+
+const ALL_AUTHORED_TABLES = [...PURE_AUTHORED_TABLES, ...MIXED_AUTHORED_TABLES] as const;
+
+export async function buildExport(
+  deps: BuildExportDeps,
+  opts: { passphrase?: string },
+): Promise<BuildExportResult> {
+  const userVersion = await deps.source.readUserVersion();
+  const authored: Record<string, readonly AuthoredRow[]> = {};
+  for (const t of PURE_AUTHORED_TABLES) {
+    authored[t] = await deps.source.readAuthoredTable(t, { manualOnly: false });
+  }
+  for (const t of MIXED_AUTHORED_TABLES) {
+    authored[t] = await deps.source.readAuthoredTable(t, { manualOnly: true });
+  }
+  const artifacts = [...(await deps.manifest.listArtifacts())].sort((a, b) =>
+    a.address < b.address ? -1 : a.address > b.address ? 1 : 0,
+  );
+  const document = {
+    kind: EXPORT_DOCUMENT_KIND,
+    formatVersion: EXPORT_FORMAT_VERSION,
+    store: { userVersion, authored },
+    archiveManifest: artifacts,
+  };
+  const container = await encodeContainer(
+    document,
+    { codec: deps.codec, crypto: deps.crypto },
+    { passphrase: opts.passphrase },
+  );
+  return {
+    container,
+    warning: EXPORT_WARNING,
+    encrypted: Boolean(opts.passphrase),
+    tables: ALL_AUTHORED_TABLES.map((t) => ({ table: t, count: authored[t].length })),
+    artifactCount: artifacts.length,
+  };
+}
+
+export async function importExport(
+  deps: ImportExportDeps,
+  opts: { container: Uint8Array; passphrase?: string },
+): Promise<ImportResult> {
+  const document = await decodeContainer(
+    opts.container,
+    { codec: deps.codec, crypto: deps.crypto },
+    { passphrase: opts.passphrase },
+  );
+  if (
+    document === null ||
+    typeof document !== "object" ||
+    (document as Record<string, unknown>).kind !== EXPORT_DOCUMENT_KIND ||
+    (document as Record<string, unknown>).formatVersion !== EXPORT_FORMAT_VERSION
+  ) {
+    throw new ExportFormatError("The export file is not a recognized enduragent export document.");
+  }
+  const store = (document as Record<string, unknown>).store;
+  const archiveManifest = (document as Record<string, unknown>).archiveManifest;
+  if (
+    store === null ||
+    typeof store !== "object" ||
+    typeof (store as Record<string, unknown>).authored !== "object" ||
+    (store as Record<string, unknown>).authored === null ||
+    !Array.isArray(archiveManifest)
+  ) {
+    throw new ExportFormatError("The export file is not a recognized enduragent export document.");
+  }
+  const storeUserVersion = (store as Record<string, unknown>).userVersion as number;
+  const authored = (store as Record<string, unknown>).authored as Record<string, readonly AuthoredRow[]>;
+  if (storeUserVersion > deps.targetUserVersion) {
+    throw new ExportSchemaMismatchError(
+      "This backup was created by a newer version of the app; update before restoring.",
+    );
+  }
+  const restored: RestoreTableResult[] = [];
+  for (const t of ALL_AUTHORED_TABLES) {
+    const rows = authored[t] ?? [];
+    restored.push(await deps.sink.restoreAuthoredTable(t, rows));
+  }
+  const manifestArtifacts = archiveManifest as readonly ArchiveArtifact[];
+  const missing: ArchiveArtifact[] = [];
+  for (const art of manifestArtifacts) {
+    if (!(await deps.presence.hasArtifact(art.address))) missing.push(art);
+  }
+  return {
+    restored,
+    manifest: {
+      total: manifestArtifacts.length,
+      present: manifestArtifacts.length - missing.length,
+      missing,
+    },
+  };
+}

--- a/packages/kernel/src/store/export/export-op.ts
+++ b/packages/kernel/src/store/export/export-op.ts
@@ -104,27 +104,28 @@ export async function importExport(
     { codec: deps.codec, crypto: deps.crypto },
     { passphrase: opts.passphrase },
   );
-  if (
-    document === null ||
-    typeof document !== "object" ||
-    (document as Record<string, unknown>).kind !== EXPORT_DOCUMENT_KIND ||
-    (document as Record<string, unknown>).formatVersion !== EXPORT_FORMAT_VERSION
-  ) {
+  if (document === null || typeof document !== "object") {
     throw new ExportFormatError("The export file is not a recognized enduragent export document.");
   }
-  const store = (document as Record<string, unknown>).store;
-  const archiveManifest = (document as Record<string, unknown>).archiveManifest;
+  const doc = document as Record<string, unknown>;
+  if (doc.kind !== EXPORT_DOCUMENT_KIND || doc.formatVersion !== EXPORT_FORMAT_VERSION) {
+    throw new ExportFormatError("The export file is not a recognized enduragent export document.");
+  }
+  const store = doc.store;
+  const archiveManifest = doc.archiveManifest;
+  if (store === null || typeof store !== "object") {
+    throw new ExportFormatError("The export file is not a recognized enduragent export document.");
+  }
+  const storeRecord = store as Record<string, unknown>;
   if (
-    store === null ||
-    typeof store !== "object" ||
-    typeof (store as Record<string, unknown>).authored !== "object" ||
-    (store as Record<string, unknown>).authored === null ||
+    typeof storeRecord.authored !== "object" ||
+    storeRecord.authored === null ||
     !Array.isArray(archiveManifest)
   ) {
     throw new ExportFormatError("The export file is not a recognized enduragent export document.");
   }
-  const storeUserVersion = (store as Record<string, unknown>).userVersion as number;
-  const authored = (store as Record<string, unknown>).authored as Record<string, readonly AuthoredRow[]>;
+  const storeUserVersion = storeRecord.userVersion as number;
+  const authored = storeRecord.authored as Record<string, readonly AuthoredRow[]>;
   if (storeUserVersion > deps.targetUserVersion) {
     throw new ExportSchemaMismatchError(
       "This backup was created by a newer version of the app; update before restoring.",

--- a/packages/kernel/src/store/export/index.ts
+++ b/packages/kernel/src/store/export/index.ts
@@ -1,0 +1,17 @@
+export { buildExport, importExport, EXPORT_WARNING, EXPORT_DOCUMENT_KIND, ExportSchemaMismatchError } from "./export-op.js";
+export type {
+  BuildExportDeps, BuildExportResult, ImportExportDeps, ImportResult, ManifestVerification,
+} from "./export-op.js";
+export {
+  encodeContainer, decodeContainer, canonicalJson, stableSerialize,
+  CONTAINER_MAGIC, EXPORT_FORMAT_VERSION, MODE_PLAINTEXT, MODE_PASSPHRASE,
+  ExportFormatError, ExportPassphraseRequiredError, ExportDecryptionError,
+} from "./container.js";
+export {
+  PURE_AUTHORED_TABLES, MIXED_AUTHORED_TABLES,
+  PBKDF2_ITERATIONS, PBKDF2_HASH, SALT_BYTES, NONCE_BYTES, AES_KEY_BITS,
+} from "./ports.js";
+export type {
+  ExportCryptoPort, TextCodec, ArchiveArtifact, AuthoredRow,
+  ExportSource, ArchiveManifestReader, ImportSink, RestoreTableResult, ArchivePresenceChecker,
+} from "./ports.js";

--- a/packages/kernel/src/store/export/ports.ts
+++ b/packages/kernel/src/store/export/ports.ts
@@ -1,0 +1,92 @@
+export const PBKDF2_ITERATIONS = 600_000 as const;
+export const PBKDF2_HASH = "SHA-256" as const;
+export const SALT_BYTES = 16 as const;
+export const NONCE_BYTES = 12 as const;
+export const AES_KEY_BITS = 256 as const;
+
+export interface ExportCryptoPort {
+  /** Cryptographically-random bytes. */
+  randomBytes(n: number): Uint8Array;
+  /** PBKDF2(SHA-256, iterations) → AES-256-GCM encrypt. Returns ciphertext||tag. */
+  encrypt(input: {
+    readonly passphrase: string;
+    readonly salt: Uint8Array;
+    readonly iterations: number;
+    readonly nonce: Uint8Array;
+    readonly aad: Uint8Array;
+    readonly plaintext: Uint8Array;
+  }): Promise<Uint8Array>;
+  /** Reverse of encrypt. MUST reject (throw) on any authentication failure
+   *  (wrong passphrase OR modified bytes — AES-GCM cannot distinguish them). */
+  decrypt(input: {
+    readonly passphrase: string;
+    readonly salt: Uint8Array;
+    readonly iterations: number;
+    readonly nonce: Uint8Array;
+    readonly aad: Uint8Array;
+    readonly ciphertext: Uint8Array;
+  }): Promise<Uint8Array>;
+}
+
+export interface TextCodec {
+  encodeUtf8(s: string): Uint8Array;
+  decodeUtf8(b: Uint8Array): string;
+}
+
+export interface ArchiveArtifact {
+  readonly address: string;
+  readonly relPath: string;
+  readonly bytes: number;
+  readonly kind: string;
+}
+
+export type AuthoredRow = Record<string, unknown>;
+
+export interface ExportSource {
+  /** The store's current PRAGMA user_version at export time. */
+  readUserVersion(): Promise<number>;
+  /** Rows of one authored-class table. For a mixed table, opts.manualOnly
+   *  is true and the source MUST return only provenance='manual' rows. Rows
+   *  MUST be JSON-serializable (the adapter normalizes any bigint columns). */
+  readAuthoredTable(table: string, opts: { readonly manualOnly: boolean }): Promise<readonly AuthoredRow[]>;
+}
+
+export interface ArchiveManifestReader {
+  /** Every raw-archive artifact as address+metadata; NO blob bytes. */
+  listArtifacts(): Promise<readonly ArchiveArtifact[]>;
+}
+
+export interface RestoreTableResult {
+  readonly table: string;
+  readonly inserted: number;
+  readonly skipped: number;
+}
+
+export interface ImportSink {
+  /** Idempotent insert-if-absent by the table's primary key. Re-importing
+   *  the same container inserts zero duplicate rows (skipped counts them). */
+  restoreAuthoredTable(table: string, rows: readonly AuthoredRow[]): Promise<RestoreTableResult>;
+}
+
+export interface ArchivePresenceChecker {
+  /** True iff an artifact with this content address exists in the archive. */
+  hasArtifact(address: string): Promise<boolean>;
+}
+
+export const PURE_AUTHORED_TABLES = [
+  "athlete",
+  "sport_settings",
+  "race_goal",
+  "intake_flags",
+  "stroke_correction_overlay",
+  "field_merge_override_overlay",
+  "pool_size_correction_overlay",
+] as const;
+
+/** Mixed source|authored tables — ONLY provenance='manual' rows are authored. */
+export const MIXED_AUTHORED_TABLES = [
+  "anchor_history",
+  "zone_set_history",
+  "wellness",
+  "planned_workout",
+] as const;

--- a/packages/kernel/tests/store-export.test.ts
+++ b/packages/kernel/tests/store-export.test.ts
@@ -1,0 +1,354 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildExport,
+  importExport,
+  decodeContainer,
+  encodeContainer,
+  EXPORT_WARNING,
+  EXPORT_FORMAT_VERSION,
+  CONTAINER_MAGIC,
+  PBKDF2_ITERATIONS,
+  ExportFormatError,
+  ExportPassphraseRequiredError,
+  ExportDecryptionError,
+  ExportSchemaMismatchError,
+  PURE_AUTHORED_TABLES,
+  MIXED_AUTHORED_TABLES,
+  type ExportCryptoPort,
+  type TextCodec,
+  type ArchiveArtifact,
+  type AuthoredRow,
+  type ExportSource,
+  type ArchiveManifestReader,
+  type ImportSink,
+  type ArchivePresenceChecker,
+  type RestoreTableResult,
+} from "@enduragent/kernel/store/export";
+
+const codec: TextCodec = {
+  encodeUtf8: (s) => new TextEncoder().encode(s),
+  decodeUtf8: (b) => new TextDecoder().decode(b),
+};
+
+function toHex(b: Uint8Array): string {
+  let s = "";
+  for (const x of b) s += x.toString(16).padStart(2, "0");
+  return s;
+}
+
+const TAG16 = new Uint8Array(16);
+
+class FakeCrypto implements ExportCryptoPort {
+  private readonly recorded = new Set<string>();
+  private counter = 0;
+  randomBytes(n: number): Uint8Array {
+    const b = new Uint8Array(n);
+    for (let i = 0; i < n; i++) b[i] = (this.counter + i) & 0xff;
+    this.counter += 1;
+    return b;
+  }
+  async encrypt(input: {
+    passphrase: string;
+    salt: Uint8Array;
+    iterations: number;
+    nonce: Uint8Array;
+    aad: Uint8Array;
+    plaintext: Uint8Array;
+  }): Promise<Uint8Array> {
+    this.recorded.add(`${input.passphrase}:${toHex(input.aad)}`);
+    const out = new Uint8Array(input.plaintext.length + 16);
+    out.set(input.plaintext, 0);
+    out.set(TAG16, input.plaintext.length);
+    return out;
+  }
+  async decrypt(input: {
+    passphrase: string;
+    salt: Uint8Array;
+    iterations: number;
+    nonce: Uint8Array;
+    aad: Uint8Array;
+    ciphertext: Uint8Array;
+  }): Promise<Uint8Array> {
+    if (!this.recorded.has(`${input.passphrase}:${toHex(input.aad)}`)) {
+      throw new Error("auth failure");
+    }
+    return input.ciphertext.subarray(0, input.ciphertext.length - 16);
+  }
+}
+
+interface Populated {
+  readonly userVersion: number;
+  readonly rows: Record<string, readonly AuthoredRow[]>;
+  readonly artifacts: readonly ArchiveArtifact[];
+}
+
+function populated(userVersion = 3): Populated {
+  const rows: Record<string, readonly AuthoredRow[]> = {};
+  for (const t of PURE_AUTHORED_TABLES) rows[t] = [{ id: `${t}-1`, v: 1 }, { id: `${t}-2`, v: 2 }];
+  for (const t of MIXED_AUTHORED_TABLES) rows[t] = [{ id: `${t}-m1`, provenance: "manual" }];
+  const artifacts: ArchiveArtifact[] = [
+    { address: "cc", relPath: "archive/2026/06/cc/cc.fit", bytes: 10, kind: "fit" },
+    { address: "aa", relPath: "archive/2026/06/aa/aa.fit", bytes: 20, kind: "fit" },
+    { address: "bb", relPath: "archive/2026/06/bb/bb.tcx", bytes: 30, kind: "tcx" },
+  ];
+  return { userVersion, rows, artifacts };
+}
+
+interface SourceCall {
+  table: string;
+  manualOnly: boolean;
+}
+
+function makeSource(data: Populated): { source: ExportSource; calls: SourceCall[] } {
+  const calls: SourceCall[] = [];
+  const source: ExportSource = {
+    async readUserVersion() {
+      return data.userVersion;
+    },
+    async readAuthoredTable(table, opts) {
+      calls.push({ table, manualOnly: opts.manualOnly });
+      return data.rows[table] ?? [];
+    },
+  };
+  return { source, calls };
+}
+
+function makeManifest(data: Populated): ArchiveManifestReader {
+  return {
+    async listArtifacts() {
+      return data.artifacts;
+    },
+  };
+}
+
+function makeSink(): ImportSink & { stored: Map<string, Set<string>> } {
+  const stored = new Map<string, Set<string>>();
+  const sink: ImportSink & { stored: Map<string, Set<string>> } = {
+    stored,
+    async restoreAuthoredTable(table, rows): Promise<RestoreTableResult> {
+      let set = stored.get(table);
+      if (!set) {
+        set = new Set<string>();
+        stored.set(table, set);
+      }
+      let inserted = 0;
+      let skipped = 0;
+      for (const row of rows) {
+        const key = JSON.stringify(row);
+        if (set.has(key)) skipped += 1;
+        else {
+          set.add(key);
+          inserted += 1;
+        }
+      }
+      return { table, inserted, skipped };
+    },
+  };
+  return sink;
+}
+
+function makePresence(missingAddresses: readonly string[] = []): ArchivePresenceChecker & { queried: string[] } {
+  const missing = new Set(missingAddresses);
+  const queried: string[] = [];
+  const p: ArchivePresenceChecker & { queried: string[] } = {
+    queried,
+    async hasArtifact(address) {
+      queried.push(address);
+      return !missing.has(address);
+    },
+  };
+  return p;
+}
+
+describe("store export op", () => {
+  it("(enumerate) exports exactly the 11 authored keys with correct manualOnly flags and no source/derived tables", async () => {
+    const data = populated();
+    const { source, calls } = makeSource(data);
+    const crypto = new FakeCrypto();
+    const result = await buildExport(
+      { source, manifest: makeManifest(data), crypto, codec },
+      {},
+    );
+    const document = (await decodeContainer(result.container, { codec, crypto }, {})) as {
+      store: { authored: Record<string, unknown[]> };
+    };
+    const keys = Object.keys(document.store.authored).sort();
+    const expected = [...PURE_AUTHORED_TABLES, ...MIXED_AUTHORED_TABLES].sort();
+    expect(keys).toEqual(expected);
+    for (const k of keys) expect(Array.isArray(document.store.authored[k])).toBe(true);
+    for (const t of PURE_AUTHORED_TABLES) {
+      expect(calls.find((c) => c.table === t)?.manualOnly).toBe(false);
+    }
+    for (const t of MIXED_AUTHORED_TABLES) {
+      expect(calls.find((c) => c.table === t)?.manualOnly).toBe(true);
+    }
+    for (const forbidden of ["workout", "session", "stream", "raw_file", "source_record", "metric_snapshot", "lap", "swim_length", "mean_max_cache"]) {
+      expect(keys).not.toContain(forbidden);
+    }
+  });
+
+  it("(roundtrip-plain) plaintext round-trip restores all 11 tables", async () => {
+    const data = populated();
+    const { source } = makeSource(data);
+    const crypto = new FakeCrypto();
+    const built = await buildExport({ source, manifest: makeManifest(data), crypto, codec }, {});
+    expect(built.warning).toBe(EXPORT_WARNING);
+    expect(built.encrypted).toBe(false);
+    expect(built.container[9]).toBe(0x00);
+    const sink = makeSink();
+    const imported = await importExport(
+      { sink, presence: makePresence(), crypto, codec, targetUserVersion: 5 },
+      { container: built.container },
+    );
+    expect(imported.restored).toHaveLength(11);
+    for (const t of PURE_AUTHORED_TABLES) {
+      expect(imported.restored.find((r) => r.table === t)?.inserted).toBe(2);
+    }
+    for (const t of MIXED_AUTHORED_TABLES) {
+      expect(imported.restored.find((r) => r.table === t)?.inserted).toBe(1);
+    }
+    expect(imported.manifest.total).toBe(data.artifacts.length);
+  });
+
+  it("(roundtrip-pass) passphrase container header + round-trip", async () => {
+    const data = populated();
+    const { source } = makeSource(data);
+    const crypto = new FakeCrypto();
+    const built = await buildExport(
+      { source, manifest: makeManifest(data), crypto, codec },
+      { passphrase: "correct horse" },
+    );
+    expect(built.encrypted).toBe(true);
+    expect(built.container[9]).toBe(0x01);
+    expect([...built.container.subarray(0, 8)]).toEqual([...CONTAINER_MAGIC]);
+    const iterations = new DataView(
+      built.container.buffer,
+      built.container.byteOffset,
+    ).getUint32(11, false);
+    expect(iterations).toBe(PBKDF2_ITERATIONS);
+    expect(built.container[15]).toBe(16);
+    expect(built.container[33]).toBe(12);
+    const sink = makeSink();
+    const imported = await importExport(
+      { sink, presence: makePresence(), crypto, codec, targetUserVersion: 5 },
+      { container: built.container, passphrase: "correct horse" },
+    );
+    expect(imported.restored).toHaveLength(11);
+  });
+
+  it("(missing-passphrase) encrypted container with no passphrase rejects", async () => {
+    const data = populated();
+    const { source } = makeSource(data);
+    const crypto = new FakeCrypto();
+    const built = await buildExport(
+      { source, manifest: makeManifest(data), crypto, codec },
+      { passphrase: "pw" },
+    );
+    const sink = makeSink();
+    await expect(
+      importExport(
+        { sink, presence: makePresence(), crypto, codec, targetUserVersion: 5 },
+        { container: built.container },
+      ),
+    ).rejects.toBeInstanceOf(ExportPassphraseRequiredError);
+  });
+
+  it("(bad-magic) wrong magic rejects with ExportFormatError", async () => {
+    const bytes = new Uint8Array(20);
+    bytes.set([1, 2, 3, 4, 5, 6, 7, 8], 0);
+    bytes[8] = 1;
+    bytes[9] = 0;
+    const crypto = new FakeCrypto();
+    await expect(decodeContainer(bytes, { codec, crypto }, {})).rejects.toBeInstanceOf(ExportFormatError);
+  });
+
+  it("(bad-version) byte 8 = 0x02 rejects with a version-2 message", async () => {
+    const crypto = new FakeCrypto();
+    const good = await encodeContainer({ kind: "x" }, { codec, crypto }, {});
+    const bad = good.slice();
+    bad[8] = 0x02;
+    await expect(decodeContainer(bad, { codec, crypto }, {})).rejects.toThrow(/2/);
+    await expect(decodeContainer(bad, { codec, crypto }, {})).rejects.toBeInstanceOf(ExportFormatError);
+  });
+
+  it("(corrupt-json) plaintext non-JSON payload rejects", async () => {
+    const crypto = new FakeCrypto();
+    const container = new Uint8Array([...CONTAINER_MAGIC, 0x01, 0x00, ...codec.encodeUtf8("{not json")]);
+    await expect(decodeContainer(container, { codec, crypto }, {})).rejects.toBeInstanceOf(ExportFormatError);
+  });
+
+  it("(schema-mismatch) newer store version refused; equal and older accepted", async () => {
+    const crypto = new FakeCrypto();
+    const build = async (userVersion: number) => {
+      const data = populated(userVersion);
+      const { source } = makeSource(data);
+      return buildExport({ source, manifest: makeManifest(data), crypto, codec }, {});
+    };
+    const newer = await build(6);
+    await expect(
+      importExport(
+        { sink: makeSink(), presence: makePresence(), crypto, codec, targetUserVersion: 5 },
+        { container: newer.container },
+      ),
+    ).rejects.toBeInstanceOf(ExportSchemaMismatchError);
+    for (const v of [5, 4]) {
+      const built = await build(v);
+      const imported = await importExport(
+        { sink: makeSink(), presence: makePresence(), crypto, codec, targetUserVersion: 5 },
+        { container: built.container },
+      );
+      expect(imported.restored).toHaveLength(11);
+    }
+  });
+
+  it("(idempotent) second import inserts zero and skips every row", async () => {
+    const data = populated();
+    const { source } = makeSource(data);
+    const crypto = new FakeCrypto();
+    const built = await buildExport({ source, manifest: makeManifest(data), crypto, codec }, {});
+    const sink = makeSink();
+    await importExport(
+      { sink, presence: makePresence(), crypto, codec, targetUserVersion: 5 },
+      { container: built.container },
+    );
+    const second = await importExport(
+      { sink, presence: makePresence(), crypto, codec, targetUserVersion: 5 },
+      { container: built.container },
+    );
+    for (const r of second.restored) {
+      expect(r.inserted).toBe(0);
+      expect(r.skipped).toBeGreaterThan(0);
+    }
+  });
+
+  it("(manifest-report) missing artifacts are reported, never fabricated", async () => {
+    const data = populated();
+    const { source } = makeSource(data);
+    const crypto = new FakeCrypto();
+    const built = await buildExport({ source, manifest: makeManifest(data), crypto, codec }, {});
+    const presence = makePresence(["aa", "bb"]);
+    const imported = await importExport(
+      { sink: makeSink(), presence, crypto, codec, targetUserVersion: 5 },
+      { container: built.container },
+    );
+    expect(imported.manifest.total).toBe(3);
+    expect(imported.manifest.missing.map((a) => a.address).sort()).toEqual(["aa", "bb"]);
+    expect(imported.manifest.present + imported.manifest.missing.length).toBe(imported.manifest.total);
+  });
+
+  it("(wrong-pass-fake) a different passphrase maps to ExportDecryptionError", async () => {
+    const data = populated();
+    const { source } = makeSource(data);
+    const crypto = new FakeCrypto();
+    const built = await buildExport(
+      { source, manifest: makeManifest(data), crypto, codec },
+      { passphrase: "right" },
+    );
+    await expect(
+      importExport(
+        { sink: makeSink(), presence: makePresence(), crypto, codec, targetUserVersion: 5 },
+        { container: built.container, passphrase: "wrong" },
+      ),
+    ).rejects.toBeInstanceOf(ExportDecryptionError);
+  });
+});

--- a/packages/kernel/tsup.config.ts
+++ b/packages/kernel/tsup.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     "store/migrations": "src/store/migrations/index.ts",
     store: "src/store/index.ts",
     "archive/index": "src/archive/index.ts",
+    "store/export/index": "src/store/export/index.ts",
   },
   loader: { ".sql": "text" },
   format: ["esm"],


### PR DESCRIPTION
Adds export/import as a pure kernel op plus its host-side crypto driver, so an athlete can move their entire local-first store to a single portable file and load it back.

## What changed

- **Pure op (`@enduragent/kernel/store/export`).** A new `store/export` subpath builds and parses a versioned single-file container holding all authored-class data together with a raw-archive manifest. The byte layout is pinned: an `ENDRXPRT` magic, a format-version byte, and a mode byte selecting either a plaintext body or a PBKDF2/AES-256-GCM passphrase-encrypted body, with the fixed-size header bound as additional authenticated data so it cannot be tampered with independently of the ciphertext.
- **Passphrase and plaintext modes.** With a passphrase, the body is key-derived and encrypted; without one, the body ships as plaintext. Both carry the same warning contract string so callers can surface a consistent "this file contains your full health and chat history" notice before writing it to disk.
- **Idempotent import.** Re-importing the same container is a no-op by primary key rather than a duplicate insert. Import refuses a container whose schema is newer than the running app, and it verifies the raw-archive manifest against what is actually present instead of fabricating missing entries — a container that references archive artifacts the host cannot produce is reported as incomplete, never silently patched.
- **Host driver (`@enduragent/kernel-node/store-export`).** A real WebCrypto-backed implementation of the crypto capability the op depends on, injected at the host edge so the compute kernel stays free of platform APIs.
- **Tests.** Round-trip coverage for both modes (build then parse yields the original rows), header-as-AAD tamper rejection, wrong-passphrase rejection, newer-schema import refusal, manifest-verification behavior, and import idempotence. The host package adds its own driver tests exercising the WebCrypto path end-to-end.

No shipping binary imports either package yet, so this is leaf work: package manifests and bundler entries gain the new subpaths only. No changeset — both packages are private and nothing here is user-visible.

## Test plan

- `pnpm build` — both packages emit the new `store/export` and `store-export` entries.
- `pnpm vitest run packages/kernel/tests/store-export.test.ts`
- `pnpm vitest run packages/kernel-node/tests/store-export.test.ts`
- `pnpm check` — full gate chain (lints, typecheck, trademark, fixture-privacy, package-deps, kernel-discipline) green end-to-end.
- `pnpm test` — full suite.
- `pnpm s8a` — exit 0, zero diffs.
- `pnpm check-parity --all` — all pairs green, zero snapshot regeneration.

## Note for the operator

The container byte layout is a one-way door. Per the delivery discipline this PR is opened for a byte-level review and is intentionally left unmerged — please do not auto-merge; merge personally after the review brief passes.
