### PR TITLE
feat(coach): add new-home composition adapter

### DIFF
--- a/packages/coach/package.json
+++ b/packages/coach/package.json
@@ -12,7 +12,8 @@
     "./backfill-benchmark": "./dist/backfill-benchmark.js",
     "./capture": "./dist/capture.js",
     "./local-bundle-producer": "./dist/local-bundle-producer.js",
-    "./store-runtime": "./dist/store-runtime.js"
+    "./store-runtime": "./dist/store-runtime.js",
+    "./local-runner": "./dist/local-runner.js"
   },
   "engines": {
     "node": ">=24"
@@ -29,7 +30,9 @@
     "season-review": "node dist/season-review-command.js"
   },
   "dependencies": {
+    "@enduragent/coach-contract": "workspace:*",
     "@enduragent/core": "workspace:*",
+    "@enduragent/engine": "workspace:*",
     "@enduragent/kernel": "workspace:*",
     "@enduragent/kernel-node": "workspace:*",
     "@enduragent/sync-intervals-icu": "workspace:*",

--- a/packages/coach/src/athlete-state-reader.ts
+++ b/packages/coach/src/athlete-state-reader.ts
@@ -1,0 +1,78 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import {
+  AthleteStateSchema,
+  type AthleteState,
+} from "@enduragent/coach-contract";
+import type { AthleteStateReaderPort } from "@enduragent/engine";
+import {
+  ERROR_STATE_SCHEMA_VERSION,
+  ErrorStateSchema,
+  LATEST_SCHEMA_VERSION,
+  LatestJsonSchema,
+} from "@enduragent/kernel/reference/schemas";
+
+export interface PersistedAthleteStateSource extends AthleteStateReaderPort {}
+
+export class AthleteStateUnavailableError extends Error {}
+
+async function readJson(path: string): Promise<unknown> {
+  return JSON.parse(await readFile(path, "utf8")) as unknown;
+}
+
+export function createPersistedAthleteStateSource(input: {
+  readonly dataDir: string;
+}): PersistedAthleteStateSource {
+  const latestPath = join(input.dataDir, "data", "latest.json");
+  const errorPath = join(input.dataDir, "data", "error_state.json");
+  return {
+    async getAthleteState(): Promise<AthleteState> {
+      const [latestResult, errorResult] = await Promise.allSettled([
+        readJson(latestPath),
+        readJson(errorPath),
+      ]);
+      if (latestResult.status === "rejected") {
+        throw new AthleteStateUnavailableError("No validated athlete state is available.");
+      }
+      const latestParsed = LatestJsonSchema.safeParse(latestResult.value);
+      if (!latestParsed.success
+        || latestParsed.data.metadata.schema_version !== LATEST_SCHEMA_VERSION) {
+        throw new AthleteStateUnavailableError("No validated athlete state is available.");
+      }
+      const errorParsed = errorResult.status === "fulfilled"
+        ? ErrorStateSchema.safeParse(errorResult.value)
+        : null;
+      const errorState = errorParsed?.success === true
+        && errorParsed.data.schema_version === ERROR_STATE_SCHEMA_VERSION
+        ? errorParsed.data
+        : null;
+      const latest = latestParsed.data;
+      const derivedMetrics = { ...latest.derived_metrics };
+      delete derivedMetrics.acwr;
+      delete derivedMetrics["capability.dfa_a1_profile"];
+      const mapped = {
+        schemaVersion: latest.metadata.schema_version,
+        lastUpdated: latest.metadata.last_updated,
+        freshness: latest.metadata.freshness,
+        degraded: errorState?.mitigation === "block_coaching",
+        lastSynced: latest.metadata.last_updated,
+        athleteProfile: latest.athlete_profile,
+        currentStatus: latest.current_status,
+        derivedMetrics,
+        ...(latest.derived_metrics_meta === undefined
+          ? {}
+          : { derivedMetricsMeta: latest.derived_metrics_meta }),
+        recentActivities: latest.recent_activities,
+        plannedWorkouts: latest.planned_workouts,
+        wellness: latest.wellness_data,
+      };
+      const state = AthleteStateSchema.safeParse(mapped);
+      if (!state.success) {
+        throw new AthleteStateUnavailableError(
+          "Persisted athlete state does not satisfy the coaching contract.",
+        );
+      }
+      return state.data;
+    },
+  };
+}

--- a/packages/coach/src/coach-engine-adapter.ts
+++ b/packages/coach/src/coach-engine-adapter.ts
@@ -1,0 +1,67 @@
+import {
+  AthleteStateSchema,
+  ChatRequestSchema,
+  ChatResponseSchema,
+  HasSessionRequestSchema,
+  HasSessionResponseSchema,
+  ResetSessionRequestSchema,
+  ResetSessionResponseSchema,
+  TurnEventSchema,
+  type AthleteState,
+  type CoachEngine,
+} from "@enduragent/coach-contract";
+import type { CyclingFtpAnchorResolver } from "@enduragent/kernel/anchors";
+
+export interface CoachEngineAdapterInput {
+  readonly backend: CoachEngine;
+  readonly getAthleteState: () => Promise<AthleteState>;
+  readonly cyclingFtpAnchorResolver: CyclingFtpAnchorResolver;
+  readonly now: () => number;
+}
+
+export function createCoachEngineAdapter(
+  input: CoachEngineAdapterInput,
+): CoachEngine {
+  return {
+    async chat(request, onEvent) {
+      const parsed = ChatRequestSchema.parse(request);
+      const callEpochS = Math.floor(input.now() / 1_000);
+      const resolvedCs = await input.cyclingFtpAnchorResolver.resolve({
+        effectiveAtEpochS: callEpochS,
+        evaluatedAtEpochS: callEpochS,
+      });
+      const resolvedRequest = {
+        ...parsed,
+        turn: {
+          ...parsed.turn,
+          resolvedCs,
+        },
+      };
+      let firstEventValidationError: unknown | undefined;
+      const response = await input.backend.chat(resolvedRequest, (event) => {
+        if (firstEventValidationError !== undefined) return;
+        const result = TurnEventSchema.safeParse(event);
+        if (!result.success) {
+          firstEventValidationError = result.error;
+          return;
+        }
+        try {
+          onEvent?.(result.data);
+        } catch {}
+      });
+      if (firstEventValidationError !== undefined) throw firstEventValidationError;
+      return ChatResponseSchema.parse(response);
+    },
+    async resetSession(request) {
+      const parsed = ResetSessionRequestSchema.parse(request);
+      return ResetSessionResponseSchema.parse(await input.backend.resetSession(parsed));
+    },
+    async hasSession(request) {
+      const parsed = HasSessionRequestSchema.parse(request);
+      return HasSessionResponseSchema.parse(await input.backend.hasSession(parsed));
+    },
+    async getAthleteState() {
+      return AthleteStateSchema.parse(await input.getAthleteState());
+    },
+  };
+}

--- a/packages/coach/src/composition.ts
+++ b/packages/coach/src/composition.ts
@@ -1,0 +1,323 @@
+import { randomBytes, randomUUID } from "node:crypto";
+import {
+  chmodSync,
+  existsSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import {
+  ChatStore,
+  Memory,
+  appendUsageLine,
+  bootstrapReference,
+  classifyFailure,
+  createMissingPlatformCalendarMutations,
+  createPlatformCalendarMutations,
+  createSubsystemLogger,
+  engineConfigFromConfig,
+  extractRetryAfterMs,
+  makeChatClient,
+  refreshCodexToken,
+  resolveSecretRef,
+  type Config,
+  type ReferenceRuntime,
+} from "@enduragent/core";
+import {
+  createCoachEngine,
+  type CreateCoachEngineInput,
+  type EngineConfig,
+  type EngineHostPorts,
+  type ModelTransportDecorator,
+  type ReferenceStateSnapshot,
+} from "@enduragent/engine";
+import {
+  createCyclingFtpAnchorResolver,
+  type CyclingFtpAnchorResolver,
+} from "@enduragent/kernel/anchors";
+import { createAnchorRepository, type AnchorRepository } from "@enduragent/kernel/store";
+import {
+  ErrorStateSchema,
+  LatestJsonSchema,
+} from "@enduragent/kernel/reference/schemas";
+import type { AthleteHome } from "@enduragent/kernel-node/home";
+import type { CoachStoreWriterContext } from "./runtime.js";
+import { cyclingSport } from "@enduragent/sport-cycling";
+import { createPersistedAthleteStateSource } from "./athlete-state-reader.js";
+import { createCoachEngineAdapter } from "./coach-engine-adapter.js";
+import {
+  createStoreRuntime,
+  type StoreRuntime,
+  type StoreRuntimeDependencies,
+  type StoreRuntimeOptions,
+} from "./store-runtime.js";
+
+interface OAuthCredential {
+  readonly type: "oauth";
+  readonly access: string;
+  readonly refresh: string;
+  readonly expires: number;
+  readonly accountId?: string;
+  readonly email?: string;
+}
+
+export interface LocalCoachComposition {
+  readonly engine: ReturnType<typeof createCoachEngineAdapter>;
+  close(): Promise<void>;
+}
+
+export interface LocalCoachCompositionInput {
+  readonly env: Record<string, string | undefined>;
+  readonly home: AthleteHome;
+  readonly context: CoachStoreWriterContext;
+  readonly config: Config;
+  readonly engineConfig: EngineConfig;
+}
+
+export interface LocalCoachCompositionDependencies {
+  readonly bootstrap?: (
+    options: Parameters<typeof bootstrapReference>[0],
+  ) => Promise<LocalReferenceRuntime>;
+  readonly createRuntime?: (options: LocalStoreRuntimeOptions) => LocalStoreRuntime;
+  readonly runtimeDependencies?: StoreRuntimeDependencies;
+  readonly createBackend?: typeof createCoachEngine;
+  readonly createRepository?: (store: CoachStoreWriterContext["store"]) => AnchorRepository;
+  readonly createResolver?: (repository: AnchorRepository) => CyclingFtpAnchorResolver;
+  readonly now?: () => number;
+  readonly randomId?: () => string;
+  readonly modelTransportDecorator?: ModelTransportDecorator;
+  readonly onToolsAssembled?: (names: readonly string[]) => void;
+  readonly closeHostAdapters?: () => void | Promise<void>;
+}
+
+export interface LocalReferenceRuntime {
+  readonly scheduler: { stop(): void };
+  runScheduledOnce(): ReturnType<ReferenceRuntime["runScheduledOnce"]>;
+}
+
+export interface LocalStoreRuntime {
+  readonly athleteData: StoreRuntime["athleteData"];
+  attemptLedgerForRun(): ReturnType<StoreRuntime["attemptLedgerForRun"]>;
+  runWindow(): ReturnType<StoreRuntime["runWindow"]>;
+  startScheduler(): void;
+  close(): Promise<void>;
+}
+
+export type LocalStoreRuntimeOptions = Omit<StoreRuntimeOptions, "reference"> & {
+  readonly reference: LocalReferenceRuntime;
+};
+
+function readReferenceState(dataDir: string): ReferenceStateSnapshot {
+  const referenceDir = join(dataDir, "data");
+  const read = <T>(path: string, parse: (value: unknown) => { success: boolean; data?: T }): T | null => {
+    try {
+      const result = parse(JSON.parse(readFileSync(path, "utf8")) as unknown);
+      return result.success ? result.data ?? null : null;
+    } catch {
+      return null;
+    }
+  };
+  return {
+    errorState: read(join(referenceDir, "error_state.json"), (value) => ErrorStateSchema.safeParse(value)),
+    latest: read(join(referenceDir, "latest.json"), (value) => LatestJsonSchema.safeParse(value)),
+  };
+}
+
+function readProfiles(path: string): Record<string, unknown> {
+  if (!existsSync(path)) return {};
+  const value = JSON.parse(readFileSync(path, "utf8")) as unknown;
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new TypeError("OAuth profiles must be a map.");
+  }
+  return value as Record<string, unknown>;
+}
+
+function credential(value: unknown): OAuthCredential {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new TypeError("OAuth profile is invalid.");
+  }
+  const candidate = value as Record<string, unknown>;
+  if (candidate.type !== "oauth"
+    || typeof candidate.access !== "string"
+    || typeof candidate.refresh !== "string"
+    || typeof candidate.expires !== "number") {
+    throw new TypeError("OAuth profile is invalid.");
+  }
+  return candidate as unknown as OAuthCredential;
+}
+
+function writeProfiles(path: string, profiles: Record<string, unknown>): void {
+  const temporaryPath = `${path}.tmp.${randomBytes(4).toString("hex")}`;
+  try {
+    writeFileSync(temporaryPath, JSON.stringify(profiles, null, 2), { mode: 0o600 });
+    chmodSync(temporaryPath, 0o600);
+    renameSync(temporaryPath, path);
+  } catch (error) {
+    try {
+      unlinkSync(temporaryPath);
+    } catch {}
+    throw error;
+  }
+}
+
+function createAccessTokenReader(configDir: string, now: () => number): EngineHostPorts["getAccessToken"] {
+  const path = join(configDir, "auth-profiles.json");
+  const queues = new Map<string, Promise<string>>();
+  const exclusive = async (profileName: string, signal?: AbortSignal): Promise<string> => {
+    const profiles = readProfiles(path);
+    const current = credential(profiles[profileName]);
+    if (Number.isFinite(current.expires) && now() <= current.expires - 300_000) {
+      return current.access;
+    }
+    const refreshed = await refreshCodexToken(current.refresh, signal);
+    profiles[profileName] = {
+      type: "oauth",
+      access: refreshed.access,
+      refresh: refreshed.refresh,
+      expires: refreshed.expires,
+      accountId: refreshed.accountId ?? current.accountId,
+      email: current.email,
+    } satisfies OAuthCredential;
+    writeProfiles(path, profiles);
+    return refreshed.access;
+  };
+  return async (profileName, signal) => {
+    const previous = queues.get(profileName) ?? Promise.resolve("");
+    const current = previous.then(
+      () => exclusive(profileName, signal),
+      () => exclusive(profileName, signal),
+    );
+    queues.set(profileName, current);
+    try {
+      return await current;
+    } finally {
+      if (queues.get(profileName) === current) queues.delete(profileName);
+    }
+  };
+}
+
+function sameHome(left: AthleteHome, right: AthleteHome): boolean {
+  return left.root === right.root
+    && left.storeDir === right.storeDir
+    && left.archiveDir === right.archiveDir
+    && left.configDir === right.configDir;
+}
+
+export async function createLocalCoachComposition(
+  input: LocalCoachCompositionInput,
+  dependencies: LocalCoachCompositionDependencies = {},
+): Promise<LocalCoachComposition> {
+  if (!sameHome(input.home, input.context.home)) {
+    throw new TypeError("Writer home does not match the selected athlete home.");
+  }
+  if (input.config.dataDir !== input.home.root) {
+    throw new TypeError("Configured data directory does not match the selected athlete home.");
+  }
+  const projected = engineConfigFromConfig(input.config);
+  if (JSON.stringify(projected) !== JSON.stringify(input.engineConfig)) {
+    throw new TypeError("Ready engine configuration does not match the selected athlete home.");
+  }
+  const now = dependencies.now ?? Date.now;
+  let runtime: LocalStoreRuntime | undefined;
+  let reference: LocalReferenceRuntime | undefined;
+  let closePromise: Promise<void> | undefined;
+  try {
+    reference = await (dependencies.bootstrap ?? bootstrapReference)({
+      dataDir: input.home.root,
+      intervals: input.config.intervals,
+      sport: cyclingSport,
+      startScheduler: false,
+      attemptLedgerForRun: () => {
+        if (runtime === undefined) throw new Error("Store runtime has not started its paired window.");
+        return runtime.attemptLedgerForRun();
+      },
+    });
+    const runtimeOptions: LocalStoreRuntimeOptions = {
+      env: input.env,
+      config: input.config,
+      home: input.home,
+      reference,
+      dependencies: dependencies.runtimeDependencies,
+    };
+    runtime = dependencies.createRuntime === undefined
+      ? createStoreRuntime({
+          ...runtimeOptions,
+          reference: reference as ReferenceRuntime,
+        })
+      : dependencies.createRuntime(runtimeOptions);
+    await runtime.runWindow();
+    runtime.startScheduler();
+    const stateReader = createPersistedAthleteStateSource({ dataDir: input.home.root });
+    const legacyClient = input.config.intervals.apiKey.length === 0
+      ? null
+      : makeChatClient({
+          apiKey: input.config.intervals.apiKey,
+          athleteId: input.config.intervals.athleteId,
+        });
+    const memory = new Memory(input.home.root, input.config.session.timezone);
+    const ports: EngineHostPorts = {
+      config: input.engineConfig,
+      memory,
+      chatStore: new ChatStore(
+        input.home.root,
+        input.config.session.resetArchiveRetentionDays,
+      ),
+      secrets: { resolve: resolveSecretRef },
+      platform: {
+        legacyClient,
+        athleteData: runtime.athleteData,
+        calendarMutations: legacyClient === null
+          ? createMissingPlatformCalendarMutations()
+          : createPlatformCalendarMutations(legacyClient),
+      },
+      logger: createSubsystemLogger("agent", input.home.root),
+      usage: { append: (line) => appendUsageLine(input.home.root, line) },
+      stateReader,
+      readReferenceState: () => readReferenceState(input.home.root),
+      getAccessToken: createAccessTokenReader(input.home.configDir, now),
+      classifyFailure,
+      extractRetryAfterMs,
+      now,
+      randomId: dependencies.randomId ?? randomUUID,
+      modelTransportDecorator: dependencies.modelTransportDecorator,
+      onToolsAssembled: dependencies.onToolsAssembled,
+    };
+    const engineInput = { sport: cyclingSport, ports } satisfies CreateCoachEngineInput;
+    const backend = (dependencies.createBackend ?? createCoachEngine)(engineInput);
+    const repository = (dependencies.createRepository ?? createAnchorRepository)(input.context.store);
+    const cyclingFtpAnchorResolver = (dependencies.createResolver
+      ?? createCyclingFtpAnchorResolver)(repository);
+    const engine = createCoachEngineAdapter({
+      backend,
+      getAthleteState: () => stateReader.getAthleteState(),
+      cyclingFtpAnchorResolver,
+      now,
+    });
+    return {
+      engine,
+      close() {
+        closePromise ??= (async () => {
+          let failure: { readonly error: unknown } | undefined;
+          const attempt = async (operation: () => void | Promise<void>): Promise<void> => {
+            try {
+              await operation();
+            } catch (error) {
+              failure ??= { error };
+            }
+          };
+          await attempt(() => dependencies.closeHostAdapters?.());
+          await attempt(() => reference!.scheduler.stop());
+          await attempt(() => runtime!.close());
+          if (failure !== undefined) throw failure.error;
+        })();
+        return closePromise;
+      },
+    };
+  } catch (error) {
+    reference?.scheduler.stop();
+    if (runtime !== undefined) await runtime.close();
+    throw error;
+  }
+}

