### PR TITLE
feat(cli): add coach verbs with streaming and session queue

### DIFF
--- a/.changeset/cli-verbs.md
+++ b/.changeset/cli-verbs.md
@@ -1,0 +1,6 @@
+---
+"@enduragent/coach": patch
+"@enduragent/coach-cli": patch
+---
+
+Add scriptable CLI verbs with stable JSON output, explicit session selection, daemon-client startup, and a lock-safe local fallback. Public package and image distribution remain unchanged.

--- a/packages/coach-cli/package.json
+++ b/packages/coach-cli/package.json
@@ -19,6 +19,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@enduragent/coach-client": "workspace:*",
     "@enduragent/coach-contract": "workspace:*"
   },
   "devDependencies": {

--- a/packages/coach-cli/src/args.ts
+++ b/packages/coach-cli/src/args.ts
@@ -1,3 +1,31 @@
+export type CoachCliOutputMode = "text" | "json" | "stream-json";
+
+export type CoachCliSessionSelection =
+  | { readonly kind: "default" }
+  | { readonly kind: "named"; readonly key: string }
+  | { readonly kind: "fresh" };
+
+export type CoachCliVerb =
+  | {
+      readonly name: "ask";
+      readonly input: { readonly kind: "argv"; readonly text: string } | { readonly kind: "stdin" };
+    }
+  | { readonly name: "state" }
+  | { readonly name: "analyze"; readonly target: string }
+  | { readonly name: "plan-week" }
+  | {
+      readonly name: "wellness-set";
+      readonly entries: readonly { readonly key: string; readonly value: string }[];
+    };
+
+export type CoachCliVerbInvocation = {
+  readonly kind: "verb";
+  readonly verb: CoachCliVerb;
+  readonly outputMode: CoachCliOutputMode;
+  readonly session: CoachCliSessionSelection;
+  readonly local: boolean;
+};
+
 export type CoachCliInvocation =
   | { readonly kind: "repl" }
   | { readonly kind: "version" }
@@ -5,7 +33,124 @@ export type CoachCliInvocation =
   | {
       readonly kind: "usage";
       readonly message: "Usage: enduragent [version|serve]";
+    }
+  | CoachCliVerbInvocation
+  | {
+      readonly kind: "verb-usage";
+      readonly message: "Usage: enduragent <ask|state|analyze|plan week|wellness set> [--json|--stream-json] [--session <key>|--fresh] [--local]";
     };
+
+const VERB_USAGE =
+  "Usage: enduragent <ask|state|analyze|plan week|wellness set> [--json|--stream-json] [--session <key>|--fresh] [--local]" as const;
+
+interface ScannedVerbArguments {
+  readonly operands: readonly string[];
+  readonly outputMode: CoachCliOutputMode;
+  readonly session: CoachCliSessionSelection;
+  readonly local: boolean;
+}
+
+function scanVerbArguments(tokens: readonly string[]): ScannedVerbArguments | undefined {
+  const operands: string[] = [];
+  const seen = new Set<string>();
+  let outputMode: CoachCliOutputMode = "text";
+  let session: CoachCliSessionSelection = { kind: "default" };
+  let local = false;
+  let flagsEnded = false;
+
+  for (let index = 0; index < tokens.length; index += 1) {
+    const token = tokens[index]!;
+    if (!flagsEnded && token === "--") {
+      flagsEnded = true;
+      continue;
+    }
+    if (flagsEnded || token === "-" || !token.startsWith("-")) {
+      operands.push(token);
+      continue;
+    }
+    if (token === "--session") {
+      if (seen.has(token) || session.kind === "fresh" || index + 1 >= tokens.length) {
+        return undefined;
+      }
+      seen.add(token);
+      session = { kind: "named", key: tokens[index + 1]! };
+      index += 1;
+      continue;
+    }
+    if (token === "--fresh") {
+      if (seen.has(token) || session.kind === "named") return undefined;
+      seen.add(token);
+      session = { kind: "fresh" };
+      continue;
+    }
+    if (token === "--json" || token === "--stream-json") {
+      if (
+        seen.has(token) ||
+        (token === "--json" && seen.has("--stream-json")) ||
+        (token === "--stream-json" && seen.has("--json"))
+      ) {
+        return undefined;
+      }
+      seen.add(token);
+      outputMode = token === "--json" ? "json" : "stream-json";
+      continue;
+    }
+    if (token === "--local") {
+      if (seen.has(token)) return undefined;
+      seen.add(token);
+      local = true;
+      continue;
+    }
+    return undefined;
+  }
+
+  return { operands, outputMode, session, local };
+}
+
+function parseVerb(root: string, scanned: ScannedVerbArguments): CoachCliVerb | undefined {
+  const operands = scanned.operands;
+  if (root === "ask") {
+    if (operands.length === 0 || (operands.length === 1 && operands[0] === "-")) {
+      return { name: "ask", input: { kind: "stdin" } };
+    }
+    const text = operands.join(" ");
+    return /\S/u.test(text) ? { name: "ask", input: { kind: "argv", text } } : undefined;
+  }
+  if (root === "state") {
+    if (
+      operands.length !== 0 ||
+      scanned.outputMode === "stream-json" ||
+      scanned.session.kind !== "default"
+    ) {
+      return undefined;
+    }
+    return { name: "state" };
+  }
+  if (root === "analyze") {
+    return operands.length === 1 && operands[0] !== "" && operands[0] !== "-"
+      ? { name: "analyze", target: operands[0]! }
+      : undefined;
+  }
+  if (root === "plan") {
+    return operands.length === 1 && operands[0] === "week" ? { name: "plan-week" } : undefined;
+  }
+  if (root !== "wellness" || operands[0] !== "set" || operands.length < 2) {
+    return undefined;
+  }
+  const entries: { readonly key: string; readonly value: string }[] = [];
+  const keys = new Set<string>();
+  for (const operand of operands.slice(1)) {
+    const separator = operand.indexOf("=");
+    const key = separator < 0 ? "" : operand.slice(0, separator);
+    const value = separator < 0 ? "" : operand.slice(separator + 1);
+    if (!/^[A-Za-z][A-Za-z0-9_-]*$/.test(key) || value.length === 0 || keys.has(key)) {
+      return undefined;
+    }
+    keys.add(key);
+    entries.push({ key, value });
+  }
+  return { name: "wellness-set", entries };
+}
 
 export function parseCoachCliInvocation(argv: readonly string[]): CoachCliInvocation {
   if (argv.length === 0) return { kind: "repl" };
@@ -13,5 +158,19 @@ export function parseCoachCliInvocation(argv: readonly string[]): CoachCliInvoca
     return { kind: "version" };
   }
   if (argv.length === 1 && argv[0] === "serve") return { kind: "serve" };
-  return { kind: "usage", message: "Usage: enduragent [version|serve]" };
+  const root = argv[0]!;
+  if (!new Set(["ask", "state", "analyze", "plan", "wellness"]).has(root)) {
+    return { kind: "usage", message: "Usage: enduragent [version|serve]" };
+  }
+  const scanned = scanVerbArguments(argv.slice(1));
+  if (scanned === undefined) return { kind: "verb-usage", message: VERB_USAGE };
+  const verb = parseVerb(root, scanned);
+  if (verb === undefined) return { kind: "verb-usage", message: VERB_USAGE };
+  return {
+    kind: "verb",
+    verb,
+    outputMode: scanned.outputMode,
+    session: scanned.session,
+    local: scanned.local,
+  };
 }

--- a/packages/coach-cli/src/index.ts
+++ b/packages/coach-cli/src/index.ts
@@ -1,2 +1,4 @@
 export * from "./args.js";
 export * from "./repl.js";
+export * from "./session-key.js";
+export * from "./verbs/index.js";

--- a/packages/coach-cli/src/session-key.ts
+++ b/packages/coach-cli/src/session-key.ts
@@ -1,0 +1,61 @@
+import { randomUUID } from "node:crypto";
+import type { CoachCliSessionSelection } from "./args.js";
+
+export const DEFAULT_CLI_SESSION_KEY = "cli:default" as const;
+
+export type ResolvedCoachCliSession =
+  | { readonly kind: "default"; readonly chatId: "cli:default" }
+  | { readonly kind: "named"; readonly chatId: string }
+  | { readonly kind: "fresh"; readonly chatId: string };
+
+export class InvalidCoachCliSessionError extends Error {
+  readonly kind = "invalid-named-session" as const;
+
+  constructor() {
+    super("Invalid CLI session key");
+    this.name = "InvalidCoachCliSessionError";
+  }
+}
+
+export class CoachCliSessionStartError extends Error {
+  readonly kind = "fresh-session-start-failed" as const;
+
+  constructor() {
+    super("CLI session start failed");
+    this.name = "CoachCliSessionStartError";
+  }
+}
+
+export function normalizeNamedSessionKey(raw: string): string {
+  const normalized = raw.trim().normalize("NFC");
+  if (
+    normalized.length < 1 ||
+    normalized.length > 128 ||
+    !/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(normalized)
+  ) {
+    throw new InvalidCoachCliSessionError();
+  }
+  return `cli:${normalized}`;
+}
+
+export function resolveCoachCliSession(
+  selection: CoachCliSessionSelection,
+  createFreshId: () => string = randomUUID,
+): ResolvedCoachCliSession {
+  if (selection.kind === "default") {
+    return { kind: "default", chatId: DEFAULT_CLI_SESSION_KEY };
+  }
+  if (selection.kind === "named") {
+    return { kind: "named", chatId: normalizeNamedSessionKey(selection.key) };
+  }
+  let id: string;
+  try {
+    id = createFreshId();
+  } catch {
+    throw new CoachCliSessionStartError();
+  }
+  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/.test(id)) {
+    throw new CoachCliSessionStartError();
+  }
+  return { kind: "fresh", chatId: `cli:fresh:${id}` };
+}

--- a/packages/coach-cli/src/verbs/dispatch.ts
+++ b/packages/coach-cli/src/verbs/dispatch.ts
@@ -1,0 +1,53 @@
+import type { CoachCliVerb } from "../args.js";
+import type { CoachVerbRequest } from "./types.js";
+
+interface CreateCoachVerbRequestInput {
+  readonly verb: CoachCliVerb;
+  readonly chatId: string | undefined;
+  readonly stdinText: string | undefined;
+  readonly signal: AbortSignal;
+}
+
+const ignoreNotification: CoachVerbRequest["onNotificationEnvelope"] = () => {};
+const ignoreTerminal: CoachVerbRequest["onTerminalEnvelope"] = () => {};
+
+function chatMessage(
+  verb: Exclude<CoachCliVerb, { readonly name: "state" }>,
+  stdinText?: string,
+): string {
+  switch (verb.name) {
+    case "ask":
+      if (verb.input.kind === "argv") return verb.input.text;
+      if (stdinText === undefined) throw new TypeError("missing stdin text");
+      return stdinText;
+    case "analyze":
+      return `/analyze ${JSON.stringify(verb.target)}`;
+    case "plan-week":
+      return "/plan";
+    case "wellness-set":
+      return `/wellness set ${JSON.stringify(verb.entries)}`;
+  }
+}
+
+export function createCoachVerbRequest(input: CreateCoachVerbRequestInput): CoachVerbRequest {
+  if (input.verb.name === "state") {
+    return {
+      method: "getAthleteState",
+      params: {},
+      signal: input.signal,
+      onNotificationEnvelope: ignoreNotification,
+      onTerminalEnvelope: ignoreTerminal,
+    };
+  }
+  if (input.chatId === undefined) throw new TypeError("missing chat session");
+  return {
+    method: "chat",
+    params: {
+      chatId: input.chatId,
+      message: chatMessage(input.verb, input.stdinText),
+    },
+    signal: input.signal,
+    onNotificationEnvelope: ignoreNotification,
+    onTerminalEnvelope: ignoreTerminal,
+  };
+}

--- a/packages/coach-cli/src/verbs/index.ts
+++ b/packages/coach-cli/src/verbs/index.ts
@@ -1,0 +1,17 @@
+export { createCoachVerbRequest } from "./dispatch.js";
+export { runCoachVerb } from "./run.js";
+export {
+  connectCoachVerbTransport,
+  connectRemoteCoachTransport,
+  createLocalCoachVerbTransport,
+} from "./transport.js";
+export {
+  CoachRemoteError,
+  type CoachRemoteFailure,
+  type CoachVerbMethodName,
+  type CoachVerbRequest,
+  type CoachVerbTransport,
+  type RemoteTransportDependencies,
+  type RunCoachVerbInput,
+  type ServiceRegistrationState,
+} from "./types.js";

--- a/packages/coach-cli/src/verbs/render.ts
+++ b/packages/coach-cli/src/verbs/render.ts
@@ -1,0 +1,55 @@
+import {
+  CoachTurnEventNotificationEnvelopeSchema,
+  JsonRpcResponseEnvelopeSchema,
+  serializeCoachRpcEnvelope,
+  type CoachTurnEventNotificationEnvelope,
+  type JsonRpcResponseEnvelope,
+} from "@enduragent/coach-contract";
+import type { CoachClientTerminalEnvelope } from "@enduragent/coach-client";
+import type { CoachCliOutputMode } from "../args.js";
+import type { CoachCliTerminal } from "../repl.js";
+import type { CoachVerbMethodName } from "./types.js";
+
+export interface CoachVerbRenderer {
+  readonly onNotificationEnvelope: (envelope: CoachTurnEventNotificationEnvelope) => void;
+  readonly onTerminalEnvelope: (envelope: CoachClientTerminalEnvelope) => void;
+  readonly observedTerminal: () => CoachClientTerminalEnvelope | undefined;
+  renderSuccess(method: CoachVerbMethodName, envelope: JsonRpcResponseEnvelope): void;
+}
+
+export function createCoachVerbRenderer(
+  outputMode: CoachCliOutputMode,
+  terminal: Pick<CoachCliTerminal, "stdout">,
+): CoachVerbRenderer {
+  let observedTerminal: CoachClientTerminalEnvelope | undefined;
+  return {
+    onNotificationEnvelope(envelope) {
+      if (outputMode !== "stream-json") return;
+      const parsed = CoachTurnEventNotificationEnvelopeSchema.parse(envelope);
+      terminal.stdout.write(`${serializeCoachRpcEnvelope(parsed)}\n`);
+    },
+    onTerminalEnvelope(envelope) {
+      const parsed = JsonRpcResponseEnvelopeSchema.parse(envelope);
+      if (parsed.id === null) throw new TypeError("unexpected protocol terminal");
+      observedTerminal = envelope;
+      if (outputMode === "stream-json") {
+        terminal.stdout.write(`${serializeCoachRpcEnvelope(parsed)}\n`);
+      }
+    },
+    observedTerminal: () => observedTerminal,
+    renderSuccess(method, envelope) {
+      if (!("result" in envelope)) throw new TypeError("expected success terminal");
+      if (outputMode === "stream-json") return;
+      if (outputMode === "json") {
+        terminal.stdout.write(`${JSON.stringify(envelope.result)}\n`);
+        return;
+      }
+      if (method === "chat") {
+        const result = envelope.result as { readonly text: string };
+        terminal.stdout.write(`${result.text}\n`);
+        return;
+      }
+      terminal.stdout.write(`${JSON.stringify(envelope.result, null, 2)}\n`);
+    },
+  };
+}

