### PR TITLE
feat(kernel-node): add launchd service mechanics

### DIFF
--- a/packages/kernel-node/package.json
+++ b/packages/kernel-node/package.json
@@ -14,6 +14,7 @@
     "./filesystem": "./dist/filesystem/index.js",
     "./ingest": "./dist/ingest/index.js",
     "./capture-manifest": "./dist/capture-manifest/index.js",
+    "./service": "./dist/service/index.js",
     "./coach-dev": "./dist/coach-dev.js"
   },
   "engines": {

--- a/packages/kernel-node/src/service/index.ts
+++ b/packages/kernel-node/src/service/index.ts
@@ -1,0 +1,31 @@
+export {
+  LAUNCHD_ENV_MODE,
+  LAUNCHD_PLIST_MODE,
+  LAUNCHD_STATE_DIR_MODE,
+  LAUNCHD_THROTTLE_INTERVAL_SECONDS,
+  LAUNCHD_WRAPPER_MODE,
+  LaunchdServiceCommandError,
+  LaunchdServiceNotInstalledError,
+  UnsupportedLaunchdPlatformError,
+  buildLaunchdServicePlist,
+  canonicalizeAthleteHome,
+  createLaunchdServiceIdentity,
+  deriveLaunchdServiceLabel,
+  installLaunchdService,
+  readLaunchdServiceStatus,
+  resolveLaunchdServicePaths,
+  restartLaunchdService,
+  restartLaunchdServiceForUpgrade,
+  resumeLaunchdService,
+  resumeLaunchdServiceAfterEphemeral,
+  uninstallLaunchdService,
+} from "./launchd-plist.js";
+
+export type {
+  LaunchdCommandResult,
+  LaunchdDesignatedSuccessorInput,
+  LaunchdServiceDependencies,
+  LaunchdServiceIdentity,
+  LaunchdServicePaths,
+  LaunchdServiceStatus,
+} from "./launchd-plist.js";

--- a/packages/kernel-node/src/service/launchd-plist.ts
+++ b/packages/kernel-node/src/service/launchd-plist.ts
@@ -1,0 +1,803 @@
+import { execFile as nodeExecFile } from "node:child_process";
+import { createHash, randomBytes } from "node:crypto";
+import { constants } from "node:fs";
+import { chmod, lstat as nodeLstat, mkdir, open, rename, unlink } from "node:fs/promises";
+import { homedir } from "node:os";
+import { basename, dirname, isAbsolute, join, resolve } from "node:path";
+
+import type { AthleteHome } from "../home/index.js";
+
+export const LAUNCHD_THROTTLE_INTERVAL_SECONDS = 10 as const;
+export const LAUNCHD_PLIST_MODE = 0o600 as const;
+export const LAUNCHD_STATE_DIR_MODE = 0o700 as const;
+export const LAUNCHD_ENV_MODE = 0o600 as const;
+export const LAUNCHD_WRAPPER_MODE = 0o700 as const;
+
+const LAUNCHCTL_PATH = "/bin/launchctl";
+const LAUNCHCTL_TIMEOUT_MS = 5_000;
+const STATUS_UNAVAILABLE_DETAIL = "launchd status unavailable";
+const COMMAND_FAILED_MESSAGE = "launchd service command failed";
+const SERVICE_LABEL_PATTERN = /^[A-Za-z0-9._-]+$/;
+const HANDOFF_CAPABILITY_PATTERN = /^[A-Za-z0-9_-]{43}$/;
+
+const LAUNCHD_WRAPPER_BYTES = `#!/bin/sh
+set -eu
+env_file="$1"
+shift
+. "$env_file"
+handoff_file="\${env_file%.env}.handoff"
+if [ -e "$handoff_file" ] || [ -L "$handoff_file" ]; then
+  if [ -L "$handoff_file" ] || [ ! -f "$handoff_file" ]; then
+    /bin/rm -f "$handoff_file"
+    exit 1
+  fi
+  handoff_mode="$(/usr/bin/stat -f '%Lp' "$handoff_file")" || {
+    /bin/rm -f "$handoff_file"
+    exit 1
+  }
+  if [ "$handoff_mode" != "600" ]; then
+    /bin/rm -f "$handoff_file"
+    exit 1
+  fi
+  exec 9< "$handoff_file"
+  IFS= read -r ENDURAGENT_HANDOFF_CAPABILITY <&9 || {
+    exec 9<&-
+    /bin/rm -f "$handoff_file"
+    exit 1
+  }
+  if IFS= read -r handoff_extra <&9; then
+    exec 9<&-
+    /bin/rm -f "$handoff_file"
+    exit 1
+  fi
+  exec 9<&-
+  /bin/rm -f "$handoff_file"
+  if [ "\${#ENDURAGENT_HANDOFF_CAPABILITY}" -ne 43 ]; then
+    exit 1
+  fi
+  case "$ENDURAGENT_HANDOFF_CAPABILITY" in
+    *[!A-Za-z0-9_-]*) exit 1 ;;
+  esac
+  export ENDURAGENT_HANDOFF_CAPABILITY
+fi
+exec "$@"
+`;
+
+export interface LaunchdServiceIdentity {
+  readonly label: string;
+  readonly executablePath: string;
+  readonly home: AthleteHome;
+}
+
+export interface LaunchdServicePaths {
+  readonly launchAgentsDir: string;
+  readonly plistPath: string;
+  readonly stateDir: string;
+  readonly envPath: string;
+  readonly wrapperPath: string;
+  readonly handoffPath: string;
+}
+
+export type LaunchdServiceStatus =
+  | {
+      readonly kind: "absent";
+      readonly registered: false;
+      readonly installed: false;
+      readonly loaded: false;
+      readonly running: false;
+      readonly label: string;
+      readonly pid: null;
+      readonly lastExitStatus: null;
+      readonly paths: LaunchdServicePaths;
+    }
+  | {
+      readonly kind: "registered";
+      readonly registered: true;
+      readonly installed: boolean;
+      readonly loaded: boolean;
+      readonly running: boolean;
+      readonly label: string;
+      readonly pid: number | null;
+      readonly lastExitStatus: number | null;
+      readonly paths: LaunchdServicePaths;
+    }
+  | {
+      readonly kind: "unknown";
+      readonly registered: null;
+      readonly installed: boolean | null;
+      readonly loaded: null;
+      readonly running: null;
+      readonly label: string;
+      readonly pid: null;
+      readonly lastExitStatus: null;
+      readonly paths: LaunchdServicePaths;
+      readonly detail: string;
+    };
+
+export type LaunchdCommandResult =
+  | {
+      readonly outcome: "exited";
+      readonly exitCode: number;
+      readonly stdout: string;
+      readonly stderr: string;
+    }
+  | {
+      readonly outcome: "timed-out" | "signaled" | "spawn-failed";
+      readonly exitCode: null;
+      readonly stdout: string;
+      readonly stderr: string;
+    };
+
+export interface LaunchdDesignatedSuccessorInput {
+  readonly targetProtocolVersion: number;
+  readonly handoffCapability: string;
+}
+
+export interface LaunchdServiceDependencies {
+  readonly platform?: NodeJS.Platform;
+  readonly uid?: number;
+  readonly userHome?: string;
+  readonly runLaunchctl?: (args: readonly string[]) => Promise<LaunchdCommandResult>;
+  readonly execFile?: typeof import("node:child_process").execFile;
+  readonly lstat?: typeof import("node:fs/promises").lstat;
+}
+
+export class UnsupportedLaunchdPlatformError extends Error {
+  constructor() {
+    super("launchd service management is unavailable");
+    this.name = "UnsupportedLaunchdPlatformError";
+  }
+}
+
+export class LaunchdServiceNotInstalledError extends Error {
+  constructor() {
+    super("launchd service is not installed");
+    this.name = "LaunchdServiceNotInstalledError";
+  }
+}
+
+export class LaunchdServiceCommandError extends Error {
+  constructor() {
+    super(COMMAND_FAILED_MESSAGE);
+    this.name = "LaunchdServiceCommandError";
+  }
+}
+
+interface LaunchdRuntime {
+  readonly uid: number;
+  readonly userHome: string;
+  readonly runLaunchctl: (args: readonly string[]) => Promise<LaunchdCommandResult>;
+  readonly lstat: typeof nodeLstat;
+}
+
+function isErrno(error: unknown, code: string): boolean {
+  return typeof error === "object" && error !== null && "code" in error && error.code === code;
+}
+
+function validateIdentity(identity: LaunchdServiceIdentity): void {
+  if (
+    !isAbsolute(identity.home.root) ||
+    !isAbsolute(identity.home.configDir) ||
+    !isAbsolute(identity.executablePath)
+  ) {
+    throw new TypeError("launchd service paths must be absolute");
+  }
+  if (!SERVICE_LABEL_PATTERN.test(identity.label)) {
+    throw new TypeError("launchd service label is invalid");
+  }
+}
+
+function createDefaultLaunchctlRunner(
+  userHome: string,
+  execFile: typeof nodeExecFile,
+): (args: readonly string[]) => Promise<LaunchdCommandResult> {
+  return async (args) =>
+    await new Promise((resolveResult) => {
+      execFile(
+        LAUNCHCTL_PATH,
+        [...args],
+        {
+          shell: false,
+          encoding: "utf8",
+          timeout: LAUNCHCTL_TIMEOUT_MS,
+          env: {
+            PATH: "/usr/bin:/bin:/usr/sbin:/sbin",
+            HOME: userHome,
+          },
+        },
+        (error, stdoutValue, stderrValue) => {
+          const stdout = typeof stdoutValue === "string" ? stdoutValue : "";
+          const stderr = typeof stderrValue === "string" ? stderrValue : "";
+          if (error === null) {
+            resolveResult({ outcome: "exited", exitCode: 0, stdout, stderr });
+            return;
+          }
+          if (error.killed === true) {
+            resolveResult({
+              outcome: "timed-out",
+              exitCode: null,
+              stdout,
+              stderr,
+            });
+            return;
+          }
+          if (typeof error.code === "number") {
+            resolveResult({
+              outcome: "exited",
+              exitCode: error.code,
+              stdout,
+              stderr,
+            });
+            return;
+          }
+          if (error.signal !== null && error.signal !== undefined) {
+            resolveResult({
+              outcome: "signaled",
+              exitCode: null,
+              stdout,
+              stderr,
+            });
+            return;
+          }
+          resolveResult({
+            outcome: "spawn-failed",
+            exitCode: null,
+            stdout,
+            stderr,
+          });
+        },
+      );
+    });
+}
+
+function resolveRuntime(dependencies: LaunchdServiceDependencies = {}): LaunchdRuntime {
+  if ((dependencies.platform ?? process.platform) !== "darwin") {
+    throw new UnsupportedLaunchdPlatformError();
+  }
+  const uid = dependencies.uid ?? process.getuid?.();
+  if (uid === undefined || !Number.isSafeInteger(uid) || uid < 0) {
+    throw new UnsupportedLaunchdPlatformError();
+  }
+  const userHome = dependencies.userHome ?? homedir();
+  if (!isAbsolute(userHome)) {
+    throw new TypeError("launchd user home must be absolute");
+  }
+  return {
+    uid,
+    userHome,
+    runLaunchctl:
+      dependencies.runLaunchctl ??
+      createDefaultLaunchctlRunner(userHome, dependencies.execFile ?? nodeExecFile),
+    lstat: dependencies.lstat ?? nodeLstat,
+  };
+}
+
+function pathsFor(identity: LaunchdServiceIdentity, userHome: string): LaunchdServicePaths {
+  const launchAgentsDir = join(userHome, "Library", "LaunchAgents");
+  const stateDir = join(identity.home.configDir, "service");
+  return Object.freeze({
+    launchAgentsDir,
+    plistPath: join(launchAgentsDir, `${identity.label}.plist`),
+    stateDir,
+    envPath: join(stateDir, `${identity.label}.env`),
+    wrapperPath: join(stateDir, `${identity.label}-env-wrapper.sh`),
+    handoffPath: join(stateDir, `${identity.label}.handoff`),
+  });
+}
+
+function domain(runtime: LaunchdRuntime): string {
+  return `gui/${runtime.uid}`;
+}
+
+function serviceTarget(identity: LaunchdServiceIdentity, runtime: LaunchdRuntime): string {
+  return `${domain(runtime)}/${identity.label}`;
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+function buildEnvironmentBytes(identity: LaunchdServiceIdentity): string {
+  return `export ENDURAGENT_HOME=${shellQuote(identity.home.root)}\nexport ENDURAGENT_DAEMON_OWNER='service-managed'\n`;
+}
+
+function xmlEscape(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;");
+}
+
+function isNotFound(result: LaunchdCommandResult): boolean {
+  if (result.outcome !== "exited" || result.exitCode === 0) return false;
+  const output = `${result.stdout}\n${result.stderr}`.toLowerCase();
+  return (
+    output.includes("could not find service") ||
+    output.includes("service not found") ||
+    output.includes("no such process")
+  );
+}
+
+async function runCommand(
+  runtime: LaunchdRuntime,
+  args: readonly string[],
+  allowNotFound = false,
+): Promise<void> {
+  let result: LaunchdCommandResult;
+  try {
+    result = await runtime.runLaunchctl(args);
+  } catch {
+    throw new LaunchdServiceCommandError();
+  }
+  if (result.outcome === "exited" && result.exitCode === 0) return;
+  if (allowNotFound && isNotFound(result)) return;
+  throw new LaunchdServiceCommandError();
+}
+
+function unknownStatus(
+  identity: LaunchdServiceIdentity,
+  paths: LaunchdServicePaths,
+  installed: boolean | null,
+): Extract<LaunchdServiceStatus, { kind: "unknown" }> {
+  return {
+    kind: "unknown",
+    registered: null,
+    installed,
+    loaded: null,
+    running: null,
+    label: identity.label,
+    pid: null,
+    lastExitStatus: null,
+    paths,
+    detail: STATUS_UNAVAILABLE_DETAIL,
+  };
+}
+
+function parsePositiveInteger(output: string, expression: RegExp): number | null {
+  const value = expression.exec(output)?.[1];
+  if (value === undefined) return null;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
+function parseInteger(output: string, expression: RegExp): number | null {
+  const value = expression.exec(output)?.[1];
+  if (value === undefined) return null;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) ? parsed : null;
+}
+
+async function statusWithRuntime(
+  identity: LaunchdServiceIdentity,
+  paths: LaunchdServicePaths,
+  runtime: LaunchdRuntime,
+): Promise<LaunchdServiceStatus> {
+  let installed: boolean;
+  try {
+    const stat = await runtime.lstat(paths.plistPath);
+    if (!stat.isFile() || stat.isSymbolicLink()) {
+      return unknownStatus(identity, paths, null);
+    }
+    installed = true;
+  } catch (error) {
+    if (!isErrno(error, "ENOENT")) {
+      return unknownStatus(identity, paths, null);
+    }
+    installed = false;
+  }
+
+  let result: LaunchdCommandResult;
+  try {
+    result = await runtime.runLaunchctl(["print", serviceTarget(identity, runtime)]);
+  } catch {
+    return unknownStatus(identity, paths, installed);
+  }
+
+  if (result.outcome === "exited" && result.exitCode === 0) {
+    const pid = parsePositiveInteger(result.stdout, /^\s*pid\s*=\s*(\d+)\s*$/im);
+    const lastExitStatus = parseInteger(result.stdout, /^\s*last exit status\s*=\s*(-?\d+)\s*$/im);
+    return {
+      kind: "registered",
+      registered: true,
+      installed,
+      loaded: true,
+      running: /^\s*state\s*=\s*running\s*$/im.test(result.stdout) || pid !== null,
+      label: identity.label,
+      pid,
+      lastExitStatus,
+      paths,
+    };
+  }
+
+  if (isNotFound(result)) {
+    if (!installed) {
+      return {
+        kind: "absent",
+        registered: false,
+        installed: false,
+        loaded: false,
+        running: false,
+        label: identity.label,
+        pid: null,
+        lastExitStatus: null,
+        paths,
+      };
+    }
+    return {
+      kind: "registered",
+      registered: true,
+      installed: true,
+      loaded: false,
+      running: false,
+      label: identity.label,
+      pid: null,
+      lastExitStatus: null,
+      paths,
+    };
+  }
+
+  return unknownStatus(identity, paths, installed);
+}
+
+async function atomicPublish(targetPath: string, bytes: string, mode: number): Promise<void> {
+  for (;;) {
+    const candidate = join(
+      dirname(targetPath),
+      `.${basename(targetPath)}.${randomBytes(12).toString("hex")}.tmp`,
+    );
+    let handle: Awaited<ReturnType<typeof open>>;
+    try {
+      handle = await open(
+        candidate,
+        constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY | constants.O_NOFOLLOW,
+        mode,
+      );
+    } catch (error) {
+      if (isErrno(error, "EEXIST")) continue;
+      throw error;
+    }
+
+    let openHandle: typeof handle | null = handle;
+    try {
+      await handle.writeFile(bytes, "utf8");
+      await handle.sync();
+      await handle.close();
+      openHandle = null;
+      await chmod(candidate, mode);
+      await rename(candidate, targetPath);
+      return;
+    } catch (error) {
+      if (openHandle !== null) {
+        try {
+          await openHandle.close();
+        } catch {}
+      }
+      try {
+        await unlink(candidate);
+      } catch (cleanupError) {
+        if (!isErrno(cleanupError, "ENOENT")) throw error;
+      }
+      throw error;
+    }
+  }
+}
+
+async function removeOwnedFile(path: string): Promise<void> {
+  let stat: Awaited<ReturnType<typeof nodeLstat>>;
+  try {
+    stat = await nodeLstat(path);
+  } catch (error) {
+    if (isErrno(error, "ENOENT")) return;
+    throw error;
+  }
+  if (!stat.isFile() || stat.isSymbolicLink()) {
+    throw new LaunchdServiceCommandError();
+  }
+  try {
+    await unlink(path);
+  } catch (error) {
+    if (!isErrno(error, "ENOENT")) throw error;
+  }
+}
+
+async function removeHandoff(paths: LaunchdServicePaths): Promise<void> {
+  try {
+    await removeOwnedFile(paths.handoffPath);
+  } catch (error) {
+    if (error instanceof LaunchdServiceCommandError) throw error;
+    throw new LaunchdServiceCommandError();
+  }
+}
+
+function validateSuccessorInput(input: LaunchdDesignatedSuccessorInput): void {
+  if (
+    !Number.isSafeInteger(input.targetProtocolVersion) ||
+    input.targetProtocolVersion < 0 ||
+    !HANDOFF_CAPABILITY_PATTERN.test(input.handoffCapability)
+  ) {
+    throw new TypeError("launchd designated successor input is invalid");
+  }
+}
+
+async function publishHandoff(
+  paths: LaunchdServicePaths,
+  input: LaunchdDesignatedSuccessorInput,
+): Promise<void> {
+  try {
+    await atomicPublish(paths.handoffPath, `${input.handoffCapability}\n`, LAUNCHD_ENV_MODE);
+  } catch {
+    throw new LaunchdServiceCommandError();
+  }
+}
+
+async function cleanFailedHandoff(paths: LaunchdServicePaths): Promise<void> {
+  try {
+    await removeOwnedFile(paths.handoffPath);
+  } catch {}
+}
+
+function requireRegistered(
+  status: LaunchdServiceStatus,
+): Extract<LaunchdServiceStatus, { kind: "registered" }> {
+  if (status.kind === "absent") {
+    throw new LaunchdServiceNotInstalledError();
+  }
+  if (status.kind === "unknown") {
+    throw new LaunchdServiceCommandError();
+  }
+  return status;
+}
+
+export function deriveLaunchdServiceLabel(athleteHomeRoot: string): string {
+  const normalizedRoot = resolve(athleteHomeRoot);
+  const suffix = createHash("sha256").update(normalizedRoot, "utf8").digest("hex").slice(0, 16);
+  return `ai.enduragent.coach.${suffix}`;
+}
+
+export function canonicalizeAthleteHome(home: AthleteHome): AthleteHome {
+  const root = resolve(home.root);
+  const storeDir = resolve(home.storeDir);
+  const archiveDir = resolve(home.archiveDir);
+  const configDir = resolve(home.configDir);
+  if (
+    storeDir !== join(root, "store") ||
+    archiveDir !== join(root, "archive") ||
+    configDir !== join(root, "config")
+  ) {
+    throw new TypeError("athlete home paths are inconsistent");
+  }
+  return Object.freeze({ root, storeDir, archiveDir, configDir });
+}
+
+export function createLaunchdServiceIdentity(input: {
+  readonly home: AthleteHome;
+  readonly executablePath: string;
+  readonly label?: string;
+}): LaunchdServiceIdentity {
+  if (
+    !isAbsolute(input.home.root) ||
+    !isAbsolute(input.home.configDir) ||
+    !isAbsolute(input.executablePath)
+  ) {
+    throw new TypeError("launchd service paths must be absolute");
+  }
+  const label = input.label ?? deriveLaunchdServiceLabel(input.home.root);
+  const identity = {
+    label,
+    executablePath: resolve(input.executablePath),
+    home: input.home,
+  };
+  validateIdentity(identity);
+  return Object.freeze(identity);
+}
+
+export function resolveLaunchdServicePaths(
+  identity: LaunchdServiceIdentity,
+  dependencies: LaunchdServiceDependencies = {},
+): LaunchdServicePaths {
+  validateIdentity(identity);
+  const runtime = resolveRuntime(dependencies);
+  return pathsFor(identity, runtime.userHome);
+}
+
+export function buildLaunchdServicePlist(
+  identity: LaunchdServiceIdentity,
+  paths: LaunchdServicePaths,
+): string {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>Label</key>
+    <string>${xmlEscape(identity.label)}</string>
+    <key>ProgramArguments</key>
+    <array>
+      <string>/bin/sh</string>
+      <string>${xmlEscape(paths.wrapperPath)}</string>
+      <string>${xmlEscape(paths.envPath)}</string>
+      <string>${xmlEscape(identity.executablePath)}</string>
+      <string>serve</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <dict>
+      <key>SuccessfulExit</key>
+      <false/>
+    </dict>
+    <key>ThrottleInterval</key>
+    <integer>${LAUNCHD_THROTTLE_INTERVAL_SECONDS}</integer>
+  </dict>
+</plist>
+`;
+}
+
+export async function readLaunchdServiceStatus(
+  identity: LaunchdServiceIdentity,
+  dependencies: LaunchdServiceDependencies = {},
+): Promise<LaunchdServiceStatus> {
+  validateIdentity(identity);
+  const runtime = resolveRuntime(dependencies);
+  const paths = pathsFor(identity, runtime.userHome);
+  return await statusWithRuntime(identity, paths, runtime);
+}
+
+export async function installLaunchdService(
+  identity: LaunchdServiceIdentity,
+  dependencies: LaunchdServiceDependencies = {},
+): Promise<Extract<LaunchdServiceStatus, { kind: "registered" }>> {
+  validateIdentity(identity);
+  const runtime = resolveRuntime(dependencies);
+  const paths = pathsFor(identity, runtime.userHome);
+  try {
+    await mkdir(paths.launchAgentsDir, { recursive: true, mode: 0o755 });
+    await mkdir(paths.stateDir, {
+      recursive: true,
+      mode: LAUNCHD_STATE_DIR_MODE,
+    });
+    const stateStat = await nodeLstat(paths.stateDir);
+    if (!stateStat.isDirectory() || stateStat.isSymbolicLink()) {
+      throw new LaunchdServiceCommandError();
+    }
+    await chmod(paths.stateDir, LAUNCHD_STATE_DIR_MODE);
+    await atomicPublish(paths.envPath, buildEnvironmentBytes(identity), LAUNCHD_ENV_MODE);
+    await atomicPublish(paths.wrapperPath, LAUNCHD_WRAPPER_BYTES, LAUNCHD_WRAPPER_MODE);
+    await atomicPublish(
+      paths.plistPath,
+      buildLaunchdServicePlist(identity, paths),
+      LAUNCHD_PLIST_MODE,
+    );
+  } catch (error) {
+    if (error instanceof LaunchdServiceCommandError) throw error;
+    throw new LaunchdServiceCommandError();
+  }
+
+  await runCommand(runtime, ["bootout", serviceTarget(identity, runtime)], true);
+  await runCommand(runtime, ["enable", serviceTarget(identity, runtime)]);
+  await runCommand(runtime, ["bootstrap", domain(runtime), paths.plistPath]);
+  const status = await statusWithRuntime(identity, paths, runtime);
+  if (status.kind !== "registered" || !status.loaded) {
+    throw new LaunchdServiceCommandError();
+  }
+  return status;
+}
+
+export async function uninstallLaunchdService(
+  identity: LaunchdServiceIdentity,
+  dependencies: LaunchdServiceDependencies = {},
+): Promise<Extract<LaunchdServiceStatus, { kind: "absent" }>> {
+  validateIdentity(identity);
+  const runtime = resolveRuntime(dependencies);
+  const paths = pathsFor(identity, runtime.userHome);
+  await runCommand(runtime, ["bootout", serviceTarget(identity, runtime)], true);
+  try {
+    for (const path of [paths.plistPath, paths.envPath, paths.wrapperPath, paths.handoffPath]) {
+      await removeOwnedFile(path);
+    }
+  } catch (error) {
+    if (error instanceof LaunchdServiceCommandError) throw error;
+    throw new LaunchdServiceCommandError();
+  }
+  const status = await statusWithRuntime(identity, paths, runtime);
+  if (status.kind !== "absent") throw new LaunchdServiceCommandError();
+  return status;
+}
+
+export async function restartLaunchdService(
+  identity: LaunchdServiceIdentity,
+  dependencies: LaunchdServiceDependencies = {},
+): Promise<Extract<LaunchdServiceStatus, { kind: "registered" }>> {
+  validateIdentity(identity);
+  const runtime = resolveRuntime(dependencies);
+  const paths = pathsFor(identity, runtime.userHome);
+  await removeHandoff(paths);
+  const initial = requireRegistered(await statusWithRuntime(identity, paths, runtime));
+  if (initial.loaded) {
+    await runCommand(runtime, ["kickstart", "-k", serviceTarget(identity, runtime)]);
+  } else {
+    await runCommand(runtime, ["enable", serviceTarget(identity, runtime)]);
+    await runCommand(runtime, ["bootstrap", domain(runtime), paths.plistPath]);
+  }
+  const status = await statusWithRuntime(identity, paths, runtime);
+  if (status.kind !== "registered") throw new LaunchdServiceCommandError();
+  return status;
+}
+
+export async function resumeLaunchdService(
+  identity: LaunchdServiceIdentity,
+  dependencies: LaunchdServiceDependencies = {},
+): Promise<"resumed" | "not-installed"> {
+  validateIdentity(identity);
+  const runtime = resolveRuntime(dependencies);
+  const paths = pathsFor(identity, runtime.userHome);
+  await removeHandoff(paths);
+  const status = await statusWithRuntime(identity, paths, runtime);
+  if (status.kind === "absent") return "not-installed";
+  if (status.kind === "unknown") throw new LaunchdServiceCommandError();
+  if (!status.loaded) {
+    await runCommand(runtime, ["enable", serviceTarget(identity, runtime)]);
+    await runCommand(runtime, ["bootstrap", domain(runtime), paths.plistPath]);
+  } else if (!status.running) {
+    await runCommand(runtime, ["kickstart", serviceTarget(identity, runtime)]);
+  }
+  return "resumed";
+}
+
+export async function restartLaunchdServiceForUpgrade(
+  identity: LaunchdServiceIdentity,
+  input: LaunchdDesignatedSuccessorInput,
+  dependencies: LaunchdServiceDependencies = {},
+): Promise<Extract<LaunchdServiceStatus, { kind: "registered" }>> {
+  validateIdentity(identity);
+  validateSuccessorInput(input);
+  const runtime = resolveRuntime(dependencies);
+  const paths = pathsFor(identity, runtime.userHome);
+  const initial = requireRegistered(await statusWithRuntime(identity, paths, runtime));
+  if (!initial.loaded) {
+    await runCommand(runtime, ["enable", serviceTarget(identity, runtime)]);
+  }
+  await publishHandoff(paths, input);
+  try {
+    if (initial.loaded) {
+      await runCommand(runtime, ["kickstart", "-k", serviceTarget(identity, runtime)]);
+    } else {
+      await runCommand(runtime, ["bootstrap", domain(runtime), paths.plistPath]);
+    }
+  } catch (error) {
+    await cleanFailedHandoff(paths);
+    throw error;
+  }
+  const status = await statusWithRuntime(identity, paths, runtime);
+  if (status.kind !== "registered") throw new LaunchdServiceCommandError();
+  return status;
+}
+
+export async function resumeLaunchdServiceAfterEphemeral(
+  identity: LaunchdServiceIdentity,
+  input: LaunchdDesignatedSuccessorInput,
+  dependencies: LaunchdServiceDependencies = {},
+): Promise<"resumed"> {
+  validateIdentity(identity);
+  validateSuccessorInput(input);
+  const runtime = resolveRuntime(dependencies);
+  const paths = pathsFor(identity, runtime.userHome);
+  const status = requireRegistered(await statusWithRuntime(identity, paths, runtime));
+  if (status.running) throw new LaunchdServiceCommandError();
+  if (!status.loaded) {
+    await runCommand(runtime, ["enable", serviceTarget(identity, runtime)]);
+  }
+  await publishHandoff(paths, input);
+  try {
+    if (status.loaded) {
+      await runCommand(runtime, ["kickstart", serviceTarget(identity, runtime)]);
+    } else {
+      await runCommand(runtime, ["bootstrap", domain(runtime), paths.plistPath]);
+    }
+  } catch (error) {
+    await cleanFailedHandoff(paths);
+    throw error;
+  }
+  return "resumed";
+}

--- a/packages/kernel-node/tests/launchd-service-live.test.ts
+++ b/packages/kernel-node/tests/launchd-service-live.test.ts
@@ -1,0 +1,155 @@
+import { execFile } from "node:child_process";
+import { chmod, mkdir, mkdtemp, readFile, realpath, rm, unlink, writeFile } from "node:fs/promises";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import type { AthleteHome } from "@enduragent/kernel-node/home";
+
+import { createLaunchdServiceIdentity, installLaunchdService } from "../src/service/index.js";
+
+interface CommandResult {
+  readonly exitCode: number;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+function runLaunchctl(args: readonly string[]): Promise<CommandResult> {
+  return new Promise((resolveResult) => {
+    execFile(
+      "/bin/launchctl",
+      [...args],
+      {
+        shell: false,
+        encoding: "utf8",
+        timeout: 5_000,
+        env: {
+          PATH: "/usr/bin:/bin:/usr/sbin:/sbin",
+          HOME: homedir(),
+        },
+      },
+      (error, stdoutValue, stderrValue) => {
+        const stdout = typeof stdoutValue === "string" ? stdoutValue : "";
+        const stderr = typeof stderrValue === "string" ? stderrValue : "";
+        resolveResult({
+          exitCode: error === null ? 0 : typeof error.code === "number" ? error.code : 1,
+          stdout,
+          stderr,
+        });
+      },
+    );
+  });
+}
+
+async function waitForStarts(path: string): Promise<number[]> {
+  const deadline = Date.now() + 50_000;
+  while (Date.now() < deadline) {
+    let bytes = "";
+    try {
+      bytes = await readFile(path, "utf8");
+    } catch {}
+    const starts = bytes
+      .trim()
+      .split("\n")
+      .filter((value) => value.length > 0)
+      .map(Number);
+    if (starts.length >= 4) return starts;
+    await new Promise((resolveDelay) => setTimeout(resolveDelay, 500));
+  }
+  throw new Error("launchd cadence probe timed out");
+}
+
+const liveDescribe =
+  process.env.RUN_ENDURAGENT_LAUNCHD_STANDARD_LOCATION === "1" ? describe : describe.skip;
+
+liveDescribe("launchd standard-location probe", () => {
+  it("accepts the owner-only plist and retains fixed crash-loop throttling", async () => {
+    expect(process.platform).toBe("darwin");
+    const temporaryDirectory = await realpath(tmpdir());
+    const root = await mkdtemp(join(temporaryDirectory, "launchd-live-probe-"));
+    const label = `ai.enduragent.coach.probe.${process.pid}.${Date.now()}`;
+    const home: AthleteHome = {
+      root: join(root, "athlete"),
+      storeDir: join(root, "athlete", "store"),
+      archiveDir: join(root, "athlete", "archive"),
+      configDir: join(root, "athlete", "config"),
+    };
+    const executablePath = join(root, "synthetic-enduragent");
+    const startsPath = join(root, "starts");
+    await mkdir(home.configDir, { recursive: true, mode: 0o700 });
+    await writeFile(executablePath, `#!/bin/sh\n/bin/date +%s >> '${startsPath}'\nexit 1\n`, {
+      mode: 0o700,
+    });
+    const identity = createLaunchdServiceIdentity({
+      home,
+      executablePath,
+      label,
+    });
+    const uid = process.getuid?.();
+    if (uid === undefined) throw new Error("launchd requires a user id");
+    const target = `gui/${uid}/${label}`;
+    let paths: Awaited<ReturnType<typeof installLaunchdService>>["paths"] | undefined;
+
+    try {
+      const installed = await installLaunchdService(identity, {
+        platform: "darwin",
+        uid,
+        userHome: homedir(),
+        runLaunchctl: async (args) =>
+          args[0] === "print"
+            ? {
+                outcome: "exited",
+                exitCode: 0,
+                stdout: "state = exited\n",
+                stderr: "",
+              }
+            : {
+                outcome: "exited",
+                exitCode: 0,
+                stdout: "",
+                stderr: "",
+              },
+      });
+      paths = installed.paths;
+      await runLaunchctl(["bootout", target]);
+      await runLaunchctl(["enable", target]);
+      let bootstrap = await runLaunchctl(["bootstrap", `gui/${uid}`, paths.plistPath]);
+      if (bootstrap.exitCode === 0) {
+        process.stdout.write("PLIST_0600_ACCEPTED_REQUIRES_DECISION_AMENDMENT\n");
+      } else {
+        const output = `${bootstrap.stdout}\n${bootstrap.stderr}`;
+        if (/EIO/i.test(output)) {
+          process.stdout.write("ENVIRONMENT_BLOCKED launchd-standard-location EIO\n");
+          return;
+        }
+        process.stdout.write("PLIST_0600_REJECTED\n");
+        await chmod(paths.plistPath, 0o644);
+        bootstrap = await runLaunchctl(["bootstrap", `gui/${uid}`, paths.plistPath]);
+        expect(bootstrap.exitCode).toBe(0);
+      }
+
+      const starts = await waitForStarts(startsPath);
+      const intervals = starts.slice(1, 4).map((value, index) => {
+        const previous = starts[index];
+        if (previous === undefined) throw new Error("missing launchd start");
+        return (value - previous) * 1_000;
+      });
+      for (const interval of intervals) {
+        expect(interval).toBeGreaterThanOrEqual(8_000);
+        expect(interval).toBeLessThanOrEqual(16_000);
+      }
+      expect(Math.max(...intervals) - Math.min(...intervals)).toBeLessThanOrEqual(4_000);
+    } finally {
+      await runLaunchctl(["bootout", target]);
+      if (paths !== undefined) {
+        for (const path of [paths.plistPath, paths.envPath, paths.wrapperPath, paths.handoffPath]) {
+          try {
+            await unlink(path);
+          } catch {}
+        }
+      }
+      await rm(root, { recursive: true, force: true });
+    }
+  }, 70_000);
+});

