### PR TITLE
feat(desktop): add ongoing ride file imports

### DIFF
--- a/.changeset/desktop-ongoing-ride-import.md
+++ b/.changeset/desktop-ongoing-ride-import.md
@@ -1,0 +1,6 @@
+---
+"cycling-coach": patch
+"@enduragent/desktop-renderer": patch
+---
+
+User-facing: Ride files can now be imported from Desktop at any time, with accurate imported and quarantined results.

--- a/apps/desktop-renderer/src/index.ts
+++ b/apps/desktop-renderer/src/index.ts
@@ -8,6 +8,7 @@ import "./chat/styles.css";
 import "./training-context/styles.css";
 import "./spend-meter/styles.css";
 import "./onboarding/onboarding.css";
+import "./ride-import.css";
 import { createChatController } from "./chat/controller.js";
 import { mountChatView } from "./chat/view.js";
 import { createDesktopCoachClientProvider } from "./coach-client.js";
@@ -20,6 +21,11 @@ import { mountTrainingContextView } from "./training-context/view.js";
 import { createTrainingSyncCoordinator } from "./training-sync.js";
 import { createSpendMeterController } from "./spend-meter/controller.js";
 import { createSpendMeterView } from "./spend-meter/view.js";
+import {
+  createRideImportController,
+  mountResidentRideImport,
+  subscribeToDroppedRideImports,
+} from "./ride-import.js";
 
 function one<T extends Element>(selector: string, kind: { new (): T }): T {
   const matches = document.querySelectorAll(selector);
@@ -231,13 +237,27 @@ setup.type = "button";
 setup.className = "setup-button";
 setup.textContent = "Setup";
 topbarActions.insertBefore(setup, connectionStatus);
+const rideImports = createRideImportController(onboardingBridge);
+const residentRideImport = mountResidentRideImport({
+  document,
+  actionHost: topbarActions,
+  before: connectionStatus,
+  imports: rideImports,
+});
 const onboarding = mountOnboarding({
   document,
   bridge: onboardingBridge,
+  rideImports,
+  onRideImportPresentationChange: (presenting) => residentRideImport.setSuppressed(presenting),
   opener: setup,
   onComplete: (completion) => void firstSyncController.start(completion),
 });
 setup.addEventListener("click", () => void onboarding.open());
+const disposeDroppedRideImports = subscribeToDroppedRideImports({
+  subscribe: onboardingBridge.onDroppedImportFiles,
+  onboarding,
+  resident: residentRideImport,
+});
 
 void trainingContextController.start();
 spendController.start();
@@ -257,7 +277,9 @@ void clients.getClient().then(
 window.addEventListener(
   "pagehide",
   () => {
+    disposeDroppedRideImports();
     onboarding.dispose();
+    residentRideImport.dispose();
     firstSyncController.dispose();
     manualSyncController.dispose();
     trainingSyncCoordinator.dispose();

--- a/apps/desktop-renderer/src/onboarding/machine.ts
+++ b/apps/desktop-renderer/src/onboarding/machine.ts
@@ -1,8 +1,4 @@
-import {
-  SaveIntakeRpcParamsSchema,
-  type CoachOperationProgressNotificationEnvelope,
-  type SaveIntakeRpcParams,
-} from "@enduragent/coach-contract";
+import { SaveIntakeRpcParamsSchema, type SaveIntakeRpcParams } from "@enduragent/coach-contract";
 import {
   DESKTOP_CREDENTIAL_SLOTS,
   ONBOARDING_STEP_IDS,
@@ -40,7 +36,6 @@ export type OnboardingErrorCode =
   | "credential-save-failed"
   | "training-account-mismatch"
   | "training-data-required"
-  | "import-failed"
   | "intake-incomplete"
   | "intake-save-failed";
 
@@ -50,8 +45,7 @@ export interface OnboardingState {
   readonly chatGptState: "absent" | "pending" | "configured" | "refused";
   readonly chatGptRuntimeReady: boolean;
   readonly chatGptRefusal: ChatGptLoginRefusalReason | null;
-  readonly acceptedImportPaths: readonly string[];
-  readonly importProgress: CoachOperationProgressNotificationEnvelope | null;
+  readonly importedRideFileCount: number;
   readonly intake: DesktopIntakeDraft;
   readonly busy: boolean;
   readonly fixedError: OnboardingErrorCode | null;
@@ -84,8 +78,7 @@ export function createOnboardingState(
     chatGptState: chatGptStatus.state,
     chatGptRuntimeReady: chatGptStatus.runtimeReady,
     chatGptRefusal: null,
-    acceptedImportPaths: [],
-    importProgress: null,
+    importedRideFileCount: 0,
     intake: { priorBsi: null, injuryStatus: null, clinicianCleared: null },
     busy: false,
     fixedError: null,
@@ -156,12 +149,8 @@ export function hasConfiguredModel(state: OnboardingState): boolean {
 
 export function hasTrainingData(state: OnboardingState): boolean {
   return (
-    state.credentialStatus["intervals-icu"] === "configured" || state.acceptedImportPaths.length > 0
+    state.credentialStatus["intervals-icu"] === "configured" || state.importedRideFileCount > 0
   );
-}
-
-export function canImportFiles(state: OnboardingState, modalOpen: boolean): boolean {
-  return modalOpen && !state.busy && state.step === "training-data";
 }
 
 export function toDesktopIntakeFlags(draft: DesktopIntakeDraft): SaveIntakeRpcParams {
@@ -228,23 +217,16 @@ export function withError(
   return { ...state, busy: false, fixedError };
 }
 
-export function withImportProgress(
+export function withImportedRideFileCount(
   state: OnboardingState,
-  importProgress: CoachOperationProgressNotificationEnvelope,
+  importedRideFileCount: number,
 ): OnboardingState {
-  return { ...state, importProgress };
-}
-
-export function withSuccessfulImport(
-  state: OnboardingState,
-  paths: readonly string[],
-): OnboardingState {
+  if (!Number.isSafeInteger(importedRideFileCount) || importedRideFileCount < 0) {
+    throw new TypeError();
+  }
   return {
     ...state,
-    acceptedImportPaths: [...paths],
-    importProgress: null,
-    busy: false,
-    fixedError: null,
+    importedRideFileCount: Math.max(state.importedRideFileCount, importedRideFileCount),
   };
 }
 

--- a/apps/desktop-renderer/src/onboarding/mount.ts
+++ b/apps/desktop-renderer/src/onboarding/mount.ts
@@ -10,7 +10,6 @@ import type { OnboardingBridge } from "./bridge.js";
 import { credentialPresentation } from "./credential-presentation.js";
 import {
   ONBOARDING_COMPLETION,
-  canImportFiles,
   createOnboardingState,
   hasConfiguredModel,
   hasTrainingData,
@@ -23,26 +22,35 @@ import {
   withChatGptStatus,
   withCredentialStatuses,
   withError,
-  withImportProgress,
+  withImportedRideFileCount,
   withIntake,
-  withSuccessfulImport,
   type CredentialSlotStatus,
   type ChatGptStatus,
   type OnboardingCompletion,
   type OnboardingErrorCode,
   type OnboardingState,
 } from "./machine.js";
+import {
+  createRideImportController,
+  rideImportStatusCopy,
+  type RideImportController,
+  type RideImportState,
+} from "../ride-import.js";
 
 export interface OnboardingController {
   open(): Promise<void>;
   close(): void;
   dispose(): void;
   state(): OnboardingState;
+  ownsDroppedImportFiles(): boolean;
+  importDroppedFiles(paths: readonly string[]): void;
 }
 
 interface MountOnboardingOptions {
   readonly document: Document;
   readonly bridge: OnboardingBridge;
+  readonly rideImports?: RideImportController;
+  readonly onRideImportPresentationChange?: (presenting: boolean) => void;
   readonly opener: HTMLElement;
   readonly onComplete: (completion: OnboardingCompletion) => void;
 }
@@ -77,7 +85,6 @@ const ERROR_COPY: Readonly<Record<OnboardingErrorCode, string>> = {
   "training-account-mismatch":
     "That intervals.icu key belongs to a different athlete than the training history already stored. Switching accounts is not supported yet.",
   "training-data-required": "Connect intervals.icu or import at least one ride file.",
-  "import-failed": "Those ride files could not be imported. Try another selection.",
   "intake-incomplete": "Answer the required safety questions to continue.",
   "intake-save-failed": "Your answers could not be saved. Please try again.",
 };
@@ -147,13 +154,23 @@ function passwordControl(
 }
 
 export function mountOnboarding(options: MountOnboardingOptions): OnboardingController {
+  const rideImports = options.rideImports ?? createRideImportController(options.bridge);
   let state = createOnboardingState();
+  let rideImportState: RideImportState = rideImports.state();
   let credentialStatuses: readonly CredentialSlotStatus[] = [];
   let scrim: HTMLElement | undefined;
   let completed = false;
   let disposed = false;
   let opening = false;
   let visit = 0;
+  let presentingRideImports = false;
+
+  const setRideImportPresentation = (presenting: boolean): void => {
+    if (presentingRideImports === presenting) return;
+    presentingRideImports = presenting;
+    options.onRideImportPresentationChange?.(presenting);
+  };
+
   const status = (slot: DesktopCredentialSlot): CredentialSlotStatus =>
     credentialStatuses.find((entry) => entry.slot === slot) ?? {
       slot,
@@ -176,6 +193,7 @@ export function mountOnboarding(options: MountOnboardingOptions): OnboardingCont
     clearPasswordInputs();
     scrim?.remove();
     scrim = undefined;
+    setRideImportPresentation(false);
     options.opener.focus();
   };
 
@@ -233,46 +251,28 @@ export function mountOnboarding(options: MountOnboardingOptions): OnboardingCont
   };
 
   const importStatusCopy = (): string => {
-    if (state.importProgress !== null) {
-      return state.importProgress.params.event.phase === "started"
-        ? "Import started."
-        : "Import completed.";
-    }
-    if (state.acceptedImportPaths.length === 0) return "";
-    return `${state.acceptedImportPaths.length} ride file${state.acceptedImportPaths.length === 1 ? "" : "s"} imported.`;
+    return rideImportStatusCopy(rideImportState);
   };
 
   const updateImportPresentation = (): void => {
     if (scrim === undefined) return;
+    const importBusy = state.step === "training-data" && rideImports.isBusy();
     for (const button of scrim.querySelectorAll<HTMLButtonElement>("button")) {
-      if (!button.classList.contains("onboarding-dismiss")) button.disabled = state.busy;
+      if (!button.classList.contains("onboarding-dismiss")) {
+        button.disabled = state.busy || importBusy;
+      }
     }
     const live = scrim.querySelector<HTMLElement>(".import-status");
-    if (live !== null) live.textContent = importStatusCopy();
+    if (live !== null) {
+      const copy = importStatusCopy();
+      live.textContent = copy;
+      live.hidden = copy.length === 0;
+      live.dataset.state = rideImportState.status;
+    }
     const error = scrim.querySelector<HTMLElement>("#onboarding-error");
     if (error !== null) {
       error.textContent = state.fixedError === null ? "" : ERROR_COPY[state.fixedError];
     }
-  };
-
-  const importPaths = async (paths: readonly string[], expectedVisit = visit): Promise<void> => {
-    if (visit !== expectedVisit || !canImportFiles(state, scrim !== undefined)) return;
-    state = withBusy(state, true);
-    updateImportPresentation();
-    try {
-      const result = await options.bridge.importFiles(paths, (envelope) => {
-        if (visit !== expectedVisit || scrim === undefined) return;
-        state = withImportProgress(state, envelope);
-        updateImportPresentation();
-      });
-      if (visit !== expectedVisit || scrim === undefined) return;
-      if (result.files.imported <= 0) throw new TypeError();
-      state = withSuccessfulImport(state, paths);
-    } catch {
-      if (visit !== expectedVisit || scrim === undefined) return;
-      state = withError(state, "import-failed");
-    }
-    updateImportPresentation();
   };
 
   const updateIntakeFromControl = (
@@ -509,29 +509,15 @@ export function mountOnboarding(options: MountOnboardingOptions): OnboardingCont
     body.append(divider);
     const chooser = make(options.document, "button", "drop-zone");
     chooser.type = "button";
-    chooser.disabled = state.busy;
+    chooser.disabled = state.busy || rideImports.isBusy();
     chooser.append(
       make(options.document, "strong", undefined, "Choose FIT, TCX, or GPX files"),
       make(options.document, "span", undefined, "You can also drop files here."),
     );
     chooser.addEventListener("click", () => {
-      const chooserVisit = visit;
-      void options.bridge.chooseImportFiles().then(
-        (paths) => {
-          if (paths.length > 0) void importPaths(paths, chooserVisit);
-        },
-        () => {
-          if (visit !== chooserVisit || scrim === undefined) return;
-          state = withError(state, "import-failed");
-          render();
-        },
-      );
+      void rideImports.chooseAndImport("onboarding");
     });
     body.append(chooser);
-    const live = make(options.document, "p", "import-status");
-    live.setAttribute("aria-live", "polite");
-    live.textContent = importStatusCopy();
-    body.append(live);
   };
 
   const renderSafetyIntake = (body: HTMLElement): void => {
@@ -637,7 +623,7 @@ export function mountOnboarding(options: MountOnboardingOptions): OnboardingCont
   };
 
   const submitCurrentStep = async (dialog: HTMLElement): Promise<void> => {
-    if (state.busy) return;
+    if (state.busy || (state.step === "training-data" && rideImports.isBusy())) return;
     const submitVisit = visit;
     state = withBusy(state, true);
     for (const button of dialog.querySelectorAll<HTMLButtonElement>("button"))
@@ -691,6 +677,7 @@ export function mountOnboarding(options: MountOnboardingOptions): OnboardingCont
       visit += 1;
       scrim?.remove();
       scrim = undefined;
+      setRideImportPresentation(false);
       options.onComplete(ONBOARDING_COMPLETION);
     }
   };
@@ -725,16 +712,25 @@ export function mountOnboarding(options: MountOnboardingOptions): OnboardingCont
       title.id = "onboarding-title";
       title.tabIndex = -1;
     }
+    const importStatus = make(options.document, "p", "import-status");
+    importStatus.setAttribute("role", "status");
+    importStatus.setAttribute("aria-live", "polite");
+    importStatus.setAttribute("aria-atomic", "true");
+    importStatus.textContent = importStatusCopy();
+    importStatus.hidden = importStatus.textContent.length === 0;
+    importStatus.dataset.state = rideImportState.status;
+    body.append(importStatus);
     const error = make(options.document, "p", "onboarding-error");
     error.id = "onboarding-error";
     error.setAttribute("aria-live", "polite");
     if (state.fixedError !== null) error.textContent = ERROR_COPY[state.fixedError];
     body.append(error);
     const footer = make(options.document, "footer", "onboarding-footer");
+    const importBusy = state.step === "training-data" && rideImports.isBusy();
     if (activeIndex > 0) {
       const back = make(options.document, "button", "secondary-button", "Back");
       back.type = "button";
-      back.disabled = state.busy;
+      back.disabled = state.busy || importBusy;
       back.addEventListener("click", () => {
         state = previousStep(state);
         render();
@@ -751,7 +747,7 @@ export function mountOnboarding(options: MountOnboardingOptions): OnboardingCont
       state.step === "ready" ? "Finish setup" : "Continue",
     );
     submit.type = "button";
-    submit.disabled = state.busy;
+    submit.disabled = state.busy || importBusy;
     submit.addEventListener("click", () => void submitCurrentStep(dialog));
     footer.append(submit);
     dialog.append(header, body, footer);
@@ -786,7 +782,15 @@ export function mountOnboarding(options: MountOnboardingOptions): OnboardingCont
     scrim.append(dialog);
   };
 
-  const disposeDrop = options.bridge.onDroppedImportFiles((paths) => void importPaths(paths));
+  const disposeImportState = rideImports.subscribe((next) => {
+    rideImportState = next;
+    if (next.status === "succeeded") {
+      state = withImportedRideFileCount(state, rideImports.importedFileCount());
+    } else if (next.status === "running" && next.owner === "onboarding") {
+      state = { ...state, fixedError: null };
+    }
+    updateImportPresentation();
+  });
 
   return {
     async open(): Promise<void> {
@@ -808,8 +812,10 @@ export function mountOnboarding(options: MountOnboardingOptions): OnboardingCont
       }
       credentialStatuses = statuses;
       state = createOnboardingState(statuses, restoredChatGptStatus);
+      state = withImportedRideFileCount(state, rideImports.importedFileCount());
       scrim = make(options.document, "div", "onboarding-scrim");
       options.document.body.append(scrim);
+      setRideImportPresentation(true);
       render();
       focusCurrentTitle();
       opening = false;
@@ -821,8 +827,22 @@ export function mountOnboarding(options: MountOnboardingOptions): OnboardingCont
       clearPasswordInputs();
       scrim?.remove();
       scrim = undefined;
-      disposeDrop();
+      setRideImportPresentation(false);
+      disposeImportState();
     },
     state: () => state,
+    ownsDroppedImportFiles: () =>
+      !disposed && scrim !== undefined && state.step === "training-data",
+    importDroppedFiles(paths) {
+      if (
+        !disposed &&
+        scrim !== undefined &&
+        state.step === "training-data" &&
+        !state.busy &&
+        !rideImports.isBusy()
+      ) {
+        void rideImports.importPaths("onboarding", paths);
+      }
+    },
   };
 }

--- a/apps/desktop-renderer/src/ride-import.css
+++ b/apps/desktop-renderer/src/ride-import.css
@@ -1,0 +1,47 @@
+.ride-import {
+  position: relative;
+}
+
+.ride-import__button {
+  min-height: 38px;
+  padding: 0 14px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  color: var(--ink);
+  background: var(--surface);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.ride-import__button:disabled {
+  cursor: default;
+  opacity: 0.5;
+}
+
+.ride-import__status {
+  position: absolute;
+  z-index: 4;
+  top: calc(100% + 10px);
+  right: 0;
+  width: min(360px, calc(100vw - 32px));
+  margin: 0;
+  padding: 11px 13px;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  color: var(--ink);
+  background: var(--surface-solid);
+  box-shadow: 0 10px 30px color-mix(in srgb, var(--ink) 12%, transparent);
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.ride-import__status[data-state="failed"] {
+  border-left: 3px solid var(--coral);
+}
+
+@media (max-width: 760px) {
+  .ride-import__button {
+    padding-right: 9px;
+    padding-left: 9px;
+  }
+}

--- a/apps/desktop-renderer/src/ride-import.ts
+++ b/apps/desktop-renderer/src/ride-import.ts
@@ -1,0 +1,262 @@
+import type {
+  CoachOperationProgressNotificationEnvelope,
+  ImportFilesRpcResult,
+} from "@enduragent/coach-contract";
+import { validateImportPaths } from "./onboarding/bridge.js";
+
+export type RideImportOwner = "onboarding" | "resident";
+
+type RideImportResult = ImportFilesRpcResult["files"];
+
+export type RideImportState =
+  | {
+      readonly status: "idle";
+      readonly owner: null;
+      readonly progress: null;
+      readonly result: null;
+    }
+  | {
+      readonly status: "running";
+      readonly owner: RideImportOwner;
+      readonly stage: "choosing" | "importing";
+      readonly progress: CoachOperationProgressNotificationEnvelope | null;
+      readonly result: null;
+    }
+  | {
+      readonly status: "succeeded";
+      readonly owner: RideImportOwner;
+      readonly progress: null;
+      readonly result: RideImportResult;
+    }
+  | {
+      readonly status: "failed";
+      readonly owner: RideImportOwner;
+      readonly progress: null;
+      readonly result: RideImportResult | null;
+    };
+
+export type RideImportAttempt = "busy" | "cancelled" | "failed" | "succeeded";
+
+export interface RideImportTransport {
+  chooseImportFiles(): Promise<readonly string[]>;
+  importFiles(
+    paths: readonly string[],
+    onProgress: (event: CoachOperationProgressNotificationEnvelope) => void,
+  ): Promise<ImportFilesRpcResult>;
+}
+
+export interface RideImportController {
+  state(): RideImportState;
+  isBusy(): boolean;
+  importedFileCount(): number;
+  subscribe(listener: (state: RideImportState) => void): () => void;
+  chooseAndImport(owner: RideImportOwner): Promise<RideImportAttempt>;
+  importPaths(owner: RideImportOwner, paths: readonly string[]): Promise<RideImportAttempt>;
+}
+
+const IDLE_STATE: RideImportState = {
+  status: "idle",
+  owner: null,
+  progress: null,
+  result: null,
+};
+
+export function createRideImportController(transport: RideImportTransport): RideImportController {
+  let state = IDLE_STATE;
+  let attempt = 0;
+  let importedFileCount = 0;
+  const listeners = new Set<(state: RideImportState) => void>();
+
+  const publish = (next: RideImportState): void => {
+    state = next;
+    for (const listener of listeners) listener(state);
+  };
+
+  const begin = (owner: RideImportOwner, stage: "choosing" | "importing"): number | null => {
+    if (state.status === "running") return null;
+    const currentAttempt = ++attempt;
+    publish({
+      status: "running",
+      owner,
+      stage,
+      progress: null,
+      result: null,
+    });
+    return currentAttempt;
+  };
+
+  const fail = (owner: RideImportOwner, result: RideImportResult | null): RideImportAttempt => {
+    publish({ status: "failed", owner, progress: null, result });
+    return "failed";
+  };
+
+  const execute = async (
+    owner: RideImportOwner,
+    paths: readonly string[],
+    currentAttempt: number,
+  ): Promise<RideImportAttempt> => {
+    try {
+      const validatedPaths = validateImportPaths(paths);
+      publish({
+        status: "running",
+        owner,
+        stage: "importing",
+        progress: null,
+        result: null,
+      });
+      const result = await transport.importFiles(validatedPaths, (progress) => {
+        if (attempt !== currentAttempt || state.status !== "running") return;
+        publish({
+          status: "running",
+          owner,
+          stage: "importing",
+          progress,
+          result: null,
+        });
+      });
+      if (result.files.imported <= 0) return fail(owner, result.files);
+      importedFileCount += result.files.imported;
+      publish({
+        status: "succeeded",
+        owner,
+        progress: null,
+        result: result.files,
+      });
+      return "succeeded";
+    } catch {
+      return fail(owner, null);
+    }
+  };
+
+  return {
+    state: () => state,
+    isBusy: () => state.status === "running",
+    importedFileCount: () => importedFileCount,
+    subscribe(listener) {
+      listeners.add(listener);
+      listener(state);
+      return () => listeners.delete(listener);
+    },
+    async chooseAndImport(owner) {
+      const currentAttempt = begin(owner, "choosing");
+      if (currentAttempt === null) return "busy";
+      try {
+        const paths = await transport.chooseImportFiles();
+        if (paths.length === 0) {
+          publish(IDLE_STATE);
+          return "cancelled";
+        }
+        return execute(owner, paths, currentAttempt);
+      } catch {
+        return fail(owner, null);
+      }
+    },
+    async importPaths(owner, paths) {
+      const currentAttempt = begin(owner, "importing");
+      if (currentAttempt === null) return "busy";
+      return execute(owner, paths, currentAttempt);
+    },
+  };
+}
+
+function rideFileCount(count: number): string {
+  return `${count} ride file${count === 1 ? "" : "s"}`;
+}
+
+export function rideImportStatusCopy(state: RideImportState): string {
+  if (state.status === "idle") return "";
+  if (state.status === "running") {
+    return state.stage === "choosing"
+      ? "Waiting for ride file selection…"
+      : "Importing ride files…";
+  }
+  if (state.result === null) {
+    return "Local library import failed. The result could not be confirmed; check the library before trying again.";
+  }
+  const result = state.result;
+  const counts = `${rideFileCount(result.imported)} imported. ${rideFileCount(result.quarantined)} quarantined.`;
+  return state.status === "failed"
+    ? `Local library import failed. ${counts}`
+    : `Local library import: ${counts}`;
+}
+
+interface ResidentRideImportOptions {
+  readonly document: Document;
+  readonly actionHost: HTMLElement;
+  readonly before?: Node;
+  readonly imports: RideImportController;
+}
+
+export interface ResidentRideImport {
+  importDroppedFiles(paths: readonly string[]): void;
+  setSuppressed(suppressed: boolean): void;
+  dispose(): void;
+}
+
+export function mountResidentRideImport(options: ResidentRideImportOptions): ResidentRideImport {
+  const root = options.document.createElement("div");
+  root.className = "ride-import";
+  const button = options.document.createElement("button");
+  button.type = "button";
+  button.className = "ride-import__button";
+  button.textContent = "Import ride files";
+  button.setAttribute("aria-describedby", "resident-ride-import-status");
+  const status = options.document.createElement("p");
+  status.id = "resident-ride-import-status";
+  status.className = "ride-import__status";
+  status.setAttribute("role", "status");
+  status.setAttribute("aria-live", "polite");
+  status.setAttribute("aria-atomic", "true");
+  status.hidden = true;
+  root.append(button, status);
+  if (options.before === undefined) options.actionHost.append(root);
+  else options.actionHost.insertBefore(root, options.before);
+
+  let suppressed = false;
+  const render = (state: RideImportState): void => {
+    button.disabled = options.imports.isBusy();
+    const copy = suppressed ? "" : rideImportStatusCopy(state);
+    status.textContent = copy;
+    status.hidden = copy.length === 0;
+    status.dataset.state = suppressed ? "idle" : state.status;
+  };
+  const disposeState = options.imports.subscribe(render);
+  button.addEventListener("click", () => {
+    void options.imports.chooseAndImport("resident");
+  });
+
+  return {
+    importDroppedFiles(paths) {
+      void options.imports.importPaths("resident", paths);
+    },
+    setSuppressed(next) {
+      suppressed = next;
+      render(options.imports.state());
+    },
+    dispose() {
+      disposeState();
+      root.remove();
+    },
+  };
+}
+
+interface DroppedRideImportRouterOptions {
+  readonly subscribe: (listener: (paths: readonly string[]) => void) => () => void;
+  readonly onboarding: {
+    ownsDroppedImportFiles(): boolean;
+    importDroppedFiles(paths: readonly string[]): void;
+  };
+  readonly resident: {
+    importDroppedFiles(paths: readonly string[]): void;
+  };
+}
+
+export function subscribeToDroppedRideImports(options: DroppedRideImportRouterOptions): () => void {
+  return options.subscribe((paths) => {
+    if (options.onboarding.ownsDroppedImportFiles()) {
+      options.onboarding.importDroppedFiles(paths);
+    } else {
+      options.resident.importDroppedFiles(paths);
+    }
+  });
+}

--- a/apps/desktop-renderer/tests/onboarding-machine.test.ts
+++ b/apps/desktop-renderer/tests/onboarding-machine.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "vitest";
 import {
-  canImportFiles,
   createOnboardingState,
   nextStep,
   previousStep,
@@ -10,21 +9,20 @@ import {
   withChatGptPending,
   withChatGptStatus,
   withIntake,
-  withSuccessfulImport,
+  withImportedRideFileCount,
 } from "../src/onboarding/machine.js";
 
 describe("desktop onboarding machine", () => {
   it("keeps the four ordered steps and exact guards", () => {
     let state = createOnboardingState();
     expect(Object.keys(state).sort()).toEqual([
-      "acceptedImportPaths",
       "busy",
       "chatGptRefusal",
       "chatGptRuntimeReady",
       "chatGptState",
       "credentialStatus",
       "fixedError",
-      "importProgress",
+      "importedRideFileCount",
       "intake",
       "step",
     ]);
@@ -41,7 +39,7 @@ describe("desktop onboarding machine", () => {
       step: "training-data",
       fixedError: "training-data-required",
     });
-    state = withSuccessfulImport(state, ["/synthetic/ride.fit"]);
+    state = withImportedRideFileCount(state, 1);
     state = nextStep(state);
     expect(state.step).toBe("safety-intake");
     expect(nextStep(state)).toMatchObject({
@@ -80,25 +78,21 @@ describe("desktop onboarding machine", () => {
       { slot: "intervals-icu", state: "configured", runtimeState: "active" },
     ]);
     state = nextStep(state);
-    state = withSuccessfulImport(state, ["/synthetic/ride.tcx"]);
+    state = withImportedRideFileCount(state, 1);
     state = nextStep(state);
     state = previousStep(state);
     state = previousStep(state);
     expect(state.step).toBe("coach-keys");
     expect(state.credentialStatus.openrouter).toBe("configured");
-    expect(state.acceptedImportPaths).toEqual(["/synthetic/ride.tcx"]);
+    expect(state.importedRideFileCount).toBe(1);
     expect("secret" in state).toBe(false);
   });
 
-  it("accepts chooser and drop imports only while the training step is open and idle", () => {
-    let state = createOnboardingState([
-      { slot: "anthropic", state: "configured", runtimeState: "active" },
-    ]);
-    state = nextStep(state);
-    expect(canImportFiles(state, true)).toBe(true);
-    expect(canImportFiles(state, false)).toBe(false);
-    expect(canImportFiles({ ...state, busy: true }, true)).toBe(false);
-    expect(canImportFiles(previousStep(state), true)).toBe(false);
+  it("preserves an earlier successful import when a later batch imports nothing", () => {
+    let state = withImportedRideFileCount(createOnboardingState(), 2);
+    state = withImportedRideFileCount(state, 0);
+    expect(state.importedRideFileCount).toBe(2);
+    expect(() => withImportedRideFileCount(state, -1)).toThrow(TypeError);
   });
 
   it("maps every cycling intake branch to the landed strict DTO", () => {

--- a/apps/desktop-renderer/tests/onboarding-mount.test.ts
+++ b/apps/desktop-renderer/tests/onboarding-mount.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { OnboardingBridge } from "../src/onboarding/bridge.js";
 import { mountOnboarding } from "../src/onboarding/mount.js";
 import type { ChatGptLoginResult } from "../src/onboarding/machine.js";
+import { createRideImportController } from "../src/ride-import.js";
 
 class FakeElement {
   readonly children: FakeElement[] = [];
@@ -138,6 +139,8 @@ function bridge(login: () => Promise<ChatGptLoginResult>): OnboardingBridge & {
   readonly credentialStatuses: ReturnType<typeof vi.fn<OnboardingBridge["credentialStatuses"]>>;
   readonly chatGptStatus: ReturnType<typeof vi.fn<OnboardingBridge["chatGptStatus"]>>;
   readonly chatGptLogin: ReturnType<typeof vi.fn<OnboardingBridge["chatGptLogin"]>>;
+  readonly importFiles: ReturnType<typeof vi.fn<OnboardingBridge["importFiles"]>>;
+  readonly onDroppedImportFiles: ReturnType<typeof vi.fn<OnboardingBridge["onDroppedImportFiles"]>>;
 } {
   const credentialStatuses = vi.fn<OnboardingBridge["credentialStatuses"]>(async () => []);
   const chatGptStatus = vi.fn<OnboardingBridge["chatGptStatus"]>(async () => ({
@@ -145,6 +148,17 @@ function bridge(login: () => Promise<ChatGptLoginResult>): OnboardingBridge & {
     runtimeReady: true,
   }));
   const chatGptLogin = vi.fn<OnboardingBridge["chatGptLogin"]>(login);
+  const importFiles = vi.fn<OnboardingBridge["importFiles"]>(async () => ({
+    schemaVersion: 1,
+    files: { total: 0, imported: 0, quarantined: 0 },
+    changes: {
+      rawFilesInserted: 0,
+      sourceRecordsInserted: 0,
+      sourceRecordsUpdated: 0,
+      relinkedSourceRecords: 0,
+    },
+  }));
+  const onDroppedImportFiles = vi.fn<OnboardingBridge["onDroppedImportFiles"]>(() => () => {});
   return {
     credentialStatuses,
     retryFailedCredentials: vi.fn<OnboardingBridge["retryFailedCredentials"]>(async () => []),
@@ -156,17 +170,8 @@ function bridge(login: () => Promise<ChatGptLoginResult>): OnboardingBridge & {
     chatGptStatus,
     chatGptLogin,
     chooseImportFiles: vi.fn<OnboardingBridge["chooseImportFiles"]>(async () => []),
-    onDroppedImportFiles: vi.fn<OnboardingBridge["onDroppedImportFiles"]>(() => () => {}),
-    importFiles: vi.fn<OnboardingBridge["importFiles"]>(async () => ({
-      schemaVersion: 1,
-      files: { total: 0, imported: 0, quarantined: 0 },
-      changes: {
-        rawFilesInserted: 0,
-        sourceRecordsInserted: 0,
-        sourceRecordsUpdated: 0,
-        relinkedSourceRecords: 0,
-      },
-    })),
+    onDroppedImportFiles,
+    importFiles,
     saveIntake: vi.fn<OnboardingBridge["saveIntake"]>(async () => {}),
   } satisfies OnboardingBridge;
 }
@@ -243,5 +248,149 @@ describe("mounted onboarding", () => {
       "ChatGPT sign-in timed out. Retry when you are ready.",
     );
     expect(buttonWithText(document, "Retry ChatGPT sign-in").disabled).toBe(false);
+  });
+
+  it("owns drops only on the training-data step and gates on returned imported counts", async () => {
+    const document = new FakeDocument();
+    const onboardingBridge = bridge(async () => ({
+      status: "configured",
+      runtimeReady: true,
+    }));
+    onboardingBridge.importFiles
+      .mockResolvedValueOnce({
+        schemaVersion: 1,
+        files: { total: 2, imported: 1, quarantined: 1 },
+        changes: {
+          rawFilesInserted: 1,
+          sourceRecordsInserted: 1,
+          sourceRecordsUpdated: 0,
+          relinkedSourceRecords: 0,
+        },
+      })
+      .mockResolvedValueOnce({
+        schemaVersion: 1,
+        files: { total: 2, imported: 0, quarantined: 2 },
+        changes: {
+          rawFilesInserted: 0,
+          sourceRecordsInserted: 0,
+          sourceRecordsUpdated: 0,
+          relinkedSourceRecords: 0,
+        },
+      });
+    const controller = mountOnboarding({
+      document: documentBoundary(document),
+      bridge: onboardingBridge,
+      opener: elementBoundary(document.createElement("button")),
+      onComplete: vi.fn(),
+    });
+    await controller.open();
+    expect(controller.ownsDroppedImportFiles()).toBe(false);
+    expect(onboardingBridge.onDroppedImportFiles).not.toHaveBeenCalled();
+
+    buttonWithText(document, "Continue").dispatch("click");
+    await vi.waitFor(() => expect(controller.ownsDroppedImportFiles()).toBe(true));
+    controller.importDroppedFiles(["/synthetic/batch.fit"]);
+    await vi.waitFor(() => expect(onboardingBridge.importFiles).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(controller.state().importedRideFileCount).toBe(1));
+    expect(document.body.textContent).toContain(
+      "Local library import: 1 ride file imported. 1 ride file quarantined.",
+    );
+
+    controller.importDroppedFiles(["/synthetic/quarantined.fit"]);
+    await vi.waitFor(() => expect(onboardingBridge.importFiles).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() =>
+      expect(document.body.textContent).toContain(
+        "Local library import failed. 0 ride files imported. 2 ride files quarantined.",
+      ),
+    );
+    expect(controller.state().importedRideFileCount).toBe(1);
+    expect(document.body.textContent).not.toContain("Import completed");
+
+    buttonWithText(document, "Continue").dispatch("click");
+    await vi.waitFor(() => expect(controller.state().step).toBe("safety-intake"));
+    expect(controller.ownsDroppedImportFiles()).toBe(false);
+    controller.importDroppedFiles(["/synthetic/not-owned.fit"]);
+    expect(onboardingBridge.importFiles).toHaveBeenCalledTimes(2);
+    controller.close();
+    expect(controller.ownsDroppedImportFiles()).toBe(false);
+    controller.dispose();
+  });
+
+  it("does not start a dropped import while the training-data step is submitting", async () => {
+    const document = new FakeDocument();
+    const onboardingBridge = bridge(async () => ({
+      status: "configured",
+      runtimeReady: true,
+    }));
+    let resolveCredential!: (value: { status: "configured"; runtimeReady: true }) => void;
+    vi.mocked(onboardingBridge.writeCredential).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveCredential = resolve;
+        }),
+    );
+    const controller = mountOnboarding({
+      document: documentBoundary(document),
+      bridge: onboardingBridge,
+      opener: elementBoundary(document.createElement("button")),
+      onComplete: vi.fn(),
+    });
+    await controller.open();
+    buttonWithText(document, "Continue").dispatch("click");
+    await vi.waitFor(() => expect(controller.ownsDroppedImportFiles()).toBe(true));
+    const intervalsInput = document.body
+      .querySelectorAll('input[type="password"][data-slot]')
+      .find((input) => input.dataset.slot === "intervals-icu");
+    expect(intervalsInput).toBeDefined();
+    intervalsInput!.value = "synthetic-key";
+
+    buttonWithText(document, "Continue").dispatch("click");
+    await vi.waitFor(() => expect(onboardingBridge.writeCredential).toHaveBeenCalledOnce());
+    controller.importDroppedFiles(["/synthetic/during-submit.fit"]);
+    expect(onboardingBridge.importFiles).not.toHaveBeenCalled();
+
+    resolveCredential({ status: "configured", runtimeReady: true });
+    await vi.waitFor(() => expect(controller.state().busy).toBe(false));
+    controller.dispose();
+  });
+
+  it("presents resident-routed import outcomes while another onboarding step is open", async () => {
+    const document = new FakeDocument();
+    const onboardingBridge = bridge(async () => ({
+      status: "configured",
+      runtimeReady: true,
+    }));
+    onboardingBridge.importFiles.mockResolvedValue({
+      schemaVersion: 1,
+      files: { total: 2, imported: 1, quarantined: 1 },
+      changes: {
+        rawFilesInserted: 1,
+        sourceRecordsInserted: 1,
+        sourceRecordsUpdated: 0,
+        relinkedSourceRecords: 0,
+      },
+    });
+    const presentationChanges = vi.fn();
+    const imports = createRideImportController(onboardingBridge);
+    const controller = mountOnboarding({
+      document: documentBoundary(document),
+      bridge: onboardingBridge,
+      rideImports: imports,
+      onRideImportPresentationChange: presentationChanges,
+      opener: elementBoundary(document.createElement("button")),
+      onComplete: vi.fn(),
+    });
+
+    await controller.open();
+    expect(controller.state().step).toBe("coach-keys");
+    expect(presentationChanges).toHaveBeenLastCalledWith(true);
+    await imports.importPaths("resident", ["/synthetic/outside-training.fit"]);
+    expect(document.body.textContent).toContain(
+      "Local library import: 1 ride file imported. 1 ride file quarantined.",
+    );
+
+    controller.close();
+    expect(presentationChanges).toHaveBeenLastCalledWith(false);
+    controller.dispose();
   });
 });

--- a/apps/desktop-renderer/tests/onboarding-mount.test.ts
+++ b/apps/desktop-renderer/tests/onboarding-mount.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import type { OnboardingBridge } from "../src/onboarding/bridge.js";
+import type { CredentialWriteResult, OnboardingBridge } from "../src/onboarding/bridge.js";
 import { mountOnboarding } from "../src/onboarding/mount.js";
 import type { ChatGptLoginResult } from "../src/onboarding/machine.js";
 import { createRideImportController } from "../src/ride-import.js";
@@ -322,10 +322,10 @@ describe("mounted onboarding", () => {
       status: "configured",
       runtimeReady: true,
     }));
-    let resolveCredential!: (value: { status: "configured"; runtimeReady: true }) => void;
+    let resolveCredential!: (value: CredentialWriteResult) => void;
     vi.mocked(onboardingBridge.writeCredential).mockImplementation(
       () =>
-        new Promise((resolve) => {
+        new Promise<CredentialWriteResult>((resolve) => {
           resolveCredential = resolve;
         }),
     );
@@ -349,7 +349,7 @@ describe("mounted onboarding", () => {
     controller.importDroppedFiles(["/synthetic/during-submit.fit"]);
     expect(onboardingBridge.importFiles).not.toHaveBeenCalled();
 
-    resolveCredential({ status: "configured", runtimeReady: true });
+    resolveCredential({ slot: "intervals-icu", status: "configured", runtimeReady: true });
     await vi.waitFor(() => expect(controller.state().busy).toBe(false));
     controller.dispose();
   });

--- a/apps/desktop-renderer/tests/ride-import.test.ts
+++ b/apps/desktop-renderer/tests/ride-import.test.ts
@@ -1,0 +1,358 @@
+import type {
+  CoachOperationProgressNotificationEnvelope,
+  ImportFilesRpcResult,
+} from "@enduragent/coach-contract";
+import { describe, expect, it, vi } from "vitest";
+import {
+  createRideImportController,
+  mountResidentRideImport,
+  rideImportStatusCopy,
+  subscribeToDroppedRideImports,
+  type RideImportState,
+  type RideImportTransport,
+} from "../src/ride-import.js";
+
+function result(
+  imported: number,
+  quarantined: number,
+  rawFilesInserted = imported,
+): ImportFilesRpcResult {
+  return {
+    schemaVersion: 1,
+    files: { total: imported + quarantined, imported, quarantined },
+    changes: {
+      rawFilesInserted,
+      sourceRecordsInserted: imported,
+      sourceRecordsUpdated: 0,
+      relinkedSourceRecords: 0,
+    },
+  };
+}
+
+function progress(phase: "started" | "completed"): CoachOperationProgressNotificationEnvelope {
+  return {
+    jsonrpc: "2.0",
+    method: "coach.operationProgress",
+    params: {
+      requestId: 7,
+      requestMethod: "importFiles",
+      event: { phase, completed: phase === "started" ? 0 : 1, total: 1 },
+    },
+  };
+}
+
+function transport(overrides: Partial<RideImportTransport> = {}): RideImportTransport & {
+  chooseImportFiles: ReturnType<typeof vi.fn<RideImportTransport["chooseImportFiles"]>>;
+  importFiles: ReturnType<typeof vi.fn<RideImportTransport["importFiles"]>>;
+} {
+  return {
+    chooseImportFiles: vi.fn(async () => []),
+    importFiles: vi.fn(async () => result(1, 0)),
+    ...overrides,
+  } as RideImportTransport & {
+    chooseImportFiles: ReturnType<typeof vi.fn<RideImportTransport["chooseImportFiles"]>>;
+    importFiles: ReturnType<typeof vi.fn<RideImportTransport["importFiles"]>>;
+  };
+}
+
+describe("ride import controller", () => {
+  it("uses the picker, validates picker and drop paths, and dispatches each valid attempt once", async () => {
+    const bridge = transport({
+      chooseImportFiles: vi
+        .fn<RideImportTransport["chooseImportFiles"]>()
+        .mockResolvedValueOnce(["/synthetic/picked.FIT"])
+        .mockResolvedValueOnce(["/synthetic/not-a-ride.zip"]),
+      importFiles: vi.fn(async () => result(1, 0)),
+    });
+    const imports = createRideImportController(bridge);
+
+    await expect(imports.chooseAndImport("resident")).resolves.toBe("succeeded");
+    await expect(imports.importPaths("onboarding", ["/synthetic/dropped.tcx"])).resolves.toBe(
+      "succeeded",
+    );
+    await expect(imports.importPaths("resident", ["relative.gpx"])).resolves.toBe("failed");
+    await expect(imports.chooseAndImport("resident")).resolves.toBe("failed");
+
+    expect(bridge.chooseImportFiles).toHaveBeenCalledTimes(2);
+    expect(bridge.importFiles).toHaveBeenCalledTimes(2);
+    expect(bridge.importFiles.mock.calls.map(([paths]) => paths)).toEqual([
+      ["/synthetic/picked.FIT"],
+      ["/synthetic/dropped.tcx"],
+    ]);
+    expect(imports.state()).toEqual({
+      status: "failed",
+      owner: "resident",
+      progress: null,
+      result: null,
+    });
+  });
+
+  it("prevents picker and drop attempts from overlapping one in-flight RPC", async () => {
+    let finish!: (value: ImportFilesRpcResult) => void;
+    const bridge = transport({
+      chooseImportFiles: vi.fn(async () => ["/synthetic/second.fit"]),
+      importFiles: vi.fn(
+        () =>
+          new Promise((resolve) => {
+            finish = resolve;
+          }),
+      ),
+    });
+    const imports = createRideImportController(bridge);
+
+    const first = imports.importPaths("resident", ["/synthetic/first.fit"]);
+    await expect(imports.chooseAndImport("resident")).resolves.toBe("busy");
+    await expect(imports.importPaths("onboarding", ["/synthetic/dropped.fit"])).resolves.toBe(
+      "busy",
+    );
+
+    expect(bridge.chooseImportFiles).not.toHaveBeenCalled();
+    expect(bridge.importFiles).toHaveBeenCalledOnce();
+    finish(result(1, 0));
+    await expect(first).resolves.toBe("succeeded");
+  });
+
+  it("uses returned partial and zero-import counts, retaining prior success without stale state", async () => {
+    const bridge = transport();
+    bridge.importFiles
+      .mockImplementationOnce(async (_paths, onProgress) => {
+        onProgress(progress("completed"));
+        return result(2, 1);
+      })
+      .mockResolvedValueOnce(result(1, 0, 0))
+      .mockImplementationOnce(async (_paths, onProgress) => {
+        onProgress(progress("started"));
+        return result(0, 3);
+      })
+      .mockRejectedValueOnce(new TypeError());
+    const imports = createRideImportController(bridge);
+    const states: RideImportState[] = [];
+    imports.subscribe((state) => states.push(state));
+
+    await expect(imports.importPaths("resident", ["/synthetic/archive.fit"])).resolves.toBe(
+      "succeeded",
+    );
+    expect(rideImportStatusCopy(imports.state())).toBe(
+      "Local library import: 2 ride files imported. 1 ride file quarantined.",
+    );
+    expect(imports.importedFileCount()).toBe(2);
+
+    await expect(imports.importPaths("resident", ["/synthetic/repeated.fit"])).resolves.toBe(
+      "succeeded",
+    );
+    expect(rideImportStatusCopy(imports.state())).toBe(
+      "Local library import: 1 ride file imported. 0 ride files quarantined.",
+    );
+    expect(imports.importedFileCount()).toBe(3);
+
+    const beforeZeroImport = states.length;
+    await expect(imports.importPaths("resident", ["/synthetic/quarantined.fit"])).resolves.toBe(
+      "failed",
+    );
+    expect(states[beforeZeroImport]).toMatchObject({
+      status: "running",
+      progress: null,
+      result: null,
+    });
+    expect(imports.state()).toEqual({
+      status: "failed",
+      owner: "resident",
+      progress: null,
+      result: { total: 3, imported: 0, quarantined: 3 },
+    });
+    expect(rideImportStatusCopy(imports.state())).toBe(
+      "Local library import failed. 0 ride files imported. 3 ride files quarantined.",
+    );
+    expect(imports.importedFileCount()).toBe(3);
+
+    await expect(imports.importPaths("resident", ["/synthetic/rejected.fit"])).resolves.toBe(
+      "failed",
+    );
+    expect(imports.state()).toEqual({
+      status: "failed",
+      owner: "resident",
+      progress: null,
+      result: null,
+    });
+    const failureCopy = rideImportStatusCopy(imports.state());
+    expect(failureCopy).toBe(
+      "Local library import failed. The result could not be confirmed; check the library before trying again.",
+    );
+    expect(failureCopy).not.toContain("Import completed");
+    expect(
+      states.filter((state) => state.status === "failed").every((state) => state.progress === null),
+    ).toBe(true);
+  });
+});
+
+class FakeElement {
+  readonly children: FakeElement[] = [];
+  readonly attributes = new Map<string, string>();
+  readonly dataset: Record<string, string> = {};
+  className = "";
+  id = "";
+  type = "";
+  disabled = false;
+  hidden = false;
+  parent: FakeElement | null = null;
+  private ownText = "";
+  private readonly listeners = new Map<string, Set<() => void>>();
+
+  get textContent(): string {
+    return this.ownText + this.children.map((child) => child.textContent).join("");
+  }
+
+  set textContent(value: string) {
+    this.ownText = value;
+    this.children.splice(0);
+  }
+
+  append(...children: FakeElement[]): void {
+    for (const child of children) {
+      child.parent = this;
+      this.children.push(child);
+    }
+  }
+
+  setAttribute(name: string, value: string): void {
+    this.attributes.set(name, value);
+  }
+
+  addEventListener(name: string, listener: () => void): void {
+    const listeners = this.listeners.get(name) ?? new Set();
+    listeners.add(listener);
+    this.listeners.set(name, listeners);
+  }
+
+  click(): void {
+    if (this.disabled) return;
+    for (const listener of this.listeners.get("click") ?? []) listener();
+  }
+
+  remove(): void {
+    if (this.parent === null) return;
+    const index = this.parent.children.indexOf(this);
+    if (index >= 0) this.parent.children.splice(index, 1);
+    this.parent = null;
+  }
+}
+
+class FakeDocument {
+  createElement(): FakeElement {
+    return new FakeElement();
+  }
+}
+
+describe("resident ride import surface", () => {
+  it("mounts a keyboard button and bounded live result using only local-library claims", async () => {
+    const document = new FakeDocument();
+    const actionHost = new FakeElement();
+    const bridge = transport({
+      chooseImportFiles: vi.fn(async () => ["/synthetic/batch.fit"]),
+      importFiles: vi.fn(async () => result(2, 1)),
+    });
+    const imports = createRideImportController(bridge);
+    const mounted = mountResidentRideImport({
+      document: document as unknown as Document,
+      actionHost: actionHost as unknown as HTMLElement,
+      imports,
+    });
+
+    const root = actionHost.children[0]!;
+    const button = root.children[0]!;
+    const status = root.children[1]!;
+    expect(button).toMatchObject({
+      type: "button",
+      textContent: "Import ride files",
+      disabled: false,
+    });
+    expect(button.attributes.get("aria-describedby")).toBe("resident-ride-import-status");
+    expect(status.attributes.get("role")).toBe("status");
+    expect(status.attributes.get("aria-live")).toBe("polite");
+    expect(status.attributes.get("aria-atomic")).toBe("true");
+
+    button.click();
+    await vi.waitFor(() => expect(status.dataset.state).toBe("succeeded"));
+    expect(status.hidden).toBe(false);
+    expect(status.textContent).toBe(
+      "Local library import: 2 ride files imported. 1 ride file quarantined.",
+    );
+    expect(status.textContent).not.toMatch(
+      /\b(?:sync(?:ed)?|training history updated|coach updated|coach-readable)\b/iu,
+    );
+    mounted.dispose();
+    expect(actionHost.children).toHaveLength(0);
+  });
+
+  it("hands an onboarding-owned attempt to the resident live region when the modal closes", async () => {
+    const document = new FakeDocument();
+    const actionHost = new FakeElement();
+    let finish!: (value: ImportFilesRpcResult) => void;
+    const bridge = transport({
+      importFiles: vi.fn(
+        () =>
+          new Promise((resolve) => {
+            finish = resolve;
+          }),
+      ),
+    });
+    const imports = createRideImportController(bridge);
+    const mounted = mountResidentRideImport({
+      document: document as unknown as Document,
+      actionHost: actionHost as unknown as HTMLElement,
+      imports,
+    });
+    const status = actionHost.children[0]!.children[1]!;
+
+    mounted.setSuppressed(true);
+    const attempt = imports.importPaths("onboarding", ["/synthetic/modal.fit"]);
+    expect(status.hidden).toBe(true);
+    expect(status.textContent).toBe("");
+
+    mounted.setSuppressed(false);
+    expect(status.hidden).toBe(false);
+    expect(status.textContent).toBe("Importing ride files…");
+    finish(result(1, 0));
+    await expect(attempt).resolves.toBe("succeeded");
+    expect(status.textContent).toBe(
+      "Local library import: 1 ride file imported. 0 ride files quarantined.",
+    );
+    mounted.dispose();
+  });
+});
+
+describe("dropped ride import routing", () => {
+  it("creates one disposable subscription and selects the current wizard or resident owner", () => {
+    let listener: ((paths: readonly string[]) => void) | undefined;
+    const dispose = vi.fn();
+    const subscribe = vi.fn((next: (paths: readonly string[]) => void) => {
+      listener = next;
+      return dispose;
+    });
+    let wizardOwnsDrop = true;
+    const onboarding = {
+      ownsDroppedImportFiles: vi.fn(() => wizardOwnsDrop),
+      importDroppedFiles: vi.fn(),
+    };
+    const resident = { importDroppedFiles: vi.fn() };
+
+    const disposeRouter = subscribeToDroppedRideImports({
+      subscribe,
+      onboarding,
+      resident,
+    });
+    expect(subscribe).toHaveBeenCalledOnce();
+
+    listener?.(["/synthetic/wizard.fit"]);
+    expect(onboarding.importDroppedFiles).toHaveBeenCalledWith(["/synthetic/wizard.fit"]);
+    expect(resident.importDroppedFiles).not.toHaveBeenCalled();
+
+    wizardOwnsDrop = false;
+    listener?.(["/synthetic/resident.gpx"]);
+    expect(resident.importDroppedFiles).toHaveBeenCalledWith(["/synthetic/resident.gpx"]);
+    expect(onboarding.importDroppedFiles).toHaveBeenCalledOnce();
+
+    disposeRouter();
+    expect(dispose).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/desktop-renderer/tests/ride-import.test.ts
+++ b/apps/desktop-renderer/tests/ride-import.test.ts
@@ -91,9 +91,9 @@ describe("ride import controller", () => {
     let finish!: (value: ImportFilesRpcResult) => void;
     const bridge = transport({
       chooseImportFiles: vi.fn(async () => ["/synthetic/second.fit"]),
-      importFiles: vi.fn(
+      importFiles: vi.fn<RideImportTransport["importFiles"]>(
         () =>
-          new Promise((resolve) => {
+          new Promise<ImportFilesRpcResult>((resolve) => {
             finish = resolve;
           }),
       ),
@@ -289,9 +289,9 @@ describe("resident ride import surface", () => {
     const actionHost = new FakeElement();
     let finish!: (value: ImportFilesRpcResult) => void;
     const bridge = transport({
-      importFiles: vi.fn(
+      importFiles: vi.fn<RideImportTransport["importFiles"]>(
         () =>
-          new Promise((resolve) => {
+          new Promise<ImportFilesRpcResult>((resolve) => {
             finish = resolve;
           }),
       ),


### PR DESCRIPTION
## Summary

- add a resident Desktop action for FIT, TCX, and GPX imports
- share one import controller and one drop subscription with onboarding
- report contract-accurate imported and quarantined counts, including partial and failed batches
- keep progress and outcomes visible when onboarding opens, changes steps, or closes

## Validation

- 5 focused renderer test files: 26 tests passed
- Desktop renderer typecheck passed
- affected lint and formatting checks passed
- fixture privacy, user-facing changeset, trademark, and diff-integrity checks passed
- one detached read-only reviewer passed with zero blockers
