### PR TITLE
feat(reference): add immutable capture manifests

### DIFF
--- a/.changeset/reference-capture-manifest.md
+++ b/.changeset/reference-capture-manifest.md
@@ -1,0 +1,8 @@
+---
+"@enduragent/core": patch
+"@enduragent/kernel": patch
+"@enduragent/kernel-node": patch
+"@enduragent/sync-intervals-icu": patch
+"@enduragent/coach": patch
+---
+Add immutable Reference capture sidecars with replayable endpoint evidence and exact live-fetch ordering. Private infrastructure; ships nothing to athletes.

--- a/packages/coach/package.json
+++ b/packages/coach/package.json
@@ -9,7 +9,8 @@
     "./runtime": "./dist/runtime.js",
     "./sync": "./dist/sync.js",
     "./backfill": "./dist/backfill.js",
-    "./backfill-benchmark": "./dist/backfill-benchmark.js"
+    "./backfill-benchmark": "./dist/backfill-benchmark.js",
+    "./capture": "./dist/capture.js"
   },
   "engines": {
     "node": ">=24"
@@ -19,7 +20,8 @@
     "check": "tsc --noEmit",
     "test": "vitest run",
     "backfill": "node dist/backfill-command.js",
-    "benchmark": "node dist/backfill-command.js --synthetic --conclusions-only"
+    "benchmark": "node dist/backfill-command.js --synthetic --conclusions-only",
+    "capture-reference": "node dist/capture-command.js"
   },
   "dependencies": {
     "@enduragent/core": "workspace:*",

--- a/packages/coach/src/capture-command.ts
+++ b/packages/coach/src/capture-command.ts
@@ -1,0 +1,92 @@
+import { createHash, randomUUID } from "node:crypto";
+import { pathToFileURL } from "node:url";
+import { serializeReferenceCaptureManifest } from "@enduragent/kernel/reference/capture";
+import { ReferenceCaptureRunError, runReferenceCapture } from "./capture.js";
+
+interface CommandOptions {
+  readonly reviewedOn: string;
+  readonly reason: "initial" | "provider-refresh" | "schema-change" | "capture-invalid" | "operator-request";
+  readonly replacesCaptureId?: string;
+}
+
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+function realDate(value: string): boolean {
+  if (!/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/.test(value)) return false;
+  const [year, month, day] = value.split("-").map(Number) as [number, number, number];
+  const parsed = new Date(Date.UTC(year, month - 1, day));
+  return parsed.getUTCFullYear() === year && parsed.getUTCMonth() + 1 === month && parsed.getUTCDate() === day;
+}
+
+export interface CaptureCommandDependencies {
+  readonly runCapture?: typeof runReferenceCapture;
+  readonly uuid?: () => string;
+  readonly wallClock?: () => Date;
+  readonly stdout?: (line: string) => void;
+  readonly stderr?: (line: string) => void;
+}
+
+function parseArgs(args: readonly string[]): CommandOptions {
+  const allowed = new Set(["--reviewed-on", "--reason", "--replaces"]);
+  const values = new Map<string, string>();
+  for (let index = 0; index < args.length; index += 1) {
+    const flag = args[index]!;
+    if (!allowed.has(flag) || values.has(flag) || index + 1 >= args.length || args[index + 1]!.startsWith("--")) {
+      throw new TypeError("invalid capture arguments");
+    }
+    values.set(flag, args[++index]!);
+  }
+  const reviewedOn = values.get("--reviewed-on"), reason = values.get("--reason");
+  if (reviewedOn === undefined || reason === undefined
+    || !realDate(reviewedOn)
+    || !["initial", "provider-refresh", "schema-change", "capture-invalid", "operator-request"].includes(reason)) {
+    throw new TypeError("capture arguments are incomplete");
+  }
+  const replacement = values.get("--replaces");
+  if ((reason === "initial") !== (replacement === undefined)
+    || (replacement !== undefined && !UUID.test(replacement))) throw new TypeError("capture replacement is invalid");
+  return { reviewedOn, reason: reason as CommandOptions["reason"],
+    ...(replacement === undefined ? {} : { replacesCaptureId: replacement }) };
+}
+
+function requiredEnvironment(env: Record<string, string | undefined>): { apiKey: string; athleteId: string } {
+  if (env.REFERENCE_CAPTURE_ENABLE !== "1" || !env.REFERENCE_CAPTURE_API_KEY
+    || !env.REFERENCE_CAPTURE_ATHLETE_ID || !env.ENDURAGENT_HOME) {
+    throw new TypeError("capture environment is invalid");
+  }
+  return { apiKey: env.REFERENCE_CAPTURE_API_KEY, athleteId: env.REFERENCE_CAPTURE_ATHLETE_ID };
+}
+
+export async function runCaptureReferenceCommand(
+  args: readonly string[],
+  env: Record<string, string | undefined>,
+  dependencies: CaptureCommandDependencies = {},
+): Promise<number> {
+  const stdout = dependencies.stdout ?? ((line: string) => process.stdout.write(`${line}\n`));
+  const stderr = dependencies.stderr ?? ((line: string) => process.stderr.write(`${line}\n`));
+  let options: CommandOptions, credentials: { apiKey: string; athleteId: string };
+  try { options = parseArgs(args); credentials = requiredEnvironment(env); }
+  catch {
+    stderr("REFERENCE_CAPTURE failed category=environment");
+    return 2;
+  }
+  try {
+    const manifest = await (dependencies.runCapture ?? runReferenceCapture)({ env, apiKey: credentials.apiKey,
+      athleteId: credentials.athleteId, reviewedOn: options.reviewedOn, reason: options.reason,
+      ...(options.replacesCaptureId === undefined ? {} : { replacesCaptureId: options.replacesCaptureId }) }, {
+      uuid: dependencies.uuid ?? randomUUID,
+      wallClock: dependencies.wallClock ?? (() => new Date()),
+    });
+    const hash = createHash("sha256").update(serializeReferenceCaptureManifest(manifest)).digest("hex");
+    stdout(`REFERENCE_CAPTURE recorded activities=${manifest.records.activities.length} wellness=${manifest.records.wellness.length} settings=${manifest.records.settings.length} streams=${manifest.records.streams.length} evidence_sha256=${hash}`);
+    return 0;
+  } catch (error) {
+    const category = error instanceof ReferenceCaptureRunError ? error.category : "capture";
+    stderr(`REFERENCE_CAPTURE failed category=${category}`);
+    return 1;
+  }
+}
+
+if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  process.exitCode = await runCaptureReferenceCommand(process.argv.slice(2), process.env);
+}

--- a/packages/coach/src/capture.ts
+++ b/packages/coach/src/capture.ts
@@ -1,0 +1,240 @@
+import { randomUUID } from "node:crypto";
+import { performance } from "node:perf_hooks";
+import { setTimeout as setTimeoutPromise } from "node:timers/promises";
+import {
+  REFERENCE_CAPTURE_STREAM_LIMIT,
+  assertReferenceCaptureReplayable,
+  serializeReferenceCaptureManifest,
+  validateReferenceCaptureManifest,
+  type RecordRef,
+  type ReferenceCaptureManifest,
+} from "@enduragent/kernel/reference/capture";
+import { H, createIntervalsSourceRepository, type SourceArtifactDraft, type SyncBudget } from "@enduragent/kernel/store";
+import {
+  loadReferenceCaptureSidecars,
+  readVerifiedReferenceSnapshot,
+  validateReferenceCaptureReview,
+  writeReferenceCaptureSidecars,
+  type AssertReferenceCaptureReplayable,
+  type ReferenceCaptureReview,
+} from "@enduragent/kernel-node/capture-manifest";
+import { createNodeCrypto, createNodeImportRuntime } from "@enduragent/kernel-node/ingest";
+import { REQUEST_ATTEMPTS, type IntervalsIcuCaptureSource, type ReferenceCaptureBatch } from "@enduragent/sync-intervals-icu";
+import { createIntervalsBackfillSource, DEFAULT_PER_REQUEST_TIMEOUT_MS, DEFAULT_REQUEST_INTERVAL_MS } from "./backfill.js";
+import { withCoachStoreWriter } from "./runtime.js";
+
+export type ReferenceCaptureFailureCategory = "capture" | "persistence" | "validation";
+
+export class ReferenceCaptureRunError extends Error {
+  readonly category: ReferenceCaptureFailureCategory;
+  constructor(category: ReferenceCaptureFailureCategory, options?: ErrorOptions) {
+    super("Reference capture failed", options);
+    this.name = "ReferenceCaptureRunError";
+    this.category = category;
+  }
+}
+
+class ReferenceCaptureValidationError extends Error {}
+
+export interface RunReferenceCaptureOptions {
+  readonly env: Record<string, string | undefined>;
+  readonly apiKey: string;
+  readonly athleteId: string;
+  readonly reviewedOn: string;
+  readonly reason: ReferenceCaptureReview["reason"];
+  readonly replacesCaptureId?: string;
+  readonly budget?: SyncBudget;
+  readonly baseFetch?: typeof globalThis.fetch;
+}
+
+export interface RunReferenceCaptureDependencies {
+  readonly wallClock?: () => Date;
+  readonly uuid?: () => string;
+  readonly monotonicNow?: () => number;
+  readonly sleep?: (ms: number, signal: AbortSignal) => Promise<void>;
+  readonly writeSidecars?: typeof writeReferenceCaptureSidecars;
+  readonly loadSidecars?: typeof loadReferenceCaptureSidecars;
+}
+
+function sourceArtifact(
+  record: ReferenceCaptureBatch["records"][keyof ReferenceCaptureBatch["records"]][number],
+): SourceArtifactDraft {
+  const lane: SourceArtifactDraft["lane"] = record.landing.kind === "activity" ? "activities"
+    : record.landing.kind === "settings" ? "settings"
+    : record.landing.kind === "wellness" ? "wellness" : "streams";
+  return {
+    source: "intervals-icu" as const,
+    lane,
+    externalId: record.externalId,
+    artifactKind: "snapshot" as const,
+    archiveAddress: record.archive.address,
+    archiveRelPath: record.archive.relPath,
+    archiveEpochSeconds: record.archiveInstant.epochSeconds,
+  };
+}
+
+function snapshot(value: { readonly archive: { readonly address: string; readonly relPath: string } }) {
+  return { address: value.archive.address, rel_path: value.archive.relPath };
+}
+
+export async function runReferenceCapture(
+  options: RunReferenceCaptureOptions,
+  dependencies: RunReferenceCaptureDependencies = {},
+): Promise<ReferenceCaptureManifest> {
+  const now = (dependencies.wallClock ?? (() => new Date()))();
+  const captureId = (dependencies.uuid ?? randomUUID)();
+  const monotonicNow = dependencies.monotonicNow ?? (() => performance.now());
+  const sleep = dependencies.sleep ?? ((ms: number, signal: AbortSignal) =>
+    setTimeoutPromise(ms, undefined, { signal }).then(() => undefined));
+  const controller = new AbortController();
+  const budget: SyncBudget = options.budget ?? {
+    signal: controller.signal,
+    clock: { monotonicNow },
+    deadlineMonotonicMs: monotonicNow() + 15 * 60 * 1_000,
+    perRequestTimeoutMs: DEFAULT_PER_REQUEST_TIMEOUT_MS,
+    maxRequests: REQUEST_ATTEMPTS * (3 + REFERENCE_CAPTURE_STREAM_LIMIT),
+    maxArtifacts: 10_000,
+  };
+  let review: ReferenceCaptureReview;
+  try {
+    review = validateReferenceCaptureReview({ schema_version: 1, capture_id: captureId,
+      reviewed_on: options.reviewedOn, replaces_capture_id: options.replacesCaptureId ?? null,
+      reason: options.reason });
+  } catch (error) {
+    throw new ReferenceCaptureRunError("validation", { cause: error });
+  }
+
+  return withCoachStoreWriter(options.env, async ({ home, store }) => {
+    const crypto = createNodeCrypto();
+    const node = createNodeImportRuntime({ archiveDir: home.archiveDir, store });
+    const source = createIntervalsBackfillSource({ apiKey: options.apiKey, athleteId: options.athleteId,
+      historyNewestDate: now.toISOString().slice(0, 10), minRequestIntervalMs: DEFAULT_REQUEST_INTERVAL_MS,
+      archive: node.archive, clock: { now: () => now.getTime(), monotonicNow }, sleep,
+      ...(options.baseFetch === undefined ? {} : { baseFetch: options.baseFetch }) }) as IntervalsIcuCaptureSource;
+    let batch: ReferenceCaptureBatch;
+    try { batch = await source.captureReference(now, budget); }
+    catch (error) { throw new ReferenceCaptureRunError("capture", { cause: error }); }
+
+    const repository = createIntervalsSourceRepository(store, (fields) => {
+      if (fields.length === 0) throw new TypeError("empty key tuple");
+      return H(crypto, ...(fields as [string | number, ...(string | number)[]]));
+    });
+    const wellnessArtifactKeys = new Map<string, string>();
+    try {
+      if (batch.records.activities.length > 0) {
+        await node.importBatchWithReport({ files: [],
+          platform_records: batch.records.activities.map((record) => record.landing.platform) });
+      }
+      await store.transaction(async () => {
+        for (const record of batch.records.settings) {
+          const evidence = await repository.recordArtifact(sourceArtifact(record));
+          await repository.recordGenericLanding({ externalId: record.landing.sourceRecordExternalId,
+            artifactKey: evidence.artifactKey, archiveAddress: record.archive.address, endpoint: "settings",
+            normalizedPayloadJson: record.landing.normalizedPayloadJson });
+          for (const anchor of record.landing.anchors) await repository.insertSyncedAnchor(anchor);
+          for (const zone of record.landing.zones) await repository.insertSyncedZone(zone);
+        }
+        for (const record of batch.records.wellness) {
+          const evidence = await repository.recordArtifact(sourceArtifact(record));
+          wellnessArtifactKeys.set(record.externalId, evidence.artifactKey);
+          await repository.upsertWellness(record.landing.row);
+        }
+        for (const record of batch.records.streams) {
+          const evidence = await repository.recordArtifact(sourceArtifact(record));
+          await repository.recordGenericLanding({ externalId: record.landing.sourceRecordExternalId,
+            artifactKey: evidence.artifactKey, archiveAddress: record.archive.address, endpoint: "streams",
+            normalizedPayloadJson: record.landing.normalizedPayloadJson });
+        }
+      });
+    } catch (error) {
+      throw new ReferenceCaptureRunError("persistence", { cause: error });
+    }
+
+    const records = { settings: [] as RecordRef[], activities: [] as RecordRef[],
+      wellness: [] as RecordRef[], streams: [] as RecordRef[] };
+    try {
+      for (const lane of ["settings", "activities", "wellness", "streams"] as const) {
+        const sourceRecords = batch.records[lane];
+        for (let ordinal = 0; ordinal < sourceRecords.length; ordinal += 1) {
+          const record = sourceRecords[ordinal]!;
+          if (lane === "wellness") {
+            const artifactKey = wellnessArtifactKeys.get(record.externalId);
+            if (artifactKey === undefined) throw new Error("wellness capture evidence is absent");
+            records[lane].push({ ordinal, endpoint_ordinal: record.endpointOrdinal,
+              payload_index: record.payloadIndex, external_id: record.externalId, snapshot: snapshot(record),
+              store_evidence: { artifact_key: artifactKey, current_revision: null } });
+          } else {
+            const evidence = await repository.readCurrentCaptureEvidence(lane, record.externalId);
+            if (evidence.archiveAddress !== record.archive.address || evidence.archiveRelPath !== record.archive.relPath) {
+              throw new Error("current capture evidence disagrees with snapshot");
+            }
+            records[lane].push({ ordinal, endpoint_ordinal: record.endpointOrdinal,
+              payload_index: record.payloadIndex, external_id: record.externalId, snapshot: snapshot(record),
+              store_evidence: { artifact_key: evidence.artifactKey,
+                current_revision: { source_record_id: evidence.sourceRecordId, revision_id: evidence.revisionId } } });
+          }
+        }
+      }
+    } catch (error) {
+      throw new ReferenceCaptureRunError("persistence", { cause: error });
+    }
+
+    let manifest: ReferenceCaptureManifest;
+    try {
+      manifest = validateReferenceCaptureManifest({
+        schema_version: 1,
+        capture_id: captureId,
+        source: "external-oracle",
+        plan: batch.plan,
+        operation_ledger: { link_kind: "capture-id", capture_id: captureId },
+        endpoints: batch.endpoints.map((endpoint) => ({ ordinal: endpoint.ordinal, lane: endpoint.lane,
+          endpoint: endpoint.endpoint, request: endpoint.request, snapshot: snapshot(endpoint) })),
+        records,
+        selected_stream_ids: [...batch.selected_stream_ids],
+        captured_stream_ids: [...batch.captured_stream_ids],
+        deterministic_order: {
+          endpoint_ordinals: batch.endpoints.map((endpoint) => endpoint.ordinal),
+          settings: batch.records.settings.map((record) => record.externalId),
+          activities: batch.records.activities.map((record) => record.externalId),
+          wellness: batch.records.wellness.map((record) => record.externalId),
+          streams: [...batch.captured_stream_ids],
+        },
+      });
+    } catch (error) {
+      throw new ReferenceCaptureRunError("validation", { cause: error });
+    }
+
+    const assertReplayable: AssertReferenceCaptureReplayable = async (candidate) => {
+      try {
+        await assertReferenceCaptureReplayable(candidate, {
+          readVerifiedSnapshot: (reference) => readVerifiedReferenceSnapshot(reference, { archive: node.archive, crypto }),
+          derivePayloadMembers: (plan, endpointPayloads) => source.deriveReferenceCaptureMembers(plan, endpointPayloads),
+          assertStoreEvidence: (record, lane) => repository.assertPinnedCaptureEvidence({ lane,
+            externalId: record.external_id, artifactKey: record.store_evidence.artifact_key,
+            archiveAddress: record.snapshot.address, archiveRelPath: record.snapshot.rel_path,
+            currentRevision: record.store_evidence.current_revision === null ? null : {
+              sourceRecordId: record.store_evidence.current_revision.source_record_id,
+              revisionId: record.store_evidence.current_revision.revision_id,
+            } }),
+        });
+      } catch (error) { throw new ReferenceCaptureValidationError("capture replay validation failed", { cause: error }); }
+    };
+
+    try {
+      const committed = await (dependencies.writeSidecars ?? writeReferenceCaptureSidecars)({
+        root: home.root, manifest, review, assertReplayable,
+      });
+      if (dependencies.loadSidecars !== undefined) {
+        const loaded = await dependencies.loadSidecars({ root: home.root, captureId, assertReplayable });
+        return loaded.manifest;
+      }
+      return committed.manifest;
+    } catch (error) {
+      throw new ReferenceCaptureRunError(error instanceof ReferenceCaptureValidationError ? "validation" : "persistence", { cause: error });
+    }
+  });
+}
+
+export function referenceCaptureEvidenceSha256Input(manifest: ReferenceCaptureManifest): Uint8Array {
+  return new TextEncoder().encode(serializeReferenceCaptureManifest(manifest));
+}

