### PR TITLE
feat(coach): add legacy home migration

### DIFF
--- a/packages/coach/package.json
+++ b/packages/coach/package.json
@@ -33,7 +33,8 @@
     "@enduragent/kernel": "workspace:*",
     "@enduragent/kernel-node": "workspace:*",
     "@enduragent/sync-intervals-icu": "workspace:*",
-    "@enduragent/sport-cycling": "workspace:*"
+    "@enduragent/sport-cycling": "workspace:*",
+    "yaml": "^2.8.3"
   },
   "devDependencies": {
     "@types/node": "^25.6.0",

--- a/packages/coach/src/legacy-migration.ts
+++ b/packages/coach/src/legacy-migration.ts
@@ -1,0 +1,2403 @@
+import { createHash, randomUUID } from "node:crypto";
+import {
+  constants,
+  link as fsLink,
+  lstat,
+  mkdir,
+  open,
+  readdir,
+  readlink,
+  realpath,
+  rename,
+  unlink,
+} from "node:fs/promises";
+import type { Stats } from "node:fs";
+import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import { isMap, parseDocument, type Document, type ParsedNode } from "yaml";
+
+export const LEGACY_MIGRATION_SCHEMA_VERSION = 1 as const;
+export const LEGACY_MIGRATION_ID = "legacy-home-v1" as const;
+export const LEGACY_MIGRATION_CONTROL_RELATIVE = "config/migrations/legacy-home-v1" as const;
+export const LEGACY_MIGRATION_NON_TTY_REFUSAL_EXIT_CODE = 2 as const;
+
+export type LegacyMigrationAction =
+  | { readonly kind: "resume"; readonly isTTY: boolean }
+  | { readonly kind: "confirm"; readonly manifestDigest: string }
+  | { readonly kind: "discard"; readonly manifestDigest: string }
+  | { readonly kind: "replan"; readonly discardedManifestDigest: string; readonly isTTY: boolean };
+
+export interface LegacyMigrationOptions {
+  readonly sourceRoot: string;
+  readonly targetRoot: string;
+  readonly action: LegacyMigrationAction;
+}
+
+export type LegacyMigrationCheckpoint =
+  | "before-journal-rename"
+  | "after-journal-rename"
+  | "before-payload-publication"
+  | "after-payload-checkpoint"
+  | "after-discard-archive-link"
+  | "after-discard-journal-unlink";
+
+export interface LegacyMigrationCheckpointContext {
+  readonly checkpoint: LegacyMigrationCheckpoint;
+  readonly journalState: "planned" | "copying" | "verified" | "done";
+  readonly revision: number;
+  readonly entryId: string | null;
+  readonly copiedCount: number;
+}
+
+export interface LegacyMigrationDependencies {
+  readonly now?: () => Date;
+  readonly randomId?: () => string;
+  readonly link?: (existingPath: string, newPath: string) => Promise<void>;
+  readonly checkpoint?: (context: LegacyMigrationCheckpointContext) => void | Promise<void>;
+}
+
+export type LegacyMigrationRefusalCode =
+  | "confirmation-required"
+  | "pinned-refusal"
+  | "manifest-mismatch"
+  | "invalid-action"
+  | "invalid-source-config"
+  | "unsupported-data-dir"
+  | "unsupported-credential-layout"
+  | "source-target-overlap"
+  | "source-drift"
+  | "target-conflict"
+  | "target-path-unsafe"
+  | "no-clobber-unavailable"
+  | "verification-failed"
+  | "legacy-mutated-after-cutover";
+
+export type LegacyMigrationResult =
+  | {
+      readonly status: "not-needed";
+      readonly exitCode: 0;
+      readonly journalPath: string;
+      readonly manifestDigest: null;
+    }
+  | {
+      readonly status: "refused";
+      readonly exitCode: 2 | 3 | 4;
+      readonly journalPath: string;
+      readonly manifestDigest: string | null;
+      readonly reason: LegacyMigrationRefusalCode;
+      readonly conflictIds: readonly string[];
+    }
+  | {
+      readonly status: "discarded";
+      readonly exitCode: 0;
+      readonly journalPath: string;
+      readonly manifestDigest: string;
+      readonly archivePath: string;
+    }
+  | {
+      readonly status: "done";
+      readonly exitCode: 0;
+      readonly journalPath: string;
+      readonly manifestDigest: string;
+      readonly completion: "complete" | "partial";
+      readonly copiedIds: readonly string[];
+      readonly skipVerifiedIds: readonly string[];
+      readonly skippedConflictIds: readonly string[];
+      readonly freezePoint: string;
+    };
+
+type SourceOwner = "legacy-root" | "data-root";
+type FileType = "regular" | "symlink" | "other";
+type Disposition = "migrate" | "skip" | "defer" | "shadowed" | "refuse";
+type Transform = "none" | "config-v1";
+type TargetAtPlan = "absent" | "identical" | "conflict" | null;
+type JournalState = "planned" | "copying" | "verified" | "done";
+
+interface LegacyMigrationManifestEntry {
+  id: string;
+  sourceOwner: SourceOwner;
+  sourcePath: string;
+  sourceRelativePath: string;
+  fileType: FileType;
+  disposition: Disposition;
+  reason: string;
+  targetRelativePath: string | null;
+  transform: Transform;
+  sourceSha256: string | null;
+  outputSha256: string | null;
+  sourceBytes: number | null;
+  outputBytes: number | null;
+  sourceMode: number | null;
+  symlinkTarget: string | null;
+  targetAtPlan: TargetAtPlan;
+  targetActualSha256: string | null;
+  requiresConfirmation: boolean;
+}
+
+interface LegacyMigrationManifest {
+  schemaVersion: 1;
+  migrationId: "legacy-home-v1";
+  sourceRoot: string;
+  dataRoot: string;
+  targetRoot: string;
+  entries: LegacyMigrationManifestEntry[];
+}
+
+interface JournalHistory {
+  revision: number;
+  state: JournalState;
+  at: string;
+}
+
+interface JournalRefusal {
+  code: LegacyMigrationRefusalCode;
+  entryIds: string[];
+  expectedHashes: Array<string | null>;
+  actualHashes: Array<string | null>;
+}
+
+interface VerificationOutput {
+  entryId: string;
+  expectedSha256: string;
+  actualSha256: string | null;
+  matches: boolean;
+}
+
+interface LegacyMigrationJournal {
+  schemaVersion: 1;
+  migrationId: "legacy-home-v1";
+  sourceRoot: string;
+  dataRoot: string;
+  targetRoot: string;
+  manifestDigest: string;
+  manifest: LegacyMigrationManifest;
+  state: JournalState;
+  revision: number;
+  history: JournalHistory[];
+  results: {
+    copiedIds: string[];
+    skipVerifiedIds: string[];
+    skippedConflictIds: string[];
+  };
+  refusal: JournalRefusal | null;
+  verification: {
+    complete: boolean;
+    allMatch: boolean;
+    outputs: VerificationOutput[];
+  };
+  completion: "pending" | "complete" | "partial";
+  freezePoint: string | null;
+}
+
+interface Dependencies {
+  now: () => Date;
+  randomId: () => string;
+  link: (existingPath: string, newPath: string) => Promise<void>;
+  checkpoint: (context: LegacyMigrationCheckpointContext) => void | Promise<void>;
+}
+
+interface ConfigPlan {
+  bytes: Buffer;
+  output: Buffer;
+  dataRoot: string;
+  provider: unknown;
+  authProfile: unknown;
+}
+
+interface InventoryBuild {
+  manifest: LegacyMigrationManifest;
+  digest: string;
+}
+
+interface SourceDifference {
+  ids: string[];
+  expected: Array<string | null>;
+  actual: Array<string | null>;
+  hasAddition: boolean;
+}
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const HASH_PATTERN = /^[0-9a-f]{64}$/;
+const JOURNAL_KEYS = [
+  "completion",
+  "dataRoot",
+  "freezePoint",
+  "history",
+  "manifest",
+  "manifestDigest",
+  "migrationId",
+  "refusal",
+  "results",
+  "revision",
+  "schemaVersion",
+  "sourceRoot",
+  "state",
+  "targetRoot",
+  "verification",
+] as const;
+const ENTRY_KEYS = [
+  "disposition",
+  "fileType",
+  "id",
+  "outputBytes",
+  "outputSha256",
+  "reason",
+  "requiresConfirmation",
+  "sourceBytes",
+  "sourceMode",
+  "sourceOwner",
+  "sourcePath",
+  "sourceRelativePath",
+  "sourceSha256",
+  "symlinkTarget",
+  "targetActualSha256",
+  "targetAtPlan",
+  "targetRelativePath",
+  "transform",
+] as const;
+
+class PlanningRefusal extends Error {
+  constructor(
+    readonly code: LegacyMigrationRefusalCode,
+    readonly exitCode: 2 | 3 | 4,
+  ) {
+    super(code);
+  }
+}
+
+function compareCodeUnits(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+function sha256(bytes: Buffer | string): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function hasExactKeys(value: Record<string, unknown>, keys: readonly string[]): boolean {
+  const actual = Object.keys(value).sort(compareCodeUnits);
+  const expected = [...keys].sort(compareCodeUnits);
+  return actual.length === expected.length && actual.every((key, index) => key === expected[index]);
+}
+
+function canonicalize(value: unknown): string {
+  if (value === null || typeof value === "string" || typeof value === "boolean")
+    return JSON.stringify(value);
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) throw new TypeError("Canonical JSON requires finite numbers");
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) return `[${value.map(canonicalize).join(",")}]`;
+  if (isObject(value)) {
+    return `{${Object.keys(value)
+      .sort(compareCodeUnits)
+      .map((key) => {
+        const child = value[key];
+        if (child === undefined) throw new TypeError("Canonical JSON forbids undefined");
+        return `${JSON.stringify(key)}:${canonicalize(child)}`;
+      })
+      .join(",")}}`;
+  }
+  throw new TypeError("Canonical JSON contains an unsupported value");
+}
+
+function validatedRandomId(randomId: () => string): string {
+  const value = randomId();
+  if (!UUID_PATTERN.test(value)) throw new TypeError("randomId must return an RFC 4122 UUID");
+  return value;
+}
+
+function errorCode(error: unknown): string | undefined {
+  return isObject(error) && typeof error.code === "string" ? error.code : undefined;
+}
+
+function isMissing(error: unknown): boolean {
+  return errorCode(error) === "ENOENT";
+}
+
+function hardLinksUnsupported(error: unknown): boolean {
+  return ["EXDEV", "ENOTSUP", "EOPNOTSUPP", "ENOSYS", "EPERM"].includes(errorCode(error) ?? "");
+}
+
+async function lstatOrNull(path: string): Promise<Stats | null> {
+  try {
+    return await lstat(path);
+  } catch (error) {
+    if (isMissing(error)) return null;
+    throw error;
+  }
+}
+
+async function readRegularNoFollow(
+  path: string,
+  expected?: Stats,
+): Promise<{ bytes: Buffer; stat: Stats }> {
+  let handle;
+  try {
+    handle = await open(path, constants.O_RDONLY | constants.O_NOFOLLOW);
+    const stat = await handle.stat();
+    if (!stat.isFile()) throw new Error("not a regular file");
+    if (expected !== undefined && (stat.dev !== expected.dev || stat.ino !== expected.ino))
+      throw new Error("file identity changed");
+    const bytes = await handle.readFile();
+    return { bytes, stat };
+  } finally {
+    await handle?.close();
+  }
+}
+
+async function syncDirectory(path: string): Promise<void> {
+  const handle = await open(path, constants.O_RDONLY);
+  try {
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+}
+
+function pathContains(parent: string, child: string): boolean {
+  const difference = relative(parent, child);
+  return (
+    difference === "" ||
+    (!difference.startsWith(`..${sep}`) && difference !== ".." && !isAbsolute(difference))
+  );
+}
+
+async function physicalPath(path: string): Promise<string> {
+  const suffix: string[] = [];
+  let cursor = path;
+  for (;;) {
+    try {
+      return resolve(await realpath(cursor), ...suffix.reverse());
+    } catch (error) {
+      if (!isMissing(error)) throw error;
+      const parent = dirname(cursor);
+      if (parent === cursor) throw error;
+      suffix.push(cursor.slice(parent.length + (parent.endsWith(sep) ? 0 : 1)));
+      cursor = parent;
+    }
+  }
+}
+
+async function rootsOverlap(a: string, b: string): Promise<boolean> {
+  if (pathContains(a, b) || pathContains(b, a)) return true;
+  const [physicalA, physicalB] = await Promise.all([physicalPath(a), physicalPath(b)]);
+  return pathContains(physicalA, physicalB) || pathContains(physicalB, physicalA);
+}
+
+function refusal(
+  journalPath: string,
+  reason: LegacyMigrationRefusalCode,
+  exitCode: 2 | 3 | 4,
+  manifestDigest: string | null,
+  conflictIds: readonly string[] = [],
+): LegacyMigrationResult {
+  return { status: "refused", exitCode, journalPath, manifestDigest, reason, conflictIds };
+}
+
+function validAction(action: unknown): action is LegacyMigrationAction {
+  if (!isObject(action) || typeof action.kind !== "string") return false;
+  if (action.kind === "resume")
+    return hasExactKeys(action, ["isTTY", "kind"]) && typeof action.isTTY === "boolean";
+  if (action.kind === "confirm" || action.kind === "discard")
+    return (
+      hasExactKeys(action, ["kind", "manifestDigest"]) && typeof action.manifestDigest === "string"
+    );
+  if (action.kind === "replan")
+    return (
+      hasExactKeys(action, ["discardedManifestDigest", "isTTY", "kind"]) &&
+      typeof action.discardedManifestDigest === "string" &&
+      typeof action.isTTY === "boolean"
+    );
+  return false;
+}
+
+function privateDirectoryMode(stat: Stats): boolean {
+  return (stat.mode & 0o7777 & ~0o700) === 0;
+}
+
+function privateFileMode(stat: Stats): boolean {
+  return (stat.mode & 0o7777 & ~0o600) === 0;
+}
+
+async function ensureSafeTargetDirectory(
+  requestedPath: string,
+  targetRoot: string,
+  create: boolean,
+): Promise<boolean> {
+  if (!pathContains(targetRoot, requestedPath)) return false;
+  const parsedRoot = resolve(sep);
+  const components = resolve(requestedPath).slice(parsedRoot.length).split(sep).filter(Boolean);
+  let cursor = parsedRoot;
+  let belowTarget = cursor === targetRoot;
+  for (const component of components) {
+    cursor = join(cursor, component);
+    if (cursor === targetRoot) belowTarget = true;
+    let stat = await lstatOrNull(cursor);
+    if (stat === null) {
+      if (!belowTarget || !create) return !belowTarget ? false : true;
+      let created = false;
+      try {
+        await mkdir(cursor, 0o700);
+        created = true;
+      } catch (error) {
+        if (errorCode(error) !== "EEXIST") throw error;
+      }
+      stat = await lstatOrNull(cursor);
+      if (created && stat !== null && stat.isDirectory() && !stat.isSymbolicLink()) {
+        const handle = await open(
+          cursor,
+          constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_DIRECTORY,
+        );
+        try {
+          const opened = await handle.stat();
+          if (!opened.isDirectory() || opened.dev !== stat.dev || opened.ino !== stat.ino)
+            return false;
+          await handle.chmod(0o700);
+        } finally {
+          await handle.close();
+        }
+        stat = await lstatOrNull(cursor);
+      }
+    }
+    if (stat === null || !stat.isDirectory() || stat.isSymbolicLink()) return false;
+    if (belowTarget && !privateDirectoryMode(stat)) return false;
+  }
+  return true;
+}
+
+function normalizeRelative(path: string): string {
+  return path.split(sep).join("/");
+}
+
+function safeRelativeTarget(path: unknown): path is string {
+  if (typeof path !== "string" || path.length === 0 || isAbsolute(path) || path.includes("\\"))
+    return false;
+  const segments = path.split("/");
+  return segments.every((segment) => segment.length > 0 && segment !== "." && segment !== "..");
+}
+
+function parseConfig(bytes: Buffer, sourceRoot: string, targetRoot: string): ConfigPlan {
+  let document: Document.Parsed<ParsedNode>;
+  try {
+    document = parseDocument(bytes.toString("utf8"), { uniqueKeys: true });
+  } catch {
+    throw new PlanningRefusal("invalid-source-config", 4);
+  }
+  if (document.errors.length > 0 || !isMap(document.contents)) {
+    throw new PlanningRefusal("invalid-source-config", 4);
+  }
+  const rawDataRoot = document.get("data_dir");
+  let dataRoot = sourceRoot;
+  if (rawDataRoot !== undefined) {
+    if (
+      typeof rawDataRoot !== "string" ||
+      rawDataRoot.length === 0 ||
+      rawDataRoot.startsWith("~/") ||
+      !isAbsolute(rawDataRoot)
+    ) {
+      throw new PlanningRefusal("unsupported-data-dir", 4);
+    }
+    dataRoot = resolve(rawDataRoot);
+  }
+  let output: Buffer;
+  let provider: unknown;
+  let authProfile: unknown;
+  try {
+    const llm = document.get("llm", true);
+    if (isMap(llm)) {
+      provider = llm.get("provider");
+      authProfile = llm.get("auth_profile");
+    }
+    document.set("data_dir", targetRoot);
+    const telegram = document.get("telegram", true);
+    if (isMap(telegram)) telegram.delete("bot_token");
+    output = Buffer.from(String(document), "utf8");
+  } catch {
+    throw new PlanningRefusal("invalid-source-config", 4);
+  }
+  return { bytes, output, dataRoot, provider, authProfile };
+}
+
+function validOAuthProfiles(bytes: Buffer): Record<string, unknown> | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(bytes.toString("utf8"));
+  } catch {
+    return null;
+  }
+  if (!isObject(parsed)) return null;
+  for (const value of Object.values(parsed)) {
+    if (!isObject(value)) return null;
+    const allowed = new Set(["type", "access", "refresh", "expires", "accountId", "email"]);
+    if (Object.keys(value).some((key) => !allowed.has(key))) return null;
+    if (
+      value.type !== "oauth" ||
+      typeof value.access !== "string" ||
+      typeof value.refresh !== "string" ||
+      typeof value.expires !== "number" ||
+      !Number.isFinite(value.expires) ||
+      (value.accountId !== undefined && typeof value.accountId !== "string") ||
+      (value.email !== undefined && typeof value.email !== "string")
+    ) {
+      return null;
+    }
+    const required = ["type", "access", "refresh", "expires"];
+    if (required.some((key) => !Object.hasOwn(value, key))) return null;
+  }
+  return parsed;
+}
+
+function routeLeaf(
+  sourceOwner: SourceOwner,
+  sourceRelativePath: string,
+  sourcePath: string,
+  fileType: FileType,
+  sourceRoot: string,
+  dataRoot: string,
+): Pick<
+  LegacyMigrationManifestEntry,
+  "disposition" | "reason" | "targetRelativePath" | "transform"
+> {
+  const sourceRelative = normalizeRelative(relative(sourceRoot, sourcePath));
+  const dataRelative = normalizeRelative(relative(dataRoot, sourcePath));
+  const underSource = pathContains(sourceRoot, sourcePath);
+  const underData = pathContains(dataRoot, sourcePath);
+
+  if (underSource && sourceRelative === "config.yaml") {
+    return {
+      disposition: "migrate",
+      reason: "config-v1",
+      targetRelativePath: "config/config.yaml",
+      transform: "config-v1",
+    };
+  }
+  if (underSource && sourceRelative === "auth-profiles.json") {
+    return {
+      disposition: "migrate",
+      reason: "oauth-profile",
+      targetRelativePath: "config/auth-profiles.json",
+      transform: "none",
+    };
+  }
+  if (
+    underSource &&
+    (sourceRelative === "auth/codex" || sourceRelative.startsWith("auth/codex/"))
+  ) {
+    return {
+      disposition: "refuse",
+      reason: "unsupported-credential-layout",
+      targetRelativePath: null,
+      transform: "none",
+    };
+  }
+  if (underData && dataRelative === "memory/MEMORY.md") {
+    return {
+      disposition: "migrate",
+      reason: "memory",
+      targetRelativePath: "memory/MEMORY.md",
+      transform: "none",
+    };
+  }
+  if (underData && /^memory\/\d{4}-\d{2}-\d{2}\.md$/.test(dataRelative)) {
+    return {
+      disposition: "migrate",
+      reason: "daily-note",
+      targetRelativePath: dataRelative,
+      transform: "none",
+    };
+  }
+  if (underData && dataRelative === "memory/MEMORY.history.jsonl") {
+    return {
+      disposition: "migrate",
+      reason: "memory-history",
+      targetRelativePath: dataRelative,
+      transform: "none",
+    };
+  }
+  if (underData && dataRelative === "memory/events.jsonl") {
+    return {
+      disposition: "migrate",
+      reason: "event-ledger",
+      targetRelativePath: dataRelative,
+      transform: "none",
+    };
+  }
+  if (underData && dataRelative === "plans/current-plan.json") {
+    return {
+      disposition: "migrate",
+      reason: "current-plan",
+      targetRelativePath: dataRelative,
+      transform: "none",
+    };
+  }
+  if (
+    dataRoot !== sourceRoot &&
+    sourceOwner === "legacy-root" &&
+    underSource &&
+    (sourceRelative.startsWith("memory/") || sourceRelative.startsWith("plans/"))
+  ) {
+    return {
+      disposition: "shadowed",
+      reason: "shadowed-by-authoritative-data-dir",
+      targetRelativePath: null,
+      transform: "none",
+    };
+  }
+  if (underData && dataRelative === "allowed-senders.json") {
+    return {
+      disposition: "defer",
+      reason: "telegram-guided-import",
+      targetRelativePath: null,
+      transform: "none",
+    };
+  }
+  if (underData && dataRelative === ".allowed-senders.lock") {
+    return {
+      disposition: "skip",
+      reason: "transient-allowlist-lock",
+      targetRelativePath: null,
+      transform: "none",
+    };
+  }
+  if (
+    underData &&
+    /^sessions\/telegram:[^/]*\.jsonl(?:\.(?:reset|precompact|corrupt)\..+|\.tmp)?$/.test(
+      dataRelative,
+    )
+  ) {
+    return {
+      disposition: "defer",
+      reason: "telegram-channel-state",
+      targetRelativePath: null,
+      transform: "none",
+    };
+  }
+  if (underData && dataRelative.startsWith("sessions/")) {
+    return {
+      disposition: "skip",
+      reason: "fresh-cli-session",
+      targetRelativePath: null,
+      transform: "none",
+    };
+  }
+  if (underData && dataRelative.startsWith("data/")) {
+    return {
+      disposition: "skip",
+      reason: "re-derivable",
+      targetRelativePath: null,
+      transform: "none",
+    };
+  }
+  if (
+    underData &&
+    (dataRelative.startsWith("logs/") || dataRelative.startsWith("usage-ledger.jsonl"))
+  ) {
+    return {
+      disposition: "skip",
+      reason: "diagnostic",
+      targetRelativePath: null,
+      transform: "none",
+    };
+  }
+  if (
+    underData &&
+    ["instance-id", "last-notified-version", "last-run.json"].includes(dataRelative)
+  ) {
+    return {
+      disposition: "skip",
+      reason: "machine-local",
+      targetRelativePath: null,
+      transform: "none",
+    };
+  }
+  const reserved = (path: string) =>
+    ["store/", "archive/", "config/"].some((prefix) => path.startsWith(prefix));
+  if ((underSource && reserved(sourceRelative)) || (underData && reserved(dataRelative))) {
+    return {
+      disposition: "skip",
+      reason: "reserved-namespace",
+      targetRelativePath: null,
+      transform: "none",
+    };
+  }
+  if (fileType === "symlink") {
+    return { disposition: "skip", reason: "symlink", targetRelativePath: null, transform: "none" };
+  }
+  if (fileType === "other") {
+    return {
+      disposition: "skip",
+      reason: "unsupported-leaf-type",
+      targetRelativePath: null,
+      transform: "none",
+    };
+  }
+  void sourceRelativePath;
+  return {
+    disposition: "skip",
+    reason: "unrecognized",
+    targetRelativePath: null,
+    transform: "none",
+  };
+}
+
+function entryIdentity(entry: LegacyMigrationManifestEntry): string {
+  return sha256(
+    canonicalize({
+      sourceOwner: entry.sourceOwner,
+      sourcePath: entry.sourcePath,
+      targetRelativePath: entry.targetRelativePath,
+      disposition: entry.disposition,
+      reason: entry.reason,
+      sourceSha256: entry.sourceSha256,
+      outputSha256: entry.outputSha256,
+    }),
+  );
+}
+
+async function walkLeaves(
+  root: string,
+  owner: SourceOwner,
+  prunePhysicalRoot: string | null,
+  visit: (path: string, owner: SourceOwner, relativePath: string, stat: Stats) => Promise<void>,
+): Promise<void> {
+  const rootStat = await lstatOrNull(root);
+  if (rootStat === null) return;
+  if (!rootStat.isDirectory() || rootStat.isSymbolicLink()) {
+    await visit(root, owner, "", rootStat);
+    return;
+  }
+  async function descend(directory: string): Promise<void> {
+    const names = (await readdir(directory)).sort(compareCodeUnits);
+    for (const name of names) {
+      const path = join(directory, name);
+      const stat = await lstat(path);
+      if (stat.isDirectory() && !stat.isSymbolicLink()) {
+        if (prunePhysicalRoot !== null) {
+          let physical: string;
+          try {
+            physical = await realpath(path);
+          } catch {
+            throw new PlanningRefusal("source-drift", 3);
+          }
+          if (physical === prunePhysicalRoot) continue;
+        }
+        await descend(path);
+      } else {
+        await visit(path, owner, normalizeRelative(relative(root, path)), stat);
+      }
+    }
+  }
+  await descend(root);
+}
+
+async function sourceInventory(
+  sourceRoot: string,
+  dataRoot: string,
+  targetRoot: string,
+  configPlan: ConfigPlan,
+  authBytes: Buffer | null,
+): Promise<LegacyMigrationManifestEntry[]> {
+  const entries: LegacyMigrationManifestEntry[] = [];
+  const sourcePhysical = await physicalPath(sourceRoot);
+  const dataPhysical = await physicalPath(dataRoot);
+  const physicalEqual = sourcePhysical === dataPhysical;
+  const dataInsideSource = !physicalEqual && pathContains(sourcePhysical, dataPhysical);
+  const sourceInsideData = !physicalEqual && pathContains(dataPhysical, sourcePhysical);
+
+  const visit = async (
+    path: string,
+    owner: SourceOwner,
+    sourceRelativePath: string,
+    stat: Stats,
+  ): Promise<void> => {
+    const fileType: FileType = stat.isFile()
+      ? "regular"
+      : stat.isSymbolicLink()
+        ? "symlink"
+        : "other";
+    const route = routeLeaf(
+      owner,
+      sourceRelativePath,
+      path,
+      fileType,
+      sourceRoot,
+      physicalEqual ? sourceRoot : dataRoot,
+    );
+    let bytes: Buffer | null = null;
+    let symlinkTarget: string | null = null;
+    if (fileType === "regular") {
+      if (path === join(sourceRoot, "config.yaml")) bytes = configPlan.bytes;
+      else if (path === join(sourceRoot, "auth-profiles.json") && authBytes !== null)
+        bytes = authBytes;
+      else {
+        try {
+          bytes = (await readRegularNoFollow(path, stat)).bytes;
+        } catch {
+          throw new PlanningRefusal("source-drift", 3);
+        }
+      }
+    } else if (fileType === "symlink") {
+      symlinkTarget = await readlink(path);
+      bytes = Buffer.from(symlinkTarget, "utf8");
+    }
+    const output =
+      route.transform === "config-v1"
+        ? configPlan.output
+        : route.disposition === "migrate"
+          ? bytes
+          : null;
+    const entry: LegacyMigrationManifestEntry = {
+      id: "",
+      sourceOwner: owner,
+      sourcePath: resolve(path),
+      sourceRelativePath,
+      fileType,
+      ...route,
+      sourceSha256: bytes === null ? null : sha256(bytes),
+      outputSha256: output === null ? null : sha256(output),
+      sourceBytes: bytes === null ? null : bytes.length,
+      outputBytes: output === null ? null : output.length,
+      sourceMode: stat.mode & 0o7777,
+      symlinkTarget,
+      targetAtPlan: null,
+      targetActualSha256: null,
+      requiresConfirmation: false,
+    };
+    entries.push(entry);
+  };
+
+  if (physicalEqual) {
+    await walkLeaves(sourceRoot, "legacy-root", null, visit);
+  } else {
+    await walkLeaves(sourceRoot, "legacy-root", dataInsideSource ? dataPhysical : null, visit);
+    await walkLeaves(dataRoot, "data-root", sourceInsideData ? sourcePhysical : null, visit);
+  }
+  entries.sort(
+    (a, b) =>
+      compareCodeUnits(a.sourcePath, b.sourcePath) ||
+      compareCodeUnits(a.sourceOwner, b.sourceOwner),
+  );
+  return entries;
+}
+
+async function inspectTarget(
+  entry: LegacyMigrationManifestEntry,
+  targetRoot: string,
+): Promise<void> {
+  if (
+    entry.disposition !== "migrate" ||
+    entry.targetRelativePath === null ||
+    entry.outputSha256 === null
+  )
+    return;
+  const target = join(targetRoot, ...entry.targetRelativePath.split("/"));
+  const safeParent = await ensureSafeTargetDirectory(dirname(target), targetRoot, false);
+  const parentStat = await lstatOrNull(dirname(target));
+  if (!safeParent && parentStat !== null) throw new PlanningRefusal("target-path-unsafe", 3);
+  const stat = await lstatOrNull(target);
+  if (stat === null) {
+    entry.targetAtPlan = "absent";
+    entry.id = entryIdentity(entry);
+    return;
+  }
+  let actual: string | null = null;
+  if (stat.isFile() && !stat.isSymbolicLink()) {
+    try {
+      actual = sha256((await readRegularNoFollow(target, stat)).bytes);
+    } catch {
+      actual = null;
+    }
+  }
+  if (actual === entry.outputSha256) {
+    entry.targetAtPlan = "identical";
+    entry.targetActualSha256 = actual;
+  } else {
+    entry.disposition = "skip";
+    entry.reason = "target-conflict";
+    entry.targetAtPlan = "conflict";
+    entry.targetActualSha256 = actual;
+    entry.requiresConfirmation = true;
+  }
+  entry.id = entryIdentity(entry);
+}
+
+async function makeInventory(
+  sourceRoot: string,
+  dataRoot: string,
+  targetRoot: string,
+  configPlan: ConfigPlan,
+  authBytes: Buffer | null,
+  preflight: boolean,
+): Promise<InventoryBuild> {
+  const entries = await sourceInventory(sourceRoot, dataRoot, targetRoot, configPlan, authBytes);
+  for (const entry of entries) {
+    if (preflight) await inspectTarget(entry, targetRoot);
+    if (entry.id === "") entry.id = entryIdentity(entry);
+  }
+  const manifest: LegacyMigrationManifest = {
+    schemaVersion: LEGACY_MIGRATION_SCHEMA_VERSION,
+    migrationId: LEGACY_MIGRATION_ID,
+    sourceRoot,
+    dataRoot,
+    targetRoot,
+    entries,
+  };
+  return { manifest, digest: sha256(canonicalize(manifest)) };
+}
+
+function sourceFields(entry: LegacyMigrationManifestEntry): unknown {
+  const disposition = entry.reason === "target-conflict" ? "migrate" : entry.disposition;
+  const reason =
+    entry.reason === "target-conflict"
+      ? routeReasonForConflict(entry.targetRelativePath)
+      : entry.reason;
+  return {
+    sourceOwner: entry.sourceOwner,
+    sourcePath: entry.sourcePath,
+    sourceRelativePath: entry.sourceRelativePath,
+    fileType: entry.fileType,
+    disposition,
+    reason,
+    targetRelativePath: entry.targetRelativePath,
+    transform: entry.transform,
+    sourceSha256: entry.sourceSha256,
+    outputSha256: entry.outputSha256,
+    sourceBytes: entry.sourceBytes,
+    outputBytes: entry.outputBytes,
+    sourceMode: entry.sourceMode,
+    symlinkTarget: entry.symlinkTarget,
+  };
+}
+
+function routeReasonForConflict(targetRelativePath: string | null): string {
+  if (targetRelativePath === "config/config.yaml") return "config-v1";
+  if (targetRelativePath === "config/auth-profiles.json") return "oauth-profile";
+  if (targetRelativePath === "memory/MEMORY.md") return "memory";
+  if (targetRelativePath === "memory/MEMORY.history.jsonl") return "memory-history";
+  if (targetRelativePath === "memory/events.jsonl") return "event-ledger";
+  if (targetRelativePath === "plans/current-plan.json") return "current-plan";
+  if (targetRelativePath !== null && /^memory\/\d{4}-\d{2}-\d{2}\.md$/.test(targetRelativePath))
+    return "daily-note";
+  return "target-conflict";
+}
+
+function sourceDifference(
+  pinned: LegacyMigrationManifest,
+  current: LegacyMigrationManifest,
+): SourceDifference | null {
+  const pinnedByPath = new Map(
+    pinned.entries.map((entry) => [`${entry.sourcePath}\0${entry.sourceOwner}`, entry]),
+  );
+  const currentByPath = new Map(
+    current.entries.map((entry) => [`${entry.sourcePath}\0${entry.sourceOwner}`, entry]),
+  );
+  const ids: string[] = [];
+  const expected: Array<string | null> = [];
+  const actual: Array<string | null> = [];
+  for (const entry of pinned.entries) {
+    const key = `${entry.sourcePath}\0${entry.sourceOwner}`;
+    const other = currentByPath.get(key);
+    if (
+      other === undefined ||
+      canonicalize(sourceFields(entry)) !== canonicalize(sourceFields(other))
+    ) {
+      ids.push(entry.id);
+      expected.push(entry.sourceSha256);
+      actual.push(other?.sourceSha256 ?? null);
+    }
+  }
+  const hasAddition = [...currentByPath.keys()].some((key) => !pinnedByPath.has(key));
+  return ids.length > 0 || hasAddition ? { ids, expected, actual, hasAddition } : null;
+}
+
+function entryValid(value: unknown): value is LegacyMigrationManifestEntry {
+  if (!isObject(value) || !hasExactKeys(value, ENTRY_KEYS)) return false;
+  if (
+    typeof value.id !== "string" ||
+    !HASH_PATTERN.test(value.id) ||
+    !["legacy-root", "data-root"].includes(String(value.sourceOwner)) ||
+    typeof value.sourcePath !== "string" ||
+    !isAbsolute(value.sourcePath) ||
+    resolve(value.sourcePath) !== value.sourcePath ||
+    typeof value.sourceRelativePath !== "string" ||
+    value.sourceRelativePath.includes("\\") ||
+    value.sourceRelativePath.split("/").some((part) => part === "." || part === "..") ||
+    !["regular", "symlink", "other"].includes(String(value.fileType)) ||
+    !["migrate", "skip", "defer", "shadowed", "refuse"].includes(String(value.disposition)) ||
+    typeof value.reason !== "string" ||
+    !(value.targetRelativePath === null || safeRelativeTarget(value.targetRelativePath)) ||
+    !["none", "config-v1"].includes(String(value.transform)) ||
+    !(
+      value.sourceSha256 === null ||
+      (typeof value.sourceSha256 === "string" && HASH_PATTERN.test(value.sourceSha256))
+    ) ||
+    !(
+      value.outputSha256 === null ||
+      (typeof value.outputSha256 === "string" && HASH_PATTERN.test(value.outputSha256))
+    ) ||
+    !(
+      value.sourceBytes === null ||
+      (Number.isSafeInteger(value.sourceBytes) && Number(value.sourceBytes) >= 0)
+    ) ||
+    !(
+      value.outputBytes === null ||
+      (Number.isSafeInteger(value.outputBytes) && Number(value.outputBytes) >= 0)
+    ) ||
+    !(
+      value.sourceMode === null ||
+      (Number.isInteger(value.sourceMode) &&
+        Number(value.sourceMode) >= 0 &&
+        Number(value.sourceMode) <= 0o7777)
+    ) ||
+    !(value.symlinkTarget === null || typeof value.symlinkTarget === "string") ||
+    ![null, "absent", "identical", "conflict"].includes(value.targetAtPlan as never) ||
+    !(
+      value.targetActualSha256 === null ||
+      (typeof value.targetActualSha256 === "string" && HASH_PATTERN.test(value.targetActualSha256))
+    ) ||
+    typeof value.requiresConfirmation !== "boolean"
+  )
+    return false;
+  const entry = value as unknown as LegacyMigrationManifestEntry;
+  if (entryIdentity(entry) !== entry.id) return false;
+  if (
+    entry.fileType === "regular" &&
+    (entry.sourceSha256 === null || entry.sourceBytes === null || entry.sourceMode === null)
+  )
+    return false;
+  if (
+    entry.fileType === "symlink" &&
+    (entry.symlinkTarget === null ||
+      entry.sourceSha256 === null ||
+      entry.sourceBytes === null ||
+      entry.sourceMode === null ||
+      entry.outputSha256 !== null ||
+      entry.outputBytes !== null ||
+      entry.transform !== "none")
+  )
+    return false;
+  if (
+    entry.fileType === "other" &&
+    (entry.sourceSha256 !== null ||
+      entry.outputSha256 !== null ||
+      entry.sourceBytes !== null ||
+      entry.outputBytes !== null ||
+      entry.sourceMode === null ||
+      entry.symlinkTarget !== null ||
+      entry.transform !== "none")
+  )
+    return false;
+  if (entry.disposition === "migrate") {
+    if (
+      entry.fileType !== "regular" ||
+      entry.targetRelativePath === null ||
+      entry.outputSha256 === null ||
+      entry.outputBytes === null ||
+      !["absent", "identical"].includes(entry.targetAtPlan ?? "") ||
+      entry.requiresConfirmation
+    )
+      return false;
+    if (entry.targetAtPlan === "absent" && entry.targetActualSha256 !== null) return false;
+    if (entry.targetAtPlan === "identical" && entry.targetActualSha256 !== entry.outputSha256)
+      return false;
+  }
+  if (
+    entry.reason === "target-conflict" &&
+    !(
+      entry.fileType === "regular" &&
+      entry.disposition === "skip" &&
+      entry.targetRelativePath !== null &&
+      entry.outputSha256 !== null &&
+      entry.outputBytes !== null &&
+      entry.targetAtPlan === "conflict" &&
+      entry.requiresConfirmation
+    )
+  )
+    return false;
+  if (entry.disposition !== "migrate" && entry.reason !== "target-conflict") {
+    if (
+      entry.outputSha256 !== null ||
+      entry.outputBytes !== null ||
+      entry.targetRelativePath !== null ||
+      entry.targetAtPlan !== null ||
+      entry.targetActualSha256 !== null ||
+      entry.requiresConfirmation ||
+      entry.transform !== "none"
+    )
+      return false;
+  }
+  if (entry.transform === "config-v1" && entry.targetRelativePath !== "config/config.yaml")
+    return false;
+  return true;
+}
+
+function orderedSubset(values: unknown, manifestIds: string[]): values is string[] {
+  if (!Array.isArray(values) || values.some((value) => typeof value !== "string")) return false;
+  const strings = values as string[];
+  if (new Set(strings).size !== strings.length) return false;
+  const indices = strings.map((id) => manifestIds.indexOf(id));
+  return (
+    indices.every((index) => index >= 0) &&
+    indices.every((index, position) => position === 0 || index > indices[position - 1]!)
+  );
+}
+
+function parseJournal(
+  bytes: Buffer,
+  sourceRoot: string,
+  targetRoot: string,
+): { journal: LegacyMigrationJournal | null; digest: string | null } {
+  let parsed: unknown;
+  let digest: string | null = null;
+  try {
+    parsed = JSON.parse(bytes.toString("utf8"));
+    if (isObject(parsed) && typeof parsed.manifestDigest === "string")
+      digest = parsed.manifestDigest;
+  } catch {
+    return { journal: null, digest };
+  }
+  if (!isObject(parsed) || !hasExactKeys(parsed, JOURNAL_KEYS)) return { journal: null, digest };
+  if (
+    parsed.schemaVersion !== 1 ||
+    parsed.migrationId !== LEGACY_MIGRATION_ID ||
+    parsed.sourceRoot !== sourceRoot ||
+    parsed.targetRoot !== targetRoot ||
+    typeof parsed.dataRoot !== "string" ||
+    !isAbsolute(parsed.dataRoot) ||
+    resolve(parsed.dataRoot) !== parsed.dataRoot ||
+    typeof parsed.manifestDigest !== "string" ||
+    !HASH_PATTERN.test(parsed.manifestDigest) ||
+    !["planned", "copying", "verified", "done"].includes(String(parsed.state)) ||
+    !Number.isSafeInteger(parsed.revision) ||
+    Number(parsed.revision) < 1 ||
+    !["pending", "complete", "partial"].includes(String(parsed.completion)) ||
+    !(parsed.freezePoint === null || typeof parsed.freezePoint === "string")
+  )
+    return { journal: null, digest };
+  if (
+    !isObject(parsed.manifest) ||
+    !hasExactKeys(parsed.manifest, [
+      "dataRoot",
+      "entries",
+      "migrationId",
+      "schemaVersion",
+      "sourceRoot",
+      "targetRoot",
+    ])
+  )
+    return { journal: null, digest };
+  if (
+    parsed.manifest.schemaVersion !== 1 ||
+    parsed.manifest.migrationId !== LEGACY_MIGRATION_ID ||
+    parsed.manifest.sourceRoot !== sourceRoot ||
+    parsed.manifest.dataRoot !== parsed.dataRoot ||
+    parsed.manifest.targetRoot !== targetRoot ||
+    !Array.isArray(parsed.manifest.entries) ||
+    !parsed.manifest.entries.every(entryValid)
+  )
+    return { journal: null, digest };
+  const entries = parsed.manifest.entries as unknown as LegacyMigrationManifestEntry[];
+  const sorted = [...entries].sort(
+    (a, b) =>
+      compareCodeUnits(a.sourcePath, b.sourcePath) ||
+      compareCodeUnits(a.sourceOwner, b.sourceOwner),
+  );
+  if (
+    entries.some((entry, index) => entry !== sorted[index]) ||
+    new Set(entries.map((entry) => entry.id)).size !== entries.length
+  )
+    return { journal: null, digest };
+  for (const entry of entries) {
+    const ownerRoot = entry.sourceOwner === "legacy-root" ? sourceRoot : String(parsed.dataRoot);
+    if (
+      !pathContains(ownerRoot, entry.sourcePath) ||
+      normalizeRelative(relative(ownerRoot, entry.sourcePath)) !== entry.sourceRelativePath
+    )
+      return { journal: null, digest };
+  }
+  if (sha256(canonicalize(parsed.manifest)) !== parsed.manifestDigest)
+    return { journal: null, digest };
+  const revision = Number(parsed.revision);
+  if (!Array.isArray(parsed.history) || parsed.history.length !== revision)
+    return { journal: null, digest };
+  const stateOrder: Record<JournalState, number> = { planned: 0, copying: 1, verified: 2, done: 3 };
+  let previousState = -1;
+  for (let index = 0; index < parsed.history.length; index++) {
+    const row = parsed.history[index];
+    if (
+      !isObject(row) ||
+      !hasExactKeys(row, ["at", "revision", "state"]) ||
+      row.revision !== index + 1 ||
+      !["planned", "copying", "verified", "done"].includes(String(row.state)) ||
+      typeof row.at !== "string"
+    )
+      return { journal: null, digest };
+    try {
+      if (new Date(row.at).toISOString() !== row.at) return { journal: null, digest };
+    } catch {
+      return { journal: null, digest };
+    }
+    const order = stateOrder[row.state as JournalState];
+    if (order < previousState || (order > previousState + 1 && previousState >= 0))
+      return { journal: null, digest };
+    previousState = order;
+  }
+  if ((parsed.history[0] as Record<string, unknown>).state !== "planned")
+    return { journal: null, digest };
+  if ((parsed.history.at(-1) as Record<string, unknown>).state !== parsed.state)
+    return { journal: null, digest };
+  const ids = entries.map((entry) => entry.id);
+  if (
+    !isObject(parsed.results) ||
+    !hasExactKeys(parsed.results, ["copiedIds", "skipVerifiedIds", "skippedConflictIds"]) ||
+    !orderedSubset(parsed.results.copiedIds, ids) ||
+    !orderedSubset(parsed.results.skipVerifiedIds, ids) ||
+    !orderedSubset(parsed.results.skippedConflictIds, ids)
+  )
+    return { journal: null, digest };
+  const conflictIds = entries
+    .filter((entry) => entry.reason === "target-conflict")
+    .map((entry) => entry.id);
+  if ((parsed.results.skippedConflictIds as string[]).some((id) => !conflictIds.includes(id)))
+    return { journal: null, digest };
+  const migrateIds = entries
+    .filter((entry) => entry.disposition === "migrate")
+    .map((entry) => entry.id);
+  if (
+    [
+      ...(parsed.results.copiedIds as string[]),
+      ...(parsed.results.skipVerifiedIds as string[]),
+    ].some((id) => !migrateIds.includes(id))
+  )
+    return { journal: null, digest };
+  if (parsed.refusal !== null) {
+    if (
+      !isObject(parsed.refusal) ||
+      !hasExactKeys(parsed.refusal, ["actualHashes", "code", "entryIds", "expectedHashes"]) ||
+      ![
+        "confirmation-required",
+        "pinned-refusal",
+        "manifest-mismatch",
+        "invalid-action",
+        "invalid-source-config",
+        "unsupported-data-dir",
+        "unsupported-credential-layout",
+        "source-target-overlap",
+        "source-drift",
+        "target-conflict",
+        "target-path-unsafe",
+        "no-clobber-unavailable",
+        "verification-failed",
+        "legacy-mutated-after-cutover",
+      ].includes(String(parsed.refusal.code)) ||
+      !orderedSubset(parsed.refusal.entryIds, ids) ||
+      !Array.isArray(parsed.refusal.expectedHashes) ||
+      !Array.isArray(parsed.refusal.actualHashes) ||
+      parsed.refusal.expectedHashes.length !== parsed.refusal.entryIds.length ||
+      parsed.refusal.actualHashes.length !== parsed.refusal.entryIds.length ||
+      [...parsed.refusal.expectedHashes, ...parsed.refusal.actualHashes].some(
+        (hash) => hash !== null && (typeof hash !== "string" || !HASH_PATTERN.test(hash)),
+      )
+    )
+      return { journal: null, digest };
+  }
+  if (
+    !isObject(parsed.verification) ||
+    !hasExactKeys(parsed.verification, ["allMatch", "complete", "outputs"]) ||
+    typeof parsed.verification.complete !== "boolean" ||
+    typeof parsed.verification.allMatch !== "boolean" ||
+    !Array.isArray(parsed.verification.outputs)
+  )
+    return { journal: null, digest };
+  for (const output of parsed.verification.outputs) {
+    if (
+      !isObject(output) ||
+      !hasExactKeys(output, ["actualSha256", "entryId", "expectedSha256", "matches"]) ||
+      typeof output.entryId !== "string" ||
+      !ids.includes(output.entryId) ||
+      typeof output.expectedSha256 !== "string" ||
+      !HASH_PATTERN.test(output.expectedSha256) ||
+      !(
+        output.actualSha256 === null ||
+        (typeof output.actualSha256 === "string" && HASH_PATTERN.test(output.actualSha256))
+      ) ||
+      typeof output.matches !== "boolean" ||
+      output.matches !== (output.actualSha256 === output.expectedSha256)
+    )
+      return { journal: null, digest };
+  }
+  const outputIds = (parsed.verification.outputs as Array<Record<string, unknown>>).map((output) =>
+    String(output.entryId),
+  );
+  if (
+    new Set(outputIds).size !== outputIds.length ||
+    outputIds.some((id, index) => id !== migrateIds[index])
+  )
+    return { journal: null, digest };
+  if (parsed.verification.complete && outputIds.length !== migrateIds.length)
+    return { journal: null, digest };
+  if (
+    parsed.verification.complete &&
+    parsed.verification.allMatch !==
+      parsed.verification.outputs.every(
+        (output) => (output as Record<string, unknown>).matches === true,
+      )
+  )
+    return { journal: null, digest };
+  if (
+    !parsed.verification.complete &&
+    (parsed.verification.allMatch || parsed.verification.outputs.length !== 0)
+  )
+    return { journal: null, digest };
+  const state = parsed.state as JournalState;
+  if (
+    (state === "planned" || state === "copying") &&
+    (parsed.freezePoint !== null || parsed.completion !== "pending")
+  )
+    return { journal: null, digest };
+  if (
+    (state === "verified" || state === "done") &&
+    (typeof parsed.freezePoint !== "string" ||
+      parsed.verification.complete !== true ||
+      parsed.verification.allMatch !== true)
+  )
+    return { journal: null, digest };
+  if (state === "done" && parsed.completion === "pending") return { journal: null, digest };
+  if (state !== "done" && parsed.completion !== "pending") return { journal: null, digest };
+  const verifiedAt = (parsed.history as Array<Record<string, unknown>>).find(
+    (row) => row.state === "verified",
+  )?.at;
+  if ((state === "verified" || state === "done") && parsed.freezePoint !== verifiedAt)
+    return { journal: null, digest };
+  if (state === "done") {
+    const expectedCompletion =
+      (parsed.results.skippedConflictIds as string[]).length > 0 ? "partial" : "complete";
+    if (parsed.completion !== expectedCompletion) return { journal: null, digest };
+    if (
+      expectedCompletion === "partial" &&
+      canonicalize(parsed.results.skippedConflictIds) !== canonicalize(conflictIds)
+    )
+      return { journal: null, digest };
+  }
+  return { journal: parsed as unknown as LegacyMigrationJournal, digest };
+}
+
+function checkpointContext(
+  checkpoint: LegacyMigrationCheckpoint,
+  journal: LegacyMigrationJournal,
+  entryId: string | null,
+): LegacyMigrationCheckpointContext {
+  return {
+    checkpoint,
+    journalState: journal.state,
+    revision: journal.revision,
+    entryId,
+    copiedCount: journal.results.copiedIds.length,
+  };
+}
+
+async function cleanupJournalTemps(controlRoot: string): Promise<void> {
+  // Control files are outside the payload manifest; under the store lock, matching temp siblings are abandoned.
+  const pattern = new RegExp(
+    `^journal\\.json\\.tmp\\.\\d+\\.${UUID_PATTERN.source.slice(1, -1)}$`,
+    "i",
+  );
+  for (const name of await readdir(controlRoot))
+    if (pattern.test(name)) await unlink(join(controlRoot, name));
+}
+
+async function allocateTemp(
+  directory: string,
+  prefix: string,
+  dependencies: Dependencies,
+): Promise<{ path: string; handle: Awaited<ReturnType<typeof open>> }> {
+  for (let attempt = 0; attempt < 16; attempt++) {
+    const id = validatedRandomId(dependencies.randomId);
+    const path = join(directory, `${prefix}${id}`);
+    try {
+      return { path, handle: await open(path, "wx", 0o600) };
+    } catch (error) {
+      if (errorCode(error) !== "EEXIST") throw error;
+    }
+  }
+  throw new Error("Unable to allocate a unique migration temp file");
+}
+
+async function writeJournal(
+  journalPath: string,
+  journal: LegacyMigrationJournal,
+  dependencies: Dependencies,
+  entryId: string | null = null,
+): Promise<void> {
+  const controlRoot = dirname(journalPath);
+  await cleanupJournalTemps(controlRoot);
+  const temp = await allocateTemp(controlRoot, `journal.json.tmp.${process.pid}.`, dependencies);
+  try {
+    await temp.handle.writeFile(`${JSON.stringify(journal)}\n`, "utf8");
+    await temp.handle.chmod(0o600);
+    await temp.handle.sync();
+  } finally {
+    await temp.handle.close();
+  }
+  await dependencies.checkpoint(checkpointContext("before-journal-rename", journal, entryId));
+  await rename(temp.path, journalPath);
+  await syncDirectory(controlRoot);
+  await dependencies.checkpoint(checkpointContext("after-journal-rename", journal, entryId));
+}
+
+function nextJournal(
+  journal: LegacyMigrationJournal,
+  state: JournalState,
+  dependencies: Dependencies,
+  mutate?: (draft: LegacyMigrationJournal, at: string) => void,
+): LegacyMigrationJournal {
+  const at = dependencies.now().toISOString();
+  const draft = structuredClone(journal);
+  draft.state = state;
+  draft.revision += 1;
+  draft.history.push({ revision: draft.revision, state, at });
+  draft.refusal = null;
+  mutate?.(draft, at);
+  return draft;
+}
+
+function manifestOrder(journal: LegacyMigrationJournal, ids: Iterable<string>): string[] {
+  const wanted = new Set(ids);
+  return journal.manifest.entries.filter((entry) => wanted.has(entry.id)).map((entry) => entry.id);
+}
+
+async function publishRefusal(
+  journalPath: string,
+  journal: LegacyMigrationJournal,
+  dependencies: Dependencies,
+  code: LegacyMigrationRefusalCode,
+  ids: string[],
+  expected: Array<string | null>,
+  actual: Array<string | null>,
+): Promise<LegacyMigrationJournal> {
+  const revised = nextJournal(journal, journal.state, dependencies, (draft) => {
+    draft.refusal = { code, entryIds: ids, expectedHashes: expected, actualHashes: actual };
+  });
+  await writeJournal(journalPath, revised, dependencies, ids[0] ?? null);
+  return revised;
+}
+
+async function readAndValidateJournal(
+  journalPath: string,
+  sourceRoot: string,
+  targetRoot: string,
+): Promise<{
+  journal: LegacyMigrationJournal | null;
+  digest: string | null;
+  exists: boolean;
+  unsafe: boolean;
+}> {
+  const stat = await lstatOrNull(journalPath);
+  if (stat === null) return { journal: null, digest: null, exists: false, unsafe: false };
+  if (!stat.isFile() || stat.isSymbolicLink() || !privateFileMode(stat))
+    return { journal: null, digest: null, exists: true, unsafe: true };
+  let bytes: Buffer;
+  try {
+    bytes = (await readRegularNoFollow(journalPath, stat)).bytes;
+  } catch {
+    return { journal: null, digest: null, exists: true, unsafe: true };
+  }
+  const parsed = parseJournal(bytes, sourceRoot, targetRoot);
+  if (parsed.journal !== null) {
+    try {
+      if (await rootsOverlap(parsed.journal.dataRoot, targetRoot))
+        return { journal: null, digest: parsed.digest, exists: true, unsafe: false };
+      const physicalEqual =
+        (await physicalPath(sourceRoot)) === (await physicalPath(parsed.journal.dataRoot));
+      const routeDataRoot = physicalEqual ? sourceRoot : parsed.journal.dataRoot;
+      for (const entry of parsed.journal.manifest.entries) {
+        if (physicalEqual && entry.sourceOwner === "data-root")
+          return { journal: null, digest: parsed.digest, exists: true, unsafe: false };
+        const routed = routeLeaf(
+          entry.sourceOwner,
+          entry.sourceRelativePath,
+          entry.sourcePath,
+          entry.fileType,
+          sourceRoot,
+          routeDataRoot,
+        );
+        if (entry.reason === "target-conflict") {
+          if (
+            routed.disposition !== "migrate" ||
+            routed.targetRelativePath !== entry.targetRelativePath ||
+            routed.transform !== entry.transform
+          )
+            return { journal: null, digest: parsed.digest, exists: true, unsafe: false };
+        } else if (
+          routed.disposition !== entry.disposition ||
+          routed.reason !== entry.reason ||
+          routed.targetRelativePath !== entry.targetRelativePath ||
+          routed.transform !== entry.transform
+        ) {
+          return { journal: null, digest: parsed.digest, exists: true, unsafe: false };
+        }
+      }
+    } catch {
+      return { journal: null, digest: parsed.digest, exists: true, unsafe: false };
+    }
+  }
+  return { ...parsed, exists: true, unsafe: false };
+}
+
+async function loadPlanningInputs(
+  sourceRoot: string,
+  targetRoot: string,
+): Promise<{ config: ConfigPlan; authBytes: Buffer | null }> {
+  const configPath = join(sourceRoot, "config.yaml");
+  const configStat = await lstatOrNull(configPath);
+  if (configStat === null || !configStat.isFile() || configStat.isSymbolicLink())
+    throw new PlanningRefusal("invalid-source-config", 4);
+  let configBytes: Buffer;
+  try {
+    configBytes = (await readRegularNoFollow(configPath, configStat)).bytes;
+  } catch {
+    throw new PlanningRefusal("invalid-source-config", 4);
+  }
+  const config = parseConfig(configBytes, sourceRoot, targetRoot);
+  const dataStat = await lstatOrNull(config.dataRoot);
+  if (dataStat?.isSymbolicLink()) throw new PlanningRefusal("unsupported-data-dir", 4);
+  const authPath = join(sourceRoot, "auth-profiles.json");
+  const authStat = await lstatOrNull(authPath);
+  let authBytes: Buffer | null = null;
+  let profiles: Record<string, unknown> | null = null;
+  if (authStat !== null) {
+    if (!authStat.isFile() || authStat.isSymbolicLink())
+      throw new PlanningRefusal("invalid-source-config", 4);
+    try {
+      authBytes = (await readRegularNoFollow(authPath, authStat)).bytes;
+    } catch {
+      throw new PlanningRefusal("invalid-source-config", 4);
+    }
+    profiles = validOAuthProfiles(authBytes);
+    if (profiles === null) throw new PlanningRefusal("invalid-source-config", 4);
+  }
+  if (config.provider === "openai-codex") {
+    const selected =
+      typeof config.authProfile === "string" && config.authProfile.length > 0
+        ? config.authProfile
+        : "openai-codex";
+    if (profiles === null || !Object.hasOwn(profiles, selected))
+      throw new PlanningRefusal("invalid-source-config", 4);
+  }
+  return { config, authBytes };
+}
+
+async function rebuildForPinned(
+  journal: LegacyMigrationJournal,
+): Promise<{ inventory: InventoryBuild; difference: SourceDifference | null }> {
+  const inputs = await loadPlanningInputs(journal.sourceRoot, journal.targetRoot);
+  if (inputs.config.dataRoot !== journal.dataRoot) {
+    return {
+      inventory: { manifest: { ...journal.manifest, entries: [] }, digest: "" },
+      difference: await differenceFromPinnedReads(journal),
+    };
+  }
+  const inventory = await makeInventory(
+    journal.sourceRoot,
+    journal.dataRoot,
+    journal.targetRoot,
+    inputs.config,
+    inputs.authBytes,
+    false,
+  );
+  return { inventory, difference: sourceDifference(journal.manifest, inventory.manifest) };
+}
+
+async function differenceFromPinnedReads(
+  journal: LegacyMigrationJournal,
+): Promise<SourceDifference> {
+  const ids: string[] = [];
+  const expected: Array<string | null> = [];
+  const actual: Array<string | null> = [];
+  for (const entry of journal.manifest.entries) {
+    const stat = await lstatOrNull(entry.sourcePath);
+    let currentHash: string | null = null;
+    let changed = stat === null || (stat.mode & 0o7777) !== entry.sourceMode;
+    if (stat !== null) {
+      const fileType: FileType = stat.isFile()
+        ? "regular"
+        : stat.isSymbolicLink()
+          ? "symlink"
+          : "other";
+      changed ||= fileType !== entry.fileType;
+      if (fileType === "regular") {
+        try {
+          currentHash = sha256((await readRegularNoFollow(entry.sourcePath, stat)).bytes);
+        } catch {
+          changed = true;
+        }
+      } else if (fileType === "symlink") {
+        try {
+          currentHash = sha256(Buffer.from(await readlink(entry.sourcePath), "utf8"));
+        } catch {
+          changed = true;
+        }
+      }
+      changed ||= currentHash !== entry.sourceSha256;
+    }
+    if (changed) {
+      ids.push(entry.id);
+      expected.push(entry.sourceSha256);
+      actual.push(currentHash);
+    }
+  }
+  return { ids, expected, actual, hasAddition: ids.length === 0 };
+}
+
+async function targetHash(path: string): Promise<string | null> {
+  const stat = await lstatOrNull(path);
+  if (stat === null || !stat.isFile() || stat.isSymbolicLink()) return null;
+  try {
+    return sha256((await readRegularNoFollow(path, stat)).bytes);
+  } catch {
+    return null;
+  }
+}
+
+async function verifyTargets(journal: LegacyMigrationJournal): Promise<VerificationOutput[]> {
+  const outputs: VerificationOutput[] = [];
+  for (const entry of journal.manifest.entries) {
+    if (
+      entry.disposition !== "migrate" ||
+      entry.targetRelativePath === null ||
+      entry.outputSha256 === null
+    )
+      continue;
+    const target = join(journal.targetRoot, ...entry.targetRelativePath.split("/"));
+    const safe = await ensureSafeTargetDirectory(dirname(target), journal.targetRoot, false);
+    const actual = safe ? await targetHash(target) : null;
+    outputs.push({
+      entryId: entry.id,
+      expectedSha256: entry.outputSha256,
+      actualSha256: actual,
+      matches: actual === entry.outputSha256,
+    });
+  }
+  return outputs;
+}
+
+async function currentOutput(
+  entry: LegacyMigrationManifestEntry,
+  targetRoot: string,
+): Promise<{ source: Buffer; output: Buffer } | null> {
+  let source: Buffer;
+  try {
+    source = (await readRegularNoFollow(entry.sourcePath)).bytes;
+  } catch {
+    return null;
+  }
+  if (sha256(source) !== entry.sourceSha256) return null;
+  if (entry.transform === "config-v1") {
+    let transformed: Buffer;
+    try {
+      transformed = parseConfig(source, dirname(entry.sourcePath), targetRoot).output;
+    } catch {
+      return null;
+    }
+    if (sha256(transformed) !== entry.outputSha256) return null;
+    return { source, output: transformed };
+  }
+  return { source, output: source };
+}
+
+async function cleanupPayloadTemps(directory: string, basename: string): Promise<void> {
+  const escaped = basename.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const pattern = new RegExp(
+    `^\\.${escaped}\\.legacy-migration\\.tmp\\.\\d+\\.${UUID_PATTERN.source.slice(1, -1)}$`,
+    "i",
+  );
+  for (const name of await readdir(directory))
+    if (pattern.test(name)) await unlink(join(directory, name));
+}
+
+async function executePlan(
+  journalPath: string,
+  initial: LegacyMigrationJournal,
+  dependencies: Dependencies,
+): Promise<LegacyMigrationResult> {
+  let journal = initial;
+  const copiedThisCall: string[] = [];
+  const skippedThisCall: string[] = [];
+
+  for (const entry of journal.manifest.entries) {
+    if (
+      entry.disposition !== "migrate" ||
+      entry.targetRelativePath === null ||
+      entry.outputSha256 === null
+    )
+      continue;
+    const target = join(journal.targetRoot, ...entry.targetRelativePath.split("/"));
+    const directory = dirname(target);
+    if (!(await ensureSafeTargetDirectory(directory, journal.targetRoot, true))) {
+      journal = await publishRefusal(
+        journalPath,
+        journal,
+        dependencies,
+        "target-path-unsafe",
+        [entry.id],
+        [entry.outputSha256],
+        [null],
+      );
+      return refusal(journalPath, "target-path-unsafe", 3, journal.manifestDigest, [entry.id]);
+    }
+    await cleanupPayloadTemps(directory, target.slice(directory.length + 1));
+    const existing = await targetHash(target);
+    if (existing === entry.outputSha256) {
+      skippedThisCall.push(entry.id);
+      journal = nextJournal(journal, "copying", dependencies, (draft) => {
+        draft.results.skipVerifiedIds = manifestOrder(draft, [
+          ...draft.results.skipVerifiedIds,
+          entry.id,
+        ]);
+      });
+      await writeJournal(journalPath, journal, dependencies, entry.id);
+      await dependencies.checkpoint(
+        checkpointContext("after-payload-checkpoint", journal, entry.id),
+      );
+      continue;
+    }
+    if ((await lstatOrNull(target)) !== null) {
+      journal = await publishRefusal(
+        journalPath,
+        journal,
+        dependencies,
+        "target-conflict",
+        [entry.id],
+        [entry.outputSha256],
+        [existing],
+      );
+      return refusal(journalPath, "target-conflict", 3, journal.manifestDigest, [entry.id]);
+    }
+    const bytes = await currentOutput(entry, journal.targetRoot);
+    if (bytes === null) {
+      journal = await publishRefusal(
+        journalPath,
+        journal,
+        dependencies,
+        "source-drift",
+        [entry.id],
+        [entry.sourceSha256],
+        [null],
+      );
+      return refusal(journalPath, "source-drift", 3, journal.manifestDigest, [entry.id]);
+    }
+    const basename = target.slice(directory.length + 1);
+    const temp = await allocateTemp(
+      directory,
+      `.${basename}.legacy-migration.tmp.${process.pid}.`,
+      dependencies,
+    );
+    try {
+      await temp.handle.writeFile(bytes.output);
+      await temp.handle.chmod(0o600);
+      await temp.handle.sync();
+    } finally {
+      await temp.handle.close();
+    }
+    if ((await targetHash(temp.path)) !== entry.outputSha256) {
+      journal = await publishRefusal(
+        journalPath,
+        journal,
+        dependencies,
+        "verification-failed",
+        [entry.id],
+        [entry.outputSha256],
+        [await targetHash(temp.path)],
+      );
+      return refusal(journalPath, "verification-failed", 3, journal.manifestDigest, [entry.id]);
+    }
+    await dependencies.checkpoint(
+      checkpointContext("before-payload-publication", journal, entry.id),
+    );
+    const checked = await currentOutput(entry, journal.targetRoot);
+    if (checked === null) {
+      journal = await publishRefusal(
+        journalPath,
+        journal,
+        dependencies,
+        "source-drift",
+        [entry.id],
+        [entry.sourceSha256],
+        [null],
+      );
+      return refusal(journalPath, "source-drift", 3, journal.manifestDigest, [entry.id]);
+    }
+    try {
+      await dependencies.link(temp.path, target);
+    } catch (error) {
+      if (errorCode(error) === "EEXIST") {
+        const actual = await targetHash(target);
+        if (actual !== entry.outputSha256) {
+          journal = await publishRefusal(
+            journalPath,
+            journal,
+            dependencies,
+            "target-conflict",
+            [entry.id],
+            [entry.outputSha256],
+            [actual],
+          );
+          return refusal(journalPath, "target-conflict", 3, journal.manifestDigest, [entry.id]);
+        }
+        skippedThisCall.push(entry.id);
+      } else if (hardLinksUnsupported(error)) {
+        journal = await publishRefusal(
+          journalPath,
+          journal,
+          dependencies,
+          "no-clobber-unavailable",
+          [entry.id],
+          [entry.outputSha256],
+          [null],
+        );
+        return refusal(journalPath, "no-clobber-unavailable", 3, journal.manifestDigest, [
+          entry.id,
+        ]);
+      } else {
+        throw error;
+      }
+    }
+    if ((await lstatOrNull(target)) !== null) {
+      await syncDirectory(directory);
+      await unlink(temp.path);
+      await syncDirectory(directory);
+    }
+    const publishedHash = await targetHash(target);
+    if (publishedHash !== entry.outputSha256) {
+      journal = await publishRefusal(
+        journalPath,
+        journal,
+        dependencies,
+        "verification-failed",
+        [entry.id],
+        [entry.outputSha256],
+        [publishedHash],
+      );
+      return refusal(journalPath, "verification-failed", 3, journal.manifestDigest, [entry.id]);
+    }
+    if (!skippedThisCall.includes(entry.id)) copiedThisCall.push(entry.id);
+    journal = nextJournal(journal, "copying", dependencies, (draft) => {
+      if (copiedThisCall.includes(entry.id))
+        draft.results.copiedIds = manifestOrder(draft, [...draft.results.copiedIds, entry.id]);
+      else
+        draft.results.skipVerifiedIds = manifestOrder(draft, [
+          ...draft.results.skipVerifiedIds,
+          entry.id,
+        ]);
+    });
+    await writeJournal(journalPath, journal, dependencies, entry.id);
+    await dependencies.checkpoint(checkpointContext("after-payload-checkpoint", journal, entry.id));
+  }
+
+  const outputs = await verifyTargets(journal);
+  const mismatched = outputs.filter((output) => !output.matches);
+  journal = nextJournal(journal, "copying", dependencies, (draft) => {
+    draft.verification = { complete: true, allMatch: mismatched.length === 0, outputs };
+  });
+  await writeJournal(journalPath, journal, dependencies, mismatched[0]?.entryId ?? null);
+  if (mismatched.length > 0) {
+    journal = await publishRefusal(
+      journalPath,
+      journal,
+      dependencies,
+      "verification-failed",
+      mismatched.map((item) => item.entryId),
+      mismatched.map((item) => item.expectedSha256),
+      mismatched.map((item) => item.actualSha256),
+    );
+    return refusal(
+      journalPath,
+      "verification-failed",
+      3,
+      journal.manifestDigest,
+      mismatched.map((item) => item.entryId),
+    );
+  }
+  let rebuilt: Awaited<ReturnType<typeof rebuildForPinned>>;
+  try {
+    rebuilt = await rebuildForPinned(journal);
+  } catch (error) {
+    if (error instanceof PlanningRefusal) {
+      const difference = await differenceFromPinnedReads(journal);
+      journal = await publishRefusal(
+        journalPath,
+        journal,
+        dependencies,
+        "source-drift",
+        difference.ids,
+        difference.expected,
+        difference.actual,
+      );
+      return refusal(journalPath, "source-drift", 3, journal.manifestDigest, difference.ids);
+    }
+    throw error;
+  }
+  if (rebuilt.difference !== null) {
+    journal = await publishRefusal(
+      journalPath,
+      journal,
+      dependencies,
+      "source-drift",
+      rebuilt.difference.ids,
+      rebuilt.difference.expected,
+      rebuilt.difference.actual,
+    );
+    return refusal(journalPath, "source-drift", 3, journal.manifestDigest, rebuilt.difference.ids);
+  }
+  journal = nextJournal(journal, "verified", dependencies, (draft, at) => {
+    draft.verification = { complete: true, allMatch: true, outputs };
+    draft.freezePoint = at;
+  });
+  await writeJournal(journalPath, journal, dependencies);
+  const completion = journal.results.skippedConflictIds.length > 0 ? "partial" : "complete";
+  journal = nextJournal(journal, "done", dependencies, (draft) => {
+    draft.completion = completion;
+  });
+  await writeJournal(journalPath, journal, dependencies);
+  return {
+    status: "done",
+    exitCode: 0,
+    journalPath,
+    manifestDigest: journal.manifestDigest,
+    completion,
+    copiedIds: copiedThisCall,
+    skipVerifiedIds: skippedThisCall,
+    skippedConflictIds: journal.results.skippedConflictIds,
+    freezePoint: journal.freezePoint!,
+  };
+}
+
+async function finishVerified(
+  journalPath: string,
+  journal: LegacyMigrationJournal,
+  dependencies: Dependencies,
+): Promise<LegacyMigrationResult> {
+  let rebuilt: Awaited<ReturnType<typeof rebuildForPinned>>;
+  try {
+    rebuilt = await rebuildForPinned(journal);
+  } catch {
+    const difference = await differenceFromPinnedReads(journal);
+    const revised = await publishRefusal(
+      journalPath,
+      journal,
+      dependencies,
+      "source-drift",
+      difference.ids,
+      difference.expected,
+      difference.actual,
+    );
+    return refusal(journalPath, "source-drift", 3, revised.manifestDigest, difference.ids);
+  }
+  if (rebuilt.difference !== null) {
+    const revised = await publishRefusal(
+      journalPath,
+      journal,
+      dependencies,
+      "source-drift",
+      rebuilt.difference.ids,
+      rebuilt.difference.expected,
+      rebuilt.difference.actual,
+    );
+    return refusal(journalPath, "source-drift", 3, revised.manifestDigest, rebuilt.difference.ids);
+  }
+  const outputs = await verifyTargets(journal);
+  const mismatched = outputs.filter((output) => !output.matches);
+  if (mismatched.length > 0) {
+    const revised = await publishRefusal(
+      journalPath,
+      journal,
+      dependencies,
+      "verification-failed",
+      mismatched.map((item) => item.entryId),
+      mismatched.map((item) => item.expectedSha256),
+      mismatched.map((item) => item.actualSha256),
+    );
+    return refusal(
+      journalPath,
+      "verification-failed",
+      3,
+      revised.manifestDigest,
+      mismatched.map((item) => item.entryId),
+    );
+  }
+  const completion = journal.results.skippedConflictIds.length > 0 ? "partial" : "complete";
+  const done = nextJournal(journal, "done", dependencies, (draft) => {
+    draft.completion = completion;
+  });
+  await writeJournal(journalPath, done, dependencies);
+  return {
+    status: "done",
+    exitCode: 0,
+    journalPath,
+    manifestDigest: done.manifestDigest,
+    completion,
+    copiedIds: [],
+    skipVerifiedIds: [],
+    skippedConflictIds: done.results.skippedConflictIds,
+    freezePoint: done.freezePoint!,
+  };
+}
+
+async function rerunDone(
+  journalPath: string,
+  journal: LegacyMigrationJournal,
+): Promise<LegacyMigrationResult> {
+  let rebuilt: Awaited<ReturnType<typeof rebuildForPinned>>;
+  try {
+    rebuilt = await rebuildForPinned(journal);
+  } catch {
+    const difference = await differenceFromPinnedReads(journal);
+    return refusal(
+      journalPath,
+      "legacy-mutated-after-cutover",
+      3,
+      journal.manifestDigest,
+      difference.ids,
+    );
+  }
+  if (rebuilt.difference !== null)
+    return refusal(
+      journalPath,
+      "legacy-mutated-after-cutover",
+      3,
+      journal.manifestDigest,
+      rebuilt.difference.ids,
+    );
+  const outputs = await verifyTargets(journal);
+  const mismatched = outputs.filter((output) => !output.matches);
+  if (mismatched.length > 0)
+    return refusal(
+      journalPath,
+      "verification-failed",
+      3,
+      journal.manifestDigest,
+      mismatched.map((item) => item.entryId),
+    );
+  return {
+    status: "done",
+    exitCode: 0,
+    journalPath,
+    manifestDigest: journal.manifestDigest,
+    completion: journal.completion as "complete" | "partial",
+    copiedIds: [],
+    skipVerifiedIds: [],
+    skippedConflictIds: journal.results.skippedConflictIds,
+    freezePoint: journal.freezePoint!,
+  };
+}
+
+async function discardJournal(
+  journalPath: string,
+  journal: LegacyMigrationJournal,
+  dependencies: Dependencies,
+): Promise<LegacyMigrationResult> {
+  const controlRoot = dirname(journalPath);
+  const archivePath = join(controlRoot, `journal.discarded.${journal.manifestDigest}.json`);
+  let linked = false;
+  try {
+    await dependencies.link(journalPath, archivePath);
+    linked = true;
+  } catch (error) {
+    if (errorCode(error) === "EEXIST") {
+      const archiveStat = await lstatOrNull(archivePath);
+      if (
+        archiveStat === null ||
+        !archiveStat.isFile() ||
+        archiveStat.isSymbolicLink() ||
+        !privateFileMode(archiveStat)
+      )
+        return refusal(journalPath, "target-path-unsafe", 3, journal.manifestDigest);
+      const canonicalStat = await lstat(journalPath);
+      const [canonical, archive] = await Promise.all([
+        readRegularNoFollow(journalPath, canonicalStat),
+        readRegularNoFollow(archivePath, archiveStat),
+      ]);
+      if (!canonical.bytes.equals(archive.bytes))
+        return refusal(journalPath, "invalid-action", 2, journal.manifestDigest);
+    } else if (hardLinksUnsupported(error)) {
+      const revised = await publishRefusal(
+        journalPath,
+        journal,
+        dependencies,
+        "no-clobber-unavailable",
+        [],
+        [],
+        [],
+      );
+      return refusal(journalPath, "no-clobber-unavailable", 3, revised.manifestDigest);
+    } else throw error;
+  }
+  void linked;
+  await syncDirectory(controlRoot);
+  await dependencies.checkpoint(checkpointContext("after-discard-archive-link", journal, null));
+  await unlink(journalPath);
+  await syncDirectory(controlRoot);
+  await dependencies.checkpoint(checkpointContext("after-discard-journal-unlink", journal, null));
+  return {
+    status: "discarded",
+    exitCode: 0,
+    journalPath,
+    manifestDigest: journal.manifestDigest,
+    archivePath,
+  };
+}
+
+async function validateArchive(
+  controlRoot: string,
+  digest: string,
+  sourceRoot: string,
+  targetRoot: string,
+): Promise<boolean> {
+  if (!HASH_PATTERN.test(digest)) return false;
+  const path = join(controlRoot, `journal.discarded.${digest}.json`);
+  const stat = await lstatOrNull(path);
+  if (stat === null || !stat.isFile() || stat.isSymbolicLink() || !privateFileMode(stat))
+    return false;
+  let bytes: Buffer;
+  try {
+    bytes = (await readRegularNoFollow(path, stat)).bytes;
+  } catch {
+    return false;
+  }
+  const parsed = parseJournal(bytes, sourceRoot, targetRoot);
+  if (
+    parsed.journal === null ||
+    parsed.journal.manifestDigest !== digest ||
+    !["planned", "copying"].includes(parsed.journal.state)
+  )
+    return false;
+  try {
+    return !(await rootsOverlap(parsed.journal.dataRoot, targetRoot));
+  } catch {
+    return false;
+  }
+}
+
+function initialJournal(
+  inventory: InventoryBuild,
+  dependencies: Dependencies,
+  refusalValue: JournalRefusal | null,
+): LegacyMigrationJournal {
+  const at = dependencies.now().toISOString();
+  return {
+    schemaVersion: 1,
+    migrationId: LEGACY_MIGRATION_ID,
+    sourceRoot: inventory.manifest.sourceRoot,
+    dataRoot: inventory.manifest.dataRoot,
+    targetRoot: inventory.manifest.targetRoot,
+    manifestDigest: inventory.digest,
+    manifest: inventory.manifest,
+    state: "planned",
+    revision: 1,
+    history: [{ revision: 1, state: "planned", at }],
+    results: { copiedIds: [], skipVerifiedIds: [], skippedConflictIds: [] },
+    refusal: refusalValue,
+    verification: { complete: false, allMatch: false, outputs: [] },
+    completion: "pending",
+    freezePoint: null,
+  };
+}
+
+async function planFresh(
+  sourceRoot: string,
+  targetRoot: string,
+  journalPath: string,
+  dependencies: Dependencies,
+): Promise<LegacyMigrationResult> {
+  const inputs = await loadPlanningInputs(sourceRoot, targetRoot);
+  if (await rootsOverlap(inputs.config.dataRoot, targetRoot))
+    return refusal(journalPath, "source-target-overlap", 3, null);
+  const inventory = await makeInventory(
+    sourceRoot,
+    inputs.config.dataRoot,
+    targetRoot,
+    inputs.config,
+    inputs.authBytes,
+    true,
+  );
+  const refusing = inventory.manifest.entries.filter((entry) => entry.disposition === "refuse");
+  const conflicts = inventory.manifest.entries.filter((entry) => entry.requiresConfirmation);
+  let plannedRefusal: JournalRefusal | null = null;
+  if (refusing.length > 0)
+    plannedRefusal = {
+      code: "unsupported-credential-layout",
+      entryIds: refusing.map((entry) => entry.id),
+      expectedHashes: refusing.map(() => null),
+      actualHashes: refusing.map(() => null),
+    };
+  else if (conflicts.length > 0)
+    plannedRefusal = {
+      code: "confirmation-required",
+      entryIds: conflicts.map((entry) => entry.id),
+      expectedHashes: conflicts.map((entry) => entry.outputSha256),
+      actualHashes: conflicts.map((entry) => entry.targetActualSha256),
+    };
+  if (!(await ensureSafeTargetDirectory(dirname(journalPath), targetRoot, true)))
+    return refusal(journalPath, "target-path-unsafe", 3, null);
+  const journal = initialJournal(inventory, dependencies, plannedRefusal);
+  await writeJournal(journalPath, journal, dependencies);
+  if (refusing.length > 0)
+    return refusal(
+      journalPath,
+      "unsupported-credential-layout",
+      4,
+      inventory.digest,
+      refusing.map((entry) => entry.id),
+    );
+  if (conflicts.length > 0)
+    return refusal(
+      journalPath,
+      "confirmation-required",
+      2,
+      inventory.digest,
+      conflicts.map((entry) => entry.id),
+    );
+  return executePlan(journalPath, journal, dependencies);
+}
+
+export async function migrateLegacyHomeUnderLock(
+  options: LegacyMigrationOptions,
+  dependencies?: LegacyMigrationDependencies,
+): Promise<LegacyMigrationResult> {
+  const rawSource = options.sourceRoot;
+  const rawTarget = options.targetRoot;
+  const provisionalJournal =
+    typeof rawTarget === "string" && rawTarget.length > 0 && isAbsolute(rawTarget)
+      ? join(resolve(rawTarget), ...LEGACY_MIGRATION_CONTROL_RELATIVE.split("/"), "journal.json")
+      : join(resolve(sep), ...LEGACY_MIGRATION_CONTROL_RELATIVE.split("/"), "journal.json");
+  if (
+    typeof rawSource !== "string" ||
+    rawSource.length === 0 ||
+    !isAbsolute(rawSource) ||
+    typeof rawTarget !== "string" ||
+    rawTarget.length === 0 ||
+    !isAbsolute(rawTarget)
+  ) {
+    return refusal(provisionalJournal, "invalid-action", 2, null);
+  }
+  if (!validAction(options.action)) return refusal(provisionalJournal, "invalid-action", 2, null);
+  const sourceRoot = resolve(rawSource);
+  const targetRoot = resolve(rawTarget);
+  const controlRoot = join(targetRoot, ...LEGACY_MIGRATION_CONTROL_RELATIVE.split("/"));
+  const journalPath = join(controlRoot, "journal.json");
+  if (await rootsOverlap(sourceRoot, targetRoot))
+    return refusal(journalPath, "source-target-overlap", 3, null);
+  const deps: Dependencies = {
+    now: dependencies?.now ?? (() => new Date()),
+    randomId: dependencies?.randomId ?? (() => randomUUID()),
+    link: dependencies?.link ?? ((existingPath, newPath) => fsLink(existingPath, newPath)),
+    checkpoint: dependencies?.checkpoint ?? (() => undefined),
+  };
+  if (!(await ensureSafeTargetDirectory(controlRoot, targetRoot, false))) {
+    const targetStat = await lstatOrNull(targetRoot);
+    if (targetStat !== null) return refusal(journalPath, "target-path-unsafe", 3, null);
+  }
+  const existing = await readAndValidateJournal(journalPath, sourceRoot, targetRoot);
+  if (existing.unsafe) return refusal(journalPath, "target-path-unsafe", 3, null);
+  if (existing.exists && existing.journal === null)
+    return refusal(journalPath, "manifest-mismatch", 2, existing.digest);
+  if (existing.journal !== null) {
+    const journal = existing.journal;
+    if (options.action.kind === "confirm" || options.action.kind === "discard") {
+      if (options.action.manifestDigest !== journal.manifestDigest)
+        return refusal(journalPath, "manifest-mismatch", 2, journal.manifestDigest);
+    }
+    if (options.action.kind === "replan")
+      return refusal(journalPath, "invalid-action", 2, journal.manifestDigest);
+    if (options.action.kind === "discard") {
+      if (!["planned", "copying"].includes(journal.state))
+        return refusal(journalPath, "invalid-action", 2, journal.manifestDigest);
+      return discardJournal(journalPath, journal, deps);
+    }
+    if (options.action.kind === "confirm") {
+      const conflicts = journal.manifest.entries.filter(
+        (entry) => entry.reason === "target-conflict",
+      );
+      const refusing = journal.manifest.entries.some((entry) => entry.disposition === "refuse");
+      if (journal.state !== "planned" || conflicts.length === 0 || refusing)
+        return refusal(journalPath, "invalid-action", 2, journal.manifestDigest);
+      const confirmed = nextJournal(journal, "copying", deps, (draft) => {
+        draft.results.skippedConflictIds = conflicts.map((entry) => entry.id);
+      });
+      await writeJournal(journalPath, confirmed, deps);
+      return executePlan(journalPath, confirmed, deps);
+    }
+    if (journal.state === "done") return rerunDone(journalPath, journal);
+    if (journal.state === "verified") return finishVerified(journalPath, journal, deps);
+    if (journal.state === "planned" && journal.refusal !== null)
+      return refusal(
+        journalPath,
+        "pinned-refusal",
+        2,
+        journal.manifestDigest,
+        journal.refusal.entryIds,
+      );
+    let rebuilt: Awaited<ReturnType<typeof rebuildForPinned>>;
+    try {
+      rebuilt = await rebuildForPinned(journal);
+    } catch {
+      const difference = await differenceFromPinnedReads(journal);
+      const revised = await publishRefusal(
+        journalPath,
+        journal,
+        deps,
+        "source-drift",
+        difference.ids,
+        difference.expected,
+        difference.actual,
+      );
+      return refusal(journalPath, "source-drift", 3, revised.manifestDigest, difference.ids);
+    }
+    if (rebuilt.difference !== null) {
+      const revised = await publishRefusal(
+        journalPath,
+        journal,
+        deps,
+        "source-drift",
+        rebuilt.difference.ids,
+        rebuilt.difference.expected,
+        rebuilt.difference.actual,
+      );
+      return refusal(
+        journalPath,
+        "source-drift",
+        3,
+        revised.manifestDigest,
+        rebuilt.difference.ids,
+      );
+    }
+    return executePlan(journalPath, journal, deps);
+  }
+  if (options.action.kind === "confirm" || options.action.kind === "discard")
+    return refusal(journalPath, "invalid-action", 2, null);
+  if (
+    options.action.kind === "replan" &&
+    !(await validateArchive(
+      controlRoot,
+      options.action.discardedManifestDigest,
+      sourceRoot,
+      targetRoot,
+    ))
+  )
+    return refusal(journalPath, "manifest-mismatch", 2, null);
+  const sourceStat = await lstatOrNull(sourceRoot);
+  if (sourceStat === null)
+    return { status: "not-needed", exitCode: 0, journalPath, manifestDigest: null };
+  if (!sourceStat.isDirectory() || sourceStat.isSymbolicLink())
+    return refusal(journalPath, "invalid-source-config", 4, null);
+  try {
+    return await planFresh(sourceRoot, targetRoot, journalPath, deps);
+  } catch (error) {
+    if (error instanceof PlanningRefusal)
+      return refusal(journalPath, error.code, error.exitCode, null);
+    throw error;
+  }
+}

