### PR TITLE
feat(desktop): add backfill progress and conversation entry

### DIFF
--- a/.changeset/desktop-backfill-conversation.md
+++ b/.changeset/desktop-backfill-conversation.md
@@ -1,0 +1,7 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Added training-history sync progress and a ready-to-use coaching conversation to the desktop app.
+
+The daemon now resumes full-history sync through the existing writer before refreshing current athlete state, while the desktop renders validated progress and focuses the ordinary coaching composer when the full refresh succeeds.

--- a/apps/desktop-renderer/src/first-sync.ts
+++ b/apps/desktop-renderer/src/first-sync.ts
@@ -1,0 +1,174 @@
+import { CoachClientDisconnectedError, CoachClientProtocolError } from "@enduragent/coach-client";
+import type {
+  CoachOperationProgressNotificationEnvelope,
+  SyncRpcResult,
+} from "@enduragent/coach-contract";
+import type { OnboardingCompletion } from "./onboarding/machine.js";
+
+export type FirstSyncState =
+  | { readonly status: "idle" }
+  | { readonly status: "syncing" }
+  | { readonly status: "ready" }
+  | {
+      readonly status: "failed";
+      readonly kind: "operation" | "disconnected" | "protocol";
+      readonly retryable: boolean;
+    };
+
+export interface FirstSyncCallOptions {
+  readonly onNotificationEnvelope: (envelope: CoachOperationProgressNotificationEnvelope) => void;
+}
+
+export interface FirstSyncPorts {
+  callSync(options: FirstSyncCallOptions): Promise<SyncRpcResult>;
+  focusComposer(): void;
+  render(state: FirstSyncState): void;
+}
+
+export interface FirstSyncController {
+  start(completion: OnboardingCompletion): Promise<void>;
+  retry(): Promise<void>;
+  dispose(): void;
+}
+
+function validCompletion(value: unknown): value is OnboardingCompletion {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const candidate = value as Record<string, unknown>;
+  const keys = Object.keys(candidate).sort();
+  return (
+    keys.join(",") === "intakeSaved,providerConfigured,trainingDataConfigured" &&
+    candidate.providerConfigured === true &&
+    candidate.trainingDataConfigured === true &&
+    candidate.intakeSaved === true
+  );
+}
+
+export function createFirstSyncController(ports: FirstSyncPorts): FirstSyncController {
+  let state: FirstSyncState = { status: "idle" };
+  let epoch = 0;
+  let inFlight: Promise<void> | undefined;
+  let disposed = false;
+  let composerFocused = false;
+
+  const render = (next: FirstSyncState): void => {
+    state = next;
+    ports.render(state);
+  };
+
+  const begin = (): Promise<void> => {
+    const selectedEpoch = ++epoch;
+    render({ status: "syncing" });
+    let progress = 0;
+    let requestId: string | number | undefined;
+    let protocolFault = false;
+    let settled = false;
+
+    const failProtocol = (): void => {
+      if (disposed || selectedEpoch !== epoch) return;
+      protocolFault = true;
+      if (settled) render({ status: "failed", kind: "protocol", retryable: false });
+    };
+
+    const task = (async () => {
+      let result: SyncRpcResult | undefined;
+      let failure: unknown;
+      try {
+        result = await ports.callSync({
+          onNotificationEnvelope(envelope) {
+            if (disposed || selectedEpoch !== epoch) return;
+            if (settled) {
+              failProtocol();
+              return;
+            }
+            if (
+              envelope.jsonrpc !== "2.0" ||
+              envelope.method !== "coach.operationProgress" ||
+              envelope.params.requestMethod !== "sync"
+            ) {
+              failProtocol();
+              return;
+            }
+            const event = envelope.params.event;
+            if (progress === 0) {
+              if (event.phase !== "started" || event.completed !== 0 || event.total !== 1) {
+                failProtocol();
+                return;
+              }
+              requestId = envelope.params.requestId;
+              progress = 1;
+              return;
+            }
+            if (
+              progress !== 1 ||
+              envelope.params.requestId !== requestId ||
+              event.phase !== "completed" ||
+              event.completed !== 1 ||
+              event.total !== 1
+            ) {
+              failProtocol();
+              return;
+            }
+            progress = 2;
+          },
+        });
+      } catch (error) {
+        failure = error;
+      }
+      if (disposed || selectedEpoch !== epoch) return;
+      settled = true;
+      if (protocolFault || failure instanceof CoachClientProtocolError) {
+        render({ status: "failed", kind: "protocol", retryable: false });
+        return;
+      }
+      if (failure !== undefined) {
+        render({
+          status: "failed",
+          kind: failure instanceof CoachClientDisconnectedError ? "disconnected" : "operation",
+          retryable: true,
+        });
+        return;
+      }
+      if (progress !== 2) {
+        render({ status: "failed", kind: "protocol", retryable: false });
+        return;
+      }
+      if (result?.published !== true || result.referenceSucceeded !== true) {
+        render({ status: "failed", kind: "operation", retryable: true });
+        return;
+      }
+      render({ status: "ready" });
+      if (!composerFocused) {
+        composerFocused = true;
+        ports.focusComposer();
+      }
+    })();
+    inFlight = task;
+    void task
+      .finally(() => {
+        if (inFlight === task) inFlight = undefined;
+      })
+      .catch(() => {});
+    return task;
+  };
+
+  return {
+    start(completion) {
+      if (!validCompletion(completion)) return Promise.reject(new TypeError("Invalid completion."));
+      if (disposed) return Promise.resolve();
+      if (inFlight !== undefined) return inFlight;
+      if (state.status === "idle" || state.status === "ready") return begin();
+      return Promise.resolve();
+    },
+    retry() {
+      if (disposed || inFlight !== undefined || state.status !== "failed" || !state.retryable) {
+        return inFlight ?? Promise.resolve();
+      }
+      return begin();
+    },
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      epoch += 1;
+    },
+  };
+}

--- a/apps/desktop-renderer/src/index.ts
+++ b/apps/desktop-renderer/src/index.ts
@@ -9,6 +9,7 @@ import type { TurnEvent } from "@enduragent/coach-contract";
 import { createOnboardingBridge } from "./onboarding/bridge.js";
 import { mountOnboarding } from "./onboarding/mount.js";
 import "./onboarding/onboarding.css";
+import { createFirstSyncController, type FirstSyncState } from "./first-sync.js";
 import { createChatTurn, reduceChatTurn, type ChatTurnState } from "./turn-state.js";
 
 const DESKTOP_CHAT_ID = "desktop" as const;
@@ -20,20 +21,7 @@ const drawer = document.querySelector<HTMLElement>(".drawer")!;
 const drawerToggle = document.querySelector<HTMLButtonElement>(".drawer-toggle")!;
 const drawerClose = document.querySelector<HTMLButtonElement>(".drawer-close")!;
 const topbar = document.querySelector<HTMLElement>(".topbar")!;
-
-const setup = document.createElement("button");
-setup.type = "button";
-setup.className = "setup-button";
-setup.textContent = "Setup";
-topbar.insertBefore(setup, topbar.lastElementChild);
-const onboarding = mountOnboarding({
-  document,
-  bridge: createOnboardingBridge(),
-  opener: setup,
-  onComplete: () => message.focus(),
-});
-setup.addEventListener("click", () => void onboarding.open());
-void onboarding.open();
+thread.closest("main")?.classList.add("desktop-shell");
 
 let connectionMaterialPromise: ReturnType<EnduragentAuth["getDaemonConnection"]> | undefined;
 let clientPromise: Promise<CoachClient> | undefined;
@@ -64,6 +52,101 @@ function coachClient(): Promise<CoachClient> {
   clientPromise ??= connectionMaterial().then((connection) => connectCoachClient(connection));
   return clientPromise;
 }
