### PR TITLE
feat(desktop): add streaming coach chat and training context

### DIFF
--- a/.changeset/desktop-chat-panels.md
+++ b/.changeset/desktop-chat-panels.md
@@ -1,0 +1,7 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Added streaming coach chat and a cycling training-context drawer for anchors, zones, Load, plan adherence, wellness, and display units.
+
+Add the desktop chat-first surface and persisted-state training panels.

--- a/apps/desktop-renderer/index.html
+++ b/apps/desktop-renderer/index.html
@@ -15,33 +15,12 @@
         </div>
       </header>
       <main class="conversation" aria-label="Coaching conversation">
-        <div class="thread" aria-live="polite"></div>
+        <div class="thread"></div>
       </main>
-      <div class="composer-wrap">
-        <form class="composer">
-          <label class="sr-only" for="message">Message your coach</label>
-          <textarea id="message" rows="1" placeholder="Message your coach…"></textarea>
-          <button type="submit" aria-label="Send message">↑</button>
-        </form>
-      </div>
-      <aside class="data-spine" aria-label="Training context drawer">
-        <button
-          type="button"
-          class="drawer-toggle"
-          aria-label="Open training context"
-          aria-expanded="false"
-        >
-          ▥
-        </button>
-      </aside>
+      <div class="composer-wrap"></div>
+      <aside class="data-spine" aria-label="Training data drawer"></aside>
     </div>
-    <aside class="drawer" aria-hidden="true" aria-label="Training context">
-      <div class="drawer-heading">
-        <h2>Training context</h2>
-        <button type="button" class="drawer-close" aria-label="Close training context">×</button>
-      </div>
-      <p>Training context will appear here after setup and sync.</p>
-    </aside>
+    <dialog id="training-context-drawer" class="drawer" aria-label="Training data"></dialog>
     <script type="module" src="/src/index.ts"></script>
   </body>
 </html>

--- a/apps/desktop-renderer/src/chat/controller.ts
+++ b/apps/desktop-renderer/src/chat/controller.ts
@@ -1,0 +1,226 @@
+import type { CoachClient, CoachClientTerminalEnvelope } from "@enduragent/coach-client";
+import { CoachClientDisconnectedError, CoachClientProtocolError } from "@enduragent/coach-client";
+import type { CoachTurnEventNotificationEnvelope, TurnEvent } from "@enduragent/coach-contract";
+import type { DesktopCoachClientProvider } from "../coach-client.js";
+import {
+  DESKTOP_CHAT_ID,
+  EMPTY_CHAT_STATE,
+  reduceChatState,
+  type ChatState,
+} from "../turn-state.js";
+
+export const CHAT_CONNECTION_INTERRUPTED_COPY =
+  "Connection interrupted. Your partial response is preserved.";
+export const CHAT_PROTOCOL_FAILURE_COPY =
+  "The coaching response could not be verified. Please try again.";
+export const CHAT_FAILURE_COPY = "The coach couldn't respond. Please try again.";
+
+export interface ChatView {
+  render(state: ChatState): void;
+}
+
+export interface ChatController {
+  submit(message: string): Promise<void>;
+  retryInterrupted(): Promise<void>;
+  dispose(): void;
+}
+
+export function createChatController(input: {
+  readonly clients: DesktopCoachClientProvider;
+  readonly view: ChatView;
+  readonly refreshTrainingContext: () => Promise<void>;
+}): ChatController {
+  let state = EMPTY_CHAT_STATE;
+  let sequence = 0;
+  let disposed = false;
+  let activeTask: Promise<void> | undefined;
+  let queuedRetry: Promise<void> | undefined;
+  let retryClient: CoachClient | undefined;
+
+  const nextId = (prefix: "request" | "message"): string => `${prefix}-${++sequence}`;
+  const render = (): void => {
+    if (disposed) return;
+    try {
+      input.view.render(state);
+    } catch {}
+  };
+  const reduce = (action: Parameters<typeof reduceChatState>[1]): void => {
+    state = reduceChatState(state, action);
+    render();
+  };
+
+  const run = (userMessage: string, includeUser: boolean, reconnect: boolean): Promise<void> => {
+    const requestKey = Number(nextId("request").slice("request-".length));
+    const userMessageId = nextId("message");
+    const assistantMessageId = nextId("message");
+    reduce({
+      type: "submit",
+      requestKey,
+      userMessage,
+      userMessageId,
+      assistantMessageId,
+      includeUser,
+    });
+    let callStarted = false;
+    const task = (async () => {
+      let boundRequestId: string | number | undefined;
+      let boundTurnId: string | undefined;
+      let pendingEnvelope: CoachTurnEventNotificationEnvelope | undefined;
+      let eventCount = 0;
+      let startSeen = false;
+      let finalText: string | undefined;
+      let terminal: CoachClientTerminalEnvelope | undefined;
+      let terminalHadFinal = false;
+      let protocolFault = false;
+      const current = (): boolean => !disposed && state.activeTurn?.requestKey === requestKey;
+      const failProtocol = (): void => {
+        protocolFault = true;
+      };
+
+      let client: CoachClient | undefined;
+      try {
+        if (reconnect) {
+          if (retryClient === undefined) {
+            client = await input.clients.reconnect();
+          } else {
+            const currentClient = await input.clients.getClient();
+            client =
+              currentClient === retryClient ? await input.clients.reconnect() : currentClient;
+          }
+          retryClient = undefined;
+        } else {
+          client = await input.clients.getClient();
+        }
+        if (!current()) return;
+        callStarted = true;
+        const result = await client.call(
+          "chat",
+          { chatId: DESKTOP_CHAT_ID, message: userMessage },
+          {
+            onNotificationEnvelope(envelope) {
+              if (!current() || protocolFault) return;
+              if (
+                envelope.method !== "coach.turnEvent" ||
+                envelope.params.requestMethod !== "chat" ||
+                envelope.params.turnId.length === 0
+              ) {
+                failProtocol();
+                return;
+              }
+              if (boundRequestId === undefined) {
+                boundRequestId = envelope.params.requestId;
+                boundTurnId = envelope.params.turnId;
+                reduce({ type: "bind-turn", requestKey, turnId: boundTurnId });
+              } else if (
+                envelope.params.requestId !== boundRequestId ||
+                envelope.params.turnId !== boundTurnId
+              ) {
+                failProtocol();
+                return;
+              }
+              pendingEnvelope = envelope;
+            },
+            onEvent(event: TurnEvent) {
+              if (!current() || protocolFault) return;
+              const envelope = pendingEnvelope;
+              pendingEnvelope = undefined;
+              if (
+                envelope === undefined ||
+                boundTurnId === undefined ||
+                event.turnId !== boundTurnId ||
+                envelope.params.event.turnId !== boundTurnId
+              ) {
+                failProtocol();
+                return;
+              }
+              if (event.type === "turn-start") {
+                if (eventCount !== 0 || startSeen || event.chatId !== DESKTOP_CHAT_ID) {
+                  failProtocol();
+                  return;
+                }
+                startSeen = true;
+              }
+              eventCount += 1;
+              if (event.type === "final-text") finalText = event.text;
+              reduce({ type: "event", requestKey, event });
+            },
+            onTerminalEnvelope(envelope) {
+              if (!current()) return;
+              terminal = envelope;
+              terminalHadFinal = finalText !== undefined;
+            },
+          },
+        );
+        if (!current()) return;
+        if (
+          protocolFault ||
+          terminal === undefined ||
+          !("result" in terminal) ||
+          !terminalHadFinal ||
+          finalText === undefined ||
+          result.text !== finalText
+        ) {
+          retryClient = client;
+          reduce({ type: "interrupt", requestKey, copy: CHAT_PROTOCOL_FAILURE_COPY });
+          return;
+        }
+        reduce({ type: "complete", requestKey });
+      } catch (error) {
+        if (!current()) return;
+        if (protocolFault || error instanceof CoachClientProtocolError) {
+          retryClient = client;
+          reduce({ type: "interrupt", requestKey, copy: CHAT_PROTOCOL_FAILURE_COPY });
+        } else if (error instanceof CoachClientDisconnectedError) {
+          retryClient = client;
+          reduce({ type: "interrupt", requestKey, copy: CHAT_CONNECTION_INTERRUPTED_COPY });
+        } else {
+          reduce({ type: "fail", requestKey, copy: CHAT_FAILURE_COPY });
+        }
+      } finally {
+        if (callStarted) {
+          try {
+            await input.refreshTrainingContext();
+          } catch {}
+        }
+      }
+    })();
+    activeTask = task;
+    void task.finally(() => {
+      if (activeTask === task) activeTask = undefined;
+    });
+    return task;
+  };
+
+  render();
+  return {
+    submit(message) {
+      if (!/\S/u.test(message) || disposed || state.status === "streaming") {
+        return activeTask ?? Promise.resolve();
+      }
+      return run(message, true, false);
+    },
+    retryInterrupted() {
+      if (disposed || state.status !== "interrupted" || state.activeTurn === null) {
+        return activeTask ?? Promise.resolve();
+      }
+      if (queuedRetry !== undefined) return queuedRetry;
+      const userMessage = state.activeTurn.userMessage;
+      if (activeTask === undefined) return run(userMessage, false, true);
+      const currentTask = activeTask;
+      const pending = currentTask
+        .then(() => {
+          if (disposed || state.status !== "interrupted") return;
+          return run(userMessage, false, true);
+        })
+        .finally(() => {
+          if (queuedRetry === pending) queuedRetry = undefined;
+        });
+      queuedRetry = pending;
+      return pending;
+    },
+    dispose() {
+      disposed = true;
+      sequence += 1;
+    },
+  };
+}

