### PR TITLE
chore(cycling-coach): ship package license and notice artifacts

### DIFF
--- a/.changeset/calm-spokes-notices.md
+++ b/.changeset/calm-spokes-notices.md
@@ -1,0 +1,5 @@
+---
+"cycling-coach": patch
+---
+
+Ship package license, notice, and graph-derived third-party legal artifacts.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,12 +70,15 @@ jobs:
         run: |
           set -euo pipefail
           PACKAGE=cycling-coach
-          cd "packages/$PACKAGE"
-          pnpm pack --pack-destination "/tmp/smoke-pack-$PACKAGE"
+          PACK_DIR="/tmp/smoke-pack-$PACKAGE"
+          mkdir -p "$PACK_DIR"
+          pnpm --dir "packages/$PACKAGE" pack --pack-destination "$PACK_DIR"
+          TARBALL=$(find "$PACK_DIR" -maxdepth 1 -name '*.tgz' -print -quit)
+          pnpm check:published-package -- "$TARBALL"
           mkdir -p "/tmp/smoke-consumer-$PACKAGE"
           cd "/tmp/smoke-consumer-$PACKAGE"
           npm init -y > /dev/null
-          npm install /tmp/smoke-pack-$PACKAGE/*.tgz
+          npm install "$TARBALL"
           timeout 30 node "node_modules/$PACKAGE/dist/index.js" --help
 
   secrets-macos:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,12 +144,15 @@ jobs:
         run: |
           set -euo pipefail
           PACKAGE="${{ needs.parse-tag.outputs.package }}"
-          cd "packages/$PACKAGE"
-          pnpm pack --pack-destination "/tmp/smoke-pack-$PACKAGE"
+          PACK_DIR="/tmp/smoke-pack-$PACKAGE"
+          mkdir -p "$PACK_DIR"
+          pnpm --dir "packages/$PACKAGE" pack --pack-destination "$PACK_DIR"
+          TARBALL=$(find "$PACK_DIR" -maxdepth 1 -name '*.tgz' -print -quit)
+          pnpm check:published-package -- "$TARBALL"
           mkdir -p "/tmp/smoke-consumer-$PACKAGE"
           cd "/tmp/smoke-consumer-$PACKAGE"
           npm init -y > /dev/null
-          npm install /tmp/smoke-pack-$PACKAGE/*.tgz
+          npm install "$TARBALL"
           timeout 30 node "node_modules/$PACKAGE/dist/index.js" --help
 
   publish:
@@ -196,14 +199,22 @@ jobs:
             exit 1
           fi
 
-      - name: Publish to npm via OIDC
-        # `pnpm publish --filter <pkg>` publishes only the named package.
+      - name: Pack, verify, and publish to npm via OIDC
+        # Publish the exact tarball accepted by the legal-artifact gate.
         # OIDC is negotiated automatically by npm 11+ when id-token: write
         # is granted (no NPM_TOKEN secret needed). The trusted publisher
         # must be configured per-package on npmjs.com (one-time operator
         # action; matches repo `yerzhansa/cycling-coach` + workflow
         # `release.yml`).
-        run: pnpm publish --filter ${{ needs.parse-tag.outputs.package }} --access public --no-git-checks
+        run: |
+          set -euo pipefail
+          PACKAGE="${{ needs.parse-tag.outputs.package }}"
+          PACK_DIR="/tmp/publish-pack-$PACKAGE"
+          mkdir -p "$PACK_DIR"
+          pnpm --dir "packages/$PACKAGE" pack --pack-destination "$PACK_DIR"
+          TARBALL=$(find "$PACK_DIR" -maxdepth 1 -name '*.tgz' -print -quit)
+          pnpm check:published-package -- "$TARBALL"
+          npm publish "$TARBALL" --access public
 
       - name: Create GitHub Release if missing
         # Tag may have been created via the GitHub UI's "Draft a new release"

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -47,7 +47,7 @@ copy; the following modifications were applied during the port:
 - **Trademark substitution.** Section-11 was authored against TrainingPeaks
   vocabulary. This codebase uses intervals.icu's plain-English alternatives
   throughout — the substitution is enforced by `pnpm check:trademarks` and
-  documented in [`CONTRIBUTING.md`](./CONTRIBUTING.md#trademark-hygiene).
+  documented in [`CONTRIBUTING.md`](https://github.com/yerzhansa/cycling-coach/blob/main/CONTRIBUTING.md#trademark-hygiene).
 - **Multi-sport adapter pattern.** Per ADR-0010, the Reference layer gains a
   per-sport seam — sports plug in via an optional `referenceAdapters?()`
   method on the `Sport` interface, returning an array of layer-owned adapters
@@ -78,7 +78,7 @@ copy; the following modifications were applied during the port:
 
 ### Canonical attribution surfaces
 
-This file (`NOTICE.md`) and the [`README.md` Credits section](./README.md#credits)
+This file (`NOTICE.md`) and the [`README.md` Credits section](https://github.com/yerzhansa/cycling-coach#credits)
 are the canonical attribution surfaces. The full upstream repository is at
 https://github.com/CrankAddict/section-11.
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "check:trademarks": "tsx tools/check-trademarks.ts",
     "check:fixture-privacy": "tsx tools/check-fixture-privacy.ts",
     "check:registry-isolation": "tsx tools/check-registry-isolation.ts",
+    "check:published-package": "node --import tsx tools/check-published-package.ts",
     "check:changeset-userfacing": "tsx tools/check-changeset-user-facing.ts",
     "release-version": "changeset version && tsx tools/bump-binaries-to-calver.ts",
     "snapshot:section-11": "tsx tools/snapshot-section-11.ts",

--- a/packages/cycling-coach/Dockerfile
+++ b/packages/cycling-coach/Dockerfile
@@ -27,6 +27,7 @@ COPY tools ./tools
 COPY packages/core ./packages/core
 COPY packages/sport-cycling ./packages/sport-cycling
 COPY packages/cycling-coach ./packages/cycling-coach
+COPY LICENSE NOTICE.md ./
 
 # Only build what cycling-coach needs (`...` = the package + all its deps in
 # topo order). Stubs aren't even copied into the image.

--- a/packages/cycling-coach/README.md
+++ b/packages/cycling-coach/README.md
@@ -115,3 +115,8 @@ npx cycling-coach
 - **Secrets backends** (1Password, macOS Keychain, Vault, AWS/GCP Secret Manager, age, env), **architecture diagram**, and **development setup** — see the [GitHub repo](https://github.com/yerzhansa/cycling-coach#readme).
 - **Issues**: <https://github.com/yerzhansa/cycling-coach/issues>
 - **License**: MIT
+
+## Notices
+
+License and attribution details for the installed package are in
+`dist/NOTICE.md` and `dist/THIRD_PARTY_LICENSES.txt`.

--- a/packages/cycling-coach/build/legal-artifacts.ts
+++ b/packages/cycling-coach/build/legal-artifacts.ts
@@ -1,0 +1,425 @@
+import {
+  copyFileSync,
+  existsSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { basename, dirname, parse, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const REVIEWED_LICENSE_EXPRESSIONS = ["Apache-2.0", "BSD-2-Clause", "ISC", "MIT"] as const;
+
+const reviewedLicenses = new Set<string>(REVIEWED_LICENSE_EXPRESSIONS);
+const packageEntryMarker = "----- PACKAGE -----";
+const packageEndMarker = "----- END PACKAGE -----";
+
+interface MetafileOutput {
+  inputs?: Record<string, unknown>;
+}
+
+export interface BuildMetafile {
+  outputs: Record<string, MetafileOutput>;
+}
+
+export interface ThirdPartyPackage {
+  id: string;
+  name: string;
+  version: string;
+  license: string;
+  packageRoot: string;
+  licenseFiles: Array<{ name: string; text: string }>;
+  noticeFiles: Array<{ name: string; text: string }>;
+  override?: { name: string; text: string };
+}
+
+export interface LegalArtifactPaths {
+  packageRoot: string;
+  repoRoot: string;
+  inputRoot: string;
+  metafilePath: string;
+  distDir: string;
+  apacheLicensePath: string;
+  overridesDir: string;
+}
+
+function defaultPaths(): LegalArtifactPaths {
+  const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+  const repoRoot = resolve(packageRoot, "../..");
+  return {
+    packageRoot,
+    repoRoot,
+    inputRoot: repoRoot,
+    metafilePath: resolve(packageRoot, "dist/metafile-esm.json"),
+    distDir: resolve(packageRoot, "dist"),
+    apacheLicensePath: resolve(packageRoot, "build/license-texts/Apache-2.0.txt"),
+    overridesDir: resolve(packageRoot, "build/license-overrides"),
+  };
+}
+
+function readText(path: string): string {
+  const text = readFileSync(path, "utf8");
+  if (text.trim().length === 0) {
+    throw new Error(`Legal material is empty: ${path}`);
+  }
+  return text.replace(/\r\n/g, "\n").trimEnd();
+}
+
+function findPackageRoot(inputPath: string, inputRoot: string): string | null {
+  const absoluteInput = resolve(inputRoot, inputPath);
+  if (!absoluteInput.split(/[\\/]/).includes("node_modules")) return null;
+
+  let current = dirname(absoluteInput);
+  const filesystemRoot = parse(current).root;
+  while (current !== filesystemRoot) {
+    const parent = dirname(current);
+    const isPackageBoundary =
+      basename(parent) === "node_modules" ||
+      (basename(dirname(parent)) === "node_modules" && basename(parent).startsWith("@"));
+    if (isPackageBoundary) {
+      const manifestPath = resolve(current, "package.json");
+      if (!existsSync(manifestPath)) return null;
+      const manifest = JSON.parse(readFileSync(manifestPath, "utf8")) as {
+        name?: unknown;
+        version?: unknown;
+      };
+      return typeof manifest.name === "string" && typeof manifest.version === "string"
+        ? current
+        : null;
+    }
+    current = parent;
+  }
+  return null;
+}
+
+function contributingPackageRoot(input: string, inputRoot: string): string | null {
+  const absoluteInput = resolve(inputRoot, input);
+  if (!absoluteInput.split(/[\\/]/).includes("node_modules")) return null;
+
+  const dependencyRoot = findPackageRoot(input, inputRoot);
+  if (!dependencyRoot) {
+    throw new Error(`Cannot resolve contributing third-party package root: ${input}`);
+  }
+  return dependencyRoot;
+}
+
+function packageIdentity(dependencyRoot: string): { name: string; version: string; id: string } {
+  const manifest = JSON.parse(readFileSync(resolve(dependencyRoot, "package.json"), "utf8")) as {
+    name?: unknown;
+    version?: unknown;
+  };
+  if (typeof manifest.name !== "string" || typeof manifest.version !== "string") {
+    throw new Error(`Contributing package has invalid identity: ${dependencyRoot}`);
+  }
+  return {
+    name: manifest.name,
+    version: manifest.version,
+    id: `${manifest.name}@${manifest.version}`,
+  };
+}
+
+export function contributingInputs(metafile: BuildMetafile, output = "dist/index.js"): string[] {
+  const matchedOutputs = Object.entries(metafile.outputs).filter(([path]) => {
+    const normalized = path.replaceAll("\\", "/");
+    return normalized === output || normalized.endsWith(`/${output}`);
+  });
+  const matchedOutput = matchedOutputs.length === 1 ? matchedOutputs[0][1] : undefined;
+  if (!matchedOutput?.inputs) {
+    throw new Error(`Metafile does not describe the required ${output} output`);
+  }
+  return Object.keys(matchedOutput.inputs).sort();
+}
+
+export function overrideFilename(name: string, version: string): string {
+  return `${name.replaceAll("/", "+")}@${version}.txt`;
+}
+
+export function contributingThirdPartyPackageIds(
+  metafile: BuildMetafile,
+  packageRoot: string,
+): string[] {
+  const ids = new Set<string>();
+  for (const input of contributingInputs(metafile)) {
+    const dependencyRoot = contributingPackageRoot(input, packageRoot);
+    if (!dependencyRoot) continue;
+    ids.add(packageIdentity(dependencyRoot).id);
+  }
+  return [...ids].sort();
+}
+
+function materialFiles(
+  packageRoot: string,
+  pattern: RegExp,
+): Array<{ name: string; text: string }> {
+  return readdirSync(packageRoot)
+    .filter((name) => pattern.test(name))
+    .sort()
+    .map((name) => {
+      const path = resolve(packageRoot, name);
+      return statSync(path).isFile() ? { name, text: readText(path) } : null;
+    })
+    .filter((entry): entry is { name: string; text: string } => entry !== null);
+}
+
+export function collectThirdPartyPackages(
+  metafile: BuildMetafile,
+  paths: Pick<LegalArtifactPaths, "inputRoot" | "overridesDir">,
+): ThirdPartyPackage[] {
+  const packages = new Map<string, ThirdPartyPackage>();
+
+  for (const input of contributingInputs(metafile)) {
+    const dependencyRoot = contributingPackageRoot(input, paths.inputRoot);
+    if (!dependencyRoot) continue;
+
+    const manifest = JSON.parse(readFileSync(resolve(dependencyRoot, "package.json"), "utf8")) as {
+      name?: unknown;
+      version?: unknown;
+      license?: unknown;
+    };
+    const { name, version, id } = packageIdentity(dependencyRoot);
+    if (typeof manifest.license !== "string") {
+      throw new Error(`Missing declared license expression for ${id}`);
+    }
+    if (!reviewedLicenses.has(manifest.license)) {
+      throw new Error(`Unreviewed license expression for ${id}: ${manifest.license}`);
+    }
+    if (packages.has(id)) continue;
+
+    const licenseFiles = materialFiles(dependencyRoot, /^(?:licen[cs]e|copying)(?:[._-].*)?$/i);
+    const noticeFiles = materialFiles(
+      dependencyRoot,
+      /^(?:notice|authors|attribution)(?:[._-].*)?$/i,
+    );
+    const overrideName = overrideFilename(name, version);
+    const overridePath = resolve(paths.overridesDir, overrideName);
+    const override = existsSync(overridePath)
+      ? { name: overrideName, text: readText(overridePath) }
+      : undefined;
+
+    if (override && licenseFiles.length > 0) {
+      throw new Error(
+        `Exact-version override conflicts with discovered license material for ${id}`,
+      );
+    }
+    if (licenseFiles.length === 0 && !override) {
+      throw new Error(`Missing license material for ${id}`);
+    }
+
+    packages.set(id, {
+      id,
+      name,
+      version,
+      license: manifest.license,
+      packageRoot: dependencyRoot,
+      licenseFiles,
+      noticeFiles,
+      override,
+    });
+  }
+
+  return [...packages.values()].sort((left, right) =>
+    left.id < right.id ? -1 : left.id > right.id ? 1 : 0,
+  );
+}
+
+function section(label: string, name: string, text: string): string {
+  return `${label}: ${name}\n\n${text}`;
+}
+
+function apachePackageSpecificText(packageText: string, canonicalText: string): string {
+  const canonicalLines = new Set(
+    canonicalText
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0),
+  );
+  const packageLines = packageText
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !canonicalLines.has(line));
+  return [...new Set(packageLines)].join("\n");
+}
+
+export function renderAggregate(packages: ThirdPartyPackage[], apacheLicenseText: string): string {
+  const canonicalApacheText = apacheLicenseText.trimEnd();
+  const parts = [
+    "THIRD-PARTY LICENSES AND NOTICES",
+    "Generated from the exact inputs contributing to dist/index.js.",
+  ];
+
+  if (packages.some((entry) => entry.license === "Apache-2.0")) {
+    parts.push(
+      [
+        "===== CANONICAL LICENSE: Apache-2.0 =====",
+        canonicalApacheText,
+        "===== END CANONICAL LICENSE =====",
+      ].join("\n\n"),
+    );
+  }
+
+  for (const entry of packages) {
+    const entryParts = [packageEntryMarker, `Package: ${entry.id}`, `License: ${entry.license}`];
+
+    if (entry.license === "Apache-2.0") {
+      entryParts.push("License text: canonical Apache-2.0 text above");
+      for (const file of entry.licenseFiles) {
+        const packageSpecificText = apachePackageSpecificText(file.text, canonicalApacheText);
+        if (packageSpecificText.length > 0) {
+          entryParts.push(section("Package notice", file.name, packageSpecificText));
+        }
+      }
+    } else {
+      for (const file of entry.licenseFiles) {
+        entryParts.push(section("License text", file.name, file.text));
+      }
+    }
+
+    if (entry.override) {
+      entryParts.push(section("Exact-version override", entry.override.name, entry.override.text));
+    }
+    for (const file of entry.noticeFiles) {
+      entryParts.push(section("Notice", file.name, file.text));
+    }
+    entryParts.push(packageEndMarker);
+    parts.push([entryParts.slice(0, 3).join("\n"), ...entryParts.slice(3)].join("\n\n"));
+  }
+
+  return `${parts.join("\n\n")}\n`;
+}
+
+export function parseAggregatePackageIds(aggregate: string): string[] {
+  const ids: string[] = [];
+  const lines = aggregate.split("\n");
+  let apacheEntries = 0;
+  let cursor = 0;
+
+  while (cursor < lines.length) {
+    const line = lines[cursor];
+    if (line === packageEndMarker) {
+      throw new Error("Unmatched third-party package entry terminator");
+    }
+    if (line !== packageEntryMarker) {
+      if (line.startsWith("Package: ") || line.startsWith("License: ")) {
+        throw new Error("Third-party package field appears outside an entry");
+      }
+      cursor += 1;
+      continue;
+    }
+
+    const end = lines.indexOf(packageEndMarker, cursor + 1);
+    const nestedStart = lines.indexOf(packageEntryMarker, cursor + 1);
+    if (end === -1) throw new Error("Unterminated third-party package entry");
+    if (nestedStart !== -1 && nestedStart < end) {
+      throw new Error("Malformed nested third-party package entry");
+    }
+
+    const packageLine = lines[cursor + 1];
+    const licenseLine = lines[cursor + 2];
+    if (!packageLine?.startsWith("Package: ") || !licenseLine?.startsWith("License: ")) {
+      throw new Error("Malformed third-party package entry header");
+    }
+    const id = packageLine.slice("Package: ".length);
+    const license = licenseLine.slice("License: ".length);
+    if (id.length === 0) throw new Error("Malformed third-party package entry");
+    if (!reviewedLicenses.has(license)) {
+      throw new Error(
+        `Unreviewed license expression in third-party aggregate for ${id}: ${license}`,
+      );
+    }
+
+    const body = lines.slice(cursor + 3, end);
+    if (
+      body.some((bodyLine) => bodyLine.startsWith("Package: ") || bodyLine.startsWith("License: "))
+    ) {
+      throw new Error(`Duplicate package field in third-party aggregate for ${id}`);
+    }
+    const hasLicenseMaterial = body.some((bodyLine, index) => {
+      if (bodyLine === "License text: canonical Apache-2.0 text above") {
+        return license === "Apache-2.0";
+      }
+      if (
+        !bodyLine.startsWith("License text: ") &&
+        !bodyLine.startsWith("Exact-version override: ")
+      ) {
+        return false;
+      }
+      const followingLines = body.slice(index + 1);
+      const nextSection = followingLines.findIndex((materialLine) =>
+        /^(?:License text|Exact-version override|Package notice|Notice): /.test(materialLine),
+      );
+      const materialLines =
+        nextSection === -1 ? followingLines : followingLines.slice(0, nextSection);
+      return materialLines.some((materialLine) => materialLine.trim().length > 0);
+    });
+    if (!hasLicenseMaterial) {
+      throw new Error(`Missing legal material in third-party aggregate for ${id}`);
+    }
+
+    ids.push(id);
+    if (license === "Apache-2.0") apacheEntries += 1;
+    cursor = end + 1;
+  }
+
+  const canonicalStarts = lines.filter(
+    (line) => line === "===== CANONICAL LICENSE: Apache-2.0 =====",
+  ).length;
+  const canonicalEnds = lines.filter((line) => line === "===== END CANONICAL LICENSE =====").length;
+  const canonicalStartIndex = lines.indexOf("===== CANONICAL LICENSE: Apache-2.0 =====");
+  const canonicalEndIndex = lines.indexOf("===== END CANONICAL LICENSE =====");
+  const hasCanonicalBody =
+    canonicalStartIndex !== -1 &&
+    canonicalEndIndex > canonicalStartIndex &&
+    lines
+      .slice(canonicalStartIndex + 1, canonicalEndIndex)
+      .some((canonicalLine) => canonicalLine.trim().length > 0);
+  if (
+    (apacheEntries > 0 && (canonicalStarts !== 1 || canonicalEnds !== 1 || !hasCanonicalBody)) ||
+    (apacheEntries === 0 && (canonicalStarts !== 0 || canonicalEnds !== 0))
+  ) {
+    throw new Error("Malformed canonical Apache-2.0 license section");
+  }
+  return ids;
+}
+
+export function assertAggregateMatchesGraph(aggregateIds: string[], graphIds: string[]): void {
+  const normalizedAggregate = [...aggregateIds].sort();
+  const normalizedGraph = [...new Set(graphIds)].sort();
+  if (
+    normalizedAggregate.length !== aggregateIds.length ||
+    JSON.stringify(normalizedAggregate) !== JSON.stringify(normalizedGraph)
+  ) {
+    throw new Error(
+      `Third-party aggregate does not match bundle graph: aggregate=${normalizedAggregate.join(",")} graph=${normalizedGraph.join(",")}`,
+    );
+  }
+}
+
+export async function generateLegalArtifacts(
+  pathOverrides: Partial<LegalArtifactPaths> = {},
+): Promise<void> {
+  const paths = { ...defaultPaths(), ...pathOverrides };
+  const rootLicense = resolve(paths.repoRoot, "LICENSE");
+  const rootNotice = resolve(paths.repoRoot, "NOTICE.md");
+  if (!existsSync(rootLicense)) throw new Error("Canonical root LICENSE is missing");
+  if (!existsSync(rootNotice)) throw new Error("Canonical root NOTICE.md is missing");
+  if (!existsSync(paths.metafilePath)) {
+    throw new Error(`Build metafile is missing: ${paths.metafilePath}`);
+  }
+
+  const metafile = JSON.parse(readFileSync(paths.metafilePath, "utf8")) as BuildMetafile;
+  const graphIds = contributingThirdPartyPackageIds(metafile, paths.inputRoot);
+  const packages = collectThirdPartyPackages(metafile, paths);
+  if (packages.length === 0) {
+    throw new Error("Bundle graph contains no third-party packages");
+  }
+  const apacheLicenseText = readText(paths.apacheLicensePath);
+  const aggregate = renderAggregate(packages, apacheLicenseText);
+  assertAggregateMatchesGraph(parseAggregatePackageIds(aggregate), graphIds);
+
+  copyFileSync(rootLicense, resolve(paths.distDir, "LICENSE"));
+  copyFileSync(rootNotice, resolve(paths.distDir, "NOTICE.md"));
+  writeFileSync(resolve(paths.distDir, "THIRD_PARTY_LICENSES.txt"), aggregate, "utf8");
+  rmSync(paths.metafilePath);
+}

--- a/packages/cycling-coach/build/license-overrides/@ai-sdk+provider-utils@4.0.24.txt
+++ b/packages/cycling-coach/build/license-overrides/@ai-sdk+provider-utils@4.0.24.txt
@@ -1,0 +1,40 @@
+BSD-3-Clause licensed file attribution
+
+Code adapted from https://github.com/fastify/secure-json-parse/blob/783fcb1b5434709466759847cec974381939673a/index.js
+
+Copyright (c) Vercel, Inc. (https://vercel.com)
+Copyright (c) 2019 The Fastify Team
+Copyright (c) 2019, Sideway Inc, and project contributors
+All rights reserved.
+
+The complete list of contributors can be found at:
+- https://github.com/hapijs/bourne/graphs/contributors
+- https://github.com/fastify/secure-json-parse/graphs/contributors
+- https://github.com/vercel/ai/commits/main/packages/provider-utils/src/secure-parse-json.ts
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+ISC licensed nested attribution
+
+Copyright (c) 2020, Stefan Terdell
+Copyright (c) 2025, Vercel Inc.
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.

--- a/packages/cycling-coach/build/license-overrides/@ai-sdk+provider-utils@4.0.30.txt
+++ b/packages/cycling-coach/build/license-overrides/@ai-sdk+provider-utils@4.0.30.txt
@@ -1,0 +1,40 @@
+BSD-3-Clause licensed file attribution
+
+Code adapted from https://github.com/fastify/secure-json-parse/blob/783fcb1b5434709466759847cec974381939673a/index.js
+
+Copyright (c) Vercel, Inc. (https://vercel.com)
+Copyright (c) 2019 The Fastify Team
+Copyright (c) 2019, Sideway Inc, and project contributors
+All rights reserved.
+
+The complete list of contributors can be found at:
+- https://github.com/hapijs/bourne/graphs/contributors
+- https://github.com/fastify/secure-json-parse/graphs/contributors
+- https://github.com/vercel/ai/commits/main/packages/provider-utils/src/secure-parse-json.ts
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+ISC licensed nested attribution
+
+Copyright (c) 2020, Stefan Terdell
+Copyright (c) 2025, Vercel Inc.
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.

--- a/packages/cycling-coach/build/license-overrides/tr46@0.0.3.txt
+++ b/packages/cycling-coach/build/license-overrides/tr46@0.0.3.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Sebastian Mayr
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/cycling-coach/build/license-texts/Apache-2.0.txt
+++ b/packages/cycling-coach/build/license-texts/Apache-2.0.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/cycling-coach/tests/dockerfile-pin-guard.test.ts
+++ b/packages/cycling-coach/tests/dockerfile-pin-guard.test.ts
@@ -8,10 +8,7 @@ const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
 
 describe("Docker image supply-chain guards", () => {
   it("pins every Dockerfile base image by digest", () => {
-    const dockerfile = readFileSync(
-      resolve(repoRoot, "packages/cycling-coach/Dockerfile"),
-      "utf8",
-    );
+    const dockerfile = readFileSync(resolve(repoRoot, "packages/cycling-coach/Dockerfile"), "utf8");
     const fromLines = dockerfile
       .split("\n")
       .map((line) => line.trim())
@@ -23,6 +20,17 @@ describe("Docker image supply-chain guards", () => {
     }
   });
 
+  it("copies canonical legal inputs before building and preserves runtime copies", () => {
+    const dockerfile = readFileSync(resolve(repoRoot, "packages/cycling-coach/Dockerfile"), "utf8");
+    const builderCopy = "COPY LICENSE NOTICE.md ./";
+    const build = "RUN pnpm --filter cycling-coach... build";
+    const runtimeCopy = "COPY --chown=root:root LICENSE NOTICE.md ./";
+
+    expect(dockerfile.indexOf(builderCopy)).toBeGreaterThan(-1);
+    expect(dockerfile.indexOf(builderCopy)).toBeLessThan(dockerfile.indexOf(build));
+    expect(dockerfile.indexOf(runtimeCopy)).toBeGreaterThan(dockerfile.indexOf(build));
+  });
+
   it("keeps Dependabot watching the cycling-coach Dockerfile", () => {
     const dependabot = YAML.parse(
       readFileSync(resolve(repoRoot, ".github/dependabot.yml"), "utf8"),
@@ -31,8 +39,7 @@ describe("Docker image supply-chain guards", () => {
     expect(
       dependabot.updates?.some(
         (entry) =>
-          entry["package-ecosystem"] === "docker" &&
-          entry.directory === "/packages/cycling-coach",
+          entry["package-ecosystem"] === "docker" && entry.directory === "/packages/cycling-coach",
       ),
     ).toBe(true);
   });

--- a/packages/cycling-coach/tests/legal-artifacts.test.ts
+++ b/packages/cycling-coach/tests/legal-artifacts.test.ts
@@ -1,0 +1,290 @@
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync, existsSync } from "node:fs";
+import { dirname, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { tmpdir } from "node:os";
+import { describe, expect, it } from "vitest";
+import {
+  assertAggregateMatchesGraph,
+  collectThirdPartyPackages,
+  contributingThirdPartyPackageIds,
+  generateLegalArtifacts,
+  overrideFilename,
+  renderAggregate,
+  type BuildMetafile,
+} from "../build/legal-artifacts.js";
+
+interface Fixture {
+  root: string;
+  packageRoot: string;
+  inputRoot: string;
+  repoRoot: string;
+  distDir: string;
+  overridesDir: string;
+  apacheLicensePath: string;
+  metafilePath: string;
+  inputs: string[];
+}
+
+function fixture(): Fixture {
+  const root = mkdtempSync(resolve(tmpdir(), "legal-artifacts-"));
+  const repoRoot = resolve(root, "repo");
+  const packageRoot = resolve(repoRoot, "packages/cycling-coach");
+  const distDir = resolve(packageRoot, "dist");
+  const overridesDir = resolve(packageRoot, "build/license-overrides");
+  const apacheLicensePath = resolve(packageRoot, "build/license-texts/Apache-2.0.txt");
+  const metafilePath = resolve(distDir, "metafile-esm.json");
+  for (const directory of [distDir, overridesDir, resolve(apacheLicensePath, "..")]) {
+    mkdirSync(directory, { recursive: true });
+  }
+  writeFileSync(resolve(repoRoot, "LICENSE"), "project license\n");
+  writeFileSync(resolve(repoRoot, "NOTICE.md"), "project notice\n");
+  writeFileSync(apacheLicensePath, "canonical apache license\n");
+  return {
+    root,
+    packageRoot,
+    inputRoot: packageRoot,
+    repoRoot,
+    distDir,
+    overridesDir,
+    apacheLicensePath,
+    metafilePath,
+    inputs: [],
+  };
+}
+
+function addPackage(
+  target: Fixture,
+  name: string,
+  version: string,
+  license: string,
+  files: Record<string, string> = { LICENSE: "complete license text" },
+): string {
+  const encoded = name.replace("/", "+");
+  const packageRoot = name.startsWith("@")
+    ? resolve(
+        target.repoRoot,
+        `node_modules/.pnpm/${encoded}@${version}_peer/node_modules`,
+        ...name.split("/"),
+      )
+    : resolve(target.repoRoot, `node_modules/.pnpm/${encoded}@${version}/node_modules/${name}`);
+  mkdirSync(resolve(packageRoot, "dist"), { recursive: true });
+  writeFileSync(resolve(packageRoot, "package.json"), JSON.stringify({ name, version, license }));
+  for (const [filename, text] of Object.entries(files)) {
+    writeFileSync(resolve(packageRoot, filename), text);
+  }
+  const input = resolve(packageRoot, "dist/index.js");
+  writeFileSync(input, "export {};\n");
+  target.inputs.push(relative(target.packageRoot, input));
+  return packageRoot;
+}
+
+function metafile(target: Fixture): BuildMetafile {
+  return {
+    outputs: {
+      "dist/index.js": {
+        inputs: Object.fromEntries(target.inputs.map((input) => [input, {}])),
+      },
+    },
+  };
+}
+
+describe("legal artifact generation", () => {
+  it("decodes scoped and unscoped pnpm roots, de-duplicates exact versions, and sorts", () => {
+    const target = fixture();
+    addPackage(target, "zeta", "1.0.0", "MIT", {
+      LICENSE: "zeta license",
+      NOTICE: "zeta notice",
+    });
+    addPackage(target, "@scope/alpha", "2.0.0", "ISC");
+    addPackage(target, "zeta", "2.0.0", "BSD-2-Clause");
+    target.inputs.push(target.inputs[0]);
+
+    const packages = collectThirdPartyPackages(metafile(target), target);
+
+    expect(packages.map((entry) => entry.id)).toEqual([
+      "@scope/alpha@2.0.0",
+      "zeta@1.0.0",
+      "zeta@2.0.0",
+    ]);
+    expect(packages[1].noticeFiles).toEqual([{ name: "NOTICE", text: "zeta notice" }]);
+    expect(contributingThirdPartyPackageIds(metafile(target), target.packageRoot)).toEqual([
+      "@scope/alpha@2.0.0",
+      "zeta@1.0.0",
+      "zeta@2.0.0",
+    ]);
+  });
+
+  it("fails closed when a third-party input has no resolvable package root", () => {
+    const target = fixture();
+    writeFileSync(
+      resolve(target.repoRoot, "package.json"),
+      JSON.stringify({ name: "workspace-root", version: "0.0.0", license: "MIT" }),
+    );
+    const input = resolve(target.repoRoot, "node_modules/orphan/index.js");
+    mkdirSync(resolve(input, ".."), { recursive: true });
+    writeFileSync(input, "export {};\n");
+    target.inputs.push(relative(target.packageRoot, input));
+
+    expect(() => contributingThirdPartyPackageIds(metafile(target), target.packageRoot)).toThrow(
+      "Cannot resolve contributing third-party package root",
+    );
+    expect(() => collectThirdPartyPackages(metafile(target), target)).toThrow(
+      "Cannot resolve contributing third-party package root",
+    );
+  });
+
+  it.each(["Apache-2.0", "MIT", "BSD-2-Clause", "ISC"])(
+    "accepts the reviewed %s expression",
+    (license) => {
+      const target = fixture();
+      addPackage(target, "accepted", "1.0.0", license);
+      expect(collectThirdPartyPackages(metafile(target), target)[0].license).toBe(license);
+    },
+  );
+
+  it.each(["unknown", "GPL-3.0-only", "MIT OR Apache-2.0"])(
+    "rejects the unreviewed %s expression even when text exists",
+    (license) => {
+      const target = fixture();
+      addPackage(target, "rejected", "1.0.0", license);
+      expect(() => collectThirdPartyPackages(metafile(target), target)).toThrow(
+        `Unreviewed license expression for rejected@1.0.0: ${license}`,
+      );
+    },
+  );
+
+  it("does not let an exact-version override bypass license policy", () => {
+    const target = fixture();
+    addPackage(target, "rejected", "1.0.0", "GPL-3.0-only", {});
+    writeFileSync(
+      resolve(target.overridesDir, overrideFilename("rejected", "1.0.0")),
+      "complete override text",
+    );
+
+    expect(() => collectThirdPartyPackages(metafile(target), target)).toThrow(
+      "Unreviewed license expression for rejected@1.0.0: GPL-3.0-only",
+    );
+  });
+
+  it("fails closed without license material and binds overrides to exact versions", () => {
+    const target = fixture();
+    addPackage(target, "missing", "1.0.1", "MIT", {});
+    writeFileSync(
+      resolve(target.overridesDir, overrideFilename("missing", "1.0.0")),
+      "old reviewed text",
+    );
+
+    expect(() => collectThirdPartyPackages(metafile(target), target)).toThrow(
+      "Missing license material for missing@1.0.1",
+    );
+
+    const exactName = overrideFilename("missing", "1.0.1");
+    writeFileSync(resolve(target.overridesDir, exactName), "exact reviewed text");
+    expect(collectThirdPartyPackages(metafile(target), target)[0].override).toEqual({
+      name: exactName,
+      text: "exact reviewed text",
+    });
+  });
+
+  it("rejects an override when the package already supplies license material", () => {
+    const target = fixture();
+    addPackage(target, "complete", "1.0.0", "MIT");
+    writeFileSync(
+      resolve(target.overridesDir, overrideFilename("complete", "1.0.0")),
+      "unnecessary override",
+    );
+
+    expect(() => collectThirdPartyPackages(metafile(target), target)).toThrow(
+      "Exact-version override conflicts with discovered license material for complete@1.0.0",
+    );
+  });
+
+  it("includes canonical Apache text once and retains a short package notice", () => {
+    const target = fixture();
+    addPackage(target, "apache-one", "1.0.0", "Apache-2.0", {
+      LICENSE: "Copyright Example One\nShort Apache notice",
+    });
+    addPackage(target, "apache-two", "1.0.0", "Apache-2.0", {
+      LICENSE: "Copyright Example Two\nShort Apache notice",
+    });
+    const aggregate = renderAggregate(
+      collectThirdPartyPackages(metafile(target), target),
+      "canonical apache license",
+    );
+
+    expect(aggregate.match(/canonical apache license/g)).toHaveLength(1);
+    expect(aggregate).toContain("Copyright Example One");
+    expect(aggregate).toContain("Copyright Example Two");
+  });
+
+  it("retains package attribution surrounding a canonical Apache license", () => {
+    const target = fixture();
+    addPackage(target, "apache-mixed", "1.0.0", "Apache-2.0", {
+      LICENSE: "Copyright Example Before\ncanonical apache license\nPackage notice after",
+    });
+    const aggregate = renderAggregate(
+      collectThirdPartyPackages(metafile(target), target),
+      "canonical apache license",
+    );
+
+    expect(aggregate.match(/canonical apache license/g)).toHaveLength(1);
+    expect(aggregate).toContain("Copyright Example Before");
+    expect(aggregate).toContain("Package notice after");
+  });
+
+  it("retains attribution from the current Apache-licensed provider package", () => {
+    const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+    const apacheText = readFileSync(
+      resolve(repoRoot, "packages/cycling-coach/build/license-texts/Apache-2.0.txt"),
+      "utf8",
+    );
+    const packageRoot = resolve(repoRoot, "packages/core/node_modules/@openrouter/ai-sdk-provider");
+    const aggregate = renderAggregate(
+      [
+        {
+          id: "@openrouter/ai-sdk-provider@2.9.1",
+          name: "@openrouter/ai-sdk-provider",
+          version: "2.9.1",
+          license: "Apache-2.0",
+          packageRoot,
+          licenseFiles: [
+            { name: "LICENSE", text: readFileSync(resolve(packageRoot, "LICENSE"), "utf8") },
+          ],
+          noticeFiles: [],
+        },
+      ],
+      apacheText,
+    );
+
+    expect(aggregate).toContain("Copyright 2025 OpenRouter Inc,");
+    expect(aggregate.match(/TERMS AND CONDITIONS FOR USE/g)).toHaveLength(1);
+  });
+
+  it("copies canonical bytes, proves graph equality, and deletes the metafile", async () => {
+    const target = fixture();
+    addPackage(target, "complete", "1.0.0", "MIT");
+    writeFileSync(target.metafilePath, JSON.stringify(metafile(target)));
+
+    await generateLegalArtifacts(target);
+
+    expect(readFileSync(resolve(target.distDir, "LICENSE"))).toEqual(
+      readFileSync(resolve(target.repoRoot, "LICENSE")),
+    );
+    expect(readFileSync(resolve(target.distDir, "NOTICE.md"))).toEqual(
+      readFileSync(resolve(target.repoRoot, "NOTICE.md")),
+    );
+    expect(readFileSync(resolve(target.distDir, "THIRD_PARTY_LICENSES.txt"), "utf8")).toContain(
+      "Package: complete@1.0.0",
+    );
+    expect(existsSync(target.metafilePath)).toBe(false);
+  });
+
+  it("rejects aggregate membership mismatches and duplicate entries", () => {
+    expect(() => assertAggregateMatchesGraph(["a@1"], ["a@1", "b@1"])).toThrow(
+      "does not match bundle graph",
+    );
+    expect(() => assertAggregateMatchesGraph(["a@1", "a@1"], ["a@1"])).toThrow(
+      "does not match bundle graph",
+    );
+  });
+});

--- a/packages/cycling-coach/tsup.config.ts
+++ b/packages/cycling-coach/tsup.config.ts
@@ -1,9 +1,22 @@
 import { defineConfig } from "tsup";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { generateLegalArtifacts } from "./build/legal-artifacts.js";
+
+const packageRoot = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(packageRoot, "../..");
 
 export default defineConfig({
   entry: ["src/index.ts"],
   format: ["esm"],
   sourcemap: true,
+  metafile: true,
+  esbuildOptions(options) {
+    options.absWorkingDir = repoRoot;
+    options.entryPoints = [resolve(packageRoot, "src/index.ts")];
+    options.outdir = resolve(packageRoot, "dist");
+    options.legalComments = "eof";
+  },
   clean: true,
   splitting: false,
   // Bundle @enduragent/* into the binary. The libs are private workspace
@@ -22,4 +35,5 @@ export default defineConfig({
       "const require = __createRequire(import.meta.url);",
     ].join("\n"),
   },
+  onSuccess: generateLegalArtifacts,
 });

--- a/tools/check-published-package.test.ts
+++ b/tools/check-published-package.test.ts
@@ -1,0 +1,315 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { verifyTarEntries } from "./check-published-package.js";
+
+function validFixture(): { entries: Map<string, Buffer>; repoRoot: string } {
+  const repoRoot = mkdtempSync(resolve(tmpdir(), "packed-package-"));
+  mkdirSync(repoRoot, { recursive: true });
+  writeFileSync(resolve(repoRoot, "LICENSE"), "project license\n");
+  writeFileSync(resolve(repoRoot, "NOTICE.md"), "project notice\n");
+  const aggregate = [
+    "THIRD-PARTY LICENSES AND NOTICES",
+    "Generated from the exact inputs contributing to dist/index.js.",
+    "",
+    "----- PACKAGE -----",
+    "Package: alpha@1.0.0",
+    "License: MIT",
+    "",
+    "License text: LICENSE",
+    "",
+    "complete text",
+    "",
+    "----- END PACKAGE -----",
+    "",
+    "----- PACKAGE -----",
+    "Package: zeta@2.0.0",
+    "License: ISC",
+    "",
+    "License text: LICENSE",
+    "",
+    "complete text",
+    "",
+    "----- END PACKAGE -----",
+    "",
+  ].join("\n");
+  return {
+    repoRoot,
+    entries: new Map(
+      Object.entries({
+        "package/dist/index.js": "bundle",
+        "package/dist/index.js.map": "map",
+        "package/dist/LICENSE": "project license\n",
+        "package/dist/NOTICE.md": "project notice\n",
+        "package/dist/THIRD_PARTY_LICENSES.txt": aggregate,
+        "package/README.md": "readme",
+        "package/package.json": "{}",
+      }).map(([path, contents]) => [path, Buffer.from(contents)]),
+    ),
+  };
+}
+
+describe("published package verifier", () => {
+  it("accepts complete, byte-identical, ordered legal artifacts", () => {
+    const target = validFixture();
+    expect(() => verifyTarEntries(target.entries, target.repoRoot)).not.toThrow();
+  });
+
+  it("rejects missing legal artifacts and noncanonical bytes", () => {
+    const missing = validFixture();
+    missing.entries.delete("package/dist/NOTICE.md");
+    expect(() => verifyTarEntries(missing.entries, missing.repoRoot)).toThrow(
+      "missing package/dist/NOTICE.md",
+    );
+
+    const changed = validFixture();
+    changed.entries.set("package/dist/LICENSE", Buffer.from("changed"));
+    expect(() => verifyTarEntries(changed.entries, changed.repoRoot)).toThrow(
+      "differs from canonical root LICENSE",
+    );
+  });
+
+  it("rejects build paths, absolute paths, duplicates, and unstable ordering", () => {
+    const buildPath = validFixture();
+    buildPath.entries.set("package/dist/metafile-esm.json", Buffer.from("{}"));
+    expect(() => verifyTarEntries(buildPath.entries, buildPath.repoRoot)).toThrow(
+      "build-only path",
+    );
+
+    const absolute = validFixture();
+    const aggregatePath = "package/dist/THIRD_PARTY_LICENSES.txt";
+    absolute.entries.set(
+      aggregatePath,
+      Buffer.concat([absolute.entries.get(aggregatePath)!, Buffer.from("/Users/build/input")]),
+    );
+    expect(() => verifyTarEntries(absolute.entries, absolute.repoRoot)).toThrow(
+      "absolute build path in package/dist/THIRD_PARTY_LICENSES.txt",
+    );
+
+    const duplicate = validFixture();
+    const aggregate = duplicate.entries.get(aggregatePath)!.toString("utf8");
+    duplicate.entries.set(
+      aggregatePath,
+      Buffer.from(
+        `${aggregate}----- PACKAGE -----\nPackage: alpha@1.0.0\nLicense: MIT\n\nLicense text: LICENSE\n\ncomplete text\n\n----- END PACKAGE -----\n`,
+      ),
+    );
+    expect(() => verifyTarEntries(duplicate.entries, duplicate.repoRoot)).toThrow(
+      "duplicate package entries",
+    );
+
+    const unstable = validFixture();
+    unstable.entries.set(
+      aggregatePath,
+      Buffer.from(
+        aggregate
+          .replace("Package: alpha@1.0.0", "Package: temporary@1.0.0")
+          .replace("Package: zeta@2.0.0", "Package: alpha@1.0.0")
+          .replace("Package: temporary@1.0.0", "Package: zeta@2.0.0"),
+      ),
+    );
+    expect(() => verifyTarEntries(unstable.entries, unstable.repoRoot)).toThrow(
+      "not deterministically ordered",
+    );
+  });
+
+  it("rejects build paths in runtime artifacts and incomplete aggregate entries", () => {
+    const runtimePath = validFixture();
+    runtimePath.entries.set(
+      "package/dist/index.js.map",
+      Buffer.from('{"sources":["../../../../Users/build/project/source.ts"]}'),
+    );
+    expect(() => verifyTarEntries(runtimePath.entries, runtimePath.repoRoot)).toThrow(
+      "absolute build path in package/dist/index.js.map",
+    );
+
+    const incomplete = validFixture();
+    const aggregatePath = "package/dist/THIRD_PARTY_LICENSES.txt";
+    incomplete.entries.set(
+      aggregatePath,
+      Buffer.from(
+        incomplete.entries
+          .get(aggregatePath)!
+          .toString("utf8")
+          .replace("License text: LICENSE\n\ncomplete text\n\n----- END PACKAGE -----", ""),
+      ),
+    );
+    expect(() => verifyTarEntries(incomplete.entries, incomplete.repoRoot)).toThrow(
+      "nested third-party package entry",
+    );
+  });
+
+  it.each([
+    "/home/runner/work/project/source.ts",
+    "/tmp/project/source.ts",
+    "/private/tmp/project/source.ts",
+    "/var/folders/cache/project/source.ts",
+    "/workspace/project/source.ts",
+    "/app/project/source.ts",
+    "C:\\Users\\runner\\work\\project\\source.ts",
+    "D:\\a\\project\\source.ts",
+  ])("rejects the build-root sentinel %s", (sentinel) => {
+    const target = validFixture();
+    target.entries.set(
+      "package/dist/index.js",
+      Buffer.from(`const source = ${JSON.stringify(sentinel)};`),
+    );
+    expect(() => verifyTarEntries(target.entries, target.repoRoot)).toThrow(
+      "absolute build path in package/dist/index.js",
+    );
+  });
+
+  it("rejects the exact checkout root in generated artifacts", () => {
+    const target = validFixture();
+    target.entries.set(
+      "package/dist/index.js.map",
+      Buffer.from(JSON.stringify({ sources: [`${target.repoRoot}/source.ts`] })),
+    );
+    expect(() => verifyTarEntries(target.entries, target.repoRoot)).toThrow(
+      "absolute build path in package/dist/index.js.map",
+    );
+
+    const windowsTarget = validFixture();
+    windowsTarget.entries.set(
+      "package/dist/index.js.map",
+      Buffer.from(JSON.stringify({ sources: ["D:/custom-checkout/project/source.ts"] })),
+    );
+    expect(() => verifyTarEntries(windowsTarget.entries, "D:\\custom-checkout\\project")).toThrow(
+      "absolute build path in package/dist/index.js.map",
+    );
+  });
+
+  it("rejects malformed entry boundaries, fields, and license policy", () => {
+    const aggregatePath = "package/dist/THIRD_PARTY_LICENSES.txt";
+
+    const unterminated = validFixture();
+    unterminated.entries.set(
+      aggregatePath,
+      Buffer.from(
+        unterminated.entries
+          .get(aggregatePath)!
+          .toString("utf8")
+          .replace("----- END PACKAGE -----", ""),
+      ),
+    );
+    expect(() => verifyTarEntries(unterminated.entries, unterminated.repoRoot)).toThrow(
+      "nested third-party package entry",
+    );
+
+    const unknownLicense = validFixture();
+    unknownLicense.entries.set(
+      aggregatePath,
+      Buffer.from(
+        unknownLicense.entries
+          .get(aggregatePath)!
+          .toString("utf8")
+          .replace("License: MIT", "License: GPL-3.0-only"),
+      ),
+    );
+    expect(() => verifyTarEntries(unknownLicense.entries, unknownLicense.repoRoot)).toThrow(
+      "Unreviewed license expression",
+    );
+
+    const duplicateField = validFixture();
+    duplicateField.entries.set(
+      aggregatePath,
+      Buffer.from(
+        duplicateField.entries
+          .get(aggregatePath)!
+          .toString("utf8")
+          .replace("License text: LICENSE", "License: MIT\n\nLicense text: LICENSE"),
+      ),
+    );
+    expect(() => verifyTarEntries(duplicateField.entries, duplicateField.repoRoot)).toThrow(
+      "Duplicate package field",
+    );
+
+    const missingText = validFixture();
+    missingText.entries.set(
+      aggregatePath,
+      Buffer.from(
+        missingText.entries
+          .get(aggregatePath)!
+          .toString("utf8")
+          .replace("License text: LICENSE\n\ncomplete text", "License text: LICENSE"),
+      ),
+    );
+    expect(() => verifyTarEntries(missingText.entries, missingText.repoRoot)).toThrow(
+      "Missing legal material",
+    );
+
+    const borrowedNotice = validFixture();
+    borrowedNotice.entries.set(
+      aggregatePath,
+      Buffer.from(
+        borrowedNotice.entries
+          .get(aggregatePath)!
+          .toString("utf8")
+          .replace(
+            "License text: LICENSE\n\ncomplete text",
+            "License text: LICENSE\n\nNotice: NOTICE\n\nnotice text",
+          ),
+      ),
+    );
+    expect(() => verifyTarEntries(borrowedNotice.entries, borrowedNotice.repoRoot)).toThrow(
+      "Missing legal material",
+    );
+
+    const wrongSentinel = validFixture();
+    wrongSentinel.entries.set(
+      aggregatePath,
+      Buffer.from(
+        wrongSentinel.entries
+          .get(aggregatePath)!
+          .toString("utf8")
+          .replace(
+            "License text: LICENSE\n\ncomplete text",
+            "License text: canonical Apache-2.0 text above",
+          ),
+      ),
+    );
+    expect(() => verifyTarEntries(wrongSentinel.entries, wrongSentinel.repoRoot)).toThrow(
+      "Missing legal material",
+    );
+  });
+
+  it("requires the packed canonical Apache text to match the reviewed source", () => {
+    const target = validFixture();
+    const pinnedPath = resolve(
+      target.repoRoot,
+      "packages/cycling-coach/build/license-texts/Apache-2.0.txt",
+    );
+    mkdirSync(resolve(pinnedPath, ".."), { recursive: true });
+    writeFileSync(pinnedPath, "reviewed apache text\n");
+    const apacheAggregate = [
+      "THIRD-PARTY LICENSES AND NOTICES",
+      "Generated from the exact inputs contributing to dist/index.js.",
+      "",
+      "===== CANONICAL LICENSE: Apache-2.0 =====",
+      "",
+      "reviewed apache text",
+      "",
+      "===== END CANONICAL LICENSE =====",
+      "",
+      "----- PACKAGE -----",
+      "Package: apache-package@1.0.0",
+      "License: Apache-2.0",
+      "",
+      "License text: canonical Apache-2.0 text above",
+      "",
+      "----- END PACKAGE -----",
+      "",
+    ].join("\n");
+    target.entries.set("package/dist/THIRD_PARTY_LICENSES.txt", Buffer.from(apacheAggregate));
+    expect(() => verifyTarEntries(target.entries, target.repoRoot)).not.toThrow();
+
+    target.entries.set(
+      "package/dist/THIRD_PARTY_LICENSES.txt",
+      Buffer.from(apacheAggregate.replace("reviewed apache text", "different apache text")),
+    );
+    expect(() => verifyTarEntries(target.entries, target.repoRoot)).toThrow(
+      "differs from the reviewed source",
+    );
+  });
+});

--- a/tools/check-published-package.ts
+++ b/tools/check-published-package.ts
@@ -1,0 +1,154 @@
+#!/usr/bin/env tsx
+
+import { gunzipSync } from "node:zlib";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseAggregatePackageIds } from "../packages/cycling-coach/build/legal-artifacts.js";
+
+const requiredFiles = [
+  "package/dist/index.js",
+  "package/dist/index.js.map",
+  "package/dist/LICENSE",
+  "package/dist/NOTICE.md",
+  "package/dist/THIRD_PARTY_LICENSES.txt",
+  "package/README.md",
+  "package/package.json",
+];
+
+export function readTarGz(path: string): Map<string, Buffer> {
+  const archive = gunzipSync(readFileSync(path));
+  const entries = new Map<string, Buffer>();
+  let offset = 0;
+
+  while (offset + 512 <= archive.length) {
+    const header = archive.subarray(offset, offset + 512);
+    if (header.every((byte) => byte === 0)) break;
+    const readString = (start: number, length: number) =>
+      header
+        .subarray(start, start + length)
+        .toString("utf8")
+        .replace(/\0.*$/s, "");
+    const name = readString(0, 100);
+    const prefix = readString(345, 155);
+    const fullName = prefix ? `${prefix}/${name}` : name;
+    const sizeText = readString(124, 12).trim();
+    const size = sizeText.length === 0 ? 0 : Number.parseInt(sizeText, 8);
+    if (!Number.isSafeInteger(size)) {
+      throw new Error(`Invalid tar entry size for ${fullName}`);
+    }
+    const type = String.fromCharCode(header[156] || 48);
+    offset += 512;
+    if (type === "0" || type === "\0") {
+      entries.set(fullName.replace(/^\.\//, ""), archive.subarray(offset, offset + size));
+    }
+    offset += Math.ceil(size / 512) * 512;
+  }
+  return entries;
+}
+
+function requiredEntry(entries: Map<string, Buffer>, path: string): Buffer {
+  const entry = entries.get(path);
+  if (!entry) throw new Error(`Published package is missing ${path}`);
+  return entry;
+}
+
+export function verifyTarEntries(entries: Map<string, Buffer>, repoRoot: string): void {
+  for (const path of requiredFiles) requiredEntry(entries, path);
+
+  const absoluteBuildPath =
+    /\/(?:Users|home)\/[^/\s]+\/|\/(?:private\/)?(?:tmp|var\/folders)\/|\/(?:app|workspace)\/|[A-Za-z]:\\{1,2}(?:Users|workspace|a|agent|build)\\{1,2}/;
+  const forwardSlashRepoRoot = repoRoot.replaceAll("\\", "/");
+  const backslashRepoRoot = forwardSlashRepoRoot.replaceAll("/", "\\");
+  const buildRootVariants = [
+    repoRoot,
+    forwardSlashRepoRoot,
+    backslashRepoRoot,
+    backslashRepoRoot.replaceAll("\\", "\\\\"),
+  ];
+  for (const [path, contents] of entries) {
+    const text = contents.toString("utf8");
+    if (
+      absoluteBuildPath.test(path) ||
+      absoluteBuildPath.test(text) ||
+      buildRootVariants.some((buildRoot) => path.includes(buildRoot) || text.includes(buildRoot))
+    ) {
+      throw new Error(`Published package contains an absolute build path in ${path}`);
+    }
+  }
+
+  const forbiddenPath = [...entries.keys()].find(
+    (path) =>
+      /(?:^|\/)metafile(?:-[^/]*)?\.json$/i.test(path) ||
+      path.startsWith("package/build/") ||
+      path.includes("/build/license-"),
+  );
+  if (forbiddenPath) {
+    throw new Error(`Published package contains build-only path: ${forbiddenPath}`);
+  }
+
+  const distLicense = requiredEntry(entries, "package/dist/LICENSE");
+  const distNotice = requiredEntry(entries, "package/dist/NOTICE.md");
+  if (!distLicense.equals(readFileSync(resolve(repoRoot, "LICENSE")))) {
+    throw new Error("Published dist/LICENSE differs from canonical root LICENSE");
+  }
+  if (!distNotice.equals(readFileSync(resolve(repoRoot, "NOTICE.md")))) {
+    throw new Error("Published dist/NOTICE.md differs from canonical root NOTICE.md");
+  }
+
+  const aggregate = requiredEntry(entries, "package/dist/THIRD_PARTY_LICENSES.txt").toString(
+    "utf8",
+  );
+  if (aggregate.trim().length === 0) {
+    throw new Error("Published third-party aggregate is empty");
+  }
+  const ids = parseAggregatePackageIds(aggregate);
+  if (ids.length === 0) {
+    throw new Error("Published third-party aggregate has no package entries");
+  }
+  if (new Set(ids).size !== ids.length) {
+    throw new Error("Published third-party aggregate has duplicate package entries");
+  }
+  const sortedIds = [...ids].sort();
+  if (JSON.stringify(ids) !== JSON.stringify(sortedIds)) {
+    throw new Error("Published third-party aggregate is not deterministically ordered");
+  }
+  if (aggregate.includes("\nLicense: Apache-2.0\n")) {
+    const startMarker = "===== CANONICAL LICENSE: Apache-2.0 =====\n\n";
+    const endMarker = "\n\n===== END CANONICAL LICENSE =====";
+    const start = aggregate.indexOf(startMarker);
+    const end = aggregate.indexOf(endMarker, start + startMarker.length);
+    const canonicalText =
+      start === -1 || end === -1 ? "" : aggregate.slice(start + startMarker.length, end);
+    const pinnedText = readFileSync(
+      resolve(repoRoot, "packages/cycling-coach/build/license-texts/Apache-2.0.txt"),
+      "utf8",
+    ).trimEnd();
+    if (canonicalText !== pinnedText) {
+      throw new Error("Published canonical Apache-2.0 text differs from the reviewed source");
+    }
+  }
+  for (const id of ids) {
+    const escaped = id.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    if (!new RegExp(`Package: ${escaped}\\nLicense: [^\\n]+`).test(aggregate)) {
+      throw new Error(`Malformed third-party aggregate entry for ${id}`);
+    }
+  }
+}
+
+export function verifyPublishedPackage(tarballPath: string, repoRoot: string): void {
+  verifyTarEntries(readTarGz(tarballPath), repoRoot);
+}
+
+const invokedPath = process.argv[1] ? resolve(process.argv[1]) : "";
+if (invokedPath === fileURLToPath(import.meta.url)) {
+  const args = process.argv.slice(2);
+  if (args[0] === "--") args.shift();
+  const tarballPath = args[0];
+  if (!tarballPath || args.length !== 1) {
+    throw new Error("usage: pnpm check:published-package -- <package.tgz>");
+  }
+  const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+  verifyPublishedPackage(resolve(tarballPath), repoRoot);
+  console.log(`Verified published package: ${tarballPath}`);
+}


### PR DESCRIPTION
## Summary

- stage the project license and canonical notice byte-for-byte into the published `dist`
- derive a deterministic third-party license aggregate from the exact bundle metafile, with a fail-closed four-expression allowlist and exact-version overrides
- preserve package-specific Apache attribution while including the reviewed canonical Apache text once
- remove build-machine paths and the temporary metafile before packing
- verify packed contents in CI, release smoke, and the publish job; the publish job now publishes the same tarball it verifies
- point installed-package readers to the shipped notice files and provide the Docker builder with the canonical legal inputs

## Package impact

- before: 757,102 compressed bytes; 3,158,776 unpacked bytes
- after: 764,552 compressed bytes; 3,174,226 unpacked bytes
- delta: +7,450 compressed bytes; +15,450 unpacked bytes
- current aggregate: nine sorted exact package-version entries; declared expressions are Apache-2.0 and MIT

## Verification

- `pnpm check`
- `pnpm test` — 210 files passed, 2 skipped; 3,177 tests passed, 5 skipped
- focused legal/Docker/verifier suite — 35 tests passed
- real build plus single-tarball verifier
- fresh consumer install of the exact verified tarball and CLI `--help`
- final Docker image build and container CLI `--help`
- three independent post-fix reviews: no remaining code or packaging blockers

The existing `no-control-regex` lint warning in `prompt-fence.ts` remains unchanged.

## Human legal gate — required before merge

- [x] approve the reviewed Apache-2.0 text (`c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4`) against the [official Apache source](https://www.apache.org/licenses/LICENSE-2.0.txt); the stored copy differs only by omitting the source file's leading blank line
- [x] approve the exact-version provider-utils overrides for [4.0.24](https://github.com/vercel/ai/tree/77a4e053a1cf1540c2da9050ace9e035c8a3ad3a/packages/provider-utils) and [4.0.30](https://github.com/vercel/ai/tree/caebb44016dbd084e5bf7b7f4ab5194fd2c7c045/packages/provider-utils), including the BSD-3 file attribution and nested ISC text
- [x] approve the `tr46@0.0.3` override against the author's [immediately-following MIT-license commit](https://github.com/jsdom/tr46/commit/3a6f29721e7063b9ffd421e461a54beae6170001), whose parent is the exact 0.0.3 tag; the override is byte-identical to that added file
- [x] confirm `Copyright 2025 OpenRouter Inc,` survives in the generated aggregate
- [x] click and approve both repaired absolute links in `NOTICE.md`
- [x] confirm the reviewed license-expression allowlist remains exactly Apache-2.0, MIT, BSD-2-Clause, and ISC

Human legal gate approved on 2026-07-14.
