### PR TITLE
fix(desktop): scope renderer console capture

### DIFF
--- a/.changeset/desktop-console-retention.md
+++ b/.changeset/desktop-console-retention.md
@@ -1,0 +1,7 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Desktop no longer retains renderer console output during normal use.
+
+Limit renderer console capture to the bounded Desktop security smoke process.

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -39,6 +39,7 @@ import {
 import { registerOnboardingIpc, runtimeConfigurationForCredential } from "./onboarding-ipc.js";
 import { createDesktopResidency, type DesktopResidency } from "./residency.js";
 import {
+  createDesktopRendererConsoleCapture,
   desktopWindowOptions,
   hardenDesktopWindow,
   installDesktopProtocol,
@@ -75,6 +76,8 @@ async function runRuntimeSmoke(): Promise<void> {
 }
 
 async function runDesktop(): Promise<void> {
+  const securitySmokeMode = process.argv.includes("--desktop-security-smoke");
+  const rendererConsoleCapture = createDesktopRendererConsoleCapture(securitySmokeMode);
   let residency: DesktopResidency | undefined;
   app.on("second-instance", () => {
     void residency?.showMainWindow();
@@ -255,7 +258,6 @@ async function runDesktop(): Promise<void> {
       rendererSource,
     });
     protocolInstalled = true;
-    const consoleMessages: string[] = [];
     const mainWindow = {
       current: currentWindow,
       show: (): Promise<BrowserWindow> => {
@@ -270,9 +272,7 @@ async function runDesktop(): Promise<void> {
         windowCreation = (async () => {
           const created = new BrowserWindow(desktopWindowOptions(preloadEntry));
           window = created;
-          created.webContents.on("console-message", (_event, _level, consoleMessage) => {
-            consoleMessages.push(consoleMessage);
-          });
+          rendererConsoleCapture.attach(created.webContents);
           hardenDesktopWindow(created);
           disposeOnboarding?.();
           disposeOnboarding = registerOnboardingIpc({
@@ -335,7 +335,7 @@ async function runDesktop(): Promise<void> {
     const initialWindow = await mainWindow.show();
     await residency.start();
 
-    if (process.argv.includes("--desktop-security-smoke")) {
+    if (securitySmokeMode) {
       const daemonPort = daemonLifecycle.currentPort();
       const rendererResult = await initialWindow.webContents.executeJavaScript(`(async () => {
       const blockedPort = ${daemonPort === 65_535 ? daemonPort - 1 : daemonPort + 1};
@@ -399,7 +399,7 @@ async function runDesktop(): Promise<void> {
           !JSON.stringify(rendererResult.rendererSurfaces).includes(
             daemonLifecycle.connection().token,
           ) &&
-          !consoleMessages.some((entry) => entry.includes(daemonLifecycle!.connection().token)) &&
+          !rendererConsoleCapture.hasMessageContaining(daemonLifecycle.connection().token) &&
           !screenshot.includes(daemonLifecycle.connection().token),
       };
       process.stdout.write(`DESKTOP_SECURITY_READY ${JSON.stringify(result)}\n`);

--- a/apps/desktop/src/main/security.ts
+++ b/apps/desktop/src/main/security.ts
@@ -1,7 +1,14 @@
 import { readFile } from "node:fs/promises";
 import { dirname, isAbsolute, normalize, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
-import { BrowserWindow, type IpcMainInvokeEvent, net, protocol, type Session } from "electron";
+import {
+  BrowserWindow,
+  type IpcMainInvokeEvent,
+  net,
+  protocol,
+  type Session,
+  type WebContents,
+} from "electron";
 import {
   DESKTOP_HOST,
   DESKTOP_RENDERER_URL,
@@ -137,6 +144,33 @@ export function hardenDesktopWindow(window: BrowserWindow): void {
     callback(false);
   });
   window.webContents.session.setPermissionCheckHandler(() => false);
+}
+
+export type DesktopRendererConsoleCapture = {
+  readonly attach: (webContents: Pick<WebContents, "on">) => void;
+  readonly hasMessageContaining: (value: string) => boolean;
+};
+
+export function createDesktopRendererConsoleCapture(
+  enabled: boolean,
+): DesktopRendererConsoleCapture {
+  if (!enabled) {
+    return {
+      attach: () => {},
+      hasMessageContaining: () => false,
+    };
+  }
+  const messages: string[] = [];
+  return {
+    attach(webContents) {
+      webContents.on("console-message", (_event, _level, message) => {
+        messages.push(message);
+      });
+    },
+    hasMessageContaining(value) {
+      return messages.some((message) => message.includes(value));
+    },
+  };
 }
 
 export function isTrustedConnectionRequest(

--- a/apps/desktop/tests/security.test.ts
+++ b/apps/desktop/tests/security.test.ts
@@ -21,6 +21,7 @@ import {
   createDesktopContentSecurityPolicy,
 } from "../src/main/constants.js";
 import {
+  createDesktopRendererConsoleCapture,
   desktopWindowOptions,
   installDesktopProtocol,
   isTrustedConnectionRequest,
@@ -158,6 +159,64 @@ describe("desktop security boundary", () => {
         allowRunningInsecureContent: false,
       },
     });
+  });
+
+  it("does not register or retain renderer console messages when capture is disabled", () => {
+    const on = vi.fn();
+    const capture = createDesktopRendererConsoleCapture(false);
+
+    capture.attach({ on } as never);
+
+    expect(on).not.toHaveBeenCalled();
+    expect(capture.hasMessageContaining("synthetic-disabled-message")).toBe(false);
+  });
+
+  it("registers one listener and captures every renderer console message when enabled", () => {
+    let listener: ((event: unknown, level: number, message: string) => void) | undefined;
+    const on = vi.fn(
+      (event: string, installed: (event: unknown, level: number, message: string) => void) => {
+        if (event === "console-message") listener = installed;
+      },
+    );
+    const capture = createDesktopRendererConsoleCapture(true);
+
+    capture.attach({ on } as never);
+    listener?.({}, 1, "synthetic-first-message");
+    listener?.({}, 2, "synthetic-second-message");
+
+    expect(on).toHaveBeenCalledOnce();
+    expect(on).toHaveBeenCalledWith("console-message", expect.any(Function));
+    expect(capture.hasMessageContaining("synthetic-first-message")).toBe(true);
+    expect(capture.hasMessageContaining("synthetic-second-message")).toBe(true);
+  });
+
+  it("keeps renderer console capture state isolated between instances", () => {
+    let firstListener: ((event: unknown, level: number, message: string) => void) | undefined;
+    let secondListener: ((event: unknown, level: number, message: string) => void) | undefined;
+    const first = createDesktopRendererConsoleCapture(true);
+    const second = createDesktopRendererConsoleCapture(true);
+    first.attach({
+      on: vi.fn(
+        (_event: string, installed: (event: unknown, level: number, message: string) => void) => {
+          firstListener = installed;
+        },
+      ),
+    } as never);
+    second.attach({
+      on: vi.fn(
+        (_event: string, installed: (event: unknown, level: number, message: string) => void) => {
+          secondListener = installed;
+        },
+      ),
+    } as never);
+
+    firstListener?.({}, 1, "synthetic-first-capture");
+    secondListener?.({}, 1, "synthetic-second-capture");
+
+    expect(first.hasMessageContaining("synthetic-first-capture")).toBe(true);
+    expect(first.hasMessageContaining("synthetic-second-capture")).toBe(false);
+    expect(second.hasMessageContaining("synthetic-first-capture")).toBe(false);
+    expect(second.hasMessageContaining("synthetic-second-capture")).toBe(true);
   });
 
   it("emits an exact CSP pin from the current daemon port on every document load", async () => {


### PR DESCRIPTION
## Summary

- disable renderer console collection during normal Desktop residency
- retain complete console capture only for the bounded security-smoke process
- preserve the existing token-absence assertion across recreated smoke windows

## Validation

- 14 focused Desktop security tests
- pnpm check
- development Electron security smoke
- ad-hoc packaged Desktop build and packaged Electron security smoke
- three independent reviewers: security, architecture, and QA