### PR TITLE
fix(core): read intervals credentials live in reference sync

### DIFF
--- a/.changeset/reference-sync-live-config.md
+++ b/.changeset/reference-sync-live-config.md
@@ -1,0 +1,6 @@
+---
+"cycling-coach": patch
+"@enduragent/desktop": patch
+---
+
+User-facing: Fixed automatic training-data sync not picking up the intervals.icu key entered during onboarding.

--- a/packages/coach/src/composition.ts
+++ b/packages/coach/src/composition.ts
@@ -382,7 +382,8 @@ export async function createLocalCoachComposition(
   try {
     reference = await (dependencies.bootstrap ?? bootstrapReference)({
       dataDir: input.home.root,
-      intervals: input.config.intervals,
+      intervals: activeConfig.intervals,
+      readIntervals: () => activeConfig.intervals,
       sport: cyclingSport,
       startScheduler: false,
       attemptLedgerForRun: () => {

--- a/packages/coach/tests/composition.test.ts
+++ b/packages/coach/tests/composition.test.ts
@@ -616,6 +616,44 @@ describe("local coach composition", () => {
     await lifecycle.close();
   });
 
+  it("passes reference bootstrap a live intervals reader updated by runtime configuration", async () => {
+    const home = await freshHome();
+    let referenceOptions:
+      | Parameters<NonNullable<LocalCoachCompositionDependencies["bootstrap"]>>[0]
+      | undefined;
+    const lifecycle = await compose(
+      home,
+      {
+        bootstrap: async (options) => {
+          referenceOptions = options;
+          return reference();
+        },
+        createRuntime: () => runtime(),
+        createBackend: () => backend(),
+        createRepository: () => ({
+          insertIfAbsent: async () => false,
+          readCurrent: async () => undefined,
+        }),
+        createResolver: () => missingResolver(),
+      },
+      fakeContext(home),
+      { apiKey: "", athleteId: "fake-initial-athlete" },
+    );
+
+    await lifecycle.operations.configureRuntime({
+      intervals: {
+        api_key: "placeholder",
+        athlete_id: "fake-configured-athlete",
+      },
+    });
+
+    expect(referenceOptions?.readIntervals?.()).toEqual({
+      apiKey: "placeholder",
+      athleteId: "fake-configured-athlete",
+    });
+    await lifecycle.close();
+  });
+
   it("persists a keyless Codex selection that reloads as ready with a valid profile", async () => {
     const home = await freshHome();
     await writeFile(

--- a/packages/core/src/reference/runtime.ts
+++ b/packages/core/src/reference/runtime.ts
@@ -35,9 +35,13 @@ export interface BootstrapReferenceDeps {
   /** Binary's per-coach data root (e.g., `~/.cycling-coach/`). */
   readonly dataDir: string;
   readonly intervals: { readonly apiKey: string; readonly athleteId?: string };
+  readonly readIntervals?: () => { readonly apiKey: string; readonly athleteId?: string };
   readonly sport: Sport;
   /** Inject a fetcher for tests. Defaults to `makeProductionFetcher`. */
-  readonly fetchReferenceData?: (signal: AbortSignal) => Promise<FetchedReference>;
+  readonly fetchReferenceData?: (
+    signal: AbortSignal,
+    intervals: { readonly apiKey: string; readonly athleteId?: string },
+  ) => Promise<FetchedReference>;
   readonly startScheduler?: boolean;
   readonly attemptLedgerForRun?: () => PhysicalRequestLedger;
 }
@@ -70,15 +74,16 @@ export async function bootstrapReference(
   const referenceDataPath = join(deps.dataDir, "data");
   mkdirSync(referenceDataPath, { recursive: true, mode: 0o700 });
 
+  const readIntervals = deps.readIntervals ?? (() => deps.intervals);
   const fetchReferenceData =
     deps.fetchReferenceData ??
     makeProductionFetcher({
-      apiKey: deps.intervals.apiKey,
-      athleteId: deps.intervals.athleteId,
       adapters,
       sportTypes: deps.sport.intervalsActivityTypes,
       attemptLedgerForRun: deps.attemptLedgerForRun,
     });
+  const fetchReferenceDataForRun = (signal: AbortSignal) =>
+    fetchReferenceData(signal, readIntervals());
 
   const mutex = new AsyncMutex();
   const cooldown = new Cooldown();
@@ -87,7 +92,7 @@ export async function bootstrapReference(
     mutex,
     cooldown,
     cooldownWindowMs: SYNC_COOLDOWN_MS,
-    fetchReferenceData,
+    fetchReferenceData: fetchReferenceDataForRun,
   });
   const scheduler = new Scheduler({
     dataDir: referenceDataPath,

--- a/packages/core/src/reference/sync/fetch-reference-data.ts
+++ b/packages/core/src/reference/sync/fetch-reference-data.ts
@@ -92,16 +92,17 @@ export function readAnalysisBasis(
  * empty stubs — they are populated by their own retention pipeline, not here.
  */
 export function makeProductionFetcher(deps: {
-  apiKey: string;
-  athleteId?: string;
   adapters: readonly ReferenceSportAdapter[];
   sportTypes: readonly IntervalsActivityType[];
   attemptLedgerForRun?: () => PhysicalRequestLedger;
-}): (signal: AbortSignal) => Promise<FetchedReference> {
-  return async (signal) => {
+}): (
+  signal: AbortSignal,
+  intervals: { readonly apiKey: string; readonly athleteId?: string },
+) => Promise<FetchedReference> {
+  return async (signal, intervals) => {
     const client = makeAbortableClient({
-      apiKey: deps.apiKey,
-      athleteId: deps.athleteId,
+      apiKey: intervals.apiKey,
+      athleteId: intervals.athleteId,
       signal,
       perRequestMs: PER_REQUEST_TIMEOUT_MS,
       attemptLedger: deps.attemptLedgerForRun?.(),

--- a/packages/core/tests/reference-runtime.test.ts
+++ b/packages/core/tests/reference-runtime.test.ts
@@ -81,6 +81,53 @@ describe("bootstrapReference (behavioral)", () => {
     runtime.scheduler.stop();
   });
 
+  it("resolves live intervals credentials for every run", async () => {
+    let intervals = { apiKey: "", athleteId: "fake-athlete-first" };
+    const observed: Array<{ readonly apiKey: string; readonly athleteId?: string }> = [];
+    const runtime = await bootstrapReference({
+      dataDir,
+      intervals,
+      readIntervals: () => intervals,
+      sport: fakeSport(),
+      fetchReferenceData: async (_signal, credentials) => {
+        observed.push(credentials);
+        return emptyFetched;
+      },
+      startScheduler: false,
+    });
+
+    await runtime.runScheduledOnce();
+    intervals = { apiKey: "placeholder", athleteId: "fake-athlete-second" };
+    await runtime.services.runSync({ chatId: "fake-chat" });
+
+    expect(observed).toEqual([
+      { apiKey: "", athleteId: "fake-athlete-first" },
+      { apiKey: "placeholder", athleteId: "fake-athlete-second" },
+    ]);
+    runtime.scheduler.stop();
+  });
+
+  it("resolves static intervals credentials when no live reader is provided", async () => {
+    const observed: Array<{ readonly apiKey: string; readonly athleteId?: string }> = [];
+    const runtime = await bootstrapReference({
+      dataDir,
+      intervals: { apiKey: "placeholder", athleteId: "fake-static-athlete" },
+      sport: fakeSport(),
+      fetchReferenceData: async (_signal, credentials) => {
+        observed.push(credentials);
+        return emptyFetched;
+      },
+      startScheduler: false,
+    });
+
+    await runtime.runScheduledOnce();
+
+    expect(observed).toEqual([
+      { apiKey: "placeholder", athleteId: "fake-static-athlete" },
+    ]);
+    runtime.scheduler.stop();
+  });
+
   it("writes the 5 cache files + .scheduler.json after the initial sync resolves", async () => {
     const fetchSpy = vi.fn().mockResolvedValue(emptyFetched);
 


### PR DESCRIPTION
## Problem

The daemon has two sync lanes. The store capture lane reads configuration through a live closure, so credentials applied later via the `configureRuntime` RPC are picked up. The reference lane baked its intervals.icu credentials into the production fetcher once at daemon boot. The desktop app never persists secrets into `config.yaml` — they live in the OS-encrypted vault and are re-applied over RPC after the daemon starts — so on every desktop install the reference lane booted with an empty key and stayed empty forever: each scheduled sync failed immediately with "Either apiKey or bearerToken must be provided". Reproduced on a real install: vault held the key, chat and store capture worked, reference sync failed on every tick.

## Fix

- The reference runtime accepts an optional live credential reader; the static `intervals` object remains the fallback for unchanged callers.
- Credential resolution moved from fetcher construction to every sync run: each invocation resolves current values and builds that run's HTTP client from them, so a key applied between two scheduled ticks is used by the next tick.
- Coach composition passes a closure over its active configuration, which observes `configureRuntime` replacements.

## Verification

- New reference-runtime coverage: changing the live values between two runs is observed by the second run; the static configuration shape still works.
- New composition coverage: after applying a runtime configuration with a new key, the reader handed to the reference bootstrap yields the new key and athlete id.
- Full repo gate green (4,613 tests); desktop build plus runtime and security smokes green.
