### PR TITLE
fix(desktop): honor athlete home when data dir is omitted

### DIFF
--- a/.changeset/desktop-default-data-dir.md
+++ b/.changeset/desktop-default-data-dir.md
@@ -1,0 +1,8 @@
+---
+"cycling-coach": patch
+"@enduragent/coach": patch
+"@enduragent/core": patch
+"@enduragent/desktop": patch
+---
+
+User-facing: Desktop can now start from an existing configuration that omits `data_dir`.

--- a/packages/coach/src/local-runner.ts
+++ b/packages/coach/src/local-runner.ts
@@ -115,7 +115,9 @@ export async function withLocalCoach<T>(
             configPath: readiness.configPath,
           };
         }
-        const config = loadConfig(context.home.configDir);
+        const config = loadConfig(context.home.configDir, {
+          defaultDataDir: context.home.root,
+        });
         if (JSON.stringify(engineConfigFromConfig(config)) !== JSON.stringify(readiness.config)) {
           throw new TypeError("Ready engine configuration changed before engine construction.");
         }

--- a/packages/coach/src/readiness.ts
+++ b/packages/coach/src/readiness.ts
@@ -13,14 +13,12 @@ function isMap(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-export async function checkHomeReadiness(
-  home: AthleteHome,
-): Promise<ReadinessResult> {
+export async function checkHomeReadiness(home: AthleteHome): Promise<ReadinessResult> {
   const configPath = join(home.configDir, "config.yaml");
   try {
     const parsedYaml = parseYaml(await readFile(configPath, "utf8")) as unknown;
     if (!isMap(parsedYaml)) return { status: "not-configured", configPath };
-    const config = loadConfig(home.configDir);
+    const config = loadConfig(home.configDir, { defaultDataDir: home.root });
     const profileName = config.llm.authProfile;
     if (profileName !== undefined) {
       const profiles = JSON.parse(

--- a/packages/coach/tests/composition.test.ts
+++ b/packages/coach/tests/composition.test.ts
@@ -347,6 +347,23 @@ afterEach(async () => {
 });
 
 describe("local coach composition", () => {
+  it("rejects configured data directories outside the selected athlete home", async () => {
+    const home = await freshHome();
+    const otherHome = await freshHome();
+    const dependencies: LocalCoachCompositionDependencies = {};
+
+    for (const dataDir of ["", "relative", home.configDir, otherHome.root]) {
+      await expect(
+        compose(home, dependencies, fakeContext(home), undefined, {
+          ...config(home),
+          dataDir,
+        }),
+      ).rejects.toThrowError(
+        new TypeError("Configured data directory does not match the selected athlete home."),
+      );
+    }
+  });
+
   it("reuses the lifecycle writer in the first store window without nested acquisition", async () => {
     const home = await freshHome();
     const context = fakeContext(home);

--- a/packages/coach/tests/first-run-serve.integration.test.ts
+++ b/packages/coach/tests/first-run-serve.integration.test.ts
@@ -1,13 +1,6 @@
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { createConnection, createServer } from "node:net";
-import {
-  mkdir,
-  mkdtemp,
-  readFile,
-  realpath,
-  rm,
-  writeFile,
-} from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, realpath, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -65,7 +58,7 @@ async function unixConnectAvailable(): Promise<boolean> {
   }
 }
 
-const hasSockets = await loopbackAvailable() && await unixConnectAvailable();
+const hasSockets = (await loopbackAvailable()) && (await unixConnectAvailable());
 
 afterEach(async () => {
   for (const child of children) child.kill("SIGKILL");
@@ -83,7 +76,7 @@ function childExit(child: ChildProcessWithoutNullStreams): Promise<{
 }
 
 describe.skipIf(!hasSockets)("first-run serve process", () => {
-  it("boots a fresh home through /healthz and shuts down cleanly", async () => {
+  it("boots an existing config without data_dir through /healthz without clobbering it", async () => {
     const scratchRoot = process.platform === "darwin" ? "/private/tmp" : await realpath(tmpdir());
     const scratch = await mkdtemp(join(scratchRoot, "ea-serve-"));
     roots.push(scratch);
@@ -96,20 +89,27 @@ describe.skipIf(!hasSockets)("first-run serve process", () => {
       mkdir(join(scratch, "cache"), { recursive: true }),
       mkdir(join(scratch, "tmp"), { recursive: true }),
     ]);
-    await writeFile(join(configDir, "config.yaml"), [
-      "data_source: store",
-      `data_dir: ${JSON.stringify(home)}`,
-      "llm:",
-      "  provider: anthropic",
-      "  model: synthetic",
-      "  api_key: synthetic",
-      "intervals:",
-      "  api_key: synthetic",
-      "  athlete_id: synthetic",
-      "session:",
-      "  timezone: UTC",
-      "",
-    ].join("\n"));
+    const configBytes = Buffer.from(
+      [
+        "data_source: store",
+        "llm:",
+        "  provider: anthropic",
+        "  model: synthetic",
+        "  api_key: synthetic",
+        "intervals:",
+        "  api_key: synthetic",
+        "  athlete_id: synthetic",
+        "session:",
+        "  timezone: UTC",
+        "",
+      ].join("\n"),
+    );
+    const configPath = join(configDir, "config.yaml");
+    await writeFile(configPath, configBytes, { mode: 0o600 });
+    const configBeforeServe = await stat(configPath);
+    const configInodeBeforeServe = configBeforeServe.ino;
+    const configModeBeforeServe = configBeforeServe.mode & 0o777;
+    expect(configModeBeforeServe).toBe(0o600);
 
     const child = spawn(process.execPath, [binary, "serve"], {
       env: {
@@ -130,14 +130,20 @@ describe.skipIf(!hasSockets)("first-run serve process", () => {
     const exited = childExit(child);
     let stdout = "";
     let stderr = "";
-    child.stdout.on("data", (chunk) => { stdout += String(chunk); });
-    child.stderr.on("data", (chunk) => { stderr += String(chunk); });
+    child.stdout.on("data", (chunk) => {
+      stdout += String(chunk);
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += String(chunk);
+    });
 
     const deadline = Date.now() + 15_000;
     let health: Response | undefined;
     while (Date.now() < deadline && health === undefined) {
       if (child.exitCode !== null || child.signalCode !== null) {
-        throw new Error(`serve exited before healthz: ${child.exitCode}/${child.signalCode}\n${stdout}${stderr}`);
+        throw new Error(
+          `serve exited before healthz: ${child.exitCode}/${child.signalCode}\n${stdout}${stderr}`,
+        );
       }
       try {
         const port = Number((await readFile(join(configDir, PORT_FILE_NAME), "utf8")).trim());
@@ -168,7 +174,15 @@ describe.skipIf(!hasSockets)("first-run serve process", () => {
     expect(result).toEqual({ code: 0, signal: null });
     expect(stdout).toBe("");
     expect(stderr).not.toContain("coach store writer is already active");
-    await expect(readFile(join(configDir, PORT_FILE_NAME), "utf8")).rejects.toMatchObject({ code: "ENOENT" });
-    await expect(readFile(join(configDir, LOCKFILE_NAME), "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+    const configAfterServe = await stat(configPath);
+    await expect(readFile(configPath)).resolves.toEqual(configBytes);
+    expect(configAfterServe.ino).toBe(configInodeBeforeServe);
+    expect(configAfterServe.mode & 0o777).toBe(configModeBeforeServe);
+    await expect(readFile(join(configDir, PORT_FILE_NAME), "utf8")).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    await expect(readFile(join(configDir, LOCKFILE_NAME), "utf8")).rejects.toMatchObject({
+      code: "ENOENT",
+    });
   }, 25_000);
 });

--- a/packages/coach/tests/local-runner.test.ts
+++ b/packages/coach/tests/local-runner.test.ts
@@ -263,6 +263,9 @@ describe("local coach runner", () => {
       "store-close",
       "writer-release",
     ]);
+    expect(mocks.loadConfig).toHaveBeenCalledExactlyOnceWith(selectedHome.configDir, {
+      defaultDataDir: selectedHome.root,
+    });
   });
 
   it("releases the writer after migration throws without opening later stages", async () => {
@@ -372,6 +375,27 @@ describe("local coach runner", () => {
     expect(ready.status).toBe("ready");
     expect(actualCore.loadConfig(selectedHome.configDir).dataDir).toBe(selectedHome.root);
     expect(actualCore.loadConfig.length).toBe(0);
+  });
+
+  it("loads an absent readiness data_dir against the selected athlete root", async () => {
+    const actualReadiness =
+      await vi.importActual<typeof import("../src/readiness.js")>("../src/readiness.js");
+    const actualCore = await vi.importActual<typeof import("@enduragent/core")>("@enduragent/core");
+    mocks.loadConfig.mockImplementation(actualCore.loadConfig);
+    mocks.project.mockImplementation(actualCore.engineConfigFromConfig);
+    await mkdir(selectedHome.configDir, { recursive: true });
+    await writeFile(
+      join(selectedHome.configDir, "config.yaml"),
+      "data_source: store\nllm:\n  provider: anthropic\n",
+      { mode: 0o600 },
+    );
+
+    await expect(actualReadiness.checkHomeReadiness(selectedHome)).resolves.toMatchObject({
+      status: "ready",
+    });
+    expect(mocks.loadConfig).toHaveBeenCalledExactlyOnceWith(selectedHome.configDir, {
+      defaultDataDir: selectedHome.root,
+    });
   });
 
   it("rethrows the exact operation object only after lifecycle, store, and writer cleanup", async () => {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -39,6 +39,10 @@ export interface Config extends EffectiveRuntimeConfig {
   dataDir: string;
 }
 
+export interface LoadConfigOptions {
+  defaultDataDir?: string;
+}
+
 // ============================================================================
 // CONFIG LOADING
 // ============================================================================
@@ -107,7 +111,10 @@ function assignFieldByPath(cfg: Config, path: SecretFieldPath, value: string): v
   else if (path === "telegram.bot_token") cfg.telegram.botToken = value;
 }
 
-export function loadConfig(configDir: string = CONFIG_DIR): Config {
+export function loadConfig(
+  configDir: string = CONFIG_DIR,
+  options: LoadConfigOptions = {},
+): Config {
   const yaml = readConfigYamlFrom(configDir);
   const dataSource = resolveDataSource(yaml.data_source);
   const llmYaml = (yaml.llm as Record<string, unknown>) ?? {};
@@ -228,7 +235,9 @@ export function loadConfig(configDir: string = CONFIG_DIR): Config {
     telegram: {
       botToken: telegramBotToken,
     },
-    dataDir: (yaml.data_dir as string) ?? configDir,
+    dataDir: Object.hasOwn(yaml, "data_dir")
+      ? ((yaml.data_dir as string) ?? configDir)
+      : (options.defaultDataDir ?? configDir),
   };
 
   if (pending.size > 0) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -153,7 +153,7 @@ export {
   readConfigYaml,
   resolveConfigSecrets,
 } from "./config.js";
-export type { Config } from "./config.js";
+export type { Config, LoadConfigOptions } from "./config.js";
 export { DATA_SOURCES, resolveDataSource } from "./config.js";
 export type { DataSource } from "./config.js";
 export {

--- a/packages/core/tests/config.data-dir.test.ts
+++ b/packages/core/tests/config.data-dir.test.ts
@@ -1,0 +1,63 @@
+import { mkdir, mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const roots: string[] = [];
+
+async function freshDirectory(prefix: string): Promise<string> {
+  const directory = await mkdtemp(join(await realpath(tmpdir()), prefix));
+  roots.push(directory);
+  return directory;
+}
+
+afterEach(async () => {
+  vi.unstubAllEnvs();
+  vi.resetModules();
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("config data directory", () => {
+  it("preserves no-argument and one-argument legacy defaults and runtime arity", async () => {
+    const defaultConfigDir = await freshDirectory("core-default-config-");
+    const suppliedConfigDir = await freshDirectory("core-supplied-config-");
+    vi.stubEnv("CYCLING_COACH_HOME", defaultConfigDir);
+    vi.resetModules();
+    const { loadConfig } = await import("../src/config.js");
+
+    expect(loadConfig.length).toBe(0);
+    expect(loadConfig().dataDir).toBe(defaultConfigDir);
+    expect(loadConfig(suppliedConfigDir).dataDir).toBe(suppliedConfigDir);
+  });
+
+  it("uses the caller default only when data_dir is absent", async () => {
+    const configDir = await freshDirectory("core-context-config-");
+    const athleteRoot = await freshDirectory("core-context-root-");
+    await mkdir(configDir, { recursive: true });
+    await writeFile(join(configDir, "config.yaml"), "data_source: store\n", { mode: 0o600 });
+    const { loadConfig } = await import("../src/config.js");
+
+    expect(loadConfig(configDir, { defaultDataDir: athleteRoot }).dataDir).toBe(athleteRoot);
+  });
+
+  it("preserves explicit YAML values and keeps null on its legacy fallback", async () => {
+    const configDir = await freshDirectory("core-explicit-config-");
+    const athleteRoot = await freshDirectory("core-explicit-root-");
+    const otherRoot = await freshDirectory("core-other-root-");
+    const { loadConfig } = await import("../src/config.js");
+    const cases = [
+      { yaml: "data_dir: null\n", expected: configDir },
+      { yaml: 'data_dir: ""\n', expected: "" },
+      { yaml: "data_dir: relative\n", expected: "relative" },
+      { yaml: `data_dir: ${JSON.stringify(configDir)}\n`, expected: configDir },
+      { yaml: `data_dir: ${JSON.stringify(otherRoot)}\n`, expected: otherRoot },
+    ];
+
+    for (const testCase of cases) {
+      await writeFile(join(configDir, "config.yaml"), testCase.yaml, { mode: 0o600 });
+      expect(loadConfig(configDir, { defaultDataDir: athleteRoot }).dataDir).toBe(
+        testCase.expected,
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- add an opt-in default data-directory option while preserving both legacy `loadConfig` calling forms and runtime arity
- use the selected athlete home consistently in readiness and local engine construction when `data_dir` is absent
- keep explicit values and the existing home-isolation guard fail closed, without rewriting configuration or changing migration behavior
- prove a real serve process reaches health and leaves the existing configuration byte-identical, on the same inode, with mode `0600`

## Verification

- `pnpm check`
- focused Core and Coach suites: 63 tests passed
- real serve-process regression: passed
- independent compatibility/path-safety, startup-composition, and persistence/QA reviews passed after the no-clobber proof was completed

CI owns the full repository test suite.
