### PR TITLE
feat(coach): add sync composition root

### DIFF
--- a/.changeset/coach-sync-composition.md
+++ b/.changeset/coach-sync-composition.md
@@ -1,0 +1,6 @@
+---
+"@enduragent/coach": patch
+"@enduragent/kernel-node": patch
+---
+
+Add the governed Reference layer sync composition root and share the existing Node writer lifecycle. Internal infrastructure; ships nothing to athletes.

--- a/packages/coach/package.json
+++ b/packages/coach/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@enduragent/coach",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Private Node composition root for governed Reference layer sync orchestration.",
+  "type": "module",
+  "files": ["dist"],
+  "exports": {
+    "./runtime": "./dist/runtime.js",
+    "./sync": "./dist/sync.js"
+  },
+  "engines": {
+    "node": ">=24"
+  },
+  "scripts": {
+    "build": "tsup",
+    "check": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@enduragent/kernel": "workspace:*",
+    "@enduragent/kernel-node": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.0",
+    "tsup": "^8.4.0",
+    "typescript": "^6.0.2",
+    "vitest": "^4.1.4"
+  },
+  "license": "MIT"
+}

--- a/packages/coach/src/runtime.ts
+++ b/packages/coach/src/runtime.ts
@@ -1,0 +1,56 @@
+import {
+  runCoachDevWriter,
+  type CoachDevWriterContext,
+  type CoachDevWriterFailureStage,
+} from "@enduragent/kernel-node/coach-dev";
+
+export type CoachStoreWriterContext = CoachDevWriterContext;
+
+export type CoachStoreWriterErrorCode = "writer-lock-held" | "writer-failed";
+
+export class CoachStoreWriterError extends Error {
+  readonly code: CoachStoreWriterErrorCode;
+  readonly stage: CoachDevWriterFailureStage | null;
+
+  constructor(code: CoachStoreWriterErrorCode, stage: CoachDevWriterFailureStage | null) {
+    super(
+      code === "writer-lock-held"
+        ? "coach store writer is already active"
+        : `coach store writer failed at ${stage}`,
+    );
+    this.name = "CoachStoreWriterError";
+    this.code = code;
+    this.stage = stage;
+  }
+}
+
+export interface CoachRuntimeDependencies {
+  readonly runWriter: typeof runCoachDevWriter;
+}
+
+const defaultDependencies: CoachRuntimeDependencies = Object.freeze({
+  runWriter: runCoachDevWriter,
+});
+
+export async function withCoachStoreWriter<T>(
+  env: Record<string, string | undefined>,
+  operation: (context: CoachStoreWriterContext) => Promise<T>,
+  deps?: CoachRuntimeDependencies,
+): Promise<T> {
+  if (typeof operation !== "function") {
+    throw new TypeError("invalid coach writer operation");
+  }
+
+  const dependencies = deps ?? defaultDependencies;
+  const result = await dependencies.runWriter({
+    env,
+    writerVersion: "coach-sync/1",
+    operation,
+  });
+
+  if (result.status === "completed") return result.value;
+  if (result.status === "writer-lock-held") {
+    throw new CoachStoreWriterError("writer-lock-held", null);
+  }
+  throw new CoachStoreWriterError("writer-failed", result.stage);
+}

