### PR TITLE
feat(contract): add wire contract and coach-client runtime

### DIFF
--- a/packages/coach-client/package.json
+++ b/packages/coach-client/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@enduragent/coach-client",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Narrow WebSocket client for the enduragent coaching contract.",
+  "license": "MIT",
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": "./dist/index.js"
+  },
+  "scripts": {
+    "build": "tsup",
+    "check": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@enduragent/coach-contract": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.0",
+    "@types/ws": "^8.18.1",
+    "tsup": "^8.4.0",
+    "typescript": "^6.0.2",
+    "vitest": "^4.1.4",
+    "ws": "^8.20.0"
+  },
+  "engines": {
+    "node": ">=24"
+  }
+}

--- a/packages/coach-client/src/client.ts
+++ b/packages/coach-client/src/client.ts
@@ -1,0 +1,556 @@
+import {
+  COACH_RPC_METHOD_REGISTRY,
+  parseCoachRpcEnvelope,
+  serializeCoachRpcEnvelope,
+  type AcceptedServerHandshakeFrame,
+  type CoachRpcEvent,
+  type CoachRpcMethodName,
+  type CoachRpcRequest,
+  type CoachRpcResponse,
+  type CoachTurnEventNotificationEnvelope,
+  type JsonRpcId,
+  type JsonRpcErrorResponseEnvelope,
+  type JsonRpcSuccessResponseEnvelope,
+} from "@enduragent/coach-contract";
+import {
+  CoachClientBackpressureError,
+  CoachClientDisconnectedError,
+  CoachClientHandshakeError,
+  CoachClientProtocolError,
+  CoachClientTransportUnavailableError,
+  CoachRpcRemoteError,
+} from "./errors.js";
+import {
+  performCoachClientHandshake,
+  type CoachClientHandshakeBinding,
+} from "./handshake-client.js";
+import { resolveCoachWebSocketFactory, type CoachWebSocketFactory } from "./transport.js";
+
+export interface ConnectCoachClientOptions {
+  readonly url: string;
+  readonly token: string;
+  readonly signal?: AbortSignal;
+  readonly connectTimeoutMs?: number;
+  readonly handshakeTimeoutMs?: number;
+  readonly closeTimeoutMs?: number;
+  readonly highWaterMarkBytes?: number;
+  readonly lowWaterMarkBytes?: number;
+  readonly maxQueuedSends?: number;
+  readonly webSocketFactory?: CoachWebSocketFactory;
+}
+
+export type CoachClientTerminalEnvelope =
+  | JsonRpcSuccessResponseEnvelope
+  | JsonRpcErrorResponseEnvelope;
+
+export interface CoachClientCallOptions<K extends CoachRpcMethodName> {
+  readonly onEvent?: (event: CoachRpcEvent<K>) => void;
+  readonly onNotificationEnvelope?: (envelope: CoachTurnEventNotificationEnvelope) => void;
+  readonly onTerminalEnvelope?: (envelope: CoachClientTerminalEnvelope) => void;
+}
+
+export interface CoachClient {
+  readonly handshake: AcceptedServerHandshakeFrame;
+  call<K extends CoachRpcMethodName>(
+    method: K,
+    request: CoachRpcRequest<K>,
+    options?: CoachClientCallOptions<K>,
+  ): Promise<CoachRpcResponse<K>>;
+  close(code?: number, reason?: string): Promise<void>;
+}
+
+interface ValidatedOptions {
+  readonly url: string;
+  readonly token: string;
+  readonly signal: AbortSignal | undefined;
+  readonly connectTimeoutMs: number;
+  readonly handshakeTimeoutMs: number;
+  readonly closeTimeoutMs: number;
+  readonly highWaterMarkBytes: number;
+  readonly lowWaterMarkBytes: number;
+  readonly maxQueuedSends: number;
+  readonly webSocketFactory: CoachWebSocketFactory | undefined;
+}
+
+interface PendingCall {
+  readonly method: CoachRpcMethodName;
+  readonly resolve: (value: unknown) => void;
+  readonly reject: (reason: unknown) => void;
+  readonly onEvent: ((event: unknown) => void) | undefined;
+  readonly onNotificationEnvelope:
+    | ((envelope: CoachTurnEventNotificationEnvelope) => void)
+    | undefined;
+  readonly onTerminalEnvelope: ((envelope: CoachClientTerminalEnvelope) => void) | undefined;
+}
+
+interface OutboundFrame {
+  readonly id: number;
+  readonly text: string;
+}
+
+function positiveSafeInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
+}
+
+function nonnegativeSafeInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+}
+
+function validateOptions(options: ConnectCoachClientOptions): ValidatedOptions {
+  const connectTimeoutMs = options.connectTimeoutMs ?? 5_000;
+  const handshakeTimeoutMs = options.handshakeTimeoutMs ?? 5_000;
+  const closeTimeoutMs = options.closeTimeoutMs ?? 5_000;
+  const highWaterMarkBytes = options.highWaterMarkBytes ?? 1_048_576;
+  const lowWaterMarkBytes = options.lowWaterMarkBytes ?? 262_144;
+  const maxQueuedSends = options.maxQueuedSends ?? 128;
+
+  if (
+    typeof options.url !== "string" ||
+    typeof options.token !== "string" ||
+    options.token.length === 0 ||
+    !positiveSafeInteger(connectTimeoutMs) ||
+    !positiveSafeInteger(handshakeTimeoutMs) ||
+    !positiveSafeInteger(closeTimeoutMs) ||
+    !positiveSafeInteger(highWaterMarkBytes) ||
+    !nonnegativeSafeInteger(lowWaterMarkBytes) ||
+    !positiveSafeInteger(maxQueuedSends) ||
+    lowWaterMarkBytes >= highWaterMarkBytes
+  ) {
+    throw new CoachClientProtocolError();
+  }
+
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(options.url);
+  } catch {
+    throw new CoachClientProtocolError();
+  }
+  if (
+    parsedUrl.protocol !== "ws:" ||
+    parsedUrl.hostname !== "127.0.0.1" ||
+    parsedUrl.port === "" ||
+    parsedUrl.username !== "" ||
+    parsedUrl.password !== "" ||
+    parsedUrl.search !== "" ||
+    parsedUrl.hash !== ""
+  ) {
+    throw new CoachClientProtocolError();
+  }
+
+  return {
+    url: options.url,
+    token: options.token,
+    signal: options.signal,
+    connectTimeoutMs,
+    handshakeTimeoutMs,
+    closeTimeoutMs,
+    highWaterMarkBytes,
+    lowWaterMarkBytes,
+    maxQueuedSends,
+    webSocketFactory: options.webSocketFactory,
+  };
+}
+
+function requestSocketClose(socket: WebSocket, code?: number, reason?: string): void {
+  if (socket.readyState === 2 || socket.readyState === 3) return;
+  try {
+    socket.close(code, reason);
+  } catch {}
+}
+
+function openCoachSocket(options: ValidatedOptions): Promise<WebSocket> {
+  return new Promise((resolve, reject) => {
+    let socket: WebSocket | undefined;
+    let settled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    const cleanup = (): void => {
+      if (timer !== undefined) clearTimeout(timer);
+      timer = undefined;
+      options.signal?.removeEventListener("abort", onAbort);
+      socket?.removeEventListener("open", onOpen);
+      socket?.removeEventListener("error", onError);
+      socket?.removeEventListener("close", onClose);
+    };
+
+    const fail = (error: Error): void => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      if (socket !== undefined) requestSocketClose(socket);
+      reject(error);
+    };
+
+    function onOpen(): void {
+      if (settled || socket === undefined) return;
+      settled = true;
+      cleanup();
+      resolve(socket);
+    }
+
+    function onAbort(): void {
+      fail(new CoachClientHandshakeError("Coach client connection aborted"));
+    }
+
+    function onError(): void {
+      fail(new CoachClientHandshakeError("Coach client connection failed"));
+    }
+
+    function onClose(): void {
+      fail(new CoachClientHandshakeError("Coach client closed before opening"));
+    }
+
+    timer = setTimeout(() => {
+      fail(new CoachClientHandshakeError("Coach client connection timed out"));
+    }, options.connectTimeoutMs);
+
+    try {
+      const factory = resolveCoachWebSocketFactory(options.webSocketFactory);
+      socket = factory(options.url);
+      socket.addEventListener("open", onOpen);
+      socket.addEventListener("error", onError);
+      socket.addEventListener("close", onClose);
+      options.signal?.addEventListener("abort", onAbort, { once: true });
+      if (options.signal?.aborted) onAbort();
+      if (socket.readyState === 1) onOpen();
+      if (socket.readyState === 2 || socket.readyState === 3) onClose();
+    } catch {
+      fail(new CoachClientTransportUnavailableError());
+    }
+  });
+}
+
+class CoachClientRuntime {
+  private readonly pending = new Map<JsonRpcId, PendingCall>();
+  private readonly sendQueue: OutboundFrame[] = [];
+  private nextId = 1;
+  private idsExhausted = false;
+  private sendPumpRunning = false;
+  private sendWaitTimer: ReturnType<typeof setTimeout> | undefined;
+  private sendWaitResolve: (() => void) | undefined;
+  private terminalCause: CoachClientProtocolError | CoachClientDisconnectedError | undefined;
+  private handshakeBinding: CoachClientHandshakeBinding | undefined;
+  private ready = false;
+  private closePromise: Promise<void> | undefined;
+
+  constructor(
+    private readonly socket: WebSocket,
+    private readonly options: ValidatedOptions,
+  ) {
+    socket.addEventListener("close", this.onSocketClose);
+  }
+
+  readonly handleRawFrame = (data: unknown): void => {
+    if (!this.ready || this.terminalCause !== undefined) return;
+    if (typeof data !== "string") {
+      this.failProtocol();
+      return;
+    }
+    let envelope: ReturnType<typeof parseCoachRpcEnvelope>;
+    try {
+      envelope = parseCoachRpcEnvelope(data);
+    } catch {
+      this.failProtocol();
+      return;
+    }
+
+    if ("method" in envelope && "id" in envelope) {
+      this.failProtocol();
+      return;
+    }
+    if ("method" in envelope) {
+      this.handleNotification(envelope);
+      return;
+    }
+    if (envelope.id === null) {
+      this.failProtocol();
+      return;
+    }
+    this.handleTerminal(envelope);
+  };
+
+  activate(binding: CoachClientHandshakeBinding): CoachClient {
+    this.handshakeBinding = binding;
+    this.ready = true;
+    return {
+      handshake: binding.accepted,
+      call: <K extends CoachRpcMethodName>(
+        method: K,
+        request: CoachRpcRequest<K>,
+        options?: CoachClientCallOptions<K>,
+      ) => this.call(method, request, options),
+      close: (code?: number, reason?: string) => this.close(code, reason),
+    };
+  }
+
+  disposeBeforeReady(): void {
+    this.socket.removeEventListener("close", this.onSocketClose);
+  }
+
+  private call<K extends CoachRpcMethodName>(
+    method: K,
+    request: CoachRpcRequest<K>,
+    options?: CoachClientCallOptions<K>,
+  ): Promise<CoachRpcResponse<K>> {
+    if (this.terminalCause !== undefined) {
+      return Promise.reject(this.terminalCause);
+    }
+    if (this.sendPumpRunning && this.sendQueue.length - 1 >= this.options.maxQueuedSends) {
+      return Promise.reject(new CoachClientBackpressureError());
+    }
+    if (this.idsExhausted) {
+      return Promise.reject(this.failProtocol());
+    }
+
+    let params: unknown;
+    let text: string;
+    const id = this.nextId;
+    try {
+      params = COACH_RPC_METHOD_REGISTRY[method].requestSchema.parse(request);
+      text = serializeCoachRpcEnvelope({
+        jsonrpc: "2.0",
+        id,
+        method,
+        params,
+      });
+    } catch {
+      return Promise.reject(new CoachClientProtocolError());
+    }
+
+    if (id === Number.MAX_SAFE_INTEGER) {
+      this.idsExhausted = true;
+    } else {
+      this.nextId = id + 1;
+    }
+
+    const promise = new Promise<CoachRpcResponse<K>>((resolve, reject) => {
+      this.pending.set(id, {
+        method,
+        resolve: resolve as (value: unknown) => void,
+        reject,
+        onEvent: options?.onEvent as ((event: unknown) => void) | undefined,
+        onNotificationEnvelope: options?.onNotificationEnvelope,
+        onTerminalEnvelope: options?.onTerminalEnvelope,
+      });
+    });
+    this.sendQueue.push({ id, text });
+    this.startSendPump();
+    return promise;
+  }
+
+  private startSendPump(): void {
+    if (this.sendPumpRunning) return;
+    this.sendPumpRunning = true;
+    void this.pumpSendQueue();
+  }
+
+  private async pumpSendQueue(): Promise<void> {
+    try {
+      while (this.sendQueue.length > 0 && this.terminalCause === undefined) {
+        if (this.socket.bufferedAmount >= this.options.highWaterMarkBytes) {
+          await this.waitForLowWater();
+          if (this.terminalCause !== undefined) break;
+        }
+        const frame = this.sendQueue[0]!;
+        try {
+          this.socket.send(frame.text);
+        } catch {
+          this.failProtocol();
+          break;
+        }
+        this.sendQueue.shift();
+      }
+    } finally {
+      this.sendPumpRunning = false;
+      if (this.sendQueue.length > 0 && this.terminalCause === undefined) {
+        this.startSendPump();
+      }
+    }
+  }
+
+  private waitForLowWater(): Promise<void> {
+    return new Promise((resolve) => {
+      this.sendWaitResolve = resolve;
+      const poll = (): void => {
+        if (
+          this.terminalCause !== undefined ||
+          this.socket.bufferedAmount <= this.options.lowWaterMarkBytes
+        ) {
+          this.sendWaitTimer = undefined;
+          this.sendWaitResolve = undefined;
+          resolve();
+          return;
+        }
+        this.sendWaitTimer = setTimeout(poll, 10);
+      };
+      this.sendWaitTimer = setTimeout(poll, 10);
+    });
+  }
+
+  private clearSendWait(): void {
+    if (this.sendWaitTimer !== undefined) clearTimeout(this.sendWaitTimer);
+    this.sendWaitTimer = undefined;
+    const resolve = this.sendWaitResolve;
+    this.sendWaitResolve = undefined;
+    resolve?.();
+  }
+
+  private handleNotification(envelope: CoachTurnEventNotificationEnvelope): void {
+    const pending = this.pending.get(envelope.params.requestId);
+    if (pending === undefined || pending.method !== envelope.params.requestMethod) {
+      this.failProtocol();
+      return;
+    }
+
+    let event: unknown;
+    try {
+      event = COACH_RPC_METHOD_REGISTRY[pending.method].eventSchema.parse(envelope.params.event);
+    } catch {
+      this.failProtocol();
+      return;
+    }
+
+    const onNotificationEnvelope = pending.onNotificationEnvelope;
+    const onEvent = pending.onEvent;
+    try {
+      onNotificationEnvelope?.(envelope);
+    } catch {}
+    try {
+      onEvent?.(event);
+    } catch {}
+  }
+
+  private handleTerminal(
+    envelope: JsonRpcSuccessResponseEnvelope | JsonRpcErrorResponseEnvelope,
+  ): void {
+    const pending = this.pending.get(envelope.id);
+    if (pending === undefined) {
+      this.failProtocol();
+      return;
+    }
+
+    if ("result" in envelope) {
+      let result: unknown;
+      try {
+        result = COACH_RPC_METHOD_REGISTRY[pending.method].responseSchema.parse(envelope.result);
+      } catch {
+        this.failProtocol();
+        return;
+      }
+      this.pending.delete(envelope.id);
+      const observer = pending.onTerminalEnvelope;
+      try {
+        observer?.(envelope);
+      } catch {}
+      pending.resolve(result);
+      return;
+    }
+
+    const remoteError = new CoachRpcRemoteError(
+      envelope.error.code,
+      envelope.error.message,
+      envelope.error.data,
+    );
+    this.pending.delete(envelope.id);
+    const observer = pending.onTerminalEnvelope;
+    try {
+      observer?.(envelope);
+    } catch {}
+    pending.reject(remoteError);
+  }
+
+  private failProtocol(): CoachClientProtocolError {
+    if (this.terminalCause !== undefined) {
+      return this.terminalCause instanceof CoachClientProtocolError
+        ? this.terminalCause
+        : new CoachClientProtocolError();
+    }
+    const error = new CoachClientProtocolError();
+    this.latchTerminal(error);
+    requestSocketClose(this.socket, 1002);
+    return error;
+  }
+
+  private latchTerminal(error: CoachClientProtocolError | CoachClientDisconnectedError): void {
+    if (this.terminalCause !== undefined) return;
+    this.terminalCause = error;
+    this.ready = false;
+    this.clearSendWait();
+    this.sendQueue.length = 0;
+    this.handshakeBinding?.dispose();
+    this.socket.removeEventListener("close", this.onSocketClose);
+    const pending = [...this.pending.values()];
+    this.pending.clear();
+    for (const entry of pending) entry.reject(error);
+  }
+
+  private readonly onSocketClose = (event: CloseEvent): void => {
+    if (!this.ready || this.terminalCause !== undefined) return;
+    this.latchTerminal(new CoachClientDisconnectedError(event.code, event.reason));
+  };
+
+  private close(code = 1000, reason = ""): Promise<void> {
+    if (this.closePromise !== undefined) return this.closePromise;
+    this.closePromise = new Promise((resolve) => {
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      let settled = false;
+
+      const cleanup = (): void => {
+        if (timer !== undefined) clearTimeout(timer);
+        timer = undefined;
+        this.socket.removeEventListener("close", onClose);
+      };
+
+      const finish = (): void => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        resolve();
+      };
+
+      const onClose = (): void => {
+        finish();
+      };
+
+      if (this.terminalCause === undefined) {
+        this.latchTerminal(new CoachClientDisconnectedError(code, reason));
+      }
+      this.socket.addEventListener("close", onClose);
+      timer = setTimeout(finish, this.options.closeTimeoutMs);
+      if (this.socket.readyState === 3) {
+        finish();
+        return;
+      }
+      requestSocketClose(this.socket, code, reason);
+    });
+    return this.closePromise;
+  }
+}
+
+export async function connectCoachClient(options: ConnectCoachClientOptions): Promise<CoachClient> {
+  let validated: ValidatedOptions;
+  try {
+    validated = validateOptions(options);
+  } catch {
+    throw new CoachClientProtocolError();
+  }
+  if (validated.signal?.aborted) {
+    throw new CoachClientHandshakeError("Coach client connection aborted");
+  }
+
+  const socket = await openCoachSocket(validated);
+  const runtime = new CoachClientRuntime(socket, validated);
+  let binding: CoachClientHandshakeBinding;
+  try {
+    binding = await performCoachClientHandshake({
+      socket,
+      token: validated.token,
+      timeoutMs: validated.handshakeTimeoutMs,
+      onReadyFrame: runtime.handleRawFrame,
+    });
+  } catch (error) {
+    runtime.disposeBeforeReady();
+    throw error;
+  }
+  return runtime.activate(binding);
+}

