### PR TITLE
feat(desktop): add secure onboarding wizard

### DIFF
--- a/.changeset/desktop-onboarding.md
+++ b/.changeset/desktop-onboarding.md
@@ -1,0 +1,5 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Added secure desktop onboarding for model keys, intervals.icu, ride imports, and cycling intake.

--- a/apps/desktop-renderer/src/global.d.ts
+++ b/apps/desktop-renderer/src/global.d.ts
@@ -3,8 +3,54 @@ interface EnduragentAuth {
     readonly url: `ws://127.0.0.1:${number}/rpc`;
     readonly token: string;
   }>;
+  credentialStatuses(): Promise<readonly CredentialSlotStatus[]>;
+  writeCredential(input: {
+    readonly slot: DesktopCredentialSlot;
+    readonly value: string;
+  }): Promise<CredentialWriteResult>;
+  chooseImportFiles(): Promise<readonly string[]>;
+  onDroppedImportFiles(listener: (paths: readonly string[]) => void): () => void;
 }
+
+type DesktopCredentialSlot =
+  | "anthropic"
+  | "openrouter"
+  | "openai"
+  | "google"
+  | "deepseek"
+  | "qwen"
+  | "minimax"
+  | "kimi"
+  | "zai"
+  | "intervals-icu";
+
+type CredentialState = "missing" | "configured" | "re-prompt";
+
+interface CredentialSlotStatus {
+  readonly slot: DesktopCredentialSlot;
+  readonly state: CredentialState;
+  readonly runtimeReady: boolean;
+}
+
+type CredentialWriteResult =
+  | {
+      readonly slot: DesktopCredentialSlot;
+      readonly status: "configured";
+      readonly runtimeReady: true;
+    }
+  | {
+      readonly slot: DesktopCredentialSlot;
+      readonly status: "refused";
+      readonly reason:
+        | "invalid-input"
+        | "encryption-unavailable"
+        | "unsafe-backend"
+        | "storage-failed"
+        | "runtime-unavailable";
+    };
 
 interface Window {
   readonly enduragentAuth: EnduragentAuth;
 }
+
+declare module "*.css" {}

--- a/apps/desktop-renderer/src/index.ts
+++ b/apps/desktop-renderer/src/index.ts
@@ -6,6 +6,9 @@ import {
   connectCoachClient,
 } from "@enduragent/coach-client";
 import type { TurnEvent } from "@enduragent/coach-contract";
+import { createOnboardingBridge } from "./onboarding/bridge.js";
+import { mountOnboarding } from "./onboarding/mount.js";
+import "./onboarding/onboarding.css";
 import { createChatTurn, reduceChatTurn, type ChatTurnState } from "./turn-state.js";
 
 const DESKTOP_CHAT_ID = "desktop" as const;
