### PR TITLE
feat(coach): add season review prototype

### DIFF
--- a/.changeset/season-review-prototype.md
+++ b/.changeset/season-review-prototype.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/coach": patch
+---
+
+Add a private cycling season review prototype over the configured store-backed coaching path.

--- a/packages/coach/package.json
+++ b/packages/coach/package.json
@@ -25,7 +25,8 @@
     "benchmark": "node dist/backfill-command.js --synthetic --conclusions-only",
     "capture-reference": "node dist/capture-command.js",
     "capture-once": "node dist/reference-capture-command.js",
-    "dogfood:store": "node dist/local-bot.js"
+    "dogfood:store": "node dist/local-bot.js",
+    "season-review": "node dist/season-review-command.js"
   },
   "dependencies": {
     "@enduragent/core": "workspace:*",

--- a/packages/coach/src/season-review-command.ts
+++ b/packages/coach/src/season-review-command.ts
@@ -1,0 +1,638 @@
+import { createHash, randomUUID } from "node:crypto";
+import { execFileSync } from "node:child_process";
+import {
+  chmodSync,
+  closeSync,
+  existsSync,
+  fsyncSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  realpathSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { isAbsolute, dirname, join, normalize } from "node:path";
+import {
+  bootstrapReference,
+  createCoachEngine,
+  isSecretRef,
+  loadConfig,
+  readConfigYaml,
+  resolveSecretRef,
+  USAGE_LEDGER_FILE,
+  type Config,
+  type ReferenceRuntime,
+} from "@enduragent/core";
+import { canonicalJson } from "@enduragent/kernel/archive";
+import type { ReferenceCaptureManifest } from "@enduragent/kernel/reference/capture";
+import { loadReferenceCaptureSidecars } from "@enduragent/kernel-node/capture-manifest";
+import { resolveAthleteHome, type AthleteHome } from "@enduragent/kernel-node/home";
+import { cyclingSport } from "@enduragent/sport-cycling";
+import type { StoreRuntime } from "./store-runtime.js";
+import {
+  SEASON_REVIEW_MODEL_SAMPLES,
+  SEASON_REVIEW_REQUEST,
+  SEASON_REVIEW_RUBRIC_SAMPLES,
+  assertExactSeasonReviewRubric,
+  assertExactSeasonReviewScoreSchema,
+  combineCosts,
+  hashSeasonReviewEvidence,
+  scoreVerdicts,
+  seasonReviewBlindKey,
+  sha256Bytes,
+  summarizeGenerateUsage,
+  validateCost,
+  validateSeasonReviewConclusion,
+  validateSeasonReviewRunRecord,
+  validateSeasonReviewScore,
+  type SeasonReviewConclusion,
+  type SeasonReviewCost,
+  type SeasonReviewModelSample,
+  type SeasonReviewRunRecord,
+  type SeasonReviewScore,
+  type SeasonReviewUsageRow,
+  type SeasonReviewVerdict,
+} from "./season-review.js";
+
+const HEAD = /^[0-9a-f]{40}$/;
+const HASH = /^[0-9a-f]{64}$/;
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const HELP = "usage: season-review-command (run|validate-score|validate-stage|seal|validate-conclusion)";
+
+export interface SeasonReviewEngine {
+  chat(chatId: string, request: string): Promise<string>;
+}
+
+export interface SeasonReviewComposition {
+  readonly engine: SeasonReviewEngine;
+  readonly provider: string;
+  readonly model: string;
+  close(): Promise<void>;
+}
+
+export interface SeasonReviewCompositionInput {
+  readonly athleteHome: string;
+  readonly agentData: string;
+}
+
+export interface SeasonReviewCommandDependencies {
+  readonly currentHead?: () => string;
+  readonly resolveHome?: (env: Record<string, string | undefined>) => AthleteHome;
+  readonly compose?: (input: SeasonReviewCompositionInput) => Promise<SeasonReviewComposition>;
+  readonly readUsage?: (agentData: string) => readonly SeasonReviewUsageRow[];
+  readonly storeInventory?: (storePath: string) => string;
+  readonly chatId?: (sample: SeasonReviewModelSample) => string;
+}
+
+export interface SeasonReviewCommandResult {
+  readonly exitCode: 0 | 1 | 2;
+  readonly stdout: string;
+}
+
+interface RunOptions {
+  readonly head: string;
+  readonly executionHead: string;
+  readonly sample: SeasonReviewModelSample;
+  readonly athleteHome: string;
+  readonly agentData: string;
+  readonly report: string;
+  readonly runRecord: string;
+  readonly marker: string;
+}
+
+interface IndexCalibration {
+  readonly sample: string;
+  readonly report_path: string;
+  readonly run_record_path: string | null;
+  readonly score_path: string;
+  readonly source_label_path: string | null;
+}
+
+interface EvidenceIndex {
+  readonly schema_version: 1;
+  readonly base_sha: string;
+  readonly execution_head_path: string;
+  readonly call_graph_path: string;
+  readonly rubric_path: string;
+  readonly score_schema_path: string;
+  readonly rubric_calibration: readonly IndexCalibration[];
+  readonly model_calibration: readonly IndexCalibration[];
+  readonly real: {
+    readonly report_path: string;
+    readonly run_record_path: string;
+    readonly score_path: string;
+  };
+}
+
+interface ValidatedCalibration {
+  readonly sample: string;
+  readonly reportPath: string;
+  readonly reportSha256: string;
+  readonly runRecordPath: string | null;
+  readonly runRecord: SeasonReviewRunRecord | null;
+  readonly scorePath: string;
+  readonly score: SeasonReviewScore;
+}
+
+function object(value: unknown, label: string): Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) throw new TypeError(`${label} is invalid.`);
+  return value as Record<string, unknown>;
+}
+
+function exactKeys(value: Record<string, unknown>, keys: readonly string[], label: string): void {
+  const actual = Object.keys(value).sort(), expected = [...keys].sort();
+  if (actual.length !== expected.length || actual.some((key, index) => key !== expected[index])) {
+    throw new TypeError(`${label} keys are invalid.`);
+  }
+}
+
+function currentHead(): string {
+  const value = execFileSync("git", ["rev-parse", "HEAD"], { encoding: "utf8" }).trim();
+  if (!HEAD.test(value)) throw new Error("Current HEAD is invalid.");
+  return value;
+}
+
+function assertMode(path: string, modes: readonly number[]): void {
+  const stats = lstatSync(path);
+  if (!stats.isFile() || stats.isSymbolicLink() || !modes.includes(stats.mode & 0o777)) {
+    throw new TypeError("Private evidence file is invalid.");
+  }
+}
+
+function readJson(path: string, modes: readonly number[]): unknown {
+  assertMode(path, modes);
+  try { return JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(readFileSync(path))); }
+  catch { throw new TypeError("Private evidence JSON is invalid."); }
+}
+
+function writeExclusive(path: string, bytes: Uint8Array, mode = 0o600): void {
+  const handle = openSync(path, "wx", 0o600);
+  try { writeFileSync(handle, bytes); fsyncSync(handle); }
+  finally { closeSync(handle); }
+  chmodSync(path, mode);
+}
+
+function fileSha256(path: string): string {
+  return createHash("sha256").update(readFileSync(path)).digest("hex");
+}
+
+function directPath(path: string, root: string, existence: "new" | "file" | "directory", modes: readonly number[] = [0o600]): void {
+  if (!isAbsolute(path) || normalize(path) !== path || dirname(path) !== root) throw new TypeError("Evidence path is invalid.");
+  if (existence === "new") {
+    if (existsSync(path)) throw new TypeError("Evidence output already exists.");
+    return;
+  }
+  const stats = lstatSync(path);
+  if (stats.isSymbolicLink() || (existence === "file" ? !stats.isFile() : !stats.isDirectory())) {
+    throw new TypeError("Evidence path type is invalid.");
+  }
+  if (existence === "file" && !modes.includes(stats.mode & 0o777)) throw new TypeError("Evidence file mode is invalid.");
+}
+
+function evidenceRootFor(path: string): string {
+  if (!isAbsolute(path) || normalize(path) !== path) throw new TypeError("Evidence path must be absolute and normalized.");
+  const parent = dirname(path), real = realpathSync(parent), stats = lstatSync(parent);
+  if (real !== parent || stats.isSymbolicLink() || !stats.isDirectory() || (stats.mode & 0o777) !== 0o700) {
+    throw new TypeError("Evidence root is invalid.");
+  }
+  return real;
+}
+
+function optionMap(args: readonly string[], names: readonly string[]): Record<string, string> {
+  if (args.length !== names.length * 2) throw new TypeError("Command options are invalid.");
+  const allowed = new Set(names), result: Record<string, string> = {};
+  for (let index = 0; index < args.length; index += 2) {
+    const raw = args[index], value = args[index + 1];
+    if (raw === undefined || value === undefined || !raw.startsWith("--")) throw new TypeError("Command options are invalid.");
+    const name = raw.slice(2);
+    if (!allowed.has(name) || result[name] !== undefined || value.startsWith("--")) throw new TypeError("Command options are invalid.");
+    result[name] = value;
+  }
+  return result;
+}
+
+function parseRun(args: readonly string[]): RunOptions {
+  const values = optionMap(args, ["head", "execution-head", "sample", "athlete-home", "agent-data", "report", "run-record", "chat-start-marker"]);
+  if (!HEAD.test(values.head ?? "") || !(SEASON_REVIEW_MODEL_SAMPLES as readonly string[]).includes(values.sample ?? "")) {
+    throw new TypeError("Run identity is invalid.");
+  }
+  return { head: values.head!, executionHead: values["execution-head"]!, sample: values.sample as SeasonReviewModelSample,
+    athleteHome: values["athlete-home"]!, agentData: values["agent-data"]!, report: values.report!,
+    runRecord: values["run-record"]!, marker: values["chat-start-marker"]! };
+}
+
+function validateExecutionHead(path: string, root: string, expected: string, actual: string): void {
+  directPath(path, root, "file", [0o444]);
+  if (readFileSync(path, "utf8") !== `${expected}\n` || expected !== actual) throw new TypeError("Execution HEAD differs.");
+}
+
+function validateAthleteHome(path: string, resolveHome: (env: Record<string, string | undefined>) => AthleteHome): string {
+  if (!isAbsolute(path) || normalize(path) !== path || process.env.ENDURAGENT_HOME !== path) {
+    throw new TypeError("Athlete home binding is invalid.");
+  }
+  const rootStats = lstatSync(path);
+  if (!rootStats.isDirectory() || rootStats.isSymbolicLink() || realpathSync(path) !== path) throw new TypeError("Athlete home is invalid.");
+  const storePath = join(path, "store", "store.db"), storeStats = lstatSync(storePath);
+  if (!storeStats.isFile() || storeStats.isSymbolicLink()) throw new TypeError("Athlete store is invalid.");
+  const resolved = resolveHome(process.env);
+  if (realpathSync(resolved.root) !== path || realpathSync(join(resolved.storeDir, "store.db")) !== realpathSync(storePath)) {
+    throw new TypeError("Resolved athlete store differs from the explicit binding.");
+  }
+  return realpathSync(storePath);
+}
+
+function storeInventory(storePath: string): string {
+  const rows = [storePath, `${storePath}-wal`, `${storePath}-shm`].filter(existsSync).map((path) => {
+    const stats = lstatSync(path);
+    if (!stats.isFile() || stats.isSymbolicLink()) throw new TypeError("Store inventory member is invalid.");
+    return { basename: path.slice(dirname(path).length + 1), size: stats.size, mtime_ms: stats.mtimeMs,
+      sha256: fileSha256(path) };
+  }).sort((left, right) => Buffer.compare(Buffer.from(left.basename), Buffer.from(right.basename)));
+  return sha256Bytes(new TextEncoder().encode(canonicalJson(rows)));
+}
+
+async function selectedCaptureManifest(root: string): Promise<ReferenceCaptureManifest> {
+  const captures = join(root, "captures"), stats = lstatSync(captures);
+  if (!stats.isDirectory() || stats.isSymbolicLink() || (stats.mode & 0o777) !== 0o700) throw new TypeError("Capture root is invalid.");
+  const entries = readdirSync(captures, { withFileTypes: true });
+  if (entries.length === 0 || entries.some((entry) => !entry.isDirectory() || !UUID.test(entry.name))) {
+    throw new TypeError("Capture set is invalid.");
+  }
+  const loaded = await Promise.all(entries.map((entry) => loadReferenceCaptureSidecars({ root, captureId: entry.name,
+    assertReplayable: async () => {} })));
+  const byId = new Map(loaded.map((item) => [item.manifest.capture_id, item]));
+  if (byId.size !== loaded.length) throw new TypeError("Capture set is ambiguous.");
+  const successor = new Map<string, string>();
+  const roots = loaded.filter((item) => item.review.replaces_capture_id === null);
+  if (roots.length !== 1) throw new TypeError("Capture replacement chain is invalid.");
+  for (const item of loaded) {
+    const prior = item.review.replaces_capture_id;
+    if (prior !== null) {
+      if (!byId.has(prior) || successor.has(prior)) throw new TypeError("Capture replacement chain is invalid.");
+      successor.set(prior, item.manifest.capture_id);
+    }
+  }
+  const seen = new Set<string>();
+  let selected = roots[0]!.manifest.capture_id;
+  while (true) {
+    if (seen.has(selected)) throw new TypeError("Capture replacement chain contains a cycle.");
+    seen.add(selected);
+    const next = successor.get(selected);
+    if (next === undefined) break;
+    selected = next;
+  }
+  if (seen.size !== loaded.length) throw new TypeError("Capture replacement chain is disconnected.");
+  return byId.get(selected)!.manifest;
+}
+
+async function productComposition(input: SeasonReviewCompositionInput): Promise<SeasonReviewComposition> {
+  const localBotModule = new URL("./local-bot.js", import.meta.url).href;
+  const storeRuntimeModule = new URL("./store-runtime.js", import.meta.url).href;
+  const [{ prepareStoreCoachComposition }, { createStoreRuntime }] = await Promise.all([
+    import(localBotModule) as Promise<typeof import("./local-bot.js")>,
+    import(storeRuntimeModule) as Promise<typeof import("./store-runtime.js")>,
+  ]);
+  const loaded = loadConfig();
+  let llmApiKey = loaded.llm.apiKey;
+  if (loaded.llm.provider !== "openai-codex" && llmApiKey.length === 0) {
+    const llmYaml = readConfigYaml().llm;
+    const configured = llmYaml !== null && typeof llmYaml === "object" && !Array.isArray(llmYaml)
+      ? (llmYaml as Record<string, unknown>).api_key : undefined;
+    if (isSecretRef(configured)) llmApiKey = await resolveSecretRef(configured);
+  }
+  if (loaded.llm.provider !== "openai-codex" && llmApiKey.length === 0) {
+    throw new TypeError("Configured model credentials are unavailable.");
+  }
+  if (loaded.dataSource !== "store") throw new TypeError("Season review requires the configured store data source.");
+  const config: Config = { ...loaded, dataDir: input.agentData,
+    intervals: { ...loaded.intervals, apiKey: "" }, telegram: { botToken: "" },
+    llm: { ...loaded.llm, apiKey: llmApiKey }, session: { ...loaded.session } };
+  const manifest = await selectedCaptureManifest(input.athleteHome);
+  const env: Record<string, string | undefined> = { ...process.env, ENDURAGENT_HOME: input.athleteHome,
+    INTERVALS_API_KEY: undefined, TELEGRAM_BOT_TOKEN: undefined };
+  let reference: ReferenceRuntime | undefined, runtime: StoreRuntime | undefined;
+  try {
+    const prepared = await prepareStoreCoachComposition({ config, sport: cyclingSport }, {
+      env,
+      bootstrap: async (options) => {
+        const productReference = await bootstrapReference({ ...options, startScheduler: false });
+        reference = { ...productReference,
+          runScheduledOnce: async () => ({ kind: "skipped", reason: "cooldown" }) as never };
+        return reference;
+      },
+      createRuntime: (options) => (runtime = createStoreRuntime(options)),
+      runtimeDependencies: { capture: async () => manifest },
+    });
+    if (prepared.athleteData === undefined) throw new TypeError("Store athlete reader is unavailable.");
+    const engine = createCoachEngine(cyclingSport, config, { athleteData: prepared.athleteData });
+    let closed = false;
+    return { engine, provider: config.llm.provider, model: config.llm.model, async close() {
+      if (closed) return;
+      closed = true;
+      try { await prepared.close?.(); }
+      finally { reference?.scheduler.stop(); }
+    } };
+  } catch (error) {
+    try { await runtime?.close(); } finally { reference?.scheduler.stop(); }
+    throw error;
+  }
+}
+
+function readUsage(agentData: string): readonly SeasonReviewUsageRow[] {
+  const path = join(agentData, USAGE_LEDGER_FILE);
+  assertMode(path, [0o600]);
+  const text = new TextDecoder("utf-8", { fatal: true }).decode(readFileSync(path));
+  if (!text.endsWith("\n")) throw new TypeError("Usage ledger is incomplete.");
+  return text.slice(0, -1).split("\n").map((line) => object(JSON.parse(line), "Usage row") as unknown as SeasonReviewUsageRow);
+}
+
+function runRecordBytes(record: SeasonReviewRunRecord): Uint8Array {
+  return new TextEncoder().encode(`${canonicalJson(record)}\n`);
+}
+
+async function executeRun(options: RunOptions, dependencies: SeasonReviewCommandDependencies): Promise<SeasonReviewCommandResult> {
+  const resolveHome = dependencies.resolveHome ?? resolveAthleteHome;
+  let createdAgentData = false;
+  let storePath: string | undefined, before: string | undefined;
+  const inventory = dependencies.storeInventory ?? storeInventory;
+  try {
+    const root = evidenceRootFor(options.executionHead);
+    for (const path of [options.agentData, options.report, options.runRecord, options.marker]) directPath(path, root, "new");
+    const actualHead = (dependencies.currentHead ?? currentHead)();
+    validateExecutionHead(options.executionHead, root, options.head, actualHead);
+    storePath = validateAthleteHome(options.athleteHome, resolveHome);
+    before = inventory(storePath);
+    if (!HASH.test(before)) throw new TypeError("Store inventory hash is invalid.");
+    mkdirSync(options.agentData, { mode: 0o700 });
+    createdAgentData = true;
+    const composition = await (dependencies.compose ?? productComposition)({ athleteHome: options.athleteHome, agentData: options.agentData });
+    let report: string | undefined, chatFailure: unknown, closeFailure: unknown;
+    try {
+      if (typeof composition.provider !== "string" || composition.provider.length === 0
+        || typeof composition.model !== "string" || composition.model.length === 0) throw new TypeError("Model identity is invalid.");
+      const chatId = (dependencies.chatId ?? ((sample) => `season-review-prototype-${sample}-${randomUUID()}`))(options.sample);
+      if (!/^season-review-prototype-[a-z0-9-]+$/.test(chatId)) throw new TypeError("Season review chat ID is invalid.");
+      writeFileSync(options.marker, `${options.head}\n`, { flag: "wx", mode: 0o600 });
+      report = await composition.engine.chat(chatId, SEASON_REVIEW_REQUEST);
+    } catch (error) { chatFailure = error; }
+    finally { try { await composition.close(); } catch (error) { closeFailure = error; } }
+    const after = inventory(storePath);
+    if (before !== after) throw new TypeError("Store changed during season review.");
+    if (chatFailure !== undefined) throw chatFailure;
+    if (closeFailure !== undefined) throw closeFailure;
+    if (typeof report !== "string") throw new TypeError("Season review report is invalid.");
+    const reportBytes = new TextEncoder().encode(report), reportSha256 = sha256Bytes(reportBytes);
+    const usage = (dependencies.readUsage ?? readUsage)(options.agentData);
+    const summarized = summarizeGenerateUsage(usage, composition.provider, composition.model);
+    const record: SeasonReviewRunRecord = validateSeasonReviewRunRecord({
+      schema_version: 1, head_sha: options.head, sample: options.sample, provider: composition.provider,
+      model: composition.model, report_sha256: reportSha256, store_before_sha256: before,
+      store_after_sha256: after, store_unchanged: true, generate_calls: summarized.generateCalls, cost: summarized.cost,
+    }, { head_sha: options.head, sample: options.sample, provider: composition.provider,
+      model: composition.model, report_sha256: reportSha256 });
+    writeExclusive(options.report, reportBytes);
+    writeExclusive(options.runRecord, runRecordBytes(record));
+    return { exitCode: 0, stdout: JSON.stringify({ status: "generated", provider: composition.provider,
+      model: composition.model, sample: options.sample, report_sha256: reportSha256,
+      generate_calls: summarized.generateCalls, priced: summarized.cost.priced_calls === summarized.generateCalls }) };
+  } catch {
+    const started = existsSync(options.marker);
+    if (storePath !== undefined && before !== undefined) {
+      try { inventory(storePath); }
+      catch {}
+    }
+    if (!started && createdAgentData && existsSync(options.agentData)) rmSync(options.agentData, { recursive: true });
+    return { exitCode: started ? 1 : 2, stdout: JSON.stringify({ status: started ? "run_failed" : "environment" }) };
+  }
+}
+
+function parseCalibration(value: unknown, label: string): IndexCalibration {
+  const candidate = object(value, label);
+  exactKeys(candidate, ["sample", "report_path", "run_record_path", "score_path", "source_label_path"], label);
+  if (typeof candidate.sample !== "string" || typeof candidate.report_path !== "string"
+    || (candidate.run_record_path !== null && typeof candidate.run_record_path !== "string")
+    || typeof candidate.score_path !== "string"
+    || (candidate.source_label_path !== null && typeof candidate.source_label_path !== "string")) throw new TypeError(`${label} is invalid.`);
+  return candidate as unknown as IndexCalibration;
+}
+
+function loadIndex(indexPath: string): { readonly root: string; readonly index: EvidenceIndex } {
+  const root = evidenceRootFor(indexPath);
+  directPath(indexPath, root, "file", [0o600]);
+  const candidate = object(readJson(indexPath, [0o600]), "Evidence index");
+  exactKeys(candidate, ["schema_version", "base_sha", "execution_head_path", "call_graph_path", "rubric_path",
+    "score_schema_path", "rubric_calibration", "model_calibration", "real"], "Evidence index");
+  if (candidate.schema_version !== 1 || typeof candidate.base_sha !== "string" || !HEAD.test(candidate.base_sha)
+    || typeof candidate.execution_head_path !== "string" || typeof candidate.call_graph_path !== "string"
+    || typeof candidate.rubric_path !== "string" || typeof candidate.score_schema_path !== "string"
+    || !Array.isArray(candidate.rubric_calibration) || !Array.isArray(candidate.model_calibration)) {
+    throw new TypeError("Evidence index is invalid.");
+  }
+  const real = object(candidate.real, "Real evidence index");
+  exactKeys(real, ["report_path", "run_record_path", "score_path"], "Real evidence index");
+  if (typeof real.report_path !== "string" || typeof real.run_record_path !== "string" || typeof real.score_path !== "string") {
+    throw new TypeError("Real evidence index is invalid.");
+  }
+  const index: EvidenceIndex = { schema_version: 1, base_sha: candidate.base_sha,
+    execution_head_path: candidate.execution_head_path, call_graph_path: candidate.call_graph_path,
+    rubric_path: candidate.rubric_path, score_schema_path: candidate.score_schema_path,
+    rubric_calibration: candidate.rubric_calibration.map((value) => parseCalibration(value, "Rubric calibration index")),
+    model_calibration: candidate.model_calibration.map((value) => parseCalibration(value, "Model calibration index")),
+    real: real as unknown as EvidenceIndex["real"] };
+  const paths = [index.execution_head_path, index.call_graph_path, index.rubric_path, index.score_schema_path,
+    ...index.rubric_calibration.flatMap((item) => [item.report_path, item.score_path, item.source_label_path].filter((path): path is string => path !== null)),
+    ...index.model_calibration.flatMap((item) => [item.report_path, item.run_record_path, item.score_path].filter((path): path is string => path !== null)),
+    index.real.report_path, index.real.run_record_path, index.real.score_path];
+  if (new Set([indexPath, ...paths]).size !== paths.length + 1) throw new TypeError("Evidence paths must be unique.");
+  for (const path of paths) directPath(path, root, "file", [0o400, 0o444, 0o600]);
+  return { root, index };
+}
+
+const RUBRIC_EXPECTED: readonly [SeasonReviewVerdict, SeasonReviewVerdict, SeasonReviewVerdict][] = [
+  ["REWORK", "KEEP", "KEEP"], ["KEEP", "REWORK", "REWORK"], ["KEEP", "KEEP", "KEEP"],
+];
+const RUBRIC_LABELS = ["unsupported-specific", "grounded-generic", "strong"] as const;
+
+function validateCalibrationFiles(
+  values: readonly IndexCalibration[],
+  root: string,
+  kind: "rubric" | "model",
+): readonly ValidatedCalibration[] {
+  if (values.length !== 3) throw new TypeError("Calibration count is invalid.");
+  const blindKeys: string[] = [];
+  const validated = values.map((item, index): ValidatedCalibration => {
+    const expectedSample = kind === "rubric" ? SEASON_REVIEW_RUBRIC_SAMPLES[index] : SEASON_REVIEW_MODEL_SAMPLES[index];
+    if (item.sample !== expectedSample) throw new TypeError("Calibration order is invalid.");
+    directPath(item.report_path, root, "file", [0o600]);
+    directPath(item.score_path, root, "file", [0o600]);
+    const reportSha256 = fileSha256(item.report_path);
+    const score = validateSeasonReviewScore(readJson(item.score_path, [0o600]), reportSha256);
+    if (kind === "rubric") {
+      if (item.run_record_path !== null || item.source_label_path === null) throw new TypeError("Rubric calibration index is invalid.");
+      directPath(item.source_label_path, root, "file", [0o600]);
+      const sourceLabel = readFileSync(item.source_label_path, "utf8").trim();
+      if (sourceLabel !== RUBRIC_LABELS[index]) throw new TypeError("Rubric source label is invalid.");
+      blindKeys.push(seasonReviewBlindKey(readFileSync(item.report_path), sourceLabel));
+      const actual = scoreVerdicts(score), expected = RUBRIC_EXPECTED[index]!;
+      if (actual.grounding !== expected[0] || actual.specificity !== expected[1] || actual.question_quality !== expected[2]) {
+        throw new TypeError("Rubric calibration map is invalid.");
+      }
+      return { sample: item.sample, reportPath: item.report_path, reportSha256, runRecordPath: null,
+        runRecord: null, scorePath: item.score_path, score };
+    }
+    if (item.run_record_path === null || item.source_label_path !== null) throw new TypeError("Model calibration index is invalid.");
+    directPath(item.run_record_path, root, "file", [0o600]);
+    const runRecord = validateSeasonReviewRunRecord(readJson(item.run_record_path, [0o600]), {
+      sample: expectedSample as SeasonReviewModelSample, report_sha256: reportSha256,
+    });
+    return { sample: item.sample, reportPath: item.report_path, reportSha256,
+      runRecordPath: item.run_record_path, runRecord, scorePath: item.score_path, score };
+  });
+  if (kind === "rubric" && new Set(blindKeys).size !== 3) throw new TypeError("Rubric blind keys are ambiguous.");
+  return validated;
+}
+
+function validateStages(indexPath: string, stage: "rubric" | "model"): {
+  readonly root: string; readonly index: EvidenceIndex; readonly rubric: readonly ValidatedCalibration[];
+  readonly model: readonly ValidatedCalibration[] | null;
+} {
+  const { root, index } = loadIndex(indexPath);
+  directPath(index.rubric_path, root, "file", stage === "rubric" ? [0o600, 0o444] : [0o444]);
+  directPath(index.score_schema_path, root, "file", [0o400]);
+  assertExactSeasonReviewRubric(readFileSync(index.rubric_path));
+  assertExactSeasonReviewScoreSchema(readFileSync(index.score_schema_path));
+  const rubric = validateCalibrationFiles(index.rubric_calibration, root, "rubric");
+  if (stage === "rubric") {
+    chmodSync(index.rubric_path, 0o444);
+    return { root, index, rubric, model: null };
+  }
+  const model = validateCalibrationFiles(index.model_calibration, root, "model");
+  const records = model.map((item) => item.runRecord!);
+  if (records.some((record) => record.head_sha !== records[0]!.head_sha || record.provider !== records[0]!.provider
+    || record.model !== records[0]!.model || record.store_before_sha256 !== records[0]!.store_before_sha256)) {
+    throw new TypeError("Model calibration identity is inconsistent.");
+  }
+  return { root, index, rubric, model };
+}
+
+function validateCallGraph(value: unknown, baseSha: string): void {
+  const candidate = object(value, "Call graph");
+  exactKeys(candidate, ["schema_version", "base_sha", "config", "store_binding", "composition", "store_open", "engine",
+    "reads", "mutations", "fencing", "projection", "shutdown", "verdict"], "Call graph");
+  if (candidate.schema_version !== 1 || candidate.base_sha !== baseSha || candidate.verdict !== "USE_PRODUCT_SEAM") {
+    throw new TypeError("Call graph identity is invalid.");
+  }
+  const visit = (value: unknown, key = ""): void => {
+    if (typeof value === "boolean") {
+      if (value !== (key === "writer_called" ? false : true)) throw new TypeError("Call graph qualification is invalid.");
+      return;
+    }
+    if (value !== null && typeof value === "object" && !Array.isArray(value)) {
+      for (const [childKey, child] of Object.entries(value)) visit(child, childKey);
+    }
+  };
+  visit(candidate);
+}
+
+function costCalls(cost: SeasonReviewCost): number { return cost.priced_calls + cost.unpriced_calls; }
+
+function conclusionCalibration(item: ValidatedCalibration): SeasonReviewConclusion["model_calibration"][number] {
+  return { sample: item.sample as "model-calibration-01" | "model-calibration-02" | "model-calibration-03",
+    report_sha256: item.reportSha256, ...scoreVerdicts(item.score) };
+}
+
+function seal(indexPath: string, conclusionPath: string, expectedHead: string): void {
+  const validated = validateStages(indexPath, "model"), { root, index } = validated;
+  directPath(conclusionPath, root, "new");
+  validateExecutionHead(index.execution_head_path, root, expectedHead, expectedHead);
+  directPath(index.call_graph_path, root, "file", [0o600]);
+  validateCallGraph(readJson(index.call_graph_path, [0o600]), index.base_sha);
+  const model = validated.model!;
+  const provider = model[0]!.runRecord!.provider, modelName = model[0]!.runRecord!.model;
+  const realReportSha256 = fileSha256(index.real.report_path);
+  const realRecord = validateSeasonReviewRunRecord(readJson(index.real.run_record_path, [0o600]), {
+    head_sha: expectedHead, sample: "real", provider, model: modelName, report_sha256: realReportSha256,
+  });
+  const realScore = validateSeasonReviewScore(readJson(index.real.score_path, [0o600]), realReportSha256);
+  if (model.some((item) => item.runRecord!.head_sha !== expectedHead)) throw new TypeError("Calibration HEAD differs.");
+  const calibrationCosts = model.map((item) => ({ cost: item.runRecord!.cost, generateCalls: item.runRecord!.generate_calls }));
+  const calibrationTotal = combineCosts(calibrationCosts);
+  const realTotal = { cost: validateCost(realRecord.cost, realRecord.generate_calls), generateCalls: realRecord.generate_calls };
+  const combinedTotal = combineCosts([calibrationTotal, realTotal]);
+  const costTotals = { calibration: calibrationTotal.cost, real: realTotal.cost, combined: combinedTotal.cost };
+  const evidenceManifest = {
+    base_sha: index.base_sha, head_sha: expectedHead, call_graph_sha256: fileSha256(index.call_graph_path),
+    execution_head_sha256: fileSha256(index.execution_head_path), rubric_sha256: fileSha256(index.rubric_path),
+    score_schema_sha256: fileSha256(index.score_schema_path),
+    rubric_calibration: validated.rubric.map((item) => ({ report_sha256: item.reportSha256, score_sha256: fileSha256(item.scorePath) })),
+    model_calibration: model.map((item) => ({ report_sha256: item.reportSha256,
+      run_record_sha256: fileSha256(item.runRecordPath!), score_sha256: fileSha256(item.scorePath) })),
+    real: { report_sha256: realReportSha256, run_record_sha256: fileSha256(index.real.run_record_path),
+      score_sha256: fileSha256(index.real.score_path) },
+    cost_totals_sha256: hashSeasonReviewEvidence(costTotals), store_unchanged: true,
+  };
+  const realVerdicts = scoreVerdicts(realScore);
+  const conclusion: SeasonReviewConclusion = validateSeasonReviewConclusion({
+    schema_version: 1, head_sha: expectedHead, provider, model: modelName,
+    rubric_sha256: fileSha256(index.rubric_path), model_calibration: model.map(conclusionCalibration),
+    ...realVerdicts, cost_totals: costTotals,
+    overall: Object.values(realVerdicts).every((value) => value === "KEEP") ? "KEEP" : "REWORK",
+    evidence_sha256: hashSeasonReviewEvidence(evidenceManifest),
+  }, expectedHead);
+  if (costCalls(conclusion.cost_totals.combined) !== combinedTotal.generateCalls) throw new TypeError("Combined call count is invalid.");
+  writeExclusive(conclusionPath, new TextEncoder().encode(`${canonicalJson(conclusion)}\n`));
+}
+
+export async function executeSeasonReviewCommand(
+  args: readonly string[],
+  dependencies: SeasonReviewCommandDependencies = {},
+): Promise<SeasonReviewCommandResult> {
+  if (args.length === 1 && args[0] === "--help") return { exitCode: 0, stdout: HELP };
+  const [command, ...rest] = args;
+  if (command === "run") return executeRun(parseRun(rest), dependencies);
+  if (command === "validate-score") {
+    const values = optionMap(rest, ["report", "score"]), root = evidenceRootFor(values.report!);
+    directPath(values.report!, root, "file", [0o600]); directPath(values.score!, root, "file", [0o600]);
+    validateSeasonReviewScore(readJson(values.score!, [0o600]), fileSha256(values.report!));
+    return { exitCode: 0, stdout: "" };
+  }
+  if (command === "validate-stage") {
+    const values = optionMap(rest, ["stage", "index"]);
+    if (values.stage !== "rubric" && values.stage !== "model") throw new TypeError("Validation stage is invalid.");
+    validateStages(values.index!, values.stage);
+    return { exitCode: 0, stdout: "" };
+  }
+  if (command === "seal") {
+    const values = optionMap(rest, ["index", "conclusion"]), headSha = (dependencies.currentHead ?? currentHead)();
+    seal(values.index!, values.conclusion!, headSha);
+    return { exitCode: 0, stdout: "" };
+  }
+  if (command === "validate-conclusion") {
+    const values = optionMap(rest, ["conclusion"]), root = evidenceRootFor(values.conclusion!);
+    directPath(values.conclusion!, root, "file", [0o444]);
+    validateSeasonReviewConclusion(readJson(values.conclusion!, [0o444]));
+    return { exitCode: 0, stdout: "" };
+  }
+  throw new TypeError("Invalid season review command.");
+}
+
+async function main(): Promise<void> {
+  const prior = { log: console.log, warn: console.warn, error: console.error };
+  console.log = () => {};
+  console.warn = () => {};
+  console.error = () => {};
+  try {
+    const result = await executeSeasonReviewCommand(process.argv.slice(2));
+    console.log = prior.log; console.warn = prior.warn; console.error = prior.error;
+    if (result.stdout.length > 0) process.stdout.write(`${result.stdout}\n`);
+    process.exitCode = result.exitCode;
+  } catch {
+    console.log = prior.log; console.warn = prior.warn; console.error = prior.error;
+    process.exitCode = 2;
+  }
+}
+
+if (process.argv[1] !== undefined && import.meta.url === new URL(process.argv[1], "file:").href) await main();