--- a/packages/coach/src/local-runner.ts
+++ b/packages/coach/src/local-runner.ts
@@ -1,0 +1,167 @@
+import {
+  engineConfigFromConfig,
+  loadConfig,
+} from "@enduragent/core";
+import type { CoachEngine } from "@enduragent/coach-contract";
+import type { AthleteHome } from "@enduragent/kernel-node/home";
+import {
+  createLocalCoachComposition,
+  type LocalCoachComposition,
+} from "./composition.js";
+import {
+  migrateLegacyHomeUnderLock,
+  type LegacyMigrationAction,
+  type LegacyMigrationResult,
+} from "./legacy-migration.js";
+import { checkHomeReadiness } from "./readiness.js";
+import { withCoachStoreWriter } from "./runtime.js";
+
+export interface LocalCoachLifecycle {
+  readonly engine: CoachEngine;
+  close(): Promise<void>;
+}
+
+export type LocalCoachRunResult<T> =
+  | { readonly status: "completed"; readonly value: T }
+  | { readonly status: "not-configured"; readonly configPath: string }
+  | {
+      readonly status: "migration-refused";
+      readonly result: Extract<LegacyMigrationResult, { status: "refused" }>;
+    }
+  | {
+      readonly status: "migration-discarded";
+      readonly result: Extract<LegacyMigrationResult, { status: "discarded" }>;
+    };
+
+export interface WithLocalCoachInput<T> {
+  readonly env: Record<string, string | undefined>;
+  readonly home: AthleteHome;
+  readonly sourceRoot: string;
+  readonly action: LegacyMigrationAction;
+  readonly operation: (lifecycle: LocalCoachLifecycle) => Promise<T>;
+}
+
+type MigrationTerminalResult = Extract<
+  LegacyMigrationResult,
+  { status: "refused" | "discarded" }
+>;
+
+class MigrationTerminal extends Error {
+  constructor(readonly result: MigrationTerminalResult) {
+    super("Legacy migration terminated before store open.");
+  }
+}
+
+type WriterValue<T> =
+  | { readonly kind: "not-configured"; readonly configPath: string }
+  | { readonly kind: "fulfilled"; readonly value: T }
+  | { readonly kind: "rejected"; readonly error: unknown };
+
+function sameHome(left: AthleteHome, right: AthleteHome): boolean {
+  return left.root === right.root
+    && left.storeDir === right.storeDir
+    && left.archiveDir === right.archiveDir
+    && left.configDir === right.configDir;
+}
+
+function migrationTerminal(error: unknown): MigrationTerminal | undefined {
+  const visited = new Set<unknown>();
+  let candidate = error;
+  while (candidate !== null
+    && (typeof candidate === "object" || typeof candidate === "function")
+    && !visited.has(candidate)) {
+    if (candidate instanceof MigrationTerminal) return candidate;
+    visited.add(candidate);
+    candidate = (candidate as { readonly cause?: unknown }).cause;
+  }
+  return undefined;
+}
+
+function migrationResult<T>(terminal: MigrationTerminal): LocalCoachRunResult<T> {
+  return terminal.result.status === "refused"
+    ? { status: "migration-refused", result: terminal.result }
+    : { status: "migration-discarded", result: terminal.result };
+}
+
+export async function withLocalCoach<T>(
+  input: WithLocalCoachInput<T>,
+): Promise<LocalCoachRunResult<T>> {
+  if (typeof input.operation !== "function") {
+    throw new TypeError("invalid local coach operation");
+  }
+  const writerEnv = { ...input.env, ENDURAGENT_HOME: input.home.root };
+  let operationOutcome: Extract<WriterValue<T>, { kind: "rejected" }> | undefined;
+  let writerValue: WriterValue<T>;
+  try {
+    writerValue = await withCoachStoreWriter(writerEnv, {
+      beforeStoreOpen: async (resolvedHome) => {
+        if (!sameHome(resolvedHome, input.home)) {
+          throw new TypeError("Writer home does not match the selected athlete home.");
+        }
+        const result = await migrateLegacyHomeUnderLock({
+          sourceRoot: input.sourceRoot,
+          targetRoot: input.home.root,
+          action: input.action,
+        });
+        if (result.status === "refused" || result.status === "discarded") {
+          throw new MigrationTerminal(result);
+        }
+      },
+      operation: async (context): Promise<WriterValue<T>> => {
+        const readiness = await checkHomeReadiness(context.home);
+        if (readiness.status === "not-configured") {
+          return {
+            kind: "not-configured",
+            configPath: readiness.configPath,
+          };
+        }
+        const config = loadConfig(context.home.configDir);
+        if (JSON.stringify(engineConfigFromConfig(config)) !== JSON.stringify(readiness.config)) {
+          throw new TypeError("Ready engine configuration changed before engine construction.");
+        }
+        let lifecycle: LocalCoachComposition | undefined;
+        let lifecycleCloseOutcome:
+          | { kind: "succeeded" }
+          | { kind: "failed"; error: unknown } = { kind: "succeeded" };
+        let outcome: WriterValue<T>;
+        try {
+          lifecycle = await createLocalCoachComposition({
+            env: writerEnv,
+            home: input.home,
+            context,
+            config,
+            engineConfig: readiness.config,
+          });
+          try {
+            outcome = { kind: "fulfilled", value: await input.operation(lifecycle) };
+          } catch (error) {
+            operationOutcome = { kind: "rejected", error };
+            outcome = operationOutcome;
+          }
+        } finally {
+          if (lifecycle !== undefined) {
+            try {
+              await lifecycle.close();
+            } catch (error) {
+              lifecycleCloseOutcome = { kind: "failed", error };
+            }
+          }
+        }
+        if (lifecycleCloseOutcome.kind === "failed" && operationOutcome === undefined) {
+          throw lifecycleCloseOutcome.error;
+        }
+        return outcome!;
+      },
+    });
+  } catch (error) {
+    const terminal = migrationTerminal(error);
+    if (terminal !== undefined) return migrationResult(terminal);
+    if (operationOutcome !== undefined) throw operationOutcome.error;
+    throw error;
+  }
+  if (writerValue.kind === "rejected") throw writerValue.error;
+  if (writerValue.kind === "not-configured") {
+    return { status: "not-configured", configPath: writerValue.configPath };
+  }
+  return { status: "completed", value: writerValue.value };
+}

