### PR TITLE
fix(kernel): enforce the cycling projection safety floor

### DIFF
--- a/.changeset/cycling-safety-floor.md
+++ b/.changeset/cycling-safety-floor.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/kernel": patch
+---
+
+Keep Reference layer projections cycling-only while retaining athlete-wide wellness and cycling FTP history. Internal infrastructure; ships nothing to athletes.

--- a/packages/coach/src/local-bundle-producer.ts
+++ b/packages/coach/src/local-bundle-producer.ts
@@ -6,10 +6,12 @@ import {
 } from "@enduragent/kernel/ingest";
 import type { ReferenceCaptureManifest } from "@enduragent/kernel/reference/capture";
 import {
+  IDENTITY_REFERENCE_BUNDLE_PROJECTION,
   KEEP_ALL_ACTIVITIES,
   type ActivityProjectionFilter,
   type LocalBundleProducer,
   type ProducedLocalBundle,
+  type ReferenceBundleProjection,
   type VerifiedSnapshotReader,
 } from "@enduragent/kernel/reference/local-bundle";
 import type { SqlReadStore } from "@enduragent/kernel/store";
@@ -40,6 +42,7 @@ export interface LocalBundleProducerOptions {
   readonly storePath: string;
   readonly archiveRoot: string;
   readonly activityFilter?: ActivityProjectionFilter;
+  readonly bundleProjection?: ReferenceBundleProjection;
 }
 
 export interface LocalBundleProducerDependencies {
@@ -69,6 +72,7 @@ export function createLocalBundleProducer(
   const makeCrypto = dependencies.crypto ?? createNodeCrypto;
   const decode = dependencies.decode ?? decodeLocalBundleProjection;
   const activityFilter = options.activityFilter ?? KEEP_ALL_ACTIVITIES;
+  const bundleProjection = options.bundleProjection ?? IDENTITY_REFERENCE_BUNDLE_PROJECTION;
 
   return Object.freeze({
     async produce(manifest: ReferenceCaptureManifest): Promise<ProducedLocalBundle> {
@@ -85,7 +89,8 @@ export function createLocalBundleProducer(
           streams: await readSelectedGenericRows(store, { source: SOURCE, lane: "streams" }),
         };
         const bundle = await decode(manifest, selected, snapshots, activityFilter);
-        produced = { captureId: manifest.capture_id, frozenNow: manifest.plan.frozenNow, bundle };
+        produced = { captureId: manifest.capture_id, frozenNow: manifest.plan.frozenNow,
+          bundle: bundleProjection(bundle) };
       } catch {
         projectionFailed = true;
       }

--- a/packages/coach/src/reference-capture-command.ts
+++ b/packages/coach/src/reference-capture-command.ts
@@ -45,6 +45,7 @@ import {
   parseCanonicalProjectionValue,
   parseRenamedActivity,
   parseRenamedWellnessRow,
+  projectCyclingReferenceBundle,
   renameTpFieldsOnActivity,
   renameTpFieldsOnWellnessRow,
   type ReferenceBundle,
@@ -790,8 +791,9 @@ export async function runReferenceCaptureCommand(
   const payloadSet = new CapturedReferencePayloadSet(manifest);
   const inputFs = dependencies.inputFileSystem ?? nodeFileSystem();
   const reader = createVerifiedSnapshotReader({ archiveRoot: input.archive_root, crypto: createNodeCrypto(), fs: inputFs });
+  const bundleProjection = projectCyclingReferenceBundle;
   let direct: ReturnType<typeof buildFixtureShape>;
-  try { direct = buildFixtureShape(await payloadSet.directBundle(reader)); }
+  try { direct = buildFixtureShape(bundleProjection(await payloadSet.directBundle(reader))); }
   catch (error) { return environment(error instanceof EnvironmentFailure ? error.code : "PROJECTION_FAILED"); }
 
   let scratch: string | undefined;
@@ -823,7 +825,7 @@ export async function runReferenceCaptureCommand(
       try {
         const produced = dependencies.produceLocalBundle === undefined
           ? await (await import(new URL("./local-bundle-producer.js", import.meta.url).href))
-            .createLocalBundleProducer(destination).produce(manifest)
+            .createLocalBundleProducer({ ...destination, bundleProjection }).produce(manifest)
           : await dependencies.produceLocalBundle(destination, manifest);
         if (produced.captureId !== manifest.capture_id || produced.frozenNow !== manifest.plan.frozenNow) {
           throw new TypeError("local bundle identity changed");

--- a/packages/coach/tests/backfill-dual-presentation.test.ts
+++ b/packages/coach/tests/backfill-dual-presentation.test.ts
@@ -1,13 +1,39 @@
 import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { chmod, mkdtemp, realpath } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { dumpStore, runMigrations, type SourceArtifact } from "@enduragent/kernel/store";
+import { canonicalJson } from "@enduragent/kernel/archive";
+import { readSelectedGenericRows, readSelectedSourceRows } from "@enduragent/kernel/ingest";
+import {
+  REFERENCE_CAPTURE_STREAM_TYPES,
+  validateReferenceCaptureManifest,
+  validateReferenceCapturePlan,
+  type RecordRef,
+} from "@enduragent/kernel/reference/capture";
+import {
+  projectCyclingReferenceBundle,
+  type ReferenceBundle,
+} from "@enduragent/kernel/reference/local-bundle";
+import { ActivitySchema } from "@enduragent/kernel/reference/schemas";
+import {
+  H,
+  createIntervalsSourceRepository,
+  dumpStore,
+  runMigrations,
+  type SourceArtifact,
+} from "@enduragent/kernel/store";
 import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
-import { createNodeImportRuntime } from "@enduragent/kernel-node/ingest";
+import { createNodeCrypto, createNodeImportRuntime, importFilesWithReport } from "@enduragent/kernel-node/ingest";
 import { openSqliteStorage } from "@enduragent/kernel-node/sqlite";
-import { mapActivityLanding, type IntervalsIcuSource } from "@enduragent/sync-intervals-icu";
+import {
+  mapActivityLanding,
+  normalizeStreamLanding,
+  type IntervalsIcuArtifact,
+  type IntervalsIcuSource,
+} from "@enduragent/sync-intervals-icu";
 import { runActivityAuditPages, runBackfillPages } from "../src/backfill.js";
+import { createLocalBundleProducer } from "../src/local-bundle-producer.js";
 
 const complete = (lane: "activities" | "bulk-fit") => ({ kind: "checkpoint" as const,
   watermark: { source: "intervals-icu" as const, lane,
@@ -23,6 +49,280 @@ describe("dual-presentation audit", () => {
     const store = openSqliteStorage(join(root, "store.db")); await runMigrations(store, MIGRATIONS);
     return { store, node: createNodeImportRuntime({ archiveDir: join(root, "archive"), store }) };
   }
+
+  it("projects only normalized cycling tokens at the single seam", () => {
+    const tokens = [
+      "VirtualSki", "Ride", "Transition", "NordicSki", "Walk", "VirtualRide", "Hike", "Run",
+      "MountainBikeRide", "VirtualRun", "TrailRun", "Swim", "GravelRide", "Rowing", "WeightTraining",
+      "EBikeRide", "Yoga", "Workout", "EMountainBikeRide", "TrackRide", "Cyclocross", "Handcycle",
+      "ride", "", "UnmappedSport",
+    ];
+    const activities = tokens.map((type, index) => ActivitySchema.parse({
+      id: type === "Ride" ? 42 : `activity-${index}`,
+      start_date_local: `1998-01-${String(index + 1).padStart(2, "0")}T08:00:00`,
+      type,
+      moving_time: 60,
+      elapsed_time: 61,
+    }));
+    const wellness = [{ id: "1998-01-02", weight: null, restingHR: null, hrv: null, sleepSecs: null,
+      sleepQuality: null, sportInfo: [{ type: "Run", eftp: 300 }, { type: "Ride", eftp: 245 }] }];
+    const ftpHistory = [{ date: "1998-01-02", ftp: 245, source: "estimate" as const }];
+    const athlete = { sportSettings: [{ types: ["Ride"], ftp: 250 }] };
+    const ftpHistoryIndoor = { "1998-01-02": 240 }, ftpHistoryOutdoor = { "1998-01-02": 250 };
+    const powerCurves = { list: [] }, hrCurves = { list: [] };
+    const sustainabilityCurves = { cycling: { power: { Ride: { list: [] } }, hr: { Ride: { list: [] } } } };
+    const streams = {
+      "activity-7": { watts: [107] },
+      "42": { watts: [242] },
+      "042": { watts: [42] },
+      "activity-5": { watts: [105] },
+      "orphan-z": { watts: [999] },
+      "activity-8": { watts: [108] },
+      "activity-12": { watts: [112] },
+      "activity-15": { watts: [115] },
+    };
+    const bundle: ReferenceBundle = { activities, wellness, ftpHistory, streams, powerCurves, hrCurves,
+      sustainabilityCurves, athlete, currentFtpIndoor: null, currentFtpOutdoor: 250,
+      ftpHistoryIndoor, ftpHistoryOutdoor, eftp: null };
+
+    const projected = projectCyclingReferenceBundle(bundle);
+    expect(projected.activities.map((activity) => activity.type)).toEqual([
+      "Ride", "VirtualRide", "MountainBikeRide", "GravelRide", "EBikeRide",
+    ]);
+    expect(projected.activities.map((activity) => activity.id)).toEqual([
+      42, "activity-5", "activity-8", "activity-12", "activity-15",
+    ]);
+    expect(Object.keys(projected.streams!)).toEqual([
+      "42", "activity-5", "activity-8", "activity-12", "activity-15",
+    ]);
+    expect(projected.streams!["42"]).toBe(streams["42"]);
+    expect(projected.streams).not.toHaveProperty("042");
+    expect(projected.wellness).toBe(wellness);
+    expect(projected.ftpHistory).toBe(ftpHistory);
+    expect(projected.athlete).toBe(athlete);
+    expect(projected.ftpHistoryIndoor).toBe(ftpHistoryIndoor);
+    expect(projected.ftpHistoryOutdoor).toBe(ftpHistoryOutdoor);
+    expect(projected.powerCurves).toBe(powerCurves);
+    expect(projected.hrCurves).toBe(hrCurves);
+    expect(projected.sustainabilityCurves).toBe(sustainabilityCurves);
+    expect(projected).toMatchObject({ currentFtpIndoor: null, currentFtpOutdoor: 250, eftp: null });
+    expect(Object.hasOwn(projected, "currentFtpIndoor")).toBe(true);
+    expect(Object.hasOwn(projected, "eftp")).toBe(true);
+
+    const omitted = projectCyclingReferenceBundle({ activities, wellness, ftpHistory });
+    expect(omitted).not.toHaveProperty("streams");
+    const presentEmpty = projectCyclingReferenceBundle({ activities: activities.filter((activity) => activity.type === "Run"),
+      wellness, ftpHistory, streams: { "activity-7": streams["activity-7"] } });
+    expect(presentEmpty).toHaveProperty("streams", {});
+    for (const candidate of [
+      { id: "null-type", start_date_local: "1998-01-01T08:00:00", type: null, moving_time: 60, elapsed_time: 61 },
+      { id: "absent-type", start_date_local: "1998-01-01T08:00:00", moving_time: 60, elapsed_time: 61 },
+    ] satisfies unknown[]) {
+      const parsed = ActivitySchema.safeParse(candidate);
+      expect(parsed.success).toBe(false);
+      if (!parsed.success) expect(parsed.error.issues.some((issue) => issue.path.join(".") === "type")).toBe(true);
+    }
+  });
+
+  it("keeps only source-lane cycling evidence after a triathlon FIT import", async () => {
+    const root = await mkdtemp(join(await realpath(tmpdir()), "cycling-source-floor-"));
+    roots.push(root);
+    await chmod(root, 0o700);
+    const storePath = join(root, "store.db"), archiveDir = join(root, "archive");
+    const store = openSqliteStorage(storePath);
+    const crypto = createNodeCrypto();
+    const node = createNodeImportRuntime({ archiveDir, store });
+    const snapshot = (value: { readonly address: string; readonly relPath: string }) =>
+      ({ address: value.address, rel_path: value.relPath });
+    const plan = validateReferenceCapturePlan({
+      capture_epoch_ms: Date.parse("2010-06-04T12:00:00Z"),
+      frozenNow: "2010-06-04T12:00:00",
+      window: { oldest: "2010-03-12", newest: "2010-06-04" },
+      stream_cutoff_epoch_ms: Date.parse("2010-05-14T12:00:00Z"),
+    });
+    try {
+      await runMigrations(store, MIGRATIONS);
+      const repository = createIntervalsSourceRepository(store, (fields) =>
+        H(crypto, ...(fields as [string | number, ...(string | number)[]])));
+      const rawActivities = [
+        { id: "synthetic-run-a", type: "Run", start_date: "2010-05-01T08:00:00Z",
+          start_date_local: "2010-05-01T08:00:00", moving_time: 1_800, elapsed_time: 1_860, distance: 5_000 },
+        { id: "synthetic-cycle-z", type: "Ride", start_date: "2010-05-02T08:00:00Z",
+          start_date_local: "2010-05-02T08:00:00", moving_time: 3_600, elapsed_time: 3_660, distance: 40_000 },
+        { id: "synthetic-swim-m", type: "Swim", start_date: "2010-05-03T08:00:00Z",
+          start_date_local: "2010-05-03T08:00:00", moving_time: 1_200, elapsed_time: 1_260, distance: 1_000 },
+      ];
+      const activityItems = [] as {
+        readonly raw: Readonly<Record<string, unknown>>;
+        readonly externalId: string;
+        readonly epochSeconds: number;
+        readonly archive: Awaited<ReturnType<typeof node.archive.writeSnapshot>>;
+        readonly platform: Awaited<ReturnType<typeof mapActivityLanding>>;
+      }[];
+      for (const raw of rawActivities) {
+        const epochSeconds = Date.parse(raw.start_date) / 1_000;
+        const archive = await node.archive.writeSnapshot(raw, { epochSeconds });
+        activityItems.push({ raw, externalId: raw.id, epochSeconds, archive,
+          platform: await mapActivityLanding({ normalized: raw, archiveInstant: { epochSeconds }, archive }) });
+      }
+      const source = {
+        id: "intervals-icu",
+        capabilities: { activities: true, streams: true, rawFiles: true, wellness: true,
+          plannedWorkoutPush: false, backfillDepth: { kind: "full-history" } },
+        pull(watermark) {
+          return (async function* (): AsyncIterable<IntervalsIcuArtifact> {
+            if (watermark.lane !== "activities") throw new TypeError("unexpected source lane");
+            for (const item of activityItems) {
+              yield { kind: "snapshot", source: "intervals-icu", lane: "activities", externalId: item.externalId,
+                archiveInstant: { epochSeconds: item.epochSeconds }, archive: item.archive, payload: item.raw,
+                landing: { kind: "activity", platform: item.platform } };
+            }
+            yield complete("activities");
+          })();
+        },
+      } as IntervalsIcuSource;
+      expect((await runActivityAuditPages({ store, node, source, clock })).artifacts).toBe(3);
+
+      const streamItems = [] as {
+        readonly activityId: string;
+        readonly raw: Readonly<Record<string, unknown>>;
+        readonly archive: Awaited<ReturnType<typeof node.archive.writeSnapshot>>;
+      }[];
+      for (let index = 0; index < activityItems.length; index += 1) {
+        const activityId = activityItems[index]!.externalId;
+        const raw = { time: [0, 60], watts: [100 + index, 110 + index] };
+        const archive = await node.archive.writeSnapshot(raw, { epochSeconds: activityItems[index]!.epochSeconds });
+        const externalId = `streams:${activityId}`;
+        const artifact = await repository.recordArtifact({ source: "intervals-icu", lane: "streams", externalId,
+          artifactKind: "snapshot", archiveAddress: archive.address, archiveRelPath: archive.relPath,
+          archiveEpochSeconds: activityItems[index]!.epochSeconds });
+        await repository.recordGenericLanding({ externalId, artifactKey: artifact.artifactKey,
+          archiveAddress: archive.address, endpoint: "streams",
+          normalizedPayloadJson: canonicalJson(normalizeStreamLanding(raw)) });
+        streamItems.push({ activityId, raw, archive });
+      }
+
+      const wellness = { id: "2010-06-03", weight: null, restingHR: null, hrv: null, sleepSecs: null,
+        sleepQuality: null, sportInfo: [{ type: "Run", eftp: 300 }, { type: "Ride", eftp: 245.4 }] };
+      const wellnessArchive = await node.archive.writeSnapshot(wellness, { epochSeconds: Date.parse("2010-06-03T00:00:00Z") / 1_000 });
+      const wellnessArtifact = await repository.recordArtifact({ source: "intervals-icu", lane: "wellness",
+        externalId: wellness.id, artifactKind: "snapshot", archiveAddress: wellnessArchive.address,
+        archiveRelPath: wellnessArchive.relPath, archiveEpochSeconds: Date.parse("2010-06-03T00:00:00Z") / 1_000 });
+      const profileEndpoint = await node.archive.writeSnapshot({ sportSettings: [] }, { epochSeconds: plan.capture_epoch_ms / 1_000 });
+      const activitiesEndpoint = await node.archive.writeSnapshot(rawActivities, { epochSeconds: plan.capture_epoch_ms / 1_000 });
+      const wellnessEndpoint = await node.archive.writeSnapshot([wellness], { epochSeconds: plan.capture_epoch_ms / 1_000 });
+
+      const activityRecords: RecordRef[] = [];
+      for (let index = 0; index < activityItems.length; index += 1) {
+        const item = activityItems[index]!;
+        const evidence = await repository.readCurrentCaptureEvidence("activities", item.externalId);
+        activityRecords.push({ ordinal: index, endpoint_ordinal: 1, payload_index: index, external_id: item.externalId,
+          snapshot: snapshot(item.archive), store_evidence: { artifact_key: evidence.artifactKey,
+            current_revision: { source_record_id: evidence.sourceRecordId, revision_id: evidence.revisionId } } });
+      }
+      const streamRecords: RecordRef[] = [];
+      for (let index = 0; index < streamItems.length; index += 1) {
+        const item = streamItems[index]!, externalId = `streams:${item.activityId}`;
+        const evidence = await repository.readCurrentCaptureEvidence("streams", externalId);
+        streamRecords.push({ ordinal: index, endpoint_ordinal: index + 3, payload_index: null, external_id: externalId,
+          snapshot: snapshot(item.archive), store_evidence: { artifact_key: evidence.artifactKey,
+            current_revision: { source_record_id: evidence.sourceRecordId, revision_id: evidence.revisionId } } });
+      }
+      const activityIds = rawActivities.map((activity) => activity.id);
+      const endpoints = [
+        { ordinal: 0, lane: "settings" as const, endpoint: "athlete-profile" as const,
+          request: { oldest: null, newest: null, activity_id: null, stream_types: [], include_defaults: null },
+          snapshot: snapshot(profileEndpoint) },
+        { ordinal: 1, lane: "activities" as const, endpoint: "activities" as const,
+          request: { oldest: plan.window.oldest, newest: plan.window.newest, activity_id: null,
+            stream_types: [], include_defaults: null }, snapshot: snapshot(activitiesEndpoint) },
+        { ordinal: 2, lane: "wellness" as const, endpoint: "wellness" as const,
+          request: { oldest: plan.window.oldest, newest: plan.window.newest, activity_id: null,
+            stream_types: [], include_defaults: null }, snapshot: snapshot(wellnessEndpoint) },
+        ...streamItems.map((item, index) => ({ ordinal: index + 3, lane: "streams" as const,
+          endpoint: "activity-streams" as const, request: { oldest: null, newest: null,
+            activity_id: item.activityId, stream_types: [...REFERENCE_CAPTURE_STREAM_TYPES], include_defaults: false as const },
+          snapshot: snapshot(item.archive) })),
+      ];
+      const manifest = validateReferenceCaptureManifest({ schema_version: 1,
+        capture_id: "00000000-0000-4000-8000-000000000010", source: "external-oracle", plan,
+        operation_ledger: { link_kind: "capture-id", capture_id: "00000000-0000-4000-8000-000000000010" },
+        endpoints, records: { settings: [], activities: activityRecords,
+          wellness: [{ ordinal: 0, endpoint_ordinal: 2, payload_index: 0, external_id: wellness.id,
+            snapshot: snapshot(wellnessArchive), store_evidence: { artifact_key: wellnessArtifact.artifactKey,
+              current_revision: null } }], streams: streamRecords },
+        selected_stream_ids: activityIds, captured_stream_ids: activityIds,
+        deterministic_order: { endpoint_ordinals: endpoints.map((endpoint) => endpoint.ordinal), settings: [],
+          activities: activityIds, wellness: [wellness.id], streams: activityIds } });
+
+      expect(await readSelectedSourceRows(store, { source: "intervals-icu", lane: "activities" })).toHaveLength(3);
+      expect(await readSelectedGenericRows(store, { source: "intervals-icu", lane: "streams" })).toHaveLength(3);
+      expect(await store.get("SELECT count(*) AS n FROM source_record")).toEqual({ n: 6 });
+      expect(await store.get("SELECT count(*) AS n FROM source_record_revision")).toEqual({ n: 6 });
+      expect(await store.get("SELECT count(*) AS n FROM source_record_current")).toEqual({ n: 6 });
+      const selectors = await store.all("SELECT source_record_id, revision_id FROM source_record_current ORDER BY source_record_id");
+
+      const fixturePath = resolve("packages/kernel-node/tests/fixtures/ingest/triathlon-multisport.fit");
+      const fitImportReport = await importFilesWithReport({ inputPaths: [fixturePath], archiveDir, store });
+      expect(fitImportReport.inserts).toEqual({ raw_file: 1, source_record: 0 });
+      expect(await store.get("SELECT count(*) AS n FROM raw_file")).toEqual({ n: 1 });
+      expect(await store.get("SELECT count(*) AS n FROM source_record")).toEqual({ n: 6 });
+      expect(await store.get("SELECT count(*) AS n FROM source_record_revision")).toEqual({ n: 6 });
+      expect(await store.get("SELECT count(*) AS n FROM source_record_current")).toEqual({ n: 6 });
+      expect(await store.all("SELECT source_record_id, revision_id FROM source_record_current ORDER BY source_record_id"))
+        .toEqual(selectors);
+      expect(await store.all("SELECT sport, is_transition FROM session WHERE start_utc < 1000000000 ORDER BY start_utc"))
+        .toEqual([{ sport: "swimming", is_transition: 0 }, { sport: "transition", is_transition: 1 },
+          { sport: "cycling", is_transition: 0 }, { sport: "transition", is_transition: 1 },
+          { sport: "running", is_transition: 0 }]);
+      expect(Number((await store.get(`SELECT count(*) AS n FROM stream AS st
+JOIN session AS s ON s.session_key = st.session_key WHERE s.start_utc < 1000000000`))?.n)).toBeGreaterThan(0);
+
+      const produced = await createLocalBundleProducer({ storePath, archiveRoot: archiveDir,
+        bundleProjection: projectCyclingReferenceBundle }).produce(manifest);
+      expect(produced.bundle.activities.map((activity) => activity.id)).toEqual(["synthetic-cycle-z"]);
+      expect(produced.bundle.streams).toEqual({ "synthetic-cycle-z": { time: [0, 60], watts: [101, 111] } });
+      expect(Object.keys(produced.bundle.streams!)).toEqual(["synthetic-cycle-z"]);
+      expect(produced.bundle.wellness).toEqual([wellness]);
+      expect(produced.bundle.ftpHistory).toEqual([{ date: "2010-06-03", ftp: 245, source: "estimate" }]);
+
+      const fitOnlyRoot = await mkdtemp(join(await realpath(tmpdir()), "cycling-fit-only-floor-"));
+      roots.push(fitOnlyRoot);
+      await chmod(fitOnlyRoot, 0o700);
+      const fitOnlyStorePath = join(fitOnlyRoot, "store.db"), fitOnlyArchive = join(fitOnlyRoot, "archive");
+      const fitOnlyStore = openSqliteStorage(fitOnlyStorePath);
+      try {
+        await runMigrations(fitOnlyStore, MIGRATIONS);
+        await importFilesWithReport({ inputPaths: [fixturePath], archiveDir: fitOnlyArchive, store: fitOnlyStore });
+        const fitOnlyNode = createNodeImportRuntime({ archiveDir: fitOnlyArchive, store: fitOnlyStore });
+        const emptyProfile = await fitOnlyNode.archive.writeSnapshot({ sportSettings: [] }, { epochSeconds: plan.capture_epoch_ms / 1_000 });
+        const emptyActivities = await fitOnlyNode.archive.writeSnapshot([], { epochSeconds: plan.capture_epoch_ms / 1_000 });
+        const emptyWellness = await fitOnlyNode.archive.writeSnapshot([], { epochSeconds: plan.capture_epoch_ms / 1_000 });
+        const emptyEndpoints = [
+          { ordinal: 0, lane: "settings" as const, endpoint: "athlete-profile" as const,
+            request: { oldest: null, newest: null, activity_id: null, stream_types: [], include_defaults: null },
+            snapshot: snapshot(emptyProfile) },
+          { ordinal: 1, lane: "activities" as const, endpoint: "activities" as const,
+            request: { oldest: plan.window.oldest, newest: plan.window.newest, activity_id: null,
+              stream_types: [], include_defaults: null }, snapshot: snapshot(emptyActivities) },
+          { ordinal: 2, lane: "wellness" as const, endpoint: "wellness" as const,
+            request: { oldest: plan.window.oldest, newest: plan.window.newest, activity_id: null,
+              stream_types: [], include_defaults: null }, snapshot: snapshot(emptyWellness) },
+        ];
+        const emptyManifest = validateReferenceCaptureManifest({ schema_version: 1,
+          capture_id: "00000000-0000-4000-8000-000000000011", source: "external-oracle", plan,
+          operation_ledger: { link_kind: "capture-id", capture_id: "00000000-0000-4000-8000-000000000011" },
+          endpoints: emptyEndpoints, records: { settings: [], activities: [], wellness: [], streams: [] },
+          selected_stream_ids: [], captured_stream_ids: [], deterministic_order: {
+            endpoint_ordinals: [0, 1, 2], settings: [], activities: [], wellness: [], streams: [],
+          } });
+        const fitOnly = await createLocalBundleProducer({ storePath: fitOnlyStorePath, archiveRoot: fitOnlyArchive,
+          bundleProjection: projectCyclingReferenceBundle }).produce(emptyManifest);
+        expect(fitOnly.bundle.activities).toEqual([]);
+        expect(fitOnly.bundle.streams).toEqual({});
+      } finally { await fitOnlyStore.close(); }
+    } finally { await store.close(); }
+  });
 
   it("persists API activity, merges original FIT, and surfaces stable rerun near misses", async () => {
     const probe = await fresh("dual-probe"), target = await fresh("dual-target");

--- a/packages/coach/tests/reference-capture-gate.test.ts
+++ b/packages/coach/tests/reference-capture-gate.test.ts
@@ -6,6 +6,7 @@ import { canonicalJson, type ArchiveWriteResult } from "@enduragent/kernel/archi
 import { buildPlatformPresentation } from "@enduragent/kernel/ingest";
 import {
   REFERENCE_CAPTURE_STREAM_TYPES,
+  selectReferenceCaptureStreamIds,
   serializeReferenceCaptureManifest,
   validateReferenceCaptureManifest,
   validateReferenceCapturePlan,
@@ -17,9 +18,11 @@ import { METRIC_REGISTRY } from "@enduragent/kernel/reference/registry";
 import { compareReferenceCapture } from "@enduragent/kernel/reference/capture-once";
 import {
   assertNoTpKeysRemain,
+  buildFixtureShape,
   normalizeStreams,
   parseRenamedActivity,
   parseRenamedWellnessRow,
+  projectCyclingReferenceBundle,
   renameTpFieldsOnActivity,
   renameTpFieldsOnWellnessRow,
   type ReferenceBundle,
@@ -114,12 +117,13 @@ async function createSyntheticCapture(value: SyntheticSeed): Promise<SyntheticCa
   const plan = validateReferenceCapturePlan({ capture_epoch_ms: captureEpoch, frozenNow: value.frozen_now,
     window: { oldest: "1998-03-12", newest: "1998-06-04" }, stream_cutoff_epoch_ms: captureEpoch - 21 * 86_400_000 });
   const activityIds = value.activities.map((activity) => String(activity.id));
+  const streamActivityIds = selectReferenceCaptureStreamIds(value.activities, plan);
   const profile = { ...value.athlete, sportSettings: value.settings_revisions };
   const endpointPayloads: unknown[] = [profile, value.activities, value.wellness,
-    ...activityIds.map((id) => value.streams[id])];
+    ...streamActivityIds.map((id) => value.streams[id])];
   const endpointEpochs = [Date.parse("1998-06-04T00:00:00Z") / 1_000,
     Date.parse("1998-03-12T00:00:00Z") / 1_000, Date.parse("1998-03-12T00:00:00Z") / 1_000,
-    ...value.activities.map((activity) => epoch(activity.start_date))];
+    ...streamActivityIds.map((id) => epoch(value.activities.find((activity) => String(activity.id) === id)!.start_date))];
   const endpointWrites: ArchiveWriteResult[] = [];
   for (let index = 0; index < endpointPayloads.length; index += 1) {
     endpointWrites.push(await archive.writeSnapshot(endpointPayloads[index], { epochSeconds: endpointEpochs[index]! }));
@@ -141,8 +145,8 @@ async function createSyntheticCapture(value: SyntheticSeed): Promise<SyntheticCa
     wellness.push({ raw, externalId: String(raw.id), archive: written, epoch: rowEpoch });
   }
   const streams = [] as { raw: Readonly<Record<string, unknown>>; externalId: string; archive: ArchiveWriteResult; epoch: number }[];
-  for (let index = 0; index < activityIds.length; index += 1) {
-    const id = activityIds[index]!, raw = value.streams[id]!, rowEpoch = epoch(value.activities[index]!.start_date);
+  for (const id of streamActivityIds) {
+    const raw = value.streams[id]!, rowEpoch = epoch(value.activities.find((activity) => String(activity.id) === id)!.start_date);
     const written = await archive.writeSnapshot(raw, { epochSeconds: rowEpoch });
     streams.push({ raw, externalId: `streams:${id}`, archive: written, epoch: rowEpoch });
   }
@@ -211,14 +215,14 @@ async function createSyntheticCapture(value: SyntheticSeed): Promise<SyntheticCa
     : ordinal === 2 ? { ordinal, lane: "wellness" as const, endpoint: "wellness" as const,
       request: { oldest: plan.window.oldest, newest: plan.window.newest, activity_id: null, stream_types: [], include_defaults: null }, snapshot: snapshot(written) }
     : { ordinal, lane: "streams" as const, endpoint: "activity-streams" as const,
-      request: { oldest: null, newest: null, activity_id: activityIds[ordinal - 3]!,
+      request: { oldest: null, newest: null, activity_id: streamActivityIds[ordinal - 3]!,
         stream_types: [...REFERENCE_CAPTURE_STREAM_TYPES], include_defaults: false as const }, snapshot: snapshot(written) });
   const manifest = validateReferenceCaptureManifest({ schema_version: 1, capture_id: value.capture_id, source: "external-oracle",
     plan, operation_ledger: { link_kind: "capture-id", capture_id: value.capture_id }, endpoints, records,
-    selected_stream_ids: activityIds, captured_stream_ids: activityIds,
+    selected_stream_ids: streamActivityIds, captured_stream_ids: streamActivityIds,
     deterministic_order: { endpoint_ordinals: endpoints.map((endpoint) => endpoint.ordinal),
       settings: records.settings.map((record) => record.external_id), activities: activityIds,
-      wellness: records.wellness.map((record) => record.external_id), streams: activityIds } });
+      wellness: records.wellness.map((record) => record.external_id), streams: streamActivityIds } });
   const manifestPath = join(root, "manifest.json"), inputPath = join(root, "input.json"), conclusionPath = join(root, "conclusion.json");
   await writeFile(manifestPath, serializeReferenceCaptureManifest(manifest), { mode: 0o600 });
   await writeFile(inputPath, `${canonicalJson({ schema_version: 1, manifest_path: manifestPath, archive_root: archiveRoot })}\n`, { mode: 0o600 });
@@ -237,6 +241,48 @@ afterEach(async () => {
 });
 
 describe.sequential("capture-once Reference layer gate", () => {
+  it("preserves manifest order and rejects asymmetric evidence drift", async () => {
+    const base = await seed();
+    const ride = { ...base.activities[0], id: "b", type: "Ride", icu_training_load: 72 };
+    const run = { ...base.activities[1], id: "a", type: "Run", icu_training_load: 72 };
+    const capture = await createSyntheticCapture(await seed({ activities: [ride, run],
+      streams: { b: base.streams["ride-zeta"]!, a: base.streams["ride-alpha"]! } }));
+    const result = await runReferenceCaptureCommand(args(capture));
+    expect(result.exitCode, result.line).toBe(0);
+    expect(result.conclusion!.direct_family_counts).toMatchObject({ activities: 1, streams: 1 });
+    expect(result.conclusion!.projected_family_counts).toMatchObject({ activities: 1, streams: 1 });
+
+    const commandSource = await readFile(new URL("../src/reference-capture-command.ts", import.meta.url), "utf8");
+    expect(commandSource).toMatch(/const bundleProjection = projectCyclingReferenceBundle/);
+    expect(commandSource).toMatch(/bundleProjection\(await payloadSet\.directBundle\(reader\)\)/);
+    expect(commandSource).toMatch(/createLocalBundleProducer\(\{ \.\.\.destination, bundleProjection \}\)/);
+    expect(projectCyclingReferenceBundle.name).toBe("projectCyclingReferenceBundle");
+
+    const activity = (id: string, type: string) => ({ id, type, start_date_local: "1998-06-03T08:00:00",
+      moving_time: 3_600, elapsed_time: 3_660, icu_training_load: 72 });
+    const fixture = (activities: readonly ReturnType<typeof activity>[], eftp: number | null | undefined = undefined) =>
+      buildFixtureShape({ activities, wellness: [], ftpHistory: [], ...(eftp === undefined ? {} : { eftp }) });
+    const frozenNow = "1998-06-04T12:00:00";
+    const rideFixture = fixture([activity("b", "Ride")]), runFixture = fixture([activity("b", "Run")]);
+    for (const [direct, projected] of [[rideFixture, runFixture], [runFixture, rideFixture]] as const) {
+      const comparison = compareReferenceCapture({ direct, projected, frozenNow });
+      expect(comparison.fixtureBytesEqual).toBe(false);
+      expect(comparison.fixtureMismatchFamilies).toEqual(["activities"]);
+    }
+    const nullEftp = fixture([activity("b", "Ride")], null), omittedEftp = fixture([activity("b", "Ride")]);
+    for (const [direct, projected] of [[nullEftp, omittedEftp], [omittedEftp, nullEftp]] as const) {
+      const comparison = compareReferenceCapture({ direct, projected, frozenNow });
+      expect(comparison.fixtureBytesEqual).toBe(false);
+      expect(comparison.fixtureMismatchFamilies).toEqual(["eftp"]);
+    }
+    const reverseOrder = fixture([activity("b", "Ride"), activity("a", "VirtualRide")]);
+    const forwardOrder = fixture([activity("a", "VirtualRide"), activity("b", "Ride")]);
+    expect(compareReferenceCapture({ direct: reverseOrder, projected: forwardOrder, frozenNow }))
+      .toMatchObject({ fixtureBytesEqual: false, fixtureMismatchFamilies: ["activities"] });
+    expect(compareReferenceCapture({ direct: reverseOrder, projected: reverseOrder, frozenNow }))
+      .toMatchObject({ fixtureBytesEqual: true, fixtureMismatchFamilies: [] });
+  });
+
   it("passes a complete synthetic capture without network or input writes", async () => {
     const capture = await createSyntheticCapture(await seed());
     const fs = nodeFileSystem();

--- a/packages/kernel/src/reference/local-bundle.ts
+++ b/packages/kernel/src/reference/local-bundle.ts
@@ -1,5 +1,6 @@
 import type { ReferenceCaptureManifest, SnapshotRef } from "./capture.js";
 import type { MetricInput } from "./metrics/metric-input.js";
+import { SPORT_FAMILIES } from "./metrics/sport-families.js";
 import {
   FixtureSchema,
   type Activity,
@@ -27,6 +28,35 @@ export interface ReferenceBundle {
   readonly ftpHistoryIndoor?: Readonly<Record<string, number>>;
   readonly ftpHistoryOutdoor?: Readonly<Record<string, number>>;
   readonly eftp?: number | null;
+}
+
+export type ReferenceBundleProjection = (bundle: ReferenceBundle) => ReferenceBundle;
+
+export const IDENTITY_REFERENCE_BUNDLE_PROJECTION: ReferenceBundleProjection = (bundle) => bundle;
+
+function isProjectedCyclingActivity(activity: ReferenceBundle["activities"][number]): boolean {
+  const type = activity.type;
+  return typeof type === "string"
+    && type !== "Transition"
+    && Object.hasOwn(SPORT_FAMILIES, type)
+    && SPORT_FAMILIES[type] === "cycling";
+}
+
+export function projectCyclingReferenceBundle(bundle: ReferenceBundle): ReferenceBundle {
+  const activities = bundle.activities.filter(isProjectedCyclingActivity);
+  const retainedActivityIds = new Set(activities.map((activity) => String(activity.id)));
+  let streams: Record<string, ActivityStreams> | undefined;
+  if (bundle.streams !== undefined) {
+    streams = {};
+    for (const [activityId, value] of Object.entries(bundle.streams)) {
+      if (retainedActivityIds.has(activityId)) streams[activityId] = value;
+    }
+  }
+  const hasNoOrphanStreams = Object.keys(streams ?? {}).every(
+    (activityId) => retainedActivityIds.has(activityId),
+  );
+  if (!hasNoOrphanStreams) throw new Error("cycling Reference projection produced an orphan stream");
+  return streams === undefined ? { ...bundle, activities } : { ...bundle, activities, streams };
 }
 
 export interface ProducedLocalBundle {


### PR DESCRIPTION
## Summary
- retain only normalized cycling activities in the Reference layer projection
- keep athlete-wide wellness and cycling FTP history unchanged
- require every projected stream to belong to a retained cycling activity

## Test plan
- run the cycling projection token, ordering, and mixed-store regressions
- run the full test and check suites