### PR TITLE
fix(desktop): show chat turn feedback

### DIFF
--- a/.changeset/desktop-chat-turn-feedback.md
+++ b/.changeset/desktop-chat-turn-feedback.md
@@ -1,0 +1,5 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Desktop chat now shows working feedback after send and offers Retry when the coach returns an empty reply.

--- a/apps/desktop-renderer/src/chat/controller.ts
+++ b/apps/desktop-renderer/src/chat/controller.ts
@@ -21,6 +21,7 @@ export const CHAT_CONNECTION_INTERRUPTED_COPY =
 export const CHAT_PROTOCOL_FAILURE_COPY =
   "The coaching response could not be verified. Please try again.";
 export const CHAT_FAILURE_COPY = "The coach couldn't respond. Please try again.";
+export const CHAT_EMPTY_RESPONSE_COPY = "The coach returned an empty response. Please try again.";
 export const NEW_CONVERSATION_SUCCESS_COPY = "New conversation started.";
 export const NEW_CONVERSATION_MEMORY_WARNING_COPY =
   "New conversation started. Some recent details may not have been saved to coach memory.";
@@ -253,6 +254,11 @@ export function createChatController(input: {
           reduce({ type: "interrupt", requestKey, copy: CHAT_PROTOCOL_FAILURE_COPY });
           return;
         }
+        if (!/\S/u.test(finalText)) {
+          retryClient = client;
+          reduce({ type: "interrupt", requestKey, copy: CHAT_EMPTY_RESPONSE_COPY });
+          return;
+        }
         reduce({ type: "complete", requestKey });
       } catch (error) {
         if (!current()) return;
@@ -347,7 +353,7 @@ export function createChatController(input: {
           }
         });
       queuedRetry = { requestKey, promise: pending, token };
