### PR TITLE
fix(desktop): recover revoked ChatGPT sign-ins

### DIFF
--- a/.changeset/reauth-refresh-rejection.md
+++ b/.changeset/reauth-refresh-rejection.md
@@ -1,0 +1,7 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: A ChatGPT sign-in recovery path now appears when a saved ChatGPT sign-in can no longer be refreshed, and failed chat notices appear only once.
+
+Classify refresh failures structurally through profile and engine retries, preserve transient retry eligibility, keep partial coach drafts without empty transcript rows, and add a guarded Sign in again action to configured onboarding.

--- a/apps/desktop-renderer/src/chat/view.ts
+++ b/apps/desktop-renderer/src/chat/view.ts
@@ -86,19 +86,21 @@ export function mountChatView(input: {
             input.conversation.scrollTop -
             input.conversation.clientHeight <=
           80;
-        const rows = state.messages.map((message) => {
-          const article = document.createElement("article");
-          article.className = `chat-message chat-message--${message.role}`;
-          article.dataset.delivery = message.delivery;
-          const role = document.createElement("p");
-          role.className = "chat-message__role";
-          role.textContent = message.role === "athlete" ? "You" : "Coach";
-          const text = document.createElement("p");
-          text.className = "chat-message__text";
-          text.textContent = message.text;
-          article.append(role, text);
-          return article;
-        });
+        const rows = state.messages
+          .filter((message) => message.role === "athlete" || message.text.length > 0)
+          .map((message) => {
+            const article = document.createElement("article");
+            article.className = `chat-message chat-message--${message.role}`;
+            article.dataset.delivery = message.delivery;
+            const role = document.createElement("p");
+            role.className = "chat-message__role";
+            role.textContent = message.role === "athlete" ? "You" : "Coach";
+            const text = document.createElement("p");
+            text.className = "chat-message__text";
+            text.textContent = message.text;
+            article.append(role, text);
+            return article;
+          });
         messages.replaceChildren(...rows);
         if (followsLatest) input.conversation.scrollTop = input.conversation.scrollHeight;
         const contractCopy = state.activeTurn?.error?.athleteMessage ?? null;

--- a/apps/desktop-renderer/src/onboarding/mount.ts
+++ b/apps/desktop-renderer/src/onboarding/mount.ts
@@ -307,6 +307,58 @@ export function mountOnboarding(options: MountOnboardingOptions): OnboardingCont
     return label;
   };
 
+  const startChatGptLogin = (): void => {
+    if (disposed || scrim === undefined || state.busy || state.chatGptState === "pending") {
+      return;
+    }
+    const loginVisit = visit;
+    state = withChatGptPending(state);
+    render();
+    void options.bridge.chatGptLogin().then(
+      async (result) => {
+        if (
+          disposed ||
+          visit !== loginVisit ||
+          scrim === undefined ||
+          state.chatGptState !== "pending"
+        ) {
+          return;
+        }
+        state = withChatGptLoginResult(state, result);
+        if (result.status === "configured") {
+          await refreshStatuses(loginVisit).catch(() => undefined);
+        }
+        if (disposed || visit !== loginVisit || scrim === undefined) return;
+        render();
+        focusCurrentTitle();
+      },
+      () => {
+        if (
+          disposed ||
+          visit !== loginVisit ||
+          scrim === undefined ||
+          state.chatGptState !== "pending"
+        ) {
+          return;
+        }
+        state = withChatGptLoginResult(state, {
+          status: "refused",
+          reason: "exchange-failed",
+        });
+        render();
+        focusCurrentTitle();
+      },
+    );
+  };
+
+  const chatGptLoginButton = (text: string): HTMLButtonElement => {
+    const button = make(options.document, "button", "primary-button chatgpt-signin-button", text);
+    button.type = "button";
+    button.disabled = state.busy;
+    button.addEventListener("click", startChatGptLogin);
+    return button;
+  };
+
   const renderCoachKeys = (body: HTMLElement): void => {
     body.append(
       make(options.document, "p", "onboarding-kicker", "Coach keys"),
@@ -348,6 +400,7 @@ export function mountOnboarding(options: MountOnboardingOptions): OnboardingCont
     } else if (state.chatGptState === "configured" && state.chatGptRuntimeReady) {
       chatGptLane.append(
         make(options.document, "p", "chatgpt-login-state configured", "ChatGPT is ready."),
+        chatGptLoginButton("Sign in again"),
       );
     } else {
       if (state.chatGptState === "refused" && state.chatGptRefusal !== null) {
@@ -370,40 +423,9 @@ export function mountOnboarding(options: MountOnboardingOptions): OnboardingCont
           ),
         );
       }
-      const login = make(
-        options.document,
-        "button",
-        "primary-button chatgpt-signin-button",
+      const login = chatGptLoginButton(
         state.chatGptState === "absent" ? "Sign in with ChatGPT" : "Retry ChatGPT sign-in",
       );
-      login.type = "button";
-      login.disabled = state.busy;
-      login.addEventListener("click", () => {
-        const loginVisit = visit;
-        state = withChatGptPending(state);
-        render();
-        void options.bridge.chatGptLogin().then(
-          async (result) => {
-            if (visit !== loginVisit || scrim === undefined) return;
-            state = withChatGptLoginResult(state, result);
-            if (result.status === "configured") {
-              await refreshStatuses(loginVisit).catch(() => undefined);
-            }
-            if (visit !== loginVisit || scrim === undefined) return;
-            render();
-            focusCurrentTitle();
-          },
-          () => {
-            if (visit !== loginVisit || scrim === undefined) return;
-            state = withChatGptLoginResult(state, {
-              status: "refused",
-              reason: "exchange-failed",
-            });
-            render();
-            focusCurrentTitle();
-          },
-        );
-      });
       chatGptLane.append(login);
     }
     body.append(chatGptLane);

--- a/apps/desktop-renderer/src/turn-state.ts
+++ b/apps/desktop-renderer/src/turn-state.ts
@@ -179,12 +179,11 @@ export function reduceChatState(state: ChatState, action: ChatAction): ChatState
     case "fail": {
       const active = current(state, action.requestKey);
       if (active === null) return state;
-      const text = active.draft.length > 0 ? active.draft : action.copy;
       return {
         ...state,
         status: "idle",
         progress: active.error === null ? action.copy : null,
-        messages: updateAssistant(state, active, text, "complete"),
+        messages: updateAssistant(state, active, active.draft, "interrupted"),
       };
     }
     default:

--- a/apps/desktop-renderer/tests/chat-controller.test.ts
+++ b/apps/desktop-renderer/tests/chat-controller.test.ts
@@ -27,7 +27,7 @@ function envelope(event: TurnEvent, requestId = 1): CoachTurnEventNotificationEn
   };
 }
 
