### PR TITLE
feat(coach): add enduragent serve daemon core

### DIFF
--- a/.changeset/daemon-core.md
+++ b/.changeset/daemon-core.md
@@ -1,0 +1,7 @@
+---
+"@enduragent/coach": patch
+"@enduragent/coach-cli": patch
+"@enduragent/kernel-node": patch
+---
+
+Add the internal localhost daemon core, authenticated RPC projection, wall-clock scheduler, and safe newer-store refusal.

--- a/packages/coach-cli/src/args.ts
+++ b/packages/coach-cli/src/args.ts
@@ -1,9 +1,10 @@
 export type CoachCliInvocation =
   | { readonly kind: "repl" }
   | { readonly kind: "version" }
+  | { readonly kind: "serve" }
   | {
       readonly kind: "usage";
-      readonly message: "Usage: enduragent [version]";
+      readonly message: "Usage: enduragent [version|serve]";
     };
 
 export function parseCoachCliInvocation(argv: readonly string[]): CoachCliInvocation {
@@ -11,5 +12,6 @@ export function parseCoachCliInvocation(argv: readonly string[]): CoachCliInvoca
   if (argv.length === 1 && (argv[0] === "version" || argv[0] === "--version")) {
     return { kind: "version" };
   }
-  return { kind: "usage", message: "Usage: enduragent [version]" };
+  if (argv.length === 1 && argv[0] === "serve") return { kind: "serve" };
+  return { kind: "usage", message: "Usage: enduragent [version|serve]" };
 }

