### PR TITLE
feat(engine): add contract and host-port scaffold

### DIFF
--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@enduragent/engine",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Private coaching engine boundary and sport contract.",
+  "type": "module",
+  "files": ["dist"],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./sport": {
+      "types": "./dist/sport.d.ts",
+      "import": "./dist/sport.js"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "check": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@enduragent/coach-contract": "workspace:*",
+    "@enduragent/kernel": "workspace:*",
+    "ai": "^6.0.158",
+    "intervals-icu-api": "^0.1.2",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.0",
+    "tsup": "^8.4.0",
+    "typescript": "^6.0.2",
+    "vitest": "^4.1.4"
+  },
+  "license": "MIT"
+}

--- a/packages/engine/src/host-ports.ts
+++ b/packages/engine/src/host-ports.ts
@@ -1,0 +1,239 @@
+import type { AthleteState } from "@enduragent/coach-contract";
+import type { ModelMessage } from "ai";
+import type { IntervalsClient } from "intervals-icu-api";
+
+export type EngineDataSource = "platform" | "store";
+
+export type EngineLlmProvider =
+  | "anthropic"
+  | "openai"
+  | "google"
+  | "openai-codex"
+  | "deepseek"
+  | "qwen"
+  | "minimax"
+  | "kimi"
+  | "zai"
+  | "openrouter";
+
+export interface EngineConfig {
+  readonly dataSource: EngineDataSource;
+  readonly llm: {
+    readonly provider: EngineLlmProvider;
+    readonly model: string;
+    readonly apiKey: string;
+    readonly authProfile?: string;
+    readonly flushModel?: string;
+    readonly compactModel?: string;
+    readonly baseUrl?: string;
+  };
+  readonly session: {
+    readonly historyTokenBudgetRatio: number;
+    readonly idleMinutes: number;
+    readonly dailyResetHour: number;
+    readonly timezone: string;
+  };
+  readonly contextWindowTokens: number;
+}
+
+export type MemoryWriteSource =
+  | "chat-tool"
+  | "flush"
+  | "sport-tool"
+  | "migration"
+  | "unattributed";
+
+export type LedgerEventKind =
+  | "decision"
+  | "override"
+  | "illness"
+  | "experiment"
+  | "outcome";
+
+export interface LedgerEventInput {
+  readonly date: string;
+  readonly kind: LedgerEventKind;
+  readonly text: string;
+  readonly source: "flush";
+}
+
+export interface MemoryStorePort {
+  readMemory(): string;
+  writeSection(section: string, content: string, source?: MemoryWriteSource): void;
+  readSection(section: string): string | null;
+  renameSection(
+    from: string,
+    to: string,
+    source?: MemoryWriteSource,
+  ): "renamed" | "noop" | "merged";
+  renameSections(
+    renames: ReadonlyArray<readonly [string, string]>,
+    source?: MemoryWriteSource,
+  ): Array<"renamed" | "noop" | "merged">;
+  readDailyNotes(date?: string): string;
+  appendDailyNote(note: string, date?: string): void;
+  readDailyNotesInRange(from: string, to: string): Array<{ date: string; text: string }>;
+  readEventsRaw(): string;
+  appendEvent(event: LedgerEventInput): void;
+  savePlan(plan: unknown, source?: MemoryWriteSource): void;
+  loadPlan(): unknown | null;
+  reload(): void;
+  getContext(): string;
+}
+
+export interface MemorySnapshot {
+  read(sectionName: string): string | null;
+  has(sectionName: string): boolean;
+  listSections(): readonly string[];
+}
+
+export interface ChatLineage {
+  readonly templateHash: string;
+  readonly assembledHash: string;
+  readonly provider: string;
+  readonly model: string;
+}
+
+export interface ChatStorePort {
+  hasSession(chatId: string): boolean;
+  load(chatId: string): { messages: ModelMessage[]; lastMessageTime: string | null };
+  appendTurn(
+    chatId: string,
+    userContent: string,
+    assistantContent: string,
+    lineage: ChatLineage,
+  ): void;
+  overwriteHistory(chatId: string, messages: ModelMessage[]): void;
+  archiveAndReset(chatId: string): void;
+  archivePreCompact(chatId: string): void;
+}
+
+export type ExecSecretRef = {
+  readonly source: "exec";
+  readonly command: string;
+  readonly args?: string[];
+};
+
+export type EnvSecretRef = {
+  readonly source: "env";
+  readonly var: string;
+};
+
+export type SecretRef = ExecSecretRef | EnvSecretRef;
+
+export interface SecretsPort {
+  resolve(ref: SecretRef): Promise<string>;
+}
+
+export interface StoredDataFreshness {
+  readonly capturedAt: string;
+  readonly ageMs: number;
+  readonly label: string;
+}
+
+export type AthleteReadResult<T> =
+  | { readonly ok: true; readonly value: T; readonly freshness?: StoredDataFreshness }
+  | {
+      readonly ok: false;
+      readonly error:
+        | "not_found"
+        | "store_read_unavailable"
+        | "invalid_snapshot"
+        | "invalid_input";
+      readonly message: string;
+    };
+
+export interface AthleteDataReaderPort {
+  getAthlete(): Promise<AthleteReadResult<unknown>>;
+  listWellness(input: {
+    start: string;
+    end?: string;
+  }): Promise<AthleteReadResult<unknown[]>>;
+  listActivities(input: {
+    start: string;
+    end?: string;
+  }): Promise<AthleteReadResult<unknown[]>>;
+  getActivity(input: { id: string }): Promise<AthleteReadResult<unknown>>;
+  getStreams(input: {
+    id: string;
+    keys: readonly string[];
+  }): Promise<AthleteReadResult<unknown>>;
+  listCalendar(input: {
+    start: string;
+    end?: string;
+  }): Promise<AthleteReadResult<unknown[]>>;
+  freshness(): StoredDataFreshness | undefined;
+}
+
+export interface CalendarEventForDelete {
+  readonly id: number;
+  readonly startDateLocal: string;
+}
+
+export interface PlatformCalendarMutationsPort {
+  createEvent(input: unknown): Promise<unknown>;
+  readEventForDelete(input: { eventId: number }): Promise<CalendarEventForDelete>;
+  deleteEvent(input: { eventId: number }): Promise<unknown>;
+}
+
+export interface PlatformClientPort {
+  readonly legacyClient: IntervalsClient | null;
+  readonly athleteData: AthleteDataReaderPort | undefined;
+  readonly calendarMutations: PlatformCalendarMutationsPort;
+}
+
+export type LoggerFields = Record<string, unknown>;
+
+export interface LoggerPort {
+  debug(event: string, fields?: LoggerFields): void;
+  info(event: string, fields?: LoggerFields): void;
+  warn(event: string, error?: unknown, fields?: LoggerFields): void;
+  error(event: string, error?: unknown, fields?: LoggerFields): void;
+}
+
+export type CallerRole = "chat" | "flush" | "compact" | "sync-triage" | "dream";
+
+export interface UsageCost {
+  readonly input: number;
+  readonly output: number;
+  readonly cacheRead: number;
+  readonly cacheWrite: number;
+  readonly total: number;
+}
+
+export interface UsageLedgerLine {
+  readonly ts: number;
+  readonly kind: "generate" | "turn" | "boot";
+  readonly provider: string;
+  readonly model: string;
+  readonly durationMs: number;
+  readonly caller?: CallerRole;
+  readonly templateHash?: string;
+  readonly steps?: number;
+  readonly inputTokens?: number;
+  readonly outputTokens?: number;
+  readonly totalTokens?: number;
+  readonly cacheReadTokens?: number;
+  readonly cacheWriteTokens?: number;
+  readonly cost?: UsageCost;
+  readonly stopReason?: string;
+}
+
+export interface UsagePort {
+  append(line: UsageLedgerLine): void;
+}
+
+export interface AthleteStateReaderPort {
+  getAthleteState(): Promise<AthleteState>;
+}
+
+export interface EngineHostPorts {
+  readonly config: EngineConfig;
+  readonly memory: MemoryStorePort;
+  readonly chatStore: ChatStorePort;
+  readonly secrets: SecretsPort;
+  readonly platform: PlatformClientPort;
+  readonly logger: LoggerPort;
+  readonly usage: UsagePort;
+  readonly stateReader: AthleteStateReaderPort;
+}

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -1,0 +1,42 @@
+import type { CoachEngine } from "@enduragent/coach-contract";
+import type { EngineHostPorts } from "./host-ports.js";
+import type { Sport } from "./sport.js";
+
+export type { CoachEngine } from "@enduragent/coach-contract";
+export type {
+  AthleteDataReaderPort,
+  AthleteReadResult,
+  AthleteStateReaderPort,
+  CalendarEventForDelete,
+  CallerRole,
+  ChatLineage,
+  ChatStorePort,
+  EngineConfig,
+  EngineDataSource,
+  EngineHostPorts,
+  EngineLlmProvider,
+  EnvSecretRef,
+  ExecSecretRef,
+  LedgerEventInput,
+  LedgerEventKind,
+  LoggerFields,
+  LoggerPort,
+  MemorySnapshot,
+  MemoryStorePort,
+  MemoryWriteSource,
+  PlatformCalendarMutationsPort,
+  PlatformClientPort,
+  SecretRef,
+  SecretsPort,
+  StoredDataFreshness,
+  UsageCost,
+  UsageLedgerLine,
+  UsagePort,
+} from "./host-ports.js";
+
+export interface CreateCoachEngineInput {
+  readonly sport: Sport;
+  readonly ports: EngineHostPorts;
+}
+
+export type CoachEngineFactory = (input: CreateCoachEngineInput) => CoachEngine;

