### PR TITLE
feat(kernel): add cycling FTP anchor resolver

### DIFF
--- a/packages/kernel-node/tests/repositories.test.ts
+++ b/packages/kernel-node/tests/repositories.test.ts
@@ -108,18 +108,28 @@ describe("repository ports over real node:sqlite", () => {
       expect(asOf2?.value).toBe(260);
     });
 
-    it("applies confidence precedence for same valid_from (manual > platform)", async () => {
+    it("applies confidence precedence for same valid_from (manual > platform > fit)", async () => {
       const repo = createAnchorRepository(store);
       await repo.insertIfAbsent(
-        anchorRow({ id: "plat", valid_from: 1000, value: 240, confidence: "platform", provenance: "sync", source: "connector" }),
+        anchorRow({ id: "fit", valid_from: 1000, value: 230, confidence: "fit", provenance: "sync", source: "fit" }),
       );
+      const fit = await repo.readCurrent("cycling", "ftp", 1500);
+      expect(fit?.confidence).toBe("fit");
+      expect(fit?.value).toBe(230);
+      await store.run(
+        "INSERT INTO anchor_history (id, sport, anchor_type, value, unit, valid_from, source, confidence, note, provenance, device_id, hlc_physical_ms, hlc_counter) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)",
+        ["plat", "cycling", "ftp", 240, "W", 1000, "connector", "platform", null, "sync", null, null, null],
+      );
+      const platform = await repo.readCurrent("cycling", "ftp", 1500);
+      expect(platform?.confidence).toBe("platform");
+      expect(platform?.value).toBe(240);
       await store.run(
         "INSERT INTO anchor_history (id, sport, anchor_type, value, unit, valid_from, source, confidence, note, provenance, device_id, hlc_physical_ms, hlc_counter) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)",
         ["man", "cycling", "ftp", 250, "W", 1000, "manual", "manual", null, "manual", null, null, null],
       );
-      const current = await repo.readCurrent("cycling", "ftp", 1500);
-      expect(current?.confidence).toBe("manual");
-      expect(current?.value).toBe(250);
+      const manual = await repo.readCurrent("cycling", "ftp", 1500);
+      expect(manual?.confidence).toBe("manual");
+      expect(manual?.value).toBe(250);
     });
   });
 

