### PR TITLE
fix(desktop): explain credential activation failures

### DIFF
--- a/.changeset/desktop-credential-refusal-recovery.md
+++ b/.changeset/desktop-credential-refusal-recovery.md
@@ -1,0 +1,5 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Onboarding now explains why a model key could not be activated and what to do next.

--- a/apps/desktop-renderer/src/onboarding/machine.ts
+++ b/apps/desktop-renderer/src/onboarding/machine.ts
@@ -34,6 +34,13 @@ export interface DesktopIntakeDraft {
 export type OnboardingErrorCode =
   | "credential-required"
   | "credential-save-failed"
+  | "invalid-input"
+  | "encryption-unavailable"
+  | "unsafe-backend"
+  | "storage-failed"
+  | "runtime-unavailable"
+  | "credential-status-unavailable"
+  | "credential-reenter-required"
   | "training-account-mismatch"
   | "training-data-required"
   | "intake-incomplete"

--- a/apps/desktop-renderer/src/onboarding/mount.ts
+++ b/apps/desktop-renderer/src/onboarding/mount.ts
@@ -6,7 +6,7 @@ import {
   type DesktopCredentialSlot,
   type ModelCredentialSlot,
 } from "./constants.js";
-import type { OnboardingBridge } from "./bridge.js";
+import type { CredentialWriteResult, OnboardingBridge } from "./bridge.js";
 import { credentialPresentation } from "./credential-presentation.js";
 import {
   ONBOARDING_COMPLETION,
@@ -70,6 +70,7 @@ export async function handoffCredential(
   let secret: string | undefined;
   try {
     secret = input.value;
+    input.value = "";
     if (secret.trim().length === 0) return false;
     await write({ slot: input.dataset.slot as DesktopCredentialSlot, value: secret });
     return true;
@@ -82,12 +83,44 @@ export async function handoffCredential(
 const ERROR_COPY: Readonly<Record<OnboardingErrorCode, string>> = {
   "credential-required": "Sign in with ChatGPT or add at least one model key to continue.",
   "credential-save-failed": "That key could not be saved. Try entering it again.",
+  "invalid-input": "That key was not accepted. Check it and enter it again.",
+  "encryption-unavailable":
+    "macOS encryption is unavailable. Make sure Keychain is available, then try again.",
+  "unsafe-backend": "The app cannot safely store that key with the current storage backend.",
+  "storage-failed":
+    "The app could not confirm that key was saved securely. Check that secure storage is available and try again.",
+  "runtime-unavailable":
+    "That key was saved, but it is not active yet. Choose Retry saved keys to activate it.",
+  "credential-status-unavailable":
+    "That key was saved, but its status could not be refreshed. Close and reopen Setup to check again.",
+  "credential-reenter-required": "That saved key could not be used. Enter it again to continue.",
   "training-account-mismatch":
     "That intervals.icu key belongs to a different athlete than the training history already stored. Switching accounts is not supported yet.",
   "training-data-required": "Connect intervals.icu or import at least one ride file.",
   "intake-incomplete": "Answer the required safety questions to continue.",
   "intake-save-failed": "Your answers could not be saved. Please try again.",
 };
+
+type CredentialWriteRefusalReason = Extract<
+  CredentialWriteResult,
+  { readonly status: "refused" }
+>["reason"];
+
+const CREDENTIAL_WRITE_REFUSAL_ERRORS = {
+  "invalid-input": "invalid-input",
+  "encryption-unavailable": "encryption-unavailable",
+  "unsafe-backend": "unsafe-backend",
+  "storage-failed": "storage-failed",
+  "runtime-unavailable": "runtime-unavailable",
+  "training-account-mismatch": "training-account-mismatch",
+} as const satisfies Readonly<Record<CredentialWriteRefusalReason, OnboardingErrorCode>>;
+
+function credentialWriteRefusalError(reason: unknown): OnboardingErrorCode {
+  if (typeof reason === "string" && Object.hasOwn(CREDENTIAL_WRITE_REFUSAL_ERRORS, reason)) {
+    return CREDENTIAL_WRITE_REFUSAL_ERRORS[reason as CredentialWriteRefusalReason];
+  }
+  return "credential-save-failed";
+}
 
 const CHATGPT_REFUSAL_COPY = {
   "already-in-progress": "A ChatGPT sign-in is already in progress.",
@@ -129,6 +162,7 @@ function passwordControl(
   slot: ModelCredentialSlot | "intervals-icu",
   labelText: string,
   status: CredentialSlotStatus,
+  disabled = false,
 ): HTMLElement {
   const presentation = credentialPresentation(status);
   const field = make(document, "div", "credential-field");
@@ -147,6 +181,7 @@ function passwordControl(
   input.id = id;
   input.type = "password";
   input.autocomplete = "off";
+  input.disabled = disabled;
   input.dataset.slot = slot;
   input.setAttribute("aria-describedby", "onboarding-error");
   field.append(label, input);
@@ -197,14 +232,27 @@ export function mountOnboarding(options: MountOnboardingOptions): OnboardingCont
     options.opener.focus();
   };
 
-  const refreshStatuses = async (expectedVisit: number): Promise<void> => {
-    const [statuses, chatGpt] = await Promise.all([
+  const refreshStatuses = async (expectedVisit: number): Promise<boolean> => {
+    const [statuses, chatGpt] = await Promise.allSettled([
       options.bridge.credentialStatuses(),
       options.bridge.chatGptStatus(),
     ]);
-    if (visit !== expectedVisit || scrim === undefined) return;
-    credentialStatuses = statuses;
-    state = withChatGptStatus(withCredentialStatuses(state, statuses), chatGpt);
+    if (visit !== expectedVisit || scrim === undefined) return false;
+    if (statuses.status === "fulfilled") {
+      credentialStatuses = statuses.value;
+      state = withCredentialStatuses(state, statuses.value);
+    }
+    if (chatGpt.status === "fulfilled") {
+      state = withChatGptStatus(state, chatGpt.value);
+    } else if (
+      statuses.status === "fulfilled" &&
+      statuses.value.some(
+        (status) => status.slot !== "intervals-icu" && status.runtimeState === "active",
+      )
+    ) {
+      state = { ...state, chatGptRuntimeReady: false };
+    }
+    return statuses.status === "fulfilled";
   };
 
   const savePasswordControls = async (
@@ -213,9 +261,20 @@ export function mountOnboarding(options: MountOnboardingOptions): OnboardingCont
   ): Promise<OnboardingErrorCode | null> => {
     const controls = Array.from(
       root.querySelectorAll<HTMLInputElement>('input[type="password"][data-slot]'),
+      (input): TransientPasswordInput => {
+        input.disabled = true;
+        const control = { value: input.value, dataset: { slot: input.dataset.slot } };
+        input.value = "";
+        return control;
+      },
     );
     let attempted = false;
-    let failure: OnboardingErrorCode | null = null;
+    const outcome: {
+      failure: OnboardingErrorCode | null;
+      nonRuntimeFailure: OnboardingErrorCode | null;
+    } = { failure: null, nonRuntimeFailure: null };
+    const runtimeUnavailableSlots = new Set<DesktopCredentialSlot>();
+    let statusRefreshFailed = false;
     for (const input of controls) {
       if (visit !== expectedVisit || scrim === undefined) return null;
       try {
@@ -224,30 +283,61 @@ export function mountOnboarding(options: MountOnboardingOptions): OnboardingCont
         let configured = false;
         await handoffCredential(input, async (value) => {
           const result = await options.bridge.writeCredential(value);
+          if (disposed || visit !== expectedVisit || scrim === undefined) return;
           if (result.status === "configured") {
             configured = true;
           } else {
-            failure =
-              result.reason === "training-account-mismatch"
-                ? "training-account-mismatch"
-                : (failure ?? "credential-save-failed");
+            if (result.reason === "runtime-unavailable") {
+              runtimeUnavailableSlots.add(result.slot);
+            }
+            const writeFailure = credentialWriteRefusalError(result.reason);
+            outcome.failure ??= writeFailure;
+            if (writeFailure !== "runtime-unavailable") {
+              outcome.nonRuntimeFailure ??= writeFailure;
+            }
           }
         });
-        if (!configured) failure ??= "credential-save-failed";
+        if (disposed || visit !== expectedVisit || scrim === undefined) return null;
+        if (!configured && outcome.failure === null) {
+          outcome.failure = "credential-save-failed";
+          outcome.nonRuntimeFailure ??= "credential-save-failed";
+        }
       } catch {
-        failure ??= "credential-save-failed";
+        outcome.failure ??= "credential-save-failed";
+        outcome.nonRuntimeFailure ??= "credential-save-failed";
       } finally {
         input.value = "";
       }
+      if (disposed || visit !== expectedVisit || scrim === undefined) return null;
     }
     if (attempted) {
-      try {
-        await refreshStatuses(expectedVisit);
-      } catch {
-        failure ??= "credential-save-failed";
+      if (!(await refreshStatuses(expectedVisit))) {
+        statusRefreshFailed = true;
       }
+      if (disposed || visit !== expectedVisit || scrim === undefined) return null;
     }
-    return failure;
+    if (statusRefreshFailed) {
+      return outcome.nonRuntimeFailure ?? "credential-status-unavailable";
+    }
+    if (runtimeUnavailableSlots.size === 0) {
+      return outcome.failure;
+    }
+    if (outcome.nonRuntimeFailure !== null) return outcome.nonRuntimeFailure;
+    const refreshedRuntimeStatuses = Array.from(runtimeUnavailableSlots, (slot) =>
+      credentialStatuses.find((entry) => entry.slot === slot),
+    );
+    if (
+      refreshedRuntimeStatuses.some(
+        (status) =>
+          status === undefined || status.state === "missing" || status.state === "re-prompt",
+      )
+    ) {
+      return "credential-reenter-required";
+    }
+    if (refreshedRuntimeStatuses.some((status) => status?.runtimeState === "failed")) {
+      return "runtime-unavailable";
+    }
+    return null;
   };
 
   const importStatusCopy = (): string => {
@@ -359,6 +449,58 @@ export function mountOnboarding(options: MountOnboardingOptions): OnboardingCont
     return button;
   };
 
+  const currentStepOwnsCredentialSlot = (slot: DesktopCredentialSlot): boolean => {
+    if (state.step === "coach-keys") return slot !== "intervals-icu";
+    return state.step === "training-data" && slot === "intervals-icu";
+  };
+
+  const currentStepHasRetryableCredential = (): boolean =>
+    credentialStatuses.some(
+      (entry) =>
+        currentStepOwnsCredentialSlot(entry.slot) && credentialPresentation(entry).retryable,
+    );
+
+  const renderCredentialRetry = (body: HTMLElement): void => {
+    if (!currentStepHasRetryableCredential()) return;
+
+    const retry = make(options.document, "button", "text-button", "Retry saved keys");
+    retry.type = "button";
+    retry.disabled = state.busy;
+    retry.addEventListener("click", () => {
+      if (disposed || scrim === undefined || state.busy) return;
+      const retryVisit = visit;
+      const retryStep = state.step;
+      state = withBusy(state, true);
+      render();
+      focusCurrentTitle();
+      void (async () => {
+        try {
+          const statuses = await options.bridge.retryFailedCredentials();
+          if (visit !== retryVisit || scrim === undefined) return;
+          let nextState = withCredentialStatuses(state, statuses);
+          if (retryStep === "coach-keys") {
+            try {
+              nextState = withChatGptStatus(nextState, await options.bridge.chatGptStatus());
+            } catch {
+              nextState = { ...nextState, chatGptRuntimeReady: false };
+            }
+          }
+          if (visit !== retryVisit || scrim === undefined) return;
+          credentialStatuses = statuses;
+          state = withBusy(nextState, false);
+          render();
+          focusCurrentTitle();
+        } catch {
+          if (visit !== retryVisit || scrim === undefined) return;
+          state = withError(state, "runtime-unavailable");
+          render();
+          focusCurrentTitle();
+        }
+      })();
+    });
+    body.append(retry);
+  };
+
   const renderCoachKeys = (body: HTMLElement): void => {
     body.append(
       make(options.document, "p", "onboarding-kicker", "Coach keys"),
@@ -437,6 +579,7 @@ export function mountOnboarding(options: MountOnboardingOptions): OnboardingCont
         provider.id,
         provider.label,
         status(provider.id),
+        state.busy,
       );
       control
         .querySelector("label")
@@ -449,39 +592,18 @@ export function mountOnboarding(options: MountOnboardingOptions): OnboardingCont
     const advancedList = make(options.document, "div", "credential-list");
     for (const provider of ADVANCED_MODEL_CREDENTIAL_SLOTS) {
       advancedList.append(
-        passwordControl(options.document, provider.id, provider.label, status(provider.id)),
+        passwordControl(
+          options.document,
+          provider.id,
+          provider.label,
+          status(provider.id),
+          state.busy,
+        ),
       );
     }
     advanced.append(advancedList);
     body.append(advanced);
-    if (credentialStatuses.some((entry) => credentialPresentation(entry).retryable)) {
-      const retry = make(options.document, "button", "text-button", "Retry saved keys");
-      retry.type = "button";
-      retry.disabled = state.busy;
-      retry.addEventListener("click", () => {
-        const retryVisit = visit;
-        state = withBusy(state, true);
-        render();
-        focusCurrentTitle();
-        void options.bridge
-          .retryFailedCredentials()
-          .then(async () => {
-            if (visit !== retryVisit || scrim === undefined) return;
-            await refreshStatuses(retryVisit);
-            if (visit !== retryVisit || scrim === undefined) return;
-            state = withBusy(state, false);
-            render();
-            focusCurrentTitle();
-          })
-          .catch(() => {
-            if (visit !== retryVisit || scrim === undefined) return;
-            state = withError(state, "credential-save-failed");
-            render();
-            focusCurrentTitle();
-          });
-      });
-      body.append(retry);
-    }
+    renderCredentialRetry(body);
   };
 
   const renderTrainingData = (body: HTMLElement): void => {
@@ -503,8 +625,10 @@ export function mountOnboarding(options: MountOnboardingOptions): OnboardingCont
         "intervals-icu",
         "intervals.icu API key",
         status("intervals-icu"),
+        state.busy,
       ),
     );
+    renderCredentialRetry(body);
     const divider = make(options.document, "div", "source-divider", "or import ride files");
     body.append(divider);
     const chooser = make(options.document, "button", "drop-zone");
@@ -628,11 +752,17 @@ export function mountOnboarding(options: MountOnboardingOptions): OnboardingCont
     state = withBusy(state, true);
     for (const button of dialog.querySelectorAll<HTMLButtonElement>("button"))
       button.disabled = true;
+    const actionStatus = dialog.querySelector<HTMLElement>(".onboarding-action-status");
+    if (actionStatus !== null) {
+      actionStatus.textContent = "Working…";
+      actionStatus.hidden = false;
+    }
     if (state.step === "coach-keys") {
       const saveError = await savePasswordControls(dialog, submitVisit);
       if (visit !== submitVisit || scrim === undefined) return;
       state = withBusy(state, false);
       if (saveError !== null) state = withError(state, saveError);
+      else if (currentStepHasRetryableCredential()) state = withError(state, "runtime-unavailable");
       else if (!hasConfiguredModel(state)) state = withError(state, "credential-required");
       else state = nextStep(state);
       render();
@@ -644,6 +774,7 @@ export function mountOnboarding(options: MountOnboardingOptions): OnboardingCont
       if (visit !== submitVisit || scrim === undefined) return;
       state = withBusy(state, false);
       if (saveError !== null) state = withError(state, saveError);
+      else if (currentStepHasRetryableCredential()) state = withError(state, "runtime-unavailable");
       else if (!hasTrainingData(state)) state = withError(state, "training-data-required");
       else state = nextStep(state);
       render();
@@ -684,6 +815,7 @@ export function mountOnboarding(options: MountOnboardingOptions): OnboardingCont
 
   const render = (): void => {
     if (scrim === undefined) return;
+    clearPasswordInputs();
     scrim.replaceChildren();
     const dialog = make(options.document, "section", "onboarding");
     dialog.setAttribute("role", "dialog");
@@ -725,6 +857,16 @@ export function mountOnboarding(options: MountOnboardingOptions): OnboardingCont
     error.setAttribute("aria-live", "polite");
     if (state.fixedError !== null) error.textContent = ERROR_COPY[state.fixedError];
     body.append(error);
+    const actionStatus = make(
+      options.document,
+      "p",
+      "onboarding-action-status",
+      state.busy ? "Working…" : "",
+    );
+    actionStatus.setAttribute("role", "status");
+    actionStatus.setAttribute("aria-live", "polite");
+    actionStatus.hidden = !state.busy;
+    body.append(actionStatus);
     const footer = make(options.document, "footer", "onboarding-footer");
     const importBusy = state.step === "training-data" && rideImports.isBusy();
     if (activeIndex > 0) {

--- a/apps/desktop-renderer/tests/onboarding-mount.test.ts
+++ b/apps/desktop-renderer/tests/onboarding-mount.test.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { describe, expect, it, vi } from "vitest";
 import type { CredentialWriteResult, OnboardingBridge } from "../src/onboarding/bridge.js";
 import { mountOnboarding } from "../src/onboarding/mount.js";
@@ -192,7 +193,795 @@ function buttonWithText(document: FakeDocument, text: string): FakeElement {
   return button;
 }
 
+function passwordInputFor(document: FakeDocument, slot: string): FakeElement {
+  const input = document.body
+    .querySelectorAll('input[type="password"][data-slot]')
+    .find((candidate) => candidate.dataset.slot === slot);
+  if (input === undefined) throw new Error(`Password input not found: ${slot}`);
+  return input;
+}
+
+function deferred<T>(): {
+  readonly promise: Promise<T>;
+  readonly resolve: (value: T) => void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve };
+}
+
+type CredentialWriteRefusalReason = Extract<
+  CredentialWriteResult,
+  { readonly status: "refused" }
+>["reason"];
+
+const CREDENTIAL_REFUSAL_CASES = [
+  {
+    reason: "invalid-input",
+    copy: "That key was not accepted. Check it and enter it again.",
+  },
+  {
+    reason: "encryption-unavailable",
+    copy: "macOS encryption is unavailable. Make sure Keychain is available, then try again.",
+  },
+  {
+    reason: "unsafe-backend",
+    copy: "The app cannot safely store that key with the current storage backend.",
+  },
+  {
+    reason: "storage-failed",
+    copy: "The app could not confirm that key was saved securely. Check that secure storage is available and try again.",
+  },
+  {
+    reason: "runtime-unavailable",
+    copy: "That key was saved, but it is not active yet. Choose Retry saved keys to activate it.",
+  },
+] as const satisfies ReadonlyArray<{
+  readonly reason: CredentialWriteRefusalReason;
+  readonly copy: string;
+}>;
+
 describe("mounted onboarding", () => {
+  it.each(CREDENTIAL_REFUSAL_CASES)(
+    "keeps the athlete on coach keys and explains $reason refusals",
+    async ({ reason, copy }) => {
+      const document = new FakeDocument();
+      const baseBridge = bridge(async () => ({
+        status: "configured",
+        runtimeReady: true,
+      }));
+      if (reason === "runtime-unavailable") {
+        baseBridge.credentialStatuses
+          .mockResolvedValueOnce([])
+          .mockResolvedValueOnce([
+            { slot: "anthropic", state: "configured", runtimeState: "failed" },
+          ]);
+      }
+      let credentialWriteCount = 0;
+      const onboardingBridge: OnboardingBridge = {
+        ...baseBridge,
+        async writeCredential({ slot }) {
+          credentialWriteCount += 1;
+          return { slot, status: "refused", reason };
+        },
+      };
+      const onComplete = vi.fn();
+      const controller = mountOnboarding({
+        document: documentBoundary(document),
+        bridge: onboardingBridge,
+        opener: elementBoundary(document.createElement("button")),
+        onComplete,
+      });
+      await controller.open();
+      const passwordInput = passwordInputFor(document, "anthropic");
+      passwordInput.value = randomUUID();
+
+      buttonWithText(document, "Continue").dispatch("click");
+
+      await vi.waitFor(() => expect(controller.state().fixedError).toBe(reason));
+      expect(document.body.querySelector("#onboarding-error")?.textContent).toBe(copy);
+      expect(controller.state().step).toBe("coach-keys");
+      expect(passwordInput.value).toBe("");
+      expect(credentialWriteCount).toBe(1);
+      expect(baseBridge.credentialStatuses).toHaveBeenCalledTimes(2);
+      expect(onComplete).not.toHaveBeenCalled();
+      controller.dispose();
+    },
+  );
+
+  it("explains a training-account mismatch on the reachable intervals.icu path", async () => {
+    const document = new FakeDocument();
+    const baseBridge = bridge(async () => ({
+      status: "configured",
+      runtimeReady: true,
+    }));
+    baseBridge.credentialStatuses.mockResolvedValue([
+      { slot: "anthropic", state: "configured", runtimeState: "active" },
+    ]);
+    const onboardingBridge: OnboardingBridge = {
+      ...baseBridge,
+      async writeCredential({ slot }) {
+        return {
+          slot,
+          status: "refused",
+          reason: "training-account-mismatch",
+        };
+      },
+    };
+    const controller = mountOnboarding({
+      document: documentBoundary(document),
+      bridge: onboardingBridge,
+      opener: elementBoundary(document.createElement("button")),
+      onComplete: vi.fn(),
+    });
+    await controller.open();
+    buttonWithText(document, "Continue").dispatch("click");
+    await vi.waitFor(() => expect(controller.state().step).toBe("training-data"));
+    passwordInputFor(document, "intervals-icu").value = randomUUID();
+
+    buttonWithText(document, "Continue").dispatch("click");
+
+    await vi.waitFor(() => expect(controller.state().fixedError).toBe("training-account-mismatch"));
+    expect(document.body.querySelector("#onboarding-error")?.textContent).toBe(
+      "That intervals.icu key belongs to a different athlete than the training history already stored. Switching accounts is not supported yet.",
+    );
+    expect(controller.state().step).toBe("training-data");
+    expect(passwordInputFor(document, "intervals-icu").value).toBe("");
+    controller.dispose();
+  });
+
+  it("offers one retry for a saved key that could not be activated", async () => {
+    const document = new FakeDocument();
+    const failedStatuses = [
+      { slot: "anthropic", state: "configured", runtimeState: "failed" },
+    ] as const;
+    const activeStatuses = [
+      { slot: "anthropic", state: "configured", runtimeState: "active" },
+    ] as const;
+    const baseBridge = bridge(async () => ({
+      status: "configured",
+      runtimeReady: true,
+    }));
+    baseBridge.chatGptStatus.mockResolvedValue({ state: "absent", runtimeReady: false });
+    baseBridge.credentialStatuses.mockResolvedValueOnce([]).mockResolvedValueOnce(failedStatuses);
+    const retry = deferred<readonly (typeof activeStatuses)[number][]>();
+    const retryFailedCredentials = vi.fn<OnboardingBridge["retryFailedCredentials"]>(
+      () => retry.promise,
+    );
+    let credentialWriteCount = 0;
+    const onboardingBridge: OnboardingBridge = {
+      ...baseBridge,
+      retryFailedCredentials,
+      async writeCredential({ slot }) {
+        credentialWriteCount += 1;
+        return { slot, status: "refused", reason: "runtime-unavailable" };
+      },
+    };
+    const onComplete = vi.fn();
+    const controller = mountOnboarding({
+      document: documentBoundary(document),
+      bridge: onboardingBridge,
+      opener: elementBoundary(document.createElement("button")),
+      onComplete,
+    });
+    await controller.open();
+    const passwordInput = passwordInputFor(document, "anthropic");
+    passwordInput.value = randomUUID();
+
+    buttonWithText(document, "Continue").dispatch("click");
+
+    await vi.waitFor(() => expect(controller.state().fixedError).toBe("runtime-unavailable"));
+    expect(document.body.textContent).toContain("That key was saved, but it is not active yet.");
+    expect(document.body.textContent).toContain("Choose Retry saved keys to activate it.");
+    expect(buttonWithText(document, "Retry saved keys").disabled).toBe(false);
+    expect(passwordInput.value).toBe("");
+    expect(baseBridge.credentialStatuses).toHaveBeenCalledTimes(2);
+
+    buttonWithText(document, "Continue").dispatch("click");
+
+    await vi.waitFor(() => expect(controller.state().busy).toBe(false));
+    expect(controller.state()).toMatchObject({
+      step: "coach-keys",
+      fixedError: "runtime-unavailable",
+    });
+    expect(credentialWriteCount).toBe(1);
+
+    const detachedPassword = passwordInputFor(document, "anthropic");
+    detachedPassword.value = randomUUID();
+    const retryButton = buttonWithText(document, "Retry saved keys");
+    retryButton.dispatch("click");
+    retryButton.dispatch("click");
+    buttonWithText(document, "Retry saved keys").dispatch("click");
+
+    expect(retryFailedCredentials).toHaveBeenCalledTimes(1);
+    expect(detachedPassword.value).toBe("");
+    expect(controller.state()).toMatchObject({ busy: true, fixedError: null });
+    expect(document.body.querySelector("#onboarding-error")?.textContent).toBe("");
+    expect(passwordInputFor(document, "anthropic").disabled).toBe(true);
+    expect(document.body.querySelector(".onboarding-action-status")?.textContent).toBe("Working…");
+    retry.resolve(activeStatuses);
+
+    await vi.waitFor(() => {
+      expect(baseBridge.credentialStatuses).toHaveBeenCalledTimes(2);
+      expect(controller.state()).toMatchObject({
+        step: "coach-keys",
+        busy: false,
+        fixedError: null,
+        credentialStatus: { anthropic: "configured" },
+      });
+      expect(
+        passwordInputFor(document, "anthropic").parent?.querySelector(".credential-state")
+          ?.textContent,
+      ).toBe("Configured");
+    });
+    expect(
+      document.body
+        .querySelectorAll("button")
+        .some((button) => button.textContent === "Retry saved keys"),
+    ).toBe(false);
+    expect(credentialWriteCount).toBe(1);
+    expect(retryFailedCredentials).toHaveBeenCalledTimes(1);
+    expect(onComplete).not.toHaveBeenCalled();
+    controller.dispose();
+  });
+
+  it("keeps activation copy and retry available when retrying fails", async () => {
+    const document = new FakeDocument();
+    const failedStatuses = [
+      { slot: "anthropic", state: "configured", runtimeState: "failed" },
+    ] as const;
+    const baseBridge = bridge(async () => ({
+      status: "configured",
+      runtimeReady: true,
+    }));
+    baseBridge.chatGptStatus.mockResolvedValue({ state: "absent", runtimeReady: false });
+    baseBridge.credentialStatuses.mockResolvedValueOnce([]).mockResolvedValueOnce(failedStatuses);
+    const onboardingBridge: OnboardingBridge = {
+      ...baseBridge,
+      async retryFailedCredentials() {
+        throw new Error("private daemon failure");
+      },
+      async writeCredential({ slot }) {
+        return { slot, status: "refused", reason: "runtime-unavailable" };
+      },
+    };
+    const controller = mountOnboarding({
+      document: documentBoundary(document),
+      bridge: onboardingBridge,
+      opener: elementBoundary(document.createElement("button")),
+      onComplete: vi.fn(),
+    });
+    await controller.open();
+    passwordInputFor(document, "anthropic").value = randomUUID();
+    buttonWithText(document, "Continue").dispatch("click");
+    await vi.waitFor(() => expect(controller.state().fixedError).toBe("runtime-unavailable"));
+
+    buttonWithText(document, "Retry saved keys").dispatch("click");
+
+    await vi.waitFor(() => expect(controller.state().busy).toBe(false));
+    expect(controller.state().fixedError).toBe("runtime-unavailable");
+    expect(document.body.querySelector("#onboarding-error")?.textContent).toBe(
+      "That key was saved, but it is not active yet. Choose Retry saved keys to activate it.",
+    );
+    expect(buttonWithText(document, "Retry saved keys").disabled).toBe(false);
+    expect(document.body.textContent).not.toContain("private daemon failure");
+    controller.dispose();
+  });
+
+  it("offers intervals.icu recovery on training data without leaving or rewriting", async () => {
+    const document = new FakeDocument();
+    const failedStatuses = [
+      { slot: "intervals-icu", state: "configured", runtimeState: "failed" },
+    ] as const;
+    const baseBridge = bridge(async () => ({
+      status: "configured",
+      runtimeReady: true,
+    }));
+    baseBridge.credentialStatuses.mockResolvedValueOnce([]).mockResolvedValue(failedStatuses);
+    const retryFailedCredentials = vi.fn<OnboardingBridge["retryFailedCredentials"]>(
+      async () => failedStatuses,
+    );
+    let credentialWriteCount = 0;
+    const onboardingBridge: OnboardingBridge = {
+      ...baseBridge,
+      retryFailedCredentials,
+      async writeCredential({ slot }) {
+        credentialWriteCount += 1;
+        return { slot, status: "refused", reason: "runtime-unavailable" };
+      },
+    };
+    const controller = mountOnboarding({
+      document: documentBoundary(document),
+      bridge: onboardingBridge,
+      opener: elementBoundary(document.createElement("button")),
+      onComplete: vi.fn(),
+    });
+    await controller.open();
+    buttonWithText(document, "Continue").dispatch("click");
+    await vi.waitFor(() => expect(controller.state().step).toBe("training-data"));
+    const intervalsInput = passwordInputFor(document, "intervals-icu");
+    intervalsInput.value = randomUUID();
+
+    buttonWithText(document, "Continue").dispatch("click");
+
+    await vi.waitFor(() => expect(controller.state().fixedError).toBe("runtime-unavailable"));
+    expect(controller.state().step).toBe("training-data");
+    expect(document.body.querySelector("#onboarding-error")?.textContent).toBe(
+      "That key was saved, but it is not active yet. Choose Retry saved keys to activate it.",
+    );
+    expect(
+      document.body
+        .querySelectorAll("button")
+        .filter((button) => button.textContent === "Retry saved keys"),
+    ).toHaveLength(1);
+    expect(intervalsInput.value).toBe("");
+
+    buttonWithText(document, "Back").dispatch("click");
+    expect(controller.state().step).toBe("coach-keys");
+    expect(
+      document.body
+        .querySelectorAll("button")
+        .filter((button) => button.textContent === "Retry saved keys"),
+    ).toHaveLength(0);
+    buttonWithText(document, "Continue").dispatch("click");
+    await vi.waitFor(() => expect(controller.state().step).toBe("training-data"));
+    expect(
+      document.body
+        .querySelectorAll("button")
+        .filter((button) => button.textContent === "Retry saved keys"),
+    ).toHaveLength(1);
+
+    buttonWithText(document, "Retry saved keys").dispatch("click");
+
+    await vi.waitFor(() => expect(retryFailedCredentials).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(controller.state().busy).toBe(false));
+    expect(controller.state().step).toBe("training-data");
+    expect(
+      document.body
+        .querySelectorAll("button")
+        .filter((button) => button.textContent === "Retry saved keys"),
+    ).toHaveLength(1);
+    expect(credentialWriteCount).toBe(1);
+    expect(retryFailedCredentials).toHaveBeenCalledOnce();
+    controller.dispose();
+  });
+
+  it("does not leak a late runtime-unavailable write into a reopened visit", async () => {
+    const document = new FakeDocument();
+    const baseBridge = bridge(async () => ({
+      status: "configured",
+      runtimeReady: true,
+    }));
+    const pendingWrite = deferred<CredentialWriteResult>();
+    let credentialWriteCount = 0;
+    const onboardingBridge: OnboardingBridge = {
+      ...baseBridge,
+      writeCredential() {
+        credentialWriteCount += 1;
+        return pendingWrite.promise;
+      },
+    };
+    const controller = mountOnboarding({
+      document: documentBoundary(document),
+      bridge: onboardingBridge,
+      opener: elementBoundary(document.createElement("button")),
+      onComplete: vi.fn(),
+    });
+    await controller.open();
+    passwordInputFor(document, "anthropic").value = randomUUID();
+    buttonWithText(document, "Continue").dispatch("click");
+    await vi.waitFor(() => expect(credentialWriteCount).toBe(1));
+
+    controller.close();
+    pendingWrite.resolve({
+      slot: "anthropic",
+      status: "refused",
+      reason: "runtime-unavailable",
+    });
+    await pendingWrite.promise;
+    await controller.open();
+
+    expect(controller.state()).toMatchObject({
+      step: "coach-keys",
+      busy: false,
+      fixedError: null,
+    });
+    expect(
+      document.body
+        .querySelectorAll("button")
+        .some((button) => button.textContent === "Retry saved keys"),
+    ).toBe(false);
+    expect(credentialWriteCount).toBe(1);
+    controller.dispose();
+  });
+
+  it("snapshots and clears every password before the first write settles", async () => {
+    const document = new FakeDocument();
+    const firstValue = randomUUID();
+    const secondValue = randomUUID();
+    const firstWrite = deferred<void>();
+    let firstValueMatched = false;
+    let secondValueMatched = false;
+    const baseBridge = bridge(async () => ({ status: "refused", reason: "cancelled" }));
+    baseBridge.writeCredential = async ({ slot, value }) => {
+      if (slot === "anthropic") {
+        firstValueMatched = value === firstValue;
+        await firstWrite.promise;
+      }
+      if (slot === "openrouter") secondValueMatched = value === secondValue;
+      return { slot, status: "configured", runtimeReady: true };
+    };
+    baseBridge.credentialStatuses
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ slot: "openrouter", state: "configured", runtimeState: "active" }]);
+    const controller = mountOnboarding({
+      document: documentBoundary(document),
+      bridge: baseBridge,
+      opener: elementBoundary(document.createElement("button")),
+      onComplete: vi.fn(),
+    });
+    await controller.open();
+    const firstInput = passwordInputFor(document, "anthropic");
+    const secondInput = passwordInputFor(document, "openrouter");
+    firstInput.value = firstValue;
+    secondInput.value = secondValue;
+
+    buttonWithText(document, "Continue").dispatch("click");
+
+    await vi.waitFor(() => expect(firstValueMatched).toBe(true));
+    expect(firstInput.disabled).toBe(true);
+    expect(secondInput.disabled).toBe(true);
+    expect(firstInput.value).toBe("");
+    expect(secondInput.value).toBe("");
+    expect(document.body.querySelector(".onboarding-action-status")?.textContent).toBe("Working…");
+    secondInput.value = randomUUID();
+    firstWrite.resolve();
+
+    await vi.waitFor(() => expect(controller.state().step).toBe("training-data"));
+    expect(secondValueMatched).toBe(true);
+    expect(secondInput.value).toBe("");
+    controller.dispose();
+  });
+
+  it.each([
+    { runtimeState: "active", badge: "Configured" },
+    { runtimeState: "stored-inactive", badge: "Saved · Not in use" },
+  ] as const)("treats a $runtimeState post-write refresh as recovered", async (status) => {
+    const document = new FakeDocument();
+    const baseBridge = bridge(async () => ({
+      status: "configured",
+      runtimeReady: true,
+    }));
+    baseBridge.chatGptStatus.mockResolvedValue({ state: "absent", runtimeReady: false });
+    baseBridge.credentialStatuses
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        { slot: "anthropic", state: "configured", runtimeState: status.runtimeState },
+      ]);
+    let credentialWriteCount = 0;
+    const onboardingBridge: OnboardingBridge = {
+      ...baseBridge,
+      async writeCredential({ slot }) {
+        credentialWriteCount += 1;
+        return { slot, status: "refused", reason: "runtime-unavailable" };
+      },
+    };
+    const controller = mountOnboarding({
+      document: documentBoundary(document),
+      bridge: onboardingBridge,
+      opener: elementBoundary(document.createElement("button")),
+      onComplete: vi.fn(),
+    });
+    await controller.open();
+    passwordInputFor(document, "anthropic").value = randomUUID();
+
+    buttonWithText(document, "Continue").dispatch("click");
+
+    await vi.waitFor(() => expect(controller.state().step).toBe("training-data"));
+    expect(controller.state().fixedError).toBeNull();
+    expect(document.body.textContent).not.toContain(
+      "That key was saved, but it is not active yet.",
+    );
+    expect(
+      document.body
+        .querySelectorAll("button")
+        .some((button) => button.textContent === "Retry saved keys"),
+    ).toBe(false);
+    buttonWithText(document, "Back").dispatch("click");
+    expect(
+      passwordInputFor(document, "anthropic").parent?.querySelector(".credential-state")
+        ?.textContent,
+    ).toBe(status.badge);
+    expect(
+      document.body
+        .querySelectorAll("button")
+        .some((button) => button.textContent === "Retry saved keys"),
+    ).toBe(false);
+    expect(credentialWriteCount).toBe(1);
+    controller.dispose();
+  });
+
+  it("keeps a later failed key retryable when an earlier key recovers", async () => {
+    const document = new FakeDocument();
+    const baseBridge = bridge(async () => ({
+      status: "configured",
+      runtimeReady: true,
+    }));
+    baseBridge.chatGptStatus.mockResolvedValue({ state: "absent", runtimeReady: false });
+    baseBridge.credentialStatuses.mockResolvedValueOnce([]).mockResolvedValueOnce([
+      { slot: "anthropic", state: "configured", runtimeState: "active" },
+      { slot: "openrouter", state: "configured", runtimeState: "failed" },
+    ]);
+    let credentialWriteCount = 0;
+    const onboardingBridge: OnboardingBridge = {
+      ...baseBridge,
+      async writeCredential({ slot }) {
+        credentialWriteCount += 1;
+        return { slot, status: "refused", reason: "runtime-unavailable" };
+      },
+    };
+    const controller = mountOnboarding({
+      document: documentBoundary(document),
+      bridge: onboardingBridge,
+      opener: elementBoundary(document.createElement("button")),
+      onComplete: vi.fn(),
+    });
+    await controller.open();
+    passwordInputFor(document, "anthropic").value = randomUUID();
+    passwordInputFor(document, "openrouter").value = randomUUID();
+
+    buttonWithText(document, "Continue").dispatch("click");
+
+    await vi.waitFor(() => expect(controller.state().fixedError).toBe("runtime-unavailable"));
+    expect(controller.state().step).toBe("coach-keys");
+    expect(
+      document.body
+        .querySelectorAll("button")
+        .filter((button) => button.textContent === "Retry saved keys"),
+    ).toHaveLength(1);
+    expect(credentialWriteCount).toBe(2);
+    controller.dispose();
+  });
+
+  it.each([
+    { refreshedState: "re-prompt", description: "must be re-entered" },
+    { refreshedState: "missing", description: "is reported missing" },
+    { refreshedState: null, description: "is absent" },
+  ] as const)("asks for the key again when the refreshed key $description", async (status) => {
+    const document = new FakeDocument();
+    const baseBridge = bridge(async () => ({
+      status: "configured",
+      runtimeReady: true,
+    }));
+    baseBridge.chatGptStatus.mockResolvedValue({ state: "absent", runtimeReady: false });
+    baseBridge.credentialStatuses
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce(
+        status.refreshedState === null
+          ? []
+          : [{ slot: "anthropic", state: status.refreshedState, runtimeState: null }],
+      );
+    const onboardingBridge: OnboardingBridge = {
+      ...baseBridge,
+      async writeCredential({ slot }) {
+        return { slot, status: "refused", reason: "runtime-unavailable" };
+      },
+    };
+    const controller = mountOnboarding({
+      document: documentBoundary(document),
+      bridge: onboardingBridge,
+      opener: elementBoundary(document.createElement("button")),
+      onComplete: vi.fn(),
+    });
+    await controller.open();
+    passwordInputFor(document, "anthropic").value = randomUUID();
+
+    buttonWithText(document, "Continue").dispatch("click");
+
+    await vi.waitFor(() => {
+      expect(controller.state()).toMatchObject({
+        fixedError: "credential-reenter-required",
+        credentialStatus: { anthropic: status.refreshedState ?? "missing" },
+      });
+    });
+    expect(document.body.querySelector("#onboarding-error")?.textContent).toBe(
+      "That saved key could not be used. Enter it again to continue.",
+    );
+    expect(
+      document.body
+        .querySelectorAll("button")
+        .some((button) => button.textContent === "Retry saved keys"),
+    ).toBe(false);
+    controller.dispose();
+  });
+
+  it.each([
+    {
+      state: "configured",
+      runtimeState: "stored-inactive",
+    },
+    {
+      state: "re-prompt",
+      runtimeState: null,
+    },
+  ] as const)("does not offer retry for an unrelated $state status", async (status) => {
+    const document = new FakeDocument();
+    const baseBridge = bridge(async () => ({
+      status: "configured",
+      runtimeReady: true,
+    }));
+    baseBridge.chatGptStatus.mockResolvedValue({ state: "absent", runtimeReady: false });
+    baseBridge.credentialStatuses.mockResolvedValue([
+      { slot: "anthropic", state: status.state, runtimeState: status.runtimeState },
+    ]);
+    const controller = mountOnboarding({
+      document: documentBoundary(document),
+      bridge: baseBridge,
+      opener: elementBoundary(document.createElement("button")),
+      onComplete: vi.fn(),
+    });
+
+    await controller.open();
+
+    expect(
+      document.body
+        .querySelectorAll("button")
+        .some((button) => button.textContent === "Retry saved keys"),
+    ).toBe(false);
+    controller.dispose();
+  });
+
+  it("uses fixed generic copy when a credential write throws", async () => {
+    const document = new FakeDocument();
+    const exceptionDetail = "write exception detail must stay private";
+    const baseBridge = bridge(async () => ({
+      status: "configured",
+      runtimeReady: true,
+    }));
+    const onboardingBridge: OnboardingBridge = {
+      ...baseBridge,
+      async writeCredential() {
+        throw new Error(exceptionDetail);
+      },
+    };
+    const controller = mountOnboarding({
+      document: documentBoundary(document),
+      bridge: onboardingBridge,
+      opener: elementBoundary(document.createElement("button")),
+      onComplete: vi.fn(),
+    });
+    await controller.open();
+    const passwordInput = passwordInputFor(document, "anthropic");
+    passwordInput.value = randomUUID();
+
+    buttonWithText(document, "Continue").dispatch("click");
+
+    await vi.waitFor(() => expect(controller.state().fixedError).toBe("credential-save-failed"));
+    expect(document.body.querySelector("#onboarding-error")?.textContent).toBe(
+      "That key could not be saved. Try entering it again.",
+    );
+    expect(document.body.textContent).not.toContain(exceptionDetail);
+    expect(controller.state().step).toBe("coach-keys");
+    expect(passwordInput.value).toBe("");
+    expect(baseBridge.credentialStatuses).toHaveBeenCalledTimes(2);
+    controller.dispose();
+  });
+
+  it("explains when a saved key's post-write status cannot be refreshed", async () => {
+    const document = new FakeDocument();
+    const exceptionDetail = "status exception detail must stay private";
+    const baseBridge = bridge(async () => ({
+      status: "configured",
+      runtimeReady: true,
+    }));
+    baseBridge.credentialStatuses
+      .mockResolvedValueOnce([])
+      .mockRejectedValueOnce(new Error(exceptionDetail));
+    const onboardingBridge: OnboardingBridge = {
+      ...baseBridge,
+      async writeCredential({ slot }) {
+        return { slot, status: "refused", reason: "runtime-unavailable" };
+      },
+    };
+    const controller = mountOnboarding({
+      document: documentBoundary(document),
+      bridge: onboardingBridge,
+      opener: elementBoundary(document.createElement("button")),
+      onComplete: vi.fn(),
+    });
+    await controller.open();
+    const passwordInput = passwordInputFor(document, "anthropic");
+    passwordInput.value = randomUUID();
+
+    buttonWithText(document, "Continue").dispatch("click");
+
+    await vi.waitFor(() =>
+      expect(controller.state().fixedError).toBe("credential-status-unavailable"),
+    );
+    expect(document.body.querySelector("#onboarding-error")?.textContent).toBe(
+      "That key was saved, but its status could not be refreshed. Close and reopen Setup to check again.",
+    );
+    expect(document.body.textContent).not.toContain(exceptionDetail);
+    expect(controller.state().step).toBe("coach-keys");
+    expect(passwordInput.value).toBe("");
+    expect(baseBridge.credentialStatuses).toHaveBeenCalledTimes(2);
+    controller.dispose();
+  });
+
+  it("accepts an active key when only the unrelated ChatGPT status refresh fails", async () => {
+    const document = new FakeDocument();
+    const exceptionDetail = "ChatGPT status detail must stay private";
+    const baseBridge = bridge(async () => ({ status: "refused", reason: "cancelled" }));
+    baseBridge.writeCredential = async ({ slot }) => ({
+      slot,
+      status: "configured",
+      runtimeReady: true,
+    });
+    baseBridge.credentialStatuses
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ slot: "anthropic", state: "configured", runtimeState: "active" }]);
+    baseBridge.chatGptStatus
+      .mockResolvedValueOnce({ state: "configured", runtimeReady: true })
+      .mockRejectedValueOnce(new Error(exceptionDetail));
+    const controller = mountOnboarding({
+      document: documentBoundary(document),
+      bridge: baseBridge,
+      opener: elementBoundary(document.createElement("button")),
+      onComplete: vi.fn(),
+    });
+    await controller.open();
+    passwordInputFor(document, "anthropic").value = randomUUID();
+
+    buttonWithText(document, "Continue").dispatch("click");
+
+    await vi.waitFor(() => expect(controller.state().step).toBe("training-data"));
+    expect(controller.state().fixedError).toBeNull();
+    expect(controller.state().chatGptRuntimeReady).toBe(false);
+    expect(document.body.textContent).not.toContain(exceptionDetail);
+    controller.dispose();
+  });
+
+  it("advances after a configured key write and refreshed active status", async () => {
+    const document = new FakeDocument();
+    const baseBridge = bridge(async () => ({
+      status: "configured",
+      runtimeReady: true,
+    }));
+    baseBridge.chatGptStatus.mockResolvedValue({ state: "absent", runtimeReady: false });
+    baseBridge.credentialStatuses
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ slot: "anthropic", state: "configured", runtimeState: "active" }]);
+    let credentialWriteCount = 0;
+    const onboardingBridge: OnboardingBridge = {
+      ...baseBridge,
+      async writeCredential({ slot }) {
+        credentialWriteCount += 1;
+        return { slot, status: "configured", runtimeReady: true };
+      },
+    };
+    const onComplete = vi.fn();
+    const controller = mountOnboarding({
+      document: documentBoundary(document),
+      bridge: onboardingBridge,
+      opener: elementBoundary(document.createElement("button")),
+      onComplete,
+    });
+    await controller.open();
+    const passwordInput = passwordInputFor(document, "anthropic");
+    passwordInput.value = randomUUID();
+
+    buttonWithText(document, "Continue").dispatch("click");
+
+    await vi.waitFor(() => expect(controller.state().step).toBe("training-data"));
+    expect(passwordInput.value).toBe("");
+    expect(credentialWriteCount).toBe(1);
+    expect(baseBridge.credentialStatuses).toHaveBeenCalledTimes(2);
+    expect(onComplete).not.toHaveBeenCalled();
+    controller.dispose();
+  });
+
   it("discloses distinct credential storage without starting sign-in, writing, or advancing", async () => {
     const document = new FakeDocument();
     const onboardingBridge = bridge(async () => ({
@@ -255,6 +1044,7 @@ describe("mounted onboarding", () => {
       expect(document.body.textContent).toContain("ChatGPT is ready.");
     });
     expect(buttonWithText(document, "Sign in again").disabled).toBe(false);
+    expect(chatGptLogin.writeCredential).not.toHaveBeenCalled();
   });
 
   it("renders the existing refusal state after configured sign-in is refused", async () => {
@@ -346,17 +1136,19 @@ describe("mounted onboarding", () => {
 
   it("does not start a dropped import while the training-data step is submitting", async () => {
     const document = new FakeDocument();
-    const onboardingBridge = bridge(async () => ({
+    const baseBridge = bridge(async () => ({
       status: "configured",
       runtimeReady: true,
     }));
-    let resolveCredential!: (value: CredentialWriteResult) => void;
-    vi.mocked(onboardingBridge.writeCredential).mockImplementation(
-      () =>
-        new Promise<CredentialWriteResult>((resolve) => {
-          resolveCredential = resolve;
-        }),
-    );
+    const pendingWrite = deferred<CredentialWriteResult>();
+    let credentialWriteCount = 0;
+    const onboardingBridge: OnboardingBridge = {
+      ...baseBridge,
+      writeCredential() {
+        credentialWriteCount += 1;
+        return pendingWrite.promise;
+      },
+    };
     const controller = mountOnboarding({
       document: documentBoundary(document),
       bridge: onboardingBridge,
@@ -370,14 +1162,14 @@ describe("mounted onboarding", () => {
       .querySelectorAll('input[type="password"][data-slot]')
       .find((input) => input.dataset.slot === "intervals-icu");
     expect(intervalsInput).toBeDefined();
-    intervalsInput!.value = "synthetic-key";
+    intervalsInput!.value = randomUUID();
 
     buttonWithText(document, "Continue").dispatch("click");
-    await vi.waitFor(() => expect(onboardingBridge.writeCredential).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(credentialWriteCount).toBe(1));
     controller.importDroppedFiles(["/synthetic/during-submit.fit"]);
     expect(onboardingBridge.importFiles).not.toHaveBeenCalled();
 
-    resolveCredential({ slot: "intervals-icu", status: "configured", runtimeReady: true });
+    pendingWrite.resolve({ slot: "intervals-icu", status: "configured", runtimeReady: true });
     await vi.waitFor(() => expect(controller.state().busy).toBe(false));
     controller.dispose();
   });

--- a/apps/desktop-renderer/tests/onboarding-provider-status.test.ts
+++ b/apps/desktop-renderer/tests/onboarding-provider-status.test.ts
@@ -297,6 +297,46 @@ describe("onboarding provider status", () => {
     controller.dispose();
   });
 
+  it("fails ChatGPT activity closed when its post-retry status is unavailable", async () => {
+    const document = new FakeDocument();
+    const failedStatuses = [
+      { slot: "anthropic" as const, state: "configured" as const, runtimeState: "failed" as const },
+    ];
+    const activeStatuses = [
+      { slot: "anthropic" as const, state: "configured" as const, runtimeState: "active" as const },
+    ];
+    const chatGptStatus = vi
+      .fn<OnboardingBridge["chatGptStatus"]>()
+      .mockResolvedValueOnce({ state: "configured", runtimeReady: true })
+      .mockRejectedValueOnce(new Error("private status failure"));
+    const retryFailedCredentials = vi.fn(async () => activeStatuses);
+    const controller = mountOnboarding({
+      document: document as never,
+      bridge: createBridge({
+        credentialStatuses: vi.fn(async () => failedStatuses),
+        chatGptStatus,
+        retryFailedCredentials,
+      }),
+      opener: new FakeElement("button", document) as never,
+      onComplete: vi.fn(),
+    });
+    await controller.open();
+
+    findByText(document.body, "button", "Retry saved keys").click();
+
+    await vi.waitFor(() => {
+      expect(retryFailedCredentials).toHaveBeenCalledOnce();
+      expect(chatGptStatus).toHaveBeenCalledTimes(2);
+      expectOneActiveProvider(document.body);
+    });
+    expect(activeProviderLanes(document.body)[0]?.textContent).toBe("Configured");
+    expect(document.body.textContent).toContain(
+      "Your ChatGPT sign-in is saved. Sign in again to activate it.",
+    );
+    expect(document.body.textContent).not.toContain("private status failure");
+    controller.dispose();
+  });
+
   it("does not report a completed sign-in as refused when status refresh fails", async () => {
     const document = new FakeDocument();
     const credentialStatuses = vi
@@ -307,9 +347,13 @@ describe("onboarding provider status", () => {
       status: "configured" as const,
       runtimeReady: true as const,
     }));
+    const chatGptStatus = vi
+      .fn<OnboardingBridge["chatGptStatus"]>()
+      .mockResolvedValueOnce({ state: "absent", runtimeReady: false })
+      .mockResolvedValueOnce({ state: "configured", runtimeReady: true });
     const controller = mountOnboarding({
       document: document as never,
-      bridge: createBridge({ credentialStatuses, chatGptLogin }),
+      bridge: createBridge({ credentialStatuses, chatGptLogin, chatGptStatus }),
       opener: new FakeElement("button", document) as never,
       onComplete: vi.fn(),
     });

--- a/apps/desktop-renderer/tests/onboarding-secret-boundary.test.ts
+++ b/apps/desktop-renderer/tests/onboarding-secret-boundary.test.ts
@@ -14,7 +14,7 @@ describe("onboarding renderer secret boundary", () => {
     ["anthropic", "synthetic-model-secret-sentinel"],
     ["intervals-icu", "synthetic-intervals-secret-sentinel"],
   ] as const) {
-    it(`releases the ${slot} password after the pending handoff settles`, async () => {
+    it(`releases the ${slot} password before the pending handoff settles`, async () => {
       const input = { value: sentinel, dataset: { slot } };
       const gate = deferred();
       let transient: { readonly slot: string; readonly value: string } | undefined;
@@ -27,7 +27,7 @@ describe("onboarding renderer secret boundary", () => {
         }
       };
       const pending = handoffCredential(input, write);
-      expect(input.value).toBe(sentinel);
+      expect(input.value).toBe("");
       expect(transient).toEqual({ slot, value: sentinel });
       gate.resolve();
       await pending;


### PR DESCRIPTION
## Summary
- preserve every fixed credential-write refusal reason through onboarding with actionable, truthful copy
- reconcile runtime failures against passive status and provide a step-scoped one-flight retry for saved keys
- clear and disable password controls before asynchronous work, including rerender and stale-visit paths

## Verification
- 64 focused renderer and main-process onboarding tests passed
- all 275 renderer tests passed in final review
- renderer TypeScript check and scoped lint, formatting, diff, and changeset checks passed
- three independent UX, secret-boundary, and cross-process contract reviewers passed

A patch changeset records the athlete-visible Setup recovery improvement.