### PR TITLE
feat(kernel): decode FIT into deterministic store rows

### DIFF
--- a/.changeset/fit-ingest-store-rows.md
+++ b/.changeset/fit-ingest-store-rows.md
@@ -1,0 +1,8 @@
+---
+"@enduragent/kernel": patch
+"@enduragent/kernel-node": patch
+---
+
+Decode FIT artifacts into deterministic local-store rows with content-derived
+keys, identity-preserving developer fields, aligned stream blobs,
+archive-first persistence, and byte-identical re-ingest verification.

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -151,3 +151,37 @@ codebase's own type vocabulary and trimmed to what the coach needs:
   truncated arguments collapse to `{}`, so the tool's own schema validation
   rejects the call cleanly rather than the model executing on a best-effort
   partial object — preferable for a write-capable coach.
+---
+
+## fit-file-parser
+
+FIT decoding uses a modified copy of fit-file-parser 3.0.2, distributed under
+the MIT License. The local patch corrects declared developer-field base-type
+decoding, preserves occurrence identity in decoded session, lap, and record
+messages, and makes CRC failures terminate; the existing flattened field-name
+view is retained for compatibility.
+
+### Original license (verbatim)
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Pierre Jacquier
+http://pierrejacquier.com | @pierremtb
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -63,7 +63,10 @@
       "esbuild",
       "msw",
       "protobufjs"
-    ]
+    ],
+    "patchedDependencies": {
+      "fit-file-parser@3.0.2": "patches/fit-file-parser@3.0.2.patch"
+    }
   },
   "license": "MIT",
   "repository": {

--- a/packages/cycling-coach/NOTICE.md
+++ b/packages/cycling-coach/NOTICE.md
@@ -151,3 +151,37 @@ codebase's own type vocabulary and trimmed to what the coach needs:
   truncated arguments collapse to `{}`, so the tool's own schema validation
   rejects the call cleanly rather than the model executing on a best-effort
   partial object — preferable for a write-capable coach.
+---
+
+## fit-file-parser
+
+FIT decoding uses a modified copy of fit-file-parser 3.0.2, distributed under
+the MIT License. The local patch corrects declared developer-field base-type
+decoding, preserves occurrence identity in decoded session, lap, and record
+messages, and makes CRC failures terminate; the existing flattened field-name
+view is retained for compatibility.
+
+### Original license (verbatim)
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Pierre Jacquier
+http://pierrejacquier.com | @pierremtb
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/kernel-node/package.json
+++ b/packages/kernel-node/package.json
@@ -10,7 +10,8 @@
     "./archive": "./dist/archive/index.js",
     "./lock": "./dist/lock/index.js",
     "./store-export": "./dist/store-export/index.js",
-    "./home": "./dist/home/index.js"
+    "./home": "./dist/home/index.js",
+    "./ingest": "./dist/ingest/index.js"
   },
   "engines": {
     "node": ">=24"
@@ -22,6 +23,7 @@
   },
   "dependencies": {
     "@enduragent/kernel": "workspace:*",
+    "fit-file-parser": "3.0.2",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/packages/kernel-node/src/ingest/fit-decoder.ts
+++ b/packages/kernel-node/src/ingest/fit-decoder.ts
@@ -1,0 +1,206 @@
+import { Buffer } from "node:buffer";
+import FitParser from "fit-file-parser";
+import {
+  FitSourceError,
+  type DecodedDeveloperField,
+  type DecodedFitFile,
+  type FitEnumInput,
+} from "@enduragent/kernel/ingest";
+
+export const FIT_PARSER_OPTIONS = Object.freeze({ force: false, mode: "list" } as const);
+
+export interface FitDecoder {
+  decode(bytes: Uint8Array): Promise<DecodedFitFile>;
+}
+
+interface PatchedDeveloperEnvelope {
+  readonly nativeMessageType: unknown;
+  readonly developer_data_index: unknown;
+  readonly field_definition_number: unknown;
+  readonly field_name: unknown;
+  readonly units: unknown;
+  readonly value: unknown;
+}
+type PatchedParserMessage = Record<string, unknown> & {
+  readonly developer_fields?: readonly PatchedDeveloperEnvelope[] | null;
+};
+
+function object(value: unknown): PatchedParserMessage {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new FitSourceError("decode_failed");
+  }
+  return value as PatchedParserMessage;
+}
+
+function family(root: PatchedParserMessage, key: string): PatchedParserMessage[] {
+  const value = root[key];
+  if (value === undefined) return [];
+  if (!Array.isArray(value)) throw new FitSourceError("decode_failed");
+  return value.map(object);
+}
+
+function nullableNumber(message: PatchedParserMessage, key: string): number | null {
+  const value = message[key];
+  if (value === undefined || value === null) return null;
+  if (typeof value !== "number") throw new FitSourceError("invalid_numeric");
+  return value;
+}
+
+function enhancedNumber(message: PatchedParserMessage, key: string): number | null {
+  const value = message[key];
+  if (value === undefined) return null;
+  if (typeof value !== "number") throw new FitSourceError("invalid_numeric");
+  return value;
+}
+
+function nullableString(message: PatchedParserMessage, key: string): string | null {
+  const value = message[key];
+  if (value === undefined || value === null) return null;
+  if (typeof value !== "string") throw new FitSourceError("decode_failed");
+  return value;
+}
+
+function enumInput(message: PatchedParserMessage, key: string): FitEnumInput {
+  const value = message[key];
+  if (value === undefined || value === null) return null;
+  if (typeof value !== "string" && typeof value !== "number") {
+    throw new FitSourceError("invalid_enum");
+  }
+  return value;
+}
+
+function fitDate(message: PatchedParserMessage, key: string, integer: boolean): number | null {
+  const value = message[key];
+  if (value === undefined || value === null) return null;
+  let seconds: number;
+  if (value instanceof Date) seconds = value.getTime() / 1000;
+  else if (typeof value === "string") seconds = Date.parse(value) / 1000;
+  else throw new FitSourceError("invalid_date");
+  if (!Number.isFinite(seconds) || (integer && !Number.isInteger(seconds))) {
+    throw new FitSourceError("invalid_date");
+  }
+  return seconds;
+}
+
+function developerFields(message: PatchedParserMessage): readonly DecodedDeveloperField[] {
+  const value = message.developer_fields;
+  if (value === undefined || value === null) return [];
+  if (!Array.isArray(value)) throw new FitSourceError("decode_failed");
+  return value.map((candidate) => {
+    const envelope = object(candidate);
+    const nativeMessageType = envelope.nativeMessageType;
+    const developerIndex = envelope.developer_data_index;
+    const fieldNumber = envelope.field_definition_number;
+    if (typeof nativeMessageType !== "number" || typeof developerIndex !== "number" || typeof fieldNumber !== "number") {
+      throw new FitSourceError("decode_failed");
+    }
+    const fieldName = envelope.field_name ?? null;
+    const units = envelope.units ?? null;
+    if ((fieldName !== null && typeof fieldName !== "string") || (units !== null && typeof units !== "string") || envelope.value === undefined) {
+      throw new FitSourceError("decode_failed");
+    }
+    return {
+      nativeMessageType,
+      developer_data_index: developerIndex,
+      field_definition_number: fieldNumber,
+      field_name: fieldName,
+      units,
+      value: envelope.value,
+    };
+  });
+}
+
+function leftRightBalance(message: PatchedParserMessage): number | null {
+  const value = message.left_right_balance;
+  if (value === undefined || value === null) return null;
+  if (typeof value !== "object" || Array.isArray(value)) throw new FitSourceError("invalid_numeric");
+  const keys = Object.keys(value).sort();
+  if (keys.join(",") !== "right,value") throw new FitSourceError("invalid_numeric");
+  const record = value as Record<string, unknown>;
+  if (typeof record.right !== "boolean" || typeof record.value !== "number" || !Number.isFinite(record.value) || !Number.isInteger(record.value) || record.value < 0 || record.value > 127) {
+    throw new FitSourceError("invalid_numeric");
+  }
+  return record.value;
+}
+
+function adapt(rootValue: unknown): DecodedFitFile {
+  const root = object(rootValue);
+  const fileIds = family(root, "file_ids").map((m) => ({
+    serialNumber: nullableNumber(m, "serial_number"),
+    timeCreated: fitDate(m, "time_created", true),
+    manufacturer: enumInput(m, "manufacturer"),
+    product: enumInput(m, "product"),
+    productName: nullableString(m, "product_name"),
+  }));
+  const activityValue = root.activity;
+  const activityMessage = activityValue === undefined || activityValue === null ? null : object(activityValue);
+  const activity = activityMessage === null ? null : {
+    timestamp: fitDate(activityMessage, "timestamp", true),
+    localTimestamp: fitDate(activityMessage, "local_timestamp", true),
+    numSessions: nullableNumber(activityMessage, "num_sessions"),
+    type: enumInput(activityMessage, "type"),
+    event: enumInput(activityMessage, "event"),
+    eventType: enumInput(activityMessage, "event_type"),
+  };
+  const sessions = family(root, "sessions").map((m, sourceIndex) => ({
+    sourceIndex,
+    sport: enumInput(m, "sport"), subSport: enumInput(m, "sub_sport"),
+    startTime: fitDate(m, "start_time", true), timestamp: fitDate(m, "timestamp", true),
+    trigger: enumInput(m, "trigger"), firstLapIndex: nullableNumber(m, "first_lap_index"),
+    numLaps: nullableNumber(m, "num_laps"), totalElapsedTime: nullableNumber(m, "total_elapsed_time"),
+    totalTimerTime: nullableNumber(m, "total_timer_time"), totalMovingTime: nullableNumber(m, "total_moving_time"),
+    totalDistance: nullableNumber(m, "total_distance"), developerFields: developerFields(m),
+  }));
+  const laps = family(root, "laps").map((m, sourceIndex) => ({
+    sourceIndex, startTime: fitDate(m, "start_time", true), timestamp: fitDate(m, "timestamp", true),
+    firstLengthIndex: nullableNumber(m, "first_length_index"), numLengths: nullableNumber(m, "num_lengths"),
+    numActiveLengths: nullableNumber(m, "num_active_lengths"), totalElapsedTime: nullableNumber(m, "total_elapsed_time"),
+    totalTimerTime: nullableNumber(m, "total_timer_time"), totalDistance: nullableNumber(m, "total_distance"),
+    developerFields: developerFields(m),
+  }));
+  const lengths = family(root, "lengths").map((m, sourceIndex) => ({
+    sourceIndex, startTime: fitDate(m, "start_time", true), timestamp: fitDate(m, "timestamp", true),
+    totalElapsedTime: nullableNumber(m, "total_elapsed_time"), totalTimerTime: nullableNumber(m, "total_timer_time"),
+    totalStrokes: nullableNumber(m, "total_strokes"), swimStroke: enumInput(m, "swim_stroke"), lengthType: enumInput(m, "length_type"),
+  }));
+  const records = family(root, "records").map((m, sourceIndex) => ({
+    sourceIndex, timestamp: fitDate(m, "timestamp", false), positionLat: nullableNumber(m, "position_lat"),
+    positionLong: nullableNumber(m, "position_long"), distance: nullableNumber(m, "distance"),
+    enhancedAltitude: enhancedNumber(m, "enhanced_altitude"), altitude: nullableNumber(m, "altitude"),
+    enhancedSpeed: enhancedNumber(m, "enhanced_speed"), speed: nullableNumber(m, "speed"),
+    heartRate: nullableNumber(m, "heart_rate"), cadence: nullableNumber(m, "cadence"),
+    fractionalCadence: nullableNumber(m, "fractional_cadence"), power: nullableNumber(m, "power"),
+    temperature: nullableNumber(m, "temperature"), stanceTime: nullableNumber(m, "stance_time"),
+    stanceTimeBalance: nullableNumber(m, "stance_time_balance"), verticalOscillation: nullableNumber(m, "vertical_oscillation"),
+    verticalRatio: nullableNumber(m, "vertical_ratio"), stepLength: nullableNumber(m, "step_length"),
+    leftRightBalance: leftRightBalance(m), respirationRate: nullableNumber(m, "respiration_rate"),
+    developerFields: developerFields(m), coordinateUnit: "degrees" as const,
+  }));
+  const events = family(root, "events").map((m, sourceIndex) => ({
+    sourceIndex, timestamp: fitDate(m, "timestamp", true), event: enumInput(m, "event"),
+    eventType: enumInput(m, "event_type"), data: nullableNumber(m, "data"),
+  }));
+  const developerDataIds = family(root, "developer_data_ids").map((m) => {
+    const index = nullableNumber(m, "developer_data_index");
+    if (index === null) throw new FitSourceError("decode_failed");
+    const app = m.application_id;
+    if (app !== undefined && app !== null && !Array.isArray(app)) throw new FitSourceError("decode_failed");
+    return { developerDataIndex: index, applicationId: app == null ? null : [...app] as number[] };
+  });
+  return { fileIds, activity, sessions, laps, lengths, records, events, developerDataIds };
+}
+
+export function createFitDecoder(): FitDecoder {
+  return {
+    async decode(bytes) {
+      const parser = new FitParser(FIT_PARSER_OPTIONS);
+      let parsed: unknown;
+      try {
+        parsed = await parser.parseAsync(Buffer.from(bytes));
+      } catch {
+        throw new FitSourceError("decode_failed");
+      }
+      return adapt(parsed);
+    },
+  };
+}

--- a/packages/kernel-node/src/ingest/fit-import.ts
+++ b/packages/kernel-node/src/ingest/fit-import.ts
@@ -1,0 +1,51 @@
+import { toHex, type ArchiveManager } from "@enduragent/kernel/archive";
+import {
+  FitSourceError,
+  mapFitArtifact,
+  rebuildRawFileInTransaction,
+  withArchivePath,
+  type FitSourceErrorCode,
+} from "@enduragent/kernel/ingest";
+import type { CryptoPort } from "@enduragent/kernel/ports";
+import type { MigratorStore, SqlStore } from "@enduragent/kernel/store";
+import type { FitDecoder } from "./fit-decoder.js";
+
+export interface FitImportDependencies {
+  readonly archive: ArchiveManager;
+  readonly crypto: CryptoPort;
+  readonly store: SqlStore & Pick<MigratorStore, "transaction">;
+  readonly decoder: FitDecoder;
+}
+export interface ImportedFitResult {
+  readonly kind: "imported";
+  readonly rawInserted: boolean;
+  readonly rawSha256: string;
+  readonly archivePath: string;
+  readonly archiveDeduped: boolean;
+}
+export interface QuarantinedFitResult {
+  readonly kind: "quarantined";
+  readonly rawSha256: string;
+  readonly archivePath: string;
+  readonly reason: `fit:${FitSourceErrorCode}`;
+}
+export type FitImportResult = ImportedFitResult | QuarantinedFitResult;
+
+export async function importFitArtifact(bytes: Uint8Array, dependencies: FitImportDependencies): Promise<FitImportResult> {
+  const rawSha256 = toHex(await dependencies.crypto.sha256(bytes));
+  let mapped;
+  try {
+    const decoded = await dependencies.decoder.decode(bytes);
+    mapped = await mapFitArtifact({crypto:dependencies.crypto,rawSha256,rawByteLength:bytes.byteLength,archivePath:null,decoded});
+  } catch (error) {
+    if (!(error instanceof FitSourceError)) throw error;
+    const reason = `fit:${error.code}` as const;
+    const quarantined = await dependencies.archive.quarantine(bytes,"fit",reason);
+    return {kind:"quarantined",rawSha256,archivePath:quarantined.relPath,reason};
+  }
+  const archived = await dependencies.archive.writeArtifact(bytes,"fit",{epochSeconds:mapped.logicalArchiveEpochSeconds});
+  if (archived.address !== rawSha256) throw new Error("archive address mismatch");
+  const artifact = withArchivePath(mapped,archived.relPath);
+  const {rawInserted} = await dependencies.store.transaction(() => rebuildRawFileInTransaction(dependencies.store,artifact));
+  return {kind:"imported",rawInserted,rawSha256,archivePath:archived.relPath,archiveDeduped:archived.deduped};
+}

--- a/packages/kernel-node/src/ingest/index.ts
+++ b/packages/kernel-node/src/ingest/index.ts
@@ -1,0 +1,2 @@
+export * from "./fit-decoder.js";
+export * from "./fit-import.js";