@@ -16,6 +19,21 @@ const submit = composer.querySelector<HTMLButtonElement>('button[type="submit"]'
 const drawer = document.querySelector<HTMLElement>(".drawer")!;
 const drawerToggle = document.querySelector<HTMLButtonElement>(".drawer-toggle")!;
 const drawerClose = document.querySelector<HTMLButtonElement>(".drawer-close")!;
+const topbar = document.querySelector<HTMLElement>(".topbar")!;
+
+const setup = document.createElement("button");
+setup.type = "button";
+setup.className = "setup-button";
+setup.textContent = "Setup";
+topbar.insertBefore(setup, topbar.lastElementChild);
+const onboarding = mountOnboarding({
+  document,
+  bridge: createOnboardingBridge(),
+  opener: setup,
+  onComplete: () => message.focus(),
+});
+setup.addEventListener("click", () => void onboarding.open());
+void onboarding.open();
 
 let connectionMaterialPromise: ReturnType<EnduragentAuth["getDaemonConnection"]> | undefined;
 let clientPromise: Promise<CoachClient> | undefined;

--- a/apps/desktop-renderer/src/onboarding/bridge.ts
+++ b/apps/desktop-renderer/src/onboarding/bridge.ts
@@ -1,0 +1,147 @@
+import type { CoachClient } from "@enduragent/coach-client";
+import { CoachClientDisconnectedError, connectCoachClient } from "@enduragent/coach-client";
+import {
+  ImportFilesRpcParamsSchema,
+  SaveIntakeRpcParamsSchema,
+  type CoachOperationProgressNotificationEnvelope,
+  type ImportFilesRpcResult,
+  type SaveIntakeRpcParams,
+} from "@enduragent/coach-contract";
+import { SUPPORTED_IMPORT_EXTENSIONS, type DesktopCredentialSlot } from "./constants.js";
+import type { CredentialSlotStatus } from "./machine.js";
+
+export type CredentialWriteResult =
+  | {
+      readonly slot: DesktopCredentialSlot;
+      readonly status: "configured";
+      readonly runtimeReady: true;
+    }
+  | {
+      readonly slot: DesktopCredentialSlot;
+      readonly status: "refused";
+      readonly reason:
+        | "invalid-input"
+        | "encryption-unavailable"
+        | "unsafe-backend"
+        | "storage-failed"
+        | "runtime-unavailable";
+    };
+
+export interface OnboardingBridge {
+  credentialStatuses(): Promise<readonly CredentialSlotStatus[]>;
+  writeCredential(input: {
+    readonly slot: DesktopCredentialSlot;
+    readonly value: string;
+  }): Promise<CredentialWriteResult>;
+  chooseImportFiles(): Promise<readonly string[]>;
+  onDroppedImportFiles(listener: (paths: readonly string[]) => void): () => void;
+  importFiles(
+    paths: readonly string[],
+    onProgress: (event: CoachOperationProgressNotificationEnvelope) => void,
+  ): Promise<ImportFilesRpcResult>;
+  saveIntake(input: SaveIntakeRpcParams): Promise<void>;
+}
+
+export interface DesktopOnboardingAuth {
+  getDaemonConnection(): Promise<{
+    readonly url: `ws://127.0.0.1:${number}/rpc`;
+    readonly token: string;
+  }>;
+  credentialStatuses(): Promise<readonly CredentialSlotStatus[]>;
+  writeCredential(input: {
+    readonly slot: DesktopCredentialSlot;
+    readonly value: string;
+  }): Promise<CredentialWriteResult>;
+  chooseImportFiles(): Promise<readonly string[]>;
+  onDroppedImportFiles(listener: (paths: readonly string[]) => void): () => void;
+}
+
+function extension(path: string): string {
+  const slash = path.lastIndexOf("/");
+  const dot = path.lastIndexOf(".");
+  return dot > slash ? path.slice(dot).toLowerCase() : "";
+}
+
+export function validateImportPaths(paths: readonly string[]): readonly string[] {
+  const normalized = [...paths];
+  if (
+    normalized.some(
+      (path) =>
+        typeof path !== "string" ||
+        !path.startsWith("/") ||
+        path.includes("\0") ||
+        !(SUPPORTED_IMPORT_EXTENSIONS as readonly string[]).includes(extension(path)),
+    )
+  ) {
+    throw new TypeError();
+  }
+  return ImportFilesRpcParamsSchema.parse({ paths: normalized }).paths;
+}
+
+export function createOnboardingBridge(
+  auth: DesktopOnboardingAuth = (
+    window as unknown as Window & { readonly enduragentAuth: DesktopOnboardingAuth }
+  ).enduragentAuth,
+  connect: typeof connectCoachClient = connectCoachClient,
+): OnboardingBridge {
+  let clientPromise: Promise<CoachClient> | undefined;
+  const client = (): Promise<CoachClient> => {
+    if (clientPromise !== undefined) return clientPromise;
+    const pending = auth
+      .getDaemonConnection()
+      .then((connection) => {
+        const url = new URL(connection.url);
+        if (
+          url.protocol !== "ws:" ||
+          url.hostname !== "127.0.0.1" ||
+          url.port === "" ||
+          !/^\d+$/u.test(url.port) ||
+          url.pathname !== "/rpc" ||
+          url.username !== "" ||
+          url.password !== "" ||
+          url.search !== "" ||
+          url.hash !== "" ||
+          !/^[A-Za-z0-9_-]{43}$/u.test(connection.token)
+        ) {
+          throw new TypeError();
+        }
+        return connect(connection);
+      })
+      .catch((error: unknown) => {
+        if (clientPromise === pending) clientPromise = undefined;
+        throw error;
+      });
+    clientPromise = pending;
+    return pending;
+  };
+  return {
+    credentialStatuses: () => auth.credentialStatuses() as Promise<readonly CredentialSlotStatus[]>,
+    writeCredential: (input) => auth.writeCredential(input) as Promise<CredentialWriteResult>,
+    chooseImportFiles: () => auth.chooseImportFiles(),
+    onDroppedImportFiles: (listener) => auth.onDroppedImportFiles(listener),
+    async importFiles(paths, onProgress) {
+      const parsedPaths = validateImportPaths(paths);
+      const connected = await client();
+      try {
+        return await connected.call(
+          "importFiles",
+          { paths: [...parsedPaths] },
+          { onNotificationEnvelope: onProgress },
+        );
+      } catch (error) {
+        if (error instanceof CoachClientDisconnectedError) clientPromise = undefined;
+        throw error;
+      }
+    },
+    async saveIntake(input) {
+      const connected = await client();
+      try {
+        const result = await connected.call("saveIntake", SaveIntakeRpcParamsSchema.parse(input));
+        if (!result.saved) throw new TypeError();
+      } catch (error) {
+        if (error instanceof CoachClientDisconnectedError) clientPromise = undefined;
+        throw error;
+      }
+    },
+  };
+}

--- a/apps/desktop-renderer/src/onboarding/constants.ts
+++ b/apps/desktop-renderer/src/onboarding/constants.ts
@@ -1,0 +1,44 @@
+export const ONBOARDING_STEP_IDS = [
+  "coach-keys",
+  "training-data",
+  "safety-intake",
+  "ready",
+] as const;
+
+export type OnboardingStepId = (typeof ONBOARDING_STEP_IDS)[number];
+
+export const PRIMARY_MODEL_CREDENTIAL_SLOTS = [
+  { id: "anthropic", label: "Anthropic API key", hint: "Recommended" },
+  { id: "openrouter", label: "OpenRouter API key", hint: "Everything else" },
+] as const;
+
+export const ADVANCED_MODEL_CREDENTIAL_SLOTS = [
+  { id: "openai", label: "OpenAI API key" },
+  { id: "google", label: "Google API key" },
+  { id: "deepseek", label: "DeepSeek API key" },
+  { id: "qwen", label: "Qwen API key" },
+  { id: "minimax", label: "MiniMax API key" },
+  { id: "kimi", label: "Kimi API key" },
+  { id: "zai", label: "Z.AI API key" },
+] as const;
+
+export const DESKTOP_CREDENTIAL_SLOTS = [
+  "anthropic",
+  "openrouter",
+  "openai",
+  "google",
+  "deepseek",
+  "qwen",
+  "minimax",
+  "kimi",
+  "zai",
+  "intervals-icu",
+] as const;
+
+export type DesktopCredentialSlot = (typeof DESKTOP_CREDENTIAL_SLOTS)[number];
+export type ModelCredentialSlot = Exclude<DesktopCredentialSlot, "intervals-icu">;
+
+export const SUPPORTED_IMPORT_EXTENSIONS = [".fit", ".tcx", ".gpx"] as const;
+
+export const INTERVALS_GUIDANCE =
+  "Connect your device platform to intervals.icu directly, not via Strava." as const;

--- a/apps/desktop-renderer/src/onboarding/machine.ts
+++ b/apps/desktop-renderer/src/onboarding/machine.ts
@@ -1,0 +1,191 @@
+import {
+  SaveIntakeRpcParamsSchema,
+  type CoachOperationProgressNotificationEnvelope,
+  type SaveIntakeRpcParams,
+} from "@enduragent/coach-contract";
+import {
+  DESKTOP_CREDENTIAL_SLOTS,
+  ONBOARDING_STEP_IDS,
+  type DesktopCredentialSlot,
+  type OnboardingStepId,
+} from "./constants.js";
+
+export type CredentialState = "missing" | "configured" | "re-prompt";
+
+export interface CredentialSlotStatus {
+  readonly slot: DesktopCredentialSlot;
+  readonly state: CredentialState;
+  readonly runtimeReady: boolean;
+}
+
+export interface DesktopIntakeDraft {
+  readonly priorBsi: boolean | null;
+  readonly injuryStatus: "none" | "managing" | "returning" | null;
+  readonly clinicianCleared: boolean | null;
+}
+
+export type OnboardingErrorCode =
+  | "credential-required"
+  | "credential-save-failed"
+  | "training-data-required"
+  | "import-failed"
+  | "intake-incomplete"
+  | "intake-save-failed";
+
+export interface OnboardingState {
+  readonly step: OnboardingStepId;
+  readonly credentialStatus: Readonly<Record<DesktopCredentialSlot, CredentialState>>;
+  readonly acceptedImportPaths: readonly string[];
+  readonly importProgress: CoachOperationProgressNotificationEnvelope | null;
+  readonly intake: DesktopIntakeDraft;
+  readonly busy: boolean;
+  readonly fixedError: OnboardingErrorCode | null;
+}
+
+export interface OnboardingCompletion {
+  readonly providerConfigured: true;
+  readonly trainingDataConfigured: true;
+  readonly intakeSaved: true;
+}
+
+function statusRecord<T>(initial: T): Record<DesktopCredentialSlot, T> {
+  return Object.fromEntries(DESKTOP_CREDENTIAL_SLOTS.map((slot) => [slot, initial])) as Record<
+    DesktopCredentialSlot,
+    T
+  >;
+}
+
+export function createOnboardingState(
+  statuses: readonly CredentialSlotStatus[] = [],
+): OnboardingState {
+  const credentialStatus = statusRecord<CredentialState>("missing");
+  for (const status of statuses) {
+    credentialStatus[status.slot] = status.state;
+  }
+  return {
+    step: "coach-keys",
+    credentialStatus,
+    acceptedImportPaths: [],
+    importProgress: null,
+    intake: { priorBsi: null, injuryStatus: null, clinicianCleared: null },
+    busy: false,
+    fixedError: null,
+  };
+}
+
+export function withCredentialStatuses(
+  state: OnboardingState,
+  statuses: readonly CredentialSlotStatus[],
+): OnboardingState {
+  const credentialStatus = { ...state.credentialStatus };
+  for (const status of statuses) {
+    credentialStatus[status.slot] = status.state;
+  }
+  return { ...state, credentialStatus };
+}
+
+export function hasConfiguredModel(state: OnboardingState): boolean {
+  return DESKTOP_CREDENTIAL_SLOTS.some(
+    (slot) => slot !== "intervals-icu" && state.credentialStatus[slot] === "configured",
+  );
+}
+
+export function hasTrainingData(state: OnboardingState): boolean {
+  return (
+    state.credentialStatus["intervals-icu"] === "configured" || state.acceptedImportPaths.length > 0
+  );
+}
+
+export function canImportFiles(state: OnboardingState, modalOpen: boolean): boolean {
+  return modalOpen && !state.busy && state.step === "training-data";
+}
+
+export function toDesktopIntakeFlags(draft: DesktopIntakeDraft): SaveIntakeRpcParams {
+  if (draft.priorBsi === null || draft.injuryStatus === null) throw new TypeError();
+  const needsClearance = draft.priorBsi || draft.injuryStatus !== "none";
+  if (needsClearance && draft.clinicianCleared === null) throw new TypeError();
+  return SaveIntakeRpcParamsSchema.parse({
+    swim_skill_floor: null,
+    continuous_distance_capable: null,
+    open_water_comfort: null,
+    prior_bsi: draft.priorBsi,
+    clinician_cleared: needsClearance ? draft.clinicianCleared : null,
+    injury_status: draft.injuryStatus,
+  });
+}
+
+export function nextStep(state: OnboardingState): OnboardingState {
+  const index = ONBOARDING_STEP_IDS.indexOf(state.step);
+  if (index >= ONBOARDING_STEP_IDS.length - 1) return state;
+  if (state.step === "coach-keys" && !hasConfiguredModel(state)) {
+    return { ...state, fixedError: "credential-required" };
+  }
+  if (state.step === "training-data" && !hasTrainingData(state)) {
+    return { ...state, fixedError: "training-data-required" };
+  }
+  if (state.step === "safety-intake") {
+    try {
+      toDesktopIntakeFlags(state.intake);
+    } catch {
+      return { ...state, fixedError: "intake-incomplete" };
+    }
+  }
+  return { ...state, step: ONBOARDING_STEP_IDS[index + 1]!, fixedError: null };
+}
+
+export function previousStep(state: OnboardingState): OnboardingState {
+  const index = ONBOARDING_STEP_IDS.indexOf(state.step);
+  if (index <= 0) return state;
+  return { ...state, step: ONBOARDING_STEP_IDS[index - 1]!, fixedError: null };
+}
+
+export function withIntake(
+  state: OnboardingState,
+  update: Partial<DesktopIntakeDraft>,
+): OnboardingState {
+  const intake = { ...state.intake, ...update };
+  const needsClearance =
+    intake.priorBsi === true || (intake.injuryStatus !== null && intake.injuryStatus !== "none");
+  return {
+    ...state,
+    intake: needsClearance ? intake : { ...intake, clinicianCleared: null },
+    fixedError: null,
+  };
+}
+
+export function withBusy(state: OnboardingState, busy: boolean): OnboardingState {
+  return { ...state, busy, fixedError: busy ? null : state.fixedError };
+}
+
+export function withError(
+  state: OnboardingState,
+  fixedError: OnboardingErrorCode,
+): OnboardingState {
+  return { ...state, busy: false, fixedError };
+}
+
+export function withImportProgress(
+  state: OnboardingState,
+  importProgress: CoachOperationProgressNotificationEnvelope,
+): OnboardingState {
+  return { ...state, importProgress };
+}
+
+export function withSuccessfulImport(
+  state: OnboardingState,
+  paths: readonly string[],
+): OnboardingState {
+  return {
+    ...state,
+    acceptedImportPaths: [...paths],
+    importProgress: null,
+    busy: false,
+    fixedError: null,
+  };
+}
+
+export const ONBOARDING_COMPLETION: OnboardingCompletion = {
+  providerConfigured: true,
+  trainingDataConfigured: true,
+  intakeSaved: true,
+};

--- a/apps/desktop-renderer/src/onboarding/mount.ts
+++ b/apps/desktop-renderer/src/onboarding/mount.ts
@@ -1,0 +1,687 @@
+import {
+  ADVANCED_MODEL_CREDENTIAL_SLOTS,
+  INTERVALS_GUIDANCE,
+  ONBOARDING_STEP_IDS,
+  PRIMARY_MODEL_CREDENTIAL_SLOTS,
+  type DesktopCredentialSlot,
+  type ModelCredentialSlot,
+} from "./constants.js";
+import type { OnboardingBridge } from "./bridge.js";
+import {
+  ONBOARDING_COMPLETION,
+  canImportFiles,
+  createOnboardingState,
+  hasConfiguredModel,
+  hasTrainingData,
+  nextStep,
+  previousStep,
+  toDesktopIntakeFlags,
+  withBusy,
+  withCredentialStatuses,
+  withError,
+  withImportProgress,
+  withIntake,
+  withSuccessfulImport,
+  type CredentialSlotStatus,
+  type OnboardingCompletion,
+  type OnboardingErrorCode,
+  type OnboardingState,
+} from "./machine.js";
+
+export interface OnboardingController {
+  open(): Promise<void>;
+  close(): void;
+  dispose(): void;
+  state(): OnboardingState;
+}
+
+interface MountOnboardingOptions {
+  readonly document: Document;
+  readonly bridge: OnboardingBridge;
+  readonly opener: HTMLElement;
+  readonly onComplete: (completion: OnboardingCompletion) => void;
+}
+
+export interface TransientPasswordInput {
+  value: string;
+  readonly dataset: { readonly slot?: string };
+}
+
+export async function handoffCredential(
+  input: TransientPasswordInput,
+  write: (value: {
+    readonly slot: DesktopCredentialSlot;
+    readonly value: string;
+  }) => Promise<unknown>,
+): Promise<boolean> {
+  let secret: string | undefined;
+  try {
+    secret = input.value;
+    if (secret.trim().length === 0) return false;
+    await write({ slot: input.dataset.slot as DesktopCredentialSlot, value: secret });
+    return true;
+  } finally {
+    input.value = "";
+    secret = undefined;
+  }
+}
+
+const ERROR_COPY: Readonly<Record<OnboardingErrorCode, string>> = {
+  "credential-required": "Add at least one model key to continue.",
+  "credential-save-failed": "That key could not be saved. Try entering it again.",
+  "training-data-required": "Connect intervals.icu or import at least one ride file.",
+  "import-failed": "Those ride files could not be imported. Try another selection.",
+  "intake-incomplete": "Answer the required safety questions to continue.",
+  "intake-save-failed": "Your answers could not be saved. Please try again.",
+};
+
+function make<K extends keyof HTMLElementTagNameMap>(
+  document: Document,
+  tag: K,
+  className?: string,
+  text?: string,
+): HTMLElementTagNameMap[K] {
+  const node = document.createElement(tag);
+  if (className !== undefined) node.className = className;
+  if (text !== undefined) node.textContent = text;
+  return node;
+}
+
+function focusableElements(root: HTMLElement): readonly HTMLElement[] {
+  return Array.from(
+    root.querySelectorAll<HTMLElement>(
+      'button:not([disabled]), input:not([disabled]), summary, [tabindex]:not([tabindex="-1"])',
+    ),
+  ).filter((element) => {
+    if (element.hasAttribute("hidden")) return false;
+    const closedDetails = element.closest("details:not([open])");
+    return closedDetails === null || element.tagName === "SUMMARY";
+  });
+}
+
+function passwordControl(
+  document: Document,
+  slot: ModelCredentialSlot | "intervals-icu",
+  labelText: string,
+  status: CredentialSlotStatus,
+): HTMLElement {
+  const field = make(document, "div", "credential-field");
+  const label = make(document, "label", "credential-label");
+  const id = `credential-${slot}`;
+  label.htmlFor = id;
+  label.append(document.createTextNode(labelText));
+  const badge = make(
+    document,
+    "span",
+    `credential-state ${status.state}`,
+    status.state === "configured"
+      ? status.runtimeReady
+        ? "Configured"
+        : "Saved · Retry"
+      : status.state === "re-prompt"
+        ? "Enter again"
+        : "Not configured",
+  );
+  label.append(badge);
+  const input = make(document, "input");
+  input.id = id;
+  input.type = "password";
+  input.autocomplete = "off";
+  input.dataset.slot = slot;
+  input.setAttribute("aria-describedby", "onboarding-error");
+  field.append(label, input);
+  return field;
+}
+
+export function mountOnboarding(options: MountOnboardingOptions): OnboardingController {
+  let state = createOnboardingState();
+  let credentialStatuses: readonly CredentialSlotStatus[] = [];
+  let scrim: HTMLElement | undefined;
+  let completed = false;
+  let disposed = false;
+  let opening = false;
+  let visit = 0;
+  const status = (slot: DesktopCredentialSlot): CredentialSlotStatus =>
+    credentialStatuses.find((entry) => entry.slot === slot) ?? {
+      slot,
+      state: state.credentialStatus[slot],
+      runtimeReady: false,
+    };
+
+  const clearPasswordInputs = (): void => {
+    for (const input of scrim?.querySelectorAll<HTMLInputElement>('input[type="password"]') ?? []) {
+      input.value = "";
+    }
+  };
+
+  const focusCurrentTitle = (): void => {
+    scrim?.querySelector<HTMLElement>("#onboarding-title")?.focus();
+  };
+
+  const close = (): void => {
+    visit += 1;
+    clearPasswordInputs();
+    scrim?.remove();
+    scrim = undefined;
+    options.opener.focus();
+  };
+
+  const refreshStatuses = async (expectedVisit: number): Promise<void> => {
+    const statuses = await options.bridge.credentialStatuses();
+    if (visit !== expectedVisit || scrim === undefined) return;
+    credentialStatuses = statuses;
+    state = withCredentialStatuses(state, statuses);
+  };
+
+  const savePasswordControls = async (
+    root: HTMLElement,
+    expectedVisit: number,
+  ): Promise<boolean> => {
+    const controls = Array.from(
+      root.querySelectorAll<HTMLInputElement>('input[type="password"][data-slot]'),
+    );
+    let attempted = false;
+    let failed = false;
+    for (const input of controls) {
+      if (visit !== expectedVisit || scrim === undefined) return false;
+      try {
+        if (input.value.trim().length === 0) continue;
+        attempted = true;
+        let configured = false;
+        await handoffCredential(input, async (value) => {
+          const result = await options.bridge.writeCredential(value);
+          configured = result.status === "configured";
+        });
+        if (!configured) failed = true;
+      } catch {
+        failed = true;
+      } finally {
+        input.value = "";
+      }
+    }
+    if (attempted) {
+      try {
+        await refreshStatuses(expectedVisit);
+      } catch {
+        failed = true;
+      }
+    }
+    return !failed;
+  };
+
+  const importStatusCopy = (): string => {
+    if (state.importProgress !== null) {
+      return state.importProgress.params.event.phase === "started"
+        ? "Import started."
+        : "Import completed.";
+    }
+    if (state.acceptedImportPaths.length === 0) return "";
+    return `${state.acceptedImportPaths.length} ride file${state.acceptedImportPaths.length === 1 ? "" : "s"} imported.`;
+  };
+
+  const updateImportPresentation = (): void => {
+    if (scrim === undefined) return;
+    for (const button of scrim.querySelectorAll<HTMLButtonElement>("button")) {
+      if (!button.classList.contains("onboarding-dismiss")) button.disabled = state.busy;
+    }
+    const live = scrim.querySelector<HTMLElement>(".import-status");
+    if (live !== null) live.textContent = importStatusCopy();
+    const error = scrim.querySelector<HTMLElement>("#onboarding-error");
+    if (error !== null) {
+      error.textContent = state.fixedError === null ? "" : ERROR_COPY[state.fixedError];
+    }
+  };
+
+  const importPaths = async (paths: readonly string[], expectedVisit = visit): Promise<void> => {
+    if (visit !== expectedVisit || !canImportFiles(state, scrim !== undefined)) return;
+    state = withBusy(state, true);
+    updateImportPresentation();
+    try {
+      const result = await options.bridge.importFiles(paths, (envelope) => {
+        if (visit !== expectedVisit || scrim === undefined) return;
+        state = withImportProgress(state, envelope);
+        updateImportPresentation();
+      });
+      if (visit !== expectedVisit || scrim === undefined) return;
+      if (result.files.imported <= 0) throw new TypeError();
+      state = withSuccessfulImport(state, paths);
+    } catch {
+      if (visit !== expectedVisit || scrim === undefined) return;
+      state = withError(state, "import-failed");
+    }
+    updateImportPresentation();
+  };
+
+  const updateIntakeFromControl = (
+    key: "priorBsi" | "injuryStatus" | "clinicianCleared",
+    value: boolean | "none" | "managing" | "returning",
+  ): void => {
+    state = withIntake(state, { [key]: value });
+    render();
+    const name = {
+      priorBsi: "prior-bsi",
+      injuryStatus: "injury-status",
+      clinicianCleared: "clinician-cleared",
+    }[key];
+    scrim?.querySelector<HTMLInputElement>(`input[name="${name}"]:checked`)?.focus();
+  };
+
+  const radio = (
+    document: Document,
+    name: string,
+    labelText: string,
+    checked: boolean,
+    onChange: () => void,
+  ): HTMLLabelElement => {
+    const label = make(document, "label", "radio-option");
+    const input = make(document, "input");
+    input.type = "radio";
+    input.name = name;
+    input.checked = checked;
+    input.setAttribute("aria-describedby", "onboarding-error");
+    input.addEventListener("change", onChange);
+    label.append(input, document.createTextNode(labelText));
+    return label;
+  };
+
+  const renderCoachKeys = (body: HTMLElement): void => {
+    body.append(
+      make(options.document, "p", "onboarding-kicker", "Coach keys"),
+      make(options.document, "h1", undefined, "Choose how your coach thinks"),
+      make(
+        options.document,
+        "p",
+        "onboarding-copy",
+        "Your keys are encrypted by macOS and sent only to the local coaching service.",
+      ),
+    );
+    const primary = make(options.document, "div", "credential-list");
+    for (const provider of PRIMARY_MODEL_CREDENTIAL_SLOTS) {
+      const control = passwordControl(
+        options.document,
+        provider.id,
+        provider.label,
+        status(provider.id),
+      );
+      control
+        .querySelector("label")
+        ?.append(make(options.document, "span", "provider-hint", provider.hint));
+      primary.append(control);
+    }
+    body.append(primary);
+    const advanced = make(options.document, "details", "advanced-credentials");
+    advanced.append(make(options.document, "summary", undefined, "Advanced providers"));
+    const advancedList = make(options.document, "div", "credential-list");
+    for (const provider of ADVANCED_MODEL_CREDENTIAL_SLOTS) {
+      advancedList.append(
+        passwordControl(options.document, provider.id, provider.label, status(provider.id)),
+      );
+    }
+    advanced.append(advancedList);
+    body.append(advanced);
+    if (credentialStatuses.some((entry) => entry.state === "configured" && !entry.runtimeReady)) {
+      const retry = make(options.document, "button", "text-button", "Retry saved keys");
+      retry.type = "button";
+      retry.disabled = state.busy;
+      retry.addEventListener("click", () => {
+        const retryVisit = visit;
+        state = withBusy(state, true);
+        render();
+        focusCurrentTitle();
+        void refreshStatuses(retryVisit).then(
+          () => {
+            if (visit !== retryVisit || scrim === undefined) return;
+            state = withBusy(state, false);
+            render();
+            focusCurrentTitle();
+          },
+          () => {
+            if (visit !== retryVisit || scrim === undefined) return;
+            state = withError(state, "credential-save-failed");
+            render();
+            focusCurrentTitle();
+          },
+        );
+      });
+      body.append(retry);
+    }
+  };
+
+  const renderTrainingData = (body: HTMLElement): void => {
+    body.append(
+      make(options.document, "p", "onboarding-kicker", "Training data"),
+      make(options.document, "h1", undefined, "Bring your riding history"),
+    );
+    const guidance = make(options.document, "p", "onboarding-copy");
+    guidance.append(
+      options.document.createTextNode("Connect your device platform to intervals.icu "),
+      make(options.document, "strong", undefined, "directly"),
+      options.document.createTextNode(", not via Strava."),
+    );
+    guidance.setAttribute("aria-label", INTERVALS_GUIDANCE);
+    body.append(guidance);
+    body.append(
+      passwordControl(
+        options.document,
+        "intervals-icu",
+        "intervals.icu API key",
+        status("intervals-icu"),
+      ),
+    );
+    const divider = make(options.document, "div", "source-divider", "or import ride files");
+    body.append(divider);
+    const chooser = make(options.document, "button", "drop-zone");
+    chooser.type = "button";
+    chooser.disabled = state.busy;
+    chooser.append(
+      make(options.document, "strong", undefined, "Choose FIT, TCX, or GPX files"),
+      make(options.document, "span", undefined, "You can also drop files here."),
+    );
+    chooser.addEventListener("click", () => {
+      const chooserVisit = visit;
+      void options.bridge.chooseImportFiles().then(
+        (paths) => {
+          if (paths.length > 0) void importPaths(paths, chooserVisit);
+        },
+        () => {
+          if (visit !== chooserVisit || scrim === undefined) return;
+          state = withError(state, "import-failed");
+          render();
+        },
+      );
+    });
+    body.append(chooser);
+    const live = make(options.document, "p", "import-status");
+    live.setAttribute("aria-live", "polite");
+    live.textContent = importStatusCopy();
+    body.append(live);
+  };
+
+  const renderSafetyIntake = (body: HTMLElement): void => {
+    body.append(
+      make(options.document, "p", "onboarding-kicker", "Safety intake"),
+      make(options.document, "h1", undefined, "A few safety checks"),
+      make(
+        options.document,
+        "p",
+        "onboarding-copy",
+        "These answers record context for your coach. They are not a diagnosis.",
+      ),
+    );
+    const bsi = make(options.document, "fieldset");
+    bsi.append(make(options.document, "legend", undefined, "Have you had a bone stress injury?"));
+    bsi.append(
+      radio(options.document, "prior-bsi", "Yes", state.intake.priorBsi === true, () =>
+        updateIntakeFromControl("priorBsi", true),
+      ),
+      radio(options.document, "prior-bsi", "No", state.intake.priorBsi === false, () =>
+        updateIntakeFromControl("priorBsi", false),
+      ),
+    );
+    const injury = make(options.document, "fieldset");
+    injury.append(
+      make(options.document, "legend", undefined, "What is your current injury status?"),
+    );
+    injury.append(
+      radio(
+        options.document,
+        "injury-status",
+        "No current injury",
+        state.intake.injuryStatus === "none",
+        () => updateIntakeFromControl("injuryStatus", "none"),
+      ),
+      radio(
+        options.document,
+        "injury-status",
+        "Managing an injury",
+        state.intake.injuryStatus === "managing",
+        () => updateIntakeFromControl("injuryStatus", "managing"),
+      ),
+      radio(
+        options.document,
+        "injury-status",
+        "Returning after an injury",
+        state.intake.injuryStatus === "returning",
+        () => updateIntakeFromControl("injuryStatus", "returning"),
+      ),
+    );
+    body.append(bsi, injury);
+    if (
+      state.intake.priorBsi === true ||
+      (state.intake.injuryStatus !== null && state.intake.injuryStatus !== "none")
+    ) {
+      const clearance = make(options.document, "fieldset");
+      clearance.append(
+        make(
+          options.document,
+          "legend",
+          undefined,
+          "Has a clinician cleared your current return to training?",
+        ),
+      );
+      clearance.append(
+        radio(
+          options.document,
+          "clinician-cleared",
+          "Yes",
+          state.intake.clinicianCleared === true,
+          () => updateIntakeFromControl("clinicianCleared", true),
+        ),
+        radio(
+          options.document,
+          "clinician-cleared",
+          "No",
+          state.intake.clinicianCleared === false,
+          () => updateIntakeFromControl("clinicianCleared", false),
+        ),
+      );
+      body.append(clearance);
+    }
+  };
+
+  const renderReady = (body: HTMLElement): void => {
+    body.append(
+      make(options.document, "p", "onboarding-kicker", "Ready"),
+      make(options.document, "h1", undefined, "Your coach is ready"),
+      make(
+        options.document,
+        "p",
+        "onboarding-copy",
+        "Start with what you are training for, how the last week felt, or what you want help deciding.",
+      ),
+    );
+    const preview = make(options.document, "div", "ready-preview");
+    preview.append(
+      make(options.document, "span", undefined, "Keys secured"),
+      make(options.document, "span", undefined, "Training data connected"),
+      make(options.document, "span", undefined, "Safety context saved"),
+    );
+    body.append(preview);
+  };
+
+  const submitCurrentStep = async (dialog: HTMLElement): Promise<void> => {
+    if (state.busy) return;
+    const submitVisit = visit;
+    state = withBusy(state, true);
+    for (const button of dialog.querySelectorAll<HTMLButtonElement>("button"))
+      button.disabled = true;
+    if (state.step === "coach-keys") {
+      const saved = await savePasswordControls(dialog, submitVisit);
+      if (visit !== submitVisit || scrim === undefined) return;
+      state = withBusy(state, false);
+      if (!saved) state = withError(state, "credential-save-failed");
+      else if (!hasConfiguredModel(state)) state = withError(state, "credential-required");
+      else state = nextStep(state);
+      render();
+      focusCurrentTitle();
+      return;
+    }
+    if (state.step === "training-data") {
+      const saved = await savePasswordControls(dialog, submitVisit);
+      if (visit !== submitVisit || scrim === undefined) return;
+      state = withBusy(state, false);
+      if (!saved) state = withError(state, "credential-save-failed");
+      else if (!hasTrainingData(state)) state = withError(state, "training-data-required");
+      else state = nextStep(state);
+      render();
+      focusCurrentTitle();
+      return;
+    }
+    if (state.step === "safety-intake") {
+      let intake: ReturnType<typeof toDesktopIntakeFlags>;
+      try {
+        intake = toDesktopIntakeFlags(state.intake);
+      } catch {
+        state = withError(state, "intake-incomplete");
+        render();
+        focusCurrentTitle();
+        return;
+      }
+      try {
+        await options.bridge.saveIntake(intake);
+        if (visit !== submitVisit || scrim === undefined) return;
+        state = nextStep(withBusy(state, false));
+      } catch {
+        if (visit !== submitVisit || scrim === undefined) return;
+        state = withError(state, "intake-save-failed");
+      }
+      render();
+      focusCurrentTitle();
+      return;
+    }
+    if (!completed) {
+      completed = true;
+      visit += 1;
+      scrim?.remove();
+      scrim = undefined;
+      options.onComplete(ONBOARDING_COMPLETION);
+    }
+  };
+
+  const render = (): void => {
+    if (scrim === undefined) return;
+    scrim.replaceChildren();
+    const dialog = make(options.document, "section", "onboarding");
+    dialog.setAttribute("role", "dialog");
+    dialog.setAttribute("aria-modal", "true");
+    dialog.setAttribute("aria-labelledby", "onboarding-title");
+    const header = make(options.document, "header", "onboarding-header");
+    const progress = make(options.document, "div", "onboarding-progress");
+    const activeIndex = ONBOARDING_STEP_IDS.indexOf(state.step);
+    ONBOARDING_STEP_IDS.forEach((step, index) => {
+      const indicator = make(options.document, "span", index <= activeIndex ? "active" : undefined);
+      if (step === state.step) indicator.setAttribute("aria-current", "step");
+      progress.append(indicator);
+    });
+    progress.setAttribute("aria-label", `Step ${activeIndex + 1} of ${ONBOARDING_STEP_IDS.length}`);
+    const dismiss = make(options.document, "button", "onboarding-dismiss", "Dismiss");
+    dismiss.type = "button";
+    dismiss.addEventListener("click", close);
+    header.append(progress, dismiss);
+    const body = make(options.document, "div", "onboarding-body");
+    if (state.step === "coach-keys") renderCoachKeys(body);
+    if (state.step === "training-data") renderTrainingData(body);
+    if (state.step === "safety-intake") renderSafetyIntake(body);
+    if (state.step === "ready") renderReady(body);
+    const title = body.querySelector("h1");
+    if (title !== null) {
+      title.id = "onboarding-title";
+      title.tabIndex = -1;
+    }
+    const error = make(options.document, "p", "onboarding-error");
+    error.id = "onboarding-error";
+    error.setAttribute("aria-live", "polite");
+    if (state.fixedError !== null) error.textContent = ERROR_COPY[state.fixedError];
+    body.append(error);
+    const footer = make(options.document, "footer", "onboarding-footer");
+    if (activeIndex > 0) {
+      const back = make(options.document, "button", "secondary-button", "Back");
+      back.type = "button";
+      back.disabled = state.busy;
+      back.addEventListener("click", () => {
+        state = previousStep(state);
+        render();
+        focusCurrentTitle();
+      });
+      footer.append(back);
+    } else {
+      footer.append(make(options.document, "span"));
+    }
+    const submit = make(
+      options.document,
+      "button",
+      "primary-button",
+      state.step === "ready" ? "Finish setup" : "Continue",
+    );
+    submit.type = "button";
+    submit.disabled = state.busy;
+    submit.addEventListener("click", () => void submitCurrentStep(dialog));
+    footer.append(submit);
+    dialog.append(header, body, footer);
+    dialog.addEventListener("keydown", (event) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        close();
+        return;
+      }
+      if (
+        event.key === "Enter" &&
+        !(event.target instanceof HTMLButtonElement) &&
+        !(event.target instanceof HTMLElement && event.target.tagName === "SUMMARY")
+      ) {
+        event.preventDefault();
+        void submitCurrentStep(dialog);
+        return;
+      }
+      if (event.key !== "Tab") return;
+      const focusable = focusableElements(dialog);
+      if (focusable.length === 0) return;
+      const first = focusable[0]!;
+      const last = focusable[focusable.length - 1]!;
+      if (event.shiftKey && options.document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && options.document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    });
+    scrim.append(dialog);
+  };
+
+  const disposeDrop = options.bridge.onDroppedImportFiles((paths) => void importPaths(paths));
+
+  return {
+    async open(): Promise<void> {
+      if (disposed || scrim !== undefined || opening) return;
+      opening = true;
+      const openVisit = ++visit;
+      completed = false;
+      let statuses: readonly CredentialSlotStatus[] = [];
+      try {
+        statuses = await options.bridge.credentialStatuses();
+      } catch {}
+      if (disposed || visit !== openVisit || scrim !== undefined) {
+        opening = false;
+        return;
+      }
+      credentialStatuses = statuses;
+      state = createOnboardingState(statuses);
+      scrim = make(options.document, "div", "onboarding-scrim");
+      options.document.body.append(scrim);
+      render();
+      focusCurrentTitle();
+      opening = false;
+    },
+    close,
+    dispose(): void {
+      disposed = true;
+      visit += 1;
+      clearPasswordInputs();
+      scrim?.remove();
+      scrim = undefined;
+      disposeDrop();
+    },
+    state: () => state,
+  };
+}

