### PR TITLE
feat(coach): redact errors at rpc and cli boundaries

### DIFF
--- a/packages/coach-cli/src/verbs/transport.ts
+++ b/packages/coach-cli/src/verbs/transport.ts
@@ -6,6 +6,7 @@ import {
   JsonRpcSuccessResponseEnvelopeSchema,
   serializeCoachRpcEnvelope,
   type CoachEngine,
+  type JsonValue,
   type JsonRpcResponseEnvelope,
 } from "@enduragent/coach-contract";
 import {
@@ -147,17 +148,24 @@ function localSuccess(method: CoachVerbMethodName, result: unknown) {
   return envelope;
 }
 
-function localError() {
+function localError(data?: JsonValue) {
   const envelope = JsonRpcErrorResponseEnvelopeSchema.parse({
     jsonrpc: "2.0",
     id: 1,
-    error: { code: -32603, message: "Internal error" },
+    error: {
+      code: -32603,
+      message: "Internal error",
+      ...(data === undefined ? {} : { data }),
+    },
   });
   serializeCoachRpcEnvelope(envelope);
   return envelope;
 }
 
-export function createLocalCoachVerbTransport(engine: CoachEngine): CoachVerbTransport {
+export function createLocalCoachVerbTransport(
+  engine: CoachEngine,
+  serializeError?: (error: unknown) => JsonValue,
+): CoachVerbTransport {
   let admitted = false;
   const closed = Promise.resolve();
   return {
@@ -194,8 +202,8 @@ export function createLocalCoachVerbTransport(engine: CoachEngine): CoachVerbTra
             input.onNotificationEnvelope(notification);
           });
           envelope = localSuccess(input.method, result);
-        } catch {
-          envelope = localError();
+        } catch (error) {
+          envelope = localError(serializeError?.(error));
         }
         if (deliveryDetached) throw new CoachRemoteError({ kind: "detached" });
         input.onTerminalEnvelope(envelope);

--- a/packages/coach/src/daemon/error-boundary.ts
+++ b/packages/coach/src/daemon/error-boundary.ts
@@ -1,0 +1,46 @@
+import { REDACTION_SENTINEL, redactObject, serializeError } from "@enduragent/core";
+import { JsonValueSchema, type JsonValue } from "@enduragent/coach-contract";
+
+export type BoundaryErrorPayload = Readonly<Record<string, JsonValue>>;
+
+const BOUNDARY_FREE_TEXT_FIELDS = new Set(["message", "stack", "value", "url", "provider"]);
+
+function suppressBoundaryFreeText(value: unknown): JsonValue {
+  if (value === REDACTION_SENTINEL) return REDACTION_SENTINEL;
+  if (value === null || typeof value === "boolean") return value;
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : REDACTION_SENTINEL;
+  }
+  if (typeof value === "string") return REDACTION_SENTINEL;
+  if (Array.isArray(value)) return value.map(suppressBoundaryFreeText);
+  if (typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, child]) => [key, suppressBoundaryFreeText(child)]),
+    );
+  }
+  return REDACTION_SENTINEL;
+}
+
+export function serializeBoundaryError(error: unknown): BoundaryErrorPayload {
+  try {
+    const serialized = serializeError(error);
+    const diagnostics: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(serialized)) {
+      if (key === "name" || BOUNDARY_FREE_TEXT_FIELDS.has(key)) continue;
+      diagnostics[key] = value;
+    }
+    const redacted = suppressBoundaryFreeText(redactObject(diagnostics));
+    const name =
+      serialized.name === "UnserializableError"
+        ? "UnserializableError"
+        : error instanceof Error
+          ? "Error"
+          : "NonError";
+    return JsonValueSchema.parse({
+      name,
+      ...(redacted as Record<string, JsonValue>),
+    }) as BoundaryErrorPayload;
+  } catch {
+    return { name: "UnserializableError" };
+  }
+}

--- a/packages/coach/src/daemon/rpc-server.ts
+++ b/packages/coach/src/daemon/rpc-server.ts
@@ -33,6 +33,7 @@ import {
   HANDOFF_CAPABILITY_BYTES,
   type MonotonicTimer,
 } from "./upgrade-fence.js";
+import { serializeBoundaryError } from "./error-boundary.js";
 
 const AUTH_TIMEOUT_MS = 1_000;
 const MAX_PAYLOAD_BYTES = 1_048_576;
@@ -270,6 +271,20 @@ function ordinaryError(id: JsonRpcId, code: number, message: string): string {
       jsonrpc: "2.0",
       id,
       error: { code, message },
+    }),
+  );
+}
+
+function internalError(id: JsonRpcId, error: unknown): string {
+  return serializeCoachRpcEnvelope(
+    JsonRpcErrorResponseEnvelopeSchema.parse({
+      jsonrpc: "2.0",
+      id,
+      error: {
+        code: -32603,
+        message: "Internal error",
+        data: serializeBoundaryError(error),
+      },
     }),
   );
 }