--- a/packages/coach-cli/tests/repl.test.ts
+++ b/packages/coach-cli/tests/repl.test.ts
@@ -100,10 +100,17 @@ describe("coach CLI contract", () => {
     expect(parseCoachCliInvocation([])).toEqual({ kind: "repl" });
     expect(parseCoachCliInvocation(["version"])).toEqual({ kind: "version" });
     expect(parseCoachCliInvocation(["--version"])).toEqual({ kind: "version" });
-    for (const argv of [["unknown"], ["version", "extra"], ["--version", "extra"], [""]]) {
+    expect(parseCoachCliInvocation(["serve"])).toEqual({ kind: "serve" });
+    for (const argv of [
+      ["unknown"],
+      ["version", "extra"],
+      ["--version", "extra"],
+      ["serve", "extra"],
+      [""],
+    ]) {
       expect(parseCoachCliInvocation(argv)).toEqual({
         kind: "usage",
-        message: "Usage: enduragent [version]",
+        message: "Usage: enduragent [version|serve]",
       });
     }
   });

--- a/packages/coach/package.json
+++ b/packages/coach/package.json
@@ -17,6 +17,7 @@
     "./local-bundle-producer": "./dist/local-bundle-producer.js",
     "./store-runtime": "./dist/store-runtime.js",
     "./local-runner": "./dist/local-runner.js",
+    "./serve": "./dist/serve.js",
     "./enduragent": "./dist/enduragent.js"
   },
   "engines": {
@@ -42,10 +43,12 @@
     "@enduragent/kernel-node": "workspace:*",
     "@enduragent/sync-intervals-icu": "workspace:*",
     "@enduragent/sport-cycling": "workspace:*",
+    "ws": "^8.20.0",
     "yaml": "^2.8.3"
   },
   "devDependencies": {
     "@types/node": "^25.6.0",
+    "@types/ws": "^8.18.1",
     "tsup": "^8.4.0",
     "typescript": "^6.0.2",
     "vitest": "^4.1.4"

--- a/packages/coach/src/daemon/healthz-server.ts
+++ b/packages/coach/src/daemon/healthz-server.ts
@@ -1,0 +1,30 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { PROTOCOL_VERSION, type DaemonOwner } from "@enduragent/coach-contract";
+import { HEALTHZ_SERVICE_MARKER } from "@enduragent/kernel-node/lock";
+
+export interface HealthzHandlerInput {
+  readonly appVersion: string;
+  readonly owner: DaemonOwner;
+}
+
+export function createHealthzRequestHandler(
+  input: HealthzHandlerInput,
+): (request: IncomingMessage, response: ServerResponse) => void {
+  const body = `${JSON.stringify({
+    service: HEALTHZ_SERVICE_MARKER,
+    version: input.appVersion,
+    protocolVersion: PROTOCOL_VERSION,
+    owner: input.owner,
+  })}\n`;
+  return (request, response) => {
+    if (request.method !== "GET" || request.url !== "/healthz") {
+      response.statusCode = 404;
+      response.end();
+      return;
+    }
+    response.statusCode = 200;
+    response.setHeader("content-type", "application/json; charset=utf-8");
+    response.setHeader("cache-control", "no-store");
+    response.end(body);
+  };
+}

--- a/packages/coach/src/daemon/rpc-server.ts
+++ b/packages/coach/src/daemon/rpc-server.ts
@@ -1,0 +1,548 @@
+import { randomBytes, timingSafeEqual } from "node:crypto";
+import { constants } from "node:fs";
+import { lstat, open } from "node:fs/promises";
+import { join } from "node:path";
+import {
+  ClientHandshakeFrameSchema,
+  COACH_RPC_METHOD_REGISTRY,
+  CoachRpcRequestEnvelopeSchema,
+  CoachTurnEventNotificationEnvelopeSchema,
+  JsonRpcErrorResponseEnvelopeSchema,
+  JsonRpcIdSchema,
+  JsonRpcProtocolErrorResponseEnvelopeSchema,
+  JsonRpcRequestEnvelopeSchema,
+  JsonRpcSuccessResponseEnvelopeSchema,
+  PROTOCOL_VERSION,
+  compareProtocolVersions,
+  createAcceptedServerHandshakeFrame,
+  createVersionMismatchServerHandshakeFrame,
+  serializeCoachRpcEnvelope,
+  type CoachEngine,
+  type CoachRpcMethodName,
+  type DaemonOwner,
+  type JsonRpcId,
+} from "@enduragent/coach-contract";
+import type { WriterProtocolHandlers } from "@enduragent/kernel-node/lock";
+import WebSocket, { WebSocketServer, type RawData } from "ws";
+
+const AUTH_TIMEOUT_MS = 1_000;
+const MAX_PAYLOAD_BYTES = 1_048_576;
+const AUTH_FAILURE_REASON = "authentication failed";
+const FORBIDDEN_RESPONSE =
+  "HTTP/1.1 403 Forbidden\r\nConnection: close\r\nContent-Length: 0\r\n\r\n";
+const BAD_REQUEST_RESPONSE =
+  "HTTP/1.1 400 Bad Request\r\nConnection: close\r\nContent-Length: 0\r\n\r\n";
+const NOT_FOUND_RESPONSE =
+  "HTTP/1.1 404 Not Found\r\nConnection: close\r\nContent-Length: 0\r\n\r\n";
+const UNAVAILABLE_RESPONSE =
+  "HTTP/1.1 503 Service Unavailable\r\nConnection: close\r\nContent-Length: 0\r\n\r\n";
+
+export interface DaemonToken {
+  readonly path: string;
+  readonly value: string;
+}
+
+export interface DaemonTokenDependencies {
+  readonly randomBytes?: typeof randomBytes;
+}
+
+function validToken(value: string): boolean {
+  return /^[A-Za-z0-9_-]{43}$/.test(value);
+}
+
+async function readExistingToken(path: string): Promise<DaemonToken> {
+  const metadata = await lstat(path);
+  if (!metadata.isFile() || metadata.isSymbolicLink() || (metadata.mode & 0o777) !== 0o600) {
+    throw new Error("daemon token file is invalid");
+  }
+  const handle = await open(path, constants.O_RDONLY | constants.O_NOFOLLOW);
+  let raw: string;
+  try {
+    const openedMetadata = await handle.stat();
+    if (
+      !openedMetadata.isFile() ||
+      (openedMetadata.mode & 0o777) !== 0o600 ||
+      openedMetadata.dev !== metadata.dev ||
+      openedMetadata.ino !== metadata.ino
+    ) {
+      throw new Error("daemon token file is invalid");
+    }
+    raw = await handle.readFile("utf8");
+  } finally {
+    await handle.close();
+  }
+  const value = raw.endsWith("\n") ? raw.slice(0, -1) : "";
+  if (!validToken(value) || raw !== `${value}\n`) {
+    throw new Error("daemon token file is invalid");
+  }
+  return { path, value };
+}
+
+export async function ensureDaemonToken(
+  configDir: string,
+  dependencies: DaemonTokenDependencies = {},
+): Promise<DaemonToken> {
+  const path = join(configDir, "daemon.token");
+  try {
+    return await readExistingToken(path);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+  const value = (dependencies.randomBytes ?? randomBytes)(32).toString("base64url");
+  if (!validToken(value)) throw new Error("daemon token generation failed");
+  let handle: Awaited<ReturnType<typeof open>> | undefined;
+  try {
+    handle = await open(path, constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY, 0o600);
+    await handle.chmod(0o600);
+    await handle.writeFile(`${value}\n`, "utf8");
+    await handle.sync();
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+      return readExistingToken(path);
+    }
+    throw error;
+  } finally {
+    await handle?.close();
+  }
+  return { path, value };
+}
+
+export interface CoachRpcServerInput {
+  readonly engine: CoachEngine;
+  readonly token: string;
+  readonly owner: DaemonOwner;
+}
+
+export interface CoachRpcServer {
+  readonly handleUpgrade: WriterProtocolHandlers["upgrade"];
+  close(): Promise<void>;
+}
+
+interface ClientState {
+  readonly ws: WebSocket;
+  readonly activeIds: Set<string>;
+  readonly requestTasks: Set<Promise<void>>;
+  readonly pendingSendResolvers: Set<() => void>;
+  readonly detachedPromise: Promise<void>;
+  readonly resolveDetached: () => void;
+  readonly closedPromise: Promise<void>;
+  readonly resolveClosed: () => void;
+  sendTail: Promise<void>;
+  authTimer: ReturnType<typeof setTimeout> | undefined;
+  authenticated: boolean;
+  detached: boolean;
+  closed: boolean;
+}
+
+function createClientState(ws: WebSocket): ClientState {
+  let resolveDetached!: () => void;
+  let resolveClosed!: () => void;
+  const detachedPromise = new Promise<void>((resolve) => {
+    resolveDetached = resolve;
+  });
+  const closedPromise = new Promise<void>((resolve) => {
+    resolveClosed = resolve;
+  });
+  return {
+    ws,
+    activeIds: new Set(),
+    requestTasks: new Set(),
+    pendingSendResolvers: new Set(),
+    detachedPromise,
+    resolveDetached,
+    closedPromise,
+    resolveClosed,
+    sendTail: Promise.resolve(),
+    authTimer: undefined,
+    authenticated: false,
+    detached: false,
+    closed: false,
+  };
+}
+
+function clearAuthTimer(state: ClientState): void {
+  if (state.authTimer === undefined) return;
+  clearTimeout(state.authTimer);
+  state.authTimer = undefined;
+}
+
+function detach(state: ClientState, closeCode?: number, reason?: string): void {
+  if (!state.detached) {
+    state.detached = true;
+    state.resolveDetached();
+    for (const resolve of state.pendingSendResolvers) resolve();
+    state.pendingSendResolvers.clear();
+  }
+  if (closeCode !== undefined && state.ws.readyState === WebSocket.OPEN) {
+    try {
+      state.ws.close(closeCode, reason);
+    } catch {
+      state.ws.terminate();
+    }
+  }
+}
+
+function enqueueSerialized(state: ClientState, serialized: string): Promise<void> {
+  const step = state.sendTail.then(async () => {
+    if (state.detached) return;
+    if (state.ws.bufferedAmount + Buffer.byteLength(serialized, "utf8") > MAX_PAYLOAD_BYTES) {
+      detach(state, 1013, "backpressure");
+      return;
+    }
+    await new Promise<void>((resolve) => {
+      let settled = false;
+      const finish = (): void => {
+        if (settled) return;
+        settled = true;
+        state.pendingSendResolvers.delete(finish);
+        resolve();
+      };
+      state.pendingSendResolvers.add(finish);
+      void state.detachedPromise.then(finish);
+      try {
+        state.ws.send(serialized, (error) => {
+          if (error !== undefined) detach(state, 1013, "backpressure");
+          finish();
+        });
+      } catch {
+        detach(state, 1013, "backpressure");
+        finish();
+      }
+    });
+  });
+  state.sendTail = step.catch(() => {});
+  return state.sendTail;
+}
+
+function protocolError(code: -32700 | -32600, message: string): string {
+  return serializeCoachRpcEnvelope(
+    JsonRpcProtocolErrorResponseEnvelopeSchema.parse({
+      jsonrpc: "2.0",
+      id: null,
+      error: { code, message },
+    }),
+  );
+}
+
+function ordinaryError(id: JsonRpcId, code: number, message: string): string {
+  return serializeCoachRpcEnvelope(
+    JsonRpcErrorResponseEnvelopeSchema.parse({
+      jsonrpc: "2.0",
+      id,
+      error: { code, message },
+    }),
+  );
+}
+
+function recoveredId(value: unknown): JsonRpcId | undefined {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return undefined;
+  if (!Object.prototype.hasOwnProperty.call(value, "id")) return undefined;
+  const parsed = JsonRpcIdSchema.safeParse((value as { readonly id?: unknown }).id);
+  return parsed.success ? parsed.data : undefined;
+}
+
+function methodExists(method: string): method is CoachRpcMethodName {
+  return Object.prototype.hasOwnProperty.call(COACH_RPC_METHOD_REGISTRY, method);
+}
+
+function idKey(id: JsonRpcId): string {
+  return `${typeof id}:${JSON.stringify(id)}`;
+}
+
+function rawText(data: RawData): string {
+  if (Buffer.isBuffer(data)) return data.toString("utf8");
+  if (data instanceof ArrayBuffer) return Buffer.from(data).toString("utf8");
+  if (Array.isArray(data)) return Buffer.concat(data).toString("utf8");
+  return Buffer.from(data).toString("utf8");
+}
+
+function sameToken(received: string, expected: string): boolean {
+  const left = Buffer.from(received, "utf8");
+  const right = Buffer.from(expected, "utf8");
+  return left.length === right.length && timingSafeEqual(left, right);
+}
+
+function refuseUpgrade(
+  socket: Parameters<WriterProtocolHandlers["upgrade"]>[1],
+  response: string,
+): void {
+  socket.once("error", () => socket.destroy());
+  socket.write(response, "ascii", () => socket.destroy());
+}
+
+export function createCoachRpcServer(input: CoachRpcServerInput): CoachRpcServer {
+  const wss = new WebSocketServer({ noServer: true, maxPayload: MAX_PAYLOAD_BYTES });
+  const clients = new Set<ClientState>();
+  let closing = false;
+  let closePromise: Promise<void> | undefined;
+
+  const handleRequest = (state: ClientState, data: RawData, isBinary: boolean): void => {
+    if (closing) {
+      detach(state, 1001);
+      return;
+    }
+    if (isBinary) {
+      void enqueueSerialized(state, protocolError(-32600, "Invalid Request"));
+      return;
+    }
+    let parsedJson: unknown;
+    try {
+      parsedJson = JSON.parse(rawText(data));
+    } catch {
+      void enqueueSerialized(state, protocolError(-32700, "Parse error"));
+      return;
+    }
+    const generic = JsonRpcRequestEnvelopeSchema.safeParse(parsedJson);
+    if (!generic.success) {
+      const id = recoveredId(parsedJson);
+      void enqueueSerialized(
+        state,
+        id === undefined
+          ? protocolError(-32600, "Invalid Request")
+          : ordinaryError(id, -32600, "Invalid Request"),
+      );
+      return;
+    }
+    if (!methodExists(generic.data.method)) {
+      void enqueueSerialized(state, ordinaryError(generic.data.id, -32601, "Method not found"));
+      return;
+    }
+    const registry = COACH_RPC_METHOD_REGISTRY[generic.data.method];
+    const specialized = CoachRpcRequestEnvelopeSchema.safeParse(generic.data);
+    const params = registry.requestSchema.safeParse(generic.data.params);
+    if (!specialized.success || !params.success) {
+      void enqueueSerialized(state, ordinaryError(generic.data.id, -32602, "Invalid params"));
+      return;
+    }
+    const key = idKey(generic.data.id);
+    if (state.activeIds.has(key)) {
+      detach(state, 1008);
+      return;
+    }
+    state.activeIds.add(key);
+    const task = (async () => {
+      let invocationFailed = false;
+      let eventFailed = false;
+      let result: unknown;
+      try {
+        switch (registry.wireName) {
+          case "chat":
+            try {
+              const request = COACH_RPC_METHOD_REGISTRY.chat.requestSchema.parse(
+                generic.data.params,
+              );
+              result = await input.engine.chat(request, (event) => {
+                if (eventFailed) return;
+                try {
+                  const parsedEvent = COACH_RPC_METHOD_REGISTRY.chat.eventSchema.parse(event);
+                  const notification = CoachTurnEventNotificationEnvelopeSchema.parse({
+                    jsonrpc: "2.0",
+                    method: "coach.turnEvent",
+                    params: {
+                      requestId: generic.data.id,
+                      requestMethod: "chat",
+                      turnId: parsedEvent.turnId,
+                      event: parsedEvent,
+                    },
+                  });
+                  void enqueueSerialized(state, serializeCoachRpcEnvelope(notification));
+                } catch {
+                  eventFailed = true;
+                }
+              });
+            } catch {
+              invocationFailed = true;
+            }
+            break;
+          case "resetSession":
+            try {
+              const request = COACH_RPC_METHOD_REGISTRY.resetSession.requestSchema.parse(
+                generic.data.params,
+              );
+              result = await input.engine.resetSession(request);
+            } catch {
+              invocationFailed = true;
+            }
+            break;
+          case "hasSession":
+            try {
+              const request = COACH_RPC_METHOD_REGISTRY.hasSession.requestSchema.parse(
+                generic.data.params,
+              );
+              result = await input.engine.hasSession(request);
+            } catch {
+              invocationFailed = true;
+            }
+            break;
+          case "getAthleteState":
+            try {
+              COACH_RPC_METHOD_REGISTRY.getAthleteState.requestSchema.parse(generic.data.params);
+              result = await input.engine.getAthleteState();
+            } catch {
+              invocationFailed = true;
+            }
+            break;
+        }
+        let terminal: string;
+        if (invocationFailed || eventFailed) {
+          terminal = ordinaryError(generic.data.id, -32603, "Internal error");
+        } else {
+          const response = registry.responseSchema.safeParse(result);
+          if (!response.success) {
+            terminal = ordinaryError(generic.data.id, -32603, "Internal error");
+          } else {
+            try {
+              terminal = serializeCoachRpcEnvelope(
+                JsonRpcSuccessResponseEnvelopeSchema.parse({
+                  jsonrpc: "2.0",
+                  id: generic.data.id,
+                  result: response.data,
+                }),
+              );
+            } catch {
+              terminal = ordinaryError(generic.data.id, -32603, "Internal error");
+            }
+          }
+        }
+        await enqueueSerialized(state, terminal);
+      } finally {
+        state.activeIds.delete(key);
+      }
+    })();
+    state.requestTasks.add(task);
+    void task.finally(() => state.requestTasks.delete(task)).catch(() => {});
+  };
+
+  const acceptClient = (ws: WebSocket): void => {
+    const state = createClientState(ws);
+    clients.add(state);
+    ws.on("close", () => {
+      clearAuthTimer(state);
+      detach(state);
+      state.closed = true;
+      state.resolveClosed();
+      void Promise.all(state.requestTasks)
+        .catch(() => {})
+        .then(() => state.sendTail)
+        .finally(() => clients.delete(state));
+    });
+    ws.on("error", () => {
+      clearAuthTimer(state);
+      detach(state);
+      if (ws.readyState !== WebSocket.CLOSED) ws.terminate();
+    });
+    state.authTimer = setTimeout(() => {
+      state.authTimer = undefined;
+      detach(state, 1008, AUTH_FAILURE_REASON);
+    }, AUTH_TIMEOUT_MS);
+    state.authTimer.unref?.();
+    ws.once("message", (data, isBinary) => {
+      clearAuthTimer(state);
+      if (isBinary) {
+        detach(state, 1008, AUTH_FAILURE_REASON);
+        return;
+      }
+      let value: unknown;
+      try {
+        value = JSON.parse(rawText(data));
+      } catch {
+        detach(state, 1008, AUTH_FAILURE_REASON);
+        return;
+      }
+      const handshake = ClientHandshakeFrameSchema.safeParse(value);
+      if (!handshake.success || !sameToken(handshake.data.token, input.token)) {
+        detach(state, 1008, AUTH_FAILURE_REASON);
+        return;
+      }
+      const comparison = compareProtocolVersions(
+        handshake.data.clientProtocolVersion,
+        PROTOCOL_VERSION,
+      );
+      if (comparison !== "equal") {
+        const frame = createVersionMismatchServerHandshakeFrame(
+          input.owner,
+          handshake.data.clientProtocolVersion,
+        );
+        void enqueueSerialized(state, JSON.stringify(frame)).then(() => {
+          clearAuthTimer(state);
+          detach(state, 1002);
+        });
+        return;
+      }
+      state.authenticated = true;
+      const frame = createAcceptedServerHandshakeFrame(
+        input.owner,
+        handshake.data.clientProtocolVersion,
+      );
+      void enqueueSerialized(state, JSON.stringify(frame));
+      ws.on("message", (requestData, requestIsBinary) => {
+        handleRequest(state, requestData, requestIsBinary);
+      });
+    });
+  };
+
+  const handleUpgrade: WriterProtocolHandlers["upgrade"] = (request, socket, head) => {
+    if (Object.prototype.hasOwnProperty.call(request.headers, "origin")) {
+      refuseUpgrade(socket, FORBIDDEN_RESPONSE);
+      return;
+    }
+    const rawTarget = request.url ?? "";
+    let target: URL;
+    try {
+      target = new URL(rawTarget, "http://127.0.0.1");
+      if (!rawTarget.startsWith("/") || target.origin !== "http://127.0.0.1") {
+        throw new TypeError("invalid relative URL");
+      }
+    } catch {
+      refuseUpgrade(socket, BAD_REQUEST_RESPONSE);
+      return;
+    }
+    if (target.pathname !== "/rpc") {
+      refuseUpgrade(socket, NOT_FOUND_RESPONSE);
+      return;
+    }
+    if (rawTarget.includes("?")) {
+      refuseUpgrade(socket, BAD_REQUEST_RESPONSE);
+      return;
+    }
+    if (closing) {
+      refuseUpgrade(socket, UNAVAILABLE_RESPONSE);
+      return;
+    }
+    wss.handleUpgrade(request, socket, head, acceptClient);
+  };
+
+  return {
+    handleUpgrade,
+    close() {
+      closePromise ??= (async () => {
+        closing = true;
+        for (const state of clients) {
+          clearAuthTimer(state);
+          if (!state.authenticated) {
+            detach(state);
+            state.ws.terminate();
+          }
+        }
+        while ([...clients].some((state) => state.requestTasks.size !== 0)) {
+          await Promise.all([...clients].flatMap((state) => [...state.requestTasks]));
+        }
+        await Promise.all([...clients].map((state) => state.sendTail));
+        const authenticated = [...clients].filter((state) => state.authenticated);
+        for (const state of authenticated) {
+          if (state.ws.readyState === WebSocket.OPEN) state.ws.close(1001);
+          detach(state);
+        }
+        await Promise.all(authenticated.map((state) => state.closedPromise));
+        await new Promise<void>((resolve, reject) => {
+          wss.close((error) => {
+            if (error === undefined) resolve();
+            else reject(error);
+          });
+        });
+        clients.clear();
+      })();
+      return closePromise;
+    },
+  };
+}

--- a/packages/coach/src/daemon/scheduler.ts
+++ b/packages/coach/src/daemon/scheduler.ts
@@ -1,0 +1,79 @@
+export interface WallClockSchedulerDependencies {
+  readonly nowEpochMs: () => number;
+  readonly setTimeout: typeof globalThis.setTimeout;
+  readonly clearTimeout: typeof globalThis.clearTimeout;
+}
+
+export interface WallClockScheduler {
+  start(): void;
+  close(): Promise<void>;
+}
+
+export interface CreateWallClockSchedulerInput {
+  readonly cadenceMs: number;
+  readonly run: () => Promise<void>;
+  readonly onError?: (error: unknown) => void;
+  readonly dependencies?: Partial<WallClockSchedulerDependencies>;
+}
+
+export function createWallClockScheduler(input: CreateWallClockSchedulerInput): WallClockScheduler {
+  if (!Number.isSafeInteger(input.cadenceMs) || input.cadenceMs <= 0) {
+    throw new RangeError("cadenceMs must be a positive safe integer");
+  }
+  const dependencies: WallClockSchedulerDependencies = {
+    nowEpochMs: input.dependencies?.nowEpochMs ?? Date.now,
+    setTimeout: input.dependencies?.setTimeout ?? globalThis.setTimeout,
+    clearTimeout: input.dependencies?.clearTimeout ?? globalThis.clearTimeout,
+  };
+  const onError = input.onError ?? (() => {});
+  let started = false;
+  let closed = false;
+  let timer: ReturnType<typeof globalThis.setTimeout> | undefined;
+  let activeRun: Promise<void> | undefined;
+  let closePromise: Promise<void> | undefined;
+
+  const schedule = (): void => {
+    if (closed) return;
+    const now = dependencies.nowEpochMs();
+    const deadline = (Math.floor(now / input.cadenceMs) + 1) * input.cadenceMs;
+    const delay = Math.max(0, deadline - dependencies.nowEpochMs());
+    timer = dependencies.setTimeout(() => {
+      timer = undefined;
+      if (closed) return;
+      const task = Promise.resolve().then(input.run);
+      activeRun = task;
+      void task
+        .catch((error) => {
+          try {
+            onError(error);
+          } catch {}
+        })
+        .finally(() => {
+          if (activeRun === task) activeRun = undefined;
+          schedule();
+        });
+    }, delay);
+    timer.unref?.();
+  };
+
+  return {
+    start() {
+      if (started || closed) return;
+      started = true;
+      schedule();
+    },
+    close() {
+      closePromise ??= (async () => {
+        closed = true;
+        if (timer !== undefined) {
+          dependencies.clearTimeout(timer);
+          timer = undefined;
+        }
+        try {
+          await activeRun;
+        } catch {}
+      })();
+      return closePromise;
+    },
+  };
+}

--- a/packages/coach/src/enduragent.ts
+++ b/packages/coach/src/enduragent.ts
@@ -9,6 +9,7 @@ import {
   EXIT_NOT_CONFIGURED,
   EXIT_SUCCESS,
   EXIT_USAGE,
+  EXIT_VERSION_MISMATCH,
   type ExitCode,
 } from "@enduragent/coach-contract";
 import {
@@ -17,12 +18,14 @@ import {
   type CoachCliTerminal,
 } from "@enduragent/coach-cli";
 import { expandTilde, resolveAthleteHome, type AthleteHome } from "@enduragent/kernel-node/home";
+import { StoreNewerThanAppError } from "@enduragent/kernel/store";
 import {
   withLocalCoach,
   type LocalCoachRunResult,
   type WithLocalCoachInput,
 } from "./local-runner.js";
 import { CoachStoreWriterError } from "./runtime.js";
+import { runCoachServe } from "./serve.js";
 
 export interface RunEnduragentInput {
   readonly argv: readonly string[];
@@ -64,6 +67,12 @@ function resolveLegacySourceRoot(env: Record<string, string | undefined>): strin
   return join(homedir(), ".cycling-coach");
 }
 
+function storeNewerThanApp(error: unknown): StoreNewerThanAppError | null {
+  if (!(error instanceof CoachStoreWriterError)) return null;
+  if (error.code !== "writer-failed" || error.stage !== "run migrations") return null;
+  return error.cause instanceof StoreNewerThanAppError ? error.cause : null;
+}
+
 export async function runEnduragent(
   input: RunEnduragentInput,
   dependencies?: EnduragentDependencies,
@@ -82,6 +91,8 @@ export async function runEnduragent(
       return EXIT_SUCCESS;
     }
 
+    const appVersion =
+      invocation.kind === "serve" ? await resolvedDependencies.readPackageVersion() : undefined;
     const home = resolvedDependencies.resolveAthleteHome(input.env);
     const sourceRoot = resolveLegacySourceRoot(input.env);
     const result = await resolvedDependencies.withLocalCoach({
@@ -90,11 +101,18 @@ export async function runEnduragent(
       sourceRoot,
       action: { kind: "resume", isTTY: input.terminal.isTTY },
       operation: async (lifecycle) =>
-        runCoachRepl({
-          engine: lifecycle.engine,
-          terminal: input.terminal,
-          signal: input.signal,
-        }),
+        invocation.kind === "serve"
+          ? runCoachServe({
+              lifecycle,
+              home,
+              appVersion: appVersion!,
+              signal: input.signal,
+            })
+          : runCoachRepl({
+              engine: lifecycle.engine,
+              terminal: input.terminal,
+              signal: input.signal,
+            }),
     });
 
     if (result.status === "completed") return result.value;
@@ -117,6 +135,12 @@ export async function runEnduragent(
     );
     return result.result.exitCode;
   } catch (error) {
+    if (storeNewerThanApp(error) !== null) {
+      input.terminal.stderr.write(
+        "Enduragent cannot start: this athlete store was created by a newer app version. Update Enduragent and retry.\n",
+      );
+      return EXIT_VERSION_MISMATCH;
+    }
     if (
       error instanceof CoachStoreWriterError &&
       error.code === "writer-lock-held" &&

--- a/packages/coach/src/local-runner.ts
+++ b/packages/coach/src/local-runner.ts
@@ -4,6 +4,7 @@ import {
 } from "@enduragent/core";
 import type { CoachEngine } from "@enduragent/coach-contract";
 import type { AthleteHome } from "@enduragent/kernel-node/home";
+import type { WriterProtocolListener } from "@enduragent/kernel-node/lock";
 import {
   createLocalCoachComposition,
   type LocalCoachComposition,
@@ -18,6 +19,7 @@ import { withCoachStoreWriter } from "./runtime.js";
 
 export interface LocalCoachLifecycle {
   readonly engine: CoachEngine;
+  readonly listener: WriterProtocolListener;
   close(): Promise<void>;
 }
 
@@ -132,8 +134,16 @@ export async function withLocalCoach<T>(
             config,
             engineConfig: readiness.config,
           });
+          const publishedLifecycle = lifecycle;
           try {
-            outcome = { kind: "fulfilled", value: await input.operation(lifecycle) };
+            outcome = {
+              kind: "fulfilled",
+              value: await input.operation({
+                engine: publishedLifecycle.engine,
+                listener: context.listener,
+                close: () => publishedLifecycle.close(),
+              }),
+            };
           } catch (error) {
             operationOutcome = { kind: "rejected", error };
             outcome = operationOutcome;

--- a/packages/coach/src/serve.ts
+++ b/packages/coach/src/serve.ts
@@ -1,0 +1,93 @@
+import { EXIT_SUCCESS, type ExitCode } from "@enduragent/coach-contract";
+import type { AthleteHome } from "@enduragent/kernel-node/home";
+import { createHealthzRequestHandler } from "./daemon/healthz-server.js";
+import { createCoachRpcServer, ensureDaemonToken } from "./daemon/rpc-server.js";
+import type { LocalCoachLifecycle } from "./local-runner.js";
+
+export interface RunCoachServeInput {
+  readonly lifecycle: LocalCoachLifecycle;
+  readonly home: AthleteHome;
+  readonly appVersion: string;
+  readonly signal: AbortSignal;
+}
+
+export interface CoachServeDependencies {
+  readonly ensureToken: typeof ensureDaemonToken;
+  readonly createRpcServer: typeof createCoachRpcServer;
+  readonly createHealthzHandler: typeof createHealthzRequestHandler;
+}
+
+const defaultDependencies: CoachServeDependencies = {
+  ensureToken: ensureDaemonToken,
+  createRpcServer: createCoachRpcServer,
+  createHealthzHandler: createHealthzRequestHandler,
+};
+
+export async function runCoachServe(
+  input: RunCoachServeInput,
+  dependencies: CoachServeDependencies = defaultDependencies,
+): Promise<ExitCode> {
+  if (input.signal.aborted) return EXIT_SUCCESS;
+  let aborted = false;
+  let resolveAbort!: () => void;
+  const abortPromise = new Promise<void>((resolve) => {
+    resolveAbort = resolve;
+  });
+  const latchAbort = (): void => {
+    if (aborted) return;
+    aborted = true;
+    resolveAbort();
+  };
+  input.signal.addEventListener("abort", latchAbort, { once: true });
+  if (input.signal.aborted) latchAbort();
+  try {
+    if (aborted) return EXIT_SUCCESS;
+    const token = await dependencies.ensureToken(input.home.configDir);
+    if (aborted) return EXIT_SUCCESS;
+    const rpc = dependencies.createRpcServer({
+      engine: input.lifecycle.engine,
+      token: token.value,
+      owner: "unmanaged-foreground",
+    });
+    if (aborted) {
+      await rpc.close();
+      return EXIT_SUCCESS;
+    }
+    let binding: Awaited<ReturnType<LocalCoachLifecycle["listener"]["bind"]>>;
+    try {
+      binding = await input.lifecycle.listener.bind({
+        request: dependencies.createHealthzHandler({
+          appVersion: input.appVersion,
+          owner: "unmanaged-foreground",
+        }),
+        upgrade: rpc.handleUpgrade,
+      });
+    } catch (error) {
+      await rpc.close().catch(() => {});
+      throw error;
+    }
+    if (!aborted) await abortPromise;
+    let bindingClose: Promise<void>;
+    try {
+      bindingClose = binding.close();
+    } catch (error) {
+      await rpc.close().catch(() => {});
+      throw error;
+    }
+    let cleanupError: unknown;
+    try {
+      await rpc.close();
+    } catch (error) {
+      cleanupError = error;
+    }
+    try {
+      await bindingClose;
+    } catch (error) {
+      cleanupError ??= error;
+    }
+    if (cleanupError !== undefined) throw cleanupError;
+    return EXIT_SUCCESS;
+  } finally {
+    input.signal.removeEventListener("abort", latchAbort);
+  }
+}

--- a/packages/coach/src/store-runtime.ts
+++ b/packages/coach/src/store-runtime.ts
@@ -13,6 +13,11 @@ import type { AthleteHome } from "@enduragent/kernel-node/home";
 import { join } from "node:path";
 import { runReferenceCapture } from "./capture.js";
 import { createLocalBundleProducer } from "./local-bundle-producer.js";
+import {
+  createWallClockScheduler,
+  type WallClockScheduler,
+  type WallClockSchedulerDependencies,
+} from "./daemon/scheduler.js";
 
 export const STORE_REFRESH_INTERVAL_MS = 21_600_000;
 export const STORE_REQUEST_LIMIT = 64 as const;
@@ -33,8 +38,7 @@ export interface StoreRuntimeDependencies {
   readonly produce?: (manifest: ReferenceCaptureManifest) => Promise<ProducedLocalBundle>;
   readonly now?: () => Date;
   readonly monotonicNow?: () => number;
-  readonly setInterval?: typeof globalThis.setInterval;
-  readonly clearInterval?: typeof globalThis.clearInterval;
+  readonly schedulerDependencies?: Partial<WallClockSchedulerDependencies>;
 }
 
 export interface StoreRuntimeOptions {
@@ -48,27 +52,38 @@ export interface StoreRuntimeOptions {
 export class StoreRuntime {
   readonly athleteData: AthleteDataReader;
   private readonly dependencies: Required<Pick<StoreRuntimeDependencies,
-    "capture" | "produce" | "now" | "monotonicNow" | "setInterval" | "clearInterval">>;
+    "capture" | "produce" | "now" | "monotonicNow">>;
+  private readonly scheduler: WallClockScheduler;
   private snapshotValue: ProducedLocalBundle | undefined;
   private activeLedger: PhysicalRequestLedger | undefined;
   private activeController: AbortController | undefined;
-  private timer: ReturnType<typeof setInterval> | undefined;
   private activeWindow: Promise<StoreWindowResult> | undefined;
   private closed = false;
 
   constructor(private readonly options: StoreRuntimeOptions) {
     const dependencies = options.dependencies ?? {};
+    const now = dependencies.now ?? (() => new Date());
+    const schedulerDependencies = dependencies.schedulerDependencies ?? {};
     this.dependencies = {
       capture: dependencies.capture ?? runReferenceCapture,
       produce: dependencies.produce ?? ((manifest) => createLocalBundleProducer({
         storePath: join(options.home.storeDir, "store.db"),
         archiveRoot: options.home.archiveDir,
       }).produce(manifest)),
-      now: dependencies.now ?? (() => new Date()),
+      now,
       monotonicNow: dependencies.monotonicNow ?? (() => performance.now()),
-      setInterval: dependencies.setInterval ?? globalThis.setInterval,
-      clearInterval: dependencies.clearInterval ?? globalThis.clearInterval,
     };
+    this.scheduler = createWallClockScheduler({
+      cadenceMs: STORE_REFRESH_INTERVAL_MS,
+      run: async () => {
+        await this.runWindow();
+      },
+      dependencies: {
+        nowEpochMs: schedulerDependencies.nowEpochMs ?? (() => now().getTime()),
+        setTimeout: schedulerDependencies.setTimeout ?? globalThis.setTimeout,
+        clearTimeout: schedulerDependencies.clearTimeout ?? globalThis.clearTimeout,
+      },
+    });
     this.athleteData = createStoreAthleteDataReader({
       snapshot: () => this.snapshotValue,
       clockNow: () => this.dependencies.now().getTime(),
@@ -85,12 +100,8 @@ export class StoreRuntime {
   }
 
   startScheduler(): void {
-    if (this.closed || this.timer !== undefined) return;
-    this.timer = this.dependencies.setInterval(() => {
-      if (this.activeWindow !== undefined) return;
-      void this.runWindow().catch(() => {});
-    }, STORE_REFRESH_INTERVAL_MS);
-    this.timer.unref?.();
+    if (this.closed) return;
+    this.scheduler.start();
   }
 
   runWindow(): Promise<StoreWindowResult> {
@@ -155,11 +166,8 @@ export class StoreRuntime {
   async close(): Promise<void> {
     if (this.closed) return;
     this.closed = true;
-    if (this.timer !== undefined) {
-      this.dependencies.clearInterval(this.timer);
-      this.timer = undefined;
-    }
     this.activeController?.abort(new Error("Store runtime closed."));
+    await this.scheduler.close();
     try { await this.activeWindow; } catch {}
   }
 }

--- a/packages/coach/src/sync.ts
+++ b/packages/coach/src/sync.ts
@@ -290,7 +290,7 @@ export async function runCoachSync(
   }
 
   const dependencies = deps ?? defaultDependencies;
-  return dependencies.withWriter(options.env, async ({ home, store }) => {
+  return dependencies.withWriter(options.env, async ({ home, store, listener }) => {
     const repository = createSyncFailureRepository(store);
     const target = join(home.root, "data", "error_state.json");
     const project = async (): Promise<void> => {
@@ -314,7 +314,7 @@ export async function runCoachSync(
       let sourceFailed = false;
       try {
         if ("run" in binding && binding.run !== undefined) {
-          await binding.run(Object.freeze({ home, store, source: binding.source }));
+          await binding.run(Object.freeze({ home, store, listener, source: binding.source }));
         } else {
           nodeRuntime ??= dependencies.createImportRuntime({ archiveDir: home.archiveDir, store });
           await runFileHydration(binding as CoachFileSourceBinding, nodeRuntime);

--- a/packages/coach/tests/coach-sync.test.ts
+++ b/packages/coach/tests/coach-sync.test.ts
@@ -1,6 +1,7 @@
-import { access, mkdtemp, rm } from "node:fs/promises";
+import { access, mkdtemp, realpath, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { createServer } from "node:net";
 import { describe, expect, it, vi } from "vitest";
 import type { ImportArtifact, ImportReport } from "@enduragent/kernel/ingest";
 import {
@@ -15,7 +16,11 @@ import {
 import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
 import type { AthleteHome } from "@enduragent/kernel-node/home";
 import { importFilesWithReport, type NodeImportRuntime } from "@enduragent/kernel-node/ingest";
-import { LOCKFILE_NAME, PORT_FILE_NAME } from "@enduragent/kernel-node/lock";
+import {
+  inertWriterProtocolListener,
+  LOCKFILE_NAME,
+  PORT_FILE_NAME,
+} from "@enduragent/kernel-node/lock";
 import {
   type CoachDevWriterFailureStage,
   type CoachDevWriterResult,
@@ -43,6 +48,19 @@ const capabilities = Object.freeze({
   wellness: false,
   plannedWorkoutPush: false,
   backfillDepth: Object.freeze({ kind: "none" as const }),
+});
+
+const hasLoopback = await new Promise<boolean>((resolve) => {
+  const server = createServer();
+  server.once("error", (error: NodeJS.ErrnoException) => {
+    if (error.code === "EPERM") {
+      process.stderr.write("SKIP_MARKER loopback-listen EPERM coach-sync\n");
+    }
+    resolve(false);
+  });
+  server.listen({ host: "127.0.0.1", port: 0 }, () => {
+    server.close(() => resolve(true));
+  });
 });
 
 function syncSource(id: SourceId): SyncSource {
@@ -94,7 +112,11 @@ function syntheticStore(): CoachStoreWriterContext["store"] {
 }
 
 function syntheticContext(root?: string): CoachStoreWriterContext {
-  return { home: syntheticHome(root), store: syntheticStore() };
+  return {
+    home: syntheticHome(root),
+    store: syntheticStore(),
+    listener: inertWriterProtocolListener,
+  };
 }
 
 async function pathExists(path: string): Promise<boolean> {
@@ -136,7 +158,7 @@ async function governedHarness(overrides: Partial<CoachSyncDependencies> = {}) {
   let ordinal = 1_000;
   const withWriter: CoachSyncDependencies["withWriter"] = async (_env, operation) => {
     events.push("writer");
-    return operation({ home, store });
+    return operation({ home, store, listener: inertWriterProtocolListener });
   };
   const dependencies = syncDependencies(withWriter, async () => importReport, {
     fileSystem: {
@@ -549,8 +571,8 @@ describe("coach sync composition", () => {
     expect(importCalls).toBe(0);
   });
 
-  it("real writer lifecycle migrates closes and releases an isolated store", async () => {
-    const root = await mkdtemp(join(tmpdir(), "coach-runtime-"));
+  it.runIf(hasLoopback)("real writer lifecycle migrates closes and releases an isolated store", async () => {
+    const root = await mkdtemp(join(await realpath(tmpdir()), "coach-runtime-"));
     const home = syntheticHome(root);
     try {
       const value = await withCoachStoreWriter(
@@ -578,9 +600,10 @@ describe("coach sync composition", () => {
     }
   });
 
-  it("isolates concurrent writers for two athlete homes", async () => {
-    const leftRoot = await mkdtemp(join(tmpdir(), "coach-left-"));
-    const rightRoot = await mkdtemp(join(tmpdir(), "coach-right-"));
+  it.runIf(hasLoopback)("isolates concurrent writers for two athlete homes", async () => {
+    const temporaryRoot = await realpath(tmpdir());
+    const leftRoot = await mkdtemp(join(temporaryRoot, "coach-left-"));
+    const rightRoot = await mkdtemp(join(temporaryRoot, "coach-right-"));
     const leftHome = syntheticHome(leftRoot);
     const rightHome = syntheticHome(rightRoot);
     const seenHomes: string[] = [];
@@ -690,8 +713,13 @@ describe("coach sync composition", () => {
               source,
               async run(context) {
                 expect(Object.isFrozen(context)).toBe(true);
-                expect(context).toEqual({ home: harness.home, store: harness.store, source });
-              expect(Object.keys(context)).toEqual(["home", "store", "source"]);
+                expect(context).toEqual({
+                  home: harness.home,
+                  store: harness.store,
+                  listener: inertWriterProtocolListener,
+                  source,
+                });
+                expect(Object.keys(context)).toEqual(["home", "store", "listener", "source"]);
                 expect(JSON.parse(harness.projected.get(target)!)).toMatchObject({
                   detail: "intervals-icu: source temporarily unavailable",
                   mitigation: "warn_only",
@@ -894,7 +922,11 @@ describe("coach sync composition", () => {
     };
     let laterCalls = 0;
     const withWriter: CoachSyncDependencies["withWriter"] = async (_env, operation) =>
-      operation({ home: syntheticHome(), store });
+      operation({
+        home: syntheticHome(),
+        store,
+        listener: inertWriterProtocolListener,
+      });
     await expect(
       runCoachSync(
         {

--- a/packages/coach/tests/composition.test.ts
+++ b/packages/coach/tests/composition.test.ts
@@ -16,6 +16,7 @@ import { createPhysicalRequestLedger, runMigrations } from "@enduragent/kernel/s
 import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
 import type { CyclingFtpAnchorResolver } from "@enduragent/kernel/anchors";
 import type { AthleteHome } from "@enduragent/kernel-node/home";
+import { inertWriterProtocolListener } from "@enduragent/kernel-node/lock";
 import { openSqliteStorage } from "@enduragent/kernel-node/sqlite";
 import {
   createLocalCoachComposition,
@@ -158,6 +159,7 @@ function missingResolver(): CyclingFtpAnchorResolver {
 function fakeContext(home: AthleteHome): CoachStoreWriterContext {
   return {
     home,
+    listener: inertWriterProtocolListener,
     store: {
       async exec() {},
       async run() {},
@@ -320,7 +322,7 @@ describe("local coach composition", () => {
         resetSession: async () => ({ memoryFlushed: true }),
       }),
       now: () => 1_752_796_800_000,
-    }, { home, store });
+    }, { home, store, listener: inertWriterProtocolListener });
     await expect(lifecycle.engine.chat({ chatId: "x", message: "status" }))
       .resolves.toEqual({ text: "anchored" });
     expect(chatRequest?.turn?.resolvedCs).toMatchObject({ kind: "ftp", watts: 275 });

--- a/packages/coach/tests/daemon-healthz-server.test.ts
+++ b/packages/coach/tests/daemon-healthz-server.test.ts
@@ -1,0 +1,64 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { describe, expect, it, vi } from "vitest";
+import { PROTOCOL_VERSION } from "@enduragent/coach-contract";
+import { createHealthzRequestHandler } from "../src/daemon/healthz-server.js";
+
+function responseCapture() {
+  const headers = new Map<string, string>();
+  let body = "";
+  const response = {
+    statusCode: 0,
+    setHeader(name: string, value: string) {
+      headers.set(name.toLowerCase(), value);
+      return response;
+    },
+    end(value?: string) {
+      body += value ?? "";
+      return response;
+    },
+  } as unknown as ServerResponse;
+  return { response, headers, body: () => body };
+}
+
+describe("healthz request handler", () => {
+  it("returns the exact healthy body and headers only for GET /healthz", () => {
+    const handler = createHealthzRequestHandler({
+      appVersion: "0.1.0-synthetic",
+      owner: "unmanaged-foreground",
+    });
+    const capture = responseCapture();
+    handler({ method: "GET", url: "/healthz" } as IncomingMessage, capture.response);
+
+    expect(capture.response.statusCode).toBe(200);
+    expect(Object.fromEntries(capture.headers)).toEqual({
+      "cache-control": "no-store",
+      "content-type": "application/json; charset=utf-8",
+    });
+    expect(capture.body()).toBe(
+      `${JSON.stringify({
+        service: "enduragent-store-writer",
+        version: "0.1.0-synthetic",
+        protocolVersion: PROTOCOL_VERSION,
+        owner: "unmanaged-foreground",
+      })}\n`,
+    );
+  });
+
+  it.each([
+    ["POST", "/healthz"],
+    ["GET", "/healthz/"],
+    ["GET", "/rpc"],
+  ])("returns an empty 404 for %s %s", (method, url) => {
+    const handler = createHealthzRequestHandler({
+      appVersion: "synthetic",
+      owner: "unmanaged-foreground",
+    });
+    const capture = responseCapture();
+    const end = vi.spyOn(capture.response, "end");
+    handler({ method, url } as IncomingMessage, capture.response);
+    expect(capture.response.statusCode).toBe(404);
+    expect(capture.headers.size).toBe(0);
+    expect(capture.body()).toBe("");
+    expect(end).toHaveBeenCalledWith();
+  });
+});

--- a/packages/coach/tests/daemon-rpc-server.test.ts
+++ b/packages/coach/tests/daemon-rpc-server.test.ts
@@ -1,0 +1,396 @@
+import { createServer } from "node:http";
+import type { IncomingMessage } from "node:http";
+import { createServer as createNetServer } from "node:net";
+import type { AddressInfo } from "node:net";
+import {
+  chmod,
+  lstat,
+  mkdtemp,
+  readFile,
+  realpath,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Duplex } from "node:stream";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import WebSocket from "ws";
+import {
+  PROTOCOL_VERSION,
+  ServerHandshakeFrameSchema,
+  createClientHandshakeFrame,
+  parseCoachRpcEnvelope,
+  type AthleteState,
+  type CoachEngine,
+} from "@enduragent/coach-contract";
+import { createCoachRpcServer, ensureDaemonToken } from "../src/daemon/rpc-server.js";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+const state: AthleteState = {
+  schemaVersion: "3",
+  lastUpdated: "2026-07-18T00:00:00.000Z",
+  freshness: "fresh",
+  degraded: false,
+  lastSynced: "2026-07-18T00:00:00.000Z",
+  athleteProfile: {},
+  currentStatus: {},
+  derivedMetrics: {},
+  recentActivities: [],
+  plannedWorkouts: [],
+  wellness: {},
+};
+
+function engine(overrides: Partial<CoachEngine> = {}): CoachEngine {
+  return {
+    chat: async () => ({ text: "ok" }),
+    resetSession: async () => ({ memoryFlushed: true }),
+    hasSession: async () => ({ hasSession: false }),
+    getAthleteState: async () => state,
+    ...overrides,
+  };
+}
+
+class CaptureSocket extends Duplex {
+  readonly writes: Buffer[] = [];
+
+  _read(): void {}
+
+  _write(
+    chunk: Buffer | string,
+    encoding: BufferEncoding,
+    callback: (error?: Error | null) => void,
+  ): void {
+    this.writes.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk, encoding));
+    callback();
+  }
+}
+
+function request(url: string, headers: IncomingMessage["headers"] = {}): IncomingMessage {
+  return { url, headers } as IncomingMessage;
+}
+
+async function turn(): Promise<void> {
+  await new Promise<void>((resolve) => setImmediate(resolve));
+}
+
+describe("daemon token", () => {
+  it("creates and reuses one exact 0600 base64url token", async () => {
+    const root = await mkdtemp(join(await realpath(tmpdir()), "daemon-token-"));
+    roots.push(root);
+    const bytes = Buffer.alloc(32, 7);
+    const created = await ensureDaemonToken(root, { randomBytes: () => bytes });
+    expect(created.path).toBe(join(root, "daemon.token"));
+    expect(created.value).toMatch(/^[A-Za-z0-9_-]{43}$/);
+    expect(await readFile(created.path, "utf8")).toBe(`${created.value}\n`);
+    expect((await lstat(created.path)).mode & 0o777).toBe(0o600);
+    await expect(ensureDaemonToken(root)).resolves.toEqual(created);
+  });
+
+  it("fails closed for symlinks, invalid content, and over-permissive modes", async () => {
+    for (const fixture of ["symlink", "invalid", "mode"] as const) {
+      const root = await mkdtemp(join(await realpath(tmpdir()), `daemon-token-${fixture}-`));
+      roots.push(root);
+      const path = join(root, "daemon.token");
+      if (fixture === "symlink") {
+        const target = join(root, "target");
+        await writeFile(target, `${"x".repeat(43)}\n`, { mode: 0o600 });
+        await symlink(target, path);
+      } else {
+        await writeFile(path, fixture === "invalid" ? "not-a-token\n" : `${"x".repeat(43)}\n`, {
+          mode: 0o600,
+        });
+        if (fixture === "mode") await chmod(path, 0o644);
+      }
+      await expect(ensureDaemonToken(root)).rejects.toThrow("daemon token file is invalid");
+      if (fixture === "mode") expect((await lstat(path)).mode & 0o777).toBe(0o644);
+    }
+  });
+});
+
+describe("RPC upgrade refusal", () => {
+  it.each([
+    [
+      "Origin wins over bad path and query",
+      "/bad?token=x",
+      { origin: "" },
+      "HTTP/1.1 403 Forbidden\r\nConnection: close\r\nContent-Length: 0\r\n\r\n",
+    ],
+    [
+      "bad relative target",
+      "http://example.test/rpc",
+      {},
+      "HTTP/1.1 400 Bad Request\r\nConnection: close\r\nContent-Length: 0\r\n\r\n",
+    ],
+    [
+      "path wins over query",
+      "/bad?token=x",
+      {},
+      "HTTP/1.1 404 Not Found\r\nConnection: close\r\nContent-Length: 0\r\n\r\n",
+    ],
+    [
+      "empty query is rejected",
+      "/rpc?",
+      {},
+      "HTTP/1.1 400 Bad Request\r\nConnection: close\r\nContent-Length: 0\r\n\r\n",
+    ],
+  ])("writes exact bytes once: %s", async (_name, url, headers, expected) => {
+    const rpc = createCoachRpcServer({
+      engine: engine(),
+      token: "x".repeat(43),
+      owner: "unmanaged-foreground",
+    });
+    const socket = new CaptureSocket();
+    rpc.handleUpgrade(request(url, headers), socket, Buffer.alloc(0));
+    await turn();
+    expect(Buffer.concat(socket.writes).toString("ascii")).toBe(expected);
+    expect(socket.writes).toHaveLength(1);
+    expect(socket.destroyed).toBe(true);
+    await rpc.close();
+  });
+});
+
+async function loopbackAvailable(): Promise<boolean> {
+  return new Promise((resolve) => {
+    const server = createNetServer();
+    server.once("error", (error: NodeJS.ErrnoException) => {
+      if (error.code === "EPERM") {
+        process.stderr.write("SKIP_MARKER loopback-listen EPERM daemon-rpc-server\n");
+        resolve(false);
+        return;
+      }
+      resolve(false);
+    });
+    server.listen({ host: "127.0.0.1", port: 0 }, () => {
+      server.close(() => resolve(true));
+    });
+  });
+}
+
+const hasLoopback = await loopbackAvailable();
+
+interface FrameQueue {
+  next(): Promise<string>;
+}
+
+function frameQueue(ws: WebSocket): FrameQueue {
+  const frames: string[] = [];
+  const waiters: Array<(frame: string) => void> = [];
+  ws.on("message", (data) => {
+    const frame = data.toString();
+    const waiter = waiters.shift();
+    if (waiter === undefined) frames.push(frame);
+    else waiter(frame);
+  });
+  return {
+    next() {
+      const frame = frames.shift();
+      return frame === undefined
+        ? new Promise<string>((resolve) => waiters.push(resolve))
+        : Promise.resolve(frame);
+    },
+  };
+}
+
+async function openSocket(
+  rpc: ReturnType<typeof createCoachRpcServer>,
+): Promise<{ readonly ws: WebSocket; readonly frames: FrameQueue; close(): Promise<void> }> {
+  const server = createServer((_request, response) => {
+    response.statusCode = 404;
+    response.end();
+  });
+  server.on("upgrade", rpc.handleUpgrade);
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen({ host: "127.0.0.1", port: 0 }, resolve);
+  });
+  const port = (server.address() as AddressInfo).port;
+  const ws = new WebSocket(`ws://127.0.0.1:${port}/rpc`);
+  await new Promise<void>((resolve, reject) => {
+    ws.once("open", resolve);
+    ws.once("error", reject);
+  });
+  return {
+    ws,
+    frames: frameQueue(ws),
+    async close() {
+      await rpc.close();
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error === undefined ? resolve() : reject(error)));
+      });
+    },
+  };
+}
+
+describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
+  it("accepts the first-frame token and projects all four registry methods", async () => {
+    const token = "x".repeat(43);
+    const calls: string[] = [];
+    const rpc = createCoachRpcServer({
+      token,
+      owner: "unmanaged-foreground",
+      engine: engine({
+        chat: async (chatRequest, onEvent) => {
+          calls.push(`chat:${chatRequest.chatId}`);
+          onEvent?.({ type: "turn-start", turnId: "turn-1", chatId: chatRequest.chatId });
+          onEvent?.({ type: "final-text", turnId: "turn-1", text: "done" });
+          return { text: "done" };
+        },
+        resetSession: async ({ chatId }) => {
+          calls.push(`resetSession:${chatId}`);
+          return { memoryFlushed: true };
+        },
+        hasSession: async ({ chatId }) => {
+          calls.push(`hasSession:${chatId}`);
+          return { hasSession: true };
+        },
+        getAthleteState: async () => {
+          calls.push("getAthleteState");
+          return state;
+        },
+      }),
+    });
+    const client = await openSocket(rpc);
+    client.ws.send(JSON.stringify(createClientHandshakeFrame(token)));
+    expect(ServerHandshakeFrameSchema.parse(JSON.parse(await client.frames.next()))).toEqual({
+      type: "handshake",
+      status: "accepted",
+      clientProtocolVersion: PROTOCOL_VERSION,
+      serverProtocolVersion: PROTOCOL_VERSION,
+      owner: "unmanaged-foreground",
+    });
+
+    client.ws.send(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: "chat-1",
+        method: "chat",
+        params: { chatId: "chat", message: "hello" },
+      }),
+    );
+    const firstEvent = parseCoachRpcEnvelope(await client.frames.next());
+    const secondEvent = parseCoachRpcEnvelope(await client.frames.next());
+    const chatTerminal = parseCoachRpcEnvelope(await client.frames.next());
+    expect(firstEvent).toMatchObject({
+      method: "coach.turnEvent",
+      params: { requestId: "chat-1", requestMethod: "chat", turnId: "turn-1" },
+    });
+    expect(secondEvent).toMatchObject({
+      method: "coach.turnEvent",
+      params: { event: { type: "final-text", text: "done" } },
+    });
+    expect(chatTerminal).toEqual({ jsonrpc: "2.0", id: "chat-1", result: { text: "done" } });
+
+    const requests = [
+      { id: 2, method: "resetSession", params: { chatId: "chat" } },
+      { id: 3, method: "hasSession", params: { chatId: "chat" } },
+      { id: 4, method: "getAthleteState", params: {} },
+    ];
+    for (const value of requests) {
+      client.ws.send(JSON.stringify({ jsonrpc: "2.0", ...value }));
+      const response = parseCoachRpcEnvelope(await client.frames.next());
+      expect(response).toMatchObject({ jsonrpc: "2.0", id: value.id });
+    }
+    expect(calls).toEqual(["chat:chat", "resetSession:chat", "hasSession:chat", "getAthleteState"]);
+    await client.close();
+  });
+
+  it("uses authoritative protocol errors, recoverable ids, and method lookup order", async () => {
+    const token = "x".repeat(43);
+    const rpc = createCoachRpcServer({
+      engine: engine(),
+      token,
+      owner: "unmanaged-foreground",
+    });
+    const client = await openSocket(rpc);
+    client.ws.send(JSON.stringify(createClientHandshakeFrame(token)));
+    await client.frames.next();
+    const cases = [
+      ["{", { id: null, error: { code: -32700, message: "Parse error" } }],
+      [JSON.stringify([]), { id: null, error: { code: -32600, message: "Invalid Request" } }],
+      [
+        JSON.stringify({ jsonrpc: "2.0", id: 7, method: "unknown", params: {} }),
+        { id: 7, error: { code: -32601, message: "Method not found" } },
+      ],
+      [
+        JSON.stringify({ jsonrpc: "2.0", id: "known", method: "chat", params: {} }),
+        { id: "known", error: { code: -32602, message: "Invalid params" } },
+      ],
+      [
+        JSON.stringify({ jsonrpc: "1.0", id: "recoverable", method: "chat", params: {} }),
+        { id: "recoverable", error: { code: -32600, message: "Invalid Request" } },
+      ],
+    ] as const;
+    for (const [payload, expected] of cases) {
+      client.ws.send(payload);
+      expect(parseCoachRpcEnvelope(await client.frames.next())).toMatchObject(expected);
+    }
+    await client.close();
+  });
+
+  it("converts a non-JSON registry result into one fixed internal terminal error", async () => {
+    const token = "x".repeat(43);
+    const rpc = createCoachRpcServer({
+      engine: engine({
+        getAthleteState: async () => ({
+          ...state,
+          athleteProfile: 1n,
+        }),
+      }),
+      token,
+      owner: "unmanaged-foreground",
+    });
+    const client = await openSocket(rpc);
+    client.ws.send(JSON.stringify(createClientHandshakeFrame(token)));
+    await client.frames.next();
+    client.ws.send(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: "non-json-result",
+        method: "getAthleteState",
+        params: {},
+      }),
+    );
+    expect(parseCoachRpcEnvelope(await client.frames.next())).toEqual({
+      jsonrpc: "2.0",
+      id: "non-json-result",
+      error: { code: -32603, message: "Internal error" },
+    });
+    await client.close();
+  });
+
+  it("returns schema-valid mismatch frames in both directions without dispatch", async () => {
+    const token = "x".repeat(43);
+    for (const clientProtocolVersion of [PROTOCOL_VERSION - 1, PROTOCOL_VERSION + 1]) {
+      const chat = vi.fn(async () => ({ text: "unused" }));
+      const rpc = createCoachRpcServer({
+        engine: engine({ chat }),
+        token,
+        owner: "unmanaged-foreground",
+      });
+      const client = await openSocket(rpc);
+      client.ws.send(
+        JSON.stringify({
+          type: "handshake",
+          token,
+          clientProtocolVersion,
+        }),
+      );
+      const frame = ServerHandshakeFrameSchema.parse(JSON.parse(await client.frames.next()));
+      expect(frame).toMatchObject({
+        status: "version-mismatch",
+        clientProtocolVersion,
+        serverProtocolVersion: PROTOCOL_VERSION,
+        direction: clientProtocolVersion < PROTOCOL_VERSION ? "client-older" : "client-newer",
+      });
+      expect(chat).not.toHaveBeenCalled();
+      await client.close();
+    }
+  });
+});

--- a/packages/coach/tests/daemon-scheduler.test.ts
+++ b/packages/coach/tests/daemon-scheduler.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it, vi } from "vitest";
+import { createWallClockScheduler } from "../src/daemon/scheduler.js";
+
+interface Deferred<T> {
+  readonly promise: Promise<T>;
+  resolve(value: T): void;
+  reject(error: unknown): void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function fakeClock(initialEpochMs: number) {
+  let epochMs = initialEpochMs;
+  let pending: { readonly callback: () => void; readonly delay: number } | undefined;
+  const unref = vi.fn();
+  const clearTimeout = vi.fn(() => {
+    pending = undefined;
+  });
+  const setTimeout = vi.fn((callback: () => void, delay?: number) => {
+    pending = { callback, delay: delay ?? 0 };
+    return { unref } as unknown as ReturnType<typeof globalThis.setTimeout>;
+  }) as unknown as typeof globalThis.setTimeout;
+  return {
+    dependencies: {
+      nowEpochMs: () => epochMs,
+      setTimeout,
+      clearTimeout: clearTimeout as unknown as typeof globalThis.clearTimeout,
+    },
+    setEpoch(value: number) {
+      epochMs = value;
+    },
+    pending() {
+      return pending;
+    },
+    fire() {
+      const timer = pending;
+      if (timer === undefined) throw new Error("no pending timer");
+      pending = undefined;
+      timer.callback();
+    },
+    unref,
+    clearTimeout,
+  };
+}
+
+async function settle(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("wall-clock scheduler", () => {
+  it("anchors 10:05 to 12:00 and recomputes 18:00 after a 12:07 completion", async () => {
+    const cadenceMs = 6 * 60 * 60 * 1_000;
+    const tenOhFive = Date.UTC(2026, 6, 18, 10, 5);
+    const clock = fakeClock(tenOhFive);
+    const run = deferred<void>();
+    const execute = vi.fn(() => run.promise);
+    const scheduler = createWallClockScheduler({
+      cadenceMs,
+      run: execute,
+      dependencies: clock.dependencies,
+    });
+
+    scheduler.start();
+    scheduler.start();
+    expect(clock.pending()?.delay).toBe(Date.UTC(2026, 6, 18, 12) - tenOhFive);
+    expect(clock.unref).toHaveBeenCalledTimes(1);
+
+    clock.setEpoch(Date.UTC(2026, 6, 18, 12));
+    clock.fire();
+    await settle();
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(clock.pending()).toBeUndefined();
+
+    clock.setEpoch(Date.UTC(2026, 6, 18, 12, 7));
+    run.resolve();
+    await settle();
+    expect(clock.pending()?.delay).toBe(Date.UTC(2026, 6, 18, 18) - Date.UTC(2026, 6, 18, 12, 7));
+    await scheduler.close();
+  });
+
+  it("skips elapsed boundaries, never overlaps, and continues after rejection", async () => {
+    const clock = fakeClock(1);
+    const first = deferred<void>();
+    const failure = new Error("refresh failed");
+    const onError = vi.fn();
+    const run = vi
+      .fn()
+      .mockImplementationOnce(() => first.promise)
+      .mockRejectedValueOnce(failure)
+      .mockResolvedValue(undefined);
+    const scheduler = createWallClockScheduler({
+      cadenceMs: 100,
+      run,
+      onError,
+      dependencies: clock.dependencies,
+    });
+
+    scheduler.start();
+    clock.setEpoch(100);
+    clock.fire();
+    await settle();
+    expect(run).toHaveBeenCalledTimes(1);
+    clock.setEpoch(450);
+    first.resolve();
+    await settle();
+    expect(clock.pending()?.delay).toBe(50);
+
+    clock.setEpoch(500);
+    clock.fire();
+    await settle();
+    expect(onError).toHaveBeenCalledWith(failure);
+    expect(clock.pending()?.delay).toBe(100);
+    await scheduler.close();
+  });
+
+  it("drains an active run and closes idempotently without rescheduling", async () => {
+    const clock = fakeClock(0);
+    const active = deferred<void>();
+    const scheduler = createWallClockScheduler({
+      cadenceMs: 100,
+      run: () => active.promise,
+      dependencies: clock.dependencies,
+    });
+
+    scheduler.start();
+    clock.setEpoch(100);
+    clock.fire();
+    await settle();
+    let closed = false;
+    const close = scheduler.close().then(() => {
+      closed = true;
+    });
+    expect(closed).toBe(false);
+    active.resolve();
+    await close;
+    await scheduler.close();
+    expect(clock.pending()).toBeUndefined();
+  });
+
+  it("rejects invalid cadence values", () => {
+    for (const cadenceMs of [0, -1, 1.5, Number.MAX_SAFE_INTEGER + 1]) {
+      expect(() => createWallClockScheduler({ cadenceMs, run: async () => {} })).toThrow(
+        RangeError,
+      );
+    }
+  });
+});

--- a/packages/coach/tests/enduragent-entry.test.ts
+++ b/packages/coach/tests/enduragent-entry.test.ts
@@ -1,6 +1,8 @@
-import { mkdir, mkdtemp, readFile, realpath, rm } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { mkdir, mkdtemp, readFile, readdir, realpath, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { createServer } from "node:net";
 import { PassThrough, Writable } from "node:stream";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -8,11 +10,15 @@ import {
   EXIT_DAEMON_UNAVAILABLE,
   EXIT_SUCCESS,
   EXIT_USAGE,
+  EXIT_VERSION_MISMATCH,
   type AthleteState,
   type CoachEngine,
 } from "@enduragent/coach-contract";
 import type { AthleteHome } from "@enduragent/kernel-node/home";
-import { PORT_FILE_NAME } from "@enduragent/kernel-node/lock";
+import { inertWriterProtocolListener, PORT_FILE_NAME } from "@enduragent/kernel-node/lock";
+import { StoreNewerThanAppError } from "@enduragent/kernel/store";
+import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
+import { openSqliteStorage } from "@enduragent/kernel-node/sqlite";
 import {
   runEnduragent,
   type EnduragentDependencies,
@@ -110,6 +116,19 @@ let scratch: string;
 let home: AthleteHome;
 let env: Record<string, string | undefined>;
 
+const hasLoopback = await new Promise<boolean>((resolve) => {
+  const server = createServer();
+  server.once("error", (error: NodeJS.ErrnoException) => {
+    if (error.code === "EPERM") {
+      process.stderr.write("SKIP_MARKER loopback-listen EPERM enduragent-entry\n");
+    }
+    resolve(false);
+  });
+  server.listen({ host: "127.0.0.1", port: 0 }, () => {
+    server.close(() => resolve(true));
+  });
+});
+
 beforeEach(async () => {
   scratch = await mkdtemp(join(await realpath(tmpdir()), "enduragent-entry-"));
   roots.push(scratch);
@@ -201,7 +220,7 @@ describe("enduragent executable composition", () => {
       ),
     ).resolves.toBe(EXIT_USAGE);
     expect(io.stdout.read()).toBe("");
-    expect(io.stderr.read()).toBe("Usage: enduragent [version]\n");
+    expect(io.stderr.read()).toBe("Usage: enduragent [version|serve]\n");
     expect(homeCalls).toBe(0);
     expect(runnerCalls).toBe(0);
   });
@@ -342,6 +361,7 @@ describe("enduragent executable composition", () => {
     });
     const lifecycle = {
       engine: mocked.engine,
+      listener: inertWriterProtocolListener,
       close: async () => {
         trace.push("lifecycle-close");
       },
@@ -392,6 +412,124 @@ describe("enduragent executable composition", () => {
     ] as const) {
       expect(trace.indexOf(earlier)).toBeLessThan(trace.indexOf(later));
     }
+  });
+
+  it("routes serve through one local runner with the shared migration inputs", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const mocked = mockEngine();
+    let captured: WithLocalCoachInput<unknown> | undefined;
+    let packageReads = 0;
+    const io = terminal(new PassThrough(), true);
+    await expect(runEnduragent(
+      {
+        argv: ["serve"],
+        env,
+        terminal: io.value,
+        signal: controller.signal,
+      },
+      {
+        resolveAthleteHome: () => home,
+        readPackageVersion: async () => {
+          packageReads += 1;
+          return "0.1.0-synthetic";
+        },
+        withLocalCoach: async <T>(input: WithLocalCoachInput<T>) => {
+          captured = input as unknown as WithLocalCoachInput<unknown>;
+          const value = await input.operation({
+            engine: mocked.engine,
+            listener: inertWriterProtocolListener,
+            async close() {},
+          });
+          return { status: "completed", value };
+        },
+      },
+    )).resolves.toBe(EXIT_SUCCESS);
+    expect(packageReads).toBe(1);
+    expect(captured).toMatchObject({
+      env,
+      home,
+      sourceRoot: env.CYCLING_COACH_HOME,
+      action: { kind: "resume", isTTY: true },
+    });
+    expect(io.stdout.read()).toBe("");
+    expect(io.stderr.read()).toBe("");
+  });
+
+  it.each([
+    { argv: [] as readonly string[] },
+    { argv: ["serve"] as readonly string[] },
+  ])("maps the exact typed newer-store cause to exit 5 for $argv", async ({ argv }) => {
+    const newer = new StoreNewerThanAppError(3, 2);
+    const failure = new CoachStoreWriterError(
+      "writer-failed",
+      "run migrations",
+      { cause: newer },
+    );
+    const io = terminal();
+    await expect(runEnduragent(
+      {
+        argv,
+        env,
+        terminal: io.value,
+        signal: new AbortController().signal,
+      },
+      {
+        resolveAthleteHome: () => home,
+        withLocalCoach: async () => {
+          throw failure;
+        },
+        readPackageVersion: async () => "0.1.0-synthetic",
+      },
+    )).resolves.toBe(EXIT_VERSION_MISMATCH);
+    expect(io.stdout.read()).toBe("");
+    expect(io.stderr.read()).toBe(
+      "Enduragent cannot start: this athlete store was created by a newer app version. Update Enduragent and retry.\n",
+    );
+  });
+
+  it.runIf(hasLoopback)("preserves a real newer store and releases the writer after serve exits 5", async () => {
+    await mkdir(home.storeDir, { recursive: true, mode: 0o700 });
+    const databasePath = join(home.storeDir, "store.db");
+    const maximum = MIGRATIONS.at(-1)!.version;
+    const seed = openSqliteStorage(databasePath);
+    await seed.setUserVersion(maximum + 1);
+    await seed.close();
+    const beforeNames = (await readdir(home.storeDir)).sort();
+    const beforeHash = createHash("sha256").update(await readFile(databasePath)).digest("hex");
+    const io = terminal();
+
+    await expect(runEnduragent(
+      {
+        argv: ["serve"],
+        env,
+        terminal: io.value,
+        signal: new AbortController().signal,
+      },
+      {
+        resolveAthleteHome: () => home,
+        readPackageVersion: async () => "0.1.0-synthetic",
+        withLocalCoach: async <T>(): Promise<LocalCoachRunResult<T>> => {
+          await withCoachStoreWriter(env, async () => {
+            throw new Error("operation must not run for a newer store");
+          });
+          throw new Error("newer store unexpectedly opened");
+        },
+      },
+    )).resolves.toBe(EXIT_VERSION_MISMATCH);
+    expect(io.stdout.read()).toBe("");
+    expect(io.stderr.read()).toBe(
+      "Enduragent cannot start: this athlete store was created by a newer app version. Update Enduragent and retry.\n",
+    );
+    expect((await readdir(home.storeDir)).sort()).toEqual(beforeNames);
+    expect(createHash("sha256").update(await readFile(databasePath)).digest("hex")).toBe(beforeHash);
+    await expect(readFile(join(home.configDir, PORT_FILE_NAME), "utf8")).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    await expect(readFile(join(home.configDir, "store-writer.lock"), "utf8"))
+      .rejects.toMatchObject({ code: "ENOENT" });
+    await expect(readFile(join(home.configDir, "daemon.token"), "utf8"))
+      .rejects.toMatchObject({ code: "ENOENT" });
   });
 
   it("uses typed writer errors and redacts every other startup failure", async () => {
@@ -468,44 +606,46 @@ describe("enduragent executable composition", () => {
   });
 
   it("reports real contention and drains an in-flight turn before release", async () => {
-    const writerAcquired = deferred<void>();
-    const releaseWriter = deferred<void>();
-    const holdingWriter = withCoachStoreWriter(env, async () => {
-      writerAcquired.resolve(undefined);
-      await releaseWriter.promise;
-    });
-    await Promise.race([
-      writerAcquired.promise,
-      holdingWriter.then(() => Promise.reject(new Error("writer ended early"))),
-    ]);
-    try {
-      const port = Number.parseInt(
-        await readFile(join(home.configDir, PORT_FILE_NAME), "utf8"),
-        10,
-      );
-      const io = terminal();
-      await expect(
-        runEnduragent(
-          {
-            argv: [],
-            env,
-            terminal: io.value,
-            signal: new AbortController().signal,
-          },
-          {
-            resolveAthleteHome: () => home,
-            withLocalCoach,
-            readPackageVersion: async () => "unused",
-          },
-        ),
-      ).resolves.toBe(EXIT_DAEMON_UNAVAILABLE);
-      expect(io.stdout.read()).toBe("");
-      expect(io.stderr.read()).toBe(
-        `Enduragent cannot start: another writer holds this athlete home (pid ${process.pid}, port ${port}). Stop it or wait, then retry.\n`,
-      );
-    } finally {
-      releaseWriter.resolve(undefined);
-      await holdingWriter;
+    if (hasLoopback) {
+      const writerAcquired = deferred<void>();
+      const releaseWriter = deferred<void>();
+      const holdingWriter = withCoachStoreWriter(env, async () => {
+        writerAcquired.resolve(undefined);
+        await releaseWriter.promise;
+      });
+      await Promise.race([
+        writerAcquired.promise,
+        holdingWriter.then(() => Promise.reject(new Error("writer ended early"))),
+      ]);
+      try {
+        const port = Number.parseInt(
+          await readFile(join(home.configDir, PORT_FILE_NAME), "utf8"),
+          10,
+        );
+        const io = terminal();
+        await expect(
+          runEnduragent(
+            {
+              argv: [],
+              env,
+              terminal: io.value,
+              signal: new AbortController().signal,
+            },
+            {
+              resolveAthleteHome: () => home,
+              withLocalCoach,
+              readPackageVersion: async () => "unused",
+            },
+          ),
+        ).resolves.toBe(EXIT_DAEMON_UNAVAILABLE);
+        expect(io.stdout.read()).toBe("");
+        expect(io.stderr.read()).toBe(
+          `Enduragent cannot start: another writer holds this athlete home (pid ${process.pid}, port ${port}). Stop it or wait, then retry.\n`,
+        );
+      } finally {
+        releaseWriter.resolve(undefined);
+        await holdingWriter;
+      }
     }
 
     const trace: string[] = [];
@@ -523,6 +663,7 @@ describe("enduragent executable composition", () => {
     ): Promise<LocalCoachRunResult<T>> => {
       const lifecycle = {
         engine: mocked.engine,
+        listener: inertWriterProtocolListener,
         close: async () => {
           trace.push("lifecycle-close");
         },

--- a/packages/coach/tests/local-runner.test.ts
+++ b/packages/coach/tests/local-runner.test.ts
@@ -6,6 +6,7 @@ import type { AthleteState, CoachEngine } from "@enduragent/coach-contract";
 import type { Config } from "@enduragent/core";
 import type { EngineConfig } from "@enduragent/engine";
 import type { AthleteHome } from "@enduragent/kernel-node/home";
+import { inertWriterProtocolListener } from "@enduragent/kernel-node/lock";
 import type { CoachStoreWriterContext, CoachStoreWriterPlan } from "../src/runtime.js";
 
 const mocks = vi.hoisted(() => ({
@@ -40,7 +41,7 @@ vi.mock("@enduragent/core", async (importOriginal) => ({
 }));
 
 import { CoachStoreWriterError } from "../src/runtime.js";
-import { withLocalCoach } from "../src/local-runner.js";
+import { withLocalCoach, type LocalCoachLifecycle } from "../src/local-runner.js";
 
 const state: AthleteState = {
   schemaVersion: "3",
@@ -126,7 +127,7 @@ function notNeeded() {
   };
 }
 
-function input(operation: (lifecycle: { engine: CoachEngine; close(): Promise<void> }) => Promise<unknown>) {
+function input(operation: (lifecycle: LocalCoachLifecycle) => Promise<unknown>) {
   return {
     env: { SYNTHETIC: "1" },
     home: selectedHome,
@@ -138,7 +139,11 @@ function input(operation: (lifecycle: { engine: CoachEngine; close(): Promise<vo
 
 beforeEach(async () => {
   selectedHome = await freshHome();
-  context = { home: selectedHome, store: store() };
+  context = {
+    home: selectedHome,
+    store: store(),
+    listener: inertWriterProtocolListener,
+  };
   trace = [];
   closeImplementation = async () => { trace.push("lifecycle-close"); };
   mocks.withWriter.mockReset();
@@ -184,7 +189,8 @@ afterEach(async () => {
 describe("local coach runner", () => {
   it("runs the exact successful lock, migration, store, engine, operation, and cleanup order", async () => {
     trace.push("resolve-supplied-home");
-    await expect(withLocalCoach(input(async () => {
+    await expect(withLocalCoach(input(async (lifecycle) => {
+      expect(lifecycle.listener).toBe(inertWriterProtocolListener);
       trace.push("operation");
       return "done";
     }))).resolves.toEqual({ status: "completed", value: "done" });

--- a/packages/coach/tests/package-exports.test.ts
+++ b/packages/coach/tests/package-exports.test.ts
@@ -6,12 +6,13 @@ import { describe, expect, it } from "vitest";
 const coachRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 
 describe("coach package handoff", () => {
-  it("preserves the dispatch package surface and adds only local-runner", async () => {
+  it("preserves the dispatch package surface and adds serve", async () => {
     const packageJson = JSON.parse(
       await readFile(join(coachRoot, "package.json"), "utf8"),
     ) as {
       exports: Record<string, string>;
       scripts: Record<string, string>;
+      bin: Record<string, string>;
     };
     expect(packageJson.exports).toEqual({
       "./runtime": "./dist/runtime.js",
@@ -22,8 +23,10 @@ describe("coach package handoff", () => {
       "./local-bundle-producer": "./dist/local-bundle-producer.js",
       "./store-runtime": "./dist/store-runtime.js",
       "./local-runner": "./dist/local-runner.js",
+      "./serve": "./dist/serve.js",
       "./enduragent": "./dist/enduragent.js",
     });
+    expect(packageJson.bin).toEqual({ enduragent: "./dist/enduragent.js" });
     expect(packageJson.scripts).toEqual({
       build: "tsup",
       check: "tsc --noEmit",
@@ -51,6 +54,7 @@ describe("coach package handoff", () => {
       "store-gate-command",
       "season-review-command",
       "local-runner",
+      "serve",
       "enduragent",
     ];
     for (const entry of entries) {

--- a/packages/coach/tests/serve.test.ts
+++ b/packages/coach/tests/serve.test.ts
@@ -1,0 +1,214 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { describe, expect, it, vi } from "vitest";
+import { EXIT_SUCCESS, type AthleteState, type CoachEngine } from "@enduragent/coach-contract";
+import type { AthleteHome } from "@enduragent/kernel-node/home";
+import type {
+  WriterProtocolBinding,
+  WriterProtocolHandlers,
+  WriterProtocolListener,
+} from "@enduragent/kernel-node/lock";
+import { runCoachServe, type CoachServeDependencies } from "../src/serve.js";
+import type { LocalCoachLifecycle } from "../src/local-runner.js";
+
+interface Deferred<T> {
+  readonly promise: Promise<T>;
+  resolve(value: T): void;
+  reject(error: unknown): void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+const state: AthleteState = {
+  schemaVersion: "3",
+  lastUpdated: "2026-07-18T00:00:00.000Z",
+  freshness: "fresh",
+  degraded: false,
+  lastSynced: "2026-07-18T00:00:00.000Z",
+  athleteProfile: {},
+  currentStatus: {},
+  derivedMetrics: {},
+  recentActivities: [],
+  plannedWorkouts: [],
+  wellness: {},
+};
+
+const engine: CoachEngine = {
+  chat: async () => ({ text: "ok" }),
+  resetSession: async () => ({ memoryFlushed: true }),
+  hasSession: async () => ({ hasSession: false }),
+  getAthleteState: async () => state,
+};
+
+const home: AthleteHome = {
+  root: "/synthetic/athlete",
+  storeDir: "/synthetic/athlete/store",
+  archiveDir: "/synthetic/athlete/archive",
+  configDir: "/synthetic/athlete/config",
+};
+
+function harness(
+  options: {
+    readonly token?: Promise<{ readonly path: string; readonly value: string }>;
+    readonly bind?: Promise<WriterProtocolBinding>;
+    readonly onCreateRpc?: () => void;
+  } = {},
+) {
+  const trace: string[] = [];
+  let handlers: WriterProtocolHandlers | undefined;
+  const binding: WriterProtocolBinding = {
+    port: 42_001,
+    async close() {
+      trace.push("protocol-stop");
+      await Promise.resolve();
+      trace.push("protocol-closed");
+    },
+  };
+  const listener: WriterProtocolListener = {
+    async bind(value) {
+      trace.push("protocol-bind");
+      handlers = value;
+      return options.bind ?? binding;
+    },
+  };
+  const lifecycle: LocalCoachLifecycle = {
+    engine,
+    listener,
+    async close() {
+      trace.push("lifecycle-close");
+    },
+  };
+  const ensureToken = vi.fn(async () => {
+    trace.push("token-ready");
+    return options.token ?? { path: `${home.configDir}/daemon.token`, value: "x".repeat(43) };
+  });
+  const rpcClose = vi.fn(async () => {
+    trace.push("rpc-drained");
+  });
+  const createRpcServer = vi.fn(() => {
+    trace.push("rpc-created");
+    options.onCreateRpc?.();
+    return { handleUpgrade: vi.fn(), close: rpcClose };
+  });
+  const createHealthzHandler = vi.fn(() => {
+    trace.push("health-handler-created");
+    return vi.fn() as unknown as (request: IncomingMessage, response: ServerResponse) => void;
+  });
+  const dependencies = {
+    ensureToken,
+    createRpcServer,
+    createHealthzHandler,
+  } as unknown as CoachServeDependencies;
+  return {
+    input: { lifecycle, home, appVersion: "0.1.0", signal: new AbortController().signal },
+    lifecycle,
+    dependencies,
+    binding,
+    trace,
+    handlers: () => handlers,
+    ensureToken,
+    createRpcServer,
+    createHealthzHandler,
+    rpcClose,
+  };
+}
+
+describe("runCoachServe", () => {
+  it("does no private setup for an already-aborted signal", async () => {
+    const controller = new AbortController();
+    controller.abort(new Error("synthetic secret reason"));
+    const test = harness();
+    await expect(
+      runCoachServe({ ...test.input, signal: controller.signal }, test.dependencies),
+    ).resolves.toBe(EXIT_SUCCESS);
+    expect(test.ensureToken).not.toHaveBeenCalled();
+    expect(test.createRpcServer).not.toHaveBeenCalled();
+    expect(test.trace).toEqual([]);
+  });
+
+  it("publishes the handler pair only at bind and drains protocol before RPC completion", async () => {
+    const controller = new AbortController();
+    const test = harness();
+    const result = runCoachServe({ ...test.input, signal: controller.signal }, test.dependencies);
+    await vi.waitFor(() => expect(test.handlers()).toBeDefined());
+    expect(test.trace).toEqual([
+      "token-ready",
+      "rpc-created",
+      "health-handler-created",
+      "protocol-bind",
+    ]);
+    expect(test.handlers()?.upgrade).toBe(
+      test.createRpcServer.mock.results[0]?.value.handleUpgrade,
+    );
+    controller.abort();
+    await expect(result).resolves.toBe(EXIT_SUCCESS);
+    expect(test.trace).toEqual([
+      "token-ready",
+      "rpc-created",
+      "health-handler-created",
+      "protocol-bind",
+      "protocol-stop",
+      "rpc-drained",
+      "protocol-closed",
+    ]);
+  });
+
+  it("stops before RPC construction when abort arrives during token setup", async () => {
+    const controller = new AbortController();
+    const token = deferred<{ path: string; value: string }>();
+    const test = harness({ token: token.promise });
+    const result = runCoachServe({ ...test.input, signal: controller.signal }, test.dependencies);
+    await vi.waitFor(() => expect(test.ensureToken).toHaveBeenCalledTimes(1));
+    controller.abort();
+    token.resolve({ path: `${home.configDir}/daemon.token`, value: "x".repeat(43) });
+    await expect(result).resolves.toBe(EXIT_SUCCESS);
+    expect(test.createRpcServer).not.toHaveBeenCalled();
+    expect(test.createHealthzHandler).not.toHaveBeenCalled();
+  });
+
+  it("closes RPC without binding when abort arrives immediately before bind", async () => {
+    const controller = new AbortController();
+    const test = harness({ onCreateRpc: () => controller.abort() });
+    await expect(
+      runCoachServe({ ...test.input, signal: controller.signal }, test.dependencies),
+    ).resolves.toBe(EXIT_SUCCESS);
+    expect(test.rpcClose).toHaveBeenCalledTimes(1);
+    expect(test.createHealthzHandler).not.toHaveBeenCalled();
+    expect(test.trace).toEqual(["token-ready", "rpc-created", "rpc-drained"]);
+  });
+
+  it("awaits an asynchronous bind raced by abort before complete shutdown", async () => {
+    const controller = new AbortController();
+    const bind = deferred<WriterProtocolBinding>();
+    const test = harness({ bind: bind.promise });
+    const result = runCoachServe({ ...test.input, signal: controller.signal }, test.dependencies);
+    await vi.waitFor(() => expect(test.createHealthzHandler).toHaveBeenCalledTimes(1));
+    controller.abort();
+    expect(test.rpcClose).not.toHaveBeenCalled();
+    bind.resolve(test.binding);
+    await expect(result).resolves.toBe(EXIT_SUCCESS);
+    expect(test.rpcClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("rethrows bind failure only after closing the constructed RPC server", async () => {
+    const failure = new Error("bind failed");
+    const bind = deferred<WriterProtocolBinding>();
+    bind.reject(failure);
+    const test = harness({ bind: bind.promise });
+    await expect(runCoachServe(test.input, test.dependencies)).rejects.toBe(failure);
+    expect(test.trace).toEqual([
+      "token-ready",
+      "rpc-created",
+      "health-handler-created",
+      "protocol-bind",
+      "rpc-drained",
+    ]);
+  });
+});

--- a/packages/coach/tests/store-runtime.test.ts
+++ b/packages/coach/tests/store-runtime.test.ts
@@ -62,7 +62,7 @@ describe("StoreRuntime", () => {
   it("owns one unref'd six-hour timer, skips overlap, and closes once", async () => {
     const root = await mkdtemp(join(await realpath(tmpdir()), "store-runtime-timer-")); roots.push(root);
     const unref = vi.fn(), clear = vi.fn(); let delay = 0;
-    const handle = { unref } as unknown as ReturnType<typeof setInterval>;
+    const handle = { unref } as unknown as ReturnType<typeof setTimeout>;
     let release!: () => void;
     const reference = { scheduler: { stop: vi.fn() }, services: {},
       runScheduledOnce: vi.fn(async () => ({ kind: "ran", lastSyncAt: "", refreshed: [] })) } as unknown as ReferenceRuntime;
@@ -70,8 +70,11 @@ describe("StoreRuntime", () => {
       archiveDir: join(root, "archive"), configDir: join(root, "config") }, reference,
       dependencies: { capture: vi.fn(() => new Promise<ReferenceCaptureManifest>((resolve) => { release = () => resolve(manifest); })),
         produce: vi.fn(async () => produced), now: () => new Date("1998-07-18T12:00:00.000Z"), monotonicNow: () => 1,
-        setInterval: ((_: () => void, ms: number) => { delay = ms; return handle; }) as typeof setInterval,
-        clearInterval: clear as unknown as typeof clearInterval } });
+        schedulerDependencies: {
+          nowEpochMs: () => new Date("1998-07-18T12:00:00.000Z").getTime(),
+          setTimeout: ((_: () => void, ms: number) => { delay = ms; return handle; }) as typeof setTimeout,
+          clearTimeout: clear as unknown as typeof clearTimeout,
+        } } });
     runtime.startScheduler(); runtime.startScheduler();
     expect(delay).toBe(STORE_REFRESH_INTERVAL_MS); expect(unref).toHaveBeenCalledTimes(1);
     const first = runtime.runWindow(), second = runtime.runWindow(); expect(first).toBe(second);
@@ -81,7 +84,7 @@ describe("StoreRuntime", () => {
 
   it("cancels an active window when closed and rejects later windows", async () => {
     const root = await mkdtemp(join(await realpath(tmpdir()), "store-runtime-close-")); roots.push(root);
-    const handle = { unref: vi.fn() } as unknown as ReturnType<typeof setInterval>;
+    const handle = { unref: vi.fn() } as unknown as ReturnType<typeof setTimeout>;
     let signal!: AbortSignal;
     const reference = { scheduler: { stop: vi.fn() }, services: {},
       runScheduledOnce: vi.fn(async () => ({ kind: "ran", lastSyncAt: "", refreshed: [] })) } as unknown as ReferenceRuntime;
@@ -93,8 +96,11 @@ describe("StoreRuntime", () => {
           signal.addEventListener("abort", () => reject(signal.reason), { once: true });
         });
       }), produce: vi.fn(async () => produced), now: () => new Date("1998-07-18T12:00:00.000Z"), monotonicNow: () => 1,
-        setInterval: vi.fn(() => handle) as unknown as typeof setInterval,
-        clearInterval: vi.fn() as unknown as typeof clearInterval } });
+        schedulerDependencies: {
+          nowEpochMs: () => new Date("1998-07-18T12:00:00.000Z").getTime(),
+          setTimeout: vi.fn(() => handle) as unknown as typeof setTimeout,
+          clearTimeout: vi.fn() as unknown as typeof clearTimeout,
+        } } });
     const window = runtime.runWindow();
     const rejectedWindow = expect(window).rejects.toThrow("Store runtime closed.");
     const close = runtime.close();

--- a/packages/coach/tsup.config.ts
+++ b/packages/coach/tsup.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
     "store-gate-command": "src/store-gate-command.ts",
     "season-review-command": "src/season-review-command.ts",
     "local-runner": "src/local-runner.ts",
+    serve: "src/serve.ts",
     enduragent: "src/enduragent.ts",
   },
   format: ["esm"],

--- a/packages/kernel-node/src/cli/coach-dev.ts
+++ b/packages/kernel-node/src/cli/coach-dev.ts
@@ -10,6 +10,7 @@ import { importFilesWithReport } from "../ingest/index.js";
 import {
   acquireWriteLock,
   WriteLockContentionError,
+  type WriterProtocolListener,
   type WriterContentionDiagnostic,
 } from "../lock/index.js";
 import { openSqliteStorage } from "../sqlite/index.js";
@@ -54,6 +55,7 @@ export type CoachDevWriterFailureStage =
 export interface CoachDevWriterContext {
   readonly home: AthleteHome;
   readonly store: ReturnType<typeof openSqliteStorage>;
+  readonly listener: WriterProtocolListener;
 }
 
 export interface RunCoachDevWriterOptions<T> {
@@ -228,7 +230,7 @@ export async function runCoachDevWriter<T>(
 
       if (failureStage === undefined && store !== undefined) {
         try {
-          value = await options.operation({ home, store });
+          value = await options.operation({ home, store, listener: lockResult.listener });
         } catch (error) {
           failureStage = "invoke operation";
           failureCause = error;

--- a/packages/kernel-node/src/lock/acquire.ts
+++ b/packages/kernel-node/src/lock/acquire.ts
@@ -1,7 +1,14 @@
+import {
+  createServer as createHttpServer,
+  type IncomingMessage,
+  type Server as HttpServer,
+  type ServerResponse,
+} from "node:http";
 import { createServer, type Server, type Socket, type AddressInfo } from "node:net";
 import { existsSync, mkdirSync, chmodSync, statSync } from "node:fs";
 import { unlink } from "node:fs/promises";
 import { join } from "node:path";
+import type { Duplex } from "node:stream";
 import { claimLockfile, readLockfile } from "./lockfile-body.js";
 import { readPortFile, writePortFile } from "./port-file.js";
 import { defaultHealthzProbe, isPortBound, type HealthzProbe } from "./healthz-probe.js";
@@ -40,11 +47,37 @@ export interface AcquireWriteLockOptions {
   readonly probeHealthz?: HealthzProbe;
 }
 
+export interface WriterProtocolHandlers {
+  readonly request: (request: IncomingMessage, response: ServerResponse) => void;
+  readonly upgrade: (request: IncomingMessage, socket: Duplex, head: Buffer) => void;
+}
+
+export interface WriterProtocolBinding {
+  readonly port: number;
+  close(): Promise<void>;
+}
+
+export interface WriterProtocolListener {
+  bind(handlers: WriterProtocolHandlers): Promise<WriterProtocolBinding>;
+}
+
+const inertWriterProtocolBinding: WriterProtocolBinding = Object.freeze({
+  port: 0,
+  async close() {},
+});
+
+export const inertWriterProtocolListener: WriterProtocolListener = Object.freeze({
+  async bind() {
+    return inertWriterProtocolBinding;
+  },
+});
+
 export interface WriteLockHandle {
   readonly status: "acquired";
   readonly port: number;
   readonly lockfilePath: string;
   readonly portFilePath: string;
+  readonly listener: WriterProtocolListener;
   release(): Promise<void>;
 }
 
@@ -88,6 +121,77 @@ function closeServer(server: Server, sockets: Set<Socket>): Promise<void> {
   return new Promise<void>((resolve) => server.close(() => resolve()));
 }
 
+interface OwnedProtocolServer {
+  readonly server: HttpServer;
+  readonly sockets: Set<Socket>;
+  readonly binding: WriterProtocolBinding;
+  forceClose(): Promise<void>;
+}
+
+function createProtocolServer(
+  handlers: WriterProtocolHandlers,
+): Promise<{ readonly server: HttpServer; readonly sockets: Set<Socket>; readonly port: number }> {
+  return new Promise((resolve, reject) => {
+    const sockets = new Set<Socket>();
+    const server = createHttpServer(handlers.request);
+    const onError = (error: Error): void => reject(error);
+    server.once("error", onError);
+    server.on("connection", (socket) => {
+      sockets.add(socket);
+      socket.on("error", () => {});
+      socket.on("close", () => sockets.delete(socket));
+    });
+    server.on("upgrade", handlers.upgrade);
+    server.listen({ host: "127.0.0.1", port: 0 }, () => {
+      server.off("error", onError);
+      resolve({ server, sockets, port: (server.address() as AddressInfo).port });
+    });
+  });
+}
+
+function ownProtocolServer(
+  server: HttpServer,
+  sockets: Set<Socket>,
+  port: number,
+): OwnedProtocolServer {
+  let closePromise: Promise<void> | undefined;
+  let force = false;
+  const close = (): Promise<void> => {
+    closePromise ??= new Promise<void>((resolve, reject) => {
+      let callbackSettled = false;
+      let callbackError: Error | undefined;
+      const settle = (): void => {
+        if (!callbackSettled || sockets.size !== 0) return;
+        if (callbackError === undefined) resolve();
+        else reject(callbackError);
+      };
+      for (const socket of sockets) socket.once("close", settle);
+      server.close((error) => {
+        callbackSettled = true;
+        callbackError = error;
+        settle();
+      });
+      server.closeAllConnections();
+      if (force) {
+        for (const socket of sockets) socket.destroy();
+      }
+      settle();
+    });
+    return closePromise;
+  };
+  const binding: WriterProtocolBinding = { port, close };
+  return {
+    server,
+    sockets,
+    binding,
+    forceClose() {
+      force = true;
+      for (const socket of sockets) socket.destroy();
+      return close();
+    },
+  };
+}
+
 async function bestEffortUnlink(path: string): Promise<void> {
   try {
     await unlink(path);
@@ -125,7 +229,9 @@ async function contentionAgainstBound(
   );
 }
 
-export async function acquireWriteLock(opts: AcquireWriteLockOptions): Promise<AcquireWriteLockResult> {
+export async function acquireWriteLock(
+  opts: AcquireWriteLockOptions,
+): Promise<AcquireWriteLockResult> {
   const probe = opts.probeHealthz ?? defaultHealthzProbe;
   ensureConfigDirSecure(opts.configDir);
   const lockfilePath = join(opts.configDir, LOCKFILE_NAME);
@@ -139,6 +245,40 @@ export async function acquireWriteLock(opts: AcquireWriteLockOptions): Promise<A
 
   const { server, sockets } = await bindWriterSocket();
   const actualPort = (server.address() as AddressInfo).port;
+  let released = false;
+  let listenerUsed = false;
+  let protocol: OwnedProtocolServer | undefined;
+  let bindingPromise: Promise<WriterProtocolBinding> | undefined;
+  let releasePromise: Promise<void> | undefined;
+
+  const listener: WriterProtocolListener = {
+    async bind(handlers): Promise<WriterProtocolBinding> {
+      if (released) throw new Error("writer protocol listener is released");
+      if (listenerUsed) throw new Error("writer protocol listener is already bound");
+      listenerUsed = true;
+      bindingPromise = (async () => {
+        const created = await createProtocolServer(handlers);
+        const owned = ownProtocolServer(created.server, created.sockets, created.port);
+        protocol = owned;
+        if (released) {
+          await owned.forceClose();
+          throw new Error("writer protocol listener is released");
+        }
+        try {
+          await writePortFile(portFilePath, created.port);
+        } catch (error) {
+          await owned.forceClose().catch(() => {});
+          throw error;
+        }
+        if (released) {
+          await owned.forceClose();
+          throw new Error("writer protocol listener is released");
+        }
+        return owned.binding;
+      })();
+      return bindingPromise;
+    },
+  };
 
   const claimAndFill = async (): Promise<WriteLockHandle> => {
     await claimLockfile(lockfilePath, {
@@ -153,10 +293,31 @@ export async function acquireWriteLock(opts: AcquireWriteLockOptions): Promise<A
       port: actualPort,
       lockfilePath,
       portFilePath,
-      release: async (): Promise<void> => {
-        await closeServer(server, sockets);
-        await bestEffortUnlink(lockfilePath);
-        await bestEffortUnlink(portFilePath);
+      listener,
+      release(): Promise<void> {
+        releasePromise ??= (async () => {
+          released = true;
+          let failure: unknown;
+          let protocolClose = protocol?.forceClose();
+          try {
+            await bindingPromise;
+          } catch {}
+          try {
+            protocolClose ??= protocol?.forceClose();
+            await protocolClose;
+          } catch (error) {
+            failure = error;
+          }
+          try {
+            await closeServer(server, sockets);
+          } catch (error) {
+            failure ??= error;
+          }
+          await bestEffortUnlink(lockfilePath);
+          await bestEffortUnlink(portFilePath);
+          if (failure !== undefined) throw failure;
+        })();
+        return releasePromise;
       },
     };
   };

--- a/packages/kernel-node/src/lock/index.ts
+++ b/packages/kernel-node/src/lock/index.ts
@@ -1,5 +1,6 @@
 export {
   acquireWriteLock,
+  inertWriterProtocolListener,
   WriteLockContentionError,
   LOCKFILE_NAME,
   PORT_FILE_NAME,
@@ -10,6 +11,9 @@ export type {
   WriteLockHandle,
   PeerHealthyOutcome,
   WriterContentionDiagnostic,
+  WriterProtocolHandlers,
+  WriterProtocolBinding,
+  WriterProtocolListener,
 } from "./acquire.js";
 export type { LockfileBody } from "./lockfile-body.js";
 export { readLockfile } from "./lockfile-body.js";

--- a/packages/kernel-node/src/sqlite/database.ts
+++ b/packages/kernel-node/src/sqlite/database.ts
@@ -21,9 +21,7 @@ export function openReadonlySqliteStorage(path: string): SqlReadStore {
 }
 
 export function openSqliteStorage(path: string): SqlStore & MigratorStore {
-  const db = new DatabaseSync(path);
-  db.exec("PRAGMA journal_mode = WAL;");
-  db.exec("PRAGMA foreign_keys = ON;");
+  const db = new DatabaseSync(path, { enableForeignKeyConstraints: false });
   return {
     async exec(sql) {
       db.exec(sql);

--- a/packages/kernel-node/tests/coach-dev-import.test.ts
+++ b/packages/kernel-node/tests/coach-dev-import.test.ts
@@ -1,13 +1,17 @@
 import { spawn } from "node:child_process";
 import { createHash } from "node:crypto";
-import { access, copyFile, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { access, copyFile, mkdir, mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promises";
 import { createServer } from "node:http";
 import { tmpdir } from "node:os";
+import { createServer as createNetServer } from "node:net";
 import { join, resolve } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import type { ImportReport } from "@enduragent/kernel/ingest";
 import type { MigratorStore, SqlStore } from "@enduragent/kernel/store";
-import type { WriteLockHandle } from "@enduragent/kernel-node/lock";
+import {
+  inertWriterProtocolListener,
+  type WriteLockHandle,
+} from "@enduragent/kernel-node/lock";
 
 type RunCoachDev = typeof import("../src/cli/coach-dev.js").runCoachDev;
 type RunCoachDevWriter = typeof import("../src/cli/coach-dev.js").runCoachDevWriter;
@@ -63,6 +67,19 @@ const DETERMINISTIC_KEYS = [
   "brick_groups",
   "orphaned_overlays",
 ] as const;
+
+const hasLoopback = await new Promise<boolean>((resolve) => {
+  const server = createNetServer();
+  server.once("error", (error: NodeJS.ErrnoException) => {
+    if (error.code === "EPERM") {
+      process.stderr.write("SKIP_MARKER loopback-listen EPERM coach-dev-import\n");
+    }
+    resolve(false);
+  });
+  server.listen({ host: "127.0.0.1", port: 0 }, () => {
+    server.close(() => resolve(true));
+  });
+});
 
 const pair = {
   member_a: "member-a",
@@ -254,7 +271,7 @@ afterAll(async () => {
 });
 
 async function freshHome(prefix: string): Promise<string> {
-  const path = await mkdtemp(join(tmpdir(), prefix));
+  const path = await mkdtemp(join(await realpath(tmpdir()), prefix));
   tempDirs.add(path);
   return path;
 }
@@ -383,6 +400,7 @@ function injected(options: InjectedOptions = {}) {
     port: 1,
     lockfilePath: "/synthetic/home/config/store-writer.lock",
     portFilePath: "/synthetic/home/config/store-writer.port",
+    listener: inertWriterProtocolListener,
     async release() {
       calls.push("release");
       fail("release");
@@ -486,7 +504,7 @@ describe("coach-dev import --report", () => {
     }
   });
 
-  it("First real child import is non-vacuous", async () => {
+  it.runIf(hasLoopback)("First real child import is non-vacuous", async () => {
     realHome = await freshHome("coach-dev-real-");
     const fixture = resolve("packages/kernel-node/tests/fixtures/ingest/triathlon-multisport.fit");
     const child = await runChild(realHome, ["import", "--report", fixture]);
@@ -526,7 +544,7 @@ describe("coach-dev import --report", () => {
     await expectLockFilesAbsent(realHome);
   });
 
-  it("Second real child import is archive-deduped", async () => {
+  it.runIf(hasLoopback)("Second real child import is archive-deduped", async () => {
     expect(realHome).toBeDefined();
     expect(firstReport).toBeDefined();
     expect(firstDump).toBeDefined();
@@ -562,7 +580,7 @@ describe("coach-dev import --report", () => {
     await expectLockFilesAbsent(realHome!);
   });
 
-  it("held-lock refuses safely", async () => {
+  it.runIf(hasLoopback)("held-lock refuses safely", async () => {
     const homePath = await freshHome("coach-dev-held-");
     const home = resolveAthleteHome({ ENDURAGENT_HOME: homePath });
     const result = await acquireWriteLock({
@@ -608,7 +626,7 @@ describe("coach-dev import --report", () => {
     await expectLockFilesAbsent(homePath);
   }, 15_000);
 
-  it("healthy-peer refuses without ownership", async () => {
+  it.runIf(hasLoopback)("healthy-peer refuses without ownership", async () => {
     const homePath = await freshHome("coach-dev-peer-");
     const home = resolveAthleteHome({ ENDURAGENT_HOME: homePath });
     await mkdir(home.configDir, { recursive: true, mode: 0o700 });
@@ -725,7 +743,11 @@ describe("coach-dev import --report", () => {
       successful.deps,
     );
     expect(result).toEqual({ status: "completed", value });
-    expect(context).toEqual({ home: successful.home, store: successful.store });
+    expect(context).toEqual({
+      home: successful.home,
+      store: successful.store,
+      listener: inertWriterProtocolListener,
+    });
     expect(successful.observed.lock).toEqual({
       configDir: successful.home.configDir,
       athleteHome: successful.home.root,
@@ -1184,7 +1206,7 @@ describe("coach-dev import --report", () => {
           writerCalls += 1;
           writerActive = true;
           try {
-            return await operation({ home, store });
+            return await operation({ home, store, listener: inertWriterProtocolListener });
           } finally {
             writerActive = false;
           }
@@ -1334,7 +1356,7 @@ describe("coach-dev import --report", () => {
       },
       {
         async withWriter(_env, operation) {
-          return operation({ home, store });
+          return operation({ home, store, listener: inertWriterProtocolListener });
         },
         async importFiles() {
           throw new Error("unexpected manual import");

--- a/packages/kernel-node/tests/inv2-overlay-recompute.test.ts
+++ b/packages/kernel-node/tests/inv2-overlay-recompute.test.ts
@@ -151,6 +151,7 @@ describe("global version and overlay recompute", () => {
     store = openSqliteStorage(databasePath);
     await runMigrations(store, MIGRATIONS);
     const competing = openSqliteStorage(databasePath);
+    await runMigrations(competing, MIGRATIONS);
     try {
       await importFilesWithReport({ inputPaths: [path("brick-cycling.fit")], archiveDir, store });
       let reached!: () => void;

--- a/packages/kernel-node/tests/lock.test.ts
+++ b/packages/kernel-node/tests/lock.test.ts
@@ -3,11 +3,15 @@
 // are proven by branch selection against an injected /healthz test double; the full
 // four-case matrix against a real daemon /healthz responder arms at W8.
 
-import { mkdtempSync, rmSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { mkdtempSync, realpathSync, rmSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createConnection, createServer, type Server, type Socket } from "node:net";
-import { createServer as createHttpServer, type Server as HttpServer } from "node:http";
+import {
+  createServer as createHttpServer,
+  get as httpGet,
+  type Server as HttpServer,
+} from "node:http";
 import { DatabaseSync } from "node:sqlite";
 import { afterEach, describe, expect, it } from "vitest";
 import {
@@ -30,10 +34,23 @@ const netServers: Server[] = [];
 const httpServers: HttpServer[] = [];
 
 function freshDir(prefix = "lock-"): string {
-  const d = mkdtempSync(join(tmpdir(), prefix));
+  const d = mkdtempSync(join(realpathSync(tmpdir()), prefix));
   tempDirs.push(d);
   return d;
 }
+
+const hasLoopback = await new Promise<boolean>((resolve) => {
+  const server = createServer();
+  server.once("error", (error: NodeJS.ErrnoException) => {
+    if (error.code === "EPERM") {
+      process.stderr.write("SKIP_MARKER loopback-listen EPERM lock.test\n");
+    }
+    resolve(false);
+  });
+  server.listen({ host: "127.0.0.1", port: 0 }, () => {
+    server.close(() => resolve(true));
+  });
+});
 
 function isHandle(r: AcquireWriteLockResult): r is WriteLockHandle {
   return r.status === "acquired";
@@ -117,7 +134,7 @@ afterEach(async () => {
   }
 });
 
-describe("acquireWriteLock", () => {
+describe.skipIf(!hasLoopback)("acquireWriteLock", () => {
   it("(bind) port-bind singleton is authoritative", async () => {
     const configDir = freshDir();
     const result = trackHandle(
@@ -201,6 +218,65 @@ describe("acquireWriteLock", () => {
       peer.destroy();
       await release;
     }
+  });
+
+  it("binds health and upgrades on a separate published protocol socket", async () => {
+    const configDir = freshDir();
+    const holder = trackHandle(
+      await acquireWriteLock({ configDir, athleteHome: "/home/a", version: "1.0.0" }),
+    );
+    const initialPort = readPortFile(join(configDir, PORT_FILE_NAME));
+    expect(initialPort).toBe(holder.port);
+
+    const binding = await holder.listener.bind({
+      request(_request, response) {
+        response.statusCode = 200;
+        response.end("ready\n");
+      },
+      upgrade(_request, socket) {
+        socket.destroy();
+      },
+    });
+    expect(binding.port).not.toBe(holder.port);
+    expect(readPortFile(join(configDir, PORT_FILE_NAME))).toBe(binding.port);
+    await expect(new Promise<string>((resolve, reject) => {
+      httpGet(`http://127.0.0.1:${binding.port}/healthz`, (response) => {
+        let body = "";
+        response.setEncoding("utf8");
+        response.on("data", (chunk) => { body += chunk; });
+        response.on("end", () => resolve(body));
+      }).once("error", reject);
+    })).resolves.toBe("ready\n");
+
+    const raw = createConnection({ host: "127.0.0.1", port: holder.port });
+    await new Promise<void>((resolve, reject) => {
+      raw.once("error", reject);
+      raw.once("connect", () => {
+        raw.write("GET /healthz HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n");
+        const timer = setTimeout(() => {
+          raw.destroy();
+          resolve();
+        }, 50);
+        raw.once("data", () => {
+          clearTimeout(timer);
+          reject(new Error("raw authority socket emitted protocol bytes"));
+        });
+      });
+    });
+
+    await expect(holder.listener.bind({
+      request() {},
+      upgrade() {},
+    })).rejects.toThrow("already bound");
+    await binding.close();
+    await expect(new Promise<void>((resolve, reject) => {
+      const socket = createConnection({ host: "127.0.0.1", port: holder.port });
+      socket.once("error", reject);
+      socket.once("connect", () => {
+        socket.destroy();
+        resolve();
+      });
+    })).resolves.toBeUndefined();
   });
 
   it("(a) healthy peer returns peer-healthy without binding", async () => {

--- a/packages/kernel-node/tests/migrator-e2e.test.ts
+++ b/packages/kernel-node/tests/migrator-e2e.test.ts
@@ -1,4 +1,6 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { mkdtempSync, realpathSync, rmSync } from "node:fs";
+import { readdir, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -7,6 +9,7 @@ import {
   createAnchorRepository,
   dumpStore,
   runMigrations,
+  StoreNewerThanAppError,
   type AnchorHistoryRow,
   type MigratorStore,
   type SqlStore,
@@ -19,7 +22,7 @@ describe("migrator end-to-end over node:sqlite", () => {
   let store: SqlStore & MigratorStore;
 
   beforeEach(() => {
-    dir = mkdtempSync(join(tmpdir(), "kn-"));
+    dir = mkdtempSync(join(realpathSync(tmpdir()), "kn-"));
     store = openSqliteStorage(join(dir, "store.db"));
   });
 
@@ -48,6 +51,7 @@ describe("migrator end-to-end over node:sqlite", () => {
       ),
     ).toEqual({ name: "idx_dedup_confirmation_effective" });
     expect(await store.get("PRAGMA journal_mode")).toEqual({ journal_mode: "wal" });
+    expect(await store.get("PRAGMA foreign_keys")).toEqual({ foreign_keys: 1 });
     await runMigrations(store, MIGRATIONS);
     expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 7 });
   });
@@ -181,5 +185,30 @@ describe("migrator end-to-end over node:sqlite", () => {
     const names = new Set(tables.map((r) => r.name as string));
     expect(names.has("first_ok")).toBe(true);
     expect(names.has("second_partial")).toBe(false);
+  });
+
+  it("refuses a newer store without changing bytes or creating sidecars", async () => {
+    const path = join(dir, "newer.db");
+    const maximum = MIGRATIONS.at(-1)!.version;
+    const seed = openSqliteStorage(path);
+    await seed.setUserVersion(maximum + 1);
+    await seed.close();
+    const beforeNames = (await readdir(dir)).sort();
+    const beforeHash = createHash("sha256").update(await readFile(path)).digest("hex");
+
+    const refused = openSqliteStorage(path);
+    const error = await runMigrations(refused, MIGRATIONS).catch((failure: unknown) => failure);
+    expect(error).toBeInstanceOf(StoreNewerThanAppError);
+    expect(error).toMatchObject({
+      storeVersion: maximum + 1,
+      appMaxVersion: maximum,
+      message: "store is newer than this app",
+    });
+    await refused.close();
+
+    expect((await readdir(dir)).sort()).toEqual(beforeNames);
+    expect(createHash("sha256").update(await readFile(path)).digest("hex")).toBe(beforeHash);
+    expect(beforeNames).not.toContain("newer.db-wal");
+    expect(beforeNames).not.toContain("newer.db-shm");
   });
 });

--- a/packages/kernel-node/tests/sqlite-adapter.test.ts
+++ b/packages/kernel-node/tests/sqlite-adapter.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, realpathSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -10,7 +10,7 @@ describe("openSqliteStorage adapter", () => {
   let store: SqlStore & MigratorStore;
 
   beforeEach(() => {
-    dir = mkdtempSync(join(tmpdir(), "kn-"));
+    dir = mkdtempSync(join(realpathSync(tmpdir()), "kn-"));
     store = openSqliteStorage(join(dir, "store.db"));
   });
 
@@ -19,11 +19,11 @@ describe("openSqliteStorage adapter", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
-  it("opens with WAL journal mode and foreign_keys enabled", async () => {
+  it("opens without changing SQLite journal or foreign-key defaults", async () => {
     const jm = await store.get("PRAGMA journal_mode");
-    expect(jm).toEqual({ journal_mode: "wal" });
+    expect(jm).toEqual({ journal_mode: "delete" });
     const fk = await store.get("PRAGMA foreign_keys");
-    expect(fk).toEqual({ foreign_keys: 1 });
+    expect(fk).toEqual({ foreign_keys: 0 });
   });
 
   it("round-trips TEXT, REAL, and BLOB values through run/get/all", async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,6 +97,9 @@ importers:
       '@enduragent/sync-intervals-icu':
         specifier: workspace:*
         version: link:../sync-intervals-icu
+      ws:
+        specifier: ^8.20.0
+        version: 8.20.0
       yaml:
         specifier: ^2.8.3
         version: 2.8.3
@@ -104,6 +107,9 @@ importers:
       '@types/node':
         specifier: ^25.6.0
         version: 25.6.0
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
       tsup:
         specifier: ^8.4.0
         version: 8.5.1(postcss@8.5.12)(tsx@4.21.0)(typescript@6.0.3)(yaml@2.8.3)


### PR DESCRIPTION
## Summary

Lands `enduragent serve` — the daemon core:

- Startup ordering: lock acquire → private bootstrap connection → typed newer-store refusal (contract exit 5) → migrations (foreign-key activation inside the migration path, after refusal) → publish runtime repositories → wall-clock-anchored schedulers → bind /healthz and the RPC WS listener only after publish (two-socket split: raw lock at acquire, protocol listener post-publish).
- JSON-RPC server projects the injected `CoachEngine` through the contract's method registry; notifications ride the full-envelope NDJSON machinery; null-id protocol-error envelope for the two parse-level codes.
- Localhost auth: first-frame bearer token from the 0600 app-private token file, Origin rejection at upgrade.
- Writer-protocol listener threaded through the store writer context (inert listener at the non-daemon sync/composition sites); RPC non-JSON result handling and immediate protocol shutdown on writer release.
- New `packages/coach/src/serve.ts` + `daemon/{healthz-server,rpc-server,scheduler}.ts`; serve entry wired; changeset included.

## Verification

- Focused daemon/migration/scheduler/lifecycle/CLI/composition suites green; socket-bound cases verified in the root gate.
- Root `pnpm build`, `pnpm check`, full `pnpm test` green after rebase.
- Dependency, prohibited-scope, changeset, and diff gates green.