--- a/packages/coach/src/readiness.ts
+++ b/packages/coach/src/readiness.ts
@@ -1,0 +1,37 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { engineConfigFromConfig, loadConfig } from "@enduragent/core";
+import type { EngineConfig } from "@enduragent/engine";
+import type { AthleteHome } from "@enduragent/kernel-node/home";
+import { parse as parseYaml } from "yaml";
+
+export type ReadinessResult =
+  | { status: "ready"; config: EngineConfig }
+  | { status: "not-configured"; configPath: string };
+
+function isMap(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export async function checkHomeReadiness(
+  home: AthleteHome,
+): Promise<ReadinessResult> {
+  const configPath = join(home.configDir, "config.yaml");
+  try {
+    const parsedYaml = parseYaml(await readFile(configPath, "utf8")) as unknown;
+    if (!isMap(parsedYaml)) return { status: "not-configured", configPath };
+    const config = loadConfig(home.configDir);
+    const profileName = config.llm.authProfile;
+    if (profileName !== undefined) {
+      const profiles = JSON.parse(
+        await readFile(join(home.configDir, "auth-profiles.json"), "utf8"),
+      ) as unknown;
+      if (!isMap(profiles) || !Object.hasOwn(profiles, profileName)) {
+        return { status: "not-configured", configPath };
+      }
+    }
+    return { status: "ready", config: engineConfigFromConfig(config) };
+  } catch {
+    return { status: "not-configured", configPath };
+  }
+}

--- a/packages/coach/src/runtime.ts
+++ b/packages/coach/src/runtime.ts
@@ -3,16 +3,27 @@ import {
   type CoachDevWriterContext,
   type CoachDevWriterFailureStage,
 } from "@enduragent/kernel-node/coach-dev";
+import type { AthleteHome } from "@enduragent/kernel-node/home";
 
 export type CoachStoreWriterContext = CoachDevWriterContext;
 
 export type CoachStoreWriterErrorCode = "writer-lock-held" | "writer-failed";
 
+export type WriterContentionDiagnostic =
+  | { readonly kind: "holder"; readonly pid: number | null; readonly port: number }
+  | { readonly kind: "foreign"; readonly port: number; readonly portFile: string };
+
 export class CoachStoreWriterError extends Error {
   readonly code: CoachStoreWriterErrorCode;
   readonly stage: CoachDevWriterFailureStage | null;
+  readonly contention: WriterContentionDiagnostic | null;
 
-  constructor(code: CoachStoreWriterErrorCode, stage: CoachDevWriterFailureStage | null, options?: ErrorOptions) {
+  constructor(
+    code: CoachStoreWriterErrorCode,
+    stage: CoachDevWriterFailureStage | null,
+    options?: ErrorOptions,
+    contention: WriterContentionDiagnostic | null = null,
+  ) {
     super(
       code === "writer-lock-held"
         ? "coach store writer is already active"
@@ -22,6 +33,7 @@ export class CoachStoreWriterError extends Error {
     this.name = "CoachStoreWriterError";
     this.code = code;
     this.stage = stage;
+    this.contention = contention;
   }
 }
 
@@ -33,25 +45,42 @@ const defaultDependencies: CoachRuntimeDependencies = Object.freeze({
   runWriter: runCoachDevWriter,
 });
 
+export interface CoachStoreWriterPlan<T> {
+  readonly beforeStoreOpen: (home: AthleteHome) => Promise<void>;
+  readonly operation: (context: CoachStoreWriterContext) => Promise<T>;
+}
+
 export async function withCoachStoreWriter<T>(
   env: Record<string, string | undefined>,
-  operation: (context: CoachStoreWriterContext) => Promise<T>,
+  operationOrPlan:
+    | ((context: CoachStoreWriterContext) => Promise<T>)
+    | CoachStoreWriterPlan<T>,
   deps?: CoachRuntimeDependencies,
 ): Promise<T> {
+  const operation = typeof operationOrPlan === "function"
+    ? operationOrPlan
+    : operationOrPlan?.operation;
   if (typeof operation !== "function") {
     throw new TypeError("invalid coach writer operation");
+  }
+  if (typeof operationOrPlan !== "function"
+    && typeof operationOrPlan?.beforeStoreOpen !== "function") {
+    throw new TypeError("invalid coach writer pre-open operation");
   }
 
   const dependencies = deps ?? defaultDependencies;
   const result = await dependencies.runWriter({
     env,
     writerVersion: "coach-sync/1",
+    ...(typeof operationOrPlan === "function"
+      ? {}
+      : { beforeStoreOpen: operationOrPlan.beforeStoreOpen }),
     operation,
   });
 
   if (result.status === "completed") return result.value;
   if (result.status === "writer-lock-held") {
-    throw new CoachStoreWriterError("writer-lock-held", null);
+    throw new CoachStoreWriterError("writer-lock-held", null, undefined, result.contention);
   }
   throw new CoachStoreWriterError("writer-failed", result.stage, result.cause === undefined ? undefined : { cause: result.cause });
 }

--- a/packages/coach/tests/athlete-state-reader.test.ts
+++ b/packages/coach/tests/athlete-state-reader.test.ts
@@ -1,0 +1,179 @@
+import { mkdir, mkdtemp, realpath, rm, utimes, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { AthleteStateSchema } from "@enduragent/coach-contract";
+import {
+  ERROR_STATE_SCHEMA_VERSION,
+  LATEST_SCHEMA_VERSION,
+} from "@enduragent/kernel/reference/schemas";
+import {
+  AthleteStateUnavailableError,
+  createPersistedAthleteStateSource,
+} from "../src/athlete-state-reader.js";
+
+const roots: string[] = [];
+
+async function home(): Promise<string> {
+  const root = await mkdtemp(join(await realpath(tmpdir()), "coach-athlete-state-"));
+  roots.push(root);
+  await mkdir(join(root, "data"));
+  return root;
+}
+
+function latest(freshness: "fresh" | "flag" | "stale" | "critical" = "fresh") {
+  return {
+    metadata: {
+      schema_version: LATEST_SCHEMA_VERSION,
+      last_updated: "2026-07-18T00:00:00.000Z",
+      freshness,
+    },
+    athlete_profile: { name: "Synthetic Athlete" },
+    current_status: { summary: "ready" },
+    derived_metrics: {
+      eftp: 250,
+      acwr: 1.2,
+      "capability.dfa_a1_profile": { value: 0.7 },
+      future_metric: { value: 1 },
+    },
+    derived_metrics_meta: {
+      sportFamily: "cycling",
+      prescriptionBasis: "power",
+      anchorType: "ftp",
+      analysisBasis: "power",
+    },
+    recent_activities: [{ id: "activity-1" }],
+    planned_workouts: [{ id: "workout-1" }],
+    wellness_data: { restingHr: 45 },
+  };
+}
+
+function errorState(mitigation: "block_coaching" | "warn_only" = "warn_only") {
+  return {
+    schema_version: ERROR_STATE_SCHEMA_VERSION,
+    step: "synthetic",
+    detail: "synthetic outage",
+    ts: "2026-07-18T01:00:00.000Z",
+    mitigation,
+  };
+}
+
+async function writeJson(root: string, name: string, value: unknown): Promise<void> {
+  await writeFile(join(root, "data", name), JSON.stringify(value));
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("persisted athlete state source", () => {
+  it("maps every persisted field into a contract-valid state", async () => {
+    const root = await home();
+    await writeJson(root, "latest.json", latest());
+    await writeJson(root, "error_state.json", errorState());
+    const state = await createPersistedAthleteStateSource({ dataDir: root }).getAthleteState();
+    expect(AthleteStateSchema.parse(state)).toEqual(state);
+    expect(state).toMatchObject({
+      schemaVersion: LATEST_SCHEMA_VERSION,
+      lastUpdated: "2026-07-18T00:00:00.000Z",
+      lastSynced: "2026-07-18T00:00:00.000Z",
+      freshness: "fresh",
+      degraded: false,
+      athleteProfile: { name: "Synthetic Athlete" },
+      currentStatus: { summary: "ready" },
+      recentActivities: [{ id: "activity-1" }],
+      plannedWorkouts: [{ id: "workout-1" }],
+      wellness: { restingHr: 45 },
+    });
+  });
+
+  it("removes both reveal-fenced keys and preserves future metric keys", async () => {
+    const root = await home();
+    await writeJson(root, "latest.json", latest());
+    const state = await createPersistedAthleteStateSource({ dataDir: root }).getAthleteState();
+    expect(state.derivedMetrics).toEqual({ eftp: 250, future_metric: { value: 1 } });
+    expect(Object.hasOwn(state.derivedMetrics, "acwr")).toBe(false);
+    expect(Object.hasOwn(state.derivedMetrics, "capability.dfa_a1_profile")).toBe(false);
+  });
+
+  it("retains the prior latest bytes and marks block-coaching degradation", async () => {
+    const root = await home();
+    await writeJson(root, "latest.json", latest("flag"));
+    await writeJson(root, "error_state.json", errorState("block_coaching"));
+    const state = await createPersistedAthleteStateSource({ dataDir: root }).getAthleteState();
+    expect(state.degraded).toBe(true);
+    expect(state.freshness).toBe("flag");
+    expect(state.currentStatus).toEqual({ summary: "ready" });
+    expect(state.plannedWorkouts).toEqual([{ id: "workout-1" }]);
+    expect(state.lastSynced).toBe(state.lastUpdated);
+  });
+
+  it("fails open for every absent, malformed, invalid, or mismatched error sidecar", async () => {
+    const variants: unknown[] = [undefined, "{", { no: "schema" }, {
+      ...errorState("block_coaching"),
+      schema_version: "different",
+    }];
+    for (const variant of variants) {
+      const root = await home();
+      await writeJson(root, "latest.json", latest());
+      if (variant !== undefined) {
+        await writeFile(
+          join(root, "data", "error_state.json"),
+          typeof variant === "string" ? variant : JSON.stringify(variant),
+        );
+      }
+      await expect(createPersistedAthleteStateSource({ dataDir: root }).getAthleteState())
+        .resolves.toMatchObject({ degraded: false });
+    }
+  });
+
+  it("preserves all persisted freshness bands despite later file timestamps", async () => {
+    for (const freshness of ["fresh", "flag", "stale", "critical"] as const) {
+      const root = await home();
+      await writeJson(root, "latest.json", latest(freshness));
+      const future = new Date("2030-01-01T00:00:00.000Z");
+      await utimes(join(root, "data", "latest.json"), future, future);
+      await expect(createPersistedAthleteStateSource({ dataDir: root }).getAthleteState())
+        .resolves.toMatchObject({ freshness });
+    }
+  });
+
+  it("throws the stable unavailable error for absent, invalid, and wrong-version latest", async () => {
+    const variants: unknown[] = [undefined, "{", latest(), {
+      ...latest(),
+      metadata: { ...latest().metadata, schema_version: "different" },
+    }];
+    (variants[2] as ReturnType<typeof latest>).metadata.freshness = "invalid" as never;
+    for (const variant of variants) {
+      const root = await home();
+      if (variant !== undefined) {
+        await writeFile(
+          join(root, "data", "latest.json"),
+          typeof variant === "string" ? variant : JSON.stringify(variant),
+        );
+      }
+      await expect(createPersistedAthleteStateSource({ dataDir: root }).getAthleteState())
+        .rejects.toEqual(new AthleteStateUnavailableError("No validated athlete state is available."));
+    }
+  });
+
+  it("reads a single persisted pair per call without exposing file paths or schema issues", async () => {
+    const root = await home();
+    const selected = latest();
+    await writeJson(root, "latest.json", selected);
+    await writeJson(root, "error_state.json", errorState());
+    const source = createPersistedAthleteStateSource({ dataDir: root });
+    const first = await source.getAthleteState();
+    selected.current_status = { summary: "changed" };
+    await writeJson(root, "latest.json", selected);
+    const second = await source.getAthleteState();
+    expect(first.currentStatus).toEqual({ summary: "ready" });
+    expect(second.currentStatus).toEqual({ summary: "changed" });
+    const unavailableRoot = await home();
+    const failure = await createPersistedAthleteStateSource({ dataDir: unavailableRoot })
+      .getAthleteState().catch((error: unknown) => error);
+    expect(failure).toBeInstanceOf(AthleteStateUnavailableError);
+    expect(String(failure)).not.toContain(unavailableRoot);
+    expect(String(failure)).not.toContain("Zod");
+  });
+});

--- a/packages/coach/tests/coach-engine-adapter.test.ts
+++ b/packages/coach/tests/coach-engine-adapter.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  type AthleteState,
+  type ChatRequest,
+  type CoachEngine,
+  type TurnEvent,
+} from "@enduragent/coach-contract";
+import type {
+  CyclingFtpAnchorResolver,
+  CyclingFtpAnchorResult,
+} from "@enduragent/kernel/anchors";
+import { createCoachEngineAdapter } from "../src/coach-engine-adapter.js";
+
+const state: AthleteState = {
+  schemaVersion: "3",
+  lastUpdated: "2026-07-18T00:00:00.000Z",
+  freshness: "fresh",
+  degraded: false,
+  lastSynced: "2026-07-18T00:00:00.000Z",
+  athleteProfile: { name: "Synthetic Athlete" },
+  currentStatus: { summary: "ready" },
+  derivedMetrics: { eftp: 250 },
+  recentActivities: [],
+  plannedWorkouts: [],
+  wellness: {},
+};
+
+const ftp: CyclingFtpAnchorResult = {
+  kind: "ftp",
+  watts: 250,
+  validFrom: "2026-07-01",
+  source: "synthetic",
+  confidence: "manual",
+  ageDays: 17,
+  stalenessBand: "fresh",
+  stale: false,
+};
+
+function resolver(result: CyclingFtpAnchorResult = ftp): {
+  value: CyclingFtpAnchorResolver;
+  resolve: ReturnType<typeof vi.fn<CyclingFtpAnchorResolver["resolve"]>>;
+} {
+  const resolve = vi.fn<CyclingFtpAnchorResolver["resolve"]>(async () => result);
+  return { value: { resolve }, resolve };
+}
+
+function backend(overrides: Partial<CoachEngine> = {}): CoachEngine {
+  return {
+    chat: async () => ({ text: "ok" }),
+    resetSession: async () => ({ memoryFlushed: true }),
+    hasSession: async () => ({ hasSession: false }),
+    getAthleteState: async () => state,
+    ...overrides,
+  };
+}
+
+describe("coach engine adapter", () => {
+  it("resolves one FTP anchor at the call epoch and validates event order and response", async () => {
+    const selected = resolver();
+    const calls: string[] = [];
+    const chat = vi.fn<CoachEngine["chat"]>(async (request, onEvent) => {
+      calls.push("backend");
+      expect(request.turn?.resolvedCs).toEqual(ftp);
+      onEvent?.({ type: "turn-start", turnId: "turn-1", chatId: request.chatId });
+      return { text: "ready" };
+    });
+    const engine = createCoachEngineAdapter({
+      backend: backend({ chat }),
+      getAthleteState: async () => state,
+      cyclingFtpAnchorResolver: selected.value,
+      now: () => 1_752_796_801_999,
+    });
+    await expect(engine.chat({ chatId: "chat-1", message: "status" }, () => {
+      calls.push("event");
+    })).resolves.toEqual({ text: "ready" });
+    expect(selected.resolve).toHaveBeenCalledOnce();
+    expect(selected.resolve).toHaveBeenCalledWith({
+      effectiveAtEpochS: 1_752_796_801,
+      evaluatedAtEpochS: 1_752_796_801,
+    });
+    expect(calls).toEqual(["backend", "event"]);
+  });
+
+  it("rejects invalid chat requests before clock, resolver, or backend", async () => {
+    const selected = resolver();
+    const chat = vi.fn<CoachEngine["chat"]>(async () => ({ text: "no" }));
+    const now = vi.fn(() => 0);
+    const engine = createCoachEngineAdapter({
+      backend: backend({ chat }),
+      getAthleteState: async () => state,
+      cyclingFtpAnchorResolver: selected.value,
+      now,
+    });
+    await expect(engine.chat({ chatId: "x", message: "x", extra: true } as ChatRequest))
+      .rejects.toThrow();
+    expect(now).not.toHaveBeenCalled();
+    expect(selected.resolve).not.toHaveBeenCalled();
+    expect(chat).not.toHaveBeenCalled();
+  });
+
+  it("latches invalid events, validates responses, keeps consumer errors advisory, and favors backend errors", async () => {
+    const selected = resolver();
+    const invalidEvent = { type: "turn-start", turnId: "x" } as unknown as TurnEvent;
+    const invalid = createCoachEngineAdapter({
+      backend: backend({ chat: async (_request, onEvent) => {
+        try {
+          onEvent?.(invalidEvent);
+        } catch {}
+        return { text: "ok" };
+      } }),
+      getAthleteState: async () => state,
+      cyclingFtpAnchorResolver: selected.value,
+      now: () => 0,
+    });
+    await expect(invalid.chat({ chatId: "x", message: "x" })).rejects.toThrow();
+    const backendError = { kind: "backend" };
+    const precedence = createCoachEngineAdapter({
+      backend: backend({ chat: async (_request, onEvent) => {
+        onEvent?.(invalidEvent);
+        throw backendError;
+      } }),
+      getAthleteState: async () => state,
+      cyclingFtpAnchorResolver: resolver().value,
+      now: () => 0,
+    });
+    await expect(precedence.chat({ chatId: "x", message: "x" })).rejects.toBe(backendError);
+    const advisory = createCoachEngineAdapter({
+      backend: backend({ chat: async (_request, onEvent) => {
+        onEvent?.({ type: "final-text", turnId: "x", text: "ok" });
+        return { text: "ok" };
+      } }),
+      getAthleteState: async () => state,
+      cyclingFtpAnchorResolver: resolver().value,
+      now: () => 0,
+    });
+    await expect(advisory.chat({ chatId: "x", message: "x" }, () => {
+      throw new Error("consumer");
+    })).resolves.toEqual({ text: "ok" });
+    const malformed = createCoachEngineAdapter({
+      backend: backend({ chat: async () => ({ text: 1 } as unknown as { text: string }) }),
+      getAthleteState: async () => state,
+      cyclingFtpAnchorResolver: resolver().value,
+      now: () => 0,
+    });
+    await expect(malformed.chat({ chatId: "x", message: "x" })).rejects.toThrow();
+  });
+
+  it("strictly validates reset requests and responses", async () => {
+    const resetSession = vi.fn<CoachEngine["resetSession"]>(async () => ({ memoryFlushed: true }));
+    const engine = createCoachEngineAdapter({
+      backend: backend({ resetSession }),
+      getAthleteState: async () => state,
+      cyclingFtpAnchorResolver: resolver().value,
+      now: () => 0,
+    });
+    await expect(engine.resetSession({ chatId: "x", extra: 1 } as never)).rejects.toThrow();
+    expect(resetSession).not.toHaveBeenCalled();
+    await expect(engine.resetSession({ chatId: "x" })).resolves.toEqual({ memoryFlushed: true });
+    resetSession.mockResolvedValueOnce({ memoryFlushed: true, extra: 1 } as never);
+    await expect(engine.resetSession({ chatId: "x" })).rejects.toThrow();
+  });
+
+  it("strictly validates has-session requests and responses asynchronously", async () => {
+    const hasSession = vi.fn<CoachEngine["hasSession"]>(async () => ({ hasSession: true }));
+    const engine = createCoachEngineAdapter({
+      backend: backend({ hasSession }),
+      getAthleteState: async () => state,
+      cyclingFtpAnchorResolver: resolver().value,
+      now: () => 0,
+    });
+    const pending = engine.hasSession({ chatId: "x" });
+    expect(pending).toBeInstanceOf(Promise);
+    await expect(pending).resolves.toEqual({ hasSession: true });
+    await expect(engine.hasSession({ chatId: "x", extra: 1 } as never)).rejects.toThrow();
+    hasSession.mockResolvedValueOnce({ hasSession: false, extra: 1 } as never);
+    await expect(engine.hasSession({ chatId: "x" })).rejects.toThrow();
+  });
+
+  it("validates injected athlete state and exposes exactly four methods", async () => {
+    const getAthleteState = vi.fn(async (): Promise<AthleteState> => state);
+    const engine = createCoachEngineAdapter({
+      backend: backend(),
+      getAthleteState,
+      cyclingFtpAnchorResolver: resolver().value,
+      now: () => 0,
+    });
+    await expect(engine.getAthleteState()).resolves.toEqual(state);
+    expect(getAthleteState).toHaveBeenCalledOnce();
+    expect(Object.keys(engine).sort()).toEqual([
+      "chat",
+      "getAthleteState",
+      "hasSession",
+      "resetSession",
+    ]);
+    await expect(createCoachEngineAdapter({
+      backend: backend(),
+      getAthleteState: async () => ({ ...state, extra: true } as AthleteState),
+      cyclingFtpAnchorResolver: resolver().value,
+      now: () => 0,
+    }).getAthleteState()).rejects.toThrow();
+  });
+
+  it("always replaces a caller FTP value without mutating either caller object", async () => {
+    const request = { chatId: "x", message: "x", turn: { resolvedCs: { old: true } } };
+    const turn = request.turn;
+    let received: ChatRequest | undefined;
+    const engine = createCoachEngineAdapter({
+      backend: backend({ chat: async (value) => {
+        received = value;
+        return { text: "ok" };
+      } }),
+      getAthleteState: async () => state,
+      cyclingFtpAnchorResolver: resolver().value,
+      now: () => 0,
+    });
+    await engine.chat(request);
+    expect(received?.turn?.resolvedCs).toEqual(ftp);
+    expect(request.turn.resolvedCs).toEqual({ old: true });
+    expect(received).not.toBe(request);
+    expect(received?.turn).not.toBe(turn);
+  });
+
+  it("forwards the complete missing-anchor result", async () => {
+    const missing = { kind: "missing" as const, refusal: "missing-cycling-ftp-anchor" as const };
+    let received: ChatRequest | undefined;
+    const engine = createCoachEngineAdapter({
+      backend: backend({ chat: async (value) => {
+        received = value;
+        return { text: "ok" };
+      } }),
+      getAthleteState: async () => state,
+      cyclingFtpAnchorResolver: resolver(missing).value,
+      now: () => 0,
+    });
+    await expect(engine.chat({ chatId: "x", message: "x" })).resolves.toEqual({ text: "ok" });
+    expect(received?.turn?.resolvedCs).toEqual(missing);
+  });
+});

--- a/packages/coach/tests/coach-sync.test.ts
+++ b/packages/coach/tests/coach-sync.test.ts
@@ -26,6 +26,7 @@ import {
   CoachStoreWriterError,
   withCoachStoreWriter,
   type CoachStoreWriterContext,
+  type CoachStoreWriterPlan,
 } from "../src/runtime.js";
 import {
   runCoachSync,
@@ -59,6 +60,16 @@ function syntheticHome(root = "synthetic-root"): AthleteHome {
     archiveDir: join(root, "archive"),
     configDir: join(root, "config"),
   };
+}
+
+function writerOperation<T>(
+  operationOrPlan:
+    | ((context: CoachStoreWriterContext) => Promise<T>)
+    | CoachStoreWriterPlan<T>,
+): (context: CoachStoreWriterContext) => Promise<T> {
+  return typeof operationOrPlan === "function"
+    ? operationOrPlan
+    : operationOrPlan.operation;
 }
 
 function syntheticStore(): CoachStoreWriterContext["store"] {
@@ -217,16 +228,19 @@ describe("coach sync composition", () => {
   it("runtime maps contention and every lifecycle failure without private error data", async () => {
     const privateValue = "private dependency data";
     const operation = async () => privateValue;
+    const contention = { kind: "holder" as const, pid: 123, port: 4567 };
     const contentionWriter = async <T>(): Promise<CoachDevWriterResult<T>> => ({
       status: "writer-lock-held",
+      contention,
     });
     await expect(
       withCoachStoreWriter({}, operation, { runWriter: contentionWriter }),
-    ).rejects.toEqual(new CoachStoreWriterError("writer-lock-held", null));
+    ).rejects.toEqual(new CoachStoreWriterError("writer-lock-held", null, undefined, contention));
 
     const stages: readonly CoachDevWriterFailureStage[] = [
       "resolve home",
       "acquire lock",
+      "run pre-open operation",
       "create store directory",
       "secure store directory",
       "open store",
@@ -275,6 +289,31 @@ describe("coach sync composition", () => {
     expect(JSON.stringify(caught)).not.toContain("private operation failure detail");
   });
 
+  it("forwards the pre-open plan and preserves the cause constructor position", async () => {
+    const context = syntheticContext();
+    const trace: string[] = [];
+    const runWriter = async <T>(
+      options: RunCoachDevWriterOptions<T>,
+    ): Promise<CoachDevWriterResult<T>> => {
+      await options.beforeStoreOpen?.(context.home);
+      return { status: "completed", value: await options.operation(context) };
+    };
+    await expect(withCoachStoreWriter({}, {
+      beforeStoreOpen: async (home) => {
+        expect(home).toBe(context.home);
+        trace.push("before");
+      },
+      operation: async (received) => {
+        expect(received).toBe(context);
+        trace.push("operation");
+        return "done";
+      },
+    }, { runWriter })).resolves.toBe("done");
+    expect(trace).toEqual(["before", "operation"]);
+    const cause = new Error("private");
+    expect(new CoachStoreWriterError("writer-failed", "open store", { cause }).cause).toBe(cause);
+  });
+
   it("validates the complete request before acquiring the writer", async () => {
     let writerCalls = 0;
     let sourceCalls = 0;
@@ -282,10 +321,12 @@ describe("coach sync composition", () => {
     const context = syntheticContext();
     const withWriter: typeof withCoachStoreWriter = async <T>(
       _env: Record<string, string | undefined>,
-      operation: (value: CoachStoreWriterContext) => Promise<T>,
+      operationOrPlan:
+        | ((value: CoachStoreWriterContext) => Promise<T>)
+        | CoachStoreWriterPlan<T>,
     ): Promise<T> => {
       writerCalls += 1;
-      return operation(context);
+      return writerOperation(operationOrPlan)(context);
     };
     const importFiles: typeof importFilesWithReport = async () => {
       importCalls += 1;
@@ -384,8 +425,10 @@ describe("coach sync composition", () => {
     let maximumRunning = 0;
     const withWriter: typeof withCoachStoreWriter = async <T>(
       _env: Record<string, string | undefined>,
-      operation: (value: CoachStoreWriterContext) => Promise<T>,
-    ): Promise<T> => operation(context);
+      operationOrPlan:
+        | ((value: CoachStoreWriterContext) => Promise<T>)
+        | CoachStoreWriterPlan<T>,
+    ): Promise<T> => writerOperation(operationOrPlan)(context);
     const importFiles: typeof importFilesWithReport = async () => importReport;
     const binding = (id: SourceId, shouldFail: boolean): CoachSourceBinding => ({
       source: syncSource(id),
@@ -442,8 +485,10 @@ describe("coach sync composition", () => {
     let importCalls = 0;
     const withWriter: typeof withCoachStoreWriter = async <T>(
       _env: Record<string, string | undefined>,
-      operation: (value: CoachStoreWriterContext) => Promise<T>,
-    ): Promise<T> => operation(context);
+      operationOrPlan:
+        | ((value: CoachStoreWriterContext) => Promise<T>)
+        | CoachStoreWriterPlan<T>,
+    ): Promise<T> => writerOperation(operationOrPlan)(context);
     const importFiles: typeof importFilesWithReport = async (options) => {
       importCalls += 1;
       order.push("import");
@@ -485,8 +530,10 @@ describe("coach sync composition", () => {
     let importCalls = 0;
     const withWriter: typeof withCoachStoreWriter = async <T>(
       _env: Record<string, string | undefined>,
-      operation: (value: CoachStoreWriterContext) => Promise<T>,
-    ): Promise<T> => operation(context);
+      operationOrPlan:
+        | ((value: CoachStoreWriterContext) => Promise<T>)
+        | CoachStoreWriterPlan<T>,
+    ): Promise<T> => writerOperation(operationOrPlan)(context);
     const importFiles: typeof importFilesWithReport = async () => {
       importCalls += 1;
       return importReport;

--- a/packages/coach/tests/composition.test.ts
+++ b/packages/coach/tests/composition.test.ts
@@ -1,0 +1,418 @@
+import { mkdir, mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AthleteState, CoachEngine } from "@enduragent/coach-contract";
+import {
+  engineConfigFromConfig,
+  type Config,
+} from "@enduragent/core";
+import type {
+  AthleteDataReaderPort,
+  CreateCoachEngineInput,
+  ModelTransportDecorator,
+} from "@enduragent/engine";
+import { createPhysicalRequestLedger, runMigrations } from "@enduragent/kernel/store";
+import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
+import type { CyclingFtpAnchorResolver } from "@enduragent/kernel/anchors";
+import type { AthleteHome } from "@enduragent/kernel-node/home";
+import { openSqliteStorage } from "@enduragent/kernel-node/sqlite";
+import {
+  createLocalCoachComposition,
+  type LocalCoachCompositionDependencies,
+  type LocalReferenceRuntime,
+  type LocalStoreRuntime,
+} from "../src/composition.js";
+import type { CoachStoreWriterContext } from "../src/runtime.js";
+
+const roots: string[] = [];
+const stores: CoachStoreWriterContext["store"][] = [];
+
+const state: AthleteState = {
+  schemaVersion: "3",
+  lastUpdated: "2026-07-18T00:00:00.000Z",
+  freshness: "fresh",
+  degraded: true,
+  lastSynced: "2026-07-18T00:00:00.000Z",
+  athleteProfile: { name: "Synthetic Athlete" },
+  currentStatus: { summary: "current" },
+  derivedMetrics: { eftp: 260, future_metric: 1 },
+  derivedMetricsMeta: {
+    sportFamily: "cycling",
+    prescriptionBasis: "power",
+    anchorType: "ftp",
+    analysisBasis: "power",
+  },
+  recentActivities: [{ id: "activity-1" }],
+  plannedWorkouts: [{ id: "workout-1" }],
+  wellness: { restingHr: 45 },
+};
+
+function latest() {
+  return {
+    metadata: {
+      schema_version: "3",
+      last_updated: state.lastUpdated,
+      freshness: state.freshness,
+    },
+    athlete_profile: state.athleteProfile,
+    current_status: state.currentStatus,
+    derived_metrics: state.derivedMetrics,
+    derived_metrics_meta: state.derivedMetricsMeta,
+    recent_activities: state.recentActivities,
+    planned_workouts: state.plannedWorkouts,
+    wellness_data: state.wellness,
+  };
+}
+
+async function freshHome(): Promise<AthleteHome> {
+  const root = await mkdtemp(join(await realpath(tmpdir()), "coach-composition-"));
+  roots.push(root);
+  const home = {
+    root,
+    storeDir: join(root, "store"),
+    archiveDir: join(root, "archive"),
+    configDir: join(root, "config"),
+  };
+  await mkdir(join(root, "data"), { recursive: true });
+  await mkdir(home.configDir, { recursive: true });
+  await writeFile(join(root, "data", "latest.json"), JSON.stringify(latest()));
+  await writeFile(join(root, "data", "error_state.json"), JSON.stringify({
+    schema_version: "1",
+    step: "synthetic",
+    detail: "synthetic outage",
+    ts: "2026-07-18T01:00:00.000Z",
+    mitigation: "block_coaching",
+  }));
+  return home;
+}
+
+function config(home: AthleteHome): Config {
+  return {
+    dataSource: "store",
+    llm: { provider: "anthropic", model: "synthetic", apiKey: "" },
+    intervals: { apiKey: "", athleteId: "synthetic" },
+    telegram: { botToken: "" },
+    session: {
+      historyTokenBudgetRatio: 0.3,
+      idleMinutes: 0,
+      dailyResetHour: 4,
+      resetArchiveRetentionDays: 0,
+      timezone: "UTC",
+    },
+    contextWindowTokens: 1000,
+    dataDir: home.root,
+  };
+}
+
+function athleteData(): AthleteDataReaderPort {
+  return {
+    async getAthlete() { return { ok: false, error: "not_found", message: "synthetic" }; },
+    async listWellness() { return { ok: true, value: [] }; },
+    async listActivities() { return { ok: true, value: [] }; },
+    async getActivity() { return { ok: false, error: "not_found", message: "synthetic" }; },
+    async getStreams() { return { ok: false, error: "not_found", message: "synthetic" }; },
+    async listCalendar() { return { ok: true, value: [] }; },
+    freshness() { return undefined; },
+  };
+}
+
+function reference(trace: string[] = []): LocalReferenceRuntime {
+  return {
+    scheduler: { stop: () => { trace.push("reference-stop"); } },
+    async runScheduledOnce() { return { kind: "skipped", reason: "cooldown" }; },
+  };
+}
+
+function runtime(
+  trace: string[] = [],
+  options: { runWindow?: () => Promise<{ published: boolean; counts: ReturnType<ReturnType<typeof createPhysicalRequestLedger>["snapshot"]>; legacySucceeded: boolean }>; close?: () => Promise<void> } = {},
+): LocalStoreRuntime {
+  const ledger = createPhysicalRequestLedger({ storeLimit: 64, legacyLimit: 15, totalLimit: 79 });
+  return {
+    athleteData: athleteData(),
+    attemptLedgerForRun: () => ledger,
+    runWindow: options.runWindow ?? (async () => {
+      trace.push("run-window");
+      return { published: true, counts: ledger.snapshot(), legacySucceeded: true };
+    }),
+    startScheduler() { trace.push("start-scheduler"); },
+    close: options.close ?? (async () => { trace.push("runtime-close"); }),
+  };
+}
+
+function backend(overrides: Partial<CoachEngine> = {}): CoachEngine {
+  return {
+    chat: async () => ({ text: "ok" }),
+    resetSession: async () => ({ memoryFlushed: true }),
+    hasSession: async () => ({ hasSession: false }),
+    getAthleteState: async () => state,
+    ...overrides,
+  };
+}
+
+function missingResolver(): CyclingFtpAnchorResolver {
+  return { resolve: async () => ({ kind: "missing", refusal: "missing-cycling-ftp-anchor" }) };
+}
+
+function fakeContext(home: AthleteHome): CoachStoreWriterContext {
+  return {
+    home,
+    store: {
+      async exec() {},
+      async run() {},
+      async get() { return undefined; },
+      async all() { return []; },
+      async close() {},
+      async getUserVersion() { return 0; },
+      async setUserVersion() {},
+      async transaction<T>(operation: () => Promise<T>) { return operation(); },
+    },
+  };
+}
+
+async function compose(
+  home: AthleteHome,
+  dependencies: LocalCoachCompositionDependencies,
+  context = fakeContext(home),
+) {
+  const coreConfig = config(home);
+  return createLocalCoachComposition({
+    env: { ENDURAGENT_HOME: home.root },
+    home,
+    context,
+    config: coreConfig,
+    engineConfig: engineConfigFromConfig(coreConfig),
+  }, dependencies);
+}
+
+function generation(text: string) {
+  return {
+    text,
+    toolCalls: [],
+    finishReason: "stop" as const,
+    usage: {
+      inputTokens: 0,
+      outputTokens: 0,
+      totalTokens: 0,
+      inputTokenDetails: { noCacheTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 },
+      outputTokenDetails: { textTokens: 0, reasoningTokens: 0 },
+    },
+    steps: 1,
+  };
+}
+
+afterEach(async () => {
+  await Promise.all(stores.splice(0).map((store) => store.close().catch(() => {})));
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("local coach composition", () => {
+  it("constructs the complete object-shaped engine input from named host owners", async () => {
+    const home = await freshHome();
+    const selectedRuntime = runtime();
+    let received: CreateCoachEngineInput | undefined;
+    const lifecycle = await compose(home, {
+      bootstrap: async () => reference(),
+      createRuntime: () => selectedRuntime,
+      createBackend: (input) => {
+        received = input;
+        return backend();
+      },
+      createRepository: () => ({
+        insertIfAbsent: async () => false,
+        readCurrent: async () => undefined,
+      }),
+      createResolver: () => missingResolver(),
+      now: () => 1000,
+      randomId: () => "synthetic-id",
+    });
+    expect(received?.sport.id).toBe("cycling");
+    expect(Object.keys(received!.ports).sort()).toEqual([
+      "chatStore",
+      "classifyFailure",
+      "config",
+      "extractRetryAfterMs",
+      "getAccessToken",
+      "logger",
+      "memory",
+      "modelTransportDecorator",
+      "now",
+      "onToolsAssembled",
+      "platform",
+      "randomId",
+      "readReferenceState",
+      "secrets",
+      "stateReader",
+      "usage",
+    ]);
+    expect(received?.ports.platform.legacyClient).toBeNull();
+    expect(received?.ports.platform.athleteData).toBe(selectedRuntime.athleteData);
+    expect(received?.ports.config).toEqual(engineConfigFromConfig(config(home)));
+    await lifecycle.close();
+  });
+
+  it("binds one persisted source to both state paths while keeping tool and disclosure readers separate", async () => {
+    const home = await freshHome();
+    const selectedRuntime = runtime();
+    let received: CreateCoachEngineInput | undefined;
+    const lifecycle = await compose(home, {
+      bootstrap: async () => reference(),
+      createRuntime: () => selectedRuntime,
+      createBackend: (input) => {
+        received = input;
+        return backend({ getAthleteState: () => input.ports.stateReader.getAthleteState() });
+      },
+      createRepository: () => ({ insertIfAbsent: async () => false, readCurrent: async () => undefined }),
+      createResolver: () => missingResolver(),
+    });
+    await expect(received!.ports.stateReader.getAthleteState()).resolves.toEqual(state);
+    await expect(lifecycle.engine.getAthleteState()).resolves.toEqual(state);
+    expect(received!.ports.platform.athleteData).toBe(selectedRuntime.athleteData);
+    expect(received!.ports.readReferenceState).not.toBe(received!.ports.stateReader.getAthleteState);
+    expect(received!.ports.readReferenceState().latest?.metadata?.last_updated).toBe(state.lastUpdated);
+    await lifecycle.close();
+  });
+
+  it("awaits cold start before scheduling and exposes no engine after cold-start failure", async () => {
+    const home = await freshHome();
+    await rm(join(home.root, "data", "latest.json"));
+    const failure = { kind: "cold-start" };
+    const trace: string[] = [];
+    const createBackend = vi.fn<(input: CreateCoachEngineInput) => CoachEngine>(() => backend());
+    await expect(compose(home, {
+      bootstrap: async () => reference(trace),
+      createRuntime: () => runtime(trace, {
+        runWindow: async () => {
+          trace.push("run-window");
+          throw failure;
+        },
+      }),
+      createBackend,
+      createRepository: () => ({ insertIfAbsent: async () => false, readCurrent: async () => undefined }),
+      createResolver: () => missingResolver(),
+    })).rejects.toBe(failure);
+    expect(createBackend).not.toHaveBeenCalled();
+    expect(trace).toEqual(["run-window", "reference-stop", "runtime-close"]);
+  });
+
+  it("backs all four methods with a real writer store, repository, resolver, and persisted render", async () => {
+    const home = await freshHome();
+    await mkdir(home.storeDir, { recursive: true });
+    const store = openSqliteStorage(join(home.storeDir, "store.db"));
+    stores.push(store);
+    await runMigrations(store, MIGRATIONS);
+    await store.run(
+      "INSERT INTO anchor_history (id, sport, anchor_type, value, unit, valid_from, source, confidence, note, provenance, device_id, hlc_physical_ms, hlc_counter) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)",
+      ["anchor-1", "cycling", "ftp", 275, "W", 1_752_796_000, "synthetic", "manual", null, "manual", null, null, null],
+    );
+    let chatRequest: Parameters<CoachEngine["chat"]>[0] | undefined;
+    const lifecycle = await compose(home, {
+      bootstrap: async () => reference(),
+      createRuntime: () => runtime(),
+      createBackend: (input) => backend({
+        chat: async (request) => {
+          chatRequest = request;
+          return { text: "anchored" };
+        },
+        getAthleteState: () => input.ports.stateReader.getAthleteState(),
+        hasSession: async () => ({ hasSession: true }),
+        resetSession: async () => ({ memoryFlushed: true }),
+      }),
+      now: () => 1_752_796_800_000,
+    }, { home, store });
+    await expect(lifecycle.engine.chat({ chatId: "x", message: "status" }))
+      .resolves.toEqual({ text: "anchored" });
+    expect(chatRequest?.turn?.resolvedCs).toMatchObject({ kind: "ftp", watts: 275 });
+    await expect(lifecycle.engine.hasSession({ chatId: "x" })).resolves.toEqual({ hasSession: true });
+    await expect(lifecycle.engine.resetSession({ chatId: "x" })).resolves.toEqual({ memoryFlushed: true });
+    await expect(lifecycle.engine.getAthleteState()).resolves.toMatchObject({
+      currentStatus: state.currentStatus,
+      derivedMetrics: state.derivedMetrics,
+      plannedWorkouts: state.plannedWorkouts,
+      degraded: true,
+    });
+    await lifecycle.close();
+  });
+
+  it("uses the extracted engine FIFO per chat id while allowing different ids to overlap", async () => {
+    const home = await freshHome();
+    let generateCalls = 0;
+    let releaseFirst!: () => void;
+    let markEntered!: () => void;
+    const entered = new Promise<void>((resolve) => { markEntered = resolve; });
+    const firstGate = new Promise<void>((resolve) => { releaseFirst = resolve; });
+    const decorator: ModelTransportDecorator = () => ({
+      generate: async () => {
+        generateCalls += 1;
+        if (generateCalls === 1) {
+          markEntered();
+          await firstGate;
+        }
+        return generation(`reply-${generateCalls}`);
+      },
+    });
+    const lifecycle = await compose(home, {
+      bootstrap: async () => reference(),
+      createRuntime: () => runtime(),
+      createRepository: () => ({ insertIfAbsent: async () => false, readCurrent: async () => undefined }),
+      createResolver: () => missingResolver(),
+      modelTransportDecorator: decorator,
+    });
+    const completion: string[] = [];
+    const first = lifecycle.engine.chat({ chatId: "same", message: "first" })
+      .then((value) => { completion.push("first"); return value; });
+    await entered;
+    const second = lifecycle.engine.chat({ chatId: "same", message: "second" })
+      .then((value) => { completion.push("second"); return value; });
+    await Promise.resolve();
+    expect(generateCalls).toBe(1);
+    const other = lifecycle.engine.chat({ chatId: "other", message: "other" })
+      .then((value) => { completion.push("other"); return value; });
+    while (generateCalls < 2) await Promise.resolve();
+    expect(generateCalls).toBe(2);
+    releaseFirst();
+    await Promise.all([first, second, other]);
+    expect(completion.indexOf("first")).toBeLessThan(completion.indexOf("second"));
+    await lifecycle.close();
+  });
+
+  it("closes host adapters, reference scheduling, and an active store runtime once in order", async () => {
+    const home = await freshHome();
+    const trace: string[] = [];
+    const hostFailure = { kind: "host-close" };
+    let releaseClose!: () => void;
+    let markCloseStarted!: () => void;
+    const closeGate = new Promise<void>((resolve) => { releaseClose = resolve; });
+    const closeStarted = new Promise<void>((resolve) => { markCloseStarted = resolve; });
+    let runtimeCloseCalls = 0;
+    const lifecycle = await compose(home, {
+      bootstrap: async () => reference(trace),
+      createRuntime: () => runtime(trace, {
+        close: async () => {
+          runtimeCloseCalls += 1;
+          trace.push("runtime-close-start");
+          markCloseStarted();
+          await closeGate;
+          trace.push("runtime-close-end");
+        },
+      }),
+      createBackend: () => backend(),
+      createRepository: () => ({ insertIfAbsent: async () => false, readCurrent: async () => undefined }),
+      createResolver: () => missingResolver(),
+      closeHostAdapters: async () => {
+        trace.push("host-close");
+        throw hostFailure;
+      },
+    });
+    const first = lifecycle.close();
+    const second = lifecycle.close();
+    await closeStarted;
+    expect(trace.slice(-3)).toEqual(["host-close", "reference-stop", "runtime-close-start"]);
+    releaseClose();
+    await expect(first).rejects.toBe(hostFailure);
+    await expect(second).rejects.toBe(hostFailure);
+    expect(runtimeCloseCalls).toBe(1);
+    expect(trace.at(-1)).toBe("runtime-close-end");
+  });
+});

--- a/packages/coach/tests/local-runner.test.ts
+++ b/packages/coach/tests/local-runner.test.ts
@@ -1,0 +1,375 @@
+import { mkdir, mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AthleteState, CoachEngine } from "@enduragent/coach-contract";
+import type { Config } from "@enduragent/core";
+import type { EngineConfig } from "@enduragent/engine";
+import type { AthleteHome } from "@enduragent/kernel-node/home";
+import type { CoachStoreWriterContext, CoachStoreWriterPlan } from "../src/runtime.js";
+
+const mocks = vi.hoisted(() => ({
+  withWriter: vi.fn(),
+  migrate: vi.fn(),
+  readiness: vi.fn(),
+  composition: vi.fn(),
+  loadConfig: vi.fn(),
+  project: vi.fn(),
+}));
+
+vi.mock("../src/runtime.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../src/runtime.js")>()),
+  withCoachStoreWriter: mocks.withWriter,
+}));
+vi.mock("../src/legacy-migration.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../src/legacy-migration.js")>()),
+  migrateLegacyHomeUnderLock: mocks.migrate,
+}));
+vi.mock("../src/readiness.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../src/readiness.js")>()),
+  checkHomeReadiness: mocks.readiness,
+}));
+vi.mock("../src/composition.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../src/composition.js")>()),
+  createLocalCoachComposition: mocks.composition,
+}));
+vi.mock("@enduragent/core", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@enduragent/core")>()),
+  loadConfig: mocks.loadConfig,
+  engineConfigFromConfig: mocks.project,
+}));
+
+import { CoachStoreWriterError } from "../src/runtime.js";
+import { withLocalCoach } from "../src/local-runner.js";
+
+const state: AthleteState = {
+  schemaVersion: "3",
+  lastUpdated: "2026-07-18T00:00:00.000Z",
+  freshness: "fresh",
+  degraded: false,
+  lastSynced: "2026-07-18T00:00:00.000Z",
+  athleteProfile: {},
+  currentStatus: {},
+  derivedMetrics: {},
+  recentActivities: [],
+  plannedWorkouts: [],
+  wellness: {},
+};
+
+const engine: CoachEngine = {
+  chat: async () => ({ text: "ok" }),
+  resetSession: async () => ({ memoryFlushed: true }),
+  hasSession: async () => ({ hasSession: false }),
+  getAthleteState: async () => state,
+};
+
+const config = {
+  dataSource: "store",
+  llm: { provider: "anthropic", model: "synthetic", apiKey: "" },
+  intervals: { apiKey: "", athleteId: "synthetic" },
+  telegram: { botToken: "" },
+  session: {
+    historyTokenBudgetRatio: 0.3,
+    idleMinutes: 0,
+    dailyResetHour: 4,
+    resetArchiveRetentionDays: 0,
+    timezone: "UTC",
+  },
+  contextWindowTokens: 1000,
+  dataDir: "",
+} satisfies Config;
+
+const engineConfig: EngineConfig = {
+  dataSource: "store",
+  llm: { provider: "anthropic", model: "synthetic", apiKey: "" },
+  session: config.session,
+  contextWindowTokens: 1000,
+  compactContextWindowTokens: 1000,
+};
+
+const roots: string[] = [];
+let selectedHome: AthleteHome;
+let context: CoachStoreWriterContext;
+let trace: string[];
+let closeImplementation: () => Promise<void>;
+
+async function freshHome(): Promise<AthleteHome> {
+  const root = await mkdtemp(join(await realpath(tmpdir()), "coach-local-runner-"));
+  roots.push(root);
+  return {
+    root,
+    storeDir: join(root, "store"),
+    archiveDir: join(root, "archive"),
+    configDir: join(root, "config"),
+  };
+}
+
+function store(): CoachStoreWriterContext["store"] {
+  return {
+    async exec() {},
+    async run() {},
+    async get() { return undefined; },
+    async all() { return []; },
+    async close() {},
+    async getUserVersion() { return 0; },
+    async setUserVersion() {},
+    async transaction<T>(operation: () => Promise<T>) { return operation(); },
+  };
+}
+
+function notNeeded() {
+  return {
+    status: "not-needed" as const,
+    exitCode: 0 as const,
+    journalPath: join(selectedHome.root, "migration.json"),
+    manifestDigest: null,
+  };
+}
+
+function input(operation: (lifecycle: { engine: CoachEngine; close(): Promise<void> }) => Promise<unknown>) {
+  return {
+    env: { SYNTHETIC: "1" },
+    home: selectedHome,
+    sourceRoot: join(selectedHome.root, "legacy-source"),
+    action: { kind: "resume" as const, isTTY: false },
+    operation,
+  };
+}
+
+beforeEach(async () => {
+  selectedHome = await freshHome();
+  context = { home: selectedHome, store: store() };
+  trace = [];
+  closeImplementation = async () => { trace.push("lifecycle-close"); };
+  mocks.withWriter.mockReset();
+  mocks.migrate.mockReset();
+  mocks.readiness.mockReset();
+  mocks.composition.mockReset();
+  mocks.loadConfig.mockReset();
+  mocks.project.mockReset();
+  mocks.migrate.mockImplementation(async () => {
+    trace.push("legacy-migration");
+    return notNeeded();
+  });
+  mocks.readiness.mockImplementation(async () => {
+    trace.push("readiness");
+    return { status: "ready", config: engineConfig };
+  });
+  mocks.loadConfig.mockReturnValue({ ...config, dataDir: selectedHome.root });
+  mocks.project.mockReturnValue(engineConfig);
+  mocks.composition.mockImplementation(async () => {
+    trace.push("engine-open");
+    return { engine, close: () => closeImplementation() };
+  });
+  mocks.withWriter.mockImplementation(async (
+    env: Record<string, string | undefined>,
+    plan: CoachStoreWriterPlan<unknown>,
+  ) => {
+    expect(env).toEqual({ SYNTHETIC: "1", ENDURAGENT_HOME: selectedHome.root });
+    trace.push("writer-acquired");
+    try {
+      await plan.beforeStoreOpen(selectedHome);
+      trace.push("store-open", "schema-migrations");
+      return await plan.operation(context);
+    } finally {
+      trace.push("store-close", "writer-release");
+    }
+  });
+});
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("local coach runner", () => {
+  it("runs the exact successful lock, migration, store, engine, operation, and cleanup order", async () => {
+    trace.push("resolve-supplied-home");
+    await expect(withLocalCoach(input(async () => {
+      trace.push("operation");
+      return "done";
+    }))).resolves.toEqual({ status: "completed", value: "done" });
+    expect(trace).toEqual([
+      "resolve-supplied-home",
+      "writer-acquired",
+      "legacy-migration",
+      "store-open",
+      "schema-migrations",
+      "readiness",
+      "engine-open",
+      "operation",
+      "lifecycle-close",
+      "store-close",
+      "writer-release",
+    ]);
+  });
+
+  it("releases the writer after migration throws without opening later stages", async () => {
+    const failure = { kind: "migration-failure" };
+    mocks.migrate.mockRejectedValue(failure);
+    await expect(withLocalCoach(input(async () => "unused"))).rejects.toBe(failure);
+    expect(trace).toEqual(["writer-acquired", "store-close", "writer-release"]);
+    expect(mocks.readiness).not.toHaveBeenCalled();
+    expect(mocks.composition).not.toHaveBeenCalled();
+  });
+
+  it("carries refused and discarded results exactly while only not-needed and done open the store", async () => {
+    const refused = {
+      status: "refused" as const,
+      exitCode: 3 as const,
+      journalPath: "synthetic-journal",
+      manifestDigest: "a".repeat(64),
+      reason: "source-drift" as const,
+      conflictIds: ["synthetic-conflict"],
+    };
+    const discarded = {
+      status: "discarded" as const,
+      exitCode: 0 as const,
+      journalPath: "synthetic-journal",
+      manifestDigest: "b".repeat(64),
+      archivePath: "synthetic-archive",
+    };
+    for (const terminal of [refused, discarded]) {
+      trace.length = 0;
+      mocks.migrate.mockResolvedValueOnce(terminal);
+      const result = await withLocalCoach(input(async () => "unused"));
+      expect(result).toEqual({
+        status: terminal.status === "refused" ? "migration-refused" : "migration-discarded",
+        result: terminal,
+      });
+      expect(trace).toEqual(["writer-acquired", "store-close", "writer-release"]);
+    }
+    for (const opening of [notNeeded(), {
+      status: "done" as const,
+      exitCode: 0 as const,
+      journalPath: "synthetic-journal",
+      manifestDigest: "c".repeat(64),
+      completion: "complete" as const,
+      copiedIds: [],
+      skipVerifiedIds: [],
+      skippedConflictIds: [],
+      freezePoint: "synthetic-freeze",
+    }]) {
+      trace.length = 0;
+      mocks.migrate.mockResolvedValueOnce(opening);
+      await expect(withLocalCoach(input(async () => "done")))
+        .resolves.toEqual({ status: "completed", value: "done" });
+      expect(trace).toContain("store-open");
+    }
+  });
+
+  it("returns not-configured with the exact path without engine construction or operation", async () => {
+    const configPath = join(selectedHome.configDir, "config.yaml");
+    mocks.readiness.mockResolvedValue({ status: "not-configured", configPath });
+    const operation = vi.fn(async () => "unused");
+    await expect(withLocalCoach(input(operation))).resolves.toEqual({
+      status: "not-configured",
+      configPath,
+    });
+    expect(mocks.composition).not.toHaveBeenCalled();
+    expect(operation).not.toHaveBeenCalled();
+    expect(trace.slice(-2)).toEqual(["store-close", "writer-release"]);
+  });
+
+  it("characterizes structural home readiness and the optional Config directory parameter", async () => {
+    const actualReadiness = await vi.importActual<typeof import("../src/readiness.js")>(
+      "../src/readiness.js",
+    );
+    const actualCore = await vi.importActual<typeof import("@enduragent/core")>("@enduragent/core");
+    mocks.loadConfig.mockImplementation(actualCore.loadConfig);
+    mocks.project.mockImplementation(actualCore.engineConfigFromConfig);
+    await mkdir(selectedHome.configDir, { recursive: true });
+    const configPath = join(selectedHome.configDir, "config.yaml");
+    await expect(actualReadiness.checkHomeReadiness(selectedHome)).resolves.toEqual({
+      status: "not-configured",
+      configPath,
+    });
+    await writeFile(configPath, "[");
+    await expect(actualReadiness.checkHomeReadiness(selectedHome)).resolves.toEqual({
+      status: "not-configured",
+      configPath,
+    });
+    await writeFile(configPath, "llm:\n  provider: openai-codex\ndata_dir: " + selectedHome.root + "\n");
+    await expect(actualReadiness.checkHomeReadiness(selectedHome)).resolves.toEqual({
+      status: "not-configured",
+      configPath,
+    });
+    await writeFile(join(selectedHome.configDir, "auth-profiles.json"), JSON.stringify({
+      "openai-codex": { type: "oauth" },
+    }));
+    const ready = await actualReadiness.checkHomeReadiness(selectedHome);
+    expect(ready.status).toBe("ready");
+    expect(actualCore.loadConfig(selectedHome.configDir).dataDir).toBe(selectedHome.root);
+    expect(actualCore.loadConfig.length).toBe(0);
+  });
+
+  it("rethrows the exact operation object only after lifecycle, store, and writer cleanup", async () => {
+    const failure = { kind: "operation-failure" };
+    await expect(withLocalCoach(input(async () => {
+      trace.push("operation");
+      throw failure;
+    }))).rejects.toBe(failure);
+    expect(trace.slice(-4)).toEqual([
+      "operation",
+      "lifecycle-close",
+      "store-close",
+      "writer-release",
+    ]);
+  });
+
+  it("gives operation failure precedence over close failures and otherwise propagates cleanup failure", async () => {
+    const operationFailure = { kind: "operation" };
+    closeImplementation = async () => {
+      trace.push("lifecycle-close");
+      throw { kind: "lifecycle-close" };
+    };
+    await expect(withLocalCoach(input(async () => {
+      throw operationFailure;
+    }))).rejects.toBe(operationFailure);
+    const cleanupFailure = new CoachStoreWriterError("writer-failed", "invoke operation");
+    closeImplementation = async () => { throw cleanupFailure; };
+    await expect(withLocalCoach(input(async () => "done"))).rejects.toBe(cleanupFailure);
+  });
+
+  it("supports idempotent lifecycle close and does not resolve before writer release", async () => {
+    let closerCalls = 0;
+    let closed = false;
+    const close = async () => {
+      if (closed) return;
+      closed = true;
+      closerCalls += 1;
+      trace.push("lifecycle-close");
+    };
+    mocks.composition.mockResolvedValue({ engine, close });
+    await expect(withLocalCoach(input(async (lifecycle) => {
+      await lifecycle.close();
+      await lifecycle.close();
+      return "done";
+    }))).resolves.toEqual({ status: "completed", value: "done" });
+    expect(closerCalls).toBe(1);
+    expect(trace.at(-1)).toBe("writer-release");
+  });
+
+  it("preserves actionable healthy-holder contention without migration or engine work", async () => {
+    const contention = { kind: "holder" as const, pid: 4321, port: 8765 };
+    const failure = new CoachStoreWriterError("writer-lock-held", null, undefined, contention);
+    mocks.withWriter.mockRejectedValue(failure);
+    await expect(withLocalCoach(input(async () => "unused"))).rejects.toBe(failure);
+    expect(failure).toMatchObject({ code: "writer-lock-held", stage: null, contention });
+    expect(mocks.migrate).not.toHaveBeenCalled();
+    expect(mocks.composition).not.toHaveBeenCalled();
+  });
+
+  it("preserves actionable foreign-port contention without migration or engine work", async () => {
+    const contention = {
+      kind: "foreign" as const,
+      port: 8765,
+      portFile: join(selectedHome.configDir, "store-writer.port"),
+    };
+    const failure = new CoachStoreWriterError("writer-lock-held", null, undefined, contention);
+    mocks.withWriter.mockRejectedValue(failure);
+    await expect(withLocalCoach(input(async () => "unused"))).rejects.toBe(failure);
+    expect(failure.contention).toEqual(contention);
+    expect(mocks.migrate).not.toHaveBeenCalled();
+    expect(mocks.composition).not.toHaveBeenCalled();
+  });
+});

--- a/packages/coach/tests/package-exports.test.ts
+++ b/packages/coach/tests/package-exports.test.ts
@@ -1,0 +1,62 @@
+import { access, readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { dirname, join, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const coachRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+describe("coach package handoff", () => {
+  it("preserves the dispatch package surface and adds only local-runner", async () => {
+    const packageJson = JSON.parse(
+      await readFile(join(coachRoot, "package.json"), "utf8"),
+    ) as {
+      exports: Record<string, string>;
+      scripts: Record<string, string>;
+    };
+    expect(packageJson.exports).toEqual({
+      "./runtime": "./dist/runtime.js",
+      "./sync": "./dist/sync.js",
+      "./backfill": "./dist/backfill.js",
+      "./backfill-benchmark": "./dist/backfill-benchmark.js",
+      "./capture": "./dist/capture.js",
+      "./local-bundle-producer": "./dist/local-bundle-producer.js",
+      "./store-runtime": "./dist/store-runtime.js",
+      "./local-runner": "./dist/local-runner.js",
+    });
+    expect(packageJson.scripts).toEqual({
+      build: "tsup",
+      check: "tsc --noEmit",
+      test: "vitest run",
+      backfill: "node dist/backfill-command.js",
+      benchmark: "node dist/backfill-command.js --synthetic --conclusions-only",
+      "capture-reference": "node dist/capture-command.js",
+      "capture-once": "node dist/reference-capture-command.js",
+      "dogfood:store": "node dist/local-bot.js",
+      "season-review": "node dist/season-review-command.js",
+    });
+    const entries = [
+      "runtime",
+      "sync",
+      "backfill",
+      "backfill-benchmark",
+      "backfill-command",
+      "capture",
+      "capture-command",
+      "reference-capture-command",
+      "local-bundle-producer",
+      "store-runtime",
+      "local-bot",
+      "soak-record",
+      "store-gate-command",
+      "season-review-command",
+      "local-runner",
+    ];
+    for (const entry of entries) {
+      await expect(access(join(coachRoot, "dist", `${entry}.js`))).resolves.toBeUndefined();
+      await expect(access(join(coachRoot, "dist", `${entry}.d.ts`))).resolves.toBeUndefined();
+    }
+    for (const subpath of Object.keys(packageJson.exports)) {
+      await expect(import(`@enduragent/coach/${subpath.slice(2)}`)).resolves.toBeDefined();
+    }
+  });
+});

--- a/packages/coach/tsup.config.ts
+++ b/packages/coach/tsup.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     "soak-record": "src/soak-record.ts",
     "store-gate-command": "src/store-gate-command.ts",
     "season-review-command": "src/season-review-command.ts",
+    "local-runner": "src/local-runner.ts",
   },
   format: ["esm"],
   dts: true,

--- a/packages/core/src/agent/engine-host-adapter.ts
+++ b/packages/core/src/agent/engine-host-adapter.ts
@@ -37,15 +37,9 @@ export interface EngineHostAdapterOverrides {
   readonly onToolsAssembled?: (names: readonly string[]) => void;
 }
 
-export function createEngineHostAdapter(input: {
-  readonly config: Config;
-  readonly stateReader: AthleteStateReaderPort;
-  readonly overrides?: EngineHostAdapterOverrides;
-}): { readonly ports: EngineHostPorts; readonly memory: Memory } {
-  const { config } = input;
-  const overrides = input.overrides ?? {};
+export function engineConfigFromConfig(config: Config): EngineConfig {
   const compactModel = config.llm.compactModel ?? config.llm.model;
-  const engineConfig: EngineConfig = Object.freeze({
+  return Object.freeze({
     dataSource: config.dataSource,
     llm: Object.freeze({ ...config.llm }),
     session: Object.freeze({ ...config.session }),
@@ -54,6 +48,16 @@ export function createEngineHostAdapter(input: {
       ? config.contextWindowTokens
       : contextWindowForModel(compactModel),
   });
+}
+
+export function createEngineHostAdapter(input: {
+  readonly config: Config;
+  readonly stateReader: AthleteStateReaderPort;
+  readonly overrides?: EngineHostAdapterOverrides;
+}): { readonly ports: EngineHostPorts; readonly memory: Memory } {
+  const { config } = input;
+  const overrides = input.overrides ?? {};
+  const engineConfig = engineConfigFromConfig(config);
   const memory = new Memory(config.dataDir, config.session.timezone || "UTC");
   const chatStore = new ChatStore(config.dataDir, config.session.resetArchiveRetentionDays);
   const legacyClient = config.intervals.apiKey

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -68,14 +68,19 @@ export interface Config {
 export const CONFIG_DIR = getCoachHome("cycling-coach");
 export const CONFIG_FILE = join(CONFIG_DIR, "config.yaml");
 
-export function readConfigYaml(): Record<string, unknown> {
-  if (!existsSync(CONFIG_FILE)) return {};
-  const raw = readFileSync(CONFIG_FILE, "utf-8");
+function readConfigYamlFrom(configDir: string): Record<string, unknown> {
+  const configFile = join(configDir, "config.yaml");
+  if (!existsSync(configFile)) return {};
+  const raw = readFileSync(configFile, "utf-8");
   try {
     return (parseYaml(raw) as Record<string, unknown>) ?? {};
   } catch {
     return {};
   }
+}
+
+export function readConfigYaml(): Record<string, unknown> {
+  return readConfigYamlFrom(CONFIG_DIR);
 }
 
 // ============================================================================
@@ -192,8 +197,8 @@ function assignFieldByPath(cfg: Config, path: SecretFieldPath, value: string): v
   else if (path === "telegram.bot_token") cfg.telegram.botToken = value;
 }
 
-export function loadConfig(): Config {
-  const yaml = readConfigYaml();
+export function loadConfig(configDir: string = CONFIG_DIR): Config {
+  const yaml = readConfigYamlFrom(configDir);
   const dataSource = resolveDataSource(yaml.data_source);
   const llmYaml = (yaml.llm as Record<string, unknown>) ?? {};
   const intervalsYaml = (yaml.intervals as Record<string, unknown>) ?? {};
@@ -338,7 +343,7 @@ export function loadConfig(): Config {
         env("COACH_TZ") ?? (sessionYaml.timezone as string | undefined) ?? "",
     },
     contextWindowTokens: resolveContextWindowTokens(model),
-    dataDir: (yaml.data_dir as string) ?? CONFIG_DIR,
+    dataDir: (yaml.data_dir as string) ?? configDir,
   };
 
   if (pending.size > 0) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -41,6 +41,7 @@ export * from "./reference/index.js";
 export { bootstrapReference } from "./reference/runtime.js";
 export type { BootstrapReferenceDeps, ReferenceRuntime } from "./reference/runtime.js";
 export { wrapFetchWithSignal } from "./reference/sync/intervals-client-factory.js";
+export { makeChatClient } from "./reference/sync/intervals-client-factory.js";
 
 export { appendUsageLine, USAGE_LEDGER_FILE, USAGE_LEDGER_MAX_BYTES } from "./usage-ledger.js";
 
@@ -113,6 +114,8 @@ export type {
   LocalCoachEngine,
 } from "./agent/coach-engine.js";
 export { ChatStore } from "./agent/chat-store.js";
+export { engineConfigFromConfig } from "./agent/engine-host-adapter.js";
+export { classifyFailure, extractRetryAfterMs } from "./agent/token-utils.js";
 
 // ─── Auth ─────────────────────────────────────────────────────────────
 export {
@@ -123,6 +126,7 @@ export {
 } from "./auth/profiles.js";
 export type { OAuthCredential } from "./auth/profiles.js";
 export { runCodexLogin } from "./auth/openai-codex-login.js";
+export { refreshCodexToken } from "./agent/codex/oauth.js";
 
 // ─── Channels ─────────────────────────────────────────────────────────
 export { createTelegramBot, notifyUpdate } from "./channels/telegram.js";

--- a/packages/kernel-node/src/cli/coach-dev.ts
+++ b/packages/kernel-node/src/cli/coach-dev.ts
@@ -7,7 +7,11 @@ import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
 import { resolveAthleteHome } from "../home/index.js";
 import type { AthleteHome } from "../home/index.js";
 import { importFilesWithReport } from "../ingest/index.js";
-import { acquireWriteLock, WriteLockContentionError } from "../lock/index.js";
+import {
+  acquireWriteLock,
+  WriteLockContentionError,
+  type WriterContentionDiagnostic,
+} from "../lock/index.js";
 import { openSqliteStorage } from "../sqlite/index.js";
 
 const USAGE = "Usage: coach-dev import --report <path>...\n";
@@ -38,6 +42,7 @@ type FailureStage = Exclude<CoachDevWriterFailureStage, "invoke operation"> | "i
 export type CoachDevWriterFailureStage =
   | "resolve home"
   | "acquire lock"
+  | "run pre-open operation"
   | "create store directory"
   | "secure store directory"
   | "open store"
@@ -54,12 +59,13 @@ export interface CoachDevWriterContext {
 export interface RunCoachDevWriterOptions<T> {
   readonly env: Record<string, string | undefined>;
   readonly writerVersion: string;
+  readonly beforeStoreOpen?: (home: AthleteHome) => Promise<void>;
   readonly operation: (context: CoachDevWriterContext) => Promise<T>;
 }
 
 export type CoachDevWriterResult<T> =
   | { readonly status: "completed"; readonly value: T }
-  | { readonly status: "writer-lock-held" }
+  | { readonly status: "writer-lock-held"; readonly contention: WriterContentionDiagnostic }
   | { readonly status: "failed"; readonly stage: CoachDevWriterFailureStage; readonly cause?: unknown };
 
 export type CoachDevWriterDependencies = typeof defaultWriterDeps;
@@ -143,14 +149,30 @@ export async function runCoachDevWriter<T>(
       version: options.writerVersion,
     });
   } catch (error) {
-    if (error instanceof WriteLockContentionError
-      || (error instanceof Error && error.name === "WriteLockContentionError")) {
-      return { status: "writer-lock-held" };
+    if (error instanceof WriteLockContentionError) {
+      if (error.contention !== null) {
+        return { status: "writer-lock-held", contention: error.contention };
+      }
+      return failedWriterResult("acquire lock", error);
+    }
+    if (error instanceof Error && error.name === "WriteLockContentionError") {
+      const contention = (error as Error & {
+        readonly contention?: WriterContentionDiagnostic | null;
+      }).contention;
+      if (contention !== undefined && contention !== null) {
+        return { status: "writer-lock-held", contention };
+      }
+      return failedWriterResult("acquire lock", error);
     }
     return failedWriterResult("acquire lock", error);
   }
 
-  if (lockResult.status === "peer-healthy") return { status: "writer-lock-held" };
+  if (lockResult.status === "peer-healthy") {
+    return {
+      status: "writer-lock-held",
+      contention: { kind: "holder", pid: lockResult.pid, port: lockResult.port },
+    };
+  }
 
   let failureStage: CoachDevWriterFailureStage | undefined;
   let failureCause: unknown;
@@ -160,7 +182,18 @@ export async function runCoachDevWriter<T>(
   try {
     try {
       try {
-        await deps.mkdir(home.storeDir, { recursive: true, mode: 0o700 });
+        if (options.beforeStoreOpen !== undefined) {
+          try {
+            await options.beforeStoreOpen(home);
+          } catch (error) {
+            failureStage = "run pre-open operation";
+            failureCause = error;
+          }
+        }
+
+        if (failureStage === undefined) {
+          await deps.mkdir(home.storeDir, { recursive: true, mode: 0o700 });
+        }
       } catch (error) {
         failureStage = "create store directory";
         failureCause = error;

--- a/packages/kernel-node/src/lock/acquire.ts
+++ b/packages/kernel-node/src/lock/acquire.ts
@@ -6,12 +6,30 @@ import { claimLockfile, readLockfile } from "./lockfile-body.js";
 import { readPortFile, writePortFile } from "./port-file.js";
 import { defaultHealthzProbe, isPortBound, type HealthzProbe } from "./healthz-probe.js";
 
+export type WriterContentionDiagnostic =
+  | {
+      readonly kind: "holder";
+      readonly pid: number | null;
+      readonly port: number;
+    }
+  | {
+      readonly kind: "foreign";
+      readonly port: number;
+      readonly portFile: string;
+    };
+
 export class WriteLockContentionError extends Error {
   readonly exitCode: number;
-  constructor(message: string, exitCode: number) {
+  readonly contention: WriterContentionDiagnostic | null;
+  constructor(
+    message: string,
+    exitCode: number,
+    contention: WriterContentionDiagnostic | null = null,
+  ) {
     super(message);
     this.name = "WriteLockContentionError";
     this.exitCode = exitCode;
+    this.contention = contention;
   }
 }
 
@@ -32,6 +50,7 @@ export interface WriteLockHandle {
 
 export interface PeerHealthyOutcome {
   readonly status: "peer-healthy";
+  readonly pid: number | null;
   readonly port: number;
   readonly peerVersion: string;
 }
@@ -85,17 +104,24 @@ async function contentionAgainstBound(
 ): Promise<PeerHealthyOutcome> {
   const verdict = await probe(boundPort);
   if (verdict.kind === "healthy") {
-    return { status: "peer-healthy", port: boundPort, peerVersion: verdict.version };
+    return {
+      status: "peer-healthy",
+      pid: bodyPid ?? null,
+      port: boundPort,
+      peerVersion: verdict.version,
+    };
   }
   if (verdict.kind === "unresponsive") {
     throw new WriteLockContentionError(
       `Another writer already holds this store (pid ${bodyPid ?? "unknown"}); stop that process or wait, then retry.`,
       3,
+      { kind: "holder", pid: bodyPid ?? null, port: boundPort },
     );
   }
   throw new WriteLockContentionError(
     `127.0.0.1:${boundPort} is held by a foreign process; change or remove the port file at ${portFilePath} and retry.`,
     3,
+    { kind: "foreign", port: boundPort, portFile: portFilePath },
   );
 }
 

--- a/packages/kernel-node/src/lock/index.ts
+++ b/packages/kernel-node/src/lock/index.ts
@@ -9,6 +9,7 @@ export type {
   AcquireWriteLockResult,
   WriteLockHandle,
   PeerHealthyOutcome,
+  WriterContentionDiagnostic,
 } from "./acquire.js";
 export type { LockfileBody } from "./lockfile-body.js";
 export { readLockfile } from "./lockfile-body.js";

--- a/packages/kernel-node/tests/coach-dev-import.test.ts
+++ b/packages/kernel-node/tests/coach-dev-import.test.ts
@@ -780,7 +780,53 @@ describe("coach-dev import --report", () => {
     }
   });
 
-  it("treats a foreign-copy write lock contention error as writer-lock-held", async () => {
+  it("runs the pre-open hook under the writer before store effects and releases on failure", async () => {
+    const successful = injected();
+    await expect(runCoachDevWriter({
+      env: {},
+      writerVersion: "generic-operation/1",
+      beforeStoreOpen: async (home) => {
+        expect(home).toBe(successful.home);
+        successful.calls.push("pre-open");
+      },
+      operation: async () => {
+        successful.calls.push("operation");
+        return "done";
+      },
+    }, successful.deps)).resolves.toEqual({ status: "completed", value: "done" });
+    expect(successful.calls).toEqual([
+      "resolve",
+      "acquire",
+      "pre-open",
+      "mkdir",
+      "chmod",
+      "open",
+      "migrate",
+      "operation",
+      "close",
+      "release",
+    ]);
+
+    const failure = { kind: "pre-open" };
+    const failed = injected();
+    const result = await runCoachDevWriter({
+      env: {},
+      writerVersion: "generic-operation/1",
+      beforeStoreOpen: async () => {
+        failed.calls.push("pre-open");
+        throw failure;
+      },
+      operation: async () => {
+        failed.calls.push("operation");
+        return null;
+      },
+    }, failed.deps);
+    expect(result).toEqual({ status: "failed", stage: "run pre-open operation" });
+    expect(result.status === "failed" && result.cause).toBe(failure);
+    expect(failed.calls).toEqual(["resolve", "acquire", "pre-open", "release"]);
+  });
+
+  it("requires typed diagnostics from a foreign-copy contention error", async () => {
     const foreign = new Error("write lock held by a healthy peer");
     foreign.name = "WriteLockContentionError";
     const scenario = injected({ fail: { acquire: foreign } });
@@ -795,8 +841,28 @@ describe("coach-dev import --report", () => {
       },
       scenario.deps,
     );
-    expect(result).toEqual({ status: "writer-lock-held" });
+    expect(result).toEqual({ status: "failed", stage: "acquire lock" });
+    expect(result.status === "failed" && result.cause).toBe(foreign);
     expect(scenario.calls).toEqual(["resolve", "acquire"]);
+
+    const typedForeign = new Error("foreign process") as Error & {
+      contention: { kind: "foreign"; port: number; portFile: string };
+    };
+    typedForeign.name = "WriteLockContentionError";
+    typedForeign.contention = {
+      kind: "foreign",
+      port: 4567,
+      portFile: "synthetic/config/store-writer.port",
+    };
+    const typedScenario = injected({ fail: { acquire: typedForeign } });
+    await expect(runCoachDevWriter({
+      env: {},
+      writerVersion: "generic-operation/1",
+      operation: async () => null,
+    }, typedScenario.deps)).resolves.toEqual({
+      status: "writer-lock-held",
+      contention: typedForeign.contention,
+    });
   });
 
   it("rejects a non-error lookalike named like the contention error", async () => {

--- a/packages/kernel-node/tests/lock.test.ts
+++ b/packages/kernel-node/tests/lock.test.ts
@@ -222,7 +222,7 @@ describe("acquireWriteLock", () => {
       version: "1.0.0",
       probeHealthz: probe,
     });
-    expect(result).toEqual({ status: "peer-healthy", port, peerVersion: "9.9.9" });
+    expect(result).toEqual({ status: "peer-healthy", pid: 777, port, peerVersion: "9.9.9" });
     expect(readFileSync(join(configDir, LOCKFILE_NAME), "utf-8")).toBe(lockBefore);
   });
 
@@ -278,6 +278,11 @@ describe("acquireWriteLock", () => {
     expect(caught).toBeInstanceOf(WriteLockContentionError);
     expect((caught as WriteLockContentionError).exitCode).toBe(3);
     expect((caught as WriteLockContentionError).message).toContain("424242");
+    expect((caught as WriteLockContentionError).contention).toEqual({
+      kind: "holder",
+      pid: 424242,
+      port,
+    });
   });
 
   it("(d) foreign process refuses exit 3 naming the port file", async () => {
@@ -296,6 +301,11 @@ describe("acquireWriteLock", () => {
     expect(caught).toBeInstanceOf(WriteLockContentionError);
     expect((caught as WriteLockContentionError).exitCode).toBe(3);
     expect((caught as WriteLockContentionError).message).toContain(portFilePath);
+    expect((caught as WriteLockContentionError).contention).toEqual({
+      kind: "foreign",
+      port,
+      portFile: portFilePath,
+    });
   });
 
   it("(RO-open) read-only open works beside the write-lock holder over WAL", async () => {
@@ -460,5 +470,11 @@ describe("acquireWriteLock", () => {
       kind: "foreign",
     });
     expect(classifyHealthzResponse(200, "not-json-garbage")).toEqual({ kind: "foreign" });
+  });
+
+  it("keeps the two-argument contention constructor compatible", () => {
+    const error = new WriteLockContentionError("synthetic contention", 3);
+    expect(error.exitCode).toBe(3);
+    expect(error.contention).toBeNull();
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,9 +73,15 @@ importers:
 
   packages/coach:
     dependencies:
+      '@enduragent/coach-contract':
+        specifier: workspace:*
+        version: link:../coach-contract
       '@enduragent/core':
         specifier: workspace:*
         version: link:../core
+      '@enduragent/engine':
+        specifier: workspace:*
+        version: link:../engine
       '@enduragent/kernel':
         specifier: workspace:*
         version: link:../kernel


### PR DESCRIPTION
## Summary

Lands the new-home coach composition and the production `CoachEngine` adapter:

- `packages/coach/src/composition.ts` — the concrete host map: builds `EngineHostPorts` field by field, reusing the extracted Core→EngineConfig projection, the Core-constructed intervals client, and the Core failure classifiers via package-root exports only.
- `athlete-state-reader.ts` — the persisted-`LatestJson` athlete-state authority behind the single async state-reader port; `coach-engine-adapter.ts` — the production four-method adapter; `readiness.ts` — pre-engine readiness with contract exit 4 remediation; `local-runner.ts` — the composition-root local runner/adapter lifecycle exported for the daemon wave.
- Core: behavior-preserving extraction of `engineConfigFromConfig` inside the host adapter plus five named root re-exports; no deep imports anywhere.
- kernel-node: lock acquire threads peer versions from the real health body; coach-dev import updated.

## Verification

- All spec ACs green, including the five persisted-state/degradation regression files (66 tests), adapter/reader/composition/local-runner focused suites, package-export and dependency-direction checks, and byte-identical snapshot comparisons.
- Root `pnpm build`, `pnpm check`, full `pnpm test` green after rebase onto the current tip.
