### PR TITLE
fix(desktop): stop reopening completed setup

### DIFF
--- a/.changeset/desktop-setup-completion.md
+++ b/.changeset/desktop-setup-completion.md
@@ -1,0 +1,5 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Desktop Setup now stays closed after onboarding is complete while remaining available from the Setup button.

--- a/apps/desktop-renderer/src/index.ts
+++ b/apps/desktop-renderer/src/index.ts
@@ -14,6 +14,7 @@ import { mountChatView } from "./chat/view.js";
 import { createDesktopCoachClientProvider } from "./coach-client.js";
 import { createFirstSyncController, type FirstSyncState } from "./first-sync.js";
 import { validateImportPaths, type OnboardingBridge } from "./onboarding/bridge.js";
+import { createOnboardingCompletionController } from "./onboarding/completion.js";
 import { mountOnboarding } from "./onboarding/mount.js";
 import { createTrainingContextController } from "./training-context/controller.js";
 import { createManualSyncController } from "./training-context/manual-sync.js";
@@ -240,15 +241,22 @@ const residentRideImport = mountResidentRideImport({
   before: connectionStatus,
   imports: rideImports,
 });
+const onboardingCompletion = createOnboardingCompletionController({
+  storage: () => window.localStorage,
+  onComplete: (completion) => void firstSyncController.start(completion),
+});
 const onboarding = mountOnboarding({
   document,
   bridge: onboardingBridge,
   rideImports,
   onRideImportPresentationChange: (presenting) => residentRideImport.setSuppressed(presenting),
   opener: setup,
-  onComplete: (completion) => void firstSyncController.start(completion),
+  onComplete: (completion) => onboardingCompletion.complete(completion),
 });