@@ -557,8 +572,8 @@ export function createCoachRpcServer(input: CoachRpcServerInput): CoachRpcServer
     }
     state.activeIds.add(key);
     const task = (async () => {
-      let invocationFailed = false;
-      let eventFailed = false;
+      let invocationFailure: { readonly error: unknown } | undefined;
+      let eventFailure: { readonly error: unknown } | undefined;
       let deliveryDetached = false;
       let result: unknown;
       try {
@@ -572,7 +587,7 @@ export function createCoachRpcServer(input: CoachRpcServerInput): CoachRpcServer
                 key: request.chatId,
                 signal: state.detachController.signal,
                 run: () => input.engine.chat(request, (event) => {
-                  if (eventFailed) return;
+                  if (eventFailure !== undefined) return;
                   try {
                     const parsedEvent = COACH_RPC_METHOD_REGISTRY.chat.eventSchema.parse(event);
                     const notification = CoachTurnEventNotificationEnvelopeSchema.parse({
@@ -586,14 +601,14 @@ export function createCoachRpcServer(input: CoachRpcServerInput): CoachRpcServer
                       },
                     });
                     void enqueueSerialized(state, serializeCoachRpcEnvelope(notification));
-                  } catch {
-                    eventFailed = true;
+                  } catch (error) {
+                    eventFailure = { error };
                   }
                 }),
               });
             } catch (error) {
               if (error instanceof DetachedSessionRequestError) deliveryDetached = true;
-              else invocationFailed = true;
+              else invocationFailure = { error };
             }
             break;
           case "resetSession":
@@ -602,8 +617,8 @@ export function createCoachRpcServer(input: CoachRpcServerInput): CoachRpcServer
                 generic.data.params,
               );
               result = await input.engine.resetSession(request);
-            } catch {
-              invocationFailed = true;
+            } catch (error) {
+              invocationFailure = { error };
             }
             break;
           case "hasSession":
@@ -612,27 +627,28 @@ export function createCoachRpcServer(input: CoachRpcServerInput): CoachRpcServer
                 generic.data.params,
               );
               result = await input.engine.hasSession(request);
-            } catch {
-              invocationFailed = true;
+            } catch (error) {
+              invocationFailure = { error };
             }
             break;
           case "getAthleteState":
             try {
               COACH_RPC_METHOD_REGISTRY.getAthleteState.requestSchema.parse(generic.data.params);
               result = await input.engine.getAthleteState();
-            } catch {
-              invocationFailed = true;
+            } catch (error) {
+              invocationFailure = { error };
             }
             break;
         }
         if (deliveryDetached) return;
         let terminal: string;
-        if (invocationFailed || eventFailed) {
-          terminal = ordinaryError(generic.data.id, -32603, "Internal error");
+        const failure = invocationFailure ?? eventFailure;
+        if (failure !== undefined) {
+          terminal = internalError(generic.data.id, failure.error);
         } else {
           const response = registry.responseSchema.safeParse(result);
           if (!response.success) {
-            terminal = ordinaryError(generic.data.id, -32603, "Internal error");
+            terminal = internalError(generic.data.id, response.error);
           } else {
             try {
               terminal = serializeCoachRpcEnvelope(
@@ -642,8 +658,8 @@ export function createCoachRpcServer(input: CoachRpcServerInput): CoachRpcServer
                   result: response.data,
                 }),
               );
-            } catch {
-              terminal = ordinaryError(generic.data.id, -32603, "Internal error");
+            } catch (error) {
+              terminal = internalError(generic.data.id, error);
             }
           }
         }

--- a/packages/coach/src/enduragent.ts
+++ b/packages/coach/src/enduragent.ts
@@ -80,6 +80,7 @@ import {
   type LocalCoachRunResult,
   type WithLocalCoachInput,
 } from "./local-runner.js";
+import { serializeBoundaryError } from "./daemon/error-boundary.js";
 import { CoachStoreWriterError } from "./runtime.js";
 import { runCoachServe } from "./serve.js";
 
@@ -1166,7 +1167,7 @@ async function runPreparedVerb(
       action: { kind: "resume", isTTY: input.terminal.isTTY },
       operation: async (lifecycle) =>
         runWithOwnedTransport(
-          createLocalCoachVerbTransport(lifecycle.engine),
+          createLocalCoachVerbTransport(lifecycle.engine, serializeBoundaryError),
           request,
           invocation,
           input.terminal,

--- a/packages/coach/tests/daemon-rpc-server.test.ts
+++ b/packages/coach/tests/daemon-rpc-server.test.ts
@@ -412,7 +412,11 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
     expect(parseCoachRpcEnvelope(await client.frames.next())).toEqual({
       jsonrpc: "2.0",
       id: "non-json-result",
-      error: { code: -32603, message: "Internal error" },
+      error: {
+        code: -32603,
+        message: "Internal error",
+        data: { name: "Error" },
+      },
     });
     await client.close();
   });