--- a/packages/coach-cli/src/verbs/run.ts
+++ b/packages/coach-cli/src/verbs/run.ts
@@ -1,0 +1,70 @@
+import {
+  EXIT_AGENT_ERROR,
+  EXIT_DAEMON_UNAVAILABLE,
+  EXIT_SUCCESS,
+  EXIT_VERSION_MISMATCH,
+  type ExitCode,
+} from "@enduragent/coach-contract";
+import { createCoachVerbRenderer } from "./render.js";
+import { CoachRemoteError, type CoachRemoteFailure, type RunCoachVerbInput } from "./types.js";
+
+function assertNever(value: never): never {
+  throw new TypeError(`Unexpected value: ${String(value)}`);
+}
+
+function renderRemoteFailure(failure: CoachRemoteFailure, input: RunCoachVerbInput): ExitCode {
+  switch (failure.kind) {
+    case "unavailable":
+      input.terminal.stderr.write("Enduragent could not reach the local service.\n");
+      return EXIT_DAEMON_UNAVAILABLE;
+    case "version-mismatch":
+      input.terminal.stderr.write(
+        "Enduragent protocol versions do not match; update this client.\n",
+      );
+      return EXIT_VERSION_MISMATCH;
+    case "agent":
+      input.terminal.stderr.write("Enduragent could not complete this command.\n");
+      return EXIT_AGENT_ERROR;
+    case "detached":
+      input.terminal.stderr.write(
+        "Enduragent detached from the running turn; the turn may still complete.\n",
+      );
+      return EXIT_AGENT_ERROR;
+    default:
+      return assertNever(failure);
+  }
+}
+
+export async function runCoachVerb(input: RunCoachVerbInput): Promise<ExitCode> {
+  const renderer = createCoachVerbRenderer(input.outputMode, input.terminal);
+  try {
+    const request =
+      input.request.method === "chat"
+        ? {
+            ...input.request,
+            onNotificationEnvelope: renderer.onNotificationEnvelope,
+            onTerminalEnvelope: renderer.onTerminalEnvelope,
+          }
+        : {
+            ...input.request,
+            onNotificationEnvelope: renderer.onNotificationEnvelope,
+            onTerminalEnvelope: renderer.onTerminalEnvelope,
+          };
+    const returnedTerminal = await input.transport.request(request);
+    const observedTerminal = renderer.observedTerminal();
+    if (observedTerminal === undefined || returnedTerminal !== observedTerminal) {
+      throw new TypeError("command terminal envelope invariant failed");
+    }
+    if ("error" in returnedTerminal) {
+      input.terminal.stderr.write("Enduragent could not complete this command.\n");
+      return EXIT_AGENT_ERROR;
+    }
+    renderer.renderSuccess(input.request.method, returnedTerminal);
+    return EXIT_SUCCESS;
+  } catch (error) {
+    if (error instanceof CoachRemoteError) {
+      return renderRemoteFailure(error.failure, input);
+    }
+    throw error;
+  }
+}

--- a/packages/coach-cli/src/verbs/transport.ts
+++ b/packages/coach-cli/src/verbs/transport.ts
@@ -1,0 +1,248 @@
+import {
+  CoachTurnEventNotificationEnvelopeSchema,
+  COACH_RPC_METHOD_REGISTRY,
+  COACH_TURN_EVENT_NOTIFICATION_METHOD,
+  JsonRpcErrorResponseEnvelopeSchema,
+  JsonRpcSuccessResponseEnvelopeSchema,
+  serializeCoachRpcEnvelope,
+  type CoachEngine,
+  type JsonRpcResponseEnvelope,
+} from "@enduragent/coach-contract";
+import {
+  CoachClientBackpressureError,
+  CoachClientDisconnectedError,
+  CoachClientHandshakeError,
+  CoachClientProtocolError,
+  CoachClientTransportUnavailableError,
+  CoachClientVersionMismatchError,
+  CoachRpcRemoteError,
+  connectCoachClient,
+  type CoachClient,
+  type CoachClientTerminalEnvelope,
+  type ConnectCoachClientOptions,
+} from "@enduragent/coach-client";
+import {
+  CoachRemoteError,
+  type CoachRemoteFailure,
+  type CoachVerbMethodName,
+  type CoachVerbRequest,
+  type CoachVerbTransport,
+  type RemoteTransportDependencies,
+} from "./types.js";
+
+function assertNever(value: never): never {
+  throw new TypeError(`Unexpected value: ${String(value)}`);
+}
+
+function remoteFailure(error: unknown, admitted: boolean): CoachRemoteFailure {
+  if (error instanceof CoachClientVersionMismatchError) {
+    return { kind: "version-mismatch", direction: error.direction };
+  }
+  if (error instanceof CoachRpcRemoteError) return { kind: "agent" };
+  if (error instanceof CoachClientDisconnectedError) {
+    return { kind: admitted ? "detached" : "unavailable" };
+  }
+  if (error instanceof CoachClientBackpressureError) return { kind: "unavailable" };
+  if (error instanceof CoachClientTransportUnavailableError) return { kind: "unavailable" };
+  if (error instanceof CoachClientHandshakeError || error instanceof CoachClientProtocolError) {
+    return { kind: admitted ? "agent" : "unavailable" };
+  }
+  return { kind: admitted ? "agent" : "unavailable" };
+}
+
+function createRemoteTransport(client: CoachClient): CoachVerbTransport {
+  let admitted = false;
+  let currentAbortCleanup: (() => void) | undefined;
+  let closePromise: Promise<void> | undefined;
+  const close = (): Promise<void> => {
+    currentAbortCleanup?.();
+    currentAbortCleanup = undefined;
+    const promise = closePromise ?? client.close();
+    closePromise = promise;
+    return promise;
+  };
+
+  return {
+    kind: "remote",
+    async request(input) {
+      if (admitted) throw new CoachRemoteError({ kind: "agent" });
+      if (input.signal.aborted) throw new CoachRemoteError({ kind: "detached" });
+      let observedTerminal: JsonRpcResponseEnvelope | undefined;
+      const onAbort = (): void => {
+        if (admitted) void close();
+      };
+      const cleanup = (): void => input.signal.removeEventListener("abort", onAbort);
+      currentAbortCleanup = cleanup;
+      input.signal.addEventListener("abort", onAbort, { once: true });
+      if (input.signal.aborted) {
+        cleanup();
+        currentAbortCleanup = undefined;
+        throw new CoachRemoteError({ kind: "detached" });
+      }
+      admitted = true;
+      try {
+        const options = {
+          onNotificationEnvelope: input.onNotificationEnvelope,
+          onTerminalEnvelope: (envelope: CoachClientTerminalEnvelope) => {
+            observedTerminal = envelope;
+            input.onTerminalEnvelope(envelope);
+          },
+        };
+        if (input.method === "chat") {
+          await client.call("chat", input.params, options);
+        } else {
+          await client.call("getAthleteState", input.params, options);
+        }
+      } catch (error) {
+        if (observedTerminal !== undefined) return observedTerminal;
+        throw new CoachRemoteError(remoteFailure(error, admitted));
+      } finally {
+        cleanup();
+        if (currentAbortCleanup === cleanup) currentAbortCleanup = undefined;
+      }
+      if (observedTerminal === undefined) throw new CoachRemoteError({ kind: "agent" });
+      return observedTerminal;
+    },
+    close,
+  };
+}
+
+export async function connectCoachVerbTransport(
+  options: ConnectCoachClientOptions,
+): Promise<CoachVerbTransport> {
+  try {
+    return createRemoteTransport(await connectCoachClient(options));
+  } catch (error) {
+    throw new CoachRemoteError(remoteFailure(error, false));
+  }
+}
+
+async function invokeLocal(
+  engine: CoachEngine,
+  input: CoachVerbRequest,
+  deliverEvent: (event: unknown) => void,
+): Promise<unknown> {
+  switch (input.method) {
+    case "chat": {
+      const params = COACH_RPC_METHOD_REGISTRY.chat.requestSchema.parse(input.params);
+      return engine.chat(params, deliverEvent);
+    }
+    case "getAthleteState": {
+      COACH_RPC_METHOD_REGISTRY.getAthleteState.requestSchema.parse(input.params);
+      return engine.getAthleteState();
+    }
+    default:
+      return assertNever(input);
+  }
+}
+
+function localSuccess(method: CoachVerbMethodName, result: unknown) {
+  const parsedResult = COACH_RPC_METHOD_REGISTRY[method].responseSchema.parse(result);
+  const envelope = JsonRpcSuccessResponseEnvelopeSchema.parse({
+    jsonrpc: "2.0",
+    id: 1,
+    result: parsedResult,
+  });
+  serializeCoachRpcEnvelope(envelope);
+  return envelope;
+}
+
+function localError() {
+  const envelope = JsonRpcErrorResponseEnvelopeSchema.parse({
+    jsonrpc: "2.0",
+    id: 1,
+    error: { code: -32603, message: "Internal error" },
+  });
+  serializeCoachRpcEnvelope(envelope);
+  return envelope;
+}
+
+export function createLocalCoachVerbTransport(engine: CoachEngine): CoachVerbTransport {
+  let admitted = false;
+  const closed = Promise.resolve();
+  return {
+    kind: "local",
+    async request(input) {
+      if (admitted) throw new CoachRemoteError({ kind: "agent" });
+      admitted = true;
+      if (input.signal.aborted) throw new CoachRemoteError({ kind: "detached" });
+      let deliveryDetached = false;
+      const onAbort = (): void => {
+        deliveryDetached = true;
+      };
+      if (input.method === "chat") {
+        input.signal.addEventListener("abort", onAbort, { once: true });
+        if (input.signal.aborted) deliveryDetached = true;
+      }
+      let envelope: ReturnType<typeof localSuccess> | ReturnType<typeof localError>;
+      try {
+        try {
+          const result = await invokeLocal(engine, input, (rawEvent) => {
+            if (deliveryDetached || input.method !== "chat") return;
+            const event = COACH_RPC_METHOD_REGISTRY.chat.eventSchema.parse(rawEvent);
+            const notification = CoachTurnEventNotificationEnvelopeSchema.parse({
+              jsonrpc: "2.0",
+              method: COACH_TURN_EVENT_NOTIFICATION_METHOD,
+              params: {
+                requestId: 1,
+                requestMethod: "chat",
+                turnId: event.turnId,
+                event,
+              },
+            });
+            serializeCoachRpcEnvelope(notification);
+            input.onNotificationEnvelope(notification);
+          });
+          envelope = localSuccess(input.method, result);
+        } catch {
+          envelope = localError();
+        }
+        if (deliveryDetached) throw new CoachRemoteError({ kind: "detached" });
+        input.onTerminalEnvelope(envelope);
+        return envelope;
+      } finally {
+        if (input.method === "chat") input.signal.removeEventListener("abort", onAbort);
+      }
+    },
+    close: () => closed,
+  };
+}
+
+function unavailable(error: unknown): error is CoachRemoteError {
+  return error instanceof CoachRemoteError && error.failure.kind === "unavailable";
+}
+
+export async function connectRemoteCoachTransport(
+  dependencies: RemoteTransportDependencies,
+): Promise<CoachVerbTransport> {
+  try {
+    return await dependencies.connect();
+  } catch (error) {
+    if (!unavailable(error)) throw error;
+  }
+  const registration = await dependencies.serviceRegistrationState();
+  if (registration !== "absent") throw new CoachRemoteError({ kind: "unavailable" });
+  const child = await dependencies.startEphemeralDaemon();
+  const startedAt = dependencies.monotonicNow();
+  let nextDelayMs = 50;
+  try {
+    while (true) {
+      const beforeDelay = dependencies.monotonicNow() - startedAt;
+      if (beforeDelay >= 5_000) throw new CoachRemoteError({ kind: "unavailable" });
+      await dependencies.delay(Math.min(nextDelayMs, 5_000 - beforeDelay));
+      const afterDelay = dependencies.monotonicNow() - startedAt;
+      if (afterDelay >= 5_000) throw new CoachRemoteError({ kind: "unavailable" });
+      try {
+        const transport = await dependencies.connect();
+        child.detachAfterHealthy();
+        return transport;
+      } catch (error) {
+        if (!unavailable(error)) throw error;
+      }
+      nextDelayMs = Math.min(nextDelayMs * 2, 200);
+    }
+  } catch (error) {
+    await child.disposeAfterFailedStart();
+    throw error;
+  }
+}

--- a/packages/coach-cli/src/verbs/types.ts
+++ b/packages/coach-cli/src/verbs/types.ts
@@ -1,0 +1,61 @@
+import type {
+  CoachRpcMethodName,
+  CoachRpcRequest,
+  CoachTurnEventNotificationEnvelope,
+  JsonRpcResponseEnvelope,
+  ProtocolVersionDirection,
+} from "@enduragent/coach-contract";
+import type { CoachClientTerminalEnvelope } from "@enduragent/coach-client";
+import type { CoachCliOutputMode } from "../args.js";
+import type { CoachCliTerminal } from "../repl.js";
+
+export type CoachVerbMethodName = Extract<CoachRpcMethodName, "chat" | "getAthleteState">;
+
+export type CoachVerbRequest = {
+  readonly [K in CoachVerbMethodName]: {
+    readonly method: K;
+    readonly params: CoachRpcRequest<K>;
+    readonly signal: AbortSignal;
+    readonly onNotificationEnvelope: (envelope: CoachTurnEventNotificationEnvelope) => void;
+    readonly onTerminalEnvelope: (envelope: CoachClientTerminalEnvelope) => void;
+  };
+}[CoachVerbMethodName];
+
+export interface CoachVerbTransport {
+  readonly kind: "remote" | "local";
+  request(input: CoachVerbRequest): Promise<JsonRpcResponseEnvelope>;
+  close(): Promise<void>;
+}
+
+export type CoachRemoteFailure =
+  | { readonly kind: "unavailable" }
+  | { readonly kind: "version-mismatch"; readonly direction: ProtocolVersionDirection }
+  | { readonly kind: "agent" }
+  | { readonly kind: "detached" };
+
+export class CoachRemoteError extends Error {
+  constructor(readonly failure: CoachRemoteFailure) {
+    super(`Coach remote failure: ${failure.kind}`);
+    this.name = "CoachRemoteError";
+  }
+}
+
+export type ServiceRegistrationState = "present" | "absent" | "unknown";
+
+export interface RemoteTransportDependencies {
+  readonly connect: () => Promise<CoachVerbTransport>;
+  readonly serviceRegistrationState: () => Promise<ServiceRegistrationState>;
+  readonly startEphemeralDaemon: () => Promise<{
+    readonly disposeAfterFailedStart: () => Promise<void>;
+    readonly detachAfterHealthy: () => void;
+  }>;
+  readonly delay: (ms: number) => Promise<void>;
+  readonly monotonicNow: () => number;
+}
+
+export interface RunCoachVerbInput {
+  readonly request: CoachVerbRequest;
+  readonly outputMode: CoachCliOutputMode;
+  readonly terminal: Pick<CoachCliTerminal, "stdout" | "stderr">;
+  readonly transport: CoachVerbTransport;
+}

