### PR TITLE
fix(desktop): count cached subscription tokens

### DIFF
--- a/.changeset/desktop-chatgpt-cache-accounting.md
+++ b/.changeset/desktop-chatgpt-cache-accounting.md
@@ -1,0 +1,5 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: ChatGPT subscription spend and cap warnings now include cached input correctly.

--- a/packages/coach/src/spend-meter.ts
+++ b/packages/coach/src/spend-meter.ts
@@ -84,6 +84,42 @@ function validProviderCost(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value) && value >= 0;
 }
 
+function safeTokenSum(...values: number[]): number | undefined {
+  let total = 0;
+  for (const value of values) {
+    if (!validToken(value)) return undefined;
+    total += value;
+    if (!Number.isSafeInteger(total)) return undefined;
+  }
+  return total;
+}
+
+function catalogInputTokens(line: UsageLedgerLine): number | undefined {
+  const inputTokens = line.inputTokens;
+  if (line.provider !== "openai-codex" || inputTokens === undefined) return inputTokens;
+
+  // Older Codex rows stored uncached input while retaining the provider's
+  // inclusive total. Only that exact identity can distinguish them safely
+  // from current rows without rewriting the ledger.
+  const { outputTokens, totalTokens, cacheReadTokens, cacheWriteTokens } = line;
+  if (
+    outputTokens === undefined ||
+    totalTokens === undefined ||
+    cacheReadTokens === undefined ||
+    cacheWriteTokens === undefined
+  ) {
+    return inputTokens;
+  }
+
+  const cachedInputTokens = safeTokenSum(cacheReadTokens, cacheWriteTokens);
+  if (cachedInputTokens === undefined || cachedInputTokens === 0) return inputTokens;
+
+  const legacyTotalTokens = safeTokenSum(inputTokens, cachedInputTokens, outputTokens);
+  if (legacyTotalTokens !== totalTokens) return inputTokens;
+
+  return safeTokenSum(inputTokens, cachedInputTokens) ?? inputTokens;
+}
+
 function readDailyCap(path: string): number {
   try {
     return DailySpendCapSchema.parse(JSON.parse(readFileSync(path, "utf8")) as unknown).dailyCapUsd;
@@ -202,7 +238,7 @@ export function createSpendMeterService(input: CreateSpendMeterServiceInput): Sp
         line.inputTokens !== undefined &&
         line.outputTokens !== undefined
           ? priceInclusiveUsage(line.provider, line.model, {
-              inputTokens: line.inputTokens,
+              inputTokens: catalogInputTokens(line) ?? line.inputTokens,
               outputTokens: line.outputTokens,
               cacheReadTokens,
               cacheWriteTokens: line.cacheWriteTokens ?? 0,

--- a/packages/coach/tests/spend-meter.test.ts
+++ b/packages/coach/tests/spend-meter.test.ts
@@ -2,7 +2,7 @@ import { chmod, mkdir, mkdtemp, readFile, realpath, rm, stat, writeFile } from "
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import type { UsageLedgerLine } from "@enduragent/engine";
+import { priceInclusiveUsage, type UsageLedgerLine } from "@enduragent/engine";
 import {
   DAILY_SPEND_CAP_FILE,
   DEFAULT_DAILY_SPEND_CAP_USD,
@@ -209,6 +209,215 @@ describe("spend meter service", () => {
       malformedLineCount: 2,
       knownSpendUsd: 0,
       capStatus: "unknown",
+    });
+  });
+
+  it("prices mixed legacy and current Codex rows once and reaches the cap with cached input included", async () => {
+    const legacyLine = line({
+      provider: "openai-codex",
+      model: "gpt-5.2",
+      inputTokens: 2_000,
+      outputTokens: 0,
+      totalTokens: 30_000,
+      cacheReadTokens: 28_000,
+      cacheWriteTokens: 0,
+    });
+    const currentLine = line({
+      provider: "openai-codex",
+      model: "gpt-5.2",
+      inputTokens: 30_000,
+      outputTokens: 0,
+      totalTokens: 30_000,
+      cacheReadTokens: 28_000,
+      cacheWriteTokens: 0,
+    });
+    await ledger("usage-ledger.jsonl", [legacyLine]);
+    const service = createSpendMeterService({
+      dataDir: root,
+      configDir,
+      timezone: "UTC",
+      now: () => Date.UTC(1998, 6, 6, 18),
+    });
+
+    const ledgerPath = join(root, "usage-ledger.jsonl");
+    const persistedLegacyLine = await readFile(ledgerPath, "utf8");
+    const legacySummary = await service.getSpendSummary();
+    expect(legacySummary.knownSpendUsd).toBe(0.0084);
+    expect(await readFile(ledgerPath, "utf8")).toBe(persistedLegacyLine);
+
+    await ledger("usage-ledger.jsonl", [legacyLine, currentLine]);
+    const summary = await service.setDailySpendCap(0.015);
+
+    expect(summary).toMatchObject({
+      generationCount: 2,
+      pricedGenerationCount: 2,
+      unpricedGenerationCount: 0,
+      malformedLineCount: 0,
+      knownSpendUsd: 0.0168,
+      capStatus: "reached",
+      cacheReadTokens: 56_000,
+    });
+    expect(summary.routes).toHaveLength(1);
+    expect(summary.routes[0]).toMatchObject({
+      provider: "openai-codex",
+      model: "gpt-5.2",
+      generationCount: 2,
+      pricedGenerationCount: 2,
+      knownSpendUsd: 0.0168,
+    });
+  });
+
+  it("does not normalize ambiguous Codex rows or any non-Codex provider", async () => {
+    await ledger("usage-ledger.jsonl", [
+      line({
+        provider: "openai-codex",
+        model: "gpt-5.2",
+        inputTokens: 2_000,
+        outputTokens: 0,
+        totalTokens: 29_999,
+        cacheReadTokens: 28_000,
+        cacheWriteTokens: 0,
+      }),
+      line({
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+        inputTokens: 600,
+        outputTokens: 100,
+        totalTokens: 1_100,
+        cacheReadTokens: 400,
+        cacheWriteTokens: 100,
+      }),
+    ]);
+    const summary = await createSpendMeterService({
+      dataDir: root,
+      configDir,
+      timezone: "UTC",
+      now: () => Date.UTC(1998, 6, 6, 18),
+    }).getSpendSummary();
+
+    expect(summary.routes.map((route) => route.provider)).toEqual(["anthropic", "openai-codex"]);
+    expect(summary.routes[0].knownSpendUsd).toBeCloseTo(0.002295, 12);
+    expect(summary.routes[1].knownSpendUsd).toBe(0.0049);
+  });
+
+  it("rejects a truly non-finite token parsed from a raw ledger number", async () => {
+    const rawLine = JSON.stringify(
+      line({
+        provider: "openai-codex",
+        model: "gpt-5.2",
+        inputTokens: 1,
+        outputTokens: 0,
+        totalTokens: 1,
+        cacheReadTokens: 0,
+        cacheWriteTokens: 0,
+      }),
+    ).replace('"inputTokens":1,', '"inputTokens":1e400,');
+    await ledger("usage-ledger.jsonl", [rawLine]);
+
+    const summary = await createSpendMeterService({
+      dataDir: root,
+      configDir,
+      timezone: "UTC",
+      now: () => Date.UTC(1998, 6, 6, 18),
+    }).getSpendSummary();
+
+    expect(summary).toMatchObject({
+      generationCount: 1,
+      pricedGenerationCount: 0,
+      unpricedGenerationCount: 1,
+      malformedLineCount: 1,
+      knownSpendUsd: 0,
+      capStatus: "unknown",
+    });
+  });
+
+  it("normalizes an exact legacy identity at Number.MAX_SAFE_INTEGER once", async () => {
+    const legacyLine = line({
+      provider: "openai-codex",
+      model: "gpt-5.2",
+      inputTokens: Number.MAX_SAFE_INTEGER - 2,
+      outputTokens: 0,
+      totalTokens: Number.MAX_SAFE_INTEGER,
+      cacheReadTokens: 1,
+      cacheWriteTokens: 1,
+    });
+    await ledger("usage-ledger.jsonl", [legacyLine]);
+    const ledgerPath = join(root, "usage-ledger.jsonl");
+    const persistedLine = await readFile(ledgerPath, "utf8");
+    const service = createSpendMeterService({
+      dataDir: root,
+      configDir,
+      timezone: "UTC",
+      now: () => Date.UTC(1998, 6, 6, 18),
+    });
+    const expected = priceInclusiveUsage("openai-codex", "gpt-5.2", {
+      inputTokens: Number.MAX_SAFE_INTEGER,
+      outputTokens: 0,
+      cacheReadTokens: 1,
+      cacheWriteTokens: 1,
+    });
+    const unnormalized = priceInclusiveUsage("openai-codex", "gpt-5.2", {
+      inputTokens: Number.MAX_SAFE_INTEGER - 2,
+      outputTokens: 0,
+      cacheReadTokens: 1,
+      cacheWriteTokens: 1,
+    });
+
+    const first = await service.getSpendSummary();
+    const second = await service.getSpendSummary();
+
+    expect(expected).toBeDefined();
+    expect(expected?.total).not.toBe(unnormalized?.total);
+    expect(first).toMatchObject({
+      generationCount: 1,
+      pricedGenerationCount: 1,
+      unpricedGenerationCount: 0,
+      malformedLineCount: 0,
+      knownSpendUsd: expected?.total,
+    });
+    expect(second.knownSpendUsd).toBe(expected?.total);
+    expect(await readFile(ledgerPath, "utf8")).toBe(persistedLine);
+  });
+
+  it("does not guess a legacy identity when individually safe components overflow", async () => {
+    const ambiguousLine = line({
+      provider: "openai-codex",
+      model: "gpt-5.2",
+      inputTokens: 100,
+      outputTokens: Number.MAX_SAFE_INTEGER,
+      totalTokens: Number.MAX_SAFE_INTEGER,
+      cacheReadTokens: 50,
+      cacheWriteTokens: 0,
+    });
+    await ledger("usage-ledger.jsonl", [ambiguousLine]);
+    const expected = priceInclusiveUsage("openai-codex", "gpt-5.2", {
+      inputTokens: 100,
+      outputTokens: Number.MAX_SAFE_INTEGER,
+      cacheReadTokens: 50,
+      cacheWriteTokens: 0,
+    });
+    const guessed = priceInclusiveUsage("openai-codex", "gpt-5.2", {
+      inputTokens: 150,
+      outputTokens: Number.MAX_SAFE_INTEGER,
+      cacheReadTokens: 50,
+      cacheWriteTokens: 0,
+    });
+
+    const summary = await createSpendMeterService({
+      dataDir: root,
+      configDir,
+      timezone: "UTC",
+      now: () => Date.UTC(1998, 6, 6, 18),
+    }).getSpendSummary();
+
+    expect(expected).toBeDefined();
+    expect(expected?.total).not.toBe(guessed?.total);
+    expect(summary).toMatchObject({
+      generationCount: 1,
+      pricedGenerationCount: 1,
+      unpricedGenerationCount: 0,
+      malformedLineCount: 0,
+      knownSpendUsd: expected?.total,
     });
   });
 });

--- a/packages/engine/src/agent/codex-bridge.ts
+++ b/packages/engine/src/agent/codex-bridge.ts
@@ -4,7 +4,12 @@ import type { FinishReason, LanguageModelUsage, ModelMessage, ToolSet } from "ai
 import type { FailureReason } from "../host-ports.js";
 import type { GenerateOpts, GenerateResult } from "../llm-types.js";
 import { codexResponses } from "./codex/responses.js";
-import type { CodexResponsesResult, CodexStopReason, CodexToolCall, CodexUsage } from "./codex/responses.js";
+import type {
+  CodexResponsesResult,
+  CodexStopReason,
+  CodexToolCall,
+  CodexUsage,
+} from "./codex/responses.js";
 import { PRICE_TABLE, priceUsage } from "./codex/cost.js";
 
 const DEFAULT_STEP_LIMIT = 10;
@@ -103,27 +108,51 @@ function emptyTokens(): CodexUsage {
   return { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0 };
 }
 
-function addTokens(acc: CodexUsage, u: CodexUsage): CodexUsage {
-  return {
-    input: acc.input + u.input,
-    output: acc.output + u.output,
-    cacheRead: acc.cacheRead + u.cacheRead,
-    cacheWrite: acc.cacheWrite + u.cacheWrite,
-    totalTokens: acc.totalTokens + u.totalTokens,
-  };
+function validToken(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+}
+
+function safeTokenSum(...values: number[]): number | undefined {
+  let total = 0;
+  for (const value of values) {
+    if (!validToken(value)) return undefined;
+    total += value;
+    if (!Number.isSafeInteger(total)) return undefined;
+  }
+  return total;
+}
+
+function addTokens(acc: CodexUsage | null, u: CodexUsage): CodexUsage | null {
+  if (acc === null) return null;
+  const input = safeTokenSum(acc.input, u.input);
+  const output = safeTokenSum(acc.output, u.output);
+  const cacheRead = safeTokenSum(acc.cacheRead, u.cacheRead);
+  const cacheWrite = safeTokenSum(acc.cacheWrite, u.cacheWrite);
+  const totalTokens = safeTokenSum(acc.totalTokens, u.totalTokens);
+  if (
+    input === undefined ||
+    output === undefined ||
+    cacheRead === undefined ||
+    cacheWrite === undefined ||
+    totalTokens === undefined ||
+    safeTokenSum(input, cacheRead, cacheWrite) === undefined
+  ) {
+    return null;
+  }
+  return { input, output, cacheRead, cacheWrite, totalTokens };
 }
 
 function mapUsage(u: CodexUsage): LanguageModelUsage {
   return {
-    inputTokens: u.input,
-    outputTokens: u.output,
-    totalTokens: u.totalTokens,
+    inputTokens: safeTokenSum(u.input, u.cacheRead, u.cacheWrite),
+    outputTokens: validToken(u.output) ? u.output : undefined,
+    totalTokens: validToken(u.totalTokens) ? u.totalTokens : undefined,
     reasoningTokens: undefined,
-    cachedInputTokens: u.cacheRead,
+    cachedInputTokens: validToken(u.cacheRead) ? u.cacheRead : undefined,
     inputTokenDetails: {
-      noCacheTokens: undefined,
-      cacheReadTokens: u.cacheRead,
-      cacheWriteTokens: u.cacheWrite,
+      noCacheTokens: validToken(u.input) ? u.input : undefined,
+      cacheReadTokens: validToken(u.cacheRead) ? u.cacheRead : undefined,
+      cacheWriteTokens: validToken(u.cacheWrite) ? u.cacheWrite : undefined,
     },
     outputTokenDetails: {
       reasoningTokens: undefined,
@@ -168,7 +197,10 @@ async function executeToolCall(
     schema: asSchema(tool.inputSchema),
   });
   if (!validation.success) {
-    return errorResult(call, `Invalid arguments for tool "${call.name}": ${validation.error.message}`);
+    return errorResult(
+      call,
+      `Invalid arguments for tool "${call.name}": ${validation.error.message}`,
+    );
   }
 
   try {
@@ -248,7 +280,7 @@ export async function codexGenerateText(
 
   const convo: ModelMessage[] = [...initialMessages];
   let lastResult: CodexResponsesResult | undefined;
-  let accumulated = emptyTokens();
+  let accumulated: CodexUsage | null = emptyTokens();
   let stepCount = 0;
 
   for (let step = 0; step < limit; step++) {
@@ -268,7 +300,10 @@ export async function codexGenerateText(
     }
 
     if (result.stopReason === "error") {
-      throw normalizeError(new Error(result.errorMessage ?? "Codex request failed"), classifyFailure);
+      throw normalizeError(
+        new Error(result.errorMessage ?? "Codex request failed"),
+        classifyFailure,
+      );
     }
 
     lastResult = result;
@@ -306,8 +341,11 @@ export async function codexGenerateText(
     toolCalls: toolCalls as GenerateResult["toolCalls"],
     finishReason: mapStopReason(lastResult.stopReason),
     usage: mapUsage(lastResult.usage),
-    totalUsage: mapUsage(accumulated),
+    totalUsage: accumulated === null ? undefined : mapUsage(accumulated),
     steps: stepCount,
-    cost: priceUsage("openai-codex", resolveCodexPriceId(modelId), accumulated),
+    cost:
+      accumulated === null
+        ? undefined
+        : priceUsage("openai-codex", resolveCodexPriceId(modelId), accumulated),
   };
 }

--- a/packages/engine/tests/codex-bridge.test.ts
+++ b/packages/engine/tests/codex-bridge.test.ts
@@ -6,6 +6,7 @@ import { zodSchema } from "ai";
 import { z } from "zod";
 import type { EngineHostPorts } from "../src/host-ports.js";
 import { normalizeError } from "../src/agent/codex-bridge.js";
+import { usageFieldsFromResult } from "../src/llm-types.js";
 import {
   classifyFailure,
   isContextOverflowError,
@@ -52,17 +53,30 @@ async function loadBridgeWithMocks(opts: {
   };
 }
 
-function asstMsg(overrides: {
-  text?: string;
-  toolCalls?: Array<{ id: string; name: string; arguments: Record<string, unknown> }>;
-  usage?: { input: number; output: number; cacheRead: number; cacheWrite: number; totalTokens: number };
-  stopReason?: "stop" | "length" | "toolUse" | "error";
-} = {}) {
+function asstMsg(
+  overrides: {
+    text?: string;
+    toolCalls?: Array<{ id: string; name: string; arguments: Record<string, unknown> }>;
+    usage?: {
+      input: number;
+      output: number;
+      cacheRead: number;
+      cacheWrite: number;
+      totalTokens: number;
+    };
+    stopReason?: "stop" | "length" | "toolUse" | "error";
+  } = {},
+) {
   return {
     text: overrides.text ?? "hello",
     toolCalls: overrides.toolCalls ?? [],
-    usage:
-      overrides.usage ?? { input: 10, output: 5, cacheRead: 0, cacheWrite: 0, totalTokens: 15 },
+    usage: overrides.usage ?? {
+      input: 10,
+      output: 5,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 15,
+    },
     stopReason: overrides.stopReason ?? "stop",
   };
 }
@@ -83,7 +97,262 @@ describe("codex-bridge", () => {
     expect(result.finishReason).toBe("stop");
     expect(result.usage.inputTokens).toBe(10);
     expect(result.usage.outputTokens).toBe(5);
+    expect(result.usage.totalTokens).toBe(15);
+    expect(result.usage.inputTokenDetails).toEqual({
+      noCacheTokens: 10,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+    });
     expect(complete).toHaveBeenCalledTimes(1);
+  });
+
+  it("maps cached input inclusively while preserving uncached input, cache details, totals, and cost", async () => {
+    const complete = vi.fn(async () =>
+      asstMsg({
+        usage: {
+          input: 2_000,
+          output: 0,
+          cacheRead: 28_000,
+          cacheWrite: 0,
+          totalTokens: 30_000,
+        },
+      }),
+    );
+    const { codexGenerateText } = await loadBridgeWithMocks({ complete });
+
+    const result = await codexGenerateText({
+      messages: [{ role: "user", content: "hi" }],
+      modelId: "gpt-5.2",
+      profileName: "openai-codex",
+    });
+
+    expect(result.usage).toMatchObject({
+      inputTokens: 30_000,
+      outputTokens: 0,
+      totalTokens: 30_000,
+      cachedInputTokens: 28_000,
+      inputTokenDetails: {
+        noCacheTokens: 2_000,
+        cacheReadTokens: 28_000,
+        cacheWriteTokens: 0,
+      },
+    });
+    expect(result.totalUsage).toEqual(result.usage);
+    expect(result.cost?.total).toBe(0.0084);
+  });
+
+  it("keeps an inclusive input sum exactly at Number.MAX_SAFE_INTEGER", async () => {
+    const complete = vi.fn(async () =>
+      asstMsg({
+        usage: {
+          input: Number.MAX_SAFE_INTEGER - 2,
+          output: 0,
+          cacheRead: 1,
+          cacheWrite: 1,
+          totalTokens: Number.MAX_SAFE_INTEGER,
+        },
+      }),
+    );
+    const { codexGenerateText } = await loadBridgeWithMocks({ complete });
+
+    const result = await codexGenerateText({
+      messages: [{ role: "user", content: "hi" }],
+      modelId: "gpt-5.2",
+      profileName: "openai-codex",
+    });
+
+    expect(result.usage.inputTokens).toBe(Number.MAX_SAFE_INTEGER);
+    expect(result.usage.inputTokenDetails).toEqual({
+      noCacheTokens: Number.MAX_SAFE_INTEGER - 2,
+      cacheReadTokens: 1,
+      cacheWriteTokens: 1,
+    });
+    expect(result.totalUsage?.inputTokens).toBe(Number.MAX_SAFE_INTEGER);
+    expect(result.cost).toBeDefined();
+  });
+
+  it("omits an inclusive input sum that exceeds Number.MAX_SAFE_INTEGER", async () => {
+    const complete = vi.fn(async () =>
+      asstMsg({
+        usage: {
+          input: Number.MAX_SAFE_INTEGER - 1,
+          output: 0,
+          cacheRead: 2,
+          cacheWrite: 0,
+          totalTokens: Number.MAX_SAFE_INTEGER,
+        },
+      }),
+    );
+    const { codexGenerateText } = await loadBridgeWithMocks({ complete });
+
+    const result = await codexGenerateText({
+      messages: [{ role: "user", content: "hi" }],
+      modelId: "gpt-5.2",
+      profileName: "openai-codex",
+    });
+
+    expect(result.usage.inputTokens).toBeUndefined();
+    expect(result.usage.inputTokenDetails).toEqual({
+      noCacheTokens: Number.MAX_SAFE_INTEGER - 1,
+      cacheReadTokens: 2,
+      cacheWriteTokens: 0,
+    });
+    expect(result.totalUsage).toBeUndefined();
+    expect(result.cost).toBeUndefined();
+  });
+
+  it("does not expose or persist negative uncached input when cached input exceeds provider input", async () => {
+    const complete = vi.fn(async () =>
+      asstMsg({
+        usage: {
+          input: -1,
+          output: 0,
+          cacheRead: 11,
+          cacheWrite: 0,
+          totalTokens: 10,
+        },
+      }),
+    );
+    const { codexGenerateText } = await loadBridgeWithMocks({ complete });
+
+    const result = await codexGenerateText({
+      messages: [{ role: "user", content: "hi" }],
+      modelId: "gpt-5.2",
+      profileName: "openai-codex",
+    });
+
+    expect(result.text).toBe("hello");
+    expect(result.usage.inputTokens).toBeUndefined();
+    expect(result.usage.inputTokenDetails).toEqual({
+      noCacheTokens: undefined,
+      cacheReadTokens: 11,
+      cacheWriteTokens: 0,
+    });
+    expect(result.totalUsage).toBeUndefined();
+    expect(result.cost).toBeUndefined();
+    expect(usageFieldsFromResult(result)).toMatchObject({
+      inputTokens: undefined,
+      outputTokens: undefined,
+      totalTokens: undefined,
+      cacheReadTokens: undefined,
+      cacheWriteTokens: undefined,
+      cost: undefined,
+    });
+  });
+
+  it("maps cached input for the final step and accumulated multi-step usage", async () => {
+    const complete = vi
+      .fn()
+      .mockResolvedValueOnce(
+        asstMsg({
+          stopReason: "toolUse",
+          toolCalls: [{ id: "c1", name: "noop", arguments: {} }],
+          usage: {
+            input: 100,
+            output: 20,
+            cacheRead: 50,
+            cacheWrite: 10,
+            totalTokens: 180,
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        asstMsg({
+          usage: {
+            input: 200,
+            output: 30,
+            cacheRead: 100,
+            cacheWrite: 20,
+            totalTokens: 350,
+          },
+        }),
+      );
+    const { codexGenerateText } = await loadBridgeWithMocks({ complete });
+
+    const result = await codexGenerateText({
+      messages: [{ role: "user", content: "hi" }],
+      tools: {} as never,
+      modelId: "gpt-5.2",
+      profileName: "openai-codex",
+    });
+
+    expect(result.steps).toBe(2);
+    expect(result.usage).toMatchObject({
+      inputTokens: 320,
+      outputTokens: 30,
+      totalTokens: 350,
+      cachedInputTokens: 100,
+      inputTokenDetails: {
+        noCacheTokens: 200,
+        cacheReadTokens: 100,
+        cacheWriteTokens: 20,
+      },
+    });
+    expect(result.totalUsage).toMatchObject({
+      inputTokens: 480,
+      outputTokens: 50,
+      totalTokens: 530,
+      cachedInputTokens: 150,
+      inputTokenDetails: {
+        noCacheTokens: 300,
+        cacheReadTokens: 150,
+        cacheWriteTokens: 30,
+      },
+    });
+  });
+
+  it("keeps the successful final step when whole-turn accumulation overflows", async () => {
+    const complete = vi
+      .fn()
+      .mockResolvedValueOnce(
+        asstMsg({
+          text: "working",
+          stopReason: "toolUse",
+          toolCalls: [{ id: "c1", name: "noop", arguments: {} }],
+          usage: {
+            input: Number.MAX_SAFE_INTEGER - 10,
+            output: 0,
+            cacheRead: 0,
+            cacheWrite: 0,
+            totalTokens: Number.MAX_SAFE_INTEGER - 10,
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        asstMsg({
+          text: "done",
+          usage: {
+            input: 11,
+            output: 0,
+            cacheRead: 0,
+            cacheWrite: 0,
+            totalTokens: 11,
+          },
+        }),
+      );
+    const { codexGenerateText } = await loadBridgeWithMocks({ complete });
+
+    const result = await codexGenerateText({
+      messages: [{ role: "user", content: "hi" }],
+      tools: {} as never,
+      modelId: "gpt-5.2",
+      profileName: "openai-codex",
+    });
+
+    expect(result.text).toBe("done");
+    expect(result.steps).toBe(2);
+    expect(result.usage).toMatchObject({
+      inputTokens: 11,
+      outputTokens: 0,
+      totalTokens: 11,
+      inputTokenDetails: {
+        noCacheTokens: 11,
+        cacheReadTokens: 0,
+        cacheWriteTokens: 0,
+      },
+    });
+    expect(result.totalUsage).toBeUndefined();
+    expect(result.cost).toBeUndefined();
   });
 
   it("maps codex rate-limit errors so isRateLimitError() recognizes them", async () => {
@@ -175,7 +444,9 @@ describe("codex-bridge", () => {
 
   it("forwards opts.cacheKey as the request sessionId; omits it when absent", async () => {
     const completeWithKey = vi.fn(async () => asstMsg());
-    const { codexGenerateText: genWithKey } = await loadBridgeWithMocks({ complete: completeWithKey });
+    const { codexGenerateText: genWithKey } = await loadBridgeWithMocks({
+      complete: completeWithKey,
+    });
 
     await genWithKey({
       messages: [{ role: "user", content: "hi" }],
@@ -198,9 +469,7 @@ describe("codex-bridge", () => {
       profileName: "openai-codex",
     });
 
-    expect(completeNoKey).toHaveBeenCalledWith(
-      expect.objectContaining({ sessionId: undefined }),
-    );
+    expect(completeNoKey).toHaveBeenCalledWith(expect.objectContaining({ sessionId: undefined }));
   });
 
   it("forwards opts.signal to the codex response request", async () => {
@@ -215,9 +484,7 @@ describe("codex-bridge", () => {
       signal,
     });
 
-    expect(complete).toHaveBeenCalledWith(
-      expect.objectContaining({ signal }),
-    );
+    expect(complete).toHaveBeenCalledWith(expect.objectContaining({ signal }));
   });
 
   it("surfaces finishReason=length so isContextOverflowError can catch it upstream via retry", async () => {
@@ -331,10 +598,12 @@ describe("codex-bridge", () => {
 
   it("forwards opts.signal to codex tool execution", async () => {
     let toolOptions: { abortSignal?: AbortSignal } | undefined;
-    const execute = vi.fn(async (_input: { minutes: number }, options: { abortSignal?: AbortSignal }) => {
-      toolOptions = options;
-      return "logged";
-    });
+    const execute = vi.fn(
+      async (_input: { minutes: number }, options: { abortSignal?: AbortSignal }) => {
+        toolOptions = options;
+        return "logged";
+      },
+    );
     const tools = {
       log_ride: {
         description: "log a ride",
@@ -414,7 +683,10 @@ describe("codex-bridge normalizeError", () => {
   });
 
   it("keeps a 429 as rate limit, not server error", () => {
-    const normalized = normalizeError(httpError(429, "quota exhausted (status=429)"), classifyFailure);
+    const normalized = normalizeError(
+      httpError(429, "quota exhausted (status=429)"),
+      classifyFailure,
+    );
     expect(isRateLimitError(normalized)).toBe(true);
     expect(isServerError(normalized)).toBe(false);
   });


### PR DESCRIPTION
## Summary

- report ChatGPT subscription input usage inclusively while preserving uncached and cache-detail fields
- price provably legacy same-day ledger rows correctly without rewriting or guessing their representation
- fail closed on negative, non-finite, or unsafe token arithmetic so invalid telemetry cannot distort spend or cap warnings

This closes Desktop parity audit item 208.

## Verification

- 84 focused Engine, Coach, Codex response, usage-cost, and usage-ledger tests
- Engine and Coach TypeScript checks
- scoped lint and formatting checks
- changeset, trademark, and fixture-privacy policy checks
- `git diff --check`
- three detached read-only reviewers: algebra, persisted-ledger compatibility, and spend-cap integration
