### PR TITLE
feat(coach): add enduragent executable and coach-cli

### DIFF
--- a/.changeset/coach-cli-executable.md
+++ b/.changeset/coach-cli-executable.md
@@ -1,0 +1,6 @@
+---
+"@enduragent/coach": patch
+"@enduragent/coach-cli": patch
+---
+
+Add the internal contract-only terminal surface and lock-owning local dogfood executable composition. Public package and image distribution remain unchanged.

--- a/packages/coach-cli/package.json
+++ b/packages/coach-cli/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@enduragent/coach-cli",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Contract-only terminal surface for the enduragent coach.",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": "./dist/index.js"
+  },
+  "files": ["dist"],
+  "engines": {
+    "node": ">=24"
+  },
+  "scripts": {
+    "build": "tsup",
+    "check": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@enduragent/coach-contract": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.0",
+    "tsup": "^8.4.0",
+    "typescript": "^6.0.2",
+    "vitest": "^4.1.4"
+  },
+  "license": "MIT"
+}

--- a/packages/coach-cli/src/args.ts
+++ b/packages/coach-cli/src/args.ts
@@ -1,0 +1,15 @@
+export type CoachCliInvocation =
+  | { readonly kind: "repl" }
+  | { readonly kind: "version" }
+  | {
+      readonly kind: "usage";
+      readonly message: "Usage: enduragent [version]";
+    };
+
+export function parseCoachCliInvocation(argv: readonly string[]): CoachCliInvocation {
+  if (argv.length === 0) return { kind: "repl" };
+  if (argv.length === 1 && (argv[0] === "version" || argv[0] === "--version")) {
+    return { kind: "version" };
+  }
+  return { kind: "usage", message: "Usage: enduragent [version]" };
+}

--- a/packages/coach-cli/src/index.ts
+++ b/packages/coach-cli/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./args.js";
+export * from "./repl.js";

--- a/packages/coach-cli/src/repl.ts
+++ b/packages/coach-cli/src/repl.ts
@@ -1,0 +1,95 @@
+import { randomUUID } from "node:crypto";
+import { createInterface } from "node:readline";
+import {
+  EXIT_AGENT_ERROR,
+  EXIT_SUCCESS,
+  type CoachEngine,
+  type ExitCode,
+} from "@enduragent/coach-contract";
+
+export interface CoachCliTerminal {
+  readonly input: NodeJS.ReadableStream;
+  readonly stdout: Pick<NodeJS.WritableStream, "write">;
+  readonly stderr: Pick<NodeJS.WritableStream, "write">;
+  readonly isTTY: boolean;
+}
+
+export interface RunCoachReplOptions {
+  readonly engine: CoachEngine;
+  readonly terminal: CoachCliTerminal;
+  readonly signal: AbortSignal;
+  readonly createSessionId?: () => string;
+}
+
+export async function runCoachRepl(options: RunCoachReplOptions): Promise<ExitCode> {
+  let sessionId: string;
+  try {
+    const createdId = (options.createSessionId ?? randomUUID)();
+    if (createdId.length === 0) throw new TypeError("empty session id");
+    sessionId = `cli:${createdId}`;
+  } catch {
+    options.terminal.stderr.write("Enduragent could not start a chat session.\n");
+    return EXIT_AGENT_ERROR;
+  }
+
+  let stopping = options.signal.aborted;
+  if (stopping) return EXIT_SUCCESS;
+
+  const input = options.terminal.input;
+  let inputEnded =
+    (input as NodeJS.ReadableStream & { readonly readableEnded?: boolean }).readableEnded === true;
+  const onInputEnd = (): void => {
+    inputEnded = true;
+  };
+  input.once("end", onInputEnd);
+
+  const rl = createInterface({ input, crlfDelay: Infinity, terminal: false });
+  const onAbort = (): void => {
+    stopping = true;
+    rl.close();
+  };
+  options.signal.addEventListener("abort", onAbort, { once: true });
+
+  let exitCode: ExitCode = EXIT_SUCCESS;
+  try {
+    if (options.terminal.isTTY) {
+      options.terminal.stderr.write("Enduragent chat. Type /quit or /exit to quit.\n");
+      options.terminal.stderr.write("> ");
+    }
+
+    if (!stopping) {
+      for await (const line of rl) {
+        if (stopping) break;
+        const message = line.trim();
+        if (message.length === 0) {
+          if (options.terminal.isTTY && !inputEnded && !stopping) {
+            options.terminal.stderr.write("> ");
+          }
+          continue;
+        }
+        if (message === "/quit" || message === "/exit") {
+          rl.close();
+          break;
+        }
+        try {
+          const response = await options.engine.chat({ chatId: sessionId, message });
+          options.terminal.stdout.write(`${response.text}\n`);
+        } catch {
+          options.terminal.stderr.write("Enduragent could not complete this turn.\n");
+          exitCode = EXIT_AGENT_ERROR;
+          stopping = true;
+          rl.close();
+        }
+        if (stopping) break;
+        if (options.terminal.isTTY && !inputEnded) {
+          options.terminal.stderr.write("> ");
+        }
+      }
+    }
+  } finally {
+    rl.close();
+    options.signal.removeEventListener("abort", onAbort);
+    input.removeListener("end", onInputEnd);
+  }
+  return exitCode;
+}

