### PR TITLE
feat(desktop): add on-demand release notes

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -37,7 +37,7 @@ Rules:
 - One sentence per `User-facing:` line, written in plain English in the bot's voice.
 - Multiple user-visible changes in one changeset → multiple `User-facing:` lines, each becomes a bullet.
 - Pure-infra changes (CI, publishing, build tooling, internal refactors) omit the line — they stay in `CHANGELOG.md` for git history but don't reach athletes.
-- The line is parsed by a simple regex (`/User-facing:\s*(.+)$/i`); anything after the colon on the same line is the bullet text.
+- The token must start the line after optional indentation. Generated changelog lines may prefix it with a Markdown bullet and an optional commit hash of 7 or more hexadecimal characters followed by a colon (for example, `- abc1234: User-facing: ...`). Mid-line prose that merely mentions `User-facing:` is ignored.
 - The convention propagates from `.changeset/*.md` → `CHANGELOG.md` → GitHub Release body automatically; `/whatsnew` reads the GitHub Release body.
 
 ## Binary packages and CalVer

--- a/.changeset/desktop-release-notes.md
+++ b/.changeset/desktop-release-notes.md
@@ -1,0 +1,8 @@
+---
+"@enduragent/core": patch
+"cycling-coach": patch
+---
+
+User-facing: Added a Desktop What’s new view for the latest published athlete-facing release notes.
+
+Fetch bounded release metadata only after an explicit Desktop action, validate it across the preload boundary, and render remote note text without HTML or Markdown interpretation.

--- a/README.md
+++ b/README.md
@@ -133,6 +133,11 @@ The check runs on Telegram-mode startup and again every 24 hours (so a long-runn
 
 Set `CYCLING_COACH_NO_UPDATE_CHECK=1` to disable the automatic background checks (both the startup check and the daily re-check). The operator-initiated `/update` and `/whatsnew` commands still query the endpoint — those are explicit requests, not background checks (and `/whatsnew` also reaches the GitHub Releases API for release notes). In managed container deploys, `/update` does not run npm; image hosts update by redeploying the container image.
 
+Desktop does not fetch release notes in the background. Choosing **What’s new** explicitly contacts
+`registry.npmjs.org` for the latest published version and the GitHub Releases API for that exact
+version’s athlete-facing notes. Those requests send no installation identifier, credential,
+configuration, or athlete data.
+
 ### First-time setup
 
 The setup wizard prompts you to send `/start` from your Telegram account; the wizard captures your user ID and writes the allowlist file automatically — you never type your numeric ID.

--- a/apps/desktop-renderer/src/global.d.ts
+++ b/apps/desktop-renderer/src/global.d.ts
@@ -14,7 +14,21 @@ interface EnduragentAuth {
   chatgptLogin(): Promise<ChatGptLoginResult>;
   chooseImportFiles(): Promise<readonly string[]>;
   onDroppedImportFiles(listener: (paths: readonly string[]) => void): () => void;
+  releaseNotes(): Promise<ReleaseNotesResult>;
 }
+
+type ReleaseNotesResult =
+  | {
+      readonly status: "available";
+      readonly version: string;
+      readonly notes: readonly string[];
+      readonly releaseUrl: string;
+    }
+  | {
+      readonly status: "unavailable";
+      readonly version: string | null;
+      readonly releaseUrl: string;
+    };
 
 type DesktopCredentialSlot =
   | "anthropic"

--- a/apps/desktop-renderer/src/index.ts
+++ b/apps/desktop-renderer/src/index.ts
@@ -7,6 +7,7 @@ import { SaveIntakeRpcParamsSchema } from "@enduragent/coach-contract";
 import "./chat/styles.css";
 import "./training-context/styles.css";
 import "./spend-meter/styles.css";
+import "./release-notes/styles.css";
 import "./onboarding/onboarding.css";
 import "./ride-import.css";
 import { createChatController } from "./chat/controller.js";
@@ -22,6 +23,8 @@ import { mountTrainingContextView } from "./training-context/view.js";
 import { createTrainingSyncCoordinator } from "./training-sync.js";
 import { createSpendMeterController } from "./spend-meter/controller.js";
 import { createSpendMeterView } from "./spend-meter/view.js";
+import { createReleaseNotesController } from "./release-notes/controller.js";
+import { createReleaseNotesView } from "./release-notes/view.js";
 import {
   createRideImportController,
   mountResidentRideImport,
@@ -63,6 +66,14 @@ window.addEventListener("enduragent-lifecycle", (event) => {
         : event.detail.status === "terminal"
           ? "Connection unavailable"
           : "Closing…";
+});
+const releaseNotesController = createReleaseNotesController({
+  request: () => window.enduragentAuth.releaseNotes(),
+  view: createReleaseNotesView({
+    document,
+    actionHost: topbarActions,
+    before: connectionStatus,
+  }),
 });
 
 const clients = createDesktopCoachClientProvider();
@@ -281,6 +292,7 @@ void clients.getClient().then(
 window.addEventListener(
   "pagehide",
   () => {
+    releaseNotesController.dispose();
     disposeDroppedRideImports();
     onboarding.dispose();
     residentRideImport.dispose();

--- a/apps/desktop-renderer/src/release-notes/controller.ts
+++ b/apps/desktop-renderer/src/release-notes/controller.ts
@@ -1,0 +1,85 @@
+export type ReleaseNotesResult =
+  | {
+      readonly status: "available";
+      readonly version: string;
+      readonly notes: readonly string[];
+      readonly releaseUrl: string;
+    }
+  | {
+      readonly status: "unavailable";
+      readonly version: string | null;
+      readonly releaseUrl: string;
+    };
+
+export interface ReleaseNotesView {
+  bind(handlers: {
+    readonly onOpen: () => void;
+    readonly onRetry: () => void;
+    readonly onClose: () => void;
+  }): void;
+  open(): void;
+  close(): void;
+  renderLoading(): void;
+  renderAvailable(result: Extract<ReleaseNotesResult, { readonly status: "available" }>): void;
+  renderUnavailable(input: {
+    readonly version: string | null;
+    readonly releaseUrl: string | null;
+  }): void;
+  dispose(): void;
+}
+
+export interface ReleaseNotesController {
+  activate(): Promise<void>;
+  dispose(): void;
+}
+
+export function createReleaseNotesController(input: {
+  readonly request: () => Promise<ReleaseNotesResult>;
+  readonly view: ReleaseNotesView;
+}): ReleaseNotesController {
+  let disposed = false;
+  let active: Promise<void> | undefined;
+
+  const activate = (): Promise<void> => {
+    if (disposed) return Promise.resolve();
+    input.view.open();
+    if (active !== undefined) return active;
+    input.view.renderLoading();
+    const pending = Promise.resolve()
+      .then(() => input.request())
+      .then(
+        (result) => {
+          if (disposed) return;
+          if (result.status === "available") input.view.renderAvailable(result);
+          else
+            input.view.renderUnavailable({
+              version: result.version,
+              releaseUrl: result.releaseUrl,
+            });
+        },
+        () => {
+          if (!disposed) input.view.renderUnavailable({ version: null, releaseUrl: null });
+        },
+      )
+      .finally(() => {
+        if (active === pending) active = undefined;
+      });
+    active = pending;
+    return pending;
+  };
+
+  input.view.bind({
+    onOpen: () => void activate(),
+    onRetry: () => void activate(),
+    onClose: () => input.view.close(),
+  });
+
+  return {
+    activate,
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      input.view.dispose();
+    },
+  };
+}

--- a/apps/desktop-renderer/src/release-notes/styles.css
+++ b/apps/desktop-renderer/src/release-notes/styles.css
@@ -1,0 +1,119 @@
+.release-notes-button {
+  min-height: 34px;
+  padding: 0 12px;
+  white-space: nowrap;
+  border: 1px solid var(--line-strong);
+  border-radius: 999px;
+  color: var(--moss-strong);
+  background: var(--surface-solid);
+  cursor: pointer;
+}
+
+.release-notes-dialog {
+  width: min(440px, calc(100vw - 32px));
+  max-width: none;
+  max-height: min(620px, calc(100vh - 32px));
+  padding: 22px;
+  overflow-y: auto;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius);
+  color: var(--ink);
+  background: var(--surface-solid);
+  box-shadow: 0 24px 70px color-mix(in srgb, var(--ink) 24%, transparent);
+}
+
+.release-notes-dialog::backdrop {
+  background: color-mix(in srgb, var(--ink) 35%, transparent);
+}
+
+.release-notes__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+}
+
+.release-notes__header h2,
+.release-notes__message {
+  margin: 0;
+}
+
+.release-notes__header h2 {
+  font-size: 20px;
+  line-height: 1.3;
+}
+
+.release-notes__close,
+.release-notes__retry,
+.release-notes__full-release {
+  min-height: 36px;
+  padding: 0 13px;
+  border: 1px solid var(--line-strong);
+  border-radius: 999px;
+  color: var(--ink);
+  background: var(--surface-solid);
+  cursor: pointer;
+}
+
+.release-notes__full-release {
+  display: inline-flex;
+  align-items: center;
+  text-decoration: none;
+}
+
+.release-notes__full-release:focus-visible {
+  outline: 3px solid var(--focus);
+  outline-offset: 2px;
+}
+
+.release-notes__full-release[hidden] {
+  display: none;
+}
+
+.release-notes__content {
+  margin-top: 18px;
+  overflow-wrap: anywhere;
+  color: var(--muted);
+  line-height: 1.55;
+}
+
+.release-notes__list {
+  display: grid;
+  gap: 10px;
+  margin: 0;
+  padding-left: 24px;
+}
+
+.release-notes__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-top: 22px;
+}
+
+.release-notes__retry:disabled {
+  cursor: default;
+  opacity: 0.5;
+}
+
+@media (max-width: 760px) {
+  .topbar-actions {
+    gap: 5px;
+  }
+
+  .release-notes-button {
+    width: 38px;
+    min-width: 38px;
+    padding: 0;
+    overflow: hidden;
+    font-size: 0;
+  }
+
+  .release-notes-button::before {
+    font-size: 10px;
+    font-weight: 750;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    content: "New";
+  }
+}

--- a/apps/desktop-renderer/src/release-notes/view.ts
+++ b/apps/desktop-renderer/src/release-notes/view.ts
@@ -1,0 +1,171 @@
+import type { ReleaseNotesView } from "./controller.js";
+
+const UNAVAILABLE_COPY =
+  "Release notes aren’t available right now. Check your connection and try again.";
+
+function element<K extends keyof HTMLElementTagNameMap>(
+  document: Document,
+  name: K,
+  className?: string,
+): HTMLElementTagNameMap[K] {
+  const value = document.createElement(name);
+  if (className !== undefined) value.className = className;
+  return value;
+}
+
+export function createReleaseNotesView(input: {
+  readonly document: Document;
+  readonly actionHost: HTMLElement;
+  readonly before?: Node | null;
+}): ReleaseNotesView {
+  const opener = element(input.document, "button", "release-notes-button");
+  opener.type = "button";
+  opener.textContent = "What’s new";
+  opener.title = "What’s new";
+  opener.setAttribute("aria-label", "What’s new");
+  opener.setAttribute("aria-haspopup", "dialog");
+  opener.setAttribute("aria-controls", "release-notes-dialog");
+  opener.setAttribute("aria-expanded", "false");
+
+  const dialog = element(input.document, "dialog", "release-notes-dialog");
+  dialog.id = "release-notes-dialog";
+  dialog.setAttribute("aria-labelledby", "release-notes-title");
+  dialog.setAttribute("aria-modal", "true");
+
+  const header = element(input.document, "header", "release-notes__header");
+  const title = element(input.document, "h2");
+  title.id = "release-notes-title";
+  title.textContent = "What’s new";
+  const close = element(input.document, "button", "release-notes__close");
+  close.type = "button";
+  close.setAttribute("aria-label", "Close release notes");
+  close.textContent = "Close";
+  header.append(title, close);
+
+  const content = element(input.document, "div", "release-notes__content");
+  content.setAttribute("role", "status");
+  content.setAttribute("aria-live", "polite");
+  content.setAttribute("aria-atomic", "true");
+
+  const actions = element(input.document, "footer", "release-notes__actions");
+  const retry = element(input.document, "button", "release-notes__retry");
+  retry.type = "button";
+  retry.textContent = "Retry";
+  retry.hidden = true;
+  const fullRelease = element(input.document, "a", "release-notes__full-release");
+  fullRelease.textContent = "View full release";
+  fullRelease.target = "_blank";
+  fullRelease.rel = "noopener noreferrer";
+  fullRelease.hidden = true;
+  actions.append(retry, fullRelease);
+  dialog.append(header, content, actions);
+
+  input.actionHost.insertBefore(opener, input.before ?? null);
+  input.document.body.append(dialog);
+
+  let disposed = false;
+  let handlers:
+    | {
+        readonly onOpen: () => void;
+        readonly onRetry: () => void;
+        readonly onClose: () => void;
+      }
+    | undefined;
+
+  const onOpen = (): void => {
+    if (!disposed) handlers?.onOpen();
+  };
+  const onRetry = (): void => {
+    if (!disposed && !retry.disabled) handlers?.onRetry();
+  };
+  const onClose = (): void => {
+    if (!disposed) handlers?.onClose();
+  };
+  const onCancel = (event: Event): void => {
+    event.preventDefault();
+    onClose();
+  };
+  opener.addEventListener("click", onOpen);
+  retry.addEventListener("click", onRetry);
+  close.addEventListener("click", onClose);
+  dialog.addEventListener("cancel", onCancel);
+
+  const setFullRelease = (releaseUrl: string | null): void => {
+    fullRelease.hidden = releaseUrl === null;
+    if (releaseUrl === null) fullRelease.removeAttribute("href");
+    else fullRelease.href = releaseUrl;
+  };
+
+  return {
+    bind(nextHandlers) {
+      handlers = nextHandlers;
+    },
+    open() {
+      if (disposed || dialog.open) return;
+      dialog.showModal();
+      opener.setAttribute("aria-expanded", "true");
+      close.focus();
+    },
+    close() {
+      if (disposed) return;
+      if (dialog.open) dialog.close();
+      opener.setAttribute("aria-expanded", "false");
+      opener.focus();
+    },
+    renderLoading() {
+      if (disposed) return;
+      dialog.setAttribute("aria-busy", "true");
+      title.textContent = "What’s new";
+      const loading = element(input.document, "p", "release-notes__message");
+      loading.textContent = "Loading release notes…";
+      content.replaceChildren(loading);
+      retry.hidden = true;
+      retry.disabled = true;
+      setFullRelease(null);
+    },
+    renderAvailable(result) {
+      if (disposed) return;
+      dialog.removeAttribute("aria-busy");
+      title.textContent = `What’s new in ${result.version}`;
+      if (result.notes.length === 0) {
+        const empty = element(input.document, "p", "release-notes__message");
+        empty.textContent = "No athlete-facing changes were listed for this release.";
+        content.replaceChildren(empty);
+      } else {
+        const list = element(input.document, "ol", "release-notes__list");
+        for (const note of result.notes) {
+          const item = element(input.document, "li");
+          item.textContent = note;
+          list.append(item);
+        }
+        content.replaceChildren(list);
+      }
+      retry.hidden = true;
+      retry.disabled = true;
+      setFullRelease(result.releaseUrl);
+    },
+    renderUnavailable({ releaseUrl }) {
+      if (disposed) return;
+      dialog.removeAttribute("aria-busy");
+      title.textContent = "What’s new";
+      const message = element(input.document, "p", "release-notes__message");
+      message.textContent = UNAVAILABLE_COPY;
+      content.replaceChildren(message);
+      retry.hidden = false;
+      retry.disabled = false;
+      setFullRelease(releaseUrl);
+    },
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      handlers = undefined;
+      opener.removeEventListener("click", onOpen);
+      retry.removeEventListener("click", onRetry);
+      close.removeEventListener("click", onClose);
+      dialog.removeEventListener("cancel", onCancel);
+      if (dialog.open) dialog.close();
+      opener.remove();
+      dialog.remove();
+    },
+  };
+}

