### PR TITLE
feat(desktop): add on-demand training sync

### DIFF
--- a/.changeset/desktop-manual-sync.md
+++ b/.changeset/desktop-manual-sync.md
@@ -1,0 +1,5 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Added a Sync now action for running a training-data check from the Desktop training-context drawer.

--- a/apps/desktop-renderer/src/first-sync.ts
+++ b/apps/desktop-renderer/src/first-sync.ts
@@ -1,9 +1,5 @@
-import { CoachClientDisconnectedError, CoachClientProtocolError } from "@enduragent/coach-client";
-import type {
-  CoachOperationProgressNotificationEnvelope,
-  SyncRpcResult,
-} from "@enduragent/coach-contract";
 import type { OnboardingCompletion } from "./onboarding/machine.js";
+import type { TrainingSyncCoordinator, TrainingSyncState } from "./training-sync.js";
 
 export type FirstSyncState =
   | { readonly status: "idle" }
@@ -15,12 +11,8 @@ export type FirstSyncState =
       readonly retryable: boolean;
     };
 
-export interface FirstSyncCallOptions {
-  readonly onNotificationEnvelope: (envelope: CoachOperationProgressNotificationEnvelope) => void;
-}
-
 export interface FirstSyncPorts {
-  callSync(options: FirstSyncCallOptions): Promise<SyncRpcResult>;
+  readonly coordinator: TrainingSyncCoordinator;
   focusComposer(): void;
   render(state: FirstSyncState): void;
 }
@@ -43,105 +35,70 @@ function validCompletion(value: unknown): value is OnboardingCompletion {
   );
 }
 