--- a/packages/kernel-node/tests/launchd-service.test.ts
+++ b/packages/kernel-node/tests/launchd-service.test.ts
@@ -1,0 +1,773 @@
+import { execFile as nodeExecFile } from "node:child_process";
+import { createHash } from "node:crypto";
+import { promisify } from "node:util";
+import {
+  chmod,
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  realpath,
+  rm,
+  stat,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { AthleteHome } from "@enduragent/kernel-node/home";
+
+import {
+  LAUNCHD_ENV_MODE,
+  LAUNCHD_PLIST_MODE,
+  LAUNCHD_STATE_DIR_MODE,
+  LAUNCHD_WRAPPER_MODE,
+  LaunchdServiceCommandError,
+  LaunchdServiceNotInstalledError,
+  UnsupportedLaunchdPlatformError,
+  buildLaunchdServicePlist,
+  canonicalizeAthleteHome,
+  createLaunchdServiceIdentity,
+  deriveLaunchdServiceLabel,
+  installLaunchdService,
+  readLaunchdServiceStatus,
+  resolveLaunchdServicePaths,
+  restartLaunchdService,
+  restartLaunchdServiceForUpgrade,
+  resumeLaunchdService,
+  resumeLaunchdServiceAfterEphemeral,
+  uninstallLaunchdService,
+  type LaunchdCommandResult,
+  type LaunchdServiceDependencies,
+  type LaunchdServiceIdentity,
+} from "../src/service/index.js";
+
+const execFile = promisify(nodeExecFile);
+const roots: string[] = [];
+const capability = "abcdefghijklmnopqrstuvwxyzABCDEFGH012345678";
+
+async function scratch(prefix = "launchd-service-"): Promise<string> {
+  const systemTemporaryDirectory = await realpath(tmpdir());
+  const root = await mkdtemp(join(systemTemporaryDirectory, prefix));
+  roots.push(root);
+  return root;
+}
+
+function athleteHome(root: string): AthleteHome {
+  return Object.freeze({
+    root,
+    storeDir: join(root, "store"),
+    archiveDir: join(root, "archive"),
+    configDir: join(root, "config"),
+  });
+}
+
+async function fixture(label = "ai.enduragent.coach.synthetic"): Promise<{
+  root: string;
+  userHome: string;
+  identity: LaunchdServiceIdentity;
+  dependencies: LaunchdServiceDependencies;
+}> {
+  const root = await scratch();
+  const userHome = join(root, "user");
+  const home = athleteHome(join(root, "athlete"));
+  const identity = createLaunchdServiceIdentity({
+    home,
+    executablePath: join(root, "bin", "enduragent"),
+    label,
+  });
+  return {
+    root,
+    userHome,
+    identity,
+    dependencies: { platform: "darwin", uid: 501, userHome },
+  };
+}
+
+function exited(exitCode = 0, stdout = "", stderr = ""): LaunchdCommandResult {
+  return { outcome: "exited", exitCode, stdout, stderr };
+}
+
+function notFound(): LaunchdCommandResult {
+  return exited(113, "", "Could not find service");
+}
+
+function mode(value: Awaited<ReturnType<typeof stat>>): number {
+  return Number(value.mode) & 0o777;
+}
+
+interface FakeLaunchctl {
+  readonly calls: string[][];
+  readonly run: NonNullable<LaunchdServiceDependencies["runLaunchctl"]>;
+  loaded: boolean;
+  running: boolean;
+}
+
+function fakeLaunchctl(
+  initial: {
+    loaded?: boolean;
+    running?: boolean;
+  } = {},
+): FakeLaunchctl {
+  const fake: FakeLaunchctl = {
+    calls: [],
+    loaded: initial.loaded ?? false,
+    running: initial.running ?? false,
+    async run(args) {
+      fake.calls.push([...args]);
+      if (args[0] === "print") {
+        if (!fake.loaded) return notFound();
+        return exited(
+          0,
+          fake.running
+            ? "state = running\npid = 321\nlast exit status = 7\n"
+            : "state = exited\nlast exit status = 0\n",
+        );
+      }
+      if (args[0] === "bootout") {
+        const wasLoaded = fake.loaded;
+        fake.loaded = false;
+        fake.running = false;
+        return wasLoaded ? exited() : notFound();
+      }
+      if (args[0] === "bootstrap") {
+        fake.loaded = true;
+        fake.running = false;
+      }
+      if (args[0] === "kickstart") {
+        fake.loaded = true;
+        fake.running = true;
+      }
+      return exited();
+    },
+  };
+  return fake;
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await Promise.all(
+    roots.splice(0).map(async (root) => {
+      await rm(root, { recursive: true, force: true });
+    }),
+  );
+});
+
+describe("launchd service identity and bytes", () => {
+  it("renders the literal escaped plist with failure-only KeepAlive", () => {
+    const identity = {
+      label: `label&<>"'`,
+      executablePath: `/tmp/exe&<>"'`,
+      home: athleteHome("/tmp/athlete"),
+    };
+    const paths = {
+      launchAgentsDir: "/tmp/LaunchAgents",
+      plistPath: "/tmp/LaunchAgents/service.plist",
+      stateDir: "/tmp/state",
+      envPath: `/tmp/state/env&<>"'`,
+      wrapperPath: `/tmp/state/wrapper&<>"'`,
+      handoffPath: "/tmp/state/service.handoff",
+    };
+
+    expect(buildLaunchdServicePlist(identity, paths)).toBe(`<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>Label</key>
+    <string>label&amp;&lt;&gt;&quot;&apos;</string>
+    <key>ProgramArguments</key>
+    <array>
+      <string>/bin/sh</string>
+      <string>/tmp/state/wrapper&amp;&lt;&gt;&quot;&apos;</string>
+      <string>/tmp/state/env&amp;&lt;&gt;&quot;&apos;</string>
+      <string>/tmp/exe&amp;&lt;&gt;&quot;&apos;</string>
+      <string>serve</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <dict>
+      <key>SuccessfulExit</key>
+      <false/>
+    </dict>
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+  </dict>
+</plist>
+`);
+  });
+
+  it("contains no forbidden launch activation or secret-bearing keys", async () => {
+    const { identity, dependencies } = await fixture();
+    const plist = buildLaunchdServicePlist(
+      identity,
+      resolveLaunchdServicePaths(identity, dependencies),
+    );
+    expect(plist).toContain("<string>serve</string>");
+    expect(plist).not.toMatch(
+      /PathState|Sockets|MachServices|EnvironmentVariables|token|port|lock/i,
+    );
+  });
+
+  it("derives stable opaque labels from normalized roots", () => {
+    const expected = createHash("sha256")
+      .update(resolve("relative-athlete"), "utf8")
+      .digest("hex")
+      .slice(0, 16);
+    expect(deriveLaunchdServiceLabel("relative-athlete")).toBe(`ai.enduragent.coach.${expected}`);
+    expect(deriveLaunchdServiceLabel("relative-athlete")).not.toBe(
+      deriveLaunchdServiceLabel("other-athlete"),
+    );
+  });
+
+  it("canonicalizes all home paths together and rejects incoherent children", () => {
+    const canonical = canonicalizeAthleteHome({
+      root: "relative-athlete",
+      storeDir: "relative-athlete/store",
+      archiveDir: "relative-athlete/archive",
+      configDir: "relative-athlete/config",
+    });
+    expect(canonical).toEqual(athleteHome(resolve("relative-athlete")));
+    expect(Object.isFrozen(canonical)).toBe(true);
+    expect(() =>
+      canonicalizeAthleteHome({
+        ...canonical,
+        configDir: resolve("somewhere-else"),
+      }),
+    ).toThrow(TypeError);
+  });
+
+  it("preserves the canonical home object and rejects invalid identity inputs", () => {
+    const home = athleteHome("/tmp/athlete");
+    const identity = createLaunchdServiceIdentity({
+      home,
+      executablePath: "/tmp/../tmp/enduragent",
+    });
+    expect(identity.home).toBe(home);
+    expect(identity.executablePath).toBe("/tmp/enduragent");
+    expect(Object.isFrozen(identity)).toBe(true);
+    expect(() =>
+      createLaunchdServiceIdentity({
+        home,
+        executablePath: "relative",
+      }),
+    ).toThrow(TypeError);
+    expect(() =>
+      createLaunchdServiceIdentity({
+        home,
+        executablePath: "/tmp/enduragent",
+        label: "invalid label",
+      }),
+    ).toThrow(TypeError);
+  });
+});
+
+describe("launchd installation and wrapper", () => {
+  it("installs exact bytes and modes and converges across lifecycle repeats", async () => {
+    const { identity, dependencies } = await fixture();
+    const fake = fakeLaunchctl();
+    const injected = { ...dependencies, runLaunchctl: fake.run };
+    const first = await installLaunchdService(identity, injected);
+    const paths = first.paths;
+    const firstBytes = {
+      env: await readFile(paths.envPath, "utf8"),
+      wrapper: await readFile(paths.wrapperPath, "utf8"),
+      plist: await readFile(paths.plistPath, "utf8"),
+    };
+    expect(first.loaded).toBe(true);
+    expect(firstBytes.env).toBe(
+      `export ENDURAGENT_HOME='${identity.home.root}'\nexport ENDURAGENT_DAEMON_OWNER='service-managed'\n`,
+    );
+    expect(firstBytes.plist).toBe(buildLaunchdServicePlist(identity, paths));
+    expect(mode(await stat(paths.plistPath))).toBe(LAUNCHD_PLIST_MODE);
+    expect(mode(await stat(paths.stateDir))).toBe(LAUNCHD_STATE_DIR_MODE);
+    expect(mode(await stat(paths.envPath))).toBe(LAUNCHD_ENV_MODE);
+    expect(mode(await stat(paths.wrapperPath))).toBe(LAUNCHD_WRAPPER_MODE);
+
+    await installLaunchdService(identity, injected);
+    expect(await readFile(paths.envPath, "utf8")).toBe(firstBytes.env);
+    expect(await readFile(paths.wrapperPath, "utf8")).toBe(firstBytes.wrapper);
+    expect(await readFile(paths.plistPath, "utf8")).toBe(firstBytes.plist);
+    expect(fake.calls.map((call) => call[0])).toEqual([
+      "bootout",
+      "enable",
+      "bootstrap",
+      "print",
+      "bootout",
+      "enable",
+      "bootstrap",
+      "print",
+    ]);
+
+    await uninstallLaunchdService(identity, injected);
+    await uninstallLaunchdService(identity, injected);
+    const reinstalled = await installLaunchdService(identity, injected);
+    expect(await readFile(reinstalled.paths.plistPath, "utf8")).toBe(firstBytes.plist);
+    expect(mode(await stat(reinstalled.paths.plistPath))).toBe(0o600);
+  });
+
+  it("executes absolute paths under a minimal PATH with quoted home bytes", async () => {
+    const root = await scratch();
+    const userHome = join(root, "user");
+    const home = athleteHome(join(root, "athlete's home"));
+    const executablePath = join(root, "bin space", "synthetic executable");
+    const outputPath = join(root, "observed");
+    await mkdir(join(root, "bin space"), { recursive: true });
+    await writeFile(
+      executablePath,
+      `#!/bin/sh\n/usr/bin/printf '%s\\n%s\\n%s\\n' "$ENDURAGENT_HOME" "$ENDURAGENT_DAEMON_OWNER" "$1" > '${outputPath}'\n`,
+      { mode: 0o700 },
+    );
+    const identity = createLaunchdServiceIdentity({
+      home,
+      executablePath,
+      label: "ai.enduragent.coach.wrapper",
+    });
+    const fake = fakeLaunchctl();
+    const installed = await installLaunchdService(identity, {
+      platform: "darwin",
+      uid: 501,
+      userHome,
+      runLaunchctl: fake.run,
+    });
+    await execFile(
+      "/bin/sh",
+      [installed.paths.wrapperPath, installed.paths.envPath, identity.executablePath, "serve"],
+      { env: { PATH: "/usr/bin:/bin:/usr/sbin:/sbin" } },
+    );
+    expect(await readFile(outputPath, "utf8")).toBe(`${home.root}\nservice-managed\nserve\n`);
+  });
+
+  it("delivers a one-use protected handoff and leaves no replay carrier", async () => {
+    const { root, identity, dependencies } = await fixture();
+    const outputPath = join(root, "handoff-observed");
+    await mkdir(join(root, "bin"), { recursive: true });
+    await writeFile(
+      identity.executablePath,
+      `#!/bin/sh\n/usr/bin/printf '%s\\n%s\\n%s\\n' "$ENDURAGENT_DAEMON_OWNER" "$ENDURAGENT_HANDOFF_CAPABILITY" "$1" > '${outputPath}'\n`,
+      { mode: 0o700 },
+    );
+    const fake = fakeLaunchctl();
+    const injected = { ...dependencies, runLaunchctl: fake.run };
+    const installed = await installLaunchdService(identity, injected);
+    await restartLaunchdServiceForUpgrade(
+      identity,
+      { targetProtocolVersion: 1, handoffCapability: capability },
+      injected,
+    );
+    expect(mode(await stat(installed.paths.handoffPath))).toBe(0o600);
+    expect(await readFile(installed.paths.handoffPath, "utf8")).toBe(`${capability}\n`);
+    expect(await readFile(installed.paths.plistPath, "utf8")).not.toContain(capability);
+    expect(fake.calls.flat().join(" ")).not.toContain(capability);
+
+    await execFile("/bin/sh", [
+      installed.paths.wrapperPath,
+      installed.paths.envPath,
+      identity.executablePath,
+      "serve",
+    ]);
+    expect(await readFile(outputPath, "utf8")).toBe(`service-managed\n${capability}\nserve\n`);
+    await expect(lstat(installed.paths.handoffPath)).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+
+    await execFile("/bin/sh", [
+      installed.paths.wrapperPath,
+      installed.paths.envPath,
+      identity.executablePath,
+      "serve",
+    ]);
+    expect(await readFile(outputPath, "utf8")).toBe("service-managed\n\nserve\n");
+  });
+
+  it("rejects malformed, multi-line, loose-mode, and symlink handoffs", async () => {
+    const { root, identity, dependencies } = await fixture();
+    const executablePath = identity.executablePath;
+    await mkdir(join(root, "bin"), { recursive: true });
+    await writeFile(executablePath, "#!/bin/sh\nexit 0\n", { mode: 0o700 });
+    const fake = fakeLaunchctl();
+    const installed = await installLaunchdService(identity, {
+      ...dependencies,
+      runLaunchctl: fake.run,
+    });
+    const rows = [
+      { bytes: "short\n", mode: 0o600 },
+      { bytes: `${capability}\nextra\n`, mode: 0o600 },
+      { bytes: `${capability}\n`, mode: 0o644 },
+    ];
+    for (const row of rows) {
+      await writeFile(installed.paths.handoffPath, row.bytes, {
+        mode: row.mode,
+      });
+      await chmod(installed.paths.handoffPath, row.mode);
+      await expect(
+        execFile("/bin/sh", [
+          installed.paths.wrapperPath,
+          installed.paths.envPath,
+          executablePath,
+          "serve",
+        ]),
+      ).rejects.toBeDefined();
+      await expect(lstat(installed.paths.handoffPath)).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+    }
+    const target = join(root, "handoff-target");
+    await writeFile(target, `${capability}\n`, { mode: 0o600 });
+    await symlink(target, installed.paths.handoffPath);
+    await expect(
+      execFile("/bin/sh", [
+        installed.paths.wrapperPath,
+        installed.paths.envPath,
+        executablePath,
+        "serve",
+      ]),
+    ).rejects.toBeDefined();
+    await expect(lstat(installed.paths.handoffPath)).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+});
+
+describe("launchd status and lifecycle", () => {
+  it("maps the installed and loaded asymmetries and parsed process fields", async () => {
+    const { identity, dependencies } = await fixture();
+    const paths = resolveLaunchdServicePaths(identity, dependencies);
+    const calls: string[][] = [];
+    const loadedRunner = async (args: readonly string[]) => {
+      calls.push([...args]);
+      return exited(0, "state = running\npid = 4321\nlast exit status = -9\n");
+    };
+    expect(
+      await readLaunchdServiceStatus(identity, {
+        ...dependencies,
+        runLaunchctl: loadedRunner,
+      }),
+    ).toMatchObject({
+      kind: "registered",
+      installed: false,
+      loaded: true,
+      running: true,
+      pid: 4321,
+      lastExitStatus: -9,
+    });
+
+    await mkdir(paths.launchAgentsDir, { recursive: true });
+    await writeFile(paths.plistPath, "synthetic", { mode: 0o600 });
+    expect(
+      await readLaunchdServiceStatus(identity, {
+        ...dependencies,
+        runLaunchctl: async () => notFound(),
+      }),
+    ).toMatchObject({
+      kind: "registered",
+      installed: true,
+      loaded: false,
+      running: false,
+    });
+    await rm(paths.plistPath);
+    expect(
+      await readLaunchdServiceStatus(identity, {
+        ...dependencies,
+        runLaunchctl: async () => notFound(),
+      }),
+    ).toMatchObject({ kind: "absent", registered: false });
+    expect(calls).toEqual([["print", "gui/501/ai.enduragent.coach.synthetic"]]);
+  });
+
+  it("fails closed on symlinks, filesystem errors, and launchctl failures", async () => {
+    const { root, identity, dependencies } = await fixture();
+    const paths = resolveLaunchdServicePaths(identity, dependencies);
+    await mkdir(paths.launchAgentsDir, { recursive: true });
+    const target = join(root, "target");
+    await writeFile(target, "synthetic");
+    await symlink(target, paths.plistPath);
+    const runner = vi.fn(async () => exited());
+    expect(
+      await readLaunchdServiceStatus(identity, {
+        ...dependencies,
+        runLaunchctl: runner,
+      }),
+    ).toMatchObject({
+      kind: "unknown",
+      installed: null,
+      detail: "launchd status unavailable",
+    });
+    expect(runner).not.toHaveBeenCalled();
+
+    const ioError = Object.assign(new Error("private detail"), { code: "EIO" });
+    expect(
+      await readLaunchdServiceStatus(identity, {
+        ...dependencies,
+        lstat: async () => {
+          throw ioError;
+        },
+        runLaunchctl: runner,
+      }),
+    ).toMatchObject({ kind: "unknown", installed: null });
+    expect(runner).not.toHaveBeenCalled();
+
+    await rm(paths.plistPath);
+    expect(
+      await readLaunchdServiceStatus(identity, {
+        ...dependencies,
+        runLaunchctl: async () => ({
+          outcome: "timed-out",
+          exitCode: null,
+          stdout: "private",
+          stderr: "private",
+        }),
+      }),
+    ).toMatchObject({
+      kind: "unknown",
+      installed: false,
+      detail: "launchd status unavailable",
+    });
+  });
+
+  it("uses destructive kickstart only for explicit restart", async () => {
+    const { identity, dependencies } = await fixture();
+    const paths = resolveLaunchdServicePaths(identity, dependencies);
+    await mkdir(paths.launchAgentsDir, { recursive: true });
+    await writeFile(paths.plistPath, "synthetic", { mode: 0o600 });
+    const fake = fakeLaunchctl({ loaded: true, running: false });
+    await restartLaunchdService(identity, {
+      ...dependencies,
+      runLaunchctl: fake.run,
+    });
+    expect(fake.calls.map((call) => call.slice(0, 2))).toEqual([
+      ["print", "gui/501/ai.enduragent.coach.synthetic"],
+      ["kickstart", "-k"],
+      ["print", "gui/501/ai.enduragent.coach.synthetic"],
+    ]);
+  });
+
+  it("bootstraps unloaded restart and refuses absent or unknown status", async () => {
+    const { identity, dependencies } = await fixture();
+    const paths = resolveLaunchdServicePaths(identity, dependencies);
+    await mkdir(paths.launchAgentsDir, { recursive: true });
+    await writeFile(paths.plistPath, "synthetic", { mode: 0o600 });
+    const fake = fakeLaunchctl();
+    await restartLaunchdService(identity, {
+      ...dependencies,
+      runLaunchctl: fake.run,
+    });
+    expect(fake.calls.map((call) => call[0])).toEqual(["print", "enable", "bootstrap", "print"]);
+
+    await rm(paths.plistPath);
+    await expect(
+      restartLaunchdService(identity, {
+        ...dependencies,
+        runLaunchctl: async () => notFound(),
+      }),
+    ).rejects.toBeInstanceOf(LaunchdServiceNotInstalledError);
+    await expect(
+      restartLaunchdService(identity, {
+        ...dependencies,
+        runLaunchctl: async () => exited(1, "private"),
+      }),
+    ).rejects.toBeInstanceOf(LaunchdServiceCommandError);
+  });
+
+  it("resumes absent, unloaded, stopped, and running registrations exactly", async () => {
+    const { identity, dependencies } = await fixture();
+    const paths = resolveLaunchdServicePaths(identity, dependencies);
+    const absent = fakeLaunchctl();
+    await expect(
+      resumeLaunchdService(identity, {
+        ...dependencies,
+        runLaunchctl: absent.run,
+      }),
+    ).resolves.toBe("not-installed");
+    expect(absent.calls.map((call) => call[0])).toEqual(["print"]);
+
+    await mkdir(paths.launchAgentsDir, { recursive: true });
+    await writeFile(paths.plistPath, "synthetic", { mode: 0o600 });
+    const unloaded = fakeLaunchctl();
+    await resumeLaunchdService(identity, {
+      ...dependencies,
+      runLaunchctl: unloaded.run,
+    });
+    expect(unloaded.calls.map((call) => call[0])).toEqual(["print", "enable", "bootstrap"]);
+
+    const stopped = fakeLaunchctl({ loaded: true });
+    await resumeLaunchdService(identity, {
+      ...dependencies,
+      runLaunchctl: stopped.run,
+    });
+    expect(stopped.calls.map((call) => call[0])).toEqual(["print", "kickstart"]);
+    expect(stopped.calls[1]).toEqual(["kickstart", "gui/501/ai.enduragent.coach.synthetic"]);
+
+    const running = fakeLaunchctl({ loaded: true, running: true });
+    await resumeLaunchdService(identity, {
+      ...dependencies,
+      runLaunchctl: running.run,
+    });
+    expect(running.calls.map((call) => call[0])).toEqual(["print"]);
+  });
+
+  it("stages designated resume once and removes the carrier on command failure", async () => {
+    const { identity, dependencies } = await fixture();
+    const paths = resolveLaunchdServicePaths(identity, dependencies);
+    await mkdir(paths.launchAgentsDir, { recursive: true });
+    await mkdir(paths.stateDir, { recursive: true });
+    await writeFile(paths.plistPath, "synthetic", { mode: 0o600 });
+    const fake = fakeLaunchctl({ loaded: true });
+    await resumeLaunchdServiceAfterEphemeral(
+      identity,
+      { targetProtocolVersion: 1, handoffCapability: capability },
+      { ...dependencies, runLaunchctl: fake.run },
+    );
+    expect(fake.calls.map((call) => call[0])).toEqual(["print", "kickstart"]);
+    expect(await readFile(paths.handoffPath, "utf8")).toBe(`${capability}\n`);
+
+    await rm(paths.handoffPath);
+    await expect(
+      resumeLaunchdServiceAfterEphemeral(
+        identity,
+        { targetProtocolVersion: 1, handoffCapability: capability },
+        {
+          ...dependencies,
+          runLaunchctl: async (args) =>
+            args[0] === "print" ? exited(0, "state = exited\n") : exited(9, "private"),
+        },
+      ),
+    ).rejects.toBeInstanceOf(LaunchdServiceCommandError);
+    await expect(lstat(paths.handoffPath)).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  it("rejects malformed successor input before launchctl or publication", async () => {
+    const { identity, dependencies } = await fixture();
+    const runner = vi.fn(async () => exited());
+    await expect(
+      restartLaunchdServiceForUpgrade(
+        identity,
+        { targetProtocolVersion: -1, handoffCapability: `${capability}\n` },
+        { ...dependencies, runLaunchctl: runner },
+      ),
+    ).rejects.toBeInstanceOf(TypeError);
+    expect(runner).not.toHaveBeenCalled();
+  });
+});
+
+describe("launchctl adapter and platform boundary", () => {
+  it("uses the absolute command, argv, fixed options, and hermetic environment", async () => {
+    const { identity, userHome } = await fixture();
+    const captured: unknown[][] = [];
+    const injectedExecFile = ((...args: unknown[]) => {
+      captured.push(args);
+      const callback = args[3] as (error: null, stdout: string, stderr: string) => void;
+      callback(null, "state = exited\n", "");
+      return {};
+    }) as unknown as typeof nodeExecFile;
+    await readLaunchdServiceStatus(identity, {
+      platform: "darwin",
+      uid: 501,
+      userHome,
+      execFile: injectedExecFile,
+      lstat: async () => {
+        throw Object.assign(new Error("missing"), { code: "ENOENT" });
+      },
+    });
+    expect(captured).toHaveLength(1);
+    expect(captured[0]?.[0]).toBe("/bin/launchctl");
+    expect(captured[0]?.[1]).toEqual(["print", "gui/501/ai.enduragent.coach.synthetic"]);
+    expect(captured[0]?.[2]).toEqual({
+      shell: false,
+      encoding: "utf8",
+      timeout: 5_000,
+      env: {
+        PATH: "/usr/bin:/bin:/usr/sbin:/sbin",
+        HOME: userHome,
+      },
+    });
+  });
+
+  it.each([
+    {
+      error: Object.assign(new Error("nonzero"), { code: 113 }),
+      expected: "absent",
+      stderr: "service not found",
+    },
+    {
+      error: Object.assign(new Error("nonzero"), { code: 7 }),
+      expected: "unknown",
+      stderr: "other",
+    },
+    {
+      error: Object.assign(new Error("timeout"), { killed: true }),
+      expected: "unknown",
+      stderr: "",
+    },
+    {
+      error: Object.assign(new Error("signal"), { signal: "SIGTERM" }),
+      expected: "unknown",
+      stderr: "",
+    },
+    {
+      error: Object.assign(new Error("spawn"), { code: "ENOENT" }),
+      expected: "unknown",
+      stderr: "",
+    },
+  ])("normalizes callback error outcomes as $expected", async ({ error, expected, stderr }) => {
+    const { identity, userHome } = await fixture();
+    const injectedExecFile = ((
+      _file: unknown,
+      _args: unknown,
+      _options: unknown,
+      callback: (error: Error, stdout: unknown, stderr: unknown) => void,
+    ) => {
+      callback(error, Buffer.from("ignored"), stderr);
+      return {};
+    }) as unknown as typeof nodeExecFile;
+    const status = await readLaunchdServiceStatus(identity, {
+      platform: "darwin",
+      uid: 501,
+      userHome,
+      execFile: injectedExecFile,
+      lstat: async () => {
+        throw Object.assign(new Error("missing"), { code: "ENOENT" });
+      },
+    });
+    expect(status.kind).toBe(expected);
+  });
+
+  it("rejects every status or mutation on non-darwin without side effects", async () => {
+    const { identity, userHome } = await fixture();
+    const runner = vi.fn(async () => exited());
+    const dependencies = {
+      platform: "linux" as const,
+      uid: 501,
+      userHome,
+      runLaunchctl: runner,
+    };
+    const operations = [
+      () => readLaunchdServiceStatus(identity, dependencies),
+      () => installLaunchdService(identity, dependencies),
+      () => uninstallLaunchdService(identity, dependencies),
+      () => restartLaunchdService(identity, dependencies),
+      () => resumeLaunchdService(identity, dependencies),
+      () =>
+        restartLaunchdServiceForUpgrade(
+          identity,
+          { targetProtocolVersion: 1, handoffCapability: capability },
+          dependencies,
+        ),
+      () =>
+        resumeLaunchdServiceAfterEphemeral(
+          identity,
+          { targetProtocolVersion: 1, handoffCapability: capability },
+          dependencies,
+        ),
+    ];
+    for (const operation of operations) {
+      await expect(operation()).rejects.toBeInstanceOf(UnsupportedLaunchdPlatformError);
+    }
+    expect(runner).not.toHaveBeenCalled();
+  });
+});

--- a/packages/kernel-node/tsup.config.ts
+++ b/packages/kernel-node/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: { index: "src/index.ts", sqlite: "src/sqlite/index.ts", "archive/index": "src/archive/index.ts", "lock/index": "src/lock/index.ts", "store-export/index": "src/store-export/index.ts", "home/index": "src/home/index.ts", "filesystem/index": "src/filesystem/index.ts", "ingest/index": "src/ingest/index.ts", "capture-manifest/index": "src/capture-manifest/index.ts", "coach-dev": "src/cli/coach-dev.ts" },
+  entry: { index: "src/index.ts", sqlite: "src/sqlite/index.ts", "archive/index": "src/archive/index.ts", "lock/index": "src/lock/index.ts", "store-export/index": "src/store-export/index.ts", "home/index": "src/home/index.ts", "filesystem/index": "src/filesystem/index.ts", "ingest/index": "src/ingest/index.ts", "capture-manifest/index": "src/capture-manifest/index.ts", "service/index": "src/service/index.ts", "coach-dev": "src/cli/coach-dev.ts" },
   format: ["esm"],
   dts: true,
   sourcemap: true,


### PR DESCRIPTION
## Summary

Adds the reusable macOS service mechanics to kernel-node (`src/service/` + public export):

- Service identity derived from executable path + home + service label only; no daemon YAML.
- Exact LaunchAgent plist/env/wrapper bytes with `KeepAlive={SuccessfulExit=false}` (failure-only restart) and permission enforcement: 0600 plist, 0700 dir, 0600 env, 0700 wrapper.
- install/uninstall/status/restart/resume primitives with injected process runners; 23 hermetic tests plus an opt-in standard-location live probe.
- Live-probe-caught fix: launchctl binary path corrected to `/bin/launchctl` (the hardcoded `/usr/bin` path does not exist on macOS, which the injected-runner hermetic tests could not detect).
- No CLI edits — verb wiring lands in the serialized follow-up half.

## Verification

- Opt-in live probe on a real macOS GUI session: green — 0600 plist accepted at the standard location; crash-loop restart cadence within the fixed throttle band.
- Focused hermetic suite 23/23; kernel-node build/declarations/import smoke green.
- Root `pnpm build`, `pnpm check`, full `pnpm test` green.