--- a/packages/coach/src/season-review.ts
+++ b/packages/coach/src/season-review.ts
@@ -1,0 +1,467 @@
+import { createHash } from "node:crypto";
+import { canonicalJson } from "@enduragent/kernel/archive";
+
+export const SEASON_REVIEW_REQUEST = `Prepare a cycling season review from the complete training history available through the local store-backed tools.
+
+Structure the response as: Season arc; What changed; What to keep or change; Questions.
+
+Ground every athlete-specific statement in tool results. Treat Load, Intensity, Fitness, Fatigue, and Form as platform-supplied Reference layer values, not locally computed values. State when evidence is absent or stale. Give at least three distinct observations across at least two parts of the season, identify a trend and an exception or recovery block, and give at least two evidence-linked actions with a time, quantity, or decision condition.
+
+Ask two to four questions only about context absent from the store. Each question must say which coaching decision its answer would change. Do not ask for a fact already available in the store. Do not create, delete, or modify calendar items or training data.`;
+
+export const SEASON_REVIEW_MODEL_SAMPLES = [
+  "model-calibration-01",
+  "model-calibration-02",
+  "model-calibration-03",
+  "real",
+] as const;
+export type SeasonReviewModelSample = (typeof SEASON_REVIEW_MODEL_SAMPLES)[number];
+
+export const SEASON_REVIEW_RUBRIC_SAMPLES = [
+  "rubric-calibration-01",
+  "rubric-calibration-02",
+  "rubric-calibration-03",
+] as const;
+
+export const SEASON_REVIEW_SCORE_SCHEMA_BYTES = `{"type":"object","additionalProperties":false,"properties":{"schema_version":{"const":1},"report_sha256":{"type":"string","pattern":"^[0-9a-f]{64}$"},"grounding":{"type":"object","additionalProperties":false,"properties":{"G1":{"type":"boolean"},"G2":{"type":"boolean"},"G3":{"type":"boolean"},"G4":{"type":"boolean"},"verdict":{"type":"string","enum":["KEEP","REWORK"]}},"required":["G1","G2","G3","G4","verdict"]},"specificity":{"type":"object","additionalProperties":false,"properties":{"S1":{"type":"boolean"},"S2":{"type":"boolean"},"S3":{"type":"boolean"},"S4":{"type":"boolean"},"verdict":{"type":"string","enum":["KEEP","REWORK"]}},"required":["S1","S2","S3","S4","verdict"]},"question_quality":{"type":"object","additionalProperties":false,"properties":{"Q1":{"type":"boolean"},"Q2":{"type":"boolean"},"Q3":{"type":"boolean"},"Q4":{"type":"boolean"},"verdict":{"type":"string","enum":["KEEP","REWORK"]}},"required":["Q1","Q2","Q3","Q4","verdict"]}},"required":["schema_version","report_sha256","grounding","specificity","question_quality"]}
+`;
+
+export const SEASON_REVIEW_RUBRIC_BYTES = `{
+  "schema_version": 1,
+  "criteria": [
+    {"id":"grounding","anchors":[{"id":"G1","text":"Every athlete-specific numeric, temporal, comparative, and causal statement maps to supplied store/tool evidence; an unsupported causal idea is explicitly labeled a hypothesis."},{"id":"G2","text":"Zero statement contradicts supplied evidence and zero quantity/date is invented."},{"id":"G3","text":"Missing, stale, or ambiguous evidence relevant to a conclusion is disclosed rather than filled in."},{"id":"G4","text":"Load, Intensity, Fitness, Fatigue, and Form provenance is called platform-supplied through the Reference layer; no local-compute or whole-store claim appears."}],"rule":"all_anchors_true"},
+    {"id":"specificity","anchors":[{"id":"S1","text":"At least three distinct evidence-backed observations span at least two season periods."},{"id":"S2","text":"At least one trend/change and at least one exception, recovery, or block are identified from evidence."},{"id":"S3","text":"At least two actions each bind to named evidence and a time, quantity, or decision condition."},{"id":"S4","text":"Every recommendation is tied to evidence or explicitly missing context; no generic-advice paragraph remains."}],"rule":"all_anchors_true"},
+    {"id":"question_quality","anchors":[{"id":"Q1","text":"The report asks two through four semantic questions, inclusive."},{"id":"Q2","text":"Every question targets context absent from supplied store evidence."},{"id":"Q3","text":"Every question names the coaching decision its answer would change."},{"id":"Q4","text":"No question restates the report or asks for a fact already supplied by the store."}],"rule":"all_anchors_true"}
+  ],
+  "overall_rule": "all_three_keep"
+}
+`;
+
+const HASH = /^[0-9a-f]{64}$/;
+const HEAD = /^[0-9a-f]{40}$/;
+const VERDICTS = ["KEEP", "REWORK"] as const;
+export type SeasonReviewVerdict = (typeof VERDICTS)[number];
+
+export type SeasonReviewCriterion<I extends string> = Readonly<Record<I, boolean>> & {
+  readonly verdict: SeasonReviewVerdict;
+};
+
+export interface SeasonReviewScore {
+  readonly schema_version: 1;
+  readonly report_sha256: string;
+  readonly grounding: SeasonReviewCriterion<"G1" | "G2" | "G3" | "G4">;
+  readonly specificity: SeasonReviewCriterion<"S1" | "S2" | "S3" | "S4">;
+  readonly question_quality: SeasonReviewCriterion<"Q1" | "Q2" | "Q3" | "Q4">;
+}
+
+export interface SeasonReviewCost {
+  readonly input_tokens: number;
+  readonly output_tokens: number;
+  readonly total_tokens: number;
+  readonly cache_read_tokens: number;
+  readonly cache_write_tokens: number;
+  readonly priced_calls: number;
+  readonly unpriced_calls: number;
+  readonly usd_input: number | null;
+  readonly usd_output: number | null;
+  readonly usd_cache_read: number | null;
+  readonly usd_cache_write: number | null;
+  readonly usd_total: number | null;
+}
+
+export interface SeasonReviewRunRecord {
+  readonly schema_version: 1;
+  readonly head_sha: string;
+  readonly sample: SeasonReviewModelSample;
+  readonly provider: string;
+  readonly model: string;
+  readonly report_sha256: string;
+  readonly store_before_sha256: string;
+  readonly store_after_sha256: string;
+  readonly store_unchanged: true;
+  readonly generate_calls: number;
+  readonly cost: SeasonReviewCost;
+}
+
+export interface SeasonReviewUsageRow {
+  readonly kind: "generate" | "turn" | "boot";
+  readonly provider: string;
+  readonly model: string;
+  readonly inputTokens?: number;
+  readonly outputTokens?: number;
+  readonly totalTokens?: number;
+  readonly cacheReadTokens?: number;
+  readonly cacheWriteTokens?: number;
+  readonly cost?: {
+    readonly input: number;
+    readonly output: number;
+    readonly cacheRead: number;
+    readonly cacheWrite: number;
+    readonly total: number;
+  };
+}
+
+export interface SeasonReviewCalibrationConclusion {
+  readonly sample: "model-calibration-01" | "model-calibration-02" | "model-calibration-03";
+  readonly report_sha256: string;
+  readonly grounding: SeasonReviewVerdict;
+  readonly specificity: SeasonReviewVerdict;
+  readonly question_quality: SeasonReviewVerdict;
+}
+
+export interface SeasonReviewConclusion {
+  readonly schema_version: 1;
+  readonly head_sha: string;
+  readonly provider: string;
+  readonly model: string;
+  readonly rubric_sha256: string;
+  readonly model_calibration: readonly SeasonReviewCalibrationConclusion[];
+  readonly grounding: SeasonReviewVerdict;
+  readonly specificity: SeasonReviewVerdict;
+  readonly question_quality: SeasonReviewVerdict;
+  readonly cost_totals: {
+    readonly calibration: SeasonReviewCost;
+    readonly real: SeasonReviewCost;
+    readonly combined: SeasonReviewCost;
+  };
+  readonly overall: SeasonReviewVerdict;
+  readonly evidence_sha256: string;
+}
+
+function record(value: unknown, label: string): Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new TypeError(`${label} is invalid.`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function exactKeys(value: Record<string, unknown>, expected: readonly string[], label: string): void {
+  const actual = Object.keys(value).sort();
+  const sorted = [...expected].sort();
+  if (actual.length !== sorted.length || actual.some((key, index) => key !== sorted[index])) {
+    throw new TypeError(`${label} keys are invalid.`);
+  }
+}
+
+function hash(value: unknown, label: string): string {
+  if (typeof value !== "string" || !HASH.test(value)) throw new TypeError(`${label} is invalid.`);
+  return value;
+}
+
+function head(value: unknown, label: string): string {
+  if (typeof value !== "string" || !HEAD.test(value)) throw new TypeError(`${label} is invalid.`);
+  return value;
+}
+
+function nonEmpty(value: unknown, label: string): string {
+  if (typeof value !== "string" || value.length === 0) throw new TypeError(`${label} is invalid.`);
+  return value;
+}
+
+function nonNegativeSafeInteger(value: unknown, label: string): number {
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) {
+    throw new TypeError(`${label} is invalid.`);
+  }
+  return value;
+}
+
+function finiteCost(value: unknown, label: string): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    throw new TypeError(`${label} is invalid.`);
+  }
+  return value;
+}
+
+function verdict(value: unknown, label: string): SeasonReviewVerdict {
+  if (value !== "KEEP" && value !== "REWORK") throw new TypeError(`${label} is invalid.`);
+  return value;
+}
+
+export function sha256Bytes(bytes: string | Uint8Array): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+export function hashSeasonReviewEvidence(manifest: unknown): string {
+  return sha256Bytes(new TextEncoder().encode(canonicalJson(manifest)));
+}
+
+export function seasonReviewBlindKey(reportBytes: Uint8Array, label: string): string {
+  if (typeof label !== "string" || label.length === 0) throw new TypeError("Blind label is invalid.");
+  return createHash("sha256").update(reportBytes).update(new Uint8Array([0])).update(label, "utf8").digest("hex");
+}
+
+export function roundUsd(value: number): number {
+  if (!Number.isFinite(value) || value < 0) throw new TypeError("USD value is invalid.");
+  return Math.round(value * 1e12) / 1e12;
+}
+
+function validateCriterion(
+  value: unknown,
+  ids: readonly string[],
+  label: string,
+): Record<string, boolean | SeasonReviewVerdict> {
+  const candidate = record(value, label);
+  exactKeys(candidate, [...ids, "verdict"], label);
+  const anchors = ids.map((id) => {
+    if (typeof candidate[id] !== "boolean") throw new TypeError(`${label}.${id} is invalid.`);
+    return candidate[id] as boolean;
+  });
+  const expected = anchors.every(Boolean) ? "KEEP" : "REWORK";
+  if (verdict(candidate.verdict, `${label}.verdict`) !== expected) {
+    throw new TypeError(`${label}.verdict does not match its anchors.`);
+  }
+  return candidate as Record<string, boolean | SeasonReviewVerdict>;
+}
+
+export function validateSeasonReviewScore(value: unknown, reportSha256?: string): SeasonReviewScore {
+  const candidate = record(value, "Season review score");
+  exactKeys(candidate, ["schema_version", "report_sha256", "grounding", "specificity", "question_quality"], "Season review score");
+  if (candidate.schema_version !== 1) throw new TypeError("Season review score version is invalid.");
+  const reportHash = hash(candidate.report_sha256, "Season review report hash");
+  if (reportSha256 !== undefined && reportHash !== hash(reportSha256, "Expected report hash")) {
+    throw new TypeError("Season review score is bound to a different report.");
+  }
+  const grounding = validateCriterion(candidate.grounding, ["G1", "G2", "G3", "G4"], "Grounding score");
+  const specificity = validateCriterion(candidate.specificity, ["S1", "S2", "S3", "S4"], "Specificity score");
+  const questionQuality = validateCriterion(candidate.question_quality, ["Q1", "Q2", "Q3", "Q4"], "Question-quality score");
+  return {
+    schema_version: 1,
+    report_sha256: reportHash,
+    grounding: grounding as unknown as SeasonReviewScore["grounding"],
+    specificity: specificity as unknown as SeasonReviewScore["specificity"],
+    question_quality: questionQuality as unknown as SeasonReviewScore["question_quality"],
+  };
+}
+
+const COST_KEYS = [
+  "input_tokens", "output_tokens", "total_tokens", "cache_read_tokens", "cache_write_tokens",
+  "priced_calls", "unpriced_calls", "usd_input", "usd_output", "usd_cache_read", "usd_cache_write", "usd_total",
+] as const;
+const USD_KEYS = ["usd_input", "usd_output", "usd_cache_read", "usd_cache_write", "usd_total"] as const;
+
+export function validateCost(value: unknown, generateCalls: number): SeasonReviewCost {
+  const calls = nonNegativeSafeInteger(generateCalls, "Generate call count");
+  const candidate = record(value, "Season review cost");
+  exactKeys(candidate, COST_KEYS, "Season review cost");
+  const cost: SeasonReviewCost = {
+    input_tokens: nonNegativeSafeInteger(candidate.input_tokens, "Input tokens"),
+    output_tokens: nonNegativeSafeInteger(candidate.output_tokens, "Output tokens"),
+    total_tokens: nonNegativeSafeInteger(candidate.total_tokens, "Total tokens"),
+    cache_read_tokens: nonNegativeSafeInteger(candidate.cache_read_tokens, "Cache-read tokens"),
+    cache_write_tokens: nonNegativeSafeInteger(candidate.cache_write_tokens, "Cache-write tokens"),
+    priced_calls: nonNegativeSafeInteger(candidate.priced_calls, "Priced call count"),
+    unpriced_calls: nonNegativeSafeInteger(candidate.unpriced_calls, "Unpriced call count"),
+    usd_input: null,
+    usd_output: null,
+    usd_cache_read: null,
+    usd_cache_write: null,
+    usd_total: null,
+  };
+  if (cost.priced_calls + cost.unpriced_calls !== calls) throw new TypeError("Cost call counts are invalid.");
+  if (cost.unpriced_calls > 0) {
+    for (const key of USD_KEYS) if (candidate[key] !== null) throw new TypeError("Unpriced costs must have null USD values.");
+    return cost;
+  }
+  const usdInput = finiteCost(candidate.usd_input, "Input cost");
+  const usdOutput = finiteCost(candidate.usd_output, "Output cost");
+  const usdCacheRead = finiteCost(candidate.usd_cache_read, "Cache-read cost");
+  const usdCacheWrite = finiteCost(candidate.usd_cache_write, "Cache-write cost");
+  const usdTotal = finiteCost(candidate.usd_total, "Total cost");
+  if (usdTotal !== roundUsd(usdInput + usdOutput + usdCacheRead + usdCacheWrite)) {
+    throw new TypeError("Total USD cost is invalid.");
+  }
+  return { ...cost, usd_input: usdInput, usd_output: usdOutput, usd_cache_read: usdCacheRead,
+    usd_cache_write: usdCacheWrite, usd_total: usdTotal };
+}
+
+function token(row: SeasonReviewUsageRow, key: "inputTokens" | "outputTokens" | "totalTokens" | "cacheReadTokens" | "cacheWriteTokens"): number {
+  return row[key] === undefined ? 0 : nonNegativeSafeInteger(row[key], `Usage ${key}`);
+}
+
+export function summarizeGenerateUsage(
+  rows: readonly SeasonReviewUsageRow[],
+  provider: string,
+  model: string,
+): { readonly generateCalls: number; readonly cost: SeasonReviewCost } {
+  nonEmpty(provider, "Provider");
+  nonEmpty(model, "Model");
+  const generated = rows.filter((row) => row.kind === "generate");
+  if (generated.length < 1) throw new TypeError("No generate usage was recorded.");
+  const sums = { input: 0, output: 0, total: 0, cacheRead: 0, cacheWrite: 0,
+    priced: 0, usdInput: 0, usdOutput: 0, usdCacheRead: 0, usdCacheWrite: 0 };
+  for (const row of generated) {
+    if (row.provider !== provider || row.model !== model) throw new TypeError("Usage identity differs from the configured model.");
+    sums.input += token(row, "inputTokens");
+    sums.output += token(row, "outputTokens");
+    sums.total += token(row, "totalTokens");
+    sums.cacheRead += token(row, "cacheReadTokens");
+    sums.cacheWrite += token(row, "cacheWriteTokens");
+    for (const [label, amount] of [["input", sums.input], ["output", sums.output], ["total", sums.total],
+      ["cache read", sums.cacheRead], ["cache write", sums.cacheWrite]] as const) {
+      if (!Number.isSafeInteger(amount)) throw new TypeError(`Summed ${label} tokens are invalid.`);
+    }
+    if (row.cost !== undefined) {
+      const priced = record(row.cost, "Generate cost");
+      exactKeys(priced, ["input", "output", "cacheRead", "cacheWrite", "total"], "Generate cost");
+      const input = finiteCost(priced.input, "Generate input cost");
+      const output = finiteCost(priced.output, "Generate output cost");
+      const cacheRead = finiteCost(priced.cacheRead, "Generate cache-read cost");
+      const cacheWrite = finiteCost(priced.cacheWrite, "Generate cache-write cost");
+      finiteCost(priced.total, "Generate total cost");
+      sums.priced += 1;
+      sums.usdInput += input; sums.usdOutput += output;
+      sums.usdCacheRead += cacheRead; sums.usdCacheWrite += cacheWrite;
+    }
+  }
+  const unpriced = generated.length - sums.priced;
+  const nullUsd = unpriced > 0;
+  return { generateCalls: generated.length, cost: validateCost({
+    input_tokens: sums.input, output_tokens: sums.output, total_tokens: sums.total,
+    cache_read_tokens: sums.cacheRead, cache_write_tokens: sums.cacheWrite,
+    priced_calls: sums.priced, unpriced_calls: unpriced,
+    usd_input: nullUsd ? null : roundUsd(sums.usdInput),
+    usd_output: nullUsd ? null : roundUsd(sums.usdOutput),
+    usd_cache_read: nullUsd ? null : roundUsd(sums.usdCacheRead),
+    usd_cache_write: nullUsd ? null : roundUsd(sums.usdCacheWrite),
+    usd_total: nullUsd ? null : roundUsd(sums.usdInput + sums.usdOutput + sums.usdCacheRead + sums.usdCacheWrite),
+  }, generated.length) };
+}
+
+export function combineCosts(costs: readonly { readonly cost: SeasonReviewCost; readonly generateCalls: number }[]): {
+  readonly cost: SeasonReviewCost; readonly generateCalls: number;
+} {
+  if (costs.length === 0) throw new TypeError("At least one cost is required.");
+  let generateCalls = 0;
+  const sums = { input: 0, output: 0, total: 0, cacheRead: 0, cacheWrite: 0, priced: 0, unpriced: 0,
+    usdInput: 0, usdOutput: 0, usdCacheRead: 0, usdCacheWrite: 0 };
+  for (const item of costs) {
+    const value = validateCost(item.cost, item.generateCalls);
+    generateCalls += item.generateCalls;
+    sums.input += value.input_tokens; sums.output += value.output_tokens; sums.total += value.total_tokens;
+    sums.cacheRead += value.cache_read_tokens; sums.cacheWrite += value.cache_write_tokens;
+    sums.priced += value.priced_calls; sums.unpriced += value.unpriced_calls;
+    sums.usdInput += value.usd_input ?? 0; sums.usdOutput += value.usd_output ?? 0;
+    sums.usdCacheRead += value.usd_cache_read ?? 0; sums.usdCacheWrite += value.usd_cache_write ?? 0;
+  }
+  for (const value of [generateCalls, sums.input, sums.output, sums.total, sums.cacheRead, sums.cacheWrite]) {
+    if (!Number.isSafeInteger(value)) throw new TypeError("Combined cost is invalid.");
+  }
+  const nullUsd = sums.unpriced > 0;
+  return { generateCalls, cost: validateCost({
+    input_tokens: sums.input, output_tokens: sums.output, total_tokens: sums.total,
+    cache_read_tokens: sums.cacheRead, cache_write_tokens: sums.cacheWrite,
+    priced_calls: sums.priced, unpriced_calls: sums.unpriced,
+    usd_input: nullUsd ? null : roundUsd(sums.usdInput),
+    usd_output: nullUsd ? null : roundUsd(sums.usdOutput),
+    usd_cache_read: nullUsd ? null : roundUsd(sums.usdCacheRead),
+    usd_cache_write: nullUsd ? null : roundUsd(sums.usdCacheWrite),
+    usd_total: nullUsd ? null : roundUsd(sums.usdInput + sums.usdOutput + sums.usdCacheRead + sums.usdCacheWrite),
+  }, generateCalls) };
+}
+
+export function validateSeasonReviewRunRecord(
+  value: unknown,
+  expected: Partial<Pick<SeasonReviewRunRecord, "head_sha" | "sample" | "provider" | "model" | "report_sha256">> = {},
+): SeasonReviewRunRecord {
+  const candidate = record(value, "Season review run record");
+  exactKeys(candidate, ["schema_version", "head_sha", "sample", "provider", "model", "report_sha256",
+    "store_before_sha256", "store_after_sha256", "store_unchanged", "generate_calls", "cost"], "Season review run record");
+  if (candidate.schema_version !== 1 || candidate.store_unchanged !== true) throw new TypeError("Season review run record is invalid.");
+  const sample = candidate.sample;
+  if (typeof sample !== "string" || !(SEASON_REVIEW_MODEL_SAMPLES as readonly string[]).includes(sample)) {
+    throw new TypeError("Season review sample is invalid.");
+  }
+  const generateCalls = nonNegativeSafeInteger(candidate.generate_calls, "Generate calls");
+  const cost = validateCost(candidate.cost, generateCalls);
+  const result: SeasonReviewRunRecord = {
+    schema_version: 1,
+    head_sha: head(candidate.head_sha, "Run HEAD"),
+    sample: sample as SeasonReviewModelSample,
+    provider: nonEmpty(candidate.provider, "Run provider"),
+    model: nonEmpty(candidate.model, "Run model"),
+    report_sha256: hash(candidate.report_sha256, "Run report hash"),
+    store_before_sha256: hash(candidate.store_before_sha256, "Store-before hash"),
+    store_after_sha256: hash(candidate.store_after_sha256, "Store-after hash"),
+    store_unchanged: true,
+    generate_calls: generateCalls,
+    cost,
+  };
+  if (result.generate_calls < 1 || result.store_before_sha256 !== result.store_after_sha256) {
+    throw new TypeError("Season review run did not preserve the store.");
+  }
+  for (const [key, value] of Object.entries(expected)) {
+    if (value !== undefined && result[key as keyof SeasonReviewRunRecord] !== value) {
+      throw new TypeError(`Season review run ${key} differs from the expected value.`);
+    }
+  }
+  return result;
+}
+
+export function scoreVerdicts(score: SeasonReviewScore): {
+  readonly grounding: SeasonReviewVerdict;
+  readonly specificity: SeasonReviewVerdict;
+  readonly question_quality: SeasonReviewVerdict;
+} {
+  return { grounding: score.grounding.verdict, specificity: score.specificity.verdict,
+    question_quality: score.question_quality.verdict };
+}
+
+export function validateSeasonReviewConclusion(value: unknown, expectedHead?: string): SeasonReviewConclusion {
+  const candidate = record(value, "Season review conclusion");
+  exactKeys(candidate, ["schema_version", "head_sha", "provider", "model", "rubric_sha256", "model_calibration",
+    "grounding", "specificity", "question_quality", "cost_totals", "overall", "evidence_sha256"], "Season review conclusion");
+  if (candidate.schema_version !== 1) throw new TypeError("Season review conclusion version is invalid.");
+  const headSha = head(candidate.head_sha, "Conclusion HEAD");
+  if (expectedHead !== undefined && headSha !== head(expectedHead, "Expected conclusion HEAD")) {
+    throw new TypeError("Season review conclusion HEAD differs.");
+  }
+  if (!Array.isArray(candidate.model_calibration) || candidate.model_calibration.length !== 3) {
+    throw new TypeError("Model calibration conclusions are invalid.");
+  }
+  const calibration = candidate.model_calibration.map((value, index): SeasonReviewCalibrationConclusion => {
+    const item = record(value, "Model calibration conclusion");
+    exactKeys(item, ["sample", "report_sha256", "grounding", "specificity", "question_quality"], "Model calibration conclusion");
+    const sample = SEASON_REVIEW_MODEL_SAMPLES[index];
+    if (index > 2 || item.sample !== sample) throw new TypeError("Model calibration order is invalid.");
+    return { sample: sample as SeasonReviewCalibrationConclusion["sample"],
+      report_sha256: hash(item.report_sha256, "Calibration report hash"),
+      grounding: verdict(item.grounding, "Calibration grounding"),
+      specificity: verdict(item.specificity, "Calibration specificity"),
+      question_quality: verdict(item.question_quality, "Calibration question quality") };
+  });
+  const grounding = verdict(candidate.grounding, "Real grounding");
+  const specificity = verdict(candidate.specificity, "Real specificity");
+  const questionQuality = verdict(candidate.question_quality, "Real question quality");
+  const expectedOverall = [grounding, specificity, questionQuality].every((value) => value === "KEEP") ? "KEEP" : "REWORK";
+  if (verdict(candidate.overall, "Overall verdict") !== expectedOverall) throw new TypeError("Overall verdict is invalid.");
+  const totals = record(candidate.cost_totals, "Cost totals");
+  exactKeys(totals, ["calibration", "real", "combined"], "Cost totals");
+  const calibrationCostRaw = record(totals.calibration, "Calibration cost");
+  const realCostRaw = record(totals.real, "Real cost");
+  const combinedCostRaw = record(totals.combined, "Combined cost");
+  const calls = (cost: Record<string, unknown>): number =>
+    nonNegativeSafeInteger(cost.priced_calls, "Priced calls") + nonNegativeSafeInteger(cost.unpriced_calls, "Unpriced calls");
+  const calibrationCost = validateCost(calibrationCostRaw, calls(calibrationCostRaw));
+  const realCost = validateCost(realCostRaw, calls(realCostRaw));
+  const combinedCost = validateCost(combinedCostRaw, calls(combinedCostRaw));
+  const expectedCombined = combineCosts([
+    { cost: calibrationCost, generateCalls: calls(calibrationCostRaw) },
+    { cost: realCost, generateCalls: calls(realCostRaw) },
+  ]).cost;
+  if (canonicalJson(combinedCost) !== canonicalJson(expectedCombined)) throw new TypeError("Combined cost is invalid.");
+  return {
+    schema_version: 1, head_sha: headSha, provider: nonEmpty(candidate.provider, "Conclusion provider"),
+    model: nonEmpty(candidate.model, "Conclusion model"), rubric_sha256: hash(candidate.rubric_sha256, "Rubric hash"),
+    model_calibration: calibration, grounding, specificity, question_quality: questionQuality,
+    cost_totals: { calibration: calibrationCost, real: realCost, combined: combinedCost },
+    overall: expectedOverall, evidence_sha256: hash(candidate.evidence_sha256, "Evidence hash"),
+  };
+}
+
+export function assertExactSeasonReviewRubric(bytes: Uint8Array): void {
+  if (!Buffer.from(bytes).equals(Buffer.from(SEASON_REVIEW_RUBRIC_BYTES))) throw new TypeError("Season review rubric bytes differ.");
+}
+
+export function assertExactSeasonReviewScoreSchema(bytes: Uint8Array): void {
+  if (!Buffer.from(bytes).equals(Buffer.from(SEASON_REVIEW_SCORE_SCHEMA_BYTES))) throw new TypeError("Season review score schema bytes differ.");
+}