--- a/packages/coach/tests/daemon/error-boundary.test.ts
+++ b/packages/coach/tests/daemon/error-boundary.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from "vitest";
+import { JsonValueSchema } from "@enduragent/coach-contract";
+import { serializeBoundaryError } from "../../src/daemon/error-boundary.js";
+
+const SENTINEL = "[redacted]";
+
+function encoded(value: unknown): string {
+  return JSON.stringify(value);
+}
+
+describe("boundary error serialization", () => {
+  it("drops free text and provider payloads while preserving safe structure", () => {
+    const nested = {
+      token: "synthetic-nested-token",
+      detail: "synthetic-arbitrary-text",
+    };
+    const error = Object.assign(new Error("synthetic-message-secret"), {
+      apiKey: "synthetic-api-key",
+      authorization: "synthetic-authorization",
+      statusCode: 503,
+      nested,
+      values: [{ cookie: "synthetic-cookie", count: 2 }],
+      url: "https://example.invalid/synthetic-url-secret",
+      provider: "synthetic-provider-secret",
+      requestBodyValues: { apiKey: "synthetic-request-secret" },
+      responseBody: "synthetic-response-secret",
+      payload: "synthetic-payload-secret",
+      body: "synthetic-body-secret",
+      data: "synthetic-data-secret",
+      active: true,
+      retryAfter: null,
+    });
+    Object.defineProperty(error, "stack", {
+      configurable: true,
+      value: "Error: synthetic-stack-secret",
+    });
+
+    const payload = serializeBoundaryError(error);
+
+    expect(payload).toEqual({
+      name: "Error",
+      statusCode: 503,
+      apiKey: SENTINEL,
+      authorization: SENTINEL,
+      nested: { token: SENTINEL, detail: SENTINEL },
+      values: [{ cookie: SENTINEL, count: 2 }],
+      active: true,
+      retryAfter: null,
+    });
+    for (const key of [
+      "message",
+      "stack",
+      "url",
+      "provider",
+      "requestBodyValues",
+      "responseBody",
+      "payload",
+      "body",
+      "data",
+    ]) {
+      expect(payload).not.toHaveProperty(key);
+    }
+    for (const secret of [
+      "synthetic-message-secret",
+      "synthetic-stack-secret",
+      "synthetic-url-secret",
+      "synthetic-provider-secret",
+      "synthetic-request-secret",
+      "synthetic-response-secret",
+      "synthetic-payload-secret",
+      "synthetic-body-secret",
+      "synthetic-data-secret",
+      "synthetic-arbitrary-text",
+    ]) {
+      expect(encoded(payload)).not.toContain(secret);
+    }
+    expect(error.apiKey).toBe("synthetic-api-key");
+    expect(error.nested).toBe(nested);
+    expect(nested).toEqual({
+      token: "synthetic-nested-token",
+      detail: "synthetic-arbitrary-text",
+    });
+    expect(JsonValueSchema.parse(payload)).toEqual(payload);
+  });
+
+  it("bounds cycles and the effective second-walk depth", () => {
+    const circular: Record<string, unknown> = { count: 1 };
+    circular.self = circular;
+    const error = Object.assign(new Error("synthetic"), {
+      circular,
+      fiveLevels: { two: { three: { four: { five: { count: 5 } } } } },
+      sixLevels: { two: { three: { four: { five: { six: { count: 6 } } } } } },
+    });
+
+    const payload = serializeBoundaryError(error);
+
+    expect(payload.circular).toEqual({ count: 1, self: SENTINEL });
+    expect(payload.fiveLevels).toEqual({
+      two: { three: { four: { five: { count: 5 } } } },
+    });
+    expect(payload.sixLevels).toEqual({
+      two: { three: { four: { five: { six: SENTINEL } } } },
+    });
+    expect(circular.self).toBe(circular);
+    expect(JsonValueSchema.parse(payload)).toEqual(payload);
+  });
+
+  it("suppresses non-errors and every non-JSON diagnostic value", () => {
+    const nonError = {
+      toString: () => "synthetic-non-error-secret",
+    };
+    const error = Object.assign(new Error("synthetic-message-secret"), {
+      diagnosticNote: "synthetic-diagnostic-secret",
+      finite: 7,
+      infinite: Number.POSITIVE_INFINITY,
+      enabled: false,
+      empty: null,
+      callable: () => "synthetic-function-secret",
+      symbolic: Symbol("synthetic-symbol-secret"),
+    });
+
+    expect(serializeBoundaryError(nonError)).toEqual({ name: "NonError" });
+    const payload = serializeBoundaryError(error);
+    expect(payload).toEqual({
+      name: "Error",
+      diagnosticNote: SENTINEL,
+      finite: 7,
+      infinite: SENTINEL,
+      enabled: false,
+      empty: null,
+      callable: SENTINEL,
+      symbolic: SENTINEL,
+    });
+    const output = encoded(payload);
+    for (const secret of [
+      "synthetic-message-secret",
+      "synthetic-diagnostic-secret",
+      "synthetic-function-secret",
+      "synthetic-symbol-secret",
+      "synthetic-non-error-secret",
+    ]) {
+      expect(output).not.toContain(secret);
+    }
+    expect(JsonValueSchema.parse(payload)).toEqual(payload);
+  });
+
+  it("never throws for hostile error properties", () => {
+    const throwingName = new Error("synthetic");
+    Object.defineProperty(throwingName, "name", {
+      get() {
+        throw new Error("synthetic-name-getter-secret");
+      },
+    });
+    expect(serializeBoundaryError(throwingName)).toEqual({
+      name: "UnserializableError",
+    });
+
+    const hostile = new Proxy(
+      {},
+      {
+        ownKeys() {
+          throw new Error("synthetic-proxy-secret");
+        },
+      },
+    );
+    for (const field of ["url", "provider"] as const) {
+      const error = Object.assign(new Error("synthetic"), { [field]: hostile });
+      expect(serializeBoundaryError(error)).toEqual({ name: "Error" });
+    }
+    expect(
+      serializeBoundaryError(Object.assign(new Error("synthetic"), { statusCode: hostile })),
+    ).toEqual({ name: "UnserializableError" });
+    expect(
+      serializeBoundaryError(Object.assign(new Error("synthetic"), { diagnostic: hostile })),
+    ).toEqual({ name: "UnserializableError" });
+  });
+});

