### PR TITLE
fix(coach): log scheduled store refresh failures

### DIFF
--- a/.changeset/scheduled-store-refresh-logging.md
+++ b/.changeset/scheduled-store-refresh-logging.md
@@ -1,0 +1,5 @@
+---
+"@enduragent/coach": patch
+---
+
+Persist redacted sync-subsystem diagnostics when a scheduled training-store refresh fails.

--- a/packages/coach/src/store-runtime.ts
+++ b/packages/coach/src/store-runtime.ts
@@ -1,6 +1,6 @@
 import { performance } from "node:perf_hooks";
 import type { Config, AthleteDataReader, ReferenceRuntime } from "@enduragent/core";
-import { createStoreAthleteDataReader } from "@enduragent/core";
+import { createStoreAthleteDataReader, createSubsystemLogger } from "@enduragent/core";
 import {
   createPhysicalRequestLedger,
   type PhysicalRequestCounts,
@@ -84,6 +84,7 @@ export class StoreRuntime {
     const dependencies = options.dependencies ?? {};
     const now = dependencies.now ?? (() => new Date());
     const schedulerDependencies = dependencies.schedulerDependencies ?? {};
+    const logger = createSubsystemLogger("sync", options.home.root);
     this.dependencies = {
       capture: dependencies.capture ?? runReferenceCapture,
       produce:
@@ -100,6 +101,9 @@ export class StoreRuntime {
       cadenceMs: STORE_REFRESH_INTERVAL_MS,
       run: async () => {
         await this.runWindow();
+      },
+      onError: (error) => {
+        logger.error("scheduled_store_refresh_failed", error);
       },
       dependencies: {
         nowEpochMs: schedulerDependencies.nowEpochMs ?? (() => now().getTime()),

--- a/packages/coach/tests/store-runtime.test.ts
+++ b/packages/coach/tests/store-runtime.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, realpath, rm } from "node:fs/promises";
+import { mkdtemp, readFile, realpath, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Config, ReferenceRuntime } from "@enduragent/core";
@@ -126,6 +126,80 @@ describe("StoreRuntime", () => {
     capture.mockRejectedValueOnce(new Error("capture failed"));
     await expect(runtime.runWindow()).rejects.toThrow("capture failed");
     expect(runtime.currentSnapshot()).toBe(produced);
+    await runtime.close();
+  });
+
+  it("logs a redacted scheduled refresh failure, retains the snapshot, and reschedules", async () => {
+    const root = await mkdtemp(join(await realpath(tmpdir()), "store-runtime-scheduled-error-"));
+    roots.push(root);
+    const scheduled: Array<() => void> = [];
+    let markRescheduled!: () => void;
+    const rescheduled = new Promise<void>((resolve) => {
+      markRescheduled = resolve;
+    });
+    const handle = { unref: vi.fn() } as unknown as ReturnType<typeof setTimeout>;
+    const reference = {
+      scheduler: { stop: vi.fn() },
+      services: {},
+      runScheduledOnce: vi.fn(async () => ({ kind: "ran", lastSyncAt: "", refreshed: [] })),
+    } as unknown as ReferenceRuntime;
+    const capture = vi
+      .fn<() => Promise<ReferenceCaptureManifest>>()
+      .mockResolvedValueOnce(manifest)
+      .mockRejectedValueOnce(
+        Object.assign(new Error("capture failed"), {
+          payload: { apiKey: "SECRET-API-KEY" },
+          authorization: "Bearer SECRET",
+        }),
+      );
+    const runtime = createStoreRuntime({
+      env: {},
+      config,
+      home: {
+        root,
+        storeDir: join(root, "store"),
+        archiveDir: join(root, "archive"),
+        configDir: join(root, "config"),
+      },
+      reference,
+      dependencies: {
+        capture,
+        produce: vi.fn(async () => produced),
+        now: () => new Date("1998-07-18T12:00:00.000Z"),
+        monotonicNow: () => 1,
+        schedulerDependencies: {
+          nowEpochMs: () => new Date("1998-07-18T12:00:00.000Z").getTime(),
+          setTimeout: vi.fn((callback: () => void) => {
+            scheduled.push(callback);
+            if (scheduled.length === 2) markRescheduled();
+            return handle;
+          }) as unknown as typeof setTimeout,
+          clearTimeout: vi.fn() as unknown as typeof clearTimeout,
+        },
+      },
+    });
+    await runtime.runWindow();
+    runtime.startScheduler();
+    scheduled[0]!();
+    await rescheduled;
+
+    const raw = await readFile(join(root, "logs", "log.jsonl"), "utf8");
+    const lines = raw.trim().split("\n");
+    expect(lines).toHaveLength(1);
+    expect(JSON.parse(lines[0]!)).toMatchObject({
+      level: "error",
+      component: "sync",
+      event: "scheduled_store_refresh_failed",
+      err: {
+        name: "Error",
+        message: "capture failed",
+        authorization: "[redacted]",
+      },
+    });
+    expect(raw).not.toContain("SECRET-API-KEY");
+    expect(raw).not.toContain("Bearer SECRET");
+    expect(runtime.currentSnapshot()).toBe(produced);
+    expect(scheduled).toHaveLength(2);
     await runtime.close();
   });
 


### PR DESCRIPTION
## Summary
- persist one redacted sync-subsystem error when a scheduled store refresh fails
- retain the last successful snapshot and continue the six-hour schedule
- keep observability separate from user-visible sync history and error state

## Verification
- 25 focused StoreRuntime tests
- failing async path repeated 10 times
- Coach typecheck and targeted lint
- clean rebase onto the current desktop tip
- one final isolated-risk review: pass

## Changeset
- patch release for @enduragent/coach
- no user-facing release note; this is diagnostic observability