### PR TITLE
fix(desktop): pin packaged renderer source

### DIFF
--- a/.changeset/packaged-renderer-provenance.md
+++ b/.changeset/packaged-renderer-provenance.md
@@ -1,0 +1,5 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Packaged Desktop now always loads its bundled interface even when a development renderer override is present.

--- a/apps/desktop/scripts/electron-smoke.mjs
+++ b/apps/desktop/scripts/electron-smoke.mjs
@@ -230,11 +230,10 @@ async function security() {
     );
     if (environment.outputDirectory !== undefined)
       await mkdir(environment.outputDirectory, { recursive: true });
-    const launchEnvironment = createSecuritySmokeLaunchEnvironment(
-      process.env,
-      environment,
-      process.platform,
-    );
+    const launchEnvironment = {
+      ...createSecuritySmokeLaunchEnvironment(process.env, environment, process.platform),
+      ...(mode === "packaged" ? { ELECTRON_RENDERER_URL: ":///synthetic-malformed-renderer" } : {}),
+    };
     running = await startElectron(
       "--desktop-security-smoke",
       launchEnvironment,

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -45,6 +45,7 @@ import {
   isTrustedConnectionRequest,
   registerDesktopScheme,
   rendererOutputRoot,
+  resolveDesktopRendererSource,
 } from "./security.js";
 import { DesktopDaemonSupervisor, isUtilityTerminalFrame } from "./supervisor.js";
 
@@ -85,6 +86,10 @@ async function runDesktop(): Promise<void> {
   await app.whenReady();
   const controller = new AbortController();
   const environment = { ...process.env };
+  const rendererSource = resolveDesktopRendererSource(
+    app.isPackaged,
+    environment.ELECTRON_RENDERER_URL,
+  );
   try {
     await seedFirstRunConfig({ env: environment });
   } catch {
@@ -247,9 +252,7 @@ async function runDesktop(): Promise<void> {
       session: session.defaultSession,
       currentDaemonPort: () => daemonLifecycle!.currentPort(),
       rendererRoot: rendererOutputRoot(),
-      ...(process.env.ELECTRON_RENDERER_URL === undefined
-        ? {}
-        : { developmentUrl: process.env.ELECTRON_RENDERER_URL }),
+      rendererSource,
     });
     protocolInstalled = true;
     const consoleMessages: string[] = [];
@@ -320,15 +323,11 @@ async function runDesktop(): Promise<void> {
       currentWindow: () => mainWindow.current() ?? undefined,
       runtime: daemonLifecycle,
     });
-    const trayPopoverUrl =
-      process.env.ELECTRON_RENDERER_URL === undefined
-        ? "enduragent://app/tray.html"
-        : new URL("/tray.html", process.env.ELECTRON_RENDERER_URL).toString();
     residency = createDesktopResidency({
       app,
       mainWindow,
       trayIconPath: join(app.getAppPath(), "resources", "trayTemplate.png"),
-      trayPopoverUrl,
+      trayPopoverUrl: rendererSource.trayPopoverUrl,
       reportFailure(operation) {
         process.stderr.write(`desktop-residency-failure ${operation}\n`);
       },

--- a/apps/desktop/src/main/security.ts
+++ b/apps/desktop/src/main/security.ts
@@ -50,11 +50,36 @@ function safeRendererPath(rendererRoot: string, pathname: string): string | unde
   return target.startsWith(rootPrefix) ? target : undefined;
 }
 
+export type DesktopRendererSource =
+  | {
+      readonly kind: "bundled";
+      readonly trayPopoverUrl: string;
+    }
+  | {
+      readonly kind: "development";
+      readonly developmentUrl: string;
+      readonly trayPopoverUrl: string;
+    };
+
+export function resolveDesktopRendererSource(
+  isPackaged: boolean,
+  developmentUrl: string | undefined,
+): DesktopRendererSource {
+  if (isPackaged || developmentUrl === undefined) {
+    return { kind: "bundled", trayPopoverUrl: "enduragent://app/tray.html" };
+  }
+  return {
+    kind: "development",
+    developmentUrl,
+    trayPopoverUrl: new URL("/tray.html", developmentUrl).toString(),
+  };
+}
+
 export async function installDesktopProtocol(input: {
   readonly session: Session;
   readonly currentDaemonPort: () => number;
   readonly rendererRoot: string;
-  readonly developmentUrl?: string;
+  readonly rendererSource: DesktopRendererSource;
 }): Promise<void> {
   const withCurrentPolicy = (response: Response): Response =>
     responseWithPolicy(response, createDesktopContentSecurityPolicy(input.currentDaemonPort()));
@@ -62,8 +87,8 @@ export async function installDesktopProtocol(input: {
     const requested = new URL(request.url);
     if (requested.host !== DESKTOP_HOST)
       return withCurrentPolicy(new Response(null, { status: 404 }));
-    if (input.developmentUrl !== undefined) {
-      const upstream = new URL(input.developmentUrl);
+    if (input.rendererSource.kind === "development") {
+      const upstream = new URL(input.rendererSource.developmentUrl);
       upstream.pathname = requested.pathname;
       upstream.search = requested.search;
       return withCurrentPolicy(await net.fetch(upstream.toString()));

--- a/apps/desktop/tests/security.test.ts
+++ b/apps/desktop/tests/security.test.ts
@@ -1,10 +1,12 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("electron", () => ({
   BrowserWindow: class {},
   net: { fetch: vi.fn() },
   protocol: { registerSchemesAsPrivileged: vi.fn() },
 }));
+
+import { net } from "electron";
 
 import {
   DESKTOP_CONNECTION_CHANNEL,
@@ -22,9 +24,93 @@ import {
   desktopWindowOptions,
   installDesktopProtocol,
   isTrustedConnectionRequest,
+  resolveDesktopRendererSource,
 } from "../src/main/security.js";
 
 describe("desktop security boundary", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    ["absent", undefined],
+    ["valid", "https://attacker.invalid/renderer"],
+    ["malformed", ":///synthetic-malformed-renderer"],
+  ])("uses bundled renderers when packaged and the override is %s", (_case, override) => {
+    expect(resolveDesktopRendererSource(true, override)).toEqual({
+      kind: "bundled",
+      trayPopoverUrl: "enduragent://app/tray.html",
+    });
+  });
+
+  it("uses bundled renderers during development without an override", () => {
+    expect(resolveDesktopRendererSource(false, undefined)).toEqual({
+      kind: "bundled",
+      trayPopoverUrl: "enduragent://app/tray.html",
+    });
+  });
+
+  it("uses the development proxy and tray path when an override is present", () => {
+    expect(
+      resolveDesktopRendererSource(
+        false,
+        "http://127.0.0.1:5173/renderer/index.html?source=synthetic",
+      ),
+    ).toEqual({
+      kind: "development",
+      developmentUrl: "http://127.0.0.1:5173/renderer/index.html?source=synthetic",
+      trayPopoverUrl: "http://127.0.0.1:5173/tray.html",
+    });
+  });
+
+  it("proxies development renderer requests through the resolved source", async () => {
+    let handler: ((request: Request) => Promise<Response>) | undefined;
+    const protocol = {
+      handle: vi.fn(async (_scheme: string, installed: (request: Request) => Promise<Response>) => {
+        handler = installed;
+      }),
+    };
+    vi.mocked(net.fetch).mockResolvedValueOnce(new Response("synthetic-proxied-renderer"));
+    await installDesktopProtocol({
+      session: { protocol } as never,
+      currentDaemonPort: () => 45_001,
+      rendererRoot: "/synthetic/renderer",
+      rendererSource: resolveDesktopRendererSource(false, "http://127.0.0.1:5173/root"),
+    });
+
+    const response = await handler!(
+      new Request("enduragent://app/assets/renderer.js?cache=synthetic"),
+    );
+
+    expect(net.fetch).toHaveBeenCalledOnce();
+    expect(net.fetch).toHaveBeenCalledWith(
+      "http://127.0.0.1:5173/assets/renderer.js?cache=synthetic",
+    );
+    expect(await response.text()).toBe("synthetic-proxied-renderer");
+  });
+
+  it("serves packaged renderer requests without fetching the override", async () => {
+    let handler: ((request: Request) => Promise<Response>) | undefined;
+    const protocol = {
+      handle: vi.fn(async (_scheme: string, installed: (request: Request) => Promise<Response>) => {
+        handler = installed;
+      }),
+    };
+    const rendererSource = resolveDesktopRendererSource(true, "https://attacker.invalid/renderer");
+    await installDesktopProtocol({
+      session: { protocol } as never,
+      currentDaemonPort: () => 45_001,
+      rendererRoot: "/synthetic/renderer",
+      rendererSource,
+    });
+
+    const response = await handler!(new Request("enduragent://app/missing.html"));
+
+    expect(rendererSource).not.toHaveProperty("developmentUrl");
+    expect(net.fetch).not.toHaveBeenCalled();
+    expect(response.status).toBe(404);
+  });
+
   it("pins the scheme, IPC, window, and assigned-port-only CSP constants", () => {
     expect({
       DESKTOP_SCHEME,
@@ -86,6 +172,7 @@ describe("desktop security boundary", () => {
       session: { protocol } as never,
       currentDaemonPort: () => port,
       rendererRoot: "/synthetic/renderer",
+      rendererSource: resolveDesktopRendererSource(false, undefined),
     });
     const first = await handler!(new Request("enduragent://app/missing.html"));
     port = 45_002;


### PR DESCRIPTION
## Summary

- make packaged Desktop ignore development renderer overrides before parsing them
- derive one renderer source for both the main protocol handler and tray popover
- exercise the packaged app with a controlled malformed override to prevent regression

## Validation

- 11 focused Desktop security tests
- pnpm check
- development Electron security smoke
- ad-hoc packaged Desktop build and packaged Electron security smoke with malformed override
- three independent reviewers: security, architecture, and QA