-setup.addEventListener("click", () => void onboarding.open());
+setup.addEventListener(
+  "click",
+  () => void onboardingCompletion.openManually(() => onboarding.open()),
+);
 const disposeDroppedRideImports = subscribeToDroppedRideImports({
   subscribe: onboardingBridge.onDroppedImportFiles,
   onboarding,
@@ -258,7 +266,7 @@ const disposeDroppedRideImports = subscribeToDroppedRideImports({
 void trainingContextController.start();
 spendController.start();
 void chatController.start();
-void onboarding.open();
+void onboardingCompletion.openOnStartup(() => onboarding.open());
 void clients.getClient().then(
   () => {
     document.documentElement.dataset.rpc = "connected";

--- a/apps/desktop-renderer/src/onboarding/completion.ts
+++ b/apps/desktop-renderer/src/onboarding/completion.ts
@@ -1,0 +1,41 @@
+import type { OnboardingCompletion } from "./machine.js";
+
+const COMPLETION_STORAGE_KEY = "enduragent.desktop.onboarding";
+const COMPLETION_STORAGE_VALUE = '{"version":1,"completed":true}';
+
+export interface OnboardingCompletionStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
+export interface OnboardingCompletionController {
+  openOnStartup(openSetup: () => Promise<void>): Promise<void>;
+  openManually(openSetup: () => Promise<void>): Promise<void>;
+  complete(completion: OnboardingCompletion): void;
+}
+
+export function createOnboardingCompletionController(options: {
+  readonly storage: () => OnboardingCompletionStorage;
+  readonly onComplete: (completion: OnboardingCompletion) => void;
+}): OnboardingCompletionController {
+  const completed = (): boolean => {
+    try {
+      return options.storage().getItem(COMPLETION_STORAGE_KEY) === COMPLETION_STORAGE_VALUE;
+    } catch {
+      return false;
+    }
+  };
+
+  return {
+    openOnStartup(openSetup) {
+      return completed() ? Promise.resolve() : openSetup();
+    },
+    openManually: (openSetup) => openSetup(),
+    complete(completion) {
+      try {
+        options.storage().setItem(COMPLETION_STORAGE_KEY, COMPLETION_STORAGE_VALUE);
+      } catch {}
+      options.onComplete(completion);
+    },
+  };
+}

--- a/apps/desktop-renderer/tests/onboarding-completion.test.ts
+++ b/apps/desktop-renderer/tests/onboarding-completion.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createOnboardingCompletionController,
+  type OnboardingCompletionStorage,
+} from "../src/onboarding/completion.js";
+
+const completion = {
+  providerConfigured: true,
+  trainingDataConfigured: true,
+  intakeSaved: true,
+} as const;
+
+function memoryStorage(
+  entries: readonly (readonly [string, string])[] = [],
+): OnboardingCompletionStorage & { readonly entries: Map<string, string> } {
+  const stored = new Map(entries);
+  return {
+    entries: stored,
+    getItem: (key) => stored.get(key) ?? null,
+    setItem: (key, value) => {
+      stored.set(key, value);
+    },
+  };
+}
+
+describe("onboarding completion", () => {
+  it("opens Setup on first launch without writing a completion marker", async () => {
+    const storage = memoryStorage();
+    const openSetup = vi.fn(async () => {});
+    const onComplete = vi.fn();
+    const controller = createOnboardingCompletionController({
+      storage: () => storage,
+      onComplete,
+    });
+
+    await controller.openOnStartup(openSetup);
+
+    expect(openSetup).toHaveBeenCalledOnce();
+    expect(storage.entries.size).toBe(0);
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+
+  it("persists the exact completion marker across a fresh window decision", async () => {
+    const storage = memoryStorage();
+    const firstSync = vi.fn();
+    const firstWindow = createOnboardingCompletionController({
+      storage: () => storage,
+      onComplete: firstSync,
+    });
+
+    firstWindow.complete(completion);
+
+    expect([...storage.entries]).toEqual([
+      ["enduragent.desktop.onboarding", '{"version":1,"completed":true}'],
+    ]);
+    expect(firstSync).toHaveBeenCalledWith(completion);
+
+    const openSetup = vi.fn(async () => {});
+    const nextWindow = createOnboardingCompletionController({
+      storage: () => storage,
+      onComplete: vi.fn(),
+    });
+    await nextWindow.openOnStartup(openSetup);
+
+    expect(openSetup).not.toHaveBeenCalled();
+  });
+
+  it("always opens Setup for a manual replay after completion", async () => {
+    const storage = memoryStorage([
+      ["enduragent.desktop.onboarding", '{"version":1,"completed":true}'],
+    ]);
+    const openSetup = vi.fn(async () => {});
+    const controller = createOnboardingCompletionController({
+      storage: () => storage,
+      onComplete: vi.fn(),
+    });
+
+    await controller.openOnStartup(openSetup);
+    await controller.openManually(openSetup);
+
+    expect(openSetup).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    "",
+    "completed",
+    '{"version":1,"completed":false}',
+    '{"version":2,"completed":true}',
+    '{"version":1,"completed":true,"extra":true}',
+  ])("opens Setup when the stored marker is malformed or inexact: %s", async (marker) => {
+    const storage = memoryStorage([["enduragent.desktop.onboarding", marker]]);
+    const openSetup = vi.fn(async () => {});
+    const controller = createOnboardingCompletionController({
+      storage: () => storage,
+      onComplete: vi.fn(),
+    });
+
+    await controller.openOnStartup(openSetup);
+
+    expect(openSetup).toHaveBeenCalledOnce();
+  });
+
+  it("opens Setup when browser storage cannot be read", async () => {
+    const openSetup = vi.fn(async () => {});
+    const controller = createOnboardingCompletionController({
+      storage: () => {
+        throw new TypeError("unavailable");
+      },
+      onComplete: vi.fn(),
+    });
+
+    await controller.openOnStartup(openSetup);
+
+    expect(openSetup).toHaveBeenCalledOnce();
+  });
+
+  it("continues first sync and leaves manual Setup available when storage cannot be written", async () => {
+    const storage: OnboardingCompletionStorage = {
+      getItem: () => null,
+      setItem: () => {
+        throw new TypeError("unavailable");
+      },
+    };
+    const firstSync = vi.fn();
+    const openSetup = vi.fn(async () => {});
+    const controller = createOnboardingCompletionController({
+      storage: () => storage,
+      onComplete: firstSync,
+    });
+
+    expect(() => controller.complete(completion)).not.toThrow();
+    await controller.openManually(openSetup);
+
+    expect(firstSync).toHaveBeenCalledWith(completion);
+    expect(openSetup).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Summary
- persist one exact versioned, non-sensitive marker when Setup genuinely completes
- suppress only automatic Setup opening on later renderer recreations
- keep manual Setup and fail-open storage behavior available, without blocking first sync

## Verification
- 25 focused renderer tests passed
- renderer production build and TypeScript check passed
- scoped lint, formatting, diff, changeset, trademark, and fixture-privacy checks passed
- one independent isolated-UX reviewer passed

A patch changeset records the athlete-visible Setup persistence fix.