--- a/packages/engine/src/sport.ts
+++ b/packages/engine/src/sport.ts
@@ -1,0 +1,144 @@
+import type { ResolvedCs } from "@enduragent/kernel/reference/cs-resolution";
+import type {
+  FinishReason,
+  LanguageModelUsage,
+  ModelMessage,
+  StopCondition,
+  Tool,
+  ToolSet,
+} from "ai";
+import type { Activity, IntervalsClient } from "intervals-icu-api";
+import type { z } from "zod";
+import type {
+  AthleteDataReaderPort,
+  MemorySnapshot,
+  MemoryStorePort,
+  PlatformCalendarMutationsPort,
+  SecretsPort,
+} from "./host-ports.js";
+
+export type SportId = "cycling" | "running" | "duathlon" | "swimming" | "triathlon";
+
+export type IntervalsActivityType =
+  | "Ride"
+  | "Run"
+  | "VirtualRide"
+  | "TrailRun"
+  | "MountainBikeRide"
+  | "GravelRide"
+  | "EBikeRide"
+  | "Swim"
+  | "OpenWaterSwim"
+  | "VirtualRun";
+
+export interface Person {
+  weight: number;
+  age: number;
+  availableDays: number;
+}
+
+export interface MemorySectionSpec {
+  name: string;
+  description: string;
+  schema?: z.ZodTypeAny;
+}
+
+export interface ToolRegistration {
+  name: string;
+  description: string;
+  inputSchema: z.ZodTypeAny;
+  tool: Tool;
+}
+
+export type CallerRole = "chat" | "flush" | "compact" | "sync-triage" | "dream";
+
+export interface GenerateOptions {
+  system?: string;
+  messages?: ModelMessage[];
+  prompt?: string;
+  tools?: ToolSet;
+  stopWhen?: StopCondition<any> | Array<StopCondition<any>>;
+  maxSteps?: number;
+  maxOutputTokens?: number;
+  signal?: AbortSignal;
+  deadlineMs?: number;
+  cacheKey?: string;
+  caller?: CallerRole;
+  context?: unknown;
+}
+
+export interface GenerateResult {
+  text: string;
+  toolCalls: Array<{
+    type: "tool-call";
+    toolCallId: string;
+    toolName: string;
+    input: unknown;
+  }>;
+  finishReason: FinishReason;
+  usage: LanguageModelUsage;
+  totalUsage?: LanguageModelUsage;
+  steps?: number;
+  cost?: {
+    input: number;
+    output: number;
+    cacheRead: number;
+    cacheWrite: number;
+    total: number;
+  };
+}
+
+export interface LanguageModelPort {
+  generate(options: GenerateOptions): Promise<GenerateResult>;
+}
+
+export interface SportRuntimePorts {
+  llm: LanguageModelPort;
+  intervals: IntervalsClient | null;
+  athleteData?: AthleteDataReaderPort;
+  calendarMutations?: PlatformCalendarMutationsPort;
+  memory: MemoryStorePort;
+  secrets: SecretsPort;
+  tz: string;
+  resolvedCs?: (options: unknown) => ResolvedCs | null;
+}
+
+export interface DfaSummary {
+  readonly sufficient: boolean;
+  readonly value?: number;
+}
+
+export interface PowerCurveDeltaSummary {
+  readonly anchorsCovered: number;
+  readonly trend?: "up" | "down" | "flat";
+}
+
+export interface ReferenceSportAdapter {
+  readonly activityTypes: readonly IntervalsActivityType[];
+  readonly zoneBasis: "power" | "pace" | "hr";
+  readonly decouplingBasis: "power" | "pace";
+  readonly sustainabilityAnchors: readonly number[];
+  readonly dfaValidated: boolean;
+  readonly anchorType: "critical-speed" | "ftp";
+  computeDfa?(activity: Activity): DfaSummary | null;
+  computePowerCurve?(activities: readonly Activity[]): PowerCurveDeltaSummary | null;
+}
+
+export interface Sport {
+  readonly id: SportId;
+  readonly soul: string;
+  readonly skills: Readonly<Record<string, string>>;
+  readonly sessionClusterGapMinutes: number;
+  readonly memorySections: readonly MemorySectionSpec[];
+  readonly mustPreserveTokens:
+    | readonly string[]
+    | ((memory: MemorySnapshot) => readonly string[]);
+  readonly intervalsActivityTypes: readonly IntervalsActivityType[];
+  readonly athleteProfileSchema: z.ZodTypeAny;
+  tools(ports: SportRuntimePorts): readonly ToolRegistration[];
+  referenceAdapters?(): readonly ReferenceSportAdapter[];
+}
+
+export type SportPersona = Pick<Sport, "soul" | "skills" | "sessionClusterGapMinutes">;
+
+export type SportMemoryShape = Pick<Sport, "memorySections" | "mustPreserveTokens">;

