### PR TITLE
fix(desktop): finish file-only setup without provider sync

### DIFF
--- a/.changeset/file-only-setup-sync.md
+++ b/.changeset/file-only-setup-sync.md
@@ -1,0 +1,7 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: File-only setup no longer reports a sync failure after rides are saved to the local library.
+
+Carry the onboarding data source into the transient completion handoff so provider sync runs only when a training platform is configured.

--- a/apps/desktop-renderer/src/first-sync.ts
+++ b/apps/desktop-renderer/src/first-sync.ts
@@ -28,10 +28,12 @@ function validCompletion(value: unknown): value is OnboardingCompletion {
   const candidate = value as Record<string, unknown>;
   const keys = Object.keys(candidate).sort();
   return (
-    keys.join(",") === "intakeSaved,providerConfigured,trainingDataConfigured" &&
+    keys.join(",") ===
+      "intakeSaved,providerConfigured,requiresProviderSync,trainingDataConfigured" &&
     candidate.providerConfigured === true &&
     candidate.trainingDataConfigured === true &&
-    candidate.intakeSaved === true
+    candidate.intakeSaved === true &&
+    typeof candidate.requiresProviderSync === "boolean"
   );
 }
 
@@ -112,6 +114,21 @@ export function createFirstSyncController(ports: FirstSyncPorts): FirstSyncContr
     start(completion) {
       if (!validCompletion(completion)) return Promise.reject(new TypeError("Invalid completion."));
       if (disposed) return Promise.resolve();
+      if (!completion.requiresProviderSync) {
+        activated = false;
+        completed = true;
+        inFlight = undefined;
+        composerFocusOperation = undefined;
+        if (state.status !== "idle") {
+          state = { status: "idle" };
+          ports.render(state);
+        }
+        if (!composerFocused) {
+          composerFocused = true;
+          ports.focusComposer();
+        }
+        return Promise.resolve();
+      }
       if (inFlight !== undefined) return inFlight;
       activated = true;
       completed = false;

--- a/apps/desktop-renderer/src/onboarding/machine.ts
+++ b/apps/desktop-renderer/src/onboarding/machine.ts
@@ -62,6 +62,7 @@ export interface OnboardingCompletion {
   readonly providerConfigured: true;
   readonly trainingDataConfigured: true;
   readonly intakeSaved: true;
+  readonly requiresProviderSync: boolean;
 }
 
 function statusRecord<T>(initial: T): Record<DesktopCredentialSlot, T> {
@@ -237,8 +238,11 @@ export function withImportedRideFileCount(
   };
 }
 
-export const ONBOARDING_COMPLETION: OnboardingCompletion = {
-  providerConfigured: true,
-  trainingDataConfigured: true,
-  intakeSaved: true,
-};
+export function toOnboardingCompletion(state: OnboardingState): OnboardingCompletion {
+  return {
+    providerConfigured: true,
+    trainingDataConfigured: true,
+    intakeSaved: true,
+    requiresProviderSync: state.credentialStatus["intervals-icu"] === "configured",
+  };
+}

--- a/apps/desktop-renderer/src/onboarding/mount.ts
+++ b/apps/desktop-renderer/src/onboarding/mount.ts
@@ -9,12 +9,12 @@ import {
 import type { CredentialWriteResult, OnboardingBridge } from "./bridge.js";
 import { credentialPresentation } from "./credential-presentation.js";
 import {
-  ONBOARDING_COMPLETION,
   createOnboardingState,
   hasConfiguredModel,
   hasTrainingData,
   nextStep,
   previousStep,
+  toOnboardingCompletion,
   toDesktopIntakeFlags,
   withBusy,
   withChatGptLoginResult,
@@ -740,7 +740,14 @@ export function mountOnboarding(options: MountOnboardingOptions): OnboardingCont
     const preview = make(options.document, "div", "ready-preview");
     preview.append(
       make(options.document, "span", undefined, "Keys secured"),
-      make(options.document, "span", undefined, "Training data connected"),
+      make(
+        options.document,
+        "span",
+        undefined,
+        state.credentialStatus["intervals-icu"] === "configured"
+          ? "Training data connected"
+          : "Ride files saved to your local library",
+      ),
       make(options.document, "span", undefined, "Safety context saved"),
     );
     body.append(preview);
@@ -809,7 +816,7 @@ export function mountOnboarding(options: MountOnboardingOptions): OnboardingCont
       scrim?.remove();
       scrim = undefined;
       setRideImportPresentation(false);
-      options.onComplete(ONBOARDING_COMPLETION);
+      options.onComplete(toOnboardingCompletion(state));
     }
   };
 

--- a/apps/desktop-renderer/tests/first-sync.test.ts
+++ b/apps/desktop-renderer/tests/first-sync.test.ts
@@ -26,7 +26,10 @@ const completion = {
   providerConfigured: true,
   trainingDataConfigured: true,
   intakeSaved: true,
+  requiresProviderSync: true,
 } as const;
+
+const fileOnlyCompletion = { ...completion, requiresProviderSync: false } as const;
 
 const success: SyncRpcResult = {
   schemaVersion: 1,
@@ -122,6 +125,12 @@ describe("first sync controller", () => {
     for (const invalid of [
       {},
       { ...completion, intakeSaved: false },
+      { ...completion, requiresProviderSync: "yes" },
+      {
+        providerConfigured: true,
+        trainingDataConfigured: true,
+        intakeSaved: true,
+      },
       { ...completion, extra: true },
       null,
     ]) {
@@ -139,6 +148,64 @@ describe("first sync controller", () => {
     await first;
     expect(ports.states.at(-1)).toEqual({ status: "ready" });
     expect(ports.focusComposer).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips provider sync for file-only completion and leaves retry inert", async () => {
+    const coordinator = new FakeCoordinator();
+    const ports = fakePorts(coordinator);
+    const controller = createFirstSyncController(ports);
+
+    await controller.start(fileOnlyCompletion);
+    await controller.retry();
+    await controller.start(fileOnlyCompletion);
+
+    expect(coordinator.requestCalls).toEqual([]);
+    expect(ports.states).toEqual([]);
+    expect(ports.focusComposer).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears a stale first-sync failure when file-only setup completes", async () => {
+    const coordinator = new FakeCoordinator();
+    const ports = fakePorts(coordinator);
+    const controller = createFirstSyncController(ports);
+    const providerSync = controller.start(completion);
+    coordinator.finish({
+      status: "failed",
+      operation: 1,
+      kind: "operation",
+      retryable: true,
+    });
+    await providerSync;
+
+    await controller.start(fileOnlyCompletion);
+    await controller.retry();
+
+    expect(coordinator.requestCalls).toEqual([1]);
+    expect(ports.states.at(-1)).toEqual({ status: "idle" });
+    expect(ports.focusComposer).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not join or cancel a concurrently running manual sync for file-only setup", async () => {
+    const coordinator = new FakeCoordinator();
+    const ports = fakePorts(coordinator);
+    const first = createFirstSyncController(ports);
+    const manual = createManualSyncController({
+      coordinator,
+      view: { render: vi.fn(), restoreKeyboardFocus: vi.fn() },
+    });
+
+    const manualTask = manual.activate("pointer");
+    await first.start(fileOnlyCompletion);
+
+    expect(coordinator.requestCalls).toEqual([1]);
+    expect(ports.states).toEqual([]);
+    expect(ports.focusComposer).toHaveBeenCalledTimes(1);
+    coordinator.finish({ status: "succeeded", operation: 1, kind: "no-change" });
+    await manualTask;
+    expect(ports.states).toEqual([]);
+
+    manual.dispose();
+    first.dispose();
   });
 
   it.each([

--- a/apps/desktop-renderer/tests/onboarding-completion.test.ts
+++ b/apps/desktop-renderer/tests/onboarding-completion.test.ts
@@ -8,7 +8,10 @@ const completion = {
   providerConfigured: true,
   trainingDataConfigured: true,
   intakeSaved: true,
+  requiresProviderSync: true,
 } as const;
+
+const fileOnlyCompletion = { ...completion, requiresProviderSync: false } as const;
 
 function memoryStorage(
   entries: readonly (readonly [string, string])[] = [],
@@ -48,12 +51,12 @@ describe("onboarding completion", () => {
       onComplete: firstSync,
     });
 
-    firstWindow.complete(completion);
+    firstWindow.complete(fileOnlyCompletion);
 
     expect([...storage.entries]).toEqual([
       ["enduragent.desktop.onboarding", '{"version":1,"completed":true}'],
     ]);
-    expect(firstSync).toHaveBeenCalledWith(completion);
+    expect(firstSync).toHaveBeenCalledWith(fileOnlyCompletion);
 
     const openSetup = vi.fn(async () => {});
     const nextWindow = createOnboardingCompletionController({

--- a/apps/desktop-renderer/tests/onboarding-machine.test.ts
+++ b/apps/desktop-renderer/tests/onboarding-machine.test.ts
@@ -3,6 +3,7 @@ import {
   createOnboardingState,
   nextStep,
   previousStep,
+  toOnboardingCompletion,
   toDesktopIntakeFlags,
   withCredentialStatuses,
   withChatGptLoginResult,
@@ -93,6 +94,24 @@ describe("desktop onboarding machine", () => {
     state = withImportedRideFileCount(state, 0);
     expect(state.importedRideFileCount).toBe(2);
     expect(() => withImportedRideFileCount(state, -1)).toThrow(TypeError);
+  });
+
+  it("derives provider sync only from the configured training platform", () => {
+    const fileOnly = withImportedRideFileCount(createOnboardingState(), 1);
+    expect(toOnboardingCompletion(fileOnly)).toEqual({
+      providerConfigured: true,
+      trainingDataConfigured: true,
+      intakeSaved: true,
+      requiresProviderSync: false,
+    });
+
+    const platformOnly = createOnboardingState([
+      { slot: "intervals-icu", state: "configured", runtimeState: "active" },
+    ]);
+    expect(toOnboardingCompletion(platformOnly).requiresProviderSync).toBe(true);
+
+    const mixed = withImportedRideFileCount(platformOnly, 1);
+    expect(toOnboardingCompletion(mixed).requiresProviderSync).toBe(true);
   });
 
   it("maps every cycling intake branch to the landed strict DTO", () => {

--- a/apps/desktop-renderer/tests/onboarding-mount.test.ts
+++ b/apps/desktop-renderer/tests/onboarding-mount.test.ts
@@ -201,6 +201,14 @@ function passwordInputFor(document: FakeDocument, slot: string): FakeElement {
   return input;
 }
 
+function radioInputFor(document: FakeDocument, name: string, copy: string): FakeElement {
+  const input = document.body
+    .querySelectorAll("input")
+    .find((candidate) => candidate.name === name && candidate.parent?.textContent === copy);
+  if (input === undefined) throw new Error(`Radio input not found: ${name} / ${copy}`);
+  return input;
+}
+
 function deferred<T>(): {
   readonly promise: Promise<T>;
   readonly resolve: (value: T) => void;
@@ -1133,6 +1141,84 @@ describe("mounted onboarding", () => {
     expect(controller.ownsDroppedImportFiles()).toBe(false);
     controller.dispose();
   });
+
+  it.each([
+    {
+      source: "file-only",
+      statuses: [],
+      importRide: true,
+      requiresProviderSync: false,
+      readyCopy: "Ride files saved to your local library",
+    },
+    {
+      source: "platform-only",
+      statuses: [{ slot: "intervals-icu", state: "configured", runtimeState: "active" }] as const,
+      importRide: false,
+      requiresProviderSync: true,
+      readyCopy: "Training data connected",
+    },
+    {
+      source: "mixed",
+      statuses: [{ slot: "intervals-icu", state: "configured", runtimeState: "active" }] as const,
+      importRide: true,
+      requiresProviderSync: true,
+      readyCopy: "Training data connected",
+    },
+  ] as const)(
+    "hands off the transient sync requirement for $source setup",
+    async ({ statuses, importRide, requiresProviderSync, readyCopy }) => {
+      const document = new FakeDocument();
+      const onboardingBridge = bridge(async () => ({
+        status: "configured",
+        runtimeReady: true,
+      }));
+      onboardingBridge.credentialStatuses.mockResolvedValue(statuses);
+      onboardingBridge.importFiles.mockResolvedValue({
+        schemaVersion: 1,
+        files: { total: 1, imported: 1, quarantined: 0 },
+        changes: {
+          rawFilesInserted: 1,
+          sourceRecordsInserted: 1,
+          sourceRecordsUpdated: 0,
+          relinkedSourceRecords: 0,
+        },
+      });
+      const onComplete = vi.fn();
+      const controller = mountOnboarding({
+        document: documentBoundary(document),
+        bridge: onboardingBridge,
+        opener: elementBoundary(document.createElement("button")),
+        onComplete,
+      });
+
+      await controller.open();
+      buttonWithText(document, "Continue").dispatch("click");
+      await vi.waitFor(() => expect(controller.state().step).toBe("training-data"));
+      if (importRide) {
+        controller.importDroppedFiles(["/synthetic/setup.fit"]);
+        await vi.waitFor(() => expect(controller.state().importedRideFileCount).toBe(1));
+      }
+      buttonWithText(document, "Continue").dispatch("click");
+      await vi.waitFor(() => expect(controller.state().step).toBe("safety-intake"));
+      radioInputFor(document, "prior-bsi", "No").dispatch("change");
+      radioInputFor(document, "injury-status", "No current injury").dispatch("change");
+      buttonWithText(document, "Continue").dispatch("click");
+      await vi.waitFor(() => expect(controller.state().step).toBe("ready"));
+      expect(
+        document.body.querySelector(".ready-preview")?.children.map((child) => child.textContent),
+      ).toEqual(["Keys secured", readyCopy, "Safety context saved"]);
+      buttonWithText(document, "Finish setup").dispatch("click");
+
+      await vi.waitFor(() => expect(onComplete).toHaveBeenCalledOnce());
+      expect(onComplete).toHaveBeenCalledWith({
+        providerConfigured: true,
+        trainingDataConfigured: true,
+        intakeSaved: true,
+        requiresProviderSync,
+      });
+      controller.dispose();
+    },
+  );
 
   it("does not start a dropped import while the training-data step is submitting", async () => {
     const document = new FakeDocument();


### PR DESCRIPTION
## Summary
- carry the transient training-data source through onboarding completion
- skip the provider sync only for file-only setup without joining or cancelling other sync work
- preserve published-sync requirements for platform and mixed setup, and show truthful local-library ready copy

## Verification
- 66 focused Desktop renderer tests
- file-only, platform-only, mixed, retry, concurrent manual-sync, strict completion, and exact marker coverage
- renderer typecheck plus scoped lint, format, and diff checks
- one final renderer/state-machine review: pass after repairing source-aware ready copy

## Changeset
- patch release for cycling-coach
- user-facing: file-only setup no longer reports a sync failure after rides are saved to the local library