### PR TITLE
fix(desktop): preserve IME composition on Enter

### DIFF
--- a/.changeset/desktop-ime-composition.md
+++ b/.changeset/desktop-ime-composition.md
@@ -1,0 +1,5 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Desktop chat now waits for your input method to finish composing text before Enter sends the message.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,5 +109,9 @@ jobs:
           cache: pnpm
       - run: test "$(uname -m)" = "arm64"
       - run: pnpm install --frozen-lockfile
+      - name: Build Desktop
+        run: pnpm --filter @enduragent/desktop build
+      - name: Test Desktop IME composition
+        run: pnpm --filter @enduragent/desktop exec vitest run tests/chat-panels.integration.test.ts
       - run: pnpm --filter @enduragent/desktop test:packaged-self-test
       - run: pnpm --filter @enduragent/desktop run smoke:security -- --mode=packaged --output=/tmp/desktop-security-packaged

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
       - run: test "$(uname -m)" = "arm64"
       - run: pnpm install --frozen-lockfile
       - name: Build Desktop
-        run: pnpm --filter @enduragent/desktop build
+        run: pnpm --filter @enduragent/desktop... build
       - name: Test Desktop IME composition
         run: pnpm --filter @enduragent/desktop exec vitest run tests/chat-panels.integration.test.ts
       - run: pnpm --filter @enduragent/desktop test:packaged-self-test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,6 @@ jobs:
       - name: Build Desktop
         run: pnpm --filter @enduragent/desktop... build
       - name: Test Desktop IME composition
-        run: pnpm --filter @enduragent/desktop exec vitest run tests/chat-panels.integration.test.ts
+        run: pnpm --filter @enduragent/desktop exec vitest run tests/chat-panels.integration.test.ts --testNamePattern "preserves IME composition until committed Enter"
       - run: pnpm --filter @enduragent/desktop test:packaged-self-test
       - run: pnpm --filter @enduragent/desktop run smoke:security -- --mode=packaged --output=/tmp/desktop-security-packaged

