### PR TITLE
fix(desktop): supervise daemon lifecycle

### DIFF
--- a/.changeset/daemon-lifecycle-supervision.md
+++ b/.changeset/daemon-lifecycle-supervision.md
@@ -1,0 +1,10 @@
+---
+"cycling-coach": patch
+"@enduragent/coach": patch
+"@enduragent/desktop": patch
+"@enduragent/desktop-renderer": patch
+---
+
+User-facing: Enduragent now explains background-service startup problems, safely reconnects after a crash, and stops repeated restart loops.
+
+Bound desktop daemon startup and runtime recovery, retain exact per-document connection containment across port changes, and refresh live renderer coordinates after recovery.

--- a/apps/desktop-renderer/src/coach-client.ts
+++ b/apps/desktop-renderer/src/coach-client.ts
@@ -7,15 +7,28 @@ export interface DesktopCoachClientProvider {
   close(): Promise<void>;
 }
 
-function validateConnection(value: unknown): { readonly url: string; readonly token: string } {
+interface DesktopConnectionBridge {
+  getDaemonConnection(failedGeneration?: number): Promise<unknown>;
+}
+
+function validateConnection(value: unknown): {
+  readonly url: string;
+  readonly token: string;
+  readonly generation: number;
+} {
   if (value === null || typeof value !== "object" || Array.isArray(value)) {
     throw new CoachClientProtocolError();
   }
   const record = value as Record<string, unknown>;
-  if (Object.keys(record).sort().join(",") !== "token,url") {
+  if (Object.keys(record).sort().join(",") !== "generation,token,url") {
     throw new CoachClientProtocolError();
   }
-  if (typeof record.url !== "string" || typeof record.token !== "string") {
+  if (
+    typeof record.url !== "string" ||
+    typeof record.token !== "string" ||
+    !Number.isSafeInteger(record.generation) ||
+    (record.generation as number) < 1
+  ) {
     throw new CoachClientProtocolError();
   }
   let url: URL;
@@ -40,29 +53,35 @@ function validateConnection(value: unknown): { readonly url: string; readonly to
   ) {
     throw new CoachClientProtocolError();
   }
-  return record as { readonly url: string; readonly token: string };
+  return record as { readonly url: string; readonly token: string; readonly generation: number };
 }
 
-export function createDesktopCoachClientProvider(): DesktopCoachClientProvider {
+export function createDesktopCoachClientProvider(
+  connect: typeof connectCoachClient = connectCoachClient,
+): DesktopCoachClientProvider {
   let client: CoachClient | undefined;
   let connection: Promise<CoachClient> | undefined;
   let reconnection: Promise<CoachClient> | undefined;
   let closing: Promise<void> | undefined;
+  let generation: number | undefined;
 
-  const connectFresh = (): Promise<CoachClient> => {
-    if (client !== undefined) return Promise.resolve(client);
-    if (connection !== undefined) return connection;
-    const auth = (
+  const auth = (): DesktopConnectionBridge =>
+    (
       window as unknown as Window & {
-        readonly enduragentAuth: {
-          getDaemonConnection(): Promise<unknown>;
-        };
+        readonly enduragentAuth: DesktopConnectionBridge;
       }
     ).enduragentAuth;
-    const pending = auth
-      .getDaemonConnection()
+
+  const connectFresh = (failedGeneration?: number): Promise<CoachClient> => {
+    if (client !== undefined) return Promise.resolve(client);
+    if (connection !== undefined) return connection;
+    const pending = auth()
+      .getDaemonConnection(failedGeneration)
       .then(validateConnection)
-      .then((options) => connectCoachClient(options))
+      .then((options) => {
+        generation = options.generation;
+        return connect({ url: options.url, token: options.token });
+      })
       .then((connected) => {
         if (connection === pending) client = connected;
         return connected;
@@ -92,7 +111,7 @@ export function createDesktopCoachClientProvider(): DesktopCoachClientProvider {
           if (client === connected) client = undefined;
           if (connection === previousConnection) connection = undefined;
         })
-        .then(connectFresh)
+        .then(() => connectFresh(generation))
         .finally(() => {
           if (reconnection === pending) reconnection = undefined;
         });
@@ -108,6 +127,7 @@ export function createDesktopCoachClientProvider(): DesktopCoachClientProvider {
         .then(() => {
           client = undefined;
           connection = undefined;
+          generation = undefined;
         });
       closing = pending;
       return pending;

--- a/apps/desktop-renderer/src/global.d.ts
+++ b/apps/desktop-renderer/src/global.d.ts
@@ -1,7 +1,8 @@
 interface EnduragentAuth {
-  getDaemonConnection(): Promise<{
+  getDaemonConnection(failedGeneration?: number): Promise<{
     readonly url: `ws://127.0.0.1:${number}/rpc`;
     readonly token: string;
+    readonly generation: number;
   }>;
   credentialStatuses(): Promise<readonly CredentialSlotStatus[]>;
   retryFailedCredentials(): Promise<readonly CredentialSlotStatus[]>;
@@ -75,6 +76,13 @@ type CredentialWriteResult =
 
 interface Window {
   readonly enduragentAuth: EnduragentAuth;
+}
+
+interface WindowEventMap {
+  readonly "enduragent-lifecycle": CustomEvent<{
+    readonly status: "ready" | "recovering" | "terminal" | "closing";
+    readonly generation: number;
+  }>;
 }
 
 declare module "*.css" {}

--- a/apps/desktop-renderer/src/index.ts
+++ b/apps/desktop-renderer/src/index.ts
@@ -36,6 +36,23 @@ const topbar = one(".topbar", HTMLElement);
 const spendRoot = one(".spend-meter", HTMLElement);
 conversation.classList.add("desktop-shell");
 
+const connectionStatus = document.createElement("span");
+connectionStatus.className = "connection-status";
+connectionStatus.setAttribute("role", "status");
+connectionStatus.textContent = "Connecting…";
+topbar.insertBefore(connectionStatus, topbar.lastElementChild);
+window.addEventListener("enduragent-lifecycle", (event) => {
+  document.documentElement.dataset.rpc = event.detail.status;
+  connectionStatus.textContent =
+    event.detail.status === "ready"
+      ? "Connected"
+      : event.detail.status === "recovering"
+        ? "Reconnecting…"
+        : event.detail.status === "terminal"
+          ? "Connection unavailable"
+          : "Closing…";
+});
+
 const clients = createDesktopCoachClientProvider();
 const clientAfterFailure = async (failedClient: CoachClient | undefined) => {
   if (failedClient === undefined) return clients.reconnect();
@@ -225,9 +242,11 @@ void onboarding.open();
 void clients.getClient().then(
   () => {
     document.documentElement.dataset.rpc = "connected";
+    connectionStatus.textContent = "Connected";
   },
   () => {
     document.documentElement.dataset.rpc = "failed";
+    connectionStatus.textContent = "Connection unavailable";
   },
 );
 

--- a/apps/desktop-renderer/tests/coach-client.test.ts
+++ b/apps/desktop-renderer/tests/coach-client.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDesktopCoachClientProvider } from "../src/coach-client.js";
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("desktop coach client lifecycle", () => {
+  it("asks the trusted main-process bridge to recover before resolving fresh coordinates", async () => {
+    const order: string[] = [];
+    const auth = {
+      getDaemonConnection: vi.fn(async (failedGeneration?: number) => {
+        order.push(failedGeneration === undefined ? "coordinates" : `recover-${failedGeneration}`);
+        return {
+          url: "ws://127.0.0.1:45001/rpc",
+          token: "s".repeat(43),
+          generation: 7,
+        };
+      }),
+    };
+    vi.stubGlobal("window", { enduragentAuth: auth });
+    const clients = createDesktopCoachClientProvider(
+      vi.fn(async () => Promise.reject(new Error())),
+    );
+    await expect(clients.getClient()).rejects.toThrow();
+    await expect(clients.reconnect()).rejects.toThrow();
+    expect(order).toEqual(["coordinates", "recover-7"]);
+    expect(auth.getDaemonConnection).toHaveBeenNthCalledWith(2, 7);
+  });
+
+  it("closes the old client and deduplicates successful generation-qualified reconnects", async () => {
+    const first = { close: vi.fn(async () => {}) };
+    const second = { close: vi.fn(async () => {}) };
+    const auth = {
+      getDaemonConnection: vi
+        .fn()
+        .mockResolvedValueOnce({
+          url: "ws://127.0.0.1:45001/rpc",
+          token: "s".repeat(43),
+          generation: 1,
+        })
+        .mockResolvedValueOnce({
+          url: "ws://127.0.0.1:45002/rpc",
+          token: "t".repeat(43),
+          generation: 2,
+        }),
+    };
+    const connect = vi.fn().mockResolvedValueOnce(first).mockResolvedValueOnce(second);
+    vi.stubGlobal("window", { enduragentAuth: auth });
+    const clients = createDesktopCoachClientProvider(connect);
+    await expect(clients.getClient()).resolves.toBe(first);
+    const reconnecting = clients.reconnect();
+    expect(clients.reconnect()).toBe(reconnecting);
+    await expect(reconnecting).resolves.toBe(second);
+    expect(first.close).toHaveBeenCalledTimes(1);
+    expect(auth.getDaemonConnection).toHaveBeenNthCalledWith(2, 1);
+    expect(connect).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/desktop/src/main/connection-ipc.ts
+++ b/apps/desktop/src/main/connection-ipc.ts
@@ -1,0 +1,36 @@
+import type { BrowserWindow, IpcMain, IpcMainInvokeEvent } from "electron";
+import { DESKTOP_CONNECTION_CHANNEL } from "./constants.js";
+import type { DesktopDaemonLifecycle } from "./daemon-lifecycle.js";
+import { isTrustedConnectionRequest } from "./security.js";
+
+export function installDesktopConnectionIpc(input: {
+  readonly ipcMain: Pick<IpcMain, "handle" | "removeHandler">;
+  readonly currentWindow: () => BrowserWindow | undefined;
+  readonly runtime: Pick<DesktopDaemonLifecycle, "connection" | "recover">;
+}): () => void {
+  const requireTrusted = (event: IpcMainInvokeEvent): void => {
+    if (!isTrustedConnectionRequest(event, input.currentWindow())) {
+      throw new Error("untrusted desktop connection request");
+    }
+  };
+  input.ipcMain.handle(DESKTOP_CONNECTION_CHANNEL, async (event, request?: unknown) => {
+    requireTrusted(event);
+    if (request !== undefined) {
+      if (
+        request === null ||
+        typeof request !== "object" ||
+        Array.isArray(request) ||
+        Object.keys(request).length !== 1 ||
+        !Number.isSafeInteger((request as { readonly generation?: unknown }).generation) ||
+        ((request as { readonly generation: number }).generation as number) < 1
+      ) {
+        throw new TypeError("invalid desktop connection request");
+      }
+      return input.runtime.recover((request as { readonly generation: number }).generation);
+    }
+    return input.runtime.connection();
+  });
+  return () => {
+    input.ipcMain.removeHandler(DESKTOP_CONNECTION_CHANNEL);
+  };
+}

--- a/apps/desktop/src/main/constants.ts
+++ b/apps/desktop/src/main/constants.ts
@@ -3,11 +3,14 @@ export const DESKTOP_HOST = "app" as const;
 export const DESKTOP_RENDERER_ORIGIN = "enduragent://app" as const;
 export const DESKTOP_RENDERER_URL = "enduragent://app/index.html" as const;
 export const DESKTOP_CONNECTION_CHANNEL = "desktop:get-daemon-connection" as const;
+export const DESKTOP_LIFECYCLE_CHANNEL = "desktop:daemon-lifecycle" as const;
 export const DESKTOP_WINDOW_WIDTH = 1_180 as const;
 export const DESKTOP_WINDOW_HEIGHT = 820 as const;
 export const DESKTOP_WINDOW_MIN_WIDTH = 760 as const;
 export const DESKTOP_WINDOW_MIN_HEIGHT = 600 as const;
 export const UTILITY_EXIT_TIMEOUT_MS = 5_000 as const;
+export const UTILITY_FORCE_EXIT_TIMEOUT_MS = 2_000 as const;
+export const UTILITY_SPAWN_TIMEOUT_MS = 5_000 as const;
 export const UTILITY_TERMINAL_ACK_TIMEOUT_MS = 1_000 as const;
 
 export function createDesktopContentSecurityPolicy(port: number): string {

--- a/apps/desktop/src/main/daemon-lifecycle.ts
+++ b/apps/desktop/src/main/daemon-lifecycle.ts
@@ -1,0 +1,359 @@
+import type { DesktopDaemonResolution } from "@enduragent/coach/enduragent";
+
+export type ConnectedDesktopDaemon = Extract<
+  DesktopDaemonResolution,
+  { readonly status: "connected" }
+>;
+
+export type DesktopDaemonLifecycleState =
+  | { readonly status: "starting" }
+  | { readonly status: "ready"; readonly generation: number }
+  | { readonly status: "recovering"; readonly generation: number }
+  | {
+      readonly status: "terminal";
+      readonly generation: number;
+      readonly cause: Extract<DesktopDaemonResolution, { status: "refused" }>["cause"];
+    }
+  | { readonly status: "closing"; readonly generation: number };
+
+export interface DesktopDaemonConnection {
+  readonly url: `ws://127.0.0.1:${number}/rpc`;
+  readonly token: string;
+  readonly generation: number;
+}
+
+export interface DesktopDaemonRecoveryBudget {
+  remainingAttempts: number;
+  readonly deadline: number;
+}
+
+interface DesktopDaemonResolver {
+  resolveForRecovery(budget: DesktopDaemonRecoveryBudget): Promise<DesktopDaemonResolution>;
+  reobserveAttached(budget: DesktopDaemonRecoveryBudget): Promise<DesktopDaemonResolution>;
+  close(): Promise<void>;
+}
+
+export interface DesktopDaemonLifecycleOptions {
+  readonly delay?: (ms: number, signal: AbortSignal) => Promise<void>;
+  readonly monotonicNow?: () => number;
+  readonly prepareReady?: (input: {
+    readonly connection: DesktopDaemonConnection;
+    readonly signal: AbortSignal;
+  }) => Promise<void>;
+  readonly onTransition?: (state: DesktopDaemonLifecycleState) => void;
+  readonly onReady?: (input: {
+    readonly previous: DesktopDaemonConnection;
+    readonly current: DesktopDaemonConnection;
+  }) => void;
+}
+
+const RESTART_BACKOFF_MS = [500, 1_000, 2_000] as const;
+const RESTART_WINDOW_MS = 60_000;
+const READINESS_TIMEOUT_MS = 5_000;
+const CLOSE_TIMEOUT_MS = 10_000;
+
+function daemonConnection(
+  resolution: ConnectedDesktopDaemon,
+  generation: number,
+): DesktopDaemonConnection {
+  return { url: resolution.url, token: resolution.token, generation };
+}
+
+function defaultDelay(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal.aborted) {
+      reject(signal.reason);
+      return;
+    }
+    const timer = setTimeout(resolve, ms);
+    signal.addEventListener(
+      "abort",
+      () => {
+        clearTimeout(timer);
+        reject(signal.reason);
+      },
+      { once: true },
+    );
+  });
+}
+
+function childIsAlive(resolution: ConnectedDesktopDaemon): boolean {
+  if (resolution.supervision === "attached") return true;
+  return resolution.isAlive();
+}
+
+export class DesktopDaemonLifecycle {
+  private current: ConnectedDesktopDaemon | undefined;
+  private lastConnection: DesktopDaemonConnection;
+  private generation = 1;
+  private state: DesktopDaemonLifecycleState;
+  private readonly restartAttempts: number[] = [];
+  private readonly delay: (ms: number, signal: AbortSignal) => Promise<void>;
+  private readonly monotonicNow: () => number;
+  private readonly controller = new AbortController();
+  private watchIdentity = 0;
+  private recovery:
+    | { readonly generation: number; readonly promise: Promise<DesktopDaemonConnection> }
+    | undefined;
+  private closePromise: Promise<void> | undefined;
+
+  constructor(
+    private readonly resolver: DesktopDaemonResolver,
+    initial: ConnectedDesktopDaemon,
+    private readonly options: DesktopDaemonLifecycleOptions = {},
+  ) {
+    this.current = initial;
+    this.lastConnection = daemonConnection(initial, 1);
+    this.state = { status: "starting" };
+    this.delay = options.delay ?? defaultDelay;
+    this.monotonicNow = options.monotonicNow ?? (() => performance.now());
+  }
+
+  start(): void {
+    if (this.state.status !== "starting") return;
+    this.transition({ status: "ready", generation: this.generation });
+    this.watch(this.current, this.generation);
+  }
+
+  snapshot(): DesktopDaemonLifecycleState {
+    return this.state;
+  }
+
+  connection(): DesktopDaemonConnection {
+    if (this.current === undefined || this.state.status !== "ready") {
+      throw new Error("desktop daemon connection unavailable");
+    }
+    return daemonConnection(this.current, this.generation);
+  }
+
+  currentPort(): number {
+    return Number(new URL(this.lastConnection.url).port);
+  }
+
+  recover(failedGeneration: number): Promise<DesktopDaemonConnection> {
+    if (!Number.isSafeInteger(failedGeneration) || failedGeneration < 1) {
+      return Promise.reject(new TypeError("invalid desktop daemon generation"));
+    }
+    if (this.state.status === "closing" || this.state.status === "terminal") {
+      return Promise.reject(new Error("desktop daemon recovery unavailable"));
+    }
+    if (this.recovery !== undefined && failedGeneration <= this.recovery.generation) {
+      return this.recovery.promise;
+    }
+    if (failedGeneration < this.generation) return Promise.resolve(this.connection());
+    if (failedGeneration > this.generation) {
+      return Promise.reject(new TypeError("unknown desktop daemon generation"));
+    }
+    const previous = this.current;
+    if (previous === undefined) {
+      return Promise.reject(new Error("desktop daemon recovery unavailable"));
+    }
+    const pending = this.recoverCurrent(previous, failedGeneration).finally(() => {
+      if (this.recovery?.promise === pending) this.recovery = undefined;
+    });
+    this.recovery = { generation: failedGeneration, promise: pending };
+    return pending;
+  }
+
+  close(): Promise<void> {
+    this.closePromise ??= this.runClose();
+    return this.closePromise;
+  }
+
+  private transition(state: DesktopDaemonLifecycleState): void {
+    this.state = state;
+    this.options.onTransition?.(state);
+  }
+
+  private watch(resolution: ConnectedDesktopDaemon | undefined, generation: number): void {
+    if (resolution?.supervision !== "app-supervised") return;
+    const identity = ++this.watchIdentity;
+    void resolution.exited.then(
+      () => this.recoverAfterOwnedExit(resolution, generation, identity),
+      () => this.recoverAfterOwnedExit(resolution, generation, identity),
+    );
+  }
+
+  private recoverAfterOwnedExit(
+    resolution: ConnectedDesktopDaemon,
+    generation: number,
+    identity: number,
+  ): void {
+    if (
+      this.state.status === "closing" ||
+      this.state.status === "terminal" ||
+      identity !== this.watchIdentity ||
+      generation !== this.generation ||
+      resolution !== this.current
+    ) {
+      return;
+    }
+    void this.recover(generation).catch(() => {});
+  }
+
+  private async recoverCurrent(
+    previousResolution: ConnectedDesktopDaemon,
+    failedGeneration: number,
+  ): Promise<DesktopDaemonConnection> {
+    if (previousResolution.supervision === "app-supervised") {
+      if (childIsAlive(previousResolution)) return this.connection();
+    }
+    const now = this.monotonicNow();
+    while (
+      this.restartAttempts[0] !== undefined &&
+      now - this.restartAttempts[0] >= RESTART_WINDOW_MS
+    ) {
+      this.restartAttempts.shift();
+    }
+    const budget: DesktopDaemonRecoveryBudget = {
+      remainingAttempts: RESTART_BACKOFF_MS.length - this.restartAttempts.length,
+      deadline: now + RESTART_WINDOW_MS,
+    };
+    if (budget.remainingAttempts < 1) {
+      this.enterTerminal("restart-exhausted");
+      throw new Error("desktop daemon restart budget exhausted");
+    }
+    if (previousResolution.supervision === "attached") {
+      this.transition({ status: "recovering", generation: failedGeneration });
+      const observed = await this.resolver.reobserveAttached(budget);
+      if (this.state.status === "closing") {
+        if (observed.status === "connected") void observed.close().catch(() => {});
+        throw new Error("desktop daemon recovery cancelled");
+      }
+      if (
+        observed.status === "connected" &&
+        observed.url === previousResolution.url &&
+        observed.token === previousResolution.token
+      ) {
+        this.transition({ status: "ready", generation: failedGeneration });
+        return this.connection();
+      }
+      if (observed.status === "connected") {
+        return this.publishSuccessor(previousResolution, observed, failedGeneration);
+      }
+      if (!observed.retryable) {
+        this.enterTerminal(observed.cause);
+        throw new Error("desktop daemon recovery refused");
+      }
+    }
+    this.current = undefined;
+    this.watchIdentity += 1;
+    this.transition({ status: "recovering", generation: failedGeneration });
+    try {
+      await previousResolution.close();
+    } catch {
+      this.enterTerminal("termination-failed");
+      throw new Error("desktop daemon termination failed");
+    }
+    let attemptsThisRecovery = 0;
+    while (
+      attemptsThisRecovery < RESTART_BACKOFF_MS.length &&
+      budget.remainingAttempts > 0 &&
+      this.state.status === "recovering"
+    ) {
+      const attemptIndex = this.restartAttempts.length;
+      const attemptAt = this.monotonicNow();
+      this.restartAttempts.push(attemptAt);
+      attemptsThisRecovery += 1;
+      await this.delay(
+        RESTART_BACKOFF_MS[Math.min(attemptIndex, 2)]!,
+        this.controller.signal,
+      ).catch(() => {});
+      if (this.state.status !== "recovering" || this.controller.signal.aborted) {
+        throw new Error("desktop daemon recovery cancelled");
+      }
+      let resolution: DesktopDaemonResolution;
+      try {
+        resolution = await this.resolver.resolveForRecovery(budget);
+      } catch {
+        continue;
+      }
+      if (this.state.status !== "recovering" || this.controller.signal.aborted) {
+        if (resolution.status === "connected") void resolution.close().catch(() => {});
+        throw new Error("desktop daemon recovery cancelled");
+      }
+      if (resolution.status === "connected") {
+        return this.publishSuccessor(previousResolution, resolution, failedGeneration);
+      }
+      if (!resolution.retryable) {
+        this.enterTerminal(resolution.cause);
+        throw new Error("desktop daemon recovery refused");
+      }
+    }
+    this.enterTerminal("restart-exhausted");
+    throw new Error("desktop daemon restart budget exhausted");
+  }
+
+  private async publishSuccessor(
+    previousResolution: ConnectedDesktopDaemon,
+    successor: ConnectedDesktopDaemon,
+    failedGeneration: number,
+  ): Promise<DesktopDaemonConnection> {
+    const nextGeneration = failedGeneration + 1;
+    const next = daemonConnection(successor, nextGeneration);
+    const readiness = Promise.resolve(
+      this.options.prepareReady?.({ connection: next, signal: this.controller.signal }),
+    );
+    const prepared = await new Promise<boolean>((resolve) => {
+      let settled = false;
+      const finish = (value: boolean): void => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        this.controller.signal.removeEventListener("abort", onAbort);
+        resolve(value);
+      };
+      const timer = setTimeout(() => finish(false), READINESS_TIMEOUT_MS);
+      const onAbort = (): void => finish(false);
+      this.controller.signal.addEventListener("abort", onAbort, { once: true });
+      void readiness.then(
+        () => finish(true),
+        () => finish(false),
+      );
+      if (this.controller.signal.aborted) onAbort();
+    });
+    if (this.state.status !== "recovering" || this.controller.signal.aborted) {
+      void successor.close().catch(() => {});
+      throw new Error("desktop daemon recovery cancelled");
+    }
+    if (!prepared) {
+      void successor.close().catch(() => {});
+      this.enterTerminal("unavailable");
+      throw new Error("desktop daemon readiness failed");
+    }
+    this.current = successor;
+    this.generation = nextGeneration;
+    this.lastConnection = next;
+    this.transition({ status: "ready", generation: nextGeneration });
+    this.watch(successor, nextGeneration);
+    this.options.onReady?.({
+      previous: daemonConnection(previousResolution, failedGeneration),
+      current: next,
+    });
+    return next;
+  }
+
+  private enterTerminal(
+    cause: Extract<DesktopDaemonResolution, { status: "refused" }>["cause"],
+  ): void {
+    if (this.state.status === "closing") return;
+    this.current = undefined;
+    this.watchIdentity += 1;
+    this.transition({ status: "terminal", generation: this.generation, cause });
+  }
+
+  private async runClose(): Promise<void> {
+    if (this.state.status === "closing") return;
+    this.transition({ status: "closing", generation: this.generation });
+    this.controller.abort(new Error("desktop daemon lifecycle closing"));
+    this.current = undefined;
+    this.watchIdentity += 1;
+    const closing = this.resolver.close().catch(() => {});
+    await Promise.race([
+      closing,
+      new Promise<void>((resolve) => {
+        setTimeout(resolve, CLOSE_TIMEOUT_MS);
+      }),
+    ]);
+  }
+}

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -15,13 +15,28 @@ import {
   utilityProcess,
 } from "electron";
 import { createChatGptAuth, hasChatGptProfile } from "./chatgpt-auth.js";
-import { DESKTOP_CONNECTION_CHANNEL, DESKTOP_RENDERER_URL, DESKTOP_SCHEME } from "./constants.js";
+import { installDesktopConnectionIpc } from "./connection-ipc.js";
+import { DESKTOP_LIFECYCLE_CHANNEL, DESKTOP_RENDERER_URL, DESKTOP_SCHEME } from "./constants.js";
 import {
   createCredentialRuntimeApplication,
   readSelectedLlmProvider,
 } from "./credential-runtime.js";
-import { CREDENTIAL_DIRECTORY_NAME, createCredentialVault } from "./credential-vault.js";
+import {
+  CREDENTIAL_DIRECTORY_NAME,
+  createCredentialVault,
+  type DesktopCredentialSlot,
+} from "./credential-vault.js";
+import {
+  DesktopDaemonLifecycle,
+  type DesktopDaemonConnection,
+  type DesktopDaemonLifecycleState,
+} from "./daemon-lifecycle.js";
 import { resolveDesktopAthleteHome, seedFirstRunConfig } from "./first-run-config.js";
+import {
+  lifecycleErrorCopy,
+  startupRefusalCopy,
+  unexpectedStartupCopy,
+} from "./lifecycle-messages.js";
 import { registerOnboardingIpc, runtimeConfigurationForCredential } from "./onboarding-ipc.js";
 import { createDesktopResidency, type DesktopResidency } from "./residency.js";
 import {
@@ -35,6 +50,8 @@ import {
 import { DesktopDaemonSupervisor, isUtilityTerminalFrame } from "./supervisor.js";
 
 registerDesktopScheme();
+
+let desktopIsClosing = false;
 
 const mainDirectory = dirname(fileURLToPath(import.meta.url));
 const utilityEntry = resolve(mainDirectory, "daemon-utility.js");
@@ -85,27 +102,27 @@ async function runDesktop(): Promise<void> {
   );
   let quitting = false;
   let protocolInstalled = false;
-  let connectionHandlerInstalled = false;
+  let disposeConnectionIpc: (() => void) | undefined;
   let disposeOnboarding: (() => void) | undefined;
+  let daemonLifecycle: DesktopDaemonLifecycle | undefined;
   let shutdownPromise: Promise<void> | undefined;
   const shutdown = (): Promise<void> => {
     shutdownPromise ??= (async () => {
       controller.abort();
-      if (connectionHandlerInstalled) {
-        ipcMain.removeHandler(DESKTOP_CONNECTION_CHANNEL);
-        connectionHandlerInstalled = false;
-      }
+      disposeConnectionIpc?.();
+      disposeConnectionIpc = undefined;
       disposeOnboarding?.();
       disposeOnboarding = undefined;
       if (protocolInstalled) {
         session.defaultSession.protocol.unhandle(DESKTOP_SCHEME);
         protocolInstalled = false;
       }
-      await supervisor.close();
+      await (daemonLifecycle?.close() ?? supervisor.close());
     })();
     return shutdownPromise;
   };
   app.on("before-quit", (event) => {
+    desktopIsClosing = true;
     residency?.close();
     if (quitting) return;
     event.preventDefault();
@@ -118,13 +135,50 @@ async function runDesktop(): Promise<void> {
   try {
     const resolution = await supervisor.resolve();
     if (resolution.status === "refused") {
+      if (!controller.signal.aborted && resolution.cause !== "cancelled") {
+        const copy = startupRefusalCopy(resolution.cause);
+        dialog.showErrorBox(copy.title, copy.content);
+      }
       await shutdown();
-      app.exit(resolution.exitCode);
+      if (!quitting) app.exit(resolution.exitCode);
       return;
     }
-    const daemonPort = Number(new URL(resolution.url).port);
-    const applyRuntimeConfig = async (request: ConfigureRuntimeRpcParams): Promise<void> => {
-      const client = await connectCoachClient({ url: resolution.url, token: resolution.token });
+    let window: BrowserWindow | null = null;
+    let windowCreation: Promise<BrowserWindow> | undefined;
+    const currentWindow = (): BrowserWindow | null =>
+      window !== null && !window.isDestroyed() ? window : null;
+    let reapplyCredentials = async (
+      _connection: DesktopDaemonConnection,
+      _signal: AbortSignal,
+    ): Promise<void> => {};
+    const publishLifecycle = (state: DesktopDaemonLifecycleState): void => {
+      const visibleWindow = currentWindow();
+      if (visibleWindow !== null && state.status !== "starting") {
+        visibleWindow.webContents.send(DESKTOP_LIFECYCLE_CHANNEL, {
+          status: state.status,
+          generation: state.generation,
+        });
+      }
+      const copy =
+        controller.signal.aborted || desktopIsClosing ? undefined : lifecycleErrorCopy(state);
+      if (copy !== undefined) dialog.showErrorBox(copy.title, copy.content);
+    };
+    daemonLifecycle = new DesktopDaemonLifecycle(supervisor, resolution, {
+      prepareReady: ({ connection, signal }) => reapplyCredentials(connection, signal),
+      onTransition: publishLifecycle,
+      onReady({ previous, current }) {
+        if (new URL(previous.url).port === new URL(current.url).port) return;
+        const visibleWindow = currentWindow();
+        if (visibleWindow === null) return;
+        visibleWindow.webContents.reload();
+      },
+    });
+    const applyRuntimeConfigToConnection = async (
+      connection: Pick<DesktopDaemonConnection, "url" | "token">,
+      request: ConfigureRuntimeRpcParams,
+    ): Promise<void> => {
+      const { url, token } = connection;
+      const client = await connectCoachClient({ url, token });
       try {
         const result = await client.call("configureRuntime", request);
         if (
@@ -137,33 +191,54 @@ async function runDesktop(): Promise<void> {
         await client.close();
       }
     };
+    const applyRuntimeConfig = (request: ConfigureRuntimeRpcParams): Promise<void> =>
+      applyRuntimeConfigToConnection(daemonLifecycle!.connection(), request);
     const configDir = join(resolveDesktopAthleteHome(environment), "config");
+    const selectedLlmProvider = async (storedCredentialSlots: readonly DesktopCredentialSlot[]) =>
+      readSelectedLlmProvider(configDir, {
+        chatGptProfilePresent: await hasChatGptProfile(configDir),
+        storedCredentialSlots,
+      });
     const credentialRuntime = createCredentialRuntimeApplication({
       configureRuntime: applyRuntimeConfig,
-      selectedLlmProvider: async (storedCredentialSlots) =>
-        readSelectedLlmProvider(configDir, {
-          chatGptProfilePresent: await hasChatGptProfile(configDir),
-          storedCredentialSlots,
-        }),
+      selectedLlmProvider,
     });
+    const credentialRoot = join(app.getPath("userData"), CREDENTIAL_DIRECTORY_NAME);
     const vault = createCredentialVault({
-      root: join(app.getPath("userData"), CREDENTIAL_DIRECTORY_NAME),
+      root: credentialRoot,
       encryption: safeStorage,
       async applyCredential(slot, value) {
         await credentialRuntime.applyExplicit(runtimeConfigurationForCredential(slot, value));
       },
       reapplyCredential: credentialRuntime.reapplyStoredCredential,
     });
+    reapplyCredentials = async (connection, signal) => {
+      if (signal.aborted) return;
+      const successorRuntime = createCredentialRuntimeApplication({
+        configureRuntime: (request) => applyRuntimeConfigToConnection(connection, request),
+        selectedLlmProvider,
+      });
+      const successorVault = createCredentialVault({
+        root: credentialRoot,
+        encryption: safeStorage,
+        async applyCredential(slot, value) {
+          await successorRuntime.applyExplicit(runtimeConfigurationForCredential(slot, value));
+        },
+        reapplyCredential: successorRuntime.reapplyStoredCredential,
+      });
+      await successorVault.reapplyConfigured();
+    };
     const chatGptAuth = createChatGptAuth({
       configDir,
       applyRuntimeConfig: credentialRuntime.applyExplicit,
       openExternal: (url) => shell.openExternal(url),
       signal: controller.signal,
     });
+    daemonLifecycle.start();
     await vault.reapplyConfigured();
     await installDesktopProtocol({
       session: session.defaultSession,
-      daemonPort,
+      currentDaemonPort: () => daemonLifecycle!.currentPort(),
       rendererRoot: rendererOutputRoot(),
       ...(process.env.ELECTRON_RENDERER_URL === undefined
         ? {}
@@ -171,11 +246,8 @@ async function runDesktop(): Promise<void> {
     });
     protocolInstalled = true;
     const consoleMessages: string[] = [];
-    let window: BrowserWindow | null = null;
-    let windowCreation: Promise<BrowserWindow> | undefined;
     const mainWindow = {
-      current: (): BrowserWindow | null =>
-        window !== null && !window.isDestroyed() ? window : null,
+      current: currentWindow,
       show: (): Promise<BrowserWindow> => {
         if (windowCreation !== undefined) return windowCreation;
         const current = mainWindow.current();
@@ -234,13 +306,11 @@ async function runDesktop(): Promise<void> {
         return windowCreation;
       },
     };
-    ipcMain.handle(DESKTOP_CONNECTION_CHANNEL, (event) => {
-      if (!isTrustedConnectionRequest(event, mainWindow.current() ?? undefined)) {
-        throw new Error("untrusted desktop connection request");
-      }
-      return { url: resolution.url, token: resolution.token };
+    disposeConnectionIpc = installDesktopConnectionIpc({
+      ipcMain,
+      currentWindow: () => mainWindow.current() ?? undefined,
+      runtime: daemonLifecycle,
     });
-    connectionHandlerInstalled = true;
     const trayPopoverUrl =
       process.env.ELECTRON_RENDERER_URL === undefined
         ? "enduragent://app/tray.html"
@@ -258,6 +328,7 @@ async function runDesktop(): Promise<void> {
     await residency.start();
 
     if (process.argv.includes("--desktop-security-smoke")) {
+      const daemonPort = daemonLifecycle.currentPort();
       const rendererResult = await initialWindow.webContents.executeJavaScript(`(async () => {
       const blockedPort = ${daemonPort === 65_535 ? daemonPort - 1 : daemonPort + 1};
       const blocked = await new Promise((resolve) => {
@@ -300,7 +371,7 @@ async function runDesktop(): Promise<void> {
       }
       const result = {
         url: rendererResult.url,
-        rpcUrl: resolution.url,
+        rpcUrl: daemonLifecycle.connection().url,
         bridgeKeys: rendererResult.bridgeKeys,
         noNodeGlobals: rendererResult.noNodeGlobals,
         rpcConnected: rendererResult.rpcConnected,
@@ -313,11 +384,15 @@ async function runDesktop(): Promise<void> {
             const keys = Object.keys(entry).sort();
             return JSON.stringify(keys) === JSON.stringify(["runtimeState", "slot", "state"]);
           }) &&
-          !JSON.stringify(rendererResult.credentialStatuses).includes(resolution.token),
+          !JSON.stringify(rendererResult.credentialStatuses).includes(
+            daemonLifecycle.connection().token,
+          ),
         tokenAbsentInRendererSurfaces:
-          !JSON.stringify(rendererResult.rendererSurfaces).includes(resolution.token) &&
-          !consoleMessages.some((entry) => entry.includes(resolution.token)) &&
-          !screenshot.includes(resolution.token),
+          !JSON.stringify(rendererResult.rendererSurfaces).includes(
+            daemonLifecycle.connection().token,
+          ) &&
+          !consoleMessages.some((entry) => entry.includes(daemonLifecycle!.connection().token)) &&
+          !screenshot.includes(daemonLifecycle.connection().token),
       };
       process.stdout.write(`DESKTOP_SECURITY_READY ${JSON.stringify(result)}\n`);
       await new Promise<void>((resolveRelease) => {
@@ -341,5 +416,10 @@ if (!primaryInstance) {
   const runPrimaryDesktop = process.argv.includes("--desktop-runtime-smoke")
     ? runRuntimeSmoke
     : runDesktop;
-  void runPrimaryDesktop().catch(() => app.exit(1));
+  void runPrimaryDesktop().catch(() => {
+    if (!desktopIsClosing) {
+      dialog.showErrorBox(unexpectedStartupCopy.title, unexpectedStartupCopy.content);
+    }
+    app.exit(1);
+  });
 }

--- a/apps/desktop/src/main/lifecycle-messages.ts
+++ b/apps/desktop/src/main/lifecycle-messages.ts
@@ -1,0 +1,51 @@
+import type { DesktopDaemonResolution } from "@enduragent/coach/enduragent";
+import type { DesktopDaemonLifecycleState } from "./daemon-lifecycle.js";
+
+export interface DesktopErrorCopy {
+  readonly title: string;
+  readonly content: string;
+}
+
+export function startupRefusalCopy(
+  cause: Extract<DesktopDaemonResolution, { status: "refused" }>["cause"],
+): DesktopErrorCopy {
+  if (cause === "contention") {
+    return {
+      title: "Enduragent couldn’t connect to its background service",
+      content:
+        "Another Enduragent process is already running or stuck. Quit that process, then reopen Enduragent. If you can’t find it, log out and back in.",
+    };
+  }
+  if (cause === "version-mismatch") {
+    return {
+      title: "Enduragent found a different background service version",
+      content:
+        "A different version of the Enduragent background service is running from the CLI or a previous install. Quit that service, then reopen Enduragent.",
+    };
+  }
+  return {
+    title: "Enduragent couldn’t start its background service",
+    content:
+      "The background service could not start or its saved connection state could not be read. Quit Enduragent and reopen it. If the problem continues, restart your Mac before trying again.",
+  };
+}
+
+export const unexpectedStartupCopy: DesktopErrorCopy = {
+  title: "Enduragent couldn’t open",
+  content:
+    "Enduragent hit an unexpected problem while starting. Quit Enduragent and try again. If it keeps happening, log out and back in before reopening it.",
+};
+
+export const restartExhaustedCopy: DesktopErrorCopy = {
+  title: "Enduragent’s background service stopped",
+  content:
+    "The background service stopped repeatedly and Enduragent could not restart it. Quit Enduragent and reopen it. If that does not help, log out and back in.",
+};
+
+export function lifecycleErrorCopy(
+  state: DesktopDaemonLifecycleState,
+): DesktopErrorCopy | undefined {
+  if (state.status !== "terminal" || state.cause === "cancelled") return undefined;
+  if (state.cause === "restart-exhausted") return restartExhaustedCopy;
+  return startupRefusalCopy(state.cause);
+}

--- a/apps/desktop/src/main/security.ts
+++ b/apps/desktop/src/main/security.ts
@@ -52,33 +52,33 @@ function safeRendererPath(rendererRoot: string, pathname: string): string | unde
 
 export async function installDesktopProtocol(input: {
   readonly session: Session;
-  readonly daemonPort: number;
+  readonly currentDaemonPort: () => number;
   readonly rendererRoot: string;
   readonly developmentUrl?: string;
 }): Promise<void> {
-  const policy = createDesktopContentSecurityPolicy(input.daemonPort);
+  const withCurrentPolicy = (response: Response): Response =>
+    responseWithPolicy(response, createDesktopContentSecurityPolicy(input.currentDaemonPort()));
   await input.session.protocol.handle(DESKTOP_SCHEME, async (request) => {
     const requested = new URL(request.url);
     if (requested.host !== DESKTOP_HOST)
-      return responseWithPolicy(new Response(null, { status: 404 }), policy);
+      return withCurrentPolicy(new Response(null, { status: 404 }));
     if (input.developmentUrl !== undefined) {
       const upstream = new URL(input.developmentUrl);
       upstream.pathname = requested.pathname;
       upstream.search = requested.search;
-      return responseWithPolicy(await net.fetch(upstream.toString()), policy);
+      return withCurrentPolicy(await net.fetch(upstream.toString()));
     }
     const target = safeRendererPath(resolve(input.rendererRoot), requested.pathname);
-    if (target === undefined)
-      return responseWithPolicy(new Response(null, { status: 404 }), policy);
+    if (target === undefined) return withCurrentPolicy(new Response(null, { status: 404 }));
     try {
       const body = await readFile(target);
       const headers = new Headers();
       if (target.endsWith(".html")) headers.set("Content-Type", "text/html; charset=utf-8");
       if (target.endsWith(".js")) headers.set("Content-Type", "text/javascript; charset=utf-8");
       if (target.endsWith(".css")) headers.set("Content-Type", "text/css; charset=utf-8");
-      return responseWithPolicy(new Response(body, { status: 200, headers }), policy);
+      return withCurrentPolicy(new Response(body, { status: 200, headers }));
     } catch {
-      return responseWithPolicy(new Response(null, { status: 404 }), policy);
+      return withCurrentPolicy(new Response(null, { status: 404 }));
     }
   });
 }

--- a/apps/desktop/src/main/supervisor.ts
+++ b/apps/desktop/src/main/supervisor.ts
@@ -1,12 +1,19 @@
 import { isAbsolute } from "node:path";
 import { utilityProcess, type UtilityProcess } from "electron";
 import {
+  AppSupervisedDaemonStartError,
   resolveDesktopDaemon,
   type AppSupervisedChildHandle,
+  type DesktopDaemonStartBudget,
   type DesktopDaemonResolution,
   type ResolveDesktopDaemonInput,
 } from "@enduragent/coach/enduragent";
-import { UTILITY_EXIT_TIMEOUT_MS } from "./constants.js";
+import type { DesktopDaemonRecoveryBudget } from "./daemon-lifecycle.js";
+import {
+  UTILITY_EXIT_TIMEOUT_MS,
+  UTILITY_FORCE_EXIT_TIMEOUT_MS,
+  UTILITY_SPAWN_TIMEOUT_MS,
+} from "./constants.js";
 
 export type UtilityStartFrame = {
   readonly type: "start";
@@ -85,22 +92,34 @@ export function createUtilityEnvironment(
   return environment;
 }
 
-function waitForSpawn(child: UtilityProcess): Promise<void> {
+function waitForSpawn(child: UtilityProcess, signal: AbortSignal): Promise<void> {
   return new Promise((resolve, reject) => {
+    const timer = setTimeout(
+      () => finish(new Error("utility process spawn deadline exceeded")),
+      UTILITY_SPAWN_TIMEOUT_MS,
+    );
     const cleanup = (): void => {
+      clearTimeout(timer);
       child.off("spawn", onSpawn);
       child.off("exit", onEarlyExit);
+      signal.removeEventListener("abort", onAbort);
+    };
+    const finish = (error?: Error): void => {
+      cleanup();
+      if (error === undefined) resolve();
+      else reject(error);
     };
     const onSpawn = (): void => {
-      cleanup();
-      resolve();
+      finish();
     };
     const onEarlyExit = (): void => {
-      cleanup();
-      reject(new Error("utility process exited before spawn"));
+      finish(new Error("utility process exited before spawn"));
     };
+    const onAbort = (): void => finish(new Error("utility process spawn cancelled"));
     child.once("spawn", onSpawn);
     child.once("exit", onEarlyExit);
+    signal.addEventListener("abort", onAbort, { once: true });
+    if (signal.aborted) onAbort();
   });
 }
 
@@ -112,19 +131,77 @@ function waitWithTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T |
       settled = true;
       resolve(undefined);
     }, timeoutMs);
-    void promise.then((value) => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timer);
-      resolve(value);
-    });
+    void promise.then(
+      (value) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve(value);
+      },
+      () => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve(undefined);
+      },
+    );
   });
+}
+
+export async function terminateOwnedUtilityProcess(input: {
+  readonly child: Pick<UtilityProcess, "postMessage" | "kill">;
+  readonly pid: number;
+  readonly exited: Promise<{ readonly exitCode: number | null }>;
+  readonly hasExited: () => boolean;
+  readonly hardStop?: (pid: number) => void;
+}): Promise<void> {
+  if (input.hasExited()) return;
+  try {
+    input.child.postMessage({ type: "shutdown" } satisfies UtilityShutdownFrame);
+  } catch {}
+  if ((await waitWithTimeout(input.exited, UTILITY_EXIT_TIMEOUT_MS)) !== undefined) return;
+  input.child.kill();
+  if ((await waitWithTimeout(input.exited, UTILITY_FORCE_EXIT_TIMEOUT_MS)) !== undefined) return;
+  if (!Number.isSafeInteger(input.pid) || input.pid <= 0) {
+    throw new Error("utility process owned pid is invalid");
+  }
+  try {
+    (input.hardStop ?? ((pid) => process.kill(pid, "SIGKILL")))(input.pid);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ESRCH") return;
+    throw error;
+  }
+  if ((await waitWithTimeout(input.exited, UTILITY_FORCE_EXIT_TIMEOUT_MS)) === undefined) {
+    throw new Error("utility process termination deadline exceeded");
+  }
+}
+
+async function terminateUnacknowledgedUtility(
+  child: UtilityProcess,
+  exited: Promise<{ readonly exitCode: number | null }>,
+): Promise<void> {
+  child.kill();
+  if ((await waitWithTimeout(exited, UTILITY_FORCE_EXIT_TIMEOUT_MS)) !== undefined) return;
+  const pid = child.pid;
+  if (pid === undefined || !Number.isSafeInteger(pid) || pid <= 0) {
+    throw new Error("unacknowledged utility process could not be reaped");
+  }
+  try {
+    process.kill(pid, "SIGKILL");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ESRCH") return;
+    throw error;
+  }
+  if ((await waitWithTimeout(exited, UTILITY_FORCE_EXIT_TIMEOUT_MS)) === undefined) {
+    throw new Error("unacknowledged utility process termination deadline exceeded");
+  }
 }
 
 export async function forkAppSupervisedDaemon(input: {
   readonly utilityEntry: string;
   readonly homeRoot: string;
   readonly handoffCapability?: string;
+  readonly signal?: AbortSignal;
 }): Promise<AppSupervisedChildHandle> {
   const start = {
     type: "start",
@@ -158,33 +235,37 @@ export async function forkAppSupervisedDaemon(input: {
     }
   });
   try {
-    await waitForSpawn(child);
+    await waitForSpawn(child, input.signal ?? new AbortController().signal);
     child.postMessage(start);
-  } catch (error) {
-    child.kill();
-    await exitedPromise;
-    throw error;
+  } catch {
+    try {
+      await terminateUnacknowledgedUtility(child, exitedPromise);
+    } catch {
+      throw new AppSupervisedDaemonStartError("termination-failed");
+    }
+    throw new AppSupervisedDaemonStartError("spawn-failed");
   }
   const pid = child.pid;
   if (pid === undefined || !Number.isSafeInteger(pid) || pid <= 0) {
-    child.kill();
-    await exitedPromise;
-    throw new Error("utility process did not publish a pid");
+    try {
+      await terminateUnacknowledgedUtility(child, exitedPromise);
+    } catch {
+      throw new AppSupervisedDaemonStartError("termination-failed");
+    }
+    throw new AppSupervisedDaemonStartError("spawn-failed");
   }
   let stopPromise: Promise<void> | undefined;
   return {
     pid,
     exited: exitedPromise,
+    isAlive: () => !exited,
     stop() {
-      stopPromise ??= (async () => {
-        if (!exited) {
-          child.postMessage({ type: "shutdown" } satisfies UtilityShutdownFrame);
-          if ((await waitWithTimeout(exitedPromise, UTILITY_EXIT_TIMEOUT_MS)) === undefined) {
-            child.kill();
-          }
-        }
-        await exitedPromise;
-      })();
+      stopPromise ??= terminateOwnedUtilityProcess({
+        child,
+        pid,
+        exited: exitedPromise,
+        hasExited: () => exited,
+      });
       return stopPromise;
     },
   };
@@ -192,6 +273,7 @@ export async function forkAppSupervisedDaemon(input: {
 
 export class DesktopDaemonSupervisor {
   private active: Promise<DesktopDaemonResolution> | undefined;
+  private closing = false;
 
   constructor(
     private readonly input: Omit<ResolveDesktopDaemonInput, "startAppSupervisedDaemon">,
@@ -201,22 +283,42 @@ export class DesktopDaemonSupervisor {
 
   resolve(): Promise<DesktopDaemonResolution> {
     if (this.active !== undefined) return this.active;
+    return this.beginResolve();
+  }
+
+  resolveForRecovery(budget: DesktopDaemonRecoveryBudget): Promise<DesktopDaemonResolution> {
+    this.active = undefined;
+    return this.beginResolve(budget);
+  }
+
+  reobserveAttached(budget: DesktopDaemonRecoveryBudget): Promise<DesktopDaemonResolution> {
+    this.active = undefined;
+    return this.beginResolve(budget, true);
+  }
+
+  private beginResolve(
+    startBudget?: DesktopDaemonStartBudget,
+    observationOnly = false,
+  ): Promise<DesktopDaemonResolution> {
     const generation = this.resolveDaemon({
       ...this.input,
+      ...(startBudget === undefined ? {} : { startBudget }),
+      ...(observationOnly ? { observationOnly: true } : {}),
       startAppSupervisedDaemon: ({ home, handoffCapability }) =>
         forkAppSupervisedDaemon({
           utilityEntry: this.utilityEntry,
           homeRoot: home.root,
+          signal: this.input.signal,
           ...(handoffCapability === undefined ? {} : { handoffCapability }),
         }),
     })
-      .then((resolution) => {
+      .then(async (resolution) => {
         if (resolution.status === "refused") {
           if (this.active === generation) this.active = undefined;
           return resolution;
         }
         let closePromise: Promise<void> | undefined;
-        return {
+        const wrapped = {
           ...resolution,
           close: () => {
             closePromise ??= resolution.close().finally(() => {
@@ -225,6 +327,17 @@ export class DesktopDaemonSupervisor {
             return closePromise;
           },
         };
+        if (this.closing) {
+          await wrapped.close().catch(() => {});
+          return {
+            status: "refused" as const,
+            exitCode: 3 as const,
+            classification: "contention-family" as const,
+            cause: "cancelled" as const,
+            retryable: true,
+          };
+        }
+        return wrapped;
       })
       .catch((error) => {
         if (this.active === generation) this.active = undefined;
@@ -235,9 +348,12 @@ export class DesktopDaemonSupervisor {
   }
 
   async close(): Promise<void> {
+    this.closing = true;
     const active = this.active;
     if (active === undefined) return;
-    const resolution = await active;
-    if (resolution.status === "connected") await resolution.close();
+    const closing = active.then(async (resolution) => {
+      if (resolution.status === "connected") await resolution.close();
+    });
+    await waitWithTimeout(closing, UTILITY_EXIT_TIMEOUT_MS + UTILITY_FORCE_EXIT_TIMEOUT_MS * 2);
   }
 }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -1,5 +1,5 @@
 import { contextBridge, ipcRenderer, webUtils } from "electron";
-import { DESKTOP_CONNECTION_CHANNEL } from "../main/constants.js";
+import { DESKTOP_CONNECTION_CHANNEL, DESKTOP_LIFECYCLE_CHANNEL } from "../main/constants.js";
 
 const DESKTOP_CREDENTIAL_STATUS_CHANNEL = "enduragent:onboarding:credential-status";
 const DESKTOP_CREDENTIAL_RETRY_CHANNEL = "enduragent:onboarding:credential-retry";
@@ -150,10 +150,38 @@ function parsePaths(value: unknown): readonly string[] {
 
 let dropDisposer: (() => void) | undefined;
 
+ipcRenderer.on(DESKTOP_LIFECYCLE_CHANNEL, (_event, value: unknown) => {
+  if (
+    !record(value) ||
+    !exactKeys(value, ["generation", "status"]) ||
+    !["ready", "recovering", "terminal", "closing"].includes(value.status as string) ||
+    !Number.isSafeInteger(value.generation) ||
+    (value.generation as number) < 1
+  ) {
+    return;
+  }
+  window.dispatchEvent(
+    new CustomEvent("enduragent-lifecycle", {
+      detail: { status: value.status, generation: value.generation },
+    }),
+  );
+});
+
 contextBridge.exposeInMainWorld(
   "enduragentAuth",
   Object.freeze({
-    getDaemonConnection: () => ipcRenderer.invoke(DESKTOP_CONNECTION_CHANNEL),
+    getDaemonConnection: (failedGeneration?: number) => {
+      if (
+        failedGeneration !== undefined &&
+        (!Number.isSafeInteger(failedGeneration) || failedGeneration < 1)
+      ) {
+        throw new TypeError();
+      }
+      return ipcRenderer.invoke(
+        DESKTOP_CONNECTION_CHANNEL,
+        ...(failedGeneration === undefined ? [] : [{ generation: failedGeneration }]),
+      );
+    },
     credentialStatuses: async () =>
       parseStatuses(await ipcRenderer.invoke(DESKTOP_CREDENTIAL_STATUS_CHANNEL)),
     retryFailedCredentials: async () =>

--- a/apps/desktop/tests/connection-ipc.test.ts
+++ b/apps/desktop/tests/connection-ipc.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("electron", () => ({
+  BrowserWindow: class {},
+  net: { fetch: vi.fn() },
+  protocol: { registerSchemesAsPrivileged: vi.fn() },
+}));
+
+import { installDesktopConnectionIpc } from "../src/main/connection-ipc.js";
+import { DESKTOP_CONNECTION_CHANNEL, DESKTOP_RENDERER_URL } from "../src/main/constants.js";
+
+type Handler = (event: unknown, request?: unknown) => unknown;
+
+function setup() {
+  const handlers = new Map<string, Handler>();
+  const ipcMain = {
+    handle: vi.fn((channel: string, handler: Handler) => handlers.set(channel, handler)),
+    removeHandler: vi.fn((channel: string) => handlers.delete(channel)),
+  };
+  const mainFrame = { url: DESKTOP_RENDERER_URL };
+  const webContents = { isDestroyed: () => false, mainFrame };
+  const window = { isDestroyed: () => false, webContents };
+  let connection: {
+    url: `ws://127.0.0.1:${number}/rpc`;
+    token: string;
+    generation: number;
+  } = {
+    url: "ws://127.0.0.1:45001/rpc" as const,
+    token: "s".repeat(43),
+    generation: 1,
+  };
+  const runtime = {
+    connection: vi.fn(() => connection),
+    recover: vi.fn(async (generation: number) => {
+      if (generation < connection.generation) return connection;
+      connection = {
+        url: "ws://127.0.0.1:45002/rpc" as const,
+        token: "t".repeat(43),
+        generation: 2,
+      };
+      return connection;
+    }),
+  };
+  const dispose = installDesktopConnectionIpc({
+    ipcMain: ipcMain as never,
+    currentWindow: () => window as never,
+    runtime,
+  });
+  const trusted = { sender: webContents, senderFrame: mainFrame };
+  return { dispose, handlers, ipcMain, runtime, trusted };
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("desktop connection IPC", () => {
+  it("reads current coordinates again after a successful recovery", async () => {
+    const { handlers, runtime, trusted } = setup();
+    const connection = handlers.get(DESKTOP_CONNECTION_CHANNEL)!;
+    expect(((await connection(trusted)) as { readonly url: string }).url).toBe(
+      "ws://127.0.0.1:45001/rpc",
+    );
+    expect(((await connection(trusted, { generation: 1 })) as { readonly url: string }).url).toBe(
+      "ws://127.0.0.1:45002/rpc",
+    );
+    expect(runtime.connection).toHaveBeenCalledTimes(1);
+    expect(runtime.recover).toHaveBeenCalledWith(1);
+    await expect(connection(trusted, { generation: 1 })).resolves.toMatchObject({ generation: 2 });
+  });
+
+  it("refuses untrusted connection and recovery requests", async () => {
+    const { handlers, runtime } = setup();
+    const untrusted = { sender: {}, senderFrame: { url: DESKTOP_RENDERER_URL } };
+    const connection = handlers.get(DESKTOP_CONNECTION_CHANNEL)!;
+    for (const request of [undefined, { generation: 1 }]) {
+      await expect(connection(untrusted, request)).rejects.toThrow(
+        "untrusted desktop connection request",
+      );
+    }
+    expect(runtime.connection).not.toHaveBeenCalled();
+    expect(runtime.recover).not.toHaveBeenCalled();
+  });
+
+  it("rejects malformed recovery requests before changing daemon state", async () => {
+    const { handlers, runtime, trusted } = setup();
+    const connection = handlers.get(DESKTOP_CONNECTION_CHANNEL)!;
+    for (const request of [
+      false,
+      {},
+      { generation: 0 },
+      { generation: 1.5 },
+      { generation: 1, extra: true },
+    ]) {
+      await expect(connection(trusted, request)).rejects.toThrow(
+        "invalid desktop connection request",
+      );
+    }
+    expect(runtime.recover).not.toHaveBeenCalled();
+  });
+
+  it("removes the trusted connection channel during shutdown", () => {
+    const { dispose, handlers, ipcMain } = setup();
+    dispose();
+    expect(handlers.size).toBe(0);
+    expect(ipcMain.removeHandler).toHaveBeenCalledWith(DESKTOP_CONNECTION_CHANNEL);
+  });
+});

--- a/apps/desktop/tests/lifecycle-messages.test.ts
+++ b/apps/desktop/tests/lifecycle-messages.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import type { DesktopDaemonLifecycleState } from "../src/main/daemon-lifecycle.js";
+import {
+  lifecycleErrorCopy,
+  restartExhaustedCopy,
+  startupRefusalCopy,
+} from "../src/main/lifecycle-messages.js";
+
+describe("desktop lifecycle messages", () => {
+  it.each([
+    [
+      "contention",
+      "Enduragent couldn’t connect to its background service",
+      "Another Enduragent process is already running or stuck. Quit that process, then reopen Enduragent. If you can’t find it, log out and back in.",
+    ],
+    [
+      "version-mismatch",
+      "Enduragent found a different background service version",
+      "A different version of the Enduragent background service is running from the CLI or a previous install. Quit that service, then reopen Enduragent.",
+    ],
+    [
+      "never-published",
+      "Enduragent couldn’t start its background service",
+      "The background service could not start or its saved connection state could not be read. Quit Enduragent and reopen it. If the problem continues, restart your Mac before trying again.",
+    ],
+  ] as const)("gives %s a specific recovery path", (classification, title, content) => {
+    expect(startupRefusalCopy(classification)).toEqual({ title, content });
+  });
+
+  it("keeps internal and sensitive details out of every refusal", () => {
+    const copies = ["contention", "version-mismatch", "never-published", "unavailable"].map(
+      (value) => startupRefusalCopy(value as Parameters<typeof startupRefusalCopy>[0]),
+    );
+    for (const copy of copies) {
+      const visible = `${copy.title}\n${copy.content}`;
+      expect(visible).not.toMatch(/contention|version-mismatch|never-published|unavailable/u);
+      expect(visible).not.toMatch(/(?:ws|http)s?:\/\//u);
+      expect(visible).not.toMatch(/[A-Za-z0-9_-]{43}/u);
+      expect(visible).not.toMatch(/exit(?:\s+|-)?code/iu);
+      expect(visible).not.toMatch(/\b(?:3|5)\b/u);
+    }
+  });
+
+  it.each([
+    ["contention", startupRefusalCopy("contention")],
+    ["version-mismatch", startupRefusalCopy("version-mismatch")],
+    ["never-published", startupRefusalCopy("never-published")],
+    ["unavailable", startupRefusalCopy("unavailable")],
+    ["termination-failed", startupRefusalCopy("termination-failed")],
+    ["restart-exhausted", restartExhaustedCopy],
+  ] as const)("presents terminal %s with its matching recovery guidance", (cause, copy) => {
+    expect(lifecycleErrorCopy({ status: "terminal", generation: 2, cause })).toEqual(copy);
+  });
+
+  it("suppresses lifecycle dialogs while closing or after cancellation", () => {
+    const nonTerminal: DesktopDaemonLifecycleState[] = [
+      { status: "starting" },
+      { status: "ready", generation: 1 },
+      { status: "recovering", generation: 1 },
+      { status: "closing", generation: 1 },
+    ];
+    for (const state of nonTerminal) expect(lifecycleErrorCopy(state)).toBeUndefined();
+    expect(
+      lifecycleErrorCopy({ status: "terminal", generation: 1, cause: "cancelled" }),
+    ).toBeUndefined();
+  });
+});

--- a/apps/desktop/tests/preload-auth.test.ts
+++ b/apps/desktop/tests/preload-auth.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => {
   const exposed: Record<string, unknown> = {};
@@ -8,16 +8,18 @@ const mocks = vi.hoisted(() => {
       exposed[name] = value;
     }),
     invoke: vi.fn(),
+    on: vi.fn(),
   };
 });
 
 vi.mock("electron", () => ({
   contextBridge: { exposeInMainWorld: mocks.exposeInMainWorld },
-  ipcRenderer: { invoke: mocks.invoke },
+  ipcRenderer: { invoke: mocks.invoke, on: mocks.on },
   webUtils: { getPathForFile: vi.fn() },
 }));
 
 interface AuthBridge {
+  getDaemonConnection(failedGeneration?: number): Promise<unknown>;
   credentialStatuses(): Promise<unknown>;
   retryFailedCredentials(): Promise<unknown>;
   chatgptStatus(): Promise<unknown>;
@@ -35,7 +37,34 @@ beforeEach(() => {
   mocks.invoke.mockReset();
 });
 
+afterEach(() => vi.unstubAllGlobals());
+
 describe("desktop preload ChatGPT auth", () => {
+  it("reuses the connection channel with a closed recovery request", async () => {
+    mocks.invoke.mockResolvedValue(undefined);
+    await bridge.getDaemonConnection();
+    await bridge.getDaemonConnection(7);
+    expect(mocks.invoke.mock.calls).toEqual([
+      ["desktop:get-daemon-connection"],
+      ["desktop:get-daemon-connection", { generation: 7 }],
+    ]);
+  });
+
+  it("forwards only closed lifecycle states to the renderer", () => {
+    const dispatchEvent = vi.fn();
+    vi.stubGlobal("window", { dispatchEvent });
+    const listener = mocks.on.mock.calls.find(
+      ([channel]) => channel === "desktop:daemon-lifecycle",
+    )?.[1] as (_event: unknown, value: unknown) => void;
+    listener(undefined, { status: "recovering", generation: 2 });
+    listener(undefined, { status: "recovering", generation: 0 });
+    expect(dispatchEvent).toHaveBeenCalledTimes(1);
+    expect(dispatchEvent.mock.calls[0]![0]).toMatchObject({
+      type: "enduragent-lifecycle",
+      detail: { status: "recovering", generation: 2 },
+    });
+  });
+
   it("exposes closed credential runtime states and the retry command", async () => {
     const statuses = [
       { slot: "anthropic", state: "configured", runtimeState: "stored-inactive" },

--- a/apps/desktop/tests/security.test.ts
+++ b/apps/desktop/tests/security.test.ts
@@ -18,7 +18,11 @@ import {
   DESKTOP_WINDOW_WIDTH,
   createDesktopContentSecurityPolicy,
 } from "../src/main/constants.js";
-import { desktopWindowOptions, isTrustedConnectionRequest } from "../src/main/security.js";
+import {
+  desktopWindowOptions,
+  installDesktopProtocol,
+  isTrustedConnectionRequest,
+} from "../src/main/security.js";
 
 describe("desktop security boundary", () => {
   it("pins the scheme, IPC, window, and assigned-port-only CSP constants", () => {
@@ -68,6 +72,29 @@ describe("desktop security boundary", () => {
         allowRunningInsecureContent: false,
       },
     });
+  });
+
+  it("emits an exact CSP pin from the current daemon port on every document load", async () => {
+    let handler: ((request: Request) => Promise<Response>) | undefined;
+    const protocol = {
+      handle: vi.fn(async (_scheme: string, installed: (request: Request) => Promise<Response>) => {
+        handler = installed;
+      }),
+    };
+    let port = 45_001;
+    await installDesktopProtocol({
+      session: { protocol } as never,
+      currentDaemonPort: () => port,
+      rendererRoot: "/synthetic/renderer",
+    });
+    const first = await handler!(new Request("enduragent://app/missing.html"));
+    port = 45_002;
+    const second = await handler!(new Request("enduragent://app/missing.html"));
+    const firstPolicy = first.headers.get("Content-Security-Policy");
+    const secondPolicy = second.headers.get("Content-Security-Policy");
+    expect(firstPolicy).toContain("connect-src ws://127.0.0.1:45001;");
+    expect(secondPolicy).toContain("connect-src ws://127.0.0.1:45002;");
+    expect(secondPolicy).not.toContain("ws://127.0.0.1:*");
   });
 
   it("requires the live window, sender, main frame, and exact URL", () => {

--- a/apps/desktop/tests/supervisor.test.ts
+++ b/apps/desktop/tests/supervisor.test.ts
@@ -4,7 +4,12 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 vi.mock("electron", () => ({ utilityProcess: { fork: vi.fn() } }));
 
 import type { DesktopDaemonResolution } from "@enduragent/coach/enduragent";
-import { DesktopDaemonSupervisor, forkAppSupervisedDaemon } from "../src/main/supervisor.js";
+import { DesktopDaemonLifecycle } from "../src/main/daemon-lifecycle.js";
+import {
+  DesktopDaemonSupervisor,
+  forkAppSupervisedDaemon,
+  terminateOwnedUtilityProcess,
+} from "../src/main/supervisor.js";
 
 class FakeUtilityProcess extends EventEmitter {
   readonly pid = 91;
@@ -13,6 +18,35 @@ class FakeUtilityProcess extends EventEmitter {
     this.emit("exit", 1);
     return true;
   });
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolveValue) => {
+    resolve = resolveValue;
+  });
+  return { promise, resolve };
+}
+
+function connected(
+  port: number,
+  exit: ReturnType<typeof deferred<{ readonly exitCode: number | null }>>,
+) {
+  const close = vi.fn(async () => {});
+  let alive = true;
+  void exit.promise.then(() => {
+    alive = false;
+  });
+  return {
+    status: "connected" as const,
+    url: `ws://127.0.0.1:${port}/rpc` as const,
+    token: "s".repeat(43),
+    owner: "app-supervised" as const,
+    supervision: "app-supervised" as const,
+    exited: exit.promise,
+    isAlive: () => alive,
+    close,
+  };
 }
 
 afterEach(() => vi.useRealTimers());
@@ -26,6 +60,8 @@ describe("desktop main supervisor", () => {
       token: "s".repeat(43),
       owner: "app-supervised",
       supervision: "app-supervised",
+      exited: new Promise(() => {}),
+      isAlive: () => true,
       close,
     };
     const resolveDaemon = vi.fn(async () => connected);
@@ -100,5 +136,427 @@ describe("desktop main supervisor", () => {
     await vi.advanceTimersByTimeAsync(5_000);
     await stopping;
     expect(child.kill).toHaveBeenCalledTimes(1);
+  });
+
+  it("bounds startup when a utility child emits neither spawn nor exit", async () => {
+    vi.useFakeTimers();
+    const child = new FakeUtilityProcess();
+    const fork = vi.mocked((await import("electron")).utilityProcess.fork);
+    fork.mockReturnValue(child as never);
+    const started = forkAppSupervisedDaemon({
+      utilityEntry: "/synthetic/daemon-utility.js",
+      homeRoot: "/synthetic/athlete",
+    });
+    const rejected = expect(started).rejects.toMatchObject({
+      name: "AppSupervisedDaemonStartError",
+      cause: "spawn-failed",
+    });
+    await vi.advanceTimersByTimeAsync(5_000);
+    await rejected;
+    expect(child.kill).toHaveBeenCalledTimes(1);
+  });
+
+  it("bounds a refused utility kill and uses only the validated owned pid for hard stop", async () => {
+    vi.useFakeTimers();
+    let resolveExit!: (value: { readonly exitCode: number | null }) => void;
+    let exited = false;
+    const exit = new Promise<{ readonly exitCode: number | null }>((resolve) => {
+      resolveExit = (value) => {
+        exited = true;
+        resolve(value);
+      };
+    });
+    const child = { postMessage: vi.fn(), kill: vi.fn(() => false) };
+    const hardStop = vi.fn((pid: number) => resolveExit({ exitCode: pid === 91 ? 137 : 1 }));
+    const stopping = terminateOwnedUtilityProcess({
+      child,
+      pid: 91,
+      exited: exit,
+      hasExited: () => exited,
+      hardStop,
+    });
+    await vi.advanceTimersByTimeAsync(7_000);
+    await stopping;
+    expect(child.postMessage).toHaveBeenCalledWith({ type: "shutdown" });
+    expect(child.kill).toHaveBeenCalledTimes(1);
+    expect(hardStop).toHaveBeenCalledWith(91);
+  });
+
+  it("restarts after an unexpected child exit and publishes the new live coordinates", async () => {
+    let now = 0;
+    const firstExit = deferred<{ readonly exitCode: number | null }>();
+    const secondExit = deferred<{ readonly exitCode: number | null }>();
+    const first = connected(45_001, firstExit);
+    const second = connected(45_002, secondExit);
+    const supervisor = {
+      resolveForRecovery: vi.fn(async (budget: { remainingAttempts: number }) => {
+        budget.remainingAttempts -= 1;
+        return second;
+      }),
+      reobserveAttached: vi.fn(),
+      close: vi.fn(async () => {}),
+    };
+    const onReady = vi.fn();
+    const runtime = new DesktopDaemonLifecycle(supervisor, first, {
+      delay: async (ms: number) => {
+        now += ms;
+      },
+      monotonicNow: () => now,
+      onReady,
+    });
+    runtime.start();
+    firstExit.resolve({ exitCode: 1 });
+    await vi.waitFor(() => expect(onReady).toHaveBeenCalledTimes(1));
+    expect(first.close).toHaveBeenCalledTimes(1);
+    expect(supervisor.resolveForRecovery).toHaveBeenCalledTimes(1);
+    expect(runtime.connection().url).toBe("ws://127.0.0.1:45002/rpc");
+    expect(runtime.currentPort()).toBe(45_002);
+    expect(runtime.connection().generation).toBe(2);
+    await expect(runtime.recover(1)).resolves.toMatchObject({ generation: 2 });
+    expect(supervisor.resolveForRecovery).toHaveBeenCalledTimes(1);
+  });
+
+  it("prepares the successor coordinates before publishing them", async () => {
+    const firstExit = deferred<{ readonly exitCode: number | null }>();
+    const first = connected(45_001, firstExit);
+    const successor = connected(45_002, deferred<{ readonly exitCode: number | null }>());
+    const order: string[] = [];
+    const supervisor = {
+      resolveForRecovery: vi.fn(async (budget: { remainingAttempts: number }) => {
+        budget.remainingAttempts -= 1;
+        return successor;
+      }),
+      reobserveAttached: vi.fn(),
+      close: vi.fn(async () => {}),
+    };
+    let runtime!: DesktopDaemonLifecycle;
+    const prepareReady = vi.fn(async ({ connection }: { readonly connection: unknown }) => {
+      order.push("prepare");
+      expect(connection).toMatchObject({
+        url: "ws://127.0.0.1:45002/rpc",
+        token: "s".repeat(43),
+        generation: 2,
+      });
+      expect(() => runtime.connection()).toThrow("desktop daemon connection unavailable");
+    });
+    runtime = new DesktopDaemonLifecycle(supervisor, first, {
+      delay: async () => {},
+      prepareReady,
+      onReady: () => order.push("ready"),
+    });
+    runtime.start();
+    firstExit.resolve({ exitCode: 1 });
+    await vi.waitFor(() => expect(runtime.connection().generation).toBe(2));
+    expect(prepareReady).toHaveBeenCalledTimes(1);
+    expect(order).toEqual(["prepare", "ready"]);
+  });
+
+  it("does not restart when shutdown requested the child exit", async () => {
+    const exit = deferred<{ readonly exitCode: number | null }>();
+    const initial = connected(45_001, exit);
+    const supervisor = {
+      resolveForRecovery: vi.fn(),
+      reobserveAttached: vi.fn(),
+      close: vi.fn(async () => {
+        exit.resolve({ exitCode: 0 });
+        await initial.close();
+      }),
+    };
+    const onReady = vi.fn();
+    const onTransition = vi.fn();
+    const runtime = new DesktopDaemonLifecycle(supervisor, initial, {
+      delay: async () => {},
+      onReady,
+      onTransition,
+    });
+    runtime.start();
+    await runtime.close();
+    await Promise.resolve();
+    expect(supervisor.resolveForRecovery).not.toHaveBeenCalled();
+    expect(onReady).not.toHaveBeenCalled();
+    expect(onTransition).toHaveBeenLastCalledWith({ status: "closing", generation: 1 });
+  });
+
+  it("stops after three quick restart attempts when children keep dying", async () => {
+    let now = 0;
+    const delays: number[] = [];
+    const exits = Array.from({ length: 4 }, () => deferred<{ readonly exitCode: number | null }>());
+    const generations = exits.map((exit, index) => connected(45_001 + index, exit));
+    const supervisor = {
+      resolveForRecovery: vi
+        .fn()
+        .mockResolvedValueOnce(generations[1])
+        .mockResolvedValueOnce(generations[2])
+        .mockResolvedValueOnce(generations[3]),
+      reobserveAttached: vi.fn(),
+      close: vi.fn(async () => {}),
+    };
+    const onReady = vi.fn();
+    const onTransition = vi.fn();
+    const runtime = new DesktopDaemonLifecycle(supervisor, generations[0]!, {
+      delay: async (ms: number) => {
+        delays.push(ms);
+        now += ms;
+      },
+      monotonicNow: () => now,
+      onReady,
+      onTransition,
+    });
+    runtime.start();
+    for (let index = 0; index < 3; index += 1) {
+      exits[index]!.resolve({ exitCode: 1 });
+      await vi.waitFor(() => expect(onReady).toHaveBeenCalledTimes(index + 1));
+    }
+    exits[3]!.resolve({ exitCode: 1 });
+    await vi.waitFor(() =>
+      expect(onTransition).toHaveBeenCalledWith({
+        status: "terminal",
+        generation: 4,
+        cause: "restart-exhausted",
+      }),
+    );
+    expect(supervisor.resolveForRecovery).toHaveBeenCalledTimes(3);
+    expect(onReady).toHaveBeenCalledTimes(3);
+    expect(delays.filter((value) => value < 5_000)).toEqual([500, 1_000, 2_000]);
+    expect(() => runtime.connection()).toThrow("desktop daemon connection unavailable");
+  });
+
+  it("returns current coordinates for stale and healthy current-generation hints", async () => {
+    const exit = deferred<{ readonly exitCode: number | null }>();
+    const initial = connected(45_001, exit);
+    const supervisor = {
+      resolveForRecovery: vi.fn(),
+      reobserveAttached: vi.fn(),
+      close: vi.fn(async () => {}),
+    };
+    const runtime = new DesktopDaemonLifecycle(supervisor, initial);
+    runtime.start();
+    await expect(runtime.recover(1)).resolves.toMatchObject({ generation: 1 });
+    await expect(runtime.recover(1)).resolves.toMatchObject({ generation: 1 });
+    expect(supervisor.resolveForRecovery).not.toHaveBeenCalled();
+    expect(initial.close).not.toHaveBeenCalled();
+  });
+
+  it("coalesces current-generation recovery and closes a successor that arrives after close", async () => {
+    const firstExit = deferred<{ readonly exitCode: number | null }>();
+    const first = connected(45_001, firstExit);
+    const successorExit = deferred<{ readonly exitCode: number | null }>();
+    const successor = connected(45_002, successorExit);
+    const resolution = deferred<ReturnType<typeof connected>>();
+    const supervisor = {
+      resolveForRecovery: vi.fn(async (budget: { remainingAttempts: number }) => {
+        budget.remainingAttempts -= 1;
+        return resolution.promise;
+      }),
+      reobserveAttached: vi.fn(),
+      close: vi.fn(async () => {}),
+    };
+    const onReady = vi.fn();
+    const runtime = new DesktopDaemonLifecycle(supervisor, first, {
+      delay: async () => {},
+      onReady,
+    });
+    runtime.start();
+    firstExit.resolve({ exitCode: 1 });
+    await vi.waitFor(() => expect(supervisor.resolveForRecovery).toHaveBeenCalledTimes(1));
+    const recovery = runtime.recover(1);
+    await runtime.close();
+    resolution.resolve(successor);
+    await expect(recovery).rejects.toThrow("cancelled");
+    await vi.waitFor(() => expect(successor.close).toHaveBeenCalledTimes(1));
+    expect(onReady).not.toHaveBeenCalled();
+    expect(runtime.snapshot()).toEqual({ status: "closing", generation: 1 });
+  });
+
+  it("joins a newer in-flight recovery when a stale generation reports failure", async () => {
+    const firstExit = deferred<{ readonly exitCode: number | null }>();
+    const secondExit = deferred<{ readonly exitCode: number | null }>();
+    const thirdExit = deferred<{ readonly exitCode: number | null }>();
+    const first = connected(45_001, firstExit);
+    const second = connected(45_002, secondExit);
+    const third = connected(45_003, thirdExit);
+    const pendingThird = deferred<ReturnType<typeof connected>>();
+    const supervisor = {
+      resolveForRecovery: vi
+        .fn()
+        .mockImplementationOnce(async (budget: { remainingAttempts: number }) => {
+          budget.remainingAttempts -= 1;
+          return second;
+        })
+        .mockImplementationOnce(async (budget: { remainingAttempts: number }) => {
+          budget.remainingAttempts -= 1;
+          return pendingThird.promise;
+        }),
+      reobserveAttached: vi.fn(),
+      close: vi.fn(async () => {}),
+    };
+    const runtime = new DesktopDaemonLifecycle(supervisor, first, { delay: async () => {} });
+    runtime.start();
+    firstExit.resolve({ exitCode: 1 });
+    await vi.waitFor(() => expect(runtime.connection().generation).toBe(2));
+    secondExit.resolve({ exitCode: 1 });
+    await vi.waitFor(() => expect(supervisor.resolveForRecovery).toHaveBeenCalledTimes(2));
+    const currentRecovery = runtime.recover(2);
+    const staleRecovery = runtime.recover(1);
+    expect(staleRecovery).toBe(currentRecovery);
+    pendingThird.resolve(third);
+    await expect(staleRecovery).resolves.toMatchObject({ generation: 3 });
+    expect(supervisor.resolveForRecovery).toHaveBeenCalledTimes(2);
+  });
+
+  it("rediscovers an attached replacement without closing the attached peer", async () => {
+    const attached = {
+      status: "connected" as const,
+      url: "ws://127.0.0.1:45001/rpc" as const,
+      token: "s".repeat(43),
+      owner: "service-managed" as const,
+      supervision: "attached" as const,
+      close: vi.fn(async () => {}),
+    };
+    const successor = {
+      ...attached,
+      url: "ws://127.0.0.1:45002/rpc" as const,
+      token: "t".repeat(43),
+      close: vi.fn(async () => {}),
+    };
+    const supervisor = {
+      resolveForRecovery: vi.fn(),
+      reobserveAttached: vi.fn(async () => successor),
+      close: vi.fn(async () => {}),
+    };
+    const runtime = new DesktopDaemonLifecycle(supervisor, attached);
+    runtime.start();
+    await expect(runtime.recover(1)).resolves.toMatchObject({
+      url: "ws://127.0.0.1:45002/rpc",
+      generation: 2,
+    });
+    expect(attached.close).not.toHaveBeenCalled();
+    expect(supervisor.resolveForRecovery).not.toHaveBeenCalled();
+  });
+
+  it("treats a changed token at the same attached URL as a new generation", async () => {
+    const attached = {
+      status: "connected" as const,
+      url: "ws://127.0.0.1:45001/rpc" as const,
+      token: "s".repeat(43),
+      owner: "service-managed" as const,
+      supervision: "attached" as const,
+      close: vi.fn(async () => {}),
+    };
+    const successor = { ...attached, token: "t".repeat(43), close: vi.fn(async () => {}) };
+    const supervisor = {
+      resolveForRecovery: vi.fn(),
+      reobserveAttached: vi.fn(async () => successor),
+      close: vi.fn(async () => {}),
+    };
+    const runtime = new DesktopDaemonLifecycle(supervisor, attached);
+    runtime.start();
+    await expect(runtime.recover(1)).resolves.toMatchObject({
+      url: attached.url,
+      token: "t".repeat(43),
+      generation: 2,
+    });
+    expect(attached.close).not.toHaveBeenCalled();
+  });
+
+  it("shares one three-attempt budget after attached re-observation", async () => {
+    let now = 0;
+    const delays: number[] = [];
+    const budgets: Array<{ remainingAttempts: number; readonly deadline: number }> = [];
+    const refusal = {
+      status: "refused" as const,
+      exitCode: 3 as const,
+      classification: "contention-family" as const,
+      cause: "unavailable" as const,
+      retryable: true,
+    };
+    const attached = {
+      status: "connected" as const,
+      url: "ws://127.0.0.1:45001/rpc" as const,
+      token: "s".repeat(43),
+      owner: "service-managed" as const,
+      supervision: "attached" as const,
+      close: vi.fn(async () => {}),
+    };
+    const supervisor = {
+      reobserveAttached: vi.fn(async (budget: (typeof budgets)[number]) => {
+        budgets.push(budget);
+        return refusal;
+      }),
+      resolveForRecovery: vi.fn(async (budget: (typeof budgets)[number]) => {
+        budgets.push(budget);
+        budget.remainingAttempts -= 1;
+        return refusal;
+      }),
+      close: vi.fn(async () => {}),
+    };
+    const runtime = new DesktopDaemonLifecycle(supervisor, attached, {
+      delay: async (ms) => {
+        delays.push(ms);
+        now += ms;
+      },
+      monotonicNow: () => now,
+    });
+    runtime.start();
+    await expect(runtime.recover(1)).rejects.toThrow("restart budget exhausted");
+    expect(supervisor.reobserveAttached).toHaveBeenCalledTimes(1);
+    expect(supervisor.resolveForRecovery).toHaveBeenCalledTimes(3);
+    expect(budgets).toHaveLength(4);
+    expect(budgets.every((budget) => budget === budgets[0])).toBe(true);
+    expect(delays).toEqual([500, 1_000, 2_000]);
+  });
+
+  it("does not start a successor after the previous child cannot be terminated", async () => {
+    const firstExit = deferred<{ readonly exitCode: number | null }>();
+    const first = connected(45_001, firstExit);
+    first.close.mockRejectedValueOnce(new Error("synthetic termination failure"));
+    const supervisor = {
+      resolveForRecovery: vi.fn(),
+      reobserveAttached: vi.fn(),
+      close: vi.fn(async () => {}),
+    };
+    const runtime = new DesktopDaemonLifecycle(supervisor, first, { delay: async () => {} });
+    runtime.start();
+    firstExit.resolve({ exitCode: 1 });
+    await vi.waitFor(() =>
+      expect(runtime.snapshot()).toEqual({
+        status: "terminal",
+        generation: 1,
+        cause: "termination-failed",
+      }),
+    );
+    expect(supervisor.resolveForRecovery).not.toHaveBeenCalled();
+  });
+
+  it("cancels pending credential replay and never publishes its successor", async () => {
+    const firstExit = deferred<{ readonly exitCode: number | null }>();
+    const first = connected(45_001, firstExit);
+    const successor = connected(45_002, deferred<{ readonly exitCode: number | null }>());
+    const replay = deferred<void>();
+    const replayStarted = vi.fn();
+    const supervisor = {
+      resolveForRecovery: vi.fn(async (budget: { remainingAttempts: number }) => {
+        budget.remainingAttempts -= 1;
+        return successor;
+      }),
+      reobserveAttached: vi.fn(),
+      close: vi.fn(async () => {}),
+    };
+    const onReady = vi.fn();
+    const runtime = new DesktopDaemonLifecycle(supervisor, first, {
+      delay: async () => {},
+      prepareReady: async () => {
+        replayStarted();
+        await replay.promise;
+      },
+      onReady,
+    });
+    runtime.start();
+    firstExit.resolve({ exitCode: 1 });
+    await vi.waitFor(() => expect(replayStarted).toHaveBeenCalledTimes(1));
+    await runtime.close();
+    replay.resolve();
+    await vi.waitFor(() => expect(successor.close).toHaveBeenCalledTimes(1));
+    expect(onReady).not.toHaveBeenCalled();
   });
 });

--- a/packages/coach/src/enduragent.ts
+++ b/packages/coach/src/enduragent.ts
@@ -147,7 +147,20 @@ export type ServiceRegistrationClass = "absent" | "registered" | "unknown";
 export interface AppSupervisedChildHandle {
   readonly pid: number;
   readonly exited: Promise<{ readonly exitCode: number | null }>;
+  isAlive(): boolean;
   stop(): Promise<void>;
+}
+
+export interface DesktopDaemonStartBudget {
+  remainingAttempts: number;
+  readonly deadline: number;
+}
+
+export class AppSupervisedDaemonStartError extends Error {
+  constructor(readonly cause: "spawn-failed" | "termination-failed") {
+    super(`app-supervised daemon ${cause}`);
+    this.name = "AppSupervisedDaemonStartError";
+  }
 }
 
 export interface StartAppSupervisedDaemonInput {
@@ -1024,6 +1037,8 @@ export interface ResolveDesktopDaemonInput {
   readonly startAppSupervisedDaemon: (
     input: StartAppSupervisedDaemonInput,
   ) => Promise<AppSupervisedChildHandle>;
+  readonly startBudget?: DesktopDaemonStartBudget;
+  readonly observationOnly?: boolean;
 }
 
 export type DesktopDaemonDependencies = Required<
@@ -1045,14 +1060,37 @@ export type DesktopDaemonResolution =
       readonly url: `ws://127.0.0.1:${number}/rpc`;
       readonly token: string;
       readonly owner: DaemonOwner;
-      readonly supervision: "attached" | "app-supervised";
+      readonly supervision: "attached";
+      close(): Promise<void>;
+    }
+  | {
+      readonly status: "connected";
+      readonly url: `ws://127.0.0.1:${number}/rpc`;
+      readonly token: string;
+      readonly owner: DaemonOwner;
+      readonly supervision: "app-supervised";
+      readonly exited: Promise<{ readonly exitCode: number | null }>;
+      isAlive(): boolean;
       close(): Promise<void>;
     }
   | {
       readonly status: "refused";
       readonly exitCode: 3 | 5;
-      readonly classification: "contention-family" | "version-mismatch";
+      readonly classification: "contention-family" | "version-mismatch" | "never-published";
+      readonly cause:
+        | "contention"
+        | "version-mismatch"
+        | "never-published"
+        | "unavailable"
+        | "cancelled"
+        | "termination-failed"
+        | "restart-exhausted";
+      readonly retryable: boolean;
     };
+
+const DESKTOP_DAEMON_PUBLICATION_WAIT_MS = 30_000;
+const DESKTOP_EPHEMERAL_START_ATTEMPTS = 3;
+const DESKTOP_EPHEMERAL_START_DEADLINE_MS = 90_000;
 
 const desktopDaemonDependencies: DesktopDaemonDependencies = {
   resolveAthleteHome: defaultDependencies.resolveAthleteHome,
@@ -1064,18 +1102,43 @@ const desktopDaemonDependencies: DesktopDaemonDependencies = {
   monotonicNow: defaultDependencies.monotonicNow!,
 };
 
-function refusedDesktop(exitCode: 3 | 5): DesktopDaemonResolution {
+function refusedDesktop(
+  exitCode: 3 | 5,
+  cause: Extract<DesktopDaemonResolution, { status: "refused" }>["cause"] = exitCode ===
+  EXIT_VERSION_MISMATCH
+    ? "version-mismatch"
+    : "contention",
+): DesktopDaemonResolution {
+  const classification =
+    cause === "version-mismatch"
+      ? "version-mismatch"
+      : cause === "never-published"
+        ? "never-published"
+        : "contention-family";
   return {
     status: "refused",
     exitCode,
-    classification: exitCode === EXIT_VERSION_MISMATCH ? "version-mismatch" : "contention-family",
+    classification,
+    cause,
+    retryable: cause !== "version-mismatch" && cause !== "termination-failed",
   };
 }
 
-async function stopAppChild(child: AppSupervisedChildHandle | undefined): Promise<void> {
-  if (child === undefined) return;
-  await child.stop().catch(() => {});
-  await child.exited.catch(() => ({ exitCode: null }));
+async function stopAppChild(child: AppSupervisedChildHandle | undefined): Promise<boolean> {
+  if (child === undefined) return true;
+  try {
+    await child.stop();
+    await child.exited;
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+class AppChildTerminationError extends Error {}
+
+async function requireStoppedAppChild(child: AppSupervisedChildHandle | undefined): Promise<void> {
+  if (!(await stopAppChild(child))) throw new AppChildTerminationError();
 }
 
 function connectedDesktop(
@@ -1085,42 +1148,117 @@ function connectedDesktop(
   child?: AppSupervisedChildHandle,
 ): DesktopDaemonResolution {
   let closePromise: Promise<void> | undefined;
-  return {
-    status: "connected",
-    url: `ws://127.0.0.1:${port}/rpc`,
-    token,
-    owner,
-    supervision: child === undefined ? "attached" : "app-supervised",
-    close() {
-      closePromise ??= stopAppChild(child);
-      return closePromise;
-    },
+  const close = (): Promise<void> => {
+    closePromise ??= stopAppChild(child).then((stopped) => {
+      if (!stopped) throw new Error("app-supervised daemon termination failed");
+    });
+    return closePromise;
   };
+  return child === undefined
+    ? {
+        status: "connected",
+        url: `ws://127.0.0.1:${port}/rpc`,
+        token,
+        owner,
+        supervision: "attached",
+        close,
+      }
+    : {
+        status: "connected",
+        url: `ws://127.0.0.1:${port}/rpc`,
+        token,
+        owner,
+        supervision: "app-supervised",
+        exited: child.exited,
+        isAlive: child.isAlive,
+        close,
+      };
 }
+
+type DesktopPublicationOutcome =
+  | { readonly kind: "published"; readonly observation: DaemonStateObservation }
+  | { readonly kind: "child-exited" }
+  | { readonly kind: "cancelled" }
+  | { readonly kind: "deadline"; readonly observation: DaemonStateObservation };
 
 async function waitForDesktopDaemon(input: {
   readonly home: AthleteHome;
   readonly signal: AbortSignal;
   readonly dependencies: DesktopDaemonDependencies;
-}): Promise<DaemonStateObservation | undefined> {
+  readonly deadline: number;
+  readonly child?: AppSupervisedChildHandle;
+}): Promise<DesktopPublicationOutcome> {
   const startedAt = input.dependencies.monotonicNow();
+  const publicationDeadline = Math.min(
+    input.deadline,
+    startedAt + DESKTOP_DAEMON_PUBLICATION_WAIT_MS,
+  );
+  let abortListener: (() => void) | undefined;
+  const cancelled = new Promise<DesktopPublicationOutcome>((resolve) => {
+    if (input.signal.aborted) {
+      resolve({ kind: "cancelled" });
+      return;
+    }
+    abortListener = () => resolve({ kind: "cancelled" });
+    input.signal.addEventListener("abort", abortListener, { once: true });
+  });
+  const childExited = input.child?.exited.then<DesktopPublicationOutcome>(() => ({
+    kind: "child-exited",
+  }));
   let nextDelayMs = 50;
-  while (!input.signal.aborted) {
-    let observation: DaemonStateObservation;
-    try {
-      observation = await input.dependencies.observeDaemonState({ home: input.home });
-    } catch {
-      observation = { kind: "auth-invalid" };
+  let lastObservation: DaemonStateObservation = { kind: "absent" };
+  try {
+    while (!input.signal.aborted) {
+      const remainingBeforeObservation = publicationDeadline - input.dependencies.monotonicNow();
+      if (remainingBeforeObservation <= 0) {
+        return { kind: "deadline", observation: lastObservation };
+      }
+      let timeout: ReturnType<typeof setTimeout> | undefined;
+      const deadline = new Promise<DesktopPublicationOutcome>((resolve) => {
+        timeout = setTimeout(
+          () => resolve({ kind: "deadline", observation: lastObservation }),
+          remainingBeforeObservation,
+        );
+      });
+      const observationAttempt = input.dependencies
+        .observeDaemonState({ home: input.home })
+        .then<DesktopPublicationOutcome>((observation) => ({ kind: "published", observation }))
+        .catch<DesktopPublicationOutcome>(() => ({
+          kind: "published",
+          observation: { kind: "auth-invalid" },
+        }));
+      const outcome = await Promise.race(
+        [observationAttempt, childExited, cancelled, deadline].filter(
+          (value): value is Promise<DesktopPublicationOutcome> => value !== undefined,
+        ),
+      );
+      if (timeout !== undefined) clearTimeout(timeout);
+      if (outcome.kind !== "published") return outcome;
+      lastObservation = outcome.observation;
+      if (lastObservation.kind !== "absent" && lastObservation.kind !== "bound-unresponsive") {
+        return outcome;
+      }
+      const remainingMs = publicationDeadline - input.dependencies.monotonicNow();
+      if (remainingMs <= 0) return { kind: "deadline", observation: lastObservation };
+      const waitOutcome = await Promise.race(
+        [
+          childExited,
+          cancelled,
+          input.dependencies
+            .delay(Math.min(nextDelayMs, remainingMs))
+            .then<DesktopPublicationOutcome>(() => ({
+              kind: "published",
+              observation: lastObservation,
+            })),
+        ].filter((value): value is Promise<DesktopPublicationOutcome> => value !== undefined),
+      );
+      if (waitOutcome.kind !== "published") return waitOutcome;
+      nextDelayMs = Math.min(nextDelayMs * 2, 200);
     }
-    if (observation.kind !== "absent" && observation.kind !== "bound-unresponsive") {
-      return observation;
-    }
-    const elapsed = input.dependencies.monotonicNow() - startedAt;
-    if (elapsed >= 5_000) return observation;
-    await input.dependencies.delay(Math.min(nextDelayMs, 5_000 - elapsed));
-    nextDelayMs = Math.min(nextDelayMs * 2, 200);
+    return { kind: "cancelled" };
+  } finally {
+    if (abortListener !== undefined) input.signal.removeEventListener("abort", abortListener);
   }
-  return undefined;
 }
 
 function createDesktopSecondStarterBinding(input: {
@@ -1142,7 +1280,7 @@ function createDesktopSecondStarterBinding(input: {
   let taken = false;
   let retirePromise: Promise<void> | undefined;
   const retirePreviousChild = (): Promise<void> => {
-    retirePromise ??= stopAppChild(input.previousChild);
+    retirePromise ??= requireStoppedAppChild(input.previousChild);
     return retirePromise;
   };
   const serviceUpgrade = createServiceUpgradePort(input.home, {
@@ -1199,15 +1337,43 @@ export async function resolveDesktopDaemon(
     });
     registration = serviceStatus.kind;
   } catch {
-    return refusedDesktop(EXIT_DAEMON_UNAVAILABLE);
+    return refusedDesktop(
+      EXIT_DAEMON_UNAVAILABLE,
+      input.signal.aborted ? "cancelled" : "unavailable",
+    );
   }
   let observation: DaemonStateObservation;
   try {
     observation = await dependencies.observeDaemonState({ home });
   } catch {
-    return refusedDesktop(EXIT_DAEMON_UNAVAILABLE);
+    return refusedDesktop(
+      EXIT_DAEMON_UNAVAILABLE,
+      input.signal.aborted ? "cancelled" : "unavailable",
+    );
+  }
+  if (input.observationOnly) {
+    if (observation.kind === "compatible-healthy") {
+      return connectedDesktop(
+        observation.authenticated.coordinates.port,
+        observation.authenticated.coordinates.token,
+        observation.authenticated.handshake.owner,
+      );
+    }
+    if (observation.kind === "version-mismatch") {
+      return refusedDesktop(EXIT_VERSION_MISMATCH, "version-mismatch");
+    }
+    return refusedDesktop(EXIT_DAEMON_UNAVAILABLE, "unavailable");
   }
   let ownedChild: AppSupervisedChildHandle | undefined;
+  const startBudget =
+    input.startBudget ??
+    ({
+      remainingAttempts: DESKTOP_EPHEMERAL_START_ATTEMPTS,
+      deadline: dependencies.monotonicNow() + DESKTOP_EPHEMERAL_START_DEADLINE_MS,
+    } satisfies DesktopDaemonStartBudget);
+  const startsThisResolutionLimit =
+    input.startBudget === undefined ? DESKTOP_EPHEMERAL_START_ATTEMPTS : 1;
+  let startsThisResolution = 0;
 
   while (!input.signal.aborted) {
     if (observation.kind === "compatible-healthy") {
@@ -1220,8 +1386,10 @@ export async function resolveDesktopDaemon(
     }
     if (observation.kind === "version-mismatch") {
       if (observation.failure.direction === "client-older") {
-        await stopAppChild(ownedChild);
-        return refusedDesktop(EXIT_VERSION_MISMATCH);
+        if (!(await stopAppChild(ownedChild))) {
+          return refusedDesktop(EXIT_DAEMON_UNAVAILABLE, "termination-failed");
+        }
+        return refusedDesktop(EXIT_VERSION_MISMATCH, "version-mismatch");
       }
       const binding = createDesktopSecondStarterBinding({
         home,
@@ -1244,18 +1412,32 @@ export async function resolveDesktopDaemon(
           },
           binding.dependencies,
         );
-      } catch {
+      } catch (error) {
         const startedChild = binding.takeStartedAppChild();
-        await stopAppChild(startedChild);
-        await stopAppChild(ownedChild);
-        return refusedDesktop(EXIT_DAEMON_UNAVAILABLE);
+        const stoppedStarted = await stopAppChild(startedChild);
+        const stoppedOwned = await stopAppChild(ownedChild);
+        return refusedDesktop(
+          EXIT_DAEMON_UNAVAILABLE,
+          error instanceof AppChildTerminationError ||
+            (error instanceof AppSupervisedDaemonStartError &&
+              error.cause === "termination-failed") ||
+            !stoppedStarted ||
+            !stoppedOwned
+            ? "termination-failed"
+            : "unavailable",
+        );
       }
       const startedChild = binding.takeStartedAppChild();
       if (startedChild !== undefined) {
-        await stopAppChild(ownedChild);
+        if (!(await stopAppChild(ownedChild))) {
+          await stopAppChild(startedChild);
+          return refusedDesktop(EXIT_DAEMON_UNAVAILABLE, "termination-failed");
+        }
         ownedChild = startedChild;
       } else if (ownedChild !== undefined) {
-        await stopAppChild(ownedChild);
+        if (!(await stopAppChild(ownedChild))) {
+          return refusedDesktop(EXIT_DAEMON_UNAVAILABLE, "termination-failed");
+        }
         ownedChild = undefined;
       }
       if (starter.status === "attach") {
@@ -1270,50 +1452,114 @@ export async function resolveDesktopDaemon(
         try {
           observation = await dependencies.observeDaemonState({ home });
         } catch {
-          await stopAppChild(ownedChild);
-          return refusedDesktop(EXIT_DAEMON_UNAVAILABLE);
+          const stopped = await stopAppChild(ownedChild);
+          return refusedDesktop(
+            EXIT_DAEMON_UNAVAILABLE,
+            stopped ? "unavailable" : "termination-failed",
+          );
         }
         continue;
       }
-      await stopAppChild(ownedChild);
+      if (!(await stopAppChild(ownedChild))) {
+        return refusedDesktop(EXIT_DAEMON_UNAVAILABLE, "termination-failed");
+      }
       ownedChild = undefined;
-      if (starter.status === "refuse") return refusedDesktop(starter.exitCode);
-      return refusedDesktop(EXIT_DAEMON_UNAVAILABLE);
+      if (starter.status === "refuse") {
+        return refusedDesktop(
+          starter.exitCode,
+          starter.exitCode === EXIT_VERSION_MISMATCH ? "version-mismatch" : "contention",
+        );
+      }
+      return refusedDesktop(EXIT_DAEMON_UNAVAILABLE, "unavailable");
     }
 
     const decision = decideServiceAwareAutoStart({ registration, peer: observation.kind });
     if (decision === "resume-service-then-attach") {
+      if (dependencies.monotonicNow() >= startBudget.deadline) {
+        return refusedDesktop(EXIT_DAEMON_UNAVAILABLE, "unavailable");
+      }
       let resumed: "resumed" | "not-installed";
       try {
         resumed = await dependencies.resumeService({ home, executablePath: input.executablePath });
       } catch {
-        return refusedDesktop(EXIT_DAEMON_UNAVAILABLE);
+        return refusedDesktop(EXIT_DAEMON_UNAVAILABLE, "unavailable");
       }
-      if (resumed !== "resumed") return refusedDesktop(EXIT_DAEMON_UNAVAILABLE);
-      const published = await waitForDesktopDaemon({ home, signal: input.signal, dependencies });
-      if (published === undefined) return refusedDesktop(EXIT_DAEMON_UNAVAILABLE);
-      observation = published;
+      if (resumed !== "resumed") return refusedDesktop(EXIT_DAEMON_UNAVAILABLE, "unavailable");
+      const published = await waitForDesktopDaemon({
+        home,
+        signal: input.signal,
+        dependencies,
+        deadline: startBudget.deadline,
+      });
+      if (published.kind === "cancelled") {
+        return refusedDesktop(EXIT_DAEMON_UNAVAILABLE, "cancelled");
+      }
+      if (published.kind !== "published") {
+        return refusedDesktop(EXIT_DAEMON_UNAVAILABLE, "unavailable");
+      }
+      observation = published.observation;
       continue;
     }
     if (decision === "spawn-ephemeral") {
+      if (
+        startBudget.remainingAttempts <= 0 ||
+        startsThisResolution >= startsThisResolutionLimit ||
+        dependencies.monotonicNow() >= startBudget.deadline
+      ) {
+        if (!(await stopAppChild(ownedChild))) {
+          return refusedDesktop(EXIT_DAEMON_UNAVAILABLE, "termination-failed");
+        }
+        ownedChild = undefined;
+        return refusedDesktop(EXIT_DAEMON_UNAVAILABLE, "never-published");
+      }
+      if (!(await stopAppChild(ownedChild))) {
+        return refusedDesktop(EXIT_DAEMON_UNAVAILABLE, "termination-failed");
+      }
+      ownedChild = undefined;
+      startBudget.remainingAttempts -= 1;
+      startsThisResolution += 1;
       try {
         ownedChild = await input.startAppSupervisedDaemon({ home });
-      } catch {
-        return refusedDesktop(EXIT_DAEMON_UNAVAILABLE);
+      } catch (error) {
+        return refusedDesktop(
+          EXIT_DAEMON_UNAVAILABLE,
+          error instanceof AppSupervisedDaemonStartError && error.cause === "termination-failed"
+            ? "termination-failed"
+            : "never-published",
+        );
       }
-      const published = await waitForDesktopDaemon({ home, signal: input.signal, dependencies });
-      if (published === undefined) {
-        await stopAppChild(ownedChild);
-        return refusedDesktop(EXIT_DAEMON_UNAVAILABLE);
+      const published = await waitForDesktopDaemon({
+        home,
+        signal: input.signal,
+        dependencies,
+        deadline: startBudget.deadline,
+        child: ownedChild,
+      });
+      if (published.kind === "published") {
+        observation = published.observation;
+        continue;
       }
-      observation = published;
+      const stopped = await stopAppChild(ownedChild);
+      ownedChild = undefined;
+      if (!stopped) return refusedDesktop(EXIT_DAEMON_UNAVAILABLE, "termination-failed");
+      if (published.kind === "cancelled") {
+        return refusedDesktop(EXIT_DAEMON_UNAVAILABLE, "cancelled");
+      }
+      observation = published.kind === "deadline" ? published.observation : { kind: "absent" };
       continue;
     }
-    await stopAppChild(ownedChild);
-    return refusedDesktop(EXIT_DAEMON_UNAVAILABLE);
+    if (!(await stopAppChild(ownedChild))) {
+      return refusedDesktop(EXIT_DAEMON_UNAVAILABLE, "termination-failed");
+    }
+    return refusedDesktop(
+      EXIT_DAEMON_UNAVAILABLE,
+      observation.kind === "foreign" ? "contention" : "unavailable",
+    );
   }
-  await stopAppChild(ownedChild);
-  return refusedDesktop(EXIT_DAEMON_UNAVAILABLE);
+  if (!(await stopAppChild(ownedChild))) {
+    return refusedDesktop(EXIT_DAEMON_UNAVAILABLE, "termination-failed");
+  }
+  return refusedDesktop(EXIT_DAEMON_UNAVAILABLE, "cancelled");
 }
 
 async function prepareVerb(

--- a/packages/coach/tests/desktop-supervisor.test.ts
+++ b/packages/coach/tests/desktop-supervisor.test.ts
@@ -7,6 +7,7 @@ import {
 import type { AthleteHome } from "@enduragent/kernel-node/home";
 import type { LaunchdServiceStatus } from "@enduragent/kernel-node/service";
 import {
+  AppSupervisedDaemonStartError,
   resolveDesktopDaemon,
   type AppSupervisedChildHandle,
   type DaemonStateObservation,
@@ -104,8 +105,17 @@ function dependencies(input: {
 }
 
 function child(): AppSupervisedChildHandle & { readonly stop: ReturnType<typeof vi.fn> } {
-  const stop = vi.fn(async () => {});
-  return { pid: 90, exited: Promise.resolve({ exitCode: 0 }), stop };
+  let alive = true;
+  let resolveExit!: (value: { readonly exitCode: number | null }) => void;
+  const exited = new Promise<{ readonly exitCode: number | null }>((resolve) => {
+    resolveExit = resolve;
+  });
+  const stop = vi.fn(async () => {
+    if (!alive) return;
+    alive = false;
+    resolveExit({ exitCode: 0 });
+  });
+  return { pid: 90, exited, isAlive: () => alive, stop };
 }
 
 describe("desktop daemon arbitration", () => {
@@ -177,14 +187,11 @@ describe("desktop daemon arbitration", () => {
     expect(owned.stop).toHaveBeenCalledTimes(1);
   });
 
-  it.each([
-    ["registered auth failure", "registered", { kind: "auth-invalid" }, 3],
-    ["registered foreign peer", "registered", { kind: "foreign" }, 3],
-    ["registered bound peer", "registered", { kind: "bound-unresponsive" }, 3],
-    ["unregistered auth failure", "absent", { kind: "auth-invalid" }, 3],
-    ["client-older mismatch", "registered", mismatch("service-managed", "client-older"), 5],
-  ] as const)("refuses %s without spawning", async (_name, registration, observation, exitCode) => {
-    const start = vi.fn();
+  it("refuses a daemon that never publishes after three starts", async () => {
+    const children = Array.from({ length: 3 }, () => child());
+    const start = vi.fn(async () => children[start.mock.calls.length - 1]!);
+    const base = dependencies({ registration: "absent", observations: [{ kind: "absent" }] });
+    const readStatus = vi.fn(base.readServiceStatus);
     const result = await resolveDesktopDaemon(
       {
         env: {},
@@ -193,11 +200,198 @@ describe("desktop daemon arbitration", () => {
         signal: new AbortController().signal,
         startAppSupervisedDaemon: start,
       },
-      dependencies({ registration, observations: [observation] }),
+      { ...base, readServiceStatus: readStatus },
     );
-    expect(result).toMatchObject({ status: "refused", exitCode });
-    expect(start).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      status: "refused",
+      exitCode: 3,
+      classification: "never-published",
+    });
+    expect(start).toHaveBeenCalledTimes(3);
+    expect(readStatus).toHaveBeenCalledTimes(1);
+    expect(children.map(({ stop }) => stop.mock.calls.length)).toEqual([1, 1, 1]);
   });
+
+  it("preserves a utility termination failure as a nonretryable refusal", async () => {
+    const start = vi.fn(async () => {
+      throw new AppSupervisedDaemonStartError("termination-failed");
+    });
+    const result = await resolveDesktopDaemon(
+      {
+        env: {},
+        executablePath: "/Applications/Enduragent",
+        appVersion: "0.1.0",
+        signal: new AbortController().signal,
+        startAppSupervisedDaemon: start,
+      },
+      dependencies({ registration: "absent", observations: [{ kind: "absent" }] }),
+    );
+    expect(result).toMatchObject({
+      status: "refused",
+      cause: "termination-failed",
+      retryable: false,
+    });
+    expect(start).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-observes without spawning or consuming the shared recovery budget", async () => {
+    const budget = { remainingAttempts: 3, deadline: 60_000 };
+    const start = vi.fn();
+    const result = await resolveDesktopDaemon(
+      {
+        env: {},
+        executablePath: "/Applications/Enduragent",
+        appVersion: "0.1.0",
+        signal: new AbortController().signal,
+        startAppSupervisedDaemon: start,
+        startBudget: budget,
+        observationOnly: true,
+      },
+      dependencies({ registration: "absent", observations: [{ kind: "absent" }] }),
+    );
+    expect(result).toMatchObject({ status: "refused", cause: "unavailable", retryable: true });
+    expect(start).not.toHaveBeenCalled();
+    expect(budget.remainingAttempts).toBe(3);
+  });
+
+  it("settles three immediate child exits without waiting for publication deadlines", async () => {
+    const children = Array.from({ length: 3 }, (_, index) => ({
+      pid: 100 + index,
+      exited: Promise.resolve({ exitCode: 1 }),
+      isAlive: () => false,
+      stop: vi.fn(async () => {}),
+    }));
+    const start = vi.fn(async () => children[start.mock.calls.length - 1]!);
+    const deps = dependencies({ registration: "absent", observations: [{ kind: "absent" }] });
+    const delay = vi.spyOn(deps, "delay");
+    const result = await resolveDesktopDaemon(
+      {
+        env: {},
+        executablePath: "/Applications/Enduragent",
+        appVersion: "0.1.0",
+        signal: new AbortController().signal,
+        startAppSupervisedDaemon: start,
+      },
+      deps,
+    );
+    expect(result).toMatchObject({ status: "refused", cause: "never-published" });
+    expect(start).toHaveBeenCalledTimes(3);
+    expect(delay).not.toHaveBeenCalled();
+    expect(children.every(({ stop }) => stop.mock.calls.length === 1)).toBe(true);
+  });
+
+  it("observes every child exit before starting its replacement", async () => {
+    const order: string[] = [];
+    const children = Array.from({ length: 3 }, (_, index) => {
+      const sequence = index + 1;
+      let resolveExit!: (value: { readonly exitCode: number | null }) => void;
+      const exited = new Promise<{ readonly exitCode: number | null }>((resolve) => {
+        resolveExit = resolve;
+      }).then((value) => {
+        order.push(`exit-${sequence}`);
+        return value;
+      });
+      const stop = vi.fn(async () => {
+        order.push(`stop-${sequence}`);
+        resolveExit({ exitCode: 0 });
+      });
+      return { pid: 90 + sequence, exited, isAlive: () => true, stop };
+    });
+    const start = vi.fn(async () => {
+      const sequence = start.mock.calls.length;
+      order.push(`start-${sequence}`);
+      return children[sequence - 1]!;
+    });
+    const result = await resolveDesktopDaemon(
+      {
+        env: {},
+        executablePath: "/Applications/Enduragent",
+        appVersion: "0.1.0",
+        signal: new AbortController().signal,
+        startAppSupervisedDaemon: start,
+      },
+      dependencies({ registration: "absent", observations: [{ kind: "absent" }] }),
+    );
+    expect(result).toMatchObject({ status: "refused", classification: "never-published" });
+    expect(order).toEqual([
+      "start-1",
+      "stop-1",
+      "exit-1",
+      "start-2",
+      "stop-2",
+      "exit-2",
+      "start-3",
+      "stop-3",
+      "exit-3",
+    ]);
+  });
+
+  it("allows a cold first start to publish after twenty-five seconds", async () => {
+    let now = 0;
+    let started = false;
+    const owned = child();
+    const start = vi.fn(async () => {
+      started = true;
+      return owned;
+    });
+    const base = dependencies({ registration: "absent", observations: [{ kind: "absent" }] });
+    const result = await resolveDesktopDaemon(
+      {
+        env: {},
+        executablePath: "/Applications/Enduragent",
+        appVersion: "0.1.0",
+        signal: new AbortController().signal,
+        startAppSupervisedDaemon: start,
+      },
+      {
+        ...base,
+        observeDaemonState: async () =>
+          started && now >= 25_000 ? healthy("app-supervised") : { kind: "absent" },
+        delay: async (ms) => {
+          now += ms;
+        },
+        monotonicNow: () => now,
+      },
+    );
+    expect(result).toMatchObject({ status: "connected", supervision: "app-supervised" });
+    expect(start).toHaveBeenCalledTimes(1);
+    expect(now).toBeGreaterThanOrEqual(25_000);
+    expect(now).toBeLessThan(30_000);
+    if (result.status === "connected") await result.close();
+    expect(owned.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ["registered auth failure", "registered", { kind: "auth-invalid" }, 3, "unavailable", true],
+    ["registered foreign peer", "registered", { kind: "foreign" }, 3, "contention", true],
+    ["registered bound peer", "registered", { kind: "bound-unresponsive" }, 3, "unavailable", true],
+    ["unregistered auth failure", "absent", { kind: "auth-invalid" }, 3, "unavailable", true],
+    [
+      "client-older mismatch",
+      "registered",
+      mismatch("service-managed", "client-older"),
+      5,
+      "version-mismatch",
+      false,
+    ],
+  ] as const)(
+    "refuses %s without spawning",
+    async (_name, registration, observation, exitCode, cause, retryable) => {
+      const start = vi.fn();
+      const result = await resolveDesktopDaemon(
+        {
+          env: {},
+          executablePath: "/Applications/Enduragent",
+          appVersion: "0.1.0",
+          signal: new AbortController().signal,
+          startAppSupervisedDaemon: start,
+        },
+        dependencies({ registration, observations: [observation] }),
+      );
+      expect(result).toMatchObject({ status: "refused", exitCode, cause, retryable });
+      expect(start).not.toHaveBeenCalled();
+    },
+  );
 
   it("fails closed for unknown registration without resume or spawn", async () => {
     const base = dependencies({ registration: "absent", observations: [{ kind: "absent" }] });
@@ -231,7 +425,7 @@ describe("desktop daemon arbitration", () => {
       },
       deps,
     );
-    expect(result).toMatchObject({ status: "refused", exitCode: 3 });
+    expect(result).toMatchObject({ status: "refused", exitCode: 3, cause: "unavailable" });
     expect(resume).not.toHaveBeenCalled();
     expect(start).not.toHaveBeenCalled();
   });
@@ -280,6 +474,44 @@ describe("desktop daemon arbitration", () => {
     expect(start).toHaveBeenCalledTimes(1);
     if (result.status === "connected") await result.close();
     expect(successor.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops client-newer handoff after an unconfirmed utility cleanup", async () => {
+    const successor = child();
+    const start = vi
+      .fn()
+      .mockRejectedValueOnce(new AppSupervisedDaemonStartError("termination-failed"))
+      .mockResolvedValue(successor);
+    const base = dependencies({
+      registration: "absent",
+      observations: [mismatch("app-supervised", "client-newer")],
+    });
+    const resolveSecondStarter = vi.fn(async (_input, binding) => {
+      await binding.serviceUpgrade.startEphemeralSuccessor({
+        home,
+        targetProtocolVersion: PROTOCOL_VERSION,
+        handoffCapability: "h".repeat(43),
+      });
+      throw new Error("unreachable");
+    });
+    const result = await resolveDesktopDaemon(
+      {
+        env: {},
+        executablePath: "/Applications/Enduragent",
+        appVersion: "0.1.0",
+        signal: new AbortController().signal,
+        startAppSupervisedDaemon: start,
+      },
+      { ...base, resolveSecondStarter },
+    );
+    expect(result).toMatchObject({
+      status: "refused",
+      cause: "termination-failed",
+      retryable: false,
+    });
+    expect(resolveSecondStarter).toHaveBeenCalledTimes(1);
+    expect(start).toHaveBeenCalledTimes(1);
+    expect(successor.stop).not.toHaveBeenCalled();
   });
 
   it("prefers registered service handoff for a client-newer app owner", async () => {
@@ -337,7 +569,7 @@ describe("desktop daemon arbitration", () => {
       },
       dependencies({ registration: "absent", observations: [{ kind: "absent" }] }),
     );
-    expect(result).toMatchObject({ status: "refused", exitCode: 3 });
+    expect(result).toMatchObject({ status: "refused", exitCode: 3, cause: "cancelled" });
     expect(owned.stop).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary

- add a generation-aware daemon lifecycle with bounded startup, recovery, and shutdown
- replay credentials only to the active successor and refresh renderer connection coordinates after recovery
- surface actionable lifecycle state without duplicate terminal dialogs while preserving origin and token boundaries

## Verification

- pnpm check
- focused Desktop, renderer, and coach lifecycle suites
- real Desktop security smoke (all seven assertions)
- three independent final reviews: lifecycle races, integration/security, and user-facing recovery behavior