### PR TITLE
fix(desktop): clarify credential storage

### DIFF
--- a/.changeset/desktop-credential-storage-disclosure.md
+++ b/.changeset/desktop-credential-storage-disclosure.md
@@ -1,0 +1,5 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Onboarding now explains how ChatGPT sign-in and API keys are stored.

--- a/apps/desktop-renderer/src/onboarding/mount.ts
+++ b/apps/desktop-renderer/src/onboarding/mount.ts
@@ -367,7 +367,7 @@ export function mountOnboarding(options: MountOnboardingOptions): OnboardingCont
         options.document,
         "p",
         "onboarding-copy",
-        "Sign in with ChatGPT or use an API key. API keys are encrypted by macOS and sent only to the local coaching service.",
+        "ChatGPT sign-in is saved in a local profile file. API keys are encrypted by macOS. The local coaching service uses your choice to contact the provider.",
       ),
     );
     const chatGptLane = make(options.document, "section", "chatgpt-lane");

--- a/apps/desktop-renderer/tests/onboarding-mount.test.ts
+++ b/apps/desktop-renderer/tests/onboarding-mount.test.ts
@@ -193,6 +193,34 @@ function buttonWithText(document: FakeDocument, text: string): FakeElement {
 }
 
 describe("mounted onboarding", () => {
+  it("discloses distinct credential storage without starting sign-in, writing, or advancing", async () => {
+    const document = new FakeDocument();
+    const onboardingBridge = bridge(async () => ({
+      status: "configured",
+      runtimeReady: true,
+    }));
+    const controller = mountOnboarding({
+      document: documentBoundary(document),
+      bridge: onboardingBridge,
+      opener: elementBoundary(document.createElement("button")),
+      onComplete: vi.fn(),
+    });
+    await controller.open();
+    const stateBeforeReading = controller.state();
+
+    const disclosure = document.body.querySelector(".onboarding-copy");
+    expect(disclosure?.textContent).toContain("ChatGPT sign-in is saved in a local profile file.");
+    expect(disclosure?.textContent).toContain("API keys are encrypted by macOS.");
+    expect(disclosure?.textContent).toContain(
+      "The local coaching service uses your choice to contact the provider.",
+    );
+
+    expect(onboardingBridge.chatGptLogin).not.toHaveBeenCalled();
+    expect(onboardingBridge.writeCredential).not.toHaveBeenCalled();
+    expect(controller.state()).toEqual(stateBeforeReading);
+    expect(controller.state().step).toBe("coach-keys");
+  });
+
   it("runs configured ChatGPT sign-in again through pending to configured", async () => {
     const document = new FakeDocument();
     let resolveLogin!: (result: ChatGptLoginResult) => void;


### PR DESCRIPTION
## Summary

- distinguish ChatGPT sign-in stored in a local profile file from API keys encrypted by macOS
- retain truthful copy that the local coaching service uses the selected method to contact the provider
- prove reading the disclosure triggers no sign-in, credential write, or onboarding-state change

This closes Desktop parity audit item 210's accepted disclosure-copy scope without changing credential storage.

## Verification

- 12 focused onboarding mount and wizard tests
- Desktop renderer TypeScript check
- scoped lint and formatting checks
- changeset, trademark, and fixture-privacy policy checks
- `git diff --check`
- one detached read-only UX/truthfulness reviewer