--- a/packages/coach-cli/tests/repl.test.ts
+++ b/packages/coach-cli/tests/repl.test.ts
@@ -1,0 +1,351 @@
+import { PassThrough, Writable } from "node:stream";
+import { describe, expect, it, vi } from "vitest";
+import {
+  EXIT_AGENT_ERROR,
+  EXIT_SUCCESS,
+  type AthleteState,
+  type CoachEngine,
+} from "@enduragent/coach-contract";
+import { parseCoachCliInvocation } from "../src/args.js";
+import { runCoachRepl, type CoachCliTerminal } from "../src/repl.js";
+
+const state: AthleteState = {
+  schemaVersion: "3",
+  lastUpdated: "2000-01-01T00:00:00.000Z",
+  freshness: "fresh",
+  degraded: false,
+  lastSynced: "2000-01-01T00:00:00.000Z",
+  athleteProfile: {},
+  currentStatus: {},
+  derivedMetrics: {},
+  recentActivities: [],
+  plannedWorkouts: [],
+  wellness: {},
+};
+
+interface Deferred<T> {
+  readonly promise: Promise<T>;
+  resolve(value: T): void;
+  reject(error: unknown): void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function capture(): { readonly stream: Writable; read(): string } {
+  let value = "";
+  return {
+    stream: new Writable({
+      write(chunk, _encoding, callback) {
+        value += Buffer.isBuffer(chunk) ? chunk.toString("utf8") : String(chunk);
+        callback();
+      },
+    }),
+    read: () => value,
+  };
+}
+
+function terminal(
+  input = new PassThrough(),
+  isTTY = false,
+): {
+  readonly input: PassThrough;
+  readonly stdout: ReturnType<typeof capture>;
+  readonly stderr: ReturnType<typeof capture>;
+  readonly value: CoachCliTerminal;
+} {
+  const stdout = capture();
+  const stderr = capture();
+  return {
+    input,
+    stdout,
+    stderr,
+    value: { input, stdout: stdout.stream, stderr: stderr.stream, isTTY },
+  };
+}
+
+function mockEngine(
+  implementation: CoachEngine["chat"] = async ({ message }) => ({ text: `${message}-response` }),
+): {
+  readonly engine: CoachEngine;
+  readonly chat: ReturnType<typeof vi.fn<CoachEngine["chat"]>>;
+  readonly resetSession: ReturnType<typeof vi.fn<CoachEngine["resetSession"]>>;
+  readonly hasSession: ReturnType<typeof vi.fn<CoachEngine["hasSession"]>>;
+} {
+  const chat = vi.fn<CoachEngine["chat"]>(implementation);
+  const resetSession = vi.fn<CoachEngine["resetSession"]>(async () => ({
+    memoryFlushed: true,
+  }));
+  const hasSession = vi.fn<CoachEngine["hasSession"]>(async () => ({
+    hasSession: false,
+  }));
+  const getAthleteState = vi.fn<CoachEngine["getAthleteState"]>(async () => state);
+  return {
+    engine: { chat, resetSession, hasSession, getAthleteState },
+    chat,
+    resetSession,
+    hasSession,
+  };
+}
+
+describe("coach CLI contract", () => {
+  it("maps the complete argument matrix", () => {
+    expect(parseCoachCliInvocation([])).toEqual({ kind: "repl" });
+    expect(parseCoachCliInvocation(["version"])).toEqual({ kind: "version" });
+    expect(parseCoachCliInvocation(["--version"])).toEqual({ kind: "version" });
+    for (const argv of [["unknown"], ["version", "extra"], ["--version", "extra"], [""]]) {
+      expect(parseCoachCliInvocation(argv)).toEqual({
+        kind: "usage",
+        message: "Usage: enduragent [version]",
+      });
+    }
+  });
+
+  it("pins one fresh session per invocation and contains factory failures", async () => {
+    const firstTerminal = terminal();
+    firstTerminal.input.end("one\ntwo\n");
+    const first = mockEngine();
+    await expect(
+      runCoachRepl({
+        engine: first.engine,
+        terminal: firstTerminal.value,
+        signal: new AbortController().signal,
+        createSessionId: () => "first-id",
+      }),
+    ).resolves.toBe(EXIT_SUCCESS);
+    expect(first.chat.mock.calls.map(([request]) => request)).toEqual([
+      { chatId: "cli:first-id", message: "one" },
+      { chatId: "cli:first-id", message: "two" },
+    ]);
+    expect(first.hasSession).not.toHaveBeenCalled();
+    expect(first.resetSession).not.toHaveBeenCalled();
+
+    const secondTerminal = terminal();
+    secondTerminal.input.end("three\n");
+    const second = mockEngine();
+    await runCoachRepl({
+      engine: second.engine,
+      terminal: secondTerminal.value,
+      signal: new AbortController().signal,
+      createSessionId: () => "second-id",
+    });
+    expect(second.chat).toHaveBeenCalledWith({
+      chatId: "cli:second-id",
+      message: "three",
+    });
+
+    for (const createSessionId of [
+      () => "",
+      () => {
+        throw new Error("private");
+      },
+    ]) {
+      const failedTerminal = terminal();
+      const failed = mockEngine();
+      await expect(
+        runCoachRepl({
+          engine: failed.engine,
+          terminal: failedTerminal.value,
+          signal: new AbortController().signal,
+          createSessionId,
+        }),
+      ).resolves.toBe(EXIT_AGENT_ERROR);
+      expect(failed.chat).not.toHaveBeenCalled();
+      expect(failedTerminal.stdout.read()).toBe("");
+      expect(failedTerminal.stderr.read()).toBe("Enduragent could not start a chat session.\n");
+    }
+  });
+
+  it("serializes non-TTY turns in FIFO order", async () => {
+    const firstResponse = deferred<{ text: string }>();
+    const secondResponse = deferred<{ text: string }>();
+    const mocked = mockEngine(async ({ message }) =>
+      message === "first" ? firstResponse.promise : secondResponse.promise,
+    );
+    const io = terminal();
+    io.input.end("first\nsecond\n");
+    const result = runCoachRepl({
+      engine: mocked.engine,
+      terminal: io.value,
+      signal: new AbortController().signal,
+      createSessionId: () => "fifo",
+    });
+    await vi.waitFor(() => expect(mocked.chat).toHaveBeenCalledTimes(1));
+    expect(mocked.chat.mock.calls[0]?.[0].message).toBe("first");
+    firstResponse.resolve({ text: "first-response" });
+    await vi.waitFor(() => expect(mocked.chat).toHaveBeenCalledTimes(2));
+    expect(mocked.chat.mock.calls[1]?.[0].message).toBe("second");
+    secondResponse.resolve({ text: "second-response" });
+    await expect(result).resolves.toBe(EXIT_SUCCESS);
+    expect(io.stdout.read()).toBe("first-response\nsecond-response\n");
+    expect(io.stderr.read()).toBe("");
+  });
+
+  it("drains the final turn after physical EOF before returning", async () => {
+    const trace: string[] = [];
+    const response = deferred<{ text: string }>();
+    const mocked = mockEngine(async () => response.promise);
+    const io = terminal();
+    io.input.once("end", () => trace.push("input-end"));
+    const result = runCoachRepl({
+      engine: mocked.engine,
+      terminal: io.value,
+      signal: new AbortController().signal,
+      createSessionId: () => "drain",
+    }).then((code) => {
+      trace.push("repl-return");
+      return code;
+    });
+    io.input.end("final\n");
+    await vi.waitFor(() => expect(mocked.chat).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() => expect(trace).toContain("input-end"));
+    expect(trace).not.toContain("repl-return");
+    response.resolve({ text: "final-response" });
+    await expect(result).resolves.toBe(EXIT_SUCCESS);
+    expect(trace).toEqual(["input-end", "repl-return"]);
+    expect(io.stdout.read()).toBe("final-response\n");
+  });
+
+  it("renders byte-exact TTY and control transcripts", async () => {
+    const banner = "Enduragent chat. Type /quit or /exit to quit.\n";
+
+    const successful = terminal(new PassThrough(), true);
+    const response = deferred<{ text: string }>();
+    const successEngine = mockEngine(async () => response.promise);
+    const successResult = runCoachRepl({
+      engine: successEngine.engine,
+      terminal: successful.value,
+      signal: new AbortController().signal,
+      createSessionId: () => "tty-success",
+    });
+    successful.input.write("hello\n");
+    await vi.waitFor(() => expect(successEngine.chat).toHaveBeenCalledTimes(1));
+    response.resolve({ text: "reply" });
+    await vi.waitFor(() => expect(successful.stdout.read()).toBe("reply\n"));
+    successful.input.write("/quit\n");
+    await expect(successResult).resolves.toBe(EXIT_SUCCESS);
+    expect(successful.stderr.read()).toBe(`${banner}> > `);
+
+    const blank = terminal(new PassThrough(), true);
+    const blankEngine = mockEngine();
+    const blankResult = runCoachRepl({
+      engine: blankEngine.engine,
+      terminal: blank.value,
+      signal: new AbortController().signal,
+      createSessionId: () => "tty-blank",
+    });
+    blank.input.write("   \n/quit\n");
+    await expect(blankResult).resolves.toBe(EXIT_SUCCESS);
+    expect(blank.stderr.read()).toBe(`${banner}> > `);
+    expect(blankEngine.chat).not.toHaveBeenCalled();
+
+    const immediateEof = terminal(new PassThrough(), true);
+    const eofEngine = mockEngine();
+    immediateEof.input.end();
+    await expect(
+      runCoachRepl({
+        engine: eofEngine.engine,
+        terminal: immediateEof.value,
+        signal: new AbortController().signal,
+        createSessionId: () => "tty-eof",
+      }),
+    ).resolves.toBe(EXIT_SUCCESS);
+    expect(immediateEof.stderr.read()).toBe(`${banner}> `);
+
+    const inflightEof = terminal(new PassThrough(), true);
+    const inflightResponse = deferred<{ text: string }>();
+    const inflightEngine = mockEngine(async () => inflightResponse.promise);
+    inflightEof.input.end("hello\n");
+    const inflightResult = runCoachRepl({
+      engine: inflightEngine.engine,
+      terminal: inflightEof.value,
+      signal: new AbortController().signal,
+      createSessionId: () => "tty-inflight",
+    });
+    await vi.waitFor(() => expect(inflightEngine.chat).toHaveBeenCalledTimes(1));
+    inflightResponse.resolve({ text: "reply" });
+    await expect(inflightResult).resolves.toBe(EXIT_SUCCESS);
+    expect(inflightEof.stderr.read()).toBe(`${banner}> `);
+    expect(inflightEof.stdout.read()).toBe("reply\n");
+
+    const exitControl = terminal();
+    exitControl.input.end("/exit\n");
+    const exitEngine = mockEngine();
+    await runCoachRepl({
+      engine: exitEngine.engine,
+      terminal: exitControl.value,
+      signal: new AbortController().signal,
+      createSessionId: () => "exit-control",
+    });
+    expect(exitEngine.chat).not.toHaveBeenCalled();
+  });
+
+  it("drains aborts, discards queued lines, removes listeners, and redacts errors", async () => {
+    const preAbortedController = new AbortController();
+    preAbortedController.abort();
+    const preAbortedTerminal = terminal();
+    const preAbortedEngine = mockEngine();
+    const factory = vi.fn(() => "pre-aborted");
+    await expect(
+      runCoachRepl({
+        engine: preAbortedEngine.engine,
+        terminal: preAbortedTerminal.value,
+        signal: preAbortedController.signal,
+        createSessionId: factory,
+      }),
+    ).resolves.toBe(EXIT_SUCCESS);
+    expect(factory).toHaveBeenCalledTimes(1);
+    expect(preAbortedEngine.chat).not.toHaveBeenCalled();
+    expect(preAbortedTerminal.stdout.read()).toBe("");
+    expect(preAbortedTerminal.stderr.read()).toBe("");
+
+    const controller = new AbortController();
+    const addListener = vi.spyOn(controller.signal, "addEventListener");
+    const removeListener = vi.spyOn(controller.signal, "removeEventListener");
+    const io = terminal();
+    const response = deferred<{ text: string }>();
+    const mocked = mockEngine(async () => response.promise);
+    const result = runCoachRepl({
+      engine: mocked.engine,
+      terminal: io.value,
+      signal: controller.signal,
+      createSessionId: () => "abort",
+    });
+    io.input.write("first\nsecond\n");
+    await vi.waitFor(() => expect(mocked.chat).toHaveBeenCalledTimes(1));
+    controller.abort();
+    response.resolve({ text: "first-response" });
+    await expect(result).resolves.toBe(EXIT_SUCCESS);
+    expect(mocked.chat).toHaveBeenCalledTimes(1);
+    expect(io.stdout.read()).toBe("first-response\n");
+    expect(io.input.listenerCount("end")).toBe(0);
+    expect(addListener).toHaveBeenCalledTimes(1);
+    expect(removeListener).toHaveBeenCalledWith("abort", addListener.mock.calls[0]?.[1]);
+
+    const errorController = new AbortController();
+    const errorIo = terminal();
+    const failure = deferred<{ text: string }>();
+    const errorEngine = mockEngine(async () => failure.promise);
+    const errorResult = runCoachRepl({
+      engine: errorEngine.engine,
+      terminal: errorIo.value,
+      signal: errorController.signal,
+      createSessionId: () => "error",
+    });
+    errorIo.input.write("first\nsecond\n");
+    await vi.waitFor(() => expect(errorEngine.chat).toHaveBeenCalledTimes(1));
+    errorController.abort();
+    failure.reject(new Error("private turn detail"));
+    await expect(errorResult).resolves.toBe(EXIT_AGENT_ERROR);
+    expect(errorEngine.chat).toHaveBeenCalledTimes(1);
+    expect(errorIo.stdout.read()).toBe("");
+    expect(errorIo.stderr.read()).toBe("Enduragent could not complete this turn.\n");
+  });
+});

--- a/packages/coach-cli/tsconfig.json
+++ b/packages/coach-cli/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "ignoreDeprecations": "6.0"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/coach-cli/tsup.config.ts
+++ b/packages/coach-cli/tsup.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: {
+    index: "src/index.ts",
+  },
+  format: ["esm"],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  splitting: false,
+  removeNodeProtocol: false,
+});

