### PR TITLE
feat(reference): add intervals.icu archive source

### DIFF
--- a/.changeset/intervals-icu-source.md
+++ b/.changeset/intervals-icu-source.md
@@ -1,0 +1,9 @@
+---
+"@enduragent/core": patch
+"@enduragent/kernel": patch
+"@enduragent/sync-intervals-icu": patch
+---
+
+Add the Reference layer intervals.icu source with archive-first activity, stream,
+wellness, sport-setting, and FIT hydration plus deterministic activity revisions.
+Private infrastructure; ships nothing to athletes.

--- a/packages/core/src/reference/index.ts
+++ b/packages/core/src/reference/index.ts
@@ -119,6 +119,11 @@ export {
   type RenamedActivityRow,
   type RenamedWellnessRow,
 } from "./sync/rename-tp-fields.js";
+export {
+  makeIntervalsHttpFactory,
+  type RunScopedHttpFactory,
+  type RunScopedHttpFactoryArgs,
+} from "./sync/intervals-client-factory.js";
 
 // ─── Validation: recommendation metadata + audit log ──────────────────
 export {

--- a/packages/core/src/reference/sync/intervals-client-factory.ts
+++ b/packages/core/src/reference/sync/intervals-client-factory.ts
@@ -1,5 +1,13 @@
 import { IntervalsClient } from "intervals-icu-api";
+import type { HttpPort } from "@enduragent/kernel/ports";
 import { chainedSignal } from "../../concurrency/abort-budget.js";
+
+export interface RunScopedHttpFactoryArgs {
+  readonly outer: AbortSignal;
+  readonly perRequestTimeoutMs: number;
+}
+
+export type RunScopedHttpFactory = (args: RunScopedHttpFactoryArgs) => HttpPort;
 
 /**
  * Construct a fetch wrapper that injects a chained `AbortSignal` (orchestrator
@@ -19,6 +27,48 @@ export function wrapFetchWithSignal(opts: {
       ...init,
       signal: chainedSignal({ outer: opts.outer, perRequestMs: opts.perRequestMs }),
     });
+}
+
+export function makeIntervalsHttpFactory(options: {
+  readonly apiKey: string;
+  readonly baseFetch?: typeof globalThis.fetch;
+}): RunScopedHttpFactory {
+  if (typeof options.apiKey !== "string" || options.apiKey.length === 0) {
+    throw new TypeError("intervals.icu API key is required");
+  }
+  const authorization = `Basic ${btoa(`API_KEY:${options.apiKey}`)}`;
+  const baseFetch = options.baseFetch ?? globalThis.fetch;
+  return ({ outer, perRequestTimeoutMs }) => {
+    const fetch = wrapFetchWithSignal({ baseFetch, outer, perRequestMs: perRequestTimeoutMs });
+    return {
+      async fetch(request) {
+        const headers = new Headers(request.headers);
+        if (headers.has("authorization")) {
+          throw new TypeError("authorization header is managed by the intervals.icu adapter");
+        }
+        headers.set("authorization", authorization);
+        const response = await fetch(request.url, {
+          method: request.method,
+          headers,
+          body:
+            typeof request.body === "string"
+              ? request.body
+              : request.body === undefined
+                ? undefined
+                : new Uint8Array(request.body),
+        });
+        const responseHeaders: Record<string, string> = {};
+        response.headers.forEach((value, key) => {
+          responseHeaders[key.toLowerCase()] = value;
+        });
+        return {
+          status: response.status,
+          headers: responseHeaders,
+          body: new Uint8Array(await response.arrayBuffer()),
+        };
+      },
+    };
+  };
 }
 
 /**

--- a/packages/core/tests/reference-intervals-client-factory.test.ts
+++ b/packages/core/tests/reference-intervals-client-factory.test.ts
@@ -3,6 +3,7 @@ import { IntervalsClient } from "intervals-icu-api";
 import {
   makeAbortableClient,
   makeChatClient,
+  makeIntervalsHttpFactory,
   wrapFetchWithSignal,
 } from "../src/reference/sync/intervals-client-factory.js";
 
@@ -148,5 +149,54 @@ describe("makeChatClient", () => {
 
     expect(stub).toHaveBeenCalledTimes(1);
     expect(result.ok).toBe(false);
+  });
+});
+
+describe("makeIntervalsHttpFactory raw adapter", () => {
+  const basicUser = ["API", "KEY"].join("_");
+
+  it("injects Basic credentials while preserving raw response bytes and headers", async () => {
+    const baseFetch = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      expect(new Headers(init?.headers).get("authorization")).toBe(`Basic ${btoa(`${basicUser}:dummy`)}`);
+      expect(init?.method).toBe("POST");
+      expect(init?.body).toEqual(new Uint8Array([1, 2]));
+      return new Response(new Uint8Array([9, 8]), { status: 201, headers: { "Retry-After": "120", "X-Test": "yes" } });
+    });
+    const outer = new AbortController();
+    const port = makeIntervalsHttpFactory({ apiKey: "dummy", baseFetch: baseFetch as typeof globalThis.fetch })({
+      outer: outer.signal,
+      perRequestTimeoutMs: 30_000,
+    });
+    await expect(port.fetch({ method: "POST", url: "https://example.test/raw", body: new Uint8Array([1, 2]) })).resolves.toEqual({
+      status: 201,
+      headers: { "retry-after": "120", "x-test": "yes" },
+      body: new Uint8Array([9, 8]),
+    });
+    expect(baseFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects empty keys and caller-supplied authorization", async () => {
+    expect(() => makeIntervalsHttpFactory({ apiKey: String() })).toThrow("API key is required");
+    const port = makeIntervalsHttpFactory({ apiKey: "dummy", baseFetch: vi.fn() as never })({
+      outer: new AbortController().signal,
+      perRequestTimeoutMs: 1_000,
+    });
+    await expect(port.fetch({ method: "GET", url: "https://example.test/", headers: { Authorization: "dummy" } }))
+      .rejects.toThrow("authorization header is managed");
+  });
+
+  it("creates a fresh run-scoped abort closure", async () => {
+    const signals: AbortSignal[] = [];
+    const baseFetch: typeof globalThis.fetch = async (_input, init) => {
+      signals.push(init?.signal as AbortSignal);
+      return new Response();
+    };
+    const factory = makeIntervalsHttpFactory({ apiKey: "dummy", baseFetch });
+    const first = new AbortController(), second = new AbortController();
+    await factory({ outer: first.signal, perRequestTimeoutMs: 30_000 }).fetch({ method: "GET", url: "https://example.test/1" });
+    await factory({ outer: second.signal, perRequestTimeoutMs: 30_000 }).fetch({ method: "GET", url: "https://example.test/2" });
+    first.abort();
+    expect(signals[0]?.aborted).toBe(true);
+    expect(signals[1]?.aborted).toBe(false);
   });
 });

--- a/packages/kernel-node/tests/inv2-overlay-recompute.test.ts
+++ b/packages/kernel-node/tests/inv2-overlay-recompute.test.ts
@@ -1,8 +1,12 @@
 import { copyFileSync, existsSync, mkdtempSync, rmSync } from "node:fs";
+import { createHash } from "node:crypto";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { dumpStore, runMigrations, type MigratorStore, type SqlStore } from "@enduragent/kernel/store";
+import { dumpStore, runMigrations, sortKeys, type MigratorStore, type SqlStore } from "@enduragent/kernel/store";
+import { canonicalJson, type ArchiveManager } from "@enduragent/kernel/archive";
+import { canonicalPick, createMaterializeClusterInTransaction, importArtifactsWithReport,
+  type ConcernValue, type PlatformImportArtifact } from "@enduragent/kernel/ingest";
 import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
 import { importFilesWithReport } from "../src/ingest/import-files.js";
 import { openSqliteStorage } from "../src/sqlite/index.js";
@@ -59,6 +63,44 @@ describe("global version and overlay recompute", () => {
     expect(await store.get("SELECT * FROM pool_size_correction_overlay")).toEqual(overlay);
     expect(await store.get("SELECT distance_m FROM session WHERE session_key=?", [sessionKey])).toEqual({ distance_m: 200 });
     expect((await store.all("SELECT distance_m FROM swim_length ORDER BY length_key")).map((row) => row.distance_m)).toEqual([50, 50, 50, 50]);
+  });
+  it("revision preserves authored overlay at the unchanged session key", async () => {
+    const values = new Map<string, unknown>();
+    const archive: ArchiveManager = {
+      async writeSnapshot(value, when) {
+        const address = createHash("sha256").update(canonicalJson(value)).digest("hex"), relPath = `${when.epochSeconds}/${address}.json.gz`;
+        values.set(relPath, structuredClone(value)); return { address, relPath, deduped: false };
+      },
+      async readSnapshot(pathValue) { return structuredClone(values.get(pathValue)); },
+      async has(pathValue) { return values.has(pathValue); },
+      async writeArtifact() { throw new Error("unused"); }, async readArtifact() { throw new Error("unused"); },
+      async quarantine() { throw new Error("unused"); },
+    };
+    const hashKey = async (fields: readonly (string | number)[]) => createHash("sha256").update(fields.join("\u001f")).digest("hex");
+    const makePlatform = async (name: string): Promise<PlatformImportArtifact> => {
+      const activity = { id: "overlay-activity", name }, instant = { epochSeconds: 884_000_000 };
+      const archived = await archive.writeSnapshot(activity, instant);
+      const concerns: Record<string, ConcernValue> = { "session.sport": "cycling", "session.start_utc": instant.epochSeconds,
+        "session.local_date_key": 19980105, "session.elapsed_s": 100, "session.is_transition": false,
+        "session.summary_json": JSON.stringify(sortKeys(activity)), "stream:time": { timestamps: [884_000_000, 884_000_100], values: [884_000_000, 884_000_100] } };
+      return { source: "intervals-icu", activity_id: activity.id, activity, concerns,
+        dedup: { sport_family: "cycling", is_transition: false, start_utc: instant.epochSeconds, duration_s: 100, distance_m: null },
+        raw_snapshot_address: archived.address, raw_snapshot_rel_path: archived.relPath,
+        sourceEvidence: { source: "intervals-icu", lane: "activities", externalId: activity.id,
+          archiveInstant: instant, archive: archived, normalizedActivityJson: canonicalJson(activity) } };
+    };
+    const deps = { store, archive, hashKey, canonicalPick, prepareFile: async () => { throw new Error("unused"); },
+      materializeClusterInTransaction: createMaterializeClusterInTransaction(hashKey), ingestVersion: 4 as const };
+    await importArtifactsWithReport({ files: [], platform_records: [await makePlatform("first")] }, deps);
+    const sessionKey = String((await store.get("SELECT session_key FROM session"))!.session_key);
+    await store.run("INSERT INTO field_merge_override_overlay(id,target_table,target_key,field_name,override_value_json,device_id,hlc_physical_ms,hlc_counter) VALUES(?,?,?,?,?,?,?,?)",
+      ["authored-overlay", "session", sessionKey, "name", '"preferred"', "device", 1, 0]);
+    const before = await store.get("SELECT * FROM field_merge_override_overlay WHERE id='authored-overlay'");
+    const report = await importArtifactsWithReport({ files: [], platform_records: [await makePlatform("renamed")] }, deps);
+    expect((await store.get("SELECT session_key FROM session"))!.session_key).toBe(sessionKey);
+    expect(await store.get("SELECT * FROM field_merge_override_overlay WHERE id='authored-overlay'")).toEqual(before);
+    expect(report.orphaned_overlays).not.toContainEqual(expect.objectContaining({ id: "authored-overlay" }));
+    expect(report.updates.source_record).toBe(1);
   });
   it("rolls back derived replacement when materialization fails", async () => {
     const options = { inputPaths: [path("brick-cycling.fit")], archiveDir, store };

--- a/packages/kernel-node/tests/source-revision-refresh.test.ts
+++ b/packages/kernel-node/tests/source-revision-refresh.test.ts
@@ -1,0 +1,126 @@
+import { createHash } from "node:crypto";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { canonicalJson, type ArchiveManager } from "@enduragent/kernel/archive";
+import { canonicalPick, createMaterializeClusterInTransaction, importArtifactsWithReport,
+  type ConcernValue, type ImportReportDeps, type PlatformImportArtifact } from "@enduragent/kernel/ingest";
+import { dumpStore, runMigrations, sortKeys, type MigratorStore, type SqlStore } from "@enduragent/kernel/store";
+import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
+import { openSqliteStorage } from "../src/sqlite/index.js";
+
+const hashKey = async (fields: readonly (string | number)[]) => createHash("sha256").update(fields.join("\u001f")).digest("hex");
+
+function memoryArchive(): ArchiveManager & { readonly snapshots: Map<string, unknown> } {
+  const snapshots = new Map<string, unknown>();
+  return {
+    snapshots,
+    async writeSnapshot(value, when) {
+      const address = createHash("sha256").update(canonicalJson(value)).digest("hex");
+      const relPath = `${when.epochSeconds}/${address}.json.gz`;
+      const deduped = snapshots.has(relPath); snapshots.set(relPath, structuredClone(value));
+      return { address, relPath, deduped };
+    },
+    async readSnapshot(path) { const value = snapshots.get(path); if (value === undefined) throw new Error("missing snapshot"); return structuredClone(value); },
+    async has(path) { return snapshots.has(path); },
+    async writeArtifact() { throw new Error("unused"); }, async readArtifact() { throw new Error("unused"); },
+    async quarantine() { throw new Error("unused"); },
+  };
+}
+
+async function platform(archive: ReturnType<typeof memoryArchive>, name: string, evidence = true): Promise<PlatformImportArtifact> {
+  const activity = { id: "synthetic-a", name };
+  const instant = { epochSeconds: 884_000_000 };
+  const stored = await archive.writeSnapshot(activity, instant);
+  const concerns: Record<string, ConcernValue> = {
+    "session.sport": "cycling", "session.start_utc": instant.epochSeconds,
+    "session.local_date_key": 19980105, "session.elapsed_s": 100, "session.moving_s": 90,
+    "session.is_transition": false, "session.summary_json": JSON.stringify(sortKeys(activity)),
+    "stream:time": { timestamps: [instant.epochSeconds, instant.epochSeconds + 100], values: [instant.epochSeconds, instant.epochSeconds + 100] },
+  };
+  return { source: "intervals-icu", activity_id: activity.id, activity, concerns,
+    dedup: { sport_family: "cycling", is_transition: false, start_utc: instant.epochSeconds, duration_s: 100, distance_m: null },
+    raw_snapshot_address: stored.address, raw_snapshot_rel_path: stored.relPath,
+    sourceEvidence: evidence ? { source: "intervals-icu", lane: "activities", externalId: activity.id,
+      archiveInstant: instant, archive: stored, normalizedActivityJson: canonicalJson(activity) } : undefined };
+}
+
+describe("activity source revision refresh", () => {
+  let root: string;
+  let store: SqlStore & MigratorStore;
+  let archive: ReturnType<typeof memoryArchive>;
+  beforeEach(async () => {
+    root = mkdtempSync(join(tmpdir(), "source-revision-"));
+    store = openSqliteStorage(join(root, "store.db"));
+    await runMigrations(store, MIGRATIONS);
+    archive = memoryArchive();
+  });
+  afterEach(async () => { await store.close(); rmSync(root, { recursive: true, force: true }); });
+
+  function deps(materialize = createMaterializeClusterInTransaction(hashKey)): ImportReportDeps {
+    return { store, archive, hashKey, canonicalPick, materializeClusterInTransaction: materialize,
+      prepareFile: async () => { throw new Error("unused"); }, ingestVersion: 4 };
+  }
+
+  it("uses payload hash only, persists archive address path and instant, and reports one update", async () => {
+    const firstArtifact = await platform(archive, "first");
+    const first = await importArtifactsWithReport({ files: [], platform_records: [firstArtifact] }, deps());
+    expect(first.inserts.source_record).toBe(1); expect(first.updates.source_record).toBe(0);
+    const persisted = await store.get(`SELECT a.archive_address,a.archive_rel_path,a.archive_epoch_s
+FROM source_record_current c JOIN source_record_revision r ON r.source_record_id=c.source_record_id AND r.revision_id=c.revision_id
+JOIN source_artifact a ON a.artifact_key=r.artifact_key`);
+    expect(persisted).toEqual({ archive_address: firstArtifact.sourceEvidence!.archive.address,
+      archive_rel_path: firstArtifact.sourceEvidence!.archive.relPath, archive_epoch_s: 884_000_000 });
+    expect(await archive.readSnapshot(String(persisted!.archive_rel_path))).toEqual(firstArtifact.activity);
+    const exactDump = await dumpStore(store);
+    const exact = await importArtifactsWithReport({ files: [], platform_records: [firstArtifact] }, deps());
+    expect(exact.updates.source_record).toBe(0); expect(await dumpStore(store)).toBe(exactDump);
+
+    const sessionKey = String((await store.get("SELECT session_key FROM session"))!.session_key);
+    const changed = await platform(archive, "changed");
+    const revision = await importArtifactsWithReport({ files: [], platform_records: [changed] }, deps());
+    expect(revision.updates.source_record).toBe(1);
+    expect((await store.get("SELECT session_key FROM session"))!.session_key).toBe(sessionKey);
+    expect((await store.get("SELECT count(*) AS c FROM source_record_revision"))!.c).toBe(2);
+  });
+
+  it("hydrates path for a legacy equal presentation and reports one update", async () => {
+    const legacy = await platform(archive, "legacy", false);
+    await importArtifactsWithReport({ files: [], platform_records: [legacy] }, deps());
+    expect(await store.get("SELECT artifact_key FROM source_record_revision")).toEqual({ artifact_key: null });
+    const hydrated = { ...legacy, sourceEvidence: { source: "intervals-icu" as const, lane: "activities" as const,
+      externalId: String(legacy.activity_id), archiveInstant: { epochSeconds: 884_000_000 },
+      archive: { address: legacy.raw_snapshot_address!, relPath: legacy.raw_snapshot_rel_path!, deduped: true },
+      normalizedActivityJson: canonicalJson(legacy.activity) } };
+    const report = await importArtifactsWithReport({ files: [], platform_records: [hydrated] }, deps());
+    expect(report.updates.source_record).toBe(1);
+    expect((await store.get(`SELECT a.archive_rel_path FROM source_record_current c
+JOIN source_record_revision r ON r.source_record_id=c.source_record_id AND r.revision_id=c.revision_id
+JOIN source_artifact a ON a.artifact_key=r.artifact_key`))!.archive_rel_path).toBe(legacy.raw_snapshot_rel_path);
+  });
+
+  it("reselects known revision, relinks, and reports one update", async () => {
+    const first = await platform(archive, "first"), second = await platform(archive, "second");
+    await importArtifactsWithReport({ files: [], platform_records: [first] }, deps());
+    await importArtifactsWithReport({ files: [], platform_records: [second] }, deps());
+    const result = await importArtifactsWithReport({ files: [], platform_records: [first] }, deps());
+    expect(result.updates.source_record).toBe(1);
+    expect((await store.get(`SELECT r.raw_sha256 FROM source_record_current c
+JOIN source_record_revision r ON r.source_record_id=c.source_record_id AND r.revision_id=c.revision_id`))!.raw_sha256)
+      .toBe(first.raw_snapshot_address);
+    expect((await store.get("SELECT workout_key,session_key FROM source_record"))!.session_key).toBe(
+      (await store.get("SELECT session_key FROM session"))!.session_key,
+    );
+  });
+
+  it("rolls back revision selection and recompute together", async () => {
+    await importArtifactsWithReport({ files: [], platform_records: [await platform(archive, "first")] }, deps());
+    const before = await dumpStore(store);
+    const changed = await platform(archive, "changed");
+    await expect(importArtifactsWithReport({ files: [], platform_records: [changed] }, deps(async () => {
+      throw new Error("injected materialization failure");
+    }))).rejects.toThrow("injected materialization failure");
+    expect(await dumpStore(store)).toBe(before);
+  });
+});

--- a/packages/kernel/src/ingest/dedup-rekey.ts
+++ b/packages/kernel/src/ingest/dedup-rekey.ts
@@ -2,14 +2,14 @@ import { assertValidAddress } from "../archive/paths.js";
 import { sortKeys } from "../store/canonical-json.js";
 import { createDedupConfirmationRepository } from "../store/dedup-confirmation-repository.js";
 import { deleteAllDerivedRowsInTransaction } from "./rebuild.js";
-import { createRawFileRepository, createSourceRecordRepository } from "../store/source-repository.js";
+import { createIntervalsSourceRepository, createRawFileRepository, createSourceRecordRepository } from "../store/source-repository.js";
 import type { RawFileRow, Row, SourceRecordRow, SqlStore } from "../store/ports.js";
 import type { Candidate, ConcernValue, LapConcern, SwimLengthConcern } from "./canonical-pick.js";
 import { DEFAULT_TRANSITION_WINDOW_S, planBrickAdjacency, type SportSettingInput } from "./brick-adjacency.js";
 import { DEFAULT_TIER3_THRESHOLDS, planDedup, type DedupCandidateSummary } from "./dedup.js";
 import { encodeStream } from "./stream-codec.js";
 import { rescalePoolDistances } from "./pool-size-rescale.js";
-import { buildPlatformPresentation, replayPlatformPresentation, type PlatformPresentation } from "./source-ledger.js";
+import { buildPlatformPresentation, parseEnvelope, replayPlatformPresentation, type PlatformPresentation } from "./source-ledger.js";
 import { FIT_INGEST_VERSION } from "./types.js";
 import {
   DEFAULT_REPAIR_FIXER_SETTINGS,
@@ -68,6 +68,73 @@ function sourceRow(row: Row): SourceRecordRow {
     quality_rank: integer(row.quality_rank, "source quality rank"),
     payload_json: string(row.payload_json, "source payload"),
   };
+}
+
+interface SelectedSourceRow extends SourceRecordRow {
+  readonly artifact_key: string | null;
+  readonly archive_rel_path: string | null;
+  readonly archive_epoch_s: number | null;
+}
+
+function selectedSourceRow(row: Row): SelectedSourceRow {
+  const source = sourceRow(row);
+  const artifactKey = row.artifact_key === null ? null : string(row.artifact_key, "source artifact key");
+  const archiveRelPath = row.archive_rel_path === null ? null : string(row.archive_rel_path, "source archive path");
+  const archiveEpoch = row.archive_epoch_s === null ? null : integer(row.archive_epoch_s, "source archive epoch");
+  if (artifactKey === null) {
+    if (archiveRelPath !== null || archiveEpoch !== null) throw new TypeError("invalid legacy source archive evidence");
+  } else if (archiveRelPath === null || archiveEpoch === null) throw new TypeError("incomplete source archive evidence");
+  return { ...source, artifact_key: artifactKey, archive_rel_path: archiveRelPath, archive_epoch_s: archiveEpoch };
+}
+
+const SELECTED_ACTIVITY_SOURCE_SQL = `SELECT
+  sr.id, sr.workout_key, sr.session_key, sr.source, sr.external_id,
+  r.raw_sha256, r.quality_rank, r.payload_json,
+  r.artifact_key, a.archive_rel_path, a.archive_epoch_s
+FROM source_record AS sr
+JOIN source_record_current AS c ON c.source_record_id = sr.id
+JOIN source_record_revision AS r
+  ON r.source_record_id = c.source_record_id AND r.revision_id = c.revision_id
+LEFT JOIN source_artifact AS a ON a.artifact_key = r.artifact_key
+WHERE sr.source = 'intervals-icu'
+  AND (a.lane = 'activities' OR r.artifact_key IS NULL)
+ORDER BY sr.id`;
+
+async function readSelectedSourceRows(store: SqlStore): Promise<SelectedSourceRow[]> {
+  return (await store.all(SELECTED_ACTIVITY_SOURCE_SQL)).map(selectedSourceRow);
+}
+
+function sourcePresentationRow(row: SelectedSourceRow): SourceRecordRow {
+  return {
+    id: row.id,
+    workout_key: row.workout_key,
+    session_key: row.session_key,
+    source: row.source,
+    external_id: row.external_id,
+    raw_sha256: row.raw_sha256,
+    quality_rank: row.quality_rank,
+    payload_json: row.payload_json,
+  };
+}
+
+async function readSourceRevisionState(store: SqlStore): Promise<readonly Row[]> {
+  return store.all(`SELECT
+  sr.id, sr.source, sr.external_id, sr.workout_key, sr.session_key,
+  c.revision_id AS current_revision_id,
+  r.revision_id, r.artifact_key, r.raw_sha256, r.quality_rank, r.payload_json,
+  a.lane AS artifact_lane, a.archive_address, a.archive_rel_path, a.archive_epoch_s
+FROM source_record AS sr
+LEFT JOIN source_record_current AS c ON c.source_record_id = sr.id
+LEFT JOIN source_record_revision AS r ON r.source_record_id = sr.id
+LEFT JOIN source_artifact AS a ON a.artifact_key = r.artifact_key
+WHERE sr.source = 'intervals-icu'
+ORDER BY sr.id COLLATE BINARY ASC, r.revision_id COLLATE BINARY ASC`);
+}
+
+function sameEnvelopeSemantics(left: string, right: string): boolean {
+  const a = parseEnvelope(left), b = parseEnvelope(right);
+  return canonical({ activity: a.activity, concerns: a.concerns, dedup: a.dedup })
+    === canonical({ activity: b.activity, concerns: b.concerns, dedup: b.dedup });
 }
 
 interface RepairFixerSettingsRow {
@@ -255,6 +322,11 @@ async function runGlobalReplan(
   }
 
   const incomingPlatforms = new Map<string, PlatformPresentation>();
+  const evidenceCount = batch.platform_records.filter((platform) => platform.sourceEvidence !== undefined).length;
+  const evidenceMode = evidenceCount > 0;
+  if (evidenceMode && evidenceCount !== batch.platform_records.length) {
+    throw new TypeError("mixed platform source evidence batch");
+  }
   for (const platform of batch.platform_records) {
     const presentation = await buildPlatformPresentation(platform, deps.hashKey);
     if (platform.raw_snapshot_address !== null) {
@@ -318,18 +390,39 @@ ORDER BY sha256 COLLATE BINARY ASC`)).map(rawRow);
     allAddresses.set(address, incoming);
   }
 
-  const persistedSourceRows = (await deps.store.all(`SELECT id, workout_key, session_key, source, external_id,
-       raw_sha256, quality_rank, payload_json
-FROM source_record
-ORDER BY id COLLATE BINARY ASC`)).map(sourceRow);
+  const persistedSourceRows = await readSelectedSourceRows(deps.store);
+  const revisionState = await readSourceRevisionState(deps.store);
+  for (const incoming of incomingPlatforms.values()) {
+    const collision = revisionState.find((row) => row.id === incoming.row.id
+      && (row.artifact_lane === "streams" || row.artifact_lane === "settings"));
+    if (collision !== undefined) throw new Error("generic landing external-id collision");
+  }
   const allPlatforms = new Map<string, PlatformPresentation>();
-  for (const row of persistedSourceRows) allPlatforms.set(row.id, await replayPlatformPresentation(row, deps.hashKey));
+  for (const row of persistedSourceRows) allPlatforms.set(row.id, await replayPlatformPresentation(sourcePresentationRow(row), deps.hashKey, {
+    archiveRelPath: row.archive_rel_path,
+    archiveEpochSeconds: row.archive_epoch_s,
+  }));
   for (const [id, incoming] of incomingPlatforms) {
     const prior = allPlatforms.get(id);
-    if (prior && canonical({ ...prior.row, workout_key: null, session_key: null }) !== canonical(incoming.row)) {
+    if (prior && evidenceMode) {
+      if (prior.row.raw_sha256 === incoming.row.raw_sha256) {
+        if (prior.row.quality_rank !== incoming.row.quality_rank
+          || !sameEnvelopeSemantics(prior.row.payload_json, incoming.row.payload_json)) {
+          throw new Error("activity landing disagrees with payload hash");
+        }
+        const priorEnvelope = parseEnvelope(prior.row.payload_json);
+        const selected = persistedSourceRows.find((row) => row.id === id)!;
+        if (priorEnvelope.version === 1 && selected.artifact_key !== null
+          && prior.row.payload_json !== incoming.row.payload_json) {
+          throw new Error("activity landing disagrees with payload hash");
+        }
+      }
+      allPlatforms.set(id, incoming);
+    } else if (prior && canonical({ ...prior.row, workout_key: null, session_key: null }) !== canonical(incoming.row)) {
       throw new Error("incoming platform source conflicts with persisted source");
+    } else {
+      allPlatforms.set(id, prior ?? incoming);
     }
-    allPlatforms.set(id, prior ?? incoming);
   }
 
   const candidates: Candidate[] = [];
@@ -348,7 +441,7 @@ ORDER BY id COLLATE BINARY ASC`)).map(sourceRow);
     .map((row): SportSettingInput => ({ sport: string(row.sport, "setting sport"),
       session_cluster_conventions_json: row.session_cluster_conventions_json === null ? null : string(row.session_cluster_conventions_json, "setting conventions") }));
   const plannedRawState = canonical(persistedRawRows);
-  const plannedSourceState = canonical(persistedSourceRows);
+  const plannedSourceState = canonical({ selected: persistedSourceRows, revisions: revisionState });
   const plannedConfirmationState = canonical(confirmations);
   const plannedSettingState = canonical(settingRows);
   const plannedRepairSettingState = repairSnapshot.canonicalRows;
@@ -387,7 +480,7 @@ ORDER BY id COLLATE BINARY ASC`)).map(sourceRow);
   const incomingRows = [...incomingAddresses.values()].sort((a, b) => compareText(a.row.sha256, b.row.sha256));
   const incomingSourceRows = [...incomingPlatforms.values()].sort((a, b) => compareText(a.row.id, b.row.id));
   const insertedRaw = new Map<string, boolean>(), insertedSource = new Map<string, boolean>();
-  let relinked = 0;
+  let relinked = 0, sourceUpdates = 0;
   let orphans: OrphanReport[] = [];
   await deps.store.transaction(async () => {
     const current = await deps.store.all("SELECT ingest_version FROM ingest_metadata WHERE singleton=1");
@@ -395,17 +488,16 @@ ORDER BY id COLLATE BINARY ASC`)).map(sourceRow);
        file_id_time_created_utc, manufacturer, product
 FROM raw_file
 ORDER BY sha256 COLLATE BINARY ASC`)).map(rawRow);
-    const currentSourceRows = (await deps.store.all(`SELECT id, workout_key, session_key, source, external_id,
-       raw_sha256, quality_rank, payload_json
-FROM source_record
-ORDER BY id COLLATE BINARY ASC`)).map(sourceRow);
+    const currentSourceRows = await readSelectedSourceRows(deps.store);
+    const currentRevisionState = await readSourceRevisionState(deps.store);
     const currentConfirmations = await createDedupConfirmationRepository(deps.store).readAll();
     const currentSettings = (await deps.store.all("SELECT sport, session_cluster_conventions_json FROM sport_settings ORDER BY sport COLLATE BINARY ASC"))
       .map((row): SportSettingInput => ({ sport: string(row.sport, "setting sport"),
         session_cluster_conventions_json: row.session_cluster_conventions_json === null ? null : string(row.session_cluster_conventions_json, "setting conventions") }));
     const currentRepairSettings = await readRepairFixerSettingsSnapshot(deps.store);
     if (current.length !== 1 || current[0]!.ingest_version !== storedVersion
-      || canonical(currentRawRows) !== plannedRawState || canonical(currentSourceRows) !== plannedSourceState
+      || canonical(currentRawRows) !== plannedRawState
+      || canonical({ selected: currentSourceRows, revisions: currentRevisionState }) !== plannedSourceState
       || canonical(currentConfirmations) !== plannedConfirmationState || canonical(currentSettings) !== plannedSettingState
       || currentRepairSettings.canonicalRows !== plannedRepairSettingState) {
       throw new Error("ingest inputs changed during planning");
@@ -425,8 +517,23 @@ ORDER BY id COLLATE BINARY ASC`)).map(sourceRow);
       }
     }
     const rawRepository = createRawFileRepository(deps.store), sourceRepository = createSourceRecordRepository(deps.store);
+    const intervalsRepository = createIntervalsSourceRepository(deps.store, deps.hashKey);
     for (const entry of incomingRows) insertedRaw.set(entry.row.sha256, await rawRepository.upsert(entry.row));
-    for (const entry of incomingSourceRows) insertedSource.set(entry.row.id, await sourceRepository.upsert(entry.row));
+    for (const entry of incomingSourceRows) {
+      const platform = batch.platform_records.find((value) => String(value.activity_id) === entry.row.external_id);
+      if (evidenceMode) {
+        const evidence = platform?.sourceEvidence;
+        if (evidence === undefined) throw new TypeError("platform source evidence is missing");
+        const recorded = await intervalsRepository.recordArtifact({ source: "intervals-icu", lane: "activities",
+          externalId: evidence.externalId, artifactKind: "snapshot", archiveAddress: evidence.archive.address,
+          archiveRelPath: evidence.archive.relPath, archiveEpochSeconds: evidence.archiveInstant.epochSeconds });
+        const revision = await intervalsRepository.applyActivityRevision({ sourceRow: entry.row, artifactKey: recorded.artifactKey });
+        insertedSource.set(entry.row.id, revision.kind === "inserted-current");
+        if (revision.selectorChanged && revision.kind !== "inserted-current") sourceUpdates += 1;
+      } else {
+        insertedSource.set(entry.row.id, await sourceRepository.upsert(entry.row));
+      }
+    }
     await deleteAllDerivedRowsInTransaction(deps.store);
     for (const cluster of planned) await deps.materializeClusterInTransaction(deps.store, cluster);
     for (const presentation of [...allPlatforms.values()].sort((a, b) => compareText(a.row.id, b.row.id))) {
@@ -472,7 +579,7 @@ ORDER BY id COLLATE BINARY ASC`)).map(sourceRow);
       effective: { tier3: DEFAULT_TIER3_THRESHOLDS, transition_window_s: DEFAULT_TRANSITION_WINDOW_S },
       files: reports,
       inserts: { raw_file: [...insertedRaw.values()].filter(Boolean).length, source_record: [...insertedSource.values()].filter(Boolean).length },
-      updates: { source_record: 0, relinked_source_records: relinked },
+      updates: { source_record: sourceUpdates, relinked_source_records: relinked },
       clusters: clusterReports,
       threshold_near_misses: dedup.threshold_near_misses,
       overlap_watchlist: dedup.overlap_watchlist,

--- a/packages/kernel/src/ingest/import-report.ts
+++ b/packages/kernel/src/ingest/import-report.ts
@@ -113,7 +113,7 @@ export interface ImportReport {
   };
   readonly files: readonly FileReport[];
   readonly inserts: { readonly raw_file: number; readonly source_record: number };
-  readonly updates: { readonly source_record: 0; readonly relinked_source_records: number };
+  readonly updates: { readonly source_record: number; readonly relinked_source_records: number };
   readonly clusters: readonly ClusterReport[];
   readonly threshold_near_misses: readonly PairDiagnostic[];
   readonly overlap_watchlist: readonly OverlapDiagnostic[];

--- a/packages/kernel/src/ingest/source-ledger.ts
+++ b/packages/kernel/src/ingest/source-ledger.ts
@@ -1,4 +1,6 @@
 import { sortKeys } from "../store/canonical-json.js";
+import { canonicalJson } from "../archive/canonical.js";
+import type { ArchiveInstant, ArchiveWriteResult } from "../archive/types.js";
 import type { SourceRecordRow } from "../store/ports.js";
 import type { Candidate, ConcernValue } from "./canonical-pick.js";
 import { QUALITY_RANK, assertQualityRank } from "./quality-rank.js";
@@ -20,6 +22,14 @@ export interface PlatformImportArtifact {
   readonly concerns: Readonly<Record<string, ConcernValue>>;
   readonly raw_snapshot_address: string | null;
   readonly raw_snapshot_rel_path: string | null;
+  readonly sourceEvidence?: {
+    readonly source: "intervals-icu";
+    readonly lane: "activities";
+    readonly externalId: string;
+    readonly archiveInstant: ArchiveInstant;
+    readonly archive: ArchiveWriteResult;
+    readonly normalizedActivityJson: string;
+  };
 }
 
 export interface PlatformPresentation {
@@ -67,6 +77,19 @@ function validateInput(platform: PlatformImportArtifact): void {
   if (platform.raw_snapshot_address !== null && !/^[0-9a-f]{64}$/.test(platform.raw_snapshot_address)) {
     throw new TypeError("platform snapshot address is invalid");
   }
+  if (platform.sourceEvidence !== undefined) {
+    const evidence = platform.sourceEvidence;
+    if (evidence.source !== "intervals-icu" || evidence.lane !== "activities"
+      || evidence.externalId !== externalId(platform.activity_id)
+      || evidence.archive.address !== platform.raw_snapshot_address
+      || evidence.archive.relPath !== platform.raw_snapshot_rel_path
+      || typeof evidence.archive.relPath !== "string" || evidence.archive.relPath.length === 0
+      || typeof evidence.archiveInstant.epochSeconds !== "number"
+      || !Number.isSafeInteger(evidence.archiveInstant.epochSeconds) || evidence.archiveInstant.epochSeconds < 0
+      || evidence.normalizedActivityJson !== canonicalJson(platform.activity)) {
+      throw new TypeError("platform source evidence is invalid");
+    }
+  }
   const concerns = platform.concerns;
   if (concerns["session.sport"] !== platform.dedup.sport_family
       || concerns["session.start_utc"] !== platform.dedup.start_utc
@@ -84,7 +107,7 @@ function validateInput(platform: PlatformImportArtifact): void {
 }
 
 function payload(platform: PlatformImportArtifact): string {
-  return canonical({
+  const envelope = {
     activity: platform.activity,
     concerns: platform.concerns,
     dedup: {
@@ -94,7 +117,10 @@ function payload(platform: PlatformImportArtifact): string {
       sport_family: platform.dedup.sport_family,
       start_utc: platform.dedup.start_utc,
     },
-  });
+  };
+  return platform.sourceEvidence === undefined
+    ? canonical(envelope)
+    : canonicalJson({ ...envelope, schema_version: 1 });
 }
 
 export async function buildPlatformPresentation(platform: PlatformImportArtifact, hashKey: HashKey): Promise<PlatformPresentation> {
@@ -113,9 +139,17 @@ export async function buildPlatformPresentation(platform: PlatformImportArtifact
     quality_rank: quality,
     payload_json: payload(platform),
   };
+  const { candidate, summary } = candidateAndSummary(platform, row);
+  return { row, candidate, summary };
+}
+
+function candidateAndSummary(platform: PlatformImportArtifact, row: SourceRecordRow): {
+  readonly candidate: Candidate;
+  readonly summary: DedupCandidateSummary;
+} {
   const candidate: Candidate = {
-    id: `platform_api:${id}:0:0`,
-    origin: { kind: "platform", source: "intervals-icu", sourceRecordId: id, persistedQualityRank: row.quality_rank },
+    id: `platform_api:${row.id}:0:0`,
+    origin: { kind: "platform", source: "intervals-icu", sourceRecordId: row.id, persistedQualityRank: row.quality_rank },
     workoutOrdinal: 0,
     sessionOrdinal: 0,
     rank: assertQualityRank(row.quality_rank),
@@ -125,7 +159,7 @@ export async function buildPlatformPresentation(platform: PlatformImportArtifact
       || candidate.rank !== QUALITY_RANK.PLATFORM_API) throw new Error("platform quality invariant mismatch");
   const summary: DedupCandidateSummary = {
     candidate_id: candidate.id,
-    member_id: id,
+    member_id: row.id,
     source_kind: "platform_api",
     source_session_seq: 0,
     sport_family: platform.dedup.sport_family,
@@ -137,15 +171,18 @@ export async function buildPlatformPresentation(platform: PlatformImportArtifact
     file_id_serial: null,
     file_id_time_created_utc: null,
   };
-  return { row, candidate, summary };
+  return { candidate, summary };
 }
 
-function parseEnvelope(value: string): { activity: Readonly<Record<string, unknown>>; concerns: Readonly<Record<string, ConcernValue>>; dedup: PlatformDedupInput } {
+export function parseEnvelope(value: string): { readonly version: 0 | 1; activity: Readonly<Record<string, unknown>>; concerns: Readonly<Record<string, ConcernValue>>; dedup: PlatformDedupInput } {
   let parsed: unknown;
   try { parsed = JSON.parse(value); } catch { throw new Error("source record payload is invalid"); }
-  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)
-      || Object.keys(parsed).join(",") !== "activity,concerns,dedup") throw new Error("source record envelope is invalid");
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) throw new Error("source record envelope is invalid");
   const envelope = parsed as Record<string, unknown>;
+  const keys = Object.keys(envelope).join(",");
+  const version = keys === "activity,concerns,dedup" ? 0
+    : keys === "activity,concerns,dedup,schema_version" && envelope.schema_version === 1 ? 1 : null;
+  if (version === null) throw new Error("source record envelope is invalid");
   if (envelope.activity === null || typeof envelope.activity !== "object" || Array.isArray(envelope.activity)
       || envelope.concerns === null || typeof envelope.concerns !== "object" || Array.isArray(envelope.concerns)
       || envelope.dedup === null || typeof envelope.dedup !== "object" || Array.isArray(envelope.dedup)) {
@@ -155,26 +192,41 @@ function parseEnvelope(value: string): { activity: Readonly<Record<string, unkno
   if (Object.keys(dedup).join(",") !== "distance_m,duration_s,is_transition,sport_family,start_utc") {
     throw new Error("source record dedup envelope is invalid");
   }
-  return { activity: envelope.activity as Readonly<Record<string, unknown>>,
+  return { version, activity: envelope.activity as Readonly<Record<string, unknown>>,
     concerns: envelope.concerns as Readonly<Record<string, ConcernValue>>, dedup: dedup as unknown as PlatformDedupInput };
 }
 
-export async function replayPlatformPresentation(row: SourceRecordRow, hashKey: HashKey): Promise<PlatformPresentation> {
+export interface ReplayPlatformEvidence {
+  readonly archiveRelPath: string | null;
+  readonly archiveEpochSeconds: number | null;
+}
+
+export async function replayPlatformPresentation(
+  row: SourceRecordRow,
+  hashKey: HashKey,
+  evidence: ReplayPlatformEvidence = { archiveRelPath: null, archiveEpochSeconds: null },
+): Promise<PlatformPresentation> {
   if (row.source !== "intervals-icu" || row.quality_rank !== QUALITY_RANK.PLATFORM_API) throw new Error("unsupported source record");
   const envelope = parseEnvelope(row.payload_json);
+  if ((evidence.archiveRelPath === null) !== (evidence.archiveEpochSeconds === null)
+    || (evidence.archiveRelPath !== null && evidence.archiveRelPath.length === 0)
+    || (evidence.archiveEpochSeconds !== null && (!Number.isSafeInteger(evidence.archiveEpochSeconds) || evidence.archiveEpochSeconds < 0))) {
+    throw new Error("source record archive evidence is invalid");
+  }
   const platform: PlatformImportArtifact = {
     source: "intervals-icu",
     activity_id: row.external_id,
     activity: envelope.activity,
     concerns: envelope.concerns,
     dedup: envelope.dedup,
-    raw_snapshot_address: row.raw_sha256,
-    raw_snapshot_rel_path: row.raw_sha256 === null ? null : "persisted",
+    raw_snapshot_address: null,
+    raw_snapshot_rel_path: null,
   };
-  const rebuilt = await buildPlatformPresentation(platform, hashKey);
-  if (rebuilt.row.id !== row.id || rebuilt.row.source !== row.source || rebuilt.row.external_id !== row.external_id
-      || rebuilt.row.raw_sha256 !== row.raw_sha256 || rebuilt.row.quality_rank !== row.quality_rank
-      || rebuilt.row.payload_json !== row.payload_json) throw new Error("source record immutable mismatch");
-  return { row: { ...rebuilt.row, workout_key: row.workout_key, session_key: row.session_key },
-    candidate: rebuilt.candidate, summary: rebuilt.summary };
+  validateInput(platform);
+  const expectedId = await hashKey(["source_record", "intervals-icu", row.external_id]);
+  if (expectedId !== row.id || (envelope.version === 1 && canonicalJson(JSON.parse(row.payload_json)) !== row.payload_json)) {
+    throw new Error("source record immutable mismatch");
+  }
+  const rebuilt = candidateAndSummary(platform, row);
+  return { row: { ...row }, candidate: rebuilt.candidate, summary: rebuilt.summary };
 }

--- a/packages/kernel/src/store/ports.ts
+++ b/packages/kernel/src/store/ports.ts
@@ -90,6 +90,78 @@ export interface SourceRecordRepository {
   upsert(row: SourceRecordRow): Promise<boolean>;
 }
 
+export interface SourceArtifactDraft {
+  readonly source: "intervals-icu";
+  readonly lane: "activities" | "streams" | "wellness" | "settings" | "bulk-fit";
+  readonly externalId: string;
+  readonly artifactKind: "snapshot" | "raw_file";
+  readonly archiveAddress: string;
+  readonly archiveRelPath: string;
+  readonly archiveEpochSeconds: number;
+}
+
+export interface GenericLandingDraft {
+  readonly externalId: string;
+  readonly artifactKey: string;
+  readonly archiveAddress: string;
+  readonly endpoint: "streams" | "settings";
+  readonly normalizedPayloadJson: string;
+}
+
+export interface WellnessLandingRow {
+  readonly id: string;
+  readonly date_key: number;
+  readonly provenance: "sync";
+  readonly source: "intervals-icu";
+  readonly resting_hr: number | null;
+  readonly hrv: number | null;
+  readonly hrv_sdnn: number | null;
+  readonly sleep_s: number | null;
+  readonly sleep_score: number | null;
+  readonly weight_kg: number | null;
+  readonly soreness: number | null;
+  readonly fatigue: number | null;
+  readonly fields_json: string;
+  readonly device_id: null;
+  readonly hlc_physical_ms: null;
+  readonly hlc_counter: null;
+}
+
+export interface ZoneSetHistoryRow {
+  readonly id: string;
+  readonly sport: string;
+  readonly stream: "power" | "hr";
+  readonly anchor_ref: "ftp" | "lthr";
+  readonly boundaries_json: string;
+  readonly valid_from: number;
+  readonly source: "intervals-icu";
+  readonly provenance: "sync";
+  readonly device_id: null;
+  readonly hlc_physical_ms: null;
+  readonly hlc_counter: null;
+}
+
+export type ActivityRevisionResult =
+  | { readonly kind: "inserted-current"; readonly revisionId: string; readonly selectorChanged: true }
+  | { readonly kind: "exact-current"; readonly revisionId: string; readonly selectorChanged: false }
+  | { readonly kind: "reselected-current"; readonly revisionId: string; readonly selectorChanged: true }
+  | { readonly kind: "appended-current"; readonly revisionId: string; readonly selectorChanged: true }
+  | { readonly kind: "hydrated-current"; readonly revisionId: string; readonly selectorChanged: true };
+
+export interface ActivityRevisionDraft {
+  readonly sourceRow: SourceRecordRow;
+  readonly artifactKey: string;
+}
+
+export interface IntervalsSourceRepository {
+  recordArtifact(draft: SourceArtifactDraft): Promise<{ readonly artifactKey: string; readonly inserted: boolean }>;
+  recordGenericLanding(draft: GenericLandingDraft): Promise<boolean>;
+  applyActivityRevision(draft: ActivityRevisionDraft): Promise<ActivityRevisionResult>;
+  upsertWellness(row: WellnessLandingRow): Promise<"inserted" | "updated" | "unchanged" | "manual-wins">;
+  insertSyncedAnchor(row: AnchorHistoryRow): Promise<boolean>;
+  insertSyncedZone(row: ZoneSetHistoryRow): Promise<boolean>;
+}
+
 export interface DedupConfirmationRow {
   id: string;
   member_a: string;

--- a/packages/kernel/src/store/source-repository.ts
+++ b/packages/kernel/src/store/source-repository.ts
@@ -1,4 +1,7 @@
-import { RawFileInvariantError, type RawFileColumn, type RawFileRepository, type RawFileRow, type SourceRecordRepository, type SourceRecordRow, type SqlStore } from "./ports.js";
+import { canonicalJson } from "../archive/canonical.js";
+import { QUALITY_RANK } from "../ingest/quality-rank.js";
+import { createAnchorRepository } from "./anchor-repository.js";
+import { RawFileInvariantError, type ActivityRevisionDraft, type ActivityRevisionResult, type AnchorHistoryRow, type GenericLandingDraft, type IntervalsSourceRepository, type RawFileColumn, type RawFileRepository, type RawFileRow, type Row, type SourceArtifactDraft, type SourceRecordRepository, type SourceRecordRow, type SqlStore, type WellnessLandingRow, type ZoneSetHistoryRow } from "./ports.js";
 
 export function createRawFileRepository(store: SqlStore): RawFileRepository {
   return {
@@ -76,4 +79,307 @@ export function createSourceRecordRepository(store: SqlStore): SourceRecordRepos
       return false;
     },
   };
+}
+
+type HashKey = (fields: readonly (string | number)[]) => Promise<string>;
+const HEX = /^[0-9a-f]{64}$/;
+
+function nonempty(value: unknown, name: string): asserts value is string {
+  if (typeof value !== "string" || value.length === 0) throw new TypeError(`${name} is invalid`);
+}
+
+function address(value: unknown, name: string): asserts value is string {
+  if (typeof value !== "string" || !HEX.test(value)) throw new TypeError(`${name} is invalid`);
+}
+
+function epoch(value: unknown, name: string): asserts value is number {
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) throw new TypeError(`${name} is invalid`);
+}
+
+function assertCanonicalJson(value: string, name: string): unknown {
+  nonempty(value, name);
+  let parsed: unknown;
+  try { parsed = JSON.parse(value); } catch { throw new TypeError(`${name} is invalid`); }
+  if (canonicalJson(parsed) !== value) throw new TypeError(`${name} is not canonical`);
+  return parsed;
+}
+
+function exactRow(selected: Row | undefined, expected: Readonly<Record<string, unknown>>, message: string): void {
+  if (selected === undefined || Object.entries(expected).some(([key, value]) => selected[key] !== value)) {
+    throw new Error(message);
+  }
+}
+
+function parseActivityEnvelope(value: string): { readonly version: 0 | 1; readonly semantic: string } {
+  let parsed: unknown;
+  try { parsed = JSON.parse(value); } catch { throw new Error("source record payload is invalid"); }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) throw new Error("source record envelope is invalid");
+  const record = parsed as Record<string, unknown>;
+  const keys = Object.keys(record).join(",");
+  const version = keys === "activity,concerns,dedup" ? 0
+    : keys === "activity,concerns,dedup,schema_version" && record.schema_version === 1 ? 1 : null;
+  if (version === null) throw new Error("source record envelope is invalid");
+  return { version, semantic: canonicalJson({ activity: record.activity, concerns: record.concerns, dedup: record.dedup }) };
+}
+
+function validateSourceRow(row: SourceRecordRow): void {
+  address(row.id, "source record id");
+  if (row.source !== "intervals-icu") throw new TypeError("source record source is invalid");
+  nonempty(row.external_id, "source record external id");
+  address(row.raw_sha256, "source record raw address");
+  if (row.quality_rank !== QUALITY_RANK.PLATFORM_API) throw new TypeError("source record quality rank is invalid");
+  if (row.workout_key !== null || row.session_key !== null) throw new TypeError("incoming source attachments must be null");
+  const envelope = parseActivityEnvelope(row.payload_json);
+  if (envelope.version !== 1 || canonicalJson(JSON.parse(row.payload_json)) !== row.payload_json) {
+    throw new TypeError("activity revision payload must be canonical version 1");
+  }
+}
+
+async function selectArtifact(store: SqlStore, artifactKey: string): Promise<Row> {
+  const selected = await store.get(`SELECT artifact_key, source, lane, external_id, artifact_kind,
+       archive_address, archive_rel_path, archive_epoch_s
+FROM source_artifact
+WHERE artifact_key = ?`, [artifactKey]);
+  if (selected === undefined) throw new Error("source artifact is absent");
+  return selected;
+}
+
+function exactSourcePresentation(selected: Row | undefined, row: SourceRecordRow, artifactKey: string): boolean {
+  return selected !== undefined
+    && selected.id === row.id
+    && selected.source === row.source
+    && selected.external_id === row.external_id
+    && selected.raw_sha256 === row.raw_sha256
+    && selected.quality_rank === row.quality_rank
+    && selected.payload_json === row.payload_json
+    && selected.artifact_key === artifactKey;
+}
+
+export function createIntervalsSourceRepository(store: SqlStore, hashKey: HashKey): IntervalsSourceRepository {
+  const anchors = createAnchorRepository(store);
+
+  async function recordArtifact(draft: SourceArtifactDraft): Promise<{ readonly artifactKey: string; readonly inserted: boolean }> {
+    if (draft.source !== "intervals-icu") throw new TypeError("source artifact source is invalid");
+    if (!["activities", "streams", "wellness", "settings", "bulk-fit"].includes(draft.lane)) throw new TypeError("source artifact lane is invalid");
+    if ((draft.lane === "bulk-fit") !== (draft.artifactKind === "raw_file")) throw new TypeError("source artifact kind is invalid");
+    nonempty(draft.externalId, "source artifact external id");
+    address(draft.archiveAddress, "source artifact address");
+    nonempty(draft.archiveRelPath, "source artifact path");
+    epoch(draft.archiveEpochSeconds, "source artifact epoch");
+    const artifactKey = await hashKey(["source_artifact", draft.source, draft.lane, draft.externalId,
+      draft.archiveAddress, draft.archiveRelPath, draft.archiveEpochSeconds]);
+    address(artifactKey, "source artifact key");
+    const values = [artifactKey, draft.source, draft.lane, draft.externalId, draft.artifactKind,
+      draft.archiveAddress, draft.archiveRelPath, draft.archiveEpochSeconds] as const;
+    const inserted = await store.get(`INSERT INTO source_artifact (
+  artifact_key, source, lane, external_id, artifact_kind,
+  archive_address, archive_rel_path, archive_epoch_s
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT DO NOTHING
+RETURNING artifact_key`, values);
+    const columns = `artifact_key, source, lane, external_id, artifact_kind,
+       archive_address, archive_rel_path, archive_epoch_s`;
+    const byKey = await store.get(`SELECT ${columns} FROM source_artifact WHERE artifact_key = ?`, [artifactKey]);
+    const byTuple = await store.get(`SELECT ${columns} FROM source_artifact
+WHERE source = ? AND lane = ? AND external_id = ? AND archive_address = ?
+  AND archive_rel_path = ? AND archive_epoch_s = ?`, [draft.source, draft.lane, draft.externalId,
+      draft.archiveAddress, draft.archiveRelPath, draft.archiveEpochSeconds]);
+    const expected = { artifact_key: artifactKey, source: draft.source, lane: draft.lane, external_id: draft.externalId,
+      artifact_kind: draft.artifactKind, archive_address: draft.archiveAddress,
+      archive_rel_path: draft.archiveRelPath, archive_epoch_s: draft.archiveEpochSeconds };
+    exactRow(byKey, expected, "source artifact invariant mismatch");
+    exactRow(byTuple, expected, "source artifact invariant mismatch");
+    if (byKey!.artifact_key !== byTuple!.artifact_key) throw new Error("source artifact invariant mismatch");
+    return { artifactKey, inserted: inserted !== undefined };
+  }
+
+  async function insertEvidenceSource(row: SourceRecordRow, artifactKey: string): Promise<boolean> {
+    const inserted = await store.get(`INSERT INTO source_record (
+  id, workout_key, session_key, source, external_id,
+  raw_sha256, quality_rank, payload_json, artifact_key
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT DO NOTHING
+RETURNING id`, [row.id, row.workout_key, row.session_key, row.source, row.external_id,
+      row.raw_sha256, row.quality_rank, row.payload_json, artifactKey]);
+    const columns = "id, source, external_id, raw_sha256, quality_rank, payload_json, artifact_key";
+    const byId = await store.get(`SELECT ${columns} FROM source_record WHERE id = ?`, [row.id]);
+    const bySource = await store.get(`SELECT ${columns} FROM source_record WHERE source = ? AND external_id = ?`, [row.source, row.external_id]);
+    if (!exactSourcePresentation(byId, row, artifactKey) || !exactSourcePresentation(bySource, row, artifactKey)
+      || byId!.id !== bySource!.id) throw new Error("source record invariant mismatch");
+    return inserted !== undefined;
+  }
+
+  async function recordGenericLanding(draft: GenericLandingDraft): Promise<boolean> {
+    nonempty(draft.externalId, "generic landing external id");
+    address(draft.artifactKey, "generic landing artifact key");
+    address(draft.archiveAddress, "generic landing archive address");
+    const landing = assertCanonicalJson(draft.normalizedPayloadJson, "generic normalized payload");
+    const expectedPrefix = `${draft.endpoint}:`;
+    if (!draft.externalId.startsWith(expectedPrefix)) throw new TypeError("generic landing external id is invalid");
+    const artifact = await selectArtifact(store, draft.artifactKey);
+    exactRow(artifact, { artifact_key: draft.artifactKey, source: "intervals-icu", lane: draft.endpoint,
+      artifact_kind: "snapshot", archive_address: draft.archiveAddress }, "generic landing artifact mismatch");
+    const sourceRecordId = await hashKey(["source_record", "intervals-icu", draft.externalId]);
+    address(sourceRecordId, "generic source record id");
+    const payloadJson = canonicalJson({ endpoint: draft.endpoint, landing, schema_version: 1 });
+    const row: SourceRecordRow = { id: sourceRecordId, workout_key: null, session_key: null, source: "intervals-icu",
+      external_id: draft.externalId, raw_sha256: draft.archiveAddress, quality_rank: QUALITY_RANK.PLATFORM_API,
+      payload_json: payloadJson };
+    const existing = await store.get(`SELECT sr.id, sr.artifact_key, a.lane
+FROM source_record AS sr
+LEFT JOIN source_artifact AS a ON a.artifact_key = sr.artifact_key
+WHERE sr.source = ? AND sr.external_id = ?`, ["intervals-icu", draft.externalId]);
+    if (existing !== undefined && (existing.artifact_key === null || existing.lane !== draft.endpoint)) {
+      throw new Error("generic landing external-id collision");
+    }
+    const inserted = await insertEvidenceSource(row, draft.artifactKey);
+    const revision = await store.get(`SELECT revision_id, source_record_id, artifact_key, raw_sha256, quality_rank, payload_json
+FROM source_record_revision WHERE source_record_id = ? AND revision_id = ?`, [sourceRecordId, sourceRecordId]);
+    exactRow(revision, { revision_id: sourceRecordId, source_record_id: sourceRecordId, artifact_key: draft.artifactKey,
+      raw_sha256: draft.archiveAddress, quality_rank: QUALITY_RANK.PLATFORM_API, payload_json: payloadJson },
+    "generic landing revision mismatch");
+    exactRow(await store.get("SELECT source_record_id, revision_id FROM source_record_current WHERE source_record_id = ?", [sourceRecordId]),
+      { source_record_id: sourceRecordId, revision_id: sourceRecordId }, "generic landing selector mismatch");
+    return inserted;
+  }
+
+  async function applyActivityRevision(draft: ActivityRevisionDraft): Promise<ActivityRevisionResult> {
+    validateSourceRow(draft.sourceRow);
+    address(draft.artifactKey, "activity artifact key");
+    const row = draft.sourceRow;
+    const artifact = await selectArtifact(store, draft.artifactKey);
+    exactRow(artifact, { artifact_key: draft.artifactKey, source: "intervals-icu", lane: "activities",
+      external_id: row.external_id, artifact_kind: "snapshot", archive_address: row.raw_sha256 },
+    "activity source artifact mismatch");
+    const existing = await store.get(`SELECT sr.id, sr.artifact_key, a.lane
+FROM source_record AS sr
+LEFT JOIN source_artifact AS a ON a.artifact_key = sr.artifact_key
+WHERE sr.source = ? AND sr.external_id = ?`, ["intervals-icu", row.external_id]);
+    if (existing === undefined) {
+      if (!await insertEvidenceSource(row, draft.artifactKey)) throw new Error("source record insert race");
+      return { kind: "inserted-current", revisionId: row.id, selectorChanged: true };
+    }
+    if (existing.id !== row.id) throw new Error("source record invariant mismatch");
+    if (existing.artifact_key !== null && existing.lane !== "activities") throw new Error("generic landing external-id collision");
+    const current = await store.get(`SELECT
+  r.revision_id, r.source_record_id, r.artifact_key, r.raw_sha256, r.quality_rank, r.payload_json,
+  a.source AS artifact_source, a.lane AS artifact_lane, a.external_id AS artifact_external_id,
+  a.archive_address, a.archive_rel_path, a.archive_epoch_s
+FROM source_record_current AS c
+JOIN source_record_revision AS r
+  ON r.source_record_id = c.source_record_id AND r.revision_id = c.revision_id
+LEFT JOIN source_artifact AS a ON a.artifact_key = r.artifact_key
+WHERE c.source_record_id = ?`, [row.id]);
+    if (current === undefined) throw new Error("activity current revision is absent");
+    const incomingEnvelope = parseActivityEnvelope(row.payload_json);
+    const currentEnvelope = parseActivityEnvelope(String(current.payload_json));
+    if (current.raw_sha256 === row.raw_sha256) {
+      const exact = current.quality_rank === row.quality_rank && current.payload_json === row.payload_json
+        && current.artifact_key === draft.artifactKey && current.artifact_source === "intervals-icu"
+        && current.artifact_lane === "activities" && current.artifact_external_id === row.external_id
+        && current.archive_address === row.raw_sha256 && typeof current.archive_rel_path === "string"
+        && current.archive_rel_path.length > 0 && typeof current.archive_epoch_s === "number";
+      if (currentEnvelope.version === 1 && exact) {
+        return { kind: "exact-current", revisionId: String(current.revision_id), selectorChanged: false };
+      }
+      if ((currentEnvelope.version === 0 || current.artifact_key === null)
+        && current.quality_rank === row.quality_rank && currentEnvelope.semantic === incomingEnvelope.semantic) {
+        const revisionId = await appendRevision(row, draft.artifactKey);
+        await selectRevision(row.id, revisionId, String(current.revision_id));
+        return { kind: "hydrated-current", revisionId, selectorChanged: true };
+      }
+      throw new Error("activity landing disagrees with payload hash");
+    }
+    const known = await store.get(`SELECT revision_id, source_record_id, artifact_key, raw_sha256, quality_rank, payload_json
+FROM source_record_revision
+WHERE source_record_id = ? AND raw_sha256 = ? AND quality_rank = ? AND payload_json = ?
+ORDER BY revision_id COLLATE BINARY ASC
+LIMIT 1`, [row.id, row.raw_sha256, row.quality_rank, row.payload_json]);
+    if (known !== undefined) {
+      if (known.artifact_key !== draft.artifactKey) throw new Error("activity landing disagrees with payload hash");
+      const revisionId = String(known.revision_id);
+      await selectRevision(row.id, revisionId, String(current.revision_id));
+      return { kind: "reselected-current", revisionId, selectorChanged: true };
+    }
+    const revisionId = await appendRevision(row, draft.artifactKey);
+    await selectRevision(row.id, revisionId, String(current.revision_id));
+    return { kind: "appended-current", revisionId, selectorChanged: true };
+  }
+
+  async function appendRevision(row: SourceRecordRow, artifactKey: string): Promise<string> {
+    const revisionId = await hashKey(["source_record_revision", row.id, row.raw_sha256!,
+      QUALITY_RANK.PLATFORM_API, row.payload_json]);
+    address(revisionId, "source record revision id");
+    await store.run(`INSERT INTO source_record_revision (
+  revision_id, source_record_id, artifact_key, raw_sha256, quality_rank, payload_json
+) VALUES (?, ?, ?, ?, ?, ?)
+ON CONFLICT DO NOTHING`, [revisionId, row.id, artifactKey, row.raw_sha256, row.quality_rank, row.payload_json]);
+    exactRow(await store.get(`SELECT revision_id, source_record_id, artifact_key, raw_sha256, quality_rank, payload_json
+FROM source_record_revision WHERE revision_id = ?`, [revisionId]), { revision_id: revisionId,
+      source_record_id: row.id, artifact_key: artifactKey, raw_sha256: row.raw_sha256,
+      quality_rank: row.quality_rank, payload_json: row.payload_json }, "activity revision invariant mismatch");
+    return revisionId;
+  }
+
+  async function selectRevision(sourceRecordId: string, revisionId: string, previousRevisionId: string): Promise<void> {
+    if (revisionId === previousRevisionId) throw new Error("activity selector transition is unchanged");
+    await store.run(`UPDATE source_record_current
+SET revision_id = ?
+WHERE source_record_id = ? AND revision_id != ?`, [revisionId, sourceRecordId, revisionId]);
+    exactRow(await store.get("SELECT source_record_id, revision_id FROM source_record_current WHERE source_record_id = ?", [sourceRecordId]),
+      { source_record_id: sourceRecordId, revision_id: revisionId }, "activity selector update failed");
+  }
+
+  async function upsertWellness(row: WellnessLandingRow): Promise<"inserted" | "updated" | "unchanged" | "manual-wins"> {
+    address(row.id, "wellness id"); epoch(row.date_key, "wellness date key");
+    if (row.provenance !== "sync" || row.source !== "intervals-icu" || row.device_id !== null
+      || row.hlc_physical_ms !== null || row.hlc_counter !== null) throw new TypeError("wellness provenance is invalid");
+    assertCanonicalJson(row.fields_json, "wellness fields");
+    const existing = await store.get("SELECT * FROM wellness WHERE date_key = ?", [row.date_key]);
+    if (existing === undefined) {
+      await store.run(`INSERT INTO wellness (id,date_key,provenance,source,resting_hr,hrv,hrv_sdnn,sleep_s,sleep_score,weight_kg,soreness,fatigue,fields_json,device_id,hlc_physical_ms,hlc_counter)
+VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`, [row.id, row.date_key, row.provenance, row.source, row.resting_hr, row.hrv,
+        row.hrv_sdnn, row.sleep_s, row.sleep_score, row.weight_kg, row.soreness, row.fatigue, row.fields_json,
+        row.device_id, row.hlc_physical_ms, row.hlc_counter]);
+      return "inserted";
+    }
+    if (existing.provenance === "manual") return "manual-wins";
+    if (existing.provenance !== "sync" || existing.source !== "intervals-icu" || existing.id !== row.id) {
+      throw new Error("wellness source collision");
+    }
+    const expected = row as unknown as Readonly<Record<string, unknown>>;
+    if (Object.entries(expected).every(([key, value]) => existing[key] === value)) return "unchanged";
+    await store.run(`UPDATE wellness SET resting_hr=?,hrv=?,hrv_sdnn=?,sleep_s=?,sleep_score=?,weight_kg=?,soreness=?,fatigue=?,fields_json=?
+WHERE date_key=? AND provenance='sync' AND source='intervals-icu'`, [row.resting_hr, row.hrv, row.hrv_sdnn,
+      row.sleep_s, row.sleep_score, row.weight_kg, row.soreness, row.fatigue, row.fields_json, row.date_key]);
+    exactRow(await store.get("SELECT * FROM wellness WHERE date_key = ?", [row.date_key]), expected, "wellness update mismatch");
+    return "updated";
+  }
+
+  async function insertSyncedAnchor(row: AnchorHistoryRow): Promise<boolean> {
+    if (row.source !== "intervals-icu" || row.provenance !== "sync" || row.confidence !== "platform"
+      || row.note !== null || row.device_id !== null || row.hlc_physical_ms !== null || row.hlc_counter !== null) {
+      throw new TypeError("anchor provenance is invalid");
+    }
+    address(row.id, "anchor id"); nonempty(row.sport, "anchor sport"); epoch(row.valid_from, "anchor valid from");
+    const inserted = await anchors.insertIfAbsent(row);
+    exactRow(await store.get("SELECT * FROM anchor_history WHERE sport=? AND anchor_type=? AND valid_from=?",
+      [row.sport, row.anchor_type, row.valid_from]), row as unknown as Readonly<Record<string, unknown>>, "anchor history mismatch");
+    return inserted;
+  }
+
+  async function insertSyncedZone(row: ZoneSetHistoryRow): Promise<boolean> {
+    if (row.source !== "intervals-icu" || row.provenance !== "sync" || row.device_id !== null
+      || row.hlc_physical_ms !== null || row.hlc_counter !== null) throw new TypeError("zone provenance is invalid");
+    address(row.id, "zone id"); nonempty(row.sport, "zone sport"); epoch(row.valid_from, "zone valid from");
+    assertCanonicalJson(row.boundaries_json, "zone boundaries");
+    const inserted = await store.get(`INSERT INTO zone_set_history (id,sport,stream,anchor_ref,boundaries_json,valid_from,source,provenance,device_id,hlc_physical_ms,hlc_counter)
+VALUES (?,?,?,?,?,?,?,?,?,?,?) ON CONFLICT DO NOTHING RETURNING id`, [row.id, row.sport, row.stream, row.anchor_ref,
+      row.boundaries_json, row.valid_from, row.source, row.provenance, row.device_id, row.hlc_physical_ms, row.hlc_counter]);
+    exactRow(await store.get("SELECT * FROM zone_set_history WHERE id=?", [row.id]),
+      row as unknown as Readonly<Record<string, unknown>>, "zone history mismatch");
+    return inserted !== undefined;
+  }
+
+  return { recordArtifact, recordGenericLanding, applyActivityRevision, upsertWellness, insertSyncedAnchor, insertSyncedZone };
 }

--- a/packages/kernel/tests/dedup-inv2.test.ts
+++ b/packages/kernel/tests/dedup-inv2.test.ts
@@ -62,7 +62,10 @@ class MemoryStore implements SqlStore {
     if (sql.startsWith("SELECT ingest_version")) return [{ ingest_version: this.metadata }];
     if (sql.startsWith("SELECT singleton")) return [{ singleton: 1, ingest_version: this.metadata }];
     if (sql.includes("FROM raw_file") && sql.includes("ORDER BY sha256")) return [...this.raw.values()].sort((a, b) => String(a.sha256).localeCompare(String(b.sha256)));
-    if (sql.includes("FROM source_record") && sql.includes("ORDER BY id")) return [...this.source.values()] as unknown as Row[];
+    if (sql.includes("FROM source_record AS sr") && sql.includes("source_record_current")) {
+      return [...this.source.values()].map((row) => ({ ...row, artifact_key: null, archive_rel_path: null, archive_epoch_s: null })) as unknown as Row[];
+    }
+    if (sql.includes("FROM source_record AS sr") && sql.includes("current_revision_id")) return [];
     if (sql.includes("FROM dedup_confirmation")) return this.confirmations as unknown as Row[];
     if (sql.includes("FROM sport_settings")) return [];
     if (sql.includes("FROM repair_fixer_settings")) return [];

--- a/packages/kernel/tests/source-ledger.test.ts
+++ b/packages/kernel/tests/source-ledger.test.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import { describe, expect, it } from "vitest";
-import { buildPlatformPresentation, replayPlatformPresentation, type ConcernValue, type PlatformImportArtifact } from "../src/ingest/index.js";
+import { buildPlatformPresentation, parseEnvelope, replayPlatformPresentation, type ConcernValue, type PlatformImportArtifact } from "../src/ingest/index.js";
+import { canonicalJson } from "../src/archive/index.js";
 import { createSourceRecordRepository, sortKeys, type Row, type SourceRecordRow, type SqlStore } from "../src/store/index.js";
 
 const hashKey = async (fields: readonly (string | number)[]) => createHash("sha256").update(fields.join("\u001f")).digest("hex");
@@ -80,5 +81,20 @@ describe("platform source ledger", () => {
     const other = await buildPlatformPresentation(platform("other"), hashKey);
     store.rows.set(other.row.id, { ...other.row, external_id: built.row.external_id });
     await expect(repo.upsert({ ...built.row, id: other.row.id })).rejects.toThrow();
+  });
+  it("builds version-one evidence envelopes and validates archive identity", async () => {
+    const base = platform("evidence"), address = "a".repeat(64), relPath = `1998/01/${address}.json.gz`;
+    const value: PlatformImportArtifact = { ...base,
+      raw_snapshot_address: address, raw_snapshot_rel_path: relPath,
+      sourceEvidence: { source: "intervals-icu", lane: "activities", externalId: "evidence",
+        archiveInstant: { epochSeconds: 1_000 }, archive: { address, relPath, deduped: false },
+        normalizedActivityJson: canonicalJson(base.activity) } };
+    const built = await buildPlatformPresentation(value, hashKey);
+    expect(parseEnvelope(built.row.payload_json).version).toBe(1);
+    expect(built.row.payload_json).toBe(canonicalJson({ activity: value.activity, concerns: value.concerns,
+      dedup: { distance_m: 1_000, duration_s: 100, is_transition: false, sport_family: "cycling", start_utc: 1_000 },
+      schema_version: 1 }));
+    await expect(buildPlatformPresentation({ ...value, raw_snapshot_rel_path: "wrong" }, hashKey)).rejects.toThrow("source evidence");
+    expect(() => parseEnvelope('{"activity":{},"concerns":{},"dedup":{},"schema_version":2}')).toThrow("envelope");
   });
 });

--- a/packages/sync-intervals-icu/package.json
+++ b/packages/sync-intervals-icu/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@enduragent/sync-intervals-icu",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Archive-first intervals.icu source for the Reference layer.",
+  "type": "module",
+  "files": ["dist"],
+  "exports": { ".": "./dist/index.js" },
+  "scripts": {
+    "build": "tsup",
+    "check": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@enduragent/kernel": "workspace:*",
+    "fflate": "0.8.3"
+  },
+  "devDependencies": {
+    "tsup": "^8.4.0",
+    "typescript": "^6.0.2",
+    "vitest": "^4.1.4"
+  },
+  "license": "MIT"
+}

--- a/packages/sync-intervals-icu/src/cursor.ts
+++ b/packages/sync-intervals-icu/src/cursor.ts
@@ -1,0 +1,92 @@
+import type { SourceLane } from "@enduragent/kernel/store";
+
+export interface RangeCursor {
+  readonly v: 1;
+  readonly cycle: number;
+  readonly window_start: string;
+  readonly window_end: string;
+  readonly last_key: string | null;
+  readonly complete: boolean;
+}
+
+export type IndexCursor = RangeCursor;
+
+export interface CursorRange {
+  readonly oldest: string;
+  readonly newest: string;
+}
+
+const DATE = /^([0-9]{4})-([0-9]{2})-([0-9]{2})$/;
+const CURSOR_KEYS = "v,cycle,window_start,window_end,last_key,complete";
+
+export function parseCivilDate(value: unknown): string {
+  if (typeof value !== "string") throw new TypeError("history date is invalid");
+  const match = DATE.exec(value);
+  if (match === null) throw new TypeError("history date is invalid");
+  const year = Number(match[1]), month = Number(match[2]), day = Number(match[3]);
+  const instant = new Date(Date.UTC(year, month - 1, day));
+  if (instant.getUTCFullYear() !== year || instant.getUTCMonth() !== month - 1 || instant.getUTCDate() !== day) {
+    throw new TypeError("history date is invalid");
+  }
+  return value;
+}
+
+export function addUtcDays(value: string, days: number): string {
+  parseCivilDate(value);
+  if (!Number.isSafeInteger(days)) throw new TypeError("day offset is invalid");
+  const date = new Date(`${value}T00:00:00.000Z`);
+  date.setUTCDate(date.getUTCDate() + days);
+  return date.toISOString().slice(0, 10);
+}
+
+export function compareBinary(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+export function windowEnd(start: string, newest: string): string {
+  const candidate = addUtcDays(start, 364);
+  return compareBinary(candidate, newest) < 0 ? candidate : newest;
+}
+
+export function initialCursor(lane: SourceLane, range: CursorRange, cycle = 0): RangeCursor {
+  const start = lane === "settings" ? range.newest : range.oldest;
+  return { v: 1, cycle, window_start: start,
+    window_end: lane === "settings" ? range.newest : windowEnd(start, range.newest), last_key: null, complete: false };
+}
+
+export function compactCursor(cursor: RangeCursor): string {
+  return JSON.stringify({ v: cursor.v, cycle: cursor.cycle, window_start: cursor.window_start,
+    window_end: cursor.window_end, last_key: cursor.last_key, complete: cursor.complete });
+}
+
+export function parseCursor(value: string | null, lane: SourceLane, range: CursorRange): RangeCursor {
+  parseCivilDate(range.oldest); parseCivilDate(range.newest);
+  if (compareBinary(range.oldest, range.newest) > 0) throw new TypeError("history range is invalid");
+  if (value === null) return initialCursor(lane, range);
+  let parsed: unknown;
+  try { parsed = JSON.parse(value); } catch { throw new TypeError("source cursor is invalid"); }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)
+    || Object.keys(parsed).join(",") !== CURSOR_KEYS) throw new TypeError("source cursor is invalid");
+  const cursor = parsed as Record<string, unknown>;
+  if (cursor.v !== 1 || !Number.isSafeInteger(cursor.cycle) || (cursor.cycle as number) < 0
+    || (cursor.last_key !== null && typeof cursor.last_key !== "string") || typeof cursor.complete !== "boolean") {
+    throw new TypeError("source cursor is invalid");
+  }
+  const start = parseCivilDate(cursor.window_start), end = parseCivilDate(cursor.window_end);
+  const expectedStart = lane === "settings" ? range.newest : start;
+  const validWindow = start === expectedStart && end === (lane === "settings" ? range.newest : windowEnd(start, range.newest))
+    && compareBinary(start, range.oldest) >= 0 && compareBinary(end, range.newest) <= 0;
+  if (!validWindow || (cursor.complete === true && cursor.last_key !== null)) throw new TypeError("source cursor range is invalid");
+  const result = { v: 1 as const, cycle: cursor.cycle as number, window_start: start, window_end: end,
+    last_key: cursor.last_key as string | null, complete: cursor.complete as boolean };
+  if (!result.complete) return result;
+  if (lane === "bulk-fit") return result;
+  if (result.cycle === Number.MAX_SAFE_INTEGER) throw new TypeError("source cursor cycle is invalid");
+  return initialCursor(lane, range, result.cycle + 1);
+}
+
+export function advanceWindow(cursor: RangeCursor, range: CursorRange): RangeCursor {
+  if (cursor.window_end === range.newest) return { ...cursor, last_key: null, complete: true };
+  const start = addUtcDays(cursor.window_end, 1);
+  return { ...cursor, window_start: start, window_end: windowEnd(start, range.newest), last_key: null };
+}

--- a/packages/sync-intervals-icu/src/http.ts
+++ b/packages/sync-intervals-icu/src/http.ts
@@ -1,0 +1,123 @@
+import { retryAfterMsFromHeaders, retryWithBackoff } from "@enduragent/kernel/concurrency";
+import type { ClockPort, HttpPort, HttpRequest, HttpResponse } from "@enduragent/kernel/ports";
+import type { SyncBudget } from "@enduragent/kernel/store";
+
+export const REQUEST_ATTEMPTS = 4;
+export const REQUEST_BACKOFF_BASE_MS = 1_000;
+export const REQUEST_BACKOFF_CAP_MS = 30_000;
+export const MIN_CONFIGURED_INTERVAL_MS = 250;
+
+export type IntervalsEndpoint = "activities" | "wellness" | "settings" | "streams" | "bulk-fit" | "fit-file";
+
+export class SyncBudgetExceededError extends Error {
+  constructor() {
+    super("intervals.icu sync budget exceeded");
+    this.name = "SyncBudgetExceededError";
+  }
+}
+
+export class IntervalsHttpError extends Error {
+  readonly endpoint: IntervalsEndpoint;
+  readonly status: number;
+  readonly retryAfterMs: number | null;
+  constructor(endpoint: IntervalsEndpoint, status: number, retryAfterMs: number | null) {
+    super("intervals.icu request failed");
+    this.name = "IntervalsHttpError";
+    this.endpoint = endpoint;
+    this.status = status;
+    this.retryAfterMs = retryAfterMs;
+  }
+}
+
+export interface IntervalsRequester {
+  request(endpoint: IntervalsEndpoint, request: HttpRequest): Promise<HttpResponse>;
+  requestsUsed(): number;
+  canRequest(count?: number): boolean;
+  assertActive(): void;
+}
+
+function positiveSafe(value: unknown, name: string): asserts value is number {
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value <= 0) throw new TypeError(`${name} is invalid`);
+}
+
+export function validateBudget(budget: SyncBudget): void {
+  positiveSafe(budget.maxRequests, "request budget");
+  positiveSafe(budget.maxArtifacts, "artifact budget");
+  positiveSafe(budget.perRequestTimeoutMs, "request timeout");
+  if (typeof budget.deadlineMonotonicMs !== "number" || !Number.isFinite(budget.deadlineMonotonicMs)
+    || budget.deadlineMonotonicMs < 0) throw new TypeError("sync deadline is invalid");
+  const now = budget.clock.monotonicNow();
+  if (typeof now !== "number" || !Number.isFinite(now) || now < 0) throw new TypeError("sync clock is invalid");
+}
+
+export function createRequester(options: {
+  readonly http: HttpPort;
+  readonly budget: SyncBudget;
+  readonly minRequestIntervalMs: number;
+  readonly wallClock: Pick<ClockPort, "now">;
+  readonly sleep: (ms: number, signal: AbortSignal) => Promise<void>;
+}): IntervalsRequester {
+  validateBudget(options.budget);
+  if (!Number.isSafeInteger(options.minRequestIntervalMs) || options.minRequestIntervalMs < MIN_CONFIGURED_INTERVAL_MS) {
+    throw new TypeError("minimum request interval is invalid");
+  }
+  let used = 0;
+  let lastAttemptStart: number | null = null;
+  const monotonicNow = (): number => {
+    const value = options.budget.clock.monotonicNow();
+    if (typeof value !== "number" || !Number.isFinite(value) || value < 0) throw new TypeError("sync clock is invalid");
+    return value;
+  };
+  const assertActive = (): void => {
+    if (options.budget.signal.aborted || monotonicNow() >= options.budget.deadlineMonotonicMs) {
+      throw new SyncBudgetExceededError();
+    }
+  };
+  const canRequest = (count = 1): boolean => Number.isSafeInteger(count) && count > 0
+    && !options.budget.signal.aborted && monotonicNow() < options.budget.deadlineMonotonicMs
+    && used + count <= options.budget.maxRequests;
+
+  return {
+    requestsUsed: () => used,
+    canRequest,
+    assertActive,
+    async request(endpoint, request) {
+      const retryableMethod = request.method === "GET" || (request.method === "POST" && endpoint === "bulk-fit");
+      return retryWithBackoff(async () => {
+        assertActive();
+        if (used >= options.budget.maxRequests) throw new SyncBudgetExceededError();
+        if (lastAttemptStart !== null) {
+          const delay = Math.max(0, lastAttemptStart + options.minRequestIntervalMs - monotonicNow());
+          if (delay > 0) {
+            if (monotonicNow() + delay >= options.budget.deadlineMonotonicMs) throw new SyncBudgetExceededError();
+            await options.sleep(delay, options.budget.signal);
+            assertActive();
+          }
+        }
+        if (used >= options.budget.maxRequests) throw new SyncBudgetExceededError();
+        lastAttemptStart = monotonicNow();
+        used += 1;
+        const response = await options.http.fetch(request);
+        if (response.status >= 200 && response.status < 300) return response;
+        throw new IntervalsHttpError(endpoint, response.status,
+          retryAfterMsFromHeaders(response.headers, options.wallClock.now()));
+      }, {
+        attempts: REQUEST_ATTEMPTS,
+        baseMs: REQUEST_BACKOFF_BASE_MS,
+        capMs: REQUEST_BACKOFF_CAP_MS,
+        signal: options.budget.signal,
+        shouldRetry(error) {
+          return retryableMethod && error instanceof IntervalsHttpError
+            && [429, 500, 502, 503, 504].includes(error.status);
+        },
+        retryAfterMs: (error) => error instanceof IntervalsHttpError ? error.retryAfterMs : null,
+        retryAfterMode: "lower-bound",
+        onRetry({ delayMs }) {
+          if (used >= options.budget.maxRequests) throw new SyncBudgetExceededError();
+          if (monotonicNow() + delayMs >= options.budget.deadlineMonotonicMs) throw new SyncBudgetExceededError();
+        },
+        sleep: (ms) => options.sleep(ms, options.budget.signal),
+      });
+    },
+  };
+}

--- a/packages/sync-intervals-icu/src/index.ts
+++ b/packages/sync-intervals-icu/src/index.ts
@@ -1,0 +1,6 @@
+export * from "./types.js";
+export * from "./cursor.js";
+export * from "./http.js";
+export * from "./landing.js";
+export * from "./source.js";
+export * from "./zip.js";

--- a/packages/sync-intervals-icu/src/landing.ts
+++ b/packages/sync-intervals-icu/src/landing.ts
@@ -1,0 +1,227 @@
+import { canonicalJson, type ArchiveInstant, type ArchiveWriteResult } from "@enduragent/kernel/archive";
+import { buildPlatformPresentation, type ConcernValue, type PlatformImportArtifact } from "@enduragent/kernel/ingest";
+import type { CryptoPort } from "@enduragent/kernel/ports";
+import { SPORT_FAMILIES } from "@enduragent/kernel/reference/metrics";
+import { H, sortKeys, type AnchorHistoryRow, type WellnessLandingRow, type ZoneSetHistoryRow } from "@enduragent/kernel/store";
+import { compareBinary, parseCivilDate } from "./cursor.js";
+
+function record(value: unknown, name: string): Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) throw new TypeError(`${name} is invalid`);
+  return value as Record<string, unknown>;
+}
+
+function nonempty(value: unknown, name: string): string {
+  if (typeof value !== "string" || value.length === 0) throw new TypeError(`${name} is invalid`);
+  return value;
+}
+
+function safeInteger(value: unknown, name: string): number {
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0 || Object.is(value, -0)) {
+    throw new TypeError(`${name} is invalid`);
+  }
+  return value;
+}
+
+function finiteNonnegative(value: unknown, name: string): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0 || Object.is(value, -0)) {
+    throw new TypeError(`${name} is invalid`);
+  }
+  return value;
+}
+
+function externalId(value: unknown): string {
+  if (typeof value === "string" && value.length > 0) return value;
+  if (typeof value === "number" && Number.isFinite(value) && Number.isSafeInteger(value) && !Object.is(value, -0)) return String(value);
+  throw new TypeError("activity id is invalid");
+}
+
+function startEpoch(value: unknown, name: string): number {
+  const text = nonempty(value, name);
+  const milliseconds = Date.parse(text);
+  if (!Number.isFinite(milliseconds) || milliseconds < 0 || milliseconds % 1_000 !== 0) throw new TypeError(`${name} is invalid`);
+  const seconds = milliseconds / 1_000;
+  if (!Number.isSafeInteger(seconds)) throw new TypeError(`${name} is invalid`);
+  return seconds;
+}
+
+function dateKey(value: unknown, name: string): number {
+  const text = nonempty(value, name).slice(0, 10);
+  parseCivilDate(text);
+  return Number(text.replaceAll("-", ""));
+}
+
+const webCrypto = {
+  async sha256(data: Uint8Array): Promise<Uint8Array> {
+    const copy = new Uint8Array(data.byteLength); copy.set(data);
+    return new Uint8Array(await globalThis.crypto.subtle.digest("SHA-256", copy));
+  },
+} as CryptoPort;
+const hash = (...fields: readonly [string | number, ...(string | number)[]]): Promise<string> => H(webCrypto, ...fields);
+const compactCanonical = (value: unknown): string => JSON.stringify(sortKeys(value));
+
+export async function mapActivityLanding(options: {
+  readonly normalized: Readonly<Record<string, unknown>>;
+  readonly archiveInstant: ArchiveInstant;
+  readonly archive: ArchiveWriteResult;
+}): Promise<PlatformImportArtifact> {
+  const activity = record(options.normalized, "activity");
+  const id = externalId(activity.id);
+  const start_utc = startEpoch(activity.start_date, "activity start");
+  const local_date_key = dateKey(activity.start_date_local, "activity local start");
+  const type = nonempty(activity.type, "activity type");
+  const moving = safeInteger(activity.moving_time, "activity moving time");
+  const duration = safeInteger(activity.elapsed_time, "activity elapsed time");
+  const distance = activity.distance === undefined || activity.distance === null
+    ? null : finiteNonnegative(activity.distance, "activity distance");
+  const sport = Object.hasOwn(SPORT_FAMILIES, type) ? SPORT_FAMILIES[type]! : "other";
+  const normalizedActivityJson = canonicalJson(activity);
+  const summaryJson = compactCanonical(activity);
+  const concerns: Record<string, ConcernValue> = {
+    "session.sport": sport,
+    "session.start_utc": start_utc,
+    "session.local_date_key": local_date_key,
+    "session.elapsed_s": duration,
+    "session.moving_s": moving,
+    "session.is_transition": type === "Transition",
+    "session.summary_json": summaryJson,
+    "stream:time": duration > 0
+      ? { timestamps: [start_utc, start_utc + duration], values: [start_utc, start_utc + duration] }
+      : { timestamps: [start_utc], values: [start_utc] },
+  };
+  if (distance !== null) concerns["session.distance_m"] = distance;
+  const platform: PlatformImportArtifact = {
+    source: "intervals-icu",
+    activity_id: id,
+    activity,
+    dedup: { sport_family: sport, is_transition: type === "Transition", start_utc, duration_s: duration, distance_m: distance },
+    concerns,
+    raw_snapshot_address: options.archive.address,
+    raw_snapshot_rel_path: options.archive.relPath,
+    sourceEvidence: { source: "intervals-icu", lane: "activities", externalId: id,
+      archiveInstant: options.archiveInstant, archive: options.archive, normalizedActivityJson },
+  };
+  await buildPlatformPresentation(platform, (fields) => hash(...fields as [string | number, ...(string | number)[]]));
+  return platform;
+}
+
+function nullableInteger(value: unknown, name: string): number | null {
+  return value === undefined || value === null ? null : safeInteger(value, name);
+}
+
+function nullableNumber(value: unknown, name: string): number | null {
+  return value === undefined || value === null ? null : finiteNonnegative(value, name);
+}
+
+export async function mapWellnessLanding(normalized: Readonly<Record<string, unknown>>): Promise<WellnessLandingRow> {
+  const values = record(normalized, "wellness");
+  const id = parseCivilDate(values.id);
+  const key = Number(id.replaceAll("-", ""));
+  return {
+    id: await hash("wellness", key, "intervals-icu"),
+    date_key: key,
+    provenance: "sync",
+    source: "intervals-icu",
+    resting_hr: nullableInteger(values.restingHR, "resting heart rate"),
+    hrv: nullableNumber(values.hrv, "heart rate variability"),
+    hrv_sdnn: nullableNumber(values.hrvSdnn, "heart rate variability SDNN"),
+    sleep_s: nullableInteger(values.sleepSecs, "sleep seconds"),
+    sleep_score: nullableInteger(values.sleepQuality, "sleep quality"),
+    weight_kg: nullableNumber(values.weight, "weight"),
+    soreness: nullableInteger(values.soreness, "soreness"),
+    fatigue: nullableInteger(values.fatigue, "fatigue"),
+    fields_json: canonicalJson({ source: "intervals-icu", values }),
+    device_id: null,
+    hlc_physical_ms: null,
+    hlc_counter: null,
+  };
+}
+
+export function normalizeStreamLanding(normalized: Readonly<Record<string, unknown>>): Readonly<Record<string, unknown>> {
+  const source = record(normalized, "streams");
+  const result: Record<string, unknown> = {};
+  let length: number | null = null;
+  for (const key of ["time", "watts", "heartrate", "dfa_a1", "artifacts"] as const) {
+    if (!Object.hasOwn(source, key)) continue;
+    const channel = source[key];
+    if (!Array.isArray(channel) || channel.some((sample) => sample !== null
+      && (typeof sample !== "number" || !Number.isFinite(sample)))) throw new TypeError("stream channel is invalid");
+    if (length === null) length = channel.length;
+    else if (channel.length !== length) throw new TypeError("stream channel lengths differ");
+    result[key] = [...channel];
+  }
+  return Object.freeze(result);
+}
+
+function optionalPositive(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : null;
+}
+
+function zones(value: unknown): readonly number[] | null {
+  return Array.isArray(value) && value.length >= 2
+    && value.every((entry) => typeof entry === "number" && Number.isFinite(entry) && entry >= 0)
+    ? value as number[] : null;
+}
+
+function zoneNames(value: unknown, length: number): readonly string[] | null {
+  return Array.isArray(value) && value.length === length
+    && value.every((entry) => typeof entry === "string" && entry.length > 0) ? value as string[] : null;
+}
+
+export interface SettingsLanding {
+  readonly externalId: string;
+  readonly sourceRecordExternalId: string;
+  readonly normalizedPayloadJson: string;
+  readonly archiveEpochSeconds: number;
+  readonly anchors: readonly AnchorHistoryRow[];
+  readonly zones: readonly ZoneSetHistoryRow[];
+}
+
+export async function mapSettingsLanding(normalized: Readonly<Record<string, unknown>>): Promise<SettingsLanding> {
+  const setting = record(normalized, "sport setting");
+  if (typeof setting.id !== "number" || !Number.isSafeInteger(setting.id)) throw new TypeError("sport setting id is invalid");
+  const athleteId = nonempty(setting.athlete_id, "sport setting athlete id");
+  if (!Array.isArray(setting.types) || setting.types.length === 0
+    || setting.types.some((type) => typeof type !== "string" || type.length === 0)) throw new TypeError("sport setting types are invalid");
+  const types = setting.types as string[];
+  const updated = nonempty(setting.updated, "sport setting update");
+  const externalId = canonicalJson([setting.id, athleteId, types, updated]);
+  const updatedMs = Date.parse(updated);
+  const validFrom = Number.isFinite(updatedMs) && updatedMs >= 0 && updatedMs % 1_000 === 0
+    && Number.isSafeInteger(updatedMs / 1_000) ? updatedMs / 1_000 : null;
+  const families = [...new Set(types.filter((type) => Object.hasOwn(SPORT_FAMILIES, type)).map((type) => SPORT_FAMILIES[type]!))]
+    .sort();
+  const anchors: AnchorHistoryRow[] = [];
+  const zoneRows: ZoneSetHistoryRow[] = [];
+  if (validFrom !== null) for (const family of families) {
+    const anchorValues = [
+      ["ftp", "W", family === "cycling" ? optionalPositive(setting.ftp) : null],
+      ["lthr", "bpm", optionalPositive(setting.lthr)],
+      ["max_hr", "bpm", optionalPositive(setting.max_hr)],
+    ] as const;
+    for (const [anchorType, unit, value] of anchorValues) if (value !== null) anchors.push({
+      id: await hash("anchor_history", "intervals-icu", externalId, family, anchorType), sport: family,
+      anchor_type: anchorType, value, unit, valid_from: validFrom, source: "intervals-icu", confidence: "platform",
+      note: null, provenance: "sync", device_id: null, hlc_physical_ms: null, hlc_counter: null,
+    });
+    for (const [stream, anchorRef, values, names] of [
+      ["power", "ftp", zones(setting.power_zones), setting.power_zone_names],
+      ["hr", "lthr", zones(setting.hr_zones), setting.hr_zone_names],
+    ] as const) if (values !== null) zoneRows.push({
+      id: await hash("zone_set_history", "intervals-icu", externalId, family, stream), sport: family,
+      stream, anchor_ref: anchorRef, boundaries_json: canonicalJson({ boundaries: values, names: zoneNames(names, values.length) }),
+      valid_from: validFrom, source: "intervals-icu", provenance: "sync", device_id: null,
+      hlc_physical_ms: null, hlc_counter: null,
+    });
+  }
+  anchors.sort((a, b) => compareBinary(a.sport, b.sport) || compareBinary(a.anchor_type, b.anchor_type));
+  zoneRows.sort((a, b) => compareBinary(a.sport, b.sport) || compareBinary(a.stream, b.stream));
+  return { externalId, sourceRecordExternalId: `settings:${externalId}`, normalizedPayloadJson: canonicalJson(setting),
+    archiveEpochSeconds: validFrom ?? 0, anchors, zones: zoneRows };
+}
+
+export function activityIdentity(row: Readonly<Record<string, unknown>>): { readonly externalId: string; readonly startUtc: number; readonly localDate: string; readonly key: string } {
+  const id = externalId(row.id);
+  const localDate = nonempty(row.start_date_local, "activity local start").slice(0, 10);
+  parseCivilDate(localDate);
+  return { externalId: id, startUtc: startEpoch(row.start_date, "activity start"), localDate, key: `${localDate}\u001f${id}` };
+}

--- a/packages/sync-intervals-icu/src/source.ts
+++ b/packages/sync-intervals-icu/src/source.ts
@@ -1,0 +1,365 @@
+import { canonicalJson, type ArchiveInstant, type ArchiveWriteResult } from "@enduragent/kernel/archive";
+import type { HttpRequest, HttpResponse } from "@enduragent/kernel/ports";
+import type { SourceCheckpoint, SourceLane, SourceWatermark, SyncBudget } from "@enduragent/kernel/store";
+import { activityIdentity, mapActivityLanding, mapSettingsLanding, mapWellnessLanding, normalizeStreamLanding } from "./landing.js";
+import { advanceWindow, compactCursor, compareBinary, parseCivilDate, parseCursor, type CursorRange, type RangeCursor } from "./cursor.js";
+import { createRequester, IntervalsHttpError, MIN_CONFIGURED_INTERVAL_MS, type IntervalsRequester } from "./http.js";
+import { BULK_FIT_BATCH_SIZE, BULK_SAFE_ACTIVITY_ID, IncompleteBulkFitBatchError, MAX_FIT_BYTES, MAX_ZIP_BYTES, extractBulkFitZip } from "./zip.js";
+import { INTERVALS_ICU_CAPABILITIES, INTERVALS_ICU_SOURCE_ID, MAX_JSON_BYTES, type IntervalsIcuArtifact, type IntervalsIcuSource, type IntervalsIcuSourceOptions } from "./types.js";
+
+const BASE_URL = "https://intervals.icu";
+const JSON_TYPE = "application/json";
+const ZIP_TYPE = "application/zip";
+
+function nonempty(value: unknown, name: string): string {
+  if (typeof value !== "string" || value.length === 0) throw new TypeError(`${name} is invalid`);
+  return value;
+}
+
+function objectRow(value: unknown, name: string): Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) throw new TypeError(`${name} is invalid`);
+  return value as Record<string, unknown>;
+}
+
+function epochForDate(date: string): number {
+  parseCivilDate(date);
+  return Math.max(0, Date.parse(`${date}T00:00:00.000Z`) / 1_000);
+}
+
+function baseContentType(response: HttpResponse): string {
+  return (response.headers["content-type"] ?? "").split(";", 1)[0]!.trim().toLowerCase();
+}
+
+function parseJsonResponse(response: HttpResponse): unknown {
+  if (response.status !== 200 || baseContentType(response) !== JSON_TYPE) throw new TypeError("intervals.icu JSON response is invalid");
+  if (response.body.byteLength > MAX_JSON_BYTES) throw new TypeError("intervals.icu JSON response is too large");
+  let text: string;
+  try { text = new TextDecoder("utf-8", { fatal: true }).decode(response.body); }
+  catch { throw new TypeError("intervals.icu JSON encoding is invalid"); }
+  try { return JSON.parse(text); }
+  catch { throw new TypeError("intervals.icu JSON response is invalid"); }
+}
+
+function endpointUrl(path: string, params: readonly (readonly [string, string])[] = []): string {
+  const url = new URL(path, BASE_URL);
+  for (const [key, value] of params) url.searchParams.append(key, value);
+  return url.toString();
+}
+
+function rangeUrl(athleteId: string, endpoint: "activities" | "wellness", cursor: RangeCursor): string {
+  return endpointUrl(`/api/v1/athlete/${encodeURIComponent(athleteId)}/${endpoint}`,
+    [["oldest", cursor.window_start], ["newest", cursor.window_end]]);
+}
+
+interface ActivityIndexEntry extends ReturnType<typeof activityIdentity> {
+  readonly row: Record<string, unknown>;
+}
+
+function activityIndex(value: unknown): readonly ActivityIndexEntry[] {
+  if (!Array.isArray(value)) throw new TypeError("activities response is invalid");
+  const rows = value.map((entry) => {
+    const row = objectRow(entry, "activity row");
+    nonempty(row.type, "activity type");
+    for (const [field, label] of [["moving_time", "moving time"], ["elapsed_time", "elapsed time"]] as const) {
+      const item = row[field];
+      if (typeof item !== "number" || !Number.isSafeInteger(item) || item < 0) throw new TypeError(`activity ${label} is invalid`);
+    }
+    return { ...activityIdentity(row), row };
+  });
+  rows.sort((a, b) => compareBinary(a.key, b.key));
+  return rows;
+}
+
+function checkpoint(lane: SourceLane, cursor: RangeCursor): SourceCheckpoint {
+  return { kind: "checkpoint", watermark: { source: "intervals-icu", lane, value: compactCursor(cursor) } };
+}
+
+function nextCursor(cursor: RangeCursor, range: CursorRange, remaining: number, processedKey: string | null): RangeCursor {
+  if (remaining > 0) return { ...cursor, last_key: processedKey };
+  return advanceWindow({ ...cursor, last_key: processedKey }, range);
+}
+
+async function fetchJson(requester: IntervalsRequester, endpoint: Parameters<IntervalsRequester["request"]>[0], request: HttpRequest): Promise<unknown> {
+  return parseJsonResponse(await requester.request(endpoint, request));
+}
+
+function rowInstant(epochSeconds: number): ArchiveInstant {
+  return { epochSeconds };
+}
+
+function wellnessIdentity(row: Record<string, unknown>): { readonly id: string; readonly key: string; readonly instant: ArchiveInstant } {
+  const id = parseCivilDate(row.id);
+  return { id, key: `${id}\u001f${id}`, instant: rowInstant(epochForDate(id)) };
+}
+
+function settingsIdentity(row: Record<string, unknown>): string {
+  if (typeof row.id !== "number" || !Number.isSafeInteger(row.id)) throw new TypeError("sport setting id is invalid");
+  const athleteId = nonempty(row.athlete_id, "sport setting athlete id");
+  if (!Array.isArray(row.types) || row.types.length === 0
+    || row.types.some((type) => typeof type !== "string" || type.length === 0)) throw new TypeError("sport setting types are invalid");
+  return canonicalJson([row.id, athleteId, row.types, nonempty(row.updated, "sport setting update")]);
+}
+
+function settingEpoch(row: Record<string, unknown>): number {
+  const milliseconds = typeof row.updated === "string" ? Date.parse(row.updated) : Number.NaN;
+  return Number.isFinite(milliseconds) && milliseconds >= 0 && milliseconds % 1_000 === 0
+    && Number.isSafeInteger(milliseconds / 1_000) ? milliseconds / 1_000 : 0;
+}
+
+function streamUrl(activityId: string): string {
+  return endpointUrl(`/api/v1/activity/${encodeURIComponent(activityId)}/streams.json`, [
+    ["types", "time"], ["types", "watts"], ["types", "heartrate"], ["types", "dfa_a1"],
+    ["types", "artifacts"], ["includeDefaults", "false"],
+  ]);
+}
+
+function bulkUrl(athleteId: string, ids: readonly string[]): string {
+  return endpointUrl(`/api/v1/athlete/${encodeURIComponent(athleteId)}/download-fit-files`, [
+    ["power", "true"], ["hr", "true"], ...ids.map((id) => ["ids", id] as const),
+  ]);
+}
+
+function fitUrl(activityId: string): string {
+  return endpointUrl(`/api/v1/activity/${encodeURIComponent(activityId)}/fit-file`);
+}
+
+interface FitReady {
+  readonly activityId: string;
+  readonly startUtc: number;
+  readonly bytes: Uint8Array;
+  readonly archive: ArchiveWriteResult;
+}
+
+export function createIntervalsIcuSource(options: IntervalsIcuSourceOptions): IntervalsIcuSource {
+  const athleteId = nonempty(options.athleteId, "athlete id");
+  const range: CursorRange = {
+    oldest: parseCivilDate(options.historyOldestDate ?? "1900-01-01"),
+    newest: parseCivilDate(options.historyNewestDate),
+  };
+  if (compareBinary(range.oldest, range.newest) > 0) throw new TypeError("history range is invalid");
+  if (!Number.isSafeInteger(options.minRequestIntervalMs) || options.minRequestIntervalMs < MIN_CONFIGURED_INTERVAL_MS) {
+    throw new TypeError("minimum request interval is invalid");
+  }
+
+  async function* pull(watermark: SourceWatermark, budget: SyncBudget): AsyncGenerator<IntervalsIcuArtifact> {
+    if (watermark.source !== "intervals-icu") throw new TypeError("source watermark does not belong to intervals.icu");
+    if (!["activities", "streams", "wellness", "settings", "bulk-fit"].includes(watermark.lane)) {
+      throw new TypeError("source lane is unsupported");
+    }
+    const lane = watermark.lane as "activities" | "streams" | "wellness" | "settings" | "bulk-fit";
+    const cursor = parseCursor(watermark.value, lane, range);
+    const requester = createRequester({
+      http: options.httpFactory({ outer: budget.signal, perRequestTimeoutMs: budget.perRequestTimeoutMs }),
+      budget,
+      minRequestIntervalMs: options.minRequestIntervalMs,
+      wallClock: options.wallClock,
+      sleep: options.sleep,
+    });
+    let yielded = 0;
+    const beforeYield = (): void => {
+      requester.assertActive();
+      if (yielded >= budget.maxArtifacts) throw new Error("artifact yield exceeds validated budget");
+      yielded += 1;
+    };
+    const yieldCheckpoint = async function* (value: RangeCursor): AsyncGenerator<IntervalsIcuArtifact> {
+      requester.assertActive();
+      yield checkpoint(lane, value);
+    };
+
+    if (lane === "bulk-fit" && cursor.complete) {
+      yield* yieldCheckpoint(cursor);
+      return;
+    }
+    if (!requester.canRequest()) {
+      yield* yieldCheckpoint(cursor);
+      return;
+    }
+
+    if (lane === "activities" || lane === "wellness") {
+      const transport = await fetchJson(requester, lane, { method: "GET", url: rangeUrl(athleteId, lane, cursor) });
+      await options.archive.writeSnapshot(transport, rowInstant(epochForDate(cursor.window_start)));
+      if (!Array.isArray(transport)) throw new TypeError(`${lane} response is invalid`);
+      const indexed = lane === "activities" ? [...activityIndex(transport)] : transport.map((entry) => {
+        const row = objectRow(entry, "wellness row"), identity = wellnessIdentity(row);
+        return { externalId: identity.id, startUtc: identity.instant.epochSeconds, localDate: identity.id, key: identity.key, row };
+      }).sort((a, b) => compareBinary(a.key, b.key));
+      const remaining = indexed.filter((entry) => cursor.last_key === null || compareBinary(entry.key, cursor.last_key) > 0);
+      let processedKey = cursor.last_key;
+      let processed = 0;
+      for (const entry of remaining) {
+        if (yielded >= budget.maxArtifacts) break;
+        const instant = rowInstant(entry.startUtc);
+        const archive = await options.archive.writeSnapshot(entry.row, instant);
+        const landingCopy = structuredClone(entry.row);
+        if (lane === "activities") {
+          const normalized = options.acl.activity(landingCopy);
+          options.acl.assertClean(normalized);
+          const platform = await mapActivityLanding({ normalized, archiveInstant: instant, archive });
+          beforeYield();
+          yield { kind: "snapshot", source: "intervals-icu", lane: "activities", externalId: entry.externalId,
+            archiveInstant: instant, archive, payload: entry.row, landing: { kind: "activity", platform } };
+        } else {
+          const normalized = options.acl.wellness(landingCopy);
+          options.acl.assertClean(normalized);
+          const row = await mapWellnessLanding(normalized);
+          if (row.date_key !== Number(entry.externalId.replaceAll("-", ""))) throw new TypeError("wellness identity changed during normalization");
+          beforeYield();
+          yield { kind: "snapshot", source: "intervals-icu", lane: "wellness", externalId: entry.externalId,
+            archiveInstant: instant, archive, payload: entry.row, landing: { kind: "wellness", row } };
+        }
+        processed += 1;
+        processedKey = entry.key;
+      }
+      yield* yieldCheckpoint(nextCursor(cursor, range, remaining.length - processed, processedKey));
+      return;
+    }
+
+    if (lane === "settings") {
+      const transport = await fetchJson(requester, "settings", { method: "GET",
+        url: endpointUrl(`/api/v1/athlete/${encodeURIComponent(athleteId)}`) });
+      await options.archive.writeSnapshot(transport, rowInstant(epochForDate(range.newest)));
+      const profile = objectRow(transport, "athlete settings");
+      const sourceSettings = profile.sportSettings === undefined ? [] : profile.sportSettings;
+      if (!Array.isArray(sourceSettings)) throw new TypeError("sport settings response is invalid");
+      const indexed = sourceSettings.map((entry) => {
+        const row = objectRow(entry, "sport setting");
+        const externalId = settingsIdentity(row);
+        return { row, externalId, key: externalId };
+      }).sort((a, b) => compareBinary(a.key, b.key));
+      const remaining = indexed.filter((entry) => cursor.last_key === null || compareBinary(entry.key, cursor.last_key) > 0);
+      let processedKey = cursor.last_key, processed = 0;
+      for (const entry of remaining) {
+        if (yielded >= budget.maxArtifacts) break;
+        const instant = rowInstant(settingEpoch(entry.row));
+        const archive = await options.archive.writeSnapshot(entry.row, instant);
+        const landingCopy = structuredClone(entry.row);
+        options.acl.assertClean(landingCopy);
+        const landing = await mapSettingsLanding(landingCopy);
+        if (landing.externalId !== entry.externalId) throw new TypeError("sport setting identity changed during normalization");
+        beforeYield();
+        yield { kind: "snapshot", source: "intervals-icu", lane: "settings",
+          externalId: landing.sourceRecordExternalId, archiveInstant: instant, archive, payload: entry.row,
+          landing: { kind: "settings", sourceRecordExternalId: landing.sourceRecordExternalId,
+            normalizedPayloadJson: landing.normalizedPayloadJson, anchors: landing.anchors, zones: landing.zones } };
+        processed += 1; processedKey = entry.key;
+      }
+      const next = remaining.length === processed ? { ...cursor, last_key: null, complete: true }
+        : { ...cursor, last_key: processedKey };
+      yield* yieldCheckpoint(next);
+      return;
+    }
+
+    const activityTransport = await fetchJson(requester, "activities", { method: "GET", url: rangeUrl(athleteId, "activities", cursor) });
+    await options.archive.writeSnapshot(activityTransport, rowInstant(epochForDate(cursor.window_start)));
+    const allActivities = activityIndex(activityTransport);
+    const remaining = allActivities.filter((entry) => cursor.last_key === null || compareBinary(entry.key, cursor.last_key) > 0);
+    let processedKey = cursor.last_key, processed = 0;
+
+    if (lane === "streams") {
+      for (const activity of remaining) {
+        if (yielded >= budget.maxArtifacts || !requester.canRequest()) break;
+        let transport: unknown;
+        try {
+          transport = await fetchJson(requester, "streams", { method: "GET", url: streamUrl(activity.externalId) });
+        } catch (error) {
+          if (error instanceof IntervalsHttpError && error.status === 404) {
+            processed += 1; processedKey = activity.key; continue;
+          }
+          throw error;
+        }
+        const instant = rowInstant(activity.startUtc);
+        const archive = await options.archive.writeSnapshot(transport, instant);
+        const landingCopy = structuredClone(transport);
+        const normalized = options.acl.streams(landingCopy);
+        options.acl.assertClean(normalized);
+        const streamLanding = normalizeStreamLanding(normalized);
+        const externalId = `streams:${activity.externalId}`;
+        beforeYield();
+        yield { kind: "snapshot", source: "intervals-icu", lane: "streams", externalId,
+          archiveInstant: instant, archive, payload: transport,
+          landing: { kind: "streams", sourceRecordExternalId: externalId,
+            normalizedPayloadJson: canonicalJson(streamLanding) } };
+        processed += 1; processedKey = activity.key;
+      }
+      yield* yieldCheckpoint(nextCursor(cursor, range, remaining.length - processed, processedKey));
+      return;
+    }
+
+    let offset = 0;
+    bulkLoop: while (offset < remaining.length) {
+      const first = remaining[offset]!;
+      const safe = BULK_SAFE_ACTIVITY_ID.test(first.externalId);
+      const group = safe
+        ? remaining.slice(offset, offset + BULK_FIT_BATCH_SIZE).filter((entry, index, values) => index === 0
+          || values.slice(0, index).every((prior) => BULK_SAFE_ACTIVITY_ID.test(prior.externalId)))
+          .filter((entry) => BULK_SAFE_ACTIVITY_ID.test(entry.externalId))
+        : [first];
+      if (yielded + group.length > budget.maxArtifacts) break;
+      if (!requester.canRequest()) break;
+      const starts = new Map(group.map((entry) => [entry.externalId, entry.startUtc]));
+      const requestedIds = group.map((entry) => entry.externalId).sort(compareBinary);
+      let container: { readonly externalId: string; readonly archiveInstant: ArchiveInstant; readonly archive: ArchiveWriteResult } | null = null;
+      let bytesById: ReadonlyMap<string, Uint8Array>;
+      if (safe) {
+        try {
+          const response = await requester.request("bulk-fit", { method: "POST", url: bulkUrl(athleteId, requestedIds) });
+          if (response.status !== 200 || baseContentType(response) !== ZIP_TYPE || response.body.byteLength === 0
+            || response.body.byteLength > MAX_ZIP_BYTES) throw new TypeError("bulk FIT ZIP response is invalid");
+          const archiveInstant = rowInstant(Math.min(...group.map((entry) => entry.startUtc)));
+          const archive = await options.archive.writeArtifact(response.body, "zip", archiveInstant);
+          container = { externalId: `batch:${canonicalJson(requestedIds)}`, archiveInstant, archive };
+          const entries = extractBulkFitZip(response.body, requestedIds);
+          bytesById = new Map(entries.map((entry) => [entry.activityId, entry.bytes]));
+        } catch (error) {
+          if (!(error instanceof IntervalsHttpError) || (error.status !== 404 && error.status !== 405)) throw error;
+          if (!requester.canRequest(requestedIds.length)) break bulkLoop;
+          const fallback = new Map<string, Uint8Array>();
+          const returned: string[] = [];
+          for (const id of requestedIds) {
+            try {
+              const response = await requester.request("fit-file", { method: "GET", url: fitUrl(id) });
+              if (response.status !== 200 || response.body.byteLength === 0 || response.body.byteLength > MAX_FIT_BYTES) {
+                throw new TypeError("fallback FIT response is invalid");
+              }
+              fallback.set(id, new Uint8Array(response.body)); returned.push(id);
+            } catch (fallbackError) {
+              if (fallbackError instanceof IntervalsHttpError && fallbackError.status === 404) continue;
+              throw fallbackError;
+            }
+          }
+          const missing = requestedIds.filter((id) => !fallback.has(id));
+          if (missing.length > 0) throw new IncompleteBulkFitBatchError({ requested: requestedIds,
+            returned, missing, unexpected: [] });
+          bytesById = fallback;
+        }
+      } else {
+        const response = await requester.request("fit-file", { method: "GET", url: fitUrl(first.externalId) });
+        if (response.status !== 200 || response.body.byteLength === 0 || response.body.byteLength > MAX_FIT_BYTES) {
+          throw new TypeError("fallback FIT response is invalid");
+        }
+        bytesById = new Map([[first.externalId, new Uint8Array(response.body)]]);
+      }
+      const ready: FitReady[] = [];
+      for (const id of requestedIds) {
+        const bytes = bytesById.get(id);
+        const startUtc = starts.get(id);
+        if (bytes === undefined || startUtc === undefined) throw new Error("complete FIT batch attribution is invalid");
+        const archive = await options.archive.writeArtifact(bytes, "fit", rowInstant(startUtc));
+        ready.push({ activityId: id, startUtc, bytes, archive });
+      }
+      for (const entry of ready) {
+        beforeYield();
+        yield { kind: "raw-file", source: "intervals-icu", lane: "bulk-fit", externalId: entry.activityId,
+          archiveInstant: rowInstant(entry.startUtc), archive: entry.archive,
+          file: { input_path: `intervals-icu/${encodeURIComponent(entry.activityId)}.fit`, ext: "fit", bytes: entry.bytes },
+          container };
+      }
+      processed += group.length;
+      processedKey = group[group.length - 1]!.key;
+      offset += group.length;
+    }
+    yield* yieldCheckpoint(nextCursor(cursor, range, remaining.length - processed, processedKey));
+  }
+
+  return Object.freeze({ id: INTERVALS_ICU_SOURCE_ID, capabilities: INTERVALS_ICU_CAPABILITIES, pull });
+}

--- a/packages/sync-intervals-icu/src/types.ts
+++ b/packages/sync-intervals-icu/src/types.ts
@@ -1,0 +1,78 @@
+import type { ArchiveManager } from "@enduragent/kernel/archive";
+import type { PlatformImportArtifact } from "@enduragent/kernel/ingest";
+import type { ClockPort, HttpPort } from "@enduragent/kernel/ports";
+import type {
+  AnchorHistoryRow,
+  WellnessLandingRow,
+  ZoneSetHistoryRow,
+} from "@enduragent/kernel/store";
+import type {
+  RawFileSourceArtifact,
+  SnapshotSourceArtifact,
+  SourceCheckpoint,
+  SourceWatermark,
+  SyncBudget,
+  SyncSource,
+} from "@enduragent/kernel/store";
+
+export const INTERVALS_ICU_SOURCE_ID = "intervals-icu" as const;
+export const INTERVALS_ICU_CAPABILITIES = Object.freeze({
+  activities: true,
+  streams: true,
+  rawFiles: true,
+  wellness: true,
+  plannedWorkoutPush: false,
+  backfillDepth: Object.freeze({ kind: "full-history" as const }),
+});
+
+export const MAX_JSON_BYTES = 67_108_864;
+
+export interface IntervalsLandingAcl {
+  activity(row: Record<string, unknown>): Readonly<Record<string, unknown>>;
+  wellness(row: Record<string, unknown>): Readonly<Record<string, unknown>>;
+  streams(value: unknown): Readonly<Record<string, unknown>>;
+  assertClean(value: unknown): void;
+}
+
+export interface IntervalsIcuSourceOptions {
+  readonly athleteId: string;
+  readonly historyNewestDate: string;
+  readonly historyOldestDate?: string;
+  readonly minRequestIntervalMs: number;
+  readonly httpFactory: (args: {
+    readonly outer: AbortSignal;
+    readonly perRequestTimeoutMs: number;
+  }) => HttpPort;
+  readonly archive: ArchiveManager;
+  readonly acl: IntervalsLandingAcl;
+  readonly wallClock: Pick<ClockPort, "now">;
+  readonly sleep: (ms: number, signal: AbortSignal) => Promise<void>;
+}
+
+export type IntervalsIcuArtifact =
+  | (SnapshotSourceArtifact & {
+      readonly source: "intervals-icu";
+      readonly landing:
+        | { readonly kind: "activity"; readonly platform: PlatformImportArtifact }
+        | { readonly kind: "streams"; readonly sourceRecordExternalId: string; readonly normalizedPayloadJson: string }
+        | { readonly kind: "wellness"; readonly row: WellnessLandingRow }
+        | { readonly kind: "settings"; readonly sourceRecordExternalId: string; readonly normalizedPayloadJson: string; readonly anchors: readonly AnchorHistoryRow[]; readonly zones: readonly ZoneSetHistoryRow[] };
+    })
+  | (RawFileSourceArtifact & {
+      readonly kind: "raw-file";
+      readonly source: "intervals-icu";
+      readonly lane: "bulk-fit";
+      readonly externalId: string;
+      readonly container: {
+        readonly externalId: string;
+        readonly archiveInstant: { readonly epochSeconds: number };
+        readonly archive: { readonly address: string; readonly relPath: string; readonly deduped: boolean };
+      } | null;
+    })
+  | SourceCheckpoint;
+
+export interface IntervalsIcuSource extends SyncSource {
+  readonly id: "intervals-icu";
+  readonly capabilities: typeof INTERVALS_ICU_CAPABILITIES;
+  pull(watermark: SourceWatermark, budget: SyncBudget): AsyncIterable<IntervalsIcuArtifact>;
+}

--- a/packages/sync-intervals-icu/src/zip.ts
+++ b/packages/sync-intervals-icu/src/zip.ts
@@ -1,0 +1,93 @@
+import { Unzip, UnzipInflate } from "fflate";
+import { compareBinary } from "./cursor.js";
+
+export const BULK_FIT_BATCH_SIZE = 8;
+export const MAX_ZIP_BYTES = 268_435_456;
+export const MAX_FIT_BYTES = 134_217_728;
+export const MAX_UNCOMPRESSED_BATCH_BYTES = 536_870_912;
+export const BULK_SAFE_ACTIVITY_ID = /^[A-Za-z0-9.-]+$/;
+
+export interface ExtractedFitEntry {
+  readonly activityId: string;
+  readonly filename: string;
+  readonly bytes: Uint8Array;
+}
+
+export class IncompleteBulkFitBatchError extends Error {
+  readonly requested: readonly string[];
+  readonly returned: readonly string[];
+  readonly missing: readonly string[];
+  readonly unexpected: readonly string[];
+  constructor(options: {
+    readonly requested: readonly string[];
+    readonly returned: readonly string[];
+    readonly missing: readonly string[];
+    readonly unexpected: readonly string[];
+  }) {
+    super("intervals.icu bulk FIT batch is incomplete");
+    this.name = "IncompleteBulkFitBatchError";
+    this.requested = Object.freeze([...options.requested].sort(compareBinary));
+    this.returned = Object.freeze([...options.returned].sort(compareBinary));
+    this.missing = Object.freeze([...options.missing].sort(compareBinary));
+    this.unexpected = Object.freeze([...options.unexpected].sort(compareBinary));
+    Object.freeze(this);
+  }
+}
+
+export function extractBulkFitZip(bytes: Uint8Array, requestedInput: readonly string[]): readonly ExtractedFitEntry[] {
+  const requested = [...requestedInput].sort(compareBinary);
+  if (requested.length === 0 || requested.length > BULK_FIT_BATCH_SIZE
+    || new Set(requested).size !== requested.length || requested.some((id) => !BULK_SAFE_ACTIVITY_ID.test(id))) {
+    throw new TypeError("bulk FIT requested ids are invalid");
+  }
+  if (bytes.byteLength === 0 || bytes.byteLength > MAX_ZIP_BYTES) throw new TypeError("bulk FIT ZIP size is invalid");
+  const filenames = new Set<string>(), prefixes = new Set<string>();
+  const entries: ExtractedFitEntry[] = [];
+  let declaredTotal = 0, total = 0;
+  const unzip = new Unzip((file) => {
+    if (file.name.endsWith("/") || file.name.includes("/") || file.name.includes("\\")) {
+      throw new TypeError("bulk FIT ZIP path is invalid");
+    }
+    if (filenames.has(file.name)) throw new TypeError("bulk FIT ZIP filename is duplicated");
+    filenames.add(file.name);
+    if (filenames.size > BULK_FIT_BATCH_SIZE) throw new TypeError("bulk FIT ZIP has too many entries");
+    const match = /^([A-Za-z0-9.-]+)_(.+)\.fit$/.exec(file.name);
+    if (match === null || match[2]!.length === 0) throw new TypeError("bulk FIT ZIP filename is invalid");
+    const activityId = match[1]!;
+    if (prefixes.has(activityId)) throw new TypeError("bulk FIT ZIP activity prefix is duplicated");
+    prefixes.add(activityId);
+    if (file.originalSize !== undefined) {
+      if (file.originalSize > MAX_FIT_BYTES) throw new TypeError("bulk FIT entry is too large");
+      declaredTotal += file.originalSize;
+      if (declaredTotal > MAX_UNCOMPRESSED_BATCH_BYTES) throw new TypeError("bulk FIT batch is too large");
+    }
+    const chunks: Uint8Array[] = [];
+    let length = 0;
+    file.ondata = (error, chunk, final) => {
+      if (error !== null) throw error;
+      length += chunk.byteLength;
+      total += chunk.byteLength;
+      if (length > MAX_FIT_BYTES) throw new TypeError("bulk FIT entry is too large");
+      if (total > MAX_UNCOMPRESSED_BATCH_BYTES) throw new TypeError("bulk FIT batch is too large");
+      chunks.push(new Uint8Array(chunk));
+      if (final) {
+        if (length === 0) throw new TypeError("bulk FIT entry is empty");
+        const output = new Uint8Array(length);
+        let offset = 0;
+        for (const value of chunks) { output.set(value, offset); offset += value.byteLength; }
+        entries.push(Object.freeze({ activityId, filename: file.name, bytes: output }));
+      }
+    };
+    file.start();
+  });
+  unzip.register(UnzipInflate);
+  unzip.push(bytes, true);
+  const returned = [...prefixes].sort(compareBinary);
+  const requestedSet = new Set(requested), returnedSet = new Set(returned);
+  const missing = requested.filter((id) => !returnedSet.has(id));
+  const unexpected = returned.filter((id) => !requestedSet.has(id));
+  if (missing.length > 0 || unexpected.length > 0) {
+    throw new IncompleteBulkFitBatchError({ requested, returned, missing, unexpected });
+  }
+  return Object.freeze(entries.sort((left, right) => compareBinary(left.activityId, right.activityId)));
+}

--- a/packages/sync-intervals-icu/tests/acl-integration.test.ts
+++ b/packages/sync-intervals-icu/tests/acl-integration.test.ts
@@ -1,0 +1,54 @@
+import { createHash } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { canonicalJson, type ArchiveManager } from "@enduragent/kernel/archive";
+import type { HttpPort } from "@enduragent/kernel/ports";
+import { assertNoTpKeysRemain, parseRenamedActivity, parseRenamedWellnessRow,
+  renameTpFieldsOnActivity, renameTpFieldsOnWellnessRow } from "../../core/src/reference/sync/rename-tp-fields.js";
+import { normalizeStreams } from "../../core/src/reference/sync/fetch-live-bundle.js";
+import { createIntervalsIcuSource } from "../src/index.js";
+
+function archive(log: string[]): ArchiveManager {
+  const values = new Map<string, unknown>();
+  return {
+    async writeSnapshot(value, when) { log.push("archive"); const address = createHash("sha256").update(canonicalJson(value)).digest("hex");
+      const relPath = `${when.epochSeconds}/${address}.json.gz`; values.set(relPath, structuredClone(value)); return { address, relPath, deduped: false }; },
+    async has(path) { return values.has(path); }, async readSnapshot(path) { return structuredClone(values.get(path)); },
+    async writeArtifact() { throw new Error("unused"); }, async readArtifact() { throw new Error("unused"); },
+    async quarantine() { throw new Error("unused"); },
+  };
+}
+
+describe("existing landing ACL integration", () => {
+  it("archives before ACL, transport remains unchanged, and normalized keys are clean", async () => {
+    const raw = { id: "acl-a", start_date: "1998-01-05T07:00:00Z", start_date_local: "1998-01-05T08:00:00",
+      type: "Ride", moving_time: 90, elapsed_time: 100, icu_ctl: 52 };
+    const original = structuredClone(raw), log: string[] = [];
+    const http: HttpPort = { fetch: async () => ({ status: 200, headers: { "content-type": "application/json" },
+      body: new TextEncoder().encode(JSON.stringify([raw])) }) };
+    const source = createIntervalsIcuSource({ athleteId: "synthetic-athlete", historyOldestDate: "1998-01-01",
+      historyNewestDate: "1998-12-31", minRequestIntervalMs: 250, httpFactory: () => http, archive: archive(log),
+      wallClock: { now: () => Date.UTC(1998, 0, 1) }, sleep: async () => {}, acl: {
+        activity(row) { log.push("acl"); return parseRenamedActivity(renameTpFieldsOnActivity(row)); },
+        wellness(row) { return parseRenamedWellnessRow(renameTpFieldsOnWellnessRow(row)); },
+        streams(value) { const normalized = normalizeStreams(value); if (normalized === null || typeof normalized !== "object" || Array.isArray(normalized)) throw new TypeError("streams invalid"); return normalized as Record<string, unknown>; },
+        assertClean: assertNoTpKeysRemain,
+      } });
+    const values = [];
+    for await (const value of source.pull({ source: "intervals-icu", lane: "activities", value: null }, {
+      signal: new AbortController().signal, clock: { monotonicNow: () => 0 }, deadlineMonotonicMs: 1_000_000,
+      perRequestTimeoutMs: 30_000, maxRequests: 5, maxArtifacts: 5 })) values.push(value);
+    expect(log.slice(0, 3)).toEqual(["archive", "archive", "acl"]);
+    expect(raw).toEqual(original);
+    const artifact = values[0] as { payload: unknown; landing: { platform: { activity: Record<string, unknown> } } };
+    expect(artifact.payload).toEqual(original);
+    expect(artifact.landing.platform.activity.fitnessAtEnd).toBe(52);
+    expect(() => assertNoTpKeysRemain(artifact.landing.platform.activity)).not.toThrow();
+  });
+
+  it("uses the existing stream normalizer without mutating raw transport", () => {
+    const raw = [{ type: "dfa_a1", data: [0.9] }, { type: "watts", data: [200] }];
+    const original = structuredClone(raw), normalized = normalizeStreams(structuredClone(raw));
+    expect(normalized).toEqual({ dfa_a1: [0.9], watts: [200] }); expect(raw).toEqual(original);
+    expect(() => assertNoTpKeysRemain(normalized)).not.toThrow();
+  });
+});

--- a/packages/sync-intervals-icu/tests/http.test.ts
+++ b/packages/sync-intervals-icu/tests/http.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { HttpPort, HttpResponse } from "@enduragent/kernel/ports";
+import type { SyncBudget } from "@enduragent/kernel/store";
+import { makeIntervalsHttpFactory } from "../../core/src/reference/sync/intervals-client-factory.js";
+import { createRequester, IntervalsHttpError, SyncBudgetExceededError } from "../src/index.js";
+
+const response = (status: number, headers: Record<string, string> = {}): HttpResponse => ({ status, headers, body: new Uint8Array([1]) });
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+function harness(http: HttpPort, options: { deadline?: number; maxRequests?: number } = {}) {
+  let now = 0;
+  const sleeps: number[] = [];
+  const budget: SyncBudget = { signal: new AbortController().signal, clock: { monotonicNow: () => now },
+    deadlineMonotonicMs: options.deadline ?? 1_000_000, perRequestTimeoutMs: 30_000,
+    maxRequests: options.maxRequests ?? 10, maxArtifacts: 10 };
+  const requester = createRequester({ http, budget, minRequestIntervalMs: 500,
+    wallClock: { now: () => Date.UTC(1998, 0, 1) }, sleep: async (ms) => { sleeps.push(ms); now += ms; } });
+  return { requester, budget, sleeps, now: () => now };
+}
+
+describe("intervals.icu request policy", () => {
+  it("honors a valid long Retry-After beyond the local cap", async () => {
+    let attempts = 0;
+    const value = harness({ fetch: async () => ++attempts === 1 ? response(429, { "retry-after": "120" }) : response(200) });
+    await expect(value.requester.request("activities", { method: "GET", url: "https://intervals.icu/api/v1/test" }))
+      .resolves.toEqual(response(200));
+    expect(attempts).toBe(2);
+    expect(value.sleeps[0]).toBeGreaterThanOrEqual(120_000);
+    expect(value.sleeps[0]).toBeGreaterThan(30_000);
+  });
+
+  it("refuses Retry-After before sleeping past the deadline", async () => {
+    const value = harness({ fetch: async () => response(429, { "retry-after": "120" }) }, { deadline: 1_000 });
+    await expect(value.requester.request("activities", { method: "GET", url: "https://intervals.icu/api/v1/test" }))
+      .rejects.toBeInstanceOf(SyncBudgetExceededError);
+    expect(value.sleeps).toEqual([]);
+  });
+
+  it("refuses a retry before sleeping when the request budget is exhausted", async () => {
+    const value = harness({ fetch: async () => response(503) }, { maxRequests: 1 });
+    await expect(value.requester.request("activities", { method: "GET", url: "https://intervals.icu/api/v1/test" }))
+      .rejects.toBeInstanceOf(SyncBudgetExceededError);
+    expect(value.requester.requestsUsed()).toBe(1);
+    expect(value.sleeps).toEqual([]);
+  });
+
+  it("applies configurable pacing before every later attempt", async () => {
+    const starts: number[] = [];
+    const value = harness({ fetch: async () => { starts.push(value.now()); return response(200); } });
+    await value.requester.request("activities", { method: "GET", url: "https://intervals.icu/api/v1/one" });
+    await value.requester.request("wellness", { method: "GET", url: "https://intervals.icu/api/v1/two" });
+    expect(starts).toEqual([0, 500]); expect(value.sleeps).toEqual([500]);
+  });
+
+  it("outer abort makes exactly one attempt and no retry", async () => {
+    let attempts = 0;
+    const controller = new AbortController();
+    const budget: SyncBudget = { signal: controller.signal, clock: { monotonicNow: () => 0 }, deadlineMonotonicMs: 10_000,
+      perRequestTimeoutMs: 10, maxRequests: 10, maxArtifacts: 10 };
+    const requester = createRequester({ http: { fetch: async () => { attempts += 1; controller.abort(); throw new DOMException("aborted", "AbortError"); } },
+      budget, minRequestIntervalMs: 250, wallClock: { now: () => 0 }, sleep: vi.fn(async () => {}) });
+    await expect(requester.request("activities", { method: "GET", url: "https://intervals.icu/api/v1/test" }))
+      .rejects.toMatchObject({ name: "AbortError" });
+    expect(attempts).toBe(1);
+  });
+
+  it("per-request abort makes exactly one attempt and no retry while the outer budget stays live", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(AbortSignal, "timeout").mockImplementation((ms: number) => {
+      const controller = new AbortController();
+      setTimeout(() => controller.abort(new DOMException("aborted", "AbortError")), ms);
+      return controller.signal;
+    });
+    const outer = new AbortController();
+    const baseFetch = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => new Promise<Response>((_resolve, reject) => {
+      const signal = init?.signal;
+      if (!(signal instanceof AbortSignal)) throw new TypeError("request signal is missing");
+      signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+    }));
+    const http = makeIntervalsHttpFactory({ apiKey: "dummy", baseFetch: baseFetch as typeof globalThis.fetch })({
+      outer: outer.signal,
+      perRequestTimeoutMs: 10,
+    });
+    const budget: SyncBudget = { signal: outer.signal, clock: { monotonicNow: () => 0 }, deadlineMonotonicMs: 10_000,
+      perRequestTimeoutMs: 10, maxRequests: 10, maxArtifacts: 10 };
+    const requester = createRequester({ http, budget, minRequestIntervalMs: 250,
+      wallClock: { now: () => 0 }, sleep: vi.fn(async () => {}) });
+
+    const pending = requester.request("activities", { method: "GET", url: "https://intervals.icu/api/v1/test" });
+    const settled = pending.then(() => null, (error: unknown) => error);
+    await vi.advanceTimersByTimeAsync(10);
+    await expect(settled).resolves.toMatchObject({ name: "AbortError" });
+    expect(baseFetch).toHaveBeenCalledTimes(1);
+    expect(requester.requestsUsed()).toBe(1);
+    expect(outer.signal.aborted).toBe(false);
+  });
+
+  it("does not retry authentication, validation, or a non-proven POST", async () => {
+    const fetch = vi.fn(async () => response(401));
+    const value = harness({ fetch });
+    await expect(value.requester.request("settings", { method: "POST", url: "https://intervals.icu/api/v1/test" }))
+      .rejects.toEqual(expect.objectContaining<Partial<IntervalsHttpError>>({ status: 401, retryAfterMs: null }));
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/sync-intervals-icu/tests/landing.test.ts
+++ b/packages/sync-intervals-icu/tests/landing.test.ts
@@ -1,0 +1,68 @@
+import { createHash } from "node:crypto";
+import { describe, expect, it, vi } from "vitest";
+import { canonicalJson } from "@enduragent/kernel/archive";
+import { createIntervalsSourceRepository, sortKeys, type Row, type SqlStore } from "@enduragent/kernel/store";
+import { mapActivityLanding, mapSettingsLanding, mapWellnessLanding, normalizeStreamLanding } from "../src/index.js";
+
+const hashKey = async (fields: readonly (string | number)[]) => createHash("sha256").update(fields.join("\u001f")).digest("hex");
+
+describe("intervals.icu landing mappings", () => {
+  it("maps exact activity concerns and dedup without invented samples", async () => {
+    const activity = { id: 7, start_date: "1998-01-05T07:00:00Z", start_date_local: "1998-01-05T08:00:00",
+      type: "Ride", moving_time: 90, elapsed_time: 100, distance: 1_000, name: "synthetic" };
+    const address = "a".repeat(64), relPath = `1998/01/${address}.json.gz`;
+    const value = await mapActivityLanding({ normalized: activity, archiveInstant: { epochSeconds: 884_000_000 },
+      archive: { address, relPath, deduped: false } });
+    expect(value.activity_id).toBe("7");
+    expect(value.dedup).toEqual({ sport_family: "cycling", is_transition: false,
+      start_utc: Date.parse(activity.start_date) / 1_000, duration_s: 100, distance_m: 1_000 });
+    expect(value.concerns).toEqual({ "session.sport": "cycling", "session.start_utc": Date.parse(activity.start_date) / 1_000,
+      "session.local_date_key": 19980105, "session.elapsed_s": 100, "session.moving_s": 90,
+      "session.distance_m": 1_000, "session.is_transition": false, "session.summary_json": JSON.stringify(sortKeys(activity)),
+      "stream:time": { timestamps: [Date.parse(activity.start_date) / 1_000, Date.parse(activity.start_date) / 1_000 + 100],
+        values: [Date.parse(activity.start_date) / 1_000, Date.parse(activity.start_date) / 1_000 + 100] } });
+    expect(value.sourceEvidence).toMatchObject({ externalId: "7", normalizedActivityJson: canonicalJson(activity) });
+    expect(Object.keys(value.concerns).filter((key) => key.startsWith("stream:")).some((key) => key !== "stream:time")).toBe(false);
+  });
+
+  it("maps wellness columns and manual wellness wins", async () => {
+    const value = await mapWellnessLanding({ id: "1998-01-05", restingHR: 48, hrv: 71.5, hrvSdnn: 40,
+      sleepSecs: 28_800, sleepQuality: 4, weight: 70.2, soreness: 1, fatigue: 2, updated: "1998-01-05T09:00:00Z" });
+    expect(value).toMatchObject({ date_key: 19980105, resting_hr: 48, hrv: 71.5, hrv_sdnn: 40,
+      sleep_s: 28_800, sleep_score: 4, weight_kg: 70.2, soreness: 1, fatigue: 2,
+      provenance: "sync", source: "intervals-icu" });
+    expect(JSON.parse(value.fields_json)).toMatchObject({ source: "intervals-icu", values: { updated: "1998-01-05T09:00:00Z" } });
+    const run = vi.fn(async () => {});
+    const store: SqlStore = { exec: async () => {}, run,
+      get: async (sql): Promise<Row | undefined> => sql.includes("FROM wellness")
+        ? { id: "manual", date_key: 19980105, provenance: "manual", source: null } : undefined,
+      all: async () => [], close: async () => {} };
+    await expect(createIntervalsSourceRepository(store, hashKey).upsertWellness(value)).resolves.toBe("manual-wins");
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it("maps sport settings to synced anchors and zones while retaining unsupported pace fields source-only", async () => {
+    const raw = { id: 9, athlete_id: "synthetic-athlete", types: ["Run", "Ride"], updated: "1998-01-05T09:00:00Z",
+      ftp: 250, lthr: 170, max_hr: 190, power_zones: [100, 200], power_zone_names: ["low", "high"],
+      hr_zones: [120, 160], hr_zone_names: ["easy", "hard"], indoor_ftp: 240,
+      threshold_pace: 250, pace_units: "seconds", pace_zones: [300, 270] };
+    const value = await mapSettingsLanding(raw);
+    expect(value.externalId).toBe(canonicalJson([9, "synthetic-athlete", ["Run", "Ride"], "1998-01-05T09:00:00Z"]));
+    expect(value.anchors).toContainEqual(expect.objectContaining({ sport: "cycling", anchor_type: "ftp", value: 250,
+      unit: "W", source: "intervals-icu", provenance: "sync", confidence: "platform" }));
+    expect(value.anchors).not.toContainEqual(expect.objectContaining({ sport: "run", anchor_type: "ftp" }));
+    expect(value.zones).toContainEqual(expect.objectContaining({ sport: "cycling", stream: "power", anchor_ref: "ftp",
+      boundaries_json: canonicalJson({ boundaries: [100, 200], names: ["low", "high"] }) }));
+    expect(JSON.parse(value.normalizedPayloadJson)).toMatchObject({ indoor_ftp: 240, threshold_pace: 250,
+      pace_units: "seconds", pace_zones: [300, 270] });
+    expect(value.anchors.some((row) => row.anchor_type.includes("pace"))).toBe(false);
+    expect(value.zones.some((row) => row.stream === ("pace" as never))).toBe(false);
+  });
+
+  it("validates stream landing channels and equal lengths", () => {
+    expect(normalizeStreamLanding({ time: [0, 1], watts: [100, null], dfa_a1: [0.9, 0.8], ignored: [1] }))
+      .toEqual({ time: [0, 1], watts: [100, null], dfa_a1: [0.9, 0.8] });
+    expect(() => normalizeStreamLanding({ time: [0], watts: [100, 101] })).toThrow("lengths differ");
+    expect(() => normalizeStreamLanding({ time: [Number.NaN] })).toThrow("channel is invalid");
+  });
+});

--- a/packages/sync-intervals-icu/tests/source.test.ts
+++ b/packages/sync-intervals-icu/tests/source.test.ts
@@ -1,0 +1,113 @@
+import { createHash } from "node:crypto";
+import { describe, expect, it, vi } from "vitest";
+import { canonicalJson, type ArchiveManager } from "@enduragent/kernel/archive";
+import type { HttpPort, HttpResponse } from "@enduragent/kernel/ports";
+import type { SourceWatermark, SyncBudget } from "@enduragent/kernel/store";
+import { compactCursor, createIntervalsIcuSource, INTERVALS_ICU_CAPABILITIES } from "../src/index.js";
+
+const json = (value: unknown): HttpResponse => ({ status: 200, headers: { "content-type": "application/json; charset=utf-8" },
+  body: new TextEncoder().encode(JSON.stringify(value)) });
+const activity = (id: string, date = "1998-01-05") => ({ id, start_date: `${date}T07:00:00Z`, start_date_local: `${date}T08:00:00`,
+  type: "Ride", moving_time: 90, elapsed_time: 100, distance: 1_000 });
+
+function archive(log: string[] = []): ArchiveManager {
+  const values = new Map<string, unknown>();
+  return {
+    async writeSnapshot(value, when) { log.push(`archive:${Array.isArray(value) ? "page" : "row"}`);
+      const address = createHash("sha256").update(canonicalJson(value)).digest("hex"), relPath = `${when.epochSeconds}/${address}.json.gz`;
+      const deduped = values.has(relPath); values.set(relPath, structuredClone(value)); return { address, relPath, deduped }; },
+    async writeArtifact(bytes, ext, when) { const address = createHash("sha256").update(bytes).digest("hex");
+      return { address, relPath: `${when.epochSeconds}/${address}.${ext}`, deduped: false }; },
+    async readSnapshot(path) { return structuredClone(values.get(path)); }, async has(path) { return values.has(path); },
+    async readArtifact() { throw new Error("unused"); }, async quarantine() { throw new Error("unused"); },
+  };
+}
+
+function budget(maxArtifacts = 100, maxRequests = 100): SyncBudget {
+  return { signal: new AbortController().signal, clock: { monotonicNow: () => 0 }, deadlineMonotonicMs: 1_000_000,
+    perRequestTimeoutMs: 30_000, maxRequests, maxArtifacts };
+}
+
+function source(http: HttpPort, options: { oldest?: string; newest?: string; archive?: ArchiveManager; log?: string[] } = {}) {
+  const log = options.log ?? [];
+  return createIntervalsIcuSource({ athleteId: "synthetic-athlete", historyOldestDate: options.oldest ?? "1998-01-01",
+    historyNewestDate: options.newest ?? "1998-12-31", minRequestIntervalMs: 250,
+    httpFactory: () => http, archive: options.archive ?? archive(log), wallClock: { now: () => Date.UTC(1998, 0, 1) },
+    sleep: async () => {}, acl: {
+      activity(row) { log.push("acl:activity"); return row; }, wellness(row) { log.push("acl:wellness"); return row; },
+      streams(value) { log.push("acl:streams"); return Array.isArray(value)
+        ? Object.fromEntries(value.map((entry) => [(entry as { type: string }).type, (entry as { data: unknown }).data])) : value as Record<string, unknown>; },
+      assertClean() {},
+    } });
+}
+
+async function collect(iterable: AsyncIterable<unknown>): Promise<unknown[]> {
+  const result: unknown[] = []; for await (const value of iterable) result.push(value); return result;
+}
+const watermark = (lane: SourceWatermark["lane"], value: string | null = null): SourceWatermark => ({ source: "intervals-icu", lane, value });
+
+describe("intervals.icu full-history source", () => {
+  it("exposes exact capabilities", () => {
+    const value = source({ fetch: async () => json([]) });
+    expect(value.id).toBe("intervals-icu"); expect(value.capabilities).toEqual(INTERVALS_ICU_CAPABILITIES);
+  });
+
+  it("uses inclusive 365-date windows with no limit parameter", async () => {
+    const requests: string[] = [];
+    const value = source({ fetch: async (request) => { requests.push(request.url); return json([]); } },
+      { oldest: "1998-01-01", newest: "1999-12-31" });
+    const result = await collect(value.pull(watermark("activities"), budget()));
+    expect(requests).toHaveLength(1);
+    const url = new URL(requests[0]!);
+    expect([...url.searchParams]).toEqual([["oldest", "1998-01-01"], ["newest", "1998-12-31"]]);
+    expect(url.searchParams.has("limit")).toBe(false);
+    const cursor = JSON.parse((result.at(-1) as { watermark: { value: string } }).watermark.value);
+    expect(cursor).toMatchObject({ window_start: "1999-01-01", window_end: "1999-12-31", complete: false });
+  });
+
+  it("supports mid-page resume and terminal refresh cycle", async () => {
+    const http: HttpPort = { fetch: async () => json([activity("a"), activity("b", "1998-01-06")]) };
+    const value = source(http);
+    const first = await collect(value.pull(watermark("activities"), budget(1)));
+    expect((first[0] as { externalId: string }).externalId).toBe("a");
+    const firstCursor = (first[1] as { watermark: { value: string } }).watermark.value;
+    const resumed = await collect(value.pull(watermark("activities", firstCursor), budget(1)));
+    expect((resumed[0] as { externalId: string }).externalId).toBe("b");
+    const terminal = compactCursor({ v: 1, cycle: 3, window_start: "1998-01-01", window_end: "1998-12-31", last_key: null, complete: true });
+    const refreshed = await collect(value.pull(watermark("activities", terminal), budget(1)));
+    expect(JSON.parse((refreshed.at(-1) as { watermark: { value: string } }).watermark.value).cycle).toBe(4);
+  });
+
+  it("archives page and row before ACL and transport remains unchanged", async () => {
+    const log: string[] = [], raw = activity("archive-order");
+    const value = source({ fetch: async () => json([raw]) }, { log, archive: archive(log) });
+    const iterator = value.pull(watermark("activities"), budget())[Symbol.asyncIterator]();
+    const first = await iterator.next(); log.push("yield");
+    expect(log).toEqual(["archive:page", "archive:row", "acl:activity", "yield"]);
+    expect((first.value as { payload: unknown }).payload).toEqual(raw);
+    expect((first.value as { landing: { platform: { activity: unknown } } }).landing.platform.activity).not.toBe(raw);
+    await iterator.next();
+  });
+
+  it("attempts all activity streams with no live-bundle cap", async () => {
+    const activities = Array.from({ length: 13 }, (_, index) => activity(`s${String(index).padStart(2, "0")}`, `1998-01-${String(index + 1).padStart(2, "0")}`));
+    const requests: string[] = [];
+    const http: HttpPort = { fetch: async (request) => {
+      requests.push(request.url);
+      return request.url.includes("/activities?") ? json(activities) : json([{ type: "time", data: [0] }, { type: "watts", data: [100] }]);
+    } };
+    const result = await collect(source(http).pull(watermark("streams"), budget(20, 20)));
+    expect(result.filter((entry) => (entry as { kind: string }).kind === "snapshot")).toHaveLength(13);
+    expect(requests.filter((url) => url.includes("streams.json"))).toHaveLength(13);
+    const streamUrl = new URL(requests.find((url) => url.includes("streams.json"))!);
+    expect(streamUrl.searchParams.getAll("types")).toEqual(["time", "watts", "heartrate", "dfa_a1", "artifacts"]);
+    expect(streamUrl.searchParams.get("includeDefaults")).toBe("false");
+  });
+
+  it("checkpoints before another request or artifact would exceed the cap", async () => {
+    const fetch = vi.fn(async () => json([activity("one"), activity("two", "1998-01-06")]));
+    const result = await collect(source({ fetch }).pull(watermark("activities"), budget(1, 1)));
+    expect(result.map((entry) => (entry as { kind: string }).kind)).toEqual(["snapshot", "checkpoint"]);
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/sync-intervals-icu/tests/zip.test.ts
+++ b/packages/sync-intervals-icu/tests/zip.test.ts
@@ -1,0 +1,176 @@
+import { createHash } from "node:crypto";
+import { zipSync } from "fflate";
+import { describe, expect, it } from "vitest";
+import type { ArchiveManager } from "@enduragent/kernel/archive";
+import type { HttpPort, HttpResponse } from "@enduragent/kernel/ports";
+import { createIntervalsIcuSource, extractBulkFitZip, IncompleteBulkFitBatchError,
+  MAX_FIT_BYTES, MAX_UNCOMPRESSED_BATCH_BYTES, MAX_ZIP_BYTES } from "../src/index.js";
+
+const json = (value: unknown): HttpResponse => ({ status: 200, headers: { "content-type": "application/json" },
+  body: new TextEncoder().encode(JSON.stringify(value)) });
+const activities = (ids: readonly string[]) => ids.map((id, index) => ({ id, start_date: `1998-01-${String(index + 1).padStart(2, "0")}T07:00:00Z`,
+  start_date_local: `1998-01-${String(index + 1).padStart(2, "0")}T08:00:00`, type: "Ride", moving_time: 90, elapsed_time: 100 }));
+const fitBytes = (index: number) => new Uint8Array([14, index, 42]);
+const zipFor = (ids: readonly string[]) => zipSync(Object.fromEntries(ids.map((id, index) => [`${id}_synthetic.fit`, fitBytes(index)])));
+
+function rewriteZipFilename(bytes: Uint8Array, from: string, to: string): Uint8Array {
+  const before = new TextEncoder().encode(from), after = new TextEncoder().encode(to);
+  if (before.byteLength !== after.byteLength) throw new TypeError("replacement filenames must have equal lengths");
+  const output = bytes.slice();
+  let replacements = 0;
+  for (let offset = 0; offset <= output.byteLength - before.byteLength; offset += 1) {
+    if (before.every((value, index) => output[offset + index] === value)) {
+      output.set(after, offset);
+      replacements += 1;
+      offset += before.byteLength - 1;
+    }
+  }
+  if (replacements !== 2) throw new TypeError("ZIP filename records were not found");
+  return output;
+}
+
+function rewriteZipUncompressedSizes(bytes: Uint8Array, sizes: readonly number[]): Uint8Array {
+  const output = bytes.slice(), view = new DataView(output.buffer, output.byteOffset, output.byteLength);
+  let local = 0, central = 0;
+  for (let offset = 0; offset <= output.byteLength - 4;) {
+    const signature = view.getUint32(offset, true);
+    if (signature === 0x04034b50) {
+      view.setUint32(offset + 22, sizes[local++]!, true);
+      const compressedSize = view.getUint32(offset + 18, true);
+      offset += 30 + view.getUint16(offset + 26, true) + view.getUint16(offset + 28, true) + compressedSize;
+    } else if (signature === 0x02014b50) {
+      view.setUint32(offset + 24, sizes[central++]!, true);
+      offset += 46 + view.getUint16(offset + 28, true) + view.getUint16(offset + 30, true)
+        + view.getUint16(offset + 32, true);
+    } else {
+      offset += 1;
+    }
+  }
+  if (local !== sizes.length || central !== sizes.length) throw new TypeError("ZIP entry records were not found");
+  return output;
+}
+
+function archive(writes: string[] = []): ArchiveManager {
+  return {
+    async writeSnapshot(value, when) { const address = createHash("sha256").update(JSON.stringify(value)).digest("hex");
+      return { address, relPath: `${when.epochSeconds}/${address}.json.gz`, deduped: false }; },
+    async writeArtifact(bytes, ext, when) { writes.push(ext); const address = createHash("sha256").update(bytes).digest("hex");
+      return { address, relPath: `${when.epochSeconds}/${address}.${ext}`, deduped: false }; },
+    async has() { return true; }, async readArtifact() { throw new Error("unused"); }, async readSnapshot() { throw new Error("unused"); },
+    async quarantine() { throw new Error("unused"); },
+  };
+}
+
+function source(http: HttpPort, rawArchive = archive()) {
+  return createIntervalsIcuSource({ athleteId: "synthetic-athlete", historyOldestDate: "1998-01-01",
+    historyNewestDate: "1998-12-31", minRequestIntervalMs: 250, httpFactory: () => http, archive: rawArchive,
+    wallClock: { now: () => Date.UTC(1998, 0, 1) }, sleep: async () => {}, acl: {
+      activity: (row) => row, wellness: (row) => row, streams: (value) => value as Record<string, unknown>, assertClean() {},
+    } });
+}
+
+async function collect(value: ReturnType<typeof source>): Promise<unknown[]> {
+  const result: unknown[] = [];
+  for await (const artifact of value.pull({ source: "intervals-icu", lane: "bulk-fit", value: null }, {
+    signal: new AbortController().signal, clock: { monotonicNow: () => 0 }, deadlineMonotonicMs: 1_000_000,
+    perRequestTimeoutMs: 30_000, maxRequests: 20, maxArtifacts: 20 })) result.push(artifact);
+  return result;
+}
+
+describe("bulk FIT ZIP attribution", () => {
+  it.each([1, 3, 8])("batch %i preserves stable container and entry bytes", (count) => {
+    const ids = Array.from({ length: count }, (_, index) => `a${index}`), bytes = zipFor(ids);
+    expect(zipFor(ids)).toEqual(bytes);
+    const entries = extractBulkFitZip(bytes, ids);
+    expect(entries.map((entry) => entry.activityId)).toEqual(ids);
+    expect(entries.map((entry) => entry.bytes)).toEqual(ids.map((_, index) => fitBytes(index)));
+  });
+
+  it("sends repeated sorted ids and yields attributed entry bytes", async () => {
+    const ids = ["b", "a", "c"], requests: { method: string; url: string; body: unknown; headers: unknown }[] = [];
+    const http: HttpPort = { fetch: async (request) => {
+      requests.push({ method: request.method, url: request.url, body: request.body, headers: request.headers });
+      return request.url.includes("/activities?") ? json(activities(ids))
+        : { status: 200, headers: { "content-type": "application/zip; charset=binary" }, body: zipFor([...ids].sort()) };
+    } };
+    const result = await collect(source(http));
+    const bulk = requests.find((request) => request.method === "POST")!;
+    const url = new URL(bulk.url);
+    expect(url.searchParams.get("power")).toBe("true"); expect(url.searchParams.get("hr")).toBe("true");
+    expect(url.searchParams.getAll("ids")).toEqual(["a", "b", "c"]);
+    expect(bulk.body).toBeUndefined(); expect(bulk.headers).toBeUndefined();
+    expect(result.filter((entry) => (entry as { kind: string }).kind === "raw-file")).toHaveLength(3);
+  });
+
+  it("fallback byte-identical response is archived and yielded without a container", async () => {
+    const exact = fitBytes(7);
+    const http: HttpPort = { fetch: async (request) => request.url.includes("/activities?") ? json(activities(["fallback-a"]))
+      : request.method === "POST" ? { status: 404, headers: {}, body: new Uint8Array() }
+        : { status: 200, headers: { "content-type": "application/octet-stream" }, body: exact } };
+    const result = await collect(source(http));
+    const artifact = result.find((entry) => (entry as { kind: string }).kind === "raw-file") as {
+      file: { bytes: Uint8Array }; container: unknown; externalId: string;
+    };
+    expect(artifact.externalId).toBe("fallback-a"); expect(artifact.file.bytes).toEqual(exact); expect(artifact.container).toBeNull();
+  });
+
+  it("silent omission set-diffs before any raw-file or checkpoint yield", async () => {
+    const writes: string[] = [], ids = ["a", "b"], yielded: unknown[] = [];
+    const http: HttpPort = { fetch: async (request) => request.url.includes("/activities?") ? json(activities(ids))
+      : { status: 200, headers: { "content-type": "application/zip" }, body: zipFor(["a"]) } };
+    const iterator = source(http, archive(writes)).pull({ source: "intervals-icu", lane: "bulk-fit", value: null }, {
+      signal: new AbortController().signal, clock: { monotonicNow: () => 0 }, deadlineMonotonicMs: 1_000_000,
+      perRequestTimeoutMs: 30_000, maxRequests: 20, maxArtifacts: 20 });
+    let caught: unknown;
+    try { for await (const value of iterator) yielded.push(value); } catch (error) { caught = error; }
+    expect(caught).toBeInstanceOf(IncompleteBulkFitBatchError);
+    expect(caught).toMatchObject({ requested: ["a", "b"], returned: ["a"], missing: ["b"], unexpected: [] });
+    expect(yielded).toEqual([]); expect(writes).toEqual(["zip"]);
+  });
+
+  it("unexpected entry reports exact sorted sets", () => {
+    expect(() => extractBulkFitZip(zipFor(["a", "x"]), ["a", "b"]))
+      .toThrow(expect.objectContaining({ requested: ["a", "b"], returned: ["a", "x"], missing: ["b"], unexpected: ["x"] }));
+  });
+
+  it("rejects empty and oversized compressed bodies before extraction", () => {
+    expect(() => extractBulkFitZip(new Uint8Array(), ["a"])).toThrow("size");
+    const oversized = new Uint8Array(MAX_ZIP_BYTES + 1);
+    oversized.set(zipFor(["a"]));
+    expect(() => extractBulkFitZip(oversized, ["a"])).toThrow("size");
+  });
+
+  it.each([
+    ["directory entry", "folder/"],
+    ["nested path", "nested/a_one.fit"],
+    ["backslash path", "nested\\a_one.fit"],
+  ])("rejects a %s", (_label, filename) => {
+    expect(() => extractBulkFitZip(zipSync({ [filename]: fitBytes(1) }), ["a"])).toThrow("path");
+  });
+
+  it("rejects duplicate filenames and duplicate activity prefixes", () => {
+    const duplicateFilename = rewriteZipFilename(zipSync({ "a_one.fit": fitBytes(1), "b_two.fit": fitBytes(2) }),
+      "b_two.fit", "a_one.fit");
+    expect(() => extractBulkFitZip(duplicateFilename, ["a", "b"])).toThrow("filename is duplicated");
+    expect(() => extractBulkFitZip(zipSync({ "a_one.fit": fitBytes(1), "a_two.fit": fitBytes(2) }), ["a"])).toThrow("prefix");
+  });
+
+  it("rejects more than eight file entries", () => {
+    const nine = Array.from({ length: 9 }, (_, index) => `a${index}`);
+    expect(() => extractBulkFitZip(zipFor(nine), nine.slice(0, 8))).toThrow("too many entries");
+  });
+
+  it("rejects empty and oversized entries", () => {
+    expect(() => extractBulkFitZip(zipSync({ "a_empty.fit": new Uint8Array() }), ["a"])).toThrow("entry is empty");
+    const oversized = rewriteZipUncompressedSizes(zipFor(["a"]), [MAX_FIT_BYTES + 1]);
+    expect(() => extractBulkFitZip(oversized, ["a"])).toThrow("entry is too large");
+  });
+
+  it("rejects declared expanded totals over the batch limit", () => {
+    const ids = ["a", "b", "c", "d", "e"];
+    const entrySize = Math.floor(MAX_UNCOMPRESSED_BATCH_BYTES / 4);
+    expect(entrySize).toBeLessThanOrEqual(MAX_FIT_BYTES);
+    const expandedOverflow = rewriteZipUncompressedSizes(zipFor(ids), ids.map(() => entrySize));
+    expect(() => extractBulkFitZip(expandedOverflow, ids)).toThrow("batch is too large");
+  });
+});

--- a/packages/sync-intervals-icu/tsconfig.json
+++ b/packages/sync-intervals-icu/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022", "DOM"],
+    "types": [],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "ignoreDeprecations": "6.0"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/sync-intervals-icu/tsup.config.ts
+++ b/packages/sync-intervals-icu/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "tsup";
+export default defineConfig({
+  entry: { index: "src/index.ts" },
+  format: ["esm"],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  splitting: false,
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -303,6 +303,25 @@ importers:
         specifier: ^4.1.4
         version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.8(vitest@4.1.5))(msw@2.14.2(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))
 
+  packages/sync-intervals-icu:
+    dependencies:
+      '@enduragent/kernel':
+        specifier: workspace:*
+        version: link:../kernel
+      fflate:
+        specifier: 0.8.3
+        version: 0.8.3
+    devDependencies:
+      tsup:
+        specifier: ^8.4.0
+        version: 8.5.1(postcss@8.5.12)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.3)
+      typescript:
+        specifier: ^6.0.2
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.4
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.8(vitest@4.1.5))(msw@2.14.2(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))
+
   packages/running-coach:
     dependencies:
       '@enduragent/core':

--- a/tools/check-package-deps.test.ts
+++ b/tools/check-package-deps.test.ts
@@ -342,7 +342,7 @@ describe("real repository", () => {
   it("marks the absent end-state rows not-present (discovery is not vacuous)", () => {
     const result = runRulesAgainst(".", RULES);
     expect(result.notPresent).toContain("packages/engine");
-    expect(result.notPresent).toContain("packages/sync-*");
+    expect(result.notPresent).not.toContain("packages/sync-*");
     expect(result.scannedFileCount).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Summary

Adds the Reference layer intervals.icu archive source (W3 PR-03):

- New `packages/sync-intervals-icu` plugin implementing the sync-source contract: archive-first activity/stream/wellness/sport-settings landing, ZIP handling with deterministic set-diff, cursor management, credentialed HTTP against the raw client factory
- Kernel store extensions: source repository revision/current-selection support, source-ledger evidence + revision metadata, dedup current-selection/global-recompute path, import-report count type
- Raw credentialed client factory export in core; new revision-refresh and ACL-integration test coverage

During verification the full suite caught one regression from the dedup changes (selected-revision rows carried extra artifact metadata into the platform replay path, tripping the equality guard on unchanged rows); fixed by projecting selected rows back to the exact `SourceRecordRow` shape before replay — the conflict guard itself is unchanged and fully enforced.

## Verification

- Full non-watch suite: 3,719 passed / 5 skipped (exit 0, Node 24), including the previously-regressed ingest-order file at 8/8
- Changed files within the spec's allowlist; single squash-ready commit; changeset included (patch, internal infrastructure)
