### PR TITLE
refactor(core): dedup Batch 11 date guards, confirmation-gate helpers, coach-event provenance

### DIFF
--- a/.changeset/batch-11-simplify-cleanups.md
+++ b/.changeset/batch-11-simplify-cleanups.md
@@ -1,0 +1,7 @@
+---
+"@enduragent/core": patch
+"@enduragent/sport-cycling": patch
+"@enduragent/sport-running": patch
+---
+
+Refactor shared workout-date validation, confirmation outcomes, proposal lookup, event provenance, and sport tool construction without changing behavior.

--- a/packages/core/src/agent/confirmation-gate.ts
+++ b/packages/core/src/agent/confirmation-gate.ts
@@ -1,8 +1,11 @@
 import { randomUUID } from "node:crypto";
 import type { Tool } from "ai";
-import type { ApiError } from "intervals-icu-api";
 import type { IntervalsClient } from "../intervals.js";
-import { guardDeletableEvent, type IntervalsEventRuntime } from "./intervals-tools.js";
+import {
+  guardDeletableEvent,
+  toTypedError,
+  type IntervalsEventRuntime,
+} from "./intervals-tools.js";
 
 export const GATED_TOOL_NAMES: ReadonlySet<string> = new Set([
   "intervals_create_workout",
@@ -26,6 +29,12 @@ export type ConfirmOutcome =
   | { status: "mismatch" }
   | { status: "none" };
 
+export function formatConfirmOutcome(outcome: ConfirmOutcome): string {
+  if (outcome.status === "executed") return `Done — ${outcome.summary}.`;
+  if (outcome.status === "failed") return `That didn't go through — ${outcome.message}`;
+  return "That proposal expired — ask me again and I'll re-propose.";
+}
+
 export class ConfirmationGate {
   private readonly proposals = new Map<string, PendingProposal>();
 
@@ -40,23 +49,28 @@ export class ConfirmationGate {
     });
   }
 
-  peek(chatId: string): { nonce: string; summary: string } | undefined {
+  private lookup(chatId: string): {
+    proposal: PendingProposal | undefined;
+    expired: boolean;
+  } {
     const proposal = this.proposals.get(chatId);
-    if (proposal === undefined) return undefined;
+    if (proposal === undefined) return { proposal: undefined, expired: false };
     if (proposal.expiresAt <= this.now()) {
       this.proposals.delete(chatId);
-      return undefined;
+      return { proposal: undefined, expired: true };
     }
+    return { proposal, expired: false };
+  }
+
+  peek(chatId: string): { nonce: string; summary: string } | undefined {
+    const { proposal } = this.lookup(chatId);
+    if (proposal === undefined) return undefined;
     return { nonce: proposal.nonce, summary: proposal.summary };
   }
 
   async confirm(chatId: string, nonce: string): Promise<ConfirmOutcome> {
-    const proposal = this.proposals.get(chatId);
-    if (proposal === undefined) return { status: "none" };
-    if (proposal.expiresAt <= this.now()) {
-      this.proposals.delete(chatId);
-      return { status: "expired" };
-    }
+    const { proposal, expired } = this.lookup(chatId);
+    if (proposal === undefined) return { status: expired ? "expired" : "none" };
     if (proposal.nonce !== nonce) return { status: "mismatch" };
     this.proposals.delete(chatId);
     try {
@@ -71,12 +85,8 @@ export class ConfirmationGate {
   }
 
   cancel(chatId: string, nonce: string): "canceled" | "mismatch" | "none" {
-    const proposal = this.proposals.get(chatId);
+    const { proposal } = this.lookup(chatId);
     if (proposal === undefined) return "none";
-    if (proposal.expiresAt <= this.now()) {
-      this.proposals.delete(chatId);
-      return "none";
-    }
     if (proposal.nonce !== nonce) return "mismatch";
     this.proposals.delete(chatId);
     return "canceled";
@@ -86,17 +96,14 @@ export class ConfirmationGate {
 export type Summarized = { summary: string } | { block: unknown };
 export type ProposalSummarizer = (input: unknown) => Promise<Summarized>;
 
-function toTypedError(error: ApiError): { error: string; status?: number; message?: string } {
-  return {
-    error: error.kind,
-    ...("status" in error ? { status: error.status } : {}),
-    ...("message" in error ? { message: error.message } : {}),
-  };
+function objectField(value: unknown, key: string): unknown {
+  return value !== null && typeof value === "object"
+    ? (value as Record<string, unknown>)[key]
+    : undefined;
 }
 
 function stringField(value: unknown, key: string): string | undefined {
-  if (value === null || typeof value !== "object") return undefined;
-  const field = (value as Record<string, unknown>)[key];
+  const field = objectField(value, key);
   return typeof field === "string" && field.trim() !== "" ? field : undefined;
 }
 
@@ -108,10 +115,7 @@ export function createProposalSummarizers(opts: {
     intervals_create_workout: async (input) => {
       if (opts.intervals === null) return { block: { error: "intervals_not_configured" } };
       const date = stringField(input, "date");
-      const workout =
-        input !== null && typeof input === "object"
-          ? (input as Record<string, unknown>).workout
-          : undefined;
+      const workout = objectField(input, "workout");
       const name = stringField(workout, "name");
       return date !== undefined && name !== undefined
         ? { summary: `Create workout "${name}" on ${date}` }
@@ -119,10 +123,7 @@ export function createProposalSummarizers(opts: {
     },
     intervals_delete_workout: async (input) => {
       if (opts.intervals === null) return { block: { error: "intervals_not_configured" } };
-      const eventId =
-        input !== null && typeof input === "object"
-          ? (input as Record<string, unknown>).eventId
-          : undefined;
+      const eventId = objectField(input, "eventId");
       if (typeof eventId !== "number") return { block: { error: "invalid_event_id" } };
       const fetched = await opts.intervals.events.get(eventId);
       if (!fetched.ok) return { block: toTypedError(fetched.error) };
@@ -133,10 +134,7 @@ export function createProposalSummarizers(opts: {
       return { summary: `Delete workout "${event.name ?? "Unnamed workout"}" on ${date}` };
     },
     plan_save: async (input) => {
-      const plan =
-        input !== null && typeof input === "object"
-          ? (input as Record<string, unknown>).plan
-          : undefined;
+      const plan = objectField(input, "plan");
       const detail = stringField(plan, "name") ?? stringField(plan, "goal");
       return {
         summary:

--- a/packages/core/src/agent/date-schema.ts
+++ b/packages/core/src/agent/date-schema.ts
@@ -6,6 +6,29 @@ export const DATE_KEY_RE = /^\d{4}-\d{2}-\d{2}$/;
 export const dateKeySchema = z.string().regex(DATE_KEY_RE);
 export const INTERVALS_LIST_MAX_RANGE_DAYS = 366;
 
+export function validateWorkoutCreationDate(
+  date: string,
+  tz: string,
+):
+  | { error: "invalid_date"; details: string }
+  | { error: "past_date_refused"; details: string }
+  | null {
+  if (!isRealDateKey(date)) {
+    return {
+      error: "invalid_date",
+      details: `${date} is not a real calendar date. Use YYYY-MM-DD.`,
+    };
+  }
+  const today = todayInTZ(tz);
+  if (date < today) {
+    return {
+      error: "past_date_refused",
+      details: `Cannot create a workout dated ${date} — it's before today (${today}). Use today's date or later.`,
+    };
+  }
+  return null;
+}
+
 export function validateListRange(
   oldest: string,
   newest: string | undefined,

--- a/packages/core/src/agent/event-provenance.ts
+++ b/packages/core/src/agent/event-provenance.ts
@@ -15,6 +15,16 @@ export function buildCoachExternalId(date: string, name: string): string {
   return `${COACH_EXTERNAL_ID_PREFIX}${date}:${slugifyName(name)}`;
 }
 
+export function buildCoachEventProvenance(
+  date: string,
+  name: string,
+): { external_id: string; tags: string[] } {
+  return {
+    external_id: buildCoachExternalId(date, name),
+    tags: [COACH_EVENT_TAG],
+  };
+}
+
 export function isCoachOwnedEvent(event: {
   tags?: string[] | null;
   externalId?: string | null;

--- a/packages/core/src/agent/intervals-tools.ts
+++ b/packages/core/src/agent/intervals-tools.ts
@@ -26,7 +26,11 @@ export const STREAM_TYPES = [
   "smooth_grade",
 ] as const;
 
-function toTypedError(error: ApiError): { error: string; status?: number; message?: string } {
+export function toTypedError(error: ApiError): {
+  error: string;
+  status?: number;
+  message?: string;
+} {
   return {
     error: error.kind,
     ...("status" in error ? { status: error.status } : {}),
@@ -290,7 +294,9 @@ export function createCoreToolsWithSportConfig(
           category: ["WORKOUT"],
         });
         if (!result.ok) return toTypedError(result.error);
-        const projected = (result.value as unknown as IntervalsEventRuntime[]).map((e) => ({
+        const events = result.value as unknown as IntervalsEventRuntime[];
+        const source = input.coachCreatedOnly === true ? events.filter(isCoachOwnedEvent) : events;
+        return source.map((e) => ({
           id: e.id,
           startDateLocal: e.startDateLocal,
           name: e.name,
@@ -299,11 +305,8 @@ export function createCoreToolsWithSportConfig(
           category: e.category,
           externalId: e.externalId,
           tags: e.tags,
-          coachCreated: isCoachOwnedEvent(e),
+          coachCreated: input.coachCreatedOnly === true ? true : isCoachOwnedEvent(e),
         }));
-        return input.coachCreatedOnly === true
-          ? projected.filter((row) => row.coachCreated)
-          : projected;
       },
     }),
   };

--- a/packages/core/src/channels/telegram.ts
+++ b/packages/core/src/channels/telegram.ts
@@ -25,6 +25,7 @@ import { formatSnapshotRaw } from "../reference/sync/snapshot-debug.js";
 import { sendSnapshotOutput } from "../reference/sync/send-snapshot.js";
 import { createSubsystemLogger } from "../logging/index.js";
 import { truncateUtf16Safe } from "../text-truncate.js";
+import { formatConfirmOutcome } from "../agent/confirmation-gate.js";
 
 // Upper bound on how long /update waits for in-flight turns to finish before
 // self-updating. A hung turn must never wedge the update, so the drain races a
@@ -685,13 +686,7 @@ export function createTelegramBot(
         return;
       }
       const outcome = await agent.confirmations.confirm(chatId, nonce);
-      if (outcome.status === "executed") {
-        await ctx.reply(`Done — ${outcome.summary}.`);
-      } else if (outcome.status === "failed") {
-        await ctx.reply(`That didn't go through — ${outcome.message}`);
-      } else {
-        await ctx.reply("That proposal expired — ask me again and I'll re-propose.");
-      }
+      await ctx.reply(formatConfirmOutcome(outcome));
     });
   });
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -190,11 +190,13 @@ export {
   dateKeySchema,
   INTERVALS_LIST_MAX_RANGE_DAYS,
   validateListRange,
+  validateWorkoutCreationDate,
 } from "./agent/date-schema.js";
 export { isRealDateKey } from "./io/date-keys.js";
 export {
   COACH_EVENT_TAG,
   COACH_EXTERNAL_ID_PREFIX,
+  buildCoachEventProvenance,
   buildCoachExternalId,
   isCoachOwnedEvent,
 } from "./agent/event-provenance.js";

--- a/packages/core/src/run-binary.ts
+++ b/packages/core/src/run-binary.ts
@@ -16,7 +16,10 @@ import {
 import { classifyAgentError } from "./agent/error-classify.js";
 import { warnOrphanSections } from "./memory/orphan-sections.js";
 import { getEffectiveSections } from "./memory/effective-sections.js";
-import type { ConfirmationGate } from "./agent/confirmation-gate.js";
+import {
+  formatConfirmOutcome,
+  type ConfirmationGate,
+} from "./agent/confirmation-gate.js";
 
 // Shared error classifier output as the CLI's athlete-facing reply, so the CLI
 // and the Telegram channel speak the same error vocabulary and never dump a raw
@@ -100,13 +103,7 @@ export async function _promptProposalConfirm(
           return;
         }
         const outcome = await agent.confirmations.confirm("cli", proposal.nonce);
-        if (outcome.status === "executed") {
-          console.log(`Done — ${outcome.summary}.`);
-        } else if (outcome.status === "failed") {
-          console.log(`That didn't go through — ${outcome.message}`);
-        } else {
-          console.log("That proposal expired — ask me again and I'll re-propose.");
-        }
+        console.log(formatConfirmOutcome(outcome));
         resolve();
       })();
     });

--- a/packages/sport-cycling/src/sport.ts
+++ b/packages/sport-cycling/src/sport.ts
@@ -91,7 +91,7 @@ export const cyclingSport: Sport = {
       ...createMemoryTools(deps.memory, sections),
       ...createPureCoreIntervalsTools(deps.intervals, deps.tz),
       ...createCoreToolsWithSportConfig(deps.intervals, cyclingSport.intervalsActivityTypes),
-      ...createCyclingTools(deps.memory, deps.intervals, deps.tz),
+      ...createCyclingTools(deps.intervals, deps.tz),
     };
     return Object.entries(toolset).map(([name, t]) => ({
       name,

--- a/packages/sport-cycling/src/tools.ts
+++ b/packages/sport-cycling/src/tools.ts
@@ -1,12 +1,10 @@
 import { tool, zodSchema } from "ai";
 import { z } from "zod";
-import type { MemoryStore } from "@enduragent/core";
 import {
-  COACH_EVENT_TAG,
-  buildCoachExternalId,
+  buildCoachEventProvenance,
   dateKeySchema,
   isRealDateKey,
-  todayInTZ,
+  validateWorkoutCreationDate,
 } from "@enduragent/core";
 import type { IntervalsClient } from "intervals-icu-api";
 import {
@@ -63,7 +61,6 @@ export const cyclingCreateWorkoutInputSchema = z.object({
  * and `createCoreToolsWithSportConfig`.
  */
 export function createCyclingTools(
-  _memory: MemoryStore,
   intervals: IntervalsClient | null,
   tz: string = "UTC",
 ) {
@@ -168,19 +165,8 @@ export function createCyclingTools(
               "Create a structured workout on the intervals.icu calendar (auto-syncs to Garmin/Wahoo). Supply structured steps — they serialize into intervals.icu's native syntax so the power chart renders. Put athlete-facing coaching narrative (feel, notes, hydration) in your chat reply, not in this tool. Past dates are refused — workouts can only be created for today or later.",
             inputSchema: zodSchema(cyclingCreateWorkoutInputSchema),
             execute: async (input: { date: string; workout: IntervalsWorkoutInput }) => {
-              if (!isRealDateKey(input.date)) {
-                return {
-                  error: "invalid_date",
-                  details: `${input.date} is not a real calendar date. Use YYYY-MM-DD.`,
-                };
-              }
-              const today = todayInTZ(tz);
-              if (input.date < today) {
-                return {
-                  error: "past_date_refused",
-                  details: `Cannot create a workout dated ${input.date} — it's before today (${today}). Use today's date or later.`,
-                };
-              }
+              const dateError = validateWorkoutCreationDate(input.date, tz);
+              if (dateError) return dateError;
               let serialized: ReturnType<typeof serializeIntervalsWorkout>;
               try {
                 serialized = serializeIntervalsWorkout(input.workout);
@@ -195,8 +181,7 @@ export function createCyclingTools(
                 category: "WORKOUT",
                 name: input.workout.name,
                 type: "Ride",
-                external_id: buildCoachExternalId(input.date, input.workout.name),
-                tags: [COACH_EVENT_TAG],
+                ...buildCoachEventProvenance(input.date, input.workout.name),
                 description: serialized.description,
               });
               if (!result.ok) return { error: result.error.kind };

--- a/packages/sport-cycling/tests/tools.test.ts
+++ b/packages/sport-cycling/tests/tools.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { todayInTZ, type MemoryStore } from "@enduragent/core";
+import { todayInTZ } from "@enduragent/core";
 import {
   buildPlanSkeletonInputSchema,
   createCyclingTools,
@@ -26,7 +26,7 @@ function fakeIntervals(
 }
 
 function createWorkoutTool(intervals: unknown, tz = "UTC") {
-  const tools = createCyclingTools({} as MemoryStore, intervals as never, tz);
+  const tools = createCyclingTools(intervals as never, tz);
   return (tools as Record<string, unknown>).intervals_create_workout as
     | { execute: (input: unknown, opts: unknown) => Promise<Record<string, unknown>> }
     | undefined;
@@ -84,7 +84,7 @@ describe("intervals_create_workout provenance", () => {
   });
 
   it("tool absent when no intervals client configured", () => {
-    const tools = createCyclingTools({} as MemoryStore, null, "UTC");
+    const tools = createCyclingTools(null, "UTC");
     expect("intervals_create_workout" in tools).toBe(false);
   });
 });
@@ -164,7 +164,7 @@ describe("intervals_create_workout payload (calendar-payload group)", () => {
 describe("build_plan_skeleton purity", () => {
   it("returns a plan and never calls savePlan", async () => {
     const savePlan = vi.fn();
-    const tools = createCyclingTools({ savePlan } as unknown as MemoryStore, null, "UTC");
+    const tools = createCyclingTools(null, "UTC");
     const result = await tools.build_plan_skeleton.execute!(
       {
         experienceLevel: "intermediate",
@@ -182,7 +182,7 @@ describe("build_plan_skeleton purity", () => {
   });
 
   it("description discloses that nothing is saved", () => {
-    const tools = createCyclingTools({} as MemoryStore, null, "UTC");
+    const tools = createCyclingTools(null, "UTC");
     expect(tools.build_plan_skeleton.description).toContain("Does NOT save anything");
   });
 });
@@ -198,7 +198,7 @@ describe("build_plan_skeleton raceDate", () => {
   };
 
   it("builds a finite plan for a valid future date", async () => {
-    const tools = createCyclingTools({} as MemoryStore, null, "UTC");
+    const tools = createCyclingTools(null, "UTC");
     const result = (await tools.build_plan_skeleton.execute!(
       { ...baseInput, raceDate: futureISODate(84) },
       {} as never,
@@ -208,7 +208,7 @@ describe("build_plan_skeleton raceDate", () => {
   });
 
   it("refuses an impossible calendar date", async () => {
-    const tools = createCyclingTools({} as MemoryStore, null, "UTC");
+    const tools = createCyclingTools(null, "UTC");
     const result = await tools.build_plan_skeleton.execute!(
       { ...baseInput, raceDate: "2026-02-31" },
       {} as never,

--- a/packages/sport-running/src/sport.ts
+++ b/packages/sport-running/src/sport.ts
@@ -86,7 +86,7 @@ export const runningSport: Sport = {
       ...createMemoryTools(deps.memory, sections),
       ...createPureCoreIntervalsTools(deps.intervals, deps.tz),
       ...createCoreToolsWithSportConfig(deps.intervals, runningSport.intervalsActivityTypes),
-      ...createRunningTools(deps.memory, deps.intervals, deps.tz, deps.resolvedCs),
+      ...createRunningTools(deps.intervals, deps.tz, deps.resolvedCs),
     };
     return Object.entries(toolset).map(([name, t]) => ({
       name,

--- a/packages/sport-running/src/tools.ts
+++ b/packages/sport-running/src/tools.ts
@@ -1,12 +1,10 @@
 import { tool, zodSchema } from "ai";
 import { z } from "zod";
-import type { MemoryStore, ResolvedCs } from "@enduragent/core";
+import type { ResolvedCs } from "@enduragent/core";
 import {
-  COACH_EVENT_TAG,
-  buildCoachExternalId,
+  buildCoachEventProvenance,
   dateKeySchema,
-  isRealDateKey,
-  todayInTZ,
+  validateWorkoutCreationDate,
 } from "@enduragent/core";
 import type { IntervalsClient } from "intervals-icu-api";
 import {
@@ -53,7 +51,6 @@ function clampLowerFraction(requested: number): { value: number; clamped: boolea
 }
 
 export function createRunningTools(
-  _memory: MemoryStore,
   intervals: IntervalsClient | null,
   tz: string = "UTC",
   resolvedCs?: () => ResolvedCs | null,
@@ -155,19 +152,8 @@ export function createRunningTools(
               "Create a structured running workout on the intervals.icu calendar (auto-syncs to Garmin/Wahoo). Steps serialize into intervals.icu's native pace syntax; the server computes load against the athlete's threshold pace. Anchor pace targets on the critical-speed zones (kind:'zone' 1-6 or kind:'cs_fraction') — RPE-checked estimates, not lab-measured thresholds. If the athlete's critical speed is a manual/coach-entered override, prefer absolute kind:'pace' targets so the prescription matches the zone table you showed them. Prescribe strides as a duration-only step (or a relaxed-fast kind:'pace'), never a CS zone; do not invent a pace the resolved CS doesn't support. A distance step needs a pace target so its planned time can be derived. Put the RPE-check + provenance framing and coaching narrative in your chat reply — the calendar entry cannot carry it. Past dates are refused — workouts can only be created for today or later.",
             inputSchema: zodSchema(runningCreateWorkoutInputSchema),
             execute: async (input: { date: string; workout: RunningWorkoutInput }) => {
-              if (!isRealDateKey(input.date)) {
-                return {
-                  error: "invalid_date",
-                  details: `${input.date} is not a real calendar date. Use YYYY-MM-DD.`,
-                };
-              }
-              const today = todayInTZ(tz);
-              if (input.date < today) {
-                return {
-                  error: "past_date_refused",
-                  details: `Cannot create a workout dated ${input.date} — it's before today (${today}). Use today's date or later.`,
-                };
-              }
+              const dateError = validateWorkoutCreationDate(input.date, tz);
+              if (dateError) return dateError;
               // The serializer stays pure: pass OUR resolved CS in so distance steps
               // with relative targets can derive their planned time.
               let serialized: ReturnType<typeof serializeRunningWorkout>;
@@ -184,8 +170,7 @@ export function createRunningTools(
                 category: "WORKOUT",
                 name: input.workout.name,
                 type: "Run",
-                external_id: buildCoachExternalId(input.date, input.workout.name),
-                tags: [COACH_EVENT_TAG],
+                ...buildCoachEventProvenance(input.date, input.workout.name),
                 moving_time: serialized.movingTime,
                 // No icu_training_load — the server derives running Pace Load from the
                 // parsed steps against the athlete's own threshold pace.

--- a/packages/sport-running/tests/sport-contract.test.ts
+++ b/packages/sport-running/tests/sport-contract.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import type { MemorySnapshot, MemoryStore } from "@enduragent/core";
+import type { MemorySnapshot } from "@enduragent/core";
 import { runningSport } from "../src/sport.js";
 import { runningReferenceAdapter } from "../src/reference/index.js";
 import { createRunningTools } from "../src/tools.js";
@@ -41,7 +41,7 @@ describe("runningSport contract", () => {
   });
 
   it("surfaces a calculate_zones tool", () => {
-    const tools = createRunningTools({} as MemoryStore, null, "UTC");
+    const tools = createRunningTools(null, "UTC");
     expect(Object.keys(tools)).toContain("calculate_zones");
   });
 });

--- a/packages/sport-running/tests/tools.test.ts
+++ b/packages/sport-running/tests/tools.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { todayInTZ, type MemoryStore, type ResolvedCs } from "@enduragent/core";
+import { todayInTZ, type ResolvedCs } from "@enduragent/core";
 import { createRunningTools, runningCreateWorkoutInputSchema } from "../src/tools.js";
 
 // The Vercel AI SDK wraps execute; call it directly with a stub options arg
@@ -13,7 +13,7 @@ function execZones(input: Record<string, unknown>): Promise<{
   framing: string;
   clampApplied?: { requested: number; clamped: number };
 }> {
-  const tools = createRunningTools({} as MemoryStore, null, "UTC");
+  const tools = createRunningTools(null, "UTC");
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return (tools.calculate_zones as any).execute(input, {});
 }
@@ -65,7 +65,7 @@ function execZonesResolved(
   platformConfidence?: string;
   error?: string;
 }> {
-  const tools = createRunningTools({} as MemoryStore, null, "UTC", () => resolved);
+  const tools = createRunningTools(null, "UTC", () => resolved);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return (tools.calculate_zones as any).execute(input, {});
 }
@@ -109,7 +109,7 @@ describe("calculate_zones CS auto-resolution", () => {
   });
 
   it("returns no_cs_anchor when no resolver is wired and no value supplied", async () => {
-    const tools = createRunningTools({} as MemoryStore, null, "UTC");
+    const tools = createRunningTools(null, "UTC");
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const out = await (tools.calculate_zones as any).execute({}, {});
     expect(out.error).toBe("no_cs_anchor");
@@ -150,7 +150,6 @@ function createWorkoutTool(
   tz = "UTC",
 ) {
   const tools = createRunningTools(
-    {} as MemoryStore,
     intervals,
     tz,
     resolved === null ? undefined : () => resolved,
@@ -168,7 +167,7 @@ function tomorrowISODate(): string {
 
 describe("intervals_create_workout tool", () => {
   it("is absent when no intervals client is configured", () => {
-    const tools = createRunningTools({} as MemoryStore, null, "UTC");
+    const tools = createRunningTools(null, "UTC");
     expect("intervals_create_workout" in tools).toBe(false);
   });
 


### PR DESCRIPTION
## What

Behavior-preserving cleanup pass over the Batch 11 diff (PRs #332–#336). Eight dedup/reuse refactors surfaced by a four-angle review (reuse, simplification, efficiency, altitude). No athlete-visible behavior change — the full existing test suite is the oracle and stays green at 3,146 tests.

## Fixes

1. **Shared workout-creation date guard** — the `invalid_date` / `past_date_refused` guard was duplicated byte-for-byte across cycling and running; extracted to `validateWorkoutCreationDate(date, tz)` in `date-schema.ts`. Both sports' original messages were already identical, so the copy is unchanged.
2. **Reuse `toTypedError`** — dropped the copy in `confirmation-gate.ts`, importing the existing one from `intervals-tools.ts`.
3. **Centralized proposal lookup + expiry** in `ConfirmationGate` — `peek`/`confirm`/`cancel` shared the same get + TTL-check + delete; folded into one private helper, outcomes unchanged.
4. **`objectField` helper** — collapsed the repeated `input !== null && typeof input === "object" ? … : undefined` narrowing in the three summarizers; `stringField` now builds on it.
5. **Shared `formatConfirmOutcome`** — the executed/failed/expired message trio was byte-identical in the Telegram and CLI paths; one formatter, channel-specific cancel wording stays local.
6. **Removed dead `_memory` param** from `createCyclingTools`/`createRunningTools` — unused since the plan-skeleton tool became pure; dropped the param, the `MemoryStore` import, and updated call sites.
7. **`coachCreatedOnly` filter-before-map** — filter coach-owned events before projecting instead of projecting all then filtering; identical output.
8. **`buildCoachEventProvenance` helper** — the `{ external_id, tags }` marker assembly was duplicated across both sports; one helper, spread at each create site.

## Deliberately skipped

Six candidate findings were left as-is: removing the serializer's public `movingTime` export (contract change), trimming intentional provenance fields from the event projection, adding an auto-expiry timer to the gate (would fight the injectable clock the tests use), reordering the security-sensitive Telegram callback flow, redesigning the confirmation gate table into per-tool registration declarations (an architectural change for an ADR, not a cleanup), and restructuring the zone-ramp serialization branch.

## Verification

`pnpm check && pnpm test` green — 3,146 tests passed / 3 skipped across 210 files, identical count to the pre-refactor tip. The test-file changes are constructor call-site updates for fix 6 only.
