### PR TITLE
fix(desktop): classify configuration startup failures

### DIFF
--- a/.changeset/desktop-config-readiness.md
+++ b/.changeset/desktop-config-readiness.md
@@ -1,0 +1,10 @@
+---
+"cycling-coach": patch
+"@enduragent/core": patch
+"@enduragent/coach": patch
+"@enduragent/desktop": patch
+---
+
+User-facing: Desktop now gives safe, actionable startup guidance when an existing configuration cannot be read or is invalid.
+
+Preserve closed configuration-readiness failures through app-supervised utility termination without retrying terminal configuration errors.

--- a/apps/desktop/src/main/lifecycle-messages.ts
+++ b/apps/desktop/src/main/lifecycle-messages.ts
@@ -9,6 +9,26 @@ export interface DesktopErrorCopy {
 export function startupRefusalCopy(
   cause: Extract<DesktopDaemonResolution, { status: "refused" }>["cause"],
 ): DesktopErrorCopy {
+  if (cause === "not-configured") {
+    return {
+      title: "Enduragent isn’t configured",
+      content:
+        "The configuration file is missing. Run Enduragent setup or restore config.yaml, then reopen Enduragent.",
+    };
+  }
+  if (cause === "unreadable") {
+    return {
+      title: "Enduragent couldn’t read its configuration",
+      content:
+        "Check that config.yaml is a readable file and its folder is accessible, then reopen Enduragent.",
+    };
+  }
+  if (cause === "malformed") {
+    return {
+      title: "Enduragent couldn’t use its configuration",
+      content: "Correct or replace the invalid config.yaml file, then reopen Enduragent.",
+    };
+  }
   if (cause === "contention") {
     return {
       title: "Enduragent couldn’t connect to its background service",

--- a/apps/desktop/src/main/supervisor.ts
+++ b/apps/desktop/src/main/supervisor.ts
@@ -6,6 +6,7 @@ import {
   type AppSupervisedChildHandle,
   type DesktopDaemonStartBudget,
   type DesktopDaemonResolution,
+  type ReadinessFailureStatus,
   type ResolveDesktopDaemonInput,
 } from "@enduragent/coach/enduragent";
 import type { DesktopDaemonRecoveryBudget } from "./daemon-lifecycle.js";
@@ -14,6 +15,9 @@ import {
   UTILITY_FORCE_EXIT_TIMEOUT_MS,
   UTILITY_SPAWN_TIMEOUT_MS,
 } from "./constants.js";
+import type { UtilityTerminalFrame } from "../utility/protocol.js";
+
+export type { UtilityTerminalFrame } from "../utility/protocol.js";
 
 export type UtilityStartFrame = {
   readonly type: "start";
@@ -22,10 +26,10 @@ export type UtilityStartFrame = {
 };
 export type UtilityShutdownFrame = { readonly type: "shutdown" };
 export type UtilityTerminalAckFrame = { readonly type: "terminal-ack" };
-export type UtilityTerminalFrame = {
-  readonly type: "terminal";
-  readonly exitCode: number;
-};
+
+function isReadinessFailureStatus(value: unknown): value is ReadinessFailureStatus {
+  return value === "not-configured" || value === "unreadable" || value === "malformed";
+}
 
 export function isUtilityStartFrame(value: unknown): value is UtilityStartFrame {
   if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
@@ -70,14 +74,23 @@ export function isUtilityTerminalAckFrame(value: unknown): value is UtilityTermi
 }
 
 export function isUtilityTerminalFrame(value: unknown): value is UtilityTerminalFrame {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const record = value as Record<string, unknown>;
+  const keys = Object.keys(record).sort();
+  if (
+    record.type !== "terminal" ||
+    !Number.isSafeInteger(record.exitCode) ||
+    (record.exitCode as number) < 0
+  ) {
+    return false;
+  }
+  if (keys.length === 2) return keys[0] === "exitCode" && keys[1] === "type";
   return (
-    value !== null &&
-    typeof value === "object" &&
-    !Array.isArray(value) &&
-    Object.keys(value).length === 2 &&
-    (value as { readonly type?: unknown }).type === "terminal" &&
-    Number.isSafeInteger((value as { readonly exitCode?: unknown }).exitCode) &&
-    (value as { readonly exitCode: number }).exitCode >= 0
+    keys.length === 3 &&
+    keys[0] === "exitCode" &&
+    keys[1] === "readinessFailure" &&
+    keys[2] === "type" &&
+    isReadinessFailureStatus(record.readinessFailure)
   );
 }
 
@@ -220,23 +233,41 @@ export async function forkAppSupervisedDaemon(input: {
   });
   let exitCode: number | null = null;
   let exited = false;
-  let resolveExited!: (value: { readonly exitCode: number | null }) => void;
-  const exitedPromise = new Promise<{ readonly exitCode: number | null }>((resolve) => {
+  let startPosted = false;
+  let terminalClaim: UtilityTerminalFrame | undefined;
+  let resolveExited!: (value: {
+    readonly exitCode: number | null;
+    readonly readinessFailure?: ReadinessFailureStatus;
+  }) => void;
+  const exitedPromise = new Promise<{
+    readonly exitCode: number | null;
+    readonly readinessFailure?: ReadinessFailureStatus;
+  }>((resolve) => {
     resolveExited = resolve;
   });
   child.once("exit", (code) => {
     exited = true;
     exitCode = Number.isInteger(code) ? code : null;
-    resolveExited({ exitCode });
+    const readinessFailure =
+      exitCode !== null &&
+      terminalClaim?.readinessFailure !== undefined &&
+      terminalClaim.exitCode === exitCode
+        ? terminalClaim.readinessFailure
+        : undefined;
+    resolveExited({
+      exitCode,
+      ...(readinessFailure === undefined ? {} : { readinessFailure }),
+    });
   });
   child.on("message", (message) => {
-    if (isUtilityTerminalFrame(message)) {
-      child.postMessage({ type: "terminal-ack" } satisfies UtilityTerminalAckFrame);
-    }
+    if (!startPosted || terminalClaim !== undefined || !isUtilityTerminalFrame(message)) return;
+    terminalClaim = message;
+    child.postMessage({ type: "terminal-ack" } satisfies UtilityTerminalAckFrame);
   });
   try {
     await waitForSpawn(child, input.signal ?? new AbortController().signal);
     child.postMessage(start);
+    startPosted = true;
   } catch {
     try {
       await terminateUnacknowledgedUtility(child, exitedPromise);

--- a/apps/desktop/src/utility/daemon.ts
+++ b/apps/desktop/src/utility/daemon.ts
@@ -3,9 +3,13 @@ import { isAbsolute, join } from "node:path";
 import { tmpdir } from "node:os";
 import { DatabaseSync } from "node:sqlite";
 import { Readable, Writable } from "node:stream";
-import { EXIT_AGENT_ERROR } from "@enduragent/coach-contract";
-import { runAppSupervisedEnduragent } from "@enduragent/coach/enduragent";
+import { EXIT_AGENT_ERROR, type ExitCode } from "@enduragent/coach-contract";
+import {
+  runAppSupervisedEnduragent,
+  type AppSupervisedEnduragentResult,
+} from "@enduragent/coach/enduragent";
 import { UTILITY_TERMINAL_ACK_TIMEOUT_MS } from "../main/constants.js";
+import { createUtilityTerminalFrame } from "./protocol.js";
 
 const parentPort = process.parentPort;
 
@@ -49,7 +53,7 @@ function exactFrame(value: unknown, type: "shutdown" | "terminal-ack"): boolean 
   );
 }
 
-async function postTerminalAndWait(exitCode: number): Promise<void> {
+async function postTerminalAndWait(result: AppSupervisedEnduragentResult): Promise<void> {
   await new Promise<void>((resolve) => {
     let settled = false;
     const finish = (): void => {
@@ -64,11 +68,11 @@ async function postTerminalAndWait(exitCode: number): Promise<void> {
     };
     const timer = setTimeout(finish, UTILITY_TERMINAL_ACK_TIMEOUT_MS);
     parentPort.on("message", onMessage);
-    parentPort.postMessage({ type: "terminal", exitCode });
+    parentPort.postMessage(createUtilityTerminalFrame(result));
   });
 }
 
-async function runtimeSmoke(): Promise<number> {
+async function runtimeSmoke(): Promise<ExitCode> {
   const base = await realpath(tmpdir());
   const directory = await mkdtemp(join(base, "enduragent-desktop-runtime-"));
   try {
@@ -94,8 +98,8 @@ async function runtimeSmoke(): Promise<number> {
 
 async function run(): Promise<void> {
   if (process.argv.includes("--desktop-runtime-smoke")) {
-    const exitCode = await runtimeSmoke().catch(() => EXIT_AGENT_ERROR);
-    await postTerminalAndWait(exitCode);
+    const exitCode: ExitCode = await runtimeSmoke().catch(() => EXIT_AGENT_ERROR);
+    await postTerminalAndWait({ exitCode });
     process.exit(exitCode);
   }
   const controller = new AbortController();
@@ -120,7 +124,7 @@ async function run(): Promise<void> {
   };
   parentPort.on("message", onMessage);
   const frame = await firstFrame;
-  let exitCode = EXIT_AGENT_ERROR;
+  let result: AppSupervisedEnduragentResult = { exitCode: EXIT_AGENT_ERROR };
   if (frame !== undefined) {
     const env: Record<string, string | undefined> = {
       ...process.env,
@@ -134,7 +138,7 @@ async function run(): Promise<void> {
         callback();
       },
     });
-    exitCode = await runAppSupervisedEnduragent({
+    result = await runAppSupervisedEnduragent({
       env,
       terminal: {
         input: Readable.from([]),
@@ -152,11 +156,11 @@ async function run(): Promise<void> {
     finished = true;
   }
   parentPort.removeListener("message", onMessage);
-  await postTerminalAndWait(exitCode);
-  process.exit(exitCode);
+  await postTerminalAndWait(result);
+  process.exit(result.exitCode);
 }
 
 await run().catch(async () => {
-  await postTerminalAndWait(EXIT_AGENT_ERROR);
+  await postTerminalAndWait({ exitCode: EXIT_AGENT_ERROR });
   process.exit(EXIT_AGENT_ERROR);
 });

--- a/apps/desktop/src/utility/protocol.ts
+++ b/apps/desktop/src/utility/protocol.ts
@@ -1,0 +1,20 @@
+import type {
+  AppSupervisedEnduragentResult,
+  ReadinessFailureStatus,
+} from "@enduragent/coach/enduragent";
+
+export type UtilityTerminalFrame = {
+  readonly type: "terminal";
+  readonly exitCode: number;
+  readonly readinessFailure?: ReadinessFailureStatus;
+};
+
+export function createUtilityTerminalFrame(
+  result: AppSupervisedEnduragentResult,
+): UtilityTerminalFrame {
+  return {
+    type: "terminal",
+    exitCode: result.exitCode,
+    ...(result.readinessFailure === undefined ? {} : { readinessFailure: result.readinessFailure }),
+  };
+}

--- a/apps/desktop/tests/lifecycle-messages.test.ts
+++ b/apps/desktop/tests/lifecycle-messages.test.ts
@@ -9,6 +9,21 @@ import {
 describe("desktop lifecycle messages", () => {
   it.each([
     [
+      "not-configured",
+      "Enduragent isn’t configured",
+      "The configuration file is missing. Run Enduragent setup or restore config.yaml, then reopen Enduragent.",
+    ],
+    [
+      "unreadable",
+      "Enduragent couldn’t read its configuration",
+      "Check that config.yaml is a readable file and its folder is accessible, then reopen Enduragent.",
+    ],
+    [
+      "malformed",
+      "Enduragent couldn’t use its configuration",
+      "Correct or replace the invalid config.yaml file, then reopen Enduragent.",
+    ],
+    [
       "contention",
       "Enduragent couldn’t connect to its background service",
       "Another Enduragent process is already running or stuck. Quit that process, then reopen Enduragent. If you can’t find it, log out and back in.",
@@ -28,12 +43,20 @@ describe("desktop lifecycle messages", () => {
   });
 
   it("keeps internal and sensitive details out of every refusal", () => {
-    const copies = ["contention", "version-mismatch", "never-published", "unavailable"].map(
-      (value) => startupRefusalCopy(value as Parameters<typeof startupRefusalCopy>[0]),
-    );
+    const copies = [
+      "not-configured",
+      "unreadable",
+      "malformed",
+      "contention",
+      "version-mismatch",
+      "never-published",
+      "unavailable",
+    ].map((value) => startupRefusalCopy(value as Parameters<typeof startupRefusalCopy>[0]));
     for (const copy of copies) {
       const visible = `${copy.title}\n${copy.content}`;
-      expect(visible).not.toMatch(/contention|version-mismatch|never-published|unavailable/u);
+      expect(visible).not.toMatch(
+        /not-configured|unreadable|malformed|contention|version-mismatch|never-published|unavailable/u,
+      );
       expect(visible).not.toMatch(/(?:ws|http)s?:\/\//u);
       expect(visible).not.toMatch(/[A-Za-z0-9_-]{43}/u);
       expect(visible).not.toMatch(/exit(?:\s+|-)?code/iu);
@@ -42,6 +65,9 @@ describe("desktop lifecycle messages", () => {
   });
 
   it.each([
+    ["not-configured", startupRefusalCopy("not-configured")],
+    ["unreadable", startupRefusalCopy("unreadable")],
+    ["malformed", startupRefusalCopy("malformed")],
     ["contention", startupRefusalCopy("contention")],
     ["version-mismatch", startupRefusalCopy("version-mismatch")],
     ["never-published", startupRefusalCopy("never-published")],

--- a/apps/desktop/tests/supervisor.test.ts
+++ b/apps/desktop/tests/supervisor.test.ts
@@ -87,7 +87,7 @@ describe("desktop main supervisor", () => {
     expect(resolveDaemon).toHaveBeenCalledTimes(2);
   });
 
-  it("starts over the closed control protocol and acknowledges terminal frames", async () => {
+  it("starts over the closed control protocol and acknowledges one exact terminal frame", async () => {
     const child = new FakeUtilityProcess();
     const fork = vi.mocked((await import("electron")).utilityProcess.fork);
     fork.mockReturnValue(child as never);
@@ -118,7 +118,123 @@ describe("desktop main supervisor", () => {
     expect(child.postMessage).toHaveBeenCalledWith({ type: "shutdown" });
     child.emit("exit", 0);
     await stopping;
+    await expect(handle.exited).resolves.toEqual({ exitCode: 0 });
     expect(child.kill).not.toHaveBeenCalled();
+  });
+
+  it("ignores terminal frames received before posting the validated start frame", async () => {
+    const child = new FakeUtilityProcess();
+    const fork = vi.mocked((await import("electron")).utilityProcess.fork);
+    fork.mockReturnValue(child as never);
+    const started = forkAppSupervisedDaemon({
+      utilityEntry: "/synthetic/daemon-utility.js",
+      homeRoot: "/synthetic/athlete",
+    });
+
+    child.emit("message", { type: "terminal", exitCode: 1, readinessFailure: "unreadable" });
+    expect(child.postMessage).not.toHaveBeenCalledWith({ type: "terminal-ack" });
+    child.emit("spawn");
+    const handle = await started;
+    child.postMessage.mockClear();
+    child.emit("message", { type: "terminal", exitCode: 1, readinessFailure: "malformed" });
+    child.emit("exit", 1);
+
+    expect(child.postMessage).toHaveBeenCalledOnce();
+    expect(child.postMessage).toHaveBeenCalledWith({ type: "terminal-ack" });
+    await expect(handle.exited).resolves.toEqual({
+      exitCode: 1,
+      readinessFailure: "malformed",
+    });
+  });
+
+  it("lets the first valid terminal frame own the claim and ignores typed duplicates", async () => {
+    const child = new FakeUtilityProcess();
+    const fork = vi.mocked((await import("electron")).utilityProcess.fork);
+    fork.mockReturnValue(child as never);
+    const started = forkAppSupervisedDaemon({
+      utilityEntry: "/synthetic/daemon-utility.js",
+      homeRoot: "/synthetic/athlete",
+    });
+    child.emit("spawn");
+    const handle = await started;
+    child.postMessage.mockClear();
+
+    child.emit("message", { type: "terminal", exitCode: 1 });
+    child.emit("message", { type: "terminal", exitCode: 1, readinessFailure: "unreadable" });
+    child.emit("message", { type: "terminal", exitCode: 1, readinessFailure: "malformed" });
+    child.emit("exit", 1);
+
+    expect(child.postMessage).toHaveBeenCalledOnce();
+    expect(child.postMessage).toHaveBeenCalledWith({ type: "terminal-ack" });
+    await expect(handle.exited).resolves.toEqual({ exitCode: 1 });
+  });
+
+  it("exposes only the first typed terminal claim when its code exactly matches the exit", async () => {
+    const child = new FakeUtilityProcess();
+    const fork = vi.mocked((await import("electron")).utilityProcess.fork);
+    fork.mockReturnValue(child as never);
+    const started = forkAppSupervisedDaemon({
+      utilityEntry: "/synthetic/daemon-utility.js",
+      homeRoot: "/synthetic/athlete",
+    });
+    child.emit("spawn");
+    const handle = await started;
+    child.postMessage.mockClear();
+
+    child.emit("message", { type: "terminal", exitCode: 1, readinessFailure: "unreadable" });
+    child.emit("message", { type: "terminal", exitCode: 1, readinessFailure: "malformed" });
+    child.emit("exit", 1);
+
+    expect(child.postMessage).toHaveBeenCalledOnce();
+    await expect(handle.exited).resolves.toEqual({
+      exitCode: 1,
+      readinessFailure: "unreadable",
+    });
+  });
+
+  it.each([
+    ["a mismatched exit code", 0],
+    ["a signal exit", null],
+  ] as const)("does not expose terminal metadata for %s", async (_case, actualExit) => {
+    const child = new FakeUtilityProcess();
+    const fork = vi.mocked((await import("electron")).utilityProcess.fork);
+    fork.mockReturnValue(child as never);
+    const started = forkAppSupervisedDaemon({
+      utilityEntry: "/synthetic/daemon-utility.js",
+      homeRoot: "/synthetic/athlete",
+    });
+    child.emit("spawn");
+    const handle = await started;
+    child.postMessage.mockClear();
+
+    child.emit("message", { type: "terminal", exitCode: 1, readinessFailure: "unreadable" });
+    child.emit("exit", actualExit);
+
+    expect(child.postMessage).toHaveBeenCalledOnce();
+    await expect(handle.exited).resolves.toEqual({ exitCode: actualExit });
+  });
+
+  it("rejects invalid terminal metadata without acknowledgement or exit exposure", async () => {
+    const child = new FakeUtilityProcess();
+    const fork = vi.mocked((await import("electron")).utilityProcess.fork);
+    fork.mockReturnValue(child as never);
+    const started = forkAppSupervisedDaemon({
+      utilityEntry: "/synthetic/daemon-utility.js",
+      homeRoot: "/synthetic/athlete",
+    });
+    child.emit("spawn");
+    const handle = await started;
+    child.postMessage.mockClear();
+
+    child.emit("message", {
+      type: "terminal",
+      exitCode: 1,
+      readinessFailure: "malformed",
+      error: "synthetic-private-detail",
+    });
+    expect(child.postMessage).not.toHaveBeenCalled();
+    child.emit("exit", 1);
+    await expect(handle.exited).resolves.toEqual({ exitCode: 1 });
   });
 
   it("uses one bounded kill fallback and still waits for observed exit", async () => {

--- a/apps/desktop/tests/utility-protocol.test.ts
+++ b/apps/desktop/tests/utility-protocol.test.ts
@@ -6,6 +6,7 @@ import {
   isUtilityTerminalFrame,
   createUtilityEnvironment,
 } from "../src/main/supervisor.js";
+import { createUtilityTerminalFrame } from "../src/utility/protocol.js";
 
 describe("desktop utility protocol", () => {
   it("accepts only strict start and shutdown control frames", () => {
@@ -30,10 +31,51 @@ describe("desktop utility protocol", () => {
 
   it("accepts only strict terminal and acknowledgement frames", () => {
     expect(isUtilityTerminalFrame({ type: "terminal", exitCode: 0 })).toBe(true);
+    for (const readinessFailure of ["not-configured", "unreadable", "malformed"]) {
+      expect(isUtilityTerminalFrame({ type: "terminal", exitCode: 1, readinessFailure })).toBe(
+        true,
+      );
+    }
     expect(isUtilityTerminalFrame({ type: "terminal", exitCode: -1 })).toBe(false);
     expect(isUtilityTerminalFrame({ type: "terminal", exitCode: 0, extra: true })).toBe(false);
+    expect(
+      isUtilityTerminalFrame({
+        type: "terminal",
+        exitCode: 1,
+        readinessFailure: "invalid-profile",
+      }),
+    ).toBe(false);
+    expect(
+      isUtilityTerminalFrame({
+        type: "terminal",
+        exitCode: 1,
+        readinessFailure: "malformed",
+        message: "synthetic-private-detail",
+      }),
+    ).toBe(false);
     expect(isUtilityTerminalAckFrame({ type: "terminal-ack" })).toBe(true);
     expect(isUtilityTerminalAckFrame({ type: "terminal-ack", extra: true })).toBe(false);
+  });
+
+  it.each([
+    [{ exitCode: 0 as const }, { type: "terminal", exitCode: 0 }],
+    [
+      { exitCode: 4 as const, readinessFailure: "not-configured" as const },
+      { type: "terminal", exitCode: 4, readinessFailure: "not-configured" },
+    ],
+    [
+      { exitCode: 1 as const, readinessFailure: "unreadable" as const },
+      { type: "terminal", exitCode: 1, readinessFailure: "unreadable" },
+    ],
+    [
+      { exitCode: 1 as const, readinessFailure: "malformed" as const },
+      { type: "terminal", exitCode: 1, readinessFailure: "malformed" },
+    ],
+  ])("constructs the exact utility terminal frame for %j", (result, expected) => {
+    const frame = createUtilityTerminalFrame(result);
+    expect(frame).toEqual(expected);
+    expect(Object.keys(frame).sort()).toEqual(Object.keys(expected).sort());
+    expect(isUtilityTerminalFrame(frame)).toBe(true);
   });
 
   it("removes daemon ownership material from the utility environment", () => {

--- a/packages/coach/src/enduragent.ts
+++ b/packages/coach/src/enduragent.ts
@@ -83,6 +83,8 @@ import {
   type LocalCoachRunResult,
   type WithLocalCoachInput,
 } from "./local-runner.js";
+import type { ReadinessFailureStatus } from "./readiness.js";
+export type { ReadinessFailureStatus } from "./readiness.js";
 import { serializeBoundaryError } from "./daemon/error-boundary.js";
 import { CoachStoreWriterError } from "./runtime.js";
 import { runCoachServe } from "./serve.js";
@@ -146,7 +148,10 @@ export type ServiceRegistrationClass = "absent" | "registered" | "unknown";
 
 export interface AppSupervisedChildHandle {
   readonly pid: number;
-  readonly exited: Promise<{ readonly exitCode: number | null }>;
+  readonly exited: Promise<{
+    readonly exitCode: number | null;
+    readonly readinessFailure?: ReadinessFailureStatus;
+  }>;
   isAlive(): boolean;
   stop(): Promise<void>;
 }
@@ -730,6 +735,18 @@ function renderLocalResult(
     );
     return EXIT_NOT_CONFIGURED;
   }
+  if (result.status === "unreadable") {
+    terminal.stderr.write(
+      "Enduragent cannot read the existing configuration. Check that config.yaml is a readable file, then retry.\n",
+    );
+    return EXIT_AGENT_ERROR;
+  }
+  if (result.status === "malformed") {
+    terminal.stderr.write(
+      "Enduragent cannot use the existing configuration. Correct or replace config.yaml, then retry.\n",
+    );
+    return EXIT_AGENT_ERROR;
+  }
   if (result.status === "migration-discarded") {
     terminal.stderr.write(
       `Enduragent migration plan ${result.result.manifestDigest} was discarded to ${result.result.archivePath}. Run enduragent again to replan.\n`,
@@ -1069,15 +1086,20 @@ export type DesktopDaemonResolution =
       readonly token: string;
       readonly owner: DaemonOwner;
       readonly supervision: "app-supervised";
-      readonly exited: Promise<{ readonly exitCode: number | null }>;
+      readonly exited: AppSupervisedChildHandle["exited"];
       isAlive(): boolean;
       close(): Promise<void>;
     }
   | {
       readonly status: "refused";
-      readonly exitCode: 3 | 5;
-      readonly classification: "contention-family" | "version-mismatch" | "never-published";
+      readonly exitCode: 1 | 3 | 4 | 5;
+      readonly classification:
+        | "configuration"
+        | "contention-family"
+        | "version-mismatch"
+        | "never-published";
       readonly cause:
+        | ReadinessFailureStatus
         | "contention"
         | "version-mismatch"
         | "never-published"
@@ -1103,42 +1125,69 @@ const desktopDaemonDependencies: DesktopDaemonDependencies = {
 };
 
 function refusedDesktop(
-  exitCode: 3 | 5,
+  exitCode: 1 | 3 | 4 | 5,
   cause: Extract<DesktopDaemonResolution, { status: "refused" }>["cause"] = exitCode ===
   EXIT_VERSION_MISMATCH
     ? "version-mismatch"
     : "contention",
 ): DesktopDaemonResolution {
   const classification =
-    cause === "version-mismatch"
-      ? "version-mismatch"
-      : cause === "never-published"
-        ? "never-published"
-        : "contention-family";
+    cause === "not-configured" || cause === "unreadable" || cause === "malformed"
+      ? "configuration"
+      : cause === "version-mismatch"
+        ? "version-mismatch"
+        : cause === "never-published"
+          ? "never-published"
+          : "contention-family";
   return {
     status: "refused",
     exitCode,
     classification,
     cause,
-    retryable: cause !== "version-mismatch" && cause !== "termination-failed",
+    retryable:
+      cause !== "not-configured" &&
+      cause !== "unreadable" &&
+      cause !== "malformed" &&
+      cause !== "version-mismatch" &&
+      cause !== "termination-failed",
   };
 }
 
-async function stopAppChild(child: AppSupervisedChildHandle | undefined): Promise<boolean> {
-  if (child === undefined) return true;
+type AppChildStopOutcome =
+  | { readonly status: "absent" }
+  | {
+      readonly status: "stopped";
+      readonly result: Awaited<AppSupervisedChildHandle["exited"]>;
+    }
+  | { readonly status: "failed" };
+
+async function stopAppChildAndObserve(
+  child: AppSupervisedChildHandle | undefined,
+): Promise<AppChildStopOutcome> {
+  if (child === undefined) return { status: "absent" };
   try {
     await child.stop();
-    await child.exited;
-    return true;
+    return { status: "stopped", result: await child.exited };
   } catch {
-    return false;
+    return { status: "failed" };
   }
+}
+
+async function stopAppChild(child: AppSupervisedChildHandle | undefined): Promise<boolean> {
+  return (await stopAppChildAndObserve(child)).status !== "failed";
 }
 
 class AppChildTerminationError extends Error {}
 
 async function requireStoppedAppChild(child: AppSupervisedChildHandle | undefined): Promise<void> {
   if (!(await stopAppChild(child))) throw new AppChildTerminationError();
+}
+
+function refusedDesktopReadiness(status: ReadinessFailureStatus): DesktopDaemonResolution {
+  return refusedDesktop(
+    status === "not-configured" ? EXIT_NOT_CONFIGURED : EXIT_AGENT_ERROR,
+    status,
+  );
 }
 
 function connectedDesktop(
@@ -1177,7 +1226,10 @@ function connectedDesktop(
 
 type DesktopPublicationOutcome =
   | { readonly kind: "published"; readonly observation: DaemonStateObservation }
-  | { readonly kind: "child-exited" }
+  | {
+      readonly kind: "child-exited";
+      readonly result: Awaited<AppSupervisedChildHandle["exited"]>;
+    }
   | { readonly kind: "cancelled" }
   | { readonly kind: "deadline"; readonly observation: DaemonStateObservation };
 
@@ -1202,8 +1254,9 @@ async function waitForDesktopDaemon(input: {
     abortListener = () => resolve({ kind: "cancelled" });
     input.signal.addEventListener("abort", abortListener, { once: true });
   });
-  const childExited = input.child?.exited.then<DesktopPublicationOutcome>(() => ({
+  const childExited = input.child?.exited.then<DesktopPublicationOutcome>((result) => ({
     kind: "child-exited",
+    result,
   }));
   let nextDelayMs = 50;
   let lastObservation: DaemonStateObservation = { kind: "absent" };
@@ -1414,18 +1467,24 @@ export async function resolveDesktopDaemon(
         );
       } catch (error) {
         const startedChild = binding.takeStartedAppChild();
-        const stoppedStarted = await stopAppChild(startedChild);
+        const stoppedStarted = await stopAppChildAndObserve(startedChild);
         const stoppedOwned = await stopAppChild(ownedChild);
-        return refusedDesktop(
-          EXIT_DAEMON_UNAVAILABLE,
+        if (
           error instanceof AppChildTerminationError ||
-            (error instanceof AppSupervisedDaemonStartError &&
-              error.cause === "termination-failed") ||
-            !stoppedStarted ||
-            !stoppedOwned
-            ? "termination-failed"
-            : "unavailable",
-        );
+          (error instanceof AppSupervisedDaemonStartError &&
+            error.cause === "termination-failed") ||
+          stoppedStarted.status === "failed" ||
+          !stoppedOwned
+        ) {
+          return refusedDesktop(EXIT_DAEMON_UNAVAILABLE, "termination-failed");
+        }
+        if (
+          stoppedStarted.status === "stopped" &&
+          stoppedStarted.result.readinessFailure !== undefined
+        ) {
+          return refusedDesktopReadiness(stoppedStarted.result.readinessFailure);
+        }
+        return refusedDesktop(EXIT_DAEMON_UNAVAILABLE, "unavailable");
       }
       const startedChild = binding.takeStartedAppChild();
       if (startedChild !== undefined) {
@@ -1449,6 +1508,16 @@ export async function resolveDesktopDaemon(
         );
       }
       if (starter.status === "retry-startup") {
+        if (startedChild !== undefined) {
+          const stopped = await stopAppChildAndObserve(ownedChild);
+          if (stopped.status === "failed") {
+            return refusedDesktop(EXIT_DAEMON_UNAVAILABLE, "termination-failed");
+          }
+          ownedChild = undefined;
+          if (stopped.status === "stopped" && stopped.result.readinessFailure !== undefined) {
+            return refusedDesktopReadiness(stopped.result.readinessFailure);
+          }
+        }
         try {
           observation = await dependencies.observeDaemonState({ home });
         } catch {
@@ -1460,10 +1529,18 @@ export async function resolveDesktopDaemon(
         }
         continue;
       }
-      if (!(await stopAppChild(ownedChild))) {
+      const stopped = await stopAppChildAndObserve(ownedChild);
+      if (stopped.status === "failed") {
         return refusedDesktop(EXIT_DAEMON_UNAVAILABLE, "termination-failed");
       }
       ownedChild = undefined;
+      if (
+        startedChild !== undefined &&
+        stopped.status === "stopped" &&
+        stopped.result.readinessFailure !== undefined
+      ) {
+        return refusedDesktopReadiness(stopped.result.readinessFailure);
+      }
       if (starter.status === "refuse") {
         return refusedDesktop(
           starter.exitCode,
@@ -1542,6 +1619,10 @@ export async function resolveDesktopDaemon(
       const stopped = await stopAppChild(ownedChild);
       ownedChild = undefined;
       if (!stopped) return refusedDesktop(EXIT_DAEMON_UNAVAILABLE, "termination-failed");
+      if (published.kind === "child-exited" && published.result.readinessFailure !== undefined) {
+        startBudget.remainingAttempts += 1;
+        return refusedDesktopReadiness(published.result.readinessFailure);
+      }
       if (published.kind === "cancelled") {
         return refusedDesktop(EXIT_DAEMON_UNAVAILABLE, "cancelled");
       }
@@ -1893,6 +1974,7 @@ async function runServeInvocation(input: {
   readonly sourceRoot: string;
   readonly appVersion: string;
   readonly dependencies: EnduragentDependencies;
+  readonly reportReadinessFailure?: (status: ReadinessFailureStatus) => void;
 }): Promise<ExitCode> {
   const admission =
     input.dependencies.withLocalCoach === defaultDependencies.withLocalCoach
@@ -1940,6 +2022,13 @@ async function runServeInvocation(input: {
       });
       if (result.status !== "completed" && successor !== undefined) {
         await successor.fence.release();
+      }
+      if (
+        result.status === "not-configured" ||
+        result.status === "unreadable" ||
+        result.status === "malformed"
+      ) {
+        input.reportReadinessFailure?.(result.status);
       }
       return result.status === "completed"
         ? result.value
@@ -2004,6 +2093,11 @@ export interface RunAppSupervisedEnduragentInput {
   readonly handoffCapability?: string;
 }
 
+export interface AppSupervisedEnduragentResult {
+  readonly exitCode: ExitCode;
+  readonly readinessFailure?: ReadinessFailureStatus;
+}
+
 function renderEnduragentFailure(
   error: unknown,
   terminal: Pick<CoachCliTerminal, "stderr">,
@@ -2041,12 +2135,17 @@ function renderEnduragentFailure(
 export async function runAppSupervisedEnduragent(
   input: RunAppSupervisedEnduragentInput,
   dependencies?: EnduragentDependencies,
-): Promise<ExitCode> {
+): Promise<AppSupervisedEnduragentResult> {
   if (
     input.handoffCapability !== undefined &&
     !/^[A-Za-z0-9_-]{43}$/.test(input.handoffCapability)
   ) {
-    return renderEnduragentFailure(new TypeError("invalid handoff capability"), input.terminal);
+    return {
+      exitCode: renderEnduragentFailure(
+        new TypeError("invalid handoff capability"),
+        input.terminal,
+      ),
+    };
   }
   const resolvedDependencies: EnduragentDependencies = {
     ...defaultDependencies,
@@ -2054,7 +2153,8 @@ export async function runAppSupervisedEnduragent(
   };
   try {
     const home = canonicalHome(resolvedDependencies.resolveAthleteHome(input.env));
-    return await runServeInvocation({
+    let readinessFailure: ReadinessFailureStatus | undefined;
+    const exitCode = await runServeInvocation({
       invocationOwner: "app-supervised",
       ...(input.handoffCapability === undefined
         ? {}
@@ -2069,9 +2169,16 @@ export async function runAppSupervisedEnduragent(
       sourceRoot: resolveLegacySourceRoot(input.env),
       appVersion: await resolvedDependencies.readPackageVersion(),
       dependencies: resolvedDependencies,
+      reportReadinessFailure: (status) => {
+        readinessFailure = status;
+      },
     });
+    return {
+      exitCode,
+      ...(readinessFailure === undefined ? {} : { readinessFailure }),
+    };
   } catch (error) {
-    return renderEnduragentFailure(error, input.terminal);
+    return { exitCode: renderEnduragentFailure(error, input.terminal) };
   }
 }
 

--- a/packages/coach/src/local-runner.ts
+++ b/packages/coach/src/local-runner.ts
@@ -1,4 +1,3 @@
-import { engineConfigFromConfig, loadConfig } from "@enduragent/core";
 import type { CoachEngine, CoachOperations } from "@enduragent/coach-contract";
 import type { AthleteHome } from "@enduragent/kernel-node/home";
 import type { WriterProtocolListener } from "@enduragent/kernel-node/lock";
@@ -9,7 +8,7 @@ import {
   type LegacyMigrationAction,
   type LegacyMigrationResult,
 } from "./legacy-migration.js";
-import { checkHomeReadiness } from "./readiness.js";
+import { checkHomeReadiness, type ReadinessFailure } from "./readiness.js";
 import { withCoachStoreWriter } from "./runtime.js";
 
 export interface LocalCoachLifecycle {
@@ -22,7 +21,7 @@ export interface LocalCoachLifecycle {
 
 export type LocalCoachRunResult<T> =
   | { readonly status: "completed"; readonly value: T }
-  | { readonly status: "not-configured"; readonly configPath: string }
+  | ReadinessFailure
   | {
       readonly status: "migration-refused";
       readonly result: Extract<LegacyMigrationResult, { status: "refused" }>;
@@ -49,7 +48,7 @@ class MigrationTerminal extends Error {
 }
 
 type WriterValue<T> =
-  | { readonly kind: "not-configured"; readonly configPath: string }
+  | { readonly kind: "readiness-failure"; readonly result: ReadinessFailure }
   | { readonly kind: "fulfilled"; readonly value: T }
   | { readonly kind: "rejected"; readonly error: unknown };
 
@@ -109,17 +108,11 @@ export async function withLocalCoach<T>(
       },
       operation: async (context): Promise<WriterValue<T>> => {
         const readiness = await checkHomeReadiness(context.home);
-        if (readiness.status === "not-configured") {
+        if (readiness.status !== "ready") {
           return {
-            kind: "not-configured",
-            configPath: readiness.configPath,
+            kind: "readiness-failure",
+            result: readiness,
           };
-        }
-        const config = loadConfig(context.home.configDir, {
-          defaultDataDir: context.home.root,
-        });
-        if (JSON.stringify(engineConfigFromConfig(config)) !== JSON.stringify(readiness.config)) {
-          throw new TypeError("Ready engine configuration changed before engine construction.");
         }
         let lifecycle: LocalCoachComposition | undefined;
         let lifecycleCloseOutcome: { kind: "succeeded" } | { kind: "failed"; error: unknown } = {
@@ -131,8 +124,8 @@ export async function withLocalCoach<T>(
             env: writerEnv,
             home: input.home,
             context,
-            config,
-            engineConfig: readiness.config,
+            config: readiness.config,
+            engineConfig: readiness.engineConfig,
           });
           const publishedLifecycle = lifecycle;
           try {
@@ -172,8 +165,6 @@ export async function withLocalCoach<T>(
     throw error;
   }
   if (writerValue.kind === "rejected") throw writerValue.error;
-  if (writerValue.kind === "not-configured") {
-    return { status: "not-configured", configPath: writerValue.configPath };
-  }
+  if (writerValue.kind === "readiness-failure") return writerValue.result;
   return { status: "completed", value: writerValue.value };
 }

--- a/packages/coach/src/readiness.ts
+++ b/packages/coach/src/readiness.ts
@@ -1,35 +1,96 @@
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
-import { engineConfigFromConfig, loadConfig } from "@enduragent/core";
+import {
+  engineConfigFromConfig,
+  loadConfigFromYaml,
+  type Config,
+  type LoadConfigOptions,
+} from "@enduragent/core";
 import type { EngineConfig } from "@enduragent/engine";
 import type { AthleteHome } from "@enduragent/kernel-node/home";
 import { parse as parseYaml } from "yaml";
 
+export type ReadinessFailureStatus = "not-configured" | "unreadable" | "malformed";
+
+export type ReadinessFailure =
+  | { readonly status: "not-configured"; readonly configPath: string }
+  | { readonly status: "unreadable" }
+  | { readonly status: "malformed" };
+
 export type ReadinessResult =
-  | { status: "ready"; config: EngineConfig }
-  | { status: "not-configured"; configPath: string };
+  | {
+      readonly status: "ready";
+      readonly config: Config;
+      readonly engineConfig: EngineConfig;
+    }
+  | ReadinessFailure;
+
+export interface ReadinessDependencies {
+  readonly readConfigFile: (path: string, encoding: "utf8") => Promise<string>;
+  readonly loadConfig: (
+    yaml: Record<string, unknown>,
+    configDir: string,
+    options: LoadConfigOptions,
+  ) => Config;
+  readonly projectConfig: (config: Config) => EngineConfig;
+}
+
+const readinessDependencies: ReadinessDependencies = {
+  readConfigFile: readFile,
+  loadConfig: loadConfigFromYaml,
+  projectConfig: engineConfigFromConfig,
+};
 
 function isMap(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-export async function checkHomeReadiness(home: AthleteHome): Promise<ReadinessResult> {
-  const configPath = join(home.configDir, "config.yaml");
+function isMissing(error: unknown): boolean {
+  return (
+    error !== null &&
+    typeof error === "object" &&
+    (error as { readonly code?: unknown }).code === "ENOENT"
+  );
+}
+
+function parseConfig(source: string): Record<string, unknown> | undefined {
   try {
-    const parsedYaml = parseYaml(await readFile(configPath, "utf8")) as unknown;
-    if (!isMap(parsedYaml)) return { status: "not-configured", configPath };
-    const config = loadConfig(home.configDir, { defaultDataDir: home.root });
-    const profileName = config.llm.authProfile;
-    if (profileName !== undefined) {
-      const profiles = JSON.parse(
-        await readFile(join(home.configDir, "auth-profiles.json"), "utf8"),
-      ) as unknown;
-      if (!isMap(profiles) || !Object.hasOwn(profiles, profileName)) {
-        return { status: "not-configured", configPath };
-      }
-    }
-    return { status: "ready", config: engineConfigFromConfig(config) };
+    const parsed = parseYaml(source) as unknown;
+    return isMap(parsed) ? parsed : undefined;
   } catch {
-    return { status: "not-configured", configPath };
+    return undefined;
+  }
+}
+
+export async function checkHomeReadiness(
+  home: AthleteHome,
+  dependencies: ReadinessDependencies = readinessDependencies,
+): Promise<ReadinessResult> {
+  const configPath = join(home.configDir, "config.yaml");
+  let initialSource: string;
+  try {
+    initialSource = await dependencies.readConfigFile(configPath, "utf8");
+  } catch (error) {
+    return isMissing(error) ? { status: "not-configured", configPath } : { status: "unreadable" };
+  }
+  if (parseConfig(initialSource) === undefined) return { status: "malformed" };
+
+  let source: string;
+  try {
+    source = await dependencies.readConfigFile(configPath, "utf8");
+  } catch {
+    return { status: "unreadable" };
+  }
+  const yaml = parseConfig(source);
+  if (yaml === undefined) return { status: "malformed" };
+  try {
+    const config = dependencies.loadConfig(yaml, home.configDir, {
+      defaultDataDir: home.root,
+    });
+    if (config.dataDir !== home.root) return { status: "malformed" };
+    const engineConfig = dependencies.projectConfig(config);
+    return { status: "ready", config, engineConfig };
+  } catch {
+    return { status: "malformed" };
   }
 }

--- a/packages/coach/tests/desktop-supervisor.test.ts
+++ b/packages/coach/tests/desktop-supervisor.test.ts
@@ -280,6 +280,51 @@ describe("desktop daemon arbitration", () => {
     expect(children.every(({ stop }) => stop.mock.calls.length === 1)).toBe(true);
   });
 
+  it.each([
+    ["not-configured", 4],
+    ["unreadable", 1],
+    ["malformed", 1],
+  ] as const)(
+    "immediately refuses typed %s without retrying or consuming the shared start budget",
+    async (readinessFailure, exitCode) => {
+      const budget = { remainingAttempts: 3, deadline: 60_000 };
+      const owned = {
+        pid: 100,
+        exited: Promise.resolve({ exitCode, readinessFailure }),
+        isAlive: () => false,
+        stop: vi.fn(async () => {}),
+      };
+      const start = vi.fn(async () => owned);
+      const deps = dependencies({ registration: "absent", observations: [{ kind: "absent" }] });
+      const delay = vi.spyOn(deps, "delay");
+
+      const result = await resolveDesktopDaemon(
+        {
+          env: {},
+          executablePath: "/Applications/Enduragent",
+          appVersion: "0.1.0",
+          signal: new AbortController().signal,
+          startAppSupervisedDaemon: start,
+          startBudget: budget,
+        },
+        deps,
+      );
+
+      expect(result).toEqual({
+        status: "refused",
+        exitCode,
+        classification: "configuration",
+        cause: readinessFailure,
+        retryable: false,
+      });
+      expect(start).toHaveBeenCalledOnce();
+      expect(owned.stop).toHaveBeenCalledOnce();
+      expect(delay).not.toHaveBeenCalled();
+      expect(budget.remainingAttempts).toBe(3);
+      expect(JSON.stringify(result)).not.toContain("synthetic-private");
+    },
+  );
+
   it("observes every child exit before starting its replacement", async () => {
     const order: string[] = [];
     const children = Array.from({ length: 3 }, (_, index) => {
@@ -474,6 +519,104 @@ describe("desktop daemon arbitration", () => {
     expect(start).toHaveBeenCalledTimes(1);
     if (result.status === "connected") await result.close();
     expect(successor.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(["refuse", "retry", "throw"] as const)(
+    "preserves a typed client-newer handoff exit when second-starter resolution ends with %s",
+    async (outcome) => {
+      const budget = { remainingAttempts: 3, deadline: 60_000 };
+      const successor = {
+        pid: 101,
+        exited: Promise.resolve({ exitCode: 1, readinessFailure: "malformed" as const }),
+        isAlive: () => false,
+        stop: vi.fn(async () => {}),
+      };
+      const start = vi.fn(async () => successor);
+      const base = dependencies({
+        registration: "absent",
+        observations: [mismatch("app-supervised", "client-newer")],
+      });
+      const resolveSecondStarter = vi.fn(async (_input, binding) => {
+        await binding.serviceUpgrade.startEphemeralSuccessor({
+          home,
+          targetProtocolVersion: PROTOCOL_VERSION,
+          handoffCapability: "h".repeat(43),
+        });
+        if (outcome === "throw") throw new Error("synthetic handoff failure");
+        if (outcome === "retry") return { status: "retry-startup" as const };
+        return {
+          status: "refuse" as const,
+          exitCode: 3 as const,
+          stdout: "" as const,
+          stderr: "",
+        };
+      });
+
+      const result = await resolveDesktopDaemon(
+        {
+          env: {},
+          executablePath: "/Applications/Enduragent",
+          appVersion: "0.1.0",
+          signal: new AbortController().signal,
+          startAppSupervisedDaemon: start,
+          startBudget: budget,
+        },
+        { ...base, resolveSecondStarter },
+      );
+
+      expect(result).toEqual({
+        status: "refused",
+        exitCode: 1,
+        classification: "configuration",
+        cause: "malformed",
+        retryable: false,
+      });
+      expect(start).toHaveBeenCalledOnce();
+      expect(successor.stop).toHaveBeenCalledOnce();
+      expect(budget.remainingAttempts).toBe(3);
+      expect(JSON.stringify(result)).not.toContain("synthetic handoff failure");
+    },
+  );
+
+  it("keeps handoff cleanup failure ahead of an already typed successor exit", async () => {
+    const successor = {
+      pid: 101,
+      exited: Promise.resolve({ exitCode: 1, readinessFailure: "unreadable" as const }),
+      isAlive: () => false,
+      stop: vi.fn(async () => {
+        throw new Error("synthetic cleanup failure");
+      }),
+    };
+    const base = dependencies({
+      registration: "absent",
+      observations: [mismatch("app-supervised", "client-newer")],
+    });
+    const resolveSecondStarter = vi.fn(async (_input, binding) => {
+      await binding.serviceUpgrade.startEphemeralSuccessor({
+        home,
+        targetProtocolVersion: PROTOCOL_VERSION,
+        handoffCapability: "h".repeat(43),
+      });
+      throw new Error("synthetic handoff failure");
+    });
+
+    const result = await resolveDesktopDaemon(
+      {
+        env: {},
+        executablePath: "/Applications/Enduragent",
+        appVersion: "0.1.0",
+        signal: new AbortController().signal,
+        startAppSupervisedDaemon: vi.fn(async () => successor),
+      },
+      { ...base, resolveSecondStarter },
+    );
+
+    expect(result).toMatchObject({
+      status: "refused",
+      cause: "termination-failed",
+      retryable: false,
+    });
+    expect(successor.stop).toHaveBeenCalledOnce();
   });
 
   it("stops client-newer handoff after an unconfirmed utility cleanup", async () => {

--- a/packages/coach/tests/enduragent-entry.test.ts
+++ b/packages/coach/tests/enduragent-entry.test.ts
@@ -29,6 +29,7 @@ import { StoreNewerThanAppError } from "@enduragent/kernel/store";
 import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
 import { openSqliteStorage } from "@enduragent/kernel-node/sqlite";
 import {
+  runAppSupervisedEnduragent,
   runEnduragent,
   type EnduragentDependencies,
   type RunEnduragentInput,
@@ -378,7 +379,7 @@ describe("enduragent executable composition", () => {
     const configPath = join(home.configDir, "config.yaml");
     const rows: ReadonlyArray<{
       readonly result: LocalCoachRunResult<never>;
-      readonly exitCode: 0 | 2 | 3 | 4;
+      readonly exitCode: 0 | 1 | 2 | 3 | 4;
       readonly stderr: string;
     }> = [
       {
@@ -445,6 +446,18 @@ describe("enduragent executable composition", () => {
         exitCode: 4,
         stderr: `Enduragent is not configured. Provision ${configPath} with provider credentials, then run: enduragent\n`,
       },
+      {
+        result: { status: "unreadable" },
+        exitCode: 1,
+        stderr:
+          "Enduragent cannot read the existing configuration. Check that config.yaml is a readable file, then retry.\n",
+      },
+      {
+        result: { status: "malformed" },
+        exitCode: 1,
+        stderr:
+          "Enduragent cannot use the existing configuration. Correct or replace config.yaml, then retry.\n",
+      },
     ];
 
     for (const row of rows) {
@@ -492,6 +505,35 @@ describe("enduragent executable composition", () => {
       expect(captured?.action).toEqual({ kind: "resume", isTTY: true });
     }
   });
+
+  it.each([
+    ["not-configured", 4],
+    ["unreadable", 1],
+    ["malformed", 1],
+  ] as const)(
+    "returns a safe typed app-supervised %s outcome while keeping the ordinary exit code",
+    async (status, exitCode) => {
+      const io = terminal();
+      const privateConfigPath = join(home.configDir, "synthetic-private-profile-token");
+      const result = await runAppSupervisedEnduragent(
+        {
+          env,
+          terminal: io.value,
+          signal: new AbortController().signal,
+        },
+        {
+          resolveAthleteHome: () => home,
+          withLocalCoach: async <T>(): Promise<LocalCoachRunResult<T>> =>
+            status === "not-configured" ? { status, configPath: privateConfigPath } : { status },
+          readPackageVersion: async () => "0.1.0-synthetic",
+        },
+      );
+
+      expect(result).toEqual({ exitCode, readinessFailure: status });
+      expect(JSON.stringify(result)).not.toContain("synthetic-private-profile-token");
+      expect(Object.keys(result).sort()).toEqual(["exitCode", "readinessFailure"]);
+    },
+  );
 
   it("preserves FIFO and lifecycle close ordering after physical EOF", async () => {
     const trace: string[] = [];

--- a/packages/coach/tests/first-run-serve.integration.test.ts
+++ b/packages/coach/tests/first-run-serve.integration.test.ts
@@ -75,8 +75,19 @@ function childExit(child: ChildProcessWithoutNullStreams): Promise<{
   });
 }
 
+async function expectPreservedFile(
+  path: string,
+  bytes: Buffer,
+  before: { readonly ino: number; readonly mode: number },
+): Promise<void> {
+  const current = await stat(path);
+  await expect(readFile(path)).resolves.toEqual(bytes);
+  expect(current.ino).toBe(before.ino);
+  expect(current.mode & 0o777).toBe(0o600);
+}
+
 describe.skipIf(!hasSockets)("first-run serve process", () => {
-  it("boots an existing config without data_dir through /healthz without clobbering it", async () => {
+  it("publishes /healthz from a blank OpenAI Codex config without clobbering existing files", async () => {
     const scratchRoot = process.platform === "darwin" ? "/private/tmp" : await realpath(tmpdir());
     const scratch = await mkdtemp(join(scratchRoot, "ea-serve-"));
     roots.push(scratch);
@@ -93,23 +104,23 @@ describe.skipIf(!hasSockets)("first-run serve process", () => {
       [
         "data_source: store",
         "llm:",
-        "  provider: anthropic",
-        "  model: synthetic",
-        "  api_key: synthetic",
-        "intervals:",
-        "  api_key: synthetic",
-        "  athlete_id: synthetic",
+        "  provider: openai-codex",
+        "  model: gpt-5.5",
+        "  auth_profile: synthetic-absent",
         "session:",
         "  timezone: UTC",
         "",
       ].join("\n"),
     );
     const configPath = join(configDir, "config.yaml");
+    const profilesBytes = Buffer.from("{}\n");
+    const profilesPath = join(configDir, "auth-profiles.json");
     await writeFile(configPath, configBytes, { mode: 0o600 });
+    await writeFile(profilesPath, profilesBytes, { mode: 0o600 });
     const configBeforeServe = await stat(configPath);
-    const configInodeBeforeServe = configBeforeServe.ino;
-    const configModeBeforeServe = configBeforeServe.mode & 0o777;
-    expect(configModeBeforeServe).toBe(0o600);
+    const profilesBeforeServe = await stat(profilesPath);
+    expect(configBeforeServe.mode & 0o777).toBe(0o600);
+    expect(profilesBeforeServe.mode & 0o777).toBe(0o600);
 
     const child = spawn(process.execPath, [binary, "serve"], {
       env: {
@@ -121,6 +132,20 @@ describe.skipIf(!hasSockets)("first-run serve process", () => {
         ENDURAGENT_HOME: home,
         CYCLING_COACH_HOME: join(scratch, "legacy-home"),
         NODE_OPTIONS: `--disable-warning=ExperimentalWarning --import=${fetchStub}`,
+        LLM_PROVIDER: undefined,
+        LLM_MODEL: undefined,
+        LLM_API_KEY: undefined,
+        ANTHROPIC_API_KEY: undefined,
+        OPENAI_API_KEY: undefined,
+        GOOGLE_GENERATIVE_AI_API_KEY: undefined,
+        DEEPSEEK_API_KEY: undefined,
+        ALIBABA_API_KEY: undefined,
+        MINIMAX_API_KEY: undefined,
+        MOONSHOT_API_KEY: undefined,
+        ZAI_API_KEY: undefined,
+        OPENROUTER_API_KEY: undefined,
+        INTERVALS_API_KEY: undefined,
+        TELEGRAM_BOT_TOKEN: undefined,
         FORCE_COLOR: undefined,
         CLICOLOR_FORCE: undefined,
       },
@@ -163,6 +188,8 @@ describe.skipIf(!hasSockets)("first-run serve process", () => {
       service: HEALTHZ_SERVICE_MARKER,
       version: "0.0.1",
     });
+    await expectPreservedFile(configPath, configBytes, configBeforeServe);
+    await expectPreservedFile(profilesPath, profilesBytes, profilesBeforeServe);
 
     child.kill("SIGTERM");
     const result = await Promise.race([
@@ -174,10 +201,8 @@ describe.skipIf(!hasSockets)("first-run serve process", () => {
     expect(result).toEqual({ code: 0, signal: null });
     expect(stdout).toBe("");
     expect(stderr).not.toContain("coach store writer is already active");
-    const configAfterServe = await stat(configPath);
-    await expect(readFile(configPath)).resolves.toEqual(configBytes);
-    expect(configAfterServe.ino).toBe(configInodeBeforeServe);
-    expect(configAfterServe.mode & 0o777).toBe(configModeBeforeServe);
+    await expectPreservedFile(configPath, configBytes, configBeforeServe);
+    await expectPreservedFile(profilesPath, profilesBytes, profilesBeforeServe);
     await expect(readFile(join(configDir, PORT_FILE_NAME), "utf8")).rejects.toMatchObject({
       code: "ENOENT",
     });

--- a/packages/coach/tests/local-runner.test.ts
+++ b/packages/coach/tests/local-runner.test.ts
@@ -14,8 +14,6 @@ const mocks = vi.hoisted(() => ({
   migrate: vi.fn(),
   readiness: vi.fn(),
   composition: vi.fn(),
-  loadConfig: vi.fn(),
-  project: vi.fn(),
 }));
 
 vi.mock("../src/runtime.js", async (importOriginal) => ({
@@ -34,12 +32,6 @@ vi.mock("../src/composition.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../src/composition.js")>()),
   createLocalCoachComposition: mocks.composition,
 }));
-vi.mock("@enduragent/core", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("@enduragent/core")>()),
-  loadConfig: mocks.loadConfig,
-  engineConfigFromConfig: mocks.project,
-}));
-
 import { CoachStoreWriterError } from "../src/runtime.js";
 import { withLocalCoach, type LocalCoachLifecycle } from "../src/local-runner.js";
 
@@ -134,6 +126,7 @@ let selectedHome: AthleteHome;
 let context: CoachStoreWriterContext;
 let trace: string[];
 let closeImplementation: () => Promise<void>;
+let readyConfig: Config;
 
 async function freshHome(): Promise<AthleteHome> {
   const root = await mkdtemp(join(await realpath(tmpdir()), "coach-local-runner-"));
@@ -201,18 +194,15 @@ beforeEach(async () => {
   mocks.migrate.mockReset();
   mocks.readiness.mockReset();
   mocks.composition.mockReset();
-  mocks.loadConfig.mockReset();
-  mocks.project.mockReset();
   mocks.migrate.mockImplementation(async () => {
     trace.push("legacy-migration");
     return notNeeded();
   });
+  readyConfig = { ...config, dataDir: selectedHome.root };
   mocks.readiness.mockImplementation(async () => {
     trace.push("readiness");
-    return { status: "ready", config: engineConfig };
+    return { status: "ready", config: readyConfig, engineConfig };
   });
-  mocks.loadConfig.mockReturnValue({ ...config, dataDir: selectedHome.root });
-  mocks.project.mockReturnValue(engineConfig);
   mocks.composition.mockImplementation(async () => {
     trace.push("engine-open");
     return { engine, operations, spendMeter, close: () => closeImplementation() };
@@ -263,9 +253,15 @@ describe("local coach runner", () => {
       "store-close",
       "writer-release",
     ]);
-    expect(mocks.loadConfig).toHaveBeenCalledExactlyOnceWith(selectedHome.configDir, {
-      defaultDataDir: selectedHome.root,
-    });
+    expect(mocks.composition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: readyConfig,
+        engineConfig,
+      }),
+    );
+    const compositionInput = mocks.composition.mock.calls[0]![0];
+    expect(compositionInput.config).toBe(readyConfig);
+    expect(compositionInput.engineConfig).toBe(engineConfig);
   });
 
   it("releases the writer after migration throws without opening later stages", async () => {
@@ -340,12 +336,23 @@ describe("local coach runner", () => {
     expect(trace.slice(-2)).toEqual(["store-close", "writer-release"]);
   });
 
+  it.each(["unreadable", "malformed"] as const)(
+    "returns %s only after releasing the writer without constructing the engine",
+    async (status) => {
+      mocks.readiness.mockResolvedValue({ status });
+      const operation = vi.fn(async () => "unused");
+
+      await expect(withLocalCoach(input(operation))).resolves.toEqual({ status });
+      expect(mocks.composition).not.toHaveBeenCalled();
+      expect(operation).not.toHaveBeenCalled();
+      expect(trace.slice(-2)).toEqual(["store-close", "writer-release"]);
+    },
+  );
+
   it("characterizes structural home readiness and the optional Config directory parameter", async () => {
     const actualReadiness =
       await vi.importActual<typeof import("../src/readiness.js")>("../src/readiness.js");
     const actualCore = await vi.importActual<typeof import("@enduragent/core")>("@enduragent/core");
-    mocks.loadConfig.mockImplementation(actualCore.loadConfig);
-    mocks.project.mockImplementation(actualCore.engineConfigFromConfig);
     await mkdir(selectedHome.configDir, { recursive: true });
     const configPath = join(selectedHome.configDir, "config.yaml");
     await expect(actualReadiness.checkHomeReadiness(selectedHome)).resolves.toEqual({
@@ -354,22 +361,11 @@ describe("local coach runner", () => {
     });
     await writeFile(configPath, "[");
     await expect(actualReadiness.checkHomeReadiness(selectedHome)).resolves.toEqual({
-      status: "not-configured",
-      configPath,
+      status: "malformed",
     });
     await writeFile(
       configPath,
       "llm:\n  provider: openai-codex\ndata_dir: " + selectedHome.root + "\n",
-    );
-    await expect(actualReadiness.checkHomeReadiness(selectedHome)).resolves.toEqual({
-      status: "not-configured",
-      configPath,
-    });
-    await writeFile(
-      join(selectedHome.configDir, "auth-profiles.json"),
-      JSON.stringify({
-        "openai-codex": { type: "oauth" },
-      }),
     );
     const ready = await actualReadiness.checkHomeReadiness(selectedHome);
     expect(ready.status).toBe("ready");
@@ -380,9 +376,6 @@ describe("local coach runner", () => {
   it("loads an absent readiness data_dir against the selected athlete root", async () => {
     const actualReadiness =
       await vi.importActual<typeof import("../src/readiness.js")>("../src/readiness.js");
-    const actualCore = await vi.importActual<typeof import("@enduragent/core")>("@enduragent/core");
-    mocks.loadConfig.mockImplementation(actualCore.loadConfig);
-    mocks.project.mockImplementation(actualCore.engineConfigFromConfig);
     await mkdir(selectedHome.configDir, { recursive: true });
     await writeFile(
       join(selectedHome.configDir, "config.yaml"),
@@ -390,12 +383,9 @@ describe("local coach runner", () => {
       { mode: 0o600 },
     );
 
-    await expect(actualReadiness.checkHomeReadiness(selectedHome)).resolves.toMatchObject({
-      status: "ready",
-    });
-    expect(mocks.loadConfig).toHaveBeenCalledExactlyOnceWith(selectedHome.configDir, {
-      defaultDataDir: selectedHome.root,
-    });
+    const readiness = await actualReadiness.checkHomeReadiness(selectedHome);
+    expect(readiness).toMatchObject({ status: "ready" });
+    if (readiness.status === "ready") expect(readiness.config.dataDir).toBe(selectedHome.root);
   });
 
   it("rethrows the exact operation object only after lifecycle, store, and writer cleanup", async () => {

--- a/packages/coach/tests/readiness.test.ts
+++ b/packages/coach/tests/readiness.test.ts
@@ -1,0 +1,186 @@
+import { mkdir, mkdtemp, readFile, realpath, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { engineConfigFromConfig, loadConfigFromYaml } from "@enduragent/core";
+import type { AthleteHome } from "@enduragent/kernel-node/home";
+import {
+  checkHomeReadiness,
+  type ReadinessDependencies,
+  type ReadinessFailureStatus,
+} from "../src/readiness.js";
+
+const roots: string[] = [];
+
+async function freshHome(): Promise<AthleteHome> {
+  const root = await mkdtemp(join(await realpath(tmpdir()), "coach-readiness-"));
+  roots.push(root);
+  const home = {
+    root,
+    storeDir: join(root, "store"),
+    archiveDir: join(root, "archive"),
+    configDir: join(root, "config"),
+  };
+  await mkdir(home.configDir, { recursive: true });
+  return home;
+}
+
+function ioError(code: string): NodeJS.ErrnoException {
+  return Object.assign(new Error("synthetic-private-io-detail"), { code });
+}
+
+function validSource(home: AthleteHome): string {
+  return `data_source: store\ndata_dir: ${JSON.stringify(home.root)}\nllm:\n  provider: openai-codex\n  auth_profile: selected-profile\n`;
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("home readiness", () => {
+  it("classifies only ENOENT from the initial read as not configured", async () => {
+    const home = await freshHome();
+    const configPath = join(home.configDir, "config.yaml");
+    const readConfigFile = vi.fn().mockRejectedValue(ioError("ENOENT"));
+
+    await expect(
+      checkHomeReadiness(home, {
+        readConfigFile,
+        loadConfig: vi.fn(),
+        projectConfig: vi.fn(),
+      }),
+    ).resolves.toEqual({ status: "not-configured", configPath });
+    expect(readConfigFile).toHaveBeenCalledExactlyOnceWith(configPath, "utf8");
+  });
+
+  it.each(["EACCES", "EPERM", "EIO"])(
+    "classifies synthetic initial %s without leaking the failure",
+    async (code) => {
+      const home = await freshHome();
+      const result = await checkHomeReadiness(home, {
+        readConfigFile: vi.fn().mockRejectedValue(ioError(code)),
+        loadConfig: vi.fn(),
+        projectConfig: vi.fn(),
+      });
+
+      expect(result).toEqual({ status: "unreadable" });
+      expect(JSON.stringify(result)).not.toContain("synthetic-private-io-detail");
+    },
+  );
+
+  it.each(["ENOENT", "EACCES", "EPERM", "EIO"])(
+    "classifies synthetic later %s as unreadable",
+    async (code) => {
+      const home = await freshHome();
+      const readConfigFile = vi
+        .fn()
+        .mockResolvedValueOnce(validSource(home))
+        .mockRejectedValueOnce(ioError(code));
+
+      await expect(
+        checkHomeReadiness(home, {
+          readConfigFile,
+          loadConfig: vi.fn(),
+          projectConfig: vi.fn(),
+        }),
+      ).resolves.toEqual({ status: "unreadable" });
+      expect(readConfigFile).toHaveBeenCalledTimes(2);
+    },
+  );
+
+  it.each([
+    ["YAML parse failure", "["],
+    ["non-map root", "- first\n- second\n"],
+    ["Core semantic validation failure", "data_source: unsupported\n"],
+  ])("classifies %s as malformed", async (_name, source) => {
+    const home = await freshHome();
+    const readConfigFile = vi.fn().mockResolvedValue(source);
+
+    await expect(
+      checkHomeReadiness(home, {
+        readConfigFile,
+        loadConfig: loadConfigFromYaml,
+        projectConfig: engineConfigFromConfig,
+      }),
+    ).resolves.toEqual({ status: "malformed" });
+  });
+
+  it("classifies an explicit data directory outside the selected home as malformed", async () => {
+    const home = await freshHome();
+    const source = "data_source: store\ndata_dir: /synthetic/other-athlete\n";
+
+    await expect(
+      checkHomeReadiness(home, {
+        readConfigFile: vi.fn().mockResolvedValue(source),
+        loadConfig: loadConfigFromYaml,
+        projectConfig: engineConfigFromConfig,
+      }),
+    ).resolves.toEqual({ status: "malformed" });
+  });
+
+  it("returns the exact loaded Core config and projected engine snapshots", async () => {
+    const home = await freshHome();
+    const loaded = loadConfigFromYaml({ data_source: "store" }, home.configDir, {
+      defaultDataDir: home.root,
+    });
+    const projected = engineConfigFromConfig(loaded);
+    const loadConfig = vi.fn(() => loaded);
+    const projectConfig = vi.fn(() => projected);
+    const dependencies: ReadinessDependencies = {
+      readConfigFile: vi.fn().mockResolvedValue("data_source: store\n"),
+      loadConfig,
+      projectConfig,
+    };
+
+    const result = await checkHomeReadiness(home, dependencies);
+    expect(result.status).toBe("ready");
+    if (result.status !== "ready") return;
+    expect(result.config).toBe(loaded);
+    expect(result.engineConfig).toBe(projected);
+    expect(projectConfig).toHaveBeenCalledExactlyOnceWith(loaded);
+  });
+
+  it.each(["missing", "unreadable", "malformed", "structurally-invalid"] as const)(
+    "keeps a valid selected credential profile ready when auth-profiles.json is %s",
+    async (profileState) => {
+      const home = await freshHome();
+      const configPath = join(home.configDir, "config.yaml");
+      const profilesPath = join(home.configDir, "auth-profiles.json");
+      await writeFile(configPath, validSource(home), { mode: 0o600 });
+      if (profileState === "unreadable") {
+        await mkdir(profilesPath);
+      } else if (profileState === "malformed") {
+        await writeFile(profilesPath, "{");
+      } else if (profileState === "structurally-invalid") {
+        await writeFile(profilesPath, JSON.stringify({ "selected-profile": [] }));
+      }
+
+      await expect(checkHomeReadiness(home)).resolves.toMatchObject({ status: "ready" });
+    },
+  );
+
+  it("does not change existing configuration bytes, inode, or mode", async () => {
+    const home = await freshHome();
+    const configPath = join(home.configDir, "config.yaml");
+    const bytes = Buffer.from("data_source: [synthetic-private-fragment]\n");
+    await writeFile(configPath, bytes, { mode: 0o600 });
+    const before = await stat(configPath);
+
+    const result = await checkHomeReadiness(home);
+    const after = await stat(configPath);
+
+    expect(result).toEqual({ status: "malformed" });
+    expect(await readFile(configPath)).toEqual(bytes);
+    expect(after.ino).toBe(before.ino);
+    expect(after.mode).toBe(before.mode);
+  });
+
+  it("exposes only the closed failure statuses", () => {
+    const statuses = [
+      "not-configured",
+      "unreadable",
+      "malformed",
+    ] satisfies ReadinessFailureStatus[];
+    expect(statuses).toEqual(["not-configured", "unreadable", "malformed"]);
+  });
+});

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -116,6 +116,14 @@ export function loadConfig(
   options: LoadConfigOptions = {},
 ): Config {
   const yaml = readConfigYamlFrom(configDir);
+  return loadConfigFromYaml(yaml, configDir, options);
+}
+
+export function loadConfigFromYaml(
+  yaml: Record<string, unknown>,
+  configDir: string = CONFIG_DIR,
+  options: LoadConfigOptions = {},
+): Config {
   const dataSource = resolveDataSource(yaml.data_source);
   const llmYaml = (yaml.llm as Record<string, unknown>) ?? {};
   const intervalsYaml = (yaml.intervals as Record<string, unknown>) ?? {};

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -150,6 +150,7 @@ export {
   CONFIG_DIR,
   CONFIG_FILE,
   loadConfig,
+  loadConfigFromYaml,
   readConfigYaml,
   resolveConfigSecrets,
 } from "./config.js";

--- a/packages/core/tests/config.data-dir.test.ts
+++ b/packages/core/tests/config.data-dir.test.ts
@@ -40,6 +40,18 @@ describe("config data directory", () => {
     expect(loadConfig(configDir, { defaultDataDir: athleteRoot }).dataDir).toBe(athleteRoot);
   });
 
+  it("loads an already parsed snapshot without reading the configuration file again", async () => {
+    const configDir = await freshDirectory("core-snapshot-config-");
+    const athleteRoot = await freshDirectory("core-snapshot-root-");
+    const { loadConfigFromYaml } = await import("../src/config.js");
+
+    expect(
+      loadConfigFromYaml({ data_source: "store" }, configDir, {
+        defaultDataDir: athleteRoot,
+      }),
+    ).toMatchObject({ dataSource: "store", dataDir: athleteRoot });
+  });
+
   it("preserves explicit YAML values and keeps null on its legacy fallback", async () => {
     const configDir = await freshDirectory("core-explicit-config-");
     const athleteRoot = await freshDirectory("core-explicit-root-");


### PR DESCRIPTION
## Summary

- Load Desktop configuration once with the contextual athlete data directory and carry the exact validated snapshot into the local runner.
- Classify missing, unreadable, and malformed configuration as closed typed startup refusals, preserving them through utility supervision and upgrade handoff.
- Prove a real serve process can start from an existing minimal configuration without changing its bytes, inode, or permissions.

## Test plan

- [x] 135 focused Core, Coach, and Desktop tests, including the real serve process
- [x] Root TypeScript check
- [x] Affected lint, format, changeset, contract, privacy, trademark, and diff checks
- [x] Three independent security, process-propagation, and QA reviews with zero blockers