### PR TITLE
feat(sport-cycling): translate zone ramps and drop client calendar estimates

### DIFF
--- a/.changeset/calendar-payload-zone-ramps.md
+++ b/.changeset/calendar-payload-zone-ramps.md
@@ -1,0 +1,5 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Zone-based warmup ramps now render on the calendar power chart, and planned duration and Load for pushed workouts are derived by intervals.icu from the steps themselves.

--- a/packages/sport-cycling/skills/intervals-icu.md
+++ b/packages/sport-cycling/skills/intervals-icu.md
@@ -117,10 +117,9 @@ Rules:
 - Zone targets accept integers 1–7 — the athlete's configured 7-zone bands (Z4 = Threshold,
   not sweet spot). `Z2` defaults to the power zone for Ride workouts. Use a zone integer only
   when `percent_ftp` is genuinely unavailable.
-- Ramps are most reliably expressed as `percent_ftp` ranges (e.g. `low: 55, high: 75`). Zone-based
-  ramps may not render — prefer `percent_ftp` for warmup ramps.
+- Ramps accept `percent_ftp`, `watts`, or `zone` bounds. Zone-kind ramps are translated at serialization to percent-of-FTP band centers (Z1→45%, Z2→65%, Z3→83%, Z4→98%, Z5→113%, Z6→136%, Z7→160% — e.g. `Z1-Z2` becomes `ramp 45-65%`), so the power chart always renders. Use explicit `percent_ftp` bounds when you want exact ramp endpoints.
 - Durations are time-only: `seconds` or `minutes`. Distance-based workouts are not supported here.
-- `moving_time` and `icu_training_load` are computed from the steps — do not pass them.
+- The tool sends only the date, name, and serialized step description — intervals.icu derives the planned duration and Load from the parsed steps. Never supply duration or Load estimates yourself.
 
 ### Example: Z2 endurance 90min
 

--- a/packages/sport-cycling/src/intervals-serializer.ts
+++ b/packages/sport-cycling/src/intervals-serializer.ts
@@ -61,10 +61,6 @@ function toSeconds(d: DurationInput): number {
   return d.unit === "seconds" ? d.value : d.value * 60;
 }
 
