### PR TITLE
refactor(kernel-node): consolidate the writer-lock's atomic temp-write ceremony

### DIFF
--- a/packages/kernel-node/src/lock/acquire.ts
+++ b/packages/kernel-node/src/lock/acquire.ts
@@ -70,27 +70,26 @@ async function bestEffortUnlink(path: string): Promise<void> {
   }
 }
 
-function contentionAgainstBound(
+async function contentionAgainstBound(
   bodyPid: number | undefined,
   boundPort: number,
   portFilePath: string,
   probe: HealthzProbe,
-): Promise<PeerHealthyOutcome | never> {
-  return probe(boundPort).then((verdict) => {
-    if (verdict.kind === "healthy") {
-      return { status: "peer-healthy", port: boundPort, peerVersion: verdict.version };
-    }
-    if (verdict.kind === "unresponsive") {
-      throw new WriteLockContentionError(
-        `Another writer already holds this store (pid ${bodyPid ?? "unknown"}); stop that process or wait, then retry.`,
-        3,
-      );
-    }
+): Promise<PeerHealthyOutcome> {
+  const verdict = await probe(boundPort);
+  if (verdict.kind === "healthy") {
+    return { status: "peer-healthy", port: boundPort, peerVersion: verdict.version };
+  }
+  if (verdict.kind === "unresponsive") {
     throw new WriteLockContentionError(
-      `127.0.0.1:${boundPort} is held by a foreign process; change or remove the port file at ${portFilePath} and retry.`,
+      `Another writer already holds this store (pid ${bodyPid ?? "unknown"}); stop that process or wait, then retry.`,
       3,
     );
-  });
+  }
+  throw new WriteLockContentionError(
+    `127.0.0.1:${boundPort} is held by a foreign process; change or remove the port file at ${portFilePath} and retry.`,
+    3,
+  );
 }
 
 export async function acquireWriteLock(opts: AcquireWriteLockOptions): Promise<AcquireWriteLockResult> {

--- a/packages/kernel-node/src/lock/lockfile-body.ts
+++ b/packages/kernel-node/src/lock/lockfile-body.ts
@@ -1,6 +1,6 @@
-import { link, open, unlink } from "node:fs/promises";
+import { link } from "node:fs/promises";
 import { readFileSync } from "node:fs";
-import { randomBytes } from "node:crypto";
+import { writeTempThenPublish } from "./write-temp.js";
 
 export interface LockfileBody {
   readonly pid: number;
@@ -16,31 +16,9 @@ export interface LockfileBody {
 // unlinked and a fresh claim published.
 export async function claimLockfile(lockfilePath: string, body: LockfileBody): Promise<void> {
   const serialized = JSON.stringify(body, null, 2) + "\n";
-  const suffix = randomBytes(4).toString("hex");
-  const tempPath = `${lockfilePath}.tmp.${suffix}`;
-
-  let fh: Awaited<ReturnType<typeof open>> | null = null;
-  try {
-    fh = await open(tempPath, "w", 0o600);
-    await fh.writeFile(serialized, "utf-8");
-    await fh.sync();
-    await fh.close();
-    fh = null;
-    await link(tempPath, lockfilePath);
-  } finally {
-    if (fh !== null) {
-      try {
-        await fh.close();
-      } catch {
-        /* already in the error path */
-      }
-    }
-    try {
-      await unlink(tempPath);
-    } catch {
-      /* temp sibling may not exist */
-    }
-  }
+  await writeTempThenPublish(lockfilePath, serialized, (tempPath, targetPath) =>
+    link(tempPath, targetPath),
+  );
 }
 
 export function readLockfile(lockfilePath: string): LockfileBody | null {

--- a/packages/kernel-node/src/lock/port-file.ts
+++ b/packages/kernel-node/src/lock/port-file.ts
@@ -1,35 +1,11 @@
-import { open, rename, unlink } from "node:fs/promises";
+import { rename } from "node:fs/promises";
 import { readFileSync } from "node:fs";
-import { randomBytes } from "node:crypto";
+import { writeTempThenPublish } from "./write-temp.js";
 
 export async function writePortFile(portFilePath: string, port: number): Promise<void> {
-  const serialized = `${port}\n`;
-  const suffix = randomBytes(4).toString("hex");
-  const tempPath = `${portFilePath}.tmp.${suffix}`;
-
-  let fh: Awaited<ReturnType<typeof open>> | null = null;
-  try {
-    fh = await open(tempPath, "w", 0o600);
-    await fh.writeFile(serialized, "utf-8");
-    await fh.sync();
-    await fh.close();
-    fh = null;
-    await rename(tempPath, portFilePath);
-  } catch (err) {
-    if (fh !== null) {
-      try {
-        await fh.close();
-      } catch {
-        /* already in the error path */
-      }
-    }
-    try {
-      await unlink(tempPath);
-    } catch {
-      /* temp sibling may not exist */
-    }
-    throw err;
-  }
+  await writeTempThenPublish(portFilePath, `${port}\n`, (tempPath, targetPath) =>
+    rename(tempPath, targetPath),
+  );
 }
 
 export function readPortFile(portFilePath: string): number | null {

--- a/packages/kernel-node/src/lock/write-temp.ts
+++ b/packages/kernel-node/src/lock/write-temp.ts
@@ -1,0 +1,34 @@
+import { open, unlink } from "node:fs/promises";
+import { randomBytes } from "node:crypto";
+
+export async function writeTempThenPublish(
+  targetPath: string,
+  contents: string,
+  publish: (tempPath: string, targetPath: string) => Promise<void>,
+): Promise<void> {
+  const suffix = randomBytes(4).toString("hex");
+  const tempPath = `${targetPath}.tmp.${suffix}`;
+
+  let fh: Awaited<ReturnType<typeof open>> | null = null;
+  try {
+    fh = await open(tempPath, "w", 0o600);
+    await fh.writeFile(contents, "utf-8");
+    await fh.sync();
+    await fh.close();
+    fh = null;
+    await publish(tempPath, targetPath);
+  } finally {
+    if (fh !== null) {
+      try {
+        await fh.close();
+      } catch {
+        /* already in the error path */
+      }
+    }
+    try {
+      await unlink(tempPath);
+    } catch {
+      /* consumed by rename or already gone */
+    }
+  }
+}


### PR DESCRIPTION
## Summary

The single-writer lock's two durable writes each carried a full copy of the temp-file ceremony (random-suffixed temp sibling, 0o600 open, write, fsync, close, publish, cleanup) — and the two copies had already diverged in cleanup shape. This folds the ceremony into one internal writeTempThenPublish primitive; the lockfile claim and the port file now inject only their genuinely different atomic publish verb (exclusive hardlink vs rename). The always-run temp unlink is a no-op on the rename path and the required cleanup on the link path.

Also rewrites the contention resolver from a .then() chain to async/await to match the rest of the module, and drops an inert `| never` return-type union.

No behavior change: arbitration semantics, error messages, byte contents, and cleanup guarantees are identical.

## Test plan

- `pnpm vitest run packages/kernel-node/tests/lock.test.ts` — 14/14, including the 25-iteration two-acquirer race loop, mid-fill live-claim protection, crash-artifact reclaim, corrupt-claim refusal, and temp-sibling hygiene assertions
- `pnpm build` + `pnpm check` green end-to-end