--- a/packages/kernel-node/tests/fit-decoder.test.ts
+++ b/packages/kernel-node/tests/fit-decoder.test.ts
@@ -1,0 +1,50 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import FitParser from "fit-file-parser";
+import { describe, expect, it, vi } from "vitest";
+import { createFitDecoder, FIT_PARSER_OPTIONS } from "../src/ingest/fit-decoder.js";
+
+const fixture=(name:string)=>new Uint8Array(readFileSync(resolve("packages/kernel-node/tests/fixtures/ingest",name)));
+function containsUndefined(value:unknown):boolean{if(value===undefined)return true;if(Array.isArray(value))return value.some(containsUndefined);if(value!==null&&typeof value==="object")return Object.values(value).some(containsUndefined);return false;}
+async function decodeRoot(root:unknown){const spy=vi.spyOn(FitParser.prototype,"parseAsync").mockResolvedValueOnce(root as never);try{return await createFitDecoder().decode(new Uint8Array())}finally{spy.mockRestore()}}
+
+describe("patched FIT decoder",()=>{
+  it("uses the literal parser options and adapts real fixtures without undefined",async()=>{
+    expect(FIT_PARSER_OPTIONS).toEqual({force:false,mode:"list"});expect(Object.isFrozen(FIT_PARSER_OPTIONS)).toBe(true);
+    const decoded=await createFitDecoder().decode(fixture("triathlon-multisport.fit"));
+    expect(containsUndefined(decoded)).toBe(false);expect(decoded.sessions).toHaveLength(5);expect(decoded.records).toHaveLength(14);
+    expect(decoded.sessions.map((s)=>[s.sport,s.subSport,s.trigger])).toEqual([["swimming","open_water","auto_multi_sport"],["transition","generic","auto_multi_sport"],["cycling","generic","auto_multi_sport"],["transition","generic","auto_multi_sport"],["running","generic","activity_end"]]);
+    expect(decoded.sessions.slice(1).map((s)=>s.startTime)).toEqual(decoded.sessions.slice(0,-1).map((s)=>s.timestamp));
+    expect(decoded.records.map((r)=>r.timestamp).filter((t)=>decoded.sessions.slice(1).some((s)=>s.startTime===t))).toEqual(decoded.sessions.slice(1).map((s)=>s.startTime));
+    expect(decoded.events.filter((e)=>e.eventType==="marker").map((e)=>[e.event,e.data,e.timestamp])).toEqual([[38,271,decoded.records[2].timestamp],[38,0,(decoded.records.at(-1)?.timestamp as number)-1]]);
+    expect(decoded.activity).toMatchObject({timestamp:decoded.sessions.at(-1)?.timestamp,numSessions:5,type:"auto_multi_sport",event:"activity",eventType:"stop"});
+  });
+  it("preserves all developer occurrences and characterized values",async()=>{
+    const decoded=await createFitDecoder().decode(fixture("dual-developer-index.fit"));
+    const fields=[...decoded.sessions.flatMap((x)=>x.developerFields),...decoded.laps.flatMap((x)=>x.developerFields),...decoded.records.flatMap((x)=>x.developerFields)];
+    expect(fields).toHaveLength(178);expect(new Set(fields.filter((x)=>x.field_name==="currHemoPerc").map((x)=>x.value))).toEqual(new Set([62.099998474121094,65.5999984741211]));
+  });
+  it("normalizes optional developer metadata and preserves duplicate occurrences",async()=>{
+    const envelope={nativeMessageType:20,developer_data_index:1,field_definition_number:2,value:{a:1}};
+    const decoded=await decodeRoot({records:[{developer_fields:[envelope,{...envelope,value:{a:1}},{...envelope,value:{a:2}}]}]});
+    expect(decoded.records[0].developerFields).toEqual([{...envelope,field_name:null,units:null},{...envelope,field_name:null,units:null},{...envelope,value:{a:2},field_name:null,units:null}]);
+    await expect(decodeRoot({records:[{developer_fields:[{...envelope,value:undefined}]}]})).rejects.toMatchObject({code:"decode_failed"});
+  });
+  it("extracts only the exact left-right mask object and distinguishes enhanced absence",async()=>{
+    const decoded=await decodeRoot({records:[{left_right_balance:{value:64,right:true},altitude:10,speed:4}]});
+    expect(decoded.records[0]).toMatchObject({leftRightBalance:64,enhancedAltitude:null,altitude:10,enhancedSpeed:null,speed:4});
+    for(const bad of [64,{value:64},{value:64,right:1},{value:-1,right:false},{value:128,right:false},{value:1.5,right:false},{value:64,right:false,extra:0}]) {
+      await expect(decodeRoot({records:[{left_right_balance:bad}]})).rejects.toMatchObject({code:"invalid_numeric"});
+    }
+    for(const key of ["enhanced_altitude","enhanced_speed"]) {
+      await expect(decodeRoot({records:[{[key]:null}]})).rejects.toMatchObject({code:"invalid_numeric"});
+      await expect(decodeRoot({records:[{[key]:"1"}]})).rejects.toMatchObject({code:"invalid_numeric"});
+    }
+  });
+  it("rejects header and file CRC corruption through ordinary awaited calls",async()=>{
+    const header=fixture("triathlon-multisport.fit");header[12]^=1;
+    await expect(createFitDecoder().decode(header)).rejects.toMatchObject({code:"decode_failed"});
+    const file=fixture("triathlon-multisport.fit");file[file.length-1]^=1;
+    await expect(createFitDecoder().decode(file)).rejects.toMatchObject({code:"decode_failed"});
+  });
+});

--- a/packages/kernel-node/tests/fit-import.test.ts
+++ b/packages/kernel-node/tests/fit-import.test.ts
@@ -1,0 +1,54 @@
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { ArchiveManager } from "@enduragent/kernel/archive";
+import type { DecodedFitFile } from "@enduragent/kernel/ingest";
+import type { CryptoPort } from "@enduragent/kernel/ports";
+import { RawFileInvariantError, runMigrations, type MigratorStore, type SqlStore } from "@enduragent/kernel/store";
+import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
+import { createFitDecoder } from "../src/ingest/fit-decoder.js";
+import { importFitArtifact } from "../src/ingest/fit-import.js";
+import { openSqliteStorage } from "../src/sqlite/index.js";
+
+const crypto:CryptoPort={async sha256(d){return new Uint8Array(createHash("sha256").update(d).digest())},async randomBytes(){throw new Error("unused")},async pbkdf2(){throw new Error("unused")},async aesGcmEncrypt(){throw new Error("unused")},async aesGcmDecrypt(){throw new Error("unused")}};
+const bytes=new Uint8Array(readFileSync(resolve("packages/kernel-node/tests/fixtures/ingest/triathlon-multisport.fit")));
+const address=()=>createHash("sha256").update(bytes).digest("hex");
+function archive(events:string[],fail=false,instants:number[]=[]):ArchiveManager{return{async writeArtifact(_b,_e,when){events.push("archive");instants.push(when.epochSeconds);if(fail)throw new Error("archive failed");return{address:address(),relPath:`1998/07/${address()}.fit`,deduped:false}},async quarantine(_b,_e,reason){events.push(`quarantine:${reason}`);return{address:address(),relPath:`quarantine/${address()}.fit`,deduped:false}},async writeSnapshot(){throw new Error("unused")},async readArtifact(){throw new Error("unused")},async readSnapshot(){throw new Error("unused")},async has(){return false}}}
+const decoder=(decoded:DecodedFitFile)=>({async decode(){return decoded}});
+
+describe("archive-first FIT import",()=>{
+  let store:SqlStore&MigratorStore;
+  beforeEach(async()=>{store=openSqliteStorage(":memory:");await runMigrations(store,MIGRATIONS)});afterEach(async()=>store.close());
+  it("quarantines decode failures with zero SQL",async()=>{
+    const events:string[]=[];const result=await importFitArtifact(new Uint8Array([1]),{archive:archive(events),crypto,store,decoder:createFitDecoder()});
+    expect(result).toMatchObject({kind:"quarantined",reason:"fit:decode_failed"});expect(events).toEqual(["quarantine:fit:decode_failed"]);expect((await store.get("SELECT count(*) c FROM raw_file"))?.c).toBe(0);
+  });
+  it("archives before transaction and writes no source ledger row",async()=>{
+    const events:string[]=[];const original=store.transaction.bind(store);store.transaction=async(fn)=>{events.push("transaction");return original(fn)};
+    const result=await importFitArtifact(bytes,{archive:archive(events),crypto,store,decoder:createFitDecoder()});
+    expect(result).toMatchObject({kind:"imported",rawInserted:true});expect(events.slice(0,2)).toEqual(["archive","transaction"]);expect((await store.get("SELECT count(*) c FROM source_record"))?.c).toBe(0);
+  });
+  it("does not start SQL when archive fails",async()=>{
+    const events:string[]=[];let transactions=0;const original=store.transaction.bind(store);store.transaction=async(fn)=>{transactions++;return original(fn)};
+    await expect(importFitArtifact(bytes,{archive:archive(events,true),crypto,store,decoder:createFitDecoder()})).rejects.toThrow("archive failed");expect(transactions).toBe(0);
+  });
+  it("leaves archive-only state when SQL fails",async()=>{
+    const events:string[]=[];const original=store.transaction.bind(store);store.transaction=async(fn)=>original(async()=>{events.push("transaction");await fn();expect(Number((await store.get("SELECT count(*) c FROM raw_file"))?.c)).toBe(1);throw new Error("sql failed")});
+    await expect(importFitArtifact(bytes,{archive:archive(events),crypto,store,decoder:createFitDecoder()})).rejects.toThrow("sql failed");expect(events).toEqual(["archive","transaction"]);expect((await store.get("SELECT count(*) c FROM raw_file"))?.c).toBe(0);
+  });
+  it("reimports exactly and rejects same-SHA metadata drift",async()=>{
+    const events:string[]=[];const decoded=await createFitDecoder().decode(bytes);const deps={archive:archive(events),crypto,store,decoder:decoder(decoded)};
+    await expect(importFitArtifact(bytes,deps)).resolves.toMatchObject({kind:"imported",rawInserted:true});
+    await expect(importFitArtifact(bytes,deps)).resolves.toMatchObject({kind:"imported",rawInserted:false});
+    const changed={...decoded,fileIds:[{...decoded.fileIds[0],productName:"different"},...decoded.fileIds.slice(1)]};
+    await expect(importFitArtifact(bytes,{...deps,decoder:decoder(changed)})).rejects.toMatchObject({name:"RawFileInvariantError",mismatchedColumns:["product"]} satisfies Partial<RawFileInvariantError>);
+    expect((await store.get("SELECT product FROM raw_file WHERE sha256=?",[address()]))?.product).not.toBe("different");
+  });
+  it("uses file creation time before session start for archive placement",async()=>{
+    const events:string[]=[];const instants:number[]=[];const decoded=await createFitDecoder().decode(bytes);const created=decoded.sessions[0].startTime!+12345;
+    const changed={...decoded,fileIds:[{...decoded.fileIds[0],timeCreated:created},...decoded.fileIds.slice(1)]};
+    await importFitArtifact(bytes,{archive:archive(events,false,instants),crypto,store,decoder:decoder(changed)});
+    expect(instants).toEqual([created]);
+  });
+});

--- a/packages/kernel-node/tests/inv2-ingest-twice.test.ts
+++ b/packages/kernel-node/tests/inv2-ingest-twice.test.ts
@@ -1,0 +1,31 @@
+import { createHash, randomBytes } from "node:crypto";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { mkdir, open, readFile, rename, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { CryptoPort, FileSystemPort } from "@enduragent/kernel/ports";
+import { DERIVED_TABLES, dumpStore, runMigrations } from "@enduragent/kernel/store";
+import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
+import { createArchiveManager } from "../src/archive/index.js";
+import { createFitDecoder } from "../src/ingest/fit-decoder.js";
+import { importFitArtifact } from "../src/ingest/fit-import.js";
+import { openSqliteStorage } from "../src/sqlite/index.js";
+
+const crypto:CryptoPort={async sha256(d){return new Uint8Array(createHash("sha256").update(d).digest())},async randomBytes(n){return new Uint8Array(randomBytes(n))},async pbkdf2(){throw new Error("unused")},async aesGcmEncrypt(){throw new Error("unused")},async aesGcmDecrypt(){throw new Error("unused")}};
+const fsPort:FileSystemPort={async readFile(p){return new Uint8Array(await readFile(p))},async readTextFile(p){return readFile(p,"utf8")},async writeFile(p,data,o){const temp=`${p}.tmp.${randomBytes(4).toString("hex")}`;const h=await open(temp,"w",o?.mode??0o600);try{await h.writeFile(typeof data==="string"?Buffer.from(data):Buffer.from(data));await h.sync()}finally{await h.close()}await rename(temp,p)},async rename(a,b){await rename(a,b)},async mkdir(p,o){await mkdir(p,{recursive:o?.recursive??false})},async list(){throw new Error("unused")},async stat(p){try{const s=await stat(p);return{kind:s.isFile()?"file":s.isDirectory()?"directory":"other",size:s.size,mtimeMs:s.mtimeMs}}catch{return undefined}}};
+let dir:string|undefined;afterEach(()=>{if(dir)rmSync(dir,{recursive:true,force:true});dir=undefined});
+
+describe("INV-2 ingest twice",()=>{
+  it("keeps one raw row and produces byte-identical non-vacuous dumps",async()=>{
+    expect(DERIVED_TABLES.join(",")).toBe("metric_snapshot,mean_max_cache,repair_log,stream,swim_length,lap,session,workout");
+    dir=mkdtempSync(join(tmpdir(),"fit-inv2-"));const archiveRoot=join(dir,"archive");await mkdir(dirname(join(archiveRoot,"x")),{recursive:true});
+    const store=openSqliteStorage(join(dir,"store.db"));try{
+      await runMigrations(store,MIGRATIONS);const archive=createArchiveManager({archiveRoot,crypto,fs:fsPort});const bytes=new Uint8Array(readFileSync(resolve("packages/kernel-node/tests/fixtures/ingest/triathlon-multisport.fit")));const deps={archive,crypto,store,decoder:createFitDecoder()};
+      const first=await importFitArtifact(bytes,deps);expect(first).toMatchObject({kind:"imported",rawInserted:true});const dump1=await dumpStore(store);
+      const second=await importFitArtifact(bytes,deps);expect(second).toMatchObject({kind:"imported",rawInserted:false});const dump2=await dumpStore(store);
+      expect(dump2).toBe(dump1);expect((await store.get("SELECT count(*) c FROM raw_file"))?.c).toBe(1);expect((await store.get("SELECT count(*) c FROM source_record"))?.c).toBe(0);
+      expect((await store.get("SELECT count(*) c FROM workout"))?.c).toBe(1);expect(Number((await store.get("SELECT count(*) c FROM session"))?.c)).toBeGreaterThan(0);expect(Number((await store.get("SELECT count(*) c FROM lap"))?.c)).toBeGreaterThan(0);expect(Number((await store.get("SELECT count(*) c FROM stream"))?.c)).toBeGreaterThan(0);
+    }finally{await store.close()}
+  });
+});

--- a/packages/kernel-node/tests/repositories.test.ts
+++ b/packages/kernel-node/tests/repositories.test.ts
@@ -4,12 +4,14 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   createAnchorRepository,
+  createActivityRepository,
   createRawFileRepository,
   createSourceRecordRepository,
   runMigrations,
   type AnchorHistoryRow,
   type MigratorStore,
   type RawFileRow,
+  RawFileInvariantError,
   type SourceRecordRow,
   type SqlStore,
 } from "@enduragent/kernel/store";
@@ -84,7 +86,7 @@ describe("repository ports over real node:sqlite", () => {
     });
   });
 
