### PR TITLE
feat(kernel-node): athlete-home resolver and idempotent FTP-history anchor seeder

### DIFF
--- a/.changeset/athlete-home-seeder.md
+++ b/.changeset/athlete-home-seeder.md
@@ -1,0 +1,9 @@
+---
+"@enduragent/kernel-node": patch
+---
+
+Add the per-athlete store-home resolver (the one-athlete `store`/`archive`/`config`
+layout with an ENDURAGENT_HOME override) and an idempotent FTP-history seeder that
+maps legacy per-binary FTP history into cycling anchor rows, insert-if-absent by
+(sport, anchor type, effective date), and no-ops cleanly on the empty-on-real-install
+case.

--- a/packages/kernel-node/package.json
+++ b/packages/kernel-node/package.json
@@ -9,7 +9,8 @@
     "./sqlite": "./dist/sqlite.js",
     "./archive": "./dist/archive/index.js",
     "./lock": "./dist/lock/index.js",
-    "./store-export": "./dist/store-export/index.js"
+    "./store-export": "./dist/store-export/index.js",
+    "./home": "./dist/home/index.js"
   },
   "engines": {
     "node": ">=24"
@@ -20,7 +21,8 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@enduragent/kernel": "workspace:*"
+    "@enduragent/kernel": "workspace:*",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/node": "^25.6.0",

--- a/packages/kernel-node/src/home/anchor-seeder.ts
+++ b/packages/kernel-node/src/home/anchor-seeder.ts
@@ -1,0 +1,112 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { FtpHistoryJsonSchema, FtpHistoryPointSchema } from "./ftp-history-schema.js";
+
+export const LEGACY_DATA_SUBDIR = "data" as const;
+export const FTP_HISTORY_FILENAME = "ftp_history.json" as const;
+
+export interface AnchorSeedRow {
+  readonly sport: "cycling";
+  readonly anchorType: "ftp";
+  readonly value: number;
+  readonly unit: "W";
+  readonly validFrom: number;
+  readonly source: string;
+  readonly confidence: "manual" | "platform";
+  readonly provenance: "sync";
+}
+
+export interface AnchorSeederStore {
+  /**
+   * Insert one anchor_history row IFF no row already exists for the 3-column
+   * key (sport, anchor_type, valid_from). Returns true if inserted, false if a
+   * row with that key already existed. The implementation derives the row's
+   * content-addressed primary key and leaves the source-class stamp columns
+   * (device_id, hlc_physical_ms, hlc_counter, note) NULL. Idempotency is this
+   * method's contract, not a schema UNIQUE constraint.
+   */
+  insertAnchorIfAbsent(row: AnchorSeedRow): Promise<boolean>;
+}
+
+export type FtpSeedSource = "absent" | "empty" | "populated" | "unreadable";
+
+export interface FtpSeedReport {
+  readonly source: FtpSeedSource;
+  readonly entriesRead: number;
+  readonly inserted: number;
+  readonly deduped: number;
+  readonly skippedMalformed: number;
+}
+
+export function epochSecondsFromDate(dateStr: string): number | null {
+  const ms = Date.parse(dateStr);
+  return Number.isNaN(ms) ? null : Math.floor(ms / 1000);
+}
+
+export interface SeedFtpHistoryOptions {
+  /** The legacy per-binary home root (the caller resolves it via the legacy per-binary home resolver in core; the seeder resolves no legacy home itself). The file read is <legacyCoachHome>/data/ftp_history.json. */
+  readonly legacyCoachHome: string;
+  readonly store: AnchorSeederStore;
+  /** Optional single-line summary sink; called at most once. Defaults to a no-op. */
+  readonly log?: (line: string) => void;
+}
+
+export async function seedFtpHistory(opts: SeedFtpHistoryOptions): Promise<FtpSeedReport> {
+  const log = opts.log ?? (() => {});
+  const finish = (report: FtpSeedReport): FtpSeedReport => {
+    log(
+      `ftp-history seed: source=${report.source} read=${report.entriesRead} inserted=${report.inserted} deduped=${report.deduped} skipped=${report.skippedMalformed}`,
+    );
+    return report;
+  };
+
+  const filePath = join(opts.legacyCoachHome, LEGACY_DATA_SUBDIR, FTP_HISTORY_FILENAME);
+
+  if (!existsSync(filePath)) {
+    return finish({ source: "absent", entriesRead: 0, inserted: 0, deduped: 0, skippedMalformed: 0 });
+  }
+
+  let parsed;
+  try {
+    const raw = readFileSync(filePath, "utf8");
+    parsed = FtpHistoryJsonSchema.parse(JSON.parse(raw));
+  } catch {
+    return finish({ source: "unreadable", entriesRead: 0, inserted: 0, deduped: 0, skippedMalformed: 0 });
+  }
+
+  const entries = parsed.entries;
+  if (entries.length === 0) {
+    return finish({ source: "empty", entriesRead: 0, inserted: 0, deduped: 0, skippedMalformed: 0 });
+  }
+
+  let inserted = 0;
+  let deduped = 0;
+  let skippedMalformed = 0;
+
+  for (const entry of entries) {
+    const res = FtpHistoryPointSchema.safeParse(entry);
+    if (!res.success) {
+      skippedMalformed++;
+      continue;
+    }
+    const validFrom = epochSecondsFromDate(res.data.date);
+    if (validFrom === null) {
+      skippedMalformed++;
+      continue;
+    }
+    const row: AnchorSeedRow = {
+      sport: "cycling",
+      anchorType: "ftp",
+      value: res.data.ftp,
+      unit: "W",
+      validFrom,
+      source: res.data.source,
+      confidence: res.data.source === "test" ? "manual" : "platform",
+      provenance: "sync",
+    };
+    if (await opts.store.insertAnchorIfAbsent(row)) inserted++;
+    else deduped++;
+  }
+
+  return finish({ source: "populated", entriesRead: entries.length, inserted, deduped, skippedMalformed });
+}

--- a/packages/kernel-node/src/home/anchor-seeder.ts
+++ b/packages/kernel-node/src/home/anchor-seeder.ts
@@ -59,11 +59,18 @@ export async function seedFtpHistory(opts: SeedFtpHistoryOptions): Promise<FtpSe
     );
     return report;
   };