--- a/packages/coach-client/src/errors.ts
+++ b/packages/coach-client/src/errors.ts
@@ -1,0 +1,74 @@
+import type { DaemonOwner, JsonValue, ProtocolVersionDirection } from "@enduragent/coach-contract";
+
+export class CoachClientTransportUnavailableError extends Error {
+  constructor() {
+    super("WebSocket transport is unavailable");
+    this.name = "CoachClientTransportUnavailableError";
+  }
+}
+
+export class CoachClientProtocolError extends Error {
+  constructor() {
+    super("Coach client protocol error");
+    this.name = "CoachClientProtocolError";
+  }
+}
+
+export class CoachClientHandshakeError extends Error {
+  constructor(
+    message:
+      | "Coach client handshake failed"
+      | "Coach client connection aborted"
+      | "Coach client connection timed out"
+      | "Coach client connection failed"
+      | "Coach client closed before opening"
+      | "Coach client handshake timed out"
+      | "Coach client handshake send failed" = "Coach client handshake failed",
+  ) {
+    super(message);
+    this.name = "CoachClientHandshakeError";
+  }
+}
+
+export class CoachClientVersionMismatchError extends Error {
+  constructor(
+    readonly clientProtocolVersion: number,
+    readonly serverProtocolVersion: number,
+    readonly direction: ProtocolVersionDirection,
+    readonly owner: DaemonOwner,
+  ) {
+    super("Coach protocol version mismatch");
+    this.name = "CoachClientVersionMismatchError";
+  }
+}
+
+export class CoachClientBackpressureError extends Error {
+  constructor() {
+    super("Coach client send queue is full");
+    this.name = "CoachClientBackpressureError";
+  }
+}
+
+export class CoachClientDisconnectedError extends Error {
+  constructor(
+    readonly code: number,
+    readonly reason: string,
+  ) {
+    super("Coach client disconnected");
+    this.name = "CoachClientDisconnectedError";
+  }
+}
+
+export class CoachRpcRemoteError extends Error {
+  readonly data: JsonValue | undefined;
+
+  constructor(
+    readonly code: number,
+    message: string,
+    data?: JsonValue,
+  ) {
+    super(message);
+    this.name = "CoachRpcRemoteError";
+    this.data = data;
+  }
+}

--- a/packages/coach-client/src/handshake-client.ts
+++ b/packages/coach-client/src/handshake-client.ts
@@ -1,0 +1,131 @@
+import {
+  PROTOCOL_VERSION,
+  ServerHandshakeFrameSchema,
+  createClientHandshakeFrame,
+  type AcceptedServerHandshakeFrame,
+} from "@enduragent/coach-contract";
+import {
+  CoachClientHandshakeError,
+  CoachClientProtocolError,
+  CoachClientVersionMismatchError,
+} from "./errors.js";
+
+export interface PerformCoachClientHandshakeInput {
+  readonly socket: WebSocket;
+  readonly token: string;
+  readonly timeoutMs: number;
+  readonly onReadyFrame: (data: unknown) => void;
+}
+
+export interface CoachClientHandshakeBinding {
+  readonly accepted: AcceptedServerHandshakeFrame;
+  dispose(): void;
+}
+
+export function performCoachClientHandshake(
+  input: PerformCoachClientHandshakeInput,
+): Promise<CoachClientHandshakeBinding> {
+  return new Promise((resolve, reject) => {
+    let accepted = false;
+    let settled = false;
+    let disposed = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    const dispose = (): void => {
+      if (disposed) return;
+      disposed = true;
+      if (timer !== undefined) clearTimeout(timer);
+      timer = undefined;
+      input.socket.removeEventListener("message", onMessage);
+      input.socket.removeEventListener("close", onClose);
+      input.socket.removeEventListener("error", onError);
+    };
+
+    const requestProtocolClose = (): void => {
+      if (input.socket.readyState !== 1) return;
+      try {
+        input.socket.close(1002);
+      } catch {}
+    };
+
+    const fail = (error: Error): void => {
+      if (settled) return;
+      settled = true;
+      dispose();
+      requestProtocolClose();
+      reject(error);
+    };
+
+    function onMessage(event: MessageEvent): void {
+      if (accepted) {
+        input.onReadyFrame(event.data);
+        return;
+      }
+      if (typeof event.data !== "string") {
+        fail(new CoachClientProtocolError());
+        return;
+      }
+      let value: unknown;
+      try {
+        value = JSON.parse(event.data);
+      } catch {
+        fail(new CoachClientProtocolError());
+        return;
+      }
+      const parsed = ServerHandshakeFrameSchema.safeParse(value);
+      if (!parsed.success) {
+        fail(new CoachClientProtocolError());
+        return;
+      }
+      const frame = parsed.data;
+      if (frame.clientProtocolVersion !== PROTOCOL_VERSION) {
+        fail(new CoachClientProtocolError());
+        return;
+      }
+      if (frame.status === "version-mismatch") {
+        settled = true;
+        dispose();
+        requestProtocolClose();
+        reject(
+          new CoachClientVersionMismatchError(
+            frame.clientProtocolVersion,
+            frame.serverProtocolVersion,
+            frame.direction,
+            frame.owner,
+          ),
+        );
+        return;
+      }
+      if (frame.serverProtocolVersion !== PROTOCOL_VERSION) {
+        fail(new CoachClientProtocolError());
+        return;
+      }
+      accepted = true;
+      settled = true;
+      if (timer !== undefined) clearTimeout(timer);
+      timer = undefined;
+      resolve({ accepted: frame, dispose });
+    }
+
+    function onClose(): void {
+      if (!accepted) fail(new CoachClientHandshakeError());
+    }
+
+    function onError(): void {
+      if (!accepted) fail(new CoachClientHandshakeError());
+    }
+
+    input.socket.addEventListener("message", onMessage);
+    input.socket.addEventListener("close", onClose);
+    input.socket.addEventListener("error", onError);
+    timer = setTimeout(() => {
+      fail(new CoachClientHandshakeError("Coach client handshake timed out"));
+    }, input.timeoutMs);
+
+    try {
+      input.socket.send(JSON.stringify(createClientHandshakeFrame(input.token)));
+    } catch {
+      fail(new CoachClientHandshakeError("Coach client handshake send failed"));
+    }
+  });
+}