+function toFirstSyncState(state: TrainingSyncState): FirstSyncState {
+  if (state.status === "idle") return { status: "idle" };
+  if (state.status === "queued" || state.status === "running") return { status: "syncing" };
+  if (state.status === "succeeded") {
+    return state.kind === "published"
+      ? { status: "ready" }
+      : { status: "failed", kind: "operation", retryable: true };
+  }
+  return {
+    status: "failed",
+    kind:
+      state.kind === "protocol"
+        ? "protocol"
+        : state.kind === "indeterminate"
+          ? "disconnected"
+          : "operation",
+    retryable: state.retryable,
+  };
+}
+
+function sameState(left: FirstSyncState, right: FirstSyncState): boolean {
+  return (
+    left.status === right.status &&
+    (left.status !== "failed" ||
+      (right.status === "failed" && left.kind === right.kind && left.retryable === right.retryable))
+  );
+}
+
 export function createFirstSyncController(ports: FirstSyncPorts): FirstSyncController {
   let state: FirstSyncState = { status: "idle" };
-  let epoch = 0;
   let inFlight: Promise<void> | undefined;
   let disposed = false;
+  let activated = false;
+  let completed = false;
   let composerFocused = false;
+  let composerFocusOperation: number | undefined;
 
-  const render = (next: FirstSyncState): void => {
-    state = next;
-    ports.render(state);
+  const apply = (syncState: TrainingSyncState): void => {
+    if (disposed || !activated || completed) return;
+    const next = toFirstSyncState(syncState);
+    if (!sameState(state, next)) {
+      state = next;
+      ports.render(state);
+    }
+    if (
+      next.status === "ready" &&
+      syncState.status === "succeeded" &&
+      syncState.operation === composerFocusOperation &&
+      !composerFocused
+    ) {
+      composerFocused = true;
+      ports.focusComposer();
+    }
+    if (next.status === "ready") completed = true;
   };
+  const unsubscribe = ports.coordinator.subscribe(apply);
 
   const begin = (): Promise<void> => {
-    const selectedEpoch = ++epoch;
-    render({ status: "syncing" });
-    let progress = 0;
-    let requestId: string | number | undefined;
-    let protocolFault = false;
-    let settled = false;
-
-    const failProtocol = (): void => {
-      if (disposed || selectedEpoch !== epoch) return;
-      protocolFault = true;
-      if (settled) render({ status: "failed", kind: "protocol", retryable: false });
-    };
-
-    const task = (async () => {
-      let result: SyncRpcResult | undefined;
-      let failure: unknown;
-      try {
-        result = await ports.callSync({
-          onNotificationEnvelope(envelope) {
-            if (disposed || selectedEpoch !== epoch) return;
-            if (settled) {
-              failProtocol();
-              return;
-            }
-            if (
-              envelope.jsonrpc !== "2.0" ||
-              envelope.method !== "coach.operationProgress" ||
-              envelope.params.requestMethod !== "sync"
-            ) {
-              failProtocol();
-              return;
-            }
-            const event = envelope.params.event;
-            if (progress === 0) {
-              if (event.phase !== "started" || event.completed !== 0 || event.total !== 1) {
-                failProtocol();
-                return;
-              }
-              requestId = envelope.params.requestId;
-              progress = 1;
-              return;
-            }
-            if (
-              progress !== 1 ||
-              envelope.params.requestId !== requestId ||
-              event.phase !== "completed" ||
-              event.completed !== 1 ||
-              event.total !== 1
-            ) {
-              failProtocol();
-              return;
-            }
-            progress = 2;
-          },
-        });
-      } catch (error) {
-        failure = error;
-      }
-      if (disposed || selectedEpoch !== epoch) return;
-      settled = true;
-      if (protocolFault || failure instanceof CoachClientProtocolError) {
-        render({ status: "failed", kind: "protocol", retryable: false });
-        return;
-      }
-      if (failure !== undefined) {
-        render({
-          status: "failed",
-          kind: failure instanceof CoachClientDisconnectedError ? "disconnected" : "operation",
-          retryable: true,
-        });
-        return;
-      }
-      if (progress !== 2) {
-        render({ status: "failed", kind: "protocol", retryable: false });
-        return;
-      }
-      if (result?.published !== true || result.referenceSucceeded !== true) {
-        render({ status: "failed", kind: "operation", retryable: true });
-        return;
-      }
-      render({ status: "ready" });
-      if (!composerFocused) {
-        composerFocused = true;
-        ports.focusComposer();
-      }
-    })();
+    const previous = ports.coordinator.getState();
+    const joining = previous.status === "queued" || previous.status === "running";
+    const task = ports.coordinator.request();
+    const selected = ports.coordinator.getState();
+    if (!joining && selected.status !== "idle") composerFocusOperation = selected.operation;
+    apply(selected);
     inFlight = task;
     void task
       .finally(() => {
@@ -156,6 +113,8 @@ export function createFirstSyncController(ports: FirstSyncPorts): FirstSyncContr
       if (!validCompletion(completion)) return Promise.reject(new TypeError("Invalid completion."));
       if (disposed) return Promise.resolve();
       if (inFlight !== undefined) return inFlight;
+      activated = true;
+      completed = false;
       if (state.status === "idle" || state.status === "ready") return begin();
       return Promise.resolve();
     },
@@ -168,7 +127,8 @@ export function createFirstSyncController(ports: FirstSyncPorts): FirstSyncContr
     dispose() {
       if (disposed) return;
       disposed = true;
-      epoch += 1;
+      inFlight = undefined;
+      unsubscribe();
     },
   };
 }

--- a/apps/desktop-renderer/src/index.ts
+++ b/apps/desktop-renderer/src/index.ts
@@ -15,7 +15,9 @@ import { createFirstSyncController, type FirstSyncState } from "./first-sync.js"
 import { validateImportPaths, type OnboardingBridge } from "./onboarding/bridge.js";
 import { mountOnboarding } from "./onboarding/mount.js";
 import { createTrainingContextController } from "./training-context/controller.js";
+import { createManualSyncController } from "./training-context/manual-sync.js";
 import { mountTrainingContextView } from "./training-context/view.js";
+import { createTrainingSyncCoordinator } from "./training-sync.js";
 import { createSpendMeterController } from "./spend-meter/controller.js";
 import { createSpendMeterView } from "./spend-meter/view.js";
 
@@ -67,6 +69,14 @@ const trainingContextController = createTrainingContextController({
   clients,
   view: mountedTrainingContext.view,
 });
+const trainingSyncCoordinator = createTrainingSyncCoordinator({
+  clients,
+  refreshTrainingContext: () => trainingContextController.refresh(),
+});
+const manualSyncController = createManualSyncController({
+  coordinator: trainingSyncCoordinator,
+  view: mountedTrainingContext.syncView,
+});
 const mountedChat = mountChatView({
   conversation,
   thread,
@@ -93,6 +103,7 @@ mountedChat.bind({
 });
 mountedTrainingContext.bind({
   onUnitsPreferenceChange: (value) => void trainingContextController.setUnitsPreference(value),
+  onSyncRequest: (kind) => void manualSyncController.activate(kind),
 });
 
 let firstSyncElement: HTMLElement | undefined;
@@ -134,7 +145,6 @@ function renderFirstSync(state: FirstSyncState): void {
     title.textContent = "Training history is ready";
     detail.textContent = "Your coach is ready when you are.";
     body.append(eyebrow, title, detail);
-    void trainingContextController.refresh();
   } else if (state.kind === "protocol") {
     title.textContent = "Enduragent needs to reconnect safely";
     detail.textContent = "Quit and reopen Enduragent.";
@@ -157,26 +167,8 @@ function renderFirstSync(state: FirstSyncState): void {
   firstSyncElement = section;
 }
 
-let syncNeedsReconnect = false;
-let syncFailedClient: CoachClient | undefined;
 firstSyncController = createFirstSyncController({
-  async callSync(options) {
-    let client: CoachClient | undefined;
-    try {
-      client = syncNeedsReconnect
-        ? await clientAfterFailure(syncFailedClient)
-        : await clients.getClient();
-      syncNeedsReconnect = false;
-      syncFailedClient = undefined;
-      return await client.call("sync", {}, options);
-    } catch (error) {
-      if (error instanceof CoachClientDisconnectedError) {
-        syncNeedsReconnect = true;
-        syncFailedClient = client;
-      }
-      throw error;
-    }
-  },
+  coordinator: trainingSyncCoordinator,
   focusComposer() {
     message.focus();
   },
@@ -267,6 +259,8 @@ window.addEventListener(
   () => {
     onboarding.dispose();
     firstSyncController.dispose();
+    manualSyncController.dispose();
+    trainingSyncCoordinator.dispose();
     chatController.dispose();
     spendController.dispose();
     mountedChat.dispose();

--- a/apps/desktop-renderer/src/training-context/manual-sync.ts
+++ b/apps/desktop-renderer/src/training-context/manual-sync.ts
@@ -1,0 +1,144 @@
+import type { TrainingSyncCoordinator, TrainingSyncState } from "../training-sync.js";
+
+export const SYNC_QUEUED_COPY = "Sync queued.";
+export const SYNC_RUNNING_COPY = "Syncing training data…";
+export const SYNC_PUBLISHED_COPY = "Training-data check completed.";
+export const SYNC_NO_CHANGE_COPY = "Local training-data processing completed.";
+export const SYNC_PARTIAL_COPY =
+  "Training-data processing partially completed. Try again to finish.";
+export const SYNC_OPERATION_FAILURE_COPY =
+  "We couldn’t complete the training-data check. Your existing data is still available.";
+export const SYNC_INDETERMINATE_COPY =
+  "Connection interrupted. The sync may still be finishing. Enduragent won’t retry it automatically.";
+export const SYNC_PROTOCOL_COPY =
+  "Enduragent couldn’t verify the sync result. Quit and reopen Enduragent.";
+
+export interface ManualSyncViewState {
+  readonly label: "Sync now" | "Sync again" | "Try again" | "Sync unavailable";
+  readonly message: string;
+  readonly disabled: boolean;
+  readonly busy: boolean;
+  readonly tone: "idle" | "active" | "success" | "partial" | "failure";
+}
+
+export interface ManualSyncView {
+  render(state: ManualSyncViewState): void;
+  restoreKeyboardFocus(): void;
+}
+
+export interface ManualSyncController {
+  activate(kind: "keyboard" | "pointer"): Promise<void>;
+  dispose(): void;
+}
+
+export function toManualSyncViewState(state: TrainingSyncState): ManualSyncViewState {
+  switch (state.status) {
+    case "idle":
+      return { label: "Sync now", message: "", disabled: false, busy: false, tone: "idle" };
+    case "queued":
+      return {
+        label: "Sync now",
+        message: SYNC_QUEUED_COPY,
+        disabled: true,
+        busy: true,
+        tone: "active",
+      };
+    case "running":
+      return {
+        label: "Sync now",
+        message: SYNC_RUNNING_COPY,
+        disabled: true,
+        busy: true,
+        tone: "active",
+      };
+    case "succeeded":
+      return {
+        label: "Sync again",
+        message: state.kind === "published" ? SYNC_PUBLISHED_COPY : SYNC_NO_CHANGE_COPY,
+        disabled: false,
+        busy: false,
+        tone: "success",
+      };
+    case "failed":
+      if (state.kind === "protocol") {
+        return {
+          label: "Sync unavailable",
+          message: SYNC_PROTOCOL_COPY,
+          disabled: true,
+          busy: false,
+          tone: "failure",
+        };
+      }
+      return {
+        label: "Try again",
+        message:
+          state.kind === "partial"
+            ? SYNC_PARTIAL_COPY
+            : state.kind === "indeterminate"
+              ? SYNC_INDETERMINATE_COPY
+              : SYNC_OPERATION_FAILURE_COPY,
+        disabled: false,
+        busy: false,
+        tone: state.kind === "partial" ? "partial" : "failure",
+      };
+  }
+}
+
+export function createManualSyncController(input: {
+  readonly coordinator: TrainingSyncCoordinator;
+  readonly view: ManualSyncView;
+}): ManualSyncController {
+  let disposed = false;
+  let activation = 0;
+  let activationTask: Promise<void> | undefined;
+  const unsubscribe = input.coordinator.subscribe((state) => {
+    if (!disposed) input.view.render(toManualSyncViewState(state));
+  });
+
+  return {
+    activate(kind) {
+      if (disposed) return Promise.resolve();
+      if (activationTask !== undefined) return activationTask;
+      const state = input.coordinator.getState();
+      if (
+        state.status === "queued" ||
+        state.status === "running" ||
+        (state.status === "failed" && state.kind === "protocol")
+      ) {
+        return Promise.resolve();
+      }
+      const selectedActivation = ++activation;
+      const task = input.coordinator.request();
+      const selectedState = input.coordinator.getState();
+      const selectedOperation =
+        selectedState.status === "idle" ? undefined : selectedState.operation;
+      activationTask = task;
+      void task
+        .then(() => {
+          const currentState = input.coordinator.getState();
+          const currentOperation =
+            currentState.status === "idle" ? undefined : currentState.operation;
+          if (
+            !disposed &&
+            selectedActivation === activation &&
+            selectedOperation === currentOperation &&
+            kind === "keyboard"
+          ) {
+            input.view.restoreKeyboardFocus();
+          }
+        })
+        .finally(() => {
+          if (activationTask === task) activationTask = undefined;
+        })
+        .catch(() => {});
+      return task;
+    },
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      activation += 1;
+      activationTask = undefined;
+      unsubscribe();
+    },
+  };
+}

--- a/apps/desktop-renderer/src/training-context/styles.css
+++ b/apps/desktop-renderer/src/training-context/styles.css
@@ -33,6 +33,7 @@
 
 .drawer {
   --attention: #b47a2c;
+  --sync-status-caution: #80520f;
   z-index: 4;
   margin: 0;
   padding: 26px;
@@ -55,6 +56,10 @@
   gap: 18px;
   padding-bottom: 22px;
   border-bottom: 1px solid var(--line);
+}
+
+.drawer-heading > div {
+  min-width: 0;
 }
 
 .drawer-heading h2 {
@@ -82,6 +87,55 @@
   align-items: center;
   gap: 7px;
   margin-top: 10px;
+}
+
+.training-sync {
+  display: grid;
+  justify-items: start;
+  gap: 9px;
+  min-width: 0;
+  margin-top: 14px;
+}
+
+.training-sync__button {
+  min-height: 34px;
+  padding: 7px 12px;
+  border: 1px solid color-mix(in srgb, var(--moss) 45%, var(--line));
+  border-radius: 9px;
+  color: var(--moss-strong);
+  background: var(--surface-soft);
+  font: inherit;
+  font-size: 12px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.training-sync__button:hover:not(:disabled) {
+  border-color: var(--moss);
+}
+
+.training-sync__button:disabled {
+  cursor: default;
+  opacity: 0.65;
+}
+
+.training-sync__status {
+  max-width: 100%;
+  min-height: 1.45em;
+  margin: 0;
+  overflow-wrap: anywhere;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.training-sync[data-state="success"] .training-sync__status {
+  color: var(--moss-strong);
+}
+
+.training-sync[data-state="partial"] .training-sync__status,
+.training-sync[data-state="failure"] .training-sync__status {
+  color: var(--sync-status-caution);
 }
 
 .drawer-metadata__item,
@@ -280,7 +334,14 @@
 @media (max-width: 720px) {
   .drawer {
     width: calc(100vw - 28px);
+    overflow-x: hidden;
     padding: 22px;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  .drawer {
+    --sync-status-caution: #e4b66f;
   }
 }
 

--- a/apps/desktop-renderer/src/training-context/view.ts
+++ b/apps/desktop-renderer/src/training-context/view.ts
@@ -12,13 +12,18 @@ import {
   formatUtcTimestamp,
   formatWholeNumber,
 } from "./format.js";
+import type { ManualSyncView, ManualSyncViewState } from "./manual-sync.js";
 
 export const TRAINING_CONTEXT_DRAWER_ID = "training-context-drawer";
 export const MAX_VISIBLE_PLAN_ITEMS = 7;
 
 export interface MountedTrainingContextView {
   readonly view: TrainingContextView;
-  bind(input: { readonly onUnitsPreferenceChange: (value: UnitsPreference) => void }): void;
+  readonly syncView: ManualSyncView;
+  bind(input: {
+    readonly onUnitsPreferenceChange: (value: UnitsPreference) => void;
+    readonly onSyncRequest: (kind: "keyboard" | "pointer") => void;
+  }): void;
   dispose(): void;
 }
 
@@ -257,7 +262,19 @@ export function mountTrainingContextView(input: {
   heading.textContent = "Training context";
   const metadata = document.createElement("div");
   metadata.className = "drawer-metadata";
-  headingWrap.append(heading, metadata);
+  const sync = document.createElement("div");
+  sync.className = "training-sync";
+  sync.dataset.state = "idle";
+  const syncButton = document.createElement("button");
+  syncButton.type = "button";
+  syncButton.className = "training-sync__button";
+  syncButton.textContent = "Sync now";
+  const syncStatus = paragraph("training-sync__status", "");
+  syncStatus.setAttribute("role", "status");
+  syncStatus.setAttribute("aria-live", "polite");
+  syncStatus.setAttribute("aria-atomic", "true");
+  sync.append(syncButton, syncStatus);
+  headingWrap.append(heading, metadata, sync);
   const close = document.createElement("button");
   close.type = "button";
   close.className = "drawer-close";
@@ -299,6 +316,7 @@ export function mountTrainingContextView(input: {
   input.drawer.append(header, status, ...panels.map((panel) => panel.root), units);
 
   let handler: ((value: UnitsPreference) => void) | undefined;
+  let syncHandler: ((kind: "keyboard" | "pointer") => void) | undefined;
   let disposed = false;
   const open = (): void => {
     if (disposed || input.drawer.open) return;
@@ -321,10 +339,15 @@ export function mountTrainingContextView(input: {
       handler?.(target.value as UnitsPreference);
     }
   };
+  const syncRequested = (event: Event): void => {
+    const detail = "detail" in event && typeof event.detail === "number" ? event.detail : 1;
+    syncHandler?.(detail === 0 ? "keyboard" : "pointer");
+  };
   opener.addEventListener("click", open);
   close.addEventListener("click", shut);
   input.drawer.addEventListener("cancel", cancel);
   units.addEventListener("change", unitsChanged);
+  syncButton.addEventListener("click", syncRequested);
 
   return {
     view: {
@@ -379,17 +402,45 @@ export function mountTrainingContextView(input: {
             : "";
       },
     },
+    syncView: {
+      render(state: ManualSyncViewState) {
+        if (disposed) return;
+        sync.dataset.state = state.tone;
+        syncButton.textContent = state.label;
+        syncButton.disabled = state.disabled;
+        if (state.busy) syncButton.setAttribute("aria-busy", "true");
+        else syncButton.removeAttribute("aria-busy");
+        syncStatus.textContent = state.message;
+      },
+      restoreKeyboardFocus() {
+        if (disposed || !input.drawer.open) return;
+        const owner = input.drawer.ownerDocument;
+        const active = owner.activeElement;
+        const focusWasLost =
+          active === null ||
+          active === owner.body ||
+          active === owner.documentElement ||
+          active === syncButton;
+        if (!focusWasLost) return;
+        const target = syncButton.disabled ? close : syncButton;
+        if (!target.isConnected || target.hidden || target.disabled) return;
+        target.focus();
+      },
+    },
     bind(next) {
       handler = next.onUnitsPreferenceChange;
+      syncHandler = next.onSyncRequest;
     },
     dispose() {
       if (disposed) return;
       disposed = true;
       handler = undefined;
+      syncHandler = undefined;
       opener.removeEventListener("click", open);
       close.removeEventListener("click", shut);
       input.drawer.removeEventListener("cancel", cancel);
       units.removeEventListener("change", unitsChanged);
+      syncButton.removeEventListener("click", syncRequested);
     },
   };
 }

--- a/apps/desktop-renderer/src/training-sync.ts
+++ b/apps/desktop-renderer/src/training-sync.ts
@@ -1,0 +1,340 @@
+import {
+  CoachClientCallAbortedError,
+  CoachClientCallTimeoutError,
+  CoachClientDisconnectedError,
+  CoachClientHandshakeError,
+  CoachClientProtocolError,
+  CoachClientTransportUnavailableError,
+  CoachRpcRemoteError,
+  type CoachClient,
+  type CoachClientTerminalEnvelope,
+} from "@enduragent/coach-client";
+import type {
+  CoachOperationProgressNotificationEnvelope,
+  SyncRpcResult,
+} from "@enduragent/coach-contract";
+import type { DesktopCoachClientProvider } from "./coach-client.js";
+
+export type TrainingSyncState =
+  | { readonly status: "idle" }
+  | { readonly status: "queued"; readonly operation: number }
+  | { readonly status: "running"; readonly operation: number }
+  | {
+      readonly status: "succeeded";
+      readonly operation: number;
+      readonly kind: "published" | "no-change";
+    }
+  | {
+      readonly status: "failed";
+      readonly operation: number;
+      readonly kind: "partial" | "operation" | "indeterminate" | "protocol";
+      readonly retryable: boolean;
+    };
+
+export type TrainingSyncStateListener = (state: TrainingSyncState) => void;
+
+export interface TrainingSyncCoordinator {
+  getState(): TrainingSyncState;
+  subscribe(listener: TrainingSyncStateListener): () => void;
+  request(): Promise<void>;
+  dispose(): void;
+}
+
+function isIndeterminateFailure(error: unknown): boolean {
+  return (
+    error instanceof CoachClientDisconnectedError ||
+    error instanceof CoachClientCallTimeoutError ||
+    error instanceof CoachClientCallAbortedError ||
+    error instanceof CoachClientHandshakeError ||
+    error instanceof CoachClientTransportUnavailableError
+  );
+}
+
+function isSameTrainingSyncState(left: TrainingSyncState, right: TrainingSyncState): boolean {
+  switch (left.status) {
+    case "idle":
+      return right.status === "idle";
+    case "queued":
+    case "running":
+      return right.status === left.status && right.operation === left.operation;
+    case "succeeded":
+      return (
+        right.status === "succeeded" &&
+        right.operation === left.operation &&
+        right.kind === left.kind
+      );
+    case "failed":
+      return (
+        right.status === "failed" &&
+        right.operation === left.operation &&
+        right.kind === left.kind &&
+        right.retryable === left.retryable
+      );
+  }
+}
+
+export function createTrainingSyncCoordinator(input: {
+  readonly clients: DesktopCoachClientProvider;
+  readonly refreshTrainingContext: () => Promise<void>;
+}): TrainingSyncCoordinator {
+  let state: TrainingSyncState = { status: "idle" };
+  let operation = 0;
+  let epoch = 0;
+  let inFlight: Promise<void> | undefined;
+  let disposed = false;
+  let needsReconnect = false;
+  let failedClient: CoachClient | undefined;
+  const listeners = new Set<TrainingSyncStateListener>();
+
+  const current = (selectedEpoch: number): boolean => !disposed && selectedEpoch === epoch;
+  const publish = (next: TrainingSyncState): void => {
+    if (disposed) return;
+    if (isSameTrainingSyncState(state, next)) return;
+    state = next;
+    for (const listener of listeners) {
+      try {
+        listener(state);
+      } catch {}
+    }
+  };
+  const publishProtocol = (selectedEpoch: number, selectedOperation: number): void => {
+    if (!current(selectedEpoch)) return;
+    publish({
+      status: "failed",
+      operation: selectedOperation,
+      kind: "protocol",
+      retryable: false,
+    });
+  };
+
+  const clientAfterFailure = async (previous: CoachClient | undefined): Promise<CoachClient> => {
+    if (previous === undefined) return input.clients.getClient();
+    const client = await input.clients.getClient();
+    return client === previous ? input.clients.reconnect() : client;
+  };
+
+  const begin = (): Promise<void> => {
+    const selectedEpoch = ++epoch;
+    const selectedOperation = ++operation;
+    publish({ status: "queued", operation: selectedOperation });
+
+    let selectedClient: CoachClient | undefined;
+    let admitted = false;
+    let progress = 0;
+    let requestId: string | number | undefined;
+    let terminal: CoachClientTerminalEnvelope | undefined;
+    let terminalValid = false;
+    let callSettled = false;
+    let protocolFault = false;
+
+    const failProtocol = (): void => {
+      if (!current(selectedEpoch)) return;
+      protocolFault = true;
+      if (callSettled || terminal !== undefined) {
+        publishProtocol(selectedEpoch, selectedOperation);
+      }
+    };
+
+    const onNotificationEnvelope = (envelope: CoachOperationProgressNotificationEnvelope): void => {
+      if (!current(selectedEpoch)) return;
+      if (callSettled || terminal !== undefined) {
+        failProtocol();
+        return;
+      }
+      if (
+        envelope.jsonrpc !== "2.0" ||
+        envelope.method !== "coach.operationProgress" ||
+        envelope.params.requestMethod !== "sync"
+      ) {
+        failProtocol();
+        return;
+      }
+      const event = envelope.params.event;
+      if (progress === 0) {
+        if (event.phase !== "started" || event.completed !== 0 || event.total !== 1) {
+          failProtocol();
+          return;
+        }
+        requestId = envelope.params.requestId;
+        progress = 1;
+        publish({ status: "running", operation: selectedOperation });
+        return;
+      }
+      if (
+        progress !== 1 ||
+        envelope.params.requestId !== requestId ||
+        event.phase !== "completed" ||
+        event.completed !== 1 ||
+        event.total !== 1
+      ) {
+        failProtocol();
+        return;
+      }
+      progress = 2;
+    };
+
+    const onTerminalEnvelope = (envelope: CoachClientTerminalEnvelope): void => {
+      if (!current(selectedEpoch)) return;
+      if (callSettled || terminal !== undefined) {
+        failProtocol();
+        return;
+      }
+      terminal = envelope;
+      const successTerminal = "result" in envelope && !("error" in envelope);
+      const errorTerminal = "error" in envelope && !("result" in envelope);
+      terminalValid =
+        !protocolFault &&
+        envelope.jsonrpc === "2.0" &&
+        envelope.id === requestId &&
+        ((successTerminal && progress === 2) || (errorTerminal && progress === 1));
+      if (!terminalValid) failProtocol();
+    };
+
+    const task = (async () => {
+      let result: SyncRpcResult | undefined;
+      let failure: unknown;
+      try {
+        selectedClient = needsReconnect
+          ? await clientAfterFailure(failedClient)
+          : await input.clients.getClient();
+        if (!current(selectedEpoch)) return;
+        needsReconnect = false;
+        failedClient = undefined;
+        const call = selectedClient.call(
+          "sync",
+          {},
+          {
+            onNotificationEnvelope,
+            onTerminalEnvelope,
+          },
+        );
+        admitted = true;
+        result = await call;
+      } catch (error) {
+        failure = error;
+      }
+      if (!current(selectedEpoch)) return;
+      callSettled = true;
+
+      if (protocolFault || failure instanceof CoachClientProtocolError) {
+        publishProtocol(selectedEpoch, selectedOperation);
+        return;
+      }
+      if (terminal === undefined) {
+        if (failure !== undefined && !admitted) {
+          if (isIndeterminateFailure(failure)) {
+            needsReconnect = true;
+            failedClient = selectedClient;
+          }
+          publish({
+            status: "failed",
+            operation: selectedOperation,
+            kind: "operation",
+            retryable: true,
+          });
+          return;
+        }
+        if (failure !== undefined && isIndeterminateFailure(failure)) {
+          needsReconnect = true;
+          failedClient = selectedClient;
+          publish({
+            status: "failed",
+            operation: selectedOperation,
+            kind: "indeterminate",
+            retryable: true,
+          });
+          return;
+        }
+        publishProtocol(selectedEpoch, selectedOperation);
+        return;
+      }
+      if (!terminalValid) {
+        publishProtocol(selectedEpoch, selectedOperation);
+        return;
+      }
+
+      const successTerminal = "result" in terminal;
+      if (
+        (successTerminal && failure !== undefined) ||
+        (!successTerminal && !(failure instanceof CoachRpcRemoteError))
+      ) {
+        publishProtocol(selectedEpoch, selectedOperation);
+        return;
+      }
+
+      try {
+        await input.refreshTrainingContext();
+      } catch {}
+      if (!current(selectedEpoch)) return;
+      if (protocolFault) {
+        publishProtocol(selectedEpoch, selectedOperation);
+        return;
+      }
+      if (!successTerminal) {
+        publish({
+          status: "failed",
+          operation: selectedOperation,
+          kind: "operation",
+          retryable: true,
+        });
+        return;
+      }
+      if (result === undefined) {
+        publishProtocol(selectedEpoch, selectedOperation);
+      } else if (result.published && result.referenceSucceeded) {
+        publish({ status: "succeeded", operation: selectedOperation, kind: "published" });
+      } else if (!result.published && result.referenceSucceeded) {
+        publish({ status: "succeeded", operation: selectedOperation, kind: "no-change" });
+      } else if (result.published) {
+        publish({
+          status: "failed",
+          operation: selectedOperation,
+          kind: "partial",
+          retryable: true,
+        });
+      } else {
+        publish({
+          status: "failed",
+          operation: selectedOperation,
+          kind: "operation",
+          retryable: true,
+        });
+      }
+    })();
+
+    inFlight = task;
+    void task
+      .finally(() => {
+        if (inFlight === task) inFlight = undefined;
+      })
+      .catch(() => {});
+    return task;
+  };
+
+  return {
+    getState: () => state,
+    subscribe(listener) {
+      if (disposed) return () => {};
+      listeners.add(listener);
+      try {
+        listener(state);
+      } catch {}
+      return () => listeners.delete(listener);
+    },
+    request() {
+      if (disposed || (state.status === "failed" && state.kind === "protocol")) {
+        return Promise.resolve();
+      }
+      return inFlight ?? begin();
+    },
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      epoch += 1;
+      inFlight = undefined;
+      needsReconnect = false;
+      failedClient = undefined;
+      listeners.clear();
+    },
+  };
+}

--- a/apps/desktop-renderer/tests/first-sync.test.ts
+++ b/apps/desktop-renderer/tests/first-sync.test.ts
@@ -1,16 +1,26 @@
 import { readFile } from "node:fs/promises";
-import { CoachClientDisconnectedError, CoachClientProtocolError } from "@enduragent/coach-client";
+import type { CoachClient, CoachClientCallOptions } from "@enduragent/coach-client";
 import type {
   CoachOperationProgressNotificationEnvelope,
   SyncRpcResult,
 } from "@enduragent/coach-contract";
 import { describe, expect, it, vi, type Mock } from "vitest";
+import type { DesktopCoachClientProvider } from "../src/coach-client.js";
 import {
   createFirstSyncController,
-  type FirstSyncCallOptions,
   type FirstSyncPorts,
   type FirstSyncState,
 } from "../src/first-sync.js";
+import {
+  createManualSyncController,
+  type ManualSyncViewState,
+} from "../src/training-context/manual-sync.js";
+import {
+  createTrainingSyncCoordinator,
+  type TrainingSyncCoordinator,
+  type TrainingSyncState,
+  type TrainingSyncStateListener,
+} from "../src/training-sync.js";
 
 const completion = {
   providerConfigured: true,
@@ -25,52 +35,89 @@ const success: SyncRpcResult = {
   requests: { store: 1, reference: 1, total: 2 },
 };
 
-function envelope(
-  phase: "started" | "completed",
-  completed: number,
-  total = 1,
-  requestId = 1,
-): CoachOperationProgressNotificationEnvelope {
-  return {
-    jsonrpc: "2.0",
-    method: "coach.operationProgress",
-    params: { requestId, requestMethod: "sync", event: { phase, completed, total } },
-  };
+function deferred<T>(): {
+  readonly promise: Promise<T>;
+  readonly resolve: (value: T) => void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((accept) => {
+    resolve = accept;
+  });
+  return { promise, resolve };
 }
 
-function fakePorts(callSync: FirstSyncPorts["callSync"]): FirstSyncPorts & {
+class FakeCoordinator implements TrainingSyncCoordinator {
+  private state: TrainingSyncState = { status: "idle" };
+  private operation = 0;
+  private task: ReturnType<typeof deferred<void>> | undefined;
+  private readonly listeners = new Set<TrainingSyncStateListener>();
+  readonly requestCalls: number[] = [];
+
+  getState(): TrainingSyncState {
+    return this.state;
+  }
+
+  subscribe(listener: TrainingSyncStateListener): () => void {
+    this.listeners.add(listener);
+    listener(this.state);
+    return () => this.listeners.delete(listener);
+  }
+
+  request(): Promise<void> {
+    if (this.task !== undefined) return this.task.promise;
+    this.requestCalls.push(this.operation + 1);
+    this.operation += 1;
+    this.task = deferred<void>();
+    this.publish({ status: "queued", operation: this.operation });
+    return this.task.promise;
+  }
+
+  publish(state: TrainingSyncState): void {
+    this.state = state;
+    for (const listener of this.listeners) listener(state);
+  }
+
+  finish(state: TrainingSyncState): void {
+    this.publish(state);
+    const task = this.task;
+    this.task = undefined;
+    task?.resolve();
+  }
+
+  dispose(): void {
+    this.listeners.clear();
+    this.task = undefined;
+  }
+}
+
+function fakePorts(coordinator: TrainingSyncCoordinator): FirstSyncPorts & {
   readonly states: FirstSyncState[];
   readonly focusComposer: Mock<() => void>;
 } {
   const states: FirstSyncState[] = [];
   return {
+    coordinator,
     states,
-    callSync,
     focusComposer: vi.fn<() => void>(),
     render: (state) => states.push(state),
   };
 }
 
-function completedCall(result: SyncRpcResult = success): FirstSyncPorts["callSync"] {
-  return async (options) => {
-    options.onNotificationEnvelope(envelope("started", 0));
-    options.onNotificationEnvelope(envelope("completed", 1));
-    return result;
+function envelope(
+  phase: "started" | "completed",
+  completed: number,
+): CoachOperationProgressNotificationEnvelope {
+  return {
+    jsonrpc: "2.0",
+    method: "coach.operationProgress",
+    params: { requestId: 1, requestMethod: "sync", event: { phase, completed, total: 1 } },
   };
 }
 
 describe("first sync controller", () => {
-  it("strictly validates completion and starts one synchronous single-flight call", async () => {
-    let resolve!: (result: SyncRpcResult) => void;
-    let options!: FirstSyncCallOptions;
-    const callSync = vi.fn(
-      (selected: FirstSyncCallOptions) =>
-        new Promise<SyncRpcResult>((done) => {
-          options = selected;
-          resolve = done;
-        }),
-    );
-    const ports = fakePorts(callSync);
+  it("strictly validates completion and joins one synchronous coordinator flight", async () => {
+    const coordinator = new FakeCoordinator();
+    const ports = fakePorts(coordinator);
     const controller = createFirstSyncController(ports);
     for (const invalid of [
       {},
@@ -80,164 +127,277 @@ describe("first sync controller", () => {
     ]) {
       await expect(controller.start(invalid as never)).rejects.toBeInstanceOf(TypeError);
     }
-    expect(callSync).not.toHaveBeenCalled();
+    expect(coordinator.requestCalls).toHaveLength(0);
     const first = controller.start(completion);
     const second = controller.start(completion);
     expect(first).toBe(second);
+    expect(coordinator.requestCalls).toEqual([1]);
     expect(ports.states).toEqual([{ status: "syncing" }]);
-    expect(callSync).toHaveBeenCalledTimes(1);
-    options.onNotificationEnvelope(envelope("started", 0));
-    options.onNotificationEnvelope(envelope("completed", 1));
-    resolve(success);
-    await expect(first).resolves.toBeUndefined();
+    coordinator.publish({ status: "running", operation: 1 });
+    expect(ports.states).toEqual([{ status: "syncing" }]);
+    coordinator.finish({ status: "succeeded", operation: 1, kind: "published" });
+    await first;
     expect(ports.states.at(-1)).toEqual({ status: "ready" });
     expect(ports.focusComposer).toHaveBeenCalledTimes(1);
   });
 
   it.each([
-    ["reversed", [envelope("completed", 1), envelope("started", 0)]],
-    ["duplicate", [envelope("started", 0), envelope("started", 0)]],
-    ["wrong total", [envelope("started", 0, 2), envelope("completed", 1)]],
-    ["skipped", [envelope("started", 0)]],
-    ["cross request", [envelope("started", 0, 1, 1), envelope("completed", 1, 1, 2)]],
-  ])("latches %s progress as a protocol failure without observer throws", async (_name, events) => {
-    const ports = fakePorts(async (options) => {
-      for (const event of events) {
-        expect(() => options.onNotificationEnvelope(event)).not.toThrow();
-      }
-      return success;
-    });
+    [
+      { status: "succeeded", operation: 1, kind: "no-change" },
+      { status: "failed", kind: "operation", retryable: true },
+    ],
+    [
+      { status: "failed", operation: 1, kind: "partial", retryable: true },
+      { status: "failed", kind: "operation", retryable: true },
+    ],
+    [
+      { status: "failed", operation: 1, kind: "operation", retryable: true },
+      { status: "failed", kind: "operation", retryable: true },
+    ],
+    [
+      { status: "failed", operation: 1, kind: "indeterminate", retryable: true },
+      { status: "failed", kind: "disconnected", retryable: true },
+    ],
+    [
+      { status: "failed", operation: 1, kind: "protocol", retryable: false },
+      { status: "failed", kind: "protocol", retryable: false },
+    ],
+  ] as const)("preserves first-sync mapping for %o", async (terminal, expected) => {
+    const coordinator = new FakeCoordinator();
+    const ports = fakePorts(coordinator);
     const controller = createFirstSyncController(ports);
-    await controller.start(completion);
-    expect(ports.states.at(-1)).toEqual({
-      status: "failed",
-      kind: "protocol",
-      retryable: false,
-    });
+    const task = controller.start(completion);
+    coordinator.finish(terminal);
+    await task;
+    expect(ports.states.at(-1)).toEqual(expected);
     expect(ports.focusComposer).not.toHaveBeenCalled();
-    await controller.retry();
-    expect(ports.states).toHaveLength(2);
   });
 
-  it("turns a late current-epoch envelope into a non-retryable protocol failure", async () => {
-    let notify!: FirstSyncCallOptions["onNotificationEnvelope"];
-    const ports = fakePorts(async (options) => {
-      notify = options.onNotificationEnvelope;
-      notify(envelope("started", 0));
-      notify(envelope("completed", 1));
-      return success;
-    });
+  it("retries only a retryable shared outcome and focuses the composer once", async () => {
+    const coordinator = new FakeCoordinator();
+    const ports = fakePorts(coordinator);
     const controller = createFirstSyncController(ports);
-    await controller.start(completion);
-    expect(() => notify(envelope("completed", 1))).not.toThrow();
-    expect(ports.states.at(-1)).toEqual({
+    const first = controller.start(completion);
+    coordinator.finish({
       status: "failed",
-      kind: "protocol",
-      retryable: false,
+      operation: 1,
+      kind: "operation",
+      retryable: true,
     });
+    await first;
+    await controller.start(completion);
+    expect(coordinator.requestCalls).toEqual([1]);
+    const retry = controller.retry();
+    expect(coordinator.requestCalls).toEqual([1, 2]);
+    coordinator.finish({ status: "succeeded", operation: 2, kind: "published" });
+    await retry;
+    expect(coordinator.requestCalls).toEqual([1, 2]);
+    expect(ports.focusComposer).toHaveBeenCalledTimes(1);
   });
 
-  it.each([
-    [false, false],
-    [false, true],
-    [true, false],
-  ])(
-    "maps published %s and Reference success %s to a retryable operation failure",
-    async (published, referenceSucceeded) => {
-      const ports = fakePorts(completedCall({ ...success, published, referenceSucceeded }));
-      await createFirstSyncController(ports).start(completion);
-      expect(ports.states.at(-1)).toEqual({
-        status: "failed",
-        kind: "operation",
-        retryable: true,
+  it.each(["owned", "joined"] as const)(
+    "quiesces a completed %s first-sync render and focus history during later manual syncs",
+    async (admission) => {
+      const coordinator = new FakeCoordinator();
+      const ports = fakePorts(coordinator);
+      const first = createFirstSyncController(ports);
+      const manualStates: ManualSyncViewState[] = [];
+      const manual = createManualSyncController({
+        coordinator,
+        view: { render: (state) => manualStates.push(state), restoreKeyboardFocus: vi.fn() },
       });
-      expect(ports.focusComposer).not.toHaveBeenCalled();
+      const joinedTask = admission === "joined" ? manual.activate("pointer") : undefined;
+      const firstTask = first.start(completion);
+      if (joinedTask !== undefined) expect(firstTask).toBe(joinedTask);
+      coordinator.finish({ status: "succeeded", operation: 1, kind: "published" });
+      await firstTask;
+      await Promise.resolve();
+      const renderedAtReady = [...ports.states];
+      const focusCallsAtReady = ports.focusComposer.mock.calls.length;
+
+      const laterManual = manual.activate("pointer");
+      coordinator.finish({ status: "succeeded", operation: 2, kind: "no-change" });
+      await laterManual;
+
+      expect(coordinator.requestCalls).toEqual([1, 2]);
+      expect(manualStates.at(-1)?.message).toBe("Local training-data processing completed.");
+      expect(ports.states).toEqual(renderedAtReady);
+      expect(ports.focusComposer).toHaveBeenCalledTimes(focusCallsAtReady);
+      manual.dispose();
+      first.dispose();
     },
   );
 
-  it.each([
-    [new Error("private operation failure"), "operation", true],
-    [new CoachClientDisconnectedError(1006, "private close reason"), "disconnected", true],
-    [new CoachClientProtocolError(), "protocol", false],
-  ] as const)("maps fixed failure state for %s", async (failure, kind, retryable) => {
-    const ports = fakePorts(async () => {
-      throw failure;
+  it("reactivates a completed first sync only for later onboarding without refocusing", async () => {
+    const coordinator = new FakeCoordinator();
+    const ports = fakePorts(coordinator);
+    const first = createFirstSyncController(ports);
+    const manual = createManualSyncController({
+      coordinator,
+      view: { render: vi.fn(), restoreKeyboardFocus: vi.fn() },
     });
-    await createFirstSyncController(ports).start(completion);
-    expect(ports.states.at(-1)).toEqual({ status: "failed", kind, retryable });
-    expect(JSON.stringify(ports.states)).not.toContain(failure.message);
-  });
 
-  it("retries once on a new epoch and ignores callbacks from the detached epoch", async () => {
-    const calls: FirstSyncCallOptions[] = [];
-    let resolveRetry!: (result: SyncRpcResult) => void;
-    const ports = fakePorts(
-      vi.fn(async (options) => {
-        calls.push(options);
-        if (calls.length === 1) throw new CoachClientDisconnectedError(1006, "detached");
-        return new Promise<SyncRpcResult>((resolve) => {
-          resolveRetry = resolve;
-        });
-      }),
-    );
-    const controller = createFirstSyncController(ports);
-    await controller.start(completion);
-    const retry = controller.retry();
-    expect(calls).toHaveLength(2);
-    calls[0]!.onNotificationEnvelope(envelope("started", 0));
-    calls[0]!.onNotificationEnvelope(envelope("completed", 1));
-    calls[1]!.onNotificationEnvelope(envelope("started", 0, 1, 2));
-    calls[1]!.onNotificationEnvelope(envelope("completed", 1, 1, 2));
-    resolveRetry(success);
-    await retry;
-    expect(ports.states.at(-1)).toEqual({ status: "ready" });
+    const initialSetup = first.start(completion);
+    coordinator.finish({ status: "succeeded", operation: 1, kind: "published" });
+    await initialSetup;
+    expect(ports.states).toEqual([{ status: "syncing" }, { status: "ready" }]);
+    const renderedAtReady = [...ports.states];
+
+    const laterManual = manual.activate("pointer");
+    coordinator.finish({ status: "succeeded", operation: 2, kind: "no-change" });
+    await laterManual;
+    expect(ports.states).toEqual(renderedAtReady);
     expect(ports.focusComposer).toHaveBeenCalledTimes(1);
-    expect(ports.callSync).toHaveBeenCalledTimes(2);
+
+    const laterSetup = first.start(completion);
+    expect(coordinator.requestCalls).toEqual([1, 2, 3]);
+    expect(ports.states).toEqual([...renderedAtReady, { status: "syncing" }]);
+    coordinator.finish({ status: "succeeded", operation: 3, kind: "published" });
+    await laterSetup;
+    expect(ports.states).toEqual([...renderedAtReady, { status: "syncing" }, { status: "ready" }]);
+    expect(ports.focusComposer).toHaveBeenCalledTimes(1);
+    manual.dispose();
+    first.dispose();
   });
 
-  it("makes pending callbacks and completion inert after disposal", async () => {
-    let options!: FirstSyncCallOptions;
-    let resolve!: (result: SyncRpcResult) => void;
-    const ports = fakePorts(
-      (selected) =>
-        new Promise<SyncRpcResult>((done) => {
-          options = selected;
-          resolve = done;
-        }),
-    );
+  it("makes shared state and completion inert after disposal", async () => {
+    const coordinator = new FakeCoordinator();
+    const ports = fakePorts(coordinator);
     const controller = createFirstSyncController(ports);
-    const call = controller.start(completion);
+    const task = controller.start(completion);
     controller.dispose();
-    options.onNotificationEnvelope(envelope("started", 0));
-    options.onNotificationEnvelope(envelope("completed", 1));
-    resolve(success);
-    await call;
+    coordinator.finish({ status: "succeeded", operation: 1, kind: "published" });
+    await task;
     await controller.retry();
     await controller.start(completion);
     expect(ports.states).toEqual([{ status: "syncing" }]);
     expect(ports.focusComposer).not.toHaveBeenCalled();
   });
 
-  it("rechecks sync after a later onboarding completion without refocusing twice", async () => {
-    const callSync = vi.fn(completedCall());
-    const ports = fakePorts(callSync);
-    const controller = createFirstSyncController(ports);
-    await controller.start(completion);
-    await controller.start(completion);
-    expect(callSync).toHaveBeenCalledTimes(2);
-    expect(ports.states).toEqual([
-      { status: "syncing" },
-      { status: "ready" },
-      { status: "syncing" },
-      { status: "ready" },
+  it("keeps the drawer coherent when first sync owns the active admission", async () => {
+    const coordinator = new FakeCoordinator();
+    const first = createFirstSyncController(fakePorts(coordinator));
+    const firstTask = first.start(completion);
+    const manualStates: ManualSyncViewState[] = [];
+    const manual = createManualSyncController({
+      coordinator,
+      view: { render: (state) => manualStates.push(state), restoreKeyboardFocus: vi.fn() },
+    });
+    await manual.activate("keyboard");
+    expect(coordinator.requestCalls).toEqual([1]);
+    expect(manualStates).toEqual([
+      {
+        label: "Sync now",
+        message: "Sync queued.",
+        disabled: true,
+        busy: true,
+        tone: "active",
+      },
     ]);
-    expect(ports.focusComposer).toHaveBeenCalledTimes(1);
+    coordinator.finish({ status: "succeeded", operation: 1, kind: "published" });
+    await firstTask;
+    expect(manualStates.at(-1)?.message).toBe("Training-data check completed.");
   });
 
-  it("keeps the controller free of chat or transcript ports and ships the exact status surface", async () => {
-    const ports = fakePorts(completedCall());
-    await createFirstSyncController(ports).start(completion);
-    expect(Object.keys(ports).sort()).toEqual(["callSync", "focusComposer", "render", "states"]);
+  it("restores focus only for the accepted keyboard activation", async () => {
+    const coordinator = new FakeCoordinator();
+    const restoreKeyboardFocus = vi.fn();
+    const manual = createManualSyncController({
+      coordinator,
+      view: { render: vi.fn(), restoreKeyboardFocus },
+    });
+    const keyboard = manual.activate("keyboard");
+    expect(manual.activate("pointer")).toBe(keyboard);
+    coordinator.finish({ status: "succeeded", operation: 1, kind: "published" });
+    await keyboard;
+    await Promise.resolve();
+    expect(restoreKeyboardFocus).toHaveBeenCalledTimes(1);
+
+    const pointer = manual.activate("pointer");
+    coordinator.finish({ status: "succeeded", operation: 2, kind: "published" });
+    await pointer;
+    await Promise.resolve();
+    expect(restoreKeyboardFocus).toHaveBeenCalledTimes(1);
+
+    const staleKeyboard = manual.activate("keyboard");
+    manual.dispose();
+    coordinator.finish({ status: "succeeded", operation: 3, kind: "published" });
+    await staleKeyboard;
+    expect(restoreKeyboardFocus).toHaveBeenCalledTimes(1);
+  });
+
+  it("shares one wire operation with manual sync and replays running state to late surfaces", async () => {
+    const callGate = deferred<SyncRpcResult>();
+    let options!: CoachClientCallOptions<"sync">;
+    const call = vi.fn(
+      async (_method: string, _params: unknown, selected?: CoachClientCallOptions<"sync">) => {
+        options = selected!;
+        return callGate.promise;
+      },
+    );
+    const client = {
+      handshake: {} as CoachClient["handshake"],
+      call: call as unknown as CoachClient["call"],
+      close: vi.fn(async () => {}),
+    } as CoachClient;
+    const clients: DesktopCoachClientProvider = {
+      getClient: vi.fn(async () => client),
+      reconnect: vi.fn(async () => client),
+      close: vi.fn(async () => {}),
+    };
+    const refreshTrainingContext = vi.fn(async () => {});
+    const coordinator = createTrainingSyncCoordinator({ clients, refreshTrainingContext });
+    const manualStates: ManualSyncViewState[] = [];
+    const manual = createManualSyncController({
+      coordinator,
+      view: {
+        render: (state) => manualStates.push(state),
+        restoreKeyboardFocus: vi.fn(),
+      },
+    });
+    const manualTask = manual.activate("pointer");
+    await Promise.resolve();
+    options.onNotificationEnvelope?.(envelope("started", 0));
+
+    const firstPorts = fakePorts(coordinator);
+    const first = createFirstSyncController(firstPorts);
+    const firstTask = first.start(completion);
+    expect(firstTask).toBe(manualTask);
+    expect(firstPorts.states).toEqual([{ status: "syncing" }]);
+    expect(manualStates.at(-1)?.message).toBe("Syncing training data…");
+    expect(call).toHaveBeenCalledTimes(1);
+
+    const lateStates: ManualSyncViewState[] = [];
+    const late = createManualSyncController({
+      coordinator,
+      view: { render: (state) => lateStates.push(state), restoreKeyboardFocus: vi.fn() },
+    });
+    expect(lateStates).toEqual([
+      {
+        label: "Sync now",
+        message: "Syncing training data…",
+        disabled: true,
+        busy: true,
+        tone: "active",
+      },
+    ]);
+    expect(call).toHaveBeenCalledTimes(1);
+
+    options.onNotificationEnvelope?.(envelope("completed", 1));
+    options.onTerminalEnvelope?.({ jsonrpc: "2.0", id: 1, result: success });
+    callGate.resolve(success);
+    await Promise.all([manualTask, firstTask]);
+    expect(call).toHaveBeenCalledTimes(1);
+    expect(refreshTrainingContext).toHaveBeenCalledTimes(1);
+    expect(firstPorts.states.at(-1)).toEqual({ status: "ready" });
+    expect(firstPorts.focusComposer).not.toHaveBeenCalled();
+    expect(lateStates.at(-1)?.message).toBe("Training-data check completed.");
+    late.dispose();
+    first.dispose();
+    manual.dispose();
+  });
+
+  it("keeps first sync free of a second wire tracker and ships the existing status surface", async () => {
     const [host, controller, styles] = await Promise.all([
       readFile(new URL("../src/index.ts", import.meta.url), "utf8"),
       readFile(new URL("../src/first-sync.ts", import.meta.url), "utf8"),
@@ -257,24 +417,10 @@ describe("first sync controller", () => {
     ]) {
       expect(host).toContain(copy);
     }
-    expect(host).toContain('section.className = "first-sync"');
-    expect(host).toContain("section.dataset.state = state.status");
-    expect(host).toContain('section.setAttribute("aria-labelledby", "first-sync-title")');
-    expect(host).toContain('track.setAttribute("role", "progressbar")');
-    expect(host).toContain('track.setAttribute("aria-label", "Syncing training history")');
-    expect(host).toContain(
-      "onComplete: (completion) => void firstSyncController.start(completion)",
-    );
-    expect(host).toContain("message.focus()");
-    expect(controller).not.toMatch(/chat|prompt|transcript|sessionStore/u);
+    expect(host).toContain("coordinator: trainingSyncCoordinator");
+    expect(host).not.toContain("syncNeedsReconnect");
+    expect(controller).not.toMatch(/onNotificationEnvelope|requestId|chat|transcript/u);
     expect(styles).toContain("width: min(680px, calc(100% - 48px))");
-    expect(styles).toContain("padding: 20px");
-    expect(styles).toContain("border-radius: 16px");
-    expect(styles).toContain("animation: first-sync-sweep 1.2s");
-    expect(styles).toContain("@media (max-width: 760px)");
-    expect(styles).toContain("width: calc(100% - 32px)");
     expect(styles).toContain("@media (prefers-reduced-motion: reduce)");
-    expect(styles).toContain("animation: none");
-    expect(styles).toContain("width: 40%");
   });
 });

--- a/apps/desktop-renderer/tests/training-context.test.ts
+++ b/apps/desktop-renderer/tests/training-context.test.ts
@@ -14,6 +14,17 @@ import {
   formatUtcTimestamp,
   formatWholeNumber,
 } from "../src/training-context/format.js";
+import {
+  SYNC_INDETERMINATE_COPY,
+  SYNC_NO_CHANGE_COPY,
+  SYNC_OPERATION_FAILURE_COPY,
+  SYNC_PARTIAL_COPY,
+  SYNC_PROTOCOL_COPY,
+  SYNC_PUBLISHED_COPY,
+  SYNC_QUEUED_COPY,
+  SYNC_RUNNING_COPY,
+  toManualSyncViewState,
+} from "../src/training-context/manual-sync.js";
 import { mountTrainingContextView } from "../src/training-context/view.js";
 
 const context: CyclingTrainingContext = {
@@ -65,11 +76,19 @@ function providerWith(call: CoachClient["call"]): DesktopCoachClientProvider {
 class FakeElement {
   readonly children: FakeElement[] = [];
   readonly attributes = new Map<string, string>();
+  readonly dataset: Record<string, string> = {};
+  readonly listeners = new Map<string, Set<(event: Event) => void>>();
   className = "";
   open = false;
+  disabled = false;
+  hidden = false;
+  isConnected = true;
   private ownText = "";
 
-  constructor(readonly tagName: string) {}
+  constructor(
+    readonly tagName: string,
+    readonly ownerDocument: FakeDocument,
+  ) {}
 
   get textContent(): string {
     return this.ownText + this.children.map((child) => child.textContent).join("");
@@ -90,7 +109,8 @@ class FakeElement {
 
   append(...values: Array<FakeElement | string>): void {
     for (const value of values) {
-      const child = typeof value === "string" ? new FakeElement("#TEXT") : value;
+      const child =
+        typeof value === "string" ? new FakeElement("#TEXT", this.ownerDocument) : value;
       if (typeof value === "string") child.textContent = value;
       this.children.push(child);
     }
@@ -110,11 +130,28 @@ class FakeElement {
     return this.attributes.get(name) ?? null;
   }
 
-  addEventListener(_name: string, _listener: (event: Event) => void): void {}
+  removeAttribute(name: string): void {
+    this.attributes.delete(name);
+  }
 
-  removeEventListener(_name: string, _listener: (event: Event) => void): void {}
+  addEventListener(name: string, listener: (event: Event) => void): void {
+    const listeners = this.listeners.get(name) ?? new Set();
+    listeners.add(listener);
+    this.listeners.set(name, listeners);
+  }
 
-  focus(): void {}
+  removeEventListener(name: string, listener: (event: Event) => void): void {
+    this.listeners.get(name)?.delete(listener);
+  }
+
+  dispatch(name: string, event: Event): void {
+    for (const listener of this.listeners.get(name) ?? []) listener(event);
+  }
+
+  focus(): void {
+    if (this.disabled || this.hidden || !this.isConnected) return;
+    this.ownerDocument.activeElement = this;
+  }
 
   showModal(): void {
     this.open = true;
@@ -126,12 +163,23 @@ class FakeElement {
 }
 
 class FakeDocument {
+  readonly documentElement: FakeElement;
+  readonly body: FakeElement;
+  activeElement: FakeElement | null;
+
+  constructor() {
+    this.documentElement = new FakeElement("HTML", this);
+    this.body = new FakeElement("BODY", this);
+    this.documentElement.append(this.body);
+    this.activeElement = this.body;
+  }
+
   createElement(name: string): FakeElement {
-    return new FakeElement(name.toUpperCase());
+    return new FakeElement(name.toUpperCase(), this);
   }
 
   createTextNode(value: string): FakeElement {
-    const node = new FakeElement("#TEXT");
+    const node = new FakeElement("#TEXT", this);
     node.textContent = value;
     return node;
   }
@@ -144,6 +192,30 @@ function descendants(root: FakeElement): FakeElement[] {
 function elementsByTagName(root: FakeElement, tagName: string): FakeElement[] {
   const normalized = tagName.toUpperCase();
   return descendants(root).filter((element) => element.tagName === normalized);
+}
+
+function elementByClassName(root: FakeElement, className: string): FakeElement {
+  const matches = descendants(root).filter((element) => element.className === className);
+  expect(matches).toHaveLength(1);
+  return matches[0]!;
+}
+
+function contrastRatio(foreground: string, background: string): number {
+  const luminance = (hex: string): number => {
+    const channels = hex
+      .match(/[0-9a-f]{2}/giu)!
+      .map((channel) => Number.parseInt(channel, 16) / 255)
+      .map((channel) =>
+        channel <= 0.04045 ? channel / 12.92 : ((channel + 0.055) / 1.055) ** 2.4,
+      );
+    return 0.2126 * channels[0]! + 0.7152 * channels[1]! + 0.0722 * channels[2]!;
+  };
+  const foregroundLuminance = luminance(foreground);
+  const backgroundLuminance = luminance(background);
+  return (
+    (Math.max(foregroundLuminance, backgroundLuminance) + 0.05) /
+    (Math.min(foregroundLuminance, backgroundLuminance) + 0.05)
+  );
 }
 
 function readyViewState(lastSynced: string): TrainingContextViewState {
@@ -583,6 +655,198 @@ describe("training context drawer contract", () => {
     } finally {
       vi.unstubAllGlobals();
     }
+  });
+
+  it("keeps one resident atomic sync region independent from training-context renders", () => {
+    const document = new FakeDocument();
+    vi.stubGlobal("document", document);
+
+    try {
+      const spine = document.createElement("aside");
+      const drawer = document.createElement("dialog");
+      const mounted = mountTrainingContextView({
+        spine: spine as unknown as HTMLElement,
+        drawer: drawer as unknown as HTMLDialogElement,
+      });
+      const button = elementByClassName(drawer, "training-sync__button");
+      const status = elementByClassName(drawer, "training-sync__status");
+      const syncRegion = elementByClassName(drawer, "training-sync");
+      const opener = elementByClassName(spine, "drawer-toggle");
+      const close = elementByClassName(drawer, "drawer-close");
+      const activations: string[] = [];
+      mounted.bind({
+        onUnitsPreferenceChange: () => {},
+        onSyncRequest: (kind) => activations.push(kind),
+      });
+
+      expect(button.textContent).toBe("Sync now");
+      expect(status.textContent).toBe("");
+      expect(status.getAttribute("role")).toBe("status");
+      expect(status.getAttribute("aria-live")).toBe("polite");
+      expect(status.getAttribute("aria-atomic")).toBe("true");
+      expect(syncRegion.dataset.state).toBe("idle");
+
+      button.dispatch("click", { detail: 0 } as unknown as Event);
+      button.dispatch("click", { detail: 1 } as unknown as Event);
+      expect(activations).toEqual(["keyboard", "pointer"]);
+
+      mounted.syncView.render(toManualSyncViewState({ status: "queued", operation: 1 }));
+      expect(button.textContent).toBe("Sync now");
+      expect(button.disabled).toBe(true);
+      expect(button.getAttribute("aria-busy")).toBe("true");
+      expect(status.textContent).toBe(SYNC_QUEUED_COPY);
+      mounted.view.render(readyViewState("1998-07-18T12:34:56.000Z"));
+      expect(elementByClassName(drawer, "training-sync__button")).toBe(button);
+      expect(elementByClassName(drawer, "training-sync__status")).toBe(status);
+      expect(status.textContent).toBe(SYNC_QUEUED_COPY);
+
+      const terminalStates = [
+        [{ status: "running", operation: 1 } as const, "Sync now", SYNC_RUNNING_COPY, true],
+        [
+          { status: "succeeded", operation: 1, kind: "published" } as const,
+          "Sync again",
+          SYNC_PUBLISHED_COPY,
+          false,
+        ],
+        [
+          { status: "succeeded", operation: 1, kind: "no-change" } as const,
+          "Sync again",
+          SYNC_NO_CHANGE_COPY,
+          false,
+        ],
+        [
+          {
+            status: "failed",
+            operation: 1,
+            kind: "partial",
+            retryable: true,
+          } as const,
+          "Try again",
+          SYNC_PARTIAL_COPY,
+          false,
+        ],
+        [
+          {
+            status: "failed",
+            operation: 1,
+            kind: "operation",
+            retryable: true,
+          } as const,
+          "Try again",
+          SYNC_OPERATION_FAILURE_COPY,
+          false,
+        ],
+        [
+          {
+            status: "failed",
+            operation: 1,
+            kind: "indeterminate",
+            retryable: true,
+          } as const,
+          "Try again",
+          SYNC_INDETERMINATE_COPY,
+          false,
+        ],
+        [
+          {
+            status: "failed",
+            operation: 1,
+            kind: "protocol",
+            retryable: false,
+          } as const,
+          "Sync unavailable",
+          SYNC_PROTOCOL_COPY,
+          true,
+        ],
+      ] as const;
+      for (const [state, label, copy, disabled] of terminalStates) {
+        mounted.syncView.render(toManualSyncViewState(state));
+        expect(button.textContent).toBe(label);
+        expect(status.textContent).toBe(copy);
+        expect(button.disabled).toBe(disabled);
+        expect(button.getAttribute("aria-busy")).toBe(state.status === "running" ? "true" : null);
+        expect(drawer.textContent).not.toContain("private-athlete-id");
+      }
+
+      opener.dispatch("click", {} as Event);
+      expect(drawer.open).toBe(true);
+      expect(document.activeElement).toBe(close);
+      mounted.syncView.render(
+        toManualSyncViewState({ status: "succeeded", operation: 1, kind: "no-change" }),
+      );
+      document.activeElement = document.body;
+      mounted.syncView.restoreKeyboardFocus();
+      expect(document.activeElement).toBe(button);
+      const elsewhere = document.createElement("button");
+      elsewhere.focus();
+      mounted.syncView.restoreKeyboardFocus();
+      expect(document.activeElement).toBe(elsewhere);
+      mounted.syncView.render(
+        toManualSyncViewState({
+          status: "failed",
+          operation: 1,
+          kind: "protocol",
+          retryable: false,
+        }),
+      );
+      expect(button.disabled).toBe(true);
+      document.activeElement = document.body;
+      button.focus();
+      expect(document.activeElement).toBe(document.body);
+      mounted.syncView.restoreKeyboardFocus();
+      expect(document.activeElement).toBe(close);
+      close.dispatch("click", {} as Event);
+      expect(drawer.open).toBe(false);
+      expect(document.activeElement).toBe(opener);
+      document.activeElement = document.body;
+      mounted.syncView.restoreKeyboardFocus();
+      expect(document.activeElement).toBe(document.body);
+      opener.dispatch("click", {} as Event);
+      expect(elementByClassName(drawer, "training-sync__button")).toBe(button);
+      mounted.dispose();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("keeps fixed sync copy contract-honest and status contrast readable in both themes", async () => {
+    expect([
+      SYNC_PUBLISHED_COPY,
+      SYNC_NO_CHANGE_COPY,
+      SYNC_PARTIAL_COPY,
+      SYNC_OPERATION_FAILURE_COPY,
+    ]).toEqual([
+      "Training-data check completed.",
+      "Local training-data processing completed.",
+      "Training-data processing partially completed. Try again to finish.",
+      "We couldn’t complete the training-data check. Your existing data is still available.",
+    ]);
+    expect(
+      [SYNC_PUBLISHED_COPY, SYNC_NO_CHANGE_COPY, SYNC_PARTIAL_COPY].join(" ").toLowerCase(),
+    ).not.toMatch(/already up to date|refreshed|new data|saved/u);
+
+    const [drawerStyles, globalStyles] = await Promise.all([
+      readFile(new URL("../src/training-context/styles.css", import.meta.url), "utf8"),
+      readFile(new URL("../src/styles.css", import.meta.url), "utf8"),
+    ]);
+    expect(drawerStyles).toContain("--sync-status-caution: #80520f;");
+    expect(drawerStyles).toContain("--sync-status-caution: #e4b66f;");
+    expect(drawerStyles).toContain("color: var(--sync-status-caution);");
+    expect(globalStyles).toContain("--surface-solid: #ffffff;");
+    expect(globalStyles).toContain("--surface-solid: #202923;");
+    expect(contrastRatio("#80520f", "#ffffff")).toBeGreaterThanOrEqual(4.5);
+    expect(contrastRatio("#e4b66f", "#202923")).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it("preserves the compact drawer width with horizontal overflow protection", async () => {
+    const styles = await readFile(
+      new URL("../src/training-context/styles.css", import.meta.url),
+      "utf8",
+    );
+    const compactDrawerStyles = styles.match(/@media \(max-width: 720px\) \{([\s\S]*?)\n\}/u)?.[1];
+    expect(compactDrawerStyles).toContain("width: calc(100vw - 28px);");
+    expect(compactDrawerStyles).not.toContain("max-width");
+    expect(compactDrawerStyles).toContain("overflow-x: hidden;");
   });
 
   it("keeps the panel surface free of excluded balance labels and local metric claims", async () => {

--- a/apps/desktop-renderer/tests/training-sync.test.ts
+++ b/apps/desktop-renderer/tests/training-sync.test.ts
@@ -1,0 +1,593 @@
+import {
+  CoachClientCallAbortedError,
+  CoachClientCallTimeoutError,
+  CoachClientDisconnectedError,
+  CoachClientHandshakeError,
+  CoachClientProtocolError,
+  CoachClientTransportUnavailableError,
+  CoachRpcRemoteError,
+  type CoachClient,
+  type CoachClientCallOptions,
+  type CoachClientTerminalEnvelope,
+} from "@enduragent/coach-client";
+import type {
+  CoachOperationProgressNotificationEnvelope,
+  SyncRpcResult,
+} from "@enduragent/coach-contract";
+import { describe, expect, it, vi } from "vitest";
+import type { DesktopCoachClientProvider } from "../src/coach-client.js";
+import { createTrainingSyncCoordinator, type TrainingSyncState } from "../src/training-sync.js";
+
+type SyncOptions = CoachClientCallOptions<"sync">;
+
+const published: SyncRpcResult = {
+  schemaVersion: 1,
+  published: true,
+  referenceSucceeded: true,
+  requests: { store: 1, reference: 1, total: 2 },
+};
+
+function deferred<T>(): {
+  readonly promise: Promise<T>;
+  readonly resolve: (value: T) => void;
+  readonly reject: (reason: unknown) => void;
+} {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((accept, decline) => {
+    resolve = accept;
+    reject = decline;
+  });
+  return { promise, resolve, reject };
+}
+
+function envelope(
+  phase: "started" | "completed",
+  completed: number,
+  total = 1,
+  requestId: string | number = 1,
+  requestMethod: "sync" | "importFiles" = "sync",
+): CoachOperationProgressNotificationEnvelope {
+  return {
+    jsonrpc: "2.0",
+    method: "coach.operationProgress",
+    params: { requestId, requestMethod, event: { phase, completed, total } },
+  };
+}
+
+function terminal(
+  result: SyncRpcResult = published,
+  id: string | number = 1,
+): CoachClientTerminalEnvelope {
+  return { jsonrpc: "2.0", id, result };
+}
+
+function remoteTerminal(id: string | number = 1): CoachClientTerminalEnvelope {
+  return {
+    jsonrpc: "2.0",
+    id,
+    error: { code: -32_000, message: "private daemon detail" },
+  };
+}
+
+function clientWith(
+  implementation: (options: SyncOptions) => Promise<SyncRpcResult>,
+): CoachClient & { readonly callMock: ReturnType<typeof vi.fn> } {
+  const callMock = vi.fn(async (method: string, params: unknown, options?: SyncOptions) => {
+    expect(method).toBe("sync");
+    expect(params).toEqual({});
+    expect(options).toBeDefined();
+    expect(options).not.toHaveProperty("signal");
+    return implementation(options!);
+  });
+  return {
+    handshake: {} as CoachClient["handshake"],
+    call: callMock as unknown as CoachClient["call"],
+    callMock,
+    close: vi.fn(async () => {}),
+  };
+}
+
+function providerWith(client: CoachClient): DesktopCoachClientProvider {
+  return {
+    getClient: vi.fn(async () => client),
+    reconnect: vi.fn(async () => client),
+    close: vi.fn(async () => {}),
+  };
+}
+
+async function exactCall(options: SyncOptions, result: SyncRpcResult): Promise<SyncRpcResult> {
+  options.onNotificationEnvelope?.(envelope("started", 0));
+  options.onNotificationEnvelope?.(envelope("completed", 1));
+  options.onTerminalEnvelope?.(terminal(result));
+  return result;
+}
+
+describe("training sync coordinator", () => {
+  it("queues synchronously, validates the exact progress sequence, and announces only after refresh", async () => {
+    const clientGate = deferred<CoachClient>();
+    const callGate = deferred<SyncRpcResult>();
+    const refreshGate = deferred<void>();
+    let options!: SyncOptions;
+    const client = clientWith((selected) => {
+      options = selected;
+      return callGate.promise;
+    });
+    const clients: DesktopCoachClientProvider = {
+      getClient: vi.fn(() => clientGate.promise),
+      reconnect: vi.fn(async () => client),
+      close: vi.fn(async () => {}),
+    };
+    const refreshTrainingContext = vi.fn(() => refreshGate.promise);
+    const states: TrainingSyncState[] = [];
+    const coordinator = createTrainingSyncCoordinator({ clients, refreshTrainingContext });
+    coordinator.subscribe((state) => states.push(state));
+
+    const first = coordinator.request();
+    const second = coordinator.request();
+    expect(first).toBe(second);
+    expect(states).toEqual([{ status: "idle" }, { status: "queued", operation: 1 }]);
+    expect(clients.getClient).toHaveBeenCalledTimes(1);
+    expect(client.callMock).not.toHaveBeenCalled();
+
+    clientGate.resolve(client);
+    await Promise.resolve();
+    expect(client.callMock).toHaveBeenCalledTimes(1);
+    expect(() => options.onNotificationEnvelope?.(envelope("started", 0))).not.toThrow();
+    expect(states.at(-1)).toEqual({ status: "running", operation: 1 });
+    expect(() => options.onNotificationEnvelope?.(envelope("completed", 1))).not.toThrow();
+    expect(states).toHaveLength(3);
+    expect(() => options.onTerminalEnvelope?.(terminal())).not.toThrow();
+    callGate.resolve(published);
+    await vi.waitFor(() => expect(refreshTrainingContext).toHaveBeenCalledTimes(1));
+    expect(states.at(-1)).toEqual({ status: "running", operation: 1 });
+
+    refreshGate.resolve();
+    await first;
+    expect(states.at(-1)).toEqual({
+      status: "succeeded",
+      operation: 1,
+      kind: "published",
+    });
+  });
+
+  it.each([
+    [true, true, { status: "succeeded", operation: 1, kind: "published" }],
+    [false, true, { status: "succeeded", operation: 1, kind: "no-change" }],
+    [true, false, { status: "failed", operation: 1, kind: "partial", retryable: true }],
+    [false, false, { status: "failed", operation: 1, kind: "operation", retryable: true }],
+  ] as const)(
+    "maps published=%s Reference-success=%s after exactly one refresh",
+    async (isPublished, referenceSucceeded, expected) => {
+      const result = { ...published, published: isPublished, referenceSucceeded };
+      const client = clientWith((options) => exactCall(options, result));
+      const refreshTrainingContext = vi.fn(async () => {});
+      const coordinator = createTrainingSyncCoordinator({
+        clients: providerWith(client),
+        refreshTrainingContext,
+      });
+      await coordinator.request();
+      expect(coordinator.getState()).toEqual(expected);
+      expect(refreshTrainingContext).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("treats an authoritative remote terminal as a fixed operation failure and refreshes once", async () => {
+    const client = clientWith(async (options) => {
+      options.onNotificationEnvelope?.(envelope("started", 0));
+      options.onTerminalEnvelope?.(remoteTerminal());
+      throw new CoachRpcRemoteError(-32_000, "private daemon detail", {
+        cursor: "private-cursor",
+      });
+    });
+    const refreshTrainingContext = vi.fn(async () => {});
+    const states: TrainingSyncState[] = [];
+    const coordinator = createTrainingSyncCoordinator({
+      clients: providerWith(client),
+      refreshTrainingContext,
+    });
+    coordinator.subscribe((state) => states.push(state));
+    await coordinator.request();
+    expect(coordinator.getState()).toEqual({
+      status: "failed",
+      operation: 1,
+      kind: "operation",
+      retryable: true,
+    });
+    expect(refreshTrainingContext).toHaveBeenCalledTimes(1);
+    expect(states).toEqual([
+      { status: "idle" },
+      { status: "queued", operation: 1 },
+      { status: "running", operation: 1 },
+      { status: "failed", operation: 1, kind: "operation", retryable: true },
+    ]);
+    expect(JSON.stringify(states)).not.toMatch(/private|cursor/u);
+  });
+
+  it("rejects completed progress followed by an error terminal as protocol-invalid", async () => {
+    const client = clientWith(async (options) => {
+      options.onNotificationEnvelope?.(envelope("started", 0));
+      options.onNotificationEnvelope?.(envelope("completed", 1));
+      options.onTerminalEnvelope?.(remoteTerminal());
+      throw new CoachRpcRemoteError(-32_000, "private daemon detail");
+    });
+    const refreshTrainingContext = vi.fn(async () => {});
+    const coordinator = createTrainingSyncCoordinator({
+      clients: providerWith(client),
+      refreshTrainingContext,
+    });
+    await coordinator.request();
+    expect(coordinator.getState()).toEqual({
+      status: "failed",
+      operation: 1,
+      kind: "protocol",
+      retryable: false,
+    });
+    expect(refreshTrainingContext).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    new CoachClientDisconnectedError(1006, "private close reason"),
+    new CoachClientCallTimeoutError("sync", 24 * 60 * 60_000),
+    new CoachClientCallAbortedError("sync"),
+  ])("settles %s without a terminal as indeterminate and never refreshes", async (failure) => {
+    const client = clientWith(async () => {
+      throw failure;
+    });
+    const refreshTrainingContext = vi.fn(async () => {});
+    const coordinator = createTrainingSyncCoordinator({
+      clients: providerWith(client),
+      refreshTrainingContext,
+    });
+    await coordinator.request();
+    expect(coordinator.getState()).toEqual({
+      status: "failed",
+      operation: 1,
+      kind: "indeterminate",
+      retryable: true,
+    });
+    expect(refreshTrainingContext).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["client acquisition", new Error("private acquisition failure")],
+    ["transport setup", new CoachClientTransportUnavailableError()],
+    ["handshake", new CoachClientHandshakeError()],
+    ["connection", new CoachClientDisconnectedError(1006, "private close reason")],
+  ])("maps a pre-admission %s failure to an ordinary retryable failure", async (_name, failure) => {
+    const clients: DesktopCoachClientProvider = {
+      getClient: vi.fn(async () => {
+        throw failure;
+      }),
+      reconnect: vi.fn(async () => {
+        throw failure;
+      }),
+      close: vi.fn(async () => {}),
+    };
+    const refreshTrainingContext = vi.fn(async () => {});
+    const coordinator = createTrainingSyncCoordinator({ clients, refreshTrainingContext });
+    await coordinator.request();
+    expect(coordinator.getState()).toEqual({
+      status: "failed",
+      operation: 1,
+      kind: "operation",
+      retryable: true,
+    });
+    expect(clients.reconnect).not.toHaveBeenCalled();
+    expect(refreshTrainingContext).not.toHaveBeenCalled();
+  });
+
+  it("uses a newer healthy provider generation after a pre-admission failure", async () => {
+    const successor = clientWith((options) => exactCall(options, published));
+    let current: CoachClient | undefined;
+    let acquisitions = 0;
+    const clients: DesktopCoachClientProvider = {
+      getClient: vi.fn(async () => {
+        acquisitions += 1;
+        if (acquisitions === 1) throw new CoachClientHandshakeError();
+        if (current === undefined) throw new Error("missing current provider generation");
+        return current;
+      }),
+      reconnect: vi.fn(async () => {
+        await current?.close();
+        return successor;
+      }),
+      close: vi.fn(async () => {}),
+    };
+    const coordinator = createTrainingSyncCoordinator({
+      clients,
+      refreshTrainingContext: vi.fn(async () => {}),
+    });
+    await coordinator.request();
+    expect(clients.reconnect).not.toHaveBeenCalled();
+    expect(successor.callMock).not.toHaveBeenCalled();
+
+    current = successor;
+    await coordinator.request();
+    expect(clients.getClient).toHaveBeenCalledTimes(2);
+    expect(clients.reconnect).not.toHaveBeenCalled();
+    expect(successor.close).not.toHaveBeenCalled();
+    expect(successor.callMock).toHaveBeenCalledTimes(1);
+    expect(coordinator.getState()).toEqual({
+      status: "succeeded",
+      operation: 2,
+      kind: "published",
+    });
+  });
+
+  it("recovers only on a later explicit retry and submits exactly one new call", async () => {
+    const failed = clientWith(async () => {
+      throw new CoachClientDisconnectedError(1006, "private close reason");
+    });
+    const recovered = clientWith((options) => exactCall(options, published));
+    const clients: DesktopCoachClientProvider = {
+      getClient: vi.fn(async () => failed),
+      reconnect: vi.fn(async () => recovered),
+      close: vi.fn(async () => {}),
+    };
+    const coordinator = createTrainingSyncCoordinator({
+      clients,
+      refreshTrainingContext: vi.fn(async () => {}),
+    });
+    await coordinator.request();
+    await Promise.resolve();
+    expect(failed.callMock).toHaveBeenCalledTimes(1);
+    expect(recovered.callMock).not.toHaveBeenCalled();
+    expect(clients.reconnect).not.toHaveBeenCalled();
+
+    await coordinator.request();
+    expect(failed.callMock).toHaveBeenCalledTimes(1);
+    expect(recovered.callMock).toHaveBeenCalledTimes(1);
+    expect(clients.reconnect).toHaveBeenCalledTimes(1);
+    expect(coordinator.getState()).toEqual({
+      status: "succeeded",
+      operation: 2,
+      kind: "published",
+    });
+  });
+
+  it.each([
+    ["reversed", [envelope("completed", 1), envelope("started", 0)]],
+    ["duplicate", [envelope("started", 0), envelope("started", 0), envelope("completed", 1)]],
+    [
+      "duplicate completed",
+      [envelope("started", 0), envelope("completed", 1), envelope("completed", 1)],
+    ],
+    ["skipped", [envelope("started", 0)]],
+    ["wrong started count", [envelope("started", 1), envelope("completed", 1)]],
+    ["wrong completed count", [envelope("started", 0), envelope("completed", 0)]],
+    ["wrong total", [envelope("started", 0, 2), envelope("completed", 1)]],
+    ["wrong method", [envelope("started", 0, 1, 1, "importFiles"), envelope("completed", 1)]],
+    ["cross request", [envelope("started", 0, 1, 1), envelope("completed", 1, 1, 2)]],
+  ])("latches %s progress as a protocol fault without observer throws", async (_name, events) => {
+    const client = clientWith(async (options) => {
+      for (const event of events) {
+        expect(() => options.onNotificationEnvelope?.(event)).not.toThrow();
+      }
+      expect(() => options.onTerminalEnvelope?.(terminal())).not.toThrow();
+      return published;
+    });
+    const refreshTrainingContext = vi.fn(async () => {});
+    const coordinator = createTrainingSyncCoordinator({
+      clients: providerWith(client),
+      refreshTrainingContext,
+    });
+    await coordinator.request();
+    expect(coordinator.getState()).toEqual({
+      status: "failed",
+      operation: 1,
+      kind: "protocol",
+      retryable: false,
+    });
+    expect(refreshTrainingContext).not.toHaveBeenCalled();
+    await coordinator.request();
+    expect(client.callMock).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ["no progress notifications", []],
+    ["completed(1,1) alone", [envelope("completed", 1)]],
+  ] as const)(
+    "rejects %s before a success terminal as a non-retryable protocol failure",
+    async (_name, events) => {
+      const client = clientWith(async (options) => {
+        for (const event of events) options.onNotificationEnvelope?.(event);
+        options.onTerminalEnvelope?.(terminal());
+        return published;
+      });
+      const refreshTrainingContext = vi.fn(async () => {});
+      const coordinator = createTrainingSyncCoordinator({
+        clients: providerWith(client),
+        refreshTrainingContext,
+      });
+      await coordinator.request();
+      expect(coordinator.getState()).toEqual({
+        status: "failed",
+        operation: 1,
+        kind: "protocol",
+        retryable: false,
+      });
+      expect(refreshTrainingContext).not.toHaveBeenCalled();
+    },
+  );
+
+  it("publishes one protocol failure for an invalid correlated terminal and replays it", async () => {
+    const client = clientWith(async (options) => {
+      options.onNotificationEnvelope?.(envelope("started", 0));
+      options.onNotificationEnvelope?.(envelope("completed", 1));
+      options.onTerminalEnvelope?.(terminal(published, 2));
+      return published;
+    });
+    const refreshTrainingContext = vi.fn(async () => {});
+    const states: TrainingSyncState[] = [];
+    const coordinator = createTrainingSyncCoordinator({
+      clients: providerWith(client),
+      refreshTrainingContext,
+    });
+    coordinator.subscribe((state) => states.push(state));
+    await coordinator.request();
+    expect(states).toEqual([
+      { status: "idle" },
+      { status: "queued", operation: 1 },
+      { status: "running", operation: 1 },
+      { status: "failed", operation: 1, kind: "protocol", retryable: false },
+    ]);
+    const replayed: TrainingSyncState[] = [];
+    coordinator.subscribe((state) => replayed.push(state));
+    expect(replayed).toEqual([
+      { status: "failed", operation: 1, kind: "protocol", retryable: false },
+    ]);
+    expect(refreshTrainingContext).not.toHaveBeenCalled();
+  });
+
+  it("requires an observed terminal even when a typed result resolves", async () => {
+    const refreshTrainingContext = vi.fn(async () => {});
+    const coordinator = createTrainingSyncCoordinator({
+      clients: providerWith(
+        clientWith(async (options) => {
+          options.onNotificationEnvelope?.(envelope("started", 0));
+          options.onNotificationEnvelope?.(envelope("completed", 1));
+          return published;
+        }),
+      ),
+      refreshTrainingContext,
+    });
+    await coordinator.request();
+    expect(coordinator.getState()).toMatchObject({ kind: "protocol", retryable: false });
+    expect(refreshTrainingContext).not.toHaveBeenCalled();
+  });
+
+  it("maps a client protocol terminal to a non-retryable protocol fault", async () => {
+    const coordinator = createTrainingSyncCoordinator({
+      clients: providerWith(
+        clientWith(async () => {
+          throw new CoachClientProtocolError();
+        }),
+      ),
+      refreshTrainingContext: vi.fn(async () => {}),
+    });
+    await coordinator.request();
+    expect(coordinator.getState()).toEqual({
+      status: "failed",
+      operation: 1,
+      kind: "protocol",
+      retryable: false,
+    });
+  });
+
+  it("turns a late current-epoch notification into a protocol fault", async () => {
+    let options!: SyncOptions;
+    const client = clientWith(async (selected) => {
+      options = selected;
+      return exactCall(selected, published);
+    });
+    const refreshTrainingContext = vi.fn(async () => {});
+    const coordinator = createTrainingSyncCoordinator({
+      clients: providerWith(client),
+      refreshTrainingContext,
+    });
+    await coordinator.request();
+    expect(coordinator.getState()).toMatchObject({ status: "succeeded" });
+    expect(() => options.onNotificationEnvelope?.(envelope("completed", 1))).not.toThrow();
+    expect(coordinator.getState()).toEqual({
+      status: "failed",
+      operation: 1,
+      kind: "protocol",
+      retryable: false,
+    });
+    expect(refreshTrainingContext).toHaveBeenCalledTimes(1);
+  });
+
+  it("turns a duplicate current-epoch terminal into a protocol fault", async () => {
+    let options!: SyncOptions;
+    const coordinator = createTrainingSyncCoordinator({
+      clients: providerWith(
+        clientWith(async (selected) => {
+          options = selected;
+          return exactCall(selected, published);
+        }),
+      ),
+      refreshTrainingContext: vi.fn(async () => {}),
+    });
+    await coordinator.request();
+    expect(() => options.onTerminalEnvelope?.(terminal())).not.toThrow();
+    expect(coordinator.getState()).toMatchObject({ kind: "protocol", retryable: false });
+  });
+
+  it("does not rewrite a verified outcome when the post-terminal refresh rejects", async () => {
+    const coordinator = createTrainingSyncCoordinator({
+      clients: providerWith(clientWith((options) => exactCall(options, published))),
+      refreshTrainingContext: vi.fn(async () => {
+        throw new Error("private refresh failure");
+      }),
+    });
+    await coordinator.request();
+    expect(coordinator.getState()).toEqual({
+      status: "succeeded",
+      operation: 1,
+      kind: "published",
+    });
+  });
+
+  it("ignores callbacks from an older epoch during an explicit new run", async () => {
+    const options: SyncOptions[] = [];
+    const retryGate = deferred<SyncRpcResult>();
+    let calls = 0;
+    const client = clientWith(async (selected) => {
+      options.push(selected);
+      calls += 1;
+      if (calls === 1) {
+        selected.onNotificationEnvelope?.(envelope("started", 0));
+        selected.onTerminalEnvelope?.(remoteTerminal());
+        throw new CoachRpcRemoteError(-32_000, "synthetic");
+      }
+      return retryGate.promise;
+    });
+    const coordinator = createTrainingSyncCoordinator({
+      clients: providerWith(client),
+      refreshTrainingContext: vi.fn(async () => {}),
+    });
+    await coordinator.request();
+    const retry = coordinator.request();
+    await Promise.resolve();
+    expect(options).toHaveLength(2);
+    expect(() => options[0]!.onNotificationEnvelope?.(envelope("started", 0))).not.toThrow();
+    options[1]!.onNotificationEnvelope?.(envelope("started", 0, 1, 2));
+    options[1]!.onNotificationEnvelope?.(envelope("completed", 1, 1, 2));
+    options[1]!.onTerminalEnvelope?.(terminal(published, 2));
+    retryGate.resolve(published);
+    await retry;
+    expect(coordinator.getState()).toEqual({
+      status: "succeeded",
+      operation: 2,
+      kind: "published",
+    });
+  });
+
+  it("makes acquisition, observer, refresh completion, and later requests inert after disposal", async () => {
+    const refreshGate = deferred<void>();
+    let options!: SyncOptions;
+    const client = clientWith(async (selected) => {
+      options = selected;
+      selected.onNotificationEnvelope?.(envelope("started", 0));
+      selected.onNotificationEnvelope?.(envelope("completed", 1));
+      selected.onTerminalEnvelope?.(terminal());
+      return published;
+    });
+    const states: TrainingSyncState[] = [];
+    const coordinator = createTrainingSyncCoordinator({
+      clients: providerWith(client),
+      refreshTrainingContext: () => refreshGate.promise,
+    });
+    coordinator.subscribe((state) => states.push(state));
+    const request = coordinator.request();
+    await Promise.resolve();
+    coordinator.dispose();
+    expect(() => options.onNotificationEnvelope?.(envelope("completed", 1))).not.toThrow();
+    refreshGate.resolve();
+    await request;
+    await coordinator.request();
+    expect(client.callMock).toHaveBeenCalledTimes(1);
+    expect(states.at(-1)).toEqual({ status: "running", operation: 1 });
+  });
+});

--- a/apps/desktop/tests/chat-panels.integration.test.ts
+++ b/apps/desktop/tests/chat-panels.integration.test.ts
@@ -104,14 +104,19 @@ function response(value: unknown): readonly string[] {
   return [JSON.stringify(value)];
 }
 
-function makeScript(calls: ScriptRequest[]): DesktopFixtureScript {
+type SyncOutcome = "no-change" | "partial";
+
+function makeScript(calls: ScriptRequest[], syncOutcome: SyncOutcome): DesktopFixtureScript {
   let units: "metric" | "imperial" = "metric";
   let hasSession = false;
+  let lastSynced: string = athleteState.lastSynced;
   return {
     onRequest(value) {
       const request = value as ScriptRequest;
       calls.push(request);
-      if (request.method === "getAthleteState") return response(athleteState);
+      if (request.method === "getAthleteState") {
+        return response({ ...athleteState, lastSynced });
+      }
       if (request.method === "getUnitsPreference") {
         return response({ value: units, source: units === "metric" ? "default" : "cycling" });
       }
@@ -156,12 +161,18 @@ ${"nonwrapping".repeat(36)}
         return response({ memoryFlushed: true });
       }
       if (request.method === "sync") {
-        return response({
-          schemaVersion: 1,
-          published: false,
-          referenceSucceeded: true,
-          requests: { store: 0, reference: 0, total: 0 },
-        });
+        lastSynced = "2026-07-19T07:55:01.000Z";
+        const partial = syncOutcome === "partial";
+        return [
+          JSON.stringify({ phase: "started", completed: 0, total: 1 }),
+          JSON.stringify({ phase: "completed", completed: 1, total: 1 }),
+          JSON.stringify({
+            schemaVersion: 1,
+            published: partial,
+            referenceSucceeded: !partial,
+            requests: { store: 1, reference: 1, total: 2 },
+          }),
+        ];
       }
       if (request.method === "importFiles") {
         return response({
@@ -194,10 +205,11 @@ async function launch(input: {
   readonly width: number;
   readonly height: number;
   readonly reducedMotion: boolean;
+  readonly syncOutcome?: SyncOutcome;
 }): Promise<{ readonly fixture: RunningDesktopFixture; readonly calls: ScriptRequest[] }> {
   const calls: ScriptRequest[] = [];
   const fixture = await launchDesktopFixture({
-    script: makeScript(calls),
+    script: makeScript(calls, input.syncOutcome ?? "no-change"),
     token,
     width: input.width,
     height: input.height,
@@ -381,7 +393,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
     ]);
   }, 30_000);
 
-  it("streams chat, persists units, preserves focus, and fits desktop geometry", async () => {
+  it("streams chat, proves no-change sync, preserves focus, and fits desktop geometry", async () => {
     const { fixture, calls } = await launch({ width: 1440, height: 900, reducedMotion: false });
     const initial = await fixture.evaluate<{
       readonly location: string;
@@ -788,6 +800,29 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       readonly closedFocus: string | null;
       readonly overflow: boolean;
       readonly units: string;
+      readonly sync: {
+        readonly buttonResident: boolean;
+        readonly queued: string;
+        readonly runningObserved: boolean;
+        readonly terminal: string;
+        readonly label: string;
+        readonly atomicLiveRegion: boolean;
+        readonly busyQueued: boolean;
+        readonly busyCleared: boolean;
+        readonly keyboardFocusRestored: boolean;
+        readonly noChangeTerminalObservations: number;
+        readonly noChangeTerminalOnlyAfterRefresh: boolean;
+        readonly onlyLastSyncedChanged: boolean;
+        readonly trainingPanelsUnchanged: boolean;
+        readonly asOfUnchanged: boolean;
+        readonly asOfBefore: string;
+        readonly asOfAfter: string;
+        readonly lastSyncedBefore: string;
+        readonly lastSyncedAfter: string;
+        readonly statusWraps: boolean;
+        readonly buttonReachable: boolean;
+        readonly drawerOverflow: boolean;
+      };
     }>(`
       const opener = document.querySelector(".drawer-toggle");
       opener.click();
@@ -798,6 +833,81 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
         label: drawer.getAttribute("aria-label"),
         order: [...drawer.querySelectorAll(".context-panel > h3")].map((node) => node.textContent),
         spineWidth: document.querySelector(".data-spine").getBoundingClientRect().width,
+      };
+      const syncButton = drawer.querySelector(".training-sync__button");
+      const syncStatus = drawer.querySelector(".training-sync__status");
+      const metadataText = () => [...drawer.querySelectorAll(".drawer-metadata__item")].map((node) => node.textContent ?? "");
+      const metadataChildrenText = () => [...drawer.querySelector(".drawer-metadata").children].map((node) => node.textContent ?? "");
+      const metadataBefore = metadataChildrenText();
+      const panelsBefore = [...drawer.querySelectorAll(".context-panel__body")].map((node) => node.textContent ?? "");
+      const asOfBefore = metadataText().find((value) => value.startsWith("As of ")) ?? "";
+      const lastSyncedBefore = metadataText().find((value) => value.startsWith("Last synced ")) ?? "";
+      const liveValues = [];
+      const noChangeCopy = "Local training-data processing completed.";
+      let noChangeTerminalObservations = 0;
+      let noChangeTerminalBeforeRefresh = false;
+      const liveObserver = new MutationObserver(() => {
+        const value = syncStatus.textContent ?? "";
+        liveValues.push(value);
+        if (value === noChangeCopy) {
+          noChangeTerminalObservations += 1;
+          const currentLastSynced = metadataText().find((item) => item.startsWith("Last synced ")) ?? "";
+          if (currentLastSynced === lastSyncedBefore) noChangeTerminalBeforeRefresh = true;
+        }
+      });
+      liveObserver.observe(syncStatus, { childList: true, characterData: true, subtree: true });
+      syncButton.focus();
+      syncButton.click();
+      const queued = syncStatus.textContent ?? "";
+      const busyQueued = syncButton.disabled && syncButton.getAttribute("aria-busy") === "true";
+      syncButton.click();
+      syncButton.blur();
+      const syncDeadline = Date.now() + 5000;
+      while (syncButton.disabled && Date.now() < syncDeadline) {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+      }
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      liveObserver.disconnect();
+      const asOfAfter = metadataText().find((value) => value.startsWith("As of ")) ?? "";
+      const lastSyncedAfter = metadataText().find((value) => value.startsWith("Last synced ")) ?? "";
+      const metadataAfter = metadataChildrenText();
+      const panelsAfter = [...drawer.querySelectorAll(".context-panel__body")].map((node) => node.textContent ?? "");
+      syncStatus.scrollIntoView({ block: "nearest" });
+      const syncButtonRect = syncButton.getBoundingClientRect();
+      const drawerRect = drawer.getBoundingClientRect();
+      const syncResult = {
+        buttonResident: syncButton === drawer.querySelector(".training-sync__button"),
+        queued,
+        runningObserved: liveValues.includes("Syncing training data…"),
+        terminal: syncStatus.textContent ?? "",
+        label: syncButton.textContent ?? "",
+        atomicLiveRegion:
+          syncStatus.getAttribute("role") === "status" &&
+          syncStatus.getAttribute("aria-live") === "polite" &&
+          syncStatus.getAttribute("aria-atomic") === "true",
+        busyQueued,
+        busyCleared: !syncButton.hasAttribute("aria-busy") && !syncButton.disabled,
+        keyboardFocusRestored: document.activeElement === syncButton,
+        noChangeTerminalObservations,
+        noChangeTerminalOnlyAfterRefresh:
+          noChangeTerminalObservations === 1 &&
+          !noChangeTerminalBeforeRefresh &&
+          lastSyncedAfter !== lastSyncedBefore,
+        onlyLastSyncedChanged:
+          metadataBefore.length === metadataAfter.length &&
+          metadataBefore.filter((value, index) => value !== metadataAfter[index]).length === 1 &&
+          metadataBefore.find((value) => value.startsWith("Last synced ")) === lastSyncedBefore &&
+          metadataAfter.find((value) => value.startsWith("Last synced ")) === lastSyncedAfter,
+        trainingPanelsUnchanged: JSON.stringify(panelsBefore) === JSON.stringify(panelsAfter),
+        asOfUnchanged: asOfBefore === asOfAfter,
+        asOfBefore,
+        asOfAfter,
+        lastSyncedBefore,
+        lastSyncedAfter,
+        statusWraps: syncStatus.scrollWidth <= syncStatus.clientWidth,
+        buttonReachable:
+          syncButtonRect.top >= drawerRect.top && syncButtonRect.bottom <= drawerRect.bottom,
+        drawerOverflow: drawer.scrollWidth > drawer.clientWidth,
       };
       const imperial = drawer.querySelector('input[value="imperial"]');
       imperial.click();
@@ -811,6 +921,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
         closedFocus: document.activeElement?.getAttribute("aria-label") ?? null,
         overflow: document.documentElement.scrollWidth > document.documentElement.clientWidth,
         units: imperial.checked ? imperial.value : "",
+        sync: syncResult,
       };
     `);
     expect(drawer).toEqual({
@@ -822,7 +933,38 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       closedFocus: "Open training data",
       overflow: false,
       units: "imperial",
+      sync: {
+        buttonResident: true,
+        queued: "Sync queued.",
+        runningObserved: true,
+        terminal: "Local training-data processing completed.",
+        label: "Sync again",
+        atomicLiveRegion: true,
+        busyQueued: true,
+        busyCleared: true,
+        keyboardFocusRestored: true,
+        noChangeTerminalObservations: 1,
+        noChangeTerminalOnlyAfterRefresh: true,
+        onlyLastSyncedChanged: true,
+        trainingPanelsUnchanged: true,
+        asOfUnchanged: true,
+        asOfBefore: "As of 2026-07-19",
+        asOfAfter: "As of 2026-07-19",
+        lastSyncedBefore: "Last synced 2026-07-19 07:55:00 UTC",
+        lastSyncedAfter: "Last synced 2026-07-19 07:55:01 UTC",
+        statusWraps: true,
+        buttonReachable: true,
+        drawerOverflow: false,
+      },
     });
+    const syncCallIndex = calls.findIndex((call) => call.method === "sync");
+    expect(syncCallIndex).toBeGreaterThan(-1);
+    expect(calls.filter((call) => call.method === "sync")).toEqual([
+      { jsonrpc: "2.0", method: "sync", params: {} },
+    ]);
+    expect(
+      calls.slice(syncCallIndex + 1).filter((call) => call.method === "getAthleteState"),
+    ).toHaveLength(1);
     expect(calls.filter((call) => call.method === "chat")).toEqual([
       {
         jsonrpc: "2.0",
@@ -854,15 +996,54 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       { jsonrpc: "2.0", method: "setUnitsPreference", params: { value: "imperial" } },
     ]);
     await fixture.setViewport(720, 800);
-    expect(
-      await fixture.evaluate<{ readonly documentOverflow: boolean; readonly topbarFits: boolean }>(`
+    const compactDrawerGeometry = await fixture.evaluate<{
+      readonly documentOverflow: boolean;
+      readonly topbarFits: boolean;
+      readonly drawerOpen: boolean;
+      readonly buttonResident: boolean;
+      readonly buttonReachable: boolean;
+      readonly noChangeStatus: boolean;
+      readonly statusFits: boolean;
+      readonly horizontalOverflow: boolean;
+    }>(`
+      const compactOpener = document.querySelector(".drawer-toggle");
+      compactOpener.click();
+      await new Promise((resolve) => setTimeout(resolve, 250));
       const topbar = document.querySelector(".topbar");
+      const compactDrawer = document.querySelector("#training-context-drawer");
+      const compactButton = compactDrawer.querySelector(".training-sync__button");
+      const compactStatus = compactDrawer.querySelector(".training-sync__status");
+      const compactRegion = compactDrawer.querySelector(".training-sync");
+      const drawerRect = compactDrawer.getBoundingClientRect();
+      const buttonRect = compactButton.getBoundingClientRect();
       return {
         documentOverflow: document.documentElement.scrollWidth > document.documentElement.clientWidth,
         topbarFits: topbar.scrollWidth <= topbar.clientWidth,
+        drawerOpen: compactDrawer.open,
+        buttonResident: compactDrawer.querySelectorAll(".training-sync__button").length === 1,
+        buttonReachable:
+          buttonRect.left >= drawerRect.left &&
+          buttonRect.right <= drawerRect.right &&
+          buttonRect.top >= drawerRect.top &&
+          buttonRect.bottom <= Math.min(drawerRect.bottom, window.innerHeight),
+        noChangeStatus: compactStatus.textContent === "Local training-data processing completed.",
+        statusFits: compactStatus.scrollWidth <= compactStatus.clientWidth,
+        horizontalOverflow:
+          compactDrawer.scrollWidth > compactDrawer.clientWidth ||
+          compactRegion.scrollWidth > compactRegion.clientWidth ||
+          compactStatus.scrollWidth > compactStatus.clientWidth,
       };
-    `),
-    ).toEqual({ documentOverflow: false, topbarFits: true });
+    `);
+    expect(compactDrawerGeometry).toEqual({
+      documentOverflow: false,
+      topbarFits: true,
+      drawerOpen: true,
+      buttonResident: true,
+      buttonReachable: true,
+      noChangeStatus: true,
+      statusFits: true,
+      horizontalOverflow: false,
+    });
     const base = await realpath(process.platform === "darwin" ? "/tmp" : tmpdir());
     const screenshotRoot = await mkdtemp(join(base, "eap-shot-"));
     scratchPaths.push(screenshotRoot);
@@ -874,6 +1055,85 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
     for (const name of ["location", "console", "stdout", "stderr", "dom"] as const) {
       expect(fixture.readCapturedSurface(name)).not.toContain(token);
     }
+    expect(await fixture.close()).toEqual({ livePids: [], listenerCount: 0 });
+    fixtures.splice(fixtures.indexOf(fixture), 1);
+  }, 30_000);
+
+  it("keeps the long partial-sync status reachable and wrapped at 720×800", async () => {
+    const { fixture, calls } = await launch({
+      width: 720,
+      height: 800,
+      reducedMotion: false,
+      syncOutcome: "partial",
+    });
+    const compact = await fixture.evaluate<{
+      readonly drawerOpen: boolean;
+      readonly buttonResident: boolean;
+      readonly buttonReachable: boolean;
+      readonly terminal: string;
+      readonly label: string;
+      readonly statusWrapped: boolean;
+      readonly keyboardFocusRestored: boolean;
+      readonly horizontalOverflow: boolean;
+    }>(`
+      const opener = document.querySelector(".drawer-toggle");
+      opener.click();
+      const drawer = document.querySelector("#training-context-drawer");
+      const syncButton = drawer.querySelector(".training-sync__button");
+      const syncStatus = drawer.querySelector(".training-sync__status");
+      const syncRegion = drawer.querySelector(".training-sync");
+      syncButton.focus();
+      syncButton.click();
+      syncButton.blur();
+      const deadline = Date.now() + 5000;
+      while (syncButton.disabled && Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+      }
+      await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+      syncStatus.scrollIntoView({ block: "nearest" });
+      const drawerRect = drawer.getBoundingClientRect();
+      const buttonRect = syncButton.getBoundingClientRect();
+      const statusRect = syncStatus.getBoundingClientRect();
+      const lineHeight = Number.parseFloat(getComputedStyle(syncStatus).lineHeight);
+      return {
+        drawerOpen: drawer.open,
+        buttonResident: drawer.querySelectorAll(".training-sync__button").length === 1,
+        buttonReachable:
+          buttonRect.left >= drawerRect.left &&
+          buttonRect.right <= drawerRect.right &&
+          buttonRect.top >= drawerRect.top &&
+          buttonRect.bottom <= Math.min(drawerRect.bottom, window.innerHeight),
+        terminal: syncStatus.textContent ?? "",
+        label: syncButton.textContent ?? "",
+        statusWrapped:
+          statusRect.height >= lineHeight * 1.9 &&
+          syncStatus.scrollWidth <= syncStatus.clientWidth,
+        keyboardFocusRestored: document.activeElement === syncButton,
+        horizontalOverflow:
+          document.documentElement.scrollWidth > document.documentElement.clientWidth ||
+          drawer.scrollWidth > drawer.clientWidth ||
+          syncRegion.scrollWidth > syncRegion.clientWidth ||
+          syncStatus.scrollWidth > syncStatus.clientWidth,
+      };
+    `);
+    expect(compact).toEqual({
+      drawerOpen: true,
+      buttonResident: true,
+      buttonReachable: true,
+      terminal: "Training-data processing partially completed. Try again to finish.",
+      label: "Try again",
+      statusWrapped: true,
+      keyboardFocusRestored: true,
+      horizontalOverflow: false,
+    });
+    const syncCallIndex = calls.findIndex((call) => call.method === "sync");
+    expect(syncCallIndex).toBeGreaterThan(-1);
+    expect(calls.filter((call) => call.method === "sync")).toEqual([
+      { jsonrpc: "2.0", method: "sync", params: {} },
+    ]);
+    expect(
+      calls.slice(syncCallIndex + 1).filter((call) => call.method === "getAthleteState"),
+    ).toHaveLength(1);
     expect(await fixture.close()).toEqual({ livePids: [], listenerCount: 0 });
     fixtures.splice(fixtures.indexOf(fixture), 1);
   }, 30_000);


### PR DESCRIPTION
## Summary

- add a resident **Sync now** action to the Training context drawer
- share one replayable sync coordinator between first-run and manual sync, with strict progress/terminal correlation and bounded reconnect ownership
- refresh training context once after the terminal result so successful, no-change, partial, failed, and indeterminate outcomes stay truthful and accessible
- preserve keyboard focus, atomic polite announcements, compact drawer geometry, and completed first-sync isolation

## Verification

- `pnpm check`
- Desktop renderer: 230 tests passed
- real Electron chat-panel integration: 4 tests passed, including the existing IME-composition scenario
- independent protocol, concurrency, and renderer UX reviews passed after accepted blockers were repaired

CI owns the full repository test suite.
