### PR TITLE
feat(coach): add daemon contention and upgrade handshake

### DIFF
--- a/packages/coach/src/daemon/handshake.ts
+++ b/packages/coach/src/daemon/handshake.ts
@@ -1,0 +1,816 @@
+import { readFile } from "node:fs/promises";
+import { get } from "node:http";
+import { createConnection } from "node:net";
+import { join } from "node:path";
+import {
+  ClientHandshakeFrameSchema,
+  EXIT_DAEMON_UNAVAILABLE,
+  EXIT_SUCCESS,
+  EXIT_VERSION_MISMATCH,
+  JsonRpcResponseEnvelopeSchema,
+  ServerHandshakeFrameSchema,
+  compareProtocolVersions,
+  type AcceptedServerHandshakeFrame,
+  type DaemonOwner,
+  type ServerHandshakeFrame,
+  type VersionMismatchServerHandshakeFrame,
+} from "@enduragent/coach-contract";
+import {
+  LOCKFILE_NAME,
+  PORT_FILE_NAME,
+  classifyHealthzResponse,
+  readLockfile,
+  type PeerHealthyOutcome,
+} from "@enduragent/kernel-node/lock";
+import type { AthleteHome } from "@enduragent/kernel-node/home";
+import {
+  HANDOFF_RESERVED_MESSAGE,
+  acquireUpgradeFence,
+} from "./upgrade-fence.js";
+import type {
+  MonotonicTimer,
+  ScheduledMonotonicTimer,
+  UpgradeFenceHandle,
+} from "./upgrade-fence.js";
+
+export { HANDOFF_RESERVED_MESSAGE } from "./upgrade-fence.js";
+export type {
+  MonotonicTimer,
+  ScheduledMonotonicTimer,
+} from "./upgrade-fence.js";
+
+export const UPGRADE_CONTROL_TIMEOUT_MS = 5_000 as const;
+export const UPGRADE_WRITER_RELEASE_TIMEOUT_MS = 30_000 as const;
+export const UPGRADE_SUCCESSOR_PUBLISH_TIMEOUT_MS = 30_000 as const;
+export const UPGRADE_OBSERVATION_INTERVAL_MS = 25 as const;
+
+export type SecondStarterCaller =
+  | "serve"
+  | "service"
+  | "cli-auto-start"
+  | "local";
+
+export type StarterResolution =
+  | {
+      readonly status: "attach";
+      readonly port: number;
+      readonly handshake: AcceptedServerHandshakeFrame;
+    }
+  | {
+      readonly status: "defer";
+      readonly exitCode: 0;
+      readonly stdout: "";
+      readonly stderr: string;
+    }
+  | {
+      readonly status: "become-successor";
+      readonly fence: UpgradeFenceHandle;
+      readonly handoffCapability: string;
+    }
+  | {
+      readonly status: "retry-startup";
+    }
+  | {
+      readonly status: "refuse";
+      readonly exitCode: 3 | 5;
+      readonly stdout: "";
+      readonly stderr: string;
+    };
+
+export interface ServiceUpgradePort {
+  isInstalled(home: AthleteHome): Promise<boolean>;
+  restartInstalledService(input: DesignatedSuccessorInput): Promise<void>;
+  kickstartInstalledServiceAfterEphemeral(input: DesignatedSuccessorInput): Promise<void>;
+  startEphemeralSuccessor(input: DesignatedSuccessorInput): Promise<void>;
+}
+
+export interface DesignatedSuccessorInput {
+  readonly home: AthleteHome;
+  readonly targetProtocolVersion: number;
+  readonly handoffCapability: string;
+}
+
+export interface ResolveSecondStarterInput {
+  readonly caller: SecondStarterCaller;
+  readonly home: AthleteHome;
+  readonly clientProtocolVersion: number;
+  readonly clientAppVersion: string;
+  readonly bearerToken: string;
+  readonly peer: PeerHealthyOutcome;
+}
+
+export type ReadOnlyPeerClassification =
+  | { readonly status: "peer-healthy"; readonly peer: PeerHealthyOutcome }
+  | { readonly status: "writer-clear" }
+  | {
+      readonly status: "bound-unresponsive";
+      readonly stdout: "";
+      readonly stderr: string;
+    }
+  | {
+      readonly status: "foreign-port";
+      readonly stdout: "";
+      readonly stderr: string;
+    };
+
+export type WriterReleaseWaitOutcome =
+  | { readonly status: "released" }
+  | { readonly status: "timeout" }
+  | { readonly status: "observation-invalid" };
+
+export type CompatiblePeerWaitOutcome =
+  | {
+      readonly status: "published";
+      readonly peer: PeerHealthyOutcome;
+      readonly handshake: AcceptedServerHandshakeFrame;
+    }
+  | { readonly status: "crashed" }
+  | {
+      readonly status: "incompatible";
+      readonly handshake: VersionMismatchServerHandshakeFrame;
+    }
+  | { readonly status: "timeout" }
+  | { readonly status: "observation-invalid" };
+
+export interface AuthenticatedDaemonControl {
+  readonly port: number;
+  readonly accepted: AcceptedServerHandshakeFrame;
+  reserveUpgrade(input: {
+    readonly targetProtocolVersion: number;
+    readonly handoffCapability: string;
+  }): Promise<{ readonly status: "reserved" }>;
+  shutdownForUpgrade(input: {
+    readonly targetProtocolVersion: number;
+    readonly handoffCapability: string;
+  }): Promise<{ readonly status: "accepted" }>;
+  close(): Promise<void>;
+}
+
+export interface OpenAuthenticatedDaemonControlInput {
+  readonly port: number;
+  readonly token: string;
+  readonly incumbentProtocolVersion: number;
+  readonly expectedOwner: DaemonOwner;
+  readonly timeoutMs?: number;
+}
+
+export interface ResolveSecondStarterDependencies {
+  readonly observePeerHandshake: typeof observePeerHandshake;
+  readonly openUpgradeControl: typeof openAuthenticatedDaemonControl;
+  readonly classifyPeerReadOnly: typeof classifyPeerReadOnly;
+  readonly acquireUpgradeFence: typeof acquireUpgradeFence;
+  readonly serviceUpgrade: ServiceUpgradePort;
+  readonly timer: MonotonicTimer;
+  readonly waitForWriterRelease: (input: {
+    readonly home: AthleteHome;
+    readonly incumbent: PeerHealthyOutcome;
+    readonly deadlineMs: number;
+    readonly pollIntervalMs: number;
+    readonly timer: MonotonicTimer;
+  }) => Promise<WriterReleaseWaitOutcome>;
+  readonly waitForCompatiblePeer: (input: {
+    readonly home: AthleteHome;
+    readonly protocolVersion: number;
+    readonly token: string;
+    readonly deadlineMs: number;
+    readonly pollIntervalMs: number;
+    readonly timer: MonotonicTimer;
+  }) => Promise<CompatiblePeerWaitOutcome>;
+}
+
+export const alreadyServingNotice = (port: number): string =>
+  `Enduragent is already serving this athlete home at 127.0.0.1:${port}.\n`;
+
+export const lowerClientMessage = (
+  clientProtocolVersion: number,
+  daemonProtocolVersion: number,
+): string =>
+  `Enduragent cannot connect: daemon protocol ${daemonProtocolVersion} is newer than client protocol ${clientProtocolVersion}. Update enduragent.\n`;
+
+export const UNMANAGED_UPGRADE_MESSAGE =
+  "A foreground daemon is running; stop it before upgrading.\n";
+
+export const UNTRUSTED_PEER_MESSAGE =
+  "Enduragent cannot start: the existing daemon could not be authenticated and validated; stop it or wait, then retry.\n";
+
+export const UPGRADE_BUSY_MESSAGE =
+  "Enduragent could not complete the daemon upgrade; the current daemon is still busy. Retry after the active turn completes.\n";
+
+export const UPGRADE_SUCCESSOR_FAILED_MESSAGE =
+  "Enduragent could not complete the daemon upgrade because the designated successor did not publish a compatible service. Retry.\n";
+
+const OBSERVATION_TIMEOUT_MS = 1_000;
+
+function refusal(exitCode: 3 | 5, stderr: string): StarterResolution {
+  return { status: "refuse", exitCode, stdout: "", stderr };
+}
+
+function holderMessage(pid: number | null, port: number): string {
+  return `Enduragent cannot start: another writer holds this athlete home (pid ${pid ?? "unknown"}, port ${port}). Stop it or wait, then retry.\n`;
+}
+
+function foreignMessage(port: number, portFile: string): string {
+  return `Enduragent cannot start: 127.0.0.1:${port} is held by a foreign process; change or remove the port file at ${portFile}, then retry.\n`;
+}
+
+async function readPublishedPort(path: string): Promise<number | null> {
+  try {
+    const raw = await readFile(path, "utf8");
+    const port = Number(raw.trim());
+    return Number.isInteger(port) && port >= 1 && port <= 65_535 ? port : null;
+  } catch {
+    return null;
+  }
+}
+
+function portBound(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = createConnection({ host: "127.0.0.1", port });
+    let settled = false;
+    const finish = (bound: boolean): void => {
+      if (settled) return;
+      settled = true;
+      socket.destroy();
+      resolve(bound);
+    };
+    socket.setTimeout(OBSERVATION_TIMEOUT_MS);
+    socket.once("connect", () => finish(true));
+    socket.once("timeout", () => finish(true));
+    socket.once("error", (error: NodeJS.ErrnoException) => {
+      finish(error.code !== "ECONNREFUSED");
+    });
+  });
+}
+
+function probeHealth(port: number): Promise<ReturnType<typeof classifyHealthzResponse>> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (value: ReturnType<typeof classifyHealthzResponse>): void => {
+      if (settled) return;
+      settled = true;
+      resolve(value);
+    };
+    const request = get(
+      { host: "127.0.0.1", port, path: "/healthz", timeout: OBSERVATION_TIMEOUT_MS },
+      (response) => {
+        const chunks: Buffer[] = [];
+        response.on("data", (chunk: Buffer) => chunks.push(chunk));
+        response.on("end", () => {
+          finish(classifyHealthzResponse(
+            response.statusCode ?? 0,
+            Buffer.concat(chunks).toString("utf8"),
+          ));
+        });
+        response.on("error", () => finish({ kind: "unresponsive" }));
+      },
+    );
+    request.once("timeout", () => {
+      request.destroy();
+      finish({ kind: "unresponsive" });
+    });
+    request.once("error", () => finish({ kind: "unresponsive" }));
+  });
+}
+
+export async function classifyPeerReadOnly(
+  home: AthleteHome,
+): Promise<ReadOnlyPeerClassification> {
+  const lockfilePath = join(home.configDir, LOCKFILE_NAME);
+  const portFilePath = join(home.configDir, PORT_FILE_NAME);
+  const body = readLockfile(lockfilePath);
+  const publishedPort = await readPublishedPort(portFilePath);
+  if (publishedPort !== null && await portBound(publishedPort)) {
+    if (body?.port === publishedPort) {
+      return {
+        status: "bound-unresponsive",
+        stdout: "",
+        stderr: holderMessage(body.pid, publishedPort),
+      };
+    }
+    const verdict = await probeHealth(publishedPort);
+    if (verdict.kind === "healthy") {
+      return {
+        status: "peer-healthy",
+        peer: {
+          status: "peer-healthy",
+          pid: body?.pid ?? null,
+          port: publishedPort,
+          peerVersion: verdict.version,
+        },
+      };
+    }
+    if (verdict.kind === "foreign") {
+      return {
+        status: "foreign-port",
+        stdout: "",
+        stderr: foreignMessage(publishedPort, portFilePath),
+      };
+    }
+    return {
+      status: "bound-unresponsive",
+      stdout: "",
+      stderr: holderMessage(body?.pid ?? null, publishedPort),
+    };
+  }
+  if (body !== null && await portBound(body.port)) {
+    return {
+      status: "bound-unresponsive",
+      stdout: "",
+      stderr: holderMessage(body.pid, body.port),
+    };
+  }
+  return { status: "writer-clear" };
+}
+
+interface OpenHandshakeResult {
+  readonly socket: WebSocket;
+  readonly frame: ServerHandshakeFrame;
+}
+
+function openHandshake(input: {
+  readonly port: number;
+  readonly token: string;
+  readonly clientProtocolVersion: number;
+  readonly timeoutMs: number;
+}): Promise<OpenHandshakeResult> {
+  if (!Number.isInteger(input.port) || input.port < 1 || input.port > 65_535) {
+    return Promise.reject(new Error("daemon handshake failed"));
+  }
+  let firstFrame: ReturnType<typeof ClientHandshakeFrameSchema.parse>;
+  try {
+    firstFrame = ClientHandshakeFrameSchema.parse({
+      type: "handshake",
+      token: input.token,
+      clientProtocolVersion: input.clientProtocolVersion,
+    });
+  } catch {
+    return Promise.reject(new Error("daemon handshake failed"));
+  }
+  return new Promise((resolve, reject) => {
+    const socket = new WebSocket(`ws://127.0.0.1:${input.port}/rpc`);
+    let settled = false;
+    const timer = setTimeout(() => finish(new Error("daemon handshake failed")), input.timeoutMs);
+    timer.unref?.();
+    const cleanup = (): void => {
+      clearTimeout(timer);
+      socket.removeEventListener("open", onOpen);
+      socket.removeEventListener("message", onMessage);
+      socket.removeEventListener("error", onError);
+      socket.removeEventListener("close", onClose);
+    };
+    const finish = (error?: Error, frame?: ServerHandshakeFrame): void => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      if (error !== undefined) {
+        try {
+          socket.close();
+        } catch {}
+        reject(error);
+      } else {
+        resolve({ socket, frame: frame! });
+      }
+    };
+    const onOpen = (): void => {
+      try {
+        socket.send(JSON.stringify(firstFrame));
+      } catch {
+        finish(new Error("daemon handshake failed"));
+      }
+    };
+    const onMessage = (event: Event): void => {
+      const data = (event as Event & { readonly data?: unknown }).data;
+      if (typeof data !== "string") {
+        finish(new Error("daemon handshake failed"));
+        return;
+      }
+      try {
+        const frame = ServerHandshakeFrameSchema.parse(JSON.parse(data));
+        if (frame.clientProtocolVersion !== input.clientProtocolVersion) {
+          throw new Error("invalid echo");
+        }
+        finish(undefined, frame);
+      } catch {
+        finish(new Error("daemon handshake failed"));
+      }
+    };
+    const onError = (): void => finish(new Error("daemon handshake failed"));
+    const onClose = (): void => finish(new Error("daemon handshake failed"));
+    socket.addEventListener("open", onOpen);
+    socket.addEventListener("message", onMessage);
+    socket.addEventListener("error", onError);
+    socket.addEventListener("close", onClose);
+  });
+}
+
+export async function observePeerHandshake(input: {
+  readonly port: number;
+  readonly token: string;
+  readonly clientProtocolVersion: number;
+}): Promise<ServerHandshakeFrame> {
+  const opened = await openHandshake({ ...input, timeoutMs: UPGRADE_CONTROL_TIMEOUT_MS });
+  try {
+    return opened.frame;
+  } finally {
+    opened.socket.close();
+  }
+}
+
+function rpcError(code: number, message: string): Error & { readonly code: number } {
+  const error = new Error(message) as Error & { code: number };
+  error.code = code;
+  return error;
+}
+
+export async function openAuthenticatedDaemonControl(
+  input: OpenAuthenticatedDaemonControlInput,
+): Promise<AuthenticatedDaemonControl> {
+  const timeoutMs = input.timeoutMs ?? UPGRADE_CONTROL_TIMEOUT_MS;
+  if (!Number.isSafeInteger(timeoutMs) || timeoutMs <= 0) {
+    throw new TypeError("invalid daemon control timeout");
+  }
+  const opened = await openHandshake({
+    port: input.port,
+    token: input.token,
+    clientProtocolVersion: input.incumbentProtocolVersion,
+    timeoutMs,
+  });
+  if (
+    opened.frame.status !== "accepted"
+    || opened.frame.clientProtocolVersion !== input.incumbentProtocolVersion
+    || opened.frame.serverProtocolVersion !== input.incumbentProtocolVersion
+    || opened.frame.owner !== input.expectedOwner
+  ) {
+    opened.socket.close();
+    throw new Error("daemon control authentication failed");
+  }
+  const socket = opened.socket;
+  let sequence = 0;
+  let closed = false;
+  const pending = new Map<number, {
+    readonly expectedStatus: "reserved" | "accepted";
+    readonly resolve: (value: { readonly status: "reserved" | "accepted" }) => void;
+    readonly reject: (error: unknown) => void;
+    readonly timer: ReturnType<typeof setTimeout>;
+  }>();
+  const rejectPending = (): void => {
+    for (const request of pending.values()) {
+      clearTimeout(request.timer);
+      request.reject(new Error("daemon control connection closed"));
+    }
+    pending.clear();
+  };
+  const onMessage = (event: Event): void => {
+    const data = (event as Event & { readonly data?: unknown }).data;
+    if (typeof data !== "string") {
+      socket.close();
+      return;
+    }
+    let parsed: ReturnType<typeof JsonRpcResponseEnvelopeSchema.parse>;
+    try {
+      parsed = JsonRpcResponseEnvelopeSchema.parse(JSON.parse(data));
+    } catch {
+      socket.close();
+      return;
+    }
+    if (parsed.id === null || typeof parsed.id !== "number") return;
+    const request = pending.get(parsed.id);
+    if (request === undefined) return;
+    pending.delete(parsed.id);
+    clearTimeout(request.timer);
+    if ("error" in parsed) {
+      request.reject(rpcError(parsed.error.code, parsed.error.message));
+      return;
+    }
+    const result = parsed.result;
+    if (
+      result === null
+      || typeof result !== "object"
+      || Array.isArray(result)
+      || Object.keys(result).length !== 1
+      || (result as { readonly status?: unknown }).status !== request.expectedStatus
+    ) {
+      request.reject(new Error("invalid daemon control response"));
+      return;
+    }
+    request.resolve({ status: request.expectedStatus });
+  };
+  const removeControlListeners = (): void => {
+    socket.removeEventListener("message", onMessage);
+    socket.removeEventListener("error", onTerminal);
+    socket.removeEventListener("close", onTerminal);
+  };
+  function onTerminal(): void {
+    closed = true;
+    removeControlListeners();
+    rejectPending();
+  }
+  socket.addEventListener("message", onMessage);
+  socket.addEventListener("error", onTerminal);
+  socket.addEventListener("close", onTerminal);
+
+  const call = (
+    method: "daemon.reserveUpgrade" | "daemon.shutdownForUpgrade",
+    params: { readonly targetProtocolVersion: number; readonly handoffCapability: string },
+    expectedStatus: "reserved" | "accepted",
+  ): Promise<{ readonly status: "reserved" | "accepted" }> => {
+    if (closed || socket.readyState !== WebSocket.OPEN) {
+      return Promise.reject(new Error("daemon control connection closed"));
+    }
+    sequence += 1;
+    const id = sequence;
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        pending.delete(id);
+        reject(new Error("daemon control request timed out"));
+        socket.close();
+      }, method === "daemon.shutdownForUpgrade" ? UPGRADE_WRITER_RELEASE_TIMEOUT_MS : timeoutMs);
+      timer.unref?.();
+      pending.set(id, { expectedStatus, resolve, reject, timer });
+      try {
+        socket.send(JSON.stringify({ jsonrpc: "2.0", id, method, params }));
+      } catch {
+        pending.delete(id);
+        clearTimeout(timer);
+        reject(new Error("daemon control request failed"));
+      }
+    });
+  };
+
+  return {
+    port: input.port,
+    accepted: opened.frame,
+    async reserveUpgrade(params) {
+      const result = await call("daemon.reserveUpgrade", params, "reserved");
+      return { status: result.status as "reserved" };
+    },
+    async shutdownForUpgrade(params) {
+      const result = await call("daemon.shutdownForUpgrade", params, "accepted");
+      return { status: result.status as "accepted" };
+    },
+    async close() {
+      if (closed) return;
+      closed = true;
+      rejectPending();
+      removeControlListeners();
+      socket.close();
+    },
+  };
+}
+
+function samePeer(left: PeerHealthyOutcome, right: PeerHealthyOutcome): boolean {
+  return left.port === right.port && left.peerVersion === right.peerVersion;
+}
+
+function sameHandshake(left: ServerHandshakeFrame, right: ServerHandshakeFrame): boolean {
+  return left.status === right.status
+    && left.clientProtocolVersion === right.clientProtocolVersion
+    && left.serverProtocolVersion === right.serverProtocolVersion
+    && left.owner === right.owner
+    && (left.status !== "version-mismatch"
+      || (right.status === "version-mismatch" && left.direction === right.direction));
+}
+
+function compatibleResolution(
+  caller: SecondStarterCaller,
+  peer: PeerHealthyOutcome,
+  handshake: AcceptedServerHandshakeFrame,
+): StarterResolution {
+  return caller === "serve" || caller === "service"
+    ? {
+        status: "defer",
+        exitCode: EXIT_SUCCESS,
+        stdout: "",
+        stderr: alreadyServingNotice(peer.port),
+      }
+    : { status: "attach", port: peer.port, handshake };
+}
+
+function errorCode(error: unknown): number | undefined {
+  return typeof error === "object" && error !== null
+    && typeof (error as { readonly code?: unknown }).code === "number"
+    ? (error as { readonly code: number }).code
+    : undefined;
+}
+
+export async function resolveSecondStarter(
+  input: ResolveSecondStarterInput,
+  dependencies: ResolveSecondStarterDependencies,
+): Promise<StarterResolution> {
+  if (input.clientAppVersion.length === 0) return refusal(EXIT_DAEMON_UNAVAILABLE, UNTRUSTED_PEER_MESSAGE);
+
+  const resolvePeer = async (
+    peer: PeerHealthyOutcome,
+    reclassificationAvailable: boolean,
+  ): Promise<StarterResolution> => {
+    let observed: ServerHandshakeFrame;
+    try {
+      observed = ServerHandshakeFrameSchema.parse(await dependencies.observePeerHandshake({
+        port: peer.port,
+        token: input.bearerToken,
+        clientProtocolVersion: input.clientProtocolVersion,
+      }));
+    } catch {
+      return refusal(EXIT_DAEMON_UNAVAILABLE, UNTRUSTED_PEER_MESSAGE);
+    }
+    if (observed.clientProtocolVersion !== input.clientProtocolVersion) {
+      return refusal(EXIT_DAEMON_UNAVAILABLE, UNTRUSTED_PEER_MESSAGE);
+    }
+    let comparison: ReturnType<typeof compareProtocolVersions>;
+    try {
+      comparison = compareProtocolVersions(
+        input.clientProtocolVersion,
+        observed.serverProtocolVersion,
+      );
+    } catch {
+      return refusal(EXIT_DAEMON_UNAVAILABLE, UNTRUSTED_PEER_MESSAGE);
+    }
+    if (comparison === "client-older") {
+      if (observed.status !== "version-mismatch" || observed.direction !== "client-older") {
+        return refusal(EXIT_DAEMON_UNAVAILABLE, UNTRUSTED_PEER_MESSAGE);
+      }
+      return refusal(
+        EXIT_VERSION_MISMATCH,
+        lowerClientMessage(input.clientProtocolVersion, observed.serverProtocolVersion),
+      );
+    }
+    if (comparison === "equal") {
+      if (observed.status !== "accepted") {
+        return refusal(EXIT_DAEMON_UNAVAILABLE, UNTRUSTED_PEER_MESSAGE);
+      }
+      return compatibleResolution(input.caller, peer, observed);
+    }
+    if (observed.status !== "version-mismatch" || observed.direction !== "client-newer") {
+      return refusal(EXIT_DAEMON_UNAVAILABLE, UNTRUSTED_PEER_MESSAGE);
+    }
+    if (observed.owner === "unmanaged-foreground") {
+      return refusal(EXIT_DAEMON_UNAVAILABLE, UNMANAGED_UPGRADE_MESSAGE);
+    }
+
+    let acquired: Awaited<ReturnType<typeof acquireUpgradeFence>>;
+    try {
+      acquired = await dependencies.acquireUpgradeFence({ configDir: input.home.configDir });
+    } catch {
+      return refusal(EXIT_DAEMON_UNAVAILABLE, UNTRUSTED_PEER_MESSAGE);
+    }
+    if (acquired.status === "reserved") {
+      return refusal(EXIT_DAEMON_UNAVAILABLE, HANDOFF_RESERVED_MESSAGE);
+    }
+    const fence = acquired.handle;
+    const handoffCapability = fence.handoffCapability;
+
+    const reclassify = async (): Promise<StarterResolution> => {
+      await fence.release();
+      if (!reclassificationAvailable) {
+        return refusal(EXIT_DAEMON_UNAVAILABLE, UNTRUSTED_PEER_MESSAGE);
+      }
+      let fresh: ReadOnlyPeerClassification;
+      try {
+        fresh = await dependencies.classifyPeerReadOnly(input.home);
+      } catch {
+        return refusal(EXIT_DAEMON_UNAVAILABLE, UNTRUSTED_PEER_MESSAGE);
+      }
+      if (fresh.status === "writer-clear") return { status: "retry-startup" };
+      if (fresh.status === "bound-unresponsive" || fresh.status === "foreign-port") {
+        return refusal(EXIT_DAEMON_UNAVAILABLE, fresh.stderr);
+      }
+      return resolvePeer(fresh.peer, false);
+    };
+
+    let immediate: ReadOnlyPeerClassification;
+    let repeated: ServerHandshakeFrame;
+    try {
+      immediate = await dependencies.classifyPeerReadOnly(input.home);
+      if (immediate.status !== "peer-healthy" || !samePeer(immediate.peer, peer)) {
+        return reclassify();
+      }
+      repeated = ServerHandshakeFrameSchema.parse(await dependencies.observePeerHandshake({
+        port: immediate.peer.port,
+        token: input.bearerToken,
+        clientProtocolVersion: input.clientProtocolVersion,
+      }));
+    } catch {
+      return reclassify();
+    }
+    if (!sameHandshake(observed, repeated)) return reclassify();
+
+    let control: AuthenticatedDaemonControl;
+    try {
+      control = await dependencies.openUpgradeControl({
+        port: peer.port,
+        token: input.bearerToken,
+        incumbentProtocolVersion: observed.serverProtocolVersion,
+        expectedOwner: observed.owner,
+      });
+    } catch {
+      await fence.release();
+      return refusal(EXIT_DAEMON_UNAVAILABLE, UNTRUSTED_PEER_MESSAGE);
+    }
+    const successorInput: DesignatedSuccessorInput = {
+      home: input.home,
+      targetProtocolVersion: input.clientProtocolVersion,
+      handoffCapability,
+    };
+    try {
+      await control.reserveUpgrade({
+        targetProtocolVersion: input.clientProtocolVersion,
+        handoffCapability,
+      });
+      await control.shutdownForUpgrade({
+        targetProtocolVersion: input.clientProtocolVersion,
+        handoffCapability,
+      });
+    } catch (error) {
+      await control.close().catch(() => {});
+      await fence.release();
+      if (errorCode(error) === -32_003) {
+        return refusal(EXIT_DAEMON_UNAVAILABLE, HANDOFF_RESERVED_MESSAGE);
+      }
+      if (errorCode(error) === -32_004) {
+        return refusal(EXIT_DAEMON_UNAVAILABLE, UPGRADE_BUSY_MESSAGE);
+      }
+      return refusal(EXIT_DAEMON_UNAVAILABLE, UNTRUSTED_PEER_MESSAGE);
+    }
+    await control.close().catch(() => {});
+
+    let releaseOutcome: WriterReleaseWaitOutcome;
+    try {
+      releaseOutcome = await dependencies.waitForWriterRelease({
+        home: input.home,
+        incumbent: peer,
+        deadlineMs: dependencies.timer.nowMs() + UPGRADE_WRITER_RELEASE_TIMEOUT_MS,
+        pollIntervalMs: UPGRADE_OBSERVATION_INTERVAL_MS,
+        timer: dependencies.timer,
+      });
+    } catch {
+      releaseOutcome = { status: "observation-invalid" };
+    }
+    if (releaseOutcome.status !== "released") {
+      await fence.release();
+      return refusal(
+        EXIT_DAEMON_UNAVAILABLE,
+        releaseOutcome.status === "timeout" ? UPGRADE_BUSY_MESSAGE : UNTRUSTED_PEER_MESSAGE,
+      );
+    }
+
+    let ephemeralServiceInstalled: boolean | undefined;
+    if (observed.owner === "ephemeral-client-started") {
+      try {
+        ephemeralServiceInstalled = await dependencies.serviceUpgrade.isInstalled(input.home);
+      } catch {
+        await fence.release();
+        return refusal(EXIT_DAEMON_UNAVAILABLE, UPGRADE_SUCCESSOR_FAILED_MESSAGE);
+      }
+      if (
+        !ephemeralServiceInstalled
+        && (input.caller === "serve" || input.caller === "service")
+      ) {
+        return { status: "become-successor", fence, handoffCapability };
+      }
+    }
+
+    try {
+      if (observed.owner === "service-managed") {
+        await dependencies.serviceUpgrade.restartInstalledService(successorInput);
+      } else if (ephemeralServiceInstalled === true) {
+        await dependencies.serviceUpgrade.kickstartInstalledServiceAfterEphemeral(successorInput);
+      } else {
+        await dependencies.serviceUpgrade.startEphemeralSuccessor(successorInput);
+      }
+    } catch {
+      await fence.release();
+      return refusal(EXIT_DAEMON_UNAVAILABLE, UPGRADE_SUCCESSOR_FAILED_MESSAGE);
+    }
+
+    let published: CompatiblePeerWaitOutcome;
+    try {
+      published = await dependencies.waitForCompatiblePeer({
+        home: input.home,
+        protocolVersion: input.clientProtocolVersion,
+        token: input.bearerToken,
+        deadlineMs: dependencies.timer.nowMs() + UPGRADE_SUCCESSOR_PUBLISH_TIMEOUT_MS,
+        pollIntervalMs: UPGRADE_OBSERVATION_INTERVAL_MS,
+        timer: dependencies.timer,
+      });
+    } catch {
+      published = { status: "observation-invalid" };
+    }
+    const publishedHandshake = published.status === "published"
+      ? ServerHandshakeFrameSchema.safeParse(published.handshake)
+      : undefined;
+    if (
+      published.status !== "published"
+      || publishedHandshake?.success !== true
+      || publishedHandshake.data.status !== "accepted"
+      || publishedHandshake.data.clientProtocolVersion !== input.clientProtocolVersion
+      || publishedHandshake.data.serverProtocolVersion !== input.clientProtocolVersion
+    ) {
+      await fence.release();
+      return refusal(EXIT_DAEMON_UNAVAILABLE, UPGRADE_SUCCESSOR_FAILED_MESSAGE);
+    }
+    await fence.release();
+    return compatibleResolution(input.caller, published.peer, publishedHandshake.data);
+  };
+
+  return resolvePeer(input.peer, true);
+}

