### PR TITLE
feat(desktop): sign in with ChatGPT subscription for coach model

### DIFF
--- a/.changeset/desktop-chatgpt-signin.md
+++ b/.changeset/desktop-chatgpt-signin.md
@@ -1,0 +1,12 @@
+---
+"cycling-coach": patch
+"@enduragent/coach": patch
+"@enduragent/coach-client": patch
+"@enduragent/coach-contract": patch
+"@enduragent/core": patch
+"@enduragent/engine": patch
+---
+
+User-facing: Sign in with your ChatGPT subscription as your coach model — no API key needed.
+
+Added desktop PKCE sign-in, daemon-owned OAuth profile storage, and keyless runtime configuration for the ChatGPT subscription provider.

--- a/apps/desktop-renderer/src/global.d.ts
+++ b/apps/desktop-renderer/src/global.d.ts
@@ -8,6 +8,8 @@ interface EnduragentAuth {
     readonly slot: DesktopCredentialSlot;
     readonly value: string;
   }): Promise<CredentialWriteResult>;
+  chatgptStatus(): Promise<ChatGptStatus>;
+  chatgptLogin(): Promise<ChatGptLoginResult>;
   chooseImportFiles(): Promise<readonly string[]>;
   onDroppedImportFiles(listener: (paths: readonly string[]) => void): () => void;
 }
@@ -31,6 +33,25 @@ interface CredentialSlotStatus {
   readonly state: CredentialState;
   readonly runtimeReady: boolean;
 }