--- a/packages/coach-cli/tests/args-verbs.test.ts
+++ b/packages/coach-cli/tests/args-verbs.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest";
+import { parseCoachCliInvocation } from "../src/args.js";
+
+const verbUsage = {
+  kind: "verb-usage",
+  message:
+    "Usage: enduragent <ask|state|analyze|plan week|wellness set> [--json|--stream-json] [--session <key>|--fresh] [--local]",
+} as const;
+
+describe("scriptable CLI arguments", () => {
+  it("preserves predecessor invocation forms", () => {
+    expect(parseCoachCliInvocation([])).toEqual({ kind: "repl" });
+    expect(parseCoachCliInvocation(["version"])).toEqual({ kind: "version" });
+    expect(parseCoachCliInvocation(["--version"])).toEqual({ kind: "version" });
+    expect(parseCoachCliInvocation(["serve"])).toEqual({ kind: "serve" });
+    for (const argv of [["unknown"], ["import"], ["sync"], ["serve", "--json"]]) {
+      expect(parseCoachCliInvocation(argv)).toEqual({
+        kind: "usage",
+        message: "Usage: enduragent [version|serve]",
+      });
+    }
+  });
+
+  it("parses every verb and permits flags around operands", () => {
+    expect(
+      parseCoachCliInvocation([
+        "ask",
+        "--session",
+        "RaceA",
+        "hello",
+        "--stream-json",
+        "world",
+        "--local",
+      ]),
+    ).toEqual({
+      kind: "verb",
+      verb: { name: "ask", input: { kind: "argv", text: "hello world" } },
+      outputMode: "stream-json",
+      session: { kind: "named", key: "RaceA" },
+      local: true,
+    });
+    expect(parseCoachCliInvocation(["state", "--local", "--json"])).toEqual({
+      kind: "verb",
+      verb: { name: "state" },
+      outputMode: "json",
+      session: { kind: "default" },
+      local: true,
+    });
+    expect(parseCoachCliInvocation(["analyze", "--fresh", "last-ride"])).toEqual({
+      kind: "verb",
+      verb: { name: "analyze", target: "last-ride" },
+      outputMode: "text",
+      session: { kind: "fresh" },
+      local: false,
+    });
+    expect(parseCoachCliInvocation(["plan", "--json", "week"])).toEqual({
+      kind: "verb",
+      verb: { name: "plan-week" },
+      outputMode: "json",
+      session: { kind: "default" },
+      local: false,
+    });
+    expect(
+      parseCoachCliInvocation([
+        "wellness",
+        "--session",
+        "recovery",
+        "set",
+        "sleep=good",
+        "note=a=b",
+      ]),
+    ).toEqual({
+      kind: "verb",
+      verb: {
+        name: "wellness-set",
+        entries: [
+          { key: "sleep", value: "good" },
+          { key: "note", value: "a=b" },
+        ],
+      },
+      outputMode: "text",
+      session: { kind: "named", key: "recovery" },
+      local: false,
+    });
+  });
+
+  it("selects stdin for empty ask and a lone dash", () => {
+    for (const argv of [["ask"], ["ask", "-"]]) {
+      expect(parseCoachCliInvocation(argv)).toEqual({
+        kind: "verb",
+        verb: { name: "ask", input: { kind: "stdin" } },
+        outputMode: "text",
+        session: { kind: "default" },
+        local: false,
+      });
+    }
+  });
+
+  it("honors the end-of-flags marker", () => {
+    expect(parseCoachCliInvocation(["ask", "--", "--json", "tail"])).toEqual({
+      kind: "verb",
+      verb: { name: "ask", input: { kind: "argv", text: "--json tail" } },
+      outputMode: "text",
+      session: { kind: "default" },
+      local: false,
+    });
+    expect(parseCoachCliInvocation(["analyze", "--", "--fresh"])).toEqual({
+      kind: "verb",
+      verb: { name: "analyze", target: "--fresh" },
+      outputMode: "text",
+      session: { kind: "default" },
+      local: false,
+    });
+  });
+
+  it("rejects duplicate, exclusive, missing, and unknown flags", () => {
+    const rows = [
+      ["ask", "x", "--json", "--json"],
+      ["ask", "x", "--stream-json", "--stream-json"],
+      ["ask", "x", "--local", "--local"],
+      ["ask", "x", "--fresh", "--fresh"],
+      ["ask", "x", "--session", "a", "--session", "b"],
+      ["ask", "x", "--json", "--stream-json"],
+      ["ask", "x", "--fresh", "--session", "a"],
+      ["ask", "x", "--session", "a", "--fresh"],
+      ["ask", "x", "--session"],
+      ["ask", "x", "--unknown"],
+    ];
+    for (const argv of rows) expect(parseCoachCliInvocation(argv)).toEqual(verbUsage);
+  });
+
+  it("rejects state-only forbidden flags and invalid operand shapes", () => {
+    const rows = [
+      ["state", "--stream-json"],
+      ["state", "--fresh"],
+      ["state", "--session", "a"],
+      ["state", "extra"],
+      ["analyze"],
+      ["analyze", "-"],
+      ["analyze", "a", "b"],
+      ["plan"],
+      ["plan", "month"],
+      ["wellness", "set"],
+      ["wellness", "set", "1sleep=good"],
+      ["wellness", "set", "sleep="],
+      ["wellness", "set", "sleep=good", "sleep=bad"],
+    ];
+    for (const argv of rows) expect(parseCoachCliInvocation(argv)).toEqual(verbUsage);
+  });
+});

--- a/packages/coach-cli/tests/session-key.test.ts
+++ b/packages/coach-cli/tests/session-key.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  CoachCliSessionStartError,
+  DEFAULT_CLI_SESSION_KEY,
+  InvalidCoachCliSessionError,
+  normalizeNamedSessionKey,
+  resolveCoachCliSession,
+} from "../src/session-key.js";
+
+describe("CLI session keys", () => {
+  it("resolves default, named, trimmed, and case-sensitive keys", () => {
+    expect(resolveCoachCliSession({ kind: "default" })).toEqual({
+      kind: "default",
+      chatId: DEFAULT_CLI_SESSION_KEY,
+    });
+    expect(resolveCoachCliSession({ kind: "named", key: " RaceA " })).toEqual({
+      kind: "named",
+      chatId: "cli:RaceA",
+    });
+    expect(normalizeNamedSessionKey("racea")).toBe("cli:racea");
+    expect(normalizeNamedSessionKey("RaceA")).toBe("cli:RaceA");
+  });
+
+  it("applies NFC before enforcing the ASCII namespace grammar", () => {
+    const decomposed = "e\u0301";
+    const composed = "é";
+    expect(() => normalizeNamedSessionKey(decomposed)).toThrow(InvalidCoachCliSessionError);
+    expect(() => normalizeNamedSessionKey(composed)).toThrow(InvalidCoachCliSessionError);
+  });
+
+  it("rejects every invalid named-key boundary with the typed error", () => {
+    const invalid = [
+      "",
+      " ",
+      ":escape",
+      "a:b",
+      ".start",
+      "with space",
+      "a/b",
+      "é",
+      "a".repeat(129),
+    ];
+    for (const raw of invalid) {
+      try {
+        normalizeNamedSessionKey(raw);
+        throw new Error("expected invalid key");
+      } catch (error) {
+        expect(error).toBeInstanceOf(InvalidCoachCliSessionError);
+        expect(error).toMatchObject({ kind: "invalid-named-session" });
+      }
+    }
+    expect(normalizeNamedSessionKey("a".repeat(128))).toBe(`cli:${"a".repeat(128)}`);
+  });
+
+  it("creates one canonical fresh key without session RPC methods", () => {
+    const factory = vi.fn(() => "123e4567-e89b-42d3-a456-426614174000");
+    const result = resolveCoachCliSession({ kind: "fresh" }, factory);
+    expect(result).toEqual({
+      kind: "fresh",
+      chatId: "cli:fresh:123e4567-e89b-42d3-a456-426614174000",
+    });
+    expect(factory).toHaveBeenCalledTimes(1);
+    expect(Object.keys(result)).toEqual(["kind", "chatId"]);
+  });
+
+  it("collapses throwing and invalid factories to the typed start error", () => {
+    for (const factory of [
+      () => {
+        throw new Error("private cause");
+      },
+      () => "123E4567-E89B-42D3-A456-426614174000",
+      () => "123e4567-e89b-02d3-a456-426614174000",
+      () => "not-a-uuid",
+    ]) {
+      try {
+        resolveCoachCliSession({ kind: "fresh" }, factory);
+        throw new Error("expected fresh failure");
+      } catch (error) {
+        expect(error).toBeInstanceOf(CoachCliSessionStartError);
+        expect(error).toMatchObject({ kind: "fresh-session-start-failed" });
+      }
+    }
+  });
+});

