### PR TITLE
test(tools): harden remaining dependency scan timing

### DIFF
--- a/tools/check-package-deps.test.ts
+++ b/tools/check-package-deps.test.ts
@@ -501,7 +501,7 @@ describe("real repository", () => {
     expect(main([])).toBe(0);
   });
 
-  it("surfaces exactly the remaining transitional edges", () => {
+  it("surfaces exactly the remaining transitional edges", { timeout: 15_000 }, () => {
     const result = runRulesAgainst(".", RULES);
     const edges = result.warnEdges.map((e) => `${e.dir} -> ${e.target}`);
     expect(edges).toEqual([
@@ -512,7 +512,7 @@ describe("real repository", () => {
     expect(result.warnEdges.filter((edge) => edge.dir.startsWith("packages/sport-"))).toEqual([]);
   });
 
-  it("activates engine without making end-state discovery vacuous", () => {
+  it("activates engine without making end-state discovery vacuous", { timeout: 15_000 }, () => {
     const result = runRulesAgainst(".", RULES);
     expect(result.notPresent).not.toContain("packages/engine");
     expect(result.notPresent).not.toContain("packages/coach-client");


### PR DESCRIPTION
## Summary
- give the final two full-repository dependency-scan tests a bounded 15-second timeout
- preserve every dependency assertion and expected edge unchanged
- prevent the known five-second false failure when coverage instrumentation slows repository scans

## Verification
- focused dependency tests: 51/51 passed
- focused dependency tests with coverage: 51/51 passed
- oxlint passed
- oxfmt check passed
- git diff check passed
- one independent reviewer passed the test-only change

No changeset: this only hardens test timing and does not change shipped behavior.