--- a/packages/coach/tests/capture-command.test.ts
+++ b/packages/coach/tests/capture-command.test.ts
@@ -1,0 +1,60 @@
+import { createReferenceCapturePlan, validateReferenceCaptureManifest } from "@enduragent/kernel/reference/capture";
+import { describe, expect, it, vi } from "vitest";
+import { ReferenceCaptureRunError } from "../src/capture.js";
+import { runCaptureReferenceCommand } from "../src/capture-command.js";
+
+const UUID = "12345678-1234-4123-8123-123456789abc";
+const ENV = { REFERENCE_CAPTURE_ENABLE: "1", REFERENCE_CAPTURE_API_KEY: "private-key",
+  REFERENCE_CAPTURE_ATHLETE_ID: "private-athlete", ENDURAGENT_HOME: "private-home" };
+
+function manifest() {
+  const plan = createReferenceCapturePlan(new Date("1998-07-18T12:00:00.000Z"));
+  const address = "a".repeat(64), snapshot = { address, rel_path: `1998/07/${address}.json.gz` };
+  return validateReferenceCaptureManifest({ schema_version: 1, capture_id: UUID, source: "external-oracle", plan,
+    operation_ledger: { link_kind: "capture-id", capture_id: UUID }, endpoints: [
+      { ordinal: 0, lane: "settings", endpoint: "athlete-profile", request: { oldest: null, newest: null, activity_id: null, stream_types: [], include_defaults: null }, snapshot },
+      { ordinal: 1, lane: "activities", endpoint: "activities", request: { oldest: plan.window.oldest, newest: plan.window.newest, activity_id: null, stream_types: [], include_defaults: null }, snapshot },
+      { ordinal: 2, lane: "wellness", endpoint: "wellness", request: { oldest: plan.window.oldest, newest: plan.window.newest, activity_id: null, stream_types: [], include_defaults: null }, snapshot },
+    ], records: { settings: [], activities: [], wellness: [], streams: [] }, selected_stream_ids: [], captured_stream_ids: [],
+    deterministic_order: { endpoint_ordinals: [0, 1, 2], settings: [], activities: [], wellness: [], streams: [] } });
+}
+
+describe("capture-reference command", () => {
+  it("prints only counts and the evidence hash on success", async () => {
+    const output: string[] = [], errors: string[] = [], runCapture = vi.fn(async () => manifest());
+    const code = await runCaptureReferenceCommand(["--reviewed-on", "1998-07-18", "--reason", "initial"], ENV,
+      { runCapture, uuid: () => UUID, wallClock: () => new Date("1998-07-18T12:00:00Z"),
+        stdout: (line) => output.push(line), stderr: (line) => errors.push(line) });
+    expect(code).toBe(0);
+    expect(errors).toEqual([]);
+    expect(output).toHaveLength(1);
+    expect(output[0]).toMatch(/^REFERENCE_CAPTURE recorded activities=0 wellness=0 settings=0 streams=0 evidence_sha256=[0-9a-f]{64}$/);
+    expect(output[0]).not.toContain(UUID);
+    expect(output[0]).not.toContain("1998");
+    expect(output[0]).not.toContain("private");
+  });
+
+  it("rejects unknown, duplicate, missing, positional, and inconsistent arguments as environment usage", async () => {
+    for (const args of [[], ["value"], ["--unknown", "x"],
+      ["--reviewed-on", "1998-07-18", "--reviewed-on", "1998-07-18", "--reason", "initial"]]) {
+      const errors: string[] = [];
+      expect(await runCaptureReferenceCommand(args, ENV, { stderr: (line) => errors.push(line) })).toBe(2);
+      expect(errors).toEqual(["REFERENCE_CAPTURE failed category=environment"]);
+    }
+    const errors: string[] = [];
+    expect(await runCaptureReferenceCommand(["--reviewed-on", "1998-07-18", "--reason", "initial"],
+      { ...ENV, REFERENCE_CAPTURE_ENABLE: "true" }, { stderr: (line) => errors.push(line) })).toBe(2);
+  });
+
+  it("uses fixed private failure lines without exception text or stacks", async () => {
+    for (const category of ["capture", "persistence", "validation"] as const) {
+      const errors: string[] = [];
+      const runCapture = async (): Promise<never> => { throw new ReferenceCaptureRunError(category, { cause: new Error("secret detail") }); };
+      const code = await runCaptureReferenceCommand(["--reviewed-on", "1998-07-18", "--reason", "initial"], ENV,
+        { runCapture, stderr: (line) => errors.push(line) });
+      expect(code).toBe(1);
+      expect(errors).toEqual([`REFERENCE_CAPTURE failed category=${category}`]);
+      expect(errors[0]).not.toContain("secret");
+    }
+  });
+});