-function errorEvent(message = "Safe athlete message"): TurnEvent {
+function errorEvent(message = "Safe athlete message"): Extract<TurnEvent, { type: "error" }> {
   return {
     type: "error",
     turnId: "turn-1",
@@ -91,6 +91,51 @@ function subject(
 }
 
 describe("chat controller", () => {
+  it("renders the reauthentication copy instead of the generic failure copy", async () => {
+    const reauthenticationCopy =
+      "Your ChatGPT sign-in is no longer valid. Open Setup and sign in again.";
+    const fake = client(async (_request, options) => {
+      deliver(options, {
+        ...errorEvent(reauthenticationCopy),
+        kind: "provider-auth",
+      });
+      options?.onTerminalEnvelope?.({
+        jsonrpc: "2.0",
+        id: 1,
+        error: { code: -32603, message: "Internal error" },
+      });
+      throw new Error("remote detail");
+    });
+    const { controller, states } = subject(fake);
+
+    await controller.submit("Help");
+
+    expect(states.at(-1)?.messages.at(-1)?.text).toBe("");
+    expect(states.at(-1)?.activeTurn?.error?.athleteMessage).toBe(reauthenticationCopy);
+    expect(states.at(-1)?.progress).toBeNull();
+    expect(states.at(-1)?.status).toBe("idle");
+  });
+
+  it("keeps a transient provider failure retryable without reauthentication copy", async () => {
+    const transientCopy = "The model provider is having trouble — try again in a few minutes.";
+    const fake = client(async (_request, options) => {
+      deliver(options, errorEvent(transientCopy));
+      options?.onTerminalEnvelope?.({
+        jsonrpc: "2.0",
+        id: 1,
+        error: { code: -32603, message: "Internal error" },
+      });
+      throw new Error("remote detail");
+    });
+    const { controller, states } = subject(fake);
+
+    await controller.submit("Help");
+
+    expect(states.at(-1)?.messages.at(-1)?.text).toBe("");
+    expect(states.at(-1)?.activeTurn?.error?.athleteMessage).toBe(transientCopy);
+    expect(states.at(-1)?.activeTurn?.error?.athleteMessage).not.toContain("sign in again");
+  });
+
   it("does not wait for spend refresh before settling a completed chat", async () => {
     const gate = new Promise<void>(() => {});
     const fake = client(async (_request, options) => {

--- a/apps/desktop-renderer/tests/chat-view.test.ts
+++ b/apps/desktop-renderer/tests/chat-view.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { mountChatView } from "../src/chat/view.js";
-import type { ChatState } from "../src/turn-state.js";
+import { EMPTY_CHAT_STATE, reduceChatState, type ChatState } from "../src/turn-state.js";
 
 class FakeElement {
   readonly children: FakeElement[] = [];
@@ -91,6 +91,28 @@ function find(root: FakeElement, predicate: (node: FakeElement) => boolean): Fak
   throw new Error("Element not found");
 }
 
+function findAll(root: FakeElement, predicate: (node: FakeElement) => boolean): FakeElement[] {
+  return [
+    ...(predicate(root) ? [root] : []),
+    ...root.children.flatMap((child) => findAll(child, predicate)),
+  ];
+}
+
+function occurrences(value: string, part: string): number {
+  return value.split(part).length - 1;
+}
+
+function submittedState(): ChatState {
+  return reduceChatState(EMPTY_CHAT_STATE, {
+    type: "submit",
+    requestKey: 1,
+    userMessage: "How should I train?",
+    userMessageId: "message-1",
+    assistantMessageId: "message-2",
+    includeUser: true,
+  });
+}
+
 const emptyState: ChatState = {
   status: "idle",
   messages: [],
@@ -106,6 +128,216 @@ beforeEach(() => {
 });
 
 describe("chat view", () => {
+  it("renders the athlete row without an empty coach row while awaiting a response", () => {
+    const thread = new FakeElement("div");
+    const mounted = mountChatView({
+      conversation: new FakeElement("main") as never,
+      thread: thread as never,
+      composerHost: new FakeElement("div") as never,
+    });
+    const state = reduceChatState(EMPTY_CHAT_STATE, {
+      type: "submit",
+      requestKey: 1,
+      userMessage: "How should I train?",
+      userMessageId: "message-1",
+      assistantMessageId: "message-2",
+      includeUser: true,
+    });
+
+    mounted.view.render(state);
+
+    expect(findAll(thread, (node) => node.className.includes("chat-message--athlete")).length).toBe(
+      1,
+    );
+    expect(findAll(thread, (node) => node.className.includes("chat-message--coach")).length).toBe(
+      0,
+    );
+  });
+
+  it("renders no-draft reauthentication once as a notice and re-enables the composer", () => {
+    const thread = new FakeElement("div");
+    const composerHost = new FakeElement("div");
+    const mounted = mountChatView({
+      conversation: new FakeElement("main") as never,
+      thread: thread as never,
+      composerHost: composerHost as never,
+    });
+    const reauthenticationCopy =
+      "Your ChatGPT sign-in is no longer valid. Open Setup and sign in again.";
+    let state = reduceChatState(submittedState(), {
+      type: "event",
+      requestKey: 1,
+      event: {
+        type: "error",
+        turnId: "turn-1",
+        chatId: "desktop",
+        error_class: "unknown",
+        kind: "provider-auth",
+        athleteMessage: reauthenticationCopy,
+        overflowAttempts: 0,
+        timeoutAttempts: 0,
+        rateLimitAttempts: 0,
+        duration_ms: 1,
+        compactions: 0,
+      },
+    });
+    state = reduceChatState(state, {
+      type: "fail",
+      requestKey: 1,
+      copy: "The coach couldn't respond. Please try again.",
+    });
+
+    mounted.view.render(state);
+
+    expect(occurrences(thread.textContent, reauthenticationCopy)).toBe(1);
+    expect(thread.textContent).not.toContain("The coach couldn't respond");
+    expect(findAll(thread, (node) => node.className.includes("chat-message--coach")).length).toBe(
+      0,
+    );
+    expect(find(thread, (node) => node.className === "chat-retry").hidden).toBe(true);
+    expect(find(composerHost, (node) => node.tagName === "textarea").disabled).toBe(false);
+    expect(find(composerHost, (node) => node.tagName === "button").disabled).toBe(false);
+  });
+
+  it("renders a partial coach draft and the reauthentication notice once each", () => {
+    const thread = new FakeElement("div");
+    const mounted = mountChatView({
+      conversation: new FakeElement("main") as never,
+      thread: thread as never,
+      composerHost: new FakeElement("div") as never,
+    });
+    const reauthenticationCopy =
+      "Your ChatGPT sign-in is no longer valid. Open Setup and sign in again.";
+    let state = reduceChatState(submittedState(), {
+      type: "event",
+      requestKey: 1,
+      event: { type: "text_delta", turnId: "turn-1", delta: "Partial coach draft" },
+    });
+    state = reduceChatState(state, {
+      type: "event",
+      requestKey: 1,
+      event: {
+        type: "error",
+        turnId: "turn-1",
+        chatId: "desktop",
+        error_class: "unknown",
+        kind: "provider-auth",
+        athleteMessage: reauthenticationCopy,
+        overflowAttempts: 0,
+        timeoutAttempts: 0,
+        rateLimitAttempts: 0,
+        duration_ms: 1,
+        compactions: 0,
+      },
+    });
+    state = reduceChatState(state, {
+      type: "fail",
+      requestKey: 1,
+      copy: "The coach couldn't respond. Please try again.",
+    });
+
+    mounted.view.render(state);
+
+    expect(occurrences(thread.textContent, "Partial coach draft")).toBe(1);
+    expect(occurrences(thread.textContent, reauthenticationCopy)).toBe(1);
+    expect(findAll(thread, (node) => node.className.includes("chat-message--coach")).length).toBe(
+      1,
+    );
+  });
+
+  it("renders canonical final text once after an error and leaves the contract notice", () => {
+    const thread = new FakeElement("div");
+    const composerHost = new FakeElement("div");
+    const mounted = mountChatView({
+      conversation: new FakeElement("main") as never,
+      thread: thread as never,
+      composerHost: composerHost as never,
+    });
+    const finalText = "Take an easy spin today.";
+    const contractNotice = "Your ChatGPT sign-in is no longer valid. Open Setup and sign in again.";
+    let state = reduceChatState(submittedState(), {
+      type: "event",
+      requestKey: 1,
+      event: {
+        type: "error",
+        turnId: "turn-1",
+        chatId: "desktop",
+        error_class: "unknown",
+        kind: "provider-auth",
+        athleteMessage: contractNotice,
+        overflowAttempts: 0,
+        timeoutAttempts: 0,
+        rateLimitAttempts: 0,
+        duration_ms: 1,
+        compactions: 0,
+      },
+    });
+    state = reduceChatState(state, {
+      type: "event",
+      requestKey: 1,
+      event: { type: "final-text", turnId: "turn-1", text: finalText },
+    });
+    state = reduceChatState(state, { type: "complete", requestKey: 1 });
+
+    mounted.view.render(state);
+
+    const coachRows = findAll(thread, (node) => node.className.includes("chat-message--coach"));
+    expect(coachRows).toHaveLength(1);
+    expect(coachRows[0]?.textContent).toContain(finalText);
+    expect(coachRows[0]?.textContent.trim()).not.toBe("");
+    expect(occurrences(thread.textContent, finalText)).toBe(1);
+    expect(occurrences(thread.textContent, contractNotice)).toBe(1);
+    expect(thread.textContent).not.toContain("The coach couldn't respond");
+    expect(find(thread, (node) => node.className === "chat-retry").hidden).toBe(true);
+    expect(find(composerHost, (node) => node.tagName === "textarea").disabled).toBe(false);
+    expect(find(composerHost, (node) => node.tagName === "button").disabled).toBe(false);
+  });
+
+  it("renders generic failure copy once as a notice without an empty coach row", () => {
+    const thread = new FakeElement("div");
+    const mounted = mountChatView({
+      conversation: new FakeElement("main") as never,
+      thread: thread as never,
+      composerHost: new FakeElement("div") as never,
+    });
+    const failureCopy = "The coach couldn't respond. Please try again.";
+    const state = reduceChatState(submittedState(), {
+      type: "fail",
+      requestKey: 1,
+      copy: failureCopy,
+    });
+
+    mounted.view.render(state);
+
+    expect(occurrences(thread.textContent, failureCopy)).toBe(1);
+    expect(findAll(thread, (node) => node.className.includes("chat-message--coach")).length).toBe(
+      0,
+    );
+  });
+
+  it("renders an empty interruption notice and retry without an empty coach row", () => {
+    const thread = new FakeElement("div");
+    const mounted = mountChatView({
+      conversation: new FakeElement("main") as never,
+      thread: thread as never,
+      composerHost: new FakeElement("div") as never,
+    });
+    const interruptionCopy = "Connection interrupted. Your partial response is preserved.";
+    const state = reduceChatState(submittedState(), {
+      type: "interrupt",
+      requestKey: 1,
+      copy: interruptionCopy,
+    });
+
+    mounted.view.render(state);
+
+    expect(occurrences(thread.textContent, interruptionCopy)).toBe(1);
+    expect(findAll(thread, (node) => node.className.includes("chat-message--coach")).length).toBe(
+      0,
+    );
+    expect(find(thread, (node) => node.className === "chat-retry").hidden).toBe(false);
+  });
+
   it("places one notice host immediately before the composer and removes it on dispose", () => {
     const composerHost = new FakeElement("div");
     const mounted = mountChatView({

--- a/apps/desktop-renderer/tests/onboarding-mount.test.ts
+++ b/apps/desktop-renderer/tests/onboarding-mount.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, it, vi } from "vitest";
+import type { OnboardingBridge } from "../src/onboarding/bridge.js";
+import { mountOnboarding } from "../src/onboarding/mount.js";
+import type { ChatGptLoginResult } from "../src/onboarding/machine.js";
+
+class FakeElement {
+  readonly children: FakeElement[] = [];
+  readonly attributes = new Map<string, string>();
+  readonly listeners = new Map<string, Set<(event: Record<string, unknown>) => void>>();
+  readonly dataset: Record<string, string> = {};
+  className = "";
+  id = "";
+  type = "";
+  value = "";
+  autocomplete = "";
+  htmlFor = "";
+  name = "";
+  disabled = false;
+  checked = false;
+  tabIndex = 0;
+  parent: FakeElement | null = null;
+  private ownText = "";
+
+  constructor(
+    readonly tagName: string,
+    private readonly owner: FakeDocument,
+  ) {}
+
+  get textContent(): string {
+    return this.ownText + this.children.map((child) => child.textContent).join("");
+  }
+
+  set textContent(value: string) {
+    this.ownText = value;
+    this.children.splice(0);
+  }
+
+  get classList(): { contains: (name: string) => boolean } {
+    return {
+      contains: (name) => this.className.split(/\s+/u).includes(name),
+    };
+  }
+
+  append(...nodes: FakeElement[]): void {
+    for (const node of nodes) {
+      node.parent = this;
+      this.children.push(node);
+    }
+  }
+
+  replaceChildren(...nodes: FakeElement[]): void {
+    for (const child of this.children) child.parent = null;
+    this.ownText = "";
+    this.children.splice(0);
+    this.append(...nodes);
+  }
+
+  setAttribute(name: string, value: string): void {
+    this.attributes.set(name, value);
+  }
+
+  hasAttribute(name: string): boolean {
+    return this.attributes.has(name);
+  }
+
+  addEventListener(name: string, listener: (event: Record<string, unknown>) => void): void {
+    const listeners = this.listeners.get(name) ?? new Set();
+    listeners.add(listener);
+    this.listeners.set(name, listeners);
+  }
+
+  removeEventListener(name: string, listener: (event: Record<string, unknown>) => void): void {
+    this.listeners.get(name)?.delete(listener);
+  }
+
+  dispatch(name: string): void {
+    if (name === "click" && this.disabled) return;
+    const event = { target: this, preventDefault() {} };
+    for (const listener of this.listeners.get(name) ?? []) listener(event);
+  }
+
+  querySelector(selector: string): FakeElement | null {
+    return this.querySelectorAll(selector)[0] ?? null;
+  }
+
+  querySelectorAll(selector: string): FakeElement[] {
+    return this.children.flatMap((child) => [
+      ...(child.matches(selector) ? [child] : []),
+      ...child.querySelectorAll(selector),
+    ]);
+  }
+
+  closest(): FakeElement | null {
+    return null;
+  }
+
+  focus(): void {
+    this.owner.activeElement = this;
+  }
+
+  remove(): void {
+    if (this.parent === null) return;
+    const index = this.parent.children.indexOf(this);
+    if (index >= 0) this.parent.children.splice(index, 1);
+    this.parent = null;
+  }
+
+  private matches(selector: string): boolean {
+    if (selector.startsWith("#")) return this.id === selector.slice(1);
+    if (selector.startsWith(".")) {
+      return this.className.split(/\s+/u).includes(selector.slice(1));
+    }
+    const tag = selector.match(/^[a-z]+/iu)?.[0];
+    if (tag !== undefined && this.tagName !== tag.toUpperCase()) return false;
+    const type = selector.match(/\[type="([^"]+)"\]/u)?.[1];
+    if (type !== undefined && this.type !== type) return false;
+    if (selector.includes("[data-slot]") && this.dataset.slot === undefined) return false;
+    return tag !== undefined;
+  }
+}
+
+class FakeDocument {
+  readonly body = new FakeElement("BODY", this);
+  activeElement: FakeElement | null = null;
+
+  createElement(name: string): FakeElement {
+    return new FakeElement(name.toUpperCase(), this);
+  }
+
+  createTextNode(value: string): FakeElement {
+    const node = new FakeElement("#TEXT", this);
+    node.textContent = value;
+    return node;
+  }
+}
+
+function bridge(login: () => Promise<ChatGptLoginResult>): OnboardingBridge & {
+  readonly credentialStatuses: ReturnType<typeof vi.fn<OnboardingBridge["credentialStatuses"]>>;
+  readonly chatGptStatus: ReturnType<typeof vi.fn<OnboardingBridge["chatGptStatus"]>>;
+  readonly chatGptLogin: ReturnType<typeof vi.fn<OnboardingBridge["chatGptLogin"]>>;
+} {
+  const credentialStatuses = vi.fn<OnboardingBridge["credentialStatuses"]>(async () => []);
+  const chatGptStatus = vi.fn<OnboardingBridge["chatGptStatus"]>(async () => ({
+    state: "configured",
+    runtimeReady: true,
+  }));
+  const chatGptLogin = vi.fn<OnboardingBridge["chatGptLogin"]>(login);
+  return {
+    credentialStatuses,
+    retryFailedCredentials: vi.fn<OnboardingBridge["retryFailedCredentials"]>(async () => []),
+    writeCredential: vi.fn<OnboardingBridge["writeCredential"]>(async ({ slot }) => ({
+      slot,
+      status: "configured",
+      runtimeReady: true,
+    })),
+    chatGptStatus,
+    chatGptLogin,
+    chooseImportFiles: vi.fn<OnboardingBridge["chooseImportFiles"]>(async () => []),
+    onDroppedImportFiles: vi.fn<OnboardingBridge["onDroppedImportFiles"]>(() => () => {}),
+    importFiles: vi.fn<OnboardingBridge["importFiles"]>(async () => ({
+      schemaVersion: 1,
+      files: { total: 0, imported: 0, quarantined: 0 },
+      changes: {
+        rawFilesInserted: 0,
+        sourceRecordsInserted: 0,
+        sourceRecordsUpdated: 0,
+        relinkedSourceRecords: 0,
+      },
+    })),
+    saveIntake: vi.fn<OnboardingBridge["saveIntake"]>(async () => {}),
+  } satisfies OnboardingBridge;
+}
+
+function documentBoundary(document: FakeDocument): Document {
+  return document as unknown as Document;
+}
+
+function elementBoundary(element: FakeElement): HTMLElement {
+  return element as unknown as HTMLElement;
+}
+
+function buttonWithText(document: FakeDocument, text: string): FakeElement {
+  const button = document.body
+    .querySelectorAll("button")
+    .find((candidate) => candidate.textContent === text);
+  if (button === undefined) throw new Error(`Button not found: ${text}`);
+  return button;
+}
+
+describe("mounted onboarding", () => {
+  it("runs configured ChatGPT sign-in again through pending to configured", async () => {
+    const document = new FakeDocument();
+    let resolveLogin!: (result: ChatGptLoginResult) => void;
+    const chatGptLogin = bridge(
+      () =>
+        new Promise((resolve) => {
+          resolveLogin = resolve;
+        }),
+    );
+    const controller = mountOnboarding({
+      document: documentBoundary(document),
+      bridge: chatGptLogin,
+      opener: elementBoundary(document.createElement("button")),
+      onComplete: vi.fn(),
+    });
+    await controller.open();
+
+    const signInAgain = buttonWithText(document, "Sign in again");
+    expect(signInAgain.type).toBe("button");
+    expect(signInAgain.disabled).toBe(false);
+    signInAgain.dispatch("click");
+    signInAgain.dispatch("click");
+
+    expect(chatGptLogin.chatGptLogin).toHaveBeenCalledTimes(1);
+    const pending = buttonWithText(document, "Finish signing in in your browser…");
+    expect(pending.disabled).toBe(true);
+    resolveLogin({ status: "configured", runtimeReady: true });
+
+    await vi.waitFor(() => {
+      expect(chatGptLogin.credentialStatuses).toHaveBeenCalledTimes(2);
+      expect(chatGptLogin.chatGptStatus).toHaveBeenCalledTimes(2);
+      expect(document.body.textContent).toContain("ChatGPT is ready.");
+    });
+    expect(buttonWithText(document, "Sign in again").disabled).toBe(false);
+  });
+
+  it("renders the existing refusal state after configured sign-in is refused", async () => {
+    const document = new FakeDocument();
+    const chatGptLogin = bridge(async () => ({ status: "refused", reason: "timed-out" }));
+    const controller = mountOnboarding({
+      document: documentBoundary(document),
+      bridge: chatGptLogin,
+      opener: elementBoundary(document.createElement("button")),
+      onComplete: vi.fn(),
+    });
+    await controller.open();
+
+    buttonWithText(document, "Sign in again").dispatch("click");
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(document.body.textContent).toContain(
+      "ChatGPT sign-in timed out. Retry when you are ready.",
+    );
+    expect(buttonWithText(document, "Retry ChatGPT sign-in").disabled).toBe(false);
+  });
+});

--- a/apps/desktop/src/main/chatgpt-auth.ts
+++ b/apps/desktop/src/main/chatgpt-auth.ts
@@ -1,7 +1,12 @@
-import { randomUUID } from "node:crypto";
-import { chmod, mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { readFile } from "node:fs/promises";
 import { join } from "node:path";
-import { loginCodex, type CodexCredentials, type CodexLoginOptions } from "@enduragent/core";
+import {
+  loadStoredProfileSnapshot,
+  loginCodex,
+  recoverAndSaveStoredProfile,
+  type CodexCredentials,
+  type CodexLoginOptions,
+} from "@enduragent/core";
 import type { ConfigureRuntimeRpcParams } from "@enduragent/coach-contract";
 import { parse as parseYaml } from "yaml";
 
@@ -72,25 +77,13 @@ function validProfile(value: unknown): boolean {
   );
 }
 
-async function readProfiles(configDir: string): Promise<Record<string, unknown>> {
-  let contents: string;
-  try {
-    contents = await readFile(join(configDir, "auth-profiles.json"), "utf8");
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") return {};
-    throw error;
-  }
-  try {
-    const parsed = JSON.parse(contents) as unknown;
-    return isRecord(parsed) ? parsed : {};
-  } catch {
-    return {};
-  }
-}
-
 export async function hasChatGptProfile(configDir: string): Promise<boolean> {
   try {
-    return validProfile((await readProfiles(configDir))[CHATGPT_PROFILE_NAME]);
+    const snapshot = loadStoredProfileSnapshot(
+      join(configDir, "auth-profiles.json"),
+      CHATGPT_PROFILE_NAME,
+    );
+    return snapshot !== null && validProfile(snapshot.profile);
   } catch {
     return false;
   }
@@ -100,31 +93,14 @@ export async function writeChatGptProfile(
   configDir: string,
   credentials: CodexCredentials,
 ): Promise<void> {
-  await mkdir(configDir, { recursive: true, mode: 0o700 });
-  const path = join(configDir, "auth-profiles.json");
-  const temporaryPath = join(configDir, `.auth-profiles.${randomUUID()}.tmp`);
-  const profiles = await readProfiles(configDir);
-  profiles[CHATGPT_PROFILE_NAME] = {
+  recoverAndSaveStoredProfile(join(configDir, "auth-profiles.json"), CHATGPT_PROFILE_NAME, {
     type: "oauth",
     access: credentials.access,
     refresh: credentials.refresh,
     expires: credentials.expires,
     ...(credentials.accountId.length > 0 ? { accountId: credentials.accountId } : {}),
     ...(credentials.email !== undefined ? { email: credentials.email } : {}),
-  };
-  try {
-    await writeFile(temporaryPath, JSON.stringify(profiles, null, 2), {
-      encoding: "utf8",
-      flag: "wx",
-      mode: 0o600,
-    });
-    await chmod(temporaryPath, 0o600);
-    await rename(temporaryPath, path);
-    await chmod(path, 0o600);
-  } catch (error) {
-    await rm(temporaryPath, { force: true }).catch(() => undefined);
-    throw error;
-  }
+  });
 }
 
 async function configuredRuntime(configDir: string): Promise<boolean> {

--- a/apps/desktop/tests/chatgpt-auth.test.ts
+++ b/apps/desktop/tests/chatgpt-auth.test.ts
@@ -25,6 +25,14 @@ function credentials() {
   };
 }
 
+function invalidUtf8ProfilesBytes(): Buffer {
+  return Buffer.concat([
+    Buffer.from('{"openai-codex":{"type":"oauth","access":"invalid-', "utf8"),
+    Buffer.from([0xc3, 0x28]),
+    Buffer.from('","refresh":"invalid-refresh","expires":4102444800000}}', "utf8"),
+  ]);
+}
+
 afterEach(async () => {
   await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
 });
@@ -51,6 +59,45 @@ describe("desktop ChatGPT auth", () => {
     await expect(hasChatGptProfile(directory)).resolves.toBe(true);
   });
 
+  it("preserves unrelated profile fields and the Desktop credential shape", async () => {
+    const directory = await configDir();
+    const path = join(directory, "auth-profiles.json");
+    await mkdir(directory, { recursive: true });
+    await writeFile(
+      path,
+      JSON.stringify({
+        other: {
+          type: "oauth",
+          access: "obviously-fake-other-access",
+          future: { generation: 1 },
+        },
+      }),
+    );
+
+    const write = writeChatGptProfile(directory, {
+      ...credentials(),
+      accountId: "",
+      email: "synthetic@example.invalid",
+    });
+
+    expect(write).toBeInstanceOf(Promise);
+    await write;
+    const stored = JSON.parse(await readFile(path, "utf8")) as Record<string, unknown>;
+    expect(stored.other).toEqual({
+      type: "oauth",
+      access: "obviously-fake-other-access",
+      future: { generation: 1 },
+    });
+    expect(stored["openai-codex"]).toEqual({
+      type: "oauth",
+      access: "obviously-fake-access",
+      refresh: "obviously-fake-refresh",
+      expires: 4_102_444_800_000,
+      email: "synthetic@example.invalid",
+    });
+    expect((await stat(path)).mode & 0o777).toBe(0o600);
+  });
+
   it("treats absent, corrupt, and invalid profiles as absent", async () => {
     const directory = await configDir();
     await expect(hasChatGptProfile(directory)).resolves.toBe(false);
@@ -64,6 +111,65 @@ describe("desktop ChatGPT auth", () => {
     await expect(hasChatGptProfile(directory)).resolves.toBe(false);
   });
 
+  it("reports invalid UTF-8 profile bytes as absent before login", async () => {
+    const directory = await configDir();
+    await mkdir(directory, { recursive: true });
+    await writeFile(join(directory, "auth-profiles.json"), invalidUtf8ProfilesBytes());
+    const auth = createChatGptAuth({
+      configDir: directory,
+      openExternal: async () => {},
+      applyRuntimeConfig: async () => {},
+    });
+
+    await expect(hasChatGptProfile(directory)).resolves.toBe(false);
+    await expect(auth.status()).resolves.toEqual({ state: "absent", runtimeReady: false });
+  });
+
+  it("reports a valid target with an invalid sibling profile as absent", async () => {
+    const directory = await configDir();
+    await mkdir(directory, { recursive: true });
+    await writeFile(
+      join(directory, "auth-profiles.json"),
+      JSON.stringify({
+        "openai-codex": {
+          type: "oauth",
+          access: "obviously-fake-access",
+          refresh: "obviously-fake-refresh",
+          expires: 4_102_444_800_000,
+        },
+        invalidSibling: "not-a-profile-map",
+      }),
+    );
+    const auth = createChatGptAuth({
+      configDir: directory,
+      openExternal: async () => {},
+      applyRuntimeConfig: async () => {},
+    });
+
+    await expect(hasChatGptProfile(directory)).resolves.toBe(false);
+    await expect(auth.status()).resolves.toEqual({ state: "absent", runtimeReady: false });
+  });
+
+  it("completes login by quarantining invalid UTF-8 profile bytes", async () => {
+    const directory = await configDir();
+    const path = join(directory, "auth-profiles.json");
+    const originalBytes = invalidUtf8ProfilesBytes();
+    await mkdir(directory, { recursive: true });
+    await writeFile(path, originalBytes, { mode: 0o600 });
+    const auth = createChatGptAuth({
+      configDir: directory,
+      openExternal: async () => {},
+      applyRuntimeConfig: async () => {},
+      dependencies: { loginCodex: async () => credentials() },
+    });
+
+    await expect(auth.login()).resolves.toEqual({ status: "configured", runtimeReady: true });
+    expect(await readFile(`${path}.corrupt`)).toEqual(originalBytes);
+    expect((await stat(`${path}.corrupt`)).mode & 0o777).toBe(0o600);
+    expect((await stat(path)).mode & 0o777).toBe(0o600);
+    await expect(hasChatGptProfile(directory)).resolves.toBe(true);
+  });
+
   it("does not replace an unreadable existing profile path", async () => {
     const directory = await configDir();
     const path = join(directory, "auth-profiles.json");
@@ -71,6 +177,17 @@ describe("desktop ChatGPT auth", () => {
     await expect(writeChatGptProfile(directory, credentials())).rejects.toBeDefined();
     expect((await stat(path)).isDirectory()).toBe(true);
     await expect(hasChatGptProfile(directory)).resolves.toBe(false);
+    const auth = createChatGptAuth({
+      configDir: directory,
+      openExternal: async () => {},
+      applyRuntimeConfig: async () => {},
+      dependencies: { loginCodex: async () => credentials() },
+    });
+    await expect(auth.login()).resolves.toEqual({
+      status: "refused",
+      reason: "storage-failed",
+    });
+    expect((await stat(path)).isDirectory()).toBe(true);
   });
 
   it("maps timeout, browser cancellation, and exchange failures", async () => {

--- a/packages/coach/src/composition.ts
+++ b/packages/coach/src/composition.ts
@@ -12,19 +12,24 @@ import { parse as parseYaml, stringify as toYaml } from "yaml";
 import {
   ChatStore,
   Memory,
+  RefreshTokenReusedError,
   appendUsageLine,
   bootstrapReference,
   classifyFailure,
+  compareAndSaveStoredProfile,
   createMissingPlatformCalendarMutations,
   createPlatformCalendarMutations,
   createSubsystemLogger,
   engineConfigFromConfig,
   extractRetryAfterMs,
+  loadStoredProfileSnapshot,
   makeChatClient,
   refreshCodexToken,
   resolveSecretRef,
   type Config,
   type ReferenceRuntime,
+  type StoredProfile,
+  type StoredProfileSnapshot,
 } from "@enduragent/core";
 import {
   createCoachEngine,
@@ -61,7 +66,7 @@ import { createCoachOperations } from "./operations.js";
 import type { CoachOperationsDependencies } from "./operations.js";
 import { createSpendMeterService, type SpendMeterService } from "./spend-meter.js";
 
-interface OAuthCredential {
+interface OAuthCredential extends StoredProfile {
   readonly type: "oauth";
   readonly access: string;
   readonly refresh: string;
@@ -262,15 +267,6 @@ function readReferenceState(dataDir: string): ReferenceStateSnapshot {
   };
 }
 
-function readProfiles(path: string): Record<string, unknown> {
-  if (!existsSync(path)) return {};
-  const value = JSON.parse(readFileSync(path, "utf8")) as unknown;
-  if (typeof value !== "object" || value === null || Array.isArray(value)) {
-    throw new TypeError("OAuth profiles must be a map.");
-  }
-  return value as Record<string, unknown>;
-}
-
 function credential(value: unknown): OAuthCredential {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
     throw new TypeError("OAuth profile is invalid.");
@@ -292,43 +288,88 @@ function credential(value: unknown): OAuthCredential {
   return candidate as unknown as OAuthCredential;
 }
 
-function writeProfiles(path: string, profiles: Record<string, unknown>): void {
-  const temporaryPath = `${path}.tmp.${randomBytes(4).toString("hex")}`;
-  try {
-    writeFileSync(temporaryPath, JSON.stringify(profiles, null, 2), { mode: 0o600 });
-    chmodSync(temporaryPath, 0o600);
-    renameSync(temporaryPath, path);
-  } catch (error) {
-    try {
-      unlinkSync(temporaryPath);
-    } catch {}
-    throw error;
-  }
-}
-
 function createAccessTokenReader(
   configDir: string,
   now: () => number,
 ): EngineHostPorts["getAccessToken"] {
   const path = join(configDir, "auth-profiles.json");
   const queues = new Map<string, Promise<string>>();
+  const delay = (milliseconds: number, signal?: AbortSignal): Promise<void> => {
+    signal?.throwIfAborted();
+    if (signal === undefined) {
+      return new Promise((resolve) => setTimeout(resolve, milliseconds));
+    }
+    return new Promise((resolve, reject) => {
+      const onAbort = (): void => {
+        clearTimeout(timeout);
+        reject(signal.reason);
+      };
+      const timeout = setTimeout(() => {
+        signal.removeEventListener("abort", onAbort);
+        resolve();
+      }, milliseconds);
+      signal.addEventListener("abort", onAbort, { once: true });
+    });
+  };
+  const refresh = async (
+    profileName: string,
+    initial: StoredProfileSnapshot,
+    current: OAuthCredential,
+    signal?: AbortSignal,
+  ) => {
+    try {
+      return {
+        refreshed: await refreshCodexToken(current.refresh, signal),
+        requestSnapshot: initial,
+        requestProfile: current,
+      };
+    } catch (error) {
+      signal?.throwIfAborted();
+      if (classifyFailure(error) !== "reauth") throw error;
+      await delay(2_000, signal);
+      const requestSnapshot = loadStoredProfileSnapshot(path, profileName);
+      if (requestSnapshot === null) throw new TypeError("OAuth profile is invalid.");
+      const requestProfile = credential(requestSnapshot.profile);
+      try {
+        return {
+          refreshed: await refreshCodexToken(requestProfile.refresh, signal),
+          requestSnapshot,
+          requestProfile,
+        };
+      } catch (retryError) {
+        signal?.throwIfAborted();
+        if (classifyFailure(retryError) === "reauth") {
+          throw new RefreshTokenReusedError(profileName, retryError);
+        }
+        throw retryError;
+      }
+    }
+  };
   const exclusive = async (profileName: string, signal?: AbortSignal): Promise<string> => {
-    const profiles = readProfiles(path);
-    const current = credential(profiles[profileName]);
+    const snapshot = loadStoredProfileSnapshot(path, profileName);
+    if (snapshot === null) throw new TypeError("OAuth profile is invalid.");
+    const current = credential(snapshot.profile);
     if (Number.isFinite(current.expires) && now() <= current.expires - 300_000) {
       return current.access;
     }
-    const refreshed = await refreshCodexToken(current.refresh, signal);
-    profiles[profileName] = {
+    const { refreshed, requestSnapshot, requestProfile } = await refresh(
+      profileName,
+      snapshot,
+      current,
+      signal,
+    );
+    const next = {
+      ...requestProfile,
       type: "oauth",
       access: refreshed.access,
       refresh: refreshed.refresh,
       expires: refreshed.expires,
-      accountId: refreshed.accountId ?? current.accountId,
-      email: current.email,
+      accountId: refreshed.accountId ?? requestProfile.accountId,
+      email: requestProfile.email,
     } satisfies OAuthCredential;
-    writeProfiles(path, profiles);
-    return refreshed.access;
+    const saved = await compareAndSaveStoredProfile(path, profileName, requestSnapshot, next);
+    if (saved.status === "missing") throw new TypeError("OAuth profile is invalid.");
+    return credential(saved.profile).access;
   };
   return async (profileName, signal) => {
     const previous = queues.get(profileName) ?? Promise.resolve("");
@@ -474,8 +515,12 @@ export async function createLocalCoachComposition(
     const applyRuntimeConfig = async (request: ConfigureRuntimeRpcParams): Promise<void> => {
       const candidate = mergedRuntimeConfig(activeConfig, request);
       if (request.llm?.provider === "openai-codex") {
-        const profiles = readProfiles(join(input.home.configDir, "auth-profiles.json"));
-        credential(profiles["openai-codex"]);
+        credential(
+          loadStoredProfileSnapshot(
+            join(input.home.configDir, "auth-profiles.json"),
+            "openai-codex",
+          )?.profile,
+        );
       }
       const replacement = buildEngine(candidate);
       persistRuntimeConfig(input.home.configDir, request);

--- a/packages/coach/tests/composition.test.ts
+++ b/packages/coach/tests/composition.test.ts
@@ -1,10 +1,17 @@
 import { mkdir, mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promises";
+import { unlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { parse as parseYaml, stringify as toYaml } from "yaml";
 import type { AthleteState, CoachEngine } from "@enduragent/coach-contract";
-import { engineConfigFromConfig, loadConfig, type Config } from "@enduragent/core";
+import {
+  RefreshTokenReusedError,
+  engineConfigFromConfig,
+  loadConfig,
+  saveStoredProfile,
+  type Config,
+} from "@enduragent/core";
 import type {
   AthleteDataReaderPort,
   CreateCoachEngineInput,
@@ -270,9 +277,63 @@ function generation(text: string) {
   };
 }
 
+function codexAccessToken(accountId: string): string {
+  const header = Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" })).toString("base64url");
+  const payload = Buffer.from(
+    JSON.stringify({
+      "https://api.openai.com/auth": { chatgpt_account_id: accountId },
+    }),
+  ).toString("base64url");
+  return `${header}.${payload}.synthetic-signature`;
+}
+
+function tokenResponse(access: string, refresh = "synthetic-rotated-refresh"): Response {
+  return new Response(
+    JSON.stringify({ access_token: access, refresh_token: refresh, expires_in: 3600 }),
+    { status: 200 },
+  );
+}
+
+async function writeExpiredOAuthProfile(home: AthleteHome): Promise<void> {
+  await writeFile(
+    join(home.configDir, "auth-profiles.json"),
+    JSON.stringify({
+      "openai-codex": {
+        type: "oauth",
+        access: "synthetic-expired-access",
+        refresh: "synthetic-refresh",
+        expires: 0,
+        accountId: "synthetic-account",
+      },
+    }),
+    { mode: 0o600 },
+  );
+}
+
+async function composeWithCapturedEngineInput(home: AthleteHome, now = 1_000) {
+  let engineInput: CreateCoachEngineInput | undefined;
+  const lifecycle = await compose(home, {
+    bootstrap: async () => reference(),
+    createRuntime: () => runtime(),
+    createBackend: (input) => {
+      engineInput = input;
+      return backend();
+    },
+    createRepository: () => ({
+      insertIfAbsent: async () => false,
+      readCurrent: async () => undefined,
+    }),
+    createResolver: () => missingResolver(),
+    now: () => now,
+  });
+  if (engineInput === undefined) throw new Error("Expected a captured engine input.");
+  return { engineInput, lifecycle };
+}
+
 afterEach(async () => {
   await Promise.all(stores.splice(0).map((store) => store.close().catch(() => {})));
   await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+  vi.restoreAllMocks();
 });
 
 describe("local coach composition", () => {
@@ -368,6 +429,330 @@ describe("local coach composition", () => {
       timezone: "UTC",
       dailyCapUsd: 0.5,
     });
+    await lifecycle.close();
+  });
+
+  it("carries an explicit refresh rejection through the composed desktop ports", async () => {
+    const home = await freshHome();
+    await writeExpiredOAuthProfile(home);
+    const fetchStub = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(() =>
+        Promise.resolve(new Response(JSON.stringify({ error: "invalid_grant" }), { status: 400 })),
+      );
+    let received: CreateCoachEngineInput | undefined;
+    const lifecycle = await compose(home, {
+      bootstrap: async () => reference(),
+      createRuntime: () => runtime(),
+      createBackend: (input) => {
+        received = input;
+        return backend();
+      },
+      createRepository: () => ({
+        insertIfAbsent: async () => false,
+        readCurrent: async () => undefined,
+      }),
+      createResolver: () => missingResolver(),
+      now: () => 1_000,
+    });
+
+    vi.useFakeTimers();
+    const settled = received!.ports.getAccessToken("openai-codex").then(
+      () => null,
+      (error: unknown) => error,
+    );
+    await vi.advanceTimersByTimeAsync(2_000);
+    const failure = await settled;
+
+    expect(failure).toBeInstanceOf(RefreshTokenReusedError);
+    expect(failure).toMatchObject({ refreshFailureReason: "reauth" });
+    expect(received!.ports.classifyFailure(failure)).toBe("reauth");
+    expect(fetchStub).toHaveBeenCalledTimes(2);
+    await lifecycle.close();
+  });
+
+  it("carries a server refresh failure through the composed desktop ports", async () => {
+    const home = await freshHome();
+    await writeExpiredOAuthProfile(home);
+    const fetchStub = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("", { status: 503 }));
+    let received: CreateCoachEngineInput | undefined;
+    const lifecycle = await compose(home, {
+      bootstrap: async () => reference(),
+      createRuntime: () => runtime(),
+      createBackend: (input) => {
+        received = input;
+        return backend();
+      },
+      createRepository: () => ({
+        insertIfAbsent: async () => false,
+        readCurrent: async () => undefined,
+      }),
+      createResolver: () => missingResolver(),
+      now: () => 1_000,
+    });
+
+    const failure = await received!.ports.getAccessToken("openai-codex").catch((error) => error);
+
+    expect(received!.ports.classifyFailure(failure)).toBe("server_error");
+    expect(failure).toMatchObject({ refreshFailureReason: "server_error" });
+    expect(fetchStub).toHaveBeenCalledTimes(1);
+    await lifecycle.close();
+  });
+
+  it("refreshes once while preserving queued readers, metadata, and a concurrent profile", async () => {
+    const home = await freshHome();
+    const profilesPath = join(home.configDir, "auth-profiles.json");
+    await writeFile(
+      profilesPath,
+      JSON.stringify({
+        "openai-codex": {
+          type: "oauth",
+          access: "synthetic-expired-access",
+          refresh: "synthetic-refresh",
+          expires: 0,
+          accountId: "synthetic-old-account",
+          email: "synthetic@example.test",
+          future: { nested: { generation: 1, retained: true } },
+        },
+        unrelated: { kind: "future-provider", retained: true },
+      }),
+      { mode: 0o600 },
+    );
+    const refreshedAccess = codexAccessToken("synthetic-new-account");
+    const fetchStub = vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+      saveStoredProfile(profilesPath, "concurrent-provider", {
+        kind: "concurrent-login",
+        retained: true,
+      });
+      return tokenResponse(refreshedAccess);
+    });
+    const { engineInput, lifecycle } = await composeWithCapturedEngineInput(home);
+
+    await expect(
+      Promise.all([
+        engineInput.ports.getAccessToken("openai-codex"),
+        engineInput.ports.getAccessToken("openai-codex"),
+      ]),
+    ).resolves.toEqual([refreshedAccess, refreshedAccess]);
+
+    expect(fetchStub).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(await readFile(profilesPath, "utf8"))).toMatchObject({
+      "openai-codex": {
+        type: "oauth",
+        access: refreshedAccess,
+        refresh: "synthetic-rotated-refresh",
+        accountId: "synthetic-new-account",
+        email: "synthetic@example.test",
+        future: { nested: { generation: 1, retained: true } },
+      },
+      unrelated: { kind: "future-provider", retained: true },
+      "concurrent-provider": { kind: "concurrent-login", retained: true },
+    });
+    await lifecycle.close();
+  });
+
+  it("retries a first reauthentication rejection with the current shared refresh token", async () => {
+    const home = await freshHome();
+    await writeExpiredOAuthProfile(home);
+    const profilesPath = join(home.configDir, "auth-profiles.json");
+    const refreshedAccess = codexAccessToken("synthetic-confirmed-account");
+    const requestBodies: string[] = [];
+    const fetchStub = vi.spyOn(globalThis, "fetch").mockImplementation(async (_input, init) => {
+      requestBodies.push(String(init?.body));
+      if (requestBodies.length === 1) {
+        saveStoredProfile(profilesPath, "openai-codex", {
+          type: "oauth",
+          access: "synthetic-shared-access",
+          refresh: "synthetic-shared-refresh",
+          expires: 0,
+          accountId: "synthetic-shared-account",
+          future: { source: "concurrent-login" },
+        });
+        return new Response(JSON.stringify({ error: "invalid_grant" }), { status: 400 });
+      }
+      return tokenResponse(refreshedAccess, "synthetic-confirmed-refresh");
+    });
+    const { engineInput, lifecycle } = await composeWithCapturedEngineInput(home);
+
+    vi.useFakeTimers();
+    const pending = engineInput.ports.getAccessToken("openai-codex");
+    await vi.advanceTimersByTimeAsync(2_000);
+    await expect(pending).resolves.toBe(refreshedAccess);
+
+    expect(fetchStub).toHaveBeenCalledTimes(2);
+    expect(requestBodies[0]).toContain("refresh_token=synthetic-refresh");
+    expect(requestBodies[1]).toContain("refresh_token=synthetic-shared-refresh");
+    expect(JSON.parse(await readFile(profilesPath, "utf8"))["openai-codex"]).toMatchObject({
+      access: refreshedAccess,
+      refresh: "synthetic-confirmed-refresh",
+      future: { source: "concurrent-login" },
+    });
+    await lifecycle.close();
+  });
+
+  it("does not retry or resurrect a profile deleted before reauthentication confirmation", async () => {
+    const home = await freshHome();
+    await writeExpiredOAuthProfile(home);
+    const profilesPath = join(home.configDir, "auth-profiles.json");
+    const fetchStub = vi.spyOn(globalThis, "fetch").mockImplementation(() => {
+      unlinkSync(profilesPath);
+      return Promise.resolve(
+        new Response(JSON.stringify({ error: "invalid_grant" }), { status: 400 }),
+      );
+    });
+    const { engineInput, lifecycle } = await composeWithCapturedEngineInput(home);
+
+    vi.useFakeTimers();
+    const settled = engineInput.ports.getAccessToken("openai-codex").then(
+      () => null,
+      (error: unknown) => error,
+    );
+    await vi.advanceTimersByTimeAsync(2_000);
+    await expect(settled).resolves.toMatchObject({ message: "OAuth profile is invalid." });
+
+    expect(fetchStub).toHaveBeenCalledTimes(1);
+    await expect(readFile(profilesPath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+    await lifecycle.close();
+  });
+
+  it("does not resurrect a profile deleted during the confirmation request", async () => {
+    const home = await freshHome();
+    await writeExpiredOAuthProfile(home);
+    const profilesPath = join(home.configDir, "auth-profiles.json");
+    const fetchStub = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: "invalid_grant" }), { status: 400 }),
+      )
+      .mockImplementationOnce(() => {
+        unlinkSync(profilesPath);
+        return Promise.resolve(tokenResponse(codexAccessToken("synthetic-stale-confirmation")));
+      });
+    const { engineInput, lifecycle } = await composeWithCapturedEngineInput(home);
+
+    vi.useFakeTimers();
+    const settled = engineInput.ports.getAccessToken("openai-codex").then(
+      () => null,
+      (error: unknown) => error,
+    );
+    await vi.advanceTimersByTimeAsync(2_000);
+    await expect(settled).resolves.toMatchObject({ message: "OAuth profile is invalid." });
+
+    expect(fetchStub).toHaveBeenCalledTimes(2);
+    await expect(readFile(profilesPath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+    await lifecycle.close();
+  });
+
+  it("aborts the reauthentication delay without a second request or commit", async () => {
+    const home = await freshHome();
+    await writeExpiredOAuthProfile(home);
+    const profilesPath = join(home.configDir, "auth-profiles.json");
+    const originalBytes = await readFile(profilesPath, "utf8");
+    const fetchStub = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(JSON.stringify({ error: "invalid_grant" }), { status: 400 }));
+    const { engineInput, lifecycle } = await composeWithCapturedEngineInput(home);
+    const controller = new AbortController();
+    const abortReason = new Error("synthetic caller abort");
+
+    vi.useFakeTimers();
+    const settled = engineInput.ports.getAccessToken("openai-codex", controller.signal).then(
+      () => null,
+      (error: unknown) => error,
+    );
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fetchStub).toHaveBeenCalledTimes(1);
+    controller.abort(abortReason);
+
+    await expect(settled).resolves.toBe(abortReason);
+    expect(fetchStub).toHaveBeenCalledTimes(1);
+    expect(await readFile(profilesPath, "utf8")).toBe(originalBytes);
+    expect(vi.getTimerCount()).toBe(0);
+    await lifecycle.close();
+  });
+
+  it("commits a successful token rotation despite a late abort", async () => {
+    const home = await freshHome();
+    await writeExpiredOAuthProfile(home);
+    const profilesPath = join(home.configDir, "auth-profiles.json");
+    const controller = new AbortController();
+    const abortReason = new DOMException("Cancelled after endpoint success", "AbortError");
+    const refreshedAccess = codexAccessToken("synthetic-late-abort-account");
+    const response = tokenResponse(refreshedAccess, "synthetic-late-abort-refresh");
+    const decodeResponse = response.json.bind(response);
+    vi.spyOn(response, "json").mockImplementation(async () => {
+      const body = await decodeResponse();
+      controller.abort(abortReason);
+      return body;
+    });
+    const fetchStub = vi.spyOn(globalThis, "fetch").mockResolvedValue(response);
+    const { engineInput, lifecycle } = await composeWithCapturedEngineInput(home);
+
+    await expect(engineInput.ports.getAccessToken("openai-codex", controller.signal)).resolves.toBe(
+      refreshedAccess,
+    );
+
+    expect(controller.signal.reason).toBe(abortReason);
+    expect(fetchStub).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(await readFile(profilesPath, "utf8"))["openai-codex"]).toMatchObject({
+      access: refreshedAccess,
+      refresh: "synthetic-late-abort-refresh",
+      accountId: "synthetic-late-abort-account",
+    });
+    await lifecycle.close();
+  });
+
+  it("returns a concurrently replaced profile instead of overwriting the newer login", async () => {
+    const home = await freshHome();
+    await writeExpiredOAuthProfile(home);
+    const profilesPath = join(home.configDir, "auth-profiles.json");
+    const fetchStub = vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+      saveStoredProfile(profilesPath, "openai-codex", {
+        type: "oauth",
+        access: "synthetic-concurrent-access",
+        refresh: "synthetic-concurrent-refresh",
+        expires: 4_102_444_800_000,
+        accountId: "synthetic-concurrent-account",
+        email: "concurrent@example.test",
+      });
+      return tokenResponse(codexAccessToken("synthetic-stale-account"));
+    });
+    const { engineInput, lifecycle } = await composeWithCapturedEngineInput(home);
+
+    await expect(engineInput.ports.getAccessToken("openai-codex")).resolves.toBe(
+      "synthetic-concurrent-access",
+    );
+
+    expect(fetchStub).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(await readFile(profilesPath, "utf8"))["openai-codex"]).toEqual({
+      type: "oauth",
+      access: "synthetic-concurrent-access",
+      refresh: "synthetic-concurrent-refresh",
+      expires: 4_102_444_800_000,
+      accountId: "synthetic-concurrent-account",
+      email: "concurrent@example.test",
+    });
+    await lifecycle.close();
+  });
+
+  it("rejects without resurrecting a profile deleted during refresh", async () => {
+    const home = await freshHome();
+    await writeExpiredOAuthProfile(home);
+    const profilesPath = join(home.configDir, "auth-profiles.json");
+    const fetchStub = vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+      await rm(profilesPath);
+      return tokenResponse(codexAccessToken("synthetic-stale-account"));
+    });
+    const { engineInput, lifecycle } = await composeWithCapturedEngineInput(home);
+
+    await expect(engineInput.ports.getAccessToken("openai-codex")).rejects.toThrow(
+      "OAuth profile is invalid.",
+    );
+
+    expect(fetchStub).toHaveBeenCalledTimes(1);
+    await expect(readFile(profilesPath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
     await lifecycle.close();
   });
 

--- a/packages/core/src/agent/codex/oauth.ts
+++ b/packages/core/src/agent/codex/oauth.ts
@@ -2,6 +2,7 @@ import { randomBytes } from "node:crypto";
 import { createServer, type Server } from "node:http";
 
 import { extractAccountId } from "@enduragent/engine";
+import { TokenRefreshError, type RefreshFailureReason } from "../../auth/refresh-failure.js";
 
 const CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
 const AUTHORIZE_URL = "https://auth.openai.com/oauth/authorize";
@@ -210,7 +211,62 @@ function startLocalOAuthServer(state: string): Promise<OAuthServerHandle> {
 
 type TokenResult =
   | { type: "success"; access: string; refresh: string; expires: number }
-  | { type: "failed" };
+  | {
+      type: "failed";
+      refreshFailureReason: RefreshFailureReason;
+      cause?: unknown;
+    };
+
+interface TokenResponse {
+  readonly access_token: string;
+  readonly refresh_token: string;
+  readonly expires_in: number;
+}
+
+function isTokenResponse(value: unknown): value is TokenResponse {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.access_token === "string" &&
+    candidate.access_token.length > 0 &&
+    typeof candidate.refresh_token === "string" &&
+    candidate.refresh_token.length > 0 &&
+    typeof candidate.expires_in === "number" &&
+    Number.isFinite(candidate.expires_in)
+  );
+}
+
+async function refreshFailureReason(response: Response): Promise<RefreshFailureReason> {
+  if (response.status === 429) return "rate_limit";
+  if (response.status >= 500 && response.status <= 599) return "server_error";
+  try {
+    const body = (await response.json()) as unknown;
+    if (body === null || typeof body !== "object" || Array.isArray(body)) return "unknown";
+    const error = (body as Record<string, unknown>).error;
+    const code =
+      typeof error === "string"
+        ? error
+        : error !== null && typeof error === "object" && !Array.isArray(error)
+          ? (error as Record<string, unknown>).code
+          : undefined;
+    return typeof code === "string" && REAUTH_REFRESH_CODES.has(code) ? "reauth" : "unknown";
+  } catch (error) {
+    if (isAbortShaped(error)) throw error;
+    return "unknown";
+  }
+}
+
+const REAUTH_REFRESH_CODES = new Set([
+  "invalid_grant",
+  "invalid_token",
+  "expired_token",
+  "revoked_token",
+  "token_expired",
+  "token_revoked",
+  "refresh_token_expired",
+  "refresh_token_revoked",
+  "refresh_token_reused",
+]);
 
 async function exchangeAuthorizationCode(
   code: string,
@@ -232,20 +288,12 @@ async function exchangeAuthorizationCode(
   });
   if (!response.ok) {
     console.error("[codex-oauth] code->token failed:", response.status);
-    return { type: "failed" };
+    return { type: "failed", refreshFailureReason: "unknown" };
   }
-  const json = (await response.json()) as {
-    access_token?: string;
-    refresh_token?: string;
-    expires_in?: number;
-  };
-  if (!json.access_token || !json.refresh_token || typeof json.expires_in !== "number") {
-    console.error("[codex-oauth] token response missing fields:", {
-      hasAccessToken: !!json.access_token,
-      hasRefreshToken: !!json.refresh_token,
-      hasExpiresIn: typeof json.expires_in === "number",
-    });
-    return { type: "failed" };
+  const json = (await response.json()) as unknown;
+  if (!isTokenResponse(json)) {
+    console.error("[codex-oauth] token response missing fields");
+    return { type: "failed", refreshFailureReason: "unknown" };
   }
   return {
     type: "success",
@@ -265,12 +313,13 @@ async function refreshAccessToken(
   refreshToken: string,
   signal?: AbortSignal,
 ): Promise<TokenResult> {
+  let response: Response;
   try {
     // The token endpoint should respond quickly; bound it with a short timeout
     // combined with the caller's deadline so a stall can't hang the turn.
     const timeout = AbortSignal.timeout(TOKEN_REFRESH_TIMEOUT_MS);
     const fetchSignal = signal ? AbortSignal.any([signal, timeout]) : timeout;
-    const response = await fetch(TOKEN_URL, {
+    response = await fetch(TOKEN_URL, {
       method: "POST",
       headers: { "Content-Type": "application/x-www-form-urlencoded" },
       body: new URLSearchParams({
@@ -280,37 +329,39 @@ async function refreshAccessToken(
       }),
       signal: fetchSignal,
     });
-    if (!response.ok) {
-      console.error("[codex-oauth] Token refresh failed:", response.status);
-      return { type: "failed" };
-    }
-    const json = (await response.json()) as {
-      access_token?: string;
-      refresh_token?: string;
-      expires_in?: number;
-    };
-    if (!json.access_token || !json.refresh_token || typeof json.expires_in !== "number") {
-      console.error("[codex-oauth] Token refresh response missing fields:", {
-        hasAccessToken: !!json.access_token,
-        hasRefreshToken: !!json.refresh_token,
-        hasExpiresIn: typeof json.expires_in === "number",
-      });
-      return { type: "failed" };
-    }
-    return {
-      type: "success",
-      access: json.access_token,
-      refresh: json.refresh_token,
-      expires: Date.now() + json.expires_in * 1000,
-    };
   } catch (error) {
     // A deadline or 30s-backstop abort is not a credential failure -- propagate it
     // with its real shape so the retry/deny path is skipped and the surfaced error
     // is the abort, not a misleading "re-run setup".
     if (isAbortShaped(error) || signal?.aborted) throw error;
-    console.error("[codex-oauth] Token refresh error:", error);
-    return { type: "failed" };
+    console.error("[codex-oauth] Token refresh error:", {
+      name: error instanceof Error ? error.name : typeof error,
+    });
+    return { type: "failed", refreshFailureReason: "network", cause: error };
   }
+  if (!response.ok) {
+    const reason = await refreshFailureReason(response);
+    console.error("[codex-oauth] Token refresh failed:", response.status);
+    return { type: "failed", refreshFailureReason: reason };
+  }
+  let json: unknown;
+  try {
+    json = (await response.json()) as unknown;
+  } catch (error) {
+    if (isAbortShaped(error)) throw error;
+    console.error("[codex-oauth] Token refresh response was malformed");
+    return { type: "failed", refreshFailureReason: "unknown" };
+  }
+  if (!isTokenResponse(json)) {
+    console.error("[codex-oauth] Token refresh response missing fields");
+    return { type: "failed", refreshFailureReason: "unknown" };
+  }
+  return {
+    type: "success",
+    access: json.access_token,
+    refresh: json.refresh_token,
+    expires: Date.now() + json.expires_in * 1000,
+  };
 }
 
 // ============================================================================
@@ -412,7 +463,7 @@ export async function refreshCodexToken(
 ): Promise<CodexCredentials> {
   const result = await refreshAccessToken(refreshToken, signal);
   if (result.type !== "success") {
-    throw new Error("Failed to refresh OpenAI Codex token");
+    throw new TokenRefreshError(result.refreshFailureReason, result.cause);
   }
   const accountId = extractAccountId(result.access);
   return {

--- a/packages/core/src/agent/error-classify.ts
+++ b/packages/core/src/agent/error-classify.ts
@@ -1,4 +1,5 @@
 import type { ApiError } from "intervals-icu-api";
+import { readRefreshFailureReason } from "../auth/refresh-failure.js";
 import {
   classifyFailure,
   extractRetryAfterMs,
@@ -13,10 +14,8 @@ export type AgentErrorKind =
   | "intervals"
   | "unknown";
 
-const PROVIDER_DOWN_MESSAGE =
-  "The model provider is having trouble — try again in a few minutes.";
-const INTERVALS_TRANSIENT_MESSAGE =
-  "Couldn't reach intervals.icu right now — try again shortly.";
+const PROVIDER_DOWN_MESSAGE = "The model provider is having trouble — try again in a few minutes.";
+const INTERVALS_TRANSIENT_MESSAGE = "Couldn't reach intervals.icu right now — try again shortly.";
 const INTERVALS_CREDENTIALS_MESSAGE =
   "intervals.icu rejected the request — check your intervals.icu connection or API key.";
 
@@ -63,10 +62,40 @@ function rateLimited(err: unknown): { kind: AgentErrorKind; athleteMessage: stri
   };
 }
 
+function assertNever(value: never): never {
+  throw new TypeError(`Unhandled failure reason: ${String(value)}`);
+}
+
 export function classifyAgentError(err: unknown): {
   kind: AgentErrorKind;
   athleteMessage: string;
 } {
+  const refreshFailureReason = readRefreshFailureReason(err);
+  switch (refreshFailureReason) {
+    case "reauth":
+      return {
+        kind: "provider-auth",
+        athleteMessage: "Your ChatGPT sign-in is no longer valid. Sign in again to continue.",
+      };
+    case "rate_limit":
+      return rateLimited(err);
+    case "server_error":
+    case "network":
+      return {
+        kind: "provider-down",
+        athleteMessage: PROVIDER_DOWN_MESSAGE,
+      };
+    case "unknown":
+      return {
+        kind: "unknown",
+        athleteMessage: "Sorry, something went wrong. Please try again.",
+      };
+    case null:
+      break;
+    default:
+      return assertNever(refreshFailureReason);
+  }
+
   if (isRateLimitError(err)) {
     return rateLimited(err);
   }
@@ -87,7 +116,15 @@ export function classifyAgentError(err: unknown): {
     };
   }
 
-  switch (classifyFailure(err)) {
+  const failure = classifyFailure(err);
+  switch (failure) {
+    case "reauth":
+      return {
+        kind: "provider-auth",
+        athleteMessage: "Your ChatGPT sign-in is no longer valid. Sign in again to continue.",
+      };
+    case "rate_limit":
+      return rateLimited(err);
     case "auth":
       return {
         kind: "provider-auth",
@@ -101,10 +138,14 @@ export function classifyAgentError(err: unknown): {
         kind: "provider-down",
         athleteMessage: PROVIDER_DOWN_MESSAGE,
       };
-    default:
+    case "overflow":
+    case "invalid_request":
+    case "unknown":
       return {
         kind: "unknown",
         athleteMessage: "Sorry, something went wrong. Please try again.",
       };
+    default:
+      return assertNever(failure);
   }
 }

--- a/packages/core/src/agent/token-utils.ts
+++ b/packages/core/src/agent/token-utils.ts
@@ -1,4 +1,5 @@
 import { APICallError } from "@ai-sdk/provider";
+import { readRefreshFailureReason } from "../auth/refresh-failure.js";
 
 export function isContextOverflowError(err: unknown): boolean {
   if (!(err instanceof Error)) return false;
@@ -42,6 +43,7 @@ export type FailureReason =
   | "server_error"
   | "network"
   | "auth"
+  | "reauth"
   | "invalid_request"
   | "unknown";
 
@@ -49,7 +51,8 @@ const NETWORK_ERROR_CODES = new Set(["ECONNRESET", "ECONNREFUSED", "ETIMEDOUT", 
 
 export function isServerError(err: unknown): boolean {
   if (APICallError.isInstance(err)) {
-    return [500, 502, 503, 504, 529].includes(err.statusCode ?? -1);
+    const statusCode = err.statusCode ?? -1;
+    return statusCode >= 500 && statusCode <= 599;
   }
   // A codex 5xx is normalized into a plain Error with this name so both
   // providers route the server-error class identically.
@@ -62,6 +65,7 @@ interface Caused {
 }
 
 export function isNetworkError(err: unknown): boolean {
+  if (err instanceof Error && err.name === "NetworkError") return true;
   // undici hides the conn code on the wrapped inner error, so chase the chain.
   let n = err as Caused | null | undefined;
   const seen = new Set<unknown>();
@@ -81,6 +85,8 @@ export function isInvalidRequestError(err: unknown): boolean {
 }
 
 export function classifyFailure(err: unknown): FailureReason {
+  const refreshFailureReason = readRefreshFailureReason(err);
+  if (refreshFailureReason !== null) return refreshFailureReason;
   if (isContextOverflowError(err)) return "overflow";
   if (isTimeoutError(err)) return "timeout";
   if (isRateLimitError(err)) return "rate_limit";

--- a/packages/core/src/auth/profile-store.ts
+++ b/packages/core/src/auth/profile-store.ts
@@ -1,0 +1,240 @@
+import { createHash } from "node:crypto";
+import {
+  closeSync,
+  constants as fsConstants,
+  fchmodSync,
+  fsyncSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { basename, dirname, join } from "node:path";
+import { atomicWriteFileSync } from "../io/atomic-write-file-sync.js";
+import {
+  withInterprocessFileLock,
+  withInterprocessFileLockSync,
+} from "../io/interprocess-file-lock-sync.js";
+
+const AUTH_PROFILES_LOCK_FILE = ".auth-profiles.lock";
+
+export interface StoredProfile {
+  readonly [field: string]: unknown;
+}
+
+export interface StoredProfileSnapshot {
+  readonly profile: StoredProfile;
+  readonly revision: string;
+}
+
+export type CompareAndSaveStoredProfileResult =
+  | { readonly status: "saved"; readonly profile: StoredProfile }
+  | { readonly status: "superseded"; readonly profile: StoredProfile }
+  | { readonly status: "missing" };
+
+type ProfilesDocument = Record<string, StoredProfile>;
+
+interface RecoverableProfilesDocument {
+  readonly profiles: ProfilesDocument;
+  readonly malformedBytes?: Buffer;
+}
+
+function isStoredProfile(value: unknown): value is StoredProfile {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function emptyProfilesDocument(): ProfilesDocument {
+  return Object.create(null) as ProfilesDocument;
+}
+
+function decodeProfilesBytes(bytes: Buffer): string {
+  return new TextDecoder("utf-8", { fatal: true, ignoreBOM: true }).decode(bytes);
+}
+
+function profileAt(profiles: ProfilesDocument, name: string): StoredProfile | undefined {
+  return Object.prototype.hasOwnProperty.call(profiles, name) ? profiles[name] : undefined;
+}
+
+function parseProfiles(contents: string): ProfilesDocument {
+  const parsed = JSON.parse(contents) as unknown;
+  if (!isStoredProfile(parsed)) throw new TypeError("OAuth profiles document must be a map.");
+  const profiles = emptyProfilesDocument();
+  for (const [name, profile] of Object.entries(parsed)) {
+    if (!isStoredProfile(profile)) {
+      throw new TypeError("OAuth profile entries must be maps.");
+    }
+    profiles[name] = profile;
+  }
+  return profiles;
+}
+
+function readProfiles(path: string): ProfilesDocument {
+  let bytes: Buffer;
+  try {
+    bytes = readFileSync(path);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return emptyProfilesDocument();
+    throw error;
+  }
+  return parseProfiles(decodeProfilesBytes(bytes));
+}
+
+function salvageProfiles(contents: string): ProfilesDocument {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(contents) as unknown;
+  } catch {
+    return emptyProfilesDocument();
+  }
+  if (!isStoredProfile(parsed)) return emptyProfilesDocument();
+  const profiles = emptyProfilesDocument();
+  for (const [name, profile] of Object.entries(parsed)) {
+    if (isStoredProfile(profile)) profiles[name] = profile;
+  }
+  return profiles;
+}
+
+function readProfilesForRecovery(path: string): RecoverableProfilesDocument {
+  let metadata;
+  try {
+    metadata = lstatSync(path);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return { profiles: emptyProfilesDocument() };
+    }
+    throw error;
+  }
+  if (!metadata.isFile()) {
+    throw new TypeError("OAuth profiles recovery requires a regular file.");
+  }
+  const malformedBytes = readFileSync(path);
+  let contents: string;
+  try {
+    contents = decodeProfilesBytes(malformedBytes);
+  } catch (error) {
+    if (!(error instanceof TypeError)) throw error;
+    return { profiles: emptyProfilesDocument(), malformedBytes };
+  }
+  try {
+    return { profiles: parseProfiles(contents) };
+  } catch (error) {
+    if (!(error instanceof SyntaxError) && !(error instanceof TypeError)) throw error;
+    return { profiles: salvageProfiles(contents), malformedBytes };
+  }
+}
+
+function quarantinePathFor(path: string, sequence: number): string {
+  const suffix = sequence === 0 ? "" : `.${sequence}`;
+  return join(dirname(path), `${basename(path)}.corrupt${suffix}`);
+}
+
+function writeQuarantine(path: string, bytes: Buffer): string {
+  for (let sequence = 0; ; sequence += 1) {
+    const candidate = quarantinePathFor(path, sequence);
+    let descriptor: number | null = null;
+    let created = false;
+    try {
+      descriptor = openSync(
+        candidate,
+        fsConstants.O_CREAT | fsConstants.O_EXCL | fsConstants.O_WRONLY,
+        0o600,
+      );
+      created = true;
+      fchmodSync(descriptor, 0o600);
+      writeFileSync(descriptor, bytes);
+      fsyncSync(descriptor);
+      closeSync(descriptor);
+      descriptor = null;
+      return candidate;
+    } catch (error) {
+      if (descriptor !== null) {
+        try {
+          closeSync(descriptor);
+        } catch {}
+      }
+      if ((error as NodeJS.ErrnoException).code === "EEXIST") continue;
+      if (created) {
+        try {
+          unlinkSync(candidate);
+        } catch {}
+      }
+      throw error;
+    }
+  }
+}
+
+function revision(profile: StoredProfile): string {
+  return createHash("sha256").update(JSON.stringify(profile)).digest("hex");
+}
+
+function snapshot(profile: StoredProfile): StoredProfileSnapshot {
+  return { profile, revision: revision(profile) };
+}
+
+function lockPathFor(profilesPath: string): string {
+  return join(dirname(profilesPath), AUTH_PROFILES_LOCK_FILE);
+}
+
+function writeProfiles(path: string, profiles: ProfilesDocument): void {
+  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+  atomicWriteFileSync(path, JSON.stringify(profiles, null, 2));
+}
+
+export function loadStoredProfileSnapshot(
+  profilesPath: string,
+  name: string,
+): StoredProfileSnapshot | null {
+  const profile = profileAt(readProfiles(profilesPath), name);
+  return profile === undefined ? null : snapshot(profile);
+}
+
+export function saveStoredProfile(
+  profilesPath: string,
+  name: string,
+  profile: StoredProfile,
+): void {
+  mkdirSync(dirname(profilesPath), { recursive: true, mode: 0o700 });
+  withInterprocessFileLockSync(lockPathFor(profilesPath), () => {
+    const profiles = readProfiles(profilesPath);
+    profiles[name] = profile;
+    writeProfiles(profilesPath, profiles);
+  });
+}
+
+export function recoverAndSaveStoredProfile(
+  profilesPath: string,
+  name: string,
+  profile: StoredProfile,
+): void {
+  mkdirSync(dirname(profilesPath), { recursive: true, mode: 0o700 });
+  withInterprocessFileLockSync(lockPathFor(profilesPath), () => {
+    const recovered = readProfilesForRecovery(profilesPath);
+    if (recovered.malformedBytes !== undefined) {
+      writeQuarantine(profilesPath, recovered.malformedBytes);
+    }
+    recovered.profiles[name] = profile;
+    writeProfiles(profilesPath, recovered.profiles);
+  });
+}
+
+export async function compareAndSaveStoredProfile(
+  profilesPath: string,
+  name: string,
+  expected: StoredProfileSnapshot,
+  next: StoredProfile,
+): Promise<CompareAndSaveStoredProfileResult> {
+  mkdirSync(dirname(profilesPath), { recursive: true, mode: 0o700 });
+  return withInterprocessFileLock(lockPathFor(profilesPath), () => {
+    const profiles = readProfiles(profilesPath);
+    const current = profileAt(profiles, name);
+    if (current === undefined) return { status: "missing" };
+    if (revision(current) !== expected.revision) {
+      return { status: "superseded", profile: current };
+    }
+    profiles[name] = next;
+    writeProfiles(profilesPath, profiles);
+    return { status: "saved", profile: next };
+  });
+}

--- a/packages/core/src/auth/profiles.ts
+++ b/packages/core/src/auth/profiles.ts
@@ -1,14 +1,16 @@
-import {
-  readFileSync,
-  writeFileSync,
-  existsSync,
-  chmodSync,
-  renameSync,
-  unlinkSync,
-} from "node:fs";
 import { join } from "node:path";
-import { randomBytes } from "node:crypto";
 import { refreshCodexToken } from "../agent/codex/oauth.js";
+import {
+  compareAndSaveStoredProfile,
+  loadStoredProfileSnapshot,
+  recoverAndSaveStoredProfile,
+  type StoredProfile,
+  type StoredProfileSnapshot,
+} from "./profile-store.js";
+import { readRefreshFailureReason } from "./refresh-failure.js";
+import { RefreshTokenReusedError } from "./refresh-token-reused-error.js";
+
+export { RefreshTokenReusedError } from "./refresh-token-reused-error.js";
 
 import { CONFIG_DIR } from "../config.js";
 
@@ -16,23 +18,13 @@ import { CONFIG_DIR } from "../config.js";
 // TYPES
 // ============================================================================
 
-export interface OAuthCredential {
+export interface OAuthCredential extends StoredProfile {
   type: "oauth";
   access: string;
   refresh: string;
   expires: number;
   accountId?: string;
   email?: string;
-}
-
-export class RefreshTokenReusedError extends Error {
-  constructor(public readonly profile: string, cause: unknown) {
-    super(
-      `OAuth token for "${profile}" could not be refreshed — if this persists after checking your connection, re-run \`npm run setup\` or \`cycling-coach setup\` to reauthenticate.`,
-    );
-    this.name = "RefreshTokenReusedError";
-    this.cause = cause;
-  }
 }
 
 // ============================================================================
@@ -42,44 +34,55 @@ export class RefreshTokenReusedError extends Error {
 const PROFILES_FILE = join(CONFIG_DIR, "auth-profiles.json");
 const REFRESH_THRESHOLD_MS = 5 * 60 * 1000;
 
-type ProfilesFile = Record<string, OAuthCredential>;
-
-function readAll(): ProfilesFile {
-  if (!existsSync(PROFILES_FILE)) return {};
-  try {
-    const raw = readFileSync(PROFILES_FILE, "utf-8");
-    return JSON.parse(raw) as ProfilesFile;
-  } catch {
-    return {};
-  }
+interface OAuthProfileSnapshot {
+  readonly profile: OAuthCredential;
+  readonly stored: StoredProfileSnapshot;
 }
 
-function writeAll(profiles: ProfilesFile): void {
-  const tempPath = `${PROFILES_FILE}.tmp.${randomBytes(4).toString("hex")}`;
-  try {
-    writeFileSync(tempPath, JSON.stringify(profiles, null, 2), { mode: 0o600 });
-    // writeFileSync's mode is masked by the process umask; chmod guarantees 0o600.
-    chmodSync(tempPath, 0o600);
-    renameSync(tempPath, PROFILES_FILE);
-  } catch (err) {
-    try {
-      unlinkSync(tempPath);
-    } catch {
-      // Temp may not exist if the initial write failed.
-    }
-    throw err;
+function decodeOAuthCredential(profile: StoredProfile): OAuthCredential | null {
+  if (
+    profile.type !== "oauth" ||
+    typeof profile.access !== "string" ||
+    typeof profile.refresh !== "string" ||
+    (typeof profile.expires !== "number" && profile.expires !== null) ||
+    (profile.accountId !== undefined && typeof profile.accountId !== "string") ||
+    (profile.email !== undefined && typeof profile.email !== "string")
+  ) {
+    return null;
   }
+  return {
+    ...profile,
+    type: "oauth",
+    access: profile.access,
+    refresh: profile.refresh,
+    expires: profile.expires === null ? Number.NaN : profile.expires,
+    accountId: profile.accountId,
+    email: profile.email,
+  };
+}
+
+function loadOAuthProfileSnapshot(name: string): OAuthProfileSnapshot | null {
+  const stored = loadStoredProfileSnapshot(PROFILES_FILE, name);
+  if (stored === null) return null;
+  const profile = decodeOAuthCredential(stored.profile);
+  return profile === null ? null : { profile, stored };
+}
+
+function missingProfile(name: string): Error {
+  return new Error(`No OAuth profile "${name}". Run \`cycling-coach setup\` to create one.`);
 }
 
 export function loadProfile(name: string): OAuthCredential | null {
-  const all = readAll();
-  return all[name] ?? null;
+  try {
+    return loadOAuthProfileSnapshot(name)?.profile ?? null;
+  } catch (error) {
+    if (error instanceof SyntaxError || error instanceof TypeError) return null;
+    throw error;
+  }
 }
 
 export function saveProfile(name: string, cred: OAuthCredential): void {
-  const all = readAll();
-  all[name] = cred;
-  writeAll(all);
+  recoverAndSaveStoredProfile(PROFILES_FILE, name, cred);
 }
 
 function isExpiredOrUnusable(cred: OAuthCredential): boolean {
@@ -93,32 +96,46 @@ function isExpiredOrUnusable(cred: OAuthCredential): boolean {
 
 const REFRESH_RETRY_DELAY_MS = 2_000;
 
-function isRefreshDenied(err: unknown): boolean {
-  const msg = err instanceof Error ? err.message : String(err);
-  return /refresh.*reuse|invalid.*refresh|Failed to refresh/i.test(msg);
+function delay(ms: number, signal?: AbortSignal): Promise<void> {
+  signal?.throwIfAborted();
+  if (signal === undefined) return new Promise((resolve) => setTimeout(resolve, ms));
+  return new Promise((resolve, reject) => {
+    const onAbort = (): void => {
+      clearTimeout(timeout);
+      reject(signal.reason);
+    };
+    const timeout = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
 }
 
-function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-async function refreshWithRetry(name: string, cred: OAuthCredential, signal?: AbortSignal) {
+async function refreshWithReauthConfirmation(
+  name: string,
+  initial: OAuthProfileSnapshot,
+  signal?: AbortSignal,
+) {
   try {
-    return await refreshCodexToken(cred.refresh, signal);
+    return {
+      refreshed: await refreshCodexToken(initial.profile.refresh, signal),
+      requestSnapshot: initial,
+    };
   } catch (err) {
-    // A caller-deadline abort is not a denied refresh -- skip the 2s retry/deny path
-    // and propagate it so the surfaced error is not a misleading "re-run setup".
-    if (signal?.aborted) throw err;
-    if (!isRefreshDenied(err)) throw err;
-    // pi-ai reports invalid_grant, 5xx, and network failures with one generic
-    // message; retry once with the on-disk token before declaring the
-    // credential dead.
-    await delay(REFRESH_RETRY_DELAY_MS);
-    const onDisk = loadProfile(name) ?? cred;
+    signal?.throwIfAborted();
+    const firstFailureReason = readRefreshFailureReason(err);
+    if (firstFailureReason !== "reauth") throw err;
+    await delay(REFRESH_RETRY_DELAY_MS, signal);
+    const onDisk = loadOAuthProfileSnapshot(name);
+    if (onDisk === null) throw missingProfile(name);
     try {
-      return await refreshCodexToken(onDisk.refresh, signal);
+      return {
+        refreshed: await refreshCodexToken(onDisk.profile.refresh, signal),
+        requestSnapshot: onDisk,
+      };
     } catch (retryErr) {
-      if (isRefreshDenied(retryErr)) {
+      if (firstFailureReason === "reauth" && readRefreshFailureReason(retryErr) === "reauth") {
         throw new RefreshTokenReusedError(name, retryErr);
       }
       throw retryErr;
@@ -145,10 +162,9 @@ export async function getFreshToken(name: string, signal?: AbortSignal): Promise
 }
 
 async function getFreshTokenExclusive(name: string, signal?: AbortSignal): Promise<string> {
-  const cred = loadProfile(name);
-  if (!cred) {
-    throw new Error(`No OAuth profile "${name}". Run \`cycling-coach setup\` to create one.`);
-  }
+  const initial = loadOAuthProfileSnapshot(name);
+  if (initial === null) throw missingProfile(name);
+  const cred = initial.profile;
 
   if (!isExpiredOrUnusable(cred)) {
     return cred.access;
@@ -158,16 +174,29 @@ async function getFreshTokenExclusive(name: string, signal?: AbortSignal): Promi
     throw new Error(`Refresh not implemented for profile "${name}"`);
   }
 
-  const refreshed = await refreshWithRetry(name, cred, signal);
+  const { refreshed, requestSnapshot } = await refreshWithReauthConfirmation(name, initial, signal);
 
   const next: OAuthCredential = {
+    ...requestSnapshot.profile,
     type: "oauth",
     access: refreshed.access,
     refresh: refreshed.refresh,
     expires: refreshed.expires,
-    accountId: typeof refreshed.accountId === "string" ? refreshed.accountId : cred.accountId,
-    email: cred.email,
+    accountId:
+      typeof refreshed.accountId === "string"
+        ? refreshed.accountId
+        : requestSnapshot.profile.accountId,
+    email: requestSnapshot.profile.email,
   };
-  saveProfile(name, next);
-  return next.access;
+  const saved = await compareAndSaveStoredProfile(
+    PROFILES_FILE,
+    name,
+    requestSnapshot.stored,
+    next,
+  );
+  if (saved.status === "missing") throw missingProfile(name);
+  if (saved.status === "saved") return next.access;
+  const superseding = decodeOAuthCredential(saved.profile);
+  if (superseding === null) throw missingProfile(name);
+  return superseding.access;
 }

--- a/packages/core/src/auth/refresh-failure.ts
+++ b/packages/core/src/auth/refresh-failure.ts
@@ -1,0 +1,41 @@
+export const REFRESH_FAILURE_REASONS = [
+  "reauth",
+  "rate_limit",
+  "server_error",
+  "network",
+  "unknown",
+] as const;
+
+export type RefreshFailureReason = (typeof REFRESH_FAILURE_REASONS)[number];
+
+export interface RefreshFailure {
+  readonly refreshFailureReason: RefreshFailureReason;
+}
+
+export function readRefreshFailureReason(value: unknown): RefreshFailureReason | null {
+  if (value === null || typeof value !== "object" || !("refreshFailureReason" in value)) {
+    return null;
+  }
+  const reason = value.refreshFailureReason;
+  switch (reason) {
+    case "reauth":
+    case "rate_limit":
+    case "server_error":
+    case "network":
+    case "unknown":
+      return reason;
+    default:
+      return null;
+  }
+}
+
+export class TokenRefreshError extends Error implements RefreshFailure {
+  constructor(
+    public readonly refreshFailureReason: RefreshFailureReason,
+    cause?: unknown,
+  ) {
+    super("OAuth token refresh failed");
+    this.name = "TokenRefreshError";
+    this.cause = cause;
+  }
+}

--- a/packages/core/src/auth/refresh-token-reused-error.ts
+++ b/packages/core/src/auth/refresh-token-reused-error.ts
@@ -1,0 +1,16 @@
+import type { RefreshFailure } from "./refresh-failure.js";
+
+export class RefreshTokenReusedError extends Error implements RefreshFailure {
+  readonly refreshFailureReason = "reauth" as const;
+
+  constructor(
+    public readonly profile: string,
+    cause: unknown,
+  ) {
+    super(
+      `OAuth token for "${profile}" could not be refreshed — if this persists after checking your connection, re-run \`npm run setup\` or \`cycling-coach setup\` to reauthenticate.`,
+    );
+    this.name = "RefreshTokenReusedError";
+    this.cause = cause;
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -125,6 +125,19 @@ export {
   saveProfile,
 } from "./auth/profiles.js";
 export type { OAuthCredential } from "./auth/profiles.js";
+export {
+  compareAndSaveStoredProfile,
+  loadStoredProfileSnapshot,
+  recoverAndSaveStoredProfile,
+  saveStoredProfile,
+} from "./auth/profile-store.js";
+export type {
+  CompareAndSaveStoredProfileResult,
+  StoredProfile,
+  StoredProfileSnapshot,
+} from "./auth/profile-store.js";
+export { TokenRefreshError } from "./auth/refresh-failure.js";
+export type { RefreshFailure, RefreshFailureReason } from "./auth/refresh-failure.js";
 export { runCodexLogin } from "./auth/openai-codex-login.js";
 export { loginCodex, refreshCodexToken } from "./agent/codex/oauth.js";
 export type { CodexCredentials, CodexLoginOptions } from "./agent/codex/oauth.js";

--- a/packages/core/src/io/interprocess-file-lock-sync.ts
+++ b/packages/core/src/io/interprocess-file-lock-sync.ts
@@ -1,0 +1,604 @@
+import { createHash, randomBytes } from "node:crypto";
+import {
+  chmodSync,
+  closeSync,
+  constants as fsConstants,
+  fchmodSync,
+  fsyncSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmdirSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { TextDecoder } from "node:util";
+
+const DEFAULT_TIMEOUT_MS = 2_000;
+const DEFAULT_RETRY_DELAY_MS = 25;
+const OWNER_MARKER_PATTERN = /^owner-[a-f0-9]{64}\.json$/u;
+const waitBuffer = new Int32Array(new SharedArrayBuffer(4));
+
+interface FileIdentity {
+  readonly dev: number;
+  readonly ino: number;
+}
+
+interface LockClaim {
+  readonly version: 1;
+  readonly pid: number;
+  readonly nonce: string;
+  readonly createdAt: string;
+}
+
+interface ObservedMarker {
+  readonly directoryIdentity: FileIdentity;
+  readonly markerIdentity: FileIdentity;
+  readonly markerName: string;
+  readonly claim: LockClaim;
+}
+
+interface ObservedDirectory {
+  readonly identity: FileIdentity;
+  readonly markers: readonly ObservedMarker[];
+}
+
+export interface InterprocessFileLockOptions {
+  readonly timeoutMs?: number;
+  readonly retryDelayMs?: number;
+  readonly now?: () => number;
+  readonly timestamp?: () => string;
+  readonly nonce?: () => string;
+  readonly pid?: number;
+  readonly pidStatus?: (pid: number) => "live" | "dead";
+  readonly sleepSync?: (milliseconds: number) => void;
+  readonly delay?: (milliseconds: number) => Promise<void>;
+  readonly afterClaimPublished?: (lockPath: string) => void;
+  readonly afterDeadClaimVerified?: (lockPath: string, markerPath: string) => void;
+  readonly afterReleaseMarkerRemoved?: (lockPath: string) => void;
+  readonly platform?: NodeJS.Platform;
+}
+
+export class InterprocessFileLockError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "InterprocessFileLockError";
+  }
+}
+
+export class InterprocessFileLockTimeoutError extends InterprocessFileLockError {
+  constructor() {
+    super("Timed out waiting for the profile writer lock.");
+    this.name = "InterprocessFileLockTimeoutError";
+  }
+}
+
+export class InterprocessFileLockClaimError extends InterprocessFileLockError {
+  constructor(options?: ErrorOptions) {
+    super("The profile writer lock claim is unreadable or malformed.", options);
+    this.name = "InterprocessFileLockClaimError";
+  }
+}
+
+export class InterprocessFileLockOwnershipError extends InterprocessFileLockError {
+  constructor() {
+    super("The profile writer lock changed while it was being acquired.");
+    this.name = "InterprocessFileLockOwnershipError";
+  }
+}
+
+interface ResolvedOptions {
+  readonly timeoutMs: number;
+  readonly retryDelayMs: number;
+  readonly now: () => number;
+  readonly timestamp: () => string;
+  readonly nonce: () => string;
+  readonly pid: number;
+  readonly pidStatus: (pid: number) => "live" | "dead";
+  readonly sleepSync: (milliseconds: number) => void;
+  readonly delay: (milliseconds: number) => Promise<void>;
+  readonly afterClaimPublished?: (lockPath: string) => void;
+  readonly afterDeadClaimVerified?: (lockPath: string, markerPath: string) => void;
+  readonly afterReleaseMarkerRemoved?: (lockPath: string) => void;
+  readonly platform: NodeJS.Platform;
+}
+
+function errorCode(error: unknown): string | undefined {
+  if (typeof error !== "object" || error === null || !("code" in error)) return undefined;
+  return typeof error.code === "string" ? error.code : undefined;
+}
+
+function defaultPidStatus(pid: number): "live" | "dead" {
+  try {
+    process.kill(pid, 0);
+    return "live";
+  } catch (error) {
+    return errorCode(error) === "ESRCH" ? "dead" : "live";
+  }
+}
+
+function resolveOptions(options: InterprocessFileLockOptions): ResolvedOptions {
+  return {
+    timeoutMs: options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    retryDelayMs: options.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS,
+    now: options.now ?? Date.now,
+    timestamp: options.timestamp ?? (() => new Date().toISOString()),
+    nonce: options.nonce ?? (() => randomBytes(16).toString("hex")),
+    pid: options.pid ?? process.pid,
+    pidStatus: options.pidStatus ?? defaultPidStatus,
+    sleepSync:
+      options.sleepSync ??
+      ((milliseconds) => {
+        Atomics.wait(waitBuffer, 0, 0, milliseconds);
+      }),
+    delay:
+      options.delay ??
+      ((milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds))),
+    afterClaimPublished: options.afterClaimPublished,
+    afterDeadClaimVerified: options.afterDeadClaimVerified,
+    afterReleaseMarkerRemoved: options.afterReleaseMarkerRemoved,
+    platform: options.platform ?? process.platform,
+  };
+}
+
+function sameIdentity(left: FileIdentity, right: FileIdentity): boolean {
+  return left.dev === right.dev && left.ino === right.ino;
+}
+
+function identity(path: string): FileIdentity | null {
+  try {
+    const metadata = lstatSync(path);
+    return { dev: metadata.dev, ino: metadata.ino };
+  } catch (error) {
+    if (errorCode(error) === "ENOENT") return null;
+    throw new InterprocessFileLockClaimError({ cause: error });
+  }
+}
+
+function parseClaim(raw: string): LockClaim | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null) return null;
+  if (!("version" in parsed) || parsed.version !== 1) return null;
+  if (!("pid" in parsed) || !Number.isInteger(parsed.pid) || Number(parsed.pid) <= 0) return null;
+  if (!("nonce" in parsed) || typeof parsed.nonce !== "string" || parsed.nonce.length === 0) {
+    return null;
+  }
+  if (
+    !("createdAt" in parsed) ||
+    typeof parsed.createdAt !== "string" ||
+    parsed.createdAt.length === 0
+  ) {
+    return null;
+  }
+  return {
+    version: 1,
+    pid: Number(parsed.pid),
+    nonce: parsed.nonce,
+    createdAt: parsed.createdAt,
+  };
+}
+
+function readUtf8File(path: string): string {
+  return new TextDecoder("utf-8", { fatal: true }).decode(readFileSync(path));
+}
+
+function markerNameFor(nonce: string): string {
+  return `owner-${createHash("sha256").update(nonce).digest("hex")}.json`;
+}
+
+function observeMarker(
+  lockPath: string,
+  directoryIdentity: FileIdentity,
+  markerName: string,
+  platform: NodeJS.Platform,
+): ObservedMarker | null {
+  if (!OWNER_MARKER_PATTERN.test(markerName)) throw new InterprocessFileLockClaimError();
+  const markerPath = join(lockPath, markerName);
+  const before = identity(markerPath);
+  if (before === null) return null;
+  let raw: string;
+  try {
+    const metadata = lstatSync(markerPath);
+    if (!metadata.isFile() || (platform !== "win32" && (metadata.mode & 0o777) !== 0o600)) {
+      throw new InterprocessFileLockClaimError();
+    }
+    raw = readUtf8File(markerPath);
+  } catch (error) {
+    if (error instanceof InterprocessFileLockClaimError) throw error;
+    if (errorCode(error) === "ENOENT") return null;
+    throw new InterprocessFileLockClaimError({ cause: error });
+  }
+  const after = identity(markerPath);
+  const currentDirectory = identity(lockPath);
+  if (
+    after === null ||
+    currentDirectory === null ||
+    !sameIdentity(before, after) ||
+    !sameIdentity(directoryIdentity, currentDirectory)
+  ) {
+    return null;
+  }
+  const claim = parseClaim(raw);
+  if (claim === null || markerNameFor(claim.nonce) !== markerName) {
+    throw new InterprocessFileLockClaimError();
+  }
+  return { directoryIdentity, markerIdentity: before, markerName, claim };
+}
+
+function observeDirectory(lockPath: string, platform: NodeJS.Platform): ObservedDirectory | null {
+  const before = identity(lockPath);
+  if (before === null) return null;
+  let entries: string[];
+  try {
+    const metadata = lstatSync(lockPath);
+    if (!metadata.isDirectory() || (platform !== "win32" && (metadata.mode & 0o777) !== 0o700)) {
+      throw new InterprocessFileLockClaimError();
+    }
+    entries = readdirSync(lockPath);
+  } catch (error) {
+    if (error instanceof InterprocessFileLockClaimError) throw error;
+    if (errorCode(error) === "ENOENT") return null;
+    throw new InterprocessFileLockClaimError({ cause: error });
+  }
+  const after = identity(lockPath);
+  if (after === null || !sameIdentity(before, after)) return null;
+  const markers: ObservedMarker[] = [];
+  for (const entry of entries) {
+    const marker = observeMarker(lockPath, before, entry, platform);
+    if (marker === null) return null;
+    markers.push(marker);
+  }
+  const finalIdentity = identity(lockPath);
+  if (finalIdentity === null || !sameIdentity(before, finalIdentity)) return null;
+  return { identity: before, markers };
+}
+
+function writeCompleteClaimTemp(lockPath: string, claim: LockClaim): string {
+  const tempPath = `${lockPath}.tmp.${claim.pid}.${markerNameFor(claim.nonce)}`;
+  let descriptor: number | null = null;
+  try {
+    descriptor = openSync(
+      tempPath,
+      fsConstants.O_CREAT | fsConstants.O_EXCL | fsConstants.O_WRONLY,
+      0o600,
+    );
+    fchmodSync(descriptor, 0o600);
+    writeFileSync(descriptor, `${JSON.stringify(claim)}\n`, "utf8");
+    fsyncSync(descriptor);
+    closeSync(descriptor);
+    descriptor = null;
+    return tempPath;
+  } catch (error) {
+    if (descriptor !== null) {
+      try {
+        closeSync(descriptor);
+      } catch {}
+    }
+    try {
+      unlinkSync(tempPath);
+    } catch {}
+    throw new InterprocessFileLockError("Unable to prepare the profile writer lock claim.", {
+      cause: error,
+    });
+  }
+}
+
+function createLockDirectory(lockPath: string, platform: NodeJS.Platform): FileIdentity | null {
+  try {
+    mkdirSync(lockPath, { mode: 0o700 });
+  } catch (error) {
+    if (errorCode(error) === "EEXIST") return null;
+    throw new InterprocessFileLockError("Unable to create the profile writer lock directory.", {
+      cause: error,
+    });
+  }
+  const beforePermissions = identity(lockPath);
+  if (beforePermissions === null) return null;
+  if (platform !== "win32") {
+    try {
+      chmodSync(lockPath, 0o700);
+    } catch (error) {
+      if (errorCode(error) === "ENOENT") return null;
+      throw new InterprocessFileLockError("Unable to secure the profile writer lock directory.", {
+        cause: error,
+      });
+    }
+  }
+  const afterPermissions = identity(lockPath);
+  if (afterPermissions === null || !sameIdentity(beforePermissions, afterPermissions)) return null;
+  return beforePermissions;
+}
+
+function publishMarker(
+  lockPath: string,
+  directoryIdentity: FileIdentity,
+  claim: LockClaim,
+): FileIdentity | null {
+  const tempPath = writeCompleteClaimTemp(lockPath, claim);
+  const markerPath = join(lockPath, markerNameFor(claim.nonce));
+  const tempIdentity = identity(tempPath);
+  if (tempIdentity === null) {
+    throw new InterprocessFileLockError("The prepared profile writer lock claim disappeared.");
+  }
+  try {
+    renameSync(tempPath, markerPath);
+    return tempIdentity;
+  } catch (error) {
+    const currentDirectory = identity(lockPath);
+    if (
+      errorCode(error) === "ENOENT" ||
+      currentDirectory === null ||
+      !sameIdentity(currentDirectory, directoryIdentity)
+    ) {
+      return null;
+    }
+    throw new InterprocessFileLockError("Unable to publish the profile writer lock claim.", {
+      cause: error,
+    });
+  } finally {
+    try {
+      unlinkSync(tempPath);
+    } catch {}
+  }
+}
+
+function stillOwnedMarker(
+  lockPath: string,
+  expected: ObservedMarker,
+  platform: NodeJS.Platform,
+): boolean {
+  const currentDirectory = identity(lockPath);
+  if (currentDirectory === null || !sameIdentity(currentDirectory, expected.directoryIdentity)) {
+    return false;
+  }
+  const current = observeMarker(
+    lockPath,
+    expected.directoryIdentity,
+    expected.markerName,
+    platform,
+  );
+  return (
+    current !== null &&
+    sameIdentity(current.markerIdentity, expected.markerIdentity) &&
+    current.claim.nonce === expected.claim.nonce
+  );
+}
+
+function stillExactMarker(
+  lockPath: string,
+  expected: ObservedMarker,
+  platform: NodeJS.Platform,
+): boolean {
+  const markerPath = join(lockPath, expected.markerName);
+  const before = identity(markerPath);
+  if (before === null || !sameIdentity(before, expected.markerIdentity)) return false;
+  let raw: string;
+  try {
+    const metadata = lstatSync(markerPath);
+    if (!metadata.isFile() || (platform !== "win32" && (metadata.mode & 0o777) !== 0o600)) {
+      return false;
+    }
+    raw = readUtf8File(markerPath);
+  } catch (error) {
+    if (errorCode(error) === "ENOENT") return false;
+    throw new InterprocessFileLockClaimError({ cause: error });
+  }
+  const after = identity(markerPath);
+  const claim = parseClaim(raw);
+  return (
+    after !== null &&
+    sameIdentity(before, after) &&
+    claim !== null &&
+    markerNameFor(claim.nonce) === expected.markerName &&
+    claim.nonce === expected.claim.nonce
+  );
+}
+
+function unlinkOwnedMarker(
+  lockPath: string,
+  expected: ObservedMarker,
+  platform: NodeJS.Platform,
+): boolean {
+  if (!stillExactMarker(lockPath, expected, platform)) return false;
+  try {
+    unlinkSync(join(lockPath, expected.markerName));
+    return true;
+  } catch (error) {
+    if (errorCode(error) === "ENOENT") return false;
+    throw new InterprocessFileLockError("Unable to release the profile writer lock.", {
+      cause: error,
+    });
+  }
+}
+
+function removeEmptyLockDirectory(lockPath: string): boolean {
+  try {
+    rmdirSync(lockPath);
+    return true;
+  } catch (error) {
+    const code = errorCode(error);
+    if (code === "ENOENT" || code === "ENOTEMPTY" || code === "EEXIST") return false;
+    throw new InterprocessFileLockError("Unable to remove the profile writer lock directory.", {
+      cause: error,
+    });
+  }
+}
+
+function removeMarkerAndDirectory(
+  lockPath: string,
+  expected: ObservedMarker,
+  platform: NodeJS.Platform,
+  afterMarkerRemoved?: (lockPath: string) => void,
+): boolean {
+  const removed = unlinkOwnedMarker(lockPath, expected, platform);
+  if (removed) afterMarkerRemoved?.(lockPath);
+  removeEmptyLockDirectory(lockPath);
+  return removed;
+}
+
+interface OwnedLock {
+  release(): void;
+}
+
+function tryAcquire(lockPath: string, options: ResolvedOptions): OwnedLock | null {
+  const claim: LockClaim = {
+    version: 1,
+    pid: options.pid,
+    nonce: options.nonce(),
+    createdAt: options.timestamp(),
+  };
+  if (claim.nonce.length === 0) throw new InterprocessFileLockClaimError();
+  const directoryIdentity = createLockDirectory(lockPath, options.platform);
+  if (directoryIdentity === null) return null;
+  const markerIdentity = publishMarker(lockPath, directoryIdentity, claim);
+  if (markerIdentity === null) {
+    removeEmptyLockDirectory(lockPath);
+    return null;
+  }
+  const published: ObservedMarker = {
+    directoryIdentity,
+    markerIdentity,
+    markerName: markerNameFor(claim.nonce),
+    claim,
+  };
+  try {
+    options.afterClaimPublished?.(lockPath);
+    const currentDirectory = identity(lockPath);
+    if (currentDirectory === null || !sameIdentity(currentDirectory, directoryIdentity)) {
+      removeMarkerAndDirectory(lockPath, published, options.platform);
+      return null;
+    }
+    if (identity(join(lockPath, published.markerName)) === null) {
+      removeEmptyLockDirectory(lockPath);
+      return null;
+    }
+    if (!stillOwnedMarker(lockPath, published, options.platform)) {
+      removeMarkerAndDirectory(lockPath, published, options.platform);
+      throw new InterprocessFileLockOwnershipError();
+    }
+    const observed = observeDirectory(lockPath, options.platform);
+    if (observed === null || !sameIdentity(observed.identity, directoryIdentity)) {
+      removeMarkerAndDirectory(lockPath, published, options.platform);
+      return null;
+    }
+    const [onlyMarker] = observed.markers;
+    if (
+      observed.markers.length !== 1 ||
+      onlyMarker === undefined ||
+      onlyMarker.markerName !== published.markerName ||
+      !sameIdentity(onlyMarker.markerIdentity, published.markerIdentity) ||
+      onlyMarker.claim.nonce !== published.claim.nonce
+    ) {
+      removeMarkerAndDirectory(lockPath, published, options.platform);
+      return null;
+    }
+    return {
+      release() {
+        removeMarkerAndDirectory(
+          lockPath,
+          published,
+          options.platform,
+          options.afterReleaseMarkerRemoved,
+        );
+      },
+    };
+  } catch (error) {
+    removeMarkerAndDirectory(lockPath, published, options.platform);
+    throw error;
+  }
+}
+
+function reclaimDeadMarker(
+  lockPath: string,
+  observed: ObservedMarker,
+  options: ResolvedOptions,
+): boolean {
+  if (!stillOwnedMarker(lockPath, observed, options.platform)) return false;
+  options.afterDeadClaimVerified?.(lockPath, join(lockPath, observed.markerName));
+  return removeMarkerAndDirectory(lockPath, observed, options.platform);
+}
+
+function contentionDelay(startedAt: number, options: ResolvedOptions): number {
+  const remaining = options.timeoutMs - (options.now() - startedAt);
+  if (remaining <= 0) throw new InterprocessFileLockTimeoutError();
+  return Math.min(options.retryDelayMs, remaining);
+}
+
+function acquireSync(lockPath: string, options: ResolvedOptions): OwnedLock {
+  const startedAt = options.now();
+  for (;;) {
+    const owned = tryAcquire(lockPath, options);
+    if (owned !== null) return owned;
+    const observed = observeDirectory(lockPath, options.platform);
+    if (observed === null) continue;
+    if (observed.markers.length === 0) {
+      removeEmptyLockDirectory(lockPath);
+      continue;
+    }
+    let reclaimed = false;
+    for (const marker of observed.markers) {
+      if (options.pidStatus(marker.claim.pid) === "dead") {
+        reclaimed = reclaimDeadMarker(lockPath, marker, options) || reclaimed;
+      }
+    }
+    if (reclaimed) continue;
+    options.sleepSync(contentionDelay(startedAt, options));
+  }
+}
+
+async function acquireAsync(lockPath: string, options: ResolvedOptions): Promise<OwnedLock> {
+  const startedAt = options.now();
+  for (;;) {
+    const owned = tryAcquire(lockPath, options);
+    if (owned !== null) return owned;
+    const observed = observeDirectory(lockPath, options.platform);
+    if (observed === null) continue;
+    if (observed.markers.length === 0) {
+      removeEmptyLockDirectory(lockPath);
+      continue;
+    }
+    let reclaimed = false;
+    for (const marker of observed.markers) {
+      if (options.pidStatus(marker.claim.pid) === "dead") {
+        reclaimed = reclaimDeadMarker(lockPath, marker, options) || reclaimed;
+      }
+    }
+    if (reclaimed) continue;
+    await options.delay(contentionDelay(startedAt, options));
+  }
+}
+
+export function withInterprocessFileLockSync<T>(
+  lockPath: string,
+  action: () => T,
+  options: InterprocessFileLockOptions = {},
+): T {
+  const owned = acquireSync(lockPath, resolveOptions(options));
+  try {
+    return action();
+  } finally {
+    owned.release();
+  }
+}
+
+export async function withInterprocessFileLock<T>(
+  lockPath: string,
+  action: () => T,
+  options: InterprocessFileLockOptions = {},
+): Promise<Awaited<T>> {
+  const owned = await acquireAsync(lockPath, resolveOptions(options));
+  try {
+    return await action();
+  } finally {
+    owned.release();
+  }
+}

--- a/packages/core/tests/auth-profiles.test.ts
+++ b/packages/core/tests/auth-profiles.test.ts
@@ -1,7 +1,19 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { mkdtempSync, rmSync, statSync, readFileSync, writeFileSync, readdirSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir, homedir } from "node:os";
 import { join } from "node:path";
+import type { RefreshFailureReason } from "../src/auth/refresh-failure.js";
+import type { OAuthCredential } from "../src/auth/profiles.js";
 
 // Redirect $HOME so the profile file lands in a temp dir.
 let tempHome: string;
@@ -25,10 +37,52 @@ function profilesPath(): string {
   return join(homedir(), ".cycling-coach", "auth-profiles.json");
 }
 
+function invalidUtf8ProfilesBytes(): Buffer {
+  return Buffer.concat([
+    Buffer.from('{"openai-codex":{"type":"oauth","access":"invalid-', "utf8"),
+    Buffer.from([0xc3, 0x28]),
+    Buffer.from('","refresh":"invalid-refresh","expires":4102444800000}}', "utf8"),
+  ]);
+}
+
 async function loadModule() {
   const mod = await import("../src/auth/profiles.js");
   return mod;
 }
+
+function createDeferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: unknown) => void;
+} {
+  let resolve = (_value: T | PromiseLike<T>): void => {
+    throw new Error("Deferred promise was not initialized");
+  };
+  let reject = (_reason?: unknown): void => {
+    throw new Error("Deferred promise was not initialized");
+  };
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, resolve, reject };
+}
+
+function refreshFailure(reason: RefreshFailureReason): Error & {
+  readonly refreshFailureReason: RefreshFailureReason;
+} {
+  return Object.assign(new Error("Synthetic refresh failure"), {
+    name: "TokenRefreshError",
+    refreshFailureReason: reason,
+  });
+}
+
+const nonReauthFailureReasons: ReadonlyArray<Exclude<RefreshFailureReason, "reauth">> = [
+  "server_error",
+  "network",
+  "rate_limit",
+  "unknown",
+];
 
 describe("auth/profiles", () => {
   it("loadProfile returns null when file is missing", async () => {
@@ -131,12 +185,132 @@ describe("auth/profiles", () => {
     expect(token).toBe("rotated");
   });
 
-  it("getFreshToken surfaces RefreshTokenReusedError only after a retry also fails", async () => {
+  it("getFreshToken preserves a newer profile when an ordinary refresh resolves stale", async () => {
+    const { mkdirSync } = await import("node:fs");
+    mkdirSync(join(tempHome, ".cycling-coach"), { recursive: true });
+
+    const staleRefresh = {
+      access: "stale-access",
+      refresh: "stale-refresh",
+      expires: Date.now() + 3_600_000,
+      accountId: "stale-account",
+    };
+    const pendingRefresh = createDeferred<typeof staleRefresh>();
+    const refreshMock = vi.fn().mockReturnValue(pendingRefresh.promise);
+    vi.doMock("../src/agent/codex/oauth.js", () => ({
+      refreshCodexToken: refreshMock,
+      loginCodex: vi.fn(),
+    }));
+
+    const { saveProfile, loadProfile, getFreshToken } = await loadModule();
+    const original: OAuthCredential = {
+      type: "oauth",
+      access: "original-access",
+      refresh: "original-refresh",
+      expires: Date.now() - 1_000,
+      accountId: "original-account",
+      email: "original@example.test",
+    };
+    const newer: OAuthCredential = {
+      type: "oauth",
+      access: "newer-access",
+      refresh: "newer-refresh",
+      expires: Date.now() + 7_200_000,
+      accountId: "original-account",
+      email: "original@example.test",
+    };
+    saveProfile("openai-codex", original);
+
+    const settled = getFreshToken("openai-codex");
+    await vi.waitFor(() => expect(refreshMock).toHaveBeenCalledTimes(1));
+    saveProfile("openai-codex", newer);
+    const newerBytes = readFileSync(profilesPath(), "utf-8");
+    pendingRefresh.resolve(staleRefresh);
+
+    expect(await settled).toBe("newer-access");
+    expect(loadProfile("openai-codex")).toEqual(newer);
+    expect(readFileSync(profilesPath(), "utf-8")).toBe(newerBytes);
+    expect(refreshMock).toHaveBeenCalledWith("original-refresh", undefined);
+  });
+
+  it("getFreshToken does not resurrect a profile deleted during an ordinary refresh", async () => {
+    const { mkdirSync } = await import("node:fs");
+    mkdirSync(join(tempHome, ".cycling-coach"), { recursive: true });
+
+    const staleRefresh = {
+      access: "stale-access",
+      refresh: "stale-refresh",
+      expires: Date.now() + 3_600_000,
+      accountId: "stale-account",
+    };
+    const pendingRefresh = createDeferred<typeof staleRefresh>();
+    const refreshMock = vi.fn().mockReturnValue(pendingRefresh.promise);
+    vi.doMock("../src/agent/codex/oauth.js", () => ({
+      refreshCodexToken: refreshMock,
+      loginCodex: vi.fn(),
+    }));
+
+    const { saveProfile, loadProfile, getFreshToken } = await loadModule();
+    saveProfile("openai-codex", {
+      type: "oauth",
+      access: "original-access",
+      refresh: "original-refresh",
+      expires: Date.now() - 1_000,
+      accountId: "original-account",
+      email: "original@example.test",
+    });
+
+    const settled = getFreshToken("openai-codex");
+    await vi.waitFor(() => expect(refreshMock).toHaveBeenCalledTimes(1));
+    unlinkSync(profilesPath());
+    pendingRefresh.resolve(staleRefresh);
+
+    await expect(settled).rejects.toThrow('No OAuth profile "openai-codex"');
+    expect(existsSync(profilesPath())).toBe(false);
+    expect(loadProfile("openai-codex")).toBeNull();
+    expect(refreshMock).toHaveBeenCalledWith("original-refresh", undefined);
+  });
+
+  it("getFreshToken stops before reauthentication confirmation when the profile was deleted", async () => {
+    const { mkdirSync } = await import("node:fs");
+    mkdirSync(join(tempHome, ".cycling-coach"), { recursive: true });
+
+    const refreshMock = vi.fn().mockImplementationOnce(async () => {
+      unlinkSync(profilesPath());
+      throw refreshFailure("reauth");
+    });
+    vi.doMock("../src/agent/codex/oauth.js", () => ({
+      refreshCodexToken: refreshMock,
+      loginCodex: vi.fn(),
+    }));
+
+    const { saveProfile, getFreshToken } = await loadModule();
+    saveProfile("openai-codex", {
+      type: "oauth",
+      access: "original-access",
+      refresh: "original-refresh",
+      expires: Date.now() - 1_000,
+    });
+
+    vi.useFakeTimers();
+    const settled = getFreshToken("openai-codex").then(
+      () => null,
+      (error: unknown) => error,
+    );
+    await vi.advanceTimersByTimeAsync(2_000);
+    const error = await settled;
+
+    expect(error).toMatchObject({ message: expect.stringContaining("No OAuth profile") });
+    expect(refreshMock).toHaveBeenCalledTimes(1);
+    expect(existsSync(profilesPath())).toBe(false);
+  });
+
+  it("getFreshToken surfaces RefreshTokenReusedError after two reauthentication failures", async () => {
     const { mkdirSync } = await import("node:fs");
     mkdirSync(join(tempHome, ".cycling-coach"), { recursive: true });
 
     const refreshMock = vi.fn(async () => {
-      throw new Error("Failed to refresh OpenAI Codex token");
+      throw refreshFailure("reauth");
     });
     vi.doMock("../src/agent/codex/oauth.js", () => ({
       refreshCodexToken: refreshMock,
@@ -157,23 +331,297 @@ describe("auth/profiles", () => {
       (err: unknown) => err,
     );
     await vi.advanceTimersByTimeAsync(2_000);
-    expect(await settled).toBeInstanceOf(RefreshTokenReusedError);
+    const error = await settled;
+    expect(error).toBeInstanceOf(RefreshTokenReusedError);
+    expect(error).toMatchObject({ refreshFailureReason: "reauth" });
     expect(refreshMock).toHaveBeenCalledTimes(2);
   });
 
-  it("getFreshToken recovers when a transient failure clears on retry", async () => {
+  it.each(nonReauthFailureReasons)(
+    "getFreshToken propagates a first %s failure without delay or retry",
+    async (reason) => {
+      const { mkdirSync } = await import("node:fs");
+      mkdirSync(join(tempHome, ".cycling-coach"), { recursive: true });
+
+      const firstFailure = refreshFailure(reason);
+      const refreshMock = vi.fn().mockRejectedValue(firstFailure);
+      vi.doMock("../src/agent/codex/oauth.js", () => ({
+        refreshCodexToken: refreshMock,
+        loginCodex: vi.fn(),
+      }));
+
+      const { saveProfile, getFreshToken } = await loadModule();
+      saveProfile("openai-codex", {
+        type: "oauth",
+        access: "old",
+        refresh: "synthetic-refresh",
+        expires: Date.now() - 1000,
+      });
+
+      vi.useFakeTimers();
+      const error = await getFreshToken("openai-codex").then(
+        () => null,
+        (failure: unknown) => failure,
+      );
+
+      expect(error).toBe(firstFailure);
+      expect(error).toMatchObject({ refreshFailureReason: reason });
+      expect(refreshMock).toHaveBeenCalledTimes(1);
+      expect(vi.getTimerCount()).toBe(0);
+    },
+  );
+
+  it.each(nonReauthFailureReasons)(
+    "getFreshToken propagates a %s failure from reauthentication confirmation unchanged",
+    async (confirmationReason) => {
+      const { mkdirSync } = await import("node:fs");
+      mkdirSync(join(tempHome, ".cycling-coach"), { recursive: true });
+
+      const confirmationFailure = refreshFailure(confirmationReason);
+      const refreshMock = vi
+        .fn()
+        .mockRejectedValueOnce(refreshFailure("reauth"))
+        .mockRejectedValueOnce(confirmationFailure);
+      vi.doMock("../src/agent/codex/oauth.js", () => ({
+        refreshCodexToken: refreshMock,
+        loginCodex: vi.fn(),
+      }));
+
+      const { saveProfile, getFreshToken, RefreshTokenReusedError } = await loadModule();
+      saveProfile("openai-codex", {
+        type: "oauth",
+        access: "synthetic-access",
+        refresh: "synthetic-refresh",
+        expires: Date.now() - 1000,
+      });
+
+      vi.useFakeTimers();
+      const settled = getFreshToken("openai-codex").then(
+        () => null,
+        (error: unknown) => error,
+      );
+      await vi.advanceTimersByTimeAsync(2_000);
+      const error = await settled;
+
+      expect(error).toBe(confirmationFailure);
+      expect(error).toMatchObject({ refreshFailureReason: confirmationReason });
+      expect(error).not.toBeInstanceOf(RefreshTokenReusedError);
+      expect(refreshMock).toHaveBeenCalledTimes(2);
+    },
+  );
+
+  it("getFreshToken confirms reauthentication with the current disk token and preserves metadata", async () => {
     const { mkdirSync } = await import("node:fs");
     mkdirSync(join(tempHome, ".cycling-coach"), { recursive: true });
 
+    const confirmationExpiry = Date.now() + 3_600_000;
     const refreshMock = vi
       .fn()
-      .mockRejectedValueOnce(new Error("Failed to refresh OpenAI Codex token"))
+      .mockImplementationOnce(async () => {
+        writeFileSync(
+          profilesPath(),
+          JSON.stringify({
+            "openai-codex": {
+              type: "oauth",
+              access: "disk-access",
+              refresh: "disk-refresh",
+              expires: 0,
+              accountId: "disk-account",
+              email: "disk@example.test",
+            },
+          }),
+        );
+        throw refreshFailure("reauth");
+      })
       .mockResolvedValueOnce({
-        access: "retry-access",
-        refresh: "retry-refresh",
-        expires: Date.now() + 3_600_000,
-        accountId: "acct",
+        access: "confirmed-access",
+        refresh: "confirmed-refresh",
+        expires: confirmationExpiry,
+        accountId: "confirmed-account",
       });
+    vi.doMock("../src/agent/codex/oauth.js", () => ({
+      refreshCodexToken: refreshMock,
+      loginCodex: vi.fn(),
+    }));
+
+    const { saveProfile, getFreshToken } = await loadModule();
+    saveProfile("openai-codex", {
+      type: "oauth",
+      access: "old",
+      refresh: "initial-refresh",
+      expires: Date.now() - 1000,
+      accountId: "initial-account",
+      email: "initial@example.test",
+    });
+
+    vi.useFakeTimers();
+    const settled = getFreshToken("openai-codex");
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(await settled).toBe("confirmed-access");
+    expect(refreshMock).toHaveBeenCalledTimes(2);
+    expect(refreshMock.mock.calls.map(([refreshToken]) => refreshToken)).toEqual([
+      "initial-refresh",
+      "disk-refresh",
+    ]);
+
+    const saved = JSON.parse(readFileSync(profilesPath(), "utf-8"));
+    expect(saved["openai-codex"]).toEqual({
+      type: "oauth",
+      access: "confirmed-access",
+      refresh: "confirmed-refresh",
+      expires: confirmationExpiry,
+      accountId: "confirmed-account",
+      email: "disk@example.test",
+    });
+  });
+
+  it("getFreshToken preserves a newer profile when reauthentication confirmation resolves stale", async () => {
+    const { mkdirSync } = await import("node:fs");
+    mkdirSync(join(tempHome, ".cycling-coach"), { recursive: true });
+
+    const staleConfirmation = {
+      access: "stale-confirmed-access",
+      refresh: "stale-confirmed-refresh",
+      expires: Date.now() + 3_600_000,
+      accountId: "stale-confirmed-account",
+    };
+    const pendingConfirmation = createDeferred<typeof staleConfirmation>();
+    const refreshMock = vi
+      .fn()
+      .mockRejectedValueOnce(refreshFailure("reauth"))
+      .mockReturnValueOnce(pendingConfirmation.promise);
+    vi.doMock("../src/agent/codex/oauth.js", () => ({
+      refreshCodexToken: refreshMock,
+      loginCodex: vi.fn(),
+    }));
+
+    const { saveProfile, loadProfile, getFreshToken } = await loadModule();
+    const original: OAuthCredential = {
+      type: "oauth",
+      access: "original-access",
+      refresh: "original-refresh",
+      expires: Date.now() - 1_000,
+      accountId: "original-account",
+      email: "original@example.test",
+    };
+    const newer: OAuthCredential = {
+      type: "oauth",
+      access: "newer-access",
+      refresh: "newer-refresh",
+      expires: Date.now() + 7_200_000,
+      accountId: "original-account",
+      email: "original@example.test",
+    };
+    saveProfile("openai-codex", original);
+
+    vi.useFakeTimers();
+    const settled = getFreshToken("openai-codex");
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(refreshMock).toHaveBeenCalledTimes(2);
+    saveProfile("openai-codex", newer);
+    const newerBytes = readFileSync(profilesPath(), "utf-8");
+    pendingConfirmation.resolve(staleConfirmation);
+
+    expect(await settled).toBe("newer-access");
+    expect(loadProfile("openai-codex")).toEqual(newer);
+    expect(readFileSync(profilesPath(), "utf-8")).toBe(newerBytes);
+    expect(refreshMock.mock.calls.map(([refreshToken]) => refreshToken)).toEqual([
+      "original-refresh",
+      "original-refresh",
+    ]);
+  });
+
+  it("getFreshToken discards a confirmation response when the profile is deleted in flight", async () => {
+    const { mkdirSync } = await import("node:fs");
+    mkdirSync(join(tempHome, ".cycling-coach"), { recursive: true });
+
+    const confirmation = createDeferred<{
+      access: string;
+      refresh: string;
+      expires: number;
+      accountId: string;
+    }>();
+    const refreshMock = vi
+      .fn()
+      .mockRejectedValueOnce(refreshFailure("reauth"))
+      .mockReturnValueOnce(confirmation.promise);
+    vi.doMock("../src/agent/codex/oauth.js", () => ({
+      refreshCodexToken: refreshMock,
+      loginCodex: vi.fn(),
+    }));
+
+    const { saveProfile, loadProfile, getFreshToken } = await loadModule();
+    saveProfile("openai-codex", {
+      type: "oauth",
+      access: "original-access",
+      refresh: "original-refresh",
+      expires: Date.now() - 1_000,
+    });
+
+    vi.useFakeTimers();
+    const settled = getFreshToken("openai-codex").then(
+      () => null,
+      (error: unknown) => error,
+    );
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(refreshMock).toHaveBeenCalledTimes(2);
+    unlinkSync(profilesPath());
+    confirmation.resolve({
+      access: "discarded-access",
+      refresh: "discarded-refresh",
+      expires: Date.now() + 3_600_000,
+      accountId: "discarded-account",
+    });
+    const error = await settled;
+
+    expect(error).toMatchObject({ message: expect.stringContaining("No OAuth profile") });
+    expect(existsSync(profilesPath())).toBe(false);
+    expect(loadProfile("openai-codex")).toBeNull();
+  });
+
+  it("getFreshToken commits a successful rotation despite a late abort", async () => {
+    const { mkdirSync } = await import("node:fs");
+    mkdirSync(join(tempHome, ".cycling-coach"), { recursive: true });
+    const controller = new AbortController();
+    const lateAbort = new DOMException("Cancelled after endpoint success", "AbortError");
+    const refreshMock = vi.fn().mockImplementationOnce(async () => {
+      controller.abort(lateAbort);
+      return {
+        access: "committed-access",
+        refresh: "committed-refresh",
+        expires: Date.now() + 3_600_000,
+        accountId: "committed-account",
+      };
+    });
+    vi.doMock("../src/agent/codex/oauth.js", () => ({
+      refreshCodexToken: refreshMock,
+      loginCodex: vi.fn(),
+    }));
+
+    const { saveProfile, loadProfile, getFreshToken } = await loadModule();
+    saveProfile("openai-codex", {
+      type: "oauth",
+      access: "original-access",
+      refresh: "original-refresh",
+      expires: Date.now() - 1_000,
+    });
+
+    await expect(getFreshToken("openai-codex", controller.signal)).resolves.toBe(
+      "committed-access",
+    );
+    expect(controller.signal.reason).toBe(lateAbort);
+    expect(loadProfile("openai-codex")).toMatchObject({
+      access: "committed-access",
+      refresh: "committed-refresh",
+    });
+  });
+
+  it("getFreshToken propagates an ordinary error without delay or retry", async () => {
+    const { mkdirSync } = await import("node:fs");
+    mkdirSync(join(tempHome, ".cycling-coach"), { recursive: true });
+
+    const ordinaryFailure = new Error("Synthetic ordinary failure");
+    const refreshMock = vi.fn().mockRejectedValue(ordinaryFailure);
     vi.doMock("../src/agent/codex/oauth.js", () => ({
       refreshCodexToken: refreshMock,
       loginCodex: vi.fn(),
@@ -188,43 +636,86 @@ describe("auth/profiles", () => {
     });
 
     vi.useFakeTimers();
-    const settled = getFreshToken("openai-codex");
-    await vi.advanceTimersByTimeAsync(2_000);
-    expect(await settled).toBe("retry-access");
-    expect(refreshMock).toHaveBeenCalledTimes(2);
-
-    const saved = JSON.parse(readFileSync(profilesPath(), "utf-8"));
-    expect(saved["openai-codex"].refresh).toBe("retry-refresh");
+    const error = await getFreshToken("openai-codex").then(
+      () => null,
+      (failure: unknown) => failure,
+    );
+    expect(error).toBe(ordinaryFailure);
+    expect(refreshMock).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(0);
   });
 
-  it("getFreshToken rethrows timeout-flavored errors untouched", async () => {
+  it("getFreshToken preserves an abort that happens before the retry wait", async () => {
     const { mkdirSync } = await import("node:fs");
     mkdirSync(join(tempHome, ".cycling-coach"), { recursive: true });
 
-    const refreshMock = vi.fn(async () => {
-      throw new Error("Request timed out");
-    });
+    const pendingRefresh = createDeferred<never>();
+    const refreshMock = vi.fn().mockReturnValue(pendingRefresh.promise);
     vi.doMock("../src/agent/codex/oauth.js", () => ({
       refreshCodexToken: refreshMock,
       loginCodex: vi.fn(),
     }));
 
-    const { saveProfile, getFreshToken, RefreshTokenReusedError } = await loadModule();
+    const { saveProfile, getFreshToken } = await loadModule();
     saveProfile("openai-codex", {
       type: "oauth",
       access: "old",
-      refresh: "old-refresh",
+      refresh: "synthetic-refresh",
       expires: Date.now() - 1000,
     });
 
-    const err = await getFreshToken("openai-codex").then(
-      () => null,
-      (e: unknown) => e,
-    );
-    expect(err).toBeInstanceOf(Error);
-    expect(err).not.toBeInstanceOf(RefreshTokenReusedError);
-    expect((err as Error).message).toBe("Request timed out");
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    const abortError = new DOMException("Cancelled before wait", "AbortError");
+    const settled = getFreshToken("openai-codex", controller.signal);
+    for (let turn = 0; turn < 10 && refreshMock.mock.calls.length === 0; turn += 1) {
+      await Promise.resolve();
+    }
     expect(refreshMock).toHaveBeenCalledTimes(1);
+    controller.abort(abortError);
+    pendingRefresh.reject(refreshFailure("reauth"));
+
+    await expect(settled).rejects.toBe(abortError);
+    expect(refreshMock).toHaveBeenCalledTimes(1);
+    expect(refreshMock).toHaveBeenCalledWith("synthetic-refresh", controller.signal);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("getFreshToken aborts an active retry wait without a second refresh", async () => {
+    const { mkdirSync } = await import("node:fs");
+    mkdirSync(join(tempHome, ".cycling-coach"), { recursive: true });
+
+    const refreshMock = vi.fn().mockRejectedValue(refreshFailure("reauth"));
+    vi.doMock("../src/agent/codex/oauth.js", () => ({
+      refreshCodexToken: refreshMock,
+      loginCodex: vi.fn(),
+    }));
+
+    const { saveProfile, getFreshToken } = await loadModule();
+    saveProfile("openai-codex", {
+      type: "oauth",
+      access: "old",
+      refresh: "synthetic-refresh",
+      expires: Date.now() - 1000,
+    });
+
+    vi.useFakeTimers();
+    const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    const controller = new AbortController();
+    const abortError = new DOMException("Cancelled during wait", "AbortError");
+    const settled = getFreshToken("openai-codex", controller.signal);
+    for (let turn = 0; turn < 10 && vi.getTimerCount() !== 1; turn += 1) {
+      await Promise.resolve();
+    }
+    expect(vi.getTimerCount()).toBe(1);
+    expect(timeoutSpy).toHaveBeenCalledTimes(1);
+    expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Function), 2_000);
+    controller.abort(abortError);
+
+    await expect(settled).rejects.toBe(abortError);
+    expect(refreshMock).toHaveBeenCalledTimes(1);
+    expect(refreshMock).toHaveBeenCalledWith("synthetic-refresh", controller.signal);
+    expect(vi.getTimerCount()).toBe(0);
   });
 
   it("concurrent getFreshToken calls perform a single refresh", async () => {
@@ -278,18 +769,74 @@ describe("auth/profiles", () => {
     expect(entries).toEqual(["auth-profiles.json"]);
 
     expect(statSync(profilesPath()).mode & 0o777).toBe(0o600);
-    expect(JSON.parse(readFileSync(profilesPath(), "utf-8"))["openai-codex"].access).toBe(
-      "second",
-    );
+    expect(JSON.parse(readFileSync(profilesPath(), "utf-8"))["openai-codex"].access).toBe("second");
     expect(loadProfile("openai-codex")?.access).toBe("second");
   });
 
-  it("survives a corrupt profiles file", async () => {
+  it("returns null without changing a corrupt profiles file", async () => {
     const { mkdirSync } = await import("node:fs");
     mkdirSync(join(tempHome, ".cycling-coach"), { recursive: true });
     writeFileSync(profilesPath(), "not-json{{", { mode: 0o600 });
 
     const { loadProfile } = await loadModule();
     expect(loadProfile("openai-codex")).toBeNull();
+    expect(readFileSync(profilesPath(), "utf8")).toBe("not-json{{");
+  });
+
+  it("returns null without changing invalid UTF-8 profile bytes", async () => {
+    const { mkdirSync } = await import("node:fs");
+    mkdirSync(join(tempHome, ".cycling-coach"), { recursive: true });
+    const originalBytes = invalidUtf8ProfilesBytes();
+    writeFileSync(profilesPath(), originalBytes, { mode: 0o600 });
+
+    const { loadProfile } = await loadModule();
+    expect(loadProfile("openai-codex")).toBeNull();
+    expect(readFileSync(profilesPath())).toEqual(originalBytes);
+  });
+
+  it.runIf(process.platform !== "win32" && process.getuid?.() !== 0)(
+    "does not treat an unreadable profiles file as absent",
+    async () => {
+      const { mkdirSync } = await import("node:fs");
+      mkdirSync(join(tempHome, ".cycling-coach"), { recursive: true });
+      const originalBytes = JSON.stringify({
+        "openai-codex": {
+          type: "oauth",
+          access: "unreadable-access",
+          refresh: "unreadable-refresh",
+          expires: 4_102_444_800_000,
+        },
+      });
+      writeFileSync(profilesPath(), originalBytes, { mode: 0o600 });
+      chmodSync(profilesPath(), 0o000);
+      try {
+        const { loadProfile } = await loadModule();
+        expect(() => loadProfile("openai-codex")).toThrow();
+      } finally {
+        chmodSync(profilesPath(), 0o600);
+      }
+      expect(readFileSync(profilesPath(), "utf8")).toBe(originalBytes);
+      expect(existsSync(`${profilesPath()}.corrupt`)).toBe(false);
+    },
+  );
+
+  it("recovers invalid UTF-8 profile bytes after a completed login save", async () => {
+    const { mkdirSync } = await import("node:fs");
+    mkdirSync(join(tempHome, ".cycling-coach"), { recursive: true });
+    const originalBytes = invalidUtf8ProfilesBytes();
+    writeFileSync(profilesPath(), originalBytes, { mode: 0o600 });
+
+    const { loadProfile, saveProfile } = await loadModule();
+    saveProfile("openai-codex", {
+      type: "oauth",
+      access: "replacement-access",
+      refresh: "replacement-refresh",
+      expires: 4_102_444_800_000,
+    });
+
+    expect(loadProfile("openai-codex")).toMatchObject({ access: "replacement-access" });
+    expect(readFileSync(`${profilesPath()}.corrupt`)).toEqual(originalBytes);
+    expect(statSync(`${profilesPath()}.corrupt`).mode & 0o777).toBe(0o600);
+    expect(statSync(profilesPath()).mode & 0o777).toBe(0o600);
   });
 });

--- a/packages/core/tests/codex-setup-flow.test.ts
+++ b/packages/core/tests/codex-setup-flow.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { mkdtempSync, rmSync, readFileSync, existsSync, mkdirSync, statSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { parse as parseYaml } from "yaml";
@@ -11,6 +19,14 @@ let tempHome: string;
 let origHome: string | undefined;
 let origStdinTTY: boolean | undefined;
 let origStdoutTTY: boolean | undefined;
+
+function invalidUtf8ProfilesBytes(): Buffer {
+  return Buffer.concat([
+    Buffer.from('{"openai-codex":{"type":"oauth","access":"invalid-', "utf8"),
+    Buffer.from([0xc3, 0x28]),
+    Buffer.from('","refresh":"invalid-refresh","expires":4102444800000}}', "utf8"),
+  ]);
+}
 
 beforeEach(() => {
   tempHome = mkdtempSync(join(tmpdir(), "cc-setup-"));
@@ -77,5 +93,37 @@ describe("codex setup flow", () => {
     const saved = JSON.parse(readFileSync(profilesPath, "utf-8"));
     expect(saved["openai-codex"].access).toBe("fake-access");
     expect(saved["openai-codex"].refresh).toBe("fake-refresh");
+  });
+
+  it("re-login quarantines invalid UTF-8 profile bytes and persists new credentials", async () => {
+    const profilesPath = join(tempHome, ".cycling-coach", "auth-profiles.json");
+    const originalBytes = invalidUtf8ProfilesBytes();
+    writeFileSync(profilesPath, originalBytes, { mode: 0o600 });
+    vi.doMock("@clack/prompts", () =>
+      scriptedPrompts({
+        selects: ["openai-codex", "gpt-5.4", "plain"],
+        passwords: ["", ""],
+      }),
+    );
+    vi.doMock("../src/auth/openai-codex-login.js", () => ({
+      runCodexLogin: vi.fn(async () => ({
+        type: "oauth",
+        access: "replacement-access",
+        refresh: "replacement-refresh",
+        expires: 4_102_444_800_000,
+        accountId: "replacement-account",
+      })),
+    }));
+
+    const { runSetup } = await import("../src/setup.js");
+    await runSetup(cyclingBinary);
+
+    expect(readFileSync(`${profilesPath}.corrupt`)).toEqual(originalBytes);
+    expect(statSync(`${profilesPath}.corrupt`).mode & 0o777).toBe(0o600);
+    expect(statSync(profilesPath).mode & 0o777).toBe(0o600);
+    expect(JSON.parse(readFileSync(profilesPath, "utf8"))["openai-codex"]).toMatchObject({
+      access: "replacement-access",
+      refresh: "replacement-refresh",
+    });
   });
 });

--- a/packages/core/tests/codex/oauth.test.ts
+++ b/packages/core/tests/codex/oauth.test.ts
@@ -1,6 +1,8 @@
 import { createServer } from "node:http";
 import { describe, it, expect, afterEach, vi } from "vitest";
 import { loginCodex, refreshCodexToken, generatePKCE } from "../../src/agent/codex/oauth.js";
+import { RefreshTokenReusedError } from "../../src/auth/profiles.js";
+import { classifyFailure } from "../../src/agent/token-utils.js";
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -18,6 +20,98 @@ const TOKEN_WITH_ACCOUNT = makeJwt({
 const TOKEN_WITHOUT_ACCOUNT = makeJwt({ sub: "user_1" });
 
 describe("refreshCodexToken", () => {
+  it("tags an explicit invalid grant as reauthentication without the profile wrapper", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ error: "invalid_grant" }), { status: 400 }),
+    );
+
+    const error = await refreshCodexToken("").catch((failure: unknown) => failure);
+
+    expect(error).toMatchObject({
+      name: "TokenRefreshError",
+      refreshFailureReason: "reauth",
+    });
+    expect(error).not.toBeInstanceOf(RefreshTokenReusedError);
+    expect(classifyFailure(error)).toBe("reauth");
+  });
+
+  it.each([
+    ["invalid_grant", 400, { error: "invalid_grant" }],
+    ["invalid_token", 401, { error: { code: "invalid_token" } }],
+    ["expired_token", 403, { error: "expired_token" }],
+    ["revoked_token", 400, { error: { code: "revoked_token" } }],
+    ["refresh_token_expired", 400, { error: "refresh_token_expired" }],
+    ["refresh_token_revoked", 400, { error: { code: "refresh_token_revoked" } }],
+  ])("classifies the explicit %s OAuth code as reauthentication", async (_code, status, body) => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify(body), { status }));
+
+    const error = await refreshCodexToken("synthetic-refresh").catch((failure: unknown) => failure);
+
+    expect(error).toMatchObject({ refreshFailureReason: "reauth" });
+    expect(classifyFailure(error)).toBe("reauth");
+  });
+
+  it.each([
+    [401, undefined, "unknown"],
+    [403, undefined, "unknown"],
+    [499, undefined, "unknown"],
+    [400, { error: "invalid_client" }, "unknown"],
+    [400, { error: { code: "unsupported_grant_type" } }, "unknown"],
+    [429, { error: "invalid_grant" }, "rate_limit"],
+    [500, { error: "invalid_grant" }, "server_error"],
+  ] as const)(
+    "classifies HTTP %s without credential-rejection proof structurally",
+    async (status, body, expected) => {
+      vi.spyOn(console, "error").mockImplementation(() => {});
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(body === undefined ? null : JSON.stringify(body), { status }),
+      );
+
+      const error = await refreshCodexToken("synthetic-refresh").catch(
+        (failure: unknown) => failure,
+      );
+
+      expect(error).toMatchObject({ refreshFailureReason: expected });
+      expect(classifyFailure(error)).toBe(expected);
+      expect(error).not.toBeInstanceOf(RefreshTokenReusedError);
+    },
+  );
+
+  it.each([
+    [500, "server_error"],
+    [501, "server_error"],
+    [599, "server_error"],
+  ] as const)("keeps HTTP %s refresh failures retryable", async (status, expected) => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("", { status }));
+
+    const error = await refreshCodexToken("").catch((failure: unknown) => failure);
+
+    expect(error).not.toBeInstanceOf(RefreshTokenReusedError);
+    expect(error).toMatchObject({
+      name: "TokenRefreshError",
+      refreshFailureReason: expected,
+    });
+    expect(classifyFailure(error)).toBe(expected);
+  });
+
+  it("keeps a fetch failure retryable", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new TypeError("fetch failed"));
+
+    const error = await refreshCodexToken("").catch((failure: unknown) => failure);
+
+    expect(error).not.toBeInstanceOf(RefreshTokenReusedError);
+    expect(error).toMatchObject({
+      name: "TokenRefreshError",
+      refreshFailureReason: "network",
+    });
+    expect((error as Error).name).not.toBe("NetworkError");
+    expect(classifyFailure(error)).toBe("network");
+  });
+
   it("returns rotated credentials with an absolute expiry and the decoded accountId", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(
@@ -40,25 +134,90 @@ describe("refreshCodexToken", () => {
     expect(creds.expires).toBeLessThanOrEqual(Date.now() + 3600 * 1000);
   });
 
-  it("throws the exact 'Failed to refresh' message on a non-OK response", async () => {
+  it("classifies an unrecognized non-OK response as unknown", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("{}", { status: 400 }));
-    await expect(refreshCodexToken("rt")).rejects.toThrow("Failed to refresh OpenAI Codex token");
+    await expect(refreshCodexToken("rt")).rejects.toMatchObject({
+      name: "TokenRefreshError",
+      refreshFailureReason: "unknown",
+    });
   });
 
-  it("throws the same message when the fetch itself throws (network)", async () => {
+  it("classifies a fetch rejection as network without the bridge retry marker", async () => {
     vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
       throw new TypeError("fetch failed");
     });
-    await expect(refreshCodexToken("rt")).rejects.toThrow("Failed to refresh OpenAI Codex token");
+    await expect(refreshCodexToken("rt")).rejects.toMatchObject({
+      name: "TokenRefreshError",
+      refreshFailureReason: "network",
+    });
   });
 
-  it("throws when the token response is missing required fields", async () => {
+  it("classifies a token response missing required fields as unknown", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(JSON.stringify({ access_token: TOKEN_WITH_ACCOUNT, expires_in: 3600 }), {
         status: 200,
       }),
     );
-    await expect(refreshCodexToken("rt")).rejects.toThrow("Failed to refresh OpenAI Codex token");
+    await expect(refreshCodexToken("rt")).rejects.toMatchObject({
+      refreshFailureReason: "unknown",
+    });
+  });
+
+  it("classifies malformed success JSON as unknown", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("{", { status: 200, headers: { "content-type": "application/json" } }),
+    );
+
+    await expect(refreshCodexToken("rt")).rejects.toMatchObject({
+      refreshFailureReason: "unknown",
+    });
+  });
+
+  it("classifies malformed failure JSON as unknown", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("{", { status: 400, headers: { "content-type": "application/json" } }),
+    );
+
+    await expect(refreshCodexToken("rt")).rejects.toMatchObject({
+      refreshFailureReason: "unknown",
+    });
+  });
+
+  it.each([null, [], "synthetic", 7, true])(
+    "classifies valid non-object success JSON %# as unknown",
+    async (body) => {
+      vi.spyOn(console, "error").mockImplementation(() => {});
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify(body), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+
+      await expect(refreshCodexToken("synthetic-refresh")).rejects.toMatchObject({
+        refreshFailureReason: "unknown",
+      });
+    },
+  );
+
+  it("rethrows an abort from failure-body decoding unchanged", async () => {
+    const abort = new DOMException("Cancelled", "AbortError");
+    const response = new Response("{}", { status: 400 });
+    vi.spyOn(response, "json").mockRejectedValue(abort);
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(response);
+
+    await expect(refreshCodexToken("synthetic-refresh")).rejects.toBe(abort);
+  });
+
+  it("rethrows an abort from success-body decoding unchanged", async () => {
+    const abort = new DOMException("Cancelled", "AbortError");
+    const response = new Response("{}", { status: 200 });
+    vi.spyOn(response, "json").mockRejectedValue(abort);
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(response);
+
+    await expect(refreshCodexToken("synthetic-refresh")).rejects.toBe(abort);
   });
 
   it("throws when the token carries no chatgpt_account_id", async () => {
@@ -112,6 +271,8 @@ describe("refreshCodexToken", () => {
     const err = await refreshCodexToken("rt").catch((e) => e);
     expect((err as Error).name).toBe("TimeoutError");
     expect((err as Error).message).not.toMatch(/Failed to refresh/);
+    expect(err).not.toBeInstanceOf(RefreshTokenReusedError);
+    expect(classifyFailure(err)).toBe("timeout");
   });
 
   it("never logs the refresh token or response body on failure (redaction)", async () => {

--- a/packages/core/tests/engine-host-adapter.test.ts
+++ b/packages/core/tests/engine-host-adapter.test.ts
@@ -1,10 +1,14 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { APICallError } from "@ai-sdk/provider";
-import { afterEach, describe, expect, it } from "vitest";
+import { createCoachEngine } from "@enduragent/engine";
+import type { Sport } from "@enduragent/engine/sport";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
 import type { Config } from "../src/config.js";
 import { createEngineHostAdapter } from "../src/agent/engine-host-adapter.js";
+import type { RefreshFailureReason } from "../src/auth/refresh-failure.js";
 import {
   LegacyAthleteStateUnavailableError,
   legacyStateReader,
@@ -44,13 +48,52 @@ function apiError(statusCode: number, responseHeaders?: Record<string, string>):
   });
 }
 
+const sport: Sport = {
+  id: "cycling",
+  soul: "",
+  skills: {},
+  sessionClusterGapMinutes: 30,
+  memorySections: [],
+  mustPreserveTokens: [],
+  intervalsActivityTypes: [],
+  athleteProfileSchema: z.object({}),
+  tools: () => [],
+};
+
+function codexConfig(dataDir: string): Config {
+  return {
+    ...config(dataDir),
+    llm: {
+      provider: "openai-codex",
+      model: "gpt-5.4",
+      apiKey: "",
+      authProfile: "openai-codex",
+    },
+  };
+}
+
+const persistentRefreshCases: ReadonlyArray<readonly [RefreshFailureReason, number]> = [
+  ["rate_limit", 4],
+  ["server_error", 3],
+  ["network", 3],
+  ["reauth", 2],
+];
+
 describe("engine host adapter", () => {
   let dataDir: string;
-  afterEach(() => rmSync(dataDir, { recursive: true, force: true }));
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+    rmSync(dataDir, { recursive: true, force: true });
+  });
 
   it("projects immutable engine config with independent chat and compact windows", () => {
     dataDir = mkdtempSync(join(tmpdir(), "engine-host-"));
-    const { ports } = createEngineHostAdapter({ config: config(dataDir), stateReader: legacyStateReader });
+    const { ports } = createEngineHostAdapter({
+      config: config(dataDir),
+      stateReader: legacyStateReader,
+    });
     expect(ports.config).toEqual({
       dataSource: "platform",
       llm: {
@@ -76,7 +119,10 @@ describe("engine host adapter", () => {
 
   it("wires the exact rejecting legacy athlete-state reader", async () => {
     dataDir = mkdtempSync(join(tmpdir(), "engine-host-"));
-    const { ports } = createEngineHostAdapter({ config: config(dataDir), stateReader: legacyStateReader });
+    const { ports } = createEngineHostAdapter({
+      config: config(dataDir),
+      stateReader: legacyStateReader,
+    });
     await expect(ports.stateReader.getAthleteState()).rejects.toEqual(
       new LegacyAthleteStateUnavailableError(
         "The legacy positional facade exposes no persisted athlete-state reader.",
@@ -84,7 +130,7 @@ describe("engine host adapter", () => {
     );
   });
 
-  it("uses one classifier for all eight failure discriminants", () => {
+  it("uses one classifier for every failure discriminant", () => {
     const timeout = Object.assign(new Error("deadline exceeded"), { name: "TimeoutError" });
     const network = Object.assign(new TypeError("fetch failed"), {
       cause: { code: "ECONNREFUSED" },
@@ -97,6 +143,7 @@ describe("engine host adapter", () => {
       classifyFailure(server),
       classifyFailure(network),
       classifyFailure(apiError(401)),
+      classifyFailure({ refreshFailureReason: "reauth" }),
       classifyFailure(apiError(400)),
       classifyFailure(new Error("unclassified")),
     ]).toEqual([
@@ -106,9 +153,35 @@ describe("engine host adapter", () => {
       "server_error",
       "network",
       "auth",
+      "reauth",
       "invalid_request",
       "unknown",
     ]);
+  });
+
+  it("classifies copied refresh failures only from the structural discriminant", () => {
+    expect(
+      classifyFailure({
+        name: "ForeignPackageError",
+        message: "Opaque synthetic failure",
+        refreshFailureReason: "reauth",
+      }),
+    ).toBe("reauth");
+    expect(
+      classifyFailure({
+        name: "ForeignPackageError",
+        message: "Opaque synthetic failure",
+        refreshFailureReason: "rate_limit",
+      }),
+    ).toBe("rate_limit");
+    expect(
+      classifyFailure(
+        Object.assign(new Error("Failed to refresh OAuth token"), {
+          name: "RefreshTokenReusedError",
+        }),
+      ),
+    ).toBe("unknown");
+    expect(classifyFailure({ refreshFailureReason: "credential_denied" })).toBe("unknown");
   });
 
   it("parses retry-after milliseconds and seconds through the injected helper", () => {
@@ -116,4 +189,61 @@ describe("engine host adapter", () => {
     expect(extractRetryAfterMs(apiError(429, { "retry-after": "3" }))).toBe(3000);
     expect(extractRetryAfterMs(new Error("none"))).toBeNull();
   });
+
+  it.each(persistentRefreshCases)(
+    "bounds persistent %s refresh failures at the owning retry layer (%i endpoint calls)",
+    async (reason, expectedCalls) => {
+      dataDir = mkdtempSync(join(tmpdir(), "engine-host-composed-"));
+      mkdirSync(join(dataDir, "memory"), { recursive: true });
+      writeFileSync(
+        join(dataDir, "auth-profiles.json"),
+        JSON.stringify({
+          "openai-codex": {
+            type: "oauth",
+            access: "synthetic-expired-access",
+            refresh: "synthetic-refresh",
+            expires: 0,
+            accountId: "synthetic-account",
+          },
+        }),
+        { mode: 0o600 },
+      );
+      vi.stubEnv("CYCLING_COACH_HOME", dataDir);
+      vi.resetModules();
+      const tokenEndpoint = "https://auth.openai.com/oauth/token";
+      const fetchStub = vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+        if (reason === "network") {
+          throw Object.assign(new TypeError("Synthetic network failure"), {
+            cause: { code: "ECONNRESET" },
+          });
+        }
+        if (reason === "rate_limit") return new Response("", { status: 429 });
+        if (reason === "server_error") return new Response("", { status: 503 });
+        return new Response(JSON.stringify({ error: "invalid_grant" }), { status: 400 });
+      });
+      vi.spyOn(console, "error").mockImplementation(() => {});
+      vi.spyOn(console, "warn").mockImplementation(() => {});
+      const { createEngineHostAdapter: createFreshAdapter } =
+        await import("../src/agent/engine-host-adapter.js");
+      const { ports } = createFreshAdapter({
+        config: codexConfig(dataDir),
+        stateReader: legacyStateReader,
+      });
+      const engine = createCoachEngine({ sport, ports });
+
+      vi.useFakeTimers();
+      const settled = engine.chat({ chatId: `persistent-${reason}`, message: "hello" }).then(
+        () => null,
+        (failure: unknown) => failure,
+      );
+      await vi.advanceTimersByTimeAsync(120_000);
+      const failure = await settled;
+
+      expect(ports.classifyFailure(failure)).toBe(reason);
+      expect(fetchStub).toHaveBeenCalledTimes(expectedCalls);
+      expect(fetchStub.mock.calls.map(([input]) => String(input))).toEqual(
+        Array.from({ length: expectedCalls }, () => tokenEndpoint),
+      );
+    },
+  );
 });

--- a/packages/core/tests/error-classify.test.ts
+++ b/packages/core/tests/error-classify.test.ts
@@ -14,6 +14,33 @@ function apiError(statusCode: number): APICallError {
 }
 
 describe("classifyAgentError", () => {
+  it("gives structurally tagged reauthentication an actionable sign-in path", () => {
+    const result = classifyAgentError(
+      Object.assign(new Error("rate limit"), {
+        refreshFailureReason: "reauth",
+        kind: "RateLimit",
+        retryAfterMs: 3_000,
+      }),
+    );
+
+    expect(result).toEqual({
+      kind: "provider-auth",
+      athleteMessage: "Your ChatGPT sign-in is no longer valid. Sign in again to continue.",
+    });
+  });
+
+  it("keeps a structurally tagged refresh rate limit in the rate-limit lane", () => {
+    const result = classifyAgentError({
+      refreshFailureReason: "rate_limit",
+      retryAfterMs: 3_000,
+    });
+
+    expect(result).toEqual({
+      kind: "rate_limit",
+      athleteMessage: "Rate limited — please try again in ~3 seconds.",
+    });
+  });
+
   it("classifies 401/403 as provider-auth with provider-neutral copy", () => {
     for (const status of [401, 403]) {
       const result = classifyAgentError(apiError(status));
@@ -26,7 +53,7 @@ describe("classifyAgentError", () => {
   });
 
   it("classifies 5xx as provider-down", () => {
-    for (const status of [500, 502, 503, 504, 529]) {
+    for (const status of [500, 501, 502, 503, 504, 529, 599]) {
       const result = classifyAgentError(apiError(status));
       expect(result.kind).toBe("provider-down");
       expect(result.athleteMessage).toBe(
@@ -52,9 +79,7 @@ describe("classifyAgentError", () => {
     const result = classifyAgentError(err);
     expect(result.kind).toBe("rate_limit");
     expect(result.athleteMessage).toContain(formatRateLimitWait(err));
-    expect(result.athleteMessage).toBe(
-      "Rate limited — please try again in about a minute.",
-    );
+    expect(result.athleteMessage).toBe("Rate limited — please try again in about a minute.");
   });
 
   it("classifies intervals Unauthorized/Forbidden as intervals with the credentials copy, NotFound as intervals transient", () => {

--- a/packages/core/tests/fixtures/profile-store-lock-child.ts
+++ b/packages/core/tests/fixtures/profile-store-lock-child.ts
@@ -1,0 +1,89 @@
+import { existsSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import {
+  compareAndSaveStoredProfile,
+  loadStoredProfileSnapshot,
+  recoverAndSaveStoredProfile,
+  saveStoredProfile,
+} from "../../src/auth/profile-store.js";
+import { atomicWriteFileSync } from "../../src/io/atomic-write-file-sync.js";
+import { withInterprocessFileLockSync } from "../../src/io/interprocess-file-lock-sync.js";
+
+const mode = process.argv[2];
+const profilesPath = process.argv[3];
+const readyPath = process.argv[4];
+const releasePath = process.argv[5];
+const profileName = process.argv[6];
+const access = process.argv[7];
+
+if (
+  (mode !== "barrier-recovery" &&
+    mode !== "barrier-writer" &&
+    mode !== "cas" &&
+    mode !== "holder" &&
+    mode !== "writer") ||
+  profilesPath === undefined ||
+  readyPath === undefined ||
+  releasePath === undefined ||
+  profileName === undefined ||
+  access === undefined
+) {
+  throw new Error("Invalid synthetic profile-store child arguments");
+}
+
+if (mode === "holder") {
+  withInterprocessFileLockSync(join(dirname(profilesPath), ".auth-profiles.lock"), () => {
+    writeFileSync(readyPath, "ready\n", { mode: 0o600 });
+    while (!existsSync(releasePath)) {
+      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);
+    }
+    atomicWriteFileSync(
+      profilesPath,
+      JSON.stringify(
+        {
+          alpha: { type: "oauth", access: "alpha-access", refresh: "alpha-refresh", expires: 1 },
+        },
+        null,
+        2,
+      ),
+    );
+  });
+} else if (mode === "writer" || mode === "barrier-writer") {
+  writeFileSync(readyPath, "attempted\n", { mode: 0o600 });
+  if (mode === "barrier-writer") {
+    while (!existsSync(releasePath)) {
+      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);
+    }
+  }
+  saveStoredProfile(profilesPath, profileName, {
+    type: "oauth",
+    access,
+    refresh: `${access}-refresh`,
+    expires: 2,
+  });
+} else if (mode === "cas") {
+  const expected = loadStoredProfileSnapshot(profilesPath, profileName);
+  if (expected === null) throw new Error("Expected synthetic profile snapshot");
+  writeFileSync(readyPath, "ready\n", { mode: 0o600 });
+  while (!existsSync(releasePath)) {
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);
+  }
+  const result = await compareAndSaveStoredProfile(profilesPath, profileName, expected, {
+    type: "oauth",
+    access,
+    refresh: `${access}-refresh`,
+    expires: 3,
+  });
+  writeFileSync(`${readyPath}.result`, JSON.stringify(result), { mode: 0o600 });
+} else {
+  writeFileSync(readyPath, "attempted\n", { mode: 0o600 });
+  while (!existsSync(releasePath)) {
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);
+  }
+  recoverAndSaveStoredProfile(profilesPath, profileName, {
+    type: "oauth",
+    access,
+    refresh: `${access}-refresh`,
+    expires: 4,
+  });
+}

--- a/packages/core/tests/interprocess-file-lock-sync.test.ts
+++ b/packages/core/tests/interprocess-file-lock-sync.test.ts
@@ -1,0 +1,596 @@
+import { createHash } from "node:crypto";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  rmdirSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  InterprocessFileLockClaimError,
+  InterprocessFileLockTimeoutError,
+  withInterprocessFileLock,
+  withInterprocessFileLockSync,
+} from "../src/io/interprocess-file-lock-sync.js";
+
+const tempDirs: string[] = [];
+
+function freshLockPath(): string {
+  const directory = mkdtempSync(join(tmpdir(), "core-file-lock-"));
+  tempDirs.push(directory);
+  return join(directory, ".auth-profiles.lock");
+}
+
+function claim(pid: number, nonce: string, createdAt = "1998-01-01T00:00:00.000Z"): string {
+  return `${JSON.stringify({ version: 1, pid, nonce, createdAt })}\n`;
+}
+
+function markerName(nonce: string): string {
+  return `owner-${createHash("sha256").update(nonce).digest("hex")}.json`;
+}
+
+function markerPath(lockPath: string, nonce: string): string {
+  return join(lockPath, markerName(nonce));
+}
+
+function publishClaim(
+  lockPath: string,
+  pid: number,
+  nonce: string,
+  options: { directoryMode?: number; markerMode?: number } = {},
+): string {
+  mkdirSync(lockPath, { mode: options.directoryMode ?? 0o700 });
+  const path = markerPath(lockPath, nonce);
+  writeFileSync(path, claim(pid, nonce), { mode: options.markerMode ?? 0o600 });
+  return path;
+}
+
+function readOnlyClaim(lockPath: string): Record<string, unknown> {
+  const entries = readdirSync(lockPath);
+  expect(entries).toHaveLength(1);
+  return JSON.parse(readFileSync(join(lockPath, entries[0]!), "utf8")) as Record<string, unknown>;
+}
+
+function removePublishedClaim(lockPath: string): void {
+  for (const entry of readdirSync(lockPath)) unlinkSync(join(lockPath, entry));
+  rmdirSync(lockPath);
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const directory of tempDirs.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("interprocess file lock", () => {
+  it("publishes a complete private owner marker before running the action", () => {
+    const lockPath = freshLockPath();
+    let observed: unknown;
+
+    withInterprocessFileLockSync(
+      lockPath,
+      () => {
+        observed = readOnlyClaim(lockPath);
+        expect(statSync(lockPath).isDirectory()).toBe(true);
+        expect(statSync(lockPath).mode & 0o777).toBe(0o700);
+        expect(statSync(markerPath(lockPath, "synthetic-owner-nonce")).mode & 0o777).toBe(0o600);
+      },
+      {
+        nonce: () => "synthetic-owner-nonce",
+        timestamp: () => "1998-02-03T04:05:06.000Z",
+      },
+    );
+
+    expect(observed).toEqual({
+      version: 1,
+      pid: process.pid,
+      nonce: "synthetic-owner-nonce",
+      createdAt: "1998-02-03T04:05:06.000Z",
+    });
+    expect(() => statSync(lockPath)).toThrow();
+    expect(readdirSync(join(lockPath, ".."))).toEqual([]);
+  });
+
+  it("bounds a synchronous wait for a live holder at exactly two seconds", () => {
+    const lockPath = freshLockPath();
+    const originalPath = publishClaim(lockPath, 42_001, "live-owner");
+    const original = readFileSync(originalPath, "utf8");
+    let elapsed = 0;
+    const waits: number[] = [];
+
+    expect(() =>
+      withInterprocessFileLockSync(lockPath, () => {}, {
+        now: () => elapsed,
+        pidStatus: () => "live",
+        sleepSync(milliseconds) {
+          waits.push(milliseconds);
+          elapsed += milliseconds;
+        },
+      }),
+    ).toThrow(InterprocessFileLockTimeoutError);
+
+    expect(elapsed).toBe(2_000);
+    expect(waits.every((milliseconds) => milliseconds === 25)).toBe(true);
+    expect(readFileSync(originalPath, "utf8")).toBe(original);
+    expect(readdirSync(join(lockPath, "..")).filter((name) => name.includes(".tmp."))).toEqual([]);
+  });
+
+  it("treats EPERM from the PID probe as a live owner", () => {
+    const lockPath = freshLockPath();
+    const originalPath = publishClaim(lockPath, 42_002, "protected-owner");
+    const denied = Object.assign(new Error("synthetic permission denial"), { code: "EPERM" });
+    vi.spyOn(process, "kill").mockImplementation(() => {
+      throw denied;
+    });
+    let elapsed = 0;
+
+    expect(() =>
+      withInterprocessFileLockSync(lockPath, () => {}, {
+        now: () => elapsed,
+        sleepSync(milliseconds) {
+          elapsed += milliseconds;
+        },
+      }),
+    ).toThrow(InterprocessFileLockTimeoutError);
+    expect(readFileSync(originalPath, "utf8")).toBe(claim(42_002, "protected-owner"));
+  });
+
+  it("reclaims a marker published by a definitely dead owner", () => {
+    const lockPath = freshLockPath();
+    publishClaim(lockPath, 42_003, "dead-owner");
+    let actionClaim: unknown;
+
+    withInterprocessFileLockSync(
+      lockPath,
+      () => {
+        actionClaim = readOnlyClaim(lockPath);
+      },
+      {
+        nonce: () => "successor-owner",
+        pidStatus: (pid) => (pid === 42_003 ? "dead" : "live"),
+      },
+    );
+
+    expect(actionClaim).toMatchObject({ pid: process.pid, nonce: "successor-owner" });
+    expect(() => statSync(lockPath)).toThrow();
+  });
+
+  it("recovers an empty provisional lock directory", () => {
+    const lockPath = freshLockPath();
+    mkdirSync(lockPath, { mode: 0o700 });
+    let actionRan = false;
+
+    withInterprocessFileLockSync(lockPath, () => {
+      actionRan = true;
+    });
+
+    expect(actionRan).toBe(true);
+    expect(() => statSync(lockPath)).toThrow();
+  });
+
+  it("fails closed on a malformed marker without changing its bytes", () => {
+    const lockPath = freshLockPath();
+    mkdirSync(lockPath, { mode: 0o700 });
+    const path = join(lockPath, markerName("malformed-owner"));
+    const malformed = "not-json{{\nprivate-token-marker";
+    writeFileSync(path, malformed, { mode: 0o600 });
+
+    expect(() => withInterprocessFileLockSync(lockPath, () => {})).toThrow(
+      InterprocessFileLockClaimError,
+    );
+    expect(readFileSync(path, "utf8")).toBe(malformed);
+  });
+
+  it("fails closed on an invalid UTF-8 marker without changing its bytes", () => {
+    const lockPath = freshLockPath();
+    mkdirSync(lockPath, { mode: 0o700 });
+    const decodedNonce = "invalid-\uFFFD-owner";
+    const path = join(lockPath, markerName(decodedNonce));
+    const invalidUtf8Claim = Buffer.concat([
+      Buffer.from('{"version":1,"pid":42013,"nonce":"invalid-'),
+      Buffer.from([0x80]),
+      Buffer.from('","createdAt":"1998-01-01T00:00:00.000Z"}\n'),
+    ]);
+    writeFileSync(path, invalidUtf8Claim, { mode: 0o600 });
+    let actionRan = false;
+
+    expect(() =>
+      withInterprocessFileLockSync(
+        lockPath,
+        () => {
+          actionRan = true;
+        },
+        {
+          nonce: () => "invalid-utf8-successor",
+          pidStatus: (pid) => (pid === 42_013 ? "dead" : "live"),
+        },
+      ),
+    ).toThrow(InterprocessFileLockClaimError);
+    expect(actionRan).toBe(false);
+    expect(readdirSync(lockPath)).toEqual([markerName(decodedNonce)]);
+    expect(readFileSync(path)).toEqual(invalidUtf8Claim);
+  });
+
+  it("fails closed when the reusable public lock path is not a directory", () => {
+    const lockPath = freshLockPath();
+    const malformed = "not-a-lock-directory";
+    writeFileSync(lockPath, malformed, { mode: 0o600 });
+
+    expect(() => withInterprocessFileLockSync(lockPath, () => {})).toThrow(
+      InterprocessFileLockClaimError,
+    );
+    expect(readFileSync(lockPath, "utf8")).toBe(malformed);
+  });
+
+  it("preserves a successor published between exact-marker release and directory removal", () => {
+    const lockPath = freshLockPath();
+    const successor = claim(42_004, "release-successor");
+
+    withInterprocessFileLockSync(lockPath, () => {}, {
+      afterReleaseMarkerRemoved(path) {
+        rmdirSync(path);
+        mkdirSync(path, { mode: 0o700 });
+        writeFileSync(markerPath(path, "release-successor"), successor, { mode: 0o600 });
+      },
+    });
+
+    expect(readFileSync(markerPath(lockPath, "release-successor"), "utf8")).toBe(successor);
+    expect(statSync(lockPath).isDirectory()).toBe(true);
+  });
+
+  it("fails closed when its nonce marker changes before the action", () => {
+    const lockPath = freshLockPath();
+    let actionRan = false;
+
+    expect(() =>
+      withInterprocessFileLockSync(
+        lockPath,
+        () => {
+          actionRan = true;
+        },
+        {
+          afterClaimPublished(path) {
+            const [entry] = readdirSync(path);
+            if (entry === undefined) throw new Error("Expected owner marker");
+            writeFileSync(join(path, entry), claim(42_006, "changed-owner"), { mode: 0o600 });
+          },
+        },
+      ),
+    ).toThrow(InterprocessFileLockClaimError);
+    expect(actionRan).toBe(false);
+    expect(statSync(lockPath).isDirectory()).toBe(true);
+  });
+
+  it("fails closed when an unexpected extra owner marker appears before the action", () => {
+    const lockPath = freshLockPath();
+    let actionRan = false;
+    let elapsed = 0;
+
+    expect(() =>
+      withInterprocessFileLockSync(
+        lockPath,
+        () => {
+          actionRan = true;
+        },
+        {
+          nonce: () => "expected-owner",
+          now: () => elapsed,
+          pidStatus: () => "live",
+          sleepSync(milliseconds) {
+            elapsed += milliseconds;
+          },
+          afterClaimPublished(path) {
+            writeFileSync(
+              markerPath(path, "unexpected-owner"),
+              claim(process.pid, "unexpected-owner"),
+              { mode: 0o600 },
+            );
+          },
+        },
+      ),
+    ).toThrow(InterprocessFileLockTimeoutError);
+    expect(actionRan).toBe(false);
+    expect(readdirSync(lockPath)).toEqual([markerName("unexpected-owner")]);
+    expect(readOnlyClaim(lockPath)).toMatchObject({ nonce: "unexpected-owner" });
+  });
+
+  it("retries when a contender removes the provisional directory during publication", () => {
+    const lockPath = freshLockPath();
+    let publications = 0;
+    let actionRan = false;
+
+    withInterprocessFileLockSync(
+      lockPath,
+      () => {
+        actionRan = true;
+      },
+      {
+        nonce: () => `creator-${publications}`,
+        afterClaimPublished(path) {
+          publications += 1;
+          if (publications !== 1) return;
+          removePublishedClaim(path);
+          mkdirSync(path, { mode: 0o700 });
+        },
+      },
+    );
+
+    expect(publications).toBe(2);
+    expect(actionRan).toBe(true);
+    expect(() => statSync(lockPath)).toThrow();
+  });
+
+  it("retries when its exact provisional marker disappears from the same directory", () => {
+    const lockPath = freshLockPath();
+    let publications = 0;
+    let actionRan = false;
+
+    withInterprocessFileLockSync(
+      lockPath,
+      () => {
+        actionRan = true;
+      },
+      {
+        nonce: () => `marker-owner-${publications}`,
+        afterClaimPublished(path) {
+          publications += 1;
+          if (publications !== 1) return;
+          const [entry] = readdirSync(path);
+          if (entry === undefined) throw new Error("Expected owner marker");
+          unlinkSync(join(path, entry));
+        },
+      },
+    );
+
+    expect(publications).toBe(2);
+    expect(actionRan).toBe(true);
+    expect(() => statSync(lockPath)).toThrow();
+  });
+
+  it("cleans up an exact published marker after a post-publication failure", () => {
+    const lockPath = freshLockPath();
+    const failure = new Error("synthetic post-publication failure");
+
+    expect(() =>
+      withInterprocessFileLockSync(lockPath, () => {}, {
+        nonce: () => "failed-published-owner",
+        afterClaimPublished() {
+          throw failure;
+        },
+      }),
+    ).toThrow(failure);
+    expect(() => statSync(lockPath)).toThrow();
+    expect(() =>
+      withInterprocessFileLockSync(lockPath, () => {}, {
+        nonce: () => "subsequent-owner",
+      }),
+    ).not.toThrow();
+    expect(readdirSync(join(lockPath, ".."))).toEqual([]);
+  });
+
+  it("keeps strict directory and marker permissions on POSIX platforms", () => {
+    const lockPath = freshLockPath();
+    publishClaim(lockPath, 42_011, "broad-posix-permissions", {
+      directoryMode: 0o755,
+      markerMode: 0o644,
+    });
+
+    expect(() => withInterprocessFileLockSync(lockPath, () => {}, { platform: "linux" })).toThrow(
+      InterprocessFileLockClaimError,
+    );
+  });
+
+  it("accepts a regular marker when Windows cannot represent POSIX mode bits", () => {
+    const lockPath = freshLockPath();
+    publishClaim(lockPath, 42_012, "windows-owner", {
+      directoryMode: 0o755,
+      markerMode: 0o644,
+    });
+    let actionRan = false;
+
+    withInterprocessFileLockSync(
+      lockPath,
+      () => {
+        actionRan = true;
+      },
+      {
+        platform: "win32",
+        pidStatus: (pid) => (pid === 42_012 ? "dead" : "live"),
+        nonce: () => "windows-successor",
+      },
+    );
+
+    expect(actionRan).toBe(true);
+    expect(() => statSync(lockPath)).toThrow();
+  });
+
+  it("does not delete a live successor when two reclaimers observe the same dead marker", async () => {
+    const lockPath = freshLockPath();
+    publishClaim(lockPath, 42_007, "observed-dead");
+    let releaseSecond!: () => void;
+    const secondGate = new Promise<void>((resolve) => {
+      releaseSecond = resolve;
+    });
+    let second: Promise<void> | undefined;
+    let activeActions = 0;
+    let maximumActiveActions = 0;
+    const writes: string[] = [];
+
+    await withInterprocessFileLock(
+      lockPath,
+      async () => {
+        activeActions += 1;
+        maximumActiveActions = Math.max(maximumActiveActions, activeActions);
+        writes.push("first");
+        activeActions -= 1;
+      },
+      {
+        nonce: () => "first-reclaimer",
+        pid: 42_101,
+        pidStatus: (pid) => (pid === 42_007 ? "dead" : "live"),
+        afterDeadClaimVerified() {
+          if (second !== undefined) return;
+          second = withInterprocessFileLock(
+            lockPath,
+            async () => {
+              activeActions += 1;
+              maximumActiveActions = Math.max(maximumActiveActions, activeActions);
+              writes.push("second");
+              await secondGate;
+              activeActions -= 1;
+            },
+            {
+              nonce: () => "second-reclaimer",
+              pid: 42_102,
+              pidStatus: (pid) => (pid === 42_007 ? "dead" : "live"),
+            },
+          );
+        },
+        async delay() {
+          expect(readOnlyClaim(lockPath)).toMatchObject({
+            pid: 42_102,
+            nonce: "second-reclaimer",
+          });
+          releaseSecond();
+          await second;
+        },
+      },
+    );
+
+    await second;
+    expect(writes).toEqual(["second", "first"]);
+    expect(maximumActiveActions).toBe(1);
+    expect(() => statSync(lockPath)).toThrow();
+  });
+
+  it("cleans up its marker, directory, and temp file when the action throws", () => {
+    const lockPath = freshLockPath();
+    const failure = new Error("synthetic action failure");
+
+    expect(() =>
+      withInterprocessFileLockSync(lockPath, () => {
+        throw failure;
+      }),
+    ).toThrow(failure);
+    expect(readdirSync(join(lockPath, ".."))).toEqual([]);
+  });
+
+  it("waits asynchronously and acquires after the holder releases", async () => {
+    const lockPath = freshLockPath();
+    publishClaim(lockPath, 42_009, "async-holder");
+    let elapsed = 0;
+    let actionRan = false;
+
+    await withInterprocessFileLock(
+      lockPath,
+      () => {
+        actionRan = true;
+      },
+      {
+        now: () => elapsed,
+        pidStatus: () => "live",
+        async delay(milliseconds) {
+          elapsed += milliseconds;
+          if (elapsed === 50) removePublishedClaim(lockPath);
+        },
+      },
+    );
+
+    expect(elapsed).toBe(50);
+    expect(actionRan).toBe(true);
+    expect(readdirSync(join(lockPath, ".."))).toEqual([]);
+  });
+
+  it("holds the lock until an asynchronous action settles", async () => {
+    const lockPath = freshLockPath();
+    let releaseFirst!: () => void;
+    let releaseRetry!: () => void;
+    let markFirstEntered!: () => void;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const retryGate = new Promise<void>((resolve) => {
+      releaseRetry = resolve;
+    });
+    const firstEntered = new Promise<void>((resolve) => {
+      markFirstEntered = resolve;
+    });
+    const first = withInterprocessFileLock(lockPath, async () => {
+      markFirstEntered();
+      await firstGate;
+    });
+    await firstEntered;
+    let secondRan = false;
+    const delay = vi.fn(async () => retryGate);
+    const second = withInterprocessFileLock(
+      lockPath,
+      () => {
+        secondRan = true;
+      },
+      { delay, pidStatus: () => "live" },
+    );
+    await vi.waitFor(() => expect(delay).toHaveBeenCalledOnce());
+
+    expect(secondRan).toBe(false);
+    expect(statSync(lockPath).isDirectory()).toBe(true);
+    releaseFirst();
+    await first;
+    releaseRetry();
+    await second;
+
+    expect(secondRan).toBe(true);
+    expect(() => statSync(lockPath)).toThrow();
+  });
+
+  it("bounds an asynchronous wait at exactly two seconds", async () => {
+    const lockPath = freshLockPath();
+    const originalPath = publishClaim(lockPath, 42_010, "async-live-holder");
+    const original = readFileSync(originalPath, "utf8");
+    let elapsed = 0;
+
+    await expect(
+      withInterprocessFileLock(lockPath, () => {}, {
+        now: () => elapsed,
+        pidStatus: () => "live",
+        async delay(milliseconds) {
+          elapsed += milliseconds;
+        },
+      }),
+    ).rejects.toBeInstanceOf(InterprocessFileLockTimeoutError);
+    expect(elapsed).toBe(2_000);
+    expect(readFileSync(originalPath, "utf8")).toBe(original);
+  });
+
+  it("does not enter when its exact marker is replaced without changing the directory", () => {
+    const lockPath = freshLockPath();
+    let actionRan = false;
+
+    expect(() =>
+      withInterprocessFileLockSync(
+        lockPath,
+        () => {
+          actionRan = true;
+        },
+        {
+          afterClaimPublished(path) {
+            const [entry] = readdirSync(path);
+            if (entry === undefined) throw new Error("Expected owner marker");
+            unlinkSync(join(path, entry));
+            writeFileSync(join(path, entry), claim(process.pid, "different-nonce"), {
+              mode: 0o600,
+            });
+          },
+        },
+      ),
+    ).toThrow(InterprocessFileLockClaimError);
+    expect(actionRan).toBe(false);
+  });
+});

--- a/packages/core/tests/profile-store.test.ts
+++ b/packages/core/tests/profile-store.test.ts
@@ -1,0 +1,718 @@
+import { createHash } from "node:crypto";
+import { type ChildProcess, spawn } from "node:child_process";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  compareAndSaveStoredProfile,
+  loadStoredProfileSnapshot,
+  recoverAndSaveStoredProfile,
+  saveStoredProfile,
+} from "../src/auth/profile-store.js";
+import { InterprocessFileLockTimeoutError } from "../src/io/interprocess-file-lock-sync.js";
+
+const tempDirs: string[] = [];
+const children: ChildProcess[] = [];
+const childFixture = fileURLToPath(
+  new URL("./fixtures/profile-store-lock-child.ts", import.meta.url),
+);
+const profileSaveOrderings: ReadonlyArray<"cas-first" | "save-first"> = ["cas-first", "save-first"];
+const reservedProfileNames = ["__proto__", "constructor", "toString"] as const;
+
+function freshProfilesPath(): string {
+  const directory = mkdtempSync(join(tmpdir(), "core-profile-store-"));
+  tempDirs.push(directory);
+  return join(directory, "auth-profiles.json");
+}
+
+function profile(access: string, extra: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    ...extra,
+    type: "oauth",
+    access,
+    refresh: `${access}-refresh`,
+    expires: 4_102_444_800_000,
+  };
+}
+
+function invalidUtf8ProfilesBytes(profileName = "alpha"): Buffer {
+  return Buffer.concat([
+    Buffer.from(`{"${profileName}":{"type":"oauth","access":"invalid-`, "utf8"),
+    Buffer.from([0xc3, 0x28]),
+    Buffer.from('","refresh":"invalid-refresh","expires":4102444800000}}', "utf8"),
+  ]);
+}
+
+function lockMarkerPath(lockPath: string, nonce: string): string {
+  const digest = createHash("sha256").update(nonce).digest("hex");
+  return join(lockPath, `owner-${digest}.json`);
+}
+
+function publishLockClaim(lockPath: string, pid: number, nonce: string): void {
+  mkdirSync(lockPath, { mode: 0o700 });
+  writeFileSync(
+    lockMarkerPath(lockPath, nonce),
+    `${JSON.stringify({
+      version: 1,
+      pid,
+      nonce,
+      createdAt: "1998-01-01T00:00:00.000Z",
+    })}\n`,
+    { mode: 0o600 },
+  );
+}
+
+function spawnStoreChild(
+  mode: "barrier-recovery" | "barrier-writer" | "cas" | "holder" | "writer",
+  profilesPath: string,
+  readyPath: string,
+  releasePath: string,
+  profileName = "beta",
+  access = "beta-access",
+): ChildProcess {
+  const child = spawn(
+    process.execPath,
+    [
+      "--import",
+      "tsx",
+      childFixture,
+      mode,
+      profilesPath,
+      readyPath,
+      releasePath,
+      profileName,
+      access,
+    ],
+    { cwd: process.cwd(), stdio: ["ignore", "ignore", "pipe"] },
+  );
+  children.push(child);
+  return child;
+}
+
+async function waitForPath(path: string): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  while (!existsSync(path)) {
+    if (Date.now() >= deadline) throw new Error("Synthetic child barrier timed out");
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
+async function waitForChild(child: ChildProcess, allowFailure = false): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    if (!allowFailure && child.exitCode !== 0)
+      throw new Error(`Synthetic child exited ${child.exitCode}`);
+    return;
+  }
+  let stderr = "";
+  child.stderr?.setEncoding("utf8");
+  child.stderr?.on("data", (chunk: string) => {
+    stderr += chunk;
+  });
+  await new Promise<void>((resolve, reject) => {
+    child.once("error", reject);
+    child.once("exit", (code, signal) => {
+      if (allowFailure || code === 0) resolve();
+      else reject(new Error(`Synthetic child exited ${code ?? signal}: ${stderr}`));
+    });
+  });
+}
+
+afterEach(async () => {
+  vi.useRealTimers();
+  for (const child of children.splice(0)) {
+    if (child.exitCode === null) child.kill("SIGKILL");
+    await waitForChild(child, true);
+  }
+  for (const directory of tempDirs.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("profile store", () => {
+  it("saves synchronously under the sibling lock and preserves unrelated profiles", () => {
+    const profilesPath = freshProfilesPath();
+    saveStoredProfile(profilesPath, "alpha", profile("alpha"));
+    saveStoredProfile(profilesPath, "beta", profile("beta"));
+
+    const stored = JSON.parse(readFileSync(profilesPath, "utf8"));
+    expect(stored).toMatchObject({
+      alpha: { access: "alpha" },
+      beta: { access: "beta" },
+    });
+    expect(statSync(profilesPath).mode & 0o777).toBe(0o600);
+    expect(readdirSync(join(profilesPath, "..")).sort()).toEqual(["auth-profiles.json"]);
+  });
+
+  it.each(reservedProfileNames)(
+    "treats the reserved profile name %s as an own key during save and load",
+    (name) => {
+      const profilesPath = freshProfilesPath();
+      saveStoredProfile(profilesPath, "unrelated", profile("unrelated"));
+
+      expect(loadStoredProfileSnapshot(profilesPath, name)).toBeNull();
+
+      saveStoredProfile(profilesPath, name, profile(`${name}-access`));
+
+      const stored = JSON.parse(readFileSync(profilesPath, "utf8")) as Record<string, unknown>;
+      expect(Object.hasOwn(stored, name)).toBe(true);
+      expect(stored[name]).toMatchObject({ access: `${name}-access` });
+      expect(stored.unrelated).toMatchObject({ access: "unrelated" });
+      expect(loadStoredProfileSnapshot(profilesPath, name)?.profile).toMatchObject({
+        access: `${name}-access`,
+      });
+    },
+  );
+
+  it.each(reservedProfileNames)(
+    "compares and saves the reserved profile name %s without inherited-key confusion",
+    async (name) => {
+      const profilesPath = freshProfilesPath();
+      saveStoredProfile(profilesPath, "unrelated", profile("unrelated"));
+      const unrelated = loadStoredProfileSnapshot(profilesPath, "unrelated");
+      if (unrelated === null) throw new Error("Expected synthetic profile snapshot");
+      const beforeMissingCompare = readFileSync(profilesPath);
+
+      await expect(
+        compareAndSaveStoredProfile(profilesPath, name, unrelated, profile("not-saved")),
+      ).resolves.toEqual({ status: "missing" });
+      expect(readFileSync(profilesPath)).toEqual(beforeMissingCompare);
+
+      saveStoredProfile(profilesPath, name, profile("original"));
+      const expected = loadStoredProfileSnapshot(profilesPath, name);
+      if (expected === null) throw new Error("Expected synthetic profile snapshot");
+
+      await expect(
+        compareAndSaveStoredProfile(profilesPath, name, expected, profile("replacement")),
+      ).resolves.toMatchObject({ status: "saved", profile: { access: "replacement" } });
+      await expect(
+        compareAndSaveStoredProfile(profilesPath, name, expected, profile("stale")),
+      ).resolves.toMatchObject({
+        status: "superseded",
+        profile: { access: "replacement" },
+      });
+
+      const stored = JSON.parse(readFileSync(profilesPath, "utf8")) as Record<string, unknown>;
+      expect(Object.hasOwn(stored, name)).toBe(true);
+      expect(stored[name]).toMatchObject({ access: "replacement" });
+      expect(stored.unrelated).toMatchObject({ access: "unrelated" });
+    },
+  );
+
+  it.each(reservedProfileNames)(
+    "salvages reserved profile keys and replaces reserved target %s during recovery",
+    (name) => {
+      const profilesPath = freshProfilesPath();
+      const originalDocument = Object.fromEntries([
+        ...reservedProfileNames.map(
+          (reservedName) => [reservedName, profile(`${reservedName}-original`)] as const,
+        ),
+        ["unrelated", profile("unrelated")],
+        ["invalid", "opaque-child"],
+      ]);
+      const originalBytes = Buffer.from(JSON.stringify(originalDocument), "utf8");
+      writeFileSync(profilesPath, originalBytes, { mode: 0o600 });
+
+      recoverAndSaveStoredProfile(profilesPath, name, profile(`${name}-replacement`));
+
+      const stored = JSON.parse(readFileSync(profilesPath, "utf8")) as Record<string, unknown>;
+      for (const reservedName of reservedProfileNames) {
+        expect(Object.hasOwn(stored, reservedName)).toBe(true);
+        expect(stored[reservedName]).toMatchObject({
+          access:
+            reservedName === name ? `${reservedName}-replacement` : `${reservedName}-original`,
+        });
+      }
+      expect(stored.unrelated).toMatchObject({ access: "unrelated" });
+      expect(Object.hasOwn(stored, "invalid")).toBe(false);
+      expect(readFileSync(`${profilesPath}.corrupt`)).toEqual(originalBytes);
+    },
+  );
+
+  it("compares the complete raw profile, including future optional fields", async () => {
+    const profilesPath = freshProfilesPath();
+    saveStoredProfile(
+      profilesPath,
+      "alpha",
+      profile("original", { future: { generation: 1, enabled: true } }),
+    );
+    const expected = loadStoredProfileSnapshot(profilesPath, "alpha");
+    expect(expected).not.toBeNull();
+    if (expected === null) throw new Error("Expected synthetic profile snapshot");
+
+    saveStoredProfile(
+      profilesPath,
+      "alpha",
+      profile("original", { future: { generation: 2, enabled: true } }),
+    );
+    const currentBytes = readFileSync(profilesPath, "utf8");
+    const result = await compareAndSaveStoredProfile(
+      profilesPath,
+      "alpha",
+      expected,
+      profile("stale-result"),
+    );
+
+    expect(result).toMatchObject({
+      status: "superseded",
+      profile: { access: "original", future: { generation: 2, enabled: true } },
+    });
+    expect(readFileSync(profilesPath, "utf8")).toBe(currentBytes);
+  });
+
+  it("preserves malformed profile bytes when synchronous save cannot read them", () => {
+    const profilesPath = freshProfilesPath();
+    const originalBytes = "{malformed-profile-document\n";
+    writeFileSync(profilesPath, originalBytes, { mode: 0o600 });
+
+    expect(() => saveStoredProfile(profilesPath, "alpha", profile("replacement"))).toThrow(
+      SyntaxError,
+    );
+    expect(readFileSync(profilesPath, "utf8")).toBe(originalBytes);
+  });
+
+  it("fails closed without mutating invalid UTF-8 during load, save, or compare-and-save", async () => {
+    const profilesPath = freshProfilesPath();
+    saveStoredProfile(profilesPath, "alpha", profile("original"));
+    const expected = loadStoredProfileSnapshot(profilesPath, "alpha");
+    if (expected === null) throw new Error("Expected synthetic profile snapshot");
+    const originalBytes = invalidUtf8ProfilesBytes();
+    writeFileSync(profilesPath, originalBytes, { mode: 0o600 });
+
+    expect(() => loadStoredProfileSnapshot(profilesPath, "alpha")).toThrow(TypeError);
+    expect(readFileSync(profilesPath)).toEqual(originalBytes);
+    expect(() => saveStoredProfile(profilesPath, "alpha", profile("replacement"))).toThrow(
+      TypeError,
+    );
+    expect(readFileSync(profilesPath)).toEqual(originalBytes);
+    await expect(
+      compareAndSaveStoredProfile(profilesPath, "alpha", expected, profile("replacement")),
+    ).rejects.toThrow(TypeError);
+    expect(readFileSync(profilesPath)).toEqual(originalBytes);
+  });
+
+  it("recovers invalid UTF-8 regular-file bytes into a private quarantine", () => {
+    const profilesPath = freshProfilesPath();
+    const originalBytes = invalidUtf8ProfilesBytes();
+    writeFileSync(profilesPath, originalBytes, { mode: 0o644 });
+
+    recoverAndSaveStoredProfile(profilesPath, "alpha", profile("replacement"));
+
+    const quarantinePath = `${profilesPath}.corrupt`;
+    expect(readFileSync(quarantinePath)).toEqual(originalBytes);
+    expect(statSync(quarantinePath).mode & 0o777).toBe(0o600);
+    expect(JSON.parse(readFileSync(profilesPath, "utf8"))).toMatchObject({
+      alpha: { access: "replacement" },
+    });
+    expect(statSync(profilesPath).mode & 0o777).toBe(0o600);
+  });
+
+  it("salvages valid unrelated entries while quarantining an invalid child", () => {
+    const profilesPath = freshProfilesPath();
+    const originalBytes = JSON.stringify({
+      retained: profile("retained"),
+      invalid: "opaque-child",
+    });
+    writeFileSync(profilesPath, originalBytes, { mode: 0o600 });
+
+    recoverAndSaveStoredProfile(profilesPath, "alpha", profile("replacement"));
+
+    expect(JSON.parse(readFileSync(profilesPath, "utf8"))).toMatchObject({
+      retained: { access: "retained" },
+      alpha: { access: "replacement" },
+    });
+    expect(readFileSync(`${profilesPath}.corrupt`, "utf8")).toBe(originalBytes);
+  });
+
+  it("retains the malformed active file when the replacement write fails", () => {
+    const profilesPath = freshProfilesPath();
+    const originalBytes = "not-json{{\n";
+    writeFileSync(profilesPath, originalBytes, { mode: 0o600 });
+
+    expect(() =>
+      recoverAndSaveStoredProfile(profilesPath, "alpha", {
+        ...profile("replacement"),
+        unsupported: 1n,
+      }),
+    ).toThrow(TypeError);
+
+    expect(readFileSync(profilesPath, "utf8")).toBe(originalBytes);
+    expect(readFileSync(`${profilesPath}.corrupt`, "utf8")).toBe(originalBytes);
+    expect(statSync(`${profilesPath}.corrupt`).mode & 0o777).toBe(0o600);
+  });
+
+  it("uses collision-safe quarantine names across repeated recoveries", () => {
+    const profilesPath = freshProfilesPath();
+    const firstBytes = "first-malformed{{";
+    const secondBytes = "second-malformed{{";
+    writeFileSync(profilesPath, firstBytes, { mode: 0o600 });
+    recoverAndSaveStoredProfile(profilesPath, "alpha", profile("first"));
+    writeFileSync(profilesPath, secondBytes, { mode: 0o600 });
+    recoverAndSaveStoredProfile(profilesPath, "alpha", profile("second"));
+
+    expect(readFileSync(`${profilesPath}.corrupt`, "utf8")).toBe(firstBytes);
+    expect(readFileSync(`${profilesPath}.corrupt.1`, "utf8")).toBe(secondBytes);
+    expect(statSync(`${profilesPath}.corrupt`).mode & 0o777).toBe(0o600);
+    expect(statSync(`${profilesPath}.corrupt.1`).mode & 0o777).toBe(0o600);
+  });
+
+  it("preserves an invalid root when compare-and-save cannot decode it", async () => {
+    const profilesPath = freshProfilesPath();
+    saveStoredProfile(profilesPath, "alpha", profile("original"));
+    const expected = loadStoredProfileSnapshot(profilesPath, "alpha");
+    if (expected === null) throw new Error("Expected synthetic profile snapshot");
+    const originalBytes = JSON.stringify([profile("unrelated")]);
+    writeFileSync(profilesPath, originalBytes, { mode: 0o600 });
+
+    await expect(
+      compareAndSaveStoredProfile(profilesPath, "alpha", expected, profile("replacement")),
+    ).rejects.toThrow("OAuth profiles document must be a map.");
+    expect(readFileSync(profilesPath, "utf8")).toBe(originalBytes);
+  });
+
+  it("preserves an invalid child entry instead of dropping it during save", () => {
+    const profilesPath = freshProfilesPath();
+    const originalBytes = JSON.stringify({ alpha: profile("original"), future: "opaque" });
+    writeFileSync(profilesPath, originalBytes, { mode: 0o600 });
+
+    expect(() => saveStoredProfile(profilesPath, "beta", profile("replacement"))).toThrow(
+      "OAuth profile entries must be maps.",
+    );
+    expect(readFileSync(profilesPath, "utf8")).toBe(originalBytes);
+  });
+
+  it.runIf(process.platform !== "win32" && process.getuid?.() !== 0)(
+    "preserves a regular profile file when permissions deny reading it",
+    () => {
+      const profilesPath = freshProfilesPath();
+      const originalBytes = JSON.stringify({ alpha: profile("original") });
+      writeFileSync(profilesPath, originalBytes, { mode: 0o600 });
+      chmodSync(profilesPath, 0o000);
+      try {
+        expect(() => saveStoredProfile(profilesPath, "beta", profile("replacement"))).toThrow();
+      } finally {
+        chmodSync(profilesPath, 0o600);
+      }
+      expect(readFileSync(profilesPath, "utf8")).toBe(originalBytes);
+    },
+  );
+
+  it("refuses recovery when the active profile path is not a regular file", () => {
+    const profilesPath = freshProfilesPath();
+    mkdirSync(profilesPath, { mode: 0o700 });
+
+    expect(() =>
+      recoverAndSaveStoredProfile(profilesPath, "alpha", profile("replacement")),
+    ).toThrow("OAuth profiles recovery requires a regular file.");
+    expect(statSync(profilesPath).isDirectory()).toBe(true);
+    expect(existsSync(`${profilesPath}.corrupt`)).toBe(false);
+  });
+
+  it.runIf(process.platform !== "win32" && process.getuid?.() !== 0)(
+    "does not quarantine or overwrite a profile file when reading is denied",
+    () => {
+      const profilesPath = freshProfilesPath();
+      const originalBytes = "not-json{{\n";
+      writeFileSync(profilesPath, originalBytes, { mode: 0o600 });
+      chmodSync(profilesPath, 0o000);
+      try {
+        expect(() =>
+          recoverAndSaveStoredProfile(profilesPath, "alpha", profile("replacement")),
+        ).toThrow();
+        expect(existsSync(`${profilesPath}.corrupt`)).toBe(false);
+      } finally {
+        chmodSync(profilesPath, 0o600);
+      }
+      expect(readFileSync(profilesPath, "utf8")).toBe(originalBytes);
+    },
+  );
+
+  it("does not quarantine or overwrite a profile file after an I/O read error", async () => {
+    const profilesPath = freshProfilesPath();
+    const originalBytes = "not-json{{\n";
+    writeFileSync(profilesPath, originalBytes, { mode: 0o600 });
+    vi.resetModules();
+    vi.doMock("node:fs", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("node:fs")>();
+      return {
+        ...actual,
+        readFileSync(path: Parameters<typeof actual.readFileSync>[0], ...args: unknown[]) {
+          if (path === profilesPath) {
+            throw Object.assign(new Error("synthetic I/O read failure"), { code: "EIO" });
+          }
+          return Reflect.apply(actual.readFileSync, actual, [path, ...args]);
+        },
+      };
+    });
+    try {
+      const profileStore = await import("../src/auth/profile-store.js");
+      expect(() =>
+        profileStore.recoverAndSaveStoredProfile(profilesPath, "alpha", profile("replacement")),
+      ).toThrow(expect.objectContaining({ code: "EIO" }));
+    } finally {
+      vi.doUnmock("node:fs");
+      vi.resetModules();
+    }
+    expect(readFileSync(profilesPath, "utf8")).toBe(originalBytes);
+    expect(existsSync(`${profilesPath}.corrupt`)).toBe(false);
+  });
+
+  it("returns missing without recreating a deleted profile", async () => {
+    const profilesPath = freshProfilesPath();
+    saveStoredProfile(profilesPath, "alpha", profile("original"));
+    const expected = loadStoredProfileSnapshot(profilesPath, "alpha");
+    if (expected === null) throw new Error("Expected synthetic profile snapshot");
+    rmSync(profilesPath);
+
+    await expect(
+      compareAndSaveStoredProfile(profilesPath, "alpha", expected, profile("stale-result")),
+    ).resolves.toEqual({ status: "missing" });
+    expect(existsSync(profilesPath)).toBe(false);
+  });
+
+  it.each(profileSaveOrderings)(
+    "preserves distinct profile keys in the %s ordering",
+    async (ordering) => {
+      const profilesPath = freshProfilesPath();
+      saveStoredProfile(profilesPath, "alpha", profile("alpha-original"));
+      const expected = loadStoredProfileSnapshot(profilesPath, "alpha");
+      if (expected === null) throw new Error("Expected synthetic profile snapshot");
+
+      if (ordering === "cas-first") {
+        await compareAndSaveStoredProfile(
+          profilesPath,
+          "alpha",
+          expected,
+          profile("alpha-rotated"),
+        );
+        saveStoredProfile(profilesPath, "beta", profile("beta-login"));
+      } else {
+        saveStoredProfile(profilesPath, "beta", profile("beta-login"));
+        await compareAndSaveStoredProfile(
+          profilesPath,
+          "alpha",
+          expected,
+          profile("alpha-rotated"),
+        );
+      }
+
+      expect(JSON.parse(readFileSync(profilesPath, "utf8"))).toMatchObject({
+        alpha: { access: "alpha-rotated" },
+        beta: { access: "beta-login" },
+      });
+      expect(statSync(profilesPath).mode & 0o777).toBe(0o600);
+    },
+  );
+
+  it("leaves the profile bytes unchanged when the writer lock times out", async () => {
+    const profilesPath = freshProfilesPath();
+    saveStoredProfile(profilesPath, "alpha", profile("original"));
+    const expected = loadStoredProfileSnapshot(profilesPath, "alpha");
+    if (expected === null) throw new Error("Expected synthetic profile snapshot");
+    const originalBytes = readFileSync(profilesPath, "utf8");
+    const lockPath = join(profilesPath, "..", ".auth-profiles.lock");
+    publishLockClaim(lockPath, process.pid, "live-profile-store-holder");
+
+    vi.useFakeTimers();
+    const settled = compareAndSaveStoredProfile(
+      profilesPath,
+      "alpha",
+      expected,
+      profile("must-not-persist"),
+    ).then(
+      () => null,
+      (error: unknown) => error,
+    );
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    const error = await settled;
+    expect(error).toBeInstanceOf(InterprocessFileLockTimeoutError);
+    expect(error).not.toMatchObject({
+      message: expect.stringMatching(/original|must-not-persist|refresh/u),
+    });
+    expect(readFileSync(profilesPath, "utf8")).toBe(originalBytes);
+  });
+
+  it("serializes real child-process writers without losing either profile", async () => {
+    const profilesPath = freshProfilesPath();
+    const directory = join(profilesPath, "..");
+    const holderReady = join(directory, "holder-ready");
+    const writerReady = join(directory, "writer-ready");
+    const release = join(directory, "release-holder");
+    const holder = spawnStoreChild("holder", profilesPath, holderReady, release);
+    await waitForPath(holderReady);
+    const writer = spawnStoreChild("writer", profilesPath, writerReady, release);
+    await waitForPath(writerReady);
+    writeFileSync(release, "release\n", { mode: 0o600 });
+
+    await Promise.all([waitForChild(holder), waitForChild(writer)]);
+
+    expect(JSON.parse(readFileSync(profilesPath, "utf8"))).toMatchObject({
+      alpha: { access: "alpha-access" },
+      beta: { access: "beta-access" },
+    });
+    expect(statSync(profilesPath).mode & 0o777).toBe(0o600);
+    expect(existsSync(join(directory, ".auth-profiles.lock"))).toBe(false);
+    expect(readdirSync(directory).filter((name) => name.includes(".tmp."))).toEqual([]);
+  });
+
+  it("recovers a real child-process claim after SIGKILL", async () => {
+    const profilesPath = freshProfilesPath();
+    const directory = join(profilesPath, "..");
+    const holderReady = join(directory, "holder-ready");
+    const release = join(directory, "never-release-holder");
+    const holder = spawnStoreChild("holder", profilesPath, holderReady, release);
+    await waitForPath(holderReady);
+    expect(holder.kill("SIGKILL")).toBe(true);
+    await waitForChild(holder, true);
+    expect(existsSync(join(directory, ".auth-profiles.lock"))).toBe(true);
+
+    const writerReady = join(directory, "writer-ready");
+    const writer = spawnStoreChild("writer", profilesPath, writerReady, release);
+    await waitForChild(writer);
+
+    expect(JSON.parse(readFileSync(profilesPath, "utf8"))).toMatchObject({
+      beta: { access: "beta-access" },
+    });
+    expect(statSync(profilesPath).mode & 0o777).toBe(0o600);
+    expect(existsSync(join(directory, ".auth-profiles.lock"))).toBe(false);
+  });
+
+  it("serializes two real child-process reclaimers after the same holder dies", async () => {
+    const profilesPath = freshProfilesPath();
+    const directory = join(profilesPath, "..");
+    const holderReady = join(directory, "holder-ready");
+    const release = join(directory, "never-release-holder");
+    const holder = spawnStoreChild("holder", profilesPath, holderReady, release);
+    await waitForPath(holderReady);
+    expect(holder.kill("SIGKILL")).toBe(true);
+    await waitForChild(holder, true);
+
+    const firstReady = join(directory, "first-writer-ready");
+    const secondReady = join(directory, "second-writer-ready");
+    const first = spawnStoreChild(
+      "writer",
+      profilesPath,
+      firstReady,
+      release,
+      "first-provider",
+      "first-access",
+    );
+    const second = spawnStoreChild(
+      "writer",
+      profilesPath,
+      secondReady,
+      release,
+      "second-provider",
+      "second-access",
+    );
+    await Promise.all([waitForPath(firstReady), waitForPath(secondReady)]);
+    await Promise.all([waitForChild(first), waitForChild(second)]);
+
+    expect(JSON.parse(readFileSync(profilesPath, "utf8"))).toMatchObject({
+      "first-provider": { access: "first-access" },
+      "second-provider": { access: "second-access" },
+    });
+    expect(statSync(profilesPath).mode & 0o777).toBe(0o600);
+    expect(existsSync(join(directory, ".auth-profiles.lock"))).toBe(false);
+    expect(readdirSync(directory).filter((name) => name.includes(".tmp."))).toEqual([]);
+  });
+
+  it("preserves a newer real child-process login against a stale CAS result", async () => {
+    const profilesPath = freshProfilesPath();
+    saveStoredProfile(profilesPath, "openai-codex", profile("original"));
+    const directory = join(profilesPath, "..");
+    const casReady = join(directory, "cas-ready");
+    const releaseCas = join(directory, "release-cas");
+    const cas = spawnStoreChild(
+      "cas",
+      profilesPath,
+      casReady,
+      releaseCas,
+      "openai-codex",
+      "stale-refresh-result",
+    );
+    await waitForPath(casReady);
+
+    const loginReady = join(directory, "login-ready");
+    const login = spawnStoreChild(
+      "writer",
+      profilesPath,
+      loginReady,
+      releaseCas,
+      "openai-codex",
+      "new-login",
+    );
+    await waitForChild(login);
+    writeFileSync(releaseCas, "release\n", { mode: 0o600 });
+    await waitForChild(cas);
+
+    expect(JSON.parse(readFileSync(profilesPath, "utf8"))).toMatchObject({
+      "openai-codex": { access: "new-login" },
+    });
+    expect(JSON.parse(readFileSync(`${casReady}.result`, "utf8"))).toMatchObject({
+      status: "superseded",
+      profile: { access: "new-login" },
+    });
+  });
+
+  it("serializes concurrent recovery and ordinary writer processes without overwriting bytes", async () => {
+    const profilesPath = freshProfilesPath();
+    const originalBytes = "not-json{{\nconcurrent-recovery-marker";
+    writeFileSync(profilesPath, originalBytes, { mode: 0o600 });
+    const directory = join(profilesPath, "..");
+    const start = join(directory, "start-concurrent-writers");
+    const recoveryReady = join(directory, "recovery-ready");
+    const writerReady = join(directory, "ordinary-writer-ready");
+    const recovery = spawnStoreChild(
+      "barrier-recovery",
+      profilesPath,
+      recoveryReady,
+      start,
+      "recovered-provider",
+      "recovered-access",
+    );
+    const writer = spawnStoreChild(
+      "barrier-writer",
+      profilesPath,
+      writerReady,
+      start,
+      "ordinary-provider",
+      "ordinary-access",
+    );
+    await Promise.all([waitForPath(recoveryReady), waitForPath(writerReady)]);
+    writeFileSync(start, "start\n", { mode: 0o600 });
+    await Promise.all([waitForChild(recovery), waitForChild(writer, true)]);
+    if (writer.exitCode !== 0) {
+      const retryReady = join(directory, "ordinary-writer-retry-ready");
+      const retry = spawnStoreChild(
+        "writer",
+        profilesPath,
+        retryReady,
+        start,
+        "ordinary-provider",
+        "ordinary-access",
+      );
+      await waitForChild(retry);
+    }
+
+    expect(readFileSync(`${profilesPath}.corrupt`, "utf8")).toBe(originalBytes);
+    expect(JSON.parse(readFileSync(profilesPath, "utf8"))).toMatchObject({
+      "recovered-provider": { access: "recovered-access" },
+      "ordinary-provider": { access: "ordinary-access" },
+    });
+    expect(statSync(`${profilesPath}.corrupt`).mode & 0o777).toBe(0o600);
+    expect(statSync(profilesPath).mode & 0o777).toBe(0o600);
+  });
+});

--- a/packages/core/tests/run-binary.test.ts
+++ b/packages/core/tests/run-binary.test.ts
@@ -157,7 +157,9 @@ describe("runBinary CLI routing", () => {
     const { runBinary } = await import("../src/run-binary.js");
     await expect(runBinary(stubRunningSport, stubRunningBinary)).rejects.toThrow("__exit_1");
 
-    expect(errSpy.mock.calls.some((c) => String(c[0]).includes("Unknown command: bogus"))).toBe(true);
+    expect(errSpy.mock.calls.some((c) => String(c[0]).includes("Unknown command: bogus"))).toBe(
+      true,
+    );
   });
 });
 
@@ -188,9 +190,25 @@ describe("formatCliReply", () => {
   it("on a provider-auth error returns the provider-neutral one-liner (no payload)", async () => {
     const { formatCliReply } = await import("../src/run-binary.js");
     const reply = formatCliReply(apiError(401));
-    expect(reply).toBe("The model provider rejected the API key — check your provider credentials.");
+    expect(reply).toBe(
+      "The model provider rejected the API key — check your provider credentials.",
+    );
     expect(reply).not.toContain("Anthropic");
     expect(reply).not.toContain("example.invalid");
+  });
+
+  it("on a refresh rejection returns the ChatGPT sign-in recovery path", async () => {
+    const { formatCliReply } = await import("../src/run-binary.js");
+    expect(formatCliReply({ refreshFailureReason: "reauth" })).toBe(
+      "Your ChatGPT sign-in is no longer valid. Sign in again to continue.",
+    );
+  });
+
+  it("on a structurally tagged refresh rate limit returns the wait copy", async () => {
+    const { formatCliReply } = await import("../src/run-binary.js");
+    expect(formatCliReply({ refreshFailureReason: "rate_limit", retryAfterMs: 2_000 })).toBe(
+      "Rate limited — please try again in ~2 seconds.",
+    );
   });
 
   it("on a provider-down error returns the one-line classified copy", async () => {

--- a/packages/core/tests/telegram-dispatch.test.ts
+++ b/packages/core/tests/telegram-dispatch.test.ts
@@ -194,7 +194,16 @@ describe("command registration", () => {
     const names = bot.command.mock.calls.map((c: unknown[]) => c[0]);
     expect(names).not.toContain("sync");
     expect(names).not.toContain("snapshot");
-    for (const c of ["start", "plan", "workout", "status", "review", "version", "whatsnew", "update"]) {
+    for (const c of [
+      "start",
+      "plan",
+      "workout",
+      "status",
+      "review",
+      "version",
+      "whatsnew",
+      "update",
+    ]) {
       expect(names).toContain(c);
     }
   });
@@ -335,15 +344,39 @@ describe("retry transformer / classified errors / delivery split", () => {
     expect(someReply(ctx, "Sorry, something went wrong generating your plan")).toBe(false);
   });
 
+  it("generation refresh rejection gives the ChatGPT sign-in recovery path", async () => {
+    const { bot, agent, drainPending } = await buildBot();
+    agent.chat.mockRejectedValue({ refreshFailureReason: "reauth" });
+    const ctx = makeCtx();
+    await getCommand(bot, "plan")(ctx);
+    await drainPending();
+    expect(
+      someReply(ctx, "Your ChatGPT sign-in is no longer valid. Sign in again to continue."),
+    ).toBe(true);
+    expect(someReply(ctx, "Sorry, something went wrong generating your plan")).toBe(false);
+  });
+
+  it("generation refresh rate limit retains the rate-limit copy", async () => {
+    const { bot, agent, drainPending } = await buildBot();
+    agent.chat.mockRejectedValue({
+      refreshFailureReason: "rate_limit",
+      retryAfterMs: 4_000,
+    });
+    const ctx = makeCtx();
+    await getCommand(bot, "plan")(ctx);
+    await drainPending();
+    expect(someReply(ctx, "Rate limited — please try again in ~4 seconds.")).toBe(true);
+  });
+
   it("generation unknown-kind error → caller genericReply (fallback only on unknown)", async () => {
     const { bot, agent, drainPending } = await buildBot();
     agent.chat.mockRejectedValue(new Error("???"));
     const ctx = makeCtx();
     await getCommand(bot, "plan")(ctx);
     await drainPending();
-    expect(someReply(ctx, "Sorry, something went wrong generating your plan. Please try again.")).toBe(
-      true,
-    );
+    expect(
+      someReply(ctx, "Sorry, something went wrong generating your plan. Please try again."),
+    ).toBe(true);
   });
 
   it("generation succeeds but delivery rejects (non-parse) → delivery copy AND the answer is resendable", async () => {
@@ -353,13 +386,17 @@ describe("retry transformer / classified errors / delivery split", () => {
     const ctx = makeCtx({ message: { text: "how's my form?" } });
     ctx.reply.mockImplementation(async (_text: string, options?: Record<string, unknown>) => {
       if (options?.parse_mode === "HTML") {
-        throw new Error("Call to 'sendMessage' failed! (403: Forbidden: bot was blocked by the user)");
+        throw new Error(
+          "Call to 'sendMessage' failed! (403: Forbidden: bot was blocked by the user)",
+        );
       }
       return undefined;
     });
     await getMessageText(bot)(ctx);
     await drainPending();
-    expect(someReply(ctx, "I generated the answer, but Telegram had trouble delivering it.")).toBe(true);
+    expect(someReply(ctx, "I generated the answer, but Telegram had trouble delivering it.")).toBe(
+      true,
+    );
 
     // The resend cache was written before delivery, so a follow-up resend re-emits it.
     const ctx2 = makeCtx({ message: { text: "resend" } });
@@ -568,7 +605,11 @@ describe("typing-indicator heartbeat", () => {
       vi.stubGlobal("setInterval", setIntervalSpy);
       vi.stubGlobal("clearInterval", clearIntervalSpy);
       try {
-        const stop = startTypingHeartbeat(async () => undefined, TYPING_HEARTBEAT_MS, () => {});
+        const stop = startTypingHeartbeat(
+          async () => undefined,
+          TYPING_HEARTBEAT_MS,
+          () => {},
+        );
         expect(setIntervalSpy).toHaveBeenCalledTimes(1);
         expect(unref).toHaveBeenCalledTimes(1);
         expect(clearIntervalSpy).not.toHaveBeenCalled();
@@ -902,7 +943,16 @@ describe("command menu (setMyCommands)", () => {
     const names = menuCommands(bot).map((c) => c.command);
     expect(names).not.toContain("sync");
     expect(names).not.toContain("snapshot");
-    for (const c of ["start", "plan", "workout", "status", "review", "version", "whatsnew", "update"]) {
+    for (const c of [
+      "start",
+      "plan",
+      "workout",
+      "status",
+      "review",
+      "version",
+      "whatsnew",
+      "update",
+    ]) {
       expect(names).toContain(c);
     }
   });

--- a/packages/engine/src/agent/coach-agent.ts
+++ b/packages/engine/src/agent/coach-agent.ts
@@ -31,7 +31,11 @@ import {
   TIMEOUT_COMPACTION_THRESHOLD,
 } from "./token-utils.js";
 import { summarizeInStages, summarizeDroppedMessages } from "./compaction.js";
-import { runMemoryFlush, FLUSH_ZERO_WRITE_MIN_MESSAGES, shouldRunMemoryFlush } from "./memory-flush.js";
+import {
+  runMemoryFlush,
+  FLUSH_ZERO_WRITE_MIN_MESSAGES,
+  shouldRunMemoryFlush,
+} from "./memory-flush.js";
 import type { MemoryFlushOutcome } from "./memory-flush.js";
 import { evaluateSessionFreshness } from "./session-freshness.js";
 import { LLM } from "../llm.js";
@@ -495,7 +499,10 @@ export class CoachAgent {
             await this.flushMemory(history, "trim", turnBudget);
           } catch (err) {
             flushed = false;
-            this.log.warn("Pre-compaction memory flush failed; keeping session file unchanged", err);
+            this.log.warn(
+              "Pre-compaction memory flush failed; keeping session file unchanged",
+              err,
+            );
           }
         }
         try {
@@ -574,7 +581,13 @@ export class CoachAgent {
           turnBudget.checkDeadline();
 
           // Preemptive: compact before sending if over budget
-          if (shouldCompact({ messages, systemPrompt: this.systemPrompt, contextWindowTokens: this.config.contextWindowTokens })) {
+          if (
+            shouldCompact({
+              messages,
+              systemPrompt: this.systemPrompt,
+              contextWindowTokens: this.config.contextWindowTokens,
+            })
+          ) {
             if (!flushedThisTurn) {
               flushedThisTurn = true;
               try {
@@ -735,14 +748,23 @@ export class CoachAgent {
                   try {
                     await this.flushMemory(messages, "overflow-recovery", turnBudget);
                   } catch (flushErr) {
-                    this.log.warn("In-turn memory flush failed; compacting without flush", flushErr);
+                    this.log.warn(
+                      "In-turn memory flush failed; compacting without flush",
+                      flushErr,
+                    );
                   }
                 }
-                messages = await summarizeInStages({ messages, ...this.compactionParams(turnBudget) });
+                messages = await summarizeInStages({
+                  messages,
+                  ...this.compactionParams(turnBudget),
+                });
                 compactions++;
                 this.memory.reload();
               } catch (rescueErr) {
-                this.log.warn("Compaction rescue failed; rethrowing the original turn error", rescueErr);
+                this.log.warn(
+                  "Compaction rescue failed; rethrowing the original turn error",
+                  rescueErr,
+                );
                 if (err instanceof Error && err.cause === undefined) {
                   (err as Error & { cause?: unknown }).cause = rescueErr;
                 }
@@ -757,11 +779,17 @@ export class CoachAgent {
               if (ratio > TIMEOUT_COMPACTION_THRESHOLD) {
                 timeoutAttempts++;
                 try {
-                  messages = await summarizeInStages({ messages, ...this.compactionParams(turnBudget) });
+                  messages = await summarizeInStages({
+                    messages,
+                    ...this.compactionParams(turnBudget),
+                  });
                   compactions++;
                   this.memory.reload();
                 } catch (rescueErr) {
-                  this.log.warn("Compaction rescue failed; rethrowing the original turn error", rescueErr);
+                  this.log.warn(
+                    "Compaction rescue failed; rethrowing the original turn error",
+                    rescueErr,
+                  );
                   if (err instanceof Error && err.cause === undefined) {
                     (err as Error & { cause?: unknown }).cause = rescueErr;
                   }
@@ -783,14 +811,16 @@ export class CoachAgent {
               // The server hint (if any) is a lower bound; absent one, fall back to a
               // capped exponential. Either feeds the primitive as the Retry-After
               // floor so the 120s ceiling and the clamp note are honored bit-for-bit.
-              const requestedMs = retryAfterFloorMs(err, this.ports.extractRetryAfterMs)
-                ?? Math.min(
-                     RATE_LIMIT_FALLBACK_BASE_MS * RATE_LIMIT_FALLBACK_MULTIPLIER ** (attemptNo - 1),
-                     RATE_LIMIT_FALLBACK_MAX_MS,
-                   );
-              const clampNote = requestedMs > RATE_LIMIT_MAX_WAIT_MS
-                ? ` (provider requested ${requestedMs}ms, clamped to ${RATE_LIMIT_MAX_WAIT_MS}ms)`
-                : "";
+              const requestedMs =
+                retryAfterFloorMs(err, this.ports.extractRetryAfterMs) ??
+                Math.min(
+                  RATE_LIMIT_FALLBACK_BASE_MS * RATE_LIMIT_FALLBACK_MULTIPLIER ** (attemptNo - 1),
+                  RATE_LIMIT_FALLBACK_MAX_MS,
+                );
+              const clampNote =
+                requestedMs > RATE_LIMIT_MAX_WAIT_MS
+                  ? ` (provider requested ${requestedMs}ms, clamped to ${RATE_LIMIT_MAX_WAIT_MS}ms)`
+                  : "";
               await backoffWithSentinelError(err, {
                 attempts: 2,
                 baseMs: requestedMs,
@@ -799,7 +829,9 @@ export class CoachAgent {
                 retryAfterMs: () => requestedMs,
                 random: () => 0,
                 onRetry: ({ delayMs }) => {
-                  console.warn(`Rate limited (attempt ${attemptNo}/${MAX_RATE_LIMIT_ATTEMPTS}), waiting ${delayMs}ms${clampNote}`);
+                  console.warn(
+                    `Rate limited (attempt ${attemptNo}/${MAX_RATE_LIMIT_ATTEMPTS}), waiting ${delayMs}ms${clampNote}`,
+                  );
                 },
               });
               // The backoff sleep is the one place a turn can silently burn
@@ -819,7 +851,8 @@ export class CoachAgent {
             // errors are plain TypeErrors (not name="NetworkError") and whose SDK
             // does zero retries. (Unifying codex network retry with the AI-SDK
             // path is tracked as a follow-up.)
-            const alreadyRetriedNetwork = failure === "network" && err instanceof Error && err.name === "NetworkError";
+            const alreadyRetriedNetwork =
+              failure === "network" && err instanceof Error && err.name === "NetworkError";
             if (
               (failure === "server_error" || failure === "network") &&
               !alreadyRetriedNetwork &&
@@ -899,22 +932,28 @@ export class CoachAgent {
             kind: "rate_limit" as const,
             athleteMessage: "Rate limited — please try again shortly.",
           }
-        : failure === "auth"
+        : failure === "reauth"
           ? {
               kind: "provider-auth" as const,
               athleteMessage:
-                "The model provider rejected the API key — check your provider credentials.",
+                "Your ChatGPT sign-in is no longer valid. Open Setup and sign in again.",
             }
-          : failure === "server_error" || failure === "network" || failure === "timeout"
+          : failure === "auth"
             ? {
-                kind: "provider-down" as const,
+                kind: "provider-auth" as const,
                 athleteMessage:
-                  "The model provider is having trouble — try again in a few minutes.",
+                  "The model provider rejected the API key — check your provider credentials.",
               }
-            : {
-                kind: "unknown" as const,
-                athleteMessage: "Sorry, something went wrong. Please try again.",
-              };
+            : failure === "server_error" || failure === "network" || failure === "timeout"
+              ? {
+                  kind: "provider-down" as const,
+                  athleteMessage:
+                    "The model provider is having trouble — try again in a few minutes.",
+                }
+              : {
+                  kind: "unknown" as const,
+                  athleteMessage: "Sorry, something went wrong. Please try again.",
+                };
     return {
       type: "error",
       turnId: input.turnId,

--- a/packages/engine/src/host-ports.ts
+++ b/packages/engine/src/host-ports.ts
@@ -201,6 +201,7 @@ export type FailureReason =
   | "server_error"
   | "network"
   | "auth"
+  | "reauth"
   | "invalid_request"
   | "unknown";
 

--- a/packages/engine/tests/coach-agent-streaming.test.ts
+++ b/packages/engine/tests/coach-agent-streaming.test.ts
@@ -81,6 +81,27 @@ function engineWithTransport(input: {
 }
 
 describe("coach agent streaming", () => {
+  it("emits actionable reauthentication copy for a rejected sign-in refresh", async () => {
+    const failure = new Error("rejected");
+    const { engine } = engineWithTransport({
+      generate: async () => {
+        throw failure;
+      },
+      classifyFailure: () => "reauth",
+    });
+    const events: TurnEvent[] = [];
+
+    await expect(
+      engine.chat({ chatId: "reauth", message: "hello" }, (event) => events.push(event)),
+    ).rejects.toBe(failure);
+
+    expect(events.at(-1)).toMatchObject({
+      type: "error",
+      kind: "provider-auth",
+      athleteMessage: "Your ChatGPT sign-in is no longer valid. Open Setup and sign in again.",
+    });
+  });
+
   it("emits ordered text_delta events before final-text", async () => {
     const { dataDir, engine } = engineWithTransport({
       generate: async (request) => {
@@ -92,9 +113,8 @@ describe("coach agent streaming", () => {
       },
     });
     const events: TurnEvent[] = [];
-    const response = await engine.chat(
-      { chatId: "stream-order", message: "hello" },
-      (event) => events.push(event),
+    const response = await engine.chat({ chatId: "stream-order", message: "hello" }, (event) =>
+      events.push(event),
     );
 
     expect(response).toEqual({ text: "Hello, athlete" });
@@ -158,6 +178,7 @@ describe("coach agent streaming", () => {
       "server_error",
       "network",
       "auth",
+      "reauth",
       "invalid_request",
       "unknown",
     ] as const)("does not retry %s after provider text", async (failure) => {

--- a/packages/engine/tests/retry-loop-codex.test.ts
+++ b/packages/engine/tests/retry-loop-codex.test.ts
@@ -27,7 +27,11 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-async function setupAgent(complete: ReturnType<typeof vi.fn>) {
+async function setupAgent(
+  complete: ReturnType<typeof vi.fn>,
+  getAccessToken: (profileName: string, signal?: AbortSignal) => Promise<string> = async () =>
+    "token",
+) {
   vi.doMock("../src/agent/codex/responses.js", () => ({
     codexResponses: complete,
   }));
@@ -43,7 +47,10 @@ async function setupAgent(complete: ReturnType<typeof vi.fn>) {
   }));
 
   const { CoachAgent } = await import("../src/agent/coach-agent.js");
-  return new CoachAgent(cyclingSport as unknown as Sport, baseAgentConfig(dataDir));
+  return new CoachAgent(cyclingSport as unknown as Sport, {
+    ...baseAgentConfig(dataDir),
+    getAccessToken,
+  });
 }
 
 function mkAssistant(text: string, stopReason: "stop" | "length" = "stop") {
@@ -62,6 +69,28 @@ function mkAssistant(text: string, stopReason: "stop" | "length" = "stop") {
 }
 
 describe("retry loop on Codex path", () => {
+  it("retries a token-refresh network failure outside the bridge retry marker", async () => {
+    const complete = vi.fn(async () => mkAssistant("recovered-after-refresh-network"));
+    const refreshFailure = Object.assign(new Error("Synthetic refresh failure"), {
+      name: "TokenRefreshError",
+      refreshFailureReason: "network" as const,
+    });
+    const getAccessToken = vi
+      .fn<(profileName: string, signal?: AbortSignal) => Promise<string>>()
+      .mockRejectedValueOnce(refreshFailure)
+      .mockResolvedValueOnce("synthetic-access");
+    vi.useFakeTimers();
+    const agent = await setupAgent(complete, getAccessToken);
+
+    const chatPromise = agent.chat("refresh-network", "hello");
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    await expect(chatPromise).resolves.toBe("recovered-after-refresh-network");
+    expect(refreshFailure.name).not.toBe("NetworkError");
+    expect(getAccessToken).toHaveBeenCalledTimes(2);
+    expect(complete).toHaveBeenCalledTimes(1);
+  });
+
   it("retries after a rate-limit error and then succeeds", async () => {
     let n = 0;
     const complete = vi.fn(async () => {


### PR DESCRIPTION
## Summary

- classify refresh failures structurally so revoked or expired ChatGPT sessions surface an actionable sign-in-again path
- keep transient retries in the engine, preserve partial coach drafts, and prevent duplicate generic failure copy
- serialize Core, Coach, and Desktop profile writes with atomic compare-and-save behavior so concurrent login and token refresh cannot lose credentials
- recover malformed profile files by preserving their exact bytes privately before replacement, while normal reads and updates fail closed

## Safety

- lock ownership is crash-recoverable, successor-safe, and tested across concurrent processes
- malformed UTF-8 and reserved profile names are handled consistently across Core and Desktop status
- no live credentials, OAuth exchange, or athlete data were used

## Verification

- `pnpm check`
- `pnpm test` — 379 files passed, 1 skipped; 4,820 tests passed, 3 skipped
- `pnpm --dir apps/desktop smoke:security` — all seven assertions passed
- three independent final release reviews: PASS / PASS / PASS

Resolves the desktop parity findings for revoked ChatGPT refresh tokens and duplicate generic chat failure copy.
