### PR TITLE
fix(desktop): seed first-run configuration before daemon start

### DIFF
--- a/.changeset/desktop-first-run-config.md
+++ b/.changeset/desktop-first-run-config.md
@@ -1,0 +1,6 @@
+---
+"cycling-coach": patch
+"@enduragent/desktop": patch
+---
+
+User-facing: The desktop app now starts correctly on a brand-new install, before any credentials are entered.

--- a/apps/desktop/src/main/first-run-config.ts
+++ b/apps/desktop/src/main/first-run-config.ts
@@ -1,0 +1,144 @@
+import { randomUUID } from "node:crypto";
+import { link, lstat, mkdir, rm, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+
+export const FIRST_RUN_CONFIG_DIRECTORY_MODE = 0o700;
+export const FIRST_RUN_CONFIG_FILE_MODE = 0o600;
+
+export interface FirstRunConfigFileSystem {
+  lstat(path: string): Promise<unknown>;
+  mkdir(path: string, options: { readonly recursive: true; readonly mode: number }): Promise<void>;
+  writeFile(
+    path: string,
+    contents: string,
+    options: { readonly encoding: "utf8"; readonly flag: "wx"; readonly mode: number },
+  ): Promise<void>;
+  link(temporaryPath: string, targetPath: string): Promise<void>;
+  rm(path: string, options: { readonly force: true }): Promise<void>;
+}
+
+export interface FirstRunConfigDependencies {
+  readonly fileSystem?: FirstRunConfigFileSystem;
+  readonly timezone?: () => string | undefined;
+  readonly createId?: () => string;
+}
+
+export interface SeedFirstRunConfigInput {
+  readonly env?: Record<string, string | undefined>;
+  readonly dependencies?: FirstRunConfigDependencies;
+}
+
+const nodeFileSystem: FirstRunConfigFileSystem = {
+  async lstat(path) {
+    await lstat(path);
+  },
+  async mkdir(path, options) {
+    await mkdir(path, options);
+  },
+  async writeFile(path, contents, options) {
+    await writeFile(path, contents, options);
+  },
+  async link(temporaryPath, targetPath) {
+    await link(temporaryPath, targetPath);
+  },
+  async rm(path, options) {
+    await rm(path, options);
+  },
+};
+
+function expandHome(path: string): string {
+  if (path === "~") return homedir();
+  if (path.startsWith("~/")) return join(homedir(), path.slice(2));
+  return path;
+}
+
+export function resolveDesktopAthleteHome(
+  env: Record<string, string | undefined> = process.env,
+): string {
+  const override = env.ENDURAGENT_HOME;
+  return resolve(
+    override !== undefined && override.length > 0
+      ? expandHome(override)
+      : join(homedir(), ".enduragent"),
+  );
+}
+
+function defaultTimezone(): string | undefined {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone;
+  } catch {
+    return undefined;
+  }
+}
+
+function yamlPath(path: string): string {
+  return /^[/A-Za-z0-9._~@%+=-]+$/.test(path) ? path : JSON.stringify(path);
+}
+
+function configContents(homeRoot: string, timezone: string): string {
+  return [
+    "data_source: store",
+    `data_dir: ${yamlPath(homeRoot)}`,
+    "llm:",
+    "  provider: anthropic",
+    "  api_key: ''",
+    "intervals:",
+    "  api_key: ''",
+    "  athlete_id: ''",
+    "session:",
+    `  timezone: ${timezone}`,
+    "",
+  ].join("\n");
+}
+
+async function exists(fileSystem: FirstRunConfigFileSystem, path: string): Promise<boolean> {
+  try {
+    await fileSystem.lstat(path);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw error;
+  }
+}
+
+export async function seedFirstRunConfig(
+  input: SeedFirstRunConfigInput = {},
+): Promise<"seeded" | "existing"> {
+  const fileSystem = input.dependencies?.fileSystem ?? nodeFileSystem;
+  const homeRoot = resolveDesktopAthleteHome(input.env);
+  const configDirectory = join(homeRoot, "config");
+  const target = join(configDirectory, "config.yaml");
+  if (await exists(fileSystem, target)) return "existing";
+
+  await fileSystem.mkdir(configDirectory, {
+    recursive: true,
+    mode: FIRST_RUN_CONFIG_DIRECTORY_MODE,
+  });
+  const temporary = join(
+    configDirectory,
+    `.config.${(input.dependencies?.createId ?? randomUUID)()}.tmp`,
+  );
+  const resolvedTimezone = (input.dependencies?.timezone ?? defaultTimezone)();
+  const timezone =
+    resolvedTimezone === undefined || resolvedTimezone.length === 0 ? "UTC" : resolvedTimezone;
+  try {
+    await fileSystem.writeFile(temporary, configContents(homeRoot, timezone), {
+      encoding: "utf8",
+      flag: "wx",
+      mode: FIRST_RUN_CONFIG_FILE_MODE,
+    });
+    try {
+      await fileSystem.link(temporary, target);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+      await fileSystem.rm(temporary, { force: true });
+      return "existing";
+    }
+    await fileSystem.rm(temporary, { force: true });
+    return "seeded";
+  } catch (error) {
+    await fileSystem.rm(temporary, { force: true }).catch(() => undefined);
+    throw error;
+  }
+}

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -13,6 +13,7 @@ import {
 } from "electron";
 import { DESKTOP_CONNECTION_CHANNEL, DESKTOP_RENDERER_URL, DESKTOP_SCHEME } from "./constants.js";
 import { CREDENTIAL_DIRECTORY_NAME, createCredentialVault } from "./credential-vault.js";