--- a/packages/coach/package.json
+++ b/packages/coach/package.json
@@ -5,6 +5,9 @@
   "description": "Private Node composition root for governed Reference layer sync orchestration.",
   "type": "module",
   "files": ["dist"],
+  "bin": {
+    "enduragent": "./dist/enduragent.js"
+  },
   "exports": {
     "./runtime": "./dist/runtime.js",
     "./sync": "./dist/sync.js",
@@ -13,7 +16,8 @@
     "./capture": "./dist/capture.js",
     "./local-bundle-producer": "./dist/local-bundle-producer.js",
     "./store-runtime": "./dist/store-runtime.js",
-    "./local-runner": "./dist/local-runner.js"
+    "./local-runner": "./dist/local-runner.js",
+    "./enduragent": "./dist/enduragent.js"
   },
   "engines": {
     "node": ">=24"
@@ -30,6 +34,7 @@
     "season-review": "node dist/season-review-command.js"
   },
   "dependencies": {
+    "@enduragent/coach-cli": "workspace:*",
     "@enduragent/coach-contract": "workspace:*",
     "@enduragent/core": "workspace:*",
     "@enduragent/engine": "workspace:*",

--- a/packages/coach/src/enduragent.ts
+++ b/packages/coach/src/enduragent.ts
@@ -1,0 +1,187 @@
+#!/usr/bin/env node
+import { readFile, realpath } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  EXIT_AGENT_ERROR,
+  EXIT_DAEMON_UNAVAILABLE,
+  EXIT_NOT_CONFIGURED,
+  EXIT_SUCCESS,
+  EXIT_USAGE,
+  type ExitCode,
+} from "@enduragent/coach-contract";
+import {
+  parseCoachCliInvocation,
+  runCoachRepl,
+  type CoachCliTerminal,
+} from "@enduragent/coach-cli";
+import { expandTilde, resolveAthleteHome, type AthleteHome } from "@enduragent/kernel-node/home";
+import {
+  withLocalCoach,
+  type LocalCoachRunResult,
+  type WithLocalCoachInput,
+} from "./local-runner.js";
+import { CoachStoreWriterError } from "./runtime.js";
+
+export interface RunEnduragentInput {
+  readonly argv: readonly string[];
+  readonly env: Record<string, string | undefined>;
+  readonly terminal: CoachCliTerminal;
+  readonly signal: AbortSignal;
+}
+
+export interface EnduragentDependencies {
+  readonly resolveAthleteHome: (env: Record<string, string | undefined>) => AthleteHome;
+  readonly withLocalCoach: <T>(input: WithLocalCoachInput<T>) => Promise<LocalCoachRunResult<T>>;
+  readonly readPackageVersion: () => Promise<string>;
+}
+
+async function readPackageVersion(): Promise<string> {
+  const raw = await readFile(new URL("../package.json", import.meta.url), "utf8");
+  const parsed: unknown = JSON.parse(raw);
+  if (parsed === null || typeof parsed !== "object") {
+    throw new TypeError("invalid package metadata");
+  }
+  const version = (parsed as { readonly version?: unknown }).version;
+  if (typeof version !== "string" || version.length === 0) {
+    throw new TypeError("invalid package version");
+  }
+  return version;
+}
+
+const defaultDependencies: EnduragentDependencies = Object.freeze({
+  resolveAthleteHome,
+  withLocalCoach,
+  readPackageVersion,
+});
+
+function resolveLegacySourceRoot(env: Record<string, string | undefined>): string {
+  const override = env.CYCLING_COACH_HOME;
+  if (override !== undefined && override.length > 0) {
+    return expandTilde(override);
+  }
+  return join(homedir(), ".cycling-coach");
+}
+
+export async function runEnduragent(
+  input: RunEnduragentInput,
+  dependencies?: EnduragentDependencies,
+): Promise<ExitCode> {
+  const invocation = parseCoachCliInvocation(input.argv);
+  if (invocation.kind === "usage") {
+    input.terminal.stderr.write(`${invocation.message}\n`);
+    return EXIT_USAGE;
+  }
+
+  const resolvedDependencies = dependencies ?? defaultDependencies;
+  try {
+    if (invocation.kind === "version") {
+      const version = await resolvedDependencies.readPackageVersion();
+      input.terminal.stdout.write(`enduragent ${version}\n`);
+      return EXIT_SUCCESS;
+    }
+
+    const home = resolvedDependencies.resolveAthleteHome(input.env);
+    const sourceRoot = resolveLegacySourceRoot(input.env);
+    const result = await resolvedDependencies.withLocalCoach({
+      env: input.env,
+      home,
+      sourceRoot,
+      action: { kind: "resume", isTTY: input.terminal.isTTY },
+      operation: async (lifecycle) =>
+        runCoachRepl({
+          engine: lifecycle.engine,
+          terminal: input.terminal,
+          signal: input.signal,
+        }),
+    });
+
+    if (result.status === "completed") return result.value;
+    if (result.status === "not-configured") {
+      input.terminal.stderr.write(
+        `Enduragent is not configured. Provision ${result.configPath} with provider credentials, then run: enduragent\n`,
+      );
+      return EXIT_NOT_CONFIGURED;
+    }
+    if (result.status === "migration-discarded") {
+      input.terminal.stderr.write(
+        `Enduragent migration plan ${result.result.manifestDigest} was discarded to ${result.result.archivePath}. Run enduragent again to replan.\n`,
+      );
+      return result.result.exitCode;
+    }
+    const manifest =
+      result.result.manifestDigest === null ? "" : ` for manifest ${result.result.manifestDigest}`;
+    input.terminal.stderr.write(
+      `Enduragent cannot start: legacy migration was refused (${result.result.reason}). Review ${result.result.journalPath}${manifest} and resolve the reported condition before retrying.\n`,
+    );
+    return result.result.exitCode;
+  } catch (error) {
+    if (
+      error instanceof CoachStoreWriterError &&
+      error.code === "writer-lock-held" &&
+      error.contention?.kind === "holder"
+    ) {
+      input.terminal.stderr.write(
+        `Enduragent cannot start: another writer holds this athlete home (pid ${error.contention.pid ?? "unknown"}, port ${error.contention.port}). Stop it or wait, then retry.\n`,
+      );
+      return EXIT_DAEMON_UNAVAILABLE;
+    }
+    if (
+      error instanceof CoachStoreWriterError &&
+      error.code === "writer-lock-held" &&
+      error.contention?.kind === "foreign"
+    ) {
+      input.terminal.stderr.write(
+        `Enduragent cannot start: 127.0.0.1:${error.contention.port} is held by a foreign process; change or remove the port file at ${error.contention.portFile}, then retry.\n`,
+      );
+      return EXIT_DAEMON_UNAVAILABLE;
+    }
+    input.terminal.stderr.write("Enduragent could not start.\n");
+    return EXIT_AGENT_ERROR;
+  }
+}
+
+export async function main(): Promise<void> {
+  const controller = new AbortController();
+  const onSigint = (): void => controller.abort();
+  const onSigterm = (): void => controller.abort();
+  process.on("SIGINT", onSigint);
+  process.on("SIGTERM", onSigterm);
+  try {
+    process.exitCode = await runEnduragent({
+      argv: process.argv.slice(2),
+      env: process.env,
+      terminal: {
+        input: process.stdin,
+        stdout: process.stdout,
+        stderr: process.stderr,
+        isTTY: process.stdin.isTTY === true,
+      },
+      signal: controller.signal,
+    });
+  } finally {
+    process.off("SIGINT", onSigint);
+    process.off("SIGTERM", onSigterm);
+  }
+}
+
+async function isDirectExecution(moduleUrl: string, argv1: string | undefined): Promise<boolean> {
+  if (argv1 === undefined) return false;
+  try {
+    const [modulePath, invokedPath] = await Promise.all([
+      realpath(fileURLToPath(moduleUrl)),
+      realpath(resolve(argv1)),
+    ]);
+    return modulePath === invokedPath;
+  } catch {
+    return false;
+  }
+}
+
+if (await isDirectExecution(import.meta.url, process.argv[1])) {
+  await main().catch(() => {
+    process.stderr.write("Enduragent could not start.\n");
+    process.exitCode = EXIT_AGENT_ERROR;
+  });
+}

