### PR TITLE
feat(coach): persist per-source sync failures

### DIFF
--- a/.changeset/per-source-sync-failures.md
+++ b/.changeset/per-source-sync-failures.md
@@ -1,0 +1,7 @@
+---
+"@enduragent/kernel": patch
+"@enduragent/kernel-node": patch
+"@enduragent/coach": patch
+---
+
+Persist per-source synchronization failures and keep mixed API and FIT activity presentations deterministic.

--- a/packages/coach/src/sync.ts
+++ b/packages/coach/src/sync.ts
@@ -1,6 +1,32 @@
+import { join } from "node:path";
 import type { ImportReport } from "@enduragent/kernel/ingest";
-import { SOURCE_IDS, type SourceId, type SyncSource } from "@enduragent/kernel/store";
-import { importFilesWithReport } from "@enduragent/kernel-node/ingest";
+import type { FileSystemPort } from "@enduragent/kernel/ports";
+import { cacheSchemas } from "@enduragent/kernel/reference/schemas";
+import {
+  SOURCE_IDS,
+  SYNC_FAILURE_SEVERITIES,
+  createSyncFailureRepository,
+  nextSyncFailureOrdinal,
+  reduceSyncFailures,
+  type SourceCheckpoint,
+  type SourceId,
+  type SourceArtifact,
+  type SourceWatermark,
+  type SyncBudget,
+  type SyncFailureDetail,
+  type SyncFailureSeverity,
+  type SyncSource,
+} from "@enduragent/kernel/store";
+import {
+  createNodeImportRuntime,
+  importFilesWithReport,
+  type NodeImportRuntime,
+} from "@enduragent/kernel-node/ingest";
+import {
+  ensurePrivateDirectory,
+  nodeFileSystem,
+  removeFileIfPresent,
+} from "@enduragent/kernel-node/filesystem";
 import { withCoachStoreWriter, type CoachStoreWriterContext } from "./runtime.js";
 
 export interface CoachSourceRunContext extends CoachStoreWriterContext {
@@ -9,10 +35,55 @@ export interface CoachSourceRunContext extends CoachStoreWriterContext {
 
 export type CoachSourceRun = (context: CoachSourceRunContext) => Promise<void>;
 
-export interface CoachSourceBinding {
+export const COACH_SOURCE_FAILURE_CODES = Object.freeze([
+  "authorization",
+  "unavailable",
+  "invalid-data",
+  "budget-exhausted",
+] as const);
+export type CoachSourceFailureCode = (typeof COACH_SOURCE_FAILURE_CODES)[number];
+
+export interface CoachSourceFailure {
+  readonly severity: SyncFailureSeverity;
+  readonly code: CoachSourceFailureCode;
+}
+
+export type CoachSourceFailureClassifier = (error: unknown) => CoachSourceFailure;
+
+export interface CoachFileBatchSource extends SyncSource {
+  readonly id: "file-import";
+  pullBatches(
+    watermark: SourceWatermark,
+    budget: SyncBudget,
+  ): AsyncIterable<
+    | {
+        readonly kind: "batch";
+        readonly artifacts: readonly Extract<SourceArtifact, { readonly kind: "raw-file" }>[];
+      }
+    | SourceCheckpoint
+  >;
+}
+
+export interface CoachFileHydration {
+  readonly watermark: SourceWatermark;
+  readonly budget: SyncBudget;
+}
+
+export interface CoachRunSourceBinding {
   readonly source: SyncSource;
   readonly run: CoachSourceRun;
+  readonly fileHydration?: never;
+  readonly classifyFailure?: CoachSourceFailureClassifier;
 }
+
+export interface CoachFileSourceBinding {
+  readonly source: CoachFileBatchSource;
+  readonly run?: never;
+  readonly fileHydration: CoachFileHydration;
+  readonly classifyFailure?: CoachSourceFailureClassifier;
+}
+
+export type CoachSourceBinding = CoachRunSourceBinding | CoachFileSourceBinding;
 
 export interface RunCoachSyncOptions {
   readonly env: Record<string, string | undefined>;
@@ -23,27 +94,166 @@ export interface RunCoachSyncOptions {
 export interface CoachSourceOutcome {
   readonly source_id: SourceId;
   readonly status: "completed" | "failed";
-  readonly message: string | null;
+  readonly severity: SyncFailureSeverity | null;
+  readonly message: SyncFailureDetail | null;
 }
 
 export interface CoachSyncReport {
-  readonly schema_version: 1;
+  readonly schema_version: 2;
   readonly sources: readonly CoachSourceOutcome[];
   readonly import_report: ImportReport | null;
 }
 
 export interface CoachSyncDependencies {
-  readonly withWriter: typeof withCoachStoreWriter;
+  readonly withWriter: <T>(
+    env: Record<string, string | undefined>,
+    run: (context: CoachStoreWriterContext) => Promise<T>,
+  ) => Promise<T>;
   readonly importFiles: typeof importFilesWithReport;
+  readonly fileSystem: Pick<FileSystemPort, "writeFile">;
+  readonly ensurePrivateDirectory: typeof ensurePrivateDirectory;
+  readonly removeFileIfPresent: typeof removeFileIfPresent;
+  readonly nowEpochMs: () => number;
+  readonly createImportRuntime: typeof createNodeImportRuntime;
 }
 
 const defaultDependencies: CoachSyncDependencies = Object.freeze({
   withWriter: withCoachStoreWriter,
   importFiles: importFilesWithReport,
+  fileSystem: nodeFileSystem(),
+  ensurePrivateDirectory,
+  removeFileIfPresent,
+  nowEpochMs: Date.now,
+  createImportRuntime: createNodeImportRuntime,
+});
+
+const DETAIL_BY_CODE: Readonly<Record<CoachSourceFailureCode, SyncFailureDetail>> = Object.freeze({
+  authorization: "source authorization failed",
+  unavailable: "source temporarily unavailable",
+  "invalid-data": "source data failed validation",
+  "budget-exhausted": "source synchronization budget exhausted",
 });
 
 function isObject(value: unknown): value is Record<PropertyKey, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isFailureSeverity(value: unknown): value is SyncFailureSeverity {
+  return (SYNC_FAILURE_SEVERITIES as readonly unknown[]).includes(value);
+}
+
+function isFailureCode(value: unknown): value is CoachSourceFailureCode {
+  return (COACH_SOURCE_FAILURE_CODES as readonly unknown[]).includes(value);
+}
+
+function classifyFailure(
+  classifier: CoachSourceFailureClassifier | undefined,
+  error: unknown,
+): { readonly severity: SyncFailureSeverity; readonly detail: SyncFailureDetail } {
+  if (classifier === undefined) {
+    return { severity: "block", detail: "source synchronization failed" };
+  }
+  try {
+    const value: unknown = classifier(error);
+    if (value === null || typeof value !== "object")
+      throw new TypeError("invalid classifier result");
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) {
+      throw new TypeError("invalid classifier result");
+    }
+    const keys = Reflect.ownKeys(value);
+    if (
+      keys.length !== 2 ||
+      keys.some((key) => typeof key !== "string" || (key !== "severity" && key !== "code")) ||
+      !keys.includes("severity") ||
+      !keys.includes("code")
+    ) {
+      throw new TypeError("invalid classifier result");
+    }
+    const severity = Object.getOwnPropertyDescriptor(value, "severity");
+    const code = Object.getOwnPropertyDescriptor(value, "code");
+    if (
+      severity === undefined ||
+      code === undefined ||
+      !("value" in severity) ||
+      !("value" in code) ||
+      !severity.enumerable ||
+      !code.enumerable ||
+      !isFailureSeverity(severity.value) ||
+      !isFailureCode(code.value)
+    ) {
+      throw new TypeError("invalid classifier result");
+    }
+    return { severity: severity.value, detail: DETAIL_BY_CODE[code.value] };
+  } catch {
+    return { severity: "block", detail: "source failure classification failed" };
+  }
+}
+
+function validateBinding(value: unknown): CoachSourceBinding {
+  if (!isObject(value) || !isObject(value.source)) {
+    throw new TypeError("invalid coach source binding");
+  }
+  const source = value.source as unknown as SyncSource;
+  const hasRun = typeof value.run === "function";
+  const hasHydration = isObject(value.fileHydration);
+  if (
+    !SOURCE_IDS.includes(source.id as SourceId) ||
+    typeof source.pull !== "function" ||
+    hasRun === hasHydration ||
+    (value.classifyFailure !== undefined && typeof value.classifyFailure !== "function")
+  ) {
+    throw new TypeError("invalid coach source binding");
+  }
+  if (hasRun) {
+    return Object.freeze({
+      source,
+      run: value.run as CoachSourceRun,
+      ...(value.classifyFailure === undefined
+        ? {}
+        : { classifyFailure: value.classifyFailure as CoachSourceFailureClassifier }),
+    });
+  }
+  const hydration = value.fileHydration as unknown as CoachFileHydration;
+  if (
+    source.id !== "file-import" ||
+    typeof (source as CoachFileBatchSource).pullBatches !== "function" ||
+    !isObject(hydration.watermark) ||
+    hydration.watermark.source !== "file-import" ||
+    hydration.watermark.lane !== "file-discovery" ||
+    !isObject(hydration.budget)
+  ) {
+    throw new TypeError("invalid coach source binding");
+  }
+  return Object.freeze({
+    source: source as CoachFileBatchSource,
+    fileHydration: Object.freeze({ watermark: hydration.watermark, budget: hydration.budget }),
+    ...(value.classifyFailure === undefined
+      ? {}
+      : { classifyFailure: value.classifyFailure as CoachSourceFailureClassifier }),
+  });
+}
+
+async function runFileHydration(
+  binding: CoachFileSourceBinding,
+  runtime: NodeImportRuntime,
+): Promise<void> {
+  let checkpointSeen = false;
+  for await (const event of binding.source.pullBatches(
+    binding.fileHydration.watermark,
+    binding.fileHydration.budget,
+  )) {
+    if (checkpointSeen) throw new TypeError("source synchronization failed");
+    if (event.kind === "checkpoint") {
+      checkpointSeen = true;
+      continue;
+    }
+    await runtime.importBatchWithReport({
+      files: event.artifacts.map((artifact) => artifact.file),
+      platform_records: [],
+    });
+  }
+  if (!checkpointSeen) throw new TypeError("source synchronization failed");
 }
 
 export async function runCoachSync(
@@ -56,21 +266,11 @@ export async function runCoachSync(
 
   const sourceIds = new Set<SourceId>();
   const sources: CoachSourceBinding[] = [];
-  for (const binding of options.sources) {
-    if (
-      !isObject(binding) ||
-      !isObject(binding.source) ||
-      !SOURCE_IDS.includes(binding.source.id as SourceId) ||
-      typeof binding.run !== "function"
-    ) {
-      throw new TypeError("invalid coach source binding");
-    }
-    const source = binding.source as unknown as SyncSource;
-    if (sourceIds.has(source.id)) {
-      throw new TypeError("duplicate coach sync source");
-    }
-    sourceIds.add(source.id);
-    sources.push(Object.freeze({ source, run: binding.run as CoachSourceRun }));
+  for (const candidate of options.sources) {
+    const binding = validateBinding(candidate);
+    if (sourceIds.has(binding.source.id)) throw new TypeError("duplicate coach sync source");
+    sourceIds.add(binding.source.id);
+    sources.push(binding);
   }
   const copiedSources = Object.freeze(sources);
 
@@ -78,9 +278,7 @@ export async function runCoachSync(
   if (options.importPaths === undefined) {
     copiedImportPaths = Object.freeze([]);
   } else {
-    if (!Array.isArray(options.importPaths)) {
-      throw new TypeError("invalid coach import paths");
-    }
+    if (!Array.isArray(options.importPaths)) throw new TypeError("invalid coach import paths");
     const paths = new Set<string>();
     for (const path of options.importPaths) {
       if (typeof path !== "string" || path.length === 0 || paths.has(path)) {
@@ -93,24 +291,69 @@ export async function runCoachSync(
 
   const dependencies = deps ?? defaultDependencies;
   return dependencies.withWriter(options.env, async ({ home, store }) => {
+    const repository = createSyncFailureRepository(store);
+    const target = join(home.root, "data", "error_state.json");
+    const project = async (): Promise<void> => {
+      const signal = reduceSyncFailures(await repository.readAll());
+      if (signal === null) {
+        await dependencies.removeFileIfPresent(target);
+        return;
+      }
+      cacheSchemas.ErrorStateSchema.parse(signal);
+      await dependencies.ensurePrivateDirectory(join(home.root, "data"));
+      await dependencies.fileSystem.writeFile(target, `${JSON.stringify(signal, null, 2)}\n`, {
+        mode: 0o600,
+      });
+    };
+
+    await project();
     const outcomes: CoachSourceOutcome[] = [];
+    let nodeRuntime: NodeImportRuntime | undefined;
     for (const binding of copiedSources) {
-      const context = Object.freeze({ home, store, source: binding.source });
+      let sourceError: unknown;
+      let sourceFailed = false;
       try {
-        await binding.run(context);
+        if ("run" in binding && binding.run !== undefined) {
+          await binding.run(Object.freeze({ home, store, source: binding.source }));
+        } else {
+          nodeRuntime ??= dependencies.createImportRuntime({ archiveDir: home.archiveDir, store });
+          await runFileHydration(binding as CoachFileSourceBinding, nodeRuntime);
+        }
+      } catch (error) {
+        sourceFailed = true;
+        sourceError = error;
+      }
+      if (!sourceFailed) {
+        await store.transaction(async () => {
+          await repository.clear(binding.source.id);
+        });
+        await project();
         outcomes.push(
           Object.freeze({
             source_id: binding.source.id,
             status: "completed",
+            severity: null,
             message: null,
           }),
         );
-      } catch {
+      } else {
+        const failure = classifyFailure(binding.classifyFailure, sourceError);
+        await store.transaction(async () => {
+          const rows = await repository.readAll();
+          await repository.upsert({
+            source: binding.source.id,
+            severity: failure.severity,
+            detail: failure.detail,
+            logical_ordinal: nextSyncFailureOrdinal(rows, dependencies.nowEpochMs()),
+          });
+        });
+        await project();
         outcomes.push(
           Object.freeze({
             source_id: binding.source.id,
             status: "failed",
-            message: "source synchronization failed",
+            severity: failure.severity,
+            message: failure.detail,
           }),
         );
       }
@@ -125,7 +368,7 @@ export async function runCoachSync(
             store,
           });
     return Object.freeze({
-      schema_version: 1,
+      schema_version: 2,
       sources: Object.freeze(outcomes),
       import_report: importReport,
     });

--- a/packages/coach/tests/coach-sync.test.ts
+++ b/packages/coach/tests/coach-sync.test.ts
@@ -1,11 +1,20 @@
 import { access, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
-import type { ImportReport } from "@enduragent/kernel/ingest";
-import type { SourceId, SyncSource } from "@enduragent/kernel/store";
+import { describe, expect, it, vi } from "vitest";
+import type { ImportArtifact, ImportReport } from "@enduragent/kernel/ingest";
+import {
+  createSyncFailureRepository,
+  dumpStore,
+  runMigrations,
+  type SourceId,
+  type SourceWatermark,
+  type SyncBudget,
+  type SyncSource,
+} from "@enduragent/kernel/store";
+import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
 import type { AthleteHome } from "@enduragent/kernel-node/home";
-import { importFilesWithReport } from "@enduragent/kernel-node/ingest";
+import { importFilesWithReport, type NodeImportRuntime } from "@enduragent/kernel-node/ingest";
 import { LOCKFILE_NAME, PORT_FILE_NAME } from "@enduragent/kernel-node/lock";
 import {
   type CoachDevWriterFailureStage,
@@ -18,7 +27,13 @@ import {
   withCoachStoreWriter,
   type CoachStoreWriterContext,
 } from "../src/runtime.js";
-import { runCoachSync, type CoachSourceBinding, type RunCoachSyncOptions } from "../src/sync.js";
+import {
+  runCoachSync,
+  type CoachFileBatchSource,
+  type CoachSourceBinding,
+  type CoachSyncDependencies,
+  type RunCoachSyncOptions,
+} from "../src/sync.js";
 
 const capabilities = Object.freeze({
   activities: false,
@@ -81,6 +96,88 @@ async function pathExists(path: string): Promise<boolean> {
 }
 
 const importReport = { report: "synthetic" } as unknown as ImportReport;
+
+function syncDependencies(
+  withWriter: CoachSyncDependencies["withWriter"],
+  importFiles: CoachSyncDependencies["importFiles"],
+  overrides: Partial<CoachSyncDependencies> = {},
+): CoachSyncDependencies {
+  return {
+    withWriter,
+    importFiles,
+    fileSystem: { async writeFile() {} },
+    async ensurePrivateDirectory() {},
+    async removeFileIfPresent() {},
+    nowEpochMs: () => 1_000,
+    createImportRuntime() {
+      throw new Error("unexpected import runtime construction");
+    },
+    ...overrides,
+  };
+}
+
+async function governedHarness(overrides: Partial<CoachSyncDependencies> = {}) {
+  const store = openSqliteStorage(":memory:");
+  await runMigrations(store, MIGRATIONS);
+  const home = syntheticHome("synthetic-governed-root");
+  const projected = new Map<string, string>();
+  const events: string[] = [];
+  let ordinal = 1_000;
+  const withWriter: CoachSyncDependencies["withWriter"] = async (_env, operation) => {
+    events.push("writer");
+    return operation({ home, store });
+  };
+  const dependencies = syncDependencies(withWriter, async () => importReport, {
+    fileSystem: {
+      async writeFile(path, data) {
+        events.push("write");
+        projected.set(path, typeof data === "string" ? data : new TextDecoder().decode(data));
+      },
+    },
+    async ensurePrivateDirectory() {
+      events.push("secure-directory");
+    },
+    async removeFileIfPresent(path) {
+      events.push("remove");
+      projected.delete(path);
+    },
+    nowEpochMs: () => ordinal++,
+    ...overrides,
+  });
+  return { store, home, projected, events, dependencies };
+}
+
+function fileHydrationInput(): {
+  readonly watermark: SourceWatermark;
+  readonly budget: SyncBudget;
+} {
+  return {
+    watermark: { source: "file-import", lane: "file-discovery", value: null },
+    budget: {
+      signal: new AbortController().signal,
+      clock: { monotonicNow: () => 0 },
+      deadlineMonotonicMs: 10_000,
+      perRequestTimeoutMs: 1_000,
+      maxRequests: 1,
+      maxArtifacts: 10,
+    },
+  };
+}
+
+function hydrationSource(
+  events: readonly (
+    | { readonly kind: "batch"; readonly artifacts: readonly never[] }
+    | { readonly kind: "checkpoint"; readonly watermark: SourceWatermark }
+  )[],
+): CoachFileBatchSource {
+  return {
+    ...syncSource("file-import"),
+    id: "file-import",
+    async *pullBatches() {
+      yield* events;
+    },
+  };
+}
 
 describe("coach sync composition", () => {
   it("runtime delegates to the exact writer version and returns the operation value", async () => {
@@ -182,7 +279,7 @@ describe("coach sync composition", () => {
         sourceCalls += 1;
       },
     };
-    const dependencies = { withWriter, importFiles };
+    const dependencies = syncDependencies(withWriter, importFiles);
     const invalidCases: readonly { value: unknown; message: string }[] = [
       { value: null, message: "invalid coach sync options" },
       { value: [], message: "invalid coach sync options" },
@@ -201,6 +298,35 @@ describe("coach sync composition", () => {
       },
       {
         value: { env: {}, sources: [{ source: syncSource("file-import"), run: null }] },
+        message: "invalid coach source binding",
+      },
+      {
+        value: {
+          env: {},
+          sources: [{ source: hydrationSource([]), run() {}, fileHydration: fileHydrationInput() }],
+        },
+        message: "invalid coach source binding",
+      },
+      {
+        value: {
+          env: {},
+          sources: [{ source: syncSource("intervals-icu"), fileHydration: fileHydrationInput() }],
+        },
+        message: "invalid coach source binding",
+      },
+      {
+        value: {
+          env: {},
+          sources: [
+            {
+              source: hydrationSource([]),
+              fileHydration: {
+                ...fileHydrationInput(),
+                watermark: { source: "file-import", lane: "activities", value: null },
+              },
+            },
+          ],
+        },
         message: "invalid coach source binding",
       },
       {
@@ -262,7 +388,7 @@ describe("coach sync composition", () => {
         env: {},
         sources: [binding("intervals-icu", true), binding("file-import", false)],
       },
-      { withWriter, importFiles },
+      syncDependencies(withWriter, importFiles),
     );
     expect(order).toEqual([
       "start:intervals-icu",
@@ -272,14 +398,15 @@ describe("coach sync composition", () => {
     ]);
     expect(maximumRunning).toBe(1);
     expect(report).toEqual({
-      schema_version: 1,
+      schema_version: 2,
       sources: [
         {
           source_id: "intervals-icu",
           status: "failed",
+          severity: "block",
           message: "source synchronization failed",
         },
-        { source_id: "file-import", status: "completed", message: null },
+        { source_id: "file-import", status: "completed", severity: null, message: null },
       ],
       import_report: null,
     });
@@ -318,7 +445,7 @@ describe("coach sync composition", () => {
         ],
         importPaths: originalPaths,
       },
-      { withWriter, importFiles },
+      syncDependencies(withWriter, importFiles),
     );
 
     expect(order).toEqual(["source", "import"]);
@@ -346,7 +473,7 @@ describe("coach sync composition", () => {
       importCalls += 1;
       return importReport;
     };
-    const dependencies = { withWriter, importFiles };
+    const dependencies = syncDependencies(withWriter, importFiles);
 
     await expect(
       runCoachSync({ env: {}, sources: [], importPaths: [] }, dependencies),
@@ -368,7 +495,7 @@ describe("coach sync composition", () => {
           return store.get("PRAGMA user_version");
         },
       );
-      expect(value).toEqual({ user_version: 6 });
+      expect(value).toEqual({ user_version: 7 });
       expect(await pathExists(join(home.storeDir, "store.db"))).toBe(true);
       expect(await pathExists(join(home.configDir, LOCKFILE_NAME))).toBe(false);
       expect(await pathExists(join(home.configDir, PORT_FILE_NAME))).toBe(false);
@@ -376,7 +503,7 @@ describe("coach sync composition", () => {
       const reopened = openSqliteStorage(join(home.storeDir, "store.db"));
       try {
         await expect(reopened.get("PRAGMA user_version")).resolves.toEqual({
-          user_version: 6,
+          user_version: 7,
         });
       } finally {
         await reopened.close();
@@ -415,10 +542,10 @@ describe("coach sync composition", () => {
         }),
       ]);
       expect(leftReport.sources).toEqual([
-        { source_id: "intervals-icu", status: "completed", message: null },
+        { source_id: "intervals-icu", status: "completed", severity: null, message: null },
       ]);
       expect(rightReport.sources).toEqual([
-        { source_id: "intervals-icu", status: "completed", message: null },
+        { source_id: "intervals-icu", status: "completed", severity: null, message: null },
       ]);
       expect(leftReport.import_report).toBeNull();
       expect(rightReport.import_report).toBeNull();
@@ -467,7 +594,7 @@ describe("coach sync composition", () => {
         stage: null,
       });
       releaseHold();
-      await expect(first).resolves.toMatchObject({ schema_version: 1 });
+      await expect(first).resolves.toMatchObject({ schema_version: 2 });
       expect(await pathExists(join(leftHome.configDir, LOCKFILE_NAME))).toBe(false);
       expect(await pathExists(join(leftHome.configDir, PORT_FILE_NAME))).toBe(false);
       expect(await pathExists(join(rightHome.configDir, LOCKFILE_NAME))).toBe(false);
@@ -475,6 +602,425 @@ describe("coach sync composition", () => {
     } finally {
       await rm(leftRoot, { recursive: true, force: true });
       await rm(rightRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("projects persisted failures before a source run and returns the schema 2 public shape", async () => {
+    const harness = await governedHarness();
+    try {
+      const repository = createSyncFailureRepository(harness.store);
+      await repository.upsert({
+        source: "intervals-icu",
+        severity: "warn",
+        detail: "source temporarily unavailable",
+        logical_ordinal: 1_000,
+      });
+      const target = join(harness.home.root, "data", "error_state.json");
+      const source = syncSource("intervals-icu");
+      const report = await runCoachSync(
+        {
+          env: {},
+          sources: [
+            {
+              source,
+              async run(context) {
+                expect(Object.isFrozen(context)).toBe(true);
+                expect(context).toEqual({ home: harness.home, store: harness.store, source });
+              expect(Object.keys(context)).toEqual(["home", "store", "source"]);
+                expect(JSON.parse(harness.projected.get(target)!)).toMatchObject({
+                  detail: "intervals-icu: source temporarily unavailable",
+                  mitigation: "warn_only",
+                });
+              },
+            },
+          ],
+        },
+        harness.dependencies,
+      );
+      expect(report).toEqual({
+        schema_version: 2,
+        sources: [
+          {
+            source_id: "intervals-icu",
+            status: "completed",
+            severity: null,
+            message: null,
+          },
+        ],
+        import_report: null,
+      });
+      expect(harness.projected.has(target)).toBe(false);
+      expect(await repository.readAll()).toEqual([]);
+    } finally {
+      await harness.store.close();
+    }
+  });
+
+  it("clears only the successful source while block remains ahead of warn", async () => {
+    const harness = await governedHarness();
+    try {
+      const repository = createSyncFailureRepository(harness.store);
+      await repository.upsert({
+        source: "intervals-icu",
+        severity: "warn",
+        detail: "source temporarily unavailable",
+        logical_ordinal: 2_000,
+      });
+      await repository.upsert({
+        source: "file-import",
+        severity: "block",
+        detail: "source data failed validation",
+        logical_ordinal: 1_000,
+      });
+      const target = join(harness.home.root, "data", "error_state.json");
+      await runCoachSync(
+        {
+          env: {},
+          sources: [
+            {
+              source: syncSource("intervals-icu"),
+              async run() {
+                expect(JSON.parse(harness.projected.get(target)!)).toMatchObject({
+                  detail: "file-import: source data failed validation",
+                  mitigation: "block_coaching",
+                });
+              },
+            },
+          ],
+        },
+        harness.dependencies,
+      );
+      expect((await repository.readAll()).map((row) => row.source)).toEqual(["file-import"]);
+      expect(JSON.parse(harness.projected.get(target)!)).toMatchObject({
+        detail: "file-import: source data failed validation",
+        mitigation: "block_coaching",
+      });
+    } finally {
+      await harness.store.close();
+    }
+  });
+
+  it("maps every classifier code and uses the fixed no-classifier fallback", async () => {
+    const harness = await governedHarness();
+    try {
+      const mappings = [
+        ["authorization", "source authorization failed"],
+        ["unavailable", "source temporarily unavailable"],
+        ["invalid-data", "source data failed validation"],
+        ["budget-exhausted", "source synchronization budget exhausted"],
+      ] as const;
+      for (const [code, detail] of mappings) {
+        const report = await runCoachSync(
+          {
+            env: {},
+            sources: [
+              {
+                source: syncSource("intervals-icu"),
+                async run() {
+                  throw new Error("synthetic private failure");
+                },
+                classifyFailure: () => ({ severity: "warn", code }),
+              },
+            ],
+          },
+          harness.dependencies,
+        );
+        expect(report.sources[0]).toMatchObject({ severity: "warn", message: detail });
+      }
+      const fallback = await runCoachSync(
+        {
+          env: {},
+          sources: [
+            {
+              source: syncSource("file-import"),
+              async run() {
+                throw new Error("synthetic private fallback");
+              },
+            },
+          ],
+        },
+        harness.dependencies,
+      );
+      expect(fallback.sources[0]).toMatchObject({
+        severity: "block",
+        message: "source synchronization failed",
+      });
+    } finally {
+      await harness.store.close();
+    }
+  });
+
+  it("contains classifier throws and adversarial descriptors without stringifying private values", async () => {
+    const harness = await governedHarness();
+    const fragments = [
+      "/synthetic/private.fit",
+      "https://invalid.test/?token=value",
+      "Bearer synthetic-secret",
+      '{"athlete":"synthetic-private"}',
+    ];
+    let stringified = 0;
+    let accessorReads = 0;
+    const privateThrown = {
+      toString() {
+        stringified += 1;
+        return fragments[0];
+      },
+    };
+    const accessor = Object.create(null) as Record<string, unknown>;
+    Object.defineProperties(accessor, {
+      severity: {
+        enumerable: true,
+        get: () => {
+          accessorReads += 1;
+          return "block";
+        },
+      },
+      code: { enumerable: true, value: "authorization" },
+    });
+    const nonEnumerable = { severity: "block" } as Record<string, unknown>;
+    Object.defineProperty(nonEnumerable, "code", { enumerable: false, value: "authorization" });
+    const symbol = Symbol("private");
+    const classifiers = [
+      () => {
+        throw privateThrown;
+      },
+      () => ({ severity: "block", code: "authorization", detail: fragments[0] }),
+      () => ({ severity: "block", code: fragments[1] }),
+      () => ({ severity: "block", code: "authorization", token: fragments[2] }),
+      () => ({ severity: "block", code: "authorization", athlete: { value: fragments[3] } }),
+      () => accessor,
+      () => ({ severity: "block", code: "authorization", [symbol]: fragments[0] }),
+      () => nonEnumerable,
+    ];
+    try {
+      for (const classifier of classifiers) {
+        const report = await runCoachSync(
+          {
+            env: {},
+            sources: [
+              {
+                source: syncSource("intervals-icu"),
+                async run() {
+                  throw privateThrown;
+                },
+                classifyFailure: classifier as never,
+              },
+            ],
+          },
+          harness.dependencies,
+        );
+        expect(report.sources[0]).toMatchObject({
+          severity: "block",
+          message: "source failure classification failed",
+        });
+        for (const fragment of fragments) expect(JSON.stringify(report)).not.toContain(fragment);
+      }
+      expect(stringified).toBe(0);
+      expect(accessorReads).toBe(0);
+    } finally {
+      await harness.store.close();
+    }
+  });
+
+  it("stops immediately when durable failure persistence fails", async () => {
+    const store = syntheticStore();
+    store.run = async (sql) => {
+      if (sql.startsWith("INSERT INTO sync_failure")) throw new Error("persistence unavailable");
+    };
+    let laterCalls = 0;
+    const withWriter: CoachSyncDependencies["withWriter"] = async (_env, operation) =>
+      operation({ home: syntheticHome(), store });
+    await expect(
+      runCoachSync(
+        {
+          env: {},
+          sources: [
+            {
+              source: syncSource("intervals-icu"),
+              async run() {
+                throw new Error("source failed");
+              },
+            },
+            {
+              source: syncSource("file-import"),
+              async run() {
+                laterCalls += 1;
+              },
+            },
+          ],
+        },
+        syncDependencies(withWriter, async () => importReport),
+      ),
+    ).rejects.toThrow("persistence unavailable");
+    expect(laterCalls).toBe(0);
+  });
+
+  it("propagates projection failure while preserving the committed SQLite row", async () => {
+    const harness = await governedHarness({
+      fileSystem: {
+        async writeFile() {
+          throw new Error("projection unavailable");
+        },
+      },
+    });
+    try {
+      await expect(
+        runCoachSync(
+          {
+            env: {},
+            sources: [
+              {
+                source: syncSource("intervals-icu"),
+                async run() {
+                  throw new Error("source failed");
+                },
+              },
+            ],
+          },
+          harness.dependencies,
+        ),
+      ).rejects.toThrow("projection unavailable");
+      expect(await createSyncFailureRepository(harness.store).readAll()).toEqual([
+        {
+          source: "intervals-icu",
+          severity: "block",
+          detail: "source synchronization failed",
+          logical_ordinal: 1_000,
+        },
+      ]);
+    } finally {
+      await harness.store.close();
+    }
+  });
+
+  it("constructs one hydration runtime inside the writer and imports validated bytes once", async () => {
+    const bytes = Uint8Array.of(1, 2, 3);
+    const artifact = {
+      kind: "raw-file",
+      source: "file-import",
+      lane: "file-discovery",
+      externalId: null,
+      archiveInstant: { epochSeconds: 1_000 },
+      archive: { address: "a".repeat(64), relPath: "synthetic.fit", deduped: false },
+      file: { input_path: "/synthetic/pre-2015.fit", bytes, ext: "fit" } satisfies ImportArtifact,
+    } as const;
+    const checkpoint = { kind: "checkpoint" as const, watermark: fileHydrationInput().watermark };
+    const importBatchWithReport = vi.fn<NodeImportRuntime["importBatchWithReport"]>(
+      async () => importReport,
+    );
+    const runtime = { importBatchWithReport } as unknown as NodeImportRuntime;
+    let writerActive = false;
+    let runtimeCalls = 0;
+    const harness = await governedHarness();
+    const originalWriter = harness.dependencies.withWriter;
+    const dependencies: CoachSyncDependencies = {
+      ...harness.dependencies,
+      async withWriter(env, operation) {
+        return originalWriter(env, async (context) => {
+          writerActive = true;
+          try {
+            return await operation(context);
+          } finally {
+            writerActive = false;
+          }
+        });
+      },
+      createImportRuntime() {
+        expect(writerActive).toBe(true);
+        runtimeCalls += 1;
+        return runtime;
+      },
+    };
+    try {
+      const noOp = await runCoachSync(
+        {
+          env: {},
+          sources: [
+            {
+              source: hydrationSource([checkpoint]),
+              fileHydration: fileHydrationInput(),
+            },
+          ],
+        },
+        dependencies,
+      );
+      expect(noOp.sources[0]?.status).toBe("completed");
+      expect(importBatchWithReport).not.toHaveBeenCalled();
+      expect(runtimeCalls).toBe(1);
+
+      const imported = await runCoachSync(
+        {
+          env: {},
+          sources: [
+            {
+              source: hydrationSource([
+                { kind: "batch", artifacts: [artifact] as never },
+                checkpoint,
+              ]),
+              fileHydration: fileHydrationInput(),
+            },
+          ],
+        },
+        dependencies,
+      );
+      expect(imported.sources[0]?.status).toBe("completed");
+      expect(runtimeCalls).toBe(2);
+      expect(importBatchWithReport).toHaveBeenCalledTimes(1);
+      const batch = importBatchWithReport.mock.calls[0]![0];
+      expect(batch.platform_records).toEqual([]);
+      expect(batch.files).toHaveLength(1);
+      expect(batch.files[0]!.bytes).toBe(bytes);
+      expect(batch.files[0]!.input_path).toBe(artifact.file.input_path);
+    } finally {
+      await harness.store.close();
+    }
+  });
+
+  it("contains hydration failure and still runs the explicit manual import after all outcomes", async () => {
+    let manualCalls = 0;
+    const harness = await governedHarness({
+      importFiles: async () => {
+        manualCalls += 1;
+        return importReport;
+      },
+      createImportRuntime: () =>
+        ({
+          async importBatchWithReport() {
+            throw new Error("/synthetic/private-source.fit?token=value");
+          },
+        }) as unknown as NodeImportRuntime,
+    });
+    try {
+      const before = await dumpStore(harness.store);
+      const checkpoint = { kind: "checkpoint" as const, watermark: fileHydrationInput().watermark };
+      const report = await runCoachSync(
+        {
+          env: {},
+          sources: [
+            {
+              source: hydrationSource([{ kind: "batch", artifacts: [] }, checkpoint]),
+              fileHydration: fileHydrationInput(),
+            },
+          ],
+          importPaths: ["/synthetic/manual.fit"],
+        },
+        harness.dependencies,
+      );
+      expect(report.sources).toEqual([
+        {
+          source_id: "file-import",
+          status: "failed",
+          severity: "block",
+          message: "source synchronization failed",
+        },
+      ]);
+      expect(report.import_report).toBe(importReport);
+      expect(manualCalls).toBe(1);
+      expect(JSON.stringify(report)).not.toContain("private-source");
+      expect(await dumpStore(harness.store)).toBe(before);
+      expect(await createSyncFailureRepository(harness.store).readAll()).toHaveLength(1);
+    } finally {
+      await harness.store.close();
     }
   });
 });

--- a/packages/core/CONTEXT.md
+++ b/packages/core/CONTEXT.md
@@ -86,6 +86,8 @@ Each subsystem's behavior under failure is a recorded fail-open / fail-closed de
 - **Sender-allowlist lock contention** → **CLOSED**. Access control is a security boundary; deny on uncertainty rather than admit an unverified sender.
 - **Secrets backend unavailable** → **CLOSED**. No credential ⇒ no upstream call; fail loudly rather than proceed with an empty/guessed secret.
 
+Per-source synchronization failures are authoritative in SQLite and project to the Reference layer's `data/error_state.json` compatibility signal after each committed source-state change and before the next source run. A blocking failure uses `block_coaching`; a warning uses `warn_only`; recovery clears only the successful source. Failure details come from a closed project-owned vocabulary and never include exception text, URLs, paths, credentials, or athlete payloads. `force_resync` remains schema-declared and unwired.
+
 ## Reference test substrate (property-based + golden fixtures)
 
 Property-based generators wrapping the Reference input schemas live at

--- a/packages/kernel-node/package.json
+++ b/packages/kernel-node/package.json
@@ -11,6 +11,7 @@
     "./lock": "./dist/lock/index.js",
     "./store-export": "./dist/store-export/index.js",
     "./home": "./dist/home/index.js",
+    "./filesystem": "./dist/filesystem/index.js",
     "./ingest": "./dist/ingest/index.js",
     "./coach-dev": "./dist/coach-dev.js"
   },

--- a/packages/kernel-node/src/filesystem/index.ts
+++ b/packages/kernel-node/src/filesystem/index.ts
@@ -1,0 +1,110 @@
+import { randomBytes as nodeRandomBytes } from "node:crypto";
+import { dirname } from "node:path";
+import { chmod, mkdir, open, readFile, readdir, rename, stat, unlink } from "node:fs/promises";
+import type { FileSystemPort } from "@enduragent/kernel/ports";
+import { createFitDecoder } from "../ingest/fit-decoder.js";
+import { parseXmlBytes } from "../ingest/xml-file.js";
+
+export function nodeFileSystem(): FileSystemPort {
+  return {
+    async readFile(path) {
+      return new Uint8Array(await readFile(path));
+    },
+    async readTextFile(path) {
+      return readFile(path, "utf8");
+    },
+    async writeFile(path, data, options) {
+      const temporary = `${path}.tmp.${nodeRandomBytes(4).toString("hex")}`;
+      let handle: Awaited<ReturnType<typeof open>> | null = null;
+      try {
+        await mkdir(dirname(path), { recursive: true });
+        handle = await open(temporary, "w", options?.mode ?? 0o600);
+        await handle.writeFile(typeof data === "string" ? data : Buffer.from(data));
+        await handle.sync();
+        await handle.close();
+        handle = null;
+        await rename(temporary, path);
+      } catch (error) {
+        if (handle !== null) {
+          try {
+            await handle.close();
+          } catch {}
+        }
+        try {
+          await unlink(temporary);
+        } catch {}
+        throw error;
+      }
+    },
+    async rename(from, to) {
+      await rename(from, to);
+    },
+    async mkdir(path, options) {
+      await mkdir(path, { recursive: options?.recursive ?? false });
+    },
+    async list(path) {
+      return (await readdir(path, { withFileTypes: true })).map((entry) => ({
+        name: entry.name,
+        kind: entry.isFile()
+          ? ("file" as const)
+          : entry.isDirectory()
+            ? ("directory" as const)
+            : ("other" as const),
+      }));
+    },
+    async stat(path) {
+      try {
+        const value = await stat(path);
+        return {
+          kind: value.isFile() ? "file" : value.isDirectory() ? "directory" : "other",
+          size: value.size,
+          mtimeMs: value.mtimeMs,
+        };
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+        throw error;
+      }
+    },
+  };
+}
+
+export async function ensurePrivateDirectory(path: string): Promise<void> {
+  await mkdir(path, { recursive: true, mode: 0o700 });
+  await chmod(path, 0o700);
+}
+
+export async function removeFileIfPresent(path: string): Promise<void> {
+  try {
+    await unlink(path);
+  } catch (error) {
+    if (typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT") {
+      return;
+    }
+    throw error;
+  }
+}
+
+export function createNodeFileStructuralValidator(): (input: {
+  readonly bytes: Uint8Array;
+  readonly ext: "fit" | "tcx" | "gpx";
+}) => Promise<void> {
+  return async (input) => {
+    try {
+      if (
+        input === null ||
+        typeof input !== "object" ||
+        !(input.bytes instanceof Uint8Array) ||
+        (input.ext !== "fit" && input.ext !== "tcx" && input.ext !== "gpx")
+      ) {
+        throw new TypeError("file failed structural validation");
+      }
+      if (input.ext === "fit") {
+        await createFitDecoder().decode(input.bytes);
+      } else if (parseXmlBytes(input.bytes, input.ext).quarantine !== null) {
+        throw new TypeError("file failed structural validation");
+      }
+    } catch {
+      throw new TypeError("file failed structural validation");
+    }
+  };
+}

--- a/packages/kernel-node/src/ingest/import-files.ts
+++ b/packages/kernel-node/src/ingest/import-files.ts
@@ -1,6 +1,5 @@
-import { randomBytes as nodeRandomBytes } from "node:crypto";
-import { extname, dirname } from "node:path";
-import { mkdir, open, readFile, readdir, rename, stat, unlink } from "node:fs/promises";
+import { extname } from "node:path";
+import { readFile } from "node:fs/promises";
 import { createArchiveManager } from "../archive/manager.js";
 import {
   FitSourceError,
@@ -29,7 +28,8 @@ import {
 } from "@enduragent/kernel/ingest";
 import type { ArchiveManager } from "@enduragent/kernel/archive";
 import { H, sortKeys, type MigratorStore, type SqlStore } from "@enduragent/kernel/store";
-import type { CryptoPort, FileSystemPort } from "@enduragent/kernel/ports";
+import type { CryptoPort } from "@enduragent/kernel/ports";
+import { nodeFileSystem } from "../filesystem/index.js";
 import { createFitDecoder } from "./fit-decoder.js";
 import { prepareXmlFile } from "./xml-file.js";
 
@@ -39,7 +39,7 @@ export interface ImportFilesOptions {
   readonly store: SqlStore & Pick<MigratorStore, "transaction">;
 }
 
-interface NodeImportCompositionOptions {
+export interface NodeImportRuntimeOptions {
   readonly archiveDir: string;
   readonly store: SqlStore & Pick<MigratorStore, "transaction">;
 }
@@ -87,44 +87,6 @@ function nodeCrypto(): CryptoPort {
       return new Uint8Array(await subtle.decrypt({ name: "AES-GCM", iv: toBufferSource(params.nonce),
         additionalData: params.additionalData === undefined ? undefined : toBufferSource(params.additionalData) },
         await key(params.key, "decrypt"), toBufferSource(params.ciphertext)));
-    },
-  };
-}
-
-function nodeFileSystem(): FileSystemPort {
-  return {
-    async readFile(path) { return new Uint8Array(await readFile(path)); },
-    async readTextFile(path) { return readFile(path, "utf8"); },
-    async writeFile(path, data, options) {
-      const temporary = `${path}.tmp.${nodeRandomBytes(4).toString("hex")}`;
-      let handle: Awaited<ReturnType<typeof open>> | null = null;
-      try {
-        await mkdir(dirname(path), { recursive: true });
-        handle = await open(temporary, "w", options?.mode ?? 0o600);
-        await handle.writeFile(typeof data === "string" ? data : Buffer.from(data));
-        await handle.sync();
-        await handle.close(); handle = null;
-        await rename(temporary, path);
-      } catch (error) {
-        if (handle !== null) try { await handle.close(); } catch {}
-        try { await unlink(temporary); } catch {}
-        throw error;
-      }
-    },
-    async rename(from, to) { await rename(from, to); },
-    async mkdir(path, options) { await mkdir(path, { recursive: options?.recursive ?? false }); },
-    async list(path) {
-      return (await readdir(path, { withFileTypes: true })).map((entry) => ({ name: entry.name,
-        kind: entry.isFile() ? "file" as const : entry.isDirectory() ? "directory" as const : "other" as const }));
-    },
-    async stat(path) {
-      try {
-        const value = await stat(path);
-        return { kind: value.isFile() ? "file" : value.isDirectory() ? "directory" : "other", size: value.size, mtimeMs: value.mtimeMs };
-      } catch (error) {
-        if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
-        throw error;
-      }
     },
   };
 }
@@ -225,7 +187,7 @@ async function prepareFit(
 }
 
 function createImportReportDeps(
-  options: NodeImportCompositionOptions,
+  options: NodeImportRuntimeOptions,
 ): ImportReportDeps {
   const crypto = nodeCrypto();
   const fs = nodeFileSystem();
@@ -261,7 +223,23 @@ export async function importFilesWithReport(options: ImportFilesOptions): Promis
   return createNodeImportRuntime(options).importBatchWithReport({ files, platform_records: [] });
 }
 
-export function createNodeImportRuntime(options: NodeImportCompositionOptions): NodeImportRuntime {
+export function createNodeImportRuntime(options: NodeImportRuntimeOptions): NodeImportRuntime {
+  if (
+    options === null ||
+    typeof options !== "object" ||
+    typeof options.archiveDir !== "string" ||
+    options.archiveDir.length === 0 ||
+    options.store === null ||
+    typeof options.store !== "object" ||
+    typeof options.store.exec !== "function" ||
+    typeof options.store.run !== "function" ||
+    typeof options.store.get !== "function" ||
+    typeof options.store.all !== "function" ||
+    typeof options.store.close !== "function" ||
+    typeof options.store.transaction !== "function"
+  ) {
+    throw new TypeError("invalid node import runtime options");
+  }
   const deps = createImportReportDeps(options);
   return Object.freeze({
     archive: deps.archive,

--- a/packages/kernel-node/tests/coach-dev-import.test.ts
+++ b/packages/kernel-node/tests/coach-dev-import.test.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
-import { access, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { access, copyFile, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
@@ -168,10 +169,19 @@ let acquireWriteLock: typeof import("@enduragent/kernel-node/lock").acquireWrite
 let resolveAthleteHome: typeof import("@enduragent/kernel-node/home").resolveAthleteHome;
 let openSqliteStorage: typeof import("@enduragent/kernel-node/sqlite").openSqliteStorage;
 let dumpStore: typeof import("@enduragent/kernel/store").dumpStore;
+let DUMP_TABLES: typeof import("@enduragent/kernel/store").DUMP_TABLES;
 let MIGRATIONS: typeof import("@enduragent/kernel/store/migrations").MIGRATIONS;
 let WriteLockContentionError: typeof import("@enduragent/kernel-node/lock").WriteLockContentionError;
 let LOCKFILE_NAME: typeof import("@enduragent/kernel-node/lock").LOCKFILE_NAME;
 let PORT_FILE_NAME: typeof import("@enduragent/kernel-node/lock").PORT_FILE_NAME;
+let runCoachSync: typeof import("../../coach/src/sync.js").runCoachSync;
+let createFileImportSource: typeof import("../../sync-file-import/src/index.js").createFileImportSource;
+let createNodeFileStructuralValidator: typeof import("@enduragent/kernel-node/filesystem").createNodeFileStructuralValidator;
+let ensurePrivateDirectory: typeof import("@enduragent/kernel-node/filesystem").ensurePrivateDirectory;
+let nodeFileSystem: typeof import("@enduragent/kernel-node/filesystem").nodeFileSystem;
+let removeFileIfPresent: typeof import("@enduragent/kernel-node/filesystem").removeFileIfPresent;
+let createNodeImportRuntime: typeof import("@enduragent/kernel-node/ingest").createNodeImportRuntime;
+let createArchiveManager: typeof import("@enduragent/kernel-node/archive").createArchiveManager;
 
 const tempDirs = new Set<string>();
 let realHome: string | undefined;
@@ -186,6 +196,7 @@ beforeAll(async () => {
     "packages/kernel-node/dist/lock/index.js",
     "packages/kernel-node/dist/sqlite.js",
     "packages/kernel-node/dist/ingest/index.js",
+    "packages/kernel-node/dist/filesystem/index.js",
   ];
   try {
     await Promise.all(requiredDist.map((path) => access(path)));
@@ -193,12 +204,28 @@ beforeAll(async () => {
     throw new Error("required public dist precondition missing");
   }
 
-  const [homeModule, lockModule, sqliteModule, storeModule, migrationModule] = await Promise.all([
+  const [
+    homeModule,
+    lockModule,
+    sqliteModule,
+    storeModule,
+    migrationModule,
+    coachModule,
+    fileSourceModule,
+    filesystemModule,
+    ingestModule,
+    archiveModule,
+  ] = await Promise.all([
     import("@enduragent/kernel-node/home"),
     import("@enduragent/kernel-node/lock"),
     import("@enduragent/kernel-node/sqlite"),
     import("@enduragent/kernel/store"),
     import("@enduragent/kernel/store/migrations"),
+    import("../../coach/src/sync.js"),
+    import("../../sync-file-import/src/index.js"),
+    import("@enduragent/kernel-node/filesystem"),
+    import("@enduragent/kernel-node/ingest"),
+    import("@enduragent/kernel-node/archive"),
   ]);
   resolveAthleteHome = homeModule.resolveAthleteHome;
   acquireWriteLock = lockModule.acquireWriteLock;
@@ -207,7 +234,16 @@ beforeAll(async () => {
   PORT_FILE_NAME = lockModule.PORT_FILE_NAME;
   openSqliteStorage = sqliteModule.openSqliteStorage;
   dumpStore = storeModule.dumpStore;
+  DUMP_TABLES = storeModule.DUMP_TABLES;
   MIGRATIONS = migrationModule.MIGRATIONS;
+  runCoachSync = coachModule.runCoachSync;
+  createFileImportSource = fileSourceModule.createFileImportSource;
+  createNodeFileStructuralValidator = filesystemModule.createNodeFileStructuralValidator;
+  ensurePrivateDirectory = filesystemModule.ensurePrivateDirectory;
+  nodeFileSystem = filesystemModule.nodeFileSystem;
+  removeFileIfPresent = filesystemModule.removeFileIfPresent;
+  createNodeImportRuntime = ingestModule.createNodeImportRuntime;
+  createArchiveManager = archiveModule.createArchiveManager;
   ({ runCoachDev, runCoachDevWriter } = await import("../src/cli/coach-dev.js"));
 });
 
@@ -474,7 +510,7 @@ describe("coach-dev import --report", () => {
     expect(await exists(databasePath)).toBe(true);
     const store = openSqliteStorage(databasePath);
     try {
-      expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 6 });
+      expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 7 });
       expect(await store.get("SELECT count(*) AS c FROM raw_file")).toEqual({ c: 1 });
       expect(await store.get("SELECT count(*) AS c FROM source_record")).toEqual({ c: 0 });
       expect(
@@ -930,4 +966,292 @@ describe("coach-dev import --report", () => {
       expect(output).not.toContain(privateValue);
     }
   });
+
+  it("hydrates one manual or quiescent watch burst from validated bytes through one governed writer call", async () => {
+    const fixtureNames = [
+      "brick-cycling.fit",
+      "fallback-cycling.tcx",
+      "fallback-cycling.gpx",
+    ] as const;
+    const crypto = {
+      async sha256(data: Uint8Array) {
+        return new Uint8Array(createHash("sha256").update(data).digest());
+      },
+      async randomBytes() {
+        throw new Error("unused");
+      },
+      async pbkdf2() {
+        throw new Error("unused");
+      },
+      async aesGcmEncrypt() {
+        throw new Error("unused");
+      },
+      async aesGcmDecrypt() {
+        throw new Error("unused");
+      },
+    } as Parameters<typeof createArchiveManager>[0]["crypto"];
+
+    for (const mode of ["manual", "watch"] as const) {
+      const root = await freshHome(`coach-hydration-${mode}-`);
+      const home = resolveAthleteHome({ ENDURAGENT_HOME: root });
+      const inputDir = join(root, "synthetic-inputs");
+      await mkdir(inputDir, { recursive: true });
+      const paths: string[] = [];
+      const expected = new Map<string, Uint8Array>();
+      for (const name of fixtureNames) {
+        const from = resolve(`packages/kernel-node/tests/fixtures/ingest/${name}`);
+        const to = join(inputDir, name);
+        await copyFile(from, to);
+        paths.push(to);
+        expected.set(to, new Uint8Array(await readFile(to)));
+      }
+
+      await ensurePrivateDirectory(home.storeDir);
+      const store = openSqliteStorage(join(home.storeDir, "store.db"));
+      const { runMigrations } = await import("@enduragent/kernel/store");
+      await runMigrations(store, MIGRATIONS);
+      const baseFs = nodeFileSystem();
+      let readCalls = 0;
+      const sourceFs = {
+        ...baseFs,
+        async readFile(path: string) {
+          readCalls += 1;
+          return baseFs.readFile(path);
+        },
+      };
+      let archived = 0;
+      const archive = createArchiveManager({ archiveRoot: home.archiveDir, crypto, fs: baseFs });
+      const validateBase = createNodeFileStructuralValidator();
+      const validated: string[] = [];
+      const source = createFileImportSource(
+        mode === "manual"
+          ? { manualPaths: paths, watchRoots: [] }
+          : { manualPaths: [], watchRoots: [inputDir] },
+        {
+          fs: sourceFs,
+          clock: {
+            setTimeout(callback, delayMs) {
+              return globalThis.setTimeout(callback, delayMs);
+            },
+            clearTimeout(handle) {
+              globalThis.clearTimeout(handle as ReturnType<typeof setTimeout>);
+            },
+          },
+          crypto,
+          archive: {
+            async writeArtifact(bytes, ext, instant) {
+              const result = await archive.writeArtifact(bytes, ext, instant);
+              archived += 1;
+              return result;
+            },
+          },
+          async validate(input) {
+            await validateBase(input);
+            validated.push(input.ext);
+          },
+        },
+      );
+      let writerCalls = 0;
+      let writerActive = false;
+      let runtimeCalls = 0;
+      let importerCalls = 0;
+      let readsAtImport = -1;
+      const dependencies: Parameters<typeof runCoachSync>[1] = {
+        async withWriter(_env, operation) {
+          writerCalls += 1;
+          writerActive = true;
+          try {
+            return await operation({ home, store });
+          } finally {
+            writerActive = false;
+          }
+        },
+        async importFiles() {
+          throw new Error("manual path importer must not run");
+        },
+        fileSystem: baseFs,
+        ensurePrivateDirectory,
+        removeFileIfPresent,
+        nowEpochMs: () => 1_000,
+        createImportRuntime(options) {
+          expect(writerActive).toBe(true);
+          runtimeCalls += 1;
+          const runtime = createNodeImportRuntime(options);
+          return {
+            archive: runtime.archive,
+            async importBatchWithReport(batch) {
+              importerCalls += 1;
+              expect(archived).toBe(3);
+              readsAtImport = readCalls;
+              for (const file of batch.files) {
+                expect(file.bytes).toEqual(expected.get(file.input_path));
+              }
+              await Promise.all(paths.map((path) => rm(path)));
+              return runtime.importBatchWithReport(batch);
+            },
+          };
+        },
+      };
+      const controller = new AbortController();
+      const report = await runCoachSync(
+        {
+          env: {},
+          sources: [
+            {
+              source,
+              fileHydration: {
+                watermark: { source: "file-import", lane: "file-discovery", value: null },
+                budget: {
+                  signal: controller.signal,
+                  clock: { monotonicNow: () => performance.now() },
+                  deadlineMonotonicMs: performance.now() + 15_000,
+                  perRequestTimeoutMs: 1_000,
+                  maxRequests: 1,
+                  maxArtifacts: 10,
+                },
+              },
+            },
+          ],
+        },
+        dependencies,
+      );
+      expect(report.sources[0]).toMatchObject({ status: "completed", message: null });
+      expect(writerCalls).toBe(1);
+      expect(runtimeCalls).toBe(1);
+      expect(importerCalls).toBe(1);
+      expect(readCalls).toBe(readsAtImport);
+      expect(validated.sort()).toEqual(["fit", "gpx", "tcx"]);
+      await store.close();
+    }
+  }, 30_000);
+
+  it("file hydration failure is path-free and leaves canonical ingest state unchanged", async () => {
+    const root = await freshHome("coach-hydration-failure-");
+    const home = resolveAthleteHome({ ENDURAGENT_HOME: root });
+    const privatePath = join(root, "synthetic-private.fit");
+    await copyFile(
+      resolve("packages/kernel-node/tests/fixtures/ingest/brick-cycling.fit"),
+      privatePath,
+    );
+    await ensurePrivateDirectory(home.storeDir);
+    const store = openSqliteStorage(join(home.storeDir, "store.db"));
+    const { runMigrations } = await import("@enduragent/kernel/store");
+    await runMigrations(store, MIGRATIONS);
+    const baseFs = nodeFileSystem();
+    const crypto = {
+      async sha256(data: Uint8Array) {
+        return new Uint8Array(createHash("sha256").update(data).digest());
+      },
+      async randomBytes() {
+        throw new Error("unused");
+      },
+      async pbkdf2() {
+        throw new Error("unused");
+      },
+      async aesGcmEncrypt() {
+        throw new Error("unused");
+      },
+      async aesGcmDecrypt() {
+        throw new Error("unused");
+      },
+    } as Parameters<typeof createArchiveManager>[0]["crypto"];
+    const archive = createArchiveManager({ archiveRoot: home.archiveDir, crypto, fs: baseFs });
+    let validationCalls = 0;
+    const validate = createNodeFileStructuralValidator();
+    const source = createFileImportSource(
+      { manualPaths: [privatePath], watchRoots: [] },
+      {
+        fs: baseFs,
+        clock: {
+          setTimeout(callback, delayMs) {
+            return globalThis.setTimeout(callback, delayMs);
+          },
+          clearTimeout(handle) {
+            globalThis.clearTimeout(handle as ReturnType<typeof setTimeout>);
+          },
+        },
+        crypto,
+        archive,
+        async validate(input) {
+          await validate(input);
+          validationCalls += 1;
+        },
+      },
+    );
+    const counts = async () =>
+      Object.fromEntries(
+        await Promise.all(
+          DUMP_TABLES.map(async ({ table }) => [
+            table,
+            Number((await store.get(`SELECT count(*) c FROM ${table}`))?.c),
+          ]),
+        ),
+      );
+    const beforeDump = await dumpStore(store);
+    const beforeCounts = await counts();
+    const report = await runCoachSync(
+      {
+        env: {},
+        sources: [
+          {
+            source,
+            fileHydration: {
+              watermark: { source: "file-import", lane: "file-discovery", value: null },
+              budget: {
+                signal: new AbortController().signal,
+                clock: { monotonicNow: () => performance.now() },
+                deadlineMonotonicMs: performance.now() + 10_000,
+                perRequestTimeoutMs: 1_000,
+                maxRequests: 1,
+                maxArtifacts: 1,
+              },
+            },
+          },
+        ],
+      },
+      {
+        async withWriter(_env, operation) {
+          return operation({ home, store });
+        },
+        async importFiles() {
+          throw new Error("unexpected manual import");
+        },
+        fileSystem: baseFs,
+        ensurePrivateDirectory,
+        removeFileIfPresent,
+        nowEpochMs: () => 1_000,
+        createImportRuntime() {
+          return {
+            async importBatchWithReport() {
+              await rm(privatePath);
+              throw new Error(`${privatePath}?token=synthetic-private`);
+            },
+          } as unknown as ReturnType<typeof createNodeImportRuntime>;
+        },
+      },
+    );
+    expect(validationCalls).toBe(1);
+    expect(report.sources).toEqual([
+      {
+        source_id: "file-import",
+        status: "failed",
+        severity: "block",
+        message: "source synchronization failed",
+      },
+    ]);
+    expect(await dumpStore(store)).toBe(beforeDump);
+    expect(await counts()).toEqual(beforeCounts);
+    expect(await store.all("SELECT source,severity,detail FROM sync_failure")).toEqual([
+      {
+        source: "file-import",
+        severity: "block",
+        detail: "source synchronization failed",
+      },
+    ]);
+    const publicValues = `${JSON.stringify(report)}${await readFile(join(home.root, "data", "error_state.json"), "utf8")}`;
+    expect(publicValues).not.toContain(root);
+    expect(publicValues).not.toContain("token=");
+    expect(publicValues).not.toContain("cause");
+    await store.close();
+  }, 15_000);
 });

--- a/packages/kernel-node/tests/filesystem.test.ts
+++ b/packages/kernel-node/tests/filesystem.test.ts
@@ -1,0 +1,65 @@
+import { mkdtemp, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  ensurePrivateDirectory,
+  nodeFileSystem,
+  removeFileIfPresent,
+} from "../src/filesystem/index.js";
+
+describe("Node filesystem adapter", () => {
+  const roots: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+  });
+
+  async function root(): Promise<string> {
+    const value = await mkdtemp(join(tmpdir(), "filesystem-adapter-"));
+    roots.push(value);
+    return value;
+  }
+
+  it("exports the one atomic Node filesystem adapter", async () => {
+    expect(typeof nodeFileSystem).toBe("function");
+    const files = [
+      resolve("packages/kernel-node/src/filesystem/index.ts"),
+      resolve("packages/kernel-node/src/ingest/import-files.ts"),
+    ];
+    const definitions = (await Promise.all(files.map((path) => readFile(path, "utf8")))).flatMap(
+      (source) => source.match(/function nodeFileSystem\s*\(/g) ?? [],
+    );
+    expect(definitions).toHaveLength(1);
+  });
+
+  it("publishes only after file sync and rename", async () => {
+    const directory = await root();
+    const target = join(directory, "nested", "state.json");
+    await nodeFileSystem().writeFile(target, "first\n", { mode: 0o600 });
+    expect(await readFile(target, "utf8")).toBe("first\n");
+    expect(await readdir(join(directory, "nested"))).toEqual(["state.json"]);
+    await writeFile(target, "old\n");
+    await nodeFileSystem().writeFile(target, "replacement\n", { mode: 0o600 });
+    expect(await readFile(target, "utf8")).toBe("replacement\n");
+    expect((await stat(target)).mode & 0o777).toBe(0o600);
+  });
+
+  it("secures private directories to mode 0700", async () => {
+    const directory = join(await root(), "private");
+    await ensurePrivateDirectory(directory);
+    expect((await stat(directory)).mode & 0o777).toBe(0o700);
+    await ensurePrivateDirectory(directory);
+    expect((await stat(directory)).mode & 0o777).toBe(0o700);
+  });
+
+  it("removes absent files idempotently and rethrows other errors", async () => {
+    const directory = await root();
+    const target = join(directory, "state.json");
+    await removeFileIfPresent(target);
+    await writeFile(target, "value");
+    await removeFileIfPresent(target);
+    await expect(readFile(target)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(removeFileIfPresent(directory)).rejects.not.toMatchObject({ code: "ENOENT" });
+  });
+});

--- a/packages/kernel-node/tests/inv2-ingest-order.test.ts
+++ b/packages/kernel-node/tests/inv2-ingest-order.test.ts
@@ -8,7 +8,7 @@ import { canonicalPick, createMaterializeClusterInTransaction, importArtifactsWi
 import type { ArchiveManager } from "@enduragent/kernel/archive";
 import { dumpStore, runMigrations, sortKeys } from "@enduragent/kernel/store";
 import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
-import { importFilesWithReport } from "../src/ingest/import-files.js";
+import { createNodeImportRuntime, importFilesWithReport } from "../src/ingest/import-files.js";
 import { openSqliteStorage } from "../src/sqlite/index.js";
 
 const roots = new Set<string>();
@@ -66,6 +66,20 @@ function differentSerialFitPaths(root: string): readonly [string, string] {
 }
 const hashKey = async (fields: readonly (string | number)[]) => createHash("sha256").update(fields.join("\u001f")).digest("hex");
 
+function matchingPlatformArtifact(): PlatformImportArtifact {
+  const start = Date.parse("1998-07-04T20:53:20Z") / 1_000;
+  const activity = { id: "synthetic-api-presentation", start, duration: 2_400, distance: 23_990 };
+  const concerns: Record<string, ConcernValue> = {
+    "session.sport": "cycling", "session.start_utc": start, "session.local_date_key": 19980704,
+    "session.elapsed_s": 2_400, "session.distance_m": 23_990, "session.is_transition": false,
+    "session.summary_json": JSON.stringify(sortKeys(activity)),
+    "stream:time": { timestamps: [start, start + 2_400], values: [start, start + 2_400] },
+  };
+  return { source: "intervals-icu", activity_id: "synthetic-api-presentation", activity,
+    dedup: { sport_family: "cycling", is_transition: false, start_utc: start, duration_s: 2_400, distance_m: 23_990 },
+    concerns, raw_snapshot_address: null, raw_snapshot_rel_path: null };
+}
+
 describe("real SQLite dedup ordering", () => {
   it("[PR05-SQL-001] makes forward and reverse paths converge to identical state", async () => {
     const left = await fresh(), right = await fresh();
@@ -97,6 +111,34 @@ describe("real SQLite dedup ordering", () => {
       const confirmed = await importFilesWithReport({ inputPaths: [serialPaths[0]], archiveDir: serials.archiveDir, store: serials.store });
       expect(confirmed.clusters).toHaveLength(1); expect(confirmed.clusters[0]).toMatchObject({ members: serialMembers, edge_tiers: ["confirmation"] });
     } finally { await fitXml.store.close(); await serials.store.close(); }
+  });
+  it("SQL API plus FIT with a present serial merges without confirmation", async () => {
+    const apiFirst = await fresh(), fitFirst = await fresh();
+    try {
+      const fitPath = path("brick-cycling.fit"), platform = matchingPlatformArtifact();
+      const leftRuntime = createNodeImportRuntime({ archiveDir: apiFirst.archiveDir, store: apiFirst.store });
+      await leftRuntime.importBatchWithReport({ files: [], platform_records: [platform] });
+      const left = await importFilesWithReport({ inputPaths: [fitPath], archiveDir: apiFirst.archiveDir, store: apiFirst.store });
+      await importFilesWithReport({ inputPaths: [fitPath], archiveDir: fitFirst.archiveDir, store: fitFirst.store });
+      const rightRuntime = createNodeImportRuntime({ archiveDir: fitFirst.archiveDir, store: fitFirst.store });
+      const right = await rightRuntime.importBatchWithReport({ files: [], platform_records: [platform] });
+      for (const [value, report] of [[apiFirst, left], [fitFirst, right]] as const) {
+        expect(report.confirm_queue).toEqual([]); expect(report.clusters).toHaveLength(1);
+        expect(report.clusters[0]).toMatchObject({ edge_tiers: ["tier3"] });
+        expect(report.clusters[0]!.members).toHaveLength(2);
+        expect(new Set(report.clusters[0]!.canonical_sources.map((source) => source.rank))).toEqual(new Set([400]));
+        expect(await value.store.get("SELECT count(*) c FROM source_record")).toEqual({ c: 1 });
+        expect(await value.store.get("SELECT count(*) c FROM workout")).toEqual({ c: 1 });
+        expect(await value.store.get("SELECT count(*) c FROM session")).toEqual({ c: 1 });
+      }
+      expect(await dumpStore(apiFirst.store)).toBe(await dumpStore(fitFirst.store));
+      const before = await dumpStore(apiFirst.store);
+      const replayApi = await leftRuntime.importBatchWithReport({ files: [], platform_records: [platform] });
+      const replayFit = await importFilesWithReport({ inputPaths: [fitPath], archiveDir: apiFirst.archiveDir, store: apiFirst.store });
+      expect(replayApi.inserts).toEqual({ raw_file: 0, source_record: 0 });
+      expect(replayFit.inserts).toEqual({ raw_file: 0, source_record: 0 });
+      expect(await dumpStore(apiFirst.store)).toBe(before);
+    } finally { await apiFirst.store.close(); await fitFirst.store.close(); }
   });
   it("[PR05-SQL-003] replans the full archive when a matching file arrives later", async () => {
     const value = await fresh();

--- a/packages/kernel-node/tests/migrator-e2e.test.ts
+++ b/packages/kernel-node/tests/migrator-e2e.test.ts
@@ -28,9 +28,9 @@ describe("migrator end-to-end over node:sqlite", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
-  it("applies the full migration list and advances user_version to 6", async () => {
+  it("applies the full migration list and advances user_version to 7", async () => {
     await runMigrations(store, MIGRATIONS);
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 6 });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 7 });
 
     const tables = await store.all("SELECT name FROM sqlite_master WHERE type='table'");
     const names = new Set(tables.map((r) => r.name as string));
@@ -49,7 +49,7 @@ describe("migrator end-to-end over node:sqlite", () => {
     ).toEqual({ name: "idx_dedup_confirmation_effective" });
     expect(await store.get("PRAGMA journal_mode")).toEqual({ journal_mode: "wal" });
     await runMigrations(store, MIGRATIONS);
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 6 });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 7 });
   });
 
   it("produces a deterministic INV-2 dump of a fixed state", async () => {
@@ -78,11 +78,11 @@ describe("migrator end-to-end over node:sqlite", () => {
     expect(await dumpStore(store)).toBe(dump);
   });
 
-  it("upgrades a version-1-on-disk store to version 6", async () => {
+  it("upgrades a version-1-on-disk store to version 7", async () => {
     await runMigrations(store, [MIGRATIONS[0]!]);
     expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 1 });
     await runMigrations(store, MIGRATIONS);
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 6 });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 7 });
     expect(await store.get("SELECT singleton,ingest_version FROM ingest_metadata")).toEqual({
       singleton: 1,
       ingest_version: 0,
@@ -102,8 +102,8 @@ describe("migrator end-to-end over node:sqlite", () => {
     );
 
     const result = await runMigrations(store, MIGRATIONS);
-    expect(result).toEqual({ fromVersion: 4, toVersion: 6, applied: [5, 6] });
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 6 });
+    expect(result).toEqual({ fromVersion: 4, toVersion: 7, applied: [5, 6, 7] });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 7 });
     expect(
       await store.get("SELECT revision_id,source_record_id FROM source_record_revision"),
     ).toEqual({
@@ -134,6 +134,36 @@ describe("migrator end-to-end over node:sqlite", () => {
     expect(objects).toEqual([]);
     const columns = await store.all("PRAGMA table_info(source_record)");
     expect(columns.some((row) => row.name === "artifact_key")).toBe(false);
+  });
+
+  it("rolls back an injected migration-007 failure to version 6 without a partial table", async () => {
+    await runMigrations(store, MIGRATIONS.slice(0, 6));
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 6 });
+    const broken007 = {
+      ...MIGRATIONS[6]!,
+      sql: `${MIGRATIONS[6]!.sql}\nINSERT INTO missing_table VALUES (1);`,
+    };
+    await expect(runMigrations(store, [...MIGRATIONS.slice(0, 6), broken007])).rejects.toThrow();
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 6 });
+    expect(
+      await store.get("SELECT name FROM sqlite_master WHERE type='table' AND name='sync_failure'"),
+    ).toBeUndefined();
+  });
+
+  it("upgrades a version-6 store to version 7 and reruns as a no-op", async () => {
+    await runMigrations(store, MIGRATIONS.slice(0, 6));
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 6 });
+    const result = await runMigrations(store, MIGRATIONS);
+    expect(result).toEqual({ fromVersion: 6, toVersion: 7, applied: [7] });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 7 });
+    expect(
+      await store.get("SELECT name FROM sqlite_master WHERE type='table' AND name='sync_failure'"),
+    ).toEqual({ name: "sync_failure" });
+    await expect(runMigrations(store, MIGRATIONS)).resolves.toEqual({
+      fromVersion: 7,
+      toVersion: 7,
+      applied: [],
+    });
   });
 
   it("shares one real transaction for exec + version bump (atomic rollback)", async () => {

--- a/packages/kernel-node/tests/sync-failure-repository.test.ts
+++ b/packages/kernel-node/tests/sync-failure-repository.test.ts
@@ -1,0 +1,246 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  DERIVED_TABLES,
+  DUMP_TABLES,
+  SYNC_FAILURE_DETAILS,
+  createSyncFailureRepository,
+  dumpStore,
+  nextSyncFailureOrdinal,
+  reduceSyncFailures,
+  runMigrations,
+  type MigratorStore,
+  type SqlStore,
+  type SyncFailureRow,
+} from "@enduragent/kernel/store";
+import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
+import { openSqliteStorage } from "../src/sqlite/index.js";
+
+const block = (source: SyncFailureRow["source"], logical_ordinal = 1): SyncFailureRow => ({
+  source,
+  severity: "block",
+  detail: "source synchronization failed",
+  logical_ordinal,
+});
+
+describe("sync failure repository", () => {
+  let store: (SqlStore & MigratorStore) | undefined;
+
+  afterEach(async () => {
+    await store?.close();
+    store = undefined;
+  });
+
+  async function fresh(): Promise<SqlStore & MigratorStore> {
+    store = openSqliteStorage(":memory:");
+    await runMigrations(store, MIGRATIONS);
+    return store;
+  }
+
+  it("accepts only the two governed sources and closed details", async () => {
+    const value = await fresh();
+    const repository = createSyncFailureRepository(value);
+    for (const [index, detail] of SYNC_FAILURE_DETAILS.entries()) {
+      await repository.upsert({
+        source: index % 2 === 0 ? "intervals-icu" : "file-import",
+        severity: index % 2 === 0 ? "warn" : "block",
+        detail,
+        logical_ordinal: index,
+      });
+    }
+    expect(await repository.readAll()).toHaveLength(2);
+  });
+
+  it("rejects every invalid severity detail and ordinal before SQL", async () => {
+    const run = vi.fn<SqlStore["run"]>();
+    const repository = createSyncFailureRepository({ run } as unknown as SqlStore);
+    for (const row of [
+      { ...block("file-import"), source: "other" },
+      { ...block("file-import"), severity: "fatal" },
+      { ...block("file-import"), detail: "/synthetic/private.fit" },
+      { ...block("file-import"), logical_ordinal: -1 },
+      { ...block("file-import"), logical_ordinal: 8_640_000_000_000_001 },
+      { ...block("file-import"), logical_ordinal: 1.5 },
+      { ...block("file-import"), extra: "field" },
+    ]) {
+      await expect(repository.upsert(row as never)).rejects.toThrow(
+        new TypeError("invalid sync failure row"),
+      );
+    }
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it("round trips one frozen row per source in binary source order", async () => {
+    const repository = createSyncFailureRepository(await fresh());
+    await repository.upsert(block("intervals-icu", 2));
+    await repository.upsert({ ...block("file-import", 1), severity: "warn" });
+    const rows = await repository.readAll();
+    expect(rows.map((row) => row.source)).toEqual(["file-import", "intervals-icu"]);
+    expect(Object.isFrozen(rows)).toBe(true);
+    expect(rows.every(Object.isFrozen)).toBe(true);
+  });
+
+  it("upserts only the addressed source", async () => {
+    const repository = createSyncFailureRepository(await fresh());
+    await repository.upsert(block("intervals-icu", 1));
+    await repository.upsert({ ...block("file-import", 2), severity: "warn" });
+    await repository.upsert({
+      ...block("intervals-icu", 3),
+      detail: "source temporarily unavailable",
+    });
+    expect(await repository.readAll()).toEqual([
+      { ...block("file-import", 2), severity: "warn" },
+      { ...block("intervals-icu", 3), detail: "source temporarily unavailable" },
+    ]);
+  });
+
+  it("clears only the addressed source and reports absence", async () => {
+    const repository = createSyncFailureRepository(await fresh());
+    await repository.upsert(block("file-import"));
+    await repository.upsert(block("intervals-icu"));
+    await expect(repository.clear("file-import")).resolves.toBe(true);
+    await expect(repository.clear("file-import")).resolves.toBe(false);
+    expect((await repository.readAll()).map((row) => row.source)).toEqual(["intervals-icu"]);
+    await expect(repository.clear("other" as never)).rejects.toThrow(
+      new TypeError("invalid sync failure row"),
+    );
+  });
+
+  it("rejects invalid selected rows", async () => {
+    const invalidRows = [
+      {
+        source: "other",
+        severity: "block",
+        detail: "source synchronization failed",
+        logical_ordinal: 1,
+      },
+      {
+        source: "file-import",
+        severity: "fatal",
+        detail: "source synchronization failed",
+        logical_ordinal: 1,
+      },
+      {
+        source: "file-import",
+        severity: "block",
+        detail: "https://invalid.test/?token=value",
+        logical_ordinal: 1,
+      },
+      {
+        source: "file-import",
+        severity: "block",
+        detail: "source synchronization failed",
+        logical_ordinal: -1,
+      },
+    ];
+    for (const row of invalidRows) {
+      const repository = createSyncFailureRepository({
+        async all() {
+          return [row];
+        },
+      } as unknown as SqlStore);
+      await expect(repository.readAll()).rejects.toThrow(new TypeError("invalid sync failure row"));
+    }
+  });
+
+  it("computes epoch-or-successor ordinal", () => {
+    expect(nextSyncFailureOrdinal([], 10)).toBe(10);
+    expect(nextSyncFailureOrdinal([block("file-import", 10)], 5)).toBe(11);
+    expect(nextSyncFailureOrdinal([block("file-import", 10)], 20)).toBe(20);
+    expect(() => nextSyncFailureOrdinal([], -1)).toThrow(new TypeError("invalid sync failure row"));
+  });
+
+  it("rejects duplicate source rows", () => {
+    expect(() => reduceSyncFailures([block("file-import", 1), block("file-import", 2)])).toThrow(
+      new TypeError("duplicate sync failure source"),
+    );
+  });
+
+  it("rejects ordinal exhaustion", () => {
+    expect(() => nextSyncFailureOrdinal([block("file-import", 8_640_000_000_000_000)], 1)).toThrow(
+      new RangeError("sync failure ordinal exhausted"),
+    );
+  });
+
+  it("reduces block before warn independent of insertion order", () => {
+    const warning = { ...block("file-import", 100), severity: "warn" as const };
+    const blocked = block("intervals-icu", 1);
+    expect(reduceSyncFailures([warning, blocked])?.detail).toBe(
+      "intervals-icu: source synchronization failed",
+    );
+    expect(reduceSyncFailures([blocked, warning])).toEqual(reduceSyncFailures([warning, blocked]));
+  });
+
+  it("reduces newer ordinal within one severity", () => {
+    expect(reduceSyncFailures([block("file-import", 1), block("intervals-icu", 2)])?.detail).toBe(
+      "intervals-icu: source synchronization failed",
+    );
+  });
+
+  it("reduces lexical source on an exact tie", () => {
+    expect(reduceSyncFailures([block("intervals-icu", 1), block("file-import", 1)])?.detail).toBe(
+      "file-import: source synchronization failed",
+    );
+  });
+
+  it("maps exact version timestamp mitigation and closed detail", () => {
+    expect(
+      reduceSyncFailures([
+        {
+          source: "file-import",
+          severity: "warn",
+          detail: "source data failed validation",
+          logical_ordinal: 1_000,
+        },
+      ]),
+    ).toEqual({
+      schema_version: "1",
+      step: "source_failure",
+      detail: "file-import: source data failed validation",
+      ts: "1970-01-01T00:00:01.000Z",
+      mitigation: "warn_only",
+    });
+  });
+
+  it("returns null for no failures", () => {
+    expect(reduceSyncFailures([])).toBeNull();
+  });
+
+  it("fresh migration accepts valid rows and rejects adversarial rows", async () => {
+    const value = await fresh();
+    await expect(
+      value.run("INSERT INTO sync_failure VALUES(?,?,?,?)", [
+        "file-import",
+        "block",
+        "source synchronization failed",
+        0,
+      ]),
+    ).resolves.toBeUndefined();
+    await value.run("DELETE FROM sync_failure");
+    for (const [source, detail] of [
+      ["file-import", "/synthetic/private.fit"],
+      ["file-import", "https://invalid.test/?token=value"],
+      ["file-import", "bearer-token-shaped-value"],
+      ["file-import", '{"athlete":"synthetic"}'],
+      ["file-import", "source synchronization failed\nprivate"],
+      ["unknown", "source synchronization failed"],
+      ["file-import", "unknown detail"],
+    ] as const) {
+      await expect(
+        value.run("INSERT INTO sync_failure VALUES(?,?,?,?)", [source, "block", detail, 1]),
+      ).rejects.toThrow();
+    }
+  });
+
+  it("upgrades a migration-six store without changing canonical dump ownership", async () => {
+    store = openSqliteStorage(":memory:");
+    await runMigrations(store, MIGRATIONS.slice(0, 6));
+    const before = await dumpStore(store);
+    await runMigrations(store, MIGRATIONS);
+    expect(await dumpStore(store)).toBe(before);
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 7 });
+    expect(DUMP_TABLES).toHaveLength(32);
+    expect(DERIVED_TABLES).toHaveLength(12);
+    expect(DUMP_TABLES.map(({ table }) => table)).not.toContain("sync_failure");
+    expect(DERIVED_TABLES).not.toContain("sync_failure");
+  });
+});

--- a/packages/kernel-node/tsup.config.ts
+++ b/packages/kernel-node/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: { index: "src/index.ts", sqlite: "src/sqlite/index.ts", "archive/index": "src/archive/index.ts", "lock/index": "src/lock/index.ts", "store-export/index": "src/store-export/index.ts", "home/index": "src/home/index.ts", "ingest/index": "src/ingest/index.ts", "coach-dev": "src/cli/coach-dev.ts" },
+  entry: { index: "src/index.ts", sqlite: "src/sqlite/index.ts", "archive/index": "src/archive/index.ts", "lock/index": "src/lock/index.ts", "store-export/index": "src/store-export/index.ts", "home/index": "src/home/index.ts", "filesystem/index": "src/filesystem/index.ts", "ingest/index": "src/ingest/index.ts", "coach-dev": "src/cli/coach-dev.ts" },
   format: ["esm"],
   dts: true,
   sourcemap: true,

--- a/packages/kernel/src/ingest/dedup.ts
+++ b/packages/kernel/src/ingest/dedup.ts
@@ -347,10 +347,14 @@ export function planDedup(
     const effectiveRow = effective.get(key);
     const differing = accepted.filter((pair) => pair.left.source_kind === "fit"
       && pair.right.source_kind === "fit"
+      && pair.left.file_id_serial !== null
+      && pair.right.file_id_serial !== null
       && pair.left.file_id_serial !== pair.right.file_id_serial);
     for (const pair of accepted) {
       const needsTwoFitSerialConfirmation = pair.left.source_kind === "fit"
         && pair.right.source_kind === "fit"
+        && pair.left.file_id_serial !== null
+        && pair.right.file_id_serial !== null
         && pair.left.file_id_serial !== pair.right.file_id_serial;
       if (!needsTwoFitSerialConfirmation) {
         selected.push({ a: pair.left, b: pair.right, tier: "tier3", diagnostic: pair.eval.diagnostic });
@@ -633,9 +637,11 @@ export function evaluateIncrementalDedupPairs(
     }
     const effectiveRow = effective.get(key);
     const differing = accepted.filter((pair) => pair.left.source_kind === "fit" && pair.right.source_kind === "fit"
+      && pair.left.file_id_serial !== null && pair.right.file_id_serial !== null
       && pair.left.file_id_serial !== pair.right.file_id_serial);
     for (const pair of accepted) {
       const needsTwoFitSerialConfirmation = pair.left.source_kind === "fit" && pair.right.source_kind === "fit"
+        && pair.left.file_id_serial !== null && pair.right.file_id_serial !== null
         && pair.left.file_id_serial !== pair.right.file_id_serial;
       if (!needsTwoFitSerialConfirmation) selected.push({ a: pair.left, b: pair.right, tier: "tier3", diagnostic: pair.eval.diagnostic });
       else if (effectiveRow?.verdict === "merge") selected.push({ a: pair.left, b: pair.right, tier: "confirmation", diagnostic: pair.eval.diagnostic });
@@ -717,6 +723,7 @@ export function planDedupFromPairStates(
       expanded_b: { start_utc: b.start_utc - 600, end_utc: b.start_utc + b.duration_s + 600 },
     }))) throw new Error("dedup pair cache disagreement");
     const needsTwoFitSerialConfirmation = a.source_kind === "fit" && b.source_kind === "fit"
+      && a.file_id_serial !== null && b.file_id_serial !== null
       && a.file_id_serial !== b.file_id_serial;
     if (state.confirm_queue !== null && (!evaluation.strict || !needsTwoFitSerialConfirmation
       || effective.get(pairKey(a.member_id, b.member_id))?.verdict === "merge"

--- a/packages/kernel/src/store/index.ts
+++ b/packages/kernel/src/store/index.ts
@@ -10,3 +10,4 @@ export * from "./activity-repository.js";
 export * from "./derived-key.js";
 export * from "./sync-source.js";
 export * from "./sync-state-repository.js";
+export * from "./sync-failure-repository.js";

--- a/packages/kernel/src/store/migrations/007_sync_failure.sql
+++ b/packages/kernel/src/store/migrations/007_sync_failure.sql
@@ -1,0 +1,16 @@
+CREATE TABLE sync_failure (
+  source TEXT PRIMARY KEY
+    CHECK (source IN ('intervals-icu','file-import')),
+  severity TEXT NOT NULL CHECK (severity IN ('warn','block')),
+  detail TEXT NOT NULL
+    CHECK (detail IN (
+      'source authorization failed',
+      'source temporarily unavailable',
+      'source data failed validation',
+      'source synchronization budget exhausted',
+      'source synchronization failed',
+      'source failure classification failed'
+    )),
+  logical_ordinal INTEGER NOT NULL
+    CHECK (logical_ordinal BETWEEN 0 AND 8640000000000000)
+) STRICT;

--- a/packages/kernel/src/store/migrations/index.ts
+++ b/packages/kernel/src/store/migrations/index.ts
@@ -4,6 +4,7 @@ import dedup003 from "./003_dedup_confirmation.sql";
 import fixerSettings004 from "./004_repair_fixer_settings.sql";
 import syncState005 from "./005_sync_state.sql";
 import incremental006 from "./006_incremental_ingest.sql";
+import syncFailure007 from "./007_sync_failure.sql";
 
 export interface Migration {
   /** Ascending schema version this migration advances the store to. */
@@ -25,4 +26,5 @@ export const MIGRATIONS: readonly Migration[] = [
   { version: 4, name: "004_repair_fixer_settings", sql: fixerSettings004 },
   { version: 5, name: "005_sync_state", sql: syncState005 },
   { version: 6, name: "006_incremental_ingest", sql: incremental006 },
+  { version: 7, name: "007_sync_failure", sql: syncFailure007 },
 ];

--- a/packages/kernel/src/store/sync-failure-repository.ts
+++ b/packages/kernel/src/store/sync-failure-repository.ts
@@ -1,0 +1,179 @@
+import type { Row, SqlStore } from "./ports.js";
+
+export const SYNC_FAILURE_SEVERITIES = Object.freeze(["warn", "block"] as const);
+export type SyncFailureSeverity = (typeof SYNC_FAILURE_SEVERITIES)[number];
+
+export const SYNC_FAILURE_DETAILS = Object.freeze([
+  "source authorization failed",
+  "source temporarily unavailable",
+  "source data failed validation",
+  "source synchronization budget exhausted",
+  "source synchronization failed",
+  "source failure classification failed",
+] as const);
+export type SyncFailureDetail = (typeof SYNC_FAILURE_DETAILS)[number];
+
+export interface SyncFailureRow {
+  readonly source: "intervals-icu" | "file-import";
+  readonly severity: SyncFailureSeverity;
+  readonly detail: SyncFailureDetail;
+  readonly logical_ordinal: number;
+}
+
+export interface SyncFailureCompatibilitySignal {
+  readonly schema_version: "1";
+  readonly step: "source_failure";
+  readonly detail: string;
+  readonly ts: string;
+  readonly mitigation: "block_coaching" | "warn_only";
+}
+
+export interface SyncFailureRepository {
+  readAll(): Promise<readonly SyncFailureRow[]>;
+  upsert(row: SyncFailureRow): Promise<void>;
+  clear(source: SyncFailureRow["source"]): Promise<boolean>;
+}
+
+const MAX_ORDINAL = 8_640_000_000_000_000;
+const ROW_KEYS = ["source", "severity", "detail", "logical_ordinal"] as const;
+
+function isSource(value: unknown): value is SyncFailureRow["source"] {
+  return value === "intervals-icu" || value === "file-import";
+}
+
+function isSeverity(value: unknown): value is SyncFailureSeverity {
+  return value === "warn" || value === "block";
+}
+
+function isDetail(value: unknown): value is SyncFailureDetail {
+  return (SYNC_FAILURE_DETAILS as readonly unknown[]).includes(value);
+}
+
+function isOrdinal(value: unknown): value is number {
+  return Number.isSafeInteger(value) && (value as number) >= 0 && (value as number) <= MAX_ORDINAL;
+}
+
+function validateRow(value: unknown): asserts value is SyncFailureRow {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new TypeError("invalid sync failure row");
+  }
+  const prototype = Object.getPrototypeOf(value);
+  const keys = Reflect.ownKeys(value);
+  const descriptors = Object.fromEntries(
+    ROW_KEYS.map((key) => [key, Object.getOwnPropertyDescriptor(value, key)]),
+  ) as Record<(typeof ROW_KEYS)[number], PropertyDescriptor | undefined>;
+  if (
+    (prototype !== Object.prototype && prototype !== null) ||
+    keys.length !== ROW_KEYS.length ||
+    !ROW_KEYS.every((key) => keys.includes(key)) ||
+    ROW_KEYS.some((key) =>
+      descriptors[key] === undefined ||
+      !("value" in descriptors[key]) ||
+      !descriptors[key].enumerable
+    ) ||
+    !isSource(descriptors.source!.value) ||
+    !isSeverity(descriptors.severity!.value) ||
+    !isDetail(descriptors.detail!.value) ||
+    !isOrdinal(descriptors.logical_ordinal!.value)
+  ) {
+    throw new TypeError("invalid sync failure row");
+  }
+}
+
+function validatedRows(values: unknown): SyncFailureRow[] {
+  if (!Array.isArray(values)) throw new TypeError("invalid sync failure row");
+  const result: SyncFailureRow[] = [];
+  const sources = new Set<SyncFailureRow["source"]>();
+  for (const value of values) {
+    validateRow(value);
+    if (sources.has(value.source)) throw new TypeError("duplicate sync failure source");
+    sources.add(value.source);
+    result.push(value);
+  }
+  return result;
+}
+
+export function nextSyncFailureOrdinal(
+  rows: readonly SyncFailureRow[],
+  observedEpochMs: number,
+): number {
+  const valid = validatedRows(rows);
+  if (!isOrdinal(observedEpochMs)) throw new TypeError("invalid sync failure row");
+  let maximum = -1;
+  for (const row of valid) maximum = Math.max(maximum, row.logical_ordinal);
+  if (maximum === MAX_ORDINAL) throw new RangeError("sync failure ordinal exhausted");
+  return Math.max(observedEpochMs, maximum + 1);
+}
+
+export function reduceSyncFailures(
+  rows: readonly SyncFailureRow[],
+): SyncFailureCompatibilitySignal | null {
+  const valid = validatedRows(rows);
+  if (valid.length === 0) return null;
+  const selected = [...valid].sort(
+    (left, right) =>
+      (left.severity === right.severity ? 0 : left.severity === "block" ? -1 : 1) ||
+      right.logical_ordinal - left.logical_ordinal ||
+      (left.source < right.source ? -1 : left.source > right.source ? 1 : 0),
+  )[0]!;
+  return Object.freeze({
+    schema_version: "1",
+    step: "source_failure",
+    detail: `${selected.source}: ${selected.detail}`,
+    ts: new Date(selected.logical_ordinal).toISOString(),
+    mitigation: selected.severity === "block" ? "block_coaching" : "warn_only",
+  });
+}
+
+const READ_ALL_SQL = `SELECT source,severity,detail,logical_ordinal
+FROM sync_failure
+ORDER BY source COLLATE BINARY ASC`;
+
+const UPSERT_SQL = `INSERT INTO sync_failure (source,severity,detail,logical_ordinal)
+VALUES (?,?,?,?)
+ON CONFLICT(source) DO UPDATE SET
+  severity=excluded.severity,
+  detail=excluded.detail,
+  logical_ordinal=excluded.logical_ordinal`;
+
+const CLEAR_SQL = "DELETE FROM sync_failure WHERE source=? RETURNING source";
+
+export function createSyncFailureRepository(store: SqlStore): SyncFailureRepository {
+  return Object.freeze({
+    async readAll(): Promise<readonly SyncFailureRow[]> {
+      const rows = validatedRows(await store.all(READ_ALL_SQL));
+      return Object.freeze(
+        rows.map((row) =>
+          Object.freeze({
+            source: row.source,
+            severity: row.severity,
+            detail: row.detail,
+            logical_ordinal: row.logical_ordinal,
+          }),
+        ),
+      );
+    },
+    async upsert(row: SyncFailureRow): Promise<void> {
+      validateRow(row);
+      await store.run(UPSERT_SQL, [row.source, row.severity, row.detail, row.logical_ordinal]);
+    },
+    async clear(source: SyncFailureRow["source"]): Promise<boolean> {
+      if (!isSource(source)) throw new TypeError("invalid sync failure row");
+      const row: Row | undefined = await store.get(CLEAR_SQL, [source]);
+      if (row === undefined) return false;
+      const keys = Reflect.ownKeys(row);
+      const descriptor = Object.getOwnPropertyDescriptor(row, "source");
+      if (
+        keys.length !== 1 ||
+        keys[0] !== "source" ||
+        descriptor === undefined ||
+        !("value" in descriptor) ||
+        !descriptor.enumerable ||
+        descriptor.value !== source
+      ) {
+        throw new TypeError("invalid sync failure row");
+      }
+      return true;
+    },
+  });
+}

--- a/packages/kernel/tests/dedup.test.ts
+++ b/packages/kernel/tests/dedup.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
   DEFAULT_TIER3_THRESHOLDS,
+  dedupPairStates,
   planDedup,
+  planDedupFromPairStates,
   ratioDelta,
   type Candidate,
   type DedupCandidateSummary,
@@ -77,9 +79,17 @@ describe("dedup tiers", () => {
   });
   it("[PR05-GRAPH-002] queues different and present-absent serial pairs", () => {
     expect(plan([presentation(1), presentation(2, { file_id_serial: 8 })]).confirm_queue).toHaveLength(1);
-    expect(plan([presentation(1), presentation(2, { file_id_serial: null })]).confirm_queue).toHaveLength(1);
+    const presentAbsent = plan([presentation(1), presentation(2, { file_id_serial: null })]);
+    expect(presentAbsent.confirm_queue).toEqual([]);
+    expect(presentAbsent.sessions[0]!.edge_tiers).toEqual(["tier3"]);
   });
-  it("merges API plus FIT at Tier 3 without consulting serial confirmation", () => {
+  it("rehydrates a present-absent serial pair from cached pair states without disagreement", () => {
+    const values = [presentation(1), presentation(2, { file_id_serial: null })];
+    const oracle = plan(values);
+    expect(oracle.confirm_queue).toEqual([]);
+    expect(planDedupFromPairStates(values.map((value) => value.candidate), values.map((value) => value.summary), [], dedupPairStates(oracle))).toEqual(oracle);
+  });
+  it("API plus FIT with a present serial merges without confirmation", () => {
     const fit = presentation(1, { file_id_manufacturer: null, file_id_serial: 7 });
     const platformMember = member(2);
     const platformId = `platform_api:${platformMember}:0:0`;
@@ -91,10 +101,10 @@ describe("dedup tiers", () => {
         source_kind: "platform_api" as const, file_id_manufacturer: null, file_id_serial: null,
         file_id_time_created_utc: null },
     };
-    const result = plan([api, fit], [confirmation(api.summary.member_id, fit.summary.member_id, "distinct")]);
+    const result = plan([api, fit]);
     expect(result.confirm_queue).toEqual([]);
-    expect(result.sessions).toHaveLength(2);
-    expect(plan([api, fit]).sessions[0]!.edge_tiers).toEqual(["tier3"]);
+    expect(result.sessions).toHaveLength(1);
+    expect(result.sessions[0]!.edge_tiers).toEqual(["tier3"]);
   });
   it("[PR05-GRAPH-003] enforces a component-wide authored distinct verdict", () => {
     const a = presentation(1), b = presentation(2), c = presentation(3);

--- a/packages/kernel/tests/migrations-ddl.test.ts
+++ b/packages/kernel/tests/migrations-ddl.test.ts
@@ -3,6 +3,7 @@ import { DatabaseSync } from "node:sqlite";
 import { afterEach, describe, expect, it } from "vitest";
 import { MIGRATIONS } from "../src/store/migrations/index.js";
 import { DERIVED_TABLES, DUMP_TABLES } from "../src/store/dump.js";
+import { MIXED_AUTHORED_TABLES, PURE_AUTHORED_TABLES } from "../src/store/export/ports.js";
 
 const EXPECTED_TABLES = [
   "athlete",
@@ -42,6 +43,7 @@ const EXPECTED_FULL_TABLES = [
   "ingest_dedup_pair_state",
   "ingest_dedup_session_state",
   "ingest_cluster_state",
+  "sync_failure",
 ];
 const MIGRATION_002 = `ALTER TABLE swim_length ADD COLUMN distance_m REAL;
 
@@ -144,6 +146,7 @@ function openFull(): DatabaseSync {
   next.exec(MIGRATIONS[3]!.sql);
   next.exec(MIGRATIONS[4]!.sql);
   next.exec(MIGRATIONS[5]!.sql);
+  next.exec(MIGRATIONS[6]!.sql);
   return next;
 }
 
@@ -161,6 +164,7 @@ describe("001_init migration", () => {
       { version: 4, name: "004_repair_fixer_settings" },
       { version: 5, name: "005_sync_state" },
       { version: 6, name: "006_incremental_ingest" },
+      { version: 7, name: "007_sync_failure" },
     ]);
     expect(typeof MIGRATIONS[0].sql).toBe("string");
     expect(MIGRATIONS[0].sql).toContain("CREATE TABLE athlete");
@@ -252,7 +256,7 @@ describe("001_init migration", () => {
     expect(MIGRATIONS[2]!.sql).toBe(MIGRATION_003);
   });
 
-  it("applies 001 through 005 with exactly twenty-nine tables and no foreign-key violations", () => {
+  it("applies 001 through 007 with exactly thirty-five tables and no foreign-key violations", () => {
     db = openFull();
     const names = (
       db
@@ -262,6 +266,7 @@ describe("001_init migration", () => {
       .map((row) => row.name)
       .sort();
     expect(names).toEqual([...EXPECTED_FULL_TABLES].sort());
+    expect(names).toHaveLength(35);
     expect(db.prepare("PRAGMA foreign_key_check").all()).toEqual([]);
   });
 
@@ -745,12 +750,14 @@ describe("001_init migration", () => {
     expect(DUMP_TABLES).toHaveLength(32);
     expect(DUMP_TABLES.map(({ table }) => String(table))).not.toContain("source_watermark");
     expect(DUMP_TABLES.map(({ table }) => String(table))).not.toContain("sync_operation");
+    expect(DUMP_TABLES.map(({ table }) => String(table))).not.toContain("sync_failure");
     for (const table of [
       "source_artifact",
       "source_record_revision",
       "source_record_current",
       "source_watermark",
       "sync_operation",
+      "sync_failure",
     ]) {
       expect(DERIVED_TABLES).not.toContain(table);
     }
@@ -761,11 +768,35 @@ describe("001_init migration", () => {
     expect(createHash("sha256").update(MIGRATIONS[5]!.sql).digest("hex")).toBe(
       "85cd423bdb7a12facbc061865035801f22c177388fe111a4e5979face9368574",
     );
-    expect(db.prepare("SELECT singleton,initialized FROM ingest_incremental_state").get()).toEqual({ singleton: 1, initialized: 0 });
+    expect(db.prepare("SELECT singleton,initialized FROM ingest_incremental_state").get()).toEqual({
+      singleton: 1,
+      initialized: 0,
+    });
     expect(() => db!.prepare("UPDATE ingest_incremental_state SET initialized=2").run()).toThrow();
-    expect(() => db!.prepare(`INSERT INTO ingest_candidate_index (
+    expect(() =>
+      db!
+        .prepare(`INSERT INTO ingest_candidate_index (
 candidate_id,artifact_kind,artifact_id,member_id,source_kind,source_session_seq,sport_family,is_transition,start_utc,duration_s,candidate_summary_json
-) VALUES ('c','raw_file','a','not-a-hash','fit',0,'cycling',0,0,0,'{}')`).run()).toThrow();
+) VALUES ('c','raw_file','a','not-a-hash','fit',0,'cycling',0,0,0,'{}')`)
+        .run(),
+    ).toThrow();
     expect(db.prepare("PRAGMA foreign_key_check").all()).toEqual([]);
+  });
+
+  it("creates the exact strict operational sync failure schema", () => {
+    db = openFull();
+    expect(createHash("sha256").update(MIGRATIONS[6]!.sql).digest("hex")).toBe(
+      "064cefa015c772c3f642c35d253316905fa41f32ab87396bcaf585f25ead9eec",
+    );
+    const tables = db.prepare("PRAGMA table_list").all() as Array<{
+      name: string;
+      strict: number;
+    }>;
+    expect(tables.find((row) => row.name === "sync_failure")?.strict).toBe(1);
+    expect(db.prepare("PRAGMA foreign_key_list(sync_failure)").all()).toEqual([]);
+    expect(DUMP_TABLES).toHaveLength(32);
+    expect(DERIVED_TABLES).toHaveLength(12);
+    expect(PURE_AUTHORED_TABLES).not.toContain("sync_failure");
+    expect(MIXED_AUTHORED_TABLES).not.toContain("sync_failure");
   });
 });


### PR DESCRIPTION
## Summary

- persist one privacy-safe failure state per synchronization source
- repair the Reference layer compatibility signal from authoritative store state
- merge mixed API and original FIT presentations without FIT-only serial confirmation
- preserve the existing atomic filesystem and governed writer paths

## Verification

- `pnpm check` — passed
- `pnpm test` — zero failed tests and no new skips
- targeted 19-file ingest and Reference-layer suite — passed
- mixed API and original FIT private audit — Tier-3 cluster, empty confirmation queue, zero input inserts, stable canonical dump
- fresh read-only migration audit — nine checks passed

## Release note

No shipping binary consumes this private composition change.
