### PR TITLE
fix(kernel-node): release writer lock cleanly after liveness probes

### DIFF
--- a/.changeset/writer-lock-release-hang.md
+++ b/.changeset/writer-lock-release-hang.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/kernel-node": patch
+---
+
+Release the writer lock cleanly after liveness probes or other peer connections.

--- a/packages/kernel-node/src/lock/acquire.ts
+++ b/packages/kernel-node/src/lock/acquire.ts
@@ -1,4 +1,4 @@
-import { createServer, type Server, type AddressInfo } from "node:net";
+import { createServer, type Server, type Socket, type AddressInfo } from "node:net";
 import { existsSync, mkdirSync, chmodSync, statSync } from "node:fs";
 import { unlink } from "node:fs/promises";
 import { join } from "node:path";
@@ -50,15 +50,22 @@ function ensureConfigDirSecure(configDir: string): void {
   }
 }
 
-function bindWriterSocket(): Promise<Server> {
-  return new Promise<Server>((resolve, reject) => {
-    const server = createServer();
+function bindWriterSocket(): Promise<{ server: Server; sockets: Set<Socket> }> {
+  return new Promise((resolve, reject) => {
+    const sockets = new Set<Socket>();
+    const server = createServer((socket) => {
+      sockets.add(socket);
+      socket.on("error", () => {});
+      socket.on("close", () => sockets.delete(socket));
+      socket.resume();
+    });
     server.on("error", reject);
-    server.listen({ host: "127.0.0.1", port: 0 }, () => resolve(server));
+    server.listen({ host: "127.0.0.1", port: 0 }, () => resolve({ server, sockets }));
   });
 }
 
-function closeServer(server: Server): Promise<void> {
+function closeServer(server: Server, sockets: Set<Socket>): Promise<void> {
+  for (const socket of sockets) socket.destroy();
   return new Promise<void>((resolve) => server.close(() => resolve()));
 }
 
@@ -104,7 +111,7 @@ export async function acquireWriteLock(opts: AcquireWriteLockOptions): Promise<A
     return contentionAgainstBound(body?.pid, recordedPort, portFilePath, probe);
   }
 
-  const server = await bindWriterSocket();
+  const { server, sockets } = await bindWriterSocket();
   const actualPort = (server.address() as AddressInfo).port;
 
   const claimAndFill = async (): Promise<WriteLockHandle> => {
@@ -121,7 +128,7 @@ export async function acquireWriteLock(opts: AcquireWriteLockOptions): Promise<A
       lockfilePath,
       portFilePath,
       release: async (): Promise<void> => {
-        await closeServer(server);
+        await closeServer(server, sockets);
         await bestEffortUnlink(lockfilePath);
         await bestEffortUnlink(portFilePath);
       },
@@ -133,7 +140,7 @@ export async function acquireWriteLock(opts: AcquireWriteLockOptions): Promise<A
       return await claimAndFill();
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code !== "EEXIST") {
-        await closeServer(server);
+        await closeServer(server, sockets);
         throw err;
       }
       const other = readLockfile(lockfilePath);
@@ -143,14 +150,14 @@ export async function acquireWriteLock(opts: AcquireWriteLockOptions): Promise<A
         // readable port (claims are born with their body via claimLockfile).
         // An unreadable claim is not proven stale, and no timer may prove it:
         // never unlink, never wait.
-        await closeServer(server);
+        await closeServer(server, sockets);
         throw new WriteLockContentionError(
           `The lockfile at ${lockfilePath} is unreadable; remove it and retry.`,
           3,
         );
       }
       if (await isPortBound(otherPort)) {
-        await closeServer(server);
+        await closeServer(server, sockets);
         return contentionAgainstBound(other?.pid, otherPort, portFilePath, probe);
       }
       await bestEffortUnlink(lockfilePath);
@@ -158,7 +165,7 @@ export async function acquireWriteLock(opts: AcquireWriteLockOptions): Promise<A
     }
   }
 