--- a/apps/desktop-renderer/tests/release-notes.test.ts
+++ b/apps/desktop-renderer/tests/release-notes.test.ts
@@ -1,0 +1,387 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createReleaseNotesController,
+  type ReleaseNotesResult,
+  type ReleaseNotesView,
+} from "../src/release-notes/controller.js";
+import { createReleaseNotesView } from "../src/release-notes/view.js";
+
+interface Deferred<T> {
+  readonly promise: Promise<T>;
+  resolve(value: T): void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+function available(overrides: Partial<Extract<ReleaseNotesResult, { status: "available" }>> = {}) {
+  return {
+    status: "available",
+    version: "2026.7.23",
+    notes: ["Improved Desktop reliability."],
+    releaseUrl: "https://github.com/yerzhansa/cycling-coach/releases/tag/cycling-coach@2026.7.23",
+    ...overrides,
+  } as const;
+}
+
+function fakeView() {
+  let handlers:
+    | {
+        readonly onOpen: () => void;
+        readonly onRetry: () => void;
+        readonly onClose: () => void;
+      }
+    | undefined;
+  const view: ReleaseNotesView = {
+    bind: vi.fn((value) => {
+      handlers = value;
+    }),
+    open: vi.fn(),
+    close: vi.fn(),
+    renderLoading: vi.fn(),
+    renderAvailable: vi.fn(),
+    renderUnavailable: vi.fn(),
+    dispose: vi.fn(),
+  };
+  return {
+    view,
+    open: () => handlers?.onOpen(),
+    retry: () => handlers?.onRetry(),
+    close: () => handlers?.onClose(),
+  };
+}
+
+describe("release notes controller", () => {
+  it("does no startup work, coalesces an active request, and fetches fresh after settlement", async () => {
+    const first = deferred<ReleaseNotesResult>();
+    const request = vi
+      .fn<() => Promise<ReleaseNotesResult>>()
+      .mockReturnValueOnce(first.promise)
+      .mockResolvedValueOnce(available({ version: "2026.7.24" }));
+    const subject = fakeView();
+    const controller = createReleaseNotesController({ request, view: subject.view });
+
+    expect(request).not.toHaveBeenCalled();
+    const one = controller.activate();
+    const two = controller.activate();
+    expect(one).toBe(two);
+    await Promise.resolve();
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(subject.view.open).toHaveBeenCalledTimes(2);
+    expect(subject.view.renderLoading).toHaveBeenCalledOnce();
+
+    first.resolve(available());
+    await one;
+    expect(subject.view.renderAvailable).toHaveBeenCalledWith(available());
+
+    await controller.activate();
+    expect(request).toHaveBeenCalledTimes(2);
+    expect(subject.view.renderLoading).toHaveBeenCalledTimes(2);
+    expect(subject.view.renderAvailable).toHaveBeenLastCalledWith(
+      available({ version: "2026.7.24" }),
+    );
+  });
+
+  it("renders typed and rejected unavailability without exposing raw errors, then retries", async () => {
+    const rawError = new Error("private network detail");
+    const request = vi
+      .fn<() => Promise<ReleaseNotesResult>>()
+      .mockResolvedValueOnce({
+        status: "unavailable",
+        version: "2026.7.23",
+        releaseUrl: "https://github.com/yerzhansa/cycling-coach/releases",
+      })
+      .mockRejectedValueOnce(rawError);
+    const subject = fakeView();
+    createReleaseNotesController({ request, view: subject.view });
+
+    subject.open();
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() =>
+      expect(subject.view.renderUnavailable).toHaveBeenLastCalledWith({
+        version: "2026.7.23",
+        releaseUrl: "https://github.com/yerzhansa/cycling-coach/releases",
+      }),
+    );
+    subject.retry();
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() =>
+      expect(subject.view.renderUnavailable).toHaveBeenLastCalledWith({
+        version: null,
+        releaseUrl: null,
+      }),
+    );
+    expect(JSON.stringify(vi.mocked(subject.view.renderUnavailable).mock.calls)).not.toContain(
+      rawError.message,
+    );
+  });
+
+  it("ignores late settlement and disposes the view exactly once", async () => {
+    const gate = deferred<ReleaseNotesResult>();
+    const subject = fakeView();
+    const controller = createReleaseNotesController({
+      request: vi.fn(() => gate.promise),
+      view: subject.view,
+    });
+
+    const pending = controller.activate();
+    await Promise.resolve();
+    controller.dispose();
+    controller.dispose();
+    gate.resolve(available());
+    await pending;
+
+    expect(subject.view.renderAvailable).not.toHaveBeenCalled();
+    expect(subject.view.renderUnavailable).not.toHaveBeenCalled();
+    expect(subject.view.dispose).toHaveBeenCalledOnce();
+    await controller.activate();
+    expect(subject.view.open).toHaveBeenCalledOnce();
+  });
+});
+
+class FakeElement {
+  readonly children: FakeElement[] = [];
+  readonly attributes = new Map<string, string>();
+  readonly listeners = new Map<string, Set<(event: Event) => void>>();
+  parent: FakeElement | undefined;
+  className = "";
+  disabled = false;
+  hidden = false;
+  open = false;
+  id = "";
+  type = "";
+  href = "";
+  target = "";
+  rel = "";
+  value = "";
+  private ownText = "";
+
+  constructor(
+    readonly tagName: string,
+    private readonly ownerDocument: FakeDocument,
+  ) {}
+
+  get textContent(): string {
+    return this.ownText + this.children.map((child) => child.textContent).join("");
+  }
+
+  set textContent(value: string) {
+    this.ownText = value;
+    this.children.splice(0);
+  }
+
+  append(...nodes: FakeElement[]): void {
+    for (const node of nodes) {
+      node.remove();
+      node.parent = this;
+      this.children.push(node);
+    }
+  }
+
+  insertBefore(node: FakeElement, before: FakeElement | null): void {
+    node.remove();
+    node.parent = this;
+    const index = before === null ? -1 : this.children.indexOf(before);
+    if (index < 0) this.children.push(node);
+    else this.children.splice(index, 0, node);
+  }
+
+  replaceChildren(...nodes: FakeElement[]): void {
+    for (const child of this.children) child.parent = undefined;
+    this.children.splice(0);
+    this.ownText = "";
+    this.append(...nodes);
+  }
+
+  setAttribute(name: string, value: string): void {
+    this.attributes.set(name, value);
+  }
+
+  removeAttribute(name: string): void {
+    this.attributes.delete(name);
+    if (name === "href") this.href = "";
+  }
+
+  addEventListener(name: string, listener: (event: Event) => void): void {
+    const listeners = this.listeners.get(name) ?? new Set();
+    listeners.add(listener);
+    this.listeners.set(name, listeners);
+  }
+
+  removeEventListener(name: string, listener: (event: Event) => void): void {
+    this.listeners.get(name)?.delete(listener);
+  }
+
+  click(): void {
+    if (this.disabled) return;
+    this.dispatch("click");
+  }
+
+  dispatch(name: string, event: Event = { preventDefault() {} } as Event): void {
+    for (const listener of this.listeners.get(name) ?? []) listener(event);
+  }
+
+  showModal(): void {
+    this.open = true;
+  }
+
+  close(): void {
+    this.open = false;
+  }
+
+  focus(): void {
+    this.ownerDocument.activeElement = this;
+  }
+
+  remove(): void {
+    if (this.parent === undefined) return;
+    const index = this.parent.children.indexOf(this);
+    if (index >= 0) this.parent.children.splice(index, 1);
+    this.parent = undefined;
+  }
+}
+
+class FakeDocument {
+  readonly body = new FakeElement("body", this);
+  activeElement: FakeElement | null = this.body;
+
+  createElement(name: string): FakeElement {
+    return new FakeElement(name, this);
+  }
+}
+
+function find(root: FakeElement, predicate: (value: FakeElement) => boolean): FakeElement {
+  if (predicate(root)) return root;
+  for (const child of root.children) {
+    try {
+      return find(child, predicate);
+    } catch {}
+  }
+  throw new Error("not found");
+}
+
+function findAll(root: FakeElement, predicate: (value: FakeElement) => boolean): FakeElement[] {
+  return [
+    ...(predicate(root) ? [root] : []),
+    ...root.children.flatMap((child) => findAll(child, predicate)),
+  ];
+}
+
+function mountedView() {
+  const document = new FakeDocument();
+  const actionHost = document.createElement("nav");
+  document.body.append(actionHost);
+  const view = createReleaseNotesView({
+    document: document as never,
+    actionHost: actionHost as never,
+  });
+  return { document, actionHost, view };
+}
+
+describe("release notes view", () => {
+  it("renders available and empty notes as literal text with only the fixed full-release link", () => {
+    const { document, view } = mountedView();
+    const hostile = `<img src=x onerror="steal()"> [click](javascript:steal())`;
+    const releaseUrl =
+      "https://github.com/yerzhansa/cycling-coach/releases/tag/cycling-coach@2026.7.23";
+
+    view.open();
+    view.renderAvailable(available({ notes: [hostile], releaseUrl }));
+
+    const dialog = find(document.body, (node) => node.tagName === "dialog");
+    expect(dialog.open).toBe(true);
+    expect(find(dialog, (node) => node.tagName === "h2").textContent).toBe(
+      "What’s new in 2026.7.23",
+    );
+    const items = findAll(dialog, (node) => node.tagName === "li");
+    expect(items).toHaveLength(1);
+    expect(items[0]?.textContent).toBe(hostile);
+    expect(items[0]?.children).toHaveLength(0);
+    const anchors = findAll(dialog, (node) => node.tagName === "a");
+    expect(anchors).toHaveLength(1);
+    expect(anchors[0]).toMatchObject({
+      textContent: "View full release",
+      href: releaseUrl,
+      target: "_blank",
+      rel: "noopener noreferrer",
+      hidden: false,
+    });
+
+    view.renderAvailable(available({ notes: [] }));
+    expect(dialog.textContent).toContain("No athlete-facing changes were listed for this release.");
+    expect(findAll(dialog, (node) => node.tagName === "li")).toHaveLength(0);
+  });
+
+  it("shows fixed offline copy, exposes Retry, and never changes the draft or transcript", () => {
+    const document = new FakeDocument();
+    const transcript = document.createElement("section");
+    transcript.className = "chat-transcript";
+    transcript.textContent = "Existing coach transcript";
+    const draft = document.createElement("textarea");
+    draft.value = "Keep this draft";
+    const actionHost = document.createElement("nav");
+    document.body.append(transcript, draft, actionHost);
+    const view = createReleaseNotesView({
+      document: document as never,
+      actionHost: actionHost as never,
+    });
+    const retryHandler = vi.fn();
+    view.bind({ onOpen: vi.fn(), onRetry: retryHandler, onClose: vi.fn() });
+
+    view.open();
+    view.renderUnavailable({
+      version: null,
+      releaseUrl: "https://github.com/yerzhansa/cycling-coach/releases",
+    });
+    const dialog = find(document.body, (node) => node.tagName === "dialog");
+    expect(dialog.textContent).toContain(
+      "Release notes aren’t available right now. Check your connection and try again.",
+    );
+    const retry = find(dialog, (node) => node.className === "release-notes__retry");
+    expect(retry.hidden).toBe(false);
+    retry.click();
+    expect(retryHandler).toHaveBeenCalledOnce();
+    expect(draft.value).toBe("Keep this draft");
+    expect(transcript.textContent).toBe("Existing coach transcript");
+  });
+
+  it("supports the native cancel path, restores opener focus, and removes listeners on dispose", () => {
+    const { document, actionHost, view } = mountedView();
+    const opener = find(actionHost, (node) => node.className === "release-notes-button");
+    const dialog = find(document.body, (node) => node.tagName === "dialog");
+    view.bind({
+      onOpen() {
+        view.open();
+        view.renderLoading();
+      },
+      onRetry: vi.fn(),
+      onClose() {
+        view.close();
+      },
+    });
+
+    opener.click();
+    expect(dialog.open).toBe(true);
+    expect(opener.attributes.get("aria-expanded")).toBe("true");
+    expect(document.activeElement?.className).toBe("release-notes__close");
+    const preventDefault = vi.fn();
+    dialog.dispatch("cancel", { preventDefault } as unknown as Event);
+    expect(preventDefault).toHaveBeenCalledOnce();
+    expect(dialog.open).toBe(false);
+    expect(document.activeElement).toBe(opener);
+    expect(opener.attributes.get("aria-expanded")).toBe("false");
+
+    view.dispose();
+    view.dispose();
+    opener.click();
+    expect(actionHost.children).not.toContain(opener);
+    expect(document.body.children).not.toContain(dialog);
+    expect(dialog.listeners.get("cancel")?.size).toBe(0);
+    expect(opener.listeners.get("click")?.size).toBe(0);
+  });
+});

