### PR TITLE
feat(desktop): render safe Markdown without transcript replay

### DIFF
--- a/.changeset/calm-desktop-coaching.md
+++ b/.changeset/calm-desktop-coaching.md
@@ -1,0 +1,5 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Desktop coaching responses now show readable formatting and update without repeatedly announcing the conversation history.

--- a/apps/desktop-renderer/src/chat/controller.ts
+++ b/apps/desktop-renderer/src/chat/controller.ts
@@ -14,6 +14,7 @@ import {
   reduceChatState,
   type ChatState,
 } from "../turn-state.js";
+import { COACH_RESPONSE_CODE_UNIT_LIMIT, COACH_TURN_EVENT_LIMIT } from "./limits.js";
 
 export const CHAT_CONNECTION_INTERRUPTED_COPY =
   "Connection interrupted. Your partial response is preserved.";
@@ -26,9 +27,17 @@ export const NEW_CONVERSATION_MEMORY_WARNING_COPY =
 export const NEW_CONVERSATION_UNCERTAIN_COPY =
   "We couldn’t confirm whether the new conversation started. Your visible conversation is preserved.";
 
+export interface ChatAppendDelta {
+  readonly messageId: string;
+  readonly previousTextLength: number;
+  readonly nextTextLength: number;
+  readonly delta: string;
+}
+
 export interface ChatViewControls {
   readonly newConversationDisabled: boolean;
   readonly workBlocked: boolean;
+  readonly appendDelta?: ChatAppendDelta;
 }
 
 export interface ChatView {
@@ -80,18 +89,22 @@ export function createChatController(input: {
     outstandingChatTasks.size === 0 &&
     queuedRetry === undefined &&
     resetTask === undefined;
-  const render = (): void => {
+  const render = (appendDelta?: ChatAppendDelta): void => {
     if (disposed) return;
     try {
       input.view.render(state, {
         newConversationDisabled: !canOpenNewConversation(),
         workBlocked: resetBlocksWork(),
+        ...(appendDelta === undefined ? {} : { appendDelta }),
       });
     } catch {}
   };
-  const reduce = (action: Parameters<typeof reduceChatState>[1]): void => {
+  const reduce = (
+    action: Parameters<typeof reduceChatState>[1],
+    appendDelta?: ChatAppendDelta,
+  ): void => {
     state = reduceChatState(state, action);
-    render();
+    render(appendDelta);
   };
 
   const run = (userMessage: string, includeUser: boolean, reconnect: boolean): Promise<void> => {
@@ -118,9 +131,12 @@ export function createChatController(input: {
       let terminal: CoachClientTerminalEnvelope | undefined;
       let terminalHadFinal = false;
       let protocolFault = false;
+      const callAbortController = new AbortController();
       const current = (): boolean => !disposed && state.activeTurn?.requestKey === requestKey;
       const failProtocol = (): void => {
+        if (protocolFault) return;
         protocolFault = true;
+        callAbortController.abort();
       };
 
       let client: CoachClient | undefined;
@@ -143,6 +159,7 @@ export function createChatController(input: {
           "chat",
           { chatId: DESKTOP_CHAT_ID, message: userMessage },
           {
+            signal: callAbortController.signal,
             onNotificationEnvelope(envelope) {
               if (!current() || protocolFault) return;
               if (
@@ -179,16 +196,42 @@ export function createChatController(input: {
                 failProtocol();
                 return;
               }
+              if (eventCount >= COACH_TURN_EVENT_LIMIT) {
+                failProtocol();
+                return;
+              }
+              eventCount += 1;
               if (event.type === "turn-start") {
-                if (eventCount !== 0 || startSeen || event.chatId !== DESKTOP_CHAT_ID) {
+                if (eventCount !== 1 || startSeen || event.chatId !== DESKTOP_CHAT_ID) {
                   failProtocol();
                   return;
                 }
                 startSeen = true;
               }
-              eventCount += 1;
+              let appendDelta: ChatAppendDelta | undefined;
+              if (event.type === "text_delta") {
+                const activeTurn = state.activeTurn;
+                if (activeTurn === null || activeTurn.requestKey !== requestKey) return;
+                const previousTextLength = activeTurn.draft.length;
+                if (event.delta.length > COACH_RESPONSE_CODE_UNIT_LIMIT - previousTextLength) {
+                  failProtocol();
+                  return;
+                }
+                appendDelta = {
+                  messageId: activeTurn.assistantMessageId,
+                  previousTextLength,
+                  nextTextLength: previousTextLength + event.delta.length,
+                  delta: event.delta,
+                };
+              } else if (
+                event.type === "final-text" &&
+                event.text.length > COACH_RESPONSE_CODE_UNIT_LIMIT
+              ) {
+                failProtocol();
+                return;
+              }
               if (event.type === "final-text") finalText = event.text;
-              reduce({ type: "event", requestKey, event });
+              reduce({ type: "event", requestKey, event }, appendDelta);
             },
             onTerminalEnvelope(envelope) {
               if (!current()) return;

--- a/apps/desktop-renderer/src/chat/limits.ts
+++ b/apps/desktop-renderer/src/chat/limits.ts
@@ -1,0 +1,2 @@
+export const COACH_RESPONSE_CODE_UNIT_LIMIT = 100_000;
+export const COACH_TURN_EVENT_LIMIT = 4_096;

--- a/apps/desktop-renderer/src/chat/markdown.ts
+++ b/apps/desktop-renderer/src/chat/markdown.ts
@@ -1,0 +1,585 @@
+import { COACH_RESPONSE_CODE_UNIT_LIMIT } from "./limits.js";
+
+export interface CoachMarkdownLimits {
+  readonly sourceCharacters: number;
+  readonly workUnits: number;
+  readonly nodes: number;
+}
+
+export const DEFAULT_COACH_MARKDOWN_LIMITS: CoachMarkdownLimits = Object.freeze({
+  sourceCharacters: COACH_RESPONSE_CODE_UNIT_LIMIT,
+  workUnits: 500_000,
+  nodes: 4_096,
+});
+
+const MAX_INLINE_DEPTH = 16;
+const FENCE_OPENING = /^ {0,3}(`{3,}|~{3,})(?:[ \t]*([\w-]+))?[ \t]*$/u;
+const HEADING = /^ {0,3}(#{1,6})[ \t]+(.+)$/u;
+const UNORDERED_ITEM = /^ {0,3}[-+*][ \t]+(.+)$/u;
+const ORDERED_ITEM = /^ {0,3}(\d+)[.)][ \t]+(.+)$/u;
+
+class MarkdownBudget {
+  private workRemaining: number;
+  private nodesRemaining: number;
+
+  constructor(source: string, limits: CoachMarkdownLimits) {
+    if (
+      !Number.isSafeInteger(limits.sourceCharacters) ||
+      limits.sourceCharacters < 0 ||
+      !Number.isSafeInteger(limits.workUnits) ||
+      limits.workUnits < 0 ||
+      !Number.isSafeInteger(limits.nodes) ||
+      limits.nodes < 0 ||
+      source.length > limits.sourceCharacters
+    ) {
+      throw new RangeError();
+    }
+    this.workRemaining = limits.workUnits;
+    this.nodesRemaining = limits.nodes;
+    this.work(source.length);
+  }
+
+  work(units: number): void {
+    this.workRemaining -= units;
+    if (this.workRemaining < 0) throw new RangeError();
+  }
+
+  node(): void {
+    this.nodesRemaining -= 1;
+    if (this.nodesRemaining < 0) throw new RangeError();
+  }
+}
+
+function element(budget: MarkdownBudget, tagName: string): HTMLElement {
+  budget.node();
+  return document.createElement(tagName);
+}
+
+function textNode(budget: MarkdownBudget, value: string): Text {
+  budget.node();
+  return document.createTextNode(value);
+}
+
+function setLiteral(element: HTMLElement, value: string, budget: MarkdownBudget): void {
+  if (value.length > 0) budget.node();
+  element.textContent = value;
+}
+
+function appendText(parent: HTMLElement, value: string, budget: MarkdownBudget): void {
+  if (value.length > 0) parent.append(textNode(budget, value));
+}
+
+function hasUnsafeUrlCodePoint(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code <= 0x20 || code === 0x7f) return true;
+  }
+  return false;
+}
+
+function canonicalExternalUrl(value: string): string | undefined {
+  if (hasUnsafeUrlCodePoint(value)) return undefined;
+  try {
+    const url = new URL(value);
+    if (
+      (url.protocol !== "http:" && url.protocol !== "https:") ||
+      url.hostname.length === 0 ||
+      url.username.length > 0 ||
+      url.password.length > 0
+    ) {
+      return undefined;
+    }
+    return url.href;
+  } catch {
+    return undefined;
+  }
+}
+
+function isWhitespace(value: string | undefined): boolean {
+  return value === undefined || /\s/u.test(value);
+}
+
+function isWord(value: string | undefined): boolean {
+  return value !== undefined && /\w/u.test(value);
+}
+
+function canOpenAsterisk(text: string, index: number): boolean {
+  const before = text[index - 1];
+  const after = text[index + 1];
+  return !isWord(before) && before !== "*" && !isWhitespace(after) && after !== "*";
+}
+
+function canCloseAsterisk(text: string, index: number): boolean {
+  const before = text[index - 1];
+  const after = text[index + 1];
+  return !isWhitespace(before) && before !== "*" && !isWord(after) && after !== "*";
+}
+
+function canOpenUnderscore(text: string, index: number): boolean {
+  return !isWord(text[index - 1]);
+}
+
+function canCloseUnderscore(text: string, index: number, length = 1): boolean {
+  return !isWord(text[index + length]);
+}
+
+function escapedAt(text: string, index: number): boolean {
+  let slashes = 0;
+  for (let cursor = index - 1; cursor >= 0 && text[cursor] === "\\"; cursor -= 1) slashes += 1;
+  return slashes % 2 === 1;
+}
+
+function findSimpleClosing(
+  text: string,
+  from: number,
+  marker: string,
+  budget: MarkdownBudget,
+): number {
+  for (let index = from; index <= text.length - marker.length; index += 1) {
+    budget.work(1);
+    if (text[index] === "\n") return -1;
+    if (text[index] !== marker[0] || escapedAt(text, index)) continue;
+    budget.work(marker.length);
+    if (text.startsWith(marker, index)) return index;
+  }
+  return -1;
+}
+
+function findSingleEmphasisClosing(
+  text: string,
+  from: number,
+  marker: "*" | "_",
+  budget: MarkdownBudget,
+): number {
+  for (let index = from; index < text.length; index += 1) {
+    budget.work(1);
+    if (marker === "*" && text[index] === "\n") return -1;
+    if (text[index] !== marker || escapedAt(text, index)) continue;
+    return index;
+  }
+  return -1;
+}
+
+type ParsedLink =
+  | { readonly kind: "none"; readonly consumed: number }
+  | { readonly kind: "unterminated" }
+  | {
+      readonly kind: "complete";
+      readonly end: number;
+      readonly label: string;
+      readonly destination: string;
+    };
+
+function parseLink(text: string, start: number, budget: MarkdownBudget): ParsedLink {
+  let labelEnd = -1;
+  for (let index = start + 1; index < text.length; index += 1) {
+    budget.work(1);
+    if (text[index] === "]" && !escapedAt(text, index)) {
+      labelEnd = index;
+      break;
+    }
+  }
+  if (labelEnd === -1) return { kind: "unterminated" };
+  if (text[labelEnd + 1] !== "(") {
+    return { kind: "none", consumed: labelEnd - start + 1 };
+  }
+
+  let depth = 1;
+  let destination = "";
+  for (let index = labelEnd + 2; index < text.length; index += 1) {
+    budget.work(1);
+    const current = text[index]!;
+    if (current === "\\" && index + 1 < text.length) {
+      budget.work(1);
+      destination += text[index + 1]!;
+      index += 1;
+      continue;
+    }
+    if (current === "(") {
+      depth += 1;
+      destination += current;
+      continue;
+    }
+    if (current === ")") {
+      depth -= 1;
+      if (depth === 0) {
+        return {
+          kind: "complete",
+          end: index + 1,
+          label: text.slice(start + 1, labelEnd),
+          destination,
+        };
+      }
+      destination += current;
+      continue;
+    }
+    destination += current;
+  }
+  return { kind: "unterminated" };
+}
+
+function appendInline(
+  parent: HTMLElement,
+  source: string,
+  budget: MarkdownBudget,
+  depth = 0,
+): void {
+  if (depth >= MAX_INLINE_DEPTH) {
+    appendText(parent, source, budget);
+    return;
+  }
+
+  let index = 0;
+  let plain = "";
+  const flush = (): void => {
+    appendText(parent, plain, budget);
+    plain = "";
+  };
+  const appendRemainder = (): void => {
+    plain += source.slice(index);
+    index = source.length;
+  };
+
+  while (index < source.length) {
+    budget.work(1);
+    const current = source[index]!;
+    if (current === "\\" && index + 1 < source.length) {
+      budget.work(1);
+      plain += source[index + 1]!;
+      index += 2;
+      continue;
+    }
+    if (current === "\n") {
+      flush();
+      parent.append(element(budget, "br"));
+      index += 1;
+      continue;
+    }
+
+    if (current === "`") {
+      let markerLength = 1;
+      while (source[index + markerLength] === "`") markerLength += 1;
+      budget.work(markerLength - 1);
+      const marker = "`".repeat(markerLength);
+      const closing = findSimpleClosing(source, index + markerLength, marker, budget);
+      if (closing === -1) {
+        appendRemainder();
+        break;
+      }
+      flush();
+      const code = element(budget, "code");
+      setLiteral(code, source.slice(index + markerLength, closing), budget);
+      parent.append(code);
+      index = closing + markerLength;
+      continue;
+    }
+
+    const pairedMarker = source.startsWith("**", index)
+      ? { marker: "**", tag: "strong" }
+      : source.startsWith("~~", index)
+        ? { marker: "~~", tag: "del" }
+        : undefined;
+    if (pairedMarker !== undefined) {
+      const contentStart = index + pairedMarker.marker.length;
+      const closing = findSimpleClosing(source, contentStart, pairedMarker.marker, budget);
+      if (closing === -1) {
+        appendRemainder();
+        break;
+      }
+      if (closing === contentStart) {
+        plain += pairedMarker.marker;
+        index = contentStart;
+        continue;
+      }
+      flush();
+      const formatted = element(budget, pairedMarker.tag);
+      appendInline(formatted, source.slice(contentStart, closing), budget, depth + 1);
+      parent.append(formatted);
+      index = closing + pairedMarker.marker.length;
+      continue;
+    }
+
+    if (current === "[" && (index === 0 || source[index - 1] !== "!")) {
+      const link = parseLink(source, index, budget);
+      if (link.kind === "unterminated") {
+        appendRemainder();
+        break;
+      }
+      if (link.kind === "none") {
+        plain += source.slice(index, index + link.consumed);
+        index += link.consumed;
+        continue;
+      }
+      const href = canonicalExternalUrl(link.destination);
+      if (href === undefined) {
+        plain += source.slice(index, link.end);
+      } else {
+        flush();
+        const anchor = element(budget, "a");
+        anchor.setAttribute("href", href);
+        anchor.setAttribute("target", "_blank");
+        anchor.setAttribute("rel", "noopener noreferrer");
+        anchor.setAttribute("referrerpolicy", "no-referrer");
+        appendInline(anchor, link.label, budget, depth + 1);
+        parent.append(anchor);
+      }
+      index = link.end;
+      continue;
+    }
+
+    const canOpenEmphasis =
+      (current === "*" && canOpenAsterisk(source, index)) ||
+      (current === "_" && canOpenUnderscore(source, index));
+    if ((current === "*" || current === "_") && canOpenEmphasis) {
+      const closing = findSingleEmphasisClosing(source, index + 1, current, budget);
+      if (closing === -1) {
+        appendRemainder();
+        break;
+      }
+      const canClose =
+        closing > index + 1 &&
+        (current === "*" ? canCloseAsterisk(source, closing) : canCloseUnderscore(source, closing));
+      if (!canClose) {
+        plain += current;
+        index += 1;
+        continue;
+      }
+      flush();
+      const emphasis = element(budget, "em");
+      appendInline(emphasis, source.slice(index + 1, closing), budget, depth + 1);
+      parent.append(emphasis);
+      index = closing + 1;
+      continue;
+    }
+
+    plain += current;
+    index += 1;
+  }
+  flush();
+}
+
+function splitTableRow(line: string, budget: MarkdownBudget): string[] {
+  budget.work(line.length);
+  const trimmed = line.trim().replace(/^\|/u, "").replace(/\|$/u, "");
+  const cells: string[] = [];
+  let cell = "";
+  let codeMarkerLength = 0;
+  for (let index = 0; index < trimmed.length; index += 1) {
+    budget.work(1);
+    const current = trimmed[index]!;
+    if (current === "\\" && trimmed[index + 1] === "|") {
+      cell += "|";
+      index += 1;
+      continue;
+    }
+    if (current === "`") {
+      let length = 1;
+      while (trimmed[index + length] === "`") length += 1;
+      if (codeMarkerLength === 0) codeMarkerLength = length;
+      else if (codeMarkerLength === length) codeMarkerLength = 0;
+      cell += "`".repeat(length);
+      index += length - 1;
+      continue;
+    }
+    if (current === "|" && codeMarkerLength === 0) {
+      cells.push(cell.trim());
+      cell = "";
+      continue;
+    }
+    cell += current;
+  }
+  cells.push(cell.trim());
+  return cells;
+}
+
+function tableColumns(
+  lines: readonly string[],
+  index: number,
+  budget: MarkdownBudget,
+): readonly string[][] | undefined {
+  if (index + 1 >= lines.length || !lines[index]!.includes("|")) return undefined;
+  const header = splitTableRow(lines[index]!, budget);
+  const separator = splitTableRow(lines[index + 1]!, budget);
+  if (
+    header.length !== separator.length ||
+    header.length === 0 ||
+    !separator.every((cell) => /^:?-{3,}:?$/u.test(cell))
+  ) {
+    return undefined;
+  }
+  return [header, separator];
+}
+
+function closesFence(line: string, marker: string, budget: MarkdownBudget): boolean {
+  budget.work(line.length);
+  let index = 0;
+  while (index < 3 && line[index] === " ") index += 1;
+  let markerLength = 0;
+  while (line[index + markerLength] === marker[0]) markerLength += 1;
+  if (markerLength < marker.length) return false;
+  for (let cursor = index + markerLength; cursor < line.length; cursor += 1) {
+    if (line[cursor] !== " " && line[cursor] !== "\t") return false;
+  }
+  return true;
+}
+
+function isBlockStart(lines: readonly string[], index: number, budget: MarkdownBudget): boolean {
+  const line = lines[index]!;
+  budget.work(line.length);
+  return (
+    HEADING.test(line) ||
+    UNORDERED_ITEM.test(line) ||
+    ORDERED_ITEM.test(line) ||
+    FENCE_OPENING.test(line) ||
+    tableColumns(lines, index, budget) !== undefined
+  );
+}
+
+function appendTable(
+  parent: DocumentFragment,
+  rows: readonly string[][],
+  budget: MarkdownBudget,
+): void {
+  const scroll = element(budget, "div");
+  scroll.className = "chat-markdown__table-scroll";
+  const table = element(budget, "table");
+  const head = element(budget, "thead");
+  const headRow = element(budget, "tr");
+  for (const value of rows[0]!) {
+    const heading = element(budget, "th");
+    heading.setAttribute("scope", "col");
+    appendInline(heading, value, budget);
+    headRow.append(heading);
+  }
+  head.append(headRow);
+  table.append(head);
+  if (rows.length > 1) {
+    const body = element(budget, "tbody");
+    for (const row of rows.slice(1)) {
+      const tableRow = element(budget, "tr");
+      for (let index = 0; index < rows[0]!.length; index += 1) {
+        const cell = element(budget, "td");
+        appendInline(cell, row[index] ?? "", budget);
+        tableRow.append(cell);
+      }
+      body.append(tableRow);
+    }
+    table.append(body);
+  }
+  scroll.append(table);
+  parent.append(scroll);
+}
+
+function parseBlocks(source: string, budget: MarkdownBudget): DocumentFragment {
+  const fragment = document.createDocumentFragment();
+  const lines = source.replace(/\r\n?/gu, "\n").split("\n");
+  let index = 0;
+  while (index < lines.length) {
+    const line = lines[index]!;
+    budget.work(line.length + 1);
+    if (line.trim().length === 0) {
+      index += 1;
+      continue;
+    }
+
+    const opening = FENCE_OPENING.exec(line);
+    if (opening !== null) {
+      const marker = opening[1]!;
+      let closingIndex = -1;
+      for (let cursor = index + 1; cursor < lines.length; cursor += 1) {
+        if (closesFence(lines[cursor]!, marker, budget)) {
+          closingIndex = cursor;
+          break;
+        }
+      }
+      const pre = element(budget, "pre");
+      const code = element(budget, "code");
+      if (closingIndex === -1) {
+        setLiteral(code, lines.slice(index).join("\n"), budget);
+        pre.append(code);
+        fragment.append(pre);
+        break;
+      }
+      if (opening[2] !== undefined) code.dataset.language = opening[2];
+      setLiteral(code, lines.slice(index + 1, closingIndex).join("\n"), budget);
+      pre.append(code);
+      fragment.append(pre);
+      index = closingIndex + 1;
+      continue;
+    }
+
+    const heading = HEADING.exec(line);
+    if (heading !== null) {
+      const headingElement = element(budget, `h${heading[1]!.length}`);
+      appendInline(headingElement, heading[2]!, budget);
+      fragment.append(headingElement);
+      index += 1;
+      continue;
+    }
+
+    const columns = tableColumns(lines, index, budget);
+    if (columns !== undefined) {
+      const rows = [columns[0]!];
+      index += 2;
+      while (
+        index < lines.length &&
+        lines[index]!.trim().length > 0 &&
+        lines[index]!.includes("|")
+      ) {
+        rows.push(splitTableRow(lines[index]!, budget));
+        index += 1;
+      }
+      appendTable(fragment, rows, budget);
+      continue;
+    }
+
+    const unordered = UNORDERED_ITEM.exec(line);
+    const ordered = ORDERED_ITEM.exec(line);
+    if (unordered !== null || ordered !== null) {
+      const orderedList = ordered !== null;
+      const list = element(budget, orderedList ? "ol" : "ul");
+      if (ordered !== null && ordered[1] !== "1") list.setAttribute("start", ordered[1]!);
+      while (index < lines.length) {
+        budget.work(lines[index]!.length);
+        const match = orderedList
+          ? ORDERED_ITEM.exec(lines[index]!)
+          : UNORDERED_ITEM.exec(lines[index]!);
+        if (match === null) break;
+        const item = element(budget, "li");
+        appendInline(item, match[orderedList ? 2 : 1]!, budget);
+        list.append(item);
+        index += 1;
+      }
+      fragment.append(list);
+      continue;
+    }
+
+    const paragraphLines = [line];
+    index += 1;
+    while (
+      index < lines.length &&
+      lines[index]!.trim().length > 0 &&
+      !isBlockStart(lines, index, budget)
+    ) {
+      paragraphLines.push(lines[index]!);
+      index += 1;
+    }
+    const paragraph = element(budget, "p");
+    appendInline(paragraph, paragraphLines.join("\n"), budget);
+    fragment.append(paragraph);
+  }
+  return fragment;
+}
+
+export function renderCoachMarkdown(
+  container: HTMLElement,
+  source: string,
+  limits: CoachMarkdownLimits = DEFAULT_COACH_MARKDOWN_LIMITS,
+): void {
+  try {
+    const budget = new MarkdownBudget(source, limits);
+    container.replaceChildren(parseBlocks(source, budget));
+  } catch {
+    container.textContent = source;
+  }
+}

--- a/apps/desktop-renderer/src/chat/styles.css
+++ b/apps/desktop-renderer/src/chat/styles.css
@@ -11,6 +11,7 @@
 .chat-message {
   display: grid;
   gap: 7px;
+  min-width: 0;
   max-width: 78%;
 }
 
@@ -46,9 +47,115 @@
 }
 
 .chat-message__text {
+  min-width: 0;
   line-height: 1.6;
-  white-space: pre-wrap;
   overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
+.chat-message__text > :first-child {
+  margin-top: 0;
+}
+
+.chat-message__text > :last-child {
+  margin-bottom: 0;
+}
+
+.chat-message__text p,
+.chat-message__text ul,
+.chat-message__text ol,
+.chat-message__text pre,
+.chat-message__text .chat-markdown__table-scroll {
+  margin: 0.65em 0;
+}
+
+.chat-message__text h1,
+.chat-message__text h2,
+.chat-message__text h3,
+.chat-message__text h4,
+.chat-message__text h5,
+.chat-message__text h6 {
+  margin: 0.85em 0 0.35em;
+  color: inherit;
+  line-height: 1.25;
+}
+
+.chat-message__text h1 {
+  font-size: 1.35em;
+}
+
+.chat-message__text h2 {
+  font-size: 1.25em;
+}
+
+.chat-message__text h3,
+.chat-message__text h4,
+.chat-message__text h5,
+.chat-message__text h6 {
+  font-size: 1.1em;
+}
+
+.chat-message__text ul,
+.chat-message__text ol {
+  padding-inline-start: 1.5em;
+}
+
+.chat-message__text li + li {
+  margin-top: 0.2em;
+}
+
+.chat-message__text code {
+  padding: 0.12em 0.35em;
+  border-radius: 4px;
+  color: inherit;
+  background: color-mix(in srgb, currentColor 9%, transparent);
+  font-family: SFMono-Regular, ui-monospace, monospace;
+  font-size: 0.9em;
+}
+
+.chat-message__text pre {
+  max-width: 100%;
+  padding: 12px;
+  overflow-x: auto;
+  border: 1px solid var(--line-strong);
+  border-radius: 8px;
+  background: color-mix(in srgb, currentColor 5%, transparent);
+}
+
+.chat-message__text pre code {
+  padding: 0;
+  background: transparent;
+  overflow-wrap: normal;
+  white-space: pre;
+  word-break: normal;
+}
+
+.chat-message__text a {
+  color: inherit;
+  font-weight: 600;
+  text-decoration-thickness: 0.08em;
+  text-underline-offset: 0.16em;
+}
+
+.chat-markdown__table-scroll {
+  max-width: 100%;
+  overflow-x: auto;
+}
+
+.chat-message__text table {
+  min-width: 100%;
+  border-collapse: collapse;
+  font-size: 0.92em;
+}
+
+.chat-message__text th,
+.chat-message__text td {
+  padding: 0.45em 0.6em;
+  border: 1px solid var(--line-strong);
+  color: inherit;
+  text-align: start;
+  vertical-align: top;
+  white-space: nowrap;
 }
 
 .chat-notice {

--- a/apps/desktop-renderer/src/chat/view.ts
+++ b/apps/desktop-renderer/src/chat/view.ts
@@ -1,7 +1,16 @@
 import type { ChatView } from "./controller.js";
 import type { ChatTranscriptMessage } from "../turn-state.js";
+import { renderCoachMarkdown } from "./markdown.js";
 
-type RenderedMessage = Pick<ChatTranscriptMessage, "role" | "text" | "delivery">;
+interface RenderedMessage {
+  readonly article: HTMLElement;
+  readonly roleNode: HTMLElement;
+  readonly textNode: HTMLElement;
+  streamTextNode: Text | null;
+  role: ChatTranscriptMessage["role"];
+  text: string;
+  delivery: ChatTranscriptMessage["delivery"];
+}
 
 export interface MountedChatView {
   readonly view: ChatView;
@@ -57,6 +66,8 @@ export function mountChatView(input: {
   transcript.className = "chat-transcript";
   transcript.setAttribute("role", "log");
   transcript.setAttribute("aria-live", "polite");
+  transcript.setAttribute("aria-relevant", "additions text");
+  transcript.setAttribute("aria-atomic", "false");
   transcript.setAttribute("aria-label", "Coach conversation");
   const messages = document.createElement("div");
   messages.className = "chat-messages";
@@ -110,7 +121,7 @@ export function mountChatView(input: {
   let disposed = false;
   let renderedResetCount = 0;
   let renderedAnnouncement: string | null = null;
-  let renderedMessages: readonly RenderedMessage[] = [];
+  const renderedMessages = new Map<string, RenderedMessage>();
   let renderedNotice: string | null = null;
 
   const onSubmit = (event: SubmitEvent): void => {
@@ -152,6 +163,14 @@ export function mountChatView(input: {
     view: {
       render(state, controls) {
         if (disposed) return;
+        const messageIds = new Set(state.messages.map((message) => message.id));
+        if (messageIds.size !== state.messages.length) {
+          throw new TypeError("duplicate chat message id");
+        }
+        const nextMessages = state.messages.filter(
+          (message) => message.role === "athlete" || message.text.length > 0,
+        );
+        const nextIds = new Set(nextMessages.map((message) => message.id));
         const workBlocked =
           controls?.workBlocked ??
           (state.session.resetPhase === "confirming" || state.session.resetPhase === "resetting");
@@ -201,36 +220,105 @@ export function mountChatView(input: {
             input.conversation.scrollTop -
             input.conversation.clientHeight <=
           80;
-        const nextMessages = state.messages
-          .filter((message) => message.role === "athlete" || message.text.length > 0)
-          .map(({ role, text, delivery }) => ({ role, text, delivery }));
-        const messagesChanged =
-          nextMessages.length !== renderedMessages.length ||
-          nextMessages.some((message, index) => {
-            const rendered = renderedMessages[index];
-            return (
-              rendered === undefined ||
-              message.role !== rendered.role ||
-              message.text !== rendered.text ||
-              message.delivery !== rendered.delivery
-            );
+        if (nextMessages.length === 0 && renderedMessages.size > 0) {
+          messages.textContent = "";
+          renderedMessages.clear();
+        } else {
+          for (const [id, rendered] of renderedMessages) {
+            if (!nextIds.has(id)) {
+              rendered.article.remove();
+              renderedMessages.delete(id);
+            }
+          }
+          nextMessages.forEach((message, index) => {
+            let rendered = renderedMessages.get(message.id);
+            if (rendered === undefined) {
+              const article = document.createElement("article");
+              article.dataset.messageId = message.id;
+              const roleNode = document.createElement("p");
+              roleNode.className = "chat-message__role";
+              const textNode = document.createElement("div");
+              textNode.className = "chat-message__text";
+              article.append(roleNode, textNode);
+              rendered = {
+                article,
+                roleNode,
+                textNode,
+                streamTextNode: null,
+                role: message.role,
+                text: message.text,
+                delivery: message.delivery,
+              };
+              renderedMessages.set(message.id, rendered);
+              article.className = `chat-message chat-message--${message.role}`;
+              article.dataset.delivery = message.delivery;
+              roleNode.textContent = message.role === "athlete" ? "You" : "Coach";
+              if (message.role === "athlete") article.setAttribute("aria-live", "off");
+              article.setAttribute("aria-atomic", message.role === "coach" ? "true" : "false");
+              if (message.role === "coach" && message.delivery === "streaming") {
+                article.setAttribute("aria-busy", "true");
+              }
+              if (message.role === "coach" && message.delivery === "streaming") {
+                rendered.streamTextNode = document.createTextNode(message.text);
+                textNode.append(rendered.streamTextNode);
+              } else if (message.role === "coach") {
+                renderCoachMarkdown(textNode, message.text);
+              } else {
+                textNode.textContent = message.text;
+              }
+            } else {
+              const roleChanged = message.role !== rendered.role;
+              const wasBusy = rendered.role === "coach" && rendered.delivery === "streaming";
+              const isBusy = message.role === "coach" && message.delivery === "streaming";
+              if (!wasBusy && isBusy) rendered.article.setAttribute("aria-busy", "true");
+              if (roleChanged) {
+                rendered.article.className = `chat-message chat-message--${message.role}`;
+                rendered.roleNode.textContent = message.role === "athlete" ? "You" : "Coach";
+                if (message.role === "athlete") rendered.article.setAttribute("aria-live", "off");
+                else rendered.article.removeAttribute("aria-live");
+                rendered.article.setAttribute(
+                  "aria-atomic",
+                  message.role === "coach" ? "true" : "false",
+                );
+              }
+              if (message.delivery !== rendered.delivery) {
+                rendered.article.dataset.delivery = message.delivery;
+              }
+              if (roleChanged || message.text !== rendered.text || wasBusy !== isBusy) {
+                if (isBusy) {
+                  const appendDelta = controls?.appendDelta;
+                  if (
+                    !roleChanged &&
+                    rendered.streamTextNode !== null &&
+                    appendDelta?.messageId === message.id &&
+                    appendDelta.previousTextLength === rendered.text.length &&
+                    appendDelta.nextTextLength === message.text.length &&
+                    appendDelta.nextTextLength ===
+                      appendDelta.previousTextLength + appendDelta.delta.length
+                  ) {
+                    rendered.streamTextNode.appendData(appendDelta.delta);
+                  } else {
+                    rendered.streamTextNode = document.createTextNode(message.text);
+                    rendered.textNode.replaceChildren(rendered.streamTextNode);
+                  }
+                } else if (message.role === "coach") {
+                  renderCoachMarkdown(rendered.textNode, message.text);
+                  rendered.streamTextNode = null;
+                } else {
+                  rendered.textNode.textContent = message.text;
+                  rendered.streamTextNode = null;
+                }
+              }
+              if (wasBusy && !isBusy) rendered.article.removeAttribute("aria-busy");
+              rendered.role = message.role;
+              rendered.text = message.text;
+              rendered.delivery = message.delivery;
+            }
+            const currentAtIndex = messages.children.item(index);
+            if (currentAtIndex !== rendered.article) {
+              messages.insertBefore(rendered.article, currentAtIndex);
+            }
           });
-        if (messagesChanged) {
-          const rows = nextMessages.map((message) => {
-            const article = document.createElement("article");
-            article.className = `chat-message chat-message--${message.role}`;
-            article.dataset.delivery = message.delivery;
-            const role = document.createElement("p");
-            role.className = "chat-message__role";
-            role.textContent = message.role === "athlete" ? "You" : "Coach";
-            const text = document.createElement("p");
-            text.className = "chat-message__text";
-            text.textContent = message.text;
-            article.append(role, text);
-            return article;
-          });
-          messages.replaceChildren(...rows);
-          renderedMessages = nextMessages;
         }
         if (followsLatest) input.conversation.scrollTop = input.conversation.scrollHeight;
         const contractCopy = state.activeTurn?.error?.athleteMessage ?? null;

--- a/apps/desktop-renderer/tests/chat-controller.test.ts
+++ b/apps/desktop-renderer/tests/chat-controller.test.ts
@@ -17,6 +17,7 @@ import {
   type ChatViewControls,
   createChatController,
 } from "../src/chat/controller.js";
+import { COACH_RESPONSE_CODE_UNIT_LIMIT, COACH_TURN_EVENT_LIMIT } from "../src/chat/limits.js";
 import type { DesktopCoachClientProvider } from "../src/coach-client.js";
 import { EMPTY_CHAT_STATE, type ChatState } from "../src/turn-state.js";
 
@@ -52,6 +53,19 @@ function errorEvent(message = "Safe athlete message"): Extract<TurnEvent, { type
 function deliver(options: CoachClientCallOptions<"chat"> | undefined, event: TurnEvent): void {
   options?.onNotificationEnvelope?.(envelope(event));
   options?.onEvent?.(event);
+}
+
+function rejectWhenAborted(options: CoachClientCallOptions<"chat"> | undefined): Promise<never> {
+  return new Promise((_, reject) => {
+    const signal = options?.signal;
+    if (signal === undefined) {
+      reject(new TypeError("missing call abort signal"));
+      return;
+    }
+    const rejectAbort = (): void => reject(new CoachClientCallAbortedError("chat"));
+    if (signal.aborted) rejectAbort();
+    else signal.addEventListener("abort", rejectAbort, { once: true });
+  });
 }
 
 function client(
@@ -198,6 +212,147 @@ describe("chat controller", () => {
     ]);
     expect(refresh).toHaveBeenCalledTimes(1);
     expect(refreshSpend).toHaveBeenCalledTimes(1);
+  });
+
+  it("admits cumulative text deltas at the exact response boundary", async () => {
+    const first = "🚴".repeat(30_000);
+    const second = "b".repeat(COACH_RESPONSE_CODE_UNIT_LIMIT - first.length);
+    let signal: AbortSignal | undefined;
+    const fake = client(async (_request, options) => {
+      signal = options?.signal;
+      deliver(options, { type: "text_delta", turnId: "turn-1", delta: first });
+      deliver(options, { type: "text_delta", turnId: "turn-1", delta: second });
+      deliver(options, { type: "final-text", turnId: "turn-1", text: "Done" });
+      options?.onTerminalEnvelope?.({ jsonrpc: "2.0", id: 1, result: { text: "Done" } });
+      return { text: "Done" };
+    });
+    const { controller, states, controls } = subject(fake);
+
+    await controller.submit("Continue");
+
+    expect(
+      states.some((state) => state.activeTurn?.draft.length === COACH_RESPONSE_CODE_UNIT_LIMIT),
+    ).toBe(true);
+    expect(controls.filter((control) => control.appendDelta).at(-1)?.appendDelta).toEqual({
+      messageId: "message-3",
+      previousTextLength: first.length,
+      nextTextLength: COACH_RESPONSE_CODE_UNIT_LIMIT,
+      delta: second,
+    });
+    expect(states.at(-1)?.messages.at(-1)?.text).toBe("Done");
+    expect(signal?.aborted).toBe(false);
+  });
+
+  it("rejects one cumulative delta code unit over the response boundary", async () => {
+    const admitted = "a".repeat(COACH_RESPONSE_CODE_UNIT_LIMIT);
+    let signal: AbortSignal | undefined;
+    const fake = client(async (_request, options) => {
+      signal = options?.signal;
+      const aborted = rejectWhenAborted(options);
+      deliver(options, { type: "text_delta", turnId: "turn-1", delta: admitted });
+      deliver(options, { type: "text_delta", turnId: "turn-1", delta: "b" });
+      return aborted;
+    });
+    const { controller, states } = subject(fake);
+
+    await controller.submit("Continue");
+
+    expect(states.at(-1)).toMatchObject({
+      status: "interrupted",
+      progress: CHAT_PROTOCOL_FAILURE_COPY,
+    });
+    expect(states.at(-1)?.messages.at(-1)?.text).toBe(admitted);
+    expect(signal?.aborted).toBe(true);
+  });
+
+  it("admits final text at the exact response boundary", async () => {
+    const finalText = "🚴".repeat(COACH_RESPONSE_CODE_UNIT_LIMIT / 2);
+    let signal: AbortSignal | undefined;
+    const fake = client(async (_request, options) => {
+      signal = options?.signal;
+      deliver(options, { type: "final-text", turnId: "turn-1", text: finalText });
+      options?.onTerminalEnvelope?.({ jsonrpc: "2.0", id: 1, result: { text: finalText } });
+      return { text: finalText };
+    });
+    const { controller, states } = subject(fake);
+
+    await controller.submit("Continue");
+
+    expect(states.at(-1)?.messages.at(-1)).toMatchObject({
+      text: finalText,
+      delivery: "complete",
+    });
+    expect(signal?.aborted).toBe(false);
+  });
+
+  it("rejects final text one code unit over the response boundary", async () => {
+    const oversized = `${"🚴".repeat(COACH_RESPONSE_CODE_UNIT_LIMIT / 2)}x`;
+    let signal: AbortSignal | undefined;
+    const fake = client(async (_request, options) => {
+      signal = options?.signal;
+      const aborted = rejectWhenAborted(options);
+      deliver(options, { type: "text_delta", turnId: "turn-1", delta: "Preserved" });
+      deliver(options, { type: "final-text", turnId: "turn-1", text: oversized });
+      return aborted;
+    });
+    const { controller, states } = subject(fake);
+
+    await controller.submit("Continue");
+
+    expect(states.at(-1)).toMatchObject({
+      status: "interrupted",
+      progress: CHAT_PROTOCOL_FAILURE_COPY,
+    });
+    expect(states.at(-1)?.messages.at(-1)?.text).toBe("Preserved");
+    expect(states.some((state) => state.messages.at(-1)?.text === oversized)).toBe(false);
+    expect(signal?.aborted).toBe(true);
+  });
+
+  it("admits the final event at the exact turn-event boundary", async () => {
+    let signal: AbortSignal | undefined;
+    const fake = client(async (_request, options) => {
+      signal = options?.signal;
+      for (let index = 0; index < COACH_TURN_EVENT_LIMIT - 1; index += 1) {
+        deliver(options, { type: "step-text", turnId: "turn-1", text: "Checking" });
+      }
+      deliver(options, { type: "final-text", turnId: "turn-1", text: "Done" });
+      options?.onTerminalEnvelope?.({ jsonrpc: "2.0", id: 1, result: { text: "Done" } });
+      return { text: "Done" };
+    });
+    const { controller, states } = subject(fake);
+
+    await controller.submit("Continue");
+
+    expect(states.at(-1)?.messages.at(-1)).toMatchObject({
+      text: "Done",
+      delivery: "complete",
+    });
+    expect(signal?.aborted).toBe(false);
+  });
+
+  it("rejects one turn event over the boundary and preserves admitted text", async () => {
+    let signal: AbortSignal | undefined;
+    const fake = client(async (_request, options) => {
+      signal = options?.signal;
+      const aborted = rejectWhenAborted(options);
+      deliver(options, { type: "text_delta", turnId: "turn-1", delta: "Preserved" });
+      for (let index = 1; index < COACH_TURN_EVENT_LIMIT; index += 1) {
+        deliver(options, { type: "step-text", turnId: "turn-1", text: "Checking" });
+      }
+      deliver(options, { type: "final-text", turnId: "turn-1", text: "Rejected" });
+      return aborted;
+    });
+    const { controller, states } = subject(fake);
+
+    await controller.submit("Continue");
+
+    expect(states.at(-1)).toMatchObject({
+      status: "interrupted",
+      progress: CHAT_PROTOCOL_FAILURE_COPY,
+    });
+    expect(states.at(-1)?.messages.at(-1)?.text).toBe("Preserved");
+    expect(states.some((state) => state.messages.at(-1)?.text === "Rejected")).toBe(false);
+    expect(signal?.aborted).toBe(true);
   });
 
   it("preserves partial text and the contract athlete message without automatic retry", async () => {

--- a/apps/desktop-renderer/tests/chat-markdown.test.ts
+++ b/apps/desktop-renderer/tests/chat-markdown.test.ts
@@ -1,0 +1,277 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  DEFAULT_COACH_MARKDOWN_LIMITS,
+  renderCoachMarkdown,
+  type CoachMarkdownLimits,
+} from "../src/chat/markdown.js";
+
+class FakeNode {
+  readonly children: FakeNode[] = [];
+  readonly attributes = new Map<string, string>();
+  readonly dataset: Record<string, string> = {};
+  className = "";
+  private ownText = "";
+
+  constructor(readonly tagName: string) {}
+
+  get textContent(): string {
+    return this.ownText + this.children.map((child) => child.textContent).join("");
+  }
+
+  set textContent(value: string) {
+    this.ownText = value;
+    this.children.splice(0);
+  }
+
+  append(...nodes: FakeNode[]): void {
+    for (const node of nodes) {
+      if (node.tagName === "#fragment") this.children.push(...node.children.splice(0));
+      else this.children.push(node);
+    }
+  }
+
+  replaceChildren(...nodes: FakeNode[]): void {
+    this.ownText = "";
+    this.children.splice(0);
+    this.append(...nodes);
+  }
+
+  setAttribute(name: string, value: string): void {
+    this.attributes.set(name, value);
+  }
+}
+
+class FakeDocument {
+  createElement(name: string): FakeNode {
+    return new FakeNode(name);
+  }
+
+  createTextNode(value: string): FakeNode {
+    const node = new FakeNode("#text");
+    node.textContent = value;
+    return node;
+  }
+
+  createDocumentFragment(): FakeNode {
+    return new FakeNode("#fragment");
+  }
+}
+
+function findAll(root: FakeNode, tagName: string): FakeNode[] {
+  return [
+    ...(root.tagName === tagName ? [root] : []),
+    ...root.children.flatMap((child) => findAll(child, tagName)),
+  ];
+}
+
+function render(source: string, limits?: CoachMarkdownLimits): FakeNode {
+  const container = new FakeNode("div");
+  renderCoachMarkdown(container as never, source, limits);
+  return container;
+}
+
+beforeEach(() => {
+  Object.assign(globalThis, { document: new FakeDocument() });
+});
+
+describe("coach markdown", () => {
+  it("renders the finite athlete-facing block and inline subset", () => {
+    const root = render(`# Today
+
+Build **steadily**, recover *fully*, and ~~skip~~ adjust \`carefully\`.
+Keep the cadence
+comfortable.
+
+- Easy start
+- Smooth finish
+
+1. Warm up
+2. Ride
+
+\`\`\`text
+const effort = "easy";
+\`\`\`
+
+| Session | Goal |
+| --- | --- |
+| Endurance | **Steady** |
+
+[Training guide](https://example.test/guide)`);
+
+    expect(findAll(root, "h1")).toHaveLength(1);
+    expect(findAll(root, "strong").map((node) => node.textContent)).toEqual(["steadily", "Steady"]);
+    expect(findAll(root, "em")[0]?.textContent).toBe("fully");
+    expect(findAll(root, "del")[0]?.textContent).toBe("skip");
+    expect(findAll(root, "br")).toHaveLength(2);
+    expect(findAll(root, "ul")[0]?.children).toHaveLength(2);
+    expect(findAll(root, "ol")[0]?.children).toHaveLength(2);
+    expect(findAll(root, "pre")[0]?.textContent).toBe('const effort = "easy";');
+    expect(findAll(root, "table")).toHaveLength(1);
+    expect(findAll(root, "th").map((node) => node.textContent)).toEqual(["Session", "Goal"]);
+    const anchor = findAll(root, "a")[0]!;
+    expect(anchor.textContent).toBe("Training guide");
+    expect(Object.fromEntries(anchor.attributes)).toEqual({
+      href: "https://example.test/guide",
+      target: "_blank",
+      rel: "noopener noreferrer",
+      referrerpolicy: "no-referrer",
+    });
+  });
+
+  it("keeps raw HTML and image syntax literal without creating network-capable elements", () => {
+    const source =
+      '<script>globalThis.executed = true</script> <img src="https://attacker.invalid/pixel"> ![route](https://attacker.invalid/route.png)';
+    const root = render(source);
+
+    expect(root.textContent).toBe(source);
+    expect(findAll(root, "script")).toHaveLength(0);
+    expect(findAll(root, "img")).toHaveLength(0);
+    expect(findAll(root, "a")).toHaveLength(0);
+    expect((globalThis as Record<string, unknown>).executed).toBeUndefined();
+  });
+
+  it.each([
+    "javascript:alert(1)",
+    "data:text/html,unsafe",
+    "mailto:coach@example.test",
+    "/relative",
+    "//example.test/path",
+    "https://user@example.test/path",
+    "https://user:secret@example.test/path",
+    " https://example.test/path",
+    "https://example.test/path\u007f",
+    "http://",
+  ])("leaves an unsafe link destination visible: %s", (destination) => {
+    const source = `[unsafe](${destination})`;
+    const root = render(source);
+
+    expect(root.textContent).toBe(source);
+    expect(findAll(root, "a")).toHaveLength(0);
+  });
+
+  it("canonicalizes safe absolute HTTP links before placing them in the DOM", () => {
+    const root = render("[safe](HTTPS://EXAMPLE.TEST:443/a/../guide)");
+
+    expect(findAll(root, "a")[0]?.attributes.get("href")).toBe("https://example.test/guide");
+  });
+
+  it("matches the coaching channel's emphasis flanking without changing interval math or identifiers", () => {
+    const source =
+      "Do 3 * 8 reps, then 2 * 20min with threshold_power_zone; this is *important* and _useful_.";
+    const root = render(source);
+
+    expect(root.textContent).toBe(
+      "Do 3 * 8 reps, then 2 * 20min with threshold_power_zone; this is important and useful.",
+    );
+    expect(findAll(root, "em").map((node) => node.textContent)).toEqual(["important", "useful"]);
+  });
+
+  it.each(["foo*bar*baz", "interval * spaced*", "interval *spaced *", "embedded_under_score"])(
+    "leaves non-flanking emphasis literal: %s",
+    (source) => {
+      const root = render(source);
+      expect(root.textContent).toBe(source);
+      expect(findAll(root, "em")).toHaveLength(0);
+    },
+  );
+
+  it("uses the coaching channel's exact underscore boundaries", () => {
+    const root = render("_ spaced_ _trailing _ __paired__ foo_bar_baz _line\nbreak_");
+
+    expect(findAll(root, "em").map((node) => node.textContent)).toEqual([
+      " spaced",
+      "trailing ",
+      "linebreak",
+    ]);
+    expect(root.textContent).toBe(" spaced trailing  __paired__ foo_bar_baz linebreak");
+  });
+
+  it("supports balanced and escaped parentheses in safe link destinations", () => {
+    const root = render(
+      "[Foo](https://en.wikipedia.org/wiki/Foo_(bar)) [plan\\]](https://example.test/a\\(b\\))",
+    );
+
+    expect(findAll(root, "a").map((anchor) => anchor.textContent)).toEqual(["Foo", "plan]"]);
+    expect(findAll(root, "a").map((anchor) => anchor.attributes.get("href"))).toEqual([
+      "https://en.wikipedia.org/wiki/Foo_(bar)",
+      "https://example.test/a(b)",
+    ]);
+  });
+
+  it.each([
+    "A cumulative **strong response",
+    "A cumulative *emphasis response",
+    "A cumulative ~~strike response",
+    "A cumulative `code response",
+    "A cumulative [link](https://example.test",
+  ])("keeps incomplete streaming syntax visible and never throws: %s", (source) => {
+    expect(() => render(source)).not.toThrow();
+    const root = render(source);
+    expect(root.textContent).toBe(source.replaceAll("\n", ""));
+    expect(findAll(root, "br")).toHaveLength(source.split("\n").length - 1);
+  });
+
+  it("consumes an unfinished fence remainder literally without interpreting later blocks", () => {
+    const source = "```ts\n# not a heading\n[not a link](https://example.test/)";
+    const root = render(source);
+
+    expect(root.textContent).toBe(source);
+    expect(findAll(root, "pre")).toHaveLength(1);
+    expect(findAll(root, "h1")).toHaveLength(0);
+    expect(findAll(root, "a")).toHaveLength(0);
+  });
+
+  it("consumes a long unfinished fence within the bounded work budget", () => {
+    const source = `\`\`\`text\n${"# still inert fence content\n".repeat(3_000)}`;
+    const root = render(source);
+
+    expect(root.textContent).toBe(source);
+    expect(findAll(root, "pre")).toHaveLength(1);
+    expect(findAll(root, "h1")).toHaveLength(0);
+  });
+
+  it("handles a long unmatched-bracket stream in one literal pass", () => {
+    const source = `${"[".repeat(8_000)}still streaming`;
+    const root = render(source);
+
+    expect(root.textContent).toBe(source);
+    expect(findAll(root, "p")).toHaveLength(1);
+    expect(findAll(root, "a")).toHaveLength(0);
+  });
+
+  it.each([
+    {
+      name: "source",
+      limits: { ...DEFAULT_COACH_MARKDOWN_LIMITS, sourceCharacters: 3 },
+    },
+    {
+      name: "work",
+      limits: { ...DEFAULT_COACH_MARKDOWN_LIMITS, workUnits: 1 },
+    },
+    {
+      name: "nodes",
+      limits: { ...DEFAULT_COACH_MARKDOWN_LIMITS, nodes: 1 },
+    },
+  ])("falls back to the complete plain source when the $name budget is exhausted", ({ limits }) => {
+    const source = "## **complete source**";
+    const root = render(source, limits);
+
+    expect(root.textContent).toBe(source);
+    expect(root.children).toHaveLength(0);
+  });
+
+  it("does not treat pipes in fences or inline code as table separators", () => {
+    const root = render(`\`\`\`
+| fenced | content |
+\`\`\`
+
+| Expression | Result |
+| --- | --- |
+| \`left|right\` | safe |`);
+
+    expect(findAll(root, "pre")[0]?.textContent).toBe("| fenced | content |");
+    expect(findAll(root, "table")).toHaveLength(1);
+    expect(findAll(root, "td")).toHaveLength(2);
+    expect(findAll(root, "td")[0]?.textContent).toBe("left|right");
+  });
+});

--- a/apps/desktop-renderer/tests/chat-view.test.ts
+++ b/apps/desktop-renderer/tests/chat-view.test.ts
@@ -1,9 +1,20 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { CoachClientCallOptions } from "@enduragent/coach-client";
+import type { TurnEvent } from "@enduragent/coach-contract";
+import { createChatController } from "../src/chat/controller.js";
 import { mountChatView } from "../src/chat/view.js";
 import { EMPTY_CHAT_STATE, reduceChatState, type ChatState } from "../src/turn-state.js";
 
+const mutationEvents: string[] = [];
+
+class FakeChildList extends Array<FakeElement> {
+  item(index: number): FakeElement | null {
+    return this[index] ?? null;
+  }
+}
+
 class FakeElement {
-  readonly children: FakeElement[] = [];
+  readonly children = new FakeChildList();
   readonly attributes = new Map<string, string>();
   readonly listeners = new Map<string, Set<(event: never) => void>>();
   readonly dataset: Record<string, string> = {};
@@ -22,6 +33,10 @@ class FakeElement {
   clientHeight = 0;
   textContentMutationCount = 0;
   replaceChildrenMutationCount = 0;
+  insertBeforeMutationCount = 0;
+  removeMutationCount = 0;
+  appendDataMutationCount = 0;
+  parentNode: FakeElement | null = null;
   private ownText = "";
 
   constructor(readonly tagName: string) {}
@@ -37,26 +52,45 @@ class FakeElement {
   set textContent(value: string) {
     this.textContentMutationCount += 1;
     this.ownText = value;
+    for (const child of this.children) child.parentNode = null;
     this.children.splice(0);
   }
 
   append(...nodes: Array<FakeElement | string>): void {
     for (const node of nodes) {
-      this.children.push(typeof node === "string" ? new FakeElement("#text") : node);
-      if (typeof node === "string") this.children.at(-1)!.textContent = node;
+      const child = typeof node === "string" ? new FakeElement("#text") : node;
+      if (typeof node === "string") child.textContent = node;
+      if (child.tagName === "#fragment") {
+        this.append(...child.children.splice(0));
+        continue;
+      }
+      child.parentNode?.detach(child);
+      child.parentNode = this;
+      this.children.push(child);
     }
   }
 
+  appendData(value: string): void {
+    this.appendDataMutationCount += 1;
+    this.ownText += value;
+  }
+
   insertBefore(node: FakeElement, reference: FakeElement | null): void {
+    this.insertBeforeMutationCount += 1;
+    node.parentNode?.detach(node);
     const index = reference === null ? -1 : this.children.indexOf(reference);
+    node.parentNode = this;
     if (index === -1) this.children.push(node);
     else this.children.splice(index, 0, node);
   }
 
   replaceChildren(...nodes: FakeElement[]): void {
     this.replaceChildrenMutationCount += 1;
+    mutationEvents.push(`${this.className || this.tagName}:replaceChildren`);
     this.ownText = "";
-    this.children.splice(0, this.children.length, ...nodes);
+    for (const child of this.children) child.parentNode = null;
+    this.children.splice(0);
+    this.append(...nodes);
   }
 
   setAttribute(name: string, value: string): void {
@@ -68,6 +102,7 @@ class FakeElement {
   }
 
   removeAttribute(name: string): void {
+    mutationEvents.push(`${this.className || this.tagName}:removeAttribute:${name}`);
     this.attributes.delete(name);
   }
 
@@ -105,6 +140,14 @@ class FakeElement {
 
   remove(): void {
     this.removed = true;
+    this.removeMutationCount += 1;
+    this.parentNode?.detach(this);
+  }
+
+  private detach(child: FakeElement): void {
+    const index = this.children.indexOf(child);
+    if (index !== -1) this.children.splice(index, 1);
+    child.parentNode = null;
   }
 }
 
@@ -113,6 +156,16 @@ class FakeDocument {
 
   createElement(name: string): FakeElement {
     return new FakeElement(name);
+  }
+
+  createTextNode(value: string): FakeElement {
+    const node = new FakeElement("#text");
+    node.textContent = value;
+    return node;
+  }
+
+  createDocumentFragment(): FakeElement {
+    return new FakeElement("#fragment");
   }
 }
 
@@ -151,6 +204,7 @@ function submittedState(): ChatState {
 const emptyState: ChatState = EMPTY_CHAT_STATE;
 
 beforeEach(() => {
+  mutationEvents.splice(0);
   Object.assign(globalThis, {
     document: new FakeDocument(),
     HTMLElement: FakeElement,
@@ -331,7 +385,12 @@ describe("chat view", () => {
       composerHost: new FakeElement("div") as never,
     });
     const failureCopy = "The coach couldn't respond. Please try again.";
-    const state = reduceChatState(submittedState(), {
+    const messages = find(thread, (node) => node.className === "chat-messages");
+    let state = submittedState();
+    mounted.view.render(state);
+    const athlete = messages.children[0]!;
+    const insertions = messages.insertBeforeMutationCount;
+    state = reduceChatState(state, {
       type: "fail",
       requestKey: 1,
       copy: failureCopy,
@@ -340,6 +399,10 @@ describe("chat view", () => {
     mounted.view.render(state);
 
     expect(occurrences(thread.textContent, failureCopy)).toBe(1);
+    expect(messages.children).toEqual([athlete]);
+    expect(messages.insertBeforeMutationCount).toBe(insertions);
+    expect(messages.textContentMutationCount).toBe(0);
+    expect(athlete.removeMutationCount).toBe(0);
     expect(findAll(thread, (node) => node.className.includes("chat-message--coach")).length).toBe(
       0,
     );
@@ -368,7 +431,7 @@ describe("chat view", () => {
     expect(find(thread, (node) => node.className === "chat-retry").hidden).toBe(false);
   });
 
-  it("mutates live transcript content only when its rendered semantics change", () => {
+  it("preserves keyed row identity while updating only changed streaming content", () => {
     const actionHost = new FakeElement("div");
     const thread = new FakeElement("div");
     const mounted = mountChatView({
@@ -386,26 +449,415 @@ describe("chat view", () => {
 
     let state = submittedState();
     mounted.view.render(state);
-    expect(messages.replaceChildrenMutationCount).toBe(1);
+    const athlete = messages.children[0]!;
+    const athleteText = find(athlete, (node) => node.className === "chat-message__text");
+    expect(messages.replaceChildrenMutationCount).toBe(0);
     expect(messages.textContent).toContain("How should I train?");
-    expect(notice.textContentMutationCount).toBe(0);
-
-    mounted.view.render({
-      ...state,
-      messages: state.messages.map((message) => ({ ...message, id: `${message.id}-clone` })),
-    });
-    expect(messages.replaceChildrenMutationCount).toBe(1);
     expect(notice.textContentMutationCount).toBe(0);
 
     state = reduceChatState(state, {
       type: "event",
       requestKey: 1,
-      event: { type: "text_delta", turnId: "turn-1", delta: "Partial coach draft" },
+      event: { type: "text_delta", turnId: "turn-1", delta: "Partial **coach" },
     });
     mounted.view.render(state);
-    expect(messages.replaceChildrenMutationCount).toBe(2);
-    expect(messages.textContent).toContain("Partial coach draft");
+    const coach = messages.children[1]!;
+    const coachText = find(coach, (node) => node.className === "chat-message__text");
+    const streamText = coachText.children[0]!;
+    const insertedRows = messages.insertBeforeMutationCount;
+    expect(messages.replaceChildrenMutationCount).toBe(0);
+    expect(messages.children[0]).toBe(athlete);
+    expect(find(athlete, (node) => node.className === "chat-message__text")).toBe(athleteText);
+    expect(messages.textContent).toContain("Partial **coach");
+    expect(findAll(coach, (node) => node.tagName === "strong")).toHaveLength(0);
+    expect(coach.attributes.get("aria-busy")).toBe("true");
     expect(notice.textContentMutationCount).toBe(0);
+
+    state = reduceChatState(state, {
+      type: "event",
+      requestKey: 1,
+      event: { type: "text_delta", turnId: "turn-1", delta: " draft**" },
+    });
+    mounted.view.render(state, {
+      newConversationDisabled: true,
+      workBlocked: false,
+      appendDelta: {
+        messageId: "message-2",
+        previousTextLength: "Partial **coach".length,
+        nextTextLength: "Partial **coach draft**".length,
+        delta: " draft**",
+      },
+    });
+    expect(coachText.children[0]).toBe(streamText);
+    expect(streamText.appendDataMutationCount).toBe(1);
+    expect(coachText.textContent).toBe("Partial **coach draft**");
+    expect(findAll(coach, (node) => node.tagName === "strong")).toHaveLength(0);
+    expect(messages.insertBeforeMutationCount).toBe(insertedRows);
+    expect(athlete.removeMutationCount).toBe(0);
+    expect(coach.removeMutationCount).toBe(0);
+
+    mounted.view.render({
+      ...state,
+      progress: "Checking your training data…",
+      messages: state.messages.map((message) => ({ ...message })),
+    });
+    expect(messages.children[0]).toBe(athlete);
+    expect(messages.children[1]).toBe(coach);
+    expect(coachText.children[0]).toBe(streamText);
+    expect(messages.insertBeforeMutationCount).toBe(insertedRows);
+
+    state = reduceChatState(state, {
+      type: "event",
+      requestKey: 1,
+      event: { type: "final-text", turnId: "turn-1", text: "Partial **coach draft**" },
+    });
+    mounted.view.render(state);
+    expect(messages.children[1]).toBe(coach);
+    expect(coachText.children[0]).toBe(streamText);
+    expect(coachText.replaceChildrenMutationCount).toBe(0);
+    expect(coach.attributes.get("aria-busy")).toBe("true");
+    expect(messages.insertBeforeMutationCount).toBe(insertedRows);
+
+    state = reduceChatState(state, { type: "complete", requestKey: 1 });
+    mounted.view.render(state);
+    expect(messages.children[0]).toBe(athlete);
+    expect(messages.children[1]).toBe(coach);
+    expect(coachText.replaceChildrenMutationCount).toBe(1);
+    expect(findAll(coach, (node) => node.tagName === "strong")[0]?.textContent).toBe("coach draft");
+    expect(coach.attributes.has("aria-busy")).toBe(false);
+    expect(coach.attributes.get("aria-atomic")).toBe("true");
+    expect(coach.attributes.has("aria-live")).toBe(false);
+    expect(athlete.attributes.get("aria-live")).toBe("off");
+    expect(messages.insertBeforeMutationCount).toBe(insertedRows);
+    expect(athlete.removeMutationCount).toBe(0);
+    expect(coach.removeMutationCount).toBe(0);
+
+    mounted.view.render(state, { newConversationDisabled: true, workBlocked: false });
+    expect(messages.children[0]).toBe(athlete);
+    expect(messages.children[1]).toBe(coach);
+    expect(coachText.replaceChildrenMutationCount).toBe(1);
+    expect(messages.insertBeforeMutationCount).toBe(insertedRows);
+  });
+
+  it("reconciles final coach content before clearing its busy state", () => {
+    const thread = new FakeElement("div");
+    const mounted = mountChatView({
+      conversation: new FakeElement("main") as never,
+      thread: thread as never,
+      composerHost: new FakeElement("div") as never,
+    });
+    let state = submittedState();
+    state = reduceChatState(state, {
+      type: "event",
+      requestKey: 1,
+      event: { type: "text_delta", turnId: "turn-1", delta: "Draft" },
+    });
+    mounted.view.render(state);
+    state = reduceChatState(state, {
+      type: "event",
+      requestKey: 1,
+      event: { type: "final-text", turnId: "turn-1", text: "Final **answer**" },
+    });
+    state = reduceChatState(state, { type: "complete", requestKey: 1 });
+    mutationEvents.splice(0);
+
+    mounted.view.render(state);
+
+    expect(mutationEvents.filter((event) => event.startsWith("chat-message"))).toEqual([
+      "chat-message__text:replaceChildren",
+      "chat-message chat-message--coach:removeAttribute:aria-busy",
+    ]);
+    const coach = find(thread, (node) => node.className.includes("chat-message--coach"));
+    expect(findAll(coach, (node) => node.tagName === "strong")[0]?.textContent).toBe("answer");
+  });
+
+  it("replaces a corrected final while busy and parses it only on completion", () => {
+    const thread = new FakeElement("div");
+    const mounted = mountChatView({
+      conversation: new FakeElement("main") as never,
+      thread: thread as never,
+      composerHost: new FakeElement("div") as never,
+    });
+    let state = submittedState();
+    state = reduceChatState(state, {
+      type: "event",
+      requestKey: 1,
+      event: { type: "text_delta", turnId: "turn-1", delta: "Draft" },
+    });
+    mounted.view.render(state);
+    const messages = find(thread, (node) => node.className === "chat-messages");
+    const coach = messages.children[1]!;
+    const coachText = find(coach, (node) => node.className === "chat-message__text");
+    const draftNode = coachText.children[0]!;
+    const insertions = messages.insertBeforeMutationCount;
+
+    state = reduceChatState(state, {
+      type: "event",
+      requestKey: 1,
+      event: { type: "final-text", turnId: "turn-1", text: "Corrected **answer**" },
+    });
+    mounted.view.render(state);
+
+    expect(coachText.children[0]).not.toBe(draftNode);
+    expect(coachText.textContent).toBe("Corrected **answer**");
+    expect(findAll(coach, (node) => node.tagName === "strong")).toHaveLength(0);
+    expect(coach.attributes.get("aria-busy")).toBe("true");
+    expect(messages.insertBeforeMutationCount).toBe(insertions);
+
+    state = reduceChatState(state, { type: "complete", requestKey: 1 });
+    mounted.view.render(state);
+
+    expect(findAll(coach, (node) => node.tagName === "strong")[0]?.textContent).toBe("answer");
+    expect(coach.attributes.has("aria-busy")).toBe(false);
+    expect(messages.insertBeforeMutationCount).toBe(insertions);
+    expect(coach.removeMutationCount).toBe(0);
+  });
+
+  it("keeps transcript rows stable when controller background cleanup releases a turn", async () => {
+    const thread = new FakeElement("div");
+    const mounted = mountChatView({
+      conversation: new FakeElement("main") as never,
+      thread: thread as never,
+      composerHost: new FakeElement("div") as never,
+    });
+    let releaseTrainingRefresh: (() => void) | undefined;
+    const trainingRefresh = new Promise<void>((resolve) => {
+      releaseTrainingRefresh = resolve;
+    });
+    const finalText = "Final **answer**";
+    const call = vi.fn(
+      async (
+        method: string,
+        _request: unknown,
+        options: CoachClientCallOptions<"chat"> | undefined,
+      ) => {
+        if (method !== "chat") throw new TypeError();
+        const deliver = (event: TurnEvent): void => {
+          options?.onNotificationEnvelope?.({
+            jsonrpc: "2.0",
+            method: "coach.turnEvent",
+            params: {
+              requestId: 1,
+              requestMethod: "chat",
+              turnId: event.turnId,
+              event,
+            },
+          });
+          options?.onEvent?.(event);
+        };
+        deliver({ type: "text_delta", turnId: "turn-1", delta: "Final **ans" });
+        deliver({ type: "text_delta", turnId: "turn-1", delta: "wer**" });
+        deliver({ type: "final-text", turnId: "turn-1", text: finalText });
+        options?.onTerminalEnvelope?.({
+          jsonrpc: "2.0",
+          id: 1,
+          result: { text: finalText },
+        });
+        return { text: finalText };
+      },
+    );
+    const fakeClient = { handshake: {}, call, close: vi.fn(async () => {}) };
+    const controller = createChatController({
+      clients: {
+        getClient: vi.fn(async () => fakeClient as never),
+        reconnect: vi.fn(async () => fakeClient as never),
+        close: vi.fn(async () => {}),
+      },
+      view: mounted.view,
+      refreshTrainingContext: () => trainingRefresh,
+      refreshSpend: async () => {},
+    });
+
+    const submission = controller.submit("How should I train?");
+    const messages = find(thread, (node) => node.className === "chat-messages");
+    await vi.waitFor(() => {
+      expect(messages.children).toHaveLength(2);
+      expect(messages.children[1]?.attributes.has("aria-busy")).toBe(false);
+    });
+    const athlete = messages.children[0]!;
+    const coach = messages.children[1]!;
+    const insertions = messages.insertBeforeMutationCount;
+    const athleteRemovals = athlete.removeMutationCount;
+    const coachRemovals = coach.removeMutationCount;
+    const coachText = find(coach, (node) => node.className === "chat-message__text");
+    const replacements = coachText.replaceChildrenMutationCount;
+
+    releaseTrainingRefresh?.();
+    await submission;
+    await Promise.resolve();
+
+    expect(messages.children[0]).toBe(athlete);
+    expect(messages.children[1]).toBe(coach);
+    expect(messages.insertBeforeMutationCount).toBe(insertions);
+    expect(athlete.removeMutationCount).toBe(athleteRemovals);
+    expect(coach.removeMutationCount).toBe(coachRemovals);
+    expect(coachText.replaceChildrenMutationCount).toBe(replacements);
+    expect(findAll(coach, (node) => node.tagName === "strong")[0]?.textContent).toBe("answer");
+  });
+
+  it("keeps one streaming text node across many controller-delivered tiny deltas", async () => {
+    const thread = new FakeElement("div");
+    const mounted = mountChatView({
+      conversation: new FakeElement("main") as never,
+      thread: thread as never,
+      composerHost: new FakeElement("div") as never,
+    });
+    let finishTurn: (() => void) | undefined;
+    const finishGate = new Promise<void>((resolve) => {
+      finishTurn = resolve;
+    });
+    let markStreamingDelivered: (() => void) | undefined;
+    const streamingDelivered = new Promise<void>((resolve) => {
+      markStreamingDelivered = resolve;
+    });
+    const finalText = `Line  one\n**steady** ${"x".repeat(256)}`;
+    const call = vi.fn(
+      async (
+        method: string,
+        _request: unknown,
+        options: CoachClientCallOptions<"chat"> | undefined,
+      ) => {
+        if (method !== "chat") throw new TypeError();
+        const deliver = (event: TurnEvent): void => {
+          options?.onNotificationEnvelope?.({
+            jsonrpc: "2.0",
+            method: "coach.turnEvent",
+            params: {
+              requestId: 1,
+              requestMethod: "chat",
+              turnId: event.turnId,
+              event,
+            },
+          });
+          options?.onEvent?.(event);
+        };
+        for (let index = 0; index < finalText.length; index += 1) {
+          deliver({ type: "text_delta", turnId: "turn-1", delta: finalText[index]! });
+        }
+        markStreamingDelivered?.();
+        await finishGate;
+        deliver({ type: "final-text", turnId: "turn-1", text: finalText });
+        options?.onTerminalEnvelope?.({
+          jsonrpc: "2.0",
+          id: 1,
+          result: { text: finalText },
+        });
+        return { text: finalText };
+      },
+    );
+    const fakeClient = { handshake: {}, call, close: vi.fn(async () => {}) };
+    const controller = createChatController({
+      clients: {
+        getClient: vi.fn(async () => fakeClient as never),
+        reconnect: vi.fn(async () => fakeClient as never),
+        close: vi.fn(async () => {}),
+      },
+      view: mounted.view,
+      refreshTrainingContext: async () => {},
+      refreshSpend: async () => {},
+    });
+
+    const submission = controller.submit("How should I train?");
+    await streamingDelivered;
+    const messages = find(thread, (node) => node.className === "chat-messages");
+    const athlete = messages.children[0]!;
+    const coach = messages.children[1]!;
+    const coachText = find(coach, (node) => node.className === "chat-message__text");
+    const streamNode = coachText.children[0]!;
+    const insertions = messages.insertBeforeMutationCount;
+
+    expect(coachText.children).toEqual([streamNode]);
+    expect(streamNode.textContent).toBe(finalText);
+    expect(streamNode.appendDataMutationCount).toBe(finalText.length - 1);
+    expect(coachText.replaceChildrenMutationCount).toBe(0);
+    expect(messages.insertBeforeMutationCount).toBe(2);
+    expect(athlete.removeMutationCount).toBe(0);
+    expect(coach.removeMutationCount).toBe(0);
+
+    finishTurn?.();
+    await submission;
+
+    expect(messages.children[0]).toBe(athlete);
+    expect(messages.children[1]).toBe(coach);
+    expect(messages.insertBeforeMutationCount).toBe(insertions);
+    expect(findAll(coach, (node) => node.tagName === "strong")[0]?.textContent).toBe("steady");
+  });
+
+  it("treats changed message ids as new row identities even when semantics match", () => {
+    const thread = new FakeElement("div");
+    const mounted = mountChatView({
+      conversation: new FakeElement("main") as never,
+      thread: thread as never,
+      composerHost: new FakeElement("div") as never,
+    });
+    const messages = find(thread, (node) => node.className === "chat-messages");
+    const state = submittedState();
+    mounted.view.render(state);
+    const original = messages.children[0]!;
+
+    mounted.view.render({
+      ...state,
+      messages: state.messages.map((message) => ({ ...message, id: `${message.id}-changed` })),
+    });
+
+    expect(messages.children[0]).not.toBe(original);
+    expect(original.removed).toBe(true);
+    expect(messages.textContent).toContain("How should I train?");
+    expect(messages.replaceChildrenMutationCount).toBe(0);
+  });
+
+  it("rejects duplicate message ids before mutating any transcript node", () => {
+    const thread = new FakeElement("div");
+    const actionHost = new FakeElement("div");
+    const mounted = mountChatView({
+      conversation: new FakeElement("main") as never,
+      thread: thread as never,
+      composerHost: new FakeElement("div") as never,
+      actionHost: actionHost as never,
+    });
+    const messages = find(thread, (node) => node.className === "chat-messages");
+    const state = submittedState();
+    mounted.view.render(state);
+    const athlete = messages.children[0]!;
+    const insertions = messages.insertBeforeMutationCount;
+    const opener = find(actionHost, (node) => node.className === "new-conversation-button");
+    const openerDisabled = opener.disabled;
+
+    expect(() =>
+      mounted.view.render({
+        ...state,
+        session: { ...state.session, presence: "present" },
+        messages: state.messages.map((message) => ({ ...message, id: "duplicate" })),
+      }),
+    ).toThrow("duplicate chat message id");
+
+    expect(messages.children).toEqual([athlete]);
+    expect(messages.insertBeforeMutationCount).toBe(insertions);
+    expect(messages.textContentMutationCount).toBe(0);
+    expect(athlete.removeMutationCount).toBe(0);
+    expect(opener.disabled).toBe(openerDisabled);
+  });
+
+  it("preserves interrupted history when retry adds a newly keyed coach row", () => {
+    const thread = new FakeElement("div");
+    const mounted = mountChatView({
+      conversation: new FakeElement("main") as never,
+      thread: thread as never,
+      composerHost: new FakeElement("div") as never,
+    });
+    const messages = find(thread, (node) => node.className === "chat-messages");
+    let state = submittedState();
+    state = reduceChatState(state, {
+      type: "event",
+      requestKey: 1,
+      event: { type: "text_delta", turnId: "turn-1", delta: "**Preserved partial**" },
+    });
+    mounted.view.render(state);
+    const athlete = messages.children[0]!;
+    const interrupted = messages.children[1]!;
+    const insertionsBeforeInterruption = messages.insertBeforeMutationCount;
+    expect(interrupted.attributes.get("aria-busy")).toBe("true");
+    expect(findAll(interrupted, (node) => node.tagName === "strong")).toHaveLength(0);
 
     state = reduceChatState(state, {
       type: "interrupt",
@@ -413,58 +865,111 @@ describe("chat view", () => {
       copy: "Connection interrupted. Your partial response is preserved.",
     });
     mounted.view.render(state);
-    expect(messages.replaceChildrenMutationCount).toBe(3);
-    expect(notice.textContentMutationCount).toBe(1);
-    expect(notice.textContent).toBe("Connection interrupted. Your partial response is preserved.");
-    expect(find(thread, (node) => node.className === "chat-retry").hidden).toBe(false);
+    expect(interrupted.attributes.has("aria-busy")).toBe(false);
+    expect(findAll(interrupted, (node) => node.tagName === "strong")[0]?.textContent).toBe(
+      "Preserved partial",
+    );
+    expect(messages.insertBeforeMutationCount).toBe(insertionsBeforeInterruption);
+    expect(athlete.removeMutationCount).toBe(0);
+    expect(interrupted.removeMutationCount).toBe(0);
 
     state = reduceChatState(state, {
-      type: "interrupt",
-      requestKey: 1,
-      copy: "Connection interrupted again. Your partial response is preserved.",
+      type: "submit",
+      requestKey: 2,
+      userMessage: "How should I train?",
+      userMessageId: "unused-message",
+      assistantMessageId: "message-3",
+      includeUser: false,
+    });
+    state = reduceChatState(state, {
+      type: "event",
+      requestKey: 2,
+      event: { type: "text_delta", turnId: "turn-2", delta: "Fresh retry" },
     });
     mounted.view.render(state);
-    expect(messages.replaceChildrenMutationCount).toBe(3);
-    expect(notice.textContentMutationCount).toBe(2);
-    expect(notice.textContent).toBe(
-      "Connection interrupted again. Your partial response is preserved.",
-    );
+
+    expect(messages.children).toHaveLength(3);
+    expect(messages.children[0]).toBe(athlete);
+    expect(messages.children[1]).toBe(interrupted);
+    expect(messages.children[2]).not.toBe(interrupted);
+    expect(messages.children[2]?.textContent).toContain("Fresh retry");
+    expect(interrupted.textContent).toContain("Preserved partial");
+    expect(messages.insertBeforeMutationCount).toBe(insertionsBeforeInterruption + 1);
+    expect(athlete.removeMutationCount).toBe(0);
+    expect(interrupted.removeMutationCount).toBe(0);
+  });
+
+  it("keeps rows stable through reset controls and clears the transcript exactly once on success", () => {
+    const thread = new FakeElement("div");
+    const mounted = mountChatView({
+      conversation: new FakeElement("main") as never,
+      thread: thread as never,
+      composerHost: new FakeElement("div") as never,
+      actionHost: new FakeElement("div") as never,
+    });
+    const messages = find(thread, (node) => node.className === "chat-messages");
+    let state = submittedState();
+    state = reduceChatState(state, {
+      type: "event",
+      requestKey: 1,
+      event: { type: "final-text", turnId: "turn-1", text: "Ride easy." },
+    });
+    state = reduceChatState(state, { type: "complete", requestKey: 1 });
+    mounted.view.render(state);
+    const athlete = messages.children[0]!;
+    const coach = messages.children[1]!;
+    const insertions = messages.insertBeforeMutationCount;
+    const expectNoStructuralMutation = (): void => {
+      expect(messages.insertBeforeMutationCount).toBe(insertions);
+      expect(messages.textContentMutationCount).toBe(0);
+      expect(athlete.removeMutationCount).toBe(0);
+      expect(coach.removeMutationCount).toBe(0);
+    };
 
     let resetState = reduceChatState(state, { type: "open-new-conversation" });
     mounted.view.render(resetState);
+    expect(messages.children[0]).toBe(athlete);
+    expect(messages.children[1]).toBe(coach);
+    expectNoStructuralMutation();
+    resetState = reduceChatState(resetState, { type: "cancel-new-conversation" });
+    mounted.view.render(resetState);
+    expect(messages.children[0]).toBe(athlete);
+    expect(messages.children[1]).toBe(coach);
+    expectNoStructuralMutation();
+    resetState = reduceChatState(resetState, { type: "open-new-conversation" });
     resetState = reduceChatState(resetState, { type: "begin-reset" });
     mounted.view.render(resetState, { newConversationDisabled: true, workBlocked: true });
-    mounted.view.render(
-      {
-        ...resetState,
-        messages: resetState.messages.map((message) => ({ ...message })),
-      },
-      { newConversationDisabled: false, workBlocked: false },
-    );
-    expect(messages.replaceChildrenMutationCount).toBe(3);
-    expect(notice.textContentMutationCount).toBe(2);
+    expect(messages.children[0]).toBe(athlete);
+    expect(messages.children[1]).toBe(coach);
+    expectNoStructuralMutation();
+
+    const failedState = reduceChatState(resetState, {
+      type: "reset-failed",
+      announcement: "Reset could not be confirmed.",
+    });
+    mounted.view.render(failedState);
+    expect(messages.children[0]).toBe(athlete);
+    expect(messages.children[1]).toBe(coach);
+    expectNoStructuralMutation();
+
+    resetState = reduceChatState(state, { type: "open-new-conversation" });
+    resetState = reduceChatState(resetState, { type: "begin-reset" });
+    mounted.view.render(resetState);
+    expectNoStructuralMutation();
 
     const clearedState = reduceChatState(resetState, {
       type: "reset-succeeded",
       announcement: "New conversation started.",
     });
     mounted.view.render(clearedState);
-    expect(messages.replaceChildrenMutationCount).toBe(4);
+    expect(messages.textContentMutationCount).toBe(1);
     expect(messages.children).toHaveLength(0);
-    expect(notice.textContentMutationCount).toBe(3);
-    expect(notice.textContent).toBe("");
-
-    mounted.view.render({
-      ...state,
-      messages: state.messages.map((message) => ({ ...message })),
-      session: { ...clearedState.session, presence: "present", announcement: null },
-    });
-    expect(messages.replaceChildrenMutationCount).toBe(5);
-    expect(messages.textContent).toContain("Partial coach draft");
-    expect(notice.textContentMutationCount).toBe(4);
-    expect(notice.textContent).toBe(
-      "Connection interrupted again. Your partial response is preserved.",
-    );
+    expect(messages.insertBeforeMutationCount).toBe(insertions);
+    expect(athlete.removeMutationCount).toBe(0);
+    expect(coach.removeMutationCount).toBe(0);
+    mounted.view.render(clearedState, { newConversationDisabled: true, workBlocked: false });
+    expect(messages.textContentMutationCount).toBe(1);
+    expect(messages.replaceChildrenMutationCount).toBe(0);
   });
 
   it("places one notice host immediately before the composer and removes it on dispose", () => {
@@ -504,9 +1009,49 @@ describe("chat view", () => {
     });
     expect(thread.textContent).toContain('<img src=x onerror="globalThis.executed=true">');
     expect((globalThis as Record<string, unknown>).executed).toBeUndefined();
+    expect(findAll(thread, (node) => node.tagName === "img")).toHaveLength(0);
     const transcript = find(thread, (node) => node.className === "chat-transcript");
     expect(transcript.attributes.get("role")).toBe("log");
     expect(transcript.attributes.get("aria-live")).toBe("polite");
+    expect(transcript.attributes.get("aria-relevant")).toBe("additions text");
+    expect(transcript.attributes.get("aria-atomic")).toBe("false");
+  });
+
+  it("renders semantic Markdown only for coach rows", () => {
+    const thread = new FakeElement("div");
+    const mounted = mountChatView({
+      conversation: new FakeElement("main") as never,
+      thread: thread as never,
+      composerHost: new FakeElement("div") as never,
+    });
+    mounted.view.render({
+      ...emptyState,
+      messages: [
+        {
+          id: "message-1",
+          role: "athlete",
+          text: "**literal athlete**",
+          delivery: "complete",
+        },
+        {
+          id: "message-2",
+          role: "coach",
+          text: "**formatted coach** [guide](https://example.test/guide)",
+          delivery: "complete",
+        },
+      ],
+    });
+
+    const athlete = find(thread, (node) => node.className.includes("chat-message--athlete"));
+    const coach = find(thread, (node) => node.className.includes("chat-message--coach"));
+    expect(findAll(athlete, (node) => node.tagName === "strong")).toHaveLength(0);
+    expect(athlete.textContent).toContain("**literal athlete**");
+    expect(findAll(coach, (node) => node.tagName === "strong")[0]?.textContent).toBe(
+      "formatted coach",
+    );
+    expect(findAll(coach, (node) => node.tagName === "a")[0]?.attributes.get("target")).toBe(
+      "_blank",
+    );
   });
 
   it("keeps a visible label, submits original text, and disables while streaming", () => {
@@ -833,6 +1378,8 @@ describe("chat view", () => {
     });
     const button = find(actionHost, (node) => node.className === "new-conversation-button");
     const dialog = find(actionHost, (node) => node.tagName === "dialog");
+    const transcript = find(thread, (node) => node.className === "chat-transcript");
+    const form = find(composerHost, (node) => node.className === "composer");
     let state = reduceChatState(emptyState, { type: "session-probe", hasSession: true });
     state = reduceChatState(state, { type: "open-new-conversation" });
     mounted.view.render(state);
@@ -844,7 +1391,7 @@ describe("chat view", () => {
     expect(dialog.open).toBe(false);
     expect(dialog.removed).toBe(true);
     expect(button.removed).toBe(true);
-    expect(find(thread, (node) => node.className === "chat-transcript").removed).toBe(true);
-    expect(find(composerHost, (node) => node.className === "composer").removed).toBe(true);
+    expect(transcript.removed).toBe(true);
+    expect(form.removed).toBe(true);
   });
 });

--- a/apps/desktop/src/main/constants.ts
+++ b/apps/desktop/src/main/constants.ts
@@ -4,6 +4,7 @@ export const DESKTOP_RENDERER_ORIGIN = "enduragent://app" as const;
 export const DESKTOP_RENDERER_URL = "enduragent://app/index.html" as const;
 export const DESKTOP_CONNECTION_CHANNEL = "desktop:get-daemon-connection" as const;
 export const DESKTOP_LIFECYCLE_CHANNEL = "desktop:daemon-lifecycle" as const;
+export const DESKTOP_OPEN_EXTERNAL_CHANNEL = "desktop:open-external" as const;
 export const DESKTOP_WINDOW_WIDTH = 1_180 as const;
 export const DESKTOP_WINDOW_HEIGHT = 820 as const;
 export const DESKTOP_WINDOW_MIN_WIDTH = 760 as const;

--- a/apps/desktop/src/main/external-link-ipc.ts
+++ b/apps/desktop/src/main/external-link-ipc.ts
@@ -1,0 +1,53 @@
+import type { BrowserWindow, IpcMain, IpcMainEvent } from "electron";
+import { DESKTOP_OPEN_EXTERNAL_CHANNEL } from "./constants.js";
+import { isTrustedConnectionRequest } from "./security.js";
+
+function hasUnsafeUrlCodePoint(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code <= 0x20 || code === 0x7f) return true;
+  }
+  return false;
+}
+
+function canonicalExternalUrl(value: string): string | undefined {
+  if (hasUnsafeUrlCodePoint(value)) return undefined;
+  try {
+    const url = new URL(value);
+    if (
+      url.href !== value ||
+      (url.protocol !== "http:" && url.protocol !== "https:") ||
+      url.hostname.length === 0 ||
+      url.username.length > 0 ||
+      url.password.length > 0
+    ) {
+      return undefined;
+    }
+    return url.href;
+  } catch {
+    return undefined;
+  }
+}
+
+export function installDesktopExternalLinkIpc(input: {
+  readonly ipcMain: Pick<IpcMain, "on" | "removeListener">;
+  readonly currentWindow: () => BrowserWindow | undefined;
+  readonly openExternal: (url: string) => Promise<void>;
+}): () => void {
+  const onOpenExternal = (event: IpcMainEvent, ...args: unknown[]): void => {
+    if (!isTrustedConnectionRequest(event, input.currentWindow())) return;
+    if (args.length !== 1 || typeof args[0] !== "string") return;
+    const url = canonicalExternalUrl(args[0]);
+    if (url === undefined) return;
+    try {
+      void input.openExternal(url).catch(() => {});
+    } catch {}
+  };
+  input.ipcMain.on(DESKTOP_OPEN_EXTERNAL_CHANNEL, onOpenExternal);
+  let installed = true;
+  return () => {
+    if (!installed) return;
+    installed = false;
+    input.ipcMain.removeListener(DESKTOP_OPEN_EXTERNAL_CHANNEL, onOpenExternal);
+  };
+}

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -15,6 +15,7 @@ import {
 } from "electron";
 import { createChatGptAuth, hasChatGptProfile } from "./chatgpt-auth.js";
 import { installDesktopConnectionIpc } from "./connection-ipc.js";
+import { installDesktopExternalLinkIpc } from "./external-link-ipc.js";
 import { DESKTOP_LIFECYCLE_CHANNEL, DESKTOP_RENDERER_URL, DESKTOP_SCHEME } from "./constants.js";
 import {
   createConnectionRuntimeAuthority,
@@ -110,6 +111,7 @@ async function runDesktop(): Promise<void> {
   let quitting = false;
   let protocolInstalled = false;
   let disposeConnectionIpc: (() => void) | undefined;
+  let disposeExternalLinkIpc: (() => void) | undefined;
   let disposeOnboarding: (() => void) | undefined;
   let daemonLifecycle: DesktopDaemonLifecycle | undefined;
   let shutdownPromise: Promise<void> | undefined;
@@ -118,6 +120,8 @@ async function runDesktop(): Promise<void> {
       controller.abort();
       disposeConnectionIpc?.();
       disposeConnectionIpc = undefined;
+      disposeExternalLinkIpc?.();
+      disposeExternalLinkIpc = undefined;
       disposeOnboarding?.();
       disposeOnboarding = undefined;
       if (protocolInstalled) {
@@ -322,6 +326,11 @@ async function runDesktop(): Promise<void> {
       ipcMain,
       currentWindow: () => mainWindow.current() ?? undefined,
       runtime: daemonLifecycle,
+    });
+    disposeExternalLinkIpc = installDesktopExternalLinkIpc({
+      ipcMain,
+      currentWindow: () => mainWindow.current() ?? undefined,
+      openExternal: (url) => shell.openExternal(url),
     });
     residency = createDesktopResidency({
       app,

--- a/apps/desktop/src/main/security.ts
+++ b/apps/desktop/src/main/security.ts
@@ -136,8 +136,8 @@ export function desktopWindowOptions(preload: string): Electron.BrowserWindowCon
 }
 
 export function hardenDesktopWindow(window: BrowserWindow): void {
-  window.webContents.on("will-navigate", (event, url) => {
-    if (url !== DESKTOP_RENDERER_URL) event.preventDefault();
+  window.webContents.on("will-navigate", (event) => {
+    event.preventDefault();
   });
   window.webContents.setWindowOpenHandler(() => ({ action: "deny" }));
   window.webContents.session.setPermissionRequestHandler((_contents, _permission, callback) => {

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -1,5 +1,9 @@
 import { contextBridge, ipcRenderer, webUtils } from "electron";
-import { DESKTOP_CONNECTION_CHANNEL, DESKTOP_LIFECYCLE_CHANNEL } from "../main/constants.js";
+import {
+  DESKTOP_CONNECTION_CHANNEL,
+  DESKTOP_LIFECYCLE_CHANNEL,
+  DESKTOP_OPEN_EXTERNAL_CHANNEL,
+} from "../main/constants.js";
 
 const DESKTOP_CREDENTIAL_STATUS_CHANNEL = "enduragent:onboarding:credential-status";
 const DESKTOP_CREDENTIAL_RETRY_CHANNEL = "enduragent:onboarding:credential-retry";
@@ -149,6 +153,20 @@ function parsePaths(value: unknown): readonly string[] {
 }
 
 let dropDisposer: (() => void) | undefined;
+
+window.addEventListener(
+  "click",
+  (event) => {
+    if (!event.isTrusted || event.defaultPrevented || event.button !== 0) return;
+    const anchor = event
+      .composedPath()
+      .find((candidate): candidate is HTMLAnchorElement => candidate instanceof HTMLAnchorElement);
+    if (anchor === undefined || anchor.target !== "_blank") return;
+    event.preventDefault();
+    ipcRenderer.send(DESKTOP_OPEN_EXTERNAL_CHANNEL, anchor.href);
+  },
+  true,
+);
 
 ipcRenderer.on(DESKTOP_LIFECYCLE_CHANNEL, (_event, value: unknown) => {
   if (

--- a/apps/desktop/tests/chat-panels.integration.test.ts
+++ b/apps/desktop/tests/chat-panels.integration.test.ts
@@ -121,11 +121,33 @@ function makeScript(calls: ScriptRequest[]): DesktopFixtureScript {
       }
       if (request.method === "chat") {
         hasSession = true;
+        const firstDelta = "## Today’s ride\n\nHold   **ste";
+        const finalText = `${firstDelta}ady**.
+
+<script>globalThis.hostile = true</script>
+
+| Segment | Prescription |
+| --- | --- |
+| Endurance | ${"steady".repeat(40)} |
+
+\`\`\`text
+${"nonwrapping".repeat(36)}
+\`\`\`
+
+[Guide](https://example.test/guide)`;
         return [
-          JSON.stringify({ type: "text_delta", turnId: "turn-fixture", delta: "Hold " }),
-          JSON.stringify({ type: "text_delta", turnId: "turn-fixture", delta: "steady" }),
-          JSON.stringify({ type: "final-text", turnId: "turn-fixture", text: "Hold steady." }),
-          JSON.stringify({ text: "Hold steady." }),
+          JSON.stringify({
+            type: "text_delta",
+            turnId: "turn-fixture",
+            delta: firstDelta,
+          }),
+          JSON.stringify({
+            type: "text_delta",
+            turnId: "turn-fixture",
+            delta: finalText.slice(firstDelta.length),
+          }),
+          JSON.stringify({ type: "final-text", turnId: "turn-fixture", text: finalText }),
+          JSON.stringify({ text: finalText }),
         ];
       }
       if (request.method === "hasSession") return response({ hasSession });
@@ -209,6 +231,24 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       readonly thread: boolean;
       readonly partial: string;
       readonly final: string;
+      readonly athleteStable: boolean;
+      readonly coachStable: boolean;
+      readonly busyObserved: boolean;
+      readonly busyCleared: boolean;
+      readonly partialWhiteSpace: string | null;
+      readonly partialSourcePreserved: boolean;
+      readonly controlExercised: boolean;
+      readonly controlOnlyMutations: number;
+      readonly heading: string;
+      readonly strong: string;
+      readonly hostileTextVisible: boolean;
+      readonly hostileElementCount: number;
+      readonly link: {
+        readonly href: string | null;
+        readonly target: string | null;
+        readonly rel: string | null;
+        readonly referrerPolicy: string | null;
+      };
       readonly drawerStatus: string;
       readonly anchorValue: string;
       readonly wellnessValue: string;
@@ -217,25 +257,101 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       const thread = document.querySelectorAll(".thread").length === 1;
       const textarea = document.querySelector("#message");
       const observed = [];
-      const observer = new MutationObserver(() => {
+      let athleteRow;
+      let coachRow;
+      let athleteStable = true;
+      let coachStable = true;
+      let busyObserved = false;
+      let busyCleared = false;
+      let partialWhiteSpace = null;
+      let partialSourcePreserved = false;
+      const capturePartial = (candidate) => {
+        if (!candidate.includes("Hold   **ste") || candidate.includes("ady**")) return;
+        partialSourcePreserved =
+          candidate.startsWith("## Today’s ride") &&
+          candidate.includes(String.fromCharCode(10) + String.fromCharCode(10));
+        partialWhiteSpace = getComputedStyle(
+          document.querySelector(".chat-message--coach .chat-message__text"),
+        ).whiteSpace;
+      };
+      const observer = new MutationObserver((records) => {
+        for (const record of records) {
+          if (record.type === "characterData" && record.oldValue) {
+            observed.push(record.oldValue);
+            capturePartial(record.oldValue);
+          }
+          if (record.type === "attributes" && record.attributeName === "aria-busy" && record.oldValue === "true") {
+            busyObserved = true;
+          }
+        }
         const value = document.querySelector(".chat-message--coach .chat-message__text")?.textContent ?? "";
-        if (value.length > 0) observed.push(value);
+        if (value.length > 0) {
+          observed.push(value);
+          capturePartial(value);
+        }
+        const currentAthlete = document.querySelector(".chat-message--athlete");
+        const currentCoach = document.querySelector(".chat-message--coach");
+        if (currentAthlete && athleteRow && currentAthlete !== athleteRow) athleteStable = false;
+        if (currentCoach && coachRow && currentCoach !== coachRow) coachStable = false;
+        athleteRow ??= currentAthlete;
+        coachRow ??= currentCoach;
+        if (currentCoach?.getAttribute("aria-busy") === "true") busyObserved = true;
+        if (busyObserved && currentCoach && !currentCoach.hasAttribute("aria-busy")) busyCleared = true;
       });
       observer.observe(document.querySelector(".chat-messages"), {
+        attributes: true,
+        attributeOldValue: true,
+        attributeFilter: ["aria-busy"],
         childList: true,
         characterData: true,
+        characterDataOldValue: true,
         subtree: true,
       });
       textarea.value = "What should I ride?";
       textarea.closest("form").requestSubmit();
+      athleteRow ??= document.querySelector(".chat-message--athlete");
       const finalDeadline = Date.now() + 5000;
       let final = "";
-      while (final !== "Hold steady." && Date.now() < finalDeadline) {
+      while (Date.now() < finalDeadline) {
         await new Promise((resolve) => setTimeout(resolve, 5));
-        final = document.querySelector(".chat-message--coach .chat-message__text")?.textContent ?? "";
+        const currentCoach = document.querySelector(".chat-message--coach");
+        final = currentCoach?.querySelector(".chat-message__text")?.textContent ?? "";
+        if (
+          final.includes("<script>globalThis.hostile = true</script>") &&
+          final.includes("Guide") &&
+          !currentCoach?.hasAttribute("aria-busy")
+        ) break;
       }
+      await new Promise((resolve) => setTimeout(resolve, 0));
       observer.disconnect();
-      const partial = observed.find((value) => value === "Hold " || value === "Hold steady") ?? "";
+      const partial = observed.find(
+        (value) => value.includes("Hold   **ste") && !value.includes("ady**"),
+      ) ?? "";
+      const opener = document.querySelector(".new-conversation-button");
+      const controlDeadline = Date.now() + 5000;
+      while (
+        (opener.disabled || opener.getAttribute("aria-disabled") === "true") &&
+        Date.now() < controlDeadline
+      ) {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+      }
+      const controlRecords = [];
+      const controlObserver = new MutationObserver((records) => controlRecords.push(...records));
+      controlObserver.observe(document.querySelector(".chat-messages"), {
+        attributes: true,
+        childList: true,
+        characterData: true,
+        subtree: true,
+      });
+      const controlExercised = !opener.disabled && opener.getAttribute("aria-disabled") !== "true";
+      if (controlExercised) {
+        opener.click();
+        document.querySelector(".new-conversation-dialog button")?.click();
+      }
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      controlObserver.disconnect();
+      const coach = document.querySelector(".chat-message--coach");
+      const link = coach?.querySelector("a");
       const panels = [...document.querySelectorAll(".context-panel__body")];
       return {
         location: location.href,
@@ -243,6 +359,24 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
         thread,
         partial,
         final,
+        athleteStable: athleteStable && athleteRow === document.querySelector(".chat-message--athlete"),
+        coachStable: coachStable && coachRow === coach,
+        busyObserved,
+        busyCleared,
+        partialWhiteSpace,
+        partialSourcePreserved,
+        controlExercised,
+        controlOnlyMutations: controlRecords.length,
+        heading: coach?.querySelector("h2")?.textContent ?? "",
+        strong: coach?.querySelector("strong")?.textContent ?? "",
+        hostileTextVisible: coach?.textContent.includes("<script>globalThis.hostile = true</script>") ?? false,
+        hostileElementCount: coach?.querySelectorAll("script, img").length ?? -1,
+        link: {
+          href: link?.getAttribute("href") ?? null,
+          target: link?.getAttribute("target") ?? null,
+          rel: link?.getAttribute("rel") ?? null,
+          referrerPolicy: link?.getAttribute("referrerpolicy") ?? null,
+        },
         drawerStatus: document.querySelector(".drawer-status")?.textContent ?? "missing",
         anchorValue: panels[0]?.querySelector(".context-panel__value")?.textContent ?? "",
         wellnessValue: panels[4]?.querySelector(".wellness-row__value")?.textContent ?? "",
@@ -261,8 +395,26 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
         "writeCredential",
       ],
       thread: true,
-      partial: expect.stringMatching(/^Hold (steady)?$/u),
-      final: "Hold steady.",
+      partial: "## Today’s ride\n\nHold   **ste",
+      final: expect.stringContaining("<script>globalThis.hostile = true</script>"),
+      athleteStable: true,
+      coachStable: true,
+      busyObserved: true,
+      busyCleared: true,
+      partialWhiteSpace: "pre-wrap",
+      partialSourcePreserved: true,
+      controlExercised: true,
+      controlOnlyMutations: 0,
+      heading: "Today’s ride",
+      strong: "steady",
+      hostileTextVisible: true,
+      hostileElementCount: 0,
+      link: {
+        href: "https://example.test/guide",
+        target: "_blank",
+        rel: "noopener noreferrer",
+        referrerPolicy: "no-referrer",
+      },
       drawerStatus: "",
       anchorValue: "300 W",
       wellnessValue: "65 ms",
@@ -274,6 +426,26 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
         params: { chatId: "desktop" },
       },
     ]);
+    await fixture.setViewport(720, 800);
+    expect(
+      await fixture.evaluate<{
+        readonly documentOverflow: boolean;
+        readonly tableScrollsLocally: boolean;
+        readonly codeScrollsLocally: boolean;
+      }>(`
+        const tableScroll = document.querySelector(".chat-markdown__table-scroll");
+        const codeBlock = document.querySelector(".chat-message--coach pre");
+        return {
+          documentOverflow: document.documentElement.scrollWidth > document.documentElement.clientWidth,
+          tableScrollsLocally: tableScroll.scrollWidth > tableScroll.clientWidth && getComputedStyle(tableScroll).overflowX === "auto",
+          codeScrollsLocally: codeBlock.scrollWidth > codeBlock.clientWidth && getComputedStyle(codeBlock).overflowX === "auto",
+        };
+      `),
+    ).toEqual({
+      documentOverflow: false,
+      tableScrollsLocally: true,
+      codeScrollsLocally: true,
+    });
     const reset = await fixture.evaluate<{
       readonly enabledBefore: boolean;
       readonly dialogOpen: boolean;
@@ -282,6 +454,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       readonly composerDisabled: boolean;
       readonly resetDisabled: boolean;
       readonly focused: string | null;
+      readonly transcriptClearMutations: number;
     }>(`
       const opener = document.querySelector(".new-conversation-button");
       const textarea = document.querySelector("#message");
@@ -293,11 +466,16 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       if (enabledBefore) opener.click();
       const dialog = document.querySelector(".new-conversation-dialog");
       const dialogOpen = dialog.open;
+      const clearRecords = [];
+      const clearObserver = new MutationObserver((records) => clearRecords.push(...records));
+      clearObserver.observe(document.querySelector(".chat-messages"), { childList: true });
       if (dialogOpen) dialog.querySelector(".new-conversation-dialog__confirm").click();
       const resetDeadline = Date.now() + 5000;
       while (dialog.open && Date.now() < resetDeadline) {
         await new Promise((resolve) => setTimeout(resolve, 5));
       }
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      clearObserver.disconnect();
       return {
         enabledBefore,
         dialogOpen,
@@ -306,6 +484,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
         composerDisabled: textarea.disabled,
         resetDisabled: opener.disabled,
         focused: document.activeElement?.id ?? null,
+        transcriptClearMutations: clearRecords.filter((record) => record.type === "childList").length,
       };
     `);
     expect(reset).toEqual({
@@ -316,6 +495,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       composerDisabled: false,
       resetDisabled: true,
       focused: "message",
+      transcriptClearMutations: 1,
     });
     expect(calls.filter((call) => call.method === "resetSession")).toEqual([
       {

--- a/apps/desktop/tests/external-link-ipc.test.ts
+++ b/apps/desktop/tests/external-link-ipc.test.ts
@@ -1,0 +1,158 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("electron", () => ({
+  BrowserWindow: class {},
+  net: { fetch: vi.fn() },
+  protocol: { registerSchemesAsPrivileged: vi.fn() },
+}));
+
+import { DESKTOP_OPEN_EXTERNAL_CHANNEL, DESKTOP_RENDERER_URL } from "../src/main/constants.js";
+import { installDesktopExternalLinkIpc } from "../src/main/external-link-ipc.js";
+
+type Listener = (event: unknown, ...args: unknown[]) => void;
+
+function setup(openExternal = vi.fn(async () => {})) {
+  const listeners = new Map<string, Set<Listener>>();
+  const ipcMain = {
+    on: vi.fn((channel: string, listener: Listener) => {
+      const channelListeners = listeners.get(channel) ?? new Set();
+      channelListeners.add(listener);
+      listeners.set(channel, channelListeners);
+    }),
+    removeListener: vi.fn((channel: string, listener: Listener) => {
+      listeners.get(channel)?.delete(listener);
+    }),
+  };
+  const mainFrame: { url: string } = { url: DESKTOP_RENDERER_URL };
+  const webContents = { isDestroyed: () => false, mainFrame };
+  const window = { isDestroyed: () => false, webContents };
+  let currentWindow: typeof window | undefined = window;
+  const dispose = installDesktopExternalLinkIpc({
+    ipcMain: ipcMain as never,
+    currentWindow: () => currentWindow as never,
+    openExternal,
+  });
+  const emit = (event: unknown, ...args: unknown[]): void => {
+    for (const listener of listeners.get(DESKTOP_OPEN_EXTERNAL_CHANNEL) ?? []) {
+      listener(event, ...args);
+    }
+  };
+  return {
+    dispose,
+    emit,
+    ipcMain,
+    listeners,
+    mainFrame,
+    openExternal,
+    setCurrentWindow(value: typeof window | undefined) {
+      currentWindow = value;
+    },
+    trusted: { sender: webContents, senderFrame: mainFrame },
+    webContents,
+    window,
+  };
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("desktop external-link IPC", () => {
+  it("opens canonical credential-free HTTP links from the trusted main frame", async () => {
+    const { emit, openExternal, trusted } = setup();
+
+    emit(trusted, "https://example.test/guide");
+    emit(trusted, "http://example.test/guide?a=1&b=2");
+    await Promise.resolve();
+
+    expect(openExternal.mock.calls).toEqual([
+      ["https://example.test/guide"],
+      ["http://example.test/guide?a=1&b=2"],
+    ]);
+  });
+
+  it("requires exactly one string argument before opening", () => {
+    const { emit, openExternal, trusted } = setup();
+
+    emit(trusted);
+    emit(trusted, "https://example.test/", "extra");
+    emit(trusted, { url: "https://example.test/" });
+    emit(trusted, null);
+
+    expect(openExternal).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    "HTTPS://EXAMPLE.TEST:443/guide",
+    "https://user@example.test/guide",
+    "https://user:secret@example.test/guide",
+    " https://example.test/guide",
+    "https://example.test/guide\u007f",
+    "https://example.test/guide\nnext",
+    "javascript:alert(1)",
+    "data:text/plain,unsafe",
+    "enduragent://app/index.html",
+    "/relative",
+    "http://",
+  ])("rejects a noncanonical or unsafe destination: %s", (url) => {
+    const { emit, openExternal, trusted } = setup();
+
+    emit(trusted, url);
+
+    expect(openExternal).not.toHaveBeenCalled();
+  });
+
+  it("rejects stale, subframe, mismatched-sender, and destroyed-window events", () => {
+    const state = setup();
+    const otherFrame = { url: DESKTOP_RENDERER_URL };
+
+    state.emit(
+      { sender: state.webContents, senderFrame: otherFrame },
+      "https://example.test/guide",
+    );
+    state.emit({ sender: {}, senderFrame: state.mainFrame }, "https://example.test/guide");
+    state.emit({ sender: state.webContents, senderFrame: null }, "https://example.test/guide");
+    state.mainFrame.url = "https://example.invalid";
+    state.emit(state.trusted, "https://example.test/guide");
+    state.mainFrame.url = DESKTOP_RENDERER_URL;
+    state.setCurrentWindow(undefined);
+    state.emit(state.trusted, "https://example.test/guide");
+    state.setCurrentWindow({ ...state.window, isDestroyed: () => true });
+    state.emit(state.trusted, "https://example.test/guide");
+    state.setCurrentWindow({
+      ...state.window,
+      webContents: { ...state.webContents, isDestroyed: () => true },
+    });
+    state.emit(state.trusted, "https://example.test/guide");
+
+    expect(state.openExternal).not.toHaveBeenCalled();
+  });
+
+  it("contains synchronous and asynchronous opener failures", async () => {
+    const syncFailure = vi.fn(() => {
+      throw new Error("synthetic synchronous failure");
+    });
+    const sync = setup(syncFailure as never);
+    expect(() => sync.emit(sync.trusted, "https://example.test/guide")).not.toThrow();
+
+    const asyncFailure = vi.fn(async () => Promise.reject(new Error("synthetic rejection")));
+    const asynchronous = setup(asyncFailure);
+    expect(() =>
+      asynchronous.emit(asynchronous.trusted, "https://example.test/guide"),
+    ).not.toThrow();
+    await Promise.resolve();
+
+    expect(syncFailure).toHaveBeenCalledOnce();
+    expect(asyncFailure).toHaveBeenCalledOnce();
+  });
+
+  it("removes only its exact listener during shutdown", () => {
+    const { dispose, ipcMain, listeners } = setup();
+    const listener = [...listeners.get(DESKTOP_OPEN_EXTERNAL_CHANNEL)!][0]!;
+
+    dispose();
+    dispose();
+
+    expect(ipcMain.removeListener).toHaveBeenCalledOnce();
+    expect(ipcMain.removeListener).toHaveBeenCalledWith(DESKTOP_OPEN_EXTERNAL_CHANNEL, listener);
+    expect(listeners.get(DESKTOP_OPEN_EXTERNAL_CHANNEL)).toEqual(new Set());
+  });
+});

--- a/apps/desktop/tests/preload-auth.test.ts
+++ b/apps/desktop/tests/preload-auth.test.ts
@@ -1,20 +1,39 @@
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => {
   const exposed: Record<string, unknown> = {};
+  class FakeAnchor {
+    constructor(
+      readonly href: string,
+      readonly target = "_blank",
+    ) {}
+  }
+  let clickListener: ((event: Record<string, unknown>) => void) | undefined;
+  const fakeWindow = {
+    addEventListener: vi.fn((name: string, listener: typeof clickListener) => {
+      if (name === "click") clickListener = listener;
+    }),
+    dispatchEvent: vi.fn(),
+  };
   return {
     exposed,
+    FakeAnchor,
+    fakeWindow,
+    get clickListener() {
+      return clickListener;
+    },
     exposeInMainWorld: vi.fn((name: string, value: unknown) => {
       exposed[name] = value;
     }),
     invoke: vi.fn(),
     on: vi.fn(),
+    send: vi.fn(),
   };
 });
 
 vi.mock("electron", () => ({
   contextBridge: { exposeInMainWorld: mocks.exposeInMainWorld },
-  ipcRenderer: { invoke: mocks.invoke, on: mocks.on },
+  ipcRenderer: { invoke: mocks.invoke, on: mocks.on, send: mocks.send },
   webUtils: { getPathForFile: vi.fn() },
 }));
 
@@ -29,15 +48,23 @@ interface AuthBridge {
 let bridge: AuthBridge;
 
 beforeAll(async () => {
+  Object.assign(globalThis, {
+    window: mocks.fakeWindow,
+    HTMLAnchorElement: mocks.FakeAnchor,
+  });
   await import("../src/preload/index.js");
   bridge = mocks.exposed.enduragentAuth as AuthBridge;
 });
 
 beforeEach(() => {
   mocks.invoke.mockReset();
+  mocks.send.mockReset();
+  mocks.fakeWindow.dispatchEvent.mockReset();
+  Object.assign(globalThis, {
+    window: mocks.fakeWindow,
+    HTMLAnchorElement: mocks.FakeAnchor,
+  });
 });
-
-afterEach(() => vi.unstubAllGlobals());
 
 describe("desktop preload ChatGPT auth", () => {
   it("reuses the connection channel with a closed recovery request", async () => {
@@ -51,18 +78,92 @@ describe("desktop preload ChatGPT auth", () => {
   });
 
   it("forwards only closed lifecycle states to the renderer", () => {
-    const dispatchEvent = vi.fn();
-    vi.stubGlobal("window", { dispatchEvent });
     const listener = mocks.on.mock.calls.find(
       ([channel]) => channel === "desktop:daemon-lifecycle",
     )?.[1] as (_event: unknown, value: unknown) => void;
     listener(undefined, { status: "recovering", generation: 2 });
     listener(undefined, { status: "recovering", generation: 0 });
-    expect(dispatchEvent).toHaveBeenCalledTimes(1);
-    expect(dispatchEvent.mock.calls[0]![0]).toMatchObject({
+    expect(mocks.fakeWindow.dispatchEvent).toHaveBeenCalledTimes(1);
+    expect(mocks.fakeWindow.dispatchEvent.mock.calls[0]![0]).toMatchObject({
       type: "enduragent-lifecycle",
       detail: { status: "recovering", generation: 2 },
     });
+  });
+
+  it("keeps the external-link sender private while preserving the exact public bridge", () => {
+    expect(Object.keys(mocks.exposed)).toEqual(["enduragentAuth"]);
+    expect(Object.keys(bridge).sort()).toEqual([
+      "chatgptLogin",
+      "chatgptStatus",
+      "chooseImportFiles",
+      "credentialStatuses",
+      "getDaemonConnection",
+      "onDroppedImportFiles",
+      "retryFailedCredentials",
+      "writeCredential",
+    ]);
+    expect(bridge).not.toHaveProperty("openExternal");
+  });
+
+  it("sends a nested trusted target-blank anchor activation over the private channel", () => {
+    const anchor = new mocks.FakeAnchor("https://example.test/guide");
+    const preventDefault = vi.fn();
+
+    mocks.clickListener?.({
+      isTrusted: true,
+      defaultPrevented: false,
+      button: 0,
+      composedPath: () => [{}, anchor],
+      preventDefault,
+    });
+
+    expect(preventDefault).toHaveBeenCalledOnce();
+    expect(mocks.send).toHaveBeenCalledWith("desktop:open-external", "https://example.test/guide");
+    expect(mocks.fakeWindow.addEventListener).toHaveBeenCalledWith(
+      "click",
+      expect.any(Function),
+      true,
+    );
+  });
+
+  it("ignores synthetic, handled, non-primary, non-anchor, and non-blank clicks", () => {
+    const preventDefault = vi.fn();
+    const cases = [
+      {
+        isTrusted: false,
+        defaultPrevented: false,
+        button: 0,
+        composedPath: () => [new mocks.FakeAnchor("https://example.test/")],
+      },
+      {
+        isTrusted: true,
+        defaultPrevented: true,
+        button: 0,
+        composedPath: () => [new mocks.FakeAnchor("https://example.test/")],
+      },
+      {
+        isTrusted: true,
+        defaultPrevented: false,
+        button: 1,
+        composedPath: () => [new mocks.FakeAnchor("https://example.test/")],
+      },
+      {
+        isTrusted: true,
+        defaultPrevented: false,
+        button: 0,
+        composedPath: () => [{}],
+      },
+      {
+        isTrusted: true,
+        defaultPrevented: false,
+        button: 0,
+        composedPath: () => [new mocks.FakeAnchor("https://example.test/", "_self")],
+      },
+    ];
+    for (const event of cases) mocks.clickListener?.({ ...event, preventDefault });
+
+    expect(preventDefault).not.toHaveBeenCalled();
+    expect(mocks.send).not.toHaveBeenCalled();
   });
 
   it("exposes closed credential runtime states and the retry command", async () => {

--- a/apps/desktop/tests/residency.test.ts
+++ b/apps/desktop/tests/residency.test.ts
@@ -79,7 +79,7 @@ vi.mock("electron", () => ({
   Tray: mocks.FakeTray,
   nativeImage: { createFromPath: vi.fn(() => mocks.image) },
   dialog: {},
-  ipcMain: { handle: vi.fn(), removeHandler: vi.fn() },
+  ipcMain: { handle: vi.fn(), on: vi.fn(), removeHandler: vi.fn(), removeListener: vi.fn() },
   safeStorage: {},
   session: { defaultSession: { protocol: { unhandle: vi.fn() } } },
   utilityProcess: { fork: vi.fn() },

--- a/apps/desktop/tests/security.test.ts
+++ b/apps/desktop/tests/security.test.ts
@@ -11,6 +11,7 @@ import { net } from "electron";
 import {
   DESKTOP_CONNECTION_CHANNEL,
   DESKTOP_HOST,
+  DESKTOP_OPEN_EXTERNAL_CHANNEL,
   DESKTOP_RENDERER_ORIGIN,
   DESKTOP_RENDERER_URL,
   DESKTOP_SCHEME,
@@ -23,6 +24,7 @@ import {
 import {
   createDesktopRendererConsoleCapture,
   desktopWindowOptions,
+  hardenDesktopWindow,
   installDesktopProtocol,
   isTrustedConnectionRequest,
   resolveDesktopRendererSource,
@@ -119,12 +121,14 @@ describe("desktop security boundary", () => {
       DESKTOP_RENDERER_ORIGIN,
       DESKTOP_RENDERER_URL,
       DESKTOP_CONNECTION_CHANNEL,
+      DESKTOP_OPEN_EXTERNAL_CHANNEL,
     }).toEqual({
       DESKTOP_SCHEME: "enduragent",
       DESKTOP_HOST: "app",
       DESKTOP_RENDERER_ORIGIN: "enduragent://app",
       DESKTOP_RENDERER_URL: "enduragent://app/index.html",
       DESKTOP_CONNECTION_CHANNEL: "desktop:get-daemon-connection",
+      DESKTOP_OPEN_EXTERNAL_CHANNEL: "desktop:open-external",
     });
     expect({
       DESKTOP_WINDOW_WIDTH,
@@ -159,6 +163,47 @@ describe("desktop security boundary", () => {
         allowRunningInsecureContent: false,
       },
     });
+  });
+
+  it("always denies renderer navigation, new windows, and permissions", () => {
+    let navigate: ((event: { preventDefault(): void }, url: string) => void) | undefined;
+    let openHandler: ((details: { url: string }) => unknown) | undefined;
+    let permissionRequest:
+      | ((_contents: unknown, _permission: string, callback: (allowed: boolean) => void) => void)
+      | undefined;
+    let permissionCheck: (() => boolean) | undefined;
+    hardenDesktopWindow({
+      webContents: {
+        on: vi.fn((name: string, listener: typeof navigate) => {
+          if (name === "will-navigate") navigate = listener;
+        }),
+        setWindowOpenHandler: vi.fn((handler: typeof openHandler) => {
+          openHandler = handler;
+        }),
+        session: {
+          setPermissionRequestHandler: vi.fn((handler: typeof permissionRequest) => {
+            permissionRequest = handler;
+          }),
+          setPermissionCheckHandler: vi.fn((handler: typeof permissionCheck) => {
+            permissionCheck = handler;
+          }),
+        },
+      },
+    } as never);
+    const preventAppNavigation = vi.fn();
+    const preventExternalNavigation = vi.fn();
+    const permissionResult = vi.fn();
+
+    navigate?.({ preventDefault: preventAppNavigation }, DESKTOP_RENDERER_URL);
+    navigate?.({ preventDefault: preventExternalNavigation }, "https://example.test/guide");
+    permissionRequest?.({}, "notifications", permissionResult);
+
+    expect(preventAppNavigation).toHaveBeenCalledOnce();
+    expect(preventExternalNavigation).toHaveBeenCalledOnce();
+    expect(openHandler?.({ url: "https://example.test/guide" })).toEqual({ action: "deny" });
+    expect(openHandler?.({ url: "javascript:alert(1)" })).toEqual({ action: "deny" });
+    expect(permissionResult).toHaveBeenCalledWith(false);
+    expect(permissionCheck?.()).toBe(false);
   });
 
   it("does not register or retain renderer console messages when capture is disabled", () => {


### PR DESCRIPTION
## Summary

- Render a bounded, dependency-free Markdown subset for coach responses while keeping raw HTML, images, and unsafe links inert.
- Preserve keyed transcript rows and append admitted stream deltas without rebuilding or re-announcing conversation history.
- Open canonical HTTP(S) links only after trusted user activation through private, sender-validated IPC.
- Keep multiline fallback text and wide tables or code responsive at compact Desktop widths.

## Validation

- pnpm check: passed with zero errors and nine pre-existing warnings.
- pnpm test: 383 files passed, 3 skipped; 5,055 tests passed, 6 skipped.
- Real Electron chat-panel integration: 2 tests passed.
- Three independent final read-only reviewers: PASS with zero blockers.