### PR TITLE
fix(desktop): dismiss completed first sync

### DIFF
--- a/.changeset/desktop-first-sync-dismissal.md
+++ b/.changeset/desktop-first-sync-dismissal.md
@@ -1,0 +1,5 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: The first-sync progress card now clears when training history is ready.

--- a/apps/desktop-renderer/src/index.ts
+++ b/apps/desktop-renderer/src/index.ts
@@ -116,7 +116,7 @@ let firstSyncElement: HTMLElement | undefined;
 let firstSyncController: ReturnType<typeof createFirstSyncController>;
 
 function renderFirstSync(state: FirstSyncState): void {
-  if (state.status === "idle") {
+  if (state.status === "idle" || state.status === "ready") {
     firstSyncElement?.remove();
     firstSyncElement = undefined;
     return;
@@ -147,10 +147,6 @@ function renderFirstSync(state: FirstSyncState): void {
     track.setAttribute("role", "progressbar");
     track.setAttribute("aria-label", "Syncing training history");
     body.append(eyebrow, title, detail, track);
-  } else if (state.status === "ready") {
-    title.textContent = "Training history is ready";
-    detail.textContent = "Your coach is ready when you are.";
-    body.append(eyebrow, title, detail);
   } else if (state.kind === "protocol") {
     title.textContent = "Enduragent needs to reconnect safely";
     detail.textContent = "Quit and reopen Enduragent.";

--- a/apps/desktop-renderer/tests/first-sync.test.ts
+++ b/apps/desktop-renderer/tests/first-sync.test.ts
@@ -407,8 +407,6 @@ describe("first sync controller", () => {
       "Getting your coach ready",
       "Syncing your training history…",
       "You can keep Enduragent open while rides, wellness, and calendar data are added.",
-      "Training history is ready",
-      "Your coach is ready when you are.",
       "We couldn’t finish syncing",
       "Your saved progress is safe.",
       "Retry sync",
@@ -417,6 +415,16 @@ describe("first sync controller", () => {
     ]) {
       expect(host).toContain(copy);
     }
+    expect(host).toContain(`if (state.status === "idle" || state.status === "ready") {
+    firstSyncElement?.remove();
+    firstSyncElement = undefined;
+    return;
+  }`);
+    expect(host).not.toContain("Training history is ready");
+    expect(host).not.toContain("Your coach is ready when you are.");
+    expect(host).toContain('section.setAttribute("aria-labelledby", "first-sync-title")');
+    expect(host).toContain('track.setAttribute("role", "progressbar")');
+    expect(host).toContain('track.setAttribute("aria-label", "Syncing training history")');
     expect(host).toContain("coordinator: trainingSyncCoordinator");
     expect(host).not.toContain("syncNeedsReconnect");
     expect(controller).not.toMatch(/onNotificationEnvelope|requestId|chat|transcript/u);


### PR DESCRIPTION
## Summary

- remove the first-sync card as soon as the controller reaches terminal readiness
- keep the controller's `ready` state, shared sync coordinator, composer focus, and failure/retry behavior unchanged
- retain syncing and failure accessibility while removing the permanent success copy below the transcript

This closes Desktop parity audit item 217.

## Verification

- 15 focused first-sync tests
- Desktop renderer TypeScript check
- scoped lint and formatting checks
- changeset, trademark, and fixture-privacy policy checks
- `git diff --check`
- one detached read-only renderer-lifecycle reviewer
