### PR TITLE
fix(desktop): stop a stored key overriding the athlete's chosen provider

### DIFF
--- a/.changeset/calm-vault-precedence.md
+++ b/.changeset/calm-vault-precedence.md
@@ -1,0 +1,7 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Kept the athlete's chosen ChatGPT or API-key provider active while saved inactive keys stay clearly marked as not in use.
+
+Stored credentials now hydrate only the provider the athlete selected, while explicit provider changes remain authoritative. Only genuine application failures offer a retry, and replay self-heals an unrecorded selection without overriding a different recorded choice.

--- a/apps/desktop-renderer/src/global.d.ts
+++ b/apps/desktop-renderer/src/global.d.ts
@@ -4,6 +4,7 @@ interface EnduragentAuth {
     readonly token: string;
   }>;
   credentialStatuses(): Promise<readonly CredentialSlotStatus[]>;
+  retryFailedCredentials(): Promise<readonly CredentialSlotStatus[]>;
   writeCredential(input: {
     readonly slot: DesktopCredentialSlot;
     readonly value: string;
@@ -27,11 +28,12 @@ type DesktopCredentialSlot =
   | "intervals-icu";
 
 type CredentialState = "missing" | "configured" | "re-prompt";
+type CredentialRuntimeState = "active" | "stored-inactive" | "failed";
 
 interface CredentialSlotStatus {
   readonly slot: DesktopCredentialSlot;
   readonly state: CredentialState;
-  readonly runtimeReady: boolean;
+  readonly runtimeState: CredentialRuntimeState | null;
 }
 
 interface ChatGptStatus {

--- a/apps/desktop-renderer/src/index.ts
+++ b/apps/desktop-renderer/src/index.ts
@@ -167,6 +167,7 @@ const onboardingClient = async () => {
 };
 const onboardingBridge: OnboardingBridge = {
   credentialStatuses: () => window.enduragentAuth.credentialStatuses(),
+  retryFailedCredentials: () => window.enduragentAuth.retryFailedCredentials(),
   writeCredential: (value) => window.enduragentAuth.writeCredential(value),
   chatGptStatus: () => window.enduragentAuth.chatgptStatus(),
   chatGptLogin: () => window.enduragentAuth.chatgptLogin(),

--- a/apps/desktop-renderer/src/onboarding/bridge.ts
+++ b/apps/desktop-renderer/src/onboarding/bridge.ts
@@ -29,6 +29,7 @@ export type CredentialWriteResult =
 
 export interface OnboardingBridge {
   credentialStatuses(): Promise<readonly CredentialSlotStatus[]>;
+  retryFailedCredentials(): Promise<readonly CredentialSlotStatus[]>;
   writeCredential(input: {
     readonly slot: DesktopCredentialSlot;
     readonly value: string;
@@ -50,6 +51,7 @@ export interface DesktopOnboardingAuth {
     readonly token: string;
   }>;
   credentialStatuses(): Promise<readonly CredentialSlotStatus[]>;
+  retryFailedCredentials(): Promise<readonly CredentialSlotStatus[]>;
   writeCredential(input: {
     readonly slot: DesktopCredentialSlot;
     readonly value: string;
@@ -120,6 +122,8 @@ export function createOnboardingBridge(
   };
   return {
     credentialStatuses: () => auth.credentialStatuses() as Promise<readonly CredentialSlotStatus[]>,
+    retryFailedCredentials: () =>
+      auth.retryFailedCredentials() as Promise<readonly CredentialSlotStatus[]>,
     writeCredential: (input) => auth.writeCredential(input) as Promise<CredentialWriteResult>,
     chatGptStatus: () => auth.chatgptStatus(),
     chatGptLogin: () => auth.chatgptLogin(),

--- a/apps/desktop-renderer/src/onboarding/credential-presentation.ts
+++ b/apps/desktop-renderer/src/onboarding/credential-presentation.ts
@@ -1,0 +1,23 @@
+import type { CredentialSlotStatus } from "./machine.js";
+
+export interface CredentialPresentation {
+  readonly className: string;
+  readonly copy: string;
+  readonly retryable: boolean;
+}
+
+export function credentialPresentation(status: CredentialSlotStatus): CredentialPresentation {
+  if (status.state === "missing") {
+    return { className: "", copy: "Not configured", retryable: false };
+  }
+  if (status.state === "re-prompt") {
+    return { className: "re-prompt", copy: "Enter again", retryable: false };
+  }
+  if (status.runtimeState === "active") {
+    return { className: "configured", copy: "Configured", retryable: false };
+  }
+  if (status.runtimeState === "stored-inactive") {
+    return { className: "stored-inactive", copy: "Saved · Not in use", retryable: false };
+  }
+  return { className: "failed", copy: "Saved · Retry", retryable: true };
+}

--- a/apps/desktop-renderer/src/onboarding/machine.ts
+++ b/apps/desktop-renderer/src/onboarding/machine.ts
@@ -12,11 +12,12 @@ import {
 } from "./constants.js";
 
 export type CredentialState = "missing" | "configured" | "re-prompt";
+export type CredentialRuntimeState = "active" | "stored-inactive" | "failed";
 
 export interface CredentialSlotStatus {
   readonly slot: DesktopCredentialSlot;
   readonly state: CredentialState;
-  readonly runtimeReady: boolean;
+  readonly runtimeState: CredentialRuntimeState | null;
 }
 
 export interface ChatGptStatus {

--- a/apps/desktop-renderer/src/onboarding/mount.ts
+++ b/apps/desktop-renderer/src/onboarding/mount.ts
@@ -7,6 +7,7 @@ import {
   type ModelCredentialSlot,
 } from "./constants.js";
 import type { OnboardingBridge } from "./bridge.js";
+import { credentialPresentation } from "./credential-presentation.js";
 import {
   ONBOARDING_COMPLETION,
   canImportFiles,
@@ -120,6 +121,7 @@ function passwordControl(
   labelText: string,
   status: CredentialSlotStatus,
 ): HTMLElement {
+  const presentation = credentialPresentation(status);
   const field = make(document, "div", "credential-field");
   const label = make(document, "label", "credential-label");
   const id = `credential-${slot}`;
@@ -128,14 +130,8 @@ function passwordControl(
   const badge = make(
     document,
     "span",
-    `credential-state ${status.state}`,
-    status.state === "configured"
-      ? status.runtimeReady
-        ? "Configured"
-        : "Saved · Retry"
-      : status.state === "re-prompt"
-        ? "Enter again"
-        : "Not configured",
+    `credential-state ${presentation.className}`,
+    presentation.copy,
   );
   label.append(badge);
   const input = make(document, "input");
@@ -160,7 +156,7 @@ export function mountOnboarding(options: MountOnboardingOptions): OnboardingCont
     credentialStatuses.find((entry) => entry.slot === slot) ?? {
       slot,
       state: state.credentialStatus[slot],
-      runtimeReady: false,
+      runtimeState: null,
     };
 
   const clearPasswordInputs = (): void => {
@@ -315,13 +311,15 @@ export function mountOnboarding(options: MountOnboardingOptions): OnboardingCont
     );
     const chatGptLane = make(options.document, "section", "chatgpt-lane");
     const chatGptHeading = make(options.document, "div", "chatgpt-lane-heading");
+    const chatGptActive = state.chatGptState === "configured" && state.chatGptRuntimeReady;
+    const chatGptStored = state.chatGptState === "configured" && !state.chatGptRuntimeReady;
     chatGptHeading.append(
       make(options.document, "strong", undefined, "ChatGPT subscription"),
       make(
         options.document,
         "span",
-        `credential-state ${state.chatGptState === "configured" ? "configured" : ""}`,
-        state.chatGptState === "configured" ? "Configured" : "No API key",
+        `credential-state ${chatGptActive ? "configured" : chatGptStored ? "stored-inactive" : ""}`,
+        chatGptActive ? "Configured" : chatGptStored ? "Saved · Not in use" : "No API key",
       ),
     );
     chatGptLane.append(
@@ -376,9 +374,13 @@ export function mountOnboarding(options: MountOnboardingOptions): OnboardingCont
         state = withChatGptPending(state);
         render();
         void options.bridge.chatGptLogin().then(
-          (result) => {
+          async (result) => {
             if (visit !== loginVisit || scrim === undefined) return;
             state = withChatGptLoginResult(state, result);
+            if (result.status === "configured") {
+              await refreshStatuses(loginVisit).catch(() => undefined);
+            }
+            if (visit !== loginVisit || scrim === undefined) return;
             render();
             focusCurrentTitle();
           },
@@ -421,7 +423,7 @@ export function mountOnboarding(options: MountOnboardingOptions): OnboardingCont
     }
     advanced.append(advancedList);
     body.append(advanced);
-    if (credentialStatuses.some((entry) => entry.state === "configured" && !entry.runtimeReady)) {
+    if (credentialStatuses.some((entry) => credentialPresentation(entry).retryable)) {
       const retry = make(options.document, "button", "text-button", "Retry saved keys");
       retry.type = "button";
       retry.disabled = state.busy;
@@ -430,20 +432,22 @@ export function mountOnboarding(options: MountOnboardingOptions): OnboardingCont
         state = withBusy(state, true);
         render();
         focusCurrentTitle();
-        void refreshStatuses(retryVisit).then(
-          () => {
+        void options.bridge
+          .retryFailedCredentials()
+          .then(async () => {
+            if (visit !== retryVisit || scrim === undefined) return;
+            await refreshStatuses(retryVisit);
             if (visit !== retryVisit || scrim === undefined) return;
             state = withBusy(state, false);
             render();
             focusCurrentTitle();
-          },
-          () => {
+          })
+          .catch(() => {
             if (visit !== retryVisit || scrim === undefined) return;
             state = withError(state, "credential-save-failed");
             render();
             focusCurrentTitle();
-          },
-        );
+          });
       });
       body.append(retry);
     }

--- a/apps/desktop-renderer/src/onboarding/onboarding.css
+++ b/apps/desktop-renderer/src/onboarding/onboarding.css
@@ -168,6 +168,10 @@
   color: #9a593f;
 }
 
+.credential-state.failed {
+  color: #9a593f;
+}
+
 .provider-hint {
   margin-left: 0;
   padding: 2px 7px;

--- a/apps/desktop-renderer/tests/credential-presentation.test.ts
+++ b/apps/desktop-renderer/tests/credential-presentation.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { credentialPresentation } from "../src/onboarding/credential-presentation.js";
+import type { CredentialSlotStatus } from "../src/onboarding/machine.js";
+
+describe("credential status presentation", () => {
+  it("presents active, stored inactive, and failed credentials as distinct states", () => {
+    const status = (
+      runtimeState: "active" | "stored-inactive" | "failed",
+    ): CredentialSlotStatus => ({ slot: "anthropic", state: "configured", runtimeState });
+
+    expect(credentialPresentation(status("active"))).toEqual({
+      className: "configured",
+      copy: "Configured",
+      retryable: false,
+    });
+    expect(credentialPresentation(status("stored-inactive"))).toEqual({
+      className: "stored-inactive",
+      copy: "Saved · Not in use",
+      retryable: false,
+    });
+    expect(credentialPresentation(status("failed"))).toEqual({
+      className: "failed",
+      copy: "Saved · Retry",
+      retryable: true,
+    });
+  });
+
+  it("keeps a dormant API key non-alarming while ChatGPT is active", () => {
+    const chatGpt = { state: "configured" as const, runtimeReady: true };
+    const dormant: CredentialSlotStatus = {
+      slot: "anthropic",
+      state: "configured",
+      runtimeState: "stored-inactive",
+    };
+    const presentation = credentialPresentation(dormant);
+
+    expect(chatGpt).toEqual({ state: "configured", runtimeReady: true });
+    expect(presentation.copy).toBe("Saved · Not in use");
+    expect(presentation.retryable).toBe(false);
+    expect(presentation.copy).not.toMatch(/error|failed|retry/iu);
+  });
+});

--- a/apps/desktop-renderer/tests/onboarding-machine.test.ts
+++ b/apps/desktop-renderer/tests/onboarding-machine.test.ts
@@ -33,7 +33,7 @@ describe("desktop onboarding machine", () => {
       fixedError: "credential-required",
     });
     state = withCredentialStatuses(state, [
-      { slot: "anthropic", state: "configured", runtimeReady: true },
+      { slot: "anthropic", state: "configured", runtimeState: "active" },
     ]);
     state = nextStep(state);
     expect(state.step).toBe("training-data");
@@ -76,8 +76,8 @@ describe("desktop onboarding machine", () => {
 
   it("preserves configured metadata and successful imports while moving back", () => {
     let state = createOnboardingState([
-      { slot: "openrouter", state: "configured", runtimeReady: true },
-      { slot: "intervals-icu", state: "configured", runtimeReady: true },
+      { slot: "openrouter", state: "configured", runtimeState: "active" },
+      { slot: "intervals-icu", state: "configured", runtimeState: "active" },
     ]);
     state = nextStep(state);
     state = withSuccessfulImport(state, ["/synthetic/ride.tcx"]);
@@ -92,7 +92,7 @@ describe("desktop onboarding machine", () => {
 
   it("accepts chooser and drop imports only while the training step is open and idle", () => {
     let state = createOnboardingState([
-      { slot: "anthropic", state: "configured", runtimeReady: true },
+      { slot: "anthropic", state: "configured", runtimeState: "active" },
     ]);
     state = nextStep(state);
     expect(canImportFiles(state, true)).toBe(true);

--- a/apps/desktop-renderer/tests/onboarding-provider-status.test.ts
+++ b/apps/desktop-renderer/tests/onboarding-provider-status.test.ts
@@ -1,0 +1,327 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, it, vi } from "vitest";
+import type { OnboardingBridge } from "../src/onboarding/bridge.js";
+import { mountOnboarding } from "../src/onboarding/mount.js";
+
+class FakeElement {
+  readonly children: FakeElement[] = [];
+  readonly attributes = new Map<string, string>();
+  readonly dataset: Record<string, string> = {};
+  readonly listeners = new Map<string, Set<() => void>>();
+  parent: FakeElement | undefined;
+  className = "";
+  disabled = false;
+  hidden = false;
+  id = "";
+  type = "";
+  value = "";
+  htmlFor = "";
+  tabIndex = 0;
+  private ownText = "";
+
+  constructor(
+    readonly tagName: string,
+    private readonly document: FakeDocument,
+  ) {}
+
+  get classList(): { contains(value: string): boolean } {
+    return { contains: (value) => this.className.split(/\s+/u).includes(value) };
+  }
+
+  get textContent(): string {
+    return this.ownText + this.children.map((child) => child.textContent).join("");
+  }
+
+  set textContent(value: string) {
+    this.ownText = value;
+    this.children.splice(0);
+  }
+
+  append(...nodes: Array<FakeElement | string>): void {
+    for (const value of nodes) {
+      const node = typeof value === "string" ? this.document.createTextNode(value) : value;
+      node.parent = this;
+      this.children.push(node);
+    }
+  }
+
+  replaceChildren(...nodes: FakeElement[]): void {
+    this.ownText = "";
+    this.children.splice(0);
+    this.append(...nodes);
+  }
+
+  setAttribute(name: string, value: string): void {
+    this.attributes.set(name, value);
+  }
+
+  hasAttribute(name: string): boolean {
+    return this.attributes.has(name);
+  }
+
+  addEventListener(name: string, listener: () => void): void {
+    const listeners = this.listeners.get(name) ?? new Set();
+    listeners.add(listener);
+    this.listeners.set(name, listeners);
+  }
+
+  click(): void {
+    for (const listener of this.listeners.get("click") ?? []) listener();
+  }
+
+  focus(): void {
+    this.document.activeElement = this;
+  }
+
+  remove(): void {
+    if (this.parent === undefined) return;
+    const index = this.parent.children.indexOf(this);
+    if (index >= 0) this.parent.children.splice(index, 1);
+    this.parent = undefined;
+  }
+
+  closest(): null {
+    return null;
+  }
+
+  querySelector(selector: string): FakeElement | null {
+    return this.querySelectorAll(selector)[0] ?? null;
+  }
+
+  querySelectorAll(selector: string): FakeElement[] {
+    return descendants(this).filter((node) => matches(node, selector));
+  }
+}
+
+class FakeDocument {
+  readonly body = new FakeElement("body", this);
+  activeElement: FakeElement | null = null;
+
+  createElement(name: string): FakeElement {
+    return new FakeElement(name, this);
+  }
+
+  createTextNode(value: string): FakeElement {
+    const node = new FakeElement("#text", this);
+    node.textContent = value;
+    return node;
+  }
+}
+
+function descendants(root: FakeElement): FakeElement[] {
+  return root.children.flatMap((child) => [child, ...descendants(child)]);
+}
+
+function matches(node: FakeElement, selector: string): boolean {
+  if (selector.startsWith("#")) return node.id === selector.slice(1);
+  if (selector === 'input[type="password"]')
+    return node.tagName === "input" && node.type === "password";
+  if (selector === 'input[type="password"][data-slot]') {
+    return node.tagName === "input" && node.type === "password" && node.dataset.slot !== undefined;
+  }
+  return node.tagName === selector;
+}
+
+function findByText(root: FakeElement, tagName: string, text: string): FakeElement {
+  const node = descendants(root).find(
+    (entry) => entry.tagName === tagName && entry.textContent === text,
+  );
+  if (node === undefined) throw new Error("Element not found");
+  return node;
+}
+
+function providerLaneBadges(root: FakeElement): FakeElement[] {
+  return descendants(root).filter(
+    (node) =>
+      node.className.startsWith("credential-state") &&
+      (node.parent?.className === "chatgpt-lane-heading" || node.parent?.tagName === "label"),
+  );
+}
+
+function activeProviderLanes(root: FakeElement): FakeElement[] {
+  return providerLaneBadges(root).filter(
+    (node) => node.className === "credential-state configured",
+  );
+}
+
+function expectOneActiveProvider(root: FakeElement): void {
+  expect(providerLaneBadges(root)).toHaveLength(10);
+  expect(activeProviderLanes(root)).toHaveLength(1);
+}
+
+function createBridge(overrides: Partial<OnboardingBridge>): OnboardingBridge {
+  return {
+    credentialStatuses: vi.fn(async () => []),
+    retryFailedCredentials: vi.fn(async () => []),
+    writeCredential: vi.fn(),
+    chatGptStatus: vi.fn(async () => ({ state: "absent", runtimeReady: false })),
+    chatGptLogin: vi.fn(async () => ({ status: "refused", reason: "cancelled" })),
+    chooseImportFiles: vi.fn(async () => []),
+    importFiles: vi.fn(),
+    saveIntake: vi.fn(),
+    onDroppedImportFiles: vi.fn(() => vi.fn()),
+    ...overrides,
+  } as OnboardingBridge;
+}
+
+describe("onboarding provider status", () => {
+  it("shows only ChatGPT as active after sign-in supersedes an API-key provider", async () => {
+    const document = new FakeDocument();
+    let selectedProvider: "anthropic" | "chatgpt" = "anthropic";
+    const credentialStatuses = vi.fn(async () => [
+      {
+        slot: "anthropic" as const,
+        state: "configured" as const,
+        runtimeState:
+          selectedProvider === "anthropic" ? ("active" as const) : ("stored-inactive" as const),
+      },
+    ]);
+    const chatGptStatus = vi.fn(async () => ({
+      state: selectedProvider === "chatgpt" ? ("configured" as const) : ("absent" as const),
+      runtimeReady: selectedProvider === "chatgpt",
+    }));
+    const chatGptLogin = vi.fn(async () => {
+      selectedProvider = "chatgpt";
+      return { status: "configured" as const, runtimeReady: true as const };
+    });
+    const controller = mountOnboarding({
+      document: document as never,
+      bridge: createBridge({ credentialStatuses, chatGptStatus, chatGptLogin }),
+      opener: new FakeElement("button", document) as never,
+      onComplete: vi.fn(),
+    });
+    await controller.open();
+
+    findByText(document.body, "button", "Sign in with ChatGPT").click();
+
+    await vi.waitFor(() => {
+      expect(credentialStatuses).toHaveBeenCalledTimes(2);
+      expectOneActiveProvider(document.body);
+    });
+    expect(activeProviderLanes(document.body)[0]?.textContent).toBe("Configured");
+    expect(findByText(document.body, "span", "Saved · Not in use").className).toBe(
+      "credential-state stored-inactive",
+    );
+    expect(document.body.textContent).not.toContain("Retry saved keys");
+    expect(chatGptStatus).toHaveBeenCalledTimes(2);
+    controller.dispose();
+  });
+
+  it("shows only the API-key provider as active after a key save", async () => {
+    const document = new FakeDocument();
+    let selectedProvider: "anthropic" | "chatgpt" = "chatgpt";
+    const credentialStatuses = vi.fn(async () =>
+      selectedProvider === "anthropic"
+        ? [
+            {
+              slot: "anthropic" as const,
+              state: "configured" as const,
+              runtimeState: "active" as const,
+            },
+          ]
+        : [],
+    );
+    const chatGptStatus = vi.fn(async () => ({
+      state: "configured" as const,
+      runtimeReady: selectedProvider === "chatgpt",
+    }));
+    const writeCredential = vi.fn(async () => {
+      selectedProvider = "anthropic";
+      return {
+        slot: "anthropic" as const,
+        status: "configured" as const,
+        runtimeReady: true as const,
+      };
+    });
+    const controller = mountOnboarding({
+      document: document as never,
+      bridge: createBridge({ credentialStatuses, chatGptStatus, writeCredential }),
+      opener: new FakeElement("button", document) as never,
+      onComplete: vi.fn(),
+    });
+    await controller.open();
+    const input = descendants(document.body).find((node) => node.dataset.slot === "anthropic");
+    if (input === undefined) throw new Error("Element not found");
+    input.value = randomUUID();
+
+    findByText(document.body, "button", "Continue").click();
+
+    await vi.waitFor(() => expect(credentialStatuses).toHaveBeenCalledTimes(2));
+    findByText(document.body, "button", "Back").click();
+    expectOneActiveProvider(document.body);
+    expect(activeProviderLanes(document.body)[0]?.textContent).toBe("Configured");
+    expect(findByText(document.body, "span", "Saved · Not in use").className).toBe(
+      "credential-state stored-inactive",
+    );
+    controller.dispose();
+  });
+
+  it("shows only the API-key provider as active after retry succeeds", async () => {
+    const document = new FakeDocument();
+    let selectedProvider: "anthropic" | "chatgpt" = "chatgpt";
+    const credentialStatuses = vi.fn(async () => [
+      {
+        slot: "anthropic" as const,
+        state: "configured" as const,
+        runtimeState: selectedProvider === "anthropic" ? ("active" as const) : ("failed" as const),
+      },
+    ]);
+    const chatGptStatus = vi.fn(async () => ({
+      state: "configured" as const,
+      runtimeReady: selectedProvider === "chatgpt",
+    }));
+    const retryFailedCredentials = vi.fn(async () => {
+      selectedProvider = "anthropic";
+      return credentialStatuses();
+    });
+    const controller = mountOnboarding({
+      document: document as never,
+      bridge: createBridge({ credentialStatuses, chatGptStatus, retryFailedCredentials }),
+      opener: new FakeElement("button", document) as never,
+      onComplete: vi.fn(),
+    });
+    await controller.open();
+
+    findByText(document.body, "button", "Retry saved keys").click();
+
+    await vi.waitFor(() => {
+      expect(retryFailedCredentials).toHaveBeenCalledOnce();
+      expect(chatGptStatus).toHaveBeenCalledTimes(2);
+      expectOneActiveProvider(document.body);
+    });
+    expect(activeProviderLanes(document.body)[0]?.textContent).toBe("Configured");
+    expect(document.body.textContent).toContain(
+      "Your ChatGPT sign-in is saved. Sign in again to activate it.",
+    );
+    expect(document.body.textContent).not.toContain("ChatGPT is ready.");
+    controller.dispose();
+  });
+
+  it("does not report a completed sign-in as refused when status refresh fails", async () => {
+    const document = new FakeDocument();
+    const credentialStatuses = vi
+      .fn()
+      .mockResolvedValueOnce([])
+      .mockRejectedValueOnce(new TypeError());
+    const chatGptLogin = vi.fn(async () => ({
+      status: "configured" as const,
+      runtimeReady: true as const,
+    }));
+    const controller = mountOnboarding({
+      document: document as never,
+      bridge: createBridge({ credentialStatuses, chatGptLogin }),
+      opener: new FakeElement("button", document) as never,
+      onComplete: vi.fn(),
+    });
+    await controller.open();
+
+    findByText(document.body, "button", "Sign in with ChatGPT").click();
+
+    await vi.waitFor(() => expect(credentialStatuses).toHaveBeenCalledTimes(2));
+    expect(document.body.textContent).toContain("ChatGPT is ready.");
+    expect(document.body.textContent).not.toContain(
+      "ChatGPT sign-in could not be completed. Please retry.",
+    );
+    controller.dispose();
+  });
+});

--- a/apps/desktop-renderer/tests/onboarding-wizard.test.ts
+++ b/apps/desktop-renderer/tests/onboarding-wizard.test.ts
@@ -87,6 +87,13 @@ describe("desktop onboarding wizard", () => {
         token: "s".repeat(43),
       })),
       credentialStatuses: vi.fn(async () => []),
+      retryFailedCredentials: vi.fn(async () => [
+        {
+          slot: "anthropic" as const,
+          state: "configured" as const,
+          runtimeState: "active" as const,
+        },
+      ]),
       writeCredential: vi.fn(),
       chooseImportFiles: vi.fn(async () => []),
       onDroppedImportFiles: vi.fn(() => vi.fn()),
@@ -126,6 +133,13 @@ describe("desktop onboarding wizard", () => {
     const auth = {
       getDaemonConnection: vi.fn(),
       credentialStatuses: vi.fn(async () => []),
+      retryFailedCredentials: vi.fn(async () => [
+        {
+          slot: "anthropic" as const,
+          state: "configured" as const,
+          runtimeState: "active" as const,
+        },
+      ]),
       writeCredential: vi.fn(),
       chatgptStatus: vi.fn(async () => ({ state: "configured" as const, runtimeReady: false })),
       chatgptLogin: vi.fn(async () => ({
@@ -145,6 +159,9 @@ describe("desktop onboarding wizard", () => {
       status: "configured",
       runtimeReady: true,
     });
+    await expect(bridge.retryFailedCredentials()).resolves.toEqual([
+      { slot: "anthropic", state: "configured", runtimeState: "active" },
+    ]);
     expect(connect).not.toHaveBeenCalled();
   });
 

--- a/apps/desktop/scripts/electron-smoke.mjs
+++ b/apps/desktop/scripts/electron-smoke.mjs
@@ -224,7 +224,7 @@ async function security() {
         spoofOrigin: spoofed === expectedForbidden,
         wrongToken: wrongCode === 1008,
         observerOrder: JSON.stringify(observerOrder) === JSON.stringify(expectedOrder),
-        preloadBridge: JSON.stringify(ready.bridgeKeys) === JSON.stringify(["chatgptLogin", "chatgptStatus", "chooseImportFiles", "credentialStatuses", "getDaemonConnection", "onDroppedImportFiles", "writeCredential"]),
+        preloadBridge: JSON.stringify(ready.bridgeKeys) === JSON.stringify(["chatgptLogin", "chatgptStatus", "chooseImportFiles", "credentialStatuses", "getDaemonConnection", "onDroppedImportFiles", "retryFailedCredentials", "writeCredential"]),
         credentialMetadata: ready.credentialStatusesMetadataOnly === true,
       },
       url: ready.url,

--- a/apps/desktop/src/main/chatgpt-auth.ts
+++ b/apps/desktop/src/main/chatgpt-auth.ts
@@ -151,7 +151,6 @@ function classifyLoginFailure(
 export function createChatGptAuth(options: CreateChatGptAuthOptions): ChatGptAuthController {
   const runLogin = options.dependencies?.loginCodex ?? loginCodex;
   const storeProfile = options.dependencies?.writeProfile ?? writeChatGptProfile;
-  let runtimeReadyThisSession = false;
   let activeLogin: Promise<ChatGptLoginResult> | undefined;
 
   const performLogin = async (): Promise<ChatGptLoginResult> => {
@@ -192,7 +191,6 @@ export function createChatGptAuth(options: CreateChatGptAuthOptions): ChatGptAut
     } catch {
       return { status: "refused", reason: "runtime-unavailable" };
     }
-    runtimeReadyThisSession = true;
     return { status: "configured", runtimeReady: true };
   };
 
@@ -201,8 +199,7 @@ export function createChatGptAuth(options: CreateChatGptAuthOptions): ChatGptAut
       const configured = await hasChatGptProfile(options.configDir);
       return {
         state: configured ? "configured" : "absent",
-        runtimeReady:
-          configured && (runtimeReadyThisSession || (await configuredRuntime(options.configDir))),
+        runtimeReady: configured && (await configuredRuntime(options.configDir)),
       };
     },
     async login() {

--- a/apps/desktop/src/main/credential-runtime.ts
+++ b/apps/desktop/src/main/credential-runtime.ts
@@ -1,0 +1,92 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import {
+  type ConfigureRuntimeRpcParams,
+  type LlmProvider,
+  LlmProviderSchema,
+} from "@enduragent/coach-contract";
+import { parse as parseYaml } from "yaml";
+import { CHATGPT_PROFILE_NAME } from "./chatgpt-auth.js";
+import type { CredentialRuntimeState, DesktopCredentialSlot } from "./credential-vault.js";
+import { runtimeConfigurationForCredential } from "./onboarding-ipc.js";
+
+export interface LlmProviderSelectionEvidence {
+  readonly chatGptProfilePresent: boolean;
+  readonly storedCredentialSlots: readonly DesktopCredentialSlot[];
+}
+
+export interface CredentialRuntimeApplication {
+  applyExplicit(request: ConfigureRuntimeRpcParams): Promise<void>;
+  reapplyStoredCredential(
+    slot: DesktopCredentialSlot,
+    value: string,
+    storedCredentialSlots: readonly DesktopCredentialSlot[],
+  ): Promise<Exclude<CredentialRuntimeState, "failed">>;
+}
+
+interface CredentialRuntimeApplicationOptions {
+  readonly selectedLlmProvider: (
+    storedCredentialSlots: readonly DesktopCredentialSlot[],
+  ) => Promise<LlmProvider | undefined>;
+  readonly configureRuntime: (request: ConfigureRuntimeRpcParams) => Promise<void>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export async function readSelectedLlmProvider(
+  configDir: string,
+  evidence: LlmProviderSelectionEvidence,
+): Promise<LlmProvider | undefined> {
+  let source: string;
+  try {
+    source = await readFile(join(configDir, "config.yaml"), "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+    throw error;
+  }
+  const parsed = parseYaml(source) as unknown;
+  if (parsed === undefined || parsed === null) return undefined;
+  if (!isRecord(parsed)) throw new TypeError();
+  if (parsed.llm === undefined) return undefined;
+  if (!isRecord(parsed.llm)) throw new TypeError();
+  if (parsed.llm.provider === undefined) return undefined;
+  const provider = LlmProviderSchema.parse(parsed.llm.provider);
+  if (provider === CHATGPT_PROFILE_NAME) {
+    return evidence.chatGptProfilePresent ? provider : undefined;
+  }
+  return evidence.storedCredentialSlots.includes(provider) ? provider : undefined;
+}
+
+export function createCredentialRuntimeApplication(
+  options: CredentialRuntimeApplicationOptions,
+): CredentialRuntimeApplication {
+  let pending: Promise<void> = Promise.resolve();
+
+  const serialize = <T>(operation: () => Promise<T>): Promise<T> => {
+    const result = pending.then(operation);
+    pending = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  };
+
+  return {
+    applyExplicit(request) {
+      return serialize(() => options.configureRuntime(request));
+    },
+    reapplyStoredCredential(slot, value, storedCredentialSlots) {
+      return serialize(async () => {
+        const request = runtimeConfigurationForCredential(slot, value);
+        const selectedProvider = await options.selectedLlmProvider(storedCredentialSlots);
+        if (request.llm !== undefined && selectedProvider !== undefined) {
+          if (selectedProvider !== request.llm.provider) return "stored-inactive";
+        }
+        await options.configureRuntime(request);
+        return "active";
+      });
+    },
+  };
+}

--- a/apps/desktop/src/main/credential-vault.ts
+++ b/apps/desktop/src/main/credential-vault.ts
@@ -17,11 +17,12 @@ export const DESKTOP_CREDENTIAL_SLOTS = [
 
 export type DesktopCredentialSlot = (typeof DESKTOP_CREDENTIAL_SLOTS)[number];
 export type CredentialState = "missing" | "configured" | "re-prompt";
+export type CredentialRuntimeState = "active" | "stored-inactive" | "failed";
 
 export interface CredentialSlotStatus {
   readonly slot: DesktopCredentialSlot;
   readonly state: CredentialState;
-  readonly runtimeReady: boolean;
+  readonly runtimeState: CredentialRuntimeState | null;
 }
 
 export type CredentialWriteResult =
@@ -60,12 +61,18 @@ export interface CredentialVault {
   }): Promise<CredentialWriteResult>;
   credentialStatuses(): Promise<readonly CredentialSlotStatus[]>;
   reapplyConfigured(): Promise<void>;
+  retryFailed(): Promise<void>;
 }
 
 interface CredentialVaultOptions {
   readonly root: string;
   readonly encryption: CredentialEncryptionPort;
   readonly applyCredential: (slot: DesktopCredentialSlot, value: string) => Promise<void>;
+  readonly reapplyCredential?: (
+    slot: DesktopCredentialSlot,
+    value: string,
+    storedCredentialSlots: readonly DesktopCredentialSlot[],
+  ) => Promise<Exclude<CredentialRuntimeState, "failed">>;
 }
 
 interface ReadCredential {
@@ -114,7 +121,7 @@ async function validTarget(path: string): Promise<boolean> {
 }
 
 export function createCredentialVault(options: CredentialVaultOptions): CredentialVault {
-  const runtimeReady = new Map<DesktopCredentialSlot, boolean>();
+  const runtimeState = new Map<DesktopCredentialSlot, CredentialRuntimeState>();
 
   const readSlot = async (slot: DesktopCredentialSlot): Promise<ReadCredential> => {
     const path = join(options.root, `${slot}.bin`);
@@ -164,12 +171,38 @@ export function createCredentialVault(options: CredentialVaultOptions): Credenti
           entry.state === "configured" && entry.value !== undefined,
       )
       .sort((left, right) => left.modifiedAt - right.modifiedAt);
+    const storedCredentialSlots = entries.map((entry) => entry.slot);
     for (const entry of entries) {
       try {
-        await options.applyCredential(entry.slot, entry.value);
-        runtimeReady.set(entry.slot, true);
+        const replayed =
+          options.reapplyCredential === undefined
+            ? await options.applyCredential(entry.slot, entry.value).then(() => "active" as const)
+            : await options.reapplyCredential(entry.slot, entry.value, storedCredentialSlots);
+        runtimeState.set(entry.slot, replayed);
       } catch {
-        runtimeReady.set(entry.slot, false);
+        runtimeState.set(entry.slot, "failed");
+      }
+    }
+  };
+
+  const retryFailed = async (): Promise<void> => {
+    const configured = (await readAll())
+      .filter(
+        (entry): entry is ReadCredential & { readonly value: string } =>
+          entry.state === "configured" && entry.value !== undefined,
+      )
+      .sort((left, right) => left.modifiedAt - right.modifiedAt);
+    const storedCredentialSlots = configured.map((entry) => entry.slot);
+    const entries = configured.filter((entry) => runtimeState.get(entry.slot) === "failed");
+    for (const entry of entries) {
+      try {
+        const retried =
+          options.reapplyCredential === undefined
+            ? await options.applyCredential(entry.slot, entry.value).then(() => "active" as const)
+            : await options.reapplyCredential(entry.slot, entry.value, storedCredentialSlots);
+        runtimeState.set(entry.slot, retried);
+      } catch {
+        runtimeState.set(entry.slot, "failed");
       }
     }
   };
@@ -234,10 +267,10 @@ export function createCredentialVault(options: CredentialVaultOptions): Credenti
       }
       try {
         await options.applyCredential(input.slot, value);
-        runtimeReady.set(input.slot, true);
+        runtimeState.set(input.slot, "active");
         return { slot: input.slot, status: "configured", runtimeReady: true };
       } catch {
-        runtimeReady.set(input.slot, false);
+        runtimeState.set(input.slot, "failed");
         return { slot: input.slot, status: "refused", reason: "runtime-unavailable" };
       }
     },
@@ -247,10 +280,12 @@ export function createCredentialVault(options: CredentialVaultOptions): Credenti
       return entries.map((entry) => ({
         slot: entry.slot,
         state: entry.state,
-        runtimeReady: entry.state === "configured" && runtimeReady.get(entry.slot) === true,
+        runtimeState:
+          entry.state === "configured" ? (runtimeState.get(entry.slot) ?? "stored-inactive") : null,
       }));
     },
 
     reapplyConfigured,
+    retryFailed,
   };
 }

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -13,8 +13,12 @@ import {
   shell,
   utilityProcess,
 } from "electron";
-import { createChatGptAuth } from "./chatgpt-auth.js";
+import { createChatGptAuth, hasChatGptProfile } from "./chatgpt-auth.js";
 import { DESKTOP_CONNECTION_CHANNEL, DESKTOP_RENDERER_URL, DESKTOP_SCHEME } from "./constants.js";
+import {
+  createCredentialRuntimeApplication,
+  readSelectedLlmProvider,
+} from "./credential-runtime.js";
 import { CREDENTIAL_DIRECTORY_NAME, createCredentialVault } from "./credential-vault.js";
 import { resolveDesktopAthleteHome, seedFirstRunConfig } from "./first-run-config.js";
 import { registerOnboardingIpc, runtimeConfigurationForCredential } from "./onboarding-ipc.js";
@@ -132,16 +136,26 @@ async function runDesktop(): Promise<void> {
         await client.close();
       }
     };
+    const configDir = join(resolveDesktopAthleteHome(environment), "config");
+    const credentialRuntime = createCredentialRuntimeApplication({
+      configureRuntime: applyRuntimeConfig,
+      selectedLlmProvider: async (storedCredentialSlots) =>
+        readSelectedLlmProvider(configDir, {
+          chatGptProfilePresent: await hasChatGptProfile(configDir),
+          storedCredentialSlots,
+        }),
+    });
     const vault = createCredentialVault({
       root: join(app.getPath("userData"), CREDENTIAL_DIRECTORY_NAME),
       encryption: safeStorage,
       async applyCredential(slot, value) {
-        await applyRuntimeConfig(runtimeConfigurationForCredential(slot, value));
+        await credentialRuntime.applyExplicit(runtimeConfigurationForCredential(slot, value));
       },
+      reapplyCredential: credentialRuntime.reapplyStoredCredential,
     });
     const chatGptAuth = createChatGptAuth({
-      configDir: join(resolveDesktopAthleteHome(environment), "config"),
-      applyRuntimeConfig,
+      configDir,
+      applyRuntimeConfig: credentialRuntime.applyExplicit,
       openExternal: (url) => shell.openExternal(url),
       signal: controller.signal,
     });
@@ -285,7 +299,7 @@ async function runDesktop(): Promise<void> {
           Array.isArray(rendererResult.credentialStatuses) &&
           rendererResult.credentialStatuses.every((entry: Record<string, unknown>) => {
             const keys = Object.keys(entry).sort();
-            return JSON.stringify(keys) === JSON.stringify(["runtimeReady", "slot", "state"]);
+            return JSON.stringify(keys) === JSON.stringify(["runtimeState", "slot", "state"]);
           }) &&
           !JSON.stringify(rendererResult.credentialStatuses).includes(resolution.token),
         tokenAbsentInRendererSurfaces:

--- a/apps/desktop/src/main/onboarding-ipc.ts
+++ b/apps/desktop/src/main/onboarding-ipc.ts
@@ -11,6 +11,7 @@ import {
 } from "./credential-vault.js";
 
 export const DESKTOP_CREDENTIAL_STATUS_CHANNEL = "enduragent:onboarding:credential-status" as const;
+export const DESKTOP_CREDENTIAL_RETRY_CHANNEL = "enduragent:onboarding:credential-retry" as const;
 export const DESKTOP_CREDENTIAL_WRITE_CHANNEL = "enduragent:onboarding:credential-write" as const;
 export const DESKTOP_CHATGPT_STATUS_CHANNEL = "enduragent:onboarding:chatgpt-status" as const;
 export const DESKTOP_CHATGPT_LOGIN_CHANNEL = "enduragent:onboarding:chatgpt-login" as const;
@@ -93,7 +94,7 @@ function minimizeStatuses(value: readonly CredentialSlotStatus[]): readonly Cred
   return value.map((entry) => ({
     slot: entry.slot,
     state: entry.state,
-    runtimeReady: entry.runtimeReady,
+    runtimeState: entry.runtimeState,
   }));
 }
 
@@ -118,9 +119,15 @@ export function registerOnboardingIpc(options: RegisterOnboardingIpcOptions): ()
       return DESKTOP_CREDENTIAL_SLOTS.map((slot) => ({
         slot,
         state: "re-prompt" as const,
-        runtimeReady: false,
+        runtimeState: null,
       }));
     }
+  });
+  options.ipcMain.handle(DESKTOP_CREDENTIAL_RETRY_CHANNEL, async (event, ...args) => {
+    requireTrusted(event);
+    if (args.length !== 0) throw new TypeError();
+    await options.vault.retryFailed();
+    return minimizeStatuses(await options.vault.credentialStatuses());
   });
   options.ipcMain.handle(DESKTOP_CREDENTIAL_WRITE_CHANNEL, async (event, ...args) => {
     requireTrusted(event);
@@ -165,6 +172,7 @@ export function registerOnboardingIpc(options: RegisterOnboardingIpcOptions): ()
   });
   return () => {
     options.ipcMain.removeHandler(DESKTOP_CREDENTIAL_STATUS_CHANNEL);
+    options.ipcMain.removeHandler(DESKTOP_CREDENTIAL_RETRY_CHANNEL);
     options.ipcMain.removeHandler(DESKTOP_CREDENTIAL_WRITE_CHANNEL);
     options.ipcMain.removeHandler(DESKTOP_CHATGPT_STATUS_CHANNEL);
     options.ipcMain.removeHandler(DESKTOP_CHATGPT_LOGIN_CHANNEL);

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -2,6 +2,7 @@ import { contextBridge, ipcRenderer, webUtils } from "electron";
 import { DESKTOP_CONNECTION_CHANNEL } from "../main/constants.js";
 
 const DESKTOP_CREDENTIAL_STATUS_CHANNEL = "enduragent:onboarding:credential-status";
+const DESKTOP_CREDENTIAL_RETRY_CHANNEL = "enduragent:onboarding:credential-retry";
 const DESKTOP_CREDENTIAL_WRITE_CHANNEL = "enduragent:onboarding:credential-write";
 const DESKTOP_CHATGPT_STATUS_CHANNEL = "enduragent:onboarding:chatgpt-status";
 const DESKTOP_CHATGPT_LOGIN_CHANNEL = "enduragent:onboarding:chatgpt-login";
@@ -20,6 +21,7 @@ const SLOTS = new Set([
   "intervals-icu",
 ]);
 const STATES = new Set(["missing", "configured", "re-prompt"]);
+const RUNTIME_STATES = new Set(["active", "stored-inactive", "failed"]);
 const REASONS = new Set([
   "invalid-input",
   "encryption-unavailable",
@@ -57,14 +59,16 @@ function parseStatuses(value: unknown): unknown {
   return value.map((entry) => {
     if (
       !record(entry) ||
-      !exactKeys(entry, ["slot", "state", "runtimeReady"]) ||
+      !exactKeys(entry, ["slot", "state", "runtimeState"]) ||
       !SLOTS.has(entry.slot as string) ||
       !STATES.has(entry.state as string) ||
-      typeof entry.runtimeReady !== "boolean"
+      (entry.state === "configured"
+        ? !RUNTIME_STATES.has(entry.runtimeState as string)
+        : entry.runtimeState !== null)
     ) {
       throw new TypeError();
     }
-    return { slot: entry.slot, state: entry.state, runtimeReady: entry.runtimeReady };
+    return { slot: entry.slot, state: entry.state, runtimeState: entry.runtimeState };
   });
 }
 
@@ -151,6 +155,8 @@ contextBridge.exposeInMainWorld(
     getDaemonConnection: () => ipcRenderer.invoke(DESKTOP_CONNECTION_CHANNEL),
     credentialStatuses: async () =>
       parseStatuses(await ipcRenderer.invoke(DESKTOP_CREDENTIAL_STATUS_CHANNEL)),
+    retryFailedCredentials: async () =>
+      parseStatuses(await ipcRenderer.invoke(DESKTOP_CREDENTIAL_RETRY_CHANNEL)),
     writeCredential: async (input: unknown) => {
       if (
         !record(input) ||

--- a/apps/desktop/tests/chat-panels.integration.test.ts
+++ b/apps/desktop/tests/chat-panels.integration.test.ts
@@ -252,6 +252,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
         "credentialStatuses",
         "getDaemonConnection",
         "onDroppedImportFiles",
+        "retryFailedCredentials",
         "writeCredential",
       ],
       thread: true,

--- a/apps/desktop/tests/chatgpt-auth.test.ts
+++ b/apps/desktop/tests/chatgpt-auth.test.ts
@@ -138,6 +138,10 @@ describe("desktop ChatGPT auth", () => {
     });
     const applyRuntimeConfig = vi.fn(async () => {
       order.push("runtime");
+      await writeFile(
+        join(directory, "config.yaml"),
+        "llm:\n  provider: openai-codex\n  model: gpt-5.5\n",
+      );
     });
     const auth = createChatGptAuth({
       configDir: directory,
@@ -245,5 +249,29 @@ describe("desktop ChatGPT auth", () => {
       status: "refused",
       reason: "runtime-unavailable",
     });
+  });
+
+  it("reports a saved ChatGPT profile as inactive after an API-key provider is selected", async () => {
+    const directory = await configDir();
+    const auth = createChatGptAuth({
+      configDir: directory,
+      openExternal: async () => {},
+      applyRuntimeConfig: async (request) => {
+        await writeFile(
+          join(directory, "config.yaml"),
+          `llm:\n  provider: ${request.llm?.provider}\n  model: ${request.llm?.model}\n`,
+        );
+      },
+      dependencies: { loginCodex: async () => credentials() },
+    });
+    await expect(auth.login()).resolves.toEqual({ status: "configured", runtimeReady: true });
+    await expect(auth.status()).resolves.toEqual({ state: "configured", runtimeReady: true });
+
+    await writeFile(
+      join(directory, "config.yaml"),
+      "llm:\n  provider: openrouter\n  model: deepseek/deepseek-v4-flash\n",
+    );
+
+    await expect(auth.status()).resolves.toEqual({ state: "configured", runtimeReady: false });
   });
 });

--- a/apps/desktop/tests/credential-runtime.test.ts
+++ b/apps/desktop/tests/credential-runtime.test.ts
@@ -1,0 +1,463 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ConfigureRuntimeRpcParams, LlmProvider } from "@enduragent/coach-contract";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createCredentialRuntimeApplication,
+  readSelectedLlmProvider,
+  type CredentialRuntimeApplication,
+} from "../src/main/credential-runtime.js";
+import {
+  createCredentialVault,
+  type CredentialEncryptionPort,
+  type CredentialVault,
+  type DesktopCredentialSlot,
+} from "../src/main/credential-vault.js";
+import {
+  DESKTOP_CREDENTIAL_STATUS_CHANNEL,
+  registerOnboardingIpc,
+  runtimeConfigurationForCredential,
+} from "../src/main/onboarding-ipc.js";
+
+const roots: string[] = [];
+
+function encryption(): CredentialEncryptionPort {
+  return {
+    isEncryptionAvailable: () => true,
+    encryptString: (value) => Buffer.from(value).reverse(),
+    decryptString: (value) => Buffer.from(value).reverse().toString(),
+  };
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+function fakeDaemon(initialProvider: LlmProvider) {
+  let persistedProvider = initialProvider;
+  let activeProvider = initialProvider;
+  let intervalsApplications = 0;
+  const modelApplications: LlmProvider[] = [];
+
+  return {
+    launch(): CredentialRuntimeApplication {
+      activeProvider = persistedProvider;
+      return createCredentialRuntimeApplication({
+        selectedLlmProvider: async () => persistedProvider,
+        async configureRuntime(request: ConfigureRuntimeRpcParams) {
+          if (request.llm !== undefined) {
+            activeProvider = request.llm.provider;
+            persistedProvider = request.llm.provider;
+            modelApplications.push(request.llm.provider);
+          }
+          if (request.intervals !== undefined) intervalsApplications += 1;
+        },
+      });
+    },
+    activeProvider: () => activeProvider,
+    persistedProvider: () => persistedProvider,
+    intervalsApplications: () => intervalsApplications,
+    modelApplications: () => [...modelApplications],
+    clearModelApplications: () => modelApplications.splice(0),
+  };
+}
+
+function fakeVault(initialRuntime: CredentialRuntimeApplication) {
+  const slots = new Set<DesktopCredentialSlot>();
+  let runtime = initialRuntime;
+  const port: CredentialVault = {
+    async writeCredential(input) {
+      slots.add(input.slot);
+      await runtime.applyExplicit(runtimeConfigurationForCredential(input.slot, randomUUID()));
+      return { slot: input.slot, status: "configured", runtimeReady: true };
+    },
+    async credentialStatuses() {
+      return [...slots].map((slot) => ({
+        slot,
+        state: "configured" as const,
+        runtimeState: "stored-inactive" as const,
+      }));
+    },
+    async reapplyConfigured() {
+      for (const slot of slots) {
+        await runtime.reapplyStoredCredential(slot, randomUUID(), [...slots]);
+      }
+    },
+    async retryFailed() {},
+  };
+
+  return {
+    port,
+    use(nextRuntime: CredentialRuntimeApplication) {
+      runtime = nextRuntime;
+    },
+  };
+}
+
+async function pollCredentialStatuses(vault: CredentialVault): Promise<void> {
+  const handlers = new Map<string, (...args: unknown[]) => unknown>();
+  const dispose = registerOnboardingIpc({
+    ipcMain: {
+      handle: (channel: string, handler: (...args: unknown[]) => unknown) => {
+        handlers.set(channel, handler);
+      },
+      removeHandler: (channel: string) => {
+        handlers.delete(channel);
+      },
+    } as never,
+    dialog: { showOpenDialog: async () => ({ canceled: true, filePaths: [] }) },
+    window: {} as never,
+    vault,
+    chatGptAuth: {
+      status: async () => ({ state: "absent", runtimeReady: false }),
+      login: async () => ({ status: "refused", reason: "cancelled" }),
+    },
+    isTrusted: () => true,
+  });
+  try {
+    await handlers.get(DESKTOP_CREDENTIAL_STATUS_CHANNEL)!({});
+  } finally {
+    dispose();
+  }
+}
+
+describe("desktop credential runtime precedence", () => {
+  it("self-heals a stored provider after the first-run seed outlives a failed apply", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "enduragent-credential-runtime-"));
+    roots.push(directory);
+    const configDir = join(directory, "config");
+    const vaultRoot = join(directory, "credentials-v1");
+    await mkdir(configDir);
+    await writeFile(
+      join(configDir, "config.yaml"),
+      "llm:\n  provider: anthropic\n  model: claude-sonnet-4-6\n",
+    );
+    let runtimeAvailable = false;
+    let activeProvider: LlmProvider = "anthropic";
+    const launchRuntime = (): CredentialRuntimeApplication =>
+      createCredentialRuntimeApplication({
+        selectedLlmProvider: (storedCredentialSlots) =>
+          readSelectedLlmProvider(configDir, {
+            chatGptProfilePresent: false,
+            storedCredentialSlots,
+          }),
+        async configureRuntime(request) {
+          if (!runtimeAvailable) throw new TypeError();
+          if (request.llm === undefined) return;
+          activeProvider = request.llm.provider;
+          await writeFile(
+            join(configDir, "config.yaml"),
+            `llm:\n  provider: ${request.llm.provider}\n  model: ${request.llm.model}\n`,
+          );
+        },
+      });
+    let runtime = launchRuntime();
+    const launchVault = () =>
+      createCredentialVault({
+        root: vaultRoot,
+        encryption: encryption(),
+        applyCredential: (slot, value) =>
+          runtime.applyExplicit(runtimeConfigurationForCredential(slot, value)),
+        reapplyCredential: runtime.reapplyStoredCredential,
+      });
+    let vault = launchVault();
+
+    await expect(
+      vault.writeCredential({ slot: "openrouter", value: randomUUID() }),
+    ).resolves.toMatchObject({ status: "refused", reason: "runtime-unavailable" });
+    await expect(vault.credentialStatuses()).resolves.toContainEqual({
+      slot: "openrouter",
+      state: "configured",
+      runtimeState: "failed",
+    });
+
+    runtimeAvailable = true;
+    runtime = launchRuntime();
+    vault = launchVault();
+    await vault.reapplyConfigured();
+
+    expect(activeProvider).toBe("openrouter");
+    await expect(vault.credentialStatuses()).resolves.toContainEqual({
+      slot: "openrouter",
+      state: "configured",
+      runtimeState: "active",
+    });
+  });
+
+  it("keeps a dormant API credential inactive across relaunch when a profile corroborates ChatGPT", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "enduragent-credential-runtime-"));
+    roots.push(directory);
+    const configDir = join(directory, "config");
+    const vaultRoot = join(directory, "credentials-v1");
+    await mkdir(configDir);
+    const initialVault = createCredentialVault({
+      root: vaultRoot,
+      encryption: encryption(),
+      applyCredential: async () => {},
+    });
+    await expect(
+      initialVault.writeCredential({ slot: "anthropic", value: randomUUID() }),
+    ).resolves.toMatchObject({ status: "configured" });
+    await writeFile(
+      join(configDir, "config.yaml"),
+      "llm:\n  provider: openai-codex\n  model: gpt-5.5\n",
+    );
+    const configureRuntime = vi.fn(async () => {});
+    const runtime = createCredentialRuntimeApplication({
+      selectedLlmProvider: (storedCredentialSlots) =>
+        readSelectedLlmProvider(configDir, {
+          chatGptProfilePresent: true,
+          storedCredentialSlots,
+        }),
+      configureRuntime,
+    });
+    const relaunchedVault = createCredentialVault({
+      root: vaultRoot,
+      encryption: encryption(),
+      applyCredential: (slot, value) =>
+        runtime.applyExplicit(runtimeConfigurationForCredential(slot, value)),
+      reapplyCredential: runtime.reapplyStoredCredential,
+    });
+
+    await relaunchedVault.reapplyConfigured();
+
+    expect(configureRuntime).not.toHaveBeenCalled();
+    await expect(relaunchedVault.credentialStatuses()).resolves.toContainEqual({
+      slot: "anthropic",
+      state: "configured",
+      runtimeState: "stored-inactive",
+    });
+  });
+
+  it("requires a profile or stored credential to corroborate the recorded provider", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "enduragent-credential-runtime-"));
+    roots.push(directory);
+    await writeFile(
+      join(directory, "config.yaml"),
+      "llm:\n  provider: openai-codex\n  model: gpt-5.5\n",
+    );
+
+    await expect(
+      readSelectedLlmProvider(directory, {
+        chatGptProfilePresent: true,
+        storedCredentialSlots: [],
+      }),
+    ).resolves.toBe("openai-codex");
+    await expect(
+      readSelectedLlmProvider(directory, {
+        chatGptProfilePresent: false,
+        storedCredentialSlots: [],
+      }),
+    ).resolves.toBeUndefined();
+
+    await writeFile(
+      join(directory, "config.yaml"),
+      "llm:\n  provider: anthropic\n  model: claude-sonnet-4-6\n",
+    );
+    await expect(
+      readSelectedLlmProvider(directory, {
+        chatGptProfilePresent: false,
+        storedCredentialSlots: ["anthropic"],
+      }),
+    ).resolves.toBe("anthropic");
+    await expect(
+      readSelectedLlmProvider(directory, {
+        chatGptProfilePresent: false,
+        storedCredentialSlots: [],
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("serializes passive replay before a later explicit provider selection", async () => {
+    let selectedProvider: LlmProvider = "anthropic";
+    let releaseReplay!: () => void;
+    let replayStarted!: () => void;
+    const replayGate = new Promise<void>((resolve) => {
+      releaseReplay = resolve;
+    });
+    const replayStart = new Promise<void>((resolve) => {
+      replayStarted = resolve;
+    });
+    const runtime = createCredentialRuntimeApplication({
+      selectedLlmProvider: async () => selectedProvider,
+      async configureRuntime(request) {
+        if (request.llm?.provider === "anthropic") {
+          replayStarted();
+          await replayGate;
+        }
+        if (request.llm !== undefined) selectedProvider = request.llm.provider;
+      },
+    });
+    const replay = runtime.reapplyStoredCredential("anthropic", randomUUID(), ["anthropic"]);
+    await replayStart;
+    const explicit = runtime.applyExplicit({
+      llm: { provider: "openai-codex", model: "gpt-5.5" },
+    });
+
+    releaseReplay();
+    await Promise.all([replay, explicit]);
+
+    expect(selectedProvider).toBe("openai-codex");
+  });
+
+  it("keeps a later ChatGPT selection when stored model credentials reapply at boot", async () => {
+    const daemon = fakeDaemon("anthropic");
+    let runtime = daemon.launch();
+    const vault = fakeVault(runtime);
+    await vault.port.writeCredential({ slot: "anthropic", value: randomUUID() });
+    await runtime.applyExplicit({ llm: { provider: "openai-codex", model: "gpt-5.5" } });
+
+    runtime = daemon.launch();
+    vault.use(runtime);
+    daemon.clearModelApplications();
+    await vault.port.reapplyConfigured();
+
+    expect(daemon.activeProvider()).toBe("openai-codex");
+    expect(daemon.persistedProvider()).toBe("openai-codex");
+    expect(daemon.modelApplications()).toEqual([]);
+  });
+
+  it("keeps a later ChatGPT selection when the wizard polls credential status", async () => {
+    const daemon = fakeDaemon("anthropic");
+    let runtime = daemon.launch();
+    const vault = fakeVault(runtime);
+    await vault.port.writeCredential({ slot: "anthropic", value: randomUUID() });
+    await runtime.applyExplicit({ llm: { provider: "openai-codex", model: "gpt-5.5" } });
+
+    daemon.clearModelApplications();
+    await pollCredentialStatuses(vault.port);
+    expect(daemon.activeProvider()).toBe("openai-codex");
+    expect(daemon.modelApplications()).toEqual([]);
+
+    runtime = daemon.launch();
+    vault.use(runtime);
+    daemon.clearModelApplications();
+    await pollCredentialStatuses(vault.port);
+    expect(daemon.activeProvider()).toBe("openai-codex");
+    expect(daemon.modelApplications()).toEqual([]);
+  });
+
+  it("reapplies an unrelated service credential without changing the ChatGPT selection", async () => {
+    const daemon = fakeDaemon("anthropic");
+    let runtime = daemon.launch();
+    const vault = fakeVault(runtime);
+    await vault.port.writeCredential({ slot: "anthropic", value: randomUUID() });
+    await runtime.applyExplicit({ llm: { provider: "openai-codex", model: "gpt-5.5" } });
+
+    daemon.clearModelApplications();
+    await vault.port.writeCredential({ slot: "intervals-icu", value: randomUUID() });
+    await pollCredentialStatuses(vault.port);
+    expect(daemon.activeProvider()).toBe("openai-codex");
+    expect(daemon.intervalsApplications()).toBe(2);
+    expect(daemon.modelApplications()).toEqual([]);
+
+    runtime = daemon.launch();
+    vault.use(runtime);
+    daemon.clearModelApplications();
+    await vault.port.reapplyConfigured();
+    expect(daemon.activeProvider()).toBe("openai-codex");
+    expect(daemon.intervalsApplications()).toBe(3);
+    expect(daemon.modelApplications()).toEqual([]);
+  });
+
+  it("reapplies the selected API-key provider when there is no ChatGPT selection", async () => {
+    const daemon = fakeDaemon("anthropic");
+    let runtime = daemon.launch();
+    const vault = fakeVault(runtime);
+    await vault.port.writeCredential({ slot: "anthropic", value: randomUUID() });
+
+    runtime = daemon.launch();
+    vault.use(runtime);
+    daemon.clearModelApplications();
+    await vault.port.reapplyConfigured();
+
+    expect(daemon.activeProvider()).toBe("anthropic");
+    expect(daemon.persistedProvider()).toBe("anthropic");
+    expect(daemon.modelApplications()).toEqual(["anthropic"]);
+  });
+
+  it("self-heals an unrecorded explicit selection after runtime application recovers", async () => {
+    let selectedProvider: LlmProvider | undefined;
+    let runtimeAvailable = false;
+    const runtime = createCredentialRuntimeApplication({
+      selectedLlmProvider: async () => selectedProvider,
+      async configureRuntime(request) {
+        if (!runtimeAvailable) throw new TypeError();
+        if (request.llm !== undefined) selectedProvider = request.llm.provider;
+      },
+    });
+    const slot = "anthropic" as const;
+
+    await expect(
+      runtime.applyExplicit(runtimeConfigurationForCredential(slot, randomUUID())),
+    ).rejects.toBeInstanceOf(TypeError);
+    runtimeAvailable = true;
+
+    await expect(runtime.reapplyStoredCredential(slot, randomUUID(), [slot])).resolves.toBe(
+      "active",
+    );
+    expect(selectedProvider).toBe(slot);
+  });
+
+  it("self-heals a failed stored key after that slot becomes the recorded selection", async () => {
+    let selectedProvider: LlmProvider | undefined;
+    let runtimeAvailable = false;
+    const runtime = createCredentialRuntimeApplication({
+      selectedLlmProvider: async () => selectedProvider,
+      async configureRuntime(request) {
+        if (!runtimeAvailable) throw new TypeError();
+        if (request.llm !== undefined) selectedProvider = request.llm.provider;
+      },
+    });
+    const slot = "anthropic" as const;
+
+    await expect(
+      runtime.applyExplicit(runtimeConfigurationForCredential(slot, randomUUID())),
+    ).rejects.toBeInstanceOf(TypeError);
+    selectedProvider = slot;
+    runtimeAvailable = true;
+
+    await expect(runtime.reapplyStoredCredential(slot, randomUUID(), [slot])).resolves.toBe(
+      "active",
+    );
+    expect(selectedProvider).toBe(slot);
+  });
+
+  it("keeps self-heal inert when another provider is the recorded selection", async () => {
+    const configureRuntime = vi.fn(async () => {});
+    const runtime = createCredentialRuntimeApplication({
+      selectedLlmProvider: async () => "openai-codex",
+      configureRuntime,
+    });
+
+    await expect(
+      runtime.reapplyStoredCredential("anthropic", randomUUID(), ["anthropic"]),
+    ).resolves.toBe("stored-inactive");
+    expect(configureRuntime).not.toHaveBeenCalled();
+  });
+
+  it("persists a deliberate switch from ChatGPT back to an API-key provider", async () => {
+    const daemon = fakeDaemon("anthropic");
+    let runtime = daemon.launch();
+    const vault = fakeVault(runtime);
+    await vault.port.writeCredential({ slot: "anthropic", value: randomUUID() });
+    await runtime.applyExplicit({ llm: { provider: "openai-codex", model: "gpt-5.5" } });
+
+    await vault.port.writeCredential({ slot: "openrouter", value: randomUUID() });
+    daemon.clearModelApplications();
+    await pollCredentialStatuses(vault.port);
+    expect(daemon.activeProvider()).toBe("openrouter");
+    expect(daemon.persistedProvider()).toBe("openrouter");
+    expect(daemon.modelApplications()).toEqual(["openrouter"]);
+
+    runtime = daemon.launch();
+    vault.use(runtime);
+    daemon.clearModelApplications();
+    await vault.port.reapplyConfigured();
+    expect(daemon.activeProvider()).toBe("openrouter");
+    expect(daemon.persistedProvider()).toBe("openrouter");
+    expect(daemon.modelApplications()).toEqual(["openrouter"]);
+  });
+});

--- a/apps/desktop/tests/credential-vault.test.ts
+++ b/apps/desktop/tests/credential-vault.test.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import {
   chmod,
   lstat,
@@ -110,7 +111,7 @@ describe("desktop credential vault", () => {
     await expect(vault.credentialStatuses()).resolves.toContainEqual({
       slot: "anthropic",
       state: "configured",
-      runtimeReady: true,
+      runtimeState: "active",
     });
   });
 
@@ -214,20 +215,144 @@ describe("desktop credential vault", () => {
     corrupted[0] = corrupted[0]! ^ 0xff;
     await writeFile(join(root, "anthropic.bin"), corrupted, { mode: 0o600 });
     const statuses = await vault.credentialStatuses();
-    expect(statuses).toContainEqual({ slot: "anthropic", state: "re-prompt", runtimeReady: false });
+    expect(statuses).toContainEqual({ slot: "anthropic", state: "re-prompt", runtimeState: null });
     expect(statuses).toContainEqual({
       slot: "openrouter",
       state: "configured",
-      runtimeReady: true,
+      runtimeState: "active",
     });
-    expect(statuses).toContainEqual({ slot: "google", state: "configured", runtimeReady: false });
+    expect(statuses).toContainEqual({
+      slot: "google",
+      state: "configured",
+      runtimeState: "failed",
+    });
     failRuntime = false;
     await vault.reapplyConfigured();
     expect(await vault.credentialStatuses()).toContainEqual({
       slot: "google",
       state: "configured",
-      runtimeReady: true,
+      runtimeState: "active",
     });
     expect(applied).toContain("google");
+  });
+
+  it("routes passive replay separately from an explicit credential selection", async () => {
+    const root = await temporaryRoot();
+    const applyCredential = vi.fn(async () => {});
+    const reapplyCredential = vi.fn(async () => "stored-inactive" as const);
+    const vault = createCredentialVault({
+      root,
+      encryption: encryption(),
+      applyCredential,
+      reapplyCredential,
+    });
+    await vault.writeCredential({
+      slot: "anthropic",
+      value: String.fromCharCode(115, 121, 110, 116, 104, 101, 116, 105, 99),
+    });
+    expect(applyCredential).toHaveBeenCalledOnce();
+    expect(reapplyCredential).not.toHaveBeenCalled();
+
+    await vault.reapplyConfigured();
+
+    expect(reapplyCredential).toHaveBeenCalledOnce();
+    expect(await vault.credentialStatuses()).toContainEqual({
+      slot: "anthropic",
+      state: "configured",
+      runtimeState: "stored-inactive",
+    });
+  });
+
+  it("retries a failed credential through selection-aware replay", async () => {
+    const root = await temporaryRoot();
+    let runtimeAvailable = false;
+    const applyCredential = vi.fn(async () => {
+      if (!runtimeAvailable) throw new TypeError();
+    });
+    const reapplyCredential = vi.fn(async () => {
+      if (!runtimeAvailable) throw new TypeError();
+      return "active" as const;
+    });
+    const vault = createCredentialVault({
+      root,
+      encryption: encryption(),
+      applyCredential,
+      reapplyCredential,
+    });
+    await vault.writeCredential({ slot: "anthropic", value: randomUUID() });
+    await expect(vault.credentialStatuses()).resolves.toContainEqual({
+      slot: "anthropic",
+      state: "configured",
+      runtimeState: "failed",
+    });
+    await vault.reapplyConfigured();
+    await expect(vault.credentialStatuses()).resolves.toContainEqual({
+      slot: "anthropic",
+      state: "configured",
+      runtimeState: "failed",
+    });
+    runtimeAvailable = true;
+
+    await vault.retryFailed();
+
+    expect(reapplyCredential).toHaveBeenCalledTimes(2);
+    expect(applyCredential).toHaveBeenCalledOnce();
+    await expect(vault.credentialStatuses()).resolves.toContainEqual({
+      slot: "anthropic",
+      state: "configured",
+      runtimeState: "active",
+    });
+  });
+
+  it("refuses a stale failed retry after another provider becomes selected", async () => {
+    const root = await temporaryRoot();
+    let selectedProvider: "anthropic" | "openrouter" = "anthropic";
+    const applyCredential = vi.fn(async () => {
+      throw new TypeError();
+    });
+    const vault = createCredentialVault({
+      root,
+      encryption: encryption(),
+      applyCredential,
+      reapplyCredential: async (slot) => (slot === selectedProvider ? "active" : "stored-inactive"),
+    });
+    await vault.writeCredential({ slot: "anthropic", value: randomUUID() });
+    await expect(vault.credentialStatuses()).resolves.toContainEqual({
+      slot: "anthropic",
+      state: "configured",
+      runtimeState: "failed",
+    });
+
+    selectedProvider = "openrouter";
+    await vault.retryFailed();
+    expect(applyCredential).toHaveBeenCalledOnce();
+    await expect(vault.credentialStatuses()).resolves.toContainEqual({
+      slot: "anthropic",
+      state: "configured",
+      runtimeState: "stored-inactive",
+    });
+  });
+
+  it("reports a deliberately skipped stored credential as inactive without retrying it", async () => {
+    const root = await temporaryRoot();
+    const applyCredential = vi.fn(async () => {});
+    const reapplyCredential = vi.fn(async () => "stored-inactive" as const);
+    const vault = createCredentialVault({
+      root,
+      encryption: encryption(),
+      applyCredential,
+      reapplyCredential,
+    });
+    await vault.writeCredential({ slot: "anthropic", value: randomUUID() });
+
+    await vault.reapplyConfigured();
+
+    await expect(vault.credentialStatuses()).resolves.toContainEqual({
+      slot: "anthropic",
+      state: "configured",
+      runtimeState: "stored-inactive",
+    });
+    await vault.retryFailed();
+    expect(applyCredential).toHaveBeenCalledOnce();
   });
 });

--- a/apps/desktop/tests/onboarding-ipc.test.ts
+++ b/apps/desktop/tests/onboarding-ipc.test.ts
@@ -4,6 +4,7 @@ import {
   DESKTOP_CHOOSE_IMPORT_FILES_CHANNEL,
   DESKTOP_CHATGPT_LOGIN_CHANNEL,
   DESKTOP_CHATGPT_STATUS_CHANNEL,
+  DESKTOP_CREDENTIAL_RETRY_CHANNEL,
   DESKTOP_CREDENTIAL_STATUS_CHANNEL,
   DESKTOP_CREDENTIAL_WRITE_CHANNEL,
   registerOnboardingIpc,
@@ -26,9 +27,14 @@ function harness() {
       runtimeReady: true as const,
     })),
     credentialStatuses: vi.fn(async () => [
-      { slot: "anthropic" as const, state: "configured" as const, runtimeReady: true },
+      {
+        slot: "anthropic" as const,
+        state: "configured" as const,
+        runtimeState: "active" as const,
+      },
     ]),
     reapplyConfigured: vi.fn(async () => {}),
+    retryFailed: vi.fn(async () => {}),
   };
   const dialog = {
     showOpenDialog: vi.fn(async () => ({
@@ -76,6 +82,7 @@ describe("desktop onboarding IPC", () => {
     expect([...subject.handlers.keys()].sort()).toEqual(
       [
         DESKTOP_CREDENTIAL_STATUS_CHANNEL,
+        DESKTOP_CREDENTIAL_RETRY_CHANNEL,
         DESKTOP_CREDENTIAL_WRITE_CHANNEL,
         DESKTOP_CHATGPT_STATUS_CHANNEL,
         DESKTOP_CHATGPT_LOGIN_CHANNEL,
@@ -84,11 +91,24 @@ describe("desktop onboarding IPC", () => {
     );
     await expect(
       subject.invoke(DESKTOP_CREDENTIAL_STATUS_CHANNEL, subject.trustedEvent),
-    ).resolves.toEqual([{ slot: "anthropic", state: "configured", runtimeReady: true }]);
+    ).resolves.toEqual([{ slot: "anthropic", state: "configured", runtimeState: "active" }]);
     expect(subject.vault.reapplyConfigured).toHaveBeenCalledTimes(1);
     expect(
       JSON.stringify(await subject.invoke(DESKTOP_CREDENTIAL_STATUS_CHANNEL, subject.trustedEvent)),
     ).not.toContain("value");
+  });
+
+  it("retries only failed credentials through the explicit vault path", async () => {
+    const subject = harness();
+    vi.mocked(subject.vault.credentialStatuses).mockResolvedValueOnce([
+      { slot: "anthropic", state: "configured", runtimeState: "active" },
+    ]);
+
+    await expect(
+      subject.invoke(DESKTOP_CREDENTIAL_RETRY_CHANNEL, subject.trustedEvent),
+    ).resolves.toEqual([{ slot: "anthropic", state: "configured", runtimeState: "active" }]);
+    expect(subject.vault.retryFailed).toHaveBeenCalledOnce();
+    expect(subject.vault.reapplyConfigured).not.toHaveBeenCalled();
   });
 
   it("gates strict ChatGPT status and login invokes", async () => {
@@ -176,10 +196,10 @@ describe("desktop onboarding IPC", () => {
     ).resolves.toEqual([]);
   });
 
-  it("disposes only its five handlers", () => {
+  it("disposes only its six handlers", () => {
     const subject = harness();
     subject.dispose();
     expect(subject.handlers.size).toBe(0);
-    expect(subject.ipcMain.removeHandler).toHaveBeenCalledTimes(5);
+    expect(subject.ipcMain.removeHandler).toHaveBeenCalledTimes(6);
   });
 });

--- a/apps/desktop/tests/preload-auth.test.ts
+++ b/apps/desktop/tests/preload-auth.test.ts
@@ -18,6 +18,8 @@ vi.mock("electron", () => ({
 }));
 
 interface AuthBridge {
+  credentialStatuses(): Promise<unknown>;
+  retryFailedCredentials(): Promise<unknown>;
   chatgptStatus(): Promise<unknown>;
   chatgptLogin(): Promise<unknown>;
 }
@@ -34,6 +36,29 @@ beforeEach(() => {
 });
 
 describe("desktop preload ChatGPT auth", () => {
+  it("exposes closed credential runtime states and the retry command", async () => {
+    const statuses = [
+      { slot: "anthropic", state: "configured", runtimeState: "stored-inactive" },
+      { slot: "openrouter", state: "configured", runtimeState: "failed" },
+      { slot: "openai", state: "configured", runtimeState: "active" },
+      { slot: "google", state: "missing", runtimeState: null },
+      { slot: "deepseek", state: "missing", runtimeState: null },
+      { slot: "qwen", state: "missing", runtimeState: null },
+      { slot: "minimax", state: "missing", runtimeState: null },
+      { slot: "kimi", state: "missing", runtimeState: null },
+      { slot: "zai", state: "missing", runtimeState: null },
+      { slot: "intervals-icu", state: "missing", runtimeState: null },
+    ];
+    mocks.invoke.mockResolvedValueOnce(statuses).mockResolvedValueOnce(statuses);
+
+    await expect(bridge.credentialStatuses()).resolves.toEqual(statuses);
+    await expect(bridge.retryFailedCredentials()).resolves.toEqual(statuses);
+    expect(mocks.invoke.mock.calls.map(([channel]) => channel)).toEqual([
+      "enduragent:onboarding:credential-status",
+      "enduragent:onboarding:credential-retry",
+    ]);
+  });
+
   it("exposes strict status and configured results", async () => {
     mocks.invoke
       .mockResolvedValueOnce({ state: "configured", runtimeReady: false })

--- a/apps/desktop/tests/spend-meter.integration.test.ts
+++ b/apps/desktop/tests/spend-meter.integration.test.ts
@@ -271,7 +271,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop spend me
     expect(narrow).toEqual({ visible: true, overflow: false });
   });
 
-  it("preserves the nine-key bridge, training-data drawer, hardened renderer, and token containment", async () => {
+  it("preserves the ten-key bridge, training-data drawer, hardened renderer, and token containment", async () => {
     const { fixture } = await launch();
     const screenshotRoot = await mkdtemp(join(await realpath(tmpdir()), "spend-shot-"));
     scratch.push(screenshotRoot);
@@ -299,6 +299,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop spend me
       "credentialStatuses",
       "getDaemonConnection",
       "onDroppedImportFiles",
+      "retryFailedCredentials",
       "writeCredential",
     ]);
     expect(state.drawer).toBe(true);


### PR DESCRIPTION
Closes `docs/issues/183`, and the duplicate reports `docs/issues/187` and `docs/issues/188` — one root cause found independently by three audit dimensions.

## The bug

Replaying stored credentials pushed every saved key into the daemon with no knowledge of which provider the athlete had selected. Each one flowed through to the persistence layer, which set the provider and deleted the auth profile — erasing a ChatGPT sign-in.

It ran at boot **and** on every credential-status poll, which the wizard fires on open and after each key save. So the wizard kept reporting ChatGPT as ready while every coaching turn was billed to the athlete's API key. On the next launch it offered "sign in again", which ran a full browser OAuth flow that was reverted on the very next poll. Forever, with no way out.

## The rule

**An explicit athlete choice beats a passively stored credential.** Three things were needed to make that true, and each was found by review after the previous one landed:

1. **Dormant keys are inert.** Replay hydrates only the selected provider; a key existing on disk is not a selection.
2. **A later explicit choice supersedes an earlier failure.** A failure marker was outliving the decision that made it irrelevant, which resurrected the warning on a healthy setup — and the only control that cleared it was the one that moved billing back onto the API key.
3. **A recorded provider only counts as a choice when corroborated** by an auth profile or a stored credential in that slot. The first-run seed writes a provider before the athlete has chosen anything; treating that as a selection left an athlete whose first save hit a transient daemon error with a dormant key, no retry offered, and no working model — behind a badge reading "Saved · Not in use".

## Honest status, honest remedies

Credential status was one boolean covering "applied", "deliberately skipped" and "failed". The renderer showed the last two identically, so a healthy athlete saw a permanent error badge.

It is now three states. A key stored but not in use is **healthy** and offers no remedy. Only a genuine apply failure offers a retry, and that retry re-derives the current selection before applying, so a stale marker cannot displace a sign-in. Every lane — including ChatGPT, which previously badged itself from a file existing on disk — derives its badge from the selected provider, so exactly one reads as active.

A key stored while its apply failed now self-heals on a later replay once that slot is the athlete's recorded selection, which is enacting their choice rather than overriding it.

## Tests

Both directions across boot, status poll, unrelated credential save, and relaunch. Fresh-install-with-seed ends with a working model. Retry refuses a slot that is not the current selection. Exactly one active lane asserted across all ten lanes after sign-in, key save, and retry. A refresh failure no longer misreports a successful sign-in as refused.

`pnpm test` — 4641 passed, 3 skipped. `pnpm check` — clean, including the root `check:types` gate.

**On the packaged security smoke:** it pins the preload bridge surface exactly, and this change adds a key, so the literal is updated. I could not execute `smoke:security` here — it never emits its ready signal in this environment and needs `coach-client`/`coach-contract` dists built first. The edit is a one-line comparison literal that runs *after* that signal, so it cannot cause the timeout. The pin is verified two other ways: a direct programmatic comparison against the actual preload exports (exact members, exact order), and the Electron-based integration suite that asserts the same surface, which passes. Worth a run on CI where the harness is built.

## Scope

Untouched: `apps/desktop/src/main/first-run-config.ts` (belongs to #401), plaintext token storage (`docs/issues/210`, by design), the revoked-refresh-token dead end (`docs/issues/184`), and model-default restoration (`docs/issues/222`). No credential deletion or sign-out flow was added — dormant keys are now inert, so the dead end this ticket described is gone.