+  const zeroReport = (source: FtpSeedReport["source"]): FtpSeedReport => ({
+    source,
+    entriesRead: 0,
+    inserted: 0,
+    deduped: 0,
+    skippedMalformed: 0,
+  });
 
   const filePath = join(opts.legacyCoachHome, LEGACY_DATA_SUBDIR, FTP_HISTORY_FILENAME);
 
   if (!existsSync(filePath)) {
-    return finish({ source: "absent", entriesRead: 0, inserted: 0, deduped: 0, skippedMalformed: 0 });
+    return finish(zeroReport("absent"));
   }
 
   let parsed;
@@ -71,12 +78,12 @@ export async function seedFtpHistory(opts: SeedFtpHistoryOptions): Promise<FtpSe
     const raw = readFileSync(filePath, "utf8");
     parsed = FtpHistoryJsonSchema.parse(JSON.parse(raw));
   } catch {
-    return finish({ source: "unreadable", entriesRead: 0, inserted: 0, deduped: 0, skippedMalformed: 0 });
+    return finish(zeroReport("unreadable"));
   }
 
   const entries = parsed.entries;
   if (entries.length === 0) {
-    return finish({ source: "empty", entriesRead: 0, inserted: 0, deduped: 0, skippedMalformed: 0 });
+    return finish(zeroReport("empty"));
   }
 
   let inserted = 0;

--- a/packages/kernel-node/src/home/ftp-history-schema.ts
+++ b/packages/kernel-node/src/home/ftp-history-schema.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+
+export const FTP_HISTORY_SCHEMA_VERSION = "1";
+
+export const FtpHistoryJsonSchema = z
+  .object({
+    metadata: z
+      .object({
+        schema_version: z.string(),
+        last_updated: z.string(),
+      })
+      .strict(),
+    entries: z.array(z.unknown()),
+  })
+  .strict();
+
+export const FtpHistoryPointSchema = z.looseObject({
+  date: z.string(),
+  ftp: z.number().int().positive(),
+  source: z.enum(["test", "estimate"]),
+});
+
+export type FtpHistoryJson = z.infer<typeof FtpHistoryJsonSchema>;
+export type FtpHistoryPoint = z.infer<typeof FtpHistoryPointSchema>;