--- a/packages/coach/tests/capture.test.ts
+++ b/packages/coach/tests/capture.test.ts
@@ -1,0 +1,80 @@
+import { mkdtemp, readFile, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { openSqliteStorage } from "@enduragent/kernel-node/sqlite";
+import { describe, expect, it } from "vitest";
+import { runReferenceCapture } from "../src/capture.js";
+
+const CAPTURE_ID = "12345678-1234-4123-8123-123456789abc";
+const NOW = new Date("1998-07-18T12:00:00.000Z");
+
+const profile = { sportSettings: [{ id: 7, athlete_id: "synthetic-athlete", types: ["Ride"],
+  updated: "1998-07-01T00:00:00.000Z", ftp: 250, lthr: 165, power_zones: [0, 125, 200, 250] }] };
+const activities = [{ id: 42, type: "Ride", start_date: "1998-07-17T10:00:00.000Z",
+  start_date_local: "1998-07-17T12:00:00", moving_time: 3600, elapsed_time: 3700, distance: 40_000 }];
+const wellness = [{ id: "1998-07-17", weight: 70, restingHR: 50, hrv: 60, sleepSecs: 28_800,
+  sleepQuality: 3, sportInfo: [{ type: "Ride", eftp: 245 }] }];
+const streams = { time: [0, 1], watts: [200, 210], heartrate: [140, 145] };
+
+function json(value: unknown): Response {
+  return new Response(JSON.stringify(value), { status: 200, headers: { "content-type": "application/json" } });
+}
+
+describe("runReferenceCapture", () => {
+  it("persists a synthetic four-lane capture and commits its manifest only after pinned evidence exists", async () => {
+    const root = await mkdtemp(join(tmpdir(), "reference-capture-home-"));
+    const requests: string[] = [];
+    const baseFetch: typeof globalThis.fetch = async (input) => {
+      const url = String(input); requests.push(url);
+      if (url.includes("/streams.json")) return json(streams);
+      if (url.includes("/activities?")) return json(activities);
+      if (url.includes("/wellness?")) return json(wellness);
+      return json(profile);
+    };
+    let monotonic = 0;
+    const manifest = await runReferenceCapture({ env: { ENDURAGENT_HOME: root }, apiKey: "synthetic-key",
+      athleteId: "synthetic-athlete", reviewedOn: "1998-07-18", reason: "initial", baseFetch }, {
+      wallClock: () => NOW, uuid: () => CAPTURE_ID, monotonicNow: () => (monotonic += 250), sleep: async () => {},
+    });
+    expect(requests).toHaveLength(4);
+    expect(manifest.plan.frozenNow).toMatch(/^1998-07-18T/);
+    expect(manifest.records.settings).toHaveLength(1);
+    expect(manifest.records.activities).toHaveLength(1);
+    expect(manifest.records.wellness).toHaveLength(1);
+    expect(manifest.records.streams).toHaveLength(1);
+    expect(manifest.records.activities[0]?.store_evidence.current_revision).not.toBeNull();
+    expect(manifest.records.wellness[0]?.store_evidence.current_revision).toBeNull();
+    expect((await stat(join(root, "captures", CAPTURE_ID, "manifest.json"))).mode & 0o777).toBe(0o444);
+
+    const store = openSqliteStorage(join(root, "store", "store.db"));
+    expect((await store.get("SELECT count(*) AS n FROM source_artifact"))?.n).toBe(4);
+    expect((await store.get("SELECT count(*) AS n FROM wellness"))?.n).toBe(1);
+    expect((await store.get("SELECT count(*) AS n FROM anchor_history"))?.n).toBeGreaterThan(0);
+    expect((await store.get("SELECT count(*) AS n FROM zone_set_history"))?.n).toBeGreaterThan(0);
+    expect((await store.get("SELECT count(*) AS n FROM raw_file"))?.n).toBe(0);
+    await store.close();
+  });
+
+  it("commits a capture whose activities lane has no retained members", async () => {
+    const root = await mkdtemp(join(tmpdir(), "reference-capture-home-"));
+    const requests: string[] = [];
+    const baseFetch: typeof globalThis.fetch = async (input) => {
+      const url = String(input); requests.push(url);
+      if (url.includes("/activities?")) return json([]);
+      if (url.includes("/wellness?")) return json(wellness);
+      return json(profile);
+    };
+    let monotonic = 0;
+    const manifest = await runReferenceCapture({ env: { ENDURAGENT_HOME: root }, apiKey: "synthetic-key",
+      athleteId: "synthetic-athlete", reviewedOn: "1998-07-18", reason: "initial", baseFetch }, {
+      wallClock: () => NOW, uuid: () => CAPTURE_ID, monotonicNow: () => (monotonic += 250), sleep: async () => {},
+    });
+    expect(requests).toHaveLength(3);
+    expect(manifest.records.activities).toEqual([]);
+    expect(manifest.selected_stream_ids).toEqual([]);
+    expect(manifest.captured_stream_ids).toEqual([]);
+    expect(manifest.deterministic_order.activities).toEqual([]);
+    expect(JSON.parse(await readFile(join(root, "captures", CAPTURE_ID, "manifest.json"), "utf8")))
+      .toMatchObject({ records: { activities: [] } });
+  });
+});

--- a/packages/coach/tsup.config.ts
+++ b/packages/coach/tsup.config.ts
@@ -7,6 +7,8 @@ export default defineConfig({
     backfill: "src/backfill.ts",
     "backfill-benchmark": "src/backfill-benchmark.ts",
     "backfill-command": "src/backfill-command.ts",
+    capture: "src/capture.ts",
+    "capture-command": "src/capture-command.ts",
   },
   format: ["esm"],
   dts: true,

--- a/packages/core/src/reference/sync/fetch-live-bundle.ts
+++ b/packages/core/src/reference/sync/fetch-live-bundle.ts
@@ -16,6 +16,15 @@
 // `SYNC_OPERATION_TIMEOUT_MS` budget.
 
 import { snakeCaseKeys } from "intervals-icu-api";
+import {
+  REFERENCE_CAPTURE_STREAM_LIMIT,
+  REFERENCE_CAPTURE_STREAM_TYPES,
+  REFERENCE_CAPTURE_STREAM_WINDOW_DAYS,
+  REFERENCE_CAPTURE_WINDOW_DAYS,
+  createReferenceCapturePlan,
+  selectReferenceCaptureStreamIds,
+  type ReferenceCapturePlan,
+} from "@enduragent/kernel/reference/capture";
 
 import {
   AthleteSchema,
@@ -39,13 +48,13 @@ import type { ReferenceBundle } from "./fixture-bridge.js";
 
 /** Trailing window pulled for metric computation (covers the widest metric
  *  window — the 42-day sustainability look-back — with margin). */
-export const FETCH_WINDOW_DAYS = 84;
+export const FETCH_WINDOW_DAYS = REFERENCE_CAPTURE_WINDOW_DAYS;
 /** Only fetch per-activity streams for rides this recent. DFA-α1's trailing
  *  aggregate reads the last few sufficient sessions, so a short window keeps
  *  the request count bounded without starving the metric. */
-export const STREAM_WINDOW_DAYS = 21;
+export const STREAM_WINDOW_DAYS = REFERENCE_CAPTURE_STREAM_WINDOW_DAYS;
 /** Hard cap on per-activity stream fetches per sync, regardless of window. */
-export const MAX_STREAM_ACTIVITIES = 12;
+export const MAX_STREAM_ACTIVITIES = REFERENCE_CAPTURE_STREAM_LIMIT;
 const STREAM_THROTTLE_MS = 250;
 /** Wall-clock budget for the whole stream phase. Streams are best-effort, so we
  *  stop fetching once this elapses rather than letting a slow account push the
@@ -56,17 +65,7 @@ const STREAM_PHASE_BUDGET_MS = 60_000;
 /** Per-second channels requested per activity. `dfa_a1` + `artifacts` are the
  *  HRV channels the DFA-α1 block reads; `watts`/`heartrate` feed the per-session
  *  capability blocks. `time` is requested for alignment and rides through. */
-export const STREAM_TYPES: readonly string[] = [
-  "time",
-  "watts",
-  "heartrate",
-  "dfa_a1",
-  "artifacts",
-];
-
-/** DFA-α1 is upstream-validated for cycling only; stream fetches target these
- *  types (the cycling adapter's `activityTypes`). */
-const STREAM_SPORT_TYPES: ReadonlySet<string> = new Set(["Ride", "VirtualRide"]);
+export const STREAM_TYPES: readonly string[] = REFERENCE_CAPTURE_STREAM_TYPES;
 
 /** Cycling sport types whose `sportInfo.eftp` seeds the FTP history series. */
 const CYCLING_TYPES: ReadonlySet<string> = new Set([
@@ -123,24 +122,6 @@ export interface LiveFetchResult {
   readonly fetchErrors?: readonly FetchEndpointError[];
 }
 
-function ymd(date: Date): string {
-  return date.toISOString().slice(0, 10);
-}
-
-// Zone-less local-time ISO (YYYY-MM-DDThh:mm:ss). The metric date-window math
-// compares this anchor's date prefix against activity `start_date_local` values,
-// which intervals.icu emits in the athlete's local time with no zone. A UTC
-// `toISOString()` here would shift the anchor's calendar date near midnight and
-// drop/include a day's activities at the window edge; the naive-local form
-// mirrors the oracle's `datetime.now()` convention so the windows line up.
-function naiveLocalIso(date: Date): string {
-  const p = (n: number): string => String(n).padStart(2, "0");
-  return (
-    `${date.getFullYear()}-${p(date.getMonth() + 1)}-${p(date.getDate())}` +
-    `T${p(date.getHours())}:${p(date.getMinutes())}:${p(date.getSeconds())}`
-  );
-}
-
 // intervals.icu's streams endpoint returns an array of channel objects
 // (`[{type, data}, …]`); the lib also camelCases response keys (so `dfa_a1`
 // becomes `dfaA1` on the object form). Normalize both into the channel-keyed
@@ -164,10 +145,6 @@ export function normalizeStreams(value: unknown): unknown {
     return snakeCaseKeys(value);
   }
   return value;
-}
-
-function isCyclingStreamType(type: unknown): boolean {
-  return typeof type === "string" && STREAM_SPORT_TYPES.has(type);
 }
 
 /** Sparse cycling FTP series from per-day `sportInfo.eftp` — one point per
@@ -249,10 +226,9 @@ export async function fetchLiveBundle(deps: LiveFetchDeps): Promise<LiveFetchRes
   const { client, signal, now } = deps;
   const log = deps.log ?? ((m: string) => console.warn(m));
   const throttleMs = deps.throttleMs ?? STREAM_THROTTLE_MS;
-  const frozenNow = naiveLocalIso(now);
-
-  const newest = ymd(now);
-  const oldest = ymd(new Date(now.getTime() - FETCH_WINDOW_DAYS * 24 * 60 * 60 * 1000));
+  const plan = createReferenceCapturePlan(now);
+  const frozenNow = plan.frozenNow;
+  const { oldest, newest } = plan.window;
 
   const fetchErrors: FetchEndpointError[] = [];
 
@@ -313,7 +289,7 @@ export async function fetchLiveBundle(deps: LiveFetchDeps): Promise<LiveFetchRes
   // ADR-0012 defense-in-depth: no TP-trademarked key may survive rename.
   assertNoTpKeysRemain({ activities, wellness });
 
-  const streams = await fetchStreams(client, activities, signal, now, throttleMs, log);
+  const streams = await fetchStreams(client, activities, signal, plan, throttleMs, log);
 
   const ftpHistory = deriveFtpHistory(wellness);
   const athlete = extractAthleteSettings(athleteProfile);
@@ -347,34 +323,16 @@ async function fetchStreams(
   client: BundleFetchClient,
   activities: readonly Activity[],
   signal: AbortSignal,
-  now: Date,
+  plan: ReferenceCapturePlan,
   throttleMs: number,
   log: (msg: string) => void,
 ): Promise<Record<string, ActivityStreams>> {
-  const streamCutoffMs = now.getTime() - STREAM_WINDOW_DAYS * 24 * 60 * 60 * 1000;
-  const seen = new Set<string>();
-  const candidates = activities
-    .filter((a) => isCyclingStreamType(a.type) && typeof a.start_date_local === "string")
-    .filter((a) => {
-      const ms = Date.parse(a.start_date_local);
-      return Number.isFinite(ms) && ms >= streamCutoffMs;
-    })
-    .sort((a, b) => Date.parse(b.start_date_local) - Date.parse(a.start_date_local))
-    .filter((a) => {
-      // Collapse duplicate ids (the sort keeps the newest first), so a repeated
-      // id can't double-fetch or mis-join the DFA profile.
-      const id = String(a.id);
-      if (seen.has(id)) return false;
-      seen.add(id);
-      return true;
-    })
-    .slice(0, MAX_STREAM_ACTIVITIES);
+  const candidates = selectReferenceCaptureStreamIds(activities, plan);
 
   const deadline = Date.now() + STREAM_PHASE_BUDGET_MS;
   const out: Record<string, ActivityStreams> = {};
-  for (const activity of candidates) {
+  for (const id of candidates) {
     if (signal.aborted || Date.now() > deadline) break;
-    const id = String(activity.id);
     let result: FetchResult<unknown>;
     try {
       result = await client.activities.getStreams(id, [...STREAM_TYPES]);

--- a/packages/core/tests/reference-fetch-live-bundle.test.ts
+++ b/packages/core/tests/reference-fetch-live-bundle.test.ts
@@ -126,6 +126,16 @@ describe("fetchLiveBundle", () => {
     expect(res.bundle.activities).toHaveLength(activities.length);
   });
 
+  it("preserves encounter order for equal stream instants instead of external-ID order", async () => {
+    const instant = daysAgo(1);
+    const { client, streamCalls } = fakeClient({ activities: [
+      camelActivity({ id: 90, startDateLocal: instant }),
+      camelActivity({ id: 10, startDateLocal: instant }),
+    ] });
+    await fetchLiveBundle({ client, signal: new AbortController().signal, now: NOW, throttleMs: 0 });
+    expect(streamCalls).toEqual(["90", "10"]);
+  });
+
   it("is best-effort: a failed stream fetch is skipped, others kept", async () => {
     const activities = [
       camelActivity({ id: 1, startDateLocal: daysAgo(1) }),

--- a/packages/kernel-node/package.json
+++ b/packages/kernel-node/package.json
@@ -13,6 +13,7 @@
     "./home": "./dist/home/index.js",
     "./filesystem": "./dist/filesystem/index.js",
     "./ingest": "./dist/ingest/index.js",
+    "./capture-manifest": "./dist/capture-manifest/index.js",
     "./coach-dev": "./dist/coach-dev.js"
   },
   "engines": {

--- a/packages/kernel-node/src/capture-manifest/index.ts
+++ b/packages/kernel-node/src/capture-manifest/index.ts
@@ -1,0 +1,192 @@
+import { chmod, lstat, mkdir, rename, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { gunzipSync } from "node:zlib";
+import { canonicalJson, toHex, type ArchiveManager } from "@enduragent/kernel/archive";
+import {
+  parseReferenceCaptureManifest,
+  serializeReferenceCaptureManifest,
+  validateReferenceCaptureManifest,
+  type ReferenceCaptureManifest,
+  type SnapshotRef,
+} from "@enduragent/kernel/reference/capture";
+import type { CryptoPort } from "@enduragent/kernel/ports";
+import { z } from "zod";
+import { ensurePrivateDirectory, nodeFileSystem } from "../filesystem/index.js";
+
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const DATE = /^[0-9]{4}-[0-9]{2}-[0-9]{2}$/;
+const HEX = /^[0-9a-f]{64}$/;
+const SNAPSHOT_PATH = /^[0-9]{4}\/[0-9]{2}\/[0-9a-f]{64}\.json\.gz$/;
+
+function realDate(value: string): boolean {
+  if (!DATE.test(value)) return false;
+  const [year, month, day] = value.split("-").map(Number) as [number, number, number];
+  const parsed = new Date(Date.UTC(year, month - 1, day));
+  return parsed.getUTCFullYear() === year && parsed.getUTCMonth() + 1 === month && parsed.getUTCDate() === day;
+}
+
+const ReviewSchema = z.object({
+  schema_version: z.literal(1),
+  capture_id: z.string().regex(UUID),
+  reviewed_on: z.string().refine(realDate, "must be a real civil date"),
+  replaces_capture_id: z.string().regex(UUID).nullable(),
+  reason: z.enum(["initial", "provider-refresh", "schema-change", "capture-invalid", "operator-request"]),
+}).strict().superRefine((value, context) => {
+  if (value.reason === "initial" && value.replaces_capture_id !== null) {
+    context.addIssue({ code: "custom", message: "initial review cannot replace a capture", path: ["replaces_capture_id"] });
+  }
+  if (value.reason !== "initial" && (value.replaces_capture_id === null || value.replaces_capture_id === value.capture_id)) {
+    context.addIssue({ code: "custom", message: "replacement review is invalid", path: ["replaces_capture_id"] });
+  }
+});
+
+export type ReferenceCaptureReview = z.infer<typeof ReviewSchema>;
+
+export function validateReferenceCaptureReview(value: unknown): ReferenceCaptureReview {
+  return ReviewSchema.parse(value);
+}
+
+export function serializeReferenceCaptureReview(value: unknown): string {
+  return `${canonicalJson(validateReferenceCaptureReview(value))}\n`;
+}
+
+export function parseReferenceCaptureReview(bytes: string | Uint8Array): ReferenceCaptureReview {
+  let text: string;
+  try { text = typeof bytes === "string" ? bytes : new TextDecoder("utf-8", { fatal: true }).decode(bytes); }
+  catch { throw new TypeError("capture review encoding is invalid"); }
+  let parsed: unknown;
+  try { parsed = JSON.parse(text); } catch { throw new TypeError("capture review JSON is invalid"); }
+  const value = validateReferenceCaptureReview(parsed);
+  if (serializeReferenceCaptureReview(value) !== text) throw new TypeError("capture review bytes are not canonical");
+  return value;
+}
+
+function validateSnapshotRef(reference: SnapshotRef): void {
+  if (reference === null || typeof reference !== "object" || !HEX.test(reference.address)
+    || !SNAPSHOT_PATH.test(reference.rel_path)
+    || reference.rel_path.split("/").at(-1) !== `${reference.address}.json.gz`) {
+    throw new TypeError("Reference snapshot is invalid");
+  }
+}
+
+export async function readVerifiedReferenceSnapshot(
+  reference: SnapshotRef,
+  dependencies: { readonly archive: ArchiveManager; readonly crypto: CryptoPort },
+): Promise<unknown> {
+  validateSnapshotRef(reference);
+  const compressed = await dependencies.archive.readArtifact(reference.rel_path);
+  if (toHex(await dependencies.crypto.sha256(compressed)) !== reference.address) {
+    throw new Error("Reference snapshot address differs");
+  }
+  let raw: Uint8Array;
+  try { raw = new Uint8Array(gunzipSync(compressed)); }
+  catch { throw new TypeError("Reference snapshot compression is invalid"); }
+  let text: string;
+  try { text = new TextDecoder("utf-8", { fatal: true }).decode(raw); }
+  catch { throw new TypeError("Reference snapshot encoding is invalid"); }
+  let parsed: unknown;
+  try { parsed = JSON.parse(text); } catch { throw new TypeError("Reference snapshot JSON is invalid"); }
+  if (canonicalJson(parsed) !== text) throw new TypeError("Reference snapshot bytes are not canonical");
+  return parsed;
+}
+
+export type AssertReferenceCaptureReplayable = (manifest: ReferenceCaptureManifest) => Promise<void>;
+
+export interface ReferenceCaptureSidecars {
+  readonly manifest: ReferenceCaptureManifest;
+  readonly review: ReferenceCaptureReview;
+}
+
+function captureDirectory(root: string, captureId: string): string {
+  if (typeof root !== "string" || root.length === 0 || !UUID.test(captureId)) {
+    throw new TypeError("capture sidecar location is invalid");
+  }
+  return join(root, "captures", captureId);
+}
+
+async function assertCommittedMode(path: string, kind: "directory" | "file", mode: number): Promise<void> {
+  const value = await lstat(path);
+  if ((kind === "directory" ? !value.isDirectory() : !value.isFile()) || (value.mode & 0o777) !== mode) {
+    throw new Error("capture sidecar mode is invalid");
+  }
+}
+
+export async function loadReferenceCaptureSidecars(input: {
+  readonly root: string;
+  readonly captureId: string;
+  readonly assertReplayable: AssertReferenceCaptureReplayable;
+}): Promise<ReferenceCaptureSidecars> {
+  if (typeof input.assertReplayable !== "function") throw new TypeError("capture replay assertion is invalid");
+  const captures = join(input.root, "captures");
+  const directory = captureDirectory(input.root, input.captureId);
+  const manifestPath = join(directory, "manifest.json"), reviewPath = join(directory, "review.json");
+  await assertCommittedMode(captures, "directory", 0o700);
+  await assertCommittedMode(directory, "directory", 0o700);
+  await assertCommittedMode(manifestPath, "file", 0o444);
+  await assertCommittedMode(reviewPath, "file", 0o444);
+  const fs = nodeFileSystem();
+  const manifest = parseReferenceCaptureManifest(await fs.readFile(manifestPath));
+  const review = parseReferenceCaptureReview(await fs.readFile(reviewPath));
+  if (manifest.capture_id !== input.captureId || review.capture_id !== input.captureId) {
+    throw new Error("capture sidecar IDs disagree");
+  }
+  await input.assertReplayable(manifest);
+  return Object.freeze({ manifest, review });
+}
+
+export async function writeReferenceCaptureSidecars(input: {
+  readonly root: string;
+  readonly manifest: ReferenceCaptureManifest;
+  readonly review: ReferenceCaptureReview;
+  readonly assertReplayable: AssertReferenceCaptureReplayable;
+}, dependencies?: { readonly beforeRename?: () => void | Promise<void> }): Promise<ReferenceCaptureSidecars> {
+  if (typeof input.assertReplayable !== "function") throw new TypeError("capture replay assertion is invalid");
+  const manifest = validateReferenceCaptureManifest(input.manifest);
+  const review = validateReferenceCaptureReview(input.review);
+  if (manifest.capture_id !== review.capture_id) throw new Error("capture sidecar IDs disagree");
+  if (review.replaces_capture_id !== null) {
+    await loadReferenceCaptureSidecars({ root: input.root, captureId: review.replaces_capture_id,
+      assertReplayable: input.assertReplayable });
+  }
+  const captures = join(input.root, "captures");
+  const finalDirectory = captureDirectory(input.root, manifest.capture_id);
+  const pendingName = `.pending-${manifest.capture_id}`;
+  const pendingDirectory = join(captures, pendingName);
+  await ensurePrivateDirectory(input.root);
+  await ensurePrivateDirectory(captures);
+  await assertCommittedMode(captures, "directory", 0o700);
+  try { await lstat(finalDirectory); throw new Error("capture sidecars already exist"); }
+  catch (error) { if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error; }
+  try { await lstat(pendingDirectory); throw new Error("capture sidecar pending directory already exists"); }
+  catch (error) { if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error; }
+
+  let createdPending = false;
+  let renamed = false;
+  try {
+    await mkdir(pendingDirectory, { mode: 0o700 });
+    createdPending = true;
+    const fs = nodeFileSystem();
+    const manifestPath = join(pendingDirectory, "manifest.json");
+    const reviewPath = join(pendingDirectory, "review.json");
+    await fs.writeFile(manifestPath, serializeReferenceCaptureManifest(manifest), { mode: 0o444 });
+    await fs.writeFile(reviewPath, serializeReferenceCaptureReview(review), { mode: 0o444 });
+    await chmod(manifestPath, 0o444);
+    await chmod(reviewPath, 0o444);
+    await chmod(pendingDirectory, 0o700);
+    await input.assertReplayable(manifest);
+    await dependencies?.beforeRename?.();
+    await rename(pendingDirectory, finalDirectory);
+    renamed = true;
+    await chmod(finalDirectory, 0o700);
+  } catch (error) {
+    if (createdPending && !renamed) {
+      if (pendingName !== `.pending-${manifest.capture_id}` || !pendingDirectory.startsWith(`${captures}/`)) {
+        throw new Error("capture pending cleanup target is invalid", { cause: error });
+      }
+      try { await rm(pendingDirectory, { recursive: true }); } catch {}
+    }
+    throw error;
+  }
+  return loadReferenceCaptureSidecars({ root: input.root, captureId: manifest.capture_id,
+    assertReplayable: input.assertReplayable });
+}

--- a/packages/kernel-node/src/ingest/import-files.ts
+++ b/packages/kernel-node/src/ingest/import-files.ts
@@ -59,7 +59,7 @@ export interface SetRepairFixerEnabledOptions {
   readonly store: SqlStore & Pick<MigratorStore, "transaction">;
 }
 
-function nodeCrypto(): CryptoPort {
+export function createNodeCrypto(): CryptoPort {
   const subtle = globalThis.crypto.subtle;
   const toBufferSource = (view: Uint8Array): Uint8Array<ArrayBuffer> => {
     if (view.byteOffset === 0 && view.byteLength === view.buffer.byteLength && view.buffer instanceof ArrayBuffer) {
@@ -189,7 +189,7 @@ async function prepareFit(
 function createImportReportDeps(
   options: NodeImportRuntimeOptions,
 ): ImportReportDeps {
-  const crypto = nodeCrypto();
+  const crypto = createNodeCrypto();
   const fs = nodeFileSystem();
   const archive = createArchiveManager({ archiveRoot: options.archiveDir, crypto, fs });
   const hashKey = (fields: readonly (string | number)[]): Promise<string> => {

--- a/packages/kernel-node/tests/capture-manifest.test.ts
+++ b/packages/kernel-node/tests/capture-manifest.test.ts
@@ -1,0 +1,108 @@
+import { chmod, mkdtemp, mkdir, readFile, readdir, stat, symlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { gzipSync } from "node:zlib";
+import { canonicalJson } from "@enduragent/kernel/archive";
+import { createReferenceCapturePlan, validateReferenceCaptureManifest, type ReferenceCaptureManifest } from "@enduragent/kernel/reference/capture";
+import { describe, expect, it, vi } from "vitest";
+import { createArchiveManager } from "../src/archive/manager.js";
+import { nodeFileSystem } from "../src/filesystem/index.js";
+import { createNodeCrypto } from "../src/ingest/import-files.js";
+import {
+  loadReferenceCaptureSidecars,
+  parseReferenceCaptureReview,
+  readVerifiedReferenceSnapshot,
+  writeReferenceCaptureSidecars,
+} from "../src/capture-manifest/index.js";
+
+const FIRST = "12345678-1234-4123-8123-123456789abc";
+const SECOND = "22345678-1234-4123-8123-123456789abc";
+
+function manifest(captureId = FIRST): ReferenceCaptureManifest {
+  const plan = createReferenceCapturePlan(new Date("1998-07-18T12:00:00.000Z"));
+  const address = "a".repeat(64), snapshot = { address, rel_path: `1998/07/${address}.json.gz` };
+  return validateReferenceCaptureManifest({ schema_version: 1, capture_id: captureId, source: "external-oracle", plan,
+    operation_ledger: { link_kind: "capture-id", capture_id: captureId },
+    endpoints: [
+      { ordinal: 0, lane: "settings", endpoint: "athlete-profile", request: { oldest: null, newest: null, activity_id: null, stream_types: [], include_defaults: null }, snapshot },
+      { ordinal: 1, lane: "activities", endpoint: "activities", request: { oldest: plan.window.oldest, newest: plan.window.newest, activity_id: null, stream_types: [], include_defaults: null }, snapshot },
+      { ordinal: 2, lane: "wellness", endpoint: "wellness", request: { oldest: plan.window.oldest, newest: plan.window.newest, activity_id: null, stream_types: [], include_defaults: null }, snapshot },
+    ], records: { settings: [], activities: [], wellness: [], streams: [] },
+    selected_stream_ids: [], captured_stream_ids: [], deterministic_order: { endpoint_ordinals: [0, 1, 2], settings: [], activities: [], wellness: [], streams: [] } });
+}
+
+describe("verified Reference snapshots", () => {
+  it("binds the exact compressed bytes and canonical decoded JSON", async () => {
+    const root = await mkdtemp(join(tmpdir(), "capture-archive-")), crypto = createNodeCrypto();
+    const archive = createArchiveManager({ archiveRoot: root, crypto, fs: nodeFileSystem() });
+    const written = await archive.writeSnapshot({ b: 2, a: 1 }, { epochSeconds: 899_424_000 });
+    await expect(readVerifiedReferenceSnapshot({ address: written.address, rel_path: written.relPath }, { archive, crypto }))
+      .resolves.toEqual({ a: 1, b: 2 });
+    const alternate = gzipSync(Buffer.from(canonicalJson({ a: 1, b: 3 })), { level: 9 });
+    await expect(readVerifiedReferenceSnapshot({ address: written.address, rel_path: written.relPath }, {
+      crypto, archive: { ...archive, readArtifact: async () => new Uint8Array(alternate) },
+    })).rejects.toThrow(/address/);
+  });
+});
+
+describe("immutable Reference capture sidecars", () => {
+  it("commits canonical read-only sidecars and replays before and after rename", async () => {
+    const root = await mkdtemp(join(tmpdir(), "capture-home-")), replay = vi.fn(async () => {});
+    const result = await writeReferenceCaptureSidecars({ root, manifest: manifest(),
+      review: { schema_version: 1, capture_id: FIRST, reviewed_on: "1998-07-18", replaces_capture_id: null, reason: "initial" },
+      assertReplayable: replay });
+    expect(result.manifest.capture_id).toBe(FIRST);
+    expect(replay).toHaveBeenCalledTimes(2);
+    const directory = join(root, "captures", FIRST);
+    expect((await stat(directory)).mode & 0o777).toBe(0o700);
+    expect((await stat(join(directory, "manifest.json"))).mode & 0o777).toBe(0o444);
+    expect((await stat(join(directory, "review.json"))).mode & 0o777).toBe(0o444);
+    await expect(writeReferenceCaptureSidecars({ root, manifest: manifest(), review: result.review,
+      assertReplayable: replay })).rejects.toThrow();
+    await expect(loadReferenceCaptureSidecars({ root, captureId: FIRST, assertReplayable: replay })).resolves.toEqual(result);
+  });
+
+  it("rejects noncanonical review bytes and cleans only failed pending state", async () => {
+    expect(() => parseReferenceCaptureReview('{"schema_version":1}\n')).toThrow();
+    const root = await mkdtemp(join(tmpdir(), "capture-home-"));
+    await expect(writeReferenceCaptureSidecars({ root, manifest: manifest(),
+      review: { schema_version: 1, capture_id: FIRST, reviewed_on: "1998-07-18", replaces_capture_id: null, reason: "initial" },
+      assertReplayable: async () => {} }, { beforeRename: () => { throw new Error("injected"); } })).rejects.toThrow("injected");
+    await expect(stat(join(root, "captures", FIRST))).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(stat(join(root, "captures", `.pending-${FIRST}`))).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("rejects a captures symlink without writing through it", async () => {
+    const root = await mkdtemp(join(tmpdir(), "capture-home-"));
+    const target = await mkdtemp(join(tmpdir(), "capture-target-"));
+    await symlink(target, join(root, "captures"));
+    await expect(writeReferenceCaptureSidecars({ root, manifest: manifest(),
+      review: { schema_version: 1, capture_id: FIRST, reviewed_on: "1998-07-18", replaces_capture_id: null, reason: "initial" },
+      assertReplayable: async () => {} })).rejects.toThrow("capture sidecar mode is invalid");
+    expect(await readdir(target)).toEqual([]);
+  });
+
+  it("rejects an unsafe captures parent while loading", async () => {
+    const root = await mkdtemp(join(tmpdir(), "capture-home-"));
+    const target = await mkdtemp(join(tmpdir(), "capture-target-"));
+    await symlink(target, join(root, "captures"));
+    await expect(loadReferenceCaptureSidecars({ root, captureId: FIRST,
+      assertReplayable: async () => {} })).rejects.toThrow("capture sidecar mode is invalid");
+
+    const otherRoot = await mkdtemp(join(tmpdir(), "capture-home-"));
+    const captures = join(otherRoot, "captures");
+    await mkdir(captures, { mode: 0o700 });
+    await chmod(captures, 0o755);
+    await expect(loadReferenceCaptureSidecars({ root: otherRoot, captureId: FIRST,
+      assertReplayable: async () => {} })).rejects.toThrow("capture sidecar mode is invalid");
+  });
+
+  it("validates and preserves the prior capture before replacement", async () => {
+    const root = await mkdtemp(join(tmpdir(), "capture-home-")), replay = vi.fn(async () => {});
+    await writeReferenceCaptureSidecars({ root, manifest: manifest(),
+      review: { schema_version: 1, capture_id: FIRST, reviewed_on: "1998-07-18", replaces_capture_id: null, reason: "initial" }, assertReplayable: replay });
+    await writeReferenceCaptureSidecars({ root, manifest: manifest(SECOND),
+      review: { schema_version: 1, capture_id: SECOND, reviewed_on: "1998-07-19", replaces_capture_id: FIRST, reason: "provider-refresh" }, assertReplayable: replay });
+    expect(await readFile(join(root, "captures", FIRST, "manifest.json"), "utf8")).toContain(FIRST);
+  });
+});

--- a/packages/kernel-node/tsup.config.ts
+++ b/packages/kernel-node/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: { index: "src/index.ts", sqlite: "src/sqlite/index.ts", "archive/index": "src/archive/index.ts", "lock/index": "src/lock/index.ts", "store-export/index": "src/store-export/index.ts", "home/index": "src/home/index.ts", "filesystem/index": "src/filesystem/index.ts", "ingest/index": "src/ingest/index.ts", "coach-dev": "src/cli/coach-dev.ts" },
+  entry: { index: "src/index.ts", sqlite: "src/sqlite/index.ts", "archive/index": "src/archive/index.ts", "lock/index": "src/lock/index.ts", "store-export/index": "src/store-export/index.ts", "home/index": "src/home/index.ts", "filesystem/index": "src/filesystem/index.ts", "ingest/index": "src/ingest/index.ts", "capture-manifest/index": "src/capture-manifest/index.ts", "coach-dev": "src/cli/coach-dev.ts" },
   format: ["esm"],
   dts: true,
   sourcemap: true,

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -21,6 +21,7 @@
     "./reference/preserve-tokens": "./dist/reference/preserve-tokens.js",
     "./reference/errors": "./dist/reference/errors.js",
     "./reference/trademark-policy": "./dist/reference/trademark-policy.js",
+    "./reference/capture": "./dist/reference/capture.js",
     "./concurrency": "./dist/concurrency.js"
   },
   "scripts": {

--- a/packages/kernel/src/reference/capture.ts
+++ b/packages/kernel/src/reference/capture.ts
@@ -1,0 +1,415 @@
+import { canonicalJson } from "../archive/canonical.js";
+import { z } from "zod";
+
+export const REFERENCE_CAPTURE_SCHEMA_VERSION = 1 as const;
+export const REFERENCE_CAPTURE_WINDOW_DAYS = 84 as const;
+export const REFERENCE_CAPTURE_STREAM_WINDOW_DAYS = 21 as const;
+export const REFERENCE_CAPTURE_STREAM_LIMIT = 12 as const;
+export const REFERENCE_CAPTURE_STREAM_TYPES = Object.freeze([
+  "time", "watts", "heartrate", "dfa_a1", "artifacts",
+] as const);
+export const REFERENCE_CAPTURE_STREAM_SPORT_TYPES = Object.freeze([
+  "Ride", "VirtualRide",
+] as const);
+
+const DAY_MS = 24 * 60 * 60 * 1_000;
+const HEX = /^[0-9a-f]{64}$/;
+const SNAPSHOT_PATH = /^[0-9]{4}\/[0-9]{2}\/[0-9a-f]{64}\.json\.gz$/;
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const DATE = /^[0-9]{4}-[0-9]{2}-[0-9]{2}$/;
+const LOCAL_DATE_TIME = /^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}$/;
+
+function realDate(value: string): boolean {
+  if (!DATE.test(value)) return false;
+  const [year, month, day] = value.split("-").map(Number) as [number, number, number];
+  const parsed = new Date(Date.UTC(year, month - 1, day));
+  return parsed.getUTCFullYear() === year && parsed.getUTCMonth() + 1 === month && parsed.getUTCDate() === day;
+}
+
+function realLocalDateTime(value: string): boolean {
+  if (!LOCAL_DATE_TIME.test(value) || !realDate(value.slice(0, 10))) return false;
+  const hour = Number(value.slice(11, 13));
+  const minute = Number(value.slice(14, 16));
+  const second = Number(value.slice(17, 19));
+  return hour >= 0 && hour <= 23 && minute >= 0 && minute <= 59 && second >= 0 && second <= 59;
+}
+
+const safeInteger = z.number().refine(Number.isSafeInteger, "must be a safe integer");
+const nonnegativeInteger = safeInteger.refine((value) => value >= 0, "must be nonnegative");
+const nonemptyString = z.string().min(1);
+const civilDate = z.string().refine(realDate, "must be a real civil date");
+const localDateTime = z.string().refine(realLocalDateTime, "must be a real local date-time");
+
+const CapturePlanSchema = z.object({
+  capture_epoch_ms: safeInteger,
+  frozenNow: localDateTime,
+  window: z.object({ oldest: civilDate, newest: civilDate }).strict(),
+  stream_cutoff_epoch_ms: safeInteger,
+}).strict().superRefine((value, context) => {
+  if (value.window.oldest > value.window.newest) {
+    context.addIssue({ code: "custom", message: "capture window is reversed", path: ["window"] });
+  }
+  if (value.stream_cutoff_epoch_ms !== value.capture_epoch_ms - REFERENCE_CAPTURE_STREAM_WINDOW_DAYS * DAY_MS) {
+    context.addIssue({ code: "custom", message: "stream cutoff does not match capture epoch", path: ["stream_cutoff_epoch_ms"] });
+  }
+});
+
+const SnapshotRefSchema = z.object({
+  address: z.string().regex(HEX),
+  rel_path: z.string().regex(SNAPSHOT_PATH),
+}).strict().superRefine((value, context) => {
+  if (value.rel_path.split("/").at(-1) !== `${value.address}.json.gz`) {
+    context.addIssue({ code: "custom", message: "snapshot basename does not match address", path: ["rel_path"] });
+  }
+});
+
+const CurrentRevisionRefSchema = z.object({
+  source_record_id: z.string().regex(HEX),
+  revision_id: z.string().regex(HEX),
+}).strict();
+
+const RecordRefSchema = z.object({
+  ordinal: nonnegativeInteger,
+  endpoint_ordinal: nonnegativeInteger,
+  payload_index: nonnegativeInteger.nullable(),
+  external_id: nonemptyString,
+  snapshot: SnapshotRefSchema,
+  store_evidence: z.object({
+    artifact_key: z.string().regex(HEX),
+    current_revision: CurrentRevisionRefSchema.nullable(),
+  }).strict(),
+}).strict();
+
+const EndpointRefSchema = z.object({
+  ordinal: nonnegativeInteger,
+  lane: z.enum(["settings", "activities", "wellness", "streams"]),
+  endpoint: z.enum(["athlete-profile", "activities", "wellness", "activity-streams"]),
+  request: z.object({
+    oldest: civilDate.nullable(),
+    newest: civilDate.nullable(),
+    activity_id: nonemptyString.nullable(),
+    stream_types: z.array(z.string()),
+    include_defaults: z.literal(false).nullable(),
+  }).strict(),
+  snapshot: SnapshotRefSchema,
+}).strict();
+
+const ManifestSchema = z.object({
+  schema_version: z.literal(REFERENCE_CAPTURE_SCHEMA_VERSION),
+  capture_id: z.string().regex(UUID),
+  source: z.literal("external-oracle"),
+  plan: CapturePlanSchema,
+  operation_ledger: z.object({
+    link_kind: z.literal("capture-id"),
+    capture_id: z.string().regex(UUID),
+  }).strict(),
+  endpoints: z.array(EndpointRefSchema),
+  records: z.object({
+    settings: z.array(RecordRefSchema),
+    activities: z.array(RecordRefSchema),
+    wellness: z.array(RecordRefSchema),
+    streams: z.array(RecordRefSchema),
+  }).strict(),
+  selected_stream_ids: z.array(nonemptyString),
+  captured_stream_ids: z.array(nonemptyString),
+  deterministic_order: z.object({
+    endpoint_ordinals: z.array(nonnegativeInteger),
+    settings: z.array(nonemptyString),
+    activities: z.array(nonemptyString),
+    wellness: z.array(nonemptyString),
+    streams: z.array(nonemptyString),
+  }).strict(),
+}).strict().superRefine((value, context) => {
+  const issue = (message: string, path: PropertyKey[] = []): void => {
+    context.addIssue({ code: "custom", message, path: path as (string | number)[] });
+  };
+  if (value.operation_ledger.capture_id !== value.capture_id) issue("capture IDs disagree", ["operation_ledger", "capture_id"]);
+
+  const expectedRequired = [
+    { lane: "settings", endpoint: "athlete-profile" },
+    { lane: "activities", endpoint: "activities" },
+    { lane: "wellness", endpoint: "wellness" },
+  ] as const;
+  if (value.endpoints.length < expectedRequired.length) issue("required endpoints are absent", ["endpoints"]);
+  for (let index = 0; index < value.endpoints.length; index += 1) {
+    const endpoint = value.endpoints[index]!;
+    if (endpoint.ordinal !== index) issue("endpoint ordinal is not dense", ["endpoints", index, "ordinal"]);
+    if (index < 3) {
+      const expected = expectedRequired[index]!;
+      if (endpoint.lane !== expected.lane || endpoint.endpoint !== expected.endpoint) {
+        issue("required endpoint is invalid", ["endpoints", index]);
+      }
+      const range = index === 0 ? [null, null] : [value.plan.window.oldest, value.plan.window.newest];
+      if (endpoint.request.oldest !== range[0] || endpoint.request.newest !== range[1]
+        || endpoint.request.activity_id !== null || endpoint.request.stream_types.length !== 0
+        || endpoint.request.include_defaults !== null) issue("required endpoint request is invalid", ["endpoints", index, "request"]);
+    } else if (endpoint.lane !== "streams" || endpoint.endpoint !== "activity-streams"
+      || endpoint.request.oldest !== null || endpoint.request.newest !== null
+      || endpoint.request.activity_id === null
+      || canonicalJson(endpoint.request.stream_types) !== canonicalJson(REFERENCE_CAPTURE_STREAM_TYPES)
+      || endpoint.request.include_defaults !== false) {
+      issue("stream endpoint request is invalid", ["endpoints", index]);
+    }
+  }
+
+  const unique = (items: readonly string[], path: string): void => {
+    if (new Set(items).size !== items.length) issue(`${path} contains duplicates`, [path]);
+  };
+  unique(value.selected_stream_ids, "selected_stream_ids");
+  unique(value.captured_stream_ids, "captured_stream_ids");
+  const endpointStreamIds = value.endpoints.slice(3).map((endpoint) => endpoint.request.activity_id!);
+  if (canonicalJson(endpointStreamIds) !== canonicalJson(value.captured_stream_ids)) {
+    issue("stream endpoints disagree with captured IDs", ["captured_stream_ids"]);
+  }
+  let selectedOffset = 0;
+  for (const id of value.captured_stream_ids) {
+    const selectedIndex = value.selected_stream_ids.indexOf(id, selectedOffset);
+    if (selectedIndex < 0) { issue("captured IDs are not a selector subsequence", ["captured_stream_ids"]); break; }
+    selectedOffset = selectedIndex + 1;
+  }
+
+  for (const lane of ["settings", "activities", "wellness", "streams"] as const) {
+    const records = value.records[lane];
+    unique(records.map((record) => record.external_id), `records.${lane}`);
+    for (let index = 0; index < records.length; index += 1) {
+      const record = records[index]!;
+      if (record.ordinal !== index) issue("record ordinal is not dense", ["records", lane, index, "ordinal"]);
+      if (lane === "streams") {
+        if (record.payload_index !== null || record.endpoint_ordinal !== 3 + index
+          || record.external_id !== `streams:${value.captured_stream_ids[index]}`
+          || canonicalJson(record.snapshot) !== canonicalJson(value.endpoints[3 + index]?.snapshot)) {
+          issue("stream record attribution is invalid", ["records", lane, index]);
+        }
+      } else {
+        const expectedEndpoint = lane === "settings" ? 0 : lane === "activities" ? 1 : 2;
+        if (record.endpoint_ordinal !== expectedEndpoint || record.payload_index === null) {
+          issue("record endpoint attribution is invalid", ["records", lane, index]);
+        }
+      }
+      if ((lane === "wellness") !== (record.store_evidence.current_revision === null)) {
+        issue("record revision evidence is invalid", ["records", lane, index, "store_evidence", "current_revision"]);
+      }
+    }
+    if (lane !== "streams") {
+      const indexes = records.map((record) => record.payload_index!);
+      if (new Set(indexes).size !== indexes.length) issue("payload indexes contain duplicates", ["records", lane]);
+    }
+  }
+
+  const ordinals = value.endpoints.map((endpoint) => endpoint.ordinal);
+  if (canonicalJson(value.deterministic_order.endpoint_ordinals) !== canonicalJson(ordinals)) {
+    issue("endpoint deterministic order is invalid", ["deterministic_order", "endpoint_ordinals"]);
+  }
+  for (const lane of ["settings", "activities", "wellness"] as const) {
+    if (canonicalJson(value.deterministic_order[lane]) !== canonicalJson(value.records[lane].map((record) => record.external_id))) {
+      issue("record deterministic order is invalid", ["deterministic_order", lane]);
+    }
+  }
+  if (canonicalJson(value.deterministic_order.streams) !== canonicalJson(value.captured_stream_ids)) {
+    issue("stream deterministic order is invalid", ["deterministic_order", "streams"]);
+  }
+});
+
+export type ReferenceCapturePlan = z.infer<typeof CapturePlanSchema>;
+export type SnapshotRef = z.infer<typeof SnapshotRefSchema>;
+export type CurrentRevisionRef = z.infer<typeof CurrentRevisionRefSchema>;
+export type RecordRef = z.infer<typeof RecordRefSchema>;
+export type EndpointRef = z.infer<typeof EndpointRefSchema>;
+export type ReferenceCaptureManifest = z.infer<typeof ManifestSchema>;
+
+export interface DerivedCaptureMember {
+  readonly endpoint_ordinal: number;
+  readonly payload_index: number | null;
+  readonly external_id: string;
+  readonly payload: unknown;
+}
+
+export interface DerivedCaptureMembers {
+  readonly settings: readonly DerivedCaptureMember[];
+  readonly activities: readonly DerivedCaptureMember[];
+  readonly wellness: readonly DerivedCaptureMember[];
+  readonly streams: readonly DerivedCaptureMember[];
+  readonly selected_stream_ids: readonly string[];
+}
+
+export interface ReferenceCaptureEndpointPayload {
+  readonly ordinal: number;
+  readonly lane: EndpointRef["lane"];
+  readonly endpoint: EndpointRef["endpoint"];
+  readonly request: EndpointRef["request"];
+  readonly payload: unknown;
+}
+
+export function createReferenceCapturePlan(now: Date): ReferenceCapturePlan {
+  if (!(now instanceof Date)) throw new TypeError("capture clock is invalid");
+  const captureEpochMs = now.getTime();
+  if (!Number.isSafeInteger(captureEpochMs)) throw new TypeError("capture clock is invalid");
+  const pad = (value: number): string => String(value).padStart(2, "0");
+  return validateReferenceCapturePlan({
+    capture_epoch_ms: captureEpochMs,
+    frozenNow: `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}T${pad(now.getHours())}:${pad(now.getMinutes())}:${pad(now.getSeconds())}`,
+    window: {
+      newest: now.toISOString().slice(0, 10),
+      oldest: new Date(captureEpochMs - REFERENCE_CAPTURE_WINDOW_DAYS * DAY_MS).toISOString().slice(0, 10),
+    },
+    stream_cutoff_epoch_ms: captureEpochMs - REFERENCE_CAPTURE_STREAM_WINDOW_DAYS * DAY_MS,
+  });
+}
+
+export function validateReferenceCapturePlan(value: unknown): ReferenceCapturePlan {
+  return CapturePlanSchema.parse(value);
+}
+
+function exactParse<T>(bytes: string | Uint8Array, validate: (value: unknown) => T, serialize: (value: T) => string): T {
+  let text: string;
+  try { text = typeof bytes === "string" ? bytes : new TextDecoder("utf-8", { fatal: true }).decode(bytes); }
+  catch { throw new TypeError("capture sidecar encoding is invalid"); }
+  let parsed: unknown;
+  try { parsed = JSON.parse(text); } catch { throw new TypeError("capture sidecar JSON is invalid"); }
+  const value = validate(parsed);
+  if (serialize(value) !== text) throw new TypeError("capture sidecar bytes are not canonical");
+  return value;
+}
+
+export function serializeReferenceCapturePlan(value: unknown): string {
+  return `${canonicalJson(validateReferenceCapturePlan(value))}\n`;
+}
+
+export function parseReferenceCapturePlan(bytes: string | Uint8Array): ReferenceCapturePlan {
+  return exactParse(bytes, validateReferenceCapturePlan, serializeReferenceCapturePlan);
+}
+
+export function selectReferenceCaptureStreamIds(activities: readonly unknown[], plan: ReferenceCapturePlan): string[] {
+  const validPlan = validateReferenceCapturePlan(plan);
+  if (!Array.isArray(activities)) throw new TypeError("capture activities are invalid");
+  const candidates: { readonly id: string; readonly time: number; readonly index: number }[] = [];
+  for (let index = 0; index < activities.length; index += 1) {
+    const value = activities[index];
+    if (value === null || typeof value !== "object" || Array.isArray(value)) continue;
+    const row = value as Record<string, unknown>;
+    if (!(REFERENCE_CAPTURE_STREAM_SPORT_TYPES as readonly unknown[]).includes(row.type)) continue;
+    if (typeof row.start_date_local !== "string") continue;
+    const time = Date.parse(row.start_date_local);
+    if (!Number.isFinite(time) || time < validPlan.stream_cutoff_epoch_ms) continue;
+    const id = String(row.id);
+    if (id.length === 0) throw new TypeError("capture stream activity ID is empty");
+    candidates.push({ id, time, index });
+  }
+  candidates.sort((left, right) => right.time - left.time || left.index - right.index);
+  const selected: string[] = [];
+  const seen = new Set<string>();
+  for (const candidate of candidates) {
+    if (seen.has(candidate.id)) continue;
+    seen.add(candidate.id);
+    selected.push(candidate.id);
+    if (selected.length === REFERENCE_CAPTURE_STREAM_LIMIT) break;
+  }
+  return selected;
+}
+
+export function validateReferenceCaptureManifest(value: unknown): ReferenceCaptureManifest {
+  return ManifestSchema.parse(value);
+}
+
+export function serializeReferenceCaptureManifest(value: unknown): string {
+  return `${canonicalJson(validateReferenceCaptureManifest(value))}\n`;
+}
+
+export function parseReferenceCaptureManifest(bytes: string | Uint8Array): ReferenceCaptureManifest {
+  return exactParse(bytes, validateReferenceCaptureManifest, serializeReferenceCaptureManifest);
+}
+
+export interface ReferenceCaptureReplayDependencies {
+  readonly readVerifiedSnapshot: (reference: SnapshotRef) => Promise<unknown>;
+  readonly derivePayloadMembers: (
+    plan: ReferenceCapturePlan,
+    endpointPayloads: readonly ReferenceCaptureEndpointPayload[],
+  ) => DerivedCaptureMembers | Promise<DerivedCaptureMembers>;
+  readonly assertStoreEvidence: (
+    record: RecordRef,
+    lane: "settings" | "activities" | "wellness" | "streams",
+  ) => Promise<void>;
+}
+
+function assertDerivedMembers(value: unknown): asserts value is DerivedCaptureMembers {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) throw new TypeError("derived capture members are invalid");
+  const derived = value as Record<string, unknown>;
+  if (Object.keys(derived).sort().join(",") !== "activities,selected_stream_ids,settings,streams,wellness") {
+    throw new TypeError("derived capture members are invalid");
+  }
+  for (const lane of ["settings", "activities", "wellness", "streams"] as const) {
+    if (!Array.isArray(derived[lane])) throw new TypeError("derived capture members are invalid");
+    const ids = new Set<string>();
+    for (const member of derived[lane]) {
+      if (member === null || typeof member !== "object" || Array.isArray(member)) throw new TypeError("derived capture member is invalid");
+      const item = member as Record<string, unknown>;
+      if (Object.keys(item).sort().join(",") !== "endpoint_ordinal,external_id,payload,payload_index"
+        || !Number.isSafeInteger(item.endpoint_ordinal) || (item.endpoint_ordinal as number) < 0
+        || (item.payload_index !== null && (!Number.isSafeInteger(item.payload_index) || (item.payload_index as number) < 0))
+        || typeof item.external_id !== "string" || item.external_id.length === 0 || ids.has(item.external_id)) {
+        throw new TypeError("derived capture member is invalid");
+      }
+      ids.add(item.external_id);
+    }
+  }
+  if (!Array.isArray(derived.selected_stream_ids) || derived.selected_stream_ids.some((id) => typeof id !== "string" || id.length === 0)
+    || new Set(derived.selected_stream_ids as string[]).size !== derived.selected_stream_ids.length) {
+    throw new TypeError("derived stream selection is invalid");
+  }
+}
+
+export async function assertReferenceCaptureReplayable(
+  input: unknown,
+  dependencies: ReferenceCaptureReplayDependencies,
+): Promise<void> {
+  const manifest = validateReferenceCaptureManifest(input);
+  const endpointPayloads: ReferenceCaptureEndpointPayload[] = [];
+  for (const endpoint of manifest.endpoints) endpointPayloads.push({
+    ordinal: endpoint.ordinal,
+    lane: endpoint.lane,
+    endpoint: endpoint.endpoint,
+    request: endpoint.request,
+    payload: await dependencies.readVerifiedSnapshot(endpoint.snapshot),
+  });
+  const recordPayloads = { settings: [] as unknown[], activities: [] as unknown[], wellness: [] as unknown[], streams: [] as unknown[] };
+  for (const lane of ["settings", "activities", "wellness", "streams"] as const) {
+    for (const record of manifest.records[lane]) recordPayloads[lane].push(await dependencies.readVerifiedSnapshot(record.snapshot));
+  }
+
+  const derived = await dependencies.derivePayloadMembers(manifest.plan, endpointPayloads);
+  assertDerivedMembers(derived);
+  for (const lane of ["settings", "activities", "wellness", "streams"] as const) {
+    const expected = manifest.records[lane];
+    const actual = derived[lane];
+    if (actual.length !== expected.length) throw new Error("capture membership count differs");
+    for (let index = 0; index < expected.length; index += 1) {
+      const record = expected[index]!, member = actual[index]!;
+      if (member.endpoint_ordinal !== record.endpoint_ordinal || member.payload_index !== record.payload_index
+        || member.external_id !== record.external_id
+        || canonicalJson(recordPayloads[lane][index]) !== canonicalJson(member.payload)) {
+        throw new Error("capture membership differs");
+      }
+    }
+  }
+  if (canonicalJson(derived.selected_stream_ids) !== canonicalJson(manifest.selected_stream_ids)) {
+    throw new Error("capture stream selection differs");
+  }
+  const derivedCapturedIds = derived.streams.map((member) => member.external_id.slice("streams:".length));
+  if (canonicalJson(derivedCapturedIds) !== canonicalJson(manifest.captured_stream_ids)) {
+    throw new Error("captured stream membership differs");
+  }
+
+  const derivedOrder = {
+    endpoint_ordinals: endpointPayloads.map((_, index) => index),
+    settings: derived.settings.map((member) => member.external_id),
+    activities: derived.activities.map((member) => member.external_id),
+    wellness: derived.wellness.map((member) => member.external_id),
+    streams: derivedCapturedIds,
+  };
+  if (canonicalJson(derivedOrder) !== canonicalJson(manifest.deterministic_order)) {
+    throw new Error("capture deterministic order differs");
+  }
+  for (const lane of ["settings", "activities", "wellness", "streams"] as const) {
+    for (const record of manifest.records[lane]) await dependencies.assertStoreEvidence(record, lane);
+  }
+}

--- a/packages/kernel/src/store/ports.ts
+++ b/packages/kernel/src/store/ports.ts
@@ -160,6 +160,24 @@ export interface IntervalsSourceRepository {
   upsertWellness(row: WellnessLandingRow): Promise<"inserted" | "updated" | "unchanged" | "manual-wins">;
   insertSyncedAnchor(row: AnchorHistoryRow): Promise<boolean>;
   insertSyncedZone(row: ZoneSetHistoryRow): Promise<boolean>;
+  readCurrentCaptureEvidence(
+    lane: "activities" | "settings" | "streams",
+    externalId: string,
+  ): Promise<{
+    readonly artifactKey: string;
+    readonly archiveAddress: string;
+    readonly archiveRelPath: string;
+    readonly sourceRecordId: string;
+    readonly revisionId: string;
+  }>;
+  assertPinnedCaptureEvidence(input: {
+    readonly lane: "activities" | "settings" | "streams" | "wellness";
+    readonly externalId: string;
+    readonly artifactKey: string;
+    readonly archiveAddress: string;
+    readonly archiveRelPath: string;
+    readonly currentRevision: { readonly sourceRecordId: string; readonly revisionId: string } | null;
+  }): Promise<void>;
 }
 
 export interface DedupConfirmationRow {

--- a/packages/kernel/src/store/source-repository.ts
+++ b/packages/kernel/src/store/source-repository.ts
@@ -83,6 +83,7 @@ export function createSourceRecordRepository(store: SqlStore): SourceRecordRepos
 
 type HashKey = (fields: readonly (string | number)[]) => Promise<string>;
 const HEX = /^[0-9a-f]{64}$/;
+const SNAPSHOT_PATH = /^[0-9]{4}\/[0-9]{2}\/[0-9a-f]{64}\.json\.gz$/;
 
 function nonempty(value: unknown, name: string): asserts value is string {
   if (typeof value !== "string" || value.length === 0) throw new TypeError(`${name} is invalid`);
@@ -90,6 +91,11 @@ function nonempty(value: unknown, name: string): asserts value is string {
 
 function address(value: unknown, name: string): asserts value is string {
   if (typeof value !== "string" || !HEX.test(value)) throw new TypeError(`${name} is invalid`);
+}
+
+function snapshotPath(value: unknown, expectedAddress: string, name: string): asserts value is string {
+  if (typeof value !== "string" || !SNAPSHOT_PATH.test(value)
+    || value.split("/").at(-1) !== `${expectedAddress}.json.gz`) throw new TypeError(`${name} is invalid`);
 }
 
 function epoch(value: unknown, name: string): asserts value is number {
@@ -381,5 +387,82 @@ VALUES (?,?,?,?,?,?,?,?,?,?,?) ON CONFLICT DO NOTHING RETURNING id`, [row.id, ro
     return inserted !== undefined;
   }
 
-  return { recordArtifact, recordGenericLanding, applyActivityRevision, upsertWellness, insertSyncedAnchor, insertSyncedZone };
+  async function readCurrentCaptureEvidence(
+    lane: "activities" | "settings" | "streams",
+    externalId: string,
+  ): Promise<{ artifactKey: string; archiveAddress: string; archiveRelPath: string; sourceRecordId: string; revisionId: string }> {
+    if (!["activities", "settings", "streams"].includes(lane)) throw new TypeError("capture evidence lane is invalid");
+    nonempty(externalId, "capture evidence external id");
+    const rows = await store.all(`SELECT
+  a.artifact_key, a.archive_address, a.archive_rel_path,
+  r.source_record_id, r.revision_id
+FROM source_record_current AS c
+JOIN source_record_revision AS r
+  ON r.source_record_id = c.source_record_id AND r.revision_id = c.revision_id
+JOIN source_record AS sr ON sr.id = r.source_record_id
+JOIN source_artifact AS a ON a.artifact_key = r.artifact_key
+WHERE sr.source = 'intervals-icu' AND sr.external_id = ?
+  AND a.source = 'intervals-icu' AND a.lane = ? AND a.external_id = ?`, [externalId, lane, externalId]);
+    if (rows.length !== 1) throw new Error("current capture evidence is absent or ambiguous");
+    const row = rows[0]!;
+    address(row.artifact_key, "capture artifact key");
+    address(row.archive_address, "capture archive address");
+    snapshotPath(row.archive_rel_path, row.archive_address, "capture archive path");
+    address(row.source_record_id, "capture source record id");
+    address(row.revision_id, "capture revision id");
+    return { artifactKey: row.artifact_key, archiveAddress: row.archive_address,
+      archiveRelPath: row.archive_rel_path, sourceRecordId: row.source_record_id, revisionId: row.revision_id };
+  }
+
+  async function assertPinnedCaptureEvidence(input: {
+    lane: "activities" | "settings" | "streams" | "wellness";
+    externalId: string;
+    artifactKey: string;
+    archiveAddress: string;
+    archiveRelPath: string;
+    currentRevision: { sourceRecordId: string; revisionId: string } | null;
+  }): Promise<void> {
+    if (input === null || typeof input !== "object"
+      || !["activities", "settings", "streams", "wellness"].includes(input.lane)) {
+      throw new TypeError("pinned capture evidence is invalid");
+    }
+    nonempty(input.externalId, "pinned capture external id");
+    address(input.artifactKey, "pinned capture artifact key");
+    address(input.archiveAddress, "pinned capture archive address");
+    snapshotPath(input.archiveRelPath, input.archiveAddress, "pinned capture archive path");
+    const artifact = await store.get(`SELECT artifact_key, source, lane, external_id, artifact_kind,
+       archive_address, archive_rel_path
+FROM source_artifact WHERE artifact_key = ?`, [input.artifactKey]);
+    exactRow(artifact, { artifact_key: input.artifactKey, source: "intervals-icu", lane: input.lane,
+      external_id: input.externalId, artifact_kind: "snapshot", archive_address: input.archiveAddress,
+      archive_rel_path: input.archiveRelPath }, "pinned capture artifact mismatch");
+    if (input.lane === "wellness") {
+      if (input.currentRevision !== null) throw new TypeError("wellness capture revision must be null");
+      const attached = await store.get("SELECT id FROM source_record WHERE artifact_key = ?", [input.artifactKey]);
+      if (attached !== undefined) throw new Error("wellness capture artifact has a source record");
+      return;
+    }
+    if (input.currentRevision === null) throw new TypeError("pinned capture revision is absent");
+    address(input.currentRevision.sourceRecordId, "pinned source record id");
+    address(input.currentRevision.revisionId, "pinned revision id");
+    const revision = await store.get(`SELECT
+  r.source_record_id, r.revision_id, r.artifact_key,
+  sr.source, sr.external_id,
+  a.source AS artifact_source, a.lane, a.external_id AS artifact_external_id,
+  a.artifact_kind, a.archive_address, a.archive_rel_path
+FROM source_record_revision AS r
+JOIN source_record AS sr ON sr.id = r.source_record_id
+JOIN source_artifact AS a ON a.artifact_key = r.artifact_key
+WHERE r.source_record_id = ? AND r.revision_id = ?`,
+    [input.currentRevision.sourceRecordId, input.currentRevision.revisionId]);
+    exactRow(revision, { source_record_id: input.currentRevision.sourceRecordId,
+      revision_id: input.currentRevision.revisionId, artifact_key: input.artifactKey,
+      source: "intervals-icu", external_id: input.externalId, artifact_source: "intervals-icu",
+      lane: input.lane, artifact_external_id: input.externalId, artifact_kind: "snapshot",
+      archive_address: input.archiveAddress, archive_rel_path: input.archiveRelPath },
+    "pinned capture revision mismatch");
+  }
+
+  return { recordArtifact, recordGenericLanding, applyActivityRevision, upsertWellness, insertSyncedAnchor,
+    insertSyncedZone, readCurrentCaptureEvidence, assertPinnedCaptureEvidence };
 }

--- a/packages/kernel/tests/reference-capture.test.ts
+++ b/packages/kernel/tests/reference-capture.test.ts
@@ -1,0 +1,207 @@
+import { createHash } from "node:crypto";
+import { describe, expect, it, vi } from "vitest";
+import { openSqliteStorage } from "../../kernel-node/src/sqlite/index.js";
+import { canonicalJson } from "../src/archive/index.js";
+import { QUALITY_RANK } from "../src/ingest/quality-rank.js";
+import {
+  assertReferenceCaptureReplayable,
+  createReferenceCapturePlan,
+  parseReferenceCaptureManifest,
+  parseReferenceCapturePlan,
+  selectReferenceCaptureStreamIds,
+  serializeReferenceCaptureManifest,
+  serializeReferenceCapturePlan,
+  validateReferenceCaptureManifest,
+  type DerivedCaptureMembers,
+  type ReferenceCaptureManifest,
+} from "../src/reference/capture.js";
+import { createIntervalsSourceRepository, runMigrations, type SourceRecordRow } from "../src/store/index.js";
+import { MIGRATIONS } from "../src/store/migrations/index.js";
+
+const ADDRESS = "a".repeat(64);
+const ARTIFACT = "b".repeat(64);
+const RECORD = "c".repeat(64);
+const REVISION = "d".repeat(64);
+const CAPTURE_ID = "12345678-1234-4123-8123-123456789abc";
+const NOW = new Date("1998-07-18T12:34:56.789Z");
+const hashKey = async (fields: readonly (string | number)[]): Promise<string> =>
+  createHash("sha256").update(fields.join("\u001f")).digest("hex");
+
+function snapshot() { return { address: ADDRESS, rel_path: `1998/07/${ADDRESS}.json.gz` }; }
+
+function manifest(): ReferenceCaptureManifest {
+  const plan = createReferenceCapturePlan(NOW);
+  return validateReferenceCaptureManifest({
+    schema_version: 1, capture_id: CAPTURE_ID, source: "external-oracle", plan,
+    operation_ledger: { link_kind: "capture-id", capture_id: CAPTURE_ID },
+    endpoints: [
+      { ordinal: 0, lane: "settings", endpoint: "athlete-profile", request: { oldest: null, newest: null,
+        activity_id: null, stream_types: [], include_defaults: null }, snapshot: snapshot() },
+      { ordinal: 1, lane: "activities", endpoint: "activities", request: { oldest: plan.window.oldest,
+        newest: plan.window.newest, activity_id: null, stream_types: [], include_defaults: null }, snapshot: snapshot() },
+      { ordinal: 2, lane: "wellness", endpoint: "wellness", request: { oldest: plan.window.oldest,
+        newest: plan.window.newest, activity_id: null, stream_types: [], include_defaults: null }, snapshot: snapshot() },
+      { ordinal: 3, lane: "streams", endpoint: "activity-streams", request: { oldest: null, newest: null,
+        activity_id: "42", stream_types: ["time", "watts", "heartrate", "dfa_a1", "artifacts"],
+        include_defaults: false }, snapshot: snapshot() },
+    ],
+    records: {
+      settings: [{ ordinal: 0, endpoint_ordinal: 0, payload_index: 1, external_id: "settings:one", snapshot: snapshot(),
+        store_evidence: { artifact_key: ARTIFACT, current_revision: { source_record_id: RECORD, revision_id: REVISION } } }],
+      activities: [{ ordinal: 0, endpoint_ordinal: 1, payload_index: 2, external_id: "42", snapshot: snapshot(),
+        store_evidence: { artifact_key: ARTIFACT, current_revision: { source_record_id: RECORD, revision_id: REVISION } } }],
+      wellness: [{ ordinal: 0, endpoint_ordinal: 2, payload_index: 0, external_id: "1998-07-17", snapshot: snapshot(),
+        store_evidence: { artifact_key: ARTIFACT, current_revision: null } }],
+      streams: [{ ordinal: 0, endpoint_ordinal: 3, payload_index: null, external_id: "streams:42", snapshot: snapshot(),
+        store_evidence: { artifact_key: ARTIFACT, current_revision: { source_record_id: RECORD, revision_id: REVISION } } }],
+    },
+    selected_stream_ids: ["99", "42"], captured_stream_ids: ["42"],
+    deterministic_order: { endpoint_ordinals: [0, 1, 2, 3], settings: ["settings:one"], activities: ["42"],
+      wellness: ["1998-07-17"], streams: ["42"] },
+  });
+}
+
+describe("Reference capture plan and manifest", () => {
+  it("owns one clock and exact canonical bytes", () => {
+    const plan = createReferenceCapturePlan(NOW);
+    expect(plan.capture_epoch_ms).toBe(NOW.getTime());
+    expect(plan.stream_cutoff_epoch_ms).toBe(NOW.getTime() - 21 * 86_400_000);
+    expect(plan.frozenNow).toMatch(/^1998-07-18T/);
+    expect(parseReferenceCapturePlan(serializeReferenceCapturePlan(plan))).toEqual(plan);
+    expect(() => createReferenceCapturePlan(new Date(Number.NaN))).toThrow();
+    expect(() => parseReferenceCapturePlan(`${serializeReferenceCapturePlan(plan)} `)).toThrow();
+  });
+
+  it("strictly validates every manifest object and exact bytes", () => {
+    const value = manifest(), bytes = serializeReferenceCaptureManifest(value);
+    expect(parseReferenceCaptureManifest(bytes)).toEqual(value);
+    expect(() => parseReferenceCaptureManifest(bytes.trim())).toThrow();
+    expect(() => validateReferenceCaptureManifest({ ...value, extra: true })).toThrow();
+    expect(() => validateReferenceCaptureManifest({ ...value,
+      records: { ...value.records, activities: [{ ...value.records.activities[0]!, store_evidence: {
+        ...value.records.activities[0]!.store_evidence, current_revision: null } }] } })).toThrow();
+  });
+
+  it("selects by parsed time then encounter index without key ordering", () => {
+    const plan = createReferenceCapturePlan(NOW);
+    const same = new Date(plan.capture_epoch_ms - 1_000).toISOString();
+    expect(selectReferenceCaptureStreamIds([
+      { id: "z", type: "Ride", start_date_local: same },
+      { id: "a", type: "VirtualRide", start_date_local: same },
+      { id: "run", type: "Run", start_date_local: same },
+      { id: "z", type: "Ride", start_date_local: new Date(plan.capture_epoch_ms).toISOString() },
+    ], plan)).toEqual(["z", "a"]);
+  });
+});
+
+describe("assertReferenceCaptureReplayable", () => {
+  function derived(): DerivedCaptureMembers {
+    return { settings: [{ endpoint_ordinal: 0, payload_index: 1, external_id: "settings:one", payload: { setting: 1 } }],
+      activities: [{ endpoint_ordinal: 1, payload_index: 2, external_id: "42", payload: { activity: 1 } }],
+      wellness: [{ endpoint_ordinal: 2, payload_index: 0, external_id: "1998-07-17", payload: { wellness: 1 } }],
+      streams: [{ endpoint_ordinal: 3, payload_index: null, external_id: "streams:42", payload: { stream: 1 } }],
+      selected_stream_ids: ["99", "42"] };
+  }
+  it("reads every reference, derives once, and checks every pinned record", async () => {
+    const value = manifest(), payloads = [{}, {}, {}, {}, { setting: 1 }, { activity: 1 }, { wellness: 1 }, { stream: 1 }];
+    const read = vi.fn(async () => payloads.shift()), derive = vi.fn(async () => derived()), evidence = vi.fn(async () => {});
+    await assertReferenceCaptureReplayable(value, { readVerifiedSnapshot: read, derivePayloadMembers: derive,
+      assertStoreEvidence: evidence });
+    expect(read).toHaveBeenCalledTimes(8);
+    expect(derive).toHaveBeenCalledTimes(1);
+    expect(evidence).toHaveBeenCalledTimes(4);
+  });
+
+  it("rejects missing, permuted, and byte-different members", async () => {
+    const value = manifest();
+    const run = (changed: DerivedCaptureMembers) => {
+      const payloads = [{}, {}, {}, {}, { setting: 1 }, { activity: 1 }, { wellness: 1 }, { stream: 1 }];
+      return assertReferenceCaptureReplayable(value, { readVerifiedSnapshot: async () => payloads.shift(),
+        derivePayloadMembers: async () => changed, assertStoreEvidence: async () => {} });
+    };
+    await expect(run({ ...derived(), activities: [] })).rejects.toThrow();
+    await expect(run({ ...derived(), activities: [{ ...derived().activities[0]!, payload: { activity: 2 } }] })).rejects.toThrow();
+    await expect(run({ ...derived(), selected_stream_ids: ["42", "99"] })).rejects.toThrow();
+  });
+
+  it("rejects a derived lane whose members jointly permute manifest record order", async () => {
+    const base = manifest();
+    const value = validateReferenceCaptureManifest({ ...base, records: { ...base.records,
+      activities: [base.records.activities[0]!, { ...base.records.activities[0]!, ordinal: 1,
+        payload_index: 3, external_id: "43" }] },
+    deterministic_order: { ...base.deterministic_order, activities: ["42", "43"] } });
+    const payloads = [{}, {}, {}, {}, { setting: 1 }, { activity: 1 }, { activity: 2 }, { wellness: 1 }, { stream: 1 }];
+    const members = derived();
+    await expect(assertReferenceCaptureReplayable(value, { readVerifiedSnapshot: async () => payloads.shift(),
+      derivePayloadMembers: async () => ({ ...members, activities: [
+        { endpoint_ordinal: 1, payload_index: 3, external_id: "43", payload: { activity: 2 } },
+        members.activities[0]!,
+      ] }), assertStoreEvidence: async () => {} })).rejects.toThrow("capture membership differs");
+  });
+
+  it("fails the whole replay when one pinned evidence assertion rejects", async () => {
+    const payloads = [{}, {}, {}, {}, { setting: 1 }, { activity: 1 }, { wellness: 1 }, { stream: 1 }];
+    const evidence = vi.fn(async (_record, lane) => {
+      if (lane === "activities") throw new Error("mismatched evidence");
+    });
+    await expect(assertReferenceCaptureReplayable(manifest(), { readVerifiedSnapshot: async () => payloads.shift(),
+      derivePayloadMembers: async () => derived(), assertStoreEvidence: evidence })).rejects.toThrow("mismatched evidence");
+    expect(evidence).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects null and present revisions for the wrong pinned evidence lanes", async () => {
+    const store = openSqliteStorage(":memory:");
+    try {
+      await runMigrations(store, MIGRATIONS);
+      const repository = createIntervalsSourceRepository(store, hashKey);
+      const activityAddress = "e".repeat(64);
+      const activityArtifact = await repository.recordArtifact({ source: "intervals-icu", lane: "activities",
+        externalId: "42", artifactKind: "snapshot", archiveAddress: activityAddress,
+        archiveRelPath: `1998/07/${activityAddress}.json.gz`, archiveEpochSeconds: 899_424_000 });
+      await expect(repository.assertPinnedCaptureEvidence({ lane: "activities", externalId: "42",
+        artifactKey: activityArtifact.artifactKey, archiveAddress: activityAddress,
+        archiveRelPath: `1998/07/${activityAddress}.json.gz`, currentRevision: null })).rejects.toThrow("revision is absent");
+
+      const wellnessAddress = "f".repeat(64);
+      const wellnessArtifact = await repository.recordArtifact({ source: "intervals-icu", lane: "wellness",
+        externalId: "1998-07-17", artifactKind: "snapshot", archiveAddress: wellnessAddress,
+        archiveRelPath: `1998/07/${wellnessAddress}.json.gz`, archiveEpochSeconds: 899_424_000 });
+      await expect(repository.assertPinnedCaptureEvidence({ lane: "wellness", externalId: "1998-07-17",
+        artifactKey: wellnessArtifact.artifactKey, archiveAddress: wellnessAddress,
+        archiveRelPath: `1998/07/${wellnessAddress}.json.gz`,
+        currentRevision: { sourceRecordId: RECORD, revisionId: REVISION } })).rejects.toThrow("must be null");
+    } finally {
+      await store.close();
+    }
+  });
+
+  it("accepts pinned evidence after a later activity revision becomes current", async () => {
+    const store = openSqliteStorage(":memory:");
+    try {
+      await runMigrations(store, MIGRATIONS);
+      const repository = createIntervalsSourceRepository(store, hashKey);
+      const firstAddress = "e".repeat(64), secondAddress = "f".repeat(64);
+      const firstArtifact = await repository.recordArtifact({ source: "intervals-icu", lane: "activities",
+        externalId: "42", artifactKind: "snapshot", archiveAddress: firstAddress,
+        archiveRelPath: `1998/07/${firstAddress}.json.gz`, archiveEpochSeconds: 899_424_000 });
+      const firstRow: SourceRecordRow = { id: RECORD, workout_key: null, session_key: null, source: "intervals-icu",
+        external_id: "42", raw_sha256: firstAddress, quality_rank: QUALITY_RANK.PLATFORM_API,
+        payload_json: canonicalJson({ activity: { version: 1 }, concerns: {}, dedup: {}, schema_version: 1 }) };
+      await repository.applyActivityRevision({ sourceRow: firstRow, artifactKey: firstArtifact.artifactKey });
+      const pinned = await repository.readCurrentCaptureEvidence("activities", "42");
+
+      const secondArtifact = await repository.recordArtifact({ source: "intervals-icu", lane: "activities",
+        externalId: "42", artifactKind: "snapshot", archiveAddress: secondAddress,
+        archiveRelPath: `1998/07/${secondAddress}.json.gz`, archiveEpochSeconds: 899_510_400 });
+      await repository.applyActivityRevision({ sourceRow: { ...firstRow, raw_sha256: secondAddress,
+        payload_json: canonicalJson({ activity: { version: 2 }, concerns: {}, dedup: {}, schema_version: 1 }) },
+      artifactKey: secondArtifact.artifactKey });
+      expect((await repository.readCurrentCaptureEvidence("activities", "42")).revisionId).not.toBe(pinned.revisionId);
+      await expect(repository.assertPinnedCaptureEvidence({ lane: "activities", externalId: "42",
+        artifactKey: pinned.artifactKey, archiveAddress: pinned.archiveAddress, archiveRelPath: pinned.archiveRelPath,
+        currentRevision: { sourceRecordId: pinned.sourceRecordId, revisionId: pinned.revisionId } })).resolves.toBeUndefined();
+    } finally {
+      await store.close();
+    }
+  });
+});

--- a/packages/kernel/tsup.config.ts
+++ b/packages/kernel/tsup.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
     "reference/preserve-tokens": "src/reference/preserve-tokens.ts",
     "reference/errors": "src/reference/errors.ts",
     "reference/trademark-policy": "src/reference/trademark-policy.ts",
+    "reference/capture": "src/reference/capture.ts",
     concurrency: "src/reference/entry/concurrency.ts",
   },
   loader: { ".sql": "text" },

--- a/packages/sync-intervals-icu/src/source.ts
+++ b/packages/sync-intervals-icu/src/source.ts
@@ -1,11 +1,21 @@
 import { canonicalJson, type ArchiveInstant, type ArchiveWriteResult } from "@enduragent/kernel/archive";
 import type { HttpRequest, HttpResponse } from "@enduragent/kernel/ports";
+import {
+  REFERENCE_CAPTURE_STREAM_TYPES,
+  createReferenceCapturePlan,
+  selectReferenceCaptureStreamIds,
+  validateReferenceCapturePlan,
+  type DerivedCaptureMember,
+  type DerivedCaptureMembers,
+  type ReferenceCaptureEndpointPayload,
+  type ReferenceCapturePlan,
+} from "@enduragent/kernel/reference/capture";
 import type { SourceCheckpoint, SourceLane, SourceWatermark, SyncBudget } from "@enduragent/kernel/store";
 import { activityIdentity, mapActivityLanding, mapSettingsLanding, mapWellnessLanding, normalizeStreamLanding } from "./landing.js";
 import { advanceWindow, compactCursor, compareBinary, parseCivilDate, parseCursor, type CursorRange, type RangeCursor } from "./cursor.js";
-import { createRequester, IntervalsHttpError, MIN_CONFIGURED_INTERVAL_MS, type IntervalsRequester } from "./http.js";
+import { createRequester, IntervalsHttpError, MIN_CONFIGURED_INTERVAL_MS, SyncBudgetExceededError, type IntervalsRequester } from "./http.js";
 import { BULK_FIT_BATCH_SIZE, BULK_SAFE_ACTIVITY_ID, IncompleteBulkFitBatchError, MAX_FIT_BYTES, MAX_ZIP_BYTES, extractBulkFitZip } from "./zip.js";
-import { INTERVALS_ICU_CAPABILITIES, INTERVALS_ICU_SOURCE_ID, MAX_JSON_BYTES, type IntervalsIcuArtifact, type IntervalsIcuSource, type IntervalsIcuSourceOptions } from "./types.js";
+import { INTERVALS_ICU_CAPABILITIES, INTERVALS_ICU_SOURCE_ID, MAX_JSON_BYTES, type IntervalsIcuArtifact, type IntervalsIcuCaptureSource, type IntervalsIcuSourceOptions, type ReferenceCaptureActivityRecord, type ReferenceCaptureBatch, type ReferenceCaptureEndpoint, type ReferenceCaptureSettingsRecord, type ReferenceCaptureStreamRecord, type ReferenceCaptureWellnessRecord } from "./types.js";
 
 const BASE_URL = "https://intervals.icu";
 const JSON_TYPE = "application/json";
@@ -130,7 +140,7 @@ interface FitReady {
   readonly archive: ArchiveWriteResult;
 }
 
-export function createIntervalsIcuSource(options: IntervalsIcuSourceOptions): IntervalsIcuSource {
+export function createIntervalsIcuSource(options: IntervalsIcuSourceOptions): IntervalsIcuCaptureSource {
   const athleteId = nonempty(options.athleteId, "athlete id");
   const range: CursorRange = {
     oldest: parseCivilDate(options.historyOldestDate ?? "1900-01-01"),
@@ -361,5 +371,224 @@ export function createIntervalsIcuSource(options: IntervalsIcuSourceOptions): In
     yield* yieldCheckpoint(nextCursor(cursor, range, remaining.length - processed, processedKey));
   }
 
-  return Object.freeze({ id: INTERVALS_ICU_SOURCE_ID, capabilities: INTERVALS_ICU_CAPABILITIES, pull });
+  const placeholderArchive: ArchiveWriteResult = Object.freeze({
+    address: "0".repeat(64),
+    relPath: `1970/01/${"0".repeat(64)}.json.gz`,
+    deduped: false,
+  });
+
+  async function deriveStreamMember(endpoint: ReferenceCaptureEndpointPayload): Promise<DerivedCaptureMember | null> {
+    try {
+      if (endpoint.lane !== "streams" || endpoint.endpoint !== "activity-streams"
+        || endpoint.request.activity_id === null) throw new TypeError("stream endpoint is invalid");
+      const normalized = options.acl.streams(structuredClone(endpoint.payload));
+      options.acl.assertClean(normalized);
+      normalizeStreamLanding(normalized);
+      return { endpoint_ordinal: endpoint.ordinal, payload_index: null,
+        external_id: `streams:${endpoint.request.activity_id}`, payload: endpoint.payload };
+    } catch {
+      return null;
+    }
+  }
+
+  async function deriveReferenceCaptureMembers(
+    capturePlan: ReferenceCapturePlan,
+    endpointPayloads: readonly ReferenceCaptureEndpointPayload[],
+  ): Promise<DerivedCaptureMembers> {
+    const plan = validateReferenceCapturePlan(capturePlan);
+    if (!Array.isArray(endpointPayloads) || endpointPayloads.length < 3) throw new TypeError("capture endpoints are invalid");
+    for (let index = 0; index < endpointPayloads.length; index += 1) {
+      const endpoint = endpointPayloads[index]!;
+      if (endpoint === null || typeof endpoint !== "object" || endpoint.ordinal !== index) {
+        throw new TypeError("capture endpoint order is invalid");
+      }
+    }
+    const profile = objectRow(endpointPayloads[0]!.payload, "athlete settings");
+    const sourceSettings = profile.sportSettings === undefined ? [] : profile.sportSettings;
+    if (!Array.isArray(sourceSettings)) throw new TypeError("sport settings response is invalid");
+    if (!Array.isArray(endpointPayloads[1]!.payload)) throw new TypeError("activities response is invalid");
+    if (!Array.isArray(endpointPayloads[2]!.payload)) throw new TypeError("wellness response is invalid");
+
+    const settings: DerivedCaptureMember[] = [];
+    for (let index = 0; index < sourceSettings.length; index += 1) {
+      try {
+        const row = objectRow(sourceSettings[index], "sport setting");
+        settingsIdentity(row);
+        const copy = structuredClone(row);
+        options.acl.assertClean(copy);
+        const landing = await mapSettingsLanding(copy);
+        settings.push({ endpoint_ordinal: 0, payload_index: index,
+          external_id: landing.sourceRecordExternalId, payload: row });
+      } catch {}
+    }
+
+    const activities: DerivedCaptureMember[] = [];
+    const activityPayload = endpointPayloads[1]!.payload as unknown[];
+    for (let index = 0; index < activityPayload.length; index += 1) {
+      try {
+        const row = objectRow(activityPayload[index], "activity row");
+        nonempty(row.type, "activity type");
+        for (const [field, label] of [["moving_time", "moving time"], ["elapsed_time", "elapsed time"]] as const) {
+          const item = row[field];
+          if (typeof item !== "number" || !Number.isSafeInteger(item) || item < 0) throw new TypeError(`activity ${label} is invalid`);
+        }
+        const identity = activityIdentity(row);
+        const normalized = options.acl.activity(structuredClone(row));
+        options.acl.assertClean(normalized);
+        await mapActivityLanding({ normalized, archiveInstant: rowInstant(identity.startUtc), archive: placeholderArchive });
+        activities.push({ endpoint_ordinal: 1, payload_index: index, external_id: identity.externalId, payload: row });
+      } catch {}
+    }
+
+    const wellness: DerivedCaptureMember[] = [];
+    const wellnessPayload = endpointPayloads[2]!.payload as unknown[];
+    for (let index = 0; index < wellnessPayload.length; index += 1) {
+      try {
+        const row = objectRow(wellnessPayload[index], "wellness row");
+        const identity = wellnessIdentity(row);
+        const normalized = options.acl.wellness(structuredClone(row));
+        options.acl.assertClean(normalized);
+        const landing = await mapWellnessLanding(normalized);
+        if (landing.date_key !== Number(identity.id.replaceAll("-", ""))) throw new TypeError("wellness identity changed");
+        wellness.push({ endpoint_ordinal: 2, payload_index: index, external_id: identity.id, payload: row });
+      } catch {}
+    }
+
+    const streams: DerivedCaptureMember[] = [];
+    for (const endpoint of endpointPayloads.slice(3)) {
+      const member = await deriveStreamMember(endpoint);
+      if (member !== null) streams.push(member);
+    }
+    for (const [lane, members] of Object.entries({ settings, activities, wellness, streams })) {
+      const ids = members.map((member) => member.external_id);
+      if (new Set(ids).size !== ids.length) throw new TypeError(`duplicate retained ${lane} ID`);
+    }
+    return Object.freeze({
+      settings: Object.freeze(settings), activities: Object.freeze(activities),
+      wellness: Object.freeze(wellness), streams: Object.freeze(streams),
+      selected_stream_ids: Object.freeze(selectReferenceCaptureStreamIds(activities.map((member) => member.payload), plan)),
+    });
+  }
+
+  async function captureReference(now: Date, budget: SyncBudget): Promise<ReferenceCaptureBatch> {
+    const plan = createReferenceCapturePlan(now);
+    const requester = createRequester({
+      http: options.httpFactory({ outer: budget.signal, perRequestTimeoutMs: budget.perRequestTimeoutMs }),
+      budget,
+      minRequestIntervalMs: options.minRequestIntervalMs,
+      wallClock: { now: () => plan.capture_epoch_ms },
+      sleep: options.sleep,
+    });
+    if (!requester.canRequest(3)) throw new SyncBudgetExceededError();
+    const required: ReferenceCaptureEndpointPayload[] = [
+      { ordinal: 0, lane: "settings", endpoint: "athlete-profile",
+        request: { oldest: null, newest: null, activity_id: null, stream_types: [], include_defaults: null },
+        payload: await fetchJson(requester, "settings", { method: "GET",
+          url: endpointUrl(`/api/v1/athlete/${encodeURIComponent(athleteId)}`) }) },
+      { ordinal: 1, lane: "activities", endpoint: "activities",
+        request: { oldest: plan.window.oldest, newest: plan.window.newest, activity_id: null, stream_types: [], include_defaults: null },
+        payload: await fetchJson(requester, "activities", { method: "GET",
+          url: rangeUrl(athleteId, "activities", { v: 1, cycle: 0, window_start: plan.window.oldest,
+            window_end: plan.window.newest, last_key: null, complete: false }) }) },
+      { ordinal: 2, lane: "wellness", endpoint: "wellness",
+        request: { oldest: plan.window.oldest, newest: plan.window.newest, activity_id: null, stream_types: [], include_defaults: null },
+        payload: await fetchJson(requester, "wellness", { method: "GET",
+          url: rangeUrl(athleteId, "wellness", { v: 1, cycle: 0, window_start: plan.window.oldest,
+            window_end: plan.window.newest, last_key: null, complete: false }) }) },
+    ];
+    const requiredMembers = await deriveReferenceCaptureMembers(plan, required);
+    const selectedIds = [...requiredMembers.selected_stream_ids];
+    const requiredUnits = 3 + requiredMembers.settings.length + requiredMembers.activities.length
+      + requiredMembers.wellness.length + selectedIds.length;
+    if (requiredUnits > budget.maxArtifacts) throw new SyncBudgetExceededError();
+    if (selectedIds.length > 0 && !requester.canRequest(selectedIds.length)) throw new SyncBudgetExceededError();
+
+    const successfulStreams: ReferenceCaptureEndpointPayload[] = [];
+    for (const activityId of selectedIds) {
+      requester.assertActive();
+      let payload: unknown;
+      try {
+        payload = await fetchJson(requester, "streams", { method: "GET", url: streamUrl(activityId) });
+      } catch (error) {
+        if (error instanceof SyncBudgetExceededError || budget.signal.aborted) throw error;
+        requester.assertActive();
+        continue;
+      }
+      const endpoint: ReferenceCaptureEndpointPayload = {
+        ordinal: 3 + successfulStreams.length,
+        lane: "streams",
+        endpoint: "activity-streams",
+        request: { oldest: null, newest: null, activity_id: activityId,
+          stream_types: [...REFERENCE_CAPTURE_STREAM_TYPES], include_defaults: false },
+        payload,
+      };
+      if (await deriveStreamMember(endpoint) !== null) successfulStreams.push(endpoint);
+    }
+    const endpointPayloads = [...required, ...successfulStreams];
+    const members = await deriveReferenceCaptureMembers(plan, endpointPayloads);
+    if (members.streams.length !== successfulStreams.length) throw new Error("captured stream attribution is invalid");
+
+    const activityInstantById = new Map<string, number>();
+    for (const member of members.activities) {
+      const identity = activityIdentity(member.payload as Record<string, unknown>);
+      activityInstantById.set(member.external_id, identity.startUtc);
+    }
+    const requiredInstants = [epochForDate(plan.window.newest), epochForDate(plan.window.oldest), epochForDate(plan.window.oldest)];
+    const endpoints: ReferenceCaptureEndpoint[] = [];
+    for (const endpoint of endpointPayloads) {
+      const epochSeconds = endpoint.ordinal < 3 ? requiredInstants[endpoint.ordinal]!
+        : activityInstantById.get(endpoint.request.activity_id!);
+      if (epochSeconds === undefined) throw new Error("stream activity instant is absent");
+      const archiveInstant = rowInstant(epochSeconds);
+      const archive = await options.archive.writeSnapshot(endpoint.payload, archiveInstant);
+      endpoints.push({ ...endpoint, archiveInstant, archive });
+    }
+
+    const settings: ReferenceCaptureSettingsRecord[] = [];
+    for (const member of members.settings) {
+      const row = member.payload as Record<string, unknown>, archiveInstant = rowInstant(settingEpoch(row));
+      const archive = await options.archive.writeSnapshot(row, archiveInstant);
+      const copy = structuredClone(row); options.acl.assertClean(copy);
+      const landing = await mapSettingsLanding(copy);
+      settings.push({ endpointOrdinal: member.endpoint_ordinal, payloadIndex: member.payload_index,
+        externalId: member.external_id, payload: row, archiveInstant, archive,
+        landing: { kind: "settings", sourceRecordExternalId: landing.sourceRecordExternalId,
+          normalizedPayloadJson: landing.normalizedPayloadJson, anchors: landing.anchors, zones: landing.zones } });
+    }
+    const activities: ReferenceCaptureActivityRecord[] = [];
+    for (const member of members.activities) {
+      const row = member.payload as Record<string, unknown>, identity = activityIdentity(row);
+      const archiveInstant = rowInstant(identity.startUtc), archive = await options.archive.writeSnapshot(row, archiveInstant);
+      const normalized = options.acl.activity(structuredClone(row)); options.acl.assertClean(normalized);
+      const platform = await mapActivityLanding({ normalized, archiveInstant, archive });
+      activities.push({ endpointOrdinal: member.endpoint_ordinal, payloadIndex: member.payload_index,
+        externalId: member.external_id, payload: row, archiveInstant, archive, landing: { kind: "activity", platform } });
+    }
+    const wellness: ReferenceCaptureWellnessRecord[] = [];
+    for (const member of members.wellness) {
+      const row = member.payload as Record<string, unknown>, identity = wellnessIdentity(row);
+      const archiveInstant = identity.instant, archive = await options.archive.writeSnapshot(row, archiveInstant);
+      const normalized = options.acl.wellness(structuredClone(row)); options.acl.assertClean(normalized);
+      wellness.push({ endpointOrdinal: member.endpoint_ordinal, payloadIndex: member.payload_index,
+        externalId: member.external_id, payload: row, archiveInstant, archive,
+        landing: { kind: "wellness", row: await mapWellnessLanding(normalized) } });
+    }
+    const streams: ReferenceCaptureStreamRecord[] = [];
+    for (let index = 0; index < members.streams.length; index += 1) {
+      const member = members.streams[index]!, endpoint = endpoints[3 + index]!;
+      const normalized = options.acl.streams(structuredClone(member.payload)); options.acl.assertClean(normalized);
+      streams.push({ endpointOrdinal: member.endpoint_ordinal, payloadIndex: null, externalId: member.external_id,
+        payload: member.payload, archiveInstant: endpoint.archiveInstant, archive: endpoint.archive,
+        landing: { kind: "streams", sourceRecordExternalId: member.external_id,
+          normalizedPayloadJson: canonicalJson(normalizeStreamLanding(normalized)) } });
+    }
+    return Object.freeze({ plan, endpoints: Object.freeze(endpoints), records: Object.freeze({
+      settings: Object.freeze(settings), activities: Object.freeze(activities),
+      wellness: Object.freeze(wellness), streams: Object.freeze(streams),
+    }), selected_stream_ids: Object.freeze(selectedIds),
+    captured_stream_ids: Object.freeze(successfulStreams.map((endpoint) => endpoint.request.activity_id!)) });
+  }
+
+  return Object.freeze({ id: INTERVALS_ICU_SOURCE_ID, capabilities: INTERVALS_ICU_CAPABILITIES,
+    pull, captureReference, deriveReferenceCaptureMembers });
 }

--- a/packages/sync-intervals-icu/src/types.ts
+++ b/packages/sync-intervals-icu/src/types.ts
@@ -2,6 +2,11 @@ import type { ArchiveManager } from "@enduragent/kernel/archive";
 import type { PlatformImportArtifact } from "@enduragent/kernel/ingest";
 import type { ClockPort, HttpPort } from "@enduragent/kernel/ports";
 import type {
+  DerivedCaptureMembers,
+  ReferenceCaptureEndpointPayload,
+  ReferenceCapturePlan,
+} from "@enduragent/kernel/reference/capture";
+import type {
   AnchorHistoryRow,
   WellnessLandingRow,
   ZoneSetHistoryRow,
@@ -75,4 +80,55 @@ export interface IntervalsIcuSource extends SyncSource {
   readonly id: "intervals-icu";
   readonly capabilities: typeof INTERVALS_ICU_CAPABILITIES;
   pull(watermark: SourceWatermark, budget: SyncBudget): AsyncIterable<IntervalsIcuArtifact>;
+}
+
+export interface IntervalsIcuCaptureSource extends IntervalsIcuSource {
+  captureReference(now: Date, budget: SyncBudget): Promise<ReferenceCaptureBatch>;
+  deriveReferenceCaptureMembers(
+    plan: ReferenceCapturePlan,
+    endpointPayloads: readonly ReferenceCaptureEndpointPayload[],
+  ): Promise<DerivedCaptureMembers>;
+}
+
+export interface ReferenceCaptureEndpoint extends ReferenceCaptureEndpointPayload {
+  readonly archiveInstant: { readonly epochSeconds: number };
+  readonly archive: { readonly address: string; readonly relPath: string; readonly deduped: boolean };
+}
+
+interface ReferenceCaptureRecordBase {
+  readonly endpointOrdinal: number;
+  readonly payloadIndex: number | null;
+  readonly externalId: string;
+  readonly payload: unknown;
+  readonly archiveInstant: { readonly epochSeconds: number };
+  readonly archive: { readonly address: string; readonly relPath: string; readonly deduped: boolean };
+}
+
+export interface ReferenceCaptureSettingsRecord extends ReferenceCaptureRecordBase {
+  readonly landing: { readonly kind: "settings"; readonly sourceRecordExternalId: string; readonly normalizedPayloadJson: string; readonly anchors: readonly AnchorHistoryRow[]; readonly zones: readonly ZoneSetHistoryRow[] };
+}
+
+export interface ReferenceCaptureActivityRecord extends ReferenceCaptureRecordBase {
+  readonly landing: { readonly kind: "activity"; readonly platform: PlatformImportArtifact };
+}
+
+export interface ReferenceCaptureWellnessRecord extends ReferenceCaptureRecordBase {
+  readonly landing: { readonly kind: "wellness"; readonly row: WellnessLandingRow };
+}
+
+export interface ReferenceCaptureStreamRecord extends ReferenceCaptureRecordBase {
+  readonly landing: { readonly kind: "streams"; readonly sourceRecordExternalId: string; readonly normalizedPayloadJson: string };
+}
+
+export interface ReferenceCaptureBatch {
+  readonly plan: ReferenceCapturePlan;
+  readonly endpoints: readonly ReferenceCaptureEndpoint[];
+  readonly records: {
+    readonly settings: readonly ReferenceCaptureSettingsRecord[];
+    readonly activities: readonly ReferenceCaptureActivityRecord[];
+    readonly wellness: readonly ReferenceCaptureWellnessRecord[];
+    readonly streams: readonly ReferenceCaptureStreamRecord[];
+  };
+  readonly selected_stream_ids: readonly string[];
+  readonly captured_stream_ids: readonly string[];
 }

--- a/packages/sync-intervals-icu/tests/capture.test.ts
+++ b/packages/sync-intervals-icu/tests/capture.test.ts
@@ -1,0 +1,85 @@
+import { createHash } from "node:crypto";
+import { canonicalJson } from "@enduragent/kernel/archive";
+import type { SyncBudget } from "@enduragent/kernel/store";
+import { describe, expect, it } from "vitest";
+import { createIntervalsIcuSource } from "../src/source.js";
+
+const NOW = new Date("1998-07-18T12:00:00.000Z");
+const PROFILE = { sportSettings: [{ id: 7, athlete_id: "synthetic-athlete", types: ["Ride"], updated: "1998-07-01T00:00:00.000Z", ftp: 250 }] };
+const ACTIVITY = { id: 42, type: "Ride", start_date: "1998-07-17T10:00:00.000Z",
+  start_date_local: "1998-07-17T12:00:00", moving_time: 3600, elapsed_time: 3700, distance: 40_000 };
+const WELLNESS = { id: "1998-07-17", restingHR: 50 };
+
+function response(value: unknown, status = 200, contentType = "application/json") {
+  return { status, headers: { "content-type": contentType }, body: new TextEncoder().encode(JSON.stringify(value)) };
+}
+
+function budget(maxArtifacts = 20): SyncBudget {
+  return { signal: new AbortController().signal, clock: { monotonicNow: () => 1 }, deadlineMonotonicMs: 1_000,
+    perRequestTimeoutMs: 1_000, maxRequests: 20, maxArtifacts };
+}
+
+function fixture(stream: unknown = { time: [0, 1], watts: [200, 210] }) {
+  const requests: string[] = [], writes: { payload: unknown; epoch: number }[] = [];
+  const queue = [response(PROFILE), response([ACTIVITY]), response([WELLNESS]), response(stream)];
+  const source = createIntervalsIcuSource({ athleteId: "synthetic-athlete", historyNewestDate: "1998-07-18",
+    minRequestIntervalMs: 250, wallClock: { now: () => NOW.getTime() }, sleep: async () => {},
+    httpFactory: () => ({ fetch: async (request) => { requests.push(request.url); return queue.shift()!; } }),
+    archive: {
+      async writeSnapshot(payload, instant) { writes.push({ payload, epoch: instant.epochSeconds });
+        const address = createHash("sha256").update(canonicalJson(payload)).update(String(instant.epochSeconds)).digest("hex");
+        return { address, relPath: `1998/07/${address}.json.gz`, deduped: false }; },
+      async writeArtifact() { throw new Error("unused"); }, async quarantine() { throw new Error("unused"); },
+      async readArtifact() { throw new Error("unused"); }, async readSnapshot() { throw new Error("unused"); }, async has() { return false; },
+    },
+    acl: { activity: (row) => row, wellness: (row) => row,
+      streams(value) { if (value === null || typeof value !== "object" || Array.isArray(value)) throw new TypeError("bad stream"); return value as Record<string, unknown>; },
+      assertClean() {} },
+  });
+  return { source, requests, writes };
+}
+
+describe("captureReference", () => {
+  it("fetches exact endpoints in selector order and archives whole/member evidence after fetch", async () => {
+    const value = fixture(), batch = await value.source.captureReference(NOW, budget());
+    expect(value.requests).toHaveLength(4);
+    expect(value.requests[0]).toMatch(/\/api\/v1\/athlete\/synthetic-athlete$/);
+    expect(value.requests[1]).toContain("/activities?oldest=");
+    expect(value.requests[2]).toContain("/wellness?oldest=");
+    expect(value.requests[3]).toContain("/api/v1/activity/42/streams.json?types=time&types=watts&types=heartrate&types=dfa_a1&types=artifacts&includeDefaults=false");
+    expect(batch.selected_stream_ids).toEqual(["42"]);
+    expect(batch.captured_stream_ids).toEqual(["42"]);
+    expect(batch.records.settings[0]?.externalId).toMatch(/^settings:/);
+    expect(batch.records.activities[0]?.externalId).toBe("42");
+    expect(batch.records.wellness[0]?.externalId).toBe("1998-07-17");
+    expect(batch.records.streams[0]?.externalId).toBe("streams:42");
+    expect(batch.records.streams[0]?.archive).toBe(batch.endpoints[3]?.archive);
+    expect(value.writes).toHaveLength(7);
+  });
+
+  it("omits malformed stream responses without omitting required lanes", async () => {
+    const value = fixture("invalid"), batch = await value.source.captureReference(NOW, budget());
+    expect(batch.selected_stream_ids).toEqual(["42"]);
+    expect(batch.captured_stream_ids).toEqual([]);
+    expect(batch.endpoints).toHaveLength(3);
+    expect(batch.records.activities).toHaveLength(1);
+  });
+
+  it("reserves every selected stream artifact before requests or archives", async () => {
+    const value = fixture();
+    await expect(value.source.captureReference(NOW, budget(6))).rejects.toThrow();
+    expect(value.requests).toHaveLength(3);
+    expect(value.writes).toHaveLength(0);
+  });
+
+  it("derives live membership in whole-payload encounter order and omits malformed members", async () => {
+    const value = fixture(), plan = (await value.source.captureReference(NOW, budget())).plan;
+    const derived = await value.source.deriveReferenceCaptureMembers(plan, [
+      { ordinal: 0, lane: "settings", endpoint: "athlete-profile", request: { oldest: null, newest: null, activity_id: null, stream_types: [], include_defaults: null }, payload: PROFILE },
+      { ordinal: 1, lane: "activities", endpoint: "activities", request: { oldest: plan.window.oldest, newest: plan.window.newest, activity_id: null, stream_types: [], include_defaults: null }, payload: [{ bad: true }, ACTIVITY] },
+      { ordinal: 2, lane: "wellness", endpoint: "wellness", request: { oldest: plan.window.oldest, newest: plan.window.newest, activity_id: null, stream_types: [], include_defaults: null }, payload: [{ id: "bad" }, WELLNESS] },
+    ]);
+    expect(derived.activities[0]?.payload_index).toBe(1);
+    expect(derived.wellness[0]?.payload_index).toBe(1);
+  });
+});

--- a/packages/sync-intervals-icu/tests/landing.test.ts
+++ b/packages/sync-intervals-icu/tests/landing.test.ts
@@ -48,6 +48,7 @@ describe("intervals.icu landing mappings", () => {
       threshold_pace: 250, pace_units: "seconds", pace_zones: [300, 270] };
     const value = await mapSettingsLanding(raw);
     expect(value.externalId).toBe(canonicalJson([9, "synthetic-athlete", ["Run", "Ride"], "1998-01-05T09:00:00Z"]));
+    expect(value.sourceRecordExternalId).toBe(`settings:${value.externalId}`);
     expect(value.anchors).toContainEqual(expect.objectContaining({ sport: "cycling", anchor_type: "ftp", value: 250,
       unit: "W", source: "intervals-icu", provenance: "sync", confidence: "platform" }));
     expect(value.anchors).not.toContainEqual(expect.objectContaining({ sport: "run", anchor_type: "ftp" }));


### PR DESCRIPTION
## Summary

- add immutable, versioned Reference capture sidecars under private athlete homes
- retain verified whole-response snapshots bound to exact store evidence
- preserve live-fetch ordering for later Reference projection

## Verification

- `pnpm check`
- `pnpm test`
- `pnpm s8a`
- `pnpm s8a --self-test`

## Scope

Private infrastructure; ships nothing to athletes.