-  await closeServer(server);
+  await closeServer(server, sockets);
   throw new WriteLockContentionError(
     `Another writer won arbitration for this store; stop that process or wait, then retry.`,
     3,

--- a/packages/kernel-node/tests/lock.test.ts
+++ b/packages/kernel-node/tests/lock.test.ts
@@ -6,7 +6,7 @@
 import { mkdtempSync, rmSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { createServer, type Server } from "node:net";
+import { createConnection, createServer, type Server, type Socket } from "node:net";
 import { createServer as createHttpServer, type Server as HttpServer } from "node:http";
 import { DatabaseSync } from "node:sqlite";
 import { afterEach, describe, expect, it } from "vitest";
@@ -43,6 +43,20 @@ function trackHandle(r: AcquireWriteLockResult): WriteLockHandle {
   if (!isHandle(r)) throw new Error(`expected acquired, got ${r.status}`);
   heldHandles.push(r);
   return r;
+}
+
+async function resolvesWithin<T>(promise: Promise<T>, timeoutMs = 2_000): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_resolve, reject) => {
+        timeout = setTimeout(() => reject(new Error(`operation did not resolve within ${timeoutMs}ms`)), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout !== undefined) clearTimeout(timeout);
+  }
 }
 
 function occupyPort(): Promise<{ port: number; server: Server }> {
@@ -143,6 +157,50 @@ describe("acquireWriteLock", () => {
     const rebind = await acquireWriteLock({ configDir, athleteHome: "/home/a", version: "1.0.0" });
     trackHandle(rebind);
     expect(rebind.status).toBe("acquired");
+  });
+
+  it("(release) resolves after a real contention probe", async () => {
+    const configDir = freshDir();
+    const holder = trackHandle(
+      await acquireWriteLock({ configDir, athleteHome: "/home/a", version: "1.0.0" }),
+    );
+
+    await expect(
+      acquireWriteLock({ configDir, athleteHome: "/home/a", version: "1.0.0" }),
+    ).rejects.toBeInstanceOf(WriteLockContentionError);
+
+    heldHandles.length = 0;
+    await expect(resolvesWithin(holder.release())).resolves.toBeUndefined();
+  });
+
+  it("(release) resolves while a connected peer socket is still open", async () => {
+    const configDir = freshDir();
+    const holder = trackHandle(
+      await acquireWriteLock({ configDir, athleteHome: "/home/a", version: "1.0.0" }),
+    );
+    const peer = await new Promise<Socket>((resolve, reject) => {
+      const socket = createConnection({ host: "127.0.0.1", port: holder.port });
+      const onError = (err: Error): void => reject(err);
+      socket.once("error", onError);
+      socket.once("connect", () => {
+        socket.off("error", onError);
+        resolve(socket);
+      });
+    });
+    const peerClosed = new Promise<void>((resolve) => peer.once("close", () => resolve()));
+    peer.on("error", () => {});
+
+    expect(peer.destroyed).toBe(false);
+    heldHandles.length = 0;
+    const release = holder.release();
+    try {
+      await expect(resolvesWithin(release)).resolves.toBeUndefined();
+      await expect(resolvesWithin(peerClosed)).resolves.toBeUndefined();
+      expect(peer.destroyed).toBe(true);
+    } finally {
+      peer.destroy();
+      await release;
+    }
   });
 
   it("(a) healthy peer returns peer-healthy without binding", async () => {


### PR DESCRIPTION
## Summary

Fixes a hang in the single-writer store lock: after any contending process probed a live writer (port-bound liveness check followed by the health probe), the holder's `release()` waited forever inside `server.close()`.

Root cause: the lock's liveness server accepted probe connections but never read or tracked them. A probe socket that the client had already abandoned never reached EOF on the server side, stayed in the server's connection list, and blocked `server.close()` indefinitely.

Fix in `acquire.ts`:

- The writer socket now tracks accepted connections in a set, swallows their errors, and resumes them so the read side can reach EOF.
- `closeServer` destroys every tracked socket before closing the server, so `release()` never waits on a peer's half-open or still-open connection.

## Verification

- Two new regression tests in `lock.test.ts`: release resolves after a real contention probe, and release resolves even while a peer socket is still connected (both hang forever without the fix; guarded by a bounded race so a regression fails fast).
- Lock test file: 16/16 pass. Full non-watch suite: 3,674 passed / 5 skipped (exit 0, Node 24).
- Changeset included (patch, internal infrastructure).