+
+interface ChatGptStatus {
+  readonly state: "configured" | "absent";
+  readonly runtimeReady: boolean;
+}
+
+type ChatGptLoginResult =
+  | { readonly status: "configured"; readonly runtimeReady: true }
+  | {
+      readonly status: "refused";
+      readonly reason:
+        | "already-in-progress"
+        | "callback-unavailable"
+        | "timed-out"
+        | "cancelled"
+        | "exchange-failed"
+        | "storage-failed"
+        | "runtime-unavailable";
+    };
 
 type CredentialWriteResult =
   | {

--- a/apps/desktop-renderer/src/index.ts
+++ b/apps/desktop-renderer/src/index.ts
@@ -168,6 +168,8 @@ const onboardingClient = async () => {
 const onboardingBridge: OnboardingBridge = {
   credentialStatuses: () => window.enduragentAuth.credentialStatuses(),
   writeCredential: (value) => window.enduragentAuth.writeCredential(value),
+  chatGptStatus: () => window.enduragentAuth.chatgptStatus(),
+  chatGptLogin: () => window.enduragentAuth.chatgptLogin(),
   chooseImportFiles: () => window.enduragentAuth.chooseImportFiles(),
   onDroppedImportFiles: (listener) => window.enduragentAuth.onDroppedImportFiles(listener),
   async importFiles(paths, onProgress) {

--- a/apps/desktop-renderer/src/onboarding/bridge.ts
+++ b/apps/desktop-renderer/src/onboarding/bridge.ts
@@ -8,7 +8,7 @@ import {
   type SaveIntakeRpcParams,
 } from "@enduragent/coach-contract";
 import { SUPPORTED_IMPORT_EXTENSIONS, type DesktopCredentialSlot } from "./constants.js";
-import type { CredentialSlotStatus } from "./machine.js";
+import type { ChatGptLoginResult, ChatGptStatus, CredentialSlotStatus } from "./machine.js";
 
 export type CredentialWriteResult =
   | {
@@ -33,6 +33,8 @@ export interface OnboardingBridge {
     readonly slot: DesktopCredentialSlot;
     readonly value: string;
   }): Promise<CredentialWriteResult>;
+  chatGptStatus(): Promise<ChatGptStatus>;
+  chatGptLogin(): Promise<ChatGptLoginResult>;
   chooseImportFiles(): Promise<readonly string[]>;
   onDroppedImportFiles(listener: (paths: readonly string[]) => void): () => void;
   importFiles(
@@ -52,6 +54,8 @@ export interface DesktopOnboardingAuth {
     readonly slot: DesktopCredentialSlot;
     readonly value: string;
   }): Promise<CredentialWriteResult>;
+  chatgptStatus(): Promise<ChatGptStatus>;
+  chatgptLogin(): Promise<ChatGptLoginResult>;
   chooseImportFiles(): Promise<readonly string[]>;
   onDroppedImportFiles(listener: (paths: readonly string[]) => void): () => void;
 }
@@ -117,6 +121,8 @@ export function createOnboardingBridge(
   return {
     credentialStatuses: () => auth.credentialStatuses() as Promise<readonly CredentialSlotStatus[]>,
     writeCredential: (input) => auth.writeCredential(input) as Promise<CredentialWriteResult>,
+    chatGptStatus: () => auth.chatgptStatus(),
+    chatGptLogin: () => auth.chatgptLogin(),
     chooseImportFiles: () => auth.chooseImportFiles(),
     onDroppedImportFiles: (listener) => auth.onDroppedImportFiles(listener),
     async importFiles(paths, onProgress) {

--- a/apps/desktop-renderer/src/onboarding/constants.ts
+++ b/apps/desktop-renderer/src/onboarding/constants.ts
@@ -38,6 +38,18 @@ export const DESKTOP_CREDENTIAL_SLOTS = [
 export type DesktopCredentialSlot = (typeof DESKTOP_CREDENTIAL_SLOTS)[number];
 export type ModelCredentialSlot = Exclude<DesktopCredentialSlot, "intervals-icu">;
 
+export const CHATGPT_LOGIN_REFUSAL_REASONS = [
+  "already-in-progress",
+  "callback-unavailable",
+  "timed-out",
+  "cancelled",
+  "exchange-failed",
+  "storage-failed",
+  "runtime-unavailable",
+] as const;
+
+export type ChatGptLoginRefusalReason = (typeof CHATGPT_LOGIN_REFUSAL_REASONS)[number];
+
 export const SUPPORTED_IMPORT_EXTENSIONS = [".fit", ".tcx", ".gpx"] as const;
 
 export const INTERVALS_GUIDANCE =

--- a/apps/desktop-renderer/src/onboarding/machine.ts
+++ b/apps/desktop-renderer/src/onboarding/machine.ts
@@ -7,6 +7,7 @@ import {
   DESKTOP_CREDENTIAL_SLOTS,
   ONBOARDING_STEP_IDS,
   type DesktopCredentialSlot,
+  type ChatGptLoginRefusalReason,
   type OnboardingStepId,
 } from "./constants.js";
 
@@ -17,6 +18,15 @@ export interface CredentialSlotStatus {
   readonly state: CredentialState;
   readonly runtimeReady: boolean;
 }
+
+export interface ChatGptStatus {
+  readonly state: "configured" | "absent";
+  readonly runtimeReady: boolean;
+}
+
+export type ChatGptLoginResult =
+  | { readonly status: "configured"; readonly runtimeReady: true }
+  | { readonly status: "refused"; readonly reason: ChatGptLoginRefusalReason };
 
 export interface DesktopIntakeDraft {
   readonly priorBsi: boolean | null;
@@ -35,6 +45,9 @@ export type OnboardingErrorCode =
 export interface OnboardingState {
   readonly step: OnboardingStepId;
   readonly credentialStatus: Readonly<Record<DesktopCredentialSlot, CredentialState>>;
+  readonly chatGptState: "absent" | "pending" | "configured" | "refused";
+  readonly chatGptRuntimeReady: boolean;
+  readonly chatGptRefusal: ChatGptLoginRefusalReason | null;
   readonly acceptedImportPaths: readonly string[];
   readonly importProgress: CoachOperationProgressNotificationEnvelope | null;
   readonly intake: DesktopIntakeDraft;
@@ -57,6 +70,7 @@ function statusRecord<T>(initial: T): Record<DesktopCredentialSlot, T> {
 
 export function createOnboardingState(
   statuses: readonly CredentialSlotStatus[] = [],
+  chatGptStatus: ChatGptStatus = { state: "absent", runtimeReady: false },
 ): OnboardingState {
   const credentialStatus = statusRecord<CredentialState>("missing");
   for (const status of statuses) {
@@ -65,12 +79,57 @@ export function createOnboardingState(
   return {
     step: "coach-keys",
     credentialStatus,
+    chatGptState: chatGptStatus.state,
+    chatGptRuntimeReady: chatGptStatus.runtimeReady,
+    chatGptRefusal: null,
     acceptedImportPaths: [],
     importProgress: null,
     intake: { priorBsi: null, injuryStatus: null, clinicianCleared: null },
     busy: false,
     fixedError: null,
   };
+}
+
+export function withChatGptStatus(state: OnboardingState, status: ChatGptStatus): OnboardingState {
+  return {
+    ...state,
+    chatGptState: status.state,
+    chatGptRuntimeReady: status.runtimeReady,
+    chatGptRefusal: null,
+  };
+}
+
+export function withChatGptPending(state: OnboardingState): OnboardingState {
+  return {
+    ...state,
+    chatGptState: "pending",
+    chatGptRuntimeReady: false,
+    chatGptRefusal: null,
+    busy: true,
+    fixedError: null,
+  };
+}
+
+export function withChatGptLoginResult(
+  state: OnboardingState,
+  result: ChatGptLoginResult,
+): OnboardingState {
+  return result.status === "configured"
+    ? {
+        ...state,
+        chatGptState: "configured",
+        chatGptRuntimeReady: true,
+        chatGptRefusal: null,
+        busy: false,
+        fixedError: null,
+      }
+    : {
+        ...state,
+        chatGptState: "refused",
+        chatGptRuntimeReady: false,
+        chatGptRefusal: result.reason,
+        busy: false,
+      };
 }
 
 export function withCredentialStatuses(
@@ -85,8 +144,11 @@ export function withCredentialStatuses(
 }
 
 export function hasConfiguredModel(state: OnboardingState): boolean {
-  return DESKTOP_CREDENTIAL_SLOTS.some(
-    (slot) => slot !== "intervals-icu" && state.credentialStatus[slot] === "configured",
+  return (
+    state.chatGptState === "configured" ||
+    DESKTOP_CREDENTIAL_SLOTS.some(
+      (slot) => slot !== "intervals-icu" && state.credentialStatus[slot] === "configured",
+    )
   );
 }
 

--- a/apps/desktop-renderer/src/onboarding/mount.ts
+++ b/apps/desktop-renderer/src/onboarding/mount.ts
@@ -17,12 +17,16 @@ import {
   previousStep,
   toDesktopIntakeFlags,
   withBusy,
+  withChatGptLoginResult,
+  withChatGptPending,
+  withChatGptStatus,
   withCredentialStatuses,
   withError,
   withImportProgress,
   withIntake,
   withSuccessfulImport,
   type CredentialSlotStatus,
+  type ChatGptStatus,
   type OnboardingCompletion,
   type OnboardingErrorCode,
   type OnboardingState,
@@ -67,13 +71,24 @@ export async function handoffCredential(
 }
 
 const ERROR_COPY: Readonly<Record<OnboardingErrorCode, string>> = {
-  "credential-required": "Add at least one model key to continue.",
+  "credential-required": "Sign in with ChatGPT or add at least one model key to continue.",
   "credential-save-failed": "That key could not be saved. Try entering it again.",
   "training-data-required": "Connect intervals.icu or import at least one ride file.",
   "import-failed": "Those ride files could not be imported. Try another selection.",
   "intake-incomplete": "Answer the required safety questions to continue.",
   "intake-save-failed": "Your answers could not be saved. Please try again.",
 };
+
+const CHATGPT_REFUSAL_COPY = {
+  "already-in-progress": "A ChatGPT sign-in is already in progress.",
+  "callback-unavailable":
+    "The local sign-in callback is unavailable. Close other sign-in flows and retry.",
+  "timed-out": "ChatGPT sign-in timed out. Retry when you are ready.",
+  cancelled: "ChatGPT sign-in was cancelled. You can retry.",
+  "exchange-failed": "ChatGPT sign-in could not be completed. Please retry.",
+  "storage-failed": "ChatGPT sign-in completed, but the profile could not be saved.",
+  "runtime-unavailable": "ChatGPT sign-in was saved, but the coach could not be configured.",
+} as const;
 
 function make<K extends keyof HTMLElementTagNameMap>(
   document: Document,
@@ -167,10 +182,13 @@ export function mountOnboarding(options: MountOnboardingOptions): OnboardingCont
   };
 
   const refreshStatuses = async (expectedVisit: number): Promise<void> => {
-    const statuses = await options.bridge.credentialStatuses();
+    const [statuses, chatGpt] = await Promise.all([
+      options.bridge.credentialStatuses(),
+      options.bridge.chatGptStatus(),
+    ]);
     if (visit !== expectedVisit || scrim === undefined) return;
     credentialStatuses = statuses;
-    state = withCredentialStatuses(state, statuses);
+    state = withChatGptStatus(withCredentialStatuses(state, statuses), chatGpt);
   };
 
   const savePasswordControls = async (
@@ -292,9 +310,93 @@ export function mountOnboarding(options: MountOnboardingOptions): OnboardingCont
         options.document,
         "p",
         "onboarding-copy",
-        "Your keys are encrypted by macOS and sent only to the local coaching service.",
+        "Sign in with ChatGPT or use an API key. API keys are encrypted by macOS and sent only to the local coaching service.",
       ),
     );
+    const chatGptLane = make(options.document, "section", "chatgpt-lane");
+    const chatGptHeading = make(options.document, "div", "chatgpt-lane-heading");
+    chatGptHeading.append(
+      make(options.document, "strong", undefined, "ChatGPT subscription"),
+      make(
+        options.document,
+        "span",
+        `credential-state ${state.chatGptState === "configured" ? "configured" : ""}`,
+        state.chatGptState === "configured" ? "Configured" : "No API key",
+      ),
+    );
+    chatGptLane.append(
+      chatGptHeading,
+      make(options.document, "p", undefined, "Requires a paid ChatGPT plan. No API key needed."),
+    );
+    if (state.chatGptState === "pending") {
+      const pending = make(
+        options.document,
+        "button",
+        "primary-button chatgpt-signin-button",
+        "Finish signing in in your browser…",
+      );
+      pending.type = "button";
+      pending.disabled = true;
+      chatGptLane.append(pending);
+    } else if (state.chatGptState === "configured" && state.chatGptRuntimeReady) {
+      chatGptLane.append(
+        make(options.document, "p", "chatgpt-login-state configured", "ChatGPT is ready."),
+      );
+    } else {
+      if (state.chatGptState === "refused" && state.chatGptRefusal !== null) {
+        const refusal = make(
+          options.document,
+          "p",
+          "chatgpt-login-state refused",
+          CHATGPT_REFUSAL_COPY[state.chatGptRefusal],
+        );
+        refusal.setAttribute("aria-live", "polite");
+        chatGptLane.append(refusal);
+      }
+      if (state.chatGptState === "configured") {
+        chatGptLane.append(
+          make(
+            options.document,
+            "p",
+            "chatgpt-login-state",
+            "Your ChatGPT sign-in is saved. Sign in again to activate it.",
+          ),
+        );
+      }
+      const login = make(
+        options.document,
+        "button",
+        "primary-button chatgpt-signin-button",
+        state.chatGptState === "absent" ? "Sign in with ChatGPT" : "Retry ChatGPT sign-in",
+      );
+      login.type = "button";
+      login.disabled = state.busy;
+      login.addEventListener("click", () => {
+        const loginVisit = visit;
+        state = withChatGptPending(state);
+        render();
+        void options.bridge.chatGptLogin().then(
+          (result) => {
+            if (visit !== loginVisit || scrim === undefined) return;
+            state = withChatGptLoginResult(state, result);
+            render();
+            focusCurrentTitle();
+          },
+          () => {
+            if (visit !== loginVisit || scrim === undefined) return;
+            state = withChatGptLoginResult(state, {
+              status: "refused",
+              reason: "exchange-failed",
+            });
+            render();
+            focusCurrentTitle();
+          },
+        );
+      });
+      chatGptLane.append(login);
+    }
+    body.append(chatGptLane);
+    body.append(make(options.document, "div", "source-divider", "or use an API key"));
     const primary = make(options.document, "div", "credential-list");
     for (const provider of PRIMARY_MODEL_CREDENTIAL_SLOTS) {
       const control = passwordControl(
@@ -658,15 +760,19 @@ export function mountOnboarding(options: MountOnboardingOptions): OnboardingCont
       const openVisit = ++visit;
       completed = false;
       let statuses: readonly CredentialSlotStatus[] = [];
-      try {
-        statuses = await options.bridge.credentialStatuses();
-      } catch {}
+      let restoredChatGptStatus: ChatGptStatus = { state: "absent", runtimeReady: false };
+      const restored = await Promise.allSettled([
+        options.bridge.credentialStatuses(),
+        options.bridge.chatGptStatus(),
+      ]);
+      if (restored[0].status === "fulfilled") statuses = restored[0].value;
+      if (restored[1].status === "fulfilled") restoredChatGptStatus = restored[1].value;
       if (disposed || visit !== openVisit || scrim !== undefined) {
         opening = false;
         return;
       }
       credentialStatuses = statuses;
-      state = createOnboardingState(statuses);
+      state = createOnboardingState(statuses, restoredChatGptStatus);
       scrim = make(options.document, "div", "onboarding-scrim");
       options.document.body.append(scrim);
       render();

--- a/apps/desktop-renderer/src/onboarding/onboarding.css
+++ b/apps/desktop-renderer/src/onboarding/onboarding.css
@@ -95,6 +95,40 @@
   gap: 14px;
 }
 
+.chatgpt-lane {
+  display: grid;
+  gap: 10px;
+  padding: 16px;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: var(--moss-soft);
+}
+
+.chatgpt-lane-heading {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.chatgpt-lane p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.chatgpt-signin-button {
+  justify-self: start;
+}
+
+.chatgpt-login-state.configured {
+  color: var(--moss);
+}
+
+.chatgpt-login-state.refused {
+  color: #9a4937;
+}
+
 .credential-field {
   display: grid;
   gap: 7px;

--- a/apps/desktop-renderer/tests/onboarding-machine.test.ts
+++ b/apps/desktop-renderer/tests/onboarding-machine.test.ts
@@ -6,6 +6,9 @@ import {
   previousStep,
   toDesktopIntakeFlags,
   withCredentialStatuses,
+  withChatGptLoginResult,
+  withChatGptPending,
+  withChatGptStatus,
   withIntake,
   withSuccessfulImport,
 } from "../src/onboarding/machine.js";
@@ -16,6 +19,9 @@ describe("desktop onboarding machine", () => {
     expect(Object.keys(state).sort()).toEqual([
       "acceptedImportPaths",
       "busy",
+      "chatGptRefusal",
+      "chatGptRuntimeReady",
+      "chatGptState",
       "credentialStatus",
       "fixedError",
       "importProgress",
@@ -45,6 +51,27 @@ describe("desktop onboarding machine", () => {
     state = withIntake(state, { priorBsi: false, injuryStatus: "none" });
     state = nextStep(state);
     expect(state.step).toBe("ready");
+  });
+
+  it("accepts a restored or newly configured ChatGPT lane and preserves refusals for retry", () => {
+    let state = createOnboardingState([], { state: "configured", runtimeReady: false });
+    expect(nextStep(state).step).toBe("training-data");
+    state = createOnboardingState();
+    state = withChatGptPending(state);
+    expect(state).toMatchObject({ chatGptState: "pending", busy: true });
+    state = withChatGptLoginResult(state, {
+      status: "refused",
+      reason: "callback-unavailable",
+    });
+    expect(state).toMatchObject({
+      chatGptState: "refused",
+      chatGptRefusal: "callback-unavailable",
+      busy: false,
+    });
+    state = withChatGptLoginResult(state, { status: "configured", runtimeReady: true });
+    expect(nextStep(state).step).toBe("training-data");
+    state = withChatGptStatus(state, { state: "absent", runtimeReady: false });
+    expect(state.chatGptState).toBe("absent");
   });
 
   it("preserves configured metadata and successful imports while moving back", () => {

--- a/apps/desktop-renderer/tests/onboarding-wizard.test.ts
+++ b/apps/desktop-renderer/tests/onboarding-wizard.test.ts
@@ -122,6 +122,32 @@ describe("desktop onboarding wizard", () => {
     expect(progress).toHaveBeenCalledTimes(1);
   });
 
+  it("passes ChatGPT status and login through without connecting the daemon", async () => {
+    const auth = {
+      getDaemonConnection: vi.fn(),
+      credentialStatuses: vi.fn(async () => []),
+      writeCredential: vi.fn(),
+      chatgptStatus: vi.fn(async () => ({ state: "configured" as const, runtimeReady: false })),
+      chatgptLogin: vi.fn(async () => ({
+        status: "configured" as const,
+        runtimeReady: true as const,
+      })),
+      chooseImportFiles: vi.fn(async () => []),
+      onDroppedImportFiles: vi.fn(() => vi.fn()),
+    } as unknown as DesktopOnboardingAuth;
+    const connect = vi.fn();
+    const bridge = createOnboardingBridge(auth, connect);
+    await expect(bridge.chatGptStatus()).resolves.toEqual({
+      state: "configured",
+      runtimeReady: false,
+    });
+    await expect(bridge.chatGptLogin()).resolves.toEqual({
+      status: "configured",
+      runtimeReady: true,
+    });
+    expect(connect).not.toHaveBeenCalled();
+  });
+
   it("retries connection resolution after a transient connection failure", async () => {
     const connection = {
       url: "ws://127.0.0.1:45001/rpc" as const,
@@ -174,6 +200,9 @@ describe("desktop onboarding wizard", () => {
     expect(mount).toContain('event.key === "Escape"');
     expect(mount).toContain('event.key !== "Tab"');
     expect(mount).toContain('setAttribute("aria-live", "polite")');
+    expect(mount).toContain("Sign in with ChatGPT");
+    expect(mount).toContain("Requires a paid ChatGPT plan. No API key needed.");
+    expect(mount).toContain("Finish signing in in your browser…");
     expect(styles).toContain("@media (max-width: 720px)");
     expect(styles).toContain("padding: 30px 24px");
     expect(styles).toContain("@media (prefers-reduced-motion: reduce)");

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -22,7 +22,9 @@
   "dependencies": {
     "@enduragent/coach": "workspace:*",
     "@enduragent/coach-client": "workspace:*",
-    "@enduragent/coach-contract": "workspace:*"
+    "@enduragent/coach-contract": "workspace:*",
+    "@enduragent/core": "workspace:*",
+    "yaml": "^2.8.3"
   },
   "devDependencies": {
     "@enduragent/desktop-renderer": "workspace:*",

--- a/apps/desktop/scripts/electron-smoke.mjs
+++ b/apps/desktop/scripts/electron-smoke.mjs
@@ -224,7 +224,7 @@ async function security() {
         spoofOrigin: spoofed === expectedForbidden,
         wrongToken: wrongCode === 1008,
         observerOrder: JSON.stringify(observerOrder) === JSON.stringify(expectedOrder),
-        preloadBridge: JSON.stringify(ready.bridgeKeys) === JSON.stringify(["chooseImportFiles", "credentialStatuses", "getDaemonConnection", "onDroppedImportFiles", "writeCredential"]),
+        preloadBridge: JSON.stringify(ready.bridgeKeys) === JSON.stringify(["chatgptLogin", "chatgptStatus", "chooseImportFiles", "credentialStatuses", "getDaemonConnection", "onDroppedImportFiles", "writeCredential"]),
         credentialMetadata: ready.credentialStatusesMetadataOnly === true,
       },
       url: ready.url,

--- a/apps/desktop/src/main/chatgpt-auth.ts
+++ b/apps/desktop/src/main/chatgpt-auth.ts
@@ -1,0 +1,221 @@
+import { randomUUID } from "node:crypto";
+import { chmod, mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { loginCodex, type CodexCredentials, type CodexLoginOptions } from "@enduragent/core";
+import type { ConfigureRuntimeRpcParams } from "@enduragent/coach-contract";
+import { parse as parseYaml } from "yaml";
+
+export const CHATGPT_PROFILE_NAME = "openai-codex" as const;
+export const CHATGPT_MODEL = "gpt-5.5" as const;
+export const CHATGPT_LOGIN_TIMEOUT_MS = 5 * 60 * 1000;
+
+export type ChatGptLoginRefusalReason =
+  | "already-in-progress"
+  | "callback-unavailable"
+  | "timed-out"
+  | "cancelled"
+  | "exchange-failed"
+  | "storage-failed"
+  | "runtime-unavailable";
+
+export interface ChatGptStatus {
+  readonly state: "configured" | "absent";
+  readonly runtimeReady: boolean;
+}
+
+export type ChatGptLoginResult =
+  | { readonly status: "configured"; readonly runtimeReady: true }
+  | { readonly status: "refused"; readonly reason: ChatGptLoginRefusalReason };
+
+export interface ChatGptAuthController {
+  status(): Promise<ChatGptStatus>;
+  login(): Promise<ChatGptLoginResult>;
+}
+
+interface ChatGptAuthDependencies {
+  readonly loginCodex?: (options: CodexLoginOptions) => Promise<CodexCredentials>;
+  readonly writeProfile?: (configDir: string, credentials: CodexCredentials) => Promise<void>;
+}
+
+interface CreateChatGptAuthOptions {
+  readonly configDir: string;
+  readonly applyRuntimeConfig: (request: ConfigureRuntimeRpcParams) => Promise<void>;
+  readonly openExternal: (url: string) => Promise<void>;
+  readonly signal?: AbortSignal;
+  readonly timeoutMs?: number;
+  readonly dependencies?: ChatGptAuthDependencies;
+}
+
+class ChatGptAuthFlowError extends Error {
+  constructor(readonly reason: "callback-unavailable" | "cancelled") {
+    super(reason);
+    this.name = "ChatGptAuthFlowError";
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function validProfile(value: unknown): boolean {
+  if (!isRecord(value)) return false;
+  return (
+    value.type === "oauth" &&
+    typeof value.access === "string" &&
+    value.access.length > 0 &&
+    typeof value.refresh === "string" &&
+    value.refresh.length > 0 &&
+    typeof value.expires === "number" &&
+    Number.isFinite(value.expires) &&
+    (value.accountId === undefined || typeof value.accountId === "string") &&
+    (value.email === undefined || typeof value.email === "string")
+  );
+}
+
+async function readProfiles(configDir: string): Promise<Record<string, unknown>> {
+  let contents: string;
+  try {
+    contents = await readFile(join(configDir, "auth-profiles.json"), "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return {};
+    throw error;
+  }
+  try {
+    const parsed = JSON.parse(contents) as unknown;
+    return isRecord(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+export async function hasChatGptProfile(configDir: string): Promise<boolean> {
+  try {
+    return validProfile((await readProfiles(configDir))[CHATGPT_PROFILE_NAME]);
+  } catch {
+    return false;
+  }
+}
+
+export async function writeChatGptProfile(
+  configDir: string,
+  credentials: CodexCredentials,
+): Promise<void> {
+  await mkdir(configDir, { recursive: true, mode: 0o700 });
+  const path = join(configDir, "auth-profiles.json");
+  const temporaryPath = join(configDir, `.auth-profiles.${randomUUID()}.tmp`);
+  const profiles = await readProfiles(configDir);
+  profiles[CHATGPT_PROFILE_NAME] = {
+    type: "oauth",
+    access: credentials.access,
+    refresh: credentials.refresh,
+    expires: credentials.expires,
+    ...(credentials.accountId.length > 0 ? { accountId: credentials.accountId } : {}),
+    ...(credentials.email !== undefined ? { email: credentials.email } : {}),
+  };
+  try {
+    await writeFile(temporaryPath, JSON.stringify(profiles, null, 2), {
+      encoding: "utf8",
+      flag: "wx",
+      mode: 0o600,
+    });
+    await chmod(temporaryPath, 0o600);
+    await rename(temporaryPath, path);
+    await chmod(path, 0o600);
+  } catch (error) {
+    await rm(temporaryPath, { force: true }).catch(() => undefined);
+    throw error;
+  }
+}
+
+async function configuredRuntime(configDir: string): Promise<boolean> {
+  try {
+    const parsed = parseYaml(await readFile(join(configDir, "config.yaml"), "utf8")) as unknown;
+    return isRecord(parsed) && isRecord(parsed.llm) && parsed.llm.provider === CHATGPT_PROFILE_NAME;
+  } catch {
+    return false;
+  }
+}
+
+function classifyLoginFailure(
+  error: unknown,
+  timeoutSignal: AbortSignal,
+  sessionSignal: AbortSignal | undefined,
+): ChatGptLoginRefusalReason {
+  if (error instanceof ChatGptAuthFlowError) return error.reason;
+  if (timeoutSignal.aborted) return "timed-out";
+  if (sessionSignal?.aborted) return "cancelled";
+  if (isRecord(error) && error.name === "AbortError") return "cancelled";
+  return "exchange-failed";
+}
+
+export function createChatGptAuth(options: CreateChatGptAuthOptions): ChatGptAuthController {
+  const runLogin = options.dependencies?.loginCodex ?? loginCodex;
+  const storeProfile = options.dependencies?.writeProfile ?? writeChatGptProfile;
+  let runtimeReadyThisSession = false;
+  let activeLogin: Promise<ChatGptLoginResult> | undefined;
+
+  const performLogin = async (): Promise<ChatGptLoginResult> => {
+    const timeoutSignal = AbortSignal.timeout(options.timeoutMs ?? CHATGPT_LOGIN_TIMEOUT_MS);
+    const browserController = new AbortController();
+    const signals = [timeoutSignal, browserController.signal];
+    if (options.signal !== undefined) signals.push(options.signal);
+    const signal = AbortSignal.any(signals);
+    let credentials: CodexCredentials;
+    try {
+      credentials = await runLogin({
+        originator: "enduragent-desktop",
+        signal,
+        onAuth: ({ url }) => {
+          void options.openExternal(url).catch(() => {
+            browserController.abort(new ChatGptAuthFlowError("cancelled"));
+          });
+        },
+        onPrompt: async () => {
+          throw new ChatGptAuthFlowError("callback-unavailable");
+        },
+      });
+    } catch (error) {
+      return {
+        status: "refused",
+        reason: classifyLoginFailure(error, timeoutSignal, options.signal),
+      };
+    }
+    try {
+      await storeProfile(options.configDir, credentials);
+    } catch {
+      return { status: "refused", reason: "storage-failed" };
+    }
+    try {
+      await options.applyRuntimeConfig({
+        llm: { provider: CHATGPT_PROFILE_NAME, model: CHATGPT_MODEL },
+      });
+    } catch {
+      return { status: "refused", reason: "runtime-unavailable" };
+    }
+    runtimeReadyThisSession = true;
+    return { status: "configured", runtimeReady: true };
+  };
+
+  return {
+    async status() {
+      const configured = await hasChatGptProfile(options.configDir);
+      return {
+        state: configured ? "configured" : "absent",
+        runtimeReady:
+          configured && (runtimeReadyThisSession || (await configuredRuntime(options.configDir))),
+      };
+    },
+    async login() {
+      if (activeLogin !== undefined) {
+        return { status: "refused", reason: "already-in-progress" };
+      }
+      const pending = performLogin();
+      activeLogin = pending;
+      try {
+        return await pending;
+      } finally {
+        if (activeLogin === pending) activeLogin = undefined;
+      }
+    },
+  };
+}

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -2,6 +2,7 @@ import { writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { connectCoachClient } from "@enduragent/coach-client";
+import type { ConfigureRuntimeRpcParams } from "@enduragent/coach-contract";
 import {
   app,
   BrowserWindow,
@@ -9,11 +10,13 @@ import {
   ipcMain,
   safeStorage,
   session,
+  shell,
   utilityProcess,
 } from "electron";
+import { createChatGptAuth } from "./chatgpt-auth.js";
 import { DESKTOP_CONNECTION_CHANNEL, DESKTOP_RENDERER_URL, DESKTOP_SCHEME } from "./constants.js";
 import { CREDENTIAL_DIRECTORY_NAME, createCredentialVault } from "./credential-vault.js";
-import { seedFirstRunConfig } from "./first-run-config.js";
+import { resolveDesktopAthleteHome, seedFirstRunConfig } from "./first-run-config.js";
 import { registerOnboardingIpc, runtimeConfigurationForCredential } from "./onboarding-ipc.js";
 import { createDesktopResidency, type DesktopResidency } from "./residency.js";
 import {
@@ -115,24 +118,32 @@ async function runDesktop(): Promise<void> {
       return;
     }
     const daemonPort = Number(new URL(resolution.url).port);
+    const applyRuntimeConfig = async (request: ConfigureRuntimeRpcParams): Promise<void> => {
+      const client = await connectCoachClient({ url: resolution.url, token: resolution.token });
+      try {
+        const result = await client.call("configureRuntime", request);
+        if (
+          (request.llm !== undefined && !result.applied.llm) ||
+          (request.intervals !== undefined && !result.applied.intervals)
+        ) {
+          throw new TypeError();
+        }
+      } finally {
+        await client.close();
+      }
+    };
     const vault = createCredentialVault({
       root: join(app.getPath("userData"), CREDENTIAL_DIRECTORY_NAME),
       encryption: safeStorage,
       async applyCredential(slot, value) {
-        const client = await connectCoachClient({ url: resolution.url, token: resolution.token });
-        try {
-          const request = runtimeConfigurationForCredential(slot, value);
-          const result = await client.call("configureRuntime", request);
-          if (
-            (request.llm !== undefined && !result.applied.llm) ||
-            (request.intervals !== undefined && !result.applied.intervals)
-          ) {
-            throw new TypeError();
-          }
-        } finally {
-          await client.close();
-        }
+        await applyRuntimeConfig(runtimeConfigurationForCredential(slot, value));
       },
+    });
+    const chatGptAuth = createChatGptAuth({
+      configDir: join(resolveDesktopAthleteHome(environment), "config"),
+      applyRuntimeConfig,
+      openExternal: (url) => shell.openExternal(url),
+      signal: controller.signal,
     });
     await vault.reapplyConfigured();
     await installDesktopProtocol({
@@ -172,6 +183,7 @@ async function runDesktop(): Promise<void> {
             dialog,
             window: created,
             vault,
+            chatGptAuth,
             isTrusted: (event) =>
               isTrustedConnectionRequest(event, mainWindow.current() ?? undefined),
           });

--- a/apps/desktop/src/main/onboarding-ipc.ts
+++ b/apps/desktop/src/main/onboarding-ipc.ts
@@ -1,6 +1,7 @@
 import { extname, isAbsolute } from "node:path";
 import type { ConfigureRuntimeRpcParams, LlmProvider } from "@enduragent/coach-contract";
 import type { BrowserWindow, IpcMain, IpcMainInvokeEvent, OpenDialogOptions } from "electron";
+import type { ChatGptAuthController } from "./chatgpt-auth.js";
 import {
   DESKTOP_CREDENTIAL_SLOTS,
   type CredentialSlotStatus,
@@ -11,6 +12,8 @@ import {
 
 export const DESKTOP_CREDENTIAL_STATUS_CHANNEL = "enduragent:onboarding:credential-status" as const;
 export const DESKTOP_CREDENTIAL_WRITE_CHANNEL = "enduragent:onboarding:credential-write" as const;
+export const DESKTOP_CHATGPT_STATUS_CHANNEL = "enduragent:onboarding:chatgpt-status" as const;
+export const DESKTOP_CHATGPT_LOGIN_CHANNEL = "enduragent:onboarding:chatgpt-login" as const;
 export const DESKTOP_CHOOSE_IMPORT_FILES_CHANNEL =
   "enduragent:onboarding:choose-import-files" as const;
 
@@ -26,6 +29,7 @@ interface RegisterOnboardingIpcOptions {
   readonly dialog: OnboardingDialogPort;
   readonly window: BrowserWindow;
   readonly vault: CredentialVault;
+  readonly chatGptAuth: ChatGptAuthController;
   readonly isTrusted: (event: IpcMainInvokeEvent) => boolean;
 }
 
@@ -128,6 +132,16 @@ export function registerOnboardingIpc(options: RegisterOnboardingIpcOptions): ()
       return { slot: input.slot, status: "refused", reason: "storage-failed" };
     }
   });
+  options.ipcMain.handle(DESKTOP_CHATGPT_STATUS_CHANNEL, async (event, ...args) => {
+    requireTrusted(event);
+    if (args.length !== 0) throw new TypeError();
+    return options.chatGptAuth.status();
+  });
+  options.ipcMain.handle(DESKTOP_CHATGPT_LOGIN_CHANNEL, async (event, ...args) => {
+    requireTrusted(event);
+    if (args.length !== 0) throw new TypeError();
+    return options.chatGptAuth.login();
+  });
   options.ipcMain.handle(DESKTOP_CHOOSE_IMPORT_FILES_CHANNEL, async (event, ...args) => {
     requireTrusted(event);
     if (args.length !== 0) throw new TypeError();
@@ -152,6 +166,8 @@ export function registerOnboardingIpc(options: RegisterOnboardingIpcOptions): ()
   return () => {
     options.ipcMain.removeHandler(DESKTOP_CREDENTIAL_STATUS_CHANNEL);
     options.ipcMain.removeHandler(DESKTOP_CREDENTIAL_WRITE_CHANNEL);
+    options.ipcMain.removeHandler(DESKTOP_CHATGPT_STATUS_CHANNEL);
+    options.ipcMain.removeHandler(DESKTOP_CHATGPT_LOGIN_CHANNEL);
     options.ipcMain.removeHandler(DESKTOP_CHOOSE_IMPORT_FILES_CHANNEL);
   };
 }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -3,6 +3,8 @@ import { DESKTOP_CONNECTION_CHANNEL } from "../main/constants.js";
 
 const DESKTOP_CREDENTIAL_STATUS_CHANNEL = "enduragent:onboarding:credential-status";
 const DESKTOP_CREDENTIAL_WRITE_CHANNEL = "enduragent:onboarding:credential-write";
+const DESKTOP_CHATGPT_STATUS_CHANNEL = "enduragent:onboarding:chatgpt-status";
+const DESKTOP_CHATGPT_LOGIN_CHANNEL = "enduragent:onboarding:chatgpt-login";
 const DESKTOP_CHOOSE_IMPORT_FILES_CHANNEL = "enduragent:onboarding:choose-import-files";
 
 const SLOTS = new Set([
@@ -22,6 +24,15 @@ const REASONS = new Set([
   "invalid-input",
   "encryption-unavailable",
   "unsafe-backend",
+  "storage-failed",
+  "runtime-unavailable",
+]);
+const CHATGPT_REASONS = new Set([
+  "already-in-progress",
+  "callback-unavailable",
+  "timed-out",
+  "cancelled",
+  "exchange-failed",
   "storage-failed",
   "runtime-unavailable",
 ]);
@@ -76,6 +87,37 @@ function parseWriteResult(value: unknown): unknown {
   throw new TypeError();
 }
 
+function parseChatGptStatus(value: unknown): unknown {
+  if (
+    !record(value) ||
+    !exactKeys(value, ["state", "runtimeReady"]) ||
+    (value.state !== "configured" && value.state !== "absent") ||
+    typeof value.runtimeReady !== "boolean"
+  ) {
+    throw new TypeError();
+  }
+  return { state: value.state, runtimeReady: value.runtimeReady };
+}
+
+function parseChatGptLogin(value: unknown): unknown {
+  if (!record(value)) throw new TypeError();
+  if (
+    value.status === "configured" &&
+    exactKeys(value, ["status", "runtimeReady"]) &&
+    value.runtimeReady === true
+  ) {
+    return { status: "configured", runtimeReady: true };
+  }
+  if (
+    value.status === "refused" &&
+    exactKeys(value, ["status", "reason"]) &&
+    CHATGPT_REASONS.has(value.reason as string)
+  ) {
+    return { status: "refused", reason: value.reason };
+  }
+  throw new TypeError();
+}
+
 function parsePaths(value: unknown): readonly string[] {
   if (!Array.isArray(value) || value.length > 256) {
     throw new TypeError();
@@ -120,6 +162,10 @@ contextBridge.exposeInMainWorld(
       }
       return parseWriteResult(await ipcRenderer.invoke(DESKTOP_CREDENTIAL_WRITE_CHANNEL, input));
     },
+    chatgptStatus: async () =>
+      parseChatGptStatus(await ipcRenderer.invoke(DESKTOP_CHATGPT_STATUS_CHANNEL)),
+    chatgptLogin: async () =>
+      parseChatGptLogin(await ipcRenderer.invoke(DESKTOP_CHATGPT_LOGIN_CHANNEL)),
     chooseImportFiles: async () =>
       parsePaths(await ipcRenderer.invoke(DESKTOP_CHOOSE_IMPORT_FILES_CHANNEL)),
     onDroppedImportFiles: (listener: unknown) => {

--- a/apps/desktop/tests/chat-panels.integration.test.ts
+++ b/apps/desktop/tests/chat-panels.integration.test.ts
@@ -246,6 +246,8 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
     expect(initial).toEqual({
       location: "enduragent://app/index.html",
       bridgeKeys: [
+        "chatgptLogin",
+        "chatgptStatus",
         "chooseImportFiles",
         "credentialStatuses",
         "getDaemonConnection",

--- a/apps/desktop/tests/chatgpt-auth.test.ts
+++ b/apps/desktop/tests/chatgpt-auth.test.ts
@@ -1,0 +1,249 @@
+import { chmod, mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createChatGptAuth,
+  hasChatGptProfile,
+  writeChatGptProfile,
+} from "../src/main/chatgpt-auth.js";
+
+const roots: string[] = [];
+
+async function configDir(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "desktop-chatgpt-auth-"));
+  roots.push(root);
+  return join(root, "config");
+}
+
+function credentials() {
+  return {
+    access: "obviously-fake-access",
+    refresh: "obviously-fake-refresh",
+    expires: 4_102_444_800_000,
+    accountId: "obviously-fake-account",
+  };
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("desktop ChatGPT auth", () => {
+  it("atomically merges the profile with mode 0600 and validates its shape", async () => {
+    const directory = await configDir();
+    await writeChatGptProfile(directory, credentials());
+    const path = join(directory, "auth-profiles.json");
+    const first = JSON.parse(await readFile(path, "utf8")) as Record<string, unknown>;
+    first.other = { type: "oauth", marker: true };
+    await writeFile(path, JSON.stringify(first));
+    await chmod(path, 0o644);
+    await writeChatGptProfile(directory, credentials());
+    const stored = JSON.parse(await readFile(path, "utf8")) as Record<string, unknown>;
+    expect(stored.other).toEqual({ type: "oauth", marker: true });
+    expect(stored["openai-codex"]).toMatchObject({
+      type: "oauth",
+      access: "obviously-fake-access",
+      refresh: "obviously-fake-refresh",
+      expires: 4_102_444_800_000,
+    });
+    expect((await stat(path)).mode & 0o777).toBe(0o600);
+    await expect(hasChatGptProfile(directory)).resolves.toBe(true);
+  });
+
+  it("treats absent, corrupt, and invalid profiles as absent", async () => {
+    const directory = await configDir();
+    await expect(hasChatGptProfile(directory)).resolves.toBe(false);
+    await writeChatGptProfile(directory, credentials());
+    await writeFile(join(directory, "auth-profiles.json"), "{");
+    await expect(hasChatGptProfile(directory)).resolves.toBe(false);
+    await writeFile(
+      join(directory, "auth-profiles.json"),
+      JSON.stringify({ "openai-codex": { type: "oauth" } }),
+    );
+    await expect(hasChatGptProfile(directory)).resolves.toBe(false);
+  });
+
+  it("does not replace an unreadable existing profile path", async () => {
+    const directory = await configDir();
+    const path = join(directory, "auth-profiles.json");
+    await mkdir(path, { recursive: true });
+    await expect(writeChatGptProfile(directory, credentials())).rejects.toBeDefined();
+    expect((await stat(path)).isDirectory()).toBe(true);
+    await expect(hasChatGptProfile(directory)).resolves.toBe(false);
+  });
+
+  it("maps timeout, browser cancellation, and exchange failures", async () => {
+    const directory = await configDir();
+    const timedOut = createChatGptAuth({
+      configDir: directory,
+      timeoutMs: 1,
+      openExternal: async () => {},
+      applyRuntimeConfig: async () => {},
+      dependencies: {
+        loginCodex: async (options) =>
+          await new Promise((_resolve, reject) => {
+            options.signal?.addEventListener("abort", () => reject(options.signal?.reason), {
+              once: true,
+            });
+          }),
+      },
+    });
+    await expect(timedOut.login()).resolves.toEqual({ status: "refused", reason: "timed-out" });
+
+    const cancelled = createChatGptAuth({
+      configDir: directory,
+      openExternal: async () => {
+        throw new TypeError();
+      },
+      applyRuntimeConfig: async () => {},
+      dependencies: {
+        loginCodex: async (options) => {
+          options.onAuth({ url: "https://auth.openai.com/obviously-fake" });
+          return await new Promise((_resolve, reject) => {
+            options.signal?.addEventListener("abort", () => reject(options.signal?.reason), {
+              once: true,
+            });
+          });
+        },
+      },
+    });
+    await expect(cancelled.login()).resolves.toEqual({ status: "refused", reason: "cancelled" });
+
+    const exchange = createChatGptAuth({
+      configDir: directory,
+      openExternal: async () => {},
+      applyRuntimeConfig: async () => {},
+      dependencies: {
+        loginCodex: async () => {
+          throw new TypeError();
+        },
+      },
+    });
+    await expect(exchange.login()).resolves.toEqual({
+      status: "refused",
+      reason: "exchange-failed",
+    });
+  });
+
+  it("opens the browser, stores first, and applies a keyless Codex request", async () => {
+    const directory = await configDir();
+    const order: string[] = [];
+    const openExternal = vi.fn(async () => {
+      order.push("browser");
+    });
+    const writeProfile = vi.fn(async () => {
+      order.push("storage");
+      await writeChatGptProfile(directory, credentials());
+    });
+    const applyRuntimeConfig = vi.fn(async () => {
+      order.push("runtime");
+    });
+    const auth = createChatGptAuth({
+      configDir: directory,
+      openExternal,
+      applyRuntimeConfig,
+      dependencies: {
+        writeProfile,
+        loginCodex: async (options) => {
+          expect(options.signal).toBeInstanceOf(AbortSignal);
+          options.onAuth({ url: "https://auth.openai.com/obviously-fake" });
+          await vi.waitFor(() => expect(openExternal).toHaveBeenCalledOnce());
+          return credentials();
+        },
+      },
+    });
+    await expect(auth.login()).resolves.toEqual({ status: "configured", runtimeReady: true });
+    expect(applyRuntimeConfig).toHaveBeenCalledWith({
+      llm: { provider: "openai-codex", model: "gpt-5.5" },
+    });
+    expect(order).toEqual(["browser", "storage", "runtime"]);
+    await expect(auth.status()).resolves.toEqual({ state: "configured", runtimeReady: true });
+  });
+
+  it("restores configured runtime readiness from the current YAML", async () => {
+    const directory = await configDir();
+    await writeChatGptProfile(directory, credentials());
+    await writeFile(
+      join(directory, "config.yaml"),
+      "llm:\n  provider: openai-codex\n  model: gpt-5.5\n",
+    );
+    const auth = createChatGptAuth({
+      configDir: directory,
+      openExternal: async () => {},
+      applyRuntimeConfig: async () => {},
+    });
+    await expect(auth.status()).resolves.toEqual({ state: "configured", runtimeReady: true });
+  });
+
+  it("refuses concurrent login and maps callback, storage, and runtime failures", async () => {
+    const directory = await configDir();
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const auth = createChatGptAuth({
+      configDir: directory,
+      openExternal: async () => {},
+      applyRuntimeConfig: async () => {},
+      dependencies: {
+        loginCodex: async () => {
+          await gate;
+          return credentials();
+        },
+      },
+    });
+    const first = auth.login();
+    await expect(auth.login()).resolves.toEqual({
+      status: "refused",
+      reason: "already-in-progress",
+    });
+    release();
+    await expect(first).resolves.toEqual({ status: "configured", runtimeReady: true });
+
+    const callback = createChatGptAuth({
+      configDir: directory,
+      openExternal: async () => {},
+      applyRuntimeConfig: async () => {},
+      dependencies: {
+        loginCodex: async (options) => {
+          await options.onPrompt({ message: "obviously-fake" });
+          return credentials();
+        },
+      },
+    });
+    await expect(callback.login()).resolves.toEqual({
+      status: "refused",
+      reason: "callback-unavailable",
+    });
+
+    const storage = createChatGptAuth({
+      configDir: directory,
+      openExternal: async () => {},
+      applyRuntimeConfig: async () => {},
+      dependencies: {
+        loginCodex: async () => credentials(),
+        writeProfile: async () => {
+          throw new TypeError();
+        },
+      },
+    });
+    await expect(storage.login()).resolves.toEqual({
+      status: "refused",
+      reason: "storage-failed",
+    });
+
+    const runtime = createChatGptAuth({
+      configDir: directory,
+      openExternal: async () => {},
+      applyRuntimeConfig: async () => {
+        throw new TypeError();
+      },
+      dependencies: { loginCodex: async () => credentials() },
+    });
+    await expect(runtime.login()).resolves.toEqual({
+      status: "refused",
+      reason: "runtime-unavailable",
+    });
+  });
+});

--- a/apps/desktop/tests/onboarding-ipc.test.ts
+++ b/apps/desktop/tests/onboarding-ipc.test.ts
@@ -2,6 +2,8 @@ import type { IpcMainInvokeEvent } from "electron";
 import { describe, expect, it, vi } from "vitest";
 import {
   DESKTOP_CHOOSE_IMPORT_FILES_CHANNEL,
+  DESKTOP_CHATGPT_LOGIN_CHANNEL,
+  DESKTOP_CHATGPT_STATUS_CHANNEL,
   DESKTOP_CREDENTIAL_STATUS_CHANNEL,
   DESKTOP_CREDENTIAL_WRITE_CHANNEL,
   registerOnboardingIpc,
@@ -34,17 +36,22 @@ function harness() {
       filePaths: ["/synthetic/ride.fit", "/synthetic/ride.txt", "relative.tcx"],
     })),
   };
+  const chatGptAuth = {
+    status: vi.fn(async () => ({ state: "configured" as const, runtimeReady: true })),
+    login: vi.fn(async () => ({ status: "configured" as const, runtimeReady: true as const })),
+  };
   const trustedEvent = {} as IpcMainInvokeEvent;
   const dispose = registerOnboardingIpc({
     ipcMain: ipcMain as never,
     dialog,
     window: {} as never,
     vault,
+    chatGptAuth,
     isTrusted: (event) => event === trustedEvent,
   });
   const invoke = (channel: string, event: IpcMainInvokeEvent, ...args: unknown[]) =>
     handlers.get(channel)!(event, ...args);
-  return { handlers, ipcMain, vault, dialog, trustedEvent, dispose, invoke };
+  return { handlers, ipcMain, vault, chatGptAuth, dialog, trustedEvent, dispose, invoke };
 }
 
 describe("desktop onboarding IPC", () => {
@@ -70,6 +77,8 @@ describe("desktop onboarding IPC", () => {
       [
         DESKTOP_CREDENTIAL_STATUS_CHANNEL,
         DESKTOP_CREDENTIAL_WRITE_CHANNEL,
+        DESKTOP_CHATGPT_STATUS_CHANNEL,
+        DESKTOP_CHATGPT_LOGIN_CHANNEL,
         DESKTOP_CHOOSE_IMPORT_FILES_CHANNEL,
       ].sort(),
     );
@@ -80,6 +89,27 @@ describe("desktop onboarding IPC", () => {
     expect(
       JSON.stringify(await subject.invoke(DESKTOP_CREDENTIAL_STATUS_CHANNEL, subject.trustedEvent)),
     ).not.toContain("value");
+  });
+
+  it("gates strict ChatGPT status and login invokes", async () => {
+    const subject = harness();
+    await expect(
+      subject.invoke(DESKTOP_CHATGPT_STATUS_CHANNEL, subject.trustedEvent),
+    ).resolves.toEqual({ state: "configured", runtimeReady: true });
+    await expect(
+      subject.invoke(DESKTOP_CHATGPT_LOGIN_CHANNEL, subject.trustedEvent),
+    ).resolves.toEqual({ status: "configured", runtimeReady: true });
+    await expect(
+      subject.invoke(DESKTOP_CHATGPT_LOGIN_CHANNEL, {} as IpcMainInvokeEvent),
+    ).rejects.toBeInstanceOf(TypeError);
+    await expect(
+      subject.invoke(DESKTOP_CHATGPT_STATUS_CHANNEL, subject.trustedEvent, null),
+    ).rejects.toBeInstanceOf(TypeError);
+    await expect(
+      subject.invoke(DESKTOP_CHATGPT_LOGIN_CHANNEL, subject.trustedEvent, null),
+    ).rejects.toBeInstanceOf(TypeError);
+    expect(subject.chatGptAuth.status).toHaveBeenCalledOnce();
+    expect(subject.chatGptAuth.login).toHaveBeenCalledOnce();
   });
 
   it("validates trusted senders and exact credential inputs before dispatch", async () => {
@@ -146,10 +176,10 @@ describe("desktop onboarding IPC", () => {
     ).resolves.toEqual([]);
   });
 
-  it("disposes only its three handlers", () => {
+  it("disposes only its five handlers", () => {
     const subject = harness();
     subject.dispose();
     expect(subject.handlers.size).toBe(0);
-    expect(subject.ipcMain.removeHandler).toHaveBeenCalledTimes(3);
+    expect(subject.ipcMain.removeHandler).toHaveBeenCalledTimes(5);
   });
 });

--- a/apps/desktop/tests/preload-auth.test.ts
+++ b/apps/desktop/tests/preload-auth.test.ts
@@ -1,0 +1,74 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const exposed: Record<string, unknown> = {};
+  return {
+    exposed,
+    exposeInMainWorld: vi.fn((name: string, value: unknown) => {
+      exposed[name] = value;
+    }),
+    invoke: vi.fn(),
+  };
+});
+
+vi.mock("electron", () => ({
+  contextBridge: { exposeInMainWorld: mocks.exposeInMainWorld },
+  ipcRenderer: { invoke: mocks.invoke },
+  webUtils: { getPathForFile: vi.fn() },
+}));
+
+interface AuthBridge {
+  chatgptStatus(): Promise<unknown>;
+  chatgptLogin(): Promise<unknown>;
+}
+
+let bridge: AuthBridge;
+
+beforeAll(async () => {
+  await import("../src/preload/index.js");
+  bridge = mocks.exposed.enduragentAuth as AuthBridge;
+});
+
+beforeEach(() => {
+  mocks.invoke.mockReset();
+});
+
+describe("desktop preload ChatGPT auth", () => {
+  it("exposes strict status and configured results", async () => {
+    mocks.invoke
+      .mockResolvedValueOnce({ state: "configured", runtimeReady: false })
+      .mockResolvedValueOnce({ status: "configured", runtimeReady: true });
+    await expect(bridge.chatgptStatus()).resolves.toEqual({
+      state: "configured",
+      runtimeReady: false,
+    });
+    await expect(bridge.chatgptLogin()).resolves.toEqual({
+      status: "configured",
+      runtimeReady: true,
+    });
+    expect(mocks.invoke.mock.calls.map(([channel]) => channel)).toEqual([
+      "enduragent:onboarding:chatgpt-status",
+      "enduragent:onboarding:chatgpt-login",
+    ]);
+  });
+
+  it("accepts only closed refusal reasons and exact keys", async () => {
+    mocks.invoke.mockResolvedValueOnce({ status: "refused", reason: "timed-out" });
+    await expect(bridge.chatgptLogin()).resolves.toEqual({
+      status: "refused",
+      reason: "timed-out",
+    });
+    for (const value of [
+      { state: "configured", runtimeReady: true, extra: true },
+      { state: "unknown", runtimeReady: false },
+      { status: "refused", reason: "unknown" },
+      { status: "configured", runtimeReady: false },
+    ]) {
+      mocks.invoke.mockResolvedValueOnce(value);
+      const operation = Object.hasOwn(value, "state")
+        ? bridge.chatgptStatus()
+        : bridge.chatgptLogin();
+      await expect(operation).rejects.toBeInstanceOf(TypeError);
+    }
+  });
+});

--- a/apps/desktop/tests/spend-meter.integration.test.ts
+++ b/apps/desktop/tests/spend-meter.integration.test.ts
@@ -271,7 +271,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop spend me
     expect(narrow).toEqual({ visible: true, overflow: false });
   });
 
-  it("preserves the five-key bridge, training-data drawer, hardened renderer, and token containment", async () => {
+  it("preserves the nine-key bridge, training-data drawer, hardened renderer, and token containment", async () => {
     const { fixture } = await launch();
     const screenshotRoot = await mkdtemp(join(await realpath(tmpdir()), "spend-shot-"));
     scratch.push(screenshotRoot);
@@ -293,6 +293,8 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop spend me
       };
     `);
     expect(state.bridgeKeys).toEqual([
+      "chatgptLogin",
+      "chatgptStatus",
       "chooseImportFiles",
       "credentialStatuses",
       "getDaemonConnection",

--- a/packages/coach-contract/src/rpc.ts
+++ b/packages/coach-contract/src/rpc.ts
@@ -274,9 +274,17 @@ const RuntimeLlmSchema = z
   .object({
     provider: LlmProviderSchema,
     model: z.string().min(1).max(512),
-    api_key: z.string().min(1).max(16_384),
+    api_key: z.string().min(1).max(16_384).optional(),
   })
-  .strict();
+  .strict()
+  .superRefine((value, context) => {
+    if (value.provider === "openai-codex" && value.api_key !== undefined) {
+      context.addIssue({ code: "custom", path: ["api_key"], message: "api_key must be absent" });
+    }
+    if (value.provider !== "openai-codex" && value.api_key === undefined) {
+      context.addIssue({ code: "custom", path: ["api_key"], message: "api_key is required" });
+    }
+  });
 
 const RuntimeIntervalsSchema = z
   .object({
@@ -380,7 +388,10 @@ export interface CoachSelfTestOperations {
   selfTest(onEvent?: (event: OperationProgressEvent) => void): Promise<SelfTestRpcResult>;
 }
 
-export type CoachRpcService = CoachEngine & CoachOperations & SpendOperations & CoachSelfTestOperations;
+export type CoachRpcService = CoachEngine &
+  CoachOperations &
+  SpendOperations &
+  CoachSelfTestOperations;
 
 export const CoachRpcRequestEnvelopeSchema = z.discriminatedUnion("method", [
   z

--- a/packages/coach-contract/src/version.ts
+++ b/packages/coach-contract/src/version.ts
@@ -1,1 +1,1 @@
-export const PROTOCOL_VERSION = 4;
+export const PROTOCOL_VERSION = 5;

--- a/packages/coach-contract/tests/contract.test.ts
+++ b/packages/coach-contract/tests/contract.test.ts
@@ -84,8 +84,8 @@ describe("exit codes", () => {
 });
 
 describe("protocol version", () => {
-  it("is 4", () => {
-    expect(PROTOCOL_VERSION).toBe(4);
+  it("is 5", () => {
+    expect(PROTOCOL_VERSION).toBe(5);
   });
 });
 

--- a/packages/coach-contract/tests/wire-contract.test.ts
+++ b/packages/coach-contract/tests/wire-contract.test.ts
@@ -372,17 +372,26 @@ describe("coach request and event projection", () => {
     });
 
     const llm = { provider: "openrouter", model: "model-a", api_key: "placeholder" } as const;
+    const codex = { provider: "openai-codex", model: "model-codex" } as const;
     const intervals = { api_key: "placeholder", athlete_id: "athlete-a" } as const;
-    for (const params of [{ llm }, { intervals }, { llm, intervals }]) {
+    for (const params of [{ llm }, { llm: codex }, { intervals }, { llm, intervals }]) {
       expect(ConfigureRuntimeRpcParamsSchema.parse(params)).toEqual(params);
     }
     for (const invalid of [
       {},
       { llm: { ...llm, extra: true } },
+      { llm: { provider: "openai-codex", model: "model-codex", api_key: "placeholder" } },
       { intervals: { api_key: "", athlete_id: "athlete-a" } },
       { llm, extra: true },
     ]) {
       expect(ConfigureRuntimeRpcParamsSchema.safeParse(invalid).success).toBe(false);
+    }
+    for (const provider of LlmProviderSchema.options.filter(
+      (provider) => provider !== "openai-codex",
+    )) {
+      expect(
+        ConfigureRuntimeRpcParamsSchema.safeParse({ llm: { provider, model: "model-a" } }).success,
+      ).toBe(false);
     }
     const result = { schemaVersion: 1, applied: { llm: true, intervals: false } } as const;
     expect(ConfigureRuntimeRpcResultSchema.parse(result)).toEqual(result);
@@ -757,7 +766,7 @@ describe("additive protocol signals", () => {
     expect(AgentErrorKindSchema.safeParse("aborted").success).toBe(false);
   });
 
-  it("uses protocol version four", () => {
-    expect(PROTOCOL_VERSION).toBe(4);
+  it("uses protocol version five", () => {
+    expect(PROTOCOL_VERSION).toBe(5);
   });
 });

--- a/packages/coach/src/composition.ts
+++ b/packages/coach/src/composition.ts
@@ -161,14 +161,21 @@ function persistRuntimeConfig(configDir: string, request: ConfigureRuntimeRpcPar
   if (!isRecord(parsed)) throw new TypeError("Runtime config must be a map.");
   const next = { ...parsed };
   if (request.llm !== undefined) {
-    next.llm = {
+    const existing = isRecord(parsed.llm) ? parsed.llm : {};
+    const llm: Record<string, unknown> = {
+      ...(existing.provider === request.llm.provider ? existing : {}),
       provider: request.llm.provider,
       model: request.llm.model,
-      ...(request.llm.provider === "openai-codex" ? { auth_profile: "openai-codex" } : {}),
     };
+    if (request.llm.provider === "openai-codex") llm.auth_profile = "openai-codex";
+    else delete llm.auth_profile;
+    next.llm = llm;
   }
   if (request.intervals !== undefined) {
-    next.intervals = { athlete_id: request.intervals.athlete_id };
+    next.intervals = {
+      ...(isRecord(parsed.intervals) ? parsed.intervals : {}),
+      athlete_id: request.intervals.athlete_id,
+    };
   }
   const temporaryPath = `${path}.tmp.${randomBytes(4).toString("hex")}`;
   try {

--- a/packages/coach/src/composition.ts
+++ b/packages/coach/src/composition.ts
@@ -8,6 +8,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { join } from "node:path";
+import { parse as parseYaml, stringify as toYaml } from "yaml";
 import {
   ChatStore,
   Memory,
@@ -137,7 +138,7 @@ function mergedRuntimeConfig(config: Config, request: ConfigureRuntimeRpcParams)
     next.llm = {
       provider: request.llm.provider,
       model: request.llm.model,
-      apiKey: request.llm.api_key,
+      apiKey: request.llm.provider === "openai-codex" ? "" : (request.llm.api_key ?? ""),
       authProfile: request.llm.provider === "openai-codex" ? "openai-codex" : undefined,
     };
   }
@@ -148,6 +149,38 @@ function mergedRuntimeConfig(config: Config, request: ConfigureRuntimeRpcParams)
     };
   }
   return next;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function persistRuntimeConfig(configDir: string, request: ConfigureRuntimeRpcParams): void {
+  const path = join(configDir, "config.yaml");
+  const parsed = existsSync(path) ? (parseYaml(readFileSync(path, "utf8")) as unknown) : {};
+  if (!isRecord(parsed)) throw new TypeError("Runtime config must be a map.");
+  const next = { ...parsed };
+  if (request.llm !== undefined) {
+    next.llm = {
+      provider: request.llm.provider,
+      model: request.llm.model,
+      ...(request.llm.provider === "openai-codex" ? { auth_profile: "openai-codex" } : {}),
+    };
+  }
+  if (request.intervals !== undefined) {
+    next.intervals = { athlete_id: request.intervals.athlete_id };
+  }
+  const temporaryPath = `${path}.tmp.${randomBytes(4).toString("hex")}`;
+  try {
+    writeFileSync(temporaryPath, toYaml(next), { mode: 0o600 });
+    chmodSync(temporaryPath, 0o600);
+    renameSync(temporaryPath, path);
+  } catch (error) {
+    try {
+      unlinkSync(temporaryPath);
+    } catch {}
+    throw error;
+  }
 }
 
 function createReconfigurableEngine(initial: CoachEngine): {
@@ -239,8 +272,13 @@ function credential(value: unknown): OAuthCredential {
   if (
     candidate.type !== "oauth" ||
     typeof candidate.access !== "string" ||
+    candidate.access.length === 0 ||
     typeof candidate.refresh !== "string" ||
-    typeof candidate.expires !== "number"
+    candidate.refresh.length === 0 ||
+    typeof candidate.expires !== "number" ||
+    !Number.isFinite(candidate.expires) ||
+    (candidate.accountId !== undefined && typeof candidate.accountId !== "string") ||
+    (candidate.email !== undefined && typeof candidate.email !== "string")
   ) {
     throw new TypeError("OAuth profile is invalid.");
   }
@@ -426,9 +464,14 @@ export async function createLocalCoachComposition(
     };
     const reconfigurable = createReconfigurableEngine(buildEngine(activeConfig));
     const applyRuntimeConfig = async (request: ConfigureRuntimeRpcParams): Promise<void> => {
+      const candidate = mergedRuntimeConfig(activeConfig, request);
+      if (request.llm?.provider === "openai-codex") {
+        const profiles = readProfiles(join(input.home.configDir, "auth-profiles.json"));
+        credential(profiles["openai-codex"]);
+      }
+      const replacement = buildEngine(candidate);
+      persistRuntimeConfig(input.home.configDir, request);
       await reconfigurable.replace(() => {
-        const candidate = mergedRuntimeConfig(activeConfig, request);
-        const replacement = buildEngine(candidate);
         activeConfig = candidate;
         return replacement;
       });

--- a/packages/coach/tests/composition.test.ts
+++ b/packages/coach/tests/composition.test.ts
@@ -1,9 +1,9 @@
-import { mkdir, mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AthleteState, CoachEngine } from "@enduragent/coach-contract";
-import { engineConfigFromConfig, type Config } from "@enduragent/core";
+import { engineConfigFromConfig, loadConfig, type Config } from "@enduragent/core";
 import type {
   AthleteDataReaderPort,
   CreateCoachEngineInput,
@@ -23,6 +23,7 @@ import {
   type LocalReferenceRuntime,
   type LocalStoreRuntime,
 } from "../src/composition.js";
+import { checkHomeReadiness } from "../src/readiness.js";
 import type { CoachStoreWriterContext } from "../src/runtime.js";
 
 const roots: string[] = [];
@@ -610,6 +611,90 @@ describe("local coach composition", () => {
     expect(runtimeOptions?.readConfig?.().intervals).toEqual({
       apiKey: "placeholder",
       athleteId: "athlete-b",
+    });
+    await lifecycle.close();
+  });
+
+  it("persists a keyless Codex selection that reloads as ready with a valid profile", async () => {
+    const home = await freshHome();
+    await writeFile(
+      join(home.configDir, "auth-profiles.json"),
+      JSON.stringify({
+        "openai-codex": {
+          type: "oauth",
+          access: "obviously-fake-access",
+          refresh: "obviously-fake-refresh",
+          expires: 4_102_444_800_000,
+          accountId: "obviously-fake-account",
+        },
+      }),
+      { mode: 0o600 },
+    );
+    const received: CreateCoachEngineInput[] = [];
+    const lifecycle = await compose(home, {
+      bootstrap: async () => reference(),
+      createRuntime: () => runtime(),
+      createBackend: (input) => {
+        received.push(input);
+        return backend();
+      },
+      createRepository: () => ({
+        insertIfAbsent: async () => false,
+        readCurrent: async () => undefined,
+      }),
+      createResolver: () => missingResolver(),
+    });
+    await lifecycle.operations.configureRuntime({
+      llm: { provider: "openai-codex", model: "gpt-5.5" },
+    });
+    expect(received.at(-1)?.ports.config.llm).toMatchObject({
+      provider: "openai-codex",
+      model: "gpt-5.5",
+      apiKey: "",
+      authProfile: "openai-codex",
+    });
+    const persisted = await readFile(join(home.configDir, "config.yaml"), "utf8");
+    expect(persisted).toContain("provider: openai-codex");
+    expect(persisted).not.toContain("api_key");
+    expect(loadConfig(home.configDir).llm).toMatchObject({
+      provider: "openai-codex",
+      model: "gpt-5.5",
+      apiKey: "",
+      authProfile: "openai-codex",
+    });
+    await expect(checkHomeReadiness(home)).resolves.toMatchObject({ status: "ready" });
+    await lifecycle.close();
+  });
+
+  it("rejects a Codex runtime selection before replacement when its profile is invalid", async () => {
+    const home = await freshHome();
+    await writeFile(
+      join(home.configDir, "auth-profiles.json"),
+      JSON.stringify({ "openai-codex": { type: "oauth" } }),
+      { mode: 0o600 },
+    );
+    const received: CreateCoachEngineInput[] = [];
+    const lifecycle = await compose(home, {
+      bootstrap: async () => reference(),
+      createRuntime: () => runtime(),
+      createBackend: (input) => {
+        received.push(input);
+        return backend();
+      },
+      createRepository: () => ({
+        insertIfAbsent: async () => false,
+        readCurrent: async () => undefined,
+      }),
+      createResolver: () => missingResolver(),
+    });
+    await expect(
+      lifecycle.operations.configureRuntime({
+        llm: { provider: "openai-codex", model: "gpt-5.5" },
+      }),
+    ).rejects.toThrow("OAuth profile is invalid.");
+    expect(received).toHaveLength(1);
+    await expect(readFile(join(home.configDir, "config.yaml"), "utf8")).rejects.toMatchObject({
+      code: "ENOENT",
     });
     await lifecycle.close();
   });

--- a/packages/coach/tests/composition.test.ts
+++ b/packages/coach/tests/composition.test.ts
@@ -2,6 +2,7 @@ import { mkdir, mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promi
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { parse as parseYaml, stringify as toYaml } from "yaml";
 import type { AthleteState, CoachEngine } from "@enduragent/coach-contract";
 import { engineConfigFromConfig, loadConfig, type Config } from "@enduragent/core";
 import type {
@@ -663,6 +664,174 @@ describe("local coach composition", () => {
       authProfile: "openai-codex",
     });
     await expect(checkHomeReadiness(home)).resolves.toMatchObject({ status: "ready" });
+    await lifecycle.close();
+  });
+
+  it("merges same-provider and intervals persistence without replacing retained fields", async () => {
+    const home = await freshHome();
+    await writeFile(
+      join(home.configDir, "config.yaml"),
+      toYaml({
+        retained_top_level: true,
+        llm: {
+          provider: "openrouter",
+          model: "previous-model",
+          auth_profile: "openai-codex",
+          api_key: "obviously-fake-persisted-llm-key",
+          base_url: "https://invalid.example.test/v1",
+          flush_model: "previous-flush-model",
+          compact_model: "previous-compact-model",
+          retained_llm_field: true,
+        },
+        intervals: {
+          athlete_id: "previous-athlete",
+          api_key: "obviously-fake-persisted-intervals-key",
+          retained_intervals_field: true,
+        },
+      }),
+      { mode: 0o600 },
+    );
+    const lifecycle = await compose(home, {
+      bootstrap: async () => reference(),
+      createRuntime: () => runtime(),
+      createBackend: () => backend(),
+      createRepository: () => ({
+        insertIfAbsent: async () => false,
+        readCurrent: async () => undefined,
+      }),
+      createResolver: () => missingResolver(),
+    });
+    await lifecycle.operations.configureRuntime({
+      llm: {
+        provider: "openrouter",
+        model: "replacement-model",
+        api_key: "obviously-fake-request-llm-key",
+      },
+      intervals: {
+        athlete_id: "replacement-athlete",
+        api_key: "obviously-fake-request-intervals-key",
+      },
+    });
+    const persisted = parseYaml(
+      await readFile(join(home.configDir, "config.yaml"), "utf8"),
+    ) as Record<string, unknown>;
+    expect(persisted).toEqual({
+      retained_top_level: true,
+      llm: {
+        provider: "openrouter",
+        model: "replacement-model",
+        api_key: "obviously-fake-persisted-llm-key",
+        base_url: "https://invalid.example.test/v1",
+        flush_model: "previous-flush-model",
+        compact_model: "previous-compact-model",
+        retained_llm_field: true,
+      },
+      intervals: {
+        athlete_id: "replacement-athlete",
+        api_key: "obviously-fake-persisted-intervals-key",
+        retained_intervals_field: true,
+      },
+    });
+    expect(JSON.stringify(persisted)).not.toContain("obviously-fake-request");
+    expect(loadConfig(home.configDir)).toMatchObject({
+      llm: {
+        provider: "openrouter",
+        model: "replacement-model",
+        apiKey: "obviously-fake-persisted-llm-key",
+        baseUrl: "https://invalid.example.test/v1",
+        flushModel: "previous-flush-model",
+        compactModel: "previous-compact-model",
+      },
+      intervals: {
+        athleteId: "replacement-athlete",
+        apiKey: "obviously-fake-persisted-intervals-key",
+      },
+    });
+    await lifecycle.close();
+  });
+
+  it("drops provider-scoped fields on switches and updates Codex auth profile ownership", async () => {
+    const home = await freshHome();
+    await writeFile(
+      join(home.configDir, "config.yaml"),
+      toYaml({
+        retained_top_level: true,
+        llm: {
+          provider: "openai-codex",
+          model: "previous-model",
+          auth_profile: "openai-codex",
+          api_key: "obviously-fake-stale-key",
+          base_url: "https://invalid.example.test/v1",
+          flush_model: "previous-flush-model",
+          compact_model: "previous-compact-model",
+          retained_llm_field: true,
+        },
+      }),
+      { mode: 0o600 },
+    );
+    await writeFile(
+      join(home.configDir, "auth-profiles.json"),
+      JSON.stringify({
+        "openai-codex": {
+          type: "oauth",
+          access: "obviously-fake-access",
+          refresh: "obviously-fake-refresh",
+          expires: 4_102_444_800_000,
+        },
+      }),
+      { mode: 0o600 },
+    );
+    const lifecycle = await compose(home, {
+      bootstrap: async () => reference(),
+      createRuntime: () => runtime(),
+      createBackend: () => backend(),
+      createRepository: () => ({
+        insertIfAbsent: async () => false,
+        readCurrent: async () => undefined,
+      }),
+      createResolver: () => missingResolver(),
+    });
+    await lifecycle.operations.configureRuntime({
+      llm: {
+        provider: "google",
+        model: "replacement-model",
+        api_key: "obviously-fake-request-key",
+      },
+    });
+    let persisted = parseYaml(
+      await readFile(join(home.configDir, "config.yaml"), "utf8"),
+    ) as Record<string, unknown>;
+    expect(persisted).toEqual({
+      retained_top_level: true,
+      llm: { provider: "google", model: "replacement-model" },
+    });
+    expect(loadConfig(home.configDir).llm).toMatchObject({
+      provider: "google",
+      model: "replacement-model",
+      apiKey: "",
+      authProfile: undefined,
+    });
+    await lifecycle.operations.configureRuntime({
+      llm: { provider: "openai-codex", model: "gpt-5.5" },
+    });
+    persisted = parseYaml(await readFile(join(home.configDir, "config.yaml"), "utf8")) as Record<
+      string,
+      unknown
+    >;
+    expect(persisted).toEqual({
+      retained_top_level: true,
+      llm: {
+        provider: "openai-codex",
+        model: "gpt-5.5",
+        auth_profile: "openai-codex",
+      },
+    });
+    expect(loadConfig(home.configDir).llm).toMatchObject({
+      provider: "openai-codex",
+      model: "gpt-5.5",
+      apiKey: "",
+      authProfile: "openai-codex",
+    });
     await lifecycle.close();
   });
 

--- a/packages/core/src/agent/codex/oauth.ts
+++ b/packages/core/src/agent/codex/oauth.ts
@@ -28,6 +28,7 @@ export interface CodexLoginOptions {
   onProgress?: (message: string) => void;
   onManualCodeInput?: () => Promise<string>;
   originator?: string;
+  signal?: AbortSignal;
 }
 
 // ============================================================================
@@ -128,7 +129,7 @@ async function createAuthorizationFlow(
 }
 
 interface OAuthServerHandle {
-  close: () => void;
+  close: () => Promise<void>;
   cancelWait: () => void;
   waitForCode: () => Promise<{ code: string } | null>;
 }
@@ -176,7 +177,7 @@ function startLocalOAuthServer(state: string): Promise<OAuthServerHandle> {
     server
       .listen(CALLBACK_PORT, CALLBACK_HOST, () => {
         resolve({
-          close: () => server.close(),
+          close: () => new Promise((resolveClose) => server.close(() => resolveClose())),
           cancelWait: () => settleWait?.(null),
           waitForCode: () => waitForCodePromise,
         });
@@ -189,7 +190,7 @@ function startLocalOAuthServer(state: string): Promise<OAuthServerHandle> {
         );
         settleWait?.(null);
         resolve({
-          close: () => {
+          close: async () => {
             try {
               server.close();
             } catch {
@@ -215,6 +216,7 @@ async function exchangeAuthorizationCode(
   code: string,
   verifier: string,
   redirectUri: string = REDIRECT_URI,
+  signal?: AbortSignal,
 ): Promise<TokenResult> {
   const response = await fetch(TOKEN_URL, {
     method: "POST",
@@ -226,6 +228,7 @@ async function exchangeAuthorizationCode(
       code_verifier: verifier,
       redirect_uri: redirectUri,
     }),
+    signal,
   });
   if (!response.ok) {
     console.error("[codex-oauth] code->token failed:", response.status);
@@ -315,9 +318,12 @@ async function refreshAccessToken(
 // ============================================================================
 
 export async function loginCodex(options: CodexLoginOptions): Promise<CodexCredentials> {
+  options.signal?.throwIfAborted();
   const { verifier, state, url } = await createAuthorizationFlow(options.originator);
+  options.signal?.throwIfAborted();
   const server = await startLocalOAuthServer(state);
-  options.onAuth({ url, instructions: "A browser window should open. Complete login to finish." });
+  const abortWait = (): void => server.cancelWait();
+  options.signal?.addEventListener("abort", abortWait, { once: true });
 
   let code: string | undefined;
   const applyParsedInput = (input: string) => {
@@ -326,6 +332,11 @@ export async function loginCodex(options: CodexLoginOptions): Promise<CodexCrede
     code = parsed.code;
   };
   try {
+    options.signal?.throwIfAborted();
+    options.onAuth({
+      url,
+      instructions: "A browser window should open. Complete login to finish.",
+    });
     if (options.onManualCodeInput) {
       // Race the browser callback against manual paste — first to yield a code wins.
       let manualCode: string | undefined;
@@ -342,6 +353,7 @@ export async function loginCodex(options: CodexLoginOptions): Promise<CodexCrede
         });
 
       const result = await server.waitForCode();
+      options.signal?.throwIfAborted();
       if (manualError) throw manualError;
       if (result?.code) {
         code = result.code;
@@ -350,6 +362,7 @@ export async function loginCodex(options: CodexLoginOptions): Promise<CodexCrede
       }
       if (!code) {
         await manualPromise;
+        options.signal?.throwIfAborted();
         if (manualError) throw manualError;
         if (manualCode) {
           applyParsedInput(manualCode);
@@ -357,6 +370,7 @@ export async function loginCodex(options: CodexLoginOptions): Promise<CodexCrede
       }
     } else {
       const result = await server.waitForCode();
+      options.signal?.throwIfAborted();
       if (result?.code) code = result.code;
     }
 
@@ -369,7 +383,13 @@ export async function loginCodex(options: CodexLoginOptions): Promise<CodexCrede
 
     if (!code) throw new Error("Missing authorization code");
 
-    const tokenResult = await exchangeAuthorizationCode(code, verifier);
+    const tokenResult = await exchangeAuthorizationCode(
+      code,
+      verifier,
+      REDIRECT_URI,
+      options.signal,
+    );
+    options.signal?.throwIfAborted();
     if (tokenResult.type !== "success") throw new Error("Token exchange failed");
 
     const accountId = extractAccountId(tokenResult.access);
@@ -381,7 +401,8 @@ export async function loginCodex(options: CodexLoginOptions): Promise<CodexCrede
       accountId,
     };
   } finally {
-    server.close();
+    options.signal?.removeEventListener("abort", abortWait);
+    await server.close();
   }
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -126,7 +126,8 @@ export {
 } from "./auth/profiles.js";
 export type { OAuthCredential } from "./auth/profiles.js";
 export { runCodexLogin } from "./auth/openai-codex-login.js";
-export { refreshCodexToken } from "./agent/codex/oauth.js";
+export { loginCodex, refreshCodexToken } from "./agent/codex/oauth.js";
+export type { CodexCredentials, CodexLoginOptions } from "./agent/codex/oauth.js";
 
 // ─── Channels ─────────────────────────────────────────────────────────
 export { createTelegramBot, notifyUpdate } from "./channels/telegram.js";

--- a/packages/core/tests/codex/oauth.test.ts
+++ b/packages/core/tests/codex/oauth.test.ts
@@ -1,5 +1,6 @@
+import { createServer } from "node:http";
 import { describe, it, expect, afterEach, vi } from "vitest";
-import { refreshCodexToken, generatePKCE } from "../../src/agent/codex/oauth.js";
+import { loginCodex, refreshCodexToken, generatePKCE } from "../../src/agent/codex/oauth.js";
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -152,5 +153,56 @@ describe("generatePKCE", () => {
     const { verifier, challenge } = await generatePKCE();
     const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(verifier));
     expect(challenge).toBe(base64url(new Uint8Array(digest)));
+  });
+});
+
+describe("loginCodex", () => {
+  it("aborts the callback wait and releases the registered port", async () => {
+    const controller = new AbortController();
+    const pending = loginCodex({
+      signal: controller.signal,
+      onAuth: () => controller.abort(new DOMException("Cancelled", "AbortError")),
+      onPrompt: async () => "",
+    });
+    await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+
+    const server = createServer();
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(1455, "127.0.0.1", resolve);
+    });
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  it("completes the localhost callback and fake token exchange", async () => {
+    const nativeFetch = globalThis.fetch;
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const url = input instanceof Request ? input.url : String(input);
+      if (url.startsWith("http://127.0.0.1:1455/")) return nativeFetch(input, init);
+      return new Response(
+        JSON.stringify({
+          access_token: TOKEN_WITH_ACCOUNT,
+          refresh_token: "obviously-fake-refresh",
+          expires_in: 3600,
+        }),
+        { status: 200 },
+      );
+    });
+    let callback: Promise<Response> | undefined;
+    const credentials = await loginCodex({
+      onAuth: ({ url }) => {
+        const state = new URL(url).searchParams.get("state");
+        callback = nativeFetch(
+          `http://127.0.0.1:1455/auth/callback?code=obviously-fake-code&state=${state}`,
+        );
+      },
+      onPrompt: async () => "",
+    });
+    await callback;
+    expect(credentials).toMatchObject({
+      access: TOKEN_WITH_ACCOUNT,
+      refresh: "obviously-fake-refresh",
+      accountId: "acct_x",
+    });
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,12 @@ importers:
       '@enduragent/coach-contract':
         specifier: workspace:*
         version: link:../../packages/coach-contract
+      '@enduragent/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      yaml:
+        specifier: ^2.8.3
+        version: 2.8.3
     devDependencies:
       '@enduragent/desktop-renderer':
         specifier: workspace:*

--- a/tools/check-package-deps.test.ts
+++ b/tools/check-package-deps.test.ts
@@ -313,14 +313,13 @@ describe("R6 desktop renderer", () => {
 });
 
 describe("R8 desktop app", () => {
-  it("allows only coach, coach-client, and coach-contract workspace edges", () => {
+  it("allows coach, coach-client, coach-contract, and core workspace edges", () => {
     write(
       "apps/desktop/src/ok.ts",
-      `import { run } from "@enduragent/coach";\nimport { connectCoachClient } from "@enduragent/coach-client";\nimport { PROTOCOL_VERSION } from "@enduragent/coach-contract";\nexport const value = [run, connectCoachClient, PROTOCOL_VERSION];\n`,
+      `import { run } from "@enduragent/coach";\nimport { connectCoachClient } from "@enduragent/coach-client";\nimport { PROTOCOL_VERSION } from "@enduragent/coach-contract";\nimport { loginCodex } from "@enduragent/core";\nexport const value = [run, connectCoachClient, PROTOCOL_VERSION, loginCodex];\n`,
     );
     expect(violationsFor(rDesktop)).toBe(0);
     for (const [index, dependency] of [
-      "@enduragent/core",
       "@enduragent/engine",
       "@enduragent/kernel",
       "@enduragent/kernel-node",
@@ -332,7 +331,7 @@ describe("R8 desktop app", () => {
         `import value from "${dependency}";\nexport { value };\n`,
       );
     }
-    expect(violationsFor(rDesktop)).toBe(6);
+    expect(violationsFor(rDesktop)).toBe(5);
   });
 });
 

--- a/tools/check-package-deps.ts
+++ b/tools/check-package-deps.ts
@@ -61,7 +61,12 @@ const COMPOSITION_ROOT_ALLOWED: readonly string[] = [
   "@enduragent/sport-*",
 ];
 
-const DESKTOP_APP_ALLOWED: readonly string[] = ["@enduragent/coach", "@enduragent/coach-client", "@enduragent/coach-contract"];
+const DESKTOP_APP_ALLOWED: readonly string[] = [
+  "@enduragent/coach",
+  "@enduragent/coach-client",
+  "@enduragent/coach-contract",
+  "@enduragent/core",
+];
 
 const LEGACY_BINARY_ALLOWED: readonly string[] = ["@enduragent/core", "@enduragent/sport-*"];
 


### PR DESCRIPTION
## What

Onboarding's coach-model step gains a "Sign in with ChatGPT" lane: the athlete clicks it, the default browser opens the OpenAI sign-in page, the app completes the PKCE OAuth flow on a localhost callback, stores the OAuth profile, and configures the running daemon to use the ChatGPT-subscription provider — no API key required. This is the same `openai-codex` provider lane the CLI setup wizard already offers; the desktop app just never had the UI for it.

## How

- **Contract**: `configureRuntime`'s LLM slot now takes `api_key` as optional — required and non-empty for every provider except `openai-codex`, where it must be absent. That is a behavior change to an existing method, so the protocol version bumps 4 → 5 and the exact-equality handshake remains the capability gate. Fail-closed old-peer coverage on both sides (daemon sends the typed version-mismatch frame + WS 1002; client raises the version-mismatch error, exit 5).
- **Core**: `loginCodex` (the in-process PKCE flow) is now exported, and gains an optional `AbortSignal` so callers can bound the wait; abort cancels the callback wait, closes the localhost server, and rejects. The CLI login path is unchanged.
- **Daemon**: applying a keyless `openai-codex` runtime config validates the stored OAuth profile first, persists the runtime configuration atomically (0600) with merge semantics — same-provider updates preserve unowned fields (`base_url`, `flush_model`, `compact_model`, key material); provider switches drop provider-scoped leftovers and own the `auth_profile` field in both directions — and secrets that arrive only in the RPC request are never written to YAML.
- **Desktop main**: a new auth controller runs the flow with a 5-minute bound, single-flight login, a closed set of refusal reasons, atomic merge-preserving 0600 profile storage in the athlete home, and an injectable browser-opening seam; two new strict IPC channels sit behind the existing trusted-sender gate.
- **Preload/renderer**: the frozen bridge gains `chatgptStatus`/`chatgptLogin` with strict result parsing; the wizard shows the lane with pending, configured, and refusal-with-retry states, restores status on mount, and treats a configured ChatGPT profile as satisfying the model step. The security smoke's pinned bridge surface is updated for the two new methods.

## Verification

- Full repo gate green: 4,610 tests passed, typecheck/lint/policy gates clean.
- Desktop build plus runtime and security smokes green.
- OAuth flow covered by unit tests against local fake servers only; the real browser sign-in is a post-merge acceptance step.