--- a/apps/desktop-renderer/src/chat/styles.css
+++ b/apps/desktop-renderer/src/chat/styles.css
@@ -1,0 +1,113 @@
+.chat-transcript {
+  display: grid;
+  gap: 18px;
+}
+
+.chat-messages {
+  display: grid;
+  gap: 28px;
+}
+
+.chat-message {
+  display: grid;
+  gap: 7px;
+  max-width: 78%;
+}
+
+.chat-message--athlete {
+  justify-self: end;
+  padding: 13px 17px;
+  border-radius: var(--radius) var(--radius) 6px var(--radius);
+  background: var(--moss-soft);
+}
+
+.chat-message--coach {
+  justify-self: start;
+}
+
+.chat-message[data-delivery="interrupted"] {
+  color: var(--muted);
+}
+
+.chat-message__role,
+.chat-message__text,
+.chat-notice {
+  margin: 0;
+}
+
+.chat-message__role {
+  color: var(--faint);
+  font:
+    11px/1.2 SFMono-Regular,
+    ui-monospace,
+    monospace;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.chat-message__text {
+  line-height: 1.6;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.chat-notice {
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.chat-retry {
+  justify-self: start;
+  padding: 8px 13px;
+  border: 1px solid var(--line-strong);
+  border-radius: 999px;
+  color: var(--moss-strong);
+  background: var(--surface-solid);
+  cursor: pointer;
+}
+
+.chat-composer__label {
+  display: block;
+  margin: 0 0 7px 14px;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.chat-composer__controls {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 42px;
+  align-items: end;
+  gap: 8px;
+  padding: 9px 9px 9px 17px;
+  border: 1px solid var(--line-strong);
+  border-radius: calc(var(--radius) + 6px);
+  background: var(--surface-solid);
+  box-shadow: 0 12px 38px rgb(29 48 38 / 10%);
+}
+
+.chat-composer__controls textarea {
+  min-height: 40px;
+  max-height: 140px;
+  padding: 8px 0;
+  resize: none;
+  border: 0;
+  outline: 0;
+  color: var(--ink);
+  background: transparent;
+}
+
+.chat-composer__controls button {
+  width: 42px;
+  height: 42px;
+  border: 0;
+  border-radius: 50%;
+  color: white;
+  background: var(--moss);
+  cursor: pointer;
+}
+
+.chat-composer__controls button:disabled {
+  cursor: default;
+  opacity: 0.45;
+}

--- a/apps/desktop-renderer/src/chat/view.ts
+++ b/apps/desktop-renderer/src/chat/view.ts
@@ -1,0 +1,122 @@
+import type { ChatView } from "./controller.js";
+
+export interface MountedChatView {
+  readonly view: ChatView;
+  bind(input: { readonly onSubmit: (message: string) => void; readonly onRetry: () => void }): void;
+  dispose(): void;
+}
+
+export function mountChatView(input: {
+  readonly conversation: HTMLElement;
+  readonly thread: HTMLElement;
+  readonly composerHost: HTMLElement;
+}): MountedChatView {
+  const transcript = document.createElement("section");
+  transcript.className = "chat-transcript";
+  transcript.setAttribute("role", "log");
+  transcript.setAttribute("aria-live", "polite");
+  transcript.setAttribute("aria-label", "Coach conversation");
+  const messages = document.createElement("div");
+  messages.className = "chat-messages";
+  const notice = document.createElement("p");
+  notice.className = "chat-notice";
+  notice.hidden = true;
+  const retry = document.createElement("button");
+  retry.type = "button";
+  retry.className = "chat-retry";
+  retry.textContent = "Retry message";
+  retry.hidden = true;
+  transcript.append(messages, notice, retry);
+  input.thread.append(transcript);
+
+  input.composerHost.replaceChildren();
+  const form = document.createElement("form");
+  form.className = "composer";
+  const label = document.createElement("label");
+  label.className = "chat-composer__label";
+  label.htmlFor = "message";
+  label.textContent = "Message your coach";
+  const controls = document.createElement("div");
+  controls.className = "chat-composer__controls";
+  const textarea = document.createElement("textarea");
+  textarea.id = "message";
+  textarea.rows = 2;
+  const submit = document.createElement("button");
+  submit.type = "submit";
+  submit.setAttribute("aria-label", "Send message");
+  submit.textContent = "↑";
+  controls.append(textarea, submit);
+  form.append(label, controls);
+  input.composerHost.append(form);
+
+  let handlers:
+    | { readonly onSubmit: (message: string) => void; readonly onRetry: () => void }
+    | undefined;
+  let disposed = false;
+
+  const onSubmit = (event: SubmitEvent): void => {
+    event.preventDefault();
+    if (submit.disabled) return;
+    const value = textarea.value;
+    if (!/\S/u.test(value)) return;
+    textarea.value = "";
+    handlers?.onSubmit(value);
+  };
+  const onKeydown = (event: KeyboardEvent): void => {
+    if (event.key === "Enter" && !event.shiftKey) {
+      event.preventDefault();
+      form.requestSubmit();
+    }
+  };
+  const onRetry = (): void => handlers?.onRetry();
+  form.addEventListener("submit", onSubmit);
+  textarea.addEventListener("keydown", onKeydown);
+  retry.addEventListener("click", onRetry);
+
+  return {
+    view: {
+      render(state) {
+        if (disposed) return;
+        const followsLatest =
+          input.conversation.scrollHeight -
+            input.conversation.scrollTop -
+            input.conversation.clientHeight <=
+          80;
+        const rows = state.messages.map((message) => {
+          const article = document.createElement("article");
+          article.className = `chat-message chat-message--${message.role}`;
+          article.dataset.delivery = message.delivery;
+          const role = document.createElement("p");
+          role.className = "chat-message__role";
+          role.textContent = message.role === "athlete" ? "You" : "Coach";
+          const text = document.createElement("p");
+          text.className = "chat-message__text";
+          text.textContent = message.text;
+          article.append(role, text);
+          return article;
+        });
+        messages.replaceChildren(...rows);
+        if (followsLatest) input.conversation.scrollTop = input.conversation.scrollHeight;
+        const contractCopy = state.activeTurn?.error?.athleteMessage ?? null;
+        const visibleNotice = contractCopy ?? state.progress;
+        notice.hidden = visibleNotice === null;
+        notice.textContent = visibleNotice ?? "";
+        retry.hidden = state.status !== "interrupted";
+        submit.disabled = state.status === "streaming";
+        textarea.disabled = state.status === "streaming";
+        input.conversation.dataset.chatStatus = state.status;
+      },
+    },
+    bind(next) {
+      handlers = next;
+    },
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      handlers = undefined;
+      form.removeEventListener("submit", onSubmit);
+      textarea.removeEventListener("keydown", onKeydown);
+      retry.removeEventListener("click", onRetry);
+    },
+  };
+}

--- a/apps/desktop-renderer/src/coach-client.ts
+++ b/apps/desktop-renderer/src/coach-client.ts
@@ -1,0 +1,116 @@
+import type { CoachClient } from "@enduragent/coach-client";
+import { CoachClientProtocolError, connectCoachClient } from "@enduragent/coach-client";
+
+export interface DesktopCoachClientProvider {
+  getClient(): Promise<CoachClient>;
+  reconnect(): Promise<CoachClient>;
+  close(): Promise<void>;
+}
+
+function validateConnection(value: unknown): { readonly url: string; readonly token: string } {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new CoachClientProtocolError();
+  }
+  const record = value as Record<string, unknown>;
+  if (Object.keys(record).sort().join(",") !== "token,url") {
+    throw new CoachClientProtocolError();
+  }
+  if (typeof record.url !== "string" || typeof record.token !== "string") {
+    throw new CoachClientProtocolError();
+  }
+  let url: URL;
+  try {
+    url = new URL(record.url);
+  } catch {
+    throw new CoachClientProtocolError();
+  }
+  if (
+    url.protocol !== "ws:" ||
+    url.hostname !== "127.0.0.1" ||
+    url.port === "" ||
+    !/^\d+$/u.test(url.port) ||
+    Number(url.port) < 1 ||
+    Number(url.port) > 65_535 ||
+    url.pathname !== "/rpc" ||
+    url.username !== "" ||
+    url.password !== "" ||
+    url.search !== "" ||
+    url.hash !== "" ||
+    !/^[A-Za-z0-9_-]{43}$/u.test(record.token)
+  ) {
+    throw new CoachClientProtocolError();
+  }
+  return record as { readonly url: string; readonly token: string };
+}
+
+export function createDesktopCoachClientProvider(): DesktopCoachClientProvider {
+  let client: CoachClient | undefined;
+  let connection: Promise<CoachClient> | undefined;
+  let reconnection: Promise<CoachClient> | undefined;
+  let closing: Promise<void> | undefined;
+
+  const connectFresh = (): Promise<CoachClient> => {
+    if (client !== undefined) return Promise.resolve(client);
+    if (connection !== undefined) return connection;
+    const auth = (
+      window as unknown as Window & {
+        readonly enduragentAuth: {
+          getDaemonConnection(): Promise<unknown>;
+        };
+      }
+    ).enduragentAuth;
+    const pending = auth
+      .getDaemonConnection()
+      .then(validateConnection)
+      .then((options) => connectCoachClient(options))
+      .then((connected) => {
+        if (connection === pending) client = connected;
+        return connected;
+      })
+      .catch((error: unknown) => {
+        if (connection === pending) connection = undefined;
+        throw error;
+      });
+    connection = pending;
+    return pending;
+  };
+
+  return {
+    getClient() {
+      return reconnection ?? connectFresh();
+    },
+    reconnect() {
+      if (reconnection !== undefined) return reconnection;
+      const previous = client;
+      const previousConnection = connection;
+      client = undefined;
+      const pending = Promise.resolve(previousConnection)
+        .catch(() => undefined)
+        .then((connected) => connected ?? previous)
+        .then(async (connected) => {
+          await connected?.close();
+          if (client === connected) client = undefined;
+          if (connection === previousConnection) connection = undefined;
+        })
+        .then(connectFresh)
+        .finally(() => {
+          if (reconnection === pending) reconnection = undefined;
+        });
+      reconnection = pending;
+      return pending;
+    },
+    close() {
+      if (closing !== undefined) return closing;
+      const pending = Promise.resolve(reconnection ?? connection)
+        .catch(() => undefined)
+        .then((connected) => connected ?? client)
+        .then((connected) => connected?.close())
+        .then(() => {
+          client = undefined;
+          connection = undefined;
+        });
+      closing = pending;
+      return pending;
+    },
+  };
+}

--- a/apps/desktop-renderer/src/index.ts
+++ b/apps/desktop-renderer/src/index.ts
@@ -1,57 +1,63 @@
-import type { CoachClient, CoachClientTerminalEnvelope } from "@enduragent/coach-client";
 import {
   CoachClientDisconnectedError,
   CoachClientProtocolError,
-  CoachRpcRemoteError,
-  connectCoachClient,
+  type CoachClient,
 } from "@enduragent/coach-client";
-import type { TurnEvent } from "@enduragent/coach-contract";
-import { createOnboardingBridge } from "./onboarding/bridge.js";
-import { mountOnboarding } from "./onboarding/mount.js";
+import { SaveIntakeRpcParamsSchema } from "@enduragent/coach-contract";
+import "./chat/styles.css";
+import "./training-context/styles.css";
 import "./onboarding/onboarding.css";
+import { createChatController } from "./chat/controller.js";
+import { mountChatView } from "./chat/view.js";
+import { createDesktopCoachClientProvider } from "./coach-client.js";
 import { createFirstSyncController, type FirstSyncState } from "./first-sync.js";
-import { createChatTurn, reduceChatTurn, type ChatTurnState } from "./turn-state.js";
+import { validateImportPaths, type OnboardingBridge } from "./onboarding/bridge.js";
+import { mountOnboarding } from "./onboarding/mount.js";
+import { createTrainingContextController } from "./training-context/controller.js";
+import { mountTrainingContextView } from "./training-context/view.js";
 
-const DESKTOP_CHAT_ID = "desktop" as const;
-const thread = document.querySelector<HTMLDivElement>(".thread")!;
-const composer = document.querySelector<HTMLFormElement>(".composer")!;
-const message = document.querySelector<HTMLTextAreaElement>("#message")!;
-const submit = composer.querySelector<HTMLButtonElement>('button[type="submit"]')!;
-const drawer = document.querySelector<HTMLElement>(".drawer")!;
-const drawerToggle = document.querySelector<HTMLButtonElement>(".drawer-toggle")!;
-const drawerClose = document.querySelector<HTMLButtonElement>(".drawer-close")!;
-const topbar = document.querySelector<HTMLElement>(".topbar")!;
-thread.closest("main")?.classList.add("desktop-shell");
-
-let connectionMaterialPromise: ReturnType<EnduragentAuth["getDaemonConnection"]> | undefined;
-let clientPromise: Promise<CoachClient> | undefined;
-
-function connectionMaterial() {
-  connectionMaterialPromise ??= window.enduragentAuth.getDaemonConnection().then((connection) => {
-    const url = new URL(connection.url);
-    if (
-      url.protocol !== "ws:" ||
-      url.hostname !== "127.0.0.1" ||
-      url.port === "" ||
-      !/^\d+$/.test(url.port) ||
-      url.pathname !== "/rpc" ||
-      url.username !== "" ||
-      url.password !== "" ||
-      url.search !== "" ||
-      url.hash !== "" ||
-      !/^[A-Za-z0-9_-]{43}$/.test(connection.token)
-    ) {
-      throw new CoachClientProtocolError();
-    }
-    return connection;
-  });
-  return connectionMaterialPromise;
+function one<T extends Element>(selector: string, kind: { new (): T }): T {
+  const matches = document.querySelectorAll(selector);
+  if (matches.length !== 1 || !(matches[0] instanceof kind)) {
+    throw new TypeError(`Desktop shell host is invalid: ${selector}`);
+  }
+  return matches[0];
 }
 
-function coachClient(): Promise<CoachClient> {
-  clientPromise ??= connectionMaterial().then((connection) => connectCoachClient(connection));
-  return clientPromise;
-}
+const conversation = one(".conversation", HTMLElement);
+const thread = one(".thread", HTMLElement);
+const composerHost = one(".composer-wrap", HTMLElement);
+const spine = one(".data-spine", HTMLElement);
+const drawer = one(".drawer", HTMLDialogElement);
+const topbar = one(".topbar", HTMLElement);
+one(".spend-meter", HTMLElement);
+conversation.classList.add("desktop-shell");
+
+const clients = createDesktopCoachClientProvider();
+const clientAfterFailure = async (failedClient: CoachClient | undefined) => {
+  if (failedClient === undefined) return clients.reconnect();
+  const current = await clients.getClient();
+  return current === failedClient ? clients.reconnect() : current;
+};
+const mountedTrainingContext = mountTrainingContextView({ spine, drawer });
+const trainingContextController = createTrainingContextController({
+  clients,
+  view: mountedTrainingContext.view,
+});
+const mountedChat = mountChatView({ conversation, thread, composerHost });
+const message = one("#message", HTMLTextAreaElement);
+const chatController = createChatController({
+  clients,
+  view: mountedChat.view,
+  refreshTrainingContext: () => trainingContextController.refresh(),
+});
+mountedChat.bind({
+  onSubmit: (message) => void chatController.submit(message),
+  onRetry: () => void chatController.retryInterrupted(),
+});
+mountedTrainingContext.bind({
+  onUnitsPreferenceChange: (value) => void trainingContextController.setUnitsPreference(value),
+});
 
 let firstSyncElement: HTMLElement | undefined;
 let firstSyncController: ReturnType<typeof createFirstSyncController>;
@@ -92,6 +98,7 @@ function renderFirstSync(state: FirstSyncState): void {
     title.textContent = "Training history is ready";
     detail.textContent = "Your coach is ready when you are.";
     body.append(eyebrow, title, detail);
+    void trainingContextController.refresh();
   } else if (state.kind === "protocol") {
     title.textContent = "Enduragent needs to reconnect safely";
     detail.textContent = "Quit and reopen Enduragent.";
@@ -114,15 +121,22 @@ function renderFirstSync(state: FirstSyncState): void {
   firstSyncElement = section;
 }
 
+let syncNeedsReconnect = false;
+let syncFailedClient: CoachClient | undefined;
 firstSyncController = createFirstSyncController({
   async callSync(options) {
+    let client: CoachClient | undefined;
     try {
-      const client = await coachClient();
+      client = syncNeedsReconnect
+        ? await clientAfterFailure(syncFailedClient)
+        : await clients.getClient();
+      syncNeedsReconnect = false;
+      syncFailedClient = undefined;
       return await client.call("sync", {}, options);
     } catch (error) {
-      if (!(error instanceof CoachClientProtocolError)) {
-        clientPromise = undefined;
-        connectionMaterialPromise = undefined;
+      if (error instanceof CoachClientDisconnectedError) {
+        syncNeedsReconnect = true;
+        syncFailedClient = client;
       }
       throw error;
     }
@@ -133,6 +147,54 @@ firstSyncController = createFirstSyncController({
   render: renderFirstSync,
 });
 
+let onboardingNeedsReconnect = false;
+let onboardingFailedClient: CoachClient | undefined;
+const onboardingClient = async () => {
+  const client = onboardingNeedsReconnect
+    ? await clientAfterFailure(onboardingFailedClient)
+    : await clients.getClient();
+  onboardingNeedsReconnect = false;
+  onboardingFailedClient = undefined;
+  return client;
+};
+const onboardingBridge: OnboardingBridge = {
+  credentialStatuses: () => window.enduragentAuth.credentialStatuses(),
+  writeCredential: (value) => window.enduragentAuth.writeCredential(value),
+  chooseImportFiles: () => window.enduragentAuth.chooseImportFiles(),
+  onDroppedImportFiles: (listener) => window.enduragentAuth.onDroppedImportFiles(listener),
+  async importFiles(paths, onProgress) {
+    let client: CoachClient | undefined;
+    try {
+      client = await onboardingClient();
+      return await client.call(
+        "importFiles",
+        { paths: [...validateImportPaths(paths)] },
+        { onNotificationEnvelope: onProgress },
+      );
+    } catch (error) {
+      if (error instanceof CoachClientDisconnectedError) {
+        onboardingNeedsReconnect = true;
+        onboardingFailedClient = client;
+      }
+      throw error;
+    }
+  },
+  async saveIntake(value) {
+    let client: CoachClient | undefined;
+    try {
+      client = await onboardingClient();
+      const result = await client.call("saveIntake", SaveIntakeRpcParamsSchema.parse(value));
+      if (!result.saved) throw new CoachClientProtocolError();
+    } catch (error) {
+      if (error instanceof CoachClientDisconnectedError) {
+        onboardingNeedsReconnect = true;
+        onboardingFailedClient = client;
+      }
+      throw error;
+    }
+  },
+};
+
 const setup = document.createElement("button");
 setup.type = "button";
 setup.className = "setup-button";
@@ -140,175 +202,33 @@ setup.textContent = "Setup";
 topbar.insertBefore(setup, topbar.lastElementChild);
 const onboarding = mountOnboarding({
   document,
-  bridge: createOnboardingBridge(),
+  bridge: onboardingBridge,
   opener: setup,
   onComplete: (completion) => void firstSyncController.start(completion),
 });
 setup.addEventListener("click", () => void onboarding.open());
-window.addEventListener("pagehide", () => firstSyncController.dispose(), { once: true });
+
+void trainingContextController.start();
 void onboarding.open();
-
-function setDrawerOpen(open: boolean): void {
-  drawer.classList.toggle("open", open);
-  drawer.setAttribute("aria-hidden", String(!open));
-  drawerToggle.setAttribute("aria-expanded", String(open));
-  if (open) drawerClose.focus();
-  else drawerToggle.focus();
-}
-
-drawerToggle.addEventListener("click", () => setDrawerOpen(true));
-drawerClose.addEventListener("click", () => setDrawerOpen(false));
-document.addEventListener("keydown", (event) => {
-  if (event.key === "Escape" && drawer.classList.contains("open")) setDrawerOpen(false);
-});
-
-function appendMessage(className: string, text: string): HTMLElement {
-  const element = document.createElement("div");
-  element.className = className;
-  element.textContent = text;
-  return element;
-}
-
-function createTurnRow(
-  state: ChatTurnState,
-  includeUser: boolean,
-): {
-  readonly row: HTMLElement;
-  readonly assistant: HTMLElement;
-} {
-  const row = document.createElement("article");
-  row.className = "turn";
-  if (includeUser) row.append(appendMessage("message user-message", state.userText));
-  const assistant = appendMessage("message assistant-message", "");
-  row.append(assistant);
-  if (firstSyncElement === undefined) thread.append(row);
-  else thread.insertBefore(row, firstSyncElement);
-  row.scrollIntoView({ block: "end" });
-  return { row, assistant };
-}
-
-function renderAssistant(input: {
-  readonly state: ChatTurnState;
-  readonly row: HTMLElement;
-  readonly assistant: HTMLElement;
-  readonly retry: () => void;
-}): void {
-  const delivery = input.state.assistant;
-  input.assistant.replaceChildren();
-  input.assistant.removeAttribute("aria-label");
-  input.row.classList.toggle("interrupted", delivery.status === "aborted");
-  if (delivery.status === "failed") {
-    input.assistant.textContent = delivery.message;
-    return;
-  }
-  input.assistant.append(document.createTextNode(delivery.text));
-  if (delivery.status === "aborted") {
-    input.assistant.setAttribute("aria-label", "Response interrupted");
-    const retry = document.createElement("button");
-    retry.type = "button";
-    retry.className = "retry";
-    retry.textContent = "Retry";
-    retry.addEventListener(
-      "click",
-      () => {
-        retry.disabled = true;
-        input.retry();
-      },
-      { once: true },
-    );
-    input.assistant.append(retry);
-  }
-}
-
-async function startTurn(userText: string, includeUser = true): Promise<void> {
-  let state = createChatTurn(userText);
-  const elements = createTurnRow(state, includeUser);
-  const generation = { active: true };
-  const render = (): void => {
-    renderAssistant({
-      state,
-      ...elements,
-      retry: () => {
-        void startTurn(userText, false);
-      },
-    });
-  };
-  render();
-  let client: CoachClient;
-  try {
-    client = await coachClient();
-  } catch {
-    state = reduceChatTurn(state, { type: "protocol-failure" });
-    render();
-    submit.disabled = false;
-    message.disabled = false;
-    return;
-  }
-  let terminal: CoachClientTerminalEnvelope | undefined;
-  const call = client.call(
-    "chat",
-    { chatId: DESKTOP_CHAT_ID, message: userText },
-    {
-      onEvent(event: TurnEvent) {
-        if (!generation.active) return;
-        state = reduceChatTurn(state, { type: "event", event });
-        render();
-      },
-      onNotificationEnvelope() {},
-      onTerminalEnvelope(envelope) {
-        if (generation.active) terminal = envelope;
-      },
-    },
-  );
-  submit.disabled = false;
-  message.disabled = false;
-  try {
-    const result = await call;
-    if (!generation.active || terminal === undefined) return;
-    state = reduceChatTurn(state, { type: "success", text: result.text });
-    render();
-  } catch (error) {
-    if (!generation.active) return;
-    if (error instanceof CoachClientDisconnectedError) {
-      generation.active = false;
-      clientPromise = undefined;
-      state = reduceChatTurn(state, { type: "abort" });
-      render();
-      return;
-    }
-    state = reduceChatTurn(state, {
-      type: error instanceof CoachClientProtocolError ? "protocol-failure" : "remote-failure",
-    });
-    if (error instanceof CoachRpcRemoteError)
-      state = reduceChatTurn(state, { type: "remote-failure" });
-    render();
-  } finally {
-    generation.active = false;
-  }
-}
-
-composer.addEventListener("submit", (event) => {
-  event.preventDefault();
-  const text = message.value;
-  if (!/\S/u.test(text) || submit.disabled) return;
-  submit.disabled = true;
-  message.disabled = true;
-  message.value = "";
-  void startTurn(text);
-});
-
-message.addEventListener("keydown", (event) => {
-  if (event.key === "Enter" && !event.shiftKey) {
-    event.preventDefault();
-    composer.requestSubmit();
-  }
-});
-
-void coachClient().then(
+void clients.getClient().then(
   () => {
     document.documentElement.dataset.rpc = "connected";
   },
   () => {
     document.documentElement.dataset.rpc = "failed";
   },
+);
+
+window.addEventListener(
+  "pagehide",
+  () => {
+    onboarding.dispose();
+    firstSyncController.dispose();
+    chatController.dispose();
+    mountedChat.dispose();
+    trainingContextController.dispose();
+    mountedTrainingContext.dispose();
+    void clients.close();
+  },
+  { once: true },
 );

--- a/apps/desktop-renderer/src/styles.css
+++ b/apps/desktop-renderer/src/styles.css
@@ -3,11 +3,18 @@
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   --canvas: #f4f6f5;
   --surface: #ffffff;
+  --surface-solid: #ffffff;
+  --surface-soft: #f8faf9;
   --ink: #17211c;
   --muted: #68736d;
+  --faint: #849089;
   --line: #dce3df;
+  --line-strong: #c5d0ca;
   --moss: #355e48;
+  --moss-strong: #1e5a3d;
   --moss-soft: #e5eee8;
+  --coral: #c96d58;
+  --radius: 16px;
   --focus: #7ba589;
 }
 
@@ -29,12 +36,14 @@ body {
 }
 
 button,
-textarea {
+textarea,
+input {
   font: inherit;
 }
 
 button:focus-visible,
-textarea:focus-visible {
+textarea:focus-visible,
+input:focus-visible {
   outline: 3px solid var(--focus);
   outline-offset: 2px;
 }
@@ -46,6 +55,8 @@ textarea:focus-visible {
   width: 100%;
   height: 100%;
   background: var(--canvas);
+  color: var(--ink);
+  font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif;
 }
 
 .topbar {
@@ -56,6 +67,7 @@ textarea:focus-visible {
   padding: 0 28px;
   border-bottom: 1px solid var(--line);
   background: color-mix(in srgb, var(--canvas) 88%, transparent);
+  min-height: 54px;
 }
 
 .brand {
@@ -83,34 +95,6 @@ textarea:focus-visible {
 .thread {
   width: min(820px, calc(100% - 48px));
   margin: 0 auto;
-}
-
-.turn {
-  display: grid;
-  gap: 16px;
-  margin-bottom: 34px;
-}
-
-.message {
-  max-width: 78%;
-  line-height: 1.55;
-  white-space: pre-wrap;
-  overflow-wrap: anywhere;
-}
-
-.user-message {
-  justify-self: end;
-  padding: 12px 16px;
-  border-radius: 18px 18px 5px 18px;
-  background: var(--moss-soft);
-}
-
-.assistant-message {
-  justify-self: start;
-}
-
-.interrupted .assistant-message {
-  color: var(--muted);
 }
 
 .first-sync {
@@ -199,62 +183,15 @@ textarea:focus-visible {
   }
 }
 
-.retry {
-  display: block;
-  margin-top: 12px;
-  padding: 7px 12px;
-  border: 1px solid var(--line);
-  border-radius: 999px;
-  color: var(--moss);
-  background: var(--surface);
-  cursor: pointer;
-}
-
 .composer-wrap {
-  position: fixed;
-  right: 48px;
+  position: sticky;
   bottom: 0;
-  left: 0;
-  padding: 28px max(24px, calc((100% - 48px - 820px) / 2));
-  background: linear-gradient(transparent, var(--canvas) 36%);
-}
-
-.composer {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) 38px;
-  align-items: end;
-  gap: 8px;
-  padding: 10px 10px 10px 18px;
-  border: 1px solid var(--line);
-  border-radius: 22px;
-  background: var(--surface);
-  box-shadow: 0 10px 32px rgb(29 48 38 / 9%);
-}
-
-.composer textarea {
-  min-height: 38px;
-  max-height: 140px;
-  padding: 8px 0;
-  resize: none;
-  border: 0;
-  outline: 0;
-  color: var(--ink);
-  background: transparent;
-}
-
-.composer button {
-  width: 38px;
-  height: 38px;
-  border: 0;
-  border-radius: 50%;
-  color: white;
-  background: var(--moss);
-  cursor: pointer;
-}
-
-.composer button:disabled {
-  cursor: default;
-  opacity: 0.45;
+  z-index: 2;
+  grid-column: 1;
+  grid-row: 2;
+  align-self: end;
+  padding: 12px max(24px, calc((100% - 48px - 820px) / 2)) 18px;
+  background: linear-gradient(transparent, var(--canvas) 28%);
 }
 
 .data-spine {
@@ -267,62 +204,19 @@ textarea:focus-visible {
   background: var(--surface);
 }
 
-.drawer-toggle,
-.drawer-close {
-  border: 0;
-  color: var(--muted);
-  background: transparent;
-  cursor: pointer;
-}
-
-.drawer-toggle {
-  width: 32px;
-  height: 32px;
-  font-size: 18px;
-}
-
 .drawer {
   position: fixed;
-  z-index: 3;
-  top: 0;
-  right: 48px;
-  width: min(420px, calc(100% - 96px));
+  inset: 0 0 0 auto;
+  width: min(420px, calc(100vw - 28px));
+  max-width: none;
   height: 100%;
-  padding: 26px;
-  border-left: 1px solid var(--line);
-  background: var(--surface);
-  box-shadow: -18px 0 50px rgb(28 41 34 / 12%);
-  transform: translateX(calc(100% + 52px));
-  visibility: hidden;
-  transition:
-    transform 180ms ease,
-    visibility 180ms;
+  max-height: none;
+  overflow-y: auto;
+  transform: translateX(100%);
 }
 
-.drawer.open {
+.drawer[open] {
   transform: translateX(0);
-  visibility: visible;
-}
-
-.drawer-heading {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
-
-.drawer h2 {
-  margin: 0;
-  font-size: 18px;
-}
-
-.drawer p {
-  margin-top: 28px;
-  color: var(--muted);
-  line-height: 1.5;
-}
-
-.drawer-close {
-  font-size: 26px;
 }
 
 .sr-only {
@@ -338,16 +232,31 @@ textarea:focus-visible {
   :root {
     --canvas: #141916;
     --surface: #1c231f;
+    --surface-solid: #202923;
+    --surface-soft: #18201b;
     --ink: #edf3ef;
     --muted: #9eaaa3;
+    --faint: #7f8c84;
     --line: #303b35;
+    --line-strong: #46534c;
     --moss: #79a889;
+    --moss-strong: #9cc8aa;
     --moss-soft: #263a2e;
+    --coral: #df8a75;
     --focus: #93b9a0;
   }
 }
 
 @media (max-width: 760px) {
+  .thread {
+    width: calc(100% - 32px);
+  }
+
+  .composer-wrap {
+    padding-right: 16px;
+    padding-left: 16px;
+  }
+
   .first-sync {
     width: calc(100% - 32px);
     margin-right: 16px;

--- a/apps/desktop-renderer/src/training-context/controller.ts
+++ b/apps/desktop-renderer/src/training-context/controller.ts
@@ -1,0 +1,229 @@
+import {
+  CoachClientDisconnectedError,
+  CoachClientProtocolError,
+  type CoachClient,
+} from "@enduragent/coach-client";
+import {
+  UNKNOWN_CYCLING_TRAINING_CONTEXT,
+  UnitsPreferenceSchema,
+  type CyclingTrainingContext,
+  type Freshness,
+  type UnitsPreference,
+} from "@enduragent/coach-contract";
+import type { DesktopCoachClientProvider } from "../coach-client.js";
+
+export type TrainingContextStatus = "loading" | "ready" | "unavailable" | "refresh-unavailable";
+
+export type UnitsPreferenceStatus = "loading" | "ready" | "saving" | "unavailable";
+
+export interface UnitsPreferenceViewState {
+  readonly status: UnitsPreferenceStatus;
+  readonly value: UnitsPreference;
+  readonly source: "cycling" | "athlete" | "default";
+}
+
+export interface TrainingContextMetadata {
+  readonly lastUpdated: string;
+  readonly lastSynced: string | null;
+  readonly freshness: Freshness;
+  readonly degraded: boolean;
+}
+
+export interface TrainingContextViewState {
+  readonly status: TrainingContextStatus;
+  readonly metadata: TrainingContextMetadata | null;
+  readonly trainingContext: CyclingTrainingContext;
+  readonly unitsPreference: UnitsPreferenceViewState;
+}
+
+export interface TrainingContextView {
+  render(state: TrainingContextViewState): void;
+}
+
+export interface TrainingContextController {
+  start(): Promise<void>;
+  refresh(): Promise<void>;
+  setUnitsPreference(value: UnitsPreference): Promise<void>;
+  dispose(): void;
+}
+
+export function createTrainingContextController(input: {
+  readonly clients: DesktopCoachClientProvider;
+  readonly view: TrainingContextView;
+}): TrainingContextController {
+  let disposed = false;
+  let generation = 0;
+  let stateRequest: Promise<void> | undefined;
+  let queuedStateRequest: Promise<void> | undefined;
+  let unitsRequest: Promise<void> | undefined;
+  let unitsTail = Promise.resolve();
+  let hasState = false;
+  let stateNeedsReconnect = false;
+  let stateFailedClient: CoachClient | undefined;
+  let unitsNeedRead = false;
+  let unitsFailedClient: CoachClient | undefined;
+  let state: TrainingContextViewState = {
+    status: "loading",
+    metadata: null,
+    trainingContext: UNKNOWN_CYCLING_TRAINING_CONTEXT,
+    unitsPreference: { status: "loading", value: "metric", source: "default" },
+  };
+
+  const render = (): void => {
+    if (!disposed) input.view.render(state);
+  };
+  const update = (next: Partial<TrainingContextViewState>): void => {
+    state = { ...state, ...next };
+    render();
+  };
+  const updateUnits = (next: UnitsPreferenceViewState): void => {
+    state = { ...state, unitsPreference: next };
+    render();
+  };
+
+  const clientAfterFailure = async (failedClient: CoachClient | undefined) => {
+    if (failedClient === undefined) return input.clients.reconnect();
+    const current = await input.clients.getClient();
+    return current === failedClient ? input.clients.reconnect() : current;
+  };
+
+  const fetchState = (): Promise<void> => {
+    if (stateRequest !== undefined) return stateRequest;
+    const selectedGeneration = ++generation;
+    if (!hasState) update({ status: "loading" });
+    let selectedClient: CoachClient | undefined;
+    const pending = (
+      stateNeedsReconnect ? clientAfterFailure(stateFailedClient) : input.clients.getClient()
+    )
+      .then((client) => {
+        selectedClient = client;
+        stateNeedsReconnect = false;
+        stateFailedClient = undefined;
+        return client.call("getAthleteState", {});
+      })
+      .then((athleteState) => {
+        if (disposed || selectedGeneration !== generation) return;
+        hasState = true;
+        update({
+          status: "ready",
+          metadata: {
+            lastUpdated: athleteState.lastUpdated,
+            lastSynced: athleteState.lastSynced,
+            freshness: athleteState.freshness,
+            degraded: athleteState.degraded,
+          },
+          trainingContext: athleteState.trainingContext ?? UNKNOWN_CYCLING_TRAINING_CONTEXT,
+        });
+      })
+      .catch((error: unknown) => {
+        if (disposed || selectedGeneration !== generation) return;
+        if (
+          error instanceof CoachClientDisconnectedError ||
+          error instanceof CoachClientProtocolError
+        ) {
+          stateNeedsReconnect = true;
+          stateFailedClient = selectedClient;
+        }
+        update({ status: hasState ? "refresh-unavailable" : "unavailable" });
+      })
+      .finally(() => {
+        if (stateRequest === pending) stateRequest = undefined;
+      });
+    stateRequest = pending;
+    return pending;
+  };
+
+  const refreshState = (): Promise<void> => {
+    if (stateRequest === undefined) return fetchState();
+    if (queuedStateRequest !== undefined) return queuedStateRequest;
+    const active = stateRequest;
+    const queued = active
+      .then(() => {
+        if (disposed) return;
+        queuedStateRequest = undefined;
+        return fetchState();
+      })
+      .finally(() => {
+        if (queuedStateRequest === queued) queuedStateRequest = undefined;
+      });
+    queuedStateRequest = queued;
+    return queued;
+  };
+
+  const fetchUnits = (reconnect: boolean): Promise<void> => {
+    if (unitsRequest !== undefined) return unitsRequest;
+    updateUnits({ ...state.unitsPreference, status: "loading" });
+    let selectedClient: CoachClient | undefined;
+    const pending = (reconnect ? clientAfterFailure(unitsFailedClient) : input.clients.getClient())
+      .then((client) => {
+        selectedClient = client;
+        return client;
+      })
+      .then((client) => client.call("getUnitsPreference", {}))
+      .then((result) => {
+        if (disposed) return;
+        unitsNeedRead = false;
+        unitsFailedClient = undefined;
+        updateUnits({ status: "ready", value: result.value, source: result.source });
+      })
+      .catch((error: unknown) => {
+        if (disposed) return;
+        if (
+          error instanceof CoachClientDisconnectedError ||
+          error instanceof CoachClientProtocolError
+        ) {
+          unitsNeedRead = true;
+          unitsFailedClient = selectedClient;
+        }
+        updateUnits({ ...state.unitsPreference, status: "unavailable" });
+      })
+      .finally(() => {
+        if (unitsRequest === pending) unitsRequest = undefined;
+      });
+    unitsRequest = pending;
+    return pending;
+  };
+
+  render();
+  return {
+    async start() {
+      await Promise.all([fetchState(), fetchUnits(false)]);
+    },
+    refresh: refreshState,
+    setUnitsPreference(value) {
+      const parsed = UnitsPreferenceSchema.parse(value);
+      const task = unitsTail.then(async () => {
+        if (disposed) return;
+        if (unitsNeedRead) {
+          await fetchUnits(true);
+          if (disposed || unitsNeedRead || state.unitsPreference.value === parsed) return;
+        }
+        const previous = state.unitsPreference;
+        updateUnits({ ...previous, status: "saving" });
+        let client: CoachClient | undefined;
+        try {
+          client = await input.clients.getClient();
+          const result = await client.call("setUnitsPreference", { value: parsed });
+          if (disposed) return;
+          updateUnits({ status: "ready", value: result.value, source: result.source });
+        } catch (error) {
+          if (disposed) return;
+          if (
+            error instanceof CoachClientDisconnectedError ||
+            error instanceof CoachClientProtocolError
+          ) {
+            unitsNeedRead = true;
+            unitsFailedClient = client;
+          }
+          updateUnits({ ...previous, status: "unavailable" });
+        }
+      });
+      unitsTail = task.catch(() => {});
+      return task;
+    },
+    dispose() {
+      disposed = true;
+      generation += 1;
+    },
+  };
+}

--- a/apps/desktop-renderer/src/training-context/format.ts
+++ b/apps/desktop-renderer/src/training-context/format.ts
@@ -1,0 +1,21 @@
+export function formatDateLabel(value: string): string {
+  const match = /^(\d{4}-\d{2}-\d{2})/u.exec(value);
+  if (match === null) return "Unknown date";
+  const date = new Date(`${match[1]}T00:00:00.000Z`);
+  return Number.isFinite(date.getTime()) && date.toISOString().slice(0, 10) === match[1]
+    ? match[1]
+    : "Unknown date";
+}
+
+export function formatWholeNumber(value: number): string {
+  return Math.round(value).toString();
+}
+
+export function formatPercentage(value: number): string {
+  return `${Math.round(value * 100)}%`;
+}
+
+export function formatSleepDuration(seconds: number): string {
+  const minutes = Math.round(seconds / 60);
+  return `${Math.floor(minutes / 60)}h ${minutes % 60}m`;
+}

--- a/apps/desktop-renderer/src/training-context/styles.css
+++ b/apps/desktop-renderer/src/training-context/styles.css
@@ -1,0 +1,293 @@
+.data-spine {
+  width: 48px;
+}
+
+.drawer-toggle,
+.drawer-close {
+  border: 0;
+  color: var(--muted);
+  background: transparent;
+  cursor: pointer;
+}
+
+.drawer-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  height: 100%;
+  padding: 14px 0;
+}
+
+.data-spine__copy {
+  color: var(--moss-strong);
+  font:
+    650 11px/1 SFMono-Regular,
+    ui-monospace,
+    monospace;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  writing-mode: vertical-rl;
+  transform: rotate(180deg);
+}
+
+.drawer {
+  --attention: #b47a2c;
+  z-index: 4;
+  margin: 0;
+  padding: 26px;
+  border: 0;
+  border-left: 1px solid var(--line);
+  color: var(--ink);
+  background: var(--surface-solid);
+  box-shadow: -18px 0 50px rgb(28 41 34 / 16%);
+  transition: transform 180ms ease;
+}
+
+.drawer::backdrop {
+  background: rgb(12 20 16 / 26%);
+}
+
+.drawer-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 18px;
+  padding-bottom: 22px;
+  border-bottom: 1px solid var(--line);
+}
+
+.drawer-heading h2 {
+  margin: 0;
+  font:
+    600 24px/1.15 Georgia,
+    serif;
+}
+
+.drawer-close {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  font-size: 25px;
+  line-height: 1;
+}
+
+.drawer-close:hover {
+  background: var(--surface-soft);
+}
+
+.drawer-metadata {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 7px;
+  margin-top: 10px;
+}
+
+.drawer-metadata__item,
+.context-panel__meta,
+.units-setting__helper,
+.units-setting__status {
+  margin: 0;
+  color: var(--muted);
+  font:
+    11px/1.45 SFMono-Regular,
+    ui-monospace,
+    monospace;
+}
+
+.drawer-status {
+  margin: 18px 0 0;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.context-panel {
+  padding: 24px 0;
+  border-bottom: 1px solid var(--line);
+}
+
+.context-panel h3,
+.context-panel h4 {
+  margin: 0;
+}
+
+.context-panel h3 {
+  font-size: 14px;
+  letter-spacing: -0.01em;
+}
+
+.context-panel h4 {
+  margin-top: 20px;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.context-panel__body {
+  margin-top: 13px;
+}
+
+.context-panel__value {
+  margin: 0 0 6px;
+  font:
+    600 36px/1 Georgia,
+    serif;
+  font-variant-numeric: tabular-nums;
+}
+
+.context-panel__support,
+.context-panel__empty {
+  margin: 9px 0 0;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.context-badge {
+  display: inline-flex;
+  align-items: center;
+  width: max-content;
+  margin: 4px 0 8px;
+  padding: 4px 7px;
+  border-radius: 999px;
+  color: var(--moss-strong);
+  background: var(--moss-soft);
+  font:
+    650 10px/1 SFMono-Regular,
+    ui-monospace,
+    monospace;
+  text-transform: capitalize;
+}
+
+.context-badge--aging,
+.context-badge--stale,
+.context-badge--very-stale {
+  color: var(--attention);
+  background: color-mix(in srgb, var(--attention) 13%, transparent);
+}
+
+.zone-list {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 8px 16px;
+  margin: 10px 0 0;
+  font-size: 12px;
+}
+
+.zone-list dt,
+.zone-list dd {
+  margin: 0;
+}
+
+.zone-list dd {
+  font-family: SFMono-Regular, ui-monospace, monospace;
+  font-variant-numeric: tabular-nums;
+}
+
+.zone-list__overlap::after {
+  color: var(--faint);
+  content: " · overlaps";
+}
+
+.plan-list {
+  display: grid;
+  gap: 12px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.plan-list li {
+  display: grid;
+  gap: 4px;
+  padding: 11px 12px;
+  border-radius: calc(var(--radius) - 5px);
+  background: var(--surface-soft);
+}
+
+.plan-list strong {
+  font-size: 13px;
+}
+
+.plan-list span {
+  color: var(--muted);
+  font:
+    11px/1.4 SFMono-Regular,
+    ui-monospace,
+    monospace;
+}
+
+.wellness-list {
+  display: grid;
+  gap: 10px;
+  margin-top: 12px;
+}
+
+.wellness-row {
+  display: grid;
+  grid-template-columns: 76px 74px minmax(80px, 1fr);
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+}
+
+.wellness-row__value,
+.wellness-empty {
+  color: var(--muted);
+  font-family: SFMono-Regular, ui-monospace, monospace;
+  font-size: 10px;
+}
+
+.wellness-sparkline {
+  width: 100%;
+  height: 30px;
+  overflow: visible;
+}
+
+.wellness-sparkline polyline {
+  fill: none;
+  stroke: var(--moss);
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 2;
+}
+
+.units-setting {
+  display: grid;
+  gap: 12px;
+  margin: 24px 0 8px;
+  padding: 0;
+  border: 0;
+}
+
+.units-setting legend {
+  margin-bottom: 14px;
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.units-setting label {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  font-size: 13px;
+}
+
+.units-setting input {
+  accent-color: var(--moss);
+}
+
+@media (max-width: 720px) {
+  .drawer {
+    width: calc(100vw - 28px);
+    padding: 22px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .drawer,
+  .chat-notice {
+    animation-duration: 0.01ms !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/apps/desktop-renderer/src/training-context/view.ts
+++ b/apps/desktop-renderer/src/training-context/view.ts
@@ -1,0 +1,391 @@
+import type {
+  CyclingTrainingContext,
+  TrainingContextUnknownReason,
+  UnitsPreference,
+  WellnessSeries,
+} from "@enduragent/coach-contract";
+import type { TrainingContextView, TrainingContextViewState } from "./controller.js";
+import {
+  formatDateLabel,
+  formatPercentage,
+  formatSleepDuration,
+  formatWholeNumber,
+} from "./format.js";
+
+export const TRAINING_CONTEXT_DRAWER_ID = "training-context-drawer";
+export const MAX_VISIBLE_PLAN_ITEMS = 7;
+
+export interface MountedTrainingContextView {
+  readonly view: TrainingContextView;
+  bind(input: { readonly onUnitsPreferenceChange: (value: UnitsPreference) => void }): void;
+  dispose(): void;
+}
+
+const unknownCopy: Record<TrainingContextUnknownReason, string> = {
+  "not-synced": "Not synced yet",
+  "missing-anchor": "No cycling FTP anchor is available",
+  "no-platform-load": "No platform Load is available for the last 7 days",
+  "no-plan": "No planned cycling workouts are available",
+  "insufficient-data": "Not enough persisted data to show this yet",
+  "no-wellness": "No wellness readings are available",
+};
+
+function paragraph(className: string, value: string): HTMLParagraphElement {
+  const node = document.createElement("p");
+  node.className = className;
+  node.textContent = value;
+  return node;
+}
+
+function section(title: string): { readonly root: HTMLElement; readonly body: HTMLElement } {
+  const root = document.createElement("section");
+  root.className = "context-panel";
+  const heading = document.createElement("h3");
+  heading.textContent = title;
+  const body = document.createElement("div");
+  body.className = "context-panel__body";
+  root.append(heading, body);
+  return { root, body };
+}
+
+function renderUnknown(body: HTMLElement, reason: TrainingContextUnknownReason): void {
+  body.replaceChildren(paragraph("context-panel__empty", unknownCopy[reason]));
+}
+
+function sparkline(series: WellnessSeries): SVGSVGElement | HTMLSpanElement {
+  if (series.points.length === 0) {
+    const empty = document.createElement("span");
+    empty.className = "wellness-empty";
+    empty.textContent = "No readings";
+    return empty;
+  }
+  const values = series.points.map((point) => point.value);
+  const minimum = Math.min(...values);
+  const maximum = Math.max(...values);
+  const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  svg.classList.add("wellness-sparkline");
+  svg.setAttribute("viewBox", "0 0 120 30");
+  svg.setAttribute("aria-hidden", "true");
+  const line = document.createElementNS("http://www.w3.org/2000/svg", "polyline");
+  const denominator = Math.max(1, series.points.length - 1);
+  const points = series.points.map((point, index) => {
+    const x = (index / denominator) * 116 + 2;
+    const y = minimum === maximum ? 15 : 27 - ((point.value - minimum) / (maximum - minimum)) * 24;
+    return `${x},${y}`;
+  });
+  line.setAttribute("points", points.join(" "));
+  svg.append(line);
+  return svg;
+}
+
+function renderPanels(bodies: readonly HTMLElement[], context: CyclingTrainingContext): void {
+  const anchorBody = bodies[0]!;
+  switch (context.anchorZones.kind) {
+    case "unknown":
+      renderUnknown(anchorBody, context.anchorZones.reason);
+      break;
+    case "computed": {
+      const value = paragraph(
+        "context-panel__value",
+        `${formatWholeNumber(context.anchorZones.anchor.watts)} W`,
+      );
+      const stale = document.createElement("span");
+      stale.className = `context-badge context-badge--${context.anchorZones.anchor.stalenessBand}`;
+      const days = Math.floor(context.anchorZones.anchor.ageDays);
+      stale.textContent =
+        context.anchorZones.anchor.stalenessBand === "fresh"
+          ? "Fresh"
+          : context.anchorZones.anchor.stalenessBand === "aging"
+            ? `Aging · ${days}d`
+            : context.anchorZones.anchor.stalenessBand === "stale"
+              ? `Stale · ${days}d`
+              : `Very stale · ${days}d`;
+      const meta = paragraph(
+        "context-panel__meta",
+        `As of ${formatDateLabel(context.anchorZones.asOf)} · ${context.anchorZones.anchor.source} · ${context.anchorZones.anchor.confidence}`,
+      );
+      const zonesHeading = document.createElement("h4");
+      zonesHeading.textContent = "Power zones";
+      const zones = document.createElement("dl");
+      zones.className = "zone-list";
+      for (const zone of context.anchorZones.zones) {
+        const name = document.createElement("dt");
+        name.textContent = zone.name;
+        if (zone.overlaps) name.className = "zone-list__overlap";
+        const range = document.createElement("dd");
+        range.textContent = zone.range;
+        zones.append(name, range);
+      }
+      anchorBody.replaceChildren(value, stale, meta, zonesHeading, zones);
+      break;
+    }
+  }
+
+  const loadBody = bodies[1]!;
+  switch (context.cyclingLoad.kind) {
+    case "unknown":
+      renderUnknown(loadBody, context.cyclingLoad.reason);
+      break;
+    case "computed": {
+      const children: Node[] = [
+        paragraph("context-panel__value", formatWholeNumber(context.cyclingLoad.value)),
+        paragraph("context-panel__meta", "From intervals.icu · 7 days"),
+        paragraph(
+          "context-panel__support",
+          `${context.cyclingLoad.activityCount} cycling activities`,
+        ),
+      ];
+      if (context.cyclingLoad.missingLoadCount > 0) {
+        children.push(
+          paragraph(
+            "context-panel__support",
+            `${context.cyclingLoad.missingLoadCount} cycling activities have no platform Load`,
+          ),
+        );
+      }
+      loadBody.replaceChildren(...children);
+      break;
+    }
+  }
+
+  const planBody = bodies[2]!;
+  switch (context.plan.kind) {
+    case "unknown":
+      renderUnknown(planBody, context.plan.reason);
+      break;
+    case "computed": {
+      const list = document.createElement("ol");
+      list.className = "plan-list";
+      for (const item of context.plan.items.slice(0, MAX_VISIBLE_PLAN_ITEMS)) {
+        const row = document.createElement("li");
+        const name = document.createElement("strong");
+        name.textContent = item.name ?? "Cycling workout";
+        const meta = document.createElement("span");
+        meta.textContent = `${formatDateLabel(item.date)} · ${item.workoutType}`;
+        row.append(name, meta);
+        list.append(row);
+      }
+      planBody.replaceChildren(list);
+      break;
+    }
+  }
+
+  const adherenceBody = bodies[3]!;
+  switch (context.adherence.kind) {
+    case "unknown":
+      renderUnknown(adherenceBody, context.adherence.reason);
+      break;
+    case "computed":
+      adherenceBody.replaceChildren(
+        paragraph("context-panel__value", formatPercentage(context.adherence.ratio)),
+        paragraph(
+          "context-panel__support",
+          `${context.adherence.matchedDays}/${context.adherence.plannedDays} planned days matched`,
+        ),
+        paragraph(
+          "context-panel__meta",
+          `${context.adherence.completedDays} completed days · As of ${formatDateLabel(context.adherence.asOf)}`,
+        ),
+      );
+      break;
+  }
+
+  const wellnessBody = bodies[4]!;
+  switch (context.wellnessTrend.kind) {
+    case "unknown":
+      renderUnknown(wellnessBody, context.wellnessTrend.reason);
+      break;
+    case "computed": {
+      const list = document.createElement("div");
+      list.className = "wellness-list";
+      const labels = ["HRV", "Sleep", "Resting HR"];
+      context.wellnessTrend.series.forEach((series, index) => {
+        const row = document.createElement("div");
+        row.className = "wellness-row";
+        const label = document.createElement("strong");
+        label.textContent = labels[index]!;
+        const latest = series.points.at(-1);
+        const value = document.createElement("span");
+        value.className = "wellness-row__value";
+        value.textContent =
+          latest === undefined
+            ? "No readings"
+            : series.metric === "sleep"
+              ? formatSleepDuration(latest.value)
+              : `${formatWholeNumber(latest.value)} ${series.unit}`;
+        row.append(label, value, sparkline(series));
+        list.append(row);
+      });
+      wellnessBody.replaceChildren(
+        paragraph(
+          "context-panel__meta",
+          `As of ${formatDateLabel(context.wellnessTrend.asOf)} · 7 mornings`,
+        ),
+        list,
+      );
+      break;
+    }
+  }
+}
+
+export function mountTrainingContextView(input: {
+  readonly spine: HTMLElement;
+  readonly drawer: HTMLDialogElement;
+}): MountedTrainingContextView {
+  input.drawer.id = TRAINING_CONTEXT_DRAWER_ID;
+  input.drawer.setAttribute("aria-label", "Training data");
+  input.spine.setAttribute("aria-label", "Training data drawer");
+  input.spine.replaceChildren();
+  const opener = document.createElement("button");
+  opener.type = "button";
+  opener.className = "drawer-toggle";
+  opener.setAttribute("aria-label", "Open training data");
+  opener.setAttribute("aria-controls", TRAINING_CONTEXT_DRAWER_ID);
+  opener.setAttribute("aria-expanded", "false");
+  const spineCopy = document.createElement("span");
+  spineCopy.className = "data-spine__copy";
+  spineCopy.textContent = "Live training context";
+  opener.append(spineCopy);
+  input.spine.append(opener);
+
+  input.drawer.replaceChildren();
+  const header = document.createElement("header");
+  header.className = "drawer-heading";
+  const headingWrap = document.createElement("div");
+  const heading = document.createElement("h2");
+  heading.textContent = "Training context";
+  const metadata = document.createElement("div");
+  metadata.className = "drawer-metadata";
+  headingWrap.append(heading, metadata);
+  const close = document.createElement("button");
+  close.type = "button";
+  close.className = "drawer-close";
+  close.setAttribute("aria-label", "Close training data");
+  close.textContent = "×";
+  header.append(headingWrap, close);
+  const status = paragraph("drawer-status", "Loading training context…");
+  const panelDefinitions = [
+    "Current cycling anchor",
+    "Cycling Load",
+    "Plan",
+    "Adherence",
+    "Wellness trend",
+  ];
+  const panels = panelDefinitions.map(section);
+
+  const units = document.createElement("fieldset");
+  units.className = "units-setting";
+  const legend = document.createElement("legend");
+  legend.textContent = "Display units";
+  const metricLabel = document.createElement("label");
+  const metric = document.createElement("input");
+  metric.type = "radio";
+  metric.name = "display-units";
+  metric.value = "metric";
+  metricLabel.append(metric, document.createTextNode("Metric · km · kg · W/kg"));
+  const imperialLabel = document.createElement("label");
+  const imperial = document.createElement("input");
+  imperial.type = "radio";
+  imperial.name = "display-units";
+  imperial.value = "imperial";
+  imperialLabel.append(imperial, document.createTextNode("Imperial · mi · lb · W/kg"));
+  const unitsHelper = paragraph(
+    "units-setting__helper",
+    "Distance and body mass follow this setting. Cycling power-to-weight remains W/kg.",
+  );
+  const unitsStatus = paragraph("units-setting__status", "");
+  units.append(legend, metricLabel, imperialLabel, unitsHelper, unitsStatus);
+  input.drawer.append(header, status, ...panels.map((panel) => panel.root), units);
+
+  let handler: ((value: UnitsPreference) => void) | undefined;
+  let disposed = false;
+  const open = (): void => {
+    if (disposed || input.drawer.open) return;
+    input.drawer.showModal();
+    opener.setAttribute("aria-expanded", "true");
+    close.focus();
+  };
+  const shut = (): void => {
+    if (input.drawer.open) input.drawer.close();
+    opener.setAttribute("aria-expanded", "false");
+    opener.focus();
+  };
+  const cancel = (event: Event): void => {
+    event.preventDefault();
+    shut();
+  };
+  const unitsChanged = (event: Event): void => {
+    const target = event.target;
+    if (target instanceof HTMLInputElement && target.checked) {
+      handler?.(target.value as UnitsPreference);
+    }
+  };
+  opener.addEventListener("click", open);
+  close.addEventListener("click", shut);
+  input.drawer.addEventListener("cancel", cancel);
+  units.addEventListener("change", unitsChanged);
+
+  return {
+    view: {
+      render(state: TrainingContextViewState) {
+        if (disposed) return;
+        metadata.replaceChildren();
+        if (state.metadata !== null) {
+          metadata.append(
+            paragraph(
+              "drawer-metadata__item",
+              `As of ${formatDateLabel(state.metadata.lastUpdated)}`,
+            ),
+            paragraph("context-badge", state.metadata.freshness),
+          );
+          if (state.metadata.degraded) {
+            metadata.append(paragraph("drawer-metadata__item", "Data may be incomplete"));
+          }
+          if (state.metadata.lastSynced !== null) {
+            metadata.append(
+              paragraph(
+                "drawer-metadata__item",
+                `Last synced ${formatDateLabel(state.metadata.lastSynced)}`,
+              ),
+            );
+          }
+        }
+        status.textContent =
+          state.status === "loading"
+            ? "Loading training context…"
+            : state.status === "unavailable"
+              ? "Training context unavailable"
+              : state.status === "refresh-unavailable"
+                ? "Refresh unavailable"
+                : "";
+        status.hidden = state.status === "ready";
+        renderPanels(
+          panels.map((panel) => panel.body),
+          state.trainingContext,
+        );
+        metric.checked = state.unitsPreference.value === "metric";
+        imperial.checked = state.unitsPreference.value === "imperial";
+        const saving = state.unitsPreference.status === "saving";
+        metric.disabled = saving || state.unitsPreference.status === "loading";
+        imperial.disabled = saving || state.unitsPreference.status === "loading";
+        unitsStatus.textContent = saving
+          ? "Saving units…"
+          : state.unitsPreference.status === "unavailable"
+            ? "Units preference unavailable"
+            : "";
+      },
+    },
+    bind(next) {
+      handler = next.onUnitsPreferenceChange;
+    },
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      handler = undefined;
+      opener.removeEventListener("click", open);
+      close.removeEventListener("click", shut);
+      input.drawer.removeEventListener("cancel", cancel);
+      units.removeEventListener("change", unitsChanged);
+    },
+  };
+}

--- a/apps/desktop-renderer/src/turn-state.ts
+++ b/apps/desktop-renderer/src/turn-state.ts
@@ -1,72 +1,193 @@
 import type { TurnEvent } from "@enduragent/coach-contract";
 
-export type AssistantDeliveryState =
-  | { readonly status: "streaming"; readonly text: string }
-  | { readonly status: "completed"; readonly text: string }
-  | { readonly status: "aborted"; readonly text: string; readonly retryable: true }
-  | { readonly status: "failed"; readonly message: string };
+export const DESKTOP_CHAT_ID = "desktop" as const;
 
-export interface ChatTurnState {
-  readonly userText: string;
-  readonly assistant: AssistantDeliveryState;
+export type ChatStatus = "idle" | "streaming" | "interrupted";
+
+export interface ChatErrorView {
+  readonly kind: Extract<TurnEvent, { type: "error" }>["kind"];
+  readonly athleteMessage: string;
 }
 
-export type ChatTurnAction =
-  | { readonly type: "event"; readonly event: TurnEvent }
-  | { readonly type: "success"; readonly text: string }
-  | { readonly type: "abort" }
-  | { readonly type: "protocol-failure" }
-  | { readonly type: "remote-failure" };
-
-export function createChatTurn(userText: string): ChatTurnState {
-  if (!/\S/u.test(userText)) throw new TypeError("chat text is empty");
-  return { userText, assistant: { status: "streaming", text: "" } };
+export interface ActiveTurn {
+  readonly requestKey: number;
+  readonly turnId: string | null;
+  readonly userMessage: string;
+  readonly assistantMessageId: string;
+  readonly draft: string;
+  readonly finalText: string | null;
+  readonly error: ChatErrorView | null;
 }
 
-export function reduceChatTurn(state: ChatTurnState, action: ChatTurnAction): ChatTurnState {
-  if (action.type === "event") {
-    if (state.assistant.status !== "streaming") return state;
-    if (action.event.type === "error") {
-      return { ...state, assistant: { status: "failed", message: action.event.athleteMessage } };
+export interface ChatTranscriptMessage {
+  readonly id: string;
+  readonly role: "athlete" | "coach";
+  readonly text: string;
+  readonly delivery: "complete" | "streaming" | "interrupted";
+}
+
+export interface ChatState {
+  readonly status: ChatStatus;
+  readonly messages: readonly ChatTranscriptMessage[];
+  readonly activeTurn: ActiveTurn | null;
+  readonly progress: string | null;
+}
+
+export const EMPTY_CHAT_STATE: ChatState = {
+  status: "idle",
+  messages: [],
+  activeTurn: null,
+  progress: null,
+};
+
+export type ChatAction =
+  | {
+      readonly type: "submit";
+      readonly requestKey: number;
+      readonly userMessage: string;
+      readonly userMessageId: string;
+      readonly assistantMessageId: string;
+      readonly includeUser: boolean;
     }
-    if (action.event.type === "text_delta") {
+  | { readonly type: "bind-turn"; readonly requestKey: number; readonly turnId: string }
+  | { readonly type: "event"; readonly requestKey: number; readonly event: TurnEvent }
+  | { readonly type: "complete"; readonly requestKey: number }
+  | { readonly type: "interrupt"; readonly requestKey: number; readonly copy: string }
+  | { readonly type: "fail"; readonly requestKey: number; readonly copy: string };
+
+function current(state: ChatState, requestKey: number): ActiveTurn | null {
+  return state.activeTurn?.requestKey === requestKey ? state.activeTurn : null;
+}
+
+function updateAssistant(
+  state: ChatState,
+  activeTurn: ActiveTurn,
+  text: string,
+  delivery: ChatTranscriptMessage["delivery"],
+): readonly ChatTranscriptMessage[] {
+  return state.messages.map((message) =>
+    message.id === activeTurn.assistantMessageId ? { ...message, text, delivery } : message,
+  );
+}
+
+function assertNever(value: never): never {
+  throw new TypeError(`Unhandled chat action: ${String(value)}`);
+}
+
+export function reduceChatState(state: ChatState, action: ChatAction): ChatState {
+  switch (action.type) {
+    case "submit": {
+      if (state.status === "streaming") return state;
+      const assistant: ChatTranscriptMessage = {
+        id: action.assistantMessageId,
+        role: "coach",
+        text: "",
+        delivery: "streaming",
+      };
+      const messages = action.includeUser
+        ? [
+            ...state.messages,
+            {
+              id: action.userMessageId,
+              role: "athlete" as const,
+              text: action.userMessage,
+              delivery: "complete" as const,
+            },
+            assistant,
+          ]
+        : [...state.messages, assistant];
       return {
-        ...state,
-        assistant: { status: "streaming", text: state.assistant.text + action.event.delta },
+        status: "streaming",
+        messages,
+        progress: null,
+        activeTurn: {
+          requestKey: action.requestKey,
+          turnId: null,
+          userMessage: action.userMessage,
+          assistantMessageId: action.assistantMessageId,
+          draft: "",
+          finalText: null,
+          error: null,
+        },
       };
     }
-    if (action.event.type === "final-text") {
-      return { ...state, assistant: { status: "streaming", text: action.event.text } };
+    case "bind-turn": {
+      const active = current(state, action.requestKey);
+      return active === null
+        ? state
+        : { ...state, activeTurn: { ...active, turnId: action.turnId } };
     }
-    return state;
+    case "event": {
+      const active = current(state, action.requestKey);
+      if (active === null || state.status !== "streaming") return state;
+      switch (action.event.type) {
+        case "turn-start":
+          return state;
+        case "text_delta": {
+          const draft = active.draft + action.event.delta;
+          const next = { ...active, draft };
+          return {
+            ...state,
+            activeTurn: next,
+            messages: updateAssistant(state, next, draft, "streaming"),
+          };
+        }
+        case "final-text": {
+          const next = { ...active, draft: action.event.text, finalText: action.event.text };
+          return {
+            ...state,
+            activeTurn: next,
+            messages: updateAssistant(state, next, action.event.text, "streaming"),
+          };
+        }
+        case "error":
+          return {
+            ...state,
+            activeTurn: {
+              ...active,
+              error: { kind: action.event.kind, athleteMessage: action.event.athleteMessage },
+            },
+          };
+        case "tool-start":
+        case "tool-end":
+        case "step-text":
+          return { ...state, progress: "Checking your training data…" };
+        default:
+          return assertNever(action.event);
+      }
+    }
+    case "complete": {
+      const active = current(state, action.requestKey);
+      if (active === null || active.finalText === null) return state;
+      return {
+        ...state,
+        status: "idle",
+        progress: null,
+        messages: updateAssistant(state, active, active.finalText, "complete"),
+      };
+    }
+    case "interrupt": {
+      const active = current(state, action.requestKey);
+      if (active === null) return state;
+      return {
+        ...state,
+        status: "interrupted",
+        progress: action.copy,
+        messages: updateAssistant(state, active, active.draft, "interrupted"),
+      };
+    }
+    case "fail": {
+      const active = current(state, action.requestKey);
+      if (active === null) return state;
+      const text = active.draft.length > 0 ? active.draft : action.copy;
+      return {
+        ...state,
+        status: "idle",
+        progress: active.error === null ? action.copy : null,
+        messages: updateAssistant(state, active, text, "complete"),
+      };
+    }
+    default:
+      return assertNever(action);
   }
-  if (action.type === "success") {
-    if (state.assistant.status !== "streaming") return state;
-    const currentText = state.assistant.text;
-    return {
-      ...state,
-      assistant: {
-        status: "completed",
-        text: currentText.length === 0 ? action.text : currentText,
-      },
-    };
-  }
-  if (action.type === "abort") {
-    if (state.assistant.status !== "streaming") return state;
-    return {
-      ...state,
-      assistant: { status: "aborted", text: state.assistant.text, retryable: true },
-    };
-  }
-  if (state.assistant.status === "completed" || state.assistant.status === "aborted") return state;
-  return {
-    ...state,
-    assistant: {
-      status: "failed",
-      message:
-        action.type === "protocol-failure"
-          ? "The coaching connection returned an invalid response."
-          : "Your coach could not complete this response.",
-    },
-  };
 }

--- a/apps/desktop-renderer/tests/chat-controller.test.ts
+++ b/apps/desktop-renderer/tests/chat-controller.test.ts
@@ -1,0 +1,303 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  CoachClientDisconnectedError,
+  CoachClientProtocolError,
+  type CoachClient,
+  type CoachClientCallOptions,
+} from "@enduragent/coach-client";
+import type { CoachTurnEventNotificationEnvelope, TurnEvent } from "@enduragent/coach-contract";
+import {
+  CHAT_CONNECTION_INTERRUPTED_COPY,
+  CHAT_PROTOCOL_FAILURE_COPY,
+  createChatController,
+} from "../src/chat/controller.js";
+import type { DesktopCoachClientProvider } from "../src/coach-client.js";
+import type { ChatState } from "../src/turn-state.js";
+
+function envelope(event: TurnEvent, requestId = 1): CoachTurnEventNotificationEnvelope {
+  return {
+    jsonrpc: "2.0",
+    method: "coach.turnEvent",
+    params: {
+      requestId,
+      requestMethod: "chat",
+      turnId: event.turnId,
+      event,
+    },
+  };
+}
+
+function errorEvent(message = "Safe athlete message"): TurnEvent {
+  return {
+    type: "error",
+    turnId: "turn-1",
+    chatId: "desktop",
+    error_class: "unknown",
+    kind: "provider-down",
+    athleteMessage: message,
+    overflowAttempts: 0,
+    timeoutAttempts: 0,
+    rateLimitAttempts: 0,
+    duration_ms: 1,
+    compactions: 0,
+  };
+}
+
+function deliver(options: CoachClientCallOptions<"chat"> | undefined, event: TurnEvent): void {
+  options?.onNotificationEnvelope?.(envelope(event));
+  options?.onEvent?.(event);
+}
+
+function client(
+  implementation: (
+    request: { chatId: string; message: string },
+    options: CoachClientCallOptions<"chat"> | undefined,
+  ) => Promise<{ text: string }>,
+): CoachClient {
+  return {
+    handshake: {} as CoachClient["handshake"],
+    call: vi.fn((method, request, options) => {
+      if (method !== "chat") throw new TypeError();
+      return implementation(
+        request as { chatId: string; message: string },
+        options as CoachClientCallOptions<"chat">,
+      ) as never;
+    }),
+    close: vi.fn(async () => {}),
+  };
+}
+
+function subject(
+  first: CoachClient,
+  reconnected: CoachClient = first,
+  refreshImplementation: () => Promise<void> = async () => {},
+) {
+  const states: ChatState[] = [];
+  const refresh = vi.fn(refreshImplementation);
+  const provider: DesktopCoachClientProvider = {
+    getClient: vi.fn(async () => first),
+    reconnect: vi.fn(async () => reconnected),
+    close: vi.fn(async () => {}),
+  };
+  const controller = createChatController({
+    clients: provider,
+    view: { render: (state) => states.push(structuredClone(state)) },
+    refreshTrainingContext: refresh,
+  });
+  return { controller, provider, states, refresh };
+}
+
+describe("chat controller", () => {
+  it("renders ordered deltas immediately and canonical final text once without turn-start", async () => {
+    const fake = client(async (_request, options) => {
+      deliver(options, { type: "text_delta", turnId: "turn-1", delta: "Hel" });
+      deliver(options, { type: "text_delta", turnId: "turn-1", delta: "lo" });
+      deliver(options, { type: "final-text", turnId: "turn-1", text: "Hello." });
+      options?.onTerminalEnvelope?.({ jsonrpc: "2.0", id: 1, result: { text: "Hello." } });
+      return { text: "Hello." };
+    });
+    const { controller, states, refresh } = subject(fake);
+    await controller.submit("Original message ");
+    expect(states.some((state) => state.messages.at(-1)?.text === "Hel")).toBe(true);
+    expect(states.at(-1)?.messages.filter((message) => message.text === "Hello.")).toHaveLength(1);
+    expect(vi.mocked(fake.call).mock.calls[0]?.slice(0, 2)).toEqual([
+      "chat",
+      { chatId: "desktop", message: "Original message " },
+    ]);
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves partial text and the contract athlete message without automatic retry", async () => {
+    const fake = client(async (_request, options) => {
+      deliver(options, { type: "text_delta", turnId: "turn-1", delta: "Partial" });
+      deliver(options, errorEvent());
+      options?.onTerminalEnvelope?.({
+        jsonrpc: "2.0",
+        id: 1,
+        error: { code: -32603, message: "Internal error" },
+      });
+      throw new Error("remote detail");
+    });
+    const { controller, states } = subject(fake);
+    await controller.submit("Help");
+    expect(states.at(-1)?.messages.at(-1)?.text).toBe("Partial");
+    expect(states.at(-1)?.activeTurn?.error?.athleteMessage).toBe("Safe athlete message");
+    expect(fake.call).toHaveBeenCalledTimes(1);
+  });
+
+  it("reconciles a safe final after an error while retaining the subdued notice", async () => {
+    const fake = client(async (_request, options) => {
+      deliver(options, { type: "text_delta", turnId: "turn-1", delta: "Draft" });
+      deliver(options, errorEvent());
+      deliver(options, { type: "final-text", turnId: "turn-1", text: "Safe fallback" });
+      options?.onTerminalEnvelope?.({ jsonrpc: "2.0", id: 1, result: { text: "Safe fallback" } });
+      return { text: "Safe fallback" };
+    });
+    const { controller, states } = subject(fake);
+    await controller.submit("Help");
+    expect(states.at(-1)?.messages.at(-1)?.text).toBe("Safe fallback");
+    expect(states.at(-1)?.activeTurn?.error?.athleteMessage).toBe("Safe athlete message");
+  });
+
+  it.each(["missing", "mismatch"])(
+    "treats a %s final confirmation as a safe protocol interruption",
+    async (variant) => {
+      const fake = client(async (_request, options) => {
+        deliver(options, { type: "text_delta", turnId: "turn-1", delta: "Draft" });
+        if (variant === "mismatch") {
+          deliver(options, { type: "final-text", turnId: "turn-1", text: "Canonical" });
+        }
+        options?.onTerminalEnvelope?.({ jsonrpc: "2.0", id: 1, result: { text: "Other" } });
+        return { text: "Other" };
+      });
+      const { controller, states } = subject(fake);
+      await controller.submit("Help");
+      expect(states.at(-1)).toMatchObject({
+        status: "interrupted",
+        progress: CHAT_PROTOCOL_FAILURE_COPY,
+      });
+      expect(states.at(-1)?.messages.at(-1)?.text).toBe(
+        variant === "mismatch" ? "Canonical" : "Draft",
+      );
+    },
+  );
+
+  it("accepts one matching first turn-start and rejects a late start", async () => {
+    const fake = client(async (_request, options) => {
+      deliver(options, { type: "text_delta", turnId: "turn-1", delta: "Draft" });
+      deliver(options, { type: "turn-start", turnId: "turn-1", chatId: "desktop" });
+      deliver(options, { type: "final-text", turnId: "turn-1", text: "Final" });
+      options?.onTerminalEnvelope?.({ jsonrpc: "2.0", id: 1, result: { text: "Final" } });
+      return { text: "Final" };
+    });
+    const { controller, states } = subject(fake);
+    await controller.submit("Help");
+    expect(states.at(-1)?.progress).toBe(CHAT_PROTOCOL_FAILURE_COPY);
+  });
+
+  it("preserves a disconnected draft and retries explicitly without duplicating the user row", async () => {
+    const first = client(async (_request, options) => {
+      deliver(options, { type: "text_delta", turnId: "turn-1", delta: "Partial" });
+      throw new CoachClientDisconnectedError(1006, "synthetic");
+    });
+    const second = client(async (_request, options) => {
+      deliver(options, { type: "final-text", turnId: "turn-2", text: "Recovered" });
+      options?.onTerminalEnvelope?.({ jsonrpc: "2.0", id: 2, result: { text: "Recovered" } });
+      return { text: "Recovered" };
+    });
+    const { controller, provider, states, refresh } = subject(first, second);
+    await controller.submit("Same message");
+    expect(states.at(-1)?.progress).toBe(CHAT_CONNECTION_INTERRUPTED_COPY);
+    await controller.retryInterrupted();
+    expect(provider.reconnect).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(second.call).mock.calls[0]?.[1]).toEqual({
+      chatId: "desktop",
+      message: "Same message",
+    });
+    expect(states.at(-1)?.messages.filter((message) => message.role === "athlete")).toHaveLength(1);
+    expect(refresh).toHaveBeenCalledTimes(2);
+  });
+
+  it("reuses a shared recovered client when retrying a stale interrupted turn", async () => {
+    let current: CoachClient;
+    const recovered = client(async (_request, options) => {
+      deliver(options, { type: "final-text", turnId: "turn-2", text: "Recovered" });
+      options?.onTerminalEnvelope?.({ jsonrpc: "2.0", id: 2, result: { text: "Recovered" } });
+      return { text: "Recovered" };
+    });
+    const failed = client(async () => {
+      current = recovered;
+      throw new CoachClientDisconnectedError(1006, "synthetic");
+    });
+    current = failed;
+    const provider: DesktopCoachClientProvider = {
+      getClient: vi.fn(async () => current),
+      reconnect: vi.fn(async () => recovered),
+      close: vi.fn(async () => {}),
+    };
+    const states: ChatState[] = [];
+    const controller = createChatController({
+      clients: provider,
+      view: { render: (state) => states.push(structuredClone(state)) },
+      refreshTrainingContext: vi.fn(async () => {}),
+    });
+    await controller.submit("Same message");
+    await controller.retryInterrupted();
+    expect(provider.reconnect).not.toHaveBeenCalled();
+    expect(recovered.call).toHaveBeenCalledTimes(1);
+    expect(states.at(-1)?.messages.at(-1)?.text).toBe("Recovered");
+  });
+
+  it("queues one explicit retry while terminal state refresh is still running", async () => {
+    let release!: () => void;
+    const refreshGate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let refreshCalls = 0;
+    const first = client(async (_request, options) => {
+      deliver(options, { type: "text_delta", turnId: "turn-1", delta: "Partial" });
+      throw new CoachClientDisconnectedError(1006, "synthetic");
+    });
+    const second = client(async (_request, options) => {
+      deliver(options, { type: "final-text", turnId: "turn-2", text: "Recovered" });
+      options?.onTerminalEnvelope?.({ jsonrpc: "2.0", id: 2, result: { text: "Recovered" } });
+      return { text: "Recovered" };
+    });
+    let interrupted!: () => void;
+    const interruptedState = new Promise<void>((resolve) => {
+      interrupted = resolve;
+    });
+    const provider: DesktopCoachClientProvider = {
+      getClient: vi.fn(async () => first),
+      reconnect: vi.fn(async () => second),
+      close: vi.fn(async () => {}),
+    };
+    const controller = createChatController({
+      clients: provider,
+      view: {
+        render(state) {
+          if (state.status === "interrupted") interrupted();
+        },
+      },
+      refreshTrainingContext: vi.fn(async () => {
+        refreshCalls += 1;
+        if (refreshCalls === 1) await refreshGate;
+      }),
+    });
+    const submission = controller.submit("Same message");
+    await interruptedState;
+    const retry = controller.retryInterrupted();
+    const duplicate = controller.retryInterrupted();
+    release();
+    await Promise.all([submission, retry, duplicate]);
+    expect(provider.reconnect).toHaveBeenCalledTimes(1);
+    expect(second.call).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows one in-flight call and treats client protocol rejection as explicit-retry state", async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const fake = client(async () => {
+      await gate;
+      throw new CoachClientProtocolError();
+    });
+    const { controller, states } = subject(fake);
+    const first = controller.submit("One");
+    const second = controller.submit("Two");
+    await Promise.resolve();
+    expect(fake.call).toHaveBeenCalledTimes(1);
+    release();
+    await Promise.all([first, second]);
+    expect(states.at(-1)?.progress).toBe(CHAT_PROTOCOL_FAILURE_COPY);
+    expect(states.at(-1)?.messages.at(-1)?.text).toBe("");
+  });
+
+  it("does not dispatch blank-only input", async () => {
+    const fake = client(async () => ({ text: "unused" }));
+    const { controller } = subject(fake);
+    await controller.submit("  \n");
+    expect(fake.call).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop-renderer/tests/chat-view.test.ts
+++ b/apps/desktop-renderer/tests/chat-view.test.ts
@@ -1,0 +1,190 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mountChatView } from "../src/chat/view.js";
+import type { ChatState } from "../src/turn-state.js";
+
+class FakeElement {
+  readonly children: FakeElement[] = [];
+  readonly attributes = new Map<string, string>();
+  readonly listeners = new Map<string, Set<(event: never) => void>>();
+  readonly dataset: Record<string, string> = {};
+  className = "";
+  hidden = false;
+  disabled = false;
+  value = "";
+  type = "";
+  id = "";
+  rows = 0;
+  htmlFor = "";
+  scrollHeight = 0;
+  scrollTop = 0;
+  clientHeight = 0;
+  private ownText = "";
+
+  constructor(readonly tagName: string) {}
+
+  get textContent(): string {
+    return this.ownText + this.children.map((child) => child.textContent).join("");
+  }
+
+  set textContent(value: string) {
+    this.ownText = value;
+    this.children.splice(0);
+  }
+
+  append(...nodes: Array<FakeElement | string>): void {
+    for (const node of nodes) {
+      this.children.push(typeof node === "string" ? new FakeElement("#text") : node);
+      if (typeof node === "string") this.children.at(-1)!.textContent = node;
+    }
+  }
+
+  replaceChildren(...nodes: FakeElement[]): void {
+    this.ownText = "";
+    this.children.splice(0, this.children.length, ...nodes);
+  }
+
+  setAttribute(name: string, value: string): void {
+    this.attributes.set(name, value);
+  }
+
+  removeAttribute(name: string): void {
+    this.attributes.delete(name);
+  }
+
+  addEventListener(name: string, listener: (event: never) => void): void {
+    const listeners = this.listeners.get(name) ?? new Set();
+    listeners.add(listener);
+    this.listeners.set(name, listeners);
+  }
+
+  removeEventListener(name: string, listener: (event: never) => void): void {
+    this.listeners.get(name)?.delete(listener);
+  }
+
+  dispatch(name: string, event: Record<string, unknown> = {}): void {
+    for (const listener of this.listeners.get(name) ?? []) listener(event as never);
+  }
+
+  requestSubmit(): void {
+    this.dispatch("submit", { preventDefault() {} });
+  }
+}
+
+class FakeDocument {
+  createElement(name: string): FakeElement {
+    return new FakeElement(name);
+  }
+}
+
+function find(root: FakeElement, predicate: (node: FakeElement) => boolean): FakeElement {
+  if (predicate(root)) return root;
+  for (const child of root.children) {
+    try {
+      return find(child, predicate);
+    } catch {}
+  }
+  throw new Error("Element not found");
+}
+
+const emptyState: ChatState = {
+  status: "idle",
+  messages: [],
+  activeTurn: null,
+  progress: null,
+};
+
+beforeEach(() => {
+  Object.assign(globalThis, {
+    document: new FakeDocument(),
+    HTMLElement: FakeElement,
+  });
+});
+
+describe("chat view", () => {
+  it("renders hostile HTML-shaped text literally in the polite log", () => {
+    const conversation = new FakeElement("main");
+    const thread = new FakeElement("div");
+    const composerHost = new FakeElement("div");
+    const mounted = mountChatView({
+      conversation: conversation as never,
+      thread: thread as never,
+      composerHost: composerHost as never,
+    });
+    mounted.view.render({
+      ...emptyState,
+      messages: [
+        {
+          id: "message-1",
+          role: "athlete",
+          text: '<img src=x onerror="globalThis.executed=true">',
+          delivery: "complete",
+        },
+      ],
+    });
+    expect(thread.textContent).toContain('<img src=x onerror="globalThis.executed=true">');
+    expect((globalThis as Record<string, unknown>).executed).toBeUndefined();
+    const transcript = find(thread, (node) => node.className === "chat-transcript");
+    expect(transcript.attributes.get("role")).toBe("log");
+    expect(transcript.attributes.get("aria-live")).toBe("polite");
+  });
+
+  it("keeps a visible label, submits original text, and disables while streaming", () => {
+    const conversation = new FakeElement("main");
+    const thread = new FakeElement("div");
+    const composerHost = new FakeElement("div");
+    const mounted = mountChatView({
+      conversation: conversation as never,
+      thread: thread as never,
+      composerHost: composerHost as never,
+    });
+    const onSubmit = vi.fn();
+    mounted.bind({ onSubmit, onRetry: vi.fn() });
+    const label = find(composerHost, (node) => node.className === "chat-composer__label");
+    const textarea = find(composerHost, (node) => node.tagName === "textarea");
+    const form = find(composerHost, (node) => node.tagName === "form");
+    expect(label.textContent).toBe("Message your coach");
+    textarea.value = "  Keep spacing  ";
+    form.dispatch("submit", { preventDefault() {} });
+    expect(onSubmit).toHaveBeenCalledWith("  Keep spacing  ");
+    mounted.view.render({ ...emptyState, status: "streaming" });
+    const button = find(composerHost, (node) => node.tagName === "button");
+    expect(textarea.disabled).toBe(true);
+    expect(button.disabled).toBe(true);
+  });
+
+  it("shows the explicit retry control only for an interrupted turn", () => {
+    const conversation = new FakeElement("main");
+    const thread = new FakeElement("div");
+    const composerHost = new FakeElement("div");
+    const mounted = mountChatView({
+      conversation: conversation as never,
+      thread: thread as never,
+      composerHost: composerHost as never,
+    });
+    const onRetry = vi.fn();
+    mounted.bind({ onSubmit: vi.fn(), onRetry });
+    mounted.view.render({ ...emptyState, status: "interrupted", progress: "Interrupted" });
+    const retry = find(thread, (node) => node.className === "chat-retry");
+    expect(retry.hidden).toBe(false);
+    retry.dispatch("click");
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("follows streamed text only when the athlete is already near the bottom", () => {
+    const conversation = new FakeElement("main");
+    conversation.scrollHeight = 240;
+    conversation.clientHeight = 100;
+    conversation.scrollTop = 135;
+    const mounted = mountChatView({
+      conversation: conversation as never,
+      thread: new FakeElement("div") as never,
+      composerHost: new FakeElement("div") as never,
+    });
+    mounted.view.render({ ...emptyState, status: "streaming" });
+    expect(conversation.scrollTop).toBe(240);
+    conversation.scrollHeight = 400;
+    conversation.scrollTop = 0;
+    mounted.view.render({ ...emptyState, status: "streaming" });
+    expect(conversation.scrollTop).toBe(0);
+  });
+});

--- a/apps/desktop-renderer/tests/training-context.test.ts
+++ b/apps/desktop-renderer/tests/training-context.test.ts
@@ -1,0 +1,383 @@
+import { readFile } from "node:fs/promises";
+import { describe, expect, it, vi } from "vitest";
+import { CoachClientDisconnectedError, type CoachClient } from "@enduragent/coach-client";
+import type { AthleteState, CyclingTrainingContext } from "@enduragent/coach-contract";
+import type { DesktopCoachClientProvider } from "../src/coach-client.js";
+import {
+  createTrainingContextController,
+  type TrainingContextViewState,
+} from "../src/training-context/controller.js";
+import {
+  formatDateLabel,
+  formatPercentage,
+  formatSleepDuration,
+  formatWholeNumber,
+} from "../src/training-context/format.js";
+
+const context: CyclingTrainingContext = {
+  anchorZones: { kind: "unknown", reason: "missing-anchor" },
+  cyclingLoad: {
+    kind: "computed",
+    asOf: "2026-07-18T00:00:00.000Z",
+    source: "intervals.icu",
+    windowDays: 7,
+    value: 120,
+    activityCount: 2,
+    missingLoadCount: 1,
+  },
+  plan: { kind: "unknown", reason: "no-plan" },
+  adherence: { kind: "unknown", reason: "insufficient-data" },
+  wellnessTrend: { kind: "unknown", reason: "no-wellness" },
+};
+
+function athlete(trainingContext: CyclingTrainingContext | undefined = context): AthleteState {
+  return {
+    schemaVersion: "3",
+    lastUpdated: "2026-07-18T00:00:00.000Z",
+    freshness: "flag",
+    degraded: true,
+    lastSynced: "2026-07-17T23:00:00.000Z",
+    athleteProfile: { hidden: true },
+    currentStatus: { hidden: true },
+    derivedMetrics: { hidden: true },
+    recentActivities: [{ hidden: true }],
+    plannedWorkouts: [{ hidden: true }],
+    wellness: { hidden: true },
+    ...(trainingContext === undefined ? {} : { trainingContext }),
+  };
+}
+
+function providerWith(call: CoachClient["call"]): DesktopCoachClientProvider {
+  const client = {
+    handshake: {} as CoachClient["handshake"],
+    call,
+    close: vi.fn(async () => {}),
+  } as CoachClient;
+  return {
+    getClient: vi.fn(async () => client),
+    reconnect: vi.fn(async () => client),
+    close: vi.fn(async () => {}),
+  };
+}
+
+describe("training context controller", () => {
+  it("fetches canonical state and units once on start without exposing raw state fields", async () => {
+    const calls: string[] = [];
+    const clients = providerWith((async (method: string) => {
+      calls.push(method);
+      if (method === "getAthleteState") return athlete();
+      if (method === "getUnitsPreference") return { value: "imperial", source: "athlete" };
+      throw new TypeError();
+    }) as CoachClient["call"]);
+    const states: TrainingContextViewState[] = [];
+    const controller = createTrainingContextController({
+      clients,
+      view: { render: (state) => states.push(structuredClone(state)) },
+    });
+    await Promise.all([controller.start(), controller.start()]);
+    expect(calls.sort()).toEqual(["getAthleteState", "getUnitsPreference"]);
+    expect(states.at(-1)).toEqual({
+      status: "ready",
+      metadata: {
+        lastUpdated: "2026-07-18T00:00:00.000Z",
+        lastSynced: "2026-07-17T23:00:00.000Z",
+        freshness: "flag",
+        degraded: true,
+      },
+      trainingContext: context,
+      unitsPreference: { status: "ready", value: "imperial", source: "athlete" },
+    });
+    expect(JSON.stringify(states.at(-1))).not.toContain("hidden");
+  });
+
+  it("uses the explicit fallback for an older state and retains it on refresh failure", async () => {
+    let stateCalls = 0;
+    const clients = providerWith((async (method: string) => {
+      if (method === "getUnitsPreference") return { value: "metric", source: "default" };
+      if (method === "getAthleteState") {
+        stateCalls += 1;
+        if (stateCalls === 1) {
+          const older = athlete();
+          delete older.trainingContext;
+          return older;
+        }
+        throw new Error("unavailable");
+      }
+      throw new TypeError();
+    }) as CoachClient["call"]);
+    const states: TrainingContextViewState[] = [];
+    const controller = createTrainingContextController({
+      clients,
+      view: { render: (state) => states.push(structuredClone(state)) },
+    });
+    await controller.start();
+    const previous = states.at(-1)?.trainingContext;
+    await controller.refresh();
+    expect(states.at(-1)?.status).toBe("refresh-unavailable");
+    expect(states.at(-1)?.trainingContext).toEqual(previous);
+    expect(states.at(-1)?.trainingContext.anchorZones).toEqual({
+      kind: "unknown",
+      reason: "not-synced",
+    });
+  });
+
+  it("coalesces refreshes during an active read into one post-flight request", async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let stateCalls = 0;
+    const clients = providerWith((async (method: string) => {
+      if (method === "getUnitsPreference") return { value: "metric", source: "default" };
+      if (method === "getAthleteState") {
+        stateCalls += 1;
+        if (stateCalls === 2) await gate;
+        return { ...athlete(), lastUpdated: `1998-07-0${stateCalls}T00:00:00.000Z` };
+      }
+      throw new TypeError();
+    }) as CoachClient["call"]);
+    const states: TrainingContextViewState[] = [];
+    const controller = createTrainingContextController({
+      clients,
+      view: { render: (state) => states.push(structuredClone(state)) },
+    });
+    await controller.start();
+    const first = controller.refresh();
+    const second = controller.refresh();
+    release();
+    await Promise.all([first, second]);
+    expect(stateCalls).toBe(3);
+    expect(states.at(-1)?.metadata?.lastUpdated).toBe("1998-07-03T00:00:00.000Z");
+  });
+
+  it("reconnects the next athlete-state read after a disconnect", async () => {
+    let stateCalls = 0;
+    const clients = providerWith((async (method: string) => {
+      if (method === "getUnitsPreference") return { value: "metric", source: "default" };
+      if (method === "getAthleteState") {
+        stateCalls += 1;
+        if (stateCalls === 1) throw new CoachClientDisconnectedError(1006, "synthetic");
+        return athlete();
+      }
+      throw new TypeError();
+    }) as CoachClient["call"]);
+    const states: TrainingContextViewState[] = [];
+    const controller = createTrainingContextController({
+      clients,
+      view: { render: (state) => states.push(structuredClone(state)) },
+    });
+    await controller.start();
+    await controller.refresh();
+    expect(clients.reconnect).toHaveBeenCalledTimes(1);
+    expect(states.at(-1)?.status).toBe("ready");
+  });
+
+  it("uses a shared recovered client instead of reconnecting a stale failed instance", async () => {
+    const failed = {
+      handshake: {} as CoachClient["handshake"],
+      call: vi.fn(async (method: string) => {
+        if (method === "getAthleteState") {
+          throw new CoachClientDisconnectedError(1006, "synthetic");
+        }
+        return { value: "metric", source: "default" };
+      }) as CoachClient["call"],
+      close: vi.fn(async () => {}),
+    } as CoachClient;
+    const recovered = {
+      handshake: {} as CoachClient["handshake"],
+      call: vi.fn(async (method: string) => {
+        if (method === "getAthleteState") return athlete();
+        return { value: "metric", source: "default" };
+      }) as CoachClient["call"],
+      close: vi.fn(async () => {}),
+    } as CoachClient;
+    let current = failed;
+    const clients: DesktopCoachClientProvider = {
+      getClient: vi.fn(async () => current),
+      reconnect: vi.fn(async () => recovered),
+      close: vi.fn(async () => {}),
+    };
+    const states: TrainingContextViewState[] = [];
+    const controller = createTrainingContextController({
+      clients,
+      view: { render: (state) => states.push(structuredClone(state)) },
+    });
+    await controller.start();
+    current = recovered;
+    await controller.refresh();
+    expect(clients.reconnect).not.toHaveBeenCalled();
+    expect(states.at(-1)?.status).toBe("ready");
+  });
+
+  it("renders only the authoritative units result and retains selection on failed save", async () => {
+    let fail = false;
+    const calls: Array<{ method: string; request: unknown }> = [];
+    const clients = providerWith((async (method: string, request: unknown) => {
+      calls.push({ method, request });
+      if (method === "getAthleteState") return athlete();
+      if (method === "getUnitsPreference") return { value: "metric", source: "default" };
+      if (method === "setUnitsPreference") {
+        if (fail) throw new Error("save failed");
+        return { value: "imperial", source: "cycling" };
+      }
+      throw new TypeError();
+    }) as CoachClient["call"]);
+    const states: TrainingContextViewState[] = [];
+    const controller = createTrainingContextController({
+      clients,
+      view: { render: (state) => states.push(structuredClone(state)) },
+    });
+    await controller.start();
+    await controller.setUnitsPreference("imperial");
+    expect(states.at(-1)?.unitsPreference).toEqual({
+      status: "ready",
+      value: "imperial",
+      source: "cycling",
+    });
+    fail = true;
+    await controller.setUnitsPreference("metric");
+    expect(states.at(-1)?.unitsPreference).toEqual({
+      status: "unavailable",
+      value: "imperial",
+      source: "cycling",
+    });
+    expect(calls.filter((entry) => entry.method === "setUnitsPreference")).toEqual([
+      { method: "setUnitsPreference", request: { value: "imperial" } },
+      { method: "setUnitsPreference", request: { value: "metric" } },
+    ]);
+  });
+
+  it("reconciles a disconnected save before applying the next explicit selection", async () => {
+    let stored: "metric" | "imperial" = "metric";
+    let disconnected = true;
+    const calls: string[] = [];
+    const clients = providerWith((async (method: string, request: unknown) => {
+      calls.push(method);
+      if (method === "getAthleteState") return athlete();
+      if (method === "getUnitsPreference") {
+        return { value: stored, source: stored === "metric" ? "default" : "cycling" };
+      }
+      if (method === "setUnitsPreference") {
+        if (disconnected) {
+          disconnected = false;
+          throw new CoachClientDisconnectedError(1006, "synthetic");
+        }
+        stored = (request as { value: "metric" | "imperial" }).value;
+        return { value: stored, source: "cycling" };
+      }
+      throw new TypeError();
+    }) as CoachClient["call"]);
+    const controller = createTrainingContextController({ clients, view: { render() {} } });
+    await controller.start();
+    await controller.setUnitsPreference("imperial");
+    await controller.setUnitsPreference("imperial");
+    expect(clients.reconnect).toHaveBeenCalledTimes(1);
+    expect(calls.slice(-3)).toEqual([
+      "setUnitsPreference",
+      "getUnitsPreference",
+      "setUnitsPreference",
+    ]);
+    expect(stored).toBe("imperial");
+  });
+
+  it("reconnects and reconciles when the initial units read disconnects", async () => {
+    let unitReads = 0;
+    let stored: "metric" | "imperial" = "metric";
+    const clients = providerWith((async (method: string, request: unknown) => {
+      if (method === "getAthleteState") return athlete();
+      if (method === "getUnitsPreference") {
+        unitReads += 1;
+        if (unitReads === 1) throw new CoachClientDisconnectedError(1006, "synthetic");
+        return { value: stored, source: "default" };
+      }
+      if (method === "setUnitsPreference") {
+        stored = (request as { value: "metric" | "imperial" }).value;
+        return { value: stored, source: "cycling" };
+      }
+      throw new TypeError();
+    }) as CoachClient["call"]);
+    const controller = createTrainingContextController({ clients, view: { render() {} } });
+    await controller.start();
+    await controller.setUnitsPreference("imperial");
+    expect(clients.reconnect).toHaveBeenCalledTimes(1);
+    expect(stored).toBe("imperial");
+  });
+
+  it("ignores late responses after disposal", async () => {
+    let resolve!: (value: AthleteState) => void;
+    const pending = new Promise<AthleteState>((accept) => {
+      resolve = accept;
+    });
+    const clients = providerWith((async (method: string) => {
+      if (method === "getAthleteState") return pending;
+      return { value: "metric", source: "default" };
+    }) as CoachClient["call"]);
+    const render = vi.fn();
+    const controller = createTrainingContextController({ clients, view: { render } });
+    const started = controller.start();
+    controller.dispose();
+    resolve(athlete());
+    await started;
+    expect(render).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe("training context display formatters", () => {
+  it("formats only display values without clock or locale inputs", () => {
+    expect(formatDateLabel("2026-07-18T12:00:00Z")).toBe("2026-07-18");
+    expect(formatDateLabel("2026-02-30")).toBe("Unknown date");
+    expect(formatWholeNumber(12.6)).toBe("13");
+    expect(formatPercentage(0.756)).toBe("76%");
+    expect(formatSleepDuration(27_901)).toBe("7h 45m");
+  });
+});
+
+describe("training context drawer contract", () => {
+  it("pins panel order, approved units copy, unknown states, and accessible drawer behavior", async () => {
+    const source = await readFile(
+      new URL("../src/training-context/view.ts", import.meta.url),
+      "utf8",
+    );
+    const order = [
+      "Current cycling anchor",
+      "Cycling Load",
+      "Plan",
+      "Adherence",
+      "Wellness trend",
+    ].map((value) => source.indexOf(`"${value}"`));
+    expect(order.every((value) => value >= 0)).toBe(true);
+    expect(order).toEqual([...order].sort((left, right) => left - right));
+    for (const copy of [
+      "Metric · km · kg · W/kg",
+      "Imperial · mi · lb · W/kg",
+      "Distance and body mass follow this setting. Cycling power-to-weight remains W/kg.",
+      "Not synced yet",
+      "No cycling FTP anchor is available",
+      "No platform Load is available for the last 7 days",
+      "No planned cycling workouts are available",
+      "Not enough persisted data to show this yet",
+      "No wellness readings are available",
+      "Training data drawer",
+      "Open training data",
+      "Close training data",
+    ]) {
+      expect(source).toContain(copy);
+    }
+    expect(source).toContain("showModal()");
+    expect(source).toContain('addEventListener("cancel", cancel)');
+    expect(source).toContain('setAttribute("aria-expanded", "true")');
+    expect(source).toContain("close.focus()");
+    expect(source).toContain("opener.focus()");
+  });
+
+  it("keeps the panel surface free of excluded balance labels and local metric claims", async () => {
+    const source = await readFile(
+      new URL("../src/training-context/view.ts", import.meta.url),
+      "utf8",
+    );
+    expect(source.toLowerCase()).not.toContain("locally-computed");
+    expect(source.toLowerCase()).not.toContain("locally computed");
+    expect(source.toLowerCase()).not.toContain("fitness");
+    expect(source.toLowerCase()).not.toContain("fatigue");
+  });
+});

--- a/apps/desktop-renderer/tests/turn-state.test.ts
+++ b/apps/desktop-renderer/tests/turn-state.test.ts
@@ -1,72 +1,65 @@
 import { describe, expect, it } from "vitest";
-import { createChatTurn, reduceChatTurn } from "../src/turn-state.js";
+import {
+  DESKTOP_CHAT_ID,
+  EMPTY_CHAT_STATE,
+  reduceChatState,
+  type ChatState,
+} from "../src/turn-state.js";
+
+function started(requestKey = 1): ChatState {
+  return reduceChatState(EMPTY_CHAT_STATE, {
+    type: "submit",
+    requestKey,
+    userMessage: "How should I train?",
+    userMessageId: "message-1",
+    assistantMessageId: "message-2",
+    includeUser: true,
+  });
+}
 
 describe("desktop turn state", () => {
-  it("streams, replaces final text, and completes only on terminal", () => {
-    let state = createChatTurn("How should I train?");
-    state = reduceChatTurn(state, {
-      type: "event",
-      event: { type: "text_delta", turnId: "turn-1", delta: "Part" },
-    });
-    state = reduceChatTurn(state, {
-      type: "event",
-      event: { type: "final-text", turnId: "turn-1", text: "Complete answer" },
-    });
-    expect(state.assistant).toEqual({ status: "streaming", text: "Complete answer" });
-    state = reduceChatTurn(state, { type: "success", text: "Complete answer" });
-    expect(state.assistant).toEqual({ status: "completed", text: "Complete answer" });
+  it("owns the one desktop conversation identity", () => {
+    expect(DESKTOP_CHAT_ID).toBe("desktop");
   });
 
-  it("preserves partial text as immutable aborted delivery", () => {
-    let state = createChatTurn("Continue");
-    state = reduceChatTurn(state, {
+  it("streams ordered deltas and replaces them with canonical final text", () => {
+    let state = started();
+    state = reduceChatState(state, {
       type: "event",
-      event: { type: "text_delta", turnId: "turn-1", delta: "Partial" },
+      requestKey: 1,
+      event: { type: "text_delta", turnId: "turn-1", delta: "Hel" },
     });
-    const aborted = reduceChatTurn(state, { type: "abort" });
-    expect(aborted.assistant).toEqual({ status: "aborted", text: "Partial", retryable: true });
-    expect(
-      reduceChatTurn(aborted, {
-        type: "event",
-        event: { type: "text_delta", turnId: "turn-1", delta: " late" },
-      }),
-    ).toBe(aborted);
-    expect(
-      reduceChatTurn(aborted, {
-        type: "event",
-        event: {
-          type: "error",
-          turnId: "turn-1",
-          chatId: "desktop",
-          error_class: "unknown",
-          kind: "unknown",
-          athleteMessage: "Late",
-          overflowAttempts: 0,
-          timeoutAttempts: 0,
-          rateLimitAttempts: 0,
-          duration_ms: 1,
-          compactions: 0,
-        },
-      }),
-    ).toBe(aborted);
-    expect(reduceChatTurn(aborted, { type: "success", text: "Late" })).toBe(aborted);
+    state = reduceChatState(state, {
+      type: "event",
+      requestKey: 1,
+      event: { type: "text_delta", turnId: "turn-1", delta: "lo" },
+    });
+    state = reduceChatState(state, {
+      type: "event",
+      requestKey: 1,
+      event: { type: "final-text", turnId: "turn-1", text: "Hello." },
+    });
+    state = reduceChatState(state, { type: "complete", requestKey: 1 });
+    expect(state.messages.at(-1)).toMatchObject({ text: "Hello.", delivery: "complete" });
   });
 
-  it("keeps protocol failure non-retryable and exposes athlete error copy", () => {
-    const protocol = reduceChatTurn(createChatTurn("Hello"), { type: "protocol-failure" });
-    expect(protocol.assistant).toEqual({
-      status: "failed",
-      message: "The coaching connection returned an invalid response.",
-    });
-    const athlete = reduceChatTurn(createChatTurn("Hello"), {
+  it("accepts optional start and retains safe contract error fields", () => {
+    let state = started();
+    state = reduceChatState(state, {
       type: "event",
+      requestKey: 1,
+      event: { type: "turn-start", turnId: "turn-1", chatId: "desktop" },
+    });
+    state = reduceChatState(state, {
+      type: "event",
+      requestKey: 1,
       event: {
         type: "error",
         turnId: "turn-1",
         chatId: "desktop",
         error_class: "unknown",
-        kind: "unknown",
-        athleteMessage: "Please retry later.",
+        kind: "provider-down",
+        athleteMessage: "Please try later.",
         overflowAttempts: 0,
         timeoutAttempts: 0,
         rateLimitAttempts: 0,
@@ -74,6 +67,33 @@ describe("desktop turn state", () => {
         compactions: 0,
       },
     });
-    expect(athlete.assistant).toEqual({ status: "failed", message: "Please retry later." });
+    expect(state.activeTurn?.error).toEqual({
+      kind: "provider-down",
+      athleteMessage: "Please try later.",
+    });
+  });
+
+  it("ignores stale local request keys and preserves interrupted drafts", () => {
+    let state = started(4);
+    state = reduceChatState(state, {
+      type: "event",
+      requestKey: 4,
+      event: { type: "text_delta", turnId: "turn-4", delta: "Partial" },
+    });
+    const stale = reduceChatState(state, {
+      type: "event",
+      requestKey: 3,
+      event: { type: "text_delta", turnId: "turn-3", delta: " hidden" },
+    });
+    expect(stale).toBe(state);
+    const interrupted = reduceChatState(state, {
+      type: "interrupt",
+      requestKey: 4,
+      copy: "Connection interrupted. Your partial response is preserved.",
+    });
+    expect(interrupted.messages.at(-1)).toMatchObject({
+      text: "Partial",
+      delivery: "interrupted",
+    });
   });
 });

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -179,7 +179,7 @@ async function runDesktop(): Promise<void> {
         noNodeGlobals: ["process", "require", "Buffer", "global", "module"].every((key) => typeof window[key] === "undefined"),
         rpcConnected: document.documentElement.dataset.rpc === "connected",
         blockedOffPort: blocked,
-        drawerPresent: document.querySelector('.drawer[aria-label="Training context"]') !== null,
+        drawerPresent: document.querySelector('.drawer[aria-label="Training data"]') !== null,
         rendererSurfaces: {
           dom: document.documentElement.outerHTML,
           localStorage: Object.entries(localStorage),

--- a/apps/desktop/tests/chat-panels.integration.test.ts
+++ b/apps/desktop/tests/chat-panels.integration.test.ts
@@ -195,7 +195,7 @@ afterEach(async () => {
   );
 });
 
-describe.skipIf(!hasLoopback)("desktop chat panels", () => {
+describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat panels", () => {
   it("streams chat, persists units, preserves focus, and fits desktop geometry", async () => {
     const { fixture, calls } = await launch({ width: 1440, height: 900, reducedMotion: false });
     const initial = await fixture.evaluate<{

--- a/apps/desktop/tests/chat-panels.integration.test.ts
+++ b/apps/desktop/tests/chat-panels.integration.test.ts
@@ -1,0 +1,355 @@
+import { createServer } from "node:net";
+import { mkdir, mkdtemp, readFile, realpath, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  launchDesktopFixture,
+  type DesktopFixtureScript,
+  type RunningDesktopFixture,
+} from "./helpers/desktop-fixture.js";
+
+const hasLoopback = await new Promise<boolean>((resolveAvailability) => {
+  const server = createServer();
+  server.once("error", () => resolveAvailability(false));
+  server.listen({ host: "127.0.0.1", port: 0 }, () => {
+    server.close(() => resolveAvailability(true));
+  });
+});
+
+const token = "t".repeat(43);
+const fixtures: RunningDesktopFixture[] = [];
+const scratchPaths: string[] = [];
+
+const trainingContext = {
+  anchorZones: {
+    kind: "computed",
+    asOf: "2026-07-19T08:00:00.000Z",
+    anchor: {
+      watts: 300,
+      validFrom: "2026-07-01",
+      source: "intervals.icu",
+      confidence: "platform",
+      ageDays: 18,
+      stalenessBand: "fresh",
+      stale: false,
+    },
+    zones: [
+      { name: "Recovery", range: "0–164 W", overlaps: false },
+      { name: "Endurance", range: "165–224 W", overlaps: false },
+      { name: "Tempo", range: "225–269 W", overlaps: false },
+      { name: "Threshold", range: "270–314 W", overlaps: false },
+      { name: "VO₂ max", range: "315–359 W", overlaps: false },
+      { name: "Anaerobic", range: "360+ W", overlaps: false },
+    ],
+  },
+  cyclingLoad: {
+    kind: "computed",
+    asOf: "2026-07-19T08:00:00.000Z",
+    source: "intervals.icu",
+    windowDays: 7,
+    value: 240,
+    activityCount: 3,
+    missingLoadCount: 1,
+  },
+  plan: {
+    kind: "computed",
+    asOf: "2026-07-19T08:00:00.000Z",
+    items: [
+      {
+        id: "plan-1",
+        date: "2026-07-20",
+        name: "Tempo ride",
+        category: "WORKOUT",
+        workoutType: "Ride",
+      },
+    ],
+  },
+  adherence: {
+    kind: "computed",
+    asOf: "2026-07-19T08:00:00.000Z",
+    ratio: 0.8,
+    plannedDays: 5,
+    completedDays: 4,
+    matchedDays: 4,
+  },
+  wellnessTrend: {
+    kind: "computed",
+    asOf: "2026-07-19T08:00:00.000Z",
+    windowDays: 7,
+    series: [
+      { metric: "hrv", unit: "ms", points: [{ date: "2026-07-19", value: 65 }] },
+      { metric: "sleep", unit: "seconds", points: [{ date: "2026-07-19", value: 27_000 }] },
+      { metric: "resting-hr", unit: "bpm", points: [{ date: "2026-07-19", value: 48 }] },
+    ],
+  },
+} as const;
+
+const athleteState = {
+  schemaVersion: "1",
+  lastUpdated: "2026-07-19T08:00:00.000Z",
+  freshness: "fresh",
+  degraded: false,
+  lastSynced: "2026-07-19T07:55:00.000Z",
+  athleteProfile: {},
+  currentStatus: {},
+  derivedMetrics: {},
+  recentActivities: [],
+  plannedWorkouts: [],
+  wellness: {},
+  trainingContext,
+} as const;
+
+function response(value: unknown): readonly string[] {
+  return [JSON.stringify(value)];
+}
+
+function makeScript(calls: ScriptRequest[]): DesktopFixtureScript {
+  let units: "metric" | "imperial" = "metric";
+  return {
+    onRequest(value) {
+      const request = value as ScriptRequest;
+      calls.push(request);
+      if (request.method === "getAthleteState") return response(athleteState);
+      if (request.method === "getUnitsPreference") {
+        return response({ value: units, source: units === "metric" ? "default" : "cycling" });
+      }
+      if (request.method === "setUnitsPreference") {
+        units = (request.params as { readonly value: "metric" | "imperial" }).value;
+        return response({ value: units, source: "cycling" });
+      }
+      if (request.method === "chat") {
+        return [
+          JSON.stringify({ type: "text_delta", turnId: "turn-fixture", delta: "Hold " }),
+          JSON.stringify({ type: "text_delta", turnId: "turn-fixture", delta: "steady" }),
+          JSON.stringify({ type: "final-text", turnId: "turn-fixture", text: "Hold steady." }),
+          JSON.stringify({ text: "Hold steady." }),
+        ];
+      }
+      if (request.method === "hasSession") return response({ hasSession: false });
+      if (request.method === "resetSession") return response({ memoryFlushed: true });
+      if (request.method === "sync") {
+        return response({
+          schemaVersion: 1,
+          published: false,
+          referenceSucceeded: true,
+          requests: { store: 0, reference: 0, total: 0 },
+        });
+      }
+      if (request.method === "importFiles") {
+        return response({
+          schemaVersion: 1,
+          files: { total: 1, imported: 1, quarantined: 0 },
+          changes: {
+            rawFilesInserted: 1,
+            sourceRecordsInserted: 1,
+            sourceRecordsUpdated: 0,
+            relinkedSourceRecords: 0,
+          },
+        });
+      }
+      if (request.method === "saveIntake") return response({ schemaVersion: 1, saved: true });
+      if (request.method === "configureRuntime") {
+        return response({ schemaVersion: 1, applied: { llm: true, intervals: true } });
+      }
+      throw new TypeError(`unexpected fixture method ${request.method}`);
+    },
+  };
+}
+
+interface ScriptRequest {
+  readonly jsonrpc: "2.0";
+  readonly method: string;
+  readonly params: unknown;
+}
+
+async function launch(input: {
+  readonly width: number;
+  readonly height: number;
+  readonly reducedMotion: boolean;
+}): Promise<{ readonly fixture: RunningDesktopFixture; readonly calls: ScriptRequest[] }> {
+  const calls: ScriptRequest[] = [];
+  const fixture = await launchDesktopFixture({
+    script: makeScript(calls),
+    token,
+    width: input.width,
+    height: input.height,
+    colorScheme: "light",
+    reducedMotion: input.reducedMotion,
+  });
+  fixtures.push(fixture);
+  await fixture.evaluate<void>(`
+    const deadline = Date.now() + 10000;
+    while ((document.documentElement.dataset.rpc !== "connected" || document.querySelector(".drawer-status")?.textContent !== "") && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+    document.querySelector(".onboarding")?.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+  `);
+  return { fixture, calls };
+}
+
+afterEach(async () => {
+  await Promise.all(fixtures.splice(0).map((fixture) => fixture.close()));
+  await Promise.all(
+    scratchPaths.splice(0).map((path) => rm(path, { recursive: true, force: true })),
+  );
+});
+
+describe.skipIf(!hasLoopback)("desktop chat panels", () => {
+  it("streams chat, persists units, preserves focus, and fits desktop geometry", async () => {
+    const { fixture, calls } = await launch({ width: 1440, height: 900, reducedMotion: false });
+    const initial = await fixture.evaluate<{
+      readonly location: string;
+      readonly bridgeKeys: readonly string[];
+      readonly thread: boolean;
+      readonly partial: string;
+      readonly final: string;
+      readonly drawerStatus: string;
+      readonly anchorValue: string;
+      readonly wellnessValue: string;
+    }>(`
+      const bridgeKeys = Object.keys(window.enduragentAuth).sort();
+      const thread = document.querySelectorAll(".thread").length === 1;
+      const textarea = document.querySelector("#message");
+      const observed = [];
+      const observer = new MutationObserver(() => {
+        const value = document.querySelector(".chat-message--coach .chat-message__text")?.textContent ?? "";
+        if (value.length > 0) observed.push(value);
+      });
+      observer.observe(document.querySelector(".chat-messages"), {
+        childList: true,
+        characterData: true,
+        subtree: true,
+      });
+      textarea.value = "What should I ride?";
+      textarea.closest("form").requestSubmit();
+      const finalDeadline = Date.now() + 5000;
+      let final = "";
+      while (final !== "Hold steady." && Date.now() < finalDeadline) {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        final = document.querySelector(".chat-message--coach .chat-message__text")?.textContent ?? "";
+      }
+      observer.disconnect();
+      const partial = observed.find((value) => value === "Hold " || value === "Hold steady") ?? "";
+      const panels = [...document.querySelectorAll(".context-panel__body")];
+      return {
+        location: location.href,
+        bridgeKeys,
+        thread,
+        partial,
+        final,
+        drawerStatus: document.querySelector(".drawer-status")?.textContent ?? "missing",
+        anchorValue: panels[0]?.querySelector(".context-panel__value")?.textContent ?? "",
+        wellnessValue: panels[4]?.querySelector(".wellness-row__value")?.textContent ?? "",
+      };
+    `);
+    expect(initial).toEqual({
+      location: "enduragent://app/index.html",
+      bridgeKeys: [
+        "chooseImportFiles",
+        "credentialStatuses",
+        "getDaemonConnection",
+        "onDroppedImportFiles",
+        "writeCredential",
+      ],
+      thread: true,
+      partial: expect.stringMatching(/^Hold (steady)?$/u),
+      final: "Hold steady.",
+      drawerStatus: "",
+      anchorValue: "300 W",
+      wellnessValue: "65 ms",
+    });
+    const drawer = await fixture.evaluate<{
+      readonly open: boolean;
+      readonly focused: string | null;
+      readonly label: string | null;
+      readonly order: readonly string[];
+      readonly spineWidth: number;
+      readonly closedFocus: string | null;
+      readonly overflow: boolean;
+      readonly units: string;
+    }>(`
+      const opener = document.querySelector(".drawer-toggle");
+      opener.click();
+      const drawer = document.querySelector("#training-context-drawer");
+      const opened = {
+        open: drawer.open,
+        focused: document.activeElement?.getAttribute("aria-label") ?? null,
+        label: drawer.getAttribute("aria-label"),
+        order: [...drawer.querySelectorAll(".context-panel > h3")].map((node) => node.textContent),
+        spineWidth: document.querySelector(".data-spine").getBoundingClientRect().width,
+      };
+      const imperial = drawer.querySelector('input[value="imperial"]');
+      imperial.click();
+      const unitsDeadline = Date.now() + 5000;
+      while ((!imperial.checked || imperial.disabled) && Date.now() < unitsDeadline) {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+      }
+      drawer.querySelector(".drawer-close").click();
+      return {
+        ...opened,
+        closedFocus: document.activeElement?.getAttribute("aria-label") ?? null,
+        overflow: document.documentElement.scrollWidth > document.documentElement.clientWidth,
+        units: imperial.checked ? imperial.value : "",
+      };
+    `);
+    expect(drawer).toEqual({
+      open: true,
+      focused: "Close training data",
+      label: "Training data",
+      order: ["Current cycling anchor", "Cycling Load", "Plan", "Adherence", "Wellness trend"],
+      spineWidth: 48,
+      closedFocus: "Open training data",
+      overflow: false,
+      units: "imperial",
+    });
+    expect(calls.filter((call) => call.method === "chat")).toEqual([
+      {
+        jsonrpc: "2.0",
+        method: "chat",
+        params: { chatId: "desktop", message: "What should I ride?" },
+      },
+    ]);
+    expect(calls.filter((call) => call.method === "setUnitsPreference")).toEqual([
+      { jsonrpc: "2.0", method: "setUnitsPreference", params: { value: "imperial" } },
+    ]);
+    await fixture.setViewport(720, 800);
+    expect(
+      await fixture.evaluate<boolean>(`
+      return document.documentElement.scrollWidth > document.documentElement.clientWidth;
+    `),
+    ).toBe(false);
+    const base = await realpath(process.platform === "darwin" ? "/tmp" : tmpdir());
+    const screenshotRoot = await mkdtemp(join(base, "eap-shot-"));
+    scratchPaths.push(screenshotRoot);
+    const screenshotPath = join(screenshotRoot, "chat-panels.png");
+    await mkdir(screenshotRoot, { recursive: true, mode: 0o700 });
+    await fixture.screenshot(screenshotPath);
+    const screenshot = await readFile(screenshotPath);
+    expect(screenshot.includes(Buffer.from(token))).toBe(false);
+    for (const name of ["location", "console", "stdout", "stderr", "dom"] as const) {
+      expect(fixture.readCapturedSurface(name)).not.toContain(token);
+    }
+    expect(await fixture.close()).toEqual({ livePids: [], listenerCount: 0 });
+    fixtures.splice(fixtures.indexOf(fixture), 1);
+  }, 30_000);
+
+  it("honors reduced motion at the compact viewport", async () => {
+    const { fixture } = await launch({ width: 720, height: 800, reducedMotion: true });
+    expect(
+      await fixture.evaluate<{
+        readonly reduced: boolean;
+        readonly overflow: boolean;
+        readonly spineWidth: number;
+      }>(`
+      return {
+        reduced: matchMedia("(prefers-reduced-motion: reduce)").matches,
+        overflow: document.documentElement.scrollWidth > document.documentElement.clientWidth,
+        spineWidth: document.querySelector(".data-spine").getBoundingClientRect().width,
+      };
+    `),
+    ).toEqual({ reduced: true, overflow: false, spineWidth: 48 });
+    expect(await fixture.close()).toEqual({ livePids: [], listenerCount: 0 });
+    fixtures.splice(fixtures.indexOf(fixture), 1);
+  }, 30_000);
+});

--- a/apps/desktop/tests/helpers/desktop-fixture.ts
+++ b/apps/desktop/tests/helpers/desktop-fixture.ts
@@ -1,0 +1,481 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createRequire } from "node:module";
+import type {
+  CoachEngine,
+  CoachOperations,
+  OperationProgressEvent,
+  TurnEvent,
+} from "@enduragent/coach-contract";
+import { acquireWriteLock } from "../../../../packages/kernel-node/src/lock/index.js";
+import { createHealthzRequestHandler } from "../../../../packages/coach/src/daemon/healthz-server.js";
+import { createCoachRpcServer } from "../../../../packages/coach/src/daemon/rpc-server.js";
+
+export interface DesktopFixtureScript {
+  readonly onRequest: (request: unknown) => readonly string[] | Promise<readonly string[]>;
+}
+
+export interface RunningDesktopFixture {
+  evaluate<T>(source: string): Promise<T>;
+  screenshot(path: string): Promise<void>;
+  setViewport(width: number, height: number): Promise<void>;
+  readCapturedSurface(name: "location" | "console" | "stdout" | "stderr" | "dom"): string;
+  close(): Promise<{
+    readonly livePids: readonly number[];
+    readonly listenerCount: number;
+  }>;
+}
+
+interface CdpResponse {
+  readonly id?: number;
+  readonly method?: string;
+  readonly params?: unknown;
+  readonly result?: Record<string, unknown>;
+  readonly error?: { readonly message?: string };
+}
+
+interface ScriptRequest {
+  readonly jsonrpc: "2.0";
+  readonly method: string;
+  readonly params: unknown;
+}
+
+const require = createRequire(import.meta.url);
+const desktopRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+
+function reservePort(): Promise<number> {
+  return new Promise((resolvePort, reject) => {
+    const server = createServer();
+    server.once("error", reject);
+    server.listen({ host: "127.0.0.1", port: 0 }, () => {
+      const address = server.address();
+      if (address === null || typeof address === "string") {
+        server.close();
+        reject(new TypeError("loopback port was not assigned"));
+        return;
+      }
+      server.close((error) => (error === undefined ? resolvePort(address.port) : reject(error)));
+    });
+  });
+}
+
+function parseScriptFrames(values: readonly string[]): readonly unknown[] {
+  return values.map((value) => JSON.parse(value) as unknown);
+}
+
+function frameValue(value: unknown): unknown {
+  if (value !== null && typeof value === "object" && !Array.isArray(value)) {
+    const record = value as Record<string, unknown>;
+    if ("result" in record) return record.result;
+  }
+  return value;
+}
+
+function frameEvent(value: unknown): unknown {
+  if (value !== null && typeof value === "object" && !Array.isArray(value)) {
+    const record = value as Record<string, unknown>;
+    if (record.params !== null && typeof record.params === "object") {
+      const event = (record.params as Record<string, unknown>).event;
+      if (event !== undefined) return event;
+    }
+    if (record.event !== undefined) return record.event;
+  }
+  return value;
+}
+
+async function scripted(
+  script: DesktopFixtureScript,
+  method: string,
+  params: unknown,
+): Promise<readonly unknown[]> {
+  const request: ScriptRequest = { jsonrpc: "2.0", method, params };
+  return parseScriptFrames(await script.onRequest(request));
+}
+
+function finalFrame(frames: readonly unknown[]): unknown {
+  const value = frames.at(-1);
+  if (value === undefined) throw new TypeError("fixture script returned no terminal frame");
+  return frameValue(value);
+}
+
+function eventFrames(frames: readonly unknown[]): readonly unknown[] {
+  return frames.length < 2 ? [] : frames.slice(0, -1).map(frameEvent);
+}
+
+async function waitForPage(port: number): Promise<string> {
+  const deadline = Date.now() + 20_000;
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(`http://127.0.0.1:${port}/json/list`);
+      if (response.ok) {
+        const entries = (await response.json()) as readonly {
+          readonly type?: unknown;
+          readonly url?: unknown;
+          readonly webSocketDebuggerUrl?: unknown;
+        }[];
+        const page = entries.find(
+          (entry) =>
+            entry.type === "page" &&
+            typeof entry.url === "string" &&
+            entry.url.startsWith("enduragent://app/") &&
+            typeof entry.webSocketDebuggerUrl === "string",
+        );
+        if (page !== undefined) return page.webSocketDebuggerUrl as string;
+      }
+    } catch {}
+    await new Promise((resolveDelay) => setTimeout(resolveDelay, 25));
+  }
+  throw new Error("timed out waiting for the desktop renderer");
+}
+
+function connectCdp(
+  url: string,
+  onEvent: (message: CdpResponse) => void,
+): Promise<{
+  readonly socket: WebSocket;
+  call(method: string, params?: Record<string, unknown>): Promise<Record<string, unknown>>;
+}> {
+  return new Promise((resolveConnection, reject) => {
+    const socket = new WebSocket(url);
+    const pending = new Map<
+      number,
+      {
+        readonly resolve: (value: Record<string, unknown>) => void;
+        readonly reject: (error: Error) => void;
+      }
+    >();
+    let sequence = 0;
+    socket.addEventListener(
+      "error",
+      () => reject(new Error("desktop debugger connection failed")),
+      { once: true },
+    );
+    socket.addEventListener("message", (event) => {
+      const message = JSON.parse(String(event.data)) as CdpResponse;
+      if (message.id === undefined) {
+        onEvent(message);
+        return;
+      }
+      const waiter = pending.get(message.id);
+      if (waiter === undefined) return;
+      pending.delete(message.id);
+      if (message.error !== undefined) {
+        waiter.reject(new Error(message.error.message ?? "desktop debugger command failed"));
+      } else {
+        waiter.resolve(message.result ?? {});
+      }
+    });
+    socket.addEventListener("close", () => {
+      for (const waiter of pending.values())
+        waiter.reject(new Error("desktop debugger disconnected"));
+      pending.clear();
+    });
+    socket.addEventListener(
+      "open",
+      () => {
+        resolveConnection({
+          socket,
+          call(method, params = {}) {
+            const id = ++sequence;
+            return new Promise((resolveCall, rejectCall) => {
+              pending.set(id, { resolve: resolveCall, reject: rejectCall });
+              socket.send(JSON.stringify({ id, method, params }));
+            });
+          },
+        });
+      },
+      { once: true },
+    );
+  });
+}
+
+function processAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function stopProcess(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  child.kill("SIGTERM");
+  const exited = await Promise.race([
+    new Promise<boolean>((resolveExit) => child.once("exit", () => resolveExit(true))),
+    new Promise<boolean>((resolveExit) => setTimeout(() => resolveExit(false), 5_000)),
+  ]);
+  if (!exited) {
+    child.kill("SIGKILL");
+    await new Promise<void>((resolveExit) => child.once("exit", () => resolveExit()));
+  }
+}
+
+export async function launchDesktopFixture(input: {
+  readonly script: DesktopFixtureScript;
+  readonly token: string;
+  readonly width: number;
+  readonly height: number;
+  readonly colorScheme: "light" | "dark";
+  readonly reducedMotion: boolean;
+}): Promise<RunningDesktopFixture> {
+  if (!/^[A-Za-z0-9_-]{43}$/.test(input.token)) throw new TypeError("invalid fixture token");
+  if (!existsSync(join(desktopRoot, "out/main/index.js"))) {
+    throw new Error("desktop build output is required before launching the fixture");
+  }
+  const base = await realpath(process.platform === "darwin" ? "/tmp" : tmpdir());
+  const scratch = await mkdtemp(join(base, "eap-"));
+  const athleteHome = join(scratch, "h");
+  const configDir = join(athleteHome, "config");
+  const userData = join(scratch, "u");
+  await Promise.all([
+    mkdir(configDir, { recursive: true, mode: 0o700 }),
+    mkdir(userData, { recursive: true, mode: 0o700 }),
+  ]);
+  await Promise.all([
+    writeFile(join(configDir, "daemon.token"), `${input.token}\n`, { mode: 0o600 }),
+    writeFile(
+      join(configDir, "config.yaml"),
+      [
+        "data_source: store",
+        `data_dir: ${JSON.stringify(athleteHome)}`,
+        "llm:",
+        "  provider: anthropic",
+        "  model: fixture",
+        "  api_key: fixture",
+        "intervals:",
+        "  api_key: ''",
+        "  athlete_id: '0'",
+        "session:",
+        "  timezone: UTC",
+        "",
+      ].join("\n"),
+      { mode: 0o600 },
+    ),
+  ]);
+  const lock = await acquireWriteLock({
+    configDir,
+    athleteHome,
+    version: "0.0.1",
+  });
+  if (lock.status !== "acquired") throw new Error("fixture writer lock was not acquired");
+  const invoke = (method: string, params: unknown) => scripted(input.script, method, params);
+  const engine: CoachEngine = {
+    async chat(request, onEvent) {
+      const frames = await invoke("chat", request);
+      for (const event of eventFrames(frames)) {
+        onEvent?.(event as TurnEvent);
+        await new Promise((resolveDelay) => setTimeout(resolveDelay, 40));
+      }
+      return finalFrame(frames) as Awaited<ReturnType<CoachEngine["chat"]>>;
+    },
+    async resetSession(request) {
+      return finalFrame(await invoke("resetSession", request)) as Awaited<
+        ReturnType<CoachEngine["resetSession"]>
+      >;
+    },
+    async hasSession(request) {
+      return finalFrame(await invoke("hasSession", request)) as Awaited<
+        ReturnType<CoachEngine["hasSession"]>
+      >;
+    },
+    async getAthleteState() {
+      return finalFrame(await invoke("getAthleteState", {})) as Awaited<
+        ReturnType<CoachEngine["getAthleteState"]>
+      >;
+    },
+  };
+  const operations: CoachOperations = {
+    async importFiles(request, onEvent) {
+      const frames = await invoke("importFiles", request);
+      for (const event of eventFrames(frames)) onEvent?.(event as OperationProgressEvent);
+      return finalFrame(frames) as Awaited<ReturnType<CoachOperations["importFiles"]>>;
+    },
+    async sync(request, onEvent) {
+      const frames = await invoke("sync", request);
+      for (const event of eventFrames(frames)) onEvent?.(event as OperationProgressEvent);
+      return finalFrame(frames) as Awaited<ReturnType<CoachOperations["sync"]>>;
+    },
+    async saveIntake(request) {
+      return finalFrame(await invoke("saveIntake", request)) as Awaited<
+        ReturnType<CoachOperations["saveIntake"]>
+      >;
+    },
+    async configureRuntime(request) {
+      return finalFrame(await invoke("configureRuntime", request)) as Awaited<
+        ReturnType<CoachOperations["configureRuntime"]>
+      >;
+    },
+    async getUnitsPreference(request) {
+      return finalFrame(await invoke("getUnitsPreference", request)) as {
+        value: "metric" | "imperial";
+        source: "cycling" | "athlete" | "default";
+      };
+    },
+    async setUnitsPreference(request) {
+      return finalFrame(await invoke("setUnitsPreference", request)) as {
+        value: "metric" | "imperial";
+        source: "cycling";
+      };
+    },
+  };
+  const rpc = createCoachRpcServer({
+    engine,
+    operations,
+    token: input.token,
+    owner: "unmanaged-foreground",
+  });
+  const binding = await lock.listener.bind({
+    request: createHealthzRequestHandler({ appVersion: "0.0.1" }),
+    upgrade: rpc.handleUpgrade,
+  });
+  const debuggerPort = await reservePort();
+  const executable = require("electron") as string;
+  const child = spawn(
+    executable,
+    [desktopRoot, `--remote-debugging-port=${debuggerPort}`, `--user-data-dir=${userData}`],
+    {
+      env: {
+        ...process.env,
+        ENDURAGENT_HOME: athleteHome,
+        FORCE_COLOR: undefined,
+        NO_COLOR: undefined,
+        CLICOLOR_FORCE: undefined,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+  let stdout = "";
+  let stderr = "";
+  child.stdout.on("data", (chunk) => {
+    stdout += String(chunk);
+  });
+  child.stderr.on("data", (chunk) => {
+    stderr += String(chunk);
+  });
+  let cdp: Awaited<ReturnType<typeof connectCdp>> | undefined;
+  const surfaces: Record<"location" | "console" | "stdout" | "stderr" | "dom", string> = {
+    location: "",
+    console: "",
+    stdout: "",
+    stderr: "",
+    dom: "",
+  };
+  const consoleMessages: string[] = [];
+  const refreshSurfaces = async (): Promise<void> => {
+    if (cdp === undefined) return;
+    const result = await cdp.call("Runtime.evaluate", {
+      expression: "({ location: location.href, dom: document.documentElement.outerHTML })",
+      returnByValue: true,
+    });
+    const value = ((result.result as Record<string, unknown> | undefined)?.value ?? {}) as Record<
+      string,
+      unknown
+    >;
+    surfaces.location = typeof value.location === "string" ? value.location : "";
+    surfaces.dom = typeof value.dom === "string" ? value.dom : "";
+    surfaces.console = consoleMessages.join("\n");
+    surfaces.stdout = stdout;
+    surfaces.stderr = stderr;
+  };
+  let closed = false;
+  try {
+    const debuggerUrl = await waitForPage(debuggerPort);
+    cdp = await connectCdp(debuggerUrl, (message) => {
+      if (message.method !== "Runtime.consoleAPICalled") return;
+      const args =
+        (message.params as { readonly args?: readonly { readonly value?: unknown }[] } | undefined)
+          ?.args ?? [];
+      consoleMessages.push(args.map((arg) => String(arg.value ?? "")).join(" "));
+    });
+    await Promise.all([
+      cdp.call("Runtime.enable"),
+      cdp.call("Page.enable"),
+      cdp.call("Emulation.setEmulatedMedia", {
+        features: [
+          { name: "prefers-color-scheme", value: input.colorScheme },
+          {
+            name: "prefers-reduced-motion",
+            value: input.reducedMotion ? "reduce" : "no-preference",
+          },
+        ],
+      }),
+      cdp.call("Emulation.setDeviceMetricsOverride", {
+        width: input.width,
+        height: input.height,
+        deviceScaleFactor: 1,
+        mobile: false,
+      }),
+    ]);
+    await refreshSurfaces();
+  } catch (error) {
+    await stopProcess(child).catch(() => {});
+    await binding.close().catch(() => {});
+    await rpc.close().catch(() => {});
+    await lock.release().catch(() => {});
+    await rm(scratch, { recursive: true, force: true });
+    throw error;
+  }
+  return {
+    async evaluate<T>(source: string): Promise<T> {
+      if (closed || cdp === undefined) throw new Error("desktop fixture is closed");
+      const response = await cdp.call("Runtime.evaluate", {
+        expression: `(async () => { ${source} })()`,
+        awaitPromise: true,
+        returnByValue: true,
+      });
+      const remote = response.result as
+        | { readonly value?: unknown; readonly description?: unknown }
+        | undefined;
+      if (remote?.description !== undefined && remote.value === undefined) {
+        throw new Error(String(remote.description));
+      }
+      await refreshSurfaces();
+      return remote?.value as T;
+    },
+    async screenshot(path: string) {
+      if (closed || cdp === undefined) throw new Error("desktop fixture is closed");
+      const response = await cdp.call("Page.captureScreenshot", { format: "png" });
+      const data = response.data;
+      if (typeof data !== "string") throw new TypeError("desktop screenshot was not returned");
+      await writeFile(path, Buffer.from(data, "base64"));
+      await refreshSurfaces();
+    },
+    async setViewport(width: number, height: number) {
+      if (closed || cdp === undefined) throw new Error("desktop fixture is closed");
+      await cdp.call("Emulation.setDeviceMetricsOverride", {
+        width,
+        height,
+        deviceScaleFactor: 1,
+        mobile: false,
+      });
+      await refreshSurfaces();
+    },
+    readCapturedSurface(name) {
+      if (name === "stdout") return stdout;
+      if (name === "stderr") return stderr;
+      return surfaces[name];
+    },
+    async close() {
+      if (closed) return { livePids: [], listenerCount: 0 };
+      closed = true;
+      const pid = child.pid;
+      if (cdp !== undefined && cdp.socket.readyState === WebSocket.OPEN) {
+        await cdp.call("Browser.close").catch(() => {});
+        cdp.socket.close();
+      }
+      await stopProcess(child).catch(() => {});
+      await binding.close().catch(() => {});
+      await rpc.close().catch(() => {});
+      await lock.release().catch(() => {});
+      await rm(scratch, { recursive: true, force: true });
+      const livePids = pid !== undefined && processAlive(pid) ? [pid] : [];
+      return { livePids, listenerCount: 0 };
+    },
+  };
+}

--- a/packages/coach-client/tests/client.test.ts
+++ b/packages/coach-client/tests/client.test.ts
@@ -484,6 +484,8 @@ describe("RPC receive and observers", () => {
         },
         saveIntake: { schemaVersion: 1, saved: true },
         configureRuntime: { schemaVersion: 1, applied: { llm: true, intervals: false } },
+        getUnitsPreference: { value: "metric", source: "default" },
+        setUnitsPreference: { value: "imperial", source: "cycling" },
       };
       socket.emitMessage(
         serializeCoachRpcEnvelope({
@@ -532,6 +534,19 @@ describe("RPC receive and observers", () => {
       "sync",
       "saveIntake",
       "configureRuntime",
+    ]);
+    await expect(client.call("getUnitsPreference", {})).resolves.toEqual({
+      value: "metric",
+      source: "default",
+    });
+    await expect(client.call("setUnitsPreference", { value: "imperial" })).resolves.toEqual({
+      value: "imperial",
+      source: "cycling",
+    });
+    expect(received.slice(-2).map((value) => (value as { id: number }).id)).toEqual([9, 10]);
+    expect(received.slice(-2).map((value) => (value as { method: string }).method)).toEqual([
+      "getUnitsPreference",
+      "setUnitsPreference",
     ]);
     socket.closeSynchronously = true;
     await client.close();

--- a/packages/coach-contract/DERIVATION.md
+++ b/packages/coach-contract/DERIVATION.md
@@ -4,7 +4,7 @@ This file maps every field of the two behavior-bearing contract schemas
 (`TurnEvent`, `AthleteState`) and the `CoachEngine` method surface to the
 engine source it derives from, so a reviewer can diff the contract
 symbol-by-symbol against the engine. Grounding commit:
-`3463f8593e91d709d78f3444c76dfc3becc8d023`.
+`0bd7a25e56a339a50efb1c917483170b64af86f8`.
 
 Re-grounding rule: any PR that edits `src/turn-event.ts` or
 `src/athlete-state.ts` must update this file's citations in the same diff. A
@@ -12,15 +12,15 @@ field with no cited source is a review blocker.
 
 ## Table A — TurnEvent variants
 
-| Variant tag | Fields | Source citations |
-|---|---|---|
-| `turn-start` | `turnId`, `chatId` | `packages/core/src/agent/coach-agent.ts:434-435` (turn bracketing: `turnStart` / `turnId` created inside the per-chat session lock), `packages/core/src/agent/coach-agent.ts:420` (`chatId` param of `chat()`) |
-| `tool-start` | `toolName` | `packages/core/src/agent/coach-agent.ts:275-292` (write-tool `execute` wrapper — the only execution-boundary hook at the grounding commit), `packages/core/src/agent/coach-agent.ts:76-84` (the five write tools) |
-| `tool-end` | `toolName`, `summary?` | `packages/core/src/agent/coach-agent.ts:275-292` (write-tool `execute` wrapper), `packages/core/src/agent/coach-agent.ts:169-180` (committed-write summaries — the `summary` source), `packages/core/src/agent/coach-agent.ts:76-84` (the five write tools) |
-| `step-text` | `text` | `packages/core/src/agent/coach-agent.ts:617` (`result.text`), `packages/core/src/agent/coach-agent.ts:620-626` (step-exhaustion recovered text) |
-| `final-text` | `text` | `packages/core/src/agent/coach-agent.ts:681` (success return `effectiveText + persistenceNote`), `packages/core/src/agent/coach-agent.ts:423` (`chat()` resolves `Promise<string>`), `packages/core/src/agent/coach-agent.ts:710` (fallback-copy resolution after a committed write) |
-| `error` | `error_class`, `kind`, `athleteMessage`, `overflowAttempts`, `timeoutAttempts`, `rateLimitAttempts`, `duration_ms`, `compactions`, plus `turnId`/`chatId` | `packages/core/src/agent/coach-agent.ts:126-136` (the frozen terminal record; snake_case `error_class` / `duration_ms` preserved verbatim), `packages/core/src/agent/coach-agent.ts:143-151` (`error_class` value set), `packages/core/src/agent/coach-agent.ts:699-709` and `packages/core/src/agent/coach-agent.ts:829-839` (emit sites), `packages/core/src/agent/error-classify.ts:9-14` and `packages/core/src/agent/error-classify.ts:66-110` (`kind` + `athleteMessage`), `packages/core/src/channels/telegram.ts:317-321` (the consuming error path) |
-| `text_delta` | `delta` | Reserved; no producer at the grounding commit — `packages/core/src/agent/coach-agent.ts:605` uses a non-streaming generate call. The variant exists so adding a streaming producer later is additive, not a contract break. |
+| Variant tag  | Fields                                                                                                                                                    | Source citations                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `turn-start` | `turnId`, `chatId`                                                                                                                                        | `packages/core/src/agent/coach-agent.ts:434-435` (turn bracketing: `turnStart` / `turnId` created inside the per-chat session lock), `packages/core/src/agent/coach-agent.ts:420` (`chatId` param of `chat()`)                                                                                                                                                                                                                                                                                                                                               |
+| `tool-start` | `toolName`                                                                                                                                                | `packages/core/src/agent/coach-agent.ts:275-292` (write-tool `execute` wrapper — the only execution-boundary hook at the grounding commit), `packages/core/src/agent/coach-agent.ts:76-84` (the five write tools)                                                                                                                                                                                                                                                                                                                                            |
+| `tool-end`   | `toolName`, `summary?`                                                                                                                                    | `packages/core/src/agent/coach-agent.ts:275-292` (write-tool `execute` wrapper), `packages/core/src/agent/coach-agent.ts:169-180` (committed-write summaries — the `summary` source), `packages/core/src/agent/coach-agent.ts:76-84` (the five write tools)                                                                                                                                                                                                                                                                                                  |
+| `step-text`  | `text`                                                                                                                                                    | `packages/core/src/agent/coach-agent.ts:617` (`result.text`), `packages/core/src/agent/coach-agent.ts:620-626` (step-exhaustion recovered text)                                                                                                                                                                                                                                                                                                                                                                                                              |
+| `final-text` | `text`                                                                                                                                                    | `packages/core/src/agent/coach-agent.ts:681` (success return `effectiveText + persistenceNote`), `packages/core/src/agent/coach-agent.ts:423` (`chat()` resolves `Promise<string>`), `packages/core/src/agent/coach-agent.ts:710` (fallback-copy resolution after a committed write)                                                                                                                                                                                                                                                                         |
+| `error`      | `error_class`, `kind`, `athleteMessage`, `overflowAttempts`, `timeoutAttempts`, `rateLimitAttempts`, `duration_ms`, `compactions`, plus `turnId`/`chatId` | `packages/core/src/agent/coach-agent.ts:126-136` (the frozen terminal record; snake_case `error_class` / `duration_ms` preserved verbatim), `packages/core/src/agent/coach-agent.ts:143-151` (`error_class` value set), `packages/core/src/agent/coach-agent.ts:699-709` and `packages/core/src/agent/coach-agent.ts:829-839` (emit sites), `packages/core/src/agent/error-classify.ts:9-14` and `packages/core/src/agent/error-classify.ts:66-110` (`kind` + `athleteMessage`), `packages/core/src/channels/telegram.ts:317-321` (the consuming error path) |
+| `text_delta` | `delta`                                                                                                                                                   | Produced by `packages/engine/src/agent/coach-agent.ts:595` from the streaming provider path defined at `packages/engine/src/llm.ts:124-126`; ordered delta/final behavior is pinned by `packages/engine/tests/coach-agent-streaming.test.ts:84-108`.                                                                                                                                                                                                                                                                                                         |
 
 Notes on Table A:
 
@@ -57,20 +57,21 @@ model, never from the `/status` chat turn —
 `packages/core/src/channels/telegram.ts:385-398` shows `/status` is a model
 turn, not a deterministic render.
 
-| Contract field | Source |
-|---|---|
-| `schemaVersion` | `packages/core/src/reference/schemas/latest.ts:59` (`metadata.schema_version`) |
-| `lastUpdated` | `packages/core/src/reference/schemas/latest.ts:60` (`metadata.last_updated`) |
-| `freshness` | `packages/core/src/reference/schemas/latest.ts:61` (`metadata.freshness`); windows documented at `packages/core/src/reference/freshness.ts:8-18` |
-| `degraded` | `packages/core/src/reference/schemas/error-state.ts:41-45` and `packages/core/src/reference/schemas/error-state.ts:77` (`mitigation`), consumed via `packages/core/src/agent/coach-agent.ts:307` (`block_coaching` is the blocking posture) |
-| `lastSynced` | `packages/core/src/agent/coach-agent.ts:315` (`latest?.metadata?.last_updated ?? errorState.ts`) |
-| `athleteProfile` | `packages/core/src/reference/schemas/latest.ts:64` (`athlete_profile`) |
-| `currentStatus` | `packages/core/src/reference/schemas/latest.ts:65` (`current_status`) |
-| `derivedMetrics` | `packages/core/src/reference/schemas/latest.ts:7-53` — verbatim key transcription, same keys, same order, same zod types, `.passthrough()` preserved (two fenced substitutions, see footnote) |
-| `derivedMetricsMeta` | `packages/core/src/reference/schemas/latest.ts:67-75` — nested strict-optional shape and member names preserved |
-| `recentActivities` | `packages/core/src/reference/schemas/latest.ts:76` (`recent_activities`) |
-| `plannedWorkouts` | `packages/core/src/reference/schemas/latest.ts:77` (`planned_workouts`) |
-| `wellness` | `packages/core/src/reference/schemas/latest.ts:78` (`wellness_data` — explicitly NOT an array; typed `z.unknown()`) |
+| Contract field       | Source                                                                                                                                                                                                                                                                                                                                                                                                      |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `schemaVersion`      | `packages/core/src/reference/schemas/latest.ts:59` (`metadata.schema_version`)                                                                                                                                                                                                                                                                                                                              |
+| `lastUpdated`        | `packages/core/src/reference/schemas/latest.ts:60` (`metadata.last_updated`)                                                                                                                                                                                                                                                                                                                                |
+| `freshness`          | `packages/core/src/reference/schemas/latest.ts:61` (`metadata.freshness`); windows documented at `packages/core/src/reference/freshness.ts:8-18`                                                                                                                                                                                                                                                            |
+| `degraded`           | `packages/core/src/reference/schemas/error-state.ts:41-45` and `packages/core/src/reference/schemas/error-state.ts:77` (`mitigation`), consumed via `packages/core/src/agent/coach-agent.ts:307` (`block_coaching` is the blocking posture)                                                                                                                                                                 |
+| `lastSynced`         | `packages/core/src/agent/coach-agent.ts:315` (`latest?.metadata?.last_updated ?? errorState.ts`)                                                                                                                                                                                                                                                                                                            |
+| `athleteProfile`     | `packages/core/src/reference/schemas/latest.ts:64` (`athlete_profile`)                                                                                                                                                                                                                                                                                                                                      |
+| `currentStatus`      | `packages/core/src/reference/schemas/latest.ts:65` (`current_status`)                                                                                                                                                                                                                                                                                                                                       |
+| `derivedMetrics`     | `packages/core/src/reference/schemas/latest.ts:7-53` — verbatim key transcription, same keys, same order, same zod types, `.passthrough()` preserved (two fenced substitutions, see footnote)                                                                                                                                                                                                               |
+| `derivedMetricsMeta` | `packages/core/src/reference/schemas/latest.ts:67-75` — nested strict-optional shape and member names preserved                                                                                                                                                                                                                                                                                             |
+| `recentActivities`   | `packages/core/src/reference/schemas/latest.ts:76` (`recent_activities`)                                                                                                                                                                                                                                                                                                                                    |
+| `plannedWorkouts`    | `packages/core/src/reference/schemas/latest.ts:77` (`planned_workouts`)                                                                                                                                                                                                                                                                                                                                     |
+| `wellness`           | `packages/core/src/reference/schemas/latest.ts:78` (`wellness_data` — explicitly NOT an array; typed `z.unknown()`)                                                                                                                                                                                                                                                                                         |
+| `trainingContext`    | Deterministic projection in `packages/coach/src/training-context.ts`, assembled by `packages/coach/src/athlete-state-reader.ts` from the same parsed latest snapshot, the persisted-anchor resolver in `packages/kernel/src/anchors/resolve-anchor.ts`, the zone calculator in `packages/sport-cycling/src/zones.ts`, and the Reference input schemas in `packages/kernel/src/reference/schemas/inputs.ts`. |
 
 Renames (source snake_case → contract camelCase): `metadata.schema_version` →
 `schemaVersion`, `metadata.last_updated` → `lastUpdated`,
@@ -79,6 +80,26 @@ Renames (source snake_case → contract camelCase): `metadata.schema_version` �
 `derivedMetricsMeta`, `recent_activities` → `recentActivities`,
 `planned_workouts` → `plannedWorkouts`, `wellness_data` → `wellness`. Keys
 INSIDE `derivedMetrics` and `derivedMetricsMeta` are not renamed.
+
+`trainingContext` is optional on the wire so older persisted and test states
+remain parseable. The production persisted-state reader always supplies it.
+An older daemon omission maps to the exported all-unknown fallback; clients do
+not infer it from raw state fields.
+
+### Table B.1 — trainingContext envelopes
+
+| Envelope or field group    | Persisted source and recipe                                                                                                                                                                                                                                                         |
+| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `anchorZones.kind`, `asOf` | Resolver result evaluated at whole epoch seconds parsed from `metadata.last_updated`; invalid time or resolver failure yields `unknown/not-synced`, and a missing resolver result yields `unknown/missing-anchor`.                                                                  |
+| `anchorZones.anchor`       | `watts`, `validFrom`, `source`, `confidence`, `ageDays`, `stalenessBand`, and `stale` are copied from `CyclingFtpAnchorResult` without reinterpretation.                                                                                                                            |
+| `anchorZones.zones`        | Six ordered rows from one `calculateCyclingZones(anchor.watts)` call; `label` becomes `name`, formatted `value` becomes `range`, and an absent overlap marker becomes `false`.                                                                                                      |
+| `cyclingLoad`              | Valid `recent_activities` rows parsed by `ActivitySchema`, restricted to the cycling sport contract. `value` sums persisted non-negative `icu_training_load`; counts describe retained cycling rows and missing platform values. No usable value yields `unknown/no-platform-load`. |
+| `plan`                     | Valid `planned_workouts` rows parsed by `PlannedEventSchema`, restricted to `WORKOUT` rows with a canonical cycling `type`, sorted by local start then numeric id and capped at seven. Empty output yields `unknown/no-plan`.                                                       |
+| `adherence`                | Only persisted `derived_metrics.consistency_index` plus `consistency_details.{planned_days,completed_days,matched_days}`. Zero planned days yields `unknown/no-plan`; malformed or incomplete values yield `unknown/insufficient-data`.                                             |
+| `wellnessTrend`            | Valid `wellness_data` rows parsed by `WellnessDaySchema`, sorted and capped to the last seven. The three ordered series project `hrv`, `sleepSecs`, and `restingHR`; absent rows and absent readings use their explicit unknown envelopes.                                          |
+
+The two reveal fences below remain unchanged and neither fenced value is a
+training-context input.
 
 ### Table B footnote — the reveal fence
 
@@ -96,12 +117,12 @@ not a silent leak. Everything else passes through no stricter than its source
 
 ## Table C — CoachEngine methods
 
-| Method | Source |
-|---|---|
-| `chat` | `packages/core/src/agent/coach-agent.ts:419-423` — param `userMessage` → field `message`; `turn.resolvedCs` erased to `z.unknown()` because this leaf package imports nothing from the workspace |
-| `resetSession` | `packages/core/src/agent/coach-agent.ts:852-879` (`{ memoryFlushed: boolean }` result) |
-| `hasSession` | `packages/core/src/agent/coach-agent.ts:848-850` — sync boolean lifted to a Promise-returning response for RPC uniformity |
-| `getAthleteState` | The Table-B derivation (the persisted latest-data model plus the degrade sources) |
+| Method            | Source                                                                                                                                                                                           |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `chat`            | `packages/core/src/agent/coach-agent.ts:419-423` — param `userMessage` → field `message`; `turn.resolvedCs` erased to `z.unknown()` because this leaf package imports nothing from the workspace |
+| `resetSession`    | `packages/core/src/agent/coach-agent.ts:852-879` (`{ memoryFlushed: boolean }` result)                                                                                                           |
+| `hasSession`      | `packages/core/src/agent/coach-agent.ts:848-850` — sync boolean lifted to a Promise-returning response for RPC uniformity                                                                        |
+| `getAthleteState` | The Table-B derivation (the persisted latest-data model plus the degrade sources)                                                                                                                |
 
 Deliberate exclusion: `getMemory`
 (`packages/core/src/agent/coach-agent.ts:881-883`) returns a live
@@ -124,17 +145,26 @@ catalogue grows against this same seam.
 
 ## Section E — exit codes
 
-| Code | Constant | Meaning |
-|---|---|---|
-| 0 | `EXIT_SUCCESS` | Success |
-| 1 | `EXIT_AGENT_ERROR` | The agent failed while handling the request |
-| 2 | `EXIT_USAGE` | Invalid arguments or usage |
-| 3 | `EXIT_DAEMON_UNAVAILABLE` | Daemon unreachable or contended |
-| 4 | `EXIT_NOT_CONFIGURED` | Installation not configured |
-| 5 | `EXIT_VERSION_MISMATCH` | Protocol version mismatch |
+| Code | Constant                  | Meaning                                     |
+| ---- | ------------------------- | ------------------------------------------- |
+| 0    | `EXIT_SUCCESS`            | Success                                     |
+| 1    | `EXIT_AGENT_ERROR`        | The agent failed while handling the request |
+| 2    | `EXIT_USAGE`              | Invalid arguments or usage                  |
+| 3    | `EXIT_DAEMON_UNAVAILABLE` | Daemon unreachable or contended             |
+| 4    | `EXIT_NOT_CONFIGURED`     | Installation not configured                 |
+| 5    | `EXIT_VERSION_MISMATCH`   | Protocol version mismatch                   |
 
 Compatibility note: today's shipped binaries use exit 1 for usage errors
 (`packages/core/src/run-binary.ts:188-191`) and exit 2 for a non-TTY setup
 (`packages/core/src/setup.ts:234`); those behaviors are unchanged. The
 constants govern the future CLI/daemon surface and the version handshake
 (`PROTOCOL_VERSION` mismatch → `EXIT_VERSION_MISMATCH`).
+
+## Section F — persisted display units
+
+`getUnitsPreference` and `setUnitsPreference` are strict authenticated methods
+in the one registry at the landed `PROTOCOL_VERSION`. They read and write the
+existing `athlete.units` and cycling `sport_settings.preferred_units` fields
+through the held writer. Read precedence is cycling override, athlete default,
+then the schema-compatible metric default. Results contain only the effective
+value and source; authored identity and store fields never cross the wire.

--- a/packages/coach-contract/src/athlete-state.ts
+++ b/packages/coach-contract/src/athlete-state.ts
@@ -3,6 +3,172 @@ import { z } from "zod";
 export const FreshnessSchema = z.enum(["fresh", "flag", "stale", "critical"]);
 export type Freshness = z.infer<typeof FreshnessSchema>;
 
+export const TrainingContextUnknownReasonSchema = z.enum([
+  "not-synced",
+  "missing-anchor",
+  "no-platform-load",
+  "no-plan",
+  "insufficient-data",
+  "no-wellness",
+]);
+
+export const CyclingAnchorSchema = z
+  .object({
+    watts: z.number().positive(),
+    validFrom: z.string().min(1),
+    source: z.string().min(1),
+    confidence: z.enum(["manual", "platform", "fit"]),
+    ageDays: z.number().nonnegative(),
+    stalenessBand: z.enum(["fresh", "aging", "stale", "very-stale"]),
+    stale: z.boolean(),
+  })
+  .strict();
+
+export const CyclingZoneRowSchema = z
+  .object({
+    name: z.string().min(1),
+    range: z.string().min(1),
+    overlaps: z.boolean(),
+  })
+  .strict();
+
+export const AnchorZonesPanelSchema = z.discriminatedUnion("kind", [
+  z
+    .object({
+      kind: z.literal("computed"),
+      asOf: z.string().min(1),
+      anchor: CyclingAnchorSchema,
+      zones: z.array(CyclingZoneRowSchema).length(6),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("unknown"),
+      reason: z.enum(["not-synced", "missing-anchor"]),
+    })
+    .strict(),
+]);
+
+export const CyclingLoadPanelSchema = z.discriminatedUnion("kind", [
+  z
+    .object({
+      kind: z.literal("computed"),
+      asOf: z.string().min(1),
+      source: z.literal("intervals.icu"),
+      windowDays: z.literal(7),
+      value: z.number().nonnegative(),
+      activityCount: z.number().int().nonnegative(),
+      missingLoadCount: z.number().int().nonnegative(),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("unknown"),
+      reason: z.enum(["not-synced", "no-platform-load"]),
+    })
+    .strict(),
+]);
+
+export const PlanItemSchema = z
+  .object({
+    id: z.string().min(1),
+    date: z.string().min(1),
+    name: z.string().nullable(),
+    category: z.string().min(1),
+    workoutType: z.string().min(1),
+  })
+  .strict();
+
+export const PlanPanelSchema = z.discriminatedUnion("kind", [
+  z
+    .object({
+      kind: z.literal("computed"),
+      asOf: z.string().min(1),
+      items: z.array(PlanItemSchema).max(7),
+    })
+    .strict(),
+  z.object({ kind: z.literal("unknown"), reason: z.enum(["not-synced", "no-plan"]) }).strict(),
+]);
+
+export const AdherencePanelSchema = z.discriminatedUnion("kind", [
+  z
+    .object({
+      kind: z.literal("computed"),
+      asOf: z.string().min(1),
+      ratio: z.number().min(0).max(1),
+      plannedDays: z.number().int().nonnegative(),
+      completedDays: z.number().int().nonnegative(),
+      matchedDays: z.number().int().nonnegative(),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("unknown"),
+      reason: z.enum(["not-synced", "no-plan", "insufficient-data"]),
+    })
+    .strict(),
+]);
+
+export const WellnessPointSchema = z
+  .object({ date: z.string().min(1), value: z.number() })
+  .strict();
+
+export const WellnessSeriesSchema = z
+  .object({
+    metric: z.enum(["hrv", "sleep", "resting-hr"]),
+    unit: z.enum(["ms", "seconds", "bpm"]),
+    points: z.array(WellnessPointSchema).max(7),
+  })
+  .strict();
+
+export const WellnessTrendPanelSchema = z.discriminatedUnion("kind", [
+  z
+    .object({
+      kind: z.literal("computed"),
+      asOf: z.string().min(1),
+      windowDays: z.literal(7),
+      series: z.array(WellnessSeriesSchema).length(3),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("unknown"),
+      reason: z.enum(["not-synced", "no-wellness", "insufficient-data"]),
+    })
+    .strict(),
+]);
+
+export const CyclingTrainingContextSchema = z
+  .object({
+    anchorZones: AnchorZonesPanelSchema,
+    cyclingLoad: CyclingLoadPanelSchema,
+    plan: PlanPanelSchema,
+    adherence: AdherencePanelSchema,
+    wellnessTrend: WellnessTrendPanelSchema,
+  })
+  .strict();
+
+export type TrainingContextUnknownReason = z.infer<typeof TrainingContextUnknownReasonSchema>;
+export type CyclingAnchor = z.infer<typeof CyclingAnchorSchema>;
+export type CyclingZoneRow = z.infer<typeof CyclingZoneRowSchema>;
+export type AnchorZonesPanel = z.infer<typeof AnchorZonesPanelSchema>;
+export type CyclingLoadPanel = z.infer<typeof CyclingLoadPanelSchema>;
+export type PlanItem = z.infer<typeof PlanItemSchema>;
+export type PlanPanel = z.infer<typeof PlanPanelSchema>;
+export type AdherencePanel = z.infer<typeof AdherencePanelSchema>;
+export type WellnessPoint = z.infer<typeof WellnessPointSchema>;
+export type WellnessSeries = z.infer<typeof WellnessSeriesSchema>;
+export type WellnessTrendPanel = z.infer<typeof WellnessTrendPanelSchema>;
+export type CyclingTrainingContext = z.infer<typeof CyclingTrainingContextSchema>;
+
+export const UNKNOWN_CYCLING_TRAINING_CONTEXT: CyclingTrainingContext = {
+  anchorZones: { kind: "unknown", reason: "not-synced" },
+  cyclingLoad: { kind: "unknown", reason: "not-synced" },
+  plan: { kind: "unknown", reason: "not-synced" },
+  adherence: { kind: "unknown", reason: "not-synced" },
+  wellnessTrend: { kind: "unknown", reason: "not-synced" },
+};
+
 export const AthleteDerivedMetricsSchema = z
   .object({
     // Fenced from surface rendering: raw workload-ratio value must not
@@ -84,6 +250,7 @@ export const AthleteStateSchema = z
     recentActivities: z.array(z.unknown()),
     plannedWorkouts: z.array(z.unknown()),
     wellness: z.unknown(),
+    trainingContext: CyclingTrainingContextSchema.optional(),
   })
   .strict();
 export type AthleteState = z.infer<typeof AthleteStateSchema>;

--- a/packages/coach-contract/src/rpc.ts
+++ b/packages/coach-contract/src/rpc.ts
@@ -110,6 +110,8 @@ export const COACH_RPC_METHOD_NAMES = [
   "sync",
   "saveIntake",
   "configureRuntime",
+  "getUnitsPreference",
+  "setUnitsPreference",
 ] as const satisfies readonly (keyof CoachRpcService)[];
 
 export const CoachRpcMethodNameSchema = z.enum(COACH_RPC_METHOD_NAMES);
@@ -295,6 +297,28 @@ export const ConfigureRuntimeRpcResultSchema = z
   .strict();
 export type ConfigureRuntimeRpcResult = z.infer<typeof ConfigureRuntimeRpcResultSchema>;
 
+export const UnitsPreferenceSchema = z.enum(["metric", "imperial"]);
+export type UnitsPreference = z.infer<typeof UnitsPreferenceSchema>;
+
+export const GetUnitsPreferenceRpcParamsSchema = EmptyRpcParamsSchema;
+export type GetUnitsPreferenceRpcParams = z.infer<typeof GetUnitsPreferenceRpcParamsSchema>;
+export const GetUnitsPreferenceRpcResultSchema = z
+  .object({
+    value: UnitsPreferenceSchema,
+    source: z.enum(["cycling", "athlete", "default"]),
+  })
+  .strict();
+export type GetUnitsPreferenceRpcResult = z.infer<typeof GetUnitsPreferenceRpcResultSchema>;
+
+export const SetUnitsPreferenceRpcParamsSchema = z
+  .object({ value: UnitsPreferenceSchema })
+  .strict();
+export type SetUnitsPreferenceRpcParams = z.infer<typeof SetUnitsPreferenceRpcParamsSchema>;
+export const SetUnitsPreferenceRpcResultSchema = z
+  .object({ value: UnitsPreferenceSchema, source: z.literal("cycling") })
+  .strict();
+export type SetUnitsPreferenceRpcResult = z.infer<typeof SetUnitsPreferenceRpcResultSchema>;
+
 export const OperationProgressEventSchema = z
   .object({
     phase: z.enum(["started", "completed"]),
@@ -334,6 +358,8 @@ export interface CoachOperations {
   ): Promise<SyncRpcResult>;
   saveIntake(request: SaveIntakeRpcParams): Promise<SaveIntakeRpcResult>;
   configureRuntime(request: ConfigureRuntimeRpcParams): Promise<ConfigureRuntimeRpcResult>;
+  getUnitsPreference?(request: GetUnitsPreferenceRpcParams): Promise<GetUnitsPreferenceRpcResult>;
+  setUnitsPreference?(request: SetUnitsPreferenceRpcParams): Promise<SetUnitsPreferenceRpcResult>;
 }
 
 export type CoachRpcService = CoachEngine & CoachOperations;
@@ -401,6 +427,22 @@ export const CoachRpcRequestEnvelopeSchema = z.discriminatedUnion("method", [
       id: JsonRpcIdSchema,
       method: z.literal("configureRuntime"),
       params: ConfigureRuntimeRpcParamsSchema,
+    })
+    .strict(),
+  z
+    .object({
+      jsonrpc: z.literal("2.0"),
+      id: JsonRpcIdSchema,
+      method: z.literal("getUnitsPreference"),
+      params: GetUnitsPreferenceRpcParamsSchema,
+    })
+    .strict(),
+  z
+    .object({
+      jsonrpc: z.literal("2.0"),
+      id: JsonRpcIdSchema,
+      method: z.literal("setUnitsPreference"),
+      params: SetUnitsPreferenceRpcParamsSchema,
     })
     .strict(),
 ]);
@@ -534,6 +576,18 @@ export const COACH_RPC_METHOD_REGISTRY = {
     wireName: "configureRuntime",
     requestSchema: ConfigureRuntimeRpcParamsSchema,
     responseSchema: ConfigureRuntimeRpcResultSchema,
+    eventSchema: NoRpcEventSchema,
+  },
+  getUnitsPreference: {
+    wireName: "getUnitsPreference",
+    requestSchema: GetUnitsPreferenceRpcParamsSchema,
+    responseSchema: GetUnitsPreferenceRpcResultSchema,
+    eventSchema: NoRpcEventSchema,
+  },
+  setUnitsPreference: {
+    wireName: "setUnitsPreference",
+    requestSchema: SetUnitsPreferenceRpcParamsSchema,
+    responseSchema: SetUnitsPreferenceRpcResultSchema,
     eventSchema: NoRpcEventSchema,
   },
 } as const satisfies CoachRpcMethodRegistryShape;

--- a/packages/coach-contract/tests/contract.test.ts
+++ b/packages/coach-contract/tests/contract.test.ts
@@ -10,6 +10,8 @@ import {
   PROTOCOL_VERSION,
   TurnEventSchema,
   AthleteStateSchema,
+  CyclingTrainingContextSchema,
+  UNKNOWN_CYCLING_TRAINING_CONTEXT,
   ChatRequestSchema,
   ChatResponseSchema,
   ResetSessionResponseSchema,
@@ -148,6 +150,76 @@ describe("AthleteState", () => {
     const state = cloneState();
     (state["derivedMetrics"] as Record<string, unknown>)["capability.dfa_a1_profile"] = {};
     expect(AthleteStateSchema.safeParse(state).success).toBe(false);
+  });
+
+  it("parses computed and unknown training-context envelopes strictly", () => {
+    const computed = {
+      anchorZones: {
+        kind: "computed",
+        asOf: "1998-07-06T09:00:00.000Z",
+        anchor: {
+          watts: 250,
+          validFrom: "1998-06-01",
+          source: "manual",
+          confidence: "manual",
+          ageDays: 35,
+          stalenessBand: "fresh",
+          stale: false,
+        },
+        zones: Array.from({ length: 6 }, (_, index) => ({
+          name: `Zone ${index + 1}`,
+          range: `${index + 1} W`,
+          overlaps: index === 3,
+        })),
+      },
+      cyclingLoad: {
+        kind: "computed",
+        asOf: "1998-07-06T09:00:00.000Z",
+        source: "intervals.icu",
+        windowDays: 7,
+        value: 120,
+        activityCount: 2,
+        missingLoadCount: 1,
+      },
+      plan: {
+        kind: "computed",
+        asOf: "1998-07-06T09:00:00.000Z",
+        items: [
+          { id: "1", date: "1998-07-07", name: null, category: "WORKOUT", workoutType: "Ride" },
+        ],
+      },
+      adherence: {
+        kind: "computed",
+        asOf: "1998-07-06T09:00:00.000Z",
+        ratio: 0.5,
+        plannedDays: 2,
+        completedDays: 3,
+        matchedDays: 1,
+      },
+      wellnessTrend: {
+        kind: "computed",
+        asOf: "1998-07-06T09:00:00.000Z",
+        windowDays: 7,
+        series: [
+          { metric: "hrv", unit: "ms", points: [{ date: "1998-07-06", value: 60 }] },
+          { metric: "sleep", unit: "seconds", points: [] },
+          { metric: "resting-hr", unit: "bpm", points: [] },
+        ],
+      },
+    } as const;
+    expect(CyclingTrainingContextSchema.parse(computed)).toEqual(computed);
+    expect(CyclingTrainingContextSchema.parse(UNKNOWN_CYCLING_TRAINING_CONTEXT)).toEqual(
+      UNKNOWN_CYCLING_TRAINING_CONTEXT,
+    );
+    expect(CyclingTrainingContextSchema.safeParse({ ...computed, extra: true }).success).toBe(
+      false,
+    );
+    expect(
+      CyclingTrainingContextSchema.safeParse({
+        ...computed,
+        adherence: { ...computed.adherence, ratio: 1.1 },
+      }).success,
+    ).toBe(false);
   });
 
   it("derivedMetricsMeta is strict", () => {

--- a/packages/coach-contract/tests/wire-contract.test.ts
+++ b/packages/coach-contract/tests/wire-contract.test.ts
@@ -17,6 +17,8 @@ import {
   EmptyRpcParamsSchema,
   ConfigureRuntimeRpcParamsSchema,
   ConfigureRuntimeRpcResultSchema,
+  GetUnitsPreferenceRpcParamsSchema,
+  GetUnitsPreferenceRpcResultSchema,
   ImportFilesRpcParamsSchema,
   ImportFilesRpcResultSchema,
   OperationProgressEventSchema,
@@ -35,8 +37,11 @@ import {
   PROTOCOL_VERSION,
   ResetSessionRequestSchema,
   ResetSessionResponseSchema,
+  SetUnitsPreferenceRpcParamsSchema,
+  SetUnitsPreferenceRpcResultSchema,
   ServerHandshakeFrameSchema,
   TurnEventSchema,
+  UNKNOWN_CYCLING_TRAINING_CONTEXT,
   compareProtocolVersions,
   createAcceptedServerHandshakeFrame,
   createClientHandshakeFrame,
@@ -155,7 +160,7 @@ describe("JSON-RPC envelopes", () => {
 });
 
 describe("coach request and event projection", () => {
-  it("admits exactly the eight strict method requests", () => {
+  it("admits exactly the ten strict method requests", () => {
     const requests = [
       { jsonrpc: "2.0", id: 1, method: "chat", params: { chatId: "chat-1", message: "hello" } },
       { jsonrpc: "2.0", id: 2, method: "resetSession", params: { chatId: "chat-1" } },
@@ -181,6 +186,13 @@ describe("coach request and event projection", () => {
         id: 8,
         method: "configureRuntime",
         params: { llm: { provider: "anthropic", model: "model", api_key: "placeholder" } },
+      },
+      { jsonrpc: "2.0", id: 9, method: "getUnitsPreference", params: {} },
+      {
+        jsonrpc: "2.0",
+        id: 10,
+        method: "setUnitsPreference",
+        params: { value: "imperial" },
       },
     ];
     for (const request of requests) {
@@ -398,6 +410,8 @@ describe("coach request and event projection", () => {
         schemaVersion: 1,
         applied: { llm: llm !== undefined, intervals: intervals !== undefined },
       }),
+      getUnitsPreference: async () => ({ value: "metric", source: "default" }),
+      setUnitsPreference: async ({ value }) => ({ value, source: "cycling" }),
     };
     expect(Object.keys(COACH_RPC_METHOD_REGISTRY)).toEqual(Object.keys(fake));
     expect(COACH_RPC_METHOD_NAMES).toEqual(Object.keys(fake));
@@ -449,12 +463,26 @@ describe("coach request and event projection", () => {
       responseSchema: ConfigureRuntimeRpcResultSchema,
       eventSchema: NoRpcEventSchema,
     });
+    expect(COACH_RPC_METHOD_REGISTRY.getUnitsPreference).toEqual({
+      wireName: "getUnitsPreference",
+      requestSchema: GetUnitsPreferenceRpcParamsSchema,
+      responseSchema: GetUnitsPreferenceRpcResultSchema,
+      eventSchema: NoRpcEventSchema,
+    });
+    expect(COACH_RPC_METHOD_REGISTRY.setUnitsPreference).toEqual({
+      wireName: "setUnitsPreference",
+      requestSchema: SetUnitsPreferenceRpcParamsSchema,
+      responseSchema: SetUnitsPreferenceRpcResultSchema,
+      eventSchema: NoRpcEventSchema,
+    });
     for (const method of [
       "resetSession",
       "hasSession",
       "getAthleteState",
       "saveIntake",
       "configureRuntime",
+      "getUnitsPreference",
+      "setUnitsPreference",
     ] as const) {
       expect(COACH_RPC_METHOD_REGISTRY[method].eventSchema.safeParse(undefined).success).toBe(
         false,
@@ -464,6 +492,63 @@ describe("coach request and event projection", () => {
     await expect(fake.chat({ chatId: "chat-1", message: "hello" })).resolves.toEqual({
       text: "ok",
     });
+  });
+
+  it("round trips strict units preference requests and results", () => {
+    expect(
+      roundTrip({ jsonrpc: "2.0", id: 40, method: "getUnitsPreference", params: {} }),
+    ).toMatchObject({ method: "getUnitsPreference" });
+    expect(
+      roundTrip({
+        jsonrpc: "2.0",
+        id: 41,
+        method: "setUnitsPreference",
+        params: { value: "imperial" },
+      }),
+    ).toMatchObject({ method: "setUnitsPreference" });
+    expect(GetUnitsPreferenceRpcResultSchema.parse({ value: "metric", source: "athlete" })).toEqual(
+      { value: "metric", source: "athlete" },
+    );
+    expect(
+      SetUnitsPreferenceRpcResultSchema.parse({ value: "imperial", source: "cycling" }),
+    ).toEqual({ value: "imperial", source: "cycling" });
+    expect(
+      SetUnitsPreferenceRpcParamsSchema.safeParse({ value: "metric", extra: true }).success,
+    ).toBe(false);
+    expect(
+      GetUnitsPreferenceRpcResultSchema.safeParse({ value: "other", source: "default" }).success,
+    ).toBe(false);
+  });
+
+  it("round trips an athlete state result with persisted training context", () => {
+    const state = AthleteStateSchema.parse({
+      schemaVersion: "1",
+      lastUpdated: "2026-07-19T08:00:00.000Z",
+      freshness: "fresh",
+      degraded: false,
+      lastSynced: "2026-07-19T07:55:00.000Z",
+      athleteProfile: {},
+      currentStatus: {},
+      derivedMetrics: {},
+      recentActivities: [],
+      plannedWorkouts: [],
+      wellness: {},
+      trainingContext: UNKNOWN_CYCLING_TRAINING_CONTEXT,
+    });
+    expect(roundTrip({ jsonrpc: "2.0", id: 42, result: state })).toEqual({
+      jsonrpc: "2.0",
+      id: 42,
+      result: state,
+    });
+    expect(
+      AthleteStateSchema.safeParse({
+        ...state,
+        trainingContext: {
+          ...state.trainingContext,
+          currentTrainingStress: 72,
+        },
+      }).success,
+    ).toBe(false);
   });
 });
 

--- a/packages/coach/src/athlete-state-reader.ts
+++ b/packages/coach/src/athlete-state-reader.ts
@@ -1,16 +1,15 @@
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
-import {
-  AthleteStateSchema,
-  type AthleteState,
-} from "@enduragent/coach-contract";
+import { AthleteStateSchema, type AthleteState } from "@enduragent/coach-contract";
 import type { AthleteStateReaderPort } from "@enduragent/engine";
+import type { CyclingFtpAnchorResolver } from "@enduragent/kernel/anchors";
 import {
   ERROR_STATE_SCHEMA_VERSION,
   ErrorStateSchema,
   LATEST_SCHEMA_VERSION,
   LatestJsonSchema,
 } from "@enduragent/kernel/reference/schemas";
+import { projectCyclingTrainingContext } from "./training-context.js";
 
 export interface PersistedAthleteStateSource extends AthleteStateReaderPort {}
 
@@ -20,9 +19,14 @@ async function readJson(path: string): Promise<unknown> {
   return JSON.parse(await readFile(path, "utf8")) as unknown;
 }
 
-export function createPersistedAthleteStateSource(input: {
+export interface CreatePersistedAthleteStateSourceOptions {
   readonly dataDir: string;
-}): PersistedAthleteStateSource {
+  readonly cyclingFtpAnchorResolver: CyclingFtpAnchorResolver;
+}
+
+export function createPersistedAthleteStateSource(
+  input: CreatePersistedAthleteStateSourceOptions,
+): PersistedAthleteStateSource {
   const latestPath = join(input.dataDir, "data", "latest.json");
   const errorPath = join(input.dataDir, "data", "error_state.json");
   return {
@@ -35,21 +39,40 @@ export function createPersistedAthleteStateSource(input: {
         throw new AthleteStateUnavailableError("No validated athlete state is available.");
       }
       const latestParsed = LatestJsonSchema.safeParse(latestResult.value);
-      if (!latestParsed.success
-        || latestParsed.data.metadata.schema_version !== LATEST_SCHEMA_VERSION) {
+      if (
+        !latestParsed.success ||
+        latestParsed.data.metadata.schema_version !== LATEST_SCHEMA_VERSION
+      ) {
         throw new AthleteStateUnavailableError("No validated athlete state is available.");
       }
-      const errorParsed = errorResult.status === "fulfilled"
-        ? ErrorStateSchema.safeParse(errorResult.value)
-        : null;
-      const errorState = errorParsed?.success === true
-        && errorParsed.data.schema_version === ERROR_STATE_SCHEMA_VERSION
-        ? errorParsed.data
-        : null;
+      const errorParsed =
+        errorResult.status === "fulfilled" ? ErrorStateSchema.safeParse(errorResult.value) : null;
+      const errorState =
+        errorParsed?.success === true &&
+        errorParsed.data.schema_version === ERROR_STATE_SCHEMA_VERSION
+          ? errorParsed.data
+          : null;
       const latest = latestParsed.data;
       const derivedMetrics = { ...latest.derived_metrics };
       delete derivedMetrics.acwr;
       delete derivedMetrics["capability.dfa_a1_profile"];
+      const parsedAsOf = Date.parse(latest.metadata.last_updated);
+      const asOfEpochS =
+        Number.isFinite(parsedAsOf) && parsedAsOf >= 0 ? Math.floor(parsedAsOf / 1_000) : null;
+      const anchor =
+        asOfEpochS === null
+          ? null
+          : await input.cyclingFtpAnchorResolver
+              .resolve({ effectiveAtEpochS: asOfEpochS, evaluatedAtEpochS: asOfEpochS })
+              .catch(() => null);
+      const trainingContext = projectCyclingTrainingContext({
+        asOf: latest.metadata.last_updated,
+        anchor,
+        derivedMetrics,
+        recentActivities: latest.recent_activities,
+        plannedWorkouts: latest.planned_workouts,
+        wellness: latest.wellness_data,
+      });
       const mapped = {
         schemaVersion: latest.metadata.schema_version,
         lastUpdated: latest.metadata.last_updated,
@@ -65,6 +88,7 @@ export function createPersistedAthleteStateSource(input: {
         recentActivities: latest.recent_activities,
         plannedWorkouts: latest.planned_workouts,
         wellness: latest.wellness_data,
+        trainingContext,
       };
       const state = AthleteStateSchema.safeParse(mapped);
       if (!state.success) {

--- a/packages/coach/src/composition.ts
+++ b/packages/coach/src/composition.ts
@@ -355,7 +355,6 @@ export async function createLocalCoachComposition(
         : dependencies.createRuntime(runtimeOptions);
     await runtime.runWindow();
     runtime.startScheduler();
-    const stateReader = createPersistedAthleteStateSource({ dataDir: input.home.root });
     const memory = new Memory(input.home.root, input.config.session.timezone);
     const chatStore = new ChatStore(
       input.home.root,
@@ -369,6 +368,10 @@ export async function createLocalCoachComposition(
     const cyclingFtpAnchorResolver = (
       dependencies.createResolver ?? createCyclingFtpAnchorResolver
     )(repository);
+    const stateReader = createPersistedAthleteStateSource({
+      dataDir: input.home.root,
+      cyclingFtpAnchorResolver,
+    });
     const buildEngine = (config: Config): CoachEngine => {
       const projectedConfig = engineConfigFromConfig(config);
       const legacyClient =

--- a/packages/coach/src/daemon/rpc-server.ts
+++ b/packages/coach/src/daemon/rpc-server.ts
@@ -700,6 +700,32 @@ export function createCoachRpcServer(input: CoachRpcServerInput): CoachRpcServer
               invocationFailure = { error };
             }
             break;
+          case "getUnitsPreference":
+            try {
+              const request = COACH_RPC_METHOD_REGISTRY.getUnitsPreference.requestSchema.parse(
+                generic.data.params,
+              );
+              if (input.operations.getUnitsPreference === undefined) {
+                throw new TypeError("Units preference operation is unavailable.");
+              }
+              result = await input.operations.getUnitsPreference(request);
+            } catch (error) {
+              invocationFailure = { error };
+            }
+            break;
+          case "setUnitsPreference":
+            try {
+              const request = COACH_RPC_METHOD_REGISTRY.setUnitsPreference.requestSchema.parse(
+                generic.data.params,
+              );
+              if (input.operations.setUnitsPreference === undefined) {
+                throw new TypeError("Units preference operation is unavailable.");
+              }
+              result = await input.operations.setUnitsPreference(request);
+            } catch (error) {
+              invocationFailure = { error };
+            }
+            break;
         }
         if (deliveryDetached) return;
         let terminal: string;

--- a/packages/coach/src/operations.ts
+++ b/packages/coach/src/operations.ts
@@ -1,25 +1,33 @@
 import {
   ConfigureRuntimeRpcParamsSchema,
   ConfigureRuntimeRpcResultSchema,
+  GetUnitsPreferenceRpcParamsSchema,
+  GetUnitsPreferenceRpcResultSchema,
   ImportFilesRpcParamsSchema,
   ImportFilesRpcResultSchema,
   OperationProgressEventSchema,
   SaveIntakeRpcParamsSchema,
   SaveIntakeRpcResultSchema,
+  SetUnitsPreferenceRpcParamsSchema,
+  SetUnitsPreferenceRpcResultSchema,
   SyncRpcParamsSchema,
   SyncRpcResultSchema,
   type ConfigureRuntimeRpcParams,
   type ConfigureRuntimeRpcResult,
+  type GetUnitsPreferenceRpcParams,
+  type GetUnitsPreferenceRpcResult,
   type CoachOperations,
   type ImportFilesRpcParams,
   type ImportFilesRpcResult,
   type OperationProgressEvent,
   type SaveIntakeRpcParams,
   type SaveIntakeRpcResult,
+  type SetUnitsPreferenceRpcParams,
+  type SetUnitsPreferenceRpcResult,
   type SyncRpcParams,
   type SyncRpcResult,
 } from "@enduragent/coach-contract";
-import { createIntakeRepository } from "@enduragent/kernel/store";
+import { createIntakeRepository, createUnitsPreferenceRepository } from "@enduragent/kernel/store";
 import {
   createAuthoredIdentity,
   type AthleteHome,
@@ -29,6 +37,7 @@ import { importFilesWithReport } from "@enduragent/kernel-node/ingest";
 import { runIntervalsBackfillInWriter } from "./backfill.js";
 import type { LocalStoreRuntime } from "./composition.js";
 import type { CoachStoreWriterContext } from "./runtime.js";
+import { createUnitsPreferenceService } from "./units-preference.js";
 
 export interface CreateCoachOperationsInput {
   readonly home: AthleteHome;
@@ -68,6 +77,7 @@ export function createCoachOperations(
   const archiveDir = input.home.archiveDir;
   const identity = (dependencies.createIdentity ?? createAuthoredIdentity)(input.home.configDir);
   const intake = (dependencies.createIntakeRepository ?? createIntakeRepository)(store);
+  const unitsPreference = createUnitsPreferenceService(createUnitsPreferenceRepository(store));
   const importFiles = dependencies.importFiles ?? importFilesWithReport;
   const backfill = dependencies.backfill ?? runIntervalsBackfillInWriter;
   let tail = Promise.resolve();
@@ -173,6 +183,18 @@ export function createCoachOperations(
           },
         });
       });
+    },
+    getUnitsPreference(request: GetUnitsPreferenceRpcParams): Promise<GetUnitsPreferenceRpcResult> {
+      GetUnitsPreferenceRpcParamsSchema.parse(request);
+      return enqueue(async () =>
+        GetUnitsPreferenceRpcResultSchema.parse(await unitsPreference.get()),
+      );
+    },
+    setUnitsPreference(request: SetUnitsPreferenceRpcParams): Promise<SetUnitsPreferenceRpcResult> {
+      const parsedRequest = SetUnitsPreferenceRpcParamsSchema.parse(request);
+      return enqueue(async () =>
+        SetUnitsPreferenceRpcResultSchema.parse(await unitsPreference.set(parsedRequest.value)),
+      );
     },
   };
 }

--- a/packages/coach/src/training-context.ts
+++ b/packages/coach/src/training-context.ts
@@ -1,0 +1,196 @@
+import type {
+  CyclingTrainingContext,
+  CyclingZoneRow,
+  WellnessSeries,
+} from "@enduragent/coach-contract";
+import type { CyclingFtpAnchorResult } from "@enduragent/kernel/anchors";
+import {
+  ActivitySchema,
+  PlannedEventSchema,
+  WellnessDaySchema,
+} from "@enduragent/kernel/reference/schemas";
+import { calculateCyclingZones, cyclingSport } from "@enduragent/sport-cycling";
+
+export interface ProjectCyclingTrainingContextInput {
+  readonly asOf: string;
+  readonly anchor: CyclingFtpAnchorResult | null;
+  readonly derivedMetrics: Record<string, unknown>;
+  readonly recentActivities: readonly unknown[];
+  readonly plannedWorkouts: readonly unknown[];
+  readonly wellness: unknown;
+}
+
+const cyclingTypes = new Set<string>(cyclingSport.intervalsActivityTypes);
+
+function projectAnchorZones(
+  input: ProjectCyclingTrainingContextInput,
+): CyclingTrainingContext["anchorZones"] {
+  if (input.anchor === null) return { kind: "unknown", reason: "not-synced" };
+  if (input.anchor.kind === "missing") return { kind: "unknown", reason: "missing-anchor" };
+  return {
+    kind: "computed",
+    asOf: input.asOf,
+    anchor: {
+      watts: input.anchor.watts,
+      validFrom: input.anchor.validFrom,
+      source: input.anchor.source,
+      confidence: input.anchor.confidence,
+      ageDays: input.anchor.ageDays,
+      stalenessBand: input.anchor.stalenessBand,
+      stale: input.anchor.stale,
+    },
+    zones: calculateCyclingZones(input.anchor.watts).map(
+      (zone): CyclingZoneRow => ({
+        name: zone.label,
+        range: zone.value,
+        overlaps: zone.overlaps ?? false,
+      }),
+    ),
+  };
+}
+
+function projectCyclingLoad(
+  input: ProjectCyclingTrainingContextInput,
+): CyclingTrainingContext["cyclingLoad"] {
+  const activities = input.recentActivities.flatMap((row) => {
+    const parsed = ActivitySchema.safeParse(row);
+    return parsed.success && cyclingTypes.has(parsed.data.type) ? [parsed.data] : [];
+  });
+  const loads = activities.flatMap((activity) =>
+    activity.icu_training_load == null ? [] : [activity.icu_training_load],
+  );
+  if (loads.length === 0) return { kind: "unknown", reason: "no-platform-load" };
+  return {
+    kind: "computed",
+    asOf: input.asOf,
+    source: "intervals.icu",
+    windowDays: 7,
+    value: loads.reduce((sum, value) => sum + value, 0),
+    activityCount: activities.length,
+    missingLoadCount: activities.length - loads.length,
+  };
+}
+
+function projectPlan(input: ProjectCyclingTrainingContextInput): CyclingTrainingContext["plan"] {
+  const items = input.plannedWorkouts
+    .flatMap((row) => {
+      const parsed = PlannedEventSchema.safeParse(row);
+      return parsed.success &&
+        parsed.data.category === "WORKOUT" &&
+        parsed.data.type != null &&
+        cyclingTypes.has(parsed.data.type)
+        ? [parsed.data]
+        : [];
+    })
+    .sort(
+      (left, right) =>
+        left.start_date_local.localeCompare(right.start_date_local) || left.id - right.id,
+    )
+    .slice(0, 7)
+    .map((row) => ({
+      id: String(row.id),
+      date: row.start_date_local,
+      name: row.name ?? null,
+      category: row.category,
+      workoutType: row.type as string,
+    }));
+  return items.length === 0
+    ? { kind: "unknown", reason: "no-plan" }
+    : { kind: "computed", asOf: input.asOf, items };
+}
+
+function nonnegativeInteger(value: unknown): value is number {
+  return Number.isSafeInteger(value) && (value as number) >= 0;
+}
+
+function projectAdherence(
+  input: ProjectCyclingTrainingContextInput,
+): CyclingTrainingContext["adherence"] {
+  const ratio = input.derivedMetrics.consistency_index;
+  const details = input.derivedMetrics.consistency_details;
+  if (
+    typeof ratio !== "number" ||
+    !Number.isFinite(ratio) ||
+    ratio < 0 ||
+    ratio > 1 ||
+    details === null ||
+    typeof details !== "object" ||
+    Array.isArray(details)
+  ) {
+    return { kind: "unknown", reason: "insufficient-data" };
+  }
+  const values = details as Record<string, unknown>;
+  if (
+    !nonnegativeInteger(values.planned_days) ||
+    !nonnegativeInteger(values.completed_days) ||
+    !nonnegativeInteger(values.matched_days)
+  ) {
+    return { kind: "unknown", reason: "insufficient-data" };
+  }
+  if (values.planned_days === 0) return { kind: "unknown", reason: "no-plan" };
+  return {
+    kind: "computed",
+    asOf: input.asOf,
+    ratio,
+    plannedDays: values.planned_days,
+    completedDays: values.completed_days,
+    matchedDays: values.matched_days,
+  };
+}
+
+function projectWellness(
+  input: ProjectCyclingTrainingContextInput,
+): CyclingTrainingContext["wellnessTrend"] {
+  if (!Array.isArray(input.wellness)) return { kind: "unknown", reason: "no-wellness" };
+  const rows = input.wellness
+    .flatMap((row) => {
+      const parsed = WellnessDaySchema.safeParse(row);
+      return parsed.success ? [parsed.data] : [];
+    })
+    .sort((left, right) => left.id.localeCompare(right.id))
+    .slice(-7);
+  if (rows.length === 0) return { kind: "unknown", reason: "no-wellness" };
+  const series: WellnessSeries[] = [
+    {
+      metric: "hrv",
+      unit: "ms",
+      points: rows.flatMap((row) =>
+        row.hrv == null || !Number.isFinite(row.hrv) ? [] : [{ date: row.id, value: row.hrv }],
+      ),
+    },
+    {
+      metric: "sleep",
+      unit: "seconds",
+      points: rows.flatMap((row) =>
+        row.sleepSecs == null || !Number.isFinite(row.sleepSecs)
+          ? []
+          : [{ date: row.id, value: row.sleepSecs }],
+      ),
+    },
+    {
+      metric: "resting-hr",
+      unit: "bpm",
+      points: rows.flatMap((row) =>
+        row.restingHR == null || !Number.isFinite(row.restingHR)
+          ? []
+          : [{ date: row.id, value: row.restingHR }],
+      ),
+    },
+  ];
+  if (series.every((entry) => entry.points.length === 0)) {
+    return { kind: "unknown", reason: "insufficient-data" };
+  }
+  return { kind: "computed", asOf: input.asOf, windowDays: 7, series };
+}
+
+export function projectCyclingTrainingContext(
+  input: ProjectCyclingTrainingContextInput,
+): CyclingTrainingContext {
+  return {
+    anchorZones: projectAnchorZones(input),
+    cyclingLoad: projectCyclingLoad(input),
+    plan: projectPlan(input),
+    adherence: projectAdherence(input),
+    wellnessTrend: projectWellness(input),
+  };
+}

--- a/packages/coach/src/units-preference.ts
+++ b/packages/coach/src/units-preference.ts
@@ -1,0 +1,58 @@
+import { randomBytes as systemRandomBytes } from "node:crypto";
+import {
+  GetUnitsPreferenceRpcResultSchema,
+  SetUnitsPreferenceRpcResultSchema,
+  UnitsPreferenceSchema,
+  type GetUnitsPreferenceRpcResult,
+  type SetUnitsPreferenceRpcResult,
+  type UnitsPreference,
+} from "@enduragent/coach-contract";
+import type { UnitsPreferenceRepository } from "@enduragent/kernel/store";
+
+const CROCKFORD = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+const MAX_ULID_TIME = 281_474_976_710_655;
+
+export interface UnitsPreferenceService {
+  get(): Promise<GetUnitsPreferenceRpcResult>;
+  set(value: UnitsPreference): Promise<SetUnitsPreferenceRpcResult>;
+}
+
+export interface UnitsPreferenceServiceDependencies {
+  readonly now?: () => number;
+  readonly randomBytes?: (size: number) => Uint8Array;
+}
+
+export function createDesktopUnitsUlid(now: number, random: Uint8Array): string {
+  if (!Number.isSafeInteger(now) || now < 0 || now > MAX_ULID_TIME || random.length !== 10) {
+    throw new TypeError("Units mutation seed is invalid.");
+  }
+  let value = BigInt(now);
+  for (const byte of random) value = (value << 8n) | BigInt(byte);
+  let encoded = "";
+  for (let index = 0; index < 26; index += 1) {
+    encoded = CROCKFORD[Number(value & 31n)] + encoded;
+    value >>= 5n;
+  }
+  return encoded;
+}
+
+export function createUnitsPreferenceService(
+  repository: UnitsPreferenceRepository,
+  dependencies: UnitsPreferenceServiceDependencies = {},
+): UnitsPreferenceService {
+  const now = dependencies.now ?? Date.now;
+  const randomBytes = dependencies.randomBytes ?? systemRandomBytes;
+  return {
+    async get() {
+      return GetUnitsPreferenceRpcResultSchema.parse(await repository.read());
+    },
+    async set(value) {
+      const parsed = UnitsPreferenceSchema.parse(value);
+      const timestamp = now();
+      const id = createDesktopUnitsUlid(timestamp, randomBytes(10));
+      return SetUnitsPreferenceRpcResultSchema.parse(
+        await repository.set(parsed, { id, deviceId: `desktop:${id}`, now: timestamp }),
+      );
+    },
+  };
+}

--- a/packages/coach/tests/athlete-state-reader.test.ts
+++ b/packages/coach/tests/athlete-state-reader.test.ts
@@ -1,7 +1,7 @@
 import { mkdir, mkdtemp, realpath, rm, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { AthleteStateSchema } from "@enduragent/coach-contract";
 import {
   ERROR_STATE_SCHEMA_VERSION,
@@ -11,6 +11,7 @@ import {
   AthleteStateUnavailableError,
   createPersistedAthleteStateSource,
 } from "../src/athlete-state-reader.js";
+import type { CyclingFtpAnchorResolver } from "@enduragent/kernel/anchors";
 
 const roots: string[] = [];
 
@@ -62,6 +63,14 @@ async function writeJson(root: string, name: string, value: unknown): Promise<vo
   await writeFile(join(root, "data", name), JSON.stringify(value));
 }
 
+const resolver: CyclingFtpAnchorResolver = {
+  resolve: async () => ({ kind: "missing", refusal: "missing-cycling-ftp-anchor" }),
+};
+
+function source(dataDir: string) {
+  return createPersistedAthleteStateSource({ dataDir, cyclingFtpAnchorResolver: resolver });
+}
+
 afterEach(async () => {
   await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
 });
@@ -71,7 +80,7 @@ describe("persisted athlete state source", () => {
     const root = await home();
     await writeJson(root, "latest.json", latest());
     await writeJson(root, "error_state.json", errorState());
-    const state = await createPersistedAthleteStateSource({ dataDir: root }).getAthleteState();
+    const state = await source(root).getAthleteState();
     expect(AthleteStateSchema.parse(state)).toEqual(state);
     expect(state).toMatchObject({
       schemaVersion: LATEST_SCHEMA_VERSION,
@@ -90,7 +99,7 @@ describe("persisted athlete state source", () => {
   it("removes both reveal-fenced keys and preserves future metric keys", async () => {
     const root = await home();
     await writeJson(root, "latest.json", latest());
-    const state = await createPersistedAthleteStateSource({ dataDir: root }).getAthleteState();
+    const state = await source(root).getAthleteState();
     expect(state.derivedMetrics).toEqual({ eftp: 250, future_metric: { value: 1 } });
     expect(Object.hasOwn(state.derivedMetrics, "acwr")).toBe(false);
     expect(Object.hasOwn(state.derivedMetrics, "capability.dfa_a1_profile")).toBe(false);
@@ -100,7 +109,7 @@ describe("persisted athlete state source", () => {
     const root = await home();
     await writeJson(root, "latest.json", latest("flag"));
     await writeJson(root, "error_state.json", errorState("block_coaching"));
-    const state = await createPersistedAthleteStateSource({ dataDir: root }).getAthleteState();
+    const state = await source(root).getAthleteState();
     expect(state.degraded).toBe(true);
     expect(state.freshness).toBe("flag");
     expect(state.currentStatus).toEqual({ summary: "ready" });
@@ -109,10 +118,15 @@ describe("persisted athlete state source", () => {
   });
 
   it("fails open for every absent, malformed, invalid, or mismatched error sidecar", async () => {
-    const variants: unknown[] = [undefined, "{", { no: "schema" }, {
-      ...errorState("block_coaching"),
-      schema_version: "different",
-    }];
+    const variants: unknown[] = [
+      undefined,
+      "{",
+      { no: "schema" },
+      {
+        ...errorState("block_coaching"),
+        schema_version: "different",
+      },
+    ];
     for (const variant of variants) {
       const root = await home();
       await writeJson(root, "latest.json", latest());
@@ -122,8 +136,7 @@ describe("persisted athlete state source", () => {
           typeof variant === "string" ? variant : JSON.stringify(variant),
         );
       }
-      await expect(createPersistedAthleteStateSource({ dataDir: root }).getAthleteState())
-        .resolves.toMatchObject({ degraded: false });
+      await expect(source(root).getAthleteState()).resolves.toMatchObject({ degraded: false });
     }
   });
 
@@ -133,16 +146,20 @@ describe("persisted athlete state source", () => {
       await writeJson(root, "latest.json", latest(freshness));
       const future = new Date("2030-01-01T00:00:00.000Z");
       await utimes(join(root, "data", "latest.json"), future, future);
-      await expect(createPersistedAthleteStateSource({ dataDir: root }).getAthleteState())
-        .resolves.toMatchObject({ freshness });
+      await expect(source(root).getAthleteState()).resolves.toMatchObject({ freshness });
     }
   });
 
   it("throws the stable unavailable error for absent, invalid, and wrong-version latest", async () => {
-    const variants: unknown[] = [undefined, "{", latest(), {
-      ...latest(),
-      metadata: { ...latest().metadata, schema_version: "different" },
-    }];
+    const variants: unknown[] = [
+      undefined,
+      "{",
+      latest(),
+      {
+        ...latest(),
+        metadata: { ...latest().metadata, schema_version: "different" },
+      },
+    ];
     (variants[2] as ReturnType<typeof latest>).metadata.freshness = "invalid" as never;
     for (const variant of variants) {
       const root = await home();
@@ -152,8 +169,9 @@ describe("persisted athlete state source", () => {
           typeof variant === "string" ? variant : JSON.stringify(variant),
         );
       }
-      await expect(createPersistedAthleteStateSource({ dataDir: root }).getAthleteState())
-        .rejects.toEqual(new AthleteStateUnavailableError("No validated athlete state is available."));
+      await expect(source(root).getAthleteState()).rejects.toEqual(
+        new AthleteStateUnavailableError("No validated athlete state is available."),
+      );
     }
   });
 
@@ -162,18 +180,103 @@ describe("persisted athlete state source", () => {
     const selected = latest();
     await writeJson(root, "latest.json", selected);
     await writeJson(root, "error_state.json", errorState());
-    const source = createPersistedAthleteStateSource({ dataDir: root });
-    const first = await source.getAthleteState();
+    const reader = source(root);
+    const first = await reader.getAthleteState();
     selected.current_status = { summary: "changed" };
     await writeJson(root, "latest.json", selected);
-    const second = await source.getAthleteState();
+    const second = await reader.getAthleteState();
     expect(first.currentStatus).toEqual({ summary: "ready" });
     expect(second.currentStatus).toEqual({ summary: "changed" });
     const unavailableRoot = await home();
-    const failure = await createPersistedAthleteStateSource({ dataDir: unavailableRoot })
-      .getAthleteState().catch((error: unknown) => error);
+    const failure = await source(unavailableRoot)
+      .getAthleteState()
+      .catch((error: unknown) => error);
     expect(failure).toBeInstanceOf(AthleteStateUnavailableError);
     expect(String(failure)).not.toContain(unavailableRoot);
     expect(String(failure)).not.toContain("Zod");
+  });
+
+  it("resolves the anchor once at the persisted instant and always returns training context", async () => {
+    const root = await home();
+    const snapshot = latest();
+    snapshot.recent_activities = [
+      {
+        id: "ride-1",
+        start_date_local: "2026-07-17T08:00:00",
+        type: "Ride",
+        moving_time: 3600,
+        elapsed_time: 3700,
+        icu_training_load: 80,
+      },
+    ] as never;
+    snapshot.planned_workouts = [
+      {
+        id: 1,
+        category: "WORKOUT",
+        start_date_local: "2026-07-19T08:00:00",
+        name: "Endurance",
+        type: "Ride",
+      },
+    ] as never;
+    snapshot.wellness_data = [
+      {
+        id: "2026-07-17",
+        weight: 70,
+        restingHR: 48,
+        hrv: 62,
+        sleepSecs: 28_800,
+        sleepQuality: 3,
+      },
+    ] as never;
+    snapshot.derived_metrics = {
+      consistency_index: 1,
+      consistency_details: { planned_days: 1, completed_days: 1, matched_days: 1 },
+    } as never;
+    await writeJson(root, "latest.json", snapshot);
+    const resolve = vi.fn(async () => ({
+      kind: "ftp" as const,
+      watts: 250,
+      validFrom: "2026-06-01",
+      source: "manual",
+      confidence: "manual" as const,
+      ageDays: 47,
+      stalenessBand: "aging" as const,
+      stale: true,
+    }));
+    const state = await createPersistedAthleteStateSource({
+      dataDir: root,
+      cyclingFtpAnchorResolver: { resolve },
+    }).getAthleteState();
+    const expectedEpoch = Date.parse(snapshot.metadata.last_updated) / 1_000;
+    expect(resolve).toHaveBeenCalledOnce();
+    expect(resolve).toHaveBeenCalledWith({
+      effectiveAtEpochS: expectedEpoch,
+      evaluatedAtEpochS: expectedEpoch,
+    });
+    expect(state.trainingContext).toMatchObject({
+      anchorZones: { kind: "computed" },
+      cyclingLoad: { kind: "computed", value: 80 },
+      plan: { kind: "computed" },
+      adherence: { kind: "computed", ratio: 1 },
+      wellnessTrend: { kind: "computed" },
+    });
+  });
+
+  it("degrades only anchor zones when persisted time or resolver is invalid", async () => {
+    for (const lastUpdated of ["invalid", "2026-07-18T00:00:00.000Z"]) {
+      const root = await home();
+      const snapshot = latest();
+      snapshot.metadata.last_updated = lastUpdated;
+      await writeJson(root, "latest.json", snapshot);
+      const state = await createPersistedAthleteStateSource({
+        dataDir: root,
+        cyclingFtpAnchorResolver: { resolve: async () => Promise.reject(new Error("synthetic")) },
+      }).getAthleteState();
+      expect(state.trainingContext?.anchorZones).toEqual({
+        kind: "unknown",
+        reason: "not-synced",
+      });
+      expect(state.trainingContext?.plan).toEqual({ kind: "unknown", reason: "no-plan" });
+    }
   });
 });

--- a/packages/coach/tests/composition.test.ts
+++ b/packages/coach/tests/composition.test.ts
@@ -46,6 +46,13 @@ const state: AthleteState = {
   recentActivities: [{ id: "activity-1" }],
   plannedWorkouts: [{ id: "workout-1" }],
   wellness: { restingHr: 45 },
+  trainingContext: {
+    anchorZones: { kind: "unknown", reason: "missing-anchor" },
+    cyclingLoad: { kind: "unknown", reason: "no-platform-load" },
+    plan: { kind: "unknown", reason: "no-plan" },
+    adherence: { kind: "unknown", reason: "insufficient-data" },
+    wellnessTrend: { kind: "unknown", reason: "no-wellness" },
+  },
 };
 
 function latest() {

--- a/packages/coach/tests/daemon-rpc-server.test.ts
+++ b/packages/coach/tests/daemon-rpc-server.test.ts
@@ -76,6 +76,8 @@ const operations: CoachOperations = {
     schemaVersion: 1,
     applied: { llm: llm !== undefined, intervals: intervals !== undefined },
   }),
+  getUnitsPreference: async () => ({ value: "metric", source: "default" }),
+  setUnitsPreference: async ({ value }) => ({ value, source: "cycling" }),
 };
 
 function createCoachRpcServer(
@@ -446,6 +448,68 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
     expect(JSON.stringify(response)).not.toContain("placeholder");
     expect(JSON.stringify(response)).not.toContain("athlete-a");
     expect(JSON.stringify(response)).not.toContain("model-a");
+    await client.close();
+  });
+
+  it("dispatches strict authenticated units reads and writes through the operations object", async () => {
+    const token = "x".repeat(43);
+    const getUnitsPreference = vi.fn(async () => ({
+      value: "metric" as const,
+      source: "athlete" as const,
+    }));
+    const setUnitsPreference = vi.fn(async ({ value }: { value: "metric" | "imperial" }) => ({
+      value,
+      source: "cycling" as const,
+    }));
+    const rpc = createCoachRpcServer({
+      engine: engine(),
+      operations: { ...operations, getUnitsPreference, setUnitsPreference },
+      token,
+      owner: "app-supervised",
+    });
+    const client = await openSocket(rpc);
+    client.ws.send(JSON.stringify(createClientHandshakeFrame(token)));
+    await client.frames.next();
+    client.ws.send(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: "units-read",
+        method: "getUnitsPreference",
+        params: {},
+      }),
+    );
+    expect(parseCoachRpcEnvelope(await client.frames.next())).toEqual({
+      jsonrpc: "2.0",
+      id: "units-read",
+      result: { value: "metric", source: "athlete" },
+    });
+    client.ws.send(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: "units-write",
+        method: "setUnitsPreference",
+        params: { value: "imperial" },
+      }),
+    );
+    expect(parseCoachRpcEnvelope(await client.frames.next())).toEqual({
+      jsonrpc: "2.0",
+      id: "units-write",
+      result: { value: "imperial", source: "cycling" },
+    });
+    expect(getUnitsPreference).toHaveBeenCalledWith({});
+    expect(setUnitsPreference).toHaveBeenCalledWith({ value: "imperial" });
+    client.ws.send(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: "units-invalid",
+        method: "setUnitsPreference",
+        params: { value: "other" },
+      }),
+    );
+    expect(parseCoachRpcEnvelope(await client.frames.next())).toMatchObject({
+      id: "units-invalid",
+      error: { code: -32602, message: "Invalid params" },
+    });
     await client.close();
   });
 

--- a/packages/coach/tests/operations.test.ts
+++ b/packages/coach/tests/operations.test.ts
@@ -570,4 +570,73 @@ describe("coach operations", () => {
       expect(serializedResults).not.toContain(value);
     }
   });
+
+  it("serializes persisted units reads and writes through the same operation FIFO", async () => {
+    const root = await mkdtemp(join(await realpath(tmpdir()), "coach-units-"));
+    const liveHome: AthleteHome = {
+      root,
+      storeDir: join(root, "store"),
+      archiveDir: join(root, "archive"),
+      configDir: join(root, "config"),
+    };
+    const store = openSqliteStorage(join(root, "coach.db"));
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const order: string[] = [];
+    try {
+      await runMigrations(store, MIGRATIONS);
+      const operations = createCoachOperations({
+        home: liveHome,
+        context: {
+          home: liveHome,
+          store,
+          listener: {} as CoachStoreWriterContext["listener"],
+        },
+        runtime: {
+          async runWindowAfter(work) {
+            order.push("sync-start");
+            await gate;
+            await work(new AbortController().signal);
+            order.push("sync-end");
+            return {
+              published: true,
+              legacySucceeded: true,
+              counts: requestCounts(0, 0),
+            };
+          },
+        },
+        intervalsCredentials: intervalsCredentials(),
+        historyNewestDate: "1998-07-18",
+        applyRuntimeConfig: async () => {},
+      });
+      const sync = operations.sync({});
+      const write = operations.setUnitsPreference!({ value: "imperial" }).then((result) => {
+        order.push("write");
+        return result;
+      });
+      const read = operations.getUnitsPreference!({}).then((result) => {
+        order.push("read");
+        return result;
+      });
+      await Promise.resolve();
+      expect(order).toEqual(["sync-start"]);
+      release();
+      await expect(sync).resolves.toMatchObject({ schemaVersion: 1 });
+      await expect(write).resolves.toEqual({ value: "imperial", source: "cycling" });
+      await expect(read).resolves.toEqual({ value: "imperial", source: "cycling" });
+      expect(order).toEqual(["sync-start", "sync-end", "write", "read"]);
+      await expect(
+        store.get("SELECT preferred_units, device_id FROM sport_settings"),
+      ).resolves.toMatchObject({
+        preferred_units: "imperial",
+        device_id: expect.stringMatching(/^desktop:[0-9A-HJKMNP-TV-Z]{26}$/u),
+      });
+    } finally {
+      release();
+      await store.close();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/coach/tests/training-context.test.ts
+++ b/packages/coach/tests/training-context.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from "vitest";
+import type { CyclingFtpAnchorResult } from "@enduragent/kernel/anchors";
+import { projectCyclingTrainingContext } from "../src/training-context.js";
+
+const anchor: CyclingFtpAnchorResult = {
+  kind: "ftp",
+  watts: 250,
+  validFrom: "2026-06-01",
+  source: "manual",
+  confidence: "manual",
+  ageDays: 48,
+  stalenessBand: "aging",
+  stale: true,
+};
+
+function activity(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "ride-1",
+    start_date_local: "2026-07-17T07:00:00",
+    type: "Ride",
+    moving_time: 3600,
+    elapsed_time: 3700,
+    icu_training_load: 70,
+    ...overrides,
+  };
+}
+
+function wellness(id: string, overrides: Record<string, unknown> = {}) {
+  return {
+    id,
+    weight: 70,
+    restingHR: 48,
+    hrv: 62,
+    sleepSecs: 28_800,
+    sleepQuality: 3,
+    ...overrides,
+  };
+}
+
+function project(overrides: Partial<Parameters<typeof projectCyclingTrainingContext>[0]> = {}) {
+  return projectCyclingTrainingContext({
+    asOf: "2026-07-18T00:00:00.000Z",
+    anchor,
+    derivedMetrics: {
+      consistency_index: 0.75,
+      consistency_details: { planned_days: 4, completed_days: 5, matched_days: 3 },
+    },
+    recentActivities: [activity(), activity({ id: "run-1", type: "Run", icu_training_load: 20 })],
+    plannedWorkouts: [
+      {
+        id: 2,
+        category: "WORKOUT",
+        start_date_local: "2026-07-20T08:00:00",
+        name: null,
+        type: "Ride",
+      },
+    ],
+    wellness: [wellness("2026-07-17")],
+    ...overrides,
+  });
+}
+
+describe("cycling training context projection", () => {
+  it("projects the canonical anchor and all six canonical zone rows", () => {
+    const result = project();
+    expect(result.anchorZones).toMatchObject({
+      kind: "computed",
+      anchor: {
+        watts: anchor.watts,
+        validFrom: anchor.validFrom,
+        source: anchor.source,
+        confidence: anchor.confidence,
+        ageDays: anchor.ageDays,
+        stalenessBand: anchor.stalenessBand,
+        stale: anchor.stale,
+      },
+      zones: expect.arrayContaining([
+        expect.objectContaining({ name: "Sweet Spot (88-94%)", overlaps: true }),
+      ]),
+    });
+    if (result.anchorZones.kind === "computed") expect(result.anchorZones.zones).toHaveLength(6);
+    expect(project({ anchor: null }).anchorZones).toEqual({
+      kind: "unknown",
+      reason: "not-synced",
+    });
+    expect(
+      project({ anchor: { kind: "missing", refusal: "missing-cycling-ftp-anchor" } }).anchorZones,
+    ).toEqual({ kind: "unknown", reason: "missing-anchor" });
+  });
+
+  it.each(["fresh", "aging", "stale", "very-stale"] as const)(
+    "preserves the %s staleness band",
+    (stalenessBand) => {
+      const result = project({ anchor: { ...anchor, stalenessBand } });
+      expect(
+        result.anchorZones.kind === "computed" && result.anchorZones.anchor.stalenessBand,
+      ).toBe(stalenessBand);
+    },
+  );
+
+  it("aggregates only valid persisted cycling platform Load values", () => {
+    const result = project({
+      recentActivities: [
+        activity({ id: "zero", icu_training_load: 0 }),
+        activity({ id: "missing", icu_training_load: null }),
+        activity({ id: "invalid", icu_training_load: -1 }),
+        activity({ id: "nonfinite", icu_training_load: Number.POSITIVE_INFINITY }),
+        activity({ id: "run", type: "Run", icu_training_load: 90 }),
+      ],
+    });
+    expect(result.cyclingLoad).toEqual({
+      kind: "computed",
+      asOf: "2026-07-18T00:00:00.000Z",
+      source: "intervals.icu",
+      windowDays: 7,
+      value: 0,
+      activityCount: 2,
+      missingLoadCount: 1,
+    });
+    expect(
+      project({ recentActivities: [activity({ icu_training_load: null })] }).cyclingLoad,
+    ).toEqual({
+      kind: "unknown",
+      reason: "no-platform-load",
+    });
+  });
+
+  it("filters, sorts, and caps cycling plan rows", () => {
+    const rows = Array.from({ length: 9 }, (_, index) => ({
+      id: 20 - index,
+      category: "WORKOUT",
+      start_date_local: `2026-07-${String(20 + (index % 2)).padStart(2, "0")}T08:00:00`,
+      name: index === 0 ? null : `Workout ${index}`,
+      type: "Ride",
+    }));
+    rows.push({
+      id: 100,
+      category: "WORKOUT",
+      start_date_local: "2026-07-19T08:00:00",
+      name: "Run",
+      type: "Run",
+    });
+    const result = project({ plannedWorkouts: rows });
+    expect(result.plan.kind === "computed" && result.plan.items).toHaveLength(7);
+    if (result.plan.kind === "computed") {
+      expect(result.plan.items.map((item) => Number(item.id))).toEqual([
+        12, 14, 16, 18, 20, 13, 15,
+      ]);
+    }
+    expect(project({ plannedWorkouts: [] }).plan).toEqual({ kind: "unknown", reason: "no-plan" });
+  });
+
+  it("projects persisted adherence only when its complete shape is valid", () => {
+    expect(project().adherence).toMatchObject({
+      kind: "computed",
+      ratio: 0.75,
+      plannedDays: 4,
+      completedDays: 5,
+      matchedDays: 3,
+    });
+    expect(
+      project({
+        derivedMetrics: {
+          consistency_index: 0,
+          consistency_details: { planned_days: 0, completed_days: 0, matched_days: 0 },
+        },
+      }).adherence,
+    ).toEqual({ kind: "unknown", reason: "no-plan" });
+    expect(project({ derivedMetrics: { consistency_index: 2 } }).adherence).toEqual({
+      kind: "unknown",
+      reason: "insufficient-data",
+    });
+  });
+
+  it("sorts and caps wellness rows while allowing partial series", () => {
+    const rows = Array.from({ length: 9 }, (_, index) =>
+      wellness(`2026-07-${String(9 - index).padStart(2, "0")}`, {
+        hrv: index === 0 ? null : 50 + index,
+        sleepSecs: null,
+      }),
+    );
+    const result = project({ wellness: rows });
+    expect(result.wellnessTrend.kind).toBe("computed");
+    if (result.wellnessTrend.kind === "computed") {
+      expect(result.wellnessTrend.series.map((entry) => entry.points.length)).toEqual([6, 0, 7]);
+      expect(result.wellnessTrend.series[0]?.points[0]?.date).toBe("2026-07-03");
+    }
+    expect(project({ wellness: {} }).wellnessTrend).toEqual({
+      kind: "unknown",
+      reason: "no-wellness",
+    });
+    expect(
+      project({
+        wellness: [wellness("2026-07-01", { hrv: null, sleepSecs: null, restingHR: null })],
+      }).wellnessTrend,
+    ).toEqual({
+      kind: "unknown",
+      reason: "insufficient-data",
+    });
+  });
+
+  it("does not project unrelated wellness balance inputs", () => {
+    const result = JSON.stringify(
+      project({ wellness: [wellness("2026-07-17", { fitness: 80, fatigue: 70 })] }),
+    );
+    expect(result).not.toContain("fitness");
+    expect(result).not.toContain("fatigue");
+  });
+});

--- a/packages/core/src/reference/sync/fetch-live-bundle.ts
+++ b/packages/core/src/reference/sync/fetch-live-bundle.ts
@@ -37,6 +37,7 @@ import {
   type ReferenceBundle,
   type RenameSummary,
 } from "@enduragent/kernel/reference/local-bundle";
+import { PlannedEventSchema, type PlannedEvent } from "@enduragent/kernel/reference/schemas";
 
 import {
   AthleteSchema,
@@ -47,6 +48,7 @@ import {
   type WellnessDay,
 } from "../schemas/inputs.js";
 import { LATEST_RETENTION_DAYS } from "../freshness.js";
+import { familyOf } from "../sport-adapter-dispatcher.js";
 
 export { deriveFtpHistory, normalizeStreams } from "@enduragent/kernel/reference/local-bundle";
 
@@ -59,6 +61,8 @@ export const FETCH_WINDOW_DAYS = REFERENCE_CAPTURE_WINDOW_DAYS;
 export const STREAM_WINDOW_DAYS = REFERENCE_CAPTURE_STREAM_WINDOW_DAYS;
 /** Hard cap on per-activity stream fetches per sync, regardless of window. */
 export const MAX_STREAM_ACTIVITIES = REFERENCE_CAPTURE_STREAM_LIMIT;
+export const PAST_PLAN_WINDOW_DAYS = 7;
+export const FUTURE_PLAN_WINDOW_DAYS = 28;
 const STREAM_THROTTLE_MS = 250;
 /** Wall-clock budget for the whole stream phase. Streams are best-effort, so we
  *  stop fetching once this elapses rather than letting a slow account push the
@@ -84,6 +88,13 @@ export interface BundleFetchClient {
   readonly wellness: {
     list(query: { oldest?: string; newest?: string }): Promise<FetchResult<unknown[]>>;
   };
+  readonly events: {
+    list(query: {
+      oldest: string;
+      newest: string;
+      category: string[];
+    }): Promise<FetchResult<unknown[]>>;
+  };
 }
 
 /** One per-endpoint fetch failure: which source envelope returned an error and
@@ -101,6 +112,7 @@ export interface LiveFetchResult {
   readonly recentActivities: readonly Activity[];
   /** Renamed wellness rows for the `latest.wellness_data` cache. */
   readonly wellnessData: readonly WellnessDay[];
+  readonly plannedWorkouts: readonly PlannedEvent[];
   /** Full-window inputs for metric computation. */
   readonly bundle: ReferenceBundle;
   /** Sync wall-clock as an ISO string — the metric date-window anchor. */
@@ -131,6 +143,7 @@ interface LiveFetchDeps {
   readonly client: BundleFetchClient;
   readonly signal: AbortSignal;
   readonly now: Date;
+  readonly sportTypes?: readonly string[];
   /** Override the inter-request throttle (tests pass 0). */
   readonly throttleMs?: number;
   /** Sink for non-fatal warnings; defaults to console.warn. */
@@ -156,10 +169,17 @@ function sleep(ms: number, signal: AbortSignal): Promise<void> {
 }
 
 function renderEndpointError(error: unknown): string {
-  const serializable = error !== null && typeof error === "object" && !(error instanceof Error)
-    ? Object.assign(new Error("Reference endpoint failed"), error)
-    : error;
+  const serializable =
+    error !== null && typeof error === "object" && !(error instanceof Error)
+      ? Object.assign(new Error("Reference endpoint failed"), error)
+      : error;
   return JSON.stringify(serializeError(serializable));
+}
+
+function shiftedDate(value: string, days: number): string {
+  const instant = new Date(`${value}T00:00:00.000Z`);
+  instant.setUTCDate(instant.getUTCDate() + days);
+  return instant.toISOString().slice(0, 10);
 }
 
 /**
@@ -175,6 +195,9 @@ export async function fetchLiveBundle(deps: LiveFetchDeps): Promise<LiveFetchRes
   const plan = createReferenceCapturePlan(now);
   const frozenNow = plan.frozenNow;
   const { oldest, newest } = plan.window;
+  const cyclingSportTypes = new Set(
+    (deps.sportTypes ?? []).filter((type) => familyOf(type, undefined) === "cycling"),
+  );
 
   const fetchErrors: FetchEndpointError[] = [];
 
@@ -212,6 +235,53 @@ export async function fetchLiveBundle(deps: LiveFetchDeps): Promise<LiveFetchRes
       ? (wellResult.value as Array<Record<string, unknown>>)
       : [];
 
+  const frozenDate = frozenNow.slice(0, 10);
+  const planOldest = shiftedDate(frozenDate, -(PAST_PLAN_WINDOW_DAYS - 1));
+  const planNewest = shiftedDate(frozenDate, FUTURE_PLAN_WINDOW_DAYS);
+  const eventResult = await client.events.list({
+    oldest: planOldest,
+    newest: planNewest,
+    category: ["WORKOUT"],
+  });
+  if (!eventResult.ok) {
+    const detail = renderEndpointError(eventResult.error);
+    log(`Reference: events.list failed: ${detail}`);
+    fetchErrors.push({ endpoint: "events", detail });
+  }
+  const plannedEvents: PlannedEvent[] = [];
+  if (eventResult.ok && Array.isArray(eventResult.value)) {
+    const rawEvents = snakeCaseKeys(eventResult.value) as Array<Record<string, unknown>>;
+    for (const row of rawEvents) {
+      const parsed = PlannedEventSchema.safeParse(row);
+      if (!parsed.success) {
+        log(`Reference: skipped malformed event row: ${parsed.error.message}`);
+        continue;
+      }
+      if (
+        parsed.data.category !== "WORKOUT" ||
+        parsed.data.type == null ||
+        !cyclingSportTypes.has(parsed.data.type)
+      ) {
+        continue;
+      }
+      plannedEvents.push(parsed.data);
+    }
+  } else if (eventResult.ok) {
+    log("Reference: events.list returned a non-array body; treating as empty");
+  }
+  plannedEvents.sort(
+    (left, right) =>
+      left.start_date_local.localeCompare(right.start_date_local) || left.id - right.id,
+  );
+  const pastEvents = plannedEvents.filter((event) => {
+    const date = event.start_date_local.slice(0, 10);
+    return date >= planOldest && date <= frozenDate;
+  });
+  const plannedWorkouts = plannedEvents.filter((event) => {
+    const date = event.start_date_local.slice(0, 10);
+    return date >= frozenDate && date <= planNewest;
+  });
+
   const actSummary: RenameSummary = { skippedNonNumeric: {} };
   const wellSummary: RenameSummary = { skippedNonNumeric: {} };
 
@@ -220,7 +290,9 @@ export async function fetchLiveBundle(deps: LiveFetchDeps): Promise<LiveFetchRes
     try {
       activities.push(parseRenamedActivity(renameTpFieldsOnActivity(row, actSummary)));
     } catch (err) {
-      log(`Reference: skipped malformed activity row: ${err instanceof Error ? err.message : String(err)}`);
+      log(
+        `Reference: skipped malformed activity row: ${err instanceof Error ? err.message : String(err)}`,
+      );
     }
   }
   const wellness: WellnessDay[] = [];
@@ -228,7 +300,9 @@ export async function fetchLiveBundle(deps: LiveFetchDeps): Promise<LiveFetchRes
     try {
       wellness.push(parseRenamedWellnessRow(renameTpFieldsOnWellnessRow(row, wellSummary)));
     } catch (err) {
-      log(`Reference: skipped malformed wellness row: ${err instanceof Error ? err.message : String(err)}`);
+      log(
+        `Reference: skipped malformed wellness row: ${err instanceof Error ? err.message : String(err)}`,
+      );
     }
   }
 
@@ -244,6 +318,7 @@ export async function fetchLiveBundle(deps: LiveFetchDeps): Promise<LiveFetchRes
     activities,
     wellness,
     ftpHistory,
+    pastEvents,
     ...(Object.keys(streams).length > 0 ? { streams } : {}),
     ...(athlete !== undefined ? { athlete } : {}),
   };
@@ -259,6 +334,7 @@ export async function fetchLiveBundle(deps: LiveFetchDeps): Promise<LiveFetchRes
     athleteProfile,
     recentActivities,
     wellnessData: wellness,
+    plannedWorkouts,
     bundle,
     frozenNow,
     ...(fetchErrors.length > 0 ? { fetchErrors } : {}),
@@ -283,7 +359,9 @@ async function fetchStreams(
     try {
       result = await client.activities.getStreams(id, [...STREAM_TYPES]);
     } catch (err) {
-      log(`Reference: streams fetch threw for an activity: ${err instanceof Error ? err.message : String(err)}`);
+      log(
+        `Reference: streams fetch threw for an activity: ${err instanceof Error ? err.message : String(err)}`,
+      );
       continue;
     }
     if (!result.ok) {

--- a/packages/core/src/reference/sync/fetch-reference-data.ts
+++ b/packages/core/src/reference/sync/fetch-reference-data.ts
@@ -41,8 +41,7 @@ export function composeProvenance(runs: readonly AdapterRun[]): {
   meta: Omit<DerivedMetricsMeta, "analysisBasis"> | undefined;
 } {
   if (runs.length === 0) return { omitPowerFamily: false, meta: undefined };
-  const covering =
-    runs.find((r) => r.adapter.zoneBasis === "power")?.adapter ?? runs[0].adapter;
+  const covering = runs.find((r) => r.adapter.zoneBasis === "power")?.adapter ?? runs[0].adapter;
   const omitPowerFamily = covering.zoneBasis !== "power";
   const firstType = covering.activityTypes[0];
   const sportFamily = firstType !== undefined ? familyOf(firstType, "other") : "other";
@@ -117,17 +116,16 @@ async function fetchOnce(
   adapters: readonly ReferenceSportAdapter[],
   sportTypes: readonly IntervalsActivityType[],
 ): Promise<FetchedReference> {
-  const live = await fetchLiveBundle({ client, signal, now: new Date() });
+  const live = await fetchLiveBundle({ client, signal, now: new Date(), sportTypes });
   const runs: readonly AdapterRun[] = runAdaptersForActivities(
     adapters,
     sportTypes,
     live.bundle.activities,
   );
   const { omitPowerFamily, meta: baseMeta } = composeProvenance(runs);
-  const derivedMetrics = computeDerivedMetrics(
-    buildMetricInput(live.bundle, live.frozenNow),
-    { omitPowerFamily },
-  );
+  const derivedMetrics = computeDerivedMetrics(buildMetricInput(live.bundle, live.frozenNow), {
+    omitPowerFamily,
+  });
   // analysisBasis is a compute OUTPUT (read off the registry's emitted
   // zone_distribution_7d), so it joins the runs-derivable meta only after
   // compute. baseMeta is undefined exactly for an empty-coverage bundle.
@@ -144,15 +142,13 @@ async function fetchOnce(
       // key-union deepCompare runs over the map only, so the tag must stay out.
       ...(meta ? { derived_metrics_meta: meta } : {}),
       recent_activities: live.recentActivities,
-      planned_workouts: [],
+      planned_workouts: live.plannedWorkouts,
       wellness_data: live.wellnessData,
     },
     history: { daily: [], weekly: [], monthly: [] },
     intervals: { by_activity: {} },
     routes: { routes: [] },
     ftp_history: { entries: [] },
-    ...(live.fetchErrors && live.fetchErrors.length > 0
-      ? { fetch_errors: live.fetchErrors }
-      : {}),
+    ...(live.fetchErrors && live.fetchErrors.length > 0 ? { fetch_errors: live.fetchErrors } : {}),
   };
 }

--- a/packages/core/tests/reference-fetch-live-bundle.test.ts
+++ b/packages/core/tests/reference-fetch-live-bundle.test.ts
@@ -55,7 +55,11 @@ function wellnessRaw(over: Record<string, unknown> = {}): Record<string, unknown
   };
 }
 
-const STREAM_OK = { ok: true as const, value: { dfa_a1: [1, 0.8], heartrate: [140, 145], watts: [200, 210] } };
+const STREAM_OK = {
+  ok: true as const,
+  value: { dfa_a1: [1, 0.8], heartrate: [140, 145], watts: [200, 210] },
+};
+const EMPTY_EVENTS = { list: async () => ({ ok: true as const, value: [] }) };
 
 interface FakeOpts {
   activities?: Record<string, unknown>[];
@@ -63,10 +67,17 @@ interface FakeOpts {
   athlete?: unknown;
   streamFor?: (id: string) => { ok: true; value: unknown } | { ok: false; error: unknown };
   activitiesFail?: boolean;
+  events?: Record<string, unknown>[];
+  eventsFail?: boolean;
 }
 
-function fakeClient(opts: FakeOpts): { client: BundleFetchClient; streamCalls: string[] } {
+function fakeClient(opts: FakeOpts): {
+  client: BundleFetchClient;
+  streamCalls: string[];
+  eventCalls: Array<{ oldest: string; newest: string; category: string[] }>;
+} {
   const streamCalls: string[] = [];
+  const eventCalls: Array<{ oldest: string; newest: string; category: string[] }> = [];
   const client: BundleFetchClient = {
     athlete: { get: async () => ({ ok: true, value: opts.athlete ?? {} }) },
     activities: {
@@ -80,8 +91,16 @@ function fakeClient(opts: FakeOpts): { client: BundleFetchClient; streamCalls: s
       },
     },
     wellness: { list: async () => ({ ok: true, value: opts.wellness ?? [] }) },
+    events: {
+      list: async (query) => {
+        eventCalls.push(query);
+        return opts.eventsFail
+          ? { ok: false, error: "event failure" }
+          : { ok: true, value: opts.events ?? [] };
+      },
+    },
   };
-  return { client, streamCalls };
+  return { client, streamCalls, eventCalls };
 }
 
 describe("fetchLiveBundle", () => {
@@ -90,7 +109,12 @@ describe("fetchLiveBundle", () => {
       activities: [camelActivity({ id: 7 })],
       wellness: [wellnessRaw()],
     });
-    const res = await fetchLiveBundle({ client, signal: new AbortController().signal, now: NOW, throttleMs: 0 });
+    const res = await fetchLiveBundle({
+      client,
+      signal: new AbortController().signal,
+      now: NOW,
+      throttleMs: 0,
+    });
 
     const act = res.bundle.activities[0]! as Record<string, unknown>;
     expect(act.start_date_local).toBeTypeOf("string");
@@ -116,7 +140,12 @@ describe("fetchLiveBundle", () => {
       camelActivity({ id: 901, startDateLocal: daysAgo(40) }), // outside stream window
     ];
     const { client, streamCalls } = fakeClient({ activities });
-    const res = await fetchLiveBundle({ client, signal: new AbortController().signal, now: NOW, throttleMs: 0 });
+    const res = await fetchLiveBundle({
+      client,
+      signal: new AbortController().signal,
+      now: NOW,
+      throttleMs: 0,
+    });
 
     expect(streamCalls).toHaveLength(MAX_STREAM_ACTIVITIES);
     expect(streamCalls).not.toContain("900"); // run excluded
@@ -128,11 +157,18 @@ describe("fetchLiveBundle", () => {
 
   it("preserves encounter order for equal stream instants instead of external-ID order", async () => {
     const instant = daysAgo(1);
-    const { client, streamCalls } = fakeClient({ activities: [
-      camelActivity({ id: 90, startDateLocal: instant }),
-      camelActivity({ id: 10, startDateLocal: instant }),
-    ] });
-    await fetchLiveBundle({ client, signal: new AbortController().signal, now: NOW, throttleMs: 0 });
+    const { client, streamCalls } = fakeClient({
+      activities: [
+        camelActivity({ id: 90, startDateLocal: instant }),
+        camelActivity({ id: 10, startDateLocal: instant }),
+      ],
+    });
+    await fetchLiveBundle({
+      client,
+      signal: new AbortController().signal,
+      now: NOW,
+      throttleMs: 0,
+    });
     expect(streamCalls).toEqual(["90", "10"]);
   });
 
@@ -145,7 +181,13 @@ describe("fetchLiveBundle", () => {
       activities,
       streamFor: (id) => (id === "1" ? { ok: false, error: "no streams" } : STREAM_OK),
     });
-    const res = await fetchLiveBundle({ client, signal: new AbortController().signal, now: NOW, throttleMs: 0, log: () => {} });
+    const res = await fetchLiveBundle({
+      client,
+      signal: new AbortController().signal,
+      now: NOW,
+      throttleMs: 0,
+      log: () => {},
+    });
     expect(res.bundle.streams?.["1"]).toBeUndefined();
     expect(res.bundle.streams?.["2"]).toBeDefined();
   });
@@ -153,7 +195,9 @@ describe("fetchLiveBundle", () => {
   it("breaks the stream loop when the signal is already aborted", async () => {
     const ac = new AbortController();
     ac.abort();
-    const { client, streamCalls } = fakeClient({ activities: [camelActivity({ id: 1, startDateLocal: daysAgo(1) })] });
+    const { client, streamCalls } = fakeClient({
+      activities: [camelActivity({ id: 1, startDateLocal: daysAgo(1) })],
+    });
     const res = await fetchLiveBundle({ client, signal: ac.signal, now: NOW, throttleMs: 0 });
     expect(streamCalls).toHaveLength(0);
     expect(res.bundle.streams).toBeUndefined();
@@ -167,7 +211,12 @@ describe("fetchLiveBundle", () => {
         wellnessRaw({ id: "2026-05-20", sportInfo: [{ type: "Ride", eftp: 250 }] }), // change
       ],
     });
-    const res = await fetchLiveBundle({ client, signal: new AbortController().signal, now: NOW, throttleMs: 0 });
+    const res = await fetchLiveBundle({
+      client,
+      signal: new AbortController().signal,
+      now: NOW,
+      throttleMs: 0,
+    });
     expect(res.bundle.ftpHistory).toEqual([
       { date: "2026-05-01", ftp: 240, source: "estimate" },
       { date: "2026-05-20", ftp: 250, source: "estimate" },
@@ -181,7 +230,12 @@ describe("fetchLiveBundle", () => {
         camelActivity({ id: 2, startDateLocal: daysAgo(30) }), // outside 7d, inside 84d
       ],
     });
-    const res = await fetchLiveBundle({ client, signal: new AbortController().signal, now: NOW, throttleMs: 0 });
+    const res = await fetchLiveBundle({
+      client,
+      signal: new AbortController().signal,
+      now: NOW,
+      throttleMs: 0,
+    });
     expect(res.recentActivities).toHaveLength(1);
     expect(res.bundle.activities).toHaveLength(2);
   });
@@ -190,7 +244,12 @@ describe("fetchLiveBundle", () => {
     const { client } = fakeClient({
       athlete: { sportSettings: [{ types: ["Ride"], ftp: 250, indoor_ftp: 240, lthr: 165 }] },
     });
-    const res = await fetchLiveBundle({ client, signal: new AbortController().signal, now: NOW, throttleMs: 0 });
+    const res = await fetchLiveBundle({
+      client,
+      signal: new AbortController().signal,
+      now: NOW,
+      throttleMs: 0,
+    });
     expect(res.bundle.athlete?.sportSettings[0]?.ftp).toBe(250);
   });
 
@@ -199,6 +258,73 @@ describe("fetchLiveBundle", () => {
     await expect(
       fetchLiveBundle({ client, signal: new AbortController().signal, now: NOW, throttleMs: 0 }),
     ).rejects.toThrow(/activities\.list failed/);
+  });
+
+  it("fetches one bounded workout window and partitions only valid cycling rows", async () => {
+    const { client, eventCalls } = fakeClient({
+      events: [
+        {
+          id: 3,
+          category: "WORKOUT",
+          startDateLocal: "2026-06-08T08:00:00",
+          name: "Past",
+          type: "Ride",
+        },
+        {
+          id: 2,
+          category: "WORKOUT",
+          startDateLocal: "2026-06-09T09:00:00",
+          name: null,
+          type: "VirtualRide",
+        },
+        {
+          id: 1,
+          category: "WORKOUT",
+          startDateLocal: "2026-06-10T08:00:00",
+          name: "Future",
+          type: "Ride",
+        },
+        {
+          id: 4,
+          category: "WORKOUT",
+          startDateLocal: "2026-06-10T08:00:00",
+          name: "Run",
+          type: "Run",
+        },
+        { id: 5, category: "WORKOUT", startDateLocal: "2026-06-10T08:00:00", name: "Untyped" },
+        { category: "WORKOUT", startDateLocal: "2026-06-10T08:00:00", type: "Ride" },
+      ],
+    });
+    const result = await fetchLiveBundle({
+      client,
+      signal: new AbortController().signal,
+      now: NOW,
+      sportTypes: ["Ride", "VirtualRide", "Run"],
+      throttleMs: 0,
+      log: () => {},
+    });
+    expect(eventCalls).toEqual([
+      { oldest: "2026-06-03", newest: "2026-07-07", category: ["WORKOUT"] },
+    ]);
+    expect(result.bundle.pastEvents?.map((event) => event.id)).toEqual([3, 2]);
+    expect(result.plannedWorkouts.map((event) => event.id)).toEqual([2, 1]);
+  });
+
+  it("records an event endpoint failure instead of publishing a false empty plan", async () => {
+    const { client } = fakeClient({ eventsFail: true });
+    const result = await fetchLiveBundle({
+      client,
+      signal: new AbortController().signal,
+      now: NOW,
+      sportTypes: ["Ride"],
+      throttleMs: 0,
+      log: () => {},
+    });
+    expect(result.fetchErrors).toContainEqual({
+      endpoint: "events",
+      detail: expect.any(String),
+    });
+    expect(result.plannedWorkouts).toEqual([]);
   });
 });
 
@@ -218,7 +344,12 @@ describe("fetchLiveBundle — real lib stream shapes + edge cases", () => {
         ],
       }),
     });
-    const res = await fetchLiveBundle({ client, signal: new AbortController().signal, now: NOW, throttleMs: 0 });
+    const res = await fetchLiveBundle({
+      client,
+      signal: new AbortController().signal,
+      now: NOW,
+      throttleMs: 0,
+    });
     expect(res.bundle.streams?.["1"]?.dfa_a1).toEqual([1, 0.8]);
     expect(res.bundle.streams?.["1"]?.watts).toEqual([200, 210]);
   });
@@ -228,7 +359,12 @@ describe("fetchLiveBundle — real lib stream shapes + edge cases", () => {
       activities: [camelActivity({ id: 1, startDateLocal: daysAgo(1) })],
       streamFor: () => ({ ok: true, value: { dfaA1: [1, 0.8], watts: [200], heartrate: [140] } }),
     });
-    const res = await fetchLiveBundle({ client, signal: new AbortController().signal, now: NOW, throttleMs: 0 });
+    const res = await fetchLiveBundle({
+      client,
+      signal: new AbortController().signal,
+      now: NOW,
+      throttleMs: 0,
+    });
     expect(res.bundle.streams?.["1"]?.dfa_a1).toEqual([1, 0.8]);
   });
 
@@ -237,7 +373,13 @@ describe("fetchLiveBundle — real lib stream shapes + edge cases", () => {
       activities: [camelActivity({ id: 1, startDateLocal: daysAgo(1) })],
       streamFor: () => ({ ok: true, value: "garbage" }),
     });
-    const res = await fetchLiveBundle({ client, signal: new AbortController().signal, now: NOW, throttleMs: 0, log: () => {} });
+    const res = await fetchLiveBundle({
+      client,
+      signal: new AbortController().signal,
+      now: NOW,
+      throttleMs: 0,
+      log: () => {},
+    });
     expect(res.bundle.streams).toBeUndefined();
   });
 
@@ -245,7 +387,12 @@ describe("fetchLiveBundle — real lib stream shapes + edge cases", () => {
     const { client } = fakeClient({
       athlete: { sportSettings: [{ types: ["Ride"], ftp: 250, indoorFtp: 240, lthr: 165 }] },
     });
-    const res = await fetchLiveBundle({ client, signal: new AbortController().signal, now: NOW, throttleMs: 0 });
+    const res = await fetchLiveBundle({
+      client,
+      signal: new AbortController().signal,
+      now: NOW,
+      throttleMs: 0,
+    });
     expect(res.bundle.athlete?.sportSettings[0]?.indoor_ftp).toBe(240);
   });
 
@@ -253,10 +400,20 @@ describe("fetchLiveBundle — real lib stream shapes + edge cases", () => {
     const logs: string[] = [];
     const client: BundleFetchClient = {
       athlete: { get: async () => ({ ok: false, error: "unauthorized" }) },
-      activities: { list: async () => ({ ok: true, value: [] }), getStreams: async () => STREAM_OK },
+      activities: {
+        list: async () => ({ ok: true, value: [] }),
+        getStreams: async () => STREAM_OK,
+      },
       wellness: { list: async () => ({ ok: true, value: [] }) },
+      events: EMPTY_EVENTS,
     };
-    const res = await fetchLiveBundle({ client, signal: new AbortController().signal, now: NOW, throttleMs: 0, log: (m) => logs.push(m) });
+    const res = await fetchLiveBundle({
+      client,
+      signal: new AbortController().signal,
+      now: NOW,
+      throttleMs: 0,
+      log: (m) => logs.push(m),
+    });
     expect(res.bundle.athlete).toBeUndefined();
     expect(logs.some((l) => l.includes("athlete.get failed"))).toBe(true);
   });
@@ -270,8 +427,12 @@ describe("fetchLiveBundle — real lib stream shapes + edge cases", () => {
           error: { kind: "Http", status: 401, message: "synthetic unauthorized" } as never,
         }),
       },
-      activities: { list: async () => ({ ok: true, value: [] }), getStreams: async () => STREAM_OK },
+      activities: {
+        list: async () => ({ ok: true, value: [] }),
+        getStreams: async () => STREAM_OK,
+      },
       wellness: { list: async () => ({ ok: true, value: [] }) },
+      events: EMPTY_EVENTS,
     };
     const result = await fetchLiveBundle({
       client,
@@ -284,16 +445,28 @@ describe("fetchLiveBundle — real lib stream shapes + edge cases", () => {
     expect(logs[0]).toContain('"stack":');
     expect(logs[0]).toContain('"kind":"Http"');
     expect(logs[0]).not.toContain("[object Object]");
-    expect(result.fetchErrors?.[0]?.detail).toBe(logs[0]?.replace("Reference: athlete.get failed: ", ""));
+    expect(result.fetchErrors?.[0]?.detail).toBe(
+      logs[0]?.replace("Reference: athlete.get failed: ", ""),
+    );
   });
 
   it("records a fetchErrors entry naming the athlete endpoint when athlete.get fails (still a usable bundle)", async () => {
     const client: BundleFetchClient = {
       athlete: { get: async () => ({ ok: false, error: "unauthorized" }) },
-      activities: { list: async () => ({ ok: true, value: [] }), getStreams: async () => STREAM_OK },
+      activities: {
+        list: async () => ({ ok: true, value: [] }),
+        getStreams: async () => STREAM_OK,
+      },
       wellness: { list: async () => ({ ok: true, value: [] }) },
+      events: EMPTY_EVENTS,
     };
-    const res = await fetchLiveBundle({ client, signal: new AbortController().signal, now: NOW, throttleMs: 0, log: () => {} });
+    const res = await fetchLiveBundle({
+      client,
+      signal: new AbortController().signal,
+      now: NOW,
+      throttleMs: 0,
+      log: () => {},
+    });
     expect(res.fetchErrors).toBeDefined();
     expect(res.fetchErrors?.some((e) => e.endpoint === "athlete")).toBe(true);
     // Bundle is still well-typed: the athlete fallback is `{}`, no crash.
@@ -304,10 +477,20 @@ describe("fetchLiveBundle — real lib stream shapes + edge cases", () => {
     const logs: string[] = [];
     const client: BundleFetchClient = {
       athlete: { get: async () => ({ ok: true, value: {} }) },
-      activities: { list: async () => ({ ok: true, value: [] }), getStreams: async () => STREAM_OK },
+      activities: {
+        list: async () => ({ ok: true, value: [] }),
+        getStreams: async () => STREAM_OK,
+      },
       wellness: { list: async () => ({ ok: false, error: "timeout" }) },
+      events: EMPTY_EVENTS,
     };
-    const res = await fetchLiveBundle({ client, signal: new AbortController().signal, now: NOW, throttleMs: 0, log: (m) => logs.push(m) });
+    const res = await fetchLiveBundle({
+      client,
+      signal: new AbortController().signal,
+      now: NOW,
+      throttleMs: 0,
+      log: (m) => logs.push(m),
+    });
     expect(res.bundle.wellness).toEqual([]);
     expect(res.bundle.ftpHistory).toEqual([]);
     expect(logs.some((l) => l.includes("wellness.list failed"))).toBe(true);
@@ -316,10 +499,20 @@ describe("fetchLiveBundle — real lib stream shapes + edge cases", () => {
   it("records a fetchErrors entry naming the wellness endpoint when wellness.list fails (still a usable bundle)", async () => {
     const client: BundleFetchClient = {
       athlete: { get: async () => ({ ok: true, value: {} }) },
-      activities: { list: async () => ({ ok: true, value: [] }), getStreams: async () => STREAM_OK },
+      activities: {
+        list: async () => ({ ok: true, value: [] }),
+        getStreams: async () => STREAM_OK,
+      },
       wellness: { list: async () => ({ ok: false, error: "timeout" }) },
+      events: EMPTY_EVENTS,
     };
-    const res = await fetchLiveBundle({ client, signal: new AbortController().signal, now: NOW, throttleMs: 0, log: () => {} });
+    const res = await fetchLiveBundle({
+      client,
+      signal: new AbortController().signal,
+      now: NOW,
+      throttleMs: 0,
+      log: () => {},
+    });
     expect(res.fetchErrors).toBeDefined();
     expect(res.fetchErrors?.some((e) => e.endpoint === "wellness")).toBe(true);
     expect(res.bundle.wellness).toEqual([]);
@@ -327,7 +520,12 @@ describe("fetchLiveBundle — real lib stream shapes + edge cases", () => {
 
   it("omits fetchErrors entirely when every endpoint succeeds", async () => {
     const { client } = fakeClient({ activities: [], wellness: [], athlete: {} });
-    const res = await fetchLiveBundle({ client, signal: new AbortController().signal, now: NOW, throttleMs: 0 });
+    const res = await fetchLiveBundle({
+      client,
+      signal: new AbortController().signal,
+      now: NOW,
+      throttleMs: 0,
+    });
     expect(res.fetchErrors).toBeUndefined();
   });
 
@@ -335,10 +533,20 @@ describe("fetchLiveBundle — real lib stream shapes + edge cases", () => {
     const logs: string[] = [];
     const client: BundleFetchClient = {
       athlete: { get: async () => ({ ok: true, value: {} }) },
-      activities: { list: async () => ({ ok: true, value: { not: "an array" } as unknown as unknown[] }), getStreams: async () => STREAM_OK },
+      activities: {
+        list: async () => ({ ok: true, value: { not: "an array" } as unknown as unknown[] }),
+        getStreams: async () => STREAM_OK,
+      },
       wellness: { list: async () => ({ ok: true, value: [] }) },
+      events: EMPTY_EVENTS,
     };
-    const res = await fetchLiveBundle({ client, signal: new AbortController().signal, now: NOW, throttleMs: 0, log: (m) => logs.push(m) });
+    const res = await fetchLiveBundle({
+      client,
+      signal: new AbortController().signal,
+      now: NOW,
+      throttleMs: 0,
+      log: (m) => logs.push(m),
+    });
     expect(res.bundle.activities).toEqual([]);
     expect(logs.some((l) => l.includes("non-array"))).toBe(true);
   });
@@ -363,7 +571,12 @@ describe("fetchLiveBundle — real lib stream shapes + edge cases", () => {
 
   it("anchors frozenNow to naive local time (no UTC Z/offset suffix)", async () => {
     const { client } = fakeClient({ activities: [] });
-    const res = await fetchLiveBundle({ client, signal: new AbortController().signal, now: NOW, throttleMs: 0 });
+    const res = await fetchLiveBundle({
+      client,
+      signal: new AbortController().signal,
+      now: NOW,
+      throttleMs: 0,
+    });
     expect(res.frozenNow).not.toMatch(/[Z+]/);
     expect(res.frozenNow).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/);
   });
@@ -379,7 +592,10 @@ describe("normalizeStreams", () => {
     ).toEqual({ dfa_a1: [1, 0.8], watts: [200] });
   });
   it("snake-cases a camelCased object body", () => {
-    expect(normalizeStreams({ dfaA1: [1], heartrate: [140] })).toEqual({ dfa_a1: [1], heartrate: [140] });
+    expect(normalizeStreams({ dfaA1: [1], heartrate: [140] })).toEqual({
+      dfa_a1: [1],
+      heartrate: [140],
+    });
   });
   it("passes a scalar through untouched", () => {
     expect(normalizeStreams("garbage")).toBe("garbage");
@@ -389,9 +605,27 @@ describe("normalizeStreams", () => {
 describe("deriveFtpHistory", () => {
   it("ignores non-cycling sportInfo and rounds eftp", () => {
     const wellness: WellnessDay[] = [
-      { id: "2026-05-01", weight: null, restingHR: null, hrv: null, sleepSecs: null, sleepQuality: null, sportInfo: [{ type: "Run", eftp: 300 }] } as WellnessDay,
-      { id: "2026-05-02", weight: null, restingHR: null, hrv: null, sleepSecs: null, sleepQuality: null, sportInfo: [{ type: "Ride", eftp: 249.6 }] } as WellnessDay,
+      {
+        id: "2026-05-01",
+        weight: null,
+        restingHR: null,
+        hrv: null,
+        sleepSecs: null,
+        sleepQuality: null,
+        sportInfo: [{ type: "Run", eftp: 300 }],
+      } as WellnessDay,
+      {
+        id: "2026-05-02",
+        weight: null,
+        restingHR: null,
+        hrv: null,
+        sleepSecs: null,
+        sleepQuality: null,
+        sportInfo: [{ type: "Ride", eftp: 249.6 }],
+      } as WellnessDay,
     ];
-    expect(deriveFtpHistory(wellness)).toEqual([{ date: "2026-05-02", ftp: 250, source: "estimate" }]);
+    expect(deriveFtpHistory(wellness)).toEqual([
+      { date: "2026-05-02", ftp: 250, source: "estimate" },
+    ]);
   });
 });

--- a/packages/core/tests/reference-input-schemas.test.ts
+++ b/packages/core/tests/reference-input-schemas.test.ts
@@ -24,6 +24,21 @@ import {
   FixtureSchema,
 } from "../src/reference/schemas/inputs.js";
 
+describe("PlannedEventSchema", () => {
+  it.each([{}, { type: null, name: null }, { type: "Ride", name: "Endurance" }])(
+    "accepts absent and nullish event provenance %#",
+    (extension) => {
+      const event = {
+        id: 1,
+        category: "WORKOUT",
+        start_date_local: "2026-07-20T08:00:00",
+        ...extension,
+      };
+      expect(PlannedEventSchema.parse(event)).toEqual(event);
+    },
+  );
+});
+
 describe("ActivitySchema (z.looseObject)", () => {
   it("round-trips a realistic intervals.icu activity preserving every field, including TP-trademark fields", () => {
     const realisticActivity = {
@@ -141,7 +156,10 @@ describe("ActivitySchema (z.looseObject)", () => {
         { id: "Z2", secs: 1800 },
         { id: "Z3", secs: 2400 },
       ],
-      hr_zone_times: [{ id: "Z1", secs: 500 }, { id: "Z2", secs: 1700 }],
+      hr_zone_times: [
+        { id: "Z1", secs: 500 },
+        { id: "Z2", secs: 1700 },
+      ],
     };
     expect(ActivitySchema.parse(objectFormActivity)).toEqual(objectFormActivity);
   });
@@ -416,9 +434,7 @@ describe("Curve / stream / athlete input schemas", () => {
 
   it("AthleteSchema round-trips the sportSettings array the upstream feeds _build_sport_thresholds", () => {
     const athlete = {
-      sportSettings: [
-        { types: ["Ride", "VirtualRide"], ftp: 200, indoor_ftp: 195, lthr: 168 },
-      ],
+      sportSettings: [{ types: ["Ride", "VirtualRide"], ftp: 200, indoor_ftp: 195, lthr: 168 }],
     };
     expect(AthleteSchema.parse(athlete)).toEqual(athlete);
   });

--- a/packages/core/tests/reference-live-sync-integration.test.ts
+++ b/packages/core/tests/reference-live-sync-integration.test.ts
@@ -10,16 +10,26 @@ import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
-import { fetchLiveBundle, type BundleFetchClient } from "../src/reference/sync/fetch-live-bundle.js";
+import {
+  fetchLiveBundle,
+  type BundleFetchClient,
+} from "../src/reference/sync/fetch-live-bundle.js";
 import { buildMetricInput } from "../src/reference/sync/fixture-bridge.js";
 import { computeDerivedMetrics } from "../src/reference/sync/compute-derived-metrics.js";
 import { runAdaptersForActivities } from "../src/reference/sport-adapter-dispatcher.js";
-import { composeProvenance, readAnalysisBasis } from "../src/reference/sync/fetch-reference-data.js";
+import {
+  composeProvenance,
+  readAnalysisBasis,
+} from "../src/reference/sync/fetch-reference-data.js";
 import type { ReferenceSportAdapter } from "../src/reference/sport-adapter.js";
 import type { IntervalsActivityType } from "../src/sport.js";
 import type { FetchedReference } from "../src/reference/sync/run-sync.js";
 import { gateLatestJson } from "../src/reference/validation/sync-gate.js";
-import { LatestJsonSchema, LATEST_SCHEMA_VERSION, type LatestJson } from "../src/reference/schemas/latest.js";
+import {
+  LatestJsonSchema,
+  LATEST_SCHEMA_VERSION,
+  type LatestJson,
+} from "../src/reference/schemas/latest.js";
 import { METRIC_REGISTRY } from "../src/reference/metrics/registry.js";
 import { safeReadJson } from "../src/io/safe-read-json.js";
 
@@ -67,22 +77,67 @@ function fakeClient(): BundleFetchClient {
     sportInfo: [{ type: "Ride", eftp: 250 }],
   }));
   return {
-    athlete: { get: async () => ({ ok: true, value: { sportSettings: [{ types: ["Ride"], ftp: 250, indoor_ftp: 240, lthr: 165 }] } }) },
+    athlete: {
+      get: async () => ({
+        ok: true,
+        value: { sportSettings: [{ types: ["Ride"], ftp: 250, indoor_ftp: 240, lthr: 165 }] },
+      }),
+    },
     activities: {
       list: async () => ({ ok: true, value: activities }),
-      getStreams: async () => ({ ok: true, value: { dfa_a1: [1, 0.8], heartrate: [140, 145], watts: [200, 210] } }),
+      getStreams: async () => ({
+        ok: true,
+        value: { dfa_a1: [1, 0.8], heartrate: [140, 145], watts: [200, 210] },
+      }),
     },
     wellness: { list: async () => ({ ok: true, value: wellness }) },
+    events: {
+      list: async () => ({
+        ok: true,
+        value: [
+          {
+            id: 1,
+            category: "WORKOUT",
+            startDateLocal: "2026-06-08T08:00:00",
+            name: "Past ride",
+            type: "Ride",
+          },
+          {
+            id: 2,
+            category: "WORKOUT",
+            startDateLocal: "2026-06-10T08:00:00",
+            name: "Future ride",
+            type: "VirtualRide",
+          },
+          {
+            id: 3,
+            category: "WORKOUT",
+            startDateLocal: "2026-06-10T09:00:00",
+            name: "Run",
+            type: "Run",
+          },
+          { id: 4, category: "WORKOUT", startDateLocal: "2026-06-11T09:00:00", name: "Untyped" },
+        ],
+      }),
+    },
   };
 }
 
 /** Compose exactly as the production `fetchOnce` does — through the shared
  *  `composeProvenance` helper, so the test exercises the production logic. */
 async function composeFetched(): Promise<FetchedReference> {
-  const live = await fetchLiveBundle({ client: fakeClient(), signal: new AbortController().signal, now: NOW, throttleMs: 0 });
+  const live = await fetchLiveBundle({
+    client: fakeClient(),
+    signal: new AbortController().signal,
+    now: NOW,
+    sportTypes: SPORT_TYPES,
+    throttleMs: 0,
+  });
   const runs = runAdaptersForActivities([CYCLING_ADAPTER], SPORT_TYPES, live.bundle.activities);
   const { omitPowerFamily, meta: baseMeta } = composeProvenance(runs);
-  const derived_metrics = computeDerivedMetrics(buildMetricInput(live.bundle, live.frozenNow), { omitPowerFamily });
+  const derived_metrics = computeDerivedMetrics(buildMetricInput(live.bundle, live.frozenNow), {
+    omitPowerFamily,
+  });
   const meta = baseMeta
     ? { ...baseMeta, analysisBasis: readAnalysisBasis(derived_metrics) }
     : undefined;
@@ -93,7 +148,7 @@ async function composeFetched(): Promise<FetchedReference> {
       derived_metrics,
       ...(meta ? { derived_metrics_meta: meta } : {}),
       recent_activities: live.recentActivities,
-      planned_workouts: [],
+      planned_workouts: live.plannedWorkouts,
       wellness_data: live.wellnessData,
     },
     history: { daily: [], weekly: [], monthly: [] },
@@ -114,7 +169,11 @@ describe("live-data bridge integration", () => {
   it("produces a latest envelope that parses against LatestJsonSchema", async () => {
     const fetched = await composeFetched();
     const onDisk = {
-      metadata: { schema_version: LATEST_SCHEMA_VERSION, last_updated: NOW.toISOString(), freshness: "fresh" as const },
+      metadata: {
+        schema_version: LATEST_SCHEMA_VERSION,
+        last_updated: NOW.toISOString(),
+        freshness: "fresh" as const,
+      },
       ...fetched.latest,
     };
     expect(() => LatestJsonSchema.parse(onDisk)).not.toThrow();
@@ -134,7 +193,11 @@ describe("live-data bridge integration", () => {
     expect(fetched.latest.derived_metrics_meta).toEqual(tag);
 
     const onDisk = {
-      metadata: { schema_version: LATEST_SCHEMA_VERSION, last_updated: NOW.toISOString(), freshness: "fresh" as const },
+      metadata: {
+        schema_version: LATEST_SCHEMA_VERSION,
+        last_updated: NOW.toISOString(),
+        freshness: "fresh" as const,
+      },
       ...fetched.latest,
     };
     const dir = mkdtempSync(join(tmpdir(), "reference-latest-"));
@@ -149,17 +212,34 @@ describe("live-data bridge integration", () => {
   it("writes a populated, full-registry derived_metrics block", async () => {
     const fetched = await composeFetched();
     const derived = fetched.latest.derived_metrics as Record<string, unknown>;
+    const planned = fetched.latest.planned_workouts as readonly { readonly id: number }[];
     expect(Object.keys(derived).sort()).toEqual(Object.keys(METRIC_REGISTRY).sort());
     expect(fetched.latest.recent_activities.length).toBeGreaterThan(0);
+    expect(planned.map((event) => event.id)).toEqual([2]);
+    expect(derived.consistency_index).toBe(1);
+    expect(derived.consistency_details).toMatchObject({
+      planned_days: 1,
+      matched_days: 1,
+    });
   });
 
   it("handles an empty bundle (zero activities/wellness): gate passes, full key-set, empty recent_activities", async () => {
     const emptyClient: BundleFetchClient = {
       athlete: { get: async () => ({ ok: true, value: {} }) },
-      activities: { list: async () => ({ ok: true, value: [] }), getStreams: async () => ({ ok: true, value: [] }) },
+      activities: {
+        list: async () => ({ ok: true, value: [] }),
+        getStreams: async () => ({ ok: true, value: [] }),
+      },
       wellness: { list: async () => ({ ok: true, value: [] }) },
+      events: { list: async () => ({ ok: true, value: [] }) },
     };
-    const live = await fetchLiveBundle({ client: emptyClient, signal: new AbortController().signal, now: NOW, throttleMs: 0 });
+    const live = await fetchLiveBundle({
+      client: emptyClient,
+      signal: new AbortController().signal,
+      now: NOW,
+      sportTypes: SPORT_TYPES,
+      throttleMs: 0,
+    });
     runAdaptersForActivities([CYCLING_ADAPTER], SPORT_TYPES, live.bundle.activities);
     const derived_metrics = computeDerivedMetrics(buildMetricInput(live.bundle, live.frozenNow));
     const fetched: FetchedReference = {

--- a/packages/kernel/src/reference/local-bundle.ts
+++ b/packages/kernel/src/reference/local-bundle.ts
@@ -9,6 +9,7 @@ import {
   type FixtureShape,
   type FtpHistoryPoint,
   type HrCurveData,
+  type PlannedEvent,
   type PowerCurveData,
   type SustainabilityFamilyCurves,
   type WellnessDay,
@@ -28,6 +29,7 @@ export interface ReferenceBundle {
   readonly ftpHistoryIndoor?: Readonly<Record<string, number>>;
   readonly ftpHistoryOutdoor?: Readonly<Record<string, number>>;
   readonly eftp?: number | null;
+  readonly pastEvents?: readonly PlannedEvent[];
 }
 
 export type ReferenceBundleProjection = (bundle: ReferenceBundle) => ReferenceBundle;
@@ -36,10 +38,12 @@ export const IDENTITY_REFERENCE_BUNDLE_PROJECTION: ReferenceBundleProjection = (
 
 function isProjectedCyclingActivity(activity: ReferenceBundle["activities"][number]): boolean {
   const type = activity.type;
-  return typeof type === "string"
-    && type !== "Transition"
-    && Object.hasOwn(SPORT_FAMILIES, type)
-    && SPORT_FAMILIES[type] === "cycling";
+  return (
+    typeof type === "string" &&
+    type !== "Transition" &&
+    Object.hasOwn(SPORT_FAMILIES, type) &&
+    SPORT_FAMILIES[type] === "cycling"
+  );
 }
 
 export function projectCyclingReferenceBundle(bundle: ReferenceBundle): ReferenceBundle {
@@ -52,10 +56,11 @@ export function projectCyclingReferenceBundle(bundle: ReferenceBundle): Referenc
       if (retainedActivityIds.has(activityId)) streams[activityId] = value;
     }
   }
-  const hasNoOrphanStreams = Object.keys(streams ?? {}).every(
-    (activityId) => retainedActivityIds.has(activityId),
+  const hasNoOrphanStreams = Object.keys(streams ?? {}).every((activityId) =>
+    retainedActivityIds.has(activityId),
   );
-  if (!hasNoOrphanStreams) throw new Error("cycling Reference projection produced an orphan stream");
+  if (!hasNoOrphanStreams)
+    throw new Error("cycling Reference projection produced an orphan stream");
   return streams === undefined ? { ...bundle, activities } : { ...bundle, activities, streams };
 }
 
@@ -82,13 +87,15 @@ export function buildFixtureShape(bundle: ReferenceBundle): FixtureShape {
   if (bundle.streams !== undefined) raw.streams = bundle.streams;
   if (bundle.powerCurves !== undefined) raw.power_curves = bundle.powerCurves;
   if (bundle.hrCurves !== undefined) raw.hr_curves = bundle.hrCurves;
-  if (bundle.sustainabilityCurves !== undefined) raw.sustainability_curves = bundle.sustainabilityCurves;
+  if (bundle.sustainabilityCurves !== undefined)
+    raw.sustainability_curves = bundle.sustainabilityCurves;
   if (bundle.athlete !== undefined) raw.athlete = bundle.athlete;
   if (bundle.currentFtpIndoor !== undefined) raw.current_ftp_indoor = bundle.currentFtpIndoor;
   if (bundle.currentFtpOutdoor !== undefined) raw.current_ftp_outdoor = bundle.currentFtpOutdoor;
   if (bundle.ftpHistoryIndoor !== undefined) raw.ftp_history_indoor = bundle.ftpHistoryIndoor;
   if (bundle.ftpHistoryOutdoor !== undefined) raw.ftp_history_outdoor = bundle.ftpHistoryOutdoor;
   if (bundle.eftp !== undefined) raw.eftp = bundle.eftp;
+  if (bundle.pastEvents !== undefined) raw.past_events = [...bundle.pastEvents];
   return FixtureSchema.parse(raw);
 }
 
@@ -112,6 +119,7 @@ export function applyActivityProjectionFilter(
   }
   const retainedIds = new Set(retained.map((activity) => String(activity.id)));
   const streams: Record<string, ActivityStreams> = {};
-  for (const [id, value] of Object.entries(bundle.streams)) if (retainedIds.has(id)) streams[id] = value;
+  for (const [id, value] of Object.entries(bundle.streams))
+    if (retainedIds.has(id)) streams[id] = value;
   return { ...bundle, activities: retained, streams };
 }

--- a/packages/kernel/src/reference/schemas/inputs.ts
+++ b/packages/kernel/src/reference/schemas/inputs.ts
@@ -196,7 +196,8 @@ export const PlannedEventSchema = z.looseObject({
   id: z.number(),
   category: z.string(), // "WORKOUT", "RACE", etc.
   start_date_local: z.string(),
-  name: z.string().optional(),
+  name: z.string().nullable().optional(),
+  type: z.string().nullable().optional(),
 });
 export type PlannedEvent = z.infer<typeof PlannedEventSchema>;
 
@@ -240,9 +241,7 @@ export const SustainabilityFamilyCurvesSchema = z.looseObject({
   power: z.record(z.string(), PowerCurveDataSchema),
   hr: z.record(z.string(), HrCurveDataSchema),
 });
-export type SustainabilityFamilyCurves = z.infer<
-  typeof SustainabilityFamilyCurvesSchema
->;
+export type SustainabilityFamilyCurves = z.infer<typeof SustainabilityFamilyCurvesSchema>;
 
 /** Per-second activity stream channels, keyed by `String(activity.id)`. The
  *  dfa-profile path joins this record back to the activities array (both
@@ -345,9 +344,7 @@ export const FixtureSchema = z
       .record(
         z.string(),
         z.looseObject({
-          intervals: z
-            .array(z.looseObject({ type: z.string() }))
-            .optional(),
+          intervals: z.array(z.looseObject({ type: z.string() })).optional(),
         }),
       )
       .optional(),
@@ -362,9 +359,7 @@ export const FixtureSchema = z
     // snapshots byte-for-byte.
     power_curves: PowerCurveDataSchema.optional(),
     hr_curves: HrCurveDataSchema.optional(),
-    sustainability_curves: z
-      .record(z.string(), SustainabilityFamilyCurvesSchema)
-      .optional(),
+    sustainability_curves: z.record(z.string(), SustainabilityFamilyCurvesSchema).optional(),
     streams: z.record(z.string(), ActivityStreamsSchema).optional(),
     athlete: AthleteSchema.optional(),
   })

--- a/packages/kernel/src/store/index.ts
+++ b/packages/kernel/src/store/index.ts
@@ -12,3 +12,4 @@ export * from "./derived-key.js";
 export * from "./sync-source.js";
 export * from "./sync-state-repository.js";
 export * from "./sync-failure-repository.js";
+export * from "./units-preference-repository.js";

--- a/packages/kernel/src/store/units-preference-repository.ts
+++ b/packages/kernel/src/store/units-preference-repository.ts
@@ -1,0 +1,111 @@
+import type { Row, SqlStore } from "./ports.js";
+
+export type PersistedUnitsPreference = "metric" | "imperial";
+export type UnitsPreferenceSource = "cycling" | "athlete" | "default";
+
+export interface UnitsPreferenceReadResult {
+  readonly value: PersistedUnitsPreference;
+  readonly source: UnitsPreferenceSource;
+}
+
+export interface UnitsPreferenceMutationStamp {
+  readonly id: string;
+  readonly deviceId: string;
+  readonly now: number;
+}
+
+export interface UnitsPreferenceRepository {
+  read(): Promise<UnitsPreferenceReadResult>;
+  set(
+    value: PersistedUnitsPreference,
+    stamp: UnitsPreferenceMutationStamp,
+  ): Promise<{ readonly value: PersistedUnitsPreference; readonly source: "cycling" }>;
+}
+
+const ULID = /^[0-9A-HJKMNP-TV-Z]{26}$/;
+const DEVICE_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+
+function preference(value: unknown, nullable: boolean): PersistedUnitsPreference | null {
+  if (value === "metric" || value === "imperial") return value;
+  if (nullable && value === null) return null;
+  throw new TypeError("Persisted units preference is invalid.");
+}
+
+function exactRows(rows: readonly Row[], maximum: number, label: string): void {
+  if (rows.length > maximum) throw new Error(`${label} row cardinality is invalid.`);
+}
+
+function validateStamp(stamp: UnitsPreferenceMutationStamp): void {
+  if (!ULID.test(stamp.id) || !DEVICE_ID.test(stamp.deviceId)) {
+    throw new TypeError("Units mutation identity is invalid.");
+  }
+  if (!Number.isSafeInteger(stamp.now) || stamp.now < 0) {
+    throw new TypeError("Units mutation time is invalid.");
+  }
+}
+
+export function createUnitsPreferenceRepository(store: SqlStore): UnitsPreferenceRepository {
+  const cyclingRows = (): Promise<Row[]> =>
+    store.all(
+      `SELECT id, sport, session_cluster_conventions_json, preferred_units,
+              activity_type_map_json, device_id, hlc_physical_ms, hlc_counter
+       FROM sport_settings WHERE sport = ?`,
+      ["cycling"],
+    );
+
+  return {
+    async read() {
+      const settings = await cyclingRows();
+      exactRows(settings, 1, "Cycling settings");
+      const athletes = await store.all("SELECT units FROM athlete");
+      exactRows(athletes, 1, "Athlete");
+      if (settings[0] !== undefined) {
+        const value = preference(settings[0].preferred_units, true);
+        if (value !== null) return { value, source: "cycling" };
+      }
+      if (athletes[0] !== undefined) {
+        return {
+          value: preference(athletes[0].units, false) as PersistedUnitsPreference,
+          source: "athlete",
+        };
+      }
+      return { value: "metric", source: "default" };
+    },
+    async set(value, stamp) {
+      preference(value, false);
+      validateStamp(stamp);
+      const settings = await cyclingRows();
+      exactRows(settings, 1, "Cycling settings");
+      const current = settings[0];
+      if (current === undefined) {
+        await store.run(
+          `INSERT INTO sport_settings
+             (id, sport, session_cluster_conventions_json, preferred_units,
+              activity_type_map_json, device_id, hlc_physical_ms, hlc_counter)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+          [stamp.id, "cycling", null, value, null, stamp.deviceId, stamp.now, 0],
+        );
+      } else {
+        if (
+          typeof current.hlc_physical_ms !== "number" ||
+          !Number.isSafeInteger(current.hlc_physical_ms) ||
+          current.hlc_physical_ms < 0 ||
+          typeof current.hlc_counter !== "number" ||
+          !Number.isSafeInteger(current.hlc_counter) ||
+          current.hlc_counter < 0
+        ) {
+          throw new TypeError("Cycling settings stamp is invalid.");
+        }
+        const physical = Math.max(stamp.now, current.hlc_physical_ms);
+        const counter = stamp.now > current.hlc_physical_ms ? 0 : current.hlc_counter + 1;
+        await store.run(
+          `UPDATE sport_settings
+           SET preferred_units = ?, hlc_physical_ms = ?, hlc_counter = ?
+           WHERE id = ? AND sport = ?`,
+          [value, physical, counter, current.id, "cycling"],
+        );
+      }
+      return { value, source: "cycling" };
+    },
+  };
+}

--- a/packages/kernel/tests/reference-local-bundle.test.ts
+++ b/packages/kernel/tests/reference-local-bundle.test.ts
@@ -18,10 +18,33 @@ import type { ActivityProjectionFilter, ReferenceBundle } from "../src/reference
 import { METRIC_REGISTRY } from "../src/reference/metrics/registry.js";
 
 const activities = [
-  { id: "b", start_date_local: "1998-06-05T08:00:00", type: "Ride", moving_time: 1, elapsed_time: 1, icu_training_load: 10 },
-  { id: "a", start_date_local: "1998-06-04T08:00:00", type: "Run", moving_time: 1, elapsed_time: 1, icu_training_load: 10 },
+  {
+    id: "b",
+    start_date_local: "1998-06-05T08:00:00",
+    type: "Ride",
+    moving_time: 1,
+    elapsed_time: 1,
+    icu_training_load: 10,
+  },
+  {
+    id: "a",
+    start_date_local: "1998-06-04T08:00:00",
+    type: "Run",
+    moving_time: 1,
+    elapsed_time: 1,
+    icu_training_load: 10,
+  },
 ] as const;
-const wellness = [{ id: "1998-06-04", weight: null, restingHR: null, hrv: null, sleepSecs: null, sleepQuality: null }];
+const wellness = [
+  {
+    id: "1998-06-04",
+    weight: null,
+    restingHR: null,
+    hrv: null,
+    sleepSecs: null,
+    sleepQuality: null,
+  },
+];
 
 function bundle(streams?: ReferenceBundle["streams"]): ReferenceBundle {
   return {
@@ -44,22 +67,36 @@ describe("kernel local bundle contracts", () => {
     expect(filtered.wellness).toBe(original.wellness);
     expect(filtered.ftpHistory).toBe(original.ftpHistory);
     expect(filtered.athlete).toBe(original.athlete);
-    expect(applyActivityProjectionFilter(bundle({}), KEEP_ALL_ACTIVITIES)).toHaveProperty("streams", {});
-    expect(applyActivityProjectionFilter(bundle(), KEEP_ALL_ACTIVITIES)).not.toHaveProperty("streams");
+    expect(applyActivityProjectionFilter(bundle({}), KEEP_ALL_ACTIVITIES)).toHaveProperty(
+      "streams",
+      {},
+    );
+    expect(applyActivityProjectionFilter(bundle(), KEEP_ALL_ACTIVITIES)).not.toHaveProperty(
+      "streams",
+    );
   });
 
   it("rejects orphan streams before returning a filtered bundle", () => {
-    expect(() => applyActivityProjectionFilter(bundle({ missing: { watts: [] } }), KEEP_ALL_ACTIVITIES))
-      .toThrowError(new TypeError("local bundle contains an orphan stream"));
+    expect(() =>
+      applyActivityProjectionFilter(bundle({ missing: { watts: [] } }), KEEP_ALL_ACTIVITIES),
+    ).toThrowError(new TypeError("local bundle contains an orphan stream"));
   });
 
   it("normalizes only top-level stream keys and fails closed on collisions", () => {
     const nested = { keepCamel: 1 };
-    expect(normalizeStreams({ dfaA1: [1], nestedValue: nested })).toEqual({ dfa_a1: [1], nested_value: nested });
-    expect(normalizeStreams([{ type: "dfa_a1", data: [1, null] }, { type: 3, data: [] }]))
-      .toEqual({ dfa_a1: [1, null] });
-    expect(() => normalizeStreams({ dfaA1: [1], dfa_a1: [1] }))
-      .toThrowError(new TypeError("stream key normalization collision"));
+    expect(normalizeStreams({ dfaA1: [1], nestedValue: nested })).toEqual({
+      dfa_a1: [1],
+      nested_value: nested,
+    });
+    expect(
+      normalizeStreams([
+        { type: "dfa_a1", data: [1, null] },
+        { type: 3, data: [] },
+      ]),
+    ).toEqual({ dfa_a1: [1, null] });
+    expect(() => normalizeStreams({ dfaA1: [1], dfa_a1: [1] })).toThrowError(
+      new TypeError("stream key normalization collision"),
+    );
     const shared = [1];
     expect(normalizeStreams({ dfaA1: shared, dfa_a1: shared })).toEqual({ dfa_a1: shared });
   });
@@ -76,22 +113,30 @@ describe("kernel local bundle contracts", () => {
     const activityJson = canonicalJson({ activity, concerns: {}, dedup: {}, schema_version: 1 });
     expect(parseActivityLandingEnvelope(activityJson).activity).toEqual(activity);
     expect(() => parseActivityLandingEnvelope(`${activityJson}\n`)).toThrow(TypeError);
-    expect(() => parseActivityLandingEnvelope(canonicalJson({ activity, concerns: {}, dedup: {}, extra: 1, schema_version: 1 })))
-      .toThrow(TypeError);
+    expect(() =>
+      parseActivityLandingEnvelope(
+        canonicalJson({ activity, concerns: {}, dedup: {}, extra: 1, schema_version: 1 }),
+      ),
+    ).toThrow(TypeError);
 
     for (const endpoint of ["streams", "settings"] as const) {
       const landing = { value: 1 };
       const envelope = canonicalJson({ endpoint, landing, schema_version: 1 });
       expect(parseGenericLandingEnvelope(envelope, endpoint).landing).toEqual(landing);
-      expect(() => parseGenericLandingEnvelope(envelope, endpoint === "streams" ? "settings" : "streams")).toThrow(TypeError);
+      expect(() =>
+        parseGenericLandingEnvelope(envelope, endpoint === "streams" ? "settings" : "streams"),
+      ).toThrow(TypeError);
     }
     expect(parseCanonicalProjectionValue(canonicalJson(activity), "activity")).toEqual(activity);
-    expect(() => assertProjectionEvidenceEqual({ value: 1 }, { value: 2 }, "activity"))
-      .toThrowError(new TypeError("activity source evidence mismatch"));
+    expect(() =>
+      assertProjectionEvidenceEqual({ value: 1 }, { value: 2 }, "activity"),
+    ).toThrowError(new TypeError("activity source evidence mismatch"));
   });
 
   it("keeps collision-safe rename behavior and omits unsupported fixture extensions", () => {
-    expect(() => renameTpFieldsOnActivity({ id: "a", icu_ctl: 1, fitnessAtEnd: 2 })).toThrow(/collision/);
+    expect(() => renameTpFieldsOnActivity({ id: "a", icu_ctl: 1, fitnessAtEnd: 2 })).toThrow(
+      /collision/,
+    );
     expect(() => assertNoTpKeysRemain({ nested: { ctl: 1 } })).toThrow(/nested\.ctl/);
     const fixture = buildFixtureShape(bundle({}));
     expect(fixture).not.toHaveProperty("power_curves");
@@ -101,9 +146,28 @@ describe("kernel local bundle contracts", () => {
     expect(fixture).not.toHaveProperty("intervals");
   });
 
+  it("carries validated trailing plan events into metric fixture input", () => {
+    const pastEvents = [
+      {
+        id: 10,
+        category: "WORKOUT",
+        start_date_local: "1998-06-04T08:00:00",
+        name: null,
+        type: "Ride",
+      },
+    ];
+    const fixture = buildFixtureShape({ ...bundle(), pastEvents });
+    expect(fixture.past_events).toEqual(pastEvents);
+    expect(fixture.activities).toEqual(activities);
+    expect(fixture.wellness).toEqual(wellness);
+  });
+
   it("preserves equal-Load encounter order for both primary-sport results", () => {
     const forward = buildMetricInput(bundle(), "1998-06-10T12:00:00");
-    const reverse = buildMetricInput({ ...bundle(), activities: [...activities].reverse() }, "1998-06-10T12:00:00");
+    const reverse = buildMetricInput(
+      { ...bundle(), activities: [...activities].reverse() },
+      "1998-06-10T12:00:00",
+    );
     for (const metric of ["seiler_tid_7d_primary", "seiler_tid_28d_primary"] as const) {
       const first = METRIC_REGISTRY[metric]!.compute(forward) as { sport: string };
       const second = METRIC_REGISTRY[metric]!.compute(reverse) as { sport: string };

--- a/packages/kernel/tests/units-preference-repository.test.ts
+++ b/packages/kernel/tests/units-preference-repository.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { openSqliteStorage } from "../../kernel-node/src/sqlite/index.js";
+import { MIGRATIONS } from "../src/store/migrations/index.js";
+import { runMigrations } from "../src/store/migrator.js";
+import { createUnitsPreferenceRepository } from "../src/store/units-preference-repository.js";
+
+let store: ReturnType<typeof openSqliteStorage>;
+
+beforeEach(async () => {
+  store = openSqliteStorage(":memory:");
+  await runMigrations(store, MIGRATIONS);
+});
+
+afterEach(async () => {
+  await store.close();
+});
+
+async function insertAthlete(id: string, units: "metric" | "imperial") {
+  await store.run(
+    `INSERT INTO athlete
+       (id, display_name, birth_year, sex, timezone, units, device_id, hlc_physical_ms, hlc_counter)
+     VALUES (?, NULL, NULL, NULL, NULL, ?, ?, 1, 0)`,
+    [id, units, `device:${id}`],
+  );
+}
+
+async function insertSettings(preferred: string | null) {
+  await store.run(
+    `INSERT INTO sport_settings
+       (id, sport, session_cluster_conventions_json, preferred_units,
+        activity_type_map_json, device_id, hlc_physical_ms, hlc_counter)
+     VALUES (?, 'cycling', ?, ?, ?, ?, ?, ?)`,
+    [
+      "01J00000000000000000000000",
+      '{"gap":30}',
+      preferred,
+      '{"Ride":"ride"}',
+      "device:original",
+      200,
+      4,
+    ],
+  );
+}
+
+describe("units preference repository", () => {
+  it("uses cycling then athlete then metric-default precedence", async () => {
+    const repository = createUnitsPreferenceRepository(store);
+    await expect(repository.read()).resolves.toEqual({ value: "metric", source: "default" });
+    await insertAthlete("01J00000000000000000000001", "imperial");
+    await expect(repository.read()).resolves.toEqual({ value: "imperial", source: "athlete" });
+    await insertSettings("metric");
+    await expect(repository.read()).resolves.toEqual({ value: "metric", source: "cycling" });
+  });
+
+  it("falls back through a null cycling preference", async () => {
+    await insertAthlete("01J00000000000000000000001", "imperial");
+    await insertSettings(null);
+    await expect(createUnitsPreferenceRepository(store).read()).resolves.toEqual({
+      value: "imperial",
+      source: "athlete",
+    });
+  });
+
+  it("inserts a cycling row with the supplied authored stamp", async () => {
+    const repository = createUnitsPreferenceRepository(store);
+    await expect(
+      repository.set("imperial", {
+        id: "01J00000000000000000000002",
+        deviceId: "desktop:01J00000000000000000000002",
+        now: 300,
+      }),
+    ).resolves.toEqual({ value: "imperial", source: "cycling" });
+    await expect(
+      store.get("SELECT * FROM sport_settings WHERE sport = 'cycling'"),
+    ).resolves.toMatchObject({
+      id: "01J00000000000000000000002",
+      preferred_units: "imperial",
+      device_id: "desktop:01J00000000000000000000002",
+      hlc_physical_ms: 300,
+      hlc_counter: 0,
+    });
+  });
+
+  it("updates only preference and HLC fields while preserving authored row identity", async () => {
+    await insertSettings("metric");
+    const before = await store.get("SELECT * FROM sport_settings WHERE sport = 'cycling'");
+    const repository = createUnitsPreferenceRepository(store);
+    await repository.set("imperial", {
+      id: "01J00000000000000000000003",
+      deviceId: "desktop:01J00000000000000000000003",
+      now: 100,
+    });
+    const regressed = await store.get("SELECT * FROM sport_settings WHERE sport = 'cycling'");
+    expect(regressed).toMatchObject({
+      id: before?.id,
+      sport: before?.sport,
+      session_cluster_conventions_json: before?.session_cluster_conventions_json,
+      activity_type_map_json: before?.activity_type_map_json,
+      device_id: before?.device_id,
+      preferred_units: "imperial",
+      hlc_physical_ms: 200,
+      hlc_counter: 5,
+    });
+    await repository.set("metric", {
+      id: "01J00000000000000000000004",
+      deviceId: "desktop:01J00000000000000000000004",
+      now: 400,
+    });
+    await expect(
+      store.get("SELECT * FROM sport_settings WHERE sport = 'cycling'"),
+    ).resolves.toMatchObject({ preferred_units: "metric", hlc_physical_ms: 400, hlc_counter: 0 });
+  });
+
+  it("fails closed for malformed literals and multi-athlete state", async () => {
+    await insertSettings("unsupported");
+    await expect(createUnitsPreferenceRepository(store).read()).rejects.toThrow(
+      "Persisted units preference is invalid.",
+    );
+    await store.run("DELETE FROM sport_settings");
+    await insertAthlete("01J00000000000000000000005", "metric");
+    await insertAthlete("01J00000000000000000000006", "imperial");
+    await expect(createUnitsPreferenceRepository(store).read()).rejects.toThrow(
+      "Athlete row cardinality is invalid.",
+    );
+    await insertSettings("metric");
+    await expect(createUnitsPreferenceRepository(store).read()).rejects.toThrow(
+      "Athlete row cardinality is invalid.",
+    );
+  });
+
+  it("rejects values and authored stamps outside the closed contracts", async () => {
+    const repository = createUnitsPreferenceRepository(store);
+    await expect(
+      repository.set("other" as never, {
+        id: "01J00000000000000000000007",
+        deviceId: "desktop:01J00000000000000000000007",
+        now: 500,
+      }),
+    ).rejects.toThrow();
+    await expect(
+      repository.set("metric", { id: "uuid", deviceId: "desktop:uuid", now: 500 }),
+    ).rejects.toThrow("Units mutation identity is invalid.");
+  });
+});


### PR DESCRIPTION
## Summary

- stream coach responses into the desktop chat pane and reconcile the canonical final response without duplicated text
- add a cycling training-context drawer for the current anchor and zones, platform Load, plan adherence, wellness, and persisted display units
- extend the persisted athlete-state contract so every panel has explicit computed or unknown provenance

## Product boundaries

- macOS and cycling only
- panels read the persisted athlete state; the renderer does not calculate coaching metrics
- no messaging migration, tray-control, or non-macOS workflow

## Verification

- [x] focused contract, projection, chat, and drawer tests
- [x] renderer dependency-boundary proof
- [x] renderer and desktop security regression tests
- [x] `pnpm check`
- [x] `pnpm test`
