### PR TITLE
feat(core): pure plan skeleton, past-date create guard, tool-schema strictness

### DIFF
--- a/.changeset/tool-purity-schema-strictness.md
+++ b/.changeset/tool-purity-schema-strictness.md
@@ -1,0 +1,8 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Sketching a training plan no longer silently saves it — the coach saves a plan only after you approve it.
+User-facing: The coach now refuses to schedule a workout on a past date instead of creating an event it can't remove.
+
+Tighten tool inputs for dates, activity IDs, streams, memory sections, and saved plans.

--- a/packages/core/src/agent/coach-agent.ts
+++ b/packages/core/src/agent/coach-agent.ts
@@ -82,15 +82,12 @@ const REPLAY_UNSAFE_TOOL_NAMES = new Set([
   "intervals_delete_workout",
   "memory_write",
   "plan_save",
-  // Commits a plan via memory.savePlan — the same non-idempotent side effect as
-  // plan_save — so a retry must not replay it. Recognized in committedWriteSummary.
-  "build_plan_skeleton",
 ]);
 
 // The subset of write tools that mutate the state behind the memoized memory
 // read tools (memory_read / memory_query / plan_load); their execution evicts
 // those cache entries so a same-turn re-read sees the write.
-const MEMORY_MUTATING_TOOL_NAMES = new Set(["memory_write", "plan_save", "build_plan_skeleton"]);
+const MEMORY_MUTATING_TOOL_NAMES = new Set(["memory_write", "plan_save"]);
 // Eviction runs inside wrapWriteTool, which early-returns for tools outside
 // REPLAY_UNSAFE_TOOL_NAMES — so a memory mutator outside that set would never
 // evict. Assert the subset relation at module load so the gap can't open silently.
@@ -200,14 +197,11 @@ function committedWriteSummary(name: string, result: unknown): string | undefine
   // wrapWriteTool composes innermost (inside markUntrustedResult and the cap),
   // so the ack inspected here is the tool's raw result.
   if (result === null || typeof result !== "object") return undefined;
-  const out = result as { created?: unknown; deleted?: unknown; saved?: unknown; phases?: unknown };
+  const out = result as { created?: unknown; deleted?: unknown; saved?: unknown };
   if (out.created === true) return "created a workout on the calendar";
   if (out.deleted === true) return "deleted a scheduled workout";
   if (out.saved === true && name === "memory_write") return "saved athlete memory";
   if (out.saved === true && name === "plan_save") return "saved the training plan";
-  // build_plan_skeleton returns the saved plan itself (a phases-bearing object),
-  // not a {saved:true} ack, so recognize its success by the plan shape.
-  if (name === "build_plan_skeleton" && Array.isArray(out.phases)) return "built training plan";
   return undefined;
 }
 

--- a/packages/core/src/agent/date-schema.ts
+++ b/packages/core/src/agent/date-schema.ts
@@ -1,0 +1,42 @@
+import { z } from "zod";
+import { isRealDateKey, parseDateKeyMs, MS_PER_DAY } from "../io/date-keys.js";
+import { todayInTZ } from "./user-time.js";
+
+export const DATE_KEY_RE = /^\d{4}-\d{2}-\d{2}$/;
+export const dateKeySchema = z.string().regex(DATE_KEY_RE);
+export const INTERVALS_LIST_MAX_RANGE_DAYS = 366;
+
+export function validateListRange(
+  oldest: string,
+  newest: string | undefined,
+  maxDays: number,
+): { error: string; details: string } | null {
+  if (!isRealDateKey(oldest)) {
+    return {
+      error: "invalid_date",
+      details: `${oldest} is not a real calendar date. Use YYYY-MM-DD.`,
+    };
+  }
+  const effectiveNewest = newest ?? todayInTZ("UTC");
+  if (!isRealDateKey(effectiveNewest)) {
+    return {
+      error: "invalid_date",
+      details: `${effectiveNewest} is not a real calendar date. Use YYYY-MM-DD.`,
+    };
+  }
+  if (oldest > effectiveNewest) {
+    return {
+      error: "invalid_range",
+      details: `oldest (${oldest}) is after newest (${effectiveNewest}). Swap the bounds.`,
+    };
+  }
+  const rangeDays =
+    (parseDateKeyMs(effectiveNewest) - parseDateKeyMs(oldest)) / MS_PER_DAY + 1;
+  if (rangeDays > maxDays) {
+    return {
+      error: "range_too_wide",
+      details: `Range is ${rangeDays} days; the maximum is ${maxDays}. Fetch the range in chunks of at most ${maxDays} days.`,
+    };
+  }
+  return null;
+}

--- a/packages/core/src/agent/intervals-tools.ts
+++ b/packages/core/src/agent/intervals-tools.ts
@@ -1,10 +1,30 @@
 import { tool, zodSchema } from "ai";
+import type { Tool } from "ai";
 import { z } from "zod";
 import type { ApiError, IntervalsClient } from "intervals-icu-api";
 import type { IntervalsActivityType } from "../sport.js";
 import { todayInTZ } from "./user-time.js";
 import { downsampleStreams } from "./stream-downsample.js";
 import { isCoachOwnedEvent } from "./event-provenance.js";
