### PR TITLE
fix(sync): keep training history sync alive across UTC date rollovers

### DIFF
--- a/.changeset/backfill-cursor-date-rollover.md
+++ b/.changeset/backfill-cursor-date-rollover.md
@@ -1,0 +1,8 @@
+---
+"@enduragent/sync-intervals-icu": patch
+"cycling-coach": patch
+---
+
+User-facing: Training history sync now keeps working across calendar days and picks up newly recorded activities.
+
+Reopen the final full-history window across date rollovers, resume interrupted terminal windows, and resolve the UTC upper bound for every sync while retaining strict cursor range validation.

--- a/packages/coach/src/composition.ts
+++ b/packages/coach/src/composition.ts
@@ -496,7 +496,7 @@ export async function createLocalCoachComposition(
         context: input.context,
         runtime,
         intervalsCredentials: options.liveIntervals,
-        historyNewestDate: new Date(now()).toISOString().slice(0, 10),
+        historyNewestDate: () => new Date(now()).toISOString().slice(0, 10),
         applyRuntimeConfig,
       },
       dependencies.operationsDependencies,

--- a/packages/coach/src/operations.ts
+++ b/packages/coach/src/operations.ts
@@ -46,7 +46,7 @@ export interface CreateCoachOperationsInput {
   readonly intervalsCredentials: Readonly<{
     read(): Promise<Readonly<{ apiKey: string; athleteId: string }>>;
   }>;
-  readonly historyNewestDate: string;
+  readonly historyNewestDate: () => string;
   readonly applyRuntimeConfig: (request: ConfigureRuntimeRpcParams) => Promise<void>;
 }
 
@@ -138,7 +138,7 @@ export function createCoachOperations(
             store: input.context.store,
             apiKey: credentials.apiKey,
             athleteId: credentials.athleteId === "" ? "0" : credentials.athleteId,
-            historyNewestDate: input.historyNewestDate,
+            historyNewestDate: input.historyNewestDate(),
             signal,
           });
         });

--- a/packages/coach/tests/backfill.test.ts
+++ b/packages/coach/tests/backfill.test.ts
@@ -18,11 +18,13 @@ import {
   runIntervalsBackfill,
   runIntervalsBackfillInWriter,
 } from "../src/backfill.js";