--- a/packages/coach/tests/season-review.test.ts
+++ b/packages/coach/tests/season-review.test.ts
@@ -1,0 +1,394 @@
+import { chmod, mkdir, mkdtemp, readFile, realpath, rm, stat, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  executeSeasonReviewCommand,
+  type SeasonReviewCommandDependencies,
+  type SeasonReviewComposition,
+} from "../src/season-review-command.js";
+import {
+  SEASON_REVIEW_REQUEST,
+  SEASON_REVIEW_RUBRIC_BYTES,
+  SEASON_REVIEW_SCORE_SCHEMA_BYTES,
+  combineCosts,
+  roundUsd,
+  seasonReviewBlindKey,
+  sha256Bytes,
+  summarizeGenerateUsage,
+  validateCost,
+  validateSeasonReviewConclusion,
+  validateSeasonReviewRunRecord,
+  validateSeasonReviewScore,
+  type SeasonReviewConclusion,
+  type SeasonReviewCost,
+  type SeasonReviewUsageRow,
+} from "../src/season-review.js";
+
+const HEAD = "a".repeat(40), OTHER_HEAD = "b".repeat(40), HASH = "c".repeat(64);
+const roots: string[] = [];
+
+afterEach(async () => {
+  delete process.env.ENDURAGENT_HOME;
+  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
+
+interface RunFixture {
+  readonly root: string;
+  readonly evidence: string;
+  readonly athleteHome: string;
+  readonly executionHead: string;
+  readonly agentData: string;
+  readonly report: string;
+  readonly runRecord: string;
+  readonly marker: string;
+  readonly args: readonly string[];
+}
+
+async function fixture(): Promise<RunFixture> {
+  const root = await mkdtemp(join(await realpath(tmpdir()), "season-review-"));
+  roots.push(root);
+  const evidence = join(root, "evidence"), athleteHome = join(root, "athlete");
+  await mkdir(evidence, { mode: 0o700 });
+  await mkdir(join(athleteHome, "store"), { recursive: true, mode: 0o700 });
+  await chmod(athleteHome, 0o700);
+  await writeFile(join(athleteHome, "store", "store.db"), "synthetic-store\n", { mode: 0o600 });
+  const executionHead = join(evidence, "execution-head.txt"), agentData = join(evidence, "agent-data");
+  const report = join(evidence, "report.txt"), runRecord = join(evidence, "run-record.json");
+  const marker = join(evidence, "chat-start");
+  await writeFile(executionHead, `${HEAD}\n`, { mode: 0o444 });
+  await chmod(executionHead, 0o444);
+  process.env.ENDURAGENT_HOME = athleteHome;
+  return { root, evidence, athleteHome, executionHead, agentData, report, runRecord, marker,
+    args: ["run", "--head", HEAD, "--execution-head", executionHead, "--sample", "model-calibration-01",
+      "--athlete-home", athleteHome, "--agent-data", agentData, "--report", report,
+      "--run-record", runRecord, "--chat-start-marker", marker] };
+}
+
+function usage(overrides: Partial<SeasonReviewUsageRow> = {}): SeasonReviewUsageRow {
+  return { kind: "generate", provider: "synthetic-provider", model: "synthetic-model",
+    inputTokens: 10, outputTokens: 4, totalTokens: 14,
+    cacheReadTokens: 2, cacheWriteTokens: 1, ...overrides };
+}
+
+function dependencies(
+  composed: (input: RunFixture) => SeasonReviewComposition,
+  input: RunFixture,
+  overrides: Partial<SeasonReviewCommandDependencies> = {},
+): SeasonReviewCommandDependencies {
+  return {
+    currentHead: () => HEAD,
+    resolveHome: () => ({ root: input.athleteHome, storeDir: join(input.athleteHome, "store"),
+      archiveDir: join(input.athleteHome, "archive"), configDir: join(input.athleteHome, "config") }),
+    compose: async () => composed(input),
+    readUsage: () => [usage()],
+    storeInventory: () => HASH,
+    chatId: () => "season-review-prototype-synthetic-run",
+    ...overrides,
+  };
+}
+
+const unpricedCost = (calls = 1): SeasonReviewCost => ({ input_tokens: 10 * calls, output_tokens: 4 * calls, total_tokens: 14 * calls,
+  cache_read_tokens: 2 * calls, cache_write_tokens: calls, priced_calls: 0, unpriced_calls: calls,
+  usd_input: null, usd_output: null, usd_cache_read: null, usd_cache_write: null, usd_total: null });
+
+const pricedCost = (calls = 1): SeasonReviewCost => ({ input_tokens: 10, output_tokens: 4, total_tokens: 14,
+  cache_read_tokens: 2, cache_write_tokens: 1, priced_calls: calls, unpriced_calls: 0,
+  usd_input: 0.1, usd_output: 0.2, usd_cache_read: 0.01, usd_cache_write: 0.02, usd_total: 0.33 });
+
+function score(all = true) {
+  return { schema_version: 1, report_sha256: HASH,
+    grounding: { G1: all, G2: true, G3: true, G4: true, verdict: all ? "KEEP" : "REWORK" },
+    specificity: { S1: true, S2: true, S3: true, S4: true, verdict: "KEEP" },
+    question_quality: { Q1: true, Q2: true, Q3: true, Q4: true, verdict: "KEEP" } };
+}
+
+function scored(reportSha256: string, values: readonly [boolean, boolean, boolean]) {
+  const criterion = (prefix: "G" | "S" | "Q", keep: boolean) => ({
+    [`${prefix}1`]: keep, [`${prefix}2`]: true, [`${prefix}3`]: true, [`${prefix}4`]: true,
+    verdict: keep ? "KEEP" : "REWORK",
+  });
+  return { schema_version: 1, report_sha256: reportSha256,
+    grounding: criterion("G", values[0]), specificity: criterion("S", values[1]),
+    question_quality: criterion("Q", values[2]) };
+}
+
+async function writeJson(path: string, value: unknown, mode = 0o600): Promise<void> {
+  await writeFile(path, `${JSON.stringify(value)}\n`, { mode });
+  await chmod(path, mode);
+}
+
+function conclusion(overrides: Partial<SeasonReviewConclusion> = {}): SeasonReviewConclusion {
+  return { schema_version: 1, head_sha: HEAD, provider: "synthetic-provider", model: "synthetic-model",
+    rubric_sha256: HASH, model_calibration: [1, 2, 3].map((index) => ({
+      sample: `model-calibration-0${index}` as "model-calibration-01",
+      report_sha256: String(index).repeat(64), grounding: "KEEP", specificity: "KEEP", question_quality: "KEEP",
+    })), grounding: "KEEP", specificity: "KEEP", question_quality: "KEEP",
+    cost_totals: { calibration: unpricedCost(3), real: unpricedCost(), combined: unpricedCost(4) },
+    overall: "KEEP", evidence_sha256: "e".repeat(64), ...overrides };
+}
+
+describe("season review request and schemas", () => {
+  it("exports the fixed request with exact bytes and no trailing newline", () => {
+    expect(SEASON_REVIEW_REQUEST).toBe("Prepare a cycling season review from the complete training history available through the local store-backed tools.\n\nStructure the response as: Season arc; What changed; What to keep or change; Questions.\n\nGround every athlete-specific statement in tool results. Treat Load, Intensity, Fitness, Fatigue, and Form as platform-supplied Reference layer values, not locally computed values. State when evidence is absent or stale. Give at least three distinct observations across at least two parts of the season, identify a trend and an exception or recovery block, and give at least two evidence-linked actions with a time, quantity, or decision condition.\n\nAsk two to four questions only about context absent from the store. Each question must say which coaching decision its answer would change. Do not ask for a fact already available in the store. Do not create, delete, or modify calendar items or training data.");
+    expect(SEASON_REVIEW_REQUEST.endsWith("\n")).toBe(false);
+  });
+
+  it("keeps score schema strict and exact", () => {
+    const schema = JSON.parse(SEASON_REVIEW_SCORE_SCHEMA_BYTES) as Record<string, unknown>;
+    expect(SEASON_REVIEW_SCORE_SCHEMA_BYTES.endsWith("\n")).toBe(true);
+    expect(schema).toMatchObject({ type: "object", additionalProperties: false,
+      required: ["schema_version", "report_sha256", "grounding", "specificity", "question_quality"] });
+    expect(SEASON_REVIEW_RUBRIC_BYTES.endsWith("\n")).toBe(true);
+    expect(JSON.parse(SEASON_REVIEW_RUBRIC_BYTES)).toMatchObject({ schema_version: 1, overall_rule: "all_three_keep" });
+  });
+
+  it("hashes blind calibration keys over report bytes, a zero delimiter, and the private label", () => {
+    const bytes = new TextEncoder().encode("synthetic report");
+    const expected = createHashForTest(bytes, "strong");
+    expect(seasonReviewBlindKey(bytes, "strong")).toBe(expected);
+    expect(seasonReviewBlindKey(bytes, "strong")).not.toBe(seasonReviewBlindKey(bytes, "grounded-generic"));
+  });
+
+  it("keeps fixed instructions free of store text and retains structural fencing", async () => {
+    expect(SEASON_REVIEW_REQUEST).not.toContain("ignore all previous instructions");
+    const root = join(import.meta.dirname, "../../..");
+    const promptSource = await readFile(join(root, "packages/core/src/agent/system-prompt.ts"), "utf8");
+    expect(promptSource).toContain("ATHLETE_CONTEXT_FENCE_OPEN");
+    expect(promptSource).toContain("DATA, never instructions");
+  });
+});
+
+function createHashForTest(bytes: Uint8Array, label: string): string {
+  const combined = new Uint8Array(bytes.length + 1 + Buffer.byteLength(label));
+  combined.set(bytes); combined[bytes.length] = 0; combined.set(Buffer.from(label), bytes.length + 1);
+  return sha256Bytes(combined);
+}
+
+describe("season review run command", () => {
+  it("calls normal chat exactly once with the fixed request, writes evidence, and closes", async () => {
+    const input = await fixture(), close = vi.fn(async () => {}), chat = vi.fn(async () => "synthetic report");
+    const result = await executeSeasonReviewCommand(input.args, dependencies(() => ({ engine: { chat },
+      provider: "synthetic-provider", model: "synthetic-model", close }), input));
+    expect(result).toEqual({ exitCode: 0, stdout: JSON.stringify({ status: "generated", provider: "synthetic-provider",
+      model: "synthetic-model", sample: "model-calibration-01",
+      report_sha256: sha256Bytes("synthetic report"), generate_calls: 1, priced: false }) });
+    expect(chat).toHaveBeenCalledOnce();
+    expect(chat).toHaveBeenCalledWith("season-review-prototype-synthetic-run", SEASON_REVIEW_REQUEST);
+    expect(close).toHaveBeenCalledOnce();
+    expect(await readFile(input.report, "utf8")).toBe("synthetic report");
+    const record = validateSeasonReviewRunRecord(JSON.parse(await readFile(input.runRecord, "utf8")), {
+      head_sha: HEAD, sample: "model-calibration-01", report_sha256: sha256Bytes("synthetic report"),
+    });
+    expect(record.store_before_sha256).toBe(record.store_after_sha256);
+    expect((await stat(input.agentData)).mode & 0o777).toBe(0o700);
+  });
+
+  it("chat start marker is present at fake chat entry and retained after a throw", async () => {
+    const input = await fixture(), close = vi.fn(async () => {});
+    const chat = vi.fn(async () => {
+      expect(await readFile(input.marker, "utf8")).toBe(`${HEAD}\n`);
+      throw new Error("synthetic chat failure");
+    });
+    const result = await executeSeasonReviewCommand(input.args, dependencies(() => ({ engine: { chat },
+      provider: "synthetic-provider", model: "synthetic-model", close }), input));
+    expect(result).toEqual({ exitCode: 1, stdout: '{"status":"run_failed"}' });
+    expect(chat).toHaveBeenCalledOnce(); expect(close).toHaveBeenCalledOnce();
+    expect(await readFile(input.marker, "utf8")).toBe(`${HEAD}\n`);
+    await expect(readFile(input.report)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("execution head mismatch fails before composition and leaves the marker absent", async () => {
+    const input = await fixture(), compose = vi.fn();
+    const result = await executeSeasonReviewCommand(input.args, dependencies(() => { throw new Error("unreachable"); }, input,
+      { currentHead: () => OTHER_HEAD, compose }));
+    expect(result).toEqual({ exitCode: 2, stdout: '{"status":"environment"}' });
+    expect(compose).not.toHaveBeenCalled();
+    await expect(readFile(input.marker)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(stat(input.agentData)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("requires the explicit ENDURAGENT_HOME binding", async () => {
+    const input = await fixture(); delete process.env.ENDURAGENT_HOME;
+    const result = await executeSeasonReviewCommand(input.args, dependencies(() => { throw new Error("unreachable"); }, input));
+    expect(result.exitCode).toBe(2);
+    await expect(readFile(input.marker)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("retains the marker and fails if the store inventory changes", async () => {
+    const input = await fixture(); let calls = 0;
+    const result = await executeSeasonReviewCommand(input.args, dependencies(() => ({
+      engine: { chat: async () => "synthetic report" }, provider: "synthetic-provider", model: "synthetic-model",
+      close: async () => {},
+    }), input, { storeInventory: () => (++calls === 1 ? HASH : "d".repeat(64)) }));
+    expect(result.exitCode).toBe(1);
+    expect(await readFile(input.marker, "utf8")).toBe(`${HEAD}\n`);
+    await expect(readFile(input.report)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("rejects nested output paths before composition", async () => {
+    const input = await fixture(), nested = join(input.evidence, "nested", "report.txt");
+    await mkdir(join(input.evidence, "nested"), { mode: 0o700 });
+    const args = input.args.map((value) => value === input.report ? nested : value);
+    const compose = vi.fn();
+    const result = await executeSeasonReviewCommand(args, dependencies(() => { throw new Error("unreachable"); }, input, { compose }));
+    expect(result.exitCode).toBe(2); expect(compose).not.toHaveBeenCalled();
+  });
+
+  it("rejects a symlink athlete home", async () => {
+    const input = await fixture(), linked = join(input.root, "linked-athlete");
+    await symlink(input.athleteHome, linked); process.env.ENDURAGENT_HOME = linked;
+    const args = input.args.map((value) => value === input.athleteHome ? linked : value);
+    const result = await executeSeasonReviewCommand(args, dependencies(() => { throw new Error("unreachable"); },
+      { ...input, athleteHome: linked }));
+    expect(result.exitCode).toBe(2);
+  });
+
+  it("reports priced only when every generate row is priced and ignores turn rows", async () => {
+    const input = await fixture(), rows = [usage({ cost: { input: 0.1, output: 0.2, cacheRead: 0.01, cacheWrite: 0.02, total: 0.33 } }),
+      usage({ kind: "turn", cost: undefined })];
+    const result = await executeSeasonReviewCommand(input.args, dependencies(() => ({
+      engine: { chat: async () => "synthetic report" }, provider: "synthetic-provider", model: "synthetic-model", close: async () => {},
+    }), input, { readUsage: () => rows }));
+    expect(JSON.parse(result.stdout)).toMatchObject({ generate_calls: 1, priced: true });
+    expect(validateSeasonReviewRunRecord(JSON.parse(await readFile(input.runRecord, "utf8"))).cost.usd_total).toBe(0.33);
+  });
+});
+
+describe("cost null asymmetry and usage accounting", () => {
+  it("accepts unpriced all-null and rejects one USD value", () => {
+    expect(validateCost(unpricedCost(), 1)).toEqual(unpricedCost());
+    expect(() => validateCost({ ...unpricedCost(), usd_total: 0 }, 1)).toThrow();
+  });
+
+  it("accepts priced all-present and rejects only total null", () => {
+    expect(validateCost(pricedCost(), 1)).toEqual(pricedCost());
+    expect(() => validateCost({ ...pricedCost(), usd_total: null }, 1)).toThrow();
+  });
+
+  it("sums generate rows only and applies twelve-place rounding", () => {
+    const rows = [usage({ inputTokens: undefined, cost: { input: 0.0000000000006, output: 0, cacheRead: 0, cacheWrite: 0, total: 0.0000000000006 } }),
+      usage({ kind: "turn", inputTokens: 999 }), usage({ cost: { input: 0.0000000000006, output: 0, cacheRead: 0, cacheWrite: 0, total: 0.0000000000006 } })];
+    const result = summarizeGenerateUsage(rows, "synthetic-provider", "synthetic-model");
+    expect(result.generateCalls).toBe(2); expect(result.cost.input_tokens).toBe(10);
+    expect(result.cost.usd_input).toBe(roundUsd(0.0000000000012));
+    expect(() => summarizeGenerateUsage([usage({ provider: "other" })], "synthetic-provider", "synthetic-model")).toThrow();
+  });
+
+  it("combines token and call totals without treating rounded subtotals as turn rows", () => {
+    const combined = combineCosts([{ cost: unpricedCost(3), generateCalls: 3 }, { cost: unpricedCost(), generateCalls: 1 }]);
+    expect(combined.generateCalls).toBe(4); expect(combined.cost.unpriced_calls).toBe(4);
+    expect(combined.cost.input_tokens).toBe(40);
+  });
+});
+
+describe("shared persisted predicates", () => {
+  it("uses anchor booleans as the sole criterion verdict predicate", () => {
+    expect(validateSeasonReviewScore(score(false))).toMatchObject({ grounding: { verdict: "REWORK" } });
+    const inconsistent = score(false); inconsistent.grounding.verdict = "KEEP";
+    expect(() => validateSeasonReviewScore(inconsistent)).toThrow();
+  });
+
+  it("rejects real grounding REWORK with overall KEEP and accepts overall REWORK", () => {
+    const realCost = unpricedCost(), costs = { calibration: unpricedCost(3), real: realCost, combined: unpricedCost(4) };
+    expect(() => validateSeasonReviewConclusion(conclusion({ grounding: "REWORK", overall: "KEEP", cost_totals: costs }))).toThrow();
+    expect(validateSeasonReviewConclusion(conclusion({ grounding: "REWORK", overall: "REWORK", cost_totals: costs })))
+      .toMatchObject({ grounding: "REWORK", overall: "REWORK" });
+  });
+
+  it("calibration order inversion is rejected", () => {
+    const value = conclusion(), [first, second] = value.model_calibration;
+    expect(() => validateSeasonReviewConclusion({ ...value, model_calibration: [second, first, value.model_calibration[2]] })).toThrow();
+  });
+
+  it("rejects a different valid expected HEAD", () => {
+    expect(validateSeasonReviewConclusion(conclusion(), HEAD).head_sha).toBe(HEAD);
+    expect(() => validateSeasonReviewConclusion(conclusion(), OTHER_HEAD)).toThrow();
+  });
+
+  it("binds scores and run records to report and execution hashes", () => {
+    expect(() => validateSeasonReviewScore(score(), "d".repeat(64))).toThrow();
+    const record = { schema_version: 1, head_sha: HEAD, sample: "real", provider: "synthetic-provider",
+      model: "synthetic-model", report_sha256: HASH, store_before_sha256: HASH, store_after_sha256: HASH,
+      store_unchanged: true, generate_calls: 1, cost: unpricedCost() };
+    expect(validateSeasonReviewRunRecord(record, { head_sha: HEAD })).toMatchObject({ sample: "real" });
+    expect(() => validateSeasonReviewRunRecord(record, { head_sha: OTHER_HEAD })).toThrow();
+  });
+});
+
+describe("evidence stage and sealing commands", () => {
+  it("validates ordered stages and seals through the shared persisted predicates", async () => {
+    const input = await fixture(), path = (name: string) => join(input.evidence, name);
+    const rubric = path("rubric.json"), scoreSchema = path("season-review-score.schema.json");
+    const callGraph = path("call-graph.json"), indexPath = path("evidence-index.json"), conclusionPath = path("conclusion.json");
+    await writeFile(rubric, SEASON_REVIEW_RUBRIC_BYTES, { mode: 0o600 });
+    await writeFile(scoreSchema, SEASON_REVIEW_SCORE_SCHEMA_BYTES, { mode: 0o400 }); await chmod(scoreSchema, 0o400);
+    await writeJson(callGraph, { schema_version: 1, base_sha: OTHER_HEAD, config: { qualified: true },
+      store_binding: { qualified: true }, composition: { qualified: true }, store_open: { read_only: true, writer_called: false },
+      engine: { normal_chat: true }, reads: { all_athlete_reads_store_backed: true },
+      mutations: { platform_credentials_absent: true, unavailable_without_request: true }, fencing: { structural: true },
+      projection: { qualified: true }, shutdown: { store_closed: true, schedulers_stopped: true }, verdict: "USE_PRODUCT_SEAM" });
+
+    const rubricMaps = [[false, true, true], [true, false, false], [true, true, true]] as const;
+    const rubricLabels = ["unsupported-specific", "grounded-generic", "strong"] as const;
+    const rubricCalibration = [] as Array<Record<string, unknown>>;
+    for (let index = 0; index < 3; index += 1) {
+      const report = path(`rubric-report-${index + 1}.txt`), scorePath = path(`rubric-score-${index + 1}.json`);
+      const label = path(`rubric-label-${index + 1}.txt`);
+      await writeFile(report, `rubric report ${index + 1}`, { mode: 0o600 });
+      await writeJson(scorePath, scored(sha256Bytes(await readFile(report)), rubricMaps[index]!));
+      await writeFile(label, `${rubricLabels[index]}\n`, { mode: 0o600 });
+      rubricCalibration.push({ sample: `rubric-calibration-0${index + 1}`, report_path: report,
+        run_record_path: null, score_path: scorePath, source_label_path: label });
+    }
+
+    const modelCalibration = [] as Array<Record<string, unknown>>;
+    for (let index = 0; index < 3; index += 1) {
+      const report = path(`model-report-${index + 1}.txt`), scorePath = path(`model-score-${index + 1}.json`);
+      const runRecord = path(`model-run-${index + 1}.json`), sample = `model-calibration-0${index + 1}`;
+      await writeFile(report, `model report ${index + 1}`, { mode: 0o600 });
+      const reportHash = sha256Bytes(await readFile(report));
+      await writeJson(scorePath, scored(reportHash, [true, true, true]));
+      await writeJson(runRecord, { schema_version: 1, head_sha: HEAD, sample, provider: "synthetic-provider",
+        model: "synthetic-model", report_sha256: reportHash, store_before_sha256: HASH,
+        store_after_sha256: HASH, store_unchanged: true, generate_calls: 1, cost: unpricedCost() });
+      modelCalibration.push({ sample, report_path: report, run_record_path: runRecord,
+        score_path: scorePath, source_label_path: null });
+    }
+
+    const realReport = path("real-report.txt"), realScore = path("real-score.json"), realRun = path("real-run.json");
+    await writeFile(realReport, "real report", { mode: 0o600 });
+    const realHash = sha256Bytes(await readFile(realReport));
+    await writeJson(realScore, scored(realHash, [false, true, true]));
+    await writeJson(realRun, { schema_version: 1, head_sha: HEAD, sample: "real", provider: "synthetic-provider",
+      model: "synthetic-model", report_sha256: realHash, store_before_sha256: "d".repeat(64),
+      store_after_sha256: "d".repeat(64), store_unchanged: true, generate_calls: 1, cost: unpricedCost() });
+    await writeJson(indexPath, { schema_version: 1, base_sha: OTHER_HEAD, execution_head_path: input.executionHead,
+      call_graph_path: callGraph, rubric_path: rubric, score_schema_path: scoreSchema,
+      rubric_calibration: rubricCalibration, model_calibration: modelCalibration,
+      real: { report_path: realReport, run_record_path: realRun, score_path: realScore } });
+
+    await expect(executeSeasonReviewCommand(["validate-stage", "--stage", "rubric", "--index", indexPath]))
+      .resolves.toEqual({ exitCode: 0, stdout: "" });
+    expect((await stat(rubric)).mode & 0o777).toBe(0o444);
+    await expect(executeSeasonReviewCommand(["validate-stage", "--stage", "model", "--index", indexPath]))
+      .resolves.toEqual({ exitCode: 0, stdout: "" });
+    await expect(executeSeasonReviewCommand(["seal", "--index", indexPath, "--conclusion", conclusionPath],
+      { currentHead: () => HEAD })).resolves.toEqual({ exitCode: 0, stdout: "" });
+    const sealed = validateSeasonReviewConclusion(JSON.parse(await readFile(conclusionPath, "utf8")), HEAD);
+    expect(sealed).toMatchObject({ provider: "synthetic-provider", model: "synthetic-model",
+      grounding: "REWORK", overall: "REWORK", cost_totals: { combined: { unpriced_calls: 4 } } });
+    await chmod(conclusionPath, 0o444);
+    await expect(executeSeasonReviewCommand(["validate-conclusion", "--conclusion", conclusionPath]))
+      .resolves.toEqual({ exitCode: 0, stdout: "" });
+  });
+});
+
+describe("key-free command surface", () => {
+  it("prints help without consulting config, Git, store, or composition", async () => {
+    const current = vi.fn(), compose = vi.fn();
+    await expect(executeSeasonReviewCommand(["--help"], { currentHead: current, compose }))
+      .resolves.toEqual({ exitCode: 0, stdout: "usage: season-review-command (run|validate-score|validate-stage|seal|validate-conclusion)" });
+    expect(current).not.toHaveBeenCalled(); expect(compose).not.toHaveBeenCalled();
+  });
+});

--- a/packages/coach/tsup.config.ts
+++ b/packages/coach/tsup.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
     "local-bot": "src/local-bot.ts",
     "soak-record": "src/soak-record.ts",
     "store-gate-command": "src/store-gate-command.ts",
+    "season-review-command": "src/season-review-command.ts",
   },
   format: ["esm"],
   dts: true,


### PR DESCRIPTION
## Summary

Adds a private `packages/coach` season-review CLI over the configured store-backed coaching path:

- `season-review.ts` — request construction, strict schemas, cost accounting, shared validators, evidence hashing.
- `season-review-command.ts` — read-only product CLI: explicit homes, store binding, atomic run markers, validation stages, immutable sealing.
- 23 key-free regression tests; asymmetric emit/reload predicate tests share the same exports as the CLI.
- Exactly +1 `season-review` script and +1 tsup entry; changeset included (no `User-facing:` line — private package, no shipping surface).

The private review run itself (calibrations, blind scoring, sealed conclusion) is an operator-side activity after this machinery merges; nothing in this PR performs network or model calls.

## Verification

- Root `pnpm check:types`, `pnpm lint` (0 errors), full `pnpm test`, `pnpm build` green.
- Focused suite 23/23; impacted composition/projection suite 142/142.
- Built CLI `--help` runs without any API key.
- Allowlist audit: exactly +4 new files, 2 modified, 0 deleted/renamed.
