### PR TITLE
feat(coach): add intake persistence and runtime configuration to the daemon wire

### DIFF
--- a/.changeset/runtime-intake-wire.md
+++ b/.changeset/runtime-intake-wire.md
@@ -1,0 +1,6 @@
+---
+"@enduragent/coach": patch
+"@enduragent/coach-contract": patch
+---
+
+Add authenticated intake persistence and in-memory runtime configuration operations to the daemon wire.

--- a/packages/coach-client/tests/client.test.ts
+++ b/packages/coach-client/tests/client.test.ts
@@ -408,8 +408,8 @@ describe("handshake failures", () => {
   });
 
   it.each([
-    [2, 3, "client-older", "ephemeral-client-started"],
-    [2, 1, "client-newer", "unmanaged-foreground"],
+    [PROTOCOL_VERSION, PROTOCOL_VERSION + 1, "client-older", "ephemeral-client-started"],
+    [PROTOCOL_VERSION, PROTOCOL_VERSION - 1, "client-newer", "unmanaged-foreground"],
   ] as const)(
     "exposes a trusted mismatch %s/%s",
     async (clientVersion, serverVersion, direction, owner) => {
@@ -482,6 +482,8 @@ describe("RPC receive and observers", () => {
           referenceSucceeded: true,
           requests: { store: 1, reference: 1, total: 2 },
         },
+        saveIntake: { schemaVersion: 1, saved: true },
+        configureRuntime: { schemaVersion: 1, applied: { llm: true, intervals: false } },
       };
       socket.emitMessage(
         serializeCoachRpcEnvelope({
@@ -505,7 +507,22 @@ describe("RPC receive and observers", () => {
       client.call("importFiles", { paths: ["/synthetic/ride.fit"] }),
     ).resolves.toMatchObject({ schemaVersion: 1 });
     await expect(client.call("sync", {})).resolves.toMatchObject({ schemaVersion: 1 });
-    expect(received.map((value) => (value as { id: number }).id)).toEqual([1, 2, 3, 4, 5, 6]);
+    await expect(
+      client.call("saveIntake", {
+        swim_skill_floor: null,
+        continuous_distance_capable: null,
+        open_water_comfort: null,
+        prior_bsi: false,
+        clinician_cleared: null,
+        injury_status: "none",
+      }),
+    ).resolves.toEqual({ schemaVersion: 1, saved: true });
+    await expect(
+      client.call("configureRuntime", {
+        llm: { provider: "anthropic", model: "synthetic", api_key: "synthetic" },
+      }),
+    ).resolves.toEqual({ schemaVersion: 1, applied: { llm: true, intervals: false } });
+    expect(received.map((value) => (value as { id: number }).id)).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
     expect(received.map((value) => (value as { method: string }).method)).toEqual([
       "chat",
       "resetSession",
@@ -513,6 +530,8 @@ describe("RPC receive and observers", () => {
       "getAthleteState",
       "importFiles",
       "sync",
+      "saveIntake",
+      "configureRuntime",
     ]);
     socket.closeSynchronously = true;
     await client.close();

--- a/packages/coach-contract/src/rpc.ts
+++ b/packages/coach-contract/src/rpc.ts
@@ -108,6 +108,8 @@ export const COACH_RPC_METHOD_NAMES = [
   "getAthleteState",
   "importFiles",
   "sync",
+  "saveIntake",
+  "configureRuntime",
 ] as const satisfies readonly (keyof CoachRpcService)[];
 
 export const CoachRpcMethodNameSchema = z.enum(COACH_RPC_METHOD_NAMES);
@@ -203,6 +205,96 @@ export const SyncRpcResultSchema = z
   });
 export type SyncRpcResult = z.infer<typeof SyncRpcResultSchema>;
 
+export const InjuryStatusSchema = z.enum(["none", "managing", "returning"]);
+export type InjuryStatus = z.infer<typeof InjuryStatusSchema>;
+
+export const SaveIntakeRpcParamsSchema = z
+  .object({
+    swim_skill_floor: z.null(),
+    continuous_distance_capable: z.null(),
+    open_water_comfort: z.null(),
+    prior_bsi: z.boolean(),
+    clinician_cleared: z.boolean().nullable(),
+    injury_status: InjuryStatusSchema,
+  })
+  .strict()
+  .superRefine((value, context) => {
+    const needsClearance = value.prior_bsi || value.injury_status !== "none";
+    if (needsClearance === (value.clinician_cleared === null)) {
+      context.addIssue({
+        code: "custom",
+        path: ["clinician_cleared"],
+        message: needsClearance
+          ? "clinician clearance is required"
+          : "clinician clearance must be null",
+      });
+    }
+  });
+export type SaveIntakeRpcParams = z.infer<typeof SaveIntakeRpcParamsSchema>;
+
+export const SaveIntakeRpcResultSchema = z
+  .object({
+    schemaVersion: z.literal(1),
+    saved: z.literal(true),
+  })
+  .strict();
+export type SaveIntakeRpcResult = z.infer<typeof SaveIntakeRpcResultSchema>;
+
+export const LlmProviderSchema = z.enum([
+  "anthropic",
+  "openai",
+  "google",
+  "openai-codex",
+  "deepseek",
+  "qwen",
+  "minimax",
+  "kimi",
+  "zai",
+  "openrouter",
+]);
+export type LlmProvider = z.infer<typeof LlmProviderSchema>;
+
+const RuntimeLlmSchema = z
+  .object({
+    provider: LlmProviderSchema,
+    model: z.string().min(1).max(512),
+    api_key: z.string().min(1).max(16_384),
+  })
+  .strict();
+
+const RuntimeIntervalsSchema = z
+  .object({
+    api_key: z.string().min(1).max(16_384),
+    athlete_id: z.string().min(1).max(512),
+  })
+  .strict();
+
+export const ConfigureRuntimeRpcParamsSchema = z
+  .object({
+    llm: RuntimeLlmSchema.optional(),
+    intervals: RuntimeIntervalsSchema.optional(),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    if (value.llm === undefined && value.intervals === undefined) {
+      context.addIssue({ code: "custom", message: "at least one runtime slot is required" });
+    }
+  });
+export type ConfigureRuntimeRpcParams = z.infer<typeof ConfigureRuntimeRpcParamsSchema>;
+
+export const ConfigureRuntimeRpcResultSchema = z
+  .object({
+    schemaVersion: z.literal(1),
+    applied: z
+      .object({
+        llm: z.boolean(),
+        intervals: z.boolean(),
+      })
+      .strict(),
+  })
+  .strict();
+export type ConfigureRuntimeRpcResult = z.infer<typeof ConfigureRuntimeRpcResultSchema>;
+
 export const OperationProgressEventSchema = z
   .object({
     phase: z.enum(["started", "completed"]),
@@ -240,6 +332,8 @@ export interface CoachOperations {
     request: SyncRpcParams,
     onEvent?: (event: OperationProgressEvent) => void,
   ): Promise<SyncRpcResult>;
+  saveIntake(request: SaveIntakeRpcParams): Promise<SaveIntakeRpcResult>;
+  configureRuntime(request: ConfigureRuntimeRpcParams): Promise<ConfigureRuntimeRpcResult>;
 }
 
 export type CoachRpcService = CoachEngine & CoachOperations;
@@ -291,6 +385,22 @@ export const CoachRpcRequestEnvelopeSchema = z.discriminatedUnion("method", [
       id: JsonRpcIdSchema,
       method: z.literal("sync"),
       params: SyncRpcParamsSchema,
+    })
+    .strict(),
+  z
+    .object({
+      jsonrpc: z.literal("2.0"),
+      id: JsonRpcIdSchema,
+      method: z.literal("saveIntake"),
+      params: SaveIntakeRpcParamsSchema,
+    })
+    .strict(),
+  z
+    .object({
+      jsonrpc: z.literal("2.0"),
+      id: JsonRpcIdSchema,
+      method: z.literal("configureRuntime"),
+      params: ConfigureRuntimeRpcParamsSchema,
     })
     .strict(),
 ]);
@@ -413,6 +523,18 @@ export const COACH_RPC_METHOD_REGISTRY = {
     requestSchema: SyncRpcParamsSchema,
     responseSchema: SyncRpcResultSchema,
     eventSchema: OperationProgressEventSchema,
+  },
+  saveIntake: {
+    wireName: "saveIntake",
+    requestSchema: SaveIntakeRpcParamsSchema,
+    responseSchema: SaveIntakeRpcResultSchema,
+    eventSchema: NoRpcEventSchema,
+  },
+  configureRuntime: {
+    wireName: "configureRuntime",
+    requestSchema: ConfigureRuntimeRpcParamsSchema,
+    responseSchema: ConfigureRuntimeRpcResultSchema,
+    eventSchema: NoRpcEventSchema,
   },
 } as const satisfies CoachRpcMethodRegistryShape;
 

--- a/packages/coach-contract/src/version.ts
+++ b/packages/coach-contract/src/version.ts
@@ -1,1 +1,1 @@
-export const PROTOCOL_VERSION = 2;
+export const PROTOCOL_VERSION = 3;

--- a/packages/coach-contract/tests/contract.test.ts
+++ b/packages/coach-contract/tests/contract.test.ts
@@ -75,8 +75,8 @@ describe("exit codes", () => {
 });
 
 describe("protocol version", () => {
-  it("is 2", () => {
-    expect(PROTOCOL_VERSION).toBe(2);
+  it("is 3", () => {
+    expect(PROTOCOL_VERSION).toBe(3);
   });
 });
 

--- a/packages/coach-contract/tests/wire-contract.test.ts
+++ b/packages/coach-contract/tests/wire-contract.test.ts
@@ -15,9 +15,13 @@ import {
   CoachTurnEventNotificationEnvelopeSchema,
   DaemonOwnerSchema,
   EmptyRpcParamsSchema,
+  ConfigureRuntimeRpcParamsSchema,
+  ConfigureRuntimeRpcResultSchema,
   ImportFilesRpcParamsSchema,
   ImportFilesRpcResultSchema,
   OperationProgressEventSchema,
+  SaveIntakeRpcParamsSchema,
+  SaveIntakeRpcResultSchema,
   SyncRpcParamsSchema,
   SyncRpcResultSchema,
   HasSessionRequestSchema,
@@ -26,6 +30,7 @@ import {
   JsonRpcProtocolErrorResponseEnvelopeSchema,
   JsonRpcResponseEnvelopeSchema,
   JsonRpcSuccessResponseEnvelopeSchema,
+  LlmProviderSchema,
   NoRpcEventSchema,
   PROTOCOL_VERSION,
   ResetSessionRequestSchema,
@@ -150,7 +155,7 @@ describe("JSON-RPC envelopes", () => {
 });
 
 describe("coach request and event projection", () => {
-  it("admits exactly the six strict method requests", () => {
+  it("admits exactly the eight strict method requests", () => {
     const requests = [
       { jsonrpc: "2.0", id: 1, method: "chat", params: { chatId: "chat-1", message: "hello" } },
       { jsonrpc: "2.0", id: 2, method: "resetSession", params: { chatId: "chat-1" } },
@@ -158,9 +163,30 @@ describe("coach request and event projection", () => {
       { jsonrpc: "2.0", id: 4, method: "getAthleteState", params: {} },
       { jsonrpc: "2.0", id: 5, method: "importFiles", params: { paths: ["/synthetic/ride.fit"] } },
       { jsonrpc: "2.0", id: 6, method: "sync", params: {} },
+      {
+        jsonrpc: "2.0",
+        id: 7,
+        method: "saveIntake",
+        params: {
+          swim_skill_floor: null,
+          continuous_distance_capable: null,
+          open_water_comfort: null,
+          prior_bsi: false,
+          clinician_cleared: null,
+          injury_status: "none",
+        },
+      },
+      {
+        jsonrpc: "2.0",
+        id: 8,
+        method: "configureRuntime",
+        params: { llm: { provider: "anthropic", model: "model", api_key: "placeholder" } },
+      },
     ];
-    for (const request of requests)
+    for (const request of requests) {
       expect(CoachRpcRequestEnvelopeSchema.parse(request)).toEqual(request);
+      expect(roundTrip(request)).toEqual(request);
+    }
     expect(
       CoachRpcRequestEnvelopeSchema.safeParse({ jsonrpc: "2.0", id: 4, method: "getAthleteState" })
         .success,
@@ -272,6 +298,66 @@ describe("coach request and event projection", () => {
     );
   });
 
+  it("validates strict intake and runtime configuration round trips", () => {
+    const safeIntake = {
+      swim_skill_floor: null,
+      continuous_distance_capable: null,
+      open_water_comfort: null,
+      prior_bsi: false,
+      clinician_cleared: null,
+      injury_status: "none",
+    } as const;
+    const clearedIntake = {
+      ...safeIntake,
+      prior_bsi: true,
+      clinician_cleared: true,
+      injury_status: "returning",
+    } as const;
+    expect(SaveIntakeRpcParamsSchema.parse(safeIntake)).toEqual(safeIntake);
+    expect(SaveIntakeRpcParamsSchema.parse(clearedIntake)).toEqual(clearedIntake);
+    for (const invalid of [
+      { ...safeIntake, swim_skill_floor: "novice" },
+      { ...safeIntake, extra: true },
+      { ...safeIntake, clinician_cleared: true },
+      { ...clearedIntake, clinician_cleared: null },
+    ]) {
+      expect(SaveIntakeRpcParamsSchema.safeParse(invalid).success).toBe(false);
+    }
+    expect(SaveIntakeRpcResultSchema.parse({ schemaVersion: 1, saved: true })).toEqual({
+      schemaVersion: 1,
+      saved: true,
+    });
+
+    const llm = { provider: "openrouter", model: "model-a", api_key: "placeholder" } as const;
+    const intervals = { api_key: "placeholder", athlete_id: "athlete-a" } as const;
+    for (const params of [{ llm }, { intervals }, { llm, intervals }]) {
+      expect(ConfigureRuntimeRpcParamsSchema.parse(params)).toEqual(params);
+    }
+    for (const invalid of [
+      {},
+      { llm: { ...llm, extra: true } },
+      { intervals: { api_key: "", athlete_id: "athlete-a" } },
+      { llm, extra: true },
+    ]) {
+      expect(ConfigureRuntimeRpcParamsSchema.safeParse(invalid).success).toBe(false);
+    }
+    const result = { schemaVersion: 1, applied: { llm: true, intervals: false } } as const;
+    expect(ConfigureRuntimeRpcResultSchema.parse(result)).toEqual(result);
+    expect(JSON.stringify(result)).not.toContain("placeholder");
+    expect(LlmProviderSchema.options).toEqual([
+      "anthropic",
+      "openai",
+      "google",
+      "openai-codex",
+      "deepseek",
+      "qwen",
+      "minimax",
+      "kimi",
+      "zai",
+      "openrouter",
+    ]);
+  });
+
   it("keeps the method registry exhaustive and schema-identical", async () => {
     const fake: CoachRpcService = {
       chat: async () => ({ text: "ok" }),
@@ -306,6 +392,11 @@ describe("coach request and event projection", () => {
         published: false,
         referenceSucceeded: true,
         requests: { store: 0, reference: 0, total: 0 },
+      }),
+      saveIntake: async () => ({ schemaVersion: 1, saved: true }),
+      configureRuntime: async ({ llm, intervals }) => ({
+        schemaVersion: 1,
+        applied: { llm: llm !== undefined, intervals: intervals !== undefined },
       }),
     };
     expect(Object.keys(COACH_RPC_METHOD_REGISTRY)).toEqual(Object.keys(fake));
@@ -346,7 +437,25 @@ describe("coach request and event projection", () => {
       responseSchema: SyncRpcResultSchema,
       eventSchema: OperationProgressEventSchema,
     });
-    for (const method of ["resetSession", "hasSession", "getAthleteState"] as const) {
+    expect(COACH_RPC_METHOD_REGISTRY.saveIntake).toEqual({
+      wireName: "saveIntake",
+      requestSchema: SaveIntakeRpcParamsSchema,
+      responseSchema: SaveIntakeRpcResultSchema,
+      eventSchema: NoRpcEventSchema,
+    });
+    expect(COACH_RPC_METHOD_REGISTRY.configureRuntime).toEqual({
+      wireName: "configureRuntime",
+      requestSchema: ConfigureRuntimeRpcParamsSchema,
+      responseSchema: ConfigureRuntimeRpcResultSchema,
+      eventSchema: NoRpcEventSchema,
+    });
+    for (const method of [
+      "resetSession",
+      "hasSession",
+      "getAthleteState",
+      "saveIntake",
+      "configureRuntime",
+    ] as const) {
       expect(COACH_RPC_METHOD_REGISTRY[method].eventSchema.safeParse(undefined).success).toBe(
         false,
       );
@@ -362,12 +471,12 @@ describe("handshake", () => {
   it("round trips client, accepted, and both mismatch directions", () => {
     const client = createClientHandshakeFrame("synthetic-test-token");
     expect(ClientHandshakeFrameSchema.parse(JSON.parse(JSON.stringify(client)))).toEqual(client);
-    const accepted = createAcceptedServerHandshakeFrame("service-managed", 2);
+    const accepted = createAcceptedServerHandshakeFrame("service-managed", 3);
     expect(ServerHandshakeFrameSchema.parse(JSON.parse(JSON.stringify(accepted)))).toEqual(
       accepted,
     );
-    const older = createVersionMismatchServerHandshakeFrame("ephemeral-client-started", 1, 2);
-    const newer = createVersionMismatchServerHandshakeFrame("unmanaged-foreground", 3, 2);
+    const older = createVersionMismatchServerHandshakeFrame("ephemeral-client-started", 2, 3);
+    const newer = createVersionMismatchServerHandshakeFrame("unmanaged-foreground", 4, 3);
     expect(ServerHandshakeFrameSchema.parse(older)).toEqual(older);
     expect(ServerHandshakeFrameSchema.parse(newer)).toEqual(newer);
   });
@@ -454,7 +563,7 @@ describe("additive protocol signals", () => {
     expect(AgentErrorKindSchema.safeParse("aborted").success).toBe(false);
   });
 
-  it("uses protocol version two", () => {
-    expect(PROTOCOL_VERSION).toBe(2);
+  it("uses protocol version three", () => {
+    expect(PROTOCOL_VERSION).toBe(3);
   });
 });

--- a/packages/coach/src/composition.ts
+++ b/packages/coach/src/composition.ts
@@ -41,7 +41,11 @@ import { createAnchorRepository, type AnchorRepository } from "@enduragent/kerne
 import { ErrorStateSchema, LatestJsonSchema } from "@enduragent/kernel/reference/schemas";
 import type { AthleteHome } from "@enduragent/kernel-node/home";
 import type { CoachStoreWriterContext } from "./runtime.js";
-import type { CoachOperations } from "@enduragent/coach-contract";
+import type {
+  CoachEngine,
+  CoachOperations,
+  ConfigureRuntimeRpcParams,
+} from "@enduragent/coach-contract";
 import { cyclingSport } from "@enduragent/sport-cycling";
 import { createPersistedAthleteStateSource } from "./athlete-state-reader.js";
 import { createCoachEngineAdapter } from "./coach-engine-adapter.js";
@@ -63,7 +67,7 @@ interface OAuthCredential {
 }
 
 export interface LocalCoachComposition {
-  readonly engine: ReturnType<typeof createCoachEngineAdapter>;
+  readonly engine: CoachEngine;
   readonly operations: CoachOperations;
   close(): Promise<void>;
 }
@@ -108,6 +112,86 @@ export interface LocalStoreRuntime {
 export type LocalStoreRuntimeOptions = Omit<StoreRuntimeOptions, "reference"> & {
   readonly reference: LocalReferenceRuntime;
 };
+
+function copyConfig(config: Config): Config {
+  return {
+    ...config,
+    llm: { ...config.llm },
+    intervals: { ...config.intervals },
+    telegram: { ...config.telegram },
+    session: { ...config.session },
+  };
+}
+
+function mergedRuntimeConfig(config: Config, request: ConfigureRuntimeRpcParams): Config {
+  const next = copyConfig(config);
+  if (request.llm !== undefined) {
+    next.llm = {
+      provider: request.llm.provider,
+      model: request.llm.model,
+      apiKey: request.llm.api_key,
+      authProfile: request.llm.provider === "openai-codex" ? "openai-codex" : undefined,
+    };
+  }
+  if (request.intervals !== undefined) {
+    next.intervals = {
+      apiKey: request.intervals.api_key,
+      athleteId: request.intervals.athlete_id,
+    };
+  }
+  return next;
+}
+
+function createReconfigurableEngine(initial: CoachEngine): {
+  readonly engine: CoachEngine;
+  replace(create: () => CoachEngine): Promise<void>;
+} {
+  let active = initial;
+  let admission = Promise.resolve();
+  let activeCalls = 0;
+  const drainWaiters = new Set<() => void>();
+
+  const run = async <T>(operation: (engine: CoachEngine) => Promise<T>): Promise<T> => {
+    await admission;
+    activeCalls += 1;
+    const selected = active;
+    try {
+      return await operation(selected);
+    } finally {
+      activeCalls -= 1;
+      if (activeCalls === 0) {
+        for (const resolve of drainWaiters) resolve();
+        drainWaiters.clear();
+      }
+    }
+  };
+
+  return {
+    engine: {
+      chat: (request, onEvent) => run((engine) => engine.chat(request, onEvent)),
+      resetSession: (request) => run((engine) => engine.resetSession(request)),
+      hasSession: (request) => run((engine) => engine.hasSession(request)),
+      getAthleteState: () => run((engine) => engine.getAthleteState()),
+    },
+    async replace(create) {
+      const previousAdmission = admission;
+      let release!: () => void;
+      const barrier = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      admission = previousAdmission.then(() => barrier);
+      await previousAdmission;
+      try {
+        if (activeCalls > 0) {
+          await new Promise<void>((resolve) => drainWaiters.add(resolve));
+        }
+        active = create();
+      } finally {
+        release();
+      }
+    },
+  };
+}
 
 function readReferenceState(dataDir: string): ReferenceStateSnapshot {
   const referenceDir = join(dataDir, "data");
@@ -232,6 +316,7 @@ export async function createLocalCoachComposition(
     throw new TypeError("Ready engine configuration does not match the selected athlete home.");
   }
   const now = dependencies.now ?? Date.now;
+  let activeConfig = copyConfig(input.config);
   let runtime: LocalStoreRuntime | undefined;
   let reference: LocalReferenceRuntime | undefined;
   let closePromise: Promise<void> | undefined;
@@ -249,7 +334,8 @@ export async function createLocalCoachComposition(
     });
     const runtimeOptions: LocalStoreRuntimeOptions = {
       env: input.env,
-      config: input.config,
+      config: activeConfig,
+      readConfig: () => activeConfig,
       home: input.home,
       reference,
       writerContext: input.context,
@@ -265,56 +351,79 @@ export async function createLocalCoachComposition(
     await runtime.runWindow();
     runtime.startScheduler();
     const stateReader = createPersistedAthleteStateSource({ dataDir: input.home.root });
-    const legacyClient =
-      input.config.intervals.apiKey.length === 0
-        ? null
-        : makeChatClient({
-            apiKey: input.config.intervals.apiKey,
-            athleteId: input.config.intervals.athleteId,
-          });
     const memory = new Memory(input.home.root, input.config.session.timezone);
-    const ports: EngineHostPorts = {
-      config: input.engineConfig,
-      memory,
-      chatStore: new ChatStore(input.home.root, input.config.session.resetArchiveRetentionDays),
-      secrets: { resolve: resolveSecretRef },
-      platform: {
-        legacyClient,
-        athleteData: runtime.athleteData,
-        calendarMutations:
-          legacyClient === null
-            ? createMissingPlatformCalendarMutations()
-            : createPlatformCalendarMutations(legacyClient),
-      },
-      logger: createSubsystemLogger("agent", input.home.root),
-      usage: { append: (line) => appendUsageLine(input.home.root, line) },
-      stateReader,
-      readReferenceState: () => readReferenceState(input.home.root),
-      getAccessToken: createAccessTokenReader(input.home.configDir, now),
-      classifyFailure,
-      extractRetryAfterMs,
-      now,
-      randomId: dependencies.randomId ?? randomUUID,
-      modelTransportDecorator: dependencies.modelTransportDecorator,
-      onToolsAssembled: dependencies.onToolsAssembled,
-    };
-    const engineInput = { sport: cyclingSport, ports } satisfies CreateCoachEngineInput;
-    const backend = (dependencies.createBackend ?? createCoachEngine)(engineInput);
+    const chatStore = new ChatStore(
+      input.home.root,
+      input.config.session.resetArchiveRetentionDays,
+    );
+    const logger = createSubsystemLogger("agent", input.home.root);
+    const getAccessToken = createAccessTokenReader(input.home.configDir, now);
     const repository = (dependencies.createRepository ?? createAnchorRepository)(
       input.context.store,
     );
     const cyclingFtpAnchorResolver = (
       dependencies.createResolver ?? createCyclingFtpAnchorResolver
     )(repository);
-    const engine = createCoachEngineAdapter({
-      backend,
-      getAthleteState: () => stateReader.getAthleteState(),
-      cyclingFtpAnchorResolver,
-      now,
+    const buildEngine = (config: Config): CoachEngine => {
+      const projectedConfig = engineConfigFromConfig(config);
+      const legacyClient =
+        config.intervals.apiKey.length === 0
+          ? null
+          : makeChatClient({
+              apiKey: config.intervals.apiKey,
+              athleteId: config.intervals.athleteId,
+            });
+      const ports: EngineHostPorts = {
+        config: projectedConfig,
+        memory,
+        chatStore,
+        secrets: { resolve: resolveSecretRef },
+        platform: {
+          legacyClient,
+          athleteData: runtime!.athleteData,
+          calendarMutations:
+            legacyClient === null
+              ? createMissingPlatformCalendarMutations()
+              : createPlatformCalendarMutations(legacyClient),
+        },
+        logger,
+        usage: { append: (line) => appendUsageLine(input.home.root, line) },
+        stateReader,
+        readReferenceState: () => readReferenceState(input.home.root),
+        getAccessToken,
+        classifyFailure,
+        extractRetryAfterMs,
+        now,
+        randomId: dependencies.randomId ?? randomUUID,
+        modelTransportDecorator: dependencies.modelTransportDecorator,
+        onToolsAssembled: dependencies.onToolsAssembled,
+      };
+      const engineInput = { sport: cyclingSport, ports } satisfies CreateCoachEngineInput;
+      const backend = (dependencies.createBackend ?? createCoachEngine)(engineInput);
+      return createCoachEngineAdapter({
+        backend,
+        getAthleteState: () => stateReader.getAthleteState(),
+        cyclingFtpAnchorResolver,
+        now,
+      });
+    };
+    const reconfigurable = createReconfigurableEngine(buildEngine(activeConfig));
+    const applyRuntimeConfig = async (request: ConfigureRuntimeRpcParams): Promise<void> => {
+      await reconfigurable.replace(() => {
+        const candidate = mergedRuntimeConfig(activeConfig, request);
+        const replacement = buildEngine(candidate);
+        activeConfig = candidate;
+        return replacement;
+      });
+    };
+    const operations = createCoachOperations({
+      home: input.home,
+      context: input.context,
+      runtime,
+      applyRuntimeConfig,
     });
-    const operations = createCoachOperations({ home: input.home, context: input.context, runtime });
     return {
-      engine,
+      engine: reconfigurable.engine,
       operations,
       close() {
         closePromise ??= (async () => {

--- a/packages/coach/src/daemon/rpc-server.ts
+++ b/packages/coach/src/daemon/rpc-server.ts
@@ -680,6 +680,26 @@ export function createCoachRpcServer(input: CoachRpcServerInput): CoachRpcServer
               invocationFailure = { error };
             }
             break;
+          case "saveIntake":
+            try {
+              const request = COACH_RPC_METHOD_REGISTRY.saveIntake.requestSchema.parse(
+                generic.data.params,
+              );
+              result = await input.operations.saveIntake(request);
+            } catch (error) {
+              invocationFailure = { error };
+            }
+            break;
+          case "configureRuntime":
+            try {
+              const request = COACH_RPC_METHOD_REGISTRY.configureRuntime.requestSchema.parse(
+                generic.data.params,
+              );
+              result = await input.operations.configureRuntime(request);
+            } catch (error) {
+              invocationFailure = { error };
+            }
+            break;
         }
         if (deliveryDetached) return;
         let terminal: string;

--- a/packages/coach/src/operations.ts
+++ b/packages/coach/src/operations.ts
@@ -1,17 +1,30 @@
 import {
+  ConfigureRuntimeRpcParamsSchema,
+  ConfigureRuntimeRpcResultSchema,
   ImportFilesRpcParamsSchema,
   ImportFilesRpcResultSchema,
   OperationProgressEventSchema,
+  SaveIntakeRpcParamsSchema,
+  SaveIntakeRpcResultSchema,
   SyncRpcParamsSchema,
   SyncRpcResultSchema,
+  type ConfigureRuntimeRpcParams,
+  type ConfigureRuntimeRpcResult,
   type CoachOperations,
   type ImportFilesRpcParams,
   type ImportFilesRpcResult,
   type OperationProgressEvent,
+  type SaveIntakeRpcParams,
+  type SaveIntakeRpcResult,
   type SyncRpcParams,
   type SyncRpcResult,
 } from "@enduragent/coach-contract";
-import type { AthleteHome } from "@enduragent/kernel-node/home";
+import { createIntakeRepository } from "@enduragent/kernel/store";
+import {
+  createAuthoredIdentity,
+  type AthleteHome,
+  type AuthoredIdentity,
+} from "@enduragent/kernel-node/home";
 import { importFilesWithReport } from "@enduragent/kernel-node/ingest";
 import type { LocalStoreRuntime } from "./composition.js";
 import type { CoachStoreWriterContext } from "./runtime.js";
@@ -20,10 +33,13 @@ export interface CreateCoachOperationsInput {
   readonly home: AthleteHome;
   readonly context: CoachStoreWriterContext;
   readonly runtime: Pick<LocalStoreRuntime, "runWindow">;
+  readonly applyRuntimeConfig: (request: ConfigureRuntimeRpcParams) => Promise<void>;
 }
 
 export interface CoachOperationsDependencies {
-  readonly importFiles: typeof importFilesWithReport;
+  readonly importFiles?: typeof importFilesWithReport;
+  readonly createIdentity?: (configDir: string) => AuthoredIdentity;
+  readonly createIntakeRepository?: typeof createIntakeRepository;
 }
 
 function sameHome(left: AthleteHome, right: AthleteHome): boolean {
@@ -37,13 +53,16 @@ function sameHome(left: AthleteHome, right: AthleteHome): boolean {
 
 export function createCoachOperations(
   input: CreateCoachOperationsInput,
-  dependencies: CoachOperationsDependencies = { importFiles: importFilesWithReport },
+  dependencies: CoachOperationsDependencies = {},
 ): CoachOperations {
   if (!sameHome(input.home, input.context.home)) {
     throw new TypeError("Writer home does not match the selected athlete home.");
   }
   const store = input.context.store;
   const archiveDir = input.home.archiveDir;
+  const identity = (dependencies.createIdentity ?? createAuthoredIdentity)(input.home.configDir);
+  const intake = (dependencies.createIntakeRepository ?? createIntakeRepository)(store);
+  const importFiles = dependencies.importFiles ?? importFilesWithReport;
   let tail = Promise.resolve();
 
   const enqueue = <T>(operation: () => Promise<T>): Promise<T> => {
@@ -71,7 +90,7 @@ export function createCoachOperations(
       const paths = [...parsedRequest.paths];
       return enqueue(async () => {
         deliver(onEvent, { phase: "started", completed: 0, total: paths.length });
-        const report = await dependencies.importFiles({ inputPaths: paths, archiveDir, store });
+        const report = await importFiles({ inputPaths: paths, archiveDir, store });
         const result = ImportFilesRpcResultSchema.parse({
           schemaVersion: 1,
           files: {
@@ -107,6 +126,34 @@ export function createCoachOperations(
         });
         deliver(onEvent, { phase: "completed", completed: 1, total: 1 });
         return result;
+      });
+    },
+    saveIntake(request: SaveIntakeRpcParams): Promise<SaveIntakeRpcResult> {
+      const parsedRequest = SaveIntakeRpcParamsSchema.parse(request);
+      return enqueue(async () => {
+        const deviceId = await identity.deviceId();
+        const stamp = identity.hlcStamp();
+        await intake.replace({
+          id: identity.newUlid(),
+          ...parsedRequest,
+          device_id: deviceId,
+          hlc_physical_ms: stamp.physicalMs,
+          hlc_counter: stamp.counter,
+        });
+        return SaveIntakeRpcResultSchema.parse({ schemaVersion: 1, saved: true });
+      });
+    },
+    configureRuntime(request: ConfigureRuntimeRpcParams): Promise<ConfigureRuntimeRpcResult> {
+      const parsedRequest = ConfigureRuntimeRpcParamsSchema.parse(request);
+      return enqueue(async () => {
+        await input.applyRuntimeConfig(parsedRequest);
+        return ConfigureRuntimeRpcResultSchema.parse({
+          schemaVersion: 1,
+          applied: {
+            llm: parsedRequest.llm !== undefined,
+            intervals: parsedRequest.intervals !== undefined,
+          },
+        });
       });
     },
   };

--- a/packages/coach/src/store-runtime.ts
+++ b/packages/coach/src/store-runtime.ts
@@ -45,6 +45,7 @@ export interface StoreRuntimeDependencies {
 export interface StoreRuntimeOptions {
   readonly env: Record<string, string | undefined>;
   readonly config: Config;
+  readonly readConfig?: () => Config;
   readonly home: AthleteHome;
   readonly reference: ReferenceRuntime;
   readonly writerContext?: CoachStoreWriterContext;
@@ -52,16 +53,19 @@ export interface StoreRuntimeOptions {
 }
 
 function sameHome(left: AthleteHome, right: AthleteHome): boolean {
-  return left.root === right.root
-    && left.storeDir === right.storeDir
-    && left.archiveDir === right.archiveDir
-    && left.configDir === right.configDir;
+  return (
+    left.root === right.root &&
+    left.storeDir === right.storeDir &&
+    left.archiveDir === right.archiveDir &&
+    left.configDir === right.configDir
+  );
 }
 
 export class StoreRuntime {
   readonly athleteData: AthleteDataReader;
-  private readonly dependencies: Required<Pick<StoreRuntimeDependencies,
-    "capture" | "produce" | "now" | "monotonicNow">>;
+  private readonly dependencies: Required<
+    Pick<StoreRuntimeDependencies, "capture" | "produce" | "now" | "monotonicNow">
+  >;
   private readonly scheduler: WallClockScheduler;
   private snapshotValue: ProducedLocalBundle | undefined;
   private activeLedger: PhysicalRequestLedger | undefined;
@@ -70,7 +74,10 @@ export class StoreRuntime {
   private closed = false;
 
   constructor(private readonly options: StoreRuntimeOptions) {
-    if (options.writerContext !== undefined && !sameHome(options.home, options.writerContext.home)) {
+    if (
+      options.writerContext !== undefined &&
+      !sameHome(options.home, options.writerContext.home)
+    ) {
       throw new TypeError("Writer home does not match the store runtime home.");
     }
     const dependencies = options.dependencies ?? {};
@@ -78,10 +85,13 @@ export class StoreRuntime {
     const schedulerDependencies = dependencies.schedulerDependencies ?? {};
     this.dependencies = {
       capture: dependencies.capture ?? runReferenceCapture,
-      produce: dependencies.produce ?? ((manifest) => createLocalBundleProducer({
-        storePath: join(options.home.storeDir, "store.db"),
-        archiveRoot: options.home.archiveDir,
-      }).produce(manifest)),
+      produce:
+        dependencies.produce ??
+        ((manifest) =>
+          createLocalBundleProducer({
+            storePath: join(options.home.storeDir, "store.db"),
+            archiveRoot: options.home.archiveDir,
+          }).produce(manifest)),
       now,
       monotonicNow: dependencies.monotonicNow ?? (() => performance.now()),
     };
@@ -121,9 +131,11 @@ export class StoreRuntime {
     if (this.activeWindow !== undefined) return this.activeWindow;
     const task = this.runWindowInternal();
     this.activeWindow = task;
-    void task.finally(() => {
-      if (this.activeWindow === task) this.activeWindow = undefined;
-    }).catch(() => {});
+    void task
+      .finally(() => {
+        if (this.activeWindow === task) this.activeWindow = undefined;
+      })
+      .catch(() => {});
     return task;
   }
 
@@ -143,23 +155,30 @@ export class StoreRuntime {
       maxArtifacts: STORE_MAX_ARTIFACTS,
     };
     try {
-      const capturePromise = this.options.config.intervals.apiKey.length === 0
-        ? Promise.resolve(undefined)
-        : this.dependencies.capture({
-            env: this.options.env,
-            ...(this.options.writerContext === undefined
-              ? {}
-              : { writerContext: this.options.writerContext }),
-            apiKey: this.options.config.intervals.apiKey,
-            athleteId: this.options.config.intervals.athleteId,
-            reviewedOn: now.toISOString().slice(0, 10),
-            reason: this.snapshotValue === undefined ? "initial" : "provider-refresh",
-            ...(this.snapshotValue === undefined ? {} : { replacesCaptureId: this.snapshotValue.captureId }),
-            budget,
-            attemptLedger: ledger,
-          });
+      const config = this.options.readConfig?.() ?? this.options.config;
+      const capturePromise =
+        config.intervals.apiKey.length === 0
+          ? Promise.resolve(undefined)
+          : this.dependencies.capture({
+              env: this.options.env,
+              ...(this.options.writerContext === undefined
+                ? {}
+                : { writerContext: this.options.writerContext }),
+              apiKey: config.intervals.apiKey,
+              athleteId: config.intervals.athleteId,
+              reviewedOn: now.toISOString().slice(0, 10),
+              reason: this.snapshotValue === undefined ? "initial" : "provider-refresh",
+              ...(this.snapshotValue === undefined
+                ? {}
+                : { replacesCaptureId: this.snapshotValue.captureId }),
+              budget,
+              attemptLedger: ledger,
+            });
       const legacyPromise = this.options.reference.runScheduledOnce();
-      const [captureResult, legacyResult] = await Promise.allSettled([capturePromise, legacyPromise]);
+      const [captureResult, legacyResult] = await Promise.allSettled([
+        capturePromise,
+        legacyPromise,
+      ]);
       let published = false;
       if (captureResult.status === "fulfilled" && captureResult.value !== undefined) {
         const produced = await this.dependencies.produce(captureResult.value);
@@ -171,8 +190,8 @@ export class StoreRuntime {
       return Object.freeze({
         published,
         counts,
-        legacySucceeded: legacyResult.status === "fulfilled"
-          && legacyResult.value.kind !== "failed",
+        legacySucceeded:
+          legacyResult.status === "fulfilled" && legacyResult.value.kind !== "failed",
       });
     } finally {
       if (this.activeLedger === ledger) this.activeLedger = undefined;
@@ -185,7 +204,9 @@ export class StoreRuntime {
     this.closed = true;
     this.activeController?.abort(new Error("Store runtime closed."));
     await this.scheduler.close();
-    try { await this.activeWindow; } catch {}
+    try {
+      await this.activeWindow;
+    } catch {}
   }
 }
 

--- a/packages/coach/tests/cli-verbs-rpc.test.ts
+++ b/packages/coach/tests/cli-verbs-rpc.test.ts
@@ -44,6 +44,11 @@ const operations: CoachOperations = {
     referenceSucceeded: true,
     requests: { store: 1, reference: 1, total: 2 },
   }),
+  saveIntake: async () => ({ schemaVersion: 1, saved: true }),
+  configureRuntime: async ({ llm, intervals }) => ({
+    schemaVersion: 1,
+    applied: { llm: llm !== undefined, intervals: intervals !== undefined },
+  }),
 };
 const state: AthleteState = {
   schemaVersion: "3",

--- a/packages/coach/tests/composition.test.ts
+++ b/packages/coach/tests/composition.test.ts
@@ -3,10 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AthleteState, CoachEngine } from "@enduragent/coach-contract";
-import {
-  engineConfigFromConfig,
-  type Config,
-} from "@enduragent/core";
+import { engineConfigFromConfig, type Config } from "@enduragent/core";
 import type {
   AthleteDataReaderPort,
   CreateCoachEngineInput,
@@ -80,13 +77,16 @@ async function freshHome(): Promise<AthleteHome> {
   await mkdir(join(root, "data"), { recursive: true });
   await mkdir(home.configDir, { recursive: true });
   await writeFile(join(root, "data", "latest.json"), JSON.stringify(latest()));
-  await writeFile(join(root, "data", "error_state.json"), JSON.stringify({
-    schema_version: "1",
-    step: "synthetic",
-    detail: "synthetic outage",
-    ts: "2026-07-18T01:00:00.000Z",
-    mitigation: "block_coaching",
-  }));
+  await writeFile(
+    join(root, "data", "error_state.json"),
+    JSON.stringify({
+      schema_version: "1",
+      step: "synthetic",
+      detail: "synthetic outage",
+      ts: "2026-07-18T01:00:00.000Z",
+      mitigation: "block_coaching",
+    }),
+  );
   return home;
 }
 
@@ -113,37 +113,72 @@ function config(
 
 function athleteData(): AthleteDataReaderPort {
   return {
-    async getAthlete() { return { ok: false, error: "not_found", message: "synthetic" }; },
-    async listWellness() { return { ok: true, value: [] }; },
-    async listActivities() { return { ok: true, value: [] }; },
-    async getActivity() { return { ok: false, error: "not_found", message: "synthetic" }; },
-    async getStreams() { return { ok: false, error: "not_found", message: "synthetic" }; },
-    async listCalendar() { return { ok: true, value: [] }; },
-    freshness() { return undefined; },
+    async getAthlete() {
+      return { ok: false, error: "not_found", message: "synthetic" };
+    },
+    async listWellness() {
+      return { ok: true, value: [] };
+    },
+    async listActivities() {
+      return { ok: true, value: [] };
+    },
+    async getActivity() {
+      return { ok: false, error: "not_found", message: "synthetic" };
+    },
+    async getStreams() {
+      return { ok: false, error: "not_found", message: "synthetic" };
+    },
+    async listCalendar() {
+      return { ok: true, value: [] };
+    },
+    freshness() {
+      return undefined;
+    },
   };
 }
 
 function reference(trace: string[] = []): LocalReferenceRuntime {
   return {
-    scheduler: { stop: () => { trace.push("reference-stop"); } },
-    async runScheduledOnce() { return { kind: "skipped", reason: "cooldown" }; },
+    scheduler: {
+      stop: () => {
+        trace.push("reference-stop");
+      },
+    },
+    async runScheduledOnce() {
+      return { kind: "skipped", reason: "cooldown" };
+    },
   };
 }
 
 function runtime(
   trace: string[] = [],
-  options: { runWindow?: () => Promise<{ published: boolean; counts: ReturnType<ReturnType<typeof createPhysicalRequestLedger>["snapshot"]>; legacySucceeded: boolean }>; close?: () => Promise<void> } = {},
+  options: {
+    runWindow?: () => Promise<{
+      published: boolean;
+      counts: ReturnType<ReturnType<typeof createPhysicalRequestLedger>["snapshot"]>;
+      legacySucceeded: boolean;
+    }>;
+    close?: () => Promise<void>;
+  } = {},
 ): LocalStoreRuntime {
   const ledger = createPhysicalRequestLedger({ storeLimit: 64, legacyLimit: 15, totalLimit: 79 });
   return {
     athleteData: athleteData(),
     attemptLedgerForRun: () => ledger,
-    runWindow: options.runWindow ?? (async () => {
-      trace.push("run-window");
-      return { published: true, counts: ledger.snapshot(), legacySucceeded: true };
-    }),
-    startScheduler() { trace.push("start-scheduler"); },
-    close: options.close ?? (async () => { trace.push("runtime-close"); }),
+    runWindow:
+      options.runWindow ??
+      (async () => {
+        trace.push("run-window");
+        return { published: true, counts: ledger.snapshot(), legacySucceeded: true };
+      }),
+    startScheduler() {
+      trace.push("start-scheduler");
+    },
+    close:
+      options.close ??
+      (async () => {
+        trace.push("runtime-close");
+      }),
   };
 }
 
@@ -168,12 +203,20 @@ function fakeContext(home: AthleteHome): CoachStoreWriterContext {
     store: {
       async exec() {},
       async run() {},
-      async get() { return undefined; },
-      async all() { return []; },
+      async get() {
+        return undefined;
+      },
+      async all() {
+        return [];
+      },
       async close() {},
-      async getUserVersion() { return 0; },
+      async getUserVersion() {
+        return 0;
+      },
       async setUserVersion() {},
-      async transaction<T>(operation: () => Promise<T>) { return operation(); },
+      async transaction<T>(operation: () => Promise<T>) {
+        return operation();
+      },
     },
   };
 }
@@ -185,13 +228,16 @@ async function compose(
   intervals?: Config["intervals"],
 ) {
   const coreConfig = config(home, intervals);
-  return createLocalCoachComposition({
-    env: { ENDURAGENT_HOME: home.root },
-    home,
-    context,
-    config: coreConfig,
-    engineConfig: engineConfigFromConfig(coreConfig),
-  }, dependencies);
+  return createLocalCoachComposition(
+    {
+      env: { ENDURAGENT_HOME: home.root },
+      home,
+      context,
+      config: coreConfig,
+      engineConfig: engineConfigFromConfig(coreConfig),
+    },
+    dependencies,
+  );
 }
 
 function generation(text: string) {
@@ -231,25 +277,33 @@ describe("local coach composition", () => {
       frozenNow: manifest.plan.frozenNow,
       bundle: { activities: [], wellness: [], ftpHistory: [] },
     };
-    const capture = vi.fn(async (
-      options: Parameters<typeof import("../src/capture.js").runReferenceCapture>[0],
-    ) => {
-      if (options.writerContext === undefined) nestedWriterAcquisition();
-      expect(options.writerContext).toBe(context);
-      return manifest;
-    });
-    const lifecycle = await compose(home, {
-      bootstrap: async () => reference(),
-      runtimeDependencies: {
-        capture,
-        produce: async () => produced,
-        now: () => new Date("1998-07-18T12:00:00.000Z"),
-        monotonicNow: () => 1,
+    const capture = vi.fn(
+      async (options: Parameters<typeof import("../src/capture.js").runReferenceCapture>[0]) => {
+        if (options.writerContext === undefined) nestedWriterAcquisition();
+        expect(options.writerContext).toBe(context);
+        return manifest;
       },
-      createBackend: () => backend(),
-      createRepository: () => ({ insertIfAbsent: async () => false, readCurrent: async () => undefined }),
-      createResolver: () => missingResolver(),
-    }, context, { apiKey: "dummy", athleteId: "synthetic" });
+    );
+    const lifecycle = await compose(
+      home,
+      {
+        bootstrap: async () => reference(),
+        runtimeDependencies: {
+          capture,
+          produce: async () => produced,
+          now: () => new Date("1998-07-18T12:00:00.000Z"),
+          monotonicNow: () => 1,
+        },
+        createBackend: () => backend(),
+        createRepository: () => ({
+          insertIfAbsent: async () => false,
+          readCurrent: async () => undefined,
+        }),
+        createResolver: () => missingResolver(),
+      },
+      context,
+      { apiKey: "dummy", athleteId: "synthetic" },
+    );
     expect(capture).toHaveBeenCalledTimes(1);
     expect(nestedWriterAcquisition).not.toHaveBeenCalled();
     await lifecycle.close();
@@ -310,14 +364,21 @@ describe("local coach composition", () => {
         received = input;
         return backend({ getAthleteState: () => input.ports.stateReader.getAthleteState() });
       },
-      createRepository: () => ({ insertIfAbsent: async () => false, readCurrent: async () => undefined }),
+      createRepository: () => ({
+        insertIfAbsent: async () => false,
+        readCurrent: async () => undefined,
+      }),
       createResolver: () => missingResolver(),
     });
     await expect(received!.ports.stateReader.getAthleteState()).resolves.toEqual(state);
     await expect(lifecycle.engine.getAthleteState()).resolves.toEqual(state);
     expect(received!.ports.platform.athleteData).toBe(selectedRuntime.athleteData);
-    expect(received!.ports.readReferenceState).not.toBe(received!.ports.stateReader.getAthleteState);
-    expect(received!.ports.readReferenceState().latest?.metadata?.last_updated).toBe(state.lastUpdated);
+    expect(received!.ports.readReferenceState).not.toBe(
+      received!.ports.stateReader.getAthleteState,
+    );
+    expect(received!.ports.readReferenceState().latest?.metadata?.last_updated).toBe(
+      state.lastUpdated,
+    );
     await lifecycle.close();
   });
 
@@ -327,18 +388,24 @@ describe("local coach composition", () => {
     const failure = { kind: "cold-start" };
     const trace: string[] = [];
     const createBackend = vi.fn<(input: CreateCoachEngineInput) => CoachEngine>(() => backend());
-    await expect(compose(home, {
-      bootstrap: async () => reference(trace),
-      createRuntime: () => runtime(trace, {
-        runWindow: async () => {
-          trace.push("run-window");
-          throw failure;
-        },
+    await expect(
+      compose(home, {
+        bootstrap: async () => reference(trace),
+        createRuntime: () =>
+          runtime(trace, {
+            runWindow: async () => {
+              trace.push("run-window");
+              throw failure;
+            },
+          }),
+        createBackend,
+        createRepository: () => ({
+          insertIfAbsent: async () => false,
+          readCurrent: async () => undefined,
+        }),
+        createResolver: () => missingResolver(),
       }),
-      createBackend,
-      createRepository: () => ({ insertIfAbsent: async () => false, readCurrent: async () => undefined }),
-      createResolver: () => missingResolver(),
-    })).rejects.toBe(failure);
+    ).rejects.toBe(failure);
     expect(createBackend).not.toHaveBeenCalled();
     expect(trace).toEqual(["run-window", "reference-stop", "runtime-close"]);
   });
@@ -351,28 +418,52 @@ describe("local coach composition", () => {
     await runMigrations(store, MIGRATIONS);
     await store.run(
       "INSERT INTO anchor_history (id, sport, anchor_type, value, unit, valid_from, source, confidence, note, provenance, device_id, hlc_physical_ms, hlc_counter) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)",
-      ["anchor-1", "cycling", "ftp", 275, "W", 1_752_796_000, "synthetic", "manual", null, "manual", null, null, null],
+      [
+        "anchor-1",
+        "cycling",
+        "ftp",
+        275,
+        "W",
+        1_752_796_000,
+        "synthetic",
+        "manual",
+        null,
+        "manual",
+        null,
+        null,
+        null,
+      ],
     );
     let chatRequest: Parameters<CoachEngine["chat"]>[0] | undefined;
-    const lifecycle = await compose(home, {
-      bootstrap: async () => reference(),
-      createRuntime: () => runtime(),
-      createBackend: (input) => backend({
-        chat: async (request) => {
-          chatRequest = request;
-          return { text: "anchored" };
-        },
-        getAthleteState: () => input.ports.stateReader.getAthleteState(),
-        hasSession: async () => ({ hasSession: true }),
-        resetSession: async () => ({ memoryFlushed: true }),
-      }),
-      now: () => 1_752_796_800_000,
-    }, { home, store, listener: inertWriterProtocolListener });
-    await expect(lifecycle.engine.chat({ chatId: "x", message: "status" }))
-      .resolves.toEqual({ text: "anchored" });
+    const lifecycle = await compose(
+      home,
+      {
+        bootstrap: async () => reference(),
+        createRuntime: () => runtime(),
+        createBackend: (input) =>
+          backend({
+            chat: async (request) => {
+              chatRequest = request;
+              return { text: "anchored" };
+            },
+            getAthleteState: () => input.ports.stateReader.getAthleteState(),
+            hasSession: async () => ({ hasSession: true }),
+            resetSession: async () => ({ memoryFlushed: true }),
+          }),
+        now: () => 1_752_796_800_000,
+      },
+      { home, store, listener: inertWriterProtocolListener },
+    );
+    await expect(lifecycle.engine.chat({ chatId: "x", message: "status" })).resolves.toEqual({
+      text: "anchored",
+    });
     expect(chatRequest?.turn?.resolvedCs).toMatchObject({ kind: "ftp", watts: 275 });
-    await expect(lifecycle.engine.hasSession({ chatId: "x" })).resolves.toEqual({ hasSession: true });
-    await expect(lifecycle.engine.resetSession({ chatId: "x" })).resolves.toEqual({ memoryFlushed: true });
+    await expect(lifecycle.engine.hasSession({ chatId: "x" })).resolves.toEqual({
+      hasSession: true,
+    });
+    await expect(lifecycle.engine.resetSession({ chatId: "x" })).resolves.toEqual({
+      memoryFlushed: true,
+    });
     await expect(lifecycle.engine.getAthleteState()).resolves.toMatchObject({
       currentStatus: state.currentStatus,
       derivedMetrics: state.derivedMetrics,
@@ -387,8 +478,12 @@ describe("local coach composition", () => {
     let generateCalls = 0;
     let releaseFirst!: () => void;
     let markEntered!: () => void;
-    const entered = new Promise<void>((resolve) => { markEntered = resolve; });
-    const firstGate = new Promise<void>((resolve) => { releaseFirst = resolve; });
+    const entered = new Promise<void>((resolve) => {
+      markEntered = resolve;
+    });
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
     const decorator: ModelTransportDecorator = () => ({
       generate: async () => {
         generateCalls += 1;
@@ -402,25 +497,104 @@ describe("local coach composition", () => {
     const lifecycle = await compose(home, {
       bootstrap: async () => reference(),
       createRuntime: () => runtime(),
-      createRepository: () => ({ insertIfAbsent: async () => false, readCurrent: async () => undefined }),
+      createRepository: () => ({
+        insertIfAbsent: async () => false,
+        readCurrent: async () => undefined,
+      }),
       createResolver: () => missingResolver(),
       modelTransportDecorator: decorator,
     });
     const completion: string[] = [];
-    const first = lifecycle.engine.chat({ chatId: "same", message: "first" })
-      .then((value) => { completion.push("first"); return value; });
+    const first = lifecycle.engine.chat({ chatId: "same", message: "first" }).then((value) => {
+      completion.push("first");
+      return value;
+    });
     await entered;
-    const second = lifecycle.engine.chat({ chatId: "same", message: "second" })
-      .then((value) => { completion.push("second"); return value; });
+    const second = lifecycle.engine.chat({ chatId: "same", message: "second" }).then((value) => {
+      completion.push("second");
+      return value;
+    });
     await Promise.resolve();
     expect(generateCalls).toBe(1);
-    const other = lifecycle.engine.chat({ chatId: "other", message: "other" })
-      .then((value) => { completion.push("other"); return value; });
+    const other = lifecycle.engine.chat({ chatId: "other", message: "other" }).then((value) => {
+      completion.push("other");
+      return value;
+    });
     while (generateCalls < 2) await Promise.resolve();
     expect(generateCalls).toBe(2);
     releaseFirst();
     await Promise.all([first, second, other]);
     expect(completion.indexOf("first")).toBeLessThan(completion.indexOf("second"));
+    await lifecycle.close();
+  });
+
+  it("atomically supersedes the in-memory runtime overlay for later turns and store windows", async () => {
+    const home = await freshHome();
+    const received: CreateCoachEngineInput[] = [];
+    let runtimeOptions:
+      | Parameters<NonNullable<LocalCoachCompositionDependencies["createRuntime"]>>[0]
+      | undefined;
+    const lifecycle = await compose(home, {
+      bootstrap: async () => reference(),
+      createRuntime: (options) => {
+        runtimeOptions = options;
+        return runtime();
+      },
+      createBackend: (input) => {
+        received.push(input);
+        const selected = `${input.ports.config.llm.provider}:${input.ports.config.llm.model}`;
+        return backend({ chat: async () => ({ text: selected }) });
+      },
+      createRepository: () => ({
+        insertIfAbsent: async () => false,
+        readCurrent: async () => undefined,
+      }),
+      createResolver: () => missingResolver(),
+    });
+
+    await expect(lifecycle.engine.chat({ chatId: "runtime", message: "initial" })).resolves.toEqual(
+      {
+        text: "anthropic:synthetic",
+      },
+    );
+    await lifecycle.operations.configureRuntime({
+      llm: { provider: "openrouter", model: "model-first", api_key: "placeholder" },
+    });
+    await expect(
+      lifecycle.engine.chat({ chatId: "runtime", message: "after-first" }),
+    ).resolves.toEqual({
+      text: "openrouter:model-first",
+    });
+    await lifecycle.operations.configureRuntime({
+      intervals: { api_key: "placeholder", athlete_id: "athlete-a" },
+    });
+    await lifecycle.operations.configureRuntime({
+      llm: { provider: "google", model: "model-second", api_key: "placeholder" },
+      intervals: { api_key: "placeholder", athlete_id: "athlete-b" },
+    });
+    await expect(
+      lifecycle.engine.chat({ chatId: "runtime", message: "after-second" }),
+    ).resolves.toEqual({
+      text: "google:model-second",
+    });
+
+    expect(
+      received.map((input) => ({
+        provider: input.ports.config.llm.provider,
+        model: input.ports.config.llm.model,
+        apiKey: input.ports.config.llm.apiKey,
+        intervals: input.ports.platform.legacyClient === null,
+      })),
+    ).toEqual([
+      { provider: "anthropic", model: "synthetic", apiKey: "", intervals: true },
+      { provider: "openrouter", model: "model-first", apiKey: "placeholder", intervals: true },
+      { provider: "openrouter", model: "model-first", apiKey: "placeholder", intervals: false },
+      { provider: "google", model: "model-second", apiKey: "placeholder", intervals: false },
+    ]);
+    expect(runtimeOptions?.readConfig?.().intervals).toEqual({
+      apiKey: "placeholder",
+      athleteId: "athlete-b",
+    });
     await lifecycle.close();
   });
 
@@ -430,22 +604,30 @@ describe("local coach composition", () => {
     const hostFailure = { kind: "host-close" };
     let releaseClose!: () => void;
     let markCloseStarted!: () => void;
-    const closeGate = new Promise<void>((resolve) => { releaseClose = resolve; });
-    const closeStarted = new Promise<void>((resolve) => { markCloseStarted = resolve; });
+    const closeGate = new Promise<void>((resolve) => {
+      releaseClose = resolve;
+    });
+    const closeStarted = new Promise<void>((resolve) => {
+      markCloseStarted = resolve;
+    });
     let runtimeCloseCalls = 0;
     const lifecycle = await compose(home, {
       bootstrap: async () => reference(trace),
-      createRuntime: () => runtime(trace, {
-        close: async () => {
-          runtimeCloseCalls += 1;
-          trace.push("runtime-close-start");
-          markCloseStarted();
-          await closeGate;
-          trace.push("runtime-close-end");
-        },
-      }),
+      createRuntime: () =>
+        runtime(trace, {
+          close: async () => {
+            runtimeCloseCalls += 1;
+            trace.push("runtime-close-start");
+            markCloseStarted();
+            await closeGate;
+            trace.push("runtime-close-end");
+          },
+        }),
       createBackend: () => backend(),
-      createRepository: () => ({ insertIfAbsent: async () => false, readCurrent: async () => undefined }),
+      createRepository: () => ({
+        insertIfAbsent: async () => false,
+        readCurrent: async () => undefined,
+      }),
       createResolver: () => missingResolver(),
       closeHostAdapters: async () => {
         trace.push("host-close");

--- a/packages/coach/tests/daemon-handshake.test.ts
+++ b/packages/coach/tests/daemon-handshake.test.ts
@@ -157,6 +157,11 @@ describe.skipIf(!hasLoopback)("production peer observations", () => {
           referenceSucceeded: true,
           requests: { store: 0, reference: 0, total: 0 },
         }),
+        saveIntake: async () => ({ schemaVersion: 1, saved: true }),
+        configureRuntime: async ({ llm, intervals }) => ({
+          schemaVersion: 1,
+          applied: { llm: llm !== undefined, intervals: intervals !== undefined },
+        }),
       },
       engine: {
         chat: async () => ({ text: "ok" }),

--- a/packages/coach/tests/daemon-rpc-server.test.ts
+++ b/packages/coach/tests/daemon-rpc-server.test.ts
@@ -71,6 +71,11 @@ const operations: CoachOperations = {
     referenceSucceeded: true,
     requests: { store: 1, reference: 1, total: 2 },
   }),
+  saveIntake: async () => ({ schemaVersion: 1, saved: true }),
+  configureRuntime: async ({ llm, intervals }) => ({
+    schemaVersion: 1,
+    applied: { llm: llm !== undefined, intervals: intervals !== undefined },
+  }),
 };
 
 function createCoachRpcServer(
@@ -380,6 +385,70 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
     await client.close();
   });
 
+  it("dispatches authenticated intake and runtime operations without value echo", async () => {
+    const token = "x".repeat(43);
+    const saveIntake = vi.fn(async () => ({ schemaVersion: 1 as const, saved: true as const }));
+    const configureRuntime = vi.fn(async ({ llm, intervals }) => ({
+      schemaVersion: 1 as const,
+      applied: { llm: llm !== undefined, intervals: intervals !== undefined },
+    }));
+    const rpc = createCoachRpcServer({
+      engine: engine(),
+      operations: { ...operations, saveIntake, configureRuntime },
+      token,
+      owner: "app-supervised",
+    });
+    const client = await openSocket(rpc);
+    client.ws.send(JSON.stringify(createClientHandshakeFrame(token)));
+    await client.frames.next();
+    const intake = {
+      swim_skill_floor: null,
+      continuous_distance_capable: null,
+      open_water_comfort: null,
+      prior_bsi: false,
+      clinician_cleared: null,
+      injury_status: "none",
+    } as const;
+    client.ws.send(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: "intake",
+        method: "saveIntake",
+        params: intake,
+      }),
+    );
+    expect(parseCoachRpcEnvelope(await client.frames.next())).toEqual({
+      jsonrpc: "2.0",
+      id: "intake",
+      result: { schemaVersion: 1, saved: true },
+    });
+    expect(saveIntake).toHaveBeenCalledWith(intake);
+
+    const runtime = {
+      llm: { provider: "openrouter", model: "model-a", api_key: "placeholder" },
+      intervals: { api_key: "placeholder", athlete_id: "athlete-a" },
+    } as const;
+    client.ws.send(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: "runtime",
+        method: "configureRuntime",
+        params: runtime,
+      }),
+    );
+    const response = parseCoachRpcEnvelope(await client.frames.next());
+    expect(response).toEqual({
+      jsonrpc: "2.0",
+      id: "runtime",
+      result: { schemaVersion: 1, applied: { llm: true, intervals: true } },
+    });
+    expect(configureRuntime).toHaveBeenCalledWith(runtime);
+    expect(JSON.stringify(response)).not.toContain("placeholder");
+    expect(JSON.stringify(response)).not.toContain("athlete-a");
+    expect(JSON.stringify(response)).not.toContain("model-a");
+    await client.close();
+  });
+
   it("uses authoritative protocol errors, recoverable ids, and method lookup order", async () => {
     const token = "x".repeat(43);
     const rpc = createCoachRpcServer({
@@ -400,6 +469,23 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
       [
         JSON.stringify({ jsonrpc: "2.0", id: "known", method: "chat", params: {} }),
         { id: "known", error: { code: -32602, message: "Invalid params" } },
+      ],
+      [
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: "strict-intake",
+          method: "saveIntake",
+          params: {
+            swim_skill_floor: null,
+            continuous_distance_capable: null,
+            open_water_comfort: null,
+            prior_bsi: false,
+            clinician_cleared: null,
+            injury_status: "none",
+            extra: true,
+          },
+        }),
+        { id: "strict-intake", error: { code: -32602, message: "Invalid params" } },
       ],
       [
         JSON.stringify({ jsonrpc: "1.0", id: "recoverable", method: "chat", params: {} }),

--- a/packages/coach/tests/daemon/redaction-rpc-cli.test.ts
+++ b/packages/coach/tests/daemon/redaction-rpc-cli.test.ts
@@ -155,6 +155,11 @@ async function startRpc(coachEngine: CoachEngine): Promise<RunningRpc> {
         referenceSucceeded: true,
         requests: { store: 0, reference: 0, total: 0 },
       }),
+      saveIntake: async () => ({ schemaVersion: 1, saved: true }),
+      configureRuntime: async ({ llm, intervals }) => ({
+        schemaVersion: 1,
+        applied: { llm: llm !== undefined, intervals: intervals !== undefined },
+      }),
     },
     token: AUTH_TOKEN,
     owner: "unmanaged-foreground",

--- a/packages/coach/tests/desktop-supervisor.test.ts
+++ b/packages/coach/tests/desktop-supervisor.test.ts
@@ -59,11 +59,11 @@ function healthy(
   owner: "service-managed" | "unmanaged-foreground" | "app-supervised",
 ): DaemonStateObservation {
   const peer = { status: "peer-healthy", pid: 12, port: 45_001, peerVersion: "0.1.0" } as const;
-  const handshake = createAcceptedServerHandshakeFrame(owner, 2);
+  const handshake = createAcceptedServerHandshakeFrame(owner, PROTOCOL_VERSION);
   return {
     kind: "compatible-healthy",
     peer,
-    serverProtocolVersion: 2,
+    serverProtocolVersion: PROTOCOL_VERSION,
     authenticated: { peer, coordinates: { port: peer.port, token }, handshake },
   };
 }

--- a/packages/coach/tests/enduragent-entry.test.ts
+++ b/packages/coach/tests/enduragent-entry.test.ts
@@ -70,6 +70,11 @@ const operations: CoachOperations = {
     referenceSucceeded: true,
     requests: { store: 0, reference: 0, total: 0 },
   }),
+  saveIntake: async () => ({ schemaVersion: 1, saved: true }),
+  configureRuntime: async ({ llm, intervals }) => ({
+    schemaVersion: 1,
+    applied: { llm: llm !== undefined, intervals: intervals !== undefined },
+  }),
 };
 
 interface Deferred<T> {

--- a/packages/coach/tests/enduragent-redaction.test.ts
+++ b/packages/coach/tests/enduragent-redaction.test.ts
@@ -146,6 +146,11 @@ describe.skipIf(!hasLoopback)("local CLI redaction boundary", () => {
               referenceSucceeded: true,
               requests: { store: 0, reference: 0, total: 0 },
             }),
+            saveIntake: async () => ({ schemaVersion: 1, saved: true }),
+            configureRuntime: async ({ llm, intervals }) => ({
+              schemaVersion: 1,
+              applied: { llm: llm !== undefined, intervals: intervals !== undefined },
+            }),
           },
           listener: context.listener,
           close: async () => {},

--- a/packages/coach/tests/local-runner.test.ts
+++ b/packages/coach/tests/local-runner.test.ts
@@ -81,6 +81,11 @@ const operations: CoachOperations = {
     referenceSucceeded: true,
     requests: { store: 0, reference: 0, total: 0 },
   }),
+  saveIntake: async () => ({ schemaVersion: 1, saved: true }),
+  configureRuntime: async ({ llm, intervals }) => ({
+    schemaVersion: 1,
+    applied: { llm: llm !== undefined, intervals: intervals !== undefined },
+  }),
 };
 
 const config = {

--- a/packages/coach/tests/operations.test.ts
+++ b/packages/coach/tests/operations.test.ts
@@ -60,6 +60,7 @@ describe("coach operations", () => {
         home: liveHome,
         context: liveContext,
         runtime: { runWindow: vi.fn() },
+        applyRuntimeConfig: async () => {},
       });
       const paths = ["brick-cycling.fit", "fallback-cycling.tcx", "fallback-cycling.gpx"].map(
         (name) => resolve("packages/kernel-node/tests/fixtures/ingest", name),
@@ -82,6 +83,83 @@ describe("coach operations", () => {
     }
   });
 
+  it("idempotently replaces one daemon-authored intake row", async () => {
+    const root = await mkdtemp(join(await realpath(tmpdir()), "coach-intake-"));
+    const liveHome: AthleteHome = {
+      root,
+      storeDir: join(root, "store"),
+      archiveDir: join(root, "archive"),
+      configDir: join(root, "config"),
+    };
+    const store = openSqliteStorage(join(root, "coach.db"));
+    try {
+      await runMigrations(store, MIGRATIONS);
+      const operations = createCoachOperations({
+        home: liveHome,
+        context: {
+          home: liveHome,
+          store,
+          listener: {} as CoachStoreWriterContext["listener"],
+        },
+        runtime: { runWindow: vi.fn() },
+        applyRuntimeConfig: async () => {},
+      });
+      await expect(
+        operations.saveIntake({
+          swim_skill_floor: null,
+          continuous_distance_capable: null,
+          open_water_comfort: null,
+          prior_bsi: false,
+          clinician_cleared: null,
+          injury_status: "none",
+        }),
+      ).resolves.toEqual({ schemaVersion: 1, saved: true });
+      const first = await store.get("SELECT * FROM intake_flags");
+      await operations.saveIntake({
+        swim_skill_floor: null,
+        continuous_distance_capable: null,
+        open_water_comfort: null,
+        prior_bsi: true,
+        clinician_cleared: false,
+        injury_status: "managing",
+      });
+      const second = await store.get("SELECT * FROM intake_flags");
+      expect(await store.all("SELECT id FROM intake_flags")).toHaveLength(1);
+      expect(second).toMatchObject({
+        prior_bsi: 1,
+        clinician_cleared: 0,
+        injury_status: "managing",
+        device_id: first?.device_id,
+      });
+      expect(second?.id).not.toBe(first?.id);
+      expect(Number(second?.hlc_counter)).toBeGreaterThanOrEqual(Number(first?.hlc_counter));
+      await expect(async () =>
+        operations.saveIntake({
+          swim_skill_floor: null,
+          continuous_distance_capable: null,
+          open_water_comfort: null,
+          prior_bsi: false,
+          clinician_cleared: null,
+          injury_status: "none",
+          extra: true,
+        } as never),
+      ).rejects.toThrow();
+      await expect(async () =>
+        operations.saveIntake({
+          swim_skill_floor: null,
+          continuous_distance_capable: null,
+          open_water_comfort: null,
+          prior_bsi: true,
+          clinician_cleared: null,
+          injury_status: "returning",
+        }),
+      ).rejects.toThrow();
+    } finally {
+      await store.close();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("maps canonical import and sync reports with exact progress", async () => {
     const importFiles = vi.fn(async () => ({
       files: [{ outcome: "imported" }, { outcome: "quarantined" }],
@@ -98,7 +176,12 @@ describe("coach operations", () => {
       counts: requestCounts(2, 1),
     }));
     const operations = createCoachOperations(
-      { home, context: context(), runtime: { runWindow } },
+      {
+        home,
+        context: context(),
+        runtime: { runWindow },
+        applyRuntimeConfig: async () => {},
+      },
       { importFiles },
     );
     const importEvents: unknown[] = [];
@@ -159,7 +242,12 @@ describe("coach operations", () => {
       };
     });
     const operations = createCoachOperations(
-      { home, context: context(), runtime: { runWindow } },
+      {
+        home,
+        context: context(),
+        runtime: { runWindow },
+        applyRuntimeConfig: async () => {},
+      },
       { importFiles },
     );
     const first = operations.importFiles({ paths: ["/synthetic/a.fit"] });
@@ -170,5 +258,54 @@ describe("coach operations", () => {
     await expect(first).rejects.toThrow("synthetic failure");
     await expect(second).resolves.toMatchObject({ schemaVersion: 1 });
     expect(trace).toEqual(["import-start", "import-end", "sync"]);
+  });
+
+  it("applies llm-only, intervals-only, both, and superseding runtime requests without echo", async () => {
+    const applied: unknown[] = [];
+    const applyRuntimeConfig = vi.fn(async (request) => {
+      applied.push(request);
+    });
+    const operations = createCoachOperations({
+      home,
+      context: context(),
+      runtime: { runWindow: vi.fn() },
+      applyRuntimeConfig,
+    });
+    const llmFirst = {
+      llm: { provider: "anthropic" as const, model: "first", api_key: "placeholder" },
+    };
+    const intervalsOnly = {
+      intervals: { api_key: "placeholder", athlete_id: "athlete-a" },
+    };
+    const both = {
+      llm: { provider: "openrouter" as const, model: "second", api_key: "placeholder" },
+      intervals: { api_key: "placeholder", athlete_id: "athlete-b" },
+    };
+    const results = [
+      await operations.configureRuntime(llmFirst),
+      await operations.configureRuntime(intervalsOnly),
+      await operations.configureRuntime(both),
+      await operations.configureRuntime({
+        llm: { provider: "google", model: "third", api_key: "placeholder" },
+      }),
+    ];
+    expect(results).toEqual([
+      { schemaVersion: 1, applied: { llm: true, intervals: false } },
+      { schemaVersion: 1, applied: { llm: false, intervals: true } },
+      { schemaVersion: 1, applied: { llm: true, intervals: true } },
+      { schemaVersion: 1, applied: { llm: true, intervals: false } },
+    ]);
+    expect(applied).toEqual([
+      llmFirst,
+      intervalsOnly,
+      both,
+      {
+        llm: { provider: "google", model: "third", api_key: "placeholder" },
+      },
+    ]);
+    const serializedResults = JSON.stringify(results);
+    for (const value of ["first", "second", "third", "placeholder", "athlete"]) {
+      expect(serializedResults).not.toContain(value);
+    }
   });
 });

--- a/packages/coach/tests/serve.test.ts
+++ b/packages/coach/tests/serve.test.ts
@@ -69,6 +69,11 @@ const operations: CoachOperations = {
     referenceSucceeded: true,
     requests: { store: 0, reference: 0, total: 0 },
   }),
+  saveIntake: async () => ({ schemaVersion: 1, saved: true }),
+  configureRuntime: async ({ llm, intervals }) => ({
+    schemaVersion: 1,
+    applied: { llm: llm !== undefined, intervals: intervals !== undefined },
+  }),
 };
 
 const home: AthleteHome = {

--- a/packages/coach/tests/store-runtime.test.ts
+++ b/packages/coach/tests/store-runtime.test.ts
@@ -21,7 +21,7 @@ const manifest = { capture_id: "12345678-1234-4123-8123-123456789abc",
 const produced: ProducedLocalBundle = { captureId: manifest.capture_id, frozenNow: manifest.plan.frozenNow,
   bundle: { activities: [], wellness: [], ftpHistory: [], athlete: { sportSettings: [] } } };
 
-async function makeRuntime(runtimeConfig: Config = config) {
+async function makeRuntime(runtimeConfig: Config = config, readConfig?: () => Config) {
   const root = await mkdtemp(join(await realpath(tmpdir()), "store-runtime-")); roots.push(root);
   let runtime!: StoreRuntime;
   const reference = { scheduler: { stop: vi.fn() }, services: {},
@@ -34,7 +34,7 @@ async function makeRuntime(runtimeConfig: Config = config) {
     return manifest;
   });
   const produce = vi.fn(async () => produced);
-  runtime = createStoreRuntime({ env: {}, config: runtimeConfig, home: { root, storeDir: join(root, "store"),
+  runtime = createStoreRuntime({ env: {}, config: runtimeConfig, readConfig, home: { root, storeDir: join(root, "store"),
     archiveDir: join(root, "archive"), configDir: join(root, "config") }, reference,
     dependencies: { capture, produce,
       now: () => new Date("1998-07-18T12:00:00.000Z"), monotonicNow: () => 1 } });
@@ -69,6 +69,26 @@ describe("StoreRuntime", () => {
     await runtime.close();
   });
 
+  it("reads an applied intervals overlay at the next store window", async () => {
+    let activeConfig: Config = {
+      ...config,
+      intervals: { apiKey: "", athleteId: "unconfigured" },
+    };
+    const { runtime, capture } = await makeRuntime(activeConfig, () => activeConfig);
+    await runtime.runWindow();
+    expect(capture).not.toHaveBeenCalled();
+    activeConfig = {
+      ...activeConfig,
+      intervals: { apiKey: "placeholder", athleteId: "new-athlete" },
+    };
+    await runtime.runWindow();
+    expect(capture).toHaveBeenCalledTimes(1);
+    expect(capture).toHaveBeenCalledWith(
+      expect.objectContaining({ apiKey: "placeholder", athleteId: "new-athlete" }),
+    );
+    await runtime.close();
+  });
+
   it("retains the prior complete snapshot after a later capture failure", async () => {
     const { runtime, capture } = await makeRuntime();
     await runtime.runWindow();
@@ -79,47 +99,101 @@ describe("StoreRuntime", () => {
   });
 
   it("owns one unref'd six-hour timer, skips overlap, and closes once", async () => {
-    const root = await mkdtemp(join(await realpath(tmpdir()), "store-runtime-timer-")); roots.push(root);
-    const unref = vi.fn(), clear = vi.fn(); let delay = 0;
+    const root = await mkdtemp(join(await realpath(tmpdir()), "store-runtime-timer-"));
+    roots.push(root);
+    const unref = vi.fn(),
+      clear = vi.fn();
+    let delay = 0;
     const handle = { unref } as unknown as ReturnType<typeof setTimeout>;
     let release!: () => void;
-    const reference = { scheduler: { stop: vi.fn() }, services: {},
-      runScheduledOnce: vi.fn(async () => ({ kind: "ran", lastSyncAt: "", refreshed: [] })) } as unknown as ReferenceRuntime;
-    const runtime = createStoreRuntime({ env: {}, config, home: { root, storeDir: join(root, "store"),
-      archiveDir: join(root, "archive"), configDir: join(root, "config") }, reference,
-      dependencies: { capture: vi.fn(() => new Promise<ReferenceCaptureManifest>((resolve) => { release = () => resolve(manifest); })),
-        produce: vi.fn(async () => produced), now: () => new Date("1998-07-18T12:00:00.000Z"), monotonicNow: () => 1,
+    const reference = {
+      scheduler: { stop: vi.fn() },
+      services: {},
+      runScheduledOnce: vi.fn(async () => ({ kind: "ran", lastSyncAt: "", refreshed: [] })),
+    } as unknown as ReferenceRuntime;
+    const runtime = createStoreRuntime({
+      env: {},
+      config,
+      home: {
+        root,
+        storeDir: join(root, "store"),
+        archiveDir: join(root, "archive"),
+        configDir: join(root, "config"),
+      },
+      reference,
+      dependencies: {
+        capture: vi.fn(
+          () =>
+            new Promise<ReferenceCaptureManifest>((resolve) => {
+              release = () => resolve(manifest);
+            }),
+        ),
+        produce: vi.fn(async () => produced),
+        now: () => new Date("1998-07-18T12:00:00.000Z"),
+        monotonicNow: () => 1,
         schedulerDependencies: {
           nowEpochMs: () => new Date("1998-07-18T12:00:00.000Z").getTime(),
-          setTimeout: ((_: () => void, ms: number) => { delay = ms; return handle; }) as typeof setTimeout,
+          setTimeout: ((_: () => void, ms: number) => {
+            delay = ms;
+            return handle;
+          }) as typeof setTimeout,
           clearTimeout: clear as unknown as typeof clearTimeout,
-        } } });
-    runtime.startScheduler(); runtime.startScheduler();
-    expect(delay).toBe(STORE_REFRESH_INTERVAL_MS); expect(unref).toHaveBeenCalledTimes(1);
-    const first = runtime.runWindow(), second = runtime.runWindow(); expect(first).toBe(second);
-    release(); await first; await runtime.close(); await runtime.close();
+        },
+      },
+    });
+    runtime.startScheduler();
+    runtime.startScheduler();
+    expect(delay).toBe(STORE_REFRESH_INTERVAL_MS);
+    expect(unref).toHaveBeenCalledTimes(1);
+    const first = runtime.runWindow(),
+      second = runtime.runWindow();
+    expect(first).toBe(second);
+    release();
+    await first;
+    await runtime.close();
+    await runtime.close();
     expect(clear).toHaveBeenCalledTimes(1);
   });
 
   it("cancels an active window when closed and rejects later windows", async () => {
-    const root = await mkdtemp(join(await realpath(tmpdir()), "store-runtime-close-")); roots.push(root);
+    const root = await mkdtemp(join(await realpath(tmpdir()), "store-runtime-close-"));
+    roots.push(root);
     const handle = { unref: vi.fn() } as unknown as ReturnType<typeof setTimeout>;
     let signal!: AbortSignal;
-    const reference = { scheduler: { stop: vi.fn() }, services: {},
-      runScheduledOnce: vi.fn(async () => ({ kind: "ran", lastSyncAt: "", refreshed: [] })) } as unknown as ReferenceRuntime;
-    const runtime = createStoreRuntime({ env: {}, config, home: { root, storeDir: join(root, "store"),
-      archiveDir: join(root, "archive"), configDir: join(root, "config") }, reference,
-      dependencies: { capture: vi.fn((options: Parameters<typeof import("../src/capture.js").runReferenceCapture>[0]) => {
-        signal = options.budget!.signal;
-        return new Promise<ReferenceCaptureManifest>((_, reject) => {
-          signal.addEventListener("abort", () => reject(signal.reason), { once: true });
-        });
-      }), produce: vi.fn(async () => produced), now: () => new Date("1998-07-18T12:00:00.000Z"), monotonicNow: () => 1,
+    const reference = {
+      scheduler: { stop: vi.fn() },
+      services: {},
+      runScheduledOnce: vi.fn(async () => ({ kind: "ran", lastSyncAt: "", refreshed: [] })),
+    } as unknown as ReferenceRuntime;
+    const runtime = createStoreRuntime({
+      env: {},
+      config,
+      home: {
+        root,
+        storeDir: join(root, "store"),
+        archiveDir: join(root, "archive"),
+        configDir: join(root, "config"),
+      },
+      reference,
+      dependencies: {
+        capture: vi.fn(
+          (options: Parameters<typeof import("../src/capture.js").runReferenceCapture>[0]) => {
+            signal = options.budget!.signal;
+            return new Promise<ReferenceCaptureManifest>((_, reject) => {
+              signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+            });
+          },
+        ),
+        produce: vi.fn(async () => produced),
+        now: () => new Date("1998-07-18T12:00:00.000Z"),
+        monotonicNow: () => 1,
         schedulerDependencies: {
           nowEpochMs: () => new Date("1998-07-18T12:00:00.000Z").getTime(),
           setTimeout: vi.fn(() => handle) as unknown as typeof setTimeout,
           clearTimeout: vi.fn() as unknown as typeof clearTimeout,
-        } } });
+        },
+      },
+    });
     const window = runtime.runWindow();
     const rejectedWindow = expect(window).rejects.toThrow("Store runtime closed.");
     const close = runtime.close();

--- a/packages/kernel-node/src/home/index.ts
+++ b/packages/kernel-node/src/home/index.ts
@@ -1,8 +1,4 @@
-export {
-  ATHLETE_HOME_ENV,
-  expandTilde,
-  resolveAthleteHome,
-} from "./resolve-athlete-home.js";
+export { ATHLETE_HOME_ENV, expandTilde, resolveAthleteHome } from "./resolve-athlete-home.js";
 export type { AthleteHome } from "./resolve-athlete-home.js";
 
 export {
@@ -25,3 +21,6 @@ export type {
   FtpSeedReport,
   SeedFtpHistoryOptions,
 } from "./anchor-seeder.js";
+
+export { createAuthoredIdentity } from "../store/authored-identity.js";
+export type { AuthoredIdentity, AuthoredIdentityDependencies } from "../store/authored-identity.js";

--- a/packages/kernel-node/src/index.ts
+++ b/packages/kernel-node/src/index.ts
@@ -1,2 +1,3 @@
 // Scaffold — the Node host adapter's content lands in later waves.
 export const KERNEL_NODE_STATUS = "scaffold-no-content-yet" as const;
+export * from "./store/authored-identity.js";

--- a/packages/kernel-node/src/store/authored-identity.ts
+++ b/packages/kernel-node/src/store/authored-identity.ts
@@ -1,0 +1,120 @@
+import { randomBytes as nodeRandomBytes } from "node:crypto";
+import { mkdir, readFile, rename } from "node:fs/promises";
+import { join } from "node:path";
+import { writeTempThenPublish } from "../lock/write-temp.js";
+
+const CROCKFORD = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+const MAX_TIMESTAMP = 0xffffffffffff;
+const RANDOM_MASK = (1n << 80n) - 1n;
+const deviceIdQueues = new Map<string, Promise<string>>();
+
+export interface AuthoredIdentity {
+  deviceId(): Promise<string>;
+  newUlid(): string;
+  hlcStamp(): { readonly physicalMs: number; readonly counter: number };
+}
+
+export interface AuthoredIdentityDependencies {
+  readonly now?: () => number;
+  readonly randomBytes?: (size: number) => Uint8Array;
+}
+
+function encodeUlid(timestamp: number, randomness: bigint): string {
+  let value = (BigInt(timestamp) << 80n) | randomness;
+  let encoded = "";
+  for (let index = 0; index < 26; index += 1) {
+    encoded = CROCKFORD[Number(value & 31n)] + encoded;
+    value >>= 5n;
+  }
+  return encoded;
+}
+
+function randomValue(bytes: Uint8Array): bigint {
+  if (bytes.length !== 10) throw new TypeError("ULID randomness is invalid");
+  let value = 0n;
+  for (const byte of bytes) value = (value << 8n) | BigInt(byte);
+  return value;
+}
+
+export function createAuthoredIdentity(
+  configDir: string,
+  dependencies: AuthoredIdentityDependencies = {},
+): AuthoredIdentity {
+  if (typeof configDir !== "string" || configDir.length === 0) {
+    throw new TypeError("authored identity directory is invalid");
+  }
+  const now = dependencies.now ?? Date.now;
+  const randomBytes = dependencies.randomBytes ?? nodeRandomBytes;
+  const deviceIdPath = join(configDir, "device-id");
+  let lastUlidTimestamp = -1;
+  let lastUlidRandomness = 0n;
+  let lastHlcPhysical = -1;
+  let lastHlcCounter = 0;
+
+  const currentTime = (): number => {
+    const value = Math.floor(now());
+    if (!Number.isSafeInteger(value) || value < 0 || value > MAX_TIMESTAMP) {
+      throw new TypeError("authored identity clock is invalid");
+    }
+    return value;
+  };
+
+  const nextUlid = (): string => {
+    const observed = currentTime();
+    let timestamp = observed;
+    let randomness: bigint;
+    if (observed > lastUlidTimestamp) {
+      randomness = randomValue(randomBytes(10));
+    } else {
+      timestamp = lastUlidTimestamp;
+      randomness = lastUlidRandomness + 1n;
+      if (randomness > RANDOM_MASK) {
+        if (timestamp === MAX_TIMESTAMP) throw new Error("ULID space is exhausted");
+        timestamp += 1;
+        randomness = 0n;
+      }
+    }
+    lastUlidTimestamp = timestamp;
+    lastUlidRandomness = randomness;
+    return encodeUlid(timestamp, randomness);
+  };
+
+  const loadOrCreateDeviceId = async (): Promise<string> => {
+    await mkdir(configDir, { recursive: true, mode: 0o700 });
+    try {
+      const existing = (await readFile(deviceIdPath, "utf8")).trim();
+      if (existing.length > 0) return existing;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    }
+    const generated = nextUlid();
+    await writeTempThenPublish(deviceIdPath, `${generated}\n`, rename);
+    return generated;
+  };
+
+  return {
+    deviceId() {
+      const previous = deviceIdQueues.get(deviceIdPath) ?? Promise.resolve("");
+      const current = previous.then(loadOrCreateDeviceId, loadOrCreateDeviceId);
+      deviceIdQueues.set(deviceIdPath, current);
+      void current
+        .finally(() => {
+          if (deviceIdQueues.get(deviceIdPath) === current) deviceIdQueues.delete(deviceIdPath);
+        })
+        .catch(() => {});
+      return current;
+    },
+    newUlid: nextUlid,
+    hlcStamp() {
+      const observed = currentTime();
+      if (observed > lastHlcPhysical) {
+        lastHlcPhysical = observed;
+        lastHlcCounter = 0;
+      } else {
+        lastHlcCounter += 1;
+        if (!Number.isSafeInteger(lastHlcCounter)) throw new Error("HLC counter is exhausted");
+      }
+      return { physicalMs: lastHlcPhysical, counter: lastHlcCounter };
+    },
+  };
+}

--- a/packages/kernel-node/tests/authored-identity.test.ts
+++ b/packages/kernel-node/tests/authored-identity.test.ts
@@ -1,0 +1,53 @@
+import { lstat, mkdtemp, readFile, realpath, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createAuthoredIdentity } from "../src/store/authored-identity.js";
+
+const roots: string[] = [];
+
+async function freshConfigDir(): Promise<string> {
+  const root = await mkdtemp(join(await realpath(tmpdir()), "authored-identity-"));
+  roots.push(root);
+  return join(root, "config");
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("authored identity", () => {
+  it("persists one stable private device id across factory instances", async () => {
+    const configDir = await freshConfigDir();
+    const first = createAuthoredIdentity(configDir);
+    const firstId = await first.deviceId();
+    const secondId = await createAuthoredIdentity(configDir).deviceId();
+    const path = join(configDir, "device-id");
+    expect(secondId).toBe(firstId);
+    expect(await readFile(path, "utf8")).toBe(`${firstId}\n`);
+    expect((await lstat(path)).mode & 0o777).toBe(0o600);
+  });
+
+  it("generates shaped monotonic ULIDs within one millisecond", () => {
+    const identity = createAuthoredIdentity("/synthetic/config", {
+      now: () => 1_721_260_800_000,
+      randomBytes: (size) => new Uint8Array(size),
+    });
+    const first = identity.newUlid();
+    const second = identity.newUlid();
+    expect(first).toMatch(/^[0-9A-HJKMNP-TV-Z]{26}$/);
+    expect(second).toMatch(/^[0-9A-HJKMNP-TV-Z]{26}$/);
+    expect(second > first).toBe(true);
+  });
+
+  it("guards HLC monotonicity while the clock stalls and regresses", () => {
+    const times = [100, 100, 99, 101];
+    const identity = createAuthoredIdentity("/synthetic/config", {
+      now: () => times.shift() ?? 101,
+    });
+    expect(identity.hlcStamp()).toEqual({ physicalMs: 100, counter: 0 });
+    expect(identity.hlcStamp()).toEqual({ physicalMs: 100, counter: 1 });
+    expect(identity.hlcStamp()).toEqual({ physicalMs: 100, counter: 2 });
+    expect(identity.hlcStamp()).toEqual({ physicalMs: 101, counter: 0 });
+  });
+});

--- a/packages/kernel-node/tests/repositories.test.ts
+++ b/packages/kernel-node/tests/repositories.test.ts
@@ -6,6 +6,7 @@ import {
   createAnchorRepository,
   createActivityRepository,
   createDedupConfirmationRepository,
+  createIntakeRepository,
   createRawFileRepository,
   createSourceRecordRepository,
   runMigrations,
@@ -50,22 +51,24 @@ function activityRows(rawSha256: string, localDateKey: number): ActivityRows {
       is_multisport: 0,
       dedup_cluster_id: rawSha256,
     },
-    sessions: [{
-      session_key: `session-${rawSha256}`,
-      workout_key: `workout-${rawSha256}`,
-      session_seq: 0,
-      sport: "cycling",
-      sub_sport: null,
-      start_utc: 1000,
-      tz_offset_s: null,
-      local_date_key: localDateKey,
-      elapsed_s: null,
-      timer_s: null,
-      moving_s: null,
-      distance_m: null,
-      is_transition: 0,
-      summary_json: null,
-    }],
+    sessions: [
+      {
+        session_key: `session-${rawSha256}`,
+        workout_key: `workout-${rawSha256}`,
+        session_seq: 0,
+        sport: "cycling",
+        sub_sport: null,
+        start_utc: 1000,
+        tz_offset_s: null,
+        local_date_key: localDateKey,
+        elapsed_s: null,
+        timer_s: null,
+        moving_s: null,
+        distance_m: null,
+        is_transition: 0,
+        summary_json: null,
+      },
+    ],
     laps: [],
     swimLengths: [],
     streams: [],
@@ -111,21 +114,56 @@ describe("repository ports over real node:sqlite", () => {
     it("applies confidence precedence for same valid_from (manual > platform > fit)", async () => {
       const repo = createAnchorRepository(store);
       await repo.insertIfAbsent(
-        anchorRow({ id: "fit", valid_from: 1000, value: 230, confidence: "fit", provenance: "sync", source: "fit" }),
+        anchorRow({
+          id: "fit",
+          valid_from: 1000,
+          value: 230,
+          confidence: "fit",
+          provenance: "sync",
+          source: "fit",
+        }),
       );
       const fit = await repo.readCurrent("cycling", "ftp", 1500);
       expect(fit?.confidence).toBe("fit");
       expect(fit?.value).toBe(230);
       await store.run(
         "INSERT INTO anchor_history (id, sport, anchor_type, value, unit, valid_from, source, confidence, note, provenance, device_id, hlc_physical_ms, hlc_counter) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)",
-        ["plat", "cycling", "ftp", 240, "W", 1000, "connector", "platform", null, "sync", null, null, null],
+        [
+          "plat",
+          "cycling",
+          "ftp",
+          240,
+          "W",
+          1000,
+          "connector",
+          "platform",
+          null,
+          "sync",
+          null,
+          null,
+          null,
+        ],
       );
       const platform = await repo.readCurrent("cycling", "ftp", 1500);
       expect(platform?.confidence).toBe("platform");
       expect(platform?.value).toBe(240);
       await store.run(
         "INSERT INTO anchor_history (id, sport, anchor_type, value, unit, valid_from, source, confidence, note, provenance, device_id, hlc_physical_ms, hlc_counter) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)",
-        ["man", "cycling", "ftp", 250, "W", 1000, "manual", "manual", null, "manual", null, null, null],
+        [
+          "man",
+          "cycling",
+          "ftp",
+          250,
+          "W",
+          1000,
+          "manual",
+          "manual",
+          null,
+          "manual",
+          null,
+          null,
+          null,
+        ],
       );
       const manual = await repo.readCurrent("cycling", "ftp", 1500);
       expect(manual?.confidence).toBe("manual");
@@ -148,11 +186,18 @@ describe("repository ports over real node:sqlite", () => {
     expect(await repo.upsert(row)).toBe(true);
     expect(await repo.upsert(row)).toBe(false);
     const changes: readonly [keyof RawFileRow, RawFileRow[keyof RawFileRow]][] = [
-      ["path", "/y.fit"], ["ext", "bin"], ["bytes", 999], ["file_id_serial", 2],
-      ["file_id_time_created_utc", 2000], ["manufacturer", "other"], ["product", "other"],
+      ["path", "/y.fit"],
+      ["ext", "bin"],
+      ["bytes", 999],
+      ["file_id_serial", 2],
+      ["file_id_time_created_utc", 2000],
+      ["manufacturer", "other"],
+      ["product", "other"],
     ];
-    for (const [key,value] of changes) {
-      await expect(repo.upsert({...row,[key]:value})).rejects.toBeInstanceOf(RawFileInvariantError);
+    for (const [key, value] of changes) {
+      await expect(repo.upsert({ ...row, [key]: value })).rejects.toBeInstanceOf(
+        RawFileInvariantError,
+      );
     }
     const count = await store.get("SELECT count(*) AS c FROM raw_file");
     expect(count?.c).toBe(1);
@@ -175,8 +220,13 @@ describe("repository ports over real node:sqlite", () => {
 
     await repo.replaceForRawFile("raw", rows, async () => {});
 
-    const remaining = await store.all("SELECT snapshot_key FROM metric_snapshot ORDER BY snapshot_key");
-    expect(remaining.map((row) => row.snapshot_key)).toEqual(["unrelated-date", "unrelated-session"]);
+    const remaining = await store.all(
+      "SELECT snapshot_key FROM metric_snapshot ORDER BY snapshot_key",
+    );
+    expect(remaining.map((row) => row.snapshot_key)).toEqual([
+      "unrelated-date",
+      "unrelated-session",
+    ]);
   });
 
   it("invalidates old and incoming date snapshots when an activity date changes", async () => {
@@ -197,8 +247,13 @@ describe("repository ports over real node:sqlite", () => {
 
     await repo.replaceForRawFile("raw", activityRows("raw", 19980102), async () => {});
 
-    const remaining = await store.all("SELECT snapshot_key FROM metric_snapshot ORDER BY snapshot_key");
-    expect(remaining.map((row) => row.snapshot_key)).toEqual(["unrelated-date", "unrelated-session"]);
+    const remaining = await store.all(
+      "SELECT snapshot_key FROM metric_snapshot ORDER BY snapshot_key",
+    );
+    expect(remaining.map((row) => row.snapshot_key)).toEqual([
+      "unrelated-date",
+      "unrelated-session",
+    ]);
   });
 
   it("[PR05-REPO-001] observes source inserts and rejects both conflict-key mismatches", async () => {
@@ -215,16 +270,28 @@ describe("repository ports over real node:sqlite", () => {
     };
     expect(await repo.upsert(row)).toBe(true);
     expect(await repo.upsert(row)).toBe(false);
-    await expect(repo.upsert({ ...row, id: "sr-2" })).rejects.toThrow("source record invariant mismatch");
-    await expect(repo.upsert({ ...row, source: "other", external_id: "other" })).rejects.toThrow("source record invariant mismatch");
+    await expect(repo.upsert({ ...row, id: "sr-2" })).rejects.toThrow(
+      "source record invariant mismatch",
+    );
+    await expect(repo.upsert({ ...row, source: "other", external_id: "other" })).rejects.toThrow(
+      "source record invariant mismatch",
+    );
     const count = await store.get("SELECT count(*) AS c FROM source_record");
     expect(count?.c).toBe(1);
   });
 
   it("[PR05-REPO-002] excludes mutable source attachments from immutable equality", async () => {
     const repo = createSourceRecordRepository(store);
-    const row: SourceRecordRow = { id: "sr-1", workout_key: null, session_key: null, source: "intervals-icu",
-      external_id: "ext-1", raw_sha256: null, quality_rank: 300, payload_json: "{}" };
+    const row: SourceRecordRow = {
+      id: "sr-1",
+      workout_key: null,
+      session_key: null,
+      source: "intervals-icu",
+      external_id: "ext-1",
+      raw_sha256: null,
+      quality_rank: 300,
+      payload_json: "{}",
+    };
     expect(await repo.upsert(row)).toBe(true);
     await store.run("UPDATE source_record SET workout_key='w',session_key='s' WHERE id='sr-1'");
     expect(await repo.upsert(row)).toBe(false);
@@ -232,26 +299,132 @@ describe("repository ports over real node:sqlite", () => {
   });
 
   it("[PR05-REPO-003] appends confirmations and reads effective tuple order", async () => {
-    const repo = createDedupConfirmationRepository(store), a = "a".repeat(64), b = "b".repeat(64);
-    const older = { id: "0".repeat(26), member_a: a, member_b: b, verdict: "merge" as const, device_id: "a", hlc_physical_ms: 1, hlc_counter: 0 };
-    const newer = { ...older, id: "1".repeat(26), verdict: "distinct" as const, device_id: "b", hlc_counter: 1 };
-    expect(await repo.insertIfAbsent(older)).toBe(true); expect(await repo.insertIfAbsent(older)).toBe(false);
+    const repo = createDedupConfirmationRepository(store),
+      a = "a".repeat(64),
+      b = "b".repeat(64);
+    const older = {
+      id: "0".repeat(26),
+      member_a: a,
+      member_b: b,
+      verdict: "merge" as const,
+      device_id: "a",
+      hlc_physical_ms: 1,
+      hlc_counter: 0,
+    };
+    const newer = {
+      ...older,
+      id: "1".repeat(26),
+      verdict: "distinct" as const,
+      device_id: "b",
+      hlc_counter: 1,
+    };
+    expect(await repo.insertIfAbsent(older)).toBe(true);
+    expect(await repo.insertIfAbsent(older)).toBe(false);
     expect(await repo.insertIfAbsent(newer)).toBe(true);
     expect((await repo.readAll()).map((row) => row.id)).toEqual([newer.id, older.id]);
   });
 
   it("[PR05-REPO-004] rejects Unicode tie breakers in repository and real DDL", async () => {
-    const repo = createDedupConfirmationRepository(store), a = "a".repeat(64), b = "b".repeat(64);
+    const repo = createDedupConfirmationRepository(store),
+      a = "a".repeat(64),
+      b = "b".repeat(64);
     for (const character of [String.fromCodePoint(0x10000), "\ue000"]) {
-      await expect(repo.insertIfAbsent({ id: `${character}${"0".repeat(25)}`, member_a: a, member_b: b,
-        verdict: "merge", device_id: "d", hlc_physical_ms: 1, hlc_counter: 0 })).rejects.toThrow();
-      await expect(repo.insertIfAbsent({ id: "2".repeat(26), member_a: a, member_b: b,
-        verdict: "merge", device_id: `d${character}`, hlc_physical_ms: 1, hlc_counter: 0 })).rejects.toThrow();
-      await expect(store.run("INSERT INTO dedup_confirmation VALUES(?,?,?,?,?,?,?)", [`${character}${"3".repeat(25)}`, a, b, "merge", "d", 1, 0])).rejects.toThrow();
-      await expect(store.run("INSERT INTO dedup_confirmation VALUES(?,?,?,?,?,?,?)", ["3".repeat(26), a, b, "merge", `d${character}`, 1, 0])).rejects.toThrow();
+      await expect(
+        repo.insertIfAbsent({
+          id: `${character}${"0".repeat(25)}`,
+          member_a: a,
+          member_b: b,
+          verdict: "merge",
+          device_id: "d",
+          hlc_physical_ms: 1,
+          hlc_counter: 0,
+        }),
+      ).rejects.toThrow();
+      await expect(
+        repo.insertIfAbsent({
+          id: "2".repeat(26),
+          member_a: a,
+          member_b: b,
+          verdict: "merge",
+          device_id: `d${character}`,
+          hlc_physical_ms: 1,
+          hlc_counter: 0,
+        }),
+      ).rejects.toThrow();
+      await expect(
+        store.run("INSERT INTO dedup_confirmation VALUES(?,?,?,?,?,?,?)", [
+          `${character}${"3".repeat(25)}`,
+          a,
+          b,
+          "merge",
+          "d",
+          1,
+          0,
+        ]),
+      ).rejects.toThrow();
+      await expect(
+        store.run("INSERT INTO dedup_confirmation VALUES(?,?,?,?,?,?,?)", [
+          "3".repeat(26),
+          a,
+          b,
+          "merge",
+          `d${character}`,
+          1,
+          0,
+        ]),
+      ).rejects.toThrow();
     }
-    await repo.insertIfAbsent({ id: "4".repeat(26), member_a: a, member_b: b, verdict: "merge", device_id: "a", hlc_physical_ms: 1, hlc_counter: 0 });
-    await repo.insertIfAbsent({ id: "5".repeat(26), member_a: a, member_b: b, verdict: "merge", device_id: "z", hlc_physical_ms: 1, hlc_counter: 0 });
+    await repo.insertIfAbsent({
+      id: "4".repeat(26),
+      member_a: a,
+      member_b: b,
+      verdict: "merge",
+      device_id: "a",
+      hlc_physical_ms: 1,
+      hlc_counter: 0,
+    });
+    await repo.insertIfAbsent({
+      id: "5".repeat(26),
+      member_a: a,
+      member_b: b,
+      verdict: "merge",
+      device_id: "z",
+      hlc_physical_ms: 1,
+      hlc_counter: 0,
+    });
     expect((await repo.readAll()).slice(0, 2).map((row) => row.device_id)).toEqual(["z", "a"]);
+  });
+
+  it("replaces the authored intake row and validates its identity and conditional fields", async () => {
+    const repo = createIntakeRepository(store);
+    const first = {
+      id: "0".repeat(26),
+      swim_skill_floor: null,
+      continuous_distance_capable: null,
+      open_water_comfort: null,
+      prior_bsi: false,
+      clinician_cleared: null,
+      injury_status: "none" as const,
+      device_id: "device-a",
+      hlc_physical_ms: 100,
+      hlc_counter: 0,
+    };
+    const second = {
+      ...first,
+      id: "1".repeat(26),
+      prior_bsi: true,
+      clinician_cleared: true,
+      injury_status: "returning" as const,
+      hlc_counter: 1,
+    };
+    await repo.replace(first);
+    expect(await repo.read()).toEqual(first);
+    await repo.replace(second);
+    expect(await repo.read()).toEqual(second);
+    expect(await store.all("SELECT id FROM intake_flags")).toHaveLength(1);
+    await expect(repo.replace({ ...second, id: "invalid" })).rejects.toThrow("intake id");
+    await expect(repo.replace({ ...second, clinician_cleared: null })).rejects.toThrow(
+      "clinician clearance",
+    );
   });
 });

--- a/packages/kernel/src/store/index.ts
+++ b/packages/kernel/src/store/index.ts
@@ -6,6 +6,7 @@ export * from "./anchor-repository.js";
 export * from "./source-repository.js";
 export * from "./repair-log-repository.js";
 export * from "./dedup-confirmation-repository.js";
+export * from "./intake-repository.js";
 export * from "./activity-repository.js";
 export * from "./derived-key.js";
 export * from "./sync-source.js";

--- a/packages/kernel/src/store/intake-repository.ts
+++ b/packages/kernel/src/store/intake-repository.ts
@@ -1,0 +1,101 @@
+import type { IntakeFlagsRow, IntakeRepository, Row, SqlStore } from "./ports.js";
+import type { MigratorStore } from "./migrator.js";
+
+const ULID = /^[0-9A-HJKMNP-TV-Z]{26}$/;
+const DEVICE_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+
+function validate(row: IntakeFlagsRow): void {
+  if (!ULID.test(row.id)) throw new TypeError("intake id is invalid");
+  if (
+    row.swim_skill_floor !== null ||
+    row.continuous_distance_capable !== null ||
+    row.open_water_comfort !== null
+  ) {
+    throw new TypeError("intake multisport flags are invalid");
+  }
+  if (typeof row.prior_bsi !== "boolean") throw new TypeError("intake prior BSI is invalid");
+  if (
+    row.injury_status !== "none" &&
+    row.injury_status !== "managing" &&
+    row.injury_status !== "returning"
+  ) {
+    throw new TypeError("intake injury status is invalid");
+  }
+  const needsClearance = row.prior_bsi || row.injury_status !== "none";
+  if (
+    (needsClearance && typeof row.clinician_cleared !== "boolean") ||
+    (!needsClearance && row.clinician_cleared !== null)
+  ) {
+    throw new TypeError("intake clinician clearance is invalid");
+  }
+  if (!DEVICE_ID.test(row.device_id)) throw new TypeError("intake device id is invalid");
+  if (
+    !Number.isSafeInteger(row.hlc_physical_ms) ||
+    row.hlc_physical_ms < 0 ||
+    !Number.isSafeInteger(row.hlc_counter) ||
+    row.hlc_counter < 0
+  ) {
+    throw new TypeError("intake HLC is invalid");
+  }
+}
+
+function booleanValue(value: unknown, nullable: false): boolean;
+function booleanValue(value: unknown, nullable: true): boolean | null;
+function booleanValue(value: unknown, nullable: boolean): boolean | null {
+  if (nullable && value === null) return null;
+  if (value === 0) return false;
+  if (value === 1) return true;
+  throw new TypeError("intake boolean is invalid");
+}
+
+function mapped(row: Row): IntakeFlagsRow {
+  const value: IntakeFlagsRow = {
+    id: String(row.id),
+    swim_skill_floor: row.swim_skill_floor as null,
+    continuous_distance_capable: row.continuous_distance_capable as null,
+    open_water_comfort: row.open_water_comfort as null,
+    prior_bsi: booleanValue(row.prior_bsi, false),
+    clinician_cleared: booleanValue(row.clinician_cleared, true),
+    injury_status: row.injury_status as IntakeFlagsRow["injury_status"],
+    device_id: String(row.device_id),
+    hlc_physical_ms: Number(row.hlc_physical_ms),
+    hlc_counter: Number(row.hlc_counter),
+  };
+  validate(value);
+  return value;
+}
+
+export function createIntakeRepository(
+  store: SqlStore & Pick<MigratorStore, "transaction">,
+): IntakeRepository {
+  return {
+    async replace(row) {
+      validate(row);
+      await store.transaction(async () => {
+        await store.run("DELETE FROM intake_flags");
+        await store.run(
+          "INSERT INTO intake_flags (id,swim_skill_floor,continuous_distance_capable,open_water_comfort,prior_bsi,clinician_cleared,injury_status,device_id,hlc_physical_ms,hlc_counter) VALUES (?,?,?,?,?,?,?,?,?,?)",
+          [
+            row.id,
+            null,
+            null,
+            null,
+            row.prior_bsi ? 1 : 0,
+            row.clinician_cleared === null ? null : row.clinician_cleared ? 1 : 0,
+            row.injury_status,
+            row.device_id,
+            row.hlc_physical_ms,
+            row.hlc_counter,
+          ],
+        );
+      });
+    },
+    async read() {
+      const rows = await store.all(
+        "SELECT id, swim_skill_floor, continuous_distance_capable, open_water_comfort, prior_bsi, clinician_cleared, injury_status, device_id, hlc_physical_ms, hlc_counter FROM intake_flags",
+      );
+      if (rows.length > 1) throw new Error("intake single-row invariant mismatch");
+      return rows[0] === undefined ? undefined : mapped(rows[0]);
+    },
+  };
+}

--- a/packages/kernel/src/store/ports.ts
+++ b/packages/kernel/src/store/ports.ts
@@ -64,7 +64,11 @@ export interface AnchorRepository {
   /** Insert iff no row exists for (sport, anchor_type, valid_from). Returns true if inserted. */
   insertIfAbsent(row: AnchorHistoryRow): Promise<boolean>;
   /** Effective-dated current row: max valid_from ≤ asOfEpochS, tie-broken by confidence precedence. */
-  readCurrent(sport: string, anchorType: string, asOfEpochS: number): Promise<AnchorHistoryRow | undefined>;
+  readCurrent(
+    sport: string,
+    anchorType: string,
+    asOfEpochS: number,
+  ): Promise<AnchorHistoryRow | undefined>;
 }
 
 export type RawFileColumn =
@@ -148,11 +152,27 @@ export interface ZoneSetHistoryRow {
 }
 
 export type ActivityRevisionResult =
-  | { readonly kind: "inserted-current"; readonly revisionId: string; readonly selectorChanged: true }
+  | {
+      readonly kind: "inserted-current";
+      readonly revisionId: string;
+      readonly selectorChanged: true;
+    }
   | { readonly kind: "exact-current"; readonly revisionId: string; readonly selectorChanged: false }
-  | { readonly kind: "reselected-current"; readonly revisionId: string; readonly selectorChanged: true }
-  | { readonly kind: "appended-current"; readonly revisionId: string; readonly selectorChanged: true }
-  | { readonly kind: "hydrated-current"; readonly revisionId: string; readonly selectorChanged: true };
+  | {
+      readonly kind: "reselected-current";
+      readonly revisionId: string;
+      readonly selectorChanged: true;
+    }
+  | {
+      readonly kind: "appended-current";
+      readonly revisionId: string;
+      readonly selectorChanged: true;
+    }
+  | {
+      readonly kind: "hydrated-current";
+      readonly revisionId: string;
+      readonly selectorChanged: true;
+    };
 
 export interface ActivityRevisionDraft {
   readonly sourceRow: SourceRecordRow;
@@ -160,10 +180,14 @@ export interface ActivityRevisionDraft {
 }
 
 export interface IntervalsSourceRepository {
-  recordArtifact(draft: SourceArtifactDraft): Promise<{ readonly artifactKey: string; readonly inserted: boolean }>;
+  recordArtifact(
+    draft: SourceArtifactDraft,
+  ): Promise<{ readonly artifactKey: string; readonly inserted: boolean }>;
   recordGenericLanding(draft: GenericLandingDraft): Promise<boolean>;
   applyActivityRevision(draft: ActivityRevisionDraft): Promise<ActivityRevisionResult>;
-  upsertWellness(row: WellnessLandingRow): Promise<"inserted" | "updated" | "unchanged" | "manual-wins">;
+  upsertWellness(
+    row: WellnessLandingRow,
+  ): Promise<"inserted" | "updated" | "unchanged" | "manual-wins">;
   insertSyncedAnchor(row: AnchorHistoryRow): Promise<boolean>;
   insertSyncedZone(row: ZoneSetHistoryRow): Promise<boolean>;
   readCurrentCaptureEvidence(
@@ -182,7 +206,10 @@ export interface IntervalsSourceRepository {
     readonly artifactKey: string;
     readonly archiveAddress: string;
     readonly archiveRelPath: string;
-    readonly currentRevision: { readonly sourceRecordId: string; readonly revisionId: string } | null;
+    readonly currentRevision: {
+      readonly sourceRecordId: string;
+      readonly revisionId: string;
+    } | null;
   }): Promise<void>;
 }
 
@@ -199,6 +226,24 @@ export interface DedupConfirmationRow {
 export interface DedupConfirmationRepository {
   insertIfAbsent(row: DedupConfirmationRow): Promise<boolean>;
   readAll(): Promise<readonly DedupConfirmationRow[]>;
+}
+
+export interface IntakeFlagsRow {
+  readonly id: string;
+  readonly swim_skill_floor: null;
+  readonly continuous_distance_capable: null;
+  readonly open_water_comfort: null;
+  readonly prior_bsi: boolean;
+  readonly clinician_cleared: boolean | null;
+  readonly injury_status: "none" | "managing" | "returning";
+  readonly device_id: string;
+  readonly hlc_physical_ms: number;
+  readonly hlc_counter: number;
+}
+
+export interface IntakeRepository {
+  replace(row: IntakeFlagsRow): Promise<void>;
+  read(): Promise<IntakeFlagsRow | undefined>;
 }
 
 export interface RepairLogInsert {


### PR DESCRIPTION
## Summary

- add the strict `saveIntake` RPC: the daemon writer persists the cycling intake answers as the single authored `intake_flags` row, generating row identity, device id, and clock stamps itself through a new kernel-owned authored-identity port (stable per-home device id, monotonic ULIDs, guarded in-process clock stamps)
- add the strict `configureRuntime` RPC: an in-memory runtime overlay for LLM provider/model/key and intervals.icu credentials, identical for both daemon owner modes; the composition swaps the active engine behind an admission barrier (in-flight turns drain, the writer lock is never released) and the next store window picks up newly configured intervals credentials
- results echo no secret material; plaintext exists only in daemon memory
- bump the authenticated wire protocol from 2 to 3

## Test plan

- contract round-trips, registry closure, and version-mismatch suites updated to the bumped protocol
- daemon dispatch, single-row replace idempotence, unknown-key refusal, conditional clearance validation
- runtime application: llm-only, intervals-only, both, supersession, no-echo results, capture lane enabled on the next window after an intervals key lands
- authored-identity port: device-id stability, ULID shape and same-millisecond monotonicity, clock-regression counter behavior
- full root `pnpm check` + `pnpm test`: 4390 passed, 0 failed