### PR TITLE
fix(coach): start service without provider credentials and report unusable socket paths

### DIFF
--- a/.changeset/daemon-unconfigured-start.md
+++ b/.changeset/daemon-unconfigured-start.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/coach": patch
+---
+
+Start the local service without an intervals.icu API key by skipping the provider capture lane, and report over-long fence socket paths truthfully instead of as an active handoff reservation.

--- a/packages/coach/src/daemon/upgrade-fence.ts
+++ b/packages/coach/src/daemon/upgrade-fence.ts
@@ -390,6 +390,11 @@ export async function admitStartupThroughUpgradeFence(input: {
     } catch (error) {
       const code = (error as NodeJS.ErrnoException).code;
       if (code === "ENOENT") return { status: "clear" };
+      if (code === "EINVAL" || code === "ENAMETOOLONG") {
+        throw new Error(
+          `Enduragent cannot start: upgrade fence socket path is too long for a Unix socket on this platform: ${socketPath}`,
+        );
+      }
       if (code !== "ECONNREFUSED") return reserved();
       const observed = await identity(socketPath);
       if (observed === undefined) return { status: "clear" };

--- a/packages/coach/src/store-runtime.ts
+++ b/packages/coach/src/store-runtime.ts
@@ -143,23 +143,25 @@ export class StoreRuntime {
       maxArtifacts: STORE_MAX_ARTIFACTS,
     };
     try {
-      const capturePromise = this.dependencies.capture({
-        env: this.options.env,
-        ...(this.options.writerContext === undefined
-          ? {}
-          : { writerContext: this.options.writerContext }),
-        apiKey: this.options.config.intervals.apiKey,
-        athleteId: this.options.config.intervals.athleteId,
-        reviewedOn: now.toISOString().slice(0, 10),
-        reason: this.snapshotValue === undefined ? "initial" : "provider-refresh",
-        ...(this.snapshotValue === undefined ? {} : { replacesCaptureId: this.snapshotValue.captureId }),
-        budget,
-        attemptLedger: ledger,
-      });
+      const capturePromise = this.options.config.intervals.apiKey.length === 0
+        ? Promise.resolve(undefined)
+        : this.dependencies.capture({
+            env: this.options.env,
+            ...(this.options.writerContext === undefined
+              ? {}
+              : { writerContext: this.options.writerContext }),
+            apiKey: this.options.config.intervals.apiKey,
+            athleteId: this.options.config.intervals.athleteId,
+            reviewedOn: now.toISOString().slice(0, 10),
+            reason: this.snapshotValue === undefined ? "initial" : "provider-refresh",
+            ...(this.snapshotValue === undefined ? {} : { replacesCaptureId: this.snapshotValue.captureId }),
+            budget,
+            attemptLedger: ledger,
+          });
       const legacyPromise = this.options.reference.runScheduledOnce();
       const [captureResult, legacyResult] = await Promise.allSettled([capturePromise, legacyPromise]);
       let published = false;
-      if (captureResult.status === "fulfilled") {
+      if (captureResult.status === "fulfilled" && captureResult.value !== undefined) {
         const produced = await this.dependencies.produce(captureResult.value);
         this.snapshotValue = produced;
         published = true;

--- a/packages/coach/tests/composition.test.ts
+++ b/packages/coach/tests/composition.test.ts
@@ -90,11 +90,14 @@ async function freshHome(): Promise<AthleteHome> {
   return home;
 }
 
-function config(home: AthleteHome): Config {
+function config(
+  home: AthleteHome,
+  intervals: Config["intervals"] = { apiKey: "", athleteId: "synthetic" },
+): Config {
   return {
     dataSource: "store",
     llm: { provider: "anthropic", model: "synthetic", apiKey: "" },
-    intervals: { apiKey: "", athleteId: "synthetic" },
+    intervals,
     telegram: { botToken: "" },
     session: {
       historyTokenBudgetRatio: 0.3,
@@ -179,8 +182,9 @@ async function compose(
   home: AthleteHome,
   dependencies: LocalCoachCompositionDependencies,
   context = fakeContext(home),
+  intervals?: Config["intervals"],
 ) {
-  const coreConfig = config(home);
+  const coreConfig = config(home, intervals);
   return createLocalCoachComposition({
     env: { ENDURAGENT_HOME: home.root },
     home,
@@ -245,7 +249,7 @@ describe("local coach composition", () => {
       createBackend: () => backend(),
       createRepository: () => ({ insertIfAbsent: async () => false, readCurrent: async () => undefined }),
       createResolver: () => missingResolver(),
-    }, context);
+    }, context, { apiKey: "dummy", athleteId: "synthetic" });
     expect(capture).toHaveBeenCalledTimes(1);
     expect(nestedWriterAcquisition).not.toHaveBeenCalled();
     await lifecycle.close();

--- a/packages/coach/tests/store-runtime.test.ts
+++ b/packages/coach/tests/store-runtime.test.ts
@@ -21,7 +21,7 @@ const manifest = { capture_id: "12345678-1234-4123-8123-123456789abc",
 const produced: ProducedLocalBundle = { captureId: manifest.capture_id, frozenNow: manifest.plan.frozenNow,
   bundle: { activities: [], wellness: [], ftpHistory: [], athlete: { sportSettings: [] } } };
 
-async function makeRuntime() {
+async function makeRuntime(runtimeConfig: Config = config) {
   const root = await mkdtemp(join(await realpath(tmpdir()), "store-runtime-")); roots.push(root);
   let runtime!: StoreRuntime;
   const reference = { scheduler: { stop: vi.fn() }, services: {},
@@ -33,11 +33,12 @@ async function makeRuntime() {
     options.attemptLedger!.charge("store", "store:settings");
     return manifest;
   });
-  runtime = createStoreRuntime({ env: {}, config, home: { root, storeDir: join(root, "store"),
+  const produce = vi.fn(async () => produced);
+  runtime = createStoreRuntime({ env: {}, config: runtimeConfig, home: { root, storeDir: join(root, "store"),
     archiveDir: join(root, "archive"), configDir: join(root, "config") }, reference,
-    dependencies: { capture, produce: vi.fn(async () => produced),
+    dependencies: { capture, produce,
       now: () => new Date("1998-07-18T12:00:00.000Z"), monotonicNow: () => 1 } });
-  return { runtime, capture, reference };
+  return { runtime, capture, produce, reference };
 }
 
 describe("StoreRuntime", () => {
@@ -47,6 +48,24 @@ describe("StoreRuntime", () => {
     expect(result.counts).toMatchObject({ storeRequests: 1, legacyRequests: 1, totalRequests: 2 });
     expect(reference.runScheduledOnce).toHaveBeenCalledTimes(1);
     expect(runtime.currentSnapshot()).toBe(produced);
+    await runtime.close();
+  });
+
+  it("runs the legacy lane without capture when the intervals.icu API key is empty", async () => {
+    const { runtime, capture, produce, reference } = await makeRuntime({
+      ...config,
+      intervals: { ...config.intervals, apiKey: "" },
+    });
+    const result = await runtime.runWindow();
+    expect(result).toMatchObject({
+      published: false,
+      counts: { storeRequests: 0, legacyRequests: 1, totalRequests: 1 },
+      legacySucceeded: true,
+    });
+    expect(capture).not.toHaveBeenCalled();
+    expect(produce).not.toHaveBeenCalled();
+    expect(reference.runScheduledOnce).toHaveBeenCalledTimes(1);
+    expect(runtime.currentSnapshot()).toBeUndefined();
     await runtime.close();
   });
 

--- a/packages/coach/tests/upgrade-fence.test.ts
+++ b/packages/coach/tests/upgrade-fence.test.ts
@@ -15,6 +15,7 @@ import {
   HANDOFF_RESERVED_MESSAGE,
   UPGRADE_FENCE_FRAME_MAX_BYTES,
   UPGRADE_FENCE_IO_TIMEOUT_MS,
+  UPGRADE_FENCE_SOCKET_NAME,
   acquireUpgradeFence,
   admitStartupThroughUpgradeFence,
   type MonotonicTimer,
@@ -116,6 +117,14 @@ async function unixSocketAvailable(): Promise<boolean> {
 const hasUnixSockets = await unixSocketAvailable();
 
 describe.skipIf(!hasUnixSockets)("upgrade fence", () => {
+  it.skipIf(process.platform !== "darwin")("reports an unusably long socket path", async () => {
+    const dir = join(await configDir(), "a".repeat(104));
+    expect(Buffer.byteLength(join(dir, UPGRADE_FENCE_SOCKET_NAME))).toBeGreaterThan(104);
+    await expect(admitStartupThroughUpgradeFence({ configDir: dir })).rejects.toThrow(
+      "upgrade fence socket path is too long for a Unix socket on this platform",
+    );
+  });
+
   it("refuses ordinary and wrong callers, admits one designated capability, and rejects replay", async () => {
     const dir = await configDir();
     const acquired = await acquireUpgradeFence({


### PR DESCRIPTION
## Summary

- a fresh athlete home with an empty `intervals.api_key` (the pre-onboarding BYOK state) crashed service startup: the store window unconditionally launched a provider capture whose HTTP factory requires a non-empty key. The capture lane is now skipped when the key is empty; the window reports `published: false`, the local Reference lane still runs, and the `sync` verb completes honestly.
- on macOS, an athlete home whose fence socket path exceeds the 104-byte Unix-socket limit failed with `EINVAL`, which admission misclassified as an active upgrade handoff ("already reserves this athlete home" for a nonexistent holder). `EINVAL`/`ENAMETOOLONG` now fail fast with a descriptive error naming the socket path.

Both defects were found by live desktop shell acceptance runs against a synthetic athlete home.

## Test plan

- new regression: empty-key store window runs the legacy lane only, capture and produce never invoked, `published: false`
- new regression (darwin): over-long fence socket path rejects with the descriptive error instead of resolving reserved
- existing configured-key capture assertion preserved via an explicit non-empty key
- full root `pnpm check` + `pnpm test`: 4345 passed, 0 failed