### PR TITLE
fix(coach): stop a second athlete's account adopting the stored history

### DIFF
--- a/.changeset/account-bound-backfill.md
+++ b/.changeset/account-bound-backfill.md
@@ -1,0 +1,9 @@
+---
+"@enduragent/coach": patch
+"@enduragent/kernel": patch
+"cycling-coach": patch
+---
+
+User-facing: Cycling Coach now refuses to save an intervals.icu key for a different athlete than the training history already stored.
+
+Record one store-level owner fingerprint from the resolved intervals.icu athlete identifier at sync time, compare it read-only before credential saves, allow saves when the comparison is unavailable, and keep credential rotation independent from account ownership.

--- a/apps/desktop-renderer/src/global.d.ts
+++ b/apps/desktop-renderer/src/global.d.ts
@@ -69,7 +69,8 @@ type CredentialWriteResult =
         | "encryption-unavailable"
         | "unsafe-backend"
         | "storage-failed"
-        | "runtime-unavailable";
+        | "runtime-unavailable"
+        | "training-account-mismatch";
     };
 
 interface Window {

--- a/apps/desktop-renderer/src/onboarding/bridge.ts
+++ b/apps/desktop-renderer/src/onboarding/bridge.ts
@@ -24,7 +24,8 @@ export type CredentialWriteResult =
         | "encryption-unavailable"
         | "unsafe-backend"
         | "storage-failed"
-        | "runtime-unavailable";
+        | "runtime-unavailable"
+        | "training-account-mismatch";
     };
 
 export interface OnboardingBridge {

--- a/apps/desktop-renderer/src/onboarding/machine.ts
+++ b/apps/desktop-renderer/src/onboarding/machine.ts
@@ -38,6 +38,7 @@ export interface DesktopIntakeDraft {
 export type OnboardingErrorCode =
   | "credential-required"
   | "credential-save-failed"
+  | "training-account-mismatch"
   | "training-data-required"
   | "import-failed"
   | "intake-incomplete"

--- a/apps/desktop-renderer/src/onboarding/mount.ts
+++ b/apps/desktop-renderer/src/onboarding/mount.ts
@@ -74,6 +74,8 @@ export async function handoffCredential(
 const ERROR_COPY: Readonly<Record<OnboardingErrorCode, string>> = {
   "credential-required": "Sign in with ChatGPT or add at least one model key to continue.",
   "credential-save-failed": "That key could not be saved. Try entering it again.",
+  "training-account-mismatch":
+    "That intervals.icu key belongs to a different athlete than the training history already stored. Switching accounts is not supported yet.",
   "training-data-required": "Connect intervals.icu or import at least one ride file.",
   "import-failed": "Those ride files could not be imported. Try another selection.",
   "intake-incomplete": "Answer the required safety questions to continue.",
@@ -190,25 +192,32 @@ export function mountOnboarding(options: MountOnboardingOptions): OnboardingCont
   const savePasswordControls = async (
     root: HTMLElement,
     expectedVisit: number,
-  ): Promise<boolean> => {
+  ): Promise<OnboardingErrorCode | null> => {
     const controls = Array.from(
       root.querySelectorAll<HTMLInputElement>('input[type="password"][data-slot]'),
     );
     let attempted = false;
-    let failed = false;
+    let failure: OnboardingErrorCode | null = null;
     for (const input of controls) {
-      if (visit !== expectedVisit || scrim === undefined) return false;
+      if (visit !== expectedVisit || scrim === undefined) return null;
       try {
         if (input.value.trim().length === 0) continue;
         attempted = true;
         let configured = false;
         await handoffCredential(input, async (value) => {
           const result = await options.bridge.writeCredential(value);
-          configured = result.status === "configured";
+          if (result.status === "configured") {
+            configured = true;
+          } else {
+            failure =
+              result.reason === "training-account-mismatch"
+                ? "training-account-mismatch"
+                : (failure ?? "credential-save-failed");
+          }
         });
-        if (!configured) failed = true;
+        if (!configured) failure ??= "credential-save-failed";
       } catch {
-        failed = true;
+        failure ??= "credential-save-failed";
       } finally {
         input.value = "";
       }
@@ -217,10 +226,10 @@ export function mountOnboarding(options: MountOnboardingOptions): OnboardingCont
       try {
         await refreshStatuses(expectedVisit);
       } catch {
-        failed = true;
+        failure ??= "credential-save-failed";
       }
     }
-    return !failed;
+    return failure;
   };
 
   const importStatusCopy = (): string => {
@@ -612,10 +621,10 @@ export function mountOnboarding(options: MountOnboardingOptions): OnboardingCont
     for (const button of dialog.querySelectorAll<HTMLButtonElement>("button"))
       button.disabled = true;
     if (state.step === "coach-keys") {
-      const saved = await savePasswordControls(dialog, submitVisit);
+      const saveError = await savePasswordControls(dialog, submitVisit);
       if (visit !== submitVisit || scrim === undefined) return;
       state = withBusy(state, false);
-      if (!saved) state = withError(state, "credential-save-failed");
+      if (saveError !== null) state = withError(state, saveError);
       else if (!hasConfiguredModel(state)) state = withError(state, "credential-required");
       else state = nextStep(state);
       render();
@@ -623,10 +632,10 @@ export function mountOnboarding(options: MountOnboardingOptions): OnboardingCont
       return;
     }
     if (state.step === "training-data") {
-      const saved = await savePasswordControls(dialog, submitVisit);
+      const saveError = await savePasswordControls(dialog, submitVisit);
       if (visit !== submitVisit || scrim === undefined) return;
       state = withBusy(state, false);
-      if (!saved) state = withError(state, "credential-save-failed");
+      if (saveError !== null) state = withError(state, saveError);
       else if (!hasTrainingData(state)) state = withError(state, "training-data-required");
       else state = nextStep(state);
       render();

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -3,6 +3,7 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { connectCoachClient } from "@enduragent/coach-client";
 import type { ConfigureRuntimeRpcParams } from "@enduragent/coach-contract";
+import { checkIntervalsStoreOwnerAtPath } from "@enduragent/coach/backfill";
 import {
   app,
   BrowserWindow,
@@ -198,6 +199,17 @@ async function runDesktop(): Promise<void> {
             window: created,
             vault,
             chatGptAuth,
+            checkIntervalsCredentialOwner: (value) =>
+              checkIntervalsStoreOwnerAtPath(
+                join(resolveDesktopAthleteHome(environment), "store", "store.db"),
+                {
+                  apiKey: value,
+                  athleteId: "0",
+                  historyNewestDate: "1970-01-01",
+                  clock: { now: () => Date.now(), monotonicNow: () => performance.now() },
+                  signal: controller.signal,
+                },
+              ),
             isTrusted: (event) =>
               isTrustedConnectionRequest(event, mainWindow.current() ?? undefined),
           });

--- a/apps/desktop/src/main/onboarding-ipc.ts
+++ b/apps/desktop/src/main/onboarding-ipc.ts
@@ -32,6 +32,9 @@ interface RegisterOnboardingIpcOptions {
   readonly vault: CredentialVault;
   readonly chatGptAuth: ChatGptAuthController;
   readonly isTrusted: (event: IpcMainInvokeEvent) => boolean;
+  readonly checkIntervalsCredentialOwner: (
+    value: string,
+  ) => Promise<"unowned" | "matched" | "mismatch" | "unresolved" | "store-unavailable">;
 }
 
 const SUPPORTED_EXTENSIONS = new Set([".fit", ".tcx", ".gpx"]);
@@ -134,6 +137,18 @@ export function registerOnboardingIpc(options: RegisterOnboardingIpcOptions): ()
     if (args.length !== 1) throw new TypeError();
     const input = parseWriteInput(args[0]);
     try {
+      if (input.slot === "intervals-icu") {
+        const ownership = await options
+          .checkIntervalsCredentialOwner(input.value)
+          .catch(() => "check-unavailable" as const);
+        if (ownership === "mismatch") {
+          return {
+            slot: input.slot,
+            status: "refused",
+            reason: "training-account-mismatch",
+          };
+        }
+      }
       return minimizeWrite(await options.vault.writeCredential(input));
     } catch {
       return { slot: input.slot, status: "refused", reason: "storage-failed" };

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -28,6 +28,7 @@ const REASONS = new Set([
   "unsafe-backend",
   "storage-failed",
   "runtime-unavailable",
+  "training-account-mismatch",
 ]);
 const CHATGPT_REASONS = new Set([
   "already-in-progress",

--- a/apps/desktop/tests/credential-runtime.test.ts
+++ b/apps/desktop/tests/credential-runtime.test.ts
@@ -98,6 +98,9 @@ function fakeVault(initialRuntime: CredentialRuntimeApplication) {
 
 async function pollCredentialStatuses(vault: CredentialVault): Promise<void> {
   const handlers = new Map<string, (...args: unknown[]) => unknown>();
+  const checkIntervalsCredentialOwner: Parameters<
+    typeof registerOnboardingIpc
+  >[0]["checkIntervalsCredentialOwner"] = vi.fn(async () => "unresolved" as const);
   const dispose = registerOnboardingIpc({
     ipcMain: {
       handle: (channel: string, handler: (...args: unknown[]) => unknown) => {
@@ -115,9 +118,11 @@ async function pollCredentialStatuses(vault: CredentialVault): Promise<void> {
       login: async () => ({ status: "refused", reason: "cancelled" }),
     },
     isTrusted: () => true,
+    checkIntervalsCredentialOwner,
   });
   try {
     await handlers.get(DESKTOP_CREDENTIAL_STATUS_CHANNEL)!({});
+    expect(checkIntervalsCredentialOwner).not.toHaveBeenCalled();
   } finally {
     dispose();
   }

--- a/apps/desktop/tests/onboarding-ipc.test.ts
+++ b/apps/desktop/tests/onboarding-ipc.test.ts
@@ -13,8 +13,13 @@ import {
 import type { CredentialVault } from "../src/main/credential-vault.js";
 
 type Handler = (event: IpcMainInvokeEvent, ...args: unknown[]) => unknown;
+type OwnershipCheck = (
+  value: string,
+) => Promise<"unowned" | "matched" | "mismatch" | "unresolved" | "store-unavailable">;
 
-function harness() {
+function harness(
+  checkIntervalsCredentialOwner: OwnershipCheck = vi.fn(async () => "unresolved" as const),
+) {
   const handlers = new Map<string, Handler>();
   const ipcMain = {
     handle: vi.fn((channel: string, handler: Handler) => handlers.set(channel, handler)),
@@ -54,13 +59,77 @@ function harness() {
     vault,
     chatGptAuth,
     isTrusted: (event) => event === trustedEvent,
+    checkIntervalsCredentialOwner,
   });
   const invoke = (channel: string, event: IpcMainInvokeEvent, ...args: unknown[]) =>
     handlers.get(channel)!(event, ...args);
-  return { handlers, ipcMain, vault, chatGptAuth, dialog, trustedEvent, dispose, invoke };
+  return {
+    handlers,
+    ipcMain,
+    vault,
+    chatGptAuth,
+    dialog,
+    checkIntervalsCredentialOwner,
+    trustedEvent,
+    dispose,
+    invoke,
+  };
 }
 
 describe("desktop onboarding IPC", () => {
+  it("refuses an intervals.icu credential for a different training account", async () => {
+    const subject = harness(vi.fn(async () => "mismatch" as const));
+
+    await expect(
+      subject.invoke(DESKTOP_CREDENTIAL_WRITE_CHANNEL, subject.trustedEvent, {
+        slot: "intervals-icu",
+        value: "synthetic",
+      }),
+    ).resolves.toEqual({
+      slot: "intervals-icu",
+      status: "refused",
+      reason: "training-account-mismatch",
+    });
+    expect(subject.vault.writeCredential).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["the same training account", "matched"],
+    ["a readable ownerless store", "unowned"],
+    ["an unresolved identity", "unresolved"],
+    ["an unavailable store", "store-unavailable"],
+  ] as const)("saves an intervals.icu credential for %s", async (_case, outcome) => {
+    const subject = harness(vi.fn(async () => outcome));
+
+    await expect(
+      subject.invoke(DESKTOP_CREDENTIAL_WRITE_CHANNEL, subject.trustedEvent, {
+        slot: "intervals-icu",
+        value: "synthetic",
+      }),
+    ).resolves.toEqual({
+      slot: "intervals-icu",
+      status: "configured",
+      runtimeReady: true,
+    });
+    expect(subject.vault.writeCredential).toHaveBeenCalledOnce();
+  });
+
+  it("saves an intervals.icu credential when the convenience check fails", async () => {
+    const subject = harness(
+      vi.fn(async () => {
+        throw new Error("check unavailable");
+      }),
+    );
+
+    await expect(
+      subject.invoke(DESKTOP_CREDENTIAL_WRITE_CHANNEL, subject.trustedEvent, {
+        slot: "intervals-icu",
+        value: "synthetic",
+      }),
+    ).resolves.toMatchObject({ status: "configured" });
+    expect(subject.vault.writeCredential).toHaveBeenCalledOnce();
+  });
+
   it("maps each credential slot to the landed runtime request", () => {
     expect(runtimeConfigurationForCredential("anthropic", "synthetic")).toEqual({
       llm: { provider: "anthropic", model: "claude-sonnet-4-6", api_key: "synthetic" },

--- a/packages/coach/src/backfill.ts
+++ b/packages/coach/src/backfill.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { setTimeout as setTimeoutPromise } from "node:timers/promises";
 import {
   makeIntervalsHttpFactory,
@@ -15,6 +16,7 @@ import type { ImportArtifact, ImportReport, ImportReportDeps, PairDiagnostic, Pl
 import { createSyncStateRepository, dumpStore, type PhysicalRequestLedger, type SourceArtifactDraft, type SqlStore, type SyncBudget } from "@enduragent/kernel/store";
 import { createNodeImportRuntime, type NodeImportRuntime } from "@enduragent/kernel-node/ingest";
 import type { AthleteHome } from "@enduragent/kernel-node/home";
+import { openReadonlySqliteStorage } from "@enduragent/kernel-node/sqlite";
 import {
   createIntervalsIcuSource,
   REQUEST_ATTEMPTS,
@@ -30,6 +32,175 @@ export const DEFAULT_PER_REQUEST_TIMEOUT_MS = 30_000;
 export const DEFAULT_BACKFILL_PAGE_DEADLINE_MS = 21_600_000;
 
 export interface BackfillClock { now(): number; monotonicNow(): number; }
+
+export interface StoreOwnerCheckOptions {
+  readonly apiKey: string;
+  readonly athleteId: string;
+  readonly historyNewestDate: string;
+  readonly clock: BackfillClock;
+  readonly sleep?: (ms: number, signal: AbortSignal) => Promise<void>;
+  readonly signal?: AbortSignal;
+  readonly baseFetch?: typeof globalThis.fetch;
+  readonly budget?: SyncBudget;
+  readonly attemptLedger?: PhysicalRequestLedger;
+}
+
+export type StoreOwnerCheckResult =
+  | "unowned"
+  | "matched"
+  | "mismatch"
+  | "unresolved"
+  | "store-unavailable";
+
+const lookupArchiveResult: ArchiveWriteResult = Object.freeze({
+  address: "0".repeat(64),
+  relPath: "1970/01/lookup.json.gz",
+  deduped: true,
+});
+
+const lookupArchive: ArchiveManager = Object.freeze({
+  async writeArtifact() { return lookupArchiveResult; },
+  async writeSnapshot() { return lookupArchiveResult; },
+  async quarantine() { return lookupArchiveResult; },
+  async readArtifact() { throw new Error("lookup archive is write-only"); },
+  async readSnapshot() { throw new Error("lookup archive is write-only"); },
+  async has() { return false; },
+});
+
+const CLAIM_STORE_OWNER_SQL =
+  "INSERT INTO store_owner (singleton, account_fingerprint) VALUES (1, ?)";
+const STORE_OWNER_CHECK_BUSY_TIMEOUT_MS = 5_000;
+
+async function readStoreOwnerFingerprint(
+  store: Pick<SqlStore, "get">,
+): Promise<string | undefined> {
+  const current = await store.get(
+    "SELECT account_fingerprint FROM store_owner WHERE singleton = 1",
+  );
+  if (current === undefined) return undefined;
+  if (
+    Object.keys(current).join(",") !== "account_fingerprint" ||
+    typeof current.account_fingerprint !== "string" ||
+    !/^[0-9a-f]{64}$/.test(current.account_fingerprint)
+  ) {
+    throw new Error("invalid store owner row");
+  }
+  return current.account_fingerprint;
+}
+
+async function compareStoreOwner(
+  store: Pick<SqlStore, "get">,
+  accountFingerprint: string,
+): Promise<Extract<StoreOwnerCheckResult, "unowned" | "matched" | "mismatch">> {
+  if (!/^[0-9a-f]{64}$/.test(accountFingerprint)) {
+    throw new TypeError("invalid store owner fingerprint");
+  }
+  const current = await readStoreOwnerFingerprint(store);
+  if (current === undefined) return "unowned";
+  return current === accountFingerprint ? "matched" : "mismatch";
+}
+
+export async function resolveIntervalsStoreOwnerFingerprint(
+  options: StoreOwnerCheckOptions,
+): Promise<string | null> {
+  const controller = new AbortController();
+  const budget = options.budget ?? {
+    signal: options.signal ?? controller.signal,
+    clock: { monotonicNow: () => options.clock.monotonicNow() },
+    deadlineMonotonicMs: options.clock.monotonicNow() + 300_000,
+    perRequestTimeoutMs: DEFAULT_PER_REQUEST_TIMEOUT_MS,
+    maxRequests: REQUEST_ATTEMPTS,
+    maxArtifacts: 1_000,
+  };
+  const source = createIntervalsBackfillSource({
+    apiKey: options.apiKey,
+    athleteId: options.athleteId,
+    historyNewestDate: options.historyNewestDate,
+    minRequestIntervalMs: DEFAULT_REQUEST_INTERVAL_MS,
+    archive: lookupArchive,
+    clock: options.clock,
+    sleep: options.sleep ?? sleepAbortably,
+    ...(options.baseFetch === undefined ? {} : { baseFetch: options.baseFetch }),
+    ...(options.attemptLedger === undefined ? {} : { attemptLedger: options.attemptLedger }),
+  });
+  const resolved = new Set<string>();
+  for await (const artifact of source.pull(
+    { source: "intervals-icu", lane: "settings", value: null },
+    budget,
+  )) {
+    if (artifact.kind !== "snapshot" || artifact.lane !== "settings") continue;
+    const payload = artifact.payload;
+    if (payload === null || typeof payload !== "object" || Array.isArray(payload)) return null;
+    const value = (payload as Record<string, unknown>).athlete_id;
+    if (typeof value !== "string" || value.length === 0) return null;
+    resolved.add(value);
+  }
+  if (resolved.size !== 1) return null;
+  return createHash("sha256")
+    .update(JSON.stringify(["store-owner-v1", [...resolved][0]]))
+    .digest("hex");
+}
+
+async function enforceIntervalsStoreOwner(
+  store: SqlStore,
+  options: StoreOwnerCheckOptions,
+  resolveFingerprint: (
+    options: StoreOwnerCheckOptions,
+  ) => Promise<string | null> = resolveIntervalsStoreOwnerFingerprint,
+): Promise<"adopted" | "matched" | "unresolved"> {
+  let fingerprint: string | null;
+  try {
+    fingerprint = await resolveFingerprint(options);
+  } catch {
+    return "unresolved";
+  }
+  if (fingerprint === null) return "unresolved";
+  const ownership = await compareStoreOwner(store, fingerprint);
+  if (ownership === "mismatch") throw new Error("training account mismatch");
+  if (ownership === "matched") return "matched";
+  await store.run(CLAIM_STORE_OWNER_SQL, [fingerprint]);
+  return "adopted";
+}
+
+export async function checkIntervalsStoreOwnerAtPath(
+  storePath: string,
+  options: StoreOwnerCheckOptions,
+): Promise<StoreOwnerCheckResult> {
+  let store: ReturnType<typeof openReadonlySqliteStorage> | undefined;
+  try {
+    store = openReadonlySqliteStorage(storePath);
+    const timeout = await store.get(`PRAGMA busy_timeout = ${STORE_OWNER_CHECK_BUSY_TIMEOUT_MS}`);
+    if (timeout?.timeout !== STORE_OWNER_CHECK_BUSY_TIMEOUT_MS) {
+      throw new Error("store owner check timeout unavailable");
+    }
+    if ((await readStoreOwnerFingerprint(store)) === undefined) {
+      await store.close();
+      return "unowned";
+    }
+  } catch {
+    await store?.close().catch(() => undefined);
+    return "store-unavailable";
+  }
+  let fingerprint: string | null;
+  try {
+    fingerprint = await resolveIntervalsStoreOwnerFingerprint(options);
+  } catch {
+    await store.close().catch(() => undefined);
+    return "unresolved";
+  }
+  if (fingerprint === null) {
+    await store.close().catch(() => undefined);
+    return "unresolved";
+  }
+  try {
+    const ownership = await compareStoreOwner(store, fingerprint);
+    await store.close();
+    return ownership;
+  } catch {
+    await store?.close().catch(() => undefined);
+    return "store-unavailable";
+  }
+}
 
 export function createIntervalsBackfillSource(options: {
   readonly apiKey: string;
@@ -282,11 +453,20 @@ const productionClock: BackfillClock = Object.freeze({ now: () => Date.now(), mo
 const sleepAbortably = (ms: number, signal: AbortSignal): Promise<void> =>
   setTimeoutPromise(ms, undefined, { signal }).then(() => undefined);
 
-export function runIntervalsBackfillInWriter(
+export async function runIntervalsBackfillInWriter(
   options: RunIntervalsBackfillInWriterOptions,
 ): Promise<BackfillRunResult> {
   const requestIntervalMs = configured(options.requestIntervalMs, DEFAULT_REQUEST_INTERVAL_MS, 250, 60_000, "request interval");
   const clock = options.clock ?? productionClock, sleep = options.sleep ?? sleepAbortably;
+  await enforceIntervalsStoreOwner(options.store, {
+    apiKey: options.apiKey,
+    athleteId: options.athleteId,
+    historyNewestDate: options.historyNewestDate,
+    clock,
+    sleep,
+    ...(options.signal === undefined ? {} : { signal: options.signal }),
+    ...(options.baseFetch === undefined ? {} : { baseFetch: options.baseFetch }),
+  });
   const node = createNodeImportRuntime({ archiveDir: options.home.archiveDir, store: options.store });
   const source = createIntervalsBackfillSource({ apiKey: options.apiKey, athleteId: options.athleteId,
     historyNewestDate: options.historyNewestDate, minRequestIntervalMs: requestIntervalMs, archive: node.archive,

--- a/packages/coach/tests/backfill.test.ts
+++ b/packages/coach/tests/backfill.test.ts
@@ -1,9 +1,10 @@
-import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   createSyncStateRepository,
+  dumpStore,
   runMigrations,
   type SourceArtifact,
 } from "@enduragent/kernel/store";
@@ -13,6 +14,7 @@ import { openSqliteStorage } from "@enduragent/kernel-node/sqlite";
 import type { IntervalsIcuSource } from "@enduragent/sync-intervals-icu";
 import type { AthleteHome } from "@enduragent/kernel-node/home";
 import {
+  checkIntervalsStoreOwnerAtPath,
   createIntervalsBackfillSource,
   runBackfillPages,
   runIntervalsBackfill,
@@ -82,6 +84,74 @@ describe("incremental backfill pages", () => {
         return pulls(watermark.value, call++);
       },
     } as IntervalsIcuSource;
+  }
+
+  function profileFetch(account: string): typeof globalThis.fetch {
+    return vi.fn(async (input) => {
+      const url = new URL(input instanceof Request ? input.url : input.toString());
+      let body: unknown;
+      if (url.pathname === "/api/v1/athlete/0") {
+        body = {
+          sportSettings: [
+            { id: 1, athlete_id: account, types: ["Ride"], updated: "2010-01-01" },
+          ],
+        };
+      } else if (url.pathname.endsWith("/activities")) {
+        body = [];
+      } else {
+        throw new Error("unexpected request");
+      }
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+  }
+
+  function unresolvedProfileFetch(): typeof globalThis.fetch {
+    return vi.fn(async () =>
+      new Response(JSON.stringify({ sportSettings: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+  }
+
+  function athleteHome(root: string, storeDir = root): AthleteHome {
+    return {
+      root,
+      storeDir,
+      archiveDir: join(root, "archive"),
+      configDir: join(root, "config"),
+    };
+  }
+
+  async function syncInWriter(
+    value: Awaited<ReturnType<typeof fresh>>,
+    account: string,
+    apiKey = "synthetic",
+  ) {
+    const baseFetch = profileFetch(account);
+    const result = await runIntervalsBackfillInWriter({
+      home: athleteHome(value.root),
+      store: value.store,
+      apiKey,
+      athleteId: "0",
+      historyNewestDate: "1900-12-31",
+      clock,
+      sleep: async () => {},
+      baseFetch,
+    });
+    return { baseFetch, result };
+  }
+
+  async function storedSyncState(store: Awaited<ReturnType<typeof fresh>>["store"]) {
+    return {
+      dump: await dumpStore(store),
+      owner: await store.all("SELECT * FROM store_owner"),
+      watermarks: await store.all("SELECT * FROM source_watermark"),
+      operations: await store.all("SELECT * FROM sync_operation"),
+    };
   }
 
   it("commits each page checkpoint atomically and finishes with one terminal no-op", async () => {
@@ -312,6 +382,229 @@ describe("incremental backfill pages", () => {
     }
   });
 
+  it("claims the owner when the first sync creates the store and detects a different credential afterward", async () => {
+    const root = mkdtempSync(join(realpathSync(tmpdir()), "backfill-first-sync-"));
+    roots.push(root);
+    const storePath = join(root, "store", "store.db");
+    const firstFetch = profileFetch("synthetic-athlete-first");
+    expect(existsSync(storePath)).toBe(false);
+
+    await runIntervalsBackfill({
+      env: { ENDURAGENT_HOME: root },
+      apiKey: "synthetic-first",
+      athleteId: "0",
+      historyNewestDate: "1900-12-31",
+      clock,
+      sleep: async () => {},
+      baseFetch: firstFetch,
+    });
+
+    expect(existsSync(storePath)).toBe(true);
+    const store = openSqliteStorage(storePath);
+    try {
+      expect(await store.get("SELECT count(*) AS count FROM store_owner")).toEqual({ count: 1 });
+    } finally {
+      await store.close();
+    }
+    expect(firstFetch).toHaveBeenCalledTimes(2);
+    const mismatchFetch = profileFetch("synthetic-athlete-other");
+    await expect(
+      checkIntervalsStoreOwnerAtPath(storePath, {
+        apiKey: "synthetic-other",
+        athleteId: "0",
+        historyNewestDate: "1900-12-31",
+        clock,
+        sleep: async () => {},
+        baseFetch: mismatchFetch,
+      }),
+    ).resolves.toBe("mismatch");
+    expect(mismatchFetch).toHaveBeenCalledOnce();
+  });
+
+  it("claims an upgraded store without re-walking or changing its existing history", async () => {
+    const root = mkdtempSync(join(realpathSync(tmpdir()), "backfill-upgrade-"));
+    roots.push(root);
+    const home = athleteHome(root, join(root, "store"));
+    mkdirSync(home.storeDir, { recursive: true, mode: 0o700 });
+    const storePath = join(home.storeDir, "store.db");
+    const legacy = openSqliteStorage(storePath);
+    await runMigrations(legacy, MIGRATIONS.slice(0, 7));
+    await legacy.run(
+      "INSERT INTO workout(workout_key,start_utc,is_multisport,dedup_cluster_id) VALUES(?,?,0,?)",
+      ["synthetic-workout", 1_262_304_000, "synthetic-cluster"],
+    );
+    await legacy.run(
+      "INSERT INTO session(session_key,workout_key,session_seq,sport,start_utc,local_date_key,is_transition) VALUES(?,?,0,?,?,?,0)",
+      ["synthetic-session", "synthetic-workout", "cycling", 1_262_304_000, 20100101],
+    );
+    await legacy.transaction(async () => {
+      await createSyncStateRepository(legacy).recordCompletionInTransaction({
+        source: "intervals-icu",
+        lane: "bulk-fit",
+        watermarkBefore: null,
+        watermarkAfter: complete,
+        artifactsSeen: 0,
+        sourceChanges: 0,
+      });
+    });
+    const before = await dumpStore(legacy);
+    await legacy.close();
+    const baseFetch = profileFetch("synthetic-athlete-upgrade");
+
+    await runIntervalsBackfill({
+      env: { ENDURAGENT_HOME: root },
+      apiKey: "synthetic-upgrade",
+      athleteId: "0",
+      historyNewestDate: "2010-12-31",
+      clock,
+      sleep: async () => {},
+      baseFetch,
+    });
+
+    expect(baseFetch).toHaveBeenCalledOnce();
+    const upgraded = openSqliteStorage(storePath);
+    try {
+      expect(await upgraded.get("PRAGMA user_version")).toEqual({ user_version: 8 });
+      expect(await upgraded.get("SELECT count(*) AS count FROM store_owner")).toEqual({ count: 1 });
+      expect(await dumpStore(upgraded)).toBe(before);
+    } finally {
+      await upgraded.close();
+    }
+    await expect(
+      checkIntervalsStoreOwnerAtPath(storePath, {
+        apiKey: "synthetic-other",
+        athleteId: "0",
+        historyNewestDate: "2010-12-31",
+        clock,
+        sleep: async () => {},
+        baseFetch: profileFetch("synthetic-athlete-other"),
+      }),
+    ).resolves.toBe("mismatch");
+  });
+
+  it("refuses a different athlete before writing any sync state or training data", async () => {
+    const value = await fresh();
+    try {
+      await syncInWriter(value, "synthetic-athlete-owner", "synthetic-owner");
+      const before = await storedSyncState(value.store);
+
+      await expect(
+        syncInWriter(value, "synthetic-athlete-other", "synthetic-other"),
+      ).rejects.toThrow("training account mismatch");
+
+      expect(await storedSyncState(value.store)).toEqual(before);
+    } finally {
+      await value.store.close();
+    }
+  });
+
+  it("syncs the same athlete normally without re-walking completed history", async () => {
+    const value = await fresh();
+    try {
+      const first = await syncInWriter(value, "synthetic-athlete-owner");
+      const repeat = await syncInWriter(value, "synthetic-athlete-owner");
+
+      expect(repeat.result).toMatchObject({ pages: 2, artifacts: 0, reports: [] });
+      expect(first.baseFetch).toHaveBeenCalledTimes(2);
+      expect(repeat.baseFetch).toHaveBeenCalledOnce();
+      expect(await value.store.get("SELECT count(*) AS count FROM store_owner")).toEqual({
+        count: 1,
+      });
+    } finally {
+      await value.store.close();
+    }
+  });
+
+  it("keeps an ownerless store unclaimed during the save-time convenience check", async () => {
+    const value = await fresh();
+    const storePath = join(value.root, "store.db");
+    await value.store.close();
+    const baseFetch = profileFetch("synthetic-athlete-ownerless");
+
+    await expect(
+      checkIntervalsStoreOwnerAtPath(storePath, {
+        apiKey: "synthetic-ownerless",
+        athleteId: "0",
+        historyNewestDate: "1900-12-31",
+        clock,
+        sleep: async () => {},
+        baseFetch,
+      }),
+    ).resolves.toBe("unowned");
+    expect(baseFetch).not.toHaveBeenCalled();
+
+    const reopened = openSqliteStorage(storePath);
+    try {
+      expect(await reopened.get("SELECT count(*) AS count FROM store_owner")).toEqual({ count: 0 });
+    } finally {
+      await reopened.close();
+    }
+  });
+
+  it("skips identity resolution when the save-time store is unavailable", async () => {
+    const root = mkdtempSync(join(realpathSync(tmpdir()), "backfill-save-check-"));
+    roots.push(root);
+    const storePath = join(root, "missing", "store.db");
+    const baseFetch = profileFetch("synthetic-athlete-resolved");
+
+    await expect(
+      checkIntervalsStoreOwnerAtPath(storePath, {
+        apiKey: "synthetic-resolved",
+        athleteId: "0",
+        historyNewestDate: "1900-12-31",
+        clock,
+        sleep: async () => {},
+        baseFetch,
+      }),
+    ).resolves.toBe("store-unavailable");
+    expect(baseFetch).not.toHaveBeenCalled();
+  });
+
+  it("allows save when an owned store identity cannot be resolved", async () => {
+    const value = await fresh();
+    try {
+      await syncInWriter(value, "synthetic-athlete-owner");
+      const baseFetch = unresolvedProfileFetch();
+      await expect(
+        checkIntervalsStoreOwnerAtPath(join(value.root, "store.db"), {
+          apiKey: "synthetic-unresolved",
+          athleteId: "0",
+          historyNewestDate: "1900-12-31",
+          clock,
+          sleep: async () => {},
+          baseFetch,
+        }),
+      ).resolves.toBe("unresolved");
+      expect(baseFetch).toHaveBeenCalledOnce();
+    } finally {
+      await value.store.close();
+    }
+  });
+
+  it("accepts a rotated credential for the same athlete at save time and sync time", async () => {
+    const value = await fresh();
+    try {
+      await syncInWriter(value, "synthetic-athlete-owner", "synthetic-old");
+      const saveFetch = profileFetch("synthetic-athlete-owner");
+      await expect(
+        checkIntervalsStoreOwnerAtPath(join(value.root, "store.db"), {
+          apiKey: "synthetic-new",
+          athleteId: "0",
+          historyNewestDate: "1900-12-31",
+          clock,
+          sleep: async () => {},
+          baseFetch: saveFetch,
+        }),
+      ).resolves.toBe("matched");
+      const sync = await syncInWriter(value, "synthetic-athlete-owner", "synthetic-new");
+      expect(sync.result).toMatchObject({ pages: 2, artifacts: 0 });
+      expect(saveFetch).toHaveBeenCalledOnce();
+      expect(sync.baseFetch).toHaveBeenCalledOnce();
+    } finally {
+      await value.store.close();
+    }
+  });
+
   it("keeps the public writer wrapper equivalent to the supplied-writer entry", async () => {
     const makeHome = async (): Promise<{
       home: AthleteHome;
@@ -344,9 +637,7 @@ describe("incremental backfill pages", () => {
     const wrapped = await makeHome();
     const directPages: unknown[] = [];
     const wrappedPages: unknown[] = [];
-    const baseFetch = vi.fn(async () => {
-      throw new Error("completed watermark performed a request");
-    });
+    const baseFetch = profileFetch("synthetic-athlete");
     const close = vi.spyOn(direct.store, "close");
     try {
       const directResult = await runIntervalsBackfillInWriter({
@@ -374,7 +665,7 @@ describe("incremental backfill pages", () => {
       expect(wrappedResult).toEqual(directResult);
       expect(wrappedPages).toEqual(directPages);
       expect(directResult).toMatchObject({ pages: 2, artifacts: 0, reports: [] });
-      expect(baseFetch).not.toHaveBeenCalled();
+      expect(baseFetch).toHaveBeenCalledTimes(2);
       expect(close).not.toHaveBeenCalled();
       await expect(
         direct.store.get("SELECT count(*) AS count FROM source_watermark"),

--- a/packages/coach/tests/backfill.test.ts
+++ b/packages/coach/tests/backfill.test.ts
@@ -34,6 +34,10 @@ const complete = JSON.stringify({
 const clock = { now: () => 1_300_000_000_000, monotonicNow: () => 1_000 };
 
 describe("incremental backfill pages", () => {
+  type BackfillRequest = Readonly<{
+    endpoint: "profile" | "activities";
+    url: URL;
+  }>;
   const roots: string[] = [];
   afterEach(() => {
     for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
@@ -86,17 +90,24 @@ describe("incremental backfill pages", () => {
     } as IntervalsIcuSource;
   }
 
-  function profileFetch(account: string): typeof globalThis.fetch {
+  function profileFetch(
+    account: string,
+    requests: BackfillRequest[] = [],
+    athleteId = "0",
+  ): typeof globalThis.fetch {
     return vi.fn(async (input) => {
       const url = new URL(input instanceof Request ? input.url : input.toString());
+      const profilePath = `/api/v1/athlete/${encodeURIComponent(athleteId)}`;
       let body: unknown;
-      if (url.pathname === "/api/v1/athlete/0") {
+      if (url.pathname === profilePath) {
+        requests.push({ endpoint: "profile", url });
         body = {
           sportSettings: [
             { id: 1, athlete_id: account, types: ["Ride"], updated: "2010-01-01" },
           ],
         };
-      } else if (url.pathname.endsWith("/activities")) {
+      } else if (url.pathname === `${profilePath}/activities`) {
+        requests.push({ endpoint: "activities", url });
         body = [];
       } else {
         throw new Error("unexpected request");
@@ -108,13 +119,24 @@ describe("incremental backfill pages", () => {
     });
   }
 
-  function unresolvedProfileFetch(): typeof globalThis.fetch {
-    return vi.fn(async () =>
-      new Response(JSON.stringify({ sportSettings: [] }), {
+  function unresolvedProfileFetch(requests: BackfillRequest[] = []): typeof globalThis.fetch {
+    return vi.fn(async (input) => {
+      const url = new URL(input instanceof Request ? input.url : input.toString());
+      let body: unknown;
+      if (url.pathname === "/api/v1/athlete/0") {
+        requests.push({ endpoint: "profile", url });
+        body = { sportSettings: [] };
+      } else if (url.pathname === "/api/v1/athlete/0/activities") {
+        requests.push({ endpoint: "activities", url });
+        body = [];
+      } else {
+        throw new Error("unexpected request");
+      }
+      return new Response(JSON.stringify(body), {
         status: 200,
         headers: { "content-type": "application/json" },
-      }),
-    );
+      });
+    });
   }
 
   function athleteHome(root: string, storeDir = root): AthleteHome {
@@ -136,6 +158,24 @@ describe("incremental backfill pages", () => {
       home: athleteHome(value.root),
       store: value.store,
       apiKey,
+      athleteId: "0",
+      historyNewestDate: "1900-12-31",
+      clock,
+      sleep: async () => {},
+      baseFetch,
+    });
+    return { baseFetch, result };
+  }
+
+  async function syncInWriterWithFetch(
+    value: Awaited<ReturnType<typeof fresh>>,
+    accountKey: string,
+    baseFetch: typeof globalThis.fetch,
+  ) {
+    const result = await runIntervalsBackfillInWriter({
+      home: athleteHome(value.root),
+      store: value.store,
+      apiKey: accountKey,
       athleteId: "0",
       historyNewestDate: "1900-12-31",
       clock,
@@ -317,11 +357,12 @@ describe("incremental backfill pages", () => {
       listener: {} as CoachStoreWriterContext["listener"],
     };
     let now = Date.UTC(1900, 0, 1);
-    const requests: string[] = [];
-    const baseFetch: typeof globalThis.fetch = vi.fn(async (input) => {
-      requests.push(input instanceof Request ? input.url : input.toString());
-      return new Response("[]", { status: 200, headers: { "content-type": "application/json" } });
-    });
+    const requests: BackfillRequest[] = [];
+    const baseFetch = profileFetch(
+      "synthetic-rollover-account",
+      requests,
+      "synthetic-athlete",
+    );
     const rollingClock = { now: () => now, monotonicNow: () => 1_000 };
     const operations = createCoachOperations(
       {
@@ -371,12 +412,36 @@ describe("incremental backfill pages", () => {
         value: JSON.stringify({ v: 1, cycle: 0, window_start: "1900-01-01", window_end: "1900-01-01",
           last_key: null, complete: true }),
       });
+      const ownerAfterFirstSync = await value.store.all("SELECT * FROM store_owner");
+      expect(ownerAfterFirstSync).toHaveLength(1);
       now = Date.UTC(1900, 0, 2);
       await expect(operations.sync({})).resolves.toMatchObject({ schemaVersion: 1 });
 
-      expect(requests).toHaveLength(2);
-      const reopened = new URL(requests[1]!);
-      expect([...reopened.searchParams]).toEqual([["oldest", "1900-01-01"], ["newest", "1900-01-02"]]);
+      expect(requests.map(({ endpoint }) => endpoint)).toEqual([
+        "profile",
+        "activities",
+        "profile",
+        "activities",
+      ]);
+      const profileRequests = requests.filter(({ endpoint }) => endpoint === "profile");
+      const activityRequests = requests.filter(({ endpoint }) => endpoint === "activities");
+      expect(profileRequests).toHaveLength(2);
+      expect(activityRequests).toHaveLength(2);
+      expect([...activityRequests[0]!.url.searchParams]).toEqual([
+        ["oldest", "1900-01-01"],
+        ["newest", "1900-01-01"],
+      ]);
+      expect([...activityRequests[1]!.url.searchParams]).toEqual([
+        ["oldest", "1900-01-01"],
+        ["newest", "1900-01-02"],
+      ]);
+      expect(await value.store.all("SELECT * FROM store_owner")).toEqual(ownerAfterFirstSync);
+      await expect(createSyncStateRepository(value.store).readWatermark("intervals-icu", "bulk-fit")).resolves.toEqual({
+        source: "intervals-icu",
+        lane: "bulk-fit",
+        value: JSON.stringify({ v: 1, cycle: 1, window_start: "1900-01-01", window_end: "1900-01-02",
+          last_key: null, complete: true }),
+      });
     } finally {
       await value.store.close();
     }
@@ -487,12 +552,33 @@ describe("incremental backfill pages", () => {
     try {
       await syncInWriter(value, "synthetic-athlete-owner", "synthetic-owner");
       const before = await storedSyncState(value.store);
+      const mismatchRequests: BackfillRequest[] = [];
+      const mismatchFetch = profileFetch("synthetic-athlete-other", mismatchRequests);
 
       await expect(
-        syncInWriter(value, "synthetic-athlete-other", "synthetic-other"),
+        syncInWriterWithFetch(value, "synthetic-other", mismatchFetch),
       ).rejects.toThrow("training account mismatch");
 
+      expect(mismatchRequests.filter(({ endpoint }) => endpoint === "profile")).toHaveLength(1);
+      expect(mismatchRequests.filter(({ endpoint }) => endpoint === "activities")).toHaveLength(0);
       expect(await storedSyncState(value.store)).toEqual(before);
+    } finally {
+      await value.store.close();
+    }
+  });
+
+  it("continues sync when profile sport settings cannot resolve an owner", async () => {
+    const value = await fresh();
+    const requests: BackfillRequest[] = [];
+    const baseFetch = unresolvedProfileFetch(requests);
+    try {
+      const sync = await syncInWriterWithFetch(value, "synthetic-unresolved", baseFetch);
+
+      expect(sync.result).toMatchObject({ pages: 2, artifacts: 0, reports: [] });
+      expect(requests.map(({ endpoint }) => endpoint)).toEqual(["profile", "activities"]);
+      expect(await value.store.get("SELECT count(*) AS count FROM store_owner")).toEqual({
+        count: 0,
+      });
     } finally {
       await value.store.close();
     }

--- a/packages/coach/tests/coach-sync.test.ts
+++ b/packages/coach/tests/coach-sync.test.ts
@@ -582,7 +582,7 @@ describe("coach sync composition", () => {
           return store.get("PRAGMA user_version");
         },
       );
-      expect(value).toEqual({ user_version: 7 });
+      expect(value).toEqual({ user_version: 8 });
       expect(await pathExists(join(home.storeDir, "store.db"))).toBe(true);
       expect(await pathExists(join(home.configDir, LOCKFILE_NAME))).toBe(false);
       expect(await pathExists(join(home.configDir, PORT_FILE_NAME))).toBe(false);
@@ -590,7 +590,7 @@ describe("coach sync composition", () => {
       const reopened = openSqliteStorage(join(home.storeDir, "store.db"));
       try {
         await expect(reopened.get("PRAGMA user_version")).resolves.toEqual({
-          user_version: 7,
+          user_version: 8,
         });
       } finally {
         await reopened.close();

--- a/packages/kernel-node/tests/coach-dev-import.test.ts
+++ b/packages/kernel-node/tests/coach-dev-import.test.ts
@@ -528,7 +528,7 @@ describe("coach-dev import --report", () => {
     expect(await exists(databasePath)).toBe(true);
     const store = openSqliteStorage(databasePath);
     try {
-      expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 7 });
+      expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 8 });
       expect(await store.get("SELECT count(*) AS c FROM raw_file")).toEqual({ c: 1 });
       expect(await store.get("SELECT count(*) AS c FROM source_record")).toEqual({ c: 0 });
       expect(

--- a/packages/kernel-node/tests/migrator-e2e.test.ts
+++ b/packages/kernel-node/tests/migrator-e2e.test.ts
@@ -31,9 +31,9 @@ describe("migrator end-to-end over node:sqlite", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
-  it("applies the full migration list and advances user_version to 7", async () => {
+  it("applies the full migration list and advances user_version to 8", async () => {
     await runMigrations(store, MIGRATIONS);
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 7 });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 8 });
 
     const tables = await store.all("SELECT name FROM sqlite_master WHERE type='table'");
     const names = new Set(tables.map((r) => r.name as string));
@@ -53,7 +53,7 @@ describe("migrator end-to-end over node:sqlite", () => {
     expect(await store.get("PRAGMA journal_mode")).toEqual({ journal_mode: "wal" });
     expect(await store.get("PRAGMA foreign_keys")).toEqual({ foreign_keys: 1 });
     await runMigrations(store, MIGRATIONS);
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 7 });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 8 });
   });
 
   it("produces a deterministic INV-2 dump of a fixed state", async () => {
@@ -82,11 +82,11 @@ describe("migrator end-to-end over node:sqlite", () => {
     expect(await dumpStore(store)).toBe(dump);
   });
 
-  it("upgrades a version-1-on-disk store to version 7", async () => {
+  it("upgrades a version-1-on-disk store to version 8", async () => {
     await runMigrations(store, [MIGRATIONS[0]!]);
     expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 1 });
     await runMigrations(store, MIGRATIONS);
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 7 });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 8 });
     expect(await store.get("SELECT singleton,ingest_version FROM ingest_metadata")).toEqual({
       singleton: 1,
       ingest_version: 0,
@@ -106,8 +106,8 @@ describe("migrator end-to-end over node:sqlite", () => {
     );
 
     const result = await runMigrations(store, MIGRATIONS);
-    expect(result).toEqual({ fromVersion: 4, toVersion: 7, applied: [5, 6, 7] });
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 7 });
+    expect(result).toEqual({ fromVersion: 4, toVersion: 8, applied: [5, 6, 7, 8] });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 8 });
     expect(
       await store.get("SELECT revision_id,source_record_id FROM source_record_revision"),
     ).toEqual({
@@ -154,20 +154,34 @@ describe("migrator end-to-end over node:sqlite", () => {
     ).toBeUndefined();
   });
 
-  it("upgrades a version-6 store to version 7 and reruns as a no-op", async () => {
+  it("upgrades a version-6 store through the current schema and reruns as a no-op", async () => {
     await runMigrations(store, MIGRATIONS.slice(0, 6));
     expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 6 });
     const result = await runMigrations(store, MIGRATIONS);
-    expect(result).toEqual({ fromVersion: 6, toVersion: 7, applied: [7] });
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 7 });
+    expect(result).toEqual({ fromVersion: 6, toVersion: 8, applied: [7, 8] });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 8 });
     expect(
       await store.get("SELECT name FROM sqlite_master WHERE type='table' AND name='sync_failure'"),
     ).toEqual({ name: "sync_failure" });
     await expect(runMigrations(store, MIGRATIONS)).resolves.toEqual({
-      fromVersion: 7,
-      toVersion: 7,
+      fromVersion: 8,
+      toVersion: 8,
       applied: [],
     });
+  });
+
+  it("preserves an existing cursor and leaves its store owner unset", async () => {
+    await runMigrations(store, MIGRATIONS.slice(0, 7));
+    await store.run(
+      "INSERT INTO source_watermark(source,lane,watermark) VALUES(?,?,?)",
+      ["intervals-icu", "bulk-fit", "legacy-cursor"],
+    );
+
+    await runMigrations(store, MIGRATIONS);
+
+    expect(await store.get("SELECT watermark FROM source_watermark"))
+      .toEqual({ watermark: "legacy-cursor" });
+    expect(await store.get("SELECT count(*) AS count FROM store_owner")).toEqual({ count: 0 });
   });
 
   it("shares one real transaction for exec + version bump (atomic rollback)", async () => {

--- a/packages/kernel-node/tests/sync-failure-repository.test.ts
+++ b/packages/kernel-node/tests/sync-failure-repository.test.ts
@@ -237,7 +237,7 @@ describe("sync failure repository", () => {
     const before = await dumpStore(store);
     await runMigrations(store, MIGRATIONS);
     expect(await dumpStore(store)).toBe(before);
-    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 7 });
+    expect(await store.get("PRAGMA user_version")).toEqual({ user_version: 8 });
     expect(DUMP_TABLES).toHaveLength(32);
     expect(DERIVED_TABLES).toHaveLength(12);
     expect(DUMP_TABLES.map(({ table }) => table)).not.toContain("sync_failure");

--- a/packages/kernel/src/store/migrations/008_store_owner.sql
+++ b/packages/kernel/src/store/migrations/008_store_owner.sql
@@ -1,0 +1,22 @@
+CREATE TABLE store_owner (
+  singleton INTEGER PRIMARY KEY
+    CHECK (singleton = 1),
+  account_fingerprint TEXT NOT NULL
+    CHECK (
+      length(account_fingerprint) = 64
+      AND account_fingerprint = lower(account_fingerprint)
+      AND account_fingerprint NOT GLOB '*[^0-9a-f]*'
+    )
+) STRICT;
+
+CREATE TRIGGER store_owner_no_update
+BEFORE UPDATE ON store_owner
+BEGIN
+  SELECT RAISE(ABORT, 'store owner is immutable');
+END;
+
+CREATE TRIGGER store_owner_no_delete
+BEFORE DELETE ON store_owner
+BEGIN
+  SELECT RAISE(ABORT, 'store owner is immutable');
+END;

--- a/packages/kernel/src/store/migrations/index.ts
+++ b/packages/kernel/src/store/migrations/index.ts
@@ -5,6 +5,7 @@ import fixerSettings004 from "./004_repair_fixer_settings.sql";
 import syncState005 from "./005_sync_state.sql";
 import incremental006 from "./006_incremental_ingest.sql";
 import syncFailure007 from "./007_sync_failure.sql";
+import storeOwner008 from "./008_store_owner.sql";
 
 export interface Migration {
   /** Ascending schema version this migration advances the store to. */
@@ -27,4 +28,5 @@ export const MIGRATIONS: readonly Migration[] = [
   { version: 5, name: "005_sync_state", sql: syncState005 },
   { version: 6, name: "006_incremental_ingest", sql: incremental006 },
   { version: 7, name: "007_sync_failure", sql: syncFailure007 },
+  { version: 8, name: "008_store_owner", sql: storeOwner008 },
 ];

--- a/packages/kernel/tests/migrations-ddl.test.ts
+++ b/packages/kernel/tests/migrations-ddl.test.ts
@@ -44,6 +44,7 @@ const EXPECTED_FULL_TABLES = [
   "ingest_dedup_session_state",
   "ingest_cluster_state",
   "sync_failure",
+  "store_owner",
 ];
 const MIGRATION_002 = `ALTER TABLE swim_length ADD COLUMN distance_m REAL;
 
@@ -147,6 +148,7 @@ function openFull(): DatabaseSync {
   next.exec(MIGRATIONS[4]!.sql);
   next.exec(MIGRATIONS[5]!.sql);
   next.exec(MIGRATIONS[6]!.sql);
+  next.exec(MIGRATIONS[7]!.sql);
   return next;
 }
 
@@ -165,6 +167,7 @@ describe("001_init migration", () => {
       { version: 5, name: "005_sync_state" },
       { version: 6, name: "006_incremental_ingest" },
       { version: 7, name: "007_sync_failure" },
+      { version: 8, name: "008_store_owner" },
     ]);
     expect(typeof MIGRATIONS[0].sql).toBe("string");
     expect(MIGRATIONS[0].sql).toContain("CREATE TABLE athlete");
@@ -256,7 +259,7 @@ describe("001_init migration", () => {
     expect(MIGRATIONS[2]!.sql).toBe(MIGRATION_003);
   });
 
-  it("applies 001 through 007 with exactly thirty-five tables and no foreign-key violations", () => {
+  it("applies 001 through 008 with exactly thirty-six tables and no foreign-key violations", () => {
     db = openFull();
     const names = (
       db
@@ -266,7 +269,7 @@ describe("001_init migration", () => {
       .map((row) => row.name)
       .sort();
     expect(names).toEqual([...EXPECTED_FULL_TABLES].sort());
-    expect(names).toHaveLength(35);
+    expect(names).toHaveLength(36);
     expect(db.prepare("PRAGMA foreign_key_check").all()).toEqual([]);
   });
 
@@ -497,6 +500,8 @@ describe("001_init migration", () => {
         "source_record_current_no_delete",
         "sync_operation_no_update",
         "sync_operation_no_delete",
+        "store_owner_no_update",
+        "store_owner_no_delete",
       ]),
     );
 
@@ -751,6 +756,7 @@ describe("001_init migration", () => {
     expect(DUMP_TABLES.map(({ table }) => String(table))).not.toContain("source_watermark");
     expect(DUMP_TABLES.map(({ table }) => String(table))).not.toContain("sync_operation");
     expect(DUMP_TABLES.map(({ table }) => String(table))).not.toContain("sync_failure");
+    expect(DUMP_TABLES.map(({ table }) => String(table))).not.toContain("store_owner");
     for (const table of [
       "source_artifact",
       "source_record_revision",
@@ -758,6 +764,7 @@ describe("001_init migration", () => {
       "source_watermark",
       "sync_operation",
       "sync_failure",
+      "store_owner",
     ]) {
       expect(DERIVED_TABLES).not.toContain(table);
     }
@@ -798,5 +805,23 @@ candidate_id,artifact_kind,artifact_id,member_id,source_kind,source_session_seq,
     expect(DERIVED_TABLES).toHaveLength(12);
     expect(PURE_AUTHORED_TABLES).not.toContain("sync_failure");
     expect(MIXED_AUTHORED_TABLES).not.toContain("sync_failure");
+  });
+
+  it("creates one immutable store owner record", () => {
+    db = openFull();
+    expect(createHash("sha256").update(MIGRATIONS[7]!.sql).digest("hex")).toBe(
+      "eca323e5177cb64f126cb89919e39d4abfcf3999b3d57ceb7237e59b6b3675e5",
+    );
+    const columns = db.prepare("PRAGMA table_info(store_owner)").all();
+    expect(columns).toContainEqual(expect.objectContaining({ name: "singleton", pk: 1 }));
+    expect(columns).toContainEqual(expect.objectContaining({ name: "account_fingerprint", notnull: 1 }));
+    expect(() =>
+      db!
+        .prepare("INSERT INTO store_owner(singleton,account_fingerprint) VALUES(1,?)")
+        .run("a".repeat(64)),
+    ).not.toThrow();
+    expect(() => db!.prepare("INSERT INTO store_owner VALUES(2,?)").run("b".repeat(64))).toThrow();
+    expect(() => db!.prepare("UPDATE store_owner SET account_fingerprint=?").run("b".repeat(64))).toThrow();
+    expect(() => db!.prepare("DELETE FROM store_owner").run()).toThrow();
   });
 });


### PR DESCRIPTION
Closes the last HIGH in batch 1. Ticket: `docs/issues/234`.

## The bug

The bulk backfill watermark was keyed on source and lane alone, with no account identity bound to it. Swap the intervals.icu credential for a different athlete's and the walk resumed against the *previous* athlete's cursor — a completed cursor suppressed every history request, so the new athlete's rides were never fetched, while the previous athlete's records stayed in the store and were served as their own. Sync reported success throughout.

## Why this isn't the obvious fix

The obvious fix — invalidate the cursor on mismatch and re-walk — is worse than the bug. **The store is structurally single-athlete:** no table carries an athlete column, and the read paths are account-blind (`dedup-rekey.ts:98-108` filters on source and lane only; `anchor-repository.ts:37` selects threshold anchors with no account predicate, so a previous athlete's FTP can become the current athlete's prescribed zones).

A re-walk would land the new athlete's rows *alongside* the old ones, leaving two athletes merged into one unattributable history that no query can separate. Before the fix the store held one athlete's data — the wrong one. That is recoverable; a blended store is not.

So the store refuses to hold two rather than trying to hold two.

## What ships

- **A store-level owner fingerprint**, claimed on first sight during sync — the point where history is actually written. An existing install adopts silently: no re-walk, no data touched, byte-identical dump before and after.
- **Identity from the resolved intervals.icu athlete identifier**, not the credential. Rotating an API key is not mistaken for changing account. Only a namespaced fingerprint is persisted.
- **Sync refuses before writing anything** once an owner is recorded and a different athlete is resolved.
- **The credential-save check is a convenience, not a boundary.** It never adopts, answers locally whenever it can — a fresh install makes zero network calls — and allows the save whenever the comparison is unavailable, deferring to sync as the real gate.

The migration keeps the record honest: singleton row, lowercase 64-hex constraint, and triggers making it immutable.

## What is deliberately not fixed

Enforcing ownership on every write path needs a single writer seam this codebase does not have. Writes reach the store from four `StoreRuntime` constructions and three unguarded operation RPCs, and a per-process guard cannot be made correct here — the verdict does not survive a restart and is not bound to the credential authorising the writes. Three rounds attempting it did not converge; partial enforcement is worse than none because it creates confidence while three RPCs still write freely.

That analysis, the full enumeration, and the remaining gaps are in `docs/issues/241`. Two gaps are explicitly accepted: an unresolvable identity proceeds (failing closed would lock out any athlete whose profile carries no sport settings — worse than the rare contamination it prevents), and hand-editing `config.yaml` to a foreign account stays unguarded.

## Tests

Fresh install claims the owner during its first sync, then refuses a different athlete. Upgrade claims on a database already full of history with no re-walk and a byte-identical dump. Sync for a different athlete writes nothing. Same athlete resumes normally. Key rotation produces no false refusal at either site. Save-time: unavailable store and unresolvable identity stay distinct and both allow the save; a fresh install issues no network request, asserted on the mock rather than the return value.

`pnpm test` — 4632 passed, 3 skipped, 0 failed. `pnpm check` — clean, including the root `check:types` gate.