--- a/packages/coach/tests/daemon/redaction-rpc-cli.test.ts
+++ b/packages/coach/tests/daemon/redaction-rpc-cli.test.ts
@@ -1,0 +1,386 @@
+import { createServer, type Server } from "node:http";
+import { createServer as createNetServer } from "node:net";
+import {
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  realpath,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Writable } from "node:stream";
+import { afterEach, describe, expect, it } from "vitest";
+import { CoachRpcRemoteError, connectCoachClient } from "@enduragent/coach-client";
+import { connectCoachVerbTransport } from "@enduragent/coach-cli";
+import {
+  ClientHandshakeFrameSchema,
+  EXIT_AGENT_ERROR,
+  JsonRpcErrorResponseEnvelopeSchema,
+  type AthleteState,
+  type CoachEngine,
+  type JsonRpcErrorResponseEnvelope,
+} from "@enduragent/coach-contract";
+import { resolveAthleteHome } from "@enduragent/kernel-node/home";
+import { runEnduragent } from "../../src/enduragent.js";
+import {
+  createCoachRpcServer,
+  ensureDaemonToken,
+  type CoachRpcServer,
+} from "../../src/daemon/rpc-server.js";
+
+const AUTH_TOKEN = "F8_AUTH_TOKEN_MUST_NOT_BE_LOGGED12345678901";
+const API_KEY_SECRET = "F8_API_KEY_MUST_NOT_ESCAPE";
+const MESSAGE_SECRET = "F8_MESSAGE_MUST_NOT_ESCAPE";
+const STACK_SECRET = "F8_STACK_MUST_NOT_ESCAPE";
+const URL_SECRET = "F8_URL_MUST_NOT_ESCAPE";
+const PROVIDER_SECRET = "F8_PROVIDER_MUST_NOT_ESCAPE";
+const ARBITRARY_SECRET = "F8_ARBITRARY_TEXT_MUST_NOT_ESCAPE";
+const NON_ERROR_SECRET = "F8_NON_ERROR_TEXT_MUST_NOT_ESCAPE";
+const NESTED_SECRET = "F8_NESTED_AUTH_MUST_NOT_ESCAPE";
+const HOSTILE_SECRET = "F8_HOSTILE_PROXY_MUST_NOT_ESCAPE";
+const roots: string[] = [];
+
+const state: AthleteState = {
+  schemaVersion: "3",
+  lastUpdated: "2000-01-01T00:00:00.000Z",
+  freshness: "fresh",
+  degraded: false,
+  lastSynced: "2000-01-01T00:00:00.000Z",
+  athleteProfile: {},
+  currentStatus: {},
+  derivedMetrics: {},
+  recentActivities: [],
+  plannedWorkouts: [],
+  wellness: {},
+};
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+function capture(): { readonly stream: Writable; read(): string } {
+  let value = "";
+  return {
+    stream: new Writable({
+      write(chunk, _encoding, callback) {
+        value += Buffer.isBuffer(chunk) ? chunk.toString("utf8") : String(chunk);
+        callback();
+      },
+    }),
+    read: () => value,
+  };
+}
+
+function fabricatedError(): Error {
+  const error = Object.assign(new Error(`synthetic failure ${MESSAGE_SECRET}`), {
+    apiKey: API_KEY_SECRET,
+    statusCode: 503,
+    nested: { authorization: `Bearer ${NESTED_SECRET}` },
+    url: `https://example.invalid/${URL_SECRET}`,
+    provider: PROVIDER_SECRET,
+    diagnosticNote: ARBITRARY_SECRET,
+  });
+  Object.defineProperty(error, "stack", {
+    configurable: true,
+    value: `Error: synthetic failure ${STACK_SECRET}`,
+  });
+  return error;
+}
+
+function hostileError(): Error {
+  const hostile = new Proxy(
+    {},
+    {
+      ownKeys() {
+        throw new Error(HOSTILE_SECRET);
+      },
+    },
+  );
+  return Object.assign(new Error("synthetic hostile failure"), { statusCode: hostile });
+}
+
+function engine(readFailure: () => unknown): CoachEngine {
+  return {
+    chat: async () => {
+      throw readFailure();
+    },
+    resetSession: async () => ({ memoryFlushed: true }),
+    hasSession: async () => ({ hasSession: false }),
+    getAthleteState: async () => state,
+  };
+}
+
+async function loopbackAvailable(): Promise<boolean> {
+  return new Promise((resolve) => {
+    const server = createNetServer();
+    server.once("error", (error: NodeJS.ErrnoException) => {
+      if (error.code === "EPERM") {
+        process.stderr.write("SKIP_MARKER loopback-listen EPERM redaction-rpc-cli\n");
+      }
+      resolve(false);
+    });
+    server.listen({ host: "127.0.0.1", port: 0 }, () => server.close(() => resolve(true)));
+  });
+}
+
+const hasLoopback = await loopbackAvailable();
+
+interface RunningRpc {
+  readonly rpc: CoachRpcServer;
+  readonly server: Server;
+  readonly url: string;
+}
+
+async function startRpc(coachEngine: CoachEngine): Promise<RunningRpc> {
+  const rpc = createCoachRpcServer({
+    engine: coachEngine,
+    token: AUTH_TOKEN,
+    owner: "unmanaged-foreground",
+  });
+  const server = createServer();
+  server.on("upgrade", rpc.handleUpgrade);
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen({ host: "127.0.0.1", port: 0 }, resolve);
+  });
+  const address = server.address();
+  if (address === null || typeof address === "string") throw new TypeError("missing test port");
+  return { rpc, server, url: `ws://127.0.0.1:${address.port}/rpc` };
+}
+
+async function closeRpc(running: RunningRpc): Promise<void> {
+  await running.rpc.close();
+  await new Promise<void>((resolve, reject) => {
+    running.server.close((error) => (error === undefined ? resolve() : reject(error)));
+  });
+}
+
+async function readTree(path: string): Promise<string[]> {
+  let entries: import("node:fs").Dirent[];
+  try {
+    entries = await readdir(path, { withFileTypes: true });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw error;
+  }
+  const values: string[] = [];
+  for (const entry of entries) {
+    const child = join(path, entry.name);
+    if (entry.isDirectory()) values.push(...(await readTree(child)));
+    else if (entry.isFile()) values.push(await readFile(child, "utf8"));
+  }
+  return values;
+}
+
+async function expectRefused(url: string): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const socket = new WebSocket(url);
+    socket.addEventListener("error", () => resolve(), { once: true });
+    socket.addEventListener(
+      "open",
+      () => {
+        socket.close();
+        reject(new Error("closed RPC port accepted a connection"));
+      },
+      { once: true },
+    );
+  });
+}
+
+function expectSafeError(envelope: JsonRpcErrorResponseEnvelope): void {
+  expect(envelope.error.code).toBe(-32603);
+  expect(envelope.error.message).toBe("Internal error");
+  expect(envelope.error.data).toEqual({
+    name: "Error",
+    statusCode: 503,
+    apiKey: "[redacted]",
+    nested: { authorization: "[redacted]" },
+    diagnosticNote: "[redacted]",
+  });
+}
+
+describe.skipIf(!hasLoopback)("redaction over real RPC and CLI", () => {
+  it("delivers only redacted diagnostics and never persists the daemon token", async () => {
+    const root = await mkdtemp(join(await realpath(tmpdir()), "redaction-rpc-cli-"));
+    roots.push(root);
+    const home = resolveAthleteHome({ ENDURAGENT_HOME: root });
+    await mkdir(home.configDir, { recursive: true, mode: 0o700 });
+    await writeFile(join(home.configDir, "daemon.token"), `${AUTH_TOKEN}\n`, { mode: 0o600 });
+    const tokenMetadata = await lstat(join(home.configDir, "daemon.token"));
+    expect(tokenMetadata.isFile()).toBe(true);
+    expect(tokenMetadata.isSymbolicLink()).toBe(false);
+    expect(tokenMetadata.mode & 0o777).toBe(0o600);
+    const token = await ensureDaemonToken(home.configDir);
+    expect(token.value).toBe(AUTH_TOKEN);
+
+    let failure: unknown = fabricatedError();
+    const running = await startRpc(engine(() => failure));
+    const clientConnections: string[][] = [];
+    const serverFrames: string[] = [];
+    const cliBytes: string[] = [];
+    const webSocketFactory = (url: string): WebSocket => {
+      const frames: string[] = [];
+      clientConnections.push(frames);
+      const socket = new WebSocket(url);
+      const send = socket.send;
+      Object.defineProperty(socket, "send", {
+        configurable: true,
+        value: (data: string | ArrayBufferLike | Blob | ArrayBufferView) => {
+          frames.push(typeof data === "string" ? data : String(data));
+          Reflect.apply(send, socket, [data]);
+        },
+      });
+      socket.addEventListener("message", (event) => {
+        serverFrames.push(String(event.data));
+      });
+      return socket;
+    };
+    const directClient = await connectCoachClient({
+      url: running.url,
+      token: token.value,
+      webSocketFactory,
+    });
+    try {
+      let observed: JsonRpcErrorResponseEnvelope | undefined;
+      let terminalCount = 0;
+      let rejected = false;
+      const directCall = directClient.call(
+        "chat",
+        { chatId: "cli:synthetic", message: "synthetic request" },
+        {
+          onTerminalEnvelope(envelope) {
+            expect(rejected).toBe(false);
+            terminalCount += 1;
+            if ("error" in envelope) observed = envelope;
+          },
+        },
+      );
+      await expect(directCall).rejects.toBeInstanceOf(CoachRpcRemoteError);
+      rejected = true;
+      expect(terminalCount).toBe(1);
+      expect(observed).toBeDefined();
+      if (observed === undefined) throw new TypeError("missing observed terminal");
+      expectSafeError(observed);
+      await directClient.close();
+
+      for (const outputMode of ["--stream-json", "--json"] as const) {
+        failure = fabricatedError();
+        const stdout = capture();
+        const stderr = capture();
+        const result = await runEnduragent(
+          {
+            argv: ["ask", "synthetic request", outputMode, "--session", "synthetic"],
+            env: { ENDURAGENT_HOME: root },
+            terminal: {
+              input: process.stdin,
+              stdout: stdout.stream,
+              stderr: stderr.stream,
+              isTTY: false,
+            },
+            signal: new AbortController().signal,
+          },
+          {
+            resolveAthleteHome: () => home,
+            withLocalCoach: async () => {
+              throw new Error("local runner must not be used");
+            },
+            readPackageVersion: async () => "synthetic",
+            connectRemoteTransport: async () =>
+              connectCoachVerbTransport({
+                url: running.url,
+                token: token.value,
+                webSocketFactory,
+              }),
+          },
+        );
+        expect(result).toBe(EXIT_AGENT_ERROR);
+        expect(stderr.read()).toBe("Enduragent could not complete this command.\n");
+        if (outputMode === "--stream-json") {
+          const lines = stdout.read().trimEnd().split("\n");
+          expect(lines).toHaveLength(1);
+          const line = lines[0];
+          if (line === undefined) throw new TypeError("missing CLI terminal line");
+          expectSafeError(JsonRpcErrorResponseEnvelopeSchema.parse(JSON.parse(line)));
+        } else {
+          expect(stdout.read()).toBe("");
+        }
+        cliBytes.push(stdout.read(), stderr.read());
+      }
+
+      for (const variant of [
+        {
+          failure: NON_ERROR_SECRET,
+          data: { name: "NonError" },
+        },
+        {
+          failure: hostileError(),
+          data: { name: "UnserializableError" },
+        },
+      ]) {
+        failure = variant.failure;
+        const client = await connectCoachClient({
+          url: running.url,
+          token: token.value,
+          webSocketFactory,
+        });
+        let terminal: JsonRpcErrorResponseEnvelope | undefined;
+        let terminalCount = 0;
+        try {
+          await expect(
+            client.call(
+              "chat",
+              { chatId: "cli:synthetic", message: "synthetic request" },
+              {
+                onTerminalEnvelope(envelope) {
+                  terminalCount += 1;
+                  if ("error" in envelope) terminal = envelope;
+                },
+              },
+            ),
+          ).rejects.toBeInstanceOf(CoachRpcRemoteError);
+          expect(terminalCount).toBe(1);
+          expect(terminal?.error.data).toEqual(variant.data);
+        } finally {
+          await client.close();
+        }
+      }
+
+      for (const frames of clientConnections) {
+        expect(frames.length).toBeGreaterThan(1);
+        const firstFrame = frames[0];
+        if (firstFrame === undefined) throw new TypeError("missing client handshake frame");
+        expect(ClientHandshakeFrameSchema.parse(JSON.parse(firstFrame))).toMatchObject({
+          type: "handshake",
+        });
+      }
+      const diagnosticFrames = [
+        ...clientConnections.flatMap((frames) => frames.slice(1)),
+        ...serverFrames,
+      ];
+      const logBytes = await readTree(join(home.root, "logs"));
+      const diagnosticBytes = [...diagnosticFrames, ...cliBytes, ...logBytes].join("\n");
+      for (const secret of [
+        AUTH_TOKEN,
+        API_KEY_SECRET,
+        MESSAGE_SECRET,
+        STACK_SECRET,
+        URL_SECRET,
+        PROVIDER_SECRET,
+        ARBITRARY_SECRET,
+        NON_ERROR_SECRET,
+        NESTED_SECRET,
+        HOSTILE_SECRET,
+      ]) {
+        expect(diagnosticBytes).not.toContain(secret);
+      }
+    } finally {
+      await directClient.close().catch(() => {});
+      await closeRpc(running);
+    }
+    await expectRefused(running.url);
+  });
+});