--- a/packages/coach/tests/legacy-migration.test.ts
+++ b/packages/coach/tests/legacy-migration.test.ts
@@ -1,0 +1,1094 @@
+import { createHash } from "node:crypto";
+import {
+  chmod,
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  readlink,
+  realpath,
+  rm,
+  symlink,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, relative } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  LEGACY_MIGRATION_CONTROL_RELATIVE,
+  LEGACY_MIGRATION_NON_TTY_REFUSAL_EXIT_CODE,
+  migrateLegacyHomeUnderLock,
+  type LegacyMigrationDependencies,
+  type LegacyMigrationResult,
+} from "../src/legacy-migration.js";
+
+interface EntryView {
+  id: string;
+  sourceOwner: string;
+  sourcePath: string;
+  sourceRelativePath: string;
+  fileType: string;
+  disposition: string;
+  reason: string;
+  targetRelativePath: string | null;
+  sourceSha256: string | null;
+  outputSha256: string | null;
+  targetAtPlan: string | null;
+  targetActualSha256: string | null;
+  requiresConfirmation: boolean;
+}
+
+interface JournalView {
+  manifestDigest: string;
+  state: string;
+  revision: number;
+  history: Array<{ revision: number; state: string; at: string }>;
+  manifest: { entries: EntryView[]; dataRoot: string };
+  results: { copiedIds: string[]; skipVerifiedIds: string[]; skippedConflictIds: string[] };
+  refusal: null | {
+    code: string;
+    entryIds: string[];
+    expectedHashes: Array<string | null>;
+    actualHashes: Array<string | null>;
+  };
+  verification: {
+    complete: boolean;
+    allMatch: boolean;
+    outputs: Array<{ entryId: string; matches: boolean }>;
+  };
+  completion: string;
+  freezePoint: string | null;
+}
+
+interface Fixture {
+  parent: string;
+  source: string;
+  target: string;
+}
+
+const parents: string[] = [];
+let uuidCounter = 0;
+
+afterEach(async () => {
+  for (const parent of parents.splice(0)) await rm(parent, { recursive: true, force: true });
+  uuidCounter = 0;
+  vi.restoreAllMocks();
+});
+
+function deterministicUuid(): string {
+  uuidCounter += 1;
+  return `00000000-0000-4000-8000-${String(uuidCounter).padStart(12, "0")}`;
+}
+
+function dependencies(overrides: LegacyMigrationDependencies = {}): LegacyMigrationDependencies {
+  let tick = 0;
+  return {
+    now: () => new Date(Date.UTC(1998, 6, 18, 12, 0, tick++)),
+    randomId: deterministicUuid,
+    ...overrides,
+  };
+}
+
+async function makeFixture(
+  config = "llm:\n  provider: anthropic\nunknown: preserved\n",
+): Promise<Fixture> {
+  const parent = await mkdtemp(join(await realpath(tmpdir()), "legacy-migration-"));
+  parents.push(parent);
+  const source = join(parent, "legacy");
+  const target = join(parent, "new-home");
+  await mkdir(source, { mode: 0o700 });
+  await write(source, "config.yaml", config);
+  return { parent, source, target };
+}
+
+async function write(
+  root: string,
+  path: string,
+  value: string | Buffer,
+  mode = 0o600,
+): Promise<void> {
+  const destination = join(root, ...path.split("/"));
+  await mkdir(dirname(destination), { recursive: true, mode: 0o700 });
+  await writeFile(destination, value, { mode });
+  await chmod(destination, mode);
+}
+
+async function privateDirectory(path: string): Promise<void> {
+  await mkdir(path, { recursive: true, mode: 0o700 });
+  await chmod(path, 0o700);
+}
+
+async function seedPayload(fixture: Fixture): Promise<void> {
+  await write(
+    fixture.source,
+    "auth-profiles.json",
+    JSON.stringify({
+      "openai-codex": {
+        type: "oauth",
+        access: "access",
+        refresh: "refresh",
+        expires: 946684800000,
+      },
+    }),
+  );
+  await write(fixture.source, "memory/MEMORY.md", "durable memory\n");
+  await write(fixture.source, "memory/1998-07-18.md", "daily note\n");
+  await write(fixture.source, "memory/MEMORY.history.jsonl", '{"memory":1}\n');
+  await write(fixture.source, "memory/events.jsonl", '{"event":1}\n');
+  await write(fixture.source, "plans/current-plan.json", '{"week":1}\n');
+}
+
+function journalPath(fixture: Fixture): string {
+  return join(fixture.target, ...LEGACY_MIGRATION_CONTROL_RELATIVE.split("/"), "journal.json");
+}
+
+async function journal(fixture: Fixture): Promise<JournalView> {
+  return JSON.parse(await readFile(journalPath(fixture), "utf8")) as JournalView;
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await lstat(path);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw error;
+  }
+}
+
+async function snapshotByteTree(root: string): Promise<string> {
+  const hash = createHash("sha256");
+  if (!(await exists(root))) return hash.update("absent").digest("hex");
+  async function walk(directory: string): Promise<void> {
+    const names = (await readdir(directory)).sort();
+    for (const name of names) {
+      const path = join(directory, name);
+      const stat = await lstat(path);
+      const rel = relative(root, path).split("/").join("/");
+      if (stat.isDirectory() && !stat.isSymbolicLink()) {
+        hash.update(`${rel}\0directory\0`);
+        await walk(path);
+      } else if (stat.isSymbolicLink()) {
+        hash.update(`${rel}\0symlink\0${await readlink(path)}\0`);
+      } else if (stat.isFile()) {
+        hash.update(`${rel}\0regular\0`);
+        hash.update(await readFile(path));
+      } else hash.update(`${rel}\0other\0`);
+    }
+  }
+  await walk(root);
+  return hash.digest("hex");
+}
+
+async function preserving<T>(roots: string[], operation: () => Promise<T>): Promise<T> {
+  const before = await Promise.all(roots.map(snapshotByteTree));
+  try {
+    return await operation();
+  } finally {
+    expect(await Promise.all(roots.map(snapshotByteTree))).toEqual(before);
+  }
+}
+
+function expectRefused(
+  result: LegacyMigrationResult,
+  reason: string,
+  exitCode?: number,
+): asserts result is Extract<LegacyMigrationResult, { status: "refused" }> {
+  expect(result.status).toBe("refused");
+  if (result.status !== "refused") throw new Error("expected refusal");
+  expect(result.reason).toBe(reason);
+  if (exitCode !== undefined) expect(result.exitCode).toBe(exitCode);
+}
+
+async function migrate(
+  fixture: Fixture,
+  overrides: LegacyMigrationDependencies = {},
+): Promise<LegacyMigrationResult> {
+  return migrateLegacyHomeUnderLock(
+    {
+      sourceRoot: fixture.source,
+      targetRoot: fixture.target,
+      action: { kind: "resume", isTTY: true },
+    },
+    dependencies(overrides),
+  );
+}
+
+async function cleanDoneFixture(): Promise<{
+  fixture: Fixture;
+  result: Extract<LegacyMigrationResult, { status: "done" }>;
+}> {
+  const fixture = await makeFixture();
+  await seedPayload(fixture);
+  const result = await migrate(fixture);
+  expect(result.status).toBe("done");
+  if (result.status !== "done") throw new Error("expected done");
+  return { fixture, result };
+}
+
+describe("legacy home migration", () => {
+  it("clean copy reaches done only after verification", async () => {
+    const fixture = await makeFixture();
+    await seedPayload(fixture);
+    await preserving([fixture.source], async () => {
+      const result = await migrate(fixture);
+      expect(result).toMatchObject({ status: "done", completion: "complete", exitCode: 0 });
+      for (const path of [
+        "config/config.yaml",
+        "config/auth-profiles.json",
+        "memory/MEMORY.md",
+        "memory/1998-07-18.md",
+        "memory/MEMORY.history.jsonl",
+        "memory/events.jsonl",
+        "plans/current-plan.json",
+      ])
+        expect(await exists(join(fixture.target, path))).toBe(true);
+      const view = await journal(fixture);
+      expect(view.history.map((row) => row.state)).toEqual(
+        expect.arrayContaining(["planned", "copying", "verified", "done"]),
+      );
+      expect(view.verification).toMatchObject({ complete: true, allMatch: true });
+      expect(view.freezePoint).toBeTruthy();
+    });
+  });
+
+  it("done rerun validates cutover without copying", async () => {
+    for (const kind of ["clean", "target", "change", "add", "delete"] as const) {
+      const { fixture } = await cleanDoneFixture();
+      const sourceBefore = await snapshotByteTree(fixture.source);
+      const journalBefore = await readFile(journalPath(fixture));
+      const targetBefore = await snapshotByteTree(fixture.target);
+      let restore: (() => Promise<void>) | undefined;
+      if (kind === "target") {
+        const path = join(fixture.target, "memory/MEMORY.md");
+        await writeFile(path, "tampered");
+        restore = async () => writeFile(path, "durable memory\n");
+      }
+      if (kind === "change") {
+        const path = join(fixture.source, "memory/MEMORY.md");
+        await writeFile(path, "changed");
+        restore = async () => writeFile(path, "durable memory\n");
+      }
+      if (kind === "add") {
+        const path = join(fixture.source, "new.txt");
+        await writeFile(path, "new");
+        restore = async () => unlink(path);
+      }
+      if (kind === "delete") {
+        const path = join(fixture.source, "memory/events.jsonl");
+        await unlink(path);
+        restore = async () => writeFile(path, '{"event":1}\n', { mode: 0o600 });
+      }
+      const result = await migrate(fixture);
+      if (kind === "clean")
+        expect(result).toMatchObject({ status: "done", copiedIds: [], skipVerifiedIds: [] });
+      else if (kind === "target") expectRefused(result, "verification-failed", 3);
+      else expectRefused(result, "legacy-mutated-after-cutover", 3);
+      expect(await readFile(journalPath(fixture))).toEqual(journalBefore);
+      if (kind !== "target") expect(await snapshotByteTree(fixture.target)).toBe(targetBefore);
+      await restore?.();
+      expect(await snapshotByteTree(fixture.source)).toBe(sourceBefore);
+    }
+  });
+
+  it("identical target collision is skip-verified", async () => {
+    const fixture = await makeFixture();
+    await write(fixture.source, "memory/MEMORY.md", "same");
+    await privateDirectory(join(fixture.target, "memory"));
+    await write(fixture.target, "memory/MEMORY.md", "same");
+    await preserving([fixture.source], async () => {
+      const result = await migrate(fixture);
+      expect(result).toMatchObject({ status: "done", completion: "complete" });
+      if (result.status === "done") expect(result.skipVerifiedIds.length).toBeGreaterThan(0);
+      expect(await readFile(join(fixture.target, "memory/MEMORY.md"), "utf8")).toBe("same");
+    });
+  });
+
+  it("different target collision refuses before any payload copy", async () => {
+    const fixture = await makeFixture();
+    await seedPayload(fixture);
+    await privateDirectory(join(fixture.target, "memory"));
+    await write(fixture.target, "memory/MEMORY.md", "newer");
+    const payloadBefore = await snapshotByteTree(join(fixture.target, "memory"));
+    await preserving([fixture.source], async () => {
+      const first = await migrate(fixture);
+      expectRefused(first, "confirmation-required", 2);
+      const second = await migrate(fixture);
+      expectRefused(second, "pinned-refusal", 2);
+      expect(await snapshotByteTree(join(fixture.target, "memory"))).toBe(payloadBefore);
+      expect((await journal(fixture)).state).toBe("planned");
+    });
+  });
+
+  it("symlinks, cycles, and regular-to-symlink swaps are never followed", async () => {
+    const fixture = await makeFixture();
+    await write(fixture.source, "memory/MEMORY.md", "safe");
+    await write(fixture.parent, "outside", "secret");
+    await symlink(join(fixture.parent, "outside"), join(fixture.source, "outside-link"));
+    await symlink(fixture.source, join(fixture.source, "cycle"));
+    const original = await readFile(join(fixture.source, "memory/MEMORY.md"));
+    await preserving([fixture.source], async () => {
+      let swapped = false;
+      const result = await migrate(fixture, {
+        checkpoint: async (context) => {
+          if (
+            !swapped &&
+            context.checkpoint === "before-payload-publication" &&
+            context.entryId !== null
+          ) {
+            const view = await journal(fixture);
+            const entry = view.manifest.entries.find(
+              (candidate) => candidate.id === context.entryId,
+            );
+            if (entry?.sourceRelativePath === "memory/MEMORY.md") {
+              swapped = true;
+              await unlink(entry.sourcePath);
+              await symlink(join(fixture.parent, "outside"), entry.sourcePath);
+            }
+          }
+        },
+      });
+      expectRefused(result, "source-drift", 3);
+      expect(await exists(join(fixture.target, "memory/MEMORY.md"))).toBe(false);
+      if (swapped) {
+        await unlink(join(fixture.source, "memory/MEMORY.md"));
+        await writeFile(join(fixture.source, "memory/MEMORY.md"), original, { mode: 0o600 });
+      }
+    });
+  });
+
+  it("data-root ownership is deterministic", async () => {
+    for (const kind of ["equal", "external", "child", "parent"] as const) {
+      const fixture = await makeFixture();
+      let dataRoot = fixture.source;
+      if (kind === "external") dataRoot = join(fixture.parent, "data");
+      if (kind === "child") dataRoot = join(fixture.source, "data-home");
+      if (kind === "parent") {
+        dataRoot = join(fixture.parent, "data-parent");
+        fixture.source = join(dataRoot, "legacy");
+        await mkdir(fixture.source, { recursive: true });
+      }
+      await privateDirectory(dataRoot);
+      await write(dataRoot, "memory/MEMORY.md", `${kind}-authoritative`);
+      await write(
+        fixture.source,
+        "config.yaml",
+        `data_dir: ${dataRoot}\nllm:\n  provider: anthropic\n`,
+      );
+      if (dataRoot !== fixture.source) await write(fixture.source, "memory/MEMORY.md", "shadowed");
+      await preserving([...new Set([fixture.source, dataRoot])], async () => {
+        const result = await migrate(fixture);
+        expect(result.status).toBe("done");
+        expect(await readFile(join(fixture.target, "memory/MEMORY.md"), "utf8")).toBe(
+          `${kind}-authoritative`,
+        );
+        const view = await journal(fixture);
+        expect(new Set(view.manifest.entries.map((entry) => entry.sourcePath)).size).toBe(
+          view.manifest.entries.length,
+        );
+        const memory = view.manifest.entries.find(
+          (entry) => entry.sourcePath === join(dataRoot, "memory/MEMORY.md"),
+        );
+        expect(memory?.sourceOwner).toBe(kind === "equal" ? "legacy-root" : "data-root");
+      });
+    }
+  });
+
+  it("mid-copy crash after two payload checkpoints resumes", async () => {
+    const fixture = await makeFixture();
+    await seedPayload(fixture);
+    let count = 0;
+    await preserving([fixture.source], async () => {
+      await expect(
+        migrate(fixture, {
+          checkpoint: (context) => {
+            if (context.checkpoint === "after-payload-checkpoint" && ++count === 2)
+              throw new Error("crash");
+          },
+        }),
+      ).rejects.toThrow("crash");
+      expect((await journal(fixture)).state).toBe("copying");
+      const result = await migrate(fixture);
+      expect(result.status).toBe("done");
+      if (result.status === "done") expect(result.skipVerifiedIds).toHaveLength(2);
+    });
+  });
+
+  it("crash around initial journal publication resumes", async () => {
+    for (const checkpoint of ["before-journal-rename", "after-journal-rename"] as const) {
+      const fixture = await makeFixture();
+      await write(fixture.source, "memory/MEMORY.md", "memory");
+      let injected = false;
+      await preserving([fixture.source], async () => {
+        await expect(
+          migrate(fixture, {
+            checkpoint: (context) => {
+              if (!injected && context.checkpoint === checkpoint) {
+                injected = true;
+                throw new Error(checkpoint);
+              }
+            },
+          }),
+        ).rejects.toThrow(checkpoint);
+        expect(await exists(journalPath(fixture))).toBe(checkpoint === "after-journal-rename");
+        expect((await migrate(fixture)).status).toBe("done");
+      });
+    }
+  });
+
+  it("config transform strips only telegram token, rewrites data_dir, and carries OAuth", async () => {
+    const fixture = await makeFixture(
+      "# comment\nllm:\n  provider: openai-codex\n  auth_profile: athlete\ntelegram:\n  bot_token: !secret token-ref\n  chat_id: 42\nintervals:\n  api_key: !secret intervals-ref\nfuture: yes\n",
+    );
+    const profiles = {
+      athlete: {
+        type: "oauth",
+        access: "a",
+        refresh: "r",
+        expires: 1,
+        accountId: "id",
+        email: "a@example.test",
+      },
+    };
+    await write(fixture.source, "auth-profiles.json", JSON.stringify(profiles));
+    await preserving([fixture.source], async () => {
+      expect((await migrate(fixture)).status).toBe("done");
+      const output = await readFile(join(fixture.target, "config/config.yaml"), "utf8");
+      expect(output).not.toContain("bot_token");
+      expect(output).toContain("chat_id: 42");
+      expect(output).toContain("intervals-ref");
+      expect(output).toContain("future: yes");
+      expect(output).toContain(`data_dir: ${fixture.target}`);
+      expect(await readFile(join(fixture.target, "config/auth-profiles.json"), "utf8")).toBe(
+        JSON.stringify(profiles),
+      );
+    });
+  });
+
+  it("confirmed immutable conflict plan completes partial without copying conflicts", async () => {
+    const fixture = await makeFixture();
+    await seedPayload(fixture);
+    await privateDirectory(join(fixture.target, "memory"));
+    await write(fixture.target, "memory/MEMORY.md", "keep");
+    await preserving([fixture.source], async () => {
+      const planned = await migrate(fixture);
+      expectRefused(planned, "confirmation-required");
+      const result = await migrateLegacyHomeUnderLock(
+        {
+          sourceRoot: fixture.source,
+          targetRoot: fixture.target,
+          action: { kind: "confirm", manifestDigest: planned.manifestDigest! },
+        },
+        dependencies(),
+      );
+      expect(result).toMatchObject({ status: "done", completion: "partial" });
+      expect(await readFile(join(fixture.target, "memory/MEMORY.md"), "utf8")).toBe("keep");
+      expect((await journal(fixture)).results.skippedConflictIds).toEqual(planned.conflictIds);
+    });
+  });
+
+  it("non-TTY conflict refusal uses exit 2 and never reads stdin", async () => {
+    const fixture = await makeFixture();
+    await write(fixture.source, "memory/MEMORY.md", "old");
+    await privateDirectory(join(fixture.target, "memory"));
+    await write(fixture.target, "memory/MEMORY.md", "new");
+    const stdin = vi.spyOn(process.stdin, "read");
+    const result = await migrateLegacyHomeUnderLock(
+      {
+        sourceRoot: fixture.source,
+        targetRoot: fixture.target,
+        action: { kind: "resume", isTTY: false },
+      },
+      dependencies(),
+    );
+    expectRefused(result, "confirmation-required", LEGACY_MIGRATION_NON_TTY_REFUSAL_EXIT_CODE);
+    expect(stdin).not.toHaveBeenCalled();
+  });
+
+  it("discard archives without clobber and recovers each boundary", async () => {
+    for (const kind of [
+      "normal",
+      "identical",
+      "different",
+      "after-link",
+      "after-unlink",
+    ] as const) {
+      const fixture = await makeFixture();
+      await write(fixture.source, "memory/MEMORY.md", "old");
+      await privateDirectory(join(fixture.target, "memory"));
+      await write(fixture.target, "memory/MEMORY.md", "new");
+      const planned = await migrate(fixture);
+      expectRefused(planned, "confirmation-required");
+      const archive = join(
+        dirname(journalPath(fixture)),
+        `journal.discarded.${planned.manifestDigest}.json`,
+      );
+      if (kind === "identical")
+        await writeFile(archive, await readFile(journalPath(fixture)), { mode: 0o600 });
+      if (kind === "different") await writeFile(archive, "different", { mode: 0o600 });
+      const checkpoint =
+        kind === "after-link"
+          ? "after-discard-archive-link"
+          : kind === "after-unlink"
+            ? "after-discard-journal-unlink"
+            : null;
+      const action = migrateLegacyHomeUnderLock(
+        {
+          sourceRoot: fixture.source,
+          targetRoot: fixture.target,
+          action: { kind: "discard", manifestDigest: planned.manifestDigest! },
+        },
+        dependencies({
+          checkpoint: (context) => {
+            if (context.checkpoint === checkpoint) throw new Error(kind);
+          },
+        }),
+      );
+      if (kind === "different") {
+        const result = await action;
+        expectRefused(result, "invalid-action", 2);
+        expect(await exists(journalPath(fixture))).toBe(true);
+      } else if (checkpoint !== null) {
+        await expect(action).rejects.toThrow(kind);
+        expect(await exists(archive)).toBe(true);
+        expect(await exists(journalPath(fixture))).toBe(kind === "after-link");
+      } else {
+        const result = await action;
+        expect(result.status).toBe("discarded");
+        expect(await exists(archive)).toBe(true);
+        expect(await exists(journalPath(fixture))).toBe(false);
+      }
+    }
+  });
+
+  it("replan requires a matching discarded digest and observes current bytes only after explicit replan", async () => {
+    const fixture = await makeFixture();
+    await write(fixture.source, "memory/MEMORY.md", "old");
+    await privateDirectory(join(fixture.target, "memory"));
+    await write(fixture.target, "memory/MEMORY.md", "new");
+    const planned = await migrate(fixture);
+    expectRefused(planned, "confirmation-required");
+    await unlink(join(fixture.target, "memory/MEMORY.md"));
+    expectRefused(await migrate(fixture), "pinned-refusal");
+    const discarded = await migrateLegacyHomeUnderLock(
+      {
+        sourceRoot: fixture.source,
+        targetRoot: fixture.target,
+        action: { kind: "discard", manifestDigest: planned.manifestDigest! },
+      },
+      dependencies(),
+    );
+    expect(discarded.status).toBe("discarded");
+    expectRefused(
+      await migrateLegacyHomeUnderLock(
+        {
+          sourceRoot: fixture.source,
+          targetRoot: fixture.target,
+          action: { kind: "replan", discardedManifestDigest: "0".repeat(64), isTTY: true },
+        },
+        dependencies(),
+      ),
+      "manifest-mismatch",
+    );
+    const result = await migrateLegacyHomeUnderLock(
+      {
+        sourceRoot: fixture.source,
+        targetRoot: fixture.target,
+        action: { kind: "replan", discardedManifestDigest: planned.manifestDigest!, isTTY: true },
+      },
+      dependencies(),
+    );
+    expect(result.status).toBe("done");
+  });
+
+  it("fresh journal temps and stale-temp cleanup survive abandoned revision temps", async () => {
+    const fixture = await makeFixture();
+    await privateDirectory(dirname(journalPath(fixture)));
+    await writeFile(
+      join(
+        dirname(journalPath(fixture)),
+        "journal.json.tmp.123.00000000-0000-4000-8000-000000000999",
+      ),
+      "stale",
+      { mode: 0o600 },
+    );
+    expect((await migrate(fixture)).status).toBe("done");
+    expect(
+      (await readdir(dirname(journalPath(fixture)))).some((name) => name.includes("000000000999")),
+    ).toBe(false);
+  });
+
+  it("payload stale-temp cleanup removes only exact migration-temp names", async () => {
+    const fixture = await makeFixture();
+    await write(fixture.source, "memory/MEMORY.md", "memory");
+    await privateDirectory(join(fixture.target, "memory"));
+    await write(
+      fixture.target,
+      "memory/.MEMORY.md.legacy-migration.tmp.123.00000000-0000-4000-8000-000000000999",
+      "stale",
+    );
+    await write(fixture.target, "memory/.MEMORY.md.unrelated.tmp", "keep");
+    expect((await migrate(fixture)).status).toBe("done");
+    expect(
+      await exists(
+        join(
+          fixture.target,
+          "memory/.MEMORY.md.legacy-migration.tmp.123.00000000-0000-4000-8000-000000000999",
+        ),
+      ),
+    ).toBe(false);
+    expect(await exists(join(fixture.target, "memory/.MEMORY.md.unrelated.tmp"))).toBe(true);
+  });
+
+  it("source drift is checked before publication and before verified", async () => {
+    for (const stage of ["publication", "final"] as const) {
+      const fixture = await makeFixture();
+      await write(fixture.source, "memory/MEMORY.md", "original");
+      const original = await readFile(join(fixture.source, "memory/MEMORY.md"));
+      let changed = false;
+      const result = await migrate(fixture, {
+        checkpoint: async (context) => {
+          if (
+            !changed &&
+            ((stage === "publication" && context.checkpoint === "before-payload-publication") ||
+              (stage === "final" &&
+                context.checkpoint === "after-payload-checkpoint" &&
+                (await exists(join(fixture.target, "memory/MEMORY.md")))))
+          ) {
+            changed = true;
+            await writeFile(join(fixture.source, "memory/MEMORY.md"), "changed");
+          }
+        },
+      });
+      expectRefused(result, "source-drift", 3);
+      expect(["verified", "done"]).not.toContain((await journal(fixture)).state);
+      await writeFile(join(fixture.source, "memory/MEMORY.md"), original, { mode: 0o600 });
+    }
+  });
+
+  it("hard-link unsupported refuses with no-clobber-unavailable", async () => {
+    const fixture = await makeFixture();
+    await write(fixture.source, "memory/MEMORY.md", "memory");
+    const error = Object.assign(new Error("unsupported"), { code: "ENOTSUP" });
+    const result = await migrate(fixture, {
+      link: async () => {
+        throw error;
+      },
+    });
+    expectRefused(result, "no-clobber-unavailable", 3);
+    expect(await exists(join(fixture.target, "memory/MEMORY.md"))).toBe(false);
+  });
+
+  it("target path and identity cannot escape", async () => {
+    for (const kind of [
+      "root-link",
+      "config-link",
+      "payload-link",
+      "physical-alias",
+      "absent-alias",
+    ] as const) {
+      const fixture = await makeFixture();
+      await write(fixture.source, "memory/MEMORY.md", "memory");
+      const outside = join(fixture.parent, "outside");
+      await privateDirectory(outside);
+      if (kind === "root-link") await symlink(outside, fixture.target);
+      if (kind === "config-link") {
+        await privateDirectory(fixture.target);
+        await symlink(outside, join(fixture.target, "config"));
+      }
+      if (kind === "payload-link") {
+        await privateDirectory(fixture.target);
+        await symlink(outside, join(fixture.target, "memory"));
+      }
+      if (kind === "physical-alias") fixture.target = await realpath(fixture.source);
+      if (kind === "absent-alias") fixture.target = join(fixture.source, "future", "home");
+      const result = await migrate(fixture);
+      expectRefused(
+        result,
+        kind.includes("alias") ? "source-target-overlap" : "target-path-unsafe",
+        3,
+      );
+      expect(await readdir(outside)).toEqual([]);
+    }
+  });
+
+  it("control namespace is excluded from payload conflicts and destination layout is exact", async () => {
+    const fixture = await makeFixture();
+    await write(fixture.source, "memory/MEMORY.md", "memory");
+    await privateDirectory(dirname(journalPath(fixture)));
+    await writeFile(join(dirname(journalPath(fixture)), "unrelated-control"), "control", {
+      mode: 0o600,
+    });
+    expect((await migrate(fixture)).status).toBe("done");
+    expect(await readFile(join(dirname(journalPath(fixture)), "unrelated-control"), "utf8")).toBe(
+      "control",
+    );
+    expect((await readdir(fixture.target)).sort()).toEqual(["config", "memory"]);
+  });
+
+  it("disposition inventory covers every excluded class", async () => {
+    const fixture = await makeFixture();
+    const cases: Array<[string, string, string]> = [
+      ["allowed-senders.json", "defer", "telegram-guided-import"],
+      [".allowed-senders.lock", "skip", "transient-allowlist-lock"],
+      ["sessions/telegram:1.jsonl", "defer", "telegram-channel-state"],
+      ["sessions/cli.jsonl", "skip", "fresh-cli-session"],
+      ["data/cache.json", "skip", "re-derivable"],
+      ["logs/run.log", "skip", "diagnostic"],
+      ["usage-ledger.jsonl.old", "skip", "diagnostic"],
+      ["instance-id", "skip", "machine-local"],
+      ["last-notified-version", "skip", "machine-local"],
+      ["last-run.json", "skip", "machine-local"],
+      ["store/db", "skip", "reserved-namespace"],
+      ["archive/old", "skip", "reserved-namespace"],
+      ["config/old", "skip", "reserved-namespace"],
+      ["unknown.txt", "skip", "unrecognized"],
+    ];
+    for (const [path] of cases) await write(fixture.source, path, path);
+    await symlink("unknown.txt", join(fixture.source, "unknown-link"));
+    expect((await migrate(fixture)).status).toBe("done");
+    const view = await journal(fixture);
+    for (const [path, disposition, reason] of cases)
+      expect(
+        view.manifest.entries.find((entry) => entry.sourceRelativePath === path),
+      ).toMatchObject({ disposition, reason, targetRelativePath: null });
+    expect(
+      view.manifest.entries.find((entry) => entry.sourceRelativePath === "unknown-link"),
+    ).toMatchObject({ fileType: "symlink", disposition: "skip", reason: "symlink" });
+  });
+
+  it("raw roots reject before I/O", async () => {
+    const fixture = await makeFixture();
+    const before = await snapshotByteTree(fixture.parent);
+    for (const root of ["", ".", "relative/child"]) {
+      for (const side of ["source", "target"] as const) {
+        const result = await migrateLegacyHomeUnderLock({
+          sourceRoot: side === "source" ? root : fixture.source,
+          targetRoot: side === "target" ? root : fixture.target,
+          action: { kind: "resume", isTTY: false },
+        });
+        expect(result).toMatchObject({
+          status: "refused",
+          reason: "invalid-action",
+          exitCode: 2,
+          manifestDigest: null,
+          conflictIds: [],
+        });
+      }
+    }
+    expect(await snapshotByteTree(fixture.parent)).toBe(before);
+  });
+
+  it("source and data roots cannot overlap target", async () => {
+    for (const kind of [
+      "equal",
+      "parent",
+      "child",
+      "data-equal",
+      "data-parent",
+      "data-child",
+    ] as const) {
+      const fixture = await makeFixture();
+      if (kind === "equal") fixture.target = fixture.source;
+      if (kind === "parent") fixture.target = fixture.parent;
+      if (kind === "child") fixture.target = join(fixture.source, "new");
+      if (kind.startsWith("data")) {
+        const data =
+          kind === "data-equal"
+            ? fixture.target
+            : kind === "data-parent"
+              ? fixture.parent
+              : join(fixture.target, "data");
+        await write(
+          fixture.source,
+          "config.yaml",
+          `data_dir: ${data}\nllm:\n  provider: anthropic\n`,
+        );
+      }
+      const result = await migrate(fixture);
+      expectRefused(result, "source-target-overlap", 3);
+    }
+  });
+
+  it("invalid source config is pre-plan", async () => {
+    const variants: Array<string | null> = [
+      null,
+      "bad: [",
+      "a: 1\na: 2\n",
+      "- list\n",
+      "*missing\n",
+    ];
+    for (const value of variants) {
+      const fixture = await makeFixture();
+      if (value === null) await unlink(join(fixture.source, "config.yaml"));
+      else await write(fixture.source, "config.yaml", value);
+      const result = await migrate(fixture);
+      expectRefused(result, "invalid-source-config", 4);
+      expect(await exists(dirname(journalPath(fixture)))).toBe(false);
+    }
+    const fixture = await makeFixture();
+    await rm(fixture.source, { recursive: true });
+    expect((await migrate(fixture)).status).toBe("not-needed");
+  });
+
+  it("unsupported data_dir is pre-plan", async () => {
+    for (const value of ["~/home", "relative", "", "42"] as const) {
+      const fixture = await makeFixture(
+        `data_dir: ${value === "" ? '""' : value}\nllm:\n  provider: anthropic\n`,
+      );
+      const result = await migrate(fixture);
+      expectRefused(result, "unsupported-data-dir", 4);
+      expect(await exists(dirname(journalPath(fixture)))).toBe(false);
+    }
+    const fixture = await makeFixture();
+    const actual = join(fixture.parent, "actual-data");
+    await privateDirectory(actual);
+    const alias = join(fixture.parent, "data-alias");
+    await symlink(actual, alias);
+    await write(fixture.source, "config.yaml", `data_dir: ${alias}\n`);
+    expectRefused(await migrate(fixture), "unsupported-data-dir", 4);
+  });
+
+  it("OAuth continuity validation is fail-closed", async () => {
+    const invalid = [
+      "bad",
+      "[]",
+      '{"p":{}}',
+      '{"p":{"type":"oauth","access":"a","refresh":"r","expires":1,"extra":1}}',
+      '{"p":{"type":"oauth","access":"a","refresh":"r","expires":1e400}}',
+    ];
+    for (const value of invalid) {
+      const fixture = await makeFixture("llm:\n  provider: openai-codex\n  auth_profile: p\n");
+      await write(fixture.source, "auth-profiles.json", value);
+      expectRefused(await migrate(fixture), "invalid-source-config", 4);
+    }
+    const missing = await makeFixture("llm:\n  provider: openai-codex\n");
+    await write(missing.source, "auth-profiles.json", "{}");
+    expectRefused(await migrate(missing), "invalid-source-config", 4);
+    const valid = await makeFixture("llm:\n  provider: openai-codex\n  auth_profile: p\n");
+    await write(
+      valid.source,
+      "auth-profiles.json",
+      '{"p":{"type":"oauth","access":"a","refresh":"r","expires":1,"accountId":"id","email":"e"}}',
+    );
+    expect((await migrate(valid)).status).toBe("done");
+  });
+
+  it("credential-layout refusal pins and blocks publication", async () => {
+    for (const kind of ["regular", "symlink"] as const) {
+      const fixture = await makeFixture();
+      await write(fixture.source, "memory/MEMORY.md", "memory");
+      if (kind === "regular") await write(fixture.source, "auth/codex/token", "token");
+      else {
+        await privateDirectory(join(fixture.source, "auth"));
+        await symlink(join(fixture.parent, "outside"), join(fixture.source, "auth/codex"));
+      }
+      const first = await migrate(fixture);
+      expectRefused(first, "unsupported-credential-layout", 4);
+      expect(await exists(join(fixture.target, "memory/MEMORY.md"))).toBe(false);
+      expectRefused(await migrate(fixture), "pinned-refusal", 2);
+      expectRefused(
+        await migrateLegacyHomeUnderLock(
+          {
+            sourceRoot: fixture.source,
+            targetRoot: fixture.target,
+            action: { kind: "confirm", manifestDigest: first.manifestDigest! },
+          },
+          dependencies(),
+        ),
+        "invalid-action",
+        2,
+      );
+    }
+  });
+
+  it("actions are state constrained", async () => {
+    const fixture = await makeFixture();
+    expectRefused(
+      await migrateLegacyHomeUnderLock({
+        sourceRoot: fixture.source,
+        targetRoot: fixture.target,
+        action: { kind: "confirm", manifestDigest: "0".repeat(64) },
+      }),
+      "invalid-action",
+    );
+    expectRefused(
+      await migrateLegacyHomeUnderLock({
+        sourceRoot: fixture.source,
+        targetRoot: fixture.target,
+        action: { kind: "discard", manifestDigest: "0".repeat(64) },
+      }),
+      "invalid-action",
+    );
+    const done = await migrate(fixture);
+    expect(done.status).toBe("done");
+    const digest = done.manifestDigest!;
+    expectRefused(
+      await migrateLegacyHomeUnderLock({
+        sourceRoot: fixture.source,
+        targetRoot: fixture.target,
+        action: { kind: "confirm", manifestDigest: digest },
+      }),
+      "invalid-action",
+    );
+    expectRefused(
+      await migrateLegacyHomeUnderLock({
+        sourceRoot: fixture.source,
+        targetRoot: fixture.target,
+        action: { kind: "discard", manifestDigest: digest },
+      }),
+      "invalid-action",
+    );
+    expectRefused(
+      await migrateLegacyHomeUnderLock({
+        sourceRoot: fixture.source,
+        targetRoot: fixture.target,
+        action: { kind: "replan", discardedManifestDigest: digest, isTTY: true },
+      }),
+      "invalid-action",
+    );
+  });
+
+  it("resume preserves immutable plan-time target fields", async () => {
+    const fixture = await makeFixture();
+    await write(fixture.source, "memory/MEMORY.md", "memory");
+    let crashed = false;
+    await expect(
+      migrate(fixture, {
+        checkpoint: (context) => {
+          if (!crashed && context.checkpoint === "after-payload-checkpoint") {
+            crashed = true;
+            throw new Error("crash");
+          }
+        },
+      }),
+    ).rejects.toThrow("crash");
+    const before = await journal(fixture);
+    const result = await migrate(fixture);
+    expect(result.status).toBe("done");
+    const after = await journal(fixture);
+    expect(after.manifestDigest).toBe(before.manifestDigest);
+    expect(after.manifest.entries.map((entry) => entry.id)).toEqual(
+      before.manifest.entries.map((entry) => entry.id),
+    );
+  });
+
+  it("journal validation is strict and ordered before source absence", async () => {
+    for (const kind of ["malformed", "unknown", "constant", "digest", "root", "mode"] as const) {
+      const fixture = await makeFixture();
+      await privateDirectory(dirname(journalPath(fixture)));
+      let value = "{";
+      if (kind !== "malformed") {
+        const clean = await cleanDoneFixture();
+        value = await readFile(journalPath(clean.fixture), "utf8");
+        const parsed = JSON.parse(value) as Record<string, unknown>;
+        if (kind === "unknown") parsed.extra = true;
+        if (kind === "constant") parsed.schemaVersion = 2;
+        if (kind === "digest") parsed.manifestDigest = "0".repeat(64);
+        if (kind === "root") parsed.sourceRoot = fixture.source;
+        value = JSON.stringify(parsed);
+      }
+      await writeFile(journalPath(fixture), value, { mode: kind === "mode" ? 0o644 : 0o600 });
+      const result = await migrate(fixture);
+      expectRefused(result, kind === "mode" ? "target-path-unsafe" : "manifest-mismatch");
+    }
+    const { fixture } = await cleanDoneFixture();
+    await rm(fixture.source, { recursive: true });
+    expectRefused(await migrate(fixture), "legacy-mutated-after-cutover", 3);
+  });
+
+  it("post-preflight target race and verification failure are pinned", async () => {
+    for (const kind of ["race", "verify"] as const) {
+      const fixture = await makeFixture();
+      await write(fixture.source, "memory/MEMORY.md", "memory");
+      let acted = false;
+      const result = await migrate(fixture, {
+        checkpoint: async (context) => {
+          if (acted) return;
+          if (kind === "race" && context.checkpoint === "before-payload-publication") {
+            acted = true;
+            await write(fixture.target, "memory/MEMORY.md", "racer");
+          }
+          if (
+            kind === "verify" &&
+            context.checkpoint === "after-payload-checkpoint" &&
+            (await exists(join(fixture.target, "memory/MEMORY.md")))
+          ) {
+            acted = true;
+            await writeFile(join(fixture.target, "memory/MEMORY.md"), "tamper");
+          }
+        },
+      });
+      expectRefused(result, kind === "race" ? "target-conflict" : "verification-failed", 3);
+      expect(["verified", "done"]).not.toContain((await journal(fixture)).state);
+    }
+  });
+
+  it("result arrays distinguish invocation from cumulative journal state", async () => {
+    const fixture = await makeFixture();
+    await seedPayload(fixture);
+    let count = 0;
+    await expect(
+      migrate(fixture, {
+        checkpoint: (context) => {
+          if (context.checkpoint === "after-payload-checkpoint" && ++count === 2)
+            throw new Error("crash");
+        },
+      }),
+    ).rejects.toThrow("crash");
+    const resumed = await migrate(fixture);
+    expect(resumed.status).toBe("done");
+    const cumulative = await journal(fixture);
+    expect(cumulative.results.copiedIds.length).toBeGreaterThan(0);
+    expect(cumulative.results.skipVerifiedIds.length).toBe(2);
+    const rerun = await migrate(fixture);
+    expect(rerun).toMatchObject({ status: "done", copiedIds: [], skipVerifiedIds: [] });
+  });
+
+  it("control and file modes are not broader than private", async () => {
+    const { fixture } = await cleanDoneFixture();
+    for (const path of [
+      fixture.target,
+      join(fixture.target, "config"),
+      join(fixture.target, "memory"),
+      dirname(journalPath(fixture)),
+    ])
+      expect((await lstat(path)).mode & 0o077).toBe(0);
+    for (const path of [
+      journalPath(fixture),
+      join(fixture.target, "config/config.yaml"),
+      join(fixture.target, "memory/MEMORY.md"),
+    ])
+      expect((await lstat(path)).mode & 0o177).toBe(0);
+    const unsafe = await makeFixture();
+    await privateDirectory(dirname(journalPath(unsafe)));
+    await chmod(dirname(journalPath(unsafe)), 0o755);
+    expectRefused(await migrate(unsafe), "target-path-unsafe", 3);
+    expect((await lstat(dirname(journalPath(unsafe)))).mode & 0o777).toBe(0o755);
+  });
+
+  it("invalid random ids never become paths", async () => {
+    for (const id of ["invalid", "../../escape"]) {
+      const fixture = await makeFixture();
+      await expect(migrate(fixture, { randomId: () => id })).rejects.toThrow(
+        new TypeError("randomId must return an RFC 4122 UUID"),
+      );
+      expect(await exists(join(fixture.parent, "escape"))).toBe(false);
+    }
+    const fixture = await makeFixture();
+    await privateDirectory(dirname(journalPath(fixture)));
+    const collision = "00000000-0000-4000-8000-000000000001";
+    await writeFile(
+      join(dirname(journalPath(fixture)), `journal.json.tmp.${process.pid}.${collision}`),
+      "collision",
+      { mode: 0o600 },
+    );
+    let calls = 0;
+    const result = await migrate(fixture, {
+      randomId: () => (calls++ === 0 ? collision : deterministicUuid()),
+    });
+    expect(result.status).toBe("done");
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,6 +88,9 @@ importers:
       '@enduragent/sync-intervals-icu':
         specifier: workspace:*
         version: link:../sync-intervals-icu
+      yaml:
+        specifier: ^2.8.3
+        version: 2.8.3
     devDependencies:
       '@types/node':
         specifier: ^25.6.0


### PR DESCRIPTION
## Summary

Adds crash-safe legacy-home migration machinery to `packages/coach`:

- `legacy-migration.ts` — immutable-manifest migration with conflict entries marked `skip` (no conflicting byte copied), journaled partial completion recorded as partial, and the destination layout pinned by the wave decisions (config/config.yaml with data_dir, memory/ and plans/ at root, control metadata in an excluded namespace).
- 33 migration tests covering crash/resume, conflict skip, journal states, and layout normalization.
- Direct `yaml` dependency on the coach package; lockfile updated for that importer only.

## Verification

- Migration suite 33/33; root `pnpm check:types`, `pnpm -r check`, `pnpm lint` (0 errors), full build/test green after rebase onto the current tip.
- All seven static policy gates green; package-deps checker 332 files clean.
