### PR TITLE
feat(desktop): add new conversation flow

### DIFF
--- a/.changeset/fresh-desktop-conversation.md
+++ b/.changeset/fresh-desktop-conversation.md
@@ -1,0 +1,5 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Desktop athletes can now start a fresh coaching conversation while keeping training data and saved coach memory.

--- a/apps/desktop-renderer/src/chat/controller.ts
+++ b/apps/desktop-renderer/src/chat/controller.ts
@@ -10,6 +10,7 @@ import type { DesktopCoachClientProvider } from "../coach-client.js";
 import {
   DESKTOP_CHAT_ID,
   EMPTY_CHAT_STATE,
+  hasClearableConversation,
   reduceChatState,
   type ChatState,
 } from "../turn-state.js";
@@ -19,15 +20,35 @@ export const CHAT_CONNECTION_INTERRUPTED_COPY =
 export const CHAT_PROTOCOL_FAILURE_COPY =
   "The coaching response could not be verified. Please try again.";
 export const CHAT_FAILURE_COPY = "The coach couldn't respond. Please try again.";
+export const NEW_CONVERSATION_SUCCESS_COPY = "New conversation started.";
+export const NEW_CONVERSATION_MEMORY_WARNING_COPY =
+  "New conversation started. Some recent details may not have been saved to coach memory.";
+export const NEW_CONVERSATION_UNCERTAIN_COPY =
+  "We couldn’t confirm whether the new conversation started. Your visible conversation is preserved.";
+
+export interface ChatViewControls {
+  readonly newConversationDisabled: boolean;
+  readonly workBlocked: boolean;
+}
 
 export interface ChatView {
-  render(state: ChatState): void;
+  render(state: ChatState, controls?: ChatViewControls): void;
 }
 
 export interface ChatController {
+  start(): Promise<void>;
   submit(message: string): Promise<void>;
   retryInterrupted(): Promise<void>;
+  openNewConversation(): boolean;
+  cancelNewConversation(): void;
+  confirmNewConversation(): Promise<void>;
   dispose(): void;
+}
+
+interface QueuedRetry {
+  readonly requestKey: number;
+  readonly promise: Promise<void>;
+  readonly token: object;
 }
 
 export function createChatController(input: {
@@ -40,14 +61,32 @@ export function createChatController(input: {
   let sequence = 0;
   let disposed = false;
   let activeTask: Promise<void> | undefined;
-  let queuedRetry: Promise<void> | undefined;
+  const outstandingChatTasks = new Set<Promise<void>>();
+  let queuedRetry: QueuedRetry | undefined;
   let retryClient: CoachClient | undefined;
+  let probeTask: Promise<void> | undefined;
+  let resetTask: Promise<void> | undefined;
+  let epoch = 0;
 
   const nextId = (prefix: "request" | "message"): string => `${prefix}-${++sequence}`;
+  const resetBlocksWork = (): boolean =>
+    state.session.resetPhase === "confirming" || state.session.resetPhase === "resetting";
+  const canOpenNewConversation = (): boolean =>
+    !disposed &&
+    hasClearableConversation(state) &&
+    state.session.resetPhase === "idle" &&
+    state.status !== "streaming" &&
+    activeTask === undefined &&
+    outstandingChatTasks.size === 0 &&
+    queuedRetry === undefined &&
+    resetTask === undefined;
   const render = (): void => {
     if (disposed) return;
     try {
-      input.view.render(state);
+      input.view.render(state, {
+        newConversationDisabled: !canOpenNewConversation(),
+        workBlocked: resetBlocksWork(),
+      });
     } catch {}
   };
   const reduce = (action: Parameters<typeof reduceChatState>[1]): void => {
@@ -56,6 +95,7 @@ export function createChatController(input: {
   };
 
   const run = (userMessage: string, includeUser: boolean, reconnect: boolean): Promise<void> => {
+    epoch += 1;
     const requestKey = Number(nextId("request").slice("request-".length));
     const userMessageId = nextId("message");
     const assistantMessageId = nextId("message");
@@ -198,41 +238,127 @@ export function createChatController(input: {
       }
     })();
     activeTask = task;
+    outstandingChatTasks.add(task);
+    render();
     void task.finally(() => {
-      if (activeTask === task) activeTask = undefined;
+      const released = outstandingChatTasks.delete(task);
+      if (activeTask === task) {
+        activeTask = undefined;
+      }
+      if (released) render();
     });
     return task;
   };
 
   render();
   return {
+    start() {
+      if (probeTask !== undefined) return probeTask;
+      const probeEpoch = epoch;
+      const task = (async () => {
+        try {
+          const client = await input.clients.getClient();
+          const result = await client.call("hasSession", { chatId: DESKTOP_CHAT_ID });
+          if (disposed || epoch !== probeEpoch) return;
+          reduce({ type: "session-probe", hasSession: result.hasSession });
+        } catch {}
+      })();
+      probeTask = task;
+      return task;
+    },
     submit(message) {
-      if (!/\S/u.test(message) || disposed || state.status === "streaming") {
+      if (!/\S/u.test(message) || disposed || state.status === "streaming" || resetBlocksWork()) {
         return activeTask ?? Promise.resolve();
       }
       return run(message, true, false);
     },
     retryInterrupted() {
-      if (disposed || state.status !== "interrupted" || state.activeTurn === null) {
+      if (
+        disposed ||
+        state.status !== "interrupted" ||
+        state.activeTurn === null ||
+        resetBlocksWork()
+      ) {
         return activeTask ?? Promise.resolve();
       }
-      if (queuedRetry !== undefined) return queuedRetry;
-      const userMessage = state.activeTurn.userMessage;
+      const { requestKey, userMessage } = state.activeTurn;
+      if (queuedRetry?.requestKey === requestKey) return queuedRetry.promise;
       if (activeTask === undefined) return run(userMessage, false, true);
       const currentTask = activeTask;
+      const token = {};
       const pending = currentTask
         .then(() => {
-          if (disposed || state.status !== "interrupted") return;
+          if (
+            disposed ||
+            state.status !== "interrupted" ||
+            state.activeTurn?.requestKey !== requestKey
+          ) {
+            return;
+          }
           return run(userMessage, false, true);
         })
         .finally(() => {
-          if (queuedRetry === pending) queuedRetry = undefined;
+          if (queuedRetry?.token === token) {
+            queuedRetry = undefined;
+            render();
+          }
         });
-      queuedRetry = pending;
+      queuedRetry = { requestKey, promise: pending, token };
+      render();
       return pending;
+    },
+    openNewConversation() {
+      if (!canOpenNewConversation()) return false;
+      epoch += 1;
+      reduce({ type: "open-new-conversation" });
+      return true;
+    },
+    cancelNewConversation() {
+      if (disposed || state.session.resetPhase !== "confirming") return;
+      reduce({ type: "cancel-new-conversation" });
+    },
+    confirmNewConversation() {
+      if (resetTask !== undefined) return resetTask;
+      if (disposed || state.session.resetPhase !== "confirming") return Promise.resolve();
+      reduce({ type: "begin-reset" });
+      const resetEpoch = ++epoch;
+      const task = (async () => {
+        try {
+          const client = await input.clients.getClient();
+          const result = await client.call("resetSession", { chatId: DESKTOP_CHAT_ID });
+          if (disposed || epoch !== resetEpoch) return;
+          sequence += 1;
+          retryClient = undefined;
+          queuedRetry = undefined;
+          reduce({
+            type: "reset-succeeded",
+            announcement: result.memoryFlushed
+              ? NEW_CONVERSATION_SUCCESS_COPY
+              : NEW_CONVERSATION_MEMORY_WARNING_COPY,
+          });
+        } catch {
+          if (disposed || epoch !== resetEpoch) return;
+          reduce({ type: "reset-failed", announcement: NEW_CONVERSATION_UNCERTAIN_COPY });
+        } finally {
+          if (!disposed && epoch === resetEpoch) {
+            try {
+              void input.refreshSpend().catch(() => {});
+            } catch {}
+          }
+        }
+      })();
+      resetTask = task;
+      void task.finally(() => {
+        if (resetTask === task) {
+          resetTask = undefined;
+          render();
+        }
+      });
+      return task;
     },
     dispose() {
       disposed = true;
+      epoch += 1;
       sequence += 1;
     },
   };

--- a/apps/desktop-renderer/src/chat/styles.css
+++ b/apps/desktop-renderer/src/chat/styles.css
@@ -66,6 +66,99 @@
   cursor: pointer;
 }
 
+.new-conversation-button {
+  min-height: 34px;
+  padding: 0 13px;
+  white-space: nowrap;
+  border: 1px solid var(--line-strong);
+  border-radius: 999px;
+  color: var(--moss-strong);
+  background: var(--surface-solid);
+  cursor: pointer;
+}
+
+.new-conversation-button:disabled,
+.chat-retry:disabled {
+  cursor: default;
+  opacity: 0.5;
+}
+
+.new-conversation-button[aria-disabled="true"] {
+  border-color: var(--muted);
+  color: var(--muted);
+  cursor: default;
+  opacity: 1;
+}
+
+.new-conversation-dialog {
+  width: min(460px, calc(100vw - 32px));
+  max-width: none;
+  padding: 24px;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius);
+  color: var(--ink);
+  background: var(--surface-solid);
+  box-shadow: 0 24px 70px color-mix(in srgb, var(--ink) 24%, transparent);
+}
+
+.new-conversation-dialog::backdrop {
+  background: color-mix(in srgb, var(--ink) 35%, transparent);
+}
+
+.new-conversation-dialog h2,
+.new-conversation-dialog p,
+.new-conversation-status {
+  margin: 0;
+}
+
+.new-conversation-dialog h2 {
+  font-size: 20px;
+}
+
+.new-conversation-dialog p {
+  margin-top: 10px;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.new-conversation-dialog__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-top: 22px;
+}
+
+.new-conversation-dialog__actions button {
+  min-height: 38px;
+  padding: 0 15px;
+  border: 1px solid var(--line-strong);
+  border-radius: 999px;
+  color: var(--ink);
+  background: var(--surface-solid);
+  cursor: pointer;
+}
+
+.new-conversation-dialog__actions .new-conversation-dialog__confirm {
+  border-color: var(--moss-strong);
+  color: var(--canvas);
+  background: var(--moss-strong);
+}
+
+.new-conversation-dialog__actions button:disabled {
+  cursor: default;
+  opacity: 0.5;
+}
+
+.new-conversation-status {
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.new-conversation-status:not(:empty) {
+  padding: 0 14px 8px;
+}
+
 .chat-composer__label {
   display: block;
   margin: 0 0 7px 14px;

--- a/apps/desktop-renderer/src/chat/view.ts
+++ b/apps/desktop-renderer/src/chat/view.ts
@@ -1,9 +1,18 @@
 import type { ChatView } from "./controller.js";
+import type { ChatTranscriptMessage } from "../turn-state.js";
+
+type RenderedMessage = Pick<ChatTranscriptMessage, "role" | "text" | "delivery">;
 
 export interface MountedChatView {
   readonly view: ChatView;
   readonly noticeHost: HTMLElement;
-  bind(input: { readonly onSubmit: (message: string) => void; readonly onRetry: () => void }): void;
+  bind(input: {
+    readonly onSubmit: (message: string) => void;
+    readonly onRetry: () => void;
+    readonly onOpenNewConversation: () => void;
+    readonly onCancelNewConversation: () => void;
+    readonly onConfirmNewConversation: () => void;
+  }): void;
   dispose(): void;
 }
 
@@ -11,7 +20,39 @@ export function mountChatView(input: {
   readonly conversation: HTMLElement;
   readonly thread: HTMLElement;
   readonly composerHost: HTMLElement;
+  readonly actionHost?: HTMLElement;
 }): MountedChatView {
+  const actionHost = input.actionHost ?? document.createElement("div");
+  const newConversation = document.createElement("button");
+  newConversation.type = "button";
+  newConversation.className = "new-conversation-button";
+  newConversation.textContent = "New conversation";
+  const dialog = document.createElement("dialog");
+  dialog.className = "new-conversation-dialog";
+  dialog.setAttribute("aria-labelledby", "new-conversation-title");
+  dialog.setAttribute("aria-describedby", "new-conversation-description");
+  dialog.setAttribute("aria-modal", "true");
+  const dialogTitle = document.createElement("h2");
+  dialogTitle.id = "new-conversation-title";
+  dialogTitle.textContent = "Start a new conversation?";
+  const dialogDescription = document.createElement("p");
+  dialogDescription.id = "new-conversation-description";
+  dialogDescription.textContent =
+    "Your visible conversation will be cleared. Your training data and saved coach memory will remain.";
+  const dialogActions = document.createElement("div");
+  dialogActions.className = "new-conversation-dialog__actions";
+  const cancelReset = document.createElement("button");
+  cancelReset.type = "button";
+  cancelReset.textContent = "Cancel";
+  const confirmReset = document.createElement("button");
+  confirmReset.type = "button";
+  confirmReset.className = "new-conversation-dialog__confirm";
+  confirmReset.textContent = "Start new conversation";
+  dialogActions.append(cancelReset, confirmReset);
+  dialog.append(dialogTitle, dialogDescription, dialogActions);
+  actionHost.insertBefore(newConversation, actionHost.firstChild);
+  actionHost.append(dialog);
+
   const transcript = document.createElement("section");
   transcript.className = "chat-transcript";
   transcript.setAttribute("role", "log");
@@ -35,6 +76,11 @@ export function mountChatView(input: {
   form.className = "composer";
   const noticeHost = document.createElement("div");
   noticeHost.className = "chat-notice-host";
+  const resetStatus = document.createElement("p");
+  resetStatus.className = "new-conversation-status";
+  resetStatus.setAttribute("role", "status");
+  resetStatus.setAttribute("aria-live", "polite");
+  noticeHost.append(resetStatus);
   const label = document.createElement("label");
   label.className = "chat-composer__label";
   label.htmlFor = "message";
@@ -53,9 +99,19 @@ export function mountChatView(input: {
   input.composerHost.append(noticeHost, form);
 
   let handlers:
-    | { readonly onSubmit: (message: string) => void; readonly onRetry: () => void }
+    | {
+        readonly onSubmit: (message: string) => void;
+        readonly onRetry: () => void;
+        readonly onOpenNewConversation: () => void;
+        readonly onCancelNewConversation: () => void;
+        readonly onConfirmNewConversation: () => void;
+      }
     | undefined;
   let disposed = false;
+  let renderedResetCount = 0;
+  let renderedAnnouncement: string | null = null;
+  let renderedMessages: readonly RenderedMessage[] = [];
+  let renderedNotice: string | null = null;
 
   const onSubmit = (event: SubmitEvent): void => {
     event.preventDefault();
@@ -72,23 +128,95 @@ export function mountChatView(input: {
     }
   };
   const onRetry = (): void => handlers?.onRetry();
+  const onOpenNewConversation = (): void => {
+    if (newConversation.disabled || newConversation.getAttribute("aria-disabled") === "true")
+      return;
+    handlers?.onOpenNewConversation();
+  };
+  const onCancelNewConversation = (): void => handlers?.onCancelNewConversation();
+  const onConfirmNewConversation = (): void => handlers?.onConfirmNewConversation();
+  const onDialogCancel = (event: Event): void => {
+    event.preventDefault();
+    if (!cancelReset.disabled) handlers?.onCancelNewConversation();
+  };
   form.addEventListener("submit", onSubmit);
   textarea.addEventListener("keydown", onKeydown);
   retry.addEventListener("click", onRetry);
+  newConversation.addEventListener("click", onOpenNewConversation);
+  cancelReset.addEventListener("click", onCancelNewConversation);
+  confirmReset.addEventListener("click", onConfirmNewConversation);
+  dialog.addEventListener("cancel", onDialogCancel);
 
   return {
     noticeHost,
     view: {
-      render(state) {
+      render(state, controls) {
         if (disposed) return;
+        const workBlocked =
+          controls?.workBlocked ??
+          (state.session.resetPhase === "confirming" || state.session.resetPhase === "resetting");
+        const newConversationUnavailable =
+          controls?.newConversationDisabled ??
+          (state.session.presence !== "present" ||
+            state.session.resetPhase !== "idle" ||
+            state.status === "streaming");
+        const focusableUncertainOpener =
+          newConversationUnavailable && state.session.resetPhase === "uncertain";
+        newConversation.disabled = newConversationUnavailable && !focusableUncertainOpener;
+        if (focusableUncertainOpener) newConversation.setAttribute("aria-disabled", "true");
+        else newConversation.removeAttribute("aria-disabled");
+        const resetPending = state.session.resetPhase === "resetting";
+        if (resetPending) dialog.setAttribute("aria-busy", "true");
+        else dialog.removeAttribute("aria-busy");
+        cancelReset.disabled = resetPending;
+        confirmReset.disabled = resetPending;
+        retry.disabled = workBlocked;
+        submit.disabled = state.status === "streaming" || workBlocked;
+        textarea.disabled = state.status === "streaming" || workBlocked;
+        const dialogRequested =
+          state.session.resetPhase === "confirming" || state.session.resetPhase === "resetting";
+        const resetCompleted = state.session.resetCount !== renderedResetCount;
+        if (dialogRequested && !dialog.open) {
+          dialog.showModal();
+          cancelReset.focus();
+        } else if (!dialogRequested && dialog.open) {
+          dialog.close();
+          if (resetCompleted) {
+            textarea.value = "";
+            textarea.focus();
+          } else {
+            newConversation.focus();
+          }
+        } else if (resetCompleted) {
+          textarea.value = "";
+          textarea.focus();
+        }
+        renderedResetCount = state.session.resetCount;
+        if (state.session.announcement !== renderedAnnouncement) {
+          renderedAnnouncement = state.session.announcement;
+          resetStatus.textContent = renderedAnnouncement ?? "";
+        }
         const followsLatest =
           input.conversation.scrollHeight -
             input.conversation.scrollTop -
             input.conversation.clientHeight <=
           80;
-        const rows = state.messages
+        const nextMessages = state.messages
           .filter((message) => message.role === "athlete" || message.text.length > 0)
-          .map((message) => {
+          .map(({ role, text, delivery }) => ({ role, text, delivery }));
+        const messagesChanged =
+          nextMessages.length !== renderedMessages.length ||
+          nextMessages.some((message, index) => {
+            const rendered = renderedMessages[index];
+            return (
+              rendered === undefined ||
+              message.role !== rendered.role ||
+              message.text !== rendered.text ||
+              message.delivery !== rendered.delivery
+            );
+          });
+        if (messagesChanged) {
+          const rows = nextMessages.map((message) => {
             const article = document.createElement("article");
             article.className = `chat-message chat-message--${message.role}`;
             article.dataset.delivery = message.delivery;
@@ -101,15 +229,18 @@ export function mountChatView(input: {
             article.append(role, text);
             return article;
           });
-        messages.replaceChildren(...rows);
+          messages.replaceChildren(...rows);
+          renderedMessages = nextMessages;
+        }
         if (followsLatest) input.conversation.scrollTop = input.conversation.scrollHeight;
         const contractCopy = state.activeTurn?.error?.athleteMessage ?? null;
         const visibleNotice = contractCopy ?? state.progress;
         notice.hidden = visibleNotice === null;
-        notice.textContent = visibleNotice ?? "";
+        if (visibleNotice !== renderedNotice) {
+          renderedNotice = visibleNotice;
+          notice.textContent = renderedNotice ?? "";
+        }
         retry.hidden = state.status !== "interrupted";
-        submit.disabled = state.status === "streaming";
-        textarea.disabled = state.status === "streaming";
         input.conversation.dataset.chatStatus = state.status;
       },
     },
@@ -123,7 +254,16 @@ export function mountChatView(input: {
       form.removeEventListener("submit", onSubmit);
       textarea.removeEventListener("keydown", onKeydown);
       retry.removeEventListener("click", onRetry);
+      newConversation.removeEventListener("click", onOpenNewConversation);
+      cancelReset.removeEventListener("click", onCancelNewConversation);
+      confirmReset.removeEventListener("click", onConfirmNewConversation);
+      dialog.removeEventListener("cancel", onDialogCancel);
+      if (dialog.open) dialog.close();
+      transcript.remove();
+      form.remove();
       noticeHost.remove();
+      newConversation.remove();
+      dialog.remove();
     },
   };
 }

--- a/apps/desktop-renderer/src/index.ts
+++ b/apps/desktop-renderer/src/index.ts
@@ -36,11 +36,14 @@ const topbar = one(".topbar", HTMLElement);
 const spendRoot = one(".spend-meter", HTMLElement);
 conversation.classList.add("desktop-shell");
 
+const topbarActions = document.createElement("div");
+topbarActions.className = "topbar-actions";
+topbar.insertBefore(topbarActions, spendRoot);
 const connectionStatus = document.createElement("span");
 connectionStatus.className = "connection-status";
 connectionStatus.setAttribute("role", "status");
 connectionStatus.textContent = "Connecting…";
-topbar.insertBefore(connectionStatus, topbar.lastElementChild);
+topbarActions.append(connectionStatus, spendRoot);
 window.addEventListener("enduragent-lifecycle", (event) => {
   document.documentElement.dataset.rpc = event.detail.status;
   connectionStatus.textContent =
@@ -64,7 +67,12 @@ const trainingContextController = createTrainingContextController({
   clients,
   view: mountedTrainingContext.view,
 });
-const mountedChat = mountChatView({ conversation, thread, composerHost });
+const mountedChat = mountChatView({
+  conversation,
+  thread,
+  composerHost,
+  actionHost: topbarActions,
+});
 const spendController = createSpendMeterController({
   clients,
   view: createSpendMeterView({ root: spendRoot, noticeHost: mountedChat.noticeHost }),
@@ -79,6 +87,9 @@ const chatController = createChatController({
 mountedChat.bind({
   onSubmit: (message) => void chatController.submit(message),
   onRetry: () => void chatController.retryInterrupted(),
+  onOpenNewConversation: () => void chatController.openNewConversation(),
+  onCancelNewConversation: () => chatController.cancelNewConversation(),
+  onConfirmNewConversation: () => void chatController.confirmNewConversation(),
 });
 mountedTrainingContext.bind({
   onUnitsPreferenceChange: (value) => void trainingContextController.setUnitsPreference(value),
@@ -227,7 +238,7 @@ const setup = document.createElement("button");
 setup.type = "button";
 setup.className = "setup-button";
 setup.textContent = "Setup";
-topbar.insertBefore(setup, topbar.lastElementChild);
+topbarActions.insertBefore(setup, connectionStatus);
 const onboarding = mountOnboarding({
   document,
   bridge: onboardingBridge,
@@ -238,6 +249,7 @@ setup.addEventListener("click", () => void onboarding.open());
 
 void trainingContextController.start();
 spendController.start();
+void chatController.start();
 void onboarding.open();
 void clients.getClient().then(
   () => {

--- a/apps/desktop-renderer/src/styles.css
+++ b/apps/desktop-renderer/src/styles.css
@@ -15,7 +15,7 @@
   --moss-soft: #e5eee8;
   --coral: #c96d58;
   --radius: 16px;
-  --focus: #7ba589;
+  --focus: #1e5a3d;
 }
 
 * {
@@ -64,10 +64,27 @@ input:focus-visible {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 18px;
+  min-width: 0;
   padding: 0 28px;
   border-bottom: 1px solid var(--line);
   background: color-mix(in srgb, var(--canvas) 88%, transparent);
   min-height: 54px;
+}
+
+.topbar-actions {
+  display: flex;
+  flex: 1;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px;
+  min-width: 0;
+}
+
+.connection-status {
+  color: var(--muted);
+  font-size: 12px;
+  white-space: nowrap;
 }
 
 .brand {
@@ -243,11 +260,27 @@ input:focus-visible {
     --moss-strong: #9cc8aa;
     --moss-soft: #263a2e;
     --coral: #df8a75;
-    --focus: #93b9a0;
+    --focus: #9cc8aa;
   }
 }
 
 @media (max-width: 760px) {
+  .topbar {
+    gap: 10px;
+    padding-right: 14px;
+    padding-left: 14px;
+  }
+
+  .topbar-actions {
+    gap: 6px;
+  }
+
+  .new-conversation-button,
+  .setup-button {
+    padding-right: 9px;
+    padding-left: 9px;
+  }
+
   .thread {
     width: calc(100% - 32px);
   }

--- a/apps/desktop-renderer/src/turn-state.ts
+++ b/apps/desktop-renderer/src/turn-state.ts
@@ -3,6 +3,15 @@ import type { TurnEvent } from "@enduragent/coach-contract";
 export const DESKTOP_CHAT_ID = "desktop" as const;
 
 export type ChatStatus = "idle" | "streaming" | "interrupted";
+export type SessionPresence = "unknown" | "absent" | "present";
+export type SessionResetPhase = "idle" | "confirming" | "resetting" | "uncertain";
+
+export interface ChatSessionState {
+  readonly presence: SessionPresence;
+  readonly resetPhase: SessionResetPhase;
+  readonly resetCount: number;
+  readonly announcement: string | null;
+}
 
 export interface ChatErrorView {
   readonly kind: Extract<TurnEvent, { type: "error" }>["kind"];
@@ -31,6 +40,7 @@ export interface ChatState {
   readonly messages: readonly ChatTranscriptMessage[];
   readonly activeTurn: ActiveTurn | null;
   readonly progress: string | null;
+  readonly session: ChatSessionState;
 }
 
 export const EMPTY_CHAT_STATE: ChatState = {
@@ -38,6 +48,12 @@ export const EMPTY_CHAT_STATE: ChatState = {
   messages: [],
   activeTurn: null,
   progress: null,
+  session: {
+    presence: "unknown",
+    resetPhase: "idle",
+    resetCount: 0,
+    announcement: null,
+  },
 };
 
 export type ChatAction =
@@ -53,7 +69,13 @@ export type ChatAction =
   | { readonly type: "event"; readonly requestKey: number; readonly event: TurnEvent }
   | { readonly type: "complete"; readonly requestKey: number }
   | { readonly type: "interrupt"; readonly requestKey: number; readonly copy: string }
-  | { readonly type: "fail"; readonly requestKey: number; readonly copy: string };
+  | { readonly type: "fail"; readonly requestKey: number; readonly copy: string }
+  | { readonly type: "session-probe"; readonly hasSession: boolean }
+  | { readonly type: "open-new-conversation" }
+  | { readonly type: "cancel-new-conversation" }
+  | { readonly type: "begin-reset" }
+  | { readonly type: "reset-succeeded"; readonly announcement: string }
+  | { readonly type: "reset-failed"; readonly announcement: string };
 
 function current(state: ChatState, requestKey: number): ActiveTurn | null {
   return state.activeTurn?.requestKey === requestKey ? state.activeTurn : null;
@@ -72,6 +94,13 @@ function updateAssistant(
 
 function assertNever(value: never): never {
   throw new TypeError(`Unhandled chat action: ${String(value)}`);
+}
+
+export function hasClearableConversation(state: ChatState): boolean {
+  return (
+    state.session.presence === "present" ||
+    state.messages.some((message) => message.role === "athlete" || /\S/u.test(message.text))
+  );
 }
 
 export function reduceChatState(state: ChatState, action: ChatAction): ChatState {
@@ -100,6 +129,7 @@ export function reduceChatState(state: ChatState, action: ChatAction): ChatState
         status: "streaming",
         messages,
         progress: null,
+        session: { ...state.session, announcement: null },
         activeTurn: {
           requestKey: action.requestKey,
           turnId: null,
@@ -163,6 +193,7 @@ export function reduceChatState(state: ChatState, action: ChatAction): ChatState
         ...state,
         status: "idle",
         progress: null,
+        session: { ...state.session, presence: "present" },
         messages: updateAssistant(state, active, active.finalText, "complete"),
       };
     }
@@ -186,6 +217,68 @@ export function reduceChatState(state: ChatState, action: ChatAction): ChatState
         messages: updateAssistant(state, active, active.draft, "interrupted"),
       };
     }
+    case "session-probe": {
+      if (state.session.resetPhase !== "idle") return state;
+      if (!action.hasSession && state.session.presence === "present") {
+        return state;
+      }
+      return {
+        ...state,
+        session: {
+          ...state.session,
+          presence: action.hasSession ? "present" : "absent",
+        },
+      };
+    }
+    case "open-new-conversation":
+      return !hasClearableConversation(state) ||
+        state.session.resetPhase !== "idle" ||
+        state.status === "streaming"
+        ? state
+        : {
+            ...state,
+            session: { ...state.session, resetPhase: "confirming" },
+          };
+    case "cancel-new-conversation":
+      return state.session.resetPhase !== "confirming"
+        ? state
+        : {
+            ...state,
+            session: { ...state.session, resetPhase: "idle" },
+          };
+    case "begin-reset":
+      return state.session.resetPhase !== "confirming"
+        ? state
+        : {
+            ...state,
+            session: { ...state.session, resetPhase: "resetting" },
+          };
+    case "reset-succeeded":
+      return state.session.resetPhase !== "resetting"
+        ? state
+        : {
+            status: "idle",
+            messages: [],
+            activeTurn: null,
+            progress: null,
+            session: {
+              presence: "absent",
+              resetPhase: "idle",
+              resetCount: state.session.resetCount + 1,
+              announcement: action.announcement,
+            },
+          };
+    case "reset-failed":
+      return state.session.resetPhase !== "resetting"
+        ? state
+        : {
+            ...state,
+            session: {
+              ...state.session,
+              resetPhase: "uncertain",
+              announcement: action.announcement,
+            },
+          };
     default:
       return assertNever(action);
   }

--- a/apps/desktop-renderer/tests/chat-controller.test.ts
+++ b/apps/desktop-renderer/tests/chat-controller.test.ts
@@ -11,10 +11,14 @@ import type { CoachTurnEventNotificationEnvelope, TurnEvent } from "@enduragent/
 import {
   CHAT_CONNECTION_INTERRUPTED_COPY,
   CHAT_PROTOCOL_FAILURE_COPY,
+  NEW_CONVERSATION_MEMORY_WARNING_COPY,
+  NEW_CONVERSATION_SUCCESS_COPY,
+  NEW_CONVERSATION_UNCERTAIN_COPY,
+  type ChatViewControls,
   createChatController,
 } from "../src/chat/controller.js";
 import type { DesktopCoachClientProvider } from "../src/coach-client.js";
-import type { ChatState } from "../src/turn-state.js";
+import { EMPTY_CHAT_STATE, type ChatState } from "../src/turn-state.js";
 
 function envelope(event: TurnEvent, requestId = 1): CoachTurnEventNotificationEnvelope {
   return {
@@ -55,10 +59,24 @@ function client(
     request: { chatId: string; message: string },
     options: CoachClientCallOptions<"chat"> | undefined,
   ) => Promise<{ text: string }>,
+  sessions: {
+    readonly hasSession?: (request: { chatId: string }) => Promise<{ hasSession: boolean }>;
+    readonly resetSession?: (request: { chatId: string }) => Promise<{ memoryFlushed: boolean }>;
+  } = {},
 ): CoachClient {
   return {
     handshake: {} as CoachClient["handshake"],
     call: vi.fn((method, request, options) => {
+      if (method === "hasSession") {
+        return (sessions.hasSession ?? (async () => ({ hasSession: false })))(
+          request as { chatId: string },
+        ) as never;
+      }
+      if (method === "resetSession") {
+        return (sessions.resetSession ?? (async () => ({ memoryFlushed: true })))(
+          request as { chatId: string },
+        ) as never;
+      }
       if (method !== "chat") throw new TypeError();
       return implementation(
         request as { chatId: string; message: string },
@@ -76,6 +94,7 @@ function subject(
   spendRefreshImplementation: () => Promise<void> = async () => {},
 ) {
   const states: ChatState[] = [];
+  const controls: ChatViewControls[] = [];
   const refresh = vi.fn(refreshImplementation);
   const refreshSpend = vi.fn(spendRefreshImplementation);
   const provider: DesktopCoachClientProvider = {
@@ -85,11 +104,16 @@ function subject(
   };
   const controller = createChatController({
     clients: provider,
-    view: { render: (state) => states.push(structuredClone(state)) },
+    view: {
+      render: (state, nextControls) => {
+        states.push(structuredClone(state));
+        if (nextControls !== undefined) controls.push(structuredClone(nextControls));
+      },
+    },
     refreshTrainingContext: refresh,
     refreshSpend,
   });
-  return { controller, provider, states, refresh, refreshSpend };
+  return { controller, provider, states, controls, refresh, refreshSpend };
 }
 
 describe("chat controller", () => {
@@ -167,6 +191,7 @@ describe("chat controller", () => {
     await controller.submit("Original message ");
     expect(states.some((state) => state.messages.at(-1)?.text === "Hel")).toBe(true);
     expect(states.at(-1)?.messages.filter((message) => message.text === "Hello.")).toHaveLength(1);
+    expect(states.at(-1)?.session.presence).toBe("present");
     expect(vi.mocked(fake.call).mock.calls[0]?.slice(0, 2)).toEqual([
       "chat",
       { chatId: "desktop", message: "Original message " },
@@ -378,10 +403,117 @@ describe("chat controller", () => {
     await interruptedState;
     const retry = controller.retryInterrupted();
     const duplicate = controller.retryInterrupted();
+    expect(controller.openNewConversation()).toBe(false);
     release();
     await Promise.all([submission, retry, duplicate]);
     expect(provider.reconnect).toHaveBeenCalledTimes(1);
     expect(second.call).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps queued retries owned by the interrupted request when a newer pre-call disconnects", async () => {
+    let releaseFirstRefresh!: () => void;
+    const firstRefreshGate = new Promise<void>((resolve) => {
+      releaseFirstRefresh = resolve;
+    });
+    let resolveReconnect!: (value: CoachClient) => void;
+    const reconnectGate = new Promise<CoachClient>((resolve) => {
+      resolveReconnect = resolve;
+    });
+    const first = client(async (_request, options) => {
+      deliver(options, { type: "text_delta", turnId: "turn-a", delta: "Partial A" });
+      throw new CoachClientDisconnectedError(1006, "chat-a-disconnected");
+    });
+    const recovered = client(async (_request, options) => {
+      deliver(options, { type: "final-text", turnId: "turn-b-retry", text: "Recovered B" });
+      options?.onTerminalEnvelope?.({
+        jsonrpc: "2.0",
+        id: 3,
+        result: { text: "Recovered B" },
+      });
+      return { text: "Recovered B" };
+    });
+    let clientAcquisitions = 0;
+    const provider: DesktopCoachClientProvider = {
+      getClient: vi.fn(async () => {
+        clientAcquisitions += 1;
+        if (clientAcquisitions === 1) return first;
+        throw new CoachClientDisconnectedError(1006, "chat-b-pre-call-disconnected");
+      }),
+      reconnect: vi.fn(() => reconnectGate),
+      close: vi.fn(async () => {}),
+    };
+    const states: ChatState[] = [];
+    let renderCount = 0;
+    let releasedFirstRefresh = false;
+    let showSecondInterruption!: () => void;
+    const secondInterruption = new Promise<void>((resolve) => {
+      showSecondInterruption = resolve;
+    });
+    const refreshTrainingContext = vi.fn(async () => {
+      if (refreshTrainingContext.mock.calls.length === 1) await firstRefreshGate;
+    });
+    const refreshSpend = vi.fn(async () => {});
+    const controller = createChatController({
+      clients: provider,
+      view: {
+        render(state) {
+          states.push(structuredClone(state));
+          renderCount += 1;
+          if (
+            !releasedFirstRefresh &&
+            state.status === "interrupted" &&
+            state.activeTurn?.userMessage === "Chat B"
+          ) {
+            releasedFirstRefresh = true;
+            releaseFirstRefresh();
+            showSecondInterruption();
+          }
+        },
+      },
+      refreshTrainingContext,
+      refreshSpend,
+    });
+
+    const chatA = controller.submit("Chat A");
+    while (states.at(-1)?.status !== "interrupted") await Promise.resolve();
+    const retryA = controller.retryInterrupted();
+    const chatB = controller.submit("Chat B");
+    await secondInterruption;
+    const rendersAtSecondInterruption = renderCount;
+    const retryB = controller.retryInterrupted();
+    const duplicateB = controller.retryInterrupted();
+
+    expect(retryB).not.toBe(retryA);
+    expect(duplicateB).toBe(retryB);
+    await Promise.all([chatA, chatB, retryA]);
+    expect(provider.getClient).toHaveBeenCalledTimes(2);
+    expect(provider.reconnect).toHaveBeenCalledTimes(1);
+    expect(renderCount).toBe(rendersAtSecondInterruption + 5);
+    expect(first.call).toHaveBeenCalledTimes(1);
+    expect(recovered.call).not.toHaveBeenCalled();
+
+    resolveReconnect(recovered);
+    await Promise.all([retryB, duplicateB]);
+
+    expect(provider.getClient).toHaveBeenCalledTimes(2);
+    expect(provider.reconnect).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(first.call).mock.calls.map(([, request]) => request)).toEqual([
+      { chatId: "desktop", message: "Chat A" },
+    ]);
+    expect(vi.mocked(recovered.call).mock.calls.map(([, request]) => request)).toEqual([
+      { chatId: "desktop", message: "Chat B" },
+    ]);
+    expect(refreshTrainingContext).toHaveBeenCalledTimes(2);
+    expect(refreshSpend).toHaveBeenCalledTimes(2);
+    expect(
+      states.at(-1)?.messages.map(({ role, text, delivery }) => ({ role, text, delivery })),
+    ).toEqual([
+      { role: "athlete", text: "Chat A", delivery: "complete" },
+      { role: "coach", text: "Partial A", delivery: "interrupted" },
+      { role: "athlete", text: "Chat B", delivery: "complete" },
+      { role: "coach", text: "", delivery: "interrupted" },
+      { role: "coach", text: "Recovered B", delivery: "complete" },
+    ]);
   });
 
   it("allows one in-flight call and treats client protocol rejection as explicit-retry state", async () => {
@@ -409,5 +541,430 @@ describe("chat controller", () => {
     const { controller } = subject(fake);
     await controller.submit("  \n");
     expect(fake.call).not.toHaveBeenCalled();
+  });
+
+  it("starts one exact session probe and deduplicates repeated starts", async () => {
+    const fake = client(async () => ({ text: "unused" }), {
+      hasSession: async () => ({ hasSession: true }),
+    });
+    const { controller, states } = subject(fake);
+
+    const first = controller.start();
+    const duplicate = controller.start();
+
+    expect(duplicate).toBe(first);
+    await first;
+    expect(vi.mocked(fake.call).mock.calls).toEqual([["hasSession", { chatId: "desktop" }]]);
+    expect(states.at(-1)?.session.presence).toBe("present");
+  });
+
+  it("keeps reset unavailable after an absent probe and exposes no probe failure", async () => {
+    const absent = client(async () => ({ text: "unused" }));
+    const first = subject(absent);
+    await first.controller.start();
+    expect(first.states.at(-1)?.session.presence).toBe("absent");
+    expect(first.controls.at(-1)?.newConversationDisabled).toBe(true);
+    expect(first.controller.openNewConversation()).toBe(false);
+    expect(first.provider.reconnect).not.toHaveBeenCalled();
+
+    const failed = client(async () => ({ text: "unused" }), {
+      hasSession: async () => Promise.reject(new Error("private probe detail")),
+    });
+    const second = subject(failed);
+    await second.controller.start();
+    expect(second.states.at(-1)?.session).toEqual(EMPTY_CHAT_STATE.session);
+    expect(second.provider.reconnect).not.toHaveBeenCalled();
+    expect(vi.mocked(failed.call).mock.calls.filter(([method]) => method !== "hasSession")).toEqual(
+      [],
+    );
+  });
+
+  it("uses visible local content without promoting an absent session after pre-client failure", async () => {
+    const fake = client(async () => ({ text: "unused" }));
+    const { controller, provider, states, controls } = subject(fake);
+    await controller.start();
+
+    let rejectClient!: (reason?: unknown) => void;
+    const clientGate = new Promise<CoachClient>((_resolve, reject) => {
+      rejectClient = reject;
+    });
+    vi.mocked(provider.getClient).mockReturnValueOnce(clientGate);
+
+    const submission = controller.submit("Keep this visible");
+    expect(states.at(-1)?.session.presence).toBe("absent");
+    expect(states.at(-1)?.messages).toMatchObject([
+      { role: "athlete", text: "Keep this visible" },
+      { role: "coach", text: "" },
+    ]);
+    expect(controls.at(-1)?.newConversationDisabled).toBe(true);
+    expect(controller.openNewConversation()).toBe(false);
+
+    rejectClient(new Error("synthetic pre-client failure"));
+    await submission;
+
+    expect(states.at(-1)?.session.presence).toBe("absent");
+    expect(states.at(-1)?.messages).toMatchObject([
+      { role: "athlete", text: "Keep this visible", delivery: "complete" },
+      { role: "coach", text: "", delivery: "interrupted" },
+    ]);
+    expect(
+      controls.slice(-2).map(({ newConversationDisabled }) => newConversationDisabled),
+    ).toEqual([true, false]);
+    expect(controller.openNewConversation()).toBe(true);
+    expect(states.at(-1)?.session).toMatchObject({
+      presence: "absent",
+      resetPhase: "confirming",
+    });
+    expect(vi.mocked(fake.call).mock.calls.filter(([method]) => method === "chat")).toEqual([]);
+
+    await controller.confirmNewConversation();
+    expect(states.at(-1)?.messages).toEqual([]);
+    expect(states.at(-1)?.session).toMatchObject({
+      presence: "absent",
+      resetPhase: "idle",
+    });
+    expect(vi.mocked(fake.call).mock.calls.filter(([method]) => method === "resetSession")).toEqual(
+      [["resetSession", { chatId: "desktop" }]],
+    );
+  });
+
+  it("ignores a delayed false probe after a locally completed chat", async () => {
+    let resolveProbe!: (value: { hasSession: boolean }) => void;
+    const probe = new Promise<{ hasSession: boolean }>((resolve) => {
+      resolveProbe = resolve;
+    });
+    const fake = client(
+      async (_request, options) => {
+        deliver(options, { type: "final-text", turnId: "turn-1", text: "Done" });
+        options?.onTerminalEnvelope?.({ jsonrpc: "2.0", id: 1, result: { text: "Done" } });
+        return { text: "Done" };
+      },
+      { hasSession: async () => probe },
+    );
+    const { controller, states } = subject(fake);
+
+    const starting = controller.start();
+    await controller.submit("Continue");
+    resolveProbe({ hasSession: false });
+    await starting;
+
+    expect(states.at(-1)?.session.presence).toBe("present");
+    expect(controller.openNewConversation()).toBe(true);
+  });
+
+  it("ignores a delayed true probe after a successful reset", async () => {
+    let resolveProbe!: (value: { hasSession: boolean }) => void;
+    const probe = new Promise<{ hasSession: boolean }>((resolve) => {
+      resolveProbe = resolve;
+    });
+    const fake = client(
+      async (_request, options) => {
+        deliver(options, { type: "final-text", turnId: "turn-1", text: "Done" });
+        options?.onTerminalEnvelope?.({ jsonrpc: "2.0", id: 1, result: { text: "Done" } });
+        return { text: "Done" };
+      },
+      {
+        hasSession: async () => probe,
+        resetSession: async () => ({ memoryFlushed: true }),
+      },
+    );
+    const { controller, states } = subject(fake);
+
+    const starting = controller.start();
+    await controller.submit("Continue");
+    expect(controller.openNewConversation()).toBe(true);
+    await controller.confirmNewConversation();
+    resolveProbe({ hasSession: true });
+    await starting;
+
+    expect(states.at(-1)?.session.presence).toBe("absent");
+    expect(states.at(-1)?.messages).toEqual([]);
+    expect(controller.openNewConversation()).toBe(false);
+  });
+
+  it("rejects confirmation while chat streaming or terminal refresh is active", async () => {
+    let releaseChat!: () => void;
+    const chatGate = new Promise<void>((resolve) => {
+      releaseChat = resolve;
+    });
+    let releaseRefresh!: () => void;
+    const refreshGate = new Promise<void>((resolve) => {
+      releaseRefresh = resolve;
+    });
+    const fake = client(async (_request, options) => {
+      await chatGate;
+      deliver(options, { type: "final-text", turnId: "turn-1", text: "Done" });
+      options?.onTerminalEnvelope?.({ jsonrpc: "2.0", id: 1, result: { text: "Done" } });
+      return { text: "Done" };
+    });
+    const { controller, refresh } = subject(fake, fake, () => refreshGate);
+
+    const submission = controller.submit("Continue");
+    await Promise.resolve();
+    expect(controller.openNewConversation()).toBe(false);
+    releaseChat();
+    while (refresh.mock.calls.length === 0) await Promise.resolve();
+    expect(controller.openNewConversation()).toBe(false);
+    releaseRefresh();
+    await submission;
+    expect(controller.openNewConversation()).toBe(true);
+  });
+
+  it("keeps reset unavailable until every accepted chat cleanup settles", async () => {
+    let releaseRefresh!: () => void;
+    const refreshGate = new Promise<void>((resolve) => {
+      releaseRefresh = resolve;
+    });
+    const fake = client(async (_request, options) => {
+      deliver(options, { type: "final-text", turnId: "turn-1", text: "Done" });
+      options?.onTerminalEnvelope?.({ jsonrpc: "2.0", id: 1, result: { text: "Done" } });
+      return { text: "Done" };
+    });
+    const { controller, provider, states, controls, refresh } = subject(
+      fake,
+      fake,
+      () => refreshGate,
+    );
+
+    const chatA = controller.submit("Chat A");
+    while (refresh.mock.calls.length === 0) await Promise.resolve();
+    expect(states.at(-1)?.status).toBe("idle");
+
+    vi.mocked(provider.getClient).mockRejectedValueOnce(new Error("synthetic admission failure"));
+    const chatB = controller.submit("Chat B");
+    await chatB;
+
+    expect(refresh).toHaveBeenCalledTimes(1);
+    expect(controls.at(-1)?.newConversationDisabled).toBe(true);
+    expect(controller.openNewConversation()).toBe(false);
+    expect(vi.mocked(fake.call).mock.calls.filter(([method]) => method === "resetSession")).toEqual(
+      [],
+    );
+
+    releaseRefresh();
+    await chatA;
+
+    expect(controls.at(-1)?.newConversationDisabled).toBe(false);
+    expect(controller.openNewConversation()).toBe(true);
+    expect(vi.mocked(fake.call).mock.calls.filter(([method]) => method === "resetSession")).toEqual(
+      [],
+    );
+  });
+
+  it("blocks submit and retry while confirmation is open, then cancel permits retry", async () => {
+    const interrupted = client(async (_request, options) => {
+      deliver(options, { type: "text_delta", turnId: "turn-1", delta: "Partial" });
+      throw new CoachClientDisconnectedError(1006, "synthetic");
+    });
+    const recovered = client(async (_request, options) => {
+      deliver(options, { type: "final-text", turnId: "turn-2", text: "Recovered" });
+      options?.onTerminalEnvelope?.({ jsonrpc: "2.0", id: 2, result: { text: "Recovered" } });
+      return { text: "Recovered" };
+    });
+    const { controller } = subject(interrupted, recovered);
+    await controller.submit("Original");
+    expect(controller.openNewConversation()).toBe(true);
+    vi.mocked(interrupted.call).mockClear();
+
+    await Promise.all([controller.submit("Blocked"), controller.retryInterrupted()]);
+    expect(interrupted.call).not.toHaveBeenCalled();
+    expect(recovered.call).not.toHaveBeenCalled();
+
+    controller.cancelNewConversation();
+    expect(controller.openNewConversation()).toBe(true);
+    controller.cancelNewConversation();
+    await controller.retryInterrupted();
+    expect(recovered.call).toHaveBeenCalledTimes(1);
+    expect(
+      vi.mocked(interrupted.call).mock.calls.filter(([method]) => method === "resetSession"),
+    ).toEqual([]);
+  });
+
+  it.each([
+    [true, NEW_CONVERSATION_SUCCESS_COPY],
+    [false, NEW_CONVERSATION_MEMORY_WARNING_COPY],
+  ] as const)(
+    "clears only after reset success when memoryFlushed is %s",
+    async (memoryFlushed, announcement) => {
+      let settleReset!: (value: { memoryFlushed: boolean }) => void;
+      const resetGate = new Promise<{ memoryFlushed: boolean }>((resolve) => {
+        settleReset = resolve;
+      });
+      const fake = client(
+        async (_request, options) => {
+          deliver(options, { type: "final-text", turnId: "turn-1", text: "Done" });
+          options?.onTerminalEnvelope?.({ jsonrpc: "2.0", id: 1, result: { text: "Done" } });
+          return { text: "Done" };
+        },
+        { resetSession: async () => resetGate },
+      );
+      const { controller, states, refreshSpend } = subject(fake);
+      await controller.submit("Original");
+      const transcript = states.at(-1)?.messages;
+      refreshSpend.mockClear();
+      expect(controller.openNewConversation()).toBe(true);
+
+      const first = controller.confirmNewConversation();
+      const duplicate = controller.confirmNewConversation();
+      expect(duplicate).toBe(first);
+      await Promise.resolve();
+      expect(
+        vi.mocked(fake.call).mock.calls.filter(([method]) => method === "resetSession"),
+      ).toEqual([["resetSession", { chatId: "desktop" }]]);
+      expect(states.at(-1)?.messages).toEqual(transcript);
+      expect(states.at(-1)?.session.resetPhase).toBe("resetting");
+
+      settleReset({ memoryFlushed });
+      await first;
+      expect(states.at(-1)).toMatchObject({
+        status: "idle",
+        messages: [],
+        activeTurn: null,
+        progress: null,
+        session: {
+          presence: "absent",
+          resetPhase: "idle",
+          announcement,
+        },
+      });
+      expect(refreshSpend).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it.each([
+    new Error("private reset detail"),
+    new CoachClientCallTimeoutError("resetSession", 660_000),
+    new CoachClientDisconnectedError(1006, "synthetic"),
+    new CoachClientProtocolError(),
+  ])("preserves conversation and blocks a second reset after $name", async (failure) => {
+    const fake = client(
+      async (_request, options) => {
+        deliver(options, { type: "final-text", turnId: "turn-1", text: "Done" });
+        options?.onTerminalEnvelope?.({ jsonrpc: "2.0", id: 1, result: { text: "Done" } });
+        return { text: "Done" };
+      },
+      { resetSession: async () => Promise.reject(failure) },
+    );
+    const { controller, states } = subject(fake);
+    await controller.submit("Original");
+    const before = structuredClone(states.at(-1)!);
+    expect(controller.openNewConversation()).toBe(true);
+    await controller.confirmNewConversation();
+
+    expect(states.at(-1)).toMatchObject({
+      status: before.status,
+      messages: before.messages,
+      activeTurn: before.activeTurn,
+      progress: before.progress,
+      session: {
+        presence: "present",
+        resetPhase: "uncertain",
+        announcement: NEW_CONVERSATION_UNCERTAIN_COPY,
+      },
+    });
+    expect(controller.openNewConversation()).toBe(false);
+    await controller.confirmNewConversation();
+    expect(
+      vi.mocked(fake.call).mock.calls.filter(([method]) => method === "resetSession"),
+    ).toHaveLength(1);
+    expect(
+      vi.mocked(fake.call).mock.calls.filter(([method]) => method === "hasSession"),
+    ).toHaveLength(0);
+  });
+
+  it("preserves interrupted retry ownership after an uncertain reset", async () => {
+    const interrupted = client(
+      async (_request, options) => {
+        deliver(options, { type: "text_delta", turnId: "turn-1", delta: "Partial" });
+        throw new CoachClientDisconnectedError(1006, "synthetic");
+      },
+      { resetSession: async () => Promise.reject(new Error("uncertain")) },
+    );
+    const recovered = client(async (_request, options) => {
+      deliver(options, { type: "final-text", turnId: "turn-2", text: "Recovered" });
+      options?.onTerminalEnvelope?.({ jsonrpc: "2.0", id: 2, result: { text: "Recovered" } });
+      return { text: "Recovered" };
+    });
+    const { controller, provider, states } = subject(interrupted, recovered);
+    await controller.submit("Original");
+    expect(controller.openNewConversation()).toBe(true);
+    await controller.confirmNewConversation();
+    await controller.retryInterrupted();
+
+    expect(provider.reconnect).toHaveBeenCalledTimes(1);
+    expect(states.at(-1)?.messages.at(-1)?.text).toBe("Recovered");
+  });
+
+  it("holds one reset pending while repeated confirm, submit, and retry dispatch no chat", async () => {
+    let settleReset!: (value: { memoryFlushed: boolean }) => void;
+    const resetGate = new Promise<{ memoryFlushed: boolean }>((resolve) => {
+      settleReset = resolve;
+    });
+    const fake = client(
+      async (_request, options) => {
+        deliver(options, { type: "text_delta", turnId: "turn-1", delta: "Partial" });
+        throw new CoachClientDisconnectedError(1006, "synthetic");
+      },
+      { resetSession: async () => resetGate },
+    );
+    const { controller } = subject(fake);
+    await controller.submit("Original");
+    expect(controller.openNewConversation()).toBe(true);
+    vi.mocked(fake.call).mockClear();
+
+    const reset = controller.confirmNewConversation();
+    const duplicate = controller.confirmNewConversation();
+    await Promise.all([controller.submit("Blocked"), controller.retryInterrupted()]);
+    await Promise.resolve();
+
+    expect(duplicate).toBe(reset);
+    expect(vi.mocked(fake.call).mock.calls).toEqual([["resetSession", { chatId: "desktop" }]]);
+    settleReset({ memoryFlushed: true });
+    await reset;
+    expect(vi.mocked(fake.call).mock.calls.filter(([method]) => method === "chat")).toEqual([]);
+  });
+
+  it("fences late probe and reset settlements after dispose without refreshing spend", async () => {
+    let settleProbe!: (value: { hasSession: boolean }) => void;
+    let settleReset!: (value: { memoryFlushed: boolean }) => void;
+    const probeGate = new Promise<{ hasSession: boolean }>((resolve) => {
+      settleProbe = resolve;
+    });
+    const resetGate = new Promise<{ memoryFlushed: boolean }>((resolve) => {
+      settleReset = resolve;
+    });
+    const fake = client(
+      async (_request, options) => {
+        deliver(options, { type: "final-text", turnId: "turn-1", text: "Done" });
+        options?.onTerminalEnvelope?.({ jsonrpc: "2.0", id: 1, result: { text: "Done" } });
+        return { text: "Done" };
+      },
+      {
+        hasSession: async () => probeGate,
+        resetSession: async () => resetGate,
+      },
+    );
+    const { controller, states, refreshSpend } = subject(fake);
+    const starting = controller.start();
+    await controller.submit("Original");
+    expect(controller.openNewConversation()).toBe(true);
+    refreshSpend.mockClear();
+    const resetting = controller.confirmNewConversation();
+    await Promise.resolve();
+    const renderCount = states.length;
+    controller.dispose();
+
+    settleProbe({ hasSession: true });
+    settleReset({ memoryFlushed: true });
+    await Promise.all([starting, resetting]);
+
+    expect(states).toHaveLength(renderCount);
+    expect(refreshSpend).not.toHaveBeenCalled();
+    expect(
+      vi.mocked(fake.call).mock.calls.filter(([method]) => method === "hasSession"),
+    ).toHaveLength(1);
+    expect(
+      vi.mocked(fake.call).mock.calls.filter(([method]) => method === "resetSession"),
+    ).toHaveLength(1);
   });
 });

--- a/apps/desktop-renderer/tests/chat-view.test.ts
+++ b/apps/desktop-renderer/tests/chat-view.test.ts
@@ -16,18 +16,26 @@ class FakeElement {
   rows = 0;
   htmlFor = "";
   removed = false;
+  open = false;
   scrollHeight = 0;
   scrollTop = 0;
   clientHeight = 0;
+  textContentMutationCount = 0;
+  replaceChildrenMutationCount = 0;
   private ownText = "";
 
   constructor(readonly tagName: string) {}
+
+  get firstChild(): FakeElement | null {
+    return this.children[0] ?? null;
+  }
 
   get textContent(): string {
     return this.ownText + this.children.map((child) => child.textContent).join("");
   }
 
   set textContent(value: string) {
+    this.textContentMutationCount += 1;
     this.ownText = value;
     this.children.splice(0);
   }
@@ -39,13 +47,24 @@ class FakeElement {
     }
   }
 
+  insertBefore(node: FakeElement, reference: FakeElement | null): void {
+    const index = reference === null ? -1 : this.children.indexOf(reference);
+    if (index === -1) this.children.push(node);
+    else this.children.splice(index, 0, node);
+  }
+
   replaceChildren(...nodes: FakeElement[]): void {
+    this.replaceChildrenMutationCount += 1;
     this.ownText = "";
     this.children.splice(0, this.children.length, ...nodes);
   }
 
   setAttribute(name: string, value: string): void {
     this.attributes.set(name, value);
+  }
+
+  getAttribute(name: string): string | null {
+    return this.attributes.get(name) ?? null;
   }
 
   removeAttribute(name: string): void {
@@ -70,12 +89,28 @@ class FakeElement {
     this.dispatch("submit", { preventDefault() {} });
   }
 
+  showModal(): void {
+    this.open = true;
+  }
+
+  close(): void {
+    this.open = false;
+    this.dispatch("close");
+  }
+
+  focus(): void {
+    if (this.disabled) return;
+    (globalThis.document as unknown as FakeDocument).activeElement = this;
+  }
+
   remove(): void {
     this.removed = true;
   }
 }
 
 class FakeDocument {
+  activeElement: FakeElement | null = null;
+
   createElement(name: string): FakeElement {
     return new FakeElement(name);
   }
@@ -113,12 +148,7 @@ function submittedState(): ChatState {
   });
 }
 
-const emptyState: ChatState = {
-  status: "idle",
-  messages: [],
-  activeTurn: null,
-  progress: null,
-};
+const emptyState: ChatState = EMPTY_CHAT_STATE;
 
 beforeEach(() => {
   Object.assign(globalThis, {
@@ -338,6 +368,105 @@ describe("chat view", () => {
     expect(find(thread, (node) => node.className === "chat-retry").hidden).toBe(false);
   });
 
+  it("mutates live transcript content only when its rendered semantics change", () => {
+    const actionHost = new FakeElement("div");
+    const thread = new FakeElement("div");
+    const mounted = mountChatView({
+      conversation: new FakeElement("main") as never,
+      thread: thread as never,
+      composerHost: new FakeElement("div") as never,
+      actionHost: actionHost as never,
+    });
+    const messages = find(thread, (node) => node.className === "chat-messages");
+    const notice = find(thread, (node) => node.className === "chat-notice");
+
+    mounted.view.render(emptyState);
+    expect(messages.replaceChildrenMutationCount).toBe(0);
+    expect(notice.textContentMutationCount).toBe(0);
+
+    let state = submittedState();
+    mounted.view.render(state);
+    expect(messages.replaceChildrenMutationCount).toBe(1);
+    expect(messages.textContent).toContain("How should I train?");
+    expect(notice.textContentMutationCount).toBe(0);
+
+    mounted.view.render({
+      ...state,
+      messages: state.messages.map((message) => ({ ...message, id: `${message.id}-clone` })),
+    });
+    expect(messages.replaceChildrenMutationCount).toBe(1);
+    expect(notice.textContentMutationCount).toBe(0);
+
+    state = reduceChatState(state, {
+      type: "event",
+      requestKey: 1,
+      event: { type: "text_delta", turnId: "turn-1", delta: "Partial coach draft" },
+    });
+    mounted.view.render(state);
+    expect(messages.replaceChildrenMutationCount).toBe(2);
+    expect(messages.textContent).toContain("Partial coach draft");
+    expect(notice.textContentMutationCount).toBe(0);
+
+    state = reduceChatState(state, {
+      type: "interrupt",
+      requestKey: 1,
+      copy: "Connection interrupted. Your partial response is preserved.",
+    });
+    mounted.view.render(state);
+    expect(messages.replaceChildrenMutationCount).toBe(3);
+    expect(notice.textContentMutationCount).toBe(1);
+    expect(notice.textContent).toBe("Connection interrupted. Your partial response is preserved.");
+    expect(find(thread, (node) => node.className === "chat-retry").hidden).toBe(false);
+
+    state = reduceChatState(state, {
+      type: "interrupt",
+      requestKey: 1,
+      copy: "Connection interrupted again. Your partial response is preserved.",
+    });
+    mounted.view.render(state);
+    expect(messages.replaceChildrenMutationCount).toBe(3);
+    expect(notice.textContentMutationCount).toBe(2);
+    expect(notice.textContent).toBe(
+      "Connection interrupted again. Your partial response is preserved.",
+    );
+
+    let resetState = reduceChatState(state, { type: "open-new-conversation" });
+    mounted.view.render(resetState);
+    resetState = reduceChatState(resetState, { type: "begin-reset" });
+    mounted.view.render(resetState, { newConversationDisabled: true, workBlocked: true });
+    mounted.view.render(
+      {
+        ...resetState,
+        messages: resetState.messages.map((message) => ({ ...message })),
+      },
+      { newConversationDisabled: false, workBlocked: false },
+    );
+    expect(messages.replaceChildrenMutationCount).toBe(3);
+    expect(notice.textContentMutationCount).toBe(2);
+
+    const clearedState = reduceChatState(resetState, {
+      type: "reset-succeeded",
+      announcement: "New conversation started.",
+    });
+    mounted.view.render(clearedState);
+    expect(messages.replaceChildrenMutationCount).toBe(4);
+    expect(messages.children).toHaveLength(0);
+    expect(notice.textContentMutationCount).toBe(3);
+    expect(notice.textContent).toBe("");
+
+    mounted.view.render({
+      ...state,
+      messages: state.messages.map((message) => ({ ...message })),
+      session: { ...clearedState.session, presence: "present", announcement: null },
+    });
+    expect(messages.replaceChildrenMutationCount).toBe(5);
+    expect(messages.textContent).toContain("Partial coach draft");
+    expect(notice.textContentMutationCount).toBe(4);
+    expect(notice.textContent).toBe(
+      "Connection interrupted again. Your partial response is preserved.",
+    );
+  });
+
   it("places one notice host immediately before the composer and removes it on dispose", () => {
     const composerHost = new FakeElement("div");
     const mounted = mountChatView({
@@ -390,7 +519,13 @@ describe("chat view", () => {
       composerHost: composerHost as never,
     });
     const onSubmit = vi.fn();
-    mounted.bind({ onSubmit, onRetry: vi.fn() });
+    mounted.bind({
+      onSubmit,
+      onRetry: vi.fn(),
+      onOpenNewConversation: vi.fn(),
+      onCancelNewConversation: vi.fn(),
+      onConfirmNewConversation: vi.fn(),
+    });
     const label = find(composerHost, (node) => node.className === "chat-composer__label");
     const textarea = find(composerHost, (node) => node.tagName === "textarea");
     const form = find(composerHost, (node) => node.tagName === "form");
@@ -414,7 +549,13 @@ describe("chat view", () => {
       composerHost: composerHost as never,
     });
     const onRetry = vi.fn();
-    mounted.bind({ onSubmit: vi.fn(), onRetry });
+    mounted.bind({
+      onSubmit: vi.fn(),
+      onRetry,
+      onOpenNewConversation: vi.fn(),
+      onCancelNewConversation: vi.fn(),
+      onConfirmNewConversation: vi.fn(),
+    });
     mounted.view.render({ ...emptyState, status: "interrupted", progress: "Interrupted" });
     const retry = find(thread, (node) => node.className === "chat-retry");
     expect(retry.hidden).toBe(false);
@@ -438,5 +579,272 @@ describe("chat view", () => {
     conversation.scrollTop = 0;
     mounted.view.render({ ...emptyState, status: "streaming" });
     expect(conversation.scrollTop).toBe(0);
+  });
+
+  it("renders and binds the visible New conversation button with disabled states", () => {
+    const actionHost = new FakeElement("div");
+    const mounted = mountChatView({
+      conversation: new FakeElement("main") as never,
+      thread: new FakeElement("div") as never,
+      composerHost: new FakeElement("div") as never,
+      actionHost: actionHost as never,
+    });
+    const onOpenNewConversation = vi.fn();
+    mounted.bind({
+      onSubmit: vi.fn(),
+      onRetry: vi.fn(),
+      onOpenNewConversation,
+      onCancelNewConversation: vi.fn(),
+      onConfirmNewConversation: vi.fn(),
+    });
+    const button = find(actionHost, (node) => node.className === "new-conversation-button");
+
+    mounted.view.render(emptyState);
+    expect(button.textContent).toBe("New conversation");
+    expect(button.disabled).toBe(true);
+
+    const present = reduceChatState(emptyState, { type: "session-probe", hasSession: true });
+    mounted.view.render(present);
+    expect(button.disabled).toBe(false);
+    button.dispatch("click");
+    expect(onOpenNewConversation).toHaveBeenCalledTimes(1);
+
+    mounted.view.render({ ...present, status: "streaming" });
+    expect(button.disabled).toBe(true);
+    mounted.view.render(present, { newConversationDisabled: true, workBlocked: false });
+    expect(button.disabled).toBe(true);
+  });
+
+  it("labels the modal, focuses Cancel, and restores the opener after cancel or Escape", () => {
+    const actionHost = new FakeElement("div");
+    const composerHost = new FakeElement("div");
+    const mounted = mountChatView({
+      conversation: new FakeElement("main") as never,
+      thread: new FakeElement("div") as never,
+      composerHost: composerHost as never,
+      actionHost: actionHost as never,
+    });
+    const onCancelNewConversation = vi.fn();
+    mounted.bind({
+      onSubmit: vi.fn(),
+      onRetry: vi.fn(),
+      onOpenNewConversation: vi.fn(),
+      onCancelNewConversation,
+      onConfirmNewConversation: vi.fn(),
+    });
+    const button = find(actionHost, (node) => node.className === "new-conversation-button");
+    const dialog = find(actionHost, (node) => node.tagName === "dialog");
+    const cancel = find(dialog, (node) => node.textContent === "Cancel");
+    const textarea = find(composerHost, (node) => node.tagName === "textarea");
+    textarea.value = "  exact draft  ";
+    const present = reduceChatState(emptyState, { type: "session-probe", hasSession: true });
+    const confirming = reduceChatState(present, { type: "open-new-conversation" });
+
+    mounted.view.render(confirming);
+    expect(dialog.open).toBe(true);
+    expect(dialog.attributes.get("aria-labelledby")).toBe("new-conversation-title");
+    expect(dialog.attributes.get("aria-describedby")).toBe("new-conversation-description");
+    expect(dialog.attributes.get("aria-modal")).toBe("true");
+    expect(dialog.textContent).toContain("Start a new conversation?");
+    expect(dialog.textContent).toContain(
+      "Your visible conversation will be cleared. Your training data and saved coach memory will remain.",
+    );
+    expect((globalThis.document as unknown as FakeDocument).activeElement).toBe(cancel);
+
+    cancel.dispatch("click");
+    expect(onCancelNewConversation).toHaveBeenCalledTimes(1);
+    mounted.view.render(present);
+    expect(dialog.open).toBe(false);
+    expect((globalThis.document as unknown as FakeDocument).activeElement).toBe(button);
+    expect(textarea.value).toBe("  exact draft  ");
+
+    mounted.view.render(confirming);
+    dialog.dispatch("cancel", { preventDefault: vi.fn() });
+    expect(onCancelNewConversation).toHaveBeenCalledTimes(2);
+    mounted.view.render(present);
+    expect((globalThis.document as unknown as FakeDocument).activeElement).toBe(button);
+    expect(textarea.value).toBe("  exact draft  ");
+  });
+
+  it("marks a pending reset busy and disables every conflicting control", () => {
+    const actionHost = new FakeElement("div");
+    const thread = new FakeElement("div");
+    const composerHost = new FakeElement("div");
+    const mounted = mountChatView({
+      conversation: new FakeElement("main") as never,
+      thread: thread as never,
+      composerHost: composerHost as never,
+      actionHost: actionHost as never,
+    });
+    let state = reduceChatState(emptyState, { type: "session-probe", hasSession: true });
+    state = reduceChatState(state, { type: "open-new-conversation" });
+    state = reduceChatState(state, { type: "begin-reset" });
+    mounted.view.render({ ...state, status: "interrupted" });
+
+    const dialog = find(actionHost, (node) => node.tagName === "dialog");
+    const dialogButtons = findAll(dialog, (node) => node.tagName === "button");
+    const composerControls = findAll(composerHost, (node) =>
+      ["textarea", "button"].includes(node.tagName),
+    );
+    const retry = find(thread, (node) => node.className === "chat-retry");
+    expect(dialog.attributes.get("aria-busy")).toBe("true");
+    expect(dialogButtons.every((button) => button.disabled)).toBe(true);
+    expect(composerControls.every((control) => control.disabled)).toBe(true);
+    expect(retry.disabled).toBe(true);
+  });
+
+  it.each([
+    "New conversation started.",
+    "New conversation started. Some recent details may not have been saved to coach memory.",
+  ])("clears and focuses the composer only after success announced as %s", (announcement) => {
+    const actionHost = new FakeElement("div");
+    const composerHost = new FakeElement("div");
+    const mounted = mountChatView({
+      conversation: new FakeElement("main") as never,
+      thread: new FakeElement("div") as never,
+      composerHost: composerHost as never,
+      actionHost: actionHost as never,
+    });
+    const textarea = find(composerHost, (node) => node.tagName === "textarea");
+    textarea.value = "preserve until success";
+    let state = reduceChatState(emptyState, { type: "session-probe", hasSession: true });
+    state = reduceChatState(state, { type: "open-new-conversation" });
+    state = reduceChatState(state, { type: "begin-reset" });
+    mounted.view.render(state);
+    expect(textarea.value).toBe("preserve until success");
+    expect(textarea.disabled).toBe(true);
+    state = reduceChatState(state, { type: "reset-succeeded", announcement });
+    mounted.view.render(state);
+
+    const status = find(composerHost, (node) => node.className === "new-conversation-status");
+    expect(textarea.value).toBe("");
+    expect((globalThis.document as unknown as FakeDocument).activeElement).toBe(textarea);
+    expect(status.attributes.get("role")).toBe("status");
+    expect(status.attributes.get("aria-live")).toBe("polite");
+    expect(status.textContent).toBe(announcement);
+  });
+
+  it("keeps one primed status region and mutates it only across announcement changes", () => {
+    const composerHost = new FakeElement("div");
+    const mounted = mountChatView({
+      conversation: new FakeElement("main") as never,
+      thread: new FakeElement("div") as never,
+      composerHost: composerHost as never,
+    });
+    const statuses = findAll(composerHost, (node) => node.className === "new-conversation-status");
+    const status = statuses[0]!;
+    const announcement = "New conversation started.";
+
+    expect(statuses).toHaveLength(1);
+    expect(status.attributes.get("role")).toBe("status");
+    expect(status.attributes.get("aria-live")).toBe("polite");
+    expect(status.hidden).toBe(false);
+    expect(status.attributes.has("hidden")).toBe(false);
+    expect(status.textContent).toBe("");
+    expect(status.textContentMutationCount).toBe(0);
+
+    let state = reduceChatState(emptyState, { type: "session-probe", hasSession: true });
+    state = reduceChatState(state, { type: "open-new-conversation" });
+    state = reduceChatState(state, { type: "begin-reset" });
+    state = reduceChatState(state, { type: "reset-succeeded", announcement });
+    mounted.view.render(state);
+    expect(status.textContent).toBe(announcement);
+    expect(status.textContentMutationCount).toBe(1);
+
+    mounted.view.render(state);
+    expect(status.textContentMutationCount).toBe(1);
+
+    state = reduceChatState(state, {
+      type: "submit",
+      requestKey: 2,
+      userMessage: "What should I ride today?",
+      userMessageId: "message-3",
+      assistantMessageId: "message-4",
+      includeUser: true,
+    });
+    mounted.view.render(state);
+    expect(status.textContent).toBe("");
+    expect(status.textContentMutationCount).toBe(2);
+
+    state = reduceChatState(state, {
+      type: "event",
+      requestKey: 2,
+      event: { type: "final-text", turnId: "turn-2", text: "Ride easy." },
+    });
+    state = reduceChatState(state, { type: "complete", requestKey: 2 });
+    state = reduceChatState(state, { type: "open-new-conversation" });
+    state = reduceChatState(state, { type: "begin-reset" });
+    state = reduceChatState(state, { type: "reset-succeeded", announcement });
+    mounted.view.render(state);
+    expect(status.textContent).toBe(announcement);
+    expect(status.textContentMutationCount).toBe(3);
+  });
+
+  it("preserves the exact draft and restores the opener after uncertain failure", () => {
+    const actionHost = new FakeElement("div");
+    const composerHost = new FakeElement("div");
+    const mounted = mountChatView({
+      conversation: new FakeElement("main") as never,
+      thread: new FakeElement("div") as never,
+      composerHost: composerHost as never,
+      actionHost: actionHost as never,
+    });
+    const textarea = find(composerHost, (node) => node.tagName === "textarea");
+    const button = find(actionHost, (node) => node.className === "new-conversation-button");
+    textarea.value = "  exact uncertain draft\n";
+    let state = reduceChatState(emptyState, { type: "session-probe", hasSession: true });
+    state = reduceChatState(state, { type: "open-new-conversation" });
+    state = reduceChatState(state, { type: "begin-reset" });
+    mounted.view.render(state);
+    state = reduceChatState(state, {
+      type: "reset-failed",
+      announcement:
+        "We couldn’t confirm whether the new conversation started. Your visible conversation is preserved.",
+    });
+    mounted.view.render(state);
+
+    const status = find(composerHost, (node) => node.className === "new-conversation-status");
+    expect(textarea.value).toBe("  exact uncertain draft\n");
+    expect((globalThis.document as unknown as FakeDocument).activeElement).toBe(button);
+    expect(button.disabled).toBe(false);
+    expect(button.attributes.get("aria-disabled")).toBe("true");
+    expect(status.textContent).toBe(
+      "We couldn’t confirm whether the new conversation started. Your visible conversation is preserved.",
+    );
+  });
+
+  it("removes new listeners and elements while safely closing an open dialog", () => {
+    const actionHost = new FakeElement("div");
+    const thread = new FakeElement("div");
+    const composerHost = new FakeElement("div");
+    const mounted = mountChatView({
+      conversation: new FakeElement("main") as never,
+      thread: thread as never,
+      composerHost: composerHost as never,
+      actionHost: actionHost as never,
+    });
+    const onOpenNewConversation = vi.fn();
+    mounted.bind({
+      onSubmit: vi.fn(),
+      onRetry: vi.fn(),
+      onOpenNewConversation,
+      onCancelNewConversation: vi.fn(),
+      onConfirmNewConversation: vi.fn(),
+    });
+    const button = find(actionHost, (node) => node.className === "new-conversation-button");
+    const dialog = find(actionHost, (node) => node.tagName === "dialog");
+    let state = reduceChatState(emptyState, { type: "session-probe", hasSession: true });
+    state = reduceChatState(state, { type: "open-new-conversation" });
+    mounted.view.render(state);
+    expect(dialog.open).toBe(true);
+
+    mounted.dispose();
+    button.dispatch("click");
+    expect(onOpenNewConversation).not.toHaveBeenCalled();
+    expect(dialog.open).toBe(false);
+    expect(dialog.removed).toBe(true);
+    expect(button.removed).toBe(true);
+    expect(find(thread, (node) => node.className === "chat-transcript").removed).toBe(true);
+    expect(find(composerHost, (node) => node.className === "composer").removed).toBe(true);
   });
 });

--- a/apps/desktop-renderer/tests/turn-state.test.ts
+++ b/apps/desktop-renderer/tests/turn-state.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   DESKTOP_CHAT_ID,
   EMPTY_CHAT_STATE,
+  hasClearableConversation,
   reduceChatState,
   type ChatState,
 } from "../src/turn-state.js";
@@ -41,6 +42,7 @@ describe("desktop turn state", () => {
     });
     state = reduceChatState(state, { type: "complete", requestKey: 1 });
     expect(state.messages.at(-1)).toMatchObject({ text: "Hello.", delivery: "complete" });
+    expect(state.session.presence).toBe("present");
   });
 
   it("accepts optional start and retains safe contract error fields", () => {
@@ -95,5 +97,236 @@ describe("desktop turn state", () => {
       text: "Partial",
       delivery: "interrupted",
     });
+  });
+
+  it("records probe presence without letting a stale absence erase proven server presence", () => {
+    const present = reduceChatState(EMPTY_CHAT_STATE, {
+      type: "session-probe",
+      hasSession: true,
+    });
+    expect(present.session.presence).toBe("present");
+
+    const absent = reduceChatState(EMPTY_CHAT_STATE, {
+      type: "session-probe",
+      hasSession: false,
+    });
+    expect(absent.session.presence).toBe("absent");
+
+    let completed = started();
+    completed = reduceChatState(completed, {
+      type: "event",
+      requestKey: 1,
+      event: { type: "final-text", turnId: "turn-1", text: "Done" },
+    });
+    completed = reduceChatState(completed, { type: "complete", requestKey: 1 });
+    const fenced = reduceChatState(completed, { type: "session-probe", hasSession: false });
+    expect(fenced).toBe(completed);
+    expect(fenced.session.presence).toBe("present");
+  });
+
+  it("keeps server absence separate from visible local content that can be cleared", () => {
+    const absent = reduceChatState(EMPTY_CHAT_STATE, {
+      type: "session-probe",
+      hasSession: false,
+    });
+    const placeholder: ChatState = {
+      ...absent,
+      messages: [
+        {
+          id: "message-1",
+          role: "coach",
+          text: "",
+          delivery: "interrupted",
+        },
+      ],
+    };
+
+    expect(hasClearableConversation(placeholder)).toBe(false);
+    expect(reduceChatState(placeholder, { type: "open-new-conversation" })).toBe(placeholder);
+
+    let visible = reduceChatState(absent, {
+      type: "submit",
+      requestKey: 1,
+      userMessage: "Keep this visible",
+      userMessageId: "message-2",
+      assistantMessageId: "message-3",
+      includeUser: true,
+    });
+    visible = reduceChatState(visible, { type: "fail", requestKey: 1, copy: "Failed" });
+
+    expect(visible.session.presence).toBe("absent");
+    expect(hasClearableConversation(visible)).toBe(true);
+    const confirming = reduceChatState(visible, { type: "open-new-conversation" });
+    expect(confirming.session).toMatchObject({
+      presence: "absent",
+      resetPhase: "confirming",
+    });
+  });
+
+  it("promotes presence only for an exact successful completion", () => {
+    const absent = reduceChatState(EMPTY_CHAT_STATE, {
+      type: "session-probe",
+      hasSession: false,
+    });
+    let state = reduceChatState(absent, {
+      type: "submit",
+      requestKey: 4,
+      userMessage: "How should I train?",
+      userMessageId: "message-1",
+      assistantMessageId: "message-2",
+      includeUser: true,
+    });
+
+    expect(reduceChatState(state, { type: "complete", requestKey: 4 })).toBe(state);
+    state = reduceChatState(state, {
+      type: "event",
+      requestKey: 4,
+      event: { type: "final-text", turnId: "turn-4", text: "Train easy." },
+    });
+    expect(reduceChatState(state, { type: "complete", requestKey: 3 })).toBe(state);
+    expect(state.session.presence).toBe("absent");
+
+    const completed = reduceChatState(state, { type: "complete", requestKey: 4 });
+    expect(completed.session.presence).toBe("present");
+  });
+
+  it("opens and cancels confirmation without changing conversation content", () => {
+    const local = reduceChatState(started(), {
+      type: "interrupt",
+      requestKey: 1,
+      copy: "Interrupted",
+    });
+    const confirming = reduceChatState(local, { type: "open-new-conversation" });
+    expect(confirming.session.resetPhase).toBe("confirming");
+    expect(confirming.messages).toBe(local.messages);
+    expect(confirming.activeTurn).toBe(local.activeTurn);
+
+    const cancelled = reduceChatState(confirming, { type: "cancel-new-conversation" });
+    expect(cancelled.session.resetPhase).toBe("idle");
+    expect(cancelled.messages).toBe(local.messages);
+    expect(cancelled.activeTurn).toBe(local.activeTurn);
+  });
+
+  it.each([
+    "New conversation started.",
+    "New conversation started. Some recent details may not have been saved to coach memory.",
+  ])("clears the turn after a successful reset announced as %s", (announcement) => {
+    let state = started();
+    state = reduceChatState(state, {
+      type: "event",
+      requestKey: 1,
+      event: { type: "text_delta", turnId: "turn-1", delta: "Partial" },
+    });
+    state = reduceChatState(state, {
+      type: "interrupt",
+      requestKey: 1,
+      copy: "Interrupted",
+    });
+    state = reduceChatState(state, { type: "open-new-conversation" });
+    state = reduceChatState(state, { type: "begin-reset" });
+    state = reduceChatState(state, { type: "reset-succeeded", announcement });
+
+    expect(state).toEqual({
+      status: "idle",
+      messages: [],
+      activeTurn: null,
+      progress: null,
+      session: {
+        presence: "absent",
+        resetPhase: "idle",
+        resetCount: 1,
+        announcement,
+      },
+    });
+  });
+
+  it("preserves the exact turn on an uncertain reset failure", () => {
+    const local = reduceChatState(started(), {
+      type: "interrupt",
+      requestKey: 1,
+      copy: "Interrupted",
+    });
+    let resetting = reduceChatState(local, { type: "open-new-conversation" });
+    resetting = reduceChatState(resetting, { type: "begin-reset" });
+    const failed = reduceChatState(resetting, {
+      type: "reset-failed",
+      announcement: "Uncertain",
+    });
+
+    expect(failed.status).toBe(local.status);
+    expect(failed.messages).toBe(local.messages);
+    expect(failed.activeTurn).toBe(local.activeTurn);
+    expect(failed.progress).toBe(local.progress);
+    expect(failed.session).toMatchObject({
+      presence: "unknown",
+      resetPhase: "uncertain",
+      announcement: "Uncertain",
+    });
+  });
+
+  it("clears a reset announcement only when the next submit is accepted", () => {
+    const announced = {
+      ...EMPTY_CHAT_STATE,
+      session: {
+        presence: "absent" as const,
+        resetPhase: "idle" as const,
+        resetCount: 3,
+        announcement: "New conversation started.",
+      },
+    };
+    const submitted = reduceChatState(announced, {
+      type: "submit",
+      requestKey: 4,
+      userMessage: "What should I ride today?",
+      userMessageId: "message-4",
+      assistantMessageId: "message-5",
+      includeUser: true,
+    });
+
+    expect(submitted.session).toEqual({
+      presence: "absent",
+      resetPhase: "idle",
+      resetCount: 3,
+      announcement: null,
+    });
+
+    const rejected = reduceChatState(
+      {
+        ...submitted,
+        session: { ...submitted.session, announcement: "Keep this announcement." },
+      },
+      {
+        type: "submit",
+        requestKey: 5,
+        userMessage: "Do not accept this yet.",
+        userMessageId: "message-6",
+        assistantMessageId: "message-7",
+        includeUser: true,
+      },
+    );
+    expect(rejected.session.announcement).toBe("Keep this announcement.");
+  });
+
+  it("ignores old turn events after reset success", () => {
+    let state = started(7);
+    state = reduceChatState(state, {
+      type: "interrupt",
+      requestKey: 7,
+      copy: "Interrupted",
+    });
+    state = reduceChatState(state, { type: "open-new-conversation" });
+    state = reduceChatState(state, { type: "begin-reset" });
+    state = reduceChatState(state, {
+      type: "reset-succeeded",
+      announcement: "New conversation started.",
+    });
+    const stale = reduceChatState(state, {
+      type: "event",
+      requestKey: 7,
+      event: { type: "text_delta", turnId: "turn-7", delta: "stale" },
+    });
+
+    expect(stale).toBe(state);
+    expect(stale.messages).toEqual([]);
   });
 });

--- a/apps/desktop/tests/chat-panels.integration.test.ts
+++ b/apps/desktop/tests/chat-panels.integration.test.ts
@@ -106,6 +106,7 @@ function response(value: unknown): readonly string[] {
 
 function makeScript(calls: ScriptRequest[]): DesktopFixtureScript {
   let units: "metric" | "imperial" = "metric";
+  let hasSession = false;
   return {
     onRequest(value) {
       const request = value as ScriptRequest;
@@ -119,6 +120,7 @@ function makeScript(calls: ScriptRequest[]): DesktopFixtureScript {
         return response({ value: units, source: "cycling" });
       }
       if (request.method === "chat") {
+        hasSession = true;
         return [
           JSON.stringify({ type: "text_delta", turnId: "turn-fixture", delta: "Hold " }),
           JSON.stringify({ type: "text_delta", turnId: "turn-fixture", delta: "steady" }),
@@ -126,8 +128,11 @@ function makeScript(calls: ScriptRequest[]): DesktopFixtureScript {
           JSON.stringify({ text: "Hold steady." }),
         ];
       }
-      if (request.method === "hasSession") return response({ hasSession: false });
-      if (request.method === "resetSession") return response({ memoryFlushed: true });
+      if (request.method === "hasSession") return response({ hasSession });
+      if (request.method === "resetSession") {
+        hasSession = false;
+        return response({ memoryFlushed: true });
+      }
       if (request.method === "sync") {
         return response({
           schemaVersion: 1,
@@ -262,6 +267,63 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       anchorValue: "300 W",
       wellnessValue: "65 ms",
     });
+    expect(calls.filter((call) => call.method === "hasSession")).toEqual([
+      {
+        jsonrpc: "2.0",
+        method: "hasSession",
+        params: { chatId: "desktop" },
+      },
+    ]);
+    const reset = await fixture.evaluate<{
+      readonly enabledBefore: boolean;
+      readonly dialogOpen: boolean;
+      readonly transcriptEmpty: boolean;
+      readonly composerValue: string;
+      readonly composerDisabled: boolean;
+      readonly resetDisabled: boolean;
+      readonly focused: string | null;
+    }>(`
+      const opener = document.querySelector(".new-conversation-button");
+      const textarea = document.querySelector("#message");
+      const readyDeadline = Date.now() + 5000;
+      while ((opener.disabled || opener.getAttribute("aria-disabled") === "true" || textarea.disabled) && Date.now() < readyDeadline) {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+      }
+      const enabledBefore = !opener.disabled && opener.getAttribute("aria-disabled") !== "true" && !textarea.disabled;
+      if (enabledBefore) opener.click();
+      const dialog = document.querySelector(".new-conversation-dialog");
+      const dialogOpen = dialog.open;
+      if (dialogOpen) dialog.querySelector(".new-conversation-dialog__confirm").click();
+      const resetDeadline = Date.now() + 5000;
+      while (dialog.open && Date.now() < resetDeadline) {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+      }
+      return {
+        enabledBefore,
+        dialogOpen,
+        transcriptEmpty: document.querySelectorAll(".chat-message").length === 0,
+        composerValue: textarea.value,
+        composerDisabled: textarea.disabled,
+        resetDisabled: opener.disabled,
+        focused: document.activeElement?.id ?? null,
+      };
+    `);
+    expect(reset).toEqual({
+      enabledBefore: true,
+      dialogOpen: true,
+      transcriptEmpty: true,
+      composerValue: "",
+      composerDisabled: false,
+      resetDisabled: true,
+      focused: "message",
+    });
+    expect(calls.filter((call) => call.method === "resetSession")).toEqual([
+      {
+        jsonrpc: "2.0",
+        method: "resetSession",
+        params: { chatId: "desktop" },
+      },
+    ]);
     const drawer = await fixture.evaluate<{
       readonly open: boolean;
       readonly focused: string | null;
@@ -318,10 +380,14 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
     ]);
     await fixture.setViewport(720, 800);
     expect(
-      await fixture.evaluate<boolean>(`
-      return document.documentElement.scrollWidth > document.documentElement.clientWidth;
+      await fixture.evaluate<{ readonly documentOverflow: boolean; readonly topbarFits: boolean }>(`
+      const topbar = document.querySelector(".topbar");
+      return {
+        documentOverflow: document.documentElement.scrollWidth > document.documentElement.clientWidth,
+        topbarFits: topbar.scrollWidth <= topbar.clientWidth,
+      };
     `),
-    ).toBe(false);
+    ).toEqual({ documentOverflow: false, topbarFits: true });
     const base = await realpath(process.platform === "darwin" ? "/tmp" : tmpdir());
     const screenshotRoot = await mkdtemp(join(base, "eap-shot-"));
     scratchPaths.push(screenshotRoot);


### PR DESCRIPTION
## Summary

- add a confirmation-gated New conversation action using the existing Desktop session operations
- preserve the visible conversation on ambiguous reset outcomes and avoid automatic replay or reset retries
- keep keyboard focus, live announcements, transcript updates, and compact top-bar behavior accessible

## Safety

- reset is disabled while chat, retry, cleanup, or another reset is active
- startup probing and old task settlements are fenced from newer local state
- ambiguous outcomes preserve the transcript and draft until the renderer is reloaded

## Validation

- renderer state, controller, and view suites: 64 tests passed
- real Electron chat-panel integration: 2 tests passed
- renderer typecheck and production build
- root `pnpm check`
- three independent final read-only reviews
