### PR TITLE
fix(kernel-node): preserve Node builtin imports

### DIFF
--- a/packages/kernel-node/tests/public-dist-import.test.ts
+++ b/packages/kernel-node/tests/public-dist-import.test.ts
@@ -1,0 +1,11 @@
+import { access } from "node:fs/promises";
+import { expect, it } from "vitest";
+
+it("imports the built SQLite public entry", async () => {
+  const entry = new URL("../dist/sqlite.js", import.meta.url);
+  await access(entry);
+
+  const publicApi = await import(entry.href);
+
+  expect(publicApi.openSqliteStorage).toBeTypeOf("function");
+});

--- a/packages/kernel-node/tsup.config.ts
+++ b/packages/kernel-node/tsup.config.ts
@@ -7,4 +7,5 @@ export default defineConfig({
   sourcemap: true,
   clean: true,
   splitting: false,
+  removeNodeProtocol: false,
 });


### PR DESCRIPTION
## Summary

- preserve Node builtin specifiers in the built Node adapter
- add a regression test that imports the built SQLite public entry

## Why

The bundler's default protocol rewrite changed the built SQLite import into an unresolvable bare package specifier. Opting out keeps the runtime import bound to the Node 24 builtin.

## Verification

- `pnpm check`
- `pnpm test` (3,629 passed; 5 skipped)
- focused built-entry and SQLite adapter tests (8 passed)