--- a/apps/desktop-renderer/src/chat/view.ts
+++ b/apps/desktop-renderer/src/chat/view.ts
@@ -179,7 +179,7 @@ export function mountChatView(input: {
     handlers?.onSubmit(value);
   };
   const onKeydown = (event: KeyboardEvent): void => {
-    if (event.key === "Enter" && !event.shiftKey) {
+    if (event.key === "Enter" && !event.shiftKey && !event.isComposing) {
       event.preventDefault();
       form.requestSubmit();
     }

--- a/apps/desktop-renderer/tests/chat-view.test.ts
+++ b/apps/desktop-renderer/tests/chat-view.test.ts
@@ -1174,6 +1174,111 @@ describe("chat view", () => {
     expect(button.disabled).toBe(true);
   });
 
+  it("leaves an IME draft untouched until a later ordinary Enter submits the committed text", () => {
+    const fakeDocument = globalThis.document as unknown as FakeDocument;
+    const conversation = new FakeElement("main");
+    const thread = new FakeElement("div");
+    const composerHost = new FakeElement("div");
+    const mounted = mountChatView({
+      conversation: conversation as never,
+      thread: thread as never,
+      composerHost: composerHost as never,
+    });
+    const onSubmit = vi.fn();
+    mounted.bind({
+      onSubmit,
+      onRetry: vi.fn(),
+      onOpenNewConversation: vi.fn(),
+      onCancelNewConversation: vi.fn(),
+      onConfirmNewConversation: vi.fn(),
+    });
+    mounted.view.render({
+      ...emptyState,
+      messages: [
+        {
+          id: "message-1",
+          role: "coach",
+          text: "Previous guidance.",
+          delivery: "complete",
+        },
+      ],
+    });
+    const textarea = find(composerHost, (node) => node.tagName === "textarea");
+    const form = find(composerHost, (node) => node.tagName === "form");
+    const submit = find(
+      composerHost,
+      (node) => node.tagName === "button" && node.type === "submit",
+    );
+    const transcript = find(thread, (node) => node.className === "chat-transcript");
+    const resetStatus = find(composerHost, (node) => node.className === "new-conversation-status");
+    const requestSubmit = vi.spyOn(form, "requestSubmit");
+    const preventComposingDefault = vi.fn();
+    textarea.value = "回復走を";
+    textarea.focus();
+    const stateBefore = {
+      chatStatus: conversation.dataset.chatStatus,
+      textareaDisabled: textarea.disabled,
+      submitDisabled: submit.disabled,
+    };
+    const transcriptBefore = {
+      text: transcript.textContent,
+      mutations: transcript.textContentMutationCount,
+      ariaLive: transcript.getAttribute("aria-live"),
+    };
+    const liveRegionBefore = {
+      text: resetStatus.textContent,
+      mutations: resetStatus.textContentMutationCount,
+      ariaLive: resetStatus.getAttribute("aria-live"),
+    };
+    const mutationEventsBefore = [...mutationEvents];
+
+    textarea.dispatch("keydown", {
+      key: "Enter",
+      shiftKey: false,
+      isComposing: true,
+      preventDefault: preventComposingDefault,
+    });
+
+    expect(preventComposingDefault).not.toHaveBeenCalled();
+    expect(requestSubmit).not.toHaveBeenCalled();
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(textarea.value).toBe("回復走を");
+    expect(fakeDocument.activeElement).toBe(textarea);
+    expect(textarea.focusCount).toBe(1);
+    expect({
+      chatStatus: conversation.dataset.chatStatus,
+      textareaDisabled: textarea.disabled,
+      submitDisabled: submit.disabled,
+    }).toEqual(stateBefore);
+    expect({
+      text: transcript.textContent,
+      mutations: transcript.textContentMutationCount,
+      ariaLive: transcript.getAttribute("aria-live"),
+    }).toEqual(transcriptBefore);
+    expect({
+      text: resetStatus.textContent,
+      mutations: resetStatus.textContentMutationCount,
+      ariaLive: resetStatus.getAttribute("aria-live"),
+    }).toEqual(liveRegionBefore);
+    expect(mutationEvents).toEqual(mutationEventsBefore);
+
+    const committedValue = "回復走を30分します。";
+    const preventSubmitDefault = vi.fn();
+    textarea.value = committedValue;
+    textarea.dispatch("keydown", {
+      key: "Enter",
+      shiftKey: false,
+      isComposing: false,
+      preventDefault: preventSubmitDefault,
+    });
+
+    expect(preventSubmitDefault).toHaveBeenCalledOnce();
+    expect(requestSubmit).toHaveBeenCalledOnce();
+    expect(onSubmit).toHaveBeenCalledOnce();
+    expect(onSubmit).toHaveBeenCalledWith(committedValue);
+    expect(textarea.value).toBe("");
+  });
+
   it("mounts four unique coaching shortcuts in exact order and preserves the draft", () => {
     const composerHost = new FakeElement("div");
     const mounted = mountChatView({

--- a/apps/desktop/tests/chat-panels.integration.test.ts
+++ b/apps/desktop/tests/chat-panels.integration.test.ts
@@ -223,22 +223,52 @@ afterEach(async () => {
 });
 
 describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat panels", () => {
-  it("streams chat, persists units, preserves focus, and fits desktop geometry", async () => {
+  it("preserves IME composition until committed Enter", async () => {
     const { fixture, calls } = await launch({ width: 1440, height: 900, reducedMotion: false });
+    const composingDraft = "回復走を";
     const composingEnter = await fixture.evaluate<{
       readonly isComposing: boolean;
       readonly dispatchResult: boolean;
       readonly defaultPrevented: boolean;
       readonly text: string;
       readonly focused: boolean;
-      readonly athleteRows: number;
+      readonly chatStateUnchanged: boolean;
       readonly transcriptUnchanged: boolean;
+      readonly liveRegionUnchanged: boolean;
+      readonly athleteRows: number;
+      readonly quickActionClicks: number;
     }>(`
       const textarea = document.querySelector("#message");
+      const submit = document.querySelector('.composer button[type="submit"]');
+      const conversation = document.querySelector(".conversation");
       const transcript = document.querySelector(".chat-transcript");
-      const transcriptText = transcript.textContent;
-      textarea.value = "回復走を";
+      const liveRegion = document.querySelector(".new-conversation-status");
+      const quickActions = [...document.querySelectorAll(".coaching-shortcut")];
+      let quickActionClicks = 0;
+      const recordQuickActionClick = () => {
+        quickActionClicks += 1;
+      };
+      for (const quickAction of quickActions) {
+        quickAction.addEventListener("click", recordQuickActionClick);
+      }
+      textarea.value = ${JSON.stringify(composingDraft)};
       textarea.focus();
+      const chatStateBefore = JSON.stringify({
+        status: conversation.dataset.chatStatus,
+        textareaDisabled: textarea.disabled,
+        submitDisabled: submit.disabled,
+      });
+      const transcriptBefore = JSON.stringify({
+        html: transcript.innerHTML,
+        ariaLive: transcript.getAttribute("aria-live"),
+        ariaRelevant: transcript.getAttribute("aria-relevant"),
+        ariaAtomic: transcript.getAttribute("aria-atomic"),
+      });
+      const liveRegionBefore = JSON.stringify({
+        html: liveRegion.innerHTML,
+        role: liveRegion.getAttribute("role"),
+        ariaLive: liveRegion.getAttribute("aria-live"),
+      });
       const event = new KeyboardEvent("keydown", {
         key: "Enter",
         isComposing: true,
@@ -247,35 +277,116 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       });
       const dispatchResult = textarea.dispatchEvent(event);
       await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+      for (const quickAction of quickActions) {
+        quickAction.removeEventListener("click", recordQuickActionClick);
+      }
       return {
         isComposing: event.isComposing,
         dispatchResult,
         defaultPrevented: event.defaultPrevented,
         text: textarea.value,
         focused: document.activeElement === textarea,
+        chatStateUnchanged:
+          JSON.stringify({
+            status: conversation.dataset.chatStatus,
+            textareaDisabled: textarea.disabled,
+            submitDisabled: submit.disabled,
+          }) === chatStateBefore,
+        transcriptUnchanged:
+          JSON.stringify({
+            html: transcript.innerHTML,
+            ariaLive: transcript.getAttribute("aria-live"),
+            ariaRelevant: transcript.getAttribute("aria-relevant"),
+            ariaAtomic: transcript.getAttribute("aria-atomic"),
+          }) === transcriptBefore,
+        liveRegionUnchanged:
+          JSON.stringify({
+            html: liveRegion.innerHTML,
+            role: liveRegion.getAttribute("role"),
+            ariaLive: liveRegion.getAttribute("aria-live"),
+          }) === liveRegionBefore,
         athleteRows: document.querySelectorAll(".chat-message--athlete").length,
-        transcriptUnchanged: transcript.textContent === transcriptText,
+        quickActionClicks,
       };
     `);
     expect(composingEnter).toEqual({
       isComposing: true,
       dispatchResult: true,
       defaultPrevented: false,
-      text: "回復走を",
+      text: composingDraft,
       focused: true,
-      athleteRows: 0,
+      chatStateUnchanged: true,
       transcriptUnchanged: true,
+      liveRegionUnchanged: true,
+      athleteRows: 0,
+      quickActionClicks: 0,
     });
     expect(calls.filter((call) => call.method === "chat")).toHaveLength(0);
 
     const committedMessage = "回復走を30分します。";
+    const committedEnter = await fixture.evaluate<{
+      readonly isComposing: boolean;
+      readonly dispatchResult: boolean;
+      readonly defaultPrevented: boolean;
+      readonly athleteMessages: readonly string[];
+      readonly quickActionClicks: number;
+    }>(`
+      const textarea = document.querySelector("#message");
+      const quickActions = [...document.querySelectorAll(".coaching-shortcut")];
+      let quickActionClicks = 0;
+      const recordQuickActionClick = () => {
+        quickActionClicks += 1;
+      };
+      for (const quickAction of quickActions) {
+        quickAction.addEventListener("click", recordQuickActionClick);
+      }
+      textarea.value = ${JSON.stringify(committedMessage)};
+      const conversation = document.querySelector(".conversation");
+      const event = new KeyboardEvent("keydown", {
+        key: "Enter",
+        bubbles: true,
+        cancelable: true,
+      });
+      const dispatchResult = textarea.dispatchEvent(event);
+      const deadline = Date.now() + 5000;
+      while (conversation.dataset.chatStatus === "streaming" && Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+      }
+      for (const quickAction of quickActions) {
+        quickAction.removeEventListener("click", recordQuickActionClick);
+      }
+      return {
+        isComposing: event.isComposing,
+        dispatchResult,
+        defaultPrevented: event.defaultPrevented,
+        athleteMessages: [...document.querySelectorAll(".chat-message--athlete")].map(
+          (row) => row.querySelector(".chat-message__text")?.textContent ?? "",
+        ),
+        quickActionClicks,
+      };
+    `);
+    expect(committedEnter).toEqual({
+      isComposing: false,
+      dispatchResult: false,
+      defaultPrevented: true,
+      athleteMessages: [committedMessage],
+      quickActionClicks: 0,
+    });
+    expect(calls.filter((call) => call.method === "chat")).toEqual([
+      {
+        jsonrpc: "2.0",
+        method: "chat",
+        params: { chatId: "desktop", message: committedMessage },
+      },
+    ]);
+  }, 30_000);
+
+  it("streams chat, persists units, preserves focus, and fits desktop geometry", async () => {
+    const { fixture, calls } = await launch({ width: 1440, height: 900, reducedMotion: false });
     const initial = await fixture.evaluate<{
       readonly location: string;
       readonly bridgeKeys: readonly string[];
       readonly thread: boolean;
-      readonly submitIsComposing: boolean;
-      readonly submitDispatchResult: boolean;
-      readonly submitDefaultPrevented: boolean;
       readonly partial: string;
       readonly final: string;
       readonly athleteStable: boolean;
@@ -355,13 +466,8 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
         characterDataOldValue: true,
         subtree: true,
       });
-      textarea.value = ${JSON.stringify(committedMessage)};
-      const submitEvent = new KeyboardEvent("keydown", {
-        key: "Enter",
-        bubbles: true,
-        cancelable: true,
-      });
-      const submitDispatchResult = textarea.dispatchEvent(submitEvent);
+      textarea.value = "What should I ride?";
+      textarea.closest("form").requestSubmit();
       athleteRow ??= document.querySelector(".chat-message--athlete");
       const finalDeadline = Date.now() + 5000;
       let final = "";
@@ -410,9 +516,6 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
         location: location.href,
         bridgeKeys,
         thread,
-        submitIsComposing: submitEvent.isComposing,
-        submitDispatchResult,
-        submitDefaultPrevented: submitEvent.defaultPrevented,
         partial,
         final,
         athleteStable: athleteStable && athleteRow === document.querySelector(".chat-message--athlete"),
@@ -452,9 +555,6 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
         "writeCredential",
       ],
       thread: true,
-      submitIsComposing: false,
-      submitDispatchResult: false,
-      submitDefaultPrevented: true,
       partial: "## Today’s ride\n\nHold   **ste",
       final: expect.stringContaining("<script>globalThis.hostile = true</script>"),
       athleteStable: true,
@@ -480,13 +580,6 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       wellnessValue: "65 ms",
       documentOverflow: false,
     });
-    expect(calls.filter((call) => call.method === "chat")).toEqual([
-      {
-        jsonrpc: "2.0",
-        method: "chat",
-        params: { chatId: "desktop", message: committedMessage },
-      },
-    ]);
     expect(calls.filter((call) => call.method === "hasSession")).toEqual([
       {
         jsonrpc: "2.0",
@@ -734,7 +827,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       {
         jsonrpc: "2.0",
         method: "chat",
-        params: { chatId: "desktop", message: committedMessage },
+        params: { chatId: "desktop", message: "What should I ride?" },
       },
       {
         jsonrpc: "2.0",

--- a/apps/desktop/tests/chat-panels.integration.test.ts
+++ b/apps/desktop/tests/chat-panels.integration.test.ts
@@ -225,10 +225,57 @@ afterEach(async () => {
 describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat panels", () => {
   it("streams chat, persists units, preserves focus, and fits desktop geometry", async () => {
     const { fixture, calls } = await launch({ width: 1440, height: 900, reducedMotion: false });
+    const composingEnter = await fixture.evaluate<{
+      readonly isComposing: boolean;
+      readonly dispatchResult: boolean;
+      readonly defaultPrevented: boolean;
+      readonly text: string;
+      readonly focused: boolean;
+      readonly athleteRows: number;
+      readonly transcriptUnchanged: boolean;
+    }>(`
+      const textarea = document.querySelector("#message");
+      const transcript = document.querySelector(".chat-transcript");
+      const transcriptText = transcript.textContent;
+      textarea.value = "回復走を";
+      textarea.focus();
+      const event = new KeyboardEvent("keydown", {
+        key: "Enter",
+        isComposing: true,
+        bubbles: true,
+        cancelable: true,
+      });
+      const dispatchResult = textarea.dispatchEvent(event);
+      await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+      return {
+        isComposing: event.isComposing,
+        dispatchResult,
+        defaultPrevented: event.defaultPrevented,
+        text: textarea.value,
+        focused: document.activeElement === textarea,
+        athleteRows: document.querySelectorAll(".chat-message--athlete").length,
+        transcriptUnchanged: transcript.textContent === transcriptText,
+      };
+    `);
+    expect(composingEnter).toEqual({
+      isComposing: true,
+      dispatchResult: true,
+      defaultPrevented: false,
+      text: "回復走を",
+      focused: true,
+      athleteRows: 0,
+      transcriptUnchanged: true,
+    });
+    expect(calls.filter((call) => call.method === "chat")).toHaveLength(0);
+
+    const committedMessage = "回復走を30分します。";
     const initial = await fixture.evaluate<{
       readonly location: string;
       readonly bridgeKeys: readonly string[];
       readonly thread: boolean;
+      readonly submitIsComposing: boolean;
+      readonly submitDispatchResult: boolean;
+      readonly submitDefaultPrevented: boolean;
       readonly partial: string;
       readonly final: string;
       readonly athleteStable: boolean;
@@ -308,8 +355,13 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
         characterDataOldValue: true,
         subtree: true,
       });
-      textarea.value = "What should I ride?";
-      textarea.closest("form").requestSubmit();
+      textarea.value = ${JSON.stringify(committedMessage)};
+      const submitEvent = new KeyboardEvent("keydown", {
+        key: "Enter",
+        bubbles: true,
+        cancelable: true,
+      });
+      const submitDispatchResult = textarea.dispatchEvent(submitEvent);
       athleteRow ??= document.querySelector(".chat-message--athlete");
       const finalDeadline = Date.now() + 5000;
       let final = "";
@@ -358,6 +410,9 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
         location: location.href,
         bridgeKeys,
         thread,
+        submitIsComposing: submitEvent.isComposing,
+        submitDispatchResult,
+        submitDefaultPrevented: submitEvent.defaultPrevented,
         partial,
         final,
         athleteStable: athleteStable && athleteRow === document.querySelector(".chat-message--athlete"),
@@ -397,6 +452,9 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
         "writeCredential",
       ],
       thread: true,
+      submitIsComposing: false,
+      submitDispatchResult: false,
+      submitDefaultPrevented: true,
       partial: "## Today’s ride\n\nHold   **ste",
       final: expect.stringContaining("<script>globalThis.hostile = true</script>"),
       athleteStable: true,
@@ -422,6 +480,13 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       wellnessValue: "65 ms",
       documentOverflow: false,
     });
+    expect(calls.filter((call) => call.method === "chat")).toEqual([
+      {
+        jsonrpc: "2.0",
+        method: "chat",
+        params: { chatId: "desktop", message: committedMessage },
+      },
+    ]);
     expect(calls.filter((call) => call.method === "hasSession")).toEqual([
       {
         jsonrpc: "2.0",
@@ -669,7 +734,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       {
         jsonrpc: "2.0",
         method: "chat",
-        params: { chatId: "desktop", message: "What should I ride?" },
+        params: { chatId: "desktop", message: committedMessage },
       },
       {
         jsonrpc: "2.0",


### PR DESCRIPTION
## Summary

- keep composing Enter events native so IME candidates are not submitted early
- submit the exact committed Unicode text once on the next ordinary Enter
- run the genuine Electron regression in the macOS CI job after a fresh Desktop build

## Verification

- `pnpm check`
- `pnpm test` — 383 files passed, 3 skipped; 5,074 tests passed, 6 skipped
- fresh Desktop build plus `chat-panels.integration.test.ts` — 2 tests passed
- three independent read-only review lenses passed