--- a/packages/coach-cli/tests/verbs.test.ts
+++ b/packages/coach-cli/tests/verbs.test.ts
@@ -1,0 +1,465 @@
+import { Writable } from "node:stream";
+import { describe, expect, it, vi } from "vitest";
+import {
+  CoachTurnEventNotificationEnvelopeSchema,
+  EXIT_AGENT_ERROR,
+  EXIT_DAEMON_UNAVAILABLE,
+  EXIT_SUCCESS,
+  EXIT_VERSION_MISMATCH,
+  JsonRpcErrorResponseEnvelopeSchema,
+  JsonRpcSuccessResponseEnvelopeSchema,
+  serializeCoachRpcEnvelope,
+  type AthleteState,
+  type CoachEngine,
+  type CoachTurnEventNotificationEnvelope,
+  type JsonRpcErrorResponseEnvelope,
+  type JsonRpcSuccessResponseEnvelope,
+} from "@enduragent/coach-contract";
+import {
+  CoachRemoteError,
+  connectRemoteCoachTransport,
+  createCoachVerbRequest,
+  createLocalCoachVerbTransport,
+  runCoachVerb,
+  type CoachVerbRequest,
+  type CoachVerbTransport,
+} from "../src/index.js";
+
+const state: AthleteState = {
+  schemaVersion: "3",
+  lastUpdated: "2000-01-01T00:00:00.000Z",
+  freshness: "fresh",
+  degraded: false,
+  lastSynced: "2000-01-01T00:00:00.000Z",
+  athleteProfile: {},
+  currentStatus: {},
+  derivedMetrics: {},
+  recentActivities: [],
+  plannedWorkouts: [],
+  wellness: {},
+};
+
+function capture(): { readonly stream: Writable; read(): string } {
+  let value = "";
+  return {
+    stream: new Writable({
+      write(chunk, _encoding, callback) {
+        value += Buffer.isBuffer(chunk) ? chunk.toString("utf8") : String(chunk);
+        callback();
+      },
+    }),
+    read: () => value,
+  };
+}
+
+function terminal() {
+  const stdout = capture();
+  const stderr = capture();
+  return { stdout, stderr, value: { stdout: stdout.stream, stderr: stderr.stream } };
+}
+
+function success(result: unknown): JsonRpcSuccessResponseEnvelope {
+  return JsonRpcSuccessResponseEnvelopeSchema.parse({ jsonrpc: "2.0", id: 1, result });
+}
+
+function failure(): JsonRpcErrorResponseEnvelope {
+  return JsonRpcErrorResponseEnvelopeSchema.parse({
+    jsonrpc: "2.0",
+    id: 1,
+    error: { code: -32603, message: "Internal error" },
+  });
+}
+
+function notification(): CoachTurnEventNotificationEnvelope {
+  return CoachTurnEventNotificationEnvelopeSchema.parse({
+    jsonrpc: "2.0",
+    method: "coach.turnEvent",
+    params: {
+      requestId: 1,
+      requestMethod: "chat",
+      turnId: "turn-1",
+      event: { type: "turn-start", turnId: "turn-1", chatId: "cli:default" },
+    },
+  });
+}
+
+function request(
+  method: "chat" | "getAthleteState" = "chat",
+  signal = new AbortController().signal,
+): CoachVerbRequest {
+  return method === "chat"
+    ? {
+        method,
+        params: { chatId: "cli:default", message: "hello" },
+        signal,
+        onNotificationEnvelope: () => {},
+        onTerminalEnvelope: () => {},
+      }
+    : {
+        method,
+        params: {},
+        signal,
+        onNotificationEnvelope: () => {},
+        onTerminalEnvelope: () => {},
+      };
+}
+
+function deliveringTransport(input: {
+  readonly terminal: JsonRpcSuccessResponseEnvelope | JsonRpcErrorResponseEnvelope;
+  readonly notifications?: readonly CoachTurnEventNotificationEnvelope[];
+}): CoachVerbTransport {
+  return {
+    kind: "remote",
+    async request(command) {
+      for (const envelope of input.notifications ?? []) {
+        command.onNotificationEnvelope(envelope);
+      }
+      command.onTerminalEnvelope(input.terminal);
+      return input.terminal;
+    },
+    async close() {},
+  };
+}
+
+describe("verb dispatch", () => {
+  it("constructs the exhaustive method and message table", () => {
+    const signal = new AbortController().signal;
+    const rows = [
+      {
+        verb: { name: "ask", input: { kind: "argv", text: "unchanged" } } as const,
+        stdinText: undefined,
+        method: "chat",
+        params: { chatId: "cli:RaceA", message: "unchanged" },
+      },
+      {
+        verb: { name: "ask", input: { kind: "stdin" } } as const,
+        stdinText: "stdin text",
+        method: "chat",
+        params: { chatId: "cli:RaceA", message: "stdin text" },
+      },
+      {
+        verb: { name: "analyze", target: "last ride" } as const,
+        stdinText: undefined,
+        method: "chat",
+        params: { chatId: "cli:RaceA", message: '/analyze "last ride"' },
+      },
+      {
+        verb: { name: "plan-week" } as const,
+        stdinText: undefined,
+        method: "chat",
+        params: { chatId: "cli:RaceA", message: "/plan" },
+      },
+      {
+        verb: {
+          name: "wellness-set",
+          entries: [
+            { key: "note", value: "a=b" },
+            { key: "sleep", value: "good" },
+          ],
+        } as const,
+        stdinText: undefined,
+        method: "chat",
+        params: {
+          chatId: "cli:RaceA",
+          message: '/wellness set [{"key":"note","value":"a=b"},{"key":"sleep","value":"good"}]',
+        },
+      },
+    ];
+    for (const row of rows) {
+      const created = createCoachVerbRequest({
+        verb: row.verb,
+        chatId: "cli:RaceA",
+        stdinText: row.stdinText,
+        signal,
+      });
+      expect(created).toMatchObject({ method: row.method, params: row.params, signal });
+      expect(created.params as Record<string, unknown>).not.toHaveProperty("turn");
+    }
+    expect(
+      createCoachVerbRequest({
+        verb: { name: "state" },
+        chatId: undefined,
+        stdinText: undefined,
+        signal,
+      }),
+    ).toMatchObject({ method: "getAthleteState", params: {}, signal });
+  });
+});
+
+describe("verb rendering", () => {
+  it("renders chat and state text exactly", async () => {
+    const chatIo = terminal();
+    await expect(
+      runCoachVerb({
+        request: request("chat"),
+        outputMode: "text",
+        terminal: chatIo.value,
+        transport: deliveringTransport({ terminal: success({ text: "answer" }) }),
+      }),
+    ).resolves.toBe(EXIT_SUCCESS);
+    expect(chatIo.stdout.read()).toBe("answer\n");
+    expect(chatIo.stderr.read()).toBe("");
+
+    const stateIo = terminal();
+    await expect(
+      runCoachVerb({
+        request: request("getAthleteState"),
+        outputMode: "text",
+        terminal: stateIo.value,
+        transport: deliveringTransport({ terminal: success(state) }),
+      }),
+    ).resolves.toBe(EXIT_SUCCESS);
+    expect(stateIo.stdout.read()).toBe(`${JSON.stringify(state, null, 2)}\n`);
+    expect(stateIo.stderr.read()).toBe("");
+  });
+
+  it("renders one unwrapped JSON result and discards notifications", async () => {
+    const io = terminal();
+    await expect(
+      runCoachVerb({
+        request: request(),
+        outputMode: "json",
+        terminal: io.value,
+        transport: deliveringTransport({
+          terminal: success({ text: "answer" }),
+          notifications: [notification()],
+        }),
+      }),
+    ).resolves.toBe(EXIT_SUCCESS);
+    expect(io.stdout.read()).toBe('{"text":"answer"}\n');
+    expect(io.stderr.read()).toBe("");
+  });
+
+  it("renders notification and terminal envelopes verbatim in order", async () => {
+    const io = terminal();
+    const event = notification();
+    const terminalEnvelope = success({ text: "answer" });
+    await expect(
+      runCoachVerb({
+        request: request(),
+        outputMode: "stream-json",
+        terminal: io.value,
+        transport: deliveringTransport({ terminal: terminalEnvelope, notifications: [event] }),
+      }),
+    ).resolves.toBe(EXIT_SUCCESS);
+    expect(io.stdout.read()).toBe(
+      `${serializeCoachRpcEnvelope(event)}\n${serializeCoachRpcEnvelope(terminalEnvelope)}\n`,
+    );
+    expect(io.stderr.read()).toBe("");
+  });
+
+  it("keeps terminal errors on stream stdout only", async () => {
+    for (const outputMode of ["text", "json", "stream-json"] as const) {
+      const io = terminal();
+      const errorEnvelope = failure();
+      await expect(
+        runCoachVerb({
+          request: request(),
+          outputMode,
+          terminal: io.value,
+          transport: deliveringTransport({ terminal: errorEnvelope }),
+        }),
+      ).resolves.toBe(EXIT_AGENT_ERROR);
+      expect(io.stdout.read()).toBe(
+        outputMode === "stream-json" ? `${serializeCoachRpcEnvelope(errorEnvelope)}\n` : "",
+      );
+      expect(io.stderr.read()).toBe("Enduragent could not complete this command.\n");
+    }
+  });
+
+  it("maps every typed remote failure without stdout diagnostics", async () => {
+    const rows = [
+      {
+        failure: { kind: "agent" } as const,
+        exitCode: EXIT_AGENT_ERROR,
+        stderr: "Enduragent could not complete this command.\n",
+      },
+      {
+        failure: { kind: "detached" } as const,
+        exitCode: EXIT_AGENT_ERROR,
+        stderr: "Enduragent detached from the running turn; the turn may still complete.\n",
+      },
+      {
+        failure: { kind: "unavailable" } as const,
+        exitCode: EXIT_DAEMON_UNAVAILABLE,
+        stderr: "Enduragent could not reach the local service.\n",
+      },
+      {
+        failure: { kind: "version-mismatch", direction: "client-newer" } as const,
+        exitCode: EXIT_VERSION_MISMATCH,
+        stderr: "Enduragent protocol versions do not match; update this client.\n",
+      },
+    ];
+    for (const row of rows) {
+      const io = terminal();
+      await expect(
+        runCoachVerb({
+          request: request(),
+          outputMode: "json",
+          terminal: io.value,
+          transport: {
+            kind: "remote",
+            request: async () => {
+              throw new CoachRemoteError(row.failure);
+            },
+            async close() {},
+          },
+        }),
+      ).resolves.toBe(row.exitCode);
+      expect(io.stdout.read()).toBe("");
+      expect(io.stderr.read()).toBe(row.stderr);
+    }
+  });
+});
+
+describe("local projection and auto-start", () => {
+  it("calls only the selected engine method and emits exact local envelopes", async () => {
+    const chat = vi.fn<CoachEngine["chat"]>(async (params, onEvent) => {
+      onEvent?.({ type: "turn-start", turnId: "turn-1", chatId: params.chatId });
+      return { text: params.message };
+    });
+    const getAthleteState = vi.fn<CoachEngine["getAthleteState"]>(async () => state);
+    const engine: CoachEngine = {
+      chat,
+      getAthleteState,
+      resetSession: vi.fn(async () => ({ memoryFlushed: true })),
+      hasSession: vi.fn(async () => ({ hasSession: false })),
+    };
+    const chatIo = terminal();
+    await expect(
+      runCoachVerb({
+        request: request("chat"),
+        outputMode: "stream-json",
+        terminal: chatIo.value,
+        transport: createLocalCoachVerbTransport(engine),
+      }),
+    ).resolves.toBe(EXIT_SUCCESS);
+    expect(chat).toHaveBeenCalledWith(
+      { chatId: "cli:default", message: "hello" },
+      expect.any(Function),
+    );
+    expect(chatIo.stdout.read().split("\n").filter(Boolean)).toHaveLength(2);
+
+    const stateIo = terminal();
+    await expect(
+      runCoachVerb({
+        request: request("getAthleteState"),
+        outputMode: "json",
+        terminal: stateIo.value,
+        transport: createLocalCoachVerbTransport(engine),
+      }),
+    ).resolves.toBe(EXIT_SUCCESS);
+    expect(getAthleteState).toHaveBeenCalledWith();
+    expect(stateIo.stdout.read()).toBe(`${JSON.stringify(state)}\n`);
+  });
+
+  it("detaches local delivery without cancelling an in-flight engine turn", async () => {
+    let resolveTurn!: (value: { text: string }) => void;
+    const turn = new Promise<{ text: string }>((resolve) => {
+      resolveTurn = resolve;
+    });
+    const engine: CoachEngine = {
+      chat: vi.fn(async () => turn),
+      getAthleteState: async () => state,
+      resetSession: async () => ({ memoryFlushed: true }),
+      hasSession: async () => ({ hasSession: false }),
+    };
+    const controller = new AbortController();
+    const io = terminal();
+    const result = runCoachVerb({
+      request: request("chat", controller.signal),
+      outputMode: "text",
+      terminal: io.value,
+      transport: createLocalCoachVerbTransport(engine),
+    });
+    await vi.waitFor(() => expect(engine.chat).toHaveBeenCalledTimes(1));
+    controller.abort();
+    let settled = false;
+    void result.then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+    resolveTurn({ text: "late" });
+    await expect(result).resolves.toBe(EXIT_AGENT_ERROR);
+    expect(io.stdout.read()).toBe("");
+    expect(io.stderr.read()).toBe(
+      "Enduragent detached from the running turn; the turn may still complete.\n",
+    );
+  });
+
+  it("spawns once only after confirmed registration absence and attaches to the winner", async () => {
+    const winner = deliveringTransport({ terminal: success({ text: "ok" }) });
+    const connect = vi
+      .fn()
+      .mockRejectedValueOnce(new CoachRemoteError({ kind: "unavailable" }))
+      .mockRejectedValueOnce(new CoachRemoteError({ kind: "unavailable" }))
+      .mockResolvedValueOnce(winner);
+    const detachAfterHealthy = vi.fn();
+    const disposeAfterFailedStart = vi.fn(async () => {});
+    const startEphemeralDaemon = vi.fn(async () => ({
+      detachAfterHealthy,
+      disposeAfterFailedStart,
+    }));
+    let now = 0;
+    await expect(
+      connectRemoteCoachTransport({
+        connect,
+        serviceRegistrationState: vi.fn(async (): Promise<"absent"> => "absent"),
+        startEphemeralDaemon,
+        delay: async (ms) => {
+          now += ms;
+        },
+        monotonicNow: () => now,
+      }),
+    ).resolves.toBe(winner);
+    expect(connect).toHaveBeenCalledTimes(3);
+    expect(startEphemeralDaemon).toHaveBeenCalledTimes(1);
+    expect(detachAfterHealthy).toHaveBeenCalledTimes(1);
+    expect(disposeAfterFailedStart).not.toHaveBeenCalled();
+  });
+
+  it("fails closed for present and unknown registrations", async () => {
+    for (const registration of ["present", "unknown"] as const) {
+      const startEphemeralDaemon = vi.fn();
+      await expect(
+        connectRemoteCoachTransport({
+          connect: async () => {
+            throw new CoachRemoteError({ kind: "unavailable" });
+          },
+          serviceRegistrationState: async () => registration,
+          startEphemeralDaemon,
+          delay: async () => {},
+          monotonicNow: () => 0,
+        }),
+      ).rejects.toMatchObject({ failure: { kind: "unavailable" } });
+      expect(startEphemeralDaemon).not.toHaveBeenCalled();
+    }
+  });
+
+  it("times out at the exact budget and reaps only its child", async () => {
+    const disposeAfterFailedStart = vi.fn(async () => {});
+    let now = 0;
+    const delays: number[] = [];
+    await expect(
+      connectRemoteCoachTransport({
+        connect: async () => {
+          throw new CoachRemoteError({ kind: "unavailable" });
+        },
+        serviceRegistrationState: async () => "absent",
+        startEphemeralDaemon: async () => ({
+          detachAfterHealthy: vi.fn(),
+          disposeAfterFailedStart,
+        }),
+        delay: async (ms) => {
+          delays.push(ms);
+          now += ms;
+        },
+        monotonicNow: () => now,
+      }),
+    ).rejects.toMatchObject({ failure: { kind: "unavailable" } });
+    expect(delays.slice(0, 3)).toEqual([50, 100, 200]);
+    expect(delays.reduce((sum, value) => sum + value, 0)).toBe(5_000);
+    expect(disposeAfterFailedStart).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/coach/package.json
+++ b/packages/coach/package.json
@@ -47,6 +47,7 @@
     "yaml": "^2.8.3"
   },
   "devDependencies": {
+    "@enduragent/coach-client": "workspace:*",
     "@types/node": "^25.6.0",
     "@types/ws": "^8.18.1",
     "tsup": "^8.4.0",

--- a/packages/coach/src/enduragent.ts
+++ b/packages/coach/src/enduragent.ts
@@ -1,23 +1,40 @@
 #!/usr/bin/env node
+import { spawn } from "node:child_process";
 import { readFile, realpath } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
+  DaemonOwnerSchema,
   EXIT_AGENT_ERROR,
   EXIT_DAEMON_UNAVAILABLE,
   EXIT_NOT_CONFIGURED,
   EXIT_SUCCESS,
   EXIT_USAGE,
   EXIT_VERSION_MISMATCH,
+  type DaemonOwner,
   type ExitCode,
 } from "@enduragent/coach-contract";
 import {
+  CoachCliSessionStartError,
+  CoachRemoteError,
+  InvalidCoachCliSessionError,
+  connectCoachVerbTransport,
+  connectRemoteCoachTransport,
+  createCoachVerbRequest,
+  createLocalCoachVerbTransport,
   parseCoachCliInvocation,
+  resolveCoachCliSession,
   runCoachRepl,
+  runCoachVerb,
   type CoachCliTerminal,
+  type CoachCliVerbInvocation,
+  type CoachVerbRequest,
+  type CoachVerbTransport,
+  type ServiceRegistrationState,
 } from "@enduragent/coach-cli";
 import { expandTilde, resolveAthleteHome, type AthleteHome } from "@enduragent/kernel-node/home";
+import { PORT_FILE_NAME } from "@enduragent/kernel-node/lock";
 import { StoreNewerThanAppError } from "@enduragent/kernel/store";
 import {
   withLocalCoach,
@@ -38,6 +55,18 @@ export interface EnduragentDependencies {
   readonly resolveAthleteHome: (env: Record<string, string | undefined>) => AthleteHome;
   readonly withLocalCoach: <T>(input: WithLocalCoachInput<T>) => Promise<LocalCoachRunResult<T>>;
   readonly readPackageVersion: () => Promise<string>;
+  readonly connectRemoteTransport?: (home: AthleteHome) => Promise<CoachVerbTransport>;
+  readonly serviceRegistrationState?: () => Promise<ServiceRegistrationState>;
+  readonly startEphemeralDaemon?: (input: {
+    readonly env: Record<string, string | undefined>;
+    readonly home: AthleteHome;
+  }) => Promise<{
+    readonly disposeAfterFailedStart: () => Promise<void>;
+    readonly detachAfterHealthy: () => void;
+  }>;
+  readonly delay?: (ms: number) => Promise<void>;
+  readonly monotonicNow?: () => number;
+  readonly createFreshId?: () => string;
 }
 
 async function readPackageVersion(): Promise<string> {
@@ -57,7 +86,89 @@ const defaultDependencies: EnduragentDependencies = Object.freeze({
   resolveAthleteHome,
   withLocalCoach,
   readPackageVersion,
+  connectRemoteTransport: async (home: AthleteHome) => {
+    try {
+      const [rawPort, rawToken] = await Promise.all([
+        readFile(join(home.configDir, PORT_FILE_NAME), "utf8"),
+        readFile(join(home.configDir, "daemon.token"), "utf8"),
+      ]);
+      const port = Number(rawPort.trim());
+      const token = rawToken.endsWith("\n") ? rawToken.slice(0, -1) : "";
+      if (!Number.isInteger(port) || port < 1 || port > 65_535 || token.length === 0) {
+        throw new TypeError("invalid daemon coordinates");
+      }
+      return await connectCoachVerbTransport({
+        url: `ws://127.0.0.1:${port}/rpc`,
+        token,
+      });
+    } catch (error) {
+      if (error instanceof CoachRemoteError) throw error;
+      throw new CoachRemoteError({ kind: "unavailable" });
+    }
+  },
+  serviceRegistrationState: async (): Promise<ServiceRegistrationState> => "unknown",
+  startEphemeralDaemon: startEphemeralDaemonProcess,
+  delay: (ms: number) => new Promise<void>((resolveDelay) => setTimeout(resolveDelay, ms)),
+  monotonicNow: () => performance.now(),
 });
+
+function childEnvironment(
+  env: Record<string, string | undefined>,
+  home: AthleteHome,
+): NodeJS.ProcessEnv {
+  const combined: Record<string, string | undefined> = {
+    ...process.env,
+    ...env,
+    ENDURAGENT_HOME: home.root,
+    ENDURAGENT_DAEMON_OWNER: "ephemeral-client-started",
+    FORCE_COLOR: undefined,
+    CLICOLOR_FORCE: undefined,
+  };
+  return Object.fromEntries(
+    Object.entries(combined).filter((entry): entry is [string, string] => entry[1] !== undefined),
+  );
+}
+
+async function startEphemeralDaemonProcess(input: {
+  readonly env: Record<string, string | undefined>;
+  readonly home: AthleteHome;
+}): Promise<{
+  readonly disposeAfterFailedStart: () => Promise<void>;
+  readonly detachAfterHealthy: () => void;
+}> {
+  const entry = process.argv[1];
+  if (entry === undefined) throw new CoachRemoteError({ kind: "unavailable" });
+  let child: ReturnType<typeof spawn>;
+  try {
+    child = spawn(process.execPath, [entry, "serve"], {
+      detached: true,
+      env: childEnvironment(input.env, input.home),
+      stdio: "ignore",
+    });
+    await new Promise<void>((resolveSpawn, rejectSpawn) => {
+      child.once("spawn", resolveSpawn);
+      child.once("error", rejectSpawn);
+    });
+  } catch {
+    throw new CoachRemoteError({ kind: "unavailable" });
+  }
+  return {
+    disposeAfterFailedStart: async () => {
+      if (child.exitCode !== null || child.signalCode !== null) return;
+      await new Promise<void>((resolveExit) => {
+        const finish = (): void => resolveExit();
+        child.once("exit", finish);
+        child.once("error", finish);
+        try {
+          child.kill("SIGTERM");
+        } catch {
+          finish();
+        }
+      });
+    },
+    detachAfterHealthy: () => child.unref(),
+  };
+}
 
 function resolveLegacySourceRoot(env: Record<string, string | undefined>): string {
   const override = env.CYCLING_COACH_HOME;
@@ -73,22 +184,284 @@ function storeNewerThanApp(error: unknown): StoreNewerThanAppError | null {
   return error.cause instanceof StoreNewerThanAppError ? error.cause : null;
 }
 
+const VERB_USAGE =
+  "Usage: enduragent <ask|state|analyze|plan week|wellness set> [--json|--stream-json] [--session <key>|--fresh] [--local]";
+
+class InvalidVerbInputError extends Error {}
+
+function explicitAskStdin(argv: readonly string[]): boolean {
+  let flagsEnded = false;
+  for (let index = 1; index < argv.length; index += 1) {
+    const token = argv[index]!;
+    if (!flagsEnded && token === "--") {
+      flagsEnded = true;
+      continue;
+    }
+    if (!flagsEnded && token === "--session") {
+      index += 1;
+      continue;
+    }
+    if (!flagsEnded && token.startsWith("-") && token !== "-") continue;
+    return token === "-";
+  }
+  return false;
+}
+
+async function readStdinText(input: NodeJS.ReadableStream): Promise<string> {
+  const decoder = new TextDecoder("utf-8", { fatal: true });
+  let text = "";
+  try {
+    for await (const chunk of input as AsyncIterable<unknown>) {
+      if (!(chunk instanceof Uint8Array)) throw new InvalidVerbInputError();
+      text += decoder.decode(chunk, { stream: true });
+    }
+    text += decoder.decode();
+  } catch {
+    throw new InvalidVerbInputError();
+  }
+  if (text.endsWith("\n")) {
+    text = text.slice(0, -1);
+    if (text.endsWith("\r")) text = text.slice(0, -1);
+  }
+  if (text.includes("\0") || !/\S/u.test(text)) throw new InvalidVerbInputError();
+  return text;
+}
+
+function daemonOwner(env: Record<string, string | undefined>): DaemonOwner {
+  const parsed = DaemonOwnerSchema.safeParse(env.ENDURAGENT_DAEMON_OWNER);
+  return parsed.success ? parsed.data : "unmanaged-foreground";
+}
+
+function writeContention(
+  terminal: Pick<CoachCliTerminal, "stderr">,
+  error: CoachStoreWriterError,
+): void {
+  if (error.contention?.kind === "holder") {
+    terminal.stderr.write(
+      `Enduragent cannot start: another writer holds this athlete home (pid ${error.contention.pid ?? "unknown"}, port ${error.contention.port}). Stop it or wait, then retry.\n`,
+    );
+    return;
+  }
+  if (error.contention?.kind === "foreign") {
+    terminal.stderr.write(
+      `Enduragent cannot start: 127.0.0.1:${error.contention.port} is held by a foreign process; change or remove the port file at ${error.contention.portFile}, then retry.\n`,
+    );
+  }
+}
+
+function renderLocalResult(
+  result: Exclude<LocalCoachRunResult<ExitCode>, { readonly status: "completed" }>,
+  terminal: Pick<CoachCliTerminal, "stderr">,
+): ExitCode {
+  if (result.status === "not-configured") {
+    terminal.stderr.write(
+      `Enduragent is not configured. Provision ${result.configPath} with provider credentials, then run: enduragent\n`,
+    );
+    return EXIT_NOT_CONFIGURED;
+  }
+  if (result.status === "migration-discarded") {
+    terminal.stderr.write(
+      `Enduragent migration plan ${result.result.manifestDigest} was discarded to ${result.result.archivePath}. Run enduragent again to replan.\n`,
+    );
+    return result.result.exitCode;
+  }
+  const manifest =
+    result.result.manifestDigest === null ? "" : ` for manifest ${result.result.manifestDigest}`;
+  terminal.stderr.write(
+    `Enduragent cannot start: legacy migration was refused (${result.result.reason}). Review ${result.result.journalPath}${manifest} and resolve the reported condition before retrying.\n`,
+  );
+  return result.result.exitCode;
+}
+
+async function runWithOwnedTransport(
+  transport: CoachVerbTransport,
+  request: CoachVerbRequest,
+  invocation: CoachCliVerbInvocation,
+  terminal: CoachCliTerminal,
+): Promise<ExitCode> {
+  let exitCode: ExitCode | undefined;
+  let primaryError: unknown;
+  try {
+    exitCode = await runCoachVerb({
+      request,
+      outputMode: invocation.outputMode,
+      terminal,
+      transport,
+    });
+  } catch (error) {
+    primaryError = error;
+  }
+  try {
+    await transport.close();
+  } catch (error) {
+    if (primaryError === undefined && exitCode === EXIT_SUCCESS) {
+      terminal.stderr.write("Enduragent could not close the command transport.\n");
+      return EXIT_AGENT_ERROR;
+    }
+    if (primaryError === undefined && exitCode === undefined) primaryError = error;
+  }
+  if (primaryError !== undefined) throw primaryError;
+  return exitCode!;
+}
+
+function remoteConnectionFailure(
+  error: CoachRemoteError,
+  terminal: Pick<CoachCliTerminal, "stderr">,
+): ExitCode {
+  switch (error.failure.kind) {
+    case "unavailable":
+      terminal.stderr.write("Enduragent could not reach the local service.\n");
+      return EXIT_DAEMON_UNAVAILABLE;
+    case "version-mismatch":
+      terminal.stderr.write("Enduragent protocol versions do not match; update this client.\n");
+      return EXIT_VERSION_MISMATCH;
+    case "agent":
+      terminal.stderr.write("Enduragent could not complete this command.\n");
+      return EXIT_AGENT_ERROR;
+    case "detached":
+      terminal.stderr.write(
+        "Enduragent detached from the running turn; the turn may still complete.\n",
+      );
+      return EXIT_AGENT_ERROR;
+  }
+}
+
+async function prepareVerb(
+  input: RunEnduragentInput,
+  invocation: CoachCliVerbInvocation,
+  dependencies: EnduragentDependencies,
+): Promise<CoachVerbRequest> {
+  let stdinText: string | undefined;
+  if (invocation.verb.name === "ask" && invocation.verb.input.kind === "stdin") {
+    if (input.terminal.isTTY && !explicitAskStdin(input.argv)) {
+      throw new InvalidVerbInputError();
+    }
+    stdinText = await readStdinText(input.terminal.input);
+  }
+  const chatId =
+    invocation.verb.name === "state"
+      ? undefined
+      : resolveCoachCliSession(invocation.session, dependencies.createFreshId).chatId;
+  return createCoachVerbRequest({
+    verb: invocation.verb,
+    chatId,
+    stdinText,
+    signal: input.signal,
+  });
+}
+
+async function runPreparedVerb(
+  input: RunEnduragentInput,
+  invocation: CoachCliVerbInvocation,
+  request: CoachVerbRequest,
+  dependencies: EnduragentDependencies,
+): Promise<ExitCode> {
+  const home = dependencies.resolveAthleteHome(input.env);
+  const connect = (): Promise<CoachVerbTransport> => dependencies.connectRemoteTransport!(home);
+  if (!invocation.local) {
+    let transport: CoachVerbTransport;
+    try {
+      transport = await connectRemoteCoachTransport({
+        connect,
+        serviceRegistrationState: dependencies.serviceRegistrationState!,
+        startEphemeralDaemon: () => dependencies.startEphemeralDaemon!({ env: input.env, home }),
+        delay: dependencies.delay!,
+        monotonicNow: dependencies.monotonicNow!,
+      });
+    } catch (error) {
+      if (error instanceof CoachRemoteError) {
+        return remoteConnectionFailure(error, input.terminal);
+      }
+      throw error;
+    }
+    return runWithOwnedTransport(transport, request, invocation, input.terminal);
+  }
+
+  const sourceRoot = resolveLegacySourceRoot(input.env);
+  try {
+    const result = await dependencies.withLocalCoach({
+      env: input.env,
+      home,
+      sourceRoot,
+      action: { kind: "resume", isTTY: input.terminal.isTTY },
+      operation: async (lifecycle) =>
+        runWithOwnedTransport(
+          createLocalCoachVerbTransport(lifecycle.engine),
+          request,
+          invocation,
+          input.terminal,
+        ),
+    });
+    return result.status === "completed" ? result.value : renderLocalResult(result, input.terminal);
+  } catch (error) {
+    if (!(error instanceof CoachStoreWriterError) || error.code !== "writer-lock-held") {
+      throw error;
+    }
+    let transport: CoachVerbTransport;
+    try {
+      transport = await connect();
+    } catch (remoteError) {
+      if (
+        remoteError instanceof CoachRemoteError &&
+        remoteError.failure.kind === "version-mismatch"
+      ) {
+        return remoteConnectionFailure(remoteError, input.terminal);
+      }
+      if (remoteError instanceof CoachRemoteError && remoteError.failure.kind === "unavailable") {
+        writeContention(input.terminal, error);
+        return EXIT_DAEMON_UNAVAILABLE;
+      }
+      throw remoteError;
+    }
+    return runWithOwnedTransport(transport, request, invocation, input.terminal);
+  }
+}
+
 export async function runEnduragent(
   input: RunEnduragentInput,
   dependencies?: EnduragentDependencies,
 ): Promise<ExitCode> {
   const invocation = parseCoachCliInvocation(input.argv);
-  if (invocation.kind === "usage") {
+  if (invocation.kind === "usage" || invocation.kind === "verb-usage") {
     input.terminal.stderr.write(`${invocation.message}\n`);
     return EXIT_USAGE;
   }
 
-  const resolvedDependencies = dependencies ?? defaultDependencies;
+  const resolvedDependencies: EnduragentDependencies = {
+    ...defaultDependencies,
+    ...dependencies,
+  };
   try {
     if (invocation.kind === "version") {
       const version = await resolvedDependencies.readPackageVersion();
       input.terminal.stdout.write(`enduragent ${version}\n`);
       return EXIT_SUCCESS;
+    }
+
+    if (invocation.kind === "verb") {
+      let request: CoachVerbRequest;
+      try {
+        request = await prepareVerb(input, invocation, resolvedDependencies);
+      } catch (error) {
+        if (
+          error instanceof InvalidCoachCliSessionError ||
+          error instanceof InvalidVerbInputError
+        ) {
+          input.terminal.stderr.write(`${VERB_USAGE}\n`);
+          return EXIT_USAGE;
+        }
+        if (error instanceof CoachCliSessionStartError) {
+          input.terminal.stderr.write("Enduragent could not start a chat session.\n");
+          return EXIT_AGENT_ERROR;
+        }
+        throw error;
+      }
+      try {
+        return await runPreparedVerb(input, invocation, request, resolvedDependencies);
+      } catch {
+        input.terminal.stderr.write("Enduragent could not complete this command.\n");
+        return EXIT_AGENT_ERROR;
+      }
     }
 
     const appVersion =
@@ -107,6 +480,7 @@ export async function runEnduragent(
               home,
               appVersion: appVersion!,
               signal: input.signal,
+              owner: daemonOwner(input.env),
             })
           : runCoachRepl({
               engine: lifecycle.engine,
@@ -115,25 +489,7 @@ export async function runEnduragent(
             }),
     });
 
-    if (result.status === "completed") return result.value;
-    if (result.status === "not-configured") {
-      input.terminal.stderr.write(
-        `Enduragent is not configured. Provision ${result.configPath} with provider credentials, then run: enduragent\n`,
-      );
-      return EXIT_NOT_CONFIGURED;
-    }
-    if (result.status === "migration-discarded") {
-      input.terminal.stderr.write(
-        `Enduragent migration plan ${result.result.manifestDigest} was discarded to ${result.result.archivePath}. Run enduragent again to replan.\n`,
-      );
-      return result.result.exitCode;
-    }
-    const manifest =
-      result.result.manifestDigest === null ? "" : ` for manifest ${result.result.manifestDigest}`;
-    input.terminal.stderr.write(
-      `Enduragent cannot start: legacy migration was refused (${result.result.reason}). Review ${result.result.journalPath}${manifest} and resolve the reported condition before retrying.\n`,
-    );
-    return result.result.exitCode;
+    return result.status === "completed" ? result.value : renderLocalResult(result, input.terminal);
   } catch (error) {
     if (storeNewerThanApp(error) !== null) {
       input.terminal.stderr.write(

--- a/packages/coach/tests/cli-verbs-rpc.test.ts
+++ b/packages/coach/tests/cli-verbs-rpc.test.ts
@@ -1,0 +1,393 @@
+import { createServer, type Server } from "node:http";
+import { createServer as createNetServer } from "node:net";
+import { Writable } from "node:stream";
+import { performance } from "node:perf_hooks";
+import { describe, expect, it, vi } from "vitest";
+import {
+  CoachClientDisconnectedError,
+  connectCoachClient,
+  type CoachClient,
+} from "@enduragent/coach-client";
+import {
+  CoachRemoteError,
+  connectCoachVerbTransport,
+  connectRemoteCoachTransport,
+  createCoachVerbRequest,
+  runCoachVerb,
+  type CoachVerbTransport,
+} from "@enduragent/coach-cli";
+import {
+  EXIT_SUCCESS,
+  serializeCoachRpcEnvelope,
+  type AthleteState,
+  type CoachEngine,
+  type TurnEvent,
+} from "@enduragent/coach-contract";
+import { createCoachRpcServer, type CoachRpcServer } from "../src/daemon/rpc-server.js";
+
+const token = "s".repeat(43);
+const state: AthleteState = {
+  schemaVersion: "3",
+  lastUpdated: "2000-01-01T00:00:00.000Z",
+  freshness: "fresh",
+  degraded: false,
+  lastSynced: "2000-01-01T00:00:00.000Z",
+  athleteProfile: {},
+  currentStatus: {},
+  derivedMetrics: {},
+  recentActivities: [],
+  plannedWorkouts: [],
+  wellness: {},
+};
+
+interface Deferred<T> {
+  readonly promise: Promise<T>;
+  resolve(value: T): void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  return {
+    promise: new Promise<T>((resolvePromise) => {
+      resolve = resolvePromise;
+    }),
+    resolve,
+  };
+}
+
+function capture(): { readonly stream: Writable; read(): string } {
+  let value = "";
+  return {
+    stream: new Writable({
+      write(chunk, _encoding, callback) {
+        value += Buffer.isBuffer(chunk) ? chunk.toString("utf8") : String(chunk);
+        callback();
+      },
+    }),
+    read: () => value,
+  };
+}
+
+async function loopbackAvailable(): Promise<boolean> {
+  return new Promise((resolve) => {
+    const server = createNetServer();
+    server.once("error", (error: NodeJS.ErrnoException) => {
+      if (error.code === "EPERM") {
+        process.stderr.write("SKIP_MARKER loopback-listen EPERM cli-verbs-rpc\n");
+      }
+      resolve(false);
+    });
+    server.listen({ host: "127.0.0.1", port: 0 }, () => server.close(() => resolve(true)));
+  });
+}
+
+const hasLoopback = await loopbackAvailable();
+
+interface RunningRpc {
+  readonly rpc: CoachRpcServer;
+  readonly server: Server;
+  readonly url: string;
+}
+
+async function startRpc(engine: CoachEngine): Promise<RunningRpc> {
+  const rpc = createCoachRpcServer({ engine, token, owner: "unmanaged-foreground" });
+  const server = createServer();
+  server.on("upgrade", rpc.handleUpgrade);
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen({ host: "127.0.0.1", port: 0 }, resolve);
+  });
+  const address = server.address();
+  if (address === null || typeof address === "string") throw new TypeError("missing test port");
+  return { rpc, server, url: `ws://127.0.0.1:${address.port}/rpc` };
+}
+
+async function closeServer(
+  running: RunningRpc,
+  clients: readonly CoachClient[] = [],
+): Promise<void> {
+  for (const client of clients) await client.close().catch(() => {});
+  await running.rpc.close();
+  await new Promise<void>((resolve, reject) => {
+    running.server.close((error) => (error === undefined ? resolve() : reject(error)));
+  });
+}
+
+async function closeTransport(transport: CoachVerbTransport | undefined): Promise<void> {
+  await transport?.close().catch(() => {});
+}
+
+describe.skipIf(!hasLoopback)("CLI verbs over real RPC framing", () => {
+  it("runs all five verbs, preserves stream envelopes, and serves warm state under 500 ms", async () => {
+    const chatCalls: Parameters<CoachEngine["chat"]>[0][] = [];
+    const getAthleteState = vi.fn<CoachEngine["getAthleteState"]>(async () => state);
+    const engine: CoachEngine = {
+      chat: vi.fn(async (request, onEvent) => {
+        chatCalls.push(request);
+        const event: TurnEvent = {
+          type: "turn-start",
+          turnId: `turn-${chatCalls.length}`,
+          chatId: request.chatId,
+        };
+        onEvent?.(event);
+        return { text: request.message };
+      }),
+      getAthleteState,
+      resetSession: async () => ({ memoryFlushed: true }),
+      hasSession: async () => ({ hasSession: false }),
+    };
+    const running = await startRpc(engine);
+    const transports: CoachVerbTransport[] = [];
+    try {
+      const rows = [
+        {
+          verb: { name: "ask", input: { kind: "argv", text: "hello" } } as const,
+          outputMode: "stream-json" as const,
+          expected: "hello",
+        },
+        {
+          verb: { name: "state" } as const,
+          outputMode: "json" as const,
+          expected: undefined,
+        },
+        {
+          verb: { name: "analyze", target: "last ride" } as const,
+          outputMode: "json" as const,
+          expected: '/analyze "last ride"',
+        },
+        {
+          verb: { name: "plan-week" } as const,
+          outputMode: "text" as const,
+          expected: "/plan",
+        },
+        {
+          verb: {
+            name: "wellness-set",
+            entries: [{ key: "sleep", value: "good" }],
+          } as const,
+          outputMode: "json" as const,
+          expected: '/wellness set [{"key":"sleep","value":"good"}]',
+        },
+      ];
+      let streamOutput = "";
+      for (const row of rows) {
+        const stdout = capture();
+        const stderr = capture();
+        const transport = await connectCoachVerbTransport({ url: running.url, token });
+        transports.push(transport);
+        const request = createCoachVerbRequest({
+          verb: row.verb,
+          chatId: row.verb.name === "state" ? undefined : "cli:RaceA",
+          stdinText: undefined,
+          signal: new AbortController().signal,
+        });
+        await expect(
+          runCoachVerb({
+            request,
+            outputMode: row.outputMode,
+            terminal: { stdout: stdout.stream, stderr: stderr.stream },
+            transport,
+          }),
+        ).resolves.toBe(EXIT_SUCCESS);
+        expect(stderr.read()).toBe("");
+        if (row.outputMode === "stream-json") streamOutput = stdout.read();
+        await transport.close();
+      }
+      expect(chatCalls).toEqual([
+        { chatId: "cli:RaceA", message: "hello" },
+        { chatId: "cli:RaceA", message: '/analyze "last ride"' },
+        { chatId: "cli:RaceA", message: "/plan" },
+        {
+          chatId: "cli:RaceA",
+          message: '/wellness set [{"key":"sleep","value":"good"}]',
+        },
+      ]);
+      expect(getAthleteState).toHaveBeenCalledOnce();
+      expect(getAthleteState).toHaveBeenCalledWith();
+      const lines = streamOutput
+        .trimEnd()
+        .split("\n")
+        .map((line) => JSON.parse(line));
+      expect(lines).toHaveLength(2);
+      expect(lines[0]).toMatchObject({
+        jsonrpc: "2.0",
+        method: "coach.turnEvent",
+        params: { requestMethod: "chat", event: { type: "turn-start" } },
+      });
+      expect(lines[1]).toMatchObject({ jsonrpc: "2.0", result: { text: "hello" } });
+      expect(streamOutput).toBe(lines.map(serializeCoachRpcEnvelope).join("\n") + "\n");
+
+      const warm = await connectCoachVerbTransport({ url: running.url, token });
+      transports.push(warm);
+      const stdout = capture();
+      const stderr = capture();
+      const startedAt = performance.now();
+      await expect(
+        runCoachVerb({
+          request: createCoachVerbRequest({
+            verb: { name: "state" },
+            chatId: undefined,
+            stdinText: undefined,
+            signal: new AbortController().signal,
+          }),
+          outputMode: "json",
+          terminal: { stdout: stdout.stream, stderr: stderr.stream },
+          transport: warm,
+        }),
+      ).resolves.toBe(EXIT_SUCCESS);
+      expect(performance.now() - startedAt).toBeLessThan(500);
+      expect(stdout.read()).toBe(`${JSON.stringify(state)}\n`);
+      expect(stderr.read()).toBe("");
+    } finally {
+      for (const transport of transports) await closeTransport(transport);
+      await closeServer(running);
+    }
+  });
+
+  it("enforces per-key FIFO, cross-key fairness, queued removal, and in-flight detach", async () => {
+    const gates = new Map<string, Deferred<{ text: string }>>();
+    const entered: string[] = [];
+    const engine: CoachEngine = {
+      async chat(request) {
+        entered.push(request.message);
+        const gate = gates.get(request.message);
+        return gate === undefined ? { text: request.message } : gate.promise;
+      },
+      getAthleteState: async () => state,
+      resetSession: async () => ({ memoryFlushed: true }),
+      hasSession: async () => ({ hasSession: false }),
+    };
+    const running = await startRpc(engine);
+    const clients: CoachClient[] = [];
+    const transports: CoachVerbTransport[] = [];
+    try {
+      const a1Gate = deferred<{ text: string }>();
+      gates.set("A1", a1Gate);
+      const a1 = await connectCoachClient({ url: running.url, token });
+      const a2 = await connectCoachClient({ url: running.url, token });
+      const b1 = await connectCoachClient({ url: running.url, token });
+      clients.push(a1, a2, b1);
+      const a1Call = a1.call("chat", { chatId: "cli:A", message: "A1" });
+      await vi.waitFor(() => expect(entered).toEqual(["A1"]));
+      const a2Call = a2.call("chat", { chatId: "cli:A", message: "A2" });
+      const b1Call = b1.call("chat", { chatId: "cli:B", message: "B1" });
+      await expect(b1Call).resolves.toEqual({ text: "B1" });
+      expect(entered).toEqual(["A1", "B1"]);
+      a1Gate.resolve({ text: "A1" });
+      await expect(a1Call).resolves.toEqual({ text: "A1" });
+      await expect(a2Call).resolves.toEqual({ text: "A2" });
+      expect(entered).toEqual(["A1", "B1", "A2"]);
+
+      const heldGate = deferred<{ text: string }>();
+      gates.set("held", heldGate);
+      const held = await connectCoachClient({ url: running.url, token });
+      const queued = await connectCoachClient({ url: running.url, token });
+      clients.push(held, queued);
+      const heldCall = held.call("chat", { chatId: "cli:cancel", message: "held" });
+      await vi.waitFor(() => expect(entered).toContain("held"));
+      const queuedCall = queued.call("chat", { chatId: "cli:cancel", message: "cancelled" });
+      await queued.close();
+      await expect(queuedCall).rejects.toBeInstanceOf(CoachClientDisconnectedError);
+      heldGate.resolve({ text: "held" });
+      await expect(heldCall).resolves.toEqual({ text: "held" });
+      await Promise.resolve();
+      expect(entered).not.toContain("cancelled");
+
+      const detachedGate = deferred<{ text: string }>();
+      gates.set("detached", detachedGate);
+      const detachedTransport = await connectCoachVerbTransport({ url: running.url, token });
+      const followerTransport = await connectCoachVerbTransport({ url: running.url, token });
+      transports.push(detachedTransport, followerTransport);
+      const controller = new AbortController();
+      const detachedCall = detachedTransport.request({
+        method: "chat",
+        params: { chatId: "cli:detach", message: "detached" },
+        signal: controller.signal,
+        onNotificationEnvelope: () => {},
+        onTerminalEnvelope: () => {},
+      });
+      await vi.waitFor(() => expect(entered).toContain("detached"));
+      const followerCall = followerTransport.request({
+        method: "chat",
+        params: { chatId: "cli:detach", message: "follower" },
+        signal: new AbortController().signal,
+        onNotificationEnvelope: () => {},
+        onTerminalEnvelope: () => {},
+      });
+      controller.abort();
+      await expect(detachedCall).rejects.toMatchObject({ failure: { kind: "detached" } });
+      expect(entered).not.toContain("follower");
+      detachedGate.resolve({ text: "detached" });
+      await expect(followerCall).resolves.toMatchObject({ result: { text: "follower" } });
+      expect(entered.indexOf("detached")).toBeLessThan(entered.indexOf("follower"));
+    } finally {
+      for (const transport of transports) await closeTransport(transport);
+      await closeServer(running, clients);
+    }
+  });
+
+  it("auto-starts once only after absence and reaps the created child on timeout", async () => {
+    const winner = {
+      kind: "remote",
+      request: vi.fn(),
+      close: vi.fn(async () => {}),
+    } as CoachVerbTransport;
+    const connect = vi
+      .fn()
+      .mockRejectedValueOnce(new CoachRemoteError({ kind: "unavailable" }))
+      .mockResolvedValueOnce(winner);
+    const detachAfterHealthy = vi.fn();
+    const disposeAfterFailedStart = vi.fn(async () => {});
+    let now = 0;
+    await expect(
+      connectRemoteCoachTransport({
+        connect,
+        serviceRegistrationState: async () => "absent",
+        startEphemeralDaemon: async () => ({ detachAfterHealthy, disposeAfterFailedStart }),
+        delay: async (ms) => {
+          now += ms;
+        },
+        monotonicNow: () => now,
+      }),
+    ).resolves.toBe(winner);
+    expect(connect).toHaveBeenCalledTimes(2);
+    expect(detachAfterHealthy).toHaveBeenCalledOnce();
+    expect(disposeAfterFailedStart).not.toHaveBeenCalled();
+
+    for (const registration of ["present", "unknown"] as const) {
+      const start = vi.fn();
+      await expect(
+        connectRemoteCoachTransport({
+          connect: async () => {
+            throw new CoachRemoteError({ kind: "unavailable" });
+          },
+          serviceRegistrationState: async () => registration,
+          startEphemeralDaemon: start,
+          delay: async () => {},
+          monotonicNow: () => 0,
+        }),
+      ).rejects.toMatchObject({ failure: { kind: "unavailable" } });
+      expect(start).not.toHaveBeenCalled();
+    }
+
+    const reap = vi.fn(async () => {});
+    now = 0;
+    await expect(
+      connectRemoteCoachTransport({
+        connect: async () => {
+          throw new CoachRemoteError({ kind: "unavailable" });
+        },
+        serviceRegistrationState: async () => "absent",
+        startEphemeralDaemon: async () => ({
+          detachAfterHealthy: vi.fn(),
+          disposeAfterFailedStart: reap,
+        }),
+        delay: async (ms) => {
+          now += ms;
+        },
+        monotonicNow: () => now,
+      }),
+    ).rejects.toMatchObject({ failure: { kind: "unavailable" } });
+    expect(reap).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/coach/tests/enduragent-entry.test.ts
+++ b/packages/coach/tests/enduragent-entry.test.ts
@@ -11,9 +11,15 @@ import {
   EXIT_SUCCESS,
   EXIT_USAGE,
   EXIT_VERSION_MISMATCH,
+  JsonRpcSuccessResponseEnvelopeSchema,
   type AthleteState,
   type CoachEngine,
 } from "@enduragent/coach-contract";
+import {
+  CoachRemoteError,
+  type CoachVerbRequest,
+  type CoachVerbTransport,
+} from "@enduragent/coach-cli";
 import type { AthleteHome } from "@enduragent/kernel-node/home";
 import { inertWriterProtocolListener, PORT_FILE_NAME } from "@enduragent/kernel-node/lock";
 import { StoreNewerThanAppError } from "@enduragent/kernel/store";
@@ -109,6 +115,29 @@ function mockEngine(
   }));
   const getAthleteState = vi.fn<CoachEngine["getAthleteState"]>(async () => state);
   return { engine: { chat, resetSession, hasSession, getAthleteState }, chat };
+}
+
+function remoteTransport(
+  result: unknown,
+  input: {
+    readonly close?: () => Promise<void>;
+    readonly received?: CoachVerbRequest[];
+  } = {},
+): CoachVerbTransport {
+  return {
+    kind: "remote",
+    async request(request) {
+      input.received?.push(request);
+      const envelope = JsonRpcSuccessResponseEnvelopeSchema.parse({
+        jsonrpc: "2.0",
+        id: 1,
+        result,
+      });
+      request.onTerminalEnvelope(envelope);
+      return envelope;
+    },
+    close: input.close ?? (async () => {}),
+  };
 }
 
 const roots: string[] = [];
@@ -421,30 +450,32 @@ describe("enduragent executable composition", () => {
     let captured: WithLocalCoachInput<unknown> | undefined;
     let packageReads = 0;
     const io = terminal(new PassThrough(), true);
-    await expect(runEnduragent(
-      {
-        argv: ["serve"],
-        env,
-        terminal: io.value,
-        signal: controller.signal,
-      },
-      {
-        resolveAthleteHome: () => home,
-        readPackageVersion: async () => {
-          packageReads += 1;
-          return "0.1.0-synthetic";
+    await expect(
+      runEnduragent(
+        {
+          argv: ["serve"],
+          env,
+          terminal: io.value,
+          signal: controller.signal,
         },
-        withLocalCoach: async <T>(input: WithLocalCoachInput<T>) => {
-          captured = input as unknown as WithLocalCoachInput<unknown>;
-          const value = await input.operation({
-            engine: mocked.engine,
-            listener: inertWriterProtocolListener,
-            async close() {},
-          });
-          return { status: "completed", value };
+        {
+          resolveAthleteHome: () => home,
+          readPackageVersion: async () => {
+            packageReads += 1;
+            return "0.1.0-synthetic";
+          },
+          withLocalCoach: async <T>(input: WithLocalCoachInput<T>) => {
+            captured = input as unknown as WithLocalCoachInput<unknown>;
+            const value = await input.operation({
+              engine: mocked.engine,
+              listener: inertWriterProtocolListener,
+              async close() {},
+            });
+            return { status: "completed", value };
+          },
         },
-      },
-    )).resolves.toBe(EXIT_SUCCESS);
+      ),
+    ).resolves.toBe(EXIT_SUCCESS);
     expect(packageReads).toBe(1);
     expect(captured).toMatchObject({
       env,
@@ -456,81 +487,94 @@ describe("enduragent executable composition", () => {
     expect(io.stderr.read()).toBe("");
   });
 
-  it.each([
-    { argv: [] as readonly string[] },
-    { argv: ["serve"] as readonly string[] },
-  ])("maps the exact typed newer-store cause to exit 5 for $argv", async ({ argv }) => {
-    const newer = new StoreNewerThanAppError(3, 2);
-    const failure = new CoachStoreWriterError(
-      "writer-failed",
-      "run migrations",
-      { cause: newer },
-    );
-    const io = terminal();
-    await expect(runEnduragent(
-      {
-        argv,
-        env,
-        terminal: io.value,
-        signal: new AbortController().signal,
-      },
-      {
-        resolveAthleteHome: () => home,
-        withLocalCoach: async () => {
-          throw failure;
-        },
-        readPackageVersion: async () => "0.1.0-synthetic",
-      },
-    )).resolves.toBe(EXIT_VERSION_MISMATCH);
-    expect(io.stdout.read()).toBe("");
-    expect(io.stderr.read()).toBe(
-      "Enduragent cannot start: this athlete store was created by a newer app version. Update Enduragent and retry.\n",
-    );
-  });
+  it.each([{ argv: [] as readonly string[] }, { argv: ["serve"] as readonly string[] }])(
+    "maps the exact typed newer-store cause to exit 5 for $argv",
+    async ({ argv }) => {
+      const newer = new StoreNewerThanAppError(3, 2);
+      const failure = new CoachStoreWriterError("writer-failed", "run migrations", {
+        cause: newer,
+      });
+      const io = terminal();
+      await expect(
+        runEnduragent(
+          {
+            argv,
+            env,
+            terminal: io.value,
+            signal: new AbortController().signal,
+          },
+          {
+            resolveAthleteHome: () => home,
+            withLocalCoach: async () => {
+              throw failure;
+            },
+            readPackageVersion: async () => "0.1.0-synthetic",
+          },
+        ),
+      ).resolves.toBe(EXIT_VERSION_MISMATCH);
+      expect(io.stdout.read()).toBe("");
+      expect(io.stderr.read()).toBe(
+        "Enduragent cannot start: this athlete store was created by a newer app version. Update Enduragent and retry.\n",
+      );
+    },
+  );
 
-  it.runIf(hasLoopback)("preserves a real newer store and releases the writer after serve exits 5", async () => {
-    await mkdir(home.storeDir, { recursive: true, mode: 0o700 });
-    const databasePath = join(home.storeDir, "store.db");
-    const maximum = MIGRATIONS.at(-1)!.version;
-    const seed = openSqliteStorage(databasePath);
-    await seed.setUserVersion(maximum + 1);
-    await seed.close();
-    const beforeNames = (await readdir(home.storeDir)).sort();
-    const beforeHash = createHash("sha256").update(await readFile(databasePath)).digest("hex");
-    const io = terminal();
+  it.runIf(hasLoopback)(
+    "preserves a real newer store and releases the writer after serve exits 5",
+    async () => {
+      await mkdir(home.storeDir, { recursive: true, mode: 0o700 });
+      const databasePath = join(home.storeDir, "store.db");
+      const maximum = MIGRATIONS.at(-1)!.version;
+      const seed = openSqliteStorage(databasePath);
+      await seed.setUserVersion(maximum + 1);
+      await seed.close();
+      const beforeNames = (await readdir(home.storeDir)).sort();
+      const beforeHash = createHash("sha256")
+        .update(await readFile(databasePath))
+        .digest("hex");
+      const io = terminal();
 
-    await expect(runEnduragent(
-      {
-        argv: ["serve"],
-        env,
-        terminal: io.value,
-        signal: new AbortController().signal,
-      },
-      {
-        resolveAthleteHome: () => home,
-        readPackageVersion: async () => "0.1.0-synthetic",
-        withLocalCoach: async <T>(): Promise<LocalCoachRunResult<T>> => {
-          await withCoachStoreWriter(env, async () => {
-            throw new Error("operation must not run for a newer store");
-          });
-          throw new Error("newer store unexpectedly opened");
-        },
-      },
-    )).resolves.toBe(EXIT_VERSION_MISMATCH);
-    expect(io.stdout.read()).toBe("");
-    expect(io.stderr.read()).toBe(
-      "Enduragent cannot start: this athlete store was created by a newer app version. Update Enduragent and retry.\n",
-    );
-    expect((await readdir(home.storeDir)).sort()).toEqual(beforeNames);
-    expect(createHash("sha256").update(await readFile(databasePath)).digest("hex")).toBe(beforeHash);
-    await expect(readFile(join(home.configDir, PORT_FILE_NAME), "utf8")).rejects.toMatchObject({
-      code: "ENOENT",
-    });
-    await expect(readFile(join(home.configDir, "store-writer.lock"), "utf8"))
-      .rejects.toMatchObject({ code: "ENOENT" });
-    await expect(readFile(join(home.configDir, "daemon.token"), "utf8"))
-      .rejects.toMatchObject({ code: "ENOENT" });
-  });
+      await expect(
+        runEnduragent(
+          {
+            argv: ["serve"],
+            env,
+            terminal: io.value,
+            signal: new AbortController().signal,
+          },
+          {
+            resolveAthleteHome: () => home,
+            readPackageVersion: async () => "0.1.0-synthetic",
+            withLocalCoach: async <T>(): Promise<LocalCoachRunResult<T>> => {
+              await withCoachStoreWriter(env, async () => {
+                throw new Error("operation must not run for a newer store");
+              });
+              throw new Error("newer store unexpectedly opened");
+            },
+          },
+        ),
+      ).resolves.toBe(EXIT_VERSION_MISMATCH);
+      expect(io.stdout.read()).toBe("");
+      expect(io.stderr.read()).toBe(
+        "Enduragent cannot start: this athlete store was created by a newer app version. Update Enduragent and retry.\n",
+      );
+      expect((await readdir(home.storeDir)).sort()).toEqual(beforeNames);
+      expect(
+        createHash("sha256")
+          .update(await readFile(databasePath))
+          .digest("hex"),
+      ).toBe(beforeHash);
+      await expect(readFile(join(home.configDir, PORT_FILE_NAME), "utf8")).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+      await expect(
+        readFile(join(home.configDir, "store-writer.lock"), "utf8"),
+      ).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(readFile(join(home.configDir, "daemon.token"), "utf8")).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+    },
+  );
 
   it("uses typed writer errors and redacts every other startup failure", async () => {
     const holder = Object.assign(Object.create(CoachStoreWriterError.prototype), {
@@ -703,6 +747,441 @@ describe("enduragent executable composition", () => {
       ["store-close", "writer-release"],
     ] as const) {
       expect(trace.indexOf(earlier)).toBeLessThan(trace.indexOf(later));
+    }
+  });
+
+  it("runs a remote-default verb without registration or spawn work on a warm daemon", async () => {
+    const received: CoachVerbRequest[] = [];
+    const connectRemoteTransport = vi.fn(async () =>
+      remoteTransport({ text: "remote" }, { received }),
+    );
+    const serviceRegistrationState = vi.fn(async () => "absent" as const);
+    const startEphemeralDaemon = vi.fn();
+    const io = terminal();
+    await expect(
+      runEnduragent(
+        {
+          argv: ["ask", "hello", "--json", "--session", "RaceA"],
+          env,
+          terminal: io.value,
+          signal: new AbortController().signal,
+        },
+        {
+          resolveAthleteHome: () => home,
+          withLocalCoach: async () => {
+            throw new Error("local runner must not be used");
+          },
+          readPackageVersion: async () => "unused",
+          connectRemoteTransport,
+          serviceRegistrationState,
+          startEphemeralDaemon,
+        },
+      ),
+    ).resolves.toBe(EXIT_SUCCESS);
+    expect(received).toHaveLength(1);
+    expect(received[0]).toMatchObject({
+      method: "chat",
+      params: { chatId: "cli:RaceA", message: "hello" },
+    });
+    expect(serviceRegistrationState).not.toHaveBeenCalled();
+    expect(startEphemeralDaemon).not.toHaveBeenCalled();
+    expect(io.stdout.read()).toBe('{"text":"remote"}\n');
+    expect(io.stderr.read()).toBe("");
+  });
+
+  it("runs local state through one lifecycle and never connects remotely", async () => {
+    const mocked = mockEngine();
+    const connectRemoteTransport = vi.fn();
+    let localCalls = 0;
+    const io = terminal();
+    await expect(
+      runEnduragent(
+        {
+          argv: ["state", "--json", "--local"],
+          env,
+          terminal: io.value,
+          signal: new AbortController().signal,
+        },
+        {
+          resolveAthleteHome: () => home,
+          withLocalCoach: async <T>(input: WithLocalCoachInput<T>) => {
+            localCalls += 1;
+            return {
+              status: "completed",
+              value: await input.operation({
+                engine: mocked.engine,
+                listener: inertWriterProtocolListener,
+                async close() {},
+              }),
+            };
+          },
+          readPackageVersion: async () => "unused",
+          connectRemoteTransport,
+        },
+      ),
+    ).resolves.toBe(EXIT_SUCCESS);
+    expect(localCalls).toBe(1);
+    expect(connectRemoteTransport).not.toHaveBeenCalled();
+    expect(mocked.chat).not.toHaveBeenCalled();
+    expect(io.stdout.read()).toBe(`${JSON.stringify(state)}\n`);
+    expect(io.stderr.read()).toBe("");
+  });
+
+  it("falls through from a held local writer only to an authenticated remote transport", async () => {
+    const contention = new CoachStoreWriterError("writer-lock-held", null, undefined, {
+      kind: "holder",
+      pid: 41,
+      port: 43_101,
+    });
+    const received: CoachVerbRequest[] = [];
+    const connectRemoteTransport = vi.fn(async () =>
+      remoteTransport({ text: "attached" }, { received }),
+    );
+    const io = terminal();
+    await expect(
+      runEnduragent(
+        {
+          argv: ["plan", "week", "--local"],
+          env,
+          terminal: io.value,
+          signal: new AbortController().signal,
+        },
+        {
+          resolveAthleteHome: () => home,
+          withLocalCoach: async () => {
+            throw contention;
+          },
+          readPackageVersion: async () => "unused",
+          connectRemoteTransport,
+          startEphemeralDaemon: vi.fn(),
+        },
+      ),
+    ).resolves.toBe(EXIT_SUCCESS);
+    expect(connectRemoteTransport).toHaveBeenCalledTimes(1);
+    expect(received[0]).toMatchObject({
+      method: "chat",
+      params: { chatId: "cli:default", message: "/plan" },
+    });
+    expect(io.stdout.read()).toBe("attached\n");
+    expect(io.stderr.read()).toBe("");
+  });
+
+  it("preserves contention diagnostics when local fall-through cannot authenticate", async () => {
+    const rows = [
+      {
+        contention: { kind: "holder" as const, pid: null, port: 43_102 },
+        stderr:
+          "Enduragent cannot start: another writer holds this athlete home (pid unknown, port 43102). Stop it or wait, then retry.\n",
+      },
+      {
+        contention: {
+          kind: "foreign" as const,
+          port: 43_103,
+          portFile: join(home.configDir, "store-writer.port"),
+        },
+        stderr: `Enduragent cannot start: 127.0.0.1:43103 is held by a foreign process; change or remove the port file at ${join(home.configDir, "store-writer.port")}, then retry.\n`,
+      },
+    ];
+    for (const row of rows) {
+      const failure = new CoachStoreWriterError(
+        "writer-lock-held",
+        null,
+        undefined,
+        row.contention,
+      );
+      const io = terminal();
+      await expect(
+        runEnduragent(
+          {
+            argv: ["ask", "hello", "--local"],
+            env,
+            terminal: io.value,
+            signal: new AbortController().signal,
+          },
+          {
+            resolveAthleteHome: () => home,
+            withLocalCoach: async () => {
+              throw failure;
+            },
+            readPackageVersion: async () => "unused",
+            connectRemoteTransport: async () => {
+              throw new CoachRemoteError({ kind: "unavailable" });
+            },
+          },
+        ),
+      ).resolves.toBe(EXIT_DAEMON_UNAVAILABLE);
+      expect(io.stdout.read()).toBe("");
+      expect(io.stderr.read()).toBe(row.stderr);
+    }
+  });
+
+  it("maps a local fall-through version mismatch to exit 5", async () => {
+    const failure = new CoachStoreWriterError("writer-lock-held", null, undefined, {
+      kind: "holder",
+      pid: 41,
+      port: 43_104,
+    });
+    const io = terminal();
+    await expect(
+      runEnduragent(
+        {
+          argv: ["ask", "hello", "--local"],
+          env,
+          terminal: io.value,
+          signal: new AbortController().signal,
+        },
+        {
+          resolveAthleteHome: () => home,
+          withLocalCoach: async () => {
+            throw failure;
+          },
+          readPackageVersion: async () => "unused",
+          connectRemoteTransport: async () => {
+            throw new CoachRemoteError({
+              kind: "version-mismatch",
+              direction: "client-newer",
+            });
+          },
+        },
+      ),
+    ).resolves.toBe(EXIT_VERSION_MISMATCH);
+    expect(io.stdout.read()).toBe("");
+    expect(io.stderr.read()).toBe(
+      "Enduragent protocol versions do not match; update this client.\n",
+    );
+  });
+
+  it("fails closed on unknown registration and never starts a daemon", async () => {
+    const startEphemeralDaemon = vi.fn();
+    const io = terminal();
+    await expect(
+      runEnduragent(
+        {
+          argv: ["state", "--json"],
+          env,
+          terminal: io.value,
+          signal: new AbortController().signal,
+        },
+        {
+          resolveAthleteHome: () => home,
+          withLocalCoach: async () => {
+            throw new Error("local runner must not be used");
+          },
+          readPackageVersion: async () => "unused",
+          connectRemoteTransport: async () => {
+            throw new CoachRemoteError({ kind: "unavailable" });
+          },
+          serviceRegistrationState: async () => "unknown",
+          startEphemeralDaemon,
+        },
+      ),
+    ).resolves.toBe(EXIT_DAEMON_UNAVAILABLE);
+    expect(startEphemeralDaemon).not.toHaveBeenCalled();
+    expect(io.stdout.read()).toBe("");
+    expect(io.stderr.read()).toBe("Enduragent could not reach the local service.\n");
+  });
+
+  it("keeps one close owner and maps a close-only failure after success", async () => {
+    const close = vi.fn(async () => {
+      throw new Error("private close cause");
+    });
+    const io = terminal();
+    await expect(
+      runEnduragent(
+        {
+          argv: ["ask", "hello"],
+          env,
+          terminal: io.value,
+          signal: new AbortController().signal,
+        },
+        {
+          resolveAthleteHome: () => home,
+          withLocalCoach: async () => {
+            throw new Error("local runner must not be used");
+          },
+          readPackageVersion: async () => "unused",
+          connectRemoteTransport: async () => remoteTransport({ text: "answer" }, { close }),
+        },
+      ),
+    ).resolves.toBe(EXIT_AGENT_ERROR);
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(io.stdout.read()).toBe("answer\n");
+    expect(io.stderr.read()).toBe("Enduragent could not close the command transport.\n");
+  });
+
+  it("keeps a primary command failure when close also fails", async () => {
+    const close = vi.fn(async () => {
+      throw new Error("private close cause");
+    });
+    const io = terminal();
+    await expect(
+      runEnduragent(
+        {
+          argv: ["ask", "hello", "--stream-json"],
+          env,
+          terminal: io.value,
+          signal: new AbortController().signal,
+        },
+        {
+          resolveAthleteHome: () => home,
+          withLocalCoach: async () => {
+            throw new Error("local runner must not be used");
+          },
+          readPackageVersion: async () => "unused",
+          connectRemoteTransport: async () => ({
+            kind: "remote",
+            async request(request) {
+              const envelope = {
+                jsonrpc: "2.0" as const,
+                id: 1,
+                error: { code: -32603, message: "Internal error" },
+              };
+              request.onTerminalEnvelope(envelope);
+              return envelope;
+            },
+            close,
+          }),
+        },
+      ),
+    ).resolves.toBe(EXIT_AGENT_ERROR);
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(io.stdout.read()).toBe(
+      '{"jsonrpc":"2.0","id":1,"error":{"code":-32603,"message":"Internal error"}}\n',
+    );
+    expect(io.stderr.read()).toBe("Enduragent could not complete this command.\n");
+  });
+
+  it("maps invalid named and fresh sessions before resolving the athlete home", async () => {
+    const rows = [
+      {
+        argv: ["ask", "hello", "--session", "a:b"],
+        createFreshId: undefined,
+        exitCode: EXIT_USAGE,
+        stderr:
+          "Usage: enduragent <ask|state|analyze|plan week|wellness set> [--json|--stream-json] [--session <key>|--fresh] [--local]\n",
+      },
+      {
+        argv: ["ask", "hello", "--fresh"],
+        createFreshId: () => {
+          throw new Error("private UUID cause");
+        },
+        exitCode: EXIT_AGENT_ERROR,
+        stderr: "Enduragent could not start a chat session.\n",
+      },
+      {
+        argv: ["ask", "hello", "--fresh"],
+        createFreshId: () => "invalid",
+        exitCode: EXIT_AGENT_ERROR,
+        stderr: "Enduragent could not start a chat session.\n",
+      },
+    ];
+    for (const row of rows) {
+      const resolveHome = vi.fn(() => home);
+      const connectRemoteTransport = vi.fn();
+      const io = terminal();
+      await expect(
+        runEnduragent(
+          {
+            argv: row.argv,
+            env,
+            terminal: io.value,
+            signal: new AbortController().signal,
+          },
+          {
+            resolveAthleteHome: resolveHome,
+            withLocalCoach: async () => {
+              throw new Error("local runner must not be used");
+            },
+            readPackageVersion: async () => "unused",
+            connectRemoteTransport,
+            createFreshId: row.createFreshId,
+          },
+        ),
+      ).resolves.toBe(row.exitCode);
+      expect(resolveHome).not.toHaveBeenCalled();
+      expect(connectRemoteTransport).not.toHaveBeenCalled();
+      expect(io.stdout.read()).toBe("");
+      expect(io.stderr.read()).toBe(row.stderr);
+    }
+  });
+
+  it("reads split UTF-8 stdin before transport and strips one terminal newline", async () => {
+    const input = new PassThrough();
+    const received: CoachVerbRequest[] = [];
+    const io = terminal(input, true);
+    input.write(Buffer.from([0x63, 0x61, 0x66, 0xc3]));
+    input.end(Buffer.from([0xa9, 0x0d, 0x0a]));
+    await expect(
+      runEnduragent(
+        {
+          argv: ["ask", "-"],
+          env,
+          terminal: io.value,
+          signal: new AbortController().signal,
+        },
+        {
+          resolveAthleteHome: () => home,
+          withLocalCoach: async () => {
+            throw new Error("local runner must not be used");
+          },
+          readPackageVersion: async () => "unused",
+          connectRemoteTransport: async () => remoteTransport({ text: "ok" }, { received }),
+        },
+      ),
+    ).resolves.toBe(EXIT_SUCCESS);
+    expect(received[0]).toMatchObject({ params: { message: "café" } });
+    expect(io.stdout.read()).toBe("ok\n");
+  });
+
+  it("rejects TTY-empty, malformed, NUL, blank, and string stdin before transport", async () => {
+    const inputs: Array<{
+      readonly argv: readonly string[];
+      readonly input: PassThrough;
+      readonly isTTY: boolean;
+    }> = [];
+    const tty = new PassThrough();
+    inputs.push({ argv: ["ask"], input: tty, isTTY: true });
+    const malformed = new PassThrough();
+    malformed.end(Buffer.from([0xc3, 0x28]));
+    inputs.push({ argv: ["ask", "-"], input: malformed, isTTY: true });
+    const nul = new PassThrough();
+    nul.end(Buffer.from("bad\0text"));
+    inputs.push({ argv: ["ask", "-"], input: nul, isTTY: true });
+    const blank = new PassThrough();
+    blank.end(Buffer.from(" \r\n"));
+    inputs.push({ argv: ["ask", "-"], input: blank, isTTY: true });
+    const strings = new PassThrough();
+    strings.setEncoding("utf8");
+    strings.end("text");
+    inputs.push({ argv: ["ask", "-"], input: strings, isTTY: true });
+    for (const row of inputs) {
+      const io = terminal(row.input, row.isTTY);
+      const connectRemoteTransport = vi.fn();
+      const resolveHome = vi.fn(() => home);
+      await expect(
+        runEnduragent(
+          {
+            argv: row.argv,
+            env,
+            terminal: io.value,
+            signal: new AbortController().signal,
+          },
+          {
+            resolveAthleteHome: resolveHome,
+            withLocalCoach: async () => {
+              throw new Error("local runner must not be used");
+            },
+            readPackageVersion: async () => "unused",
+            connectRemoteTransport,
+          },
+        ),
+      ).resolves.toBe(EXIT_USAGE);
+      expect(resolveHome).not.toHaveBeenCalled();
+      expect(connectRemoteTransport).not.toHaveBeenCalled();
+      expect(io.stdout.read()).toBe("");
+      expect(io.stderr.read()).toBe(
+        "Usage: enduragent <ask|state|analyze|plan week|wellness set> [--json|--stream-json] [--session <key>|--fresh] [--local]\n",
+      );
     }
   });
 });

--- a/packages/sport-cycling/tests/prescription-posture.test.ts
+++ b/packages/sport-cycling/tests/prescription-posture.test.ts
@@ -142,7 +142,10 @@ describe("cycling prescription posture", () => {
   it("keeps the posture once in the stable prompt prefix below the token ceiling", () => {
     const emptyMemory = { getContext: () => "" } as Parameters<typeof buildSystemPrompt>[1];
     const prompt = buildSystemPrompt(cyclingSport, emptyMemory);
-    const { prefix, volatile } = splitSystemPromptAtBoundary(prompt);
+    const blocks = splitSystemPromptAtBoundary(prompt);
+    expect(blocks).toBeDefined();
+    if (blocks === undefined) throw new TypeError("missing system prompt cache boundary");
+    const { prefix, volatile } = blocks;
     expect(prefix.match(/## Skill: cycling-prescription-posture/g)).toHaveLength(1);
     expect(volatile.match(/## Skill: cycling-prescription-posture/g)).toBeNull();
     expect(estimateTokens(prompt)).toBeLessThan(13_000);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,6 +104,9 @@ importers:
         specifier: ^2.8.3
         version: 2.8.3
     devDependencies:
+      '@enduragent/coach-client':
+        specifier: workspace:*
+        version: link:../coach-client
       '@types/node':
         specifier: ^25.6.0
         version: 25.6.0
@@ -122,6 +125,9 @@ importers:
 
   packages/coach-cli:
     dependencies:
+      '@enduragent/coach-client':
+        specifier: workspace:*
+        version: link:../coach-client
       '@enduragent/coach-contract':
         specifier: workspace:*
         version: link:../coach-contract


### PR DESCRIPTION
## Summary

Lands the daemon-backed CLI verbs:

- `ask`, `state`, `analyze`, `plan week`, `wellness set` with `--json` / `--stream-json` / `--session` / `--fresh` / stdin and the contract exit taxonomy (0-5); import/sync stay descoped to the wave that owns their store-side seams.
- Daemon auto-start on the attach path — never while a launchd service registration exists; `--local` falls through only for a healthy compatible peer, reusing the landed second-starter classification.
- Per-session-key FIFO: queued turns cancellable, in-flight disconnect classifies as the additive `detached` error kind (never a silent cancel); session-key normalization shared with the daemon.
- Rendering: `--stream-json` emits envelope lines verbatim; `--json` prints the unwrapped terminal result only.
- Additive `CoachCliInvocation` union + verb dispatch table over the landed W7 coach-cli; coach-client dependency wired.

## Verification

- Root `pnpm check:types` green; focused CLI/entry suites 42 tests; spec aggregate 101 tests; socket-bound cases verified in the root gate.
- Root `pnpm build`, `pnpm check`, full `pnpm test` green after rebase.