--- a/packages/engine/tests/scaffold.test.ts
+++ b/packages/engine/tests/scaffold.test.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, expectTypeOf, it } from "vitest";
+import type { CoachEngine as ContractCoachEngine } from "@enduragent/coach-contract";
+import type {
+  CoachEngine,
+  CoachEngineFactory,
+  CreateCoachEngineInput,
+  EngineHostPorts,
+} from "@enduragent/engine";
+import type { Sport } from "@enduragent/engine/sport";
+
+// @ts-expect-error The export map must deny every engine-internal deep import.
+import type { EngineHostPorts as ForbiddenDeepImport } from "@enduragent/engine/host-ports";
+
+const deepImportMustStayUnresolvable = null as unknown as ForbiddenDeepImport;
+void deepImportMustStayUnresolvable;
+
+describe("engine scaffold", () => {
+  it("pins the only two public package entry points", () => {
+    const manifest = JSON.parse(
+      readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+    ) as { exports: unknown };
+    expect(manifest.exports).toEqual({
+      ".": {
+        types: "./dist/index.d.ts",
+        import: "./dist/index.js",
+      },
+      "./sport": {
+        types: "./dist/sport.d.ts",
+        import: "./dist/sport.js",
+      },
+    });
+  });
+
+  it("exports no runtime behavior", async () => {
+    expect(Object.keys(await import("@enduragent/engine"))).toEqual([]);
+    expect(Object.keys(await import("@enduragent/engine/sport"))).toEqual([]);
+  });
+
+  it("reuses the contract and pins the injected factory input", () => {
+    expectTypeOf<CoachEngine>().toEqualTypeOf<ContractCoachEngine>();
+    expectTypeOf<CoachEngineFactory>().toBeFunction();
+    expectTypeOf<CreateCoachEngineInput>().toEqualTypeOf<{
+      readonly sport: Sport;
+      readonly ports: EngineHostPorts;
+    }>();
+  });
+});

