### PR TITLE
fix(desktop): avoid unusable OAuth browser

### DIFF
--- a/.changeset/desktop-chatgpt-callback-port-guard.md
+++ b/.changeset/desktop-chatgpt-callback-port-guard.md
@@ -1,0 +1,5 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: ChatGPT sign-in no longer opens an unusable browser tab when another local sign-in flow is using the callback.

--- a/apps/desktop/src/main/chatgpt-auth.ts
+++ b/apps/desktop/src/main/chatgpt-auth.ts
@@ -140,7 +140,8 @@ export function createChatGptAuth(options: CreateChatGptAuthOptions): ChatGptAut
       credentials = await runLogin({
         originator: "enduragent-desktop",
         signal,
-        onAuth: ({ url }) => {
+        onAuth: ({ url, callbackAvailable }) => {
+          if (callbackAvailable === false) return;
           void options.openExternal(url).catch(() => {
             browserController.abort(new ChatGptAuthFlowError("cancelled"));
           });

--- a/apps/desktop/tests/chatgpt-auth.test.ts
+++ b/apps/desktop/tests/chatgpt-auth.test.ts
@@ -279,6 +279,56 @@ describe("desktop ChatGPT auth", () => {
     });
   });
 
+  it("does not open or abort the browser flow when the callback listener is unavailable", async () => {
+    const directory = await configDir();
+    const openExternal = vi.fn(async () => {});
+    let reachedPrompt = false;
+    const auth = createChatGptAuth({
+      configDir: directory,
+      openExternal,
+      applyRuntimeConfig: async () => {},
+      dependencies: {
+        loginCodex: async (options) => {
+          options.onAuth({
+            url: "https://auth.openai.com/obviously-fake",
+            callbackAvailable: false,
+          });
+          expect(options.signal?.aborted).toBe(false);
+          reachedPrompt = true;
+          await options.onPrompt({ message: "obviously-fake" });
+          return credentials();
+        },
+      },
+    });
+
+    await expect(auth.login()).resolves.toEqual({
+      status: "refused",
+      reason: "callback-unavailable",
+    });
+    expect(reachedPrompt).toBe(true);
+    expect(openExternal).not.toHaveBeenCalled();
+  });
+
+  it("treats missing callback availability as available for compatibility", async () => {
+    const directory = await configDir();
+    const openExternal = vi.fn(async () => {});
+    const auth = createChatGptAuth({
+      configDir: directory,
+      openExternal,
+      applyRuntimeConfig: async () => {},
+      dependencies: {
+        loginCodex: async (options) => {
+          options.onAuth({ url: "https://auth.openai.com/obviously-fake" });
+          await vi.waitFor(() => expect(openExternal).toHaveBeenCalledOnce());
+          return credentials();
+        },
+      },
+    });
+
+    await expect(auth.login()).resolves.toEqual({ status: "configured", runtimeReady: true });
+    expect(openExternal).toHaveBeenCalledOnce();
+  });
+
   it("opens the browser, stores first, and applies a keyless Codex request", async () => {
     const directory = await configDir();
     const order: string[] = [];
@@ -304,7 +354,10 @@ describe("desktop ChatGPT auth", () => {
         writeProfile,
         loginCodex: async (options) => {
           expect(options.signal).toBeInstanceOf(AbortSignal);
-          options.onAuth({ url: "https://auth.openai.com/obviously-fake" });
+          options.onAuth({
+            url: "https://auth.openai.com/obviously-fake",
+            callbackAvailable: true,
+          });
           await vi.waitFor(() => expect(openExternal).toHaveBeenCalledOnce());
           return credentials();
         },

--- a/packages/core/src/agent/codex/oauth.ts
+++ b/packages/core/src/agent/codex/oauth.ts
@@ -24,7 +24,7 @@ export interface CodexCredentials {
 }
 
 export interface CodexLoginOptions {
-  onAuth: (info: { url: string; instructions?: string }) => void;
+  onAuth: (info: { url: string; instructions?: string; callbackAvailable?: boolean }) => void;
   onPrompt: (prompt: { message: string }) => Promise<string>;
   onProgress?: (message: string) => void;
   onManualCodeInput?: () => Promise<string>;
@@ -130,6 +130,7 @@ async function createAuthorizationFlow(
 }
 
 interface OAuthServerHandle {
+  callbackAvailable: boolean;
   close: () => Promise<void>;
   cancelWait: () => void;
   waitForCode: () => Promise<{ code: string } | null>;
@@ -178,6 +179,7 @@ function startLocalOAuthServer(state: string): Promise<OAuthServerHandle> {
     server
       .listen(CALLBACK_PORT, CALLBACK_HOST, () => {
         resolve({
+          callbackAvailable: true,
           close: () => new Promise((resolveClose) => server.close(() => resolveClose())),
           cancelWait: () => settleWait?.(null),
           waitForCode: () => waitForCodePromise,
@@ -191,6 +193,7 @@ function startLocalOAuthServer(state: string): Promise<OAuthServerHandle> {
         );
         settleWait?.(null);
         resolve({
+          callbackAvailable: false,
           close: async () => {
             try {
               server.close();
@@ -387,6 +390,7 @@ export async function loginCodex(options: CodexLoginOptions): Promise<CodexCrede
     options.onAuth({
       url,
       instructions: "A browser window should open. Complete login to finish.",
+      callbackAvailable: server.callbackAvailable,
     });
     if (options.onManualCodeInput) {
       // Race the browser callback against manual paste — first to yield a code wins.

--- a/packages/core/tests/codex/oauth.test.ts
+++ b/packages/core/tests/codex/oauth.test.ts
@@ -1,6 +1,11 @@
 import { createServer } from "node:http";
 import { describe, it, expect, afterEach, vi } from "vitest";
-import { loginCodex, refreshCodexToken, generatePKCE } from "../../src/agent/codex/oauth.js";
+import {
+  loginCodex,
+  refreshCodexToken,
+  generatePKCE,
+  type CodexLoginOptions,
+} from "../../src/agent/codex/oauth.js";
 import { RefreshTokenReusedError } from "../../src/auth/profiles.js";
 import { classifyFailure } from "../../src/agent/token-utils.js";
 
@@ -318,6 +323,69 @@ describe("generatePKCE", () => {
 });
 
 describe("loginCodex", () => {
+  it("keeps manual-code login available when another callback listener owns the port", async () => {
+    const foreignServer = createServer((_request, response) => {
+      response.end("foreign listener");
+    });
+    await new Promise<void>((resolve, reject) => {
+      foreignServer.once("error", reject);
+      foreignServer.listen(1455, "127.0.0.1", () => {
+        foreignServer.off("error", reject);
+        resolve();
+      });
+    });
+
+    try {
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            access_token: TOKEN_WITH_ACCOUNT,
+            refresh_token: "obviously-fake-port-collision-refresh",
+            expires_in: 3600,
+          }),
+          { status: 200 },
+        ),
+      );
+      let authorizationInfo: Parameters<CodexLoginOptions["onAuth"]>[0] | undefined;
+      const onPrompt = vi.fn(async () => "unexpected-prompt-input");
+
+      const credentials = await loginCodex({
+        onAuth: (info) => {
+          authorizationInfo = info;
+        },
+        onManualCodeInput: async () => "obviously-fake-port-collision-code",
+        onPrompt,
+      });
+
+      expect(authorizationInfo).toMatchObject({
+        url: expect.stringMatching(/^https:\/\/auth\.openai\.com\/oauth\/authorize\?/),
+        callbackAvailable: false,
+      });
+      expect(onPrompt).not.toHaveBeenCalled();
+      expect(credentials).toMatchObject({
+        access: TOKEN_WITH_ACCOUNT,
+        refresh: "obviously-fake-port-collision-refresh",
+        accountId: "acct_x",
+      });
+      expect(foreignServer.listening).toBe(true);
+      expect(errorSpy).toHaveBeenCalledOnce();
+      expect(errorSpy).toHaveBeenCalledWith(
+        "[codex-oauth] Failed to bind http://127.0.0.1:1455 (",
+        "EADDRINUSE",
+        ") Falling back to manual paste.",
+      );
+      const logged = errorSpy.mock.calls.flat().join(" ");
+      expect(logged).not.toContain("obviously-fake-port-collision-code");
+      expect(logged).not.toContain("obviously-fake-port-collision-refresh");
+      expect(logged).not.toContain(TOKEN_WITH_ACCOUNT);
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        foreignServer.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  });
+
   it("aborts the callback wait and releases the registered port", async () => {
     const controller = new AbortController();
     const pending = loginCodex({
@@ -351,7 +419,8 @@ describe("loginCodex", () => {
     });
     let callback: Promise<Response> | undefined;
     const credentials = await loginCodex({
-      onAuth: ({ url }) => {
+      onAuth: ({ url, callbackAvailable }) => {
+        expect(callbackAvailable).toBe(true);
         const state = new URL(url).searchParams.get("state");
         callback = nativeFetch(
           `http://127.0.0.1:1455/auth/callback?code=obviously-fake-code&state=${state}`,


### PR DESCRIPTION
## Summary

- surface whether the local OAuth callback listener bound successfully without changing the CLI authorization or manual-code fallback
- skip Desktop's browser launch only when that listener is explicitly unavailable, preserving the existing fixed refusal reason
- cover occupied-port recovery, successful callbacks, Desktop suppression, and source-compatible callers

## Verification

- 56 focused Core OAuth and Desktop authentication tests
- Core and Desktop typechecks
- scoped lint, format, changeset, trademark, fixture-privacy, and diff-integrity checks
- three independent read-only reviews covering auth sequencing, callback lifecycle, and CLI compatibility; zero blockers

No real OAuth, credentials, profiles, Electron, or network services were used in local verification.