--- a/packages/kernel-node/src/home/index.ts
+++ b/packages/kernel-node/src/home/index.ts
@@ -1,0 +1,27 @@
+export {
+  ATHLETE_HOME_ENV,
+  expandTilde,
+  resolveAthleteHome,
+} from "./resolve-athlete-home.js";
+export type { AthleteHome } from "./resolve-athlete-home.js";
+
+export {
+  FTP_HISTORY_SCHEMA_VERSION,
+  FtpHistoryJsonSchema,
+  FtpHistoryPointSchema,
+} from "./ftp-history-schema.js";
+export type { FtpHistoryJson, FtpHistoryPoint } from "./ftp-history-schema.js";
+
+export {
+  LEGACY_DATA_SUBDIR,
+  FTP_HISTORY_FILENAME,
+  epochSecondsFromDate,
+  seedFtpHistory,
+} from "./anchor-seeder.js";
+export type {
+  AnchorSeedRow,
+  AnchorSeederStore,
+  FtpSeedSource,
+  FtpSeedReport,
+  SeedFtpHistoryOptions,
+} from "./anchor-seeder.js";

--- a/packages/kernel-node/src/home/resolve-athlete-home.ts
+++ b/packages/kernel-node/src/home/resolve-athlete-home.ts
@@ -1,0 +1,37 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export const ATHLETE_HOME_ENV = "ENDURAGENT_HOME" as const;
+
+export interface AthleteHome {
+  /** The athlete home root: `~/.enduragent` by default, or the ENDURAGENT_HOME override. */
+  readonly root: string;
+  /** App-private, never file-synced. Holds the live derived SQLite DB. */
+  readonly storeDir: string;
+  /** Sync-safe (iCloud/Syncthing) — content-addressed immutable inputs only. */
+  readonly archiveDir: string;
+  /** App-private, never file-synced. Holds the single-writer lockfile + port file + bearer token. */
+  readonly configDir: string;
+}
+
+export function expandTilde(p: string): string {
+  if (p === "~") return homedir();
+  if (p.startsWith("~/")) return join(homedir(), p.slice(2));
+  return p;
+}
+
+export function resolveAthleteHome(
+  env: Record<string, string | undefined> = process.env,
+): AthleteHome {
+  const override = env[ATHLETE_HOME_ENV];
+  const root =
+    override !== undefined && override.length > 0
+      ? expandTilde(override)
+      : join(homedir(), ".enduragent");
+  return {
+    root,
+    storeDir: join(root, "store"),
+    archiveDir: join(root, "archive"),
+    configDir: join(root, "config"),
+  };
+}

--- a/packages/kernel-node/tests/anchor-seeder.test.ts
+++ b/packages/kernel-node/tests/anchor-seeder.test.ts
@@ -37,16 +37,14 @@ describe("seedFtpHistory", () => {
     rmSync(home, { recursive: true, force: true });
   });
 
