### PR TITLE
feat(engine): stream chat replies with delta validation

### DIFF
--- a/.changeset/stream-chat-replies.md
+++ b/.changeset/stream-chat-replies.md
@@ -1,0 +1,5 @@
+---
+"cycling-coach": patch
+---
+
+Activate progressive chat events inside the Engine while preserving background generation and per-model-call usage accounting. Rendering remains owned by later CLI and desktop consumers.

--- a/packages/coach/tests/coach-engine-adapter.test.ts
+++ b/packages/coach/tests/coach-engine-adapter.test.ts
@@ -145,6 +145,62 @@ describe("coach engine adapter", () => {
     await expect(malformed.chat({ chatId: "x", message: "x" })).rejects.toThrow();
   });
 
+  it("validates every text_delta before advisory delivery and latches malformed deltas", async () => {
+    const received: TurnEvent[] = [];
+    const valid = createCoachEngineAdapter({
+      backend: backend({
+        chat: async (_request, onEvent) => {
+          onEvent?.({ type: "text_delta", turnId: "turn-1", delta: "one" });
+          onEvent?.({ type: "text_delta", turnId: "turn-1", delta: " two" });
+          return { text: "one two" };
+        },
+      }),
+      getAthleteState: async () => state,
+      cyclingFtpAnchorResolver: resolver().value,
+      now: () => 0,
+    });
+    await expect(
+      valid.chat({ chatId: "x", message: "x" }, (event) => received.push(event)),
+    ).resolves.toEqual({ text: "one two" });
+    expect(received).toEqual([
+      { type: "text_delta", turnId: "turn-1", delta: "one" },
+      { type: "text_delta", turnId: "turn-1", delta: " two" },
+    ]);
+
+    const malformedDelta = {
+      type: "text_delta",
+      turnId: "turn-1",
+      delta: 1,
+      extra: true,
+    } as unknown as TurnEvent;
+    const malformed = createCoachEngineAdapter({
+      backend: backend({
+        chat: async (_request, onEvent) => {
+          expect(() => onEvent?.(malformedDelta)).not.toThrow();
+          return { text: "ok" };
+        },
+      }),
+      getAthleteState: async () => state,
+      cyclingFtpAnchorResolver: resolver().value,
+      now: () => 0,
+    });
+    await expect(malformed.chat({ chatId: "x", message: "x" })).rejects.toThrow();
+
+    const backendError = new Error("backend wins");
+    const precedence = createCoachEngineAdapter({
+      backend: backend({
+        chat: async (_request, onEvent) => {
+          onEvent?.(malformedDelta);
+          throw backendError;
+        },
+      }),
+      getAthleteState: async () => state,
+      cyclingFtpAnchorResolver: resolver().value,
+      now: () => 0,
+    });
+    await expect(precedence.chat({ chatId: "x", message: "x" })).rejects.toBe(backendError);
+  });
+
   it("strictly validates reset requests and responses", async () => {
     const resetSession = vi.fn<CoachEngine["resetSession"]>(async () => ({ memoryFlushed: true }));
     const engine = createCoachEngineAdapter({

--- a/packages/core/tests/usage-ledger.test.ts
+++ b/packages/core/tests/usage-ledger.test.ts
@@ -206,14 +206,37 @@ describe("appendUsageLine", () => {
 });
 
 describe("LLM.generate — AI-SDK path", () => {
+  function streamed(stub: Record<string, unknown>) {
+    return {
+      fullStream: (async function* () {
+        if (typeof stub.text === "string" && stub.text !== "") {
+          yield { type: "text-delta", id: "text-1", text: stub.text };
+        }
+        yield {
+          type: "finish",
+          finishReason: stub.finishReason,
+          rawFinishReason: stub.finishReason,
+          totalUsage: stub.totalUsage,
+        };
+      })(),
+      text: Promise.resolve(stub.text),
+      toolCalls: Promise.resolve(stub.toolCalls),
+      finishReason: Promise.resolve(stub.finishReason),
+      usage: Promise.resolve(stub.usage),
+      totalUsage: Promise.resolve(stub.totalUsage),
+      steps: Promise.resolve(stub.steps),
+    };
+  }
+
   async function loadLLMWithGenerateText(stub: Record<string, unknown>) {
     const generateText = vi.fn(async () => stub);
+    const streamText = vi.fn(() => streamed(stub));
     vi.doMock("ai", async () => {
       const actual = await vi.importActual<typeof import("ai")>("ai");
-      return { ...actual, generateText };
+      return { ...actual, generateText, streamText };
     });
     const { LLM } = await import("../../engine/src/llm.js");
-    return { LLM, generateText };
+    return { LLM, generateText, streamText };
   }
 
   it("returns whole-turn totalUsage and the step count from the SDK result", async () => {

--- a/packages/engine/src/agent/coach-agent.ts
+++ b/packages/engine/src/agent/coach-agent.ts
@@ -2,6 +2,7 @@ import { stepCountIs } from "ai";
 import type { FinishReason, ModelMessage, Tool, ToolSet } from "ai";
 import { retryWithBackoff } from "@enduragent/kernel/concurrency";
 import type { ResolvedCs } from "@enduragent/kernel/reference/cs-resolution";
+import type { TurnEvent, TurnEventHandler } from "@enduragent/coach-contract";
 import type {
   ChatStorePort,
   EngineConfig,
@@ -129,10 +130,12 @@ interface TurnOutcome {
   compactions: number;
 }
 
+type ClassifiedTurnFailure = ReturnType<EngineHostPorts["classifyFailure"]> | "budget";
+
 function classifyError(
   err: unknown,
   classifyFailure: EngineHostPorts["classifyFailure"],
-): string {
+): ClassifiedTurnFailure {
   // TurnBudgetExceededError crosses a dynamic-import boundary in tests, so match
   // on the structural name rather than instanceof.
   if (err instanceof Error && err.name === "TurnBudgetExceededError") return "budget";
@@ -350,6 +353,7 @@ export class CoachAgent {
     messages: ModelMessage[],
     cacheKey: string,
     turnBudget: TurnBudget,
+    onTextDelta: (delta: string) => void,
   ): Promise<string> {
     if (!isStepExhaustedEmpty(text, finishReason)) return text;
     // Charge OUTSIDE the recovery try/catch: a TurnBudgetExceededError is
@@ -364,6 +368,7 @@ export class CoachAgent {
         caller: "chat",
         cacheKey,
         deadlineMs: turnBudget.remainingMs(),
+        onTextDelta,
       });
       return recovery.text.trim() !== "" ? recovery.text : STEP_LIMIT_TRUNCATION_MESSAGE;
     } catch (recoveryErr) {
@@ -397,6 +402,7 @@ export class CoachAgent {
     chatId: string,
     userMessage: string,
     turn?: { resolvedCs?: ResolvedCs | null },
+    onEvent?: TurnEventHandler,
   ): Promise<string> {
     // One explicit context per turn, created synchronously before the session
     // lock is queued so rapid same-chat sends can never share turn state. Tool
@@ -407,6 +413,13 @@ export class CoachAgent {
     return withSessionLock(chatId, async () => {
       const turnStart = this.ports.now();
       const turnId = this.ports.randomId();
+      const emitEvent = (event: TurnEvent): void => {
+        try {
+          onEvent?.(event);
+        } catch {
+          return;
+        }
+      };
       let compactions = 0;
       const turnBudget = createTurnBudget(this.ports.now);
       // One flush per turn: the latch flips on entry (before the await
@@ -547,6 +560,7 @@ export class CoachAgent {
       let plainTimeoutAttempts = 0;
       let rateLimitAttempts = 0;
       let serverErrorAttempts = 0;
+      let classifiedTerminalFailure: ClassifiedTurnFailure | undefined;
 
       // Loop-invariant: the prompt cache key derives only from the chat id.
       const cacheKey = sha256_16(chatId);
@@ -574,6 +588,13 @@ export class CoachAgent {
             this.memory.reload();
           }
 
+          let attemptObservedText = false;
+          classifiedTerminalFailure = undefined;
+          const onAttemptTextDelta = (delta: string): void => {
+            attemptObservedText = true;
+            emitEvent({ type: "text_delta", turnId, delta });
+          };
+
           try {
             turnBudget.chargeModelCall();
             const result = await this.llm.generate({
@@ -588,6 +609,7 @@ export class CoachAgent {
               // Cap this call by the turn's remaining wall-clock budget so a retry
               // after an early timeout inherits only the time the turn has left.
               deadlineMs: turnBudget.remainingMs(),
+              onTextDelta: onAttemptTextDelta,
             });
             const { text, finishReason } = result;
 
@@ -598,6 +620,7 @@ export class CoachAgent {
               messages,
               cacheKey,
               turnBudget,
+              onAttemptTextDelta,
             );
 
             const templateHash = (this.templateHash ??= computeTemplateHash({
@@ -654,7 +677,9 @@ export class CoachAgent {
               compactions,
             });
 
-            return effectiveText + persistenceNote;
+            const responseText = effectiveText + persistenceNote;
+            emitEvent({ type: "final-text", turnId, text: responseText });
+            return responseText;
           } catch (err) {
             // The classified budget error is terminal: re-throw it before any
             // retry branch so a future reordering can never mistake it for one of
@@ -664,6 +689,7 @@ export class CoachAgent {
             // would re-send the pre-turn messages and could re-run the write.
             const committedWrites = ctx.turnWrites;
             if (committedWrites.writesCommitted > 0) {
+              const failure = classifyError(err, this.ports.classifyFailure);
               console.warn(
                 JSON.stringify({
                   event: "turn_failed_after_write",
@@ -676,17 +702,32 @@ export class CoachAgent {
                 turnId,
                 chatId,
                 ok: false,
-                error_class: classifyError(err, this.ports.classifyFailure),
+                error_class: failure,
                 overflowAttempts,
                 timeoutAttempts,
                 rateLimitAttempts,
                 duration_ms: this.ports.now() - turnStart,
                 compactions,
               });
+              emitEvent(
+                this.createErrorEvent({
+                  failure,
+                  turnId,
+                  chatId,
+                  overflowAttempts,
+                  timeoutAttempts,
+                  rateLimitAttempts,
+                  durationMs: this.ports.now() - turnStart,
+                  compactions,
+                }),
+              );
+              emitEvent({ type: "final-text", turnId, text: TAINTED_BY_WRITES_MESSAGE });
               return TAINTED_BY_WRITES_MESSAGE;
             }
+            if (attemptObservedText) throw err;
+            const failure = this.ports.classifyFailure(err);
             // Reactive: context overflow → flush + compact + retry
-            if (this.ports.classifyFailure(err) === "overflow" && overflowAttempts < MAX_OVERFLOW_ATTEMPTS) {
+            if (failure === "overflow" && overflowAttempts < MAX_OVERFLOW_ATTEMPTS) {
               overflowAttempts++;
               try {
                 if (!flushedThisTurn) {
@@ -705,12 +746,13 @@ export class CoachAgent {
                 if (err instanceof Error && err.cause === undefined) {
                   (err as Error & { cause?: unknown }).cause = rescueErr;
                 }
+                classifiedTerminalFailure = failure;
                 throw err;
               }
               continue;
             }
             // Timeout with high context usage → compact + retry (no flush)
-            if (this.ports.classifyFailure(err) === "timeout" && timeoutAttempts < MAX_TIMEOUT_ATTEMPTS) {
+            if (failure === "timeout" && timeoutAttempts < MAX_TIMEOUT_ATTEMPTS) {
               const ratio = estimateMessagesTokens(messages) / this.config.contextWindowTokens;
               if (ratio > TIMEOUT_COMPACTION_THRESHOLD) {
                 timeoutAttempts++;
@@ -723,6 +765,7 @@ export class CoachAgent {
                   if (err instanceof Error && err.cause === undefined) {
                     (err as Error & { cause?: unknown }).cause = rescueErr;
                   }
+                  classifiedTerminalFailure = failure;
                   throw err;
                 }
                 continue;
@@ -734,7 +777,7 @@ export class CoachAgent {
               }
             }
             // Rate limit → backoff (respect retry-after) + retry
-            if (this.ports.classifyFailure(err) === "rate_limit" && rateLimitAttempts < MAX_RATE_LIMIT_ATTEMPTS) {
+            if (failure === "rate_limit" && rateLimitAttempts < MAX_RATE_LIMIT_ATTEMPTS) {
               rateLimitAttempts++;
               const attemptNo = rateLimitAttempts;
               // The server hint (if any) is a lower bound; absent one, fall back to a
@@ -769,7 +812,6 @@ export class CoachAgent {
             // The residual class: only fires when overflow/timeout/rate_limit did
             // not match, so a single 502 or connection blip no longer kills the
             // turn on attempt 1 and discards paid multi-step tool work.
-            const failure = this.ports.classifyFailure(err);
             // A codex network throw is surfaced as a single attempt and tagged
             // NetworkError by the bridge's normalizeError. We deliberately cap the
             // codex network class at zero outer retries to keep it at exactly one
@@ -796,26 +838,95 @@ export class CoachAgent {
               continue;
             }
             // Rate limit retries exhausted → throw to caller (skip compaction — API is rate limited)
+            classifiedTerminalFailure = failure;
             throw err;
           }
         }
       } catch (terminalErr) {
+        const failure =
+          classifiedTerminalFailure ?? classifyError(terminalErr, this.ports.classifyFailure);
         // Single failure-emit point: every terminal throw out of the loop is one
         // failed turn, so the outcome line fires exactly once before the rethrow.
         this.emitTurnOutcome({
           turnId,
           chatId,
           ok: false,
-          error_class: classifyError(terminalErr, this.ports.classifyFailure),
+          error_class: failure,
           overflowAttempts,
           timeoutAttempts,
           rateLimitAttempts,
           duration_ms: this.ports.now() - turnStart,
           compactions,
         });
+        emitEvent(
+          this.createErrorEvent({
+            failure,
+            turnId,
+            chatId,
+            overflowAttempts,
+            timeoutAttempts,
+            rateLimitAttempts,
+            durationMs: this.ports.now() - turnStart,
+            compactions,
+          }),
+        );
         throw terminalErr;
       }
     });
+  }
+
+  private createErrorEvent(input: {
+    failure: ClassifiedTurnFailure;
+    turnId: string;
+    chatId: string;
+    overflowAttempts: number;
+    timeoutAttempts: number;
+    rateLimitAttempts: number;
+    durationMs: number;
+    compactions: number;
+  }): Extract<TurnEvent, { type: "error" }> {
+    const failure = input.failure;
+    const errorClass =
+      failure === "budget" ||
+      failure === "overflow" ||
+      failure === "timeout" ||
+      failure === "rate_limit"
+        ? failure
+        : "unknown";
+    const presentation =
+      failure === "rate_limit"
+        ? {
+            kind: "rate_limit" as const,
+            athleteMessage: "Rate limited — please try again shortly.",
+          }
+        : failure === "auth"
+          ? {
+              kind: "provider-auth" as const,
+              athleteMessage:
+                "The model provider rejected the API key — check your provider credentials.",
+            }
+          : failure === "server_error" || failure === "network" || failure === "timeout"
+            ? {
+                kind: "provider-down" as const,
+                athleteMessage:
+                  "The model provider is having trouble — try again in a few minutes.",
+              }
+            : {
+                kind: "unknown" as const,
+                athleteMessage: "Sorry, something went wrong. Please try again.",
+              };
+    return {
+      type: "error",
+      turnId: input.turnId,
+      chatId: input.chatId,
+      error_class: errorClass,
+      ...presentation,
+      overflowAttempts: input.overflowAttempts,
+      timeoutAttempts: input.timeoutAttempts,
+      rateLimitAttempts: input.rateLimitAttempts,
+      duration_ms: input.durationMs,
+      compactions: input.compactions,
+    };
   }
 
   hasSession(chatId: string): boolean {

--- a/packages/engine/src/host-ports.ts
+++ b/packages/engine/src/host-ports.ts
@@ -236,6 +236,11 @@ export interface ModelTransport {
 
 export type ModelTransportDecorator = (next: ModelTransport) => ModelTransport;
 
+export interface ChatStreamTimeouts {
+  readonly ttftMs: number;
+  readonly interChunkMs: number;
+}
+
 export interface AthleteStateReaderPort {
   getAthleteState(): Promise<AthleteState>;
 }
@@ -265,6 +270,7 @@ export interface EngineHostPorts {
   readonly extractRetryAfterMs: (error: unknown) => number | null;
   readonly now: () => number;
   readonly randomId: () => string;
+  readonly chatStreamTimeouts?: ChatStreamTimeouts;
   readonly modelTransportDecorator?: ModelTransportDecorator;
   readonly onToolsAssembled?: (names: readonly string[]) => void;
 }

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -6,6 +6,7 @@ import type { Sport } from "./sport.js";
 import type { ResolvedCs } from "@enduragent/kernel/reference/cs-resolution";
 
 export type { CoachEngine } from "@enduragent/coach-contract";
+export type { ChatStreamTimeouts } from "./host-ports.js";
 export type {
   AthleteDataReaderPort,
   AthleteReadResult,
@@ -48,11 +49,12 @@ export interface CreateCoachEngineInput {
 export function createCoachEngine(input: CreateCoachEngineInput): CoachEngine {
   const agent = new CoachAgent(input.sport, input.ports);
   return {
-    chat: async (request) => ({
+    chat: async (request, onEvent) => ({
       text: await agent.chat(
         request.chatId,
         request.message,
         request.turn as { resolvedCs?: ResolvedCs | null } | undefined,
+        onEvent,
       ),
     }),
     resetSession: (request) => agent.resetSession(request.chatId),

--- a/packages/engine/src/llm.ts
+++ b/packages/engine/src/llm.ts
@@ -1,4 +1,4 @@
-import { generateText } from "ai";
+import { generateText, streamText } from "ai";
 import { createAnthropic } from "@ai-sdk/anthropic";
 import { createOpenAI } from "@ai-sdk/openai";
 import { createGoogleGenerativeAI } from "@ai-sdk/google";
@@ -15,14 +15,21 @@ import type {
   EngineConfig,
   EngineHostPorts,
   ModelTransport,
+  ChatStreamTimeouts,
 } from "./host-ports.js";
 import { codexGenerateText } from "./agent/codex-bridge.js";
 import type { GenerateOpts, GenerateResult } from "./llm-types.js";
 import { cacheTokenDetails, usageFieldsFromResult } from "./llm-types.js";
+import type { ModelStreamActivity } from "./sport.js";
 
 export type { GenerateOpts, GenerateResult } from "./llm-types.js";
 export const LLM_CALL_DEADLINE_MS = 300_000;
 export const CHAT_LLM_CALL_DEADLINE_MS = 600_000;
+
+const DEFAULT_CHAT_STREAM_TIMEOUTS: ChatStreamTimeouts = {
+  ttftMs: 30_000,
+  interChunkMs: 30_000,
+};
 
 const PROVIDER_BASE_URLS: Record<string, string> = {
   deepseek: "https://api.deepseek.com/v1",
@@ -35,7 +42,12 @@ const PROVIDER_BASE_URLS: Record<string, string> = {
 
 type LLMHostPorts = Pick<
   EngineHostPorts,
-  "usage" | "now" | "getAccessToken" | "classifyFailure" | "modelTransportDecorator"
+  | "usage"
+  | "now"
+  | "getAccessToken"
+  | "classifyFailure"
+  | "modelTransportDecorator"
+  | "chatStreamTimeouts"
 >;
 
 // ============================================================================
@@ -73,6 +85,7 @@ export class LLM {
   // Instance-constant for the same reason: the cache-breakpoint decision depends
   // only on provider + model, so resolve it once rather than per dispatch().
   private breakpointKey: "anthropic" | "openrouter" | undefined;
+  private chatStreamTimeouts: ChatStreamTimeouts;
 
   constructor(config: EngineConfig, ports: LLMHostPorts) {
     this.config = config;
@@ -80,6 +93,9 @@ export class LLM {
     this.aiSdkModel = config.llm.provider === "openai-codex" ? null : buildAiSdkModel(config);
     this.priced = isPriced(config.llm.provider, config.llm.model);
     this.breakpointKey = cacheBreakpointKey(config.llm.provider, config.llm.model);
+    this.chatStreamTimeouts = validateChatStreamTimeouts(
+      ports.chatStreamTimeouts ?? DEFAULT_CHAT_STREAM_TIMEOUTS,
+    );
     const canonical: ModelTransport = {
       generate: (request) => this.dispatch(request.options),
     };
@@ -95,21 +111,51 @@ export class LLM {
       deadlineMsForCaller(opts.caller),
       opts.deadlineMs ?? Number.POSITIVE_INFINITY,
     );
-    const { signal, deadline } = withLLMDeadline(opts.signal, deadlineMs);
+    const { signal: deadlineSignal, deadline } = withLLMDeadline(opts.signal, deadlineMs);
+    const watchdog =
+      opts.caller === "chat" && this.config.llm.provider !== "openai-codex"
+        ? createChatStreamWatchdog(this.chatStreamTimeouts)
+        : undefined;
+    const signal =
+      watchdog === undefined
+        ? deadlineSignal
+        : AbortSignal.any([deadlineSignal, watchdog.signal]);
+    const handleTextDelta = (delta: string): void => {
+      watchdog?.textDelta(delta);
+      try {
+        opts.onTextDelta?.(delta);
+      } catch {}
+    };
+    const handleStreamActivity = (activity: ModelStreamActivity): void => {
+      watchdog?.activity(activity);
+      try {
+        opts.onStreamActivity?.(activity);
+      } catch {}
+    };
     let result: GenerateResult;
     try {
       result = await this.transport.generate({
         provider: this.config.llm.provider,
         model: this.config.llm.model,
-        options: { ...opts, signal },
+        options: {
+          ...opts,
+          signal,
+          onTextDelta: handleTextDelta,
+          onStreamActivity: handleStreamActivity,
+        },
       });
     } catch (err) {
+      if (watchdog?.error !== undefined && isAbortError(err, watchdog.signal)) {
+        throw watchdog.error;
+      }
       // Relabel to TimeoutError only when OUR per-call timer fired AND the error
       // is abort-shaped: a 5xx/429/network thrown while the timer happens to be
       // aborted must keep its own class, and an outer caller cancellation that
       // never tripped our timer is not our deadline.
       if (deadline.aborted && isAbortError(err, deadline)) throw toTimeoutError(err);
       throw err;
+    } finally {
+      watchdog?.clear();
     }
     const durationMs = this.ports.now() - start;
     this.recordGenerate(opts, result, durationMs);
@@ -118,7 +164,7 @@ export class LLM {
 
   private async dispatch(opts: GenerateOpts): Promise<GenerateResult> {
     if (this.config.llm.provider === "openai-codex") {
-      return await codexGenerateText(
+      const result = await codexGenerateText(
         {
           ...opts,
           modelId: this.config.llm.model,
@@ -130,6 +176,10 @@ export class LLM {
           classifyFailure: this.ports.classifyFailure,
         },
       );
+      if (opts.caller === "chat" && result.text !== "") {
+        notifyTextDelta(opts.onTextDelta, result.text);
+      }
+      return result;
     }
 
     if (!this.aiSdkModel) {
@@ -181,6 +231,67 @@ export class LLM {
       abortSignal: opts.signal,
       experimental_context: opts.context,
     };
+    if (opts.caller === "chat") {
+      const result = opts.prompt !== undefined
+        ? streamText({ ...base, prompt: opts.prompt })
+        : streamText({ ...base, messages });
+      for await (const part of result.fullStream) {
+        switch (part.type) {
+          case "text-delta":
+            if (part.text === "") {
+              notifyStreamActivity(opts.onStreamActivity, { type: "activity" });
+            } else {
+              notifyTextDelta(opts.onTextDelta, part.text);
+            }
+            break;
+          case "tool-call":
+            notifyStreamActivity(opts.onStreamActivity, {
+              type: "tool_start",
+              toolCallId: part.toolCallId,
+            });
+            break;
+          case "tool-result":
+          case "tool-error":
+          case "tool-output-denied":
+            notifyStreamActivity(opts.onStreamActivity, {
+              type: "tool_end",
+              toolCallId: part.toolCallId,
+            });
+            break;
+          case "finish":
+            break;
+          case "error":
+            throw part.error;
+          case "abort":
+            throw new DOMException(part.reason ?? "Model stream aborted", "AbortError");
+          default:
+            notifyStreamActivity(opts.onStreamActivity, { type: "activity" });
+        }
+      }
+      const [text, toolCalls, finishReason, usage, totalUsage, steps] = await Promise.all([
+        result.text,
+        result.toolCalls,
+        result.finishReason,
+        result.usage,
+        result.totalUsage,
+        result.steps,
+      ]);
+      return {
+        text,
+        toolCalls: toolCalls as GenerateResult["toolCalls"],
+        finishReason,
+        usage,
+        totalUsage,
+        steps: steps.length,
+        cost: priceAiSdkUsage(
+          this.config.llm.provider,
+          this.config.llm.model,
+          this.priced,
+          totalUsage,
+        ),
+      };
+    }
+
     const result = opts.prompt !== undefined
       ? await generateText({ ...base, prompt: opts.prompt })
       : await generateText({ ...base, messages });
@@ -209,6 +320,102 @@ export class LLM {
       stopReason: result.finishReason,
     });
   }
+}
+
+class ChatStreamTimeoutError extends Error {
+  readonly code: "CHAT_TTFT_TIMEOUT" | "CHAT_INTER_CHUNK_TIMEOUT";
+
+  constructor(code: "CHAT_TTFT_TIMEOUT" | "CHAT_INTER_CHUNK_TIMEOUT") {
+    super(code);
+    this.name = "TimeoutError";
+    this.code = code;
+  }
+}
+
+interface ChatStreamWatchdog {
+  readonly signal: AbortSignal;
+  readonly error: ChatStreamTimeoutError | undefined;
+  textDelta(delta: string): void;
+  activity(activity: ModelStreamActivity): void;
+  clear(): void;
+}
+
+function createChatStreamWatchdog(timeouts: ChatStreamTimeouts): ChatStreamWatchdog {
+  const controller = new AbortController();
+  const activeToolIds = new Set<string>();
+  let observedText = false;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let error: ChatStreamTimeoutError | undefined;
+
+  const disarm = (): void => {
+    if (timer !== undefined) clearTimeout(timer);
+    timer = undefined;
+  };
+  const arm = (): void => {
+    disarm();
+    if (activeToolIds.size > 0 || controller.signal.aborted) return;
+    const delayMs = observedText ? timeouts.interChunkMs : timeouts.ttftMs;
+    timer = setTimeout(() => {
+      error = new ChatStreamTimeoutError(
+        observedText ? "CHAT_INTER_CHUNK_TIMEOUT" : "CHAT_TTFT_TIMEOUT",
+      );
+      controller.abort(error);
+    }, delayMs);
+  };
+
+  arm();
+  return {
+    signal: controller.signal,
+    get error() {
+      return error;
+    },
+    textDelta(delta) {
+      if (delta === "") {
+        arm();
+        return;
+      }
+      observedText = true;
+      arm();
+    },
+    activity(activity) {
+      if (activity.type === "tool_start") {
+        activeToolIds.add(activity.toolCallId);
+        disarm();
+        return;
+      }
+      if (activity.type === "tool_end" && activeToolIds.delete(activity.toolCallId)) {
+        if (activeToolIds.size === 0) arm();
+        return;
+      }
+      arm();
+    },
+    clear: disarm,
+  };
+}
+
+function validateChatStreamTimeouts(timeouts: ChatStreamTimeouts): ChatStreamTimeouts {
+  for (const field of ["ttftMs", "interChunkMs"] as const) {
+    const value = timeouts[field];
+    if (!Number.isFinite(value) || !Number.isInteger(value) || value <= 0) {
+      throw new TypeError(`chatStreamTimeouts.${field} must be a finite positive integer`);
+    }
+  }
+  return timeouts;
+}
+
+function notifyTextDelta(observer: GenerateOpts["onTextDelta"], delta: string): void {
+  try {
+    observer?.(delta);
+  } catch {}
+}
+
+function notifyStreamActivity(
+  observer: GenerateOpts["onStreamActivity"],
+  activity: ModelStreamActivity,
+): void {
+  try {
+    observer?.(activity);
+  } catch {}
 }
 
 // The AI SDK reports token usage but no cost, so derive it from the vendored

--- a/packages/engine/src/sport.ts
+++ b/packages/engine/src/sport.ts
@@ -98,7 +98,14 @@ export interface GenerateOptions {
   cacheKey?: string;
   caller?: CallerRole;
   context?: unknown;
+  onTextDelta?: (delta: string) => void;
+  onStreamActivity?: (activity: ModelStreamActivity) => void;
 }
+
+export type ModelStreamActivity =
+  | { readonly type: "activity" }
+  | { readonly type: "tool_start"; readonly toolCallId: string }
+  | { readonly type: "tool_end"; readonly toolCallId: string };
 
 export interface GenerateResult {
   text: string;

--- a/packages/engine/tests/coach-agent-streaming.test.ts
+++ b/packages/engine/tests/coach-agent-streaming.test.ts
@@ -1,0 +1,190 @@
+import { mkdtempSync, readFileSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { TurnEvent } from "@enduragent/coach-contract";
+import { cyclingSport } from "@enduragent/sport-cycling";
+import { createCoachEngine } from "../src/index.js";
+import type {
+  EngineHostPorts,
+  FailureReason,
+  ModelTransportRequest,
+  UsageLedgerLine,
+} from "../src/host-ports.js";
+import type { GenerateResult, Sport } from "../src/sport.js";
+import { baseAgentConfig } from "./helpers/base-agent-config.js";
+
+const createdDirs: string[] = [];
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  for (const dir of createdDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function makeDir(): string {
+  const dir = mkdtempSync(join(realpathSync(tmpdir()), "engine-streaming-"));
+  createdDirs.push(dir);
+  return dir;
+}
+
+function result(
+  text: string,
+  finishReason: GenerateResult["finishReason"] = "stop",
+): GenerateResult {
+  const usage = {
+    inputTokens: 2,
+    outputTokens: 1,
+    totalTokens: 3,
+    inputTokenDetails: {
+      noCacheTokens: 2,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+    },
+    outputTokenDetails: { textTokens: 1, reasoningTokens: 0 },
+  };
+  return {
+    text,
+    toolCalls: [],
+    finishReason,
+    usage,
+    totalUsage: usage,
+    steps: 1,
+  };
+}
+
+function engineWithTransport(input: {
+  generate: (request: ModelTransportRequest) => Promise<GenerateResult>;
+  classifyFailure?: (error: unknown) => FailureReason;
+  usage?: UsageLedgerLine[];
+}) {
+  const dataDir = makeDir();
+  const base = baseAgentConfig(dataDir);
+  const ports: EngineHostPorts = {
+    ...base,
+    randomId: () => "turn-stream-1",
+    classifyFailure: input.classifyFailure ?? base.classifyFailure,
+    usage: {
+      append: (line) => input.usage?.push(line),
+    },
+    modelTransportDecorator: () => ({ generate: input.generate }),
+  };
+  return {
+    dataDir,
+    engine: createCoachEngine({
+      sport: cyclingSport as unknown as Sport,
+      ports,
+    }),
+  };
+}
+
+describe("coach agent streaming", () => {
+  it("emits ordered text_delta events before final-text", async () => {
+    const { dataDir, engine } = engineWithTransport({
+      generate: async (request) => {
+        request.options.onTextDelta?.("Hello");
+        request.options.onStreamActivity?.({ type: "activity" });
+        request.options.onTextDelta?.(", ");
+        request.options.onTextDelta?.("athlete");
+        return result("Hello, athlete");
+      },
+    });
+    const events: TurnEvent[] = [];
+    const response = await engine.chat(
+      { chatId: "stream-order", message: "hello" },
+      (event) => events.push(event),
+    );
+
+    expect(response).toEqual({ text: "Hello, athlete" });
+    expect(events).toEqual([
+      { type: "text_delta", turnId: "turn-stream-1", delta: "Hello" },
+      { type: "text_delta", turnId: "turn-stream-1", delta: ", " },
+      { type: "text_delta", turnId: "turn-stream-1", delta: "athlete" },
+      { type: "final-text", turnId: "turn-stream-1", text: "Hello, athlete" },
+    ]);
+    const session = readFileSync(join(dataDir, "sessions", "stream-order.jsonl"), "utf8");
+    expect(session).not.toContain("text_delta");
+    expect(session).toContain("Hello, athlete");
+  });
+
+  it("keeps consumer failures advisory while observing provider text", async () => {
+    const { engine } = engineWithTransport({
+      generate: async (request) => {
+        request.options.onTextDelta?.("still delivered");
+        return result("still delivered");
+      },
+    });
+    await expect(
+      engine.chat({ chatId: "advisory", message: "hello" }, () => {
+        throw new Error("consumer failed");
+      }),
+    ).resolves.toEqual({ text: "still delivered" });
+  });
+
+  it("streams primary and recovery calls under one turn and records stream usage per model call", async () => {
+    const calls: ModelTransportRequest[] = [];
+    const usage: UsageLedgerLine[] = [];
+    const { engine } = engineWithTransport({
+      usage,
+      generate: async (request) => {
+        calls.push(request);
+        if (calls.length === 1) return result("", "tool-calls");
+        request.options.onTextDelta?.("recovered reply");
+        return result("recovered reply");
+      },
+    });
+    const events: TurnEvent[] = [];
+    await expect(
+      engine.chat({ chatId: "recovery", message: "hello" }, (event) => events.push(event)),
+    ).resolves.toEqual({ text: "recovered reply" });
+
+    expect(calls).toHaveLength(2);
+    expect(calls.every((call) => call.options.caller === "chat")).toBe(true);
+    expect(events).toEqual([
+      { type: "text_delta", turnId: "turn-stream-1", delta: "recovered reply" },
+      { type: "final-text", turnId: "turn-stream-1", text: "recovered reply" },
+    ]);
+    expect(usage.filter((line) => line.kind === "generate")).toHaveLength(2);
+    expect(usage.filter((line) => line.kind === "turn")).toHaveLength(1);
+  });
+
+  describe("applies the complete partial-stream retry table", () => {
+    it.each([
+      "overflow",
+      "timeout",
+      "rate_limit",
+      "server_error",
+      "network",
+      "auth",
+      "invalid_request",
+      "unknown",
+    ] as const)("does not retry %s after provider text", async (failure) => {
+      const providerError = new Error(failure);
+      const generate = vi.fn(async (request: ModelTransportRequest) => {
+        request.options.onTextDelta?.("partial");
+        throw providerError;
+      });
+      const { engine } = engineWithTransport({
+        generate,
+        classifyFailure: () => failure,
+      });
+      const events: TurnEvent[] = [];
+
+      await expect(
+        engine.chat({ chatId: `partial-${failure}`, message: "hello" }, (event) =>
+          events.push(event),
+        ),
+      ).rejects.toBe(providerError);
+      expect(generate).toHaveBeenCalledOnce();
+      expect(events[0]).toEqual({
+        type: "text_delta",
+        turnId: "turn-stream-1",
+        delta: "partial",
+      });
+      expect(events.at(-1)?.type).toBe("error");
+      expect(events.some((event) => event.type === "final-text")).toBe(false);
+    });
+  });
+});

--- a/packages/engine/tests/export-map.test.ts
+++ b/packages/engine/tests/export-map.test.ts
@@ -2,6 +2,9 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import * as engine from "../src/index.js";
+import type { ChatStreamTimeouts } from "../src/index.js";
+
+const timeoutTypeProof: ChatStreamTimeouts = { ttftMs: 1, interChunkMs: 1 };
 
 describe("engine public export surface", () => {
   it("keeps only the root and sport package subpaths", () => {
@@ -14,6 +17,8 @@ describe("engine public export surface", () => {
 
   it("exports only the canonical factory and the authorized JWT account helper at runtime", () => {
     expect(Object.keys(engine).sort()).toEqual(["createCoachEngine", "extractAccountId"]);
+    expect(timeoutTypeProof).toEqual({ ttftMs: 1, interChunkMs: 1 });
+    expect("DEFAULT_CHAT_STREAM_TIMEOUTS" in engine).toBe(false);
   });
 
   it("retains the Core test helper only as a pure re-export", () => {

--- a/packages/engine/tests/llm-dispatch.test.ts
+++ b/packages/engine/tests/llm-dispatch.test.ts
@@ -77,6 +77,18 @@ async function runAiSdk(opts: Parameters<import("../src/llm.js").LLM["generate"]
       captured.called++;
       return MINIMAL_RESULT;
     }),
+    streamText: vi.fn((o: { abortSignal?: AbortSignal; maxRetries?: number; prompt?: string; messages?: unknown; experimental_context?: unknown }) => {
+      captured.abortSignal = o.abortSignal;
+      captured.maxRetries = o.maxRetries;
+      captured.prompt = o.prompt;
+      captured.messages = o.messages;
+      captured.experimentalContext = o.experimental_context;
+      captured.called++;
+      return streamedResult([
+        { type: "text-delta", id: "text-1", text: "ok" },
+        { type: "finish", finishReason: "stop", rawFinishReason: "stop", totalUsage: {} },
+      ], { text: "ok", steps: [] });
+    }),
     stepCountIs: vi.fn((count: number) => ({ type: "step-count", count })),
   }));
   vi.doMock("@ai-sdk/anthropic", () => ({
@@ -307,5 +319,198 @@ describe("LLM generate — timeout reclassification gated on our timer + abort s
     });
     const caught = await generateThrowing(wrapped);
     expect((caught as Error).name).toBe("TimeoutError");
+  });
+});
+
+function streamedResult(
+  parts: unknown[],
+  overrides: Partial<{
+    text: string;
+    toolCalls: unknown[];
+    finishReason: "stop";
+    usage: Record<string, number>;
+    totalUsage: Record<string, number>;
+    steps: unknown[];
+  }> = {},
+) {
+  const usage = overrides.usage ?? { inputTokens: 2, outputTokens: 1, totalTokens: 3 };
+  const totalUsage = overrides.totalUsage ?? {
+    inputTokens: 20,
+    outputTokens: 10,
+    totalTokens: 30,
+  };
+  return {
+    fullStream: (async function* () {
+      for (const part of parts) yield part;
+    })(),
+    text: Promise.resolve(overrides.text ?? "complete"),
+    toolCalls: Promise.resolve(overrides.toolCalls ?? []),
+    finishReason: Promise.resolve(overrides.finishReason ?? "stop"),
+    usage: Promise.resolve(usage),
+    totalUsage: Promise.resolve(totalUsage),
+    steps: Promise.resolve(overrides.steps ?? [{}, {}]),
+  };
+}
+
+async function loadStreamingLlm(parts: unknown[]) {
+  const generateText = vi.fn(async (_request: { maxRetries?: number }) => MINIMAL_RESULT);
+  const streamText = vi.fn((_request: { maxRetries?: number }) => streamedResult(parts));
+  vi.doMock("ai", () => ({
+    generateText,
+    streamText,
+    stepCountIs: vi.fn((count: number) => ({ type: "step-count", count })),
+  }));
+  vi.doMock("@ai-sdk/anthropic", () => ({
+    createAnthropic: () => () => ({ provider: "anthropic-stub" }),
+  }));
+  const { LLM } = await import("../src/llm.js");
+  return { llm: new LLM(anthropicConfig(), llmTestPorts()), generateText, streamText };
+}
+
+describe("LLM dispatch — streaming roles and part mapping", () => {
+  it("routes chat to streamText and background roles to generateText", async () => {
+    const { llm, generateText, streamText } = await loadStreamingLlm([
+      { type: "text-delta", id: "text-1", text: "complete" },
+      { type: "finish", finishReason: "stop", rawFinishReason: "stop", totalUsage: {} },
+    ]);
+    const chatDeltas: string[] = [];
+    await llm.generate({
+      messages: [{ role: "user", content: "chat" }],
+      caller: "chat",
+      onTextDelta: (delta) => chatDeltas.push(delta),
+    });
+    expect(chatDeltas).toEqual(["complete"]);
+    expect(streamText).toHaveBeenCalledOnce();
+    expect(generateText).not.toHaveBeenCalled();
+    expect(streamText.mock.calls[0][0].maxRetries).toBe(0);
+
+    for (const caller of ["flush", "compact", "sync-triage", "dream"] as const) {
+      const onTextDelta = vi.fn();
+      const onStreamActivity = vi.fn();
+      await llm.generate({
+        prompt: "background",
+        caller,
+        onTextDelta,
+        onStreamActivity,
+      });
+      expect(onTextDelta).not.toHaveBeenCalled();
+      expect(onStreamActivity).not.toHaveBeenCalled();
+    }
+    expect(generateText).toHaveBeenCalledTimes(4);
+    expect(streamText).toHaveBeenCalledOnce();
+    expect(generateText.mock.calls.every(([request]) => request.maxRetries === 0)).toBe(true);
+  });
+
+  it("maps every AI SDK stream part", async () => {
+    const providerError = new Error("provider stream error");
+    const activities: unknown[] = [];
+    const deltas: string[] = [];
+    const { llm } = await loadStreamingLlm([
+      { type: "start" },
+      { type: "text-delta", id: "text-1", text: "one" },
+      { type: "text-delta", id: "text-1", text: "" },
+      { type: "tool-call", toolCallId: "tool-1", toolName: "probe", input: {} },
+      { type: "tool-call", toolCallId: "tool-1", toolName: "probe", input: {} },
+      { type: "tool-result", toolCallId: "tool-1", toolName: "probe", input: {}, output: {} },
+      { type: "tool-error", toolCallId: "tool-2", toolName: "probe", input: {}, error: providerError },
+      { type: "tool-output-denied", toolCallId: "tool-3", toolName: "probe" },
+      { type: "finish", finishReason: "stop", rawFinishReason: "stop", totalUsage: {} },
+    ]);
+    const result = await llm.generate({
+      messages: [{ role: "user", content: "chat" }],
+      caller: "chat",
+      onTextDelta: (delta) => deltas.push(delta),
+      onStreamActivity: (activity) => activities.push(activity),
+    });
+    expect(deltas).toEqual(["one"]);
+    expect(activities).toEqual([
+      { type: "activity" },
+      { type: "activity" },
+      { type: "tool_start", toolCallId: "tool-1" },
+      { type: "tool_start", toolCallId: "tool-1" },
+      { type: "tool_end", toolCallId: "tool-1" },
+      { type: "tool_end", toolCallId: "tool-2" },
+      { type: "tool_end", toolCallId: "tool-3" },
+    ]);
+    expect(result).toMatchObject({ text: "complete", steps: 2, totalUsage: { totalTokens: 30 } });
+  });
+
+  it("normalizes yielded aborts and preserves yielded provider errors", async () => {
+    const providerError = new Error("provider stream error");
+    const first = await loadStreamingLlm([{ type: "error", error: providerError }]);
+    await expect(
+      first.llm.generate({ messages: [], caller: "chat" }),
+    ).rejects.toBe(providerError);
+
+    vi.resetModules();
+    const second = await loadStreamingLlm([{ type: "abort", reason: "provider stopped" }]);
+    await expect(second.llm.generate({ messages: [], caller: "chat" })).rejects.toMatchObject({
+      name: "AbortError",
+      message: "provider stopped",
+    });
+  });
+});
+
+describe("LLM dispatch — chat stream watchdog", () => {
+  it.each(["ttftMs", "interChunkMs"] as const)(
+    "validates chatStreamTimeouts.%s synchronously",
+    async (field) => {
+      const { LLM } = await import("../src/llm.js");
+      for (const invalid of [0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY]) {
+        expect(
+          () =>
+            new LLM(anthropicConfig(), {
+              ...llmTestPorts(),
+              chatStreamTimeouts: { ttftMs: 1, interChunkMs: 1, [field]: invalid },
+            }),
+        ).toThrow(`chatStreamTimeouts.${field}`);
+      }
+      expect(
+        () =>
+          new LLM(anthropicConfig(), {
+            ...llmTestPorts(),
+            chatStreamTimeouts: { ttftMs: 1, interChunkMs: 1 },
+          }),
+      ).not.toThrow();
+    },
+  );
+
+  it.each([
+    { expectedCode: "CHAT_TTFT_TIMEOUT", emitText: false },
+    { expectedCode: "CHAT_INTER_CHUNK_TIMEOUT", emitText: true },
+  ] as const)("surfaces $expectedCode", async ({ expectedCode, emitText }) => {
+    vi.useFakeTimers();
+    const streamText = vi.fn((request: { abortSignal?: AbortSignal }) => ({
+      ...streamedResult([]),
+      fullStream: (async function* () {
+        if (emitText) yield { type: "text-delta", id: "text-1", text: "partial" };
+        await new Promise<void>((_resolve, reject) => {
+          request.abortSignal?.addEventListener("abort", () => {
+            reject(new DOMException("aborted", "AbortError"));
+          });
+        });
+      })(),
+    }));
+    vi.doMock("ai", () => ({
+      generateText: vi.fn(),
+      streamText,
+      stepCountIs: vi.fn((count: number) => ({ type: "step-count", count })),
+    }));
+    vi.doMock("@ai-sdk/anthropic", () => ({
+      createAnthropic: () => () => ({ provider: "anthropic-stub" }),
+    }));
+    const { LLM } = await import("../src/llm.js");
+    const llm = new LLM(anthropicConfig(), {
+      ...llmTestPorts(),
+      chatStreamTimeouts: { ttftMs: 10, interChunkMs: 20 },
+    });
+    const pending = llm.generate({ messages: [], caller: "chat" });
+    const rejection = expect(pending).rejects.toMatchObject({
+      name: "TimeoutError",
+      code: expectedCode,
+    });
+    await vi.advanceTimersByTimeAsync(emitText ? 20 : 10);
+    await rejection;
+    vi.useRealTimers();
   });
 });

--- a/packages/engine/tests/model-transport-seam.test.ts
+++ b/packages/engine/tests/model-transport-seam.test.ts
@@ -43,13 +43,34 @@ function result(text: string) {
   };
 }
 
+function streamed(text: string) {
+  const completed = result(text);
+  return {
+    fullStream: (async function* () {
+      yield { type: "text-delta", id: "text-1", text };
+      yield {
+        type: "finish",
+        finishReason: completed.finishReason,
+        rawFinishReason: completed.finishReason,
+        totalUsage: completed.totalUsage,
+      };
+    })(),
+    text: Promise.resolve(completed.text),
+    toolCalls: Promise.resolve(completed.toolCalls),
+    finishReason: Promise.resolve(completed.finishReason),
+    usage: Promise.resolve(completed.usage),
+    totalUsage: Promise.resolve(completed.totalUsage),
+    steps: Promise.resolve([{}]),
+  };
+}
+
 async function loadLlm(
   decorator: ModelTransportDecorator,
-  generateText: ReturnType<typeof vi.fn>,
+  streamText: ReturnType<typeof vi.fn>,
 ): Promise<{ llm: import("../src/llm.js").LLM; usage: UsageLedgerLine[] }> {
   vi.doMock("ai", async () => {
     const actual = await vi.importActual<typeof import("ai")>("ai");
-    return { ...actual, generateText };
+    return { ...actual, streamText };
   });
   const { LLM } = await import("../src/llm.js");
   const usage: UsageLedgerLine[] = [];
@@ -74,7 +95,7 @@ afterEach(() => {
 
 describe("model transport decorator", () => {
   it("record mode delegates exactly once through the canonical request", async () => {
-    const sdkGenerate = vi.fn(async () => ({ ...result("recorded"), steps: [{}] }));
+    const sdkGenerate = vi.fn(() => streamed("recorded"));
     let delegated = 0;
     const decorator: ModelTransportDecorator = (next) => ({
       generate: async (request) => {
@@ -92,7 +113,7 @@ describe("model transport decorator", () => {
   });
 
   it("replay mode delegates zero times while the outer path appends one usage line", async () => {
-    const sdkGenerate = vi.fn(async () => ({ ...result("unexpected"), steps: [{}] }));
+    const sdkGenerate = vi.fn(() => streamed("unexpected"));
     const replay = result("replayed");
     const decorator: ModelTransportDecorator = () => ({
       generate: async () => replay,

--- a/packages/engine/tests/provider-error-taxonomy.test.ts
+++ b/packages/engine/tests/provider-error-taxonomy.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { APICallError } from "@ai-sdk/provider";
 import { mkdtempSync, rmSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -47,13 +46,13 @@ async function setupCodexAgent(complete: ReturnType<typeof vi.fn>) {
   return new CoachAgent(cyclingSport as unknown as Sport, baseAgentConfig(dataDir));
 }
 
-// Drives the AI-SDK path (anthropic provider): the `ai` generateText call is
+// Drives the AI-SDK path (anthropic provider): the `ai` streamText call is
 // mocked. Network errors on this path are plain (not name="NetworkError"), so the
 // outer loop retries them — unlike the codex path.
-async function setupAiSdkAgent(generateText: ReturnType<typeof vi.fn>) {
+async function setupAiSdkAgent(streamText: ReturnType<typeof vi.fn>) {
   vi.doMock("ai", async () => {
     const actual = await vi.importActual<typeof import("ai")>("ai");
-    return { ...actual, generateText };
+    return { ...actual, streamText };
   });
   const { CoachAgent } = await import("../src/agent/coach-agent.js");
   const ports = baseAgentConfig(dataDir);
@@ -77,23 +76,34 @@ function mkAssistant(text: string) {
 }
 
 function aiSdkResult(text: string) {
+  const usage = { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
   return {
-    text,
-    toolCalls: [],
-    finishReason: "stop",
-    usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
-    totalUsage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
-    steps: [{}],
+    fullStream: (async function* () {
+      if (text !== "") yield { type: "text-delta", id: "text-1", text };
+      yield { type: "finish", finishReason: "stop", rawFinishReason: "stop", totalUsage: usage };
+    })(),
+    text: Promise.resolve(text),
+    toolCalls: Promise.resolve([]),
+    finishReason: Promise.resolve("stop"),
+    usage: Promise.resolve(usage),
+    totalUsage: Promise.resolve(usage),
+    steps: Promise.resolve([{}]),
   };
 }
 
-function apiError(statusCode: number): APICallError {
-  return new APICallError({
-    message: "server error",
-    url: "https://chatgpt.com/backend-api",
-    requestBodyValues: {},
-    statusCode,
-  });
+function failingAiSdkResult(error: unknown) {
+  return {
+    ...aiSdkResult(""),
+    fullStream: {
+      [Symbol.asyncIterator]() {
+        return {
+          next: async () => {
+            throw error;
+          },
+        };
+      },
+    },
+  };
 }
 
 describe("provider error taxonomy", () => {
@@ -101,7 +111,7 @@ describe("provider error taxonomy", () => {
     let n = 0;
     const complete = vi.fn(async () => {
       n++;
-      if (n === 1) throw apiError(502);
+      if (n === 1) throw Object.assign(new Error("server error"), { name: "ServerError" });
       return mkAssistant("recovered-502");
     });
 
@@ -118,24 +128,25 @@ describe("provider error taxonomy", () => {
 
   it("recovers an AI-SDK network error (ECONNREFUSED on .cause) in two attempts", async () => {
     let n = 0;
-    const generateText = vi.fn(async () => {
+    const streamText = vi.fn((_request: { maxRetries?: number }) => {
       n++;
       if (n === 1) {
         const e = new TypeError("fetch failed");
         (e as Error & { cause?: unknown }).cause = { code: "ECONNREFUSED" };
-        throw e;
+        return failingAiSdkResult(e);
       }
       return aiSdkResult("recovered-network");
     });
 
     vi.useFakeTimers();
-    const agent = await setupAiSdkAgent(generateText);
+    const agent = await setupAiSdkAgent(streamText);
     const chatPromise = agent.chat("taxonomy-network", "hello");
     await vi.advanceTimersByTimeAsync(10_000);
     const text = await chatPromise;
 
     expect(text).toBe("recovered-network");
-    expect(generateText).toHaveBeenCalledTimes(2);
+    expect(streamText).toHaveBeenCalledTimes(2);
+    expect(streamText.mock.calls.every(([request]) => request.maxRetries === 0)).toBe(true);
     vi.useRealTimers();
   });
 

--- a/tools/s8a/lib/patch-llm.test.ts
+++ b/tools/s8a/lib/patch-llm.test.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type {
   ModelTransport,
   ModelTransportDecorator,
@@ -232,15 +232,38 @@ describe("s8a replay engine", () => {
     expect(result.text).toBe("recorded-reply");
   });
 
-  it("ignores a non-null events field (forward tolerance)", async () => {
+  it("replays recorded text deltas in order and accepts legacy null", async () => {
     const call = recordedCall({ ordinal: 0 });
-    (call as unknown as { events: unknown }).events = [{ type: "text_delta" }];
-    const { FakeLLM, handle } = setup([call]);
-    const result = await new FakeLLM().generate(chatOpts);
+    call.events = [
+      { type: "text_delta", delta: "one" },
+      { type: "text_delta", delta: " two" },
+    ];
+    const { FakeLLM, handle } = setup([call, recordedCall({ ordinal: 1 })]);
+    const deltas: string[] = [];
+    const result = await new FakeLLM().generate({
+      ...chatOpts,
+      onTextDelta: (delta) => deltas.push(delta),
+    });
+    await new FakeLLM().generate(chatOpts);
     handle.finalize();
     handle.restore();
     expect(result.text).toBe("recorded-reply");
+    expect(deltas).toEqual(["one", " two"]);
     expect(handle.state.failures).toEqual([]);
+  });
+
+  it("rejects malformed recorded text deltas before delivery", async () => {
+    const call = recordedCall({ ordinal: 0 });
+    (call as unknown as { events: unknown }).events = [
+      { type: "text_delta", delta: "one", extra: true },
+    ];
+    const { FakeLLM, handle } = setup([call]);
+    const observer = vi.fn();
+    await expect(
+      new FakeLLM().generate({ ...chatOpts, onTextDelta: observer }),
+    ).rejects.toThrow(/malformed text_delta/);
+    expect(observer).not.toHaveBeenCalled();
+    handle.restore();
   });
 });
 
@@ -253,6 +276,8 @@ describe("s8a record engine", () => {
           const opts = request.options as GenerateOptsLike;
           // Simulate the SDK executing a tool during the call.
           await opts.tools?.probe_tool.execute?.({ q: 1 }, { toolCallId: "t1", messages: [] });
+          request.options.onTextDelta?.("one");
+          request.options.onTextDelta?.(" two");
           return {
             text: "reply",
             toolCalls: [],
@@ -298,7 +323,10 @@ describe("s8a record engine", () => {
         { seq: 0, toolName: "probe_tool", input: { q: 1 }, resultCanonical: { answer: 42 } },
       ]);
       expect(call.result.text).toBe("reply");
-      expect(call.events).toBeNull();
+      expect(call.events).toEqual([
+        { type: "text_delta", delta: "one" },
+        { type: "text_delta", delta: " two" },
+      ]);
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }
@@ -319,8 +347,23 @@ describe("s8a record engine", () => {
         expect(req.maxOutputTokens).toBe(512);
         expect(req.cacheKey).toBeNull();
       }
+      expect(handle.calls[0].events).toBeNull();
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }
   });
+
+  it.each(["sync-triage", "dream"] as const)(
+    "rejects unsupported %s callers before delegation or recording",
+    async (caller) => {
+      const next = { generate: vi.fn() } satisfies ModelTransport;
+      const handle = patchForRecord();
+      const FakeLLM = makeFakeLlmClass(handle.modelTransportDecorator, next);
+      await expect(new FakeLLM().generate({ ...chatOpts, caller })).rejects.toThrow(
+        `unsupported Tier-R caller: ${caller}`,
+      );
+      expect(next.generate).not.toHaveBeenCalled();
+      expect(handle.calls).toEqual([]);
+    },
+  );
 });

--- a/tools/s8a/lib/patch-llm.ts
+++ b/tools/s8a/lib/patch-llm.ts
@@ -12,6 +12,7 @@ import type {
   PendingHashMismatch,
   RecordedCall,
   RecordedRequest,
+  RecordedTextDeltaEvent,
   RecordedToolExecution,
   S8aRecording,
 } from "./types.js";
@@ -29,8 +30,9 @@ export interface GenerateOptsLike {
   maxSteps?: number;
   maxOutputTokens?: number;
   cacheKey?: string;
-  caller?: "chat" | "flush" | "compact";
+  caller?: "chat" | "flush" | "compact" | "sync-triage" | "dream";
   context?: unknown;
+  onTextDelta?: (delta: string) => void;
   [key: string]: unknown;
 }
 
@@ -75,8 +77,10 @@ export function patchForRecord(): RecordHandle {
   const modelTransportDecorator: ModelTransportDecorator = (next) => ({
     generate: async (request) => {
     const opts = request.options as GenerateOptsLike;
+    assertSupportedCaller(opts.caller);
     const callOrdinal = ordinal++;
     const executions: RecordedToolExecution[] = [];
+    const events: RecordedTextDeltaEvent[] = [];
     let seq = 0;
 
     // Wrap a COPY of each tool so the agent's own tool objects are never
@@ -107,10 +111,23 @@ export function patchForRecord(): RecordHandle {
       tools = wrapped;
     }
 
+    const originalOnTextDelta = request.options.onTextDelta;
+    const wrappedOnTextDelta = (delta: string): void => {
+      events.push({ type: "text_delta", delta });
+      try {
+        originalOnTextDelta?.(delta);
+      } catch {}
+    };
     const result = await next.generate({
       ...request,
-      options: { ...request.options, tools: tools as ModelTransportRequest["options"]["tools"] },
+      options: {
+        ...request.options,
+        tools: tools as ModelTransportRequest["options"]["tools"],
+        onTextDelta: wrappedOnTextDelta,
+      },
     });
+    const recordedEvents = opts.caller === "chat" || opts.caller === undefined ? events : null;
+    assertRecordedTextDeltaEvents(recordedEvents);
     calls.push({
       ordinal: callOrdinal,
       caller: opts.caller ?? "chat",
@@ -126,7 +143,7 @@ export function patchForRecord(): RecordHandle {
         steps: result.steps ?? 0,
         ...(result.cost !== undefined ? { cost: JSON.parse(JSON.stringify(result.cost)) } : {}),
       },
-      events: null,
+      events: recordedEvents,
     });
     return result;
     },
@@ -208,6 +225,7 @@ export function patchForReplay(
   const modelTransportDecorator: ModelTransportDecorator = () => ({
     generate: async (request) => {
     const opts = request.options as GenerateOptsLike;
+    assertSupportedCaller(opts.caller);
     const entry = recording.calls[state.cursor];
     const ordinal = state.cursor;
     state.cursor++;
@@ -225,6 +243,13 @@ export function patchForReplay(
 
     assertRequest(entry, opts, ordinal, currentTurn, state, fail);
     await executeRecordedTools(entry, opts, ordinal, fail);
+
+    assertRecordedTextDeltaEvents(entry.events);
+    for (const event of entry.events ?? []) {
+      try {
+        request.options.onTextDelta?.(event.delta);
+      } catch {}
+    }
 
     return entry.result as unknown as GenerateResult;
     },
@@ -250,6 +275,34 @@ export function patchForReplay(
     },
     restore: () => undefined,
   };
+}
+
+function assertSupportedCaller(
+  caller: GenerateOptsLike["caller"],
+): asserts caller is "chat" | "flush" | "compact" | undefined {
+  if (caller === "sync-triage" || caller === "dream") {
+    throw new S8aDriftError(`unsupported Tier-R caller: ${caller}`);
+  }
+}
+
+function assertRecordedTextDeltaEvents(
+  events: unknown,
+): asserts events is RecordedTextDeltaEvent[] | null {
+  if (events === null) return;
+  if (!Array.isArray(events)) {
+    throw new S8aDriftError("recorded events must be null or a text_delta array");
+  }
+  for (const event of events) {
+    if (
+      typeof event !== "object" ||
+      event === null ||
+      Object.keys(event).length !== 2 ||
+      (event as { type?: unknown }).type !== "text_delta" ||
+      typeof (event as { delta?: unknown }).delta !== "string"
+    ) {
+      throw new S8aDriftError("recorded events contain a malformed text_delta entry");
+    }
+  }
 }
 
 function callerCounts(calls: RecordedCall[]): string {

--- a/tools/s8a/lib/record-validate.test.ts
+++ b/tools/s8a/lib/record-validate.test.ts
@@ -58,6 +58,22 @@ describe("record validation", () => {
     expect(validateRecording(input())).toEqual([]);
   });
 
+  it("accepts strict text_delta arrays and rejects malformed entries", () => {
+    const valid = chatCall({ ordinal: 0 });
+    valid.events = [{ type: "text_delta", delta: "hello" }];
+    expect(validateRecording(input({ calls: [valid] }))).toEqual([]);
+
+    const malformed = chatCall({ ordinal: 0 });
+    (malformed as unknown as { events: unknown }).events = [
+      { type: "text_delta", delta: "hello", extra: true },
+    ];
+    expect(
+      validateRecording(input({ calls: [malformed] })).some((value) =>
+        value.includes("malformed text_delta"),
+      ),
+    ).toBe(true);
+  });
+
   it("rejects an implicit dataset section touched by a captured execution", () => {
     const violations = validateRecording(
       input({

--- a/tools/s8a/lib/record-validate.ts
+++ b/tools/s8a/lib/record-validate.ts
@@ -29,6 +29,25 @@ export function validateRecording(input: RecordValidationInput): string[] {
   const { scenario, calls, replies, artifacts, deletedEventIds } = input;
   const violations: string[] = [];
 
+  for (const call of calls) {
+    if (call.events === null) continue;
+    if (!Array.isArray(call.events)) {
+      violations.push(`call ${call.ordinal} events must be null or a text_delta array`);
+      continue;
+    }
+    for (const event of call.events as unknown[]) {
+      if (
+        typeof event !== "object" ||
+        event === null ||
+        Object.keys(event).length !== 2 ||
+        (event as { type?: unknown }).type !== "text_delta" ||
+        typeof (event as { delta?: unknown }).delta !== "string"
+      ) {
+        violations.push(`call ${call.ordinal} contains a malformed text_delta event`);
+      }
+    }
+  }
+
   // Implicit-dataset-section guard.
   for (const call of calls) {
     for (const exec of call.toolExecutions) {

--- a/tools/s8a/lib/types.ts
+++ b/tools/s8a/lib/types.ts
@@ -42,6 +42,11 @@ export interface RecordedToolExecution {
   resultCanonical: unknown; // stable-serialized tool result
 }
 
+export interface RecordedTextDeltaEvent {
+  readonly type: "text_delta";
+  readonly delta: string;
+}
+
 /** The recorded request is a discriminated union: compact-caller calls are
  *  prompt-shaped, and flush calls carry no cacheKey — a messages-only schema
  *  cannot round-trip the trim/compaction scenario. */
@@ -88,7 +93,7 @@ export interface RecordedCall {
     steps: number;
     cost?: unknown;
   };
-  events: null; // RESERVED for a future streaming-capture producer; nothing emits it today. Replay tolerates non-null.
+  events: RecordedTextDeltaEvent[] | null;
 }
 
 export interface S8aRecording {


### PR DESCRIPTION
## Summary

Activates streaming for the chat role in the engine's LLM facade, and lands the event plumbing the contract promised:

- `createCoachEngine` now threads the contract's event callback through the agent loop; terminal final-text and error TurnEvents are emitted at the loop's terminal points (terminal-before-settlement), every event validated against the contract schema at the boundary.
- Chat routes through `streamText` with TTFT and inter-chunk stall watchdogs, partial-stream retry classification, and final-chunk usage accounting; `generateText` is retained for background roles.
- Tier-R delta recording/replay/validation extended for the streaming lane; the pre-existing transport-seam test's AI SDK fake gains a completed streamText result (its delegation/usage assertions preserved).
- Changeset included (`User-facing:` streaming chat replies).

## Verification

- Focused acceptance set 10 files / 107 tests; engine suite 57 files / 407 tests; Tier-R fixture and supersession diff clean.
- Root `pnpm build`, `pnpm check`, full `pnpm test`, and s8a replay green in the root gate.