--- a/packages/engine/tsconfig.json
+++ b/packages/engine/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "ignoreDeprecations": "6.0"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/engine/tsup.config.ts
+++ b/packages/engine/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: {
+    index: "src/index.ts",
+    sport: "src/sport.ts",
+  },
+  format: ["esm"],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  splitting: false,
+  removeNodeProtocol: false,
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -262,6 +262,37 @@ importers:
         specifier: ^6.0.2
         version: 6.0.3
 
+  packages/engine:
+    dependencies:
+      '@enduragent/coach-contract':
+        specifier: workspace:*
+        version: link:../coach-contract
+      '@enduragent/kernel':
+        specifier: workspace:*
+        version: link:../kernel
+      ai:
+        specifier: ^6.0.158
+        version: 6.0.170(zod@4.4.1)
+      intervals-icu-api:
+        specifier: ^0.1.2
+        version: 0.1.2(typescript@6.0.3)
+      zod:
+        specifier: ^4.3.6
+        version: 4.4.1
+    devDependencies:
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.6.0
+      tsup:
+        specifier: ^8.4.0
+        version: 8.5.1(postcss@8.5.12)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.3)
+      typescript:
+        specifier: ^6.0.2
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.4
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.8(vitest@4.1.5))(msw@2.14.2(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))
+
   packages/kernel:
     dependencies:
       '@xmldom/xmldom':