--- a/packages/coach/src/daemon/healthz-server.ts
+++ b/packages/coach/src/daemon/healthz-server.ts
@@ -1,10 +1,26 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
-import { PROTOCOL_VERSION, type DaemonOwner } from "@enduragent/coach-contract";
 import { HEALTHZ_SERVICE_MARKER } from "@enduragent/kernel-node/lock";
 
 export interface HealthzHandlerInput {
   readonly appVersion: string;
-  readonly owner: DaemonOwner;
+  readonly state?: DaemonHealthState;
+}
+
+export interface DaemonHealthState {
+  readonly healthy: boolean;
+  setHealthy(healthy: boolean): void;
+}
+
+export function createDaemonHealthState(): DaemonHealthState {
+  let healthy = true;
+  return {
+    get healthy() {
+      return healthy;
+    },
+    setHealthy(value) {
+      healthy = value;
+    },
+  };
 }
 
 export function createHealthzRequestHandler(
@@ -13,13 +29,18 @@ export function createHealthzRequestHandler(
   const body = `${JSON.stringify({
     service: HEALTHZ_SERVICE_MARKER,
     version: input.appVersion,
-    protocolVersion: PROTOCOL_VERSION,
-    owner: input.owner,
   })}\n`;
   return (request, response) => {
     if (request.method !== "GET" || request.url !== "/healthz") {
       response.statusCode = 404;
       response.end();
+      return;
+    }
+    if (input.state?.healthy === false) {
+      response.statusCode = 503;
+      response.setHeader("content-type", "application/json; charset=utf-8");
+      response.setHeader("cache-control", "no-store");
+      response.end(`${JSON.stringify({ status: "unavailable" })}\n`);
       return;
     }
     response.statusCode = 200;

--- a/packages/coach/src/daemon/rpc-server.ts
+++ b/packages/coach/src/daemon/rpc-server.ts
@@ -24,6 +24,15 @@ import {
 } from "@enduragent/coach-contract";
 import type { WriterProtocolHandlers } from "@enduragent/kernel-node/lock";
 import WebSocket, { WebSocketServer, type RawData } from "ws";
+import type { DaemonHealthState } from "./healthz-server.js";
+import {
+  DetachedSessionRequestError,
+  createSessionRequestQueue,
+} from "./session-queue.js";
+import {
+  HANDOFF_CAPABILITY_BYTES,
+  type MonotonicTimer,
+} from "./upgrade-fence.js";
 
 const AUTH_TIMEOUT_MS = 1_000;
 const MAX_PAYLOAD_BYTES = 1_048_576;
@@ -36,6 +45,29 @@ const NOT_FOUND_RESPONSE =
   "HTTP/1.1 404 Not Found\r\nConnection: close\r\nContent-Length: 0\r\n\r\n";
 const UNAVAILABLE_RESPONSE =
   "HTTP/1.1 503 Service Unavailable\r\nConnection: close\r\nContent-Length: 0\r\n\r\n";
+
+export const UPGRADE_DRAIN_TIMEOUT_MS = 30_000 as const;
+
+export type UpgradeDrainOutcome =
+  | { readonly status: "accepted" }
+  | { readonly status: "timeout" };
+
+export interface UpgradeDrainCoordinator {
+  shutdownForUpgrade(input: {
+    readonly connectionId: string;
+    readonly targetProtocolVersion: number;
+    readonly handoffCapability: string;
+    readonly deadlineMs: number;
+    readonly timer: MonotonicTimer;
+  }): Promise<UpgradeDrainOutcome>;
+}
+
+export interface UpgradeReservation {
+  readonly connectionId: string;
+  readonly targetProtocolVersion: number;
+  readonly handoffCapabilityBytes: Buffer;
+  readonly state: "reserved" | "shutdown-consumed";
+}
 
 export interface DaemonToken {
   readonly path: string;
@@ -111,10 +143,13 @@ export interface CoachRpcServerInput {
   readonly engine: CoachEngine;
   readonly token: string;
   readonly owner: DaemonOwner;
+  readonly healthState?: DaemonHealthState;
+  readonly timer?: MonotonicTimer;
 }
 
 export interface CoachRpcServer {
   readonly handleUpgrade: WriterProtocolHandlers["upgrade"];
+  readonly shutdownRequested: Promise<void>;
   close(): Promise<void>;
 }
 
@@ -127,6 +162,8 @@ interface ClientState {
   readonly resolveDetached: () => void;
   readonly closedPromise: Promise<void>;
   readonly resolveClosed: () => void;
+  readonly detachController: AbortController;
+  readonly connectionId: string;
   sendTail: Promise<void>;
   authTimer: ReturnType<typeof setTimeout> | undefined;
   authenticated: boolean;
@@ -134,7 +171,7 @@ interface ClientState {
   closed: boolean;
 }
 
-function createClientState(ws: WebSocket): ClientState {
+function createClientState(ws: WebSocket, connectionId: string): ClientState {
   let resolveDetached!: () => void;
   let resolveClosed!: () => void;
   const detachedPromise = new Promise<void>((resolve) => {
@@ -152,6 +189,8 @@ function createClientState(ws: WebSocket): ClientState {
     resolveDetached,
     closedPromise,
     resolveClosed,
+    detachController: new AbortController(),
+    connectionId,
     sendTail: Promise.resolve(),
     authTimer: undefined,
     authenticated: false,
@@ -169,6 +208,7 @@ function clearAuthTimer(state: ClientState): void {
 function detach(state: ClientState, closeCode?: number, reason?: string): void {
   if (!state.detached) {
     state.detached = true;
+    state.detachController.abort();
     state.resolveDetached();
     for (const resolve of state.pendingSendResolvers) resolve();
     state.pendingSendResolvers.clear();
@@ -234,6 +274,12 @@ function ordinaryError(id: JsonRpcId, code: number, message: string): string {
   );
 }
 
+function ordinarySuccess(id: JsonRpcId, result: unknown): string {
+  return serializeCoachRpcEnvelope(
+    JsonRpcSuccessResponseEnvelopeSchema.parse({ jsonrpc: "2.0", id, result }),
+  );
+}
+
 function recoveredId(value: unknown): JsonRpcId | undefined {
   if (value === null || typeof value !== "object" || Array.isArray(value)) return undefined;
   if (!Object.prototype.hasOwnProperty.call(value, "id")) return undefined;
@@ -262,6 +308,52 @@ function sameToken(received: string, expected: string): boolean {
   return left.length === right.length && timingSafeEqual(left, right);
 }
 
+function productionTimer(): MonotonicTimer {
+  return {
+    nowMs: () => performance.now(),
+    schedule(delayMs, callback) {
+      const handle = setTimeout(callback, Math.max(0, delayMs));
+      handle.unref?.();
+      return { cancel: () => clearTimeout(handle) };
+    },
+  };
+}
+
+function canonicalCapability(value: unknown): Buffer | undefined {
+  if (typeof value !== "string" || !/^[A-Za-z0-9_-]{43}$/.test(value)) return undefined;
+  const decoded = Buffer.from(value, "base64url");
+  if (
+    decoded.length !== HANDOFF_CAPABILITY_BYTES
+    || decoded.toString("base64url") !== value
+  ) {
+    return undefined;
+  }
+  return decoded;
+}
+
+function controlParams(value: unknown): {
+  readonly targetProtocolVersion: number;
+  readonly handoffCapability: string;
+} | undefined {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const record = value as Record<string, unknown>;
+  const keys = Object.keys(record).sort();
+  if (
+    keys.length !== 2
+    || keys[0] !== "handoffCapability"
+    || keys[1] !== "targetProtocolVersion"
+    || !Number.isSafeInteger(record.targetProtocolVersion)
+    || (record.targetProtocolVersion as number) < 0
+    || typeof record.handoffCapability !== "string"
+  ) {
+    return undefined;
+  }
+  return {
+    targetProtocolVersion: record.targetProtocolVersion as number,
+    handoffCapability: record.handoffCapability,
+  };
+}
+
 function refuseUpgrade(
   socket: Parameters<WriterProtocolHandlers["upgrade"]>[1],
   response: string,
@@ -273,8 +365,56 @@ function refuseUpgrade(
 export function createCoachRpcServer(input: CoachRpcServerInput): CoachRpcServer {
   const wss = new WebSocketServer({ noServer: true, maxPayload: MAX_PAYLOAD_BYTES });
   const clients = new Set<ClientState>();
+  const sessionQueue = createSessionRequestQueue();
+  const coachingTasks = new Set<Promise<void>>();
+  const timer = input.timer ?? productionTimer();
   let closing = false;
+  let acceptingCoaching = true;
   let closePromise: Promise<void> | undefined;
+  let reservation: UpgradeReservation | undefined;
+  let connectionSequence = 0;
+  let resolveShutdownRequested!: () => void;
+  const shutdownRequested = new Promise<void>((resolve) => {
+    resolveShutdownRequested = resolve;
+  });
+
+  const clearReservation = (): void => {
+    reservation?.handoffCapabilityBytes.fill(0);
+    reservation = undefined;
+  };
+
+  const awaitDrain = (
+    deadlineMs: number,
+    state: ClientState,
+  ): Promise<UpgradeDrainOutcome | { readonly status: "connection-closed" }> => {
+    const tasks = [...coachingTasks];
+    if (tasks.length === 0) {
+      return Promise.resolve(
+        state.detached ? { status: "connection-closed" } : { status: "accepted" },
+      );
+    }
+    return new Promise((resolve) => {
+      let settled = false;
+      const deadline = timer.schedule(Math.max(0, deadlineMs - timer.nowMs()), () => {
+        if (settled) return;
+        settled = true;
+        deadline.cancel();
+        resolve({ status: "timeout" });
+      });
+      void Promise.all(tasks).then(() => {
+        if (settled) return;
+        settled = true;
+        deadline.cancel();
+        resolve({ status: "accepted" });
+      });
+      void state.detachedPromise.then(() => {
+        if (settled) return;
+        settled = true;
+        deadline.cancel();
+        resolve({ status: "connection-closed" });
+      });
+    });
+  };
 
   const handleRequest = (state: ClientState, data: RawData, isBinary: boolean): void => {
     if (closing) {
@@ -303,6 +443,102 @@ export function createCoachRpcServer(input: CoachRpcServerInput): CoachRpcServer
       );
       return;
     }
+    if (
+      generic.data.method === "daemon.reserveUpgrade"
+      || generic.data.method === "daemon.shutdownForUpgrade"
+    ) {
+      const params = controlParams(generic.data.params);
+      if (params === undefined) {
+        void enqueueSerialized(state, ordinaryError(generic.data.id, -32602, "Invalid params"));
+        return;
+      }
+      if (generic.data.method === "daemon.reserveUpgrade") {
+        const capability = canonicalCapability(params.handoffCapability);
+        if (
+          reservation !== undefined
+          || capability === undefined
+          || params.targetProtocolVersion <= PROTOCOL_VERSION
+          || input.owner === "unmanaged-foreground"
+        ) {
+          void enqueueSerialized(
+            state,
+            ordinaryError(generic.data.id, -32_003, "handoff-reservation-refused"),
+          );
+          return;
+        }
+        reservation = {
+          connectionId: state.connectionId,
+          targetProtocolVersion: params.targetProtocolVersion,
+          handoffCapabilityBytes: Buffer.from(capability),
+          state: "reserved",
+        };
+        capability.fill(0);
+        void enqueueSerialized(
+          state,
+          ordinarySuccess(generic.data.id, { status: "reserved" }),
+        );
+        return;
+      }
+      const capability = canonicalCapability(params.handoffCapability);
+      const activeReservation = reservation;
+      if (
+        capability === undefined
+        || activeReservation === undefined
+        || activeReservation.state !== "reserved"
+        || activeReservation.connectionId !== state.connectionId
+        || activeReservation.targetProtocolVersion !== params.targetProtocolVersion
+        || capability.length !== activeReservation.handoffCapabilityBytes.length
+        || !timingSafeEqual(capability, activeReservation.handoffCapabilityBytes)
+      ) {
+        capability?.fill(0);
+        void enqueueSerialized(
+          state,
+          ordinaryError(generic.data.id, -32_003, "handoff-reservation-refused"),
+        );
+        return;
+      }
+      capability.fill(0);
+      reservation = { ...activeReservation, state: "shutdown-consumed" };
+      acceptingCoaching = false;
+      input.healthState?.setHealthy(false);
+      const task = (async () => {
+        const outcome = await awaitDrain(
+          timer.nowMs() + UPGRADE_DRAIN_TIMEOUT_MS,
+          state,
+        );
+        if (outcome.status !== "accepted") {
+          acceptingCoaching = true;
+          input.healthState?.setHealthy(true);
+          clearReservation();
+          if (outcome.status === "timeout") {
+            await enqueueSerialized(
+              state,
+              ordinaryError(generic.data.id, -32_004, "upgrade-drain-timeout"),
+            );
+          }
+          return;
+        }
+        await enqueueSerialized(
+          state,
+          ordinarySuccess(generic.data.id, { status: "accepted" }),
+        );
+        if (state.detached) {
+          acceptingCoaching = true;
+          input.healthState?.setHealthy(true);
+          clearReservation();
+          return;
+        }
+        clearReservation();
+        resolveShutdownRequested();
+      })();
+      state.requestTasks.add(task);
+      void task.finally(() => state.requestTasks.delete(task)).catch(() => {});
+      return;
+    }
+    if (!acceptingCoaching) {
+      void enqueueSerialized(state, ordinaryError(generic.data.id, -32_005, "daemon-upgrading"));
+      return;
+    }
     if (!methodExists(generic.data.method)) {
       void enqueueSerialized(state, ordinaryError(generic.data.id, -32601, "Method not found"));
       return;
@@ -323,6 +559,7 @@ export function createCoachRpcServer(input: CoachRpcServerInput): CoachRpcServer
     const task = (async () => {
       let invocationFailed = false;
       let eventFailed = false;
+      let deliveryDetached = false;
       let result: unknown;
       try {
         switch (registry.wireName) {
@@ -331,27 +568,32 @@ export function createCoachRpcServer(input: CoachRpcServerInput): CoachRpcServer
               const request = COACH_RPC_METHOD_REGISTRY.chat.requestSchema.parse(
                 generic.data.params,
               );
-              result = await input.engine.chat(request, (event) => {
-                if (eventFailed) return;
-                try {
-                  const parsedEvent = COACH_RPC_METHOD_REGISTRY.chat.eventSchema.parse(event);
-                  const notification = CoachTurnEventNotificationEnvelopeSchema.parse({
-                    jsonrpc: "2.0",
-                    method: "coach.turnEvent",
-                    params: {
-                      requestId: generic.data.id,
-                      requestMethod: "chat",
-                      turnId: parsedEvent.turnId,
-                      event: parsedEvent,
-                    },
-                  });
-                  void enqueueSerialized(state, serializeCoachRpcEnvelope(notification));
-                } catch {
-                  eventFailed = true;
-                }
+              result = await sessionQueue.run({
+                key: request.chatId,
+                signal: state.detachController.signal,
+                run: () => input.engine.chat(request, (event) => {
+                  if (eventFailed) return;
+                  try {
+                    const parsedEvent = COACH_RPC_METHOD_REGISTRY.chat.eventSchema.parse(event);
+                    const notification = CoachTurnEventNotificationEnvelopeSchema.parse({
+                      jsonrpc: "2.0",
+                      method: "coach.turnEvent",
+                      params: {
+                        requestId: generic.data.id,
+                        requestMethod: "chat",
+                        turnId: parsedEvent.turnId,
+                        event: parsedEvent,
+                      },
+                    });
+                    void enqueueSerialized(state, serializeCoachRpcEnvelope(notification));
+                  } catch {
+                    eventFailed = true;
+                  }
+                }),
               });
-            } catch {
-              invocationFailed = true;
+            } catch (error) {
+              if (error instanceof DetachedSessionRequestError) deliveryDetached = true;
+              else invocationFailed = true;
             }
             break;
           case "resetSession":
@@ -383,6 +625,7 @@ export function createCoachRpcServer(input: CoachRpcServerInput): CoachRpcServer
             }
             break;
         }
+        if (deliveryDetached) return;
         let terminal: string;
         if (invocationFailed || eventFailed) {
           terminal = ordinaryError(generic.data.id, -32603, "Internal error");
@@ -410,15 +653,26 @@ export function createCoachRpcServer(input: CoachRpcServerInput): CoachRpcServer
       }
     })();
     state.requestTasks.add(task);
-    void task.finally(() => state.requestTasks.delete(task)).catch(() => {});
+    coachingTasks.add(task);
+    void task.finally(() => {
+      state.requestTasks.delete(task);
+      coachingTasks.delete(task);
+    }).catch(() => {});
   };
 
   const acceptClient = (ws: WebSocket): void => {
-    const state = createClientState(ws);
+    connectionSequence += 1;
+    const state = createClientState(ws, `connection-${connectionSequence}`);
     clients.add(state);
     ws.on("close", () => {
       clearAuthTimer(state);
       detach(state);
+      if (
+        reservation?.connectionId === state.connectionId
+        && reservation.state === "reserved"
+      ) {
+        clearReservation();
+      }
       state.closed = true;
       state.resolveClosed();
       void Promise.all(state.requestTasks)
@@ -514,9 +768,12 @@ export function createCoachRpcServer(input: CoachRpcServerInput): CoachRpcServer
 
   return {
     handleUpgrade,
+    shutdownRequested,
     close() {
       closePromise ??= (async () => {
         closing = true;
+        acceptingCoaching = false;
+        input.healthState?.setHealthy(false);
         for (const state of clients) {
           clearAuthTimer(state);
           if (!state.authenticated) {
@@ -540,6 +797,7 @@ export function createCoachRpcServer(input: CoachRpcServerInput): CoachRpcServer
             else reject(error);
           });
         });
+        clearReservation();
         clients.clear();
       })();
       return closePromise;

--- a/packages/coach/src/daemon/session-queue.ts
+++ b/packages/coach/src/daemon/session-queue.ts
@@ -1,0 +1,125 @@
+export interface SessionQueueRequest<T> {
+  readonly key: string;
+  readonly signal: AbortSignal;
+  readonly run: () => Promise<T>;
+}
+
+export interface SessionRequestQueue {
+  run<T>(request: SessionQueueRequest<T>): Promise<T>;
+  readonly activeKeyCount: number;
+}
+
+export class DetachedSessionRequestError extends Error {
+  readonly kind = "detached" as const;
+
+  constructor() {
+    super("Session request delivery detached.");
+    this.name = "DetachedSessionRequestError";
+  }
+}
+
+interface QueueNode {
+  readonly key: string;
+  readonly signal: AbortSignal;
+  readonly run: () => Promise<unknown>;
+  readonly resolve: (value: unknown) => void;
+  readonly reject: (error: unknown) => void;
+  readonly onAbort: () => void;
+  previous: QueueNode | undefined;
+  next: QueueNode | undefined;
+  started: boolean;
+  detached: boolean;
+}
+
+interface KeyQueue {
+  head: QueueNode | undefined;
+  tail: QueueNode | undefined;
+}
+
+export function createSessionRequestQueue(): SessionRequestQueue {
+  const queues = new Map<string, KeyQueue>();
+
+  const removeQueued = (queue: KeyQueue, node: QueueNode): void => {
+    if (node.previous === undefined) queue.head = node.next;
+    else node.previous.next = node.next;
+    if (node.next === undefined) queue.tail = node.previous;
+    else node.next.previous = node.previous;
+    node.previous = undefined;
+    node.next = undefined;
+  };
+
+  const start = (queue: KeyQueue, node: QueueNode): void => {
+    node.started = true;
+    let running: Promise<unknown>;
+    try {
+      running = node.run();
+    } catch (error) {
+      running = Promise.reject(error);
+    }
+    const advance = (): void => {
+      node.signal.removeEventListener("abort", node.onAbort);
+      if (queue.head === node) removeQueued(queue, node);
+      const next = queue.head;
+      if (next === undefined) {
+        if (queues.get(node.key) === queue) queues.delete(node.key);
+        return;
+      }
+      start(queue, next);
+    };
+    void running.then(
+      (value) => {
+        advance();
+        if (node.detached) node.reject(new DetachedSessionRequestError());
+        else node.resolve(value);
+      },
+      (error) => {
+        advance();
+        if (node.detached) node.reject(new DetachedSessionRequestError());
+        else node.reject(error);
+      },
+    );
+  };
+
+  return {
+    run<T>(request: SessionQueueRequest<T>): Promise<T> {
+      if (request.signal.aborted) {
+        return Promise.reject(new DetachedSessionRequestError());
+      }
+      return new Promise<T>((resolve, reject) => {
+        const queue = queues.get(request.key) ?? { head: undefined, tail: undefined };
+        const node: QueueNode = {
+          key: request.key,
+          signal: request.signal,
+          run: request.run,
+          resolve: (value) => resolve(value as T),
+          reject,
+          onAbort: () => {
+            if (node.started) {
+              node.detached = true;
+              return;
+            }
+            removeQueued(queue, node);
+            request.signal.removeEventListener("abort", node.onAbort);
+            reject(new DetachedSessionRequestError());
+            if (queue.head === undefined && queues.get(request.key) === queue) {
+              queues.delete(request.key);
+            }
+          },
+          previous: queue.tail,
+          next: undefined,
+          started: false,
+          detached: false,
+        };
+        if (queue.tail === undefined) queue.head = node;
+        else queue.tail.next = node;
+        queue.tail = node;
+        queues.set(request.key, queue);
+        request.signal.addEventListener("abort", node.onAbort, { once: true });
+        if (queue.head === node) start(queue, node);
+      });
+    },
+    get activeKeyCount(): number {
+      return queues.size;
+    },
+  };
+}

--- a/packages/coach/src/daemon/upgrade-fence.ts
+++ b/packages/coach/src/daemon/upgrade-fence.ts
@@ -1,0 +1,377 @@
+import { randomBytes as cryptoRandomBytes, timingSafeEqual } from "node:crypto";
+import { chmod, lstat, mkdir, rename, unlink } from "node:fs/promises";
+import { createConnection, createServer, type Server, type Socket } from "node:net";
+import { join } from "node:path";
+import { performance } from "node:perf_hooks";
+import { TextDecoder } from "node:util";
+import { EXIT_DAEMON_UNAVAILABLE } from "@enduragent/coach-contract";
+
+export const UPGRADE_FENCE_SOCKET_NAME = "upgrade.sock" as const;
+export const HANDOFF_CAPABILITY_BYTES = 32 as const;
+export const UPGRADE_FENCE_FRAME_MAX_BYTES = 4_096 as const;
+export const UPGRADE_FENCE_IO_TIMEOUT_MS = 5_000 as const;
+export const HANDOFF_RESERVED_MESSAGE =
+  "Enduragent cannot start: an authenticated upgrade handoff already reserves this athlete home.\n";
+
+export interface ScheduledMonotonicTimer {
+  cancel(): void;
+}
+
+export interface MonotonicTimer {
+  nowMs(): number;
+  schedule(delayMs: number, callback: () => void): ScheduledMonotonicTimer;
+}
+
+export type UpgradeFenceAdmission =
+  | { readonly status: "clear" }
+  | { readonly status: "designated" }
+  | {
+      readonly status: "reserved";
+      readonly exitCode: 3;
+      readonly message: typeof HANDOFF_RESERVED_MESSAGE;
+    };
+
+export interface UpgradeFenceHandle {
+  readonly socketPath: string;
+  readonly handoffCapability: string;
+  release(): Promise<void>;
+}
+
+export interface AcquireUpgradeFenceInput {
+  readonly configDir: string;
+  readonly randomBytes?: (size: number) => Buffer;
+  readonly timer?: MonotonicTimer;
+}
+
+export type AcquireUpgradeFenceResult =
+  | { readonly status: "acquired"; readonly handle: UpgradeFenceHandle }
+  | {
+      readonly status: "reserved";
+      readonly exitCode: 3;
+      readonly message: typeof HANDOFF_RESERVED_MESSAGE;
+    };
+
+interface FileIdentity {
+  readonly dev: number;
+  readonly ino: number;
+}
+
+const decoder = new TextDecoder("utf-8", { fatal: true });
+let staleSequence = 0;
+
+function productionTimer(): MonotonicTimer {
+  return {
+    nowMs: () => performance.now(),
+    schedule(delayMs, callback) {
+      const handle = setTimeout(callback, Math.max(0, delayMs));
+      handle.unref?.();
+      return { cancel: () => clearTimeout(handle) };
+    },
+  };
+}
+
+function reserved(): Extract<UpgradeFenceAdmission, { status: "reserved" }> {
+  return {
+    status: "reserved",
+    exitCode: EXIT_DAEMON_UNAVAILABLE,
+    message: HANDOFF_RESERVED_MESSAGE,
+  };
+}
+
+async function identity(path: string): Promise<FileIdentity | undefined> {
+  try {
+    const metadata = await lstat(path);
+    return { dev: metadata.dev, ino: metadata.ino };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+    throw error;
+  }
+}
+
+function sameIdentity(left: FileIdentity | undefined, right: FileIdentity): boolean {
+  return left?.dev === right.dev && left.ino === right.ino;
+}
+
+async function unlinkIdentity(path: string, expected: FileIdentity): Promise<void> {
+  if (!sameIdentity(await identity(path), expected)) return;
+  try {
+    await unlink(path);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+}
+
+async function reclaimStaleSocket(path: string, expected: FileIdentity): Promise<boolean> {
+  if (!sameIdentity(await identity(path), expected)) return false;
+  staleSequence += 1;
+  const stalePath = `${path}.stale.${process.pid}.${staleSequence}`;
+  try {
+    await rename(path, stalePath);
+  } catch (error) {
+    if (["ENOENT", "EEXIST"].includes((error as NodeJS.ErrnoException).code ?? "")) return false;
+    throw error;
+  }
+  await unlinkIdentity(stalePath, expected);
+  return true;
+}
+
+function readFrame(socket: Socket, timer: MonotonicTimer): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let bytes = Buffer.alloc(0);
+    let settled = false;
+    const deadline = timer.schedule(UPGRADE_FENCE_IO_TIMEOUT_MS, () => finish(new Error("timeout")));
+    const cleanup = (): void => {
+      deadline.cancel();
+      socket.off("data", onData);
+      socket.off("error", onError);
+      socket.off("close", onClose);
+    };
+    const finish = (error?: Error, value?: string): void => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      if (error === undefined) resolve(value!);
+      else reject(error);
+    };
+    const onError = (): void => finish(new Error("io"));
+    const onClose = (): void => finish(new Error("closed"));
+    const onData = (chunk: Buffer): void => {
+      bytes = Buffer.concat([bytes, chunk]);
+      if (bytes.length > UPGRADE_FENCE_FRAME_MAX_BYTES) {
+        finish(new Error("oversized"));
+        return;
+      }
+      const newline = bytes.indexOf(0x0a);
+      if (newline === -1) return;
+      if (newline !== bytes.length - 1 || bytes.indexOf(0x0a, newline + 1) !== -1) {
+        finish(new Error("trailing"));
+        return;
+      }
+      try {
+        finish(undefined, decoder.decode(bytes.subarray(0, -1)));
+      } catch {
+        finish(new Error("encoding"));
+      }
+    };
+    socket.on("data", onData);
+    socket.once("error", onError);
+    socket.once("close", onClose);
+  });
+}
+
+function canonicalCapability(value: unknown): Buffer | undefined {
+  if (typeof value !== "string" || !/^[A-Za-z0-9_-]{43}$/.test(value)) return undefined;
+  const decoded = Buffer.from(value, "base64url");
+  if (
+    decoded.length !== HANDOFF_CAPABILITY_BYTES
+    || decoded.toString("base64url") !== value
+  ) {
+    return undefined;
+  }
+  return decoded;
+}
+
+function strictRequest(value: unknown):
+  | { readonly kind: "ordinary-starter" }
+  | { readonly kind: "designated-successor"; readonly handoffCapability: string }
+  | undefined {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const record = value as Record<string, unknown>;
+  const keys = Object.keys(record).sort();
+  if (keys.length === 1 && keys[0] === "kind" && record.kind === "ordinary-starter") {
+    return { kind: "ordinary-starter" };
+  }
+  if (
+    keys.length === 2
+    && keys[0] === "handoffCapability"
+    && keys[1] === "kind"
+    && record.kind === "designated-successor"
+    && typeof record.handoffCapability === "string"
+  ) {
+    return { kind: "designated-successor", handoffCapability: record.handoffCapability };
+  }
+  return undefined;
+}
+
+function strictResponse(value: unknown): "reserved" | "designated" | undefined {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const record = value as Record<string, unknown>;
+  const keys = Object.keys(record);
+  return keys.length === 1 && keys[0] === "status"
+    && (record.status === "reserved" || record.status === "designated")
+    ? record.status
+    : undefined;
+}
+
+function listen(server: Server, socketPath: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const onError = (error: Error): void => reject(error);
+    server.once("error", onError);
+    server.listen(socketPath, () => {
+      server.off("error", onError);
+      resolve();
+    });
+  });
+}
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve) => server.close(() => resolve()));
+}
+
+async function requestAdmission(
+  socketPath: string,
+  request: { readonly kind: "ordinary-starter" }
+    | { readonly kind: "designated-successor"; readonly handoffCapability: string },
+  timer: MonotonicTimer,
+): Promise<"reserved" | "designated"> {
+  const socket = createConnection(socketPath);
+  try {
+    await new Promise<void>((resolve, reject) => {
+      socket.once("connect", resolve);
+      socket.once("error", reject);
+    });
+    const response = readFrame(socket, timer);
+    socket.end(`${JSON.stringify(request)}\n`);
+    const parsed = strictResponse(JSON.parse(await response));
+    if (parsed === undefined) throw new Error("invalid response");
+    return parsed;
+  } finally {
+    socket.destroy();
+  }
+}
+
+async function ensureConfigDir(configDir: string): Promise<void> {
+  await mkdir(configDir, { recursive: true, mode: 0o700 });
+  await chmod(configDir, 0o700);
+}
+
+export async function acquireUpgradeFence(
+  input: AcquireUpgradeFenceInput,
+): Promise<AcquireUpgradeFenceResult> {
+  await ensureConfigDir(input.configDir);
+  const socketPath = join(input.configDir, UPGRADE_FENCE_SOCKET_NAME);
+  const timer = input.timer ?? productionTimer();
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const capabilityBytes = Buffer.from(
+      (input.randomBytes ?? cryptoRandomBytes)(HANDOFF_CAPABILITY_BYTES),
+    );
+    if (capabilityBytes.length !== HANDOFF_CAPABILITY_BYTES) {
+      throw new Error("upgrade fence capability generation failed");
+    }
+    let consumed = false;
+    const sockets = new Set<Socket>();
+    const server = createServer((socket) => {
+      sockets.add(socket);
+      socket.once("close", () => sockets.delete(socket));
+      socket.once("error", () => socket.destroy());
+      void readFrame(socket, timer).then((raw) => {
+        let request: ReturnType<typeof strictRequest>;
+        try {
+          request = strictRequest(JSON.parse(raw));
+        } catch {
+          request = undefined;
+        }
+        let status: "reserved" | "designated" = "reserved";
+        if (request?.kind === "designated-successor" && !consumed) {
+          const received = canonicalCapability(request.handoffCapability);
+          const matches =
+            received !== undefined
+            && received.length === capabilityBytes.length
+            && timingSafeEqual(received, capabilityBytes);
+          received?.fill(0);
+          if (matches) {
+            consumed = true;
+            status = "designated";
+          }
+        }
+        socket.end(`${JSON.stringify({ status })}\n`);
+      }).catch(() => socket.end(`${JSON.stringify({ status: "reserved" })}\n`));
+    });
+    try {
+      await listen(server, socketPath);
+    } catch (error) {
+      for (const socket of sockets) socket.destroy();
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code !== "EADDRINUSE") {
+        capabilityBytes.fill(0);
+        throw error;
+      }
+      const observed = await identity(socketPath);
+      if (observed === undefined) {
+        capabilityBytes.fill(0);
+        continue;
+      }
+      try {
+        await requestAdmission(socketPath, { kind: "ordinary-starter" }, timer);
+        capabilityBytes.fill(0);
+        return reserved();
+      } catch (probeError) {
+        if ((probeError as NodeJS.ErrnoException).code !== "ECONNREFUSED") {
+          capabilityBytes.fill(0);
+          return reserved();
+        }
+      }
+      if (!(await reclaimStaleSocket(socketPath, observed))) {
+        capabilityBytes.fill(0);
+        return reserved();
+      }
+      capabilityBytes.fill(0);
+      continue;
+    }
+    await chmod(socketPath, 0o600);
+    const ownedIdentity = await identity(socketPath);
+    if (ownedIdentity === undefined) {
+      await closeServer(server);
+      throw new Error("upgrade fence socket identity unavailable");
+    }
+    const handoffCapability = capabilityBytes.toString("base64url");
+    let releasePromise: Promise<void> | undefined;
+    return {
+      status: "acquired",
+      handle: {
+        socketPath,
+        handoffCapability,
+        release() {
+          releasePromise ??= (async () => {
+            for (const socket of sockets) socket.destroy();
+            await closeServer(server);
+            await unlinkIdentity(socketPath, ownedIdentity);
+            capabilityBytes.fill(0);
+          })();
+          return releasePromise;
+        },
+      },
+    };
+  }
+  return reserved();
+}
+
+export async function admitStartupThroughUpgradeFence(input: {
+  readonly configDir: string;
+  readonly handoffCapability?: string;
+  readonly timer?: MonotonicTimer;
+}): Promise<UpgradeFenceAdmission> {
+  await ensureConfigDir(input.configDir);
+  const socketPath = join(input.configDir, UPGRADE_FENCE_SOCKET_NAME);
+  const timer = input.timer ?? productionTimer();
+  const request = input.handoffCapability === undefined
+    ? { kind: "ordinary-starter" as const }
+    : {
+        kind: "designated-successor" as const,
+        handoffCapability: input.handoffCapability,
+      };
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      const status = await requestAdmission(socketPath, request, timer);
+      return status === "designated" ? { status: "designated" } : reserved();
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code === "ENOENT") return { status: "clear" };
+      if (code !== "ECONNREFUSED") return reserved();
+      const observed = await identity(socketPath);
+      if (observed === undefined) return { status: "clear" };
+      if (!(await reclaimStaleSocket(socketPath, observed))) return reserved();
+    }
+  }
+  return reserved();
+}

--- a/packages/coach/src/serve.ts
+++ b/packages/coach/src/serve.ts
@@ -1,6 +1,13 @@
-import { EXIT_SUCCESS, type ExitCode } from "@enduragent/coach-contract";
+import {
+  EXIT_SUCCESS,
+  type DaemonOwner,
+  type ExitCode,
+} from "@enduragent/coach-contract";
 import type { AthleteHome } from "@enduragent/kernel-node/home";
-import { createHealthzRequestHandler } from "./daemon/healthz-server.js";
+import {
+  createDaemonHealthState,
+  createHealthzRequestHandler,
+} from "./daemon/healthz-server.js";
 import { createCoachRpcServer, ensureDaemonToken } from "./daemon/rpc-server.js";
 import type { LocalCoachLifecycle } from "./local-runner.js";
 
@@ -9,18 +16,21 @@ export interface RunCoachServeInput {
   readonly home: AthleteHome;
   readonly appVersion: string;
   readonly signal: AbortSignal;
+  readonly owner?: DaemonOwner;
 }
 
 export interface CoachServeDependencies {
   readonly ensureToken: typeof ensureDaemonToken;
   readonly createRpcServer: typeof createCoachRpcServer;
   readonly createHealthzHandler: typeof createHealthzRequestHandler;
+  readonly createHealthState: typeof createDaemonHealthState;
 }
 
 const defaultDependencies: CoachServeDependencies = {
   ensureToken: ensureDaemonToken,
   createRpcServer: createCoachRpcServer,
   createHealthzHandler: createHealthzRequestHandler,
+  createHealthState: createDaemonHealthState,
 };
 
 export async function runCoachServe(
@@ -44,10 +54,12 @@ export async function runCoachServe(
     if (aborted) return EXIT_SUCCESS;
     const token = await dependencies.ensureToken(input.home.configDir);
     if (aborted) return EXIT_SUCCESS;
+    const healthState = dependencies.createHealthState();
     const rpc = dependencies.createRpcServer({
       engine: input.lifecycle.engine,
       token: token.value,
-      owner: "unmanaged-foreground",
+      owner: input.owner ?? "unmanaged-foreground",
+      healthState,
     });
     if (aborted) {
       await rpc.close();
@@ -58,7 +70,7 @@ export async function runCoachServe(
       binding = await input.lifecycle.listener.bind({
         request: dependencies.createHealthzHandler({
           appVersion: input.appVersion,
-          owner: "unmanaged-foreground",
+          state: healthState,
         }),
         upgrade: rpc.handleUpgrade,
       });
@@ -66,7 +78,7 @@ export async function runCoachServe(
       await rpc.close().catch(() => {});
       throw error;
     }
-    if (!aborted) await abortPromise;
+    if (!aborted) await Promise.race([abortPromise, rpc.shutdownRequested]);
     let bindingClose: Promise<void>;
     try {
       bindingClose = binding.close();

--- a/packages/coach/tests/daemon-contention.integration.test.ts
+++ b/packages/coach/tests/daemon-contention.integration.test.ts
@@ -1,0 +1,179 @@
+import { fork, type ChildProcess } from "node:child_process";
+import { mkdtemp, realpath, rm } from "node:fs/promises";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import type { AthleteHome } from "@enduragent/kernel-node/home";
+
+const fixture = fileURLToPath(new URL("./fixtures/daemon-process.ts", import.meta.url));
+const roots: string[] = [];
+const children = new Set<ChildProcess>();
+
+afterEach(async () => {
+  for (const child of children) child.kill("SIGKILL");
+  children.clear();
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+async function syntheticHome(label: string): Promise<AthleteHome> {
+  const root = await mkdtemp(join(await realpath(tmpdir()), `${label}-`));
+  roots.push(root);
+  return {
+    root,
+    storeDir: join(root, "store"),
+    archiveDir: join(root, "archive"),
+    configDir: join(root, "config"),
+  };
+}
+
+function isolatedEnv(root: string): NodeJS.ProcessEnv {
+  const env = { ...process.env };
+  delete env.FORCE_COLOR;
+  delete env.CLICOLOR_FORCE;
+  for (const name of [
+    "HOME",
+    "ENDURAGENT_HOME",
+    "XDG_CONFIG_HOME",
+    "XDG_CACHE_HOME",
+    "TMPDIR",
+    "UV_CACHE_DIR",
+  ]) {
+    env[name] = root;
+  }
+  return env;
+}
+
+function spawn(role: string, home: AthleteHome): ChildProcess {
+  const child = fork(fixture, [role], {
+    execArgv: ["--import", "tsx"],
+    env: isolatedEnv(home.root),
+    stdio: ["ignore", "pipe", "pipe", "ipc"],
+  });
+  children.add(child);
+  child.once("exit", () => children.delete(child));
+  return child;
+}
+
+function message<T>(child: ChildProcess, type: string): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const onMessage = (value: unknown): void => {
+      const record = value as { readonly type?: unknown };
+      if (record.type === "error") {
+        cleanup();
+        reject(new Error("fixture failed"));
+      } else if (record.type === type) {
+        cleanup();
+        resolve(value as T);
+      }
+    };
+    const onExit = (code: number | null): void => {
+      cleanup();
+      reject(new Error(`fixture exited before ${type}: ${code}`));
+    };
+    const cleanup = (): void => {
+      child.off("message", onMessage);
+      child.off("exit", onExit);
+    };
+    child.on("message", onMessage);
+    child.once("exit", onExit);
+  });
+}
+
+function send(child: ChildProcess, value: Parameters<ChildProcess["send"]>[0]): Promise<void> {
+  return new Promise((resolve, reject) => {
+    child.send(value, (error) => error === null ? resolve() : reject(error));
+  });
+}
+
+function exit(child: ChildProcess): Promise<void> {
+  return new Promise((resolve) => child.once("exit", () => resolve()));
+}
+
+async function loopbackAvailable(): Promise<boolean> {
+  return new Promise((resolve) => {
+    const server = createServer();
+    server.once("error", (error: NodeJS.ErrnoException) => {
+      if (error.code === "EPERM") {
+        process.stderr.write("SKIP_MARKER loopback-listen EPERM daemon-contention\n");
+      }
+      resolve(false);
+    });
+    server.listen({ host: "127.0.0.1", port: 0 }, () => server.close(() => resolve(true)));
+  });
+}
+
+const hasLoopback = await loopbackAvailable();
+
+describe.skipIf(!hasLoopback)("real daemon contention matrix", () => {
+  it("covers healthy, SIGKILL-stale, bound-unresponsive, and foreign-port processes", async () => {
+    const healthyHome = await syntheticHome("contention-healthy");
+    const healthy = spawn("writer", healthyHome);
+    const healthyReadyPromise = message<{
+      readonly rawPort: number;
+      readonly protocolPort: number;
+      readonly pid: number;
+    }>(healthy, "ready");
+    await send(healthy, { type: "start", home: healthyHome, mode: "healthy" });
+    const healthyReady = await healthyReadyPromise;
+    expect(healthyReady.rawPort).not.toBe(healthyReady.protocolPort);
+    const healthyStarter = spawn("classify", healthyHome);
+    const healthyClassification = message<{
+      readonly result: { readonly status: string; readonly peer?: { readonly port: number } };
+    }>(healthyStarter, "classification");
+    await send(healthyStarter, { type: "start", home: healthyHome });
+    await expect(healthyClassification).resolves.toMatchObject({
+      result: { status: "peer-healthy", peer: { port: healthyReady.protocolPort } },
+    });
+    const healthyExit = exit(healthy);
+    await send(healthy, { type: "stop" });
+    await healthyExit;
+
+    const staleHome = await syntheticHome("contention-stale");
+    const killed = spawn("writer", staleHome);
+    const killedReady = message(killed, "ready");
+    await send(killed, { type: "start", home: staleHome, mode: "healthy" });
+    await killedReady;
+    const killedExit = exit(killed);
+    killed.kill("SIGKILL");
+    await killedExit;
+    const successor = spawn("writer", staleHome);
+    const successorReady = message<{ readonly rw: string }>(successor, "ready");
+    await send(successor, { type: "start", home: staleHome, mode: "healthy" });
+    await expect(successorReady).resolves.toMatchObject({ rw: "open" });
+    const successorExit = exit(successor);
+    await send(successor, { type: "stop" });
+    await successorExit;
+
+    const boundHome = await syntheticHome("contention-bound");
+    const bound = spawn("writer", boundHome);
+    const boundReady = message(bound, "ready");
+    await send(bound, { type: "start", home: boundHome, mode: "bound" });
+    await boundReady;
+    const boundStarter = spawn("classify", boundHome);
+    const boundClassification = message(boundStarter, "classification");
+    await send(boundStarter, { type: "start", home: boundHome });
+    await expect(boundClassification).resolves.toMatchObject({
+      result: { status: "bound-unresponsive", stdout: "" },
+    });
+    const boundExit = exit(bound);
+    await send(bound, { type: "stop" });
+    await boundExit;
+
+    const foreignHome = await syntheticHome("contention-foreign");
+    const foreign = spawn("writer", foreignHome);
+    const foreignReady = message(foreign, "ready");
+    await send(foreign, { type: "start", home: foreignHome, mode: "foreign" });
+    await foreignReady;
+    const foreignStarter = spawn("classify", foreignHome);
+    const foreignClassification = message(foreignStarter, "classification");
+    await send(foreignStarter, { type: "start", home: foreignHome });
+    await expect(foreignClassification).resolves.toMatchObject({
+      result: { status: "foreign-port", stdout: "" },
+    });
+    const foreignExit = exit(foreign);
+    await send(foreign, { type: "stop" });
+    await foreignExit;
+  });
+});

--- a/packages/coach/tests/daemon-handoff.integration.test.ts
+++ b/packages/coach/tests/daemon-handoff.integration.test.ts
@@ -1,0 +1,191 @@
+import { fork, type ChildProcess } from "node:child_process";
+import { mkdtemp, realpath, rm } from "node:fs/promises";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { performance } from "node:perf_hooks";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import type { AthleteHome } from "@enduragent/kernel-node/home";
+import { HANDOFF_RESERVED_MESSAGE } from "../src/daemon/handshake.js";
+
+const fixture = fileURLToPath(new URL("./fixtures/daemon-process.ts", import.meta.url));
+const roots: string[] = [];
+const children = new Set<ChildProcess>();
+
+afterEach(async () => {
+  for (const child of children) child.kill("SIGKILL");
+  children.clear();
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+async function syntheticHome(): Promise<AthleteHome> {
+  const root = await mkdtemp(join(await realpath(tmpdir()), "daemon-handoff-"));
+  roots.push(root);
+  return {
+    root,
+    storeDir: join(root, "store"),
+    archiveDir: join(root, "archive"),
+    configDir: join(root, "config"),
+  };
+}
+
+function spawn(role: string, home: AthleteHome): ChildProcess {
+  const env = { ...process.env };
+  delete env.FORCE_COLOR;
+  delete env.CLICOLOR_FORCE;
+  for (const name of [
+    "HOME",
+    "ENDURAGENT_HOME",
+    "XDG_CONFIG_HOME",
+    "XDG_CACHE_HOME",
+    "TMPDIR",
+    "UV_CACHE_DIR",
+  ]) {
+    env[name] = home.root;
+  }
+  const child = fork(fixture, [role], {
+    execArgv: ["--import", "tsx"],
+    env,
+    stdio: ["ignore", "pipe", "pipe", "ipc"],
+  });
+  children.add(child);
+  child.once("exit", () => children.delete(child));
+  return child;
+}
+
+function nextMessage<T>(child: ChildProcess, type: string): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const onMessage = (value: unknown): void => {
+      const record = value as { readonly type?: unknown };
+      if (record.type === "error") {
+        cleanup();
+        reject(new Error("fixture failed"));
+      } else if (record.type === type) {
+        cleanup();
+        resolve(value as T);
+      }
+    };
+    const onExit = (code: number | null): void => {
+      cleanup();
+      reject(new Error(`fixture exited before ${type}: ${code}`));
+    };
+    const cleanup = (): void => {
+      child.off("message", onMessage);
+      child.off("exit", onExit);
+    };
+    child.on("message", onMessage);
+    child.once("exit", onExit);
+  });
+}
+
+function send(child: ChildProcess, value: Parameters<ChildProcess["send"]>[0]): Promise<void> {
+  return new Promise((resolve, reject) => {
+    child.send(value, (error) => error === null ? resolve() : reject(error));
+  });
+}
+
+function exited(child: ChildProcess): Promise<void> {
+  return new Promise((resolve) => child.once("exit", () => resolve()));
+}
+
+async function unixSocketAvailable(): Promise<boolean> {
+  const path = join(await realpath(tmpdir()), `handoff-preflight-${process.pid}.sock`);
+  return new Promise((resolve) => {
+    const server = createServer();
+    server.once("error", (error: NodeJS.ErrnoException) => {
+      if (error.code === "EPERM") {
+        process.stderr.write("SKIP_MARKER unix-listen EPERM daemon-handoff\n");
+      }
+      resolve(false);
+    });
+    server.listen(path, () => server.close(() => resolve(true)));
+  });
+}
+
+const hasUnixSockets = await unixSocketAvailable();
+
+describe.skipIf(!hasUnixSockets)("real successor-held handoff fence", () => {
+  it("reserves every third starter, consumes one capability, coalesces controllers, and crash-releases", async () => {
+    const home = await syntheticHome();
+    const events: Array<{ readonly name: string; readonly at: number }> = [];
+    const holder = spawn("fence-holder", home);
+    const holderReady = nextMessage<{
+      readonly result: {
+        readonly status: "acquired";
+        readonly handoffCapability: string;
+      };
+    }>(holder, "fence");
+    await send(holder, { type: "start", home });
+    const fence = await holderReady;
+    events.push({ name: "fence-acquired", at: performance.now() });
+
+    const ordinary = spawn("fence-admit", home);
+    const ordinaryResult = nextMessage<{
+      readonly result: {
+        readonly status: string;
+        readonly exitCode: number;
+        readonly message: string;
+      };
+    }>(ordinary, "admission");
+    await send(ordinary, { type: "start", home });
+    await expect(ordinaryResult).resolves.toMatchObject({
+      result: {
+        status: "reserved",
+        exitCode: 3,
+        message: HANDOFF_RESERVED_MESSAGE,
+      },
+    });
+
+    const designated = spawn("fence-admit", home);
+    const designatedResult = nextMessage(designated, "admission");
+    await send(designated, {
+      type: "start",
+      home,
+      handoffCapability: fence.result.handoffCapability,
+    });
+    await expect(designatedResult).resolves.toMatchObject({
+      result: { status: "designated" },
+    });
+    events.push({ name: "designated-admitted", at: performance.now() });
+
+    const replay = spawn("fence-admit", home);
+    const concurrentController = spawn("fence-admit", home);
+    const replayResult = nextMessage(replay, "admission");
+    const concurrentResult = nextMessage(concurrentController, "admission");
+    await Promise.all([
+      send(replay, {
+        type: "start",
+        home,
+        handoffCapability: fence.result.handoffCapability,
+      }),
+      send(concurrentController, { type: "start", home }),
+    ]);
+    await expect(replayResult).resolves.toMatchObject({ result: { status: "reserved" } });
+    const losing = await concurrentResult as {
+      readonly result: { readonly status: string; readonly message: string };
+    };
+    expect(losing.result).toMatchObject({
+      status: "reserved",
+      message: HANDOFF_RESERVED_MESSAGE,
+    });
+    expect(losing.result.message).not.toContain("handoff-reservation-refused");
+
+    const holderExit = exited(holder);
+    holder.kill("SIGKILL");
+    await holderExit;
+    events.push({ name: "fence-crashed", at: performance.now() });
+    const recovery = spawn("fence-admit", home);
+    const recoveryResult = nextMessage(recovery, "admission");
+    await send(recovery, { type: "start", home });
+    await expect(recoveryResult).resolves.toMatchObject({ result: { status: "clear" } });
+    events.push({ name: "recovery-clear", at: performance.now() });
+    expect(events.map((event) => event.name)).toEqual([
+      "fence-acquired",
+      "designated-admitted",
+      "fence-crashed",
+      "recovery-clear",
+    ]);
+    expect(events.every((event, index) => index === 0 || event.at >= events[index - 1]!.at)).toBe(true);
+  });
+});

--- a/packages/coach/tests/daemon-handshake.test.ts
+++ b/packages/coach/tests/daemon-handshake.test.ts
@@ -1,0 +1,389 @@
+import { mkdtemp, realpath, rm } from "node:fs/promises";
+import { createServer as createNetServer } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  EXIT_VERSION_MISMATCH,
+  PROTOCOL_VERSION,
+  createAcceptedServerHandshakeFrame,
+  createVersionMismatchServerHandshakeFrame,
+  type DaemonOwner,
+} from "@enduragent/coach-contract";
+import type { AthleteHome } from "@enduragent/kernel-node/home";
+import { acquireWriteLock } from "@enduragent/kernel-node/lock";
+import {
+  HANDOFF_RESERVED_MESSAGE,
+  UNMANAGED_UPGRADE_MESSAGE,
+  UPGRADE_SUCCESSOR_FAILED_MESSAGE,
+  alreadyServingNotice,
+  classifyPeerReadOnly,
+  lowerClientMessage,
+  observePeerHandshake,
+  openAuthenticatedDaemonControl,
+  resolveSecondStarter,
+  type ResolveSecondStarterDependencies,
+} from "../src/daemon/handshake.js";
+import { createCoachRpcServer } from "../src/daemon/rpc-server.js";
+import type { UpgradeFenceHandle } from "../src/daemon/upgrade-fence.js";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+async function home(): Promise<AthleteHome> {
+  const root = await mkdtemp(join(await realpath(tmpdir()), "daemon-handshake-"));
+  roots.push(root);
+  return {
+    root,
+    storeDir: join(root, "store"),
+    archiveDir: join(root, "archive"),
+    configDir: join(root, "config"),
+  };
+}
+
+async function loopbackAvailable(): Promise<boolean> {
+  return new Promise((resolve) => {
+    const server = createNetServer();
+    server.once("error", (error: NodeJS.ErrnoException) => {
+      if (error.code === "EPERM") {
+        process.stderr.write("SKIP_MARKER loopback-listen EPERM daemon-handshake\n");
+      }
+      resolve(false);
+    });
+    server.listen({ host: "127.0.0.1", port: 0 }, () => server.close(() => resolve(true)));
+  });
+}
+
+const hasLoopback = await loopbackAvailable();
+
+describe.skipIf(!hasLoopback)("production peer observations", () => {
+  it("classifies writer-clear, healthy, bound-unresponsive, and foreign cases", async () => {
+    const clearHome = await home();
+    await expect(classifyPeerReadOnly(clearHome)).resolves.toEqual({ status: "writer-clear" });
+
+    const healthyHome = await home();
+    const healthy = await acquireWriteLock({
+      configDir: healthyHome.configDir,
+      athleteHome: healthyHome.root,
+      version: "0.1.0",
+    });
+    expect(healthy.status).toBe("acquired");
+    if (healthy.status !== "acquired") return;
+    const healthyBinding = await healthy.listener.bind({
+      request: (_request, response) => {
+        response.end(`${JSON.stringify({
+          service: "enduragent-store-writer",
+          version: "0.1.0",
+        })}\n`);
+      },
+      upgrade: (_request, socket) => socket.destroy(),
+    });
+    await expect(classifyPeerReadOnly(healthyHome)).resolves.toEqual({
+      status: "peer-healthy",
+      peer: {
+        status: "peer-healthy",
+        pid: process.pid,
+        port: healthyBinding.port,
+        peerVersion: "0.1.0",
+      },
+    });
+    await healthy.release();
+
+    const boundHome = await home();
+    const bound = await acquireWriteLock({
+      configDir: boundHome.configDir,
+      athleteHome: boundHome.root,
+      version: "0.1.0",
+    });
+    expect(bound.status).toBe("acquired");
+    if (bound.status !== "acquired") return;
+    await expect(classifyPeerReadOnly(boundHome)).resolves.toMatchObject({
+      status: "bound-unresponsive",
+      stdout: "",
+    });
+    await bound.release();
+
+    const foreignHome = await home();
+    const foreign = await acquireWriteLock({
+      configDir: foreignHome.configDir,
+      athleteHome: foreignHome.root,
+      version: "0.1.0",
+    });
+    expect(foreign.status).toBe("acquired");
+    if (foreign.status !== "acquired") return;
+    await foreign.listener.bind({
+      request: (_request, response) => response.end("foreign\n"),
+      upgrade: (_request, socket) => socket.destroy(),
+    });
+    await expect(classifyPeerReadOnly(foreignHome)).resolves.toMatchObject({
+      status: "foreign-port",
+      stdout: "",
+    });
+    await foreign.release();
+  });
+
+  it("observes strict compatible, mismatch, and auth-invalid handshakes", async () => {
+    const selectedHome = await home();
+    const lock = await acquireWriteLock({
+      configDir: selectedHome.configDir,
+      athleteHome: selectedHome.root,
+      version: "0.1.0",
+    });
+    expect(lock.status).toBe("acquired");
+    if (lock.status !== "acquired") return;
+    const token = "x".repeat(43);
+    const rpc = createCoachRpcServer({
+      token,
+      owner: "service-managed",
+      engine: {
+        chat: async () => ({ text: "ok" }),
+        resetSession: async () => ({ memoryFlushed: true }),
+        hasSession: async () => ({ hasSession: false }),
+        getAthleteState: async () => ({
+          schemaVersion: "3",
+          lastUpdated: "2026-01-01T00:00:00.000Z",
+          freshness: "fresh",
+          degraded: false,
+          lastSynced: "2026-01-01T00:00:00.000Z",
+          athleteProfile: {},
+          currentStatus: {},
+          derivedMetrics: {},
+          recentActivities: [],
+          plannedWorkouts: [],
+          wellness: {},
+        }),
+      },
+    });
+    const binding = await lock.listener.bind({
+      request: (_request, response) => response.end(),
+      upgrade: rpc.handleUpgrade,
+    });
+    await expect(observePeerHandshake({
+      port: binding.port,
+      token,
+      clientProtocolVersion: PROTOCOL_VERSION,
+    })).resolves.toMatchObject({ status: "accepted", owner: "service-managed" });
+    await expect(observePeerHandshake({
+      port: binding.port,
+      token,
+      clientProtocolVersion: PROTOCOL_VERSION + 1,
+    })).resolves.toMatchObject({ status: "version-mismatch", direction: "client-newer" });
+    const control = await openAuthenticatedDaemonControl({
+      port: binding.port,
+      token,
+      incumbentProtocolVersion: PROTOCOL_VERSION,
+      expectedOwner: "service-managed",
+    });
+    await expect(control.reserveUpgrade({
+      targetProtocolVersion: PROTOCOL_VERSION + 1,
+      handoffCapability: Buffer.alloc(32, 6).toString("base64url"),
+    })).resolves.toEqual({ status: "reserved" });
+    await control.close();
+    await expect(observePeerHandshake({
+      port: binding.port,
+      token: "wrong",
+      clientProtocolVersion: PROTOCOL_VERSION,
+    })).rejects.toThrow("daemon handshake failed");
+    await rpc.close();
+    await binding.close();
+    await lock.release();
+  });
+});
+
+function resolverHarness(owner: DaemonOwner, clientVersion: number, serverVersion: number) {
+  const selectedHome: AthleteHome = {
+    root: "/synthetic",
+    storeDir: "/synthetic/store",
+    archiveDir: "/synthetic/archive",
+    configDir: "/synthetic/config",
+  };
+  const peer = { status: "peer-healthy", pid: 7, port: 41_001, peerVersion: "old" } as const;
+  const publishedPeer = {
+    status: "peer-healthy",
+    pid: 8,
+    port: 41_002,
+    peerVersion: "new",
+  } as const;
+  const handshake = clientVersion === serverVersion
+    ? createAcceptedServerHandshakeFrame(owner, clientVersion, serverVersion)
+    : createVersionMismatchServerHandshakeFrame(owner, clientVersion, serverVersion);
+  const publishedHandshake = createAcceptedServerHandshakeFrame(
+    owner,
+    clientVersion,
+    clientVersion,
+  );
+  const fence: UpgradeFenceHandle = {
+    socketPath: "/synthetic/config/upgrade.sock",
+    handoffCapability: Buffer.alloc(32, 1).toString("base64url"),
+    release: vi.fn(async () => {}),
+  };
+  const serviceUpgrade = {
+    isInstalled: vi.fn(async () => true),
+    restartInstalledService: vi.fn(async () => {}),
+    kickstartInstalledServiceAfterEphemeral: vi.fn(async () => {}),
+    startEphemeralSuccessor: vi.fn(async () => {}),
+  };
+  const control = {
+    port: peer.port,
+    accepted: createAcceptedServerHandshakeFrame(owner, serverVersion, serverVersion),
+    reserveUpgrade: vi.fn(async () => ({ status: "reserved" as const })),
+    shutdownForUpgrade: vi.fn(async () => ({ status: "accepted" as const })),
+    close: vi.fn(async () => {}),
+  };
+  const acquireFence = vi.fn<ResolveSecondStarterDependencies["acquireUpgradeFence"]>(
+    async () => ({ status: "acquired", handle: fence }),
+  );
+  const dependencies = {
+    observePeerHandshake: vi.fn(async () => handshake),
+    openUpgradeControl: vi.fn(async () => control),
+    classifyPeerReadOnly: vi.fn(async () => ({ status: "peer-healthy" as const, peer })),
+    acquireUpgradeFence: acquireFence,
+    serviceUpgrade,
+    timer: { nowMs: () => 100, schedule: () => ({ cancel() {} }) },
+    waitForWriterRelease: vi.fn(async () => ({ status: "released" as const })),
+    waitForCompatiblePeer: vi.fn(async () => ({
+      status: "published" as const,
+      peer: publishedPeer,
+      handshake: publishedHandshake,
+    })),
+  } satisfies ResolveSecondStarterDependencies;
+  return { selectedHome, peer, publishedPeer, handshake, dependencies, fence, control, serviceUpgrade };
+}
+
+describe("second starter resolution", () => {
+  it("defers daemon starters and attaches client races for compatible peers", async () => {
+    for (const caller of ["serve", "service", "cli-auto-start", "local"] as const) {
+      const test = resolverHarness("service-managed", PROTOCOL_VERSION, PROTOCOL_VERSION);
+      const result = await resolveSecondStarter({
+        caller,
+        home: test.selectedHome,
+        clientProtocolVersion: PROTOCOL_VERSION,
+        clientAppVersion: "new",
+        bearerToken: "token",
+        peer: test.peer,
+      }, test.dependencies);
+      if (caller === "serve" || caller === "service") {
+        expect(result).toEqual({
+          status: "defer",
+          exitCode: 0,
+          stdout: "",
+          stderr: alreadyServingNotice(test.peer.port),
+        });
+      } else {
+        expect(result).toMatchObject({ status: "attach", port: test.peer.port });
+      }
+      expect(test.dependencies.acquireUpgradeFence).not.toHaveBeenCalled();
+    }
+  });
+
+  it("returns exit 5 for a lower client and never restarts downward", async () => {
+    const test = resolverHarness("service-managed", PROTOCOL_VERSION, PROTOCOL_VERSION + 1);
+    const result = await resolveSecondStarter({
+      caller: "cli-auto-start",
+      home: test.selectedHome,
+      clientProtocolVersion: PROTOCOL_VERSION,
+      clientAppVersion: "old",
+      bearerToken: "token",
+      peer: test.peer,
+    }, test.dependencies);
+    expect(result).toEqual({
+      status: "refuse",
+      exitCode: EXIT_VERSION_MISMATCH,
+      stdout: "",
+      stderr: lowerClientMessage(PROTOCOL_VERSION, PROTOCOL_VERSION + 1),
+    });
+    expect(test.dependencies.acquireUpgradeFence).not.toHaveBeenCalled();
+    expect(test.serviceUpgrade.restartInstalledService).not.toHaveBeenCalled();
+  });
+
+  it("refuses an authenticated unmanaged owner with exit 3 and zero takeover", async () => {
+    const test = resolverHarness("unmanaged-foreground", PROTOCOL_VERSION + 1, PROTOCOL_VERSION);
+    const result = await resolveSecondStarter({
+      caller: "local",
+      home: test.selectedHome,
+      clientProtocolVersion: PROTOCOL_VERSION + 1,
+      clientAppVersion: "new",
+      bearerToken: "token",
+      peer: test.peer,
+    }, test.dependencies);
+    expect(result).toEqual({
+      status: "refuse",
+      exitCode: 3,
+      stdout: "",
+      stderr: UNMANAGED_UPGRADE_MESSAGE,
+    });
+    expect(test.dependencies.acquireUpgradeFence).not.toHaveBeenCalled();
+  });
+
+  it("performs one fenced upward restart and attaches to the new port", async () => {
+    const test = resolverHarness("service-managed", PROTOCOL_VERSION + 1, PROTOCOL_VERSION);
+    const result = await resolveSecondStarter({
+      caller: "cli-auto-start",
+      home: test.selectedHome,
+      clientProtocolVersion: PROTOCOL_VERSION + 1,
+      clientAppVersion: "new",
+      bearerToken: "token",
+      peer: test.peer,
+    }, test.dependencies);
+    expect(result).toMatchObject({ status: "attach", port: test.publishedPeer.port });
+    expect(test.control.reserveUpgrade).toHaveBeenCalledTimes(1);
+    expect(test.control.shutdownForUpgrade).toHaveBeenCalledTimes(1);
+    expect(test.serviceUpgrade.restartInstalledService).toHaveBeenCalledTimes(1);
+    expect(test.fence.release).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns the fence to a designated ephemeral daemon starter", async () => {
+    const test = resolverHarness(
+      "ephemeral-client-started",
+      PROTOCOL_VERSION + 1,
+      PROTOCOL_VERSION,
+    );
+    test.serviceUpgrade.isInstalled.mockResolvedValue(false);
+    const result = await resolveSecondStarter({
+      caller: "serve",
+      home: test.selectedHome,
+      clientProtocolVersion: PROTOCOL_VERSION + 1,
+      clientAppVersion: "new",
+      bearerToken: "token",
+      peer: test.peer,
+    }, test.dependencies);
+    expect(result).toMatchObject({
+      status: "become-successor",
+      handoffCapability: test.fence.handoffCapability,
+    });
+    expect(test.fence.release).not.toHaveBeenCalled();
+  });
+
+  it("maps a live fence and successor failure to their exact terminal diagnostics", async () => {
+    const reserved = resolverHarness("service-managed", PROTOCOL_VERSION + 1, PROTOCOL_VERSION);
+    reserved.dependencies.acquireUpgradeFence.mockResolvedValue({
+      status: "reserved",
+      exitCode: 3,
+      message: HANDOFF_RESERVED_MESSAGE,
+    });
+    const reservedResult = await resolveSecondStarter({
+      caller: "serve",
+      home: reserved.selectedHome,
+      clientProtocolVersion: PROTOCOL_VERSION + 1,
+      clientAppVersion: "new",
+      bearerToken: "token",
+      peer: reserved.peer,
+    }, reserved.dependencies);
+    expect(reservedResult).toMatchObject({ stderr: HANDOFF_RESERVED_MESSAGE });
+
+    const failed = resolverHarness("service-managed", PROTOCOL_VERSION + 1, PROTOCOL_VERSION);
+    failed.serviceUpgrade.restartInstalledService.mockRejectedValue(new Error("secret"));
+    const failedResult = await resolveSecondStarter({
+      caller: "service",
+      home: failed.selectedHome,
+      clientProtocolVersion: PROTOCOL_VERSION + 1,
+      clientAppVersion: "new",
+      bearerToken: "token",
+      peer: failed.peer,
+    }, failed.dependencies);
+    expect(failedResult).toMatchObject({ stderr: UPGRADE_SUCCESSOR_FAILED_MESSAGE });
+  });
+});

--- a/packages/coach/tests/daemon-healthz-server.test.ts
+++ b/packages/coach/tests/daemon-healthz-server.test.ts
@@ -1,7 +1,9 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { describe, expect, it, vi } from "vitest";
-import { PROTOCOL_VERSION } from "@enduragent/coach-contract";
-import { createHealthzRequestHandler } from "../src/daemon/healthz-server.js";
+import {
+  createDaemonHealthState,
+  createHealthzRequestHandler,
+} from "../src/daemon/healthz-server.js";
 
 function responseCapture() {
   const headers = new Map<string, string>();
@@ -24,7 +26,6 @@ describe("healthz request handler", () => {
   it("returns the exact healthy body and headers only for GET /healthz", () => {
     const handler = createHealthzRequestHandler({
       appVersion: "0.1.0-synthetic",
-      owner: "unmanaged-foreground",
     });
     const capture = responseCapture();
     handler({ method: "GET", url: "/healthz" } as IncomingMessage, capture.response);
@@ -38,10 +39,20 @@ describe("healthz request handler", () => {
       `${JSON.stringify({
         service: "enduragent-store-writer",
         version: "0.1.0-synthetic",
-        protocolVersion: PROTOCOL_VERSION,
-        owner: "unmanaged-foreground",
       })}\n`,
     );
+  });
+
+  it("omits the healthy marker and version while draining", () => {
+    const state = createDaemonHealthState();
+    const handler = createHealthzRequestHandler({ appVersion: "synthetic", state });
+    state.setHealthy(false);
+    const capture = responseCapture();
+    handler({ method: "GET", url: "/healthz" } as IncomingMessage, capture.response);
+    expect(capture.response.statusCode).toBe(503);
+    expect(capture.body()).toBe(`${JSON.stringify({ status: "unavailable" })}\n`);
+    expect(capture.body()).not.toContain("enduragent-store-writer");
+    expect(capture.body()).not.toContain("synthetic");
   });
 
   it.each([
@@ -51,7 +62,6 @@ describe("healthz request handler", () => {
   ])("returns an empty 404 for %s %s", (method, url) => {
     const handler = createHealthzRequestHandler({
       appVersion: "synthetic",
-      owner: "unmanaged-foreground",
     });
     const capture = responseCapture();
     const end = vi.spyOn(capture.response, "end");

--- a/packages/coach/tests/daemon-rpc-server.test.ts
+++ b/packages/coach/tests/daemon-rpc-server.test.ts
@@ -26,6 +26,11 @@ import {
   type CoachEngine,
 } from "@enduragent/coach-contract";
 import { createCoachRpcServer, ensureDaemonToken } from "../src/daemon/rpc-server.js";
+import { createDaemonHealthState } from "../src/daemon/healthz-server.js";
+import type {
+  MonotonicTimer,
+  ScheduledMonotonicTimer,
+} from "../src/daemon/upgrade-fence.js";
 
 const roots: string[] = [];
 
@@ -78,6 +83,53 @@ function request(url: string, headers: IncomingMessage["headers"] = {}): Incomin
 
 async function turn(): Promise<void> {
   await new Promise<void>((resolve) => setImmediate(resolve));
+}
+
+interface Deferred<T> {
+  readonly promise: Promise<T>;
+  resolve(value: T): void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+class FakeTimer implements MonotonicTimer {
+  private now = 0;
+  private readonly callbacks = new Set<{
+    readonly deadline: number;
+    readonly callback: () => void;
+    cancelled: boolean;
+  }>();
+
+  nowMs(): number {
+    return this.now;
+  }
+
+  schedule(delayMs: number, callback: () => void): ScheduledMonotonicTimer {
+    const scheduled = { deadline: this.now + delayMs, callback, cancelled: false };
+    this.callbacks.add(scheduled);
+    return {
+      cancel: () => {
+        scheduled.cancelled = true;
+        this.callbacks.delete(scheduled);
+      },
+    };
+  }
+
+  advance(ms: number): void {
+    this.now += ms;
+    for (const scheduled of this.callbacks) {
+      if (!scheduled.cancelled && scheduled.deadline <= this.now) {
+        this.callbacks.delete(scheduled);
+        scheduled.callback();
+      }
+    }
+  }
 }
 
 describe("daemon token", () => {
@@ -392,5 +444,201 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
       expect(chat).not.toHaveBeenCalled();
       await client.close();
     }
+  });
+});
+
+describe.skipIf(!hasLoopback)("authenticated upgrade control", () => {
+  it("binds one reservation to the authenticated connection and consumes it once", async () => {
+    const token = "x".repeat(43);
+    const healthState = createDaemonHealthState();
+    const rpc = createCoachRpcServer({
+      engine: engine(),
+      token,
+      owner: "service-managed",
+      healthState,
+    });
+    const client = await openSocket(rpc);
+    client.ws.send(JSON.stringify(createClientHandshakeFrame(token)));
+    await client.frames.next();
+    const handoffCapability = Buffer.alloc(32, 3).toString("base64url");
+    client.ws.send(JSON.stringify({
+      jsonrpc: "2.0",
+      id: "reserve",
+      method: "daemon.reserveUpgrade",
+      params: { targetProtocolVersion: PROTOCOL_VERSION + 1, handoffCapability },
+    }));
+    expect(JSON.parse(await client.frames.next())).toEqual({
+      jsonrpc: "2.0",
+      id: "reserve",
+      result: { status: "reserved" },
+    });
+    client.ws.send(JSON.stringify({
+      jsonrpc: "2.0",
+      id: "second",
+      method: "daemon.reserveUpgrade",
+      params: { targetProtocolVersion: PROTOCOL_VERSION + 1, handoffCapability },
+    }));
+    expect(JSON.parse(await client.frames.next())).toMatchObject({
+      id: "second",
+      error: { code: -32_003, message: "handoff-reservation-refused" },
+    });
+    client.ws.send(JSON.stringify({
+      jsonrpc: "2.0",
+      id: "shutdown",
+      method: "daemon.shutdownForUpgrade",
+      params: { targetProtocolVersion: PROTOCOL_VERSION + 1, handoffCapability },
+    }));
+    expect(JSON.parse(await client.frames.next())).toEqual({
+      jsonrpc: "2.0",
+      id: "shutdown",
+      result: { status: "accepted" },
+    });
+    await expect(rpc.shutdownRequested).resolves.toBeUndefined();
+    expect(healthState.healthy).toBe(false);
+    client.ws.send(JSON.stringify({
+      jsonrpc: "2.0",
+      id: "replay",
+      method: "daemon.shutdownForUpgrade",
+      params: { targetProtocolVersion: PROTOCOL_VERSION + 1, handoffCapability },
+    }));
+    expect(JSON.parse(await client.frames.next())).toMatchObject({
+      id: "replay",
+      error: { code: -32_003, message: "handoff-reservation-refused" },
+    });
+    await client.close();
+  });
+
+  it("drains a running and queued same-key pair before flushing shutdown acceptance", async () => {
+    const token = "x".repeat(43);
+    const first = deferred<{ text: string }>();
+    const second = deferred<{ text: string }>();
+    let call = 0;
+    const healthState = createDaemonHealthState();
+    const rpc = createCoachRpcServer({
+      token,
+      owner: "ephemeral-client-started",
+      healthState,
+      engine: engine({
+        chat: () => {
+          call += 1;
+          return call === 1 ? first.promise : second.promise;
+        },
+      }),
+    });
+    const client = await openSocket(rpc);
+    client.ws.send(JSON.stringify(createClientHandshakeFrame(token)));
+    await client.frames.next();
+    for (const id of ["chat-1", "chat-2"]) {
+      client.ws.send(JSON.stringify({
+        jsonrpc: "2.0",
+        id,
+        method: "chat",
+        params: { chatId: "same", message: id },
+      }));
+    }
+    await vi.waitFor(() => expect(call).toBe(1));
+    const handoffCapability = Buffer.alloc(32, 4).toString("base64url");
+    client.ws.send(JSON.stringify({
+      jsonrpc: "2.0",
+      id: "reserve",
+      method: "daemon.reserveUpgrade",
+      params: { targetProtocolVersion: PROTOCOL_VERSION + 1, handoffCapability },
+    }));
+    expect(JSON.parse(await client.frames.next())).toMatchObject({
+      id: "reserve",
+      result: { status: "reserved" },
+    });
+    client.ws.send(JSON.stringify({
+      jsonrpc: "2.0",
+      id: "shutdown",
+      method: "daemon.shutdownForUpgrade",
+      params: { targetProtocolVersion: PROTOCOL_VERSION + 1, handoffCapability },
+    }));
+    await vi.waitFor(() => expect(healthState.healthy).toBe(false));
+    client.ws.send(JSON.stringify({
+      jsonrpc: "2.0",
+      id: "post-close",
+      method: "getAthleteState",
+      params: {},
+    }));
+    expect(JSON.parse(await client.frames.next())).toMatchObject({
+      id: "post-close",
+      error: { code: -32_005, message: "daemon-upgrading" },
+    });
+    first.resolve({ text: "first" });
+    expect(JSON.parse(await client.frames.next())).toMatchObject({ id: "chat-1" });
+    await vi.waitFor(() => expect(call).toBe(2));
+    second.resolve({ text: "second" });
+    const terminal = [
+      JSON.parse(await client.frames.next()),
+      JSON.parse(await client.frames.next()),
+    ];
+    expect(terminal).toContainEqual({
+      jsonrpc: "2.0",
+      id: "chat-2",
+      result: { text: "second" },
+    });
+    expect(terminal).toContainEqual({
+      jsonrpc: "2.0",
+      id: "shutdown",
+      result: { status: "accepted" },
+    });
+    await client.close();
+  });
+
+  it("restores intake and healthy state after the monotonic drain deadline", async () => {
+    const token = "x".repeat(43);
+    const work = deferred<{ text: string }>();
+    const timer = new FakeTimer();
+    const healthState = createDaemonHealthState();
+    const chat = vi.fn(() => work.promise);
+    const rpc = createCoachRpcServer({
+      token,
+      owner: "service-managed",
+      healthState,
+      timer,
+      engine: engine({ chat }),
+    });
+    const client = await openSocket(rpc);
+    client.ws.send(JSON.stringify(createClientHandshakeFrame(token)));
+    await client.frames.next();
+    client.ws.send(JSON.stringify({
+      jsonrpc: "2.0",
+      id: "running",
+      method: "chat",
+      params: { chatId: "same", message: "running" },
+    }));
+    await vi.waitFor(() => expect(chat).toHaveBeenCalledTimes(1));
+    const handoffCapability = Buffer.alloc(32, 5).toString("base64url");
+    client.ws.send(JSON.stringify({
+      jsonrpc: "2.0",
+      id: "reserve",
+      method: "daemon.reserveUpgrade",
+      params: { targetProtocolVersion: PROTOCOL_VERSION + 1, handoffCapability },
+    }));
+    await client.frames.next();
+    client.ws.send(JSON.stringify({
+      jsonrpc: "2.0",
+      id: "shutdown",
+      method: "daemon.shutdownForUpgrade",
+      params: { targetProtocolVersion: PROTOCOL_VERSION + 1, handoffCapability },
+    }));
+    await vi.waitFor(() => expect(healthState.healthy).toBe(false));
+    timer.advance(30_000);
+    expect(JSON.parse(await client.frames.next())).toMatchObject({
+      id: "shutdown",
+      error: { code: -32_004, message: "upgrade-drain-timeout" },
+    });
+    expect(healthState.healthy).toBe(true);
+    client.ws.send(JSON.stringify({
+      jsonrpc: "2.0",
+      id: "read-after-timeout",
+      method: "getAthleteState",
+      params: {},
+    }));
+    expect(JSON.parse(await client.frames.next())).toMatchObject({ id: "read-after-timeout" });
+    work.resolve({ text: "done" });
+    expect(JSON.parse(await client.frames.next())).toMatchObject({ id: "running" });
+    await client.close();
   });
 });

--- a/packages/coach/tests/fixtures/daemon-process.ts
+++ b/packages/coach/tests/fixtures/daemon-process.ts
@@ -1,0 +1,114 @@
+import { createHealthzRequestHandler } from "../../src/daemon/healthz-server.js";
+import { classifyPeerReadOnly } from "../../src/daemon/handshake.js";
+import {
+  acquireUpgradeFence,
+  admitStartupThroughUpgradeFence,
+} from "../../src/daemon/upgrade-fence.js";
+import type { AthleteHome } from "@enduragent/kernel-node/home";
+import { acquireWriteLock } from "@enduragent/kernel-node/lock";
+
+interface StartMessage {
+  readonly type: "start";
+  readonly home: AthleteHome;
+  readonly mode?: "healthy" | "bound" | "foreign";
+  readonly handoffCapability?: string;
+}
+
+function send(value: unknown): void {
+  process.send?.(value);
+}
+
+async function runWriter(message: StartMessage): Promise<void> {
+  const lock = await acquireWriteLock({
+    configDir: message.home.configDir,
+    athleteHome: message.home.root,
+    version: "0.1.0-synthetic",
+  });
+  if (lock.status !== "acquired") {
+    send({ type: "peer", peer: lock });
+    return;
+  }
+  let binding: Awaited<ReturnType<typeof lock.listener.bind>> | undefined;
+  if (message.mode !== "bound") {
+    binding = await lock.listener.bind({
+      request: message.mode === "healthy"
+        ? createHealthzRequestHandler({ appVersion: "0.1.0-synthetic" })
+        : (_request, response) => response.end("foreign\n"),
+      upgrade: (_request, socket) => socket.destroy(),
+    });
+  }
+  send({
+    type: "ready",
+    pid: process.pid,
+    rawPort: lock.port,
+    protocolPort: binding?.port,
+    rw: "open",
+  });
+  await new Promise<void>((resolve) => {
+    process.on("message", (value) => {
+      if ((value as { readonly type?: unknown }).type === "stop") resolve();
+    });
+  });
+  await binding?.close();
+  await lock.release();
+  send({ type: "stopped", rw: "closed" });
+}
+
+async function main(): Promise<void> {
+  const role = process.argv[2];
+  const message = await new Promise<StartMessage>((resolve) => {
+    process.once("message", (value) => resolve(value as StartMessage));
+  });
+  if (role === "writer") {
+    await runWriter(message);
+    return;
+  }
+  if (role === "classify") {
+    send({ type: "classification", result: await classifyPeerReadOnly(message.home) });
+    return;
+  }
+  if (role === "fence-holder") {
+    const acquired = await acquireUpgradeFence({ configDir: message.home.configDir });
+    if (acquired.status !== "acquired") {
+      send({ type: "fence", result: acquired });
+      return;
+    }
+    send({
+      type: "fence",
+      result: {
+        status: "acquired",
+        socketPath: acquired.handle.socketPath,
+        handoffCapability: acquired.handle.handoffCapability,
+      },
+    });
+    await new Promise<void>((resolve) => {
+      process.on("message", (value) => {
+        if ((value as { readonly type?: unknown }).type === "stop") resolve();
+      });
+    });
+    await acquired.handle.release();
+    return;
+  }
+  if (role === "fence-admit") {
+    send({
+      type: "admission",
+      result: await admitStartupThroughUpgradeFence({
+        configDir: message.home.configDir,
+        ...(message.handoffCapability === undefined
+          ? {}
+          : { handoffCapability: message.handoffCapability }),
+      }),
+    });
+    return;
+  }
+  throw new Error("unknown daemon fixture role");
+}
+
+try {
+  await main();
+  process.disconnect?.();
+} catch {
+  send({ type: "error" });
+  process.exitCode = 70;
+  process.disconnect?.();
+}

--- a/packages/coach/tests/serve.test.ts
+++ b/packages/coach/tests/serve.test.ts
@@ -58,6 +58,7 @@ function harness(
   options: {
     readonly token?: Promise<{ readonly path: string; readonly value: string }>;
     readonly bind?: Promise<WriterProtocolBinding>;
+    readonly shutdownRequested?: Promise<void>;
     readonly onCreateRpc?: () => void;
   } = {},
 ) {
@@ -95,7 +96,11 @@ function harness(
   const createRpcServer = vi.fn(() => {
     trace.push("rpc-created");
     options.onCreateRpc?.();
-    return { handleUpgrade: vi.fn(), close: rpcClose };
+    return {
+      handleUpgrade: vi.fn(),
+      shutdownRequested: options.shutdownRequested ?? new Promise<void>(() => {}),
+      close: rpcClose,
+    };
   });
   const createHealthzHandler = vi.fn(() => {
     trace.push("health-handler-created");
@@ -105,6 +110,7 @@ function harness(
     ensureToken,
     createRpcServer,
     createHealthzHandler,
+    createHealthState: () => ({ healthy: true, setHealthy: vi.fn() }),
   } as unknown as CoachServeDependencies;
   return {
     input: { lifecycle, home, appVersion: "0.1.0", signal: new AbortController().signal },
@@ -195,6 +201,20 @@ describe("runCoachServe", () => {
     bind.resolve(test.binding);
     await expect(result).resolves.toBe(EXIT_SUCCESS);
     expect(test.rpcClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns from the local operation only after the upgrade response flush signal", async () => {
+    const shutdown = deferred<void>();
+    const test = harness({ shutdownRequested: shutdown.promise });
+    const result = runCoachServe(test.input, test.dependencies);
+    await vi.waitFor(() => expect(test.handlers()).toBeDefined());
+    shutdown.resolve();
+    await expect(result).resolves.toBe(EXIT_SUCCESS);
+    expect(test.trace.slice(-3)).toEqual([
+      "protocol-stop",
+      "rpc-drained",
+      "protocol-closed",
+    ]);
   });
 
   it("rethrows bind failure only after closing the constructed RPC server", async () => {

--- a/packages/coach/tests/session-queue.test.ts
+++ b/packages/coach/tests/session-queue.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  DetachedSessionRequestError,
+  createSessionRequestQueue,
+} from "../src/daemon/session-queue.js";
+
+interface Deferred<T> {
+  readonly promise: Promise<T>;
+  resolve(value: T): void;
+  reject(error: unknown): void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("session request queue", () => {
+  it("runs the same key in FIFO order and different keys independently", async () => {
+    const queue = createSessionRequestQueue();
+    const first = deferred<string>();
+    const order: string[] = [];
+    const firstResult = queue.run({
+      key: "a",
+      signal: new AbortController().signal,
+      run: () => {
+        order.push("a1-start");
+        return first.promise;
+      },
+    });
+    const secondResult = queue.run({
+      key: "a",
+      signal: new AbortController().signal,
+      run: async () => {
+        order.push("a2-start");
+        return "second";
+      },
+    });
+    const otherResult = queue.run({
+      key: "b",
+      signal: new AbortController().signal,
+      run: async () => {
+        order.push("b-start");
+        return "other";
+      },
+    });
+    expect(order).toEqual(["a1-start", "b-start"]);
+    expect(queue.activeKeyCount).toBe(2);
+    first.resolve("first");
+    await expect(firstResult).resolves.toBe("first");
+    await expect(secondResult).resolves.toBe("second");
+    await expect(otherResult).resolves.toBe("other");
+    expect(order).toEqual(["a1-start", "b-start", "a2-start"]);
+    expect(queue.activeKeyCount).toBe(0);
+  });
+
+  it("removes pre-aborted and queued-aborted requests without calling run", async () => {
+    const queue = createSessionRequestQueue();
+    const pre = new AbortController();
+    pre.abort();
+    const preRun = vi.fn(async () => "unused");
+    await expect(queue.run({ key: "pre", signal: pre.signal, run: preRun }))
+      .rejects.toBeInstanceOf(DetachedSessionRequestError);
+    expect(preRun).not.toHaveBeenCalled();
+
+    const first = deferred<void>();
+    const queued = new AbortController();
+    const head = queue.run({
+      key: "same",
+      signal: new AbortController().signal,
+      run: () => first.promise,
+    });
+    const queuedRun = vi.fn(async () => "unused");
+    const tail = queue.run({ key: "same", signal: queued.signal, run: queuedRun });
+    queued.abort();
+    await expect(tail).rejects.toBeInstanceOf(DetachedSessionRequestError);
+    expect(queuedRun).not.toHaveBeenCalled();
+    first.resolve();
+    await head;
+    expect(queue.activeKeyCount).toBe(0);
+  });
+
+  it("detaches in-flight delivery without cancelling or replaying work", async () => {
+    const queue = createSessionRequestQueue();
+    const controller = new AbortController();
+    const work = deferred<object>();
+    const run = vi.fn(() => work.promise);
+    const result = queue.run({ key: "a", signal: controller.signal, run });
+    controller.abort();
+    expect(run).toHaveBeenCalledTimes(1);
+    work.resolve({ done: true });
+    await expect(result).rejects.toBeInstanceOf(DetachedSessionRequestError);
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(queue.activeKeyCount).toBe(0);
+  });
+
+  it("preserves original result and error identity and removes abort listeners", async () => {
+    const queue = createSessionRequestQueue();
+    const result = { identity: true };
+    const failure = new Error("identity");
+    const controller = new AbortController();
+    const add = vi.spyOn(controller.signal, "addEventListener");
+    const remove = vi.spyOn(controller.signal, "removeEventListener");
+    await expect(queue.run({
+      key: "result",
+      signal: controller.signal,
+      run: async () => result,
+    })).resolves.toBe(result);
+    await expect(queue.run({
+      key: "error",
+      signal: new AbortController().signal,
+      run: async () => {
+        throw failure;
+      },
+    })).rejects.toBe(failure);
+    expect(add).toHaveBeenCalledTimes(1);
+    expect(remove).toHaveBeenCalledTimes(1);
+    expect(remove.mock.calls[0]?.[1]).toBe(add.mock.calls[0]?.[1]);
+    expect(queue.activeKeyCount).toBe(0);
+  });
+
+  it("does not let an old settlement delete a replacement key queue", async () => {
+    const queue = createSessionRequestQueue();
+    const first = deferred<void>();
+    const second = deferred<void>();
+    const firstResult = queue.run({
+      key: "key",
+      signal: new AbortController().signal,
+      run: () => first.promise,
+    });
+    const secondResult = queue.run({
+      key: "key",
+      signal: new AbortController().signal,
+      run: () => second.promise,
+    });
+    first.resolve();
+    await firstResult;
+    expect(queue.activeKeyCount).toBe(1);
+    second.resolve();
+    await secondResult;
+    expect(queue.activeKeyCount).toBe(0);
+  });
+});

--- a/packages/coach/tests/upgrade-fence.test.ts
+++ b/packages/coach/tests/upgrade-fence.test.ts
@@ -1,0 +1,169 @@
+import { createConnection, createServer } from "node:net";
+import {
+  lstat,
+  mkdtemp,
+  readFile,
+  realpath,
+  rename,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  HANDOFF_RESERVED_MESSAGE,
+  UPGRADE_FENCE_FRAME_MAX_BYTES,
+  UPGRADE_FENCE_IO_TIMEOUT_MS,
+  acquireUpgradeFence,
+  admitStartupThroughUpgradeFence,
+  type MonotonicTimer,
+  type ScheduledMonotonicTimer,
+} from "../src/daemon/upgrade-fence.js";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+async function configDir(): Promise<string> {
+  const root = await mkdtemp(join(await realpath(tmpdir()), "upgrade-fence-"));
+  roots.push(root);
+  return join(root, "config");
+}
+
+class FakeTimer implements MonotonicTimer {
+  private now = 0;
+  private readonly scheduled = new Set<{
+    readonly at: number;
+    readonly callback: () => void;
+    cancelled: boolean;
+  }>();
+
+  nowMs(): number {
+    return this.now;
+  }
+
+  schedule(delayMs: number, callback: () => void): ScheduledMonotonicTimer {
+    const item = { at: this.now + delayMs, callback, cancelled: false };
+    this.scheduled.add(item);
+    return {
+      cancel: () => {
+        item.cancelled = true;
+        this.scheduled.delete(item);
+      },
+    };
+  }
+
+  advance(ms: number): void {
+    this.now += ms;
+    for (const item of this.scheduled) {
+      if (!item.cancelled && item.at <= this.now) {
+        this.scheduled.delete(item);
+        item.callback();
+      }
+    }
+  }
+}
+
+function rawAdmission(socketPath: string, bytes: Buffer): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const socket = createConnection(socketPath);
+    const chunks: Buffer[] = [];
+    socket.once("error", reject);
+    socket.on("data", (chunk: Buffer) => chunks.push(chunk));
+    socket.once("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+    socket.once("connect", () => socket.end(bytes));
+  });
+}
+
+async function unixSocketAvailable(): Promise<boolean> {
+  const path = join(await realpath(tmpdir()), `upgrade-fence-preflight-${process.pid}.sock`);
+  return new Promise((resolve) => {
+    const server = createServer();
+    server.once("error", (error: NodeJS.ErrnoException) => {
+      if (error.code === "EPERM") {
+        process.stderr.write("SKIP_MARKER unix-listen EPERM upgrade-fence\n");
+      }
+      resolve(false);
+    });
+    server.listen(path, () => server.close(() => resolve(true)));
+  });
+}
+
+const hasUnixSockets = await unixSocketAvailable();
+
+describe.skipIf(!hasUnixSockets)("upgrade fence", () => {
+  it("refuses ordinary and wrong callers, admits one designated capability, and rejects replay", async () => {
+    const dir = await configDir();
+    const acquired = await acquireUpgradeFence({
+      configDir: dir,
+      randomBytes: () => Buffer.alloc(32, 7),
+    });
+    expect(acquired.status).toBe("acquired");
+    if (acquired.status !== "acquired") return;
+    expect(await admitStartupThroughUpgradeFence({ configDir: dir })).toEqual({
+      status: "reserved",
+      exitCode: 3,
+      message: HANDOFF_RESERVED_MESSAGE,
+    });
+    expect(await admitStartupThroughUpgradeFence({
+      configDir: dir,
+      handoffCapability: Buffer.alloc(32, 8).toString("base64url"),
+    })).toMatchObject({ status: "reserved" });
+    await expect(admitStartupThroughUpgradeFence({
+      configDir: dir,
+      handoffCapability: acquired.handle.handoffCapability,
+    })).resolves.toEqual({ status: "designated" });
+    await expect(admitStartupThroughUpgradeFence({
+      configDir: dir,
+      handoffCapability: acquired.handle.handoffCapability,
+    })).resolves.toMatchObject({ status: "reserved" });
+    expect((await lstat(dir)).mode & 0o777).toBe(0o700);
+    expect((await lstat(acquired.handle.socketPath)).mode & 0o777).toBe(0o600);
+    await acquired.handle.release();
+    await acquired.handle.release();
+    await expect(admitStartupThroughUpgradeFence({ configDir: dir })).resolves.toEqual({
+      status: "clear",
+    });
+  });
+
+  it("enforces byte boundaries and the incomplete-frame monotonic deadline", async () => {
+    const dir = await configDir();
+    const timer = new FakeTimer();
+    const acquired = await acquireUpgradeFence({ configDir: dir, timer });
+    expect(acquired.status).toBe("acquired");
+    if (acquired.status !== "acquired") return;
+    const ordinary = JSON.stringify({ kind: "ordinary-starter" });
+    const exact = Buffer.from(`${ordinary.padEnd(UPGRADE_FENCE_FRAME_MAX_BYTES - 1, " ")}\n`);
+    expect(exact.length).toBe(UPGRADE_FENCE_FRAME_MAX_BYTES);
+    await expect(rawAdmission(acquired.handle.socketPath, exact)).resolves.toBe(
+      `${JSON.stringify({ status: "reserved" })}\n`,
+    );
+    const oversized = Buffer.from(`${ordinary.padEnd(UPGRADE_FENCE_FRAME_MAX_BYTES, " ")}\n`);
+    expect(oversized.length).toBe(UPGRADE_FENCE_FRAME_MAX_BYTES + 1);
+    await expect(rawAdmission(acquired.handle.socketPath, oversized)).resolves.toBe(
+      `${JSON.stringify({ status: "reserved" })}\n`,
+    );
+    const incompleteBytes = Buffer.alloc(UPGRADE_FENCE_FRAME_MAX_BYTES - 1, "é");
+    expect(incompleteBytes.length).toBe(UPGRADE_FENCE_FRAME_MAX_BYTES - 1);
+    const incomplete = rawAdmission(acquired.handle.socketPath, incompleteBytes);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    timer.advance(UPGRADE_FENCE_IO_TIMEOUT_MS);
+    await expect(incomplete).resolves.toBe(`${JSON.stringify({ status: "reserved" })}\n`);
+    await acquired.handle.release();
+  });
+
+  it("does not unlink a replacement socket-path inode during release", async () => {
+    const dir = await configDir();
+    const acquired = await acquireUpgradeFence({ configDir: dir });
+    expect(acquired.status).toBe("acquired");
+    if (acquired.status !== "acquired") return;
+    const moved = `${acquired.handle.socketPath}.moved`;
+    await rename(acquired.handle.socketPath, moved);
+    await writeFile(acquired.handle.socketPath, "replacement\n", { mode: 0o600 });
+    await acquired.handle.release();
+    await expect(readFile(acquired.handle.socketPath, "utf8")).resolves.toBe("replacement\n");
+  });
+});

--- a/packages/kernel-node/src/lock/acquire.ts
+++ b/packages/kernel-node/src/lock/acquire.ts
@@ -6,7 +6,7 @@ import {
 } from "node:http";
 import { createServer, type Server, type Socket, type AddressInfo } from "node:net";
 import { existsSync, mkdirSync, chmodSync, statSync } from "node:fs";
-import { unlink } from "node:fs/promises";
+import { lstat, rename, unlink } from "node:fs/promises";
 import { join } from "node:path";
 import type { Duplex } from "node:stream";
 import { claimLockfile, readLockfile } from "./lockfile-body.js";
@@ -192,12 +192,51 @@ function ownProtocolServer(
   };
 }
 
-async function bestEffortUnlink(path: string): Promise<void> {
+interface FileIdentity {
+  readonly dev: number;
+  readonly ino: number;
+}
+
+let staleSequence = 0;
+
+async function fileIdentity(path: string): Promise<FileIdentity | undefined> {
+  try {
+    const metadata = await lstat(path);
+    return { dev: metadata.dev, ino: metadata.ino };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+    throw error;
+  }
+}
+
+function sameIdentity(left: FileIdentity | undefined, right: FileIdentity): boolean {
+  return left?.dev === right.dev && left.ino === right.ino;
+}
+
+async function unlinkOwned(path: string, owned: FileIdentity | undefined): Promise<boolean> {
+  if (owned === undefined || !sameIdentity(await fileIdentity(path), owned)) return false;
   try {
     await unlink(path);
-  } catch {
-    /* already gone */
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
   }
+  return true;
+}
+
+async function reclaimStale(path: string, stale: FileIdentity | undefined): Promise<boolean> {
+  if (stale === undefined || !sameIdentity(await fileIdentity(path), stale)) return false;
+  staleSequence += 1;
+  const stalePath = `${path}.stale.${process.pid}.${staleSequence}`;
+  try {
+    await rename(path, stalePath);
+  } catch (error) {
+    if (["ENOENT", "EEXIST"].includes((error as NodeJS.ErrnoException).code ?? "")) {
+      return false;
+    }
+    throw error;
+  }
+  await unlinkOwned(stalePath, stale);
+  return true;
 }
 
 async function contentionAgainstBound(
@@ -250,6 +289,8 @@ export async function acquireWriteLock(
   let protocol: OwnedProtocolServer | undefined;
   let bindingPromise: Promise<WriterProtocolBinding> | undefined;
   let releasePromise: Promise<void> | undefined;
+  let ownedLockfile: FileIdentity | undefined;
+  let ownedPortFile: FileIdentity | undefined;
 
   const listener: WriterProtocolListener = {
     async bind(handlers): Promise<WriterProtocolBinding> {
@@ -266,6 +307,7 @@ export async function acquireWriteLock(
         }
         try {
           await writePortFile(portFilePath, created.port);
+          ownedPortFile = await fileIdentity(portFilePath);
         } catch (error) {
           await owned.forceClose().catch(() => {});
           throw error;
@@ -287,7 +329,9 @@ export async function acquireWriteLock(
       version: opts.version,
       athleteHome: opts.athleteHome,
     });
+    ownedLockfile = await fileIdentity(lockfilePath);
     await writePortFile(portFilePath, actualPort);
+    ownedPortFile = await fileIdentity(portFilePath);
     return {
       status: "acquired",
       port: actualPort,
@@ -313,8 +357,8 @@ export async function acquireWriteLock(
           } catch (error) {
             failure ??= error;
           }
-          await bestEffortUnlink(lockfilePath);
-          await bestEffortUnlink(portFilePath);
+          await unlinkOwned(lockfilePath, ownedLockfile);
+          await unlinkOwned(portFilePath, ownedPortFile);
           if (failure !== undefined) throw failure;
         })();
         return releasePromise;
@@ -330,6 +374,8 @@ export async function acquireWriteLock(
         await closeServer(server, sockets);
         throw err;
       }
+      const staleLockfile = await fileIdentity(lockfilePath);
+      const stalePortFile = await fileIdentity(portFilePath);
       const other = readLockfile(lockfilePath);
       const otherPort = other?.port ?? readPortFile(portFilePath);
       if (otherPort === null) {
@@ -347,8 +393,8 @@ export async function acquireWriteLock(
         await closeServer(server, sockets);
         return contentionAgainstBound(other?.pid, otherPort, portFilePath, probe);
       }
-      await bestEffortUnlink(lockfilePath);
-      await bestEffortUnlink(portFilePath);
+      if (!(await reclaimStale(lockfilePath, staleLockfile))) continue;
+      await reclaimStale(portFilePath, stalePortFile);
     }
   }
 

--- a/packages/kernel-node/tests/lock.test.ts
+++ b/packages/kernel-node/tests/lock.test.ts
@@ -3,7 +3,15 @@
 // are proven by branch selection against an injected /healthz test double; the full
 // four-case matrix against a real daemon /healthz responder arms at W8.
 
-import { mkdtempSync, realpathSync, rmSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import {
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createConnection, createServer, type Server, type Socket } from "node:net";
@@ -218,6 +226,26 @@ describe.skipIf(!hasLoopback)("acquireWriteLock", () => {
       peer.destroy();
       await release;
     }
+  });
+
+  it("release preserves successor replacement metadata with different inodes", async () => {
+    const configDir = freshDir();
+    const holder = trackHandle(
+      await acquireWriteLock({ configDir, athleteHome: "/home/a", version: "1.0.0" }),
+    );
+    const lockfilePath = join(configDir, LOCKFILE_NAME);
+    const portFilePath = join(configDir, PORT_FILE_NAME);
+    renameSync(lockfilePath, `${lockfilePath}.incumbent`);
+    renameSync(portFilePath, `${portFilePath}.incumbent`);
+    const successorLock = "successor-lock\n";
+    const successorPort = "41000\n";
+    writeFileSync(lockfilePath, successorLock, { mode: 0o600 });
+    writeFileSync(portFilePath, successorPort, { mode: 0o600 });
+
+    heldHandles.length = 0;
+    await holder.release();
+    expect(readFileSync(lockfilePath, "utf8")).toBe(successorLock);
+    expect(readFileSync(portFilePath, "utf8")).toBe(successorPort);
   });
 
   it("binds health and upgrades on a separate published protocol socket", async () => {


### PR DESCRIPTION
## Summary

Lands the daemon singleton discipline: contention, directional handshake, and the upgrade fence:

- Four-case contention matrix (healthy peer / stale lockfile / bound-unresponsive / foreign-port) with caller-specific second-starter behavior: `serve` exits 0 with a notice, a CLI race attaches as a client, `--local` falls through only for a healthy compatible peer; unknown owners fail closed (exit 3, never takeover).
- Directional version handshake: a lower-versioned client classifies exit 5 and never restarts a higher daemon downward.
- Successor-held upgrade fence over a one-time authenticated Unix-socket handoff capability; a third starter exits 3 (handoff-reservation-refused); drain/restore and response-flushed shutdown wired through serve.
- Production `classifyPeerReadOnly` / `observePeerHandshake` exports; lock acquire threads real peer versions from the /healthz body, with inode-safe release and stale reclaim.
- Detachable per-session FIFO queue seam for the CLI verbs PR.

## Verification

- Focused contention/handoff suites green (socket-bound cases verified in the root gate); affected regression suites green.
- Root `pnpm build`, `pnpm check`, full `pnpm test` green after rebase.