-  it("upserts raw_file idempotently by sha256", async () => {
+  it("inserts raw_file once and rejects same-address metadata drift", async () => {
     const repo = createRawFileRepository(store);
     const row: RawFileRow = {
       sha256: "abc",
@@ -96,10 +98,33 @@ describe("repository ports over real node:sqlite", () => {
       manufacturer: "garmin",
       product: "edge",
     };
-    await repo.upsert(row);
-    await repo.upsert({ ...row, bytes: 999 });
+    expect(await repo.upsert(row)).toBe(true);
+    expect(await repo.upsert(row)).toBe(false);
+    const changes: readonly [keyof RawFileRow, RawFileRow[keyof RawFileRow]][] = [
+      ["path", "/y.fit"], ["ext", "bin"], ["bytes", 999], ["file_id_serial", 2],
+      ["file_id_time_created_utc", 2000], ["manufacturer", "other"], ["product", "other"],
+    ];
+    for (const [key,value] of changes) {
+      await expect(repo.upsert({...row,[key]:value})).rejects.toBeInstanceOf(RawFileInvariantError);
+    }
     const count = await store.get("SELECT count(*) AS c FROM raw_file");
     expect(count?.c).toBe(1);
+  });
+
+  it("replaces affected activity snapshots and preserves unrelated snapshots", async () => {
+    const repo=createActivityRepository(store);
+    const rows={
+      workout:{workout_key:"wk",start_utc:1000,tz_offset_s:null,name:null,notes:null,is_multisport:0,dedup_cluster_id:"raw"},
+      sessions:[{session_key:"se",workout_key:"wk",session_seq:0,sport:"cycling",sub_sport:null,start_utc:1000,tz_offset_s:null,local_date_key:19980101,elapsed_s:null,timer_s:null,moving_s:null,distance_m:null,is_transition:0,summary_json:null}],
+      laps:[],swimLengths:[],streams:[],
+    } as const;
+    await repo.replaceForRawFile("raw",rows);
+    for(const [key,kind,id] of [["a","session","se"],["b","date","19980101"],["c","session","other"],["d","date","19980102"]] as const) {
+      await store.run("INSERT INTO metric_snapshot (snapshot_key,scope_kind,scope_id,metric_key,value_json,kernel_version,basis_version) VALUES (?,?,?,?,?,?,?)",[key,kind,id,"m","{}","k","b"]);
+    }
+    await repo.replaceForRawFile("raw",rows);
+    const remaining=await store.all("SELECT snapshot_key FROM metric_snapshot ORDER BY snapshot_key");
+    expect(remaining.map((r)=>r.snapshot_key)).toEqual(["c","d"]);
   });
 
   it("upserts source_record idempotently by (source, external_id)", async () => {

--- a/packages/kernel-node/tsup.config.ts
+++ b/packages/kernel-node/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: { index: "src/index.ts", sqlite: "src/sqlite/index.ts", "archive/index": "src/archive/index.ts", "lock/index": "src/lock/index.ts", "store-export/index": "src/store-export/index.ts", "home/index": "src/home/index.ts" },
+  entry: { index: "src/index.ts", sqlite: "src/sqlite/index.ts", "archive/index": "src/archive/index.ts", "lock/index": "src/lock/index.ts", "store-export/index": "src/store-export/index.ts", "home/index": "src/home/index.ts", "ingest/index": "src/ingest/index.ts" },
   format: ["esm"],
   dts: true,
   sourcemap: true,

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -10,12 +10,16 @@
     "./store/migrations": "./dist/store/migrations.js",
     "./store": "./dist/store.js",
     "./archive": "./dist/archive/index.js",
-    "./store/export": "./dist/store/export/index.js"
+    "./store/export": "./dist/store/export/index.js",
+    "./ingest": "./dist/ingest/index.js"
   },
   "scripts": {
     "build": "tsup",
     "check": "tsc --noEmit",
     "test": "vitest run"
+  },
+  "dependencies": {
+    "fflate": "0.8.3"
   },
   "devDependencies": {
     "tsup": "^8.4.0",

--- a/packages/kernel/src/ingest/fit-row-mapper.ts
+++ b/packages/kernel/src/ingest/fit-row-mapper.ts
@@ -1,0 +1,357 @@
+import { sortKeys } from "../store/canonical-json.js";
+import { H, compareUtf8, encodeUtf8Strict } from "../store/derived-key.js";
+import type { CryptoPort } from "../ports/crypto.js";
+import type { ActivityRows, LapRow, SessionRow, StreamRow, SwimLengthRow } from "../store/activity-repository.js";
+import { encodeStream } from "./stream-codec.js";
+import {
+  FitSourceError,
+  type DecodedDeveloperField,
+  type DecodedFitFile,
+  type FitEnumInput,
+  type FitJsonValue,
+  type MappedFitArtifact,
+} from "./types.js";
+
+export interface MapFitArtifactInput {
+  readonly crypto: CryptoPort;
+  readonly rawSha256: string;
+  readonly rawByteLength: number;
+  readonly archivePath: string | null;
+  readonly decoded: DecodedFitFile;
+}
+
+const SPORT: Readonly<Record<number, string>> = Object.freeze({
+  0:"generic",1:"running",2:"cycling",3:"transition",4:"fitness_equipment",5:"swimming",6:"basketball",7:"soccer",8:"tennis",9:"american_football",10:"training",11:"walking",12:"cross_country_skiing",13:"alpine_skiing",14:"snowboarding",15:"rowing",16:"mountaineering",17:"hiking",18:"multisport",19:"paddling",20:"flying",21:"e_biking",22:"motorcycling",23:"boating",24:"driving",25:"golf",26:"hang_gliding",27:"horseback_riding",28:"hunting",29:"fishing",30:"inline_skating",31:"rock_climbing",32:"sailing",33:"ice_skating",34:"sky_diving",35:"snowshoeing",36:"snowmobiling",37:"stand_up_paddleboarding",38:"surfing",39:"wakeboarding",40:"water_skiing",41:"kayaking",42:"rafting",43:"windsurfing",44:"kitesurfing",45:"tactical",46:"jumpmaster",47:"boxing",48:"floor_climbing",53:"diving",254:"all",
+});
+const SUB_SPORT: Readonly<Record<number, string>> = Object.freeze({
+  0:"generic",1:"treadmill",2:"street",3:"trail",4:"track",5:"spin",6:"indoor_cycling",7:"road",8:"mountain",9:"downhill",10:"recumbent",11:"cyclocross",12:"hand_cycling",13:"track_cycling",14:"indoor_rowing",15:"elliptical",16:"stair_climbing",17:"lap_swimming",18:"open_water",19:"flexibility_training",20:"strength_training",21:"warm_up",22:"match",23:"exercise",24:"challenge",25:"indoor_skiing",26:"cardio_training",27:"indoor_walking",28:"e_bike_fitness",29:"bmx",30:"casual_walking",31:"speed_walking",32:"bike_to_run_transition",33:"run_to_bike_transition",34:"swim_to_bike_transition",35:"atv",36:"motocross",37:"backcountry",38:"resort",39:"rc_drone",40:"wingsuit",41:"whitewater",42:"skate_skiing",43:"yoga",44:"pilates",45:"indoor_running",46:"gravel_cycling",47:"e_bike_mountain",48:"commuting",49:"mixed_surface",50:"navigate",51:"track_me",52:"map",53:"single_gas_diving",54:"multi_gas_diving",55:"gauge_diving",56:"apnea_diving",57:"apnea_hunting",58:"virtual_activity",59:"obstacle",254:"all",
+});
+const TRIGGER: Readonly<Record<number, string>> = Object.freeze({0:"activity_end",1:"manual",2:"auto_multi_sport",3:"fitness_equipment"});
+const SWIM_STROKE: Readonly<Record<number, string>> = Object.freeze({0:"freestyle",1:"backstroke",2:"breaststroke",3:"butterfly",4:"drill",5:"mixed",6:"im"});
+const LENGTH_TYPE: Readonly<Record<number, string>> = Object.freeze({0:"idle",1:"active"});
+
+function normalizeText(value: string): string {
+  return value.normalize("NFKC").replace(/([a-z\d])([A-Z])/g, "$1_$2").replace(/[-\s]+/g, "_").toLowerCase().replace(/_+/g, "_").replace(/^_+|_+$/g, "");
+}
+
+function normalizeEnum(value: FitEnumInput, table: Readonly<Record<number, string>>, optional: boolean, unknownInteger = false): string | null {
+  if (value === null) return optional ? null : null;
+  if (typeof value === "number") {
+    if (!Number.isSafeInteger(value)) throw new FitSourceError("invalid_enum");
+    const known = table[value];
+    if (known !== undefined) return known;
+    if (unknownInteger) return `unknown:${value.toString()}`;
+    throw new FitSourceError("invalid_enum");
+  }
+  if (typeof value !== "string") throw new FitSourceError("invalid_enum");
+  const normalized = normalizeText(value);
+  if (normalized.length === 0) throw new FitSourceError("invalid_enum");
+  if (Object.values(table).includes(normalized)) return normalized;
+  throw new FitSourceError("invalid_enum");
+}
+
+function dateValue(value: number | null, integer: boolean): void {
+  if (value === null) return;
+  if (typeof value !== "number" || !Number.isFinite(value) || (integer && !Number.isInteger(value))) throw new FitSourceError("invalid_date");
+}
+function finite(value: number | null, nonnegative = false, safeInteger = false): void {
+  if (value === null) return;
+  if (typeof value !== "number" || !Number.isFinite(value) || (nonnegative && value < 0) || (safeInteger && !Number.isSafeInteger(value))) throw new FitSourceError("invalid_numeric");
+}
+function duration(value: number | null): number | null {
+  if (value === null) return null;
+  finite(value, true);
+  const rounded = Math.floor(value + 0.5);
+  if (!Number.isSafeInteger(rounded)) throw new FitSourceError("invalid_numeric");
+  return rounded;
+}
+function distance(value: number | null): number | null { finite(value, true); return value; }
+
+function validateDates(decoded: DecodedFitFile): void {
+  for (const f of decoded.fileIds) dateValue(f.timeCreated, true);
+  if (decoded.activity) { dateValue(decoded.activity.timestamp, true); dateValue(decoded.activity.localTimestamp, true); }
+  for (const s of decoded.sessions) { dateValue(s.startTime, true); dateValue(s.timestamp, true); }
+  for (const l of decoded.laps) { dateValue(l.startTime, true); dateValue(l.timestamp, true); }
+  for (const l of decoded.lengths) { dateValue(l.startTime, true); dateValue(l.timestamp, true); }
+  for (const r of decoded.records) dateValue(r.timestamp, false);
+  for (const e of decoded.events) dateValue(e.timestamp, true);
+}
+
+function validateNumerics(decoded: DecodedFitFile): void {
+  for (const f of decoded.fileIds) finite(f.serialNumber, false, true);
+  if (decoded.activity) finite(decoded.activity.numSessions, true, true);
+  for (const s of decoded.sessions) {
+    finite(s.totalElapsedTime, true); finite(s.totalTimerTime, true); finite(s.totalMovingTime, true); finite(s.totalDistance, true);
+  }
+  for (const l of decoded.laps) {
+    finite(l.totalElapsedTime, true); finite(l.totalTimerTime, true); finite(l.totalDistance, true);
+  }
+  for (const l of decoded.lengths) {
+    finite(l.totalElapsedTime, true); finite(l.totalTimerTime, true); finite(l.totalStrokes, true, true);
+  }
+  for (const r of decoded.records) {
+    finite(r.positionLat); finite(r.positionLong); finite(r.distance); finite(r.enhancedAltitude); finite(r.altitude);
+    finite(r.enhancedSpeed); finite(r.speed); finite(r.heartRate); finite(r.cadence); finite(r.fractionalCadence);
+    finite(r.power); finite(r.temperature); finite(r.stanceTime); finite(r.stanceTimeBalance); finite(r.verticalOscillation);
+    finite(r.verticalRatio); finite(r.stepLength); finite(r.leftRightBalance, true, true); finite(r.respirationRate);
+    if (r.leftRightBalance !== null && r.leftRightBalance > 127) throw new FitSourceError("invalid_numeric");
+  }
+  for (const e of decoded.events) finite(e.data);
+}
+
+function validateSlice(first: number | null, count: number | null, total: number, code: "lap_slice_invalid" | "length_slice_invalid"): readonly [number, number] {
+  if (count === null) {
+    if (first !== null) throw new FitSourceError(code);
+    return [0, 0];
+  }
+  if (!Number.isSafeInteger(count) || count < 0) throw new FitSourceError(code);
+  if (count === 0) {
+    const start = first === null ? 0 : first;
+    if (!Number.isSafeInteger(start) || start < 0 || start > total) throw new FitSourceError(code);
+    return [start, start];
+  }
+  if (first === null || !Number.isSafeInteger(first) || first < 0 || first + count > total) throw new FitSourceError(code);
+  return [first, first + count];
+}
+
+function applicationIds(decoded: DecodedFitFile): Map<number, string> {
+  const result = new Map<number, string>();
+  for (const item of decoded.developerDataIds) {
+    const index = item.developerDataIndex;
+    if (!Number.isSafeInteger(index) || index < 0) throw new FitSourceError("developer_identity_invalid");
+    let id = `idx-${index}`;
+    if (item.applicationId !== null) {
+      if (item.applicationId.length !== 16 || item.applicationId.some((b) => !Number.isSafeInteger(b) || b < 0 || b > 255)) throw new FitSourceError("developer_identity_invalid");
+      id = item.applicationId.map((b) => b.toString(16).padStart(2,"0")).join("");
+    }
+    const previous = result.get(index);
+    if (previous !== undefined && previous !== id) throw new FitSourceError("developer_identity_conflict");
+    result.set(index, id);
+  }
+  return result;
+}
+
+function normalizedDeveloperName(name: string | null, fieldNumber: number): string {
+  if (name === null || name.normalize("NFKC").toLowerCase().trim().replace(/\s+/gu,"_").length === 0) return `field-${fieldNumber}`;
+  const normalized = name.normalize("NFKC").toLowerCase().trim().replace(/\s+/gu,"_");
+  encodeUtf8Strict(normalized);
+  let out = "";
+  for (const char of normalized) {
+    if (/^[a-z0-9._-]$/.test(char)) out += char;
+    else for (const byte of encodeUtf8Strict(char)) out += `%${byte.toString(16).padStart(2,"0")}`;
+  }
+  return out.length === 0 ? `field-${fieldNumber}` : out;
+}
+
+function jsonSafe(value: unknown, ancestors = new Set<object>()): FitJsonValue {
+  if (value === null || typeof value === "boolean" || typeof value === "string") return value;
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) throw new FitSourceError("developer_identity_invalid");
+    return Object.is(value, -0) ? 0 : value;
+  }
+  if (typeof value !== "object") throw new FitSourceError("developer_identity_invalid");
+  if (ancestors.has(value)) throw new FitSourceError("developer_identity_invalid");
+  ancestors.add(value);
+  try {
+    if (Array.isArray(value)) return value.map((item) => jsonSafe(item, ancestors));
+    const proto = Object.getPrototypeOf(value);
+    if (proto !== Object.prototype && proto !== null) throw new FitSourceError("developer_identity_invalid");
+    if (Object.getOwnPropertySymbols(value).length > 0) throw new FitSourceError("developer_identity_invalid");
+    const output: Record<string, FitJsonValue> = {};
+    for (const key of Object.keys(value)) {
+      const descriptor = Object.getOwnPropertyDescriptor(value, key);
+      if (!descriptor || descriptor.get || descriptor.set) throw new FitSourceError("developer_identity_invalid");
+      output[key] = jsonSafe(descriptor.value, ancestors);
+    }
+    return output;
+  } finally { ancestors.delete(value); }
+}
+
+interface DeveloperEntry {
+  readonly nativeMessageType: number;
+  readonly developer_data_index: number;
+  readonly field_definition_number: number;
+  readonly application_id: string;
+  readonly normalized_name: string;
+  readonly units: string | null;
+  readonly value: FitJsonValue;
+  readonly canonical: string;
+  readonly channel: string;
+}
+
+function compareDeveloper(a: DeveloperEntry, b: DeveloperEntry): number {
+  if (a.nativeMessageType !== b.nativeMessageType) return a.nativeMessageType < b.nativeMessageType ? -1 : 1;
+  if (a.developer_data_index !== b.developer_data_index) return a.developer_data_index < b.developer_data_index ? -1 : 1;
+  if (a.field_definition_number !== b.field_definition_number) return a.field_definition_number < b.field_definition_number ? -1 : 1;
+  let c = compareUtf8(a.application_id,b.application_id) || compareUtf8(a.normalized_name,b.normalized_name);
+  if (c !== 0) return c;
+  if (a.units !== b.units) { if (a.units === null) return -1; if (b.units === null) return 1; c = compareUtf8(a.units,b.units); if (c) return c; }
+  return compareUtf8(a.canonical,b.canonical);
+}
+
+function developerEntries(fields: readonly DecodedDeveloperField[], ids: Map<number,string>, cross: Map<string,string>): DeveloperEntry[] {
+  const byIdentity = new Map<string, DeveloperEntry>();
+  for (const field of fields) {
+    const { nativeMessageType, developer_data_index: index, field_definition_number: number } = field;
+    if (![nativeMessageType,index,number].every((v) => typeof v === "number" && Number.isSafeInteger(v) && v >= 0)) throw new FitSourceError("developer_identity_invalid");
+    if (field.field_name !== null && typeof field.field_name !== "string") throw new FitSourceError("developer_identity_invalid");
+    if (field.units !== null && typeof field.units !== "string") throw new FitSourceError("developer_identity_invalid");
+    const application_id = ids.get(index) ?? `idx-${index}`;
+    const normalized_name = normalizedDeveloperName(field.field_name, number);
+    const value = jsonSafe(field.value);
+    const canonical = JSON.stringify(sortKeys(value));
+    const base = `${nativeMessageType}:${index}:${number}`;
+    const metadata = JSON.stringify([application_id,normalized_name,field.units]);
+    const priorMetadata = cross.get(base);
+    if (priorMetadata !== undefined && priorMetadata !== metadata) throw new FitSourceError("developer_identity_conflict");
+    cross.set(base, metadata);
+    const entry: DeveloperEntry = { nativeMessageType, developer_data_index:index, field_definition_number:number, application_id, normalized_name, units:field.units, value, canonical, channel:`dev:${application_id}:${index}:${number}:${normalized_name}` };
+    const prior = byIdentity.get(base);
+    if (prior !== undefined) {
+      if (prior.canonical !== canonical || metadata !== JSON.stringify([prior.application_id,prior.normalized_name,prior.units])) throw new FitSourceError("developer_identity_conflict");
+    } else byIdentity.set(base, entry);
+  }
+  return [...byIdentity.values()].sort(compareDeveloper);
+}
+
+function summaryEntry(entry: DeveloperEntry): Record<string, FitJsonValue> {
+  return { nativeMessageType:entry.nativeMessageType, developer_data_index:entry.developer_data_index, field_definition_number:entry.field_definition_number, application_id:entry.application_id, normalized_name:entry.normalized_name, units:entry.units, value:entry.value };
+}
+function canonicalSummary(value: unknown): string { return JSON.stringify(sortKeys(value)); }
+
+function localDate(start: number, offset: number | null): number {
+  const date = new Date((start + (offset ?? 0)) * 1000);
+  if (!Number.isFinite(date.getTime())) throw new FitSourceError("invalid_date");
+  return date.getUTCFullYear()*10000 + (date.getUTCMonth()+1)*100 + date.getUTCDate();
+}
+
+const NATIVE_CHANNELS: readonly [keyof DecodedFitFile["records"][number], string][] = [
+  ["positionLat","lat"],["positionLong","lng"],["distance","distance"],["heartRate","heart_rate"],
+  ["cadence","cadence"],["fractionalCadence","fractional_cadence"],["power","power"],["temperature","temperature"],
+  ["stanceTime","stance_time"],["stanceTimeBalance","stance_time_balance"],["verticalOscillation","vertical_oscillation"],
+  ["verticalRatio","vertical_ratio"],["stepLength","step_length"],["leftRightBalance","left_right_balance"],["respirationRate","respiration_rate"],
+];
+
+export async function mapFitArtifact(input: MapFitArtifactInput): Promise<MappedFitArtifact> {
+  if (!/^[0-9a-f]{64}$/.test(input.rawSha256) || !Number.isSafeInteger(input.rawByteLength) || input.rawByteLength < 0) throw new RangeError("invalid raw artifact metadata");
+  const d = input.decoded;
+  if (d.sessions.length === 0) throw new FitSourceError("missing_session");
+  validateDates(d);
+  validateNumerics(d);
+
+  const sports: string[] = [], subSports: (string|null)[] = [], triggers: (string|null)[] = [];
+  for (const s of d.sessions) {
+    sports.push(normalizeEnum(s.sport,SPORT,false) ?? "");
+    subSports.push(normalizeEnum(s.subSport,SUB_SPORT,true));
+    triggers.push(normalizeEnum(s.trigger,TRIGGER,true,true));
+  }
+  const strokes = d.lengths.map((l) => normalizeEnum(l.swimStroke,SWIM_STROKE,true));
+  const lengthTypes = d.lengths.map((l) => normalizeEnum(l.lengthType,LENGTH_TYPE,true));
+
+  let tzOffset: number | null = null;
+  if (d.activity?.timestamp !== null && d.activity?.timestamp !== undefined && d.activity.localTimestamp !== null) {
+    tzOffset = d.activity.localTimestamp - d.activity.timestamp;
+    if (!Number.isSafeInteger(tzOffset)) throw new FitSourceError("invalid_activity_offset");
+  }
+  for (const s of d.sessions) if (s.startTime === null) throw new FitSourceError("missing_session_start");
+  for (const s of d.sessions) if (s.timestamp === null) throw new FitSourceError("missing_session_end");
+  for (let i=0;i<d.sessions.length;i++) if (d.sessions[i].sport === null || sports[i] === "") throw new FitSourceError("missing_session_sport");
+  for (let i=0;i<d.sessions.length;i++) {
+    const s=d.sessions[i];
+    if ((s.startTime as number) > (s.timestamp as number)) throw new FitSourceError("invalid_session_range");
+    if (i+1<d.sessions.length && (s.timestamp as number) > (d.sessions[i+1].startTime as number)) throw new FitSourceError("invalid_session_range");
+  }
+
+  const sessionLapSlices = d.sessions.map((s) => validateSlice(s.firstLapIndex,s.numLaps,d.laps.length,"lap_slice_invalid"));
+  const lapOwners = Array<number>(d.laps.length).fill(0);
+  for (const [start,end] of sessionLapSlices) for(let i=start;i<end;i++) lapOwners[i]++;
+  if (lapOwners.some((n)=>n!==1)) throw new FitSourceError("lap_slice_invalid");
+  const lapLengthSlices = d.laps.map((l) => validateSlice(l.firstLengthIndex,l.numLengths,d.lengths.length,"length_slice_invalid"));
+  const lengthOwners = Array<number>(d.lengths.length).fill(0);
+  for (const [start,end] of lapLengthSlices) for(let i=start;i<end;i++) lengthOwners[i]++;
+  if (lengthOwners.some((n)=>n!==1)) throw new FitSourceError("length_slice_invalid");
+  for (let i=0;i<d.laps.length;i++) {
+    const expected=d.laps[i].numActiveLengths;
+    if (expected !== null) {
+      if (!Number.isSafeInteger(expected) || expected<0) throw new FitSourceError("active_length_count_mismatch");
+      const [start,end]=lapLengthSlices[i];
+      let actual=0; for(let j=start;j<end;j++) if(lengthTypes[j]==="active") actual++;
+      if(actual!==expected) throw new FitSourceError("active_length_count_mismatch");
+    }
+  }
+
+  const ids=applicationIds(d), metadata=new Map<string,string>();
+  const sessionDevelopers=d.sessions.map((s)=>developerEntries(s.developerFields,ids,metadata));
+  const lapDevelopers=d.laps.map((l)=>developerEntries(l.developerFields,ids,metadata));
+  const recordDevelopers=d.records.map((r)=>developerEntries(r.developerFields,ids,metadata));
+
+  if (d.records.some((r)=>r.timestamp===null)) throw new FitSourceError("record_time_missing");
+  const recordOwners=d.records.map((r)=>d.sessions.map((s,i)=>{
+    const t=r.timestamp as number, start=s.startTime as number, end=s.timestamp as number;
+    return t>=start && (i===d.sessions.length-1 ? t<=end : t<end);
+  }).filter(Boolean).length);
+  if(recordOwners.some((n)=>n===0)) throw new FitSourceError("record_unassigned");
+  if(recordOwners.some((n)=>n>1)) throw new FitSourceError("record_ambiguous");
+  const assigned=d.sessions.map(()=>[] as number[]);
+  for(let r=0;r<d.records.length;r++) {
+    const t=d.records[r].timestamp as number;
+    const owner=d.sessions.findIndex((s,i)=>t>=(s.startTime as number)&&(i===d.sessions.length-1?t<=(s.timestamp as number):t<(s.timestamp as number)));
+    assigned[owner].push(r);
+  }
+  for(const indexes of assigned) for(let i=1;i<indexes.length;i++) if((d.records[indexes[i]].timestamp as number)<=(d.records[indexes[i-1]].timestamp as number)) throw new FitSourceError("record_time_nonmonotonic");
+
+  const workoutKey=await H(input.crypto,"workout",input.rawSha256);
+  const sessionKeys=await Promise.all(d.sessions.map((_,i)=>H(input.crypto,"session",workoutKey,i)));
+  const sessions: SessionRow[]=[]; const laps: LapRow[]=[]; const swimLengths: SwimLengthRow[]=[]; const streams: StreamRow[]=[];
+  for(let i=0;i<d.sessions.length;i++) {
+    const source=d.sessions[i], key=sessionKeys[i];
+    sessions.push({ session_key:key,workout_key:workoutKey,session_seq:i,sport:sports[i],sub_sport:subSports[i],start_utc:source.startTime as number,tz_offset_s:tzOffset,local_date_key:localDate(source.startTime as number,tzOffset),elapsed_s:duration(source.totalElapsedTime),timer_s:duration(source.totalTimerTime),moving_s:duration(source.totalMovingTime),distance_m:distance(source.totalDistance),is_transition:sports[i]==="transition"?1:0,summary_json:canonicalSummary({developer_fields:sessionDevelopers[i].map(summaryEntry),trigger:triggers[i]}) });
+    const [lapStart,lapEnd]=sessionLapSlices[i];
+    for(let g=lapStart;g<lapEnd;g++) {
+      const sourceLap=d.laps[g], lapKey=await H(input.crypto,"lap",key,g);
+      laps.push({lap_key:lapKey,session_key:key,lap_seq:g,start_utc:sourceLap.startTime,elapsed_s:duration(sourceLap.totalElapsedTime),timer_s:duration(sourceLap.totalTimerTime),distance_m:distance(sourceLap.totalDistance),summary_json:canonicalSummary({developer_fields:lapDevelopers[g].map(summaryEntry)})});
+      const [lengthStart,lengthEnd]=lapLengthSlices[g];
+      for(let sourceIndex=lengthStart;sourceIndex<lengthEnd;sourceIndex++) {
+        const sourceLength=d.lengths[sourceIndex], seq=sourceIndex-lengthStart;
+        swimLengths.push({length_key:await H(input.crypto,"swim_length",lapKey,seq),lap_key:lapKey,length_seq:seq,start_utc:sourceLength.startTime,elapsed_s:duration(sourceLength.totalElapsedTime),timer_s:duration(sourceLength.totalTimerTime),strokes:sourceLength.totalStrokes,stroke_type:strokes[sourceIndex],length_type:lengthTypes[sourceIndex]});
+      }
+    }
+    const indexes=assigned[i];
+    if(indexes.length>0) {
+      const values=new Map<string,(number|null)[]>();
+      values.set("time",indexes.map((x)=>d.records[x].timestamp));
+      for(const [property,channel] of NATIVE_CHANNELS) values.set(channel,indexes.map((x)=>d.records[x][property] as number|null));
+      values.set("altitude",indexes.map((x)=>d.records[x].enhancedAltitude ?? d.records[x].altitude));
+      values.set("speed",indexes.map((x)=>d.records[x].enhancedSpeed ?? d.records[x].speed));
+      for(let slot=0;slot<indexes.length;slot++) for(const entry of recordDevelopers[indexes[slot]]) {
+        if(typeof entry.value!=="number") continue;
+        let channel=values.get(entry.channel); if(!channel){channel=Array<number|null>(indexes.length).fill(null);values.set(entry.channel,channel);} channel[slot]=entry.value;
+      }
+      for(const [channel,channelValues] of values) {
+        if(channel!=="time"&&channelValues.every((v)=>v===null)) continue;
+        if(channelValues.length!==indexes.length) throw new FitSourceError("stream_alignment_invalid");
+        const encoded=encodeStream(channel==="time"?"time":"value",channelValues);
+        streams.push({stream_key:await H(input.crypto,"stream",key,channel),session_key:key,channel,encoding:encoded.encoding,sample_rate:null,n:encoded.n,data:encoded.data});
+      }
+    }
+  }
+  const firstFile=d.fileIds[0];
+  let manufacturer:string|null=null;
+  if(firstFile?.manufacturer!==null&&firstFile?.manufacturer!==undefined) {
+    if(typeof firstFile.manufacturer!=="string") throw new FitSourceError("invalid_enum");
+    manufacturer=normalizeText(firstFile.manufacturer); if(!manufacturer) throw new FitSourceError("invalid_enum");
+  }
+  let product:string|null=null;
+  if(firstFile?.productName!==null&&firstFile?.productName!==undefined&&firstFile.productName.length>0) product=firstFile.productName;
+  else if(typeof firstFile?.product==="string") { product=normalizeText(firstFile.product); if(!product) throw new FitSourceError("invalid_enum"); }
+  else if(typeof firstFile?.product==="number") { if(!Number.isSafeInteger(firstFile.product)) throw new FitSourceError("invalid_enum"); product=firstFile.product.toString(); }
+  const startUtc=Math.min(...d.sessions.map((s)=>s.startTime as number));
+  const activity:ActivityRows={workout:{workout_key:workoutKey,start_utc:startUtc,tz_offset_s:tzOffset,name:null,notes:null,is_multisport:d.sessions.length>1?1:0,dedup_cluster_id:input.rawSha256},sessions,laps,swimLengths,streams};
+  const logicalArchiveEpochSeconds=firstFile?.timeCreated ?? Math.min(...d.sessions.map((s)=>s.startTime as number)) ?? Math.min(...d.records.map((r)=>r.timestamp as number)) ?? 0;
+  return {rawFile:{sha256:input.rawSha256,path:input.archivePath,ext:"fit",bytes:input.rawByteLength,file_id_serial:firstFile?.serialNumber??null,file_id_time_created_utc:firstFile?.timeCreated??null,manufacturer,product},activity,logicalArchiveEpochSeconds};
+}
+
+export function withArchivePath(artifact: MappedFitArtifact, archivePath: string): MappedFitArtifact {
+  if (archivePath.length===0 || archivePath.startsWith("/") || archivePath.split("/").includes("..")) throw new RangeError("archive path must be relative");
+  return {...artifact,rawFile:{...artifact.rawFile,path:archivePath}};
+}

--- a/packages/kernel/src/ingest/index.ts
+++ b/packages/kernel/src/ingest/index.ts
@@ -1,0 +1,4 @@
+export * from "./types.js";
+export * from "./fit-row-mapper.js";
+export * from "./stream-codec.js";
+export * from "./rebuild.js";

--- a/packages/kernel/src/ingest/rebuild.ts
+++ b/packages/kernel/src/ingest/rebuild.ts
@@ -1,0 +1,20 @@
+import { createActivityRepository } from "../store/activity-repository.js";
+import { DERIVED_TABLES } from "../store/dump.js";
+import type { MigratorStore } from "../store/migrator.js";
+import type { SqlStore } from "../store/ports.js";
+import { createRawFileRepository } from "../store/source-repository.js";
+import type { MappedFitArtifact } from "./types.js";
+
+export async function rebuildRawFileInTransaction(store: SqlStore, artifact: MappedFitArtifact): Promise<{ rawInserted: boolean }> {
+  const rawInserted = await createRawFileRepository(store).upsert(artifact.rawFile);
+  await createActivityRepository(store).replaceForRawFile(artifact.rawFile.sha256, artifact.activity);
+  return { rawInserted };
+}
+
+export async function rebuildRawFile(store: SqlStore & Pick<MigratorStore, "transaction">, artifact: MappedFitArtifact): Promise<{ rawInserted: boolean }> {
+  return store.transaction(() => rebuildRawFileInTransaction(store, artifact));
+}
+
+export async function deleteAllDerivedRowsInTransaction(store: SqlStore): Promise<void> {
+  for (const table of DERIVED_TABLES) await store.exec(`DELETE FROM ${table}`);
+}

--- a/packages/kernel/src/ingest/stream-codec.ts
+++ b/packages/kernel/src/ingest/stream-codec.ts
@@ -1,0 +1,143 @@
+import { unzlibSync, zlibSync } from "fflate";
+
+export const STREAM_ENCODING = "f64:raw:zdeflate:le" as const;
+export type StreamKind = "time" | "value";
+export type StreamCodecErrorCode =
+  | "unsupported_encoding"
+  | "inflate_failed"
+  | "bad_magic"
+  | "bad_version"
+  | "bad_dtype"
+  | "bad_delta"
+  | "bad_endian"
+  | "invalid_n"
+  | "n_mismatch"
+  | "bitmap_length"
+  | "high_bitmap_bits"
+  | "payload_length"
+  | "trailing_bytes"
+  | "missing_slot_nonzero"
+  | "present_nonfinite"
+  | "time_missing"
+  | "time_nonmonotonic"
+  | "all_missing";
+
+export class StreamCodecError extends Error {
+  readonly code: StreamCodecErrorCode;
+  constructor(code: StreamCodecErrorCode) {
+    super(`stream codec rejected: ${code}`);
+    this.name = "StreamCodecError";
+    this.code = code;
+  }
+}
+
+export interface EncodedStream {
+  readonly encoding: typeof STREAM_ENCODING;
+  readonly n: number;
+  readonly data: Uint8Array;
+}
+export interface DecodeStreamInput {
+  readonly encoding: string;
+  readonly n: number;
+  readonly kind: StreamKind;
+  readonly data: Uint8Array;
+}
+
+function validN(n: number): boolean {
+  return Number.isSafeInteger(n) && n >= 1 && n <= 0xffffffff;
+}
+
+export function encodeStream(
+  kind: StreamKind,
+  values: readonly (number | null)[],
+): EncodedStream {
+  const n = values.length;
+  if (!validN(n)) throw new StreamCodecError("invalid_n");
+  for (const value of values) {
+    if (value !== null && (typeof value !== "number" || !Number.isFinite(value))) {
+      throw new StreamCodecError("present_nonfinite");
+    }
+  }
+  if (kind === "time") {
+    if (values.some((value) => value === null)) throw new StreamCodecError("time_missing");
+    for (let i = 1; i < n; i++) {
+      if ((values[i] as number) <= (values[i - 1] as number)) {
+        throw new StreamCodecError("time_nonmonotonic");
+      }
+    }
+  } else if (values.every((value) => value === null)) {
+    throw new StreamCodecError("all_missing");
+  }
+
+  const bitmapLength = Math.ceil(n / 8);
+  const payload = new Uint8Array(16 + bitmapLength + n * 8);
+  payload.set([0x53, 0x54, 0x52, 0x4d, 1, 1, 0, 0]);
+  const view = new DataView(payload.buffer, payload.byteOffset, payload.byteLength);
+  view.setUint32(8, n, true);
+  view.setUint32(12, bitmapLength, true);
+  for (let i = 0; i < n; i++) {
+    const value = values[i];
+    if (value !== null) {
+      payload[16 + Math.floor(i / 8)] |= 1 << (i % 8);
+      view.setFloat64(16 + bitmapLength + i * 8, Object.is(value, -0) ? 0 : value, true);
+    }
+  }
+  return { encoding: STREAM_ENCODING, n, data: zlibSync(payload, { level: 6 }) };
+}
+
+export function decodeStream(input: DecodeStreamInput): readonly (number | null)[] {
+  if (input.encoding !== STREAM_ENCODING) throw new StreamCodecError("unsupported_encoding");
+  let payload: Uint8Array;
+  try {
+    payload = unzlibSync(input.data);
+  } catch {
+    throw new StreamCodecError("inflate_failed");
+  }
+  if (payload.length < 16) throw new StreamCodecError("payload_length");
+  if (payload[0] !== 0x53 || payload[1] !== 0x54 || payload[2] !== 0x52 || payload[3] !== 0x4d)
+    throw new StreamCodecError("bad_magic");
+  if (payload[4] !== 1) throw new StreamCodecError("bad_version");
+  if (payload[5] !== 1) throw new StreamCodecError("bad_dtype");
+  if (payload[6] !== 0) throw new StreamCodecError("bad_delta");
+  if (payload[7] !== 0) throw new StreamCodecError("bad_endian");
+  const view = new DataView(payload.buffer, payload.byteOffset, payload.byteLength);
+  const headerN = view.getUint32(8, true);
+  if (!validN(input.n) || !validN(headerN)) throw new StreamCodecError("invalid_n");
+  if (headerN !== input.n) throw new StreamCodecError("n_mismatch");
+  const bitmapLength = view.getUint32(12, true);
+  const expectedBitmapLength = Math.ceil(headerN / 8);
+  if (bitmapLength !== expectedBitmapLength) throw new StreamCodecError("bitmap_length");
+  const expectedLength = 16 + bitmapLength + headerN * 8;
+  if (payload.length < expectedLength) throw new StreamCodecError("payload_length");
+  if (payload.length > expectedLength) throw new StreamCodecError("trailing_bytes");
+  const unusedBits = bitmapLength * 8 - headerN;
+  if (unusedBits > 0 && (payload[16 + bitmapLength - 1] & (0xff << (8 - unusedBits))) !== 0) {
+    throw new StreamCodecError("high_bitmap_bits");
+  }
+  const values: (number | null)[] = [];
+  for (let i = 0; i < headerN; i++) {
+    const present = (payload[16 + Math.floor(i / 8)] & (1 << (i % 8))) !== 0;
+    const valueOffset = 16 + bitmapLength + i * 8;
+    if (!present) {
+      for (let j = 0; j < 8; j++) {
+        if (payload[valueOffset + j] !== 0) throw new StreamCodecError("missing_slot_nonzero");
+      }
+      values.push(null);
+    } else {
+      const value = view.getFloat64(valueOffset, true);
+      if (!Number.isFinite(value)) throw new StreamCodecError("present_nonfinite");
+      values.push(Object.is(value, -0) ? 0 : value);
+    }
+  }
+  if (input.kind === "time") {
+    if (values.some((value) => value === null)) throw new StreamCodecError("time_missing");
+    for (let i = 1; i < values.length; i++) {
+      if ((values[i] as number) <= (values[i - 1] as number)) {
+        throw new StreamCodecError("time_nonmonotonic");
+      }
+    }
+  } else if (values.every((value) => value === null)) {
+    throw new StreamCodecError("all_missing");
+  }
+  return values;
+}

--- a/packages/kernel/src/ingest/types.ts
+++ b/packages/kernel/src/ingest/types.ts
@@ -1,0 +1,166 @@
+import type { ActivityRows } from "../store/activity-repository.js";
+import type { RawFileRow } from "../store/ports.js";
+
+export const FIT_INGEST_VERSION = 1 as const;
+
+export type FitSourceErrorCode =
+  | "decode_failed"
+  | "missing_session"
+  | "missing_session_start"
+  | "missing_session_end"
+  | "missing_session_sport"
+  | "invalid_date"
+  | "invalid_numeric"
+  | "invalid_enum"
+  | "invalid_activity_offset"
+  | "invalid_session_range"
+  | "record_unassigned"
+  | "record_ambiguous"
+  | "record_time_missing"
+  | "record_time_nonmonotonic"
+  | "lap_slice_invalid"
+  | "length_slice_invalid"
+  | "active_length_count_mismatch"
+  | "developer_identity_invalid"
+  | "developer_identity_conflict"
+  | "stream_alignment_invalid";
+
+export class FitSourceError extends Error {
+  readonly code: FitSourceErrorCode;
+  constructor(code: FitSourceErrorCode) {
+    super(`FIT source rejected: ${code}`);
+    this.name = "FitSourceError";
+    this.code = code;
+  }
+}
+
+export type FitEnumInput = string | number | null;
+export type FitJsonValue =
+  | null
+  | boolean
+  | string
+  | number
+  | readonly FitJsonValue[]
+  | { readonly [key: string]: FitJsonValue };
+
+export interface DecodedDeveloperField {
+  readonly nativeMessageType: number;
+  readonly developer_data_index: number;
+  readonly field_definition_number: number;
+  readonly field_name: string | null;
+  readonly units: string | null;
+  readonly value: unknown;
+}
+
+export interface DecodedFileId {
+  readonly serialNumber: number | null;
+  readonly timeCreated: number | null;
+  readonly manufacturer: FitEnumInput;
+  readonly product: FitEnumInput;
+  readonly productName: string | null;
+}
+
+export interface DecodedActivity {
+  readonly timestamp: number | null;
+  readonly localTimestamp: number | null;
+  readonly numSessions: number | null;
+  readonly type: FitEnumInput;
+  readonly event: FitEnumInput;
+  readonly eventType: FitEnumInput;
+}
+
+export interface DecodedSession {
+  readonly sourceIndex: number;
+  readonly sport: FitEnumInput;
+  readonly subSport: FitEnumInput;
+  readonly startTime: number | null;
+  readonly timestamp: number | null;
+  readonly trigger: FitEnumInput;
+  readonly firstLapIndex: number | null;
+  readonly numLaps: number | null;
+  readonly totalElapsedTime: number | null;
+  readonly totalTimerTime: number | null;
+  readonly totalMovingTime: number | null;
+  readonly totalDistance: number | null;
+  readonly developerFields: readonly DecodedDeveloperField[];
+}
+
+export interface DecodedLap {
+  readonly sourceIndex: number;
+  readonly startTime: number | null;
+  readonly timestamp: number | null;
+  readonly firstLengthIndex: number | null;
+  readonly numLengths: number | null;
+  readonly numActiveLengths: number | null;
+  readonly totalElapsedTime: number | null;
+  readonly totalTimerTime: number | null;
+  readonly totalDistance: number | null;
+  readonly developerFields: readonly DecodedDeveloperField[];
+}
+
+export interface DecodedLength {
+  readonly sourceIndex: number;
+  readonly startTime: number | null;
+  readonly timestamp: number | null;
+  readonly totalElapsedTime: number | null;
+  readonly totalTimerTime: number | null;
+  readonly totalStrokes: number | null;
+  readonly swimStroke: FitEnumInput;
+  readonly lengthType: FitEnumInput;
+}
+
+export interface DecodedRecord {
+  readonly sourceIndex: number;
+  readonly timestamp: number | null;
+  readonly positionLat: number | null;
+  readonly positionLong: number | null;
+  readonly distance: number | null;
+  readonly enhancedAltitude: number | null;
+  readonly altitude: number | null;
+  readonly enhancedSpeed: number | null;
+  readonly speed: number | null;
+  readonly heartRate: number | null;
+  readonly cadence: number | null;
+  readonly fractionalCadence: number | null;
+  readonly power: number | null;
+  readonly temperature: number | null;
+  readonly stanceTime: number | null;
+  readonly stanceTimeBalance: number | null;
+  readonly verticalOscillation: number | null;
+  readonly verticalRatio: number | null;
+  readonly stepLength: number | null;
+  readonly leftRightBalance: number | null;
+  readonly respirationRate: number | null;
+  readonly developerFields: readonly DecodedDeveloperField[];
+  readonly coordinateUnit: "degrees";
+}
+
+export interface DecodedEvent {
+  readonly sourceIndex: number;
+  readonly timestamp: number | null;
+  readonly event: FitEnumInput;
+  readonly eventType: FitEnumInput;
+  readonly data: number | null;
+}
+
+export interface DecodedDeveloperDataId {
+  readonly developerDataIndex: number;
+  readonly applicationId: readonly number[] | null;
+}
+
+export interface DecodedFitFile {
+  readonly fileIds: readonly DecodedFileId[];
+  readonly activity: DecodedActivity | null;
+  readonly sessions: readonly DecodedSession[];
+  readonly laps: readonly DecodedLap[];
+  readonly lengths: readonly DecodedLength[];
+  readonly records: readonly DecodedRecord[];
+  readonly events: readonly DecodedEvent[];
+  readonly developerDataIds: readonly DecodedDeveloperDataId[];
+}
+
+export interface MappedFitArtifact {
+  readonly rawFile: RawFileRow;
+  readonly activity: ActivityRows;
+  readonly logicalArchiveEpochSeconds: number;
+}

--- a/packages/kernel/src/store/activity-repository.ts
+++ b/packages/kernel/src/store/activity-repository.ts
@@ -1,0 +1,49 @@
+import { compareUtf8 } from "./derived-key.js";
+import type { SqlStore } from "./ports.js";
+
+export interface WorkoutRow { readonly workout_key: string; readonly start_utc: number; readonly tz_offset_s: number | null; readonly name: string | null; readonly notes: string | null; readonly is_multisport: number; readonly dedup_cluster_id: string; }
+export interface SessionRow { readonly session_key: string; readonly workout_key: string; readonly session_seq: number; readonly sport: string; readonly sub_sport: string | null; readonly start_utc: number; readonly tz_offset_s: number | null; readonly local_date_key: number; readonly elapsed_s: number | null; readonly timer_s: number | null; readonly moving_s: number | null; readonly distance_m: number | null; readonly is_transition: number; readonly summary_json: string | null; }
+export interface LapRow { readonly lap_key: string; readonly session_key: string; readonly lap_seq: number; readonly start_utc: number | null; readonly elapsed_s: number | null; readonly timer_s: number | null; readonly distance_m: number | null; readonly summary_json: string | null; }
+export interface SwimLengthRow { readonly length_key: string; readonly lap_key: string; readonly length_seq: number; readonly start_utc: number | null; readonly elapsed_s: number | null; readonly timer_s: number | null; readonly strokes: number | null; readonly stroke_type: string | null; readonly length_type: string | null; }
+export interface StreamRow { readonly stream_key: string; readonly session_key: string; readonly channel: string; readonly encoding: "f64:raw:zdeflate:le"; readonly sample_rate: null; readonly n: number; readonly data: Uint8Array; }
+export interface ActivityRows { readonly workout: WorkoutRow; readonly sessions: readonly SessionRow[]; readonly laps: readonly LapRow[]; readonly swimLengths: readonly SwimLengthRow[]; readonly streams: readonly StreamRow[]; }
+export interface ActivityRepository { replaceForRawFile(rawSha256: string, rows: ActivityRows): Promise<void>; }
+
+export function createActivityRepository(store: SqlStore): ActivityRepository {
+  return {
+    async replaceForRawFile(rawSha256, rows) {
+      await store.run(
+        `DELETE FROM metric_snapshot
+WHERE (
+  scope_kind = 'session'
+  AND scope_id IN (
+    SELECT s.session_key FROM session AS s JOIN workout AS w ON w.workout_key = s.workout_key
+    WHERE w.dedup_cluster_id = ?
+  )
+) OR (
+  scope_kind = 'date'
+  AND scope_id IN (
+    SELECT CAST(s.local_date_key AS TEXT) FROM session AS s JOIN workout AS w ON w.workout_key = s.workout_key
+    WHERE w.dedup_cluster_id = ?
+  )
+)`,
+        [rawSha256, rawSha256],
+      );
+      await store.run("DELETE FROM workout WHERE dedup_cluster_id = ?", [rawSha256]);
+      const w = rows.workout;
+      await store.run("INSERT INTO workout (workout_key,start_utc,tz_offset_s,name,notes,is_multisport,dedup_cluster_id) VALUES (?,?,?,?,?,?,?)", [w.workout_key,w.start_utc,w.tz_offset_s,w.name,w.notes,w.is_multisport,w.dedup_cluster_id]);
+      for (const s of [...rows.sessions].sort((a,b) => a.session_seq - b.session_seq)) {
+        await store.run("INSERT INTO session (session_key,workout_key,session_seq,sport,sub_sport,start_utc,tz_offset_s,local_date_key,elapsed_s,timer_s,moving_s,distance_m,is_transition,summary_json) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)", [s.session_key,s.workout_key,s.session_seq,s.sport,s.sub_sport,s.start_utc,s.tz_offset_s,s.local_date_key,s.elapsed_s,s.timer_s,s.moving_s,s.distance_m,s.is_transition,s.summary_json]);
+      }
+      for (const l of [...rows.laps].sort((a,b) => compareUtf8(a.session_key,b.session_key) || a.lap_seq-b.lap_seq)) {
+        await store.run("INSERT INTO lap (lap_key,session_key,lap_seq,start_utc,elapsed_s,timer_s,distance_m,summary_json) VALUES (?,?,?,?,?,?,?,?)", [l.lap_key,l.session_key,l.lap_seq,l.start_utc,l.elapsed_s,l.timer_s,l.distance_m,l.summary_json]);
+      }
+      for (const l of [...rows.swimLengths].sort((a,b) => compareUtf8(a.lap_key,b.lap_key) || a.length_seq-b.length_seq)) {
+        await store.run("INSERT INTO swim_length (length_key,lap_key,length_seq,start_utc,elapsed_s,timer_s,strokes,stroke_type,length_type) VALUES (?,?,?,?,?,?,?,?,?)", [l.length_key,l.lap_key,l.length_seq,l.start_utc,l.elapsed_s,l.timer_s,l.strokes,l.stroke_type,l.length_type]);
+      }
+      for (const s of [...rows.streams].sort((a,b) => compareUtf8(a.session_key,b.session_key) || compareUtf8(a.channel,b.channel))) {
+        await store.run("INSERT INTO stream (stream_key,session_key,channel,encoding,sample_rate,n,data) VALUES (?,?,?,?,?,?,?)", [s.stream_key,s.session_key,s.channel,s.encoding,s.sample_rate,s.n,s.data]);
+      }
+    },
+  };
+}

--- a/packages/kernel/src/store/derived-key.ts
+++ b/packages/kernel/src/store/derived-key.ts
@@ -1,0 +1,76 @@
+import { toHex } from "../archive/paths.js";
+import type { CryptoPort } from "../ports/crypto.js";
+
+export class DerivedKeyError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "DerivedKeyError";
+  }
+}
+
+export function encodeUtf8Strict(input: string): Uint8Array {
+  const out: number[] = [];
+  for (let i = 0; i < input.length; i++) {
+    let cp = input.charCodeAt(i);
+    if (cp >= 0xd800 && cp <= 0xdbff) {
+      if (i + 1 >= input.length) throw new DerivedKeyError("unpaired UTF-16 surrogate");
+      const lo = input.charCodeAt(++i);
+      if (lo < 0xdc00 || lo > 0xdfff) throw new DerivedKeyError("unpaired UTF-16 surrogate");
+      cp = 0x10000 + ((cp - 0xd800) << 10) + (lo - 0xdc00);
+    } else if (cp >= 0xdc00 && cp <= 0xdfff) {
+      throw new DerivedKeyError("unpaired UTF-16 surrogate");
+    }
+    if (cp <= 0x7f) out.push(cp);
+    else if (cp <= 0x7ff) out.push(0xc0 | (cp >> 6), 0x80 | (cp & 0x3f));
+    else if (cp <= 0xffff)
+      out.push(0xe0 | (cp >> 12), 0x80 | ((cp >> 6) & 0x3f), 0x80 | (cp & 0x3f));
+    else
+      out.push(
+        0xf0 | (cp >> 18),
+        0x80 | ((cp >> 12) & 0x3f),
+        0x80 | ((cp >> 6) & 0x3f),
+        0x80 | (cp & 0x3f),
+      );
+  }
+  return Uint8Array.from(out);
+}
+
+export function compareUtf8(left: string, right: string): number {
+  const a = encodeUtf8Strict(left);
+  const b = encodeUtf8Strict(right);
+  const length = Math.min(a.length, b.length);
+  for (let i = 0; i < length; i++) {
+    if (a[i] !== b[i]) return a[i] < b[i] ? -1 : 1;
+  }
+  return a.length === b.length ? 0 : a.length < b.length ? -1 : 1;
+}
+
+export async function H(
+  crypto: CryptoPort,
+  ...fields: readonly [string | number, ...(string | number)[]]
+): Promise<string> {
+  if (fields.length === 0) throw new DerivedKeyError("empty key tuple");
+  const encoded: Uint8Array[] = [];
+  let byteLength = fields.length - 1;
+  for (const field of fields) {
+    let normalized: string;
+    if (typeof field === "string") {
+      normalized = field;
+    } else if (typeof field === "number" && Number.isFinite(field) && Number.isSafeInteger(field)) {
+      normalized = Object.is(field, -0) ? "0" : field.toString();
+    } else {
+      throw new DerivedKeyError("unsupported key field");
+    }
+    const bytes = encodeUtf8Strict(normalized);
+    encoded.push(bytes);
+    byteLength += bytes.length;
+  }
+  const framed = new Uint8Array(byteLength);
+  let offset = 0;
+  for (let i = 0; i < encoded.length; i++) {
+    if (i > 0) framed[offset++] = 0x1f;
+    framed.set(encoded[i], offset);
+    offset += encoded[i].length;
+  }
+  return toHex(await crypto.sha256(framed));
+}

--- a/packages/kernel/src/store/dump.ts
+++ b/packages/kernel/src/store/dump.ts
@@ -1,6 +1,8 @@
 import { canonicalRowJson } from "./canonical-json.js";
 import type { Row, SqlStore } from "./ports.js";
 
+export const DERIVED_TABLES = ["metric_snapshot", "mean_max_cache", "repair_log", "stream", "swim_length", "lap", "session", "workout"] as const;
+
 /** Every table in 001_init.sql, alphabetical, with its content-derived order key (DDL-SPEC §4/§8). */
 export const DUMP_TABLES: readonly { readonly table: string; readonly orderBy: string }[] = [
   { table: "anchor_history", orderBy: "id" },

--- a/packages/kernel/src/store/index.ts
+++ b/packages/kernel/src/store/index.ts
@@ -4,3 +4,5 @@ export * from "./canonical-json.js";
 export * from "./dump.js";
 export * from "./anchor-repository.js";
 export * from "./source-repository.js";
+export * from "./activity-repository.js";
+export * from "./derived-key.js";

--- a/packages/kernel/src/store/ports.ts
+++ b/packages/kernel/src/store/ports.ts
@@ -59,8 +59,29 @@ export interface AnchorRepository {
   readCurrent(sport: string, anchorType: string, asOfEpochS: number): Promise<AnchorHistoryRow | undefined>;
 }
 
+export type RawFileColumn =
+  | "sha256"
+  | "path"
+  | "ext"
+  | "bytes"
+  | "file_id_serial"
+  | "file_id_time_created_utc"
+  | "manufacturer"
+  | "product";
+
+export class RawFileInvariantError extends Error {
+  readonly sha256: string;
+  readonly mismatchedColumns: readonly RawFileColumn[];
+  constructor(sha256: string, mismatchedColumns: readonly RawFileColumn[]) {
+    super("raw file invariant mismatch");
+    this.name = "RawFileInvariantError";
+    this.sha256 = sha256;
+    this.mismatchedColumns = [...mismatchedColumns];
+  }
+}
+
 export interface RawFileRepository {
-  upsert(row: RawFileRow): Promise<void>;
+  upsert(row: RawFileRow): Promise<boolean>;
 }
 
 export interface SourceRecordRepository {

--- a/packages/kernel/src/store/source-repository.ts
+++ b/packages/kernel/src/store/source-repository.ts
@@ -1,16 +1,10 @@
-import type {
-  RawFileRepository,
-  RawFileRow,
-  SourceRecordRepository,
-  SourceRecordRow,
-  SqlStore,
-} from "./ports.js";
+import { RawFileInvariantError, type RawFileColumn, type RawFileRepository, type RawFileRow, type SourceRecordRepository, type SourceRecordRow, type SqlStore } from "./ports.js";
 
 export function createRawFileRepository(store: SqlStore): RawFileRepository {
   return {
-    async upsert(row: RawFileRow): Promise<void> {
-      await store.run(
-        "INSERT INTO raw_file (sha256, path, ext, bytes, file_id_serial, file_id_time_created_utc, manufacturer, product) VALUES (?,?,?,?,?,?,?,?) ON CONFLICT DO NOTHING",
+    async upsert(row: RawFileRow): Promise<boolean> {
+      const inserted = await store.get(
+        "INSERT INTO raw_file (sha256, path, ext, bytes, file_id_serial, file_id_time_created_utc, manufacturer, product) VALUES (?,?,?,?,?,?,?,?) ON CONFLICT DO NOTHING RETURNING sha256",
         [
           row.sha256,
           row.path,
@@ -22,6 +16,24 @@ export function createRawFileRepository(store: SqlStore): RawFileRepository {
           row.product,
         ],
       );
+      const selected = await store.get(
+        "SELECT sha256, path, ext, bytes, file_id_serial, file_id_time_created_utc, manufacturer, product FROM raw_file WHERE sha256=?",
+        [row.sha256],
+      );
+      const columns: readonly RawFileColumn[] = [
+        "sha256",
+        "path",
+        "ext",
+        "bytes",
+        "file_id_serial",
+        "file_id_time_created_utc",
+        "manufacturer",
+        "product",
+      ];
+      if (selected === undefined) throw new RawFileInvariantError(row.sha256, columns);
+      const mismatched = columns.filter((column) => selected[column] !== row[column]);
+      if (mismatched.length > 0) throw new RawFileInvariantError(row.sha256, mismatched);
+      return inserted !== undefined;
     },
   };
 }

--- a/packages/kernel/tests/derived-key.test.ts
+++ b/packages/kernel/tests/derived-key.test.ts
@@ -1,0 +1,32 @@
+import { createHash } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import type { CryptoPort } from "../src/ports/crypto.js";
+import { DerivedKeyError, H, encodeUtf8Strict } from "../src/store/derived-key.js";
+
+function crypto(digest?: Uint8Array):CryptoPort{return{async sha256(data){return digest??new Uint8Array(createHash("sha256").update(data).digest());},async randomBytes(){throw new Error("unused")},async pbkdf2(){throw new Error("unused")},async aesGcmEncrypt(){throw new Error("unused")},async aesGcmDecrypt(){throw new Error("unused")}}}
+
+describe("derived keys",()=>{
+  it("matches every chained vector",async()=>{
+    const c=crypto(),raw="0123456789abcdef".repeat(4);
+    const workout=await H(c,"workout",raw); expect(workout).toBe("5016f224d978cf82ac99f3c35812dfb9956958e51d50d9c2b600dc057b9b5404");
+    const session=await H(c,"session",workout,0); expect(session).toBe("773c0ea27fed8112a27f2b4f60f7033e6a18dae42ba717c0fd3f89a922ac20cb");
+    expect(await H(c,"lap",session,3)).toBe("89c9171ca9556909fbb4182302e396a63d282f0832a1c5eaf416cac97041814f");
+    const lap=await H(c,"lap",session,3); expect(await H(c,"swim_length",lap,2)).toBe("3a296f220d950bb4ff6a9dfa97ab5188899d564bf87da5ee07cc57265eb7d5c8");
+    expect(await H(c,"stream",session,"heart_rate")).toBe("f80c186930ab43acb807754dc240bed666d87ad6425a41efe06690dd776969ef");
+  });
+  it("frames fields, encodes strict UTF-8, and normalizes minus zero",async()=>{
+    let framed:Uint8Array|undefined;
+    const observing={...crypto(),async sha256(data:Uint8Array){framed=data;return new Uint8Array(32)}};
+    await H(observing,"a","b");expect([...framed!]).toEqual([97,31,98]);
+    expect([...encodeUtf8Strict("A😀")]).toEqual([65,240,159,152,128]);
+    expect(await H(crypto(),-0)).toBe(await H(crypto(),0));
+  });
+  it("preserves digest leading zeroes and rejects invalid fields",async()=>{
+    expect(await H(crypto(new Uint8Array(32)),"x")).toBe("0".repeat(64));
+    await expect(H(crypto(),...( [] as unknown as [string]))).rejects.toBeInstanceOf(DerivedKeyError);
+    for(const value of [NaN,Infinity,1.5,Number.MAX_SAFE_INTEGER+1,null,undefined] as unknown[]){
+      await expect(H(crypto(),value as string)).rejects.toBeInstanceOf(DerivedKeyError);
+    }
+    expect(()=>encodeUtf8Strict("\ud800")).toThrow(DerivedKeyError);
+  });
+});

--- a/packages/kernel/tests/fit-row-mapper.test.ts
+++ b/packages/kernel/tests/fit-row-mapper.test.ts
@@ -1,0 +1,92 @@
+import { createHash } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import type { CryptoPort } from "../src/ports/crypto.js";
+import { FitSourceError, mapFitArtifact, type DecodedActivity, type DecodedFitFile, type DecodedLap, type DecodedLength, type DecodedRecord, type DecodedSession } from "../src/ingest/index.js";
+import { decodeStream } from "../src/ingest/stream-codec.js";
+
+const crypto:CryptoPort={async sha256(d){return new Uint8Array(createHash("sha256").update(d).digest())},async randomBytes(){throw new Error("unused")},async pbkdf2(){throw new Error("unused")},async aesGcmEncrypt(){throw new Error("unused")},async aesGcmDecrypt(){throw new Error("unused")}};
+const session=(sourceIndex:number,startTime:number,timestamp:number,overrides:Partial<DecodedSession>={}):DecodedSession=>({sourceIndex,sport:"cycling",subSport:"generic",startTime,timestamp,trigger:"activity_end",firstLapIndex:null,numLaps:null,totalElapsedTime:1.5,totalTimerTime:1.499,totalMovingTime:.5,totalDistance:10,developerFields:[],...overrides});
+const record=(sourceIndex:number,timestamp:number,overrides:Partial<DecodedRecord>={}):DecodedRecord=>({sourceIndex,timestamp,positionLat:null,positionLong:null,distance:null,enhancedAltitude:null,altitude:null,enhancedSpeed:null,speed:null,heartRate:null,cadence:null,fractionalCadence:null,power:null,temperature:null,stanceTime:null,stanceTimeBalance:null,verticalOscillation:null,verticalRatio:null,stepLength:null,leftRightBalance:null,respirationRate:null,developerFields:[],coordinateUnit:"degrees",...overrides});
+const lap=(sourceIndex:number,overrides:Partial<DecodedLap>={}):DecodedLap=>({sourceIndex,startTime:1000,timestamp:1001,firstLengthIndex:null,numLengths:null,numActiveLengths:null,totalElapsedTime:1,totalTimerTime:1,totalDistance:25,developerFields:[],...overrides});
+const length=(sourceIndex:number,overrides:Partial<DecodedLength>={}):DecodedLength=>({sourceIndex,startTime:1000,timestamp:1001,totalElapsedTime:1,totalTimerTime:1,totalStrokes:10,swimStroke:"freestyle",lengthType:"active",...overrides});
+const decoded=(sessions:DecodedSession[],records:DecodedRecord[],overrides:Partial<DecodedFitFile>={}):DecodedFitFile=>({fileIds:[{serialNumber:1,timeCreated:900,manufacturer:"development",product:1,productName:null}],activity:null,sessions,laps:[],lengths:[],records,events:[],developerDataIds:[],...overrides});
+const map=(d:DecodedFitFile)=>mapFitArtifact({crypto,rawSha256:"01".repeat(32),rawByteLength:10,archivePath:null,decoded:d});
+const error=async(promise:Promise<unknown>,code:string)=>expect(promise).rejects.toMatchObject({code});
+
+describe("FIT row mapper",()=>{
+  it("maps rows, enhanced fields, integer durations, local date, and aligned channels",async()=>{
+    const d=decoded([session(0,1000,1002,{developerFields:[{nativeMessageType:18,developer_data_index:0,field_definition_number:1,field_name:"Score %",units:"%",value:{b:2,a:1}}]})],[record(0,1000,{enhancedAltitude:20,altitude:10,heartRate:120,developerFields:[{nativeMessageType:20,developer_data_index:0,field_definition_number:2,field_name:"Metric",units:"u",value:3.5}]}),record(1,1001,{altitude:11,heartRate:null})]);
+    const out=await map({...d,developerDataIds:[{developerDataIndex:0,applicationId:Array.from({length:16},(_,i)=>i)}]});expect(out.activity.sessions[0]).toMatchObject({sport:"cycling",elapsed_s:2,timer_s:1,moving_s:1,distance_m:10,local_date_key:19700101});
+    expect(out.activity.sessions[0].summary_json).toContain('"normalized_name":"score_%25"');
+    const altitude=out.activity.streams.find((s)=>s.channel==="altitude")!;expect(decodeStream({...altitude,kind:"value"})).toEqual([20,11]);
+    const heart=out.activity.streams.find((s)=>s.channel==="heart_rate")!;expect(decodeStream({...heart,kind:"value"})).toEqual([120,null]);
+    expect(out.activity.streams.some((s)=>s.channel.endsWith(":metric"))).toBe(true);
+  });
+  it("maps every native record channel and prefers enhanced values",async()=>{
+    const values:Partial<DecodedRecord>={positionLat:1,positionLong:2,distance:3,enhancedAltitude:4,altitude:40,enhancedSpeed:5,speed:50,heartRate:6,cadence:7,fractionalCadence:8,power:9,temperature:10,stanceTime:11,stanceTimeBalance:12,verticalOscillation:13,verticalRatio:14,stepLength:15,leftRightBalance:16,respirationRate:17};
+    const out=await map(decoded([session(0,0,1)],[record(0,0,values)]));
+    const expected={time:0,lat:1,lng:2,distance:3,altitude:4,speed:5,heart_rate:6,cadence:7,fractional_cadence:8,power:9,temperature:10,stance_time:11,stance_time_balance:12,vertical_oscillation:13,vertical_ratio:14,step_length:15,left_right_balance:16,respiration_rate:17};
+    expect(out.activity.streams.map((s)=>s.channel).sort()).toEqual(Object.keys(expected).sort());
+    for(const row of out.activity.streams) expect(decodeStream({...row,kind:row.channel==="time"?"time":"value"})).toEqual([expected[row.channel as keyof typeof expected]]);
+    await error(map(decoded([session(0,0,1)],[record(0,0,{leftRightBalance:-1})])),"invalid_numeric");
+    await error(map(decoded([session(0,0,1)],[record(0,0,{leftRightBalance:1.5})])),"invalid_numeric");
+    await error(map(decoded([session(0,0,1)],[record(0,0,{leftRightBalance:128})])),"invalid_numeric");
+  });
+  it("uses the exact duration rounding vectors and rejects invalid values",async()=>{
+    for(const [value,want] of [[1.001,1],[1.499,1],[1.5,2],[.499,0],[.5,1]] as const){
+      const out=await map(decoded([session(0,0,1,{totalElapsedTime:value,totalTimerTime:value,totalMovingTime:value})],[]));
+      expect(out.activity.sessions[0]).toMatchObject({elapsed_s:want,timer_s:want,moving_s:want});
+    }
+    await error(map(decoded([session(0,0,1,{totalElapsedTime:-.001})],[])),"invalid_numeric");
+    await error(map(decoded([session(0,0,1,{totalElapsedTime:Number.MAX_SAFE_INTEGER+1})],[])),"invalid_numeric");
+  });
+  it("uses half-open shared boundaries by session index",async()=>{
+    const sessions=[session(0,0,3,{sport:"swimming",subSport:"open_water",trigger:2}),session(1,3,5,{sport:"transition",trigger:2}),session(2,5,9,{sport:"cycling",trigger:2}),session(3,9,11,{sport:"transition",trigger:2}),session(4,11,14,{sport:"running",trigger:0})];
+    const times=[0,1,2,3,4,5,6,7,8,9,10,11,12,14];const out=await map(decoded(sessions,times.map((t,i)=>record(i,t))));
+    const timeRows=out.activity.streams.filter((s)=>s.channel==="time").sort((a,b)=>out.activity.sessions.findIndex((x)=>x.session_key===a.session_key)-out.activity.sessions.findIndex((x)=>x.session_key===b.session_key));
+    expect(timeRows.map((s)=>s.n)).toEqual([3,2,4,2,3]);expect(out.activity.sessions.filter((s)=>s.is_transition).map((s)=>s.session_seq)).toEqual([1,3]);
+  });
+  it("honors source-error precedence and does not sort records",async()=>{
+    await expect(map(decoded([], [record(0,NaN)]))).rejects.toMatchObject({code:"missing_session"});
+    await expect(map(decoded([session(0,0,3,{sport:null,startTime:NaN})],[]))).rejects.toMatchObject({code:"invalid_date"});
+    await expect(map(decoded([session(0,0,3)],[record(0,2),record(1,1)]))).rejects.toMatchObject({code:"record_time_nonmonotonic"});
+    await expect(map(decoded([session(0,0,1),session(1,2,3)],[record(0,1.5)]))).rejects.toMatchObject({code:"record_unassigned"});
+  });
+  it("rejects unequal developer duplicates and accepts equal structured duplicates",async()=>{
+    const a={nativeMessageType:18,developer_data_index:0,field_definition_number:1,field_name:"x",units:null,value:{b:2,a:1}};
+    await expect(map(decoded([session(0,0,1,{developerFields:[a,{...a,value:{a:1,b:2}}]})],[]))).resolves.toBeDefined();
+    await expect(map(decoded([session(0,0,1,{developerFields:[a,{...a,value:2}]})],[]))).rejects.toMatchObject({code:"developer_identity_conflict"} satisfies Partial<FitSourceError>);
+  });
+  it("normalizes exhaustive enums from numeric and string forms",async()=>{
+    const sports={0:"generic",1:"running",2:"cycling",3:"transition",4:"fitness_equipment",5:"swimming",6:"basketball",7:"soccer",8:"tennis",9:"american_football",10:"training",11:"walking",12:"cross_country_skiing",13:"alpine_skiing",14:"snowboarding",15:"rowing",16:"mountaineering",17:"hiking",18:"multisport",19:"paddling",20:"flying",21:"e_biking",22:"motorcycling",23:"boating",24:"driving",25:"golf",26:"hang_gliding",27:"horseback_riding",28:"hunting",29:"fishing",30:"inline_skating",31:"rock_climbing",32:"sailing",33:"ice_skating",34:"sky_diving",35:"snowshoeing",36:"snowmobiling",37:"stand_up_paddleboarding",38:"surfing",39:"wakeboarding",40:"water_skiing",41:"kayaking",42:"rafting",43:"windsurfing",44:"kitesurfing",45:"tactical",46:"jumpmaster",47:"boxing",48:"floor_climbing",53:"diving",254:"all"} as const;
+    const subSports={0:"generic",1:"treadmill",2:"street",3:"trail",4:"track",5:"spin",6:"indoor_cycling",7:"road",8:"mountain",9:"downhill",10:"recumbent",11:"cyclocross",12:"hand_cycling",13:"track_cycling",14:"indoor_rowing",15:"elliptical",16:"stair_climbing",17:"lap_swimming",18:"open_water",19:"flexibility_training",20:"strength_training",21:"warm_up",22:"match",23:"exercise",24:"challenge",25:"indoor_skiing",26:"cardio_training",27:"indoor_walking",28:"e_bike_fitness",29:"bmx",30:"casual_walking",31:"speed_walking",32:"bike_to_run_transition",33:"run_to_bike_transition",34:"swim_to_bike_transition",35:"atv",36:"motocross",37:"backcountry",38:"resort",39:"rc_drone",40:"wingsuit",41:"whitewater",42:"skate_skiing",43:"yoga",44:"pilates",45:"indoor_running",46:"gravel_cycling",47:"e_bike_mountain",48:"commuting",49:"mixed_surface",50:"navigate",51:"track_me",52:"map",53:"single_gas_diving",54:"multi_gas_diving",55:"gauge_diving",56:"apnea_diving",57:"apnea_hunting",58:"virtual_activity",59:"obstacle",254:"all"} as const;
+    for(const [raw,name] of Object.entries(sports)) for(const input of [Number(raw),name]) expect((await map(decoded([session(0,0,1,{sport:input})],[]))).activity.sessions[0].sport).toBe(name);
+    for(const [raw,name] of Object.entries(subSports)) for(const input of [Number(raw),name]) expect((await map(decoded([session(0,0,1,{subSport:input})],[]))).activity.sessions[0].sub_sport).toBe(name);
+    for(const [raw,name] of Object.entries({0:"activity_end",1:"manual",2:"auto_multi_sport",3:"fitness_equipment"})) for(const input of [Number(raw),name]) expect(JSON.parse((await map(decoded([session(0,0,1,{trigger:input})],[]))).activity.sessions[0].summary_json!).trigger).toBe(name);
+    expect(JSON.parse((await map(decoded([session(0,0,1,{trigger:99})],[]))).activity.sessions[0].summary_json!).trigger).toBe("unknown:99");
+    for(const bad of ["",99,1.5,NaN] as const) await error(map(decoded([session(0,0,1,{sport:bad})],[])),"invalid_enum");
+  });
+  it("maps lap and length scalars, drill values, and ownership truth tables",async()=>{
+    const baseSession=session(0,1000,1002,{firstLapIndex:0,numLaps:1});
+    const baseLap=lap(0,{firstLengthIndex:0,numLengths:1,numActiveLengths:1,totalElapsedTime:1.5,totalTimerTime:.5});
+    const out=await map(decoded([baseSession],[],{laps:[baseLap],lengths:[length(0,{swimStroke:4,lengthType:1,totalElapsedTime:1.499,totalTimerTime:.5})]}));
+    expect(out.activity.laps[0]).toMatchObject({lap_seq:0,elapsed_s:2,timer_s:1,distance_m:25});
+    expect(out.activity.swimLengths[0]).toMatchObject({length_seq:0,elapsed_s:1,timer_s:1,strokes:10,stroke_type:"drill",length_type:"active"});
+    await expect(map(decoded([session(0,0,1,{firstLapIndex:null,numLaps:null})],[]))).resolves.toBeDefined();
+    await error(map(decoded([session(0,0,1,{firstLapIndex:0,numLaps:null})],[])),"lap_slice_invalid");
+    await expect(map(decoded([session(0,0,1,{firstLapIndex:null,numLaps:0})],[]))).resolves.toBeDefined();
+    await error(map(decoded([session(0,0,1,{firstLapIndex:1,numLaps:0})],[])),"lap_slice_invalid");
+    await error(map(decoded([session(0,0,1,{firstLapIndex:null,numLaps:1})],[],{laps:[lap(0)]})),"lap_slice_invalid");
+    await error(map(decoded([baseSession],[],{laps:[lap(0,{firstLengthIndex:0,numLengths:null})]})),"length_slice_invalid");
+    await error(map(decoded([baseSession],[],{laps:[lap(0,{firstLengthIndex:null,numLengths:1})],lengths:[length(0)]})),"length_slice_invalid");
+    await error(map(decoded([baseSession],[],{laps:[baseLap],lengths:[length(0,{lengthType:"idle"})]})),"active_length_count_mismatch");
+  });
+  it("keeps total source-error precedence for compound failures",async()=>{
+    const badActivity={timestamp:NaN,localTimestamp:null,numSessions:null,type:null,event:null,eventType:null} satisfies DecodedActivity;
+    await error(map(decoded([],[],{activity:badActivity})),"missing_session");
+    await error(map(decoded([session(0,NaN,1,{sport:null})],[])),"invalid_date");
+    await error(map(decoded([session(0,0,1,{sport:"bad",firstLapIndex:0,numLaps:null})],[])),"invalid_enum");
+    await error(map(decoded([session(0,0,1)],[record(0,0,{timestamp:null}),record(1,2)])),"record_time_missing");
+    await error(map(decoded([session(0,0,1),session(1,2,3)],[record(0,1.5),record(1,2.5)])),"record_unassigned");
+  });
+});

--- a/packages/kernel/tests/migrations-ddl.test.ts
+++ b/packages/kernel/tests/migrations-ddl.test.ts
@@ -1,6 +1,7 @@
 import { DatabaseSync } from "node:sqlite";
 import { afterEach, describe, expect, it } from "vitest";
 import { MIGRATIONS } from "../src/store/migrations/index.js";
+import { DERIVED_TABLES } from "../src/store/dump.js";
 
 const EXPECTED_TABLES = [
   "athlete",
@@ -38,16 +39,6 @@ const EXPECTED_INDEXES = [
   "idx_metric_snapshot_metric",
   "idx_stroke_correction_target",
   "idx_pool_size_target",
-];
-
-const DERIVED_TABLES = [
-  "metric_snapshot",
-  "mean_max_cache",
-  "workout",
-  "session",
-  "lap",
-  "swim_length",
-  "stream",
 ];
 
 const RESERVED_DOMAIN_I_TABLES = [
@@ -129,7 +120,8 @@ describe("001_init migration", () => {
 
   it("carries no wall-clock column on any derived table (INV-2)", () => {
     db = openMigrated();
-    for (const table of DERIVED_TABLES) {
+    expect(DERIVED_TABLES.join(",")).toBe("metric_snapshot,mean_max_cache,repair_log,stream,swim_length,lap,session,workout");
+    for (const table of DERIVED_TABLES.filter((name) => EXPECTED_TABLES.includes(name))) {
       const cols = db
         .prepare(`PRAGMA table_info(${table});`)
         .all() as Array<{ name: string }>;

--- a/packages/kernel/tests/stream-codec.test.ts
+++ b/packages/kernel/tests/stream-codec.test.ts
@@ -1,0 +1,71 @@
+import { unzlibSync, zlibSync } from "fflate";
+import { describe, expect, it } from "vitest";
+import { decodeStream, encodeStream, STREAM_ENCODING, StreamCodecError } from "../src/ingest/stream-codec.js";
+
+const hex=(x:Uint8Array)=>[...x].map((b)=>b.toString(16).padStart(2,"0")).join("");
+const compressed=(raw:Uint8Array)=>zlibSync(raw,{level:6});
+const raw=(values:readonly(number|null)[]=[1])=>unzlibSync(encodeStream("value",values).data);
+const changed=(values:readonly(number|null)[],change:(payload:Uint8Array)=>Uint8Array|void)=>{const payload=raw(values);return compressed(change(payload)??payload)};
+const u32=(payload:Uint8Array,offset:number,value:number)=>new DataView(payload.buffer,payload.byteOffset,payload.byteLength).setUint32(offset,value,true);
+const f64=(payload:Uint8Array,offset:number,value:number)=>new DataView(payload.buffer,payload.byteOffset,payload.byteLength).setFloat64(offset,value,true);
+function rejects(run:()=>unknown,want:string){try{run();throw new Error("accepted")}catch(error){expect(error).toBeInstanceOf(StreamCodecError);expect((error as StreamCodecError).code).toBe(want)}}
+
+describe("STRM v1 codec",()=>{
+  it("matches the exact raw and compressed n=3 golden and round trips both kinds",()=>{
+    const encoded=encodeStream("value",[1,null,-2.5]);
+    expect(encoded).toMatchObject({encoding:STREAM_ENCODING,n:3});
+    expect(hex(unzlibSync(encoded.data))).toBe("5354524d01010000030000000100000005000000000000f03f000000000000000000000000000004c0");
+    expect(hex(encoded.data)).toBe("789c0b0e09f2656464606066606000520cac400c041fec21340cb01c0000499d0345");
+    expect(decodeStream({...encoded,kind:"value"})).toEqual([1,null,-2.5]);
+    const time=encodeStream("time",[1,2.5,4]);expect(decodeStream({...time,kind:"time"})).toEqual([1,2.5,4]);
+    expect(encodeStream("value",[1,null,-2.5]).data).toEqual(encodeStream("value",[1,null,-2.5]).data);
+  });
+  it("uses LSB-first n=10 bitmaps and normalizes minus zero",()=>{
+    const values=Array<number|null>(10).fill(null);values[0]=1;values[7]=2;values[8]=-0;
+    const payload=raw(values);expect([payload[16],payload[17]]).toEqual([0x81,0x01]);
+    expect(Object.is(decodeStream({...encodeStream("value",values),kind:"value"})[8],-0)).toBe(false);
+  });
+  it("applies every direct-encode error in contract order",()=>{
+    rejects(()=>encodeStream("value",[]),"invalid_n");
+    rejects(()=>encodeStream("value",[undefined] as unknown as number[]),"present_nonfinite");
+    rejects(()=>encodeStream("value",[NaN]),"present_nonfinite");
+    rejects(()=>encodeStream("value",[Infinity]),"present_nonfinite");
+    rejects(()=>encodeStream("time",[null]),"time_missing");
+    rejects(()=>encodeStream("time",[2,2]),"time_nonmonotonic");
+    rejects(()=>encodeStream("value",[null]),"all_missing");
+  });
+  it("returns every stable decode error",()=>{
+    const good=encodeStream("value",[1]);
+    rejects(()=>decodeStream({...good,encoding:"x",data:new Uint8Array([1]),kind:"value"}),"unsupported_encoding");
+    rejects(()=>decodeStream({...good,data:new Uint8Array([1]),kind:"value"}),"inflate_failed");
+    rejects(()=>decodeStream({...good,data:compressed(new Uint8Array(15)),kind:"value"}),"payload_length");
+    rejects(()=>decodeStream({...good,data:changed([1],p=>{p[0]=0}),kind:"value"}),"bad_magic");
+    rejects(()=>decodeStream({...good,data:changed([1],p=>{p[4]=2}),kind:"value"}),"bad_version");
+    rejects(()=>decodeStream({...good,data:changed([1],p=>{p[5]=2}),kind:"value"}),"bad_dtype");
+    rejects(()=>decodeStream({...good,data:changed([1],p=>{p[6]=1}),kind:"value"}),"bad_delta");
+    rejects(()=>decodeStream({...good,data:changed([1],p=>{p[7]=1}),kind:"value"}),"bad_endian");
+    rejects(()=>decodeStream({...good,n:0,kind:"value"}),"invalid_n");
+    rejects(()=>decodeStream({...good,data:changed([1],p=>{u32(p,8,0)}),kind:"value"}),"invalid_n");
+    rejects(()=>decodeStream({...good,n:2,kind:"value"}),"n_mismatch");
+    rejects(()=>decodeStream({...good,data:changed([1],p=>{u32(p,12,2)}),kind:"value"}),"bitmap_length");
+    rejects(()=>decodeStream({...good,data:changed([1],p=>p.slice(0,-1)),kind:"value"}),"payload_length");
+    rejects(()=>decodeStream({...good,data:changed([1],p=>{const x=new Uint8Array(p.length+1);x.set(p);return x}),kind:"value"}),"trailing_bytes");
+    rejects(()=>decodeStream({...good,data:changed([1],p=>{p[16]|=2}),kind:"value"}),"high_bitmap_bits");
+    rejects(()=>decodeStream({...good,data:changed([1],p=>{p[16]=0}),kind:"value"}),"missing_slot_nonzero");
+    rejects(()=>decodeStream({...good,data:changed([1],p=>{f64(p,17,NaN)}),kind:"value"}),"present_nonfinite");
+    const missing=encodeStream("value",[null,2]);rejects(()=>decodeStream({...missing,kind:"time"}),"time_missing");
+    const nonmonotonic=encodeStream("value",[2,1]);rejects(()=>decodeStream({...nonmonotonic,kind:"time"}),"time_nonmonotonic");
+    rejects(()=>decodeStream({...good,data:changed([1],p=>{p[16]=0;p.fill(0,17)}),kind:"value"}),"all_missing");
+  });
+  it("keeps compound corruption precedence deterministic",()=>{
+    const one=encodeStream("value",[1]);
+    const bitmapAndTrailing=changed([1],p=>{u32(p,12,2);const x=new Uint8Array(p.length+1);x.set(p);return x});
+    rejects(()=>decodeStream({...one,data:bitmapAndTrailing,kind:"value"}),"bitmap_length");
+    const shortAndHigh=changed([1],p=>{p[16]|=2;return p.slice(0,-1)});
+    rejects(()=>decodeStream({...one,data:shortAndHigh,kind:"value"}),"payload_length");
+    const missingAndNan=changed([1,2],p=>{p[16]&=~1;f64(p,17+8,NaN)});
+    rejects(()=>decodeStream({...encodeStream("value",[1,2]),data:missingAndNan,kind:"value"}),"missing_slot_nonzero");
+    const missingAndNonmonotonic=changed([1,2,1],p=>{p[16]&=~1;p.fill(0,17,25)});
+    rejects(()=>decodeStream({...encodeStream("value",[1,2,1]),data:missingAndNonmonotonic,kind:"time"}),"time_missing");
+  });
+});

--- a/packages/kernel/tsup.config.ts
+++ b/packages/kernel/tsup.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     store: "src/store/index.ts",
     "archive/index": "src/archive/index.ts",
     "store/export/index": "src/store/export/index.ts",
+    "ingest/index": "src/ingest/index.ts",
   },
   loader: { ".sql": "text" },
   format: ["esm"],

--- a/patches/fit-file-parser@3.0.2.patch
+++ b/patches/fit-file-parser@3.0.2.patch
@@ -1,0 +1,188 @@
+diff --git a/dist/binary.js b/dist/binary.js
+index 556ced544885769304b7c880e90d5587580bb526..c2ac0d8201715cc74a10884c90ab3ca21f12af77 100644
+--- a/dist/binary.js
++++ b/dist/binary.js
+@@ -324,7 +324,10 @@ export function readRecord(blob, messageTypes, developerFields, startIndex, opti
+                 const size = blob[fDefIndex + 1];
+                 const devDataIndex = blob[fDefIndex + 2];
+                 const devDef = developerFields[devDataIndex][fieldNum];
+-                const baseType = devDef.fit_base_type_id;
++                const declaredBaseType = devDef.fit_base_type_id;
++                const baseType = FIT.types.fit_base_type[declaredBaseType] === undefined
++                    ? declaredBaseType | 128
++                    : declaredBaseType;
+                 const fDef = {
+                     type: FIT.types.fit_base_type[baseType],
+                     fDefNo: fieldNum,
+@@ -333,6 +336,7 @@ export function readRecord(blob, messageTypes, developerFields, startIndex, opti
+                     littleEndian: lEnd,
+                     baseTypeNo: baseType,
+                     name: devDef.field_name,
++                    units: devDef.units == null ? null : devDef.units,
+                     dataType: getFitMessageBaseType(baseType & 15),
+                     scale: devDef.scale || 1,
+                     offset: devDef.offset || 0,
+@@ -362,6 +366,22 @@ export function readRecord(blob, messageTypes, developerFields, startIndex, opti
+     let messageSize = 0;
+     let readDataFromIndex = startIndex + 1;
+     const fields = {};
++    const developerFieldOccurrences = [];
++    let developerFieldOccurrenceIndex = 0;
++    const stageDeveloperField = (fDef) => {
++        developerFieldOccurrences.push({
++            nativeMessageType: messageType.globalMessageNumber,
++            developer_data_index: fDef.developerDataIndex,
++            field_definition_number: fDef.fDefNo,
++            field_name: fDef.name,
++            units: fDef.units == null ? null : fDef.units,
++        });
++    };
++    const emitDeveloperField = (value) => {
++        const identity = developerFieldOccurrences[developerFieldOccurrenceIndex++];
++        fields.developer_fields = fields.developer_fields || [];
++        fields.developer_fields.push({ ...identity, value });
++    };
+     const message = getFitMessage(messageType.globalMessageNumber);
+     const rawFields = [];
+     for (let i = 0; i < messageType.fieldDefs.length; i++) {
+@@ -376,6 +396,9 @@ export function readRecord(blob, messageTypes, developerFields, startIndex, opti
+     for (const { fDef, data } of rawFields) {
+         const { field } = fDef.isDeveloperField ? { field: fDef.name } : message.getAttributes(fDef.fDefNo);
+         if (field !== 'unknown' && field !== '' && field !== undefined) {
++            if (fDef.isDeveloperField) {
++                stageDeveloperField(fDef);
++            }
+             fields[field] = data;
+         }
+     }
+@@ -385,7 +408,9 @@ export function readRecord(blob, messageTypes, developerFields, startIndex, opti
+             const { type } = fDef;
+             const scale = (_a = fDef.scale) !== null && _a !== void 0 ? _a : null;
+             const offset = (_b = fDef.offset) !== null && _b !== void 0 ? _b : 0;
+-            fields[fDef.name] = applyOptions(formatByType(data, type, scale, offset), field, options, fields);
++            const decodedValue = applyOptions(formatByType(data, type, scale, offset), field, options, fields);
++            emitDeveloperField(decodedValue);
++            fields[fDef.name] = decodedValue;
+         }
+         else {
+             const { field, type, scale, offset } = message.getAttributes(fDef.fDefNo);
+diff --git a/dist/cjs/binary.js b/dist/cjs/binary.js
+index 60206c115ad85959a02ca13a1eb50e839c384475..874e4daaf576788a62c92bc2814c9ab00eb22a7b 100644
+--- a/dist/cjs/binary.js
++++ b/dist/cjs/binary.js
+@@ -330,7 +330,10 @@ function readRecord(blob, messageTypes, developerFields, startIndex, options, st
+                 const size = blob[fDefIndex + 1];
+                 const devDataIndex = blob[fDefIndex + 2];
+                 const devDef = developerFields[devDataIndex][fieldNum];
+-                const baseType = devDef.fit_base_type_id;
++                const declaredBaseType = devDef.fit_base_type_id;
++                const baseType = fit_js_1.FIT.types.fit_base_type[declaredBaseType] === undefined
++                    ? declaredBaseType | 128
++                    : declaredBaseType;
+                 const fDef = {
+                     type: fit_js_1.FIT.types.fit_base_type[baseType],
+                     fDefNo: fieldNum,
+@@ -339,6 +342,7 @@ function readRecord(blob, messageTypes, developerFields, startIndex, options, st
+                     littleEndian: lEnd,
+                     baseTypeNo: baseType,
+                     name: devDef.field_name,
++                    units: devDef.units == null ? null : devDef.units,
+                     dataType: (0, messages_js_1.getFitMessageBaseType)(baseType & 15),
+                     scale: devDef.scale || 1,
+                     offset: devDef.offset || 0,
+@@ -368,6 +372,22 @@ function readRecord(blob, messageTypes, developerFields, startIndex, options, st
+     let messageSize = 0;
+     let readDataFromIndex = startIndex + 1;
+     const fields = {};
++    const developerFieldOccurrences = [];
++    let developerFieldOccurrenceIndex = 0;
++    const stageDeveloperField = (fDef) => {
++        developerFieldOccurrences.push({
++            nativeMessageType: messageType.globalMessageNumber,
++            developer_data_index: fDef.developerDataIndex,
++            field_definition_number: fDef.fDefNo,
++            field_name: fDef.name,
++            units: fDef.units == null ? null : fDef.units,
++        });
++    };
++    const emitDeveloperField = (value) => {
++        const identity = developerFieldOccurrences[developerFieldOccurrenceIndex++];
++        fields.developer_fields = fields.developer_fields || [];
++        fields.developer_fields.push({ ...identity, value });
++    };
+     const message = (0, messages_js_1.getFitMessage)(messageType.globalMessageNumber);
+     const rawFields = [];
+     for (let i = 0; i < messageType.fieldDefs.length; i++) {
+@@ -382,6 +402,9 @@ function readRecord(blob, messageTypes, developerFields, startIndex, options, st
+     for (const { fDef, data } of rawFields) {
+         const { field } = fDef.isDeveloperField ? { field: fDef.name } : message.getAttributes(fDef.fDefNo);
+         if (field !== 'unknown' && field !== '' && field !== undefined) {
++            if (fDef.isDeveloperField) {
++                stageDeveloperField(fDef);
++            }
+             fields[field] = data;
+         }
+     }
+@@ -391,7 +414,9 @@ function readRecord(blob, messageTypes, developerFields, startIndex, options, st
+             const { type } = fDef;
+             const scale = (_a = fDef.scale) !== null && _a !== void 0 ? _a : null;
+             const offset = (_b = fDef.offset) !== null && _b !== void 0 ? _b : 0;
+-            fields[fDef.name] = applyOptions(formatByType(data, type, scale, offset), field, options, fields);
++            const decodedValue = applyOptions(formatByType(data, type, scale, offset), field, options, fields);
++            emitDeveloperField(decodedValue);
++            fields[fDef.name] = decodedValue;
+         }
+         else {
+             const { field, type, scale, offset } = message.getAttributes(fDef.fDefNo);
+diff --git a/dist/cjs/fit-parser.js b/dist/cjs/fit-parser.js
+index 848331ed6fdf408ccb9d34c3e329c72e0a33bac4..57960ff6210488cc26b4b0bf5eace8b899477181 100644
+--- a/dist/cjs/fit-parser.js
++++ b/dist/cjs/fit-parser.js
+@@ -56,9 +56,8 @@ class FitParser {
+             const crcHeader = blob[12] + (blob[13] << 8);
+             const crcHeaderCalc = (0, binary_js_1.calculateCRC)(blob, 0, 12);
+             if (crcHeader !== crcHeaderCalc) {
+-                // callback('Header CRC mismatch', {});
+-                // TODO: fix Header CRC check
+                 if (!this.options.force) {
++                    callback('Header CRC mismatch', undefined);
+                     return;
+                 }
+             }
+@@ -70,9 +69,8 @@ class FitParser {
+         const crcFile = blob[crcStart] + (blob[crcStart + 1] << 8);
+         const crcFileCalc = (0, binary_js_1.calculateCRC)(blob, headerLength === 12 ? 0 : headerLength, crcStart);
+         if (crcFile !== crcFileCalc) {
+-            // callback('File CRC mismatch', {});
+-            // TODO: fix File CRC check
+             if (!this.options.force) {
++                callback('File CRC mismatch', undefined);
+                 return;
+             }
+         }
+diff --git a/dist/fit-parser.js b/dist/fit-parser.js
+index 373cc5dc6ac553f834202c3d62a3c5254c9e5201..49199e76f8571e0052f44b12ea173e99a1b2ce65 100644
+--- a/dist/fit-parser.js
++++ b/dist/fit-parser.js
+@@ -54,9 +54,8 @@ export default class FitParser {
+             const crcHeader = blob[12] + (blob[13] << 8);
+             const crcHeaderCalc = calculateCRC(blob, 0, 12);
+             if (crcHeader !== crcHeaderCalc) {
+-                // callback('Header CRC mismatch', {});
+-                // TODO: fix Header CRC check
+                 if (!this.options.force) {
++                    callback('Header CRC mismatch', undefined);
+                     return;
+                 }
+             }
+@@ -68,9 +67,8 @@ export default class FitParser {
+         const crcFile = blob[crcStart] + (blob[crcStart + 1] << 8);
+         const crcFileCalc = calculateCRC(blob, headerLength === 12 ? 0 : headerLength, crcStart);
+         if (crcFile !== crcFileCalc) {
+-            // callback('File CRC mismatch', {});
+-            // TODO: fix File CRC check
+             if (!this.options.force) {
++                callback('File CRC mismatch', undefined);
+                 return;
+             }
+         }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  fit-file-parser@3.0.2:
+    hash: 355579765a4bbdcd08b22da684d697bdac747c0e1603fb410ecb822574876a9a
+    path: patches/fit-file-parser@3.0.2.patch
+
 importers:
 
   .:
@@ -221,6 +226,10 @@ importers:
         version: 6.0.3
 
   packages/kernel:
+    dependencies:
+      fflate:
+        specifier: 0.8.3
+        version: 0.8.3
     devDependencies:
       tsup:
         specifier: ^8.4.0
@@ -237,6 +246,9 @@ importers:
       '@enduragent/kernel':
         specifier: workspace:*
         version: link:../kernel
+      fit-file-parser:
+        specifier: 3.0.2
+        version: 3.0.2(patch_hash=355579765a4bbdcd08b22da684d697bdac747c0e1603fb410ecb822574876a9a)
       zod:
         specifier: ^4.3.6
         version: 4.4.1
@@ -1380,6 +1392,9 @@ packages:
   ast-v8-to-istanbul@1.0.4:
     resolution: {integrity: sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
@@ -1387,6 +1402,9 @@ packages:
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
+
+  buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
   bundle-require@5.1.0:
     resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
@@ -1538,6 +1556,9 @@ packages:
       picomatch:
         optional: true
 
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
+
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
@@ -1545,6 +1566,9 @@ packages:
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
+
+  fit-file-parser@3.0.2:
+    resolution: {integrity: sha512-Yg7XfByuKh8CypgHqNcZSLyV9aWo14pkZ1oWR8VfdHBhuJN856PvlfYAkLSTD58USE5S+iSYE9f9diil043Xag==}
 
   fix-dts-default-cjs-exports@1.0.1:
     resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
@@ -1605,6 +1629,9 @@ packages:
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -3183,6 +3210,8 @@ snapshots:
       estree-walker: 3.0.3
       js-tokens: 10.0.0
 
+  base64-js@1.5.1: {}
+
   better-path-resolve@1.0.0:
     dependencies:
       is-windows: 1.0.2
@@ -3190,6 +3219,11 @@ snapshots:
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
+
+  buffer@6.0.3:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
 
   bundle-require@5.1.0(esbuild@0.27.7):
     dependencies:
@@ -3332,6 +3366,8 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
+  fflate@0.8.3: {}
+
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
@@ -3340,6 +3376,10 @@ snapshots:
     dependencies:
       locate-path: 5.0.0
       path-exists: 4.0.0
+
+  fit-file-parser@3.0.2(patch_hash=355579765a4bbdcd08b22da684d697bdac747c0e1603fb410ecb822574876a9a):
+    dependencies:
+      buffer: 6.0.3
 
   fix-dts-default-cjs-exports@1.0.1:
     dependencies:
@@ -3409,6 +3449,8 @@ snapshots:
   iconv-lite@0.7.2:
     dependencies:
       safer-buffer: 2.1.2
+
+  ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
 


### PR DESCRIPTION
Node-host FIT decoding feeds parser-neutral mapping in the pure kernel.

Aligned stream blobs and chained keys rebuild deterministically from immutable archives.

Bare file re-ingest is raw-row-idempotent and byte-identical; no source ledger row is fabricated.

Ships to users: nothing. Rollback: remove the unused ingest surface and exact dependencies; no migration or schema rollback is involved.

Verification:
- pnpm check
- pnpm test: 236 files passed, 3436 tests passed, 3 skipped
- focused ingest suite: 8 files and 43 tests passed
- deterministic replay, self-test, and all registered parity checks passed
- independent local decode comparisons passed for both private device classes and all eight committed synthetic FIT fixtures
- fixture privacy and the exact 32-path allowlist passed