### PR TITLE
feat(sync-file-import): add stable file source

### DIFF
--- a/.changeset/file-import-source.md
+++ b/.changeset/file-import-source.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/sync-file-import": patch
+---
+
+Add stable manual-path and watch-folder intake for the Reference layer. Internal infrastructure; ships nothing to athletes.

--- a/packages/sync-file-import/package.json
+++ b/packages/sync-file-import/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@enduragent/sync-file-import",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Private stable file source for the Reference layer.",
+  "type": "module",
+  "files": ["dist"],
+  "exports": {
+    ".": "./dist/index.js",
+    "./manual": "./dist/manual.js",
+    "./watcher": "./dist/watcher.js"
+  },
+  "engines": {
+    "node": ">=24"
+  },
+  "scripts": {
+    "build": "tsup",
+    "check": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@enduragent/kernel": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.0",
+    "tsup": "^8.4.0",
+    "typescript": "^6.0.2",
+    "vitest": "^4.1.4"
+  },
+  "license": "MIT"
+}

--- a/packages/sync-file-import/src/index.ts
+++ b/packages/sync-file-import/src/index.ts
@@ -1,0 +1,638 @@
+import { extname, join } from "node:path";
+import type { ArchiveManager } from "@enduragent/kernel/archive";
+import type { Clock } from "@enduragent/kernel/concurrency";
+import type { CryptoPort, FileSystemPort } from "@enduragent/kernel/ports";
+import type {
+  SourceArtifact,
+  SourceCheckpoint,
+  SourceWatermark,
+  SyncBudget,
+  SyncSource,
+} from "@enduragent/kernel/store";
+
+export const FILE_IMPORT_POLL_INTERVAL_MS = 250 as const;
+export const FILE_IMPORT_IDENTITY_STABILITY_MS = 500 as const;
+export const FILE_IMPORT_QUIESCE_MS = 500 as const;
+export const FILE_IMPORT_REVALIDATION_POLLS = 8 as const;
+
+export type FileImportExtension = "fit" | "tcx" | "gpx";
+export type RawFileSourceArtifact = Extract<SourceArtifact, { readonly kind: "raw-file" }>;
+
+export interface FileStructuralValidationInput {
+  readonly bytes: Uint8Array;
+  readonly ext: FileImportExtension;
+}
+
+export type FileStructuralValidator = (input: FileStructuralValidationInput) => Promise<void>;
+
+export interface FileImportPorts {
+  readonly fs: Pick<FileSystemPort, "list" | "stat" | "readFile">;
+  readonly clock: Pick<Clock, "setTimeout" | "clearTimeout">;
+  readonly crypto: Pick<CryptoPort, "sha256">;
+  readonly archive: Pick<ArchiveManager, "writeArtifact">;
+  readonly validate: FileStructuralValidator;
+}
+
+export interface FileImportSourceConfig {
+  readonly manualPaths: readonly string[];
+  readonly watchRoots: readonly string[];
+}
+
+export type FileImportBatchEvent =
+  | { readonly kind: "batch"; readonly artifacts: readonly RawFileSourceArtifact[] }
+  | SourceCheckpoint;
+
+export interface FileImportSource extends SyncSource {
+  readonly id: "file-import";
+  pullBatches(watermark: SourceWatermark, budget: SyncBudget): AsyncIterable<FileImportBatchEvent>;
+}
+
+export interface CollectReadyBatchOptions {
+  readonly paths: readonly string[];
+  readonly watermark: SourceWatermark;
+  readonly budget: SyncBudget;
+}
+
+export interface CollectedReadyBatch {
+  readonly artifacts: readonly RawFileSourceArtifact[];
+  readonly checkpoint: SourceCheckpoint;
+}
+
+interface FileIdentity {
+  readonly kind: "file";
+  readonly size: number;
+  readonly mtimeMs: number;
+}
+
+interface Candidate {
+  readonly path: string;
+  readonly ext: FileImportExtension;
+  readonly identity: FileIdentity;
+}
+
+interface StagedCandidate extends Candidate {
+  readonly bytes: Uint8Array;
+  readonly digest: string;
+  readonly archiveInstant: { readonly epochSeconds: number };
+}
+
+interface DeliveredMarker {
+  readonly identity: FileIdentity;
+  readonly digest: string;
+  readonly unchangedPollsSinceValidation: number;
+}
+
+interface ProposalSuccess {
+  readonly kind: "success";
+  readonly artifacts: readonly RawFileSourceArtifact[];
+  readonly lastDigest: string | null;
+  readonly staged: readonly StagedCandidate[];
+}
+
+type ProposalResult = ProposalSuccess | { readonly kind: "retry" } | { readonly kind: "inactive" };
+type ScanResult =
+  | { readonly kind: "ready"; readonly candidates: readonly Candidate[] }
+  | { readonly kind: "unavailable" }
+  | { readonly kind: "inactive" };
+
+const STABLE_POLLS_REQUIRED = FILE_IMPORT_IDENTITY_STABILITY_MS / FILE_IMPORT_POLL_INTERVAL_MS;
+const QUIESCENT_POLLS_REQUIRED = FILE_IMPORT_QUIESCE_MS / FILE_IMPORT_POLL_INTERVAL_MS;
+
+if (
+  !Number.isSafeInteger(STABLE_POLLS_REQUIRED) ||
+  STABLE_POLLS_REQUIRED <= 0 ||
+  !Number.isSafeInteger(QUIESCENT_POLLS_REQUIRED) ||
+  QUIESCENT_POLLS_REQUIRED <= 0 ||
+  !Number.isSafeInteger(FILE_IMPORT_REVALIDATION_POLLS) ||
+  FILE_IMPORT_REVALIDATION_POLLS <= 0
+) {
+  throw new Error("file import timing invariant");
+}
+
+const EXTENSIONS = new Set<FileImportExtension>(["fit", "tcx", "gpx"]);
+const CAPABILITIES = Object.freeze({
+  activities: false,
+  streams: false,
+  rawFiles: true,
+  wellness: false,
+  plannedWorkoutPush: false,
+  backfillDepth: Object.freeze({ kind: "none" as const }),
+});
+
+function extension(path: string): FileImportExtension | null {
+  const value = extname(path).slice(1).toLowerCase();
+  return EXTENSIONS.has(value as FileImportExtension) ? (value as FileImportExtension) : null;
+}
+
+function validIdentity(value: unknown): value is FileIdentity {
+  if (value === null || typeof value !== "object") return false;
+  const stat = value as { kind?: unknown; size?: unknown; mtimeMs?: unknown };
+  return (
+    stat.kind === "file" &&
+    typeof stat.size === "number" &&
+    Number.isSafeInteger(stat.size) &&
+    stat.size >= 0 &&
+    typeof stat.mtimeMs === "number" &&
+    Number.isFinite(stat.mtimeMs) &&
+    stat.mtimeMs >= 0
+  );
+}
+
+function sameIdentity(left: FileIdentity, right: FileIdentity): boolean {
+  return left.size === right.size && left.mtimeMs === right.mtimeMs;
+}
+
+function sameVector(left: readonly Candidate[], right: readonly Candidate[]): boolean {
+  return (
+    left.length === right.length &&
+    left.every(
+      (candidate, index) =>
+        candidate.path === right[index]?.path &&
+        sameIdentity(candidate.identity, right[index].identity),
+    )
+  );
+}
+
+function active(budget: SyncBudget): boolean {
+  return !budget.signal.aborted && budget.clock.monotonicNow() < budget.deadlineMonotonicMs;
+}
+
+function validateConfiguration(config: FileImportSourceConfig): void {
+  const manualPaths = config?.manualPaths;
+  const watchRoots = config?.watchRoots;
+  const validArray = (value: unknown): value is readonly string[] =>
+    Array.isArray(value) && value.every((item) => typeof item === "string" && item.length > 0);
+  if (
+    !validArray(manualPaths) ||
+    !validArray(watchRoots) ||
+    new Set(manualPaths).size !== manualPaths.length ||
+    new Set(watchRoots).size !== watchRoots.length ||
+    manualPaths.length + watchRoots.length === 0 ||
+    manualPaths.some((path) => extension(path) === null)
+  ) {
+    throw new TypeError("invalid file import configuration");
+  }
+}
+
+function validatePull(watermark: SourceWatermark, budget: SyncBudget): void {
+  if (
+    watermark?.source !== "file-import" ||
+    watermark.lane !== "file-discovery" ||
+    !(watermark.value === null || /^sha256:[0-9a-f]{64}$/.test(watermark.value))
+  ) {
+    throw new TypeError("invalid file import watermark");
+  }
+  const positiveSafeInteger = (value: unknown): value is number =>
+    typeof value === "number" && Number.isSafeInteger(value) && value > 0;
+  if (
+    !(budget?.signal instanceof AbortSignal) ||
+    typeof budget.clock?.monotonicNow !== "function" ||
+    !Number.isFinite(budget.deadlineMonotonicMs) ||
+    budget.deadlineMonotonicMs < 0 ||
+    !positiveSafeInteger(budget.perRequestTimeoutMs) ||
+    !positiveSafeInteger(budget.maxRequests) ||
+    !positiveSafeInteger(budget.maxArtifacts)
+  ) {
+    throw new TypeError("invalid file import budget");
+  }
+}
+
+async function waitForPoll(ports: FileImportPorts, budget: SyncBudget): Promise<boolean> {
+  if (!active(budget)) return false;
+  return new Promise<boolean>((resolve) => {
+    let settled = false;
+    let handle: unknown;
+    const finish = (result: boolean, clear: boolean): void => {
+      if (settled) return;
+      settled = true;
+      budget.signal.removeEventListener("abort", onAbort);
+      if (clear) ports.clock.clearTimeout(handle);
+      resolve(result);
+    };
+    const onAbort = (): void => finish(false, true);
+    handle = ports.clock.setTimeout(() => finish(true, false), FILE_IMPORT_POLL_INTERVAL_MS);
+    budget.signal.addEventListener("abort", onAbort, { once: true });
+    if (budget.signal.aborted) onAbort();
+  });
+}
+
+async function scanManual(
+  paths: readonly string[],
+  ports: FileImportPorts,
+  budget: SyncBudget,
+): Promise<ScanResult> {
+  const candidates: Candidate[] = [];
+  for (const path of paths) {
+    if (!active(budget)) return { kind: "inactive" };
+    let stat: Awaited<ReturnType<FileImportPorts["fs"]["stat"]>>;
+    try {
+      stat = await ports.fs.stat(path);
+    } catch {
+      return { kind: "unavailable" };
+    }
+    if (!validIdentity(stat)) return { kind: "unavailable" };
+    candidates.push({ path, ext: extension(path)!, identity: stat });
+  }
+  return { kind: "ready", candidates };
+}
+
+async function scanWatch(
+  roots: readonly string[],
+  ports: FileImportPorts,
+  budget: SyncBudget,
+): Promise<ScanResult> {
+  const paths = new Map<string, FileImportExtension>();
+  let unavailable = false;
+  for (const root of roots) {
+    if (!active(budget)) return { kind: "inactive" };
+    try {
+      const entries = await ports.fs.list(root);
+      for (const entry of entries) {
+        const ext = entry.kind === "file" ? extension(entry.name) : null;
+        if (ext !== null) paths.set(join(root, entry.name), ext);
+      }
+    } catch {
+      unavailable = true;
+    }
+  }
+  if (unavailable) return { kind: "unavailable" };
+  const candidates: Candidate[] = [];
+  const sortedPaths = [...paths.keys()].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+  for (const path of sortedPaths) {
+    if (!active(budget)) return { kind: "inactive" };
+    let stat: Awaited<ReturnType<FileImportPorts["fs"]["stat"]>>;
+    try {
+      stat = await ports.fs.stat(path);
+    } catch {
+      return { kind: "unavailable" };
+    }
+    if (!validIdentity(stat)) return { kind: "unavailable" };
+    candidates.push({ path, ext: paths.get(path)!, identity: stat });
+  }
+  return { kind: "ready", candidates };
+}
+
+function hexDigest(bytes: Uint8Array): string {
+  if (bytes.length !== 32) throw new Error("invalid SHA-256 digest");
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+async function processProposal(
+  candidates: readonly Candidate[],
+  expectedVector: readonly Candidate[],
+  scanVector: () => Promise<ScanResult>,
+  lastDigest: string | null,
+  deliveredMarkers: ReadonlyMap<string, DeliveredMarker> | null,
+  artifactsYielded: number,
+  ports: FileImportPorts,
+  budget: SyncBudget,
+): Promise<ProposalResult> {
+  const staged: StagedCandidate[] = [];
+  for (const candidate of candidates) {
+    if (!active(budget)) return { kind: "inactive" };
+    let pre: Awaited<ReturnType<FileImportPorts["fs"]["stat"]>>;
+    try {
+      pre = await ports.fs.stat(candidate.path);
+    } catch {
+      return { kind: "retry" };
+    }
+    if (!validIdentity(pre) || !sameIdentity(pre, candidate.identity)) return { kind: "retry" };
+    if (!active(budget)) return { kind: "inactive" };
+    let bytes: Uint8Array;
+    try {
+      bytes = new Uint8Array(await ports.fs.readFile(candidate.path));
+    } catch {
+      return { kind: "retry" };
+    }
+    if (!active(budget)) return { kind: "inactive" };
+    let post: Awaited<ReturnType<FileImportPorts["fs"]["stat"]>>;
+    try {
+      post = await ports.fs.stat(candidate.path);
+    } catch {
+      return { kind: "retry" };
+    }
+    if (
+      !validIdentity(post) ||
+      !sameIdentity(post, pre) ||
+      !sameIdentity(post, candidate.identity)
+    ) {
+      return { kind: "retry" };
+    }
+    if (!active(budget)) return { kind: "inactive" };
+    try {
+      await ports.validate({ bytes: bytes.slice(), ext: candidate.ext });
+    } catch {
+      return { kind: "retry" };
+    }
+    if (!active(budget)) return { kind: "inactive" };
+    const digest = hexDigest(await ports.crypto.sha256(bytes));
+    staged.push({
+      ...candidate,
+      bytes,
+      digest,
+      archiveInstant: Object.freeze({ epochSeconds: Math.floor(post.mtimeMs / 1000) }),
+    });
+  }
+
+  if (!active(budget)) return { kind: "inactive" };
+  const beforeArchive = await scanVector();
+  if (beforeArchive.kind === "inactive") return beforeArchive;
+  if (
+    beforeArchive.kind === "unavailable" ||
+    !sameVector(beforeArchive.candidates, expectedVector)
+  ) {
+    return { kind: "retry" };
+  }
+
+  let provisionalLastDigest = lastDigest;
+  const kept: StagedCandidate[] = [];
+  for (const candidate of staged) {
+    if (
+      candidate.digest !== provisionalLastDigest &&
+      candidate.digest !== deliveredMarkers?.get(candidate.path)?.digest
+    ) {
+      kept.push(candidate);
+    }
+    provisionalLastDigest = candidate.digest;
+  }
+  if (kept.length > budget.maxArtifacts - artifactsYielded) {
+    throw new RangeError("file import burst exceeds artifact budget");
+  }
+
+  const artifacts: RawFileSourceArtifact[] = [];
+  for (const candidate of kept) {
+    if (!active(budget)) return { kind: "inactive" };
+    let archive: Awaited<ReturnType<FileImportPorts["archive"]["writeArtifact"]>>;
+    try {
+      archive = await ports.archive.writeArtifact(
+        candidate.bytes,
+        candidate.ext,
+        candidate.archiveInstant,
+      );
+    } catch {
+      if (!active(budget)) return { kind: "inactive" };
+      throw new Error("file archive failed");
+    }
+    if (
+      archive.address !== candidate.digest ||
+      typeof archive.relPath !== "string" ||
+      archive.relPath.length === 0 ||
+      typeof archive.deduped !== "boolean"
+    ) {
+      throw new Error("file archive result mismatch");
+    }
+    Object.freeze(archive);
+    const file = Object.freeze({
+      input_path: candidate.path,
+      bytes: candidate.bytes.slice(),
+      ext: candidate.ext,
+    });
+    artifacts.push(
+      Object.freeze({
+        kind: "raw-file" as const,
+        source: "file-import" as const,
+        lane: "file-discovery" as const,
+        externalId: null,
+        archiveInstant: candidate.archiveInstant,
+        archive,
+        file,
+      }),
+    );
+  }
+
+  if (!active(budget)) return { kind: "inactive" };
+  const afterArchive = await scanVector();
+  if (afterArchive.kind === "inactive") return afterArchive;
+  if (afterArchive.kind === "unavailable" || !sameVector(afterArchive.candidates, expectedVector)) {
+    return { kind: "retry" };
+  }
+  return {
+    kind: "success",
+    artifacts: Object.freeze(artifacts),
+    lastDigest: provisionalLastDigest,
+    staged: Object.freeze(staged),
+  };
+}
+
+function checkpoint(lastDigest: string | null, input: SourceWatermark): SourceCheckpoint {
+  return Object.freeze({
+    kind: "checkpoint" as const,
+    watermark: Object.freeze({
+      source: "file-import" as const,
+      lane: "file-discovery" as const,
+      value: lastDigest === null ? input.value : `sha256:${lastDigest}`,
+    }),
+  });
+}
+
+function cloneMarkers(markers: ReadonlyMap<string, DeliveredMarker>): Map<string, DeliveredMarker> {
+  return new Map(
+    [...markers].map(([path, marker]) => [path, { ...marker, identity: { ...marker.identity } }]),
+  );
+}
+
+export function createFileImportSource(
+  config: FileImportSourceConfig,
+  ports: FileImportPorts,
+): FileImportSource {
+  validateConfiguration(config);
+  const manualPaths = [...config.manualPaths];
+  const watchRoots = [...config.watchRoots];
+  let committedMarkers = new Map<string, DeliveredMarker>();
+
+  async function* pullBatches(
+    watermark: SourceWatermark,
+    budget: SyncBudget,
+  ): AsyncGenerator<FileImportBatchEvent> {
+    validatePull(watermark, budget);
+    if (!active(budget)) return;
+    let tentativeLastDigest =
+      watermark.value === null ? null : watermark.value.slice("sha256:".length);
+    const tentativeMarkers = cloneMarkers(committedMarkers);
+    let artifactsYielded = 0;
+
+    if (manualPaths.length > 0) {
+      let observed: readonly Candidate[] | null = null;
+      let unchangedPolls = 0;
+      while (true) {
+        const scan = await scanManual(manualPaths, ports, budget);
+        if (scan.kind === "inactive") return;
+        if (scan.kind === "unavailable") {
+          observed = null;
+          unchangedPolls = 0;
+        } else if (observed !== null && sameVector(observed, scan.candidates)) {
+          unchangedPolls += 1;
+          if (unchangedPolls >= STABLE_POLLS_REQUIRED) {
+            const proposal = await processProposal(
+              scan.candidates,
+              scan.candidates,
+              () => scanManual(manualPaths, ports, budget),
+              tentativeLastDigest,
+              null,
+              artifactsYielded,
+              ports,
+              budget,
+            );
+            if (proposal.kind === "inactive") return;
+            if (proposal.kind === "retry") {
+              observed = null;
+              unchangedPolls = 0;
+            } else {
+              if (proposal.artifacts.length > 0) {
+                if (!active(budget)) return;
+                yield Object.freeze({ kind: "batch" as const, artifacts: proposal.artifacts });
+                if (!active(budget)) return;
+                artifactsYielded += proposal.artifacts.length;
+              }
+              tentativeLastDigest = proposal.lastDigest;
+              break;
+            }
+          }
+        } else {
+          observed = scan.candidates;
+          unchangedPolls = 0;
+        }
+        if (!(await waitForPoll(ports, budget))) return;
+      }
+    }
+
+    if (watchRoots.length > 0) {
+      let observed: readonly Candidate[] | null = null;
+      let unchangedPolls = 0;
+      while (true) {
+        const scan = await scanWatch(watchRoots, ports, budget);
+        if (scan.kind === "inactive") return;
+        if (scan.kind === "unavailable") {
+          observed = null;
+          unchangedPolls = 0;
+          for (const [path, marker] of tentativeMarkers) {
+            tentativeMarkers.set(path, { ...marker, unchangedPollsSinceValidation: 0 });
+          }
+        } else {
+          const present = new Set(scan.candidates.map((candidate) => candidate.path));
+          for (const path of tentativeMarkers.keys()) {
+            if (!present.has(path)) tentativeMarkers.delete(path);
+          }
+          for (const candidate of scan.candidates) {
+            const marker = tentativeMarkers.get(candidate.path);
+            if (marker === undefined) continue;
+            if (!sameIdentity(marker.identity, candidate.identity)) {
+              tentativeMarkers.delete(candidate.path);
+            } else {
+              const previous = observed?.find((item) => item.path === candidate.path);
+              tentativeMarkers.set(candidate.path, {
+                ...marker,
+                unchangedPollsSinceValidation:
+                  previous !== undefined && sameIdentity(previous.identity, candidate.identity)
+                    ? marker.unchangedPollsSinceValidation + 1
+                    : marker.unchangedPollsSinceValidation,
+              });
+            }
+          }
+
+          if (observed !== null && sameVector(observed, scan.candidates)) {
+            unchangedPolls += 1;
+          } else {
+            observed = scan.candidates;
+            unchangedPolls = 0;
+          }
+
+          if (unchangedPolls >= Math.max(STABLE_POLLS_REQUIRED, QUIESCENT_POLLS_REQUIRED)) {
+            const candidates = scan.candidates.filter((candidate) => {
+              const marker = tentativeMarkers.get(candidate.path);
+              return (
+                marker === undefined ||
+                marker.unchangedPollsSinceValidation >= FILE_IMPORT_REVALIDATION_POLLS
+              );
+            });
+            if (candidates.length > 0 || scan.candidates.length === 0) {
+              const proposal = await processProposal(
+                candidates,
+                scan.candidates,
+                () => scanWatch(watchRoots, ports, budget),
+                tentativeLastDigest,
+                tentativeMarkers,
+                artifactsYielded,
+                ports,
+                budget,
+              );
+              if (proposal.kind === "inactive") return;
+              if (proposal.kind === "retry") {
+                observed = null;
+                unchangedPolls = 0;
+              } else {
+                const nextMarkers = cloneMarkers(tentativeMarkers);
+                for (const candidate of proposal.staged) {
+                  nextMarkers.set(candidate.path, {
+                    identity: candidate.identity,
+                    digest: candidate.digest,
+                    unchangedPollsSinceValidation: 0,
+                  });
+                }
+                if (proposal.artifacts.length > 0) {
+                  if (!active(budget)) return;
+                  yield Object.freeze({ kind: "batch" as const, artifacts: proposal.artifacts });
+                  if (!active(budget)) return;
+                  artifactsYielded += proposal.artifacts.length;
+                }
+                tentativeLastDigest = proposal.lastDigest;
+                tentativeMarkers.clear();
+                for (const [path, marker] of nextMarkers) tentativeMarkers.set(path, marker);
+                break;
+              }
+            }
+          }
+        }
+        if (!(await waitForPoll(ports, budget))) return;
+      }
+    }
+
+    if (!active(budget)) return;
+    yield checkpoint(tentativeLastDigest, watermark);
+    if (!active(budget)) return;
+    committedMarkers = cloneMarkers(tentativeMarkers);
+  }
+
+  const source: FileImportSource = {
+    id: "file-import",
+    capabilities: CAPABILITIES,
+    pullBatches,
+    async *pull(watermark, budget) {
+      for await (const event of pullBatches(watermark, budget)) {
+        if (event.kind === "batch") {
+          for (const artifact of event.artifacts) {
+            if (!active(budget)) return;
+            yield artifact;
+          }
+        } else {
+          if (!active(budget)) return;
+          yield event;
+        }
+      }
+    },
+  };
+  return Object.freeze(source);
+}
+
+export function createFolderWatcher(
+  watchRoots: readonly string[],
+  ports: FileImportPorts,
+): FileImportSource {
+  return createFileImportSource({ manualPaths: [], watchRoots }, ports);
+}
+
+export async function collectReadyBatch(
+  options: CollectReadyBatchOptions,
+  ports: FileImportPorts,
+): Promise<CollectedReadyBatch | null> {
+  const source = createFileImportSource({ manualPaths: options.paths, watchRoots: [] }, ports);
+  const artifacts: RawFileSourceArtifact[] = [];
+  let terminal: SourceCheckpoint | null = null;
+  for await (const event of source.pullBatches(options.watermark, options.budget)) {
+    if (event.kind === "batch") artifacts.push(...event.artifacts);
+    else terminal = event;
+  }
+  return terminal === null
+    ? null
+    : Object.freeze({ artifacts: Object.freeze(artifacts), checkpoint: terminal });
+}

--- a/packages/sync-file-import/src/manual.ts
+++ b/packages/sync-file-import/src/manual.ts
@@ -1,0 +1,6 @@
+export { collectReadyBatch } from "./index.js";
+export type {
+  CollectedReadyBatch,
+  CollectReadyBatchOptions,
+  FileImportPorts,
+} from "./index.js";

--- a/packages/sync-file-import/src/watcher.ts
+++ b/packages/sync-file-import/src/watcher.ts
@@ -1,0 +1,5 @@
+export { createFolderWatcher } from "./index.js";
+export type {
+  FileImportPorts,
+  FileImportSource,
+} from "./index.js";

--- a/packages/sync-file-import/tests/file-import.test.ts
+++ b/packages/sync-file-import/tests/file-import.test.ts
@@ -1,0 +1,730 @@
+import { basename, dirname } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import type { ArchiveWriteResult } from "@enduragent/kernel/archive";
+import type { FileStat } from "@enduragent/kernel/ports";
+import type { SourceWatermark, SyncBudget } from "@enduragent/kernel/store";
+import {
+  collectReadyBatch,
+  createFileImportSource,
+  createFolderWatcher,
+  FILE_IMPORT_POLL_INTERVAL_MS,
+  type FileImportBatchEvent,
+  type FileImportPorts,
+} from "../src/index.js";
+import { collectReadyBatch as collectFromManual } from "../src/manual.js";
+import { createFolderWatcher as createFromWatcher } from "../src/watcher.js";
+
+const ROOT = "/synthetic/inbox";
+const ROOT_B = "/synthetic/second";
+const MTIME = 946_684_800_000;
+
+type FileImportBatch = Extract<FileImportBatchEvent, { readonly kind: "batch" }>;
+
+interface FakeFile {
+  bytes: Uint8Array;
+  size: number;
+  mtimeMs: number;
+}
+
+class FakeFileSystem {
+  readonly files = new Map<string, FakeFile>();
+  readonly extras = new Map<string, { name: string; kind: "file" | "directory" | "other" }[]>();
+  readonly statCounts = new Map<string, number>();
+  readonly readCounts = new Map<string, number>();
+  readonly listCounts = new Map<string, number>();
+  statHook?: (path: string, call: number) => FileStat | "missing" | "throw" | null;
+  readHook?: (path: string, call: number) => Uint8Array | "throw" | null;
+  listHook?: (root: string, call: number) => "throw" | null;
+
+  put(
+    path: string,
+    bytes: readonly number[],
+    options: { size?: number; mtimeMs?: number } = {},
+  ): void {
+    this.files.set(path, {
+      bytes: Uint8Array.from(bytes),
+      size: options.size ?? bytes.length,
+      mtimeMs: options.mtimeMs ?? MTIME,
+    });
+  }
+
+  async list(root: string) {
+    const call = (this.listCounts.get(root) ?? 0) + 1;
+    this.listCounts.set(root, call);
+    if (this.listHook?.(root, call) === "throw") throw new Error("unavailable");
+    const entries = [...this.files.keys()]
+      .filter((path) => dirname(path) === root)
+      .map((path) => ({ name: basename(path), kind: "file" as const }));
+    return [...entries, ...(this.extras.get(root) ?? [])];
+  }
+
+  async stat(path: string): Promise<FileStat | undefined> {
+    const call = (this.statCounts.get(path) ?? 0) + 1;
+    this.statCounts.set(path, call);
+    const hooked = this.statHook?.(path, call);
+    if (hooked === "throw") throw new Error("unavailable");
+    if (hooked === "missing") return undefined;
+    if (hooked !== null && hooked !== undefined) return hooked;
+    const file = this.files.get(path);
+    return file === undefined
+      ? undefined
+      : { kind: "file", size: file.size, mtimeMs: file.mtimeMs };
+  }
+
+  async readFile(path: string): Promise<Uint8Array> {
+    const call = (this.readCounts.get(path) ?? 0) + 1;
+    this.readCounts.set(path, call);
+    const hooked = this.readHook?.(path, call);
+    if (hooked === "throw") throw new Error("unavailable");
+    if (hooked instanceof Uint8Array) return hooked;
+    const file = this.files.get(path);
+    if (file === undefined) throw new Error("unavailable");
+    return file.bytes;
+  }
+}
+
+class TimerClock {
+  readonly delays: number[] = [];
+  readonly cleared: unknown[] = [];
+  tick = 0;
+  onTick?: (tick: number) => void;
+  private nextId = 1;
+  private readonly timers = new Map<number, () => void>();
+
+  constructor(readonly automatic = true) {}
+
+  setTimeout = (fn: () => void, ms: number): unknown => {
+    const id = this.nextId++;
+    this.delays.push(ms);
+    this.timers.set(id, fn);
+    if (this.automatic) queueMicrotask(() => this.fire(id));
+    return id;
+  };
+
+  clearTimeout = (handle: unknown): void => {
+    this.cleared.push(handle);
+    this.timers.delete(handle as number);
+  };
+
+  fire(id = this.timers.keys().next().value as number): void {
+    const fn = this.timers.get(id);
+    if (fn === undefined) return;
+    this.timers.delete(id);
+    this.tick += 1;
+    this.onTick?.(this.tick);
+    fn();
+  }
+
+  pending(): number {
+    return this.timers.size;
+  }
+}
+
+function digestBytes(bytes: Uint8Array): Uint8Array {
+  let state = bytes.length;
+  for (const byte of bytes) state = (state * 33 + byte) & 0xff;
+  return Uint8Array.from({ length: 32 }, (_, index) => (state + index * 17) & 0xff);
+}
+
+function digestHex(bytes: Uint8Array): string {
+  return Array.from(digestBytes(bytes), (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+function watermark(value: string | null = null): SourceWatermark {
+  return { source: "file-import", lane: "file-discovery", value };
+}
+
+function budget(
+  overrides: Partial<SyncBudget> = {},
+  monotonicNow: () => number = () => 0,
+): SyncBudget {
+  return {
+    signal: new AbortController().signal,
+    clock: { monotonicNow },
+    deadlineMonotonicMs: 1_000_000,
+    perRequestTimeoutMs: 30_000,
+    maxRequests: 10,
+    maxArtifacts: 100,
+    ...overrides,
+  };
+}
+
+function harness(
+  options: {
+    clock?: TimerClock;
+    fs?: FakeFileSystem;
+    validate?: FileImportPorts["validate"];
+    sha256?: FileImportPorts["crypto"]["sha256"];
+    writeArtifact?: FileImportPorts["archive"]["writeArtifact"];
+  } = {},
+) {
+  const fs = options.fs ?? new FakeFileSystem();
+  const clock = options.clock ?? new TimerClock();
+  const archiveCalls: { bytes: Uint8Array; ext: string; epochSeconds: number }[] = [];
+  const validate = options.validate ?? vi.fn(async () => {});
+  const sha256 = options.sha256 ?? vi.fn(async (bytes: Uint8Array) => digestBytes(bytes));
+  const writeArtifact =
+    options.writeArtifact ??
+    vi.fn(async (bytes: Uint8Array, ext: string, when: { epochSeconds: number }) => {
+      archiveCalls.push({ bytes: bytes.slice(), ext, epochSeconds: when.epochSeconds });
+      const address = digestHex(bytes);
+      return { address, relPath: `2000/01/${address}.${ext}`, deduped: false };
+    });
+  const ports: FileImportPorts = {
+    fs,
+    clock,
+    crypto: { sha256 },
+    archive: { writeArtifact },
+    validate,
+  };
+  return { fs, clock, ports, archiveCalls, validate, sha256, writeArtifact };
+}
+
+async function collect<T>(iterable: AsyncIterable<T>): Promise<T[]> {
+  const values: T[] = [];
+  for await (const value of iterable) values.push(value);
+  return values;
+}
+
+async function flush(count = 20): Promise<void> {
+  for (let index = 0; index < count; index += 1) await Promise.resolve();
+}
+
+function config(manualPaths: readonly string[] = [], watchRoots: readonly string[] = []) {
+  return { manualPaths, watchRoots };
+}
+
+describe("stable file import source", () => {
+  it("declares the exact file-discovery capability and public subpaths", () => {
+    const value = harness();
+    const source = createFileImportSource(config([], [ROOT]), value.ports);
+    expect(source.id).toBe("file-import");
+    expect(source.capabilities).toEqual({
+      activities: false,
+      streams: false,
+      rawFiles: true,
+      wellness: false,
+      plannedWorkoutPush: false,
+      backfillDepth: { kind: "none" },
+    });
+    expect(Object.isFrozen(source)).toBe(true);
+    expect(Object.isFrozen(source.capabilities)).toBe(true);
+    expect("pushPlannedWorkout" in source).toBe(false);
+    expect(collectFromManual).toBe(collectReadyBatch);
+    expect(createFromWatcher).toBe(createFolderWatcher);
+    expect(createFolderWatcher([ROOT], value.ports).id).toBe("file-import");
+  });
+
+  it("rejects invalid configuration without exposing paths", () => {
+    const value = harness();
+    const invalid = [
+      config(),
+      config([""], []),
+      config([`${ROOT}/secret.bin`], []),
+      config([`${ROOT}/same.fit`, `${ROOT}/same.fit`], []),
+      config([], [ROOT, ROOT]),
+    ];
+    for (const candidate of invalid) {
+      let error: unknown;
+      try {
+        createFileImportSource(candidate, value.ports);
+      } catch (caught) {
+        error = caught;
+      }
+      expect(error).toEqual(new TypeError("invalid file import configuration"));
+      expect(String(error)).not.toContain(ROOT);
+      expect(Object.hasOwn(error as object, "cause")).toBe(false);
+    }
+    expect(value.fs.statCounts.size + value.fs.listCounts.size).toBe(0);
+  });
+
+  it("rejects foreign watermark and invalid or zero budget", async () => {
+    const path = `${ROOT}/one.fit`,
+      value = harness();
+    value.fs.put(path, [1]);
+    const source = createFileImportSource(config([path]), value.ports);
+    const invalidWatermarks = [
+      { source: "intervals-icu", lane: "file-discovery", value: null },
+      { source: "file-import", lane: "activities", value: null },
+      { source: "file-import", lane: "file-discovery", value: "sha256:ABC" },
+    ] as SourceWatermark[];
+    for (const input of invalidWatermarks) {
+      await expect(
+        source.pullBatches(input, budget())[Symbol.asyncIterator]().next(),
+      ).rejects.toEqual(new TypeError("invalid file import watermark"));
+    }
+    for (const overrides of [
+      { maxArtifacts: 0 },
+      { maxRequests: 0 },
+      { perRequestTimeoutMs: 0 },
+      { deadlineMonotonicMs: Number.NaN },
+    ]) {
+      await expect(
+        source.pullBatches(watermark(), budget(overrides))[Symbol.asyncIterator]().next(),
+      ).rejects.toEqual(new TypeError("invalid file import budget"));
+    }
+    expect(value.fs.statCounts.size).toBe(0);
+  });
+
+  it("manual FIT TCX and GPX wait two intervals and return one batch plus checkpoint", async () => {
+    const value = harness();
+    const paths = [`${ROOT}/a.FIT`, `${ROOT}/b.tcx`, `${ROOT}/c.GpX`];
+    paths.forEach((path, index) => value.fs.put(path, [index + 1]));
+    const result = await collectReadyBatch(
+      { paths, watermark: watermark(), budget: budget() },
+      value.ports,
+    );
+    expect(value.clock.delays).toEqual([250, 250]);
+    expect(result?.artifacts.map((artifact) => artifact.file.ext)).toEqual(["fit", "tcx", "gpx"]);
+    expect(result?.artifacts.map((artifact) => artifact.file.input_path)).toEqual(paths);
+    expect(result?.checkpoint.kind).toBe("checkpoint");
+    expect(result?.checkpoint.watermark.value).toBe(`sha256:${digestHex(Uint8Array.of(3))}`);
+    expect(value.archiveCalls).toHaveLength(3);
+  });
+
+  it("manual-only duplicate suppression returns a terminal no-op checkpoint", async () => {
+    const path = `${ROOT}/same.fit`,
+      value = harness();
+    value.fs.put(path, [7, 7]);
+    const prior = `sha256:${digestHex(Uint8Array.of(7, 7))}`;
+    const result = await collectReadyBatch(
+      { paths: [path], watermark: watermark(prior), budget: budget() },
+      value.ports,
+    );
+    expect(result).toEqual({
+      artifacts: [],
+      checkpoint: { kind: "checkpoint", watermark: watermark(prior) },
+    });
+    expect(value.archiveCalls).toHaveLength(0);
+  });
+
+  it("polling uses 250 ms and abort clears the timer without a checkpoint", async () => {
+    const clock = new TimerClock(false),
+      value = harness({ clock });
+    const path = `${ROOT}/paused.fit`;
+    value.fs.put(path, [1]);
+    const controller = new AbortController();
+    const iterator = createFileImportSource(config([path]), value.ports)
+      .pullBatches(watermark(), budget({ signal: controller.signal }))
+      [Symbol.asyncIterator]();
+    const pending = iterator.next();
+    await flush();
+    expect(clock.delays).toEqual([FILE_IMPORT_POLL_INTERVAL_MS]);
+    expect(clock.pending()).toBe(1);
+    controller.abort();
+    await expect(pending).resolves.toEqual({ done: true, value: undefined });
+    expect(clock.cleared).toHaveLength(1);
+    expect(value.archiveCalls).toHaveLength(0);
+
+    const helperClock = new TimerClock(false),
+      helper = harness({ clock: helperClock });
+    helper.fs.put(path, [1]);
+    const helperController = new AbortController();
+    const helperPending = collectReadyBatch(
+      {
+        paths: [path],
+        watermark: watermark(),
+        budget: budget({ signal: helperController.signal }),
+      },
+      helper.ports,
+    );
+    await flush();
+    helperController.abort();
+    await expect(helperPending).resolves.toBeNull();
+    await expect(
+      collectReadyBatch(
+        { paths: [path], watermark: watermark(), budget: budget({ deadlineMonotonicMs: 0 }) },
+        helper.ports,
+      ),
+    ).resolves.toBeNull();
+  });
+
+  it("paused content remains blocked until structural validation succeeds", async () => {
+    let attempts = 0;
+    const value = harness({
+      validate: vi.fn(async () => {
+        attempts += 1;
+        if (attempts === 1) throw new Error("paused");
+      }),
+    });
+    const path = `${ROOT}/paused.fit`;
+    value.fs.put(path, [1, 2]);
+    const events = await collect(
+      createFileImportSource(config([path]), value.ports).pullBatches(watermark(), budget()),
+    );
+    expect(events.map((event) => event.kind)).toEqual(["batch", "checkpoint"]);
+    expect(attempts).toBe(2);
+    expect(value.clock.delays).toHaveLength(5);
+    expect(value.archiveCalls).toHaveLength(1);
+  });
+
+  it("pre-read post-read and final identity changes discard the entire proposal", async () => {
+    for (const faultCall of [4, 5, 7]) {
+      const value = harness(),
+        path = `${ROOT}/moving.fit`;
+      value.fs.put(path, [4]);
+      let faulted = false;
+      value.fs.statHook = (candidate, call) => {
+        if (candidate === path && call === faultCall && !faulted) {
+          faulted = true;
+          return { kind: "file", size: 5, mtimeMs: MTIME };
+        }
+        return null;
+      };
+      const events = await collect(
+        createFileImportSource(config([path]), value.ports).pullBatches(watermark(), budget()),
+      );
+      expect(events.map((event) => event.kind)).toEqual(["batch", "checkpoint"]);
+      expect(faulted).toBe(true);
+      expect(value.clock.delays.length).toBeGreaterThanOrEqual(4);
+      expect(value.archiveCalls.length).toBe(faultCall === 7 ? 2 : 1);
+    }
+  });
+
+  it("read stat missing-root and sleep wake pauses reset globally and recover", async () => {
+    for (const unavailable of ["read", "stat"] as const) {
+      const value = harness(),
+        path = `${ROOT}/${unavailable}.fit`;
+      value.fs.put(path, [2]);
+      if (unavailable === "read")
+        value.fs.readHook = (_path, call) => (call === 1 ? "throw" : null);
+      else value.fs.statHook = (_path, call) => (call === 4 ? "missing" : null);
+      const events = await collect(
+        createFileImportSource(config([path]), value.ports).pullBatches(watermark(), budget()),
+      );
+      expect(events.map((event) => event.kind)).toEqual(["batch", "checkpoint"]);
+      expect(value.clock.delays.length).toBeGreaterThanOrEqual(4);
+    }
+    const value = harness();
+    value.fs.put(`${ROOT}/b.fit`, [2]);
+    value.fs.put(`${ROOT}/a.fit`, [1]);
+    value.clock.onTick = (tick) => {
+      value.fs.listHook = () => (tick === 1 ? "throw" : null);
+    };
+    const events = await collect(
+      createFolderWatcher([ROOT], value.ports).pullBatches(watermark(), budget()),
+    );
+    expect(value.clock.delays).toHaveLength(4);
+    expect(events[0]).toMatchObject({
+      kind: "batch",
+      artifacts: [
+        { file: { input_path: `${ROOT}/a.fit` } },
+        { file: { input_path: `${ROOT}/b.fit` } },
+      ],
+    });
+    expect(events.at(-1)?.kind).toBe("checkpoint");
+  });
+
+  it("atomic temp rename ignores the temporary name and admits the final name", async () => {
+    const value = harness();
+    value.fs.extras.set(ROOT, [{ name: "incoming.fit.part", kind: "file" }]);
+    value.clock.onTick = (tick) => {
+      if (tick === 1) {
+        value.fs.extras.set(ROOT, []);
+        value.fs.put(`${ROOT}/final.fit`, [9]);
+      }
+    };
+    const events = await collect(
+      createFolderWatcher([ROOT], value.ports).pullBatches(watermark(), budget()),
+    );
+    expect(value.clock.delays).toHaveLength(3);
+    expect(
+      (events[0] as FileImportBatch).artifacts[0]?.file.input_path,
+    ).toBe(`${ROOT}/final.fit`);
+  });
+
+  it("mixed valid and invalid watch files stay in one atomic proposal", async () => {
+    let rejected = false;
+    const value = harness({
+      validate: vi.fn(async ({ bytes }) => {
+        if (bytes[0] === 0 && !rejected) {
+          rejected = true;
+          throw new Error("paused");
+        }
+      }),
+    });
+    value.fs.put(`${ROOT}/a.fit`, [1]);
+    value.fs.put(`${ROOT}/b.fit`, [0]);
+    const events = await collect(
+      createFolderWatcher([ROOT], value.ports).pullBatches(watermark(), budget()),
+    );
+    expect(rejected).toBe(true);
+    expect(value.archiveCalls).toHaveLength(2);
+    expect((events[0] as FileImportBatch).artifacts).toHaveLength(2);
+    expect(events.map((event) => event.kind)).toEqual(["batch", "checkpoint"]);
+  });
+
+  it("twenty arriving files produce one quiescent batch", async () => {
+    const value = harness();
+    value.clock.onTick = (tick) => {
+      if (tick <= 20) value.fs.put(`${ROOT}/f${String(tick).padStart(2, "0")}.fit`, [tick]);
+    };
+    const events = await collect(
+      createFolderWatcher([ROOT], value.ports).pullBatches(watermark(), budget()),
+    );
+    expect(value.clock.delays).toHaveLength(22);
+    expect(events.map((event) => event.kind)).toEqual(["batch", "checkpoint"]);
+    expect((events[0] as FileImportBatch).artifacts).toHaveLength(20);
+    expect(value.archiveCalls).toHaveLength(20);
+  });
+
+  it("sixty arriving files produce one quiescent batch", async () => {
+    const value = harness();
+    value.clock.onTick = (tick) => {
+      if (tick <= 60) value.fs.put(`${ROOT}/f${String(tick).padStart(2, "0")}.gpx`, [tick]);
+    };
+    const events = await collect(
+      createFolderWatcher([ROOT], value.ports).pullBatches(watermark(), budget()),
+    );
+    expect(value.clock.delays).toHaveLength(62);
+    expect((events[0] as FileImportBatch).artifacts).toHaveLength(60);
+    expect(value.archiveCalls).toHaveLength(60);
+  });
+
+  it("two roots share one globally sorted quiescent batch", async () => {
+    const value = harness();
+    value.fs.put(`${ROOT_B}/a.fit`, [3]);
+    value.fs.put(`${ROOT}/z.tcx`, [4]);
+    value.fs.put(`${ROOT}/a.gpx`, [5]);
+    const events = await collect(
+      createFolderWatcher([ROOT_B, ROOT], value.ports).pullBatches(watermark(), budget()),
+    );
+    const paths = (events[0] as FileImportBatch).artifacts.map((item) => item.file.input_path);
+    expect(paths).toEqual([...paths].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0)));
+    expect(paths).toHaveLength(3);
+    expect(value.fs.listCounts.get(ROOT)).toBe(value.fs.listCounts.get(ROOT_B));
+  });
+
+  it("duplicate content inside one batch uses a provisional last digest", async () => {
+    const value = harness();
+    value.fs.put(`${ROOT}/a.fit`, [8]);
+    value.fs.put(`${ROOT}/b.fit`, [8]);
+    const events = await collect(
+      createFolderWatcher([ROOT], value.ports).pullBatches(watermark(), budget()),
+    );
+    const batch = events[0] as FileImportBatch;
+    expect(batch.artifacts.map((artifact) => artifact.file.input_path)).toEqual([`${ROOT}/a.fit`]);
+    expect(value.archiveCalls).toHaveLength(1);
+    expect((events[1] as { watermark: { value: string } }).watermark.value).toBe(
+      `sha256:${digestHex(Uint8Array.of(8))}`,
+    );
+  });
+
+  it("unchanged delivered metadata is revalidated every eight stable polls", async () => {
+    const value = harness();
+    value.fs.put(`${ROOT}/one.fit`, [1]);
+    value.fs.put(`${ROOT}/two.fit`, [2]);
+    const source = createFolderWatcher([ROOT], value.ports);
+    await collect(source.pullBatches(watermark(), budget()));
+    const hashesBefore = vi.mocked(value.sha256).mock.calls.length;
+    value.clock.delays.length = 0;
+    const events = await collect(
+      source.pullBatches(watermark(`sha256:${digestHex(Uint8Array.of(2))}`), budget()),
+    );
+    expect(value.clock.delays).toHaveLength(8);
+    expect(vi.mocked(value.sha256).mock.calls.length).toBe(hashesBefore + 2);
+    expect(events).toEqual([
+      { kind: "checkpoint", watermark: watermark(`sha256:${digestHex(Uint8Array.of(2))}`) },
+    ]);
+    expect(value.archiveCalls).toHaveLength(2);
+  });
+
+  it("same-size same-mtime content after delivery is eventually emitted", async () => {
+    const value = harness();
+    value.fs.put(`${ROOT}/one.fit`, [1]);
+    const source = createFolderWatcher([ROOT], value.ports);
+    const first = await collect(source.pullBatches(watermark(), budget()));
+    const firstMark = (first.at(-1) as { watermark: SourceWatermark }).watermark.value;
+    value.fs.put(`${ROOT}/one.fit`, [2], { size: 1, mtimeMs: MTIME });
+    value.clock.delays.length = 0;
+    const second = await collect(source.pullBatches(watermark(firstMark), budget()));
+    expect(value.clock.delays).toHaveLength(8);
+    expect(second.map((event) => event.kind)).toEqual(["batch", "checkpoint"]);
+    expect(
+      (second[0] as FileImportBatch).artifacts[0]?.file.bytes,
+    ).toEqual(Uint8Array.of(2));
+    expect(value.archiveCalls).toHaveLength(2);
+  });
+
+  it("archive completes before artifact yield and checkpoint is terminal", async () => {
+    let resolveArchive!: (value: ArchiveWriteResult) => void;
+    const path = `${ROOT}/ordered.fit`,
+      bytes = Uint8Array.of(6);
+    const clock = new TimerClock(false);
+    const value = harness({
+      clock,
+      writeArtifact: vi.fn<FileImportPorts["archive"]["writeArtifact"]>(
+        () =>
+          new Promise<ArchiveWriteResult>((resolve) => {
+            resolveArchive = resolve;
+          }),
+      ),
+    });
+    value.fs.put(path, [...bytes]);
+    const source = createFileImportSource(config([path]), value.ports);
+    const iterator = source.pullBatches(watermark(), budget())[Symbol.asyncIterator]();
+    const first = iterator.next();
+    await flush();
+    clock.fire();
+    await flush();
+    clock.fire();
+    await flush();
+    let yielded = false;
+    void first.then(() => {
+      yielded = true;
+    });
+    await flush();
+    expect(yielded).toBe(false);
+    resolveArchive({ address: digestHex(bytes), relPath: "2000/01/archive.fit", deduped: false });
+    expect((await first).value).toMatchObject({ kind: "batch" });
+    expect((await iterator.next()).value).toMatchObject({ kind: "checkpoint" });
+    await expect(iterator.next()).resolves.toEqual({ done: true, value: undefined });
+    await expect(iterator.next()).resolves.toEqual({ done: true, value: undefined });
+
+    const rollback = harness();
+    rollback.fs.put(`${ROOT}/rollback.fit`, [3]);
+    const uncommitted = createFolderWatcher([ROOT], rollback.ports);
+    const abandoned = uncommitted.pullBatches(watermark(), budget())[Symbol.asyncIterator]();
+    expect((await abandoned.next()).value).toMatchObject({ kind: "batch" });
+    await abandoned.return?.();
+    rollback.clock.delays.length = 0;
+    const retried = await collect(uncommitted.pullBatches(watermark(), budget()));
+    expect(rollback.clock.delays).toHaveLength(2);
+    expect(retried.map((event) => event.kind)).toEqual(["batch", "checkpoint"]);
+
+    const expired = harness();
+    expired.fs.put(`${ROOT}/expired.fit`, [4]);
+    const tentative = createFolderWatcher([ROOT], expired.ports);
+    let now = 0;
+    const expiring = tentative
+      .pullBatches(watermark(), budget({}, () => now))
+      [Symbol.asyncIterator]();
+    expect((await expiring.next()).value).toMatchObject({ kind: "batch" });
+    expect((await expiring.next()).value).toMatchObject({ kind: "checkpoint" });
+    now = 1_000_000;
+    await expect(expiring.next()).resolves.toEqual({ done: true, value: undefined });
+    expired.clock.delays.length = 0;
+    const afterExpiry = await collect(tentative.pullBatches(watermark(), budget()));
+    expect(expired.clock.delays).toHaveLength(2);
+    expect(afterExpiry.map((event) => event.kind)).toEqual(["batch", "checkpoint"]);
+  });
+
+  it("archive failure and public errors are path-free and carry no cause", async () => {
+    const suppliedPath = `${ROOT}/private.fit`;
+    const errors: unknown[] = [];
+    for (const writeArtifact of [
+      vi.fn(async () => {
+        throw new Error(suppliedPath);
+      }),
+      vi.fn(async () => ({ address: "bad", relPath: suppliedPath, deduped: false })),
+    ]) {
+      const value = harness({ writeArtifact });
+      value.fs.put(suppliedPath, [1]);
+      try {
+        await collect(
+          createFileImportSource(config([suppliedPath]), value.ports).pullBatches(
+            watermark(),
+            budget(),
+          ),
+        );
+      } catch (error) {
+        errors.push(error);
+      }
+    }
+    const shortDigest = harness({ sha256: vi.fn(async () => Uint8Array.of(1)) });
+    shortDigest.fs.put(suppliedPath, [1]);
+    try {
+      await collect(
+        createFileImportSource(config([suppliedPath]), shortDigest.ports).pullBatches(
+          watermark(),
+          budget(),
+        ),
+      );
+    } catch (error) {
+      errors.push(error);
+    }
+    expect(errors.map((error) => (error as Error).message)).toEqual([
+      "file archive failed",
+      "file archive result mismatch",
+      "invalid SHA-256 digest",
+    ]);
+    for (const error of errors) {
+      const own: unknown[] = [];
+      const visit = (value: unknown): void => {
+        if (value === null || (typeof value !== "object" && typeof value !== "function")) {
+          own.push(value);
+          return;
+        }
+        for (const key of Object.getOwnPropertyNames(value)) {
+          own.push(key);
+          visit((value as Record<string, unknown>)[key]);
+        }
+      };
+      visit(error);
+      expect(
+        [String(error), (error as Error).message, JSON.stringify(error), JSON.stringify(own)].join(
+          " ",
+        ),
+      ).not.toContain(suppliedPath);
+      expect(Object.hasOwn(error as object, "cause")).toBe(false);
+    }
+  });
+
+  it("remaining artifact budget never splits a burst or emits a checkpoint", async () => {
+    const first = harness();
+    first.fs.put(`${ROOT}/a.fit`, [1]);
+    first.fs.put(`${ROOT}/b.fit`, [2]);
+    const oversized = createFolderWatcher([ROOT], first.ports).pullBatches(
+      watermark(),
+      budget({ maxArtifacts: 1 }),
+    );
+    await expect(collect(oversized)).rejects.toEqual(
+      new RangeError("file import burst exceeds artifact budget"),
+    );
+    expect(first.archiveCalls).toHaveLength(0);
+
+    const exact = harness();
+    exact.fs.put(`${ROOT}/a.fit`, [1]);
+    exact.fs.put(`${ROOT}/b.fit`, [2]);
+    expect(
+      (
+        await collect(
+          createFolderWatcher([ROOT], exact.ports).pullBatches(
+            watermark(),
+            budget({ maxArtifacts: 2 }),
+          ),
+        )
+      ).map((event) => event.kind),
+    ).toEqual(["batch", "checkpoint"]);
+
+    const mixed = harness();
+    mixed.fs.put(`${ROOT}/manual.fit`, [1]);
+    mixed.fs.put(`${ROOT_B}/a.fit`, [2]);
+    mixed.fs.put(`${ROOT_B}/b.fit`, [3]);
+    const iterator = createFileImportSource(config([`${ROOT}/manual.fit`], [ROOT_B]), mixed.ports)
+      .pullBatches(watermark(), budget({ maxArtifacts: 2 }))
+      [Symbol.asyncIterator]();
+    expect((await iterator.next()).value).toMatchObject({
+      kind: "batch",
+      artifacts: [{ file: { input_path: `${ROOT}/manual.fit` } }],
+    });
+    await expect(iterator.next()).rejects.toEqual(
+      new RangeError("file import burst exceeds artifact budget"),
+    );
+    expect(mixed.archiveCalls).toHaveLength(1);
+  });
+
+  it("generic pull flattens batches and ends with the exact checkpoint", async () => {
+    const value = harness();
+    value.fs.put(`${ROOT}/a.fit`, [1]);
+    value.fs.put(`${ROOT}/b.gpx`, [2]);
+    const source = createFileImportSource(config([`${ROOT}/a.fit`, `${ROOT}/b.gpx`]), value.ports);
+    const events = await collect(source.pull(watermark(), budget()));
+    expect(events.map((event) => event.kind)).toEqual(["raw-file", "raw-file", "checkpoint"]);
+    expect(events.at(-1)).toEqual({
+      kind: "checkpoint",
+      watermark: watermark(`sha256:${digestHex(Uint8Array.of(2))}`),
+    });
+    expect(Object.isFrozen(events.at(-1))).toBe(true);
+  });
+});

--- a/packages/sync-file-import/tsconfig.json
+++ b/packages/sync-file-import/tsconfig.json
@@ -1,0 +1,31 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": [
+      "ES2022"
+    ],
+    "types": [
+      "node"
+    ],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "ignoreDeprecations": "6.0"
+  },
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/packages/sync-file-import/tsup.config.ts
+++ b/packages/sync-file-import/tsup.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: {
+    index: "src/index.ts",
+    manual: "src/manual.ts",
+    watcher: "src/watcher.ts",
+  },
+  format: ["esm"],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  splitting: false,
+  removeNodeProtocol: false,
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -431,6 +431,25 @@ importers:
         specifier: ^4.1.4
         version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.8(vitest@4.1.5))(msw@2.14.2(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))
 