--- a/apps/desktop-renderer/src/onboarding/onboarding.css
+++ b/apps/desktop-renderer/src/onboarding/onboarding.css
@@ -1,0 +1,280 @@
+.onboarding-scrim {
+  position: fixed;
+  z-index: 4;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  padding: max(44px, env(safe-area-inset-top)) 18px 18px;
+  background: rgba(9, 14, 11, 0.36);
+  backdrop-filter: blur(9px);
+}
+
+.onboarding {
+  width: min(510px, 100%);
+  max-height: 100%;
+  overflow: auto;
+  border: 1px solid var(--line-strong, var(--line));
+  border-radius: 22px;
+  background: var(--surface-solid, var(--surface));
+  box-shadow: 0 28px 80px rgb(9 20 14 / 24%);
+  animation: onboarding-enter 180ms ease-out;
+}
+
+.onboarding-header,
+.onboarding-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 18px 24px;
+}
+
+.onboarding-header {
+  border-bottom: 1px solid var(--line);
+}
+
+.onboarding-footer {
+  border-top: 1px solid var(--line);
+}
+
+.onboarding-progress {
+  display: flex;
+  gap: 7px;
+}
+
+.onboarding-progress span {
+  width: 26px;
+  height: 3px;
+  border-radius: 999px;
+  background: var(--line);
+  transition: background 160ms ease;
+}
+
+.onboarding-progress span.active {
+  background: var(--moss);
+}
+
+.onboarding-dismiss,
+.text-button {
+  border: 0;
+  color: var(--muted);
+  background: transparent;
+  cursor: pointer;
+}
+
+.onboarding-body {
+  min-height: 310px;
+  padding: 38px 42px 34px;
+}
+
+.onboarding-kicker {
+  margin: 0 0 10px;
+  color: var(--moss);
+  font-size: 12px;
+  font-weight: 720;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.onboarding h1 {
+  margin: 0;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: clamp(29px, 4vw, 38px);
+  font-weight: 500;
+  letter-spacing: -0.035em;
+  line-height: 1.08;
+}
+
+.onboarding-copy {
+  margin: 15px 0 24px;
+  color: var(--muted);
+  line-height: 1.55;
+}
+
+.credential-list {
+  display: grid;
+  gap: 14px;
+}
+
+.credential-field {
+  display: grid;
+  gap: 7px;
+}
+
+.credential-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  font-weight: 650;
+}
+
+.credential-field input {
+  width: 100%;
+  height: 42px;
+  padding: 0 12px;
+  border: 1px solid var(--line);
+  border-radius: 11px;
+  color: var(--ink);
+  background: var(--surface);
+}
+
+.credential-state,
+.provider-hint {
+  margin-left: auto;
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 500;
+}
+
+.credential-state.configured {
+  color: var(--moss);
+}
+
+.credential-state.re-prompt {
+  color: #9a593f;
+}
+
+.provider-hint {
+  margin-left: 0;
+  padding: 2px 7px;
+  border-radius: 999px;
+  background: var(--moss-soft);
+}
+
+.advanced-credentials {
+  margin-top: 18px;
+}
+
+.advanced-credentials summary {
+  color: var(--moss);
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 650;
+}
+
+.advanced-credentials .credential-list {
+  margin-top: 15px;
+}
+
+.source-divider {
+  margin: 22px 0 13px;
+  color: var(--muted);
+  font-size: 12px;
+  text-align: center;
+}
+
+.drop-zone {
+  display: grid;
+  gap: 5px;
+  width: 100%;
+  padding: 20px;
+  border: 1px dashed var(--focus);
+  border-radius: 14px;
+  color: var(--ink);
+  background: var(--moss-soft);
+  cursor: pointer;
+}
+
+.drop-zone span,
+.import-status {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.import-status {
+  min-height: 18px;
+  margin-bottom: 0;
+}
+
+.onboarding fieldset {
+  display: grid;
+  gap: 9px;
+  margin: 0 0 20px;
+  padding: 0;
+  border: 0;
+}
+
+.onboarding legend {
+  margin-bottom: 10px;
+  font-weight: 680;
+}
+
+.radio-option {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  color: var(--muted);
+}
+
+.radio-option input {
+  accent-color: var(--moss);
+}
+
+.ready-preview {
+  display: grid;
+  gap: 1px;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+}
+
+.ready-preview span {
+  padding: 13px 15px;
+  background: var(--moss-soft);
+}
+
+.onboarding-error {
+  min-height: 20px;
+  margin: 14px 0 0;
+  color: #9a4937;
+  font-size: 13px;
+}
+
+.primary-button,
+.secondary-button,
+.setup-button {
+  min-height: 38px;
+  padding: 0 16px;
+  border-radius: 999px;
+  cursor: pointer;
+}
+
+.primary-button {
+  border: 1px solid var(--moss);
+  color: white;
+  background: var(--moss);
+}
+
+.secondary-button,
+.setup-button {
+  border: 1px solid var(--line);
+  color: var(--ink);
+  background: var(--surface);
+}
+
+.primary-button:disabled,
+.secondary-button:disabled {
+  cursor: default;
+  opacity: 0.5;
+}
+
+@keyframes onboarding-enter {
+  from {
+    opacity: 0;
+    transform: translateY(8px) scale(0.99);
+  }
+}
+
+@media (max-width: 720px) {
+  .onboarding-body {
+    padding: 30px 24px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .onboarding,
+  .onboarding-progress span {
+    animation: none;
+    transition: none;
+  }
+}

--- a/apps/desktop-renderer/tests/onboarding-machine.test.ts
+++ b/apps/desktop-renderer/tests/onboarding-machine.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import {
+  canImportFiles,
+  createOnboardingState,
+  nextStep,
+  previousStep,
+  toDesktopIntakeFlags,
+  withCredentialStatuses,
+  withIntake,
+  withSuccessfulImport,
+} from "../src/onboarding/machine.js";
+
+describe("desktop onboarding machine", () => {
+  it("keeps the four ordered steps and exact guards", () => {
+    let state = createOnboardingState();
+    expect(Object.keys(state).sort()).toEqual([
+      "acceptedImportPaths",
+      "busy",
+      "credentialStatus",
+      "fixedError",
+      "importProgress",
+      "intake",
+      "step",
+    ]);
+    expect(nextStep(state)).toMatchObject({
+      step: "coach-keys",
+      fixedError: "credential-required",
+    });
+    state = withCredentialStatuses(state, [
+      { slot: "anthropic", state: "configured", runtimeReady: true },
+    ]);
+    state = nextStep(state);
+    expect(state.step).toBe("training-data");
+    expect(nextStep(state)).toMatchObject({
+      step: "training-data",
+      fixedError: "training-data-required",
+    });
+    state = withSuccessfulImport(state, ["/synthetic/ride.fit"]);
+    state = nextStep(state);
+    expect(state.step).toBe("safety-intake");
+    expect(nextStep(state)).toMatchObject({
+      step: "safety-intake",
+      fixedError: "intake-incomplete",
+    });
+    state = withIntake(state, { priorBsi: false, injuryStatus: "none" });
+    state = nextStep(state);
+    expect(state.step).toBe("ready");
+  });
+
+  it("preserves configured metadata and successful imports while moving back", () => {
+    let state = createOnboardingState([
+      { slot: "openrouter", state: "configured", runtimeReady: true },
+      { slot: "intervals-icu", state: "configured", runtimeReady: true },
+    ]);
+    state = nextStep(state);
+    state = withSuccessfulImport(state, ["/synthetic/ride.tcx"]);
+    state = nextStep(state);
+    state = previousStep(state);
+    state = previousStep(state);
+    expect(state.step).toBe("coach-keys");
+    expect(state.credentialStatus.openrouter).toBe("configured");
+    expect(state.acceptedImportPaths).toEqual(["/synthetic/ride.tcx"]);
+    expect("secret" in state).toBe(false);
+  });
+
+  it("accepts chooser and drop imports only while the training step is open and idle", () => {
+    let state = createOnboardingState([
+      { slot: "anthropic", state: "configured", runtimeReady: true },
+    ]);
+    state = nextStep(state);
+    expect(canImportFiles(state, true)).toBe(true);
+    expect(canImportFiles(state, false)).toBe(false);
+    expect(canImportFiles({ ...state, busy: true }, true)).toBe(false);
+    expect(canImportFiles(previousStep(state), true)).toBe(false);
+  });
+
+  it("maps every cycling intake branch to the landed strict DTO", () => {
+    expect(
+      toDesktopIntakeFlags({ priorBsi: false, injuryStatus: "none", clinicianCleared: null }),
+    ).toEqual({
+      swim_skill_floor: null,
+      continuous_distance_capable: null,
+      open_water_comfort: null,
+      prior_bsi: false,
+      clinician_cleared: null,
+      injury_status: "none",
+    });
+    for (const priorBsi of [false, true]) {
+      for (const injuryStatus of ["managing", "returning"] as const) {
+        for (const clinicianCleared of [false, true]) {
+          expect(toDesktopIntakeFlags({ priorBsi, injuryStatus, clinicianCleared })).toMatchObject({
+            prior_bsi: priorBsi,
+            injury_status: injuryStatus,
+            clinician_cleared: clinicianCleared,
+          });
+        }
+      }
+    }
+    expect(() =>
+      toDesktopIntakeFlags({ priorBsi: true, injuryStatus: "none", clinicianCleared: null }),
+    ).toThrow(TypeError);
+  });
+});

--- a/apps/desktop-renderer/tests/onboarding-secret-boundary.test.ts
+++ b/apps/desktop-renderer/tests/onboarding-secret-boundary.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { handoffCredential } from "../src/onboarding/mount.js";
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve };
+}
+
+describe("onboarding renderer secret boundary", () => {
+  for (const [slot, sentinel] of [
+    ["anthropic", "synthetic-model-secret-sentinel"],
+    ["intervals-icu", "synthetic-intervals-secret-sentinel"],
+  ] as const) {
+    it(`releases the ${slot} password after the pending handoff settles`, async () => {
+      const input = { value: sentinel, dataset: { slot } };
+      const gate = deferred();
+      let transient: { readonly slot: string; readonly value: string } | undefined;
+      const write = async (value: { readonly slot: string; readonly value: string }) => {
+        try {
+          transient = value;
+          await gate.promise;
+        } finally {
+          transient = undefined;
+        }
+      };
+      const pending = handoffCredential(input, write);
+      expect(input.value).toBe(sentinel);
+      expect(transient).toEqual({ slot, value: sentinel });
+      gate.resolve();
+      await pending;
+      expect(input.value).toBe("");
+      expect(transient).toBeUndefined();
+      const capturedSurfaces = {
+        innerHTML: "",
+        outerHTML: '<input type="password">',
+        text: "",
+        attributes: ["type=password"],
+        snapshot: { input: "" },
+        location: "enduragent://app/index.html",
+        console: [],
+        bridgeResult: { slot, status: "configured", runtimeReady: true },
+        rpc: [],
+        browserStorage: [],
+      };
+      expect(JSON.stringify(capturedSurfaces)).not.toContain(sentinel);
+    });
+  }
+
+  it("clears the live control when the privileged handoff rejects", async () => {
+    const sentinel = "synthetic-refused-secret-sentinel";
+    const input = { value: sentinel, dataset: { slot: "openrouter" } };
+    await expect(
+      handoffCredential(input, async () => {
+        throw new TypeError();
+      }),
+    ).rejects.toBeInstanceOf(TypeError);
+    expect(input.value).toBe("");
+    expect(JSON.stringify(input)).not.toContain(sentinel);
+  });
+});

