### PR TITLE
fix(desktop): keep credential status reads passive

### DIFF
--- a/.changeset/desktop-setup-status-read.md
+++ b/.changeset/desktop-setup-status-read.md
@@ -1,0 +1,5 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Desktop Setup now opens promptly while training-data work is running.

--- a/apps/desktop/src/main/credential-vault.ts
+++ b/apps/desktop/src/main/credential-vault.ts
@@ -18,6 +18,7 @@ export const DESKTOP_CREDENTIAL_SLOTS = [
 export type DesktopCredentialSlot = (typeof DESKTOP_CREDENTIAL_SLOTS)[number];
 export type CredentialState = "missing" | "configured" | "re-prompt";
 export type CredentialRuntimeState = "active" | "stored-inactive" | "failed";
+export type CredentialRuntimeStateMap = Map<DesktopCredentialSlot, CredentialRuntimeState>;
 
 export interface CredentialSlotStatus {
   readonly slot: DesktopCredentialSlot;
@@ -67,12 +68,47 @@ export interface CredentialVault {
 interface CredentialVaultOptions {
   readonly root: string;
   readonly encryption: CredentialEncryptionPort;
+  readonly runtimeState?: CredentialRuntimeStateMap;
+  readonly onRuntimeStateChange?: (slot: DesktopCredentialSlot) => void;
+  readonly createRuntimePublicationGuard?: (slot: DesktopCredentialSlot) => () => boolean;
   readonly applyCredential: (slot: DesktopCredentialSlot, value: string) => Promise<void>;
   readonly reapplyCredential?: (
     slot: DesktopCredentialSlot,
     value: string,
     storedCredentialSlots: readonly DesktopCredentialSlot[],
   ) => Promise<Exclude<CredentialRuntimeState, "failed">>;
+}
+
+export function replaceCredentialRuntimeStates(
+  target: CredentialRuntimeStateMap,
+  statuses: readonly CredentialSlotStatus[],
+  shouldReplace: (slot: DesktopCredentialSlot) => boolean = () => true,
+): void {
+  for (const status of statuses) {
+    if (!shouldReplace(status.slot)) {
+      target.set(status.slot, "failed");
+      continue;
+    }
+    if (status.state === "configured" && status.runtimeState !== null) {
+      target.set(status.slot, status.runtimeState);
+    } else {
+      target.delete(status.slot);
+    }
+  }
+}
+
+export function markUnselectedModelCredentialsInactive(
+  target: CredentialRuntimeStateMap,
+  selected: DesktopCredentialSlot | undefined,
+  onChange: (slot: DesktopCredentialSlot) => void = () => {},
+): void {
+  for (const slot of target.keys()) {
+    if (slot === "intervals-icu" || slot === selected || target.get(slot) === "stored-inactive") {
+      continue;
+    }
+    target.set(slot, "stored-inactive");
+    onChange(slot);
+  }
 }
 
 interface ReadCredential {
@@ -121,7 +157,15 @@ async function validTarget(path: string): Promise<boolean> {
 }
 
 export function createCredentialVault(options: CredentialVaultOptions): CredentialVault {
-  const runtimeState = new Map<DesktopCredentialSlot, CredentialRuntimeState>();
+  const runtimeState =
+    options.runtimeState ?? new Map<DesktopCredentialSlot, CredentialRuntimeState>();
+  const setRuntimeState = (slot: DesktopCredentialSlot, state: CredentialRuntimeState): void => {
+    if (state === "active" && slot !== "intervals-icu") {
+      markUnselectedModelCredentialsInactive(runtimeState, slot, options.onRuntimeStateChange);
+    }
+    runtimeState.set(slot, state);
+    options.onRuntimeStateChange?.(slot);
+  };
 
   const readSlot = async (slot: DesktopCredentialSlot): Promise<ReadCredential> => {
     const path = join(options.root, `${slot}.bin`);
@@ -174,13 +218,15 @@ export function createCredentialVault(options: CredentialVaultOptions): Credenti
     const storedCredentialSlots = entries.map((entry) => entry.slot);
     for (const entry of entries) {
       try {
+        const canPublish = options.createRuntimePublicationGuard?.(entry.slot);
         const replayed =
           options.reapplyCredential === undefined
             ? await options.applyCredential(entry.slot, entry.value).then(() => "active" as const)
             : await options.reapplyCredential(entry.slot, entry.value, storedCredentialSlots);
-        runtimeState.set(entry.slot, replayed);
+        if (canPublish !== undefined && !canPublish()) throw new TypeError();
+        setRuntimeState(entry.slot, replayed);
       } catch {
-        runtimeState.set(entry.slot, "failed");
+        setRuntimeState(entry.slot, "failed");
       }
     }
   };
@@ -196,13 +242,15 @@ export function createCredentialVault(options: CredentialVaultOptions): Credenti
     const entries = configured.filter((entry) => runtimeState.get(entry.slot) === "failed");
     for (const entry of entries) {
       try {
+        const canPublish = options.createRuntimePublicationGuard?.(entry.slot);
         const retried =
           options.reapplyCredential === undefined
             ? await options.applyCredential(entry.slot, entry.value).then(() => "active" as const)
             : await options.reapplyCredential(entry.slot, entry.value, storedCredentialSlots);
-        runtimeState.set(entry.slot, retried);
+        if (canPublish !== undefined && !canPublish()) throw new TypeError();
+        setRuntimeState(entry.slot, retried);
       } catch {
-        runtimeState.set(entry.slot, "failed");
+        setRuntimeState(entry.slot, "failed");
       }
     }
   };
@@ -249,6 +297,7 @@ export function createCredentialVault(options: CredentialVaultOptions): Credenti
         await handle.close();
         handle = undefined;
         await rename(temporary, target);
+        setRuntimeState(input.slot, "failed");
         const directory = await open(options.root, "r");
         try {
           await directory.sync();
@@ -266,11 +315,13 @@ export function createCredentialVault(options: CredentialVaultOptions): Credenti
         encrypted?.fill(0);
       }
       try {
+        const canPublish = options.createRuntimePublicationGuard?.(input.slot);
         await options.applyCredential(input.slot, value);
-        runtimeState.set(input.slot, "active");
+        if (canPublish !== undefined && !canPublish()) throw new TypeError();
+        setRuntimeState(input.slot, "active");
         return { slot: input.slot, status: "configured", runtimeReady: true };
       } catch {
-        runtimeState.set(input.slot, "failed");
+        setRuntimeState(input.slot, "failed");
         return { slot: input.slot, status: "refused", reason: "runtime-unavailable" };
       }
     },

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -25,7 +25,16 @@ import {
   type CredentialRuntimeApplication,
   type RuntimeConfigurationAuthority,
 } from "./credential-runtime.js";
-import { CREDENTIAL_DIRECTORY_NAME, createCredentialVault } from "./credential-vault.js";
+import {
+  CREDENTIAL_DIRECTORY_NAME,
+  createCredentialVault,
+  DESKTOP_CREDENTIAL_SLOTS,
+  markUnselectedModelCredentialsInactive,
+  replaceCredentialRuntimeStates,
+  type CredentialRuntimeState,
+  type CredentialSlotStatus,
+  type DesktopCredentialSlot,
+} from "./credential-vault.js";
 import {
   DesktopDaemonLifecycle,
   type DesktopDaemonConnection,
@@ -163,12 +172,64 @@ async function runDesktop(): Promise<void> {
       readonly credentials: CredentialRuntimeApplication;
     };
     let activeRuntimeBinding: RuntimeBinding | undefined;
-    const preparedRuntimeBindings = new Map<number, RuntimeBinding>();
+    const preparedRuntimeBindings = new Map<
+      number,
+      {
+        readonly binding: RuntimeBinding;
+        readonly statuses: readonly CredentialSlotStatus[];
+        readonly revisions: ReadonlyMap<DesktopCredentialSlot, number>;
+      }
+    >();
+    const credentialRuntimeState = new Map<DesktopCredentialSlot, CredentialRuntimeState>();
+    const credentialRuntimeRevisions = new Map<DesktopCredentialSlot, number>();
+    const markCredentialRuntimeChange = (slot: DesktopCredentialSlot): void => {
+      credentialRuntimeRevisions.set(slot, (credentialRuntimeRevisions.get(slot) ?? 0) + 1);
+    };
+    const failModelCredentialRuntimeStates = (): void => {
+      for (const slot of DESKTOP_CREDENTIAL_SLOTS) {
+        if (slot === "intervals-icu") continue;
+        credentialRuntimeState.set(slot, "failed");
+        markCredentialRuntimeChange(slot);
+      }
+    };
+    let recoveringCredentialRuntime:
+      | {
+          readonly states: ReadonlyMap<DesktopCredentialSlot, CredentialRuntimeState>;
+          readonly revisions: ReadonlyMap<DesktopCredentialSlot, number>;
+        }
+      | undefined;
     let reapplyCredentials = async (
       _connection: DesktopDaemonConnection,
       _signal: AbortSignal,
     ): Promise<void> => {};
     const publishLifecycle = (state: DesktopDaemonLifecycleState): void => {
+      if (state.status === "recovering" && recoveringCredentialRuntime === undefined) {
+        recoveringCredentialRuntime = {
+          states: new Map(credentialRuntimeState),
+          revisions: new Map(credentialRuntimeRevisions),
+        };
+        for (const slot of credentialRuntimeState.keys()) {
+          credentialRuntimeState.set(slot, "failed");
+        }
+      }
+      if (state.status === "ready" && recoveringCredentialRuntime !== undefined) {
+        for (const [slot, runtimeState] of recoveringCredentialRuntime.states) {
+          if (
+            (credentialRuntimeRevisions.get(slot) ?? 0) ===
+            (recoveringCredentialRuntime.revisions.get(slot) ?? 0)
+          ) {
+            credentialRuntimeState.set(slot, runtimeState);
+          }
+        }
+        recoveringCredentialRuntime = undefined;
+      }
+      if (state.status === "closing" || state.status === "terminal") {
+        for (const slot of credentialRuntimeState.keys()) {
+          credentialRuntimeState.set(slot, "failed");
+        }
+        recoveringCredentialRuntime = undefined;
+        preparedRuntimeBindings.clear();
+      }
       const visibleWindow = currentWindow();
       if (visibleWindow !== null && state.status !== "starting") {
         visibleWindow.webContents.send(DESKTOP_LIFECYCLE_CHANNEL, {
@@ -186,7 +247,13 @@ async function runDesktop(): Promise<void> {
       onReady({ previous, current }) {
         const prepared = preparedRuntimeBindings.get(current.generation);
         if (prepared !== undefined) {
-          activeRuntimeBinding = prepared;
+          activeRuntimeBinding = prepared.binding;
+          replaceCredentialRuntimeStates(
+            credentialRuntimeState,
+            prepared.statuses,
+            (slot) =>
+              (credentialRuntimeRevisions.get(slot) ?? 0) === (prepared.revisions.get(slot) ?? 0),
+          );
           preparedRuntimeBindings.delete(current.generation);
         }
         if (new URL(previous.url).port === new URL(current.url).port) return;
@@ -220,20 +287,50 @@ async function runDesktop(): Promise<void> {
     const vault = createCredentialVault({
       root: credentialRoot,
       encryption: safeStorage,
-      async applyCredential(slot, value) {
-        await activeRuntimeBinding!.credentials.applyExplicit(
-          runtimeConfigurationForCredential(slot, value),
-        );
+      runtimeState: credentialRuntimeState,
+      onRuntimeStateChange: markCredentialRuntimeChange,
+      createRuntimePublicationGuard(slot) {
+        const binding = activeRuntimeBinding;
+        const lifecycleState = daemonLifecycle?.snapshot();
+        return () => {
+          const currentLifecycleState = daemonLifecycle?.snapshot();
+          const canPublish =
+            binding !== undefined &&
+            activeRuntimeBinding === binding &&
+            lifecycleState?.status === "ready" &&
+            currentLifecycleState?.status === "ready" &&
+            lifecycleState.generation === currentLifecycleState.generation;
+          if (!canPublish && slot !== "intervals-icu") failModelCredentialRuntimeStates();
+          return canPublish;
+        };
       },
-      reapplyCredential: (slot, value, storedCredentialSlots) =>
-        activeRuntimeBinding!.credentials.reapplyStoredCredential(
+      async applyCredential(slot, value) {
+        const binding = activeRuntimeBinding!;
+        if (daemonLifecycle?.snapshot().status !== "ready") throw new TypeError();
+        await binding.credentials.applyExplicit(runtimeConfigurationForCredential(slot, value));
+        if (activeRuntimeBinding !== binding || daemonLifecycle?.snapshot().status !== "ready") {
+          if (slot !== "intervals-icu") failModelCredentialRuntimeStates();
+          throw new TypeError();
+        }
+      },
+      async reapplyCredential(slot, value, storedCredentialSlots) {
+        const binding = activeRuntimeBinding!;
+        if (daemonLifecycle?.snapshot().status !== "ready") throw new TypeError();
+        const status = await binding.credentials.reapplyStoredCredential(
           slot,
           value,
           storedCredentialSlots,
-        ),
+        );
+        if (activeRuntimeBinding !== binding || daemonLifecycle?.snapshot().status !== "ready") {
+          if (slot !== "intervals-icu") failModelCredentialRuntimeStates();
+          throw new TypeError();
+        }
+        return status;
+      },
     });
     reapplyCredentials = async (connection, signal) => {
       if (signal.aborted) return;
+      const revisions = new Map(credentialRuntimeRevisions);
       const successor = createRuntimeBinding(connection);
       const successorVault = createCredentialVault({
         root: credentialRoot,
@@ -244,11 +341,37 @@ async function runDesktop(): Promise<void> {
         reapplyCredential: successor.credentials.reapplyStoredCredential,
       });
       await successorVault.reapplyConfigured();
-      if (!signal.aborted) preparedRuntimeBindings.set(connection.generation, successor);
+      const successorStatuses = await successorVault.credentialStatuses();
+      const lifecycleState = daemonLifecycle?.snapshot();
+      if (
+        signal.aborted ||
+        lifecycleState?.status !== "recovering" ||
+        lifecycleState.generation + 1 !== connection.generation
+      ) {
+        return;
+      }
+      preparedRuntimeBindings.set(connection.generation, {
+        binding: successor,
+        statuses: successorStatuses,
+        revisions,
+      });
     };
     const chatGptAuth = createChatGptAuth({
       configDir,
-      applyRuntimeConfig: (request) => activeRuntimeBinding!.credentials.applyExplicit(request),
+      async applyRuntimeConfig(request) {
+        const binding = activeRuntimeBinding!;
+        if (daemonLifecycle?.snapshot().status !== "ready") throw new TypeError();
+        await binding.credentials.applyExplicit(request);
+        if (activeRuntimeBinding !== binding || daemonLifecycle?.snapshot().status !== "ready") {
+          failModelCredentialRuntimeStates();
+          throw new TypeError();
+        }
+        markUnselectedModelCredentialsInactive(
+          credentialRuntimeState,
+          undefined,
+          markCredentialRuntimeChange,
+        );
+      },
       getRuntimeConfig: () => activeRuntimeBinding!.authority.getRuntimeConfig(),
       openExternal: (url) => shell.openExternal(url),
       signal: controller.signal,

--- a/apps/desktop/src/main/onboarding-ipc.ts
+++ b/apps/desktop/src/main/onboarding-ipc.ts
@@ -101,7 +101,6 @@ export function registerOnboardingIpc(options: RegisterOnboardingIpcOptions): ()
     requireTrusted(event);
     if (args.length !== 0) throw new TypeError();
     try {
-      await options.vault.reapplyConfigured();
       return minimizeStatuses(await options.vault.credentialStatuses());
     } catch {
       return DESKTOP_CREDENTIAL_SLOTS.map((slot) => ({

--- a/apps/desktop/tests/credential-runtime.test.ts
+++ b/apps/desktop/tests/credential-runtime.test.ts
@@ -462,7 +462,7 @@ describe("desktop credential runtime precedence", () => {
     expect(daemon.modelApplications()).toEqual([]);
   });
 
-  it("reapplies an unrelated service credential without changing the ChatGPT selection", async () => {
+  it("reads an unrelated service credential without changing the ChatGPT selection", async () => {
     const daemon = fakeDaemon("anthropic");
     let runtime = daemon.launch();
     const vault = fakeVault(runtime);
@@ -473,7 +473,7 @@ describe("desktop credential runtime precedence", () => {
     await vault.port.writeCredential({ slot: "intervals-icu", value: randomUUID() });
     await pollCredentialStatuses(vault.port);
     expect(daemon.activeProvider()).toBe("openai-codex");
-    expect(daemon.intervalsApplications()).toBe(2);
+    expect(daemon.intervalsApplications()).toBe(1);
     expect(daemon.modelApplications()).toEqual([]);
 
     runtime = daemon.launch();
@@ -481,7 +481,7 @@ describe("desktop credential runtime precedence", () => {
     daemon.clearModelApplications();
     await vault.port.reapplyConfigured();
     expect(daemon.activeProvider()).toBe("openai-codex");
-    expect(daemon.intervalsApplications()).toBe(3);
+    expect(daemon.intervalsApplications()).toBe(2);
     expect(daemon.modelApplications()).toEqual([]);
   });
 
@@ -574,7 +574,7 @@ describe("desktop credential runtime precedence", () => {
     await pollCredentialStatuses(vault.port);
     expect(daemon.activeProvider()).toBe("openrouter");
     expect(daemon.persistedProvider()).toBe("openrouter");
-    expect(daemon.modelApplications()).toEqual(["openrouter"]);
+    expect(daemon.modelApplications()).toEqual([]);
 
     runtime = daemon.launch();
     vault.use(runtime);

--- a/apps/desktop/tests/credential-vault.test.ts
+++ b/apps/desktop/tests/credential-vault.test.ts
@@ -17,6 +17,8 @@ import {
   CREDENTIAL_DIRECTORY_MODE,
   CREDENTIAL_FILE_MODE,
   createCredentialVault,
+  markUnselectedModelCredentialsInactive,
+  replaceCredentialRuntimeStates,
   type CredentialEncryptionPort,
 } from "../src/main/credential-vault.js";
 
@@ -304,6 +306,44 @@ describe("desktop credential vault", () => {
     });
   });
 
+  it("fails closed when runtime publication becomes stale after apply, replay, or retry", async () => {
+    const root = await temporaryRoot();
+    let current = true;
+    const vault = createCredentialVault({
+      root,
+      encryption: encryption(),
+      createRuntimePublicationGuard: () => () => current,
+      async applyCredential() {
+        current = false;
+      },
+      async reapplyCredential() {
+        current = false;
+        return "active";
+      },
+    });
+
+    await expect(
+      vault.writeCredential({ slot: "anthropic", value: randomUUID() }),
+    ).resolves.toMatchObject({
+      status: "refused",
+      reason: "runtime-unavailable",
+    });
+    current = true;
+    await vault.reapplyConfigured();
+    await expect(vault.credentialStatuses()).resolves.toContainEqual({
+      slot: "anthropic",
+      state: "configured",
+      runtimeState: "failed",
+    });
+    current = true;
+    await vault.retryFailed();
+    await expect(vault.credentialStatuses()).resolves.toContainEqual({
+      slot: "anthropic",
+      state: "configured",
+      runtimeState: "failed",
+    });
+  });
+
   it("refuses a stale failed retry after another provider becomes selected", async () => {
     const root = await temporaryRoot();
     let selectedProvider: "anthropic" | "openrouter" = "anthropic";
@@ -354,5 +394,93 @@ describe("desktop credential vault", () => {
     });
     await vault.retryFailed();
     expect(applyCredential).toHaveBeenCalledOnce();
+  });
+
+  it("publishes successor replay failures into the long-lived retry state", async () => {
+    const root = await temporaryRoot();
+    const runtimeState = new Map();
+    let applyCredentialCount = 0;
+    const applyCredential = async (): Promise<void> => {
+      applyCredentialCount += 1;
+    };
+    const vault = createCredentialVault({
+      root,
+      encryption: encryption(),
+      runtimeState,
+      applyCredential,
+    });
+    await vault.writeCredential({ slot: "anthropic", value: randomUUID() });
+
+    const successor = createCredentialVault({
+      root,
+      encryption: encryption(),
+      applyCredential: async () => {
+        throw new TypeError();
+      },
+    });
+    await successor.reapplyConfigured();
+    replaceCredentialRuntimeStates(runtimeState, await successor.credentialStatuses());
+
+    await expect(vault.credentialStatuses()).resolves.toContainEqual({
+      slot: "anthropic",
+      state: "configured",
+      runtimeState: "failed",
+    });
+    await vault.retryFailed();
+    expect(applyCredentialCount).toBe(2);
+    await expect(vault.credentialStatuses()).resolves.toContainEqual({
+      slot: "anthropic",
+      state: "configured",
+      runtimeState: "active",
+    });
+  });
+
+  it("marks a concurrently changed slot failed instead of publishing stale successor state", () => {
+    const runtimeState = new Map([["anthropic" as const, "active" as const]]);
+
+    replaceCredentialRuntimeStates(
+      runtimeState,
+      [{ slot: "anthropic", state: "configured", runtimeState: "active" }],
+      () => false,
+    );
+
+    expect(runtimeState.get("anthropic")).toBe("failed");
+  });
+
+  it("keeps only the selected model credential active", async () => {
+    const root = await temporaryRoot();
+    const vault = createCredentialVault({
+      root,
+      encryption: encryption(),
+      applyCredential: async () => {},
+    });
+
+    await vault.writeCredential({ slot: "anthropic", value: randomUUID() });
+    await vault.writeCredential({ slot: "openrouter", value: randomUUID() });
+
+    await expect(vault.credentialStatuses()).resolves.toEqual(
+      expect.arrayContaining([
+        { slot: "anthropic", state: "configured", runtimeState: "stored-inactive" },
+        { slot: "openrouter", state: "configured", runtimeState: "active" },
+      ]),
+    );
+  });
+
+  it("marks model credentials inactive when a profile becomes selected", () => {
+    const runtimeState = new Map([
+      ["anthropic" as const, "active" as const],
+      ["openrouter" as const, "failed" as const],
+      ["intervals-icu" as const, "active" as const],
+    ]);
+
+    markUnselectedModelCredentialsInactive(runtimeState, undefined);
+
+    expect(runtimeState).toEqual(
+      new Map([
+        ["anthropic", "stored-inactive"],
+        ["openrouter", "stored-inactive"],
+        ["intervals-icu", "active"],
+      ]),
+    );
   });
 });

--- a/apps/desktop/tests/onboarding-ipc.test.ts
+++ b/apps/desktop/tests/onboarding-ipc.test.ts
@@ -161,10 +161,41 @@ describe("desktop onboarding IPC", () => {
     await expect(
       subject.invoke(DESKTOP_CREDENTIAL_STATUS_CHANNEL, subject.trustedEvent),
     ).resolves.toEqual([{ slot: "anthropic", state: "configured", runtimeState: "active" }]);
-    expect(subject.vault.reapplyConfigured).toHaveBeenCalledTimes(1);
+    expect(subject.vault.reapplyConfigured).not.toHaveBeenCalled();
     expect(
       JSON.stringify(await subject.invoke(DESKTOP_CREDENTIAL_STATUS_CHANNEL, subject.trustedEvent)),
     ).not.toContain("value");
+  });
+
+  it("reads credential metadata without waiting for credential replay", async () => {
+    const subject = harness();
+    vi.mocked(subject.vault.reapplyConfigured).mockImplementation(
+      () => new Promise<void>(() => {}),
+    );
+
+    await expect(
+      subject.invoke(DESKTOP_CREDENTIAL_STATUS_CHANNEL, subject.trustedEvent),
+    ).resolves.toEqual([{ slot: "anthropic", state: "configured", runtimeState: "active" }]);
+    expect(subject.vault.credentialStatuses).toHaveBeenCalledOnce();
+    expect(subject.vault.reapplyConfigured).not.toHaveBeenCalled();
+  });
+
+  it("fails closed to re-entry metadata when stored status cannot be read", async () => {
+    const subject = harness();
+    vi.mocked(subject.vault.credentialStatuses).mockRejectedValueOnce(
+      new Error("private storage detail"),
+    );
+
+    const statuses = await subject.invoke(DESKTOP_CREDENTIAL_STATUS_CHANNEL, subject.trustedEvent);
+
+    expect(statuses).toHaveLength(10);
+    expect(statuses).toContainEqual({
+      slot: "anthropic",
+      state: "re-prompt",
+      runtimeState: null,
+    });
+    expect(JSON.stringify(statuses)).not.toContain("private storage detail");
+    expect(subject.vault.reapplyConfigured).not.toHaveBeenCalled();
   });
 
   it("retries only failed credentials through the explicit vault path", async () => {


### PR DESCRIPTION
## Summary
- make Setup credential-status reads local and side-effect free
- publish replayed runtime state only for the accepted daemon generation
- fail model-selection state closed across recovery, concurrent writes, and terminal transitions

## Verification
- 88 focused Desktop credential, lifecycle, supervisor, and auth tests passed
- Desktop TypeScript check passed
- scoped lint, formatting, diff, and changeset checks passed
- three independent security, concurrency, and runtime-state reviewers passed

A patch changeset records the athlete-visible Setup responsiveness fix.