### PR TITLE
perf(core): trim tool-schema payloads and pin toolset size ceilings

### DIFF
--- a/.changeset/tool-schema-payload-trim.md
+++ b/.changeset/tool-schema-payload-trim.md
@@ -1,0 +1,5 @@
+---
+"cycling-coach": patch
+---
+
+Trim serialized tool descriptions and add per-sport payload size regression ceilings.

--- a/packages/core/src/agent/tools.ts
+++ b/packages/core/src/agent/tools.ts
@@ -7,7 +7,7 @@ import { truncateUtf16Safe } from "../text-truncate.js";
 import { DATE_KEY_RE } from "./date-schema.js";
 
 function buildMemoryWriteDescription(sections: readonly MemorySectionSpec[]): string {
-  const sectionList = sections.map((s) => `${s.name} (${s.description})`).join("; ");
+  const sectionList = sections.map((s) => `${s.name} (${s.hint ?? s.description})`).join("; ");
   return (
     "Write to long-term memory (replaces section content) or daily notes. " +
     `Sections: ${sectionList}.`

--- a/packages/core/src/memory/shared-sections.ts
+++ b/packages/core/src/memory/shared-sections.ts
@@ -11,11 +11,13 @@ export const CORE_SHARED_SECTIONS: readonly MemorySectionSpec[] = [
     description:
       "Name, weight (kg), age, available training days per week. " +
       "Sport-specific physiology (FTP, VDOT, max HR) goes to the sport-prefixed profile section.",
+    hint: "name, weight, age, available training days",
     inject: true,
   },
   {
     name: "schedule",
     description: "Weekly training availability, time windows, blackout days",
+    hint: "weekly availability, time windows, blackout days",
     inject: true,
   },
   {
@@ -23,22 +25,26 @@ export const CORE_SHARED_SECTIONS: readonly MemorySectionSpec[] = [
     description:
       "Target events, race dates, fitness targets, milestones " +
       "(e.g., 'sub-3:30 century in October', 'reach 280W FTP by Q3')",
+    hint: "target events, race dates, fitness targets",
     inject: true,
   },
   {
     name: "preferences",
     description: "Coaching style, training environment, communication preferences",
+    hint: "coaching style, communication preferences",
     inject: true,
   },
   {
     name: "notes",
     description: "Anything else important not covered by other sections",
+    hint: "anything not covered by other sections",
     inject: false,
   },
   {
     name: "medical-history",
     description:
       "Chronic conditions, medications, long-term injuries — facts that persist across sports",
+    hint: "chronic conditions, medications, long-term injuries",
     inject: true,
   },
 ];

--- a/packages/core/src/sport.ts
+++ b/packages/core/src/sport.ts
@@ -37,6 +37,8 @@ export interface MemorySectionSpec {
   name: string;
   /** Description shown to the LLM in section headers + memory_write tool docs. */
   description: string;
+  /** Short routing discriminator for the chat memory_write catalog. Omitted = full description is used. */
+  hint?: string;
   /** Always inject into the system prompt's Athlete Context. Omitted = true. */
   inject?: boolean;
 }
@@ -172,4 +174,3 @@ export function mergeSportSkills(
   }
   return merged;
 }
-

--- a/packages/core/tests/toolset-token-ceiling.test.ts
+++ b/packages/core/tests/toolset-token-ceiling.test.ts
@@ -1,0 +1,69 @@
+import { asSchema } from "@ai-sdk/provider-utils";
+import { cyclingSport } from "@enduragent/sport-cycling";
+import {
+  CHARS_PER_TOKEN,
+  SAFETY_MARGIN,
+  createMemoryTools,
+  estimateTokens,
+  getEffectiveSections,
+  type CoreDeps,
+  type MemoryStore,
+  type ToolRegistration,
+} from "@enduragent/core";
+import { describe, expect, it } from "vitest";
+
+const deps = {
+  llm: null,
+  secrets: null,
+  intervals: {},
+  memory: {},
+  tz: "UTC",
+} as unknown as CoreDeps;
+
+async function serializeToolset(regs: readonly ToolRegistration[]): Promise<string> {
+  const parts = await Promise.all(
+    regs.map(async (r) => {
+      const t = r.tool as { description?: string; inputSchema: never };
+      const schema = await Promise.resolve(asSchema(t.inputSchema).jsonSchema);
+      return JSON.stringify({ name: r.name, description: t.description ?? "", schema });
+    }),
+  );
+  return parts.join("\n");
+}
+
+// Serialized-toolset budget guard (name + description + JSON schema per tool,
+// the payload that rides position 0 of every request on every step). Pinned
+// ~10% above the measured post-trim toolset; growth past it must be deliberate.
+const CYCLING_TOOLSET_CHAR_CEILING = 17_500;
+
+describe("cycling chat toolset serialized-size ceiling", () => {
+  it("keeps the full 17-tool cycling toolset under the ceiling", async () => {
+    const serialized = await serializeToolset(cyclingSport.tools(deps));
+    expect(serialized.length).toBeLessThan(CYCLING_TOOLSET_CHAR_CEILING);
+    expect(estimateTokens(serialized)).toBeLessThan(
+      Math.ceil((CYCLING_TOOLSET_CHAR_CEILING / CHARS_PER_TOKEN) * SAFETY_MARGIN),
+    );
+  });
+
+  it("measures a real toolset, not a stub", async () => {
+    const regs = cyclingSport.tools(deps);
+    expect(regs.length).toBeGreaterThanOrEqual(17);
+    expect((await serializeToolset(regs)).length).toBeGreaterThan(8_000);
+  });
+});
+
+describe("memory_write section catalog", () => {
+  it("names every effective cycling section in ≤700 chars", async () => {
+    const sections = getEffectiveSections(cyclingSport);
+    const description = createMemoryTools(deps.memory, sections).memory_write.description ?? "";
+    for (const section of sections) expect(description).toContain(section.name);
+    expect(description.length).toBeLessThanOrEqual(700);
+  });
+
+  it("falls back to the full description when a section has no hint", () => {
+    const description = createMemoryTools({} as MemoryStore, [
+      { name: "goals", description: "Athlete goals" },
+    ]).memory_write.description;
+    expect(description).toContain("Athlete goals");
+  });
+});

--- a/packages/sport-cycling/src/sport.ts
+++ b/packages/sport-cycling/src/sport.ts
@@ -39,11 +39,13 @@ const memorySections: readonly MemorySectionSpec[] = [
     description:
       "FTP (watts), max HR, resting HR, W/kg ratio, experience level. " +
       "Body data lives in `person`; this is cycling-specific physiology.",
+    hint: "FTP, max/resting HR, W/kg, experience level",
     inject: true,
   },
   {
     name: "cycling-equipment",
     description: "Bikes, trainer, power meter, head unit, indoor setup",
+    hint: "bikes, trainer, power meter, sensors",
     inject: false,
   },
   {
@@ -52,6 +54,7 @@ const memorySections: readonly MemorySectionSpec[] = [
       "Cycling-specific injuries (knee, lower back, fit issues), FTP test history, " +
       "recovery patterns from rides, ride-related sleep/HRV trends. " +
       "Chronic conditions belong in `medical-history`, not here.",
+    hint: "cycling injuries, FTP test history, ride recovery patterns",
     inject: false,
   },
 ];

--- a/packages/sport-cycling/src/tools.ts
+++ b/packages/sport-cycling/src/tools.ts
@@ -51,7 +51,7 @@ export const buildPlanSkeletonInputSchema = z.object({
 export const cyclingCreateWorkoutInputSchema = z.object({
   date: dateKeySchema.describe("Workout date (YYYY-MM-DD)"),
   workout: intervalsWorkoutInputSchema.describe(
-    "Structured workout: name + ordered steps. Top-level steps can be simple (warmup/steady/interval/ramp/recovery/rest/cooldown/freeride) or a set {type:'set', repeat, interval, recovery}. Durations use seconds or minutes only. Power targets: {kind:'percent_ftp'|'watts'|'zone', value} or {kind, low, high} for ranges. Ramps require low+high.",
+    "Structured workout: name + ordered steps — simple steps or repeat sets. Use value for a single power target, or low+high for ranges; ramps require low+high. Durations are seconds or minutes only.",
   ),
 });
 
@@ -165,10 +165,7 @@ export function createCyclingTools(
       ? {
           intervals_create_workout: tool({
             description:
-              "Create a structured workout on the intervals.icu calendar. Auto-syncs to Garmin/Wahoo. " +
-              "Supply the workout as structured steps — the tool serializes them into the intervals.icu " +
-              "native description syntax so the power chart renders. Put athlete-facing coaching narrative " +
-              "(feel, notes, hydration) in your chat reply, not in this tool. Past dates are refused — workouts can only be created for today or later.",
+              "Create a structured workout on the intervals.icu calendar (auto-syncs to Garmin/Wahoo). Supply structured steps — they serialize into intervals.icu's native syntax so the power chart renders. Put athlete-facing coaching narrative (feel, notes, hydration) in your chat reply, not in this tool. Past dates are refused — workouts can only be created for today or later.",
             inputSchema: zodSchema(cyclingCreateWorkoutInputSchema),
             execute: async (input: { date: string; workout: IntervalsWorkoutInput }) => {
               if (!isRealDateKey(input.date)) {

--- a/packages/sport-running/src/sport.ts
+++ b/packages/sport-running/src/sport.ts
@@ -38,11 +38,13 @@ const memorySections: readonly MemorySectionSpec[] = [
     description:
       "Critical speed (CS), threshold pace, max HR, resting HR, experience level. " +
       "Body data lives in `person`; this is running-specific physiology.",
+    hint: "critical speed, threshold pace, HRs, experience level",
     inject: true,
   },
   {
     name: "running-equipment",
     description: "Shoes (model, mileage), GPS watch, treadmill, racing flats",
+    hint: "shoes, GPS watch, treadmill",
     inject: false,
   },
   {
@@ -50,6 +52,7 @@ const memorySections: readonly MemorySectionSpec[] = [
     description:
       "Running-specific injuries (shin splints, IT band, plantar, calf, Achilles), CS/threshold " +
       "test history, recovery patterns from runs. Chronic conditions belong in `medical-history`, not here.",
+    hint: "running injuries, CS test history, run recovery patterns",
     inject: false,
   },
 ];

--- a/packages/sport-running/src/tools.ts
+++ b/packages/sport-running/src/tools.ts
@@ -43,13 +43,7 @@ const RPE_FRAMING =
 export const runningCreateWorkoutInputSchema = z.object({
   date: dateKeySchema.describe("Workout date (YYYY-MM-DD)"),
   workout: runningWorkoutInputSchema.describe(
-    "Structured workout: name + ordered steps. Top-level steps can be simple " +
-      "(warmup/steady/tempo/threshold/interval/repetition/strides/ramp/recovery/rest/cooldown) " +
-      "or a set {type:'set', repeat, interval, recovery}. Durations use time (seconds/minutes) " +
-      "or distance (meters/distance_km/distance_mi); a distance step needs a pace target. Pace " +
-      "targets: {kind:'zone'|'cs_fraction'|'pace', value} or {kind, low, high} for ranges. " +
-      "cs_fraction is a fraction of critical speed (1.0 = threshold). Absolute 'pace' is M:SS " +
-      "strings, slower-first for ranges. Ramps require low+high.",
+    "Structured workout: name + ordered steps — simple steps or repeat sets. Durations are time (seconds/minutes) or distance (meters/distance_km/distance_mi); a distance step needs a pace target. Pace targets: {kind, value} or {kind, low, high} for ranges; cs_fraction is a fraction of critical speed (1.0 = threshold); absolute 'pace' is M:SS strings, slower-first for ranges. Ramps require low+high.",
   ),
 });
 
@@ -67,17 +61,7 @@ export function createRunningTools(
   return {
     calculate_zones: tool({
       description:
-        "Calculate 6 critical-speed-anchored running pace zones. When the athlete's " +
-        "critical speed is synced from intervals.icu, OMIT criticalSpeedMps — the tool " +
-        "uses the synced anchor automatically and reports its provenance. Pass " +
-        "criticalSpeedMps (in m/s; intervals.icu stores threshold_pace in SI m/s, e.g. " +
-        "4.0 m/s ≈ 4:10/km) only to override the synced value — a coach-entered number " +
-        "or a hypothetical. An explicit value outranks the synced anchor; a manual " +
-        "lower-boundary override is clamped and the clamp is disclosed. Returns zones " +
-        "plus real source/confidence fields — surface the RPE-checked estimate framing " +
-        "to the athlete; never present these as lab-measured thresholds. If no critical " +
-        "speed is synced or supplied, the tool returns a no_cs_anchor error — ask the " +
-        "athlete for a recent CS / threshold test rather than guessing.",
+        "Calculate 6 critical-speed-anchored running pace zones. When the athlete's critical speed is synced from intervals.icu, OMIT criticalSpeedMps — the synced anchor is used and its provenance reported; pass a value only to override it. Returns zones plus source/confidence fields — surface the RPE-checked-estimate framing to the athlete; never present these as lab-measured thresholds. If no critical speed is synced or supplied, the tool returns a no_cs_anchor error — ask the athlete for a recent CS/threshold test rather than guessing.",
       inputSchema: zodSchema(
         z.object({
           criticalSpeedMps: z
@@ -168,20 +152,7 @@ export function createRunningTools(
       ? {
           intervals_create_workout: tool({
             description:
-              "Create a structured running workout on the intervals.icu calendar (auto-syncs to " +
-              "Garmin/Wahoo). Supply the workout as structured steps — the tool serializes them into " +
-              "intervals.icu's native pace syntax so the pace chart renders and the server computes load " +
-              "against the athlete's own threshold pace. Anchor pace targets on the critical-speed zones " +
-              "(kind:'zone' 1-6, or kind:'cs_fraction') — these are RPE-checked estimates from a " +
-              "population-mean model, not lab-measured thresholds. If the athlete's critical speed is a " +
-              "manual/coach-entered override, prefer absolute kind:'pace' targets so the prescription " +
-              "matches the zone table you showed them. Strides are a neuromuscular drill — prescribe them " +
-              "as a duration-only step (or with a relaxed-fast kind:'pace'), never a CS zone. Do not invent " +
-              "a pace the resolved CS doesn't support. Durations may be time (seconds/minutes) or distance " +
-              "(meters/km/mi); a distance step needs a pace target so its planned time can be derived. For " +
-              "every pushed workout, put the RPE-check + provenance framing, plus athlete-facing coaching " +
-              "narrative (feel, RPE cues, target spm, hydration), in your chat reply — the calendar entry " +
-              "cannot carry it. Past dates are refused — workouts can only be created for today or later.",
+              "Create a structured running workout on the intervals.icu calendar (auto-syncs to Garmin/Wahoo). Steps serialize into intervals.icu's native pace syntax; the server computes load against the athlete's threshold pace. Anchor pace targets on the critical-speed zones (kind:'zone' 1-6 or kind:'cs_fraction') — RPE-checked estimates, not lab-measured thresholds. If the athlete's critical speed is a manual/coach-entered override, prefer absolute kind:'pace' targets so the prescription matches the zone table you showed them. Prescribe strides as a duration-only step (or a relaxed-fast kind:'pace'), never a CS zone; do not invent a pace the resolved CS doesn't support. A distance step needs a pace target so its planned time can be derived. Put the RPE-check + provenance framing and coaching narrative in your chat reply — the calendar entry cannot carry it. Past dates are refused — workouts can only be created for today or later.",
             inputSchema: zodSchema(runningCreateWorkoutInputSchema),
             execute: async (input: { date: string; workout: RunningWorkoutInput }) => {
               if (!isRealDateKey(input.date)) {

--- a/packages/sport-running/tests/toolset-token-ceiling.test.ts
+++ b/packages/sport-running/tests/toolset-token-ceiling.test.ts
@@ -1,0 +1,50 @@
+import { asSchema } from "ai";
+import {
+  CHARS_PER_TOKEN,
+  SAFETY_MARGIN,
+  estimateTokens,
+  type CoreDeps,
+  type ToolRegistration,
+} from "@enduragent/core";
+import { describe, expect, it } from "vitest";
+import { runningSport } from "../src/sport.js";
+
+const deps = {
+  llm: null,
+  secrets: null,
+  intervals: {},
+  memory: {},
+  tz: "UTC",
+} as unknown as CoreDeps;
+
+async function serializeToolset(regs: readonly ToolRegistration[]): Promise<string> {
+  const parts = await Promise.all(
+    regs.map(async (r) => {
+      const t = r.tool as { description?: string; inputSchema: never };
+      const schema = await Promise.resolve(asSchema(t.inputSchema).jsonSchema);
+      return JSON.stringify({ name: r.name, description: t.description ?? "", schema });
+    }),
+  );
+  return parts.join("\n");
+}
+
+// Serialized-toolset budget guard (name + description + JSON schema per tool,
+// the payload that rides position 0 of every request on every step). Pinned
+// ~10% above the measured post-trim toolset; growth past it must be deliberate.
+const RUNNING_TOOLSET_CHAR_CEILING = 16_500;
+
+describe("running chat toolset serialized-size ceiling", () => {
+  it("keeps the full 14-tool running toolset under the ceiling", async () => {
+    const serialized = await serializeToolset(runningSport.tools(deps));
+    expect(serialized.length).toBeLessThan(RUNNING_TOOLSET_CHAR_CEILING);
+    expect(estimateTokens(serialized)).toBeLessThan(
+      Math.ceil((RUNNING_TOOLSET_CHAR_CEILING / CHARS_PER_TOKEN) * SAFETY_MARGIN),
+    );
+  });
+
+  it("measures a real toolset, not a stub", async () => {
+    const regs = runningSport.tools(deps);
+    expect(regs.length).toBeGreaterThanOrEqual(14);
+    expect((await serializeToolset(regs)).length).toBeGreaterThan(6_000);
+  });
+});


### PR DESCRIPTION
## What

Trims the serialized tool-schema payload that rides position 0 of every request, and pins a regression ceiling so the toolset size can't silently balloon again. Routing quality is preserved: full memory-section descriptions and the flush catalog are untouched; only the chat catalog swaps in short per-section routing hints.

- `MemorySectionSpec` gains an optional `hint`; the chat tool catalog uses `hint ?? description` while the flush catalog and the section descriptions themselves are byte-identical (flush routing unchanged).
- Cycling create and running zone/create tool descriptions trimmed, each keeping the "Past dates are refused" disclosure and every domain rule / section name.
- Two new toolset-size ceiling tests assert the real serialized size against a pinned ceiling (measured × 1.1, rounded up to 500), using shared chars-per-token constants rather than a bare divisor.

## Measured payload (name + description + JSON-schema serialization per tool)

| Toolset | Before | After | Ceiling pinned |
|---|---|---|---|
| Cycling (17 tools) | 16,488 chars (~4,122 tok) | 15,810 chars (~3,953 tok) | 17,500 chars |
| Running (14 tools) | 16,010 chars (~4,003 tok) | 14,729 chars (~3,682 tok) | 16,500 chars |

Approximate tokens are chars/4. The ceilings sit ~10% above the current measured size so incidental growth passes but a regression trips the test.

## Test plan

- `pnpm check && pnpm test` green (208 files, 3,103 passed / 3 skipped).
- New `toolset-token-ceiling.test.ts` (core + running) assert size ≤ ceiling non-vacuously.
- Flush-outcome, memory-query, and inject-tiering suites unchanged and green (routing preserved).
