### PR TITLE
fix(kernel): accept real FIT ownership shapes

### DIFF
--- a/packages/kernel-node/src/ingest/fit-decoder.ts
+++ b/packages/kernel-node/src/ingest/fit-decoder.ts
@@ -115,8 +115,10 @@ function leftRightBalance(message: PatchedParserMessage): number | null {
   if (value === undefined || value === null) return null;
   if (typeof value !== "object" || Array.isArray(value)) throw new FitSourceError("invalid_numeric");
   const keys = Object.keys(value).sort();
-  if (keys.join(",") !== "right,value") throw new FitSourceError("invalid_numeric");
+  const shape = keys.join(",");
+  if (shape !== "right,value" && shape !== "0,right,value") throw new FitSourceError("invalid_numeric");
   const record = value as Record<string, unknown>;
+  if (shape === "0,right,value" && record["0"] !== false) throw new FitSourceError("invalid_numeric");
   if (typeof record.right !== "boolean" || typeof record.value !== "number" || !Number.isFinite(record.value) || !Number.isInteger(record.value) || record.value < 0 || record.value > 127) {
     throw new FitSourceError("invalid_numeric");
   }

--- a/packages/kernel-node/src/ingest/import-files.ts
+++ b/packages/kernel-node/src/ingest/import-files.ts
@@ -4,6 +4,7 @@ import { mkdir, open, readFile, readdir, rename, stat, unlink } from "node:fs/pr
 import { createArchiveManager } from "../archive/manager.js";
 import {
   FitSourceError,
+  FIT_INGEST_VERSION,
   QUALITY_RANK,
   canonicalPick,
   createMaterializeClusterInTransaction,
@@ -210,6 +211,6 @@ export async function importFilesWithReport(options: ImportFilesOptions): Promis
     prepareFile: (artifact) => artifact.ext === "fit" ? prepareFit(artifact, crypto) : prepareXmlFile(artifact.bytes, artifact.ext, { crypto }),
     canonicalPick,
     materializeClusterInTransaction: createMaterializeClusterInTransaction(hashKey),
-    ingestVersion: 2,
+    ingestVersion: FIT_INGEST_VERSION,
   });
 }