--- a/packages/coach/tests/enduragent-redaction.test.ts
+++ b/packages/coach/tests/enduragent-redaction.test.ts
@@ -1,0 +1,302 @@
+import { createServer as createNetServer } from "node:net";
+import { mkdtemp, realpath, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { PassThrough, Writable } from "node:stream";
+import { afterEach, describe, expect, it } from "vitest";
+import { CoachRemoteError, type CoachVerbTransport } from "@enduragent/coach-cli";
+import {
+  EXIT_AGENT_ERROR,
+  EXIT_DAEMON_UNAVAILABLE,
+  JsonRpcErrorResponseEnvelopeSchema,
+  type AthleteState,
+  type CoachEngine,
+} from "@enduragent/coach-contract";
+import { resolveAthleteHome } from "@enduragent/kernel-node/home";
+import { runEnduragent, type EnduragentDependencies } from "../src/enduragent.js";
+import type { WithLocalCoachInput } from "../src/local-runner.js";
+import { withCoachStoreWriter } from "../src/runtime.js";
+
+const API_KEY_SECRET = "F8_LOCAL_API_KEY_MUST_NOT_ESCAPE";
+const MESSAGE_SECRET = "F8_LOCAL_MESSAGE_MUST_NOT_ESCAPE";
+const STACK_SECRET = "F8_LOCAL_STACK_MUST_NOT_ESCAPE";
+const URL_SECRET = "F8_LOCAL_URL_MUST_NOT_ESCAPE";
+const PROVIDER_SECRET = "F8_LOCAL_PROVIDER_MUST_NOT_ESCAPE";
+const ARBITRARY_SECRET = "F8_LOCAL_ARBITRARY_MUST_NOT_ESCAPE";
+const NON_ERROR_SECRET = "F8_LOCAL_NON_ERROR_MUST_NOT_ESCAPE";
+const NESTED_SECRET = "F8_LOCAL_NESTED_AUTH_MUST_NOT_ESCAPE";
+const roots: string[] = [];
+
+const state: AthleteState = {
+  schemaVersion: "3",
+  lastUpdated: "2000-01-01T00:00:00.000Z",
+  freshness: "fresh",
+  degraded: false,
+  lastSynced: "2000-01-01T00:00:00.000Z",
+  athleteProfile: {},
+  currentStatus: {},
+  derivedMetrics: {},
+  recentActivities: [],
+  plannedWorkouts: [],
+  wellness: {},
+};
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+function capture(): { readonly stream: Writable; read(): string } {
+  let value = "";
+  return {
+    stream: new Writable({
+      write(chunk, _encoding, callback) {
+        value += Buffer.isBuffer(chunk) ? chunk.toString("utf8") : String(chunk);
+        callback();
+      },
+    }),
+    read: () => value,
+  };
+}
+
+function fabricatedError(): Error {
+  const error = Object.assign(new Error(`synthetic failure ${MESSAGE_SECRET}`), {
+    apiKey: API_KEY_SECRET,
+    statusCode: 503,
+    nested: { authorization: `Bearer ${NESTED_SECRET}` },
+    url: `https://example.invalid/${URL_SECRET}`,
+    provider: PROVIDER_SECRET,
+    diagnosticNote: ARBITRARY_SECRET,
+  });
+  Object.defineProperty(error, "stack", {
+    configurable: true,
+    value: `Error: synthetic failure ${STACK_SECRET}`,
+  });
+  return error;
+}
+
+function hostileError(): Error {
+  const hostile = new Proxy(
+    {},
+    {
+      ownKeys() {
+        throw new Error("F8_LOCAL_HOSTILE_PROXY_MUST_NOT_ESCAPE");
+      },
+    },
+  );
+  return Object.assign(new Error("synthetic hostile failure"), { statusCode: hostile });
+}
+
+function engine(readFailure: () => unknown): CoachEngine {
+  return {
+    chat: async () => {
+      throw readFailure();
+    },
+    resetSession: async () => ({ memoryFlushed: true }),
+    hasSession: async () => ({ hasSession: false }),
+    getAthleteState: async () => state,
+  };
+}
+
+async function loopbackAvailable(): Promise<boolean> {
+  return new Promise((resolve) => {
+    const server = createNetServer();
+    server.once("error", (error: NodeJS.ErrnoException) => {
+      if (error.code === "EPERM") {
+        process.stderr.write("SKIP_MARKER loopback-listen EPERM enduragent-redaction\n");
+      }
+      resolve(false);
+    });
+    server.listen({ host: "127.0.0.1", port: 0 }, () => server.close(() => resolve(true)));
+  });
+}
+
+const hasLoopback = await loopbackAvailable();
+
+describe.skipIf(!hasLoopback)("local CLI redaction boundary", () => {
+  it("renders local engine failures only through redacted terminal envelopes", async () => {
+    const root = await mkdtemp(join(await realpath(tmpdir()), "enduragent-redaction-"));
+    roots.push(root);
+    const env = {
+      ENDURAGENT_HOME: root,
+      CYCLING_COACH_HOME: root,
+    };
+    const home = resolveAthleteHome(env);
+    let failure: unknown = fabricatedError();
+    const coachEngine = engine(() => failure);
+    const withLocalCoach: EnduragentDependencies["withLocalCoach"] = async <T>(
+      input: WithLocalCoachInput<T>,
+    ) => {
+      const value = await withCoachStoreWriter(env, async (context) =>
+        input.operation({
+          engine: coachEngine,
+          listener: context.listener,
+          close: async () => {},
+        }),
+      );
+      return { status: "completed", value };
+    };
+    const dependencies: EnduragentDependencies = {
+      resolveAthleteHome: () => home,
+      withLocalCoach,
+      readPackageVersion: async () => "synthetic",
+    };
+
+    for (const outputMode of ["--stream-json", "--json", undefined] as const) {
+      failure = fabricatedError();
+      const stdout = capture();
+      const stderr = capture();
+      const result = await runEnduragent(
+        {
+          argv: [
+            "ask",
+            "synthetic request",
+            "--local",
+            "--session",
+            "synthetic",
+            ...(outputMode === undefined ? [] : [outputMode]),
+          ],
+          env,
+          terminal: {
+            input: new PassThrough(),
+            stdout: stdout.stream,
+            stderr: stderr.stream,
+            isTTY: false,
+          },
+          signal: new AbortController().signal,
+        },
+        dependencies,
+      );
+      expect(result).toBe(EXIT_AGENT_ERROR);
+      expect(stderr.read()).toBe("Enduragent could not complete this command.\n");
+      if (outputMode === "--stream-json") {
+        const lines = stdout.read().trimEnd().split("\n");
+        expect(lines).toHaveLength(1);
+        const line = lines[0];
+        if (line === undefined) throw new TypeError("missing local terminal line");
+        const envelope = JsonRpcErrorResponseEnvelopeSchema.parse(JSON.parse(line));
+        expect(envelope).toEqual({
+          jsonrpc: "2.0",
+          id: 1,
+          error: {
+            code: -32603,
+            message: "Internal error",
+            data: {
+              name: "Error",
+              statusCode: 503,
+              apiKey: "[redacted]",
+              nested: { authorization: "[redacted]" },
+              diagnosticNote: "[redacted]",
+            },
+          },
+        });
+      } else {
+        expect(stdout.read()).toBe("");
+      }
+      const emitted = `${stdout.read()}${stderr.read()}`;
+      for (const secret of [
+        API_KEY_SECRET,
+        MESSAGE_SECRET,
+        STACK_SECRET,
+        URL_SECRET,
+        PROVIDER_SECRET,
+        ARBITRARY_SECRET,
+        NESTED_SECRET,
+      ]) {
+        expect(emitted).not.toContain(secret);
+      }
+      await expect(withCoachStoreWriter(env, async () => undefined)).resolves.toBeUndefined();
+    }
+
+    for (const variant of [
+      { failure: NON_ERROR_SECRET, data: { name: "NonError" } },
+      { failure: hostileError(), data: { name: "UnserializableError" } },
+    ]) {
+      failure = variant.failure;
+      const stdout = capture();
+      const stderr = capture();
+      await expect(
+        runEnduragent(
+          {
+            argv: ["ask", "synthetic request", "--local", "--stream-json"],
+            env,
+            terminal: {
+              input: new PassThrough(),
+              stdout: stdout.stream,
+              stderr: stderr.stream,
+              isTTY: false,
+            },
+            signal: new AbortController().signal,
+          },
+          dependencies,
+        ),
+      ).resolves.toBe(EXIT_AGENT_ERROR);
+      const envelope = JsonRpcErrorResponseEnvelopeSchema.parse(JSON.parse(stdout.read().trim()));
+      expect(envelope.error.data).toEqual(variant.data);
+      expect(`${stdout.read()}${stderr.read()}`).not.toContain(String(variant.failure));
+    }
+  });
+
+  it("keeps transport classifications fixed without fabricating terminals", async () => {
+    const root = await mkdtemp(join(await realpath(tmpdir()), "enduragent-transport-redaction-"));
+    roots.push(root);
+    const env = { ENDURAGENT_HOME: root, CYCLING_COACH_HOME: root };
+    const home = resolveAthleteHome(env);
+    const rows = [
+      {
+        failure: Object.assign(new CoachRemoteError({ kind: "agent" }), {
+          apiKey: API_KEY_SECRET,
+          diagnosticNote: ARBITRARY_SECRET,
+        }),
+        exit: EXIT_AGENT_ERROR,
+        stderr: "Enduragent could not complete this command.\n",
+      },
+      {
+        failure: Object.assign(new CoachRemoteError({ kind: "unavailable" }), {
+          apiKey: API_KEY_SECRET,
+          diagnosticNote: ARBITRARY_SECRET,
+        }),
+        exit: EXIT_DAEMON_UNAVAILABLE,
+        stderr: "Enduragent could not reach the local service.\n",
+      },
+    ];
+    for (const row of rows) {
+      for (const outputMode of ["--stream-json", "--json", undefined] as const) {
+        const stdout = capture();
+        const stderr = capture();
+        const transport: CoachVerbTransport = {
+          kind: "remote",
+          request: async () => {
+            throw row.failure;
+          },
+          close: async () => {},
+        };
+        const result = await runEnduragent(
+          {
+            argv: ["ask", "synthetic request", ...(outputMode === undefined ? [] : [outputMode])],
+            env,
+            terminal: {
+              input: new PassThrough(),
+              stdout: stdout.stream,
+              stderr: stderr.stream,
+              isTTY: false,
+            },
+            signal: new AbortController().signal,
+          },
+          {
+            resolveAthleteHome: () => home,
+            withLocalCoach: async () => {
+              throw new Error("local runner must not be used");
+            },
+            readPackageVersion: async () => "synthetic",
+            connectRemoteTransport: async () => transport,
+          },
+        );
+        expect(result).toBe(row.exit);
+        expect(stdout.read()).toBe("");
+        expect(stderr.read()).toBe(row.stderr);
+        expect(`${stdout.read()}${stderr.read()}`).not.toContain(API_KEY_SECRET);
+        expect(`${stdout.read()}${stderr.read()}`).not.toContain(ARBITRARY_SECRET);
+      }
+    }
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -49,6 +49,8 @@ export { appendUsageLine, USAGE_LEDGER_FILE, USAGE_LEDGER_MAX_BYTES } from "./us
 export {
   createSubsystemLogger,
   createSubsystemLoggers,
+  redactObject,
+  REDACTION_SENTINEL,
   serializeError,
   LOG_LEVELS,
   normalizeLogLevel,


### PR DESCRIPTION
## Summary

Closes the daemon train with the redaction boundary:

- Every error crossing the RPC boundary (daemon) and the CLI boundary passes the redaction walk (core `logging/redact.ts` + `serialize-error.ts` via coach's transitional core edge); `redactObject` added to core's barrel.
- The local transport helper now propagates caught engine failures cause-preservingly to the composition root instead of discarding them, keeping classification and exits identical.
- Proven with a fabricated apiKey-bearing error arriving redacted at the CLI and the daemon token absent from logs; synthetic-secret fixtures only.
- The composition adapter from the extraction train stays untouched.

## Verification

- Boundary unit tests, core regressions (26), and CLI suite (42) green; socket-bound cases verified in the root gate.
- Root `pnpm build`, `pnpm check`, full `pnpm test` green after rebase.
