### PR TITLE
feat(core): calendar event provenance markers and delete guards

### DIFF
--- a/.changeset/calendar-provenance-delete-guard.md
+++ b/.changeset/calendar-provenance-delete-guard.md
@@ -1,0 +1,7 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Workouts the coach adds to your intervals.icu calendar are now marked as coach-created, and the coach will only delete its own scheduled workouts — races, notes, and workouts you added yourself are always refused.
+
+Calendar create tools in both sport packages stamp an `external_id` and `tags` provenance marker on every event they push. The list projection surfaces `category`, `externalId`, `tags`, and a derived `coachCreated` flag, plus an opt-in `coachCreatedOnly` filter. The delete tool now refuses non-WORKOUT events (`not_a_workout`) and marker-less events (`not_coach_created`) before the destructive delete call, ahead of the existing past-date guard.

--- a/packages/core/src/agent/event-provenance.ts
+++ b/packages/core/src/agent/event-provenance.ts
@@ -1,0 +1,25 @@
+export const COACH_EVENT_TAG = "cycling-coach";
+export const COACH_EXTERNAL_ID_PREFIX = `${COACH_EVENT_TAG}:`;
+
+function slugifyName(name: string): string {
+  const slug = name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 40)
+    .replace(/-+$/g, "");
+  return slug.length > 0 ? slug : "workout";
+}
+
+export function buildCoachExternalId(date: string, name: string): string {
+  return `${COACH_EXTERNAL_ID_PREFIX}${date}:${slugifyName(name)}`;
+}
+
+export function isCoachOwnedEvent(event: {
+  tags?: string[] | null;
+  externalId?: string | null;
+}): boolean {
+  if (event.tags?.includes(COACH_EVENT_TAG)) return true;
+  if (event.externalId?.startsWith(COACH_EXTERNAL_ID_PREFIX)) return true;
+  return false;
+}

--- a/packages/core/src/agent/intervals-tools.ts
+++ b/packages/core/src/agent/intervals-tools.ts
@@ -4,6 +4,7 @@ import type { ApiError, IntervalsClient } from "intervals-icu-api";
 import type { IntervalsActivityType } from "../sport.js";
 import { todayInTZ } from "./user-time.js";
 import { downsampleStreams } from "./stream-downsample.js";