--- a/apps/desktop-renderer/tests/onboarding-wizard.test.ts
+++ b/apps/desktop-renderer/tests/onboarding-wizard.test.ts
@@ -1,0 +1,181 @@
+import { readFile } from "node:fs/promises";
+import { describe, expect, it, vi } from "vitest";
+import {
+  ADVANCED_MODEL_CREDENTIAL_SLOTS,
+  INTERVALS_GUIDANCE,
+  ONBOARDING_STEP_IDS,
+  PRIMARY_MODEL_CREDENTIAL_SLOTS,
+} from "../src/onboarding/constants.js";
+import {
+  createOnboardingBridge,
+  validateImportPaths,
+  type DesktopOnboardingAuth,
+} from "../src/onboarding/bridge.js";
+
+describe("desktop onboarding wizard", () => {
+  it("pins the ratified steps, provider catalogue, and intervals guidance", () => {
+    expect(ONBOARDING_STEP_IDS).toEqual(["coach-keys", "training-data", "safety-intake", "ready"]);
+    expect(PRIMARY_MODEL_CREDENTIAL_SLOTS).toEqual([
+      { id: "anthropic", label: "Anthropic API key", hint: "Recommended" },
+      { id: "openrouter", label: "OpenRouter API key", hint: "Everything else" },
+    ]);
+    expect(ADVANCED_MODEL_CREDENTIAL_SLOTS.map(({ id }) => id)).toEqual([
+      "openai",
+      "google",
+      "deepseek",
+      "qwen",
+      "minimax",
+      "kimi",
+      "zai",
+    ]);
+    expect(INTERVALS_GUIDANCE).toBe(
+      "Connect your device platform to intervals.icu directly, not via Strava.",
+    );
+  });
+
+  it("enforces absolute unique FIT, TCX, and GPX selections before dispatch", () => {
+    expect(
+      validateImportPaths(["/synthetic/a.FIT", "/synthetic/b.tcx", "/synthetic/c.GpX"]),
+    ).toEqual(["/synthetic/a.FIT", "/synthetic/b.tcx", "/synthetic/c.GpX"]);
+    expect(() => validateImportPaths(["relative.fit"])).toThrow(TypeError);
+    expect(() => validateImportPaths(["/synthetic/a.zip"])).toThrow(TypeError);
+    expect(() => validateImportPaths(["/synthetic/a.fit", "/synthetic/a.fit"])).toThrow();
+    expect(() =>
+      validateImportPaths(Array.from({ length: 257 }, (_, index) => `/synthetic/${index}.fit`)),
+    ).toThrow();
+    expect(() => validateImportPaths([`/synthetic/${"a".repeat(4_090)}.fit`])).toThrow();
+  });
+
+  it("uses the authenticated client for exact import and intake methods", async () => {
+    const calls: Array<{ readonly method: string; readonly request: unknown }> = [];
+    const client = {
+      handshake: {},
+      async call(
+        method: string,
+        request: unknown,
+        options?: { onNotificationEnvelope?: (value: unknown) => void },
+      ) {
+        calls.push({ method, request });
+        if (method === "importFiles") {
+          options?.onNotificationEnvelope?.({
+            jsonrpc: "2.0",
+            method: "coach.operationProgress",
+            params: {
+              requestId: 1,
+              requestMethod: "importFiles",
+              event: { phase: "started", completed: 0, total: 1 },
+            },
+          });
+          return {
+            schemaVersion: 1,
+            files: { total: 1, imported: 1, quarantined: 0 },
+            changes: {
+              rawFilesInserted: 1,
+              sourceRecordsInserted: 1,
+              sourceRecordsUpdated: 0,
+              relinkedSourceRecords: 0,
+            },
+          };
+        }
+        return { schemaVersion: 1, saved: true };
+      },
+      close: vi.fn(),
+    };
+    const auth = {
+      getDaemonConnection: vi.fn(async () => ({
+        url: "ws://127.0.0.1:45001/rpc" as const,
+        token: "s".repeat(43),
+      })),
+      credentialStatuses: vi.fn(async () => []),
+      writeCredential: vi.fn(),
+      chooseImportFiles: vi.fn(async () => []),
+      onDroppedImportFiles: vi.fn(() => vi.fn()),
+    } as unknown as DesktopOnboardingAuth;
+    const bridge = createOnboardingBridge(
+      auth,
+      vi.fn(async () => client as never),
+    );
+    const progress = vi.fn();
+    await bridge.importFiles(["/synthetic/ride.fit"], progress);
+    await bridge.saveIntake({
+      swim_skill_floor: null,
+      continuous_distance_capable: null,
+      open_water_comfort: null,
+      prior_bsi: false,
+      clinician_cleared: null,
+      injury_status: "none",
+    });
+    expect(calls).toEqual([
+      { method: "importFiles", request: { paths: ["/synthetic/ride.fit"] } },
+      {
+        method: "saveIntake",
+        request: {
+          swim_skill_floor: null,
+          continuous_distance_capable: null,
+          open_water_comfort: null,
+          prior_bsi: false,
+          clinician_cleared: null,
+          injury_status: "none",
+        },
+      },
+    ]);
+    expect(progress).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries connection resolution after a transient connection failure", async () => {
+    const connection = {
+      url: "ws://127.0.0.1:45001/rpc" as const,
+      token: "s".repeat(43),
+    };
+    const getDaemonConnection = vi
+      .fn<DesktopOnboardingAuth["getDaemonConnection"]>()
+      .mockRejectedValueOnce(new TypeError())
+      .mockResolvedValue(connection);
+    const auth = {
+      getDaemonConnection,
+      credentialStatuses: vi.fn(async () => []),
+      writeCredential: vi.fn(),
+      chooseImportFiles: vi.fn(async () => []),
+      onDroppedImportFiles: vi.fn(() => vi.fn()),
+    } as unknown as DesktopOnboardingAuth;
+    const client = {
+      handshake: {},
+      call: vi.fn(async () => ({
+        schemaVersion: 1,
+        files: { total: 1, imported: 1, quarantined: 0 },
+        changes: {
+          rawFilesInserted: 1,
+          sourceRecordsInserted: 1,
+          sourceRecordsUpdated: 0,
+          relinkedSourceRecords: 0,
+        },
+      })),
+      close: vi.fn(),
+    };
+    const connect = vi.fn(async () => client as never);
+    const bridge = createOnboardingBridge(auth, connect);
+    await expect(bridge.importFiles(["/synthetic/ride.fit"], vi.fn())).rejects.toBeInstanceOf(
+      TypeError,
+    );
+    await expect(bridge.importFiles(["/synthetic/ride.fit"], vi.fn())).resolves.toMatchObject({
+      files: { imported: 1 },
+    });
+    expect(getDaemonConnection).toHaveBeenCalledTimes(2);
+    expect(connect).toHaveBeenCalledTimes(1);
+  });
+
+  it("ships the exact dialog and responsive accessibility hooks", async () => {
+    const [mount, styles] = await Promise.all([
+      readFile(new URL("../src/onboarding/mount.ts", import.meta.url), "utf8"),
+      readFile(new URL("../src/onboarding/onboarding.css", import.meta.url), "utf8"),
+    ]);
+    expect(mount).toContain('setAttribute("role", "dialog")');
+    expect(mount).toContain('setAttribute("aria-modal", "true")');
+    expect(mount).toContain('event.key === "Escape"');
+    expect(mount).toContain('event.key !== "Tab"');
+    expect(mount).toContain('setAttribute("aria-live", "polite")');
+    expect(styles).toContain("@media (max-width: 720px)");
+    expect(styles).toContain("padding: 30px 24px");
+    expect(styles).toContain("@media (prefers-reduced-motion: reduce)");
+  });
+});

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -11,10 +11,12 @@
     "package:dir": "electron-vite build && electron-builder --dir",
     "smoke:runtime": "node scripts/electron-smoke.mjs runtime",
     "smoke:security": "node scripts/electron-smoke.mjs security",
