### PR TITLE
fix(desktop): wait for renderer before showing window

### DIFF
--- a/.changeset/desktop-cold-start-window-visibility.md
+++ b/.changeset/desktop-cold-start-window-visibility.md
@@ -1,0 +1,5 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Closing the Desktop app after it appears now reliably keeps it available from the menu bar during cold startup.

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -301,9 +301,6 @@ async function runDesktop(): Promise<void> {
             isTrusted: (event) =>
               isTrustedConnectionRequest(event, mainWindow.current() ?? undefined),
           });
-          created.once("ready-to-show", () => {
-            if (!created.isDestroyed()) created.show();
-          });
           created.once("closed", () => {
             if (window === created) {
               window = null;

--- a/apps/desktop/tests/residency.test.ts
+++ b/apps/desktop/tests/residency.test.ts
@@ -270,6 +270,29 @@ describe("desktop residency", () => {
     expect(events).toEqual([]);
   });
 
+  it("presents the initial window only after its renderer URL loads", async () => {
+    const source = await readFile(resolve(import.meta.dirname, "../src/main/index.ts"), "utf8");
+    const creationStart = source.indexOf("windowCreation = (async () => {");
+    const load = source.indexOf("await created.loadURL(DESKTOP_RENDERER_URL);", creationStart);
+    const restore = source.indexOf("if (created.isMinimized()) created.restore();", load);
+    const show = source.indexOf("created.show();", load);
+    const focus = source.indexOf("created.focus();", load);
+    const creationEnd = source.indexOf("})().finally(() => {", focus);
+    const initialShow = source.indexOf("const initialWindow = await mainWindow.show();");
+    const residencyStart = source.indexOf("await residency.start();", initialShow);
+
+    expect(source).not.toContain('created.once("ready-to-show"');
+    expect(creationStart).toBeGreaterThanOrEqual(0);
+    expect(load).toBeGreaterThan(creationStart);
+    expect(restore).toBeGreaterThan(load);
+    expect(show).toBeGreaterThan(restore);
+    expect(focus).toBeGreaterThan(show);
+    expect(creationEnd).toBeGreaterThan(focus);
+    expect(source.slice(load, creationEnd)).not.toMatch(/\bcatch\b/);
+    expect(initialShow).toBeGreaterThan(creationEnd);
+    expect(residencyStart).toBeGreaterThan(initialShow);
+  });
+
   it("keeps the production failure adapter closed and gates the loser before bootstrap", async () => {
     const source = await readFile(resolve(import.meta.dirname, "../src/main/index.ts"), "utf8");
     expect(source).toContain("desktop-residency-failure ${operation}\\n");


### PR DESCRIPTION
## Summary
- keep the initial Desktop window hidden until its renderer URL has fully loaded
- remove the premature ready-to-show presentation path while preserving restore, show, and focus ordering
- preserve real renderer-load failures and existing menu-bar residency behavior

## Verification
- focused Desktop residency and security tests: 23/23 passed
- Desktop TypeScript check passed
- scoped lint, formatting, and diff checks passed
- three independent startup timing, residency, and packaged-security reviewers passed

A patch changeset records the athlete-visible cold-start reliability fix.