--- a/packages/kernel-node/tests/coach-dev-import.test.ts
+++ b/packages/kernel-node/tests/coach-dev-import.test.ts
@@ -81,7 +81,7 @@ const pair = {
 
 const fullReportFixture: ImportReport = {
   schema_version: 1,
-  ingest_version: 2,
+  ingest_version: 3,
   effective: {
     tier3: {
       startSeconds: 120,

--- a/packages/kernel-node/tests/fit-decoder.test.ts
+++ b/packages/kernel-node/tests/fit-decoder.test.ts
@@ -30,10 +30,11 @@ describe("patched FIT decoder",()=>{
     expect(decoded.records[0].developerFields).toEqual([{...envelope,field_name:null,units:null},{...envelope,field_name:null,units:null},{...envelope,value:{a:2},field_name:null,units:null}]);
     await expect(decodeRoot({records:[{developer_fields:[{...envelope,value:undefined}]}]})).rejects.toMatchObject({code:"decode_failed"});
   });
-  it("extracts only the exact left-right mask object and distinguishes enhanced absence",async()=>{
+  it("extracts supported left-right mask objects and distinguishes enhanced absence",async()=>{
     const decoded=await decodeRoot({records:[{left_right_balance:{value:64,right:true},altitude:10,speed:4}]});
     expect(decoded.records[0]).toMatchObject({leftRightBalance:64,enhancedAltitude:null,altitude:10,enhancedSpeed:null,speed:4});
-    for(const bad of [64,{value:64},{value:64,right:1},{value:-1,right:false},{value:128,right:false},{value:1.5,right:false},{value:64,right:false,extra:0}]) {
+    expect((await decodeRoot({records:[{left_right_balance:{0:false,value:63,right:false}}]})).records[0].leftRightBalance).toBe(63);
+    for(const bad of [64,{value:64},{value:64,right:1},{value:-1,right:false},{value:128,right:false},{value:1.5,right:false},{0:0,value:64,right:false},{0:false,value:64,right:false,extra:0}]) {
       await expect(decodeRoot({records:[{left_right_balance:bad}]})).rejects.toMatchObject({code:"invalid_numeric"});
     }
     for(const key of ["enhanced_altitude","enhanced_speed"]) {

--- a/packages/kernel-node/tests/fit-import.test.ts
+++ b/packages/kernel-node/tests/fit-import.test.ts
@@ -28,7 +28,7 @@ describe("global file import runner", () => {
     expect(result.files[0]).toMatchObject({ outcome: "imported", raw_file_inserted: true });
     expect(result.inserts).toEqual({ raw_file: 1, source_record: 0 });
     expect((await store.get("SELECT count(*) c FROM source_record"))?.c).toBe(0);
-    expect((await store.get("SELECT ingest_version FROM ingest_metadata"))?.ingest_version).toBe(2);
+    expect((await store.get("SELECT ingest_version FROM ingest_metadata"))?.ingest_version).toBe(3);
   });
   it("sorts planning deterministically while retaining exact input paths", async () => {
     const inputPaths = [fixture("brick-running.fit"), fixture("brick-cycling.fit")];
@@ -63,7 +63,7 @@ describe("global file import runner", () => {
     await expect(importFilesWithReport({ inputPaths: [txt], archiveDir, store })).rejects.toThrow("unsupported input extension");
   });
   it("refuses a newer stored version before archive side effects", async () => {
-    await store.run("UPDATE ingest_metadata SET ingest_version=3");
+    await store.run("UPDATE ingest_metadata SET ingest_version=4");
     await expect(importFilesWithReport({ inputPaths: [fixture("brick-cycling.fit")], archiveDir, store })).rejects.toThrow("newer ingest semantics");
     expect(existsSync(archiveDir)).toBe(false);
   });

--- a/packages/kernel-node/tests/inv2-ingest-order.test.ts
+++ b/packages/kernel-node/tests/inv2-ingest-order.test.ts
@@ -153,7 +153,7 @@ describe("real SQLite dedup ordering", () => {
         prepareFile: async (_artifact: ImportArtifact) => { throw new Error("unused"); },
         canonicalPick(group: Parameters<typeof canonicalPick>[0]) {
           origins.push(...group.candidates.map((candidate) => candidate.origin)); return canonicalPick(group);
-        }, materializeClusterInTransaction: createMaterializeClusterInTransaction(hashKey), ingestVersion: 2 as const };
+        }, materializeClusterInTransaction: createMaterializeClusterInTransaction(hashKey), ingestVersion: 3 as const };
       const first = await importArtifactsWithReport({ files: [], platform_records: [platform] }, deps);
       expect(first.inserts.source_record).toBe(1); expect(first.updates.relinked_source_records).toBe(1);
       expect(sourceInsertAttachments[0]).toEqual([null, null]);
@@ -165,15 +165,15 @@ describe("real SQLite dedup ordering", () => {
       expect(origins).toContainEqual(expect.objectContaining({ kind: "platform", persistedQualityRank: 300 }));
     } finally { await value.store.close(); }
   });
-  it("[PR05-SQL-007] proves zero and one upgrades, current two, and early refusal of three", async () => {
+  it("[PR05-SQL-007] proves zero through two upgrade, current three, and early refusal of four", async () => {
     const value = await fresh();
     try {
       const options = { inputPaths: [path("brick-cycling.fit")], archiveDir: value.archiveDir, store: value.store };
-      for (const version of [0, 1, 2]) {
+      for (const version of [0, 1, 2, 3]) {
         await value.store.run("UPDATE ingest_metadata SET ingest_version=?", [version]);
-        expect((await importFilesWithReport(options)).ingest_version).toBe(2);
+        expect((await importFilesWithReport(options)).ingest_version).toBe(3);
       }
-      await value.store.run("UPDATE ingest_metadata SET ingest_version=3");
+      await value.store.run("UPDATE ingest_metadata SET ingest_version=4");
       const count = (await value.store.get("SELECT count(*) c FROM raw_file"))?.c;
       await expect(importFilesWithReport(options)).rejects.toThrow("newer ingest semantics");
       expect((await value.store.get("SELECT count(*) c FROM raw_file"))?.c).toBe(count);

--- a/packages/kernel-node/tests/inv2-ingest-twice.test.ts
+++ b/packages/kernel-node/tests/inv2-ingest-twice.test.ts
@@ -11,7 +11,7 @@ let dir: string | undefined;
 afterEach(() => { if (dir) rmSync(dir, { recursive: true, force: true }); dir = undefined; });
 
 describe("INV-2 ingest twice", () => {
-  it("keeps stream and repair rows identical with zero second-run inserts and metadata two", async () => {
+  it("keeps stream and repair rows identical with zero second-run inserts and metadata three", async () => {
     expect(DERIVED_TABLES.join(",")).toBe("metric_snapshot,mean_max_cache,repair_log,stream,swim_length,lap,session,workout");
     dir = mkdtempSync(join(tmpdir(), "fit-inv2-"));
     const store = openSqliteStorage(join(dir, "store.db"));
@@ -27,7 +27,7 @@ describe("INV-2 ingest twice", () => {
       expect(await store.all("SELECT * FROM stream ORDER BY stream_key")).toEqual(streams1);
       expect(await store.all("SELECT * FROM repair_log ORDER BY repair_key")).toEqual(logs1);
       expect(await dumpStore(store)).toBe(dump1);
-      expect(await store.get("SELECT singleton,ingest_version FROM ingest_metadata")).toEqual({ singleton: 1, ingest_version: 2 });
+      expect(await store.get("SELECT singleton,ingest_version FROM ingest_metadata")).toEqual({ singleton: 1, ingest_version: 3 });
       expect(logs1.length).toBeGreaterThan(0); expect(streams1.length).toBeGreaterThan(0);
     } finally { await store.close(); }
   });

--- a/packages/kernel-node/tests/inv2-overlay-recompute.test.ts
+++ b/packages/kernel-node/tests/inv2-overlay-recompute.test.ts
@@ -22,24 +22,24 @@ describe("global version and overlay recompute", () => {
     return () => count;
   }
 
-  it("upgrades stored versions zero and one to two through the global planner", async () => {
-    for (const version of [0, 1]) {
+  it("upgrades stored versions zero through two to three through the global planner", async () => {
+    for (const version of [0, 1, 2]) {
       await store.run("UPDATE ingest_metadata SET ingest_version=?", [version]);
       const result = await importFilesWithReport({ inputPaths: [path("brick-cycling.fit")], archiveDir, store });
-      expect(result.ingest_version).toBe(2);
-      expect((await store.get("SELECT ingest_version FROM ingest_metadata"))?.ingest_version).toBe(2);
+      expect(result.ingest_version).toBe(3);
+      expect((await store.get("SELECT ingest_version FROM ingest_metadata"))?.ingest_version).toBe(3);
     }
   });
-  it("keeps current version two while still globally replanning a nonempty batch", async () => {
+  it("keeps current version three while still globally replanning a nonempty batch", async () => {
     await importFilesWithReport({ inputPaths: [path("brick-cycling.fit")], archiveDir, store });
     const transactions = countTransactions();
     const result = await importFilesWithReport({ inputPaths: [path("brick-cycling.fit")], archiveDir, store });
-    expect(result.ingest_version).toBe(2);
+    expect(result.ingest_version).toBe(3);
     expect(transactions()).toBe(1);
-    expect((await store.get("SELECT ingest_version FROM ingest_metadata"))?.ingest_version).toBe(2);
+    expect((await store.get("SELECT ingest_version FROM ingest_metadata"))?.ingest_version).toBe(3);
   });
-  it("refuses version three before archive and SQL side effects", async () => {
-    await store.run("UPDATE ingest_metadata SET ingest_version=3");
+  it("refuses version four before archive and SQL side effects", async () => {
+    await store.run("UPDATE ingest_metadata SET ingest_version=4");
     await expect(importFilesWithReport({ inputPaths: [path("brick-cycling.fit")], archiveDir, store })).rejects.toThrow("newer ingest semantics");
     expect(existsSync(archiveDir)).toBe(false); expect((await store.get("SELECT count(*) c FROM raw_file"))?.c).toBe(0);
   });

--- a/packages/kernel/src/ingest/canonical-pick.ts
+++ b/packages/kernel/src/ingest/canonical-pick.ts
@@ -299,7 +299,7 @@ function validChannelName(name: string): boolean {
   return embedded === undefined || (Number.isSafeInteger(Number(embedded)) && Number(embedded) === developerIndex && app === `idx-${embedded}`);
 }
 
-function validateChannel(value: unknown, name: string, candidateId: string): XmlChannel {
+function validateChannel(value: unknown, name: string, candidateId: string, allowInterpolatedSamples: boolean): XmlChannel {
   const channel = record(value, ["timestamps", "values"], "canonical.concern_invalid", candidateId);
   const timestamps = denseArray(channel.timestamps, "canonical.concern_invalid", candidateId);
   const values = denseArray(channel.values, "canonical.concern_invalid", candidateId);
@@ -315,14 +315,14 @@ function validateChannel(value: unknown, name: string, candidateId: string): Xml
     if (name === "lat" && entry !== null && ((entry as number) < -90 || (entry as number) > 90)) fail("canonical.concern_invalid", candidateId, `stream:${name}`);
     if (name === "lng" && entry !== null && ((entry as number) < -180 || (entry as number) > 180)) fail("canonical.concern_invalid", candidateId, `stream:${name}`);
     if (["distance", "speed", "power"].includes(name) && entry !== null && (entry as number) < 0) fail("canonical.concern_invalid", candidateId, `stream:${name}`);
-    if (name === "heart_rate" && entry !== null && (!Number.isInteger(entry) || (entry as number) < 1 || (entry as number) > 255)) fail("canonical.concern_invalid", candidateId, `stream:${name}`);
-    if (name === "cadence" && entry !== null && (!Number.isInteger(entry) || (entry as number) < 0 || (entry as number) > 255)) fail("canonical.concern_invalid", candidateId, `stream:${name}`);
+    if (name === "heart_rate" && entry !== null && ((!allowInterpolatedSamples && !Number.isInteger(entry)) || (entry as number) < 1 || (entry as number) > 255)) fail("canonical.concern_invalid", candidateId, `stream:${name}`);
+    if (name === "cadence" && entry !== null && ((!allowInterpolatedSamples && !Number.isInteger(entry)) || (entry as number) < 0 || (entry as number) > 255)) fail("canonical.concern_invalid", candidateId, `stream:${name}`);
   }
   if (!hasValue) fail("canonical.concern_invalid", candidateId, `stream:${name}`);
   return value as XmlChannel;
 }
 
-function validateConcerns(value: unknown, candidateId: string): Readonly<Record<string, ConcernValue>> {
+function validateConcerns(value: unknown, candidateId: string, allowInterpolatedSamples: boolean): Readonly<Record<string, ConcernValue>> {
   const concerns = record(value, null, "canonical.concern_invalid", candidateId);
   let lapSeqs = new Set<number>();
   if (Object.hasOwn(concerns, "lap[]")) {
@@ -338,7 +338,7 @@ function validateConcerns(value: unknown, candidateId: string): Readonly<Record<
     if (key.startsWith("stream:")) {
       const name = key.slice(7);
       if (!validChannelName(name)) fail("canonical.concern_invalid", candidateId, key);
-      validateChannel(entry, name, candidateId);
+      validateChannel(entry, name, candidateId, allowInterpolatedSamples);
       continue;
     }
     if (!SCALAR_KEYS.has(key)) fail("canonical.concern_invalid", candidateId, key);
@@ -384,7 +384,7 @@ function validateCandidate(value: unknown): Candidate {
   let rank: QualityRank;
   try { rank = assertQualityRank(candidate.rank as number); } catch { fail("canonical.rank_invalid", id); }
   if (rank! !== expectedRank) fail("canonical.rank_invalid", id);
-  validateConcerns(candidate.concerns, id);
+  validateConcerns(candidate.concerns, id, origin.kind === "file" && origin.format === "fit");
   return value as Candidate;
 }
 

--- a/packages/kernel/src/ingest/dedup-rekey.ts
+++ b/packages/kernel/src/ingest/dedup-rekey.ts
@@ -10,6 +10,7 @@ import { DEFAULT_TIER3_THRESHOLDS, planDedup, type DedupCandidateSummary } from 
 import { encodeStream } from "./stream-codec.js";
 import { rescalePoolDistances } from "./pool-size-rescale.js";
 import { buildPlatformPresentation, replayPlatformPresentation, type PlatformPresentation } from "./source-ledger.js";
+import { FIT_INGEST_VERSION } from "./types.js";
 import type {
   ClusterReport,
   FileReport,
@@ -133,12 +134,11 @@ async function orphanReports(store: SqlStore, members: ReadonlySet<string>): Pro
 
 export async function importArtifactsWithReport(batch: ImportBatch, deps: ImportReportDeps): Promise<ImportReport> {
   if (batch.files.length + batch.platform_records.length === 0) throw new TypeError("import batch is empty");
-  if (deps.ingestVersion !== 2) throw new Error("ingest dependency version mismatch");
+  if (deps.ingestVersion !== FIT_INGEST_VERSION) throw new Error("ingest dependency version mismatch");
   const metadata = await deps.store.all("SELECT ingest_version FROM ingest_metadata WHERE singleton=1");
   if (metadata.length !== 1) throw new Error("ingest metadata invariant mismatch");
   const storedVersion = integer(metadata[0]!.ingest_version, "ingest version");
   if (storedVersion > deps.ingestVersion) throw new Error("store uses newer ingest semantics");
-  if (storedVersion !== 0 && storedVersion !== 1 && storedVersion !== 2) throw new Error("unsupported ingest version");
   const inputPaths = new Set<string>();
   for (const file of batch.files) {
     if (typeof file.input_path !== "string" || file.input_path.length === 0 || inputPaths.has(file.input_path)) throw new TypeError("duplicate or invalid input path");
@@ -325,7 +325,7 @@ ORDER BY id COLLATE BINARY ASC`)).map(sourceRow);
       && insertedRaw.get(address) === true })).sort((a, b) => compareText(a.address, b.address) || compareText(a.input_path, b.input_path));
   return {
     schema_version: 1,
-    ingest_version: 2,
+    ingest_version: deps.ingestVersion,
     effective: { tier3: DEFAULT_TIER3_THRESHOLDS, transition_window_s: DEFAULT_TRANSITION_WINDOW_S },
     files: reports,
     inserts: { raw_file: [...insertedRaw.values()].filter(Boolean).length, source_record: [...insertedSource.values()].filter(Boolean).length },

--- a/packages/kernel/src/ingest/fit-row-mapper.ts
+++ b/packages/kernel/src/ingest/fit-row-mapper.ts
@@ -258,13 +258,20 @@ export async function mapFitArtifact(input: MapFitArtifactInput): Promise<Mapped
   for (const s of d.sessions) if (s.startTime === null) throw new FitSourceError("missing_session_start");
   for (const s of d.sessions) if (s.timestamp === null) throw new FitSourceError("missing_session_end");
   for (let i=0;i<d.sessions.length;i++) if (d.sessions[i].sport === null || sports[i] === "") throw new FitSourceError("missing_session_sport");
+  const singleSessionShape=d.sessions.length===1&&(d.activity?.numSessions===null||d.activity?.numSessions===undefined||d.activity.numSessions===1);
+  // FIT timestamps are whole seconds while elapsed time may retain a fractional terminal second.
+  const sessionEnds=d.sessions.map((s)=>singleSessionShape&&s.timestamp===s.startTime&&s.totalElapsedTime!==null&&s.totalElapsedTime>0
+    ? (s.startTime as number)+Math.ceil(s.totalElapsedTime)
+    : s.timestamp as number);
   for (let i=0;i<d.sessions.length;i++) {
     const s=d.sessions[i];
-    if ((s.startTime as number) > (s.timestamp as number)) throw new FitSourceError("invalid_session_range");
-    if (i+1<d.sessions.length && (s.timestamp as number) > (d.sessions[i+1].startTime as number)) throw new FitSourceError("invalid_session_range");
+    if ((s.startTime as number) > sessionEnds[i]) throw new FitSourceError("invalid_session_range");
+    if (i+1<d.sessions.length && sessionEnds[i] > (d.sessions[i+1].startTime as number)) throw new FitSourceError("invalid_session_range");
   }
 
-  const sessionLapSlices = d.sessions.map((s) => validateSlice(s.firstLapIndex,s.numLaps,d.laps.length,"lap_slice_invalid"));
+  const sessionLapSlices = d.sessions.map((s) => singleSessionShape&&d.laps.length>0&&s.firstLapIndex===null&&(s.numLaps===null||s.numLaps===d.laps.length)
+    ? [0,d.laps.length] as const
+    : validateSlice(s.firstLapIndex,s.numLaps,d.laps.length,"lap_slice_invalid"));
   const lapOwners = Array<number>(d.laps.length).fill(0);
   for (const [start,end] of sessionLapSlices) for(let i=start;i<end;i++) lapOwners[i]++;
   if (lapOwners.some((n)=>n!==1)) throw new FitSourceError("lap_slice_invalid");
@@ -289,7 +296,7 @@ export async function mapFitArtifact(input: MapFitArtifactInput): Promise<Mapped
 
   if (d.records.some((r)=>r.timestamp===null)) throw new FitSourceError("record_time_missing");
   const recordOwners=d.records.map((r)=>d.sessions.map((s,i)=>{
-    const t=r.timestamp as number, start=s.startTime as number, end=s.timestamp as number;
+    const t=r.timestamp as number, start=s.startTime as number, end=sessionEnds[i];
     return t>=start && (i===d.sessions.length-1 ? t<=end : t<end);
   }).filter(Boolean).length);
   if(recordOwners.some((n)=>n===0)) throw new FitSourceError("record_unassigned");
@@ -297,7 +304,7 @@ export async function mapFitArtifact(input: MapFitArtifactInput): Promise<Mapped
   const assigned=d.sessions.map(()=>[] as number[]);
   for(let r=0;r<d.records.length;r++) {
     const t=d.records[r].timestamp as number;
-    const owner=d.sessions.findIndex((s,i)=>t>=(s.startTime as number)&&(i===d.sessions.length-1?t<=(s.timestamp as number):t<(s.timestamp as number)));
+    const owner=d.sessions.findIndex((s,i)=>t>=(s.startTime as number)&&(i===d.sessions.length-1?t<=sessionEnds[i]:t<sessionEnds[i]));
     assigned[owner].push(r);
   }
   for(const indexes of assigned) for(let i=1;i<indexes.length;i++) if((d.records[indexes[i]].timestamp as number)<=(d.records[indexes[i-1]].timestamp as number)) throw new FitSourceError("record_time_nonmonotonic");

--- a/packages/kernel/src/ingest/import-report.ts
+++ b/packages/kernel/src/ingest/import-report.ts
@@ -96,7 +96,7 @@ export interface OrphanReport {
 
 export interface ImportReport {
   readonly schema_version: 1;
-  readonly ingest_version: 2;
+  readonly ingest_version: typeof FIT_INGEST_VERSION;
   readonly effective: {
     readonly tier3: {
       readonly startSeconds: 120;

--- a/packages/kernel/src/ingest/types.ts
+++ b/packages/kernel/src/ingest/types.ts
@@ -1,7 +1,7 @@
 import type { ActivityRows } from "../store/activity-repository.js";
 import type { RawFileRow } from "../store/ports.js";
 
-export const FIT_INGEST_VERSION = 2 as const;
+export const FIT_INGEST_VERSION = 3 as const;
 
 export type FitSourceErrorCode =
   | "decode_failed"

--- a/packages/kernel/tests/dedup-inv2.test.ts
+++ b/packages/kernel/tests/dedup-inv2.test.ts
@@ -122,7 +122,7 @@ function deps(store: MemoryStore, rawArchive: ReturnType<typeof archive>, materi
   const groups: Candidate[][] = [];
   return { groups, value: { archive: rawArchive, store, hashKey, prepareFile: async (artifact: ImportArtifact) => prepared(artifact),
     canonicalPick(group: Parameters<typeof canonicalPick>[0]) { groups.push([...group.candidates]); return canonicalPick(group); },
-    materializeClusterInTransaction: async () => { store.events.push("materialize"); await materialize(); }, ingestVersion: 2 as const } };
+    materializeClusterInTransaction: async () => { store.events.push("materialize"); await materialize(); }, ingestVersion: 3 as const } };
 }
 
 describe("global replan invariant", () => {
@@ -257,6 +257,6 @@ describe("global replan invariant", () => {
   it("[PR05-INV2-008] upgrades old metadata and reports the current code version", async () => {
     const store = new MemoryStore(); store.metadata = 0; const a = archive(), d = deps(store, a);
     const value = await importArtifactsWithReport({ files: [{ input_path: "a.fit", bytes: new Uint8Array([1]), ext: "fit" }], platform_records: [] }, d.value);
-    expect(value.ingest_version).toBe(2); expect(store.metadata).toBe(2);
+    expect(value.ingest_version).toBe(3); expect(store.metadata).toBe(3);
   });
 });

--- a/packages/kernel/tests/fit-row-mapper.test.ts
+++ b/packages/kernel/tests/fit-row-mapper.test.ts
@@ -46,6 +46,14 @@ describe("FIT row mapper",()=>{
     const timeRows=out.activity.streams.filter((s)=>s.channel==="time").sort((a,b)=>out.activity.sessions.findIndex((x)=>x.session_key===a.session_key)-out.activity.sessions.findIndex((x)=>x.session_key===b.session_key));
     expect(timeRows.map((s)=>s.n)).toEqual([3,2,4,2,4]);expect(out.activity.sessions.filter((s)=>s.is_transition).map((s)=>s.session_seq)).toEqual([1,3]);
   });
+  it("uses positive elapsed time for a single-session zero-width source range",async()=>{
+    const source=session(0,0,0,{totalElapsedTime:1.1});
+    await expect(map(decoded([source],[record(0,0),record(1,1),record(2,2)]))).resolves.toBeDefined();
+    await error(map(decoded([source],[record(0,0),record(1,3)])),"record_unassigned");
+    await error(map(decoded([source,session(1,2,3)],[record(0,.5),record(1,2)])),"record_unassigned");
+    const activity:DecodedActivity={timestamp:null,localTimestamp:null,numSessions:2,type:null,event:null,eventType:null};
+    await error(map(decoded([source],[record(0,0),record(1,1)],{activity})),"record_unassigned");
+  });
   it("honors source-error precedence and does not sort records",async()=>{
     await expect(map(decoded([], [record(0,NaN)]))).rejects.toMatchObject({code:"missing_session"});
     await expect(map(decoded([session(0,0,3,{sport:null,startTime:NaN})],[]))).rejects.toMatchObject({code:"invalid_date"});
@@ -76,7 +84,11 @@ describe("FIT row mapper",()=>{
     await error(map(decoded([session(0,0,1,{firstLapIndex:0,numLaps:null})],[])),"lap_slice_invalid");
     await expect(map(decoded([session(0,0,1,{firstLapIndex:null,numLaps:0})],[]))).resolves.toBeDefined();
     await error(map(decoded([session(0,0,1,{firstLapIndex:1,numLaps:0})],[])),"lap_slice_invalid");
-    await error(map(decoded([session(0,0,1,{firstLapIndex:null,numLaps:1})],[],{laps:[lap(0)]})),"lap_slice_invalid");
+    await expect(map(decoded([session(0,0,1,{firstLapIndex:null,numLaps:1})],[],{laps:[lap(0)]}))).resolves.toBeDefined();
+    await expect(map(decoded([session(0,0,1,{firstLapIndex:null,numLaps:null})],[],{laps:[lap(0)]}))).resolves.toBeDefined();
+    await error(map(decoded([session(0,0,1,{firstLapIndex:null,numLaps:2})],[],{laps:[lap(0)]})),"lap_slice_invalid");
+    await error(map(decoded([session(0,0,1,{firstLapIndex:null,numLaps:1}),session(1,2,3,{firstLapIndex:null,numLaps:1})],[],{laps:[lap(0),lap(1)]})),"lap_slice_invalid");
+    await error(map(decoded([session(0,0,1,{firstLapIndex:null,numLaps:1})],[],{activity:{timestamp:null,localTimestamp:null,numSessions:2,type:null,event:null,eventType:null},laps:[lap(0)]})),"lap_slice_invalid");
     await error(map(decoded([baseSession],[],{laps:[lap(0,{firstLengthIndex:0,numLengths:null})]})),"length_slice_invalid");
     await error(map(decoded([baseSession],[],{laps:[lap(0,{firstLengthIndex:null,numLengths:1})],lengths:[length(0)]})),"length_slice_invalid");
     await error(map(decoded([baseSession],[],{laps:[baseLap],lengths:[length(0,{lengthType:"idle"})]})),"active_length_count_mismatch");

--- a/packages/kernel/tests/import-report.test.ts
+++ b/packages/kernel/tests/import-report.test.ts
@@ -86,7 +86,7 @@ function prepare(artifact: ImportArtifact): PrepareFileResult {
 
 function harness(store = new ReportStore(), rawArchive = archive()) {
   return { store, rawArchive, deps: { store, archive: rawArchive, hashKey, prepareFile: async (artifact: ImportArtifact) => prepare(artifact),
-    canonicalPick, materializeClusterInTransaction: async () => {}, ingestVersion: 2 as const } };
+    canonicalPick, materializeClusterInTransaction: async () => {}, ingestVersion: 3 as const } };
 }
 
 const file = (input_path: string, byte: number): ImportArtifact => ({ input_path, bytes: new Uint8Array([byte]), ext: "fit" });
@@ -168,7 +168,7 @@ describe("stable import report", () => {
     const { report } = await run([file("bad.fit", 0)]);
     const expected = `{
   "schema_version": 1,
-  "ingest_version": 2,
+  "ingest_version": 3,
   "effective": {
     "tier3": {
       "startSeconds": 120,
@@ -232,9 +232,9 @@ describe("stable import report", () => {
     ]);
     expect(report.inserts.raw_file).toBe(1);
   });
-  it("[PR05-REPORT-007] carries quarantine, defaults, and ingest version two", async () => {
+  it("[PR05-REPORT-007] carries quarantine, defaults, and ingest version three", async () => {
     const { report } = await run([file("bad.fit", 0)]);
-    expect(report).toMatchObject({ ingest_version: 2, effective: { tier3: DEFAULT_TIER3_THRESHOLDS,
+    expect(report).toMatchObject({ ingest_version: 3, effective: { tier3: DEFAULT_TIER3_THRESHOLDS,
       transition_window_s: DEFAULT_TRANSITION_WINDOW_S } });
     expect(report.files[0]).toMatchObject({ outcome: "quarantined", raw_file_inserted: false,
       quarantine: { code: "fit:decode_failed", message: "rejected" } });

--- a/packages/kernel/tests/ingest/canonical-pick.test.ts
+++ b/packages/kernel/tests/ingest/canonical-pick.test.ts
@@ -245,7 +245,9 @@ describe("canonical concern selection", () => {
       { ...ready(1), "stream:power": channel([1, 2], [1, -0]) },
       { ...ready(1), "stream:time": channel([1, 2], [1, 3]) },
       { ...ready(1), "stream:heart_rate": channel([1, 2], [0, 120]) },
+      { ...ready(1), "stream:heart_rate": channel([1, 2], [120.5, 121]) },
       { ...ready(1), "stream:cadence": channel([1, 2], [1.5, 2]) },
+      { ...ready(1), "stream:cadence": channel([1, 2], [1, 256]) },
       { ...ready(1), "stream:distance": channel([1, 2], [-1, 2]) },
       { ...ready(1), "stream:unknown": channel([1, 2], [1, 2]) },
       { ...ready(1), "stream:dev:idx-2:1:0:field": channel([1, 2], [1, 2]) },
@@ -254,6 +256,9 @@ describe("canonical concern selection", () => {
     for (const concerns of bad) error(() => canonicalPick(group([{ ...base, concerns }])), "canonical.concern_invalid");
     const validDeveloper = { ...ready(1), "stream:dev:idx-2:2:0:field%20name": channel([1, 2], [1, 2]) };
     expect(canonicalPick(group([{ ...base, concerns: validDeveloper }])).winners).toHaveLength(6);
+    const repairedChannels = { ...ready(1), "stream:heart_rate": channel([1, 2], [120.5, 121.5]), "stream:cadence": channel([1, 2], [1.5, 2.5]) };
+    const repairedFit = file("fit", digest("f"), repairedChannels);
+    expect(canonicalPick(group([repairedFit],{[repairedFit.id]:1})).winners).toHaveLength(7);
   });
 
   it("validates every platform-origin and rank near miss with the required precedence", () => {


### PR DESCRIPTION
## Summary

- accept the strict balance-mask shape emitted by real FIT parsing while rejecting every other extra field
- recover lap and record ownership only for complete single-session shapes
- allow bounded interpolated heart-rate and cadence samples only for FIT-derived candidates
- advance ingest semantics to version 3 so persisted derived rows are rebuilt under the corrected rules

## Verification

- Node 24: pnpm check
- Node 24: pnpm test (252 files, 3,642 tests passed)
- Node 24: pnpm check-parity --all
- Node 24: pnpm s8a
- two independent read-only reviews: PASS
- private 300-file Garmin/Wahoo archive: 234 imports, 66 independently explained malformed sources, zero unexplained quarantines, no wrong dedup, and a byte-identical zero-insert rerun
