### PR TITLE
fix(desktop): bound coach RPC calls

### DIFF
--- a/.changeset/desktop-rpc-deadlines.md
+++ b/.changeset/desktop-rpc-deadlines.md
@@ -1,0 +1,5 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Desktop operations now stop waiting on stalled local-service requests and recover on the next explicit retry.

--- a/apps/desktop-renderer/src/chat/controller.ts
+++ b/apps/desktop-renderer/src/chat/controller.ts
@@ -1,5 +1,10 @@
 import type { CoachClient, CoachClientTerminalEnvelope } from "@enduragent/coach-client";
-import { CoachClientDisconnectedError, CoachClientProtocolError } from "@enduragent/coach-client";
+import {
+  CoachClientCallAbortedError,
+  CoachClientCallTimeoutError,
+  CoachClientDisconnectedError,
+  CoachClientProtocolError,
+} from "@enduragent/coach-client";
 import type { CoachTurnEventNotificationEnvelope, TurnEvent } from "@enduragent/coach-contract";
 import type { DesktopCoachClientProvider } from "../coach-client.js";
 import {
@@ -171,7 +176,11 @@ export function createChatController(input: {
         if (protocolFault || error instanceof CoachClientProtocolError) {
           retryClient = client;
           reduce({ type: "interrupt", requestKey, copy: CHAT_PROTOCOL_FAILURE_COPY });
-        } else if (error instanceof CoachClientDisconnectedError) {
+        } else if (
+          error instanceof CoachClientDisconnectedError ||
+          error instanceof CoachClientCallTimeoutError ||
+          error instanceof CoachClientCallAbortedError
+        ) {
           retryClient = client;
           reduce({ type: "interrupt", requestKey, copy: CHAT_CONNECTION_INTERRUPTED_COPY });
         } else {

--- a/apps/desktop-renderer/src/coach-client.ts
+++ b/apps/desktop-renderer/src/coach-client.ts
@@ -1,5 +1,10 @@
 import type { CoachClient } from "@enduragent/coach-client";
-import { CoachClientProtocolError, connectCoachClient } from "@enduragent/coach-client";
+import {
+  CoachClientDisconnectedError,
+  CoachClientProtocolError,
+  connectCoachClient,
+  type CoachClientTerminalCause,
+} from "@enduragent/coach-client";
 
 export interface DesktopCoachClientProvider {
   getClient(): Promise<CoachClient>;
@@ -63,7 +68,9 @@ export function createDesktopCoachClientProvider(
   let connection: Promise<CoachClient> | undefined;
   let reconnection: Promise<CoachClient> | undefined;
   let closing: Promise<void> | undefined;
+  let shutdownCause: CoachClientDisconnectedError | undefined;
   let generation: number | undefined;
+  let failedGeneration: number | undefined;
 
   const auth = (): DesktopConnectionBridge =>
     (
@@ -72,22 +79,61 @@ export function createDesktopCoachClientProvider(
       }
     ).enduragentAuth;
 
-  const connectFresh = (failedGeneration?: number): Promise<CoachClient> => {
+  const connectFresh = (recoveryGeneration = failedGeneration): Promise<CoachClient> => {
+    if (shutdownCause !== undefined) return Promise.reject(shutdownCause);
     if (client !== undefined) return Promise.resolve(client);
     if (connection !== undefined) return connection;
+    let connectingClient: CoachClient | undefined;
+    let terminalDuringConnect:
+      | { readonly client: CoachClient; readonly cause: CoachClientTerminalCause }
+      | undefined;
+    let connectionGeneration: number | undefined;
+    const onTerminal = (failedClient: CoachClient, cause: CoachClientTerminalCause): void => {
+      if (connectingClient === undefined) {
+        terminalDuringConnect = { client: failedClient, cause };
+        return;
+      }
+      if (failedClient !== connectingClient || client !== failedClient) return;
+      client = undefined;
+      if (connection === pending) connection = undefined;
+      failedGeneration = connectionGeneration;
+    };
     const pending = auth()
-      .getDaemonConnection(failedGeneration)
+      .getDaemonConnection(recoveryGeneration)
       .then(validateConnection)
       .then((options) => {
+        if (shutdownCause !== undefined) throw shutdownCause;
+        connectionGeneration = options.generation;
         generation = options.generation;
-        return connect({ url: options.url, token: options.token });
+        return connect({ url: options.url, token: options.token, onTerminal });
       })
-      .then((connected) => {
-        if (connection === pending) client = connected;
+      .then(async (connected) => {
+        connectingClient = connected;
+        if (terminalDuringConnect?.client === connected) {
+          if (connection === pending) {
+            connection = undefined;
+            failedGeneration = connectionGeneration;
+          }
+          throw terminalDuringConnect.cause;
+        }
+        if (shutdownCause !== undefined) {
+          await connected.close();
+          throw shutdownCause;
+        }
+        if (connection === pending) {
+          client = connected;
+          generation = connectionGeneration;
+          failedGeneration = undefined;
+        }
         return connected;
       })
       .catch((error: unknown) => {
-        if (connection === pending) connection = undefined;
+        if (connection === pending) {
+          if (shutdownCause === undefined && connectionGeneration !== undefined) {
+            failedGeneration = connectionGeneration;
+          }
+          connection = undefined;
+        }
         throw error;
       });
     connection = pending;
@@ -96,9 +142,11 @@ export function createDesktopCoachClientProvider(
 
   return {
     getClient() {
-      return reconnection ?? connectFresh();
+      if (shutdownCause !== undefined) return Promise.reject(shutdownCause);
+      return reconnection ?? connectFresh(failedGeneration);
     },
     reconnect() {
+      if (shutdownCause !== undefined) return Promise.reject(shutdownCause);
       if (reconnection !== undefined) return reconnection;
       const previous = client;
       const previousConnection = connection;
@@ -111,7 +159,7 @@ export function createDesktopCoachClientProvider(
           if (client === connected) client = undefined;
           if (connection === previousConnection) connection = undefined;
         })
-        .then(() => connectFresh(generation))
+        .then(() => connectFresh(failedGeneration ?? generation))
         .finally(() => {
           if (reconnection === pending) reconnection = undefined;
         });
@@ -120,14 +168,32 @@ export function createDesktopCoachClientProvider(
     },
     close() {
       if (closing !== undefined) return closing;
-      const pending = Promise.resolve(reconnection ?? connection)
+      shutdownCause = new CoachClientDisconnectedError(1000, "");
+      const closingClient = client;
+      const closingConnection = connection;
+      const closingReconnection = reconnection;
+      let targetClient: CoachClient | undefined;
+      let targetConnection: Promise<CoachClient> | undefined;
+      let targetReconnection: Promise<CoachClient> | undefined;
+      const pending = Promise.resolve(closingReconnection ?? closingConnection)
         .catch(() => undefined)
-        .then((connected) => connected ?? client)
-        .then((connected) => connected?.close())
-        .then(() => {
-          client = undefined;
-          connection = undefined;
+        .then((connected) => connected ?? closingClient)
+        .then(async (connected) => {
+          targetClient = client === connected ? client : undefined;
+          targetConnection = targetClient === undefined ? undefined : connection;
+          targetReconnection = targetClient === undefined ? undefined : reconnection;
+          await connected?.close();
+        })
+        .finally(() => {
+          if (client === closingClient || client === targetClient) client = undefined;
+          if (connection === closingConnection || connection === targetConnection) {
+            connection = undefined;
+          }
+          if (reconnection === closingReconnection || reconnection === targetReconnection) {
+            reconnection = undefined;
+          }
           generation = undefined;
+          failedGeneration = undefined;
         });
       closing = pending;
       return pending;

--- a/apps/desktop-renderer/tests/chat-controller.test.ts
+++ b/apps/desktop-renderer/tests/chat-controller.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  CoachClientCallAbortedError,
+  CoachClientCallTimeoutError,
   CoachClientDisconnectedError,
   CoachClientProtocolError,
   type CoachClient,
@@ -263,6 +265,46 @@ describe("chat controller", () => {
     expect(states.at(-1)?.messages.filter((message) => message.role === "athlete")).toHaveLength(1);
     expect(refresh).toHaveBeenCalledTimes(2);
   });
+
+  it.each([
+    new CoachClientCallTimeoutError("chat", 11 * 60_000),
+    new CoachClientCallAbortedError("chat"),
+  ])(
+    "preserves a draft after $name and makes one new call only on explicit retry",
+    async (failure) => {
+      const first = client(async (_request, options) => {
+        deliver(options, { type: "text_delta", turnId: "turn-1", delta: "Partial" });
+        throw failure;
+      });
+      const second = client(async (_request, options) => {
+        deliver(options, { type: "final-text", turnId: "turn-2", text: "Recovered" });
+        options?.onTerminalEnvelope?.({
+          jsonrpc: "2.0",
+          id: 2,
+          result: { text: "Recovered" },
+        });
+        return { text: "Recovered" };
+      });
+      const { controller, provider, states } = subject(first, second);
+
+      await controller.submit("Same message");
+
+      expect(states.at(-1)?.status).toBe("interrupted");
+      expect(states.at(-1)?.progress).toBe(CHAT_CONNECTION_INTERRUPTED_COPY);
+      expect(states.at(-1)?.messages.at(-1)?.text).toBe("Partial");
+      expect(first.call).toHaveBeenCalledTimes(1);
+      expect(second.call).not.toHaveBeenCalled();
+      expect(provider.reconnect).not.toHaveBeenCalled();
+
+      await controller.retryInterrupted();
+
+      expect(second.call).toHaveBeenCalledTimes(1);
+      expect(states.at(-1)?.messages.filter((message) => message.role === "athlete")).toHaveLength(
+        1,
+      );
+      expect(states.at(-1)?.messages.at(-1)?.text).toBe("Recovered");
+    },
+  );
 
   it("reuses a shared recovered client when retrying a stale interrupted turn", async () => {
     let current: CoachClient;

--- a/apps/desktop-renderer/tests/coach-client.test.ts
+++ b/apps/desktop-renderer/tests/coach-client.test.ts
@@ -1,4 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  CoachClientCallTimeoutError,
+  CoachClientDisconnectedError,
+  type CoachClient,
+  type ConnectCoachClientOptions,
+} from "@enduragent/coach-client";
 import { createDesktopCoachClientProvider } from "../src/coach-client.js";
 
 afterEach(() => vi.unstubAllGlobals());
@@ -53,5 +59,214 @@ describe("desktop coach client lifecycle", () => {
     expect(first.close).toHaveBeenCalledTimes(1);
     expect(auth.getDaemonConnection).toHaveBeenNthCalledWith(2, 1);
     expect(connect).toHaveBeenCalledTimes(2);
+  });
+
+  it("recovers a terminal client lazily, generation-qualified, and coalesced", async () => {
+    const first = { close: vi.fn(async () => {}) } as unknown as CoachClient;
+    const second = { close: vi.fn(async () => {}) } as unknown as CoachClient;
+    const auth = {
+      getDaemonConnection: vi
+        .fn()
+        .mockResolvedValueOnce({
+          url: "ws://127.0.0.1:45001/rpc",
+          token: "s".repeat(43),
+          generation: 4,
+        })
+        .mockResolvedValueOnce({
+          url: "ws://127.0.0.1:45002/rpc",
+          token: "t".repeat(43),
+          generation: 5,
+        }),
+    };
+    const connect = vi.fn().mockResolvedValueOnce(first).mockResolvedValueOnce(second);
+    vi.stubGlobal("window", { enduragentAuth: auth });
+    const clients = createDesktopCoachClientProvider(connect);
+    await expect(clients.getClient()).resolves.toBe(first);
+    const options = connect.mock.calls[0]![0] as ConnectCoachClientOptions;
+    const cause = new CoachClientCallTimeoutError("chat", 11 * 60_000);
+
+    options.onTerminal?.(first, cause);
+
+    expect(auth.getDaemonConnection).toHaveBeenCalledTimes(1);
+    expect(connect).toHaveBeenCalledTimes(1);
+    expect(first.close).not.toHaveBeenCalled();
+    const recovery = clients.getClient();
+    expect(clients.getClient()).toBe(recovery);
+    await expect(recovery).resolves.toBe(second);
+    expect(auth.getDaemonConnection).toHaveBeenNthCalledWith(2, 4);
+    expect(connect).toHaveBeenCalledTimes(2);
+  });
+
+  it("advances recovery past coordinates whose client connection fails", async () => {
+    const first = { close: vi.fn(async () => {}) } as unknown as CoachClient;
+    const third = { close: vi.fn(async () => {}) } as unknown as CoachClient;
+    const connectionFailure = new Error("generation 5 connection failed");
+    const auth = {
+      getDaemonConnection: vi
+        .fn()
+        .mockResolvedValueOnce({
+          url: "ws://127.0.0.1:45001/rpc",
+          token: "s".repeat(43),
+          generation: 4,
+        })
+        .mockResolvedValueOnce({
+          url: "ws://127.0.0.1:45002/rpc",
+          token: "t".repeat(43),
+          generation: 5,
+        })
+        .mockResolvedValueOnce({
+          url: "ws://127.0.0.1:45003/rpc",
+          token: "u".repeat(43),
+          generation: 6,
+        }),
+    };
+    const connect = vi
+      .fn()
+      .mockResolvedValueOnce(first)
+      .mockRejectedValueOnce(connectionFailure)
+      .mockResolvedValueOnce(third);
+    vi.stubGlobal("window", { enduragentAuth: auth });
+    const clients = createDesktopCoachClientProvider(connect);
+    await expect(clients.getClient()).resolves.toBe(first);
+    const options = connect.mock.calls[0]![0] as ConnectCoachClientOptions;
+
+    options.onTerminal?.(first, new CoachClientDisconnectedError(1006, ""));
+
+    await expect(clients.getClient()).rejects.toBe(connectionFailure);
+    expect(auth.getDaemonConnection).toHaveBeenCalledTimes(2);
+    expect(connect).toHaveBeenCalledTimes(2);
+
+    await expect(clients.getClient()).resolves.toBe(third);
+    expect(auth.getDaemonConnection.mock.calls.map(([failed]) => failed)).toEqual([
+      undefined,
+      4,
+      5,
+    ]);
+    expect(connect).toHaveBeenCalledTimes(3);
+    await expect(clients.getClient()).resolves.toBe(third);
+    expect(auth.getDaemonConnection).toHaveBeenCalledTimes(3);
+    expect(connect).toHaveBeenCalledTimes(3);
+  });
+
+  it("rejects a client terminalized during connection resolution and recovers on the next call", async () => {
+    const first = { close: vi.fn(async () => {}) } as unknown as CoachClient;
+    const second = { close: vi.fn(async () => {}) } as unknown as CoachClient;
+    const cause = new CoachClientDisconnectedError(1006, "");
+    const auth = {
+      getDaemonConnection: vi
+        .fn()
+        .mockResolvedValueOnce({
+          url: "ws://127.0.0.1:45001/rpc",
+          token: "s".repeat(43),
+          generation: 8,
+        })
+        .mockResolvedValueOnce({
+          url: "ws://127.0.0.1:45002/rpc",
+          token: "t".repeat(43),
+          generation: 9,
+        }),
+    };
+    const connect = vi
+      .fn()
+      .mockImplementationOnce(async (options: ConnectCoachClientOptions) => {
+        options.onTerminal?.(first, cause);
+        return first;
+      })
+      .mockResolvedValueOnce(second);
+    vi.stubGlobal("window", { enduragentAuth: auth });
+    const clients = createDesktopCoachClientProvider(connect);
+
+    await expect(clients.getClient()).rejects.toBe(cause);
+    expect(auth.getDaemonConnection).toHaveBeenCalledTimes(1);
+    await expect(clients.getClient()).resolves.toBe(second);
+    expect(auth.getDaemonConnection).toHaveBeenNthCalledWith(2, 8);
+  });
+
+  it("fences a stale terminal callback from the replacement client", async () => {
+    const first = { close: vi.fn(async () => {}) } as unknown as CoachClient;
+    const second = { close: vi.fn(async () => {}) } as unknown as CoachClient;
+    const auth = {
+      getDaemonConnection: vi
+        .fn()
+        .mockResolvedValueOnce({
+          url: "ws://127.0.0.1:45001/rpc",
+          token: "s".repeat(43),
+          generation: 1,
+        })
+        .mockResolvedValueOnce({
+          url: "ws://127.0.0.1:45002/rpc",
+          token: "t".repeat(43),
+          generation: 2,
+        }),
+    };
+    const connect = vi.fn().mockResolvedValueOnce(first).mockResolvedValueOnce(second);
+    vi.stubGlobal("window", { enduragentAuth: auth });
+    const clients = createDesktopCoachClientProvider(connect);
+    await clients.getClient();
+    const oldOptions = connect.mock.calls[0]![0] as ConnectCoachClientOptions;
+    await expect(clients.reconnect()).resolves.toBe(second);
+
+    oldOptions.onTerminal?.(first, new CoachClientDisconnectedError(1000, "old close"));
+
+    await expect(clients.getClient()).resolves.toBe(second);
+    expect(auth.getDaemonConnection).toHaveBeenCalledTimes(2);
+    expect(connect).toHaveBeenCalledTimes(2);
+    expect(second.close).not.toHaveBeenCalled();
+  });
+
+  it("latches shutdown before a deferred client close can invalidate the provider", async () => {
+    let releaseClose!: () => void;
+    const closeGate = new Promise<void>((resolve) => {
+      releaseClose = resolve;
+    });
+    const terminalCause = new CoachClientDisconnectedError(1000, "");
+    let capturedOptions!: ConnectCoachClientOptions;
+    const closeClient = vi.fn(async () => {
+      capturedOptions.onTerminal?.(first, terminalCause);
+      await closeGate;
+    });
+    const first = { close: closeClient } as unknown as CoachClient;
+    const auth = {
+      getDaemonConnection: vi.fn(async () => ({
+        url: "ws://127.0.0.1:45001/rpc",
+        token: "s".repeat(43),
+        generation: 12,
+      })),
+    };
+    const connect = vi.fn(async (options: ConnectCoachClientOptions) => {
+      capturedOptions = options;
+      return first;
+    });
+    vi.stubGlobal("window", { enduragentAuth: auth });
+    const clients = createDesktopCoachClientProvider(connect);
+    await expect(clients.getClient()).resolves.toBe(first);
+
+    let closeSettled = false;
+    const closing = clients.close();
+    void closing.then(() => {
+      closeSettled = true;
+    });
+    expect(clients.close()).toBe(closing);
+    await vi.waitFor(() => expect(closeClient).toHaveBeenCalledTimes(1));
+
+    const getDuringClose = await clients.getClient().catch((error: unknown) => error);
+    const reconnectDuringClose = await clients.reconnect().catch((error: unknown) => error);
+    expect(closeSettled).toBe(false);
+    expect(getDuringClose).toBeInstanceOf(CoachClientDisconnectedError);
+    expect(getDuringClose).toMatchObject({ code: 1000, reason: "" });
+    expect(reconnectDuringClose).toBe(getDuringClose);
+    expect(auth.getDaemonConnection).toHaveBeenCalledTimes(1);
+    expect(connect).toHaveBeenCalledTimes(1);
+
+    releaseClose();
+    await expect(closing).resolves.toBeUndefined();
+    expect(closeClient).toHaveBeenCalledTimes(1);
+
+    const getAfterClose = await clients.getClient().catch((error: unknown) => error);
+    const reconnectAfterClose = await clients.reconnect().catch((error: unknown) => error);
+    expect(getAfterClose).toBe(getDuringClose);
+    expect(reconnectAfterClose).toBe(getDuringClose);
+    expect(auth.getDaemonConnection).toHaveBeenCalledTimes(1);
+    expect(connect).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/coach-cli/src/self-test.ts
+++ b/packages/coach-cli/src/self-test.ts
@@ -14,6 +14,8 @@ import {
 } from "@enduragent/coach-contract";
 import {
   CoachClientBackpressureError,
+  CoachClientCallAbortedError,
+  CoachClientCallTimeoutError,
   CoachClientDisconnectedError,
   CoachClientHandshakeError,
   CoachClientProtocolError,
@@ -84,6 +86,8 @@ function errorTerminal(error: unknown): SelfTestCommandTerminal {
     error instanceof CoachClientTransportUnavailableError ||
     error instanceof CoachClientHandshakeError ||
     error instanceof CoachClientDisconnectedError ||
+    error instanceof CoachClientCallTimeoutError ||
+    error instanceof CoachClientCallAbortedError ||
     error instanceof CoachClientBackpressureError ||
     (error instanceof CoachRemoteError && error.failure.kind === "unavailable")
   ) {

--- a/packages/coach-cli/src/verbs/transport.ts
+++ b/packages/coach-cli/src/verbs/transport.ts
@@ -11,6 +11,8 @@ import {
 } from "@enduragent/coach-contract";
 import {
   CoachClientBackpressureError,
+  CoachClientCallAbortedError,
+  CoachClientCallTimeoutError,
   CoachClientDisconnectedError,
   CoachClientHandshakeError,
   CoachClientProtocolError,
@@ -40,6 +42,12 @@ function remoteFailure(error: unknown, admitted: boolean): CoachRemoteFailure {
     return { kind: "version-mismatch", direction: error.direction };
   }
   if (error instanceof CoachRpcRemoteError) return { kind: "agent" };
+  if (
+    error instanceof CoachClientCallAbortedError ||
+    error instanceof CoachClientCallTimeoutError
+  ) {
+    return { kind: "detached" };
+  }
   if (error instanceof CoachClientDisconnectedError) {
     return { kind: admitted ? "detached" : "unavailable" };
   }
@@ -53,11 +61,8 @@ function remoteFailure(error: unknown, admitted: boolean): CoachRemoteFailure {
 
 function createRemoteTransport(client: CoachClient): CoachVerbTransport {
   let admitted = false;
-  let currentAbortCleanup: (() => void) | undefined;
   let closePromise: Promise<void> | undefined;
   const close = (): Promise<void> => {
-    currentAbortCleanup?.();
-    currentAbortCleanup = undefined;
     const promise = closePromise ?? client.close();
     closePromise = promise;
     return promise;
@@ -69,17 +74,6 @@ function createRemoteTransport(client: CoachClient): CoachVerbTransport {
       if (admitted) throw new CoachRemoteError({ kind: "agent" });
       if (input.signal.aborted) throw new CoachRemoteError({ kind: "detached" });
       let observedTerminal: JsonRpcResponseEnvelope | undefined;
-      const onAbort = (): void => {
-        if (admitted) void close();
-      };
-      const cleanup = (): void => input.signal.removeEventListener("abort", onAbort);
-      currentAbortCleanup = cleanup;
-      input.signal.addEventListener("abort", onAbort, { once: true });
-      if (input.signal.aborted) {
-        cleanup();
-        currentAbortCleanup = undefined;
-        throw new CoachRemoteError({ kind: "detached" });
-      }
       admitted = true;
       try {
         const onTerminalEnvelope = (envelope: CoachClientTerminalEnvelope): void => {
@@ -88,21 +82,25 @@ function createRemoteTransport(client: CoachClient): CoachVerbTransport {
         };
         if (input.method === "chat") {
           await client.call("chat", input.params, {
+            signal: input.signal,
             onNotificationEnvelope: input.onNotificationEnvelope,
             onTerminalEnvelope,
           });
         } else if (input.method === "getAthleteState") {
           await client.call("getAthleteState", input.params, {
+            signal: input.signal,
             onNotificationEnvelope: input.onNotificationEnvelope,
             onTerminalEnvelope,
           });
         } else if (input.method === "importFiles") {
           await client.call("importFiles", input.params, {
+            signal: input.signal,
             onNotificationEnvelope: input.onNotificationEnvelope,
             onTerminalEnvelope,
           });
         } else {
           await client.call("sync", input.params, {
+            signal: input.signal,
             onNotificationEnvelope: input.onNotificationEnvelope,
             onTerminalEnvelope,
           });
@@ -110,9 +108,6 @@ function createRemoteTransport(client: CoachClient): CoachVerbTransport {
       } catch (error) {
         if (observedTerminal !== undefined) return observedTerminal;
         throw new CoachRemoteError(remoteFailure(error, admitted));
-      } finally {
-        cleanup();
-        if (currentAbortCleanup === cleanup) currentAbortCleanup = undefined;
       }
       if (observedTerminal === undefined) throw new CoachRemoteError({ kind: "agent" });
       return observedTerminal;

--- a/packages/coach-cli/tests/self-test.test.ts
+++ b/packages/coach-cli/tests/self-test.test.ts
@@ -10,6 +10,8 @@ import {
   type SelfTestRpcResult,
 } from "@enduragent/coach-contract";
 import {
+  CoachClientCallAbortedError,
+  CoachClientCallTimeoutError,
   CoachClientHandshakeError,
   CoachClientVersionMismatchError,
   type CoachClient,
@@ -166,6 +168,25 @@ describe("self-test command", () => {
     });
     expect(mismatch.exit).toBe(EXIT_VERSION_MISMATCH);
     expect(mismatch.terminal).toMatchObject({ error: { code: "VERSION_MISMATCH" } });
+  });
+
+  it.each([
+    new CoachClientCallTimeoutError("selfTest", 2 * 60_000),
+    new CoachClientCallAbortedError("selfTest"),
+  ])("maps $name to one fixed daemon-unavailable line", async (failure) => {
+    const close = vi.fn(async () => {});
+    const fake = {
+      call: vi.fn(async () => Promise.reject(failure)),
+      close,
+    } as unknown as CoachClient;
+
+    const outcome = await invoke(async () => fake);
+
+    expect(outcome.exit).toBe(EXIT_DAEMON_UNAVAILABLE);
+    expect(outcome.lines).toHaveLength(1);
+    expect(outcome.stderr).toBe("");
+    expect(outcome.terminal).toMatchObject({ error: { code: "DAEMON_UNAVAILABLE" } });
+    expect(close).toHaveBeenCalledOnce();
   });
 
   it("turns malformed progress and a close failure after success into one fixed failure", async () => {

--- a/packages/coach-cli/tests/verbs-rpc.test.ts
+++ b/packages/coach-cli/tests/verbs-rpc.test.ts
@@ -1,9 +1,14 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   CoachOperationProgressNotificationEnvelopeSchema,
   JsonRpcSuccessResponseEnvelopeSchema,
 } from "@enduragent/coach-contract";
-import type { CoachClient, CoachClientCallOptions } from "@enduragent/coach-client";
+import {
+  CoachClientCallAbortedError,
+  CoachClientCallTimeoutError,
+  type CoachClient,
+  type CoachClientCallOptions,
+} from "@enduragent/coach-client";
 
 const mocks = vi.hoisted(() => ({ connectCoachClient: vi.fn() }));
 
@@ -17,8 +22,11 @@ import {
   connectCoachVerbTransport,
   connectRemoteCoachTransport,
   connectWithBoundedRetry,
+  type CoachVerbRequest,
   type CoachVerbTransport,
 } from "../src/index.js";
+
+afterEach(() => mocks.connectCoachClient.mockReset());
 
 const transport: CoachVerbTransport = {
   kind: "remote",
@@ -78,6 +86,105 @@ describe("bounded remote connection", () => {
     expect(returned).toBe(terminal);
     await remote.close();
     expect(close).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    ["chat", { chatId: "chat-1", message: "hello" }],
+    ["getAthleteState", {}],
+    ["importFiles", { paths: ["/synthetic/ride.fit"] }],
+    ["sync", {}],
+  ] as const)("forwards the exact request signal for %s", async (method, params) => {
+    const terminal = JsonRpcSuccessResponseEnvelopeSchema.parse({
+      jsonrpc: "2.0",
+      id: 1,
+      result: {},
+    });
+    const call = vi.fn(
+      async (
+        _method: string,
+        _params: unknown,
+        options?: Pick<CoachClientCallOptions<"sync">, "signal" | "onTerminalEnvelope">,
+      ) => {
+        options?.onTerminalEnvelope?.(terminal);
+        return {};
+      },
+    );
+    mocks.connectCoachClient.mockResolvedValue({
+      call,
+      close: vi.fn(async () => {}),
+    } as unknown as CoachClient);
+    const remote = await connectCoachVerbTransport({
+      url: "ws://127.0.0.1:43123/rpc",
+      token: "synthetic-token",
+    });
+    const controller = new AbortController();
+    const request = {
+      method,
+      params,
+      signal: controller.signal,
+      onNotificationEnvelope: vi.fn(),
+      onTerminalEnvelope: vi.fn(),
+    } as CoachVerbRequest;
+
+    await expect(remote.request(request)).resolves.toBe(terminal);
+
+    expect(call).toHaveBeenCalledTimes(1);
+    expect(call.mock.calls[0]![0]).toBe(method);
+    expect(call.mock.calls[0]![2]?.signal).toBe(controller.signal);
+  });
+
+  it("detaches a pre-aborted request without calling the client or fabricating a terminal", async () => {
+    const call = vi.fn();
+    mocks.connectCoachClient.mockResolvedValue({
+      call,
+      close: vi.fn(async () => {}),
+    } as unknown as CoachClient);
+    const remote = await connectCoachVerbTransport({
+      url: "ws://127.0.0.1:43123/rpc",
+      token: "synthetic-token",
+    });
+    const controller = new AbortController();
+    controller.abort();
+    const terminal = vi.fn();
+
+    await expect(
+      remote.request({
+        method: "sync",
+        params: {},
+        signal: controller.signal,
+        onNotificationEnvelope: vi.fn(),
+        onTerminalEnvelope: terminal,
+      }),
+    ).rejects.toMatchObject({ failure: { kind: "detached" } });
+    expect(call).not.toHaveBeenCalled();
+    expect(terminal).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    new CoachClientCallAbortedError("sync"),
+    new CoachClientCallTimeoutError("sync", 24 * 60 * 60_000),
+  ])("maps $name after admission to detached without a terminal envelope", async (failure) => {
+    const call = vi.fn(async () => Promise.reject(failure));
+    mocks.connectCoachClient.mockResolvedValue({
+      call,
+      close: vi.fn(async () => {}),
+    } as unknown as CoachClient);
+    const remote = await connectCoachVerbTransport({
+      url: "ws://127.0.0.1:43123/rpc",
+      token: "synthetic-token",
+    });
+    const terminal = vi.fn();
+
+    await expect(
+      remote.request({
+        method: "sync",
+        params: {},
+        signal: new AbortController().signal,
+        onNotificationEnvelope: vi.fn(),
+        onTerminalEnvelope: terminal,
+      }),
+    ).rejects.toMatchObject({ failure: { kind: "detached" } });
+    expect(terminal).not.toHaveBeenCalled();
   });
 
   it("attempts immediately and pins 50/100/200 delays", async () => {

--- a/packages/coach-client/src/client.ts
+++ b/packages/coach-client/src/client.ts
@@ -15,6 +15,8 @@ import {
 } from "@enduragent/coach-contract";
 import {
   CoachClientBackpressureError,
+  CoachClientCallAbortedError,
+  CoachClientCallTimeoutError,
   CoachClientDisconnectedError,
   CoachClientHandshakeError,
   CoachClientProtocolError,
@@ -38,6 +40,7 @@ export interface ConnectCoachClientOptions {
   readonly lowWaterMarkBytes?: number;
   readonly maxQueuedSends?: number;
   readonly webSocketFactory?: CoachWebSocketFactory;
+  readonly onTerminal?: CoachClientTerminalObserver;
 }
 
 export type CoachClientTerminalEnvelope =
@@ -45,6 +48,7 @@ export type CoachClientTerminalEnvelope =
   | JsonRpcErrorResponseEnvelope;
 
 export interface CoachClientCallOptions<K extends CoachRpcMethodName> {
+  readonly signal?: AbortSignal;
   readonly onEvent?: (event: CoachRpcEvent<K>) => void;
   readonly onNotificationEnvelope?: (envelope: CoachRpcNotification<K>) => void;
   readonly onTerminalEnvelope?: (envelope: CoachClientTerminalEnvelope) => void;
@@ -60,6 +64,17 @@ export interface CoachClient {
   close(code?: number, reason?: string): Promise<void>;
 }
 
+export type CoachClientTerminalCause =
+  | CoachClientCallTimeoutError
+  | CoachClientCallAbortedError
+  | CoachClientProtocolError
+  | CoachClientDisconnectedError;
+
+export type CoachClientTerminalObserver = (
+  client: CoachClient,
+  cause: CoachClientTerminalCause,
+) => void;
+
 interface ValidatedOptions {
   readonly url: string;
   readonly token: string;
@@ -71,6 +86,7 @@ interface ValidatedOptions {
   readonly lowWaterMarkBytes: number;
   readonly maxQueuedSends: number;
   readonly webSocketFactory: CoachWebSocketFactory | undefined;
+  readonly onTerminal: CoachClientTerminalObserver | undefined;
 }
 
 interface PendingCall {
@@ -80,12 +96,32 @@ interface PendingCall {
   readonly onEvent: ((event: unknown) => void) | undefined;
   readonly onNotificationEnvelope: ((envelope: CoachRpcNotificationEnvelope) => void) | undefined;
   readonly onTerminalEnvelope: ((envelope: CoachClientTerminalEnvelope) => void) | undefined;
+  timer: ReturnType<typeof setTimeout> | undefined;
+  readonly signal: AbortSignal | undefined;
+  readonly onAbort: (() => void) | undefined;
 }
 
 interface OutboundFrame {
   readonly id: number;
   readonly text: string;
 }
+
+const COACH_RPC_CALL_TIMEOUT_MS: Record<CoachRpcMethodName, number> = {
+  chat: 11 * 60_000,
+  resetSession: 11 * 60_000,
+  hasSession: 30_000,
+  getAthleteState: 30_000,
+  importFiles: 60 * 60_000,
+  sync: 24 * 60 * 60_000,
+  saveIntake: 30_000,
+  configureRuntime: 30_000,
+  getRuntimeConfig: 30_000,
+  getUnitsPreference: 30_000,
+  setUnitsPreference: 30_000,
+  getSpendSummary: 30_000,
+  setDailySpendCap: 30_000,
+  selfTest: 2 * 60_000,
+};
 
 function positiveSafeInteger(value: unknown): value is number {
   return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
@@ -147,6 +183,7 @@ function validateOptions(options: ConnectCoachClientOptions): ValidatedOptions {
     lowWaterMarkBytes,
     maxQueuedSends,
     webSocketFactory: options.webSocketFactory,
+    onTerminal: options.onTerminal,
   };
 }
 
@@ -227,8 +264,10 @@ class CoachClientRuntime {
   private sendPumpRunning = false;
   private sendWaitTimer: ReturnType<typeof setTimeout> | undefined;
   private sendWaitResolve: (() => void) | undefined;
-  private terminalCause: CoachClientProtocolError | CoachClientDisconnectedError | undefined;
+  private terminalCause: CoachClientTerminalCause | undefined;
+  private preActivationCause: CoachClientDisconnectedError | undefined;
   private handshakeBinding: CoachClientHandshakeBinding | undefined;
+  private publicClient: CoachClient | undefined;
   private ready = false;
   private closePromise: Promise<void> | undefined;
 
@@ -237,6 +276,7 @@ class CoachClientRuntime {
     private readonly options: ValidatedOptions,
   ) {
     socket.addEventListener("close", this.onSocketClose);
+    socket.addEventListener("error", this.onSocketError);
   }
 
   readonly handleRawFrame = (data: unknown): void => {
@@ -270,8 +310,7 @@ class CoachClientRuntime {
 
   activate(binding: CoachClientHandshakeBinding): CoachClient {
     this.handshakeBinding = binding;
-    this.ready = true;
-    return {
+    const client: CoachClient = {
       handshake: binding.accepted,
       call: <K extends CoachRpcMethodName>(
         method: K,
@@ -280,10 +319,15 @@ class CoachClientRuntime {
       ) => this.call(method, request, options),
       close: (code?: number, reason?: string) => this.close(code, reason),
     };
+    this.publicClient = client;
+    this.ready = true;
+    if (this.preActivationCause !== undefined) this.latchTerminal(this.preActivationCause);
+    return client;
   }
 
   disposeBeforeReady(): void {
     this.socket.removeEventListener("close", this.onSocketClose);
+    this.socket.removeEventListener("error", this.onSocketError);
   }
 
   private call<K extends CoachRpcMethodName>(
@@ -294,16 +338,11 @@ class CoachClientRuntime {
     if (this.terminalCause !== undefined) {
       return Promise.reject(this.terminalCause);
     }
-    if (this.sendPumpRunning && this.sendQueue.length - 1 >= this.options.maxQueuedSends) {
-      return Promise.reject(new CoachClientBackpressureError());
-    }
-    if (this.idsExhausted) {
-      return Promise.reject(this.failProtocol());
-    }
 
     let params: unknown;
     let text: string;
     const id = this.nextId;
+    const signal = options?.signal;
     try {
       params = COACH_RPC_METHOD_REGISTRY[method].requestSchema.parse(request);
       text = serializeCoachRpcEnvelope({
@@ -316,14 +355,29 @@ class CoachClientRuntime {
       return Promise.reject(new CoachClientProtocolError());
     }
 
+    if (signal?.aborted) {
+      return Promise.reject(new CoachClientCallAbortedError(method));
+    }
+    if (this.sendPumpRunning && this.sendQueue.length - 1 >= this.options.maxQueuedSends) {
+      return Promise.reject(new CoachClientBackpressureError());
+    }
+    if (this.idsExhausted) {
+      return Promise.reject(this.failProtocol());
+    }
+
     if (id === Number.MAX_SAFE_INTEGER) {
       this.idsExhausted = true;
     } else {
       this.nextId = id + 1;
     }
 
+    const timeoutMs = COACH_RPC_CALL_TIMEOUT_MS[method];
     const promise = new Promise<CoachRpcResponse<K>>((resolve, reject) => {
-      this.pending.set(id, {
+      const onAbort =
+        signal === undefined
+          ? undefined
+          : () => this.latchTerminal(new CoachClientCallAbortedError(method));
+      const pending: PendingCall = {
         method,
         resolve: resolve as (value: unknown) => void,
         reject,
@@ -332,7 +386,15 @@ class CoachClientRuntime {
           | ((envelope: CoachRpcNotificationEnvelope) => void)
           | undefined,
         onTerminalEnvelope: options?.onTerminalEnvelope,
-      });
+        timer: undefined,
+        signal,
+        onAbort,
+      };
+      this.pending.set(id, pending);
+      signal?.addEventListener("abort", onAbort!, { once: true });
+      pending.timer = setTimeout(() => {
+        this.latchTerminal(new CoachClientCallTimeoutError(method, timeoutMs));
+      }, timeoutMs);
     });
     this.sendQueue.push({ id, text });
     this.startSendPump();
@@ -438,7 +500,7 @@ class CoachClientRuntime {
         this.failProtocol();
         return;
       }
-      this.pending.delete(envelope.id);
+      this.claimPending(envelope.id, pending);
       const observer = pending.onTerminalEnvelope;
       try {
         observer?.(envelope);
@@ -452,7 +514,7 @@ class CoachClientRuntime {
       envelope.error.message,
       envelope.error.data,
     );
-    this.pending.delete(envelope.id);
+    this.claimPending(envelope.id, pending);
     const observer = pending.onTerminalEnvelope;
     try {
       observer?.(envelope);
@@ -467,12 +529,28 @@ class CoachClientRuntime {
         : new CoachClientProtocolError();
     }
     const error = new CoachClientProtocolError();
-    this.latchTerminal(error);
-    requestSocketClose(this.socket, 1002);
+    this.latchTerminal(error, 1002);
     return error;
   }
 
-  private latchTerminal(error: CoachClientProtocolError | CoachClientDisconnectedError): void {
+  private claimPending(id: JsonRpcId, pending: PendingCall): void {
+    this.pending.delete(id);
+    this.cleanupPending(pending);
+  }
+
+  private cleanupPending(pending: PendingCall): void {
+    if (pending.timer !== undefined) clearTimeout(pending.timer);
+    pending.timer = undefined;
+    if (pending.signal !== undefined && pending.onAbort !== undefined) {
+      pending.signal.removeEventListener("abort", pending.onAbort);
+    }
+  }
+
+  private latchTerminal(
+    error: CoachClientTerminalCause,
+    closeCode?: number,
+    closeReason?: string,
+  ): void {
     if (this.terminalCause !== undefined) return;
     this.terminalCause = error;
     this.ready = false;
@@ -480,51 +558,78 @@ class CoachClientRuntime {
     this.sendQueue.length = 0;
     this.handshakeBinding?.dispose();
     this.socket.removeEventListener("close", this.onSocketClose);
+    this.socket.removeEventListener("error", this.onSocketError);
     const pending = [...this.pending.values()];
     this.pending.clear();
-    for (const entry of pending) entry.reject(error);
+    for (const entry of pending) {
+      this.cleanupPending(entry);
+      entry.reject(error);
+    }
+    requestSocketClose(this.socket, closeCode, closeReason);
+    const client = this.publicClient;
+    if (client !== undefined) {
+      try {
+        this.options.onTerminal?.(client, error);
+      } catch {}
+    }
   }
 
   private readonly onSocketClose = (event: CloseEvent): void => {
-    if (!this.ready || this.terminalCause !== undefined) return;
-    this.latchTerminal(new CoachClientDisconnectedError(event.code, event.reason));
+    if (this.terminalCause !== undefined) return;
+    const error = new CoachClientDisconnectedError(event.code, event.reason);
+    if (!this.ready) {
+      this.preActivationCause ??= error;
+      return;
+    }
+    this.latchTerminal(error);
+  };
+
+  private readonly onSocketError = (): void => {
+    if (this.terminalCause !== undefined) return;
+    const error = new CoachClientDisconnectedError(1006, "");
+    if (!this.ready) {
+      this.preActivationCause ??= error;
+      return;
+    }
+    this.latchTerminal(error);
   };
 
   private close(code = 1000, reason = ""): Promise<void> {
     if (this.closePromise !== undefined) return this.closePromise;
-    this.closePromise = new Promise((resolve) => {
-      let timer: ReturnType<typeof setTimeout> | undefined;
-      let settled = false;
-
-      const cleanup = (): void => {
-        if (timer !== undefined) clearTimeout(timer);
-        timer = undefined;
-        this.socket.removeEventListener("close", onClose);
-      };
-
-      const finish = (): void => {
-        if (settled) return;
-        settled = true;
-        cleanup();
-        resolve();
-      };
-
-      const onClose = (): void => {
-        finish();
-      };
-
-      if (this.terminalCause === undefined) {
-        this.latchTerminal(new CoachClientDisconnectedError(code, reason));
-      }
-      this.socket.addEventListener("close", onClose);
-      timer = setTimeout(finish, this.options.closeTimeoutMs);
-      if (this.socket.readyState === 3) {
-        finish();
-        return;
-      }
-      requestSocketClose(this.socket, code, reason);
+    let resolveClose!: () => void;
+    const promise = new Promise<void>((resolve) => {
+      resolveClose = resolve;
     });
-    return this.closePromise;
+    this.closePromise = promise;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let settled = false;
+
+    const cleanup = (): void => {
+      if (timer !== undefined) clearTimeout(timer);
+      timer = undefined;
+      this.socket.removeEventListener("close", onClose);
+    };
+
+    const finish = (): void => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolveClose();
+    };
+
+    const onClose = (): void => {
+      finish();
+    };
+
+    this.socket.addEventListener("close", onClose);
+    timer = setTimeout(finish, this.options.closeTimeoutMs);
+    if (this.terminalCause === undefined) {
+      this.latchTerminal(new CoachClientDisconnectedError(code, reason), code, reason);
+    } else {
+      requestSocketClose(this.socket, code, reason);
+    }
+    if (this.socket.readyState === 3) finish();
+    return promise;
   }
 }
 

--- a/packages/coach-client/src/errors.ts
+++ b/packages/coach-client/src/errors.ts
@@ -1,4 +1,9 @@
-import type { DaemonOwner, JsonValue, ProtocolVersionDirection } from "@enduragent/coach-contract";
+import type {
+  CoachRpcMethodName,
+  DaemonOwner,
+  JsonValue,
+  ProtocolVersionDirection,
+} from "@enduragent/coach-contract";
 
 export class CoachClientTransportUnavailableError extends Error {
   constructor() {
@@ -46,6 +51,23 @@ export class CoachClientBackpressureError extends Error {
   constructor() {
     super("Coach client send queue is full");
     this.name = "CoachClientBackpressureError";
+  }
+}
+
+export class CoachClientCallTimeoutError extends Error {
+  constructor(
+    readonly method: CoachRpcMethodName,
+    readonly timeoutMs: number,
+  ) {
+    super("Coach client call timed out");
+    this.name = "CoachClientCallTimeoutError";
+  }
+}
+
+export class CoachClientCallAbortedError extends Error {
+  constructor(readonly method: CoachRpcMethodName) {
+    super("Coach client call aborted");
+    this.name = "CoachClientCallAbortedError";
   }
 }
 

--- a/packages/coach-client/tests/client.test.ts
+++ b/packages/coach-client/tests/client.test.ts
@@ -1,16 +1,20 @@
 import { afterEach, describe, expect, expectTypeOf, it, vi } from "vitest";
 import { WebSocketServer, type WebSocket as ServerWebSocket } from "ws";
 import {
+  COACH_RPC_METHOD_REGISTRY,
   PROTOCOL_VERSION,
   createAcceptedServerHandshakeFrame,
   createVersionMismatchServerHandshakeFrame,
   parseCoachRpcEnvelope,
   serializeCoachRpcEnvelope,
+  type CoachRpcMethodName,
   type CoachTurnEventNotificationEnvelope,
   type JsonRpcProtocolErrorResponseEnvelope,
 } from "@enduragent/coach-contract";
 import {
   CoachClientBackpressureError,
+  CoachClientCallAbortedError,
+  CoachClientCallTimeoutError,
   CoachClientDisconnectedError,
   CoachClientHandshakeError,
   CoachClientProtocolError,
@@ -21,10 +25,40 @@ import {
   resolveCoachWebSocketFactory,
   type CoachClient,
   type CoachClientCallOptions,
+  type CoachClientTerminalCause,
   type CoachClientTerminalEnvelope,
+  type ConnectCoachClientOptions,
 } from "../src/index.js";
 
 const token = "synthetic-test-token";
+
+const rpcDeadlineCases = [
+  ["chat", { chatId: "chat-1", message: "deadline" }, 660_000],
+  ["resetSession", { chatId: "chat-1" }, 660_000],
+  ["hasSession", { chatId: "chat-1" }, 30_000],
+  ["getAthleteState", {}, 30_000],
+  ["importFiles", { paths: ["/synthetic/ride.fit"] }, 3_600_000],
+  ["sync", {}, 86_400_000],
+  [
+    "saveIntake",
+    {
+      swim_skill_floor: null,
+      continuous_distance_capable: null,
+      open_water_comfort: null,
+      prior_bsi: false,
+      clinician_cleared: null,
+      injury_status: "none",
+    },
+    30_000,
+  ],
+  ["configureRuntime", { llm: { provider: "openai" } }, 30_000],
+  ["getRuntimeConfig", {}, 30_000],
+  ["getUnitsPreference", {}, 30_000],
+  ["setUnitsPreference", { value: "metric" }, 30_000],
+  ["getSpendSummary", {}, 30_000],
+  ["setDailySpendCap", { dailyCapUsd: 25 }, 30_000],
+  ["selfTest", {}, 120_000],
+] as const satisfies ReadonlyArray<readonly [CoachRpcMethodName, unknown, number]>;
 
 class ControllableSocket extends EventTarget {
   readyState = 0;
@@ -78,7 +112,10 @@ function deferred<T>(): Deferred<T> {
   return { promise, resolve };
 }
 
-function acceptedSocket(owner = "service-managed" as const): {
+function acceptedSocket(
+  owner = "service-managed" as const,
+  options: Pick<ConnectCoachClientOptions, "onTerminal"> = {},
+): {
   readonly socket: ControllableSocket;
   readonly connecting: Promise<CoachClient>;
 } {
@@ -95,6 +132,7 @@ function acceptedSocket(owner = "service-managed" as const): {
     url: "ws://127.0.0.1:49152",
     token,
     webSocketFactory: () => socket as unknown as WebSocket,
+    ...options,
   });
   socket.emitOpen();
   return { socket, connecting };
@@ -318,6 +356,33 @@ describe("connection and transport", () => {
 });
 
 describe("handshake failures", () => {
+  it("terminalizes a socket error delivered after handshake acceptance but before resolution", async () => {
+    const socket = new ControllableSocket();
+    const observer = vi.fn();
+    socket.sendHook = () => {
+      socket.emitMessage(
+        JSON.stringify(createAcceptedServerHandshakeFrame("service-managed", PROTOCOL_VERSION)),
+      );
+      socket.emitError();
+    };
+    const connection = connectCoachClient({
+      url: "ws://127.0.0.1:49152",
+      token,
+      onTerminal: observer,
+      webSocketFactory: () => socket as unknown as WebSocket,
+    });
+    socket.emitOpen();
+
+    const client = await connection;
+    const cause = await client
+      .call("hasSession", { chatId: "chat-1" })
+      .catch((error: unknown) => error);
+
+    expect(cause).toBeInstanceOf(CoachClientDisconnectedError);
+    expect(observer).toHaveBeenCalledExactlyOnceWith(client, cause);
+    expect(socket.closeCalls).toHaveLength(1);
+  });
+
   it.each([
     {
       kind: "timeout",
@@ -1000,19 +1065,24 @@ describe("RPC receive and observers", () => {
     "not-json",
     new Uint8Array([1, 2]),
   ])("fails all pending work for violating frame", async (frame) => {
-    const { socket, connecting } = acceptedSocket();
+    const observer = vi.fn();
+    const { socket, connecting } = acceptedSocket("service-managed", { onTerminal: observer });
     const client = await connecting;
     socket.sendHook = () => {};
     const terminals = vi.fn();
+    const firstController = new AbortController();
+    const secondController = new AbortController();
+    const firstRemove = vi.spyOn(firstController.signal, "removeEventListener");
+    const secondRemove = vi.spyOn(secondController.signal, "removeEventListener");
     const first = client.call(
       "chat",
       { chatId: "chat-1", message: "one" },
-      { onTerminalEnvelope: terminals },
+      { signal: firstController.signal, onTerminalEnvelope: terminals },
     );
     const second = client.call(
       "hasSession",
       { chatId: "chat-2" },
-      { onTerminalEnvelope: terminals },
+      { signal: secondController.signal, onTerminalEnvelope: terminals },
     );
     socket.emitMessage(frame);
     const [a, b] = await Promise.all([
@@ -1022,15 +1092,347 @@ describe("RPC receive and observers", () => {
     expect(a).toBeInstanceOf(CoachClientProtocolError);
     expect(b).toBe(a);
     expect(terminals).not.toHaveBeenCalled();
+    expect(observer).toHaveBeenCalledExactlyOnceWith(client, a);
+    expect(firstRemove).toHaveBeenCalledWith("abort", expect.any(Function));
+    expect(secondRemove).toHaveBeenCalledWith("abort", expect.any(Function));
+    expect(socket.closeCalls).toHaveLength(1);
     const closing = client.close();
     socket.emitClose(1002, "protocol");
     await closing;
+    firstController.abort();
+    secondController.abort();
+    expect(observer).toHaveBeenCalledTimes(1);
   });
+
+  it.each([false, true])(
+    "reserves a protocol close before a %s synchronous observer close",
+    async (closeSynchronously) => {
+      let observerClose: Promise<void> | undefined;
+      const observer = vi.fn((terminalClient: CoachClient) => {
+        observerClose = terminalClient.close();
+      });
+      const { socket, connecting } = acceptedSocket("service-managed", {
+        onTerminal: observer,
+      });
+      const client = await connecting;
+      socket.sendHook = () => {};
+      socket.closeSynchronously = closeSynchronously;
+      const call = client.call("hasSession", { chatId: "chat-1" }).catch((error: unknown) => error);
+
+      socket.emitMessage("not-json");
+
+      const cause = await call;
+      expect(cause).toBeInstanceOf(CoachClientProtocolError);
+      expect(observer).toHaveBeenCalledExactlyOnceWith(client, cause);
+      expect(socket.closeCalls).toEqual([{ code: 1002, reason: undefined }]);
+      await expect(client.call("hasSession", { chatId: "future" })).rejects.toBe(cause);
+      expect(observerClose).toBeDefined();
+      if (!closeSynchronously) socket.emitClose(1002, "protocol");
+      await observerClose;
+      expect(observer).toHaveBeenCalledTimes(1);
+      expect(socket.closeCalls).toEqual([{ code: 1002, reason: undefined }]);
+    },
+  );
 });
 
 describe("disconnect, close, and send bounds", () => {
-  it("fans an unexpected disconnect to every pending and future call", async () => {
+  it("rejects a pre-aborted call without sending or consuming an id", async () => {
     const { socket, connecting } = acceptedSocket();
+    const client = await connecting;
+    socket.sent.length = 0;
+    const controller = new AbortController();
+    controller.abort(new Error("private abort detail"));
+
+    const aborted = await client
+      .call("hasSession", { chatId: "chat-1" }, { signal: controller.signal })
+      .catch((error: unknown) => error);
+
+    expect(aborted).toBeInstanceOf(CoachClientCallAbortedError);
+    expect(aborted).toMatchObject({
+      name: "CoachClientCallAbortedError",
+      message: "Coach client call aborted",
+      method: "hasSession",
+    });
+    expect(String(aborted)).not.toContain("private abort detail");
+    expect(socket.sent).toEqual([]);
+
+    socket.sendHook = (text) => {
+      const request = JSON.parse(text) as { id: number };
+      socket.emitMessage(
+        JSON.stringify({ jsonrpc: "2.0", id: request.id, result: { hasSession: true } }),
+      );
+    };
+    await expect(client.call("hasSession", { chatId: "chat-2" })).resolves.toEqual({
+      hasSession: true,
+    });
+    expect((JSON.parse(socket.sent[0]!) as { id: number }).id).toBe(1);
+    socket.closeSynchronously = true;
+    await client.close();
+  });
+
+  it("covers every registered method in the deadline cases", () => {
+    expect(rpcDeadlineCases.map(([method]) => method).sort()).toEqual(
+      Object.keys(COACH_RPC_METHOD_REGISTRY).sort(),
+    );
+  });
+
+  it.each(rpcDeadlineCases)(
+    "applies the absolute %s deadline at %sms",
+    async (method, params, timeoutMs) => {
+      vi.useFakeTimers();
+      const terminals: Array<{ client: CoachClient; cause: CoachClientTerminalCause }> = [];
+      const { socket, connecting } = acceptedSocket("service-managed", {
+        onTerminal: (client, cause) => terminals.push({ client, cause }),
+      });
+      const client = await connecting;
+      socket.sendHook = () => {};
+      let settled = false;
+      const call = client.call(method, params as never).then(
+        (result) => {
+          settled = true;
+          return result;
+        },
+        (error: unknown) => {
+          settled = true;
+          return error;
+        },
+      );
+
+      await vi.advanceTimersByTimeAsync(timeoutMs - 1);
+      expect(settled).toBe(false);
+      expect(terminals).toEqual([]);
+      expect(socket.closeCalls).toEqual([]);
+      await vi.advanceTimersByTimeAsync(1);
+
+      const error = await call;
+      expect(error).toBeInstanceOf(CoachClientCallTimeoutError);
+      expect(error).toMatchObject({
+        name: "CoachClientCallTimeoutError",
+        message: "Coach client call timed out",
+        method,
+        timeoutMs,
+      });
+      expect(terminals).toEqual([{ client, cause: error }]);
+      expect(socket.closeCalls).toHaveLength(1);
+    },
+  );
+
+  it("lets a response just before the deadline win and times out at the exact boundary", async () => {
+    vi.useFakeTimers();
+    const before = acceptedSocket();
+    const beforeClient = await before.connecting;
+    before.socket.sendHook = () => {};
+    const winning = beforeClient.call("hasSession", { chatId: "chat-1" });
+    await vi.advanceTimersByTimeAsync(29_999);
+    before.socket.emitMessage(
+      JSON.stringify({ jsonrpc: "2.0", id: 1, result: { hasSession: true } }),
+    );
+    await expect(winning).resolves.toEqual({ hasSession: true });
+    await vi.advanceTimersByTimeAsync(1);
+    expect(before.socket.closeCalls).toEqual([]);
+    before.socket.closeSynchronously = true;
+    await beforeClient.close();
+
+    const terminal = vi.fn();
+    const exact = acceptedSocket("service-managed", { onTerminal: terminal });
+    const exactClient = await exact.connecting;
+    exact.socket.sendHook = () => {};
+    const timedOut = exactClient
+      .call("hasSession", { chatId: "chat-2" })
+      .catch((error: unknown) => error);
+    await vi.advanceTimersByTimeAsync(30_000);
+    const timeout = await timedOut;
+    exact.socket.emitMessage(
+      JSON.stringify({ jsonrpc: "2.0", id: 1, result: { hasSession: true } }),
+    );
+    expect(timeout).toBeInstanceOf(CoachClientCallTimeoutError);
+    expect(terminal).toHaveBeenCalledExactlyOnceWith(exactClient, timeout);
+    expect(exact.socket.closeCalls).toHaveLength(1);
+  });
+
+  it("does not slide the self-test deadline when valid progress keeps arriving", async () => {
+    vi.useFakeTimers();
+    const { socket, connecting } = acceptedSocket();
+    const client = await connecting;
+    socket.sendHook = () => {};
+    const progress = vi.fn();
+    const call = client
+      .call("selfTest", {}, { onEvent: progress })
+      .catch((error: unknown) => error);
+    for (let elapsed = 30_000; elapsed < 120_000; elapsed += 30_000) {
+      await vi.advanceTimersByTimeAsync(30_000);
+      socket.emitMessage(
+        serializeCoachRpcEnvelope({
+          jsonrpc: "2.0",
+          method: "coach.operationProgress",
+          params: {
+            requestId: 1,
+            requestMethod: "selfTest",
+            event: { phase: "started", completed: 0, total: 1 },
+          },
+        }),
+      );
+    }
+    await vi.advanceTimersByTimeAsync(30_000);
+    await expect(call).resolves.toBeInstanceOf(CoachClientCallTimeoutError);
+    expect(progress).toHaveBeenCalledTimes(3);
+    expect(socket.closeCalls).toHaveLength(1);
+  });
+
+  it("latches one mid-flight abort across pending and future calls without replay", async () => {
+    const observer = vi.fn(() => {
+      throw new Error("advisory");
+    });
+    const { socket, connecting } = acceptedSocket("service-managed", { onTerminal: observer });
+    const client = await connecting;
+    socket.sent.length = 0;
+    socket.sendHook = () => {};
+    const controller = new AbortController();
+    const secondController = new AbortController();
+    const firstRemove = vi.spyOn(controller.signal, "removeEventListener");
+    const secondRemove = vi.spyOn(secondController.signal, "removeEventListener");
+    const terminalEnvelope = vi.fn();
+    const first = client
+      .call(
+        "chat",
+        { chatId: "chat-1", message: "one" },
+        {
+          signal: controller.signal,
+          onTerminalEnvelope: terminalEnvelope,
+        },
+      )
+      .catch((error: unknown) => error);
+    const second = client
+      .call("hasSession", { chatId: "chat-2" }, { signal: secondController.signal })
+      .catch((error: unknown) => error);
+    controller.abort(new Error("private abort detail"));
+    const [a, b] = await Promise.all([first, second]);
+
+    expect(a).toBeInstanceOf(CoachClientCallAbortedError);
+    expect(a).toMatchObject({ method: "chat", message: "Coach client call aborted" });
+    expect(String(a)).not.toContain("private abort detail");
+    expect(b).toBe(a);
+    await expect(client.call("hasSession", { chatId: "future" })).rejects.toBe(a);
+    expect(observer).toHaveBeenCalledExactlyOnceWith(client, a);
+    expect(terminalEnvelope).not.toHaveBeenCalled();
+    expect(firstRemove).toHaveBeenCalledWith("abort", expect.any(Function));
+    expect(secondRemove).toHaveBeenCalledWith("abort", expect.any(Function));
+    expect(socket.closeCalls).toHaveLength(1);
+    expect(socket.sent).toHaveLength(2);
+    socket.emitMessage(JSON.stringify({ jsonrpc: "2.0", id: 1, result: { text: "late" } }));
+    expect(observer).toHaveBeenCalledTimes(1);
+    expect(socket.sent).toHaveLength(2);
+  });
+
+  it("clears queued sends and fans one timeout cause to all pending and future calls", async () => {
+    vi.useFakeTimers();
+    const observer = vi.fn();
+    const { socket, connecting } = acceptedSocket("service-managed", { onTerminal: observer });
+    const client = await connecting;
+    socket.sent.length = 0;
+    socket.bufferedAmount = 1_048_576;
+    const firstController = new AbortController();
+    const secondController = new AbortController();
+    const firstRemove = vi.spyOn(firstController.signal, "removeEventListener");
+    const secondRemove = vi.spyOn(secondController.signal, "removeEventListener");
+    const first = client
+      .call("hasSession", { chatId: "chat-1" }, { signal: firstController.signal })
+      .catch((error: unknown) => error);
+    const second = client
+      .call(
+        "chat",
+        { chatId: "chat-2", message: "queued" },
+        {
+          signal: secondController.signal,
+        },
+      )
+      .catch((error: unknown) => error);
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    const [a, b] = await Promise.all([first, second]);
+
+    expect(a).toBeInstanceOf(CoachClientCallTimeoutError);
+    expect(a).toMatchObject({ method: "hasSession", timeoutMs: 30_000 });
+    expect(b).toBe(a);
+    await expect(client.call("hasSession", { chatId: "future" })).rejects.toBe(a);
+    expect(observer).toHaveBeenCalledExactlyOnceWith(client, a);
+    expect(firstRemove).toHaveBeenCalledWith("abort", expect.any(Function));
+    expect(secondRemove).toHaveBeenCalledWith("abort", expect.any(Function));
+    expect(socket.closeCalls).toHaveLength(1);
+    socket.bufferedAmount = 0;
+    await vi.advanceTimersByTimeAsync(100);
+    expect(socket.sent).toEqual([]);
+    socket.emitMessage(JSON.stringify({ jsonrpc: "2.0", id: 1, result: { hasSession: true } }));
+    expect(observer).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(["success", "remote-error"] as const)(
+    "cleans the call deadline and abort listener before %s terminal observation",
+    async (kind) => {
+      vi.useFakeTimers();
+      const connectionTerminal = vi.fn();
+      const { socket, connecting } = acceptedSocket("service-managed", {
+        onTerminal: connectionTerminal,
+      });
+      const client = await connecting;
+      const controller = new AbortController();
+      const remove = vi.spyOn(controller.signal, "removeEventListener");
+      socket.sendHook = () => {};
+      const call = client
+        .call(
+          "hasSession",
+          { chatId: "chat-1" },
+          {
+            signal: controller.signal,
+            onTerminalEnvelope: () => controller.abort(),
+          },
+        )
+        .catch((error: unknown) => error);
+      socket.emitMessage(
+        JSON.stringify(
+          kind === "success"
+            ? { jsonrpc: "2.0", id: 1, result: { hasSession: true } }
+            : { jsonrpc: "2.0", id: 1, error: { code: -32600, message: "remote" } },
+        ),
+      );
+      const outcome = await call;
+      if (kind === "success") expect(outcome).toEqual({ hasSession: true });
+      else expect(outcome).toBeInstanceOf(CoachRpcRemoteError);
+      expect(remove).toHaveBeenCalledWith("abort", expect.any(Function));
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(connectionTerminal).not.toHaveBeenCalled();
+      expect(socket.closeCalls).toEqual([]);
+      socket.closeSynchronously = true;
+      await client.close();
+    },
+  );
+
+  it("uses one first cause for socket error and later close while cleaning call listeners", async () => {
+    const observer = vi.fn();
+    const { socket, connecting } = acceptedSocket("service-managed", { onTerminal: observer });
+    const client = await connecting;
+    const controller = new AbortController();
+    const remove = vi.spyOn(controller.signal, "removeEventListener");
+    socket.sendHook = () => {};
+    const call = client
+      .call("hasSession", { chatId: "chat-1" }, { signal: controller.signal })
+      .catch((error: unknown) => error);
+    socket.emitError();
+    const cause = await call;
+    socket.emitClose(1006, "later close");
+    controller.abort();
+
+    expect(cause).toBeInstanceOf(CoachClientDisconnectedError);
+    expect(cause).toMatchObject({ code: 1006, reason: "" });
+    expect(observer).toHaveBeenCalledExactlyOnceWith(client, cause);
+    expect(remove).toHaveBeenCalledWith("abort", expect.any(Function));
+    expect(socket.closeCalls).toHaveLength(1);
+    await expect(client.call("hasSession", { chatId: "future" })).rejects.toBe(cause);
+  });
+
+  it("fans an unexpected disconnect to every pending and future call", async () => {
+    const observer = vi.fn();
+    const { socket, connecting } = acceptedSocket("service-managed", { onTerminal: observer });
     const client = await connecting;
     socket.sendHook = () => {};
     const terminal = vi.fn();
@@ -1053,16 +1455,26 @@ describe("disconnect, close, and send bounds", () => {
     });
     expect(second).toBe(first);
     expect(terminal).not.toHaveBeenCalled();
+    expect(observer).toHaveBeenCalledExactlyOnceWith(client, first);
     await expect(client.call("hasSession", { chatId: "chat-1" })).rejects.toBe(first);
+    socket.emitError();
+    expect(observer).toHaveBeenCalledTimes(1);
     await client.close();
   });
 
   it("explicit close is idempotent, settles pending, and handles synchronous close", async () => {
-    const { socket, connecting } = acceptedSocket();
+    const observer = vi.fn();
+    const { socket, connecting } = acceptedSocket("service-managed", { onTerminal: observer });
     const client = await connecting;
     socket.sendHook = () => {};
     socket.closeSynchronously = true;
-    const pending = client.call("chat", { chatId: "chat-1", message: "one" });
+    const controller = new AbortController();
+    const remove = vi.spyOn(controller.signal, "removeEventListener");
+    const pending = client.call(
+      "chat",
+      { chatId: "chat-1", message: "one" },
+      { signal: controller.signal },
+    );
     const first = client.close(1000, "done");
     const second = client.close(1001, "ignored");
     expect(first).toBe(second);
@@ -1074,6 +1486,10 @@ describe("disconnect, close, and send bounds", () => {
     });
     await expect(first).resolves.toBeUndefined();
     expect(socket.closeCalls).toHaveLength(1);
+    expect(observer).toHaveBeenCalledExactlyOnceWith(client, error);
+    expect(remove).toHaveBeenCalledWith("abort", expect.any(Function));
+    controller.abort();
+    expect(observer).toHaveBeenCalledTimes(1);
   });
 
   it("resolves explicit close at its bounded timeout when no event arrives", async () => {
@@ -1167,6 +1583,9 @@ describe("disconnect, close, and send bounds", () => {
 
 describe("public observer types", () => {
   it("exports the generic observers and excludes null-id protocol terminals", () => {
+    expectTypeOf<CoachClientCallOptions<"chat">["signal"]>().toEqualTypeOf<
+      AbortSignal | undefined
+    >();
     expectTypeOf<CoachClientCallOptions<"chat">["onNotificationEnvelope"]>().toEqualTypeOf<
       ((envelope: CoachTurnEventNotificationEnvelope) => void) | undefined
     >();


### PR DESCRIPTION
## Summary

- add finite, method-specific absolute deadlines and optional abort signals to every coach RPC
- retire ambiguous stalled connections once, clean pending resources, and lazily recover the exact failed Desktop daemon generation without replaying requests
- preserve interrupted chat drafts and map timeout/abort outcomes safely in the CLI and packaged self-test

## Validation

- `pnpm --filter @enduragent/coach-client test` — 87 passed
- focused Desktop renderer suites — 23 passed
- focused CLI/self-test suites — 20 passed
- `pnpm check` — passed with the nine pre-existing warnings
- `pnpm test` — 4,951 passed, 6 skipped; the known spend-meter integration timing test hit its 5-second ceiling and passed immediately in isolation
- three fresh read-only final reviews — concurrency, recovery, and release-quality lenses all passed with zero blockers
