### PR TITLE
Harden dependency scan coverage timeout

### DIFF
--- a/tools/check-package-deps.test.ts
+++ b/tools/check-package-deps.test.ts
@@ -497,7 +497,7 @@ describe("matchers", () => {
 });
 
 describe("real repository", () => {
-  it("the committed workspace is clean", () => {
+  it("the committed workspace is clean", { timeout: 15_000 }, () => {
     expect(main([])).toBe(0);
   });
 


### PR DESCRIPTION
## Summary

- Give the full-repository dependency-graph assertion a bounded 15-second timeout so whole-suite coverage contention cannot trip Vitest's generic five-second limit after the scan succeeds.
- Keep production dependency rules, scanner behavior, global test configuration, and coverage configuration unchanged.

## Test plan

- [x] `pnpm exec vitest run tools/check-package-deps.test.ts` (51 passed)
- [x] `pnpm exec vitest run tools/check-package-deps.test.ts --coverage` (51 passed; 7.98 seconds test time)
- [x] `pnpm exec oxfmt --check tools/check-package-deps.test.ts`
- [x] `pnpm exec oxlint tools/check-package-deps.test.ts`
- [x] `git diff --check`
