### PR TITLE
feat(desktop): centralize runtime configuration

### DIFF
--- a/.changeset/runtime-config-authority.md
+++ b/.changeset/runtime-config-authority.md
@@ -1,0 +1,7 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Saved credentials no longer reset your chosen model or related settings.
+
+Use one canonical runtime configuration authority for startup, credential replay, and daemon replacement.

--- a/apps/desktop/src/main/chatgpt-auth.ts
+++ b/apps/desktop/src/main/chatgpt-auth.ts
@@ -1,4 +1,3 @@
-import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import {
   loadStoredProfileSnapshot,
@@ -7,11 +6,9 @@ import {
   type CodexCredentials,
   type CodexLoginOptions,
 } from "@enduragent/core";
-import type { ConfigureRuntimeRpcParams } from "@enduragent/coach-contract";
-import { parse as parseYaml } from "yaml";
+import type { ConfigureRuntimeRpcParams, RuntimeConfigSnapshot } from "@enduragent/coach-contract";
 
 export const CHATGPT_PROFILE_NAME = "openai-codex" as const;
-export const CHATGPT_MODEL = "gpt-5.5" as const;
 export const CHATGPT_LOGIN_TIMEOUT_MS = 5 * 60 * 1000;
 
 export type ChatGptLoginRefusalReason =
@@ -45,6 +42,7 @@ interface ChatGptAuthDependencies {
 interface CreateChatGptAuthOptions {
   readonly configDir: string;
   readonly applyRuntimeConfig: (request: ConfigureRuntimeRpcParams) => Promise<void>;
+  readonly getRuntimeConfig: () => Promise<RuntimeConfigSnapshot>;
   readonly openExternal: (url: string) => Promise<void>;
   readonly signal?: AbortSignal;
   readonly timeoutMs?: number;
@@ -103,12 +101,14 @@ export async function writeChatGptProfile(
   });
 }
 
-async function configuredRuntime(configDir: string): Promise<boolean> {
+async function configuredRuntime(
+  getRuntimeConfig: () => Promise<RuntimeConfigSnapshot>,
+): Promise<boolean | undefined> {
   try {
-    const parsed = parseYaml(await readFile(join(configDir, "config.yaml"), "utf8")) as unknown;
-    return isRecord(parsed) && isRecord(parsed.llm) && parsed.llm.provider === CHATGPT_PROFILE_NAME;
+    const llm = (await getRuntimeConfig()).llm;
+    return llm.provider === CHATGPT_PROFILE_NAME && llm.credential_configured;
   } catch {
-    return false;
+    return undefined;
   }
 }
 
@@ -162,7 +162,7 @@ export function createChatGptAuth(options: CreateChatGptAuthOptions): ChatGptAut
     }
     try {
       await options.applyRuntimeConfig({
-        llm: { provider: CHATGPT_PROFILE_NAME, model: CHATGPT_MODEL },
+        llm: { provider: CHATGPT_PROFILE_NAME },
       });
     } catch {
       return { status: "refused", reason: "runtime-unavailable" };
@@ -173,9 +173,10 @@ export function createChatGptAuth(options: CreateChatGptAuthOptions): ChatGptAut
   return {
     async status() {
       const configured = await hasChatGptProfile(options.configDir);
+      const runtimeReady = await configuredRuntime(options.getRuntimeConfig);
       return {
-        state: configured ? "configured" : "absent",
-        runtimeReady: configured && (await configuredRuntime(options.configDir)),
+        state: configured || runtimeReady === true ? "configured" : "absent",
+        runtimeReady: runtimeReady ?? false,
       };
     },
     async login() {

--- a/apps/desktop/src/main/credential-runtime.ts
+++ b/apps/desktop/src/main/credential-runtime.ts
@@ -1,11 +1,9 @@
-import { readFile } from "node:fs/promises";
-import { join } from "node:path";
+import { connectCoachClient, type CoachClient } from "@enduragent/coach-client";
 import {
   type ConfigureRuntimeRpcParams,
   type LlmProvider,
-  LlmProviderSchema,
+  type RuntimeConfigSnapshot,
 } from "@enduragent/coach-contract";
-import { parse as parseYaml } from "yaml";
 import { CHATGPT_PROFILE_NAME } from "./chatgpt-auth.js";
 import type { CredentialRuntimeState, DesktopCredentialSlot } from "./credential-vault.js";
 import { runtimeConfigurationForCredential } from "./onboarding-ipc.js";
@@ -31,32 +29,53 @@ interface CredentialRuntimeApplicationOptions {
   readonly configureRuntime: (request: ConfigureRuntimeRpcParams) => Promise<void>;
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
+export interface RuntimeConfigurationAuthority {
+  configureRuntime(request: ConfigureRuntimeRpcParams): Promise<void>;
+  getRuntimeConfig(): Promise<RuntimeConfigSnapshot>;
 }
 
-export async function readSelectedLlmProvider(
-  configDir: string,
+export function intervalsAthleteIdForOwnership(snapshot: RuntimeConfigSnapshot): string {
+  return snapshot.intervals.athlete_id === "" ? "0" : snapshot.intervals.athlete_id;
+}
+
+export function readSelectedLlmProvider(
+  snapshot: RuntimeConfigSnapshot,
   evidence: LlmProviderSelectionEvidence,
-): Promise<LlmProvider | undefined> {
-  let source: string;
-  try {
-    source = await readFile(join(configDir, "config.yaml"), "utf8");
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
-    throw error;
-  }
-  const parsed = parseYaml(source) as unknown;
-  if (parsed === undefined || parsed === null) return undefined;
-  if (!isRecord(parsed)) throw new TypeError();
-  if (parsed.llm === undefined) return undefined;
-  if (!isRecord(parsed.llm)) throw new TypeError();
-  if (parsed.llm.provider === undefined) return undefined;
-  const provider = LlmProviderSchema.parse(parsed.llm.provider);
+): LlmProvider | undefined {
+  const provider = snapshot.llm.provider;
+  if (snapshot.llm.credential_configured) return provider;
   if (provider === CHATGPT_PROFILE_NAME) {
     return evidence.chatGptProfilePresent ? provider : undefined;
   }
   return evidence.storedCredentialSlots.includes(provider) ? provider : undefined;
+}
+
+export function createConnectionRuntimeAuthority(
+  connection: Readonly<{ url: `ws://127.0.0.1:${number}/rpc`; token: string }>,
+  connect: typeof connectCoachClient = connectCoachClient,
+): RuntimeConfigurationAuthority {
+  const call = async <T>(operation: (client: CoachClient) => Promise<T>): Promise<T> => {
+    const client = await connect({ url: connection.url, token: connection.token });
+    try {
+      return (await operation(client)) as T;
+    } finally {
+      await client.close();
+    }
+  };
+  return {
+    async configureRuntime(request) {
+      const result = await call((client) => client.call("configureRuntime", request));
+      if (
+        (request.llm !== undefined && !result.applied.llm) ||
+        (request.intervals !== undefined && !result.applied.intervals)
+      ) {
+        throw new TypeError();
+      }
+    },
+    getRuntimeConfig() {
+      return call((client) => client.call("getRuntimeConfig", {}));
+    },
+  };
 }
 
 export function createCredentialRuntimeApplication(

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -2,7 +2,6 @@ import { writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { connectCoachClient } from "@enduragent/coach-client";
-import type { ConfigureRuntimeRpcParams } from "@enduragent/coach-contract";
 import { checkIntervalsStoreOwnerAtPath } from "@enduragent/coach/backfill";
 import {
   app,
@@ -18,14 +17,14 @@ import { createChatGptAuth, hasChatGptProfile } from "./chatgpt-auth.js";
 import { installDesktopConnectionIpc } from "./connection-ipc.js";
 import { DESKTOP_LIFECYCLE_CHANNEL, DESKTOP_RENDERER_URL, DESKTOP_SCHEME } from "./constants.js";
 import {
+  createConnectionRuntimeAuthority,
   createCredentialRuntimeApplication,
+  intervalsAthleteIdForOwnership,
   readSelectedLlmProvider,
+  type CredentialRuntimeApplication,
+  type RuntimeConfigurationAuthority,
 } from "./credential-runtime.js";
-import {
-  CREDENTIAL_DIRECTORY_NAME,
-  createCredentialVault,
-  type DesktopCredentialSlot,
-} from "./credential-vault.js";
+import { CREDENTIAL_DIRECTORY_NAME, createCredentialVault } from "./credential-vault.js";
 import {
   DesktopDaemonLifecycle,
   type DesktopDaemonConnection,
@@ -147,6 +146,12 @@ async function runDesktop(): Promise<void> {
     let windowCreation: Promise<BrowserWindow> | undefined;
     const currentWindow = (): BrowserWindow | null =>
       window !== null && !window.isDestroyed() ? window : null;
+    type RuntimeBinding = {
+      readonly authority: RuntimeConfigurationAuthority;
+      readonly credentials: CredentialRuntimeApplication;
+    };
+    let activeRuntimeBinding: RuntimeBinding | undefined;
+    const preparedRuntimeBindings = new Map<number, RuntimeBinding>();
     let reapplyCredentials = async (
       _connection: DesktopDaemonConnection,
       _signal: AbortSignal,
@@ -167,70 +172,72 @@ async function runDesktop(): Promise<void> {
       prepareReady: ({ connection, signal }) => reapplyCredentials(connection, signal),
       onTransition: publishLifecycle,
       onReady({ previous, current }) {
+        const prepared = preparedRuntimeBindings.get(current.generation);
+        if (prepared !== undefined) {
+          activeRuntimeBinding = prepared;
+          preparedRuntimeBindings.delete(current.generation);
+        }
         if (new URL(previous.url).port === new URL(current.url).port) return;
         const visibleWindow = currentWindow();
         if (visibleWindow === null) return;
         visibleWindow.webContents.reload();
       },
     });
-    const applyRuntimeConfigToConnection = async (
-      connection: Pick<DesktopDaemonConnection, "url" | "token">,
-      request: ConfigureRuntimeRpcParams,
-    ): Promise<void> => {
-      const { url, token } = connection;
-      const client = await connectCoachClient({ url, token });
-      try {
-        const result = await client.call("configureRuntime", request);
-        if (
-          (request.llm !== undefined && !result.applied.llm) ||
-          (request.intervals !== undefined && !result.applied.intervals)
-        ) {
-          throw new TypeError();
-        }
-      } finally {
-        await client.close();
-      }
-    };
-    const applyRuntimeConfig = (request: ConfigureRuntimeRpcParams): Promise<void> =>
-      applyRuntimeConfigToConnection(daemonLifecycle!.connection(), request);
     const configDir = join(resolveDesktopAthleteHome(environment), "config");
-    const selectedLlmProvider = async (storedCredentialSlots: readonly DesktopCredentialSlot[]) =>
-      readSelectedLlmProvider(configDir, {
-        chatGptProfilePresent: await hasChatGptProfile(configDir),
-        storedCredentialSlots,
-      });
-    const credentialRuntime = createCredentialRuntimeApplication({
-      configureRuntime: applyRuntimeConfig,
-      selectedLlmProvider,
+    const createRuntimeBinding = (
+      connection: Pick<DesktopDaemonConnection, "url" | "token">,
+    ): RuntimeBinding => {
+      const authority = createConnectionRuntimeAuthority(connection, connectCoachClient);
+      return {
+        authority,
+        credentials: createCredentialRuntimeApplication({
+          configureRuntime: authority.configureRuntime,
+          selectedLlmProvider: async (storedCredentialSlots) =>
+            readSelectedLlmProvider(await authority.getRuntimeConfig(), {
+              chatGptProfilePresent: await hasChatGptProfile(configDir),
+              storedCredentialSlots,
+            }),
+        }),
+      };
+    };
+    activeRuntimeBinding = createRuntimeBinding({
+      url: resolution.url,
+      token: resolution.token,
     });
     const credentialRoot = join(app.getPath("userData"), CREDENTIAL_DIRECTORY_NAME);
     const vault = createCredentialVault({
       root: credentialRoot,
       encryption: safeStorage,
       async applyCredential(slot, value) {
-        await credentialRuntime.applyExplicit(runtimeConfigurationForCredential(slot, value));
+        await activeRuntimeBinding!.credentials.applyExplicit(
+          runtimeConfigurationForCredential(slot, value),
+        );
       },
-      reapplyCredential: credentialRuntime.reapplyStoredCredential,
+      reapplyCredential: (slot, value, storedCredentialSlots) =>
+        activeRuntimeBinding!.credentials.reapplyStoredCredential(
+          slot,
+          value,
+          storedCredentialSlots,
+        ),
     });
     reapplyCredentials = async (connection, signal) => {
       if (signal.aborted) return;
-      const successorRuntime = createCredentialRuntimeApplication({
-        configureRuntime: (request) => applyRuntimeConfigToConnection(connection, request),
-        selectedLlmProvider,
-      });
+      const successor = createRuntimeBinding(connection);
       const successorVault = createCredentialVault({
         root: credentialRoot,
         encryption: safeStorage,
         async applyCredential(slot, value) {
-          await successorRuntime.applyExplicit(runtimeConfigurationForCredential(slot, value));
+          await successor.credentials.applyExplicit(runtimeConfigurationForCredential(slot, value));
         },
-        reapplyCredential: successorRuntime.reapplyStoredCredential,
+        reapplyCredential: successor.credentials.reapplyStoredCredential,
       });
       await successorVault.reapplyConfigured();
+      if (!signal.aborted) preparedRuntimeBindings.set(connection.generation, successor);
     };
     const chatGptAuth = createChatGptAuth({
       configDir,
-      applyRuntimeConfig: credentialRuntime.applyExplicit,
+      applyRuntimeConfig: (request) => activeRuntimeBinding!.credentials.applyExplicit(request),
+      getRuntimeConfig: () => activeRuntimeBinding!.authority.getRuntimeConfig(),
       openExternal: (url) => shell.openExternal(url),
       signal: controller.signal,
     });
@@ -271,17 +278,19 @@ async function runDesktop(): Promise<void> {
             window: created,
             vault,
             chatGptAuth,
-            checkIntervalsCredentialOwner: (value) =>
-              checkIntervalsStoreOwnerAtPath(
+            checkIntervalsCredentialOwner: async (value) => {
+              const snapshot = await activeRuntimeBinding!.authority.getRuntimeConfig();
+              return checkIntervalsStoreOwnerAtPath(
                 join(resolveDesktopAthleteHome(environment), "store", "store.db"),
                 {
                   apiKey: value,
-                  athleteId: "0",
+                  athleteId: intervalsAthleteIdForOwnership(snapshot),
                   historyNewestDate: "1970-01-01",
                   clock: { now: () => Date.now(), monotonicNow: () => performance.now() },
                   signal: controller.signal,
                 },
-              ),
+              );
+            },
             isTrusted: (event) =>
               isTrustedConnectionRequest(event, mainWindow.current() ?? undefined),
           });

--- a/apps/desktop/src/main/onboarding-ipc.ts
+++ b/apps/desktop/src/main/onboarding-ipc.ts
@@ -39,31 +39,16 @@ interface RegisterOnboardingIpcOptions {
 
 const SUPPORTED_EXTENSIONS = new Set([".fit", ".tcx", ".gpx"]);
 
-const DEFAULT_MODEL_BY_SLOT: Readonly<
-  Record<Exclude<DesktopCredentialSlot, "intervals-icu">, string>
-> = {
-  anthropic: "claude-sonnet-4-6",
-  openrouter: "deepseek/deepseek-v4-flash",
-  openai: "gpt-5.5",
-  google: "gemini-3.5-flash",
-  deepseek: "deepseek-v4-flash",
-  qwen: "qwen3.5-plus",
-  minimax: "MiniMax-M2.7",
-  kimi: "kimi-k2.6",
-  zai: "glm-4.7",
-};
-
 export function runtimeConfigurationForCredential(
   slot: DesktopCredentialSlot,
   value: string,
 ): ConfigureRuntimeRpcParams {
   if (slot === "intervals-icu") {
-    return { intervals: { api_key: value, athlete_id: "0" } };
+    return { intervals: { api_key: value } };
   }
   return {
     llm: {
       provider: slot satisfies LlmProvider,
-      model: DEFAULT_MODEL_BY_SLOT[slot],
       api_key: value,
     },
   };

--- a/apps/desktop/tests/chatgpt-auth.test.ts
+++ b/apps/desktop/tests/chatgpt-auth.test.ts
@@ -2,8 +2,9 @@ import { chmod, mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/pr
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { LlmProvider, RuntimeConfigSnapshot } from "@enduragent/coach-contract";
 import {
-  createChatGptAuth,
+  createChatGptAuth as createChatGptAuthSubject,
   hasChatGptProfile,
   writeChatGptProfile,
 } from "../src/main/chatgpt-auth.js";
@@ -23,6 +24,39 @@ function credentials() {
     expires: 4_102_444_800_000,
     accountId: "obviously-fake-account",
   };
+}
+
+function runtimeSnapshot(
+  provider: LlmProvider = "openai-codex",
+  credentialConfigured = provider === "openai-codex",
+): RuntimeConfigSnapshot {
+  return {
+    schemaVersion: 1,
+    llm: {
+      provider,
+      model: "custom-selected-model",
+      credential_configured: credentialConfigured,
+    },
+    intervals: { athlete_id: "custom-athlete" },
+    session: {
+      historyTokenBudgetRatio: 0.3,
+      idleMinutes: 0,
+      dailyResetHour: 4,
+      resetArchiveRetentionDays: 0,
+      timezone: "UTC",
+    },
+  };
+}
+
+function createChatGptAuth(
+  options: Omit<Parameters<typeof createChatGptAuthSubject>[0], "getRuntimeConfig"> & {
+    readonly getRuntimeConfig?: () => Promise<RuntimeConfigSnapshot>;
+  },
+) {
+  return createChatGptAuthSubject({
+    ...options,
+    getRuntimeConfig: options.getRuntimeConfig ?? (async () => runtimeSnapshot()),
+  });
 }
 
 function invalidUtf8ProfilesBytes(): Buffer {
@@ -119,6 +153,7 @@ describe("desktop ChatGPT auth", () => {
       configDir: directory,
       openExternal: async () => {},
       applyRuntimeConfig: async () => {},
+      getRuntimeConfig: async () => runtimeSnapshot("openai-codex", false),
     });
 
     await expect(hasChatGptProfile(directory)).resolves.toBe(false);
@@ -144,6 +179,7 @@ describe("desktop ChatGPT auth", () => {
       configDir: directory,
       openExternal: async () => {},
       applyRuntimeConfig: async () => {},
+      getRuntimeConfig: async () => runtimeSnapshot("openai-codex", false),
     });
 
     await expect(hasChatGptProfile(directory)).resolves.toBe(false);
@@ -276,13 +312,13 @@ describe("desktop ChatGPT auth", () => {
     });
     await expect(auth.login()).resolves.toEqual({ status: "configured", runtimeReady: true });
     expect(applyRuntimeConfig).toHaveBeenCalledWith({
-      llm: { provider: "openai-codex", model: "gpt-5.5" },
+      llm: { provider: "openai-codex" },
     });
     expect(order).toEqual(["browser", "storage", "runtime"]);
     await expect(auth.status()).resolves.toEqual({ state: "configured", runtimeReady: true });
   });
 
-  it("restores configured runtime readiness from the current YAML", async () => {
+  it("restores configured runtime readiness from the daemon snapshot", async () => {
     const directory = await configDir();
     await writeChatGptProfile(directory, credentials());
     await writeFile(
@@ -295,6 +331,34 @@ describe("desktop ChatGPT auth", () => {
       applyRuntimeConfig: async () => {},
     });
     await expect(auth.status()).resolves.toEqual({ state: "configured", runtimeReady: true });
+  });
+
+  it("reports a valid active custom profile from the daemon without a default local profile", async () => {
+    const directory = await configDir();
+    const auth = createChatGptAuth({
+      configDir: directory,
+      openExternal: async () => {},
+      applyRuntimeConfig: async () => {},
+      getRuntimeConfig: async () => runtimeSnapshot("openai-codex", true),
+    });
+
+    await expect(hasChatGptProfile(directory)).resolves.toBe(false);
+    await expect(auth.status()).resolves.toEqual({ state: "configured", runtimeReady: true });
+  });
+
+  it("falls back to local default-profile status when the daemon read is unavailable", async () => {
+    const directory = await configDir();
+    await writeChatGptProfile(directory, credentials());
+    const auth = createChatGptAuth({
+      configDir: directory,
+      openExternal: async () => {},
+      applyRuntimeConfig: async () => {},
+      getRuntimeConfig: async () => {
+        throw new TypeError("synthetic daemon unavailable");
+      },
+    });
+
+    await expect(auth.status()).resolves.toEqual({ state: "configured", runtimeReady: false });
   });
 
   it("refuses concurrent login and maps callback, storage, and runtime failures", async () => {
@@ -370,15 +434,18 @@ describe("desktop ChatGPT auth", () => {
 
   it("reports a saved ChatGPT profile as inactive after an API-key provider is selected", async () => {
     const directory = await configDir();
+    let provider: LlmProvider = "anthropic";
     const auth = createChatGptAuth({
       configDir: directory,
       openExternal: async () => {},
       applyRuntimeConfig: async (request) => {
+        provider = request.llm?.provider ?? provider;
         await writeFile(
           join(directory, "config.yaml"),
           `llm:\n  provider: ${request.llm?.provider}\n  model: ${request.llm?.model}\n`,
         );
       },
+      getRuntimeConfig: async () => runtimeSnapshot(provider),
       dependencies: { loginCodex: async () => credentials() },
     });
     await expect(auth.login()).resolves.toEqual({ status: "configured", runtimeReady: true });
@@ -388,6 +455,7 @@ describe("desktop ChatGPT auth", () => {
       join(directory, "config.yaml"),
       "llm:\n  provider: openrouter\n  model: deepseek/deepseek-v4-flash\n",
     );
+    provider = "openrouter";
 
     await expect(auth.status()).resolves.toEqual({ state: "configured", runtimeReady: false });
   });

--- a/apps/desktop/tests/credential-runtime.test.ts
+++ b/apps/desktop/tests/credential-runtime.test.ts
@@ -2,10 +2,16 @@ import { randomUUID } from "node:crypto";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { ConfigureRuntimeRpcParams, LlmProvider } from "@enduragent/coach-contract";
+import type {
+  ConfigureRuntimeRpcParams,
+  LlmProvider,
+  RuntimeConfigSnapshot,
+} from "@enduragent/coach-contract";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  createConnectionRuntimeAuthority,
   createCredentialRuntimeApplication,
+  intervalsAthleteIdForOwnership,
   readSelectedLlmProvider,
   type CredentialRuntimeApplication,
 } from "../src/main/credential-runtime.js";
@@ -31,6 +37,26 @@ function encryption(): CredentialEncryptionPort {
   };
 }
 
+function runtimeSnapshot(
+  provider: LlmProvider,
+  model = "custom-selected-model",
+  credentialConfigured = false,
+  athleteId = "custom-athlete",
+): RuntimeConfigSnapshot {
+  return {
+    schemaVersion: 1,
+    llm: { provider, model, credential_configured: credentialConfigured },
+    intervals: { athlete_id: athleteId },
+    session: {
+      historyTokenBudgetRatio: 0.3,
+      idleMinutes: 0,
+      dailyResetHour: 4,
+      resetArchiveRetentionDays: 0,
+      timezone: "UTC",
+    },
+  };
+}
+
 afterEach(async () => {
   await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
 });
@@ -38,19 +64,24 @@ afterEach(async () => {
 function fakeDaemon(initialProvider: LlmProvider) {
   let persistedProvider = initialProvider;
   let activeProvider = initialProvider;
+  let persistedModel = "custom-selected-model";
+  let activeModel = persistedModel;
   let intervalsApplications = 0;
   const modelApplications: LlmProvider[] = [];
 
   return {
     launch(): CredentialRuntimeApplication {
       activeProvider = persistedProvider;
+      activeModel = persistedModel;
       return createCredentialRuntimeApplication({
         selectedLlmProvider: async () => persistedProvider,
         async configureRuntime(request: ConfigureRuntimeRpcParams) {
           if (request.llm !== undefined) {
-            activeProvider = request.llm.provider;
-            persistedProvider = request.llm.provider;
-            modelApplications.push(request.llm.provider);
+            activeProvider = request.llm.provider ?? activeProvider;
+            persistedProvider = activeProvider;
+            activeModel = request.llm.model ?? activeModel;
+            persistedModel = activeModel;
+            modelApplications.push(activeProvider);
           }
           if (request.intervals !== undefined) intervalsApplications += 1;
         },
@@ -58,6 +89,7 @@ function fakeDaemon(initialProvider: LlmProvider) {
     },
     activeProvider: () => activeProvider,
     persistedProvider: () => persistedProvider,
+    activeModel: () => activeModel,
     intervalsApplications: () => intervalsApplications,
     modelApplications: () => [...modelApplications],
     clearModelApplications: () => modelApplications.splice(0),
@@ -129,6 +161,35 @@ async function pollCredentialStatuses(vault: CredentialVault): Promise<void> {
 }
 
 describe("desktop credential runtime precedence", () => {
+  it("uses the current-account sentinel only for a blank ownership preflight", () => {
+    expect(intervalsAthleteIdForOwnership(runtimeSnapshot("anthropic", undefined, false, ""))).toBe(
+      "0",
+    );
+    expect(
+      intervalsAthleteIdForOwnership(
+        runtimeSnapshot("anthropic", undefined, false, "selected-athlete"),
+      ),
+    ).toBe("selected-athlete");
+  });
+
+  it("replays an intervals credential as the key-only canonical runtime patch", async () => {
+    const configureRuntime = vi.fn(async () => {});
+    const runtime = createCredentialRuntimeApplication({
+      selectedLlmProvider: async () => undefined,
+      configureRuntime,
+    });
+
+    await expect(
+      runtime.reapplyStoredCredential("intervals-icu", "obviously-fake-intervals-key", [
+        "intervals-icu",
+      ]),
+    ).resolves.toBe("active");
+
+    expect(configureRuntime).toHaveBeenCalledWith({
+      intervals: { api_key: "obviously-fake-intervals-key" },
+    });
+  });
+
   it("self-heals a stored provider after the first-run seed outlives a failed apply", async () => {
     const directory = await mkdtemp(join(tmpdir(), "enduragent-credential-runtime-"));
     roots.push(directory);
@@ -143,18 +204,18 @@ describe("desktop credential runtime precedence", () => {
     let activeProvider: LlmProvider = "anthropic";
     const launchRuntime = (): CredentialRuntimeApplication =>
       createCredentialRuntimeApplication({
-        selectedLlmProvider: (storedCredentialSlots) =>
-          readSelectedLlmProvider(configDir, {
+        selectedLlmProvider: async (storedCredentialSlots) =>
+          readSelectedLlmProvider(runtimeSnapshot(activeProvider), {
             chatGptProfilePresent: false,
             storedCredentialSlots,
           }),
         async configureRuntime(request) {
           if (!runtimeAvailable) throw new TypeError();
           if (request.llm === undefined) return;
-          activeProvider = request.llm.provider;
+          activeProvider = request.llm.provider ?? activeProvider;
           await writeFile(
             join(configDir, "config.yaml"),
-            `llm:\n  provider: ${request.llm.provider}\n  model: ${request.llm.model}\n`,
+            `llm:\n  provider: ${activeProvider}\n  model: custom-selected-model\n`,
           );
         },
       });
@@ -211,8 +272,8 @@ describe("desktop credential runtime precedence", () => {
     );
     const configureRuntime = vi.fn(async () => {});
     const runtime = createCredentialRuntimeApplication({
-      selectedLlmProvider: (storedCredentialSlots) =>
-        readSelectedLlmProvider(configDir, {
+      selectedLlmProvider: async (storedCredentialSlots) =>
+        readSelectedLlmProvider(runtimeSnapshot("openai-codex"), {
           chatGptProfilePresent: true,
           storedCredentialSlots,
         }),
@@ -236,6 +297,51 @@ describe("desktop credential runtime precedence", () => {
     });
   });
 
+  it.each([
+    ["externally configured provider", runtimeSnapshot("google", "external-model", true)],
+    ["custom active ChatGPT profile", runtimeSnapshot("openai-codex", "chat-model", true)],
+  ])(
+    "keeps an unrelated vault key inactive at boot for an authoritative %s",
+    async (_case, snapshot) => {
+      const directory = await mkdtemp(join(tmpdir(), "enduragent-credential-runtime-"));
+      roots.push(directory);
+      const vaultRoot = join(directory, "credentials-v1");
+      const initialVault = createCredentialVault({
+        root: vaultRoot,
+        encryption: encryption(),
+        applyCredential: async () => {},
+      });
+      await expect(
+        initialVault.writeCredential({ slot: "anthropic", value: randomUUID() }),
+      ).resolves.toMatchObject({ status: "configured" });
+      const configureRuntime = vi.fn(async () => {});
+      const runtime = createCredentialRuntimeApplication({
+        selectedLlmProvider: async (storedCredentialSlots) =>
+          readSelectedLlmProvider(snapshot, {
+            chatGptProfilePresent: false,
+            storedCredentialSlots,
+          }),
+        configureRuntime,
+      });
+      const relaunchedVault = createCredentialVault({
+        root: vaultRoot,
+        encryption: encryption(),
+        applyCredential: (slot, value) =>
+          runtime.applyExplicit(runtimeConfigurationForCredential(slot, value)),
+        reapplyCredential: runtime.reapplyStoredCredential,
+      });
+
+      await relaunchedVault.reapplyConfigured();
+
+      expect(configureRuntime).not.toHaveBeenCalled();
+      await expect(relaunchedVault.credentialStatuses()).resolves.toContainEqual({
+        slot: "anthropic",
+        state: "configured",
+        runtimeState: "stored-inactive",
+      });
+    },
+  );
+
   it("requires a profile or stored credential to corroborate the recorded provider", async () => {
     const directory = await mkdtemp(join(tmpdir(), "enduragent-credential-runtime-"));
     roots.push(directory);
@@ -244,35 +350,47 @@ describe("desktop credential runtime precedence", () => {
       "llm:\n  provider: openai-codex\n  model: gpt-5.5\n",
     );
 
-    await expect(
-      readSelectedLlmProvider(directory, {
+    expect(
+      readSelectedLlmProvider(runtimeSnapshot("openai-codex"), {
         chatGptProfilePresent: true,
         storedCredentialSlots: [],
       }),
-    ).resolves.toBe("openai-codex");
-    await expect(
-      readSelectedLlmProvider(directory, {
+    ).toBe("openai-codex");
+    expect(
+      readSelectedLlmProvider(runtimeSnapshot("openai-codex"), {
         chatGptProfilePresent: false,
         storedCredentialSlots: [],
       }),
-    ).resolves.toBeUndefined();
+    ).toBeUndefined();
 
     await writeFile(
       join(directory, "config.yaml"),
       "llm:\n  provider: anthropic\n  model: claude-sonnet-4-6\n",
     );
-    await expect(
-      readSelectedLlmProvider(directory, {
+    expect(
+      readSelectedLlmProvider(runtimeSnapshot("anthropic"), {
         chatGptProfilePresent: false,
         storedCredentialSlots: ["anthropic"],
       }),
-    ).resolves.toBe("anthropic");
-    await expect(
-      readSelectedLlmProvider(directory, {
+    ).toBe("anthropic");
+    expect(
+      readSelectedLlmProvider(runtimeSnapshot("anthropic"), {
         chatGptProfilePresent: false,
         storedCredentialSlots: [],
       }),
-    ).resolves.toBeUndefined();
+    ).toBeUndefined();
+    expect(
+      readSelectedLlmProvider(runtimeSnapshot("google", "external-model", true), {
+        chatGptProfilePresent: false,
+        storedCredentialSlots: ["anthropic"],
+      }),
+    ).toBe("google");
+    expect(
+      readSelectedLlmProvider(runtimeSnapshot("openai-codex", "chat-model", true), {
+        chatGptProfilePresent: false,
+        storedCredentialSlots: ["anthropic"],
+      }),
+    ).toBe("openai-codex");
   });
 
   it("serializes passive replay before a later explicit provider selection", async () => {
@@ -292,7 +410,7 @@ describe("desktop credential runtime precedence", () => {
           replayStarted();
           await replayGate;
         }
-        if (request.llm !== undefined) selectedProvider = request.llm.provider;
+        if (request.llm?.provider !== undefined) selectedProvider = request.llm.provider;
       },
     });
     const replay = runtime.reapplyStoredCredential("anthropic", randomUUID(), ["anthropic"]);
@@ -381,6 +499,7 @@ describe("desktop credential runtime precedence", () => {
     expect(daemon.activeProvider()).toBe("anthropic");
     expect(daemon.persistedProvider()).toBe("anthropic");
     expect(daemon.modelApplications()).toEqual(["anthropic"]);
+    expect(daemon.activeModel()).toBe("custom-selected-model");
   });
 
   it("self-heals an unrecorded explicit selection after runtime application recovers", async () => {
@@ -390,7 +509,7 @@ describe("desktop credential runtime precedence", () => {
       selectedLlmProvider: async () => selectedProvider,
       async configureRuntime(request) {
         if (!runtimeAvailable) throw new TypeError();
-        if (request.llm !== undefined) selectedProvider = request.llm.provider;
+        if (request.llm?.provider !== undefined) selectedProvider = request.llm.provider;
       },
     });
     const slot = "anthropic" as const;
@@ -413,7 +532,7 @@ describe("desktop credential runtime precedence", () => {
       selectedLlmProvider: async () => selectedProvider,
       async configureRuntime(request) {
         if (!runtimeAvailable) throw new TypeError();
-        if (request.llm !== undefined) selectedProvider = request.llm.provider;
+        if (request.llm?.provider !== undefined) selectedProvider = request.llm.provider;
       },
     });
     const slot = "anthropic" as const;
@@ -465,4 +584,87 @@ describe("desktop credential runtime precedence", () => {
     expect(daemon.persistedProvider()).toBe("openrouter");
     expect(daemon.modelApplications()).toEqual(["openrouter"]);
   });
+
+  it("binds successor reads and credential replay to the supplied connection", async () => {
+    const calls: string[] = [];
+    const connect = vi.fn(async (_options: { readonly url: string; readonly token: string }) => ({
+      handshake: {} as never,
+      async call(method: string) {
+        calls.push(method);
+        if (method === "getRuntimeConfig") return runtimeSnapshot("anthropic");
+        return { schemaVersion: 1, applied: { llm: true, intervals: false } };
+      },
+      async close() {},
+    }));
+    const successor = createConnectionRuntimeAuthority(
+      {
+        url: "ws://127.0.0.1:45002/rpc",
+        token: "obviously-fake-successor-token",
+      },
+      connect as never,
+    );
+
+    await expect(successor.getRuntimeConfig()).resolves.toEqual(runtimeSnapshot("anthropic"));
+    await successor.configureRuntime({
+      llm: { provider: "anthropic", api_key: "obviously-fake-successor-key" },
+    });
+
+    expect(connect).toHaveBeenCalledTimes(2);
+    expect(connect).toHaveBeenNthCalledWith(1, {
+      url: "ws://127.0.0.1:45002/rpc",
+      token: "obviously-fake-successor-token",
+    });
+    expect(connect).toHaveBeenNthCalledWith(2, {
+      url: "ws://127.0.0.1:45002/rpc",
+      token: "obviously-fake-successor-token",
+    });
+    expect(calls).toEqual(["getRuntimeConfig", "configureRuntime"]);
+  });
+
+  it.each([
+    ["externally configured provider", runtimeSnapshot("google", "external-model", true)],
+    ["custom active ChatGPT profile", runtimeSnapshot("openai-codex", "chat-model", true)],
+  ])(
+    "binds authoritative %s replay evidence to the successor without LLM reconfiguration",
+    async (_case, snapshot) => {
+      const calls: string[] = [];
+      const connect = vi.fn(async () => ({
+        handshake: {} as never,
+        async call(method: string) {
+          calls.push(method);
+          if (method === "getRuntimeConfig") return snapshot;
+          return { schemaVersion: 1, applied: { llm: true, intervals: false } };
+        },
+        async close() {},
+      }));
+      const successor = createConnectionRuntimeAuthority(
+        {
+          url: "ws://127.0.0.1:45003/rpc",
+          token: "obviously-fake-successor-token",
+        },
+        connect as never,
+      );
+      const configureRuntime = vi.fn(successor.configureRuntime);
+      const runtime = createCredentialRuntimeApplication({
+        selectedLlmProvider: async (storedCredentialSlots) =>
+          readSelectedLlmProvider(await successor.getRuntimeConfig(), {
+            chatGptProfilePresent: false,
+            storedCredentialSlots,
+          }),
+        configureRuntime,
+      });
+
+      await expect(
+        runtime.reapplyStoredCredential("anthropic", randomUUID(), ["anthropic"]),
+      ).resolves.toBe("stored-inactive");
+
+      expect(configureRuntime).not.toHaveBeenCalled();
+      expect(calls).toEqual(["getRuntimeConfig"]);
+      expect(connect).toHaveBeenCalledOnce();
+      expect(connect).toHaveBeenCalledWith({
+        url: "ws://127.0.0.1:45003/rpc",
+        token: "obviously-fake-successor-token",
+      });
+    },
+  );
 });

--- a/apps/desktop/tests/helpers/desktop-fixture.ts
+++ b/apps/desktop/tests/helpers/desktop-fixture.ts
@@ -312,6 +312,11 @@ export async function launchDesktopFixture(input: {
         ReturnType<CoachOperations["configureRuntime"]>
       >;
     },
+    async getRuntimeConfig(request) {
+      return finalFrame(await invoke("getRuntimeConfig", request)) as Awaited<
+        ReturnType<CoachOperations["getRuntimeConfig"]>
+      >;
+    },
     async getUnitsPreference(request) {
       return finalFrame(await invoke("getUnitsPreference", request)) as {
         value: "metric" | "imperial";

--- a/apps/desktop/tests/onboarding-ipc.test.ts
+++ b/apps/desktop/tests/onboarding-ipc.test.ts
@@ -90,6 +90,7 @@ describe("desktop onboarding IPC", () => {
       status: "refused",
       reason: "training-account-mismatch",
     });
+    expect(subject.checkIntervalsCredentialOwner).toHaveBeenCalledWith("synthetic");
     expect(subject.vault.writeCredential).not.toHaveBeenCalled();
   });
 
@@ -132,17 +133,16 @@ describe("desktop onboarding IPC", () => {
 
   it("maps each credential slot to the landed runtime request", () => {
     expect(runtimeConfigurationForCredential("anthropic", "synthetic")).toEqual({
-      llm: { provider: "anthropic", model: "claude-sonnet-4-6", api_key: "synthetic" },
+      llm: { provider: "anthropic", api_key: "synthetic" },
     });
     expect(runtimeConfigurationForCredential("openrouter", "synthetic")).toEqual({
       llm: {
         provider: "openrouter",
-        model: "deepseek/deepseek-v4-flash",
         api_key: "synthetic",
       },
     });
     expect(runtimeConfigurationForCredential("intervals-icu", "synthetic")).toEqual({
-      intervals: { api_key: "synthetic", athlete_id: "0" },
+      intervals: { api_key: "synthetic" },
     });
   });
 

--- a/packages/coach-client/tests/client.test.ts
+++ b/packages/coach-client/tests/client.test.ts
@@ -441,6 +441,37 @@ describe("handshake failures", () => {
 });
 
 describe("RPC receive and observers", () => {
+  it("rejects a runtime snapshot without the strict credential evidence boolean", async () => {
+    const { socket, connecting } = acceptedSocket();
+    const client = await connecting;
+    socket.closeSynchronously = true;
+    socket.sendHook = (text) => {
+      const request = JSON.parse(text) as { readonly id: number };
+      socket.emitMessage(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: request.id,
+          result: {
+            schemaVersion: 1,
+            llm: { provider: "anthropic", model: "synthetic-model" },
+            intervals: { athlete_id: "" },
+            session: {
+              historyTokenBudgetRatio: 0.3,
+              idleMinutes: 0,
+              dailyResetHour: 4,
+              resetArchiveRetentionDays: 0,
+              timezone: "UTC",
+            },
+          },
+        }),
+      );
+    };
+
+    await expect(client.call("getRuntimeConfig", {})).rejects.toBeInstanceOf(
+      CoachClientProtocolError,
+    );
+  });
+
   it("rejects a contradictory spend response before typed delivery", async () => {
     const { socket, connecting } = acceptedSocket();
     const client = await connecting;
@@ -518,6 +549,22 @@ describe("RPC receive and observers", () => {
         },
         saveIntake: { schemaVersion: 1, saved: true },
         configureRuntime: { schemaVersion: 1, applied: { llm: true, intervals: false } },
+        getRuntimeConfig: {
+          schemaVersion: 1,
+          llm: {
+            provider: "anthropic",
+            model: "synthetic-model",
+            credential_configured: true,
+          },
+          intervals: { athlete_id: "synthetic-athlete" },
+          session: {
+            historyTokenBudgetRatio: 0.3,
+            idleMinutes: 0,
+            dailyResetHour: 4,
+            resetArchiveRetentionDays: 0,
+            timezone: "UTC",
+          },
+        },
         getUnitsPreference: { value: "metric", source: "default" },
         setUnitsPreference: { value: "imperial", source: "cycling" },
         getSpendSummary: {
@@ -596,7 +643,12 @@ describe("RPC receive and observers", () => {
         llm: { provider: "anthropic", model: "synthetic", api_key: "synthetic" },
       }),
     ).resolves.toEqual({ schemaVersion: 1, applied: { llm: true, intervals: false } });
-    expect(received.map((value) => (value as { id: number }).id)).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
+    await expect(client.call("getRuntimeConfig", {})).resolves.toMatchObject({
+      llm: { provider: "anthropic", model: "synthetic-model" },
+    });
+    expect(received.map((value) => (value as { id: number }).id)).toEqual([
+      1, 2, 3, 4, 5, 6, 7, 8, 9,
+    ]);
     expect(received.map((value) => (value as { method: string }).method)).toEqual([
       "chat",
       "resetSession",
@@ -606,6 +658,7 @@ describe("RPC receive and observers", () => {
       "sync",
       "saveIntake",
       "configureRuntime",
+      "getRuntimeConfig",
     ]);
     await expect(client.call("getUnitsPreference", {})).resolves.toEqual({
       value: "metric",
@@ -615,7 +668,7 @@ describe("RPC receive and observers", () => {
       value: "imperial",
       source: "cycling",
     });
-    expect(received.slice(-2).map((value) => (value as { id: number }).id)).toEqual([9, 10]);
+    expect(received.slice(-2).map((value) => (value as { id: number }).id)).toEqual([10, 11]);
     expect(received.slice(-2).map((value) => (value as { method: string }).method)).toEqual([
       "getUnitsPreference",
       "setUnitsPreference",
@@ -626,7 +679,7 @@ describe("RPC receive and observers", () => {
     await expect(client.call("setDailySpendCap", { dailyCapUsd: 0.75 })).resolves.toMatchObject({
       dailyCapUsd: 0.75,
     });
-    expect(received.slice(-2).map((value) => (value as { id: number }).id)).toEqual([11, 12]);
+    expect(received.slice(-2).map((value) => (value as { id: number }).id)).toEqual([12, 13]);
     expect(received.slice(-2).map((value) => (value as { method: string }).method)).toEqual([
       "getSpendSummary",
       "setDailySpendCap",

--- a/packages/coach-contract/src/rpc.ts
+++ b/packages/coach-contract/src/rpc.ts
@@ -121,6 +121,7 @@ export const COACH_RPC_METHOD_NAMES = [
   "sync",
   "saveIntake",
   "configureRuntime",
+  "getRuntimeConfig",
   "getUnitsPreference",
   "setUnitsPreference",
   "getSpendSummary",
@@ -270,28 +271,38 @@ export const LlmProviderSchema = z.enum([
 ]);
 export type LlmProvider = z.infer<typeof LlmProviderSchema>;
 
+const RuntimeOptionalStringSchema = z.string().min(1).max(512).nullable();
+
 const RuntimeLlmSchema = z
   .object({
-    provider: LlmProviderSchema,
-    model: z.string().min(1).max(512),
+    provider: LlmProviderSchema.optional(),
+    model: z.string().min(1).max(512).optional(),
     api_key: z.string().min(1).max(16_384).optional(),
+    base_url: z.string().min(1).max(4_096).nullable().optional(),
+    flush_model: RuntimeOptionalStringSchema.optional(),
+    compact_model: RuntimeOptionalStringSchema.optional(),
   })
   .strict()
   .superRefine((value, context) => {
     if (value.provider === "openai-codex" && value.api_key !== undefined) {
       context.addIssue({ code: "custom", path: ["api_key"], message: "api_key must be absent" });
     }
-    if (value.provider !== "openai-codex" && value.api_key === undefined) {
-      context.addIssue({ code: "custom", path: ["api_key"], message: "api_key is required" });
+    if (Object.keys(value).length === 0) {
+      context.addIssue({ code: "custom", message: "llm patch must not be empty" });
     }
   });
 
 const RuntimeIntervalsSchema = z
   .object({
-    api_key: z.string().min(1).max(16_384),
-    athlete_id: z.string().min(1).max(512),
+    api_key: z.string().min(1).max(16_384).optional(),
+    athlete_id: z.string().min(1).max(512).optional(),
   })
-  .strict();
+  .strict()
+  .superRefine((value, context) => {
+    if (Object.keys(value).length === 0) {
+      context.addIssue({ code: "custom", message: "intervals patch must not be empty" });
+    }
+  });
 
 export const ConfigureRuntimeRpcParamsSchema = z
   .object({
@@ -318,6 +329,39 @@ export const ConfigureRuntimeRpcResultSchema = z
   })
   .strict();
 export type ConfigureRuntimeRpcResult = z.infer<typeof ConfigureRuntimeRpcResultSchema>;
+
+export const RuntimeConfigSnapshotSchema = z
+  .object({
+    schemaVersion: z.literal(1),
+    llm: z
+      .object({
+        provider: LlmProviderSchema,
+        model: z.string().min(1).max(512),
+        credential_configured: z.boolean(),
+      })
+      .strict(),
+    intervals: z
+      .object({
+        athlete_id: z.string().max(512),
+      })
+      .strict(),
+    session: z
+      .object({
+        historyTokenBudgetRatio: z.number().finite(),
+        idleMinutes: z.number().int(),
+        dailyResetHour: z.number().int(),
+        resetArchiveRetentionDays: z.number().int(),
+        timezone: z.string().max(512),
+      })
+      .strict(),
+  })
+  .strict();
+export type RuntimeConfigSnapshot = z.infer<typeof RuntimeConfigSnapshotSchema>;
+
+export const GetRuntimeConfigRpcParamsSchema = EmptyRpcParamsSchema;
+export type GetRuntimeConfigRpcParams = z.infer<typeof GetRuntimeConfigRpcParamsSchema>;
+export const GetRuntimeConfigRpcResultSchema = RuntimeConfigSnapshotSchema;
+export type GetRuntimeConfigRpcResult = z.infer<typeof GetRuntimeConfigRpcResultSchema>;
 
 export const UnitsPreferenceSchema = z.enum(["metric", "imperial"]);
 export type UnitsPreference = z.infer<typeof UnitsPreferenceSchema>;
@@ -380,6 +424,7 @@ export interface CoachOperations {
   ): Promise<SyncRpcResult>;
   saveIntake(request: SaveIntakeRpcParams): Promise<SaveIntakeRpcResult>;
   configureRuntime(request: ConfigureRuntimeRpcParams): Promise<ConfigureRuntimeRpcResult>;
+  getRuntimeConfig(request: GetRuntimeConfigRpcParams): Promise<GetRuntimeConfigRpcResult>;
   getUnitsPreference?(request: GetUnitsPreferenceRpcParams): Promise<GetUnitsPreferenceRpcResult>;
   setUnitsPreference?(request: SetUnitsPreferenceRpcParams): Promise<SetUnitsPreferenceRpcResult>;
 }
@@ -456,6 +501,14 @@ export const CoachRpcRequestEnvelopeSchema = z.discriminatedUnion("method", [
       id: JsonRpcIdSchema,
       method: z.literal("configureRuntime"),
       params: ConfigureRuntimeRpcParamsSchema,
+    })
+    .strict(),
+  z
+    .object({
+      jsonrpc: z.literal("2.0"),
+      id: JsonRpcIdSchema,
+      method: z.literal("getRuntimeConfig"),
+      params: GetRuntimeConfigRpcParamsSchema,
     })
     .strict(),
   z
@@ -629,6 +682,12 @@ export const COACH_RPC_METHOD_REGISTRY = {
     wireName: "configureRuntime",
     requestSchema: ConfigureRuntimeRpcParamsSchema,
     responseSchema: ConfigureRuntimeRpcResultSchema,
+    eventSchema: NoRpcEventSchema,
+  },
+  getRuntimeConfig: {
+    wireName: "getRuntimeConfig",
+    requestSchema: GetRuntimeConfigRpcParamsSchema,
+    responseSchema: GetRuntimeConfigRpcResultSchema,
     eventSchema: NoRpcEventSchema,
   },
   getUnitsPreference: {

--- a/packages/coach-contract/src/version.ts
+++ b/packages/coach-contract/src/version.ts
@@ -1,1 +1,1 @@
-export const PROTOCOL_VERSION = 5;
+export const PROTOCOL_VERSION = 6;

--- a/packages/coach-contract/tests/contract.test.ts
+++ b/packages/coach-contract/tests/contract.test.ts
@@ -84,8 +84,8 @@ describe("exit codes", () => {
 });
 
 describe("protocol version", () => {
-  it("is 5", () => {
-    expect(PROTOCOL_VERSION).toBe(5);
+  it("is 6", () => {
+    expect(PROTOCOL_VERSION).toBe(6);
   });
 });
 

--- a/packages/coach-contract/tests/wire-contract.test.ts
+++ b/packages/coach-contract/tests/wire-contract.test.ts
@@ -17,6 +17,8 @@ import {
   EmptyRpcParamsSchema,
   ConfigureRuntimeRpcParamsSchema,
   ConfigureRuntimeRpcResultSchema,
+  GetRuntimeConfigRpcParamsSchema,
+  GetRuntimeConfigRpcResultSchema,
   GetUnitsPreferenceRpcParamsSchema,
   GetUnitsPreferenceRpcResultSchema,
   ImportFilesRpcParamsSchema,
@@ -183,7 +185,7 @@ const spendSummary = SpendSummarySchema.parse({
 });
 
 describe("coach request and event projection", () => {
-  it("admits exactly the thirteen strict method requests", () => {
+  it("admits exactly the fourteen strict method requests", () => {
     const requests = [
       { jsonrpc: "2.0", id: 1, method: "chat", params: { chatId: "chat-1", message: "hello" } },
       { jsonrpc: "2.0", id: 2, method: "resetSession", params: { chatId: "chat-1" } },
@@ -208,23 +210,24 @@ describe("coach request and event projection", () => {
         jsonrpc: "2.0",
         id: 8,
         method: "configureRuntime",
-        params: { llm: { provider: "anthropic", model: "model", api_key: "placeholder" } },
+        params: { llm: { provider: "anthropic", api_key: "placeholder" } },
       },
-      { jsonrpc: "2.0", id: 9, method: "getUnitsPreference", params: {} },
+      { jsonrpc: "2.0", id: 9, method: "getRuntimeConfig", params: {} },
+      { jsonrpc: "2.0", id: 10, method: "getUnitsPreference", params: {} },
       {
         jsonrpc: "2.0",
-        id: 10,
+        id: 11,
         method: "setUnitsPreference",
         params: { value: "imperial" },
       },
-      { jsonrpc: "2.0", id: 11, method: "getSpendSummary", params: {} },
+      { jsonrpc: "2.0", id: 12, method: "getSpendSummary", params: {} },
       {
         jsonrpc: "2.0",
-        id: 12,
+        id: 13,
         method: "setDailySpendCap",
         params: { dailyCapUsd: 0.75 },
       },
-      { jsonrpc: "2.0", id: 13, method: "selfTest", params: {} },
+      { jsonrpc: "2.0", id: 14, method: "selfTest", params: {} },
     ];
     for (const request of requests) {
       expect(CoachRpcRequestEnvelopeSchema.parse(request)).toEqual(request);
@@ -371,31 +374,105 @@ describe("coach request and event projection", () => {
       saved: true,
     });
 
-    const llm = { provider: "openrouter", model: "model-a", api_key: "placeholder" } as const;
-    const codex = { provider: "openai-codex", model: "model-codex" } as const;
-    const intervals = { api_key: "placeholder", athlete_id: "athlete-a" } as const;
-    for (const params of [{ llm }, { llm: codex }, { intervals }, { llm, intervals }]) {
+    const llm = {
+      provider: "openrouter",
+      model: "model-a",
+      api_key: "placeholder",
+      base_url: "https://invalid.example.test/v1",
+      flush_model: "model-flush",
+      compact_model: null,
+    } as const;
+    const codex = { provider: "openai-codex" } as const;
+    const intervals = { api_key: "placeholder" } as const;
+    for (const params of [
+      { llm },
+      { llm: codex },
+      { llm: { model: "model-only" } },
+      { intervals },
+      { intervals: { athlete_id: "athlete-a" } },
+      { llm, intervals },
+    ]) {
       expect(ConfigureRuntimeRpcParamsSchema.parse(params)).toEqual(params);
     }
     for (const invalid of [
       {},
+      { llm: {} },
+      { intervals: {} },
       { llm: { ...llm, extra: true } },
-      { llm: { provider: "openai-codex", model: "model-codex", api_key: "placeholder" } },
-      { intervals: { api_key: "", athlete_id: "athlete-a" } },
+      { llm: { provider: "openai-codex", api_key: "placeholder" } },
+      { intervals: { api_key: "" } },
+      { intervals: { athlete_id: "" } },
       { llm, extra: true },
     ]) {
       expect(ConfigureRuntimeRpcParamsSchema.safeParse(invalid).success).toBe(false);
     }
-    for (const provider of LlmProviderSchema.options.filter(
-      (provider) => provider !== "openai-codex",
-    )) {
-      expect(
-        ConfigureRuntimeRpcParamsSchema.safeParse({ llm: { provider, model: "model-a" } }).success,
-      ).toBe(false);
-    }
     const result = { schemaVersion: 1, applied: { llm: true, intervals: false } } as const;
     expect(ConfigureRuntimeRpcResultSchema.parse(result)).toEqual(result);
+    expect(
+      ConfigureRuntimeRpcResultSchema.safeParse({ ...result, api_key: "placeholder" }).success,
+    ).toBe(false);
     expect(JSON.stringify(result)).not.toContain("placeholder");
+    const snapshot = {
+      schemaVersion: 1,
+      llm: {
+        provider: "openrouter",
+        model: "model-a",
+        credential_configured: true,
+      },
+      intervals: { athlete_id: "athlete-a" },
+      session: {
+        historyTokenBudgetRatio: 0.3,
+        idleMinutes: 0,
+        dailyResetHour: 4,
+        resetArchiveRetentionDays: 0,
+        timezone: "UTC",
+      },
+    } as const;
+    expect(GetRuntimeConfigRpcResultSchema.parse(snapshot)).toEqual(snapshot);
+    expect(
+      GetRuntimeConfigRpcResultSchema.parse({
+        ...snapshot,
+        llm: {
+          provider: "openrouter",
+          model: "model-a",
+          credential_configured: true,
+        },
+        intervals: { athlete_id: "" },
+      }),
+    ).toEqual({
+      ...snapshot,
+      llm: {
+        provider: "openrouter",
+        model: "model-a",
+        credential_configured: true,
+      },
+      intervals: { athlete_id: "" },
+    });
+    for (const malformed of [
+      { ...snapshot, api_key: "placeholder" },
+      { ...snapshot, llm: { ...snapshot.llm, api_key: "placeholder" } },
+      {
+        ...snapshot,
+        llm: {
+          provider: snapshot.llm.provider,
+          model: snapshot.llm.model,
+        },
+      },
+      { ...snapshot, llm: { ...snapshot.llm, credential_configured: "true" } },
+      { ...snapshot, intervals: { ...snapshot.intervals, api_key: "placeholder" } },
+      { ...snapshot, intervals: { athlete_id: "a".repeat(513) } },
+      { ...snapshot, session: { ...snapshot.session, dataDir: "/private" } },
+      { ...snapshot, llm: { provider: "openrouter" } },
+    ]) {
+      expect(GetRuntimeConfigRpcResultSchema.safeParse(malformed).success).toBe(false);
+    }
+    expect(
+      GetRuntimeConfigRpcResultSchema.safeParse({
+        ...snapshot,
+        llm: { ...snapshot.llm, base_url: "https://api.example.invalid/v1" },
+      }).success,
+    ).toBe(false);
+    expect(JSON.stringify(snapshot)).not.toContain("api_key");
     expect(LlmProviderSchema.options).toEqual([
       "anthropic",
       "openai",
@@ -449,6 +526,18 @@ describe("coach request and event projection", () => {
       configureRuntime: async ({ llm, intervals }) => ({
         schemaVersion: 1,
         applied: { llm: llm !== undefined, intervals: intervals !== undefined },
+      }),
+      getRuntimeConfig: async () => ({
+        schemaVersion: 1,
+        llm: { provider: "anthropic", model: "model", credential_configured: false },
+        intervals: { athlete_id: "athlete" },
+        session: {
+          historyTokenBudgetRatio: 0.3,
+          idleMinutes: 0,
+          dailyResetHour: 4,
+          resetArchiveRetentionDays: 0,
+          timezone: "UTC",
+        },
       }),
       getUnitsPreference: async () => ({ value: "metric", source: "default" }),
       setUnitsPreference: async ({ value }) => ({ value, source: "cycling" }),
@@ -511,6 +600,12 @@ describe("coach request and event projection", () => {
       responseSchema: ConfigureRuntimeRpcResultSchema,
       eventSchema: NoRpcEventSchema,
     });
+    expect(COACH_RPC_METHOD_REGISTRY.getRuntimeConfig).toEqual({
+      wireName: "getRuntimeConfig",
+      requestSchema: GetRuntimeConfigRpcParamsSchema,
+      responseSchema: GetRuntimeConfigRpcResultSchema,
+      eventSchema: NoRpcEventSchema,
+    });
     expect(COACH_RPC_METHOD_REGISTRY.getUnitsPreference).toEqual({
       wireName: "getUnitsPreference",
       requestSchema: GetUnitsPreferenceRpcParamsSchema,
@@ -547,6 +642,7 @@ describe("coach request and event projection", () => {
       "getAthleteState",
       "saveIntake",
       "configureRuntime",
+      "getRuntimeConfig",
       "getUnitsPreference",
       "setUnitsPreference",
       "getSpendSummary",
@@ -766,7 +862,7 @@ describe("additive protocol signals", () => {
     expect(AgentErrorKindSchema.safeParse("aborted").success).toBe(false);
   });
 
-  it("uses protocol version five", () => {
-    expect(PROTOCOL_VERSION).toBe(5);
+  it("uses protocol version six", () => {
+    expect(PROTOCOL_VERSION).toBe(6);
   });
 });

--- a/packages/coach/src/composition.ts
+++ b/packages/coach/src/composition.ts
@@ -25,9 +25,11 @@ import {
   loadStoredProfileSnapshot,
   makeChatClient,
   refreshCodexToken,
+  resolveRuntimeConfig,
   resolveSecretRef,
   type Config,
   type ReferenceRuntime,
+  type RuntimeConfigPatch,
   type StoredProfile,
   type StoredProfileSnapshot,
 } from "@enduragent/core";
@@ -48,10 +50,11 @@ import { createAnchorRepository, type AnchorRepository } from "@enduragent/kerne
 import { ErrorStateSchema, LatestJsonSchema } from "@enduragent/kernel/reference/schemas";
 import type { AthleteHome } from "@enduragent/kernel-node/home";
 import type { CoachStoreWriterContext } from "./runtime.js";
-import type {
-  CoachEngine,
-  CoachOperations,
-  ConfigureRuntimeRpcParams,
+import {
+  type CoachEngine,
+  type CoachOperations,
+  type ConfigureRuntimeRpcParams,
+  type GetRuntimeConfigRpcResult,
 } from "@enduragent/coach-contract";
 import { cyclingSport } from "@enduragent/sport-cycling";
 import { createPersistedAthleteStateSource } from "./athlete-state-reader.js";
@@ -105,6 +108,7 @@ export interface LocalCoachCompositionDependencies {
   readonly onToolsAssembled?: (names: readonly string[]) => void;
   readonly closeHostAdapters?: () => void | Promise<void>;
   readonly operationsDependencies?: CoachOperationsDependencies;
+  readonly persistRuntimeConfig?: typeof persistRuntimeConfig;
 }
 
 export interface LocalReferenceRuntime {
@@ -137,49 +141,82 @@ function copyConfig(config: Config): Config {
   };
 }
 
+function runtimePatch(request: ConfigureRuntimeRpcParams): RuntimeConfigPatch {
+  return {
+    ...(request.llm === undefined
+      ? {}
+      : {
+          llm: {
+            provider: request.llm.provider,
+            model: request.llm.model,
+            apiKey: request.llm.api_key,
+            baseUrl: request.llm.base_url,
+            flushModel: request.llm.flush_model,
+            compactModel: request.llm.compact_model,
+          },
+        }),
+    ...(request.intervals === undefined
+      ? {}
+      : {
+          intervals: {
+            apiKey: request.intervals.api_key,
+            athleteId: request.intervals.athlete_id,
+          },
+        }),
+  };
+}
+
 function mergedRuntimeConfig(config: Config, request: ConfigureRuntimeRpcParams): Config {
-  const next = copyConfig(config);
-  if (request.llm !== undefined) {
-    next.llm = {
-      provider: request.llm.provider,
-      model: request.llm.model,
-      apiKey: request.llm.provider === "openai-codex" ? "" : (request.llm.api_key ?? ""),
-      authProfile: request.llm.provider === "openai-codex" ? "openai-codex" : undefined,
-    };
-  }
-  if (request.intervals !== undefined) {
-    next.intervals = {
-      apiKey: request.intervals.api_key,
-      athleteId: request.intervals.athlete_id,
-    };
-  }
-  return next;
+  return { ...config, ...resolveRuntimeConfig(runtimePatch(request), config) };
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function persistRuntimeConfig(configDir: string, request: ConfigureRuntimeRpcParams): void {
+function assignOptionalField(
+  target: Record<string, unknown>,
+  field: string,
+  value: string | undefined,
+): void {
+  if (value === undefined) delete target[field];
+  else target[field] = value;
+}
+
+function persistRuntimeConfig(
+  configDir: string,
+  candidate: Config,
+  request: ConfigureRuntimeRpcParams,
+  previous: Config,
+): void {
   const path = join(configDir, "config.yaml");
   const parsed = existsSync(path) ? (parseYaml(readFileSync(path, "utf8")) as unknown) : {};
   if (!isRecord(parsed)) throw new TypeError("Runtime config must be a map.");
   const next = { ...parsed };
   if (request.llm !== undefined) {
-    const existing = isRecord(parsed.llm) ? parsed.llm : {};
+    const existing =
+      candidate.llm.provider === previous.llm.provider &&
+      isRecord(parsed.llm) &&
+      (parsed.llm.provider === undefined || parsed.llm.provider === candidate.llm.provider)
+        ? parsed.llm
+        : {};
     const llm: Record<string, unknown> = {
-      ...(existing.provider === request.llm.provider ? existing : {}),
-      provider: request.llm.provider,
-      model: request.llm.model,
+      ...existing,
+      provider: candidate.llm.provider,
+      model: candidate.llm.model,
     };
-    if (request.llm.provider === "openai-codex") llm.auth_profile = "openai-codex";
-    else delete llm.auth_profile;
+    if (candidate.llm.provider === "openai-codex") {
+      llm.auth_profile = candidate.llm.authProfile ?? "openai-codex";
+    } else delete llm.auth_profile;
+    assignOptionalField(llm, "base_url", candidate.llm.baseUrl);
+    assignOptionalField(llm, "flush_model", candidate.llm.flushModel);
+    assignOptionalField(llm, "compact_model", candidate.llm.compactModel);
     next.llm = llm;
   }
   if (request.intervals !== undefined) {
     next.intervals = {
       ...(isRecord(parsed.intervals) ? parsed.intervals : {}),
-      athlete_id: request.intervals.athlete_id,
+      athlete_id: candidate.intervals.athleteId,
     };
   }
   const temporaryPath = `${path}.tmp.${randomBytes(4).toString("hex")}`;
@@ -193,6 +230,34 @@ function persistRuntimeConfig(configDir: string, request: ConfigureRuntimeRpcPar
     } catch {}
     throw error;
   }
+}
+
+function runtimeCredentialConfigured(configDir: string, config: Config): boolean {
+  if (config.llm.provider !== "openai-codex") return config.llm.apiKey.length > 0;
+  try {
+    const snapshot = loadStoredProfileSnapshot(
+      join(configDir, "auth-profiles.json"),
+      config.llm.authProfile ?? "openai-codex",
+    );
+    if (snapshot === null) return false;
+    credential(snapshot.profile);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function runtimeConfigSnapshot(configDir: string, config: Config): GetRuntimeConfigRpcResult {
+  return {
+    schemaVersion: 1,
+    llm: {
+      provider: config.llm.provider,
+      model: config.llm.model,
+      credential_configured: runtimeCredentialConfigured(configDir, config),
+    },
+    intervals: { athlete_id: config.intervals.athleteId },
+    session: { ...config.session },
+  };
 }
 
 function createReconfigurableEngine(initial: CoachEngine): {
@@ -512,18 +577,19 @@ export async function createLocalCoachComposition(
       });
     };
     const reconfigurable = createReconfigurableEngine(buildEngine(activeConfig));
+    const persistConfig = dependencies.persistRuntimeConfig ?? persistRuntimeConfig;
     const applyRuntimeConfig = async (request: ConfigureRuntimeRpcParams): Promise<void> => {
       const candidate = mergedRuntimeConfig(activeConfig, request);
-      if (request.llm?.provider === "openai-codex") {
+      if (request.llm !== undefined && candidate.llm.provider === "openai-codex") {
         credential(
           loadStoredProfileSnapshot(
             join(input.home.configDir, "auth-profiles.json"),
-            "openai-codex",
+            candidate.llm.authProfile ?? "openai-codex",
           )?.profile,
         );
       }
       const replacement = buildEngine(candidate);
-      persistRuntimeConfig(input.home.configDir, request);
+      persistConfig(input.home.configDir, candidate, request, activeConfig);
       await reconfigurable.replace(() => {
         activeConfig = candidate;
         return replacement;
@@ -543,6 +609,7 @@ export async function createLocalCoachComposition(
         intervalsCredentials: options.liveIntervals,
         historyNewestDate: () => new Date(now()).toISOString().slice(0, 10),
         applyRuntimeConfig,
+        readRuntimeConfig: () => runtimeConfigSnapshot(input.home.configDir, activeConfig),
       },
       dependencies.operationsDependencies,
     );

--- a/packages/coach/src/daemon/rpc-server.ts
+++ b/packages/coach/src/daemon/rpc-server.ts
@@ -711,6 +711,16 @@ export function createCoachRpcServer(input: CoachRpcServerInput): CoachRpcServer
               invocationFailure = { error };
             }
             break;
+          case "getRuntimeConfig":
+            try {
+              const request = COACH_RPC_METHOD_REGISTRY.getRuntimeConfig.requestSchema.parse(
+                generic.data.params,
+              );
+              result = await input.operations.getRuntimeConfig(request);
+            } catch (error) {
+              invocationFailure = { error };
+            }
+            break;
           case "getUnitsPreference":
             try {
               const request = COACH_RPC_METHOD_REGISTRY.getUnitsPreference.requestSchema.parse(

--- a/packages/coach/src/operations.ts
+++ b/packages/coach/src/operations.ts
@@ -1,6 +1,8 @@
 import {
   ConfigureRuntimeRpcParamsSchema,
   ConfigureRuntimeRpcResultSchema,
+  GetRuntimeConfigRpcParamsSchema,
+  GetRuntimeConfigRpcResultSchema,
   GetUnitsPreferenceRpcParamsSchema,
   GetUnitsPreferenceRpcResultSchema,
   ImportFilesRpcParamsSchema,
@@ -14,6 +16,8 @@ import {
   SyncRpcResultSchema,
   type ConfigureRuntimeRpcParams,
   type ConfigureRuntimeRpcResult,
+  type GetRuntimeConfigRpcParams,
+  type GetRuntimeConfigRpcResult,
   type GetUnitsPreferenceRpcParams,
   type GetUnitsPreferenceRpcResult,
   type CoachOperations,
@@ -48,6 +52,7 @@ export interface CreateCoachOperationsInput {
   }>;
   readonly historyNewestDate: () => string;
   readonly applyRuntimeConfig: (request: ConfigureRuntimeRpcParams) => Promise<void>;
+  readonly readRuntimeConfig?: () => GetRuntimeConfigRpcResult;
 }
 
 export interface CoachOperationsDependencies {
@@ -182,6 +187,15 @@ export function createCoachOperations(
             intervals: parsedRequest.intervals !== undefined,
           },
         });
+      });
+    },
+    getRuntimeConfig(request: GetRuntimeConfigRpcParams): Promise<GetRuntimeConfigRpcResult> {
+      GetRuntimeConfigRpcParamsSchema.parse(request);
+      return enqueue(async () => {
+        if (input.readRuntimeConfig === undefined) {
+          throw new TypeError("Runtime configuration read is unavailable.");
+        }
+        return GetRuntimeConfigRpcResultSchema.parse(input.readRuntimeConfig());
       });
     },
     getUnitsPreference(request: GetUnitsPreferenceRpcParams): Promise<GetUnitsPreferenceRpcResult> {

--- a/packages/coach/tests/cli-verbs-rpc.test.ts
+++ b/packages/coach/tests/cli-verbs-rpc.test.ts
@@ -49,6 +49,18 @@ const operations: CoachOperations = {
     schemaVersion: 1,
     applied: { llm: llm !== undefined, intervals: intervals !== undefined },
   }),
+  getRuntimeConfig: async () => ({
+    schemaVersion: 1,
+    llm: { provider: "anthropic", model: "synthetic-model", credential_configured: false },
+    intervals: { athlete_id: "synthetic-athlete" },
+    session: {
+      historyTokenBudgetRatio: 0.3,
+      idleMinutes: 0,
+      dailyResetHour: 4,
+      resetArchiveRetentionDays: 0,
+      timezone: "UTC",
+    },
+  }),
 };
 const state: AthleteState = {
   schemaVersion: "3",

--- a/packages/coach/tests/composition.test.ts
+++ b/packages/coach/tests/composition.test.ts
@@ -247,8 +247,9 @@ async function compose(
   dependencies: LocalCoachCompositionDependencies,
   context = fakeContext(home),
   intervals?: Config["intervals"],
+  configOverride?: Config,
 ) {
-  const coreConfig = config(home, intervals);
+  const coreConfig = configOverride ?? config(home, intervals);
   return createLocalCoachComposition(
     {
       env: { ENDURAGENT_HOME: home.root },
@@ -1090,7 +1091,382 @@ describe("local coach composition", () => {
     await lifecycle.close();
   });
 
-  it("merges same-provider and intervals persistence without replacing retained fields", async () => {
+  it("activates the default Codex profile for an explicit same-provider selection", async () => {
+    const home = await freshHome();
+    await writeFile(
+      join(home.configDir, "auth-profiles.json"),
+      JSON.stringify({
+        "test-profile": {
+          type: "oauth",
+          access: "obviously-fake-custom-access",
+          refresh: "obviously-fake-custom-refresh",
+          expires: 4_102_444_800_000,
+        },
+        "openai-codex": {
+          type: "oauth",
+          access: "obviously-fake-default-access",
+          refresh: "obviously-fake-default-refresh",
+          expires: 4_102_444_800_000,
+        },
+      }),
+      { mode: 0o600 },
+    );
+    await writeFile(
+      join(home.configDir, "config.yaml"),
+      toYaml({
+        llm: {
+          provider: "openai-codex",
+          model: "custom-chat-model",
+          auth_profile: "test-profile",
+        },
+      }),
+      { mode: 0o600 },
+    );
+    const initial: Config = {
+      ...config(home),
+      llm: {
+        provider: "openai-codex",
+        model: "custom-chat-model",
+        apiKey: "",
+        authProfile: "test-profile",
+        compactModel: "custom-chat-model",
+      },
+    };
+    expect(loadConfig(home.configDir).llm).toMatchObject({
+      provider: "openai-codex",
+      model: "custom-chat-model",
+      authProfile: "test-profile",
+    });
+    const received: CreateCoachEngineInput[] = [];
+    const lifecycle = await compose(
+      home,
+      {
+        bootstrap: async () => reference(),
+        createRuntime: () => runtime(),
+        createBackend: (input) => {
+          received.push(input);
+          return backend();
+        },
+        createRepository: () => ({
+          insertIfAbsent: async () => false,
+          readCurrent: async () => undefined,
+        }),
+        createResolver: () => missingResolver(),
+      },
+      fakeContext(home),
+      undefined,
+      initial,
+    );
+    expect(received[0]?.ports.config.llm.authProfile).toBe("test-profile");
+    await expect(received[0]?.ports.getAccessToken("test-profile")).resolves.toBe(
+      "obviously-fake-custom-access",
+    );
+
+    await lifecycle.operations.configureRuntime({ llm: { provider: "openai-codex" } });
+
+    expect(loadConfig(home.configDir).llm).toMatchObject({
+      provider: "openai-codex",
+      model: "custom-chat-model",
+      authProfile: "openai-codex",
+      compactModel: "custom-chat-model",
+    });
+    expect(received).toHaveLength(2);
+    expect(received.at(-1)?.ports.config.llm.authProfile).toBe("openai-codex");
+    await expect(received.at(-1)?.ports.getAccessToken("openai-codex")).resolves.toBe(
+      "obviously-fake-default-access",
+    );
+    expect(parseYaml(await readFile(join(home.configDir, "config.yaml"), "utf8"))).toMatchObject({
+      llm: { auth_profile: "openai-codex" },
+    });
+    const snapshot = await lifecycle.operations.getRuntimeConfig({});
+    expect(snapshot.llm).toEqual({
+      provider: "openai-codex",
+      model: "custom-chat-model",
+      credential_configured: true,
+    });
+    expect(JSON.stringify(snapshot)).not.toContain("test-profile");
+    expect(JSON.stringify(snapshot)).not.toContain(home.configDir);
+    expect(JSON.stringify(snapshot)).not.toContain("obviously-fake-default-access");
+    await rm(join(home.configDir, "auth-profiles.json"));
+    await expect(lifecycle.operations.getRuntimeConfig({})).resolves.toMatchObject({
+      llm: { provider: "openai-codex", credential_configured: false },
+    });
+    await lifecycle.close();
+  });
+
+  it("preserves a custom Codex profile when a live LLM patch omits provider", async () => {
+    const home = await freshHome();
+    await writeFile(
+      join(home.configDir, "auth-profiles.json"),
+      JSON.stringify({
+        "test-profile": {
+          type: "oauth",
+          access: "obviously-fake-custom-access",
+          refresh: "obviously-fake-custom-refresh",
+          expires: 4_102_444_800_000,
+        },
+      }),
+      { mode: 0o600 },
+    );
+    await writeFile(
+      join(home.configDir, "config.yaml"),
+      toYaml({
+        llm: {
+          provider: "openai-codex",
+          model: "custom-chat-model",
+          auth_profile: "test-profile",
+        },
+      }),
+      { mode: 0o600 },
+    );
+    const initial: Config = {
+      ...config(home),
+      llm: {
+        provider: "openai-codex",
+        model: "custom-chat-model",
+        apiKey: "",
+        authProfile: "test-profile",
+        compactModel: "custom-chat-model",
+      },
+    };
+    const lifecycle = await compose(
+      home,
+      {
+        bootstrap: async () => reference(),
+        createRuntime: () => runtime(),
+        createBackend: () => backend(),
+        createRepository: () => ({
+          insertIfAbsent: async () => false,
+          readCurrent: async () => undefined,
+        }),
+        createResolver: () => missingResolver(),
+      },
+      fakeContext(home),
+      undefined,
+      initial,
+    );
+
+    await lifecycle.operations.configureRuntime({ llm: { model: "new-chat-model" } });
+
+    expect(loadConfig(home.configDir).llm).toMatchObject({
+      provider: "openai-codex",
+      model: "new-chat-model",
+      authProfile: "test-profile",
+      compactModel: "new-chat-model",
+    });
+    const snapshot = await lifecycle.operations.getRuntimeConfig({});
+    expect(snapshot.llm).toEqual({
+      provider: "openai-codex",
+      model: "new-chat-model",
+      credential_configured: true,
+    });
+    expect(JSON.stringify(snapshot)).not.toContain("test-profile");
+    await lifecycle.close();
+  });
+
+  it("preserves an implicit-provider YAML key across a model-only patch and reload", async () => {
+    const home = await freshHome();
+    await writeFile(
+      join(home.configDir, "config.yaml"),
+      toYaml({
+        data_source: "store",
+        data_dir: home.root,
+        llm: {
+          model: "old-model",
+          api_key: "obviously-fake-implicit-provider-key",
+          retained_llm_field: true,
+        },
+      }),
+      { mode: 0o600 },
+    );
+    const initial = loadConfig(home.configDir);
+    const lifecycle = await compose(
+      home,
+      {
+        bootstrap: async () => reference(),
+        createRuntime: () => runtime(),
+        createBackend: () => backend(),
+        createRepository: () => ({
+          insertIfAbsent: async () => false,
+          readCurrent: async () => undefined,
+        }),
+        createResolver: () => missingResolver(),
+      },
+      fakeContext(home),
+      undefined,
+      initial,
+    );
+
+    await lifecycle.operations.configureRuntime({ llm: { model: "new-model" } });
+
+    expect(parseYaml(await readFile(join(home.configDir, "config.yaml"), "utf8"))).toEqual({
+      data_source: "store",
+      data_dir: home.root,
+      llm: {
+        provider: "anthropic",
+        model: "new-model",
+        api_key: "obviously-fake-implicit-provider-key",
+        compact_model: "claude-haiku-4-5-20251001",
+        retained_llm_field: true,
+      },
+    });
+    expect(loadConfig(home.configDir).llm).toMatchObject({
+      provider: "anthropic",
+      model: "new-model",
+      apiKey: "obviously-fake-implicit-provider-key",
+    });
+    const snapshot = await lifecycle.operations.getRuntimeConfig({});
+    expect(snapshot.llm).toMatchObject({
+      provider: "anthropic",
+      model: "new-model",
+      credential_configured: true,
+    });
+    expect(JSON.stringify(snapshot)).not.toContain("obviously-fake-implicit-provider-key");
+    await lifecycle.close();
+  });
+
+  it("starts and snapshots the Desktop seeded blank athlete ID", async () => {
+    const home = await freshHome();
+    const initial = config(home, { apiKey: "", athleteId: "" });
+    let runtimeOptions:
+      | Parameters<NonNullable<LocalCoachCompositionDependencies["createRuntime"]>>[0]
+      | undefined;
+    const lifecycle = await compose(
+      home,
+      {
+        bootstrap: async () => reference(),
+        createRuntime: (options) => {
+          runtimeOptions = options;
+          return runtime();
+        },
+        createBackend: () => backend(),
+        createRepository: () => ({
+          insertIfAbsent: async () => false,
+          readCurrent: async () => undefined,
+        }),
+        createResolver: () => missingResolver(),
+      },
+      fakeContext(home),
+      undefined,
+      initial,
+    );
+
+    await expect(lifecycle.operations.getRuntimeConfig({})).resolves.toMatchObject({
+      llm: { credential_configured: false },
+      intervals: { athlete_id: "" },
+    });
+    expect(() =>
+      lifecycle.operations.configureRuntime({ intervals: { athlete_id: "" } } as never),
+    ).toThrow("Too small");
+
+    await lifecycle.operations.configureRuntime({
+      intervals: { api_key: "obviously-fake-intervals-key" },
+    });
+
+    expect(runtimeOptions?.readConfig?.().intervals).toEqual({
+      apiKey: "obviously-fake-intervals-key",
+      athleteId: "0",
+    });
+    await expect(lifecycle.operations.getRuntimeConfig({})).resolves.toMatchObject({
+      intervals: { athlete_id: "0" },
+    });
+    expect(parseYaml(await readFile(join(home.configDir, "config.yaml"), "utf8"))).toMatchObject({
+      intervals: { athlete_id: "0" },
+    });
+    expect(loadConfig(home.configDir).intervals.athleteId).toBe("0");
+    await lifecycle.close();
+  });
+
+  it.each([
+    ["ordinary custom endpoint", "https://api.example.invalid/tenant/opaque-access-segment/v1"],
+    ["path-bearing opaque value", "opaque-endpoint/tenant/opaque-access-segment/v1"],
+  ])("omits a configured %s from runtime snapshots", async (_case, baseUrl) => {
+    const home = await freshHome();
+    const initial: Config = {
+      ...config(home),
+      llm: {
+        provider: "anthropic",
+        model: "synthetic",
+        apiKey: "",
+        baseUrl,
+      },
+    };
+    const lifecycle = await compose(
+      home,
+      {
+        bootstrap: async () => reference(),
+        createRuntime: () => runtime(),
+        createBackend: () => backend(),
+        createRepository: () => ({
+          insertIfAbsent: async () => false,
+          readCurrent: async () => undefined,
+        }),
+        createResolver: () => missingResolver(),
+      },
+      fakeContext(home),
+      undefined,
+      initial,
+    );
+
+    const snapshot = await lifecycle.operations.getRuntimeConfig({});
+    expect(snapshot.llm).toEqual({
+      provider: "anthropic",
+      model: "synthetic",
+      credential_configured: false,
+    });
+    expect(JSON.stringify(snapshot)).not.toContain(baseUrl);
+    await lifecycle.close();
+  });
+
+  it.each([
+    ["newline", "https://api.example.invalid/v1\nobviously-fake-marker"],
+    ["tab", "https://api.example.invalid/v1\tobviously-fake-marker"],
+    ["leading whitespace", " https://api.example.invalid/obviously-fake-marker"],
+    ["trailing whitespace", "https://api.example.invalid/obviously-fake-marker "],
+    ["empty query", "https://api.example.invalid/obviously-fake-marker?"],
+    ["empty fragment", "https://api.example.invalid/obviously-fake-marker#"],
+    ["backslashes", "https:\\api.example.invalid\\obviously-fake-marker"],
+    ["host case normalization", "https://API.EXAMPLE.INVALID/obviously-fake-marker"],
+    ["default port normalization", "https://api.example.invalid:443/obviously-fake-marker"],
+    ["userinfo", "https://obviously-fake-marker:synthetic-pass@api.example.invalid/v1"],
+    ["query", "https://api.example.invalid/v1?signature=obviously-fake-marker"],
+    ["fragment", "https://api.example.invalid/v1#obviously-fake-marker"],
+    ["non-HTTP protocol", "ftp://api.example.invalid/obviously-fake-marker"],
+    ["invalid", "not-a-url-obviously-fake-marker"],
+  ])("omits a legacy %s base URL from runtime snapshots", async (_case, baseUrl) => {
+    const home = await freshHome();
+    const initial: Config = {
+      ...config(home),
+      llm: { provider: "anthropic", model: "synthetic", apiKey: "", baseUrl },
+    };
+    const lifecycle = await compose(
+      home,
+      {
+        bootstrap: async () => reference(),
+        createRuntime: () => runtime(),
+        createBackend: () => backend(),
+        createRepository: () => ({
+          insertIfAbsent: async () => false,
+          readCurrent: async () => undefined,
+        }),
+        createResolver: () => missingResolver(),
+      },
+      fakeContext(home),
+      undefined,
+      initial,
+    );
+
+    const snapshot = await lifecycle.operations.getRuntimeConfig({});
+    expect(snapshot.llm).toEqual({
+      provider: "anthropic",
+      model: "synthetic",
+      credential_configured: false,
+    });
+    expect(JSON.stringify(snapshot)).not.toContain("obviously-fake-marker");
+    await lifecycle.close();
+  });
+
+  it("preserves custom same-provider settings and the athlete ID for credential-only patches", async () => {
     const home = await freshHome();
     await writeFile(
       join(home.configDir, "config.yaml"),
@@ -1114,24 +1490,54 @@ describe("local coach composition", () => {
       }),
       { mode: 0o600 },
     );
-    const lifecycle = await compose(home, {
-      bootstrap: async () => reference(),
-      createRuntime: () => runtime(),
-      createBackend: () => backend(),
-      createRepository: () => ({
-        insertIfAbsent: async () => false,
-        readCurrent: async () => undefined,
-      }),
-      createResolver: () => missingResolver(),
-    });
+    const received: CreateCoachEngineInput[] = [];
+    const initial: Config = {
+      ...config(home),
+      llm: {
+        provider: "openrouter",
+        model: "previous-model",
+        apiKey: "obviously-fake-active-llm-key",
+        baseUrl: "https://invalid.example.test/v1",
+        flushModel: "previous-flush-model",
+        compactModel: "previous-compact-model",
+      },
+      intervals: {
+        apiKey: "obviously-fake-active-intervals-key",
+        athleteId: "previous-athlete",
+      },
+      contextWindowTokens: 200_000,
+    };
+    let runtimeOptions:
+      | Parameters<NonNullable<LocalCoachCompositionDependencies["createRuntime"]>>[0]
+      | undefined;
+    const lifecycle = await compose(
+      home,
+      {
+        bootstrap: async () => reference(),
+        createRuntime: (options) => {
+          runtimeOptions = options;
+          return runtime();
+        },
+        createBackend: (input) => {
+          received.push(input);
+          return backend();
+        },
+        createRepository: () => ({
+          insertIfAbsent: async () => false,
+          readCurrent: async () => undefined,
+        }),
+        createResolver: () => missingResolver(),
+      },
+      fakeContext(home),
+      undefined,
+      initial,
+    );
     await lifecycle.operations.configureRuntime({
       llm: {
         provider: "openrouter",
-        model: "replacement-model",
         api_key: "obviously-fake-request-llm-key",
       },
       intervals: {
-        athlete_id: "replacement-athlete",
         api_key: "obviously-fake-request-intervals-key",
       },
     });
@@ -1142,7 +1548,7 @@ describe("local coach composition", () => {
       retained_top_level: true,
       llm: {
         provider: "openrouter",
-        model: "replacement-model",
+        model: "previous-model",
         api_key: "obviously-fake-persisted-llm-key",
         base_url: "https://invalid.example.test/v1",
         flush_model: "previous-flush-model",
@@ -1150,7 +1556,7 @@ describe("local coach composition", () => {
         retained_llm_field: true,
       },
       intervals: {
-        athlete_id: "replacement-athlete",
+        athlete_id: "previous-athlete",
         api_key: "obviously-fake-persisted-intervals-key",
         retained_intervals_field: true,
       },
@@ -1159,15 +1565,110 @@ describe("local coach composition", () => {
     expect(loadConfig(home.configDir)).toMatchObject({
       llm: {
         provider: "openrouter",
-        model: "replacement-model",
+        model: "previous-model",
         apiKey: "obviously-fake-persisted-llm-key",
         baseUrl: "https://invalid.example.test/v1",
         flushModel: "previous-flush-model",
         compactModel: "previous-compact-model",
       },
       intervals: {
-        athleteId: "replacement-athlete",
+        athleteId: "previous-athlete",
         apiKey: "obviously-fake-persisted-intervals-key",
+      },
+    });
+    expect(received.at(-1)?.ports.config.llm).toMatchObject({
+      provider: "openrouter",
+      model: "previous-model",
+      apiKey: "obviously-fake-request-llm-key",
+      baseUrl: "https://invalid.example.test/v1",
+      flushModel: "previous-flush-model",
+      compactModel: "previous-compact-model",
+    });
+    expect(runtimeOptions?.readConfig?.()).toMatchObject({
+      llm: {
+        provider: "openrouter",
+        model: "previous-model",
+        baseUrl: "https://invalid.example.test/v1",
+        flushModel: "previous-flush-model",
+        compactModel: "previous-compact-model",
+      },
+      intervals: { athleteId: "previous-athlete" },
+    });
+    await expect(lifecycle.operations.getRuntimeConfig({})).resolves.toEqual({
+      schemaVersion: 1,
+      llm: {
+        provider: "openrouter",
+        model: "previous-model",
+        credential_configured: true,
+      },
+      intervals: { athlete_id: "previous-athlete" },
+      session: initial.session,
+    });
+    await lifecycle.close();
+  });
+
+  it("applies canonical defaults when switching from a one-million to a 200k context", async () => {
+    const home = await freshHome();
+    const received: CreateCoachEngineInput[] = [];
+    const initial: Config = {
+      ...config(home),
+      llm: {
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+        apiKey: "obviously-fake-anthropic-key",
+        baseUrl: "https://invalid.example.test/old",
+        flushModel: "old-flush-model",
+        compactModel: "old-compact-model",
+      },
+      contextWindowTokens: 1_000_000,
+    };
+    const lifecycle = await compose(
+      home,
+      {
+        bootstrap: async () => reference(),
+        createRuntime: () => runtime(),
+        createBackend: (input) => {
+          received.push(input);
+          return backend();
+        },
+        createRepository: () => ({
+          insertIfAbsent: async () => false,
+          readCurrent: async () => undefined,
+        }),
+        createResolver: () => missingResolver(),
+      },
+      fakeContext(home),
+      undefined,
+      initial,
+    );
+
+    await lifecycle.operations.configureRuntime({
+      llm: { provider: "zai", api_key: "obviously-fake-zai-key" },
+    });
+
+    expect(received.at(-1)?.ports.config).toMatchObject({
+      contextWindowTokens: 200_000,
+      llm: {
+        provider: "zai",
+        model: "glm-4.7",
+        apiKey: "obviously-fake-zai-key",
+        baseUrl: "https://api.z.ai/api/openai/v1",
+        flushModel: undefined,
+        compactModel: "glm-4.7",
+      },
+    });
+    expect(parseYaml(await readFile(join(home.configDir, "config.yaml"), "utf8"))).toEqual({
+      llm: {
+        provider: "zai",
+        model: "glm-4.7",
+        base_url: "https://api.z.ai/api/openai/v1",
+        compact_model: "glm-4.7",
+      },
+    });
+    await expect(lifecycle.operations.getRuntimeConfig({})).resolves.toMatchObject({
+      llm: {
+        provider: "zai",
+        model: "glm-4.7",
       },
     });
     await lifecycle.close();
@@ -1226,7 +1727,11 @@ describe("local coach composition", () => {
     ) as Record<string, unknown>;
     expect(persisted).toEqual({
       retained_top_level: true,
-      llm: { provider: "google", model: "replacement-model" },
+      llm: {
+        provider: "google",
+        model: "replacement-model",
+        compact_model: "replacement-model",
+      },
     });
     expect(loadConfig(home.configDir).llm).toMatchObject({
       provider: "google",
@@ -1247,6 +1752,7 @@ describe("local coach composition", () => {
         provider: "openai-codex",
         model: "gpt-5.5",
         auth_profile: "openai-codex",
+        compact_model: "gpt-5.5",
       },
     });
     expect(loadConfig(home.configDir).llm).toMatchObject({
@@ -1290,6 +1796,62 @@ describe("local coach composition", () => {
     });
     await lifecycle.close();
   });
+
+  it.each(["build", "persist"] as const)(
+    "does not publish or overwrite YAML after a failed candidate %s",
+    async (failurePoint) => {
+      const home = await freshHome();
+      const originalYaml = toYaml({
+        retained_top_level: true,
+        llm: { provider: "anthropic", model: "synthetic" },
+      });
+      await writeFile(join(home.configDir, "config.yaml"), originalYaml, { mode: 0o600 });
+      let builds = 0;
+      const lifecycle = await compose(home, {
+        bootstrap: async () => reference(),
+        createRuntime: () => runtime(),
+        createBackend: (input) => {
+          builds += 1;
+          if (failurePoint === "build" && builds === 2) {
+            throw new Error("synthetic candidate build failure");
+          }
+          return backend({
+            chat: async () => ({ text: input.ports.config.llm.model }),
+          });
+        },
+        createRepository: () => ({
+          insertIfAbsent: async () => false,
+          readCurrent: async () => undefined,
+        }),
+        createResolver: () => missingResolver(),
+        ...(failurePoint === "persist"
+          ? {
+              persistRuntimeConfig: () => {
+                throw new Error("synthetic persistence failure");
+              },
+            }
+          : {}),
+      });
+
+      await expect(
+        lifecycle.operations.configureRuntime({
+          llm: { model: "candidate-model", api_key: "obviously-fake-candidate-key" },
+        }),
+      ).rejects.toThrow(
+        failurePoint === "build"
+          ? "synthetic candidate build failure"
+          : "synthetic persistence failure",
+      );
+      await expect(
+        lifecycle.engine.chat({ chatId: "atomic", message: "active model" }),
+      ).resolves.toEqual({ text: "synthetic" });
+      await expect(lifecycle.operations.getRuntimeConfig({})).resolves.toMatchObject({
+        llm: { provider: "anthropic", model: "synthetic" },
+      });
+      expect(await readFile(join(home.configDir, "config.yaml"), "utf8")).toBe(originalYaml);
+      await lifecycle.close();
+    },
+  );
 
   it("passes the live intervals authority and one deterministic UTC history date into sync", async () => {
     const home = await freshHome();

--- a/packages/coach/tests/daemon-handshake.test.ts
+++ b/packages/coach/tests/daemon-handshake.test.ts
@@ -170,6 +170,22 @@ describe.skipIf(!hasLoopback)("production peer observations", () => {
           schemaVersion: 1,
           applied: { llm: llm !== undefined, intervals: intervals !== undefined },
         }),
+        getRuntimeConfig: async () => ({
+          schemaVersion: 1,
+          llm: {
+            provider: "anthropic",
+            model: "synthetic-model",
+            credential_configured: false,
+          },
+          intervals: { athlete_id: "synthetic-athlete" },
+          session: {
+            historyTokenBudgetRatio: 0.3,
+            idleMinutes: 0,
+            dailyResetHour: 4,
+            resetArchiveRetentionDays: 0,
+            timezone: "UTC",
+          },
+        }),
       },
       spend: {
         getSpendSummary: () => Promise.reject(new Error("Spend handler is not used.")),

--- a/packages/coach/tests/daemon-rpc-server.test.ts
+++ b/packages/coach/tests/daemon-rpc-server.test.ts
@@ -77,6 +77,22 @@ const operations: CoachOperations = {
     schemaVersion: 1,
     applied: { llm: llm !== undefined, intervals: intervals !== undefined },
   }),
+  getRuntimeConfig: async () => ({
+    schemaVersion: 1,
+    llm: {
+      provider: "anthropic",
+      model: "synthetic-model",
+      credential_configured: false,
+    },
+    intervals: { athlete_id: "synthetic-athlete" },
+    session: {
+      historyTokenBudgetRatio: 0.3,
+      idleMinutes: 0,
+      dailyResetHour: 4,
+      resetArchiveRetentionDays: 0,
+      timezone: "UTC",
+    },
+  }),
   getUnitsPreference: async () => ({ value: "metric", source: "default" }),
   setUnitsPreference: async ({ value }) => ({ value, source: "cycling" }),
 };
@@ -430,9 +446,26 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
       schemaVersion: 1 as const,
       applied: { llm: llm !== undefined, intervals: intervals !== undefined },
     }));
+    const runtimeSnapshot = {
+      schemaVersion: 1 as const,
+      llm: {
+        provider: "openrouter" as const,
+        model: "model-a",
+        credential_configured: true,
+      },
+      intervals: { athlete_id: "athlete-a" },
+      session: {
+        historyTokenBudgetRatio: 0.3,
+        idleMinutes: 0,
+        dailyResetHour: 4,
+        resetArchiveRetentionDays: 0,
+        timezone: "UTC",
+      },
+    };
+    const getRuntimeConfig = vi.fn(async () => runtimeSnapshot);
     const rpc = createCoachRpcServer({
       engine: engine(),
-      operations: { ...operations, saveIntake, configureRuntime },
+      operations: { ...operations, saveIntake, configureRuntime, getRuntimeConfig },
       token,
       owner: "app-supervised",
     });
@@ -484,6 +517,24 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
     expect(JSON.stringify(response)).not.toContain("placeholder");
     expect(JSON.stringify(response)).not.toContain("athlete-a");
     expect(JSON.stringify(response)).not.toContain("model-a");
+    client.ws.send(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: "runtime-read",
+        method: "getRuntimeConfig",
+        params: {},
+      }),
+    );
+    const snapshotResponse = parseCoachRpcEnvelope(await client.frames.next());
+    expect(snapshotResponse).toEqual({
+      jsonrpc: "2.0",
+      id: "runtime-read",
+      result: runtimeSnapshot,
+    });
+    expect(getRuntimeConfig).toHaveBeenCalledWith({});
+    expect(JSON.stringify(snapshotResponse)).not.toContain("api_key");
+    expect(JSON.stringify(snapshotResponse)).not.toContain("token");
+    expect(JSON.stringify(snapshotResponse)).not.toContain("path");
     await client.close();
   });
 

--- a/packages/coach/tests/daemon/redaction-rpc-cli.test.ts
+++ b/packages/coach/tests/daemon/redaction-rpc-cli.test.ts
@@ -168,6 +168,22 @@ async function startRpc(coachEngine: CoachEngine): Promise<RunningRpc> {
         schemaVersion: 1,
         applied: { llm: llm !== undefined, intervals: intervals !== undefined },
       }),
+      getRuntimeConfig: async () => ({
+        schemaVersion: 1,
+        llm: {
+          provider: "anthropic",
+          model: "synthetic-model",
+          credential_configured: false,
+        },
+        intervals: { athlete_id: "synthetic-athlete" },
+        session: {
+          historyTokenBudgetRatio: 0.3,
+          idleMinutes: 0,
+          dailyResetHour: 4,
+          resetArchiveRetentionDays: 0,
+          timezone: "UTC",
+        },
+      }),
     },
     spend: {
       getSpendSummary: () => Promise.reject(new Error("Spend handler is not used.")),

--- a/packages/coach/tests/enduragent-entry.test.ts
+++ b/packages/coach/tests/enduragent-entry.test.ts
@@ -78,6 +78,18 @@ const operations: CoachOperations = {
     schemaVersion: 1,
     applied: { llm: llm !== undefined, intervals: intervals !== undefined },
   }),
+  getRuntimeConfig: async () => ({
+    schemaVersion: 1,
+    llm: { provider: "anthropic", model: "synthetic-model", credential_configured: false },
+    intervals: { athlete_id: "synthetic-athlete" },
+    session: {
+      historyTokenBudgetRatio: 0.3,
+      idleMinutes: 0,
+      dailyResetHour: 4,
+      resetArchiveRetentionDays: 0,
+      timezone: "UTC",
+    },
+  }),
 };
 
 const spendMeter: SpendMeterService = {

--- a/packages/coach/tests/enduragent-redaction.test.ts
+++ b/packages/coach/tests/enduragent-redaction.test.ts
@@ -161,6 +161,22 @@ describe.skipIf(!hasLoopback)("local CLI redaction boundary", () => {
               schemaVersion: 1,
               applied: { llm: llm !== undefined, intervals: intervals !== undefined },
             }),
+            getRuntimeConfig: async () => ({
+              schemaVersion: 1,
+              llm: {
+                provider: "anthropic",
+                model: "synthetic-model",
+                credential_configured: false,
+              },
+              intervals: { athlete_id: "synthetic-athlete" },
+              session: {
+                historyTokenBudgetRatio: 0.3,
+                idleMinutes: 0,
+                dailyResetHour: 4,
+                resetArchiveRetentionDays: 0,
+                timezone: "UTC",
+              },
+            }),
           },
           spendMeter,
           listener: context.listener,

--- a/packages/coach/tests/local-runner.test.ts
+++ b/packages/coach/tests/local-runner.test.ts
@@ -86,6 +86,18 @@ const operations: CoachOperations = {
     schemaVersion: 1,
     applied: { llm: llm !== undefined, intervals: intervals !== undefined },
   }),
+  getRuntimeConfig: async () => ({
+    schemaVersion: 1,
+    llm: { provider: "anthropic", model: "synthetic-model", credential_configured: false },
+    intervals: { athlete_id: "synthetic-athlete" },
+    session: {
+      historyTokenBudgetRatio: 0.3,
+      idleMinutes: 0,
+      dailyResetHour: 4,
+      resetArchiveRetentionDays: 0,
+      timezone: "UTC",
+    },
+  }),
 };
 
 const spendMeter = {

--- a/packages/coach/tests/operations.test.ts
+++ b/packages/coach/tests/operations.test.ts
@@ -532,6 +532,18 @@ describe("coach operations", () => {
       intervalsCredentials: intervalsCredentials(),
       historyNewestDate: () => "1998-07-18",
       applyRuntimeConfig,
+      readRuntimeConfig: () => ({
+        schemaVersion: 1,
+        llm: { provider: "google", model: "third", credential_configured: true },
+        intervals: { athlete_id: "athlete-b" },
+        session: {
+          historyTokenBudgetRatio: 0.3,
+          idleMinutes: 0,
+          dailyResetHour: 4,
+          resetArchiveRetentionDays: 0,
+          timezone: "UTC",
+        },
+      }),
     });
     const llmFirst = {
       llm: { provider: "anthropic" as const, model: "first", api_key: "placeholder" },
@@ -569,6 +581,18 @@ describe("coach operations", () => {
     for (const value of ["first", "second", "third", "placeholder", "athlete"]) {
       expect(serializedResults).not.toContain(value);
     }
+    await expect(operations.getRuntimeConfig({})).resolves.toEqual({
+      schemaVersion: 1,
+      llm: { provider: "google", model: "third", credential_configured: true },
+      intervals: { athlete_id: "athlete-b" },
+      session: {
+        historyTokenBudgetRatio: 0.3,
+        idleMinutes: 0,
+        dailyResetHour: 4,
+        resetArchiveRetentionDays: 0,
+        timezone: "UTC",
+      },
+    });
   });
 
   it("serializes persisted units reads and writes through the same operation FIFO", async () => {

--- a/packages/coach/tests/serve.test.ts
+++ b/packages/coach/tests/serve.test.ts
@@ -75,6 +75,18 @@ const operations: CoachOperations = {
     schemaVersion: 1,
     applied: { llm: llm !== undefined, intervals: intervals !== undefined },
   }),
+  getRuntimeConfig: async () => ({
+    schemaVersion: 1,
+    llm: { provider: "anthropic", model: "synthetic-model", credential_configured: false },
+    intervals: { athlete_id: "synthetic-athlete" },
+    session: {
+      historyTokenBudgetRatio: 0.3,
+      idleMinutes: 0,
+      dailyResetHour: 4,
+      resetArchiveRetentionDays: 0,
+      timezone: "UTC",
+    },
+  }),
 };
 
 const spendSummary = {

--- a/packages/core/src/agent/engine-host-adapter.ts
+++ b/packages/core/src/agent/engine-host-adapter.ts
@@ -9,12 +9,9 @@ import type {
   PlatformCalendarMutationsPort,
   ReferenceStateSnapshot,
 } from "@enduragent/engine";
-import {
-  ErrorStateSchema,
-  LatestJsonSchema,
-} from "@enduragent/kernel/reference/schemas";
+import { ErrorStateSchema, LatestJsonSchema } from "@enduragent/kernel/reference/schemas";
 import type { Config } from "../config.js";
-import { contextWindowForModel } from "../config.js";
+import { contextWindowForModel } from "../runtime-config.js";
 import {
   createMissingPlatformCalendarMutations,
   createPlatformAthleteDataReader,
@@ -44,9 +41,10 @@ export function engineConfigFromConfig(config: Config): EngineConfig {
     llm: Object.freeze({ ...config.llm }),
     session: Object.freeze({ ...config.session }),
     contextWindowTokens: config.contextWindowTokens,
-    compactContextWindowTokens: compactModel === config.llm.model
-      ? config.contextWindowTokens
-      : contextWindowForModel(compactModel),
+    compactContextWindowTokens:
+      compactModel === config.llm.model
+        ? config.contextWindowTokens
+        : contextWindowForModel(compactModel),
   });
 }
 
@@ -66,11 +64,15 @@ export function createEngineHostAdapter(input: {
         athleteId: config.intervals.athleteId,
       })
     : null;
-  const athleteData = config.dataSource === "store"
-    ? overrides.athleteData
-    : (legacyClient === null ? undefined : createPlatformAthleteDataReader(legacyClient));
-  const calendarMutations = overrides.calendarMutations
-    ?? (legacyClient === null
+  const athleteData =
+    config.dataSource === "store"
+      ? overrides.athleteData
+      : legacyClient === null
+        ? undefined
+        : createPlatformAthleteDataReader(legacyClient);
+  const calendarMutations =
+    overrides.calendarMutations ??
+    (legacyClient === null
       ? createMissingPlatformCalendarMutations()
       : createPlatformCalendarMutations(legacyClient));
   const referenceDir = join(config.dataDir, "data");

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -4,6 +4,20 @@ import { parse as parseYaml } from "yaml";
 import { getCoachHome } from "./coach-home.js";
 import { SecretRef, isSecretRef, SecretResolutionError } from "./secrets/types.js";
 import { resolveSecretRef } from "./secrets/resolve.js";
+import {
+  resolveLlmProvider,
+  resolveRuntimeConfig,
+  type EffectiveRuntimeConfig,
+} from "./runtime-config.js";
+
+export {
+  COMPACT_MODEL_DEFAULTS,
+  DEFAULT_MODELS,
+  LLM_PROVIDERS,
+  PROVIDER_BASE_URLS,
+  contextWindowForModel,
+} from "./runtime-config.js";
+export type { LlmProvider } from "./runtime-config.js";
 
 // ============================================================================
 // TYPES
@@ -17,47 +31,11 @@ export function resolveDataSource(value: unknown): DataSource {
   throw new TypeError('Config field data_source must be "platform" or "store".');
 }
 
-export interface Config {
+export interface Config extends EffectiveRuntimeConfig {
   dataSource: DataSource;
-  llm: {
-    provider:
-      | "anthropic"
-      | "openai"
-      | "google"
-      | "openai-codex"
-      | "deepseek"
-      | "qwen"
-      | "minimax"
-      | "kimi"
-      | "zai"
-      | "openrouter";
-    model: string;
-    apiKey: string;
-    authProfile?: string;
-    /** Cheaper model for the memory flush; unset reuses the chat model. */
-    flushModel?: string;
-    /** Cheaper model for conversation compaction; unset resolves per provider (see COMPACT_MODEL_DEFAULTS). */
-    compactModel?: string;
-    /** Override base URL for OpenAI-compatible / direct providers. Empty = provider default. */
-    baseUrl?: string;
-  };
-  intervals: {
-    apiKey: string;
-    athleteId: string;
-  };
   telegram: {
     botToken: string;
   };
-  session: {
-    historyTokenBudgetRatio: number;
-    idleMinutes: number;
-    dailyResetHour: number;
-    /** Days to keep session reset archives; 0 = keep forever (pruning disabled). */
-    resetArchiveRetentionDays: number;
-    /** Athlete IANA timezone (e.g. "Europe/Berlin"). Empty = resolver picks host TZ. */
-    timezone: string;
-  };
-  contextWindowTokens: number;
   dataDir: string;
 }
 
@@ -81,74 +59,6 @@ function readConfigYamlFrom(configDir: string): Record<string, unknown> {
 
 export function readConfigYaml(): Record<string, unknown> {
   return readConfigYamlFrom(CONFIG_DIR);
-}
-
-// ============================================================================
-// CONTEXT WINDOW RESOLUTION
-// ============================================================================
-
-const CONTEXT_WINDOWS: Record<string, number> = {
-  "claude-sonnet-4-6": 1_000_000,
-  "claude-opus-4-8": 1_000_000,
-  "claude-haiku-4-5-20251001": 200_000,
-  "gpt-4o": 128_000,
-  "gpt-5.5": 1_050_000,
-  "gpt-5.4": 1_050_000,
-  "gpt-5.4-mini": 400_000,
-  "gpt-5.4-nano": 400_000,
-  "gemini-3.5-flash": 1_048_576,
-  "gemini-3.1-pro-preview": 1_048_576,
-  "gemini-3.1-flash-lite": 1_048_576,
-  "deepseek-v4-flash": 1_000_000,
-  "deepseek-v4-pro": 1_000_000,
-  "qwen3.5-plus": 1_000_000,
-  "qwen3-max": 262_144,
-  "MiniMax-M2.7": 204_800,
-  "MiniMax-M3": 1_000_000,
-  "kimi-k2.6": 262_144,
-  "kimi-k2.5": 262_144,
-  "glm-5.2": 1_000_000,
-  "glm-4.7": 200_000,
-  "glm-4.7-flashx": 200_000,
-  "deepseek/deepseek-v4-flash": 1_000_000,
-  "z-ai/glm-5.2": 1_000_000,
-  "qwen/qwen3.7-plus": 1_000_000,
-  "moonshotai/kimi-k2.6": 262_000,
-};
-
-// Per-provider default API host. OpenAI-compatible providers (minimax/kimi/zai)
-// REQUIRE a base URL; the direct providers and OpenRouter ship a package default
-// but accept an override for proxies / mainland endpoints. The built-in four
-// (anthropic/openai/google/openai-codex) have no entry, so their base URL stays
-// undefined unless the operator sets one. Single source of truth: loadConfig
-// resolves it, the setup wizard prompts with it, and llm.ts uses it as the
-// required-baseURL fallback for the OpenAI-compatible providers.
-export const PROVIDER_BASE_URLS: Record<string, string> = {
-  deepseek: "https://api.deepseek.com/v1",
-  qwen: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
-  minimax: "https://api.minimax.io/v1",
-  kimi: "https://api.moonshot.ai/v1",
-  zai: "https://api.z.ai/api/openai/v1",
-  openrouter: "https://openrouter.ai/api/v1",
-};
-
-// Background-role (compaction) lane defaults. Only the two first-class slots
-// get a cheaper default; every other provider keeps the chat model so an
-// unconfigured setup never routes to a model its provider cannot serve.
-export const COMPACT_MODEL_DEFAULTS: Record<string, string> = {
-  anthropic: "claude-haiku-4-5-20251001",
-  openrouter: "deepseek/deepseek-v4-flash",
-};
-
-export function contextWindowForModel(model: string): number {
-  return CONTEXT_WINDOWS[model] ?? 200_000;
-}
-
-function resolveContextWindowTokens(model: string): number {
-  const envTokens = parseInt(process.env.CONTEXT_WINDOW_TOKENS ?? "", 10);
-  if (envTokens > 0) return envTokens;
-
-  return contextWindowForModel(model);
 }
 
 // ============================================================================
@@ -205,9 +115,9 @@ export function loadConfig(configDir: string = CONFIG_DIR): Config {
   const telegramYaml = (yaml.telegram as Record<string, unknown>) ?? {};
   const sessionYaml = (yaml.session as Record<string, unknown>) ?? {};
 
-  const provider = (env("LLM_PROVIDER") ??
-    (llmYaml.provider as string | undefined) ??
-    "anthropic") as Config["llm"]["provider"];
+  const provider = resolveLlmProvider(
+    env("LLM_PROVIDER") ?? (llmYaml.provider as string | undefined) ?? "anthropic",
+  );
 
   const llmApiKeyRaw = readSecretField(llmYaml.api_key, "llm.api_key");
   const intervalsApiKeyRaw = readSecretField(intervalsYaml.api_key, "intervals.api_key");
@@ -255,7 +165,9 @@ export function loadConfig(configDir: string = CONFIG_DIR): Config {
     provider === "openai-codex"
       ? ""
       : resolveWithPrecedence(
-          [envKeyForProvider[provider], "LLM_API_KEY"].filter((key): key is string => key !== undefined),
+          [envKeyForProvider[provider], "LLM_API_KEY"].filter(
+            (key): key is string => key !== undefined,
+          ),
           llmApiKeyRaw,
           "llm.api_key",
         );
@@ -270,79 +182,52 @@ export function loadConfig(configDir: string = CONFIG_DIR): Config {
     "telegram.bot_token",
   );
 
-  const defaultModelMap: Record<string, string> = {
-    anthropic: "claude-sonnet-4-6",
-    openai: "gpt-5.5",
-    google: "gemini-3.5-flash",
-    "openai-codex": "gpt-5.5",
-    deepseek: "deepseek-v4-flash",
-    qwen: "qwen3.5-plus",
-    minimax: "MiniMax-M2.7",
-    kimi: "kimi-k2.6",
-    zai: "glm-4.7",
-    openrouter: "deepseek/deepseek-v4-flash",
-  };
-
-  const model =
-    env("LLM_MODEL") ?? (llmYaml.model as string | undefined) ?? defaultModelMap[provider];
-
-  const flushModel =
-    env("LLM_FLUSH_MODEL") ?? (llmYaml.flush_model as string | undefined);
-
-  const compactModel =
-    provider === "openai-codex"
-      ? model
-      : (env("LLM_COMPACT_MODEL") ??
-         (llmYaml.compact_model as string | undefined) ??
-         COMPACT_MODEL_DEFAULTS[provider] ??
-         model);
-
-  const baseUrl =
-    env("LLM_BASE_URL") ??
-    (llmYaml.base_url as string | undefined) ??
-    PROVIDER_BASE_URLS[provider];
+  const contextWindowTokens = parseInt(env("CONTEXT_WINDOW_TOKENS") ?? "", 10);
+  const runtime = resolveRuntimeConfig(
+    {
+      llm: {
+        provider,
+        model: env("LLM_MODEL") ?? (llmYaml.model as string | undefined),
+        ...(provider === "openai-codex" ? {} : { apiKey }),
+        flushModel: env("LLM_FLUSH_MODEL") ?? (llmYaml.flush_model as string | undefined),
+        compactModel: env("LLM_COMPACT_MODEL") ?? (llmYaml.compact_model as string | undefined),
+        baseUrl: env("LLM_BASE_URL") ?? (llmYaml.base_url as string | undefined),
+      },
+      intervals: {
+        apiKey: intervalsApiKey,
+        athleteId: env("INTERVALS_ATHLETE_ID") ?? (intervalsYaml.athlete_id as string | undefined),
+      },
+      session: {
+        historyTokenBudgetRatio:
+          envFloat("HISTORY_TOKEN_BUDGET_RATIO") ??
+          (sessionYaml.historyTokenBudgetRatio as number | undefined),
+        idleMinutes:
+          envInt("SESSION_IDLE_MINUTES") ?? (sessionYaml.idleMinutes as number | undefined),
+        dailyResetHour:
+          envInt("SESSION_DAILY_RESET_HOUR") ?? (sessionYaml.dailyResetHour as number | undefined),
+        resetArchiveRetentionDays:
+          envInt("SESSION_RESET_ARCHIVE_RETENTION_DAYS") ??
+          (sessionYaml.resetArchiveRetentionDays as number | undefined),
+        timezone: env("COACH_TZ") ?? (sessionYaml.timezone as string | undefined),
+      },
+    },
+    undefined,
+    {
+      ...(Number.isFinite(contextWindowTokens) && contextWindowTokens > 0
+        ? { contextWindowTokens }
+        : {}),
+      ...(provider === "openai-codex" && typeof llmYaml.auth_profile === "string"
+        ? { authProfile: llmYaml.auth_profile }
+        : {}),
+    },
+  );
 
   const config: Config = {
+    ...runtime,
     dataSource,
-    llm: {
-      provider,
-      model,
-      apiKey,
-      authProfile:
-        provider === "openai-codex"
-          ? ((llmYaml.auth_profile as string | undefined) ?? "openai-codex")
-          : undefined,
-      flushModel,
-      compactModel,
-      baseUrl,
-    },
-    intervals: {
-      apiKey: intervalsApiKey,
-      athleteId:
-        env("INTERVALS_ATHLETE_ID") ??
-        (intervalsYaml.athlete_id as string | undefined) ??
-        "0",
-    },
     telegram: {
       botToken: telegramBotToken,
     },
-    session: {
-      historyTokenBudgetRatio:
-        envFloat("HISTORY_TOKEN_BUDGET_RATIO") ??
-        (sessionYaml.historyTokenBudgetRatio as number) ??
-        0.3,
-      idleMinutes:
-        envInt("SESSION_IDLE_MINUTES") ?? (sessionYaml.idleMinutes as number) ?? 0,
-      dailyResetHour:
-        envInt("SESSION_DAILY_RESET_HOUR") ?? (sessionYaml.dailyResetHour as number) ?? 4,
-      resetArchiveRetentionDays:
-        envInt("SESSION_RESET_ARCHIVE_RETENTION_DAYS") ??
-        (sessionYaml.resetArchiveRetentionDays as number) ??
-        0,
-      timezone:
-        env("COACH_TZ") ?? (sessionYaml.timezone as string | undefined) ?? "",
-    },
-    contextWindowTokens: resolveContextWindowTokens(model),
     dataDir: (yaml.data_dir as string) ?? configDir,
   };
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -157,6 +157,21 @@ export type { Config } from "./config.js";
 export { DATA_SOURCES, resolveDataSource } from "./config.js";
 export type { DataSource } from "./config.js";
 export {
+  COMPACT_MODEL_DEFAULTS,
+  DEFAULT_MODELS,
+  LLM_PROVIDERS,
+  PROVIDER_BASE_URLS,
+  contextWindowForModel,
+  resolveLlmProvider,
+  resolveRuntimeConfig,
+} from "./runtime-config.js";
+export type {
+  EffectiveRuntimeConfig,
+  LlmProvider,
+  RuntimeConfigPatch,
+  RuntimeConfigResolverOptions,
+} from "./runtime-config.js";
+export {
   createPlatformAthleteDataReader,
   createPlatformCalendarMutations,
   createMissingPlatformCalendarMutations,

--- a/packages/core/src/runtime-config.ts
+++ b/packages/core/src/runtime-config.ts
@@ -1,0 +1,332 @@
+export const LLM_PROVIDERS = [
+  "anthropic",
+  "openai",
+  "google",
+  "openai-codex",
+  "deepseek",
+  "qwen",
+  "minimax",
+  "kimi",
+  "zai",
+  "openrouter",
+] as const;
+
+export type LlmProvider = (typeof LLM_PROVIDERS)[number];
+
+export const DEFAULT_MODELS = {
+  anthropic: "claude-sonnet-4-6",
+  openai: "gpt-5.5",
+  google: "gemini-3.5-flash",
+  "openai-codex": "gpt-5.5",
+  deepseek: "deepseek-v4-flash",
+  qwen: "qwen3.5-plus",
+  minimax: "MiniMax-M2.7",
+  kimi: "kimi-k2.6",
+  zai: "glm-4.7",
+  openrouter: "deepseek/deepseek-v4-flash",
+} as const satisfies Record<LlmProvider, string>;
+
+export const PROVIDER_BASE_URLS = {
+  deepseek: "https://api.deepseek.com/v1",
+  qwen: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+  minimax: "https://api.minimax.io/v1",
+  kimi: "https://api.moonshot.ai/v1",
+  zai: "https://api.z.ai/api/openai/v1",
+  openrouter: "https://openrouter.ai/api/v1",
+} as const satisfies Partial<Record<LlmProvider, string>>;
+
+export const COMPACT_MODEL_DEFAULTS = {
+  anthropic: "claude-haiku-4-5-20251001",
+  openrouter: "deepseek/deepseek-v4-flash",
+} as const satisfies Partial<Record<LlmProvider, string>>;
+
+const CONTEXT_WINDOWS: Readonly<Record<string, number>> = {
+  "claude-sonnet-4-6": 1_000_000,
+  "claude-opus-4-8": 1_000_000,
+  "claude-haiku-4-5-20251001": 200_000,
+  "gpt-4o": 128_000,
+  "gpt-5.5": 1_050_000,
+  "gpt-5.4": 1_050_000,
+  "gpt-5.4-mini": 400_000,
+  "gpt-5.4-nano": 400_000,
+  "gemini-3.5-flash": 1_048_576,
+  "gemini-3.1-pro-preview": 1_048_576,
+  "gemini-3.1-flash-lite": 1_048_576,
+  "deepseek-v4-flash": 1_000_000,
+  "deepseek-v4-pro": 1_000_000,
+  "qwen3.5-plus": 1_000_000,
+  "qwen3-max": 262_144,
+  "MiniMax-M2.7": 204_800,
+  "MiniMax-M3": 1_000_000,
+  "kimi-k2.6": 262_144,
+  "kimi-k2.5": 262_144,
+  "glm-5.2": 1_000_000,
+  "glm-4.7": 200_000,
+  "glm-4.7-flashx": 200_000,
+  "deepseek/deepseek-v4-flash": 1_000_000,
+  "z-ai/glm-5.2": 1_000_000,
+  "qwen/qwen3.7-plus": 1_000_000,
+  "moonshotai/kimi-k2.6": 262_000,
+};
+
+export interface EffectiveRuntimeConfig {
+  llm: {
+    provider: LlmProvider;
+    model: string;
+    apiKey: string;
+    authProfile?: string;
+    flushModel?: string;
+    compactModel?: string;
+    baseUrl?: string;
+  };
+  intervals: {
+    apiKey: string;
+    athleteId: string;
+  };
+  session: {
+    historyTokenBudgetRatio: number;
+    idleMinutes: number;
+    dailyResetHour: number;
+    resetArchiveRetentionDays: number;
+    timezone: string;
+  };
+  contextWindowTokens: number;
+}
+
+export interface RuntimeConfigPatch {
+  readonly llm?: {
+    readonly provider?: LlmProvider;
+    readonly model?: string;
+    readonly apiKey?: string;
+    readonly flushModel?: string | null;
+    readonly compactModel?: string | null;
+    readonly baseUrl?: string | null;
+  };
+  readonly intervals?: {
+    readonly apiKey?: string;
+    readonly athleteId?: string;
+  };
+  readonly session?: Partial<EffectiveRuntimeConfig["session"]>;
+}
+
+export interface RuntimeConfigResolverOptions {
+  readonly contextWindowTokens?: number;
+  readonly authProfile?: string;
+}
+
+const ROOT_FIELDS = new Set(["llm", "intervals", "session"]);
+const LLM_FIELDS = new Set([
+  "provider",
+  "model",
+  "apiKey",
+  "flushModel",
+  "compactModel",
+  "baseUrl",
+]);
+const INTERVALS_FIELDS = new Set(["apiKey", "athleteId"]);
+const SESSION_FIELDS = new Set([
+  "historyTokenBudgetRatio",
+  "idleMinutes",
+  "dailyResetHour",
+  "resetArchiveRetentionDays",
+  "timezone",
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function assertKnownFields(value: unknown, fields: ReadonlySet<string>, name: string): void {
+  if (!isRecord(value)) throw new TypeError(`${name} must be a map.`);
+  for (const field of Object.keys(value)) {
+    if (!fields.has(field)) throw new TypeError(`Unknown ${name} field: ${field}.`);
+  }
+}
+
+function isSpecified(value: object, field: string): boolean {
+  return Object.hasOwn(value, field) && (value as Record<string, unknown>)[field] !== undefined;
+}
+
+function requireString(value: unknown, name: string, allowEmpty = false): string {
+  if (typeof value !== "string" || (!allowEmpty && value.length === 0)) {
+    throw new TypeError(`${name} must be ${allowEmpty ? "a string" : "a non-empty string"}.`);
+  }
+  return value;
+}
+
+function requireFiniteNumber(value: unknown, name: string): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new TypeError(`${name} must be a finite number.`);
+  }
+  return value;
+}
+
+function requireInteger(value: unknown, name: string): number {
+  const parsed = requireFiniteNumber(value, name);
+  if (!Number.isInteger(parsed)) throw new TypeError(`${name} must be an integer.`);
+  return parsed;
+}
+
+export function resolveLlmProvider(value: unknown): LlmProvider {
+  if (typeof value === "string" && (LLM_PROVIDERS as readonly string[]).includes(value)) {
+    return value as LlmProvider;
+  }
+  throw new TypeError("Unsupported LLM provider.");
+}
+
+export function contextWindowForModel(model: string): number {
+  return CONTEXT_WINDOWS[model] ?? 200_000;
+}
+
+function providerBaseUrl(provider: LlmProvider): string | undefined {
+  return PROVIDER_BASE_URLS[provider as keyof typeof PROVIDER_BASE_URLS];
+}
+
+function compactModelDefault(provider: LlmProvider): string | undefined {
+  return COMPACT_MODEL_DEFAULTS[provider as keyof typeof COMPACT_MODEL_DEFAULTS];
+}
+
+function optionalModel(
+  patch: NonNullable<RuntimeConfigPatch["llm"]>,
+  field: "flushModel" | "compactModel",
+): string | null | undefined {
+  if (!isSpecified(patch, field)) return undefined;
+  const value = patch[field];
+  return value === null ? null : requireString(value, `llm.${field}`);
+}
+
+export function resolveRuntimeConfig(
+  patch: RuntimeConfigPatch = {},
+  current?: EffectiveRuntimeConfig,
+  options: RuntimeConfigResolverOptions = {},
+): EffectiveRuntimeConfig {
+  assertKnownFields(patch, ROOT_FIELDS, "runtime config");
+  const llmPatch = patch.llm ?? {};
+  const intervalsPatch = patch.intervals ?? {};
+  const sessionPatch = patch.session ?? {};
+  assertKnownFields(llmPatch, LLM_FIELDS, "llm");
+  assertKnownFields(intervalsPatch, INTERVALS_FIELDS, "intervals");
+  assertKnownFields(sessionPatch, SESSION_FIELDS, "session");
+
+  const provider = isSpecified(llmPatch, "provider")
+    ? resolveLlmProvider(llmPatch.provider)
+    : (current?.llm.provider ?? "anthropic");
+  const providerChanged = current !== undefined && provider !== current.llm.provider;
+  const model = isSpecified(llmPatch, "model")
+    ? requireString(llmPatch.model, "llm.model")
+    : current !== undefined && !providerChanged
+      ? current.llm.model
+      : DEFAULT_MODELS[provider];
+  const selectionChanged = current === undefined || providerChanged || model !== current.llm.model;
+  const apiKey =
+    provider === "openai-codex"
+      ? ""
+      : isSpecified(llmPatch, "apiKey")
+        ? requireString(llmPatch.apiKey, "llm.apiKey", true)
+        : current !== undefined && !providerChanged
+          ? current.llm.apiKey
+          : "";
+  if (provider === "openai-codex" && isSpecified(llmPatch, "apiKey")) {
+    throw new TypeError("llm.apiKey must be absent for openai-codex.");
+  }
+
+  const requestedFlushModel = optionalModel(llmPatch, "flushModel");
+  const flushModel =
+    requestedFlushModel === null
+      ? undefined
+      : (requestedFlushModel ??
+        (current !== undefined && !providerChanged ? current.llm.flushModel : undefined));
+
+  const requestedCompactModel = optionalModel(llmPatch, "compactModel");
+  const compactModel =
+    provider === "openai-codex"
+      ? model
+      : requestedCompactModel === null
+        ? (compactModelDefault(provider) ?? model)
+        : (requestedCompactModel ??
+          (current !== undefined && !providerChanged
+            ? model !== current.llm.model && current.llm.compactModel === current.llm.model
+              ? model
+              : current.llm.compactModel
+            : (compactModelDefault(provider) ?? model)));
+
+  let baseUrl: string | undefined;
+  if (isSpecified(llmPatch, "baseUrl")) {
+    baseUrl =
+      llmPatch.baseUrl === null
+        ? providerBaseUrl(provider)
+        : requireString(llmPatch.baseUrl, "llm.baseUrl", true) || undefined;
+  } else {
+    baseUrl =
+      current !== undefined && !providerChanged ? current.llm.baseUrl : providerBaseUrl(provider);
+  }
+
+  const intervalsApiKeySpecified = isSpecified(intervalsPatch, "apiKey");
+  const intervalsApiKey = intervalsApiKeySpecified
+    ? requireString(intervalsPatch.apiKey, "intervals.apiKey", true)
+    : (current?.intervals.apiKey ?? "");
+  const intervals = {
+    apiKey: intervalsApiKey,
+    athleteId: isSpecified(intervalsPatch, "athleteId")
+      ? requireString(intervalsPatch.athleteId, "intervals.athleteId", current === undefined)
+      : current?.intervals.athleteId === "" &&
+          intervalsApiKeySpecified &&
+          intervalsApiKey.length > 0
+        ? "0"
+        : (current?.intervals.athleteId ?? "0"),
+  };
+
+  const session = {
+    historyTokenBudgetRatio: isSpecified(sessionPatch, "historyTokenBudgetRatio")
+      ? requireFiniteNumber(sessionPatch.historyTokenBudgetRatio, "session.historyTokenBudgetRatio")
+      : (current?.session.historyTokenBudgetRatio ?? 0.3),
+    idleMinutes: isSpecified(sessionPatch, "idleMinutes")
+      ? requireInteger(sessionPatch.idleMinutes, "session.idleMinutes")
+      : (current?.session.idleMinutes ?? 0),
+    dailyResetHour: isSpecified(sessionPatch, "dailyResetHour")
+      ? requireInteger(sessionPatch.dailyResetHour, "session.dailyResetHour")
+      : (current?.session.dailyResetHour ?? 4),
+    resetArchiveRetentionDays: isSpecified(sessionPatch, "resetArchiveRetentionDays")
+      ? requireInteger(sessionPatch.resetArchiveRetentionDays, "session.resetArchiveRetentionDays")
+      : (current?.session.resetArchiveRetentionDays ?? 0),
+    timezone: isSpecified(sessionPatch, "timezone")
+      ? requireString(sessionPatch.timezone, "session.timezone", true)
+      : (current?.session.timezone ?? ""),
+  };
+
+  const contextWindowTokens =
+    options.contextWindowTokens !== undefined
+      ? requireInteger(options.contextWindowTokens, "contextWindowTokens")
+      : current !== undefined && !selectionChanged
+        ? current.contextWindowTokens
+        : contextWindowForModel(model);
+  if (contextWindowTokens <= 0) throw new TypeError("contextWindowTokens must be positive.");
+
+  const authProfile =
+    provider === "openai-codex"
+      ? isSpecified(llmPatch, "provider")
+        ? options.authProfile === undefined
+          ? "openai-codex"
+          : requireString(options.authProfile, "authProfile")
+        : current !== undefined
+          ? (current.llm.authProfile ?? "openai-codex")
+          : options.authProfile === undefined
+            ? "openai-codex"
+            : requireString(options.authProfile, "authProfile")
+      : undefined;
+
+  return {
+    llm: {
+      provider,
+      model,
+      apiKey,
+      authProfile,
+      flushModel,
+      compactModel,
+      baseUrl,
+    },
+    intervals,
+    session,
+    contextWindowTokens,
+  };
+}

--- a/packages/core/src/setup.ts
+++ b/packages/core/src/setup.ts
@@ -1,15 +1,20 @@
-import { intro, outro, select, text, password, confirm, isCancel, cancel, log } from "@clack/prompts";
+import {
+  intro,
+  outro,
+  select,
+  text,
+  password,
+  confirm,
+  isCancel,
+  cancel,
+  log,
+} from "@clack/prompts";
 import { spawn } from "node:child_process";
 import { existsSync, mkdirSync, writeFileSync, readFileSync, unlinkSync, chmodSync } from "node:fs";
 import { stringify as toYaml } from "yaml";
 import { type BinaryConfig, binaryEnvVar } from "./binary.js";
-import {
-  CONFIG_DIR,
-  CONFIG_FILE,
-  PROVIDER_BASE_URLS,
-  envInt,
-  readConfigYaml,
-} from "./config.js";
+import { CONFIG_DIR, CONFIG_FILE, envInt, readConfigYaml } from "./config.js";
+import { DEFAULT_MODELS, PROVIDER_BASE_URLS } from "./runtime-config.js";
 import { captureAndPersistOperator } from "./channels/operator-capture.js";
 import { loadAllowedSenders } from "./channels/allowed-senders.js";
 import { runCodexLogin } from "./auth/openai-codex-login.js";
@@ -110,7 +115,11 @@ const MODELS: Record<string, { value: string; label: string; hint?: string }[]> 
     { value: "glm-4.7-flashx", label: "GLM-4.7 FlashX", hint: "cheapest" },
   ],
   openrouter: [
-    { value: "deepseek/deepseek-v4-flash", label: "DeepSeek V4 Flash (via OpenRouter)", hint: "cheap" },
+    {
+      value: "deepseek/deepseek-v4-flash",
+      label: "DeepSeek V4 Flash (via OpenRouter)",
+      hint: "cheap",
+    },
     { value: "z-ai/glm-5.2", label: "GLM-5.2 (via OpenRouter)", hint: "most capable" },
     { value: "qwen/qwen3.7-plus", label: "Qwen3.7 Plus (via OpenRouter)" },
     { value: "moonshotai/kimi-k2.6", label: "Kimi K2.6 (via OpenRouter)" },
@@ -139,19 +148,6 @@ export type CreatedEntry = {
 
 export type WizardCtx = {
   createdThisRun: CreatedEntry[];
-};
-
-const DEFAULT_MODELS: Record<string, string> = {
-  anthropic: "claude-sonnet-4-6",
-  openai: "gpt-5.5",
-  google: "gemini-3.5-flash",
-  "openai-codex": "gpt-5.5",
-  deepseek: "deepseek-v4-flash",
-  qwen: "qwen3.5-plus",
-  minimax: "MiniMax-M2.7",
-  kimi: "kimi-k2.6",
-  zai: "glm-4.7",
-  openrouter: "deepseek/deepseek-v4-flash",
 };
 
 const FIELD_KEYCHAIN_ACCOUNT: Record<SecretFieldPath, string> = {
@@ -259,10 +255,7 @@ function getString(obj: Record<string, unknown>, ...keys: string[]): string | un
   return typeof cur === "string" ? cur : undefined;
 }
 
-function readFieldValue(
-  obj: Record<string, unknown>,
-  ...keys: string[]
-): unknown {
+function readFieldValue(obj: Record<string, unknown>, ...keys: string[]): unknown {
   let cur: unknown = obj;
   for (const k of keys) {
     if (cur && typeof cur === "object" && k in (cur as Record<string, unknown>)) {
@@ -330,9 +323,12 @@ async function _runWizardCore(ctx: WizardCtx, binary: BinaryConfig): Promise<voi
   // Model
   const sameProvider = provider === prevProvider;
   const knownModel = MODELS[provider]?.some((m) => m.value === prevModel);
-  const initialModel = sameProvider && prevModel
-    ? (knownModel ? prevModel : CUSTOM_MODEL_SENTINEL)
-    : DEFAULT_MODELS[provider];
+  const initialModel =
+    sameProvider && prevModel
+      ? knownModel
+        ? prevModel
+        : CUSTOM_MODEL_SENTINEL
+      : DEFAULT_MODELS[provider as keyof typeof DEFAULT_MODELS];
   const modelResp = await select({
     message: "Model",
     options: [
@@ -359,7 +355,7 @@ async function _runWizardCore(ctx: WizardCtx, binary: BinaryConfig): Promise<voi
   // default. The built-in providers (anthropic/openai/google/openai-codex) have
   // no PROVIDER_BASE_URLS entry, so their prompt order is unchanged.
   let baseUrl: string | undefined;
-  const defaultBaseUrl = PROVIDER_BASE_URLS[provider];
+  const defaultBaseUrl = PROVIDER_BASE_URLS[provider as keyof typeof PROVIDER_BASE_URLS];
   if (defaultBaseUrl) {
     const prevBaseUrl = getString(previous, "llm", "base_url");
     const baseUrlResp = await text({
@@ -419,16 +415,20 @@ async function _runWizardCore(ctx: WizardCtx, binary: BinaryConfig): Promise<voi
   // llm.api_key (required unless Codex)
   if (provider !== "openai-codex") {
     const hasPrev = provider === prevProvider && isNonEmptySecret(prevLlmKey);
-    const result = await _collectAndWriteSecret(ctx, {
-      field: "llm.api_key",
-      label: `${API_KEY_LABELS[provider]}`,
-      required: !hasPrev,
-      prevValue: provider === prevProvider ? prevLlmKey : undefined,
-      backend,
-      chosenVaultRef: { current: chosenVault },
-      opAbsPathRef: { current: opAbsPath },
-      keychainPathRef: { current: keychainPath },
-    }, binary);
+    const result = await _collectAndWriteSecret(
+      ctx,
+      {
+        field: "llm.api_key",
+        label: `${API_KEY_LABELS[provider]}`,
+        required: !hasPrev,
+        prevValue: provider === prevProvider ? prevLlmKey : undefined,
+        backend,
+        chosenVaultRef: { current: chosenVault },
+        opAbsPathRef: { current: opAbsPath },
+        keychainPathRef: { current: keychainPath },
+      },
+      binary,
+    );
     chosenVault = result.chosenVault;
     opAbsPath = result.opAbsPath;
     keychainPath = result.keychainPath;
@@ -443,16 +443,20 @@ async function _runWizardCore(ctx: WizardCtx, binary: BinaryConfig): Promise<voi
   let intervalsAthleteId = prevIntervalsId ?? "";
   {
     const hasPrev = isNonEmptySecret(prevIntervalsKey);
-    const result = await _collectAndWriteSecret(ctx, {
-      field: "intervals.api_key",
-      label: "intervals.icu API key",
-      required: false,
-      prevValue: prevIntervalsKey,
-      backend,
-      chosenVaultRef: { current: chosenVault },
-      opAbsPathRef: { current: opAbsPath },
-      keychainPathRef: { current: keychainPath },
-    }, binary);
+    const result = await _collectAndWriteSecret(
+      ctx,
+      {
+        field: "intervals.api_key",
+        label: "intervals.icu API key",
+        required: false,
+        prevValue: prevIntervalsKey,
+        backend,
+        chosenVaultRef: { current: chosenVault },
+        opAbsPathRef: { current: opAbsPath },
+        keychainPathRef: { current: keychainPath },
+      },
+      binary,
+    );
     chosenVault = result.chosenVault;
     opAbsPath = result.opAbsPath;
     keychainPath = result.keychainPath;
@@ -486,16 +490,20 @@ async function _runWizardCore(ctx: WizardCtx, binary: BinaryConfig): Promise<voi
 
   // telegram.bot_token (optional)
   {
-    const result = await _collectAndWriteSecret(ctx, {
-      field: "telegram.bot_token",
-      label: "Telegram bot token",
-      required: false,
-      prevValue: prevTelegramToken,
-      backend,
-      chosenVaultRef: { current: chosenVault },
-      opAbsPathRef: { current: opAbsPath },
-      keychainPathRef: { current: keychainPath },
-    }, binary);
+    const result = await _collectAndWriteSecret(
+      ctx,
+      {
+        field: "telegram.bot_token",
+        label: "Telegram bot token",
+        required: false,
+        prevValue: prevTelegramToken,
+        backend,
+        chosenVaultRef: { current: chosenVault },
+        opAbsPathRef: { current: opAbsPath },
+        keychainPathRef: { current: keychainPath },
+      },
+      binary,
+    );
     chosenVault = result.chosenVault;
     opAbsPath = result.opAbsPath;
     keychainPath = result.keychainPath;
@@ -535,7 +543,11 @@ async function _runWizardCore(ctx: WizardCtx, binary: BinaryConfig): Promise<voi
         writeFileSync(CONFIG_FILE, originalBytes, { mode: 0o600 });
         chmodSync(CONFIG_FILE, 0o600);
       } else {
-        try { unlinkSync(CONFIG_FILE); } catch { /* best-effort */ }
+        try {
+          unlinkSync(CONFIG_FILE);
+        } catch {
+          /* best-effort */
+        }
       }
       cancel(`Failed to save OAuth profile: ${err instanceof Error ? err.message : String(err)}`);
       process.exit(1);
@@ -585,8 +597,7 @@ async function runOperatorCaptureStep(
     timeoutMs,
     confirm: async (info) => {
       const ok = await confirm({
-        message:
-          `Captured operator id ${info.capturedId} (Telegram: @${info.senderUsername ?? "—"}, name: ${info.senderFirstName ?? "—"}) for bot @${info.botUsername}. Save?`,
+        message: `Captured operator id ${info.capturedId} (Telegram: @${info.senderUsername ?? "—"}, name: ${info.senderFirstName ?? "—"}) for bot @${info.botUsername}. Save?`,
         initialValue: false,
       });
       handleCancel(ok, ctx, binary);
@@ -823,10 +834,7 @@ async function _collectAndWriteSecret(
       validate: (v) => (!v ? `${label} is required when migrating.` : undefined),
     });
     handleCancel(second, ctx, binary);
-    const cleanedSecond = _processSecretInput(
-      typeof second === "string" ? second : "",
-      field,
-    );
+    const cleanedSecond = _processSecretInput(typeof second === "string" ? second : "", field);
     if (cleanedSecond.length === 0) {
       cancel(`${label} is required when migrating.`);
       process.exit(1);

--- a/packages/core/tests/config.session-defaults.test.ts
+++ b/packages/core/tests/config.session-defaults.test.ts
@@ -33,6 +33,13 @@ describe("config — session defaults", () => {
     expect(loadConfig().contextWindowTokens).toBe(1_000_000);
   });
 
+  it("loads Desktop's explicitly seeded blank athlete ID", async () => {
+    writeFileSync(CONFIG(), toYaml({ intervals: { athlete_id: "" } }), { mode: 0o600 });
+    const { loadConfig } = await import("../src/config.js");
+
+    expect(loadConfig().intervals.athleteId).toBe("");
+  });
+
   it("applies YAML overrides for the four session fields", async () => {
     writeFileSync(
       CONFIG(),

--- a/packages/core/tests/runtime-config.test.ts
+++ b/packages/core/tests/runtime-config.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+import { resolveRuntimeConfig } from "../src/runtime-config.js";
+
+describe("runtime configuration authority", () => {
+  it("preserves same-provider custom fields for a credential-only patch", () => {
+    const initial = resolveRuntimeConfig({
+      llm: {
+        provider: "openrouter",
+        model: "custom-chat-model",
+        apiKey: "obviously-fake-old-key",
+        baseUrl: "https://invalid.example.test/v1",
+        flushModel: "custom-flush-model",
+        compactModel: "custom-compact-model",
+      },
+      intervals: { athleteId: "athlete-custom" },
+    });
+
+    const next = resolveRuntimeConfig(
+      { llm: { provider: "openrouter", apiKey: "obviously-fake-new-key" } },
+      initial,
+    );
+
+    expect(next.llm).toEqual({
+      provider: "openrouter",
+      model: "custom-chat-model",
+      apiKey: "obviously-fake-new-key",
+      authProfile: undefined,
+      baseUrl: "https://invalid.example.test/v1",
+      flushModel: "custom-flush-model",
+      compactModel: "custom-compact-model",
+    });
+    expect(next.intervals).toEqual(initial.intervals);
+    expect(next.session).toEqual(initial.session);
+    expect(next.contextWindowTokens).toBe(initial.contextWindowTokens);
+  });
+
+  it("applies canonical defaults and recomputes context after a provider change", () => {
+    const initial = resolveRuntimeConfig({
+      llm: {
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+        apiKey: "obviously-fake-anthropic-key",
+        baseUrl: "https://invalid.example.test/anthropic",
+        flushModel: "custom-flush-model",
+        compactModel: "custom-compact-model",
+      },
+    });
+    expect(initial.contextWindowTokens).toBe(1_000_000);
+
+    const next = resolveRuntimeConfig(
+      { llm: { provider: "zai", apiKey: "obviously-fake-zai-key" } },
+      initial,
+    );
+
+    expect(next.llm).toEqual({
+      provider: "zai",
+      model: "glm-4.7",
+      apiKey: "obviously-fake-zai-key",
+      authProfile: undefined,
+      flushModel: undefined,
+      compactModel: "glm-4.7",
+      baseUrl: "https://api.z.ai/api/openai/v1",
+    });
+    expect(next.contextWindowTokens).toBe(200_000);
+  });
+
+  it("keeps ChatGPT compaction aligned at startup and after model changes", () => {
+    const initial = resolveRuntimeConfig(
+      {
+        llm: {
+          provider: "openai-codex",
+          model: "gpt-5.5",
+          compactModel: "ignored-compact-model",
+        },
+      },
+      undefined,
+      { authProfile: "test-profile" },
+    );
+    expect(initial.llm.compactModel).toBe("gpt-5.5");
+    expect(initial.llm.authProfile).toBe("test-profile");
+
+    const next = resolveRuntimeConfig({ llm: { model: "gpt-5.4-mini" } }, initial);
+    expect(next.llm.compactModel).toBe("gpt-5.4-mini");
+    expect(next.llm.authProfile).toBe("test-profile");
+    expect(next.contextWindowTokens).toBe(400_000);
+  });
+
+  it("treats an explicit ChatGPT provider as a default-profile selection", () => {
+    const initial = resolveRuntimeConfig(
+      { llm: { provider: "openai-codex", model: "custom-model" } },
+      undefined,
+      { authProfile: "custom-profile" },
+    );
+
+    expect(initial.llm.authProfile).toBe("custom-profile");
+    expect(
+      resolveRuntimeConfig({ llm: { provider: "openai-codex" } }, initial).llm.authProfile,
+    ).toBe("openai-codex");
+    expect(resolveRuntimeConfig({ llm: { model: "new-model" } }, initial).llm.authProfile).toBe(
+      "custom-profile",
+    );
+  });
+
+  it("preserves the athlete ID for an intervals-key-only replay", () => {
+    const initial = resolveRuntimeConfig({
+      intervals: {
+        apiKey: "obviously-fake-old-intervals-key",
+        athleteId: "athlete-custom",
+      },
+    });
+
+    const next = resolveRuntimeConfig(
+      { intervals: { apiKey: "obviously-fake-new-intervals-key" } },
+      initial,
+    );
+
+    expect(next.intervals).toEqual({
+      apiKey: "obviously-fake-new-intervals-key",
+      athleteId: "athlete-custom",
+    });
+  });
+
+  it("accepts a seeded blank athlete ID at startup but rejects it as a live patch", () => {
+    const initial = resolveRuntimeConfig({ intervals: { athleteId: "" } });
+
+    expect(initial.intervals.athleteId).toBe("");
+    expect(
+      resolveRuntimeConfig({ intervals: { apiKey: "obviously-fake-intervals-key" } }, initial)
+        .intervals,
+    ).toEqual({ apiKey: "obviously-fake-intervals-key", athleteId: "0" });
+    expect(() => resolveRuntimeConfig({ intervals: { athleteId: "" } }, initial)).toThrow(
+      "intervals.athleteId",
+    );
+  });
+
+  it("rejects unknown fields and malformed values", () => {
+    expect(() => resolveRuntimeConfig({ unexpected: true } as never)).toThrow(
+      "Unknown runtime config field",
+    );
+    expect(() =>
+      resolveRuntimeConfig({ llm: { provider: "anthropic", unexpected: true } } as never),
+    ).toThrow("Unknown llm field");
+  });
+});


### PR DESCRIPTION
## Summary

- establish one canonical runtime configuration authority across startup, credential replay, and daemon hot configuration
- expose a strictly redacted protocol-v6 configuration snapshot while preserving custom endpoint and auth-profile behavior
- keep model, athlete, and session choices stable when credentials are saved or replaced

## Validation

- 287 focused tests across 18 changed test files
- pnpm check
- pnpm --filter @enduragent/desktop smoke:security
- pnpm --filter @enduragent/desktop smoke:runtime
- three independent final reviewers: regression, semantics, and security