+
+let firstSyncElement: HTMLElement | undefined;
+let firstSyncController: ReturnType<typeof createFirstSyncController>;
+
+function renderFirstSync(state: FirstSyncState): void {
+  if (state.status === "idle") {
+    firstSyncElement?.remove();
+    firstSyncElement = undefined;
+    return;
+  }
+  const section = firstSyncElement ?? document.createElement("section");
+  section.className = "first-sync";
+  section.dataset.state = state.status;
+  section.setAttribute("aria-labelledby", "first-sync-title");
+  section.replaceChildren();
+  const mark = document.createElement("div");
+  mark.className = "first-sync__mark";
+  mark.setAttribute("aria-hidden", "true");
+  const body = document.createElement("div");
+  body.className = "first-sync__body";
+  const eyebrow = document.createElement("p");
+  eyebrow.className = "first-sync__eyebrow";
+  eyebrow.textContent = "Getting your coach ready";
+  const title = document.createElement("h2");
+  title.id = "first-sync-title";
+  const detail = document.createElement("p");
+  detail.className = "first-sync__detail";
+  if (state.status === "syncing") {
+    title.textContent = "Syncing your training history…";
+    detail.textContent =
+      "You can keep Enduragent open while rides, wellness, and calendar data are added.";
+    const track = document.createElement("div");
+    track.className = "first-sync__track";
+    track.setAttribute("role", "progressbar");
+    track.setAttribute("aria-label", "Syncing training history");
+    body.append(eyebrow, title, detail, track);
+  } else if (state.status === "ready") {
+    title.textContent = "Training history is ready";
+    detail.textContent = "Your coach is ready when you are.";
+    body.append(eyebrow, title, detail);
+  } else if (state.kind === "protocol") {
+    title.textContent = "Enduragent needs to reconnect safely";
+    detail.textContent = "Quit and reopen Enduragent.";
+    body.append(eyebrow, title, detail);
+  } else {
+    title.textContent = "We couldn’t finish syncing";
+    detail.textContent = "Your saved progress is safe.";
+    const retry = document.createElement("button");
+    retry.type = "button";
+    retry.className = "first-sync__retry";
+    retry.textContent = "Retry sync";
+    retry.addEventListener("click", () => {
+      retry.disabled = true;
+      void firstSyncController.retry();
+    });
+    body.append(eyebrow, title, detail, retry);
+  }
+  section.append(mark, body);
+  if (firstSyncElement === undefined) thread.append(section);
+  firstSyncElement = section;
+}
+
+firstSyncController = createFirstSyncController({
+  async callSync(options) {
+    try {
+      const client = await coachClient();
+      return await client.call("sync", {}, options);
+    } catch (error) {
+      if (!(error instanceof CoachClientProtocolError)) {
+        clientPromise = undefined;
+        connectionMaterialPromise = undefined;
+      }
+      throw error;
+    }
+  },
+  focusComposer() {
+    message.focus();
+  },
+  render: renderFirstSync,
+});
+
+const setup = document.createElement("button");
+setup.type = "button";
+setup.className = "setup-button";
+setup.textContent = "Setup";
+topbar.insertBefore(setup, topbar.lastElementChild);
+const onboarding = mountOnboarding({
+  document,
+  bridge: createOnboardingBridge(),
+  opener: setup,
+  onComplete: (completion) => void firstSyncController.start(completion),
+});
+setup.addEventListener("click", () => void onboarding.open());
+window.addEventListener("pagehide", () => firstSyncController.dispose(), { once: true });
+void onboarding.open();
 
 function setDrawerOpen(open: boolean): void {
   drawer.classList.toggle("open", open);
@@ -98,7 +181,8 @@ function createTurnRow(
   if (includeUser) row.append(appendMessage("message user-message", state.userText));
   const assistant = appendMessage("message assistant-message", "");
   row.append(assistant);
-  thread.append(row);
+  if (firstSyncElement === undefined) thread.append(row);
+  else thread.insertBefore(row, firstSyncElement);
   row.scrollIntoView({ block: "end" });
   return { row, assistant };
 }

--- a/apps/desktop-renderer/src/styles.css
+++ b/apps/desktop-renderer/src/styles.css
@@ -113,6 +113,92 @@ textarea:focus-visible {
   color: var(--muted);
 }
 
+.first-sync {
+  display: grid;
+  grid-template-columns: 10px minmax(0, 1fr);
+  gap: 14px;
+  width: min(680px, calc(100% - 48px));
+  margin: 24px auto;
+  padding: 20px;
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  background: var(--surface);
+}
+
+.first-sync__mark {
+  width: 10px;
+  height: 10px;
+  margin-top: 5px;
+  border-radius: 50%;
+  background: var(--moss);
+}
+
+.first-sync__eyebrow,
+.first-sync__detail {
+  margin: 0;
+}
+
+.first-sync__eyebrow {
+  color: var(--moss);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.first-sync h2 {
+  margin: 7px 0 6px;
+  font-size: 18px;
+  line-height: 1.3;
+}
+
+.first-sync__detail {
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.first-sync__track {
+  position: relative;
+  height: 4px;
+  margin-top: 16px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: var(--moss-soft);
+}
+
+.first-sync__track::before {
+  position: absolute;
+  width: 40%;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--moss);
+  content: "";
+  transform: translateX(-100%);
+  animation: first-sync-sweep 1.2s ease-in-out infinite;
+}
+
+.first-sync__retry {
+  margin-top: 14px;
+  padding: 8px 13px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  color: var(--moss);
+  background: var(--surface);
+  cursor: pointer;
+}
+
+.first-sync__retry:disabled {
+  cursor: default;
+  opacity: 0.55;
+}
+
+@keyframes first-sync-sweep {
+  to {
+    transform: translateX(250%);
+  }
+}
+
 .retry {
   display: block;
   margin-top: 12px;
@@ -261,11 +347,24 @@ textarea:focus-visible {
   }
 }
 
+@media (max-width: 760px) {
+  .first-sync {
+    width: calc(100% - 32px);
+    margin-right: 16px;
+    margin-left: 16px;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,
   *::after {
     scroll-behavior: auto !important;
     transition-duration: 0.01ms !important;
+  }
+
+  .first-sync__track::before {
+    animation: none;
+    transform: translateX(0);
   }
 }

--- a/apps/desktop-renderer/tests/first-sync.test.ts
+++ b/apps/desktop-renderer/tests/first-sync.test.ts
@@ -1,0 +1,280 @@
+import { readFile } from "node:fs/promises";
+import { CoachClientDisconnectedError, CoachClientProtocolError } from "@enduragent/coach-client";
+import type {
+  CoachOperationProgressNotificationEnvelope,
+  SyncRpcResult,
+} from "@enduragent/coach-contract";
+import { describe, expect, it, vi, type Mock } from "vitest";
+import {
+  createFirstSyncController,
+  type FirstSyncCallOptions,
+  type FirstSyncPorts,
+  type FirstSyncState,
+} from "../src/first-sync.js";
+
+const completion = {
+  providerConfigured: true,
+  trainingDataConfigured: true,
+  intakeSaved: true,
+} as const;
+
+const success: SyncRpcResult = {
+  schemaVersion: 1,
+  published: true,
+  referenceSucceeded: true,
+  requests: { store: 1, reference: 1, total: 2 },
+};
+
+function envelope(
+  phase: "started" | "completed",
+  completed: number,
+  total = 1,
+  requestId = 1,
+): CoachOperationProgressNotificationEnvelope {
+  return {
+    jsonrpc: "2.0",
+    method: "coach.operationProgress",
+    params: { requestId, requestMethod: "sync", event: { phase, completed, total } },
+  };
+}
+
+function fakePorts(callSync: FirstSyncPorts["callSync"]): FirstSyncPorts & {
+  readonly states: FirstSyncState[];
+  readonly focusComposer: Mock<() => void>;
+} {
+  const states: FirstSyncState[] = [];
+  return {
+    states,
+    callSync,
+    focusComposer: vi.fn<() => void>(),
+    render: (state) => states.push(state),
+  };
+}
+
+function completedCall(result: SyncRpcResult = success): FirstSyncPorts["callSync"] {
+  return async (options) => {
+    options.onNotificationEnvelope(envelope("started", 0));
+    options.onNotificationEnvelope(envelope("completed", 1));
+    return result;
+  };
+}
+
+describe("first sync controller", () => {
+  it("strictly validates completion and starts one synchronous single-flight call", async () => {
+    let resolve!: (result: SyncRpcResult) => void;
+    let options!: FirstSyncCallOptions;
+    const callSync = vi.fn(
+      (selected: FirstSyncCallOptions) =>
+        new Promise<SyncRpcResult>((done) => {
+          options = selected;
+          resolve = done;
+        }),
+    );
+    const ports = fakePorts(callSync);
+    const controller = createFirstSyncController(ports);
+    for (const invalid of [
+      {},
+      { ...completion, intakeSaved: false },
+      { ...completion, extra: true },
+      null,
+    ]) {
+      await expect(controller.start(invalid as never)).rejects.toBeInstanceOf(TypeError);
+    }
+    expect(callSync).not.toHaveBeenCalled();
+    const first = controller.start(completion);
+    const second = controller.start(completion);
+    expect(first).toBe(second);
+    expect(ports.states).toEqual([{ status: "syncing" }]);
+    expect(callSync).toHaveBeenCalledTimes(1);
+    options.onNotificationEnvelope(envelope("started", 0));
+    options.onNotificationEnvelope(envelope("completed", 1));
+    resolve(success);
+    await expect(first).resolves.toBeUndefined();
+    expect(ports.states.at(-1)).toEqual({ status: "ready" });
+    expect(ports.focusComposer).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ["reversed", [envelope("completed", 1), envelope("started", 0)]],
+    ["duplicate", [envelope("started", 0), envelope("started", 0)]],
+    ["wrong total", [envelope("started", 0, 2), envelope("completed", 1)]],
+    ["skipped", [envelope("started", 0)]],
+    ["cross request", [envelope("started", 0, 1, 1), envelope("completed", 1, 1, 2)]],
+  ])("latches %s progress as a protocol failure without observer throws", async (_name, events) => {
+    const ports = fakePorts(async (options) => {
+      for (const event of events) {
+        expect(() => options.onNotificationEnvelope(event)).not.toThrow();
+      }
+      return success;
+    });
+    const controller = createFirstSyncController(ports);
+    await controller.start(completion);
+    expect(ports.states.at(-1)).toEqual({
+      status: "failed",
+      kind: "protocol",
+      retryable: false,
+    });
+    expect(ports.focusComposer).not.toHaveBeenCalled();
+    await controller.retry();
+    expect(ports.states).toHaveLength(2);
+  });
+
+  it("turns a late current-epoch envelope into a non-retryable protocol failure", async () => {
+    let notify!: FirstSyncCallOptions["onNotificationEnvelope"];
+    const ports = fakePorts(async (options) => {
+      notify = options.onNotificationEnvelope;
+      notify(envelope("started", 0));
+      notify(envelope("completed", 1));
+      return success;
+    });
+    const controller = createFirstSyncController(ports);
+    await controller.start(completion);
+    expect(() => notify(envelope("completed", 1))).not.toThrow();
+    expect(ports.states.at(-1)).toEqual({
+      status: "failed",
+      kind: "protocol",
+      retryable: false,
+    });
+  });
+
+  it.each([
+    [false, false],
+    [false, true],
+    [true, false],
+  ])(
+    "maps published %s and Reference success %s to a retryable operation failure",
+    async (published, referenceSucceeded) => {
+      const ports = fakePorts(completedCall({ ...success, published, referenceSucceeded }));
+      await createFirstSyncController(ports).start(completion);
+      expect(ports.states.at(-1)).toEqual({
+        status: "failed",
+        kind: "operation",
+        retryable: true,
+      });
+      expect(ports.focusComposer).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    [new Error("private operation failure"), "operation", true],
+    [new CoachClientDisconnectedError(1006, "private close reason"), "disconnected", true],
+    [new CoachClientProtocolError(), "protocol", false],
+  ] as const)("maps fixed failure state for %s", async (failure, kind, retryable) => {
+    const ports = fakePorts(async () => {
+      throw failure;
+    });
+    await createFirstSyncController(ports).start(completion);
+    expect(ports.states.at(-1)).toEqual({ status: "failed", kind, retryable });
+    expect(JSON.stringify(ports.states)).not.toContain(failure.message);
+  });
+
+  it("retries once on a new epoch and ignores callbacks from the detached epoch", async () => {
+    const calls: FirstSyncCallOptions[] = [];
+    let resolveRetry!: (result: SyncRpcResult) => void;
+    const ports = fakePorts(
+      vi.fn(async (options) => {
+        calls.push(options);
+        if (calls.length === 1) throw new CoachClientDisconnectedError(1006, "detached");
+        return new Promise<SyncRpcResult>((resolve) => {
+          resolveRetry = resolve;
+        });
+      }),
+    );
+    const controller = createFirstSyncController(ports);
+    await controller.start(completion);
+    const retry = controller.retry();
+    expect(calls).toHaveLength(2);
+    calls[0]!.onNotificationEnvelope(envelope("started", 0));
+    calls[0]!.onNotificationEnvelope(envelope("completed", 1));
+    calls[1]!.onNotificationEnvelope(envelope("started", 0, 1, 2));
+    calls[1]!.onNotificationEnvelope(envelope("completed", 1, 1, 2));
+    resolveRetry(success);
+    await retry;
+    expect(ports.states.at(-1)).toEqual({ status: "ready" });
+    expect(ports.focusComposer).toHaveBeenCalledTimes(1);
+    expect(ports.callSync).toHaveBeenCalledTimes(2);
+  });
+
+  it("makes pending callbacks and completion inert after disposal", async () => {
+    let options!: FirstSyncCallOptions;
+    let resolve!: (result: SyncRpcResult) => void;
+    const ports = fakePorts(
+      (selected) =>
+        new Promise<SyncRpcResult>((done) => {
+          options = selected;
+          resolve = done;
+        }),
+    );
+    const controller = createFirstSyncController(ports);
+    const call = controller.start(completion);
+    controller.dispose();
+    options.onNotificationEnvelope(envelope("started", 0));
+    options.onNotificationEnvelope(envelope("completed", 1));
+    resolve(success);
+    await call;
+    await controller.retry();
+    await controller.start(completion);
+    expect(ports.states).toEqual([{ status: "syncing" }]);
+    expect(ports.focusComposer).not.toHaveBeenCalled();
+  });
+
+  it("rechecks sync after a later onboarding completion without refocusing twice", async () => {
+    const callSync = vi.fn(completedCall());
+    const ports = fakePorts(callSync);
+    const controller = createFirstSyncController(ports);
+    await controller.start(completion);
+    await controller.start(completion);
+    expect(callSync).toHaveBeenCalledTimes(2);
+    expect(ports.states).toEqual([
+      { status: "syncing" },
+      { status: "ready" },
+      { status: "syncing" },
+      { status: "ready" },
+    ]);
+    expect(ports.focusComposer).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the controller free of chat or transcript ports and ships the exact status surface", async () => {
+    const ports = fakePorts(completedCall());
+    await createFirstSyncController(ports).start(completion);
+    expect(Object.keys(ports).sort()).toEqual(["callSync", "focusComposer", "render", "states"]);
+    const [host, controller, styles] = await Promise.all([
+      readFile(new URL("../src/index.ts", import.meta.url), "utf8"),
+      readFile(new URL("../src/first-sync.ts", import.meta.url), "utf8"),
+      readFile(new URL("../src/styles.css", import.meta.url), "utf8"),
+    ]);
+    for (const copy of [
+      "Getting your coach ready",
+      "Syncing your training history…",
+      "You can keep Enduragent open while rides, wellness, and calendar data are added.",
+      "Training history is ready",
+      "Your coach is ready when you are.",
+      "We couldn’t finish syncing",
+      "Your saved progress is safe.",
+      "Retry sync",
+      "Enduragent needs to reconnect safely",
+      "Quit and reopen Enduragent.",
+    ]) {
+      expect(host).toContain(copy);
+    }
+    expect(host).toContain('section.className = "first-sync"');
+    expect(host).toContain("section.dataset.state = state.status");
+    expect(host).toContain('section.setAttribute("aria-labelledby", "first-sync-title")');
+    expect(host).toContain('track.setAttribute("role", "progressbar")');
+    expect(host).toContain('track.setAttribute("aria-label", "Syncing training history")');
+    expect(host).toContain(
+      "onComplete: (completion) => void firstSyncController.start(completion)",
+    );
+    expect(host).toContain("message.focus()");
+    expect(controller).not.toMatch(/chat|prompt|transcript|sessionStore/u);
+    expect(styles).toContain("width: min(680px, calc(100% - 48px))");
+    expect(styles).toContain("padding: 20px");
+    expect(styles).toContain("border-radius: 16px");
+    expect(styles).toContain("animation: first-sync-sweep 1.2s");
+    expect(styles).toContain("@media (max-width: 760px)");
+    expect(styles).toContain("width: calc(100% - 32px)");
+    expect(styles).toContain("@media (prefers-reduced-motion: reduce)");
+    expect(styles).toContain("animation: none");
+    expect(styles).toContain("width: 40%");
+  });
+});

--- a/packages/coach/src/backfill.ts
+++ b/packages/coach/src/backfill.ts
@@ -14,6 +14,7 @@ import type { ArchiveInstant, ArchiveManager, ArchiveWriteResult } from "@endura
 import type { ImportArtifact, ImportReport, ImportReportDeps, PairDiagnostic, PlatformImportArtifact } from "@enduragent/kernel/ingest";
 import { createSyncStateRepository, dumpStore, type PhysicalRequestLedger, type SourceArtifactDraft, type SqlStore, type SyncBudget } from "@enduragent/kernel/store";
 import { createNodeImportRuntime, type NodeImportRuntime } from "@enduragent/kernel-node/ingest";
+import type { AthleteHome } from "@enduragent/kernel-node/home";
 import {
   createIntervalsIcuSource,
   REQUEST_ATTEMPTS,
@@ -269,24 +270,39 @@ export interface RunIntervalsBackfillOptions {
   readonly onPageCommitted?: RunBackfillPagesOptions["onPageCommitted"];
 }
 
+export interface RunIntervalsBackfillInWriterOptions
+  extends Omit<RunIntervalsBackfillOptions, "env"> {
+  readonly home: AthleteHome;
+  readonly store: SqlStore & {
+    transaction<T>(work: () => Promise<T>): Promise<T>;
+  };
+}
+
 const productionClock: BackfillClock = Object.freeze({ now: () => Date.now(), monotonicNow: () => performance.now() });
 const sleepAbortably = (ms: number, signal: AbortSignal): Promise<void> =>
   setTimeoutPromise(ms, undefined, { signal }).then(() => undefined);
 
-export function runIntervalsBackfill(options: RunIntervalsBackfillOptions): Promise<BackfillRunResult> {
+export function runIntervalsBackfillInWriter(
+  options: RunIntervalsBackfillInWriterOptions,
+): Promise<BackfillRunResult> {
   const requestIntervalMs = configured(options.requestIntervalMs, DEFAULT_REQUEST_INTERVAL_MS, 250, 60_000, "request interval");
   const clock = options.clock ?? productionClock, sleep = options.sleep ?? sleepAbortably;
-  return withCoachStoreWriter(options.env, async ({ home, store }) => {
-    const node = createNodeImportRuntime({ archiveDir: home.archiveDir, store });
-    const source = createIntervalsBackfillSource({ apiKey: options.apiKey, athleteId: options.athleteId,
-      historyNewestDate: options.historyNewestDate, minRequestIntervalMs: requestIntervalMs, archive: node.archive,
-      clock, sleep, ...(options.baseFetch === undefined ? {} : { baseFetch: options.baseFetch }) });
-    return runBackfillPages({ store, node, source, clock,
-      ...(options.signal === undefined ? {} : { signal: options.signal }), ...(options.batchSize === undefined ? {} : { batchSize: options.batchSize }),
-      ...(options.perRequestTimeoutMs === undefined ? {} : { perRequestTimeoutMs: options.perRequestTimeoutMs }),
-      ...(options.backfillPageDeadlineMs === undefined ? {} : { backfillPageDeadlineMs: options.backfillPageDeadlineMs }),
-      ...(options.measurePhase === undefined ? {} : { measurePhase: options.measurePhase }),
-      ...(options.onPageCommitted === undefined ? {} : { onPageCommitted: options.onPageCommitted }) });
+  const node = createNodeImportRuntime({ archiveDir: options.home.archiveDir, store: options.store });
+  const source = createIntervalsBackfillSource({ apiKey: options.apiKey, athleteId: options.athleteId,
+    historyNewestDate: options.historyNewestDate, minRequestIntervalMs: requestIntervalMs, archive: node.archive,
+    clock, sleep, ...(options.baseFetch === undefined ? {} : { baseFetch: options.baseFetch }) });
+  return runBackfillPages({ store: options.store, node, source, clock,
+    ...(options.signal === undefined ? {} : { signal: options.signal }), ...(options.batchSize === undefined ? {} : { batchSize: options.batchSize }),
+    ...(options.perRequestTimeoutMs === undefined ? {} : { perRequestTimeoutMs: options.perRequestTimeoutMs }),
+    ...(options.backfillPageDeadlineMs === undefined ? {} : { backfillPageDeadlineMs: options.backfillPageDeadlineMs }),
+    ...(options.measurePhase === undefined ? {} : { measurePhase: options.measurePhase }),
+    ...(options.onPageCommitted === undefined ? {} : { onPageCommitted: options.onPageCommitted }) });
+}
+
+export function runIntervalsBackfill(options: RunIntervalsBackfillOptions): Promise<BackfillRunResult> {
+  const { env, ...inWriterOptions } = options;
+  return withCoachStoreWriter(env, ({ home, store }) => {
+    return runIntervalsBackfillInWriter({ ...inWriterOptions, home, store });
   });
 }
 

--- a/packages/coach/src/composition.ts
+++ b/packages/coach/src/composition.ts
@@ -56,6 +56,7 @@ import {
   type StoreRuntimeOptions,
 } from "./store-runtime.js";
 import { createCoachOperations } from "./operations.js";
+import type { CoachOperationsDependencies } from "./operations.js";
 
 interface OAuthCredential {
   readonly type: "oauth";
@@ -94,6 +95,7 @@ export interface LocalCoachCompositionDependencies {
   readonly modelTransportDecorator?: ModelTransportDecorator;
   readonly onToolsAssembled?: (names: readonly string[]) => void;
   readonly closeHostAdapters?: () => void | Promise<void>;
+  readonly operationsDependencies?: CoachOperationsDependencies;
 }
 
 export interface LocalReferenceRuntime {
@@ -105,6 +107,9 @@ export interface LocalStoreRuntime {
   readonly athleteData: StoreRuntime["athleteData"];
   attemptLedgerForRun(): ReturnType<StoreRuntime["attemptLedgerForRun"]>;
   runWindow(): ReturnType<StoreRuntime["runWindow"]>;
+  runWindowAfter(
+    work: (signal: AbortSignal) => Promise<void>,
+  ): ReturnType<StoreRuntime["runWindow"]>;
   startScheduler(): void;
   close(): Promise<void>;
 }
@@ -416,12 +421,23 @@ export async function createLocalCoachComposition(
         return replacement;
       });
     };
-    const operations = createCoachOperations({
-      home: input.home,
-      context: input.context,
-      runtime,
-      applyRuntimeConfig,
+    const liveIntervals = Object.freeze({
+      async read() {
+        return Object.freeze({ ...activeConfig.intervals });
+      },
     });
+    const options = Object.freeze({ liveIntervals });
+    const operations = createCoachOperations(
+      {
+        home: input.home,
+        context: input.context,
+        runtime,
+        intervalsCredentials: options.liveIntervals,
+        historyNewestDate: new Date(now()).toISOString().slice(0, 10),
+        applyRuntimeConfig,
+      },
+      dependencies.operationsDependencies,
+    );
     return {
       engine: reconfigurable.engine,
       operations,

--- a/packages/coach/src/operations.ts
+++ b/packages/coach/src/operations.ts
@@ -26,18 +26,24 @@ import {
   type AuthoredIdentity,
 } from "@enduragent/kernel-node/home";
 import { importFilesWithReport } from "@enduragent/kernel-node/ingest";
+import { runIntervalsBackfillInWriter } from "./backfill.js";
 import type { LocalStoreRuntime } from "./composition.js";
 import type { CoachStoreWriterContext } from "./runtime.js";
 
 export interface CreateCoachOperationsInput {
   readonly home: AthleteHome;
   readonly context: CoachStoreWriterContext;
-  readonly runtime: Pick<LocalStoreRuntime, "runWindow">;
+  readonly runtime: Pick<LocalStoreRuntime, "runWindowAfter">;
+  readonly intervalsCredentials: Readonly<{
+    read(): Promise<Readonly<{ apiKey: string; athleteId: string }>>;
+  }>;
+  readonly historyNewestDate: string;
   readonly applyRuntimeConfig: (request: ConfigureRuntimeRpcParams) => Promise<void>;
 }
 
 export interface CoachOperationsDependencies {
   readonly importFiles?: typeof importFilesWithReport;
+  readonly backfill?: typeof runIntervalsBackfillInWriter;
   readonly createIdentity?: (configDir: string) => AuthoredIdentity;
   readonly createIntakeRepository?: typeof createIntakeRepository;
 }
@@ -63,6 +69,7 @@ export function createCoachOperations(
   const identity = (dependencies.createIdentity ?? createAuthoredIdentity)(input.home.configDir);
   const intake = (dependencies.createIntakeRepository ?? createIntakeRepository)(store);
   const importFiles = dependencies.importFiles ?? importFilesWithReport;
+  const backfill = dependencies.backfill ?? runIntervalsBackfillInWriter;
   let tail = Promise.resolve();
 
   const enqueue = <T>(operation: () => Promise<T>): Promise<T> => {
@@ -113,7 +120,18 @@ export function createCoachOperations(
       SyncRpcParamsSchema.parse(request);
       return enqueue(async () => {
         deliver(onEvent, { phase: "started", completed: 0, total: 1 });
-        const window = await input.runtime.runWindow();
+        const window = await input.runtime.runWindowAfter(async (signal) => {
+          const credentials = await input.intervalsCredentials.read();
+          if (credentials.apiKey.length === 0) return;
+          await backfill({
+            home: input.home,
+            store: input.context.store,
+            apiKey: credentials.apiKey,
+            athleteId: credentials.athleteId === "" ? "0" : credentials.athleteId,
+            historyNewestDate: input.historyNewestDate,
+            signal,
+          });
+        });
         const result = SyncRpcResultSchema.parse({
           schemaVersion: 1,
           published: window.published,

--- a/packages/coach/src/store-runtime.ts
+++ b/packages/coach/src/store-runtime.ts
@@ -70,6 +70,7 @@ export class StoreRuntime {
   private snapshotValue: ProducedLocalBundle | undefined;
   private activeLedger: PhysicalRequestLedger | undefined;
   private activeController: AbortController | undefined;
+  private activeBeforeWindowController: AbortController | undefined;
   private activeWindow: Promise<StoreWindowResult> | undefined;
   private closed = false;
 
@@ -139,6 +140,55 @@ export class StoreRuntime {
     return task;
   }
 
+  runWindowAfter(work: (signal: AbortSignal) => Promise<void>): Promise<StoreWindowResult> {
+    if (typeof work !== "function")
+      return Promise.reject(new TypeError("Window work must be a function."));
+    if (this.closed) return Promise.reject(new Error("Store runtime is closed."));
+    if (this.activeWindow !== undefined) {
+      const active = this.activeWindow;
+      const task = active.then(
+        () => this.runBeforeWindow(work),
+        () => this.runBeforeWindow(work),
+      );
+      this.installActiveWindow(task);
+      return task;
+    }
+    const task = this.runBeforeWindow(work);
+    this.installActiveWindow(task);
+    return task;
+  }
+
+  private runBeforeWindow(
+    work: (signal: AbortSignal) => Promise<void>,
+  ): Promise<StoreWindowResult> {
+    if (this.closed) return Promise.reject(new Error("Store runtime is closed."));
+    const controller = new AbortController();
+    const task = Promise.resolve()
+      .then(() => work(controller.signal))
+      .then(() => {
+        if (controller.signal.aborted) throw controller.signal.reason;
+        return this.runWindowInternal();
+      });
+    this.activeBeforeWindowController = controller;
+    void task
+      .finally(() => {
+        if (this.activeBeforeWindowController === controller) {
+          this.activeBeforeWindowController = undefined;
+        }
+      })
+      .catch(() => {});
+    return task;
+  }
+
+  private installActiveWindow(task: Promise<StoreWindowResult>): void {
+    this.activeWindow = task;
+    void task
+      .finally(() => {
+        if (this.activeWindow === task) this.activeWindow = undefined;
+      })
+      .catch(() => {});
+  }
+
   private async runWindowInternal(): Promise<StoreWindowResult> {
     const ledger = createPhysicalRequestLedger({ storeLimit: 64, legacyLimit: 15, totalLimit: 79 });
     const controller = new AbortController();
@@ -202,6 +252,7 @@ export class StoreRuntime {
   async close(): Promise<void> {
     if (this.closed) return;
     this.closed = true;
+    this.activeBeforeWindowController?.abort(new Error("Store runtime closed."));
     this.activeController?.abort(new Error("Store runtime closed."));
     await this.scheduler.close();
     try {

--- a/packages/coach/tests/backfill.test.ts
+++ b/packages/coach/tests/backfill.test.ts
@@ -1,91 +1,336 @@
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
-import { runMigrations, type MigratorStore, type SourceArtifact, type SqlStore } from "@enduragent/kernel/store";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createSyncStateRepository,
+  runMigrations,
+  type SourceArtifact,
+} from "@enduragent/kernel/store";
 import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
 import { createNodeImportRuntime } from "@enduragent/kernel-node/ingest";
 import { openSqliteStorage } from "@enduragent/kernel-node/sqlite";
 import type { IntervalsIcuSource } from "@enduragent/sync-intervals-icu";
-import { createIntervalsBackfillSource, runBackfillPages } from "../src/backfill.js";
+import type { AthleteHome } from "@enduragent/kernel-node/home";
+import {
+  createIntervalsBackfillSource,
+  runBackfillPages,
+  runIntervalsBackfill,
+  runIntervalsBackfillInWriter,
+} from "../src/backfill.js";
 
-const complete = JSON.stringify({ v: 1, cycle: 0, window_start: "2010-01-01", window_end: "2010-12-31", last_key: null, complete: true });
+const complete = JSON.stringify({
+  v: 1,
+  cycle: 0,
+  window_start: "2010-01-01",
+  window_end: "2010-12-31",
+  last_key: null,
+  complete: true,
+});
 const clock = { now: () => 1_300_000_000_000, monotonicNow: () => 1_000 };
 
 describe("incremental backfill pages", () => {
   const roots: string[] = [];
-  afterEach(() => { for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true }); });
+  afterEach(() => {
+    for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+  });
   async function fresh() {
-    const root = mkdtempSync(join(tmpdir(), "backfill-page-")); roots.push(root);
-    const store = openSqliteStorage(join(root, "store.db")); await runMigrations(store, MIGRATIONS);
+    const root = mkdtempSync(join(realpathSync(tmpdir()), "backfill-page-"));
+    roots.push(root);
+    const store = openSqliteStorage(join(root, "store.db"));
+    await runMigrations(store, MIGRATIONS);
     const node = createNodeImportRuntime({ archiveDir: join(root, "archive"), store });
     return { root, store, node };
   }
-  async function raw(node: ReturnType<typeof createNodeImportRuntime>, name = "one.fit"): Promise<Extract<SourceArtifact, { kind: "raw-file" }>> {
-    const bytes = new Uint8Array(readFileSync("packages/kernel-node/tests/fixtures/ingest/brick-cycling.fit"));
+  async function raw(
+    node: ReturnType<typeof createNodeImportRuntime>,
+    name = "one.fit",
+  ): Promise<Extract<SourceArtifact, { kind: "raw-file" }>> {
+    const bytes = new Uint8Array(
+      readFileSync("packages/kernel-node/tests/fixtures/ingest/brick-cycling.fit"),
+    );
     const archiveInstant = { epochSeconds: 899_585_600 };
     const archive = await node.archive.writeArtifact(bytes, "fit", archiveInstant);
-    return { kind: "raw-file", source: "intervals-icu", lane: "bulk-fit", externalId: name,
-      archiveInstant, archive, container: null, file: { input_path: name, bytes, ext: "fit" } } as Extract<SourceArtifact, { kind: "raw-file" }>;
+    return {
+      kind: "raw-file",
+      source: "intervals-icu",
+      lane: "bulk-fit",
+      externalId: name,
+      archiveInstant,
+      archive,
+      container: null,
+      file: { input_path: name, bytes, ext: "fit" },
+    } as Extract<SourceArtifact, { kind: "raw-file" }>;
   }
-  function source(pulls: (watermark: string | null, call: number) => AsyncIterable<SourceArtifact>): IntervalsIcuSource {
+  function source(
+    pulls: (watermark: string | null, call: number) => AsyncIterable<SourceArtifact>,
+  ): IntervalsIcuSource {
     let call = 0;
-    return { id: "intervals-icu", capabilities: { activities: true, streams: true, rawFiles: true, wellness: true,
-      plannedWorkoutPush: false, backfillDepth: { kind: "full-history" } },
-    pull(watermark) { return pulls(watermark.value, call++); } } as IntervalsIcuSource;
+    return {
+      id: "intervals-icu",
+      capabilities: {
+        activities: true,
+        streams: true,
+        rawFiles: true,
+        wellness: true,
+        plannedWorkoutPush: false,
+        backfillDepth: { kind: "full-history" },
+      },
+      pull(watermark) {
+        return pulls(watermark.value, call++);
+      },
+    } as IntervalsIcuSource;
   }
 
   it("commits each page checkpoint atomically and finishes with one terminal no-op", async () => {
     const value = await fresh();
     try {
       const item = await raw(value.node);
-      const fake = source((_watermark, call) => (async function* () {
-        if (call === 0) yield item;
-        yield { kind: "checkpoint", watermark: { source: "intervals-icu", lane: "bulk-fit", value: complete } };
-      })());
-      const result = await runBackfillPages({ store: value.store, node: value.node, source: fake, clock });
+      const fake = source((_watermark, call) =>
+        (async function* () {
+          if (call === 0) yield item;
+          yield {
+            kind: "checkpoint",
+            watermark: { source: "intervals-icu", lane: "bulk-fit", value: complete },
+          };
+        })(),
+      );
+      const result = await runBackfillPages({
+        store: value.store,
+        node: value.node,
+        source: fake,
+        clock,
+      });
       expect(result).toMatchObject({ pages: 2, artifacts: 1 });
-      expect(await value.store.get("SELECT watermark FROM source_watermark WHERE source='intervals-icu' AND lane='bulk-fit'")).toEqual({ watermark: complete });
-      expect(await value.store.all("SELECT artifacts_seen,completion_kind FROM sync_operation ORDER BY operation_id")).toEqual([
-        { artifacts_seen: 1, completion_kind: "applied" }, { artifacts_seen: 0, completion_kind: "no-op" },
+      expect(
+        await value.store.get(
+          "SELECT watermark FROM source_watermark WHERE source='intervals-icu' AND lane='bulk-fit'",
+        ),
+      ).toEqual({ watermark: complete });
+      expect(
+        await value.store.all(
+          "SELECT artifacts_seen,completion_kind FROM sync_operation ORDER BY operation_id",
+        ),
+      ).toEqual([
+        { artifacts_seen: 1, completion_kind: "applied" },
+        { artifacts_seen: 0, completion_kind: "no-op" },
       ]);
       expect(await value.store.get("SELECT count(*) AS n FROM raw_file")).toEqual({ n: 1 });
-    } finally { await value.store.close(); }
+    } finally {
+      await value.store.close();
+    }
   });
 
   it.each([
-    ["wrong checkpoint", () => source(() => (async function* () { yield { kind: "checkpoint", watermark: { source: "file-import", lane: "bulk-fit", value: complete } } as SourceArtifact; })())],
-    ["multiple checkpoint", () => source(() => (async function* () { const checkpoint = { kind: "checkpoint", watermark: { source: "intervals-icu", lane: "bulk-fit", value: complete } } as SourceArtifact; yield checkpoint; yield checkpoint; })())],
-    ["nonterminal invalid checkpoint", () => source(() => (async function* () { yield { kind: "checkpoint", watermark: { source: "intervals-icu", lane: "bulk-fit", value: "{}" } } as SourceArtifact; })())],
+    [
+      "wrong checkpoint",
+      () =>
+        source(() =>
+          (async function* () {
+            yield {
+              kind: "checkpoint",
+              watermark: { source: "file-import", lane: "bulk-fit", value: complete },
+            } as SourceArtifact;
+          })(),
+        ),
+    ],
+    [
+      "multiple checkpoint",
+      () =>
+        source(() =>
+          (async function* () {
+            const checkpoint = {
+              kind: "checkpoint",
+              watermark: { source: "intervals-icu", lane: "bulk-fit", value: complete },
+            } as SourceArtifact;
+            yield checkpoint;
+            yield checkpoint;
+          })(),
+        ),
+    ],
+    [
+      "nonterminal invalid checkpoint",
+      () =>
+        source(() =>
+          (async function* () {
+            yield {
+              kind: "checkpoint",
+              watermark: { source: "intervals-icu", lane: "bulk-fit", value: "{}" },
+            } as SourceArtifact;
+          })(),
+        ),
+    ],
   ])("rejects %s and commits nothing", async (_name, makeSource) => {
     const value = await fresh();
     try {
-      await expect(runBackfillPages({ store: value.store, node: value.node, source: makeSource(), clock })).rejects.toThrow();
+      await expect(
+        runBackfillPages({ store: value.store, node: value.node, source: makeSource(), clock }),
+      ).rejects.toThrow();
       expect(await value.store.get("SELECT count(*) AS n FROM sync_operation")).toEqual({ n: 0 });
       expect(await value.store.get("SELECT count(*) AS n FROM raw_file")).toEqual({ n: 0 });
-    } finally { await value.store.close(); }
+    } finally {
+      await value.store.close();
+    }
   });
 
   it("deduplicates an over-yielded immutable artifact within a page", async () => {
     const value = await fresh();
     try {
-      const one = await raw(value.node, "one"), two = { ...one, externalId: "two", file: { ...one.file, input_path: "two.fit" } } as SourceArtifact;
-      const fake = source((_watermark, call) => (async function* () {
-        if (call === 0) { yield one; yield two; }
-        yield { kind: "checkpoint", watermark: { source: "intervals-icu", lane: "bulk-fit", value: complete } };
-      })());
-      const result = await runBackfillPages({ store: value.store, node: value.node, source: fake, clock, batchSize: 2 });
+      const one = await raw(value.node, "one"),
+        two = {
+          ...one,
+          externalId: "two",
+          file: { ...one.file, input_path: "two.fit" },
+        } as SourceArtifact;
+      const fake = source((_watermark, call) =>
+        (async function* () {
+          if (call === 0) {
+            yield one;
+            yield two;
+          }
+          yield {
+            kind: "checkpoint",
+            watermark: { source: "intervals-icu", lane: "bulk-fit", value: complete },
+          };
+        })(),
+      );
+      const result = await runBackfillPages({
+        store: value.store,
+        node: value.node,
+        source: fake,
+        clock,
+        batchSize: 2,
+      });
       expect(result.artifacts).toBe(2);
       expect(await value.store.get("SELECT count(*) AS n FROM raw_file")).toEqual({ n: 1 });
       expect(await value.store.get("SELECT count(*) AS n FROM source_artifact")).toEqual({ n: 2 });
-    } finally { await value.store.close(); }
+    } finally {
+      await value.store.close();
+    }
   });
 
   it("constructs the backfill source with the fixed full-history floor", () => {
-    const archive = { writeArtifact: async () => { throw new Error("unused"); } } as never;
-    const created = createIntervalsBackfillSource({ apiKey: String.fromCharCode(116, 101, 115, 116), athleteId: "test-athlete", historyNewestDate: "2010-12-31",
-      minRequestIntervalMs: 250, archive, clock, sleep: async () => {}, baseFetch: async () => { throw new Error("unused"); } });
+    const archive = {
+      writeArtifact: async () => {
+        throw new Error("unused");
+      },
+    } as never;
+    const created = createIntervalsBackfillSource({
+      apiKey: String.fromCharCode(116, 101, 115, 116),
+      athleteId: "test-athlete",
+      historyNewestDate: "2010-12-31",
+      minRequestIntervalMs: 250,
+      archive,
+      clock,
+      sleep: async () => {},
+      baseFetch: async () => {
+        throw new Error("unused");
+      },
+    });
     expect(created.id).toBe("intervals-icu");
     expect(created.capabilities.backfillDepth).toEqual({ kind: "full-history" });
+  });
+
+  it("keeps the public writer wrapper equivalent to the supplied-writer entry", async () => {
+    const makeHome = async (): Promise<{
+      home: AthleteHome;
+      store: ReturnType<typeof openSqliteStorage>;
+    }> => {
+      const root = mkdtempSync(join(realpathSync(tmpdir()), "backfill-writer-"));
+      roots.push(root);
+      const home = {
+        root,
+        storeDir: join(root, "store"),
+        archiveDir: join(root, "archive"),
+        configDir: join(root, "config"),
+      };
+      mkdirSync(home.storeDir, { recursive: true, mode: 0o700 });
+      const store = openSqliteStorage(join(home.storeDir, "store.db"));
+      await runMigrations(store, MIGRATIONS);
+      await store.transaction(async () => {
+        await createSyncStateRepository(store).recordCompletionInTransaction({
+          source: "intervals-icu",
+          lane: "bulk-fit",
+          watermarkBefore: null,
+          watermarkAfter: complete,
+          artifactsSeen: 0,
+          sourceChanges: 0,
+        });
+      });
+      return { home, store };
+    };
+    const direct = await makeHome();
+    const wrapped = await makeHome();
+    const directPages: unknown[] = [];
+    const wrappedPages: unknown[] = [];
+    const baseFetch = vi.fn(async () => {
+      throw new Error("completed watermark performed a request");
+    });
+    const close = vi.spyOn(direct.store, "close");
+    try {
+      const directResult = await runIntervalsBackfillInWriter({
+        home: direct.home,
+        store: direct.store,
+        apiKey: String.fromCharCode(116, 101, 115, 116),
+        athleteId: "synthetic-athlete",
+        historyNewestDate: "2010-12-31",
+        clock,
+        sleep: async () => {},
+        baseFetch,
+        onPageCommitted: (page) => directPages.push(page),
+      });
+      await wrapped.store.close();
+      const wrappedResult = await runIntervalsBackfill({
+        env: { ENDURAGENT_HOME: wrapped.home.root },
+        apiKey: String.fromCharCode(116, 101, 115, 116),
+        athleteId: "synthetic-athlete",
+        historyNewestDate: "2010-12-31",
+        clock,
+        sleep: async () => {},
+        baseFetch,
+        onPageCommitted: (page) => wrappedPages.push(page),
+      });
+      expect(wrappedResult).toEqual(directResult);
+      expect(wrappedPages).toEqual(directPages);
+      expect(directResult).toMatchObject({ pages: 2, artifacts: 0, reports: [] });
+      expect(baseFetch).not.toHaveBeenCalled();
+      expect(close).not.toHaveBeenCalled();
+      await expect(
+        direct.store.get("SELECT count(*) AS count FROM source_watermark"),
+      ).resolves.toEqual({ count: 1 });
+    } finally {
+      close.mockRestore();
+      await direct.store.close();
+    }
+  });
+
+  it("preserves in-writer bounds and leaves the caller store open after rejection", async () => {
+    const value = await fresh();
+    const home: AthleteHome = {
+      root: value.root,
+      storeDir: join(value.root, "store"),
+      archiveDir: join(value.root, "archive"),
+      configDir: join(value.root, "config"),
+    };
+    const close = vi.spyOn(value.store, "close");
+    try {
+      await expect(
+        runIntervalsBackfillInWriter({
+          home,
+          store: value.store,
+          apiKey: String.fromCharCode(116, 101, 115, 116),
+          athleteId: "synthetic-athlete",
+          historyNewestDate: "2010-12-31",
+          batchSize: 0,
+        }),
+      ).rejects.toThrow("invalid batch size");
+      expect(close).not.toHaveBeenCalled();
+      await expect(
+        value.store.get("SELECT count(*) AS count FROM source_watermark"),
+      ).resolves.toEqual({ count: 0 });
+    } finally {
+      close.mockRestore();
+      await value.store.close();
+    }
   });
 });

--- a/packages/coach/tests/composition.test.ts
+++ b/packages/coach/tests/composition.test.ts
@@ -162,15 +162,20 @@ function runtime(
   } = {},
 ): LocalStoreRuntime {
   const ledger = createPhysicalRequestLedger({ storeLimit: 64, legacyLimit: 15, totalLimit: 79 });
+  const runWindow =
+    options.runWindow ??
+    (async () => {
+      trace.push("run-window");
+      return { published: true, counts: ledger.snapshot(), legacySucceeded: true };
+    });
   return {
     athleteData: athleteData(),
     attemptLedgerForRun: () => ledger,
-    runWindow:
-      options.runWindow ??
-      (async () => {
-        trace.push("run-window");
-        return { published: true, counts: ledger.snapshot(), legacySucceeded: true };
-      }),
+    runWindow,
+    async runWindowAfter(work) {
+      await work(new AbortController().signal);
+      return runWindow();
+    },
     startScheduler() {
       trace.push("start-scheduler");
     },
@@ -595,6 +600,51 @@ describe("local coach composition", () => {
       apiKey: "placeholder",
       athleteId: "athlete-b",
     });
+    await lifecycle.close();
+  });
+
+  it("passes the live intervals authority and one deterministic UTC history date into sync", async () => {
+    const home = await freshHome();
+    const context = fakeContext(home);
+    const selectedRuntime = runtime();
+    const backfill = vi.fn(async () => ({ pages: 1, artifacts: 0, reports: [] }));
+    const lifecycle = await compose(
+      home,
+      {
+        bootstrap: async () => reference(),
+        createRuntime: () => selectedRuntime,
+        createBackend: () => backend(),
+        createRepository: () => ({
+          insertIfAbsent: async () => false,
+          readCurrent: async () => undefined,
+        }),
+        createResolver: () => missingResolver(),
+        now: () => Date.parse("1998-07-18T23:59:59.000Z"),
+        operationsDependencies: { backfill },
+      },
+      context,
+      { apiKey: String.fromCharCode(111, 108, 100), athleteId: "stale-athlete" },
+    );
+    await lifecycle.operations.configureRuntime({
+      intervals: { api_key: String.fromCharCode(110, 101, 119), athlete_id: "live-athlete" },
+    });
+    await expect(lifecycle.operations.sync({})).resolves.toMatchObject({
+      published: true,
+      referenceSucceeded: true,
+    });
+    expect(backfill).toHaveBeenCalledTimes(1);
+    expect(backfill).toHaveBeenCalledWith({
+      home,
+      store: context.store,
+      apiKey: String.fromCharCode(110, 101, 119),
+      athleteId: "live-athlete",
+      historyNewestDate: "1998-07-18",
+      signal: expect.any(AbortSignal),
+    });
+    expect(backfill).not.toHaveBeenCalledWith(
+      expect.objectContaining({ apiKey: String.fromCharCode(111, 108, 100) }),
+    );
+    expect(JSON.stringify(backfill.mock.calls)).not.toContain("stale-athlete");
     await lifecycle.close();
   });
 

--- a/packages/coach/tests/operations.test.ts
+++ b/packages/coach/tests/operations.test.ts
@@ -39,6 +39,12 @@ function requestCounts(storeRequests: number, legacyRequests: number) {
   };
 }
 
+function intervalsCredentials(apiKey = "", athleteId = "0") {
+  return {
+    read: vi.fn(async () => ({ apiKey, athleteId })),
+  };
+}
+
 describe("coach operations", () => {
   it("imports synthetic activity files through the live store and deduplicates reruns", async () => {
     const root = await mkdtemp(join(await realpath(tmpdir()), "coach-operations-"));
@@ -59,7 +65,9 @@ describe("coach operations", () => {
       const operations = createCoachOperations({
         home: liveHome,
         context: liveContext,
-        runtime: { runWindow: vi.fn() },
+        runtime: { runWindowAfter: vi.fn() },
+        intervalsCredentials: intervalsCredentials(),
+        historyNewestDate: "1998-07-18",
         applyRuntimeConfig: async () => {},
       });
       const paths = ["brick-cycling.fit", "fallback-cycling.tcx", "fallback-cycling.gpx"].map(
@@ -101,7 +109,9 @@ describe("coach operations", () => {
           store,
           listener: {} as CoachStoreWriterContext["listener"],
         },
-        runtime: { runWindow: vi.fn() },
+        runtime: { runWindowAfter: vi.fn() },
+        intervalsCredentials: intervalsCredentials(),
+        historyNewestDate: "1998-07-18",
         applyRuntimeConfig: async () => {},
       });
       await expect(
@@ -170,16 +180,21 @@ describe("coach operations", () => {
         ? F
         : never
       : never;
-    const runWindow = vi.fn(async () => ({
-      published: true,
-      legacySucceeded: false,
-      counts: requestCounts(2, 1),
-    }));
+    const runWindowAfter = vi.fn(async (work: (signal: AbortSignal) => Promise<void>) => {
+      await work(new AbortController().signal);
+      return {
+        published: true,
+        legacySucceeded: false,
+        counts: requestCounts(2, 1),
+      };
+    });
     const operations = createCoachOperations(
       {
         home,
         context: context(),
-        runtime: { runWindow },
+        runtime: { runWindowAfter },
+        intervalsCredentials: intervalsCredentials(),
+        historyNewestDate: "1998-07-18",
         applyRuntimeConfig: async () => {},
       },
       { importFiles },
@@ -214,7 +229,7 @@ describe("coach operations", () => {
       requests: { store: 2, reference: 1, total: 3 },
     });
     expect(importFiles).toHaveBeenCalledTimes(1);
-    expect(runWindow).toHaveBeenCalledTimes(1);
+    expect(runWindowAfter).toHaveBeenCalledTimes(1);
   });
 
   it("serializes both methods in admission order and recovers after rejection", async () => {
@@ -233,7 +248,8 @@ describe("coach operations", () => {
         ? F
         : never
       : never;
-    const runWindow = vi.fn(async () => {
+    const runWindowAfter = vi.fn(async (work: (signal: AbortSignal) => Promise<void>) => {
+      await work(new AbortController().signal);
       trace.push("sync");
       return {
         published: false,
@@ -245,7 +261,9 @@ describe("coach operations", () => {
       {
         home,
         context: context(),
-        runtime: { runWindow },
+        runtime: { runWindowAfter },
+        intervalsCredentials: intervalsCredentials(),
+        historyNewestDate: "1998-07-18",
         applyRuntimeConfig: async () => {},
       },
       { importFiles },
@@ -260,6 +278,248 @@ describe("coach operations", () => {
     expect(trace).toEqual(["import-start", "import-end", "sync"]);
   });
 
+  it("reads live credentials after admission and orders backfill before refresh and completion", async () => {
+    const trace: string[] = [];
+    const selectedContext = context();
+    const credentials = {
+      read: vi.fn(async () => {
+        trace.push("credentials");
+        return {
+          apiKey: String.fromCharCode(116, 101, 115, 116),
+          athleteId: "synthetic-athlete",
+        };
+      }),
+    };
+    const backfill = vi.fn(async () => {
+      trace.push("backfill");
+      return { pages: 1, artifacts: 1, reports: [] };
+    });
+    const runWindowAfter = vi.fn(async (work: (signal: AbortSignal) => Promise<void>) => {
+      trace.push("admitted");
+      await work(new AbortController().signal);
+      trace.push("window");
+      return {
+        published: true,
+        legacySucceeded: true,
+        counts: requestCounts(3, 2),
+      };
+    });
+    const operations = createCoachOperations(
+      {
+        home,
+        context: selectedContext,
+        runtime: { runWindowAfter },
+        intervalsCredentials: credentials,
+        historyNewestDate: "1998-07-18",
+        applyRuntimeConfig: async () => {},
+      },
+      { backfill },
+    );
+    const result = await operations.sync({}, (event) => trace.push(event.phase));
+    trace.push("terminal");
+    expect(trace).toEqual([
+      "started",
+      "admitted",
+      "credentials",
+      "backfill",
+      "window",
+      "completed",
+      "terminal",
+    ]);
+    expect(credentials.read).toHaveBeenCalledTimes(1);
+    expect(backfill).toHaveBeenCalledWith({
+      home,
+      store: selectedContext.store,
+      apiKey: String.fromCharCode(116, 101, 115, 116),
+      athleteId: "synthetic-athlete",
+      historyNewestDate: "1998-07-18",
+      signal: expect.any(AbortSignal),
+    });
+    expect(result).toEqual({
+      schemaVersion: 1,
+      published: true,
+      referenceSucceeded: true,
+      requests: { store: 3, reference: 2, total: 5 },
+    });
+    const terminal = JSON.stringify(result);
+    for (const privateValue of [
+      String.fromCharCode(116, 101, 115, 116),
+      "synthetic-athlete",
+      "1998-07-18",
+      home.archiveDir,
+      "cursor",
+      "payload",
+      "cause",
+    ]) {
+      expect(terminal).not.toContain(privateValue);
+    }
+  });
+
+  it("skips backfill for every empty-key state and defaults an empty athlete id", async () => {
+    const pairs = [
+      { apiKey: "", athleteId: "", outcome: "skip" },
+      { apiKey: "", athleteId: "0", outcome: "skip" },
+      { apiKey: "", athleteId: "synthetic-athlete", outcome: "skip" },
+      { apiKey: String.fromCharCode(116, 101, 115, 116), athleteId: "0", outcome: "backfill" },
+      {
+        apiKey: String.fromCharCode(116, 101, 115, 116),
+        athleteId: "synthetic-athlete",
+        outcome: "backfill",
+      },
+      { apiKey: String.fromCharCode(116, 101, 115, 116), athleteId: "", outcome: "backfill" },
+    ] as const;
+    for (const options of pairs) {
+      const events: unknown[] = [];
+      const backfill = vi.fn(async () => ({ pages: 1, artifacts: 0, reports: [] }));
+      const refresh = vi.fn();
+      const runtime = {
+        credentials: intervalsCredentials(options.apiKey, options.athleteId),
+        async runWindowAfter(work: (signal: AbortSignal) => Promise<void>) {
+          await work(new AbortController().signal);
+          refresh();
+          return {
+            published: true,
+            legacySucceeded: true,
+            counts: requestCounts(0, 0),
+          };
+        },
+      };
+      const operations = createCoachOperations(
+        {
+          home,
+          context: context(),
+          runtime,
+          intervalsCredentials: runtime.credentials,
+          historyNewestDate: "1998-07-18",
+          applyRuntimeConfig: async () => {},
+        },
+        { backfill },
+      );
+      await expect(operations.sync({}, (event) => events.push(event))).resolves.toMatchObject({
+        schemaVersion: 1,
+      });
+      expect(events).toEqual([
+        { phase: "started", completed: 0, total: 1 },
+        { phase: "completed", completed: 1, total: 1 },
+      ]);
+      expect(refresh).toHaveBeenCalledTimes(1);
+      expect(backfill).toHaveBeenCalledTimes(options.outcome === "backfill" ? 1 : 0);
+      if (options.outcome === "backfill") {
+        expect(backfill).toHaveBeenCalledWith(
+          expect.objectContaining({
+            apiKey: options.apiKey,
+            athleteId: options.athleteId === "" ? "0" : options.athleteId,
+          }),
+        );
+      }
+    }
+  });
+
+  it("emits no false completion when backfill or the following refresh fails", async () => {
+    for (const failurePoint of ["backfill", "window"] as const) {
+      const events: unknown[] = [];
+      const refresh = vi.fn();
+      const backfill = vi.fn(async () => {
+        if (failurePoint === "backfill") throw new Error("synthetic backfill failure");
+        return { pages: 1, artifacts: 1, reports: [] };
+      });
+      const runtime = {
+        intervals: intervalsCredentials(
+          String.fromCharCode(116, 101, 115, 116),
+          "synthetic-athlete",
+        ),
+        async runWindowAfter(work: (signal: AbortSignal) => Promise<void>) {
+          await work(new AbortController().signal);
+          refresh();
+          if (failurePoint === "window") throw new Error("synthetic window failure");
+          return {
+            published: true,
+            legacySucceeded: true,
+            counts: requestCounts(0, 0),
+          };
+        },
+      };
+      const operations = createCoachOperations(
+        {
+          home,
+          context: context(),
+          runtime,
+          intervalsCredentials: runtime.intervals,
+          historyNewestDate: "1998-07-18",
+          applyRuntimeConfig: async () => {},
+        },
+        { backfill },
+      );
+      await expect(operations.sync({}, (event) => events.push(event))).rejects.toThrow(
+        `synthetic ${failurePoint} failure`,
+      );
+      expect(events).toEqual([{ phase: "started", completed: 0, total: 1 }]);
+      expect(refresh).toHaveBeenCalledTimes(failurePoint === "window" ? 1 : 0);
+    }
+  });
+
+  it("resumes a committed synthetic backfill step without duplicating input rows", async () => {
+    const root = await mkdtemp(join(await realpath(tmpdir()), "coach-sync-resume-"));
+    const liveHome: AthleteHome = {
+      root,
+      storeDir: join(root, "store"),
+      archiveDir: join(root, "archive"),
+      configDir: join(root, "config"),
+    };
+    const store = openSqliteStorage(join(root, "coach.db"));
+    try {
+      await runMigrations(store, MIGRATIONS);
+      await store.exec("CREATE TABLE synthetic_backfill_checkpoint (id TEXT PRIMARY KEY NOT NULL)");
+      let attempt = 0;
+      const backfill = vi.fn(async () => {
+        await store.run("INSERT OR IGNORE INTO synthetic_backfill_checkpoint (id) VALUES (?)", [
+          "page-1",
+        ]);
+        attempt += 1;
+        if (attempt === 1) throw new Error("synthetic interruption");
+        return { pages: 1, artifacts: 0, reports: [] };
+      });
+      const runtime = {
+        intervals: intervalsCredentials(
+          String.fromCharCode(116, 101, 115, 116),
+          "synthetic-athlete",
+        ),
+        async runWindowAfter(work: (signal: AbortSignal) => Promise<void>) {
+          await work(new AbortController().signal);
+          return {
+            published: true,
+            legacySucceeded: true,
+            counts: requestCounts(0, 0),
+          };
+        },
+      };
+      const operations = createCoachOperations(
+        {
+          home: liveHome,
+          context: {
+            home: liveHome,
+            store,
+            listener: {} as CoachStoreWriterContext["listener"],
+          },
+          runtime,
+          intervalsCredentials: runtime.intervals,
+          historyNewestDate: "1998-07-18",
+          applyRuntimeConfig: async () => {},
+        },
+        { backfill },
+      );
+      await expect(operations.sync({})).rejects.toThrow("synthetic interruption");
+      await expect(operations.sync({})).resolves.toMatchObject({ schemaVersion: 1 });
+      expect(
+        await store.get("SELECT count(*) AS count FROM synthetic_backfill_checkpoint"),
+      ).toEqual({ count: 1 });
+      expect(backfill).toHaveBeenCalledTimes(2);
+    } finally {
+      await store.close();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("applies llm-only, intervals-only, both, and superseding runtime requests without echo", async () => {
     const applied: unknown[] = [];
     const applyRuntimeConfig = vi.fn(async (request) => {
@@ -268,7 +528,9 @@ describe("coach operations", () => {
     const operations = createCoachOperations({
       home,
       context: context(),
-      runtime: { runWindow: vi.fn() },
+      runtime: { runWindowAfter: vi.fn() },
+      intervalsCredentials: intervalsCredentials(),
+      historyNewestDate: "1998-07-18",
       applyRuntimeConfig,
     });
     const llmFirst = {

--- a/packages/coach/tests/store-runtime.test.ts
+++ b/packages/coach/tests/store-runtime.test.ts
@@ -5,10 +5,16 @@ import type { Config, ReferenceRuntime } from "@enduragent/core";
 import type { ReferenceCaptureManifest } from "@enduragent/kernel/reference/capture";
 import type { ProducedLocalBundle } from "@enduragent/kernel/reference/local-bundle";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createStoreRuntime, STORE_REFRESH_INTERVAL_MS, type StoreRuntime } from "../src/store-runtime.js";
+import {
+  createStoreRuntime,
+  STORE_REFRESH_INTERVAL_MS,
+  type StoreRuntime,
+} from "../src/store-runtime.js";
 
 const roots: string[] = [];
-afterEach(async () => { for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true }); });
+afterEach(async () => {
+  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true });
+});
 
 const config: Config = {
   dataSource: "store", llm: { provider: "openai-codex", model: "gpt-5.4", apiKey: "" },
@@ -16,28 +22,53 @@ const config: Config = {
   session: { historyTokenBudgetRatio: 0.3, idleMinutes: 0, dailyResetHour: 4,
     resetArchiveRetentionDays: 0, timezone: "UTC" }, contextWindowTokens: 1000, dataDir: "unused",
 };
-const manifest = { capture_id: "12345678-1234-4123-8123-123456789abc",
-  plan: { frozenNow: "1998-07-18T12:00:00.000Z" } } as ReferenceCaptureManifest;
-const produced: ProducedLocalBundle = { captureId: manifest.capture_id, frozenNow: manifest.plan.frozenNow,
-  bundle: { activities: [], wellness: [], ftpHistory: [], athlete: { sportSettings: [] } } };
+const manifest = {
+  capture_id: "12345678-1234-4123-8123-123456789abc",
+  plan: { frozenNow: "1998-07-18T12:00:00.000Z" },
+} as ReferenceCaptureManifest;
+const produced: ProducedLocalBundle = {
+  captureId: manifest.capture_id,
+  frozenNow: manifest.plan.frozenNow,
+  bundle: { activities: [], wellness: [], ftpHistory: [], athlete: { sportSettings: [] } },
+};
 
 async function makeRuntime(runtimeConfig: Config = config, readConfig?: () => Config) {
-  const root = await mkdtemp(join(await realpath(tmpdir()), "store-runtime-")); roots.push(root);
+  const root = await mkdtemp(join(await realpath(tmpdir()), "store-runtime-"));
+  roots.push(root);
   let runtime!: StoreRuntime;
-  const reference = { scheduler: { stop: vi.fn() }, services: {},
+  const reference = {
+    scheduler: { stop: vi.fn() },
+    services: {},
     runScheduledOnce: vi.fn(async () => {
       runtime.attemptLedgerForRun().charge("legacy", "legacy:reference");
       return { kind: "ran", lastSyncAt: "1998-07-18T12:00:00.000Z", refreshed: [] } as const;
-    }) } as unknown as ReferenceRuntime;
-  const capture = vi.fn(async (options: Parameters<typeof import("../src/capture.js").runReferenceCapture>[0]) => {
-    options.attemptLedger!.charge("store", "store:settings");
-    return manifest;
-  });
+    }),
+  } as unknown as ReferenceRuntime;
+  const capture = vi.fn(
+    async (options: Parameters<typeof import("../src/capture.js").runReferenceCapture>[0]) => {
+      options.attemptLedger!.charge("store", "store:settings");
+      return manifest;
+    },
+  );
   const produce = vi.fn(async () => produced);
-  runtime = createStoreRuntime({ env: {}, config: runtimeConfig, readConfig, home: { root, storeDir: join(root, "store"),
-    archiveDir: join(root, "archive"), configDir: join(root, "config") }, reference,
-    dependencies: { capture, produce,
-      now: () => new Date("1998-07-18T12:00:00.000Z"), monotonicNow: () => 1 } });
+  runtime = createStoreRuntime({
+    env: {},
+    config: runtimeConfig,
+    readConfig,
+    home: {
+      root,
+      storeDir: join(root, "store"),
+      archiveDir: join(root, "archive"),
+      configDir: join(root, "config"),
+    },
+    reference,
+    dependencies: {
+      capture,
+      produce,
+      now: () => new Date("1998-07-18T12:00:00.000Z"),
+      monotonicNow: () => 1,
+    },
+  });
   return { runtime, capture, produce, reference };
 }
 
@@ -153,6 +184,102 @@ describe("StoreRuntime", () => {
     await runtime.close();
     await runtime.close();
     expect(clear).toHaveBeenCalledTimes(1);
+  });
+
+  it("settles an active window before exclusive work and coalesces refreshes behind it", async () => {
+    const { runtime, capture, reference } = await makeRuntime();
+    let releaseWindow!: () => void;
+    let captureCalls = 0;
+    capture.mockImplementation(async () => {
+      captureCalls += 1;
+      if (captureCalls === 1) {
+        await new Promise<void>((resolve) => {
+          releaseWindow = resolve;
+        });
+      }
+      return manifest;
+    });
+    const active = runtime.runWindow();
+    while (releaseWindow === undefined) await Promise.resolve();
+    let releaseWork!: () => void;
+    let markWorkStarted!: () => void;
+    const workStarted = new Promise<void>((resolve) => {
+      markWorkStarted = resolve;
+    });
+    const trace: string[] = [];
+    const after = runtime.runWindowAfter(async () => {
+      trace.push("work");
+      markWorkStarted();
+      await new Promise<void>((resolve) => {
+        releaseWork = resolve;
+      });
+    });
+    await Promise.resolve();
+    expect(trace).toEqual([]);
+    releaseWindow();
+    await active;
+    await workStarted;
+    const manual = runtime.runWindow();
+    expect(manual).toBe(after);
+    expect(capture).toHaveBeenCalledTimes(1);
+    expect(reference.runScheduledOnce).toHaveBeenCalledTimes(1);
+    releaseWork();
+    await expect(after).resolves.toMatchObject({ published: true });
+    expect(capture).toHaveBeenCalledTimes(2);
+    expect(reference.runScheduledOnce).toHaveBeenCalledTimes(2);
+    await runtime.close();
+  });
+
+  it("does not let failed work poison a later exclusive admission", async () => {
+    const { runtime, capture } = await makeRuntime();
+    await expect(
+      runtime.runWindowAfter(async () => {
+        throw new Error("synthetic work failure");
+      }),
+    ).rejects.toThrow("synthetic work failure");
+    expect(capture).not.toHaveBeenCalled();
+    await expect(runtime.runWindowAfter(async () => {})).resolves.toMatchObject({
+      published: true,
+    });
+    expect(capture).toHaveBeenCalledTimes(1);
+    await expect(runtime.runWindowAfter(null as never)).rejects.toThrow(
+      "Window work must be a function.",
+    );
+    await runtime.close();
+  });
+
+  it("aborts and drains pre-window work on close without starting the internal refresh", async () => {
+    const { runtime, capture, reference } = await makeRuntime();
+    let signal!: AbortSignal;
+    let settlements = 0;
+    const window = runtime.runWindowAfter(
+      (selectedSignal) =>
+        new Promise<void>((_, reject) => {
+          signal = selectedSignal;
+          selectedSignal.addEventListener(
+            "abort",
+            () => {
+              settlements += 1;
+              reject(selectedSignal.reason);
+            },
+            { once: true },
+          );
+        }),
+    );
+    while (signal === undefined) await Promise.resolve();
+    const rejectedWindow = expect(window).rejects.toThrow("Store runtime closed.");
+    const firstClose = runtime.close();
+    const secondClose = runtime.close();
+    expect(signal.aborted).toBe(true);
+    await expect(firstClose).resolves.toBeUndefined();
+    await expect(secondClose).resolves.toBeUndefined();
+    await rejectedWindow;
+    expect(settlements).toBe(1);
+    expect(capture).not.toHaveBeenCalled();
+    expect(reference.runScheduledOnce).not.toHaveBeenCalled();
+    await expect(runtime.runWindowAfter(async () => {})).rejects.toThrow(
+      "Store runtime is closed.",
+    );
   });
 
   it("cancels an active window when closed and rejects later windows", async () => {


### PR DESCRIPTION
## Summary

- run resumable training-history backfill inside the daemon's existing writer before current-state refresh
- render authenticated, request-correlated sync progress inside the chat-first desktop shell
- focus the ordinary coaching composer after a fully successful first sync without manufacturing an athlete message
- keep file import and sync CLI verbs on the same daemon operation authority

## Verification

- backfill watermark resumption, operation serialization, failure ordering, and result privacy
- first-sync state, progress validation, terminal result flags, retry epochs, and ordinary composer focus
- renderer dependency boundary plus Electron auth, Origin, CSP, sandbox, and token-leak regressions
- workspace typecheck, tests, lint, trademark, fixture-privacy, and desktop build