--- a/packages/coach-client/src/index.ts
+++ b/packages/coach-client/src/index.ts
@@ -1,0 +1,4 @@
+export * from "./client.js";
+export * from "./errors.js";
+export * from "./handshake-client.js";
+export * from "./transport.js";

--- a/packages/coach-client/src/transport.ts
+++ b/packages/coach-client/src/transport.ts
@@ -1,0 +1,14 @@
+import { CoachClientTransportUnavailableError } from "./errors.js";
+
+export type CoachWebSocketFactory = (url: string) => WebSocket;
+
+export function resolveCoachWebSocketFactory(
+  override?: CoachWebSocketFactory,
+): CoachWebSocketFactory {
+  if (override !== undefined) return override;
+  const WebSocketImplementation = globalThis.WebSocket;
+  if (typeof WebSocketImplementation !== "function") {
+    throw new CoachClientTransportUnavailableError();
+  }
+  return (url: string) => new WebSocketImplementation(url);
+}

--- a/packages/coach-client/tests/client.test.ts
+++ b/packages/coach-client/tests/client.test.ts
@@ -1,0 +1,867 @@
+import { afterEach, describe, expect, expectTypeOf, it, vi } from "vitest";
+import { WebSocketServer, type WebSocket as ServerWebSocket } from "ws";
+import {
+  PROTOCOL_VERSION,
+  createAcceptedServerHandshakeFrame,
+  createVersionMismatchServerHandshakeFrame,
+  parseCoachRpcEnvelope,
+  serializeCoachRpcEnvelope,
+  type CoachTurnEventNotificationEnvelope,
+  type JsonRpcProtocolErrorResponseEnvelope,
+} from "@enduragent/coach-contract";
+import {
+  CoachClientBackpressureError,
+  CoachClientDisconnectedError,
+  CoachClientHandshakeError,
+  CoachClientProtocolError,
+  CoachClientTransportUnavailableError,
+  CoachClientVersionMismatchError,
+  CoachRpcRemoteError,
+  connectCoachClient,
+  resolveCoachWebSocketFactory,
+  type CoachClient,
+  type CoachClientCallOptions,
+  type CoachClientTerminalEnvelope,
+} from "../src/index.js";
+
+const token = "synthetic-test-token";
+
+class ControllableSocket extends EventTarget {
+  readyState = 0;
+  bufferedAmount = 0;
+  readonly sent: string[] = [];
+  readonly closeCalls: Array<{ code: number | undefined; reason: string | undefined }> = [];
+  sendHook: ((text: string) => void) | undefined;
+  closeSynchronously = false;
+
+  send(data: string | ArrayBufferLike | Blob | ArrayBufferView): void {
+    const text = String(data);
+    this.sent.push(text);
+    this.sendHook?.(text);
+  }
+
+  close(code?: number, reason?: string): void {
+    this.closeCalls.push({ code, reason });
+    this.readyState = 2;
+    if (this.closeSynchronously) this.emitClose(code ?? 1000, reason ?? "");
+  }
+
+  emitOpen(): void {
+    this.readyState = 1;
+    this.dispatchEvent(new Event("open"));
+  }
+
+  emitMessage(data: unknown): void {
+    this.dispatchEvent(new MessageEvent("message", { data }));
+  }
+
+  emitError(): void {
+    this.dispatchEvent(new Event("error"));
+  }
+
+  emitClose(code = 1006, reason = "closed"): void {
+    this.readyState = 3;
+    this.dispatchEvent(new CloseEvent("close", { code, reason }));
+  }
+}
+
+interface Deferred<T> {
+  readonly promise: Promise<T>;
+  resolve(value: T): void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve };
+}
+
+function acceptedSocket(owner = "service-managed" as const): {
+  readonly socket: ControllableSocket;
+  readonly connecting: Promise<CoachClient>;
+} {
+  const socket = new ControllableSocket();
+  socket.sendHook = (text) => {
+    const frame = JSON.parse(text) as { type?: string };
+    if (frame.type === "handshake") {
+      socket.emitMessage(
+        JSON.stringify(createAcceptedServerHandshakeFrame(owner, PROTOCOL_VERSION)),
+      );
+    }
+  };
+  const connecting = connectCoachClient({
+    url: "ws://127.0.0.1:49152",
+    token,
+    webSocketFactory: () => socket as unknown as WebSocket,
+  });
+  socket.emitOpen();
+  return { socket, connecting };
+}
+
+const servers: WebSocketServer[] = [];
+const serverSockets: ServerWebSocket[] = [];
+
+afterEach(async () => {
+  vi.useRealTimers();
+  for (const socket of serverSockets.splice(0)) socket.terminate();
+  await Promise.all(
+    servers
+      .splice(0)
+      .map((server) => new Promise<void>((resolve) => server.close(() => resolve()))),
+  );
+});
+
+async function startServer(
+  onConnection: (socket: ServerWebSocket, requestUrl: string | undefined) => void,
+): Promise<string> {
+  const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+  await new Promise<void>((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  servers.push(server);
+  server.on("connection", (socket, request) => {
+    serverSockets.push(socket);
+    onConnection(socket, request.url);
+  });
+  const address = server.address();
+  if (typeof address === "string" || address === null) throw new Error("missing server address");
+  return `ws://127.0.0.1:${address.port}`;
+}
+
+describe("connection and transport", () => {
+  it("uses the Node global, sends the token frame first, and accepts a verbatim browser factory", async () => {
+    const firstFrame = deferred<Record<string, unknown>>();
+    const urls: Array<string | undefined> = [];
+    const url = await startServer((socket, requestUrl) => {
+      urls.push(requestUrl);
+      socket.once("message", (data) => {
+        const frame = JSON.parse(data.toString()) as Record<string, unknown>;
+        firstFrame.resolve(frame);
+        socket.send(JSON.stringify(createAcceptedServerHandshakeFrame("service-managed", 1)));
+      });
+    });
+    const client = await connectCoachClient({ url, token });
+    expect(await firstFrame.promise).toEqual({
+      type: "handshake",
+      token,
+      clientProtocolVersion: 1,
+    });
+    expect(urls).toEqual(["/"]);
+    expect(client.handshake.owner).toBe("service-managed");
+    await client.close();
+
+    const socket = new ControllableSocket();
+    const factory = vi.fn(() => socket as unknown as WebSocket);
+    expect(resolveCoachWebSocketFactory(factory)).toBe(factory);
+    socket.sendHook = () =>
+      socket.emitMessage(
+        JSON.stringify(createAcceptedServerHandshakeFrame("unmanaged-foreground", 1)),
+      );
+    const browserConnection = connectCoachClient({
+      url: "ws://127.0.0.1:49153",
+      token,
+      webSocketFactory: factory,
+    });
+    socket.emitOpen();
+    const browserClient = await browserConnection;
+    expect(factory).toHaveBeenCalledExactlyOnceWith("ws://127.0.0.1:49153");
+    socket.closeSynchronously = true;
+    await browserClient.close();
+  });
+
+  it("maps missing and throwing transports to the stable unavailable error", async () => {
+    const descriptor = Object.getOwnPropertyDescriptor(globalThis, "WebSocket");
+    Object.defineProperty(globalThis, "WebSocket", { configurable: true, value: undefined });
+    try {
+      expect(() => resolveCoachWebSocketFactory()).toThrow(CoachClientTransportUnavailableError);
+    } finally {
+      if (descriptor !== undefined) Object.defineProperty(globalThis, "WebSocket", descriptor);
+    }
+    const error = await connectCoachClient({
+      url: "ws://127.0.0.1:49152",
+      token,
+      webSocketFactory: () => {
+        throw new Error("private constructor detail");
+      },
+    }).catch((caught: unknown) => caught);
+    expect(error).toBeInstanceOf(CoachClientTransportUnavailableError);
+    expect(error).toMatchObject({
+      name: "CoachClientTransportUnavailableError",
+      message: "WebSocket transport is unavailable",
+    });
+    expect(String(error)).not.toContain("private constructor detail");
+  });
+
+  it.each([
+    "not a url",
+    "http://127.0.0.1:80",
+    "https://127.0.0.1:443",
+    "wss://127.0.0.1:443",
+    "ws://127.0.0.1",
+    "ws://127.0.0.1:80",
+    "ws://user@127.0.0.1:49152",
+    "ws://user:pass@127.0.0.1:49152",
+    "ws://127.0.0.1:49152?token=synthetic-test-token",
+    "ws://127.0.0.1:49152#fragment",
+    "ws://localhost:49152",
+    "ws://127.0.0.2:49152",
+    "ws://[::1]:49152",
+  ])("rejects forbidden URL %s before transport", async (url) => {
+    const factory = vi.fn();
+    const error = await connectCoachClient({ url, token, webSocketFactory: factory }).catch(
+      (caught: unknown) => caught,
+    );
+    expect(error).toBeInstanceOf(CoachClientProtocolError);
+    expect(error).toMatchObject({
+      name: "CoachClientProtocolError",
+      message: "Coach client protocol error",
+    });
+    expect(factory).not.toHaveBeenCalled();
+    expect(String(error)).not.toContain(token);
+  });
+
+  it.each([
+    { token: "" },
+    { connectTimeoutMs: NaN },
+    { connectTimeoutMs: Infinity },
+    { handshakeTimeoutMs: -1 },
+    { closeTimeoutMs: 0 },
+    { maxQueuedSends: 1.5 },
+    { maxQueuedSends: Number.MAX_SAFE_INTEGER + 1 },
+    { highWaterMarkBytes: 0 },
+    { highWaterMarkBytes: -Infinity },
+    { lowWaterMarkBytes: -1 },
+    { lowWaterMarkBytes: NaN },
+    { highWaterMarkBytes: 10, lowWaterMarkBytes: 10 },
+    { highWaterMarkBytes: 10, lowWaterMarkBytes: 11 },
+  ])("rejects invalid options before transport: %o", async (override) => {
+    const factory = vi.fn();
+    const error = await connectCoachClient({
+      url: "ws://127.0.0.1:49152",
+      token,
+      webSocketFactory: factory,
+      ...override,
+    }).catch((caught: unknown) => caught);
+    expect(error).toBeInstanceOf(CoachClientProtocolError);
+    expect(factory).not.toHaveBeenCalled();
+  });
+
+  it("times out an inert connection exactly and cleans up", async () => {
+    vi.useFakeTimers();
+    const socket = new ControllableSocket();
+    const connection = connectCoachClient({
+      url: "ws://127.0.0.1:49152",
+      token,
+      connectTimeoutMs: 37,
+      webSocketFactory: () => socket as unknown as WebSocket,
+    });
+    let settled = false;
+    void connection.catch(() => {
+      settled = true;
+    });
+    await vi.advanceTimersByTimeAsync(36);
+    expect(settled).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+    const error = await connection.catch((caught: unknown) => caught);
+    expect(error).toMatchObject({
+      name: "CoachClientHandshakeError",
+      message: "Coach client connection timed out",
+    });
+    expect(socket.sent).toEqual([]);
+    expect(socket.closeCalls).toHaveLength(1);
+  });
+
+  it("distinguishes pre-aborted and mid-connect aborted signals", async () => {
+    const before = new AbortController();
+    before.abort();
+    const factory = vi.fn();
+    await expect(
+      connectCoachClient({
+        url: "ws://127.0.0.1:49152",
+        token,
+        signal: before.signal,
+        webSocketFactory: factory,
+      }),
+    ).rejects.toMatchObject({ message: "Coach client connection aborted" });
+    expect(factory).not.toHaveBeenCalled();
+
+    const during = new AbortController();
+    const socket = new ControllableSocket();
+    const connection = connectCoachClient({
+      url: "ws://127.0.0.1:49152",
+      token,
+      signal: during.signal,
+      webSocketFactory: () => socket as unknown as WebSocket,
+    });
+    during.abort();
+    await expect(connection).rejects.toMatchObject({
+      name: "CoachClientHandshakeError",
+      message: "Coach client connection aborted",
+    });
+    expect(socket.sent).toEqual([]);
+    expect(socket.closeCalls).toHaveLength(1);
+  });
+});
+
+describe("handshake failures", () => {
+  it.each([
+    {
+      kind: "timeout",
+      expected: CoachClientHandshakeError,
+      message: "Coach client handshake timed out",
+    },
+    {
+      kind: "close",
+      expected: CoachClientHandshakeError,
+      message: "Coach client handshake failed",
+    },
+    {
+      kind: "error",
+      expected: CoachClientHandshakeError,
+      message: "Coach client handshake failed",
+    },
+    { kind: "binary", expected: CoachClientProtocolError, message: "Coach client protocol error" },
+    {
+      kind: "unknown-owner",
+      expected: CoachClientProtocolError,
+      message: "Coach client protocol error",
+    },
+    {
+      kind: "invalid-accepted",
+      expected: CoachClientProtocolError,
+      message: "Coach client protocol error",
+    },
+  ])("fails closed for $kind", async ({ kind, expected, message }) => {
+    vi.useFakeTimers();
+    const socket = new ControllableSocket();
+    const connection = connectCoachClient({
+      url: "ws://127.0.0.1:49152",
+      token,
+      handshakeTimeoutMs: 23,
+      webSocketFactory: () => socket as unknown as WebSocket,
+    });
+    const outcome = connection.catch((caught: unknown) => caught);
+    socket.emitOpen();
+    await Promise.resolve();
+    if (kind === "timeout") await vi.advanceTimersByTimeAsync(23);
+    if (kind === "close") socket.emitClose();
+    if (kind === "error") socket.emitError();
+    if (kind === "binary") socket.emitMessage(new Uint8Array([1]));
+    if (kind === "unknown-owner")
+      socket.emitMessage(
+        JSON.stringify({
+          type: "handshake",
+          status: "accepted",
+          clientProtocolVersion: 1,
+          serverProtocolVersion: 1,
+          owner: "app-supervised",
+        }),
+      );
+    if (kind === "invalid-accepted")
+      socket.emitMessage(
+        JSON.stringify({
+          type: "handshake",
+          status: "accepted",
+          clientProtocolVersion: 1,
+          serverProtocolVersion: 2,
+          owner: "service-managed",
+        }),
+      );
+    const error = await outcome;
+    expect(error).toBeInstanceOf(expected);
+    expect(error).toMatchObject({ name: expected.name, message });
+    expect(String(error)).not.toContain(token);
+  });
+
+  it("maps handshake send throws without retry", async () => {
+    const socket = new ControllableSocket();
+    socket.sendHook = () => {
+      throw new Error("raw send detail");
+    };
+    const connection = connectCoachClient({
+      url: "ws://127.0.0.1:49152",
+      token,
+      webSocketFactory: () => socket as unknown as WebSocket,
+    });
+    socket.emitOpen();
+    const error = await connection.catch((caught: unknown) => caught);
+    expect(error).toMatchObject({
+      name: "CoachClientHandshakeError",
+      message: "Coach client handshake send failed",
+    });
+    expect(socket.sent).toHaveLength(1);
+    expect(String(error)).not.toContain(token);
+  });
+
+  it.each([
+    [1, 2, "client-older", "ephemeral-client-started"],
+    [1, 0, "client-newer", "unmanaged-foreground"],
+  ] as const)(
+    "exposes a trusted mismatch %s/%s",
+    async (clientVersion, serverVersion, direction, owner) => {
+      const socket = new ControllableSocket();
+      socket.sendHook = () =>
+        socket.emitMessage(
+          JSON.stringify(
+            createVersionMismatchServerHandshakeFrame(owner, clientVersion, serverVersion),
+          ),
+        );
+      const connection = connectCoachClient({
+        url: "ws://127.0.0.1:49152",
+        token,
+        webSocketFactory: () => socket as unknown as WebSocket,
+      });
+      socket.emitOpen();
+      const error = await connection.catch((caught: unknown) => caught);
+      expect(error).toBeInstanceOf(CoachClientVersionMismatchError);
+      expect(error).toMatchObject({
+        name: "CoachClientVersionMismatchError",
+        message: "Coach protocol version mismatch",
+        clientProtocolVersion: clientVersion,
+        serverProtocolVersion: serverVersion,
+        direction,
+        owner,
+      });
+    },
+  );
+});
+
+describe("RPC receive and observers", () => {
+  it("exercises all methods with monotonic strict requests and parsed results", async () => {
+    const received: unknown[] = [];
+    const { socket, connecting } = acceptedSocket();
+    const client = await connecting;
+    socket.sendHook = (text) => {
+      const request = parseCoachRpcEnvelope(text);
+      received.push(request);
+      if (!("id" in request) || !("method" in request)) return;
+      const results = {
+        chat: { text: "answer" },
+        resetSession: { memoryFlushed: true },
+        hasSession: { hasSession: true },
+        getAthleteState: {
+          schemaVersion: "1",
+          lastUpdated: "2020-01-01T00:00:00.000Z",
+          freshness: "fresh",
+          degraded: false,
+          lastSynced: null,
+          athleteProfile: {},
+          currentStatus: {},
+          derivedMetrics: {},
+          recentActivities: [],
+          plannedWorkouts: [],
+          wellness: {},
+        },
+      };
+      socket.emitMessage(
+        serializeCoachRpcEnvelope({
+          jsonrpc: "2.0",
+          id: request.id,
+          result: results[request.method],
+        }),
+      );
+    };
+    await expect(client.call("chat", { chatId: "chat-1", message: "hello" })).resolves.toEqual({
+      text: "answer",
+    });
+    await expect(client.call("resetSession", { chatId: "chat-1" })).resolves.toEqual({
+      memoryFlushed: true,
+    });
+    await expect(client.call("hasSession", { chatId: "chat-1" })).resolves.toEqual({
+      hasSession: true,
+    });
+    await expect(client.call("getAthleteState", {})).resolves.toMatchObject({ schemaVersion: "1" });
+    expect(received.map((value) => (value as { id: number }).id)).toEqual([1, 2, 3, 4]);
+    expect(received.map((value) => (value as { method: string }).method)).toEqual([
+      "chat",
+      "resetSession",
+      "hasSession",
+      "getAthleteState",
+    ]);
+    socket.closeSynchronously = true;
+    await client.close();
+  });
+
+  it("rejects non-JSON chat params without sending or consuming an id", async () => {
+    const { socket, connecting } = acceptedSocket();
+    const client = await connecting;
+    socket.sent.length = 0;
+    await expect(
+      client.call("chat", {
+        chatId: "chat-1",
+        message: "hello",
+        turn: { resolvedCs: { nested: () => undefined } },
+      }),
+    ).rejects.toBeInstanceOf(CoachClientProtocolError);
+    expect(socket.sent).toEqual([]);
+    socket.sendHook = (text) => {
+      const request = JSON.parse(text) as { id: number };
+      socket.emitMessage(
+        JSON.stringify({ jsonrpc: "2.0", id: request.id, result: { text: "ok" } }),
+      );
+    };
+    await expect(client.call("chat", { chatId: "chat-1", message: "hello" })).resolves.toEqual({
+      text: "ok",
+    });
+    expect((JSON.parse(socket.sent[0]!) as { id: number }).id).toBe(1);
+    socket.closeSynchronously = true;
+    await client.close();
+  });
+
+  it("routes interleaved notifications in parser-object order and isolates observer throws", async () => {
+    const { socket, connecting } = acceptedSocket();
+    const client = await connecting;
+    const calls: Array<{ id: number; text: string }> = [];
+    socket.sendHook = (text) => {
+      const request = JSON.parse(text) as { id: number };
+      calls.push({ id: request.id, text });
+    };
+    const observed: string[] = [];
+    const envelopes: CoachTurnEventNotificationEnvelope[] = [];
+    const first = client.call(
+      "chat",
+      { chatId: "chat-1", message: "one" },
+      {
+        onNotificationEnvelope: (envelope) => {
+          envelopes.push(envelope);
+          observed.push(`envelope:${envelope.params.event.turnId}`);
+          throw new Error("advisory");
+        },
+        onEvent: (event) => {
+          observed.push(`event:${event.turnId}`);
+        },
+      },
+    );
+    const second = client.call(
+      "chat",
+      { chatId: "chat-2", message: "two" },
+      {
+        onNotificationEnvelope: (envelope) => {
+          envelopes.push(envelope);
+          observed.push(`envelope:${envelope.params.event.turnId}`);
+        },
+        onEvent: (event) => {
+          observed.push(`event:${event.turnId}`);
+          throw new Error("advisory");
+        },
+      },
+    );
+    for (const [id, turnId] of [
+      [2, "turn-2"],
+      [1, "turn-1"],
+      [2, "turn-3"],
+    ] as const) {
+      socket.emitMessage(
+        serializeCoachRpcEnvelope({
+          jsonrpc: "2.0",
+          method: "coach.turnEvent",
+          params: {
+            requestId: id,
+            requestMethod: "chat",
+            turnId,
+            event: { type: "turn-start", turnId, chatId: `chat-${id}` },
+          },
+        }),
+      );
+    }
+    expect(observed).toEqual([
+      "envelope:turn-2",
+      "event:turn-2",
+      "envelope:turn-1",
+      "event:turn-1",
+      "envelope:turn-3",
+      "event:turn-3",
+    ]);
+    for (const envelope of envelopes)
+      expect(parseCoachRpcEnvelope(serializeCoachRpcEnvelope(envelope))).toEqual(envelope);
+    socket.emitMessage(JSON.stringify({ jsonrpc: "2.0", id: 1, result: { text: "one" } }));
+    socket.emitMessage(JSON.stringify({ jsonrpc: "2.0", id: 2, result: { text: "two" } }));
+    await expect(first).resolves.toEqual({ text: "one" });
+    await expect(second).resolves.toEqual({ text: "two" });
+    expect(calls.map((call) => call.id)).toEqual([1, 2]);
+    socket.closeSynchronously = true;
+    await client.close();
+  });
+
+  it("delivers terminal envelopes before settlement and preserves typed remote errors", async () => {
+    const { socket, connecting } = acceptedSocket();
+    const client = await connecting;
+    const order: string[] = [];
+    socket.sendHook = (text) => {
+      const request = JSON.parse(text) as { id: number };
+      if (request.id === 1)
+        socket.emitMessage(
+          JSON.stringify({ jsonrpc: "2.0", id: 1, result: { hasSession: false } }),
+        );
+      else
+        socket.emitMessage(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: 2,
+            error: { code: -32600, message: "public remote message", data: { safe: true } },
+          }),
+        );
+    };
+    const successEnvelopes: CoachClientTerminalEnvelope[] = [];
+    const success = client.call(
+      "hasSession",
+      { chatId: "chat-1" },
+      {
+        onTerminalEnvelope: (envelope) => {
+          successEnvelopes.push(envelope);
+          order.push("success-observer");
+          throw new Error("advisory");
+        },
+      },
+    );
+    await success.then(() => order.push("success-resolve"));
+    expect(order).toEqual(["success-observer", "success-resolve"]);
+    const failure = client.call(
+      "hasSession",
+      { chatId: "chat-1" },
+      {
+        onTerminalEnvelope: (envelope) => {
+          successEnvelopes.push(envelope);
+          order.push("error-observer");
+        },
+      },
+    );
+    const error = await failure.catch((caught: unknown) => {
+      order.push("error-catch");
+      return caught;
+    });
+    expect(order.slice(-2)).toEqual(["error-observer", "error-catch"]);
+    expect(error).toBeInstanceOf(CoachRpcRemoteError);
+    expect(error).toMatchObject({
+      name: "CoachRpcRemoteError",
+      message: "public remote message",
+      code: -32600,
+      data: { safe: true },
+    });
+    expect(successEnvelopes).toHaveLength(2);
+    for (const envelope of successEnvelopes)
+      expect(parseCoachRpcEnvelope(serializeCoachRpcEnvelope(envelope))).toEqual(envelope);
+    socket.closeSynchronously = true;
+    await client.close();
+  });
+
+  it.each([-32700, -32600] as const)(
+    "treats null-id protocol error %s as connection-wide",
+    async (code) => {
+      const { socket, connecting } = acceptedSocket();
+      const client = await connecting;
+      socket.sendHook = () => {};
+      const terminals = vi.fn();
+      const first = client.call(
+        "chat",
+        { chatId: "chat-1", message: "one" },
+        { onTerminalEnvelope: terminals },
+      );
+      const second = client.call(
+        "hasSession",
+        { chatId: "chat-2" },
+        { onTerminalEnvelope: terminals },
+      );
+      socket.emitMessage(
+        JSON.stringify({ jsonrpc: "2.0", id: null, error: { code, message: "protocol" } }),
+      );
+      const [a, b] = await Promise.all([
+        first.catch((error: unknown) => error),
+        second.catch((error: unknown) => error),
+      ]);
+      expect(a).toBeInstanceOf(CoachClientProtocolError);
+      expect(b).toBe(a);
+      expect(terminals).not.toHaveBeenCalled();
+      await expect(client.call("hasSession", { chatId: "chat-1" })).rejects.toBe(a);
+      const closing = client.close();
+      socket.emitClose(1002, "protocol");
+      await closing;
+    },
+  );
+
+  it.each([
+    JSON.stringify({ jsonrpc: "2.0", id: 999, result: { text: "unknown" } }),
+    JSON.stringify({ jsonrpc: "2.0", id: 1, error: { code: -32700, message: "bad id" } }),
+    JSON.stringify({ jsonrpc: "2.0", id: null, error: { code: -32000, message: "foreign" } }),
+    "not-json",
+    new Uint8Array([1, 2]),
+  ])("fails all pending work for violating frame", async (frame) => {
+    const { socket, connecting } = acceptedSocket();
+    const client = await connecting;
+    socket.sendHook = () => {};
+    const terminals = vi.fn();
+    const first = client.call(
+      "chat",
+      { chatId: "chat-1", message: "one" },
+      { onTerminalEnvelope: terminals },
+    );
+    const second = client.call(
+      "hasSession",
+      { chatId: "chat-2" },
+      { onTerminalEnvelope: terminals },
+    );
+    socket.emitMessage(frame);
+    const [a, b] = await Promise.all([
+      first.catch((error: unknown) => error),
+      second.catch((error: unknown) => error),
+    ]);
+    expect(a).toBeInstanceOf(CoachClientProtocolError);
+    expect(b).toBe(a);
+    expect(terminals).not.toHaveBeenCalled();
+    const closing = client.close();
+    socket.emitClose(1002, "protocol");
+    await closing;
+  });
+});
+
+describe("disconnect, close, and send bounds", () => {
+  it("fans an unexpected disconnect to every pending and future call", async () => {
+    const { socket, connecting } = acceptedSocket();
+    const client = await connecting;
+    socket.sendHook = () => {};
+    const terminal = vi.fn();
+    const a = client.call(
+      "chat",
+      { chatId: "chat-1", message: "one" },
+      { onTerminalEnvelope: terminal },
+    );
+    const b = client.call("hasSession", { chatId: "chat-2" }, { onTerminalEnvelope: terminal });
+    socket.emitClose(1006, "network gone");
+    const [first, second] = await Promise.all([
+      a.catch((error: unknown) => error),
+      b.catch((error: unknown) => error),
+    ]);
+    expect(first).toBeInstanceOf(CoachClientDisconnectedError);
+    expect(first).toMatchObject({
+      code: 1006,
+      reason: "network gone",
+      message: "Coach client disconnected",
+    });
+    expect(second).toBe(first);
+    expect(terminal).not.toHaveBeenCalled();
+    await expect(client.call("hasSession", { chatId: "chat-1" })).rejects.toBe(first);
+    await client.close();
+  });
+
+  it("explicit close is idempotent, settles pending, and handles synchronous close", async () => {
+    const { socket, connecting } = acceptedSocket();
+    const client = await connecting;
+    socket.sendHook = () => {};
+    socket.closeSynchronously = true;
+    const pending = client.call("chat", { chatId: "chat-1", message: "one" });
+    const first = client.close(1000, "done");
+    const second = client.close(1001, "ignored");
+    expect(first).toBe(second);
+    const error = await pending.catch((caught: unknown) => caught);
+    expect(error).toMatchObject({
+      name: "CoachClientDisconnectedError",
+      code: 1000,
+      reason: "done",
+    });
+    await expect(first).resolves.toBeUndefined();
+    expect(socket.closeCalls).toHaveLength(1);
+  });
+
+  it("resolves explicit close at its bounded timeout when no event arrives", async () => {
+    vi.useFakeTimers();
+    const { socket, connecting } = acceptedSocket();
+    const client = await connecting;
+    const closing = client.close();
+    let settled = false;
+    void closing.then(() => {
+      settled = true;
+    });
+    await vi.advanceTimersByTimeAsync(4_999);
+    expect(settled).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(closing).resolves.toBeUndefined();
+    expect(socket.closeCalls).toHaveLength(1);
+  });
+
+  it("enforces high-low hysteresis, FIFO order, and 128 waiting sends", async () => {
+    vi.useFakeTimers();
+    const socket = new ControllableSocket();
+    socket.sendHook = (text) => {
+      const frame = JSON.parse(text) as { type?: string; id?: number };
+      if (frame.type === "handshake")
+        socket.emitMessage(
+          JSON.stringify(createAcceptedServerHandshakeFrame("service-managed", 1)),
+        );
+      else if (frame.id !== undefined)
+        socket.emitMessage(
+          JSON.stringify({ jsonrpc: "2.0", id: frame.id, result: { hasSession: true } }),
+        );
+    };
+    const connecting = connectCoachClient({
+      url: "ws://127.0.0.1:49152",
+      token,
+      highWaterMarkBytes: 20,
+      lowWaterMarkBytes: 5,
+      webSocketFactory: () => socket as unknown as WebSocket,
+    });
+    socket.emitOpen();
+    const client = await connecting;
+    socket.sent.length = 0;
+    socket.bufferedAmount = 20;
+    const admitted = Array.from({ length: 129 }, (_, index) =>
+      client.call("hasSession", { chatId: `chat-${index}` }),
+    );
+    for (const promise of admitted) void promise.catch(() => undefined);
+    await expect(client.call("hasSession", { chatId: "overflow" })).rejects.toBeInstanceOf(
+      CoachClientBackpressureError,
+    );
+    expect(socket.sent).toEqual([]);
+    socket.bufferedAmount = 6;
+    await vi.advanceTimersByTimeAsync(20);
+    expect(socket.sent).toEqual([]);
+    socket.bufferedAmount = 5;
+    await vi.advanceTimersByTimeAsync(10);
+    await Promise.all(admitted);
+    expect(socket.sent.map((text) => (JSON.parse(text) as { id: number }).id)).toEqual(
+      Array.from({ length: 129 }, (_, index) => index + 1),
+    );
+    socket.closeSynchronously = true;
+    await client.close();
+  });
+
+  it.each([1, 2])("latches a synchronous RPC send throw at position %s", async (throwAt) => {
+    vi.useFakeTimers();
+    const { socket, connecting } = acceptedSocket();
+    const client = await connecting;
+    let sends = 0;
+    socket.sendHook = () => {
+      sends++;
+      if (sends === throwAt) throw new Error("private send detail");
+    };
+    if (throwAt === 2) socket.bufferedAmount = 1_048_576;
+    const first = client.call("hasSession", { chatId: "chat-1" }).catch((error: unknown) => error);
+    const second = client.call("hasSession", { chatId: "chat-2" }).catch((error: unknown) => error);
+    if (throwAt === 2) {
+      socket.bufferedAmount = 0;
+      await vi.advanceTimersByTimeAsync(10);
+    }
+    const [a, b] = await Promise.all([first, second]);
+    expect(a).toBeInstanceOf(CoachClientProtocolError);
+    expect(b).toBe(a);
+    expect(String(a)).not.toContain("private send detail");
+    await expect(client.call("hasSession", { chatId: "future" })).rejects.toBe(a);
+    const closing = client.close();
+    socket.emitClose(1002, "protocol");
+    await closing;
+  });
+});
+
+describe("public observer types", () => {
+  it("exports the generic observers and excludes null-id protocol terminals", () => {
+    expectTypeOf<CoachClientCallOptions<"chat">["onNotificationEnvelope"]>().toEqualTypeOf<
+      ((envelope: CoachTurnEventNotificationEnvelope) => void) | undefined
+    >();
+    expectTypeOf<CoachClientCallOptions<"chat">["onTerminalEnvelope"]>().toEqualTypeOf<
+      ((envelope: CoachClientTerminalEnvelope) => void) | undefined
+    >();
+    expectTypeOf<JsonRpcProtocolErrorResponseEnvelope>().not.toExtend<CoachClientTerminalEnvelope>();
+  });
+});

