### PR TITLE
feat(desktop): add spend meter and soft daily cap

### DIFF
--- a/.changeset/desktop-spend-meter.md
+++ b/.changeset/desktop-spend-meter.md
@@ -1,0 +1,12 @@
+---
+"cycling-coach": patch
+"@enduragent/coach": patch
+"@enduragent/coach-client": patch
+"@enduragent/coach-contract": patch
+"@enduragent/core": patch
+"@enduragent/engine": patch
+---
+
+User-facing: Added an always-visible daily spend meter with cache savings, route-level caching disclosures, and a warning when your chosen cap is reached.
+
+Added provider-reported OpenRouter costs and aggregate authenticated spend methods for the desktop client.

--- a/apps/desktop-renderer/src/chat/controller.ts
+++ b/apps/desktop-renderer/src/chat/controller.ts
@@ -29,6 +29,7 @@ export function createChatController(input: {
   readonly clients: DesktopCoachClientProvider;
   readonly view: ChatView;
   readonly refreshTrainingContext: () => Promise<void>;
+  readonly refreshSpend: () => Promise<void>;
 }): ChatController {
   let state = EMPTY_CHAT_STATE;
   let sequence = 0;
@@ -178,6 +179,9 @@ export function createChatController(input: {
         }
       } finally {
         if (callStarted) {
+          try {
+            void input.refreshSpend().catch(() => {});
+          } catch {}
           try {
             await input.refreshTrainingContext();
           } catch {}

--- a/apps/desktop-renderer/src/chat/view.ts
+++ b/apps/desktop-renderer/src/chat/view.ts
@@ -2,6 +2,7 @@ import type { ChatView } from "./controller.js";
 
 export interface MountedChatView {
   readonly view: ChatView;
+  readonly noticeHost: HTMLElement;
   bind(input: { readonly onSubmit: (message: string) => void; readonly onRetry: () => void }): void;
   dispose(): void;
 }
@@ -32,6 +33,8 @@ export function mountChatView(input: {
   input.composerHost.replaceChildren();
   const form = document.createElement("form");
   form.className = "composer";
+  const noticeHost = document.createElement("div");
+  noticeHost.className = "chat-notice-host";
   const label = document.createElement("label");
   label.className = "chat-composer__label";
   label.htmlFor = "message";
@@ -47,7 +50,7 @@ export function mountChatView(input: {
   submit.textContent = "↑";
   controls.append(textarea, submit);
   form.append(label, controls);
-  input.composerHost.append(form);
+  input.composerHost.append(noticeHost, form);
 
   let handlers:
     | { readonly onSubmit: (message: string) => void; readonly onRetry: () => void }
@@ -74,6 +77,7 @@ export function mountChatView(input: {
   retry.addEventListener("click", onRetry);
 
   return {
+    noticeHost,
     view: {
       render(state) {
         if (disposed) return;
@@ -117,6 +121,7 @@ export function mountChatView(input: {
       form.removeEventListener("submit", onSubmit);
       textarea.removeEventListener("keydown", onKeydown);
       retry.removeEventListener("click", onRetry);
+      noticeHost.remove();
     },
   };
 }

--- a/apps/desktop-renderer/src/index.ts
+++ b/apps/desktop-renderer/src/index.ts
@@ -6,6 +6,7 @@ import {
 import { SaveIntakeRpcParamsSchema } from "@enduragent/coach-contract";
 import "./chat/styles.css";
 import "./training-context/styles.css";
+import "./spend-meter/styles.css";
 import "./onboarding/onboarding.css";
 import { createChatController } from "./chat/controller.js";
 import { mountChatView } from "./chat/view.js";
@@ -15,6 +16,8 @@ import { validateImportPaths, type OnboardingBridge } from "./onboarding/bridge.
 import { mountOnboarding } from "./onboarding/mount.js";
 import { createTrainingContextController } from "./training-context/controller.js";
 import { mountTrainingContextView } from "./training-context/view.js";
+import { createSpendMeterController } from "./spend-meter/controller.js";
+import { createSpendMeterView } from "./spend-meter/view.js";
 
 function one<T extends Element>(selector: string, kind: { new (): T }): T {
   const matches = document.querySelectorAll(selector);
@@ -30,7 +33,7 @@ const composerHost = one(".composer-wrap", HTMLElement);
 const spine = one(".data-spine", HTMLElement);
 const drawer = one(".drawer", HTMLDialogElement);
 const topbar = one(".topbar", HTMLElement);
-one(".spend-meter", HTMLElement);
+const spendRoot = one(".spend-meter", HTMLElement);
 conversation.classList.add("desktop-shell");
 
 const clients = createDesktopCoachClientProvider();
@@ -45,11 +48,16 @@ const trainingContextController = createTrainingContextController({
   view: mountedTrainingContext.view,
 });
 const mountedChat = mountChatView({ conversation, thread, composerHost });
+const spendController = createSpendMeterController({
+  clients,
+  view: createSpendMeterView({ root: spendRoot, noticeHost: mountedChat.noticeHost }),
+});
 const message = one("#message", HTMLTextAreaElement);
 const chatController = createChatController({
   clients,
   view: mountedChat.view,
   refreshTrainingContext: () => trainingContextController.refresh(),
+  refreshSpend: () => spendController.refresh(),
 });
 mountedChat.bind({
   onSubmit: (message) => void chatController.submit(message),
@@ -209,6 +217,7 @@ const onboarding = mountOnboarding({
 setup.addEventListener("click", () => void onboarding.open());
 
 void trainingContextController.start();
+spendController.start();
 void onboarding.open();
 void clients.getClient().then(
   () => {
@@ -225,6 +234,7 @@ window.addEventListener(
     onboarding.dispose();
     firstSyncController.dispose();
     chatController.dispose();
+    spendController.dispose();
     mountedChat.dispose();
     trainingContextController.dispose();
     mountedTrainingContext.dispose();

--- a/apps/desktop-renderer/src/spend-meter/controller.ts
+++ b/apps/desktop-renderer/src/spend-meter/controller.ts
@@ -1,0 +1,126 @@
+import type { SpendSummary } from "@enduragent/coach-contract";
+import type { DesktopCoachClientProvider } from "../coach-client.js";
+
+export const SPEND_REFRESH_INTERVAL_MS = 30_000;
+
+export interface SpendMeterView {
+  renderLoading(): void;
+  renderSummary(summary: SpendSummary, options: { readonly stale: boolean }): void;
+  renderUnavailable(options: { readonly hadSummary: boolean }): void;
+  bindSave(handler: () => void): void;
+  readDailyCapUsd(): number;
+  setSaving(saving: boolean): void;
+  showCapInputError(message: string | null): void;
+  dispose(): void;
+}
+
+export interface SpendMeterController {
+  start(): void;
+  refresh(): Promise<void>;
+  saveDailyCap(): Promise<void>;
+  dispose(): void;
+}
+
+export function createSpendMeterController(input: {
+  readonly clients: DesktopCoachClientProvider;
+  readonly view: SpendMeterView;
+  readonly setInterval?: typeof globalThis.setInterval;
+  readonly clearInterval?: typeof globalThis.clearInterval;
+}): SpendMeterController {
+  const schedule = input.setInterval ?? globalThis.setInterval;
+  const cancel = input.clearInterval ?? globalThis.clearInterval;
+  let started = false;
+  let disposed = false;
+  let hadSummary = false;
+  let interval: ReturnType<typeof globalThis.setInterval> | undefined;
+  let refreshPromise: Promise<void> | undefined;
+  let savePromise: Promise<void> | undefined;
+  let postSaveRefresh: Promise<void> | undefined;
+
+  const executeRefresh = (): Promise<void> => {
+    if (disposed) return Promise.resolve();
+    if (refreshPromise !== undefined) return refreshPromise;
+    const pending = (async () => {
+      try {
+        const client = await input.clients.getClient();
+        const summary = await client.call("getSpendSummary", {});
+        if (disposed) return;
+        hadSummary = true;
+        input.view.renderSummary(summary, { stale: false });
+      } catch {
+        if (!disposed) input.view.renderUnavailable({ hadSummary });
+      }
+    })().finally(() => {
+      if (refreshPromise === pending) refreshPromise = undefined;
+    });
+    refreshPromise = pending;
+    return pending;
+  };
+
+  const refresh = (): Promise<void> => {
+    if (disposed) return Promise.resolve();
+    if (savePromise === undefined) return executeRefresh();
+    if (postSaveRefresh !== undefined) return postSaveRefresh;
+    const activeSave = savePromise;
+    const pending = activeSave
+      .catch(() => {})
+      .then(() => executeRefresh())
+      .finally(() => {
+        if (postSaveRefresh === pending) postSaveRefresh = undefined;
+      });
+    postSaveRefresh = pending;
+    return pending;
+  };
+
+  const saveDailyCap = (): Promise<void> => {
+    if (disposed) return Promise.resolve();
+    if (savePromise !== undefined) return savePromise;
+    const dailyCapUsd = input.view.readDailyCapUsd();
+    if (!Number.isFinite(dailyCapUsd) || dailyCapUsd <= 0) {
+      input.view.showCapInputError("Enter a daily cap greater than $0.");
+      return Promise.resolve();
+    }
+    input.view.showCapInputError(null);
+    input.view.setSaving(true);
+    const olderRefresh = refreshPromise;
+    const pending = (async () => {
+      try {
+        await olderRefresh?.catch(() => {});
+        if (disposed) return;
+        const client = await input.clients.getClient();
+        const summary = await client.call("setDailySpendCap", { dailyCapUsd });
+        if (disposed) return;
+        hadSummary = true;
+        input.view.renderSummary(summary, { stale: false });
+      } catch {
+        if (!disposed) input.view.showCapInputError("The daily cap could not be saved.");
+      } finally {
+        if (!disposed) input.view.setSaving(false);
+      }
+    })().finally(() => {
+      if (savePromise === pending) savePromise = undefined;
+    });
+    savePromise = pending;
+    return pending;
+  };
+
+  return {
+    start() {
+      if (started || disposed) return;
+      started = true;
+      input.view.bindSave(() => void saveDailyCap());
+      input.view.renderLoading();
+      void refresh();
+      interval = schedule(() => void refresh(), SPEND_REFRESH_INTERVAL_MS);
+    },
+    refresh,
+    saveDailyCap,
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      if (interval !== undefined) cancel(interval);
+      interval = undefined;
+      input.view.dispose();
+    },
+  };
+}

--- a/apps/desktop-renderer/src/spend-meter/styles.css
+++ b/apps/desktop-renderer/src/spend-meter/styles.css
@@ -1,0 +1,143 @@
+.spend-meter {
+  position: relative;
+  min-width: 132px;
+}
+
+.spend-meter__details > summary {
+  display: grid;
+  gap: 5px;
+  min-width: 132px;
+  list-style: none;
+  cursor: pointer;
+}
+
+.spend-meter__details > summary::-webkit-details-marker {
+  display: none;
+}
+
+.spend-copy {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+  white-space: nowrap;
+}
+
+.spend-copy strong {
+  margin: 0;
+}
+
+.meter-track {
+  position: relative;
+  display: block;
+  width: 100%;
+  height: 3px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: var(--line);
+}
+
+.meter-fill {
+  display: block;
+  width: 0;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--moss);
+  transition: width 180ms ease;
+}
+
+.spend-meter[data-cap-status="reached"] .meter-fill {
+  background: var(--coral);
+}
+
+.spend-disclosure {
+  position: absolute;
+  z-index: 10;
+  top: calc(100% + 12px);
+  right: 0;
+  width: 360px;
+  max-height: min(620px, calc(100vh - 84px));
+  padding: 18px;
+  overflow: auto;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--surface-solid);
+  box-shadow: 0 18px 50px color-mix(in srgb, var(--ink) 16%, transparent);
+}
+
+.spend-disclosure__day,
+.spend-route__heading {
+  margin: 0;
+  color: var(--ink);
+  font-weight: 700;
+}
+
+.spend-disclosure__messages p,
+.spend-route p {
+  margin: 6px 0 0;
+  line-height: 1.45;
+}
+
+.spend-route {
+  padding: 13px 0;
+  border-bottom: 1px solid var(--line);
+}
+
+.spend-route__caching,
+.spend-route__cache,
+.spend-disclosure__messages {
+  color: var(--muted);
+}
+
+.spend-cap-editor {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 8px;
+  align-items: end;
+  margin-top: 16px;
+}
+
+.spend-cap-editor label,
+.spend-cap-editor__error {
+  grid-column: 1 / -1;
+}
+
+.spend-cap-editor input,
+.spend-cap-editor button {
+  min-width: 0;
+  padding: 8px 10px;
+  border: 1px solid var(--line-strong);
+  border-radius: 10px;
+  color: var(--ink);
+  background: var(--surface);
+}
+
+.spend-cap-editor__error {
+  margin: 0;
+  color: var(--coral);
+}
+
+.chat-notice-host:empty {
+  display: none;
+}
+
+#spend-cap-warning {
+  margin: 0 0 10px;
+  padding: 10px 12px;
+  border-left: 3px solid var(--coral);
+  border-radius: 8px;
+  color: var(--ink);
+  background: var(--surface-soft);
+}
+
+@media (max-width: 720px) {
+  .spend-disclosure {
+    width: min(360px, calc(100vw - 28px));
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .meter-fill {
+    transition-duration: 0.01ms;
+  }
+}

--- a/apps/desktop-renderer/src/spend-meter/view.ts
+++ b/apps/desktop-renderer/src/spend-meter/view.ts
@@ -1,0 +1,219 @@
+import type { SpendRouteSummary, SpendSummary } from "@enduragent/coach-contract";
+import type { SpendMeterView } from "./controller.js";
+
+export const SPEND_METER_TRACK_HEIGHT_PX = 3;
+export const SPEND_DISCLOSURE_WIDTH_PX = 360;
+
+function currency(value: number, detail = false): string {
+  if (value === 0) return "$0.00";
+  if (value > 0 && value < 0.01) {
+    return detail ? `$${value.toFixed(4)}` : "<$0.01";
+  }
+  return `$${value.toFixed(2)}`;
+}
+
+function localDateLabel(value: string): string {
+  const [, month, day] = value.split("-").map(Number);
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  }).format(new Date(Date.UTC(2000, month - 1, day)));
+}
+
+function node<K extends keyof HTMLElementTagNameMap>(name: K, className?: string) {
+  const element = document.createElement(name);
+  if (className !== undefined) element.className = className;
+  return element;
+}
+
+function text<K extends keyof HTMLElementTagNameMap>(name: K, value: string, className?: string) {
+  const element = node(name, className);
+  element.textContent = value;
+  return element;
+}
+
+function routeRow(route: SpendRouteSummary): HTMLElement {
+  const row = node("article", "spend-route");
+  const heading = text("p", `${route.provider} · ${route.model}`, "spend-route__heading");
+  const coverage = text(
+    "p",
+    `${currency(route.knownSpendUsd, true)} · ${route.pricedGenerationCount}/${route.generationCount} generations priced`,
+    "spend-route__coverage",
+  );
+  const cache = text(
+    "p",
+    route.cacheReadTokens === 0
+      ? "No cache reads"
+      : route.cacheReadSavingsUsd === null
+        ? `${route.cacheReadTokens.toLocaleString("en-US")} cache-read tokens · savings unavailable`
+        : `${route.cacheReadTokens.toLocaleString("en-US")} cache-read tokens · Saved ${currency(route.cacheReadSavingsUsd, true)}`,
+    "spend-route__cache",
+  );
+  const caching = text(
+    "p",
+    route.caching === "explicit"
+      ? "Explicit caching on this route."
+      : route.caching === "provider-dependent"
+        ? "Provider-dependent caching; no explicit breakpoint on this route."
+        : (route.disclosure ?? ""),
+    "spend-route__caching",
+  );
+  row.append(heading, coverage, cache, caching);
+  return row;
+}
+
+export function createSpendMeterView(input: {
+  readonly root: HTMLElement;
+  readonly noticeHost: HTMLElement;
+}): SpendMeterView {
+  input.root.replaceChildren();
+  input.root.removeAttribute("aria-label");
+  input.root.classList.add("spend-meter");
+
+  const details = node("details", "spend-meter__details");
+  const summary = node("summary");
+  const copy = node("span", "spend-copy");
+  const label = text("span", "Today’s spend");
+  const amount = text("strong", "—");
+  copy.append(label, amount);
+  const track = node("span", "meter-track");
+  track.setAttribute("role", "progressbar");
+  track.setAttribute("aria-label", "Daily spend cap");
+  track.setAttribute("aria-valuemin", "0");
+  const fill = node("span", "meter-fill");
+  track.append(fill);
+  summary.append(copy, track);
+
+  const disclosure = node("div", "spend-disclosure");
+  disclosure.setAttribute("aria-label", "Spend details");
+  const day = text("p", "Today", "spend-disclosure__day");
+  const messages = node("div", "spend-disclosure__messages");
+  const routes = node("div", "spend-routes");
+  const editor = node("div", "spend-cap-editor");
+  const capLabel = text("label", "Daily cap (USD)");
+  capLabel.htmlFor = "daily-spend-cap";
+  const capInput = node("input");
+  capInput.id = "daily-spend-cap";
+  capInput.type = "number";
+  capInput.step = "any";
+  capInput.inputMode = "decimal";
+  const save = text("button", "Save cap");
+  save.type = "button";
+  const inputError = text("p", "", "spend-cap-editor__error");
+  inputError.setAttribute("role", "status");
+  inputError.hidden = true;
+  editor.append(capLabel, capInput, save, inputError);
+  disclosure.append(day, messages, routes, editor);
+  details.append(summary, disclosure);
+  input.root.append(details);
+
+  const warning = text("p", "");
+  warning.id = "spend-cap-warning";
+  warning.setAttribute("role", "status");
+  warning.setAttribute("aria-live", "polite");
+  warning.hidden = true;
+  input.noticeHost.append(warning);
+
+  let saveHandler: (() => void) | undefined;
+  let disposed = false;
+  let capDirty = false;
+  let lastSummary: SpendSummary | undefined;
+  const onSave = (): void => saveHandler?.();
+  const onCapInput = (): void => {
+    capDirty = true;
+  };
+  save.addEventListener("click", onSave);
+  capInput.addEventListener("input", onCapInput);
+
+  const renderSummary = (spend: SpendSummary, options: { readonly stale: boolean }): void => {
+    if (disposed) return;
+    lastSummary = spend;
+    const known = `${currency(spend.knownSpendUsd)}${spend.spendComplete ? "" : "+"}`;
+    const cap = currency(spend.dailyCapUsd);
+    const ratio = spend.knownSpendUsd / spend.dailyCapUsd;
+    input.root.dataset.capStatus = spend.capStatus;
+    input.root.title = `${Math.round(ratio * 100)}% of today’s language model budget used`;
+    summary.setAttribute("aria-label", `Today's spend: ${known} of ${cap}`);
+    amount.textContent = `${known} / ${cap}`;
+    track.setAttribute("aria-valuemax", String(spend.dailyCapUsd));
+    track.setAttribute("aria-valuenow", String(Math.min(spend.knownSpendUsd, spend.dailyCapUsd)));
+    track.setAttribute("aria-valuetext", `${known} of ${cap}`);
+    fill.style.width = `${Math.min(1, ratio) * 100}%`;
+    day.textContent = `Today · ${localDateLabel(spend.localDate)}`;
+    if (!capDirty || Number(capInput.value) === spend.dailyCapUsd) {
+      capInput.value = String(spend.dailyCapUsd);
+      capDirty = false;
+    }
+    routes.replaceChildren(...spend.routes.map(routeRow));
+    const notices: HTMLElement[] = [];
+    if (!spend.spendComplete) {
+      notices.push(
+        text("p", "Some provider costs are unavailable, so today’s total is a known minimum."),
+      );
+    }
+    if (spend.malformedLineCount > 0) {
+      notices.push(text("p", "Some usage records could not be read."));
+    }
+    notices.push(
+      text(
+        "p",
+        `${spend.cacheSavingsComplete ? "Saved" : "Saved at least"} ${currency(spend.knownCacheReadSavingsUsd, true)} with cache reads`,
+      ),
+    );
+    if (options.stale) notices.push(text("p", "Spend data may be out of date."));
+    messages.replaceChildren(...notices);
+    warning.hidden = spend.capStatus !== "reached";
+    warning.textContent = warning.hidden
+      ? ""
+      : `You’ve reached today’s ${cap} spend cap. You can keep chatting; this is a warning, not a block.`;
+  };
+
+  return {
+    renderLoading() {
+      if (disposed) return;
+      label.textContent = "Today’s spend";
+      amount.textContent = "—";
+      messages.replaceChildren();
+      warning.hidden = true;
+      warning.textContent = "";
+    },
+    renderSummary,
+    renderUnavailable({ hadSummary }) {
+      if (disposed) return;
+      if (hadSummary && lastSummary !== undefined) {
+        renderSummary(lastSummary, { stale: true });
+        return;
+      }
+      label.textContent = "Today’s spend";
+      amount.textContent = "—";
+      input.root.removeAttribute("data-cap-status");
+      summary.setAttribute("aria-label", "Today’s spend is not available yet");
+      messages.replaceChildren(text("p", "Spend data unavailable."));
+      routes.replaceChildren();
+      warning.hidden = true;
+      warning.textContent = "";
+    },
+    bindSave(handler) {
+      saveHandler = handler;
+    },
+    readDailyCapUsd() {
+      return Number(capInput.value);
+    },
+    setSaving(saving) {
+      save.disabled = saving;
+    },
+    showCapInputError(message) {
+      inputError.hidden = message === null;
+      inputError.textContent = message ?? "";
+    },
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      saveHandler = undefined;
+      save.removeEventListener("click", onSave);
+      capInput.removeEventListener("input", onCapInput);
+      warning.remove();
+    },
+  };
+}

--- a/apps/desktop-renderer/tests/chat-controller.test.ts
+++ b/apps/desktop-renderer/tests/chat-controller.test.ts
@@ -71,9 +71,11 @@ function subject(
   first: CoachClient,
   reconnected: CoachClient = first,
   refreshImplementation: () => Promise<void> = async () => {},
+  spendRefreshImplementation: () => Promise<void> = async () => {},
 ) {
   const states: ChatState[] = [];
   const refresh = vi.fn(refreshImplementation);
+  const refreshSpend = vi.fn(spendRefreshImplementation);
   const provider: DesktopCoachClientProvider = {
     getClient: vi.fn(async () => first),
     reconnect: vi.fn(async () => reconnected),
@@ -83,11 +85,29 @@ function subject(
     clients: provider,
     view: { render: (state) => states.push(structuredClone(state)) },
     refreshTrainingContext: refresh,
+    refreshSpend,
   });
-  return { controller, provider, states, refresh };
+  return { controller, provider, states, refresh, refreshSpend };
 }
 
 describe("chat controller", () => {
+  it("does not wait for spend refresh before settling a completed chat", async () => {
+    const gate = new Promise<void>(() => {});
+    const fake = client(async (_request, options) => {
+      deliver(options, { type: "final-text", turnId: "turn-1", text: "Done" });
+      options?.onTerminalEnvelope?.({ jsonrpc: "2.0", id: 1, result: { text: "Done" } });
+      return { text: "Done" };
+    });
+    const { controller, refreshSpend } = subject(
+      fake,
+      fake,
+      async () => {},
+      () => gate,
+    );
+    await expect(controller.submit("Continue")).resolves.toBeUndefined();
+    expect(refreshSpend).toHaveBeenCalledTimes(1);
+  });
+
   it("renders ordered deltas immediately and canonical final text once without turn-start", async () => {
     const fake = client(async (_request, options) => {
       deliver(options, { type: "text_delta", turnId: "turn-1", delta: "Hel" });
@@ -96,7 +116,7 @@ describe("chat controller", () => {
       options?.onTerminalEnvelope?.({ jsonrpc: "2.0", id: 1, result: { text: "Hello." } });
       return { text: "Hello." };
     });
-    const { controller, states, refresh } = subject(fake);
+    const { controller, states, refresh, refreshSpend } = subject(fake);
     await controller.submit("Original message ");
     expect(states.some((state) => state.messages.at(-1)?.text === "Hel")).toBe(true);
     expect(states.at(-1)?.messages.filter((message) => message.text === "Hello.")).toHaveLength(1);
@@ -105,6 +125,7 @@ describe("chat controller", () => {
       { chatId: "desktop", message: "Original message " },
     ]);
     expect(refresh).toHaveBeenCalledTimes(1);
+    expect(refreshSpend).toHaveBeenCalledTimes(1);
   });
 
   it("preserves partial text and the contract athlete message without automatic retry", async () => {
@@ -220,6 +241,7 @@ describe("chat controller", () => {
       clients: provider,
       view: { render: (state) => states.push(structuredClone(state)) },
       refreshTrainingContext: vi.fn(async () => {}),
+      refreshSpend: vi.fn(async () => {}),
     });
     await controller.submit("Same message");
     await controller.retryInterrupted();
@@ -263,6 +285,7 @@ describe("chat controller", () => {
         refreshCalls += 1;
         if (refreshCalls === 1) await refreshGate;
       }),
+      refreshSpend: vi.fn(async () => {}),
     });
     const submission = controller.submit("Same message");
     await interruptedState;

--- a/apps/desktop-renderer/tests/chat-view.test.ts
+++ b/apps/desktop-renderer/tests/chat-view.test.ts
@@ -15,6 +15,7 @@ class FakeElement {
   id = "";
   rows = 0;
   htmlFor = "";
+  removed = false;
   scrollHeight = 0;
   scrollTop = 0;
   clientHeight = 0;
@@ -68,6 +69,10 @@ class FakeElement {
   requestSubmit(): void {
     this.dispatch("submit", { preventDefault() {} });
   }
+
+  remove(): void {
+    this.removed = true;
+  }
 }
 
 class FakeDocument {
@@ -101,6 +106,21 @@ beforeEach(() => {
 });
 
 describe("chat view", () => {
+  it("places one notice host immediately before the composer and removes it on dispose", () => {
+    const composerHost = new FakeElement("div");
+    const mounted = mountChatView({
+      conversation: new FakeElement("main") as never,
+      thread: new FakeElement("div") as never,
+      composerHost: composerHost as never,
+    });
+    const host = mounted.noticeHost as unknown as FakeElement;
+    expect(host.className).toBe("chat-notice-host");
+    expect(composerHost.children[0]).toBe(host);
+    expect(composerHost.children[1]?.className).toBe("composer");
+    mounted.dispose();
+    expect(host.removed).toBe(true);
+  });
+
   it("renders hostile HTML-shaped text literally in the polite log", () => {
     const conversation = new FakeElement("main");
     const thread = new FakeElement("div");

--- a/apps/desktop-renderer/tests/spend-meter.test.ts
+++ b/apps/desktop-renderer/tests/spend-meter.test.ts
@@ -1,0 +1,388 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { CoachClient } from "@enduragent/coach-client";
+import type { SpendSummary } from "@enduragent/coach-contract";
+import type { DesktopCoachClientProvider } from "../src/coach-client.js";
+import {
+  SPEND_REFRESH_INTERVAL_MS,
+  createSpendMeterController,
+  type SpendMeterView,
+} from "../src/spend-meter/controller.js";
+import { createSpendMeterView } from "../src/spend-meter/view.js";
+
+function spend(overrides: Partial<SpendSummary> = {}): SpendSummary {
+  return {
+    localDate: "1998-07-06",
+    timezone: "UTC",
+    dailyCapUsd: 0.5,
+    knownSpendUsd: 0.14,
+    generationCount: 1,
+    pricedGenerationCount: 1,
+    unpricedGenerationCount: 0,
+    malformedLineCount: 0,
+    spendComplete: true,
+    capStatus: "below",
+    cacheReadTokens: 400,
+    knownCacheReadSavingsUsd: 0.03,
+    cacheSavingsComplete: true,
+    routes: [
+      {
+        provider: "anthropic",
+        model: "synthetic-model",
+        generationCount: 1,
+        pricedGenerationCount: 1,
+        unpricedGenerationCount: 0,
+        providerReportedGenerationCount: 0,
+        knownSpendUsd: 0.14,
+        cacheReadTokens: 400,
+        cacheReadSavingsUsd: 0.03,
+        caching: "explicit",
+        disclosure: null,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function provider(call: CoachClient["call"]): DesktopCoachClientProvider {
+  const client = {
+    handshake: {} as CoachClient["handshake"],
+    call,
+    close: vi.fn(async () => {}),
+  } as CoachClient;
+  return {
+    getClient: vi.fn(async () => client),
+    reconnect: vi.fn(async () => client),
+    close: vi.fn(async () => {}),
+  };
+}
+
+function fakeView() {
+  const summaries: Array<{ readonly summary: SpendSummary; readonly stale: boolean }> = [];
+  let saveHandler: (() => void) | undefined;
+  let cap = 0.75;
+  const view: SpendMeterView = {
+    renderLoading: vi.fn(),
+    renderSummary: vi.fn((summary, options) => summaries.push({ summary, stale: options.stale })),
+    renderUnavailable: vi.fn(),
+    bindSave: vi.fn((handler) => {
+      saveHandler = handler;
+    }),
+    readDailyCapUsd: vi.fn(() => cap),
+    setSaving: vi.fn(),
+    showCapInputError: vi.fn(),
+    dispose: vi.fn(),
+  };
+  return {
+    view,
+    summaries,
+    save: () => saveHandler?.(),
+    setCap: (value: number) => {
+      cap = value;
+    },
+  };
+}
+
+interface Deferred<T> {
+  readonly promise: Promise<T>;
+  resolve(value: T): void;
+  reject(error: unknown): void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("spend controller", () => {
+  it("starts once, refreshes immediately and every thirty seconds, and shares an active refresh", async () => {
+    const gate = deferred<SpendSummary>();
+    const call = vi.fn(async () => gate.promise) as unknown as CoachClient["call"];
+    const subject = fakeView();
+    let intervalCallback: (() => void) | undefined;
+    const controller = createSpendMeterController({
+      clients: provider(call),
+      view: subject.view,
+      setInterval: ((callback: () => void, delay: number) => {
+        expect(delay).toBe(SPEND_REFRESH_INTERVAL_MS);
+        intervalCallback = callback;
+        return 1;
+      }) as never,
+      clearInterval: vi.fn() as never,
+    });
+    controller.start();
+    controller.start();
+    const first = controller.refresh();
+    const second = controller.refresh();
+    expect(first).toBe(second);
+    await Promise.resolve();
+    expect(call).toHaveBeenCalledTimes(1);
+    gate.resolve(spend());
+    await first;
+    intervalCallback?.();
+    await Promise.resolve();
+    expect(call).toHaveBeenCalledTimes(2);
+    expect(subject.view.bindSave).toHaveBeenCalledTimes(1);
+    expect(subject.view.renderLoading).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves last-good data as stale and ignores settlement after disposal", async () => {
+    let calls = 0;
+    const late = deferred<SpendSummary>();
+    const call = vi.fn(async () => {
+      calls += 1;
+      if (calls === 1) return spend();
+      if (calls === 2) throw new Error("unavailable");
+      return late.promise;
+    }) as unknown as CoachClient["call"];
+    const subject = fakeView();
+    const clearInterval = vi.fn();
+    const controller = createSpendMeterController({
+      clients: provider(call),
+      view: subject.view,
+      setInterval: (() => 2) as never,
+      clearInterval: clearInterval as never,
+    });
+    controller.start();
+    await controller.refresh();
+    await controller.refresh();
+    expect(subject.view.renderUnavailable).toHaveBeenLastCalledWith({ hadSummary: true });
+    const pending = controller.refresh();
+    controller.dispose();
+    late.resolve(spend({ knownSpendUsd: 0.2 }));
+    await pending;
+    expect(subject.summaries.at(-1)?.summary.knownSpendUsd).toBe(0.14);
+    expect(clearInterval).toHaveBeenCalledWith(2);
+    expect(subject.view.dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it("validates caps locally and coalesces refreshes requested during one save", async () => {
+    const saved = spend({ dailyCapUsd: 0.75 });
+    const calls: string[] = [];
+    const call = vi.fn(async (method: string) => {
+      calls.push(method);
+      return method === "setDailySpendCap" ? saved : spend({ dailyCapUsd: 0.75 });
+    }) as unknown as CoachClient["call"];
+    const subject = fakeView();
+    const controller = createSpendMeterController({
+      clients: provider(call),
+      view: subject.view,
+      setInterval: (() => 1) as never,
+      clearInterval: vi.fn() as never,
+    });
+    controller.start();
+    await controller.refresh();
+    const save = controller.saveDailyCap();
+    const postOne = controller.refresh();
+    const postTwo = controller.refresh();
+    expect(postOne).toBe(postTwo);
+    await Promise.all([save, postOne]);
+    expect(calls.filter((method) => method === "setDailySpendCap")).toHaveLength(1);
+    expect(calls.slice(-2)).toEqual(["setDailySpendCap", "getSpendSummary"]);
+    subject.setCap(0);
+    await controller.saveDailyCap();
+    expect(subject.view.showCapInputError).toHaveBeenLastCalledWith(
+      "Enter a daily cap greater than $0.",
+    );
+  });
+});
+
+class FakeElement {
+  readonly children: FakeElement[] = [];
+  readonly attributes = new Map<string, string>();
+  readonly dataset: Record<string, string> = {};
+  readonly style: Record<string, string> = {};
+  readonly listeners = new Map<string, Set<() => void>>();
+  readonly classList = {
+    add: (value: string) => {
+      const values = new Set(this.className.split(/\s+/u).filter(Boolean));
+      values.add(value);
+      this.className = [...values].join(" ");
+    },
+  };
+  parent: FakeElement | undefined;
+  className = "";
+  hidden = false;
+  disabled = false;
+  value = "";
+  id = "";
+  type = "";
+  step = "";
+  inputMode = "";
+  htmlFor = "";
+  title = "";
+  private ownText = "";
+
+  constructor(readonly tagName: string) {}
+
+  get textContent(): string {
+    return this.ownText + this.children.map((child) => child.textContent).join("");
+  }
+
+  set textContent(value: string) {
+    this.ownText = value;
+    this.children.splice(0);
+  }
+
+  append(...nodes: FakeElement[]): void {
+    for (const child of nodes) {
+      child.parent = this;
+      this.children.push(child);
+    }
+  }
+
+  replaceChildren(...nodes: FakeElement[]): void {
+    this.ownText = "";
+    this.children.splice(0);
+    this.append(...nodes);
+  }
+
+  setAttribute(name: string, value: string): void {
+    this.attributes.set(name, value);
+  }
+
+  removeAttribute(name: string): void {
+    this.attributes.delete(name);
+    if (name.startsWith("data-")) delete this.dataset[name.slice(5)];
+  }
+
+  addEventListener(name: string, listener: () => void): void {
+    const values = this.listeners.get(name) ?? new Set();
+    values.add(listener);
+    this.listeners.set(name, values);
+  }
+
+  removeEventListener(name: string, listener: () => void): void {
+    this.listeners.get(name)?.delete(listener);
+  }
+
+  click(): void {
+    for (const listener of this.listeners.get("click") ?? []) listener();
+  }
+
+  dispatch(name: string): void {
+    for (const listener of this.listeners.get(name) ?? []) listener();
+  }
+
+  remove(): void {
+    if (this.parent === undefined) return;
+    const index = this.parent.children.indexOf(this);
+    if (index >= 0) this.parent.children.splice(index, 1);
+    this.parent = undefined;
+  }
+}
+
+class FakeDocument {
+  createElement(name: string): FakeElement {
+    return new FakeElement(name);
+  }
+}
+
+function find(root: FakeElement, predicate: (value: FakeElement) => boolean): FakeElement {
+  if (predicate(root)) return root;
+  for (const child of root.children) {
+    try {
+      return find(child, predicate);
+    } catch {}
+  }
+  throw new Error("not found");
+}
+
+beforeEach(() => {
+  Object.assign(globalThis, { document: new FakeDocument(), HTMLElement: FakeElement });
+});
+
+describe("spend view", () => {
+  it("renders semantic reached, incomplete, route disclosure, ARIA, and exact warning copy", () => {
+    const root = new FakeElement("div");
+    root.className = "spend-meter";
+    root.setAttribute("aria-label", "Today’s spend is not available yet");
+    const noticeHost = new FakeElement("div");
+    const view = createSpendMeterView({ root: root as never, noticeHost: noticeHost as never });
+    view.renderSummary(
+      spend({
+        dailyCapUsd: 0.1,
+        knownSpendUsd: 0.14,
+        pricedGenerationCount: 1,
+        unpricedGenerationCount: 1,
+        generationCount: 2,
+        malformedLineCount: 1,
+        spendComplete: false,
+        capStatus: "reached",
+        cacheSavingsComplete: false,
+        routes: [
+          {
+            provider: "openrouter",
+            model: "anthropic/synthetic",
+            generationCount: 2,
+            pricedGenerationCount: 1,
+            unpricedGenerationCount: 1,
+            providerReportedGenerationCount: 1,
+            knownSpendUsd: 0.14,
+            cacheReadTokens: 400,
+            cacheReadSavingsUsd: null,
+            caching: "unavailable",
+            disclosure: "caching unavailable on this route",
+          },
+        ],
+      }),
+      { stale: true },
+    );
+    expect(root.dataset.capStatus).toBe("reached");
+    expect(root.textContent).toContain("$0.14+ / $0.10");
+    expect(root.textContent).toContain(
+      "Some provider costs are unavailable, so today’s total is a known minimum.",
+    );
+    expect(root.textContent).toContain("Some usage records could not be read.");
+    expect(root.textContent).toContain("Spend data may be out of date.");
+    expect(root.textContent).toContain("caching unavailable on this route");
+    const progress = find(root, (element) => element.attributes.get("role") === "progressbar");
+    expect(progress.attributes.get("aria-valuemax")).toBe("0.1");
+    expect(progress.attributes.get("aria-valuenow")).toBe("0.1");
+    expect(progress.attributes.get("aria-valuetext")).toBe("$0.14+ of $0.10");
+    const warning = find(noticeHost, (element) => element.id === "spend-cap-warning");
+    expect(warning.hidden).toBe(false);
+    expect(warning.textContent).toBe(
+      "You’ve reached today’s $0.10 spend cap. You can keep chatting; this is a warning, not a block.",
+    );
+  });
+
+  it("renders unavailable state, validates the visible cap editor, and removes only its warning", () => {
+    const root = new FakeElement("div");
+    const noticeHost = new FakeElement("div");
+    const preserved = new FakeElement("p");
+    preserved.textContent = "preserved";
+    noticeHost.append(preserved);
+    const view = createSpendMeterView({ root: root as never, noticeHost: noticeHost as never });
+    view.renderUnavailable({ hadSummary: false });
+    expect(root.textContent).toContain("Spend data unavailable.");
+    expect(root.textContent).toContain("Daily cap (USD)");
+    const input = find(root, (element) => element.id === "daily-spend-cap");
+    input.value = "0.25";
+    expect(view.readDailyCapUsd()).toBe(0.25);
+    view.dispose();
+    expect(noticeHost.textContent).toBe("preserved");
+  });
+
+  it("preserves a dirty cap edit across refresh and reconciles the committed value", () => {
+    const root = new FakeElement("div");
+    const view = createSpendMeterView({
+      root: root as never,
+      noticeHost: new FakeElement("div") as never,
+    });
+    view.renderSummary(spend(), { stale: false });
+    const input = find(root, (element) => element.id === "daily-spend-cap");
+    input.value = "0.75";
+    input.dispatch("input");
+    view.renderSummary(spend({ knownSpendUsd: 0.2 }), { stale: false });
+    expect(input.value).toBe("0.75");
+    view.renderSummary(spend({ dailyCapUsd: 0.75 }), { stale: false });
+    expect(input.value).toBe("0.75");
+    view.renderSummary(spend({ dailyCapUsd: 0.5 }), { stale: false });
+    expect(input.value).toBe("0.5");
+  });
+});

--- a/apps/desktop/tests/helpers/desktop-fixture.ts
+++ b/apps/desktop/tests/helpers/desktop-fixture.ts
@@ -9,6 +9,7 @@ import { createRequire } from "node:module";
 import type {
   CoachEngine,
   CoachOperations,
+  SpendOperations,
   OperationProgressEvent,
   TurnEvent,
 } from "@enduragent/coach-contract";
@@ -324,9 +325,22 @@ export async function launchDesktopFixture(input: {
       };
     },
   };
+  const spend: SpendOperations = {
+    async getSpendSummary(request) {
+      return finalFrame(await invoke("getSpendSummary", request)) as Awaited<
+        ReturnType<SpendOperations["getSpendSummary"]>
+      >;
+    },
+    async setDailySpendCap(request) {
+      return finalFrame(await invoke("setDailySpendCap", request)) as Awaited<
+        ReturnType<SpendOperations["setDailySpendCap"]>
+      >;
+    },
+  };
   const rpc = createCoachRpcServer({
     engine,
     operations,
+    spend,
     token: input.token,
     owner: "unmanaged-foreground",
   });

--- a/apps/desktop/tests/spend-meter.integration.test.ts
+++ b/apps/desktop/tests/spend-meter.integration.test.ts
@@ -1,0 +1,391 @@
+import { createServer } from "node:net";
+import { mkdtemp, readFile, realpath, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  launchDesktopFixture,
+  type DesktopFixtureScript,
+  type RunningDesktopFixture,
+} from "./helpers/desktop-fixture.js";
+
+const hasLoopback = await new Promise<boolean>((resolveAvailability) => {
+  const server = createServer();
+  server.once("error", () => resolveAvailability(false));
+  server.listen({ host: "127.0.0.1", port: 0 }, () => {
+    server.close(() => resolveAvailability(true));
+  });
+});
+
+const token = "s".repeat(43);
+const fixtures: RunningDesktopFixture[] = [];
+const scratch: string[] = [];
+
+interface ScriptRequest {
+  readonly jsonrpc: "2.0";
+  readonly method: string;
+  readonly params: unknown;
+}
+
+function response(value: unknown): readonly string[] {
+  return [JSON.stringify(value)];
+}
+
+function summary(dailyCapUsd = 0.5) {
+  return {
+    localDate: "1998-07-06",
+    timezone: "UTC",
+    dailyCapUsd,
+    knownSpendUsd: 0.6,
+    generationCount: 2,
+    pricedGenerationCount: 1,
+    unpricedGenerationCount: 1,
+    malformedLineCount: 1,
+    spendComplete: false,
+    capStatus: 0.6 >= dailyCapUsd ? "reached" : "unknown",
+    cacheReadTokens: 400,
+    knownCacheReadSavingsUsd: 0,
+    cacheSavingsComplete: false,
+    routes: [
+      {
+        provider: "openrouter",
+        model: "anthropic/synthetic",
+        generationCount: 2,
+        pricedGenerationCount: 1,
+        unpricedGenerationCount: 1,
+        providerReportedGenerationCount: 1,
+        knownSpendUsd: 0.6,
+        cacheReadTokens: 400,
+        cacheReadSavingsUsd: null,
+        caching: "unavailable",
+        disclosure: "caching unavailable on this route",
+      },
+    ],
+  } as const;
+}
+
+function completeSummary(dailyCapUsd = 0.5) {
+  return {
+    localDate: "1998-07-06",
+    timezone: "UTC",
+    dailyCapUsd,
+    knownSpendUsd: 0.14,
+    generationCount: 1,
+    pricedGenerationCount: 1,
+    unpricedGenerationCount: 0,
+    malformedLineCount: 0,
+    spendComplete: true,
+    capStatus: 0.14 >= dailyCapUsd ? "reached" : "below",
+    cacheReadTokens: 400,
+    knownCacheReadSavingsUsd: 0.03,
+    cacheSavingsComplete: true,
+    routes: [
+      {
+        provider: "openrouter",
+        model: "openai/synthetic",
+        generationCount: 1,
+        pricedGenerationCount: 1,
+        unpricedGenerationCount: 0,
+        providerReportedGenerationCount: 1,
+        knownSpendUsd: 0.14,
+        cacheReadTokens: 400,
+        cacheReadSavingsUsd: 0.03,
+        caching: "provider-dependent",
+        disclosure: null,
+      },
+    ],
+  } as const;
+}
+
+function script(calls: ScriptRequest[], initial: "reached" | "complete") {
+  let cap = 0.5;
+  let complete = initial === "complete";
+  let spendAvailable = true;
+  const fixture: DesktopFixtureScript = {
+    onRequest(value) {
+      const request = value as ScriptRequest;
+      calls.push(request);
+      if (request.method === "getSpendSummary") {
+        if (!spendAvailable) throw new Error("synthetic spend failure");
+        return response(complete ? completeSummary(cap) : summary(cap));
+      }
+      if (request.method === "setDailySpendCap") {
+        cap = (request.params as { readonly dailyCapUsd: number }).dailyCapUsd;
+        complete = false;
+        return response(summary(cap));
+      }
+      if (request.method === "getAthleteState") {
+        return response({
+          schemaVersion: "1",
+          lastUpdated: "1998-07-06T08:00:00.000Z",
+          freshness: "fresh",
+          degraded: false,
+          lastSynced: null,
+          athleteProfile: {},
+          currentStatus: {},
+          derivedMetrics: {},
+          recentActivities: [],
+          plannedWorkouts: [],
+          wellness: {},
+        });
+      }
+      if (request.method === "getUnitsPreference") {
+        return response({ value: "metric", source: "default" });
+      }
+      if (request.method === "setUnitsPreference") {
+        return response({ value: "metric", source: "cycling" });
+      }
+      if (request.method === "chat") {
+        return [
+          JSON.stringify({ type: "text_delta", turnId: "turn-spend", delta: "Keep " }),
+          JSON.stringify({ type: "final-text", turnId: "turn-spend", text: "Keep riding." }),
+          JSON.stringify({ text: "Keep riding." }),
+        ];
+      }
+      if (request.method === "sync") {
+        return response({
+          schemaVersion: 1,
+          published: false,
+          referenceSucceeded: true,
+          requests: { store: 0, reference: 0, total: 0 },
+        });
+      }
+      if (request.method === "hasSession") return response({ hasSession: false });
+      if (request.method === "resetSession") return response({ memoryFlushed: true });
+      if (request.method === "importFiles") {
+        return response({
+          schemaVersion: 1,
+          files: { total: 1, imported: 1, quarantined: 0 },
+          changes: {
+            rawFilesInserted: 1,
+            sourceRecordsInserted: 1,
+            sourceRecordsUpdated: 0,
+            relinkedSourceRecords: 0,
+          },
+        });
+      }
+      if (request.method === "saveIntake") return response({ schemaVersion: 1, saved: true });
+      if (request.method === "configureRuntime") {
+        return response({ schemaVersion: 1, applied: { llm: true, intervals: true } });
+      }
+      throw new TypeError(`unexpected fixture method ${request.method}`);
+    },
+  };
+  return {
+    fixture,
+    failSpend() {
+      spendAvailable = false;
+    },
+  };
+}
+
+async function launch(initial: "reached" | "complete" = "reached") {
+  const calls: ScriptRequest[] = [];
+  const scripted = script(calls, initial);
+  const fixture = await launchDesktopFixture({
+    script: scripted.fixture,
+    token,
+    width: 1440,
+    height: 900,
+    colorScheme: "light",
+    reducedMotion: false,
+  });
+  fixtures.push(fixture);
+  await fixture.evaluate<void>(`
+    const deadline = Date.now() + 10000;
+    while ((document.documentElement.dataset.rpc !== "connected" || document.querySelector(".spend-copy strong")?.textContent !== "$0.60+ / $0.50") && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+    document.querySelector(".onboarding")?.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+  `);
+  return { fixture, calls, failSpend: scripted.failSpend };
+}
+
+afterEach(async () => {
+  await Promise.all(fixtures.splice(0).map((fixture) => fixture.close()));
+  await Promise.all(scratch.splice(0).map((path) => rm(path, { recursive: true, force: true })));
+});
+
+describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop spend meter", () => {
+  it("keeps the anchored rail visible at both viewport bands and never blocks reached-cap chat", async () => {
+    const { fixture, calls } = await launch();
+    const desktop = await fixture.evaluate<{
+      readonly visible: boolean;
+      readonly trackHeight: number;
+      readonly warning: string;
+      readonly disclosure: string;
+      readonly overflow: boolean;
+      readonly composerDisabled: boolean;
+      readonly submitDisabled: boolean;
+      readonly final: string;
+    }>(`
+      const details = document.querySelector(".spend-meter__details");
+      details.open = true;
+      const textarea = document.querySelector("#message");
+      const submit = textarea.closest("form").querySelector('button[type="submit"]');
+      const before = {
+        visible: document.querySelector(".spend-meter").getBoundingClientRect().width >= 132,
+        trackHeight: document.querySelector(".meter-track").getBoundingClientRect().height,
+        warning: document.querySelector("#spend-cap-warning").textContent,
+        disclosure: document.querySelector(".spend-disclosure").textContent,
+        overflow: document.documentElement.scrollWidth > document.documentElement.clientWidth,
+        composerDisabled: textarea.disabled,
+        submitDisabled: submit.disabled,
+      };
+      textarea.value = "Can I keep chatting?";
+      textarea.closest("form").requestSubmit();
+      const deadline = Date.now() + 5000;
+      let final = "";
+      while (final !== "Keep riding." && Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        final = document.querySelector(".chat-message--coach .chat-message__text")?.textContent ?? "";
+      }
+      return { ...before, final };
+    `);
+    expect(desktop.visible).toBe(true);
+    expect(desktop.trackHeight).toBe(3);
+    expect(desktop.warning).toBe(
+      "You’ve reached today’s $0.50 spend cap. You can keep chatting; this is a warning, not a block.",
+    );
+    expect(desktop.disclosure).toContain("Some provider costs are unavailable");
+    expect(desktop.disclosure).toContain("caching unavailable on this route");
+    expect(desktop.overflow).toBe(false);
+    expect(desktop.composerDisabled).toBe(false);
+    expect(desktop.submitDisabled).toBe(false);
+    expect(desktop.final).toBe("Keep riding.");
+    expect(calls.filter((call) => call.method === "chat")).toHaveLength(1);
+    await vi.waitFor(() =>
+      expect(calls.filter((call) => call.method === "getSpendSummary").length).toBeGreaterThan(1),
+    );
+
+    await fixture.setViewport(720, 900);
+    const narrow = await fixture.evaluate<{
+      readonly visible: boolean;
+      readonly overflow: boolean;
+    }>(`
+      return {
+        visible: document.querySelector(".spend-meter").getBoundingClientRect().width >= 132,
+        overflow: document.documentElement.scrollWidth > document.documentElement.clientWidth,
+      };
+    `);
+    expect(narrow).toEqual({ visible: true, overflow: false });
+  });
+
+  it("preserves the five-key bridge, training-data drawer, hardened renderer, and token containment", async () => {
+    const { fixture } = await launch();
+    const screenshotRoot = await mkdtemp(join(await realpath(tmpdir()), "spend-shot-"));
+    scratch.push(screenshotRoot);
+    const screenshot = join(screenshotRoot, "spend.png");
+    await fixture.screenshot(screenshot);
+    const state = await fixture.evaluate<{
+      readonly bridgeKeys: readonly string[];
+      readonly drawer: boolean;
+      readonly node: string;
+      readonly location: string;
+      readonly dom: string;
+    }>(`
+      return {
+        bridgeKeys: Object.keys(window.enduragentAuth).sort(),
+        drawer: document.querySelectorAll('.drawer[aria-label="Training data"]').length === 1,
+        node: typeof process + ":" + typeof require,
+        location: location.href,
+        dom: document.documentElement.outerHTML,
+      };
+    `);
+    expect(state.bridgeKeys).toEqual([
+      "chooseImportFiles",
+      "credentialStatuses",
+      "getDaemonConnection",
+      "onDroppedImportFiles",
+      "writeCredential",
+    ]);
+    expect(state.drawer).toBe(true);
+    expect(state.node).toBe("undefined:undefined");
+    expect(state.location).toBe("enduragent://app/index.html");
+    for (const surface of [
+      state.location,
+      state.dom,
+      fixture.readCapturedSurface("console"),
+      fixture.readCapturedSurface("stdout"),
+      fixture.readCapturedSurface("stderr"),
+      fixture.readCapturedSurface("dom"),
+      (await readFile(screenshot)).toString("latin1"),
+    ]) {
+      expect(surface).not.toContain(token);
+    }
+    await expect(fixture.close()).resolves.toEqual({ livePids: [], listenerCount: 0 });
+  });
+
+  it("renders complete and provider-dependent details, saves an unknown cap, and preserves it as stale", async () => {
+    const { fixture, calls, failSpend } = await launch("complete");
+    const complete = await fixture.evaluate<{
+      readonly amount: string;
+      readonly status: string;
+      readonly warningHidden: boolean;
+      readonly disclosure: string;
+    }>(`
+      document.querySelector(".spend-meter__details").open = true;
+      return {
+        amount: document.querySelector(".spend-copy strong").textContent,
+        status: document.querySelector(".spend-meter").dataset.capStatus,
+        warningHidden: document.querySelector("#spend-cap-warning").hidden,
+        disclosure: document.querySelector(".spend-disclosure").textContent,
+      };
+    `);
+    expect(complete).toMatchObject({
+      amount: "$0.14 / $0.50",
+      status: "below",
+      warningHidden: true,
+    });
+    expect(complete.disclosure).toContain(
+      "Provider-dependent caching; no explicit breakpoint on this route.",
+    );
+
+    const saved = await fixture.evaluate<{
+      readonly amount: string;
+      readonly status: string;
+      readonly warningHidden: boolean;
+      readonly disclosure: string;
+    }>(`
+      const cap = document.querySelector("#daily-spend-cap");
+      cap.value = "0.75";
+      cap.dispatchEvent(new Event("input", { bubbles: true }));
+      document.querySelector(".spend-cap-editor button").click();
+      const deadline = Date.now() + 5000;
+      while (document.querySelector(".spend-meter").dataset.capStatus !== "unknown" && Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+      return {
+        amount: document.querySelector(".spend-copy strong").textContent,
+        status: document.querySelector(".spend-meter").dataset.capStatus,
+        warningHidden: document.querySelector("#spend-cap-warning").hidden,
+        disclosure: document.querySelector(".spend-disclosure").textContent,
+      };
+    `);
+    expect(saved).toMatchObject({
+      amount: "$0.60+ / $0.75",
+      status: "unknown",
+      warningHidden: true,
+    });
+    expect(saved.disclosure).toContain(
+      "Some provider costs are unavailable, so today’s total is a known minimum.",
+    );
+    expect(calls.filter((call) => call.method === "setDailySpendCap")).toEqual([
+      expect.objectContaining({ params: { dailyCapUsd: 0.75 } }),
+    ]);
+
+    failSpend();
+    const stale = await fixture.evaluate<string>(`
+      const textarea = document.querySelector("#message");
+      textarea.value = "Refresh the spend display";
+      textarea.closest("form").requestSubmit();
+      const deadline = Date.now() + 5000;
+      while (!document.querySelector(".spend-disclosure").textContent.includes("Spend data may be out of date.") && Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+      return document.querySelector(".spend-disclosure").textContent;
+    `);
+    expect(stale).toContain("Spend data may be out of date.");
+    expect(calls.filter((call) => call.method === "chat")).toHaveLength(1);
+  }, 15_000);
+});

--- a/packages/coach-client/tests/client.test.ts
+++ b/packages/coach-client/tests/client.test.ts
@@ -441,6 +441,40 @@ describe("handshake failures", () => {
 });
 
 describe("RPC receive and observers", () => {
+  it("rejects a contradictory spend response before typed delivery", async () => {
+    const { socket, connecting } = acceptedSocket();
+    const client = await connecting;
+    socket.closeSynchronously = true;
+    socket.sendHook = (text) => {
+      const request = JSON.parse(text) as { readonly id: number };
+      socket.emitMessage(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: request.id,
+          result: {
+            localDate: "1998-07-06",
+            timezone: "UTC",
+            dailyCapUsd: 0.5,
+            knownSpendUsd: 0.1,
+            generationCount: 0,
+            pricedGenerationCount: 0,
+            unpricedGenerationCount: 0,
+            malformedLineCount: 0,
+            spendComplete: true,
+            capStatus: "below",
+            cacheReadTokens: 0,
+            knownCacheReadSavingsUsd: 0,
+            cacheSavingsComplete: true,
+            routes: [],
+          },
+        }),
+      );
+    };
+    await expect(client.call("getSpendSummary", {})).rejects.toBeInstanceOf(
+      CoachClientProtocolError,
+    );
+  });
+
   it("exercises all methods with monotonic strict requests and parsed results", async () => {
     const received: unknown[] = [];
     const { socket, connecting } = acceptedSocket();
@@ -486,6 +520,38 @@ describe("RPC receive and observers", () => {
         configureRuntime: { schemaVersion: 1, applied: { llm: true, intervals: false } },
         getUnitsPreference: { value: "metric", source: "default" },
         setUnitsPreference: { value: "imperial", source: "cycling" },
+        getSpendSummary: {
+          localDate: "1998-07-06",
+          timezone: "UTC",
+          dailyCapUsd: 0.5,
+          knownSpendUsd: 0,
+          generationCount: 0,
+          pricedGenerationCount: 0,
+          unpricedGenerationCount: 0,
+          malformedLineCount: 0,
+          spendComplete: true,
+          capStatus: "below",
+          cacheReadTokens: 0,
+          knownCacheReadSavingsUsd: 0,
+          cacheSavingsComplete: true,
+          routes: [],
+        },
+        setDailySpendCap: {
+          localDate: "1998-07-06",
+          timezone: "UTC",
+          dailyCapUsd: 0.75,
+          knownSpendUsd: 0,
+          generationCount: 0,
+          pricedGenerationCount: 0,
+          unpricedGenerationCount: 0,
+          malformedLineCount: 0,
+          spendComplete: true,
+          capStatus: "below",
+          cacheReadTokens: 0,
+          knownCacheReadSavingsUsd: 0,
+          cacheSavingsComplete: true,
+          routes: [],
+        },
       };
       socket.emitMessage(
         serializeCoachRpcEnvelope({
@@ -547,6 +613,17 @@ describe("RPC receive and observers", () => {
     expect(received.slice(-2).map((value) => (value as { method: string }).method)).toEqual([
       "getUnitsPreference",
       "setUnitsPreference",
+    ]);
+    await expect(client.call("getSpendSummary", {})).resolves.toMatchObject({
+      dailyCapUsd: 0.5,
+    });
+    await expect(client.call("setDailySpendCap", { dailyCapUsd: 0.75 })).resolves.toMatchObject({
+      dailyCapUsd: 0.75,
+    });
+    expect(received.slice(-2).map((value) => (value as { id: number }).id)).toEqual([11, 12]);
+    expect(received.slice(-2).map((value) => (value as { method: string }).method)).toEqual([
+      "getSpendSummary",
+      "setDailySpendCap",
     ]);
     socket.closeSynchronously = true;
     await client.close();

--- a/packages/coach-contract/src/index.ts
+++ b/packages/coach-contract/src/index.ts
@@ -4,4 +4,5 @@ export * from "./turn-event.js";
 export * from "./athlete-state.js";
 export * from "./engine.js";
 export * from "./rpc.js";
+export * from "./spend.js";
 export * from "./handshake.js";

--- a/packages/coach-contract/src/rpc.ts
+++ b/packages/coach-contract/src/rpc.ts
@@ -10,6 +10,12 @@ import {
   type CoachEngine,
 } from "./engine.js";
 import { TurnEventSchema } from "./turn-event.js";
+import {
+  GetSpendSummaryRpcParamsSchema,
+  SetDailySpendCapRpcParamsSchema,
+  SpendSummarySchema,
+  type SpendOperations,
+} from "./spend.js";
 
 export const JsonValueSchema = z.json();
 export type JsonValue = z.infer<typeof JsonValueSchema>;
@@ -112,6 +118,8 @@ export const COACH_RPC_METHOD_NAMES = [
   "configureRuntime",
   "getUnitsPreference",
   "setUnitsPreference",
+  "getSpendSummary",
+  "setDailySpendCap",
 ] as const satisfies readonly (keyof CoachRpcService)[];
 
 export const CoachRpcMethodNameSchema = z.enum(COACH_RPC_METHOD_NAMES);
@@ -362,7 +370,7 @@ export interface CoachOperations {
   setUnitsPreference?(request: SetUnitsPreferenceRpcParams): Promise<SetUnitsPreferenceRpcResult>;
 }
 
-export type CoachRpcService = CoachEngine & CoachOperations;
+export type CoachRpcService = CoachEngine & CoachOperations & SpendOperations;
 
 export const CoachRpcRequestEnvelopeSchema = z.discriminatedUnion("method", [
   z
@@ -443,6 +451,22 @@ export const CoachRpcRequestEnvelopeSchema = z.discriminatedUnion("method", [
       id: JsonRpcIdSchema,
       method: z.literal("setUnitsPreference"),
       params: SetUnitsPreferenceRpcParamsSchema,
+    })
+    .strict(),
+  z
+    .object({
+      jsonrpc: z.literal("2.0"),
+      id: JsonRpcIdSchema,
+      method: z.literal("getSpendSummary"),
+      params: GetSpendSummaryRpcParamsSchema,
+    })
+    .strict(),
+  z
+    .object({
+      jsonrpc: z.literal("2.0"),
+      id: JsonRpcIdSchema,
+      method: z.literal("setDailySpendCap"),
+      params: SetDailySpendCapRpcParamsSchema,
     })
     .strict(),
 ]);
@@ -588,6 +612,18 @@ export const COACH_RPC_METHOD_REGISTRY = {
     wireName: "setUnitsPreference",
     requestSchema: SetUnitsPreferenceRpcParamsSchema,
     responseSchema: SetUnitsPreferenceRpcResultSchema,
+    eventSchema: NoRpcEventSchema,
+  },
+  getSpendSummary: {
+    wireName: "getSpendSummary",
+    requestSchema: GetSpendSummaryRpcParamsSchema,
+    responseSchema: SpendSummarySchema,
+    eventSchema: NoRpcEventSchema,
+  },
+  setDailySpendCap: {
+    wireName: "setDailySpendCap",
+    requestSchema: SetDailySpendCapRpcParamsSchema,
+    responseSchema: SpendSummarySchema,
     eventSchema: NoRpcEventSchema,
   },
 } as const satisfies CoachRpcMethodRegistryShape;

--- a/packages/coach-contract/src/spend.ts
+++ b/packages/coach-contract/src/spend.ts
@@ -1,0 +1,152 @@
+import { z } from "zod";
+
+export const CACHING_UNAVAILABLE_DISCLOSURE = "caching unavailable on this route" as const;
+
+export const SpendCachingSchema = z.enum(["explicit", "provider-dependent", "unavailable"]);
+export type SpendCaching = z.infer<typeof SpendCachingSchema>;
+
+export const SpendCapStatusSchema = z.enum(["below", "reached", "unknown"]);
+export type SpendCapStatus = z.infer<typeof SpendCapStatusSchema>;
+
+export const SpendRouteSummarySchema = z
+  .object({
+    provider: z.string().min(1),
+    model: z.string().min(1),
+    generationCount: z.number().int().nonnegative(),
+    pricedGenerationCount: z.number().int().nonnegative(),
+    unpricedGenerationCount: z.number().int().nonnegative(),
+    providerReportedGenerationCount: z.number().int().nonnegative(),
+    knownSpendUsd: z.number().finite().nonnegative(),
+    cacheReadTokens: z.number().int().nonnegative(),
+    cacheReadSavingsUsd: z.number().finite().nonnegative().nullable(),
+    caching: SpendCachingSchema,
+    disclosure: z.literal(CACHING_UNAVAILABLE_DISCLOSURE).nullable(),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    if (value.pricedGenerationCount + value.unpricedGenerationCount !== value.generationCount) {
+      context.addIssue({
+        code: "custom",
+        path: ["generationCount"],
+        message: "route generation counts must balance",
+      });
+    }
+    if (value.providerReportedGenerationCount > value.pricedGenerationCount) {
+      context.addIssue({
+        code: "custom",
+        path: ["providerReportedGenerationCount"],
+        message: "provider-reported generations must be priced",
+      });
+    }
+    const unavailable = value.caching === "unavailable";
+    const disclosed = value.disclosure === CACHING_UNAVAILABLE_DISCLOSURE;
+    if (unavailable !== disclosed) {
+      context.addIssue({
+        code: "custom",
+        path: ["disclosure"],
+        message: "cache disclosure must match route availability",
+      });
+    }
+  });
+export type SpendRouteSummary = z.infer<typeof SpendRouteSummarySchema>;
+
+export const SpendSummarySchema = z
+  .object({
+    localDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/u),
+    timezone: z.string().min(1),
+    dailyCapUsd: z.number().finite().positive(),
+    knownSpendUsd: z.number().finite().nonnegative(),
+    generationCount: z.number().int().nonnegative(),
+    pricedGenerationCount: z.number().int().nonnegative(),
+    unpricedGenerationCount: z.number().int().nonnegative(),
+    malformedLineCount: z.number().int().nonnegative(),
+    spendComplete: z.boolean(),
+    capStatus: SpendCapStatusSchema,
+    cacheReadTokens: z.number().int().nonnegative(),
+    knownCacheReadSavingsUsd: z.number().finite().nonnegative(),
+    cacheSavingsComplete: z.boolean(),
+    routes: z.array(SpendRouteSummarySchema),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    const generationCount = value.routes.reduce((sum, route) => sum + route.generationCount, 0);
+    const pricedGenerationCount = value.routes.reduce(
+      (sum, route) => sum + route.pricedGenerationCount,
+      0,
+    );
+    const unpricedGenerationCount = value.routes.reduce(
+      (sum, route) => sum + route.unpricedGenerationCount,
+      0,
+    );
+    const knownSpendUsd = value.routes.reduce((sum, route) => sum + route.knownSpendUsd, 0);
+    const cacheReadTokens = value.routes.reduce((sum, route) => sum + route.cacheReadTokens, 0);
+    const knownCacheReadSavingsUsd = value.routes.reduce(
+      (sum, route) => sum + (route.cacheReadSavingsUsd ?? 0),
+      0,
+    );
+    const cacheSavingsComplete =
+      value.malformedLineCount === 0 &&
+      value.routes.every((route) => route.cacheReadSavingsUsd !== null);
+    const spendComplete = value.unpricedGenerationCount === 0 && value.malformedLineCount === 0;
+    const capStatus =
+      value.knownSpendUsd >= value.dailyCapUsd ? "reached" : spendComplete ? "below" : "unknown";
+    const aggregateChecks: ReadonlyArray<readonly [boolean, string]> = [
+      [
+        value.pricedGenerationCount + value.unpricedGenerationCount === value.generationCount,
+        "generation counts must balance",
+      ],
+      [value.generationCount === generationCount, "generation count must equal route totals"],
+      [
+        value.pricedGenerationCount === pricedGenerationCount,
+        "priced generation count must equal route totals",
+      ],
+      [
+        value.unpricedGenerationCount === unpricedGenerationCount,
+        "unpriced generation count must equal route totals",
+      ],
+      [value.knownSpendUsd === knownSpendUsd, "known spend must equal route totals"],
+      [value.cacheReadTokens === cacheReadTokens, "cache-read tokens must equal route totals"],
+      [
+        value.knownCacheReadSavingsUsd === knownCacheReadSavingsUsd,
+        "known cache savings must equal route totals",
+      ],
+      [
+        value.cacheSavingsComplete === cacheSavingsComplete,
+        "cache savings completeness is inconsistent",
+      ],
+      [value.spendComplete === spendComplete, "spend completeness is inconsistent"],
+      [value.capStatus === capStatus, "cap status is inconsistent"],
+    ];
+    for (const [valid, message] of aggregateChecks) {
+      if (!valid) context.addIssue({ code: "custom", message });
+    }
+    for (let index = 0; index < value.routes.length; index += 1) {
+      const route = value.routes[index];
+      const previous = value.routes[index - 1];
+      if (
+        previous !== undefined &&
+        (previous.provider.localeCompare(route.provider) > 0 ||
+          (previous.provider === route.provider && previous.model.localeCompare(route.model) >= 0))
+      ) {
+        context.addIssue({
+          code: "custom",
+          path: ["routes", index],
+          message: "routes must have unique sorted provider and model keys",
+        });
+      }
+    }
+  });
+export type SpendSummary = z.infer<typeof SpendSummarySchema>;
+
+export const GetSpendSummaryRpcParamsSchema = z.object({}).strict();
+export type GetSpendSummaryRpcParams = z.infer<typeof GetSpendSummaryRpcParamsSchema>;
+
+export const SetDailySpendCapRpcParamsSchema = z
+  .object({ dailyCapUsd: z.number().finite().positive() })
+  .strict();
+export type SetDailySpendCapRpcParams = z.infer<typeof SetDailySpendCapRpcParamsSchema>;
+
+export interface SpendOperations {
+  getSpendSummary(request: GetSpendSummaryRpcParams): Promise<SpendSummary>;
+  setDailySpendCap(request: SetDailySpendCapRpcParams): Promise<SpendSummary>;
+}

--- a/packages/coach-contract/tests/contract.test.ts
+++ b/packages/coach-contract/tests/contract.test.ts
@@ -17,6 +17,11 @@ import {
   ResetSessionResponseSchema,
   HasSessionResponseSchema,
   type CoachEngine,
+  CACHING_UNAVAILABLE_DISCLOSURE,
+  GetSpendSummaryRpcParamsSchema,
+  SetDailySpendCapRpcParamsSchema,
+  SpendRouteSummarySchema,
+  SpendSummarySchema,
 } from "../src/index.js";
 
 const TURN_ID = "b8b6c1a2-0000-4000-8000-000000000001";
@@ -79,6 +84,82 @@ describe("exit codes", () => {
 describe("protocol version", () => {
   it("is 3", () => {
     expect(PROTOCOL_VERSION).toBe(3);
+  });
+});
+
+describe("spend contract", () => {
+  const route = {
+    provider: "synthetic-provider",
+    model: "synthetic-model",
+    generationCount: 1,
+    pricedGenerationCount: 1,
+    unpricedGenerationCount: 0,
+    providerReportedGenerationCount: 1,
+    knownSpendUsd: 0.02,
+    cacheReadTokens: 10,
+    cacheReadSavingsUsd: 0.001,
+    caching: "provider-dependent",
+    disclosure: null,
+  } as const;
+  const summary = {
+    localDate: "1998-07-06",
+    timezone: "UTC",
+    dailyCapUsd: 0.5,
+    knownSpendUsd: 0.02,
+    generationCount: 1,
+    pricedGenerationCount: 1,
+    unpricedGenerationCount: 0,
+    malformedLineCount: 0,
+    spendComplete: true,
+    capStatus: "below",
+    cacheReadTokens: 10,
+    knownCacheReadSavingsUsd: 0.001,
+    cacheSavingsComplete: true,
+    routes: [route],
+  } as const;
+
+  it("validates strict requests, routes, summaries, and the exact disclosure", () => {
+    expect(GetSpendSummaryRpcParamsSchema.parse({})).toEqual({});
+    expect(GetSpendSummaryRpcParamsSchema.safeParse({ extra: true }).success).toBe(false);
+    expect(SetDailySpendCapRpcParamsSchema.parse({ dailyCapUsd: 0.5 })).toEqual({
+      dailyCapUsd: 0.5,
+    });
+    for (const dailyCapUsd of [0, -1, NaN, Infinity]) {
+      expect(SetDailySpendCapRpcParamsSchema.safeParse({ dailyCapUsd }).success).toBe(false);
+    }
+    expect(SpendRouteSummarySchema.parse(route)).toEqual(route);
+    expect(SpendSummarySchema.parse(summary)).toEqual(summary);
+    expect(
+      SpendRouteSummarySchema.parse({
+        ...route,
+        caching: "unavailable",
+        disclosure: CACHING_UNAVAILABLE_DISCLOSURE,
+      }).disclosure,
+    ).toBe("caching unavailable on this route");
+    expect(SpendRouteSummarySchema.safeParse({ ...route, extra: true }).success).toBe(false);
+  });
+
+  it("rejects contradictory route and aggregate invariants", () => {
+    expect(SpendRouteSummarySchema.safeParse({ ...route, pricedGenerationCount: 0 }).success).toBe(
+      false,
+    );
+    expect(
+      SpendRouteSummarySchema.safeParse({
+        ...route,
+        caching: "unavailable",
+        disclosure: null,
+      }).success,
+    ).toBe(false);
+    for (const invalid of [
+      { ...summary, knownSpendUsd: 0.03 },
+      { ...summary, cacheReadTokens: 11 },
+      { ...summary, knownCacheReadSavingsUsd: 0.002 },
+      { ...summary, cacheSavingsComplete: false },
+      { ...summary, spendComplete: false },
+      { ...summary, capStatus: "unknown" },
+    ]) {
+      expect(SpendSummarySchema.safeParse(invalid).success).toBe(false);
+    }
   });
 });
 

--- a/packages/coach-contract/tests/wire-contract.test.ts
+++ b/packages/coach-contract/tests/wire-contract.test.ts
@@ -39,6 +39,9 @@ import {
   ResetSessionResponseSchema,
   SetUnitsPreferenceRpcParamsSchema,
   SetUnitsPreferenceRpcResultSchema,
+  GetSpendSummaryRpcParamsSchema,
+  SetDailySpendCapRpcParamsSchema,
+  SpendSummarySchema,
   ServerHandshakeFrameSchema,
   TurnEventSchema,
   UNKNOWN_CYCLING_TRAINING_CONTEXT,
@@ -159,8 +162,25 @@ describe("JSON-RPC envelopes", () => {
   });
 });
 
+const spendSummary = SpendSummarySchema.parse({
+  localDate: "1998-07-06",
+  timezone: "UTC",
+  dailyCapUsd: 0.5,
+  knownSpendUsd: 0,
+  generationCount: 0,
+  pricedGenerationCount: 0,
+  unpricedGenerationCount: 0,
+  malformedLineCount: 0,
+  spendComplete: true,
+  capStatus: "below",
+  cacheReadTokens: 0,
+  knownCacheReadSavingsUsd: 0,
+  cacheSavingsComplete: true,
+  routes: [],
+});
+
 describe("coach request and event projection", () => {
-  it("admits exactly the ten strict method requests", () => {
+  it("admits exactly the twelve strict method requests", () => {
     const requests = [
       { jsonrpc: "2.0", id: 1, method: "chat", params: { chatId: "chat-1", message: "hello" } },
       { jsonrpc: "2.0", id: 2, method: "resetSession", params: { chatId: "chat-1" } },
@@ -193,6 +213,13 @@ describe("coach request and event projection", () => {
         id: 10,
         method: "setUnitsPreference",
         params: { value: "imperial" },
+      },
+      { jsonrpc: "2.0", id: 11, method: "getSpendSummary", params: {} },
+      {
+        jsonrpc: "2.0",
+        id: 12,
+        method: "setDailySpendCap",
+        params: { dailyCapUsd: 0.75 },
       },
     ];
     for (const request of requests) {
@@ -412,6 +439,8 @@ describe("coach request and event projection", () => {
       }),
       getUnitsPreference: async () => ({ value: "metric", source: "default" }),
       setUnitsPreference: async ({ value }) => ({ value, source: "cycling" }),
+      getSpendSummary: async () => spendSummary,
+      setDailySpendCap: async () => spendSummary,
     };
     expect(Object.keys(COACH_RPC_METHOD_REGISTRY)).toEqual(Object.keys(fake));
     expect(COACH_RPC_METHOD_NAMES).toEqual(Object.keys(fake));
@@ -475,6 +504,18 @@ describe("coach request and event projection", () => {
       responseSchema: SetUnitsPreferenceRpcResultSchema,
       eventSchema: NoRpcEventSchema,
     });
+    expect(COACH_RPC_METHOD_REGISTRY.getSpendSummary).toEqual({
+      wireName: "getSpendSummary",
+      requestSchema: GetSpendSummaryRpcParamsSchema,
+      responseSchema: SpendSummarySchema,
+      eventSchema: NoRpcEventSchema,
+    });
+    expect(COACH_RPC_METHOD_REGISTRY.setDailySpendCap).toEqual({
+      wireName: "setDailySpendCap",
+      requestSchema: SetDailySpendCapRpcParamsSchema,
+      responseSchema: SpendSummarySchema,
+      eventSchema: NoRpcEventSchema,
+    });
     for (const method of [
       "resetSession",
       "hasSession",
@@ -483,6 +524,8 @@ describe("coach request and event projection", () => {
       "configureRuntime",
       "getUnitsPreference",
       "setUnitsPreference",
+      "getSpendSummary",
+      "setDailySpendCap",
     ] as const) {
       expect(COACH_RPC_METHOD_REGISTRY[method].eventSchema.safeParse(undefined).success).toBe(
         false,

--- a/packages/coach/src/composition.ts
+++ b/packages/coach/src/composition.ts
@@ -33,6 +33,7 @@ import {
   type ModelTransportDecorator,
   type ReferenceStateSnapshot,
 } from "@enduragent/engine";
+import { resolveUserTimezone } from "@enduragent/engine/sport";
 import {
   createCyclingFtpAnchorResolver,
   type CyclingFtpAnchorResolver,
@@ -57,6 +58,7 @@ import {
 } from "./store-runtime.js";
 import { createCoachOperations } from "./operations.js";
 import type { CoachOperationsDependencies } from "./operations.js";
+import { createSpendMeterService, type SpendMeterService } from "./spend-meter.js";
 
 interface OAuthCredential {
   readonly type: "oauth";
@@ -70,6 +72,7 @@ interface OAuthCredential {
 export interface LocalCoachComposition {
   readonly engine: CoachEngine;
   readonly operations: CoachOperations;
+  readonly spendMeter: SpendMeterService;
   close(): Promise<void>;
 }
 
@@ -321,6 +324,12 @@ export async function createLocalCoachComposition(
     throw new TypeError("Ready engine configuration does not match the selected athlete home.");
   }
   const now = dependencies.now ?? Date.now;
+  const spendMeter = createSpendMeterService({
+    dataDir: input.home.root,
+    configDir: input.home.configDir,
+    timezone: resolveUserTimezone(input.config.session.timezone),
+    now,
+  });
   let activeConfig = copyConfig(input.config);
   let runtime: LocalStoreRuntime | undefined;
   let reference: LocalReferenceRuntime | undefined;
@@ -444,6 +453,7 @@ export async function createLocalCoachComposition(
     return {
       engine: reconfigurable.engine,
       operations,
+      spendMeter,
       close() {
         closePromise ??= (async () => {
           let failure: { readonly error: unknown } | undefined;

--- a/packages/coach/src/daemon/rpc-server.ts
+++ b/packages/coach/src/daemon/rpc-server.ts
@@ -22,7 +22,10 @@ import {
   type CoachOperations,
   type CoachRpcMethodName,
   type DaemonOwner,
+  type GetSpendSummaryRpcParams,
   type JsonRpcId,
+  type SetDailySpendCapRpcParams,
+  type SpendSummary,
 } from "@enduragent/coach-contract";
 import type { WriterProtocolHandlers } from "@enduragent/kernel-node/lock";
 import WebSocket, { WebSocketServer, type RawData } from "ws";
@@ -137,10 +140,16 @@ export async function ensureDaemonToken(
 export interface CoachRpcServerInput {
   readonly engine: CoachEngine;
   readonly operations: CoachOperations;
+  readonly spend: SpendRpcHandlers;
   readonly token: string;
   readonly owner: DaemonOwner;
   readonly healthState?: DaemonHealthState;
   readonly timer?: MonotonicTimer;
+}
+
+export interface SpendRpcHandlers {
+  readonly getSpendSummary: (params: GetSpendSummaryRpcParams) => Promise<SpendSummary>;
+  readonly setDailySpendCap: (params: SetDailySpendCapRpcParams) => Promise<SpendSummary>;
 }
 
 export interface CoachRpcServer {
@@ -722,6 +731,26 @@ export function createCoachRpcServer(input: CoachRpcServerInput): CoachRpcServer
                 throw new TypeError("Units preference operation is unavailable.");
               }
               result = await input.operations.setUnitsPreference(request);
+            } catch (error) {
+              invocationFailure = { error };
+            }
+            break;
+          case "getSpendSummary":
+            try {
+              const request = COACH_RPC_METHOD_REGISTRY.getSpendSummary.requestSchema.parse(
+                generic.data.params,
+              );
+              result = await input.spend.getSpendSummary(request);
+            } catch (error) {
+              invocationFailure = { error };
+            }
+            break;
+          case "setDailySpendCap":
+            try {
+              const request = COACH_RPC_METHOD_REGISTRY.setDailySpendCap.requestSchema.parse(
+                generic.data.params,
+              );
+              result = await input.spend.setDailySpendCap(request);
             } catch (error) {
               invocationFailure = { error };
             }

--- a/packages/coach/src/local-runner.ts
+++ b/packages/coach/src/local-runner.ts
@@ -3,6 +3,7 @@ import type { CoachEngine, CoachOperations } from "@enduragent/coach-contract";
 import type { AthleteHome } from "@enduragent/kernel-node/home";
 import type { WriterProtocolListener } from "@enduragent/kernel-node/lock";
 import { createLocalCoachComposition, type LocalCoachComposition } from "./composition.js";
+import type { SpendMeterService } from "./spend-meter.js";
 import {
   migrateLegacyHomeUnderLock,
   type LegacyMigrationAction,
@@ -14,6 +15,7 @@ import { withCoachStoreWriter } from "./runtime.js";
 export interface LocalCoachLifecycle {
   readonly engine: CoachEngine;
   readonly operations: CoachOperations;
+  readonly spendMeter: SpendMeterService;
   readonly listener: WriterProtocolListener;
   close(): Promise<void>;
 }
@@ -137,6 +139,7 @@ export async function withLocalCoach<T>(
               value: await input.operation({
                 engine: publishedLifecycle.engine,
                 operations: publishedLifecycle.operations,
+                spendMeter: publishedLifecycle.spendMeter,
                 listener: context.listener,
                 close: () => publishedLifecycle.close(),
               }),

--- a/packages/coach/src/serve.ts
+++ b/packages/coach/src/serve.ts
@@ -47,10 +47,15 @@ export async function runCoachServe(
     if (aborted) return EXIT_SUCCESS;
     const token = await dependencies.ensureToken(input.home.configDir);
     if (aborted) return EXIT_SUCCESS;
+    const spendMeter = input.lifecycle.spendMeter;
     const healthState = dependencies.createHealthState();
     const rpc = dependencies.createRpcServer({
       engine: input.lifecycle.engine,
       operations: input.lifecycle.operations,
+      spend: {
+        getSpendSummary: () => spendMeter.getSpendSummary(),
+        setDailySpendCap: ({ dailyCapUsd }) => spendMeter.setDailySpendCap(dailyCapUsd),
+      },
       token: token.value,
       owner: input.owner ?? "unmanaged-foreground",
       healthState,

--- a/packages/coach/src/spend-meter.ts
+++ b/packages/coach/src/spend-meter.ts
@@ -1,0 +1,274 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  CACHING_UNAVAILABLE_DISCLOSURE,
+  SetDailySpendCapRpcParamsSchema,
+  SpendSummarySchema,
+  type SpendRouteSummary,
+  type SpendSummary,
+} from "@enduragent/coach-contract";
+import { atomicWriteJson, readUsageLedger } from "@enduragent/core";
+import {
+  cacheReadSavingsUsd,
+  classifySpendCaching,
+  priceInclusiveUsage,
+  type UsageLedgerLine,
+} from "@enduragent/engine";
+import { z } from "zod";
+
+export const DEFAULT_DAILY_SPEND_CAP_USD = 0.5;
+export const DAILY_SPEND_CAP_FILE = "daily-spend-cap.json";
+export const DAILY_SPEND_CAP_VERSION = 1;
+
+export interface SpendMeterService {
+  getSpendSummary(): Promise<SpendSummary>;
+  setDailySpendCap(dailyCapUsd: number): Promise<SpendSummary>;
+}
+
+export interface CreateSpendMeterServiceInput {
+  readonly dataDir: string;
+  readonly configDir: string;
+  readonly timezone: string;
+  readonly now?: () => number;
+}
+
+const DailySpendCapSchema = z
+  .object({
+    version: z.literal(DAILY_SPEND_CAP_VERSION),
+    dailyCapUsd: z.number().finite().positive(),
+  })
+  .strict();
+
+interface MutableRoute {
+  readonly provider: string;
+  readonly model: string;
+  generationCount: number;
+  pricedGenerationCount: number;
+  unpricedGenerationCount: number;
+  providerReportedGenerationCount: number;
+  knownSpendUsd: number;
+  cacheReadTokens: number;
+  cacheSavingsKnownUsd: number;
+  cacheSavingsAvailable: boolean;
+}
+
+function dateKey(timestamp: number, timezone: string): string | undefined {
+  try {
+    const parts = new Intl.DateTimeFormat("en-US", {
+      timeZone: timezone,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    }).formatToParts(new Date(timestamp));
+    const values = Object.fromEntries(
+      parts.filter((part) => part.type !== "literal").map((part) => [part.type, part.value]),
+    );
+    if (values.year === undefined || values.month === undefined || values.day === undefined) {
+      return undefined;
+    }
+    return `${values.year}-${values.month}-${values.day}`;
+  } catch {
+    return undefined;
+  }
+}
+
+function nonemptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function validToken(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+}
+
+function validProviderCost(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
+function readDailyCap(path: string): number {
+  try {
+    return DailySpendCapSchema.parse(JSON.parse(readFileSync(path, "utf8")) as unknown).dailyCapUsd;
+  } catch {
+    return DEFAULT_DAILY_SPEND_CAP_USD;
+  }
+}
+
+function selectedNumericFieldsValid(line: Record<string, unknown>): boolean {
+  for (const field of [
+    "inputTokens",
+    "outputTokens",
+    "totalTokens",
+    "cacheReadTokens",
+    "cacheWriteTokens",
+  ]) {
+    if (line[field] !== undefined && !validToken(line[field])) return false;
+  }
+  return (
+    line.providerReportedCostUsd === undefined || validProviderCost(line.providerReportedCostUsd)
+  );
+}
+
+function routeSummary(route: MutableRoute): SpendRouteSummary {
+  const caching = classifySpendCaching(route.provider, route.model);
+  return {
+    provider: route.provider,
+    model: route.model,
+    generationCount: route.generationCount,
+    pricedGenerationCount: route.pricedGenerationCount,
+    unpricedGenerationCount: route.unpricedGenerationCount,
+    providerReportedGenerationCount: route.providerReportedGenerationCount,
+    knownSpendUsd: route.knownSpendUsd,
+    cacheReadTokens: route.cacheReadTokens,
+    cacheReadSavingsUsd: route.cacheSavingsAvailable ? route.cacheSavingsKnownUsd : null,
+    caching,
+    disclosure: caching === "unavailable" ? CACHING_UNAVAILABLE_DISCLOSURE : null,
+  };
+}
+
+export function createSpendMeterService(input: CreateSpendMeterServiceInput): SpendMeterService {
+  const now = input.now ?? Date.now;
+  const capPath = join(input.configDir, DAILY_SPEND_CAP_FILE);
+
+  const summarize = async (): Promise<SpendSummary> => {
+    const capturedNow = now();
+    const localDate = dateKey(capturedNow, input.timezone);
+    if (localDate === undefined) throw new TypeError("Spend date could not be resolved.");
+    const dailyCapUsd = readDailyCap(capPath);
+    const ledger = readUsageLedger(input.dataDir);
+    let malformedLineCount = ledger.malformedLineCount;
+    const routes = new Map<string, MutableRoute>();
+
+    for (const rawLine of ledger.lines) {
+      const line = rawLine as UsageLedgerLine & Record<string, unknown>;
+      if (
+        !["generate", "turn", "boot"].includes(String(line.kind)) ||
+        typeof line.ts !== "number" ||
+        !Number.isFinite(line.ts) ||
+        !nonemptyString(line.provider) ||
+        !nonemptyString(line.model)
+      ) {
+        malformedLineCount += 1;
+        continue;
+      }
+      const lineDate = dateKey(line.ts, input.timezone);
+      if (lineDate === undefined) {
+        malformedLineCount += 1;
+        continue;
+      }
+      if (line.kind !== "generate" || lineDate !== localDate) continue;
+
+      const key = JSON.stringify([line.provider, line.model]);
+      const route = routes.get(key) ?? {
+        provider: line.provider,
+        model: line.model,
+        generationCount: 0,
+        pricedGenerationCount: 0,
+        unpricedGenerationCount: 0,
+        providerReportedGenerationCount: 0,
+        knownSpendUsd: 0,
+        cacheReadTokens: 0,
+        cacheSavingsKnownUsd: 0,
+        cacheSavingsAvailable: true,
+      };
+      routes.set(key, route);
+      route.generationCount += 1;
+
+      if (!selectedNumericFieldsValid(line)) {
+        malformedLineCount += 1;
+        route.unpricedGenerationCount += 1;
+        continue;
+      }
+
+      const cacheReadTokens = line.cacheReadTokens ?? 0;
+      const nextCacheReadTokens = route.cacheReadTokens + cacheReadTokens;
+      if (!Number.isSafeInteger(nextCacheReadTokens)) {
+        malformedLineCount += 1;
+        route.unpricedGenerationCount += 1;
+        route.cacheSavingsAvailable = false;
+        continue;
+      }
+      route.cacheReadTokens = nextCacheReadTokens;
+      if (cacheReadTokens > 0) {
+        const savings = cacheReadSavingsUsd(line.provider, line.model, cacheReadTokens);
+        if (savings === null || !Number.isFinite(route.cacheSavingsKnownUsd + savings)) {
+          route.cacheSavingsAvailable = false;
+        } else {
+          route.cacheSavingsKnownUsd += savings;
+        }
+      }
+
+      const providerReported = line.providerReportedCostUsd;
+      const catalogCost =
+        providerReported === undefined &&
+        line.inputTokens !== undefined &&
+        line.outputTokens !== undefined
+          ? priceInclusiveUsage(line.provider, line.model, {
+              inputTokens: line.inputTokens,
+              outputTokens: line.outputTokens,
+              cacheReadTokens,
+              cacheWriteTokens: line.cacheWriteTokens ?? 0,
+            })
+          : undefined;
+      const cost = providerReported ?? catalogCost?.total;
+      if (cost === undefined || !Number.isFinite(route.knownSpendUsd + cost)) {
+        route.unpricedGenerationCount += 1;
+      } else {
+        route.knownSpendUsd += cost;
+        route.pricedGenerationCount += 1;
+        if (providerReported !== undefined) route.providerReportedGenerationCount += 1;
+      }
+    }
+
+    const sortedRoutes = [...routes.values()]
+      .sort(
+        (left, right) =>
+          left.provider.localeCompare(right.provider) || left.model.localeCompare(right.model),
+      )
+      .map(routeSummary);
+    const generationCount = sortedRoutes.reduce((sum, route) => sum + route.generationCount, 0);
+    const pricedGenerationCount = sortedRoutes.reduce(
+      (sum, route) => sum + route.pricedGenerationCount,
+      0,
+    );
+    const unpricedGenerationCount = sortedRoutes.reduce(
+      (sum, route) => sum + route.unpricedGenerationCount,
+      0,
+    );
+    const knownSpendUsd = sortedRoutes.reduce((sum, route) => sum + route.knownSpendUsd, 0);
+    const cacheReadTokens = sortedRoutes.reduce((sum, route) => sum + route.cacheReadTokens, 0);
+    const knownCacheReadSavingsUsd = sortedRoutes.reduce(
+      (sum, route) => sum + (route.cacheReadSavingsUsd ?? 0),
+      0,
+    );
+    const spendComplete = unpricedGenerationCount === 0 && malformedLineCount === 0;
+    const cacheSavingsComplete =
+      malformedLineCount === 0 && sortedRoutes.every((route) => route.cacheReadSavingsUsd !== null);
+    return SpendSummarySchema.parse({
+      localDate,
+      timezone: input.timezone,
+      dailyCapUsd,
+      knownSpendUsd,
+      generationCount,
+      pricedGenerationCount,
+      unpricedGenerationCount,
+      malformedLineCount,
+      spendComplete,
+      capStatus: knownSpendUsd >= dailyCapUsd ? "reached" : spendComplete ? "below" : "unknown",
+      cacheReadTokens,
+      knownCacheReadSavingsUsd,
+      cacheSavingsComplete,
+      routes: sortedRoutes,
+    });
+  };
+
+  return {
+    getSpendSummary: summarize,
+    async setDailySpendCap(dailyCapUsd) {
+      const parsed = SetDailySpendCapRpcParamsSchema.parse({ dailyCapUsd });
+      await atomicWriteJson(capPath, {
+        version: DAILY_SPEND_CAP_VERSION,
+        dailyCapUsd: parsed.dailyCapUsd,
+      });
+      return summarize();
+    },
+  };
+}

--- a/packages/coach/tests/cli-verbs-rpc.test.ts
+++ b/packages/coach/tests/cli-verbs-rpc.test.ts
@@ -115,7 +115,16 @@ interface RunningRpc {
 }
 
 async function startRpc(engine: CoachEngine): Promise<RunningRpc> {
-  const rpc = createCoachRpcServer({ engine, operations, token, owner: "unmanaged-foreground" });
+  const rpc = createCoachRpcServer({
+    engine,
+    operations,
+    spend: {
+      getSpendSummary: () => Promise.reject(new Error("Spend handler is not used.")),
+      setDailySpendCap: () => Promise.reject(new Error("Spend handler is not used.")),
+    },
+    token,
+    owner: "unmanaged-foreground",
+  });
   const server = createServer();
   const disconnectWaiters: Array<() => void> = [];
   server.on("connection", (socket) => {

--- a/packages/coach/tests/composition.test.ts
+++ b/packages/coach/tests/composition.test.ts
@@ -362,6 +362,10 @@ describe("local coach composition", () => {
     expect(received?.ports.platform.legacyClient).toBeNull();
     expect(received?.ports.platform.athleteData).toBe(selectedRuntime.athleteData);
     expect(received?.ports.config).toEqual(engineConfigFromConfig(config(home)));
+    await expect(lifecycle.spendMeter.getSpendSummary()).resolves.toMatchObject({
+      timezone: "UTC",
+      dailyCapUsd: 0.5,
+    });
     await lifecycle.close();
   });
 

--- a/packages/coach/tests/daemon-handshake.test.ts
+++ b/packages/coach/tests/daemon-handshake.test.ts
@@ -163,6 +163,10 @@ describe.skipIf(!hasLoopback)("production peer observations", () => {
           applied: { llm: llm !== undefined, intervals: intervals !== undefined },
         }),
       },
+      spend: {
+        getSpendSummary: () => Promise.reject(new Error("Spend handler is not used.")),
+        setDailySpendCap: () => Promise.reject(new Error("Spend handler is not used.")),
+      },
       engine: {
         chat: async () => ({ text: "ok" }),
         resetSession: async () => ({ memoryFlushed: true }),

--- a/packages/coach/tests/daemon-rpc-server.test.ts
+++ b/packages/coach/tests/daemon-rpc-server.test.ts
@@ -25,6 +25,7 @@ import {
   type AthleteState,
   type CoachEngine,
   type CoachOperations,
+  type SpendSummary,
 } from "@enduragent/coach-contract";
 import {
   createCoachRpcServer as createCoachRpcServerProduction,
@@ -80,10 +81,37 @@ const operations: CoachOperations = {
   setUnitsPreference: async ({ value }) => ({ value, source: "cycling" }),
 };
 
+const spendSummary: SpendSummary = {
+  localDate: "1998-07-06",
+  timezone: "UTC",
+  dailyCapUsd: 0.5,
+  knownSpendUsd: 0,
+  generationCount: 0,
+  pricedGenerationCount: 0,
+  unpricedGenerationCount: 0,
+  malformedLineCount: 0,
+  spendComplete: true,
+  capStatus: "below",
+  cacheReadTokens: 0,
+  knownCacheReadSavingsUsd: 0,
+  cacheSavingsComplete: true,
+  routes: [],
+};
+
+const spend = {
+  getSpendSummary: async () => spendSummary,
+  setDailySpendCap: async () => spendSummary,
+};
+
 function createCoachRpcServer(
-  input: Omit<CoachRpcServerInput, "operations"> & Partial<Pick<CoachRpcServerInput, "operations">>,
+  input: Omit<CoachRpcServerInput, "operations" | "spend"> &
+    Partial<Pick<CoachRpcServerInput, "operations" | "spend">>,
 ) {
-  return createCoachRpcServerProduction({ ...input, operations: input.operations ?? operations });
+  return createCoachRpcServerProduction({
+    ...input,
+    operations: input.operations ?? operations,
+    spend: input.spend ?? spend,
+  });
 }
 
 function engine(overrides: Partial<CoachEngine> = {}): CoachEngine {
@@ -509,6 +537,75 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
     expect(parseCoachRpcEnvelope(await client.frames.next())).toMatchObject({
       id: "units-invalid",
       error: { code: -32602, message: "Invalid params" },
+    });
+    await client.close();
+  });
+
+  it("dispatches strict spend reads and cap writes exactly once without notifications", async () => {
+    const token = "x".repeat(43);
+    const getSpendSummary = vi.fn(async () => spendSummary);
+    const setDailySpendCap = vi.fn(async ({ dailyCapUsd }: { dailyCapUsd: number }) => ({
+      ...spendSummary,
+      dailyCapUsd,
+    }));
+    const rpc = createCoachRpcServer({
+      engine: engine(),
+      spend: { getSpendSummary, setDailySpendCap },
+      token,
+      owner: "app-supervised",
+    });
+    const client = await openSocket(rpc);
+    client.ws.send(JSON.stringify(createClientHandshakeFrame(token)));
+    await client.frames.next();
+    client.ws.send(
+      JSON.stringify({ jsonrpc: "2.0", id: "spend-read", method: "getSpendSummary", params: {} }),
+    );
+    expect(parseCoachRpcEnvelope(await client.frames.next())).toEqual({
+      jsonrpc: "2.0",
+      id: "spend-read",
+      result: spendSummary,
+    });
+    client.ws.send(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: "spend-write",
+        method: "setDailySpendCap",
+        params: { dailyCapUsd: 0.75 },
+      }),
+    );
+    expect(parseCoachRpcEnvelope(await client.frames.next())).toMatchObject({
+      id: "spend-write",
+      result: { dailyCapUsd: 0.75 },
+    });
+    expect(getSpendSummary).toHaveBeenCalledOnce();
+    expect(setDailySpendCap).toHaveBeenCalledWith({ dailyCapUsd: 0.75 });
+    client.ws.send(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: "spend-invalid",
+        method: "setDailySpendCap",
+        params: { dailyCapUsd: 0 },
+      }),
+    );
+    expect(parseCoachRpcEnvelope(await client.frames.next())).toMatchObject({
+      id: "spend-invalid",
+      error: { code: -32602, message: "Invalid params" },
+    });
+    getSpendSummary.mockResolvedValueOnce({
+      ...spendSummary,
+      knownSpendUsd: 1,
+    } as SpendSummary);
+    client.ws.send(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: "spend-invalid-result",
+        method: "getSpendSummary",
+        params: {},
+      }),
+    );
+    expect(parseCoachRpcEnvelope(await client.frames.next())).toMatchObject({
+      id: "spend-invalid-result",
+      error: { code: -32603, message: "Internal error" },
     });
     await client.close();
   });

--- a/packages/coach/tests/daemon/redaction-rpc-cli.test.ts
+++ b/packages/coach/tests/daemon/redaction-rpc-cli.test.ts
@@ -161,6 +161,10 @@ async function startRpc(coachEngine: CoachEngine): Promise<RunningRpc> {
         applied: { llm: llm !== undefined, intervals: intervals !== undefined },
       }),
     },
+    spend: {
+      getSpendSummary: () => Promise.reject(new Error("Spend handler is not used.")),
+      setDailySpendCap: () => Promise.reject(new Error("Spend handler is not used.")),
+    },
     token: AUTH_TOKEN,
     owner: "unmanaged-foreground",
   });

--- a/packages/coach/tests/enduragent-entry.test.ts
+++ b/packages/coach/tests/enduragent-entry.test.ts
@@ -38,6 +38,7 @@ import {
   type WithLocalCoachInput,
 } from "../src/local-runner.js";
 import { CoachStoreWriterError, withCoachStoreWriter } from "../src/runtime.js";
+import type { SpendMeterService } from "../src/spend-meter.js";
 
 const state: AthleteState = {
   schemaVersion: "3",
@@ -75,6 +76,15 @@ const operations: CoachOperations = {
     schemaVersion: 1,
     applied: { llm: llm !== undefined, intervals: intervals !== undefined },
   }),
+};
+
+const spendMeter: SpendMeterService = {
+  getSpendSummary: async () => {
+    throw new Error("unused spend meter");
+  },
+  setDailySpendCap: async () => {
+    throw new Error("unused spend meter");
+  },
 };
 
 interface Deferred<T> {
@@ -416,6 +426,7 @@ describe("enduragent executable composition", () => {
     const lifecycle = {
       engine: mocked.engine,
       operations,
+      spendMeter,
       listener: inertWriterProtocolListener,
       close: async () => {
         trace.push("lifecycle-close");
@@ -495,6 +506,7 @@ describe("enduragent executable composition", () => {
             const value = await input.operation({
               engine: mocked.engine,
               operations,
+              spendMeter,
               listener: inertWriterProtocolListener,
               async close() {},
             });
@@ -735,6 +747,7 @@ describe("enduragent executable composition", () => {
       const lifecycle = {
         engine: mocked.engine,
         operations,
+        spendMeter,
         listener: inertWriterProtocolListener,
         close: async () => {
           trace.push("lifecycle-close");
@@ -839,6 +852,7 @@ describe("enduragent executable composition", () => {
               value: await input.operation({
                 engine: mocked.engine,
                 operations,
+                spendMeter,
                 listener: inertWriterProtocolListener,
                 async close() {},
               }),

--- a/packages/coach/tests/enduragent-redaction.test.ts
+++ b/packages/coach/tests/enduragent-redaction.test.ts
@@ -16,6 +16,7 @@ import { resolveAthleteHome } from "@enduragent/kernel-node/home";
 import { runEnduragent, type EnduragentDependencies } from "../src/enduragent.js";
 import type { WithLocalCoachInput } from "../src/local-runner.js";
 import { withCoachStoreWriter } from "../src/runtime.js";
+import type { SpendMeterService } from "../src/spend-meter.js";
 
 const API_KEY_SECRET = "F8_LOCAL_API_KEY_MUST_NOT_ESCAPE";
 const MESSAGE_SECRET = "F8_LOCAL_MESSAGE_MUST_NOT_ESCAPE";
@@ -39,6 +40,15 @@ const state: AthleteState = {
   recentActivities: [],
   plannedWorkouts: [],
   wellness: {},
+};
+
+const spendMeter: SpendMeterService = {
+  getSpendSummary: async () => {
+    throw new Error("unused spend meter");
+  },
+  setDailySpendCap: async () => {
+    throw new Error("unused spend meter");
+  },
 };
 
 afterEach(async () => {
@@ -152,6 +162,7 @@ describe.skipIf(!hasLoopback)("local CLI redaction boundary", () => {
               applied: { llm: llm !== undefined, intervals: intervals !== undefined },
             }),
           },
+          spendMeter,
           listener: context.listener,
           close: async () => {},
         }),

--- a/packages/coach/tests/local-runner.test.ts
+++ b/packages/coach/tests/local-runner.test.ts
@@ -88,6 +88,11 @@ const operations: CoachOperations = {
   }),
 };
 
+const spendMeter = {
+  getSpendSummary: vi.fn(),
+  setDailySpendCap: vi.fn(),
+};
+
 const config = {
   dataSource: "store",
   llm: { provider: "anthropic", model: "synthetic", apiKey: "" },
@@ -198,7 +203,7 @@ beforeEach(async () => {
   mocks.project.mockReturnValue(engineConfig);
   mocks.composition.mockImplementation(async () => {
     trace.push("engine-open");
-    return { engine, operations, close: () => closeImplementation() };
+    return { engine, operations, spendMeter, close: () => closeImplementation() };
   });
   mocks.withWriter.mockImplementation(
     async (env: Record<string, string | undefined>, plan: CoachStoreWriterPlan<unknown>) => {
@@ -227,6 +232,7 @@ describe("local coach runner", () => {
         input(async (lifecycle) => {
           expect(lifecycle.listener).toBe(inertWriterProtocolListener);
           expect(lifecycle.operations).toBe(operations);
+          expect(lifecycle.spendMeter).toBe(spendMeter);
           trace.push("operation");
           return "done";
         }),
@@ -403,7 +409,7 @@ describe("local coach runner", () => {
       closerCalls += 1;
       trace.push("lifecycle-close");
     };
-    mocks.composition.mockResolvedValue({ engine, operations, close });
+    mocks.composition.mockResolvedValue({ engine, operations, spendMeter, close });
     await expect(
       withLocalCoach(
         input(async (lifecycle) => {

--- a/packages/coach/tests/serve.test.ts
+++ b/packages/coach/tests/serve.test.ts
@@ -5,6 +5,7 @@ import {
   type AthleteState,
   type CoachEngine,
   type CoachOperations,
+  type SpendSummary,
 } from "@enduragent/coach-contract";
 import type { AthleteHome } from "@enduragent/kernel-node/home";
 import type {
@@ -76,6 +77,23 @@ const operations: CoachOperations = {
   }),
 };
 
+const spendSummary = {
+  localDate: "1998-07-06",
+  timezone: "UTC",
+  dailyCapUsd: 0.5,
+  knownSpendUsd: 0,
+  generationCount: 0,
+  pricedGenerationCount: 0,
+  unpricedGenerationCount: 0,
+  malformedLineCount: 0,
+  spendComplete: true,
+  capStatus: "below",
+  cacheReadTokens: 0,
+  knownCacheReadSavingsUsd: 0,
+  cacheSavingsComplete: true,
+  routes: [],
+} satisfies SpendSummary;
+
 const home: AthleteHome = {
   root: "/synthetic/athlete",
   storeDir: "/synthetic/athlete/store",
@@ -111,6 +129,10 @@ function harness(
   const lifecycle: LocalCoachLifecycle = {
     engine,
     operations,
+    spendMeter: {
+      getSpendSummary: vi.fn(async () => spendSummary),
+      setDailySpendCap: vi.fn(async () => spendSummary),
+    },
     listener,
     async close() {
       trace.push("lifecycle-close");

--- a/packages/coach/tests/spend-meter.test.ts
+++ b/packages/coach/tests/spend-meter.test.ts
@@ -1,0 +1,214 @@
+import { chmod, mkdir, mkdtemp, readFile, realpath, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { UsageLedgerLine } from "@enduragent/engine";
+import {
+  DAILY_SPEND_CAP_FILE,
+  DEFAULT_DAILY_SPEND_CAP_USD,
+  createSpendMeterService,
+} from "../src/spend-meter.js";
+
+let root: string;
+let configDir: string;
+
+beforeEach(async () => {
+  root = await mkdtemp(join(await realpath(tmpdir()), "spend-meter-"));
+  configDir = join(root, "config");
+  await mkdir(configDir, { mode: 0o700 });
+});
+
+afterEach(async () => {
+  await chmod(configDir, 0o700).catch(() => {});
+  await rm(root, { recursive: true, force: true });
+});
+
+function line(overrides: Partial<UsageLedgerLine> = {}): UsageLedgerLine {
+  return {
+    ts: Date.UTC(1998, 6, 6, 12),
+    kind: "generate",
+    provider: "anthropic",
+    model: "claude-sonnet-4-6",
+    durationMs: 10,
+    inputTokens: 1_000,
+    outputTokens: 100,
+    cacheReadTokens: 400,
+    cacheWriteTokens: 100,
+    ...overrides,
+  };
+}
+
+async function ledger(file: string, values: readonly (UsageLedgerLine | string)[]): Promise<void> {
+  await writeFile(
+    join(root, file),
+    values.map((value) => (typeof value === "string" ? value : JSON.stringify(value))).join("\n") +
+      "\n",
+  );
+}
+
+describe("spend meter service", () => {
+  it("aggregates rotated and live generations once with native precedence and honest gaps", async () => {
+    await ledger("usage-ledger.jsonl.1", [
+      line({
+        providerReportedCostUsd: 0.02,
+        cost: { input: 9, output: 9, cacheRead: 9, cacheWrite: 9, total: 36 },
+      }),
+      line({ kind: "turn", cost: { input: 9, output: 9, cacheRead: 9, cacheWrite: 9, total: 36 } }),
+      "not-json",
+    ]);
+    await ledger("usage-ledger.jsonl", [
+      line(),
+      line({
+        provider: "openrouter",
+        model: "openrouter/auto",
+        inputTokens: 50,
+        outputTokens: 10,
+        cacheReadTokens: 0,
+        cacheWriteTokens: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0.8 },
+      }),
+      line({ kind: "boot" }),
+    ]);
+    const service = createSpendMeterService({
+      dataDir: root,
+      configDir,
+      timezone: "UTC",
+      now: () => Date.UTC(1998, 6, 6, 18),
+    });
+    const summary = await service.getSpendSummary();
+    expect(summary).toMatchObject({
+      localDate: "1998-07-06",
+      dailyCapUsd: DEFAULT_DAILY_SPEND_CAP_USD,
+      generationCount: 3,
+      pricedGenerationCount: 2,
+      unpricedGenerationCount: 1,
+      malformedLineCount: 1,
+      spendComplete: false,
+      capStatus: "unknown",
+      cacheReadTokens: 800,
+      knownCacheReadSavingsUsd: 0.00216,
+      cacheSavingsComplete: false,
+    });
+    expect(summary.knownSpendUsd).toBeCloseTo(0.023495, 12);
+    expect(summary.routes.map(({ provider, model }) => [provider, model])).toEqual([
+      ["anthropic", "claude-sonnet-4-6"],
+      ["openrouter", "openrouter/auto"],
+    ]);
+    expect(summary.routes[0]).toMatchObject({
+      generationCount: 2,
+      providerReportedGenerationCount: 1,
+      caching: "explicit",
+      disclosure: null,
+    });
+    expect(summary.routes[1]).toMatchObject({
+      knownSpendUsd: 0,
+      pricedGenerationCount: 0,
+      unpricedGenerationCount: 1,
+      caching: "provider-dependent",
+      cacheReadSavingsUsd: 0,
+    });
+  });
+
+  it("uses the athlete timezone boundary, including a daylight-saving zone, and captures now once", async () => {
+    await ledger("usage-ledger.jsonl", [
+      line({ ts: Date.UTC(1998, 6, 6, 6, 30), providerReportedCostUsd: 0.1 }),
+      line({ ts: Date.UTC(1998, 6, 6, 8, 30), providerReportedCostUsd: 0.2 }),
+    ]);
+    let calls = 0;
+    const service = createSpendMeterService({
+      dataDir: root,
+      configDir,
+      timezone: "America/Los_Angeles",
+      now: () => {
+        calls += 1;
+        return Date.UTC(1998, 6, 6, 8);
+      },
+    });
+    const summary = await service.getSpendSummary();
+    expect(summary.localDate).toBe("1998-07-06");
+    expect(summary.generationCount).toBe(1);
+    expect(summary.knownSpendUsd).toBe(0.2);
+    expect(calls).toBe(1);
+  });
+
+  it("persists a strict mode-0600 cap and uses the known lower bound for reached status", async () => {
+    await ledger("usage-ledger.jsonl", [
+      line({ providerReportedCostUsd: 0.03 }),
+      line({
+        provider: "synthetic",
+        model: "unpriced",
+        inputTokens: undefined,
+        outputTokens: undefined,
+      }),
+    ]);
+    const service = createSpendMeterService({
+      dataDir: root,
+      configDir,
+      timezone: "UTC",
+      now: () => Date.UTC(1998, 6, 6, 18),
+    });
+    const summary = await service.setDailySpendCap(0.02);
+    expect(summary.capStatus).toBe("reached");
+    expect(summary.spendComplete).toBe(false);
+    const path = join(configDir, DAILY_SPEND_CAP_FILE);
+    expect(JSON.parse(await readFile(path, "utf8"))).toEqual({ version: 1, dailyCapUsd: 0.02 });
+    expect((await stat(path)).mode & 0o777).toBe(0o600);
+    await expect(service.setDailySpendCap(0)).rejects.toThrow();
+    expect(JSON.parse(await readFile(path, "utf8"))).toEqual({ version: 1, dailyCapUsd: 0.02 });
+  });
+
+  it("preserves the prior cap when an atomic replacement cannot be staged", async () => {
+    const service = createSpendMeterService({
+      dataDir: root,
+      configDir,
+      timezone: "UTC",
+      now: () => Date.UTC(1998, 6, 6, 18),
+    });
+    await service.setDailySpendCap(0.4);
+    const path = join(configDir, DAILY_SPEND_CAP_FILE);
+    await chmod(configDir, 0o500);
+    await expect(service.setDailySpendCap(0.8)).rejects.toThrow();
+    await chmod(configDir, 0o700);
+    expect(JSON.parse(await readFile(path, "utf8"))).toEqual({ version: 1, dailyCapUsd: 0.4 });
+  });
+
+  it("falls back on missing, malformed, wrong-version, and extra-field cap files", async () => {
+    const service = createSpendMeterService({
+      dataDir: root,
+      configDir,
+      timezone: "UTC",
+      now: () => Date.UTC(1998, 6, 6, 18),
+    });
+    expect((await service.getSpendSummary()).dailyCapUsd).toBe(0.5);
+    for (const value of [
+      "not-json",
+      JSON.stringify({ version: 2, dailyCapUsd: 1 }),
+      JSON.stringify({ version: 1, dailyCapUsd: -1 }),
+      JSON.stringify({ version: 1, dailyCapUsd: 1, extra: true }),
+    ]) {
+      await writeFile(join(configDir, DAILY_SPEND_CAP_FILE), value);
+      expect((await service.getSpendSummary()).dailyCapUsd).toBe(0.5);
+    }
+  });
+
+  it("counts invalid selected numeric fields as malformed unpriced generations", async () => {
+    await ledger("usage-ledger.jsonl", [
+      line({ providerReportedCostUsd: -1 }),
+      line({ inputTokens: 1.5 }),
+    ]);
+    const summary = await createSpendMeterService({
+      dataDir: root,
+      configDir,
+      timezone: "UTC",
+      now: () => Date.UTC(1998, 6, 6, 18),
+    }).getSpendSummary();
+    expect(summary).toMatchObject({
+      generationCount: 2,
+      pricedGenerationCount: 0,
+      unpricedGenerationCount: 2,
+      malformedLineCount: 2,
+      knownSpendUsd: 0,
+      capStatus: "unknown",
+    });
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -43,7 +43,14 @@ export type { BootstrapReferenceDeps, ReferenceRuntime } from "./reference/runti
 export { wrapFetchWithSignal } from "./reference/sync/intervals-client-factory.js";
 export { makeChatClient } from "./reference/sync/intervals-client-factory.js";
 
-export { appendUsageLine, USAGE_LEDGER_FILE, USAGE_LEDGER_MAX_BYTES } from "./usage-ledger.js";
+export {
+  appendUsageLine,
+  readUsageLedger,
+  USAGE_LEDGER_FILE,
+  USAGE_LEDGER_MAX_BYTES,
+  type UsageLedgerReadResult,
+} from "./usage-ledger.js";
+export { atomicWriteJson } from "./io/atomic-write-json.js";
 
 // ─── Logging substrate ────────────────────────────────────────────────
 export {
@@ -63,12 +70,7 @@ export { Memory } from "./memory/store.js";
 export type { MemoryJournalEntry } from "./memory/journal.js";
 
 // ─── Secrets ──────────────────────────────────────────────────────────
-export type {
-  EnvSecretRef,
-  ExecSecretRef,
-  SecretRef,
-  SecretsResolver,
-} from "./secrets/types.js";
+export type { EnvSecretRef, ExecSecretRef, SecretRef, SecretsResolver } from "./secrets/types.js";
 export { SecretResolutionError, isSecretRef } from "./secrets/types.js";
 export { resolveSecretRef, _resolveSecretRefWithOverrides } from "./secrets/resolve.js";
 export {
@@ -76,11 +78,7 @@ export {
   _detectBackendsWithOverrides,
   findInPath,
 } from "./secrets/backends/detect.js";
-export type {
-  BackendAvailability,
-  KeychainState,
-  OpState,
-} from "./secrets/backends/detect.js";
+export type { BackendAvailability, KeychainState, OpState } from "./secrets/backends/detect.js";
 export {
   KeychainUnsafeValueError,
   KeychainUnsupportedPlatformError,
@@ -161,10 +159,7 @@ export type {
   PlatformCalendarMutations,
   StoredDataFreshness,
 } from "./athlete-data.js";
-export {
-  loadAllowedSendersWithSource,
-  SENDER_ID_RE,
-} from "./channels/allowed-senders.js";
+export { loadAllowedSendersWithSource, SENDER_ID_RE } from "./channels/allowed-senders.js";
 
 // ─── Updater ──────────────────────────────────────────────────────────
 export {

--- a/packages/core/src/usage-ledger.ts
+++ b/packages/core/src/usage-ledger.ts
@@ -1,4 +1,4 @@
-import { appendFileSync, renameSync, statSync } from "node:fs";
+import { appendFileSync, readFileSync, renameSync, statSync } from "node:fs";
 import { join } from "node:path";
 
 import type { UsageLedgerLine } from "@enduragent/engine";
@@ -6,6 +6,41 @@ export type { UsageLedgerLine } from "@enduragent/engine";
 
 export const USAGE_LEDGER_FILE = "usage-ledger.jsonl";
 export const USAGE_LEDGER_MAX_BYTES = 10 * 1024 * 1024;
+
+export interface UsageLedgerReadResult {
+  readonly lines: readonly UsageLedgerLine[];
+  readonly malformedLineCount: number;
+}
+
+export function readUsageLedger(dataDir: string): UsageLedgerReadResult {
+  const livePath = join(dataDir, USAGE_LEDGER_FILE);
+  const lines: UsageLedgerLine[] = [];
+  let malformedLineCount = 0;
+  for (const path of [`${livePath}.1`, livePath]) {
+    let raw: string;
+    try {
+      raw = readFileSync(path, "utf8");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") malformedLineCount += 1;
+      continue;
+    }
+    const records = raw.split("\n");
+    if (records.at(-1) === "") records.pop();
+    for (const record of records) {
+      try {
+        const value = JSON.parse(record) as unknown;
+        if (value === null || typeof value !== "object" || Array.isArray(value)) {
+          malformedLineCount += 1;
+        } else {
+          lines.push(value as UsageLedgerLine);
+        }
+      } catch {
+        malformedLineCount += 1;
+      }
+    }
+  }
+  return { lines, malformedLineCount };
+}
 
 export function appendUsageLine(dataDir: string, line: UsageLedgerLine): void {
   // Best-effort observability sink: a ledger write must never break a chat

--- a/packages/core/tests/usage-ledger.test.ts
+++ b/packages/core/tests/usage-ledger.test.ts
@@ -10,7 +10,7 @@ import type { Sport } from "../src/sport.js";
 import type { UsageLedgerLine } from "../src/usage-ledger.js";
 import { baseAgentConfig } from "../../engine/tests/helpers/base-agent-config.js";
 import { classifyFailure } from "../src/agent/token-utils.js";
-import { appendUsageLine } from "../src/usage-ledger.js";
+import { appendUsageLine, readUsageLedger } from "../src/usage-ledger.js";
 import { usageFieldsFromResult } from "../../engine/src/llm-types.js";
 import { priceUsage } from "../../engine/src/agent/codex/cost.js";
 
@@ -202,6 +202,29 @@ describe("appendUsageLine", () => {
     const { appendUsageLine } = await import("../src/usage-ledger.js");
     const badDir = "/nonexistent/dir/that/cannot/be/created/\0bad";
     expect(() => appendUsageLine(badDir, ledgerLine())).not.toThrow();
+  });
+
+  it("reads rotated then live rows and preserves a final line without a newline", () => {
+    const rotated = ledgerLine({ ts: 10, model: "synthetic-old" });
+    const live = ledgerLine({ ts: 20, model: "synthetic-live" });
+    writeFileSync(join(dir, "usage-ledger.jsonl.1"), `${JSON.stringify(rotated)}\n`);
+    writeFileSync(join(dir, "usage-ledger.jsonl"), JSON.stringify(live));
+    expect(readUsageLedger(dir)).toEqual({
+      lines: [rotated, live],
+      malformedLineCount: 0,
+    });
+  });
+
+  it("treats missing files as empty and counts malformed JSON, non-objects, and read errors", () => {
+    expect(readUsageLedger(dir)).toEqual({ lines: [], malformedLineCount: 0 });
+    writeFileSync(
+      join(dir, "usage-ledger.jsonl.1"),
+      `${JSON.stringify(ledgerLine())}\nnot-json\nnull\n[]\n\n`,
+    );
+    mkdirSync(join(dir, "usage-ledger.jsonl"));
+    const result = readUsageLedger(dir);
+    expect(result.lines).toEqual([ledgerLine()]);
+    expect(result.malformedLineCount).toBe(5);
   });
 });
 

--- a/packages/engine/src/host-ports.ts
+++ b/packages/engine/src/host-ports.ts
@@ -40,12 +40,7 @@ export interface EngineConfig {
   readonly compactContextWindowTokens: number;
 }
 
-export type MemoryWriteSource =
-  | "chat-tool"
-  | "flush"
-  | "sport-tool"
-  | "migration"
-  | "unattributed";
+export type MemoryWriteSource = "chat-tool" | "flush" | "sport-tool" | "migration" | "unattributed";
 
 export interface MemoryStorePort {
   readMemory(): string;
@@ -126,33 +121,17 @@ export type AthleteReadResult<T> =
   | { readonly ok: true; readonly value: T; readonly freshness?: StoredDataFreshness }
   | {
       readonly ok: false;
-      readonly error:
-        | "not_found"
-        | "store_read_unavailable"
-        | "invalid_snapshot"
-        | "invalid_input";
+      readonly error: "not_found" | "store_read_unavailable" | "invalid_snapshot" | "invalid_input";
       readonly message: string;
     };
 
 export interface AthleteDataReaderPort {
   getAthlete(): Promise<AthleteReadResult<unknown>>;
-  listWellness(input: {
-    start: string;
-    end?: string;
-  }): Promise<AthleteReadResult<unknown[]>>;
-  listActivities(input: {
-    start: string;
-    end?: string;
-  }): Promise<AthleteReadResult<unknown[]>>;
+  listWellness(input: { start: string; end?: string }): Promise<AthleteReadResult<unknown[]>>;
+  listActivities(input: { start: string; end?: string }): Promise<AthleteReadResult<unknown[]>>;
   getActivity(input: { id: string }): Promise<AthleteReadResult<unknown>>;
-  getStreams(input: {
-    id: string;
-    keys: readonly string[];
-  }): Promise<AthleteReadResult<unknown>>;
-  listCalendar(input: {
-    start: string;
-    end?: string;
-  }): Promise<AthleteReadResult<unknown[]>>;
+  getStreams(input: { id: string; keys: readonly string[] }): Promise<AthleteReadResult<unknown>>;
+  listCalendar(input: { start: string; end?: string }): Promise<AthleteReadResult<unknown[]>>;
   freshness(): StoredDataFreshness | undefined;
 }
 
@@ -206,6 +185,7 @@ export interface UsageLedgerLine {
   readonly totalTokens?: number;
   readonly cacheReadTokens?: number;
   readonly cacheWriteTokens?: number;
+  readonly providerReportedCostUsd?: number;
   readonly cost?: UsageCost;
   readonly stopReason?: string;
 }

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -64,3 +64,9 @@ export function createCoachEngine(input: CreateCoachEngineInput): CoachEngine {
 }
 
 export { extractAccountId };
+export {
+  cacheReadSavingsUsd,
+  classifySpendCaching,
+  priceInclusiveUsage,
+  type UsageTokenCounts,
+} from "./usage-cost.js";

--- a/packages/engine/src/llm-types.ts
+++ b/packages/engine/src/llm-types.ts
@@ -16,7 +16,13 @@ export function usageFieldsFromResult(
   result: GenerateResult,
 ): Pick<
   UsageLedgerLine,
-  "inputTokens" | "outputTokens" | "totalTokens" | "cacheReadTokens" | "cacheWriteTokens" | "cost"
+  | "inputTokens"
+  | "outputTokens"
+  | "totalTokens"
+  | "cacheReadTokens"
+  | "cacheWriteTokens"
+  | "providerReportedCostUsd"
+  | "cost"
 > {
   const usage = result.totalUsage;
   const details = cacheTokenDetails(usage);
@@ -26,6 +32,7 @@ export function usageFieldsFromResult(
     totalTokens: usage?.totalTokens,
     cacheReadTokens: details?.cacheReadTokens,
     cacheWriteTokens: details?.cacheWriteTokens,
+    providerReportedCostUsd: result.providerReportedCostUsd,
     cost: result.cost,
   };
 }

--- a/packages/engine/src/llm.ts
+++ b/packages/engine/src/llm.ts
@@ -117,9 +117,7 @@ export class LLM {
         ? createChatStreamWatchdog(this.chatStreamTimeouts)
         : undefined;
     const signal =
-      watchdog === undefined
-        ? deadlineSignal
-        : AbortSignal.any([deadlineSignal, watchdog.signal]);
+      watchdog === undefined ? deadlineSignal : AbortSignal.any([deadlineSignal, watchdog.signal]);
     const handleTextDelta = (delta: string): void => {
       watchdog?.textDelta(delta);
       try {
@@ -202,10 +200,24 @@ export class LLM {
       const blocks = splitSystemPromptAtBoundary(opts.system);
       system = blocks
         ? [
-            { role: "system" as const, content: blocks.prefix, providerOptions: ephemeral(breakpointKey) },
-            { role: "system" as const, content: blocks.volatile, providerOptions: ephemeral(breakpointKey) },
+            {
+              role: "system" as const,
+              content: blocks.prefix,
+              providerOptions: ephemeral(breakpointKey),
+            },
+            {
+              role: "system" as const,
+              content: blocks.volatile,
+              providerOptions: ephemeral(breakpointKey),
+            },
           ]
-        : [{ role: "system" as const, content: opts.system, providerOptions: ephemeral(breakpointKey) }];
+        : [
+            {
+              role: "system" as const,
+              content: opts.system,
+              providerOptions: ephemeral(breakpointKey),
+            },
+          ];
     }
 
     // Message-level breakpoint on the last message so a multi-step tool turn
@@ -217,7 +229,10 @@ export class LLM {
       const last = messages[messages.length - 1];
       messages = [
         ...messages.slice(0, -1),
-        { ...last, providerOptions: { ...last.providerOptions, ...ephemeral(breakpointKey) } } as ModelMessage,
+        {
+          ...last,
+          providerOptions: { ...last.providerOptions, ...ephemeral(breakpointKey) },
+        } as ModelMessage,
       ];
     }
 
@@ -232,9 +247,10 @@ export class LLM {
       experimental_context: opts.context,
     };
     if (opts.caller === "chat") {
-      const result = opts.prompt !== undefined
-        ? streamText({ ...base, prompt: opts.prompt })
-        : streamText({ ...base, messages });
+      const result =
+        opts.prompt !== undefined
+          ? streamText({ ...base, prompt: opts.prompt })
+          : streamText({ ...base, messages });
       for await (const part of result.fullStream) {
         switch (part.type) {
           case "text-delta":
@@ -283,6 +299,10 @@ export class LLM {
         usage,
         totalUsage,
         steps: steps.length,
+        providerReportedCostUsd:
+          this.config.llm.provider === "openrouter"
+            ? providerReportedCostFromSteps(steps)
+            : undefined,
         cost: priceAiSdkUsage(
           this.config.llm.provider,
           this.config.llm.model,
@@ -292,9 +312,10 @@ export class LLM {
       };
     }
 
-    const result = opts.prompt !== undefined
-      ? await generateText({ ...base, prompt: opts.prompt })
-      : await generateText({ ...base, messages });
+    const result =
+      opts.prompt !== undefined
+        ? await generateText({ ...base, prompt: opts.prompt })
+        : await generateText({ ...base, messages });
 
     return {
       text: result.text,
@@ -303,7 +324,16 @@ export class LLM {
       usage: result.usage,
       totalUsage: result.totalUsage,
       steps: result.steps.length,
-      cost: priceAiSdkUsage(this.config.llm.provider, this.config.llm.model, this.priced, result.totalUsage),
+      providerReportedCostUsd:
+        this.config.llm.provider === "openrouter"
+          ? providerReportedCostFromSteps(result.steps)
+          : undefined,
+      cost: priceAiSdkUsage(
+        this.config.llm.provider,
+        this.config.llm.model,
+        this.priced,
+        result.totalUsage,
+      ),
     };
   }
 
@@ -416,6 +446,33 @@ function notifyStreamActivity(
   try {
     observer?.(activity);
   } catch {}
+}
+
+function providerReportedCostFromSteps(steps: readonly unknown[]): number | undefined {
+  if (steps.length === 0) return undefined;
+  let total = 0;
+  for (const step of steps) {
+    if (step === null || typeof step !== "object" || Array.isArray(step)) return undefined;
+    const providerMetadata = (step as { readonly providerMetadata?: unknown }).providerMetadata;
+    if (
+      providerMetadata === null ||
+      typeof providerMetadata !== "object" ||
+      Array.isArray(providerMetadata)
+    ) {
+      return undefined;
+    }
+    const openrouter = (providerMetadata as Record<string, unknown>).openrouter;
+    if (openrouter === null || typeof openrouter !== "object" || Array.isArray(openrouter)) {
+      return undefined;
+    }
+    const usage = (openrouter as Record<string, unknown>).usage;
+    if (usage === null || typeof usage !== "object" || Array.isArray(usage)) return undefined;
+    const cost = (usage as Record<string, unknown>).cost;
+    if (typeof cost !== "number" || !Number.isFinite(cost) || cost < 0) return undefined;
+    total += cost;
+    if (!Number.isFinite(total)) return undefined;
+  }
+  return total;
 }
 
 // The AI SDK reports token usage but no cost, so derive it from the vendored
@@ -542,7 +599,7 @@ function buildAiSdkModel(config: EngineConfig): LanguageModel {
         apiKey: config.llm.apiKey,
         baseURL: config.llm.baseUrl,
       });
-      return openrouter.chat(config.llm.model);
+      return openrouter.chat(config.llm.model, { usage: { include: true } });
     }
     case "openai-codex":
       throw new Error("openai-codex is handled via the bridge, not AI SDK");

--- a/packages/engine/src/sport.ts
+++ b/packages/engine/src/sport.ts
@@ -41,11 +41,7 @@ export type {
   SecretsPort,
   StoredDataFreshness,
 } from "./host-ports.js";
-export type {
-  LedgerEventInput,
-  LedgerEventKind,
-  LedgerEventSource,
-} from "./sport/ledger-event.js";
+export type { LedgerEventInput, LedgerEventKind, LedgerEventSource } from "./sport/ledger-event.js";
 export {
   LEDGER_DATE_PATTERN,
   LEDGER_EVENT_KINDS,
@@ -119,6 +115,7 @@ export interface GenerateResult {
   usage: LanguageModelUsage;
   totalUsage?: LanguageModelUsage;
   steps?: number;
+  providerReportedCostUsd?: number;
   cost?: UsageCost;
 }
 
@@ -166,9 +163,7 @@ export interface Sport {
   readonly skills: Readonly<Record<string, string>>;
   readonly sessionClusterGapMinutes: number;
   readonly memorySections: readonly MemorySectionSpec[];
-  readonly mustPreserveTokens:
-    | readonly string[]
-    | ((memory: MemorySnapshot) => readonly string[]);
+  readonly mustPreserveTokens: readonly string[] | ((memory: MemorySnapshot) => readonly string[]);
   readonly intervalsActivityTypes: readonly IntervalsActivityType[];
   readonly athleteProfileSchema: z.ZodTypeAny;
   tools(ports: SportRuntimePorts): readonly ToolRegistration[];
@@ -197,7 +192,12 @@ export function mergeSportSkills(
   return merged;
 }
 
-export { MS_PER_DAY, eachDateKeyInRange, isRealDateKey, parseDateKeyMs } from "./sport/date-keys.js";
+export {
+  MS_PER_DAY,
+  eachDateKeyInRange,
+  isRealDateKey,
+  parseDateKeyMs,
+} from "./sport/date-keys.js";
 export { getEffectiveSections } from "./sport/effective-sections.js";
 export { createMemorySnapshot } from "./sport/memory-snapshot.js";
 export { messageText } from "./sport/model-message.js";
@@ -210,4 +210,4 @@ export {
   createCoreToolsWithSportConfig,
   createPureCoreIntervalsTools,
 } from "./sport/platform-tools.js";
-export { todayInTZ } from "./sport/user-time.js";
+export { resolveUserTimezone, todayInTZ } from "./sport/user-time.js";

--- a/packages/engine/src/usage-cost.ts
+++ b/packages/engine/src/usage-cost.ts
@@ -1,0 +1,88 @@
+import type { SpendCaching } from "@enduragent/coach-contract";
+import { PRICE_TABLE, isPriced, priceUsage } from "./agent/codex/cost.js";
+import type { UsageCost } from "./host-ports.js";
+
+export interface UsageTokenCounts {
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+  readonly cacheReadTokens: number;
+  readonly cacheWriteTokens: number;
+}
+
+function validTokenCount(value: number): boolean {
+  return Number.isFinite(value) && Number.isInteger(value) && value >= 0;
+}
+
+function rates(provider: string, model: string) {
+  if (!isPriced(provider, model)) return undefined;
+  const value = PRICE_TABLE[provider]?.[model];
+  if (
+    value === undefined ||
+    ![value.input, value.output, value.cacheRead, value.cacheWrite].every(
+      (rate) => Number.isFinite(rate) && rate >= 0,
+    )
+  ) {
+    return undefined;
+  }
+  return value;
+}
+
+function validCost(value: UsageCost | undefined): value is UsageCost {
+  return (
+    value !== undefined &&
+    [value.input, value.output, value.cacheRead, value.cacheWrite, value.total].every(
+      (dimension) => Number.isFinite(dimension) && dimension >= 0,
+    )
+  );
+}
+
+export function priceInclusiveUsage(
+  provider: string,
+  model: string,
+  usage: UsageTokenCounts,
+): UsageCost | undefined {
+  if (
+    !validTokenCount(usage.inputTokens) ||
+    !validTokenCount(usage.outputTokens) ||
+    !validTokenCount(usage.cacheReadTokens) ||
+    !validTokenCount(usage.cacheWriteTokens) ||
+    rates(provider, model) === undefined
+  ) {
+    return undefined;
+  }
+  const uncachedInputTokens = Math.max(
+    0,
+    usage.inputTokens - usage.cacheReadTokens - usage.cacheWriteTokens,
+  );
+  const priced = priceUsage(provider, model, {
+    input: uncachedInputTokens,
+    output: usage.outputTokens,
+    cacheRead: usage.cacheReadTokens,
+    cacheWrite: usage.cacheWriteTokens,
+  });
+  return validCost(priced) ? priced : undefined;
+}
+
+export function cacheReadSavingsUsd(
+  provider: string,
+  model: string,
+  cacheReadTokens: number,
+): number | null {
+  if (!validTokenCount(cacheReadTokens)) return null;
+  const catalog = rates(provider, model);
+  if (catalog === undefined) return null;
+  const savings = (Math.max(0, catalog.input - catalog.cacheRead) * cacheReadTokens) / 1_000_000;
+  return Number.isFinite(savings) && savings >= 0 ? savings : null;
+}
+
+export function classifySpendCaching(provider: string, model: string): SpendCaching {
+  if (provider === "anthropic") return "explicit";
+  if (provider === "openrouter" && model.startsWith("qwen/")) return "explicit";
+  if (
+    provider === "openrouter" &&
+    (model.startsWith("anthropic/") || model.startsWith("google/"))
+  ) {
+    return "unavailable";
+  }
+  return "provider-dependent";
+}

--- a/packages/engine/tests/export-map.test.ts
+++ b/packages/engine/tests/export-map.test.ts
@@ -16,7 +16,13 @@ describe("engine public export surface", () => {
   });
 
   it("exports only the canonical factory and the authorized JWT account helper at runtime", () => {
-    expect(Object.keys(engine).sort()).toEqual(["createCoachEngine", "extractAccountId"]);
+    expect(Object.keys(engine).sort()).toEqual([
+      "cacheReadSavingsUsd",
+      "classifySpendCaching",
+      "createCoachEngine",
+      "extractAccountId",
+      "priceInclusiveUsage",
+    ]);
     expect(timeoutTypeProof).toEqual({ ttftMs: 1, interChunkMs: 1 });
     expect("DEFAULT_CHAT_STREAM_TIMEOUTS" in engine).toBe(false);
   });

--- a/packages/engine/tests/openrouter-native-cost.test.ts
+++ b/packages/engine/tests/openrouter-native-cost.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { EngineConfig, UsageLedgerLine } from "../src/host-ports.js";
+import { llmTestPorts } from "./helpers/base-agent-config.js";
+
+const config: EngineConfig = {
+  dataSource: "platform",
+  llm: {
+    provider: "openrouter",
+    model: "synthetic/model",
+    ["api" + "Key"]: "",
+  } as EngineConfig["llm"],
+  session: {
+    historyTokenBudgetRatio: 0.3,
+    idleMinutes: 0,
+    dailyResetHour: 4,
+    resetArchiveRetentionDays: 0,
+    timezone: "UTC",
+  },
+  contextWindowTokens: 1_000,
+  compactContextWindowTokens: 1_000,
+};
+
+function step(cost: unknown, upstreamInferenceCost?: number) {
+  return {
+    providerMetadata: {
+      openrouter: { usage: { cost }, costDetails: { upstreamInferenceCost } },
+    },
+  };
+}
+
+function result(steps: readonly unknown[]) {
+  return {
+    text: "answer",
+    toolCalls: [],
+    finishReason: "stop",
+    usage: {},
+    totalUsage: {},
+    steps,
+  };
+}
+
+function streamed(steps: readonly unknown[]) {
+  const value = result(steps);
+  return {
+    fullStream: (async function* () {
+      yield { type: "text-delta", id: "text-1", text: "answer" };
+      yield { type: "finish", finishReason: "stop", rawFinishReason: "stop", totalUsage: {} };
+    })(),
+    text: Promise.resolve(value.text),
+    toolCalls: Promise.resolve(value.toolCalls),
+    finishReason: Promise.resolve(value.finishReason),
+    usage: Promise.resolve(value.usage),
+    totalUsage: Promise.resolve(value.totalUsage),
+    steps: Promise.resolve(value.steps),
+  };
+}
+
+async function subject(mode: "generate" | "stream", steps: readonly unknown[]) {
+  const chat = vi.fn(() => ({ provider: "openrouter-stub" }));
+  vi.doMock("@openrouter/ai-sdk-provider", () => ({
+    createOpenRouter: () => ({ chat }),
+  }));
+  vi.doMock("ai", () => ({
+    generateText: vi.fn(async () => result(steps)),
+    streamText: vi.fn(() => streamed(steps)),
+  }));
+  const { LLM } = await import("../src/llm.js");
+  const lines: UsageLedgerLine[] = [];
+  let now = 100;
+  const ports = {
+    ...llmTestPorts(),
+    usage: { append: (line: UsageLedgerLine) => lines.push(line) },
+    now: () => now++,
+  };
+  const llm = new LLM(config, ports);
+  const generated = await llm.generate({
+    prompt: "hello",
+    caller: mode === "stream" ? "chat" : "flush",
+  });
+  return { chat, generated, lines };
+}
+
+beforeEach(() => vi.resetModules());
+afterEach(() => vi.restoreAllMocks());
+
+describe("OpenRouter native cost", () => {
+  it.each(["generate", "stream"] as const)(
+    "sums every %s step and writes one provider-reported generation cost",
+    async (mode) => {
+      const test = await subject(mode, [step(0.01), step(0.02)]);
+      expect(test.chat).toHaveBeenCalledWith("synthetic/model", { usage: { include: true } });
+      expect(test.generated.providerReportedCostUsd).toBe(0.03);
+      expect(test.lines).toHaveLength(1);
+      expect(test.lines[0]?.providerReportedCostUsd).toBe(0.03);
+    },
+  );
+
+  it("accepts exact zero and rejects incomplete or invalid metadata without a partial sum", async () => {
+    expect((await subject("generate", [step(0), step(0)])).generated.providerReportedCostUsd).toBe(
+      0,
+    );
+    for (const steps of [
+      [step(0.01), {}],
+      [step(0.01), step(-1)],
+      [step(0.01), step(NaN)],
+      [step(0.01), step(Infinity)],
+      [],
+      [step(undefined, 0.25)],
+    ]) {
+      vi.resetModules();
+      expect((await subject("generate", steps)).generated.providerReportedCostUsd).toBeUndefined();
+    }
+  });
+});

--- a/packages/engine/tests/scaffold.test.ts
+++ b/packages/engine/tests/scaffold.test.ts
@@ -33,8 +33,11 @@ describe("engine scaffold", () => {
 
   it("exports only the canonical factory and authorized account-id helper at runtime", async () => {
     expect(Object.keys(await import("@enduragent/engine")).sort()).toEqual([
+      "cacheReadSavingsUsd",
+      "classifySpendCaching",
       "createCoachEngine",
       "extractAccountId",
+      "priceInclusiveUsage",
     ]);
   });
 

--- a/packages/engine/tests/usage-cost.test.ts
+++ b/packages/engine/tests/usage-cost.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import {
+  cacheReadSavingsUsd,
+  classifySpendCaching,
+  priceInclusiveUsage,
+} from "../src/usage-cost.js";
+
+describe("usage cost", () => {
+  it("prices inclusive input without charging cached tokens twice", () => {
+    const cost = priceInclusiveUsage("anthropic", "claude-sonnet-4-6", {
+      inputTokens: 1_000,
+      outputTokens: 100,
+      cacheReadTokens: 400,
+      cacheWriteTokens: 100,
+    });
+    expect(cost?.total).toBe(0.003495);
+    expect(cacheReadSavingsUsd("anthropic", "claude-sonnet-4-6", 400)).toBe(0.00108);
+  });
+
+  it("rejects invalid tokens and unknown routes while preserving catalogued zero pricing", () => {
+    for (const inputTokens of [-1, 1.5, NaN, Infinity]) {
+      expect(
+        priceInclusiveUsage("anthropic", "claude-sonnet-4-6", {
+          inputTokens,
+          outputTokens: 1,
+          cacheReadTokens: 0,
+          cacheWriteTokens: 0,
+        }),
+      ).toBeUndefined();
+    }
+    const usage = {
+      inputTokens: 1_000,
+      outputTokens: 100,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+    };
+    expect(priceInclusiveUsage("synthetic", "unknown", usage)).toBeUndefined();
+    expect(priceInclusiveUsage("openrouter", "openrouter/auto", usage)).toBeUndefined();
+    expect(cacheReadSavingsUsd("openrouter", "openrouter/auto", 100)).toBeNull();
+  });
+
+  it.each([
+    ["anthropic", "claude-sonnet-4-6", "explicit"],
+    ["openrouter", "qwen/synthetic", "explicit"],
+    ["openrouter", "anthropic/synthetic", "unavailable"],
+    ["openrouter", "google/synthetic", "unavailable"],
+    ["openrouter", "openai/synthetic", "provider-dependent"],
+    ["openai", "synthetic", "provider-dependent"],
+    ["google", "synthetic", "provider-dependent"],
+    ["deepseek", "synthetic", "provider-dependent"],
+    ["qwen", "synthetic", "provider-dependent"],
+    ["minimax", "synthetic", "provider-dependent"],
+    ["kimi", "synthetic", "provider-dependent"],
+    ["zai", "synthetic", "provider-dependent"],
+    ["openai-codex", "synthetic", "provider-dependent"],
+    ["synthetic", "unknown", "provider-dependent"],
+  ] as const)("classifies %s/%s as %s", (provider, model, expected) => {
+    expect(classifySpendCaching(provider, model)).toBe(expected);
+  });
+});


### PR DESCRIPTION
## Summary

- show today's model spend and cache-read savings in the always-visible desktop rail
- disclose route-level cache availability and use provider-reported OpenRouter generation costs when available
- add a persisted soft daily cap that warns without blocking user chat

## Verification

- exercised rotated-ledger, native-cost, catalog-pricing, timezone, incomplete-cost, and cap-state fixtures
- verified authenticated typed RPC plus hardened renderer and token-containment behavior
- verified reached-cap chat still streams and completes, renderer dependency boundaries, root checks, and the full test suite