--- a/packages/kernel/package.json
+++ b/packages/kernel/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "files": ["dist"],
   "exports": {
+    "./anchors": "./dist/anchors.js",
     "./ports": "./dist/ports.js",
     "./store/migrations": "./dist/store/migrations.js",
     "./store": "./dist/store.js",

--- a/packages/kernel/src/anchors/index.ts
+++ b/packages/kernel/src/anchors/index.ts
@@ -1,0 +1,1 @@
+export * from "./resolve-anchor.js";

--- a/packages/kernel/src/anchors/resolve-anchor.ts
+++ b/packages/kernel/src/anchors/resolve-anchor.ts
@@ -1,0 +1,143 @@
+import type { AnchorRepository } from "../store/ports.js";
+
+export type AnchorConfidence = "manual" | "platform" | "fit";
+
+export type CyclingFtpStalenessBand =
+  | "fresh"
+  | "aging"
+  | "stale"
+  | "very-stale";
+
+export interface CyclingFtpStalenessThresholds {
+  readonly freshMaxDays: number;
+  readonly agingMaxDays: number;
+  readonly staleMaxDays: number;
+}
+
+// Product display defaults, not validated physiological safety boundaries.
+export const CYCLING_FTP_STALENESS_DEFAULTS: Readonly<CyclingFtpStalenessThresholds> = Object.freeze({
+  freshMaxDays: 42,
+  agingMaxDays: 90,
+  staleMaxDays: 180,
+});
+
+export interface CyclingFtpAnchorResolverOptions {
+  readonly thresholds?: Partial<CyclingFtpStalenessThresholds>;
+}
+
+export interface ResolveCyclingFtpAnchorInput {
+  readonly effectiveAtEpochS: number;
+  readonly evaluatedAtEpochS: number;
+}
+
+export interface ResolvedCyclingFtpAnchor {
+  readonly kind: "ftp";
+  readonly watts: number;
+  readonly validFrom: string;
+  readonly source: string;
+  readonly confidence: AnchorConfidence;
+  readonly ageDays: number;
+  readonly stalenessBand: CyclingFtpStalenessBand;
+  readonly stale: boolean;
+}
+
+export interface MissingCyclingFtpAnchor {
+  readonly kind: "missing";
+  readonly refusal: "missing-cycling-ftp-anchor";
+}
+
+export type CyclingFtpAnchorResult =
+  | ResolvedCyclingFtpAnchor
+  | MissingCyclingFtpAnchor;
+
+export interface CyclingFtpAnchorResolver {
+  resolve(input: ResolveCyclingFtpAnchorInput): Promise<CyclingFtpAnchorResult>;
+}
+
+const SECONDS_PER_DAY = 86_400;
+const MAX_YMD_EPOCH_S = 253_402_300_799;
+
+function isValidThreshold(value: number): boolean {
+  return Number.isFinite(value) && Number.isInteger(value) && value >= 0;
+}
+
+function isValidEpoch(value: number): boolean {
+  return Number.isFinite(value)
+    && Number.isSafeInteger(value)
+    && value >= 0
+    && value <= MAX_YMD_EPOCH_S;
+}
+
+function isAnchorConfidence(value: string): value is AnchorConfidence {
+  return value === "manual" || value === "platform" || value === "fit";
+}
+
+export function createCyclingFtpAnchorResolver(
+  repository: AnchorRepository,
+  options?: CyclingFtpAnchorResolverOptions,
+): CyclingFtpAnchorResolver {
+  const thresholds = {
+    ...CYCLING_FTP_STALENESS_DEFAULTS,
+    ...options?.thresholds,
+  };
+
+  if (
+    !isValidThreshold(thresholds.freshMaxDays)
+    || !isValidThreshold(thresholds.agingMaxDays)
+    || !isValidThreshold(thresholds.staleMaxDays)
+    || thresholds.freshMaxDays >= thresholds.agingMaxDays
+    || thresholds.agingMaxDays >= thresholds.staleMaxDays
+  ) {
+    throw new RangeError("Invalid cycling FTP staleness thresholds");
+  }
+
+  return {
+    async resolve(input: ResolveCyclingFtpAnchorInput): Promise<CyclingFtpAnchorResult> {
+      if (
+        !isValidEpoch(input.effectiveAtEpochS)
+        || !isValidEpoch(input.evaluatedAtEpochS)
+        || input.evaluatedAtEpochS < input.effectiveAtEpochS
+      ) {
+        throw new RangeError("Invalid cycling FTP anchor epochs");
+      }
+
+      const row = await repository.readCurrent("cycling", "ftp", input.effectiveAtEpochS);
+      if (row === undefined) {
+        return { kind: "missing", refusal: "missing-cycling-ftp-anchor" };
+      }
+
+      if (
+        !isAnchorConfidence(row.confidence)
+        || !isValidEpoch(row.valid_from)
+        || row.valid_from > input.effectiveAtEpochS
+      ) {
+        throw new TypeError("Malformed cycling FTP anchor repository row");
+      }
+
+      const elapsedSeconds = input.evaluatedAtEpochS - row.valid_from;
+      const ageDays = elapsedSeconds / SECONDS_PER_DAY;
+      let stalenessBand: CyclingFtpStalenessBand;
+
+      if (ageDays <= thresholds.freshMaxDays) {
+        stalenessBand = "fresh";
+      } else if (ageDays <= thresholds.agingMaxDays) {
+        stalenessBand = "aging";
+      } else if (ageDays <= thresholds.staleMaxDays) {
+        stalenessBand = "stale";
+      } else {
+        stalenessBand = "very-stale";
+      }
+
+      return {
+        kind: "ftp",
+        watts: row.value,
+        validFrom: new Date(row.valid_from * 1_000).toISOString().slice(0, 10),
+        source: row.source,
+        confidence: row.confidence,
+        ageDays,
+        stalenessBand,
+        stale: stalenessBand !== "fresh",
+      };
+    },
+  };
+}

--- a/packages/kernel/tests/resolve-anchor.test.ts
+++ b/packages/kernel/tests/resolve-anchor.test.ts
@@ -1,0 +1,353 @@
+import { describe, expect, it } from "vitest";
+import {
+  createCyclingFtpAnchorResolver,
+  CYCLING_FTP_STALENESS_DEFAULTS,
+  type CyclingFtpStalenessThresholds,
+} from "../src/anchors/index.js";
+import type {
+  AnchorHistoryRow,
+  AnchorRepository,
+} from "../src/store/ports.js";
+
+const SECONDS_PER_DAY = 86_400;
+const BASE_EPOCH_S = 946_684_800;
+const MAX_YMD_EPOCH_S = 253_402_300_799;
+
+type ReadCurrentCall = readonly [
+  sport: string,
+  anchorType: string,
+  asOfEpochS: number,
+];
+
+class ProgrammableAnchorRepository implements AnchorRepository {
+  readonly readCurrentCalls: ReadCurrentCall[] = [];
+
+  constructor(public result: AnchorHistoryRow | undefined) {}
+
+  async insertIfAbsent(_row: AnchorHistoryRow): Promise<boolean> {
+    throw new Error("insertIfAbsent must not be called");
+  }
+
+  async readCurrent(
+    sport: string,
+    anchorType: string,
+    asOfEpochS: number,
+  ): Promise<AnchorHistoryRow | undefined> {
+    this.readCurrentCalls.push([sport, anchorType, asOfEpochS]);
+    return this.result;
+  }
+}
+
+function anchorRow(overrides: Partial<AnchorHistoryRow> = {}): AnchorHistoryRow {
+  return {
+    id: "synthetic-ftp",
+    sport: "cycling",
+    anchor_type: "ftp",
+    value: 250,
+    unit: "W",
+    valid_from: BASE_EPOCH_S,
+    source: "manual-entry",
+    confidence: "manual",
+    note: null,
+    provenance: "synthetic",
+    device_id: null,
+    hlc_physical_ms: null,
+    hlc_counter: null,
+    ...overrides,
+  };
+}
+
+async function resolveAtAge(ageSeconds: number) {
+  const repository = new ProgrammableAnchorRepository(anchorRow());
+  const resolver = createCyclingFtpAnchorResolver(repository);
+  return resolver.resolve({
+    effectiveAtEpochS: BASE_EPOCH_S,
+    evaluatedAtEpochS: BASE_EPOCH_S + ageSeconds,
+  });
+}
+
+describe("createCyclingFtpAnchorResolver", () => {
+  it("returns the exact missing result and delegates once when no row is effective", async () => {
+    const repository = new ProgrammableAnchorRepository(undefined);
+    const resolver = createCyclingFtpAnchorResolver(repository);
+
+    await expect(resolver.resolve({
+      effectiveAtEpochS: BASE_EPOCH_S,
+      evaluatedAtEpochS: BASE_EPOCH_S,
+    })).resolves.toEqual({
+      kind: "missing",
+      refusal: "missing-cycling-ftp-anchor",
+    });
+    expect(repository.readCurrentCalls).toEqual([
+      ["cycling", "ftp", BASE_EPOCH_S],
+    ]);
+  });
+
+  it("returns the same missing result when the repository has only a future row", async () => {
+    const repository = new ProgrammableAnchorRepository(undefined);
+    const resolver = createCyclingFtpAnchorResolver(repository);
+
+    const result = await resolver.resolve({
+      effectiveAtEpochS: BASE_EPOCH_S,
+      evaluatedAtEpochS: BASE_EPOCH_S + 1,
+    });
+
+    expect(result).toEqual({
+      kind: "missing",
+      refusal: "missing-cycling-ftp-anchor",
+    });
+    expect(Object.keys(result)).toEqual(["kind", "refusal"]);
+    expect(repository.readCurrentCalls).toEqual([
+      ["cycling", "ftp", BASE_EPOCH_S],
+    ]);
+  });
+
+  it("maps a current row at age zero and exposes frozen defaults", async () => {
+    const repository = new ProgrammableAnchorRepository(anchorRow());
+    const resolver = createCyclingFtpAnchorResolver(repository);
+
+    await expect(resolver.resolve({
+      effectiveAtEpochS: BASE_EPOCH_S,
+      evaluatedAtEpochS: BASE_EPOCH_S,
+    })).resolves.toEqual({
+      kind: "ftp",
+      watts: 250,
+      validFrom: "2000-01-01",
+      source: "manual-entry",
+      confidence: "manual",
+      ageDays: 0,
+      stalenessBand: "fresh",
+      stale: false,
+    });
+    expect(Object.isFrozen(CYCLING_FTP_STALENESS_DEFAULTS)).toBe(true);
+    expect(Object.keys(CYCLING_FTP_STALENESS_DEFAULTS)).toEqual([
+      "freshMaxDays",
+      "agingMaxDays",
+      "staleMaxDays",
+    ]);
+  });
+
+  it("classifies exactly 42 days as fresh", async () => {
+    await expect(resolveAtAge(42 * SECONDS_PER_DAY)).resolves.toMatchObject({
+      kind: "ftp",
+      stalenessBand: "fresh",
+      stale: false,
+    });
+  });
+
+  it("classifies 42 days plus one second as aging", async () => {
+    await expect(resolveAtAge(42 * SECONDS_PER_DAY + 1)).resolves.toMatchObject({
+      kind: "ftp",
+      stalenessBand: "aging",
+      stale: true,
+    });
+  });
+
+  it("classifies exactly 90 days as aging", async () => {
+    await expect(resolveAtAge(90 * SECONDS_PER_DAY)).resolves.toMatchObject({
+      kind: "ftp",
+      stalenessBand: "aging",
+      stale: true,
+    });
+  });
+
+  it("classifies 90 days plus one second as stale", async () => {
+    await expect(resolveAtAge(90 * SECONDS_PER_DAY + 1)).resolves.toMatchObject({
+      kind: "ftp",
+      stalenessBand: "stale",
+      stale: true,
+    });
+  });
+
+  it("classifies exactly 180 days as stale", async () => {
+    await expect(resolveAtAge(180 * SECONDS_PER_DAY)).resolves.toMatchObject({
+      kind: "ftp",
+      stalenessBand: "stale",
+      stale: true,
+    });
+  });
+
+  it("keeps watts exposed beyond 180 days without adding a refusal", async () => {
+    const result = await resolveAtAge(180 * SECONDS_PER_DAY + 1);
+
+    expect(result).toMatchObject({
+      kind: "ftp",
+      watts: 250,
+      stalenessBand: "very-stale",
+      stale: true,
+    });
+    expect("refusal" in result).toBe(false);
+  });
+
+  it("maps separately selected platform and manual rows without reinterpretation", async () => {
+    const platformRepository = new ProgrammableAnchorRepository(anchorRow({
+      id: "platform-ftp",
+      value: 245,
+      source: "connector",
+      confidence: "platform",
+    }));
+    const manualRepository = new ProgrammableAnchorRepository(anchorRow({
+      id: "manual-ftp",
+      value: 255,
+      source: "athlete-entry",
+      confidence: "manual",
+    }));
+
+    await expect(createCyclingFtpAnchorResolver(platformRepository).resolve({
+      effectiveAtEpochS: BASE_EPOCH_S,
+      evaluatedAtEpochS: BASE_EPOCH_S,
+    })).resolves.toMatchObject({
+      kind: "ftp",
+      watts: 245,
+      source: "connector",
+      confidence: "platform",
+    });
+    await expect(createCyclingFtpAnchorResolver(manualRepository).resolve({
+      effectiveAtEpochS: BASE_EPOCH_S,
+      evaluatedAtEpochS: BASE_EPOCH_S,
+    })).resolves.toMatchObject({
+      kind: "ftp",
+      watts: 255,
+      source: "athlete-entry",
+      confidence: "manual",
+    });
+    expect(platformRepository.readCurrentCalls).toEqual([
+      ["cycling", "ftp", BASE_EPOCH_S],
+    ]);
+    expect(manualRepository.readCurrentCalls).toEqual([
+      ["cycling", "ftp", BASE_EPOCH_S],
+    ]);
+  });
+
+  it("uses all three injected staleness boundaries", async () => {
+    const repository = new ProgrammableAnchorRepository(anchorRow());
+    const resolver = createCyclingFtpAnchorResolver(repository, {
+      thresholds: {
+        freshMaxDays: 7,
+        agingMaxDays: 14,
+        staleMaxDays: 21,
+      },
+    });
+    const cases = [
+      [7 * SECONDS_PER_DAY + 1, "aging"],
+      [14 * SECONDS_PER_DAY + 1, "stale"],
+      [21 * SECONDS_PER_DAY + 1, "very-stale"],
+    ] as const;
+
+    for (const [ageSeconds, stalenessBand] of cases) {
+      await expect(resolver.resolve({
+        effectiveAtEpochS: BASE_EPOCH_S,
+        evaluatedAtEpochS: BASE_EPOCH_S + ageSeconds,
+      })).resolves.toMatchObject({
+        kind: "ftp",
+        stalenessBand,
+        stale: true,
+      });
+    }
+    expect(repository.readCurrentCalls).toHaveLength(3);
+  });
+
+  it("rejects every invalid threshold set during factory construction", () => {
+    const fields: readonly (keyof CyclingFtpStalenessThresholds)[] = [
+      "freshMaxDays",
+      "agingMaxDays",
+      "staleMaxDays",
+    ];
+    const invalidValues = [
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+      Number.NEGATIVE_INFINITY,
+      -1,
+      1.5,
+    ];
+    const invalidThresholds: Partial<CyclingFtpStalenessThresholds>[] = [];
+
+    for (const field of fields) {
+      for (const value of invalidValues) {
+        invalidThresholds.push({
+          ...CYCLING_FTP_STALENESS_DEFAULTS,
+          [field]: value,
+        });
+      }
+    }
+    invalidThresholds.push(
+      { freshMaxDays: 42, agingMaxDays: 42, staleMaxDays: 180 },
+      { freshMaxDays: 42, agingMaxDays: 180, staleMaxDays: 180 },
+      { freshMaxDays: 91, agingMaxDays: 90, staleMaxDays: 180 },
+      { freshMaxDays: 42, agingMaxDays: 181, staleMaxDays: 180 },
+    );
+
+    for (const thresholds of invalidThresholds) {
+      const repository = new ProgrammableAnchorRepository(anchorRow());
+      expect(() => createCyclingFtpAnchorResolver(repository, {
+        thresholds,
+      })).toThrow(RangeError);
+      expect(repository.readCurrentCalls).toHaveLength(0);
+    }
+  });
+
+  it("validates both epochs, ordering, and the upper date boundary", async () => {
+    const invalidValues = [
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+      Number.NEGATIVE_INFINITY,
+      -1,
+      1.5,
+      Number.MAX_SAFE_INTEGER + 1,
+      MAX_YMD_EPOCH_S + 1,
+    ];
+    const invalidInputs = invalidValues.flatMap((value) => [
+      { effectiveAtEpochS: value, evaluatedAtEpochS: BASE_EPOCH_S },
+      { effectiveAtEpochS: BASE_EPOCH_S, evaluatedAtEpochS: value },
+    ]);
+    invalidInputs.push({
+      effectiveAtEpochS: BASE_EPOCH_S + 1,
+      evaluatedAtEpochS: BASE_EPOCH_S,
+    });
+
+    for (const input of invalidInputs) {
+      const repository = new ProgrammableAnchorRepository(anchorRow());
+      const resolver = createCyclingFtpAnchorResolver(repository);
+      await expect(resolver.resolve(input)).rejects.toBeInstanceOf(RangeError);
+      expect(repository.readCurrentCalls).toHaveLength(0);
+    }
+
+    const repository = new ProgrammableAnchorRepository(anchorRow({
+      valid_from: MAX_YMD_EPOCH_S,
+    }));
+    const resolver = createCyclingFtpAnchorResolver(repository);
+    await expect(resolver.resolve({
+      effectiveAtEpochS: MAX_YMD_EPOCH_S,
+      evaluatedAtEpochS: MAX_YMD_EPOCH_S,
+    })).resolves.toMatchObject({
+      kind: "ftp",
+      validFrom: "9999-12-31",
+    });
+  });
+
+  it("rejects malformed repository rows with TypeError", async () => {
+    const malformedRows = [
+      anchorRow({ confidence: "unsupported" }),
+      ...[
+        Number.NaN,
+        Number.POSITIVE_INFINITY,
+        Number.NEGATIVE_INFINITY,
+        -1,
+        99.5,
+        Number.MAX_SAFE_INTEGER + 1,
+        MAX_YMD_EPOCH_S + 1,
+        101,
+      ].map((valid_from) => anchorRow({ valid_from })),
+    ];
+
+    for (const row of malformedRows) {
+      const repository = new ProgrammableAnchorRepository(row);
+      const resolver = createCyclingFtpAnchorResolver(repository);
+      await expect(resolver.resolve({
+        effectiveAtEpochS: 100,
+        evaluatedAtEpochS: 200,
+      })).rejects.toBeInstanceOf(TypeError);
+      expect(repository.readCurrentCalls).toHaveLength(1);
+    }
+  });
+});

--- a/packages/kernel/tsup.config.ts
+++ b/packages/kernel/tsup.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "tsup";
 
 export default defineConfig({
   entry: {
+    anchors: "src/anchors/index.ts",
     ports: "src/ports/index.ts",
     "store/migrations": "src/store/migrations/index.ts",
     store: "src/store/index.ts",


### PR DESCRIPTION
## Summary

Adds the pure cycling FTP anchor resolver to `@enduragent/kernel`:

- New `packages/kernel/src/anchors/` module exported via a new `./anchors` subpath (package.json export + tsup entry).
- Pure resolution logic — no ambient clock, no SQL, no reimplementation of existing kernel primitives (verified by search).
- 14 specified resolver test cases; `fit → platform → manual` precedence characterization added to kernel-node repository tests.
- Engine/cycling integration is deferred to the composition-adapter PR by design; nothing imports the resolver yet.

## Verification

- Resolver suite 14/14; repository suite 10/10; kernel package check, build, and declaration generation green.
- Packaged `@enduragent/kernel/anchors` import verified.
- Root `pnpm check:types`, `pnpm lint` (0 errors), full build/check/test green.
- Exhaustive allowlist comparison passed; no ambient-clock/SQL matches.