--- a/packages/coach-client/tsconfig.json
+++ b/packages/coach-client/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022", "DOM"],
+    "types": ["node"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "ignoreDeprecations": "6.0"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/coach-client/tsup.config.ts
+++ b/packages/coach-client/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: { index: "src/index.ts" },
+  format: ["esm"],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  splitting: false,
+  platform: "neutral",
+  target: "es2022",
+});

--- a/packages/coach-contract/src/handshake.ts
+++ b/packages/coach-contract/src/handshake.ts
@@ -1,0 +1,131 @@
+import { z } from "zod";
+import { PROTOCOL_VERSION } from "./version.js";
+
+export const DaemonOwnerSchema = z.enum([
+  "service-managed",
+  "ephemeral-client-started",
+  "unmanaged-foreground",
+]);
+export type DaemonOwner = z.infer<typeof DaemonOwnerSchema>;
+
+export const ProtocolVersionDirectionSchema = z.enum(["client-older", "client-newer"]);
+export type ProtocolVersionDirection = z.infer<typeof ProtocolVersionDirectionSchema>;
+
+export const ProtocolVersionNumberSchema = z
+  .number()
+  .int()
+  .nonnegative()
+  .max(Number.MAX_SAFE_INTEGER);
+export type ProtocolVersionNumber = z.infer<typeof ProtocolVersionNumberSchema>;
+
+export const ClientHandshakeFrameSchema = z
+  .object({
+    type: z.literal("handshake"),
+    token: z.string().min(1),
+    clientProtocolVersion: ProtocolVersionNumberSchema,
+  })
+  .strict();
+export type ClientHandshakeFrame = z.infer<typeof ClientHandshakeFrameSchema>;
+
+export const ServerHandshakeFrameSchema = z
+  .discriminatedUnion("status", [
+    z
+      .object({
+        type: z.literal("handshake"),
+        status: z.literal("accepted"),
+        clientProtocolVersion: ProtocolVersionNumberSchema,
+        serverProtocolVersion: ProtocolVersionNumberSchema,
+        owner: DaemonOwnerSchema,
+      })
+      .strict(),
+    z
+      .object({
+        type: z.literal("handshake"),
+        status: z.literal("version-mismatch"),
+        clientProtocolVersion: ProtocolVersionNumberSchema,
+        serverProtocolVersion: ProtocolVersionNumberSchema,
+        direction: ProtocolVersionDirectionSchema,
+        owner: DaemonOwnerSchema,
+      })
+      .strict(),
+  ])
+  .superRefine((value, context) => {
+    const comparison = compareProtocolVersions(
+      value.clientProtocolVersion,
+      value.serverProtocolVersion,
+    );
+    if (value.status === "accepted" && comparison !== "equal") {
+      context.addIssue({ code: "custom", message: "accepted versions must match" });
+    }
+    if (value.status === "version-mismatch" && comparison !== value.direction) {
+      context.addIssue({
+        code: "custom",
+        path: ["direction"],
+        message: "version direction does not match compared versions",
+      });
+    }
+  });
+export type ServerHandshakeFrame = z.infer<typeof ServerHandshakeFrameSchema>;
+
+export type ProtocolVersionComparison = "equal" | ProtocolVersionDirection;
+
+export function compareProtocolVersions(
+  clientProtocolVersion: number,
+  serverProtocolVersion: number,
+): ProtocolVersionComparison {
+  ProtocolVersionNumberSchema.parse(clientProtocolVersion);
+  ProtocolVersionNumberSchema.parse(serverProtocolVersion);
+  if (clientProtocolVersion < serverProtocolVersion) return "client-older";
+  if (clientProtocolVersion > serverProtocolVersion) return "client-newer";
+  return "equal";
+}
+
+export type AcceptedServerHandshakeFrame = Extract<ServerHandshakeFrame, { status: "accepted" }>;
+export type VersionMismatchServerHandshakeFrame = Extract<
+  ServerHandshakeFrame,
+  { status: "version-mismatch" }
+>;
+
+export function createClientHandshakeFrame(token: string): ClientHandshakeFrame {
+  return ClientHandshakeFrameSchema.parse({
+    type: "handshake",
+    token,
+    clientProtocolVersion: PROTOCOL_VERSION,
+  });
+}
+
+export function createAcceptedServerHandshakeFrame(
+  owner: DaemonOwner,
+  clientProtocolVersion: number,
+  serverProtocolVersion: number = PROTOCOL_VERSION,
+): AcceptedServerHandshakeFrame {
+  if (compareProtocolVersions(clientProtocolVersion, serverProtocolVersion) !== "equal") {
+    throw new Error("accepted versions must match");
+  }
+  return ServerHandshakeFrameSchema.parse({
+    type: "handshake",
+    status: "accepted",
+    clientProtocolVersion,
+    serverProtocolVersion,
+    owner,
+  }) as AcceptedServerHandshakeFrame;
+}
+
+export function createVersionMismatchServerHandshakeFrame(
+  owner: DaemonOwner,
+  clientProtocolVersion: number,
+  serverProtocolVersion: number = PROTOCOL_VERSION,
+): VersionMismatchServerHandshakeFrame {
+  const direction = compareProtocolVersions(clientProtocolVersion, serverProtocolVersion);
+  if (direction === "equal") {
+    throw new Error("version mismatch requires unequal versions");
+  }
+  return ServerHandshakeFrameSchema.parse({
+    type: "handshake",
+    status: "version-mismatch",
+    clientProtocolVersion,
+    serverProtocolVersion,
+    direction,
+    owner,
+  }) as VersionMismatchServerHandshakeFrame;
+}

