### PR TITLE
feat(desktop): add coaching quick actions

### DIFF
--- a/.changeset/desktop-coaching-shortcuts.md
+++ b/.changeset/desktop-coaching-shortcuts.md
@@ -1,0 +1,5 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Added quick actions for training plans, today’s workout, training status, and session reviews in Desktop.

--- a/apps/desktop-renderer/src/chat/styles.css
+++ b/apps/desktop-renderer/src/chat/styles.css
@@ -1,3 +1,8 @@
+.conversation.desktop-shell {
+  grid-row: 2;
+  padding-bottom: var(--chat-composer-clearance, 150px);
+}
+
 .chat-transcript {
   display: grid;
   gap: 18px;
@@ -264,6 +269,51 @@
 
 .new-conversation-status:not(:empty) {
   padding: 0 14px 8px;
+}
+
+.coaching-shortcuts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  min-width: 0;
+  margin: 0 0 10px;
+}
+
+.coaching-shortcut {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  min-width: 0;
+  max-width: 100%;
+  min-height: 34px;
+  padding: 6px 12px;
+  border: 1px solid var(--line-strong);
+  border-radius: 999px;
+  color: var(--moss-strong);
+  background: var(--surface-solid);
+  cursor: pointer;
+}
+
+.coaching-shortcut__label {
+  overflow-wrap: anywhere;
+}
+
+.coaching-shortcut__command {
+  color: var(--muted);
+  font:
+    11px/1.2 SFMono-Regular,
+    ui-monospace,
+    monospace;
+}
+
+.coaching-shortcut:focus-visible {
+  outline: 3px solid var(--focus);
+  outline-offset: 2px;
+}
+
+.coaching-shortcut:disabled {
+  cursor: default;
+  opacity: 0.5;
 }
 
 .chat-composer__label {

--- a/apps/desktop-renderer/src/chat/view.ts
+++ b/apps/desktop-renderer/src/chat/view.ts
@@ -12,6 +12,20 @@ interface RenderedMessage {
   delivery: ChatTranscriptMessage["delivery"];
 }
 
+interface PendingShortcutFocus {
+  readonly button: HTMLButtonElement;
+  observedTurnLock: boolean;
+}
+
+const COMPOSER_CLEARANCE_PROPERTY = "--chat-composer-clearance";
+
+const COACHING_SHORTCUTS = Object.freeze([
+  Object.freeze({ command: "/plan", label: "Build a plan" }),
+  Object.freeze({ command: "/workout", label: "Today’s workout" }),
+  Object.freeze({ command: "/status", label: "Training status" }),
+  Object.freeze({ command: "/review", label: "Review last session" }),
+]);
+
 export interface MountedChatView {
   readonly view: ChatView;
   readonly noticeHost: HTMLElement;
@@ -92,6 +106,25 @@ export function mountChatView(input: {
   resetStatus.setAttribute("role", "status");
   resetStatus.setAttribute("aria-live", "polite");
   noticeHost.append(resetStatus);
+  const shortcutGroup = document.createElement("div");
+  shortcutGroup.className = "coaching-shortcuts";
+  shortcutGroup.setAttribute("role", "group");
+  shortcutGroup.setAttribute("aria-label", "Coaching shortcuts");
+  const shortcutControls = COACHING_SHORTCUTS.map((shortcut) => {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "coaching-shortcut";
+    button.setAttribute("aria-label", `${shortcut.label}, ${shortcut.command} command`);
+    const buttonLabel = document.createElement("span");
+    buttonLabel.className = "coaching-shortcut__label";
+    buttonLabel.textContent = shortcut.label;
+    const command = document.createElement("span");
+    command.className = "coaching-shortcut__command";
+    command.textContent = shortcut.command;
+    button.append(buttonLabel, command);
+    shortcutGroup.append(button);
+    return { button, shortcut };
+  });
   const label = document.createElement("label");
   label.className = "chat-composer__label";
   label.htmlFor = "message";
@@ -107,7 +140,7 @@ export function mountChatView(input: {
   submit.textContent = "↑";
   controls.append(textarea, submit);
   form.append(label, controls);
-  input.composerHost.append(noticeHost, form);
+  input.composerHost.append(noticeHost, shortcutGroup, form);
 
   let handlers:
     | {
@@ -123,6 +156,19 @@ export function mountChatView(input: {
   let renderedAnnouncement: string | null = null;
   const renderedMessages = new Map<string, RenderedMessage>();
   let renderedNotice: string | null = null;
+  let pendingShortcutFocus: PendingShortcutFocus | undefined;
+
+  const updateComposerClearance = (): void => {
+    if (disposed) return;
+    const height = input.composerHost.getBoundingClientRect().height;
+    if (Number.isFinite(height) && height > 0) {
+      input.conversation.style.setProperty(COMPOSER_CLEARANCE_PROPERTY, `${height}px`);
+    }
+  };
+  updateComposerClearance();
+  const composerResizeObserver =
+    typeof ResizeObserver === "undefined" ? undefined : new ResizeObserver(updateComposerClearance);
+  composerResizeObserver?.observe(input.composerHost);
 
   const onSubmit = (event: SubmitEvent): void => {
     event.preventDefault();
@@ -150,6 +196,31 @@ export function mountChatView(input: {
     event.preventDefault();
     if (!cancelReset.disabled) handlers?.onCancelNewConversation();
   };
+  const onDocumentFocusIn = (event: FocusEvent): void => {
+    if (
+      pendingShortcutFocus !== undefined &&
+      event.target !== pendingShortcutFocus.button &&
+      event.target !== document.body &&
+      event.target !== document.documentElement
+    ) {
+      pendingShortcutFocus = undefined;
+    }
+  };
+  const shortcutListeners = shortcutControls.map(({ button, shortcut }) => {
+    const listener = (event: MouseEvent): void => {
+      if (disposed || button.disabled) return;
+      const onShortcutSubmit = handlers?.onSubmit;
+      if (onShortcutSubmit === undefined) return;
+      pendingShortcutFocus =
+        event.detail === 0 && document.activeElement === button
+          ? { button, observedTurnLock: false }
+          : undefined;
+      onShortcutSubmit(shortcut.command);
+    };
+    button.addEventListener("click", listener);
+    return { button, listener };
+  });
+  document.addEventListener("focusin", onDocumentFocusIn);
   form.addEventListener("submit", onSubmit);
   textarea.addEventListener("keydown", onKeydown);
   retry.addEventListener("click", onRetry);
@@ -190,11 +261,32 @@ export function mountChatView(input: {
         cancelReset.disabled = resetPending;
         confirmReset.disabled = resetPending;
         retry.disabled = workBlocked;
-        submit.disabled = state.status === "streaming" || workBlocked;
-        textarea.disabled = state.status === "streaming" || workBlocked;
+        const composerDisabled = state.status === "streaming" || workBlocked;
+        for (const { button } of shortcutControls) button.disabled = composerDisabled;
+        submit.disabled = composerDisabled;
+        textarea.disabled = composerDisabled;
         const dialogRequested =
           state.session.resetPhase === "confirming" || state.session.resetPhase === "resetting";
         const resetCompleted = state.session.resetCount !== renderedResetCount;
+        if (pendingShortcutFocus !== undefined) {
+          if (state.session.resetPhase !== "idle" || resetCompleted) {
+            pendingShortcutFocus = undefined;
+          } else if (composerDisabled) {
+            pendingShortcutFocus.observedTurnLock = true;
+          } else if (pendingShortcutFocus.observedTurnLock) {
+            const { button } = pendingShortcutFocus;
+            pendingShortcutFocus = undefined;
+            const activeElement = document.activeElement;
+            if (
+              activeElement !== button &&
+              (activeElement === null ||
+                activeElement === document.body ||
+                activeElement === document.documentElement)
+            ) {
+              button.focus();
+            }
+          }
+        }
         if (dialogRequested && !dialog.open) {
           dialog.showModal();
           cancelReset.focus();
@@ -339,6 +431,9 @@ export function mountChatView(input: {
       if (disposed) return;
       disposed = true;
       handlers = undefined;
+      pendingShortcutFocus = undefined;
+      composerResizeObserver?.disconnect();
+      input.conversation.style.removeProperty(COMPOSER_CLEARANCE_PROPERTY);
       form.removeEventListener("submit", onSubmit);
       textarea.removeEventListener("keydown", onKeydown);
       retry.removeEventListener("click", onRetry);
@@ -346,8 +441,13 @@ export function mountChatView(input: {
       cancelReset.removeEventListener("click", onCancelNewConversation);
       confirmReset.removeEventListener("click", onConfirmNewConversation);
       dialog.removeEventListener("cancel", onDialogCancel);
+      document.removeEventListener("focusin", onDocumentFocusIn);
+      for (const { button, listener } of shortcutListeners) {
+        button.removeEventListener("click", listener);
+      }
       if (dialog.open) dialog.close();
       transcript.remove();
+      shortcutGroup.remove();
       form.remove();
       noticeHost.remove();
       newConversation.remove();

--- a/apps/desktop-renderer/tests/chat-view.test.ts
+++ b/apps/desktop-renderer/tests/chat-view.test.ts
@@ -7,6 +7,27 @@ import { EMPTY_CHAT_STATE, reduceChatState, type ChatState } from "../src/turn-s
 
 const mutationEvents: string[] = [];
 
+class FakeStyle {
+  readonly properties = new Map<string, string>();
+  mutationCount = 0;
+
+  setProperty(name: string, value: string): void {
+    this.mutationCount += 1;
+    this.properties.set(name, value);
+  }
+
+  removeProperty(name: string): string {
+    this.mutationCount += 1;
+    const previous = this.properties.get(name) ?? "";
+    this.properties.delete(name);
+    return previous;
+  }
+
+  getPropertyValue(name: string): string {
+    return this.properties.get(name) ?? "";
+  }
+}
+
 class FakeChildList extends Array<FakeElement> {
   item(index: number): FakeElement | null {
     return this[index] ?? null;
@@ -18,6 +39,7 @@ class FakeElement {
   readonly attributes = new Map<string, string>();
   readonly listeners = new Map<string, Set<(event: never) => void>>();
   readonly dataset: Record<string, string> = {};
+  readonly style = new FakeStyle();
   className = "";
   hidden = false;
   disabled = false;
@@ -36,6 +58,8 @@ class FakeElement {
   insertBeforeMutationCount = 0;
   removeMutationCount = 0;
   appendDataMutationCount = 0;
+  focusCount = 0;
+  rectHeight = 0;
   parentNode: FakeElement | null = null;
   private ownText = "";
 
@@ -135,7 +159,14 @@ class FakeElement {
 
   focus(): void {
     if (this.disabled) return;
-    (globalThis.document as unknown as FakeDocument).activeElement = this;
+    this.focusCount += 1;
+    const fakeDocument = globalThis.document as unknown as FakeDocument;
+    fakeDocument.activeElement = this;
+    fakeDocument.dispatch("focusin", { target: this });
+  }
+
+  getBoundingClientRect(): { readonly height: number } {
+    return { height: this.rectHeight };
   }
 
   remove(): void {
@@ -152,6 +183,9 @@ class FakeElement {
 }
 
 class FakeDocument {
+  readonly body = new FakeElement("body");
+  readonly documentElement = new FakeElement("html");
+  readonly listeners = new Map<string, Set<(event: never) => void>>();
   activeElement: FakeElement | null = null;
 
   createElement(name: string): FakeElement {
@@ -166,6 +200,44 @@ class FakeDocument {
 
   createDocumentFragment(): FakeElement {
     return new FakeElement("#fragment");
+  }
+
+  addEventListener(name: string, listener: (event: never) => void): void {
+    const listeners = this.listeners.get(name) ?? new Set();
+    listeners.add(listener);
+    this.listeners.set(name, listeners);
+  }
+
+  removeEventListener(name: string, listener: (event: never) => void): void {
+    this.listeners.get(name)?.delete(listener);
+  }
+
+  dispatch(name: string, event: Record<string, unknown> = {}): void {
+    for (const listener of this.listeners.get(name) ?? []) listener(event as never);
+  }
+}
+
+class FakeResizeObserver {
+  static readonly instances: FakeResizeObserver[] = [];
+
+  readonly observed = new Set<unknown>();
+  disconnected = false;
+
+  constructor(private readonly callback: ResizeObserverCallback) {
+    FakeResizeObserver.instances.push(this);
+  }
+
+  observe(target: unknown): void {
+    this.observed.add(target);
+  }
+
+  disconnect(): void {
+    this.disconnected = true;
+    this.observed.clear();
+  }
+
+  notify(): void {
+    this.callback([], this as never);
   }
 }
 
@@ -205,9 +277,11 @@ const emptyState: ChatState = EMPTY_CHAT_STATE;
 
 beforeEach(() => {
   mutationEvents.splice(0);
+  FakeResizeObserver.instances.splice(0);
   Object.assign(globalThis, {
     document: new FakeDocument(),
     HTMLElement: FakeElement,
+    ResizeObserver: undefined,
   });
 });
 
@@ -280,7 +354,9 @@ describe("chat view", () => {
     );
     expect(find(thread, (node) => node.className === "chat-retry").hidden).toBe(true);
     expect(find(composerHost, (node) => node.tagName === "textarea").disabled).toBe(false);
-    expect(find(composerHost, (node) => node.tagName === "button").disabled).toBe(false);
+    expect(
+      find(composerHost, (node) => node.tagName === "button" && node.type === "submit").disabled,
+    ).toBe(false);
   });
 
   it("renders a partial coach draft and the reauthentication notice once each", () => {
@@ -374,7 +450,9 @@ describe("chat view", () => {
     expect(thread.textContent).not.toContain("The coach couldn't respond");
     expect(find(thread, (node) => node.className === "chat-retry").hidden).toBe(true);
     expect(find(composerHost, (node) => node.tagName === "textarea").disabled).toBe(false);
-    expect(find(composerHost, (node) => node.tagName === "button").disabled).toBe(false);
+    expect(
+      find(composerHost, (node) => node.tagName === "button" && node.type === "submit").disabled,
+    ).toBe(false);
   });
 
   it("renders generic failure copy once as a notice without an empty coach row", () => {
@@ -972,7 +1050,7 @@ describe("chat view", () => {
     expect(messages.replaceChildrenMutationCount).toBe(0);
   });
 
-  it("places one notice host immediately before the composer and removes it on dispose", () => {
+  it("places one notice host and one shortcut group before the composer", () => {
     const composerHost = new FakeElement("div");
     const mounted = mountChatView({
       conversation: new FakeElement("main") as never,
@@ -982,7 +1060,8 @@ describe("chat view", () => {
     const host = mounted.noticeHost as unknown as FakeElement;
     expect(host.className).toBe("chat-notice-host");
     expect(composerHost.children[0]).toBe(host);
-    expect(composerHost.children[1]?.className).toBe("composer");
+    expect(composerHost.children[1]?.className).toBe("coaching-shortcuts");
+    expect(composerHost.children[2]?.className).toBe("composer");
     mounted.dispose();
     expect(host.removed).toBe(true);
   });
@@ -1054,7 +1133,7 @@ describe("chat view", () => {
     );
   });
 
-  it("keeps a visible label, submits original text, and disables while streaming", () => {
+  it("keeps a visible label, submits manual text byte-for-byte, and disables while streaming", () => {
     const conversation = new FakeElement("main");
     const thread = new FakeElement("div");
     const composerHost = new FakeElement("div");
@@ -1077,11 +1156,427 @@ describe("chat view", () => {
     expect(label.textContent).toBe("Message your coach");
     textarea.value = "  Keep spacing  ";
     form.dispatch("submit", { preventDefault() {} });
-    expect(onSubmit).toHaveBeenCalledWith("  Keep spacing  ");
+    textarea.value = "\t/review deep\r\n";
+    form.dispatch("submit", { preventDefault() {} });
+    textarea.value = "  /unknown exact\n";
+    form.dispatch("submit", { preventDefault() {} });
+    expect(onSubmit.mock.calls.map(([message]) => message)).toEqual([
+      "  Keep spacing  ",
+      "\t/review deep\r\n",
+      "  /unknown exact\n",
+    ]);
     mounted.view.render({ ...emptyState, status: "streaming" });
-    const button = find(composerHost, (node) => node.tagName === "button");
+    const button = find(
+      composerHost,
+      (node) => node.tagName === "button" && node.type === "submit",
+    );
     expect(textarea.disabled).toBe(true);
     expect(button.disabled).toBe(true);
+  });
+
+  it("mounts four unique coaching shortcuts in exact order and preserves the draft", () => {
+    const composerHost = new FakeElement("div");
+    const mounted = mountChatView({
+      conversation: new FakeElement("main") as never,
+      thread: new FakeElement("div") as never,
+      composerHost: composerHost as never,
+    });
+    const onSubmit = vi.fn();
+    mounted.bind({
+      onSubmit,
+      onRetry: vi.fn(),
+      onOpenNewConversation: vi.fn(),
+      onCancelNewConversation: vi.fn(),
+      onConfirmNewConversation: vi.fn(),
+    });
+    mounted.view.render(emptyState);
+
+    const group = find(composerHost, (node) => node.className === "coaching-shortcuts");
+    const buttons = findAll(group, (node) => node.className === "coaching-shortcut");
+    const textarea = find(composerHost, (node) => node.tagName === "textarea");
+    const labels = buttons.map(
+      (button) => find(button, (node) => node.className === "coaching-shortcut__label").textContent,
+    );
+    const commands = buttons.map(
+      (button) =>
+        find(button, (node) => node.className === "coaching-shortcut__command").textContent,
+    );
+
+    expect(group.attributes.get("role")).toBe("group");
+    expect(group.attributes.get("aria-label")).toBe("Coaching shortcuts");
+    expect(buttons).toHaveLength(4);
+    expect(labels).toEqual([
+      "Build a plan",
+      "Today’s workout",
+      "Training status",
+      "Review last session",
+    ]);
+    expect(commands).toEqual(["/plan", "/workout", "/status", "/review"]);
+    expect(new Set(commands)).toHaveProperty("size", 4);
+    expect(buttons.map((button) => button.type)).toEqual(["button", "button", "button", "button"]);
+    expect(buttons.map((button) => button.attributes.get("aria-label"))).toEqual([
+      "Build a plan, /plan command",
+      "Today’s workout, /workout command",
+      "Training status, /status command",
+      "Review last session, /review command",
+    ]);
+
+    textarea.value = "  draft\r\nbyte-for-byte  ";
+    for (const button of buttons) button.dispatch("click");
+    expect(onSubmit.mock.calls.map(([message]) => message)).toEqual(commands);
+    expect(textarea.value).toBe("  draft\r\nbyte-for-byte  ");
+  });
+
+  it("guards every shortcut while streaming or resetting and re-enables them with the composer", () => {
+    const composerHost = new FakeElement("div");
+    const mounted = mountChatView({
+      conversation: new FakeElement("main") as never,
+      thread: new FakeElement("div") as never,
+      composerHost: composerHost as never,
+    });
+    const onSubmit = vi.fn();
+    mounted.bind({
+      onSubmit,
+      onRetry: vi.fn(),
+      onOpenNewConversation: vi.fn(),
+      onCancelNewConversation: vi.fn(),
+      onConfirmNewConversation: vi.fn(),
+    });
+    const buttons = findAll(
+      find(composerHost, (node) => node.className === "coaching-shortcuts"),
+      (node) => node.className === "coaching-shortcut",
+    );
+    const submit = find(
+      composerHost,
+      (node) => node.tagName === "button" && node.type === "submit",
+    );
+    const textarea = find(composerHost, (node) => node.tagName === "textarea");
+    const present = reduceChatState(emptyState, { type: "session-probe", hasSession: true });
+    const confirming = reduceChatState(present, { type: "open-new-conversation" });
+    const resetting = reduceChatState(confirming, { type: "begin-reset" });
+
+    mounted.view.render({ ...present, status: "streaming" });
+    expect([...buttons, submit, textarea].every((control) => control.disabled)).toBe(true);
+    for (const button of buttons) button.dispatch("click");
+    expect(onSubmit).not.toHaveBeenCalled();
+
+    mounted.view.render(confirming);
+    expect(buttons.every((button) => button.disabled)).toBe(true);
+    for (const button of buttons) button.dispatch("click");
+    expect(onSubmit).not.toHaveBeenCalled();
+
+    mounted.view.render(resetting);
+    expect(buttons.every((button) => button.disabled)).toBe(true);
+    for (const button of buttons) button.dispatch("click");
+    expect(onSubmit).not.toHaveBeenCalled();
+
+    mounted.view.render(present);
+    expect([...buttons, submit, textarea].every((control) => !control.disabled)).toBe(true);
+    buttons[2]?.dispatch("click");
+    expect(onSubmit).toHaveBeenCalledOnce();
+    expect(onSubmit).toHaveBeenCalledWith("/status");
+  });
+
+  it("keeps shortcut nodes and their single listeners resident across repeated renders", () => {
+    const composerHost = new FakeElement("div");
+    const mounted = mountChatView({
+      conversation: new FakeElement("main") as never,
+      thread: new FakeElement("div") as never,
+      composerHost: composerHost as never,
+    });
+    const group = find(composerHost, (node) => node.className === "coaching-shortcuts");
+    const buttons = findAll(group, (node) => node.className === "coaching-shortcut");
+    const listeners = buttons.map((button) => [...(button.listeners.get("click") ?? [])][0]);
+
+    for (let index = 0; index < 8; index += 1) {
+      mounted.view.render({ ...emptyState, status: index % 2 === 0 ? "idle" : "streaming" });
+    }
+
+    expect(find(composerHost, (node) => node.className === "coaching-shortcuts")).toBe(group);
+    expect(findAll(composerHost, (node) => node.className === "coaching-shortcuts")).toHaveLength(
+      1,
+    );
+    expect(findAll(group, (node) => node.className === "coaching-shortcut")).toEqual(buttons);
+    expect(buttons.map((button) => button.listeners.get("click")?.size)).toEqual([1, 1, 1, 1]);
+    expect(buttons.map((button) => [...(button.listeners.get("click") ?? [])][0])).toEqual(
+      listeners,
+    );
+  });
+
+  it("restores keyboard-owned focus to the same shortcut after its turn unlocks", () => {
+    const fakeDocument = globalThis.document as unknown as FakeDocument;
+    const composerHost = new FakeElement("div");
+    const mounted = mountChatView({
+      conversation: new FakeElement("main") as never,
+      thread: new FakeElement("div") as never,
+      composerHost: composerHost as never,
+    });
+    mounted.bind({
+      onSubmit: () => mounted.view.render({ ...emptyState, status: "streaming" }),
+      onRetry: vi.fn(),
+      onOpenNewConversation: vi.fn(),
+      onCancelNewConversation: vi.fn(),
+      onConfirmNewConversation: vi.fn(),
+    });
+    mounted.view.render(emptyState);
+    const shortcut = find(
+      composerHost,
+      (node) => node.className === "coaching-shortcut" && node.textContent.includes("/workout"),
+    );
+
+    shortcut.focus();
+    shortcut.dispatch("click", { detail: 0 });
+    expect(shortcut.disabled).toBe(true);
+    fakeDocument.activeElement = fakeDocument.body;
+
+    mounted.view.render(emptyState);
+
+    expect(fakeDocument.activeElement).toBe(shortcut);
+    expect(shortcut.focusCount).toBe(2);
+  });
+
+  it("does not restore shortcut focus after pointer activation", () => {
+    const fakeDocument = globalThis.document as unknown as FakeDocument;
+    const composerHost = new FakeElement("div");
+    const mounted = mountChatView({
+      conversation: new FakeElement("main") as never,
+      thread: new FakeElement("div") as never,
+      composerHost: composerHost as never,
+    });
+    mounted.bind({
+      onSubmit: () => mounted.view.render({ ...emptyState, status: "streaming" }),
+      onRetry: vi.fn(),
+      onOpenNewConversation: vi.fn(),
+      onCancelNewConversation: vi.fn(),
+      onConfirmNewConversation: vi.fn(),
+    });
+    mounted.view.render(emptyState);
+    const shortcut = find(composerHost, (node) => node.className === "coaching-shortcut");
+
+    shortcut.focus();
+    shortcut.dispatch("click", { detail: 1 });
+    fakeDocument.activeElement = fakeDocument.body;
+    mounted.view.render(emptyState);
+
+    expect(fakeDocument.activeElement).toBe(fakeDocument.body);
+    expect(shortcut.focusCount).toBe(1);
+  });
+
+  it("abandons keyboard focus restoration when focus deliberately moves elsewhere", () => {
+    const fakeDocument = globalThis.document as unknown as FakeDocument;
+    const composerHost = new FakeElement("div");
+    const mounted = mountChatView({
+      conversation: new FakeElement("main") as never,
+      thread: new FakeElement("div") as never,
+      composerHost: composerHost as never,
+    });
+    mounted.bind({
+      onSubmit: () => mounted.view.render({ ...emptyState, status: "streaming" }),
+      onRetry: vi.fn(),
+      onOpenNewConversation: vi.fn(),
+      onCancelNewConversation: vi.fn(),
+      onConfirmNewConversation: vi.fn(),
+    });
+    mounted.view.render(emptyState);
+    const shortcut = find(composerHost, (node) => node.className === "coaching-shortcut");
+    const otherControl = new FakeElement("button");
+
+    shortcut.focus();
+    shortcut.dispatch("click", { detail: 0 });
+    fakeDocument.activeElement = fakeDocument.body;
+    otherControl.focus();
+    mounted.view.render(emptyState);
+
+    expect(fakeDocument.activeElement).toBe(otherControl);
+    expect(shortcut.focusCount).toBe(1);
+
+    shortcut.focus();
+    shortcut.dispatch("click", { detail: 0 });
+    fakeDocument.activeElement = fakeDocument.body;
+    otherControl.focus();
+    fakeDocument.activeElement = fakeDocument.body;
+    mounted.view.render(emptyState);
+
+    expect(fakeDocument.activeElement).toBe(fakeDocument.body);
+    expect(shortcut.focusCount).toBe(2);
+  });
+
+  it("abandons keyboard focus restoration when reset begins", () => {
+    const fakeDocument = globalThis.document as unknown as FakeDocument;
+    const composerHost = new FakeElement("div");
+    const mounted = mountChatView({
+      conversation: new FakeElement("main") as never,
+      thread: new FakeElement("div") as never,
+      composerHost: composerHost as never,
+    });
+    const present = reduceChatState(emptyState, { type: "session-probe", hasSession: true });
+    const confirming = reduceChatState(present, { type: "open-new-conversation" });
+    mounted.bind({
+      onSubmit: () => mounted.view.render({ ...present, status: "streaming" }),
+      onRetry: vi.fn(),
+      onOpenNewConversation: vi.fn(),
+      onCancelNewConversation: vi.fn(),
+      onConfirmNewConversation: vi.fn(),
+    });
+    mounted.view.render(present);
+    const shortcut = find(composerHost, (node) => node.className === "coaching-shortcut");
+
+    shortcut.focus();
+    shortcut.dispatch("click", { detail: 0 });
+    fakeDocument.activeElement = fakeDocument.body;
+    mounted.view.render(confirming);
+    mounted.view.render(present);
+
+    expect(fakeDocument.activeElement).not.toBe(shortcut);
+    expect(shortcut.focusCount).toBe(1);
+  });
+
+  it("does not restore shortcut focus after disposal", () => {
+    const fakeDocument = globalThis.document as unknown as FakeDocument;
+    const composerHost = new FakeElement("div");
+    const mounted = mountChatView({
+      conversation: new FakeElement("main") as never,
+      thread: new FakeElement("div") as never,
+      composerHost: composerHost as never,
+    });
+    mounted.bind({
+      onSubmit: () => mounted.view.render({ ...emptyState, status: "streaming" }),
+      onRetry: vi.fn(),
+      onOpenNewConversation: vi.fn(),
+      onCancelNewConversation: vi.fn(),
+      onConfirmNewConversation: vi.fn(),
+    });
+    mounted.view.render(emptyState);
+    const shortcut = find(composerHost, (node) => node.className === "coaching-shortcut");
+
+    shortcut.focus();
+    shortcut.dispatch("click", { detail: 0 });
+    fakeDocument.activeElement = fakeDocument.body;
+    mounted.dispose();
+    mounted.view.render(emptyState);
+
+    expect(fakeDocument.activeElement).toBe(fakeDocument.body);
+    expect(shortcut.focusCount).toBe(1);
+    expect(fakeDocument.listeners.get("focusin")?.size).toBe(0);
+  });
+
+  it("measures composer clearance, follows resize, and stops updates after disposal", () => {
+    Object.assign(globalThis, { ResizeObserver: FakeResizeObserver });
+    const conversation = new FakeElement("main");
+    const composerHost = new FakeElement("div");
+    composerHost.rectHeight = 148;
+
+    const mounted = mountChatView({
+      conversation: conversation as never,
+      thread: new FakeElement("div") as never,
+      composerHost: composerHost as never,
+    });
+    const observer = FakeResizeObserver.instances[0]!;
+
+    expect(FakeResizeObserver.instances).toHaveLength(1);
+    expect(observer.observed.has(composerHost)).toBe(true);
+    expect(conversation.style.getPropertyValue("--chat-composer-clearance")).toBe("148px");
+
+    composerHost.rectHeight = 226;
+    observer.notify();
+    expect(conversation.style.getPropertyValue("--chat-composer-clearance")).toBe("226px");
+
+    mounted.dispose();
+    expect(observer.disconnected).toBe(true);
+    expect(conversation.style.getPropertyValue("--chat-composer-clearance")).toBe("");
+    const mutationsAfterDisposal = conversation.style.mutationCount;
+
+    composerHost.rectHeight = 310;
+    observer.notify();
+    expect(conversation.style.mutationCount).toBe(mutationsAfterDisposal);
+    expect(conversation.style.getPropertyValue("--chat-composer-clearance")).toBe("");
+  });
+
+  it("admits one paid turn before rapid shortcut and Enter repetitions", async () => {
+    const composerHost = new FakeElement("div");
+    const mounted = mountChatView({
+      conversation: new FakeElement("main") as never,
+      thread: new FakeElement("div") as never,
+      composerHost: composerHost as never,
+    });
+    let releaseTurn: (() => void) | undefined;
+    const turnGate = new Promise<void>((resolve) => {
+      releaseTurn = resolve;
+    });
+    const call = vi.fn(
+      async (
+        method: string,
+        _request: unknown,
+        options: CoachClientCallOptions<"chat"> | undefined,
+      ) => {
+        if (method !== "chat") throw new TypeError();
+        await turnGate;
+        const event: TurnEvent = { type: "final-text", turnId: "turn-1", text: "Ready." };
+        options?.onNotificationEnvelope?.({
+          jsonrpc: "2.0",
+          method: "coach.turnEvent",
+          params: {
+            requestId: 1,
+            requestMethod: "chat",
+            turnId: event.turnId,
+            event,
+          },
+        });
+        options?.onEvent?.(event);
+        options?.onTerminalEnvelope?.({
+          jsonrpc: "2.0",
+          id: 1,
+          result: { text: event.text },
+        });
+        return { text: event.text };
+      },
+    );
+    const fakeClient = { handshake: {}, call, close: vi.fn(async () => {}) };
+    const controller = createChatController({
+      clients: {
+        getClient: vi.fn(async () => fakeClient as never),
+        reconnect: vi.fn(async () => fakeClient as never),
+        close: vi.fn(async () => {}),
+      },
+      view: mounted.view,
+      refreshTrainingContext: async () => {},
+      refreshSpend: async () => {},
+    });
+    mounted.bind({
+      onSubmit: (message) => void controller.submit(message),
+      onRetry: vi.fn(),
+      onOpenNewConversation: vi.fn(),
+      onCancelNewConversation: vi.fn(),
+      onConfirmNewConversation: vi.fn(),
+    });
+    const shortcuts = findAll(
+      find(composerHost, (node) => node.className === "coaching-shortcuts"),
+      (node) => node.className === "coaching-shortcut",
+    );
+    const plan = shortcuts[0]!;
+    const textarea = find(composerHost, (node) => node.tagName === "textarea");
+    const submit = find(
+      composerHost,
+      (node) => node.tagName === "button" && node.type === "submit",
+    );
+    textarea.value = "keep this draft";
+
+    plan.dispatch("click");
+    expect(shortcuts.every((button) => button.disabled)).toBe(true);
+    expect(submit.disabled).toBe(true);
+    plan.dispatch("click");
+    textarea.dispatch("keydown", {
+      key: "Enter",
+      shiftKey: false,
+      preventDefault: vi.fn(),
+    });
+
+    await vi.waitFor(() => expect(call).toHaveBeenCalledOnce());
+    expect(call.mock.calls[0]?.[1]).toEqual({ chatId: "desktop", message: "/plan" });
+    expect(textarea.value).toBe("keep this draft");
+    releaseTurn?.();
+    await vi.waitFor(() => expect(plan.disabled).toBe(false));
+    expect(call).toHaveBeenCalledOnce();
   });
 
   it("shows the explicit retry control only for an interrupted turn", () => {
@@ -1358,7 +1853,7 @@ describe("chat view", () => {
     );
   });
 
-  it("removes new listeners and elements while safely closing an open dialog", () => {
+  it("removes shortcut listeners and detached controls stay inert after dispose", () => {
     const actionHost = new FakeElement("div");
     const thread = new FakeElement("div");
     const composerHost = new FakeElement("div");
@@ -1369,8 +1864,9 @@ describe("chat view", () => {
       actionHost: actionHost as never,
     });
     const onOpenNewConversation = vi.fn();
+    const onSubmit = vi.fn();
     mounted.bind({
-      onSubmit: vi.fn(),
+      onSubmit,
       onRetry: vi.fn(),
       onOpenNewConversation,
       onCancelNewConversation: vi.fn(),
@@ -1380,6 +1876,9 @@ describe("chat view", () => {
     const dialog = find(actionHost, (node) => node.tagName === "dialog");
     const transcript = find(thread, (node) => node.className === "chat-transcript");
     const form = find(composerHost, (node) => node.className === "composer");
+    const shortcutGroup = find(composerHost, (node) => node.className === "coaching-shortcuts");
+    const shortcut = find(shortcutGroup, (node) => node.className === "coaching-shortcut");
+    expect(shortcut.listeners.get("click")?.size).toBe(1);
     let state = reduceChatState(emptyState, { type: "session-probe", hasSession: true });
     state = reduceChatState(state, { type: "open-new-conversation" });
     mounted.view.render(state);
@@ -1387,7 +1886,12 @@ describe("chat view", () => {
 
     mounted.dispose();
     button.dispatch("click");
+    shortcut.dispatch("click");
     expect(onOpenNewConversation).not.toHaveBeenCalled();
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(shortcut.listeners.get("click")?.size).toBe(0);
+    expect(shortcutGroup.removed).toBe(true);
+    expect(shortcutGroup.parentNode).toBeNull();
     expect(dialog.open).toBe(false);
     expect(dialog.removed).toBe(true);
     expect(button.removed).toBe(true);

--- a/apps/desktop/tests/chat-panels.integration.test.ts
+++ b/apps/desktop/tests/chat-panels.integration.test.ts
@@ -252,6 +252,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       readonly drawerStatus: string;
       readonly anchorValue: string;
       readonly wellnessValue: string;
+      readonly documentOverflow: boolean;
     }>(`
       const bridgeKeys = Object.keys(window.enduragentAuth).sort();
       const thread = document.querySelectorAll(".thread").length === 1;
@@ -380,6 +381,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
         drawerStatus: document.querySelector(".drawer-status")?.textContent ?? "missing",
         anchorValue: panels[0]?.querySelector(".context-panel__value")?.textContent ?? "",
         wellnessValue: panels[4]?.querySelector(".wellness-row__value")?.textContent ?? "",
+        documentOverflow: document.documentElement.scrollWidth > document.documentElement.clientWidth,
       };
     `);
     expect(initial).toEqual({
@@ -418,6 +420,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       drawerStatus: "",
       anchorValue: "300 W",
       wellnessValue: "65 ms",
+      documentOverflow: false,
     });
     expect(calls.filter((call) => call.method === "hasSession")).toEqual([
       {
@@ -426,26 +429,140 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
         params: { chatId: "desktop" },
       },
     ]);
+    const quickActions = await fixture.evaluate<{
+      readonly groupLabel: string | null;
+      readonly labels: readonly string[];
+      readonly commands: readonly string[];
+      readonly terminalResponses: number;
+      readonly keyboardActivationDetail: number | null;
+      readonly keyboardShortcutResidentAfterTerminal: boolean;
+      readonly keyboardShortcutFocusedAfterTerminal: boolean;
+      readonly draft: string;
+      readonly documentOverflow: boolean;
+      readonly composerHeight: number;
+      readonly composerClearanceTracksHeight: boolean;
+      readonly finalTranscriptClearsComposer: boolean;
+    }>(`
+      const group = document.querySelector(".coaching-shortcuts");
+      const buttons = [...group.querySelectorAll(".coaching-shortcut")];
+      const keyboardShortcut = buttons.at(-1);
+      const textarea = document.querySelector("#message");
+      textarea.value = "  keep draft\\n";
+      let terminalResponses = 0;
+      let keyboardActivationDetail = null;
+      let keyboardShortcutResidentAfterTerminal = false;
+      let keyboardShortcutFocusedAfterTerminal = false;
+      keyboardShortcut.addEventListener("click", (event) => {
+        keyboardActivationDetail = event.detail;
+      }, { once: true });
+      for (const button of buttons) {
+        const readyDeadline = Date.now() + 5000;
+        while (button.disabled && Date.now() < readyDeadline) {
+          await new Promise((resolve) => setTimeout(resolve, 5));
+        }
+        const coachCount = document.querySelectorAll(".chat-message--coach").length;
+        if (button === keyboardShortcut) button.focus();
+        button.click();
+        const terminalDeadline = Date.now() + 5000;
+        while (Date.now() < terminalDeadline) {
+          await new Promise((resolve) => setTimeout(resolve, 5));
+          const coaches = [...document.querySelectorAll(".chat-message--coach")];
+          const latest = coaches.at(-1);
+          if (coaches.length === coachCount + 1 && latest && !latest.hasAttribute("aria-busy")) {
+            terminalResponses += 1;
+            if (button === keyboardShortcut) {
+              keyboardShortcutResidentAfterTerminal =
+                [...group.querySelectorAll(".coaching-shortcut")].at(-1) === keyboardShortcut;
+              keyboardShortcutFocusedAfterTerminal = document.activeElement === keyboardShortcut;
+            }
+            break;
+          }
+        }
+      }
+      await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+      const conversation = document.querySelector(".conversation");
+      const composer = document.querySelector(".composer-wrap");
+      conversation.scrollTop = conversation.scrollHeight;
+      const composerRect = composer.getBoundingClientRect();
+      const finalTranscriptItem = [...document.querySelectorAll(".chat-message, .chat-notice, .chat-retry")]
+        .filter((node) => !node.hidden)
+        .at(-1);
+      const reservedBottom = Number.parseFloat(getComputedStyle(conversation).paddingBottom);
+      return {
+        groupLabel: group.getAttribute("aria-label"),
+        labels: buttons.map((button) => button.querySelector(".coaching-shortcut__label")?.textContent ?? ""),
+        commands: buttons.map((button) => button.querySelector(".coaching-shortcut__command")?.textContent ?? ""),
+        terminalResponses,
+        keyboardActivationDetail,
+        keyboardShortcutResidentAfterTerminal,
+        keyboardShortcutFocusedAfterTerminal,
+        draft: textarea.value,
+        documentOverflow: document.documentElement.scrollWidth > document.documentElement.clientWidth,
+        composerHeight: composerRect.height,
+        composerClearanceTracksHeight: Math.abs(reservedBottom - composerRect.height) < 1,
+        finalTranscriptClearsComposer:
+          finalTranscriptItem.getBoundingClientRect().bottom <= composerRect.top + 1,
+      };
+    `);
+    expect(quickActions).toEqual({
+      groupLabel: "Coaching shortcuts",
+      labels: ["Build a plan", "Today’s workout", "Training status", "Review last session"],
+      commands: ["/plan", "/workout", "/status", "/review"],
+      terminalResponses: 4,
+      keyboardActivationDetail: 0,
+      keyboardShortcutResidentAfterTerminal: true,
+      keyboardShortcutFocusedAfterTerminal: true,
+      draft: "  keep draft\n",
+      documentOverflow: false,
+      composerHeight: expect.any(Number),
+      composerClearanceTracksHeight: true,
+      finalTranscriptClearsComposer: true,
+    });
+    expect(quickActions.composerHeight).toBeGreaterThan(0);
     await fixture.setViewport(720, 800);
-    expect(
-      await fixture.evaluate<{
-        readonly documentOverflow: boolean;
-        readonly tableScrollsLocally: boolean;
-        readonly codeScrollsLocally: boolean;
-      }>(`
+    const compact = await fixture.evaluate<{
+      readonly documentOverflow: boolean;
+      readonly tableScrollsLocally: boolean;
+      readonly codeScrollsLocally: boolean;
+      readonly shortcutsWrapped: boolean;
+      readonly composerHeight: number;
+      readonly composerClearanceTracksHeight: boolean;
+      readonly finalTranscriptClearsComposer: boolean;
+    }>(`
+        await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
         const tableScroll = document.querySelector(".chat-markdown__table-scroll");
         const codeBlock = document.querySelector(".chat-message--coach pre");
+        const conversation = document.querySelector(".conversation");
+        const composer = document.querySelector(".composer-wrap");
+        const shortcutGroup = document.querySelector(".coaching-shortcuts");
+        const firstShortcut = shortcutGroup.querySelector(".coaching-shortcut");
+        conversation.scrollTop = conversation.scrollHeight;
+        const composerRect = composer.getBoundingClientRect();
+        const finalTranscriptItem = [...document.querySelectorAll(".chat-message, .chat-notice, .chat-retry")]
+          .filter((node) => !node.hidden)
+          .at(-1);
+        const reservedBottom = Number.parseFloat(getComputedStyle(conversation).paddingBottom);
         return {
           documentOverflow: document.documentElement.scrollWidth > document.documentElement.clientWidth,
           tableScrollsLocally: tableScroll.scrollWidth > tableScroll.clientWidth && getComputedStyle(tableScroll).overflowX === "auto",
           codeScrollsLocally: codeBlock.scrollWidth > codeBlock.clientWidth && getComputedStyle(codeBlock).overflowX === "auto",
+          shortcutsWrapped: shortcutGroup.getBoundingClientRect().height > firstShortcut.getBoundingClientRect().height,
+          composerHeight: composerRect.height,
+          composerClearanceTracksHeight: Math.abs(reservedBottom - composerRect.height) < 1,
+          finalTranscriptClearsComposer:
+            finalTranscriptItem.getBoundingClientRect().bottom <= composerRect.top + 1,
         };
-      `),
-    ).toEqual({
+      `);
+    expect(compact).toEqual({
       documentOverflow: false,
       tableScrollsLocally: true,
       codeScrollsLocally: true,
+      shortcutsWrapped: true,
+      composerHeight: expect.any(Number),
+      composerClearanceTracksHeight: true,
+      finalTranscriptClearsComposer: true,
     });
+    expect(compact.composerHeight).toBeGreaterThan(quickActions.composerHeight);
     const reset = await fixture.evaluate<{
       readonly enabledBefore: boolean;
       readonly dialogOpen: boolean;
@@ -553,6 +670,26 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
         jsonrpc: "2.0",
         method: "chat",
         params: { chatId: "desktop", message: "What should I ride?" },
+      },
+      {
+        jsonrpc: "2.0",
+        method: "chat",
+        params: { chatId: "desktop", message: "/plan" },
+      },
+      {
+        jsonrpc: "2.0",
+        method: "chat",
+        params: { chatId: "desktop", message: "/workout" },
+      },
+      {
+        jsonrpc: "2.0",
+        method: "chat",
+        params: { chatId: "desktop", message: "/status" },
+      },
+      {
+        jsonrpc: "2.0",
+        method: "chat",
+        params: { chatId: "desktop", message: "/review" },
       },
     ]);
     expect(calls.filter((call) => call.method === "setUnitsPreference")).toEqual([


### PR DESCRIPTION
## Summary

- add persistent `/plan`, `/workout`, `/status`, and `/review` coaching actions through the existing chat path
- preserve the athlete's draft and share the existing streaming/reset work lock
- keep keyboard focus stable after activation and measure compact composer clearance so the latest response stays visible
- cover exact wire requests, resident controls, disposal, focus, wrapping, and packaged Desktop geometry

## Verification

- `pnpm check`
- `pnpm test` — 5,065 passed, 6 skipped
- focused packaged Electron integration — 2 passed
- three independent read-only reviews — PASS, zero blockers