--- a/packages/coach/src/sync.ts
+++ b/packages/coach/src/sync.ts
@@ -1,0 +1,133 @@
+import type { ImportReport } from "@enduragent/kernel/ingest";
+import { SOURCE_IDS, type SourceId, type SyncSource } from "@enduragent/kernel/store";
+import { importFilesWithReport } from "@enduragent/kernel-node/ingest";
+import { withCoachStoreWriter, type CoachStoreWriterContext } from "./runtime.js";
+
+export interface CoachSourceRunContext extends CoachStoreWriterContext {
+  readonly source: SyncSource;
+}
+
+export type CoachSourceRun = (context: CoachSourceRunContext) => Promise<void>;
+
+export interface CoachSourceBinding {
+  readonly source: SyncSource;
+  readonly run: CoachSourceRun;
+}
+
+export interface RunCoachSyncOptions {
+  readonly env: Record<string, string | undefined>;
+  readonly sources: readonly CoachSourceBinding[];
+  readonly importPaths?: readonly string[];
+}
+
+export interface CoachSourceOutcome {
+  readonly source_id: SourceId;
+  readonly status: "completed" | "failed";
+  readonly message: string | null;
+}
+
+export interface CoachSyncReport {
+  readonly schema_version: 1;
+  readonly sources: readonly CoachSourceOutcome[];
+  readonly import_report: ImportReport | null;
+}
+
+export interface CoachSyncDependencies {
+  readonly withWriter: typeof withCoachStoreWriter;
+  readonly importFiles: typeof importFilesWithReport;
+}
+
+const defaultDependencies: CoachSyncDependencies = Object.freeze({
+  withWriter: withCoachStoreWriter,
+  importFiles: importFilesWithReport,
+});
+
+function isObject(value: unknown): value is Record<PropertyKey, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export async function runCoachSync(
+  options: RunCoachSyncOptions,
+  deps?: CoachSyncDependencies,
+): Promise<CoachSyncReport> {
+  if (!isObject(options) || !isObject(options.env) || !Array.isArray(options.sources)) {
+    throw new TypeError("invalid coach sync options");
+  }
+
+  const sourceIds = new Set<SourceId>();
+  const sources: CoachSourceBinding[] = [];
+  for (const binding of options.sources) {
+    if (
+      !isObject(binding) ||
+      !isObject(binding.source) ||
+      !SOURCE_IDS.includes(binding.source.id as SourceId) ||
+      typeof binding.run !== "function"
+    ) {
+      throw new TypeError("invalid coach source binding");
+    }
+    const source = binding.source as unknown as SyncSource;
+    if (sourceIds.has(source.id)) {
+      throw new TypeError("duplicate coach sync source");
+    }
+    sourceIds.add(source.id);
+    sources.push(Object.freeze({ source, run: binding.run as CoachSourceRun }));
+  }
+  const copiedSources = Object.freeze(sources);
+
+  let copiedImportPaths: readonly string[];
+  if (options.importPaths === undefined) {
+    copiedImportPaths = Object.freeze([]);
+  } else {
+    if (!Array.isArray(options.importPaths)) {
+      throw new TypeError("invalid coach import paths");
+    }
+    const paths = new Set<string>();
+    for (const path of options.importPaths) {
+      if (typeof path !== "string" || path.length === 0 || paths.has(path)) {
+        throw new TypeError("invalid coach import paths");
+      }
+      paths.add(path);
+    }
+    copiedImportPaths = Object.freeze([...options.importPaths]);
+  }
+
+  const dependencies = deps ?? defaultDependencies;
+  return dependencies.withWriter(options.env, async ({ home, store }) => {
+    const outcomes: CoachSourceOutcome[] = [];
+    for (const binding of copiedSources) {
+      const context = Object.freeze({ home, store, source: binding.source });
+      try {
+        await binding.run(context);
+        outcomes.push(
+          Object.freeze({
+            source_id: binding.source.id,
+            status: "completed",
+            message: null,
+          }),
+        );
+      } catch {
+        outcomes.push(
+          Object.freeze({
+            source_id: binding.source.id,
+            status: "failed",
+            message: "source synchronization failed",
+          }),
+        );
+      }
+    }
+
+    const importReport =
+      copiedImportPaths.length === 0
+        ? null
+        : await dependencies.importFiles({
+            inputPaths: copiedImportPaths,
+            archiveDir: home.archiveDir,
+            store,
+          });
+    return Object.freeze({
+      schema_version: 1,
+      sources: Object.freeze(outcomes),
+      import_report: importReport,
+    });
+  });
+}