--- a/packages/coach-contract/src/index.ts
+++ b/packages/coach-contract/src/index.ts
@@ -3,3 +3,5 @@ export * from "./exit-codes.js";
 export * from "./turn-event.js";
 export * from "./athlete-state.js";
 export * from "./engine.js";
+export * from "./rpc.js";
+export * from "./handshake.js";

--- a/packages/coach-contract/src/rpc.ts
+++ b/packages/coach-contract/src/rpc.ts
@@ -1,0 +1,260 @@
+import { z } from "zod";
+import { AthleteStateSchema } from "./athlete-state.js";
+import {
+  ChatRequestSchema,
+  ChatResponseSchema,
+  HasSessionRequestSchema,
+  HasSessionResponseSchema,
+  ResetSessionRequestSchema,
+  ResetSessionResponseSchema,
+  type CoachEngine,
+} from "./engine.js";
+import { TurnEventSchema } from "./turn-event.js";
+
+export const JsonValueSchema = z.json();
+export type JsonValue = z.infer<typeof JsonValueSchema>;
+
+export const JsonRpcIdSchema = z.union([
+  z.string().min(1),
+  z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER),
+]);
+export type JsonRpcId = z.infer<typeof JsonRpcIdSchema>;
+
+export const JsonRpcErrorObjectSchema = z
+  .object({
+    code: z.number().int(),
+    message: z.string(),
+    data: JsonValueSchema.optional(),
+  })
+  .strict();
+export type JsonRpcErrorObject = z.infer<typeof JsonRpcErrorObjectSchema>;
+
+export const JsonRpcRequestEnvelopeSchema = z
+  .object({
+    jsonrpc: z.literal("2.0"),
+    id: JsonRpcIdSchema,
+    method: z.string().min(1),
+    params: JsonValueSchema,
+  })
+  .strict();
+export type JsonRpcRequestEnvelope = z.infer<typeof JsonRpcRequestEnvelopeSchema>;
+
+export const JsonRpcSuccessResponseEnvelopeSchema = z
+  .object({
+    jsonrpc: z.literal("2.0"),
+    id: JsonRpcIdSchema,
+    result: JsonValueSchema,
+  })
+  .strict();
+export type JsonRpcSuccessResponseEnvelope = z.infer<typeof JsonRpcSuccessResponseEnvelopeSchema>;
+
+export const JsonRpcErrorResponseEnvelopeSchema = z
+  .object({
+    jsonrpc: z.literal("2.0"),
+    id: JsonRpcIdSchema,
+    error: JsonRpcErrorObjectSchema,
+  })
+  .strict()
+  .superRefine((value, context) => {
+    if (value.error.code === -32700) {
+      context.addIssue({
+        code: "custom",
+        path: ["error", "code"],
+        message: "parse error must use an unrecoverable null id",
+      });
+    }
+  });
+export type JsonRpcErrorResponseEnvelope = z.infer<typeof JsonRpcErrorResponseEnvelopeSchema>;
+
+export const JsonRpcProtocolErrorCodeSchema = z.union([z.literal(-32700), z.literal(-32600)]);
+export type JsonRpcProtocolErrorCode = z.infer<typeof JsonRpcProtocolErrorCodeSchema>;
+
+export const JsonRpcProtocolErrorObjectSchema = JsonRpcErrorObjectSchema.extend({
+  code: JsonRpcProtocolErrorCodeSchema,
+}).strict();
+export type JsonRpcProtocolErrorObject = z.infer<typeof JsonRpcProtocolErrorObjectSchema>;
+
+export const JsonRpcProtocolErrorResponseEnvelopeSchema = z
+  .object({
+    jsonrpc: z.literal("2.0"),
+    id: z.null(),
+    error: JsonRpcProtocolErrorObjectSchema,
+  })
+  .strict();
+export type JsonRpcProtocolErrorResponseEnvelope = z.infer<
+  typeof JsonRpcProtocolErrorResponseEnvelopeSchema
+>;
+
+export const JsonRpcResponseEnvelopeSchema = z.union([
+  JsonRpcSuccessResponseEnvelopeSchema,
+  JsonRpcErrorResponseEnvelopeSchema,
+  JsonRpcProtocolErrorResponseEnvelopeSchema,
+]);
+export type JsonRpcResponseEnvelope = z.infer<typeof JsonRpcResponseEnvelopeSchema>;
+
+export const JsonRpcNotificationEnvelopeSchema = z
+  .object({
+    jsonrpc: z.literal("2.0"),
+    method: z.string().min(1),
+    params: JsonValueSchema,
+  })
+  .strict();
+export type JsonRpcNotificationEnvelope = z.infer<typeof JsonRpcNotificationEnvelopeSchema>;
+
+export const COACH_RPC_METHOD_NAMES = [
+  "chat",
+  "resetSession",
+  "hasSession",
+  "getAthleteState",
+] as const satisfies readonly (keyof CoachEngine)[];
+
+export const CoachRpcMethodNameSchema = z.enum(COACH_RPC_METHOD_NAMES);
+export type CoachRpcMethodName = z.infer<typeof CoachRpcMethodNameSchema>;
+
+export const COACH_TURN_EVENT_NOTIFICATION_METHOD = "coach.turnEvent" as const;
+
+export const ChatRpcParamsSchema = ChatRequestSchema.superRefine((value, context) => {
+  if (!JsonValueSchema.safeParse(value).success) {
+    context.addIssue({
+      code: "custom",
+      message: "chat params must contain only JSON values",
+    });
+  }
+});
+export type ChatRpcParams = z.infer<typeof ChatRpcParamsSchema>;
+
+export const EmptyRpcParamsSchema = z.object({}).strict();
+export type EmptyRpcParams = z.infer<typeof EmptyRpcParamsSchema>;
+
+export const CoachRpcRequestEnvelopeSchema = z.discriminatedUnion("method", [
+  z
+    .object({
+      jsonrpc: z.literal("2.0"),
+      id: JsonRpcIdSchema,
+      method: z.literal("chat"),
+      params: ChatRpcParamsSchema,
+    })
+    .strict(),
+  z
+    .object({
+      jsonrpc: z.literal("2.0"),
+      id: JsonRpcIdSchema,
+      method: z.literal("resetSession"),
+      params: ResetSessionRequestSchema,
+    })
+    .strict(),
+  z
+    .object({
+      jsonrpc: z.literal("2.0"),
+      id: JsonRpcIdSchema,
+      method: z.literal("hasSession"),
+      params: HasSessionRequestSchema,
+    })
+    .strict(),
+  z
+    .object({
+      jsonrpc: z.literal("2.0"),
+      id: JsonRpcIdSchema,
+      method: z.literal("getAthleteState"),
+      params: EmptyRpcParamsSchema,
+    })
+    .strict(),
+]);
+export type CoachRpcRequestEnvelope = z.infer<typeof CoachRpcRequestEnvelopeSchema>;
+
+export const CoachTurnEventNotificationEnvelopeSchema = z
+  .object({
+    jsonrpc: z.literal("2.0"),
+    method: z.literal(COACH_TURN_EVENT_NOTIFICATION_METHOD),
+    params: z
+      .object({
+        requestId: JsonRpcIdSchema,
+        requestMethod: z.literal("chat"),
+        turnId: z.string().min(1),
+        event: TurnEventSchema,
+      })
+      .strict(),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    if (value.params.turnId !== value.params.event.turnId) {
+      context.addIssue({
+        code: "custom",
+        path: ["params", "turnId"],
+        message: "notification turnId must equal event.turnId",
+      });
+    }
+  });
+export type CoachTurnEventNotificationEnvelope = z.infer<
+  typeof CoachTurnEventNotificationEnvelopeSchema
+>;
+
+export const CoachRpcEnvelopeSchema = z.union([
+  CoachRpcRequestEnvelopeSchema,
+  JsonRpcResponseEnvelopeSchema,
+  CoachTurnEventNotificationEnvelopeSchema,
+]);
+export type CoachRpcEnvelope = z.infer<typeof CoachRpcEnvelopeSchema>;
+
+export function parseCoachRpcEnvelope(text: string): CoachRpcEnvelope {
+  return CoachRpcEnvelopeSchema.parse(JSON.parse(text));
+}
+
+export function serializeCoachRpcEnvelope(value: unknown): string {
+  const parsed = CoachRpcEnvelopeSchema.parse(value);
+  JsonValueSchema.parse(parsed);
+  return JSON.stringify(parsed);
+}
+
+export type CoachRpcMethodRegistryShape = {
+  readonly [K in keyof CoachEngine]: {
+    readonly wireName: K;
+    readonly requestSchema: z.ZodType;
+    readonly responseSchema: z.ZodType;
+    readonly eventSchema: z.ZodType;
+  };
+};
+
+export const NoRpcEventSchema = z.never();
+export type NoRpcEvent = z.infer<typeof NoRpcEventSchema>;
+
+export const COACH_RPC_METHOD_REGISTRY = {
+  chat: {
+    wireName: "chat",
+    requestSchema: ChatRpcParamsSchema,
+    responseSchema: ChatResponseSchema,
+    eventSchema: TurnEventSchema,
+  },
+  resetSession: {
+    wireName: "resetSession",
+    requestSchema: ResetSessionRequestSchema,
+    responseSchema: ResetSessionResponseSchema,
+    eventSchema: NoRpcEventSchema,
+  },
+  hasSession: {
+    wireName: "hasSession",
+    requestSchema: HasSessionRequestSchema,
+    responseSchema: HasSessionResponseSchema,
+    eventSchema: NoRpcEventSchema,
+  },
+  getAthleteState: {
+    wireName: "getAthleteState",
+    requestSchema: EmptyRpcParamsSchema,
+    responseSchema: AthleteStateSchema,
+    eventSchema: NoRpcEventSchema,
+  },
+} as const satisfies CoachRpcMethodRegistryShape;
+
+export type CoachRpcRequest<K extends CoachRpcMethodName> = z.input<
+  (typeof COACH_RPC_METHOD_REGISTRY)[K]["requestSchema"]
+>;
+export type CoachRpcResponse<K extends CoachRpcMethodName> = z.output<
+  (typeof COACH_RPC_METHOD_REGISTRY)[K]["responseSchema"]
+>;
+export type CoachRpcEvent<K extends CoachRpcMethodName> = z.output<
+  (typeof COACH_RPC_METHOD_REGISTRY)[K]["eventSchema"]
+>;
+
+type Assert<T extends true> = T;
+type IsNever<T> = [T] extends [never] ? true : false;
+type NonChatEventsAreNever = Assert<IsNever<CoachRpcEvent<Exclude<CoachRpcMethodName, "chat">>>>;

