### PR TITLE
feat(kernel): add sync source contract and state

### DIFF
--- a/.changeset/sync-source-contract.md
+++ b/.changeset/sync-source-contract.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/kernel": patch
+---
+
+Add the sync-source contract, deterministic source revision state, and opt-in Retry-After lower-bound handling while preserving existing capped retries. Internal infrastructure; ships nothing to athletes.

--- a/packages/kernel-node/tests/coach-dev-import.test.ts
+++ b/packages/kernel-node/tests/coach-dev-import.test.ts
@@ -383,7 +383,7 @@ function injected(options: InjectedOptions = {}) {
       calls.push("migrate");
       observed.migrations = migrations;
       fail("migrate");
-      return { fromVersion: 0, toVersion: 4, applied: [1, 2, 3, 4] };
+      return { fromVersion: 0, toVersion: 5, applied: [1, 2, 3, 4, 5] };
     },
     async importFilesWithReport(value: {
       readonly inputPaths: readonly string[];
@@ -472,7 +472,7 @@ describe("coach-dev import --report", () => {
     expect(await exists(databasePath)).toBe(true);
     const store = openSqliteStorage(databasePath);
     try {
-      expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 4 });
+      expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 5 });
       expect(await store.get("SELECT count(*) AS c FROM raw_file")).toEqual({ c: 1 });
       expect(await store.get("SELECT count(*) AS c FROM source_record")).toEqual({ c: 0 });
       expect(

--- a/packages/kernel-node/tests/migrator-e2e.test.ts
+++ b/packages/kernel-node/tests/migrator-e2e.test.ts
@@ -28,9 +28,9 @@ describe("migrator end-to-end over node:sqlite", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
-  it("applies the full migration list and advances user_version to 4", async () => {
+  it("applies the full migration list and advances user_version to 5", async () => {
     await runMigrations(store, MIGRATIONS);
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 4 });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 5 });
 
     const tables = await store.all("SELECT name FROM sqlite_master WHERE type='table'");
     const names = new Set(tables.map((r) => r.name as string));
@@ -39,11 +39,17 @@ describe("migrator end-to-end over node:sqlite", () => {
     }
 
     expect(await store.all("PRAGMA foreign_key_check")).toEqual([]);
-    expect(await store.all("SELECT fixer,enabled FROM repair_fixer_settings ORDER BY fixer")).toEqual([]);
-    expect(await store.get("SELECT name FROM sqlite_master WHERE type='index' AND name='idx_dedup_confirmation_effective'")).toEqual({ name: "idx_dedup_confirmation_effective" });
+    expect(
+      await store.all("SELECT fixer,enabled FROM repair_fixer_settings ORDER BY fixer"),
+    ).toEqual([]);
+    expect(
+      await store.get(
+        "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_dedup_confirmation_effective'",
+      ),
+    ).toEqual({ name: "idx_dedup_confirmation_effective" });
     expect(await store.get("PRAGMA journal_mode")).toEqual({ journal_mode: "wal" });
     await runMigrations(store, MIGRATIONS);
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 4 });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 5 });
   });
 
   it("produces a deterministic INV-2 dump of a fixed state", async () => {
@@ -72,20 +78,71 @@ describe("migrator end-to-end over node:sqlite", () => {
     expect(await dumpStore(store)).toBe(dump);
   });
 
-  it("upgrades a version-1-on-disk store to version 4", async () => {
+  it("upgrades a version-1-on-disk store to version 5", async () => {
     await runMigrations(store, [MIGRATIONS[0]!]);
-    expect(await store.get("PRAGMA user_version")).toEqual({user_version:1});
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 1 });
     await runMigrations(store, MIGRATIONS);
-    expect(await store.get("PRAGMA user_version")).toEqual({user_version:4});
-    expect(await store.get("SELECT singleton,ingest_version FROM ingest_metadata")).toEqual({singleton:1,ingest_version:0});
-    expect(await store.all("SELECT fixer,enabled FROM repair_fixer_settings ORDER BY fixer")).toEqual([]);
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 5 });
+    expect(await store.get("SELECT singleton,ingest_version FROM ingest_metadata")).toEqual({
+      singleton: 1,
+      ingest_version: 0,
+    });
+    expect(
+      await store.all("SELECT fixer,enabled FROM repair_fixer_settings ORDER BY fixer"),
+    ).toEqual([]);
     expect(await store.all("PRAGMA foreign_key_check")).toEqual([]);
+  });
+
+  it("upgrades an existing version-4 store and backfills legacy source records", async () => {
+    await runMigrations(store, MIGRATIONS.slice(0, 4));
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 4 });
+    await store.run(
+      "INSERT INTO source_record(id,workout_key,session_key,source,external_id,raw_sha256,quality_rank,payload_json) VALUES(?,?,?,?,?,?,?,?)",
+      ["legacy-source", null, null, "intervals-icu", "42", null, 300, '{"v":1}'],
+    );
+
+    const result = await runMigrations(store, MIGRATIONS);
+    expect(result).toEqual({ fromVersion: 4, toVersion: 5, applied: [5] });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 5 });
+    expect(
+      await store.get("SELECT revision_id,source_record_id FROM source_record_revision"),
+    ).toEqual({
+      revision_id: "legacy-source",
+      source_record_id: "legacy-source",
+    });
+    expect(
+      await store.get("SELECT source_record_id,revision_id FROM source_record_current"),
+    ).toEqual({
+      source_record_id: "legacy-source",
+      revision_id: "legacy-source",
+    });
+    expect(await store.all("PRAGMA foreign_key_check")).toEqual([]);
+  });
+
+  it("rolls back an injected migration-005 failure to version 4 without 005 objects", async () => {
+    await runMigrations(store, MIGRATIONS.slice(0, 4));
+    const broken005 = {
+      ...MIGRATIONS[4]!,
+      sql: `${MIGRATIONS[4]!.sql}\nINSERT INTO missing_table VALUES (1);`,
+    };
+    await expect(runMigrations(store, [...MIGRATIONS.slice(0, 4), broken005])).rejects.toThrow();
+
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 4 });
+    const objects = await store.all(
+      "SELECT name FROM sqlite_master WHERE name IN ('source_artifact','source_record_revision','source_record_current','source_watermark','sync_operation')",
+    );
+    expect(objects).toEqual([]);
+    const columns = await store.all("PRAGMA table_info(source_record)");
+    expect(columns.some((row) => row.name === "artifact_key")).toBe(false);
   });
 
   it("shares one real transaction for exec + version bump (atomic rollback)", async () => {
     const migrations = [
       { version: 1, sql: "CREATE TABLE first_ok (a TEXT);" },
-      { version: 2, sql: "CREATE TABLE second_partial (a TEXT); INSERT INTO nonexistent VALUES (1);" },
+      {
+        version: 2,
+        sql: "CREATE TABLE second_partial (a TEXT); INSERT INTO nonexistent VALUES (1);",
+      },
     ];
     await expect(runMigrations(store, migrations)).rejects.toThrow();
 

--- a/packages/kernel/src/concurrency/retry.ts
+++ b/packages/kernel/src/concurrency/retry.ts
@@ -8,16 +8,16 @@
  *     backoff across the whole interval (rather than sleeping the full interval)
  *     de-correlates a herd of clients that would otherwise wake on identical
  *     schedules.
- *  2. POSITIVE-ONLY jitter when a server `Retry-After` hint is honored — the
- *     hint is a *lower bound*, so the sleep is `hint + jitter`, strictly never
- *     below the hint. Full jitter must NOT be applied to a server hint, or a
- *     client could retry before the server told it to.
+ *  2. POSITIVE-ONLY jitter when a server Retry-After hint is supplied. The
+ *     default "cap" mode preserves the existing caller ceiling after jitter.
+ *     Explicit "lower-bound" mode treats the hint as a true lower bound and
+ *     may exceed capMs. Full jitter is never applied to a server hint.
  *
  * `Math.random` is intentionally used here, and this is its only use in core
  * source — a single, contained jitter source.
  */
 
-/** Bounded additive spread (ms) layered on top of a honored server hint. */
+/** Bounded additive spread (ms) layered on top of a supplied server hint. */
 const RETRY_AFTER_JITTER_SPREAD_MS = 1_000;
 
 export interface RetryOptions {
@@ -25,7 +25,11 @@ export interface RetryOptions {
   attempts: number;
   /** Base backoff in ms before jitter (the schedule's first interval). */
   baseMs: number;
-  /** Hard ceiling for any single backoff in ms (applied before jitter). */
+  /**
+   * Ceiling for locally computed exponential backoff. In the default "cap"
+   * Retry-After mode it also caps a jittered server hint. A caller that
+   * explicitly selects "lower-bound" may wait longer than capMs.
+   */
   capMs: number;
   /** Decide whether a thrown error is retryable. */
   shouldRetry: (err: unknown, attempt: number) => boolean;
@@ -35,6 +39,12 @@ export interface RetryOptions {
    * (the hint is a lower bound — never sleep less than it).
    */
   retryAfterMs?: (err: unknown) => number | null;
+  /**
+   * How a valid server Retry-After hint interacts with capMs.
+   * Omitted/"cap" preserves the existing caller policy and caps the jittered
+   * hint. "lower-bound" preserves the full server hint and may exceed capMs.
+   */
+  retryAfterMode?: "cap" | "lower-bound";
   /** Visibility hook fired before each backoff sleep. */
   onRetry?: (info: { attempt: number; delayMs: number; err: unknown }) => void;
   /** Abortable backoff: an abort resolves the sleep early. */
@@ -85,13 +95,99 @@ function computeDelayMs(
 ): number {
   const hint = opts.retryAfterMs?.(err) ?? null;
   if (hint !== null) {
-    // Positive-only jitter: the server hint is a lower bound, never go below it.
-    const jittered = hint + random() * RETRY_AFTER_JITTER_SPREAD_MS;
-    return Math.min(jittered, opts.capMs);
+    if (!Number.isSafeInteger(hint) || hint < 0) {
+      throw new TypeError("invalid retry-after delay");
+    }
+    const mode = opts.retryAfterMode ?? "cap";
+    if (mode !== "cap" && mode !== "lower-bound") {
+      throw new TypeError("invalid retry-after mode");
+    }
+    const hintedDelayMs = hint + random() * RETRY_AFTER_JITTER_SPREAD_MS;
+    if (!Number.isFinite(hintedDelayMs) || hintedDelayMs > Number.MAX_SAFE_INTEGER) {
+      throw new TypeError("invalid retry-after delay");
+    }
+    return mode === "lower-bound" ? hintedDelayMs : Math.min(hintedDelayMs, opts.capMs);
   }
   const interval = Math.min(opts.baseMs * 2 ** (attempt - 1), opts.capMs);
   // Full jitter on the exponential schedule: uniform draw across [0, interval).
   return random() * interval;
+}
+
+const IMF_FIXDATE =
+  /^(Mon|Tue|Wed|Thu|Fri|Sat|Sun), ([0-9]{2}) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) ([0-9]{4}) ([0-9]{2}):([0-9]{2}):([0-9]{2}) GMT$/;
+const MONTHS = [
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+] as const;
+const WEEKDAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"] as const;
+
+function validateRetryClock(nowEpochMs: number): void {
+  if (!Number.isSafeInteger(nowEpochMs) || nowEpochMs < 0) {
+    throw new TypeError("invalid retry clock");
+  }
+}
+
+export function parseRetryAfterMs(value: string | null, nowEpochMs: number): number | null {
+  validateRetryClock(nowEpochMs);
+  const normalized = value?.replace(/^[\t ]+|[\t ]+$/g, "") ?? null;
+  if (normalized === null || normalized.length === 0) return null;
+
+  if (/^[0-9]+$/.test(normalized)) {
+    const seconds = Number.parseInt(normalized, 10);
+    const milliseconds = seconds * 1_000;
+    return Number.isSafeInteger(seconds) && Number.isSafeInteger(milliseconds)
+      ? milliseconds
+      : null;
+  }
+
+  const match = IMF_FIXDATE.exec(normalized);
+  if (match === null) return null;
+  const [, weekday, dayText, monthText, yearText, hourText, minuteText, secondText] = match;
+  const day = Number(dayText);
+  const month = MONTHS.indexOf(monthText as (typeof MONTHS)[number]);
+  const year = Number(yearText);
+  const hour = Number(hourText);
+  const minute = Number(minuteText);
+  const second = Number(secondText);
+  const parsedEpochMs = Date.UTC(year, month, day, hour, minute, second);
+  const parsed = new Date(parsedEpochMs);
+  if (
+    parsed.getUTCFullYear() !== year ||
+    parsed.getUTCMonth() !== month ||
+    parsed.getUTCDate() !== day ||
+    parsed.getUTCHours() !== hour ||
+    parsed.getUTCMinutes() !== minute ||
+    parsed.getUTCSeconds() !== second ||
+    WEEKDAYS[parsed.getUTCDay()] !== weekday
+  ) {
+    return null;
+  }
+  const difference = parsedEpochMs - nowEpochMs;
+  return Number.isSafeInteger(difference) ? Math.max(0, difference) : null;
+}
+
+export function retryAfterMsFromHeaders(
+  headers: Readonly<Record<string, string>>,
+  nowEpochMs: number,
+): number | null {
+  validateRetryClock(nowEpochMs);
+  const matches = Object.keys(headers).filter((key) => {
+    const asciiLower = key.replace(/[A-Z]/g, (character) =>
+      String.fromCharCode(character.charCodeAt(0) + 32),
+    );
+    return asciiLower === "retry-after";
+  });
+  return matches.length === 1 ? parseRetryAfterMs(headers[matches[0]!]!, nowEpochMs) : null;
 }
 
 function abortableSleep(ms: number, signal?: AbortSignal): Promise<void> {

--- a/packages/kernel/src/store/dump.ts
+++ b/packages/kernel/src/store/dump.ts
@@ -1,7 +1,16 @@
 import { canonicalRowJson } from "./canonical-json.js";
 import type { Row, SqlStore } from "./ports.js";
 
-export const DERIVED_TABLES = ["metric_snapshot", "mean_max_cache", "repair_log", "stream", "swim_length", "lap", "session", "workout"] as const;
+export const DERIVED_TABLES = [
+  "metric_snapshot",
+  "mean_max_cache",
+  "repair_log",
+  "stream",
+  "swim_length",
+  "lap",
+  "session",
+  "workout",
+] as const;
 
 /** Every current store table, alphabetical, with its content-derived order key. */
 export const DUMP_TABLES = [
@@ -21,7 +30,11 @@ export const DUMP_TABLES = [
   { table: "repair_fixer_settings", orderBy: "fixer" },
   { table: "repair_log", orderBy: "repair_key" },
   { table: "session", orderBy: "session_key" },
+  { table: "source_artifact", orderBy: "artifact_key" },
   { table: "source_record", orderBy: "id" },
+  { table: "source_record_current", orderBy: "source_record_id" },
+  { table: "source_record_revision", orderBy: "revision_id" },
+  { table: "source_watermark", orderBy: "source, lane" },
   { table: "sport_settings", orderBy: "id" },
   { table: "stream", orderBy: "stream_key" },
   { table: "stroke_correction_overlay", orderBy: "id" },

--- a/packages/kernel/src/store/index.ts
+++ b/packages/kernel/src/store/index.ts
@@ -8,3 +8,5 @@ export * from "./repair-log-repository.js";
 export * from "./dedup-confirmation-repository.js";
 export * from "./activity-repository.js";
 export * from "./derived-key.js";
+export * from "./sync-source.js";
+export * from "./sync-state-repository.js";

--- a/packages/kernel/src/store/migrations/005_sync_state.sql
+++ b/packages/kernel/src/store/migrations/005_sync_state.sql
@@ -1,0 +1,214 @@
+CREATE TABLE source_artifact (
+  artifact_key TEXT PRIMARY KEY,
+  source TEXT NOT NULL
+    CHECK (source IN ('intervals-icu','file-import')),
+  lane TEXT NOT NULL
+    CHECK (lane IN ('activities','streams','wellness','settings','bulk-fit','file-discovery')),
+  external_id TEXT,
+  artifact_kind TEXT NOT NULL
+    CHECK (artifact_kind IN ('snapshot','raw_file')),
+  archive_address TEXT NOT NULL
+    CHECK (length(archive_address) = 64 AND archive_address = lower(archive_address) AND archive_address NOT GLOB '*[^0-9a-f]*'),
+  archive_rel_path TEXT NOT NULL
+    CHECK (length(archive_rel_path) > 0),
+  archive_epoch_s INTEGER NOT NULL
+    CHECK (archive_epoch_s >= 0),
+  CHECK (
+    (source = 'intervals-icu' AND lane != 'file-discovery')
+    OR (source = 'file-import' AND lane = 'file-discovery')
+  ),
+  CHECK (
+    (artifact_kind = 'snapshot' AND lane IN ('activities','streams','wellness','settings'))
+    OR (artifact_kind = 'raw_file' AND lane IN ('bulk-fit','file-discovery'))
+  ),
+  CHECK (
+    (lane = 'file-discovery' AND external_id IS NULL)
+    OR (lane != 'file-discovery' AND external_id IS NOT NULL AND length(external_id) > 0)
+  )
+) STRICT;
+
+CREATE INDEX idx_source_artifact_address
+  ON source_artifact (archive_address, source, lane);
+
+ALTER TABLE source_record
+  ADD COLUMN artifact_key TEXT
+  REFERENCES source_artifact(artifact_key) ON DELETE RESTRICT;
+
+CREATE TABLE source_record_revision (
+  revision_id TEXT PRIMARY KEY,
+  source_record_id TEXT NOT NULL
+    REFERENCES source_record(id) ON DELETE RESTRICT,
+  artifact_key TEXT
+    REFERENCES source_artifact(artifact_key) ON DELETE RESTRICT,
+  raw_sha256 TEXT,
+  quality_rank INTEGER NOT NULL,
+  payload_json TEXT NOT NULL,
+  CHECK (
+    raw_sha256 IS NULL
+    OR (
+      length(raw_sha256) = 64
+      AND raw_sha256 = lower(raw_sha256)
+      AND raw_sha256 NOT GLOB '*[^0-9a-f]*'
+    )
+  ),
+  CHECK (artifact_key IS NOT NULL OR revision_id = source_record_id),
+  UNIQUE (source_record_id, revision_id)
+) STRICT;
+
+CREATE INDEX idx_source_record_revision_record
+  ON source_record_revision (source_record_id, revision_id);
+
+INSERT INTO source_record_revision (
+  revision_id,
+  source_record_id,
+  artifact_key,
+  raw_sha256,
+  quality_rank,
+  payload_json
+)
+SELECT
+  id,
+  id,
+  artifact_key,
+  raw_sha256,
+  quality_rank,
+  payload_json
+FROM source_record;
+
+CREATE TABLE source_record_current (
+  source_record_id TEXT PRIMARY KEY
+    REFERENCES source_record(id) ON DELETE RESTRICT,
+  revision_id TEXT NOT NULL,
+  FOREIGN KEY (source_record_id, revision_id)
+    REFERENCES source_record_revision(source_record_id, revision_id)
+    ON DELETE RESTRICT
+) STRICT;
+
+INSERT INTO source_record_current (source_record_id, revision_id)
+SELECT id, id
+FROM source_record;
+
+CREATE TRIGGER source_record_seed_revision
+AFTER INSERT ON source_record
+BEGIN
+  INSERT INTO source_record_revision (
+    revision_id,
+    source_record_id,
+    artifact_key,
+    raw_sha256,
+    quality_rank,
+    payload_json
+  ) VALUES (
+    NEW.id,
+    NEW.id,
+    NEW.artifact_key,
+    NEW.raw_sha256,
+    NEW.quality_rank,
+    NEW.payload_json
+  );
+  INSERT INTO source_record_current (source_record_id, revision_id)
+  VALUES (NEW.id, NEW.id);
+END;
+
+CREATE TRIGGER source_record_immutable_presentation
+BEFORE UPDATE OF source, external_id, raw_sha256, quality_rank, payload_json, artifact_key
+ON source_record
+BEGIN
+  SELECT RAISE(ABORT, 'source record presentation is immutable');
+END;
+
+CREATE TABLE source_watermark (
+  source TEXT NOT NULL
+    CHECK (source IN ('intervals-icu','file-import')),
+  lane TEXT NOT NULL
+    CHECK (lane IN ('activities','streams','wellness','settings','bulk-fit','file-discovery')),
+  watermark TEXT NOT NULL
+    CHECK (length(watermark) > 0),
+  PRIMARY KEY (source, lane),
+  CHECK (
+    (source = 'intervals-icu' AND lane != 'file-discovery')
+    OR (source = 'file-import' AND lane = 'file-discovery')
+  )
+) STRICT, WITHOUT ROWID;
+
+CREATE TABLE sync_operation (
+  operation_id INTEGER PRIMARY KEY,
+  source TEXT NOT NULL
+    CHECK (source IN ('intervals-icu','file-import')),
+  lane TEXT NOT NULL
+    CHECK (lane IN ('activities','streams','wellness','settings','bulk-fit','file-discovery')),
+  watermark_before TEXT,
+  watermark_after TEXT,
+  artifacts_seen INTEGER NOT NULL
+    CHECK (artifacts_seen >= 0),
+  source_changes INTEGER NOT NULL
+    CHECK (source_changes >= 0),
+  completion_kind TEXT NOT NULL
+    CHECK (completion_kind IN ('applied','no-op')),
+  CHECK (
+    (source = 'intervals-icu' AND lane != 'file-discovery')
+    OR (source = 'file-import' AND lane = 'file-discovery')
+  ),
+  CHECK (watermark_before IS NULL OR length(watermark_before) > 0),
+  CHECK (watermark_after IS NULL OR length(watermark_after) > 0),
+  CHECK (
+    (
+      completion_kind = 'no-op'
+      AND source_changes = 0
+      AND watermark_before IS watermark_after
+    )
+    OR
+    (
+      completion_kind = 'applied'
+      AND (
+        source_changes > 0
+        OR watermark_before IS NOT watermark_after
+      )
+    )
+  )
+) STRICT;
+
+CREATE INDEX idx_sync_operation_source_lane
+  ON sync_operation (source, lane, operation_id);
+
+CREATE TRIGGER source_artifact_no_update
+BEFORE UPDATE ON source_artifact
+BEGIN
+  SELECT RAISE(ABORT, 'source artifact is append-only');
+END;
+
+CREATE TRIGGER source_artifact_no_delete
+BEFORE DELETE ON source_artifact
+BEGIN
+  SELECT RAISE(ABORT, 'source artifact is append-only');
+END;
+
+CREATE TRIGGER source_record_revision_no_update
+BEFORE UPDATE ON source_record_revision
+BEGIN
+  SELECT RAISE(ABORT, 'source record revision is append-only');
+END;
+
+CREATE TRIGGER source_record_revision_no_delete
+BEFORE DELETE ON source_record_revision
+BEGIN
+  SELECT RAISE(ABORT, 'source record revision is append-only');
+END;
+
+CREATE TRIGGER source_record_current_no_delete
+BEFORE DELETE ON source_record_current
+BEGIN
+  SELECT RAISE(ABORT, 'source record current selection cannot be deleted');
+END;
+
+CREATE TRIGGER sync_operation_no_update
+BEFORE UPDATE ON sync_operation
+BEGIN
+  SELECT RAISE(ABORT, 'sync operation is append-only');
+END;
+
+CREATE TRIGGER sync_operation_no_delete
+BEFORE DELETE ON sync_operation
+BEGIN
+  SELECT RAISE(ABORT, 'sync operation is append-only');
+END;

--- a/packages/kernel/src/store/migrations/index.ts
+++ b/packages/kernel/src/store/migrations/index.ts
@@ -2,6 +2,7 @@ import init001 from "./001_init.sql";
 import sql from "./002_repair_log.sql";
 import dedup003 from "./003_dedup_confirmation.sql";
 import fixerSettings004 from "./004_repair_fixer_settings.sql";
+import syncState005 from "./005_sync_state.sql";
 
 export interface Migration {
   /** Ascending schema version this migration advances the store to. */
@@ -18,7 +19,8 @@ export interface Migration {
  */
 export const MIGRATIONS: readonly Migration[] = [
   { version: 1, name: "001_init", sql: init001 },
-  {version:2,name:'002_repair_log',sql},
+  { version: 2, name: "002_repair_log", sql },
   { version: 3, name: "003_dedup_confirmation", sql: dedup003 },
   { version: 4, name: "004_repair_fixer_settings", sql: fixerSettings004 },
+  { version: 5, name: "005_sync_state", sql: syncState005 },
 ];

--- a/packages/kernel/src/store/sync-source.ts
+++ b/packages/kernel/src/store/sync-source.ts
@@ -1,0 +1,110 @@
+import type { ArchiveInstant, ArchiveWriteResult } from "../archive/types.js";
+import type { ImportArtifact } from "../ingest/import-report.js";
+import type { ClockPort } from "../ports/clock.js";
+
+export const SOURCE_IDS = ["intervals-icu", "file-import"] as const;
+export type SourceId = (typeof SOURCE_IDS)[number];
+
+export const SOURCE_LANES = [
+  "activities",
+  "streams",
+  "wellness",
+  "settings",
+  "bulk-fit",
+  "file-discovery",
+] as const;
+export type SourceLane = (typeof SOURCE_LANES)[number];
+
+export type BackfillDepth =
+  | { readonly kind: "none" }
+  | { readonly kind: "bounded"; readonly days: number }
+  | { readonly kind: "full-history" };
+
+export interface SourceCapabilities {
+  readonly activities: boolean;
+  readonly streams: boolean;
+  readonly rawFiles: boolean;
+  readonly wellness: boolean;
+  readonly plannedWorkoutPush: boolean;
+  readonly backfillDepth: BackfillDepth;
+}
+
+export interface SourceWatermark {
+  readonly source: SourceId;
+  readonly lane: SourceLane;
+  readonly value: string | null;
+}
+
+export interface SyncBudget {
+  readonly signal: AbortSignal;
+  readonly clock: Pick<ClockPort, "monotonicNow">;
+  readonly deadlineMonotonicMs: number;
+  readonly perRequestTimeoutMs: number;
+  readonly maxRequests: number;
+  readonly maxArtifacts: number;
+}
+
+export interface SnapshotSourceArtifact {
+  readonly kind: "snapshot";
+  readonly source: SourceId;
+  readonly lane: "activities" | "streams" | "wellness" | "settings";
+  readonly externalId: string;
+  readonly archiveInstant: ArchiveInstant;
+  readonly archive: ArchiveWriteResult;
+  readonly payload: unknown;
+}
+
+export interface RawFileSourceArtifact {
+  readonly kind: "raw-file";
+  readonly source: SourceId;
+  readonly lane: "bulk-fit" | "file-discovery";
+  readonly externalId: string | null;
+  readonly archiveInstant: ArchiveInstant;
+  readonly archive: ArchiveWriteResult;
+  readonly file: ImportArtifact;
+}
+
+export interface SourceCheckpoint {
+  readonly kind: "checkpoint";
+  readonly watermark: SourceWatermark;
+}
+
+export type SourceArtifact = SnapshotSourceArtifact | RawFileSourceArtifact | SourceCheckpoint;
+
+export interface PlannedWorkoutDoc {
+  readonly idempotencyKey: string;
+  readonly dateKey: number;
+  readonly sport: "cycling" | "running" | "swimming" | "duathlon" | "triathlon";
+  readonly structure: Readonly<Record<string, unknown>>;
+}
+
+export type PushResult =
+  | { readonly outcome: "created"; readonly externalId: string }
+  | { readonly outcome: "updated"; readonly externalId: string }
+  | { readonly outcome: "unchanged"; readonly externalId: string };
+
+export interface SyncCompletion {
+  readonly source: SourceId;
+  readonly lane: SourceLane;
+  readonly watermarkBefore: string | null;
+  readonly watermarkAfter: string | null;
+  readonly artifactsSeen: number;
+  readonly sourceChanges: number;
+}
+
+export interface SyncCompletionResult {
+  readonly operationId: number;
+  readonly completionKind: "applied" | "no-op";
+}
+
+export interface SyncStateRepository {
+  readWatermark(source: SourceId, lane: SourceLane): Promise<SourceWatermark>;
+  recordCompletionInTransaction(input: SyncCompletion): Promise<SyncCompletionResult>;
+}
+
+export interface SyncSource {
+  readonly id: SourceId;
+  readonly capabilities: SourceCapabilities;
+  pull(watermark: SourceWatermark, budget: SyncBudget): AsyncIterable<SourceArtifact>;
+  pushPlannedWorkout?(doc: PlannedWorkoutDoc): Promise<PushResult>;
+}

--- a/packages/kernel/src/store/sync-state-repository.ts
+++ b/packages/kernel/src/store/sync-state-repository.ts
@@ -1,0 +1,137 @@
+import type { Row, SqlStore } from "./ports.js";
+import type {
+  SourceId,
+  SourceLane,
+  SyncCompletion,
+  SyncCompletionResult,
+  SyncStateRepository,
+  SourceWatermark,
+} from "./sync-source.js";
+
+const READ_WATERMARK_SQL = `SELECT watermark
+FROM source_watermark
+WHERE source = ? AND lane = ?`;
+
+function isValidKey(source: unknown, lane: unknown): source is SourceId {
+  if (
+    (source !== "intervals-icu" && source !== "file-import") ||
+    (lane !== "activities" &&
+      lane !== "streams" &&
+      lane !== "wellness" &&
+      lane !== "settings" &&
+      lane !== "bulk-fit" &&
+      lane !== "file-discovery")
+  ) {
+    return false;
+  }
+  return source === "intervals-icu" ? lane !== "file-discovery" : lane === "file-discovery";
+}
+
+function isWatermark(value: unknown): value is string | null {
+  return value === null || (typeof value === "string" && value.length > 0);
+}
+
+function hasExactKeys(row: Row, keys: readonly string[]): boolean {
+  const actual = Object.keys(row);
+  return actual.length === keys.length && actual.every((key, index) => key === keys[index]);
+}
+
+function validateCompletion(input: SyncCompletion): void {
+  if (
+    input === null ||
+    typeof input !== "object" ||
+    !isValidKey(input.source, input.lane) ||
+    !isWatermark(input.watermarkBefore) ||
+    !isWatermark(input.watermarkAfter) ||
+    (input.watermarkBefore !== null && input.watermarkAfter === null) ||
+    !Number.isSafeInteger(input.artifactsSeen) ||
+    input.artifactsSeen < 0 ||
+    !Number.isSafeInteger(input.sourceChanges) ||
+    input.sourceChanges < 0
+  ) {
+    throw new TypeError("invalid sync completion");
+  }
+}
+
+export function createSyncStateRepository(store: SqlStore): SyncStateRepository {
+  const readWatermark = async (source: SourceId, lane: SourceLane): Promise<SourceWatermark> => {
+    if (!isValidKey(source, lane)) {
+      throw new TypeError("invalid sync watermark key");
+    }
+    const row = await store.get(READ_WATERMARK_SQL, [source, lane]);
+    if (row === undefined) {
+      return Object.freeze({ source, lane, value: null });
+    }
+    if (
+      !hasExactKeys(row, ["watermark"]) ||
+      typeof row.watermark !== "string" ||
+      row.watermark.length === 0
+    ) {
+      throw new Error("invalid sync watermark row");
+    }
+    return Object.freeze({ source, lane, value: row.watermark });
+  };
+
+  return {
+    readWatermark,
+    async recordCompletionInTransaction(input: SyncCompletion): Promise<SyncCompletionResult> {
+      validateCompletion(input);
+      const current = await readWatermark(input.source, input.lane);
+      if (current.value !== input.watermarkBefore) {
+        throw new Error("sync watermark changed during planning");
+      }
+
+      const completionKind =
+        input.sourceChanges === 0 && input.watermarkBefore === input.watermarkAfter
+          ? "no-op"
+          : "applied";
+      const inserted = await store.get(
+        `INSERT INTO sync_operation (
+  source,
+  lane,
+  watermark_before,
+  watermark_after,
+  artifacts_seen,
+  source_changes,
+  completion_kind
+) VALUES (?, ?, ?, ?, ?, ?, ?)
+RETURNING operation_id`,
+        [
+          input.source,
+          input.lane,
+          input.watermarkBefore,
+          input.watermarkAfter,
+          input.artifactsSeen,
+          input.sourceChanges,
+          completionKind,
+        ],
+      );
+      if (
+        inserted === undefined ||
+        !hasExactKeys(inserted, ["operation_id"]) ||
+        typeof inserted.operation_id !== "number" ||
+        !Number.isSafeInteger(inserted.operation_id) ||
+        inserted.operation_id <= 0
+      ) {
+        throw new Error("sync operation insert failed");
+      }
+      const operationId = inserted.operation_id;
+
+      if (input.watermarkAfter !== null && input.watermarkAfter !== input.watermarkBefore) {
+        await store.run(
+          `INSERT INTO source_watermark (source, lane, watermark)
+VALUES (?, ?, ?)
+ON CONFLICT(source, lane) DO UPDATE
+SET watermark = excluded.watermark`,
+          [input.source, input.lane, input.watermarkAfter],
+        );
+      }
+
+      const updated = await readWatermark(input.source, input.lane);
+      if (updated.value !== input.watermarkAfter) {
+        throw new Error("sync watermark update failed");
+      }
+      return Object.freeze({ operationId, completionKind });
+    },
+  };
+}

--- a/packages/kernel/tests/concurrency-retry.test.ts
+++ b/packages/kernel/tests/concurrency-retry.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  parseRetryAfterMs,
+  retryAfterMsFromHeaders,
+  retryWithBackoff,
+} from "../src/concurrency/retry.js";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("Retry-After handling", () => {
+  it("parses Retry-After at the raw header seam", () => {
+    const now = Date.UTC(1998, 0, 2, 3, 4, 5);
+    expect(retryAfterMsFromHeaders({}, now)).toBeNull();
+    expect(retryAfterMsFromHeaders({ "ReTrY-AfTeR": "120" }, now)).toBe(120_000);
+    expect(retryAfterMsFromHeaders({ "Retry-After": "1", "retry-after": "2" }, now)).toBeNull();
+    expect(
+      retryAfterMsFromHeaders(Object.create({ "Retry-After": "3" }) as Record<string, string>, now),
+    ).toBeNull();
+
+    expect(parseRetryAfterMs(null, now)).toBeNull();
+    expect(parseRetryAfterMs("", now)).toBeNull();
+    expect(parseRetryAfterMs("0", now)).toBe(0);
+    expect(parseRetryAfterMs("120", now)).toBe(120_000);
+    expect(parseRetryAfterMs("\t 120 \t", now)).toBe(120_000);
+    expect(parseRetryAfterMs(String(Number.MAX_SAFE_INTEGER), now)).toBeNull();
+    for (const malformed of [
+      "1.5",
+      "+1",
+      "1e2",
+      "1,000",
+      "1 2",
+      "\r120",
+      "120\n",
+      "\v120",
+      "120\f",
+      "\u00a0120",
+      "120\u2003",
+    ]) {
+      expect(parseRetryAfterMs(malformed, now), malformed).toBeNull();
+    }
+
+    expect(parseRetryAfterMs("Fri, 02 Jan 1998 03:05:05 GMT", now)).toBe(60_000);
+    expect(parseRetryAfterMs("Fri, 02 Jan 1998 03:03:05 GMT", now)).toBe(0);
+    expect(parseRetryAfterMs("Tue, 29 Feb 2000 00:00:00 GMT", Date.UTC(2000, 1, 28))).toBe(
+      86_400_000,
+    );
+    for (const malformed of [
+      "Mon, 29 Feb 1999 00:00:00 GMT",
+      "Thu, 02 Jan 1998 03:05:05 GMT",
+      "Friday, 02-Jan-98 03:05:05 GMT",
+      "Fri Jan  2 03:05:05 1998",
+      "Fri, 02 Jan 1998 03:05:05 UTC",
+      "Fri, 02 Jan 1998 03:05:05 gmt",
+    ]) {
+      expect(parseRetryAfterMs(malformed, now), malformed).toBeNull();
+    }
+
+    for (const invalidClock of [-1, 1.5, Number.POSITIVE_INFINITY, Number.MAX_SAFE_INTEGER + 1]) {
+      expect(() => parseRetryAfterMs("0", invalidClock)).toThrowError(
+        new TypeError("invalid retry clock"),
+      );
+      expect(() => retryAfterMsFromHeaders({}, invalidClock)).toThrowError(
+        new TypeError("invalid retry clock"),
+      );
+    }
+  });
+
+  it("preserves an opt-in server lower bound above the local cap", async () => {
+    const delays: number[] = [];
+    const run = (retryAfterMode?: "cap" | "lower-bound") => {
+      const fn = vi
+        .fn<() => Promise<string>>()
+        .mockRejectedValueOnce(new Error("busy"))
+        .mockResolvedValue("ok");
+      return retryWithBackoff(fn, {
+        attempts: 2,
+        baseMs: 100,
+        capMs: 30_000,
+        shouldRetry: () => true,
+        retryAfterMs: () => 120_000,
+        retryAfterMode,
+        random: () => 0.5,
+        sleep: async (delay) => {
+          delays.push(delay);
+        },
+      });
+    };
+
+    await expect(run("lower-bound")).resolves.toBe("ok");
+    await expect(run()).resolves.toBe("ok");
+    expect(delays).toEqual([120_500, 30_000]);
+  });
+
+  it("rejects invalid callback hints before retry visibility or sleep", async () => {
+    for (const hint of [-1, 1.5, Number.MAX_SAFE_INTEGER, Number.POSITIVE_INFINITY]) {
+      const onRetry = vi.fn();
+      const sleep = vi.fn(async () => undefined);
+      await expect(
+        retryWithBackoff(
+          async () => {
+            throw new Error("busy");
+          },
+          {
+            attempts: 2,
+            baseMs: 1,
+            capMs: 2,
+            shouldRetry: () => true,
+            retryAfterMs: () => hint,
+            random: () => 0.5,
+            onRetry,
+            sleep,
+          },
+        ),
+      ).rejects.toThrow("invalid retry-after delay");
+      expect(onRetry).not.toHaveBeenCalled();
+      expect(sleep).not.toHaveBeenCalled();
+    }
+
+    await expect(
+      retryWithBackoff(
+        async () => {
+          throw new Error("busy");
+        },
+        {
+          attempts: 2,
+          baseMs: 1,
+          capMs: 2,
+          shouldRetry: () => true,
+          retryAfterMs: () => 1,
+          retryAfterMode: "invalid" as "cap",
+        },
+      ),
+    ).rejects.toThrow("invalid retry-after mode");
+  });
+
+  it("aborts a scheduled long hint before another attempt", async () => {
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    const attemptError = new Error("busy");
+    const fn = vi.fn<() => Promise<string>>().mockRejectedValue(attemptError);
+    const onRetry = vi.fn();
+    const promise = retryWithBackoff(fn, {
+      attempts: 3,
+      baseMs: 1,
+      capMs: 30_000,
+      shouldRetry: () => true,
+      retryAfterMs: () => 120_000,
+      retryAfterMode: "lower-bound",
+      random: () => 0.5,
+      signal: controller.signal,
+      onRetry,
+    });
+    const settled = promise.catch((error: unknown) => error);
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(onRetry).toHaveBeenCalledTimes(1);
+    expect(onRetry.mock.calls[0]![0]).toMatchObject({ delayMs: 120_500 });
+    controller.abort();
+    await vi.advanceTimersByTimeAsync(0);
+
+    await expect(settled).resolves.toBe(attemptError);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/kernel/tests/migrations-ddl.test.ts
+++ b/packages/kernel/tests/migrations-ddl.test.ts
@@ -1,7 +1,8 @@
+import { createHash } from "node:crypto";
 import { DatabaseSync } from "node:sqlite";
 import { afterEach, describe, expect, it } from "vitest";
 import { MIGRATIONS } from "../src/store/migrations/index.js";
-import { DERIVED_TABLES } from "../src/store/dump.js";
+import { DERIVED_TABLES, DUMP_TABLES } from "../src/store/dump.js";
 
 const EXPECTED_TABLES = [
   "athlete",
@@ -25,7 +26,18 @@ const EXPECTED_TABLES = [
   "field_merge_override_overlay",
   "pool_size_correction_overlay",
 ];
-const EXPECTED_FULL_TABLES = [...EXPECTED_TABLES, "ingest_metadata", "repair_log", "dedup_confirmation", "repair_fixer_settings"];
+const EXPECTED_FULL_TABLES = [
+  ...EXPECTED_TABLES,
+  "ingest_metadata",
+  "repair_log",
+  "dedup_confirmation",
+  "repair_fixer_settings",
+  "source_artifact",
+  "source_record_revision",
+  "source_record_current",
+  "source_watermark",
+  "sync_operation",
+];
 const MIGRATION_002 = `ALTER TABLE swim_length ADD COLUMN distance_m REAL;
 
 CREATE TABLE ingest_metadata (
@@ -125,6 +137,7 @@ function openFull(): DatabaseSync {
   next.exec(MIGRATIONS[1]!.sql);
   next.exec(MIGRATIONS[2]!.sql);
   next.exec(MIGRATIONS[3]!.sql);
+  next.exec(MIGRATIONS[4]!.sql);
   return next;
 }
 
@@ -135,7 +148,13 @@ afterEach(() => {
 
 describe("001_init migration", () => {
   it("wires the ordered migration list with real inlined SQL", () => {
-    expect(MIGRATIONS.map(({version,name})=>({version,name}))).toEqual([{version:1,name:"001_init"},{version:2,name:"002_repair_log"},{version:3,name:"003_dedup_confirmation"},{version:4,name:"004_repair_fixer_settings"}]);
+    expect(MIGRATIONS.map(({ version, name }) => ({ version, name }))).toEqual([
+      { version: 1, name: "001_init" },
+      { version: 2, name: "002_repair_log" },
+      { version: 3, name: "003_dedup_confirmation" },
+      { version: 4, name: "004_repair_fixer_settings" },
+      { version: 5, name: "005_sync_state" },
+    ]);
     expect(typeof MIGRATIONS[0].sql).toBe("string");
     expect(MIGRATIONS[0].sql).toContain("CREATE TABLE athlete");
   });
@@ -151,9 +170,7 @@ describe("001_init migration", () => {
   it("creates exactly the 20 Domains A-H tables", () => {
     db = openMigrated();
     const rows = db
-      .prepare(
-        "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'",
-      )
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'")
       .all() as Array<{ name: string }>;
     const names = rows.map((r) => r.name).sort();
     expect(names).toEqual([...EXPECTED_TABLES].sort());
@@ -162,9 +179,7 @@ describe("001_init migration", () => {
   it("creates exactly the 12 named indexes", () => {
     db = openMigrated();
     const rows = db
-      .prepare(
-        "SELECT name FROM sqlite_master WHERE type='index' AND name LIKE 'idx_%'",
-      )
+      .prepare("SELECT name FROM sqlite_master WHERE type='index' AND name LIKE 'idx_%'")
       .all() as Array<{ name: string }>;
     const names = rows.map((r) => r.name).sort();
     expect(names).toEqual([...EXPECTED_INDEXES].sort());
@@ -172,9 +187,9 @@ describe("001_init migration", () => {
 
   it("does NOT build any Domain I table (reservation check)", () => {
     db = openMigrated();
-    const rows = db
-      .prepare("SELECT name FROM sqlite_master WHERE type='table'")
-      .all() as Array<{ name: string }>;
+    const rows = db.prepare("SELECT name FROM sqlite_master WHERE type='table'").all() as Array<{
+      name: string;
+    }>;
     const names = new Set(rows.map((r) => r.name));
     for (const reserved of RESERVED_DOMAIN_I_TABLES) {
       expect(names.has(reserved)).toBe(false);
@@ -186,11 +201,11 @@ describe("001_init migration", () => {
 
   it("carries no wall-clock column on any derived table (INV-2)", () => {
     db = openMigrated();
-    expect(DERIVED_TABLES.join(",")).toBe("metric_snapshot,mean_max_cache,repair_log,stream,swim_length,lap,session,workout");
+    expect(DERIVED_TABLES.join(",")).toBe(
+      "metric_snapshot,mean_max_cache,repair_log,stream,swim_length,lap,session,workout",
+    );
     for (const table of DERIVED_TABLES.filter((name) => EXPECTED_TABLES.includes(name))) {
-      const cols = db
-        .prepare(`PRAGMA table_info(${table});`)
-        .all() as Array<{ name: string }>;
+      const cols = db.prepare(`PRAGMA table_info(${table});`).all() as Array<{ name: string }>;
       const colNames = cols.map((c) => c.name);
       expect(colNames).not.toContain("computed_at");
       expect(colNames).not.toContain("fetched_at");
@@ -204,15 +219,7 @@ describe("001_init migration", () => {
         .prepare(
           "INSERT INTO metric_snapshot (snapshot_key, scope_kind, scope_id, metric_key, value_json, kernel_version, basis_version) VALUES (?, ?, ?, ?, ?, ?, ?)",
         )
-        .run(
-          `snap-${scopeKind}`,
-          scopeKind,
-          "scope",
-          "metric",
-          "{}",
-          "k",
-          "b",
-        );
+        .run(`snap-${scopeKind}`, scopeKind, "scope", "metric", "{}", "k", "b");
     expect(() => insert("bogus")).toThrow();
     expect(() => insert("session")).not.toThrow();
   });
@@ -225,13 +232,9 @@ describe("001_init migration", () => {
     db.prepare(
       "INSERT INTO session (session_key, workout_key, session_seq, sport, start_utc, local_date_key, is_transition) VALUES (?, ?, ?, ?, ?, ?, ?)",
     ).run("se-1", "wk-1", 0, "cycling", 1000, 19980101, 0);
-    expect(
-      (db.prepare("SELECT count(*) c FROM session").get() as { c: number }).c,
-    ).toBe(1);
+    expect((db.prepare("SELECT count(*) c FROM session").get() as { c: number }).c).toBe(1);
     db.prepare("DELETE FROM workout").run();
-    expect(
-      (db.prepare("SELECT count(*) c FROM session").get() as { c: number }).c,
-    ).toBe(0);
+    expect((db.prepare("SELECT count(*) c FROM session").get() as { c: number }).c).toBe(0);
   });
 
   it("preserves the exact migration 002 SQL string", () => {
@@ -242,9 +245,15 @@ describe("001_init migration", () => {
     expect(MIGRATIONS[2]!.sql).toBe(MIGRATION_003);
   });
 
-  it("applies 001 through 004 with exactly twenty-four tables and no foreign-key violations", () => {
+  it("applies 001 through 005 with exactly twenty-nine tables and no foreign-key violations", () => {
     db = openFull();
-    const names = (db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'").all() as Array<{name:string}>).map((row)=>row.name).sort();
+    const names = (
+      db
+        .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'")
+        .all() as Array<{ name: string }>
+    )
+      .map((row) => row.name)
+      .sort();
     expect(names).toEqual([...EXPECTED_FULL_TABLES].sort());
     expect(db.prepare("PRAGMA foreign_key_check").all()).toEqual([]);
   });
@@ -252,62 +261,486 @@ describe("001_init migration", () => {
   it("preserves migration 004 and creates strict sparse fixer settings with exact constraints", () => {
     expect(MIGRATIONS[3]!.sql).toBe(MIGRATION_004);
     db = openFull();
-    expect(db.prepare("SELECT fixer,enabled FROM repair_fixer_settings ORDER BY fixer").all()).toEqual([]);
+    expect(
+      db.prepare("SELECT fixer,enabled FROM repair_fixer_settings ORDER BY fixer").all(),
+    ).toEqual([]);
     expect(db.prepare("PRAGMA foreign_key_list(repair_fixer_settings)").all()).toEqual([]);
-    const tables = db.prepare("PRAGMA table_list").all() as Array<{name:string;strict:number}>;
-    expect(tables.find((row)=>row.name==="repair_fixer_settings")?.strict).toBe(1);
-    for (const fixer of ["chronoBridge","summitGuard","pulseWeave"]) {
-      expect(()=>db!.prepare("INSERT INTO repair_fixer_settings(fixer,enabled) VALUES(?,1)").run(fixer)).not.toThrow();
+    const tables = db.prepare("PRAGMA table_list").all() as Array<{ name: string; strict: number }>;
+    expect(tables.find((row) => row.name === "repair_fixer_settings")?.strict).toBe(1);
+    for (const fixer of ["chronoBridge", "summitGuard", "pulseWeave"]) {
+      expect(() =>
+        db!.prepare("INSERT INTO repair_fixer_settings(fixer,enabled) VALUES(?,1)").run(fixer),
+      ).not.toThrow();
     }
-    expect(()=>db!.prepare("INSERT INTO repair_fixer_settings(fixer,enabled) VALUES('unknown',1)").run()).toThrow();
-    expect(()=>db!.prepare("UPDATE repair_fixer_settings SET enabled=0 WHERE fixer='chronoBridge'").run()).toThrow();
+    expect(() =>
+      db!.prepare("INSERT INTO repair_fixer_settings(fixer,enabled) VALUES('unknown',1)").run(),
+    ).toThrow();
+    expect(() =>
+      db!.prepare("UPDATE repair_fixer_settings SET enabled=0 WHERE fixer='chronoBridge'").run(),
+    ).toThrow();
   });
 
   it("creates strict append-only confirmation history with canonical ASCII pairs and descending effective index", () => {
     db = openFull();
-    const tables = db.prepare("PRAGMA table_list").all() as Array<{name:string;strict:number}>;
+    const tables = db.prepare("PRAGMA table_list").all() as Array<{ name: string; strict: number }>;
     expect(tables.find((row) => row.name === "dedup_confirmation")?.strict).toBe(1);
     expect(db.prepare("PRAGMA foreign_key_list(dedup_confirmation)").all()).toEqual([]);
-    const a = "a".repeat(64), b = "b".repeat(64), id = "0".repeat(26);
-    db.prepare("INSERT INTO dedup_confirmation VALUES(?,?,?,?,?,?,?)").run(id, a, b, "merge", "device-1", 1, 0);
-    expect(() => db!.prepare("INSERT INTO dedup_confirmation VALUES(?,?,?,?,?,?,?)").run("1".repeat(26), b, a, "merge", "device-1", 1, 0)).toThrow();
-    expect(() => db!.prepare("INSERT INTO dedup_confirmation VALUES(?,?,?,?,?,?,?)").run("2".repeat(26), a, b, "unknown", "device-1", 1, 0)).toThrow();
+    const a = "a".repeat(64),
+      b = "b".repeat(64),
+      id = "0".repeat(26);
+    db.prepare("INSERT INTO dedup_confirmation VALUES(?,?,?,?,?,?,?)").run(
+      id,
+      a,
+      b,
+      "merge",
+      "device-1",
+      1,
+      0,
+    );
+    expect(() =>
+      db!
+        .prepare("INSERT INTO dedup_confirmation VALUES(?,?,?,?,?,?,?)")
+        .run("1".repeat(26), b, a, "merge", "device-1", 1, 0),
+    ).toThrow();
+    expect(() =>
+      db!
+        .prepare("INSERT INTO dedup_confirmation VALUES(?,?,?,?,?,?,?)")
+        .run("2".repeat(26), a, b, "unknown", "device-1", 1, 0),
+    ).toThrow();
     for (const [index, character] of [String.fromCodePoint(0x10000), "\ue000"].entries()) {
-      expect(() => db!.prepare("INSERT INTO dedup_confirmation VALUES(?,?,?,?,?,?,?)").run(`${character}${String(index).repeat(25)}`, a, b, "merge", "device", 1, 0)).toThrow();
-      expect(() => db!.prepare("INSERT INTO dedup_confirmation VALUES(?,?,?,?,?,?,?)").run(String(index + 3).repeat(26), a, b, "merge", `device-${character}`, 1, 0)).toThrow();
+      expect(() =>
+        db!
+          .prepare("INSERT INTO dedup_confirmation VALUES(?,?,?,?,?,?,?)")
+          .run(`${character}${String(index).repeat(25)}`, a, b, "merge", "device", 1, 0),
+      ).toThrow();
+      expect(() =>
+        db!
+          .prepare("INSERT INTO dedup_confirmation VALUES(?,?,?,?,?,?,?)")
+          .run(String(index + 3).repeat(26), a, b, "merge", `device-${character}`, 1, 0),
+      ).toThrow();
     }
-    const sql = (db.prepare("SELECT sql FROM sqlite_master WHERE type='index' AND name='idx_dedup_confirmation_effective'").get() as {sql:string}).sql;
-    expect(sql).toContain("hlc_physical_ms DESC"); expect(sql).toContain("hlc_counter DESC");
-    expect(sql).toContain("device_id DESC"); expect(sql).toContain("id DESC");
+    const sql = (
+      db
+        .prepare(
+          "SELECT sql FROM sqlite_master WHERE type='index' AND name='idx_dedup_confirmation_effective'",
+        )
+        .get() as { sql: string }
+    ).sql;
+    expect(sql).toContain("hlc_physical_ms DESC");
+    expect(sql).toContain("hlc_counter DESC");
+    expect(sql).toContain("device_id DESC");
+    expect(sql).toContain("id DESC");
   });
 
   it("adds nullable REAL distance_m to swim_length", () => {
     db = openFull();
-    const column = (db.prepare("PRAGMA table_info(swim_length)").all() as Array<{name:string;type:string;notnull:number}>).find((entry)=>entry.name==="distance_m");
-    expect(column).toMatchObject({name:"distance_m",type:"REAL",notnull:0});
+    const column = (
+      db.prepare("PRAGMA table_info(swim_length)").all() as Array<{
+        name: string;
+        type: string;
+        notnull: number;
+      }>
+    ).find((entry) => entry.name === "distance_m");
+    expect(column).toMatchObject({ name: "distance_m", type: "REAL", notnull: 0 });
   });
 
   it("creates both STRICT tables with exact foreign keys and unique repair tuple", () => {
     db = openFull();
-    const strict = db.prepare("PRAGMA table_list").all() as Array<{name:string;strict:number}>;
-    expect(strict.find((row)=>row.name==="ingest_metadata")?.strict).toBe(1);
-    expect(strict.find((row)=>row.name==="repair_log")?.strict).toBe(1);
-    expect(db.prepare("PRAGMA foreign_key_list(repair_log)").all()).toEqual(expect.arrayContaining([
-      expect.objectContaining({from:"raw_sha256",table:"raw_file",to:"sha256",on_delete:"RESTRICT"}),
-      expect.objectContaining({from:"session_key",table:"session",to:"session_key",on_delete:"CASCADE"}),
-    ]));
-    const indexes=db.prepare("PRAGMA index_list(repair_log)").all() as Array<{name:string;unique:number}>;
-    expect(indexes.some((index)=>index.unique===1)).toBe(true);
+    const strict = db.prepare("PRAGMA table_list").all() as Array<{ name: string; strict: number }>;
+    expect(strict.find((row) => row.name === "ingest_metadata")?.strict).toBe(1);
+    expect(strict.find((row) => row.name === "repair_log")?.strict).toBe(1);
+    expect(db.prepare("PRAGMA foreign_key_list(repair_log)").all()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          from: "raw_sha256",
+          table: "raw_file",
+          to: "sha256",
+          on_delete: "RESTRICT",
+        }),
+        expect.objectContaining({
+          from: "session_key",
+          table: "session",
+          to: "session_key",
+          on_delete: "CASCADE",
+        }),
+      ]),
+    );
+    const indexes = db.prepare("PRAGMA index_list(repair_log)").all() as Array<{
+      name: string;
+      unique: number;
+    }>;
+    expect(indexes.some((index) => index.unique === 1)).toBe(true);
   });
 
   it("seeds and enforces singleton, version, and changed-count constraints", () => {
     db = openFull();
-    expect(db.prepare("SELECT singleton,ingest_version FROM ingest_metadata").all()).toEqual([{singleton:1,ingest_version:0}]);
-    expect(()=>db!.prepare("INSERT INTO ingest_metadata(singleton,ingest_version) VALUES(2,0)").run()).toThrow();
-    expect(()=>db!.prepare("UPDATE ingest_metadata SET ingest_version=-1").run()).toThrow();
-    db.prepare("INSERT INTO raw_file(sha256,path,ext,bytes) VALUES(?,?,?,?)").run("01".repeat(32),"x.fit","fit",1);
-    db.prepare("INSERT INTO workout(workout_key,start_utc,is_multisport,dedup_cluster_id) VALUES('w',0,0,'d')").run();
-    db.prepare("INSERT INTO session(session_key,workout_key,session_seq,sport,start_utc,local_date_key,is_transition) VALUES('s','w',0,'cycling',0,19700101,0)").run();
-    expect(()=>db!.prepare("INSERT INTO repair_log VALUES(?,?,?,?,?,?,?,?)").run("k","01".repeat(32),"s","power","summitGuard",-1,"[]","{}")).toThrow();
+    expect(db.prepare("SELECT singleton,ingest_version FROM ingest_metadata").all()).toEqual([
+      { singleton: 1, ingest_version: 0 },
+    ]);
+    expect(() =>
+      db!.prepare("INSERT INTO ingest_metadata(singleton,ingest_version) VALUES(2,0)").run(),
+    ).toThrow();
+    expect(() => db!.prepare("UPDATE ingest_metadata SET ingest_version=-1").run()).toThrow();
+    db.prepare("INSERT INTO raw_file(sha256,path,ext,bytes) VALUES(?,?,?,?)").run(
+      "01".repeat(32),
+      "x.fit",
+      "fit",
+      1,
+    );
+    db.prepare(
+      "INSERT INTO workout(workout_key,start_utc,is_multisport,dedup_cluster_id) VALUES('w',0,0,'d')",
+    ).run();
+    db.prepare(
+      "INSERT INTO session(session_key,workout_key,session_seq,sport,start_utc,local_date_key,is_transition) VALUES('s','w',0,'cycling',0,19700101,0)",
+    ).run();
+    expect(() =>
+      db!
+        .prepare("INSERT INTO repair_log VALUES(?,?,?,?,?,?,?,?)")
+        .run("k", "01".repeat(32), "s", "power", "summitGuard", -1, "[]", "{}"),
+    ).toThrow();
+  });
+
+  it("registers migration 005 with its exact digest and schema shapes", () => {
+    expect(createHash("sha256").update(MIGRATIONS[4]!.sql).digest("hex")).toBe(
+      "dd7b012efe7253849973fbb5d74022aa86494d1230da1ab16a46835505cc0a7f",
+    );
+    db = openFull();
+    const tables = db.prepare("PRAGMA table_list").all() as Array<{
+      name: string;
+      strict: number;
+      wr: number;
+    }>;
+    for (const name of [
+      "source_artifact",
+      "source_record_revision",
+      "source_record_current",
+      "source_watermark",
+      "sync_operation",
+    ]) {
+      expect(tables.find((row) => row.name === name)?.strict).toBe(1);
+    }
+    expect(tables.find((row) => row.name === "source_watermark")?.wr).toBe(1);
+
+    const indexes = new Set(
+      (
+        db.prepare("SELECT name FROM sqlite_master WHERE type='index'").all() as Array<{
+          name: string;
+        }>
+      ).map(({ name }) => name),
+    );
+    expect(indexes.has("idx_source_artifact_address")).toBe(true);
+    expect(indexes.has("idx_source_record_revision_record")).toBe(true);
+    expect(indexes.has("idx_sync_operation_source_lane")).toBe(true);
+
+    const revisionForeignKeys = db.prepare("PRAGMA foreign_key_list(source_record_revision)").all();
+    expect(revisionForeignKeys).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          from: "source_record_id",
+          table: "source_record",
+          to: "id",
+          on_delete: "RESTRICT",
+        }),
+        expect.objectContaining({
+          from: "artifact_key",
+          table: "source_artifact",
+          to: "artifact_key",
+          on_delete: "RESTRICT",
+        }),
+      ]),
+    );
+    const currentForeignKeys = db.prepare("PRAGMA foreign_key_list(source_record_current)").all();
+    expect(currentForeignKeys).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          from: "source_record_id",
+          table: "source_record_revision",
+          to: "source_record_id",
+          on_delete: "RESTRICT",
+        }),
+        expect.objectContaining({
+          from: "revision_id",
+          table: "source_record_revision",
+          to: "revision_id",
+          on_delete: "RESTRICT",
+        }),
+      ]),
+    );
+
+    const triggers = new Set(
+      (
+        db.prepare("SELECT name FROM sqlite_master WHERE type='trigger'").all() as Array<{
+          name: string;
+        }>
+      ).map(({ name }) => name),
+    );
+    expect(triggers).toEqual(
+      new Set([
+        "source_record_seed_revision",
+        "source_record_immutable_presentation",
+        "source_artifact_no_update",
+        "source_artifact_no_delete",
+        "source_record_revision_no_update",
+        "source_record_revision_no_delete",
+        "source_record_current_no_delete",
+        "sync_operation_no_update",
+        "sync_operation_no_delete",
+      ]),
+    );
+
+    const forbiddenColumns = new Set([
+      "started_at",
+      "completed_at",
+      "updated_at",
+      "duration",
+      "error",
+      "failure",
+      "retry",
+      "hlc",
+      "device_id",
+    ]);
+    for (const table of [
+      "source_artifact",
+      "source_record_revision",
+      "source_record_current",
+      "source_watermark",
+      "sync_operation",
+    ]) {
+      const columns = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>;
+      for (const { name } of columns) expect(forbiddenColumns.has(name)).toBe(false);
+    }
+  });
+
+  it("backfills immutable base revisions and enforces DDL selection constraints", () => {
+    db = new DatabaseSync(":memory:");
+    db.exec("PRAGMA foreign_keys = ON");
+    for (const migration of MIGRATIONS.slice(0, 4)) db.exec(migration.sql);
+    db.prepare(
+      "INSERT INTO source_record(id,workout_key,session_key,source,external_id,raw_sha256,quality_rank,payload_json) VALUES(?,?,?,?,?,?,?,?)",
+    ).run("legacy-record", null, null, "intervals-icu", "42", null, 300, '{"v":1}');
+    db.exec(MIGRATIONS[4]!.sql);
+
+    expect(db.prepare("SELECT * FROM source_record_revision").all()).toEqual([
+      {
+        revision_id: "legacy-record",
+        source_record_id: "legacy-record",
+        artifact_key: null,
+        raw_sha256: null,
+        quality_rank: 300,
+        payload_json: '{"v":1}',
+      },
+    ]);
+    expect(db.prepare("SELECT * FROM source_record_current").all()).toEqual([
+      {
+        source_record_id: "legacy-record",
+        revision_id: "legacy-record",
+      },
+    ]);
+
+    db.prepare(
+      "INSERT INTO source_record(id,workout_key,session_key,source,external_id,raw_sha256,quality_rank,payload_json) VALUES(?,?,?,?,?,?,?,?)",
+    ).run("new-record", null, null, "intervals-icu", "43", null, 300, '{"v":1}');
+    expect(
+      db
+        .prepare(
+          "SELECT revision_id FROM source_record_revision WHERE source_record_id='new-record'",
+        )
+        .all(),
+    ).toEqual([{ revision_id: "new-record" }]);
+    expect(
+      db
+        .prepare(
+          "SELECT revision_id FROM source_record_current WHERE source_record_id='new-record'",
+        )
+        .get(),
+    ).toEqual({
+      revision_id: "new-record",
+    });
+    expect(() =>
+      db!.prepare("UPDATE source_record SET payload_json='{}' WHERE id='new-record'").run(),
+    ).toThrow(/presentation is immutable/);
+
+    db.prepare("INSERT INTO source_artifact VALUES(?,?,?,?,?,?,?,?)").run(
+      "artifact-revision",
+      "intervals-icu",
+      "activities",
+      "43",
+      "snapshot",
+      "a".repeat(64),
+      "1998/01/a.json.gz",
+      883_612_800,
+    );
+    db.prepare("INSERT INTO source_record_revision VALUES(?,?,?,?,?,?)").run(
+      "changed-revision",
+      "new-record",
+      "artifact-revision",
+      null,
+      300,
+      '{"v":2}',
+    );
+    db.prepare("UPDATE source_record_current SET revision_id=? WHERE source_record_id=?").run(
+      "changed-revision",
+      "new-record",
+    );
+    expect(
+      db
+        .prepare(
+          "SELECT revision_id FROM source_record_current WHERE source_record_id='new-record'",
+        )
+        .get(),
+    ).toEqual({
+      revision_id: "changed-revision",
+    });
+    db.prepare(
+      "UPDATE source_record_current SET revision_id='new-record' WHERE source_record_id='new-record'",
+    ).run();
+    expect(() =>
+      db!
+        .prepare("INSERT INTO source_record_revision VALUES(?,?,?,?,?,?)")
+        .run("changed-revision", "new-record", "artifact-revision", null, 300, '{"v":2}'),
+    ).toThrow();
+    expect(() =>
+      db!
+        .prepare("INSERT INTO source_record_revision VALUES(?,?,?,?,?,?)")
+        .run("missing-artifact-revision", "new-record", null, null, 300, "{}"),
+    ).toThrow();
+    expect(() =>
+      db!
+        .prepare(
+          "UPDATE source_record_current SET revision_id='legacy-record' WHERE source_record_id='new-record'",
+        )
+        .run(),
+    ).toThrow();
+    expect(() =>
+      db!
+        .prepare(
+          "UPDATE source_record_revision SET quality_rank=200 WHERE revision_id='changed-revision'",
+        )
+        .run(),
+    ).toThrow(/append-only/);
+    expect(() =>
+      db!.prepare("DELETE FROM source_record_revision WHERE revision_id='changed-revision'").run(),
+    ).toThrow(/append-only/);
+    expect(() =>
+      db!.prepare("DELETE FROM source_record_current WHERE source_record_id='new-record'").run(),
+    ).toThrow(/cannot be deleted/);
+    expect(() => db!.prepare("UPDATE source_artifact SET archive_epoch_s=1").run()).toThrow(
+      /append-only/,
+    );
+    expect(() => db!.prepare("DELETE FROM source_artifact").run()).toThrow(/append-only/);
+    expect(db.prepare("PRAGMA foreign_key_check").all()).toEqual([]);
+  });
+
+  it("enforces source, lane, artifact, watermark, and completion checks", () => {
+    db = openFull();
+    const artifact = (values: readonly (string | number | null)[]) =>
+      db!.prepare("INSERT INTO source_artifact VALUES(?,?,?,?,?,?,?,?)").run(...values);
+    const validAddress = "b".repeat(64);
+    expect(() =>
+      artifact([
+        "a1",
+        "intervals-icu",
+        "activities",
+        "1",
+        "snapshot",
+        validAddress,
+        "1998/01/a",
+        1,
+      ]),
+    ).not.toThrow();
+    for (const values of [
+      ["a2", "unknown", "activities", "1", "snapshot", validAddress, "p", 1],
+      ["a3", "intervals-icu", "file-discovery", null, "raw_file", validAddress, "p", 1],
+      ["a4", "file-import", "activities", "1", "snapshot", validAddress, "p", 1],
+      ["a5", "file-import", "file-discovery", "1", "raw_file", validAddress, "p", 1],
+      ["a6", "file-import", "file-discovery", null, "snapshot", validAddress, "p", 1],
+      ["a7", "intervals-icu", "bulk-fit", "1", "raw_file", "B".repeat(64), "p", 1],
+      ["a8", "intervals-icu", "bulk-fit", "1", "raw_file", validAddress, "", 1],
+      ["a9", "intervals-icu", "bulk-fit", "1", "raw_file", validAddress, "p", -1],
+    ]) {
+      expect(() => artifact(values)).toThrow();
+    }
+
+    expect(() =>
+      db!.prepare("INSERT INTO source_watermark VALUES('intervals-icu','activities','next')").run(),
+    ).not.toThrow();
+    expect(() =>
+      db!
+        .prepare("INSERT INTO source_watermark VALUES('intervals-icu','file-discovery','x')")
+        .run(),
+    ).toThrow();
+    expect(() =>
+      db!.prepare("INSERT INTO source_watermark VALUES('file-import','file-discovery','')").run(),
+    ).toThrow();
+
+    expect(() =>
+      db!
+        .prepare(
+          "INSERT INTO sync_operation(source,lane,watermark_before,watermark_after,artifacts_seen,source_changes,completion_kind) VALUES(?,?,?,?,?,?,?)",
+        )
+        .run("intervals-icu", "activities", "next", "next", 0, 0, "no-op"),
+    ).not.toThrow();
+    expect(() =>
+      db!
+        .prepare(
+          "INSERT INTO sync_operation(source,lane,watermark_before,watermark_after,artifacts_seen,source_changes,completion_kind) VALUES(?,?,?,?,?,?,?)",
+        )
+        .run("intervals-icu", "activities", "next", "changed", 0, 0, "no-op"),
+    ).toThrow();
+    expect(() =>
+      db!
+        .prepare(
+          "INSERT INTO sync_operation(source,lane,watermark_before,watermark_after,artifacts_seen,source_changes,completion_kind) VALUES(?,?,?,?,?,?,?)",
+        )
+        .run("intervals-icu", "activities", "next", "next", 0, 0, "applied"),
+    ).toThrow();
+    expect(() => db!.prepare("UPDATE sync_operation SET artifacts_seen=1").run()).toThrow(
+      /append-only/,
+    );
+    expect(() => db!.prepare("DELETE FROM sync_operation").run()).toThrow(/append-only/);
+  });
+
+  it("enumerates sync state ownership", () => {
+    expect(DUMP_TABLES).toEqual([
+      { table: "anchor_history", orderBy: "id" },
+      { table: "athlete", orderBy: "id" },
+      { table: "dedup_confirmation", orderBy: "id" },
+      { table: "field_merge_override_overlay", orderBy: "id" },
+      { table: "ingest_metadata", orderBy: "singleton" },
+      { table: "intake_flags", orderBy: "id" },
+      { table: "lap", orderBy: "lap_key" },
+      { table: "mean_max_cache", orderBy: "mmax_key" },
+      { table: "metric_snapshot", orderBy: "snapshot_key" },
+      { table: "planned_workout", orderBy: "id" },
+      { table: "pool_size_correction_overlay", orderBy: "id" },
+      { table: "race_goal", orderBy: "id" },
+      { table: "raw_file", orderBy: "sha256" },
+      { table: "repair_fixer_settings", orderBy: "fixer" },
+      { table: "repair_log", orderBy: "repair_key" },
+      { table: "session", orderBy: "session_key" },
+      { table: "source_artifact", orderBy: "artifact_key" },
+      { table: "source_record", orderBy: "id" },
+      { table: "source_record_current", orderBy: "source_record_id" },
+      { table: "source_record_revision", orderBy: "revision_id" },
+      { table: "source_watermark", orderBy: "source, lane" },
+      { table: "sport_settings", orderBy: "id" },
+      { table: "stream", orderBy: "stream_key" },
+      { table: "stroke_correction_overlay", orderBy: "id" },
+      { table: "swim_length", orderBy: "length_key" },
+      { table: "wellness", orderBy: "id" },
+      { table: "workout", orderBy: "workout_key" },
+      { table: "zone_set_history", orderBy: "id" },
+    ]);
+    expect(DUMP_TABLES).toHaveLength(28);
+    expect(DUMP_TABLES.map(({ table }) => String(table))).not.toContain("sync_operation");
+    for (const table of [
+      "source_artifact",
+      "source_record_revision",
+      "source_record_current",
+      "source_watermark",
+      "sync_operation",
+    ]) {
+      expect(DERIVED_TABLES).not.toContain(table);
+    }
   });
 });

--- a/packages/kernel/tests/store-export.test.ts
+++ b/packages/kernel/tests/store-export.test.ts
@@ -84,7 +84,11 @@ interface Populated {
 
 function populated(userVersion = 3): Populated {
   const rows: Record<string, readonly AuthoredRow[]> = {};
-  for (const t of PURE_AUTHORED_TABLES) rows[t] = [{ id: `${t}-1`, v: 1 }, { id: `${t}-2`, v: 2 }];
+  for (const t of PURE_AUTHORED_TABLES)
+    rows[t] = [
+      { id: `${t}-1`, v: 1 },
+      { id: `${t}-2`, v: 2 },
+    ];
   for (const t of MIXED_AUTHORED_TABLES) rows[t] = [{ id: `${t}-m1`, provenance: "manual" }];
   const artifacts: ArchiveArtifact[] = [
     { address: "cc", relPath: "archive/2026/06/cc/cc.fit", bytes: 10, kind: "fit" },
@@ -147,7 +151,9 @@ function makeSink(): ImportSink & { stored: Map<string, Set<string>> } {
   return sink;
 }
 
-function makePresence(missingAddresses: readonly string[] = []): ArchivePresenceChecker & { queried: string[] } {
+function makePresence(
+  missingAddresses: readonly string[] = [],
+): ArchivePresenceChecker & { queried: string[] } {
   const missing = new Set(missingAddresses);
   const queried: string[] = [];
   const p: ArchivePresenceChecker & { queried: string[] } = {
@@ -165,10 +171,7 @@ describe("store export op", () => {
     const data = populated();
     const { source, calls } = makeSource(data);
     const crypto = new FakeCrypto();
-    const result = await buildExport(
-      { source, manifest: makeManifest(data), crypto, codec },
-      {},
-    );
+    const result = await buildExport({ source, manifest: makeManifest(data), crypto, codec }, {});
     const document = (await decodeContainer(result.container, { codec, crypto }, {})) as {
       store: { authored: Record<string, unknown[]> };
     };
@@ -182,8 +185,34 @@ describe("store export op", () => {
     for (const t of MIXED_AUTHORED_TABLES) {
       expect(calls.find((c) => c.table === t)?.manualOnly).toBe(true);
     }
-    for (const forbidden of ["workout", "session", "stream", "raw_file", "source_record", "metric_snapshot", "lap", "swim_length", "mean_max_cache"]) {
+    for (const forbidden of [
+      "workout",
+      "session",
+      "stream",
+      "raw_file",
+      "source_record",
+      "metric_snapshot",
+      "lap",
+      "swim_length",
+      "mean_max_cache",
+      "source_artifact",
+      "source_record_revision",
+      "source_record_current",
+      "source_watermark",
+      "sync_operation",
+    ]) {
       expect(keys).not.toContain(forbidden);
+    }
+    const portableTables = [...PURE_AUTHORED_TABLES, ...MIXED_AUTHORED_TABLES];
+    for (const excluded of [
+      "source_artifact",
+      "source_record_revision",
+      "source_record_current",
+      "source_watermark",
+      "sync_operation",
+    ]) {
+      expect(portableTables).not.toContain(excluded);
+      expect(calls.some(({ table }) => table === excluded)).toBe(false);
     }
   });
 
@@ -222,10 +251,10 @@ describe("store export op", () => {
     expect(built.encrypted).toBe(true);
     expect(built.container[9]).toBe(0x01);
     expect([...built.container.subarray(0, 8)]).toEqual([...CONTAINER_MAGIC]);
-    const iterations = new DataView(
-      built.container.buffer,
-      built.container.byteOffset,
-    ).getUint32(11, false);
+    const iterations = new DataView(built.container.buffer, built.container.byteOffset).getUint32(
+      11,
+      false,
+    );
     expect(iterations).toBe(PBKDF2_ITERATIONS);
     expect(built.container[15]).toBe(16);
     expect(built.container[33]).toBe(12);
@@ -261,7 +290,9 @@ describe("store export op", () => {
     bytes[8] = 1;
     bytes[9] = 0;
     const crypto = new FakeCrypto();
-    await expect(decodeContainer(bytes, { codec, crypto }, {})).rejects.toBeInstanceOf(ExportFormatError);
+    await expect(decodeContainer(bytes, { codec, crypto }, {})).rejects.toBeInstanceOf(
+      ExportFormatError,
+    );
   });
 
   it("(bad-version) byte 8 = 0x02 rejects with a version-2 message", async () => {
@@ -270,13 +301,22 @@ describe("store export op", () => {
     const bad = good.slice();
     bad[8] = 0x02;
     await expect(decodeContainer(bad, { codec, crypto }, {})).rejects.toThrow(/2/);
-    await expect(decodeContainer(bad, { codec, crypto }, {})).rejects.toBeInstanceOf(ExportFormatError);
+    await expect(decodeContainer(bad, { codec, crypto }, {})).rejects.toBeInstanceOf(
+      ExportFormatError,
+    );
   });
 
   it("(corrupt-json) plaintext non-JSON payload rejects", async () => {
     const crypto = new FakeCrypto();
-    const container = new Uint8Array([...CONTAINER_MAGIC, 0x01, 0x00, ...codec.encodeUtf8("{not json")]);
-    await expect(decodeContainer(container, { codec, crypto }, {})).rejects.toBeInstanceOf(ExportFormatError);
+    const container = new Uint8Array([
+      ...CONTAINER_MAGIC,
+      0x01,
+      0x00,
+      ...codec.encodeUtf8("{not json"),
+    ]);
+    await expect(decodeContainer(container, { codec, crypto }, {})).rejects.toBeInstanceOf(
+      ExportFormatError,
+    );
   });
 
   it("(schema-mismatch) newer store version refused; equal and older accepted", async () => {
@@ -335,7 +375,9 @@ describe("store export op", () => {
     );
     expect(imported.manifest.total).toBe(3);
     expect(imported.manifest.missing.map((a) => a.address).sort()).toEqual(["aa", "bb"]);
-    expect(imported.manifest.present + imported.manifest.missing.length).toBe(imported.manifest.total);
+    expect(imported.manifest.present + imported.manifest.missing.length).toBe(
+      imported.manifest.total,
+    );
   });
 
   it("(wrong-pass-fake) a different passphrase maps to ExportDecryptionError", async () => {

--- a/packages/kernel/tests/sync-source.test.ts
+++ b/packages/kernel/tests/sync-source.test.ts
@@ -1,0 +1,97 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, expectTypeOf, it } from "vitest";
+import {
+  SOURCE_IDS,
+  SOURCE_LANES,
+  type BackfillDepth,
+  type PlannedWorkoutDoc,
+  type PushResult,
+  type RawFileSourceArtifact,
+  type SnapshotSourceArtifact,
+  type SourceArtifact,
+  type SourceCapabilities,
+  type SourceCheckpoint,
+  type SourceId,
+  type SourceLane,
+  type SourceWatermark,
+  type SyncBudget,
+  type SyncCompletion,
+  type SyncCompletionResult,
+  type SyncSource,
+  type SyncStateRepository,
+} from "../src/store/index.js";
+
+describe("sync source contract", () => {
+  it("exports the closed sync source type surface", () => {
+    expect(SOURCE_IDS).toEqual(["intervals-icu", "file-import"]);
+    expect(SOURCE_LANES).toEqual([
+      "activities",
+      "streams",
+      "wellness",
+      "settings",
+      "bulk-fit",
+      "file-discovery",
+    ]);
+
+    expectTypeOf<SourceId>().toEqualTypeOf<"intervals-icu" | "file-import">();
+    expectTypeOf<SourceLane>().toEqualTypeOf<
+      "activities" | "streams" | "wellness" | "settings" | "bulk-fit" | "file-discovery"
+    >();
+    expectTypeOf<keyof SourceCapabilities>().toEqualTypeOf<
+      "activities" | "streams" | "rawFiles" | "wellness" | "plannedWorkoutPush" | "backfillDepth"
+    >();
+    expectTypeOf<BackfillDepth>().toEqualTypeOf<
+      | { readonly kind: "none" }
+      | { readonly kind: "bounded"; readonly days: number }
+      | { readonly kind: "full-history" }
+    >();
+    expectTypeOf<SourceWatermark>().toMatchTypeOf<{
+      readonly source: SourceId;
+      readonly lane: SourceLane;
+      readonly value: string | null;
+    }>();
+    expectTypeOf<SyncBudget>().toMatchTypeOf<{
+      readonly signal: AbortSignal;
+      readonly clock: { monotonicNow(): number };
+      readonly deadlineMonotonicMs: number;
+      readonly perRequestTimeoutMs: number;
+      readonly maxRequests: number;
+      readonly maxArtifacts: number;
+    }>();
+    expectTypeOf<SourceArtifact>().toEqualTypeOf<
+      SnapshotSourceArtifact | RawFileSourceArtifact | SourceCheckpoint
+    >();
+    expectTypeOf<PlannedWorkoutDoc>().toEqualTypeOf<{
+      readonly idempotencyKey: string;
+      readonly dateKey: number;
+      readonly sport: "cycling" | "running" | "swimming" | "duathlon" | "triathlon";
+      readonly structure: Readonly<Record<string, unknown>>;
+    }>();
+    expectTypeOf<PushResult>().toEqualTypeOf<
+      | { readonly outcome: "created"; readonly externalId: string }
+      | { readonly outcome: "updated"; readonly externalId: string }
+      | { readonly outcome: "unchanged"; readonly externalId: string }
+    >();
+    expectTypeOf<SyncCompletion>().toMatchTypeOf<{
+      readonly source: SourceId;
+      readonly lane: SourceLane;
+      readonly watermarkBefore: string | null;
+      readonly watermarkAfter: string | null;
+      readonly artifactsSeen: number;
+      readonly sourceChanges: number;
+    }>();
+    expectTypeOf<SyncCompletionResult>().toEqualTypeOf<{
+      readonly operationId: number;
+      readonly completionKind: "applied" | "no-op";
+    }>();
+    expectTypeOf<SyncStateRepository["readWatermark"]>().toBeFunction();
+    expectTypeOf<SyncStateRepository["recordCompletionInTransaction"]>().toBeFunction();
+    expectTypeOf<SyncSource["pull"]>().toBeFunction();
+    expectTypeOf<SyncSource["pushPlannedWorkout"]>().toEqualTypeOf<
+      ((doc: PlannedWorkoutDoc) => Promise<PushResult>) | undefined
+    >();
+
+    const source = readFileSync(new URL("../src/store/sync-source.ts", import.meta.url), "utf8");
+    expect(source).not.toMatch(/validator|collector|consumePlannedWorkout/);
+  });
+});

--- a/packages/kernel/tests/sync-state-repository.test.ts
+++ b/packages/kernel/tests/sync-state-repository.test.ts
@@ -1,0 +1,348 @@
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, describe, expect, it } from "vitest";
+import { MIGRATIONS } from "../src/store/migrations/index.js";
+import type { Row, SqlStore, SqlValue } from "../src/store/ports.js";
+import { createSyncStateRepository } from "../src/store/sync-state-repository.js";
+import type { SyncCompletion } from "../src/store/sync-source.js";
+
+interface Call {
+  readonly method: "get" | "run";
+  readonly sql: string;
+  readonly params: readonly SqlValue[];
+}
+
+class FakeStore implements SqlStore {
+  readonly calls: Call[] = [];
+  readonly gets: Array<Row | undefined> = [];
+
+  async exec(sql: string): Promise<void> {
+    throw new Error(`unexpected exec: ${sql}`);
+  }
+
+  async run(sql: string, params: readonly SqlValue[] = []): Promise<void> {
+    if (/\b(?:BEGIN|COMMIT|ROLLBACK)\b|transaction\s*\(/i.test(sql)) {
+      throw new Error("transaction control forbidden");
+    }
+    this.calls.push({ method: "run", sql, params });
+  }
+
+  async get(sql: string, params: readonly SqlValue[] = []): Promise<Row | undefined> {
+    if (/\b(?:BEGIN|COMMIT|ROLLBACK)\b|transaction\s*\(/i.test(sql)) {
+      throw new Error("transaction control forbidden");
+    }
+    this.calls.push({ method: "get", sql, params });
+    return this.gets.shift();
+  }
+
+  async all(): Promise<Row[]> {
+    throw new Error("unexpected all");
+  }
+
+  async close(): Promise<void> {}
+}
+
+const readSql = `SELECT watermark
+FROM source_watermark
+WHERE source = ? AND lane = ?`;
+const insertSql = `INSERT INTO sync_operation (
+  source,
+  lane,
+  watermark_before,
+  watermark_after,
+  artifacts_seen,
+  source_changes,
+  completion_kind
+) VALUES (?, ?, ?, ?, ?, ?, ?)
+RETURNING operation_id`;
+const upsertSql = `INSERT INTO source_watermark (source, lane, watermark)
+VALUES (?, ?, ?)
+ON CONFLICT(source, lane) DO UPDATE
+SET watermark = excluded.watermark`;
+
+const baseCompletion: SyncCompletion = {
+  source: "intervals-icu",
+  lane: "activities",
+  watermarkBefore: null,
+  watermarkAfter: "opaque-next",
+  artifactsSeen: 2,
+  sourceChanges: 1,
+};
+
+describe("sync state repository", () => {
+  it("reads absent, present, and long opaque watermarks with exact SQL", async () => {
+    const store = new FakeStore();
+    store.gets.push(undefined, { watermark: "cursor:" + "x".repeat(4_096) });
+    const repository = createSyncStateRepository(store);
+
+    const absent = await repository.readWatermark("intervals-icu", "activities");
+    const present = await repository.readWatermark("intervals-icu", "activities");
+    expect(absent).toEqual({ source: "intervals-icu", lane: "activities", value: null });
+    expect(present.value).toBe("cursor:" + "x".repeat(4_096));
+    expect(Object.isFrozen(absent)).toBe(true);
+    expect(Object.isFrozen(present)).toBe(true);
+    expect(store.calls).toEqual([
+      { method: "get", sql: readSql, params: ["intervals-icu", "activities"] },
+      { method: "get", sql: readSql, params: ["intervals-icu", "activities"] },
+    ]);
+  });
+
+  it("validates watermark keys and selected row shapes", async () => {
+    const store = new FakeStore();
+    const repository = createSyncStateRepository(store);
+    for (const [source, lane] of [
+      ["unknown", "activities"],
+      ["intervals-icu", "file-discovery"],
+      ["file-import", "activities"],
+      ["file-import", "unknown"],
+    ] as const) {
+      await expect(repository.readWatermark(source as never, lane as never)).rejects.toThrowError(
+        new TypeError("invalid sync watermark key"),
+      );
+    }
+    expect(store.calls).toEqual([]);
+
+    const malformedRows: Row[] = [
+      { watermark: "", extra: null },
+      { watermark: "" },
+      { watermark: null },
+      { other: "x" },
+    ];
+    for (const malformed of malformedRows) {
+      store.gets.push(malformed);
+      await expect(repository.readWatermark("file-import", "file-discovery")).rejects.toThrow(
+        "invalid sync watermark row",
+      );
+    }
+  });
+
+  it("records applied and no-op completions without transaction control", async () => {
+    const store = new FakeStore();
+    store.gets.push(undefined, { operation_id: 7 }, { watermark: "opaque-next" });
+    const repository = createSyncStateRepository(store);
+    const applied = await repository.recordCompletionInTransaction(baseCompletion);
+
+    expect(applied).toEqual({ operationId: 7, completionKind: "applied" });
+    expect(Object.isFrozen(applied)).toBe(true);
+    expect(store.calls).toEqual([
+      { method: "get", sql: readSql, params: ["intervals-icu", "activities"] },
+      {
+        method: "get",
+        sql: insertSql,
+        params: ["intervals-icu", "activities", null, "opaque-next", 2, 1, "applied"],
+      },
+      { method: "run", sql: upsertSql, params: ["intervals-icu", "activities", "opaque-next"] },
+      { method: "get", sql: readSql, params: ["intervals-icu", "activities"] },
+    ]);
+    expect(
+      store.calls.every(({ sql }) => !/\b(?:BEGIN|COMMIT|ROLLBACK)\b|transaction\s*\(/i.test(sql)),
+    ).toBe(true);
+
+    store.calls.length = 0;
+    store.gets.push({ watermark: "same" }, { operation_id: 8 }, { watermark: "same" });
+    const noOp = await repository.recordCompletionInTransaction({
+      ...baseCompletion,
+      watermarkBefore: "same",
+      watermarkAfter: "same",
+      artifactsSeen: 0,
+      sourceChanges: 0,
+    });
+    expect(noOp).toEqual({ operationId: 8, completionKind: "no-op" });
+    expect(store.calls.some(({ method }) => method === "run")).toBe(false);
+    expect(store.calls[1]).toEqual({
+      method: "get",
+      sql: insertSql,
+      params: ["intervals-icu", "activities", "same", "same", 0, 0, "no-op"],
+    });
+  });
+
+  it("rejects stale planning, watermark clearing, invalid counts, and malformed insert results", async () => {
+    const invalidInputs = [
+      { ...baseCompletion, source: "unknown" },
+      { ...baseCompletion, source: "file-import", lane: "activities" },
+      { ...baseCompletion, watermarkBefore: "" },
+      { ...baseCompletion, watermarkBefore: "set", watermarkAfter: null },
+      { ...baseCompletion, artifactsSeen: -1 },
+      { ...baseCompletion, artifactsSeen: 1.5 },
+      { ...baseCompletion, sourceChanges: -1 },
+      { ...baseCompletion, sourceChanges: Number.MAX_SAFE_INTEGER + 1 },
+    ];
+    for (const input of invalidInputs) {
+      const store = new FakeStore();
+      await expect(
+        createSyncStateRepository(store).recordCompletionInTransaction(input as SyncCompletion),
+      ).rejects.toThrowError(new TypeError("invalid sync completion"));
+      expect(store.calls).toEqual([]);
+    }
+
+    const staleStore = new FakeStore();
+    staleStore.gets.push({ watermark: "changed" });
+    await expect(
+      createSyncStateRepository(staleStore).recordCompletionInTransaction({
+        ...baseCompletion,
+        watermarkBefore: "planned",
+      }),
+    ).rejects.toThrow("sync watermark changed during planning");
+    expect(staleStore.calls).toHaveLength(1);
+
+    const malformedInsertRows: Array<Row | undefined> = [
+      undefined,
+      {},
+      { operation_id: 0 },
+      { operation_id: 1.5 },
+      { operation_id: 1, extra: 2 },
+    ];
+    for (const row of malformedInsertRows) {
+      const store = new FakeStore();
+      store.gets.push(undefined, row);
+      await expect(
+        createSyncStateRepository(store).recordCompletionInTransaction(baseCompletion),
+      ).rejects.toThrow("sync operation insert failed");
+    }
+
+    const updateStore = new FakeStore();
+    updateStore.gets.push(undefined, { operation_id: 1 }, undefined);
+    await expect(
+      createSyncStateRepository(updateStore).recordCompletionInTransaction(baseCompletion),
+    ).rejects.toThrow("sync watermark update failed");
+  });
+});
+
+describe("sync state repository with SQLite", () => {
+  let db: DatabaseSync | undefined;
+
+  afterEach(() => {
+    db?.close();
+    db = undefined;
+  });
+
+  function openStore(): { store: SqlStore; database: DatabaseSync } {
+    const database = new DatabaseSync(":memory:");
+    database.exec("PRAGMA foreign_keys = ON");
+    for (const migration of MIGRATIONS) database.exec(migration.sql);
+    const store: SqlStore = {
+      async exec(sql) {
+        database.exec(sql);
+      },
+      async run(sql, params = []) {
+        database.prepare(sql).run(...params);
+      },
+      async get(sql, params = []) {
+        const row = database.prepare(sql).get(...params);
+        return row === undefined ? undefined : ({ ...row } as Row);
+      },
+      async all(sql, params = []) {
+        return database
+          .prepare(sql)
+          .all(...params)
+          .map((row) => ({ ...row }) as Row);
+      },
+      async close() {
+        database.close();
+      },
+    };
+    return { store, database };
+  }
+
+  it("commits batch data, operation, and watermark atomically and rolls all back", async () => {
+    const opened = openStore();
+    db = opened.database;
+    const repository = createSyncStateRepository(opened.store);
+    const address = "a".repeat(64);
+
+    db.exec("BEGIN IMMEDIATE");
+    db.prepare("INSERT INTO source_artifact VALUES(?,?,?,?,?,?,?,?)").run(
+      "artifact-commit",
+      "intervals-icu",
+      "activities",
+      "42",
+      "snapshot",
+      address,
+      "1998/01/a.json.gz",
+      883_612_800,
+    );
+    const result = await repository.recordCompletionInTransaction(baseCompletion);
+    db.exec("COMMIT");
+
+    expect(result).toEqual({ operationId: 1, completionKind: "applied" });
+    expect(db.prepare("SELECT artifact_key FROM source_artifact").all()).toEqual([
+      { artifact_key: "artifact-commit" },
+    ]);
+    expect(db.prepare("SELECT source,lane,watermark FROM source_watermark").all()).toEqual([
+      { source: "intervals-icu", lane: "activities", watermark: "opaque-next" },
+    ]);
+    expect(db.prepare("SELECT operation_id,completion_kind FROM sync_operation").all()).toEqual([
+      { operation_id: 1, completion_kind: "applied" },
+    ]);
+
+    db.exec("BEGIN IMMEDIATE");
+    db.prepare("INSERT INTO source_artifact VALUES(?,?,?,?,?,?,?,?)").run(
+      "artifact-rollback",
+      "intervals-icu",
+      "activities",
+      "43",
+      "snapshot",
+      address,
+      "1998/01/b.json.gz",
+      883_612_801,
+    );
+    await repository.recordCompletionInTransaction({
+      ...baseCompletion,
+      watermarkBefore: "opaque-next",
+      watermarkAfter: "opaque-rollback",
+    });
+    db.exec("ROLLBACK");
+
+    expect(
+      db.prepare("SELECT artifact_key FROM source_artifact ORDER BY artifact_key").all(),
+    ).toEqual([{ artifact_key: "artifact-commit" }]);
+    expect(db.prepare("SELECT watermark FROM source_watermark").get()).toEqual({
+      watermark: "opaque-next",
+    });
+    expect(db.prepare("SELECT count(*) AS count FROM sync_operation").get()).toEqual({ count: 1 });
+  });
+
+  it("records each no-op and enforces append-only operation and artifact history", async () => {
+    const opened = openStore();
+    db = opened.database;
+    const repository = createSyncStateRepository(opened.store);
+    const noOp = {
+      source: "file-import",
+      lane: "file-discovery",
+      watermarkBefore: null,
+      watermarkAfter: null,
+      artifactsSeen: 0,
+      sourceChanges: 0,
+    } as const;
+    await repository.recordCompletionInTransaction(noOp);
+    await repository.recordCompletionInTransaction(noOp);
+    expect(
+      db
+        .prepare("SELECT operation_id,completion_kind FROM sync_operation ORDER BY operation_id")
+        .all(),
+    ).toEqual([
+      { operation_id: 1, completion_kind: "no-op" },
+      { operation_id: 2, completion_kind: "no-op" },
+    ]);
+    expect(() =>
+      db!.prepare("UPDATE sync_operation SET artifacts_seen=1 WHERE operation_id=1").run(),
+    ).toThrow(/append-only/);
+    expect(() => db!.prepare("DELETE FROM sync_operation WHERE operation_id=1").run()).toThrow(
+      /append-only/,
+    );
+
+    db.prepare("INSERT INTO source_artifact VALUES(?,?,?,?,?,?,?,?)").run(
+      "artifact-key",
+      "file-import",
+      "file-discovery",
+      null,
+      "raw_file",
+      "b".repeat(64),
+      "1998/01/b.fit",
+      883_612_800,
+    );
+    expect(() => db!.prepare("UPDATE source_artifact SET archive_epoch_s=1").run()).toThrow(
+      /append-only/,
+    );
+    expect(() => db!.prepare("DELETE FROM source_artifact").run()).toThrow(/append-only/);
+  });
+});


### PR DESCRIPTION
## Summary

Adds the sync-source contract and deterministic source revision state to the kernel store (W3 PR-01):

- New `sync-source.ts` contract and `sync-state-repository.ts` in `packages/kernel/src/store/`
- Migration `005_sync_state.sql` (store-schema only; FIT ingest version stays at 4) with append-only enforcement on `sync_operation` and `source_artifact`
- Opt-in Retry-After lower-bound handling in `concurrency/retry.ts`, preserving existing capped retry behavior
- Store export/dump coverage for the new tables

## Verification

- Full non-watch suite: 3,672 passed / 5 skipped (exit 0, Node 24)
- Changed files within the spec allowlist; single squash-ready commit; changeset included (patch, internal infrastructure)