-  function writeHistory(contents: unknown): void {
-    const dataDir = join(home, "data");
-    mkdirSync(dataDir, { recursive: true });
-    writeFileSync(join(dataDir, "ftp_history.json"), JSON.stringify(contents), "utf8");
-  }
-
   function writeRaw(raw: string): void {
     const dataDir = join(home, "data");
     mkdirSync(dataDir, { recursive: true });
     writeFileSync(join(dataDir, "ftp_history.json"), raw, "utf8");
+  }
+
+  function writeHistory(contents: unknown): void {
+    writeRaw(JSON.stringify(contents));
   }
 
   it("(absent) no file → no-op", async () => {

--- a/packages/kernel-node/tests/anchor-seeder.test.ts
+++ b/packages/kernel-node/tests/anchor-seeder.test.ts
@@ -1,0 +1,225 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  type AnchorSeedRow,
+  type AnchorSeederStore,
+  epochSecondsFromDate,
+  seedFtpHistory,
+} from "../src/home/anchor-seeder.js";
+
+function makeFakeAnchorStore() {
+  const seen = new Set<string>();
+  const rows: AnchorSeedRow[] = [];
+  const store: AnchorSeederStore = {
+    async insertAnchorIfAbsent(row) {
+      const key = `${row.sport}|${row.anchorType}|${row.validFrom}`;
+      if (seen.has(key)) return false;
+      seen.add(key);
+      rows.push(row);
+      return true;
+    },
+  };
+  return { store, rows };
+}
+
+const VALID_METADATA = { schema_version: "1", last_updated: "2021-01-01T00:00:00Z" };
+
+describe("seedFtpHistory", () => {
+  let home: string;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "legacy-coach-home-"));
+  });
+
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  function writeHistory(contents: unknown): void {
+    const dataDir = join(home, "data");
+    mkdirSync(dataDir, { recursive: true });
+    writeFileSync(join(dataDir, "ftp_history.json"), JSON.stringify(contents), "utf8");
+  }
+
+  function writeRaw(raw: string): void {
+    const dataDir = join(home, "data");
+    mkdirSync(dataDir, { recursive: true });
+    writeFileSync(join(dataDir, "ftp_history.json"), raw, "utf8");
+  }
+
+  it("(absent) no file → no-op", async () => {
+    const { store, rows } = makeFakeAnchorStore();
+    const report = await seedFtpHistory({ legacyCoachHome: home, store });
+    expect(report).toEqual({
+      source: "absent",
+      entriesRead: 0,
+      inserted: 0,
+      deduped: 0,
+      skippedMalformed: 0,
+    });
+    expect(rows).toHaveLength(0);
+  });
+
+  it("(empty) real-install case → clean no-op", async () => {
+    writeHistory({ metadata: VALID_METADATA, entries: [] });
+    const { store, rows } = makeFakeAnchorStore();
+    const report = await seedFtpHistory({ legacyCoachHome: home, store });
+    expect(report).toEqual({
+      source: "empty",
+      entriesRead: 0,
+      inserted: 0,
+      deduped: 0,
+      skippedMalformed: 0,
+    });
+    expect(rows).toHaveLength(0);
+  });
+
+  it("(populated) fixture-driven happy path", async () => {
+    writeHistory({
+      metadata: VALID_METADATA,
+      entries: [
+        { date: "2021-03-15", ftp: 250, source: "estimate" },
+        { date: "2022-06-01", ftp: 265, source: "test" },
+      ],
+    });
+    const { store, rows } = makeFakeAnchorStore();
+    const report = await seedFtpHistory({ legacyCoachHome: home, store });
+    expect(report).toEqual({
+      source: "populated",
+      entriesRead: 2,
+      inserted: 2,
+      deduped: 0,
+      skippedMalformed: 0,
+    });
+    expect(rows[0]).toEqual({
+      sport: "cycling",
+      anchorType: "ftp",
+      value: 250,
+      unit: "W",
+      validFrom: 1615766400,
+      source: "estimate",
+      confidence: "platform",
+      provenance: "sync",
+    });
+    expect(rows[1]).toEqual({
+      sport: "cycling",
+      anchorType: "ftp",
+      value: 265,
+      unit: "W",
+      validFrom: epochSecondsFromDate("2022-06-01"),
+      source: "test",
+      confidence: "manual",
+      provenance: "sync",
+    });
+  });
+
+  it("(idempotent) run twice → zero duplicates", async () => {
+    writeHistory({
+      metadata: VALID_METADATA,
+      entries: [
+        { date: "2021-03-15", ftp: 250, source: "estimate" },
+        { date: "2022-06-01", ftp: 265, source: "test" },
+      ],
+    });
+    const { store, rows } = makeFakeAnchorStore();
+    const first = await seedFtpHistory({ legacyCoachHome: home, store });
+    expect(first.inserted).toBe(2);
+    const second = await seedFtpHistory({ legacyCoachHome: home, store });
+    expect(second).toEqual({
+      source: "populated",
+      entriesRead: 2,
+      inserted: 0,
+      deduped: 2,
+      skippedMalformed: 0,
+    });
+    expect(rows).toHaveLength(2);
+  });
+
+  it("(malformed) skip + report", async () => {
+    writeHistory({
+      metadata: VALID_METADATA,
+      entries: [
+        { date: "2021-03-15", ftp: 250, source: "estimate" },
+        { date: "2021-04-01", source: "test" },
+        { date: "2021-05-01", ftp: -1, source: "test" },
+        { date: "2021-06-01", ftp: 3.5, source: "test" },
+        { date: "2021-07-01", ftp: 200, source: "guess" },
+        { date: 12345, ftp: 200, source: "test" },
+      ],
+    });
+    const { store, rows } = makeFakeAnchorStore();
+    const report = await seedFtpHistory({ legacyCoachHome: home, store });
+    expect(report.inserted).toBe(1);
+    expect(report.skippedMalformed).toBe(5);
+    expect(report.deduped).toBe(0);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.value).toBe(250);
+  });
+
+  it("(epoch) date → UTC epoch seconds + unparseable date skipped", async () => {
+    expect(epochSecondsFromDate("2021-03-15")).toBe(1615766400);
+    expect(epochSecondsFromDate("not-a-date")).toBeNull();
+    writeHistory({
+      metadata: VALID_METADATA,
+      entries: [
+        { date: "2021-03-15", ftp: 250, source: "estimate" },
+        { date: "not-a-date", ftp: 260, source: "test" },
+      ],
+    });
+    const { store, rows } = makeFakeAnchorStore();
+    const report = await seedFtpHistory({ legacyCoachHome: home, store });
+    expect(report.inserted).toBe(1);
+    expect(report.skippedMalformed).toBe(1);
+    expect(rows[0]?.validFrom).toBe(1615766400);
+  });
+
+  it("(confidence) source → tier mapping", async () => {
+    writeHistory({
+      metadata: VALID_METADATA,
+      entries: [
+        { date: "2021-03-15", ftp: 250, source: "estimate" },
+        { date: "2022-06-01", ftp: 265, source: "test" },
+      ],
+    });
+    const { store, rows } = makeFakeAnchorStore();
+    await seedFtpHistory({ legacyCoachHome: home, store });
+    const estimateRow = rows.find((r) => r.source === "estimate");
+    const testRow = rows.find((r) => r.source === "test");
+    expect(estimateRow?.confidence).toBe("platform");
+    expect(testRow?.confidence).toBe("manual");
+  });
+
+  it("(unreadable) corrupt file → no-op, no throw", async () => {
+    writeRaw("{ not valid json");
+    const first = makeFakeAnchorStore();
+    const r1 = await seedFtpHistory({ legacyCoachHome: home, store: first.store });
+    expect(r1).toEqual({
+      source: "unreadable",
+      entriesRead: 0,
+      inserted: 0,
+      deduped: 0,
+      skippedMalformed: 0,
+    });
+    expect(first.rows).toHaveLength(0);
+
+    writeHistory({ entries: [] });
+    const second = makeFakeAnchorStore();
+    const r2 = await seedFtpHistory({ legacyCoachHome: home, store: second.store });
+    expect(r2.source).toBe("unreadable");
+    expect(second.rows).toHaveLength(0);
+  });
+
+  it("(log-once) the summary sink is called at most once", async () => {
+    writeHistory({
+      metadata: VALID_METADATA,
+      entries: [{ date: "2021-03-15", ftp: 250, source: "estimate" }],
+    });
+    const { store } = makeFakeAnchorStore();
+    const lines: string[] = [];
+    await seedFtpHistory({ legacyCoachHome: home, store, log: (line) => lines.push(line) });
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain("source=populated");
+  });
+});

