### PR TITLE
test(desktop): isolate security smoke credentials

### DIFF
--- a/apps/desktop/scripts/electron-smoke.mjs
+++ b/apps/desktop/scripts/electron-smoke.mjs
@@ -1,34 +1,47 @@
 import { spawn } from "node:child_process";
 import { connect } from "node:net";
 import { existsSync } from "node:fs";
-import { mkdir, mkdtemp, readFile, readdir, realpath, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, readdir, realpath, writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { connectCoachClient } from "../../../packages/coach-client/dist/index.js";
 import { createClientHandshakeFrame } from "../../../packages/coach-contract/dist/index.js";
+import {
+  cleanupSecuritySmokeEnvironment,
+  createElectronLaunchArguments,
+  createSecuritySmokeEnvironment,
+  createSecuritySmokeLaunchEnvironment,
+} from "../smoke/security-smoke-environment.mjs";
 
 const require = createRequire(import.meta.url);
 const desktopRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const command = process.argv[2];
-const options = Object.fromEntries(process.argv.slice(3).filter((value) => value.startsWith("--") && value.includes("=")).map((value) => {
-  const separator = value.indexOf("=");
-  return [value.slice(2, separator), value.slice(separator + 1)];
-}));
+const options = Object.fromEntries(
+  process.argv
+    .slice(3)
+    .filter((value) => value.startsWith("--") && value.includes("="))
+    .map((value) => {
+      const separator = value.indexOf("=");
+      return [value.slice(2, separator), value.slice(separator + 1)];
+    }),
+);
 const mode = options.mode ?? "development";
 
 async function packagedExecutable() {
   const root = join(desktopRoot, "dist");
   const entries = await readdir(root, { recursive: true });
-  const relative = entries.find((entry) => entry.endsWith("Enduragent.app/Contents/MacOS/Enduragent"));
+  const relative = entries.find((entry) =>
+    entry.endsWith("Enduragent.app/Contents/MacOS/Enduragent"),
+  );
   if (relative === undefined) throw new Error("packaged Enduragent executable not found");
   return join(root, relative);
 }
 
 async function startElectron(flag, env, extraArgs = []) {
   const executable = mode === "packaged" ? await packagedExecutable() : require("electron");
-  const args = mode === "packaged" ? [flag, ...extraArgs] : [desktopRoot, flag, ...extraArgs];
+  const args = createElectronLaunchArguments(mode, desktopRoot, flag, extraArgs);
   const child = spawn(executable, args, { env, stdio: ["pipe", "pipe", "pipe"] });
   let stdout = "";
   let stderr = "";
@@ -46,24 +59,30 @@ async function startElectron(flag, env, extraArgs = []) {
       for (const waiter of [...waiters]) waiter();
     }
   });
-  child.stderr.on("data", (chunk) => { stderr += String(chunk); });
+  child.stderr.on("data", (chunk) => {
+    stderr += String(chunk);
+  });
   const exited = new Promise((resolveExit, reject) => {
     child.once("error", reject);
     child.once("exit", (code, signal) => resolveExit({ code, signal }));
   });
