### PR TITLE
feat(cli): wire daemon service verbs and arbitration

### DIFF
--- a/.changeset/launchd-service.md
+++ b/.changeset/launchd-service.md
@@ -1,0 +1,7 @@
+---
+"@enduragent/coach": patch
+"@enduragent/coach-cli": patch
+"@enduragent/kernel-node": patch
+---
+
+Add macOS service installation, status, restart, and fail-closed service-owner arbitration for the internal enduragent executable.

--- a/packages/coach-cli/src/args.ts
+++ b/packages/coach-cli/src/args.ts
@@ -31,6 +31,10 @@ export type CoachCliInvocation =
   | { readonly kind: "version" }
   | { readonly kind: "serve" }
   | {
+      readonly kind: "daemon";
+      readonly action: "install" | "status" | "restart";
+    }
+  | {
       readonly kind: "usage";
       readonly message: "Usage: enduragent [version|serve]";
     }
@@ -158,6 +162,13 @@ export function parseCoachCliInvocation(argv: readonly string[]): CoachCliInvoca
     return { kind: "version" };
   }
   if (argv.length === 1 && argv[0] === "serve") return { kind: "serve" };
+  if (
+    argv.length === 2 &&
+    argv[0] === "daemon" &&
+    (argv[1] === "install" || argv[1] === "status" || argv[1] === "restart")
+  ) {
+    return { kind: "daemon", action: argv[1] };
+  }
   const root = argv[0]!;
   if (!new Set(["ask", "state", "analyze", "plan", "wellness"]).has(root)) {
     return { kind: "usage", message: "Usage: enduragent [version|serve]" };

--- a/packages/coach-cli/src/index.ts
+++ b/packages/coach-cli/src/index.ts
@@ -2,3 +2,10 @@ export * from "./args.js";
 export * from "./repl.js";
 export * from "./session-key.js";
 export * from "./verbs/index.js";
+export {
+  runCoachDaemonCommand,
+  type CoachDaemonController,
+  type DaemonServiceSnapshot,
+  type RunCoachDaemonCommandOptions,
+} from "./verbs/daemon.js";
+export { connectWithBoundedRetry, type BoundedConnectDependencies } from "./verbs/transport.js";

--- a/packages/coach-cli/src/verbs/daemon.ts
+++ b/packages/coach-cli/src/verbs/daemon.ts
@@ -1,0 +1,91 @@
+import {
+  EXIT_AGENT_ERROR,
+  EXIT_DAEMON_UNAVAILABLE,
+  EXIT_SUCCESS,
+  EXIT_USAGE,
+  type ExitCode,
+} from "@enduragent/coach-contract";
+import type { CoachCliTerminal } from "../repl.js";
+
+export type DaemonServiceSnapshot =
+  | {
+      readonly kind: "absent";
+      readonly label: string;
+      readonly installed: false;
+      readonly loaded: false;
+      readonly running: false;
+      readonly pid: null;
+    }
+  | {
+      readonly kind: "registered";
+      readonly label: string;
+      readonly installed: boolean;
+      readonly loaded: boolean;
+      readonly running: boolean;
+      readonly pid: number | null;
+    }
+  | {
+      readonly kind: "unknown";
+      readonly label: string;
+      readonly installed: boolean | null;
+      readonly loaded: null;
+      readonly running: null;
+      readonly pid: null;
+    };
+
+export interface CoachDaemonController {
+  readonly supported: boolean;
+  install(): Promise<DaemonServiceSnapshot>;
+  status(): Promise<DaemonServiceSnapshot>;
+  restart(): Promise<DaemonServiceSnapshot>;
+}
+
+export interface RunCoachDaemonCommandOptions {
+  readonly action: "install" | "status" | "restart";
+  readonly controller: CoachDaemonController;
+  readonly terminal: CoachCliTerminal;
+}
+
+export async function runCoachDaemonCommand(
+  options: RunCoachDaemonCommandOptions,
+): Promise<ExitCode> {
+  if (!options.controller.supported) {
+    options.terminal.stderr.write("Enduragent service management is available only on macOS.\n");
+    return EXIT_USAGE;
+  }
+
+  try {
+    const snapshot = await options.controller[options.action]();
+    if (snapshot.kind === "unknown") {
+      options.terminal.stderr.write("Enduragent service status is unavailable.\n");
+      return EXIT_DAEMON_UNAVAILABLE;
+    }
+    if (options.action === "install") {
+      if (snapshot.kind !== "registered") throw new Error("service installation failed");
+      options.terminal.stdout.write(`Enduragent service installed (${snapshot.label}).\n`);
+      return EXIT_SUCCESS;
+    }
+    if (options.action === "restart") {
+      if (snapshot.kind !== "registered") throw new Error("service restart failed");
+      options.terminal.stdout.write(`Enduragent service restarted (${snapshot.label}).\n`);
+      return EXIT_SUCCESS;
+    }
+    if (snapshot.kind === "absent") {
+      options.terminal.stdout.write(`Enduragent service is not installed (${snapshot.label}).\n`);
+      return EXIT_DAEMON_UNAVAILABLE;
+    }
+    if (!snapshot.running) {
+      options.terminal.stdout.write(
+        `Enduragent service is registered but stopped (${snapshot.label}).\n`,
+      );
+      return EXIT_DAEMON_UNAVAILABLE;
+    }
+    options.terminal.stdout.write(
+      `Enduragent service is running (${snapshot.label}, pid ${snapshot.pid ?? "unknown"}).\n`,
+    );
+    return EXIT_SUCCESS;
+  } catch {
+    options.terminal.stderr.write("Enduragent service command failed.\n");
+    return EXIT_AGENT_ERROR;
+  }
+}

--- a/packages/coach-cli/src/verbs/transport.ts
+++ b/packages/coach-cli/src/verbs/transport.ts
@@ -212,8 +212,38 @@ function unavailable(error: unknown): error is CoachRemoteError {
   return error instanceof CoachRemoteError && error.failure.kind === "unavailable";
 }
 
+export interface BoundedConnectDependencies {
+  readonly connect: () => Promise<CoachVerbTransport>;
+  readonly delay: (ms: number) => Promise<void>;
+  readonly monotonicNow: () => number;
+}
+
+export interface ServiceAwareRemoteTransportDependencies extends RemoteTransportDependencies {
+  readonly resumeService?: () => Promise<"resumed" | "not-installed">;
+}
+
+export async function connectWithBoundedRetry(
+  dependencies: BoundedConnectDependencies,
+): Promise<CoachVerbTransport> {
+  const startedAt = dependencies.monotonicNow();
+  let nextDelayMs = 50;
+  while (true) {
+    try {
+      return await dependencies.connect();
+    } catch (error) {
+      if (!unavailable(error)) throw error;
+    }
+    const beforeDelay = dependencies.monotonicNow() - startedAt;
+    if (beforeDelay >= 5_000) throw new CoachRemoteError({ kind: "unavailable" });
+    await dependencies.delay(Math.min(nextDelayMs, 5_000 - beforeDelay));
+    const afterDelay = dependencies.monotonicNow() - startedAt;
+    if (afterDelay >= 5_000) throw new CoachRemoteError({ kind: "unavailable" });
+    nextDelayMs = Math.min(nextDelayMs * 2, 200);
+  }
+}
+
 export async function connectRemoteCoachTransport(
-  dependencies: RemoteTransportDependencies,
+  dependencies: ServiceAwareRemoteTransportDependencies,
 ): Promise<CoachVerbTransport> {
   try {
     return await dependencies.connect();
@@ -221,26 +251,20 @@ export async function connectRemoteCoachTransport(
     if (!unavailable(error)) throw error;
   }
   const registration = await dependencies.serviceRegistrationState();
-  if (registration !== "absent") throw new CoachRemoteError({ kind: "unavailable" });
-  const child = await dependencies.startEphemeralDaemon();
-  const startedAt = dependencies.monotonicNow();
-  let nextDelayMs = 50;
-  try {
-    while (true) {
-      const beforeDelay = dependencies.monotonicNow() - startedAt;
-      if (beforeDelay >= 5_000) throw new CoachRemoteError({ kind: "unavailable" });
-      await dependencies.delay(Math.min(nextDelayMs, 5_000 - beforeDelay));
-      const afterDelay = dependencies.monotonicNow() - startedAt;
-      if (afterDelay >= 5_000) throw new CoachRemoteError({ kind: "unavailable" });
-      try {
-        const transport = await dependencies.connect();
-        child.detachAfterHealthy();
-        return transport;
-      } catch (error) {
-        if (!unavailable(error)) throw error;
-      }
-      nextDelayMs = Math.min(nextDelayMs * 2, 200);
+  if (registration === "unknown") throw new CoachRemoteError({ kind: "unavailable" });
+  if (registration === "present") {
+    if (dependencies.resumeService === undefined) {
+      throw new CoachRemoteError({ kind: "unavailable" });
     }
+    const resumed = await dependencies.resumeService();
+    if (resumed !== "resumed") throw new CoachRemoteError({ kind: "unavailable" });
+    return connectWithBoundedRetry(dependencies);
+  }
+  const child = await dependencies.startEphemeralDaemon();
+  try {
+    const transport = await connectWithBoundedRetry(dependencies);
+    child.detachAfterHealthy();
+    return transport;
   } catch (error) {
     await child.disposeAfterFailedStart();
     throw error;

--- a/packages/coach-cli/tests/daemon.test.ts
+++ b/packages/coach-cli/tests/daemon.test.ts
@@ -1,0 +1,185 @@
+import { PassThrough, Writable } from "node:stream";
+import { readFile } from "node:fs/promises";
+import { describe, expect, it, vi } from "vitest";
+import {
+  EXIT_AGENT_ERROR,
+  EXIT_DAEMON_UNAVAILABLE,
+  EXIT_SUCCESS,
+  EXIT_USAGE,
+} from "@enduragent/coach-contract";
+import {
+  parseCoachCliInvocation,
+  runCoachDaemonCommand,
+  type CoachDaemonController,
+  type DaemonServiceSnapshot,
+} from "../src/index.js";
+
+function capture(): { readonly stream: Writable; read(): string } {
+  let text = "";
+  return {
+    stream: new Writable({
+      write(chunk, _encoding, callback) {
+        text += String(chunk);
+        callback();
+      },
+    }),
+    read: () => text,
+  };
+}
+
+function terminal() {
+  const stdout = capture();
+  const stderr = capture();
+  return {
+    stdout,
+    stderr,
+    value: {
+      input: new PassThrough(),
+      stdout: stdout.stream,
+      stderr: stderr.stream,
+      isTTY: false,
+    },
+  };
+}
+
+const registered = (running = true, pid: number | null = 42): DaemonServiceSnapshot => ({
+  kind: "registered",
+  label: "ai.enduragent.coach.synthetic",
+  installed: true,
+  loaded: true,
+  running,
+  pid: running ? pid : null,
+});
+
+const absent: DaemonServiceSnapshot = {
+  kind: "absent",
+  label: "ai.enduragent.coach.synthetic",
+  installed: false,
+  loaded: false,
+  running: false,
+  pid: null,
+};
+
+const unknown: DaemonServiceSnapshot = {
+  kind: "unknown",
+  label: "ai.enduragent.coach.synthetic",
+  installed: null,
+  loaded: null,
+  running: null,
+  pid: null,
+};
+
+function controller(snapshot: DaemonServiceSnapshot): CoachDaemonController {
+  return {
+    supported: true,
+    install: vi.fn(async () => snapshot),
+    status: vi.fn(async () => snapshot),
+    restart: vi.fn(async () => snapshot),
+  };
+}
+
+describe("daemon command", () => {
+  it("parses only the three exact additive forms", () => {
+    for (const action of ["install", "status", "restart"] as const) {
+      expect(parseCoachCliInvocation(["daemon", action])).toEqual({ kind: "daemon", action });
+    }
+    for (const argv of [["daemon"], ["daemon", "stop"], ["daemon", "status", "extra"]]) {
+      expect(parseCoachCliInvocation(argv)).toEqual({
+        kind: "usage",
+        message: "Usage: enduragent [version|serve]",
+      });
+    }
+  });
+
+  it.each([
+    [
+      "install",
+      registered(),
+      "Enduragent service installed (ai.enduragent.coach.synthetic).\n",
+      "",
+      EXIT_SUCCESS,
+    ],
+    [
+      "restart",
+      registered(),
+      "Enduragent service restarted (ai.enduragent.coach.synthetic).\n",
+      "",
+      EXIT_SUCCESS,
+    ],
+    [
+      "status",
+      registered(),
+      "Enduragent service is running (ai.enduragent.coach.synthetic, pid 42).\n",
+      "",
+      EXIT_SUCCESS,
+    ],
+    [
+      "status",
+      registered(true, null),
+      "Enduragent service is running (ai.enduragent.coach.synthetic, pid unknown).\n",
+      "",
+      EXIT_SUCCESS,
+    ],
+    [
+      "status",
+      registered(false),
+      "Enduragent service is registered but stopped (ai.enduragent.coach.synthetic).\n",
+      "",
+      EXIT_DAEMON_UNAVAILABLE,
+    ],
+    [
+      "status",
+      absent,
+      "Enduragent service is not installed (ai.enduragent.coach.synthetic).\n",
+      "",
+      EXIT_DAEMON_UNAVAILABLE,
+    ],
+    ["status", unknown, "", "Enduragent service status is unavailable.\n", EXIT_DAEMON_UNAVAILABLE],
+  ] as const)(
+    "renders %s without cross-stream output",
+    async (action, snapshot, stdout, stderr, exit) => {
+      const io = terminal();
+      await expect(
+        runCoachDaemonCommand({ action, controller: controller(snapshot), terminal: io.value }),
+      ).resolves.toBe(exit);
+      expect(io.stdout.read()).toBe(stdout);
+      expect(io.stderr.read()).toBe(stderr);
+    },
+  );
+
+  it("short-circuits unsupported platforms without a controller call", async () => {
+    const io = terminal();
+    const service = controller(registered());
+    Object.defineProperty(service, "supported", { value: false });
+    await expect(
+      runCoachDaemonCommand({ action: "install", controller: service, terminal: io.value }),
+    ).resolves.toBe(EXIT_USAGE);
+    expect(service.install).not.toHaveBeenCalled();
+    expect(io.stdout.read()).toBe("");
+    expect(io.stderr.read()).toBe("Enduragent service management is available only on macOS.\n");
+  });
+
+  it("redacts rejections and rejects absent mutation results", async () => {
+    for (const service of [
+      {
+        ...controller(absent),
+        install: async () => {
+          throw new Error("sensitive detail");
+        },
+      },
+      controller(absent),
+    ]) {
+      const io = terminal();
+      await expect(
+        runCoachDaemonCommand({ action: "install", controller: service, terminal: io.value }),
+      ).resolves.toBe(EXIT_AGENT_ERROR);
+      expect(io.stdout.read()).toBe("");
+      expect(io.stderr.read()).toBe("Enduragent service command failed.\n");
+    }
+  });
+
+  it("keeps the R6 source boundary free of host packages", async () => {
+    const source = await readFile(new URL("../src/verbs/daemon.ts", import.meta.url), "utf8");
+    expect(source).not.toMatch(/@enduragent\/(?:kernel-node|coach|engine|kernel)(?:\/|["'])/);
+  });
+});

--- a/packages/coach-cli/tests/verbs-rpc.test.ts
+++ b/packages/coach-cli/tests/verbs-rpc.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  CoachRemoteError,
+  connectRemoteCoachTransport,
+  connectWithBoundedRetry,
+  type CoachVerbTransport,
+} from "../src/index.js";
+
+const transport: CoachVerbTransport = {
+  kind: "remote",
+  request: async () => {
+    throw new Error("unused");
+  },
+  close: async () => {},
+};
+
+describe("bounded remote connection", () => {
+  it("attempts immediately and pins 50/100/200 delays", async () => {
+    const connect = vi
+      .fn()
+      .mockRejectedValueOnce(new CoachRemoteError({ kind: "unavailable" }))
+      .mockRejectedValueOnce(new CoachRemoteError({ kind: "unavailable" }))
+      .mockRejectedValueOnce(new CoachRemoteError({ kind: "unavailable" }))
+      .mockResolvedValueOnce(transport);
+    let now = 0;
+    const delays: number[] = [];
+    await expect(
+      connectWithBoundedRetry({
+        connect,
+        delay: async (ms) => {
+          delays.push(ms);
+          now += ms;
+        },
+        monotonicNow: () => now,
+      }),
+    ).resolves.toBe(transport);
+    expect(connect).toHaveBeenCalledTimes(4);
+    expect(delays).toEqual([50, 100, 200]);
+  });
+
+  it("stops at 5000ms and propagates non-unavailable failures immediately", async () => {
+    let now = 0;
+    const delays: number[] = [];
+    await expect(
+      connectWithBoundedRetry({
+        connect: async () => {
+          throw new CoachRemoteError({ kind: "unavailable" });
+        },
+        delay: async (ms) => {
+          delays.push(ms);
+          now += ms;
+        },
+        monotonicNow: () => now,
+      }),
+    ).rejects.toMatchObject({ failure: { kind: "unavailable" } });
+    expect(delays.reduce((sum, value) => sum + value, 0)).toBe(5_000);
+    const mismatch = new CoachRemoteError({ kind: "version-mismatch", direction: "client-newer" });
+    const delay = vi.fn();
+    await expect(
+      connectWithBoundedRetry({
+        connect: async () => {
+          throw mismatch;
+        },
+        delay,
+        monotonicNow: () => 0,
+      }),
+    ).rejects.toBe(mismatch);
+    expect(delay).not.toHaveBeenCalled();
+  });
+
+  it("resumes a registered service once and never spawns a competitor", async () => {
+    const connect = vi
+      .fn()
+      .mockRejectedValueOnce(new CoachRemoteError({ kind: "unavailable" }))
+      .mockResolvedValueOnce(transport);
+    const resumeService = vi.fn(async () => "resumed" as const);
+    const startEphemeralDaemon = vi.fn();
+    await expect(
+      connectRemoteCoachTransport({
+        connect,
+        serviceRegistrationState: async () => "present",
+        resumeService,
+        startEphemeralDaemon,
+        delay: async () => {},
+        monotonicNow: () => 0,
+      }),
+    ).resolves.toBe(transport);
+    expect(resumeService).toHaveBeenCalledTimes(1);
+    expect(startEphemeralDaemon).not.toHaveBeenCalled();
+  });
+});

--- a/packages/coach/src/enduragent.ts
+++ b/packages/coach/src/enduragent.ts
@@ -1,8 +1,10 @@
 #!/usr/bin/env node
 import { spawn } from "node:child_process";
+import { createReadStream } from "node:fs";
 import { readFile, realpath } from "node:fs/promises";
 import { homedir } from "node:os";
-import { join, resolve } from "node:path";
+import { isAbsolute, join, resolve } from "node:path";
+import { performance } from "node:perf_hooks";
 import { fileURLToPath } from "node:url";
 import {
   DaemonOwnerSchema,
@@ -12,6 +14,8 @@ import {
   EXIT_SUCCESS,
   EXIT_USAGE,
   EXIT_VERSION_MISMATCH,
+  PROTOCOL_VERSION,
+  ServerHandshakeFrameSchema,
   type DaemonOwner,
   type ExitCode,
 } from "@enduragent/coach-contract";
@@ -20,22 +24,57 @@ import {
   CoachRemoteError,
   InvalidCoachCliSessionError,
   connectCoachVerbTransport,
-  connectRemoteCoachTransport,
+  connectWithBoundedRetry,
   createCoachVerbRequest,
   createLocalCoachVerbTransport,
   parseCoachCliInvocation,
   resolveCoachCliSession,
   runCoachRepl,
+  runCoachDaemonCommand,
   runCoachVerb,
+  type CoachDaemonController,
   type CoachCliTerminal,
   type CoachCliVerbInvocation,
+  type CoachRemoteFailure,
   type CoachVerbRequest,
   type CoachVerbTransport,
+  type DaemonServiceSnapshot,
   type ServiceRegistrationState,
 } from "@enduragent/coach-cli";
 import { expandTilde, resolveAthleteHome, type AthleteHome } from "@enduragent/kernel-node/home";
 import { PORT_FILE_NAME } from "@enduragent/kernel-node/lock";
+import {
+  canonicalizeAthleteHome,
+  createLaunchdServiceIdentity,
+  installLaunchdService,
+  readLaunchdServiceStatus,
+  restartLaunchdService,
+  restartLaunchdServiceForUpgrade,
+  resumeLaunchdService,
+  resumeLaunchdServiceAfterEphemeral,
+  type LaunchdServiceStatus,
+} from "@enduragent/kernel-node/service";
 import { StoreNewerThanAppError } from "@enduragent/kernel/store";
+import {
+  classifyPeerReadOnly,
+  observePeerHandshake,
+  openAuthenticatedDaemonControl,
+  resolveSecondStarter as resolveSecondStarterProduction,
+  type CompatiblePeerWaitOutcome,
+  type DesignatedSuccessorInput,
+  type ReadOnlyPeerClassification,
+  type ResolveSecondStarterDependencies,
+  type ResolveSecondStarterInput,
+  type ServiceUpgradePort,
+  type StarterResolution,
+  type WriterReleaseWaitOutcome,
+} from "./daemon/handshake.js";
+import {
+  acquireUpgradeFence,
+  admitStartupThroughUpgradeFence,
+  type MonotonicTimer,
+  type UpgradeFenceHandle,
+} from "./daemon/upgrade-fence.js";
 import {
   withLocalCoach,
   type LocalCoachRunResult,
@@ -55,11 +94,15 @@ export interface EnduragentDependencies {
   readonly resolveAthleteHome: (env: Record<string, string | undefined>) => AthleteHome;
   readonly withLocalCoach: <T>(input: WithLocalCoachInput<T>) => Promise<LocalCoachRunResult<T>>;
   readonly readPackageVersion: () => Promise<string>;
-  readonly connectRemoteTransport?: (home: AthleteHome) => Promise<CoachVerbTransport>;
+  readonly connectRemoteTransport?: (
+    home: AthleteHome,
+    expectedPort?: number,
+  ) => Promise<CoachVerbTransport>;
   readonly serviceRegistrationState?: () => Promise<ServiceRegistrationState>;
   readonly startEphemeralDaemon?: (input: {
     readonly env: Record<string, string | undefined>;
     readonly home: AthleteHome;
+    readonly executablePath?: string;
   }) => Promise<{
     readonly disposeAfterFailedStart: () => Promise<void>;
     readonly detachAfterHealthy: () => void;
@@ -67,6 +110,71 @@ export interface EnduragentDependencies {
   readonly delay?: (ms: number) => Promise<void>;
   readonly monotonicNow?: () => number;
   readonly createFreshId?: () => string;
+  readonly resolveExecutablePath?: () => Promise<string>;
+  readonly createDaemonController?: (input: {
+    readonly home: AthleteHome;
+    readonly executablePath: string;
+  }) => CoachDaemonController;
+  readonly readServiceStatus?: (input: {
+    readonly home: AthleteHome;
+    readonly executablePath: string;
+  }) => Promise<LaunchdServiceStatus>;
+  readonly resumeService?: (input: {
+    readonly home: AthleteHome;
+    readonly executablePath: string;
+  }) => Promise<"resumed" | "not-installed">;
+  readonly observeDaemonState?: (input: {
+    readonly home: AthleteHome;
+  }) => Promise<DaemonStateObservation>;
+  readonly startEphemeralSuccessor?: (input: DesignatedSuccessorInput) => Promise<void>;
+  readonly resolveSecondStarter?: (
+    input: ResolveSecondStarterInput,
+    dependencies: ResolveSecondStarterDependencies,
+  ) => Promise<StarterResolution>;
+  readonly platform?: NodeJS.Platform;
+}
+
+export type ServiceRegistrationClass = "absent" | "registered" | "unknown";
+
+export type DaemonStateObservation =
+  | {
+      readonly kind: "compatible-healthy";
+      readonly peer: {
+        readonly pid: number | null;
+        readonly port: number;
+        readonly peerVersion: string;
+      };
+      readonly serverProtocolVersion: number;
+    }
+  | { readonly kind: "absent" }
+  | { readonly kind: "bound-unresponsive" }
+  | { readonly kind: "foreign" }
+  | { readonly kind: "auth-invalid" }
+  | {
+      readonly kind: "version-mismatch";
+      readonly failure: Extract<CoachRemoteFailure, { kind: "version-mismatch" }>;
+    };
+
+export type PeerAvailabilityClass = DaemonStateObservation["kind"];
+
+export type ServiceAwareAutoStartDecision =
+  | "attach"
+  | "resume-service-then-attach"
+  | "spawn-ephemeral"
+  | "refuse-daemon-unavailable";
+
+export function decideServiceAwareAutoStart(input: {
+  readonly registration: ServiceRegistrationClass;
+  readonly peer: PeerAvailabilityClass;
+}): ServiceAwareAutoStartDecision {
+  if (input.peer === "compatible-healthy") return "attach";
+  if (input.registration === "registered" && input.peer === "absent") {
+    return "resume-service-then-attach";
+  }
+  if (input.registration === "absent" && input.peer === "absent") {
+    return "spawn-ephemeral";
+  }
+  return "refuse-daemon-unavailable";
 }
 
 async function readPackageVersion(): Promise<string> {
@@ -82,20 +190,171 @@ async function readPackageVersion(): Promise<string> {
   return version;
 }
 
+interface DaemonCoordinates {
+  readonly port: number;
+  readonly token: string;
+}
+
+async function readDaemonCoordinates(home: AthleteHome): Promise<DaemonCoordinates> {
+  const [rawPort, rawToken] = await Promise.all([
+    readFile(join(home.configDir, PORT_FILE_NAME), "utf8"),
+    readFile(join(home.configDir, "daemon.token"), "utf8"),
+  ]);
+  const port = Number(rawPort.trim());
+  const token = rawToken.endsWith("\n") ? rawToken.slice(0, -1) : "";
+  if (!Number.isInteger(port) || port < 1 || port > 65_535 || !/^[A-Za-z0-9_-]{43}$/.test(token)) {
+    throw new TypeError("invalid daemon coordinates");
+  }
+  return { port, token };
+}
+
+export interface ObserveDaemonStateDependencies {
+  readonly classifyPeerReadOnly: typeof classifyPeerReadOnly;
+  readonly observePeerHandshake: typeof observePeerHandshake;
+  readonly readDaemonCoordinates: (home: AthleteHome) => Promise<DaemonCoordinates>;
+}
+
+const observeDaemonStateDependencies: ObserveDaemonStateDependencies = {
+  classifyPeerReadOnly,
+  observePeerHandshake,
+  readDaemonCoordinates,
+};
+
+export async function observeDaemonState(
+  input: { readonly home: AthleteHome },
+  dependencies: ObserveDaemonStateDependencies = observeDaemonStateDependencies,
+): Promise<DaemonStateObservation> {
+  let classified: ReadOnlyPeerClassification;
+  try {
+    classified = await dependencies.classifyPeerReadOnly(input.home);
+  } catch {
+    return { kind: "auth-invalid" };
+  }
+  if (classified.status === "writer-clear") return { kind: "absent" };
+  if (classified.status === "bound-unresponsive") return { kind: "bound-unresponsive" };
+  if (classified.status === "foreign-port") return { kind: "foreign" };
+  try {
+    const coordinates = await dependencies.readDaemonCoordinates(input.home);
+    if (coordinates.port !== classified.peer.port) return { kind: "auth-invalid" };
+    const { token } = coordinates;
+    const frame = ServerHandshakeFrameSchema.parse(
+      await dependencies.observePeerHandshake({
+        port: classified.peer.port,
+        token,
+        clientProtocolVersion: PROTOCOL_VERSION,
+      }),
+    );
+    if (frame.clientProtocolVersion !== PROTOCOL_VERSION) {
+      return { kind: "auth-invalid" };
+    }
+    if (
+      frame.status === "accepted" &&
+      frame.clientProtocolVersion === PROTOCOL_VERSION &&
+      frame.serverProtocolVersion === PROTOCOL_VERSION
+    ) {
+      return {
+        kind: "compatible-healthy",
+        peer: {
+          pid: classified.peer.pid,
+          port: classified.peer.port,
+          peerVersion: classified.peer.peerVersion,
+        },
+        serverProtocolVersion: frame.serverProtocolVersion,
+      };
+    }
+    if (frame.status === "version-mismatch") {
+      return {
+        kind: "version-mismatch",
+        failure: { kind: "version-mismatch", direction: frame.direction },
+      };
+    }
+    return { kind: "auth-invalid" };
+  } catch {
+    return { kind: "auth-invalid" };
+  }
+}
+
+async function resolveExecutablePath(): Promise<string> {
+  const executable = process.argv[1];
+  if (executable === undefined || executable.length === 0 || !isAbsolute(executable)) {
+    throw new TypeError("invalid executable path");
+  }
+  return realpath(resolve(executable));
+}
+
+async function resolveConfiguredExecutable(dependencies: EnduragentDependencies): Promise<string> {
+  const executablePath = await dependencies.resolveExecutablePath!();
+  if (!isAbsolute(executablePath)) throw new TypeError("invalid executable path");
+  return executablePath;
+}
+
+function serviceSnapshot(status: LaunchdServiceStatus): DaemonServiceSnapshot {
+  if (status.kind === "absent") {
+    return {
+      kind: "absent",
+      label: status.label,
+      installed: false,
+      loaded: false,
+      running: false,
+      pid: null,
+    };
+  }
+  if (status.kind === "registered") {
+    return {
+      kind: "registered",
+      label: status.label,
+      installed: status.installed,
+      loaded: status.loaded,
+      running: status.running,
+      pid: status.pid,
+    };
+  }
+  return {
+    kind: "unknown",
+    label: status.label,
+    installed: status.installed,
+    loaded: null,
+    running: null,
+    pid: null,
+  };
+}
+
+function createDaemonController(input: {
+  readonly home: AthleteHome;
+  readonly executablePath: string;
+}): CoachDaemonController {
+  const identity = createLaunchdServiceIdentity(input);
+  return {
+    supported: process.platform === "darwin",
+    install: async () => serviceSnapshot(await installLaunchdService(identity)),
+    status: async () => serviceSnapshot(await readLaunchdServiceStatus(identity)),
+    restart: async () => serviceSnapshot(await restartLaunchdService(identity)),
+  };
+}
+
+async function defaultReadServiceStatus(input: {
+  readonly home: AthleteHome;
+  readonly executablePath: string;
+}): Promise<LaunchdServiceStatus> {
+  return readLaunchdServiceStatus(createLaunchdServiceIdentity(input));
+}
+
+async function defaultResumeService(input: {
+  readonly home: AthleteHome;
+  readonly executablePath: string;
+}): Promise<"resumed" | "not-installed"> {
+  return resumeLaunchdService(createLaunchdServiceIdentity(input));
+}
+
 const defaultDependencies: EnduragentDependencies = Object.freeze({
   resolveAthleteHome,
   withLocalCoach,
   readPackageVersion,
-  connectRemoteTransport: async (home: AthleteHome) => {
+  connectRemoteTransport: async (home: AthleteHome, expectedPort?: number) => {
     try {
-      const [rawPort, rawToken] = await Promise.all([
-        readFile(join(home.configDir, PORT_FILE_NAME), "utf8"),
-        readFile(join(home.configDir, "daemon.token"), "utf8"),
-      ]);
-      const port = Number(rawPort.trim());
-      const token = rawToken.endsWith("\n") ? rawToken.slice(0, -1) : "";
-      if (!Number.isInteger(port) || port < 1 || port > 65_535 || token.length === 0) {
-        throw new TypeError("invalid daemon coordinates");
+      const { port, token } = await readDaemonCoordinates(home);
+      if (expectedPort !== undefined && expectedPort !== port) {
+        throw new TypeError("daemon peer changed");
       }
       return await connectCoachVerbTransport({
         url: `ws://127.0.0.1:${port}/rpc`,
@@ -110,6 +369,14 @@ const defaultDependencies: EnduragentDependencies = Object.freeze({
   startEphemeralDaemon: startEphemeralDaemonProcess,
   delay: (ms: number) => new Promise<void>((resolveDelay) => setTimeout(resolveDelay, ms)),
   monotonicNow: () => performance.now(),
+  resolveExecutablePath,
+  createDaemonController,
+  readServiceStatus: defaultReadServiceStatus,
+  resumeService: defaultResumeService,
+  observeDaemonState,
+  startEphemeralSuccessor: startEphemeralSuccessorProcess,
+  resolveSecondStarter: resolveSecondStarterProduction,
+  platform: process.platform,
 });
 
 function childEnvironment(
@@ -120,7 +387,9 @@ function childEnvironment(
     ...process.env,
     ...env,
     ENDURAGENT_HOME: home.root,
-    ENDURAGENT_DAEMON_OWNER: "ephemeral-client-started",
+    ENDURAGENT_DAEMON_OWNER: undefined,
+    ENDURAGENT_HANDOFF_CAPABILITY: undefined,
+    ENDURAGENT_STARTER_CONTEXT_FD: "3",
     FORCE_COLOR: undefined,
     CLICOLOR_FORCE: undefined,
   };
@@ -129,27 +398,60 @@ function childEnvironment(
   );
 }
 
+function starterContextLine(successor?: DesignatedSuccessorInput): string {
+  return `${JSON.stringify(
+    successor === undefined
+      ? { owner: "ephemeral-client-started" }
+      : {
+          owner: "ephemeral-client-started",
+          targetProtocolVersion: successor.targetProtocolVersion,
+          handoffCapability: successor.handoffCapability,
+        },
+  )}\n`;
+}
+
+function writeStarterContext(child: ReturnType<typeof spawn>, line: string): Promise<void> {
+  const stream = child.stdio[3];
+  if (stream === null || typeof (stream as { end?: unknown }).end !== "function") {
+    return Promise.reject(new Error("starter context pipe unavailable"));
+  }
+  return new Promise((resolveWrite, rejectWrite) => {
+    const writable = stream as NodeJS.WritableStream;
+    const onError = (): void => rejectWrite(new Error("starter context write failed"));
+    writable.once("error", onError);
+    writable.end(line, "utf8", () => {
+      writable.removeListener("error", onError);
+      resolveWrite();
+    });
+  });
+}
+
 async function startEphemeralDaemonProcess(input: {
   readonly env: Record<string, string | undefined>;
   readonly home: AthleteHome;
+  readonly executablePath?: string;
+  readonly successor?: DesignatedSuccessorInput;
 }): Promise<{
   readonly disposeAfterFailedStart: () => Promise<void>;
   readonly detachAfterHealthy: () => void;
 }> {
-  const entry = process.argv[1];
-  if (entry === undefined) throw new CoachRemoteError({ kind: "unavailable" });
-  let child: ReturnType<typeof spawn>;
+  const executablePath = input.executablePath ?? (await resolveExecutablePath());
+  let child!: ReturnType<typeof spawn>;
   try {
-    child = spawn(process.execPath, [entry, "serve"], {
+    child = spawn(executablePath, ["serve"], {
       detached: true,
       env: childEnvironment(input.env, input.home),
-      stdio: "ignore",
+      stdio: ["ignore", "ignore", "ignore", "pipe"],
     });
     await new Promise<void>((resolveSpawn, rejectSpawn) => {
       child.once("spawn", resolveSpawn);
       child.once("error", rejectSpawn);
     });
+    await writeStarterContext(child, starterContextLine(input.successor));
   } catch {
+    try {
+      child?.kill("SIGTERM");
+    } catch {}
     throw new CoachRemoteError({ kind: "unavailable" });
   }
   return {
@@ -168,6 +470,16 @@ async function startEphemeralDaemonProcess(input: {
     },
     detachAfterHealthy: () => child.unref(),
   };
+}
+
+async function startEphemeralSuccessorProcess(input: DesignatedSuccessorInput): Promise<void> {
+  const child = await startEphemeralDaemonProcess({
+    env: process.env,
+    home: input.home,
+    executablePath: await resolveExecutablePath(),
+    successor: input,
+  });
+  child.detachAfterHealthy();
 }
 
 function resolveLegacySourceRoot(env: Record<string, string | undefined>): string {
@@ -227,9 +539,108 @@ async function readStdinText(input: NodeJS.ReadableStream): Promise<string> {
   return text;
 }
 
-function daemonOwner(env: Record<string, string | undefined>): DaemonOwner {
-  const parsed = DaemonOwnerSchema.safeParse(env.ENDURAGENT_DAEMON_OWNER);
-  return parsed.success ? parsed.data : "unmanaged-foreground";
+interface ServeStarterContext {
+  readonly owner: DaemonOwner;
+  readonly handoffCapability?: string;
+}
+
+function readStarterContextFd(): Promise<string> {
+  return new Promise((resolveContext, rejectContext) => {
+    const stream = createReadStream("/dev/null", { fd: 3, autoClose: true });
+    const chunks: Buffer[] = [];
+    let size = 0;
+    let settled = false;
+    const timeout = setTimeout(() => finish(new Error("starter context timed out")), 5_000);
+    timeout.unref?.();
+    const finish = (error?: Error): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      stream.removeAllListeners();
+      if (error !== undefined) {
+        stream.destroy();
+        rejectContext(error);
+        return;
+      }
+      try {
+        const bytes = Buffer.concat(chunks);
+        const newline = bytes.indexOf(0x0a);
+        if (newline !== bytes.length - 1 || bytes.indexOf(0x0a, newline + 1) !== -1) {
+          throw new TypeError("invalid starter context framing");
+        }
+        resolveContext(new TextDecoder("utf-8", { fatal: true }).decode(bytes.subarray(0, -1)));
+      } catch (decodeError) {
+        rejectContext(decodeError);
+      }
+    };
+    stream.on("data", (chunk: Buffer) => {
+      size += chunk.length;
+      if (size > 4_096) {
+        finish(new Error("starter context is too large"));
+        return;
+      }
+      chunks.push(chunk);
+    });
+    stream.once("end", () => finish());
+    stream.once("error", () => finish(new Error("starter context read failed")));
+  });
+}
+
+async function serveStarterContext(
+  env: Record<string, string | undefined>,
+): Promise<ServeStarterContext> {
+  const fd = env.ENDURAGENT_STARTER_CONTEXT_FD;
+  const ownerValue = env.ENDURAGENT_DAEMON_OWNER;
+  const launchdCapability = env.ENDURAGENT_HANDOFF_CAPABILITY;
+  delete env.ENDURAGENT_STARTER_CONTEXT_FD;
+  delete env.ENDURAGENT_DAEMON_OWNER;
+  delete env.ENDURAGENT_HANDOFF_CAPABILITY;
+
+  if (fd !== undefined) {
+    if (fd !== "3" || ownerValue !== undefined || launchdCapability !== undefined) {
+      throw new TypeError("invalid starter context source");
+    }
+    const parsed: unknown = JSON.parse(await readStarterContextFd());
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new TypeError("invalid starter context");
+    }
+    const record = parsed as Record<string, unknown>;
+    const keys = Object.keys(record).sort();
+    const owner = DaemonOwnerSchema.parse(record.owner);
+    if (owner !== "ephemeral-client-started") {
+      throw new TypeError("invalid starter owner");
+    }
+    if (keys.length === 1 && keys[0] === "owner") {
+      return { owner };
+    }
+    if (
+      keys.length !== 3 ||
+      keys[0] !== "handoffCapability" ||
+      keys[1] !== "owner" ||
+      keys[2] !== "targetProtocolVersion" ||
+      record.targetProtocolVersion !== PROTOCOL_VERSION ||
+      typeof record.handoffCapability !== "string" ||
+      !/^[A-Za-z0-9_-]{43}$/.test(record.handoffCapability)
+    ) {
+      throw new TypeError("invalid designated starter context");
+    }
+    return {
+      owner,
+      handoffCapability: record.handoffCapability,
+    };
+  }
+
+  if (ownerValue === undefined && launchdCapability === undefined) {
+    return { owner: "unmanaged-foreground" };
+  }
+  const owner = DaemonOwnerSchema.parse(ownerValue);
+  if (owner !== "service-managed") throw new TypeError("invalid launchd starter owner");
+  if (launchdCapability !== undefined && !/^[A-Za-z0-9_-]{43}$/.test(launchdCapability)) {
+    throw new TypeError("invalid launchd handoff capability");
+  }
+  return launchdCapability === undefined
+    ? { owner }
+    : { owner, handoffCapability: launchdCapability };
 }
 
 function writeContention(
@@ -326,6 +737,228 @@ function remoteConnectionFailure(
   }
 }
 
+function sameAthleteHome(left: AthleteHome, right: AthleteHome): boolean {
+  return (
+    left.root === right.root &&
+    left.storeDir === right.storeDir &&
+    left.archiveDir === right.archiveDir &&
+    left.configDir === right.configDir
+  );
+}
+
+function canonicalHome(home: AthleteHome): AthleteHome {
+  const canonical = canonicalizeAthleteHome(home);
+  return sameAthleteHome(home, canonical) ? home : canonical;
+}
+
+function validateSuccessorInput(home: AthleteHome, input: DesignatedSuccessorInput): void {
+  if (
+    home.root !== input.home.root ||
+    input.targetProtocolVersion !== PROTOCOL_VERSION ||
+    !/^[A-Za-z0-9_-]{43}$/.test(input.handoffCapability)
+  ) {
+    throw new TypeError("invalid designated successor");
+  }
+}
+
+export interface ServiceUpgradeBindingDependencies {
+  readonly readStatus: () => Promise<LaunchdServiceStatus>;
+  readonly restartInstalled: (input: DesignatedSuccessorInput) => Promise<void>;
+  readonly resumeAfterEphemeral: (input: DesignatedSuccessorInput) => Promise<void>;
+  readonly startEphemeral: (input: DesignatedSuccessorInput) => Promise<void>;
+}
+
+export function createServiceUpgradePort(
+  home: AthleteHome,
+  dependencies: ServiceUpgradeBindingDependencies,
+): ServiceUpgradePort {
+  return {
+    async isInstalled(inputHome) {
+      if (home.root !== inputHome.root) throw new TypeError("athlete home changed");
+      const status = await dependencies.readStatus();
+      if (status.kind === "registered") return true;
+      if (status.kind === "absent") return false;
+      throw new Error("service status unavailable");
+    },
+    async restartInstalledService(input) {
+      validateSuccessorInput(home, input);
+      await dependencies.restartInstalled(input);
+    },
+    async kickstartInstalledServiceAfterEphemeral(input) {
+      validateSuccessorInput(home, input);
+      await dependencies.resumeAfterEphemeral(input);
+    },
+    async startEphemeralSuccessor(input) {
+      validateSuccessorInput(home, input);
+      await dependencies.startEphemeral(input);
+    },
+  };
+}
+
+function productionMonotonicTimer(now: () => number): MonotonicTimer {
+  return {
+    nowMs: now,
+    schedule(delayMs, callback) {
+      const timeout = setTimeout(callback, Math.max(0, delayMs));
+      timeout.unref?.();
+      return { cancel: () => clearTimeout(timeout) };
+    },
+  };
+}
+
+function timerDelay(timer: MonotonicTimer, delayMs: number): Promise<void> {
+  return new Promise((resolveDelay) => {
+    timer.schedule(delayMs, resolveDelay);
+  });
+}
+
+async function waitForWriterRelease(input: {
+  readonly home: AthleteHome;
+  readonly incumbent: { readonly port: number; readonly peerVersion: string };
+  readonly deadlineMs: number;
+  readonly pollIntervalMs: number;
+  readonly timer: MonotonicTimer;
+}): Promise<WriterReleaseWaitOutcome> {
+  while (input.timer.nowMs() < input.deadlineMs) {
+    let classified: ReadOnlyPeerClassification;
+    try {
+      classified = await classifyPeerReadOnly(input.home);
+    } catch {
+      return { status: "observation-invalid" };
+    }
+    if (classified.status === "writer-clear") return { status: "released" };
+    if (classified.status === "foreign-port") return { status: "observation-invalid" };
+    if (
+      classified.status === "peer-healthy" &&
+      (classified.peer.port !== input.incumbent.port ||
+        classified.peer.peerVersion !== input.incumbent.peerVersion)
+    ) {
+      return { status: "observation-invalid" };
+    }
+    await timerDelay(
+      input.timer,
+      Math.min(input.pollIntervalMs, input.deadlineMs - input.timer.nowMs()),
+    );
+  }
+  return { status: "timeout" };
+}
+
+class CompatiblePeerObservationError extends Error {
+  constructor(
+    readonly outcome: Exclude<CompatiblePeerWaitOutcome, { status: "published" | "timeout" }>,
+  ) {
+    super("compatible peer observation failed");
+  }
+}
+
+const observationTransport: CoachVerbTransport = {
+  kind: "remote",
+  request: async () => {
+    throw new CoachRemoteError({ kind: "agent" });
+  },
+  close: async () => {},
+};
+
+async function waitForCompatiblePeer(input: {
+  readonly home: AthleteHome;
+  readonly protocolVersion: number;
+  readonly token: string;
+  readonly deadlineMs: number;
+  readonly pollIntervalMs: number;
+  readonly timer: MonotonicTimer;
+}): Promise<CompatiblePeerWaitOutcome> {
+  let published: Extract<CompatiblePeerWaitOutcome, { status: "published" }> | undefined;
+  while (input.timer.nowMs() < input.deadlineMs) {
+    try {
+      await connectWithBoundedRetry({
+        connect: async () => {
+          let classified: ReadOnlyPeerClassification;
+          try {
+            classified = await classifyPeerReadOnly(input.home);
+          } catch {
+            throw new CompatiblePeerObservationError({ status: "observation-invalid" });
+          }
+          if (classified.status === "writer-clear" || classified.status === "bound-unresponsive") {
+            throw new CoachRemoteError({ kind: "unavailable" });
+          }
+          if (classified.status === "foreign-port") {
+            throw new CompatiblePeerObservationError({ status: "observation-invalid" });
+          }
+          let handshake: Awaited<ReturnType<typeof observePeerHandshake>>;
+          try {
+            handshake = await observePeerHandshake({
+              port: classified.peer.port,
+              token: input.token,
+              clientProtocolVersion: input.protocolVersion,
+            });
+          } catch {
+            throw new CompatiblePeerObservationError({ status: "observation-invalid" });
+          }
+          if (handshake.status === "version-mismatch") {
+            throw new CompatiblePeerObservationError({ status: "incompatible", handshake });
+          }
+          if (
+            handshake.clientProtocolVersion !== input.protocolVersion ||
+            handshake.serverProtocolVersion !== input.protocolVersion
+          ) {
+            throw new CompatiblePeerObservationError({ status: "observation-invalid" });
+          }
+          published = {
+            status: "published",
+            peer: classified.peer,
+            handshake,
+          };
+          return observationTransport;
+        },
+        delay: (delayMs) => timerDelay(input.timer, Math.max(input.pollIntervalMs, delayMs)),
+        monotonicNow: input.timer.nowMs,
+      });
+      return published!;
+    } catch (error) {
+      if (error instanceof CompatiblePeerObservationError) return error.outcome;
+      if (!(error instanceof CoachRemoteError) || error.failure.kind !== "unavailable") {
+        return { status: "observation-invalid" };
+      }
+    }
+  }
+  return { status: "timeout" };
+}
+
+function createSecondStarterDependencies(input: {
+  readonly home: AthleteHome;
+  readonly executablePath: string;
+  readonly dependencies: EnduragentDependencies;
+}): ResolveSecondStarterDependencies {
+  const identity = createLaunchdServiceIdentity({
+    home: input.home,
+    executablePath: input.executablePath,
+  });
+  const serviceUpgrade = createServiceUpgradePort(input.home, {
+    readStatus: () =>
+      input.dependencies.readServiceStatus!({
+        home: input.home,
+        executablePath: input.executablePath,
+      }),
+    restartInstalled: async (successor) => {
+      await restartLaunchdServiceForUpgrade(identity, successor);
+    },
+    resumeAfterEphemeral: async (successor) => {
+      await resumeLaunchdServiceAfterEphemeral(identity, successor);
+    },
+    startEphemeral: input.dependencies.startEphemeralSuccessor!,
+  });
+  return {
+    observePeerHandshake,
+    openUpgradeControl: openAuthenticatedDaemonControl,
+    classifyPeerReadOnly,
+    acquireUpgradeFence,
+    serviceUpgrade,
+    timer: productionMonotonicTimer(input.dependencies.monotonicNow!),
+    waitForWriterRelease,
+    waitForCompatiblePeer,
+  };
+}
+
 async function prepareVerb(
   input: RunEnduragentInput,
   invocation: CoachCliVerbInvocation,
@@ -350,23 +983,170 @@ async function prepareVerb(
   });
 }
 
+async function serviceRegistrationClass(input: {
+  readonly home: AthleteHome;
+  readonly executablePath: string;
+  readonly dependencies: EnduragentDependencies;
+}): Promise<ServiceRegistrationClass> {
+  if (
+    input.dependencies.serviceRegistrationState !== defaultDependencies.serviceRegistrationState
+  ) {
+    const state = await input.dependencies.serviceRegistrationState!();
+    return state === "present" ? "registered" : state;
+  }
+  return (
+    await input.dependencies.readServiceStatus!({
+      home: input.home,
+      executablePath: input.executablePath,
+    })
+  ).kind;
+}
+
+async function connectAfterEphemeralStart(input: {
+  readonly home: AthleteHome;
+  readonly executablePath: string;
+  readonly env: Record<string, string | undefined>;
+  readonly dependencies: EnduragentDependencies;
+}): Promise<CoachVerbTransport> {
+  const child = await input.dependencies.startEphemeralDaemon!({
+    env: input.env,
+    home: input.home,
+    executablePath: input.executablePath,
+  });
+  try {
+    const transport = await connectWithBoundedRetry({
+      connect: () => input.dependencies.connectRemoteTransport!(input.home),
+      delay: input.dependencies.delay!,
+      monotonicNow: input.dependencies.monotonicNow!,
+    });
+    child.detachAfterHealthy();
+    return transport;
+  } catch (error) {
+    await child.disposeAfterFailedStart();
+    throw error;
+  }
+}
+
+async function connectServiceAwareRemote(input: {
+  readonly home: AthleteHome;
+  readonly env: Record<string, string | undefined>;
+  readonly dependencies: EnduragentDependencies;
+}): Promise<CoachVerbTransport> {
+  let initialVersionMismatch: Extract<CoachRemoteFailure, { kind: "version-mismatch" }> | undefined;
+  try {
+    return await input.dependencies.connectRemoteTransport!(input.home);
+  } catch (error) {
+    if (!(error instanceof CoachRemoteError)) throw error;
+    if (error.failure.kind === "version-mismatch") {
+      initialVersionMismatch = error.failure;
+    } else if (error.failure.kind !== "unavailable") {
+      throw error;
+    }
+  }
+
+  const executablePath = await resolveConfiguredExecutable(input.dependencies);
+  const registration = await serviceRegistrationClass({
+    home: input.home,
+    executablePath,
+    dependencies: input.dependencies,
+  });
+  if (initialVersionMismatch !== undefined) {
+    let classified: ReadOnlyPeerClassification;
+    try {
+      classified = await classifyPeerReadOnly(input.home);
+    } catch {
+      throw new CoachRemoteError(initialVersionMismatch);
+    }
+    if (classified.status !== "peer-healthy") {
+      throw new CoachRemoteError(initialVersionMismatch);
+    }
+    let coordinates: DaemonCoordinates;
+    try {
+      coordinates = await readDaemonCoordinates(input.home);
+    } catch {
+      throw new CoachRemoteError({ kind: "unavailable" });
+    }
+    if (coordinates.port !== classified.peer.port) {
+      throw new CoachRemoteError({ kind: "unavailable" });
+    }
+    const { token: bearerToken } = coordinates;
+    const resolution = await input.dependencies.resolveSecondStarter!(
+      {
+        caller: "cli-auto-start",
+        home: input.home,
+        clientProtocolVersion: PROTOCOL_VERSION,
+        clientAppVersion: await input.dependencies.readPackageVersion(),
+        bearerToken,
+        peer: classified.peer,
+      },
+      createSecondStarterDependencies({
+        home: input.home,
+        executablePath,
+        dependencies: input.dependencies,
+      }),
+    );
+    if (resolution.status === "attach") {
+      return input.dependencies.connectRemoteTransport!(input.home, resolution.port);
+    }
+    if (resolution.status !== "retry-startup") {
+      if (resolution.status === "refuse" && resolution.exitCode === EXIT_VERSION_MISMATCH) {
+        throw new CoachRemoteError(initialVersionMismatch);
+      }
+      throw new CoachRemoteError({ kind: "unavailable" });
+    }
+  }
+  const observation = await input.dependencies.observeDaemonState!({ home: input.home });
+  const decision = decideServiceAwareAutoStart({
+    registration,
+    peer: observation.kind,
+  });
+  if (decision === "attach") {
+    if (observation.kind !== "compatible-healthy") {
+      throw new CoachRemoteError({ kind: "unavailable" });
+    }
+    return input.dependencies.connectRemoteTransport!(input.home, observation.peer.port);
+  }
+  if (decision === "resume-service-then-attach") {
+    const resumed = await input.dependencies.resumeService!({
+      home: input.home,
+      executablePath,
+    });
+    if (resumed !== "resumed") throw new CoachRemoteError({ kind: "unavailable" });
+    return connectWithBoundedRetry({
+      connect: () => input.dependencies.connectRemoteTransport!(input.home),
+      delay: input.dependencies.delay!,
+      monotonicNow: input.dependencies.monotonicNow!,
+    });
+  }
+  if (decision === "spawn-ephemeral") {
+    return connectAfterEphemeralStart({
+      home: input.home,
+      executablePath,
+      env: input.env,
+      dependencies: input.dependencies,
+    });
+  }
+  if (observation.kind === "version-mismatch") {
+    throw new CoachRemoteError(observation.failure);
+  }
+  throw new CoachRemoteError({ kind: "unavailable" });
+}
+
 async function runPreparedVerb(
   input: RunEnduragentInput,
   invocation: CoachCliVerbInvocation,
   request: CoachVerbRequest,
   dependencies: EnduragentDependencies,
 ): Promise<ExitCode> {
-  const home = dependencies.resolveAthleteHome(input.env);
+  const home = canonicalHome(dependencies.resolveAthleteHome(input.env));
   const connect = (): Promise<CoachVerbTransport> => dependencies.connectRemoteTransport!(home);
   if (!invocation.local) {
     let transport: CoachVerbTransport;
     try {
-      transport = await connectRemoteCoachTransport({
-        connect,
-        serviceRegistrationState: dependencies.serviceRegistrationState!,
-        startEphemeralDaemon: () => dependencies.startEphemeralDaemon!({ env: input.env, home }),
-        delay: dependencies.delay!,
-        monotonicNow: dependencies.monotonicNow!,
+      transport = await connectServiceAwareRemote({
+        home,
+        env: input.env,
+        dependencies,
       });
     } catch (error) {
       if (error instanceof CoachRemoteError) {
@@ -417,6 +1197,191 @@ async function runPreparedVerb(
   }
 }
 
+async function runServeAsSuccessor(input: {
+  readonly lifecycle: Parameters<typeof runCoachServe>[0]["lifecycle"];
+  readonly home: AthleteHome;
+  readonly appVersion: string;
+  readonly signal: AbortSignal;
+  readonly owner: DaemonOwner;
+  readonly authentication: string;
+  readonly fence: UpgradeFenceHandle;
+  readonly timer: MonotonicTimer;
+}): Promise<ExitCode> {
+  const { authentication: token } = input;
+  const controller = new AbortController();
+  const servePromise = runCoachServe({
+    lifecycle: input.lifecycle,
+    home: input.home,
+    appVersion: input.appVersion,
+    signal: AbortSignal.any([input.signal, controller.signal]),
+    owner: input.owner,
+  });
+  const stopped = { status: "serve-stopped" } as const;
+  const published = await Promise.race([
+    waitForCompatiblePeer({
+      home: input.home,
+      protocolVersion: PROTOCOL_VERSION,
+      token,
+      deadlineMs: input.timer.nowMs() + 30_000,
+      pollIntervalMs: 25,
+      timer: input.timer,
+    }),
+    servePromise.then(() => stopped),
+  ]);
+  if (published.status !== "published") {
+    controller.abort();
+    await servePromise.catch(() => {});
+    await input.fence.release();
+    throw new Error("designated successor did not publish");
+  }
+  await input.fence.release();
+  return servePromise;
+}
+
+async function runServeInvocation(input: {
+  readonly invocationOwner: DaemonOwner;
+  readonly starterCapability?: string;
+  readonly runInput: RunEnduragentInput;
+  readonly home: AthleteHome;
+  readonly sourceRoot: string;
+  readonly appVersion: string;
+  readonly dependencies: EnduragentDependencies;
+}): Promise<ExitCode> {
+  const admission =
+    input.dependencies.withLocalCoach === defaultDependencies.withLocalCoach
+      ? await admitStartupThroughUpgradeFence({
+          configDir: input.home.configDir,
+          ...(input.starterCapability === undefined
+            ? {}
+            : { handoffCapability: input.starterCapability }),
+        })
+      : { status: "clear" as const };
+  if (admission.status === "reserved") {
+    input.runInput.terminal.stderr.write(admission.message);
+    return EXIT_DAEMON_UNAVAILABLE;
+  }
+
+  let successor:
+    | { readonly fence: UpgradeFenceHandle; readonly authentication: string }
+    | undefined;
+  while (true) {
+    try {
+      const result = await input.dependencies.withLocalCoach({
+        env: input.runInput.env,
+        home: input.home,
+        sourceRoot: input.sourceRoot,
+        action: { kind: "resume", isTTY: input.runInput.terminal.isTTY },
+        operation: async (lifecycle) =>
+          successor === undefined
+            ? runCoachServe({
+                lifecycle,
+                home: input.home,
+                appVersion: input.appVersion,
+                signal: input.runInput.signal,
+                owner: input.invocationOwner,
+              })
+            : runServeAsSuccessor({
+                lifecycle,
+                home: input.home,
+                appVersion: input.appVersion,
+                signal: input.runInput.signal,
+                owner: input.invocationOwner,
+                authentication: successor.authentication,
+                fence: successor.fence,
+                timer: productionMonotonicTimer(input.dependencies.monotonicNow!),
+              }),
+      });
+      if (result.status !== "completed" && successor !== undefined) {
+        await successor.fence.release();
+      }
+      return result.status === "completed"
+        ? result.value
+        : renderLocalResult(result, input.runInput.terminal);
+    } catch (error) {
+      if (!(error instanceof CoachStoreWriterError) || error.code !== "writer-lock-held") {
+        if (successor !== undefined) await successor.fence.release().catch(() => {});
+        throw error;
+      }
+      let classified: ReadOnlyPeerClassification;
+      try {
+        classified = await classifyPeerReadOnly(input.home);
+      } catch {
+        throw error;
+      }
+      if (classified.status !== "peer-healthy") throw error;
+      const executablePath = await resolveConfiguredExecutable(input.dependencies);
+      const coordinates = await readDaemonCoordinates(input.home);
+      if (coordinates.port !== classified.peer.port) throw error;
+      const { token: bearerToken } = coordinates;
+      const resolution = await input.dependencies.resolveSecondStarter!(
+        {
+          caller: input.invocationOwner === "service-managed" ? "service" : "serve",
+          home: input.home,
+          clientProtocolVersion: PROTOCOL_VERSION,
+          clientAppVersion: input.appVersion,
+          bearerToken,
+          peer: classified.peer,
+        },
+        createSecondStarterDependencies({
+          home: input.home,
+          executablePath,
+          dependencies: input.dependencies,
+        }),
+      );
+      if (resolution.status === "retry-startup") continue;
+      if (resolution.status === "become-successor") {
+        successor = { fence: resolution.fence, authentication: coordinates.token };
+        continue;
+      }
+      if (resolution.status === "defer" || resolution.status === "refuse") {
+        input.runInput.terminal.stderr.write(resolution.stderr);
+        return resolution.exitCode;
+      }
+      throw error;
+    }
+  }
+}
+
+async function runDaemonInvocation(input: {
+  readonly action: "install" | "status" | "restart";
+  readonly runInput: RunEnduragentInput;
+  readonly dependencies: EnduragentDependencies;
+}): Promise<ExitCode> {
+  if (input.dependencies.platform !== "darwin") {
+    const unavailableController: CoachDaemonController = {
+      supported: false,
+      install: async () => {
+        throw new Error("unsupported");
+      },
+      status: async () => {
+        throw new Error("unsupported");
+      },
+      restart: async () => {
+        throw new Error("unsupported");
+      },
+    };
+    return runCoachDaemonCommand({
+      action: input.action,
+      controller: unavailableController,
+      terminal: input.runInput.terminal,
+    });
+  }
+  let controller: CoachDaemonController;
+  try {
+    const home = canonicalHome(input.dependencies.resolveAthleteHome(input.runInput.env));
+    const executablePath = await resolveConfiguredExecutable(input.dependencies);
+    controller = input.dependencies.createDaemonController!({ home, executablePath });
+  } catch {
+    input.runInput.terminal.stderr.write("Enduragent could not start.\n");
+    return EXIT_AGENT_ERROR;
+  }
+  return runCoachDaemonCommand({
+    action: input.action,
+    controller,
+    terminal: input.runInput.terminal,
+  });
+}
+
 export async function runEnduragent(
   input: RunEnduragentInput,
   dependencies?: EnduragentDependencies,
@@ -436,6 +1401,14 @@ export async function runEnduragent(
       const version = await resolvedDependencies.readPackageVersion();
       input.terminal.stdout.write(`enduragent ${version}\n`);
       return EXIT_SUCCESS;
+    }
+
+    if (invocation.kind === "daemon") {
+      return runDaemonInvocation({
+        action: invocation.action,
+        runInput: input,
+        dependencies: resolvedDependencies,
+      });
     }
 
     if (invocation.kind === "verb") {
@@ -466,27 +1439,33 @@ export async function runEnduragent(
 
     const appVersion =
       invocation.kind === "serve" ? await resolvedDependencies.readPackageVersion() : undefined;
-    const home = resolvedDependencies.resolveAthleteHome(input.env);
+    const home = canonicalHome(resolvedDependencies.resolveAthleteHome(input.env));
     const sourceRoot = resolveLegacySourceRoot(input.env);
+    if (invocation.kind === "serve") {
+      const starter = await serveStarterContext(input.env);
+      return await runServeInvocation({
+        invocationOwner: starter.owner,
+        ...(starter.handoffCapability === undefined
+          ? {}
+          : { starterCapability: starter.handoffCapability }),
+        runInput: input,
+        home,
+        sourceRoot,
+        appVersion: appVersion!,
+        dependencies: resolvedDependencies,
+      });
+    }
     const result = await resolvedDependencies.withLocalCoach({
       env: input.env,
       home,
       sourceRoot,
       action: { kind: "resume", isTTY: input.terminal.isTTY },
       operation: async (lifecycle) =>
-        invocation.kind === "serve"
-          ? runCoachServe({
-              lifecycle,
-              home,
-              appVersion: appVersion!,
-              signal: input.signal,
-              owner: daemonOwner(input.env),
-            })
-          : runCoachRepl({
-              engine: lifecycle.engine,
-              terminal: input.terminal,
-              signal: input.signal,
-            }),
+        runCoachRepl({
+          engine: lifecycle.engine,
+          terminal: input.terminal,
+          signal: input.signal,
+        }),
     });
 
     return result.status === "completed" ? result.value : renderLocalResult(result, input.terminal);

--- a/packages/coach/tests/enduragent-daemon-service.test.ts
+++ b/packages/coach/tests/enduragent-daemon-service.test.ts
@@ -1,0 +1,360 @@
+import { PassThrough, Writable } from "node:stream";
+import { resolve } from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { EXIT_SUCCESS, PROTOCOL_VERSION } from "@enduragent/coach-contract";
+import {
+  CoachRemoteError,
+  type CoachDaemonController,
+  type CoachVerbTransport,
+} from "@enduragent/coach-cli";
+import type { AthleteHome } from "@enduragent/kernel-node/home";
+import type { LaunchdServiceStatus } from "@enduragent/kernel-node/service";
+import {
+  createServiceUpgradePort,
+  decideServiceAwareAutoStart,
+  observeDaemonState,
+  runEnduragent,
+  type DaemonStateObservation,
+} from "../src/enduragent.js";
+
+function capture(): { readonly stream: Writable; read(): string } {
+  let text = "";
+  return {
+    stream: new Writable({
+      write(chunk, _encoding, callback) {
+        text += String(chunk);
+        callback();
+      },
+    }),
+    read: () => text,
+  };
+}
+
+function terminal() {
+  const stdout = capture();
+  const stderr = capture();
+  return {
+    stdout,
+    stderr,
+    value: {
+      input: new PassThrough(),
+      stdout: stdout.stream,
+      stderr: stderr.stream,
+      isTTY: false,
+    },
+  };
+}
+
+const home: AthleteHome = {
+  root: "/tmp/synthetic-athlete",
+  storeDir: "/tmp/synthetic-athlete/store",
+  archiveDir: "/tmp/synthetic-athlete/archive",
+  configDir: "/tmp/synthetic-athlete/config",
+};
+
+const paths = {
+  launchAgentsDir: "/tmp/LaunchAgents",
+  plistPath: "/tmp/LaunchAgents/ai.enduragent.coach.synthetic.plist",
+  stateDir: "/tmp/synthetic-athlete/config/service",
+  envPath: "/tmp/synthetic-athlete/config/service/service.env",
+  wrapperPath: "/tmp/synthetic-athlete/config/service/service.sh",
+  handoffPath: "/tmp/synthetic-athlete/config/service/service.handoff",
+};
+
+const registeredStatus: LaunchdServiceStatus = {
+  kind: "registered",
+  registered: true,
+  installed: true,
+  loaded: true,
+  running: false,
+  label: "ai.enduragent.coach.synthetic",
+  pid: null,
+  lastExitStatus: 0,
+  paths,
+};
+
+describe("service-aware arbitration", () => {
+  it("implements every registration and peer decision row", () => {
+    const peers: DaemonStateObservation["kind"][] = [
+      "compatible-healthy",
+      "absent",
+      "bound-unresponsive",
+      "foreign",
+      "auth-invalid",
+      "version-mismatch",
+    ];
+    for (const registration of ["unknown", "registered", "absent"] as const) {
+      for (const peer of peers) {
+        const expected =
+          peer === "compatible-healthy"
+            ? "attach"
+            : registration === "registered" && peer === "absent"
+              ? "resume-service-then-attach"
+              : registration === "absent" && peer === "absent"
+                ? "spawn-ephemeral"
+                : "refuse-daemon-unavailable";
+        expect(decideServiceAwareAutoStart({ registration, peer })).toBe(expected);
+      }
+    }
+  });
+
+  it("maps the landed classifier and authenticated handshake without preserving transport", async () => {
+    const peer = { status: "peer-healthy" as const, pid: 7, port: 43_210, peerVersion: "0.1.0" };
+    const classify = vi.fn(async () => ({ status: "peer-healthy" as const, peer }));
+    const handshake = vi.fn(async () => ({
+      type: "handshake" as const,
+      status: "accepted" as const,
+      clientProtocolVersion: PROTOCOL_VERSION,
+      serverProtocolVersion: PROTOCOL_VERSION,
+      owner: "service-managed" as const,
+    }));
+    await expect(
+      observeDaemonState(
+        { home },
+        {
+          classifyPeerReadOnly: classify,
+          observePeerHandshake: handshake,
+          readDaemonCoordinates: async () => ({ port: peer.port, token: "x".repeat(43) }),
+        },
+      ),
+    ).resolves.toEqual({
+      kind: "compatible-healthy",
+      peer: { pid: 7, port: 43_210, peerVersion: "0.1.0" },
+      serverProtocolVersion: PROTOCOL_VERSION,
+    });
+    expect(handshake).toHaveBeenCalledWith({
+      port: peer.port,
+      token: "x".repeat(43),
+      clientProtocolVersion: PROTOCOL_VERSION,
+    });
+
+    for (const [classification, expected] of [
+      [{ status: "writer-clear" as const }, { kind: "absent" }],
+      [
+        { status: "bound-unresponsive" as const, stdout: "" as const, stderr: "x" },
+        { kind: "bound-unresponsive" },
+      ],
+      [{ status: "foreign-port" as const, stdout: "" as const, stderr: "x" }, { kind: "foreign" }],
+    ] as const) {
+      await expect(
+        observeDaemonState(
+          { home },
+          {
+            classifyPeerReadOnly: async () => classification,
+            observePeerHandshake: vi.fn(),
+            readDaemonCoordinates: vi.fn(),
+          },
+        ),
+      ).resolves.toEqual(expected);
+    }
+  });
+
+  it("collapses handshake rejection to auth-invalid and preserves typed mismatch", async () => {
+    const peer = { status: "peer-healthy" as const, pid: null, port: 43_211, peerVersion: "old" };
+    const common = {
+      classifyPeerReadOnly: async () => ({ status: "peer-healthy" as const, peer }),
+      readDaemonCoordinates: async () => ({ port: peer.port, token: "y".repeat(43) }),
+    };
+    await expect(
+      observeDaemonState(
+        { home },
+        {
+          ...common,
+          observePeerHandshake: async () => {
+            throw new Error("private auth cause");
+          },
+        },
+      ),
+    ).resolves.toEqual({ kind: "auth-invalid" });
+    await expect(
+      observeDaemonState(
+        { home },
+        {
+          ...common,
+          observePeerHandshake: async () => ({
+            type: "handshake",
+            status: "version-mismatch",
+            clientProtocolVersion: PROTOCOL_VERSION,
+            serverProtocolVersion: PROTOCOL_VERSION + 1,
+            direction: "client-older",
+            owner: "service-managed",
+          }),
+        },
+      ),
+    ).resolves.toEqual({
+      kind: "version-mismatch",
+      failure: { kind: "version-mismatch", direction: "client-older" },
+    });
+  });
+});
+
+describe("launchd composition", () => {
+  it("preserves the designated successor input and fails closed on unknown status", async () => {
+    const input = {
+      home,
+      targetProtocolVersion: PROTOCOL_VERSION,
+      handoffCapability: "z".repeat(43),
+    };
+    const restartInstalled = vi.fn(async () => {});
+    const resumeAfterEphemeral = vi.fn(async () => {});
+    const startEphemeral = vi.fn(async () => {});
+    const service = createServiceUpgradePort(home, {
+      readStatus: async () => registeredStatus,
+      restartInstalled,
+      resumeAfterEphemeral,
+      startEphemeral,
+    });
+    await expect(service.isInstalled(home)).resolves.toBe(true);
+    await service.restartInstalledService(input);
+    await service.kickstartInstalledServiceAfterEphemeral(input);
+    await service.startEphemeralSuccessor(input);
+    expect(restartInstalled).toHaveBeenCalledWith(input);
+    expect(resumeAfterEphemeral).toHaveBeenCalledWith(input);
+    expect(startEphemeral).toHaveBeenCalledWith(input);
+    await expect(
+      createServiceUpgradePort(home, {
+        readStatus: async () => ({
+          ...registeredStatus,
+          kind: "unknown",
+          registered: null,
+          installed: null,
+          loaded: null,
+          running: null,
+          pid: null,
+          lastExitStatus: null,
+          detail: "launchd status unavailable",
+        }),
+        restartInstalled,
+        resumeAfterEphemeral,
+        startEphemeral,
+      }).isInstalled(home),
+    ).rejects.toThrow("service status unavailable");
+  });
+
+  it("short-circuits unsupported daemon verbs before resolving home or executable", async () => {
+    const io = terminal();
+    const resolveHome = vi.fn(() => home);
+    const resolveExecutablePath = vi.fn(async () => "/tmp/enduragent");
+    await expect(
+      runEnduragent(
+        {
+          argv: ["daemon", "status"],
+          env: {},
+          terminal: io.value,
+          signal: new AbortController().signal,
+        },
+        {
+          resolveAthleteHome: resolveHome,
+          withLocalCoach: vi.fn(),
+          readPackageVersion: async () => "unused",
+          resolveExecutablePath,
+          platform: "linux",
+        },
+      ),
+    ).resolves.toBe(2);
+    expect(resolveHome).not.toHaveBeenCalled();
+    expect(resolveExecutablePath).not.toHaveBeenCalled();
+    expect(io.stderr.read()).toBe("Enduragent service management is available only on macOS.\n");
+  });
+
+  it("canonicalizes one Darwin home and invokes one daemon controller action", async () => {
+    const io = terminal();
+    const relativeHome: AthleteHome = {
+      root: "synthetic-relative",
+      storeDir: "synthetic-relative/store",
+      archiveDir: "synthetic-relative/archive",
+      configDir: "synthetic-relative/config",
+    };
+    const install = vi.fn(async () => ({
+      kind: "registered" as const,
+      label: "ai.enduragent.coach.synthetic",
+      installed: true,
+      loaded: true,
+      running: true,
+      pid: 9,
+    }));
+    let received: { readonly home: AthleteHome; readonly executablePath: string } | undefined;
+    const controller: CoachDaemonController = {
+      supported: true,
+      install,
+      status: vi.fn(),
+      restart: vi.fn(),
+    };
+    await expect(
+      runEnduragent(
+        {
+          argv: ["daemon", "install"],
+          env: {},
+          terminal: io.value,
+          signal: new AbortController().signal,
+        },
+        {
+          resolveAthleteHome: () => relativeHome,
+          withLocalCoach: vi.fn(),
+          readPackageVersion: async () => "unused",
+          platform: "darwin",
+          resolveExecutablePath: async () => "/tmp/real-enduragent",
+          createDaemonController: (input) => {
+            received = input;
+            return controller;
+          },
+        },
+      ),
+    ).resolves.toBe(EXIT_SUCCESS);
+    expect(received).toEqual({
+      home: {
+        root: resolve("synthetic-relative"),
+        storeDir: resolve("synthetic-relative/store"),
+        archiveDir: resolve("synthetic-relative/archive"),
+        configDir: resolve("synthetic-relative/config"),
+      },
+      executablePath: "/tmp/real-enduragent",
+    });
+    expect(install).toHaveBeenCalledTimes(1);
+  });
+
+  it("resumes a registered stopped service before bounded retry and never spawns", async () => {
+    const io = terminal();
+    const transport: CoachVerbTransport = {
+      kind: "remote",
+      async request(request) {
+        const envelope = { jsonrpc: "2.0" as const, id: 1, result: { text: "ok" } };
+        request.onTerminalEnvelope(envelope);
+        return envelope;
+      },
+      close: async () => {},
+    };
+    const connect = vi
+      .fn()
+      .mockRejectedValueOnce(new CoachRemoteError({ kind: "unavailable" }))
+      .mockResolvedValueOnce(transport);
+    const resumeService = vi.fn(async () => "resumed" as const);
+    const startEphemeralDaemon = vi.fn();
+    await expect(
+      runEnduragent(
+        {
+          argv: ["ask", "hello"],
+          env: {},
+          terminal: io.value,
+          signal: new AbortController().signal,
+        },
+        {
+          resolveAthleteHome: () => home,
+          withLocalCoach: vi.fn(),
+          readPackageVersion: async () => "unused",
+          connectRemoteTransport: connect,
+          serviceRegistrationState: async (): Promise<"present"> => "present",
+          observeDaemonState: async () => ({ kind: "absent" }),
+          resolveExecutablePath: async () => "/tmp/real-enduragent",
+          resumeService,
+          startEphemeralDaemon,
+          delay: async () => {},
+          monotonicNow: () => 0,
+        },
+      ),
+    ).resolves.toBe(EXIT_SUCCESS);
+    expect(resumeService).toHaveBeenCalledTimes(1);
+    expect(startEphemeralDaemon).not.toHaveBeenCalled();
+    expect(io.stdout.read()).toBe("ok\n");
+  });
+});


### PR DESCRIPTION
## Summary

Wires the launchd service into the CLI and closes the ownership arbitration:

- `enduragent daemon install|status|restart` verbs over the kernel-node service primitives.
- Every CLI auto-start path consults the service registration status before spawning — a registered service is an ownership authority even while stopped: recovery routes through kickstart, never a competing spawn; the spawn-free `connectWithBoundedRetry` seam extracted from the verbs' polling loop.
- Production arbitration composition: `resolveSecondStarter` is constructed from the landed primitives (upgrade-fence acquisition, peer waiter, writer-release waiter, injected clock) and called at the serve/CLI arbitration points; ephemeral relinquish kickstarts the installed service via the PR-03 successor methods.
- Changeset included (`User-facing:` daemon service management commands).

## Verification

- Required regression suite 69 tests; five package builds + export smoke green; plist assertions and forbidden-architecture scans green.
- Root `pnpm build`, `pnpm check`, full `pnpm test` green after rebase; live launchd acceptance covered by the merged 05a live probe on this host.