--- a/packages/kernel-node/tests/resolve-athlete-home.test.ts
+++ b/packages/kernel-node/tests/resolve-athlete-home.test.ts
@@ -1,0 +1,62 @@
+import { existsSync, mkdtempSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { basename, dirname, join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  expandTilde,
+  resolveAthleteHome,
+} from "../src/home/resolve-athlete-home.js";
+
+describe("resolveAthleteHome", () => {
+  it("default (no env) → ~/.enduragent with store/archive/config children", () => {
+    const home = resolveAthleteHome({});
+    expect(basename(home.root)).toBe(".enduragent");
+    expect(dirname(home.root)).toBe(homedir());
+    expect(home.storeDir).toBe(join(home.root, "store"));
+    expect(home.archiveDir).toBe(join(home.root, "archive"));
+    expect(home.configDir).toBe(join(home.root, "config"));
+  });
+
+  it("absolute override", () => {
+    const home = resolveAthleteHome({ ENDURAGENT_HOME: "/tmp/custom-home" });
+    expect(home.root).toBe("/tmp/custom-home");
+    expect(home.storeDir).toBe(join("/tmp/custom-home", "store"));
+    expect(home.archiveDir).toBe(join("/tmp/custom-home", "archive"));
+    expect(home.configDir).toBe(join("/tmp/custom-home", "config"));
+  });
+
+  it("tilde override", () => {
+    const home = resolveAthleteHome({ ENDURAGENT_HOME: "~/myhome" });
+    expect(home.root).toBe(join(homedir(), "myhome"));
+  });
+
+  it("empty-string override ignored → default root", () => {
+    const home = resolveAthleteHome({ ENDURAGENT_HOME: "" });
+    expect(home.root).toBe(join(homedir(), ".enduragent"));
+  });
+
+  it("no per-binary subdir / not binary-keyed", () => {
+    expect(resolveAthleteHome.length).toBe(0);
+    const home = resolveAthleteHome({});
+    expect(home.root).not.toBe(join(homedir(), ".enduragent", "cycling"));
+    expect(dirname(home.storeDir)).toBe(home.root);
+    expect(dirname(home.archiveDir)).toBe(home.root);
+    expect(dirname(home.configDir)).toBe(home.root);
+  });
+
+  it("pure, no mkdir — resolver creates nothing", () => {
+    const base = mkdtempSync(join(tmpdir(), "athlete-home-"));
+    const absent = join(base, "definitely-absent");
+    const home = resolveAthleteHome({ ENDURAGENT_HOME: absent });
+    expect(home.root).toBe(absent);
+    expect(existsSync(home.storeDir)).toBe(false);
+    expect(existsSync(home.archiveDir)).toBe(false);
+    expect(existsSync(home.configDir)).toBe(false);
+  });
+
+  it("expandTilde units", () => {
+    expect(expandTilde("~")).toBe(homedir());
+    expect(expandTilde("~/x")).toBe(join(homedir(), "x"));
+    expect(expandTilde("/abs")).toBe("/abs");
+  });
+});

--- a/packages/kernel-node/tsup.config.ts
+++ b/packages/kernel-node/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: { index: "src/index.ts", sqlite: "src/sqlite/index.ts", "archive/index": "src/archive/index.ts", "lock/index": "src/lock/index.ts", "store-export/index": "src/store-export/index.ts" },
+  entry: { index: "src/index.ts", sqlite: "src/sqlite/index.ts", "archive/index": "src/archive/index.ts", "lock/index": "src/lock/index.ts", "store-export/index": "src/store-export/index.ts", "home/index": "src/home/index.ts" },
   format: ["esm"],
   dts: true,
   sourcemap: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -234,6 +234,9 @@ importers:
       '@enduragent/kernel':
         specifier: workspace:*
         version: link:../kernel
+      zod:
+        specifier: ^4.3.6
+        version: 4.4.1
     devDependencies:
       '@types/node':
         specifier: ^25.6.0


### PR DESCRIPTION
## Summary

Adds a per-athlete home resolver and an idempotent FTP-history anchor seeder to the `@enduragent/kernel-node` package, under a new `./home` subpath export.

### Surfaces

- **`resolve-athlete-home.ts`** — a pure `resolveAthleteHome()` that returns the athlete's `AthleteHome` (`{ root, storeDir, archiveDir, configDir }`) rooted at `~/.enduragent/{store,archive,config}`, honoring the `ENDURAGENT_HOME` environment override. The resolver is per-athlete (no per-binary subdirectory), side-effect-free (no directory creation, no filesystem probing), and re-implements tilde expansion locally so it pulls in no compute-kernel code.

- **`ftp-history-schema.ts`** — locally declared zod schemas for the legacy per-binary `ftp_history.json` envelope and its point entries (`date`, positive-integer `ftp`, `source`), kept self-contained rather than imported from another package.

- **`anchor-seeder.ts`** — an idempotent `seedFtpHistory()` that reads the legacy `ftp_history.json`, maps each valid point to a cycling anchor-history content row, and inserts insert-if-absent on `(sport, anchor_type, valid_from)` through a narrow injected store capability. Absent, unreadable, empty, and malformed-entry inputs are all non-fatal and surfaced in a small report; a fresh install (no legacy file) no-ops cleanly and seeds nothing. Emits a single summary log line.

- **`index.ts`** — the `./home` subpath barrel re-exporting the three modules.

- **`package.json` / `tsup.config.ts`** — wire the `./home` export (preserving the existing subpaths), add the `zod` dependency, and append the new build entry. `pnpm-lock.yaml` regenerated for the added dependency.

## Test plan

- `pnpm build` — the new `dist/home/index.js` and `dist/home/index.d.ts` are emitted.
- `pnpm vitest run packages/kernel-node/tests/resolve-athlete-home.test.ts packages/kernel-node/tests/anchor-seeder.test.ts` — resolver cases (override, default, tilde) and seeder cases (absent / empty / populated / idempotent / malformed / epoch / confidence / unreadable / log-once) pass.
- `pnpm test` — full package suite green.
- `pnpm check` — end-to-end gates green (trademark, fixture-privacy, registry-isolation, changeset), the new `home/` subtree governed with no violation.
- `pnpm check-parity --all` — all pairs green, zero snapshot regeneration.
- `pnpm s8a` and `pnpm s8a --self-test` — exit 0, zero diffs.
