### PR TITLE
feat(kernel): add opt-in repair chain settings

### DIFF
--- a/.changeset/repair-chain-settings.md
+++ b/.changeset/repair-chain-settings.md
@@ -1,0 +1,6 @@
+---
+"@enduragent/kernel": patch
+"@enduragent/kernel-node": patch
+---
+
+Add opt-in repair-fixer settings with deterministic derived-state rebuilds. Internal infrastructure; ships nothing to athletes.

--- a/packages/kernel-node/src/ingest/import-files.ts
+++ b/packages/kernel-node/src/ingest/import-files.ts
@@ -6,6 +6,7 @@ import {
   FitSourceError,
   FIT_INGEST_VERSION,
   QUALITY_RANK,
+  applyRepairFixerSettingWithRebuild,
   canonicalPick,
   createMaterializeClusterInTransaction,
   decodeStream,
@@ -16,10 +17,14 @@ import {
   type DedupCandidateSummary,
   type ImportArtifact,
   type ImportReport,
+  type ImportReportDeps,
   type LapConcern,
   type PrepareFileResult,
   type PreparedFile,
   type PreparedRepairEvent,
+  type RepairFixer,
+  type RepairFixerSettingChangeResult,
+  type RepairFixerSettings,
   type SwimLengthConcern,
 } from "@enduragent/kernel/ingest";
 import { H, sortKeys, type MigratorStore, type SqlStore } from "@enduragent/kernel/store";
@@ -29,6 +34,18 @@ import { prepareXmlFile } from "./xml-file.js";
 
 export interface ImportFilesOptions {
   readonly inputPaths: readonly string[];
+  readonly archiveDir: string;
+  readonly store: SqlStore & Pick<MigratorStore, "transaction">;
+}
+
+interface NodeImportCompositionOptions {
+  readonly archiveDir: string;
+  readonly store: SqlStore & Pick<MigratorStore, "transaction">;
+}
+
+export interface SetRepairFixerEnabledOptions {
+  readonly fixer: RepairFixer;
+  readonly enabled: boolean;
   readonly archiveDir: string;
   readonly store: SqlStore & Pick<MigratorStore, "transaction">;
 }
@@ -141,13 +158,24 @@ function concernsForSession(mapped: Awaited<ReturnType<typeof mapFitArtifact>>, 
   return concerns;
 }
 
-async function prepareFit(artifact: ImportArtifact, crypto: CryptoPort): Promise<PrepareFileResult> {
+async function prepareFit(
+  artifact: ImportArtifact,
+  crypto: CryptoPort,
+  repairSettings: RepairFixerSettings,
+): Promise<PrepareFileResult> {
   const digest = await crypto.sha256(artifact.bytes);
   const address = [...digest].map((byte) => byte.toString(16).padStart(2, "0")).join("");
   let mapped: Awaited<ReturnType<typeof mapFitArtifact>>;
   try {
     const decoded = await createFitDecoder().decode(artifact.bytes);
-    mapped = await mapFitArtifact({ crypto, rawSha256: address, rawByteLength: artifact.bytes.byteLength, archivePath: null, decoded });
+    mapped = await mapFitArtifact({
+      crypto,
+      rawSha256: address,
+      rawByteLength: artifact.bytes.byteLength,
+      archivePath: null,
+      decoded,
+      repairSettings,
+    });
   } catch (error) {
     if (!(error instanceof FitSourceError)) throw error;
     return { outcome: "quarantined", quarantine: { code: `fit:${error.code}`, message: error.message } };
@@ -187,6 +215,29 @@ async function prepareFit(artifact: ImportArtifact, crypto: CryptoPort): Promise
   return { outcome: "prepared", value };
 }
 
+function createImportReportDeps(
+  options: NodeImportCompositionOptions,
+): ImportReportDeps {
+  const crypto = nodeCrypto();
+  const fs = nodeFileSystem();
+  const archive = createArchiveManager({ archiveRoot: options.archiveDir, crypto, fs });
+  const hashKey = (fields: readonly (string | number)[]): Promise<string> => {
+    if (fields.length === 0) throw new TypeError("empty key tuple");
+    return H(crypto, ...(fields as [string | number, ...(string | number)[]]));
+  };
+  return {
+    archive,
+    store: options.store,
+    hashKey,
+    prepareFile: (artifact, repairSettings) => artifact.ext === "fit"
+      ? prepareFit(artifact, crypto, repairSettings)
+      : prepareXmlFile(artifact.bytes, artifact.ext, { crypto }),
+    canonicalPick,
+    materializeClusterInTransaction: createMaterializeClusterInTransaction(hashKey),
+    ingestVersion: FIT_INGEST_VERSION,
+  };
+}
+
 export async function importFilesWithReport(options: ImportFilesOptions): Promise<ImportReport> {
   if (options.inputPaths.length === 0) throw new TypeError("input path list is empty");
   const seen = new Set<string>();
@@ -198,19 +249,17 @@ export async function importFilesWithReport(options: ImportFilesOptions): Promis
     if (ext !== "fit" && ext !== "tcx" && ext !== "gpx") throw new TypeError("unsupported input extension");
     files.push({ input_path: inputPath, bytes: new Uint8Array(await readFile(inputPath)), ext });
   }
-  const crypto = nodeCrypto();
-  const archive = createArchiveManager({ archiveRoot: options.archiveDir, crypto, fs: nodeFileSystem() });
-  const hashKey = (fields: readonly (string | number)[]): Promise<string> => {
-    if (fields.length === 0) throw new TypeError("empty key tuple");
-    return H(crypto, ...(fields as [string | number, ...(string | number)[]]));
-  };
-  return importArtifactsWithReport({ files, platform_records: [] }, {
-    archive,
-    store: options.store,
-    hashKey,
-    prepareFile: (artifact) => artifact.ext === "fit" ? prepareFit(artifact, crypto) : prepareXmlFile(artifact.bytes, artifact.ext, { crypto }),
-    canonicalPick,
-    materializeClusterInTransaction: createMaterializeClusterInTransaction(hashKey),
-    ingestVersion: FIT_INGEST_VERSION,
-  });
+  return importArtifactsWithReport(
+    { files, platform_records: [] },
+    createImportReportDeps(options),
+  );
+}
+
+export function setRepairFixerEnabled(
+  options: SetRepairFixerEnabledOptions,
+): Promise<RepairFixerSettingChangeResult> {
+  return applyRepairFixerSettingWithRebuild(
+    { fixer: options.fixer, enabled: options.enabled },
+    createImportReportDeps(options),
+  );
 }

--- a/packages/kernel-node/tests/coach-dev-import.test.ts
+++ b/packages/kernel-node/tests/coach-dev-import.test.ts
@@ -81,7 +81,7 @@ const pair = {
 
 const fullReportFixture: ImportReport = {
   schema_version: 1,
-  ingest_version: 3,
+  ingest_version: 4,
   effective: {
     tier3: {
       startSeconds: 120,
@@ -383,7 +383,7 @@ function injected(options: InjectedOptions = {}) {
       calls.push("migrate");
       observed.migrations = migrations;
       fail("migrate");
-      return { fromVersion: 0, toVersion: 3, applied: [1, 2, 3] };
+      return { fromVersion: 0, toVersion: 4, applied: [1, 2, 3, 4] };
     },
     async importFilesWithReport(value: {
       readonly inputPaths: readonly string[];
@@ -472,7 +472,7 @@ describe("coach-dev import --report", () => {
     expect(await exists(databasePath)).toBe(true);
     const store = openSqliteStorage(databasePath);
     try {
-      expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 3 });
+      expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 4 });
       expect(await store.get("SELECT count(*) AS c FROM raw_file")).toEqual({ c: 1 });
       expect(await store.get("SELECT count(*) AS c FROM source_record")).toEqual({ c: 0 });
       expect(

--- a/packages/kernel-node/tests/fit-import.test.ts
+++ b/packages/kernel-node/tests/fit-import.test.ts
@@ -28,7 +28,7 @@ describe("global file import runner", () => {
     expect(result.files[0]).toMatchObject({ outcome: "imported", raw_file_inserted: true });
     expect(result.inserts).toEqual({ raw_file: 1, source_record: 0 });
     expect((await store.get("SELECT count(*) c FROM source_record"))?.c).toBe(0);
-    expect((await store.get("SELECT ingest_version FROM ingest_metadata"))?.ingest_version).toBe(3);
+    expect((await store.get("SELECT ingest_version FROM ingest_metadata"))?.ingest_version).toBe(4);
   });
   it("sorts planning deterministically while retaining exact input paths", async () => {
     const inputPaths = [fixture("brick-running.fit"), fixture("brick-cycling.fit")];
@@ -63,7 +63,7 @@ describe("global file import runner", () => {
     await expect(importFilesWithReport({ inputPaths: [txt], archiveDir, store })).rejects.toThrow("unsupported input extension");
   });
   it("refuses a newer stored version before archive side effects", async () => {
-    await store.run("UPDATE ingest_metadata SET ingest_version=4");
+    await store.run("UPDATE ingest_metadata SET ingest_version=5");
     await expect(importFilesWithReport({ inputPaths: [fixture("brick-cycling.fit")], archiveDir, store })).rejects.toThrow("newer ingest semantics");
     expect(existsSync(archiveDir)).toBe(false);
   });

--- a/packages/kernel-node/tests/inv2-ingest-order.test.ts
+++ b/packages/kernel-node/tests/inv2-ingest-order.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { canonicalPick, createMaterializeClusterInTransaction, importArtifactsWithReport, type ConcernValue,
-  type ImportArtifact, type PlatformImportArtifact } from "@enduragent/kernel/ingest";
+  type ImportArtifact, type PlatformImportArtifact, type RepairFixerSettings } from "@enduragent/kernel/ingest";
 import type { ArchiveManager } from "@enduragent/kernel/archive";
 import { dumpStore, runMigrations, sortKeys } from "@enduragent/kernel/store";
 import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
@@ -150,10 +150,10 @@ describe("real SQLite dedup ordering", () => {
         return originalGet(sql, params);
       };
       const deps = { store: value.store, archive: unusedArchive, hashKey,
-        prepareFile: async (_artifact: ImportArtifact) => { throw new Error("unused"); },
+        prepareFile: async (_artifact: ImportArtifact, _repairSettings: RepairFixerSettings) => { throw new Error("unused"); },
         canonicalPick(group: Parameters<typeof canonicalPick>[0]) {
           origins.push(...group.candidates.map((candidate) => candidate.origin)); return canonicalPick(group);
-        }, materializeClusterInTransaction: createMaterializeClusterInTransaction(hashKey), ingestVersion: 3 as const };
+        }, materializeClusterInTransaction: createMaterializeClusterInTransaction(hashKey), ingestVersion: 4 as const };
       const first = await importArtifactsWithReport({ files: [], platform_records: [platform] }, deps);
       expect(first.inserts.source_record).toBe(1); expect(first.updates.relinked_source_records).toBe(1);
       expect(sourceInsertAttachments[0]).toEqual([null, null]);
@@ -165,15 +165,15 @@ describe("real SQLite dedup ordering", () => {
       expect(origins).toContainEqual(expect.objectContaining({ kind: "platform", persistedQualityRank: 300 }));
     } finally { await value.store.close(); }
   });
-  it("[PR05-SQL-007] proves zero through two upgrade, current three, and early refusal of four", async () => {
+  it("[PR05-SQL-007] proves zero through three upgrade, current four, and early refusal of five", async () => {
     const value = await fresh();
     try {
       const options = { inputPaths: [path("brick-cycling.fit")], archiveDir: value.archiveDir, store: value.store };
-      for (const version of [0, 1, 2, 3]) {
+      for (const version of [0, 1, 2, 3, 4]) {
         await value.store.run("UPDATE ingest_metadata SET ingest_version=?", [version]);
-        expect((await importFilesWithReport(options)).ingest_version).toBe(3);
+        expect((await importFilesWithReport(options)).ingest_version).toBe(4);
       }
-      await value.store.run("UPDATE ingest_metadata SET ingest_version=4");
+      await value.store.run("UPDATE ingest_metadata SET ingest_version=5");
       const count = (await value.store.get("SELECT count(*) c FROM raw_file"))?.c;
       await expect(importFilesWithReport(options)).rejects.toThrow("newer ingest semantics");
       expect((await value.store.get("SELECT count(*) c FROM raw_file"))?.c).toBe(count);

--- a/packages/kernel-node/tests/inv2-ingest-twice.test.ts
+++ b/packages/kernel-node/tests/inv2-ingest-twice.test.ts
@@ -4,14 +4,15 @@ import { join, resolve } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { DERIVED_TABLES, dumpStore, runMigrations } from "@enduragent/kernel/store";
 import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
-import { importFilesWithReport } from "../src/ingest/import-files.js";
+import { REPAIR_FIXERS } from "@enduragent/kernel/ingest";
+import { importFilesWithReport, setRepairFixerEnabled } from "../src/ingest/import-files.js";
 import { openSqliteStorage } from "../src/sqlite/index.js";
 
 let dir: string | undefined;
 afterEach(() => { if (dir) rmSync(dir, { recursive: true, force: true }); dir = undefined; });
 
 describe("INV-2 ingest twice", () => {
-  it("keeps stream and repair rows identical with zero second-run inserts and metadata three", async () => {
+  async function ingestTwice(allOn: boolean) {
     expect(DERIVED_TABLES.join(",")).toBe("metric_snapshot,mean_max_cache,repair_log,stream,swim_length,lap,session,workout");
     dir = mkdtempSync(join(tmpdir(), "fit-inv2-"));
     const store = openSqliteStorage(join(dir, "store.db"));
@@ -19,6 +20,9 @@ describe("INV-2 ingest twice", () => {
       await runMigrations(store, MIGRATIONS);
       const options = { inputPaths: [resolve("packages/kernel-node/tests/fixtures/ingest/triathlon-multisport.fit")],
         archiveDir: join(dir, "archive"), store };
+      if (allOn) for (const fixer of REPAIR_FIXERS) {
+        await setRepairFixerEnabled({ fixer, enabled: true, archiveDir: options.archiveDir, store });
+      }
       const first = await importFilesWithReport(options); expect(first.inserts.raw_file).toBe(1);
       const dump1 = await dumpStore(store), streams1 = await store.all("SELECT * FROM stream ORDER BY stream_key"),
         logs1 = await store.all("SELECT * FROM repair_log ORDER BY repair_key");
@@ -27,8 +31,18 @@ describe("INV-2 ingest twice", () => {
       expect(await store.all("SELECT * FROM stream ORDER BY stream_key")).toEqual(streams1);
       expect(await store.all("SELECT * FROM repair_log ORDER BY repair_key")).toEqual(logs1);
       expect(await dumpStore(store)).toBe(dump1);
-      expect(await store.get("SELECT singleton,ingest_version FROM ingest_metadata")).toEqual({ singleton: 1, ingest_version: 3 });
-      expect(logs1.length).toBeGreaterThan(0); expect(streams1.length).toBeGreaterThan(0);
+      expect(await store.get("SELECT singleton,ingest_version FROM ingest_metadata")).toEqual({ singleton: 1, ingest_version: 4 });
+      expect(streams1.length).toBeGreaterThan(0);
+      if (allOn) expect(logs1.length).toBeGreaterThan(0);
+      else expect(logs1).toEqual([]);
     } finally { await store.close(); }
+  }
+
+  it("keeps default-off dumps byte-identical across repeated ingest", async () => {
+    await ingestTwice(false);
+  });
+
+  it("keeps explicit-all-on dumps byte-identical across repeated ingest", async () => {
+    await ingestTwice(true);
   });
 });

--- a/packages/kernel-node/tests/inv2-overlay-recompute.test.ts
+++ b/packages/kernel-node/tests/inv2-overlay-recompute.test.ts
@@ -22,24 +22,24 @@ describe("global version and overlay recompute", () => {
     return () => count;
   }
 
-  it("upgrades stored versions zero through two to three through the global planner", async () => {
-    for (const version of [0, 1, 2]) {
+  it("upgrades stored versions zero through three to four through the global planner", async () => {
+    for (const version of [0, 1, 2, 3]) {
       await store.run("UPDATE ingest_metadata SET ingest_version=?", [version]);
       const result = await importFilesWithReport({ inputPaths: [path("brick-cycling.fit")], archiveDir, store });
-      expect(result.ingest_version).toBe(3);
-      expect((await store.get("SELECT ingest_version FROM ingest_metadata"))?.ingest_version).toBe(3);
+      expect(result.ingest_version).toBe(4);
+      expect((await store.get("SELECT ingest_version FROM ingest_metadata"))?.ingest_version).toBe(4);
     }
   });
-  it("keeps current version three while still globally replanning a nonempty batch", async () => {
+  it("keeps current version four while still globally replanning a nonempty batch", async () => {
     await importFilesWithReport({ inputPaths: [path("brick-cycling.fit")], archiveDir, store });
     const transactions = countTransactions();
     const result = await importFilesWithReport({ inputPaths: [path("brick-cycling.fit")], archiveDir, store });
-    expect(result.ingest_version).toBe(3);
+    expect(result.ingest_version).toBe(4);
     expect(transactions()).toBe(1);
-    expect((await store.get("SELECT ingest_version FROM ingest_metadata"))?.ingest_version).toBe(3);
+    expect((await store.get("SELECT ingest_version FROM ingest_metadata"))?.ingest_version).toBe(4);
   });
-  it("refuses version four before archive and SQL side effects", async () => {
-    await store.run("UPDATE ingest_metadata SET ingest_version=4");
+  it("refuses version five before archive and SQL side effects", async () => {
+    await store.run("UPDATE ingest_metadata SET ingest_version=5");
     await expect(importFilesWithReport({ inputPaths: [path("brick-cycling.fit")], archiveDir, store })).rejects.toThrow("newer ingest semantics");
     expect(existsSync(archiveDir)).toBe(false); expect((await store.get("SELECT count(*) c FROM raw_file"))?.c).toBe(0);
   });

--- a/packages/kernel-node/tests/migrator-e2e.test.ts
+++ b/packages/kernel-node/tests/migrator-e2e.test.ts
@@ -28,9 +28,9 @@ describe("migrator end-to-end over node:sqlite", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
-  it("applies the full migration list and advances user_version to 3", async () => {
+  it("applies the full migration list and advances user_version to 4", async () => {
     await runMigrations(store, MIGRATIONS);
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 3 });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 4 });
 
     const tables = await store.all("SELECT name FROM sqlite_master WHERE type='table'");
     const names = new Set(tables.map((r) => r.name as string));
@@ -39,10 +39,11 @@ describe("migrator end-to-end over node:sqlite", () => {
     }
 
     expect(await store.all("PRAGMA foreign_key_check")).toEqual([]);
+    expect(await store.all("SELECT fixer,enabled FROM repair_fixer_settings ORDER BY fixer")).toEqual([]);
     expect(await store.get("SELECT name FROM sqlite_master WHERE type='index' AND name='idx_dedup_confirmation_effective'")).toEqual({ name: "idx_dedup_confirmation_effective" });
     expect(await store.get("PRAGMA journal_mode")).toEqual({ journal_mode: "wal" });
     await runMigrations(store, MIGRATIONS);
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 3 });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 4 });
   });
 
   it("produces a deterministic INV-2 dump of a fixed state", async () => {
@@ -71,12 +72,13 @@ describe("migrator end-to-end over node:sqlite", () => {
     expect(await dumpStore(store)).toBe(dump);
   });
 
-  it("upgrades a version-1-on-disk store to version 3", async () => {
+  it("upgrades a version-1-on-disk store to version 4", async () => {
     await runMigrations(store, [MIGRATIONS[0]!]);
     expect(await store.get("PRAGMA user_version")).toEqual({user_version:1});
     await runMigrations(store, MIGRATIONS);
-    expect(await store.get("PRAGMA user_version")).toEqual({user_version:3});
+    expect(await store.get("PRAGMA user_version")).toEqual({user_version:4});
     expect(await store.get("SELECT singleton,ingest_version FROM ingest_metadata")).toEqual({singleton:1,ingest_version:0});
+    expect(await store.all("SELECT fixer,enabled FROM repair_fixer_settings ORDER BY fixer")).toEqual([]);
     expect(await store.all("PRAGMA foreign_key_check")).toEqual([]);
   });
 

--- a/packages/kernel-node/tests/repair-fixer-settings.test.ts
+++ b/packages/kernel-node/tests/repair-fixer-settings.test.ts
@@ -1,0 +1,220 @@
+import { existsSync, mkdtempSync, renameSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { REPAIR_FIXERS } from "@enduragent/kernel/ingest";
+import {
+  DERIVED_TABLES,
+  DUMP_TABLES,
+  dumpStore,
+  runMigrations,
+  type MigratorStore,
+  type Row,
+  type SqlStore,
+} from "@enduragent/kernel/store";
+import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
+import { importFilesWithReport, setRepairFixerEnabled } from "../src/ingest/import-files.js";
+import { openSqliteStorage } from "../src/sqlite/index.js";
+
+type Store = SqlStore & MigratorStore;
+
+const roots = new Set<string>();
+const stores = new Set<Store>();
+const fixture = resolve("packages/kernel-node/tests/fixtures/ingest/triathlon-multisport.fit");
+
+afterEach(async () => {
+  for (const store of stores) await store.close();
+  stores.clear();
+  for (const root of roots) rmSync(root, { recursive: true, force: true });
+  roots.clear();
+});
+
+async function fresh(label: string) {
+  const root = mkdtempSync(join(tmpdir(), `${label}-`));
+  roots.add(root);
+  const store = openSqliteStorage(join(root, "store.db"));
+  stores.add(store);
+  await runMigrations(store, MIGRATIONS);
+  return { root, store, archiveDir: join(root, "archive") };
+}
+
+const importFixture = (value: Awaited<ReturnType<typeof fresh>>) => importFilesWithReport({
+  inputPaths: [fixture],
+  archiveDir: value.archiveDir,
+  store: value.store,
+});
+
+const settings = (store: Store) => store.all("SELECT fixer,enabled FROM repair_fixer_settings ORDER BY fixer COLLATE BINARY ASC");
+const streams = (store: Store) => store.all("SELECT * FROM stream ORDER BY stream_key COLLATE BINARY ASC");
+const logs = (store: Store) => store.all("SELECT * FROM repair_log ORDER BY repair_key COLLATE BINARY ASC");
+const metadata = (store: Store) => store.get("SELECT singleton,ingest_version FROM ingest_metadata WHERE singleton=1");
+
+async function derivedSnapshot(store: Store): Promise<Readonly<Record<string, readonly Row[]>>> {
+  const result: Record<string, readonly Row[]> = {};
+  for (const { table, orderBy } of DUMP_TABLES) {
+    if ((DERIVED_TABLES as readonly string[]).includes(table)) {
+      result[table] = await store.all(`SELECT * FROM ${table} ORDER BY ${orderBy} COLLATE BINARY ASC`);
+    }
+  }
+  return result;
+}
+
+describe("repair fixer settings", () => {
+  it("defaults all fixers off and ingests zero repair rows", async () => {
+    const value = await fresh("repair-default-off");
+    expect(await settings(value.store)).toEqual([]);
+    await importFixture(value);
+    expect((await streams(value.store)).length).toBeGreaterThan(0);
+    expect(await logs(value.store)).toEqual([]);
+    expect(await settings(value.store)).toEqual([]);
+    expect(await metadata(value.store)).toEqual({ singleton: 1, ingest_version: 4 });
+  });
+
+  it("enables and disables each fixer through a global rebuild", async () => {
+    const value = await fresh("repair-toggle");
+    await importFixture(value);
+    const offDump = await dumpStore(value.store);
+    const offStreams = await streams(value.store);
+    const offLogs = await logs(value.store);
+    const rawCount = await value.store.get("SELECT count(*) AS count FROM raw_file");
+    expect(offLogs).toEqual([]);
+    for (const fixer of REPAIR_FIXERS) {
+      await expect(setRepairFixerEnabled({ fixer, enabled: true, archiveDir: value.archiveDir, store: value.store }))
+        .resolves.toEqual({ changed: true, rebuilt: true, from: false, to: true, ingest_version: 4 });
+      expect(await settings(value.store)).toEqual([{ fixer, enabled: 1 }]);
+      const enabledLogs = await logs(value.store);
+      expect(enabledLogs.length).toBeGreaterThan(0);
+      expect(new Set(enabledLogs.map((row) => row.fixer))).toEqual(new Set([fixer]));
+      expect(enabledLogs).not.toEqual(offLogs);
+      expect(await value.store.get("SELECT count(*) AS count FROM raw_file")).toEqual(rawCount);
+      expect(await metadata(value.store)).toEqual({ singleton: 1, ingest_version: 4 });
+      await expect(setRepairFixerEnabled({ fixer, enabled: false, archiveDir: value.archiveDir, store: value.store }))
+        .resolves.toEqual({ changed: true, rebuilt: true, from: true, to: false, ingest_version: 4 });
+      expect(await settings(value.store)).toEqual([]);
+      expect(await streams(value.store)).toEqual(offStreams);
+      expect(await logs(value.store)).toEqual(offLogs);
+      expect(await dumpStore(value.store)).toBe(offDump);
+    }
+  });
+
+  it("all-on transition matches fresh all-on ingest byte for byte", async () => {
+    const transitioned = await fresh("repair-transitioned");
+    const freshOn = await fresh("repair-fresh-on");
+    await importFixture(transitioned);
+    for (const fixer of REPAIR_FIXERS) {
+      await setRepairFixerEnabled({ fixer, enabled: true, archiveDir: transitioned.archiveDir, store: transitioned.store });
+      await setRepairFixerEnabled({ fixer, enabled: true, archiveDir: freshOn.archiveDir, store: freshOn.store });
+    }
+    await importFixture(freshOn);
+    expect(await dumpStore(transitioned.store)).toBe(await dumpStore(freshOn.store));
+    expect(await streams(transitioned.store)).toEqual(await streams(freshOn.store));
+    expect(await logs(transitioned.store)).toEqual(await logs(freshOn.store));
+  });
+
+  it("rolls back the setting and derived state when rebuild fails", async () => {
+    const value = await fresh("repair-rollback");
+    await importFixture(value);
+    const before = await dumpStore(value.store);
+    const beforeStreams = await streams(value.store);
+    const beforeLogs = await logs(value.store);
+    const beforeRaw = await value.store.get("SELECT count(*) AS count FROM raw_file");
+    const originalRun = value.store.run.bind(value.store);
+    let failed = false;
+    value.store.run = async (sql, params) => {
+      if (!failed && sql.startsWith("INSERT INTO session")) {
+        failed = true;
+        throw new Error("injected session failure");
+      }
+      return originalRun(sql, params);
+    };
+    await expect(setRepairFixerEnabled({
+      fixer: "chronoBridge",
+      enabled: true,
+      archiveDir: value.archiveDir,
+      store: value.store,
+    })).rejects.toThrow("injected session failure");
+    value.store.run = originalRun;
+    expect(await dumpStore(value.store)).toBe(before);
+    expect(await settings(value.store)).toEqual([]);
+    expect(await metadata(value.store)).toEqual({ singleton: 1, ingest_version: 4 });
+    expect(await streams(value.store)).toEqual(beforeStreams);
+    expect(await logs(value.store)).toEqual(beforeLogs);
+    expect(await value.store.get("SELECT count(*) AS count FROM raw_file")).toEqual(beforeRaw);
+  });
+
+  it("current-version setting no-op performs no rebuild", async () => {
+    const value = await fresh("repair-current-noop");
+    await importFixture(value);
+    const before = await dumpStore(value.store);
+    const parkedArchive = `${value.archiveDir}-parked`;
+    renameSync(value.archiveDir, parkedArchive);
+    let transactions = 0;
+    const originalTransaction = value.store.transaction.bind(value.store);
+    value.store.transaction = async (fn) => { transactions += 1; return originalTransaction(fn); };
+    await expect(setRepairFixerEnabled({
+      fixer: "chronoBridge",
+      enabled: false,
+      archiveDir: value.archiveDir,
+      store: value.store,
+    })).resolves.toEqual({ changed: false, rebuilt: false, from: false, to: false, ingest_version: 4 });
+    expect(existsSync(value.archiveDir)).toBe(false);
+    expect(transactions).toBe(0);
+    expect(await dumpStore(value.store)).toBe(before);
+    renameSync(parkedArchive, value.archiveDir);
+  });
+
+  it("stale-version setting no-op still performs one rebuild", async () => {
+    const value = await fresh("repair-stale-noop");
+    let transactions = 0;
+    const originalTransaction = value.store.transaction.bind(value.store);
+    value.store.transaction = async (fn) => { transactions += 1; return originalTransaction(fn); };
+    await expect(setRepairFixerEnabled({
+      fixer: "chronoBridge",
+      enabled: false,
+      archiveDir: value.archiveDir,
+      store: value.store,
+    })).resolves.toEqual({ changed: false, rebuilt: true, from: false, to: false, ingest_version: 4 });
+    expect(existsSync(value.archiveDir)).toBe(false);
+    expect(transactions).toBe(1);
+    expect(await metadata(value.store)).toEqual({ singleton: 1, ingest_version: 4 });
+    expect(await value.store.all("SELECT * FROM raw_file")).toEqual([]);
+    expect(await settings(value.store)).toEqual([]);
+    for (const table of DERIVED_TABLES) expect(await value.store.all(`SELECT * FROM ${table}`)).toEqual([]);
+    expect(await dumpStore(value.store)).toContain("# repair_fixer_settings");
+  });
+
+  it("rejects a concurrent settings change before mutation", async () => {
+    const value = await fresh("repair-race");
+    await importFixture(value);
+    await value.store.close();
+    stores.delete(value.store);
+    const databasePath = join(value.root, "store.db");
+    const primary = openSqliteStorage(databasePath);
+    const competing = openSqliteStorage(databasePath);
+    stores.add(primary);
+    stores.add(competing);
+    const beforeDerived = await derivedSnapshot(primary);
+    let reached!: () => void;
+    let release!: () => void;
+    const planningComplete = new Promise<void>((resolveReached) => { reached = resolveReached; });
+    const continueTransaction = new Promise<void>((resolveRelease) => { release = resolveRelease; });
+    const originalTransaction = primary.transaction.bind(primary);
+    primary.transaction = async (fn) => {
+      reached();
+      await continueTransaction;
+      return originalTransaction(fn);
+    };
+    const stale = setRepairFixerEnabled({
+      fixer: "chronoBridge",
+      enabled: true,
+      archiveDir: value.archiveDir,
+      store: primary,
+    });
+    await planningComplete;
+    await competing.run("INSERT INTO repair_fixer_settings (fixer, enabled) VALUES (?, 1)", ["summitGuard"]);
+    release();
+    await expect(stale).rejects.toThrow(new Error("ingest inputs changed during planning"));
+    expect(await settings(primary)).toEqual([{ fixer: "summitGuard", enabled: 1 }]);
+    expect(await derivedSnapshot(primary)).toEqual(beforeDerived);
+  });
+});

--- a/packages/kernel/src/ingest/dedup-rekey.ts
+++ b/packages/kernel/src/ingest/dedup-rekey.ts
@@ -11,6 +11,13 @@ import { encodeStream } from "./stream-codec.js";
 import { rescalePoolDistances } from "./pool-size-rescale.js";
 import { buildPlatformPresentation, replayPlatformPresentation, type PlatformPresentation } from "./source-ledger.js";
 import { FIT_INGEST_VERSION } from "./types.js";
+import {
+  DEFAULT_REPAIR_FIXER_SETTINGS,
+  REPAIR_FIXERS,
+  normalizeRepairFixerSettings,
+  type RepairFixer,
+  type RepairFixerSettings,
+} from "./repair/types.js";
 import type {
   ClusterReport,
   FileReport,
@@ -62,6 +69,74 @@ function sourceRow(row: Row): SourceRecordRow {
     payload_json: string(row.payload_json, "source payload"),
   };
 }
+
+interface RepairFixerSettingsRow {
+  readonly fixer: RepairFixer;
+  readonly enabled: 1;
+}
+
+interface RepairFixerSettingsSnapshot {
+  readonly rows: readonly RepairFixerSettingsRow[];
+  readonly settings: RepairFixerSettings;
+  readonly canonicalRows: string;
+}
+
+async function readRepairFixerSettingsSnapshot(
+  store: SqlStore,
+): Promise<RepairFixerSettingsSnapshot> {
+  const selected = await store.all(`SELECT fixer, enabled
+FROM repair_fixer_settings
+ORDER BY fixer COLLATE BINARY ASC`);
+  if (selected.length > REPAIR_FIXERS.length) {
+    throw new TypeError("invalid repair fixer settings row");
+  }
+  const mutableSettings: Record<RepairFixer, boolean> = {
+    ...DEFAULT_REPAIR_FIXER_SETTINGS,
+  };
+  const seen = new Set<RepairFixer>();
+  const rows: RepairFixerSettingsRow[] = [];
+  for (const row of selected) {
+    const fixer = row.fixer;
+    if (typeof fixer !== "string" || !REPAIR_FIXERS.includes(fixer as RepairFixer)
+      || row.enabled !== 1 || seen.has(fixer as RepairFixer)) {
+      throw new TypeError("invalid repair fixer settings row");
+    }
+    const validFixer = fixer as RepairFixer;
+    seen.add(validFixer);
+    mutableSettings[validFixer] = true;
+    rows.push(Object.freeze({ fixer: validFixer, enabled: 1 }));
+  }
+  const frozenRows = Object.freeze(rows);
+  const settings = normalizeRepairFixerSettings(mutableSettings);
+  return Object.freeze({ rows: frozenRows, settings, canonicalRows: canonical(frozenRows) });
+}
+
+export async function readRepairFixerSettings(
+  store: SqlStore,
+): Promise<RepairFixerSettings> {
+  return (await readRepairFixerSettingsSnapshot(store)).settings;
+}
+
+export interface RepairFixerSettingChange {
+  readonly fixer: RepairFixer;
+  readonly enabled: boolean;
+}
+
+export interface RepairFixerSettingChangeResult {
+  readonly changed: boolean;
+  readonly rebuilt: boolean;
+  readonly from: boolean;
+  readonly to: boolean;
+  readonly ingest_version: typeof FIT_INGEST_VERSION;
+}
+
+type GlobalReplanRequest =
+  | { readonly kind: "import"; readonly batch: ImportBatch }
+  | { readonly kind: "repair-fixer-setting"; readonly change: RepairFixerSettingChange };
+
+type GlobalReplanResult =
+  | { readonly kind: "import"; readonly report: ImportReport }
+  | { readonly kind: "repair-fixer-setting"; readonly result: RepairFixerSettingChangeResult };
 
 function exactPrepared(left: PreparedFile, right: PreparedFile): boolean {
   return canonical({ ...left, archive_instant: left.archive_instant }) === canonical({ ...right, archive_instant: right.archive_instant });
@@ -132,13 +207,46 @@ async function orphanReports(store: SqlStore, members: ReadonlySet<string>): Pro
     || compareText(a.target_key, b.target_key) || compareText(a.id, b.id));
 }
 
-export async function importArtifactsWithReport(batch: ImportBatch, deps: ImportReportDeps): Promise<ImportReport> {
-  if (batch.files.length + batch.platform_records.length === 0) throw new TypeError("import batch is empty");
+async function runGlobalReplan(
+  request: GlobalReplanRequest,
+  deps: ImportReportDeps,
+): Promise<GlobalReplanResult> {
   if (deps.ingestVersion !== FIT_INGEST_VERSION) throw new Error("ingest dependency version mismatch");
   const metadata = await deps.store.all("SELECT ingest_version FROM ingest_metadata WHERE singleton=1");
   if (metadata.length !== 1) throw new Error("ingest metadata invariant mismatch");
   const storedVersion = integer(metadata[0]!.ingest_version, "ingest version");
   if (storedVersion > deps.ingestVersion) throw new Error("store uses newer ingest semantics");
+  const repairSnapshot = await readRepairFixerSettingsSnapshot(deps.store);
+  let targetSettings = repairSnapshot.settings;
+  let settingFrom: boolean | undefined;
+  let settingChanged = false;
+  if (request.kind === "repair-fixer-setting") {
+    if (!REPAIR_FIXERS.includes(request.change.fixer)) throw new TypeError("invalid repair fixer");
+    if (typeof request.change.enabled !== "boolean") {
+      throw new TypeError("repair fixer enabled must be boolean");
+    }
+    settingFrom = repairSnapshot.settings[request.change.fixer];
+    settingChanged = settingFrom !== request.change.enabled;
+    targetSettings = normalizeRepairFixerSettings({
+      ...repairSnapshot.settings,
+      [request.change.fixer]: request.change.enabled,
+    });
+    if (!settingChanged && storedVersion === FIT_INGEST_VERSION) {
+      return {
+        kind: "repair-fixer-setting",
+        result: {
+          changed: false,
+          rebuilt: false,
+          from: settingFrom,
+          to: settingFrom,
+          ingest_version: FIT_INGEST_VERSION,
+        },
+      };
+    }
+  }
+  const batch: ImportBatch = request.kind === "import"
+    ? request.batch
+    : { files: [], platform_records: [] };
   const inputPaths = new Set<string>();
   for (const file of batch.files) {
     if (typeof file.input_path !== "string" || file.input_path.length === 0 || inputPaths.has(file.input_path)) throw new TypeError("duplicate or invalid input path");
@@ -163,7 +271,7 @@ export async function importArtifactsWithReport(batch: ImportBatch, deps: Import
   const fileWork: FileWork[] = [];
   const incomingAddresses = new Map<string, PreparedAddress>();
   for (const file of files) {
-    const result = await deps.prepareFile(file);
+    const result = await deps.prepareFile(file, targetSettings);
     if (result.outcome === "quarantined") {
       const archived = await deps.archive.quarantine(file.bytes, file.ext, `${canonical(result.quarantine)}\n`);
       assertValidAddress(archived.address);
@@ -192,7 +300,10 @@ ORDER BY sha256 COLLATE BINARY ASC`)).map(rawRow);
   for (const row of persistedRawRows) {
     const bytes = await deps.archive.readArtifact(row.path!);
     if (bytes.byteLength !== row.bytes) throw new Error("persisted raw byte count mismatch");
-    const result = await deps.prepareFile({ input_path: row.path!, bytes, ext: row.ext as "fit" | "tcx" | "gpx" });
+    const result = await deps.prepareFile(
+      { input_path: row.path!, bytes, ext: row.ext as "fit" | "tcx" | "gpx" },
+      targetSettings,
+    );
     if (result.outcome !== "prepared") throw new Error("persisted raw artifact is quarantined");
     if (result.value.expected_address !== row.sha256 || canonical({ ...result.value.raw_file, path: row.path }) !== canonical(row)) {
       throw new Error("persisted raw artifact invariant mismatch");
@@ -240,6 +351,7 @@ ORDER BY id COLLATE BINARY ASC`)).map(sourceRow);
   const plannedSourceState = canonical(persistedSourceRows);
   const plannedConfirmationState = canonical(confirmations);
   const plannedSettingState = canonical(settingRows);
+  const plannedRepairSettingState = repairSnapshot.canonicalRows;
   const dedup = planDedup(candidates, summaries, confirmations);
   const bricks = planBrickAdjacency(dedup, settingRows);
   const sessionById = new Map(dedup.sessions.map((session) => [session.group.id, session]));
@@ -279,7 +391,6 @@ ORDER BY id COLLATE BINARY ASC`)).map(sourceRow);
   let orphans: OrphanReport[] = [];
   await deps.store.transaction(async () => {
     const current = await deps.store.all("SELECT ingest_version FROM ingest_metadata WHERE singleton=1");
-    if (current.length !== 1 || current[0]!.ingest_version !== storedVersion) throw new Error("ingest version changed during planning");
     const currentRawRows = (await deps.store.all(`SELECT sha256, path, ext, bytes, file_id_serial,
        file_id_time_created_utc, manufacturer, product
 FROM raw_file
@@ -292,9 +403,26 @@ ORDER BY id COLLATE BINARY ASC`)).map(sourceRow);
     const currentSettings = (await deps.store.all("SELECT sport, session_cluster_conventions_json FROM sport_settings ORDER BY sport COLLATE BINARY ASC"))
       .map((row): SportSettingInput => ({ sport: string(row.sport, "setting sport"),
         session_cluster_conventions_json: row.session_cluster_conventions_json === null ? null : string(row.session_cluster_conventions_json, "setting conventions") }));
-    if (canonical(currentRawRows) !== plannedRawState || canonical(currentSourceRows) !== plannedSourceState
-      || canonical(currentConfirmations) !== plannedConfirmationState || canonical(currentSettings) !== plannedSettingState) {
+    const currentRepairSettings = await readRepairFixerSettingsSnapshot(deps.store);
+    if (current.length !== 1 || current[0]!.ingest_version !== storedVersion
+      || canonical(currentRawRows) !== plannedRawState || canonical(currentSourceRows) !== plannedSourceState
+      || canonical(currentConfirmations) !== plannedConfirmationState || canonical(currentSettings) !== plannedSettingState
+      || currentRepairSettings.canonicalRows !== plannedRepairSettingState) {
       throw new Error("ingest inputs changed during planning");
+    }
+    if (request.kind === "repair-fixer-setting" && settingChanged) {
+      if (request.change.enabled) {
+        await deps.store.run(
+          "INSERT INTO repair_fixer_settings (fixer, enabled) VALUES (?, 1) ON CONFLICT(fixer) DO NOTHING",
+          [request.change.fixer],
+        );
+      } else {
+        await deps.store.run("DELETE FROM repair_fixer_settings WHERE fixer = ?", [request.change.fixer]);
+      }
+      const updatedRepairSettings = await readRepairFixerSettingsSnapshot(deps.store);
+      if (canonical(updatedRepairSettings.settings) !== canonical(targetSettings)) {
+        throw new Error("repair fixer settings update mismatch");
+      }
     }
     const rawRepository = createRawFileRepository(deps.store), sourceRepository = createSourceRecordRepository(deps.store);
     for (const entry of incomingRows) insertedRaw.set(entry.row.sha256, await rawRepository.upsert(entry.row));
@@ -315,6 +443,19 @@ ORDER BY id COLLATE BINARY ASC`)).map(sourceRow);
     orphans = await orphanReports(deps.store, members);
   });
 
+  if (request.kind === "repair-fixer-setting") {
+    return {
+      kind: "repair-fixer-setting",
+      result: {
+        changed: settingChanged,
+        rebuilt: true,
+        from: settingFrom!,
+        to: request.change.enabled,
+        ingest_version: FIT_INGEST_VERSION,
+      },
+    };
+  }
+
   const ownerByAddress = new Map<string, string>();
   for (const work of fileWork.filter((entry) => entry.report.outcome === "imported")) {
     const owner = ownerByAddress.get(work.address);
@@ -324,20 +465,42 @@ ORDER BY id COLLATE BINARY ASC`)).map(sourceRow);
     raw_file_inserted: report.outcome === "imported" && ownerByAddress.get(address) === report.input_path
       && insertedRaw.get(address) === true })).sort((a, b) => compareText(a.address, b.address) || compareText(a.input_path, b.input_path));
   return {
-    schema_version: 1,
-    ingest_version: deps.ingestVersion,
-    effective: { tier3: DEFAULT_TIER3_THRESHOLDS, transition_window_s: DEFAULT_TRANSITION_WINDOW_S },
-    files: reports,
-    inserts: { raw_file: [...insertedRaw.values()].filter(Boolean).length, source_record: [...insertedSource.values()].filter(Boolean).length },
-    updates: { source_record: 0, relinked_source_records: relinked },
-    clusters: clusterReports,
-    threshold_near_misses: dedup.threshold_near_misses,
-    overlap_watchlist: dedup.overlap_watchlist,
-    confirm_queue: dedup.confirm_queue,
-    applied_confirmations: dedup.applied_confirmations,
-    brick_groups: bricks.brick_groups,
-    orphaned_overlays: orphans,
+    kind: "import",
+    report: {
+      schema_version: 1,
+      ingest_version: deps.ingestVersion,
+      effective: { tier3: DEFAULT_TIER3_THRESHOLDS, transition_window_s: DEFAULT_TRANSITION_WINDOW_S },
+      files: reports,
+      inserts: { raw_file: [...insertedRaw.values()].filter(Boolean).length, source_record: [...insertedSource.values()].filter(Boolean).length },
+      updates: { source_record: 0, relinked_source_records: relinked },
+      clusters: clusterReports,
+      threshold_near_misses: dedup.threshold_near_misses,
+      overlap_watchlist: dedup.overlap_watchlist,
+      confirm_queue: dedup.confirm_queue,
+      applied_confirmations: dedup.applied_confirmations,
+      brick_groups: bricks.brick_groups,
+      orphaned_overlays: orphans,
+    },
   };
+}
+
+export async function importArtifactsWithReport(
+  batch: ImportBatch,
+  deps: ImportReportDeps,
+): Promise<ImportReport> {
+  if (batch.files.length + batch.platform_records.length === 0) throw new TypeError("import batch is empty");
+  const result = await runGlobalReplan({ kind: "import", batch }, deps);
+  if (result.kind !== "import") throw new Error("global replan result invariant mismatch");
+  return result.report;
+}
+
+export async function applyRepairFixerSettingWithRebuild(
+  change: RepairFixerSettingChange,
+  deps: ImportReportDeps,
+): Promise<RepairFixerSettingChangeResult> {
+  const result = await runGlobalReplan({ kind: "repair-fixer-setting", change }, deps);
+  if (result.kind !== "repair-fixer-setting") throw new Error("global replan result invariant mismatch");
+  return result.result;
 }
 
 function winnerMap(session: PlannedLogicalSession): Map<string, ConcernValue> {

--- a/packages/kernel/src/ingest/fit-row-mapper.ts
+++ b/packages/kernel/src/ingest/fit-row-mapper.ts
@@ -5,6 +5,7 @@ import type { ActivityRows, LapRow, SessionRow, StreamRow, SwimLengthRow } from 
 import { encodeStream } from "./stream-codec.js";
 import { rescalePoolDistances, type PoolLengthDistanceInput } from "./pool-size-rescale.js";
 import { runRepairChain } from "./repair/chain.js";
+import type { RepairFixerSettings } from "./repair/types.js";
 import {
   FitSourceError,
   type DecodedDeveloperField,
@@ -20,6 +21,7 @@ export interface MapFitArtifactInput {
   readonly rawByteLength: number;
   readonly archivePath: string | null;
   readonly decoded: DecodedFitFile;
+  readonly repairSettings?: RepairFixerSettings;
 }
 
 const SPORT: Readonly<Record<number, string>> = Object.freeze({
@@ -360,7 +362,10 @@ export async function mapFitArtifact(input: MapFitArtifactInput): Promise<Mapped
         if(channel==="time"||channelValues.every((value)=>value===null)) continue;
         repairChannels[channel]=channelValues;
       }
-      const repaired=runRepairChain({time:timeValues as readonly number[],channels:repairChannels});
+      const repaired=runRepairChain(
+        {time:timeValues as readonly number[],channels:repairChannels},
+        input.repairSettings,
+      );
       for(const log of repaired.logs) for(const change of log.changes) repairLogs.push({sessionKey:key,fixer:log.fixer,channel:change.channel,changedIndices:change.changedIndices,params:log.params});
       const repairedValues=new Map<string,readonly (number|null)[]>([["time",repaired.stream.time],...Object.entries(repaired.stream.channels)]);
       for(const [channel,channelValues] of repairedValues) {

--- a/packages/kernel/src/ingest/import-report.ts
+++ b/packages/kernel/src/ingest/import-report.ts
@@ -5,6 +5,7 @@ import type { CanonicalPickResult, Candidate, LogicalSessionGroup } from "./cano
 import type { DedupCandidateSummary, PairDiagnostic, OverlapDiagnostic, AppliedConfirmationReport } from "./dedup.js";
 import type { PlatformImportArtifact } from "./source-ledger.js";
 import type { BrickReport } from "./brick-adjacency.js";
+import type { RepairFixerSettings } from "./repair/types.js";
 import type { FIT_INGEST_VERSION } from "./types.js";
 
 export interface ImportArtifact {
@@ -59,7 +60,10 @@ export interface ImportReportDeps {
   readonly archive: ArchiveManager;
   readonly store: SqlStore & Pick<MigratorStore, "transaction">;
   readonly hashKey: (fields: readonly (string | number)[]) => Promise<string>;
-  readonly prepareFile: (artifact: ImportArtifact) => Promise<PrepareFileResult>;
+  readonly prepareFile: (
+    artifact: ImportArtifact,
+    repairSettings: RepairFixerSettings,
+  ) => Promise<PrepareFileResult>;
   readonly canonicalPick: (group: LogicalSessionGroup) => CanonicalPickResult;
   readonly materializeClusterInTransaction: (store: SqlStore, cluster: PlannedCluster) => Promise<void>;
   readonly ingestVersion: typeof FIT_INGEST_VERSION;

--- a/packages/kernel/src/ingest/repair/chain.ts
+++ b/packages/kernel/src/ingest/repair/chain.ts
@@ -1,7 +1,15 @@
 import { chronoBridge, CHRONO_BRIDGE_PARAMS } from "./chrono-bridge.js";
 import { pulseWeave, PULSE_WEAVE_PARAMS } from "./pulse-weave.js";
 import { summitGuard, SUMMIT_GUARD_PARAMS } from "./summit-guard.js";
-import type { CanonicalRepairStream, RepairChainResult } from "./types.js";
+import {
+  DEFAULT_REPAIR_FIXER_SETTINGS,
+  cloneValidatedRepairStream,
+  normalizeRepairFixerSettings,
+  type CanonicalRepairStream,
+  type RepairChainResult,
+  type RepairFixerSettings,
+  type RepairInvocationLog,
+} from "./types.js";
 
 export const REPAIR_CHAIN_SLOTS = Object.freeze([
   Object.freeze({ slot: "010", fixer: "chronoBridge" }),
@@ -12,16 +20,27 @@ export const REPAIR_CHAIN_SLOTS = Object.freeze([
   Object.freeze({ slot: "060", fixer: null, reserved: "reserved-w5c-c" }),
 ] as const);
 
-export function runRepairChain(stream: CanonicalRepairStream): RepairChainResult {
-  const chrono = chronoBridge(stream);
-  const summit = summitGuard(chrono.stream);
-  const pulse = pulseWeave(summit.stream);
-  return {
-    stream: pulse.stream,
-    logs: [
-      { fixer: "chronoBridge", params: CHRONO_BRIDGE_PARAMS, changes: chrono.changes },
-      { fixer: "summitGuard", params: SUMMIT_GUARD_PARAMS, changes: summit.changes },
-      { fixer: "pulseWeave", params: PULSE_WEAVE_PARAMS, changes: pulse.changes },
-    ],
-  };
+export function runRepairChain(
+  stream: CanonicalRepairStream,
+  settings: RepairFixerSettings = DEFAULT_REPAIR_FIXER_SETTINGS,
+): RepairChainResult {
+  const effective = normalizeRepairFixerSettings(settings);
+  let current = cloneValidatedRepairStream(stream);
+  const logs: RepairInvocationLog[] = [];
+  if (effective.chronoBridge) {
+    const result = chronoBridge(current);
+    current = result.stream;
+    logs.push({ fixer: "chronoBridge", params: CHRONO_BRIDGE_PARAMS, changes: result.changes });
+  }
+  if (effective.summitGuard) {
+    const result = summitGuard(current);
+    current = result.stream;
+    logs.push({ fixer: "summitGuard", params: SUMMIT_GUARD_PARAMS, changes: result.changes });
+  }
+  if (effective.pulseWeave) {
+    const result = pulseWeave(current);
+    current = result.stream;
+    logs.push({ fixer: "pulseWeave", params: PULSE_WEAVE_PARAMS, changes: result.changes });
+  }
+  return { stream: current, logs };
 }

--- a/packages/kernel/src/ingest/repair/types.ts
+++ b/packages/kernel/src/ingest/repair/types.ts
@@ -17,6 +17,64 @@ export interface RepairStageResult {
 
 export type RepairFixer = "chronoBridge" | "summitGuard" | "pulseWeave";
 
+export const REPAIR_FIXERS = Object.freeze([
+  "chronoBridge",
+  "summitGuard",
+  "pulseWeave",
+] as const);
+
+export interface RepairFixerSettings {
+  readonly chronoBridge: boolean;
+  readonly summitGuard: boolean;
+  readonly pulseWeave: boolean;
+}
+
+export const DEFAULT_REPAIR_FIXER_SETTINGS: RepairFixerSettings = Object.freeze({
+  chronoBridge: false,
+  summitGuard: false,
+  pulseWeave: false,
+});
+
+export const ALL_REPAIR_FIXERS_ENABLED: RepairFixerSettings = Object.freeze({
+  chronoBridge: true,
+  summitGuard: true,
+  pulseWeave: true,
+});
+
+export function normalizeRepairFixerSettings(value: unknown): RepairFixerSettings {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new TypeError("invalid repair fixer settings");
+  }
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) {
+    throw new TypeError("invalid repair fixer settings");
+  }
+  const ownKeys = Reflect.ownKeys(value);
+  if (ownKeys.length !== REPAIR_FIXERS.length || ownKeys.some((key) => typeof key !== "string")
+    || REPAIR_FIXERS.some((fixer) => !Object.prototype.hasOwnProperty.call(value, fixer))) {
+    throw new TypeError("invalid repair fixer settings");
+  }
+  const descriptors = Object.getOwnPropertyDescriptors(value);
+  const settings: Record<RepairFixer, boolean> = {
+    chronoBridge: false,
+    summitGuard: false,
+    pulseWeave: false,
+  };
+  for (const fixer of REPAIR_FIXERS) {
+    const descriptor = descriptors[fixer];
+    if (descriptor === undefined || !descriptor.enumerable || !("value" in descriptor)
+      || typeof descriptor.value !== "boolean") {
+      throw new TypeError("invalid repair fixer settings");
+    }
+    settings[fixer] = descriptor.value;
+  }
+  return Object.freeze({
+    chronoBridge: settings.chronoBridge,
+    summitGuard: settings.summitGuard,
+    pulseWeave: settings.pulseWeave,
+  });
+}
+
 export interface RepairInvocationLog {
   readonly fixer: RepairFixer;
   readonly params: Readonly<Record<string, unknown>>;

--- a/packages/kernel/src/ingest/types.ts
+++ b/packages/kernel/src/ingest/types.ts
@@ -1,7 +1,7 @@
 import type { ActivityRows } from "../store/activity-repository.js";
 import type { RawFileRow } from "../store/ports.js";
 
-export const FIT_INGEST_VERSION = 3 as const;
+export const FIT_INGEST_VERSION = 4 as const;
 
 export type FitSourceErrorCode =
   | "decode_failed"

--- a/packages/kernel/src/store/dump.ts
+++ b/packages/kernel/src/store/dump.ts
@@ -18,6 +18,7 @@ export const DUMP_TABLES = [
   { table: "pool_size_correction_overlay", orderBy: "id" },
   { table: "race_goal", orderBy: "id" },
   { table: "raw_file", orderBy: "sha256" },
+  { table: "repair_fixer_settings", orderBy: "fixer" },
   { table: "repair_log", orderBy: "repair_key" },
   { table: "session", orderBy: "session_key" },
   { table: "source_record", orderBy: "id" },

--- a/packages/kernel/src/store/migrations/004_repair_fixer_settings.sql
+++ b/packages/kernel/src/store/migrations/004_repair_fixer_settings.sql
@@ -1,0 +1,5 @@
+CREATE TABLE repair_fixer_settings (
+  fixer TEXT PRIMARY KEY
+    CHECK (fixer IN ('chronoBridge','summitGuard','pulseWeave')),
+  enabled INTEGER NOT NULL CHECK (enabled = 1)
+) STRICT;

--- a/packages/kernel/src/store/migrations/index.ts
+++ b/packages/kernel/src/store/migrations/index.ts
@@ -1,6 +1,7 @@
 import init001 from "./001_init.sql";
 import sql from "./002_repair_log.sql";
 import dedup003 from "./003_dedup_confirmation.sql";
+import fixerSettings004 from "./004_repair_fixer_settings.sql";
 
 export interface Migration {
   /** Ascending schema version this migration advances the store to. */
@@ -19,4 +20,5 @@ export const MIGRATIONS: readonly Migration[] = [
   { version: 1, name: "001_init", sql: init001 },
   {version:2,name:'002_repair_log',sql},
   { version: 3, name: "003_dedup_confirmation", sql: dedup003 },
+  { version: 4, name: "004_repair_fixer_settings", sql: fixerSettings004 },
 ];

--- a/packages/kernel/tests/dedup-inv2.test.ts
+++ b/packages/kernel/tests/dedup-inv2.test.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { describe, expect, it } from "vitest";
 import { canonicalPick, createMaterializeClusterInTransaction, decodeStream, importArtifactsWithReport, type Candidate,
-  type ConcernValue, type ImportArtifact, type PlatformImportArtifact, type PrepareFileResult } from "../src/ingest/index.js";
+  type ConcernValue, type ImportArtifact, type PlatformImportArtifact, type PreparedFile, type PrepareFileResult } from "../src/ingest/index.js";
 import type { ArchiveManager } from "../src/archive/index.js";
 import { DERIVED_TABLES, sortKeys, type DedupConfirmationRow, type Row, type SourceRecordRow, type SqlStore, type SqlValue } from "../src/store/index.js";
 
@@ -65,6 +65,7 @@ class MemoryStore implements SqlStore {
     if (sql.includes("FROM source_record") && sql.includes("ORDER BY id")) return [...this.source.values()] as unknown as Row[];
     if (sql.includes("FROM dedup_confirmation")) return this.confirmations as unknown as Row[];
     if (sql.includes("FROM sport_settings")) return [];
+    if (sql.includes("FROM repair_fixer_settings")) return [];
     if (sql.includes("FROM workout")) return [];
     if (sql.includes("FROM stroke_correction_overlay")) {
       if (this.failOrphans) throw new Error("orphan enumeration failed");
@@ -122,7 +123,7 @@ function deps(store: MemoryStore, rawArchive: ReturnType<typeof archive>, materi
   const groups: Candidate[][] = [];
   return { groups, value: { archive: rawArchive, store, hashKey, prepareFile: async (artifact: ImportArtifact) => prepared(artifact),
     canonicalPick(group: Parameters<typeof canonicalPick>[0]) { groups.push([...group.candidates]); return canonicalPick(group); },
-    materializeClusterInTransaction: async () => { store.events.push("materialize"); await materialize(); }, ingestVersion: 3 as const } };
+    materializeClusterInTransaction: async () => { store.events.push("materialize"); await materialize(); }, ingestVersion: 4 as const } };
 }
 
 describe("global replan invariant", () => {
@@ -182,13 +183,14 @@ describe("global replan invariant", () => {
       { id: "stroke", target_kind: "stroke_correction_overlay:swim_length", target_key: "missing-length", reason: "target_missing_after_rekey" },
     ]);
   });
-  it("[PR05-INV2-007] owns one outer transaction and passes atomic concerns to materialization", async () => {
+  it("[PR05-INV2-007] owns one outer transaction and passes atomic concerns to materialization with empty PreparedRepairEvent carry", async () => {
     const store = new MemoryStore(), a = archive(), d = deps(store, a);
     const materialize = createMaterializeClusterInTransaction(hashKey);
     const selectedTime = { timestamps: [1_000, 1_050, 1_100], values: [1_000, 1_050, 1_100] };
     const selectedPower = { timestamps: [1_000, 1_050, 1_100], values: [101, 202, 303] };
     const lowerTime = { timestamps: [1_001, 1_051, 1_101], values: [1_001, 1_051, 1_101] };
     const lowerPower = { timestamps: [1_001, 1_051, 1_101], values: [901, 902, 903] };
+    const preparedRepairEvents: PreparedFile["repair_events"][] = [];
     const competingPrepared = (artifact: ImportArtifact): PrepareFileResult => {
       const result = prepared(artifact);
       if (result.outcome !== "prepared") throw new Error("fixture preparation failed");
@@ -203,8 +205,10 @@ describe("global replan invariant", () => {
         concerns: { ...baseCandidate.concerns, "stream:time": selected ? selectedTime : lowerTime,
           "stream:power": selected ? selectedPower : lowerPower },
       };
-      return { outcome: "prepared", value: { ...result.value, candidates: [candidate], summaries: [{ ...baseSummary,
-        candidate_id: candidate.id, source_kind: artifact.ext }] } };
+      const value = { ...result.value, candidates: [candidate], summaries: [{ ...baseSummary,
+        candidate_id: candidate.id, source_kind: artifact.ext }] };
+      preparedRepairEvents.push(value.repair_events);
+      return { outcome: "prepared", value };
     };
     await importArtifactsWithReport({ files: [
       { input_path: "selected.fit", bytes: new Uint8Array([1]), ext: "fit" },
@@ -222,6 +226,8 @@ describe("global replan invariant", () => {
     expect(store.streamWrites.map(({ channel, n }) => ({ channel, n }))).toEqual([
       { channel: "time", n: 3 }, { channel: "power", n: 3 },
     ]);
+    expect(preparedRepairEvents).toEqual([[], []]);
+    expect(store.events.filter((event) => event === "insert:repair_log")).toEqual([]);
     const persisted = (channel: "time" | "power") => {
       const row = store.streamWrites.find((entry) => entry.channel === channel);
       if (!row) throw new Error(`missing persisted ${channel} stream`);
@@ -257,6 +263,6 @@ describe("global replan invariant", () => {
   it("[PR05-INV2-008] upgrades old metadata and reports the current code version", async () => {
     const store = new MemoryStore(); store.metadata = 0; const a = archive(), d = deps(store, a);
     const value = await importArtifactsWithReport({ files: [{ input_path: "a.fit", bytes: new Uint8Array([1]), ext: "fit" }], platform_records: [] }, d.value);
-    expect(value.ingest_version).toBe(3); expect(store.metadata).toBe(3);
+    expect(value.ingest_version).toBe(4); expect(store.metadata).toBe(4);
   });
 });

--- a/packages/kernel/tests/fit-row-mapper.test.ts
+++ b/packages/kernel/tests/fit-row-mapper.test.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { describe, expect, it } from "vitest";
 import type { CryptoPort } from "../src/ports/crypto.js";
-import { FitSourceError, mapFitArtifact, type DecodedActivity, type DecodedFitFile, type DecodedLap, type DecodedLength, type DecodedRecord, type DecodedSession } from "../src/ingest/index.js";
+import { ALL_REPAIR_FIXERS_ENABLED, FitSourceError, mapFitArtifact, type DecodedActivity, type DecodedFitFile, type DecodedLap, type DecodedLength, type DecodedRecord, type DecodedSession, type RepairFixerSettings } from "../src/ingest/index.js";
 import { decodeStream } from "../src/ingest/stream-codec.js";
 
 const crypto:CryptoPort={async sha256(d){return new Uint8Array(createHash("sha256").update(d).digest())},async randomBytes(){throw new Error("unused")},async pbkdf2(){throw new Error("unused")},async aesGcmEncrypt(){throw new Error("unused")},async aesGcmDecrypt(){throw new Error("unused")}};
@@ -10,7 +10,7 @@ const record=(sourceIndex:number,timestamp:number,overrides:Partial<DecodedRecor
 const lap=(sourceIndex:number,overrides:Partial<DecodedLap>={}):DecodedLap=>({sourceIndex,startTime:1000,timestamp:1001,firstLengthIndex:null,numLengths:null,numActiveLengths:null,totalElapsedTime:1,totalTimerTime:1,totalDistance:25,developerFields:[],...overrides});
 const length=(sourceIndex:number,overrides:Partial<DecodedLength>={}):DecodedLength=>({sourceIndex,startTime:1000,timestamp:1001,totalElapsedTime:1,totalTimerTime:1,totalStrokes:10,swimStroke:"freestyle",lengthType:"active",...overrides});
 const decoded=(sessions:DecodedSession[],records:DecodedRecord[],overrides:Partial<DecodedFitFile>={}):DecodedFitFile=>({fileIds:[{serialNumber:1,timeCreated:900,manufacturer:"development",product:1,productName:null}],activity:null,sessions,laps:[],lengths:[],records,events:[],developerDataIds:[],...overrides});
-const map=(d:DecodedFitFile)=>mapFitArtifact({crypto,rawSha256:"01".repeat(32),rawByteLength:10,archivePath:null,decoded:d});
+const map=(d:DecodedFitFile,repairSettings?:RepairFixerSettings)=>mapFitArtifact({crypto,rawSha256:"01".repeat(32),rawByteLength:10,archivePath:null,decoded:d,repairSettings});
 const error=async(promise:Promise<unknown>,code:string)=>expect(promise).rejects.toMatchObject({code});
 
 describe("FIT row mapper",()=>{
@@ -44,7 +44,22 @@ describe("FIT row mapper",()=>{
     const sessions=[session(0,0,3,{sport:"swimming",subSport:"open_water",trigger:2}),session(1,3,5,{sport:"transition",trigger:2}),session(2,5,9,{sport:"cycling",trigger:2}),session(3,9,11,{sport:"transition",trigger:2}),session(4,11,14,{sport:"running",trigger:0})];
     const times=[0,1,2,3,4,5,6,7,8,9,10,11,12,14];const out=await map(decoded(sessions,times.map((t,i)=>record(i,t))));
     const timeRows=out.activity.streams.filter((s)=>s.channel==="time").sort((a,b)=>out.activity.sessions.findIndex((x)=>x.session_key===a.session_key)-out.activity.sessions.findIndex((x)=>x.session_key===b.session_key));
-    expect(timeRows.map((s)=>s.n)).toEqual([3,2,4,2,4]);expect(out.activity.sessions.filter((s)=>s.is_transition).map((s)=>s.session_seq)).toEqual([1,3]);
+    expect(timeRows.map((s)=>s.n)).toEqual([3,2,4,2,3]);expect(out.activity.sessions.filter((s)=>s.is_transition).map((s)=>s.session_seq)).toEqual([1,3]);
+  });
+  it("keeps repair-producing streams unchanged by default and repairs them when all fixers are on",async()=>{
+    const source=decoded([session(0,0,3,{totalElapsedTime:3})],[record(0,0,{power:100}),record(1,3,{power:130})]);
+    const off=await map(source);
+    const offTime=off.activity.streams.find((row)=>row.channel==="time")!;
+    const offPower=off.activity.streams.find((row)=>row.channel==="power")!;
+    expect(decodeStream({...offTime,kind:"time"})).toEqual([0,3]);
+    expect(decodeStream({...offPower,kind:"value"})).toEqual([100,130]);
+    expect(off.activity.repairLogs).toEqual([]);
+    const on=await map(source,ALL_REPAIR_FIXERS_ENABLED);
+    const onTime=on.activity.streams.find((row)=>row.channel==="time")!;
+    const onPower=on.activity.streams.find((row)=>row.channel==="power")!;
+    expect(decodeStream({...onTime,kind:"time"})).toEqual([0,1,2,3]);
+    expect(decodeStream({...onPower,kind:"value"})).toEqual([100,110,120,130]);
+    expect(on.activity.repairLogs.length).toBeGreaterThan(0);
   });
   it("uses positive elapsed time for a single-session zero-width source range",async()=>{
     const source=session(0,0,0,{totalElapsedTime:1.1});

--- a/packages/kernel/tests/import-report.test.ts
+++ b/packages/kernel/tests/import-report.test.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { describe, expect, it } from "vitest";
 import { canonicalPick, DEFAULT_TIER3_THRESHOLDS, DEFAULT_TRANSITION_WINDOW_S, importArtifactsWithReport,
-  serializeImportReport, type Candidate, type ImportArtifact, type PrepareFileResult } from "../src/ingest/index.js";
+  serializeImportReport, type Candidate, type ImportArtifact, type PrepareFileResult, type RepairFixerSettings } from "../src/ingest/index.js";
 import type { ArchiveManager } from "../src/archive/index.js";
 import type { DedupConfirmationRow, Row, SqlStore, SqlValue } from "../src/store/index.js";
 
@@ -35,6 +35,7 @@ class ReportStore implements SqlStore {
     if (sql.startsWith("SELECT singleton")) return [{ singleton: 1, ingest_version: this.metadata }];
     if (sql.includes("FROM raw_file") && sql.includes("ORDER BY sha256")) return [...this.raw.values()].sort((a, b) => String(a.sha256).localeCompare(String(b.sha256)));
     if (sql.includes("FROM dedup_confirmation")) return this.confirmations as unknown as Row[];
+    if (sql.includes("FROM repair_fixer_settings")) return [];
     if (sql.includes("FROM stroke_correction_overlay")) return this.strokeOverlays;
     if (sql.includes("FROM pool_size_correction_overlay")) return this.poolOverlays;
     if (sql.includes("FROM field_merge_override_overlay")) return this.fieldOverlays;
@@ -85,8 +86,9 @@ function prepare(artifact: ImportArtifact): PrepareFileResult {
 }
 
 function harness(store = new ReportStore(), rawArchive = archive()) {
-  return { store, rawArchive, deps: { store, archive: rawArchive, hashKey, prepareFile: async (artifact: ImportArtifact) => prepare(artifact),
-    canonicalPick, materializeClusterInTransaction: async () => {}, ingestVersion: 3 as const } };
+  return { store, rawArchive, deps: { store, archive: rawArchive, hashKey,
+    prepareFile: async (artifact: ImportArtifact, _repairSettings: RepairFixerSettings) => prepare(artifact),
+    canonicalPick, materializeClusterInTransaction: async () => {}, ingestVersion: 4 as const } };
 }
 
 const file = (input_path: string, byte: number): ImportArtifact => ({ input_path, bytes: new Uint8Array([byte]), ext: "fit" });
@@ -168,7 +170,7 @@ describe("stable import report", () => {
     const { report } = await run([file("bad.fit", 0)]);
     const expected = `{
   "schema_version": 1,
-  "ingest_version": 3,
+  "ingest_version": 4,
   "effective": {
     "tier3": {
       "startSeconds": 120,
@@ -232,9 +234,9 @@ describe("stable import report", () => {
     ]);
     expect(report.inserts.raw_file).toBe(1);
   });
-  it("[PR05-REPORT-007] carries quarantine, defaults, and ingest version three", async () => {
+  it("[PR05-REPORT-007] carries quarantine, defaults, and ingest version four", async () => {
     const { report } = await run([file("bad.fit", 0)]);
-    expect(report).toMatchObject({ ingest_version: 3, effective: { tier3: DEFAULT_TIER3_THRESHOLDS,
+    expect(report).toMatchObject({ ingest_version: 4, effective: { tier3: DEFAULT_TIER3_THRESHOLDS,
       transition_window_s: DEFAULT_TRANSITION_WINDOW_S } });
     expect(report.files[0]).toMatchObject({ outcome: "quarantined", raw_file_inserted: false,
       quarantine: { code: "fit:decode_failed", message: "rejected" } });

--- a/packages/kernel/tests/migrations-ddl.test.ts
+++ b/packages/kernel/tests/migrations-ddl.test.ts
@@ -25,7 +25,7 @@ const EXPECTED_TABLES = [
   "field_merge_override_overlay",
   "pool_size_correction_overlay",
 ];
-const EXPECTED_FULL_TABLES = [...EXPECTED_TABLES, "ingest_metadata", "repair_log", "dedup_confirmation"];
+const EXPECTED_FULL_TABLES = [...EXPECTED_TABLES, "ingest_metadata", "repair_log", "dedup_confirmation", "repair_fixer_settings"];
 const MIGRATION_002 = `ALTER TABLE swim_length ADD COLUMN distance_m REAL;
 
 CREATE TABLE ingest_metadata (
@@ -79,6 +79,12 @@ CREATE INDEX idx_dedup_confirmation_effective
     id DESC
   );
 `;
+const MIGRATION_004 = `CREATE TABLE repair_fixer_settings (
+  fixer TEXT PRIMARY KEY
+    CHECK (fixer IN ('chronoBridge','summitGuard','pulseWeave')),
+  enabled INTEGER NOT NULL CHECK (enabled = 1)
+) STRICT;
+`;
 
 const EXPECTED_INDEXES = [
   "idx_anchor_history_current",
@@ -118,6 +124,7 @@ function openFull(): DatabaseSync {
   const next = openMigrated();
   next.exec(MIGRATIONS[1]!.sql);
   next.exec(MIGRATIONS[2]!.sql);
+  next.exec(MIGRATIONS[3]!.sql);
   return next;
 }
 
@@ -128,7 +135,7 @@ afterEach(() => {
 
 describe("001_init migration", () => {
   it("wires the ordered migration list with real inlined SQL", () => {
-    expect(MIGRATIONS.map(({version,name})=>({version,name}))).toEqual([{version:1,name:"001_init"},{version:2,name:"002_repair_log"},{version:3,name:"003_dedup_confirmation"}]);
+    expect(MIGRATIONS.map(({version,name})=>({version,name}))).toEqual([{version:1,name:"001_init"},{version:2,name:"002_repair_log"},{version:3,name:"003_dedup_confirmation"},{version:4,name:"004_repair_fixer_settings"}]);
     expect(typeof MIGRATIONS[0].sql).toBe("string");
     expect(MIGRATIONS[0].sql).toContain("CREATE TABLE athlete");
   });
@@ -235,11 +242,25 @@ describe("001_init migration", () => {
     expect(MIGRATIONS[2]!.sql).toBe(MIGRATION_003);
   });
 
-  it("applies 001 through 003 with exactly twenty-three tables and no foreign-key violations", () => {
+  it("applies 001 through 004 with exactly twenty-four tables and no foreign-key violations", () => {
     db = openFull();
     const names = (db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'").all() as Array<{name:string}>).map((row)=>row.name).sort();
     expect(names).toEqual([...EXPECTED_FULL_TABLES].sort());
     expect(db.prepare("PRAGMA foreign_key_check").all()).toEqual([]);
+  });
+
+  it("preserves migration 004 and creates strict sparse fixer settings with exact constraints", () => {
+    expect(MIGRATIONS[3]!.sql).toBe(MIGRATION_004);
+    db = openFull();
+    expect(db.prepare("SELECT fixer,enabled FROM repair_fixer_settings ORDER BY fixer").all()).toEqual([]);
+    expect(db.prepare("PRAGMA foreign_key_list(repair_fixer_settings)").all()).toEqual([]);
+    const tables = db.prepare("PRAGMA table_list").all() as Array<{name:string;strict:number}>;
+    expect(tables.find((row)=>row.name==="repair_fixer_settings")?.strict).toBe(1);
+    for (const fixer of ["chronoBridge","summitGuard","pulseWeave"]) {
+      expect(()=>db!.prepare("INSERT INTO repair_fixer_settings(fixer,enabled) VALUES(?,1)").run(fixer)).not.toThrow();
+    }
+    expect(()=>db!.prepare("INSERT INTO repair_fixer_settings(fixer,enabled) VALUES('unknown',1)").run()).toThrow();
+    expect(()=>db!.prepare("UPDATE repair_fixer_settings SET enabled=0 WHERE fixer='chronoBridge'").run()).toThrow();
   });
 
   it("creates strict append-only confirmation history with canonical ASCII pairs and descending effective index", () => {

--- a/packages/kernel/tests/repair-chain.test.ts
+++ b/packages/kernel/tests/repair-chain.test.ts
@@ -1,13 +1,16 @@
 import fc from "fast-check";
 import { describe, expect, it } from "vitest";
 import {
+  ALL_REPAIR_FIXERS_ENABLED,
   CHRONO_BRIDGE_PARAMS,
+  DEFAULT_REPAIR_FIXER_SETTINGS,
   PULSE_WEAVE_PARAMS,
   REPAIR_CHAIN_SLOTS,
   SUMMIT_GUARD_PARAMS,
   averageFinite,
   chronoBridge,
   pulseWeave,
+  normalizeRepairFixerSettings,
   runRepairChain,
   summitGuard,
   summitGuardSweep,
@@ -24,6 +27,90 @@ const finitePresent = (stream: CanonicalRepairStream) =>
   stream.time.every(Number.isFinite) && Object.values(stream.channels).every((values) => values.every((value) => value === null || Number.isFinite(value)));
 
 describe("deterministic repair chain", () => {
+  it("defaults all fixers off and gates partial settings", () => {
+    const stream = {
+      time: [0, 1, 2, 3, 4, 5, 6],
+      channels: {
+        heart_rate: [100, 0, 0, 103, 104, 105, 106],
+        power: [100, 100, 100, 1000, 100, 100, 100],
+      },
+    };
+    const off = runRepairChain(stream);
+    expect(off).toEqual({ stream, logs: [] });
+    expect(off.stream).not.toBe(stream);
+    expect(off.stream.time).not.toBe(stream.time);
+    expect(off.stream.channels.power).not.toBe(stream.channels.power);
+    expect(DEFAULT_REPAIR_FIXER_SETTINGS).toEqual({
+      chronoBridge: false,
+      summitGuard: false,
+      pulseWeave: false,
+    });
+    for (const fixer of ["chronoBridge", "summitGuard", "pulseWeave"] as const) {
+      const result = runRepairChain(stream, {
+        chronoBridge: fixer === "chronoBridge",
+        summitGuard: fixer === "summitGuard",
+        pulseWeave: fixer === "pulseWeave",
+      });
+      expect(result.logs.map((log) => log.fixer)).toEqual([fixer]);
+    }
+  });
+
+  it("all-on matches the former composition byte for byte", () => {
+    const stream = {
+      time: [0, 3, 4, 5, 6, 7, 8, 9],
+      channels: {
+        heart_rate: [100, 130, 0, 0, 133, 134, 135, 136],
+        power: [100, 130, 100, 100, 1000, 100, 100, 100],
+      },
+    };
+    const chrono = chronoBridge(stream);
+    const summit = summitGuard(chrono.stream);
+    const pulse = pulseWeave(summit.stream);
+    expect(runRepairChain(stream, ALL_REPAIR_FIXERS_ENABLED)).toEqual({
+      stream: pulse.stream,
+      logs: [
+        { fixer: "chronoBridge", params: CHRONO_BRIDGE_PARAMS, changes: chrono.changes },
+        { fixer: "summitGuard", params: SUMMIT_GUARD_PARAMS, changes: summit.changes },
+        { fixer: "pulseWeave", params: PULSE_WEAVE_PARAMS, changes: pulse.changes },
+      ],
+    });
+  });
+
+  it("rejects exotic settings without invoking accessors", () => {
+    class Settings {
+      chronoBridge = false;
+      summitGuard = false;
+      pulseWeave = false;
+    }
+    const missing = { chronoBridge: false, summitGuard: false };
+    const extra = { ...DEFAULT_REPAIR_FIXER_SETTINGS, extra: false };
+    const symbolic = { ...DEFAULT_REPAIR_FIXER_SETTINGS, [Symbol("extra")]: false };
+    const nonEnumerable = { ...DEFAULT_REPAIR_FIXER_SETTINGS };
+    Object.defineProperty(nonEnumerable, "pulseWeave", { value: false, enumerable: false });
+    const wrong = { ...DEFAULT_REPAIR_FIXER_SETTINGS, pulseWeave: 0 };
+    let getterCalls = 0;
+    const accessor = { ...DEFAULT_REPAIR_FIXER_SETTINGS };
+    Object.defineProperty(accessor, "pulseWeave", {
+      enumerable: true,
+      get() { getterCalls += 1; return false; },
+    });
+    for (const invalid of [null, [], new Settings(), missing, extra, symbolic, nonEnumerable, wrong, accessor]) {
+      expect(() => normalizeRepairFixerSettings(invalid)).toThrow(new TypeError("invalid repair fixer settings"));
+    }
+    expect(getterCalls).toBe(0);
+    const accepted = Object.assign(Object.create(null) as Record<string, boolean>, {
+      chronoBridge: true,
+      summitGuard: false,
+      pulseWeave: true,
+    });
+    const normalized = normalizeRepairFixerSettings(accepted);
+    expect(Object.keys(normalized)).toEqual(["chronoBridge", "summitGuard", "pulseWeave"]);
+    expect(Object.getPrototypeOf(normalized)).toBe(Object.prototype);
+    expect(Object.isFrozen(normalized)).toBe(true);
+    expect(normalized).toEqual({ chronoBridge: true, summitGuard: false, pulseWeave: true });
+    expect(normalized).not.toBe(accepted);
+  });
+
   it("chronoBridge interpolates the pinned example and safely crosses maximum finite opposites", () => {
     expect(chronoBridge({ time: [0, 3], channels: { power: [100, 130], speed: [10, 13], heart_rate: [100, 103] } }).stream).toEqual({
       time: [0, 1, 2, 3], channels: { heart_rate: [100, 101, 102, 103], power: [100, 110, 120, 130], speed: [10, 11, 12, 13] },
@@ -199,10 +286,10 @@ describe("deterministic repair chain", () => {
   it("keeps the composed chain pure, finite, scalar-ordered, and deeply idempotent", { timeout: 30_000 }, () => {
     fc.assert(fc.property(canonicalRepairStreamArbitrary, (stream) => {
       const before = structuredClone(stream);
-      const once = runRepairChain(stream);
+      const once = runRepairChain(stream, ALL_REPAIR_FIXERS_ENABLED);
       expect(stream).toEqual(before);
       expect(finitePresent(once.stream)).toBe(true);
-      expect(runRepairChain(once.stream).stream).toEqual(once.stream);
+      expect(runRepairChain(once.stream, ALL_REPAIR_FIXERS_ENABLED).stream).toEqual(once.stream);
       expect(once.logs).toHaveLength(3);
       expect(once.logs[0]!.changes.map((change) => change.channel)).toEqual(["time", "cadence", "heart_rate", "power", "speed"]);
     }), { numRuns: 1000 });


### PR DESCRIPTION
## Summary

Adds opt-in settings for the ingest repair-fixer chain, shipping **default OFF** per the W2 close-out containment ruling, plus a deterministic derived-data rebuild path when settings change.

- New authored table `repair_fixer_settings` (migration 004, STRICT, singleton-guarded) with per-fixer enable flags; included in the dump inventory as an authored table.
- `repair/types.ts` gains the settings contract; `repair/chain.ts` consults it and skips disabled fixers deterministically.
- `dedup-rekey.ts` extended so a settings flip triggers a deterministic rebuild of derived rows instead of leaving stale repair output in place.
- Import report and FIT row mapper record which fixers were active for each run.
- New `repair-fixer-settings.test.ts` (settings CRUD, default-OFF behavior, rebuild determinism) plus updates across ingest/migration/dedup suites; full workspace suite green (3657 tests) on this exact commit.

## Test plan

- `pnpm -r build && pnpm test` green at the base SHA this branch forks from.
- CI on this PR re-runs the full suite.