-  const waitForLine = (prefix) => new Promise((resolveLine, reject) => {
-    const deadline = setTimeout(() => reject(new Error(`timed out waiting for ${prefix}`)), 30_000);
-    const inspect = () => {
-      const line = lines.find((candidate) => candidate.startsWith(`${prefix} `));
-      if (line === undefined) return;
-      clearTimeout(deadline);
-      const index = waiters.indexOf(inspect);
-      if (index >= 0) waiters.splice(index, 1);
-      resolveLine(JSON.parse(line.slice(prefix.length + 1)));
-    };
-    waiters.push(inspect);
-    inspect();
-  });
+  const waitForLine = (prefix) =>
+    new Promise((resolveLine, reject) => {
+      const deadline = setTimeout(
+        () => reject(new Error(`timed out waiting for ${prefix}`)),
+        30_000,
+      );
+      const inspect = () => {
+        const line = lines.find((candidate) => candidate.startsWith(`${prefix} `));
+        if (line === undefined) return;
+        clearTimeout(deadline);
+        const index = waiters.indexOf(inspect);
+        if (index >= 0) waiters.splice(index, 1);
+        resolveLine(JSON.parse(line.slice(prefix.length + 1)));
+      };
+      waiters.push(inspect);
+      inspect();
+    });
   return {
     child,
     args,
@@ -78,7 +97,8 @@ async function launch(flag, env) {
   const running = await startElectron(flag, env);
   const result = await running.exited;
   const { stdout, stderr } = running.output();
-  if (result.code !== 0 || result.signal !== null) throw new Error(`Electron smoke failed: ${result.code}/${result.signal}\n${stderr}`);
+  if (result.code !== 0 || result.signal !== null)
+    throw new Error(`Electron smoke failed: ${result.code}/${result.signal}\n${stderr}`);
   return { stdout, stderr };
 }
 
@@ -90,9 +110,18 @@ function summaryLine(stdout, prefix) {
 }
 
 async function runtime() {
-  const result = await launch("--desktop-runtime-smoke", { ...process.env, FORCE_COLOR: undefined, CLICOLOR_FORCE: undefined });
+  const result = await launch("--desktop-runtime-smoke", {
+    ...process.env,
+    FORCE_COLOR: undefined,
+    CLICOLOR_FORCE: undefined,
+  });
   const summary = summaryLine(result.stdout, "DESKTOP_RUNTIME_SMOKE");
-  if (summary.electron !== "43.1.1" || summary.node !== "24.18.0" || summary.result !== "tempo threshold" || existsSync(summary.directory)) {
+  if (
+    summary.electron !== "43.1.1" ||
+    summary.node !== "24.18.0" ||
+    summary.result !== "tempo threshold" ||
+    existsSync(summary.directory)
+  ) {
     throw new Error("desktop runtime assertions failed");
   }
   process.stdout.write(`DESKTOP_RUNTIME_SMOKE ${JSON.stringify(summary)}\n`);
@@ -105,20 +134,24 @@ async function spoofOriginResponse(url) {
     let response = "";
     socket.setEncoding("ascii");
     socket.once("error", reject);
-    socket.on("data", (chunk) => { response += chunk; });
+    socket.on("data", (chunk) => {
+      response += chunk;
+    });
     socket.once("close", () => resolveResponse(response));
     socket.once("connect", () => {
-      socket.end([
-        "GET /rpc HTTP/1.1",
-        `Host: 127.0.0.1:${target.port}`,
-        "Upgrade: websocket",
-        "Connection: Upgrade",
-        "Sec-WebSocket-Key: c3ludGhldGljLXNtb2tl",
-        "Sec-WebSocket-Version: 13",
-        "Origin: https://spoof.invalid",
-        "",
-        "",
-      ].join("\r\n"));
+      socket.end(
+        [
+          "GET /rpc HTTP/1.1",
+          `Host: 127.0.0.1:${target.port}`,
+          "Upgrade: websocket",
+          "Connection: Upgrade",
+          "Sec-WebSocket-Key: c3ludGhldGljLXNtb2tl",
+          "Sec-WebSocket-Version: 13",
+          "Origin: https://spoof.invalid",
+          "",
+          "",
+        ].join("\r\n"),
+      );
     });
   });
 }
@@ -130,13 +163,21 @@ async function wrongTokenCloseCode(url) {
       socket.close();
       reject(new Error("wrong-token socket did not close"));
     }, 5_000);