@@ -302,25 +333,6 @@ importers:
       '@types/node':
         specifier: ^25.6.0
         version: 25.6.0
-      tsup:
-        specifier: ^8.4.0
-        version: 8.5.1(postcss@8.5.12)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.3)
-      typescript:
-        specifier: ^6.0.2
-        version: 6.0.3
-      vitest:
-        specifier: ^4.1.4
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.8(vitest@4.1.5))(msw@2.14.2(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))
-
-  packages/sync-intervals-icu:
-    dependencies:
-      '@enduragent/kernel':
-        specifier: workspace:*
-        version: link:../kernel
-      fflate:
-        specifier: 0.8.3
-        version: 0.8.3
-    devDependencies:
       tsup:
         specifier: ^8.4.0
         version: 8.5.1(postcss@8.5.12)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.3)
@@ -449,6 +461,25 @@ importers:
       '@types/node':
         specifier: ^25.6.0
         version: 25.6.0
+      tsup:
+        specifier: ^8.4.0
+        version: 8.5.1(postcss@8.5.12)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.3)
+      typescript:
+        specifier: ^6.0.2
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.4
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.8(vitest@4.1.5))(msw@2.14.2(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))
+
+  packages/sync-intervals-icu:
+    dependencies:
+      '@enduragent/kernel':
+        specifier: workspace:*
+        version: link:../kernel
+      fflate:
+        specifier: 0.8.3
+        version: 0.8.3
+    devDependencies:
       tsup:
         specifier: ^8.4.0
         version: 8.5.1(postcss@8.5.12)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.3)

--- a/tools/check-package-deps.test.ts
+++ b/tools/check-package-deps.test.ts
@@ -340,9 +340,9 @@ describe("real repository", () => {
     ]);
   });
 
-  it("marks the absent end-state rows not-present (discovery is not vacuous)", () => {
+  it("activates engine without making end-state discovery vacuous", () => {
     const result = runRulesAgainst(".", RULES);
-    expect(result.notPresent).toContain("packages/engine");
+    expect(result.notPresent).not.toContain("packages/engine");
     expect(result.notPresent).not.toContain("packages/sync-*");
     expect(result.scannedFileCount).toBeGreaterThan(0);
   });


### PR DESCRIPTION
## Summary

Creates the private `@enduragent/engine` workspace package as an empty-behavior boundary:

- Exact two-entry public export map (`.` and `./sport`); prompt/loop/LLM/persistence internals stay unexported.
- Reuses the existing four-method `CoachEngine` contract from `@enduragent/coach-contract` without redefining it.
- Declares the engine-owned host-port interfaces that the behavior-move PR will inject; no implementations.
- Sport contract subpath declarations only; no behavior moves in this PR.
- `tools/check-package-deps.test.ts`: flips only the engine-absence characterization; every other assertion preserved byte-for-byte.
- `pnpm-lock.yaml`: new `packages/engine` importer. pnpm also re-sorted the pre-existing `packages/sync-intervals-icu` importer block into canonical position — verified byte-identical content, pure move.

No changeset: private, unused, type-only scaffold with no athlete-visible behavior.

## Verification

- Root `pnpm check:types`, `pnpm lint`, `pnpm build`, full `pnpm test` green.
- `pnpm exec vitest run packages/engine tools/check-package-deps.test.ts`: 2 files / 41 tests green.
- Public export audit: `engine-scaffold-export-shape: clean`.
- Exact nine-path allowlist audit passed.