+import {
+  dateKeySchema,
+  INTERVALS_LIST_MAX_RANGE_DAYS,
+  validateListRange,
+} from "./date-schema.js";
+
+export const ACTIVITY_ID_RE = /^i?\d+$/;
+export const STREAM_TYPES = [
+  "watts",
+  "heartrate",
+  "cadence",
+  "time",
+  "altitude",
+  "distance",
+  "lat",
+  "lng",
+  "temp",
+  "smooth_grade",
+] as const;
 
 function toTypedError(error: ApiError): { error: string; status?: number; message?: string } {
   return {
@@ -58,11 +78,17 @@ export function createPureCoreIntervalsTools(
         "Fetch wellness data from intervals.icu (fitness, fatigue, weight, HRV, resting HR, sleep). Form = fitness - fatigue.",
       inputSchema: zodSchema(
         z.object({
-          oldest: z.string().describe("Start date (YYYY-MM-DD)"),
-          newest: z.string().optional().describe("End date (YYYY-MM-DD)"),
+          oldest: dateKeySchema.describe("Start date (YYYY-MM-DD)"),
+          newest: dateKeySchema.optional().describe("End date (YYYY-MM-DD)"),
         }),
       ),
       execute: async (input: { oldest: string; newest?: string }) => {
+        const rangeError = validateListRange(
+          input.oldest,
+          input.newest,
+          INTERVALS_LIST_MAX_RANGE_DAYS,
+        );
+        if (rangeError) return rangeError;
         const result = await intervals.wellness.list({
           oldest: input.oldest,
           newest: input.newest ?? undefined,
@@ -82,11 +108,16 @@ export function createPureCoreIntervalsTools(
         "summary-only Tier A, use `intervals_fetch_activities`.",
       inputSchema: zodSchema(
         z.object({
-          activityId: z.number().int().describe("Activity ID from intervals_fetch_activities"),
+          activityId: z
+            .string()
+            .regex(ACTIVITY_ID_RE)
+            .describe(
+              "Activity ID from intervals_fetch_activities — numeric, or i-prefixed for intervals-native activities. Pass exactly as listed.",
+            ),
         }),
       ),
-      execute: async (input: { activityId: number }) => {
-        const result = await intervals.activities.get(String(input.activityId));
+      execute: async (input: { activityId: string }) => {
+        const result = await intervals.activities.get(input.activityId);
         if (!result.ok) return toTypedError(result.error);
         return result.value;
       },
@@ -105,27 +136,31 @@ export function createPureCoreIntervalsTools(
         "cadence, time, altitude.",
       inputSchema: zodSchema(
         z.object({
-          activityId: z.number().int().describe("Activity ID"),
+          activityId: z
+            .string()
+            .regex(ACTIVITY_ID_RE)
+            .describe(
+              "Activity ID from intervals_fetch_activities — numeric, or i-prefixed for intervals-native activities. Pass exactly as listed.",
+            ),
           types: z
-            .array(z.string())
+            .array(z.enum(STREAM_TYPES))
             .optional()
             .describe(
-              "Stream types to fetch. Defaults to ['watts','heartrate','cadence','time','altitude']. " +
-                "Other valid types: distance, lat, lng, temp, smooth_grade.",
+              "Stream types to fetch. Defaults to ['watts','heartrate','cadence','time','altitude'].",
             ),
         }),
       ),
-      execute: async (input: { activityId: number; types?: string[] }) => {
+      execute: async (input: { activityId: string; types?: (typeof STREAM_TYPES)[number][] }) => {
         // Treat empty array the same as omitted — defensively handle the LLM
         // calling with `types: []` "to play it safe" instead of dropping the field.
         const types = input.types?.length
           ? input.types
           : ["watts", "heartrate", "cadence", "time", "altitude"];
-        const result = await intervals.activities.getStreams(String(input.activityId), types);
+        const result = await intervals.activities.getStreams(input.activityId, types);
         if (!result.ok) return toTypedError(result.error);
         return downsampleStreams(result.value as Record<string, unknown> | unknown[]);
       },
-    }),
+    }) as Tool,
 
     intervals_delete_workout: tool({
       description:
@@ -194,11 +229,17 @@ export function createCoreToolsWithSportConfig(
         "Fetch recent activities from intervals.icu. Returns rides with load, intensity, duration, distance.",
       inputSchema: zodSchema(
         z.object({
-          oldest: z.string().describe("Oldest date (YYYY-MM-DD)"),
-          newest: z.string().optional().describe("Newest date (YYYY-MM-DD)"),
+          oldest: dateKeySchema.describe("Oldest date (YYYY-MM-DD)"),
+          newest: dateKeySchema.optional().describe("Newest date (YYYY-MM-DD)"),
         }),
       ),
       execute: async (input: { oldest: string; newest?: string }) => {
+        const rangeError = validateListRange(
+          input.oldest,
+          input.newest,
+          INTERVALS_LIST_MAX_RANGE_DAYS,
+        );
+        if (rangeError) return rangeError;
         const result = await intervals.activities.list({
           oldest: input.oldest,
           newest: input.newest ?? undefined,
@@ -218,8 +259,8 @@ export function createCoreToolsWithSportConfig(
         "coach-created events.",
       inputSchema: zodSchema(
         z.object({
-          oldest: z.string().describe("Oldest date (YYYY-MM-DD)"),
-          newest: z.string().optional().describe("Newest date (YYYY-MM-DD)"),
+          oldest: dateKeySchema.describe("Oldest date (YYYY-MM-DD)"),
+          newest: dateKeySchema.optional().describe("Newest date (YYYY-MM-DD)"),
           coachCreatedOnly: z
             .boolean()
             .optional()
@@ -227,6 +268,12 @@ export function createCoreToolsWithSportConfig(
         }),
       ),
       execute: async (input: { oldest: string; newest?: string; coachCreatedOnly?: boolean }) => {
+        const rangeError = validateListRange(
+          input.oldest,
+          input.newest,
+          INTERVALS_LIST_MAX_RANGE_DAYS,
+        );
+        if (rangeError) return rangeError;
         const result = await intervals.events.list({
           oldest: input.oldest,
           newest: input.newest ?? undefined,

--- a/packages/core/src/agent/read-memoizer.ts
+++ b/packages/core/src/agent/read-memoizer.ts
@@ -3,12 +3,13 @@ import type { Tool } from "ai";
 // Membership requires the tool's `execute` to be side-effect-free: a memoized
 // hit returns the cached value WITHOUT re-invoking `execute`, so any tool that
 // mutates state on each call must stay off this set. The cautionary case is
-// `build_plan_skeleton` — it returns a value AND writes a plan via savePlan, so
-// memoizing it would silently skip the write on a duplicate call. This is a
+// `plan_save` — it returns {saved:true} AND writes a plan, so memoizing it would
+// silently skip the write on a duplicate call. This is a
 // positive, hand-audited allowlist, NOT the negation of the calendar-write set.
 export const READ_ONLY_TOOL_NAMES: ReadonlySet<string> = new Set([
   "calculate_zones",
   "assess_feasibility",
+  "build_plan_skeleton",
   "get_sample_week",
   "intervals_fetch_athlete",
   "intervals_fetch_wellness",
@@ -38,8 +39,8 @@ export function stableStringify(value: unknown): string {
   return "{" + entries.join(",") + "}";
 }
 
-// The memory read tools serve snapshots of state that memory_write /
-// plan_save / build_plan_skeleton mutate mid-turn. After such a write commits,
+// The memory read tools serve snapshots of state that memory_write / plan_save
+// mutate mid-turn. After such a write commits,
 // their cached entries are stale — and the chat memory_read description
 // explicitly invites a re-read after a same-turn write — so the write boundary
 // evicts them rather than serving the pre-write snapshot as fresh.

--- a/packages/core/src/agent/tools.ts
+++ b/packages/core/src/agent/tools.ts
@@ -2,9 +2,9 @@ import { tool, zodSchema } from "ai";
 import { z } from "zod";
 import type { MemorySectionSpec } from "../sport.js";
 import type { MemoryStore } from "../memory.js";
-import { PlanFileSchema } from "../memory/store.js";
 import { isRealDateKey, parseDateKeyMs, MS_PER_DAY } from "../io/date-keys.js";
 import { truncateUtf16Safe } from "../text-truncate.js";
+import { DATE_KEY_RE } from "./date-schema.js";
 
 function buildMemoryWriteDescription(sections: readonly MemorySectionSpec[]): string {
   const sectionList = sections.map((s) => `${s.name} (${s.description})`).join("; ");
@@ -13,6 +13,30 @@ function buildMemoryWriteDescription(sections: readonly MemorySectionSpec[]): st
     `Sections: ${sectionList}.`
   );
 }
+
+export function buildMemoryWriteInputSchema(sectionNames: [string, ...string[]]) {
+  return z.object({
+    type: z
+      .enum(["memory", "daily"])
+      .describe("'memory' for long-term facts, 'daily' for today's notes"),
+    section: z
+      .enum(sectionNames)
+      .optional()
+      .describe(
+        "Memory section to write to. REQUIRED when type='memory' — the write replaces the section content.",
+      ),
+    content: z.string().describe("The information to save"),
+  });
+}
+
+export const PlanSaveInputSchema = z
+  .object({
+    name: z.string(),
+    primaryGoal: z.string().optional(),
+    totalWeeks: z.number().int().positive().optional(),
+    status: z.string().optional(),
+  })
+  .passthrough();
 
 // Default is the flush-safe read-role copy; the chat toolset overrides it with a
 // dedupe nudge (the always-injected sections are already in the Athlete Context).
@@ -32,7 +56,6 @@ export function createMemoryReadTool(memory: MemoryStore, description: string) {
 
 const MEMORY_QUERY_MAX_RANGE_DAYS = 366;
 const MEMORY_QUERY_MAX_RESULT_CHARS = 20_000;
-const MEMORY_QUERY_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 
 export function createMemoryQueryTool(memory: MemoryStore) {
   return tool({
@@ -44,11 +67,11 @@ export function createMemoryQueryTool(memory: MemoryStore) {
       z.object({
         from: z
           .string()
-          .regex(MEMORY_QUERY_DATE_RE)
+          .regex(DATE_KEY_RE)
           .describe("Start date (inclusive), YYYY-MM-DD"),
         to: z
           .string()
-          .regex(MEMORY_QUERY_DATE_RE)
+          .regex(DATE_KEY_RE)
           .describe("End date (inclusive), YYYY-MM-DD"),
         query: z
           .string()
@@ -129,24 +152,17 @@ export function createMemoryTools(
 
     memory_write: tool({
       description: buildMemoryWriteDescription(sections),
-      inputSchema: zodSchema(
-        z.object({
-          type: z
-            .enum(["memory", "daily"])
-            .describe("'memory' for long-term facts, 'daily' for today's notes"),
-          section: z
-            .enum(sectionNames)
-            .optional()
-            .describe(
-              "Memory section to write to (required when type='memory'). Replaces the section content.",
-            ),
-          content: z.string().describe("The information to save"),
-        }),
-      ),
+      inputSchema: zodSchema(buildMemoryWriteInputSchema(sectionNames)),
       execute: async (input: { type: "memory" | "daily"; section?: string; content: string }) => {
-        if (input.type === "memory") {
-          // "notes" is a CORE_SHARED_SECTIONS catch-all — safe default when the LLM forgets to pick a section.
-          memory.writeSection(input.section ?? "notes", input.content, "chat-tool");
+        if (input.type === "memory" && input.section === undefined) {
+          return {
+            error: "section_required",
+            details:
+              "type='memory' requires a section. Pick one of the listed sections, or use type='daily' for free-form notes.",
+          };
+        }
+        if (input.type === "memory" && input.section !== undefined) {
+          memory.writeSection(input.section, input.content, "chat-tool");
         } else {
           memory.appendDailyNote(input.content);
         }
@@ -158,7 +174,7 @@ export function createMemoryTools(
       description: "Save or update the current training plan",
       inputSchema: zodSchema(
         z.object({
-          plan: PlanFileSchema.describe("The training plan object to save"),
+          plan: PlanSaveInputSchema.describe("The training plan object to save"),
         }),
       ),
       execute: async (input: { plan: Record<string, unknown> }) => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -180,6 +180,13 @@ export {
   createCoreToolsWithSportConfig,
 } from "./agent/intervals-tools.js";
 export {
+  DATE_KEY_RE,
+  dateKeySchema,
+  INTERVALS_LIST_MAX_RANGE_DAYS,
+  validateListRange,
+} from "./agent/date-schema.js";
+export { isRealDateKey } from "./io/date-keys.js";
+export {
   COACH_EVENT_TAG,
   COACH_EXTERNAL_ID_PREFIX,
   buildCoachExternalId,

--- a/packages/core/src/memory/store.ts
+++ b/packages/core/src/memory/store.ts
@@ -38,11 +38,10 @@ const UPDATED_STAMP_PREFIX = "_updated: ";
 
 export const SECTION_SOFT_WARN_CHARS = 4000;
 
-// Loose passthrough: any JSON object passes with all keys intact; any non-object
-// top level fails → null. Shared with the plan_save tool's input schema so
-// anything the tool can save, loadPlan accepts — one constant, no drift. A typed
-// schema would null the entire plan when one hand-edited field is mistyped; the
-// per-field guards in getContext handle mistypes gracefully instead.
+// PlanFileSchema is the tolerant read-side loadPlan schema. The write side uses
+// PlanSaveInputSchema in agent/tools.ts (typed headline keys plus passthrough), so
+// anything saved still loads while malformed headline fields are rejected at the
+// tool boundary. Per-field guards in getContext handle hand-edited mistypes.
 export const PlanFileSchema = z.record(z.string(), z.unknown());
 
 // Embedded H2 lines would match SECTION_SPLIT and fragment the file into

--- a/packages/core/tests/date-schema.test.ts
+++ b/packages/core/tests/date-schema.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import {
+  dateKeySchema,
+  validateListRange,
+} from "../src/agent/date-schema.js";
+
+describe("dateKeySchema", () => {
+  it("accepts the required shape and rejects alternate formats", () => {
+    expect(dateKeySchema.safeParse("2026-07-10").success).toBe(true);
+    for (const value of ["June 15", "2026-7-1", "20260710"]) {
+      expect(dateKeySchema.safeParse(value).success).toBe(false);
+    }
+  });
+});
+
+describe("validateListRange", () => {
+  it("allows an inclusive 366-day range", () => {
+    expect(validateListRange("2025-01-01", "2026-01-01", 366)).toBeNull();
+  });
+
+  it("refuses 367 days with chunking guidance", () => {
+    const result = validateListRange("2025-01-01", "2026-01-02", 366);
+    expect(result?.error).toBe("range_too_wide");
+    expect(result?.details).toContain("367 days");
+    expect(result?.details).toContain("chunks");
+    expect(result?.details).toContain("366");
+  });
+
+  it("refuses swapped bounds", () => {
+    expect(validateListRange("2026-07-11", "2026-07-10", 366)?.error).toBe(
+      "invalid_range",
+    );
+  });
+
+  it("refuses impossible dates", () => {
+    expect(validateListRange("2026-02-31", "2026-03-01", 366)?.error).toBe(
+      "invalid_date",
+    );
+    expect(validateListRange("2026-02-01", "2026-02-31", 366)?.error).toBe(
+      "invalid_date",
+    );
+  });
+
+  it("caps an omitted newest bound against today in UTC", () => {
+    const oldest = new Date(Date.now() - 400 * 86_400_000).toISOString().slice(0, 10);
+    expect(validateListRange(oldest, undefined, 366)?.error).toBe("range_too_wide");
+  });
+});

--- a/packages/core/tests/intervals-tools-fetch-activity.test.ts
+++ b/packages/core/tests/intervals-tools-fetch-activity.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect } from "vitest";
 import type { IntervalsClient } from "intervals-icu-api";
-import { createPureCoreIntervalsTools } from "../src/agent/intervals-tools.js";
+import {
+  ACTIVITY_ID_RE,
+  createPureCoreIntervalsTools,
+} from "../src/agent/intervals-tools.js";
 
 type AnyResult = { ok: true; value: unknown } | { ok: false; error: { kind: string } };
 
@@ -36,7 +39,7 @@ describe("intervals_fetch_activity", () => {
     const tools = createPureCoreIntervalsTools(fake);
     const tool = tools.intervals_fetch_activity!;
 
-    const result = await tool.execute!({ activityId: 12345 }, {} as never);
+    const result = await tool.execute!({ activityId: "12345" }, {} as never);
 
     expect(result).toEqual(activity);
     expect(capture.calledWith).toBe("12345");
@@ -48,7 +51,7 @@ describe("intervals_fetch_activity", () => {
     const tools = createPureCoreIntervalsTools(fake);
     const tool = tools.intervals_fetch_activity!;
 
-    const result = await tool.execute!({ activityId: 99999 }, {} as never);
+    const result = await tool.execute!({ activityId: "99999" }, {} as never);
 
     expect(result).toEqual({ error: "not_found" });
   });
@@ -61,5 +64,19 @@ describe("intervals_fetch_activity", () => {
     expect(description).toMatch(/icu_intervals/);
     expect(description).toMatch(/analyzed/);
     expect(description).toMatch(/paired_event_id/);
+  });
+
+  it("passes an i-prefixed activity ID through verbatim", async () => {
+    const capture: { calledWith?: string } = {};
+    const fake = makeFakeIntervals({ ok: true, value: { id: "i9876543" } }, capture);
+    const tool = createPureCoreIntervalsTools(fake).intervals_fetch_activity!;
+
+    await tool.execute!({ activityId: "i9876543" }, {} as never);
+
+    expect(capture.calledWith).toBe("i9876543");
+  });
+
+  it.each(["abc", "12 34", "i"])("rejects invalid activity ID %s", (activityId) => {
+    expect(ACTIVITY_ID_RE.test(activityId)).toBe(false);
   });
 });

--- a/packages/core/tests/intervals-tools-fetch-streams.test.ts
+++ b/packages/core/tests/intervals-tools-fetch-streams.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from "vitest";
+import { z } from "zod";
 import type { IntervalsClient } from "intervals-icu-api";
-import { createPureCoreIntervalsTools } from "../src/agent/intervals-tools.js";
+import {
+  ACTIVITY_ID_RE,
+  STREAM_TYPES,
+  createPureCoreIntervalsTools,
+} from "../src/agent/intervals-tools.js";
 
 type AnyResult = { ok: true; value: unknown } | { ok: false; error: { kind: string } };
 
@@ -33,7 +38,7 @@ describe("intervals_fetch_streams", () => {
     const tools = createPureCoreIntervalsTools(fake);
     const tool = tools.intervals_fetch_streams!;
 
-    await tool.execute!({ activityId: 12345 }, {} as never);
+    await tool.execute!({ activityId: "12345" }, {} as never);
 
     expect(capture.activityId).toBe("12345");
     expect(capture.types).toEqual(["watts", "heartrate", "cadence", "time", "altitude"]);
@@ -45,7 +50,7 @@ describe("intervals_fetch_streams", () => {
     const tools = createPureCoreIntervalsTools(fake);
     const tool = tools.intervals_fetch_streams!;
 
-    await tool.execute!({ activityId: 999, types: ["watts", "heartrate"] }, {} as never);
+    await tool.execute!({ activityId: "999", types: ["watts", "heartrate"] }, {} as never);
 
     expect(capture.types).toEqual(["watts", "heartrate"]);
   });
@@ -56,7 +61,7 @@ describe("intervals_fetch_streams", () => {
     const tools = createPureCoreIntervalsTools(fake);
     const tool = tools.intervals_fetch_streams!;
 
-    await tool.execute!({ activityId: 1, types: [] }, {} as never);
+    await tool.execute!({ activityId: "1", types: [] }, {} as never);
 
     expect(capture.types).toEqual(["watts", "heartrate", "cadence", "time", "altitude"]);
   });
@@ -67,7 +72,7 @@ describe("intervals_fetch_streams", () => {
     const tools = createPureCoreIntervalsTools(fake);
     const tool = tools.intervals_fetch_streams!;
 
-    const result = (await tool.execute!({ activityId: 1 }, {} as never)) as {
+    const result = (await tool.execute!({ activityId: "1" }, {} as never)) as {
       sampleCount: number;
       channels: Record<string, { max: number }>;
     };
@@ -81,7 +86,7 @@ describe("intervals_fetch_streams", () => {
     const tools = createPureCoreIntervalsTools(fake);
     const tool = tools.intervals_fetch_streams!;
 
-    const result = await tool.execute!({ activityId: 1 }, {} as never);
+    const result = await tool.execute!({ activityId: "1" }, {} as never);
 
     expect(result).toEqual({ error: "not_found" });
   });
@@ -92,5 +97,25 @@ describe("intervals_fetch_streams", () => {
     const description = (tools.intervals_fetch_streams as { description: string }).description;
     expect(description).toContain("EXPENSIVE");
     expect(description).toContain("ONLY call for Tier C");
+  });
+
+  it("passes an i-prefixed activity ID through verbatim", async () => {
+    const capture: { activityId?: string; types?: string[] } = {};
+    const fake = makeFakeIntervals({ ok: true, value: {} }, capture);
+    const tool = createPureCoreIntervalsTools(fake).intervals_fetch_streams!;
+
+    await tool.execute!({ activityId: "i9876543" }, {} as never);
+
+    expect(capture.activityId).toBe("i9876543");
+  });
+
+  it.each(["abc", "12 34", "i"])("rejects invalid activity ID %s", (activityId) => {
+    expect(ACTIVITY_ID_RE.test(activityId)).toBe(false);
+  });
+
+  it("accepts all stream types and rejects unknown values", () => {
+    const schema = z.array(z.enum(STREAM_TYPES));
+    expect(schema.safeParse([...STREAM_TYPES]).success).toBe(true);
+    expect(schema.safeParse(["bogus"]).success).toBe(false);
   });
 });

--- a/packages/core/tests/intervals-tools-range-cap.test.ts
+++ b/packages/core/tests/intervals-tools-range-cap.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import type { IntervalsClient } from "intervals-icu-api";
+import {
+  createCoreToolsWithSportConfig,
+  createPureCoreIntervalsTools,
+} from "../src/agent/intervals-tools.js";
+
+function fakeIntervals(calls: string[]): IntervalsClient {
+  const ok = { ok: true as const, value: [] };
+  return {
+    wellness: {
+      list: async () => {
+        calls.push("wellness");
+        return ok;
+      },
+    },
+    activities: {
+      list: async () => {
+        calls.push("activities");
+        return ok;
+      },
+    },
+    events: {
+      list: async () => {
+        calls.push("events");
+        return ok;
+      },
+    },
+  } as unknown as IntervalsClient;
+}
+
+describe("intervals list range caps", () => {
+  it.each([
+    ["wellness", "intervals_fetch_wellness"],
+    ["activities", "intervals_fetch_activities"],
+    ["events", "intervals_list_events"],
+  ] as const)("caps %s without calling the SDK and passes valid ranges", async (callName, toolName) => {
+    const calls: string[] = [];
+    const intervals = fakeIntervals(calls);
+    const tools = {
+      ...createPureCoreIntervalsTools(intervals),
+      ...createCoreToolsWithSportConfig(intervals, ["Ride"]),
+    };
+    const execute = tools[toolName]!.execute!;
+
+    const refused = await execute(
+      { oldest: "2024-01-01", newest: "2026-01-01" },
+      {} as never,
+    );
+    expect(refused).toMatchObject({ error: "range_too_wide" });
+    expect(calls).toEqual([]);
+
+    await execute({ oldest: "2026-06-01", newest: "2026-06-30" }, {} as never);
+    expect(calls).toEqual([callName]);
+  });
+
+  it.each(["intervals_fetch_wellness", "intervals_fetch_activities", "intervals_list_events"] as const)(
+    "refuses swapped bounds for %s",
+    async (toolName) => {
+      const calls: string[] = [];
+      const intervals = fakeIntervals(calls);
+      const tools = {
+        ...createPureCoreIntervalsTools(intervals),
+        ...createCoreToolsWithSportConfig(intervals, ["Ride"]),
+      };
+      const result = await tools[toolName]!.execute!(
+        { oldest: "2026-06-30", newest: "2026-06-01" },
+        {} as never,
+      );
+      expect(result).toMatchObject({ error: "invalid_range" });
+      expect(calls).toEqual([]);
+    },
+  );
+});

--- a/packages/core/tests/memory-tools-schema.test.ts
+++ b/packages/core/tests/memory-tools-schema.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from "vitest";
+import { zodSchema } from "ai";
+import type { MemoryStore } from "../src/memory.js";
+import {
+  buildMemoryWriteInputSchema,
+  createMemoryTools,
+  PlanSaveInputSchema,
+} from "../src/agent/tools.js";
+
+const sections = [{ name: "profile", description: "Athlete profile" }];
+
+function memorySpy() {
+  return {
+    writeSection: vi.fn(),
+    appendDailyNote: vi.fn(),
+    savePlan: vi.fn(),
+    getContext: vi.fn(),
+    readDailyNotesInRange: vi.fn(() => []),
+    readEventsRaw: vi.fn(() => ""),
+    loadPlan: vi.fn(),
+  } as unknown as MemoryStore;
+}
+
+describe("memory_write schema and guard", () => {
+  const schema = buildMemoryWriteInputSchema(["profile"]);
+
+  it("keeps an object-rooted serialized input schema", () => {
+    expect(zodSchema(schema).jsonSchema.type).toBe("object");
+  });
+
+  it("allows omitted section at schema level but refuses the memory write", async () => {
+    const memory = memorySpy();
+    expect(schema.safeParse({ type: "memory", content: "x" }).success).toBe(true);
+    const tool = createMemoryTools(memory, sections).memory_write;
+
+    const result = await tool.execute!({ type: "memory", content: "x" }, {} as never);
+
+    expect(result).toMatchObject({ error: "section_required" });
+    expect(memory.writeSection).not.toHaveBeenCalled();
+  });
+
+  it("rejects unknown sections and writes a valid section", async () => {
+    expect(
+      schema.safeParse({ type: "memory", section: "unknown", content: "x" }).success,
+    ).toBe(false);
+    const memory = memorySpy();
+    const tool = createMemoryTools(memory, sections).memory_write;
+    await tool.execute!(
+      { type: "memory", section: "profile", content: "x" },
+      {} as never,
+    );
+    expect(memory.writeSection).toHaveBeenCalledWith("profile", "x", "chat-tool");
+  });
+
+  it("appends daily content without a section", async () => {
+    const memory = memorySpy();
+    expect(schema.safeParse({ type: "daily", content: "x" }).success).toBe(true);
+    await createMemoryTools(memory, sections).memory_write.execute!(
+      { type: "daily", content: "x" },
+      {} as never,
+    );
+    expect(memory.appendDailyNote).toHaveBeenCalledWith("x");
+  });
+});
+
+describe("PlanSaveInputSchema", () => {
+  it("requires a name and typed headline fields", () => {
+    expect(PlanSaveInputSchema.safeParse({}).success).toBe(false);
+    expect(PlanSaveInputSchema.safeParse({ name: "P", totalWeeks: null }).success).toBe(
+      false,
+    );
+    expect(PlanSaveInputSchema.safeParse({ name: "P", totalWeeks: 0 }).success).toBe(false);
+    expect(PlanSaveInputSchema.safeParse({ name: "P", totalWeeks: 12.5 }).success).toBe(
+      false,
+    );
+  });
+
+  it("preserves passthrough fields", () => {
+    const result = PlanSaveInputSchema.safeParse({ name: "P", extra: "kept" });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.extra).toBe("kept");
+  });
+});

--- a/packages/core/tests/read-memoizer.test.ts
+++ b/packages/core/tests/read-memoizer.test.ts
@@ -10,6 +10,7 @@ import {
 
 const EXPECTED_NAMES = [
   "assess_feasibility",
+  "build_plan_skeleton",
   "calculate_zones",
   "get_sample_week",
   "intervals_fetch_activities",
@@ -34,7 +35,6 @@ describe("READ_ONLY_TOOL_NAMES allowlist", () => {
 
   it("excludes every writer tool", () => {
     for (const writer of [
-      "build_plan_skeleton",
       "intervals_create_workout",
       "intervals_delete_workout",
       "memory_write",
@@ -76,7 +76,7 @@ describe("memoizeReadTool caching", () => {
 
   it("does not memoize a non-allowlisted writer tool", async () => {
     const inner = vi.fn(async () => ({ created: true }));
-    const wrapped = memoizeReadTool("build_plan_skeleton", makeTool(inner), new Map());
+    const wrapped = memoizeReadTool("plan_save", makeTool(inner), new Map());
     const exec = wrapped.execute as (i: unknown, o: unknown) => Promise<unknown>;
     await exec({ a: 1 }, {});
     await exec({ a: 1 }, {});

--- a/packages/core/tests/turn-tainted-by-writes.test.ts
+++ b/packages/core/tests/turn-tainted-by-writes.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { mkdtempSync, rmSync, mkdirSync, readdirSync, readFileSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync, mkdirSync, readdirSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { http, HttpResponse } from "msw";
@@ -232,7 +232,7 @@ describe("tainted-by-writes refusal", () => {
     expect((dailyMemoryText().match(new RegExp(note, "g")) ?? []).length).toBe(1);
   });
 
-  it("a plan-skeleton build then a timeout refuses without replaying the plan save", async () => {
+  it("a plan-skeleton build then a timeout retries normally without saving a plan", async () => {
     let mainTurns = 0;
     const complete = vi.fn(async (params: { system?: string }) => {
       const sys = params.system ?? "";
@@ -258,25 +258,28 @@ describe("tainted-by-writes refusal", () => {
           stopReason: "toolUse",
         });
       }
-      const err = new Error("deadline exceeded");
-      err.name = "TimeoutError";
-      throw err;
+      if (mainTurns === 2) {
+        const err = new Error("deadline exceeded");
+        err.name = "TimeoutError";
+        throw err;
+      }
+      return mkAssistant({ text: "recovered after retry" });
     });
     vi.spyOn(console, "warn").mockImplementation(() => {});
     const agent = await setupAgent(complete);
 
     const result = await agent.chat("taint-plan", "build me a training plan");
 
-    expect(result).toBe(TAINTED_BY_WRITES_MESSAGE);
-    expect(mainTurns).toBe(2);
-    // The plan committed exactly once and was never replayed on the retry.
+    expect(result).toBe("recovered after retry");
+    expect(result).not.toBe(TAINTED_BY_WRITES_MESSAGE);
+    expect(mainTurns).toBe(3);
     const journal = join(dataDir, "memory", "MEMORY.history.jsonl");
-    const planSaves = readFileSync(journal, "utf-8")
+    const planSaves = (existsSync(journal) ? readFileSync(journal, "utf-8") : "")
       .split("\n")
       .filter((line) => line.trim() !== "")
       .map((line) => JSON.parse(line) as { op?: string })
       .filter((entry) => entry.op === "save-plan");
-    expect(planSaves.length).toBe(1);
+    expect(planSaves.length).toBe(0);
   });
 
   it("keeps write taint scoped when different chats run concurrently", async () => {

--- a/packages/sport-cycling/src/tools.ts
+++ b/packages/sport-cycling/src/tools.ts
@@ -1,7 +1,13 @@
 import { tool, zodSchema } from "ai";
 import { z } from "zod";
 import type { MemoryStore } from "@enduragent/core";
-import { COACH_EVENT_TAG, buildCoachExternalId } from "@enduragent/core";
+import {
+  COACH_EVENT_TAG,
+  buildCoachExternalId,
+  dateKeySchema,
+  isRealDateKey,
+  todayInTZ,
+} from "@enduragent/core";
 import type { IntervalsClient } from "intervals-icu-api";
 import {
   calculateCyclingZones,
@@ -23,6 +29,32 @@ import type {
 
 const daysEnum = z.enum(["mon", "tue", "wed", "thu", "fri", "sat", "sun"]);
 
+export const buildPlanSkeletonInputSchema = z.object({
+  experienceLevel: z.enum(["beginner", "intermediate", "advanced", "elite"]),
+  ftpWatts: z.number().int().min(50).max(600),
+  weightKg: z.number().positive().optional(),
+  volumeTier: z.enum(["low", "medium", "high"]),
+  scheduleType: z.enum(["fixed", "flexible"]),
+  availableDays: z.array(daysEnum).optional(),
+  keySessionDay: daysEnum.optional(),
+  sessionsPerWeek: z.number().int().min(3).max(6).optional(),
+  goalType: z.enum(["race", "general"]),
+  raceType: z
+    .enum(["century", "gran_fondo", "criterium", "time_trial", "other"])
+    .optional(),
+  raceDate: dateKeySchema.optional().describe("Target race date, YYYY-MM-DD"),
+  targetTime: z.string().optional().describe("Goal finish time, e.g. 5:30:00"),
+  generalGoal: z.string().optional(),
+  generalGoalTarget: z.string().optional(),
+});
+
+export const cyclingCreateWorkoutInputSchema = z.object({
+  date: dateKeySchema.describe("Workout date (YYYY-MM-DD)"),
+  workout: intervalsWorkoutInputSchema.describe(
+    "Structured workout: name + ordered steps. Top-level steps can be simple (warmup/steady/interval/ramp/recovery/rest/cooldown/freeride) or a set {type:'set', repeat, interval, recovery}. Durations use seconds or minutes only. Power targets: {kind:'percent_ftp'|'watts'|'zone', value} or {kind, low, high} for ranges. Ramps require low+high.",
+  ),
+});
+
 /**
  * Pure-Sport cycling tools per ADR-0004 — sport-specific math (FTP zones,
  * periodized plan-skeleton) + the cycling-flavored intervals.icu workout
@@ -31,7 +63,7 @@ const daysEnum = z.enum(["mon", "tue", "wed", "thu", "fri", "sat", "sun"]);
  * and `createCoreToolsWithSportConfig`.
  */
 export function createCyclingTools(
-  memory: MemoryStore,
+  _memory: MemoryStore,
   intervals: IntervalsClient | null,
   tz: string = "UTC",
 ) {
@@ -48,27 +80,8 @@ export function createCyclingTools(
 
     build_plan_skeleton: tool({
       description:
-        "Build a periodized training plan skeleton from athlete profile. Returns phases, volume targets, zone tables, and testing protocols.",
-      inputSchema: zodSchema(
-        z.object({
-          experienceLevel: z.enum(["beginner", "intermediate", "advanced", "elite"]),
-          ftpWatts: z.number().int().min(50).max(600),
-          weightKg: z.number().positive().optional(),
-          volumeTier: z.enum(["low", "medium", "high"]),
-          scheduleType: z.enum(["fixed", "flexible"]),
-          availableDays: z.array(daysEnum).optional(),
-          keySessionDay: daysEnum.optional(),
-          sessionsPerWeek: z.number().int().min(3).max(6).optional(),
-          goalType: z.enum(["race", "general"]),
-          raceType: z
-            .enum(["century", "gran_fondo", "criterium", "time_trial", "other"])
-            .optional(),
-          raceDate: z.string().optional(),
-          targetTime: z.string().optional(),
-          generalGoal: z.string().optional(),
-          generalGoalTarget: z.string().optional(),
-        }),
-      ),
+        "Build a periodized training plan skeleton from athlete profile. Returns phases, volume targets, zone tables, and testing protocols. Does NOT save anything — present the skeleton to the athlete and call plan_save only after they approve.",
+      inputSchema: zodSchema(buildPlanSkeletonInputSchema),
       execute: async (params: {
         experienceLevel: ExperienceLevel;
         ftpWatts: number;
@@ -85,9 +98,14 @@ export function createCyclingTools(
         generalGoal?: string;
         generalGoalTarget?: string;
       }) => {
+        if (params.raceDate !== undefined && !isRealDateKey(params.raceDate)) {
+          return {
+            error: "invalid_date",
+            details: `${params.raceDate} is not a real calendar date. Use YYYY-MM-DD.`,
+          };
+        }
         const profile: AthleteProfile = { ...params, needsExtraRecovery: false };
         const plan = buildPlanSkeleton(profile, tz);
-        memory.savePlan(plan, "sport-tool");
         return plan;
       },
     }),
@@ -150,16 +168,22 @@ export function createCyclingTools(
               "Create a structured workout on the intervals.icu calendar. Auto-syncs to Garmin/Wahoo. " +
               "Supply the workout as structured steps — the tool serializes them into the intervals.icu " +
               "native description syntax so the power chart renders. Put athlete-facing coaching narrative " +
-              "(feel, notes, hydration) in your chat reply, not in this tool.",
-            inputSchema: zodSchema(
-              z.object({
-                date: z.string().describe("Workout date (YYYY-MM-DD)"),
-                workout: intervalsWorkoutInputSchema.describe(
-                  "Structured workout: name + ordered steps. Top-level steps can be simple (warmup/steady/interval/ramp/recovery/rest/cooldown/freeride) or a set {type:'set', repeat, interval, recovery}. Durations use seconds or minutes only. Power targets: {kind:'percent_ftp'|'watts'|'zone', value} or {kind, low, high} for ranges. Ramps require low+high.",
-                ),
-              }),
-            ),
+              "(feel, notes, hydration) in your chat reply, not in this tool. Past dates are refused — workouts can only be created for today or later.",
+            inputSchema: zodSchema(cyclingCreateWorkoutInputSchema),
             execute: async (input: { date: string; workout: IntervalsWorkoutInput }) => {
+              if (!isRealDateKey(input.date)) {
+                return {
+                  error: "invalid_date",
+                  details: `${input.date} is not a real calendar date. Use YYYY-MM-DD.`,
+                };
+              }
+              const today = todayInTZ(tz);
+              if (input.date < today) {
+                return {
+                  error: "past_date_refused",
+                  details: `Cannot create a workout dated ${input.date} — it's before today (${today}). Use today's date or later.`,
+                };
+              }
               let serialized: ReturnType<typeof serializeIntervalsWorkout>;
               try {
                 serialized = serializeIntervalsWorkout(input.workout);

--- a/packages/sport-cycling/tests/tools.test.ts
+++ b/packages/sport-cycling/tests/tools.test.ts
@@ -1,6 +1,10 @@
-import { describe, it, expect } from "vitest";
-import type { MemoryStore } from "@enduragent/core";
-import { createCyclingTools } from "../src/tools.js";
+import { describe, it, expect, vi } from "vitest";
+import { todayInTZ, type MemoryStore } from "@enduragent/core";
+import {
+  buildPlanSkeletonInputSchema,
+  createCyclingTools,
+  cyclingCreateWorkoutInputSchema,
+} from "../src/tools.js";
 
 type CreateResult =
   | { ok: true; value: { id: number } }
@@ -21,11 +25,23 @@ function fakeIntervals(
   return { client, calls };
 }
 
-function createWorkoutTool(intervals: unknown) {
-  const tools = createCyclingTools({} as MemoryStore, intervals as never, "UTC");
+function createWorkoutTool(intervals: unknown, tz = "UTC") {
+  const tools = createCyclingTools({} as MemoryStore, intervals as never, tz);
   return (tools as Record<string, unknown>).intervals_create_workout as
     | { execute: (input: unknown, opts: unknown) => Promise<Record<string, unknown>> }
     | undefined;
+}
+
+function tomorrowISODate(): string {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() + 1);
+  return d.toISOString().slice(0, 10);
+}
+
+function futureISODate(days: number): string {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().slice(0, 10);
 }
 
 const validWorkout = {
@@ -43,13 +59,14 @@ describe("intervals_create_workout provenance", () => {
   it("payload carries external_id 'cycling-coach:<date>:<slug>' and tags ['cycling-coach']", async () => {
     const { client, calls } = fakeIntervals({ ok: true, value: { id: 42 } });
     const tool = createWorkoutTool(client)!;
+    const date = tomorrowISODate();
 
-    const out = await tool.execute({ date: "2026-06-21", workout: validWorkout }, {});
+    const out = await tool.execute({ date, workout: validWorkout }, {});
 
     expect(out).toEqual({ created: true, event: { id: 42 } });
     expect(calls).toHaveLength(1);
     const payload = calls[0];
-    expect(payload.external_id).toBe("cycling-coach:2026-06-21:z2-endurance-90min");
+    expect(payload.external_id).toBe(`cycling-coach:${date}:z2-endurance-90min`);
     expect(payload.tags).toEqual(["cycling-coach"]);
   });
 
@@ -57,7 +74,7 @@ describe("intervals_create_workout provenance", () => {
     const { client, calls } = fakeIntervals({ ok: true, value: { id: 1 } });
     const tool = createWorkoutTool(client)!;
 
-    await tool.execute({ date: "2026-06-21", workout: validWorkout }, {});
+    await tool.execute({ date: tomorrowISODate(), workout: validWorkout }, {});
 
     const payload = calls[0];
     expect(payload.type).toBe("Ride");
@@ -69,5 +86,126 @@ describe("intervals_create_workout provenance", () => {
   it("tool absent when no intervals client configured", () => {
     const tools = createCyclingTools({} as MemoryStore, null, "UTC");
     expect("intervals_create_workout" in tools).toBe(false);
+  });
+});
+
+describe("build_plan_skeleton purity", () => {
+  it("returns a plan and never calls savePlan", async () => {
+    const savePlan = vi.fn();
+    const tools = createCyclingTools({ savePlan } as unknown as MemoryStore, null, "UTC");
+    const result = await tools.build_plan_skeleton.execute!(
+      {
+        experienceLevel: "intermediate",
+        ftpWatts: 250,
+        volumeTier: "medium",
+        scheduleType: "flexible",
+        goalType: "general",
+        generalGoal: "build aerobic base",
+      },
+      {} as never,
+    );
+
+    expect(result).toMatchObject({ phases: expect.any(Array) });
+    expect(savePlan).not.toHaveBeenCalled();
+  });
+
+  it("description discloses that nothing is saved", () => {
+    const tools = createCyclingTools({} as MemoryStore, null, "UTC");
+    expect(tools.build_plan_skeleton.description).toContain("Does NOT save anything");
+  });
+});
+
+describe("build_plan_skeleton raceDate", () => {
+  const baseInput = {
+    experienceLevel: "intermediate" as const,
+    ftpWatts: 250,
+    volumeTier: "medium" as const,
+    scheduleType: "flexible" as const,
+    goalType: "race" as const,
+    raceType: "century" as const,
+  };
+
+  it("builds a finite plan for a valid future date", async () => {
+    const tools = createCyclingTools({} as MemoryStore, null, "UTC");
+    const result = (await tools.build_plan_skeleton.execute!(
+      { ...baseInput, raceDate: futureISODate(84) },
+      {} as never,
+    )) as { totalWeeks: number; name: string };
+    expect(Number.isFinite(result.totalWeeks)).toBe(true);
+    expect(result.name).not.toContain("NaN");
+  });
+
+  it("refuses an impossible calendar date", async () => {
+    const tools = createCyclingTools({} as MemoryStore, null, "UTC");
+    const result = await tools.build_plan_skeleton.execute!(
+      { ...baseInput, raceDate: "2026-02-31" },
+      {} as never,
+    );
+    expect(result).toMatchObject({ error: "invalid_date" });
+  });
+
+  it("rejects a prose race date at schema level", () => {
+    expect(
+      buildPlanSkeletonInputSchema.safeParse({ ...baseInput, raceDate: "June 15" }).success,
+    ).toBe(false);
+  });
+});
+
+describe("intervals_create_workout date guard", () => {
+  it("allows tomorrow and today", async () => {
+    const { client, calls } = fakeIntervals({ ok: true, value: { id: 42 } });
+    const tool = createWorkoutTool(client)!;
+    expect(
+      await tool.execute({ date: tomorrowISODate(), workout: validWorkout }, {}),
+    ).toMatchObject({ created: true });
+    expect(
+      await tool.execute({ date: todayInTZ("UTC"), workout: validWorkout }, {}),
+    ).toMatchObject({ created: true });
+    expect(calls).toHaveLength(2);
+  });
+
+  it("refuses a past date without calling events.create", async () => {
+    const { client, calls } = fakeIntervals({ ok: true, value: { id: 42 } });
+    const result = await createWorkoutTool(client)!.execute(
+      { date: "2020-01-01", workout: validWorkout },
+      {},
+    );
+    expect(result).toMatchObject({ error: "past_date_refused" });
+    expect(result.details).toContain("2020-01-01");
+    expect(result.details).toContain(todayInTZ("UTC"));
+    expect(calls).toHaveLength(0);
+  });
+
+  it("refuses an impossible date and rejects non-YYYY-MM-DD schema input", async () => {
+    const { client, calls } = fakeIntervals({ ok: true, value: { id: 42 } });
+    const result = await createWorkoutTool(client)!.execute(
+      { date: "2026-02-31", workout: validWorkout },
+      {},
+    );
+    expect(result).toMatchObject({ error: "invalid_date" });
+    expect(calls).toHaveLength(0);
+    expect(
+      cyclingCreateWorkoutInputSchema.safeParse({ date: "June 15", workout: validWorkout })
+        .success,
+    ).toBe(false);
+  });
+
+  it("uses the constructor timezone for the today boundary", async () => {
+    const date = todayInTZ("Pacific/Midway");
+    const midway = fakeIntervals({ ok: true, value: { id: 1 } });
+    const kiritimati = fakeIntervals({ ok: true, value: { id: 2 } });
+
+    expect(
+      await createWorkoutTool(midway.client, "Pacific/Midway")!.execute(
+        { date, workout: validWorkout },
+        {},
+      ),
+    ).toMatchObject({ created: true });
+    expect(
+      await createWorkoutTool(kiritimati.client, "Pacific/Kiritimati")!.execute(
+        { date, workout: validWorkout },
+        {},
+      ),
+    ).toMatchObject({ error: "past_date_refused" });
   });
 });

--- a/packages/sport-running/src/tools.ts
+++ b/packages/sport-running/src/tools.ts
@@ -1,7 +1,13 @@
 import { tool, zodSchema } from "ai";
 import { z } from "zod";
 import type { MemoryStore, ResolvedCs } from "@enduragent/core";
-import { COACH_EVENT_TAG, buildCoachExternalId } from "@enduragent/core";
+import {
+  COACH_EVENT_TAG,
+  buildCoachExternalId,
+  dateKeySchema,
+  isRealDateKey,
+  todayInTZ,
+} from "@enduragent/core";
 import type { IntervalsClient } from "intervals-icu-api";
 import {
   calculateRunningZones,
@@ -34,6 +40,19 @@ const RPE_FRAMING =
   "The single table carries individual and sex-specific spread; CS is a monitoring " +
   "anchor, not a hold-forever pace.";
 
+export const runningCreateWorkoutInputSchema = z.object({
+  date: dateKeySchema.describe("Workout date (YYYY-MM-DD)"),
+  workout: runningWorkoutInputSchema.describe(
+    "Structured workout: name + ordered steps. Top-level steps can be simple " +
+      "(warmup/steady/tempo/threshold/interval/repetition/strides/ramp/recovery/rest/cooldown) " +
+      "or a set {type:'set', repeat, interval, recovery}. Durations use time (seconds/minutes) " +
+      "or distance (meters/distance_km/distance_mi); a distance step needs a pace target. Pace " +
+      "targets: {kind:'zone'|'cs_fraction'|'pace', value} or {kind, low, high} for ranges. " +
+      "cs_fraction is a fraction of critical speed (1.0 = threshold). Absolute 'pace' is M:SS " +
+      "strings, slower-first for ranges. Ramps require low+high.",
+  ),
+});
+
 function clampLowerFraction(requested: number): { value: number; clamped: boolean } {
   const value = Math.min(LOWER_FRACTION_CLAMP.max, Math.max(LOWER_FRACTION_CLAMP.min, requested));
   return { value, clamped: value !== requested };
@@ -42,7 +61,7 @@ function clampLowerFraction(requested: number): { value: number; clamped: boolea
 export function createRunningTools(
   _memory: MemoryStore,
   intervals: IntervalsClient | null,
-  _tz: string = "UTC",
+  tz: string = "UTC",
   resolvedCs?: () => ResolvedCs | null,
 ) {
   return {
@@ -162,22 +181,22 @@ export function createRunningTools(
               "(meters/km/mi); a distance step needs a pace target so its planned time can be derived. For " +
               "every pushed workout, put the RPE-check + provenance framing, plus athlete-facing coaching " +
               "narrative (feel, RPE cues, target spm, hydration), in your chat reply — the calendar entry " +
-              "cannot carry it.",
-            inputSchema: zodSchema(
-              z.object({
-                date: z.string().describe("Workout date (YYYY-MM-DD)"),
-                workout: runningWorkoutInputSchema.describe(
-                  "Structured workout: name + ordered steps. Top-level steps can be simple " +
-                    "(warmup/steady/tempo/threshold/interval/repetition/strides/ramp/recovery/rest/cooldown) " +
-                    "or a set {type:'set', repeat, interval, recovery}. Durations use time (seconds/minutes) " +
-                    "or distance (meters/distance_km/distance_mi); a distance step needs a pace target. Pace " +
-                    "targets: {kind:'zone'|'cs_fraction'|'pace', value} or {kind, low, high} for ranges. " +
-                    "cs_fraction is a fraction of critical speed (1.0 = threshold). Absolute 'pace' is M:SS " +
-                    "strings, slower-first for ranges. Ramps require low+high.",
-                ),
-              }),
-            ),
+              "cannot carry it. Past dates are refused — workouts can only be created for today or later.",
+            inputSchema: zodSchema(runningCreateWorkoutInputSchema),
             execute: async (input: { date: string; workout: RunningWorkoutInput }) => {
+              if (!isRealDateKey(input.date)) {
+                return {
+                  error: "invalid_date",
+                  details: `${input.date} is not a real calendar date. Use YYYY-MM-DD.`,
+                };
+              }
+              const today = todayInTZ(tz);
+              if (input.date < today) {
+                return {
+                  error: "past_date_refused",
+                  details: `Cannot create a workout dated ${input.date} — it's before today (${today}). Use today's date or later.`,
+                };
+              }
               // The serializer stays pure: pass OUR resolved CS in so distance steps
               // with relative targets can derive their planned time.
               let serialized: ReturnType<typeof serializeRunningWorkout>;

--- a/packages/sport-running/tests/tools.test.ts
+++ b/packages/sport-running/tests/tools.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
-import type { MemoryStore, ResolvedCs } from "@enduragent/core";
-import { createRunningTools } from "../src/tools.js";
+import { todayInTZ, type MemoryStore, type ResolvedCs } from "@enduragent/core";
+import { createRunningTools, runningCreateWorkoutInputSchema } from "../src/tools.js";
 
 // The Vercel AI SDK wraps execute; call it directly with a stub options arg
 // (the running tool ignores options). Schema validation is the SDK's job at
@@ -144,16 +144,26 @@ function fakeIntervals(
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function createWorkoutTool(intervals: any, resolved: ResolvedCs | null = null) {
+function createWorkoutTool(
+  intervals: any,
+  resolved: ResolvedCs | null = null,
+  tz = "UTC",
+) {
   const tools = createRunningTools(
     {} as MemoryStore,
     intervals,
-    "UTC",
+    tz,
     resolved === null ? undefined : () => resolved,
   );
   return (tools as Record<string, unknown>).intervals_create_workout as
     | { execute: (input: unknown, opts: unknown) => Promise<Record<string, unknown>> }
     | undefined;
+}
+
+function tomorrowISODate(): string {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() + 1);
+  return d.toISOString().slice(0, 10);
 }
 
 describe("intervals_create_workout tool", () => {
@@ -171,10 +181,11 @@ describe("intervals_create_workout tool", () => {
   it("posts type:'Run', WORKOUT, the serialized description, no icu_training_load", async () => {
     const { client, calls } = fakeIntervals({ ok: true, value: { id: 42 } });
     const tool = createWorkoutTool(client)!;
+    const date = tomorrowISODate();
 
     const out = await tool.execute(
       {
-        date: "2026-06-21",
+        date,
         workout: {
           name: "Easy 30",
           steps: [{ type: "steady", duration: { value: 30, unit: "minutes" }, pace: { kind: "cs_fraction", value: 0.75 } }],
@@ -192,7 +203,7 @@ describe("intervals_create_workout tool", () => {
     expect(typeof payload.description).toBe("string");
     expect(payload.description).toContain("75% Pace");
     expect("icu_training_load" in payload).toBe(false);
-    expect(payload.external_id).toBe("cycling-coach:2026-06-21:easy-30");
+    expect(payload.external_id).toBe(`cycling-coach:${date}:easy-30`);
     expect(payload.tags).toEqual(["cycling-coach"]);
   });
 
@@ -206,7 +217,7 @@ describe("intervals_create_workout tool", () => {
 
     const out = await tool.execute(
       {
-        date: "2026-06-21",
+        date: tomorrowISODate(),
         workout: {
           name: "Manual CS 400s",
           steps: [{ type: "interval", duration: { value: 400, unit: "meters" }, pace: { kind: "cs_fraction", value: 1.06 } }],
@@ -226,7 +237,7 @@ describe("intervals_create_workout tool", () => {
 
     const out = await tool.execute(
       {
-        date: "2026-06-21",
+        date: tomorrowISODate(),
         workout: {
           name: "Bad",
           steps: [{ type: "ramp", duration: { value: 10, unit: "minutes" }, pace: { kind: "cs_fraction", value: 0.7 } }],
@@ -246,7 +257,7 @@ describe("intervals_create_workout tool", () => {
 
     const out = await tool.execute(
       {
-        date: "2026-06-21",
+        date: tomorrowISODate(),
         workout: {
           name: "Easy 30",
           steps: [{ type: "steady", duration: { value: 30, unit: "minutes" }, pace: { kind: "cs_fraction", value: 0.75 } }],
@@ -256,5 +267,55 @@ describe("intervals_create_workout tool", () => {
     );
 
     expect(out.error).toBe("rate_limited");
+  });
+});
+
+describe("intervals_create_workout date guard", () => {
+  const workout = {
+    name: "Easy 30",
+    steps: [
+      {
+        type: "steady" as const,
+        duration: { value: 30, unit: "minutes" as const },
+        pace: { kind: "cs_fraction" as const, value: 0.75 },
+      },
+    ],
+  };
+
+  it("allows tomorrow and today", async () => {
+    const { client, calls } = fakeIntervals({ ok: true, value: { id: 42 } });
+    const tool = createWorkoutTool(client)!;
+    expect(await tool.execute({ date: tomorrowISODate(), workout }, {})).toMatchObject({
+      created: true,
+    });
+    expect(await tool.execute({ date: todayInTZ("UTC"), workout }, {})).toMatchObject({
+      created: true,
+    });
+    expect(calls).toHaveLength(2);
+  });
+
+  it("refuses a past date without calling events.create", async () => {
+    const { client, calls } = fakeIntervals({ ok: true, value: { id: 42 } });
+    const result = await createWorkoutTool(client)!.execute(
+      { date: "2020-01-01", workout },
+      {},
+    );
+    expect(result).toMatchObject({ error: "past_date_refused" });
+    expect(result.details).toContain("2020-01-01");
+    expect(result.details).toContain(todayInTZ("UTC"));
+    expect(calls).toHaveLength(0);
+  });
+
+  it("refuses an impossible date and rejects non-YYYY-MM-DD schema input", async () => {
+    const { client, calls } = fakeIntervals({ ok: true, value: { id: 42 } });
+    const result = await createWorkoutTool(client)!.execute(
+      { date: "2026-02-31", workout },
+      {},
+    );
+    expect(result).toMatchObject({ error: "invalid_date" });
+    expect(calls).toHaveLength(0);
+    expect(
+      runningCreateWorkoutInputSchema.safeParse({ date: "June 15", workout }).success,
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
## What

Removes an undisclosed write, adds a deterministic date guard on workout creation, and tightens the tool-schema surface so model mistakes fail loudly instead of degrading silently.

- **Pure plan skeleton** — `build_plan_skeleton` no longer saves anything; the model must call `plan_save` explicitly after athlete approval. It is removed from the replay-unsafe / memory-mutating sets and joins the read-only (memoizable) set; its description now discloses it writes nothing.
- **Past-date create guard** — both sport packages refuse creating a workout dated before today (athlete timezone; today allowed) with a descriptive error, mirroring the existing delete guard. The running tool's timezone is now honored and its tests are date-relative.
- **Schema strictness pass** — activity ids accept the `i`-prefixed string form and pass through verbatim (event ids stay numeric); stream types are an enum; a shared date-schema helper enforces a date regex and a 366-day list-fetch cap; `memory_write` is object-rooted with a required-section guard (the silent whole-section `notes` overwrite fallback is gone); `plan_save` validates its headline fields at the write boundary while the plan read path stays tolerant.

## Test plan

- `pnpm check && pnpm test` green (206 files, 3097 passed / 3 skipped).
- New `date-schema.test.ts`, `intervals-tools-range-cap.test.ts`, `memory-tools-schema.test.ts`; updated fetch/read-memoizer/taint tests.
- Verify-command matrix (purity greps, guard behavior, schema shapes) all pass.