--- a/packages/coach/tests/coach-sync.test.ts
+++ b/packages/coach/tests/coach-sync.test.ts
@@ -1,0 +1,480 @@
+import { access, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import type { ImportReport } from "@enduragent/kernel/ingest";
+import type { SourceId, SyncSource } from "@enduragent/kernel/store";
+import type { AthleteHome } from "@enduragent/kernel-node/home";
+import { importFilesWithReport } from "@enduragent/kernel-node/ingest";
+import { LOCKFILE_NAME, PORT_FILE_NAME } from "@enduragent/kernel-node/lock";
+import {
+  type CoachDevWriterFailureStage,
+  type CoachDevWriterResult,
+  type RunCoachDevWriterOptions,
+} from "@enduragent/kernel-node/coach-dev";
+import { openSqliteStorage } from "@enduragent/kernel-node/sqlite";
+import {
+  CoachStoreWriterError,
+  withCoachStoreWriter,
+  type CoachStoreWriterContext,
+} from "../src/runtime.js";
+import { runCoachSync, type CoachSourceBinding, type RunCoachSyncOptions } from "../src/sync.js";
+
+const capabilities = Object.freeze({
+  activities: false,
+  streams: false,
+  rawFiles: false,
+  wellness: false,
+  plannedWorkoutPush: false,
+  backfillDepth: Object.freeze({ kind: "none" as const }),
+});
+
+function syncSource(id: SourceId): SyncSource {
+  return {
+    id,
+    capabilities,
+    async *pull() {},
+  };
+}
+
+function syntheticHome(root = "synthetic-root"): AthleteHome {
+  return {
+    root,
+    storeDir: join(root, "store"),
+    archiveDir: join(root, "archive"),
+    configDir: join(root, "config"),
+  };
+}
+
+function syntheticStore(): CoachStoreWriterContext["store"] {
+  return {
+    async exec() {},
+    async run() {},
+    async get() {
+      return undefined;
+    },
+    async all() {
+      return [];
+    },
+    async close() {},
+    async getUserVersion() {
+      return 0;
+    },
+    async setUserVersion() {},
+    async transaction<T>(operation: () => Promise<T>) {
+      return operation();
+    },
+  };
+}
+
+function syntheticContext(root?: string): CoachStoreWriterContext {
+  return { home: syntheticHome(root), store: syntheticStore() };
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const importReport = { report: "synthetic" } as unknown as ImportReport;
+
+describe("coach sync composition", () => {
+  it("runtime delegates to the exact writer version and returns the operation value", async () => {
+    const context = syntheticContext();
+    const value = { outcome: "exact-value" } as const;
+    const observed: { options?: RunCoachDevWriterOptions<unknown>; calls: number } = {
+      calls: 0,
+    };
+    const runWriter = async <T>(
+      options: RunCoachDevWriterOptions<T>,
+    ): Promise<CoachDevWriterResult<T>> => {
+      observed.calls += 1;
+      observed.options = options as RunCoachDevWriterOptions<unknown>;
+      return { status: "completed", value: await options.operation(context) };
+    };
+    const operation = async (received: CoachStoreWriterContext) => {
+      expect(received).toBe(context);
+      return value;
+    };
+
+    await expect(
+      withCoachStoreWriter({ ENDURAGENT_HOME: "synthetic-root" }, operation, { runWriter }),
+    ).resolves.toBe(value);
+    expect(observed.calls).toBe(1);
+    expect(observed.options).toMatchObject({
+      env: { ENDURAGENT_HOME: "synthetic-root" },
+      writerVersion: "coach-sync/1",
+      operation,
+    });
+
+    await expect(withCoachStoreWriter({}, undefined as never, { runWriter })).rejects.toThrow(
+      new TypeError("invalid coach writer operation"),
+    );
+    expect(observed.calls).toBe(1);
+  });
+
+  it("runtime maps contention and every lifecycle failure without private error data", async () => {
+    const privateValue = "private dependency data";
+    const operation = async () => privateValue;
+    const contentionWriter = async <T>(): Promise<CoachDevWriterResult<T>> => ({
+      status: "writer-lock-held",
+    });
+    await expect(
+      withCoachStoreWriter({}, operation, { runWriter: contentionWriter }),
+    ).rejects.toEqual(new CoachStoreWriterError("writer-lock-held", null));
+
+    const stages: readonly CoachDevWriterFailureStage[] = [
+      "resolve home",
+      "acquire lock",
+      "create store directory",
+      "secure store directory",
+      "open store",
+      "run migrations",
+      "invoke operation",
+      "close store",
+      "release lock",
+    ];
+    for (const stage of stages) {
+      const failedWriter = async <T>(): Promise<CoachDevWriterResult<T>> => ({
+        status: "failed",
+        stage,
+      });
+      let caught: unknown;
+      try {
+        await withCoachStoreWriter({}, operation, { runWriter: failedWriter });
+      } catch (error) {
+        caught = error;
+      }
+      expect(caught).toBeInstanceOf(CoachStoreWriterError);
+      expect(caught).toMatchObject({
+        name: "CoachStoreWriterError",
+        code: "writer-failed",
+        stage,
+        message: `coach store writer failed at ${stage}`,
+      });
+      expect(JSON.stringify(caught)).not.toContain(privateValue);
+    }
+  });
+
+  it("validates the complete request before acquiring the writer", async () => {
+    let writerCalls = 0;
+    let sourceCalls = 0;
+    let importCalls = 0;
+    const context = syntheticContext();
+    const withWriter: typeof withCoachStoreWriter = async <T>(
+      _env: Record<string, string | undefined>,
+      operation: (value: CoachStoreWriterContext) => Promise<T>,
+    ): Promise<T> => {
+      writerCalls += 1;
+      return operation(context);
+    };
+    const importFiles: typeof importFilesWithReport = async () => {
+      importCalls += 1;
+      return importReport;
+    };
+    const validBinding: CoachSourceBinding = {
+      source: syncSource("intervals-icu"),
+      async run() {
+        sourceCalls += 1;
+      },
+    };
+    const dependencies = { withWriter, importFiles };
+    const invalidCases: readonly { value: unknown; message: string }[] = [
+      { value: null, message: "invalid coach sync options" },
+      { value: [], message: "invalid coach sync options" },
+      { value: {}, message: "invalid coach sync options" },
+      { value: { env: null, sources: [] }, message: "invalid coach sync options" },
+      { value: { env: [], sources: [] }, message: "invalid coach sync options" },
+      { value: { env: {}, sources: {} }, message: "invalid coach sync options" },
+      { value: { env: {}, sources: [null] }, message: "invalid coach source binding" },
+      {
+        value: { env: {}, sources: [{ source: null, run() {} }] },
+        message: "invalid coach source binding",
+      },
+      {
+        value: { env: {}, sources: [{ source: { id: "other" }, run() {} }] },
+        message: "invalid coach source binding",
+      },
+      {
+        value: { env: {}, sources: [{ source: syncSource("file-import"), run: null }] },
+        message: "invalid coach source binding",
+      },
+      {
+        value: { env: {}, sources: [validBinding, { source: null, run() {} }] },
+        message: "invalid coach source binding",
+      },
+      {
+        value: { env: {}, sources: [validBinding, validBinding] },
+        message: "duplicate coach sync source",
+      },
+      {
+        value: { env: {}, sources: [], importPaths: "input.fit" },
+        message: "invalid coach import paths",
+      },
+      { value: { env: {}, sources: [], importPaths: [""] }, message: "invalid coach import paths" },
+      { value: { env: {}, sources: [], importPaths: [1] }, message: "invalid coach import paths" },
+      {
+        value: { env: {}, sources: [], importPaths: ["input.fit", "input.fit"] },
+        message: "invalid coach import paths",
+      },
+    ];
+
+    for (const { value, message } of invalidCases) {
+      await expect(runCoachSync(value as RunCoachSyncOptions, dependencies)).rejects.toThrow(
+        new TypeError(message),
+      );
+    }
+    expect(writerCalls).toBe(0);
+    expect(sourceCalls).toBe(0);
+    expect(importCalls).toBe(0);
+  });
+
+  it("runs sources sequentially and continues with a safe failure", async () => {
+    const context = syntheticContext();
+    const order: string[] = [];
+    let running = 0;
+    let maximumRunning = 0;
+    const withWriter: typeof withCoachStoreWriter = async <T>(
+      _env: Record<string, string | undefined>,
+      operation: (value: CoachStoreWriterContext) => Promise<T>,
+    ): Promise<T> => operation(context);
+    const importFiles: typeof importFilesWithReport = async () => importReport;
+    const binding = (id: SourceId, shouldFail: boolean): CoachSourceBinding => ({
+      source: syncSource(id),
+      async run(received) {
+        expect(Object.isFrozen(received)).toBe(true);
+        running += 1;
+        maximumRunning = Math.max(maximumRunning, running);
+        order.push(`start:${id}`);
+        await Promise.resolve();
+        order.push(`end:${id}`);
+        running -= 1;
+        if (shouldFail) throw new Error("private source failure");
+      },
+    });
+
+    const report = await runCoachSync(
+      {
+        env: {},
+        sources: [binding("intervals-icu", true), binding("file-import", false)],
+      },
+      { withWriter, importFiles },
+    );
+    expect(order).toEqual([
+      "start:intervals-icu",
+      "end:intervals-icu",
+      "start:file-import",
+      "end:file-import",
+    ]);
+    expect(maximumRunning).toBe(1);
+    expect(report).toEqual({
+      schema_version: 1,
+      sources: [
+        {
+          source_id: "intervals-icu",
+          status: "failed",
+          message: "source synchronization failed",
+        },
+        { source_id: "file-import", status: "completed", message: null },
+      ],
+      import_report: null,
+    });
+    expect(Object.isFrozen(report)).toBe(true);
+    expect(Object.isFrozen(report.sources)).toBe(true);
+    expect(report.sources.every(Object.isFrozen)).toBe(true);
+    expect(JSON.stringify(report)).not.toContain("private source failure");
+  });
+
+  it("imports one nonempty path batch exactly once after sources", async () => {
+    const context = syntheticContext();
+    const order: string[] = [];
+    const originalPaths = ["z.fit", "a.fit"];
+    let observedImport: Parameters<typeof importFilesWithReport>[0] | undefined;
+    let importCalls = 0;
+    const withWriter: typeof withCoachStoreWriter = async <T>(
+      _env: Record<string, string | undefined>,
+      operation: (value: CoachStoreWriterContext) => Promise<T>,
+    ): Promise<T> => operation(context);
+    const importFiles: typeof importFilesWithReport = async (options) => {
+      importCalls += 1;
+      order.push("import");
+      observedImport = options;
+      return importReport;
+    };
+    const report = await runCoachSync(
+      {
+        env: {},
+        sources: [
+          {
+            source: syncSource("intervals-icu"),
+            async run() {
+              order.push("source");
+            },
+          },
+        ],
+        importPaths: originalPaths,
+      },
+      { withWriter, importFiles },
+    );
+
+    expect(order).toEqual(["source", "import"]);
+    expect(importCalls).toBe(1);
+    expect(observedImport).toEqual({
+      inputPaths: originalPaths,
+      archiveDir: context.home.archiveDir,
+      store: context.store,
+    });
+    expect(observedImport?.inputPaths).not.toBe(originalPaths);
+    expect(Object.isFrozen(observedImport?.inputPaths)).toBe(true);
+    expect(observedImport?.store).toBe(context.store);
+    expect(report.import_report).toBe(importReport);
+    expect(Object.isFrozen(importReport)).toBe(false);
+  });
+
+  it("skips file import for an empty path list", async () => {
+    const context = syntheticContext();
+    let importCalls = 0;
+    const withWriter: typeof withCoachStoreWriter = async <T>(
+      _env: Record<string, string | undefined>,
+      operation: (value: CoachStoreWriterContext) => Promise<T>,
+    ): Promise<T> => operation(context);
+    const importFiles: typeof importFilesWithReport = async () => {
+      importCalls += 1;
+      return importReport;
+    };
+    const dependencies = { withWriter, importFiles };
+
+    await expect(
+      runCoachSync({ env: {}, sources: [], importPaths: [] }, dependencies),
+    ).resolves.toMatchObject({ import_report: null });
+    await expect(runCoachSync({ env: {}, sources: [] }, dependencies)).resolves.toMatchObject({
+      import_report: null,
+    });
+    expect(importCalls).toBe(0);
+  });
+
+  it("real writer lifecycle migrates closes and releases an isolated store", async () => {
+    const root = await mkdtemp(join(tmpdir(), "coach-runtime-"));
+    const home = syntheticHome(root);
+    try {
+      const value = await withCoachStoreWriter(
+        { ENDURAGENT_HOME: root },
+        async ({ home: receivedHome, store }) => {
+          expect(receivedHome).toEqual(home);
+          return store.get("PRAGMA user_version");
+        },
+      );
+      expect(value).toEqual({ user_version: 5 });
+      expect(await pathExists(join(home.storeDir, "store.db"))).toBe(true);
+      expect(await pathExists(join(home.configDir, LOCKFILE_NAME))).toBe(false);
+      expect(await pathExists(join(home.configDir, PORT_FILE_NAME))).toBe(false);
+
+      const reopened = openSqliteStorage(join(home.storeDir, "store.db"));
+      try {
+        await expect(reopened.get("PRAGMA user_version")).resolves.toEqual({
+          user_version: 5,
+        });
+      } finally {
+        await reopened.close();
+      }
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("isolates concurrent writers for two athlete homes", async () => {
+    const leftRoot = await mkdtemp(join(tmpdir(), "coach-left-"));
+    const rightRoot = await mkdtemp(join(tmpdir(), "coach-right-"));
+    const leftHome = syntheticHome(leftRoot);
+    const rightHome = syntheticHome(rightRoot);
+    const seenHomes: string[] = [];
+    const binding = (home: AthleteHome, marker: string): CoachSourceBinding => ({
+      source: syncSource("intervals-icu"),
+      async run(context) {
+        expect(context.home).toEqual(home);
+        seenHomes.push(context.home.root);
+        await context.store.run(
+          "INSERT INTO source_watermark (source,lane,watermark) VALUES (?,?,?)",
+          ["intervals-icu", "activities", marker],
+        );
+      },
+    });
+    try {
+      const [leftReport, rightReport] = await Promise.all([
+        runCoachSync({
+          env: { ENDURAGENT_HOME: leftRoot },
+          sources: [binding(leftHome, "left-marker")],
+        }),
+        runCoachSync({
+          env: { ENDURAGENT_HOME: rightRoot },
+          sources: [binding(rightHome, "right-marker")],
+        }),
+      ]);
+      expect(leftReport.sources).toEqual([
+        { source_id: "intervals-icu", status: "completed", message: null },
+      ]);
+      expect(rightReport.sources).toEqual([
+        { source_id: "intervals-icu", status: "completed", message: null },
+      ]);
+      expect(leftReport.import_report).toBeNull();
+      expect(rightReport.import_report).toBeNull();
+      expect(new Set(seenHomes)).toEqual(new Set([leftRoot, rightRoot]));
+
+      const leftStore = openSqliteStorage(join(leftHome.storeDir, "store.db"));
+      const rightStore = openSqliteStorage(join(rightHome.storeDir, "store.db"));
+      try {
+        await expect(leftStore.all("SELECT watermark FROM source_watermark")).resolves.toEqual([
+          { watermark: "left-marker" },
+        ]);
+        await expect(rightStore.all("SELECT watermark FROM source_watermark")).resolves.toEqual([
+          { watermark: "right-marker" },
+        ]);
+      } finally {
+        await leftStore.close();
+        await rightStore.close();
+      }
+
+      let releaseHold!: () => void;
+      let markEntered!: () => void;
+      const entered = new Promise<void>((resolve) => {
+        markEntered = resolve;
+      });
+      const hold = new Promise<void>((resolve) => {
+        releaseHold = resolve;
+      });
+      const first = runCoachSync({
+        env: { ENDURAGENT_HOME: leftRoot },
+        sources: [
+          {
+            source: syncSource("file-import"),
+            async run() {
+              markEntered();
+              await hold;
+            },
+          },
+        ],
+      });
+      await entered;
+      await expect(
+        runCoachSync({ env: { ENDURAGENT_HOME: leftRoot }, sources: [] }),
+      ).rejects.toMatchObject({
+        name: "CoachStoreWriterError",
+        code: "writer-lock-held",
+        stage: null,
+      });
+      releaseHold();
+      await expect(first).resolves.toMatchObject({ schema_version: 1 });
+      expect(await pathExists(join(leftHome.configDir, LOCKFILE_NAME))).toBe(false);
+      expect(await pathExists(join(leftHome.configDir, PORT_FILE_NAME))).toBe(false);
+      expect(await pathExists(join(rightHome.configDir, LOCKFILE_NAME))).toBe(false);
+      expect(await pathExists(join(rightHome.configDir, PORT_FILE_NAME))).toBe(false);
+    } finally {
+      await rm(leftRoot, { recursive: true, force: true });
+      await rm(rightRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/coach/tsconfig.json
+++ b/packages/coach/tsconfig.json
@@ -1,0 +1,31 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": [
+      "ES2022"
+    ],
+    "types": [
+      "node"
+    ],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "ignoreDeprecations": "6.0"
+  },
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/packages/coach/tsup.config.ts
+++ b/packages/coach/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: {
+    runtime: "src/runtime.ts",
+    sync: "src/sync.ts",
+  },
+  format: ["esm"],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  splitting: false,
+  removeNodeProtocol: false,
+});

--- a/packages/kernel-node/package.json
+++ b/packages/kernel-node/package.json
@@ -11,7 +11,8 @@
     "./lock": "./dist/lock/index.js",
     "./store-export": "./dist/store-export/index.js",
     "./home": "./dist/home/index.js",
-    "./ingest": "./dist/ingest/index.js"
+    "./ingest": "./dist/ingest/index.js",
+    "./coach-dev": "./dist/coach-dev.js"
   },
   "engines": {
     "node": ">=24"

--- a/packages/kernel-node/src/cli/coach-dev.ts
+++ b/packages/kernel-node/src/cli/coach-dev.ts
@@ -1,45 +1,68 @@
 import { chmod, mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
-import { resolveAthleteHome } from "@enduragent/kernel-node/home";
-import { acquireWriteLock, WriteLockContentionError } from "@enduragent/kernel-node/lock";
-import { openSqliteStorage } from "@enduragent/kernel-node/sqlite";
-import { importFilesWithReport } from "@enduragent/kernel-node/ingest";
 import type { ImportReport } from "@enduragent/kernel/ingest";
 import { runMigrations } from "@enduragent/kernel/store";
 import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
+import { resolveAthleteHome } from "../home/index.js";
+import type { AthleteHome } from "../home/index.js";
+import { importFilesWithReport } from "../ingest/index.js";
+import { acquireWriteLock, WriteLockContentionError } from "../lock/index.js";
+import { openSqliteStorage } from "../sqlite/index.js";
 
 const USAGE = "Usage: coach-dev import --report <path>...\n";
-const WRITER_VERSION = "coach-dev-import/1";
-
 type CliResult = {
   readonly exitCode: 0 | 1 | 2 | 3;
   readonly stdout: string;
   readonly stderr: string;
 };
 
-const defaultDeps = {
+const defaultWriterDeps = {
   resolveAthleteHome,
   acquireWriteLock,
   mkdir,
   chmod,
   openSqliteStorage,
   runMigrations,
+};
+
+const defaultDeps = {
+  ...defaultWriterDeps,
   importFilesWithReport,
 };
 
 type CoachDevDependencies = typeof defaultDeps;
 
-type FailureStage =
+type FailureStage = Exclude<CoachDevWriterFailureStage, "invoke operation"> | "import files";
+
+export type CoachDevWriterFailureStage =
   | "resolve home"
   | "acquire lock"
   | "create store directory"
   | "secure store directory"
   | "open store"
   | "run migrations"
-  | "import files"
+  | "invoke operation"
   | "close store"
   | "release lock";
+
+export interface CoachDevWriterContext {
+  readonly home: AthleteHome;
+  readonly store: ReturnType<typeof openSqliteStorage>;
+}
+
+export interface RunCoachDevWriterOptions<T> {
+  readonly env: Record<string, string | undefined>;
+  readonly writerVersion: string;
+  readonly operation: (context: CoachDevWriterContext) => Promise<T>;
+}
+
+export type CoachDevWriterResult<T> =
+  | { readonly status: "completed"; readonly value: T }
+  | { readonly status: "writer-lock-held" }
+  | { readonly status: "failed"; readonly stage: CoachDevWriterFailureStage };
+
+export type CoachDevWriterDependencies = typeof defaultWriterDeps;
 
 function help(): CliResult {
   return { exitCode: 0, stdout: USAGE, stderr: "" };
@@ -95,52 +118,34 @@ function success(report: ImportReport): CliResult {
   };
 }
 
-export async function runCoachDev(
-  argv: readonly string[],
-  env: Record<string, string | undefined>,
-  deps: CoachDevDependencies = defaultDeps,
-): Promise<CliResult> {
-  if (
-    (argv.length === 1 && argv[0] === "--help") ||
-    (argv.length === 2 && argv[0] === "import" && argv[1] === "--help")
-  ) {
-    return help();
-  }
-
-  const inputPaths = argv.slice(2);
-  if (
-    argv[0] !== "import" ||
-    argv[1] !== "--report" ||
-    inputPaths.length === 0 ||
-    inputPaths.some((path) => path.length === 0 || path.startsWith("-"))
-  ) {
-    return usageError();
-  }
-
-  let home: ReturnType<CoachDevDependencies["resolveAthleteHome"]>;
+export async function runCoachDevWriter<T>(
+  options: RunCoachDevWriterOptions<T>,
+  deps: CoachDevWriterDependencies = defaultWriterDeps,
+): Promise<CoachDevWriterResult<T>> {
+  let home: AthleteHome;
   try {
-    home = deps.resolveAthleteHome(env);
+    home = deps.resolveAthleteHome(options.env);
   } catch {
-    return importFailed("resolve home");
+    return { status: "failed", stage: "resolve home" };
   }
 
-  let lockResult: Awaited<ReturnType<CoachDevDependencies["acquireWriteLock"]>>;
+  let lockResult: Awaited<ReturnType<CoachDevWriterDependencies["acquireWriteLock"]>>;
   try {
     lockResult = await deps.acquireWriteLock({
       configDir: home.configDir,
       athleteHome: home.root,
-      version: WRITER_VERSION,
+      version: options.writerVersion,
     });
   } catch (error) {
-    if (error instanceof WriteLockContentionError) return writerLockHeld();
-    return importFailed("acquire lock");
+    if (error instanceof WriteLockContentionError) return { status: "writer-lock-held" };
+    return { status: "failed", stage: "acquire lock" };
   }
 
-  if (lockResult.status === "peer-healthy") return writerLockHeld();
+  if (lockResult.status === "peer-healthy") return { status: "writer-lock-held" };
 
-  let failureStage: FailureStage | undefined;
-  let report: ImportReport | undefined;
-  let store: ReturnType<CoachDevDependencies["openSqliteStorage"]> | undefined;
+  let failureStage: CoachDevWriterFailureStage | undefined;
+  let value!: T;
+  let store: ReturnType<CoachDevWriterDependencies["openSqliteStorage"]> | undefined;
 
   try {
     try {
@@ -176,13 +181,9 @@ export async function runCoachDev(
 
       if (failureStage === undefined && store !== undefined) {
         try {
-          report = await deps.importFilesWithReport({
-            inputPaths,
-            archiveDir: home.archiveDir,
-            store,
-          });
+          value = await options.operation({ home, store });
         } catch {
-          failureStage = "import files";
+          failureStage = "invoke operation";
         }
       }
     } finally {
@@ -202,11 +203,50 @@ export async function runCoachDev(
     }
   }
 
-  if (failureStage !== undefined) return importFailed(failureStage);
-  return success(report!);
+  if (failureStage !== undefined) return { status: "failed", stage: failureStage };
+  return { status: "completed", value };
 }
 
-if (import.meta.url === pathToFileURL(process.argv[1]!).href) {
+export async function runCoachDev(
+  argv: readonly string[],
+  env: Record<string, string | undefined>,
+  deps: CoachDevDependencies = defaultDeps,
+): Promise<CliResult> {
+  if (
+    (argv.length === 1 && argv[0] === "--help") ||
+    (argv.length === 2 && argv[0] === "import" && argv[1] === "--help")
+  ) {
+    return help();
+  }
+
+  const inputPaths = argv.slice(2);
+  if (
+    argv[0] !== "import" ||
+    argv[1] !== "--report" ||
+    inputPaths.length === 0 ||
+    inputPaths.some((path) => path.length === 0 || path.startsWith("-"))
+  ) {
+    return usageError();
+  }
+
+  const result = await runCoachDevWriter(
+    {
+      env,
+      writerVersion: "coach-dev-import/1",
+      operation: ({ home, store }) =>
+        deps.importFilesWithReport({ inputPaths, archiveDir: home.archiveDir, store }),
+    },
+    deps,
+  );
+
+  if (result.status === "writer-lock-held") return writerLockHeld();
+  if (result.status === "failed") {
+    return importFailed(result.stage === "invoke operation" ? "import files" : result.stage);
+  }
+  return success(result.value);
+}
+
+if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href) {
   const result = await runCoachDev(process.argv.slice(2), process.env);
   process.stdout.write(result.stdout);
   process.stderr.write(result.stderr);

--- a/packages/kernel-node/tests/coach-dev-import.test.ts
+++ b/packages/kernel-node/tests/coach-dev-import.test.ts
@@ -9,6 +9,7 @@ import type { MigratorStore, SqlStore } from "@enduragent/kernel/store";
 import type { WriteLockHandle } from "@enduragent/kernel-node/lock";
 
 type RunCoachDev = typeof import("../src/cli/coach-dev.js").runCoachDev;
+type RunCoachDevWriter = typeof import("../src/cli/coach-dev.js").runCoachDevWriter;
 type Dependencies = NonNullable<Parameters<RunCoachDev>[2]>;
 
 const USAGE = "Usage: coach-dev import --report <path>...\n";
@@ -162,6 +163,7 @@ const fullReportFixture: ImportReport = {
 };
 
 let runCoachDev: RunCoachDev;
+let runCoachDevWriter: RunCoachDevWriter;
 let acquireWriteLock: typeof import("@enduragent/kernel-node/lock").acquireWriteLock;
 let resolveAthleteHome: typeof import("@enduragent/kernel-node/home").resolveAthleteHome;
 let openSqliteStorage: typeof import("@enduragent/kernel-node/sqlite").openSqliteStorage;
@@ -206,7 +208,7 @@ beforeAll(async () => {
   openSqliteStorage = sqliteModule.openSqliteStorage;
   dumpStore = storeModule.dumpStore;
   MIGRATIONS = migrationModule.MIGRATIONS;
-  ({ runCoachDev } = await import("../src/cli/coach-dev.js"));
+  ({ runCoachDev, runCoachDevWriter } = await import("../src/cli/coach-dev.js"));
 });
 
 afterAll(async () => {
@@ -668,6 +670,77 @@ describe("coach-dev import --report", () => {
       archiveDir: scenario.home.archiveDir,
       store: scenario.store,
     });
+  });
+
+  it("shared writer lifecycle owns generic operation and cleanup", async () => {
+    const successful = injected();
+    const value = { result: "generic-operation-value" } as const;
+    let context: unknown;
+    const result = await runCoachDevWriter(
+      {
+        env: { ENDURAGENT_HOME: successful.home.root },
+        writerVersion: "generic-operation/1",
+        operation: async (received) => {
+          successful.calls.push("operation");
+          context = received;
+          return value;
+        },
+      },
+      successful.deps,
+    );
+    expect(result).toEqual({ status: "completed", value });
+    expect(context).toEqual({ home: successful.home, store: successful.store });
+    expect(successful.observed.lock).toEqual({
+      configDir: successful.home.configDir,
+      athleteHome: successful.home.root,
+      version: "generic-operation/1",
+    });
+    expect(successful.calls).toEqual([
+      "resolve",
+      "acquire",
+      "mkdir",
+      "chmod",
+      "open",
+      "migrate",
+      "operation",
+      "close",
+      "release",
+    ]);
+
+    const privateValues = ["private operation data", "private close data", "private release data"];
+    const failed = injected({
+      fail: {
+        close: new Error(privateValues[1]),
+        release: new Error(privateValues[2]),
+      },
+    });
+    const failure = await runCoachDevWriter(
+      {
+        env: {},
+        writerVersion: "generic-operation/1",
+        operation: async () => {
+          failed.calls.push("operation");
+          throw new Error(privateValues[0]);
+        },
+      },
+      failed.deps,
+    );
+    expect(failure).toEqual({ status: "failed", stage: "invoke operation" });
+    expect(failed.calls).toEqual([
+      "resolve",
+      "acquire",
+      "mkdir",
+      "chmod",
+      "open",
+      "migrate",
+      "operation",
+      "close",
+      "release",
+    ]);
+    const serialized = JSON.stringify(failure);
+    for (const privateValue of privateValues) {
+      expect(serialized).not.toContain(privateValue);
+    }
   });
 
   it("pre-store failure table uses safe stage diagnostics", async () => {

--- a/packages/kernel-node/tsup.config.ts
+++ b/packages/kernel-node/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: { index: "src/index.ts", sqlite: "src/sqlite/index.ts", "archive/index": "src/archive/index.ts", "lock/index": "src/lock/index.ts", "store-export/index": "src/store-export/index.ts", "home/index": "src/home/index.ts", "ingest/index": "src/ingest/index.ts" },
+  entry: { index: "src/index.ts", sqlite: "src/sqlite/index.ts", "archive/index": "src/archive/index.ts", "lock/index": "src/lock/index.ts", "store-export/index": "src/store-export/index.ts", "home/index": "src/home/index.ts", "ingest/index": "src/ingest/index.ts", "coach-dev": "src/cli/coach-dev.ts" },
   format: ["esm"],
   dts: true,
   sourcemap: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,28 @@ importers:
         specifier: ^4.3.6
         version: 4.4.1
 
+  packages/coach:
+    dependencies:
+      '@enduragent/kernel':
+        specifier: workspace:*
+        version: link:../kernel
+      '@enduragent/kernel-node':
+        specifier: workspace:*
+        version: link:../kernel-node
+    devDependencies:
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.6.0
+      tsup:
+        specifier: ^8.4.0
+        version: 8.5.1(postcss@8.5.12)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.3)
+      typescript:
+        specifier: ^6.0.2
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.4
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.8(vitest@4.1.5))(msw@2.14.2(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))
+
   packages/coach-contract:
     dependencies:
       zod:


### PR DESCRIPTION
## Summary

Adds the coach sync composition root (W3 PR-02):

- New private `packages/coach` package with `runtime.ts` (store-writer wrapper contract over the shared Node writer lifecycle) and `sync.ts` (governed sync orchestration: validated source bindings, sequential source runs with safe per-source failure, optional file-import batch after sources)
- Extracts the writer lifecycle from the kernel-node `coach-dev` CLI behind a public `./coach-dev` export, preserving CLI behavior
- Eight new composition tests, one added lifecycle test, lockfile/multi-entry build wiring

Spec note: the spec's public-subpath self-import requirement conflicted with its clean multi-entry build requirement (tsup cleans `dist` before that self-import can resolve); resolved with source-relative internal imports while preserving the public `./coach-dev` export surface.

Depends on #355 (writer-lock release fix), which this branch is rebased on — the new concurrent-writers isolation test is what exposed that pre-existing bug.

## Verification

- Full non-watch suite on the rebased branch: 3,683 passed / 5 skipped (exit 0, Node 24)
- Changed files within the spec's 12-file allowlist; single squash-ready commit; changeset included (patch, internal infrastructure)