+  packages/sync-file-import:
+    dependencies:
+      '@enduragent/kernel':
+        specifier: workspace:*
+        version: link:../kernel
+    devDependencies:
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.6.0
+      tsup:
+        specifier: ^8.4.0
+        version: 8.5.1(postcss@8.5.12)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.3)
+      typescript:
+        specifier: ^6.0.2
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.4
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.8(vitest@4.1.5))(msw@2.14.2(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))
+
 packages:
 
   '@ai-sdk/alibaba@1.0.29':


### PR DESCRIPTION
## Summary

Adds `@enduragent/sync-file-import`, the stable file source plugin for the Reference layer's sync contract: manual-path and watch-folder discovery of activity files feeding the archive-first ingest pipeline.

- **Discovery**: manual path submission and watch-folder polling, with duplicate suppression and bounded eight-poll digest revalidation.
- **Read gate**: three-identity check (path, size, digest) before a file is admitted to a batch.
- **Batching**: atomic archive-first batches with terminal checkpoints; structural validation before archive writes.
- **Safety**: privacy-safe error surfaces (no raw private paths in messages) and explicit budgets on discovery and read work.

## Scope

New package only — 8 new files plus an importer-only `pnpm-lock.yaml` entry. No existing package is modified; the predecessor intervals.icu importer lockfile block is preserved byte-for-byte.

## Testing

- Package suite: 21/21 new tests.
- Full monorepo `pnpm test` (non-watch) green on the rebased branch.
- `pnpm -r build` and `tsc --noEmit` clean; oxlint 0 warnings.

## Changeset

`patch` for `@enduragent/sync-file-import` — internal infrastructure, no athlete-facing change (no `User-facing:` line).