-    socket.addEventListener("open", () => {
-      socket.send(JSON.stringify(createClientHandshakeFrame("w".repeat(43))));
-    }, { once: true });
-    socket.addEventListener("close", (event) => {
-      clearTimeout(timer);
-      resolveCode(event.code);
-    }, { once: true });
+    socket.addEventListener(
+      "open",
+      () => {
+        socket.send(JSON.stringify(createClientHandshakeFrame("w".repeat(43))));
+      },
+      { once: true },
+    );
+    socket.addEventListener(
+      "close",
+      (event) => {
+        clearTimeout(timer);
+        resolveCode(event.code);
+      },
+      { once: true },
+    );
   });
 }
 
@@ -144,11 +185,15 @@ async function operationalObserverOrder(url, token) {
   const client = await connectCoachClient({ url, token });
   const order = [];
   try {
-    await client.call("sync", {}, {
-      onNotificationEnvelope: (envelope) => order.push(`envelope:${envelope.params.event.phase}`),
-      onEvent: (event) => order.push(`event:${event.phase}`),
-      onTerminalEnvelope: () => order.push("terminal"),
-    });
+    await client.call(
+      "sync",
+      {},
+      {
+        onNotificationEnvelope: (envelope) => order.push(`envelope:${envelope.params.event.phase}`),
+        onEvent: (event) => order.push(`event:${event.phase}`),
+        onTerminalEnvelope: () => order.push("terminal"),
+      },
+    );
   } finally {
     await client.close();
   }
@@ -158,46 +203,47 @@ async function operationalObserverOrder(url, token) {
 async function security() {
   const base = await realpath(process.platform === "darwin" ? "/tmp" : tmpdir());
   const scratch = await mkdtemp(join(base, "eas-"));
-  const home = join(scratch, "athlete-home");
-  const configDir = join(home, "config");
-  const operatorHome = join(scratch, "operator-home");
+  const environment = createSecuritySmokeEnvironment(scratch, options.output);
   let running;
   try {
     await Promise.all([
-      mkdir(configDir, { recursive: true, mode: 0o700 }),
-      mkdir(operatorHome, { recursive: true, mode: 0o700 }),
+      mkdir(environment.configDirectory, { recursive: true, mode: 0o700 }),
+      mkdir(environment.operatorHome, { recursive: true, mode: 0o700 }),
+      mkdir(environment.electronUserData, { recursive: true, mode: 0o700 }),
     ]);
-    await writeFile(join(configDir, "config.yaml"), [
-      "data_source: store",
-      `data_dir: ${JSON.stringify(home)}`,
-      "llm:",
-      "  provider: anthropic",
-      "  model: synthetic",
-      "  api_key: synthetic",
-      "intervals:",
-      "  api_key: ''",
-      "  athlete_id: synthetic",
-      "session:",
-      "  timezone: UTC",
-      "",
-    ].join("\n"));
-    const screenshotPath = join(options.output ?? scratch, "desktop-security.png");
-    if (options.output !== undefined) await mkdir(options.output, { recursive: true });
-    const launchEnvironment = {
-      ...process.env,
-      HOME: operatorHome,
-      ENDURAGENT_HOME: home,
-      CYCLING_COACH_HOME: join(scratch, "legacy-home"),
-      FORCE_COLOR: undefined,
-      CLICOLOR_FORCE: undefined,
-    };
+    await writeFile(
+      join(environment.configDirectory, "config.yaml"),
+      [
+        "data_source: store",
+        `data_dir: ${JSON.stringify(environment.athleteHome)}`,
+        "llm:",
+        "  provider: anthropic",
+        "  model: synthetic",
+        "  api_key: synthetic",
+        "intervals:",
+        "  api_key: ''",
+        "  athlete_id: synthetic",
+        "session:",
+        "  timezone: UTC",
+        "",
+      ].join("\n"),
+    );
+    if (environment.outputDirectory !== undefined)
+      await mkdir(environment.outputDirectory, { recursive: true });
+    const launchEnvironment = createSecuritySmokeLaunchEnvironment(
+      process.env,
+      environment,
+      process.platform,
+    );
     running = await startElectron(
       "--desktop-security-smoke",
       launchEnvironment,
-      [`--desktop-security-output=${screenshotPath}`],
+      environment.extraArguments,
     );
     const ready = await running.waitForLine("DESKTOP_SECURITY_READY");
-    const token = (await readFile(join(configDir, "daemon.token"), "utf8")).trim();
+    const token = (
+      await readFile(join(environment.configDirectory, "daemon.token"), "utf8")
+    ).trim();
     const [spoofed, wrongCode, observerOrder] = await Promise.all([
       spoofOriginResponse(ready.rpcUrl),
       wrongTokenCloseCode(ready.rpcUrl),
@@ -209,7 +255,8 @@ async function security() {
     if (exit.code !== 0 || exit.signal !== null) {
       throw new Error(`Electron smoke failed: ${exit.code}/${exit.signal}\n${result.stderr}`);
     }
-    const expectedForbidden = "HTTP/1.1 403 Forbidden\r\nConnection: close\r\nContent-Length: 0\r\n\r\n";
+    const expectedForbidden =
+      "HTTP/1.1 403 Forbidden\r\nConnection: close\r\nContent-Length: 0\r\n\r\n";
     const expectedOrder = [
       "envelope:started",
       "event:started",
@@ -224,7 +271,18 @@ async function security() {
         spoofOrigin: spoofed === expectedForbidden,
         wrongToken: wrongCode === 1008,
         observerOrder: JSON.stringify(observerOrder) === JSON.stringify(expectedOrder),
-        preloadBridge: JSON.stringify(ready.bridgeKeys) === JSON.stringify(["chatgptLogin", "chatgptStatus", "chooseImportFiles", "credentialStatuses", "getDaemonConnection", "onDroppedImportFiles", "retryFailedCredentials", "writeCredential"]),
+        preloadBridge:
+          JSON.stringify(ready.bridgeKeys) ===
+          JSON.stringify([
+            "chatgptLogin",
+            "chatgptStatus",
+            "chooseImportFiles",
+            "credentialStatuses",
+            "getDaemonConnection",
+            "onDroppedImportFiles",
+            "retryFailedCredentials",
+            "writeCredential",
+          ]),
         credentialMetadata: ready.credentialStatusesMetadataOnly === true,
       },
       url: ready.url,
@@ -237,12 +295,22 @@ async function security() {
         !result.stdout.includes(token) &&
         !result.stderr.includes(token) &&
         !JSON.stringify(ready.credentialStatuses).includes(token) &&
-        !screenshotPath.includes(token),
+        !environment.screenshotPath.includes(token),
     };
-    if (Object.values(summary.passes).some((value) => value !== true) || summary.blockedOffPort !== true || summary.drawerPresent !== true || summary.tokenAbsent !== true || !existsSync(screenshotPath)) {
+    if (
+      Object.values(summary.passes).some((value) => value !== true) ||
+      summary.blockedOffPort !== true ||
+      summary.drawerPresent !== true ||
+      summary.tokenAbsent !== true ||
+      !existsSync(environment.screenshotPath)
+    ) {
       throw new Error("desktop security assertions failed");
     }
-    if (options.output !== undefined) await writeFile(join(options.output, "summary.json"), `${JSON.stringify(summary, null, 2)}\n`);
+    if (environment.outputDirectory !== undefined)
+      await writeFile(
+        join(environment.outputDirectory, "summary.json"),
+        `${JSON.stringify(summary, null, 2)}\n`,
+      );
     process.stdout.write(`DESKTOP_SECURITY_SMOKE ${JSON.stringify(summary)}\n`);
   } finally {
     if (running !== undefined) {
@@ -253,7 +321,7 @@ async function security() {
       ]);
       if (!settled) running.child.kill();
     }
-    await rm(scratch, { recursive: true, force: true });
+    await cleanupSecuritySmokeEnvironment(environment);
   }
 }
 

--- a/apps/desktop/smoke/security-smoke-environment.d.mts
+++ b/apps/desktop/smoke/security-smoke-environment.d.mts
@@ -1,0 +1,41 @@
+export interface SecuritySmokeEnvironment {
+  readonly scratchRoot: string;
+  readonly athleteHome: string;
+  readonly configDirectory: string;
+  readonly operatorHome: string;
+  readonly legacyHome: string;
+  readonly electronUserData: string;
+  readonly outputDirectory: string | undefined;
+  readonly screenshotDirectory: string;
+  readonly screenshotPath: string;
+  readonly launchEnvironment: Readonly<{
+    HOME: string;
+    ENDURAGENT_HOME: string;
+    CYCLING_COACH_HOME: string;
+    FORCE_COLOR: undefined;
+    CLICOLOR_FORCE: undefined;
+  }>;
+  readonly extraArguments: readonly [string, string];
+}
+
+export function createElectronLaunchArguments(
+  mode: "development" | "packaged",
+  desktopRoot: string,
+  flag: string,
+  extraArguments?: readonly string[],
+): string[];
+
+export function createSecuritySmokeEnvironment(
+  scratchRoot: string,
+  outputDirectory?: string,
+): SecuritySmokeEnvironment;
+
+export function createSecuritySmokeLaunchEnvironment(
+  sourceEnvironment: Readonly<Record<string, string | undefined>>,
+  securityEnvironment: Pick<SecuritySmokeEnvironment, "launchEnvironment">,
+  platform: NodeJS.Platform,
+): Record<string, string | undefined>;
+
+export function cleanupSecuritySmokeEnvironment(
+  environment: Pick<SecuritySmokeEnvironment, "scratchRoot">,
+): Promise<void>;

--- a/apps/desktop/smoke/security-smoke-environment.mjs
+++ b/apps/desktop/smoke/security-smoke-environment.mjs
@@ -1,0 +1,74 @@
+import { rm } from "node:fs/promises";
+import { join, resolve } from "node:path";
+
+const LINUX_LAUNCH_ENVIRONMENT_KEYS = [
+  "DISPLAY",
+  "WAYLAND_DISPLAY",
+  "XDG_SESSION_TYPE",
+  "XDG_RUNTIME_DIR",
+  "DBUS_SESSION_BUS_ADDRESS",
+  "XAUTHORITY",
+];
+const WINDOWS_LAUNCH_ENVIRONMENT_KEYS = ["SystemRoot", "WINDIR"];
+
+export function createElectronLaunchArguments(mode, desktopRoot, flag, extraArguments = []) {
+  return mode === "packaged" ? [flag, ...extraArguments] : [desktopRoot, flag, ...extraArguments];
+}
+
+export function createSecuritySmokeEnvironment(scratchRoot, outputDirectory) {
+  const normalizedScratchRoot = resolve(scratchRoot);
+  const athleteHome = join(normalizedScratchRoot, "athlete-home");
+  const configDirectory = join(athleteHome, "config");
+  const operatorHome = join(normalizedScratchRoot, "operator-home");
+  const legacyHome = join(normalizedScratchRoot, "legacy-home");
+  const electronUserData = join(normalizedScratchRoot, "electron-user-data");
+  const screenshotDirectory = outputDirectory ?? normalizedScratchRoot;
+  const screenshotPath = join(screenshotDirectory, "desktop-security.png");
+  return {
+    scratchRoot: normalizedScratchRoot,
+    athleteHome,
+    configDirectory,
+    operatorHome,
+    legacyHome,
+    electronUserData,
+    outputDirectory,
+    screenshotDirectory,
+    screenshotPath,
+    launchEnvironment: {
+      HOME: operatorHome,
+      ENDURAGENT_HOME: athleteHome,
+      CYCLING_COACH_HOME: legacyHome,
+      FORCE_COLOR: undefined,
+      CLICOLOR_FORCE: undefined,
+    },
+    extraArguments: [
+      `--desktop-security-output=${screenshotPath}`,
+      `--user-data-dir=${electronUserData}`,
+    ],
+  };
+}
+
+export function createSecuritySmokeLaunchEnvironment(
+  sourceEnvironment,
+  securityEnvironment,
+  platform,
+) {
+  const launchEnvironment = {};
+  const inheritedKeys =
+    platform === "linux"
+      ? LINUX_LAUNCH_ENVIRONMENT_KEYS
+      : platform === "win32"
+        ? WINDOWS_LAUNCH_ENVIRONMENT_KEYS
+        : [];
+
+  for (const key of inheritedKeys) {
+    const value = sourceEnvironment[key];
+    if (value !== undefined) launchEnvironment[key] = value;
+  }
+
+  return { ...launchEnvironment, ...securityEnvironment.launchEnvironment };
+}
+
+export async function cleanupSecuritySmokeEnvironment(environment) {
+  await rm(environment.scratchRoot, { recursive: true, force: true });
+}

--- a/apps/desktop/tests/security-smoke-environment.test.ts
+++ b/apps/desktop/tests/security-smoke-environment.test.ts
@@ -1,0 +1,207 @@
+import { mkdir, mkdtemp, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { isAbsolute, join, relative, resolve, sep } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  cleanupSecuritySmokeEnvironment,
+  createElectronLaunchArguments,
+  createSecuritySmokeEnvironment,
+  createSecuritySmokeLaunchEnvironment,
+} from "../smoke/security-smoke-environment.mjs";
+
+const sourceEnvironment = {
+  LLM_PROVIDER: "sentinel-llm-provider",
+  ANTHROPIC_API_KEY: "sentinel-anthropic-api-key",
+  OPENAI_API_KEY: "sentinel-openai-api-key",
+  GOOGLE_GENERATIVE_AI_API_KEY: "sentinel-google-generative-ai-api-key",
+  DEEPSEEK_API_KEY: "sentinel-deepseek-api-key",
+  ALIBABA_API_KEY: "sentinel-alibaba-api-key",
+  MINIMAX_API_KEY: "sentinel-minimax-api-key",
+  MOONSHOT_API_KEY: "sentinel-moonshot-api-key",
+  ZAI_API_KEY: "sentinel-zai-api-key",
+  OPENROUTER_API_KEY: "sentinel-openrouter-api-key",
+  LLM_API_KEY: "sentinel-llm-api-key",
+  INTERVALS_API_KEY: "sentinel-intervals-api-key",
+  TELEGRAM_BOT_TOKEN: "sentinel-telegram-bot-token",
+  LLM_MODEL: "sentinel-llm-model",
+  LLM_FLUSH_MODEL: "sentinel-llm-flush-model",
+  LLM_COMPACT_MODEL: "sentinel-llm-compact-model",
+  LLM_BASE_URL: "sentinel-llm-base-url",
+  INTERVALS_ATHLETE_ID: "sentinel-intervals-athlete-id",
+  HISTORY_TOKEN_BUDGET_RATIO: "sentinel-history-token-budget-ratio",
+  SESSION_IDLE_MINUTES: "sentinel-session-idle-minutes",
+  SESSION_DAILY_RESET_HOUR: "sentinel-session-daily-reset-hour",
+  SESSION_RESET_ARCHIVE_RETENTION_DAYS: "sentinel-session-reset-archive-retention-days",
+  COACH_TZ: "sentinel-coach-tz",
+  CONTEXT_WINDOW_TOKENS: "sentinel-context-window-tokens",
+  MY_LLM_KEY: "sentinel-my-llm-key",
+  ELECTRON_RENDERER_URL: "sentinel-electron-renderer-url",
+  NODE_OPTIONS: "sentinel-node-options",
+  ELECTRON_RUN_AS_NODE: "sentinel-electron-run-as-node",
+  LD_PRELOAD: "sentinel-ld-preload",
+  DYLD_INSERT_LIBRARIES: "sentinel-dyld-insert-libraries",
+  PATH: "sentinel-path",
+  HTTP_PROXY: "sentinel-http-proxy",
+  HTTPS_PROXY: "sentinel-https-proxy",
+  ALL_PROXY: "sentinel-all-proxy",
+  NO_PROXY: "sentinel-no-proxy",
+  LANG: "sentinel-lang",
+  LANGUAGE: "sentinel-language",
+  LC_ALL: "sentinel-lc-all",
+  HOME: "sentinel-home",
+  ENDURAGENT_HOME: "sentinel-enduragent-home",
+  CYCLING_COACH_HOME: "sentinel-cycling-coach-home",
+  FORCE_COLOR: "sentinel-force-color",
+  CLICOLOR_FORCE: "sentinel-clicolor-force",
+  UNRELATED_VARIABLE: "sentinel-unrelated-variable",
+  DISPLAY: "sentinel-display",
+  WAYLAND_DISPLAY: "sentinel-wayland-display",
+  XDG_SESSION_TYPE: "sentinel-xdg-session-type",
+  XDG_RUNTIME_DIR: "sentinel-xdg-runtime-dir",
+  DBUS_SESSION_BUS_ADDRESS: "sentinel-dbus-session-bus-address",
+  XAUTHORITY: "sentinel-xauthority",
+  SystemRoot: "sentinel-system-root",
+  WINDIR: "sentinel-windir",
+};
+
+function isContained(root: string, path: string): boolean {
+  const relation = relative(root, path);
+  return (
+    relation === "" ||
+    (relation !== ".." && !relation.startsWith(`..${sep}`) && !isAbsolute(relation))
+  );
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe("desktop security smoke environment", () => {
+  it.each([
+    ["darwin", {}],
+    [
+      "linux",
+      {
+        DISPLAY: sourceEnvironment.DISPLAY,
+        WAYLAND_DISPLAY: sourceEnvironment.WAYLAND_DISPLAY,
+        XDG_SESSION_TYPE: sourceEnvironment.XDG_SESSION_TYPE,
+        XDG_RUNTIME_DIR: sourceEnvironment.XDG_RUNTIME_DIR,
+        DBUS_SESSION_BUS_ADDRESS: sourceEnvironment.DBUS_SESSION_BUS_ADDRESS,
+        XAUTHORITY: sourceEnvironment.XAUTHORITY,
+      },
+    ],
+    [
+      "win32",
+      {
+        SystemRoot: sourceEnvironment.SystemRoot,
+        WINDIR: sourceEnvironment.WINDIR,
+      },
+    ],
+  ] satisfies readonly [NodeJS.Platform, Record<string, string>][])(
+    "builds the exact isolated launch environment on %s",
+    (platform, inheritedEnvironment) => {
+      const environment = createSecuritySmokeEnvironment("synthetic-scratch");
+
+      expect(
+        createSecuritySmokeLaunchEnvironment(sourceEnvironment, environment, platform),
+      ).toEqual({
+        ...inheritedEnvironment,
+        HOME: environment.operatorHome,
+        ENDURAGENT_HOME: environment.athleteHome,
+        CYCLING_COACH_HOME: environment.legacyHome,
+        FORCE_COLOR: undefined,
+        CLICOLOR_FORCE: undefined,
+      });
+    },
+  );
+
+  it("normalizes private paths and builds the exact launch arguments for both modes", () => {
+    const scratchSpelling = join(".", "relative scratch=fixture", "nested path=component");
+    const scratchRoot = resolve(scratchSpelling);
+    const desktopRoot = join("desktop root=fixture", "nested app=component");
+    const flag = "--desktop-security-smoke";
+    const environment = createSecuritySmokeEnvironment(scratchSpelling);
+    const privatePaths = [
+      environment.scratchRoot,
+      environment.athleteHome,
+      environment.configDirectory,
+      environment.operatorHome,
+      environment.legacyHome,
+      environment.electronUserData,
+      environment.screenshotDirectory,
+      environment.screenshotPath,
+    ];
+    const expectedExtraArguments = [
+      `--desktop-security-output=${join(scratchRoot, "desktop-security.png")}`,
+      `--user-data-dir=${join(scratchRoot, "electron-user-data")}`,
+    ];
+    const developmentArguments = createElectronLaunchArguments(
+      "development",
+      desktopRoot,
+      flag,
+      environment.extraArguments,
+    );
+    const packagedArguments = createElectronLaunchArguments(
+      "packaged",
+      desktopRoot,
+      flag,
+      environment.extraArguments,
+    );
+
+    expect(isAbsolute(scratchSpelling)).toBe(false);
+    expect(environment.scratchRoot).toBe(scratchRoot);
+    expect(environment.extraArguments).toEqual(expectedExtraArguments);
+    expect(developmentArguments).toEqual([desktopRoot, flag, ...expectedExtraArguments]);
+    expect(packagedArguments).toEqual([flag, ...expectedExtraArguments]);
+    for (const argumentsForMode of [developmentArguments, packagedArguments]) {
+      expect(
+        argumentsForMode.filter((argument) => argument.startsWith("--desktop-security-output=")),
+      ).toHaveLength(1);
+      expect(
+        argumentsForMode.filter((argument) => argument.startsWith("--user-data-dir=")),
+      ).toHaveLength(1);
+    }
+    expect(privatePaths.every((path) => isContained(scratchRoot, path))).toBe(true);
+    expect(isContained(scratchRoot, `${scratchRoot}-decoy`)).toBe(false);
+    expect(environment.launchEnvironment).toEqual({
+      HOME: environment.operatorHome,
+      ENDURAGENT_HOME: environment.athleteHome,
+      CYCLING_COACH_HOME: environment.legacyHome,
+      FORCE_COLOR: undefined,
+      CLICOLOR_FORCE: undefined,
+    });
+  });
+
+  it("removes only scratch while preserving a decoy and external output", async () => {
+    const fixtureRoot = await mkdtemp(join(tmpdir(), "desktop-security-cleanup-"));
+    const scratchRoot = join(fixtureRoot, "scratch");
+    const externalOutput = join(fixtureRoot, "external-output");
+    const decoyVault = join(fixtureRoot, "operator-decoy", "vault");
+    const environment = createSecuritySmokeEnvironment(scratchRoot, externalOutput);
+
+    try {
+      await Promise.all([
+        mkdir(environment.electronUserData, { recursive: true }),
+        mkdir(decoyVault, { recursive: true }),
+        mkdir(externalOutput, { recursive: true }),
+      ]);
+
+      expect(environment.extraArguments[0]).toBe(
+        `--desktop-security-output=${join(externalOutput, "desktop-security.png")}`,
+      );
+      expect(environment.outputDirectory).toBe(externalOutput);
+      await cleanupSecuritySmokeEnvironment(environment);
+      expect(await exists(environment.scratchRoot)).toBe(false);
+      expect(await exists(environment.electronUserData)).toBe(false);
+      expect(await exists(decoyVault)).toBe(true);
+      expect(await exists(externalOutput)).toBe(true);
+    } finally {
+      await rm(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- isolates the Desktop security smoke's Electron profile and private paths under a per-run scratch directory
- replaces inherited operator configuration with a tested, positive platform environment allowlist
- exercises exact development and packaged arguments, cross-platform environment filtering, and owned cleanup
- normalizes the already-touched smoke launcher so changed-file formatting gates are green

## Verification

- focused security-smoke environment tests: 5/5
- three independent source-read-only review passes
- `pnpm check`
- Desktop production build
- development Electron security smoke: all seven security assertions passed; off-port blocking, drawer presence, and token absence passed
- retained screenshot and structured summary verified non-empty

No changeset: this changes a development verification harness, not athlete-visible behavior.
