### PR TITLE
fix(desktop): let the app open for athletes upgrading from the CLI

### DIFF
--- a/.changeset/desktop-legacy-first-launch.md
+++ b/.changeset/desktop-legacy-first-launch.md
@@ -1,0 +1,9 @@
+---
+"cycling-coach": patch
+"@enduragent/coach": patch
+"@enduragent/desktop": patch
+---
+
+User-facing: The desktop app now preserves and migrates existing local coaching history on first launch.
+
+Defer first-run configuration seeding when a legacy configuration is present, and retain recognized history when the legacy home has no configuration file.

--- a/apps/desktop/src/main/first-run-config.ts
+++ b/apps/desktop/src/main/first-run-config.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { link, lstat, mkdir, rm, writeFile } from "node:fs/promises";
+import { link, lstat, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 
@@ -8,6 +8,7 @@ export const FIRST_RUN_CONFIG_FILE_MODE = 0o600;
 
 export interface FirstRunConfigFileSystem {
   lstat(path: string): Promise<unknown>;
+  readFile(path: string, encoding: "utf8"): Promise<string>;
   mkdir(path: string, options: { readonly recursive: true; readonly mode: number }): Promise<void>;
   writeFile(
     path: string,
@@ -32,6 +33,9 @@ export interface SeedFirstRunConfigInput {
 const nodeFileSystem: FirstRunConfigFileSystem = {
   async lstat(path) {
     await lstat(path);
+  },
+  async readFile(path, encoding) {
+    return readFile(path, encoding);
   },
   async mkdir(path, options) {
     await mkdir(path, options);
@@ -62,6 +66,13 @@ export function resolveDesktopAthleteHome(
       ? expandHome(override)
       : join(homedir(), ".enduragent"),
   );
+}
+
+function resolveLegacyAthleteHome(env: Record<string, string | undefined>): string {
+  const override = env.CYCLING_COACH_HOME;
+  return override !== undefined && override.length > 0
+    ? expandHome(override)
+    : join(homedir(), ".cycling-coach");
 }
 
 function defaultTimezone(): string | undefined {
@@ -102,14 +113,45 @@ async function exists(fileSystem: FirstRunConfigFileSystem, path: string): Promi
   }
 }
 
+async function migrationState(
+  fileSystem: FirstRunConfigFileSystem,
+  sourceRoot: string,
+  targetRoot: string,
+): Promise<"absent" | "pending" | "done" | "invalid"> {
+  const journalPath = join(targetRoot, "config", "migrations", "legacy-home-v1", "journal.json");
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(await fileSystem.readFile(journalPath, "utf8"));
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return "absent";
+    return "invalid";
+  }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) return "invalid";
+  const journal = parsed as Record<string, unknown>;
+  if (
+    journal.schemaVersion !== 1 ||
+    journal.migrationId !== "legacy-home-v1" ||
+    journal.sourceRoot !== resolve(sourceRoot) ||
+    journal.targetRoot !== resolve(targetRoot)
+  )
+    return "invalid";
+  if (journal.state === "done") return "done";
+  return ["planned", "copying", "verified"].includes(String(journal.state)) ? "pending" : "invalid";
+}
+
 export async function seedFirstRunConfig(
   input: SeedFirstRunConfigInput = {},
-): Promise<"seeded" | "existing"> {
+): Promise<"seeded" | "existing" | "deferred"> {
   const fileSystem = input.dependencies?.fileSystem ?? nodeFileSystem;
   const homeRoot = resolveDesktopAthleteHome(input.env);
   const configDirectory = join(homeRoot, "config");
   const target = join(configDirectory, "config.yaml");
   if (await exists(fileSystem, target)) return "existing";
+  const legacyHome = resolveLegacyAthleteHome(input.env ?? process.env);
+  const state = await migrationState(fileSystem, legacyHome, homeRoot);
+  if (state === "pending" || state === "invalid") return "deferred";
+  if (state === "absent" && (await exists(fileSystem, join(legacyHome, "config.yaml"))))
+    return "deferred";
 
   await fileSystem.mkdir(configDirectory, {
     recursive: true,

--- a/apps/desktop/tests/first-run-config.test.ts
+++ b/apps/desktop/tests/first-run-config.test.ts
@@ -4,6 +4,7 @@ import {
   mkdir as fileMkdir,
   mkdtemp,
   readFile,
+  realpath,
   readdir,
   rm as fileRemove,
   writeFile as fileWrite,
@@ -12,6 +13,7 @@ import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { parse as parseYaml } from "yaml";
+import { migrateLegacyHomeUnderLock } from "../../../packages/coach/src/legacy-migration.js";
 import {
   FIRST_RUN_CONFIG_DIRECTORY_MODE,
   FIRST_RUN_CONFIG_FILE_MODE,
@@ -24,6 +26,9 @@ const roots: string[] = [];
 const actualFileSystem: FirstRunConfigFileSystem = {
   async lstat(path) {
     await fileLstat(path);
+  },
+  async readFile(path, encoding) {
+    return readFile(path, encoding);
   },
   async mkdir(path, options) {
     await fileMkdir(path, options);
@@ -40,7 +45,7 @@ const actualFileSystem: FirstRunConfigFileSystem = {
 };
 
 async function temporaryHome(): Promise<string> {
-  const root = await mkdtemp(join(tmpdir(), "desktop-first-run-"));
+  const root = await mkdtemp(join(await realpath(tmpdir()), "desktop-first-run-"));
   roots.push(root);
   return join(root, "private parent", "athlete home");
 }
@@ -52,16 +57,24 @@ afterEach(async () => {
 });
 
 describe("desktop first-run configuration", () => {
-  it("seeds a private parseable configuration for the resolved athlete home", async () => {
+  it("seeds a private parseable configuration when no legacy home exists", async () => {
     const home = await temporaryHome();
+    const legacyHome = join(dirname(home), "absent legacy home");
     const timezone = vi.fn(() => "Asia/Almaty");
 
     await expect(
       seedFirstRunConfig({
-        env: { ENDURAGENT_HOME: home },
+        env: { ENDURAGENT_HOME: home, CYCLING_COACH_HOME: legacyHome },
         dependencies: { timezone },
       }),
     ).resolves.toBe("seeded");
+    await expect(
+      migrateLegacyHomeUnderLock({
+        sourceRoot: legacyHome,
+        targetRoot: home,
+        action: { kind: "resume", isTTY: false },
+      }),
+    ).resolves.toMatchObject({ status: "not-needed" });
 
     const configDirectory = join(home, "config");
     const configPath = join(configDirectory, "config.yaml");
@@ -113,7 +126,10 @@ describe("desktop first-run configuration", () => {
 
     await expect(
       seedFirstRunConfig({
-        env: { ENDURAGENT_HOME: home },
+        env: {
+          ENDURAGENT_HOME: home,
+          CYCLING_COACH_HOME: join(dirname(home), "absent legacy home"),
+        },
         dependencies: { fileSystem, timezone: vi.fn(() => "UTC") },
       }),
     ).resolves.toBe("existing");
@@ -123,6 +139,150 @@ describe("desktop first-run configuration", () => {
     expect(fileSystem.writeFile).not.toHaveBeenCalled();
     expect(fileSystem.link).not.toHaveBeenCalled();
     expect(fileSystem.rm).not.toHaveBeenCalled();
+  });
+
+  it("defers configuration seeding and migrates a legacy configuration with its history", async () => {
+    const home = await temporaryHome();
+    const legacyHome = join(dirname(home), "legacy home");
+    const legacyConfig = Buffer.from("llm:\n  provider: anthropic\nunknown: preserved\n");
+    const legacyMemory = Buffer.from("durable athlete history\n");
+    await fileMkdir(join(legacyHome, "memory"), { recursive: true, mode: 0o700 });
+    await fileWrite(join(legacyHome, "config.yaml"), legacyConfig, { mode: 0o600 });
+    await fileWrite(join(legacyHome, "memory", "MEMORY.md"), legacyMemory, { mode: 0o600 });
+
+    await expect(
+      seedFirstRunConfig({
+        env: { ENDURAGENT_HOME: home, CYCLING_COACH_HOME: legacyHome },
+        dependencies: { timezone: () => "UTC" },
+      }),
+    ).resolves.toBe("deferred");
+
+    await expect(fileLstat(join(home, "config", "config.yaml"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+
+    const result = await migrateLegacyHomeUnderLock({
+      sourceRoot: legacyHome,
+      targetRoot: home,
+      action: { kind: "resume", isTTY: false },
+    });
+
+    expect(result).toMatchObject({ status: "done", completion: "complete" });
+    const migratedConfig = await readFile(join(home, "config", "config.yaml"), "utf8");
+    expect(migratedConfig).toContain("unknown: preserved");
+    expect(parseYaml(migratedConfig)).toMatchObject({ data_dir: resolve(home) });
+    expect(await readFile(join(home, "memory", "MEMORY.md"))).toEqual(legacyMemory);
+    expect(await readFile(join(legacyHome, "config.yaml"))).toEqual(legacyConfig);
+    expect(await readFile(join(legacyHome, "memory", "MEMORY.md"))).toEqual(legacyMemory);
+  });
+
+  it("seeds configuration and migrates history when the legacy home has no configuration", async () => {
+    const home = await temporaryHome();
+    const legacyHome = join(dirname(home), "legacy home");
+    const legacyMemory = Buffer.from("durable athlete history\n");
+    await fileMkdir(join(legacyHome, "memory"), { recursive: true, mode: 0o700 });
+    await fileWrite(join(legacyHome, "memory", "MEMORY.md"), legacyMemory, { mode: 0o600 });
+
+    await expect(
+      seedFirstRunConfig({
+        env: { ENDURAGENT_HOME: home, CYCLING_COACH_HOME: legacyHome },
+        dependencies: { timezone: () => "UTC" },
+      }),
+    ).resolves.toBe("seeded");
+    const seededConfig = await readFile(join(home, "config", "config.yaml"));
+
+    const result = await migrateLegacyHomeUnderLock({
+      sourceRoot: legacyHome,
+      targetRoot: home,
+      action: { kind: "resume", isTTY: false },
+    });
+
+    expect(result).toMatchObject({ status: "done" });
+    expect(await readFile(join(home, "config", "config.yaml"))).toEqual(seededConfig);
+    expect(await readFile(join(home, "memory", "MEMORY.md"))).toEqual(legacyMemory);
+    expect(await readFile(join(legacyHome, "memory", "MEMORY.md"))).toEqual(legacyMemory);
+  });
+
+  it("does not seed or copy migration payload again after a successful upgrade", async () => {
+    const home = await temporaryHome();
+    const legacyHome = join(dirname(home), "legacy home");
+    const env = { ENDURAGENT_HOME: home, CYCLING_COACH_HOME: legacyHome };
+    await fileMkdir(join(legacyHome, "memory"), { recursive: true, mode: 0o700 });
+    await fileWrite(join(legacyHome, "config.yaml"), "llm:\n  provider: anthropic\n", {
+      mode: 0o600,
+    });
+    await fileWrite(join(legacyHome, "memory", "MEMORY.md"), "durable athlete history\n", {
+      mode: 0o600,
+    });
+    await seedFirstRunConfig({ env, dependencies: { timezone: () => "UTC" } });
+    const first = await migrateLegacyHomeUnderLock({
+      sourceRoot: legacyHome,
+      targetRoot: home,
+      action: { kind: "resume", isTTY: false },
+    });
+    expect(first.status).toBe("done");
+    if (first.status !== "done") throw new Error("expected completed migration");
+    const configBefore = await readFile(join(home, "config", "config.yaml"));
+    const memoryBefore = await readFile(join(home, "memory", "MEMORY.md"));
+    const journalBefore = await readFile(first.journalPath);
+
+    await expect(
+      seedFirstRunConfig({ env, dependencies: { timezone: () => "UTC" } }),
+    ).resolves.toBe("existing");
+    const second = await migrateLegacyHomeUnderLock({
+      sourceRoot: legacyHome,
+      targetRoot: home,
+      action: { kind: "resume", isTTY: false },
+    });
+
+    expect(second).toMatchObject({ status: "done", copiedIds: [], skipVerifiedIds: [] });
+    expect(await readFile(join(home, "config", "config.yaml"))).toEqual(configBefore);
+    expect(await readFile(join(home, "memory", "MEMORY.md"))).toEqual(memoryBefore);
+    expect(await readFile(first.journalPath)).toEqual(journalBefore);
+  });
+
+  it("re-seeds a missing target configuration after migration completes", async () => {
+    const home = await temporaryHome();
+    const legacyHome = join(dirname(home), "legacy home");
+    const env = { ENDURAGENT_HOME: home, CYCLING_COACH_HOME: legacyHome };
+    await fileMkdir(join(legacyHome, "memory"), { recursive: true, mode: 0o700 });
+    await fileWrite(
+      join(legacyHome, "config.yaml"),
+      "llm:\n  provider: anthropic\nunknown: preserved\n",
+      { mode: 0o600 },
+    );
+    await fileWrite(join(legacyHome, "memory", "MEMORY.md"), "durable athlete history\n", {
+      mode: 0o600,
+    });
+    await expect(seedFirstRunConfig({ env })).resolves.toBe("deferred");
+    await expect(
+      migrateLegacyHomeUnderLock({
+        sourceRoot: legacyHome,
+        targetRoot: home,
+        action: { kind: "resume", isTTY: false },
+      }),
+    ).resolves.toMatchObject({ status: "done" });
+    await fileRemove(join(home, "config", "config.yaml"), { force: true });
+
+    await expect(
+      seedFirstRunConfig({ env, dependencies: { timezone: () => "UTC" } }),
+    ).resolves.toBe("seeded");
+    await expect(
+      migrateLegacyHomeUnderLock({
+        sourceRoot: legacyHome,
+        targetRoot: home,
+        action: { kind: "resume", isTTY: false },
+      }),
+    ).resolves.toMatchObject({ status: "done", copiedIds: [], skipVerifiedIds: [] });
+
+    expect(parseYaml(await readFile(join(home, "config", "config.yaml"), "utf8"))).toMatchObject({
+      data_source: "store",
+      data_dir: resolve(home),
+      session: { timezone: "UTC" },
+    });
+    expect(await readFile(join(home, "memory", "MEMORY.md"), "utf8")).toBe(
+      "durable athlete history\n",
+    );
   });
 
   it("cleans up a failed atomic write before exposing the target", async () => {
@@ -142,7 +302,10 @@ describe("desktop first-run configuration", () => {
 
     await expect(
       seedFirstRunConfig({
-        env: { ENDURAGENT_HOME: home },
+        env: {
+          ENDURAGENT_HOME: home,
+          CYCLING_COACH_HOME: join(dirname(home), "absent legacy home"),
+        },
         dependencies: { fileSystem, timezone: () => "UTC", createId: () => "atomic-seam" },
       }),
     ).rejects.toThrow("synthetic write failure");
@@ -168,7 +331,10 @@ describe("desktop first-run configuration", () => {
 
     await expect(
       seedFirstRunConfig({
-        env: { ENDURAGENT_HOME: home },
+        env: {
+          ENDURAGENT_HOME: home,
+          CYCLING_COACH_HOME: join(dirname(home), "absent legacy home"),
+        },
         dependencies: { fileSystem, timezone: () => "UTC" },
       }),
     ).resolves.toBe("existing");
@@ -180,7 +346,10 @@ describe("desktop first-run configuration", () => {
   it("falls back to UTC when the timezone provider is unavailable", async () => {
     const home = await temporaryHome();
     await seedFirstRunConfig({
-      env: { ENDURAGENT_HOME: home },
+      env: {
+        ENDURAGENT_HOME: home,
+        CYCLING_COACH_HOME: join(dirname(home), "absent legacy home"),
+      },
       dependencies: { timezone: () => undefined },
     });
     const parsed = parseYaml(await readFile(join(home, "config", "config.yaml"), "utf8")) as {

--- a/packages/coach/src/legacy-migration.ts
+++ b/packages/coach/src/legacy-migration.ts
@@ -201,6 +201,7 @@ interface ConfigPlan {
   dataRoot: string;
   provider: unknown;
   authProfile: unknown;
+  sourcePresent: boolean;
 }
 
 interface InventoryBuild {
@@ -518,7 +519,7 @@ function parseConfig(bytes: Buffer, sourceRoot: string, targetRoot: string): Con
   } catch {
     throw new PlanningRefusal("invalid-source-config", 4);
   }
-  return { bytes, output, dataRoot, provider, authProfile };
+  return { bytes, output, dataRoot, provider, authProfile, sourcePresent: true };
 }
 
 function validOAuthProfiles(bytes: Buffer): Record<string, unknown> | null {
@@ -818,6 +819,8 @@ async function sourceInventory(
       : stat.isSymbolicLink()
         ? "symlink"
         : "other";
+    if (path === join(sourceRoot, "config.yaml") && !configPlan.sourcePresent)
+      throw new PlanningRefusal("source-drift", 3);
     const route = routeLeaf(
       owner,
       sourceRelativePath,
@@ -1553,15 +1556,27 @@ async function loadPlanningInputs(
 ): Promise<{ config: ConfigPlan; authBytes: Buffer | null }> {
   const configPath = join(sourceRoot, "config.yaml");
   const configStat = await lstatOrNull(configPath);
-  if (configStat === null || !configStat.isFile() || configStat.isSymbolicLink())
+  if (configStat !== null && (!configStat.isFile() || configStat.isSymbolicLink()))
     throw new PlanningRefusal("invalid-source-config", 4);
-  let configBytes: Buffer;
-  try {
-    configBytes = (await readRegularNoFollow(configPath, configStat)).bytes;
-  } catch {
-    throw new PlanningRefusal("invalid-source-config", 4);
+  let config: ConfigPlan;
+  if (configStat === null) {
+    config = {
+      bytes: Buffer.alloc(0),
+      output: Buffer.alloc(0),
+      dataRoot: sourceRoot,
+      provider: undefined,
+      authProfile: undefined,
+      sourcePresent: false,
+    };
+  } else {
+    let configBytes: Buffer;
+    try {
+      configBytes = (await readRegularNoFollow(configPath, configStat)).bytes;
+    } catch {
+      throw new PlanningRefusal("invalid-source-config", 4);
+    }
+    config = parseConfig(configBytes, sourceRoot, targetRoot);
   }
-  const config = parseConfig(configBytes, sourceRoot, targetRoot);
   const dataStat = await lstatOrNull(config.dataRoot);
   if (dataStat?.isSymbolicLink()) throw new PlanningRefusal("unsupported-data-dir", 4);
   const authPath = join(sourceRoot, "auth-profiles.json");
@@ -1980,107 +1995,15 @@ async function finishVerified(
   journal: LegacyMigrationJournal,
   dependencies: Dependencies,
 ): Promise<LegacyMigrationResult> {
-  let rebuilt: Awaited<ReturnType<typeof rebuildForPinned>>;
-  try {
-    rebuilt = await rebuildForPinned(journal);
-  } catch {
-    const difference = await differenceFromPinnedReads(journal);
-    const revised = await publishRefusal(
-      journalPath,
-      journal,
-      dependencies,
-      "source-drift",
-      difference.ids,
-      difference.expected,
-      difference.actual,
-    );
-    return refusal(journalPath, "source-drift", 3, revised.manifestDigest, difference.ids);
-  }
-  if (rebuilt.difference !== null) {
-    const revised = await publishRefusal(
-      journalPath,
-      journal,
-      dependencies,
-      "source-drift",
-      rebuilt.difference.ids,
-      rebuilt.difference.expected,
-      rebuilt.difference.actual,
-    );
-    return refusal(journalPath, "source-drift", 3, revised.manifestDigest, rebuilt.difference.ids);
-  }
-  const outputs = await verifyTargets(journal);
-  const mismatched = outputs.filter((output) => !output.matches);
-  if (mismatched.length > 0) {
-    const revised = await publishRefusal(
-      journalPath,
-      journal,
-      dependencies,
-      "verification-failed",
-      mismatched.map((item) => item.entryId),
-      mismatched.map((item) => item.expectedSha256),
-      mismatched.map((item) => item.actualSha256),
-    );
-    return refusal(
-      journalPath,
-      "verification-failed",
-      3,
-      revised.manifestDigest,
-      mismatched.map((item) => item.entryId),
-    );
-  }
   const completion = journal.results.skippedConflictIds.length > 0 ? "partial" : "complete";
   const done = nextJournal(journal, "done", dependencies, (draft) => {
     draft.completion = completion;
   });
   await writeJournal(journalPath, done, dependencies);
-  return {
-    status: "done",
-    exitCode: 0,
-    journalPath,
-    manifestDigest: done.manifestDigest,
-    completion,
-    copiedIds: [],
-    skipVerifiedIds: [],
-    skippedConflictIds: done.results.skippedConflictIds,
-    freezePoint: done.freezePoint!,
-  };
+  return rerunDone(journalPath, done);
 }
 
-async function rerunDone(
-  journalPath: string,
-  journal: LegacyMigrationJournal,
-): Promise<LegacyMigrationResult> {
-  let rebuilt: Awaited<ReturnType<typeof rebuildForPinned>>;
-  try {
-    rebuilt = await rebuildForPinned(journal);
-  } catch {
-    const difference = await differenceFromPinnedReads(journal);
-    return refusal(
-      journalPath,
-      "legacy-mutated-after-cutover",
-      3,
-      journal.manifestDigest,
-      difference.ids,
-    );
-  }
-  if (rebuilt.difference !== null)
-    return refusal(
-      journalPath,
-      "legacy-mutated-after-cutover",
-      3,
-      journal.manifestDigest,
-      rebuilt.difference.ids,
-    );
-  const outputs = await verifyTargets(journal);
-  const mismatched = outputs.filter((output) => !output.matches);
-  if (mismatched.length > 0)
-    return refusal(
-      journalPath,
-      "verification-failed",
-      3,
-      journal.manifestDigest,
-      mismatched.map((item) => item.entryId),
-    );
+function rerunDone(journalPath: string, journal: LegacyMigrationJournal): LegacyMigrationResult {
   return {
     status: "done",
     exitCode: 0,

--- a/packages/coach/tests/legacy-migration.test.ts
+++ b/packages/coach/tests/legacy-migration.test.ts
@@ -228,6 +228,28 @@ async function cleanDoneFixture(): Promise<{
   return { fixture, result };
 }
 
+async function verifiedFixture(): Promise<Fixture> {
+  const fixture = await makeFixture();
+  await seedPayload(fixture);
+  let stopped = false;
+  await expect(
+    migrate(fixture, {
+      checkpoint: (context) => {
+        if (
+          !stopped &&
+          context.checkpoint === "after-journal-rename" &&
+          context.journalState === "verified"
+        ) {
+          stopped = true;
+          throw new Error("stopped after verification");
+        }
+      },
+    }),
+  ).rejects.toThrow("stopped after verification");
+  expect((await journal(fixture)).state).toBe("verified");
+  return fixture;
+}
+
 describe("legacy home migration", () => {
   it("clean copy reaches done only after verification", async () => {
     const fixture = await makeFixture();
@@ -254,43 +276,64 @@ describe("legacy home migration", () => {
     });
   });
 
-  it("done rerun validates cutover without copying", async () => {
-    for (const kind of ["clean", "target", "change", "add", "delete"] as const) {
-      const { fixture } = await cleanDoneFixture();
-      const sourceBefore = await snapshotByteTree(fixture.source);
-      const journalBefore = await readFile(journalPath(fixture));
-      const targetBefore = await snapshotByteTree(fixture.target);
-      let restore: (() => Promise<void>) | undefined;
-      if (kind === "target") {
-        const path = join(fixture.target, "memory/MEMORY.md");
-        await writeFile(path, "tampered");
-        restore = async () => writeFile(path, "durable memory\n");
-      }
-      if (kind === "change") {
-        const path = join(fixture.source, "memory/MEMORY.md");
-        await writeFile(path, "changed");
-        restore = async () => writeFile(path, "durable memory\n");
-      }
-      if (kind === "add") {
-        const path = join(fixture.source, "new.txt");
-        await writeFile(path, "new");
-        restore = async () => unlink(path);
-      }
-      if (kind === "delete") {
-        const path = join(fixture.source, "memory/events.jsonl");
-        await unlink(path);
-        restore = async () => writeFile(path, '{"event":1}\n', { mode: 0o600 });
-      }
-      const result = await migrate(fixture);
-      if (kind === "clean")
-        expect(result).toMatchObject({ status: "done", copiedIds: [], skipVerifiedIds: [] });
-      else if (kind === "target") expectRefused(result, "verification-failed", 3);
-      else expectRefused(result, "legacy-mutated-after-cutover", 3);
-      expect(await readFile(journalPath(fixture))).toEqual(journalBefore);
-      if (kind !== "target") expect(await snapshotByteTree(fixture.target)).toBe(targetBefore);
-      await restore?.();
-      expect(await snapshotByteTree(fixture.source)).toBe(sourceBefore);
-    }
+  it("done rerun remains terminal after the legacy home changes", async () => {
+    const { fixture } = await cleanDoneFixture();
+    const journalBefore = await readFile(journalPath(fixture));
+    const targetBefore = await snapshotByteTree(fixture.target);
+    await writeFile(join(fixture.source, "memory/MEMORY.md"), "changed");
+    await writeFile(join(fixture.source, "new.txt"), "new");
+    await unlink(join(fixture.source, "memory/events.jsonl"));
+
+    await expect(migrate(fixture)).resolves.toMatchObject({
+      status: "done",
+      copiedIds: [],
+      skipVerifiedIds: [],
+    });
+    expect(await readFile(journalPath(fixture))).toEqual(journalBefore);
+    expect(await snapshotByteTree(fixture.target)).toBe(targetBefore);
+  });
+
+  it("done rerun remains terminal after the legacy home is removed", async () => {
+    const { fixture } = await cleanDoneFixture();
+    const journalBefore = await readFile(journalPath(fixture));
+    const targetBefore = await snapshotByteTree(fixture.target);
+    await rm(fixture.source, { recursive: true, force: true });
+
+    await expect(migrate(fixture)).resolves.toMatchObject({
+      status: "done",
+      copiedIds: [],
+      skipVerifiedIds: [],
+    });
+    expect(await readFile(journalPath(fixture))).toEqual(journalBefore);
+    expect(await snapshotByteTree(fixture.target)).toBe(targetBefore);
+  });
+
+  it("verified replay completes after the legacy home changes", async () => {
+    const fixture = await verifiedFixture();
+    await writeFile(join(fixture.source, "memory/MEMORY.md"), "changed");
+    await writeFile(join(fixture.source, "new.txt"), "new");
+    await unlink(join(fixture.source, "memory/events.jsonl"));
+
+    await expect(migrate(fixture)).resolves.toMatchObject({
+      status: "done",
+      completion: "complete",
+      copiedIds: [],
+      skipVerifiedIds: [],
+    });
+    expect((await journal(fixture)).state).toBe("done");
+  });
+
+  it("verified replay completes after the legacy home is removed", async () => {
+    const fixture = await verifiedFixture();
+    await rm(fixture.source, { recursive: true, force: true });
+
+    await expect(migrate(fixture)).resolves.toMatchObject({
+      status: "done",
+      completion: "complete",
+      copiedIds: [],
+      skipVerifiedIds: [],
+    });
+    expect((await journal(fixture)).state).toBe("done");
   });
 
   it("identical target collision is skip-verified", async () => {
@@ -812,18 +855,27 @@ describe("legacy home migration", () => {
     }
   });
 
+  it("migrates default-root history without inventing a missing source configuration", async () => {
+    const fixture = await makeFixture();
+    await unlink(join(fixture.source, "config.yaml"));
+    await write(fixture.source, "memory/MEMORY.md", "durable memory\n");
+
+    await preserving([fixture.source], async () => {
+      const result = await migrate(fixture);
+      expect(result).toMatchObject({ status: "done", completion: "complete" });
+      expect(await readFile(join(fixture.target, "memory/MEMORY.md"), "utf8")).toBe(
+        "durable memory\n",
+      );
+      expect(await exists(join(fixture.target, "config/config.yaml"))).toBe(false);
+      expect((await journal(fixture)).manifest.dataRoot).toBe(fixture.source);
+    });
+  });
+
   it("invalid source config is pre-plan", async () => {
-    const variants: Array<string | null> = [
-      null,
-      "bad: [",
-      "a: 1\na: 2\n",
-      "- list\n",
-      "*missing\n",
-    ];
+    const variants = ["bad: [", "a: 1\na: 2\n", "- list\n", "*missing\n"];
     for (const value of variants) {
       const fixture = await makeFixture();
-      if (value === null) await unlink(join(fixture.source, "config.yaml"));
-      else await write(fixture.source, "config.yaml", value);
+      await write(fixture.source, "config.yaml", value);
       const result = await migrate(fixture);
       expectRefused(result, "invalid-source-config", 4);
       expect(await exists(dirname(journalPath(fixture)))).toBe(false);
@@ -996,7 +1048,7 @@ describe("legacy home migration", () => {
     }
     const { fixture } = await cleanDoneFixture();
     await rm(fixture.source, { recursive: true });
-    expectRefused(await migrate(fixture), "legacy-mutated-after-cutover", 3);
+    expect(await migrate(fixture)).toMatchObject({ status: "done" });
   });
 
   it("post-preflight target race and verification failure are pinned", async () => {


### PR DESCRIPTION
Closes the second day-2 stop-loss. Ticket: `docs/issues/186`.

## The bug

The main process seeded `config/config.yaml` before starting the daemon. The legacy home migration targets that exact path, found the file the desktop had just written, treated it as a conflict, refused, and the process exited before creating a window.

**Every athlete upgrading from the published package got an app that never opened.** No window, no dialog, stderr discarded.

## The fix

Seeding stands down while a migration is still pending. The predicate reads the migration **journal state**, not merely whether a legacy config file exists — that file survives migration forever, so an existence check would disable the seeder permanently and leave a later-lost config unrecoverable.

Two migration states are also made terminal on relaunch:

- **`done`** no longer re-reads the legacy home. It could not keep doing so: `persistRuntimeConfig` legitimately rewrites the target config whenever onboarding saves a credential, so the old post-cutover check would have refused startup for *every* migrated athlete the first time they signed in. That turns a rare edge case into a universal one.
- **`verified`** is written as a separate durable journal write from `done`. A crash between the two leaves a migration that has already copied and byte-verified every payload — functionally complete — yet relaunch re-derived its plan from the legacy home and refused. That state was unrecoverable: `discard` is rejected outside planned/copying and `replan` is rejected whenever a journal exists, so there was no escape hatch. It now finishes instead.

A legacy home holding history but no config now migrates that history rather than refusing, without inventing a source config.

## What was deliberately removed

An auto-recovery path for machines already broken by the previous build was implemented, reviewed, and **deleted**. It unlinked the athlete's config, discarded the journal, then re-planned — with the re-plan call outside any refusal handler, so an ordinary planning refusal escaped as an unhandled rejection *after* the config was already gone. Destructive-then-crash is a worse failure than the bug it repairs. Tracked as `docs/issues/239`, which records the correct ordering: plan first, swap second, never destroy before the replacement is known valid.

Post-cutover drift detection is likewise gone, deliberately, for the reason given above. Tracked as `docs/issues/240` — the right answer is to surface divergence as recoverable state, not to refuse startup, and it depends on the error-surfacing work in #182/#190.

## Data safety

A review lens was spent solely on data destruction and returned a clean pass: every filesystem write reachable from this diff was enumerated and ordered, and no path can destroy or corrupt an upgrading athlete's history. The deferral branch performs zero writes — it strictly removes one and adds none.

## Tests

Fresh install; upgrade with a legacy config; upgrade with a legacy home but no config; idempotent relaunch; relaunch after completion with the legacy home mutated, and with it deleted; a journal interrupted at `verified` with the legacy home mutated, and with it deleted; a target config that goes missing post-migration is re-seeded.

`pnpm test` — 4624 passed, 3 skipped. `pnpm check` — clean.

One unrelated test flaked on the first run and did not reproduce across three subsequent full runs; this repo has two documented flakes. It touches none of the changed files.

## Scope

Silent-exit-with-no-dialog on a startup refusal is untouched — that belongs to `docs/issues/182` and `docs/issues/190`.
