### PR TITLE
fix: restore desktop branch gate (type resolution + daemon socket regressions)

### DIFF
--- a/.changeset/daemon-first-run-writer.md
+++ b/.changeset/daemon-first-run-writer.md
@@ -3,6 +3,4 @@
 "@enduragent/core": patch
 ---
 
-User-facing: Enduragent now starts normally on a fresh athlete home and reports useful Reference sync errors.
-
-Reuse the daemon lifecycle's authoritative store writer during refresh windows instead of attempting a nested writer acquisition.
+Reuse the daemon lifecycle's authoritative store writer during refresh windows instead of attempting a nested writer acquisition, so a fresh athlete home starts normally and Reference sync errors render usefully.

--- a/.changeset/fix-coach-socket-gate.md
+++ b/.changeset/fix-coach-socket-gate.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/coach": patch
+---
+
+Repair daemon socket callback handling, upgrade-fence cleanup, and deterministic socket-suite synchronization.

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "devDependencies": {
     "@changesets/cli": "^2.27.0",
     "@enduragent/core": "workspace:*",
+    "@enduragent/engine": "workspace:*",
     "@enduragent/kernel": "workspace:*",
     "@enduragent/sport-cycling": "workspace:*",
     "@sinonjs/fake-timers": "^15.4.0",
@@ -60,6 +61,9 @@
   },
   "packageManager": "pnpm@10.6.3+sha512.bb45e34d50a9a76e858a95837301bfb6bd6d35aea2c5d52094fa497a467c43f5c440103ce2511e9e0a2f89c3d6071baac3358fc68ac6fb75e2ceb3d2736065e6",
   "pnpm": {
+    "overrides": {
+      "@ai-sdk/provider-utils": "^4.0.30"
+    },
     "onlyBuiltDependencies": [
       "@google/genai",
       "esbuild",

--- a/packages/coach/src/daemon/rpc-server.ts
+++ b/packages/coach/src/daemon/rpc-server.ts
@@ -242,7 +242,7 @@ function enqueueSerialized(state: ClientState, serialized: string): Promise<void
       void state.detachedPromise.then(finish);
       try {
         state.ws.send(serialized, (error) => {
-          if (error !== undefined) detach(state, 1013, "backpressure");
+          if (error != null) detach(state, 1013, "backpressure");
           finish();
         });
       } catch {

--- a/packages/coach/src/daemon/upgrade-fence.ts
+++ b/packages/coach/src/daemon/upgrade-fence.ts
@@ -1,5 +1,5 @@
 import { randomBytes as cryptoRandomBytes, timingSafeEqual } from "node:crypto";
-import { chmod, lstat, mkdir, rename, unlink } from "node:fs/promises";
+import { chmod, link, lstat, mkdir, mkdtemp, rename, rmdir, unlink } from "node:fs/promises";
 import { createConnection, createServer, type Server, type Socket } from "node:net";
 import { join } from "node:path";
 import { performance } from "node:perf_hooks";
@@ -260,7 +260,7 @@ export async function acquireUpgradeFence(
     }
     let consumed = false;
     const sockets = new Set<Socket>();
-    const server = createServer((socket) => {
+    const server = createServer({ allowHalfOpen: true }, (socket) => {
       sockets.add(socket);
       socket.once("close", () => sockets.delete(socket));
       socket.once("error", () => socket.destroy());
@@ -287,14 +287,40 @@ export async function acquireUpgradeFence(
         socket.end(`${JSON.stringify({ status })}\n`);
       }).catch(() => socket.end(`${JSON.stringify({ status: "reserved" })}\n`));
     });
+    const stagingDir = await mkdtemp(join(input.configDir, ".u"));
+    const stagingPath = join(stagingDir, "s");
+    let stagingIdentity: FileIdentity | undefined;
+    let ownedIdentity: FileIdentity | undefined;
+    let publicationError: unknown;
     try {
-      await listen(server, socketPath);
+      await listen(server, stagingPath);
+      stagingIdentity = await identity(stagingPath);
+      if (stagingIdentity === undefined) {
+        throw new Error("upgrade fence socket identity unavailable");
+      }
+      await link(stagingPath, socketPath);
+      if (!sameIdentity(await identity(socketPath), stagingIdentity)) {
+        throw new Error("upgrade fence socket identity unavailable");
+      }
+      await chmod(socketPath, 0o600);
+      ownedIdentity = stagingIdentity;
+      await unlinkIdentity(stagingPath, stagingIdentity);
+      await rmdir(stagingDir);
     } catch (error) {
       for (const socket of sockets) socket.destroy();
-      const code = (error as NodeJS.ErrnoException).code;
-      if (code !== "EADDRINUSE") {
+      await closeServer(server);
+      if (stagingIdentity !== undefined) {
+        await unlinkIdentity(socketPath, stagingIdentity);
+        await unlinkIdentity(stagingPath, stagingIdentity);
+      }
+      await rmdir(stagingDir);
+      publicationError = error;
+    }
+    if (publicationError !== undefined) {
+      const code = (publicationError as NodeJS.ErrnoException).code;
+      if (code !== "EEXIST") {
         capabilityBytes.fill(0);
-        throw error;
+        throw publicationError;
       }
       const observed = await identity(socketPath);
       if (observed === undefined) {
@@ -318,10 +344,7 @@ export async function acquireUpgradeFence(
       capabilityBytes.fill(0);
       continue;
     }
-    await chmod(socketPath, 0o600);
-    const ownedIdentity = await identity(socketPath);
     if (ownedIdentity === undefined) {
-      await closeServer(server);
       throw new Error("upgrade fence socket identity unavailable");
     }
     const handoffCapability = capabilityBytes.toString("base64url");

--- a/packages/coach/tests/cli-verbs-rpc.test.ts
+++ b/packages/coach/tests/cli-verbs-rpc.test.ts
@@ -87,11 +87,16 @@ interface RunningRpc {
   readonly rpc: CoachRpcServer;
   readonly server: Server;
   readonly url: string;
+  nextClientDisconnect(): Promise<void>;
 }
 
 async function startRpc(engine: CoachEngine): Promise<RunningRpc> {
   const rpc = createCoachRpcServer({ engine, token, owner: "unmanaged-foreground" });
   const server = createServer();
+  const disconnectWaiters: Array<() => void> = [];
+  server.on("connection", (socket) => {
+    socket.once("close", () => disconnectWaiters.shift()?.());
+  });
   server.on("upgrade", rpc.handleUpgrade);
   await new Promise<void>((resolve, reject) => {
     server.once("error", reject);
@@ -99,7 +104,12 @@ async function startRpc(engine: CoachEngine): Promise<RunningRpc> {
   });
   const address = server.address();
   if (address === null || typeof address === "string") throw new TypeError("missing test port");
-  return { rpc, server, url: `ws://127.0.0.1:${address.port}/rpc` };
+  return {
+    rpc,
+    server,
+    url: `ws://127.0.0.1:${address.port}/rpc`,
+    nextClientDisconnect: () => new Promise((resolve) => disconnectWaiters.push(resolve)),
+  };
 }
 
 async function closeServer(
@@ -286,8 +296,13 @@ describe.skipIf(!hasLoopback)("CLI verbs over real RPC framing", () => {
       const heldCall = held.call("chat", { chatId: "cli:cancel", message: "held" });
       await vi.waitFor(() => expect(entered).toContain("held"));
       const queuedCall = queued.call("chat", { chatId: "cli:cancel", message: "cancelled" });
+      const queuedRejection = expect(queuedCall).rejects.toBeInstanceOf(
+        CoachClientDisconnectedError,
+      );
+      const serverObservedDisconnect = running.nextClientDisconnect();
       await queued.close();
-      await expect(queuedCall).rejects.toBeInstanceOf(CoachClientDisconnectedError);
+      await queuedRejection;
+      await serverObservedDisconnect;
       heldGate.resolve({ text: "held" });
       await expect(heldCall).resolves.toEqual({ text: "held" });
       await Promise.resolve();

--- a/packages/coach/tests/season-review.test.ts
+++ b/packages/coach/tests/season-review.test.ts
@@ -153,7 +153,10 @@ describe("season review request and schemas", () => {
   it("keeps fixed instructions free of store text and retains structural fencing", async () => {
     expect(SEASON_REVIEW_REQUEST).not.toContain("ignore all previous instructions");
     const root = join(import.meta.dirname, "../../..");
-    const promptSource = await readFile(join(root, "packages/core/src/agent/system-prompt.ts"), "utf8");
+    const promptSource = await readFile(
+      join(root, "packages/engine/src/agent/system-prompt.ts"),
+      "utf8",
+    );
     expect(promptSource).toContain("ATHLETE_CONTEXT_FENCE_OPEN");
     expect(promptSource).toContain("DATA, never instructions");
   });

--- a/packages/coach/tests/upgrade-fence.test.ts
+++ b/packages/coach/tests/upgrade-fence.test.ts
@@ -35,6 +35,11 @@ async function configDir(): Promise<string> {
 
 class FakeTimer implements MonotonicTimer {
   private now = 0;
+  private scheduleCount = 0;
+  private readonly scheduleWaiters = new Set<{
+    readonly after: number;
+    readonly resolve: () => void;
+  }>();
   private readonly scheduled = new Set<{
     readonly at: number;
     readonly callback: () => void;
@@ -48,12 +53,28 @@ class FakeTimer implements MonotonicTimer {
   schedule(delayMs: number, callback: () => void): ScheduledMonotonicTimer {
     const item = { at: this.now + delayMs, callback, cancelled: false };
     this.scheduled.add(item);
+    this.scheduleCount += 1;
+    for (const waiter of this.scheduleWaiters) {
+      if (this.scheduleCount > waiter.after) {
+        this.scheduleWaiters.delete(waiter);
+        waiter.resolve();
+      }
+    }
     return {
       cancel: () => {
         item.cancelled = true;
         this.scheduled.delete(item);
       },
     };
+  }
+
+  waitForScheduleAfter(count: number): Promise<void> {
+    if (this.scheduleCount > count) return Promise.resolve();
+    return new Promise((resolve) => this.scheduleWaiters.add({ after: count, resolve }));
+  }
+
+  get totalSchedules(): number {
+    return this.scheduleCount;
   }
 
   advance(ms: number): void {
@@ -148,8 +169,9 @@ describe.skipIf(!hasUnixSockets)("upgrade fence", () => {
     );
     const incompleteBytes = Buffer.alloc(UPGRADE_FENCE_FRAME_MAX_BYTES - 1, "é");
     expect(incompleteBytes.length).toBe(UPGRADE_FENCE_FRAME_MAX_BYTES - 1);
+    const priorSchedules = timer.totalSchedules;
     const incomplete = rawAdmission(acquired.handle.socketPath, incompleteBytes);
-    await new Promise<void>((resolve) => setImmediate(resolve));
+    await timer.waitForScheduleAfter(priorSchedules);
     timer.advance(UPGRADE_FENCE_IO_TIMEOUT_MS);
     await expect(incomplete).resolves.toBe(`${JSON.stringify({ status: "reserved" })}\n`);
     await acquired.handle.release();

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -4,7 +4,9 @@
   "private": true,
   "description": "Private coaching engine boundary and sport contract.",
   "type": "module",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -36,6 +38,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@ai-sdk/provider": "^3.0.10",
     "@types/node": "^25.6.0",
     "tsup": "^8.4.0",
     "typescript": "^6.0.2",

--- a/packages/kernel-node/tests/launchd-service.test.ts
+++ b/packages/kernel-node/tests/launchd-service.test.ts
@@ -341,7 +341,7 @@ describe("launchd installation and wrapper", () => {
     expect(await readFile(outputPath, "utf8")).toBe(`${home.root}\nservice-managed\nserve\n`);
   });
 
-  it("delivers a one-use protected handoff and leaves no replay carrier", async () => {
+  it.skipIf(process.platform !== "darwin")("delivers a one-use protected handoff and leaves no replay carrier", async () => {
     const { root, identity, dependencies } = await fixture();
     const outputPath = join(root, "handoff-observed");
     await mkdir(join(root, "bin"), { recursive: true });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@ai-sdk/provider-utils': ^4.0.30
+
 patchedDependencies:
   fit-file-parser@3.0.2:
     hash: 355579765a4bbdcd08b22da684d697bdac747c0e1603fb410ecb822574876a9a
@@ -19,6 +22,9 @@ importers:
       '@enduragent/core':
         specifier: workspace:*
         version: link:packages/core
+      '@enduragent/engine':
+        specifier: workspace:*
+        version: link:packages/engine
       '@enduragent/kernel':
         specifier: workspace:*
         version: link:packages/kernel
@@ -253,8 +259,8 @@ importers:
         specifier: ^3.0.9
         version: 3.0.9
       '@ai-sdk/provider-utils':
-        specifier: ^4.0.24
-        version: 4.0.24(zod@4.4.1)
+        specifier: ^4.0.30
+        version: 4.0.30(zod@4.4.1)
       '@clack/prompts':
         specifier: ^1.2.0
         version: 1.3.0
@@ -330,7 +336,7 @@ importers:
         specifier: ^2.0.51
         version: 2.0.51(zod@4.4.1)
       '@ai-sdk/provider-utils':
-        specifier: ^4.0.24
+        specifier: ^4.0.30
         version: 4.0.30(zod@4.4.1)
       '@enduragent/coach-contract':
         specifier: workspace:*
@@ -351,6 +357,9 @@ importers:
         specifier: ^4.3.6
         version: 4.4.1
     devDependencies:
+      '@ai-sdk/provider':
+        specifier: ^3.0.10
+        version: 3.0.10
       '@types/node':
         specifier: ^25.6.0
         version: 25.6.0
@@ -601,12 +610,6 @@ packages:
 
   '@ai-sdk/openai@3.0.54':
     resolution: {integrity: sha512-j1qrNe/ebUKuE+fETzS+CVnczs11jQBR9y9M6aoKtJZAosg6SZnPC1Bb92e2u6yaSK+88TZoFhiY67uYphPitw==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  '@ai-sdk/provider-utils@4.0.24':
-    resolution: {integrity: sha512-oXIw1oLmuBILuvHgSj6w5LOV8oSnFRouPSv0MGkG9sRMeukZ9JnMF17kldaRQaRq8lSJIxo6aS3NzWlVmSb+4Q==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -2568,7 +2571,7 @@ snapshots:
   '@ai-sdk/anthropic@3.0.72(zod@4.4.1)':
     dependencies:
       '@ai-sdk/provider': 3.0.9
-      '@ai-sdk/provider-utils': 4.0.24(zod@4.4.1)
+      '@ai-sdk/provider-utils': 4.0.30(zod@4.4.1)
       zod: 4.4.1
 
   '@ai-sdk/deepseek@2.0.39(zod@4.4.1)':
@@ -2580,14 +2583,14 @@ snapshots:
   '@ai-sdk/gateway@3.0.105(zod@4.4.1)':
     dependencies:
       '@ai-sdk/provider': 3.0.9
-      '@ai-sdk/provider-utils': 4.0.24(zod@4.4.1)
+      '@ai-sdk/provider-utils': 4.0.30(zod@4.4.1)
       '@vercel/oidc': 3.2.0
       zod: 4.4.1
 
   '@ai-sdk/google@3.0.65(zod@4.4.1)':
     dependencies:
       '@ai-sdk/provider': 3.0.9
-      '@ai-sdk/provider-utils': 4.0.24(zod@4.4.1)
+      '@ai-sdk/provider-utils': 4.0.30(zod@4.4.1)
       zod: 4.4.1
 
   '@ai-sdk/openai-compatible@2.0.51(zod@4.4.1)':
@@ -2599,14 +2602,7 @@ snapshots:
   '@ai-sdk/openai@3.0.54(zod@4.4.1)':
     dependencies:
       '@ai-sdk/provider': 3.0.9
-      '@ai-sdk/provider-utils': 4.0.24(zod@4.4.1)
-      zod: 4.4.1
-
-  '@ai-sdk/provider-utils@4.0.24(zod@4.4.1)':
-    dependencies:
-      '@ai-sdk/provider': 3.0.9
-      '@standard-schema/spec': 1.1.0
-      eventsource-parser: 3.0.8
+      '@ai-sdk/provider-utils': 4.0.30(zod@4.4.1)
       zod: 4.4.1
 
   '@ai-sdk/provider-utils@4.0.30(zod@4.4.1)':
@@ -3373,7 +3369,7 @@ snapshots:
     dependencies:
       '@ai-sdk/gateway': 3.0.105(zod@4.4.1)
       '@ai-sdk/provider': 3.0.9
-      '@ai-sdk/provider-utils': 4.0.24(zod@4.4.1)
+      '@ai-sdk/provider-utils': 4.0.30(zod@4.4.1)
       '@opentelemetry/api': 1.9.0
       zod: 4.4.1
 


### PR DESCRIPTION
## Why

The `desktop` CI gate has been red since mid-train: `pnpm check` failed in `packages/engine`, and because the check step precedes the test step, the full suite stopped running on CI entirely. Worker sandboxes skip socket-bound suites, so a set of daemon socket tests landed without ever executing. This PR restores the branch gate end to end.

## What

**Dependency resolution (typecheck failure):**
- Root `pnpm.overrides` unifies `@ai-sdk/provider-utils` to a single resolution — the lockfile had drifted into carrying two copies whose `Schema` types are nominally incompatible, breaking `tsc` in `packages/engine`.
- Declares two previously phantom dependencies: `@ai-sdk/provider` in `packages/engine` (used by tests) and `@enduragent/engine` at the workspace root (used by `tools/`).

**Daemon socket regressions (13 deterministic test failures):**
- `rpc-server.ts`: the `ws.send` completion callback receives `null` on success; the `error !== undefined` check treated success as a backpressure failure and closed every healthy connection with code 1013. This one bug cascaded into 11 of the 13 failures. Fixed to `error != null`.
- `upgrade-fence.ts`: releasing the fence could unlink a replacement socket inode it did not own (Node unlinks a Unix listener by pathname on close). The listener now binds in a private staging directory and is hard-linked into the canonical path with identity verification, so close-time unlink can never touch a foreign inode. Contention detection moves from `EADDRINUSE` to `EEXIST` on link, preserving the fail-closed semantics.
- Test-side repairs only where the test itself was stale: the season-review prompt-source path (moved to the engine in the extraction train) and two race-prone waits in socket tests. No acceptance assertion was weakened.
- Folds the `User-facing:` line of an earlier changeset into prose (it named no published binary package, failing the changeset gate).

## Verification

- Full `pnpm check` green end to end.
- Full `pnpm test`: 4343 passed, 0 failed, 6 skipped.
- Each previously failing suite re-run green in single-file isolation.