--- a/apps/desktop/scripts/electron-smoke.mjs
+++ b/apps/desktop/scripts/electron-smoke.mjs
@@ -279,6 +279,7 @@ async function security() {
             "credentialStatuses",
             "getDaemonConnection",
             "onDroppedImportFiles",
+            "releaseNotes",
             "retryFailedCredentials",
             "writeCredential",
           ]),

--- a/apps/desktop/src/main/constants.ts
+++ b/apps/desktop/src/main/constants.ts
@@ -3,6 +3,7 @@ export const DESKTOP_HOST = "app" as const;
 export const DESKTOP_RENDERER_ORIGIN = "enduragent://app" as const;
 export const DESKTOP_RENDERER_URL = "enduragent://app/index.html" as const;
 export const DESKTOP_CONNECTION_CHANNEL = "desktop:get-daemon-connection" as const;
+export const DESKTOP_RELEASE_NOTES_CHANNEL = "desktop:get-release-notes" as const;
 export const DESKTOP_LIFECYCLE_CHANNEL = "desktop:daemon-lifecycle" as const;
 export const DESKTOP_OPEN_EXTERNAL_CHANNEL = "desktop:open-external" as const;
 export const DESKTOP_WINDOW_WIDTH = 1_180 as const;

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -47,6 +47,7 @@ import {
   unexpectedStartupCopy,
 } from "./lifecycle-messages.js";
 import { registerOnboardingIpc, runtimeConfigurationForCredential } from "./onboarding-ipc.js";