+import { seedFirstRunConfig } from "./first-run-config.js";
 import { registerOnboardingIpc, runtimeConfigurationForCredential } from "./onboarding-ipc.js";
 import { createDesktopResidency, type DesktopResidency } from "./residency.js";
 import {
@@ -59,9 +60,15 @@ async function runDesktop(): Promise<void> {
   app.on("window-all-closed", () => {});
   await app.whenReady();
   const controller = new AbortController();
+  const environment = { ...process.env };
+  try {
+    await seedFirstRunConfig({ env: environment });
+  } catch {
+    process.stderr.write("desktop-first-run-config-failure seed\n");
+  }
   const supervisor = new DesktopDaemonSupervisor(
     {
-      env: { ...process.env },
+      env: environment,
       executablePath: process.execPath,
       appVersion: app.getVersion(),
       signal: controller.signal,

--- a/apps/desktop/tests/first-run-config.test.ts
+++ b/apps/desktop/tests/first-run-config.test.ts
@@ -1,0 +1,200 @@
+import {
+  lstat as fileLstat,
+  link as fileLink,
+  mkdir as fileMkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rm as fileRemove,
+  writeFile as fileWrite,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { parse as parseYaml } from "yaml";
+import {
+  FIRST_RUN_CONFIG_DIRECTORY_MODE,
+  FIRST_RUN_CONFIG_FILE_MODE,
+  seedFirstRunConfig,
+  type FirstRunConfigFileSystem,
+} from "../src/main/first-run-config.js";
+
+const roots: string[] = [];
+
+const actualFileSystem: FirstRunConfigFileSystem = {
+  async lstat(path) {
+    await fileLstat(path);
+  },
+  async mkdir(path, options) {
+    await fileMkdir(path, options);
+  },
+  async writeFile(path, contents, options) {
+    await fileWrite(path, contents, options);
+  },
+  async link(temporaryPath, targetPath) {
+    await fileLink(temporaryPath, targetPath);
+  },
+  async rm(path, options) {
+    await fileRemove(path, options);
+  },
+};
+
+async function temporaryHome(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "desktop-first-run-"));
+  roots.push(root);
+  return join(root, "private parent", "athlete home");
+}
+
+afterEach(async () => {
+  await Promise.all(
+    roots.splice(0).map((root) => fileRemove(root, { recursive: true, force: true })),
+  );
+});
+
+describe("desktop first-run configuration", () => {
+  it("seeds a private parseable configuration for the resolved athlete home", async () => {
+    const home = await temporaryHome();
+    const timezone = vi.fn(() => "Asia/Almaty");
+
+    await expect(
+      seedFirstRunConfig({
+        env: { ENDURAGENT_HOME: home },
+        dependencies: { timezone },
+      }),
+    ).resolves.toBe("seeded");
+
+    const configDirectory = join(home, "config");
+    const configPath = join(configDirectory, "config.yaml");
+    for (const path of [dirname(home), home, configDirectory]) {
+      expect((await fileLstat(path)).mode & 0o777).toBe(FIRST_RUN_CONFIG_DIRECTORY_MODE);
+    }
+    expect((await fileLstat(configPath)).mode & 0o777).toBe(FIRST_RUN_CONFIG_FILE_MODE);
+    const contents = await readFile(configPath, "utf8");
+    expect(contents).toBe(
+      [
+        "data_source: store",
+        `data_dir: ${JSON.stringify(resolve(home))}`,
+        "llm:",
+        "  provider: anthropic",
+        "  api_key: ''",
+        "intervals:",
+        "  api_key: ''",
+        "  athlete_id: ''",
+        "session:",
+        "  timezone: Asia/Almaty",
+        "",
+      ].join("\n"),
+    );
+    const parsed = parseYaml(contents) as Record<string, unknown>;
+    expect(parsed).toMatchObject({
+      data_source: "store",
+      data_dir: resolve(home),
+      llm: { provider: "anthropic", api_key: "" },
+      intervals: { api_key: "", athlete_id: "" },
+      session: { timezone: "Asia/Almaty" },
+    });
+    expect(timezone).toHaveBeenCalledOnce();
+  });
+
+  it("leaves an existing arbitrary configuration byte-identical without mutations", async () => {
+    const home = await temporaryHome();
+    const configDirectory = join(home, "config");
+    const configPath = join(configDirectory, "config.yaml");
+    const original = Buffer.from([0x3a, 0x00, 0xff, 0x0a]);
+    await fileMkdir(configDirectory, { recursive: true, mode: 0o700 });
+    await fileWrite(configPath, original, { mode: 0o600 });
+    const fileSystem: FirstRunConfigFileSystem = {
+      ...actualFileSystem,
+      mkdir: vi.fn(actualFileSystem.mkdir),
+      writeFile: vi.fn(actualFileSystem.writeFile),
+      link: vi.fn(actualFileSystem.link),
+      rm: vi.fn(actualFileSystem.rm),
+    };
+
+    await expect(
+      seedFirstRunConfig({
+        env: { ENDURAGENT_HOME: home },
+        dependencies: { fileSystem, timezone: vi.fn(() => "UTC") },
+      }),
+    ).resolves.toBe("existing");
+
+    expect(await readFile(configPath)).toEqual(original);
+    expect(fileSystem.mkdir).not.toHaveBeenCalled();
+    expect(fileSystem.writeFile).not.toHaveBeenCalled();
+    expect(fileSystem.link).not.toHaveBeenCalled();
+    expect(fileSystem.rm).not.toHaveBeenCalled();
+  });
+
+  it("cleans up a failed atomic write before exposing the target", async () => {
+    const home = await temporaryHome();
+    const configPath = join(home, "config", "config.yaml");
+    let temporaryPath = "";
+    const link = vi.fn(actualFileSystem.link);
+    const fileSystem: FirstRunConfigFileSystem = {
+      ...actualFileSystem,
+      async writeFile(path) {
+        temporaryPath = path;
+        await fileWrite(path, "partial", { flag: "wx", mode: 0o600 });
+        throw new Error("synthetic write failure");
+      },
+      link,
+    };
+
+    await expect(
+      seedFirstRunConfig({
+        env: { ENDURAGENT_HOME: home },
+        dependencies: { fileSystem, timezone: () => "UTC", createId: () => "atomic-seam" },
+      }),
+    ).rejects.toThrow("synthetic write failure");
+
+    expect(dirname(temporaryPath)).toBe(dirname(configPath));
+    expect(temporaryPath).toBe(join(dirname(configPath), ".config.atomic-seam.tmp"));
+    await expect(fileLstat(configPath)).rejects.toMatchObject({ code: "ENOENT" });
+    expect(await readdir(dirname(configPath))).toEqual([]);
+    expect(link).not.toHaveBeenCalled();
+  });
+
+  it("preserves a configuration published concurrently with the seed", async () => {
+    const home = await temporaryHome();
+    const configPath = join(home, "config", "config.yaml");
+    const concurrent = Buffer.from("concurrent invalid bytes\u0000\n");
+    const fileSystem: FirstRunConfigFileSystem = {
+      ...actualFileSystem,
+      async link(temporaryPath, targetPath) {
+        await fileWrite(targetPath, concurrent, { flag: "wx", mode: 0o600 });
+        await fileLink(temporaryPath, targetPath);
+      },
+    };
+
+    await expect(
+      seedFirstRunConfig({
+        env: { ENDURAGENT_HOME: home },
+        dependencies: { fileSystem, timezone: () => "UTC" },
+      }),
+    ).resolves.toBe("existing");
+
+    expect(await readFile(configPath)).toEqual(concurrent);
+    expect(await readdir(dirname(configPath))).toEqual(["config.yaml"]);
+  });
+
+  it("falls back to UTC when the timezone provider is unavailable", async () => {
+    const home = await temporaryHome();
+    await seedFirstRunConfig({
+      env: { ENDURAGENT_HOME: home },
+      dependencies: { timezone: () => undefined },
+    });
+    const parsed = parseYaml(await readFile(join(home, "config", "config.yaml"), "utf8")) as {
+      session: { timezone: string };
+    };
+    expect(parsed.session.timezone).toBe("UTC");
+  });
+
+  it("integrates the seed before constructing the daemon supervisor", async () => {
+    const source = await readFile(resolve(import.meta.dirname, "../src/main/index.ts"), "utf8");
+    const seedCall = source.indexOf("await seedFirstRunConfig({ env: environment });");
+    const supervisorConstruction = source.indexOf("new DesktopDaemonSupervisor(");
+    expect(seedCall).toBeGreaterThan(-1);
+    expect(supervisorConstruction).toBeGreaterThan(seedCall);
+    expect(source).toContain('process.stderr.write("desktop-first-run-config-failure seed\\n");');
+  });
+});


### PR DESCRIPTION
## Problem

On a brand-new install the daemon exited immediately with a not-configured readiness result: readiness requires `config/config.yaml` to exist and parse as a YAML map, but onboarding writes configuration through the `configureRuntime` RPC — which needs the daemon up. Nothing ever created the initial file, so a fresh machine could never reach onboarding without hand-seeding the config.

## Fix

The desktop main process now seeds a minimal pre-onboarding `config/config.yaml` before constructing the daemon supervisor, only when the file is absent:

- Resolves the same athlete home the daemon uses (`ENDURAGENT_HOME` override or `~/.enduragent`).
- Creates the directory chain with mode `0700` and the file with mode `0600`.
- Publishes atomically via a same-directory temp file + no-clobber hard link, so a concurrently created configuration is never overwritten (POSIX `rename` would replace it; `link` fails with `EEXIST` and preserves the competing bytes).
- Fills `session.timezone` from the host (`Intl.DateTimeFormat().resolvedOptions().timeZone`, `UTC` fallback); all credential fields seed empty for onboarding to fill.
- Seeding failure is reported on stderr and startup continues to the supervisor unchanged.

## Verification

- 10 new unit tests (seeding, existing-config no-op, concurrent-creator byte preservation, permissions, timezone fallback, home resolution).
- Full repo gate green (4592 passed) plus desktop build, runtime and security smokes.
- Packaged-app proof: launched the built app against a nonexistent home — `config.yaml` seeded with mode `600` and the daemon came up and published its connection files with no manual intervention.