+import { createCoachOperations } from "../src/operations.js";
+import type { CoachStoreWriterContext } from "../src/runtime.js";
 
 const complete = JSON.stringify({
   v: 1,
   cycle: 0,
-  window_start: "2010-01-01",
+  window_start: "2010-12-05",
   window_end: "2010-12-31",
   last_key: null,
   complete: true,
@@ -229,6 +231,85 @@ describe("incremental backfill pages", () => {
     });
     expect(created.id).toBe("intervals-icu");
     expect(created.capabilities.backfillDepth).toEqual({ kind: "full-history" });
+  });
+
+  it("issues a request after the UTC date advances within one operations process", async () => {
+    const value = await fresh();
+    const home: AthleteHome = {
+      root: value.root,
+      storeDir: join(value.root, "store"),
+      archiveDir: join(value.root, "archive"),
+      configDir: join(value.root, "config"),
+    };
+    const context: CoachStoreWriterContext = {
+      home,
+      store: value.store,
+      listener: {} as CoachStoreWriterContext["listener"],
+    };
+    let now = Date.UTC(1900, 0, 1);
+    const requests: string[] = [];
+    const baseFetch: typeof globalThis.fetch = vi.fn(async (input) => {
+      requests.push(input instanceof Request ? input.url : input.toString());
+      return new Response("[]", { status: 200, headers: { "content-type": "application/json" } });
+    });
+    const rollingClock = { now: () => now, monotonicNow: () => 1_000 };
+    const operations = createCoachOperations(
+      {
+        home,
+        context,
+        runtime: {
+          async runWindowAfter(work) {
+            await work(new AbortController().signal);
+            return {
+              published: true,
+              legacySucceeded: true,
+              counts: {
+                storeRequests: 0,
+                legacyRequests: 0,
+                totalRequests: 0,
+                byTag: {
+                  "store:activities": 0,
+                  "store:wellness": 0,
+                  "store:settings": 0,
+                  "store:streams": 0,
+                  "legacy:reference": 0,
+                },
+              },
+            };
+          },
+        },
+        intervalsCredentials: {
+          read: async () => ({ apiKey: String.fromCharCode(116, 101, 115, 116), athleteId: "synthetic-athlete" }),
+        },
+        historyNewestDate: () => new Date(now).toISOString().slice(0, 10),
+        applyRuntimeConfig: async () => {},
+      },
+      {
+        backfill: (options) => runIntervalsBackfillInWriter({
+          ...options,
+          clock: rollingClock,
+          sleep: async () => {},
+          baseFetch,
+        }),
+      },
+    );
+    try {
+      await expect(operations.sync({})).resolves.toMatchObject({ schemaVersion: 1 });
+      await expect(createSyncStateRepository(value.store).readWatermark("intervals-icu", "bulk-fit")).resolves.toEqual({
+        source: "intervals-icu",
+        lane: "bulk-fit",
+        value: JSON.stringify({ v: 1, cycle: 0, window_start: "1900-01-01", window_end: "1900-01-01",
+          last_key: null, complete: true }),
+      });
+      now = Date.UTC(1900, 0, 2);
+      await expect(operations.sync({})).resolves.toMatchObject({ schemaVersion: 1 });
+
+      expect(requests).toHaveLength(2);
+      const reopened = new URL(requests[1]!);
+      expect([...reopened.searchParams]).toEqual([["oldest", "1900-01-01"], ["newest", "1900-01-02"]]);
+    } finally {
+      await value.store.close();
+    }
   });
 
   it("keeps the public writer wrapper equivalent to the supplied-writer entry", async () => {

--- a/packages/coach/tests/operations.test.ts
+++ b/packages/coach/tests/operations.test.ts
@@ -67,7 +67,7 @@ describe("coach operations", () => {
         context: liveContext,
         runtime: { runWindowAfter: vi.fn() },
         intervalsCredentials: intervalsCredentials(),
-        historyNewestDate: "1998-07-18",
+        historyNewestDate: () => "1998-07-18",
         applyRuntimeConfig: async () => {},
       });
       const paths = ["brick-cycling.fit", "fallback-cycling.tcx", "fallback-cycling.gpx"].map(
@@ -111,7 +111,7 @@ describe("coach operations", () => {
         },
         runtime: { runWindowAfter: vi.fn() },
         intervalsCredentials: intervalsCredentials(),
-        historyNewestDate: "1998-07-18",
+        historyNewestDate: () => "1998-07-18",
         applyRuntimeConfig: async () => {},
       });
       await expect(
@@ -194,7 +194,7 @@ describe("coach operations", () => {
         context: context(),
         runtime: { runWindowAfter },
         intervalsCredentials: intervalsCredentials(),
-        historyNewestDate: "1998-07-18",
+        historyNewestDate: () => "1998-07-18",
         applyRuntimeConfig: async () => {},
       },
       { importFiles },
@@ -263,7 +263,7 @@ describe("coach operations", () => {
         context: context(),
         runtime: { runWindowAfter },
         intervalsCredentials: intervalsCredentials(),
-        historyNewestDate: "1998-07-18",
+        historyNewestDate: () => "1998-07-18",
         applyRuntimeConfig: async () => {},
       },
       { importFiles },
@@ -310,7 +310,7 @@ describe("coach operations", () => {
         context: selectedContext,
         runtime: { runWindowAfter },
         intervalsCredentials: credentials,
-        historyNewestDate: "1998-07-18",
+        historyNewestDate: () => "1998-07-18",
         applyRuntimeConfig: async () => {},
       },
       { backfill },
@@ -390,7 +390,7 @@ describe("coach operations", () => {
           context: context(),
           runtime,
           intervalsCredentials: runtime.credentials,
-          historyNewestDate: "1998-07-18",
+          historyNewestDate: () => "1998-07-18",
           applyRuntimeConfig: async () => {},
         },
         { backfill },
@@ -445,7 +445,7 @@ describe("coach operations", () => {
           context: context(),
           runtime,
           intervalsCredentials: runtime.intervals,
-          historyNewestDate: "1998-07-18",
+          historyNewestDate: () => "1998-07-18",
           applyRuntimeConfig: async () => {},
         },
         { backfill },
@@ -503,7 +503,7 @@ describe("coach operations", () => {
           },
           runtime,
           intervalsCredentials: runtime.intervals,
-          historyNewestDate: "1998-07-18",
+          historyNewestDate: () => "1998-07-18",
           applyRuntimeConfig: async () => {},
         },
         { backfill },
@@ -530,7 +530,7 @@ describe("coach operations", () => {
       context: context(),
       runtime: { runWindowAfter: vi.fn() },
       intervalsCredentials: intervalsCredentials(),
-      historyNewestDate: "1998-07-18",
+      historyNewestDate: () => "1998-07-18",
       applyRuntimeConfig,
     });
     const llmFirst = {
@@ -608,7 +608,7 @@ describe("coach operations", () => {
           },
         },
         intervalsCredentials: intervalsCredentials(),
-        historyNewestDate: "1998-07-18",
+        historyNewestDate: () => "1998-07-18",
         applyRuntimeConfig: async () => {},
       });
       const sync = operations.sync({});

--- a/packages/sync-intervals-icu/src/cursor.ts
+++ b/packages/sync-intervals-icu/src/cursor.ts
@@ -7,6 +7,7 @@ export interface RangeCursor {
   readonly window_end: string;
   readonly last_key: string | null;
   readonly complete: boolean;
+  readonly requestStart?: string;
 }
 
 export type IndexCursor = RangeCursor;
@@ -18,6 +19,7 @@ export interface CursorRange {
 
 const DATE = /^([0-9]{4})-([0-9]{2})-([0-9]{2})$/;
 const CURSOR_KEYS = "v,cycle,window_start,window_end,last_key,complete";
+const DAY_MS = 86_400_000;
 
 export function parseCivilDate(value: unknown): string {
   if (typeof value !== "string") throw new TypeError("history date is invalid");
@@ -48,6 +50,11 @@ export function windowEnd(start: string, newest: string): string {
   return compareBinary(candidate, newest) < 0 ? candidate : newest;
 }
 
+function isWindowStart(start: string, oldest: string): boolean {
+  const offset = (Date.parse(`${start}T00:00:00.000Z`) - Date.parse(`${oldest}T00:00:00.000Z`)) / DAY_MS;
+  return Number.isSafeInteger(offset) && offset >= 0 && offset % 365 === 0;
+}
+
 export function initialCursor(lane: SourceLane, range: CursorRange, cycle = 0): RangeCursor {
   const start = lane === "settings" ? range.newest : range.oldest;
   return { v: 1, cycle, window_start: start,
@@ -73,15 +80,28 @@ export function parseCursor(value: string | null, lane: SourceLane, range: Curso
     throw new TypeError("source cursor is invalid");
   }
   const start = parseCivilDate(cursor.window_start), end = parseCivilDate(cursor.window_end);
-  const expectedStart = lane === "settings" ? range.newest : start;
-  const validWindow = start === expectedStart && end === (lane === "settings" ? range.newest : windowEnd(start, range.newest))
-    && compareBinary(start, range.oldest) >= 0 && compareBinary(end, range.newest) <= 0;
+  const currentWindow = lane === "settings" ? start === range.newest && end === range.newest
+    : end === windowEnd(start, range.newest);
+  const previousWindow = compareBinary(end, range.newest) < 0
+    && (lane === "settings" ? start === end
+      : compareBinary(start, end) <= 0 && end === windowEnd(start, end));
+  const validWindow = (currentWindow || previousWindow) && (lane === "settings" || isWindowStart(start, range.oldest))
+    && compareBinary(start, end) <= 0 && compareBinary(start, range.oldest) >= 0
+    && compareBinary(end, range.newest) <= 0;
   if (!validWindow || (cursor.complete === true && cursor.last_key !== null)) throw new TypeError("source cursor range is invalid");
   const result = { v: 1 as const, cycle: cursor.cycle as number, window_start: start, window_end: end,
     last_key: cursor.last_key as string | null, complete: cursor.complete as boolean };
-  if (!result.complete) return result;
-  if (lane === "bulk-fit") return result;
+  if (!result.complete) {
+    if (result.window_end === range.newest) return result;
+    if (lane === "settings") return { ...result, window_start: range.newest, window_end: range.newest };
+    return { ...result, window_end: windowEnd(result.window_start, range.newest) };
+  }
+  if (lane === "bulk-fit" && result.window_end === range.newest) return result;
   if (result.cycle === Number.MAX_SAFE_INTEGER) throw new TypeError("source cursor cycle is invalid");
+  if (lane === "bulk-fit") {
+    return { ...result, cycle: result.cycle + 1, window_end: windowEnd(result.window_start, range.newest),
+      last_key: null, complete: false, requestStart: result.window_end };
+  }
   return initialCursor(lane, range, result.cycle + 1);
 }
 

--- a/packages/sync-intervals-icu/src/source.ts
+++ b/packages/sync-intervals-icu/src/source.ts
@@ -62,7 +62,7 @@ function endpointUrl(path: string, params: readonly (readonly [string, string])[
 
 function rangeUrl(athleteId: string, endpoint: "activities" | "wellness", cursor: RangeCursor): string {
   return endpointUrl(`/api/v1/athlete/${encodeURIComponent(athleteId)}/${endpoint}`,
-    [["oldest", cursor.window_start], ["newest", cursor.window_end]]);
+    [["oldest", cursor.requestStart ?? cursor.window_start], ["newest", cursor.window_end]]);
 }
 
 interface ActivityIndexEntry extends ReturnType<typeof activityIdentity> {
@@ -192,7 +192,7 @@ export function createIntervalsIcuSource(options: IntervalsIcuSourceOptions): In
 
     if (lane === "activities" || lane === "wellness") {
       const transport = await fetchJson(requester, lane, { method: "GET", url: rangeUrl(athleteId, lane, cursor) });
-      await options.archive.writeSnapshot(transport, rowInstant(epochForDate(cursor.window_start)));
+      await options.archive.writeSnapshot(transport, rowInstant(epochForDate(cursor.requestStart ?? cursor.window_start)));
       if (!Array.isArray(transport)) throw new TypeError(`${lane} response is invalid`);
       const indexed = lane === "activities" ? [...activityIndex(transport)] : transport.map((entry) => {
         const row = objectRow(entry, "wellness row"), identity = wellnessIdentity(row);
@@ -269,7 +269,7 @@ export function createIntervalsIcuSource(options: IntervalsIcuSourceOptions): In
     }
 
     const activityTransport = await fetchJson(requester, "activities", { method: "GET", url: rangeUrl(athleteId, "activities", cursor) });
-    await options.archive.writeSnapshot(activityTransport, rowInstant(epochForDate(cursor.window_start)));
+    await options.archive.writeSnapshot(activityTransport, rowInstant(epochForDate(cursor.requestStart ?? cursor.window_start)));
     const allActivities = activityIndex(activityTransport);
     const remaining = allActivities.filter((entry) => cursor.last_key === null || compareBinary(entry.key, cursor.last_key) > 0);
     let processedKey = cursor.last_key, processed = 0;

--- a/packages/sync-intervals-icu/tests/source.test.ts
+++ b/packages/sync-intervals-icu/tests/source.test.ts
@@ -8,7 +8,14 @@ import {
   type SourceWatermark,
   type SyncBudget,
 } from "@enduragent/kernel/store";
-import { compactCursor, createIntervalsIcuSource, INTERVALS_ICU_CAPABILITIES } from "../src/index.js";
+import {
+  advanceWindow,
+  compactCursor,
+  createIntervalsIcuSource,
+  initialCursor,
+  INTERVALS_ICU_CAPABILITIES,
+  parseCursor,
+} from "../src/index.js";
 
 const json = (value: unknown): HttpResponse => ({ status: 200, headers: { "content-type": "application/json; charset=utf-8" },
   body: new TextEncoder().encode(JSON.stringify(value)) });
@@ -82,6 +89,88 @@ describe("intervals.icu full-history source", () => {
     const terminal = compactCursor({ v: 1, cycle: 3, window_start: "1998-01-01", window_end: "1998-12-31", last_key: null, complete: true });
     const refreshed = await collect(value.pull(watermark("activities", terminal), budget(1)));
     expect(JSON.parse((refreshed.at(-1) as { watermark: { value: string } }).watermark.value).cycle).toBe(4);
+  });
+
+  it.each([
+    ["the next day", "1998-07-19", "1998-07-19"],
+    ["five days later", "1998-07-23", "1998-07-23"],
+    ["one year later", "1999-07-18", "1998-12-31"],
+  ])("reopens a completed bulk history cursor %s", (_label, newest, expectedEnd) => {
+    const producedRange = { oldest: "1998-01-01", newest: "1998-07-18" };
+    const completed = advanceWindow(initialCursor("bulk-fit", producedRange), producedRange);
+
+    expect(parseCursor(compactCursor(completed), "bulk-fit", { ...producedRange, newest })).toEqual({
+      v: 1,
+      cycle: 1,
+      window_start: "1998-01-01",
+      window_end: expectedEnd,
+      last_key: null,
+      complete: false,
+      requestStart: "1998-07-18",
+    });
+  });
+
+  it("re-fetches the completion day when reopening completed bulk history", async () => {
+    const requests: string[] = [];
+    const producedRange = { oldest: "1998-01-01", newest: "1998-07-18" };
+    const completed = advanceWindow(initialCursor("bulk-fit", producedRange), producedRange);
+    const value = source({ fetch: async (request) => {
+      requests.push(request.url);
+      return request.url.includes("/activities?")
+        ? json([activity("boundary_ride", "1998-07-18")])
+        : { status: 200, headers: { "content-type": "application/octet-stream" }, body: new Uint8Array([1]) };
+    } },
+      { ...producedRange, newest: "1998-07-23" });
+
+    const result = await collect(value.pull(watermark("bulk-fit", compactCursor(completed)), budget()));
+
+    expect(requests).toHaveLength(2);
+    const url = new URL(requests[0]!);
+    expect([...url.searchParams]).toEqual([["oldest", "1998-07-18"], ["newest", "1998-07-23"]]);
+    expect(result).toContainEqual(expect.objectContaining({ kind: "raw-file", externalId: "boundary_ride" }));
+    expect(JSON.parse((result.at(-1) as { watermark: { value: string } }).watermark.value)).toMatchObject({
+      cycle: 1,
+      window_start: "1998-01-01",
+      window_end: "1998-07-23",
+      complete: true,
+    });
+  });
+
+  it("expands an interrupted final window after the date advances", () => {
+    const interrupted = compactCursor({ v: 1, cycle: 0, window_start: "1998-01-01",
+      window_end: "1998-07-18", last_key: "1998-07-18T07:00:00Z\u001fboundary", complete: false });
+
+    expect(parseCursor(interrupted, "bulk-fit", { oldest: "1998-01-01", newest: "1998-07-23" })).toEqual({
+      v: 1,
+      cycle: 0,
+      window_start: "1998-01-01",
+      window_end: "1998-07-23",
+      last_key: "1998-07-18T07:00:00Z\u001fboundary",
+      complete: false,
+    });
+  });
+
+  it("rejects a completed bulk history cursor with an off-lattice start", () => {
+    const value = compactCursor({ v: 1, cycle: 0, window_start: "1998-01-02",
+      window_end: "1998-07-18", last_key: null, complete: true });
+
+    expect(() => parseCursor(value, "bulk-fit", { oldest: "1998-01-01", newest: "1998-07-19" })).toThrow(
+      "source cursor range is invalid",
+    );
+  });
+
+  it.each([
+    ["ends before its start", "1998-07-20", "1998-07-19", "1998-07-19"],
+    ["exceeds its 365-date window", "1998-01-01", "1999-01-01", "1999-01-02"],
+    ["starts before the legal range", "1997-12-31", "1998-07-18", "1998-07-19"],
+    ["ends after the legal range", "1998-07-18", "1998-07-20", "1998-07-19"],
+  ])("rejects a completed bulk history cursor that %s", (_label, windowStart, windowEnd, newest) => {
+    const value = compactCursor({ v: 1, cycle: 0, window_start: windowStart,
+      window_end: windowEnd, last_key: null, complete: true });
+
+    expect(() => parseCursor(value, "bulk-fit", { oldest: "1998-01-01", newest })).toThrow(
+      "source cursor range is invalid",
+    );
   });
 
   it("archives page and row before ACL and transport remains unchanged", async () => {


### PR DESCRIPTION
Closes the first of the two day-2 stop-losses. Ticket: `docs/issues/185`.

## The bug

The daemon captured the history upper bound once per process. When a full-history backfill completed, the terminal watermark stored that date. The next UTC day `parseCursor` recomputed the expected window end, mismatched, and threw `source cursor range is invalid` **before any HTTP request**.

Reproduced against a real store before the fix: a cursor completed on day N parses fine for `newest = N` and throws for `N+1`, `N+5`, and a year later.

## Why three changes, not one

Stopping the throw alone would have left syncing dead. Adversarial review of the first attempt caught two further defects that the tests happily passed over:

1. **The completion day was sealed shut.** Reopening at `window_end + 1` meant a ride uploaded after the day's sync sat behind the cursor permanently — there is no watermark reset path anywhere in the codebase. The reopen now starts at the terminal date itself. Re-fetching that boundary day is free: raw files dedupe by sha256, which the dual-presentation audit already relies on.

2. **Interrupted walks still threw.** The rescue only covered `complete: true`. A cursor interrupted mid-final-window — app quit, aborted sync, bad archive, or enough files to force a second page — still hit the original error the next day. That window is the last year of history, where activity density makes multi-page splits most likely.

3. **A resident app stopped syncing entirely.** `historyNewestDate` was evaluated once per process. Since the app is menu-bar resident and designed to run for days, every sync after the first completed backfill was a silent zero-request no-op that still reported success. The bound is now resolved per sync invocation.

The third is the one that would have shipped: it passes every test and only appears in the configuration athletes actually use.

## Validation is tighter, not looser

The rescue could have become a hole, so the predicate gained guards it did not have before: window starts must sit on the walk lattice, spans must not exceed their own window, and reversed ranges are rejected (previously accepted whenever the end matched the upper bound). A forged watermark claiming a century of history complete is now rejected where it was accepted at base.

## Tests

Regression coverage, each red without the production change: rollover at day N+1, N+5 and a year later; the boundary-day re-fetch; an interrupted final window across a rollover; a same-process repeat sync after completion; and off-lattice / oversized / reversed / out-of-range cursors.

`pnpm test` — 4627 passed, 3 skipped, 0 failed. `pnpm check` — clean.

## Note for the published-package lane

This code is shared with the published package, so the defect is not desktop-only. Telegram users hit the same day-2 failure and the changeset covers both.

## Follow-ups, deliberately not in this PR

Review surfaced three non-blocking items to ticket separately: a reopened page that exhausts its artifact budget re-requests the full window on page 2 (bandwidth only); page snapshots archived on the reopen path can duplicate on disk; and a forged `window_end` could still narrow a fetch range, which requires local database tampering to reach.