--- a/packages/coach/tests/enduragent-entry.test.ts
+++ b/packages/coach/tests/enduragent-entry.test.ts
@@ -1,0 +1,567 @@
+import { mkdir, mkdtemp, readFile, realpath, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { PassThrough, Writable } from "node:stream";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  EXIT_AGENT_ERROR,
+  EXIT_DAEMON_UNAVAILABLE,
+  EXIT_SUCCESS,
+  EXIT_USAGE,
+  type AthleteState,
+  type CoachEngine,
+} from "@enduragent/coach-contract";
+import type { AthleteHome } from "@enduragent/kernel-node/home";
+import { PORT_FILE_NAME } from "@enduragent/kernel-node/lock";
+import {
+  runEnduragent,
+  type EnduragentDependencies,
+  type RunEnduragentInput,
+} from "../src/enduragent.js";
+import {
+  withLocalCoach,
+  type LocalCoachLifecycle,
+  type LocalCoachRunResult,
+  type WithLocalCoachInput,
+} from "../src/local-runner.js";
+import { CoachStoreWriterError, withCoachStoreWriter } from "../src/runtime.js";
+
+const state: AthleteState = {
+  schemaVersion: "3",
+  lastUpdated: "2000-01-01T00:00:00.000Z",
+  freshness: "fresh",
+  degraded: false,
+  lastSynced: "2000-01-01T00:00:00.000Z",
+  athleteProfile: {},
+  currentStatus: {},
+  derivedMetrics: {},
+  recentActivities: [],
+  plannedWorkouts: [],
+  wellness: {},
+};
+
+interface Deferred<T> {
+  readonly promise: Promise<T>;
+  resolve(value: T): void;
+  reject(error: unknown): void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function capture(): { readonly stream: Writable; read(): string } {
+  let value = "";
+  return {
+    stream: new Writable({
+      write(chunk, _encoding, callback) {
+        value += Buffer.isBuffer(chunk) ? chunk.toString("utf8") : String(chunk);
+        callback();
+      },
+    }),
+    read: () => value,
+  };
+}
+
+function terminal(
+  input = new PassThrough(),
+  isTTY = false,
+): {
+  readonly input: PassThrough;
+  readonly stdout: ReturnType<typeof capture>;
+  readonly stderr: ReturnType<typeof capture>;
+  readonly value: RunEnduragentInput["terminal"];
+} {
+  const stdout = capture();
+  const stderr = capture();
+  return {
+    input,
+    stdout,
+    stderr,
+    value: { input, stdout: stdout.stream, stderr: stderr.stream, isTTY },
+  };
+}
+
+function mockEngine(
+  implementation: CoachEngine["chat"] = async ({ message }) => ({ text: `${message}-response` }),
+): {
+  readonly engine: CoachEngine;
+  readonly chat: ReturnType<typeof vi.fn<CoachEngine["chat"]>>;
+} {
+  const chat = vi.fn<CoachEngine["chat"]>(implementation);
+  const resetSession = vi.fn<CoachEngine["resetSession"]>(async () => ({
+    memoryFlushed: true,
+  }));
+  const hasSession = vi.fn<CoachEngine["hasSession"]>(async () => ({
+    hasSession: false,
+  }));
+  const getAthleteState = vi.fn<CoachEngine["getAthleteState"]>(async () => state);
+  return { engine: { chat, resetSession, hasSession, getAthleteState }, chat };
+}
+
+const roots: string[] = [];
+let scratch: string;
+let home: AthleteHome;
+let env: Record<string, string | undefined>;
+
+beforeEach(async () => {
+  scratch = await mkdtemp(join(await realpath(tmpdir()), "enduragent-entry-"));
+  roots.push(scratch);
+  home = {
+    root: join(scratch, "athlete-home"),
+    storeDir: join(scratch, "athlete-home", "store"),
+    archiveDir: join(scratch, "athlete-home", "archive"),
+    configDir: join(scratch, "athlete-home", "config"),
+  };
+  env = {
+    HOME: join(scratch, "home"),
+    ENDURAGENT_HOME: home.root,
+    CYCLING_COACH_HOME: join(scratch, "legacy-home"),
+    XDG_CONFIG_HOME: join(scratch, "xdg-config"),
+    XDG_CACHE_HOME: join(scratch, "xdg-cache"),
+    TMPDIR: join(scratch, "tmp"),
+    FORCE_COLOR: undefined,
+    CLICOLOR_FORCE: undefined,
+  };
+  await Promise.all([
+    mkdir(env.HOME!, { recursive: true }),
+    mkdir(env.XDG_CONFIG_HOME!, { recursive: true }),
+    mkdir(env.XDG_CACHE_HOME!, { recursive: true }),
+    mkdir(env.TMPDIR!, { recursive: true }),
+  ]);
+});
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("enduragent executable composition", () => {
+  it("short-circuits version without resolving or composing", async () => {
+    let homeCalls = 0;
+    let runnerCalls = 0;
+    const dependencies: EnduragentDependencies = {
+      resolveAthleteHome: () => {
+        homeCalls += 1;
+        return home;
+      },
+      withLocalCoach: async () => {
+        runnerCalls += 1;
+        return { status: "not-configured", configPath: "unused" };
+      },
+      readPackageVersion: async () => "0.1.2",
+    };
+    const io = terminal();
+    await expect(
+      runEnduragent(
+        {
+          argv: ["version"],
+          env,
+          terminal: io.value,
+          signal: new AbortController().signal,
+        },
+        dependencies,
+      ),
+    ).resolves.toBe(EXIT_SUCCESS);
+    expect(io.stdout.read()).toBe("enduragent 0.1.2\n");
+    expect(io.stderr.read()).toBe("");
+    expect(homeCalls).toBe(0);
+    expect(runnerCalls).toBe(0);
+  });
+
+  it("short-circuits invalid usage without resolving or composing", async () => {
+    let homeCalls = 0;
+    let runnerCalls = 0;
+    const dependencies: EnduragentDependencies = {
+      resolveAthleteHome: () => {
+        homeCalls += 1;
+        return home;
+      },
+      withLocalCoach: async () => {
+        runnerCalls += 1;
+        return { status: "not-configured", configPath: "unused" };
+      },
+      readPackageVersion: async () => "unused",
+    };
+    const io = terminal();
+    await expect(
+      runEnduragent(
+        {
+          argv: ["unknown"],
+          env,
+          terminal: io.value,
+          signal: new AbortController().signal,
+        },
+        dependencies,
+      ),
+    ).resolves.toBe(EXIT_USAGE);
+    expect(io.stdout.read()).toBe("");
+    expect(io.stderr.read()).toBe("Usage: enduragent [version]\n");
+    expect(homeCalls).toBe(0);
+    expect(runnerCalls).toBe(0);
+  });
+
+  it("renders migration and readiness outcomes with unchanged exit codes", async () => {
+    const digestA = "a".repeat(64);
+    const digestB = "b".repeat(64);
+    const digestC = "c".repeat(64);
+    const journalPath = join(home.root, "config", "migration.json");
+    const archivePath = join(home.root, "archive", "discarded.json");
+    const configPath = join(home.configDir, "config.yaml");
+    const rows: ReadonlyArray<{
+      readonly result: LocalCoachRunResult<never>;
+      readonly exitCode: 0 | 2 | 3 | 4;
+      readonly stderr: string;
+    }> = [
+      {
+        result: {
+          status: "migration-refused",
+          result: {
+            status: "refused",
+            exitCode: 2,
+            journalPath,
+            manifestDigest: null,
+            reason: "confirmation-required",
+            conflictIds: [],
+          },
+        },
+        exitCode: 2,
+        stderr: `Enduragent cannot start: legacy migration was refused (confirmation-required). Review ${journalPath} and resolve the reported condition before retrying.\n`,
+      },
+      {
+        result: {
+          status: "migration-refused",
+          result: {
+            status: "refused",
+            exitCode: 3,
+            journalPath,
+            manifestDigest: digestA,
+            reason: "source-drift",
+            conflictIds: ["synthetic-conflict"],
+          },
+        },
+        exitCode: 3,
+        stderr: `Enduragent cannot start: legacy migration was refused (source-drift). Review ${journalPath} for manifest ${digestA} and resolve the reported condition before retrying.\n`,
+      },
+      {
+        result: {
+          status: "migration-refused",
+          result: {
+            status: "refused",
+            exitCode: 4,
+            journalPath,
+            manifestDigest: digestB,
+            reason: "invalid-source-config",
+            conflictIds: [],
+          },
+        },
+        exitCode: 4,
+        stderr: `Enduragent cannot start: legacy migration was refused (invalid-source-config). Review ${journalPath} for manifest ${digestB} and resolve the reported condition before retrying.\n`,
+      },
+      {
+        result: {
+          status: "migration-discarded",
+          result: {
+            status: "discarded",
+            exitCode: 0,
+            journalPath,
+            manifestDigest: digestC,
+            archivePath,
+          },
+        },
+        exitCode: 0,
+        stderr: `Enduragent migration plan ${digestC} was discarded to ${archivePath}. Run enduragent again to replan.\n`,
+      },
+      {
+        result: { status: "not-configured", configPath },
+        exitCode: 4,
+        stderr: `Enduragent is not configured. Provision ${configPath} with provider credentials, then run: enduragent\n`,
+      },
+    ];
+
+    for (const row of rows) {
+      let captured: WithLocalCoachInput<unknown> | undefined;
+      let operationCalls = 0;
+      const runner: EnduragentDependencies["withLocalCoach"] = async <T>(
+        input: WithLocalCoachInput<T>,
+      ): Promise<LocalCoachRunResult<T>> => {
+        captured = input as unknown as WithLocalCoachInput<unknown>;
+        return row.result as LocalCoachRunResult<T>;
+      };
+      const io = terminal(new PassThrough(), true);
+      const result = await runEnduragent(
+        {
+          argv: [],
+          env,
+          terminal: io.value,
+          signal: new AbortController().signal,
+        },
+        {
+          resolveAthleteHome: () => home,
+          withLocalCoach: async <T>(
+            input: WithLocalCoachInput<T>,
+          ): Promise<LocalCoachRunResult<T>> => {
+            const value = await runner(input);
+            const originalOperation = input.operation;
+            captured = {
+              ...input,
+              operation: async (lifecycle: LocalCoachLifecycle) => {
+                operationCalls += 1;
+                return originalOperation(lifecycle);
+              },
+            } as unknown as WithLocalCoachInput<unknown>;
+            return value;
+          },
+          readPackageVersion: async () => "unused",
+        },
+      );
+      expect(result).toBe(row.exitCode);
+      expect(io.stdout.read()).toBe("");
+      expect(io.stderr.read()).toBe(row.stderr);
+      expect(operationCalls).toBe(0);
+      expect(captured?.home).toBe(home);
+      expect(captured?.sourceRoot).toBe(env.CYCLING_COACH_HOME);
+      expect(captured?.action).toEqual({ kind: "resume", isTTY: true });
+    }
+  });
+
+  it("preserves FIFO and lifecycle close ordering after physical EOF", async () => {
+    const trace: string[] = [];
+    const first = deferred<{ text: string }>();
+    const second = deferred<{ text: string }>();
+    const mocked = mockEngine(async ({ message }) => {
+      trace.push(`${message}-chat-start`);
+      const response = await (message === "first" ? first.promise : second.promise);
+      trace.push(`${message}-chat-end`);
+      return response;
+    });
+    const lifecycle = {
+      engine: mocked.engine,
+      close: async () => {
+        trace.push("lifecycle-close");
+      },
+    };
+    const runner: EnduragentDependencies["withLocalCoach"] = async <T>(
+      input: WithLocalCoachInput<T>,
+    ): Promise<LocalCoachRunResult<T>> => {
+      try {
+        const value = await input.operation(lifecycle);
+        trace.push("repl-return");
+        return { status: "completed", value };
+      } finally {
+        await lifecycle.close();
+        trace.push("store-close", "writer-release");
+      }
+    };
+    const io = terminal();
+    io.input.once("end", () => trace.push("input-eof"));
+    io.input.end("first\nsecond\n");
+    const result = runEnduragent(
+      {
+        argv: [],
+        env,
+        terminal: io.value,
+        signal: new AbortController().signal,
+      },
+      {
+        resolveAthleteHome: () => home,
+        withLocalCoach: runner,
+        readPackageVersion: async () => "unused",
+      },
+    );
+    await vi.waitFor(() => expect(mocked.chat).toHaveBeenCalledTimes(1));
+    first.resolve({ text: "first-response" });
+    await vi.waitFor(() => expect(mocked.chat).toHaveBeenCalledTimes(2));
+    second.resolve({ text: "second-response" });
+    await expect(result).resolves.toBe(EXIT_SUCCESS);
+    expect(io.stdout.read()).toBe("first-response\nsecond-response\n");
+    for (const [earlier, later] of [
+      ["first-chat-start", "first-chat-end"],
+      ["first-chat-end", "second-chat-start"],
+      ["second-chat-start", "second-chat-end"],
+      ["second-chat-end", "repl-return"],
+      ["repl-return", "lifecycle-close"],
+      ["lifecycle-close", "store-close"],
+      ["store-close", "writer-release"],
+      ["input-eof", "repl-return"],
+    ] as const) {
+      expect(trace.indexOf(earlier)).toBeLessThan(trace.indexOf(later));
+    }
+  });
+
+  it("uses typed writer errors and redacts every other startup failure", async () => {
+    const holder = Object.assign(Object.create(CoachStoreWriterError.prototype), {
+      name: "CoachStoreWriterError",
+      message: "private holder detail",
+      code: "writer-lock-held" as const,
+      stage: null,
+      contention: { kind: "holder" as const, pid: null, port: 43100 },
+    }) as CoachStoreWriterError;
+    const foreignPortFile = join(home.configDir, "store-writer.port");
+    const foreign = Object.assign(Object.create(CoachStoreWriterError.prototype), {
+      name: "CoachStoreWriterError",
+      message: "private foreign detail",
+      code: "writer-lock-held" as const,
+      stage: null,
+      contention: { kind: "foreign" as const, port: 43101, portFile: foreignPortFile },
+    }) as CoachStoreWriterError;
+    const failed = Object.assign(Object.create(CoachStoreWriterError.prototype), {
+      name: "CoachStoreWriterError",
+      message: "private writer detail",
+      code: "writer-failed" as const,
+      stage: "open store" as const,
+      contention: null,
+    }) as CoachStoreWriterError;
+    const rows = [
+      {
+        error: holder,
+        exitCode: EXIT_DAEMON_UNAVAILABLE,
+        stderr:
+          "Enduragent cannot start: another writer holds this athlete home (pid unknown, port 43100). Stop it or wait, then retry.\n",
+      },
+      {
+        error: foreign,
+        exitCode: EXIT_DAEMON_UNAVAILABLE,
+        stderr: `Enduragent cannot start: 127.0.0.1:43101 is held by a foreign process; change or remove the port file at ${foreignPortFile}, then retry.\n`,
+      },
+      {
+        error: failed,
+        exitCode: EXIT_AGENT_ERROR,
+        stderr: "Enduragent could not start.\n",
+      },
+      {
+        error: new Error("private unrelated detail"),
+        exitCode: EXIT_AGENT_ERROR,
+        stderr: "Enduragent could not start.\n",
+      },
+    ];
+
+    for (const row of rows) {
+      const io = terminal();
+      const result = await runEnduragent(
+        {
+          argv: [],
+          env,
+          terminal: io.value,
+          signal: new AbortController().signal,
+        },
+        {
+          resolveAthleteHome: () => home,
+          withLocalCoach: async <T>(
+            input: WithLocalCoachInput<T>,
+          ): Promise<LocalCoachRunResult<T>> => {
+            void input;
+            throw row.error;
+          },
+          readPackageVersion: async () => "unused",
+        },
+      );
+      expect(result).toBe(row.exitCode);
+      expect(io.stdout.read()).toBe("");
+      expect(io.stderr.read()).toBe(row.stderr);
+    }
+  });
+
+  it("reports real contention and drains an in-flight turn before release", async () => {
+    const writerAcquired = deferred<void>();
+    const releaseWriter = deferred<void>();
+    const holdingWriter = withCoachStoreWriter(env, async () => {
+      writerAcquired.resolve(undefined);
+      await releaseWriter.promise;
+    });
+    await Promise.race([
+      writerAcquired.promise,
+      holdingWriter.then(() => Promise.reject(new Error("writer ended early"))),
+    ]);
+    try {
+      const port = Number.parseInt(
+        await readFile(join(home.configDir, PORT_FILE_NAME), "utf8"),
+        10,
+      );
+      const io = terminal();
+      await expect(
+        runEnduragent(
+          {
+            argv: [],
+            env,
+            terminal: io.value,
+            signal: new AbortController().signal,
+          },
+          {
+            resolveAthleteHome: () => home,
+            withLocalCoach,
+            readPackageVersion: async () => "unused",
+          },
+        ),
+      ).resolves.toBe(EXIT_DAEMON_UNAVAILABLE);
+      expect(io.stdout.read()).toBe("");
+      expect(io.stderr.read()).toBe(
+        `Enduragent cannot start: another writer holds this athlete home (pid ${process.pid}, port ${port}). Stop it or wait, then retry.\n`,
+      );
+    } finally {
+      releaseWriter.resolve(undefined);
+      await holdingWriter;
+    }
+
+    const trace: string[] = [];
+    const response = deferred<{ text: string }>();
+    const mocked = mockEngine(async () => {
+      trace.push("turn-start");
+      const value = await response.promise;
+      trace.push("turn-end");
+      return value;
+    });
+    const controller = new AbortController();
+    const io = terminal();
+    const runner: EnduragentDependencies["withLocalCoach"] = async <T>(
+      input: WithLocalCoachInput<T>,
+    ): Promise<LocalCoachRunResult<T>> => {
+      const lifecycle = {
+        engine: mocked.engine,
+        close: async () => {
+          trace.push("lifecycle-close");
+        },
+      };
+      try {
+        const value = await input.operation(lifecycle);
+        trace.push("repl-return");
+        return { status: "completed", value };
+      } finally {
+        await lifecycle.close();
+        trace.push("store-close", "writer-release");
+      }
+    };
+    const result = runEnduragent(
+      {
+        argv: [],
+        env,
+        terminal: io.value,
+        signal: controller.signal,
+      },
+      {
+        resolveAthleteHome: () => home,
+        withLocalCoach: runner,
+        readPackageVersion: async () => "unused",
+      },
+    );
+    io.input.write("turn\n");
+    await vi.waitFor(() => expect(mocked.chat).toHaveBeenCalledTimes(1));
+    controller.abort();
+    response.resolve({ text: "turn-response" });
+    await expect(result).resolves.toBe(EXIT_SUCCESS);
+    for (const [earlier, later] of [
+      ["turn-start", "turn-end"],
+      ["turn-end", "repl-return"],
+      ["repl-return", "lifecycle-close"],
+      ["lifecycle-close", "store-close"],
+      ["store-close", "writer-release"],
+    ] as const) {
+      expect(trace.indexOf(earlier)).toBeLessThan(trace.indexOf(later));
+    }
+  });
+});

--- a/packages/coach/tests/package-exports.test.ts
+++ b/packages/coach/tests/package-exports.test.ts
@@ -22,6 +22,7 @@ describe("coach package handoff", () => {
       "./local-bundle-producer": "./dist/local-bundle-producer.js",
       "./store-runtime": "./dist/store-runtime.js",
       "./local-runner": "./dist/local-runner.js",
+      "./enduragent": "./dist/enduragent.js",
     });
     expect(packageJson.scripts).toEqual({
       build: "tsup",
@@ -50,6 +51,7 @@ describe("coach package handoff", () => {
       "store-gate-command",
       "season-review-command",
       "local-runner",
+      "enduragent",
     ];
     for (const entry of entries) {
       await expect(access(join(coachRoot, "dist", `${entry}.js`))).resolves.toBeUndefined();

--- a/packages/coach/tsup.config.ts
+++ b/packages/coach/tsup.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
     "store-gate-command": "src/store-gate-command.ts",
     "season-review-command": "src/season-review-command.ts",
     "local-runner": "src/local-runner.ts",
+    enduragent: "src/enduragent.ts",
   },
   format: ["esm"],
   dts: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,6 +73,9 @@ importers:
 
   packages/coach:
     dependencies:
+      '@enduragent/coach-cli':
+        specifier: workspace:*
+        version: link:../coach-cli
       '@enduragent/coach-contract':
         specifier: workspace:*
         version: link:../coach-contract
@@ -97,6 +100,25 @@ importers:
       yaml:
         specifier: ^2.8.3
         version: 2.8.3
+    devDependencies:
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.6.0
+      tsup:
+        specifier: ^8.4.0
+        version: 8.5.1(postcss@8.5.12)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.3)
+      typescript:
+        specifier: ^6.0.2
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.4
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.8(vitest@4.1.5))(msw@2.14.2(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))
+
+  packages/coach-cli:
+    dependencies:
+      '@enduragent/coach-contract':
+        specifier: workspace:*
+        version: link:../coach-contract
     devDependencies:
       '@types/node':
         specifier: ^25.6.0


### PR DESCRIPTION
## Summary

Closes the engine-extraction train with the user-facing executable:

- NEW `packages/coach-cli` (R6): argument/REPL behavior against an injected `CoachEngine` and terminal I/O; imports only the contract package. Non-TTY protocol: newline-delimited FIFO turns under the pinned session, no banner off-TTY, writer released after EOF plus the last in-flight turn.
- `packages/coach/src/enduragent.ts` + `bin` wiring: home resolution, migration-before-engine-open under the store writer, readiness refusal (contract exit 4 with actionable remediation) before entering the REPL, delegation to coach-cli, and the composition-root local-runner lifecycle consumed as shipped by PR-6.
- Package-exports test extended additively for the new `./enduragent` subpath; changeset included.

## Verification

- Coach CLI 6/6; executable suite green (real loopback contention case verified in the root gate); amended three-file regression command 51 tests green.
- Export-map imports, shebang, symlinked-bin smoke, and protocol-scope search green.
- Root `pnpm build`, `pnpm check`, full `pnpm test` green.