+    "test:safe-storage-packaged": "node scripts/test-safe-storage-packaged.mjs",
     "test": "vitest run"
   },
   "dependencies": {
     "@enduragent/coach": "workspace:*",
+    "@enduragent/coach-client": "workspace:*",
     "@enduragent/coach-contract": "workspace:*"
   },
   "devDependencies": {

--- a/apps/desktop/scripts/electron-smoke.mjs
+++ b/apps/desktop/scripts/electron-smoke.mjs
@@ -224,7 +224,8 @@ async function security() {
         spoofOrigin: spoofed === expectedForbidden,
         wrongToken: wrongCode === 1008,
         observerOrder: JSON.stringify(observerOrder) === JSON.stringify(expectedOrder),
-        preloadBridge: JSON.stringify(ready.bridgeKeys) === JSON.stringify(["getDaemonConnection"]),
+        preloadBridge: JSON.stringify(ready.bridgeKeys) === JSON.stringify(["chooseImportFiles", "credentialStatuses", "getDaemonConnection", "onDroppedImportFiles", "writeCredential"]),
+        credentialMetadata: ready.credentialStatusesMetadataOnly === true,
       },
       url: ready.url,
       blockedOffPort: ready.blockedOffPort,
@@ -235,6 +236,7 @@ async function security() {
         !JSON.stringify(running.env).includes(token) &&
         !result.stdout.includes(token) &&
         !result.stderr.includes(token) &&
+        !JSON.stringify(ready.credentialStatuses).includes(token) &&
         !screenshotPath.includes(token),
     };
     if (Object.values(summary.passes).some((value) => value !== true) || summary.blockedOffPort !== true || summary.drawerPresent !== true || summary.tokenAbsent !== true || !existsSync(screenshotPath)) {

--- a/apps/desktop/scripts/test-safe-storage-packaged.mjs
+++ b/apps/desktop/scripts/test-safe-storage-packaged.mjs
@@ -1,0 +1,259 @@
+import { spawn } from "node:child_process";
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  realpath,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+delete process.env.FORCE_COLOR;
+delete process.env.CLICOLOR_FORCE;
+const { transformWithEsbuild } = await import("vite");
+
+const desktopRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const base = await realpath(process.platform === "darwin" ? "/tmp" : tmpdir());
+const scratch = await mkdtemp(join(base, "eav-"));
+const staging = join(scratch, "fixture");
+const userData = join(scratch, "user-data");
+const commandPath = join(scratch, "command.json");
+const resultPath = join(scratch, "result.json");
+const sentinel = "synthetic-packaged-safe-storage-sentinel";
+const unaffected = "synthetic-packaged-unaffected-sentinel";
+
+function run(command, args, options = {}) {
+  return new Promise((resolveRun, rejectRun) => {
+    const { timeoutMs = 120_000, ...spawnOptions } = options;
+    const child = spawn(command, args, { ...spawnOptions, stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      child.kill();
+    }, timeoutMs);
+    child.stdout.on("data", (chunk) => {
+      stdout += String(chunk);
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += String(chunk);
+    });
+    child.once("error", (error) => {
+      clearTimeout(timeout);
+      rejectRun(error);
+    });
+    child.once("exit", (code, signal) => {
+      clearTimeout(timeout);
+      resolveRun({ code, signal, stdout, stderr, timedOut });
+    });
+  });
+}
+
+async function executable() {
+  const entries = await readdir(join(staging, "dist"), { recursive: true });
+  const relative = entries.find((entry) =>
+    entry.endsWith("Safe Storage Fixture.app/Contents/MacOS/Safe Storage Fixture"),
+  );
+  if (relative === undefined) throw new TypeError();
+  return join(staging, "dist", relative);
+}
+
+async function treeContains(root, value) {
+  const entries = await readdir(root, { recursive: true });
+  for (const entry of entries) {
+    try {
+      if ((await readFile(join(root, entry))).includes(Buffer.from(value))) return true;
+    } catch {}
+  }
+  return false;
+}
+
+const fixtureMain = `
+const { app, safeStorage } = require("electron");
+const { readFileSync } = require("node:fs");
+const { readFile, writeFile } = require("node:fs/promises");
+const { join } = require("node:path");
+const { CREDENTIAL_DIRECTORY_NAME, createCredentialVault } = require("./credential-vault.cjs");
+
+const command = JSON.parse(readFileSync(process.env.W9_SAFE_STORAGE_COMMAND, "utf8"));
+
+async function execute() {
+  const applied = new Map();
+  const vault = createCredentialVault({
+    root: join(command.userData, CREDENTIAL_DIRECTORY_NAME),
+    encryption: safeStorage,
+    async applyCredential(slot, value) {
+      applied.set(slot, value);
+    },
+  });
+  if (command.mode === "write") {
+    const first = await vault.writeCredential({ slot: "anthropic", value: command.sentinel });
+    const second = await vault.writeCredential({ slot: "openrouter", value: command.unaffected });
+    const ciphertext = first.status === "configured"
+      ? await readFile(join(command.userData, CREDENTIAL_DIRECTORY_NAME, "anthropic.bin"))
+      : Buffer.alloc(0);
+    await writeFile(command.resultPath, JSON.stringify({
+      encryptionAvailable: safeStorage.isEncryptionAvailable(),
+      ciphertextContainsPlaintext: ciphertext.includes(Buffer.from(command.sentinel)),
+      firstConfigured: first.status === "configured",
+      secondConfigured: second.status === "configured",
+      firstReason: first.status === "refused" ? first.reason : null,
+      secondReason: second.status === "refused" ? second.reason : null,
+    }), { mode: 0o600 });
+    app.exit(0);
+    return;
+  }
+  await vault.reapplyConfigured();
+  const relaunchRoundTrip = applied.get("anthropic") === command.sentinel;
+  const ciphertextPath = join(command.userData, CREDENTIAL_DIRECTORY_NAME, "anthropic.bin");
+  const ciphertext = await readFile(ciphertextPath);
+  ciphertext[ciphertext.length - 1] ^= 0x01;
+  await writeFile(ciphertextPath, ciphertext, { mode: 0o600 });
+  const statuses = await vault.credentialStatuses();
+  const corrupt = statuses.find((entry) => entry.slot === "anthropic");
+  const healthy = statuses.find((entry) => entry.slot === "openrouter");
+  await writeFile(command.resultPath, JSON.stringify({
+    relaunchRoundTrip,
+    corruptionRejected: corrupt?.state === "re-prompt",
+    corruptSlotState: corrupt?.state,
+    unaffectedSlotState: healthy?.state,
+  }), { mode: 0o600 });
+  app.exit(0);
+}
+
+app.whenReady().then(execute, () => app.exit(1));
+`;
+
+try {
+  await Promise.all([
+    mkdir(staging, { recursive: true, mode: 0o700 }),
+    mkdir(userData, { recursive: true, mode: 0o700 }),
+  ]);
+  await writeFile(join(staging, "main.cjs"), fixtureMain);
+  await writeFile(
+    join(staging, "package.json"),
+    JSON.stringify({
+      name: "enduragent-safe-storage-fixture",
+      version: "0.0.0",
+      private: true,
+      main: "main.cjs",
+    }),
+  );
+  await writeFile(
+    join(staging, "electron-builder.yml"),
+    [
+      "appId: icu.enduragent.safe-storage-fixture",
+      "productName: Safe Storage Fixture",
+      "electronVersion: 43.1.1",
+      "asar: true",
+      "directories:",
+      "  output: dist",
+      "files:",
+      "  - main.cjs",
+      "  - credential-vault.cjs",
+      "  - package.json",
+      "mac:",
+      "  identity: null",
+      "  target:",
+      "    - target: dir",
+      "      arch: [arm64]",
+      "",
+    ].join("\n"),
+  );
+  const vaultSource = await readFile(join(desktopRoot, "src/main/credential-vault.ts"), "utf8");
+  const compiled = await transformWithEsbuild(
+    vaultSource,
+    join(desktopRoot, "src/main/credential-vault.ts"),
+    { loader: "ts", format: "cjs", target: "es2022" },
+  );
+  await writeFile(join(staging, "credential-vault.cjs"), compiled.code);
+  const packaged = await run(
+    resolve(desktopRoot, "node_modules/.bin/electron-builder"),
+    ["--dir", `--projectDir=${staging}`],
+    {
+      cwd: desktopRoot,
+      env: { ...process.env, FORCE_COLOR: undefined, CLICOLOR_FORCE: undefined },
+    },
+  );
+  if (packaged.code !== 0 || packaged.signal !== null) {
+    throw new Error(packaged.stderr || packaged.stdout || "packaging failed");
+  }
+  const appExecutable = await executable();
+  const launchEnvironment = {
+    ...process.env,
+    W9_SAFE_STORAGE_COMMAND: commandPath,
+    FORCE_COLOR: undefined,
+    CLICOLOR_FORCE: undefined,
+  };
+  await writeFile(
+    commandPath,
+    JSON.stringify({ mode: "write", userData, resultPath, sentinel, unaffected }),
+    { mode: 0o600 },
+  );
+  await chmod(commandPath, 0o600);
+  const firstExit = await run(appExecutable, [], { env: launchEnvironment, timeoutMs: 20_000 });
+  if (firstExit.timedOut || firstExit.code !== 0 || firstExit.signal !== null) {
+    throw new Error(firstExit.stderr || firstExit.stdout || "first fixture launch failed");
+  }
+  const first = JSON.parse(await readFile(resultPath, "utf8"));
+  if (first.firstConfigured !== true || first.secondConfigured !== true) {
+    throw new Error(JSON.stringify(first));
+  }
+  await writeFile(
+    commandPath,
+    JSON.stringify({ mode: "read", userData, resultPath, sentinel, unaffected }),
+    { mode: 0o600 },
+  );
+  const secondExit = await run(appExecutable, [], { env: launchEnvironment, timeoutMs: 20_000 });
+  if (secondExit.timedOut || secondExit.code !== 0 || secondExit.signal !== null) {
+    throw new Error(secondExit.stderr || secondExit.stdout || "second fixture launch failed");
+  }
+  const second = JSON.parse(await readFile(resultPath, "utf8"));
+  const captured = JSON.stringify({
+    packaged,
+    firstExit,
+    secondExit,
+    first,
+    second,
+    command: { path: commandPath },
+  });
+  const packageEntries = await readdir(join(staging, "dist"), { recursive: true });
+  const packageContainsPlaintext = await treeContains(join(staging, "dist"), sentinel);
+  const appExitObserved =
+    firstExit.code === 0 &&
+    firstExit.signal === null &&
+    secondExit.code === 0 &&
+    secondExit.signal === null;
+  const summary = {
+    ok:
+      first.encryptionAvailable === true &&
+      first.ciphertextContainsPlaintext === false &&
+      first.firstConfigured === true &&
+      first.secondConfigured === true &&
+      second.relaunchRoundTrip === true &&
+      second.corruptionRejected === true &&
+      second.corruptSlotState === "re-prompt" &&
+      second.unaffectedSlotState === "configured" &&
+      appExitObserved &&
+      !captured.includes(sentinel) &&
+      !packageContainsPlaintext &&
+      !packageEntries.some((entry) => entry.includes("vitest") || entry.endsWith(".map")),
+    encryptionAvailable: first.encryptionAvailable,
+    ciphertextContainsPlaintext: first.ciphertextContainsPlaintext,
+    relaunchRoundTrip: second.relaunchRoundTrip,
+    corruptionRejected: second.corruptionRejected,
+    corruptSlotState: second.corruptSlotState,
+    unaffectedSlotState: second.unaffectedSlotState,
+    appExitObserved,
+  };
+  if (!summary.ok) throw new Error(JSON.stringify(summary));
+  process.stdout.write(`${JSON.stringify(summary)}\n`);
+} finally {
+  await rm(scratch, { recursive: true, force: true });
+}

--- a/apps/desktop/src/main/credential-vault.ts
+++ b/apps/desktop/src/main/credential-vault.ts
@@ -1,0 +1,256 @@
+import { randomUUID } from "node:crypto";
+import { lstat, mkdir, open, readFile, rename, rm } from "node:fs/promises";
+import { join } from "node:path";
+
+export const DESKTOP_CREDENTIAL_SLOTS = [
+  "anthropic",
+  "openrouter",
+  "openai",
+  "google",
+  "deepseek",
+  "qwen",
+  "minimax",
+  "kimi",
+  "zai",
+  "intervals-icu",
+] as const;
+
+export type DesktopCredentialSlot = (typeof DESKTOP_CREDENTIAL_SLOTS)[number];
+export type CredentialState = "missing" | "configured" | "re-prompt";
+
+export interface CredentialSlotStatus {
+  readonly slot: DesktopCredentialSlot;
+  readonly state: CredentialState;
+  readonly runtimeReady: boolean;
+}
+
+export type CredentialWriteResult =
+  | {
+      readonly slot: DesktopCredentialSlot;
+      readonly status: "configured";
+      readonly runtimeReady: true;
+    }
+  | {
+      readonly slot: DesktopCredentialSlot;
+      readonly status: "refused";
+      readonly reason:
+        | "invalid-input"
+        | "encryption-unavailable"
+        | "unsafe-backend"
+        | "storage-failed"
+        | "runtime-unavailable";
+    };
+
+export const CREDENTIAL_DIRECTORY_NAME = "credentials-v1" as const;
+export const CREDENTIAL_DIRECTORY_MODE = 0o700;
+export const CREDENTIAL_FILE_MODE = 0o600;
+export const UNSAFE_STORAGE_BACKEND = "basic_text" as const;
+
+export interface CredentialEncryptionPort {
+  isEncryptionAvailable(): boolean;
+  encryptString(value: string): Buffer;
+  decryptString(value: Buffer): string;
+  getSelectedStorageBackend?: () => string;
+}
+
+export interface CredentialVault {
+  writeCredential(input: {
+    readonly slot: DesktopCredentialSlot;
+    readonly value: string;
+  }): Promise<CredentialWriteResult>;
+  credentialStatuses(): Promise<readonly CredentialSlotStatus[]>;
+  reapplyConfigured(): Promise<void>;
+}
+
+interface CredentialVaultOptions {
+  readonly root: string;
+  readonly encryption: CredentialEncryptionPort;
+  readonly applyCredential: (slot: DesktopCredentialSlot, value: string) => Promise<void>;
+}
+
+interface ReadCredential {
+  readonly slot: DesktopCredentialSlot;
+  readonly state: CredentialState;
+  readonly value?: string;
+  readonly modifiedAt: number;
+}
+
+function isCredentialSlot(value: unknown): value is DesktopCredentialSlot {
+  return (
+    typeof value === "string" && (DESKTOP_CREDENTIAL_SLOTS as readonly string[]).includes(value)
+  );
+}
+
+function permissions(mode: number): number {
+  return mode & 0o777;
+}
+
+async function secureDirectory(root: string): Promise<boolean> {
+  try {
+    await mkdir(root, { recursive: true, mode: CREDENTIAL_DIRECTORY_MODE });
+    const entry = await lstat(root);
+    return (
+      entry.isDirectory() &&
+      !entry.isSymbolicLink() &&
+      permissions(entry.mode) === CREDENTIAL_DIRECTORY_MODE
+    );
+  } catch {
+    return false;
+  }
+}
+
+async function validTarget(path: string): Promise<boolean> {
+  try {
+    const entry = await lstat(path);
+    return (
+      entry.isFile() &&
+      !entry.isSymbolicLink() &&
+      entry.size > 0 &&
+      permissions(entry.mode) === CREDENTIAL_FILE_MODE
+    );
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "ENOENT";
+  }
+}
+
+export function createCredentialVault(options: CredentialVaultOptions): CredentialVault {
+  const runtimeReady = new Map<DesktopCredentialSlot, boolean>();
+
+  const readSlot = async (slot: DesktopCredentialSlot): Promise<ReadCredential> => {
+    const path = join(options.root, `${slot}.bin`);
+    let encrypted: Buffer | undefined;
+    try {
+      const directory = await lstat(options.root);
+      if (
+        !directory.isDirectory() ||
+        directory.isSymbolicLink() ||
+        permissions(directory.mode) !== CREDENTIAL_DIRECTORY_MODE
+      ) {
+        return { slot, state: "re-prompt", modifiedAt: 0 };
+      }
+      const entry = await lstat(path);
+      if (
+        !entry.isFile() ||
+        entry.isSymbolicLink() ||
+        entry.size === 0 ||
+        permissions(entry.mode) !== CREDENTIAL_FILE_MODE
+      ) {
+        return { slot, state: "re-prompt", modifiedAt: entry.mtimeMs };
+      }
+      encrypted = await readFile(path);
+      const value = options.encryption.decryptString(encrypted).trim();
+      if (value.length === 0) return { slot, state: "re-prompt", modifiedAt: entry.mtimeMs };
+      return { slot, state: "configured", value, modifiedAt: entry.mtimeMs };
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        return { slot, state: "missing", modifiedAt: 0 };
+      }
+      return { slot, state: "re-prompt", modifiedAt: 0 };
+    } finally {
+      encrypted?.fill(0);
+    }
+  };
+
+  const readAll = async (): Promise<readonly ReadCredential[]> => {
+    const entries: ReadCredential[] = [];
+    for (const slot of DESKTOP_CREDENTIAL_SLOTS) entries.push(await readSlot(slot));
+    return entries;
+  };
+
+  const reapplyConfigured = async (): Promise<void> => {
+    const entries = (await readAll())
+      .filter(
+        (entry): entry is ReadCredential & { readonly value: string } =>
+          entry.state === "configured" && entry.value !== undefined,
+      )
+      .sort((left, right) => left.modifiedAt - right.modifiedAt);
+    for (const entry of entries) {
+      try {
+        await options.applyCredential(entry.slot, entry.value);
+        runtimeReady.set(entry.slot, true);
+      } catch {
+        runtimeReady.set(entry.slot, false);
+      }
+    }
+  };
+
+  return {
+    async writeCredential(input): Promise<CredentialWriteResult> {
+      if (!isCredentialSlot(input?.slot) || typeof input.value !== "string") {
+        return {
+          slot: isCredentialSlot(input?.slot) ? input.slot : "anthropic",
+          status: "refused",
+          reason: "invalid-input",
+        };
+      }
+      const value = input.value.trim();
+      if (value.length === 0) {
+        return { slot: input.slot, status: "refused", reason: "invalid-input" };
+      }
+      try {
+        if (!options.encryption.isEncryptionAvailable()) {
+          return { slot: input.slot, status: "refused", reason: "encryption-unavailable" };
+        }
+        if (options.encryption.getSelectedStorageBackend?.() === UNSAFE_STORAGE_BACKEND) {
+          return { slot: input.slot, status: "refused", reason: "unsafe-backend" };
+        }
+      } catch {
+        return { slot: input.slot, status: "refused", reason: "encryption-unavailable" };
+      }
+      if (!(await secureDirectory(options.root))) {
+        return { slot: input.slot, status: "refused", reason: "storage-failed" };
+      }
+      const target = join(options.root, `${input.slot}.bin`);
+      if (!(await validTarget(target))) {
+        return { slot: input.slot, status: "refused", reason: "storage-failed" };
+      }
+      const temporary = join(options.root, `.${input.slot}.${randomUUID()}.tmp`);
+      let encrypted: Buffer | undefined;
+      let handle: Awaited<ReturnType<typeof open>> | undefined;
+      try {
+        encrypted = options.encryption.encryptString(value);
+        if (!Buffer.isBuffer(encrypted) || encrypted.length === 0) throw new TypeError();
+        handle = await open(temporary, "wx", CREDENTIAL_FILE_MODE);
+        await handle.writeFile(encrypted);
+        await handle.sync();
+        await handle.close();
+        handle = undefined;
+        await rename(temporary, target);
+        const directory = await open(options.root, "r");
+        try {
+          await directory.sync();
+        } finally {
+          await directory.close();
+        }
+      } catch {
+        try {
+          await handle?.close();
+        } catch {}
+        await rm(temporary, { force: true }).catch(() => undefined);
+        encrypted?.fill(0);
+        return { slot: input.slot, status: "refused", reason: "storage-failed" };
+      } finally {
+        encrypted?.fill(0);
+      }
+      try {
+        await options.applyCredential(input.slot, value);
+        runtimeReady.set(input.slot, true);
+        return { slot: input.slot, status: "configured", runtimeReady: true };
+      } catch {
+        runtimeReady.set(input.slot, false);
+        return { slot: input.slot, status: "refused", reason: "runtime-unavailable" };
+      }
+    },
+
+    async credentialStatuses(): Promise<readonly CredentialSlotStatus[]> {
+      const entries = await readAll();
+      return entries.map((entry) => ({
+        slot: entry.slot,
+        state: entry.state,
+        runtimeReady: entry.state === "configured" && runtimeReady.get(entry.slot) === true,
+      }));
+    },
+
+    reapplyConfigured,
+  };
+}

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1,8 +1,19 @@
 import { writeFile } from "node:fs/promises";
-import { dirname, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { app, BrowserWindow, ipcMain, session, utilityProcess } from "electron";
+import { connectCoachClient } from "@enduragent/coach-client";
+import {
+  app,
+  BrowserWindow,
+  dialog,
+  ipcMain,
+  safeStorage,
+  session,
+  utilityProcess,
+} from "electron";
 import { DESKTOP_CONNECTION_CHANNEL, DESKTOP_RENDERER_URL, DESKTOP_SCHEME } from "./constants.js";
+import { CREDENTIAL_DIRECTORY_NAME, createCredentialVault } from "./credential-vault.js";
+import { registerOnboardingIpc, runtimeConfigurationForCredential } from "./onboarding-ipc.js";
 import {
   desktopWindowOptions,
   hardenDesktopWindow,
@@ -51,6 +62,7 @@ async function runDesktop(): Promise<void> {
   let quitting = false;
   let protocolInstalled = false;
   let connectionHandlerInstalled = false;
+  let disposeOnboarding: (() => void) | undefined;
   let shutdownPromise: Promise<void> | undefined;
   const shutdown = (): Promise<void> => {
     shutdownPromise ??= (async () => {
@@ -59,6 +71,8 @@ async function runDesktop(): Promise<void> {
         ipcMain.removeHandler(DESKTOP_CONNECTION_CHANNEL);
         connectionHandlerInstalled = false;
       }
+      disposeOnboarding?.();
+      disposeOnboarding = undefined;
       if (protocolInstalled) {
         session.defaultSession.protocol.unhandle(DESKTOP_SCHEME);
         protocolInstalled = false;
@@ -84,6 +98,26 @@ async function runDesktop(): Promise<void> {
       return;
     }
     const daemonPort = Number(new URL(resolution.url).port);
+    const vault = createCredentialVault({
+      root: join(app.getPath("userData"), CREDENTIAL_DIRECTORY_NAME),
+      encryption: safeStorage,
+      async applyCredential(slot, value) {
+        const client = await connectCoachClient({ url: resolution.url, token: resolution.token });
+        try {
+          const request = runtimeConfigurationForCredential(slot, value);
+          const result = await client.call("configureRuntime", request);
+          if (
+            (request.llm !== undefined && !result.applied.llm) ||
+            (request.intervals !== undefined && !result.applied.intervals)
+          ) {
+            throw new TypeError();
+          }
+        } finally {
+          await client.close();
+        }
+      },
+    });
+    await vault.reapplyConfigured();
     await installDesktopProtocol({
       session: session.defaultSession,
       daemonPort,
@@ -106,6 +140,13 @@ async function runDesktop(): Promise<void> {
       return { url: resolution.url, token: resolution.token };
     });
     connectionHandlerInstalled = true;
+    disposeOnboarding = registerOnboardingIpc({
+      ipcMain,
+      dialog,
+      window,
+      vault,
+      isTrusted: (event) => isTrustedConnectionRequest(event, window),
+    });
     window.once("ready-to-show", () => window?.show());
     window.once("closed", () => {
       window = undefined;
@@ -130,9 +171,11 @@ async function runDesktop(): Promise<void> {
       while (document.documentElement.dataset.rpc === undefined && Date.now() < deadline) {
         await new Promise((resolve) => setTimeout(resolve, 20));
       }
+      const credentialStatuses = await window.enduragentAuth.credentialStatuses();
       return {
         url: location.href,
-        bridgeKeys: Object.keys(window.enduragentAuth ?? {}),
+        bridgeKeys: Object.keys(window.enduragentAuth ?? {}).sort(),
+        credentialStatuses,
         noNodeGlobals: ["process", "require", "Buffer", "global", "module"].every((key) => typeof window[key] === "undefined"),
         rpcConnected: document.documentElement.dataset.rpc === "connected",
         blockedOffPort: blocked,
@@ -159,6 +202,14 @@ async function runDesktop(): Promise<void> {
         rpcConnected: rendererResult.rpcConnected,
         blockedOffPort: rendererResult.blockedOffPort,
         drawerPresent: rendererResult.drawerPresent,
+        credentialStatuses: rendererResult.credentialStatuses,
+        credentialStatusesMetadataOnly:
+          Array.isArray(rendererResult.credentialStatuses) &&
+          rendererResult.credentialStatuses.every((entry: Record<string, unknown>) => {
+            const keys = Object.keys(entry).sort();
+            return JSON.stringify(keys) === JSON.stringify(["runtimeReady", "slot", "state"]);
+          }) &&
+          !JSON.stringify(rendererResult.credentialStatuses).includes(resolution.token),
         tokenAbsentInRendererSurfaces:
           !JSON.stringify(rendererResult.rendererSurfaces).includes(resolution.token) &&
           !consoleMessages.some((entry) => entry.includes(resolution.token)) &&

--- a/apps/desktop/src/main/onboarding-ipc.ts
+++ b/apps/desktop/src/main/onboarding-ipc.ts
@@ -1,0 +1,157 @@
+import { extname, isAbsolute } from "node:path";
+import type { ConfigureRuntimeRpcParams, LlmProvider } from "@enduragent/coach-contract";
+import type { BrowserWindow, IpcMain, IpcMainInvokeEvent, OpenDialogOptions } from "electron";
+import {
+  DESKTOP_CREDENTIAL_SLOTS,
+  type CredentialSlotStatus,
+  type CredentialVault,
+  type CredentialWriteResult,
+  type DesktopCredentialSlot,
+} from "./credential-vault.js";
+
+export const DESKTOP_CREDENTIAL_STATUS_CHANNEL = "enduragent:onboarding:credential-status" as const;
+export const DESKTOP_CREDENTIAL_WRITE_CHANNEL = "enduragent:onboarding:credential-write" as const;
+export const DESKTOP_CHOOSE_IMPORT_FILES_CHANNEL =
+  "enduragent:onboarding:choose-import-files" as const;
+
+export interface OnboardingDialogPort {
+  showOpenDialog(
+    window: BrowserWindow,
+    options: OpenDialogOptions,
+  ): Promise<{ readonly canceled: boolean; readonly filePaths: readonly string[] }>;
+}
+
+interface RegisterOnboardingIpcOptions {
+  readonly ipcMain: IpcMain;
+  readonly dialog: OnboardingDialogPort;
+  readonly window: BrowserWindow;
+  readonly vault: CredentialVault;
+  readonly isTrusted: (event: IpcMainInvokeEvent) => boolean;
+}
+
+const SUPPORTED_EXTENSIONS = new Set([".fit", ".tcx", ".gpx"]);
+
+const DEFAULT_MODEL_BY_SLOT: Readonly<
+  Record<Exclude<DesktopCredentialSlot, "intervals-icu">, string>
+> = {
+  anthropic: "claude-sonnet-4-6",
+  openrouter: "deepseek/deepseek-v4-flash",
+  openai: "gpt-5.5",
+  google: "gemini-3.5-flash",
+  deepseek: "deepseek-v4-flash",
+  qwen: "qwen3.5-plus",
+  minimax: "MiniMax-M2.7",
+  kimi: "kimi-k2.6",
+  zai: "glm-4.7",
+};
+
+export function runtimeConfigurationForCredential(
+  slot: DesktopCredentialSlot,
+  value: string,
+): ConfigureRuntimeRpcParams {
+  if (slot === "intervals-icu") {
+    return { intervals: { api_key: value, athlete_id: "0" } };
+  }
+  return {
+    llm: {
+      provider: slot satisfies LlmProvider,
+      model: DEFAULT_MODEL_BY_SLOT[slot],
+      api_key: value,
+    },
+  };
+}
+
+function isSlot(value: unknown): value is DesktopCredentialSlot {
+  return (
+    typeof value === "string" && (DESKTOP_CREDENTIAL_SLOTS as readonly string[]).includes(value)
+  );
+}
+
+function parseWriteInput(value: unknown): {
+  readonly slot: DesktopCredentialSlot;
+  readonly value: string;
+} {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) throw new TypeError();
+  const input = value as Record<string, unknown>;
+  if (
+    Object.keys(input).length !== 2 ||
+    !Object.hasOwn(input, "slot") ||
+    !Object.hasOwn(input, "value") ||
+    !isSlot(input.slot) ||
+    typeof input.value !== "string"
+  ) {
+    throw new TypeError();
+  }
+  return { slot: input.slot, value: input.value };
+}
+
+function minimizeStatuses(value: readonly CredentialSlotStatus[]): readonly CredentialSlotStatus[] {
+  return value.map((entry) => ({
+    slot: entry.slot,
+    state: entry.state,
+    runtimeReady: entry.runtimeReady,
+  }));
+}
+
+function minimizeWrite(value: CredentialWriteResult): CredentialWriteResult {
+  if (value.status === "configured") {
+    return { slot: value.slot, status: "configured", runtimeReady: true };
+  }
+  return { slot: value.slot, status: "refused", reason: value.reason };
+}
+
+export function registerOnboardingIpc(options: RegisterOnboardingIpcOptions): () => void {
+  const requireTrusted = (event: IpcMainInvokeEvent): void => {
+    if (!options.isTrusted(event)) throw new TypeError();
+  };
+  options.ipcMain.handle(DESKTOP_CREDENTIAL_STATUS_CHANNEL, async (event, ...args) => {
+    requireTrusted(event);
+    if (args.length !== 0) throw new TypeError();
+    try {
+      await options.vault.reapplyConfigured();
+      return minimizeStatuses(await options.vault.credentialStatuses());
+    } catch {
+      return DESKTOP_CREDENTIAL_SLOTS.map((slot) => ({
+        slot,
+        state: "re-prompt" as const,
+        runtimeReady: false,
+      }));
+    }
+  });
+  options.ipcMain.handle(DESKTOP_CREDENTIAL_WRITE_CHANNEL, async (event, ...args) => {
+    requireTrusted(event);
+    if (args.length !== 1) throw new TypeError();
+    const input = parseWriteInput(args[0]);
+    try {
+      return minimizeWrite(await options.vault.writeCredential(input));
+    } catch {
+      return { slot: input.slot, status: "refused", reason: "storage-failed" };
+    }
+  });
+  options.ipcMain.handle(DESKTOP_CHOOSE_IMPORT_FILES_CHANNEL, async (event, ...args) => {
+    requireTrusted(event);
+    if (args.length !== 0) throw new TypeError();
+    let result: Awaited<ReturnType<OnboardingDialogPort["showOpenDialog"]>>;
+    try {
+      result = await options.dialog.showOpenDialog(options.window, {
+        properties: ["openFile", "multiSelections"],
+        filters: [{ name: "Ride files", extensions: ["fit", "tcx", "gpx"] }],
+      });
+    } catch {
+      return [];
+    }
+    if (result.canceled) return [];
+    return result.filePaths.filter(
+      (path) =>
+        typeof path === "string" &&
+        path.length <= 4_096 &&
+        isAbsolute(path) &&
+        SUPPORTED_EXTENSIONS.has(extname(path).toLowerCase()),
+    );
+  });
+  return () => {
+    options.ipcMain.removeHandler(DESKTOP_CREDENTIAL_STATUS_CHANNEL);
+    options.ipcMain.removeHandler(DESKTOP_CREDENTIAL_WRITE_CHANNEL);
+    options.ipcMain.removeHandler(DESKTOP_CHOOSE_IMPORT_FILES_CHANNEL);
+  };
+}

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -1,9 +1,146 @@
-import { contextBridge, ipcRenderer } from "electron";
+import { contextBridge, ipcRenderer, webUtils } from "electron";
 import { DESKTOP_CONNECTION_CHANNEL } from "../main/constants.js";
+
+const DESKTOP_CREDENTIAL_STATUS_CHANNEL = "enduragent:onboarding:credential-status";
+const DESKTOP_CREDENTIAL_WRITE_CHANNEL = "enduragent:onboarding:credential-write";
+const DESKTOP_CHOOSE_IMPORT_FILES_CHANNEL = "enduragent:onboarding:choose-import-files";
+
+const SLOTS = new Set([
+  "anthropic",
+  "openrouter",
+  "openai",
+  "google",
+  "deepseek",
+  "qwen",
+  "minimax",
+  "kimi",
+  "zai",
+  "intervals-icu",
+]);
+const STATES = new Set(["missing", "configured", "re-prompt"]);
+const REASONS = new Set([
+  "invalid-input",
+  "encryption-unavailable",
+  "unsafe-backend",
+  "storage-failed",
+  "runtime-unavailable",
+]);
+const IMPORT_EXTENSIONS = new Set([".fit", ".tcx", ".gpx"]);
+
+function record(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function exactKeys(value: Record<string, unknown>, keys: readonly string[]): boolean {
+  return JSON.stringify(Object.keys(value).sort()) === JSON.stringify([...keys].sort());
+}
+
+function parseStatuses(value: unknown): unknown {
+  if (
+    !Array.isArray(value) ||
+    value.length !== SLOTS.size ||
+    new Set(value.map((entry) => (record(entry) ? entry.slot : undefined))).size !== SLOTS.size
+  ) {
+    throw new TypeError();
+  }
+  return value.map((entry) => {
+    if (
+      !record(entry) ||
+      !exactKeys(entry, ["slot", "state", "runtimeReady"]) ||
+      !SLOTS.has(entry.slot as string) ||
+      !STATES.has(entry.state as string) ||
+      typeof entry.runtimeReady !== "boolean"
+    ) {
+      throw new TypeError();
+    }
+    return { slot: entry.slot, state: entry.state, runtimeReady: entry.runtimeReady };
+  });
+}
+
+function parseWriteResult(value: unknown): unknown {
+  if (!record(value) || !SLOTS.has(value.slot as string)) throw new TypeError();
+  if (
+    value.status === "configured" &&
+    exactKeys(value, ["slot", "status", "runtimeReady"]) &&
+    value.runtimeReady === true
+  ) {
+    return { slot: value.slot, status: "configured", runtimeReady: true };
+  }
+  if (
+    value.status === "refused" &&
+    exactKeys(value, ["slot", "status", "reason"]) &&
+    REASONS.has(value.reason as string)
+  ) {
+    return { slot: value.slot, status: "refused", reason: value.reason };
+  }
+  throw new TypeError();
+}
+
+function parsePaths(value: unknown): readonly string[] {
+  if (!Array.isArray(value) || value.length > 256) {
+    throw new TypeError();
+  }
+  const paths = value.map((path) => {
+    if (
+      typeof path !== "string" ||
+      path.length === 0 ||
+      path.length > 4_096 ||
+      !path.startsWith("/") ||
+      path.includes("\0")
+    ) {
+      throw new TypeError();
+    }
+    const slash = path.lastIndexOf("/");
+    const dot = path.lastIndexOf(".");
+    if (dot <= slash || !IMPORT_EXTENSIONS.has(path.slice(dot).toLowerCase())) {
+      throw new TypeError();
+    }
+    return path;
+  });
+  if (new Set(paths).size !== paths.length) throw new TypeError();
+  return paths;
+}
+
+let dropDisposer: (() => void) | undefined;
 
 contextBridge.exposeInMainWorld(
   "enduragentAuth",
   Object.freeze({
     getDaemonConnection: () => ipcRenderer.invoke(DESKTOP_CONNECTION_CHANNEL),
+    credentialStatuses: async () =>
+      parseStatuses(await ipcRenderer.invoke(DESKTOP_CREDENTIAL_STATUS_CHANNEL)),
+    writeCredential: async (input: unknown) => {
+      if (
+        !record(input) ||
+        !exactKeys(input, ["slot", "value"]) ||
+        !SLOTS.has(input.slot as string) ||
+        typeof input.value !== "string"
+      ) {
+        throw new TypeError();
+      }
+      return parseWriteResult(await ipcRenderer.invoke(DESKTOP_CREDENTIAL_WRITE_CHANNEL, input));
+    },
+    chooseImportFiles: async () =>
+      parsePaths(await ipcRenderer.invoke(DESKTOP_CHOOSE_IMPORT_FILES_CHANNEL)),
+    onDroppedImportFiles: (listener: unknown) => {
+      if (typeof listener !== "function" || dropDisposer !== undefined) throw new TypeError();
+      const onDrop = (event: DragEvent): void => {
+        event.preventDefault();
+        const paths = Array.from(event.dataTransfer?.files ?? [])
+          .map((file) => webUtils.getPathForFile(file))
+          .filter((path) => path.length > 0);
+        if (paths.length > 0) listener(paths);
+      };
+      const onDragOver = (event: DragEvent): void => event.preventDefault();
+      window.addEventListener("dragover", onDragOver);
+      window.addEventListener("drop", onDrop);
+      const dispose = (): void => {
+        window.removeEventListener("dragover", onDragOver);
+        window.removeEventListener("drop", onDrop);
+        if (dropDisposer === dispose) dropDisposer = undefined;
+      };
+      dropDisposer = dispose;
+      return dispose;
+    },
   }),
 );

--- a/apps/desktop/tests/credential-vault.test.ts
+++ b/apps/desktop/tests/credential-vault.test.ts
@@ -1,0 +1,233 @@
+import {
+  chmod,
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  CREDENTIAL_DIRECTORY_MODE,
+  CREDENTIAL_FILE_MODE,
+  createCredentialVault,
+  type CredentialEncryptionPort,
+} from "../src/main/credential-vault.js";
+
+const roots: string[] = [];
+
+async function temporaryRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "desktop-vault-"));
+  roots.push(root);
+  return join(root, "credentials-v1");
+}
+
+function encryption(): CredentialEncryptionPort {
+  return {
+    isEncryptionAvailable: () => true,
+    encryptString: (value) =>
+      Buffer.concat([Buffer.from("SAFE:"), Buffer.from(value).reverse(), Buffer.from(":END")]),
+    decryptString(value) {
+      if (
+        !value.subarray(0, 5).equals(Buffer.from("SAFE:")) ||
+        !value.subarray(-4).equals(Buffer.from(":END"))
+      ) {
+        throw new TypeError();
+      }
+      return value.subarray(5, -4).reverse().toString();
+    },
+  };
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("desktop credential vault", () => {
+  it("refuses unavailable encryption and invalid input before filesystem work", async () => {
+    const root = await temporaryRoot();
+    const encryptString = vi.fn(() => Buffer.from("unused"));
+    const vault = createCredentialVault({
+      root,
+      encryption: { isEncryptionAvailable: () => false, encryptString, decryptString: vi.fn() },
+      applyCredential: vi.fn(),
+    });
+    await expect(vault.writeCredential({ slot: "anthropic", value: "synthetic" })).resolves.toEqual(
+      {
+        slot: "anthropic",
+        status: "refused",
+        reason: "encryption-unavailable",
+      },
+    );
+    await expect(vault.writeCredential({ slot: "anthropic", value: "  " })).resolves.toEqual({
+      slot: "anthropic",
+      status: "refused",
+      reason: "invalid-input",
+    });
+    await expect(
+      vault.writeCredential({ slot: "unknown", value: "synthetic" } as never),
+    ).resolves.toEqual({
+      slot: "anthropic",
+      status: "refused",
+      reason: "invalid-input",
+    });
+    expect(encryptString).not.toHaveBeenCalled();
+    await expect(lstat(root)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("accepts the macOS encryption shape and writes one atomic secure ciphertext", async () => {
+    const root = await temporaryRoot();
+    const sentinel = "desktop-sentinel-model-key";
+    const applyCredential = vi.fn(async () => {
+      const committed = await readFile(join(root, "anthropic.bin"));
+      expect(committed.length).toBeGreaterThan(0);
+      expect(committed.includes(Buffer.from(sentinel))).toBe(false);
+      expect((await readdir(root)).filter((entry) => entry.endsWith(".tmp"))).toEqual([]);
+    });
+    const vault = createCredentialVault({ root, encryption: encryption(), applyCredential });
+    await expect(
+      vault.writeCredential({ slot: "anthropic", value: ` ${sentinel} ` }),
+    ).resolves.toEqual({
+      slot: "anthropic",
+      status: "configured",
+      runtimeReady: true,
+    });
+    const directory = await lstat(root);
+    const path = join(root, "anthropic.bin");
+    const file = await lstat(path);
+    const ciphertext = await readFile(path);
+    expect(directory.mode & 0o777).toBe(CREDENTIAL_DIRECTORY_MODE);
+    expect(file.mode & 0o777).toBe(CREDENTIAL_FILE_MODE);
+    expect(ciphertext.length).toBeGreaterThan(0);
+    expect(ciphertext.includes(Buffer.from(sentinel))).toBe(false);
+    expect(await readdir(root)).toEqual(["anthropic.bin"]);
+    expect(applyCredential).toHaveBeenCalledWith("anthropic", sentinel);
+    await expect(vault.credentialStatuses()).resolves.toContainEqual({
+      slot: "anthropic",
+      state: "configured",
+      runtimeReady: true,
+    });
+  });
+
+  it("fails closed for insecure directories and targets", async () => {
+    const root = await temporaryRoot();
+    await mkdir(root, { mode: 0o755 });
+    const vault = createCredentialVault({
+      root,
+      encryption: encryption(),
+      applyCredential: vi.fn(),
+    });
+    await expect(
+      vault.writeCredential({ slot: "anthropic", value: "synthetic" }),
+    ).resolves.toMatchObject({
+      status: "refused",
+      reason: "storage-failed",
+    });
+    await chmod(root, 0o700);
+    await symlink(join(root, "missing"), join(root, "anthropic.bin"));
+    await expect(
+      vault.writeCredential({ slot: "anthropic", value: "synthetic" }),
+    ).resolves.toMatchObject({
+      status: "refused",
+      reason: "storage-failed",
+    });
+    await rm(join(root, "anthropic.bin"));
+    await writeFile(join(root, "anthropic.bin"), "", { mode: 0o600 });
+    await expect(
+      vault.writeCredential({ slot: "anthropic", value: "synthetic" }),
+    ).resolves.toMatchObject({
+      status: "refused",
+      reason: "storage-failed",
+    });
+    await rm(join(root, "anthropic.bin"));
+    await mkdir(join(root, "anthropic.bin"), { mode: 0o700 });
+    await expect(
+      vault.writeCredential({ slot: "anthropic", value: "synthetic" }),
+    ).resolves.toMatchObject({
+      status: "refused",
+      reason: "storage-failed",
+    });
+    await rm(join(root, "anthropic.bin"), { recursive: true });
+    await writeFile(join(root, "anthropic.bin"), "ciphertext", { mode: 0o644 });
+    await expect(
+      vault.writeCredential({ slot: "anthropic", value: "synthetic" }),
+    ).resolves.toMatchObject({
+      status: "refused",
+      reason: "storage-failed",
+    });
+  });
+
+  it("minimizes encryption backend failures without touching storage", async () => {
+    const root = await temporaryRoot();
+    const encryptString = vi.fn(() => Buffer.from("unused"));
+    const vault = createCredentialVault({
+      root,
+      encryption: {
+        isEncryptionAvailable: () => {
+          throw new TypeError("synthetic backend detail");
+        },
+        encryptString,
+        decryptString: vi.fn(),
+      },
+      applyCredential: vi.fn(),
+    });
+    await expect(
+      vault.writeCredential({ slot: "anthropic", value: "synthetic-secret" }),
+    ).resolves.toEqual({
+      slot: "anthropic",
+      status: "refused",
+      reason: "encryption-unavailable",
+    });
+    expect(encryptString).not.toHaveBeenCalled();
+    await expect(lstat(root)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("isolates corruption and retries a committed runtime failure in main", async () => {
+    const root = await temporaryRoot();
+    let failRuntime = false;
+    const applied: string[] = [];
+    const vault = createCredentialVault({
+      root,
+      encryption: encryption(),
+      async applyCredential(slot) {
+        if (failRuntime) throw new TypeError();
+        applied.push(slot);
+      },
+    });
+    await vault.writeCredential({ slot: "anthropic", value: "synthetic-one" });
+    await vault.writeCredential({ slot: "openrouter", value: "synthetic-two" });
+    failRuntime = true;
+    await expect(
+      vault.writeCredential({ slot: "google", value: "synthetic-three" }),
+    ).resolves.toEqual({
+      slot: "google",
+      status: "refused",
+      reason: "runtime-unavailable",
+    });
+    expect((await lstat(join(root, "google.bin"))).isFile()).toBe(true);
+    const corrupted = await readFile(join(root, "anthropic.bin"));
+    corrupted[0] = corrupted[0]! ^ 0xff;
+    await writeFile(join(root, "anthropic.bin"), corrupted, { mode: 0o600 });
+    const statuses = await vault.credentialStatuses();
+    expect(statuses).toContainEqual({ slot: "anthropic", state: "re-prompt", runtimeReady: false });
+    expect(statuses).toContainEqual({
+      slot: "openrouter",
+      state: "configured",
+      runtimeReady: true,
+    });
+    expect(statuses).toContainEqual({ slot: "google", state: "configured", runtimeReady: false });
+    failRuntime = false;
+    await vault.reapplyConfigured();
+    expect(await vault.credentialStatuses()).toContainEqual({
+      slot: "google",
+      state: "configured",
+      runtimeReady: true,
+    });
+    expect(applied).toContain("google");
+  });
+});

--- a/apps/desktop/tests/onboarding-ipc.test.ts
+++ b/apps/desktop/tests/onboarding-ipc.test.ts
@@ -1,0 +1,155 @@
+import type { IpcMainInvokeEvent } from "electron";
+import { describe, expect, it, vi } from "vitest";
+import {
+  DESKTOP_CHOOSE_IMPORT_FILES_CHANNEL,
+  DESKTOP_CREDENTIAL_STATUS_CHANNEL,
+  DESKTOP_CREDENTIAL_WRITE_CHANNEL,
+  registerOnboardingIpc,
+  runtimeConfigurationForCredential,
+} from "../src/main/onboarding-ipc.js";
+import type { CredentialVault } from "../src/main/credential-vault.js";
+
+type Handler = (event: IpcMainInvokeEvent, ...args: unknown[]) => unknown;
+
+function harness() {
+  const handlers = new Map<string, Handler>();
+  const ipcMain = {
+    handle: vi.fn((channel: string, handler: Handler) => handlers.set(channel, handler)),
+    removeHandler: vi.fn((channel: string) => handlers.delete(channel)),
+  };
+  const vault: CredentialVault = {
+    writeCredential: vi.fn(async (input) => ({
+      slot: input.slot,
+      status: "configured" as const,
+      runtimeReady: true as const,
+    })),
+    credentialStatuses: vi.fn(async () => [
+      { slot: "anthropic" as const, state: "configured" as const, runtimeReady: true },
+    ]),
+    reapplyConfigured: vi.fn(async () => {}),
+  };
+  const dialog = {
+    showOpenDialog: vi.fn(async () => ({
+      canceled: false,
+      filePaths: ["/synthetic/ride.fit", "/synthetic/ride.txt", "relative.tcx"],
+    })),
+  };
+  const trustedEvent = {} as IpcMainInvokeEvent;
+  const dispose = registerOnboardingIpc({
+    ipcMain: ipcMain as never,
+    dialog,
+    window: {} as never,
+    vault,
+    isTrusted: (event) => event === trustedEvent,
+  });
+  const invoke = (channel: string, event: IpcMainInvokeEvent, ...args: unknown[]) =>
+    handlers.get(channel)!(event, ...args);
+  return { handlers, ipcMain, vault, dialog, trustedEvent, dispose, invoke };
+}
+
+describe("desktop onboarding IPC", () => {
+  it("maps each credential slot to the landed runtime request", () => {
+    expect(runtimeConfigurationForCredential("anthropic", "synthetic")).toEqual({
+      llm: { provider: "anthropic", model: "claude-sonnet-4-6", api_key: "synthetic" },
+    });
+    expect(runtimeConfigurationForCredential("openrouter", "synthetic")).toEqual({
+      llm: {
+        provider: "openrouter",
+        model: "deepseek/deepseek-v4-flash",
+        api_key: "synthetic",
+      },
+    });
+    expect(runtimeConfigurationForCredential("intervals-icu", "synthetic")).toEqual({
+      intervals: { api_key: "synthetic", athlete_id: "0" },
+    });
+  });
+
+  it("registers only semantic onboarding channels and returns metadata", async () => {
+    const subject = harness();
+    expect([...subject.handlers.keys()].sort()).toEqual(
+      [
+        DESKTOP_CREDENTIAL_STATUS_CHANNEL,
+        DESKTOP_CREDENTIAL_WRITE_CHANNEL,
+        DESKTOP_CHOOSE_IMPORT_FILES_CHANNEL,
+      ].sort(),
+    );
+    await expect(
+      subject.invoke(DESKTOP_CREDENTIAL_STATUS_CHANNEL, subject.trustedEvent),
+    ).resolves.toEqual([{ slot: "anthropic", state: "configured", runtimeReady: true }]);
+    expect(subject.vault.reapplyConfigured).toHaveBeenCalledTimes(1);
+    expect(
+      JSON.stringify(await subject.invoke(DESKTOP_CREDENTIAL_STATUS_CHANNEL, subject.trustedEvent)),
+    ).not.toContain("value");
+  });
+
+  it("validates trusted senders and exact credential inputs before dispatch", async () => {
+    const subject = harness();
+    await expect(
+      subject.invoke(DESKTOP_CREDENTIAL_WRITE_CHANNEL, {} as IpcMainInvokeEvent, {
+        slot: "anthropic",
+        value: "synthetic",
+      }),
+    ).rejects.toBeInstanceOf(TypeError);
+    await expect(
+      subject.invoke(DESKTOP_CREDENTIAL_WRITE_CHANNEL, subject.trustedEvent, {
+        slot: "unknown",
+        value: "synthetic",
+      }),
+    ).rejects.toBeInstanceOf(TypeError);
+    await expect(
+      subject.invoke(DESKTOP_CREDENTIAL_WRITE_CHANNEL, subject.trustedEvent, {
+        slot: "anthropic",
+        value: "synthetic",
+        extra: true,
+      }),
+    ).rejects.toBeInstanceOf(TypeError);
+    await expect(
+      subject.invoke(DESKTOP_CREDENTIAL_WRITE_CHANNEL, subject.trustedEvent, {
+        slot: "anthropic",
+        value: "synthetic",
+      }),
+    ).resolves.toEqual({ slot: "anthropic", status: "configured", runtimeReady: true });
+    expect(subject.vault.writeCredential).toHaveBeenCalledTimes(1);
+  });
+
+  it("minimizes failures without exposing raw errors", async () => {
+    const subject = harness();
+    vi.mocked(subject.vault.writeCredential).mockResolvedValueOnce({
+      slot: "anthropic",
+      status: "refused",
+      reason: "runtime-unavailable",
+    });
+    const result = await subject.invoke(DESKTOP_CREDENTIAL_WRITE_CHANNEL, subject.trustedEvent, {
+      slot: "anthropic",
+      value: "synthetic",
+    });
+    expect(result).toEqual({
+      slot: "anthropic",
+      status: "refused",
+      reason: "runtime-unavailable",
+    });
+    expect(Object.keys(result as object)).toEqual(["slot", "status", "reason"]);
+  });
+
+  it("uses the bounded native chooser and filters its result", async () => {
+    const subject = harness();
+    await expect(
+      subject.invoke(DESKTOP_CHOOSE_IMPORT_FILES_CHANNEL, subject.trustedEvent),
+    ).resolves.toEqual(["/synthetic/ride.fit"]);
+    expect(subject.dialog.showOpenDialog).toHaveBeenCalledWith(expect.anything(), {
+      properties: ["openFile", "multiSelections"],
+      filters: [{ name: "Ride files", extensions: ["fit", "tcx", "gpx"] }],
+    });
+    subject.dialog.showOpenDialog.mockResolvedValueOnce({ canceled: true, filePaths: [] });
+    await expect(
+      subject.invoke(DESKTOP_CHOOSE_IMPORT_FILES_CHANNEL, subject.trustedEvent),
+    ).resolves.toEqual([]);
+  });
+
+  it("disposes only its three handlers", () => {
+    const subject = harness();
+    subject.dispose();
+    expect(subject.handlers.size).toBe(0);
+    expect(subject.ipcMain.removeHandler).toHaveBeenCalledTimes(3);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,6 +83,9 @@ importers:
       '@enduragent/coach':
         specifier: workspace:*
         version: link:../../packages/coach
+      '@enduragent/coach-client':
+        specifier: workspace:*
+        version: link:../../packages/coach-client
       '@enduragent/coach-contract':
         specifier: workspace:*
         version: link:../../packages/coach-contract

--- a/tools/check-package-deps.test.ts
+++ b/tools/check-package-deps.test.ts
@@ -313,14 +313,13 @@ describe("R6 desktop renderer", () => {
 });
 
 describe("R8 desktop app", () => {
-  it("allows only coach and coach-contract workspace edges", () => {
+  it("allows only coach, coach-client, and coach-contract workspace edges", () => {
     write(
       "apps/desktop/src/ok.ts",
-      `import { run } from "@enduragent/coach";\nimport { PROTOCOL_VERSION } from "@enduragent/coach-contract";\nexport const value = [run, PROTOCOL_VERSION];\n`,
+      `import { run } from "@enduragent/coach";\nimport { connectCoachClient } from "@enduragent/coach-client";\nimport { PROTOCOL_VERSION } from "@enduragent/coach-contract";\nexport const value = [run, connectCoachClient, PROTOCOL_VERSION];\n`,
     );
     expect(violationsFor(rDesktop)).toBe(0);
     for (const [index, dependency] of [
-      "@enduragent/coach-client",
       "@enduragent/core",
       "@enduragent/engine",
       "@enduragent/kernel",
@@ -333,7 +332,7 @@ describe("R8 desktop app", () => {
         `import value from "${dependency}";\nexport { value };\n`,
       );
     }
-    expect(violationsFor(rDesktop)).toBe(7);
+    expect(violationsFor(rDesktop)).toBe(6);
   });
 });
 

--- a/tools/check-package-deps.ts
+++ b/tools/check-package-deps.ts
@@ -61,7 +61,7 @@ const COMPOSITION_ROOT_ALLOWED: readonly string[] = [
   "@enduragent/sport-*",
 ];
 
-const DESKTOP_APP_ALLOWED: readonly string[] = ["@enduragent/coach", "@enduragent/coach-contract"];
+const DESKTOP_APP_ALLOWED: readonly string[] = ["@enduragent/coach", "@enduragent/coach-client", "@enduragent/coach-contract"];
 
 const LEGACY_BINARY_ALLOWED: readonly string[] = ["@enduragent/core", "@enduragent/sport-*"];
 


### PR DESCRIPTION
## Summary

- add a chat-first desktop onboarding wizard for model credentials, intervals.icu, ride-file imports, and cycling intake
- encrypt credentials with macOS safe storage and recover from unreadable ciphertext by asking for the affected key again
- keep imports and intake persistence behind the authenticated daemon operations, with no renderer access to the store

## Verification

- focused desktop main, preload, and renderer tests
- packaged macOS safe-storage round-trip and corruption check
- renderer security and dependency-boundary checks
- canonical workspace checks and full test suite