-      render();
+      reduce({ type: "retry-pending", requestKey });
       return pending;
     },
     openNewConversation() {

--- a/apps/desktop-renderer/src/turn-state.ts
+++ b/apps/desktop-renderer/src/turn-state.ts
@@ -1,6 +1,7 @@
 import type { TurnEvent } from "@enduragent/coach-contract";
 
 export const DESKTOP_CHAT_ID = "desktop" as const;
+export const CHAT_WORKING_COPY = "Coach is working…";
 
 export type ChatStatus = "idle" | "streaming" | "interrupted";
 export type SessionPresence = "unknown" | "absent" | "present";
@@ -69,6 +70,7 @@ export type ChatAction =
   | { readonly type: "event"; readonly requestKey: number; readonly event: TurnEvent }
   | { readonly type: "complete"; readonly requestKey: number }
   | { readonly type: "interrupt"; readonly requestKey: number; readonly copy: string }
+  | { readonly type: "retry-pending"; readonly requestKey: number }
   | { readonly type: "fail"; readonly requestKey: number; readonly copy: string }
   | { readonly type: "session-probe"; readonly hasSession: boolean }
   | { readonly type: "open-new-conversation" }
@@ -90,6 +92,14 @@ function updateAssistant(
   return state.messages.map((message) =>
     message.id === activeTurn.assistantMessageId ? { ...message, text, delivery } : message,
   );
+}
+
+function visibleDraft(draft: string): string {
+  return /\S/u.test(draft) ? draft : "";
+}
+
+function clearGenericProgress(progress: string | null, text: string): string | null {
+  return progress === CHAT_WORKING_COPY && /\S/u.test(text) ? null : progress;
 }
 
 function assertNever(value: never): never {
@@ -128,7 +138,7 @@ export function reduceChatState(state: ChatState, action: ChatAction): ChatState
       return {
         status: "streaming",
         messages,
-        progress: null,
+        progress: CHAT_WORKING_COPY,
         session: { ...state.session, announcement: null },
         activeTurn: {
           requestKey: action.requestKey,
@@ -158,16 +168,27 @@ export function reduceChatState(state: ChatState, action: ChatAction): ChatState
           const next = { ...active, draft };
           return {
             ...state,
+            progress: clearGenericProgress(state.progress, action.event.delta),
             activeTurn: next,
-            messages: updateAssistant(state, next, draft, "streaming"),
+            messages: /\S/u.test(draft)
+              ? updateAssistant(state, next, draft, "streaming")
+              : state.messages,
           };
         }
         case "final-text": {
-          const next = { ...active, draft: action.event.text, finalText: action.event.text };
+          const hasText = /\S/u.test(action.event.text);
+          const next = {
+            ...active,
+            draft: hasText ? action.event.text : active.draft,
+            finalText: action.event.text,
+          };
           return {
             ...state,
+            progress: clearGenericProgress(state.progress, action.event.text),
             activeTurn: next,
-            messages: updateAssistant(state, next, action.event.text, "streaming"),
+            messages: hasText
+              ? updateAssistant(state, next, action.event.text, "streaming")
+              : state.messages,
           };
         }
         case "error":
@@ -188,7 +209,8 @@ export function reduceChatState(state: ChatState, action: ChatAction): ChatState
     }
     case "complete": {
       const active = current(state, action.requestKey);
-      if (active === null || active.finalText === null) return state;
+      if (active === null || active.finalText === null || !/\S/u.test(active.finalText))
+        return state;
       return {
         ...state,
         status: "idle",
@@ -204,8 +226,18 @@ export function reduceChatState(state: ChatState, action: ChatAction): ChatState
         ...state,
         status: "interrupted",
         progress: action.copy,
-        messages: updateAssistant(state, active, active.draft, "interrupted"),
+        messages: updateAssistant(state, active, visibleDraft(active.draft), "interrupted"),
       };
+    }
+    case "retry-pending": {
+      const active = current(state, action.requestKey);
+      return active === null || state.status !== "interrupted"
+        ? state
+        : {
+            ...state,
+            progress: CHAT_WORKING_COPY,
+            activeTurn: { ...active, error: null },
+          };
     }
     case "fail": {
       const active = current(state, action.requestKey);
@@ -214,7 +246,7 @@ export function reduceChatState(state: ChatState, action: ChatAction): ChatState
         ...state,
         status: "idle",
         progress: active.error === null ? action.copy : null,
-        messages: updateAssistant(state, active, active.draft, "interrupted"),
+        messages: updateAssistant(state, active, visibleDraft(active.draft), "interrupted"),
       };
     }
     case "session-probe": {

--- a/apps/desktop-renderer/tests/chat-controller.test.ts
+++ b/apps/desktop-renderer/tests/chat-controller.test.ts
@@ -10,6 +10,7 @@ import {
 import type { CoachTurnEventNotificationEnvelope, TurnEvent } from "@enduragent/coach-contract";
 import {
   CHAT_CONNECTION_INTERRUPTED_COPY,
+  CHAT_EMPTY_RESPONSE_COPY,
   CHAT_PROTOCOL_FAILURE_COPY,
   NEW_CONVERSATION_MEMORY_WARNING_COPY,
   NEW_CONVERSATION_SUCCESS_COPY,
@@ -19,7 +20,7 @@ import {
 } from "../src/chat/controller.js";
 import { COACH_RESPONSE_CODE_UNIT_LIMIT, COACH_TURN_EVENT_LIMIT } from "../src/chat/limits.js";
 import type { DesktopCoachClientProvider } from "../src/coach-client.js";
-import { EMPTY_CHAT_STATE, type ChatState } from "../src/turn-state.js";
+import { CHAT_WORKING_COPY, EMPTY_CHAT_STATE, type ChatState } from "../src/turn-state.js";
 
 function envelope(event: TurnEvent, requestId = 1): CoachTurnEventNotificationEnvelope {
   return {
@@ -191,6 +192,54 @@ describe("chat controller", () => {
     );
     await expect(controller.submit("Continue")).resolves.toBeUndefined();
     expect(refreshSpend).toHaveBeenCalledTimes(1);
+  });
+
+  it("publishes working feedback immediately for an accepted submit", async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const fake = client(async (_request, options) => {
+      await gate;
+      deliver(options, { type: "final-text", turnId: "turn-1", text: "Done" });
+      options?.onTerminalEnvelope?.({ jsonrpc: "2.0", id: 1, result: { text: "Done" } });
+      return { text: "Done" };
+    });
+    const { controller, states } = subject(fake);
+
+    const submission = controller.submit("Continue");
+
+    expect(states.at(-1)).toMatchObject({
+      status: "streaming",
+      progress: CHAT_WORKING_COPY,
+      messages: [
+        { role: "athlete", text: "Continue" },
+        { role: "coach", text: "", delivery: "streaming" },
+      ],
+    });
+
+    release();
+    await submission;
+  });
+
+  it("clears only generic working feedback on the first substantive delta", async () => {
+    const fake = client(async (_request, options) => {
+      deliver(options, { type: "text_delta", turnId: "turn-1", delta: " \n" });
+      deliver(options, { type: "text_delta", turnId: "turn-1", delta: "Ride easy." });
+      deliver(options, { type: "final-text", turnId: "turn-1", text: "Ride easy." });
+      options?.onTerminalEnvelope?.({ jsonrpc: "2.0", id: 1, result: { text: "Ride easy." } });
+      return { text: "Ride easy." };
+    });
+    const { controller, states } = subject(fake);
+
+    await controller.submit("Continue");
+
+    const whitespace = states.find((state) => state.activeTurn?.draft === " \n");
+    expect(whitespace?.progress).toBe(CHAT_WORKING_COPY);
+    expect(whitespace?.messages.at(-1)?.text).toBe("");
+    const firstText = states.find((state) => state.activeTurn?.draft === " \nRide easy.");
+    expect(firstText?.progress).toBeNull();
+    expect(firstText?.messages.at(-1)?.text).toBe(" \nRide easy.");
   });
 
   it("renders ordered deltas immediately and canonical final text once without turn-start", async () => {
@@ -410,6 +459,44 @@ describe("chat controller", () => {
     },
   );
 
+  it.each([
+    { finalText: "", partial: "" },
+    { finalText: " \n\t", partial: "Preserved partial" },
+  ])(
+    "keeps a matching whitespace-only terminal retryable without completing %#",
+    async ({ finalText, partial }) => {
+      const fake = client(async (_request, options) => {
+        if (partial.length > 0) {
+          deliver(options, { type: "text_delta", turnId: "turn-1", delta: partial });
+        }
+        deliver(options, { type: "final-text", turnId: "turn-1", text: finalText });
+        options?.onTerminalEnvelope?.({ jsonrpc: "2.0", id: 1, result: { text: finalText } });
+        return { text: finalText };
+      });
+      const { controller, states } = subject(fake);
+      await controller.start();
+
+      await controller.submit("Help");
+
+      expect(states.at(-1)).toMatchObject({
+        status: "interrupted",
+        progress: CHAT_EMPTY_RESPONSE_COPY,
+        session: { presence: "absent" },
+      });
+      expect(states.at(-1)?.messages).toMatchObject([
+        { role: "athlete", text: "Help", delivery: "complete" },
+        { role: "coach", text: partial, delivery: "interrupted" },
+      ]);
+      expect(
+        states.some(
+          (state) =>
+            state.messages.at(-1)?.delivery === "complete" &&
+            !/\S/u.test(state.messages.at(-1)?.text ?? ""),
+        ),
+      ).toBe(false);
+    },
+  );
+
   it("accepts one matching first turn-start and rejects a late start", async () => {
     const fake = client(async (_request, options) => {
       deliver(options, { type: "text_delta", turnId: "turn-1", delta: "Draft" });
@@ -436,7 +523,10 @@ describe("chat controller", () => {
     const { controller, provider, states, refresh } = subject(first, second);
     await controller.submit("Same message");
     expect(states.at(-1)?.progress).toBe(CHAT_CONNECTION_INTERRUPTED_COPY);
-    await controller.retryInterrupted();
+    const retry = controller.retryInterrupted();
+    expect(states.at(-1)?.progress).toBe(CHAT_WORKING_COPY);
+    expect(states.at(-1)?.messages.filter((message) => message.role === "athlete")).toHaveLength(1);
+    await retry;
     expect(provider.reconnect).toHaveBeenCalledTimes(1);
     expect(vi.mocked(second.call).mock.calls[0]?.[1]).toEqual({
       chatId: "desktop",
@@ -541,10 +631,12 @@ describe("chat controller", () => {
       reconnect: vi.fn(async () => second),
       close: vi.fn(async () => {}),
     };
+    let latestState = EMPTY_CHAT_STATE;
     const controller = createChatController({
       clients: provider,
       view: {
         render(state) {
+          latestState = structuredClone(state);
           if (state.status === "interrupted") interrupted();
         },
       },
@@ -558,6 +650,8 @@ describe("chat controller", () => {
     await interruptedState;
     const retry = controller.retryInterrupted();
     const duplicate = controller.retryInterrupted();
+    expect(latestState.progress).toBe(CHAT_WORKING_COPY);
+    expect(latestState.messages.filter((message) => message.role === "athlete")).toHaveLength(1);
     expect(controller.openNewConversation()).toBe(false);
     release();
     await Promise.all([submission, retry, duplicate]);

--- a/apps/desktop-renderer/tests/chat-view.test.ts
+++ b/apps/desktop-renderer/tests/chat-view.test.ts
@@ -1,9 +1,21 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { CoachClientCallOptions } from "@enduragent/coach-client";
+import {
+  CoachClientDisconnectedError,
+  type CoachClientCallOptions,
+} from "@enduragent/coach-client";
 import type { TurnEvent } from "@enduragent/coach-contract";
-import { createChatController } from "../src/chat/controller.js";
+import {
+  CHAT_CONNECTION_INTERRUPTED_COPY,
+  CHAT_EMPTY_RESPONSE_COPY,
+  createChatController,
+} from "../src/chat/controller.js";
 import { mountChatView } from "../src/chat/view.js";
-import { EMPTY_CHAT_STATE, reduceChatState, type ChatState } from "../src/turn-state.js";
+import {
+  CHAT_WORKING_COPY,
+  EMPTY_CHAT_STATE,
+  reduceChatState,
+  type ChatState,
+} from "../src/turn-state.js";
 
 const mutationEvents: string[] = [];
 
@@ -286,7 +298,7 @@ beforeEach(() => {
 });
 
 describe("chat view", () => {
-  it("renders the athlete row without an empty coach row while awaiting a response", () => {
+  it("renders one working notice and the athlete row without an empty coach row", () => {
     const thread = new FakeElement("div");
     const mounted = mountChatView({
       conversation: new FakeElement("main") as never,
@@ -304,6 +316,8 @@ describe("chat view", () => {
 
     mounted.view.render(state);
 
+    expect(occurrences(thread.textContent, CHAT_WORKING_COPY)).toBe(1);
+    expect(findAll(thread, (node) => node.className === "chat-notice")).toHaveLength(1);
     expect(findAll(thread, (node) => node.className.includes("chat-message--athlete")).length).toBe(
       1,
     );
@@ -486,28 +500,35 @@ describe("chat view", () => {
     );
   });
 
-  it("renders an empty interruption notice and retry without an empty coach row", () => {
-    const thread = new FakeElement("div");
-    const mounted = mountChatView({
-      conversation: new FakeElement("main") as never,
-      thread: thread as never,
-      composerHost: new FakeElement("div") as never,
-    });
-    const interruptionCopy = "Connection interrupted. Your partial response is preserved.";
-    const state = reduceChatState(submittedState(), {
-      type: "interrupt",
-      requestKey: 1,
-      copy: interruptionCopy,
-    });
+  it.each(["", " \n\t"])(
+    "renders retryable recovery for a whitespace-only terminal %j without an empty coach row",
+    (finalText) => {
+      const thread = new FakeElement("div");
+      const mounted = mountChatView({
+        conversation: new FakeElement("main") as never,
+        thread: thread as never,
+        composerHost: new FakeElement("div") as never,
+      });
+      let state = reduceChatState(submittedState(), {
+        type: "event",
+        requestKey: 1,
+        event: { type: "final-text", turnId: "turn-1", text: finalText },
+      });
+      state = reduceChatState(state, {
+        type: "interrupt",
+        requestKey: 1,
+        copy: CHAT_EMPTY_RESPONSE_COPY,
+      });
 
-    mounted.view.render(state);
+      mounted.view.render(state);
 
-    expect(occurrences(thread.textContent, interruptionCopy)).toBe(1);
-    expect(findAll(thread, (node) => node.className.includes("chat-message--coach")).length).toBe(
-      0,
-    );
-    expect(find(thread, (node) => node.className === "chat-retry").hidden).toBe(false);
-  });
+      expect(occurrences(thread.textContent, CHAT_EMPTY_RESPONSE_COPY)).toBe(1);
+      expect(
+        findAll(thread, (node) => node.className.includes("chat-message--coach")),
+      ).toHaveLength(0);
+      expect(find(thread, (node) => node.className === "chat-retry").hidden).toBe(false);
+    },
+  );
 
   it("preserves keyed row identity while updating only changed streaming content", () => {
     const actionHost = new FakeElement("div");
@@ -531,7 +552,8 @@ describe("chat view", () => {
     const athleteText = find(athlete, (node) => node.className === "chat-message__text");
     expect(messages.replaceChildrenMutationCount).toBe(0);
     expect(messages.textContent).toContain("How should I train?");
-    expect(notice.textContentMutationCount).toBe(0);
+    expect(occurrences(thread.textContent, CHAT_WORKING_COPY)).toBe(1);
+    expect(notice.textContentMutationCount).toBe(1);
 
     state = reduceChatState(state, {
       type: "event",
@@ -549,7 +571,12 @@ describe("chat view", () => {
     expect(messages.textContent).toContain("Partial **coach");
     expect(findAll(coach, (node) => node.tagName === "strong")).toHaveLength(0);
     expect(coach.attributes.get("aria-busy")).toBe("true");
-    expect(notice.textContentMutationCount).toBe(0);
+    expect(notice.hidden).toBe(true);
+    expect(notice.textContent).toBe("");
+    expect(notice.textContentMutationCount).toBe(2);
+    expect(occurrences(thread.textContent, CHAT_WORKING_COPY)).toBe(0);
+    expect(messages.children[0]).toBe(athlete);
+    expect(athlete.removeMutationCount).toBe(0);
 
     state = reduceChatState(state, {
       type: "event",
@@ -773,6 +800,164 @@ describe("chat view", () => {
     expect(findAll(coach, (node) => node.tagName === "strong")[0]?.textContent).toBe("answer");
   });
 
+  it("replaces a queued interrupted contract error with one working announcement", async () => {
+    const thread = new FakeElement("div");
+    const mounted = mountChatView({
+      conversation: new FakeElement("main") as never,
+      thread: thread as never,
+      composerHost: new FakeElement("div") as never,
+    });
+    let releaseTrainingRefresh: (() => void) | undefined;
+    const trainingRefreshGate = new Promise<void>((resolve) => {
+      releaseTrainingRefresh = resolve;
+    });
+    let markTrainingRefreshStarted: (() => void) | undefined;
+    const trainingRefreshStarted = new Promise<void>((resolve) => {
+      markTrainingRefreshStarted = resolve;
+    });
+    const contractCopy = "The coaching provider is temporarily unavailable.";
+    const firstCall = vi.fn(
+      async (
+        method: string,
+        _request: unknown,
+        options: CoachClientCallOptions<"chat"> | undefined,
+      ) => {
+        if (method !== "chat") throw new TypeError();
+        const event: TurnEvent = {
+          type: "error",
+          turnId: "turn-1",
+          chatId: "desktop",
+          error_class: "unknown",
+          kind: "provider-down",
+          athleteMessage: contractCopy,
+          overflowAttempts: 0,
+          timeoutAttempts: 0,
+          rateLimitAttempts: 0,
+          duration_ms: 1,
+          compactions: 0,
+        };
+        options?.onNotificationEnvelope?.({
+          jsonrpc: "2.0",
+          method: "coach.turnEvent",
+          params: {
+            requestId: 1,
+            requestMethod: "chat",
+            turnId: event.turnId,
+            event,
+          },
+        });
+        options?.onEvent?.(event);
+        throw new CoachClientDisconnectedError(1006, "synthetic");
+      },
+    );
+    const secondCall = vi.fn(
+      async (
+        method: string,
+        _request: unknown,
+        options: CoachClientCallOptions<"chat"> | undefined,
+      ) => {
+        if (method !== "chat") throw new TypeError();
+        const event: TurnEvent = {
+          type: "final-text",
+          turnId: "turn-2",
+          text: "Recovered.",
+        };
+        options?.onNotificationEnvelope?.({
+          jsonrpc: "2.0",
+          method: "coach.turnEvent",
+          params: {
+            requestId: 2,
+            requestMethod: "chat",
+            turnId: event.turnId,
+            event,
+          },
+        });
+        options?.onEvent?.(event);
+        options?.onTerminalEnvelope?.({
+          jsonrpc: "2.0",
+          id: 2,
+          result: { text: event.text },
+        });
+        return { text: event.text };
+      },
+    );
+    const firstClient = { handshake: {}, call: firstCall, close: vi.fn(async () => {}) };
+    const secondClient = { handshake: {}, call: secondCall, close: vi.fn(async () => {}) };
+    const reconnect = vi.fn(async () => secondClient as never);
+    let refreshCalls = 0;
+    const controller = createChatController({
+      clients: {
+        getClient: vi.fn(async () => firstClient as never),
+        reconnect,
+        close: vi.fn(async () => {}),
+      },
+      view: mounted.view,
+      refreshTrainingContext: async () => {
+        refreshCalls += 1;
+        if (refreshCalls !== 1) return;
+        markTrainingRefreshStarted?.();
+        await trainingRefreshGate;
+      },
+      refreshSpend: async () => {},
+    });
+    const retries: Promise<void>[] = [];
+    mounted.bind({
+      onSubmit: (message) => void controller.submit(message),
+      onRetry: () => retries.push(controller.retryInterrupted()),
+      onOpenNewConversation: vi.fn(),
+      onCancelNewConversation: vi.fn(),
+      onConfirmNewConversation: vi.fn(),
+    });
+
+    const submission = controller.submit("How should I train?");
+    await trainingRefreshStarted;
+    const messages = find(thread, (node) => node.className === "chat-messages");
+    const athlete = messages.children[0]!;
+    const retry = find(thread, (node) => node.className === "chat-retry");
+
+    expect(occurrences(thread.textContent, contractCopy)).toBe(1);
+    expect(occurrences(thread.textContent, CHAT_CONNECTION_INTERRUPTED_COPY)).toBe(0);
+    expect(findAll(thread, (node) => node.className.includes("chat-message--athlete"))).toEqual([
+      athlete,
+    ]);
+    expect(secondCall).not.toHaveBeenCalled();
+
+    retry.dispatch("click");
+    retry.dispatch("click");
+
+    expect(retries).toHaveLength(2);
+    expect(retries[1]).toBe(retries[0]);
+    expect(occurrences(thread.textContent, contractCopy)).toBe(0);
+    expect(occurrences(thread.textContent, CHAT_WORKING_COPY)).toBe(1);
+    expect(find(thread, (node) => node.className === "chat-notice").textContent).toBe(
+      CHAT_WORKING_COPY,
+    );
+    expect(firstCall).toHaveBeenCalledOnce();
+    expect(secondCall).not.toHaveBeenCalled();
+    expect(messages.children[0]).toBe(athlete);
+    expect(athlete.removeMutationCount).toBe(0);
+
+    releaseTrainingRefresh?.();
+    await Promise.all([submission, ...retries]);
+
+    expect(reconnect).toHaveBeenCalledOnce();
+    expect(firstCall).toHaveBeenCalledOnce();
+    expect(secondCall).toHaveBeenCalledOnce();
+    expect(firstCall.mock.calls[0]?.[1]).toEqual({
+      chatId: "desktop",
+      message: "How should I train?",
+    });
+    expect(secondCall.mock.calls[0]?.[1]).toEqual({
+      chatId: "desktop",
+      message: "How should I train?",
+    });
+    expect(findAll(thread, (node) => node.className.includes("chat-message--athlete"))).toEqual([
+      athlete,
+    ]);
+    expect(messages.children[0]).toBe(athlete);
+    expect(athlete.removeMutationCount).toBe(0);
+  });
+
   it("keeps one streaming text node across many controller-delivered tiny deltas", async () => {
     const thread = new FakeElement("div");
     const mounted = mountChatView({
@@ -959,6 +1144,14 @@ describe("chat view", () => {
       assistantMessageId: "message-3",
       includeUser: false,
     });
+    mounted.view.render(state);
+
+    expect(occurrences(thread.textContent, CHAT_WORKING_COPY)).toBe(1);
+    expect(messages.children).toEqual([athlete, interrupted]);
+    expect(state.messages.filter((message) => message.role === "athlete")).toHaveLength(1);
+    expect(athlete.removeMutationCount).toBe(0);
+    expect(interrupted.removeMutationCount).toBe(0);
+
     state = reduceChatState(state, {
       type: "event",
       requestKey: 2,

--- a/apps/desktop-renderer/tests/turn-state.test.ts
+++ b/apps/desktop-renderer/tests/turn-state.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  CHAT_WORKING_COPY,
   DESKTOP_CHAT_ID,
   EMPTY_CHAT_STATE,
   hasClearableConversation,
@@ -22,6 +23,84 @@ describe("desktop turn state", () => {
   it("owns the one desktop conversation identity", () => {
     expect(DESKTOP_CHAT_ID).toBe("desktop");
   });
+
+  it("starts with one generic working state and clears it on the first substantive text", () => {
+    let state = started();
+    expect(state.progress).toBe(CHAT_WORKING_COPY);
+    expect(state.messages).toMatchObject([
+      { id: "message-1", role: "athlete", text: "How should I train?" },
+      { id: "message-2", role: "coach", text: "", delivery: "streaming" },
+    ]);
+
+    state = reduceChatState(state, {
+      type: "event",
+      requestKey: 1,
+      event: { type: "text_delta", turnId: "turn-1", delta: " \n" },
+    });
+    expect(state.progress).toBe(CHAT_WORKING_COPY);
+    expect(state.activeTurn?.draft).toBe(" \n");
+    expect(state.messages.at(-1)?.text).toBe("");
+
+    state = reduceChatState(state, {
+      type: "event",
+      requestKey: 1,
+      event: { type: "text_delta", turnId: "turn-1", delta: "Ride easy." },
+    });
+    expect(state.progress).toBeNull();
+    expect(state.messages.at(-1)?.text).toBe(" \nRide easy.");
+  });
+
+  it("clears generic progress on final text but keeps replacement tool progress", () => {
+    const finalOnly = reduceChatState(started(), {
+      type: "event",
+      requestKey: 1,
+      event: { type: "final-text", turnId: "turn-1", text: "Ride easy." },
+    });
+    expect(finalOnly.progress).toBeNull();
+
+    let state = started();
+    state = reduceChatState(state, {
+      type: "event",
+      requestKey: 1,
+      event: { type: "tool-start", turnId: "turn-1", toolName: "training_data" },
+    });
+    expect(state.progress).toBe("Checking your training data…");
+
+    state = reduceChatState(state, {
+      type: "event",
+      requestKey: 1,
+      event: { type: "final-text", turnId: "turn-1", text: "Ride easy." },
+    });
+    expect(state.progress).toBe("Checking your training data…");
+  });
+
+  it.each(["", " \n\t"])(
+    "does not complete or expose a whitespace-only final text %j",
+    (finalText) => {
+      const absent = reduceChatState(EMPTY_CHAT_STATE, {
+        type: "session-probe",
+        hasSession: false,
+      });
+      let state = reduceChatState(absent, {
+        type: "submit",
+        requestKey: 1,
+        userMessage: "How should I train?",
+        userMessageId: "message-1",
+        assistantMessageId: "message-2",
+        includeUser: true,
+      });
+      state = reduceChatState(state, {
+        type: "event",
+        requestKey: 1,
+        event: { type: "final-text", turnId: "turn-1", text: finalText },
+      });
+
+      expect(state.activeTurn?.finalText).toBe(finalText);
+      expect(state.messages.at(-1)?.text).toBe("");
+      expect(reduceChatState(state, { type: "complete", requestKey: 1 })).toBe(state);
+      expect(state.session.presence).toBe("absent");
+    },
+  );
 
   it("streams ordered deltas and replaces them with canonical final text", () => {
     let state = started();
@@ -73,6 +152,39 @@ describe("desktop turn state", () => {
       kind: "provider-down",
       athleteMessage: "Please try later.",
     });
+  });
+
+  it("clears a contract error only for a matching interrupted retry", () => {
+    let state = reduceChatState(started(), {
+      type: "event",
+      requestKey: 1,
+      event: {
+        type: "error",
+        turnId: "turn-1",
+        chatId: "desktop",
+        error_class: "unknown",
+        kind: "provider-down",
+        athleteMessage: "Please try later.",
+        overflowAttempts: 0,
+        timeoutAttempts: 0,
+        rateLimitAttempts: 0,
+        duration_ms: 1,
+        compactions: 0,
+      },
+    });
+    expect(reduceChatState(state, { type: "retry-pending", requestKey: 1 })).toBe(state);
+
+    state = reduceChatState(state, {
+      type: "interrupt",
+      requestKey: 1,
+      copy: "Connection interrupted. Your partial response is preserved.",
+    });
+    expect(state.activeTurn?.error?.athleteMessage).toBe("Please try later.");
+    expect(reduceChatState(state, { type: "retry-pending", requestKey: 2 })).toBe(state);
+
+    const retrying = reduceChatState(state, { type: "retry-pending", requestKey: 1 });
+    expect(retrying.progress).toBe(CHAT_WORKING_COPY);
+    expect(retrying.activeTurn?.error).toBeNull();
   });
 
   it("ignores stale local request keys and preserves interrupted drafts", () => {


### PR DESCRIPTION
## Summary

- show a fixed working notice immediately after accepted sends and retries while preserving richer tool progress
- clear stale retry errors only at the accepted retry boundary without duplicating requests or athlete rows
- keep empty or whitespace coach replies retryable instead of completing with a blank coach row

This closes Desktop parity audit items 196 and 198.

## Verification

- 104 focused Desktop renderer tests
- Desktop renderer TypeScript check
- scoped lint and formatting checks
- all seven repository policy checks
- `git diff --check`
- one detached read-only reviewer
