### PR TITLE
fix(coach): reuse held writer in daemon refresh windows

### DIFF
--- a/.changeset/daemon-first-run-writer.md
+++ b/.changeset/daemon-first-run-writer.md
@@ -1,0 +1,8 @@
+---
+"@enduragent/coach": patch
+"@enduragent/core": patch
+---
+
+User-facing: Enduragent now starts normally on a fresh athlete home and reports useful Reference sync errors.
+
+Reuse the daemon lifecycle's authoritative store writer during refresh windows instead of attempting a nested writer acquisition.

--- a/packages/coach/src/capture.ts
+++ b/packages/coach/src/capture.ts
@@ -21,7 +21,10 @@ import {
 import { createNodeCrypto, createNodeImportRuntime } from "@enduragent/kernel-node/ingest";
 import { REQUEST_ATTEMPTS, type IntervalsIcuCaptureSource, type ReferenceCaptureBatch } from "@enduragent/sync-intervals-icu";
 import { createIntervalsBackfillSource, DEFAULT_PER_REQUEST_TIMEOUT_MS, DEFAULT_REQUEST_INTERVAL_MS } from "./backfill.js";
-import { withCoachStoreWriter } from "./runtime.js";
+import {
+  withCoachStoreWriter,
+  type CoachStoreWriterContext,
+} from "./runtime.js";
 
 export type ReferenceCaptureFailureCategory = "capture" | "persistence" | "validation";
 
@@ -38,6 +41,7 @@ class ReferenceCaptureValidationError extends Error {}
 
 export interface RunReferenceCaptureOptions {
   readonly env: Record<string, string | undefined>;
+  readonly writerContext?: CoachStoreWriterContext;
   readonly apiKey: string;
   readonly athleteId: string;
   readonly reviewedOn: string;
@@ -105,7 +109,7 @@ export async function runReferenceCapture(
     throw new ReferenceCaptureRunError("validation", { cause: error });
   }
 
-  return withCoachStoreWriter(options.env, async ({ home, store }) => {
+  const capture = async ({ home, store }: CoachStoreWriterContext): Promise<ReferenceCaptureManifest> => {
     const crypto = createNodeCrypto();
     const node = createNodeImportRuntime({ archiveDir: home.archiveDir, store });
     const source = createIntervalsBackfillSource({
@@ -240,7 +244,10 @@ export async function runReferenceCapture(
     } catch (error) {
       throw new ReferenceCaptureRunError(error instanceof ReferenceCaptureValidationError ? "validation" : "persistence", { cause: error });
     }
-  });
+  };
+  return options.writerContext === undefined
+    ? withCoachStoreWriter(options.env, capture)
+    : capture(options.writerContext);
 }
 
 export function referenceCaptureEvidenceSha256Input(manifest: ReferenceCaptureManifest): Uint8Array {

--- a/packages/coach/src/composition.ts
+++ b/packages/coach/src/composition.ts
@@ -239,6 +239,7 @@ export async function createLocalCoachComposition(
       config: input.config,
       home: input.home,
       reference,
+      writerContext: input.context,
       dependencies: dependencies.runtimeDependencies,
     };
     runtime = dependencies.createRuntime === undefined

--- a/packages/coach/src/store-runtime.ts
+++ b/packages/coach/src/store-runtime.ts
@@ -13,6 +13,7 @@ import type { AthleteHome } from "@enduragent/kernel-node/home";
 import { join } from "node:path";
 import { runReferenceCapture } from "./capture.js";
 import { createLocalBundleProducer } from "./local-bundle-producer.js";
+import type { CoachStoreWriterContext } from "./runtime.js";
 import {
   createWallClockScheduler,
   type WallClockScheduler,
@@ -46,7 +47,15 @@ export interface StoreRuntimeOptions {
   readonly config: Config;
   readonly home: AthleteHome;
   readonly reference: ReferenceRuntime;
+  readonly writerContext?: CoachStoreWriterContext;
   readonly dependencies?: StoreRuntimeDependencies;
+}
+
+function sameHome(left: AthleteHome, right: AthleteHome): boolean {
+  return left.root === right.root
+    && left.storeDir === right.storeDir
+    && left.archiveDir === right.archiveDir
+    && left.configDir === right.configDir;
 }
 
 export class StoreRuntime {
@@ -61,6 +70,9 @@ export class StoreRuntime {
   private closed = false;
 
   constructor(private readonly options: StoreRuntimeOptions) {
+    if (options.writerContext !== undefined && !sameHome(options.home, options.writerContext.home)) {
+      throw new TypeError("Writer home does not match the store runtime home.");
+    }
     const dependencies = options.dependencies ?? {};
     const now = dependencies.now ?? (() => new Date());
     const schedulerDependencies = dependencies.schedulerDependencies ?? {};
@@ -133,6 +145,9 @@ export class StoreRuntime {
     try {
       const capturePromise = this.dependencies.capture({
         env: this.options.env,
+        ...(this.options.writerContext === undefined
+          ? {}
+          : { writerContext: this.options.writerContext }),
         apiKey: this.options.config.intervals.apiKey,
         athleteId: this.options.config.intervals.athleteId,
         reviewedOn: now.toISOString().slice(0, 10),

--- a/packages/coach/tests/composition.test.ts
+++ b/packages/coach/tests/composition.test.ts
@@ -14,6 +14,8 @@ import type {
 } from "@enduragent/engine";
 import { createPhysicalRequestLedger, runMigrations } from "@enduragent/kernel/store";
 import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
+import type { ReferenceCaptureManifest } from "@enduragent/kernel/reference/capture";
+import type { ProducedLocalBundle } from "@enduragent/kernel/reference/local-bundle";
 import type { CyclingFtpAnchorResolver } from "@enduragent/kernel/anchors";
 import type { AthleteHome } from "@enduragent/kernel-node/home";
 import { inertWriterProtocolListener } from "@enduragent/kernel-node/lock";
@@ -210,6 +212,45 @@ afterEach(async () => {
 });
 
 describe("local coach composition", () => {
+  it("reuses the lifecycle writer in the first store window without nested acquisition", async () => {
+    const home = await freshHome();
+    const context = fakeContext(home);
+    const nestedWriterAcquisition = vi.fn(() => {
+      throw new Error("nested writer acquisition");
+    });
+    const manifest = {
+      capture_id: "12345678-1234-4123-8123-123456789abc",
+      plan: { frozenNow: "1998-07-18T12:00:00.000Z" },
+    } as ReferenceCaptureManifest;
+    const produced: ProducedLocalBundle = {
+      captureId: manifest.capture_id,
+      frozenNow: manifest.plan.frozenNow,
+      bundle: { activities: [], wellness: [], ftpHistory: [] },
+    };
+    const capture = vi.fn(async (
+      options: Parameters<typeof import("../src/capture.js").runReferenceCapture>[0],
+    ) => {
+      if (options.writerContext === undefined) nestedWriterAcquisition();
+      expect(options.writerContext).toBe(context);
+      return manifest;
+    });
+    const lifecycle = await compose(home, {
+      bootstrap: async () => reference(),
+      runtimeDependencies: {
+        capture,
+        produce: async () => produced,
+        now: () => new Date("1998-07-18T12:00:00.000Z"),
+        monotonicNow: () => 1,
+      },
+      createBackend: () => backend(),
+      createRepository: () => ({ insertIfAbsent: async () => false, readCurrent: async () => undefined }),
+      createResolver: () => missingResolver(),
+    }, context);
+    expect(capture).toHaveBeenCalledTimes(1);
+    expect(nestedWriterAcquisition).not.toHaveBeenCalled();
+    await lifecycle.close();
+  });
+
   it("constructs the complete object-shaped engine input from named host owners", async () => {
     const home = await freshHome();
     const selectedRuntime = runtime();

--- a/packages/coach/tests/first-run-serve.integration.test.ts
+++ b/packages/coach/tests/first-run-serve.integration.test.ts
@@ -1,0 +1,174 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { createConnection, createServer } from "node:net";
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  realpath,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  HEALTHZ_SERVICE_MARKER,
+  LOCKFILE_NAME,
+  PORT_FILE_NAME,
+} from "@enduragent/kernel-node/lock";
+
+const binary = fileURLToPath(new URL("../dist/enduragent.js", import.meta.url));
+const fetchStub = fileURLToPath(new URL("./fixtures/serve-fetch-stub.mjs", import.meta.url));
+const roots: string[] = [];
+const children = new Set<ChildProcessWithoutNullStreams>();
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function loopbackAvailable(): Promise<boolean> {
+  return new Promise((resolve) => {
+    const server = createServer();
+    server.once("error", (error: NodeJS.ErrnoException) => {
+      if (error.code === "EPERM") {
+        process.stderr.write("SKIP_MARKER loopback-listen EPERM first-run-serve\n");
+      }
+      resolve(false);
+    });
+    server.listen({ host: "127.0.0.1", port: 0 }, () => {
+      server.close(() => resolve(true));
+    });
+  });
+}
+
+async function unixConnectAvailable(): Promise<boolean> {
+  const root = await mkdtemp(join(await realpath(tmpdir()), "serve-unix-probe-"));
+  try {
+    return await new Promise((resolve) => {
+      const socket = createConnection(join(root, "absent.sock"));
+      socket.once("connect", () => {
+        socket.destroy();
+        resolve(true);
+      });
+      socket.once("error", (error: NodeJS.ErrnoException) => {
+        if (error.code === "EPERM") {
+          process.stderr.write("SKIP_MARKER unix-connect EPERM first-run-serve\n");
+          resolve(false);
+          return;
+        }
+        resolve(error.code === "ENOENT");
+      });
+    });
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+const hasSockets = await loopbackAvailable() && await unixConnectAvailable();
+
+afterEach(async () => {
+  for (const child of children) child.kill("SIGKILL");
+  children.clear();
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+function childExit(child: ChildProcessWithoutNullStreams): Promise<{
+  readonly code: number | null;
+  readonly signal: NodeJS.Signals | null;
+}> {
+  return new Promise((resolve) => {
+    child.once("exit", (code, signal) => resolve({ code, signal }));
+  });
+}
+
+describe.skipIf(!hasSockets)("first-run serve process", () => {
+  it("boots a fresh home through /healthz and shuts down cleanly", async () => {
+    const scratchRoot = process.platform === "darwin" ? "/private/tmp" : await realpath(tmpdir());
+    const scratch = await mkdtemp(join(scratchRoot, "ea-serve-"));
+    roots.push(scratch);
+    const home = join(scratch, "athlete-home");
+    const configDir = join(home, "config");
+    await mkdir(home, { mode: 0o700 });
+    await Promise.all([
+      mkdir(configDir, { mode: 0o700 }),
+      mkdir(join(scratch, "home"), { recursive: true }),
+      mkdir(join(scratch, "cache"), { recursive: true }),
+      mkdir(join(scratch, "tmp"), { recursive: true }),
+    ]);
+    await writeFile(join(configDir, "config.yaml"), [
+      "data_source: store",
+      `data_dir: ${JSON.stringify(home)}`,
+      "llm:",
+      "  provider: anthropic",
+      "  model: synthetic",
+      "  api_key: synthetic",
+      "intervals:",
+      "  api_key: synthetic",
+      "  athlete_id: synthetic",
+      "session:",
+      "  timezone: UTC",
+      "",
+    ].join("\n"));
+
+    const child = spawn(process.execPath, [binary, "serve"], {
+      env: {
+        ...process.env,
+        HOME: join(scratch, "home"),
+        XDG_CONFIG_HOME: join(scratch, "config-home"),
+        XDG_CACHE_HOME: join(scratch, "cache"),
+        TMPDIR: join(scratch, "tmp"),
+        ENDURAGENT_HOME: home,
+        CYCLING_COACH_HOME: join(scratch, "legacy-home"),
+        NODE_OPTIONS: `--disable-warning=ExperimentalWarning --import=${fetchStub}`,
+        FORCE_COLOR: undefined,
+        CLICOLOR_FORCE: undefined,
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    children.add(child);
+    const exited = childExit(child);
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => { stdout += String(chunk); });
+    child.stderr.on("data", (chunk) => { stderr += String(chunk); });
+
+    const deadline = Date.now() + 15_000;
+    let health: Response | undefined;
+    while (Date.now() < deadline && health === undefined) {
+      if (child.exitCode !== null || child.signalCode !== null) {
+        throw new Error(`serve exited before healthz: ${child.exitCode}/${child.signalCode}\n${stdout}${stderr}`);
+      }
+      try {
+        const port = Number((await readFile(join(configDir, PORT_FILE_NAME), "utf8")).trim());
+        if (Number.isInteger(port) && port > 0) {
+          const response = await fetch(`http://127.0.0.1:${port}/healthz`, {
+            signal: AbortSignal.timeout(500),
+          });
+          if (response.status === 200) health = response;
+        }
+      } catch {}
+      if (health === undefined) await delay(25);
+    }
+    if (health === undefined) {
+      throw new Error(`serve did not publish healthz\n${stdout}${stderr}`);
+    }
+    await expect(health.json()).resolves.toMatchObject({
+      service: HEALTHZ_SERVICE_MARKER,
+      version: "0.0.1",
+    });
+
+    child.kill("SIGTERM");
+    const result = await Promise.race([
+      exited,
+      delay(5_000).then(() => ({ code: null, signal: "SIGKILL" as const })),
+    ]);
+    if (result.signal === "SIGKILL") child.kill("SIGKILL");
+    children.delete(child);
+    expect(result).toEqual({ code: 0, signal: null });
+    expect(stdout).toBe("");
+    expect(stderr).not.toContain("coach store writer is already active");
+    await expect(readFile(join(configDir, PORT_FILE_NAME), "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(readFile(join(configDir, LOCKFILE_NAME), "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+  }, 25_000);
+});

--- a/packages/coach/tests/fixtures/serve-fetch-stub.mjs
+++ b/packages/coach/tests/fixtures/serve-fetch-stub.mjs
@@ -1,0 +1,10 @@
+globalThis.fetch = async (input) => {
+  const url = new URL(input instanceof Request ? input.url : String(input));
+  const payload = url.pathname.endsWith("/activities") || url.pathname.endsWith("/wellness")
+    ? []
+    : { sportSettings: [] };
+  return new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+};

--- a/packages/core/src/reference/sync/fetch-live-bundle.ts
+++ b/packages/core/src/reference/sync/fetch-live-bundle.ts
@@ -16,6 +16,7 @@
 // `SYNC_OPERATION_TIMEOUT_MS` budget.
 
 import { snakeCaseKeys } from "intervals-icu-api";
+import { serializeError } from "../../logging/serialize-error.js";
 import {
   REFERENCE_CAPTURE_STREAM_LIMIT,
   REFERENCE_CAPTURE_STREAM_TYPES,
@@ -154,6 +155,13 @@ function sleep(ms: number, signal: AbortSignal): Promise<void> {
   });
 }
 
+function renderEndpointError(error: unknown): string {
+  const serializable = error !== null && typeof error === "object" && !(error instanceof Error)
+    ? Object.assign(new Error("Reference endpoint failed"), error)
+    : error;
+  return JSON.stringify(serializeError(serializable));
+}
+
 /**
  * Fetch + assemble the live Reference bundle. Throws only on a hard
  * precondition failure (activities list unreachable) or a surviving
@@ -172,7 +180,7 @@ export async function fetchLiveBundle(deps: LiveFetchDeps): Promise<LiveFetchRes
 
   const athleteResult = await client.athlete.get();
   if (!athleteResult.ok) {
-    const detail = String(athleteResult.error);
+    const detail = renderEndpointError(athleteResult.error);
     log(`Reference: athlete.get failed: ${detail}`);
     fetchErrors.push({ endpoint: "athlete", detail });
   }
@@ -180,7 +188,7 @@ export async function fetchLiveBundle(deps: LiveFetchDeps): Promise<LiveFetchRes
 
   const actResult = await client.activities.list({ oldest, newest });
   if (!actResult.ok) {
-    throw new Error(`activities.list failed: ${String(actResult.error)}`);
+    throw new Error(`activities.list failed: ${renderEndpointError(actResult.error)}`);
   }
   // The lib auto-camelCases activity responses; ActivitySchema requires
   // snake_case (start_date_local, icu_training_load, …). Reverse it here only —
@@ -195,7 +203,7 @@ export async function fetchLiveBundle(deps: LiveFetchDeps): Promise<LiveFetchRes
 
   const wellResult = await client.wellness.list({ oldest, newest });
   if (!wellResult.ok) {
-    const detail = String(wellResult.error);
+    const detail = renderEndpointError(wellResult.error);
     log(`Reference: wellness.list failed: ${detail}`);
     fetchErrors.push({ endpoint: "wellness", detail });
   }
@@ -279,7 +287,7 @@ async function fetchStreams(
       continue;
     }
     if (!result.ok) {
-      log(`Reference: streams fetch failed for an activity: ${String(result.error)}`);
+      log(`Reference: streams fetch failed for an activity: ${renderEndpointError(result.error)}`);
       continue;
     }
     const parsed = ActivityStreamsSchema.safeParse(normalizeStreams(result.value));

--- a/packages/core/tests/reference-fetch-live-bundle.test.ts
+++ b/packages/core/tests/reference-fetch-live-bundle.test.ts
@@ -261,6 +261,32 @@ describe("fetchLiveBundle — real lib stream shapes + edge cases", () => {
     expect(logs.some((l) => l.includes("athlete.get failed"))).toBe(true);
   });
 
+  it("serializes structured endpoint errors without Object stringification", async () => {
+    const logs: string[] = [];
+    const client: BundleFetchClient = {
+      athlete: {
+        get: async () => ({
+          ok: false,
+          error: { kind: "Http", status: 401, message: "synthetic unauthorized" } as never,
+        }),
+      },
+      activities: { list: async () => ({ ok: true, value: [] }), getStreams: async () => STREAM_OK },
+      wellness: { list: async () => ({ ok: true, value: [] }) },
+    };
+    const result = await fetchLiveBundle({
+      client,
+      signal: new AbortController().signal,
+      now: NOW,
+      throttleMs: 0,
+      log: (message) => logs.push(message),
+    });
+    expect(logs[0]).toContain('"message":"synthetic unauthorized"');
+    expect(logs[0]).toContain('"stack":');
+    expect(logs[0]).toContain('"kind":"Http"');
+    expect(logs[0]).not.toContain("[object Object]");
+    expect(result.fetchErrors?.[0]?.detail).toBe(logs[0]?.replace("Reference: athlete.get failed: ", ""));
+  });
+
   it("records a fetchErrors entry naming the athlete endpoint when athlete.get fails (still a usable bundle)", async () => {
     const client: BundleFetchClient = {
       athlete: { get: async () => ({ ok: false, error: "unauthorized" }) },


### PR DESCRIPTION
## Summary

Fixes a live-probe-discovered defect: `enduragent serve` exited 1 on every fresh-home first run before publishing `/healthz`, with `CoachStoreWriterError: coach store writer is already active` — the daemon composition holds the store writer for its lifecycle while the store runtime's refresh window independently re-acquired it.

- Daemon refresh windows now reuse the lifecycle-held writer context after validating it belongs to the same athlete home; the bot and standalone capture paths still acquire per operation; `withCoachStoreWriter` contention and refusal semantics are untouched, so distinct or cross-process writers still fail closed.
- Structured endpoint failures now pass through `serializeError` — the startup refusal renders the real message instead of `[object Object]`.
- Regression coverage: a first-run serve integration test (boot to `/healthz`, clean SIGTERM teardown, lock/port files removed) plus non-nested-acquisition and error-rendering units.

## Verification

- Fresh-home `enduragent serve` boots, serves `/healthz`, exits 0 on SIGTERM with lock/port cleanup — verified live on macOS.
- Focused suites 43/43; root `pnpm build`, `pnpm check`, full `pnpm test` green.
