### PR TITLE
fix(coach): attribute writer failures across bundle copies and carry causes

### DIFF
--- a/.changeset/coach-writer-error-attribution.md
+++ b/.changeset/coach-writer-error-attribution.md
@@ -1,0 +1,6 @@
+---
+"@enduragent/kernel-node": patch
+"@enduragent/coach": patch
+---
+
+Attribute coach store writer failures precisely: recognize write-lock contention across bundle copies by error name, and carry the underlying failure cause through the writer result onto the thrown error.

--- a/packages/coach/src/runtime.ts
+++ b/packages/coach/src/runtime.ts
@@ -12,11 +12,12 @@ export class CoachStoreWriterError extends Error {
   readonly code: CoachStoreWriterErrorCode;
   readonly stage: CoachDevWriterFailureStage | null;
 
-  constructor(code: CoachStoreWriterErrorCode, stage: CoachDevWriterFailureStage | null) {
+  constructor(code: CoachStoreWriterErrorCode, stage: CoachDevWriterFailureStage | null, options?: ErrorOptions) {
     super(
       code === "writer-lock-held"
         ? "coach store writer is already active"
         : `coach store writer failed at ${stage}`,
+      options,
     );
     this.name = "CoachStoreWriterError";
     this.code = code;
@@ -52,5 +53,5 @@ export async function withCoachStoreWriter<T>(
   if (result.status === "writer-lock-held") {
     throw new CoachStoreWriterError("writer-lock-held", null);
   }
-  throw new CoachStoreWriterError("writer-failed", result.stage);
+  throw new CoachStoreWriterError("writer-failed", result.stage, result.cause === undefined ? undefined : { cause: result.cause });
 }

--- a/packages/coach/tests/coach-sync.test.ts
+++ b/packages/coach/tests/coach-sync.test.ts
@@ -257,6 +257,24 @@ describe("coach sync composition", () => {
     }
   });
 
+  it("preserves the writer failure cause on the thrown error", async () => {
+    const operationFailure = new Error("private operation failure detail");
+    const failedWriter = async <T>(): Promise<CoachDevWriterResult<T>> => ({
+      status: "failed",
+      stage: "invoke operation",
+      cause: operationFailure,
+    });
+    let caught: unknown;
+    try {
+      await withCoachStoreWriter({}, async () => null, { runWriter: failedWriter });
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(CoachStoreWriterError);
+    expect((caught as CoachStoreWriterError).cause).toBe(operationFailure);
+    expect(JSON.stringify(caught)).not.toContain("private operation failure detail");
+  });
+
   it("validates the complete request before acquiring the writer", async () => {
     let writerCalls = 0;
     let sourceCalls = 0;

--- a/packages/kernel-node/src/cli/coach-dev.ts
+++ b/packages/kernel-node/src/cli/coach-dev.ts
@@ -60,7 +60,7 @@ export interface RunCoachDevWriterOptions<T> {
 export type CoachDevWriterResult<T> =
   | { readonly status: "completed"; readonly value: T }
   | { readonly status: "writer-lock-held" }
-  | { readonly status: "failed"; readonly stage: CoachDevWriterFailureStage };
+  | { readonly status: "failed"; readonly stage: CoachDevWriterFailureStage; readonly cause?: unknown };
 
 export type CoachDevWriterDependencies = typeof defaultWriterDeps;
 
@@ -118,6 +118,12 @@ function success(report: ImportReport): CliResult {
   };
 }
 
+function failedWriterResult<T>(stage: CoachDevWriterFailureStage, cause: unknown): CoachDevWriterResult<T> {
+  const result: { status: "failed"; stage: CoachDevWriterFailureStage; cause?: unknown } = { status: "failed", stage };
+  Object.defineProperty(result, "cause", { value: cause, enumerable: false, writable: false, configurable: true });
+  return result;
+}
+
 export async function runCoachDevWriter<T>(
   options: RunCoachDevWriterOptions<T>,
   deps: CoachDevWriterDependencies = defaultWriterDeps,
@@ -125,8 +131,8 @@ export async function runCoachDevWriter<T>(
   let home: AthleteHome;
   try {
     home = deps.resolveAthleteHome(options.env);
-  } catch {
-    return { status: "failed", stage: "resolve home" };
+  } catch (error) {
+    return failedWriterResult("resolve home", error);
   }
 
   let lockResult: Awaited<ReturnType<CoachDevWriterDependencies["acquireWriteLock"]>>;
@@ -137,13 +143,17 @@ export async function runCoachDevWriter<T>(
       version: options.writerVersion,
     });
   } catch (error) {
-    if (error instanceof WriteLockContentionError) return { status: "writer-lock-held" };
-    return { status: "failed", stage: "acquire lock" };
+    if (error instanceof WriteLockContentionError
+      || (error instanceof Error && error.name === "WriteLockContentionError")) {
+      return { status: "writer-lock-held" };
+    }
+    return failedWriterResult("acquire lock", error);
   }
 
   if (lockResult.status === "peer-healthy") return { status: "writer-lock-held" };
 
   let failureStage: CoachDevWriterFailureStage | undefined;
+  let failureCause: unknown;
   let value!: T;
   let store: ReturnType<CoachDevWriterDependencies["openSqliteStorage"]> | undefined;
 
@@ -151,59 +161,70 @@ export async function runCoachDevWriter<T>(
     try {
       try {
         await deps.mkdir(home.storeDir, { recursive: true, mode: 0o700 });
-      } catch {
+      } catch (error) {
         failureStage = "create store directory";
+        failureCause = error;
       }
 
       if (failureStage === undefined) {
         try {
           await deps.chmod(home.storeDir, 0o700);
-        } catch {
+        } catch (error) {
           failureStage = "secure store directory";
+          failureCause = error;
         }
       }
 
       if (failureStage === undefined) {
         try {
           store = deps.openSqliteStorage(join(home.storeDir, "store.db"));
-        } catch {
+        } catch (error) {
           failureStage = "open store";
+          failureCause = error;
         }
       }
 
       if (failureStage === undefined && store !== undefined) {
         try {
           await deps.runMigrations(store, MIGRATIONS);
-        } catch {
+        } catch (error) {
           failureStage = "run migrations";
+          failureCause = error;
         }
       }
 
       if (failureStage === undefined && store !== undefined) {
         try {
           value = await options.operation({ home, store });
-        } catch {
+        } catch (error) {
           failureStage = "invoke operation";
+          failureCause = error;
         }
       }
     } finally {
       if (store !== undefined) {
         try {
           await store.close();
-        } catch {
-          failureStage ??= "close store";
+        } catch (error) {
+          if (failureStage === undefined) {
+            failureStage = "close store";
+            failureCause = error;
+          }
         }
       }
     }
   } finally {
     try {
       await lockResult.release();
-    } catch {
-      failureStage ??= "release lock";
+    } catch (error) {
+      if (failureStage === undefined) {
+        failureStage = "release lock";
+        failureCause = error;
+      }
     }
   }
 
-  if (failureStage !== undefined) return { status: "failed", stage: failureStage };
+  if (failureStage !== undefined) return failedWriterResult(failureStage, failureCause);
   return { status: "completed", value };
 }
 

--- a/packages/kernel-node/tests/coach-dev-import.test.ts
+++ b/packages/kernel-node/tests/coach-dev-import.test.ts
@@ -762,6 +762,7 @@ describe("coach-dev import --report", () => {
       failed.deps,
     );
     expect(failure).toEqual({ status: "failed", stage: "invoke operation" });
+    expect(failure.status === "failed" && failure.cause instanceof Error && failure.cause.message).toBe(privateValues[0]);
     expect(failed.calls).toEqual([
       "resolve",
       "acquire",
@@ -776,6 +777,62 @@ describe("coach-dev import --report", () => {
     const serialized = JSON.stringify(failure);
     for (const privateValue of privateValues) {
       expect(serialized).not.toContain(privateValue);
+    }
+  });
+
+  it("treats a foreign-copy write lock contention error as writer-lock-held", async () => {
+    const foreign = new Error("write lock held by a healthy peer");
+    foreign.name = "WriteLockContentionError";
+    const scenario = injected({ fail: { acquire: foreign } });
+    const result = await runCoachDevWriter(
+      {
+        env: {},
+        writerVersion: "generic-operation/1",
+        operation: async () => {
+          scenario.calls.push("operation");
+          return null;
+        },
+      },
+      scenario.deps,
+    );
+    expect(result).toEqual({ status: "writer-lock-held" });
+    expect(scenario.calls).toEqual(["resolve", "acquire"]);
+  });
+
+  it("rejects a non-error lookalike named like the contention error", async () => {
+    const lookalike = { name: "WriteLockContentionError", message: "not an Error instance" };
+    const scenario = injected({ fail: { acquire: lookalike } });
+    const result = await runCoachDevWriter(
+      {
+        env: {},
+        writerVersion: "generic-operation/1",
+        operation: async () => null,
+      },
+      scenario.deps,
+    );
+    expect(result).toEqual({ status: "failed", stage: "acquire lock" });
+    expect(result.status === "failed" && result.cause).toBe(lookalike);
+  });
+
+  it("never serializes failure causes carrying enumerable private data", async () => {
+    const privateTexts = ["/private/athlete/home/store.db", "thrown-plain-object-secret", "thrown-string-secret"];
+    const fsLike = Object.assign(new Error("EACCES: permission denied"), { path: privateTexts[0], syscall: "open" });
+    for (const thrown of [fsLike, { detail: privateTexts[1] }, privateTexts[2]]) {
+      const scenario = injected();
+      const failure = await runCoachDevWriter(
+        {
+          env: {},
+          writerVersion: "generic-operation/1",
+          operation: async () => {
+            throw thrown;
+          },
+        },
+        scenario.deps,
+      );
+      expect(failure).toEqual({ status: "failed", stage: "invoke operation" });
+      expect(failure.status === "failed" && failure.cause).toBe(thrown);
+      const serialized = JSON.stringify(failure);
+      for (const text of privateTexts) expect(serialized).not.toContain(text);
     }
   });
 

--- a/packages/kernel/tests/incremental-rekey.test.ts
+++ b/packages/kernel/tests/incremental-rekey.test.ts
@@ -172,6 +172,26 @@ archive_rel_path,archive_epoch_s FROM source_artifact`)).toEqual({ source: entry
     } finally { await value.store.close(); }
   });
 
+  it("accepts source evidence placement independent of the import placement through the full oracle", async () => {
+    const value = await harness();
+    try {
+      await importArtifactsIncrementally({ files: [file(1)], platform_records: [] }, value.deps);
+      await value.store.run("UPDATE ingest_metadata SET ingest_version=3");
+      const artifact = file(2), address = digest(artifact.bytes);
+      const entry = { source: "intervals-icu" as const, lane: "bulk-fit" as const, externalId: "synthetic-entry-oracle",
+        artifactKind: "raw_file" as const, archiveAddress: address,
+        archiveRelPath: `2024/11/${address}.fit`, archiveEpochSeconds: 1_730_603_881 };
+      value.counts.clear();
+      await expect(importArtifactsIncrementally({ files: [{ ...artifact, source_evidence: { container: null, entry } }],
+        platform_records: [] }, value.deps)).resolves.toBeDefined();
+      expect(value.counts.get(digest(file(1).bytes))).toBe(1);
+      expect(await value.store.get("SELECT archive_rel_path,archive_epoch_s FROM source_artifact WHERE archive_address=?", [address]))
+        .toEqual({ archive_rel_path: entry.archiveRelPath, archive_epoch_s: entry.archiveEpochSeconds });
+      expect(await value.store.get("SELECT path FROM raw_file WHERE sha256=?", [address])).toEqual({ path: `${address}.fit` });
+      expect(await value.store.get("SELECT ingest_version FROM ingest_metadata")).toEqual({ ingest_version: 4 });
+    } finally { await value.store.close(); }
+  });
+
   it("recomputes exactly the affected closure", async () => {
     const value = await harness();
     try {


### PR DESCRIPTION
## Summary

- recognize write-lock contention thrown by a different bundle copy of the lock error class by error name, so injected lock dependencies are never misreported as an acquire-lock failure
- carry the underlying failure cause through the coach-dev writer result and attach it as the thrown store-writer error's cause, ending the swallowed-error diagnosis gap
- pin full-oracle acceptance of source evidence placement that differs from the import's own placement

## Verification

- `pnpm check` — passed
- `pnpm test` — 274 files, 3846 passed, no new skips
- new regression tests: foreign-copy lock contention → writer-lock-held; writer failure cause preserved end-to-end and never serialized; full-oracle differing-placement evidence acceptance

## Release note

Internal diagnosability fix; no user-visible behavior change.