-function mid(a: number | undefined, b: number | undefined): number | undefined {
-  return a !== undefined && b !== undefined ? (a + b) / 2 : undefined;
-}
-
 function formatDuration(d: DurationInput): string {
   const total = Math.round(toSeconds(d));
   if (total < 60) return `${total}s`;
@@ -110,7 +106,12 @@ function formatPower(p: PowerTarget, isRamp: boolean, path: string): string {
     if (p.kind === "zone") {
       assertZone(p.low!, `${path}.power.low`);
       assertZone(p.high!, `${path}.power.high`);
-      return `${prefix}Z${p.low}-Z${p.high}`;
+      if (isRamp) {
+        const lowPct = Math.round(ZONE_INTENSITY_MIDPOINTS[p.low!]! * 100);
+        const highPct = Math.round(ZONE_INTENSITY_MIDPOINTS[p.high!]! * 100);
+        return `${prefix}${lowPct}-${highPct}%`;
+      }
+      return `Z${p.low}-Z${p.high}`;
     }
     if (p.kind === "percent_ftp") return `${prefix}${p.low}-${p.high}%`;
     return `${prefix}${p.low}-${p.high}w`;
@@ -191,48 +192,6 @@ function walkSimpleSteps(
   for (const s of steps) go(s, 1);
 }
 
-function intensityFor(step: SimpleStep, ftpWatts: number | undefined): number | undefined {
-  if (!step.power) return 0;
-  const p = step.power;
-
-  if (p.kind === "zone") {
-    const z = p.value ?? mid(p.low, p.high);
-    if (z === undefined) return undefined;
-    const lo = ZONE_INTENSITY_MIDPOINTS[Math.floor(z)];
-    const hi = ZONE_INTENSITY_MIDPOINTS[Math.ceil(z)];
-    if (lo === undefined || hi === undefined) return undefined;
-    return (lo + hi) / 2;
-  }
-
-  if (p.kind === "percent_ftp") {
-    const pct = p.value ?? mid(p.low, p.high);
-    return pct === undefined ? undefined : pct / 100;
-  }
-
-  if (ftpWatts === undefined) return undefined;
-  const w = p.value ?? mid(p.low, p.high);
-  return w === undefined ? undefined : w / ftpWatts;
-}
-
-function computeLoad(steps: AnyStep[], ftpWatts: number | undefined): number | undefined {
-  let sum = 0;
-  let anyPower = false;
-  let wattsNoFtp = false;
-
-  walkSimpleSteps(steps, (step, multiplier) => {
-    const intensity = intensityFor(step, ftpWatts);
-    if (intensity === undefined) {
-      if (step.power?.kind === "watts") wattsNoFtp = true;
-      return;
-    }
-    if (intensity > 0) anyPower = true;
-    sum += toSeconds(step.duration) * multiplier * intensity * intensity;
-  });
-
-  if (wattsNoFtp || !anyPower) return undefined;
-  return Math.round((sum / 3600) * 100);
-}
-
 function totalSeconds(steps: AnyStep[]): number {
   let total = 0;
   walkSimpleSteps(steps, (step, multiplier) => {
@@ -243,8 +202,7 @@ function totalSeconds(steps: AnyStep[]): number {
 
 export function serializeIntervalsWorkout(
   input: IntervalsWorkoutInput,
-  ftpWatts?: number,
-): { description: string; movingTime: number; trainingLoad: number | undefined } {
+): { description: string; movingTime: number } {
   // Defense in depth: tool callers already pass a parsed object via zodSchema(),
   // but direct callers (tests, future library use) may not. Wrap ZodError so
   // both paths surface as InvalidWorkoutError to consumers.
@@ -278,6 +236,5 @@ export function serializeIntervalsWorkout(
   return {
     description: lines.join("\n"),
     movingTime: totalSeconds(checked.steps),
-    trainingLoad: computeLoad(checked.steps, ftpWatts),
   };
 }

--- a/packages/sport-cycling/src/tools.ts
+++ b/packages/sport-cycling/src/tools.ts
@@ -197,8 +197,6 @@ export function createCyclingTools(
                 type: "Ride",
                 external_id: buildCoachExternalId(input.date, input.workout.name),
                 tags: [COACH_EVENT_TAG],
-                moving_time: serialized.movingTime,
-                icu_training_load: serialized.trainingLoad,
                 description: serialized.description,
               });
               if (!result.ok) return { error: result.error.kind };

--- a/packages/sport-cycling/src/zones.ts
+++ b/packages/sport-cycling/src/zones.ts
@@ -58,12 +58,10 @@ export const ZONE_DESCRIPTIONS: Record<string, string> = {
   "Z5 VO2max": "High intensity intervals, 3-8 minute efforts",
 };
 
-// Zone intensity midpoints as a fraction of FTP, keyed to the mainstream 7-zone
-// Coggan model intervals.icu resolves serialized targets against (Z4 Threshold,
-// Z5 VO2max, Z6 Anaerobic, Z7 Neuromuscular). Each index is the band-center of
-// the athlete's Z<n> band, so the calendar Load estimate for a `kind: "zone"`
-// target agrees with the band a rendered `Z<n>` step actually demands. Sweet
-// spot (88-94% FTP) is a named sub-range, accessed by percent, not a zone index.
+// Zone intensity midpoints as a fraction of FTP, codifying the band-center
+// semantics of the mainstream 7-zone model. The serializer uses these centers
+// to translate zone-kind ramps into percent-of-FTP bounds. Sweet spot (88-94%
+// FTP) is a named sub-range, accessed by percent, not a zone index.
 export const ZONE_INTENSITY_MIDPOINTS: Record<number, number> = {
   1: 0.45,
   2: 0.65,

--- a/packages/sport-cycling/tests/intervals-serializer.test.ts
+++ b/packages/sport-cycling/tests/intervals-serializer.test.ts
@@ -255,70 +255,116 @@ describe("serializeIntervalsWorkout — movingTime", () => {
   });
 });
 
-describe("serializeIntervalsWorkout — trainingLoad", () => {
-  it("computes load ≈ 40 for a pure Z2 60min ride", () => {
-    const input: IntervalsWorkoutInput = {
-      name: "Z2 60min",
+describe("serializeIntervalsWorkout — zone-ramp translation", () => {
+  it("translates a zone-kind ramp to percent-of-FTP band centers", () => {
+    const result = serializeIntervalsWorkout({
+      name: "Zone ramp",
+      steps: [
+        {
+          type: "ramp",
+          duration: { value: 10, unit: "minutes" },
+          power: { kind: "zone", low: 1, high: 2 },
+        },
+      ],
+    });
+
+    expect(result.description).toContain("- 10m ramp 45-65%");
+    expect(result.description).not.toMatch(/ramp Z/);
+    expect(result).toEqual({ description: "Main set\n- 10m ramp 45-65%", movingTime: 600 });
+  });
+
+  it("rounds the Z6 half-percent band center", () => {
+    const { description } = serializeIntervalsWorkout({
+      name: "High zone ramp",
+      steps: [
+        {
+          type: "ramp",
+          duration: { value: 1, unit: "minutes" },
+          power: { kind: "zone", low: 6, high: 7 },
+        },
+      ],
+    });
+
+    expect(description).toContain("ramp 136-160%");
+  });
+
+  it("emits equal bounds for an equal-zone ramp", () => {
+    const { description } = serializeIntervalsWorkout({
+      name: "Equal zone ramp",
+      steps: [
+        {
+          type: "ramp",
+          duration: { value: 5, unit: "minutes" },
+          power: { kind: "zone", low: 2, high: 2 },
+        },
+      ],
+    });
+
+    expect(description).toContain("ramp 65-65%");
+  });
+
+  it("leaves non-ramp zone ranges in Z form", () => {
+    const { description } = serializeIntervalsWorkout({
+      name: "Zone range",
       steps: [
         {
           type: "steady",
-          duration: { value: 60, unit: "minutes" },
-          power: { kind: "percent_ftp", value: 65 },
+          duration: { value: 30, unit: "minutes" },
+          power: { kind: "zone", low: 2, high: 3 },
         },
       ],
-    };
+    });
 
-    const { trainingLoad } = serializeIntervalsWorkout(input);
-    // 60min at 65% FTP: intensity=0.65, load = 3600 * 0.65^2 / 3600 * 100 = 42.25 → 42
-    expect(trainingLoad).toBe(42);
+    expect(description).toContain("- 30m Z2-Z3");
   });
 
-  it("returns undefined when any step uses watts and ftpWatts is missing", () => {
-    const input: IntervalsWorkoutInput = {
-      name: "Watts workout",
+  it("still rejects a zone ramp missing low/high", () => {
+    const input = {
+      name: "Missing bounds",
       steps: [
         {
-          type: "steady",
-          duration: { value: 60, unit: "minutes" },
-          power: { kind: "watts", value: 200 },
+          type: "ramp" as const,
+          duration: { value: 10, unit: "minutes" as const },
+          power: { kind: "zone" as const, value: 2 },
         },
       ],
     };
 
-    const { trainingLoad } = serializeIntervalsWorkout(input);
-    expect(trainingLoad).toBeUndefined();
+    expect(() => serializeIntervalsWorkout(input)).toThrow(InvalidWorkoutError);
+    expect(() => serializeIntervalsWorkout(input)).toThrow(
+      /ramp requires power\.low and power\.high/,
+    );
   });
 
-  it("computes load from watts when ftpWatts is provided", () => {
-    const input: IntervalsWorkoutInput = {
-      name: "Watts workout",
+  it("still rejects out-of-range zone bounds on a ramp", () => {
+    const input = {
+      name: "Invalid zone ramp",
       steps: [
         {
-          type: "steady",
-          duration: { value: 60, unit: "minutes" },
-          power: { kind: "watts", value: 200 },
+          type: "ramp" as const,
+          duration: { value: 10, unit: "minutes" as const },
+          power: { kind: "zone" as const, low: 1, high: 8 },
         },
       ],
     };
 
-    const { trainingLoad } = serializeIntervalsWorkout(input, 200);
-    // intensity = 200/200 = 1.0, load = 100
-    expect(trainingLoad).toBe(100);
+    expect(() => serializeIntervalsWorkout(input)).toThrow(InvalidWorkoutError);
+    expect(() => serializeIntervalsWorkout(input)).toThrow(/zone must be an integer/);
   });
 
-  it("returns undefined when no step has a power target", () => {
-    const input: IntervalsWorkoutInput = {
-      name: "Freeride",
+  it("still rejects an inverted zone ramp", () => {
+    const input = {
+      name: "Inverted zone ramp",
       steps: [
         {
-          type: "freeride",
-          duration: { value: 60, unit: "minutes" },
+          type: "ramp" as const,
+          duration: { value: 10, unit: "minutes" as const },
+          power: { kind: "zone" as const, low: 5, high: 1 },
         },
       ],
     };
 
-    const { trainingLoad } = serializeIntervalsWorkout(input);
-    expect(trainingLoad).toBeUndefined();
+    expect(() => serializeIntervalsWorkout(input)).toThrow(InvalidWorkoutError);
   });
 });
 

--- a/packages/sport-cycling/tests/tools.test.ts
+++ b/packages/sport-cycling/tests/tools.test.ts
@@ -89,6 +89,78 @@ describe("intervals_create_workout provenance", () => {
   });
 });
 
+describe("intervals_create_workout payload (calendar-payload group)", () => {
+  it("posts Ride, WORKOUT, name, and serialized description without client-derived fields", async () => {
+    const { client, calls } = fakeIntervals({ ok: true, value: { id: 42 } });
+    const tool = createWorkoutTool(client)!;
+
+    await tool.execute({ date: tomorrowISODate(), workout: validWorkout }, {});
+
+    const payload = calls[0];
+    expect(payload.type).toBe("Ride");
+    expect(payload.category).toBe("WORKOUT");
+    expect(payload.name).toBe("Z2 Endurance 90min");
+    expect(typeof payload.description).toBe("string");
+    expect("moving_time" in payload).toBe(false);
+    expect("icu_training_load" in payload).toBe(false);
+  });
+
+  it("pushes a zone-ramp workout with translated percent bounds", async () => {
+    const { client, calls } = fakeIntervals({ ok: true, value: { id: 42 } });
+    const tool = createWorkoutTool(client)!;
+    const workout = {
+      name: "Zone ramp",
+      steps: [
+        {
+          type: "ramp" as const,
+          duration: { value: 10, unit: "minutes" as const },
+          power: { kind: "zone" as const, low: 1, high: 2 },
+        },
+      ],
+    };
+
+    await tool.execute({ date: tomorrowISODate(), workout }, {});
+
+    expect(calls[0].description).toContain("ramp 45-65%");
+  });
+
+  it("returns invalid_workout without calling events.create on a serialization failure", async () => {
+    const { client, calls } = fakeIntervals({ ok: true, value: { id: 42 } });
+    const tool = createWorkoutTool(client)!;
+    const workout = {
+      name: "Invalid ramp",
+      steps: [
+        {
+          type: "ramp" as const,
+          duration: { value: 10, unit: "minutes" as const },
+          power: { kind: "zone" as const, value: 2 },
+        },
+      ],
+    };
+
+    const result = await tool.execute({ date: tomorrowISODate(), workout }, {});
+
+    expect(result).toMatchObject({ error: "invalid_workout" });
+    expect(calls).toHaveLength(0);
+  });
+
+  it("surfaces the API error kind when events.create fails", async () => {
+    const { client, calls } = fakeIntervals({
+      ok: false,
+      error: { kind: "rate_limited" },
+    });
+    const tool = createWorkoutTool(client)!;
+
+    const result = await tool.execute(
+      { date: tomorrowISODate(), workout: validWorkout },
+      {},
+    );
+
+    expect(result).toEqual({ error: "rate_limited" });
+    expect(calls).toHaveLength(1);
+  });
+});
+
 describe("build_plan_skeleton purity", () => {
   it("returns a plan and never calls savePlan", async () => {
     const savePlan = vi.fn();


### PR DESCRIPTION
## What

Two fixes to how cycling workouts are pushed to the calendar:

1. **Zone-kind ramps now render.** A ramp with `{kind: "zone", low: 1, high: 2}` used to serialize as `ramp Z1-Z2`, which the platform can't chart — the power trace showed up flat or partial. It now translates to percent-of-FTP band centers at serialization (`ramp 45-65%`), so every ramp renders on the head unit.
2. **Drop client-derived planned Load and duration.** The create payload no longer sends `moving_time` or `icu_training_load` — the platform is the source of truth for its own derived planned values, computed from the serialized steps.

## Why

The zone-ramp gap was a silent degradation at exactly the trust-forming moment — an athlete's first pushed workout showing a broken power chart. And shipping our own planned-Load estimate alongside the platform's meant two numbers that could disagree; the platform's derivation wins.

## How

- **Ramp translation** (`intervals-serializer.ts`): zone-kind ramps map through `ZONE_INTENSITY_MIDPOINTS` band centers with integer rounding — Z1→45, Z2→65, Z3→83, Z4→98, Z5→113, Z6→136, Z7→160 (all under the 200% sanity cap). Non-ramp zone ranges keep their `Z<a>-Z<b>` form; single-zone targets stay `Z<n>`. Existing ramp validation (missing range, inverted bounds, integer-zone) still fires first.
- **Serializer trim**: `serializeIntervalsWorkout` now returns `{ description, movingTime }`; the Load estimate (`computeLoad`/`intensityFor`) and the `ftpWatts` parameter are removed.
- **Payload**: the two fields are dropped from the cycling `events.create` call; every sibling field from prior work — coach-ownership markers (`external_id`, `tags`), the past-date create guard, and the host-confirmation gate — is preserved.
- Zone-midpoint doc comment and the athlete-facing skill guidance are updated to describe the translation.
- The running lane is deliberately untouched (its `moving_time` is live-probe verified).

## Verification

`pnpm check && pnpm test` green (210 files, 3146 tests). New coverage exercises the previously-untested `ramp Z` path, the fractional Z6 midpoint rounding, degenerate equal-zone ramps, and confirms the payload carries neither dropped field while siblings survive.

User-facing: Zone-based warmup ramps now render on the calendar power chart, and planned duration and Load for pushed workouts are derived by intervals.icu from the steps themselves.