+import { isCoachOwnedEvent } from "./event-provenance.js";
 
 function toTypedError(error: ApiError): { error: string; status?: number; message?: string } {
   return {
@@ -22,6 +23,9 @@ type IntervalsEventRuntime = {
   name?: string | null;
   movingTime?: number | null;
   icuTrainingLoad?: number | null;
+  category?: string | null;
+  tags?: string[] | null;
+  externalId?: string | null;
 };
 
 /**
@@ -127,8 +131,11 @@ export function createPureCoreIntervalsTools(
       description:
         "Delete a scheduled workout from the intervals.icu calendar by event ID. " +
         "ALWAYS call intervals_list_events first, show the athlete the list, and " +
-        "confirm which workout to delete before calling this. Past workouts (before " +
-        "today) are protected — the tool refuses without calling the server.",
+        "confirm which workout to delete before calling this. Only deletes workouts " +
+        "this coach created (provenance-marked). Races, notes, plans, athlete-added " +
+        "workouts, and pre-marker coach workouts are refused — tell the athlete to " +
+        "remove those directly on intervals.icu. Past workouts (before today) are " +
+        "protected — the tool refuses without calling the server.",
       inputSchema: zodSchema(
         z.object({
           eventId: z.number().int().describe("Event ID from intervals_list_events"),
@@ -138,6 +145,19 @@ export function createPureCoreIntervalsTools(
         const fetched = await intervals.events.get(input.eventId);
         if (!fetched.ok) return toTypedError(fetched.error);
         const event = fetched.value as unknown as IntervalsEventRuntime;
+        if (event.category !== "WORKOUT") {
+          return {
+            error: "not_a_workout",
+            details: `Event ${input.eventId} is category ${event.category ?? "unknown"}, not a scheduled workout. Races, notes, plans, and other calendar entries cannot be deleted by the coach.`,
+          };
+        }
+        if (!isCoachOwnedEvent(event)) {
+          return {
+            error: "not_coach_created",
+            details:
+              "This workout was not created by this coach (no provenance marker) — it may be athlete-added, from another app, or created before provenance markers shipped. It will not be deleted; the athlete can remove it directly on intervals.icu.",
+          };
+        }
         const today = todayInTZ(tz);
         const eventDate = event.startDateLocal.slice(0, 10);
         if (eventDate < today) {
@@ -192,27 +212,41 @@ export function createCoreToolsWithSportConfig(
       description:
         "List scheduled calendar workouts on intervals.icu for a date range. " +
         "Use this BEFORE deleting so you can show the athlete the list (id, date, name) " +
-        "and ask which one to delete. Filters to WORKOUT category only.",
+        "and ask which one to delete. Filters to WORKOUT category only. Each row carries " +
+        "a coachCreated flag; only coach-created workouts can be deleted with " +
+        "intervals_delete_workout. Pass coachCreatedOnly: true to return only " +
+        "coach-created events.",
       inputSchema: zodSchema(
         z.object({
           oldest: z.string().describe("Oldest date (YYYY-MM-DD)"),
           newest: z.string().optional().describe("Newest date (YYYY-MM-DD)"),
+          coachCreatedOnly: z
+            .boolean()
+            .optional()
+            .describe("Return only events created by this coach"),
         }),
       ),
-      execute: async (input: { oldest: string; newest?: string }) => {
+      execute: async (input: { oldest: string; newest?: string; coachCreatedOnly?: boolean }) => {
         const result = await intervals.events.list({
           oldest: input.oldest,
           newest: input.newest ?? undefined,
           category: ["WORKOUT"],
         });
         if (!result.ok) return toTypedError(result.error);
-        return (result.value as unknown as IntervalsEventRuntime[]).map((e) => ({
+        const projected = (result.value as unknown as IntervalsEventRuntime[]).map((e) => ({
           id: e.id,
           startDateLocal: e.startDateLocal,
           name: e.name,
           movingTime: e.movingTime,
           icuTrainingLoad: e.icuTrainingLoad,
+          category: e.category,
+          externalId: e.externalId,
+          tags: e.tags,
+          coachCreated: isCoachOwnedEvent(e),
         }));
+        return input.coachCreatedOnly === true
+          ? projected.filter((row) => row.coachCreated)
+          : projected;
       },
     }),
   };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -180,6 +180,12 @@ export {
   createCoreToolsWithSportConfig,
 } from "./agent/intervals-tools.js";
 export {
+  COACH_EVENT_TAG,
+  COACH_EXTERNAL_ID_PREFIX,
+  buildCoachExternalId,
+  isCoachOwnedEvent,
+} from "./agent/event-provenance.js";
+export {
   appendCurrentTimeLine,
   buildCurrentTimeLine,
   formatTimeInTZ,

--- a/packages/core/tests/intervals-tools-events.test.ts
+++ b/packages/core/tests/intervals-tools-events.test.ts
@@ -1,0 +1,278 @@
+import { describe, expect, it } from "vitest";
+import {
+  COACH_EVENT_TAG,
+  COACH_EXTERNAL_ID_PREFIX,
+  buildCoachExternalId,
+  isCoachOwnedEvent,
+} from "../src/agent/event-provenance.js";
+import {
+  createPureCoreIntervalsTools,
+  createCoreToolsWithSportConfig,
+} from "../src/agent/intervals-tools.js";
+import type { IntervalsClient } from "intervals-icu-api";
+
+type EventKnobs = {
+  id?: number;
+  startDateLocal?: string;
+  category?: string | null;
+  omitCategory?: boolean;
+  tags?: string[] | null;
+  externalId?: string | null;
+  name?: string | null;
+};
+
+function makeDeleteFake(event: EventKnobs): {
+  client: IntervalsClient;
+  deleteCalls: number[];
+} {
+  const deleteCalls: number[] = [];
+  const fake = {
+    events: {
+      get: async (id: number) => ({
+        ok: true,
+        value: {
+          id,
+          startDateLocal: event.startDateLocal ?? "2999-01-01T00:00:00",
+          ...(event.omitCategory
+            ? {}
+            : {
+                category:
+                  event.category === undefined ? "WORKOUT" : event.category,
+              }),
+          tags: event.tags,
+          externalId: event.externalId,
+          name: event.name,
+        },
+      }),
+      delete: async (id: number) => {
+        deleteCalls.push(id);
+        return { ok: true };
+      },
+    },
+  };
+  return { client: fake as unknown as IntervalsClient, deleteCalls };
+}
+
+function makeListFake(events: EventKnobs[]): IntervalsClient {
+  const fake = {
+    events: {
+      list: async () => ({
+        ok: true,
+        value: events.map((e, i) => ({
+          id: e.id ?? i + 1,
+          startDateLocal: e.startDateLocal ?? "2999-01-01T00:00:00",
+          name: e.name ?? null,
+          movingTime: 3600,
+          icuTrainingLoad: 50,
+          category: e.category === undefined ? "WORKOUT" : e.category,
+          tags: e.tags,
+          externalId: e.externalId,
+        })),
+      }),
+    },
+  };
+  return fake as unknown as IntervalsClient;
+}
+
+type DeleteResult = { deleted?: true; error?: string; details?: string };
+
+async function runDelete(event: EventKnobs, tz = "UTC") {
+  const { client, deleteCalls } = makeDeleteFake(event);
+  const tools = createPureCoreIntervalsTools(client, tz);
+  const result = (await tools.intervals_delete_workout!.execute!(
+    { eventId: event.id ?? 1 },
+    {} as never,
+  )) as DeleteResult;
+  return { result, deleteCalls };
+}
+
+describe("event provenance helpers", () => {
+  it("buildCoachExternalId formats prefix:date:slug", () => {
+    expect(buildCoachExternalId("2026-05-01", "Threshold 3x10")).toBe(
+      `${COACH_EXTERNAL_ID_PREFIX}2026-05-01:threshold-3x10`,
+    );
+  });
+
+  it("slugs unicode/emoji/whitespace names, caps at 40 chars, falls back to 'workout'", () => {
+    expect(buildCoachExternalId("2026-05-01", "  Café  Ride! 🚴 ")).toBe(
+      `${COACH_EXTERNAL_ID_PREFIX}2026-05-01:caf-ride`,
+    );
+    const long = "a".repeat(60);
+    const built = buildCoachExternalId("2026-05-01", long);
+    const slug = built.slice(`${COACH_EXTERNAL_ID_PREFIX}2026-05-01:`.length);
+    expect(slug.length).toBeLessThanOrEqual(40);
+    expect(buildCoachExternalId("2026-05-01", "🚴🚴🚴")).toBe(
+      `${COACH_EXTERNAL_ID_PREFIX}2026-05-01:workout`,
+    );
+    expect(buildCoachExternalId("2026-05-01", "")).toBe(
+      `${COACH_EXTERNAL_ID_PREFIX}2026-05-01:workout`,
+    );
+  });
+
+  it("isCoachOwnedEvent: coach tag alone matches", () => {
+    expect(isCoachOwnedEvent({ tags: [COACH_EVENT_TAG] })).toBe(true);
+  });
+
+  it("isCoachOwnedEvent: externalId prefix alone matches", () => {
+    expect(isCoachOwnedEvent({ externalId: `${COACH_EXTERNAL_ID_PREFIX}2026-05-01:x` })).toBe(true);
+  });
+
+  it("isCoachOwnedEvent: neither -> false; null/undefined tags and externalId -> false", () => {
+    expect(isCoachOwnedEvent({})).toBe(false);
+    expect(isCoachOwnedEvent({ tags: null, externalId: null })).toBe(false);
+    expect(isCoachOwnedEvent({ tags: [], externalId: undefined })).toBe(false);
+    expect(isCoachOwnedEvent({ tags: ["other"] })).toBe(false);
+  });
+
+  it("rejects near-miss forgeries: tag 'cycling-coach-pro', externalId 'evil-cycling-coach:...'", () => {
+    expect(isCoachOwnedEvent({ tags: ["cycling-coach-pro"] })).toBe(false);
+    expect(isCoachOwnedEvent({ externalId: "evil-cycling-coach:2026-05-01:x" })).toBe(false);
+  });
+});
+
+describe("intervals_delete_workout guards", () => {
+  it("refuses category RACE_A with not_a_workout; delete not called", async () => {
+    const { result, deleteCalls } = await runDelete({
+      category: "RACE_A",
+      tags: [COACH_EVENT_TAG],
+    });
+    expect(result.error).toBe("not_a_workout");
+    expect(deleteCalls).toEqual([]);
+  });
+
+  it("refuses category NOTE with not_a_workout; delete not called", async () => {
+    const { result, deleteCalls } = await runDelete({
+      category: "NOTE",
+      tags: [COACH_EVENT_TAG],
+    });
+    expect(result.error).toBe("not_a_workout");
+    expect(deleteCalls).toEqual([]);
+  });
+
+  it("refuses missing category (undefined) with not_a_workout", async () => {
+    const { result, deleteCalls } = await runDelete({
+      omitCategory: true,
+      tags: [COACH_EVENT_TAG],
+    });
+    expect(result.error).toBe("not_a_workout");
+    expect(deleteCalls).toEqual([]);
+  });
+
+  it("refuses null category with not_a_workout", async () => {
+    const { result, deleteCalls } = await runDelete({
+      category: null,
+      tags: [COACH_EVENT_TAG],
+    });
+    expect(result.error).toBe("not_a_workout");
+    expect(deleteCalls).toEqual([]);
+  });
+
+  it("refuses unmarked WORKOUT with not_coach_created; delete not called; details mention intervals.icu", async () => {
+    const { result, deleteCalls } = await runDelete({ category: "WORKOUT" });
+    expect(result.error).toBe("not_coach_created");
+    expect(result.details).toContain("intervals.icu");
+    expect(deleteCalls).toEqual([]);
+  });
+
+  it("deletes a future WORKOUT with coach tag only", async () => {
+    const { result, deleteCalls } = await runDelete({
+      id: 55,
+      category: "WORKOUT",
+      tags: [COACH_EVENT_TAG],
+      startDateLocal: "2999-01-01T00:00:00",
+    });
+    expect(result.deleted).toBe(true);
+    expect(deleteCalls).toEqual([55]);
+  });
+
+  it("deletes a future WORKOUT with externalId prefix only", async () => {
+    const { result, deleteCalls } = await runDelete({
+      id: 56,
+      category: "WORKOUT",
+      externalId: `${COACH_EXTERNAL_ID_PREFIX}2999-01-01:x`,
+      startDateLocal: "2999-01-01T00:00:00",
+    });
+    expect(result.deleted).toBe(true);
+    expect(deleteCalls).toEqual([56]);
+  });
+
+  it("past-dated marked WORKOUT -> past_workout_protected (ownership passes, date refuses)", async () => {
+    const { result, deleteCalls } = await runDelete({
+      category: "WORKOUT",
+      tags: [COACH_EVENT_TAG],
+      startDateLocal: "2000-01-01T00:00:00",
+    });
+    expect(result.error).toBe("past_workout_protected");
+    expect(deleteCalls).toEqual([]);
+  });
+
+  it("past-dated NOTE -> not_a_workout (category precedes date guard)", async () => {
+    const { result, deleteCalls } = await runDelete({
+      category: "NOTE",
+      tags: [COACH_EVENT_TAG],
+      startDateLocal: "2000-01-01T00:00:00",
+    });
+    expect(result.error).toBe("not_a_workout");
+    expect(deleteCalls).toEqual([]);
+  });
+});
+
+type ListRow = {
+  id: number;
+  category?: string | null;
+  externalId?: string | null;
+  tags?: string[] | null;
+  coachCreated: boolean;
+};
+
+async function runList(events: EventKnobs[], coachCreatedOnly?: boolean) {
+  const client = makeListFake(events);
+  const tools = createCoreToolsWithSportConfig(client, ["Ride"]);
+  return (await tools.intervals_list_events!.execute!(
+    { oldest: "2026-01-01", coachCreatedOnly },
+    {} as never,
+  )) as ListRow[];
+}
+
+describe("intervals_list_events projection", () => {
+  it("rows carry category, externalId, tags, coachCreated", async () => {
+    const rows = await runList([
+      { id: 1, category: "WORKOUT", tags: [COACH_EVENT_TAG], externalId: null },
+    ]);
+    expect(rows[0]).toMatchObject({
+      id: 1,
+      category: "WORKOUT",
+      tags: [COACH_EVENT_TAG],
+      externalId: null,
+      coachCreated: true,
+    });
+  });
+
+  it("coachCreated true for tag-marked, false for unmarked", async () => {
+    const rows = await runList([
+      { id: 1, category: "WORKOUT", tags: [COACH_EVENT_TAG] },
+      { id: 2, category: "WORKOUT" },
+    ]);
+    expect(rows.find((r) => r.id === 1)!.coachCreated).toBe(true);
+    expect(rows.find((r) => r.id === 2)!.coachCreated).toBe(false);
+  });
+
+  it("coachCreatedOnly:true filters to marked rows only", async () => {
+    const rows = await runList(
+      [
+        { id: 1, category: "WORKOUT", tags: [COACH_EVENT_TAG] },
+        { id: 2, category: "WORKOUT" },
+      ],
+      true,
+    );
+    expect(rows.map((r) => r.id)).toEqual([1]);
+  });
+
+  it("omitted coachCreatedOnly returns all rows (memoizer-arg default)", async () => {
+    const rows = await runList([
+      { id: 1, category: "WORKOUT", tags: [COACH_EVENT_TAG] },
+      { id: 2, category: "WORKOUT" },
+    ]);
+    expect(rows.map((r) => r.id)).toEqual([1, 2]);
+  });
+});

--- a/packages/core/tests/turn-tainted-by-writes.test.ts
+++ b/packages/core/tests/turn-tainted-by-writes.test.ts
@@ -8,6 +8,7 @@ import { createMockIntervalsServer } from "./helpers/mock-intervals.js";
 import { cyclingSport } from "@enduragent/sport-cycling";
 import type { Sport } from "../src/sport.js";
 import { TAINTED_BY_WRITES_MESSAGE } from "../src/agent/coach-agent-copy.js";
+import { COACH_EVENT_TAG } from "../src/agent/event-provenance.js";
 
 let tempHome: string;
 let origHome: string | undefined;
@@ -350,6 +351,7 @@ describe("tainted-by-writes refusal", () => {
       name: "To delete",
       type: "Ride",
       moving_time: 3600,
+      tags: [COACH_EVENT_TAG],
     });
     server.listen({ onUnhandledRequest: "bypass" });
     try {

--- a/packages/core/tests/user-time.test.ts
+++ b/packages/core/tests/user-time.test.ts
@@ -14,6 +14,7 @@ import { Memory } from "../src/memory/store.js";
 import { buildSystemPrompt } from "../src/agent/system-prompt.js";
 import { resolveDailyResetAtMs } from "../src/agent/session-freshness.js";
 import { createPureCoreIntervalsTools } from "../src/agent/intervals-tools.js";
+import { COACH_EVENT_TAG } from "../src/agent/event-provenance.js";
 import type { IntervalsClient } from "intervals-icu-api";
 
 // ────────────────────────────────────────────────────────────────────────
@@ -175,7 +176,12 @@ function makeFakeIntervals(eventDateLocal: string): IntervalsClient {
     events: {
       get: async (_id: number) => ({
         ok: true,
-        value: { id: _id, startDateLocal: eventDateLocal },
+        value: {
+          id: _id,
+          startDateLocal: eventDateLocal,
+          category: "WORKOUT",
+          tags: [COACH_EVENT_TAG],
+        },
       }),
       delete: async (id: number) => {
         deleteCalls.push(id);

--- a/packages/sport-cycling/src/tools.ts
+++ b/packages/sport-cycling/src/tools.ts
@@ -1,6 +1,7 @@
 import { tool, zodSchema } from "ai";
 import { z } from "zod";
 import type { MemoryStore } from "@enduragent/core";
+import { COACH_EVENT_TAG, buildCoachExternalId } from "@enduragent/core";
 import type { IntervalsClient } from "intervals-icu-api";
 import {
   calculateCyclingZones,
@@ -173,6 +174,8 @@ export function createCyclingTools(
                 category: "WORKOUT",
                 name: input.workout.name,
                 type: "Ride",
+                external_id: buildCoachExternalId(input.date, input.workout.name),
+                tags: [COACH_EVENT_TAG],
                 moving_time: serialized.movingTime,
                 icu_training_load: serialized.trainingLoad,
                 description: serialized.description,

--- a/packages/sport-cycling/tests/tools.test.ts
+++ b/packages/sport-cycling/tests/tools.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import type { MemoryStore } from "@enduragent/core";
+import { createCyclingTools } from "../src/tools.js";
+
+type CreateResult =
+  | { ok: true; value: { id: number } }
+  | { ok: false; error: { kind: string } };
+
+function fakeIntervals(
+  result: CreateResult,
+): { client: unknown; calls: Record<string, unknown>[] } {
+  const calls: Record<string, unknown>[] = [];
+  const client = {
+    events: {
+      create: async (payload: Record<string, unknown>) => {
+        calls.push(payload);
+        return result;
+      },
+    },
+  };
+  return { client, calls };
+}
+
+function createWorkoutTool(intervals: unknown) {
+  const tools = createCyclingTools({} as MemoryStore, intervals as never, "UTC");
+  return (tools as Record<string, unknown>).intervals_create_workout as
+    | { execute: (input: unknown, opts: unknown) => Promise<Record<string, unknown>> }
+    | undefined;
+}
+
+const validWorkout = {
+  name: "Z2 Endurance 90min",
+  steps: [
+    {
+      type: "steady" as const,
+      duration: { value: 70, unit: "minutes" as const },
+      power: { kind: "percent_ftp" as const, low: 56, high: 75 },
+    },
+  ],
+};
+
+describe("intervals_create_workout provenance", () => {
+  it("payload carries external_id 'cycling-coach:<date>:<slug>' and tags ['cycling-coach']", async () => {
+    const { client, calls } = fakeIntervals({ ok: true, value: { id: 42 } });
+    const tool = createWorkoutTool(client)!;
+
+    const out = await tool.execute({ date: "2026-06-21", workout: validWorkout }, {});
+
+    expect(out).toEqual({ created: true, event: { id: 42 } });
+    expect(calls).toHaveLength(1);
+    const payload = calls[0];
+    expect(payload.external_id).toBe("cycling-coach:2026-06-21:z2-endurance-90min");
+    expect(payload.tags).toEqual(["cycling-coach"]);
+  });
+
+  it("existing fields unchanged: type Ride, category WORKOUT, name, description", async () => {
+    const { client, calls } = fakeIntervals({ ok: true, value: { id: 1 } });
+    const tool = createWorkoutTool(client)!;
+
+    await tool.execute({ date: "2026-06-21", workout: validWorkout }, {});
+
+    const payload = calls[0];
+    expect(payload.type).toBe("Ride");
+    expect(payload.category).toBe("WORKOUT");
+    expect(payload.name).toBe("Z2 Endurance 90min");
+    expect(typeof payload.description).toBe("string");
+  });
+
+  it("tool absent when no intervals client configured", () => {
+    const tools = createCyclingTools({} as MemoryStore, null, "UTC");
+    expect("intervals_create_workout" in tools).toBe(false);
+  });
+});

--- a/packages/sport-running/src/tools.ts
+++ b/packages/sport-running/src/tools.ts
@@ -1,6 +1,7 @@
 import { tool, zodSchema } from "ai";
 import { z } from "zod";
 import type { MemoryStore, ResolvedCs } from "@enduragent/core";
+import { COACH_EVENT_TAG, buildCoachExternalId } from "@enduragent/core";
 import type { IntervalsClient } from "intervals-icu-api";
 import {
   calculateRunningZones,
@@ -193,6 +194,8 @@ export function createRunningTools(
                 category: "WORKOUT",
                 name: input.workout.name,
                 type: "Run",
+                external_id: buildCoachExternalId(input.date, input.workout.name),
+                tags: [COACH_EVENT_TAG],
                 moving_time: serialized.movingTime,
                 // No icu_training_load — the server derives running Pace Load from the
                 // parsed steps against the athlete's own threshold pace.

--- a/packages/sport-running/tests/tools.test.ts
+++ b/packages/sport-running/tests/tools.test.ts
@@ -192,6 +192,8 @@ describe("intervals_create_workout tool", () => {
     expect(typeof payload.description).toBe("string");
     expect(payload.description).toContain("75% Pace");
     expect("icu_training_load" in payload).toBe(false);
+    expect(payload.external_id).toBe("cycling-coach:2026-06-21:easy-30");
+    expect(payload.tags).toEqual(["cycling-coach"]);
   });
 
   it("passes a manual-source resolved CS through and still serializes (DOM-1)", async () => {


### PR DESCRIPTION
## What

Stamps a provenance marker (`external_id` + `tags`) on every workout the coach creates in both sport packages, surfaces the marker in the calendar list projection, and adds a deterministic two-leg delete guard so the coach only removes its own scheduled workouts.

- Both create tools stamp `external_id: "cycling-coach:<date>:<slug>"` and `tags: ["cycling-coach"]` (snake_case, write side only).
- `intervals_list_events` rows now carry `category`, `externalId`, `tags`, and a derived `coachCreated` flag, plus an opt-in `coachCreatedOnly` filter.
- `intervals_delete_workout` refuses non-WORKOUT events (`not_a_workout`) and marker-less events (`not_coach_created`) before the destructive delete call, ahead of the existing past-date guard. Ownership matching is exact — near-miss forgeries (`cycling-coach-pro` tag, `evil-cycling-coach:` external id) are refused.

By design the agent never deletes an event dated before today, and never deletes a marker-less event, regardless of creator; the refusal guidance tells the athlete to remove those directly on intervals.icu.

## Test plan

- `pnpm check && pnpm test` green (203 files, 3058 passed / 3 skipped).
- New `intervals-tools-events.test.ts`: provenance helpers (slug/cap/fallback, exact matching, near-miss rejection), delete-guard vectors (category → ownership → past-date ordering, missing/undefined category, null category, tag-only and external-id-only ownership), and the list projection + `coachCreatedOnly` filter.
- New cycling tools test and extended running tools test assert both marker fields on create without coupling to platform-derived Load fields.
- Existing end-to-end fixtures updated to carry the marker so their delete/taint assertions still hold.

The read side reads camelCase `externalId`; snake_case `external_id` appears only in the two create payloads.