+import { installDesktopReleaseNotesIpc } from "./release-notes-ipc.js";
 import { createDesktopResidency, type DesktopResidency } from "./residency.js";
 import {
   createDesktopRendererConsoleCapture,
@@ -121,6 +122,7 @@ async function runDesktop(): Promise<void> {
   let protocolInstalled = false;
   let disposeConnectionIpc: (() => void) | undefined;
   let disposeExternalLinkIpc: (() => void) | undefined;
+  let disposeReleaseNotesIpc: (() => void) | undefined;
   let disposeOnboarding: (() => void) | undefined;
   let daemonLifecycle: DesktopDaemonLifecycle | undefined;
   let shutdownPromise: Promise<void> | undefined;
@@ -131,6 +133,8 @@ async function runDesktop(): Promise<void> {
       disposeConnectionIpc = undefined;
       disposeExternalLinkIpc?.();
       disposeExternalLinkIpc = undefined;
+      disposeReleaseNotesIpc?.();
+      disposeReleaseNotesIpc = undefined;
       disposeOnboarding?.();
       disposeOnboarding = undefined;
       if (protocolInstalled) {
@@ -451,6 +455,10 @@ async function runDesktop(): Promise<void> {
       ipcMain,
       currentWindow: () => mainWindow.current() ?? undefined,
       openExternal: (url) => shell.openExternal(url),
+    });
+    disposeReleaseNotesIpc = installDesktopReleaseNotesIpc({
+      ipcMain,
+      currentWindow: () => mainWindow.current() ?? undefined,
     });
     residency = createDesktopResidency({
       app,

--- a/apps/desktop/src/main/release-notes-ipc.ts
+++ b/apps/desktop/src/main/release-notes-ipc.ts
@@ -1,0 +1,80 @@
+import { fetchLatestReleaseNotes, type ReleaseNotesResult } from "@enduragent/core";
+import type { BrowserWindow, IpcMain, IpcMainInvokeEvent } from "electron";
+import { DESKTOP_RELEASE_NOTES_CHANNEL } from "./constants.js";
+import { isTrustedConnectionRequest } from "./security.js";
+
+const RELEASE_NOTES_REPO = Object.freeze({
+  owner: "yerzhansa",
+  name: "cycling-coach",
+});
+const RELEASES_URL = "https://github.com/yerzhansa/cycling-coach/releases";
+
+function unavailableReleaseNotes(): ReleaseNotesResult {
+  return {
+    status: "unavailable",
+    version: null,
+    releaseUrl: RELEASES_URL,
+  };
+}
+
+export function installDesktopReleaseNotesIpc(input: {
+  readonly ipcMain: Pick<IpcMain, "handle" | "removeHandler">;
+  readonly currentWindow: () => BrowserWindow | undefined;
+  readonly loadReleaseNotes?: typeof fetchLatestReleaseNotes;
+}): () => void {
+  const loadReleaseNotes = input.loadReleaseNotes ?? fetchLatestReleaseNotes;
+  let inFlight: Promise<ReleaseNotesResult> | undefined;
+
+  const performLoad = async (): Promise<ReleaseNotesResult> => {
+    try {
+      const result = await loadReleaseNotes("cycling-coach", RELEASE_NOTES_REPO);
+      if (result.status === "available") {
+        return {
+          status: "available",
+          version: result.version,
+          notes: [...result.notes],
+          releaseUrl: result.releaseUrl,
+        };
+      }
+      if (result.status === "unavailable") {
+        return {
+          status: "unavailable",
+          version: result.version,
+          releaseUrl: result.releaseUrl,
+        };
+      }
+      return unavailableReleaseNotes();
+    } catch {
+      return unavailableReleaseNotes();
+    }
+  };
+
+  const onReleaseNotes = (
+    event: IpcMainInvokeEvent,
+    ...args: unknown[]
+  ): Promise<ReleaseNotesResult> => {
+    if (!isTrustedConnectionRequest(event, input.currentWindow())) {
+      throw new Error("untrusted desktop release notes request");
+    }
+    if (args.length !== 0) {
+      throw new TypeError("invalid desktop release notes request");
+    }
+    if (inFlight !== undefined) return inFlight;
+
+    const pending = performLoad();
+    inFlight = pending;
+    const clear = (): void => {
+      if (inFlight === pending) inFlight = undefined;
+    };
+    void pending.then(clear, clear);
+    return pending;
+  };
+
+  input.ipcMain.handle(DESKTOP_RELEASE_NOTES_CHANNEL, onReleaseNotes);
+  let installed = true;
+  return () => {
+    if (!installed) return;
+    installed = false;
+    input.ipcMain.removeHandler(DESKTOP_RELEASE_NOTES_CHANNEL);
+  };
+}

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -3,6 +3,7 @@ import {
   DESKTOP_CONNECTION_CHANNEL,
   DESKTOP_LIFECYCLE_CHANNEL,
   DESKTOP_OPEN_EXTERNAL_CHANNEL,
+  DESKTOP_RELEASE_NOTES_CHANNEL,
 } from "../main/constants.js";
 
 const DESKTOP_CREDENTIAL_STATUS_CHANNEL = "enduragent:onboarding:credential-status";
@@ -44,6 +45,11 @@ const CHATGPT_REASONS = new Set([
   "runtime-unavailable",
 ]);
 const IMPORT_EXTENSIONS = new Set([".fit", ".tcx", ".gpx"]);
+const RELEASES_URL = "https://github.com/yerzhansa/cycling-coach/releases";
+const RELEASE_NOTES_MAX_TOTAL_BYTES = 64 * 1024;
+const RELEASE_VERSION_RE =
+  /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+const textEncoder = new TextEncoder();
 
 function record(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -51,6 +57,76 @@ function record(value: unknown): value is Record<string, unknown> {
 
 function exactKeys(value: Record<string, unknown>, keys: readonly string[]): boolean {
   return JSON.stringify(Object.keys(value).sort()) === JSON.stringify([...keys].sort());
+}
+
+function safeString(value: unknown, maximumLength: number): value is string {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.length > maximumLength ||
+    value.trim() !== value
+  ) {
+    return false;
+  }
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code <= 0x1f || code === 0x7f) return false;
+  }
+  return true;
+}
+
+function releaseVersion(value: unknown): value is string {
+  return safeString(value, 64) && RELEASE_VERSION_RE.test(value);
+}
+
+function releaseTagUrl(version: string): string {
+  return `${RELEASES_URL}/tag/cycling-coach@${encodeURIComponent(version)}`;
+}
+
+function parseReleaseNotes(value: unknown): unknown {
+  if (!record(value) || (value.status !== "available" && value.status !== "unavailable")) {
+    throw new TypeError();
+  }
+  if (value.status === "unavailable") {
+    if (
+      !exactKeys(value, ["status", "version", "releaseUrl"]) ||
+      (value.version !== null && !releaseVersion(value.version)) ||
+      typeof value.releaseUrl !== "string" ||
+      value.releaseUrl.length > 2_048 ||
+      value.releaseUrl !== (value.version === null ? RELEASES_URL : releaseTagUrl(value.version))
+    ) {
+      throw new TypeError();
+    }
+    return {
+      status: "unavailable",
+      version: value.version,
+      releaseUrl: value.releaseUrl,
+    };
+  }
+  if (
+    !exactKeys(value, ["status", "version", "notes", "releaseUrl"]) ||
+    !releaseVersion(value.version) ||
+    !Array.isArray(value.notes) ||
+    value.notes.length > 100 ||
+    typeof value.releaseUrl !== "string" ||
+    value.releaseUrl.length > 2_048 ||
+    value.releaseUrl !== releaseTagUrl(value.version)
+  ) {
+    throw new TypeError();
+  }
+  let totalBytes = 0;
+  const notes = value.notes.map((note) => {
+    if (!safeString(note, 2_000)) throw new TypeError();
+    totalBytes += textEncoder.encode(note).byteLength;
+    if (totalBytes > RELEASE_NOTES_MAX_TOTAL_BYTES) throw new TypeError();
+    return note;
+  });
+  return {
+    status: "available",
+    version: value.version,
+    notes,
+    releaseUrl: value.releaseUrl,
+  };
 }
 
 function parseStatuses(value: unknown): unknown {
@@ -221,6 +297,8 @@ contextBridge.exposeInMainWorld(
       parseChatGptLogin(await ipcRenderer.invoke(DESKTOP_CHATGPT_LOGIN_CHANNEL)),
     chooseImportFiles: async () =>
       parsePaths(await ipcRenderer.invoke(DESKTOP_CHOOSE_IMPORT_FILES_CHANNEL)),
+    releaseNotes: async () =>
+      parseReleaseNotes(await ipcRenderer.invoke(DESKTOP_RELEASE_NOTES_CHANNEL)),
     onDroppedImportFiles: (listener: unknown) => {
       if (typeof listener !== "function" || dropDisposer !== undefined) throw new TypeError();
       const onDrop = (event: DragEvent): void => {

--- a/apps/desktop/tests/preload-auth.test.ts
+++ b/apps/desktop/tests/preload-auth.test.ts
@@ -41,6 +41,7 @@ interface AuthBridge {
   getDaemonConnection(failedGeneration?: number): Promise<unknown>;
   credentialStatuses(): Promise<unknown>;
   retryFailedCredentials(): Promise<unknown>;
+  releaseNotes(): Promise<unknown>;
   chatgptStatus(): Promise<unknown>;
   chatgptLogin(): Promise<unknown>;
 }
@@ -99,10 +100,170 @@ describe("desktop preload ChatGPT auth", () => {
       "credentialStatuses",
       "getDaemonConnection",
       "onDroppedImportFiles",
+      "releaseNotes",
       "retryFailedCredentials",
       "writeCredential",
     ]);
     expect(bridge).not.toHaveProperty("openExternal");
+  });
+
+  it("returns closed copied release note results from the zero-argument channel", async () => {
+    const notes = ["Added release notes to the desktop."];
+    const available = {
+      status: "available",
+      version: "2026.7.23",
+      notes,
+      releaseUrl: "https://github.com/yerzhansa/cycling-coach/releases/tag/cycling-coach@2026.7.23",
+    };
+    mocks.invoke.mockResolvedValueOnce(available).mockResolvedValueOnce({
+      status: "unavailable",
+      version: null,
+      releaseUrl: "https://github.com/yerzhansa/cycling-coach/releases",
+    });
+
+    const availableCopy = (await bridge.releaseNotes()) as typeof available;
+    expect(availableCopy).toEqual(available);
+    expect(availableCopy).not.toBe(available);
+    expect(availableCopy.notes).not.toBe(notes);
+    await expect(bridge.releaseNotes()).resolves.toEqual({
+      status: "unavailable",
+      version: null,
+      releaseUrl: "https://github.com/yerzhansa/cycling-coach/releases",
+    });
+    expect(mocks.invoke.mock.calls).toEqual([
+      ["desktop:get-release-notes"],
+      ["desktop:get-release-notes"],
+    ]);
+  });
+
+  it("accepts a known unavailable version with only a canonical tag URL", async () => {
+    mocks.invoke.mockResolvedValueOnce({
+      status: "unavailable",
+      version: "2026.7.23",
+      releaseUrl: "https://github.com/yerzhansa/cycling-coach/releases/tag/cycling-coach@2026.7.23",
+    });
+
+    await expect(bridge.releaseNotes()).resolves.toEqual({
+      status: "unavailable",
+      version: "2026.7.23",
+      releaseUrl: "https://github.com/yerzhansa/cycling-coach/releases/tag/cycling-coach@2026.7.23",
+    });
+  });
+
+  it("rejects malformed release note unions, strings, counts, and totals", async () => {
+    const tagUrl =
+      "https://github.com/yerzhansa/cycling-coach/releases/tag/cycling-coach@2026.7.23";
+    const malformed = [
+      null,
+      {
+        status: "available",
+        version: "2026.7.23",
+        notes: [],
+        releaseUrl: tagUrl,
+        extra: true,
+      },
+      {
+        status: "unavailable",
+        version: null,
+        notes: [],
+        releaseUrl: "https://github.com/yerzhansa/cycling-coach/releases",
+      },
+      {
+        status: "available",
+        version: `v${"1".repeat(64)}`,
+        notes: [],
+        releaseUrl: tagUrl,
+      },
+      {
+        status: "available",
+        version: " 2026.7.23",
+        notes: [],
+        releaseUrl: tagUrl,
+      },
+      {
+        status: "available",
+        version: "latest",
+        notes: [],
+        releaseUrl: tagUrl,
+      },
+      {
+        status: "available",
+        version: "2026.7.23",
+        notes: ["unsafe\u0000note"],
+        releaseUrl: tagUrl,
+      },
+      {
+        status: "available",
+        version: "2026.7.23",
+        notes: Array.from({ length: 101 }, () => "note"),
+        releaseUrl: tagUrl,
+      },
+      {
+        status: "available",
+        version: "2026.7.23",
+        notes: ["x".repeat(2_001)],
+        releaseUrl: tagUrl,
+      },
+      {
+        status: "available",
+        version: "2026.7.23",
+        notes: Array.from({ length: 33 }, () => "x".repeat(2_000)),
+        releaseUrl: tagUrl,
+      },
+    ];
+
+    for (const value of malformed) {
+      mocks.invoke.mockResolvedValueOnce(value);
+      await expect(bridge.releaseNotes()).rejects.toBeInstanceOf(TypeError);
+    }
+  });
+
+  it("requires release URLs to match the result version exactly", async () => {
+    const values = [
+      {
+        status: "available",
+        version: "2026.7.23",
+        notes: [],
+        releaseUrl:
+          "https://github.com/yerzhansa/cycling-coach/releases/tag/cycling-coach@2026.7.22",
+      },
+      {
+        status: "unavailable",
+        version: "2026.7.23",
+        releaseUrl: "https://github.com/yerzhansa/cycling-coach/releases",
+      },
+      {
+        status: "unavailable",
+        version: null,
+        releaseUrl:
+          "https://github.com/yerzhansa/cycling-coach/releases/tag/cycling-coach@2026.7.23",
+      },
+    ];
+
+    for (const value of values) {
+      mocks.invoke.mockResolvedValueOnce(value);
+      await expect(bridge.releaseNotes()).rejects.toBeInstanceOf(TypeError);
+    }
+  });
+
+  it.each([
+    "http://github.com/yerzhansa/cycling-coach/releases/tag/cycling-coach@2026.7.23",
+    "https://user:secret@github.com/yerzhansa/cycling-coach/releases/tag/cycling-coach@2026.7.23",
+    "https://github.com:444/yerzhansa/cycling-coach/releases/tag/cycling-coach@2026.7.23",
+    "https://github.com/other/cycling-coach/releases/tag/cycling-coach@2026.7.23",
+    "https://github.com/yerzhansa/cycling-coach/releases/latest",
+    "https://github.com/yerzhansa/cycling-coach/releases/tag/",
+    "https://github.com/yerzhansa/cycling-coach/releases/tag/cycling-coach@2026.7.23?token=secret",
+    "https://github.com/yerzhansa/cycling-coach/releases/tag/cycling-coach@2026.7.23#notes",
+  ])("rejects a noncanonical or out-of-repository release URL: %s", async (releaseUrl) => {
+    mocks.invoke.mockResolvedValueOnce({
+      status: "available",
+      version: "2026.7.23",
+      notes: [],
+      releaseUrl,
+    });
+
+    await expect(bridge.releaseNotes()).rejects.toBeInstanceOf(TypeError);
   });
 
   it("sends a nested trusted target-blank anchor activation over the private channel", () => {

--- a/apps/desktop/tests/release-notes-ipc.test.ts
+++ b/apps/desktop/tests/release-notes-ipc.test.ts
@@ -1,0 +1,179 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const coreMocks = vi.hoisted(() => ({
+  fetchLatestReleaseNotes: vi.fn(),
+}));
+
+vi.mock("electron", () => ({
+  BrowserWindow: class {},
+  net: { fetch: vi.fn() },
+  protocol: { registerSchemesAsPrivileged: vi.fn() },
+}));
+vi.mock("@enduragent/core", () => ({
+  fetchLatestReleaseNotes: coreMocks.fetchLatestReleaseNotes,
+}));
+
+import { DESKTOP_RELEASE_NOTES_CHANNEL, DESKTOP_RENDERER_URL } from "../src/main/constants.js";
+import { installDesktopReleaseNotesIpc } from "../src/main/release-notes-ipc.js";
+
+type Handler = (event: unknown, ...args: unknown[]) => Promise<unknown>;
+type LoadReleaseNotes = (...args: unknown[]) => Promise<unknown>;
+
+const availableResult = {
+  status: "available",
+  version: "2026.7.23",
+  notes: ["Added release notes to the desktop."],
+  releaseUrl: "https://github.com/yerzhansa/cycling-coach/releases/tag/cycling-coach@2026.7.23",
+} as const;
+
+function setup(loadReleaseNotes: LoadReleaseNotes = vi.fn(async () => availableResult)) {
+  const handlers = new Map<string, Handler>();
+  const ipcMain = {
+    handle: vi.fn((channel: string, handler: Handler) => handlers.set(channel, handler)),
+    removeHandler: vi.fn((channel: string) => handlers.delete(channel)),
+  };
+  const mainFrame: { url: string } = { url: DESKTOP_RENDERER_URL };
+  const webContents = { isDestroyed: () => false, mainFrame };
+  const window = { isDestroyed: () => false, webContents };
+  let currentWindow: typeof window | undefined = window;
+  const dispose = installDesktopReleaseNotesIpc({
+    ipcMain: ipcMain as never,
+    currentWindow: () => currentWindow as never,
+    loadReleaseNotes: loadReleaseNotes as never,
+  });
+  return {
+    dispose,
+    handlers,
+    ipcMain,
+    loadReleaseNotes,
+    mainFrame,
+    setCurrentWindow(value: typeof window | undefined) {
+      currentWindow = value;
+    },
+    trusted: { sender: webContents, senderFrame: mainFrame },
+    webContents,
+    window,
+  };
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("desktop release notes IPC", () => {
+  it("loads the fixed binary and repository for a trusted zero-argument request", async () => {
+    const state = setup();
+    const releaseNotes = state.handlers.get(DESKTOP_RELEASE_NOTES_CHANNEL)!;
+
+    await expect(releaseNotes(state.trusted)).resolves.toEqual(availableResult);
+    expect(state.loadReleaseNotes).toHaveBeenCalledOnce();
+    expect(state.loadReleaseNotes).toHaveBeenCalledWith("cycling-coach", {
+      owner: "yerzhansa",
+      name: "cycling-coach",
+    });
+  });
+
+  it("returns a closed copy of an available result", async () => {
+    const notes = ["First athlete-facing change."];
+    const loadReleaseNotes = vi.fn(async () => ({
+      status: "available" as const,
+      version: "2026.7.23",
+      notes,
+      releaseUrl: "https://github.com/yerzhansa/cycling-coach/releases/tag/cycling-coach@2026.7.23",
+      internalFeedUrl: "https://example.invalid/private-feed",
+    }));
+    const state = setup(loadReleaseNotes);
+
+    const result = (await state.handlers.get(DESKTOP_RELEASE_NOTES_CHANNEL)!(state.trusted)) as {
+      readonly notes: readonly string[];
+    };
+
+    expect(Object.keys(result).sort()).toEqual(["notes", "releaseUrl", "status", "version"]);
+    expect(result.notes).toEqual(notes);
+    expect(result.notes).not.toBe(notes);
+    expect(result).not.toHaveProperty("internalFeedUrl");
+  });
+
+  it("coalesces only concurrent invocations and retries after settlement", async () => {
+    let resolveFirst!: (value: typeof availableResult) => void;
+    const firstLoad = new Promise<typeof availableResult>((resolve) => {
+      resolveFirst = resolve;
+    });
+    const loadReleaseNotes = vi
+      .fn()
+      .mockReturnValueOnce(firstLoad)
+      .mockResolvedValueOnce(availableResult);
+    const state = setup(loadReleaseNotes);
+    const releaseNotes = state.handlers.get(DESKTOP_RELEASE_NOTES_CHANNEL)!;
+
+    const first = releaseNotes(state.trusted);
+    const concurrent = releaseNotes(state.trusted);
+    expect(concurrent).toBe(first);
+    expect(loadReleaseNotes).toHaveBeenCalledOnce();
+
+    resolveFirst(availableResult);
+    await expect(first).resolves.toEqual(availableResult);
+    await expect(releaseNotes(state.trusted)).resolves.toEqual(availableResult);
+    expect(loadReleaseNotes).toHaveBeenCalledTimes(2);
+  });
+
+  it("contains loader failures and retries the next request", async () => {
+    const loadReleaseNotes = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("secret path /private/synthetic"))
+      .mockResolvedValueOnce(availableResult);
+    const state = setup(loadReleaseNotes);
+    const releaseNotes = state.handlers.get(DESKTOP_RELEASE_NOTES_CHANNEL)!;
+
+    await expect(releaseNotes(state.trusted)).resolves.toEqual({
+      status: "unavailable",
+      version: null,
+      releaseUrl: "https://github.com/yerzhansa/cycling-coach/releases",
+    });
+    await expect(releaseNotes(state.trusted)).resolves.toEqual(availableResult);
+    expect(loadReleaseNotes).toHaveBeenCalledTimes(2);
+  });
+
+  it("refuses untrusted, stale, subframe, and wrong-origin senders", async () => {
+    const state = setup();
+    const releaseNotes = state.handlers.get(DESKTOP_RELEASE_NOTES_CHANNEL)!;
+    const subframe = { url: DESKTOP_RENDERER_URL };
+
+    expect(() => releaseNotes({ sender: state.webContents, senderFrame: subframe })).toThrow(
+      "untrusted desktop release notes request",
+    );
+    expect(() => releaseNotes({ sender: {}, senderFrame: state.mainFrame })).toThrow(
+      "untrusted desktop release notes request",
+    );
+    state.mainFrame.url = "https://example.invalid";
+    expect(() => releaseNotes(state.trusted)).toThrow("untrusted desktop release notes request");
+    state.mainFrame.url = DESKTOP_RENDERER_URL;
+    state.setCurrentWindow(undefined);
+    expect(() => releaseNotes(state.trusted)).toThrow("untrusted desktop release notes request");
+
+    expect(state.loadReleaseNotes).not.toHaveBeenCalled();
+  });
+
+  it("rejects every argument without loading release notes", async () => {
+    const state = setup();
+    const releaseNotes = state.handlers.get(DESKTOP_RELEASE_NOTES_CHANNEL)!;
+
+    for (const args of [[undefined], [{}], ["extra"], [1, 2]]) {
+      expect(() => releaseNotes(state.trusted, ...args)).toThrow(
+        "invalid desktop release notes request",
+      );
+    }
+    expect(state.loadReleaseNotes).not.toHaveBeenCalled();
+  });
+
+  it("removes its handler exactly once during shutdown", () => {
+    const state = setup();
+    state.handlers.set("synthetic:unrelated", vi.fn());
+
+    state.dispose();
+    state.dispose();
+
+    expect(state.ipcMain.removeHandler).toHaveBeenCalledOnce();
+    expect(state.ipcMain.removeHandler).toHaveBeenCalledWith(DESKTOP_RELEASE_NOTES_CHANNEL);
+    expect(state.handlers.has(DESKTOP_RELEASE_NOTES_CHANNEL)).toBe(false);
+    expect(state.handlers.has("synthetic:unrelated")).toBe(true);
+  });
+});

--- a/apps/desktop/tests/security.test.ts
+++ b/apps/desktop/tests/security.test.ts
@@ -12,6 +12,7 @@ import {
   DESKTOP_CONNECTION_CHANNEL,
   DESKTOP_HOST,
   DESKTOP_OPEN_EXTERNAL_CHANNEL,
+  DESKTOP_RELEASE_NOTES_CHANNEL,
   DESKTOP_RENDERER_ORIGIN,
   DESKTOP_RENDERER_URL,
   DESKTOP_SCHEME,
@@ -122,6 +123,7 @@ describe("desktop security boundary", () => {
       DESKTOP_RENDERER_URL,
       DESKTOP_CONNECTION_CHANNEL,
       DESKTOP_OPEN_EXTERNAL_CHANNEL,
+      DESKTOP_RELEASE_NOTES_CHANNEL,
     }).toEqual({
       DESKTOP_SCHEME: "enduragent",
       DESKTOP_HOST: "app",
@@ -129,6 +131,7 @@ describe("desktop security boundary", () => {
       DESKTOP_RENDERER_URL: "enduragent://app/index.html",
       DESKTOP_CONNECTION_CHANNEL: "desktop:get-daemon-connection",
       DESKTOP_OPEN_EXTERNAL_CHANNEL: "desktop:open-external",
+      DESKTOP_RELEASE_NOTES_CHANNEL: "desktop:get-release-notes",
     });
     expect({
       DESKTOP_WINDOW_WIDTH,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -206,3 +206,12 @@ export {
   setLastNotifiedVersion,
 } from "./updater.js";
 export type { UpdateInfo } from "./updater.js";
+
+// ─── Release notes ───────────────────────────────────────────────────
+export { fetchLatestReleaseNotes } from "./release-notes.js";
+export type {
+  FetchLatestReleaseNotesOptions,
+  ReleaseNotesFetch,
+  ReleaseNotesResult,
+  RepoInfo,
+} from "./release-notes.js";

--- a/packages/core/src/release-notes.ts
+++ b/packages/core/src/release-notes.ts
@@ -5,6 +5,47 @@ export interface RepoInfo {
   name: string;
 }
 
+export type ReleaseNotesResult =
+  | {
+      status: "available";
+      version: string;
+      notes: readonly string[];
+      releaseUrl: string;
+    }
+  | {
+      status: "unavailable";
+      version: string | null;
+      releaseUrl: string;
+    };
+
+export type ReleaseNotesFetch = (input: string, init?: RequestInit) => Promise<Response>;
+
+export interface FetchLatestReleaseNotesOptions {
+  fetch?: ReleaseNotesFetch;
+  timeoutMs?: number;
+  signal?: AbortSignal;
+}
+
+const NPM_REGISTRY = "https://registry.npmjs.org";
+const GITHUB_API = "https://api.github.com";
+const DEFAULT_TIMEOUT_MS = 5000;
+const MAX_TIMEOUT_MS = 30_000;
+const MAX_REGISTRY_RESPONSE_BYTES = 64 * 1024;
+const MAX_GITHUB_RESPONSE_BYTES = 256 * 1024;
+const MAX_VERSION_LENGTH = 64;
+const MAX_NOTES = 100;
+const MAX_NOTE_LENGTH = 2000;
+const MAX_TOTAL_NOTE_BYTES = 64 * 1024;
+const MAX_RELEASE_URL_LENGTH = 2048;
+const MAX_BINARY_NAME_LENGTH = 214;
+const INVALID_REPOSITORY_RELEASES_URL = "https://github.com/_/_/releases";
+
+const BINARY_NAME_RE = /^(?:@[a-z0-9][a-z0-9._-]*\/)?[a-z0-9][a-z0-9._-]*$/;
+const VERSION_RE =
+  /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+const USER_FACING_LINE_RE =
+  /^[ \t]*(?:[-*+][ \t]+(?:[0-9a-f]{7,}:[ \t]+)?)?User-facing:[ \t]*(.*?)[ \t\r]*$/i;
+
 export function parseRepoFromUrl(url: string): RepoInfo | null {
   const m = url.match(/github\.com[/:]([^/]+)\/([^/.]+?)(?:\.git)?(?:#.*)?$/);
   if (!m) return null;
@@ -18,13 +59,255 @@ export function getRepoForBinary(binaryName: string): RepoInfo | null {
   return url ? parseRepoFromUrl(url) : null;
 }
 
-export function parseUserFacing(body: string): string[] {
+function parseUserFacingBounded(body: string): string[] | null {
   const out: string[] = [];
+  let totalBytes = 0;
+  const encoder = new TextEncoder();
+
   for (const raw of body.split("\n")) {
-    const m = raw.match(/User-facing:\s*(.+?)\s*$/i);
-    if (m && m[1]) out.push(m[1].trim());
+    const m = USER_FACING_LINE_RE.exec(raw);
+    const note = m?.[1]?.trim();
+    if (!note) continue;
+    if (note.length > MAX_NOTE_LENGTH || out.length === MAX_NOTES) return null;
+    totalBytes += encoder.encode(note).byteLength;
+    if (totalBytes > MAX_TOTAL_NOTE_BYTES) return null;
+    out.push(note);
   }
   return out;
+}
+
+export function parseUserFacing(body: string): string[] {
+  return parseUserFacingBounded(body) ?? [];
+}
+
+async function cancelResponseBody(response: Response): Promise<void> {
+  try {
+    await response.body?.cancel();
+  } catch {
+    // The request has already failed closed.
+  }
+}
+
+async function readBoundedText(
+  response: Response,
+  maxBytes: number,
+  signal: AbortSignal,
+): Promise<string | null> {
+  const contentLength = response.headers.get("content-length");
+  if (contentLength !== null && /^\d+$/.test(contentLength) && Number(contentLength) > maxBytes) {
+    await cancelResponseBody(response);
+    return null;
+  }
+  if (response.body === null) return "";
+
+  const reader = response.body.getReader();
+  const abort = (): void => {
+    void reader.cancel().catch(() => undefined);
+  };
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+  if (signal.aborted) {
+    try {
+      await reader.cancel();
+    } catch {
+      // The request has already failed closed.
+    }
+    reader.releaseLock();
+    return null;
+  }
+  signal.addEventListener("abort", abort, { once: true });
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      totalBytes += value.byteLength;
+      if (totalBytes > maxBytes) {
+        try {
+          await reader.cancel();
+        } catch {
+          // The response is already rejected; cancellation is best-effort.
+        }
+        return null;
+      }
+      chunks.push(value);
+    }
+  } catch {
+    return null;
+  } finally {
+    signal.removeEventListener("abort", abort);
+    reader.releaseLock();
+  }
+
+  const joined = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    joined.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(joined);
+  } catch {
+    return null;
+  }
+}
+
+async function withDeadline<T>(
+  timeoutMs: number,
+  operation: (signal: AbortSignal) => Promise<T>,
+  signal?: AbortSignal,
+): Promise<T> {
+  const controller = new AbortController();
+  if (signal?.aborted) {
+    controller.abort();
+    throw new Error("Release notes request aborted");
+  }
+
+  let rejectAbort: (error: Error) => void = () => undefined;
+  const aborted = new Promise<never>((_resolve, reject) => {
+    rejectAbort = reject;
+  });
+  const abort = (): void => {
+    controller.abort();
+    rejectAbort(new Error("Release notes request aborted"));
+  };
+  signal?.addEventListener("abort", abort, { once: true });
+  const timer = setTimeout(abort, timeoutMs);
+
+  try {
+    return await Promise.race([operation(controller.signal), aborted]);
+  } finally {
+    clearTimeout(timer);
+    signal?.removeEventListener("abort", abort);
+  }
+}
+
+async function fetchBoundedJson(
+  fetchImpl: ReleaseNotesFetch,
+  url: string,
+  maxBytes: number,
+  timeoutMs: number,
+  signal?: AbortSignal,
+  headers?: RequestInit["headers"],
+): Promise<unknown | null> {
+  try {
+    return await withDeadline(
+      timeoutMs,
+      async (requestSignal) => {
+        const response = await fetchImpl(url, {
+          headers,
+          redirect: "error",
+          signal: requestSignal,
+        });
+        if (!response.ok) {
+          await cancelResponseBody(response);
+          return null;
+        }
+        const text = await readBoundedText(response, maxBytes, requestSignal);
+        if (text === null) return null;
+        return JSON.parse(text) as unknown;
+      },
+      signal,
+    );
+  } catch {
+    return null;
+  }
+}
+
+function isSafeBinaryName(binaryName: string): boolean {
+  return (
+    binaryName.length > 0 &&
+    binaryName.length <= MAX_BINARY_NAME_LENGTH &&
+    BINARY_NAME_RE.test(binaryName)
+  );
+}
+
+function isSafeVersion(version: unknown): version is string {
+  return (
+    typeof version === "string" &&
+    version.length > 0 &&
+    version.length <= MAX_VERSION_LENGTH &&
+    VERSION_RE.test(version)
+  );
+}
+
+function repositoryReleasesUrl(repo: RepoInfo): string | null {
+  if (!repo.owner || !repo.name) return null;
+  const url =
+    `https://github.com/${encodeURIComponent(repo.owner)}/${encodeURIComponent(repo.name)}` +
+    "/releases";
+  return url.length <= MAX_RELEASE_URL_LENGTH ? url : null;
+}
+
+function encodedTag(binaryName: string, version: string): string {
+  return encodeURIComponent(`${binaryName}@${version}`).replace(/%40/gi, "@");
+}
+
+function releaseTagUrl(releasesUrl: string, binaryName: string, version: string): string | null {
+  const url = `${releasesUrl}/tag/${encodedTag(binaryName, version)}`;
+  return url.length <= MAX_RELEASE_URL_LENGTH ? url : null;
+}
+
+function unavailable(version: string | null, releaseUrl: string): ReleaseNotesResult {
+  return { status: "unavailable", version, releaseUrl };
+}
+
+export async function fetchLatestReleaseNotes(
+  binaryName: string,
+  repo: RepoInfo,
+  options: FetchLatestReleaseNotesOptions = {},
+): Promise<ReleaseNotesResult> {
+  const releasesUrl = repositoryReleasesUrl(repo);
+  if (releasesUrl === null || !isSafeBinaryName(binaryName)) {
+    return unavailable(null, releasesUrl ?? INVALID_REPOSITORY_RELEASES_URL);
+  }
+
+  const fetchImpl = options.fetch ?? globalThis.fetch;
+  const timeoutMs =
+    Number.isFinite(options.timeoutMs) && (options.timeoutMs ?? 0) > 0
+      ? Math.min(MAX_TIMEOUT_MS, Math.max(1, Math.floor(options.timeoutMs as number)))
+      : DEFAULT_TIMEOUT_MS;
+
+  try {
+    const registryData = await fetchBoundedJson(
+      fetchImpl,
+      `${NPM_REGISTRY}/${encodeURIComponent(binaryName)}/latest`,
+      MAX_REGISTRY_RESPONSE_BYTES,
+      timeoutMs,
+      options.signal,
+    );
+    const version =
+      typeof registryData === "object" && registryData !== null && "version" in registryData
+        ? (registryData as { version?: unknown }).version
+        : null;
+    if (!isSafeVersion(version)) return unavailable(null, releasesUrl);
+
+    const releaseUrl = releaseTagUrl(releasesUrl, binaryName, version);
+    if (releaseUrl === null) return unavailable(version, releasesUrl);
+
+    const tag = encodedTag(binaryName, version);
+    const releaseData = await fetchBoundedJson(
+      fetchImpl,
+      `${GITHUB_API}/repos/${encodeURIComponent(repo.owner)}/${encodeURIComponent(repo.name)}` +
+        `/releases/tags/${tag}`,
+      MAX_GITHUB_RESPONSE_BYTES,
+      timeoutMs,
+      options.signal,
+      { Accept: "application/vnd.github+json" },
+    );
+    if (typeof releaseData !== "object" || releaseData === null) {
+      return unavailable(version, releaseUrl);
+    }
+
+    const body = (releaseData as { body?: unknown }).body;
+    if (body !== undefined && body !== null && typeof body !== "string") {
+      return unavailable(version, releaseUrl);
+    }
+    const notes = parseUserFacingBounded(typeof body === "string" ? body : "");
+    if (notes === null) return unavailable(version, releaseUrl);
+    return { status: "available", version, notes, releaseUrl };
+  } catch {
+    return unavailable(null, releasesUrl);
+  }
 }
 
 export async function fetchReleaseBody(
@@ -33,16 +316,18 @@ export async function fetchReleaseBody(
   timeoutMs = 5000,
 ): Promise<string | null> {
   try {
-    const res = await fetch(
-      `https://api.github.com/repos/${repo.owner}/${repo.name}/releases/tags/${encodeURIComponent(tag)}`,
-      {
-        signal: AbortSignal.timeout(timeoutMs),
-        headers: { Accept: "application/vnd.github+json" },
-      },
+    const data = await fetchBoundedJson(
+      globalThis.fetch,
+      `${GITHUB_API}/repos/${encodeURIComponent(repo.owner)}/${encodeURIComponent(repo.name)}` +
+        `/releases/tags/${encodeURIComponent(tag)}`,
+      MAX_GITHUB_RESPONSE_BYTES,
+      timeoutMs,
+      undefined,
+      { Accept: "application/vnd.github+json" },
     );
-    if (!res.ok) return null;
-    const data = (await res.json()) as { body?: string };
-    return data.body ?? null;
+    if (typeof data !== "object" || data === null) return null;
+    const body = (data as { body?: unknown }).body;
+    return typeof body === "string" ? body : null;
   } catch {
     return null;
   }

--- a/packages/core/tests/release-notes.test.ts
+++ b/packages/core/tests/release-notes.test.ts
@@ -1,10 +1,28 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
-import { parseRepoFromUrl, parseUserFacing } from "../src/release-notes.js";
+import {
+  fetchLatestReleaseNotes,
+  parseRepoFromUrl,
+  parseUserFacing,
+  type ReleaseNotesFetch,
+} from "../src/release-notes.js";
+
+const REPO = { owner: "yerzhansa", name: "cycling-coach" };
+const RELEASES_URL = "https://github.com/yerzhansa/cycling-coach/releases";
+
+function jsonResponse(value: unknown, status = 200): Response {
+  return new Response(JSON.stringify(value), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
 
 describe("parseRepoFromUrl", () => {
   it("parses git+https URL with .git suffix", () => {
-    expect(parseRepoFromUrl("git+https://github.com/foo/bar.git")).toEqual({ owner: "foo", name: "bar" });
+    expect(parseRepoFromUrl("git+https://github.com/foo/bar.git")).toEqual({
+      owner: "foo",
+      name: "bar",
+    });
   });
 
   it("parses ssh URL", () => {
@@ -16,7 +34,10 @@ describe("parseRepoFromUrl", () => {
   });
 
   it("ignores trailing #readme fragment", () => {
-    expect(parseRepoFromUrl("https://github.com/foo/bar#readme")).toEqual({ owner: "foo", name: "bar" });
+    expect(parseRepoFromUrl("https://github.com/foo/bar#readme")).toEqual({
+      owner: "foo",
+      name: "bar",
+    });
   });
 
   it("returns null for non-GitHub host", () => {
@@ -36,8 +57,8 @@ describe("parseUserFacing", () => {
 
   it("extracts multiple user-facing lines", () => {
     const body = [
-      "- abc: User-facing: First change.",
-      "- def: User-facing: Second change.",
+      "- abc1234: User-facing: First change.",
+      "- def5678: User-facing: Second change.",
     ].join("\n");
     expect(parseUserFacing(body)).toEqual(["First change.", "Second change."]);
   });
@@ -60,7 +81,335 @@ describe("parseUserFacing", () => {
     expect(parseUserFacing(body)).toEqual(["Indented entry."]);
   });
 
+  it("ignores mid-line phantom markers", () => {
+    const body = "Engineering prose mentions User-facing: but this is not a release-note marker.";
+    expect(parseUserFacing(body)).toEqual([]);
+  });
+
+  it("accepts only a changelog bullet and hexadecimal hash before the marker", () => {
+    expect(parseUserFacing("- af3186e: User-facing: Published entry.")).toEqual([
+      "Published entry.",
+    ]);
+    expect(parseUserFacing("- abc123: User-facing: Too-short hash.")).toEqual([]);
+    expect(parseUserFacing("- not-a-hash: User-facing: Phantom entry.")).toEqual([]);
+  });
+
   it("ignores empty captures", () => {
     expect(parseUserFacing("User-facing:\nUser-facing: real one.")).toEqual(["real one."]);
+  });
+});
+
+describe("fetchLatestReleaseNotes", () => {
+  it("looks up npm latest and then the exact GitHub release tag", async () => {
+    const requests: Array<{ url: string; init?: RequestInit }> = [];
+    const fetchImpl: ReleaseNotesFetch = vi.fn(async (url, init) => {
+      requests.push({ url, init });
+      if (requests.length === 1) return jsonResponse({ version: "2026.7.23" });
+      return jsonResponse({
+        body: [
+          "- af3186e: User-facing: Added desktop release notes.",
+          "Engineering detail.",
+          "  User-facing: Improved update guidance.",
+        ].join("\n"),
+        html_url: "https://attacker.invalid/not-used",
+      });
+    });
+
+    await expect(
+      fetchLatestReleaseNotes("cycling-coach", REPO, { fetch: fetchImpl }),
+    ).resolves.toEqual({
+      status: "available",
+      version: "2026.7.23",
+      notes: ["Added desktop release notes.", "Improved update guidance."],
+      releaseUrl: `${RELEASES_URL}/tag/cycling-coach@2026.7.23`,
+    });
+    expect(requests.map(({ url }) => url)).toEqual([
+      "https://registry.npmjs.org/cycling-coach/latest",
+      "https://api.github.com/repos/yerzhansa/cycling-coach/releases/tags/cycling-coach@2026.7.23",
+    ]);
+    expect(requests[1].init?.headers).toEqual({ Accept: "application/vnd.github+json" });
+    expect(requests.every(({ init }) => init?.redirect === "error")).toBe(true);
+  });
+
+  it("returns available with an empty notes list", async () => {
+    const fetchImpl: ReleaseNotesFetch = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ version: "2026.7.23" }))
+      .mockResolvedValueOnce(jsonResponse({ body: "Engineering details only." }));
+
+    await expect(
+      fetchLatestReleaseNotes("cycling-coach", REPO, { fetch: fetchImpl }),
+    ).resolves.toEqual({
+      status: "available",
+      version: "2026.7.23",
+      notes: [],
+      releaseUrl: `${RELEASES_URL}/tag/cycling-coach@2026.7.23`,
+    });
+  });
+
+  it("fails closed when npm is unavailable", async () => {
+    const fetchImpl: ReleaseNotesFetch = vi.fn(async () => jsonResponse({}, 503));
+    await expect(
+      fetchLatestReleaseNotes("cycling-coach", REPO, { fetch: fetchImpl }),
+    ).resolves.toEqual({
+      status: "unavailable",
+      version: null,
+      releaseUrl: RELEASES_URL,
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails closed on a registry redirect without attempting GitHub", async () => {
+    let streamCancelled = false;
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array([1]));
+      },
+      cancel() {
+        streamCancelled = true;
+      },
+    });
+    const fetchImpl: ReleaseNotesFetch = vi.fn(
+      async () =>
+        new Response(stream, {
+          status: 302,
+          headers: { Location: "https://attacker.invalid/latest" },
+        }),
+    );
+    await expect(
+      fetchLatestReleaseNotes("cycling-coach", REPO, { fetch: fetchImpl }),
+    ).resolves.toEqual({
+      status: "unavailable",
+      version: null,
+      releaseUrl: RELEASES_URL,
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(streamCancelled).toBe(true);
+  });
+
+  it("preserves the known version and local tag URL when GitHub fails", async () => {
+    const fetchImpl: ReleaseNotesFetch = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ version: "2026.7.23" }))
+      .mockRejectedValueOnce(new Error("remote details must not escape"));
+
+    await expect(
+      fetchLatestReleaseNotes("cycling-coach", REPO, { fetch: fetchImpl }),
+    ).resolves.toEqual({
+      status: "unavailable",
+      version: "2026.7.23",
+      releaseUrl: `${RELEASES_URL}/tag/cycling-coach@2026.7.23`,
+    });
+  });
+
+  it("aborts a timed-out request and never throws", async () => {
+    let observedAbort = false;
+    const fetchImpl: ReleaseNotesFetch = vi.fn(
+      async (_url, init) =>
+        await new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener(
+            "abort",
+            () => {
+              observedAbort = true;
+              reject(new Error("aborted"));
+            },
+            { once: true },
+          );
+        }),
+    );
+
+    await expect(
+      fetchLatestReleaseNotes("cycling-coach", REPO, { fetch: fetchImpl, timeoutMs: 1 }),
+    ).resolves.toEqual({
+      status: "unavailable",
+      version: null,
+      releaseUrl: RELEASES_URL,
+    });
+    expect(observedAbort).toBe(true);
+  });
+
+  it("times out after response headers when the streamed body never finishes", async () => {
+    let streamCancelled = false;
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('{"version":"2026.7.23"'));
+      },
+      cancel() {
+        streamCancelled = true;
+      },
+    });
+    const fetchImpl: ReleaseNotesFetch = vi.fn(async () => new Response(stream));
+
+    await expect(
+      fetchLatestReleaseNotes("cycling-coach", REPO, { fetch: fetchImpl, timeoutMs: 1 }),
+    ).resolves.toEqual({
+      status: "unavailable",
+      version: null,
+      releaseUrl: RELEASES_URL,
+    });
+    expect(streamCancelled).toBe(true);
+  });
+
+  it("caps an excessive supplied timeout at 30 seconds", async () => {
+    vi.useFakeTimers();
+    let observedAbort = false;
+    const fetchImpl: ReleaseNotesFetch = vi.fn(
+      async (_url, init) =>
+        await new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener(
+            "abort",
+            () => {
+              observedAbort = true;
+              reject(new Error("aborted"));
+            },
+            { once: true },
+          );
+        }),
+    );
+
+    try {
+      const result = fetchLatestReleaseNotes("cycling-coach", REPO, {
+        fetch: fetchImpl,
+        timeoutMs: Number.MAX_SAFE_INTEGER,
+      });
+      await vi.advanceTimersByTimeAsync(29_999);
+      expect(observedAbort).toBe(false);
+      await vi.advanceTimersByTimeAsync(1);
+      await expect(result).resolves.toMatchObject({ status: "unavailable", version: null });
+      expect(observedAbort).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("honors an already-aborted caller signal without making a request", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const fetchImpl: ReleaseNotesFetch = vi.fn();
+
+    await expect(
+      fetchLatestReleaseNotes("cycling-coach", REPO, {
+        fetch: fetchImpl,
+        signal: controller.signal,
+      }),
+    ).resolves.toEqual({
+      status: "unavailable",
+      version: null,
+      releaseUrl: RELEASES_URL,
+    });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["missing", {}],
+    ["wrong type", { version: 20260723 }],
+    ["malformed", { version: "not-a-version" }],
+    ["oversize", { version: `1.0.0-${"a".repeat(65)}` }],
+    ["unsafe", { version: "1.0.0/../../latest" }],
+  ])("rejects a %s npm version", async (_label, registryBody) => {
+    const fetchImpl: ReleaseNotesFetch = vi.fn(async () => jsonResponse(registryBody));
+    await expect(
+      fetchLatestReleaseNotes("cycling-coach", REPO, { fetch: fetchImpl }),
+    ).resolves.toEqual({
+      status: "unavailable",
+      version: null,
+      releaseUrl: RELEASES_URL,
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects a registry response over 64 KiB", async () => {
+    const fetchImpl: ReleaseNotesFetch = vi.fn(async () =>
+      jsonResponse({ version: "2026.7.23", padding: "x".repeat(64 * 1024) }),
+    );
+    await expect(
+      fetchLatestReleaseNotes("cycling-coach", REPO, { fetch: fetchImpl }),
+    ).resolves.toMatchObject({ status: "unavailable", version: null });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels a registry body rejected from its oversized content-length header", async () => {
+    let streamCancelled = false;
+    const stream = new ReadableStream<Uint8Array>({
+      cancel() {
+        streamCancelled = true;
+      },
+    });
+    const fetchImpl: ReleaseNotesFetch = vi.fn(
+      async () =>
+        new Response(stream, {
+          headers: { "Content-Length": String(64 * 1024 + 1) },
+        }),
+    );
+
+    await expect(
+      fetchLatestReleaseNotes("cycling-coach", REPO, { fetch: fetchImpl }),
+    ).resolves.toMatchObject({ status: "unavailable", version: null });
+    expect(streamCancelled).toBe(true);
+  });
+
+  it("rejects a GitHub response over 256 KiB without parsing it unbounded", async () => {
+    const fetchImpl: ReleaseNotesFetch = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ version: "2026.7.23" }))
+      .mockResolvedValueOnce(jsonResponse({ body: "x".repeat(256 * 1024) }));
+
+    await expect(
+      fetchLatestReleaseNotes("cycling-coach", REPO, { fetch: fetchImpl }),
+    ).resolves.toMatchObject({ status: "unavailable", version: "2026.7.23" });
+  });
+
+  it("rejects more than 100 user-facing notes rather than truncating", async () => {
+    const body = Array.from({ length: 101 }, (_, i) => `User-facing: Note ${i}.`).join("\n");
+    const fetchImpl: ReleaseNotesFetch = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ version: "2026.7.23" }))
+      .mockResolvedValueOnce(jsonResponse({ body }));
+
+    await expect(
+      fetchLatestReleaseNotes("cycling-coach", REPO, { fetch: fetchImpl }),
+    ).resolves.toMatchObject({ status: "unavailable", version: "2026.7.23" });
+  });
+
+  it("rejects a note longer than 2,000 UTF-16 units rather than truncating", async () => {
+    const fetchImpl: ReleaseNotesFetch = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ version: "2026.7.23" }))
+      .mockResolvedValueOnce(jsonResponse({ body: `User-facing: ${"x".repeat(2001)}` }));
+
+    await expect(
+      fetchLatestReleaseNotes("cycling-coach", REPO, { fetch: fetchImpl }),
+    ).resolves.toMatchObject({ status: "unavailable", version: "2026.7.23" });
+  });
+
+  it("rejects more than 64 KiB of total note text rather than truncating", async () => {
+    const body = Array.from(
+      { length: 33 },
+      (_, i) => `User-facing: ${String(i).padStart(2, "0")}${"x".repeat(1998)}`,
+    ).join("\n");
+    const fetchImpl: ReleaseNotesFetch = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ version: "2026.7.23" }))
+      .mockResolvedValueOnce(jsonResponse({ body }));
+
+    await expect(
+      fetchLatestReleaseNotes("cycling-coach", REPO, { fetch: fetchImpl }),
+    ).resolves.toMatchObject({ status: "unavailable", version: "2026.7.23" });
+  });
+
+  it("keeps every returned release URL locally constructed and under 2,048 characters", async () => {
+    const fetchImpl: ReleaseNotesFetch = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ version: "2026.7.23" }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          body: "User-facing: Safe local URL.",
+          html_url: `https://attacker.invalid/${"x".repeat(3000)}`,
+        }),
+      );
+    const result = await fetchLatestReleaseNotes("cycling-coach", REPO, { fetch: fetchImpl });
+
+    expect(result.releaseUrl).toBe(`${RELEASES_URL}/tag/cycling-coach@2026.7.23`);
+    expect(result.releaseUrl.length).toBeLessThanOrEqual(2048);
   });
 });


### PR DESCRIPTION
## Summary

- add an explicit Desktop What’s new action with loading, empty, unavailable, retry, and accessible close states
- fetch the latest published package version and its exact GitHub release only after athlete action, with fixed origins, deadlines, bounded bodies, and canonical local links
- validate the result across the main/preload boundary and render every remote note as literal text
- anchor User-facing release-note parsing to real lines so mid-line markers cannot create phantom notes
- document the explicit network behavior and athlete-facing release-note contract

## Validation

- Core release-notes tests: 36 passed
- Desktop IPC, preload, and security tests: 84 focused tests passed
- Renderer release-notes and chat tests: 92 focused tests passed; full renderer package suite also passed with 298 tests
- Core, Desktop, and renderer typechecks passed
- aggregate typecheck passed
- renderer build passed
- focused Electron security smoke passed
- changeset User-facing validation passed
- three independent reviews passed for security/privacy, release correctness, and renderer UX/accessibility/lifecycle

Resolves the supported Desktop release-notes gap tracked locally as #226 and the parser correctness prerequisite tracked locally as #144.