--- a/packages/coach-contract/src/turn-event.ts
+++ b/packages/coach-contract/src/turn-event.ts
@@ -17,6 +17,7 @@ export const AgentErrorKindSchema = z.enum([
   "provider-down",
   "intervals",
   "unknown",
+  "detached",
 ]);
 export type AgentErrorKind = z.infer<typeof AgentErrorKindSchema>;
 

--- a/packages/coach-contract/tests/wire-contract.test.ts
+++ b/packages/coach-contract/tests/wire-contract.test.ts
@@ -1,0 +1,361 @@
+import { describe, expect, it } from "vitest";
+import {
+  AgentErrorKindSchema,
+  AthleteStateSchema,
+  COACH_RPC_METHOD_NAMES,
+  COACH_RPC_METHOD_REGISTRY,
+  COACH_TURN_EVENT_NOTIFICATION_METHOD,
+  ChatResponseSchema,
+  ChatRpcParamsSchema,
+  ClientHandshakeFrameSchema,
+  CoachRpcEnvelopeSchema,
+  CoachRpcRequestEnvelopeSchema,
+  CoachTurnEventNotificationEnvelopeSchema,
+  DaemonOwnerSchema,
+  EmptyRpcParamsSchema,
+  HasSessionRequestSchema,
+  HasSessionResponseSchema,
+  JsonRpcErrorResponseEnvelopeSchema,
+  JsonRpcProtocolErrorResponseEnvelopeSchema,
+  JsonRpcResponseEnvelopeSchema,
+  JsonRpcSuccessResponseEnvelopeSchema,
+  NoRpcEventSchema,
+  PROTOCOL_VERSION,
+  ResetSessionRequestSchema,
+  ResetSessionResponseSchema,
+  ServerHandshakeFrameSchema,
+  TurnEventSchema,
+  compareProtocolVersions,
+  createAcceptedServerHandshakeFrame,
+  createClientHandshakeFrame,
+  createVersionMismatchServerHandshakeFrame,
+  parseCoachRpcEnvelope,
+  serializeCoachRpcEnvelope,
+  type CoachEngine,
+  type CoachRpcEnvelope,
+} from "../src/index.js";
+
+const turnEvent = {
+  type: "turn-start",
+  turnId: "turn-1",
+  chatId: "chat-1",
+} as const;
+
+const notification = {
+  jsonrpc: "2.0",
+  method: COACH_TURN_EVENT_NOTIFICATION_METHOD,
+  params: {
+    requestId: 1,
+    requestMethod: "chat",
+    turnId: "turn-1",
+    event: turnEvent,
+  },
+} as const;
+
+function roundTrip(value: unknown): CoachRpcEnvelope {
+  const serialized = serializeCoachRpcEnvelope(value);
+  expect(serialized.endsWith("\n")).toBe(false);
+  const first = parseCoachRpcEnvelope(serialized);
+  const second = parseCoachRpcEnvelope(serializeCoachRpcEnvelope(first));
+  expect(second).toEqual(first);
+  return second;
+}
+
+describe("JSON-RPC envelopes", () => {
+  it("round trips requests, successes, ordinary errors, protocol errors, and notifications", () => {
+    const values = [
+      { jsonrpc: "2.0", id: 1, method: "chat", params: { chatId: "chat-1", message: "hello" } },
+      { jsonrpc: "2.0", id: 1, result: { text: "hello" } },
+      { jsonrpc: "2.0", id: 1, error: { code: -32600, message: "invalid request" } },
+      { jsonrpc: "2.0", id: null, error: { code: -32700, message: "parse error" } },
+      { jsonrpc: "2.0", id: null, error: { code: -32600, message: "invalid request" } },
+      notification,
+    ];
+    for (const value of values) expect(roundTrip(value)).toEqual(value);
+  });
+
+  it("keeps null ids exclusive to the two unrecoverable protocol errors", () => {
+    expect(
+      JsonRpcErrorResponseEnvelopeSchema.safeParse({
+        jsonrpc: "2.0",
+        id: 1,
+        error: { code: -32700, message: "parse error" },
+      }).success,
+    ).toBe(false);
+    expect(
+      JsonRpcSuccessResponseEnvelopeSchema.safeParse({
+        jsonrpc: "2.0",
+        id: null,
+        result: {},
+      }).success,
+    ).toBe(false);
+    expect(
+      JsonRpcProtocolErrorResponseEnvelopeSchema.safeParse({
+        jsonrpc: "2.0",
+        id: null,
+        error: { code: -32000, message: "foreign" },
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects malformed JSON, missing and extra keys, invalid ids, and mixed terminals", () => {
+    expect(() => parseCoachRpcEnvelope("{")).toThrow();
+    const invalid = [
+      { jsonrpc: "2.0", id: 1, method: "chat" },
+      { jsonrpc: "2.0", id: 1, method: "chat", params: {}, extra: true },
+      { jsonrpc: "2.0", id: "", method: "chat", params: {} },
+      { jsonrpc: "2.0", id: -1, method: "chat", params: {} },
+      { jsonrpc: "2.0", id: 1.5, method: "chat", params: {} },
+      { jsonrpc: "2.0", id: Number.MAX_SAFE_INTEGER + 1, method: "chat", params: {} },
+      { jsonrpc: "2.0", id: 1, result: {}, error: { code: 1, message: "mixed" } },
+      { ...notification, id: 1 },
+    ];
+    for (const value of invalid)
+      expect(CoachRpcEnvelopeSchema.safeParse(value).success).toBe(false);
+  });
+
+  it("rejects non-JSON payload values", () => {
+    const invalid = [undefined, () => undefined, Symbol("x"), 1n, NaN, Infinity, -Infinity];
+    for (const value of invalid) {
+      expect(
+        JsonRpcResponseEnvelopeSchema.safeParse({ jsonrpc: "2.0", id: 1, result: value }).success,
+      ).toBe(false);
+      expect(() =>
+        serializeCoachRpcEnvelope({
+          jsonrpc: "2.0",
+          id: 1,
+          error: { code: 1, message: "x", data: value },
+        }),
+      ).toThrow();
+    }
+  });
+});
+
+describe("coach request and event projection", () => {
+  it("admits exactly the four strict method requests", () => {
+    const requests = [
+      { jsonrpc: "2.0", id: 1, method: "chat", params: { chatId: "chat-1", message: "hello" } },
+      { jsonrpc: "2.0", id: 2, method: "resetSession", params: { chatId: "chat-1" } },
+      { jsonrpc: "2.0", id: 3, method: "hasSession", params: { chatId: "chat-1" } },
+      { jsonrpc: "2.0", id: 4, method: "getAthleteState", params: {} },
+    ];
+    for (const request of requests)
+      expect(CoachRpcRequestEnvelopeSchema.parse(request)).toEqual(request);
+    expect(
+      CoachRpcRequestEnvelopeSchema.safeParse({ jsonrpc: "2.0", id: 4, method: "getAthleteState" })
+        .success,
+    ).toBe(false);
+    expect(
+      CoachRpcRequestEnvelopeSchema.safeParse({
+        jsonrpc: "2.0",
+        id: 4,
+        method: "getAthleteState",
+        params: { chatId: "x" },
+      }).success,
+    ).toBe(false);
+    expect(
+      CoachRpcRequestEnvelopeSchema.safeParse({
+        jsonrpc: "2.0",
+        id: 5,
+        method: "analyze",
+        params: {},
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects every nested non-JSON resolvedCs value at every wire boundary", () => {
+    const values = [() => undefined, Symbol("x"), undefined, 1n, NaN, Infinity, -Infinity];
+    for (const value of values) {
+      const params = {
+        chatId: "chat-1",
+        message: "hello",
+        turn: { resolvedCs: { nested: value } },
+      };
+      const request = { jsonrpc: "2.0", id: 1, method: "chat", params };
+      expect(ChatRpcParamsSchema.safeParse(params).success).toBe(false);
+      expect(CoachRpcRequestEnvelopeSchema.safeParse(request).success).toBe(false);
+      expect(CoachRpcEnvelopeSchema.safeParse(request).success).toBe(false);
+      expect(() => serializeCoachRpcEnvelope(request)).toThrow();
+    }
+  });
+
+  it("binds notification request and turn identifiers", () => {
+    expect(CoachTurnEventNotificationEnvelopeSchema.parse(notification)).toEqual(notification);
+    expect(
+      CoachTurnEventNotificationEnvelopeSchema.safeParse({
+        ...notification,
+        params: { ...notification.params, turnId: "turn-2" },
+      }).success,
+    ).toBe(false);
+    expect(
+      CoachTurnEventNotificationEnvelopeSchema.safeParse({
+        ...notification,
+        params: { ...notification.params, requestMethod: "hasSession" },
+      }).success,
+    ).toBe(false);
+  });
+
+  it("keeps the method registry exhaustive and schema-identical", async () => {
+    const fake: CoachEngine = {
+      chat: async () => ({ text: "ok" }),
+      resetSession: async () => ({ memoryFlushed: true }),
+      hasSession: async () => ({ hasSession: false }),
+      getAthleteState: async () =>
+        AthleteStateSchema.parse({
+          schemaVersion: "1",
+          lastUpdated: "2020-01-01T00:00:00.000Z",
+          freshness: "fresh",
+          degraded: false,
+          lastSynced: null,
+          athleteProfile: {},
+          currentStatus: {},
+          derivedMetrics: {},
+          recentActivities: [],
+          plannedWorkouts: [],
+          wellness: {},
+        }),
+    };
+    expect(Object.keys(COACH_RPC_METHOD_REGISTRY)).toEqual(Object.keys(fake));
+    expect(COACH_RPC_METHOD_NAMES).toEqual(Object.keys(fake));
+    expect(COACH_RPC_METHOD_REGISTRY.chat).toEqual({
+      wireName: "chat",
+      requestSchema: ChatRpcParamsSchema,
+      responseSchema: ChatResponseSchema,
+      eventSchema: TurnEventSchema,
+    });
+    expect(COACH_RPC_METHOD_REGISTRY.resetSession).toEqual({
+      wireName: "resetSession",
+      requestSchema: ResetSessionRequestSchema,
+      responseSchema: ResetSessionResponseSchema,
+      eventSchema: NoRpcEventSchema,
+    });
+    expect(COACH_RPC_METHOD_REGISTRY.hasSession).toEqual({
+      wireName: "hasSession",
+      requestSchema: HasSessionRequestSchema,
+      responseSchema: HasSessionResponseSchema,
+      eventSchema: NoRpcEventSchema,
+    });
+    expect(COACH_RPC_METHOD_REGISTRY.getAthleteState).toEqual({
+      wireName: "getAthleteState",
+      requestSchema: EmptyRpcParamsSchema,
+      responseSchema: AthleteStateSchema,
+      eventSchema: NoRpcEventSchema,
+    });
+    for (const method of ["resetSession", "hasSession", "getAthleteState"] as const) {
+      expect(COACH_RPC_METHOD_REGISTRY[method].eventSchema.safeParse(undefined).success).toBe(
+        false,
+      );
+      expect(COACH_RPC_METHOD_REGISTRY[method].eventSchema.safeParse({}).success).toBe(false);
+    }
+    await expect(fake.chat({ chatId: "chat-1", message: "hello" })).resolves.toEqual({
+      text: "ok",
+    });
+  });
+});
+
+describe("handshake", () => {
+  it("round trips client, accepted, and both mismatch directions", () => {
+    const client = createClientHandshakeFrame("synthetic-test-token");
+    expect(ClientHandshakeFrameSchema.parse(JSON.parse(JSON.stringify(client)))).toEqual(client);
+    const accepted = createAcceptedServerHandshakeFrame("service-managed", 1);
+    expect(ServerHandshakeFrameSchema.parse(JSON.parse(JSON.stringify(accepted)))).toEqual(
+      accepted,
+    );
+    const older = createVersionMismatchServerHandshakeFrame("ephemeral-client-started", 1, 2);
+    const newer = createVersionMismatchServerHandshakeFrame("unmanaged-foreground", 3, 2);
+    expect(ServerHandshakeFrameSchema.parse(older)).toEqual(older);
+    expect(ServerHandshakeFrameSchema.parse(newer)).toEqual(newer);
+  });
+
+  it("rejects invalid token and fail-open handshake shapes", () => {
+    const invalid = [
+      { type: "handshake", clientProtocolVersion: 1 },
+      { type: "handshake", token: "", clientProtocolVersion: 1 },
+      { type: "handshake", token: "x", clientProtocolVersion: 1, extra: true },
+    ];
+    for (const frame of invalid)
+      expect(ClientHandshakeFrameSchema.safeParse(frame).success).toBe(false);
+    const serverInvalid = [
+      {
+        type: "handshake",
+        status: "accepted",
+        clientProtocolVersion: 1,
+        serverProtocolVersion: 2,
+        owner: "service-managed",
+      },
+      {
+        type: "handshake",
+        status: "version-mismatch",
+        clientProtocolVersion: 2,
+        serverProtocolVersion: 2,
+        direction: "client-older",
+        owner: "service-managed",
+      },
+      {
+        type: "handshake",
+        status: "version-mismatch",
+        clientProtocolVersion: 1,
+        serverProtocolVersion: 2,
+        direction: "client-newer",
+        owner: "service-managed",
+      },
+      {
+        type: "handshake",
+        status: "future",
+        clientProtocolVersion: 1,
+        serverProtocolVersion: 1,
+        owner: "service-managed",
+      },
+      {
+        type: "handshake",
+        status: "accepted",
+        clientProtocolVersion: 1,
+        serverProtocolVersion: 1,
+        owner: "app-supervised",
+      },
+      {
+        type: "handshake",
+        status: "accepted",
+        clientProtocolVersion: 1,
+        serverProtocolVersion: 1,
+        owner: "service-managed",
+        extra: true,
+      },
+    ];
+    for (const frame of serverInvalid)
+      expect(ServerHandshakeFrameSchema.safeParse(frame).success).toBe(false);
+  });
+
+  it("pins the closed owner enum and independent comparison truth table", () => {
+    expect(DaemonOwnerSchema.options).toEqual([
+      "service-managed",
+      "ephemeral-client-started",
+      "unmanaged-foreground",
+    ]);
+    expect(compareProtocolVersions(1, 2)).toBe("client-older");
+    expect(compareProtocolVersions(2, 2)).toBe("equal");
+    expect(compareProtocolVersions(3, 2)).toBe("client-newer");
+    expect(() => createAcceptedServerHandshakeFrame("service-managed", 1, 2)).toThrow();
+    expect(() => createVersionMismatchServerHandshakeFrame("service-managed", 2, 2)).toThrow();
+  });
+});
+
+describe("additive protocol signals", () => {
+  it("keeps all existing error kinds and adds detached only", () => {
+    for (const kind of [
+      "rate_limit",
+      "provider-auth",
+      "provider-down",
+      "intervals",
+      "unknown",
+      "detached",
+    ] as const) {
+      expect(AgentErrorKindSchema.parse(kind)).toBe(kind);
+    }
+    expect(AgentErrorKindSchema.safeParse("aborted").success).toBe(false);
+  });
+
+  it("keeps protocol version one", () => {
+    expect(PROTOCOL_VERSION).toBe(1);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,6 +133,31 @@ importers:
         specifier: ^4.1.4
         version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.8(vitest@4.1.5))(msw@2.14.2(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))
 
+  packages/coach-client:
+    dependencies:
+      '@enduragent/coach-contract':
+        specifier: workspace:*
+        version: link:../coach-contract
+    devDependencies:
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.6.0
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
+      tsup:
+        specifier: ^8.4.0
+        version: 8.5.1(postcss@8.5.12)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.3)
+      typescript:
+        specifier: ^6.0.2
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.4
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.8(vitest@4.1.5))(msw@2.14.2(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))
+      ws:
+        specifier: ^8.20.0
+        version: 8.20.0
+
   packages/coach-contract:
     dependencies:
       zod:
@@ -1441,6 +1466,9 @@ packages:
 
   '@types/statuses@2.0.6':
     resolution: {integrity: sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@vercel/oidc@3.2.0':
     resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
@@ -3248,6 +3276,10 @@ snapshots:
       '@types/node': 25.6.0
 
   '@types/statuses@2.0.6': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 25.6.0
 
   '@vercel/oidc@3.2.0': {}
 

--- a/tools/check-package-deps.test.ts
+++ b/tools/check-package-deps.test.ts
@@ -50,6 +50,8 @@ const rEngine = ruleForDir("packages/engine");
 const rCore = ruleForDir("packages/core");
 const r4 = ruleForDir("packages/sport-*");
 const r5 = ruleForDir("packages/sync-*");
+const rCoachCli = ruleForDir("packages/coach-cli");
+const rCoachClient = ruleForDir("packages/coach-client");
 const rRenderer = ruleForDir("apps/desktop-renderer");
 const rCoach = ruleForDir("packages/coach");
 const rBin = ruleForDir("packages/cycling-coach");
@@ -256,6 +258,80 @@ describe("R6 desktop renderer", () => {
   });
 });
 
+describe("R6 coach client", () => {
+  it("allows only globals, relative modules, and the contract in source and runtime manifest", () => {
+    write(
+      "packages/coach-client/src/ok.ts",
+      `import type { CoachEngine } from "@enduragent/coach-contract";\nimport { local } from "./local.js";\nexport const socket: WebSocket | null = null;\nexport const signal: AbortSignal | null = null;\nexport const timer = setTimeout;\nexport const value: CoachEngine | null = local;\n`,
+    );
+    write("packages/coach-client/src/local.ts", `export const local = null;\n`);
+    writeJson("packages/coach-client/package.json", {
+      name: "@enduragent/coach-client",
+      private: true,
+      dependencies: { "@enduragent/coach-contract": "workspace:*" },
+    });
+    expect(violationsFor(rCoachClient)).toBe(0);
+  });
+
+  it.each([
+    [`import value from "ws";\nexport { value };\n`, "ws"],
+    [`import type { Config } from 'other-external';\nexport const value: Config | null = null;\n`, "other-external"],
+    [`import 'ws';\n`, "ws"],
+    [`export { value } from 'other-external';\n`, "other-external"],
+    [`export const value = import("ws");\n`, "ws"],
+    [`declare const require: (name: string) => unknown;\nexport const value = require('other-external');\n`, "other-external"],
+    [`import { readFileSync } from "node:fs";\nexport { readFileSync };\n`, "node:fs"],
+    [`import fs from 'fs';\nexport { fs };\n`, "fs"],
+  ])("rejects closed source import form for %s", (source, specifier) => {
+    write("packages/coach-client/src/bad.ts", source);
+    writeJson("packages/coach-client/package.json", {
+      name: "@enduragent/coach-client",
+      private: true,
+    });
+    const result = runRulesAgainst(tempDir, [rCoachClient]);
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0]!.specifier).toBe(specifier);
+  });
+
+  it("rejects an external runtime manifest dependency", () => {
+    write("packages/coach-client/src/ok.ts", `export const value = 1;\n`);
+    writeJson("packages/coach-client/package.json", {
+      name: "@enduragent/coach-client",
+      private: true,
+      dependencies: {
+        "@enduragent/coach-contract": "workspace:*",
+        ws: "^8.20.0",
+      },
+    });
+    const result = runRulesAgainst(tempDir, [rCoachClient]);
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0]!.specifier).toBe("ws");
+  });
+});
+
+describe("R6 coach CLI", () => {
+  it("allows contract and client while rejecting engine, kernel, and coach", () => {
+    write(
+      "packages/coach-cli/src/ok.ts",
+      `import { contract } from "@enduragent/coach-contract";\nimport { client } from "@enduragent/coach-client";\nexport const value = contract ?? client;\n`,
+    );
+    writeJson("packages/coach-cli/package.json", {
+      name: "@enduragent/coach-cli",
+      private: true,
+      dependencies: {
+        "@enduragent/coach-contract": "workspace:*",
+        "@enduragent/coach-client": "workspace:*",
+      },
+    });
+    expect(violationsFor(rCoachCli)).toBe(0);
+
+    for (const specifier of ["@enduragent/engine", "@enduragent/kernel", "@enduragent/coach"]) {
+      write("packages/coach-cli/src/bad.ts", `import value from "${specifier}";\nexport { value };\n`);
+      expect(runRulesAgainst(tempDir, [rCoachCli]).violations.some((violation) => violation.specifier === specifier)).toBe(true);
+    }
+  });
+});
+
 describe("R7 private-package check", () => {
   it("R7 flags an @enduragent package without private:true", () => {
     writeJson("packages/leaky/package.json", { name: "@enduragent/leaky" });
@@ -343,6 +419,7 @@ describe("real repository", () => {
   it("activates engine without making end-state discovery vacuous", () => {
     const result = runRulesAgainst(".", RULES);
     expect(result.notPresent).not.toContain("packages/engine");
+    expect(result.notPresent).not.toContain("packages/coach-client");
     expect(result.notPresent).not.toContain("packages/sync-*");
     expect(result.scannedFileCount).toBeGreaterThan(0);
   });

--- a/tools/check-package-deps.ts
+++ b/tools/check-package-deps.ts
@@ -46,6 +46,7 @@ export interface PackageDepRule {
   readonly srcOnly: boolean;
   readonly allowedWorkspace: readonly string[];
   readonly allowedManifestWorkspace?: readonly string[];
+  readonly allowedExternal?: readonly string[];
   readonly transitionalWorkspace: readonly string[];
   readonly forbidNode: boolean;
 }
@@ -121,9 +122,18 @@ export const RULES: readonly PackageDepRule[] = [
     ruleId: "R6",
     dir: "packages/coach-cli",
     srcOnly: true,
-    allowedWorkspace: ["@enduragent/coach-contract"],
+    allowedWorkspace: ["@enduragent/coach-contract", "@enduragent/coach-client"],
     transitionalWorkspace: [],
     forbidNode: false,
+  },
+  {
+    ruleId: "R6",
+    dir: "packages/coach-client",
+    srcOnly: true,
+    allowedWorkspace: ["@enduragent/coach-contract"],
+    transitionalWorkspace: [],
+    allowedExternal: [],
+    forbidNode: true,
   },
   {
     ruleId: "R6",
@@ -400,15 +410,31 @@ export function runRulesAgainst(root: string, rules: readonly PackageDepRule[]):
             }
             continue;
           }
-          if (!spec.startsWith(WORKSPACE_SCOPE)) continue;
-          const isSelfReference = packageRoot(spec) === packageName;
-          if (isSelfReference) {
-            const exportKey = spec === packageName ? null : `.${spec.slice(packageName.length)}`;
-            const isDeclaredPublicSubpath =
-              exportKey !== null &&
-              Object.prototype.hasOwnProperty.call(packageExports, exportKey) &&
-              packageExports[exportKey] !== null;
-            if (isDeclaredPublicSubpath) continue;
+          if (spec.startsWith(WORKSPACE_SCOPE)) {
+            const isSelfReference = packageRoot(spec) === packageName;
+            if (isSelfReference) {
+              const exportKey = spec === packageName ? null : `.${spec.slice(packageName.length)}`;
+              const isDeclaredPublicSubpath =
+                exportKey !== null &&
+                Object.prototype.hasOwnProperty.call(packageExports, exportKey) &&
+                packageExports[exportKey] !== null;
+              if (isDeclaredPublicSubpath) continue;
+              violations.push({
+                file,
+                line: ref.line,
+                column: ref.column,
+                ruleId: rule.ruleId,
+                specifier: spec,
+                pkg: dir,
+              });
+              continue;
+            }
+            const verdict = classifySourceWorkspace(spec, rule);
+            if (verdict === "allowed") continue;
+            if (verdict === "transitional") {
+              recordWarn(dir, packageRoot(spec));
+              continue;
+            }
             violations.push({
               file,
               line: ref.line,
@@ -419,10 +445,11 @@ export function runRulesAgainst(root: string, rules: readonly PackageDepRule[]):
             });
             continue;
           }
-          const verdict = classifySourceWorkspace(spec, rule);
-          if (verdict === "allowed") continue;
-          if (verdict === "transitional") {
-            recordWarn(dir, packageRoot(spec));
+          if (spec.startsWith("./") || spec.startsWith("../")) continue;
+          if (
+            rule.allowedExternal === undefined ||
+            rule.allowedExternal.some((entry) => matchesEntry(spec, entry))
+          ) {
             continue;
           }
           violations.push({
@@ -439,13 +466,27 @@ export function runRulesAgainst(root: string, rules: readonly PackageDepRule[]):
       // (2) Manifest check over declared runtime dependency edges.
       const manifestFile = join(dir, "package.json");
       for (const { name } of deps) {
-        if (!name.startsWith(WORKSPACE_SCOPE)) continue;
-        const verdict = classifyManifestWorkspace(name, rule);
-        if (verdict === "allowed") continue;
-        if (verdict === "transitional") {
-          recordWarn(dir, packageRoot(name));
+        if (name.startsWith(WORKSPACE_SCOPE)) {
+          const verdict = classifyManifestWorkspace(name, rule);
+          if (verdict === "allowed") continue;
+          if (verdict === "transitional") {
+            recordWarn(dir, packageRoot(name));
+            continue;
+          }
+          violations.push({
+            file: manifestFile,
+            line: 1,
+            column: 1,
+            ruleId: rule.ruleId,
+            specifier: name,
+            pkg: dir,
+          });
           continue;
         }
+        if (
+          rule.allowedExternal === undefined ||
+          rule.allowedExternal.some((entry) => matchesEntry(name, entry))
+        ) continue;
         violations.push({
           file: manifestFile,
           line: 1,


### PR DESCRIPTION
## Summary

Lands the daemon wire contract and the browser-safe client runtime:

- `coach-contract`: `rpc.ts` (JSON-RPC 2.0 envelope schemas, strict parse/serialize, four-method registry, notification correlation, null-id protocol-error envelope) and `handshake.ts` (closed owner enum, protocol version fields, fail-closed discriminated union); additive `detached` error kind.
- NEW `@enduragent/coach-client` (R6, browser-safe, `forbidNode` dependency closure): transport resolution (Node-vs-browser WebSocket), first-frame handshake binding, typed errors, bounded FIFO backpressure, fail-closed receive handling, and per-call `onNotificationEnvelope` / `onTerminalEnvelope` observers (validated parses only; terminal-before-settlement; no fire on connection-wide failures).
- `tools/check-package-deps.ts`: closed coach-client R6 rule plus the declarative coach-cli client edge.

## Verification

- Contract wire suite and client injected-transport suite (56 tests) green; real-loopback case verified in the root gate.
- Package/contract dependency gates green; public-export smoke green.
- Root `pnpm build`, `pnpm check`, full `pnpm test` green after rebase over the executable and launchd PRs.
