### PR TITLE
fix(release): make CalVer allocation fail closed

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -44,4 +44,6 @@ Rules:
 
 Library packages (`@enduragent/*`) follow SemVer via standard changesets bumps.
 
-Binary packages (`cycling-coach`, `running-coach`, `duathlon-coach`) are CalVer (`YYYY.M.D[-N]`). Changesets doesn't natively understand CalVer, so the publish workflow runs `tools/bump-binaries-to-calver.ts` after `changeset version` to override the binary bumps with today's CalVer string. Your changeset should still be written normally (any bump type — the CalVer override ignores the choice for binaries).
+Binary packages (`cycling-coach`, `running-coach`, `duathlon-coach`) use stable, SemVer-compatible CalVer: `YYYY.MONTH.RELEASE-WITHIN-MONTH`. The first release after a UTC month or year rollover uses `.0`; each later release in that UTC month increments the third component from the highest version already occupied in npm or the committed repository. New releases never use a prerelease suffix. Historical `YYYY.M.P-N` versions remain valid history and count as occupying patch `P`, but are never generated again.
+
+Changesets doesn't natively understand this policy, so the publish workflow runs `tools/bump-binaries-to-calver.ts` after `changeset version`. Your changeset should still select a normal patch, minor, or major bump; that choice is overridden for binary packages. The script rewrites only the new top changelog header when necessary and never rewrites historical entries.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,13 +139,13 @@ The bot enforces a per-user-ID allowlist via `~/.cycling-coach/allowed-senders.j
 
 ## Versioning
 
-Calendar-based for npm-published binaries: `YYYY.M.D` (e.g., `2026.4.16` — first release of the day; `2026.4.16-1` — patch later the same day; `2026.4.17` — next day). Private workspace packages (`@enduragent/*`, stub binaries) use SemVer and are not published. See ADR-0007 and ADR-0009.
+Calendar-based for npm-published binaries: stable, SemVer-compatible `YYYY.MONTH.RELEASE-WITHIN-MONTH` (for example, `2026.7.0` is the first release in July UTC, followed by `2026.7.1`; August resets to `2026.8.0`). New releases increment the third component and never use a prerelease suffix. Historical `YYYY.M.P-N` versions remain accepted as release history but their successors use stable `P+1`. Private workspace packages (`@enduragent/*`, stub binaries) use SemVer and are not published. See ADR-0007 and ADR-0009.
 
 ## Releasing
 
-Changesets-driven and CI-automated. Contributors do **not** create tags or GitHub Releases by hand — those steps are wrong, and the tag namespace is `<package>@<version>` (e.g., `cycling-coach@2026.5.4`), not `vYYYY.M.D`.
+Changesets-driven and CI-automated. Contributors do **not** create tags or GitHub Releases by hand — those steps are wrong, and the tag namespace is `<package>@<version>` (e.g., `cycling-coach@2026.5.4`), not a `v`-prefixed CalVer tag.
 
-1. **Add a changeset to your PR.** Run `pnpm exec changeset`, pick the affected publishable package(s), describe the change in athlete-readable language. Commit the resulting `.changeset/<slug>.md`. A PR with a user-visible change but no changeset will skip release — this is intentional, not a bug.
+1. **Add a changeset to your PR.** Run `pnpm exec changeset`, pick the affected publishable package(s), describe the change in athlete-readable language. Commit the resulting `.changeset/<slug>.md`. A PR with a user-visible change but no changeset will skip release — this is intentional, not a bug. The required patch/minor/major choice is overridden by the CalVer policy for binary packages.
 
    For user-visible changes, add a `User-facing: <one-sentence description>` line at the top of the changeset body — see `.changeset/README.md` for the convention. The bot's `/whatsnew` command surfaces only those lines to athletes; engineering details, hashes, and infra-only changesets stay in `CHANGELOG.md` for git history but never reach users.
 2. **Merge your PR to `main`.** `version-pr.yml` opens (or updates) a bot-managed "Version Packages" PR aggregating all pending changesets.
@@ -156,4 +156,4 @@ Today only `cycling-coach` is `private: false`, so only `cycling-coach@<v>` is t
 
 **If a release fails partway** (e.g., a flaky smoke test), re-run `release.yml` via Actions → "Run workflow" with the existing tag as input. `workflow_dispatch` is a fallback for re-running on a tag that already exists — it does **not** create the tag, so don't use it before the version-PR-merge has pushed one.
 
-`tools/bump-binaries-to-calver.ts` runs after `changeset version` to override the SemVer bump for binary packages with today's CalVer (handles same-day re-releases by querying npm).
+`tools/bump-binaries-to-calver.ts` runs after `changeset version`. It reads the committed pre-Changesets version and all occupied npm versions, then overrides binary versions with the next stable release number for the current UTC month. It rewrites only the new matching changelog header; historical entries are immutable.

--- a/packages/core/src/updater.ts
+++ b/packages/core/src/updater.ts
@@ -24,14 +24,9 @@ export function isManagedDeploy(
 }
 
 /**
- * Parse a CalVer string `YYYY.M.D` (with optional same-day re-release suffix
- * `-N`) into a comparable 4-tuple. Returns null for unparseable input —
- * "unknown" (the getCurrentVersion fallback) or a malformed npm response.
- *
- * Note: this is NOT semver. The project's binaries use CalVer where `-N`
- * means "newer same-day re-release", whereas semver treats `-N` as an older
- * pre-release. Using `semver.gt` here would silently miss every same-day
- * patch notification.
+ * Parse stable `YYYY.M.P` CalVer into a comparable tuple. The optional fourth
+ * element exists only for compatibility with installed historical `-N`
+ * releases, where a suffix was ordered after its unsuffixed base.
  */
 function calverParts(v: string): [number, number, number, number] | null {
   const m = v.match(/^(\d+)\.(\d+)\.(\d+)(?:-(\d+))?$/);

--- a/packages/core/tests/updater.test.ts
+++ b/packages/core/tests/updater.test.ts
@@ -43,13 +43,20 @@ describe("isUpdateAvailable", () => {
     expect(isUpdateAvailable("2026.5.9", "2026.5.10")).toBe(false);
   });
 
-  it("CalVer same-day re-release suffix is treated as NEWER", () => {
-    // The project's CalVer scheme: 2026.5.3 → 2026.5.3-1 → 2026.5.3-2 ships
-    // suffix bumps as same-day re-releases that come AFTER the original.
-    // (This inverts standard semver, where -1 is a pre-release.)
+  it("orders stable successors within the same month", () => {
+    expect(isUpdateAvailable("2026.7.3", "2026.7.2")).toBe(true);
+    expect(isUpdateAvailable("2026.7.2", "2026.7.3")).toBe(false);
+  });
+
+  it("orders installed historical suffix releases for compatibility", () => {
     expect(isUpdateAvailable("2026.5.3-1", "2026.5.3")).toBe(true);
     expect(isUpdateAvailable("2026.5.3-2", "2026.5.3-1")).toBe(true);
     expect(isUpdateAvailable("2026.5.3", "2026.5.3-1")).toBe(false);
+  });
+
+  it("recognizes the stable successor to an installed historical suffix release", () => {
+    expect(isUpdateAvailable("2026.6.26", "2026.6.25-1")).toBe(true);
+    expect(isUpdateAvailable("2026.6.25-1", "2026.6.26")).toBe(false);
   });
 });
 
@@ -69,7 +76,7 @@ describe("buildSelfUpdateCommand", () => {
     expect(cmd).toContain("--registry=https://registry.npmjs.org");
   });
 
-  it("accepts a CalVer same-day re-release suffix", () => {
+  it("accepts an installed historical CalVer suffix", () => {
     expect(buildSelfUpdateCommand("cycling-coach", "2026.5.3-1")).toContain(
       "cycling-coach@2026.5.3-1",
     );

--- a/packages/cycling-coach/CONTEXT.md
+++ b/packages/cycling-coach/CONTEXT.md
@@ -4,7 +4,7 @@ The published `cycling-coach` npm binary. A 7-line shim that wires the cycling s
 
 ## Status: published
 
-Bundled via tsup with `@enduragent/*` **inlined** (`noExternal`). The published tarball's `dist/index.js` contains all the workspace code — Core, sport-cycling, and the binary shim — so end users install one self-contained package. CalVer scheme (`YYYY.M.D[-N]`) continues. Library packages stay private workspace deps until an external consumer needs them; see ADR-0009.
+Bundled via tsup with `@enduragent/*` **inlined** (`noExternal`). The published tarball's `dist/index.js` contains all the workspace code — Core, sport-cycling, and the binary shim — so end users install one self-contained package. Releases use stable, SemVer-compatible CalVer (`YYYY.MONTH.RELEASE-WITHIN-MONTH`): `.0` starts each UTC month and the third component increments thereafter; binary changeset bump choices are overridden. Historical suffixed versions remain history and are never rewritten. Library packages stay private workspace deps until an external consumer needs them; see ADR-0009.
 
 ## What lives here
 

--- a/tools/bump-binaries-to-calver.test.ts
+++ b/tools/bump-binaries-to-calver.test.ts
@@ -1,0 +1,472 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  main,
+  nextCalVer,
+  parseCalVer,
+  parseRegistryVersions,
+  planBinaryVersionBump,
+  rewriteFirstChangelogHeader,
+  runCli,
+} from "./bump-binaries-to-calver.js";
+
+function isStandardSemVerGreater(candidate: string, occupied: string): boolean {
+  const parse = (version: string) => {
+    const match = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?$/.exec(version);
+    if (match === null) throw new Error(`Invalid test SemVer: ${version}`);
+    return {
+      core: [Number(match[1]), Number(match[2]), Number(match[3])],
+      prerelease: match[4],
+    };
+  };
+  const left = parse(candidate);
+  const right = parse(occupied);
+  for (let index = 0; index < left.core.length; index++) {
+    if (left.core[index] !== right.core[index]) {
+      return left.core[index] > right.core[index];
+    }
+  }
+  return left.prerelease === undefined && right.prerelease !== undefined;
+}
+
+describe("CalVer parsing", () => {
+  it("accepts stable and historical versions but rejects malformed calendar versions", () => {
+    expect(parseCalVer("2026.7.2")).toMatchObject({
+      year: 2026,
+      month: 7,
+      patch: 2,
+      legacyRevision: 0,
+    });
+    expect(parseCalVer("2026.6.25-1")).toMatchObject({
+      year: 2026,
+      month: 6,
+      patch: 25,
+      legacyRevision: 1,
+    });
+    expect(parseCalVer("2026.13.0")).toBeNull();
+    expect(parseCalVer("2026.07.0")).toBeNull();
+    expect(parseCalVer("not-a-version")).toBeNull();
+  });
+
+  it("validates every version in registry JSON", () => {
+    expect(parseRegistryVersions('["0.0.1","2026.6.25-1","2026.7.2"]')).toEqual([
+      "2026.6.25-1",
+      "2026.7.2",
+    ]);
+    expect(() => parseRegistryVersions("{")).toThrow(/registry JSON/i);
+    expect(() => parseRegistryVersions('["2026.7.2","broken"]')).toThrow(/registry version/i);
+    expect(() => parseRegistryVersions('{"version":"2026.7.2"}')).toThrow(/array/i);
+  });
+});
+
+describe("nextCalVer", () => {
+  it("increments stable releases monotonically within the current UTC month", () => {
+    const now = new Date("2026-07-31T23:59:59.000Z");
+    const third = nextCalVer(["2026.7.2"], now);
+    const fourth = nextCalVer(["2026.7.2", third], now);
+
+    expect(third).toBe("2026.7.3");
+    expect(fourth).toBe("2026.7.4");
+    expect(third).not.toContain("-");
+    expect(fourth).not.toContain("-");
+  });
+
+  it("treats a historical suffix as occupancy and emits the next stable patch", () => {
+    const occupied = ["2026.6.25", "2026.6.25-1"];
+    const next = nextCalVer(occupied, new Date("2026-06-26T00:00:00.000Z"));
+
+    expect(next).toBe("2026.6.26");
+    expect(occupied.every((version) => isStandardSemVerGreater(next, version))).toBe(true);
+  });
+
+  it("resets to patch zero after a UTC month or year rollover", () => {
+    expect(nextCalVer(["2026.6.25"], new Date("2026-07-31T23:59:59.000Z"))).toBe("2026.7.0");
+    expect(nextCalVer(["2026.12.9"], new Date("2027-01-01T00:00:00.000Z"))).toBe("2027.1.0");
+  });
+
+  it("uses the UTC month when the local offset has already crossed midnight", () => {
+    expect(nextCalVer(["2026.7.2"], new Date("2026-08-01T00:30:00+05:00"))).toBe("2026.7.3");
+  });
+
+  it("fails when the UTC clock is behind occupancy or the patch would overflow", () => {
+    expect(() => nextCalVer(["2026.8.0"], new Date("2026-07-31T23:59:59.000Z"))).toThrow(
+      /precedes occupied version/i,
+    );
+    expect(() =>
+      nextCalVer([`2026.7.${Number.MAX_SAFE_INTEGER}`], new Date("2026-07-31T23:59:59.000Z")),
+    ).toThrow(/overflow/i);
+  });
+});
+
+describe("planBinaryVersionBump", () => {
+  it("advances from the committed version when the repository is ahead of npm", () => {
+    const plan = planBinaryVersionBump({
+      packageName: "cycling-coach",
+      packageJsonPath: "packages/cycling-coach/package.json",
+      changelogPath: "packages/cycling-coach/CHANGELOG.md",
+      packageJsonContents: JSON.stringify({ name: "cycling-coach", version: "2026.8.0" }),
+      committedPackageJsonContents: JSON.stringify({
+        name: "cycling-coach",
+        version: "2026.7.4",
+      }),
+      registryVersionsJson: '["2026.7.1","2026.7.2"]',
+      changelogContents: "# cycling-coach\n\n## 2026.8.0\n\nNew release.\n",
+      now: new Date("2026-07-23T12:00:00.000Z"),
+    });
+
+    expect(plan.oldVersion).toBe("2026.8.0");
+    expect(plan.committedVersion).toBe("2026.7.4");
+    expect(plan.newVersion).toBe("2026.7.5");
+    expect(JSON.parse(plan.packageJsonContents).version).toBe("2026.7.5");
+    expect(plan.changelogContents).toContain("## 2026.7.5");
+  });
+
+  it("rewrites only the first exact matching changelog header", () => {
+    const original =
+      "# cycling-coach\n\n## 2026.8.0\n\nCurrent.\n\n## 2026.8.0\n\nHistorical duplicate.\n";
+    const rewritten = rewriteFirstChangelogHeader(original, "2026.8.0", "2026.7.3");
+
+    expect(rewritten.changed).toBe(true);
+    expect(rewritten.contents).toBe(
+      "# cycling-coach\n\n## 2026.7.3\n\nCurrent.\n\n## 2026.8.0\n\nHistorical duplicate.\n",
+    );
+  });
+
+  it("never rewrites a later historical header when the top release differs", () => {
+    const original = "# cycling-coach\n\n## 2026.8.1\n\nCurrent.\n\n## 2026.8.0\n\nHistorical.\n";
+
+    expect(rewriteFirstChangelogHeader(original, "2026.8.0", "2026.7.3")).toEqual({
+      contents: original,
+      changed: false,
+    });
+    expect(
+      rewriteFirstChangelogHeader(
+        "# cycling-coach\n\n## 2026.8.00\n\nDifferent release.\n",
+        "2026.8.0",
+        "2026.7.3",
+      ),
+    ).toMatchObject({ changed: false });
+  });
+
+  it("requires the top changelog release to match both the working and planned versions", () => {
+    const base = {
+      packageName: "cycling-coach",
+      packageJsonPath: "packages/cycling-coach/package.json",
+      changelogPath: "packages/cycling-coach/CHANGELOG.md",
+      packageJsonContents: JSON.stringify({ name: "cycling-coach", version: "2026.7.3" }),
+      committedPackageJsonContents: JSON.stringify({
+        name: "cycling-coach",
+        version: "2026.7.2",
+      }),
+      registryVersionsJson: '["0.0.1","2026.7.2"]',
+      now: new Date("2026-07-23T12:00:00.000Z"),
+    };
+
+    expect(() =>
+      planBinaryVersionBump({
+        ...base,
+        changelogContents: "# cycling-coach\n\n## 2026.7.2\n\nStale.\n",
+      }),
+    ).toThrow(/top release header is inconsistent/i);
+    expect(() => planBinaryVersionBump(base)).toThrow(/CHANGELOG\.md is required/i);
+    expect(
+      planBinaryVersionBump({
+        ...base,
+        changelogContents: "# cycling-coach\n\n## 2026.7.3\n\nCurrent.\n",
+      }),
+    ).toMatchObject({
+      packageChanged: false,
+      changelogChanged: false,
+      newVersion: "2026.7.3",
+    });
+  });
+});
+
+interface CommandCall {
+  readonly command: string;
+  readonly args: readonly string[];
+}
+
+interface DependencyFixtureOptions {
+  readonly workingVersions?: Readonly<Record<string, string>>;
+  readonly committedVersions?: Readonly<Record<string, string>>;
+  readonly registryResults?: Readonly<Record<string, string>>;
+  readonly changelogVersions?: Readonly<Record<string, string>>;
+  readonly missingChangelogs?: readonly string[];
+  readonly commandErrors?: Readonly<Record<string, Error>>;
+}
+
+function dependencyFixture(options: DependencyFixtureOptions = {}) {
+  const writes: Array<{ path: string; contents: string }> = [];
+  const commandCalls: CommandCall[] = [];
+  const committedVersions = options.committedVersions ?? {
+    "cycling-coach": "2026.7.2",
+  };
+  const registryResults = options.registryResults ?? {
+    "cycling-coach": '["2026.6.25-1","2026.7.2"]',
+  };
+
+  return {
+    writes,
+    commandCalls,
+    dependencies: {
+      execFileSync(command: string, args: readonly string[]): string {
+        commandCalls.push({ command, args: [...args] });
+        const packageName =
+          command === "git"
+            ? args[1]?.match(/^HEAD:packages\/([^/]+)\/package\.json$/)?.[1]
+            : args[1];
+        if (packageName === undefined) throw new Error("Unexpected command arguments");
+        const commandError = options.commandErrors?.[`${command}:${packageName}`];
+        if (commandError !== undefined) throw commandError;
+        if (command === "git") {
+          const version = committedVersions[packageName];
+          if (version === undefined) throw new Error(`No committed fixture for ${packageName}`);
+          return JSON.stringify({ name: packageName, version });
+        }
+        if (command === "npm") {
+          const result = registryResults[packageName];
+          if (result === undefined) throw new Error(`No registry fixture for ${packageName}`);
+          return result;
+        }
+        throw new Error(`Unexpected command: ${command}`);
+      },
+      readFileSync(path: string): string {
+        const packageName = path.match(
+          /\/packages\/([^/]+)\/(?:package\.json|CHANGELOG\.md)$/,
+        )?.[1];
+        if (packageName === undefined) throw new Error(`Unexpected read: ${path}`);
+        const version = options.workingVersions?.[packageName] ?? "2026.8.0";
+        if (path.endsWith("/CHANGELOG.md")) {
+          const changelogVersion = options.changelogVersions?.[packageName] ?? version;
+          return `# package\n\n## ${changelogVersion}\n\nCurrent release.\n`;
+        }
+        return JSON.stringify({
+          name: packageName,
+          version,
+          description: "preserved",
+        });
+      },
+      writeFileSync(path: string, contents: string): void {
+        writes.push({ path, contents });
+      },
+      existsSync(path: string): boolean {
+        const packageName = path.match(/\/packages\/([^/]+)\/CHANGELOG\.md$/)?.[1];
+        return (
+          packageName !== undefined && !(options.missingChangelogs ?? []).includes(packageName)
+        );
+      },
+      log(): void {},
+    },
+  };
+}
+
+describe("CalVer bump CLI planning", () => {
+  it("uses argv-based git and npm lookups, then applies the complete plan", () => {
+    const fixture = dependencyFixture();
+    const plans = main({
+      rootDir: "/repo",
+      now: new Date("2026-07-23T12:00:00.000Z"),
+      dependencies: fixture.dependencies,
+    });
+
+    expect(fixture.commandCalls).toEqual([
+      {
+        command: "git",
+        args: ["show", "HEAD:packages/cycling-coach/package.json"],
+      },
+      {
+        command: "npm",
+        args: [
+          "view",
+          "cycling-coach",
+          "versions",
+          "--json",
+          "--registry=https://registry.npmjs.org",
+        ],
+      },
+    ]);
+    expect(plans[0].newVersion).toBe("2026.7.3");
+    expect(fixture.writes).toHaveLength(2);
+    expect(JSON.parse(fixture.writes[0].contents)).toMatchObject({
+      version: "2026.7.3",
+      description: "preserved",
+    });
+    expect(fixture.writes[1].contents).toContain("## 2026.7.3");
+  });
+
+  it("plans every binary before writing when a later registry lookup fails", () => {
+    const fixture = dependencyFixture({
+      committedVersions: { first: "2026.7.1", second: "2026.7.1" },
+      registryResults: { first: '["2026.7.1"]' },
+      commandErrors: { "npm:second": new Error("ETIMEDOUT") },
+    });
+
+    expect(() =>
+      main({
+        rootDir: "/repo",
+        now: new Date("2026-07-23T12:00:00.000Z"),
+        packages: ["first", "second"],
+        dependencies: fixture.dependencies,
+      }),
+    ).toThrow(/^npm view second versions failed$/i);
+    expect(fixture.writes).toEqual([]);
+  });
+
+  it("does not query npm or manufacture a release without a Changesets bump", () => {
+    const fixture = dependencyFixture({
+      workingVersions: { "cycling-coach": "2026.7.2" },
+      committedVersions: { "cycling-coach": "2026.7.2" },
+      registryResults: { "cycling-coach": "not consulted" },
+    });
+
+    expect(
+      main({
+        rootDir: "/repo",
+        now: new Date("2026-07-23T12:00:00.000Z"),
+        dependencies: fixture.dependencies,
+      }),
+    ).toEqual([
+      expect.objectContaining({
+        oldVersion: "2026.7.2",
+        newVersion: "2026.7.2",
+        packageChanged: false,
+        changelogChanged: false,
+      }),
+    ]);
+    expect(fixture.commandCalls).toEqual([
+      {
+        command: "git",
+        args: ["show", "HEAD:packages/cycling-coach/package.json"],
+      },
+    ]);
+    expect(fixture.writes).toEqual([]);
+  });
+
+  it("plans all binaries before writing when a later changelog is stale", () => {
+    const fixture = dependencyFixture({
+      committedVersions: { first: "2026.7.1", second: "2026.7.1" },
+      registryResults: { first: '["2026.7.1"]', second: '["2026.7.1"]' },
+      changelogVersions: { second: "2026.7.1" },
+    });
+
+    expect(() =>
+      main({
+        rootDir: "/repo",
+        now: new Date("2026-07-23T12:00:00.000Z"),
+        packages: ["first", "second"],
+        dependencies: fixture.dependencies,
+      }),
+    ).toThrow(/second: CHANGELOG\.md top release header is inconsistent/i);
+    expect(fixture.writes).toEqual([]);
+  });
+
+  it("fails closed without writes when a binary changelog is missing", () => {
+    const fixture = dependencyFixture({
+      missingChangelogs: ["cycling-coach"],
+    });
+
+    expect(() =>
+      main({
+        rootDir: "/repo",
+        now: new Date("2026-07-23T12:00:00.000Z"),
+        dependencies: fixture.dependencies,
+      }),
+    ).toThrow(/CHANGELOG\.md is required/i);
+    expect(fixture.writes).toEqual([]);
+  });
+
+  it("returns a nonzero CLI status without exposing child-process diagnostics", () => {
+    const fixture = dependencyFixture({
+      commandErrors: { "npm:cycling-coach": new Error("SECRET\u001b[31m") },
+    });
+    const errors: string[] = [];
+
+    expect(
+      runCli(
+        {
+          rootDir: "/repo",
+          now: new Date("2026-07-23T12:00:00.000Z"),
+          dependencies: fixture.dependencies,
+        },
+        (message) => errors.push(message),
+      ),
+    ).toBe(1);
+    expect(errors).toEqual(["npm view cycling-coach versions failed"]);
+    expect(errors.join("")).not.toContain("SECRET");
+    expect(errors.join("")).not.toContain("\u001b");
+    expect(fixture.writes).toEqual([]);
+  });
+
+  it("identifies a malformed registry entry by index without echoing its value", () => {
+    const secret = "SECRET\u001b[31m";
+    const fixture = dependencyFixture({
+      registryResults: { "cycling-coach": JSON.stringify(["2026.7.2", secret]) },
+    });
+    const errors: string[] = [];
+
+    expect(
+      runCli(
+        {
+          rootDir: "/repo",
+          now: new Date("2026-07-23T12:00:00.000Z"),
+          dependencies: fixture.dependencies,
+        },
+        (message) => errors.push(message),
+      ),
+    ).toBe(1);
+    expect(errors).toEqual(["Malformed npm registry version at index 1"]);
+    expect(errors.join("")).not.toContain("SECRET");
+    expect(errors.join("")).not.toContain("\u001b");
+    expect(fixture.writes).toEqual([]);
+  });
+
+  for (const scenario of [
+    {
+      name: "malformed registry JSON",
+      options: { registryResults: { "cycling-coach": "{" } },
+      expected: /registry JSON/i,
+    },
+    {
+      name: "malformed registry version",
+      options: { registryResults: { "cycling-coach": '["broken"]' } },
+      expected: /registry version/i,
+    },
+    {
+      name: "future registry maximum",
+      options: { registryResults: { "cycling-coach": '["2026.8.0"]' } },
+      expected: /precedes occupied version/i,
+    },
+    {
+      name: "invalid committed version",
+      options: { committedVersions: { "cycling-coach": "1.0.0" } },
+      expected: /committed version is not valid CalVer/i,
+    },
+    {
+      name: "patch overflow",
+      options: {
+        committedVersions: {
+          "cycling-coach": `2026.7.${Number.MAX_SAFE_INTEGER}`,
+        },
+      },
+      expected: /overflow/i,
+    },
+    {
+      name: "failed committed lookup",
+      options: { commandErrors: { "git:cycling-coach": new Error("missing HEAD") } },
+      expected: /^git show for cycling-coach failed$/i,
+    },
+  ] as const) {
+    it(`fails closed without writes for ${scenario.name}`, () => {
+      const fixture = dependencyFixture(scenario.options);
+      expect(() =>
+        main({
+          rootDir: "/repo",
+          now: new Date("2026-07-23T12:00:00.000Z"),
+          dependencies: fixture.dependencies,
+        }),
+      ).toThrow(scenario.expected);
+      expect(fixture.writes).toEqual([]);
+    });
+  }
+});

--- a/tools/bump-binaries-to-calver.ts
+++ b/tools/bump-binaries-to-calver.ts
@@ -1,118 +1,403 @@
 #!/usr/bin/env tsx
-/**
- * Override changesets' SemVer bumps on published binary packages with CalVer
- * (YYYY.M.D[-N]). All other packages (libs, private stub binaries) keep
- * changesets' SemVer bumps.
- *
- * Run after `pnpm exec changeset version` in CI, before `pnpm publish -r`.
- *
- * Currently the only published binary is `cycling-coach`. When `running-coach`
- * or `duathlon-coach` graduate from private stubs to real npm-published
- * binaries, add their names to BINARY_PACKAGES. See ADR-0010.
- *
- * Same-day re-release strategy:
- *   The -N suffix handles multiple binary releases on a single day. The next
- *   available suffix is determined by querying npm for the latest published
- *   version of each binary package (`npm view <pkg> version`), not by reading
- *   the local package.json. The local file is whatever changesets last wrote
- *   to it on this CI run; npm is the source of truth for what already exists.
- *
- *   Example: if 2026.5.1 and 2026.5.1-1 are already on npm and we run again
- *   today, npm view returns "2026.5.1-1" and this script writes "2026.5.1-2"
- *   into the local package.json so `pnpm publish -r` succeeds.
- *
- * Network failure fallback:
- *   If `npm view` fails (registry down, package never published, no network)
- *   or exceeds the 30s execSync timeout, we fall back to today's CalVer base
- *   and log a warning naming the failed package + reason. On a first publish
- *   this is correct; on a subsequent publish with no network the publish step
- *   will fail with a "version already exists" error — surfaced clearly to the
- *   operator rather than silently corrupting state.
- */
-import { execSync } from "node:child_process";
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
 
-const BINARY_PACKAGES = ["cycling-coach"];
+import { execFileSync as nodeExecFileSync } from "node:child_process";
+import {
+  existsSync as nodeExistsSync,
+  readFileSync as nodeReadFileSync,
+  writeFileSync as nodeWriteFileSync,
+} from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join, resolve } from "node:path";
 
-function todayCalVer(): string {
-  const now = new Date();
-  const y = now.getFullYear();
-  const m = now.getMonth() + 1;
-  const d = now.getDate();
-  return `${y}.${m}.${d}`;
+export const BINARY_PACKAGES = ["cycling-coach"] as const;
+
+export interface CalVer {
+  readonly version: string;
+  readonly year: number;
+  readonly month: number;
+  readonly patch: number;
+  readonly legacyRevision: number;
 }
 
-function getLatestPublishedVersion(pkg: string): string | null {
-  try {
-    return execSync(`npm view ${pkg} version`, {
-      encoding: "utf-8",
-      stdio: ["ignore", "pipe", "ignore"],
-      timeout: 30_000,
-    }).trim();
-  } catch (err) {
-    console.warn(
-      `npm view ${pkg} failed (${err instanceof Error ? err.message : String(err)}). Falling back to today's CalVer base.`,
-    );
+const CALVER_PATTERN = /^([1-9]\d{3})\.([1-9]\d*)\.(0|[1-9]\d*)(?:-(0|[1-9]\d*))?$/;
+const IGNORED_LEGACY_REGISTRY_VERSIONS = new Set(["0.0.1"]);
+
+export function parseCalVer(version: string): CalVer | null {
+  const match = CALVER_PATTERN.exec(version);
+  if (match === null) return null;
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const patch = Number(match[3]);
+  const legacyRevision = match[4] === undefined ? 0 : Number(match[4]);
+  if (month > 12 || !Number.isSafeInteger(patch) || !Number.isSafeInteger(legacyRevision)) {
     return null;
   }
+  return { version, year, month, patch, legacyRevision };
 }
 
-function nextCalVer(pkg: string, base: string): string {
-  const latest = getLatestPublishedVersion(pkg);
-  if (!latest) return base;
-  if (latest === base) return `${base}-1`;
-  const m = latest.match(new RegExp(`^${base.replace(/\./g, "\\.")}-(\\d+)$`));
-  if (m) return `${base}-${parseInt(m[1], 10) + 1}`;
-  return base;
-}
-
-const packagesDir = "packages";
-const today = todayCalVer();
-
-/**
- * After overriding package.json, rewrite the latest `## <version>` header in
- * CHANGELOG.md so it matches. `changeset version` writes the SemVer header
- * before our override runs, so without this the header lags by one release.
- * Only the FIRST `## ` line is rewritten — historical entries are preserved.
- */
-function rewriteChangelogHeader(pkg: string, oldVersion: string, newVersion: string): void {
-  const changelogPath = join(packagesDir, pkg, "CHANGELOG.md");
-  if (!existsSync(changelogPath)) return;
-  const contents = readFileSync(changelogPath, "utf-8");
-  const headerNeedle = `## ${oldVersion}`;
-  const headerIndex = contents.indexOf(headerNeedle);
-  if (headerIndex === -1) {
-    console.warn(
-      `${pkg}: CHANGELOG.md has no '${headerNeedle}' header to rewrite — leaving as-is`,
-    );
-    return;
-  }
-  const updated =
-    contents.slice(0, headerIndex) +
-    `## ${newVersion}` +
-    contents.slice(headerIndex + headerNeedle.length);
-  writeFileSync(changelogPath, updated);
-  console.log(`${pkg}: CHANGELOG.md header ${oldVersion} → ${newVersion}`);
-}
-
-for (const pkg of BINARY_PACKAGES) {
-  const pkgJsonPath = join(packagesDir, pkg, "package.json");
-  let pkgJson: { version: string; [k: string]: unknown };
+export function parseRegistryVersions(registryJson: string): string[] {
+  let parsed: unknown;
   try {
-    pkgJson = JSON.parse(readFileSync(pkgJsonPath, "utf-8"));
+    parsed = JSON.parse(registryJson);
   } catch {
-    console.error(`skip: ${pkgJsonPath} not found`);
-    continue;
+    throw new Error("npm registry JSON is malformed");
   }
-  const oldVersion = pkgJson.version;
-  const newVersion = nextCalVer(pkg, today);
-  if (newVersion === oldVersion) {
-    console.log(`${pkg}: already ${newVersion} (no bump)`);
-    continue;
+  if (!Array.isArray(parsed)) {
+    throw new Error("npm registry JSON must contain a versions array");
   }
-  pkgJson.version = newVersion;
-  writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2) + "\n");
-  rewriteChangelogHeader(pkg, oldVersion, newVersion);
-  console.log(`${pkg}: ${oldVersion} → ${newVersion}`);
+  return parsed.flatMap((version, index) => {
+    if (typeof version !== "string") {
+      throw new Error(`Malformed npm registry version at index ${index}`);
+    }
+    if (IGNORED_LEGACY_REGISTRY_VERSIONS.has(version)) return [];
+    if (parseCalVer(version) === null) {
+      throw new Error(`Malformed npm registry version at index ${index}`);
+    }
+    return [version];
+  });
+}
+
+function compareCalVer(left: CalVer, right: CalVer): number {
+  for (const key of ["year", "month", "patch", "legacyRevision"] as const) {
+    if (left[key] !== right[key]) return left[key] - right[key];
+  }
+  return 0;
+}
+
+export function nextCalVer(occupiedVersions: readonly string[], now: Date): string {
+  if (Number.isNaN(now.getTime())) throw new Error("Current UTC clock is invalid");
+  const year = now.getUTCFullYear();
+  const month = now.getUTCMonth() + 1;
+  if (year < 1000 || year > 9999) {
+    throw new Error(`Current UTC year ${year} cannot be represented as CalVer`);
+  }
+
+  const occupied = occupiedVersions.map((version) => {
+    const parsed = parseCalVer(version);
+    if (parsed === null) throw new Error(`Invalid occupied CalVer version: ${version}`);
+    return parsed;
+  });
+  if (occupied.length === 0) throw new Error("At least one occupied CalVer version is required");
+
+  const maximum = occupied.reduce((left, right) =>
+    compareCalVer(left, right) >= 0 ? left : right,
+  );
+  if (year < maximum.year || (year === maximum.year && month < maximum.month)) {
+    throw new Error(
+      `Current UTC period ${year}.${month} precedes occupied version ${maximum.version}`,
+    );
+  }
+  if (year !== maximum.year || month !== maximum.month) return `${year}.${month}.0`;
+  if (maximum.patch === Number.MAX_SAFE_INTEGER) {
+    throw new Error(`CalVer patch would overflow after ${maximum.version}`);
+  }
+  return `${year}.${month}.${maximum.patch + 1}`;
+}
+
+export interface ChangelogRewrite {
+  readonly contents: string;
+  readonly changed: boolean;
+}
+
+export function rewriteFirstChangelogHeader(
+  contents: string,
+  oldVersion: string,
+  newVersion: string,
+): ChangelogRewrite {
+  const heading = /^## ([^\r\n]+)(?=\r?$)/m.exec(contents);
+  if (heading === null || heading[1] !== oldVersion) return { contents, changed: false };
+  const headerNeedle = heading[0];
+  const headerIndex = heading.index;
+  return {
+    contents:
+      contents.slice(0, headerIndex) +
+      `## ${newVersion}` +
+      contents.slice(headerIndex + headerNeedle.length),
+    changed: true,
+  };
+}
+
+export interface BinaryVersionPlanInput {
+  readonly packageName: string;
+  readonly packageJsonPath: string;
+  readonly changelogPath: string;
+  readonly packageJsonContents: string;
+  readonly committedPackageJsonContents: string;
+  readonly registryVersionsJson: string;
+  readonly changelogContents?: string;
+  readonly now: Date;
+}
+
+export interface BinaryVersionPlan {
+  readonly packageName: string;
+  readonly packageJsonPath: string;
+  readonly changelogPath: string;
+  readonly oldVersion: string;
+  readonly committedVersion: string;
+  readonly newVersion: string;
+  readonly packageJsonContents: string;
+  readonly changelogContents?: string;
+  readonly packageChanged: boolean;
+  readonly changelogChanged: boolean;
+}
+
+function parsePackageManifest(
+  contents: string,
+  label: string,
+): { manifest: Record<string, unknown>; version: string } {
+  let manifest: unknown;
+  try {
+    manifest = JSON.parse(contents);
+  } catch {
+    throw new Error(`${label} package.json is malformed`);
+  }
+  if (
+    manifest === null ||
+    typeof manifest !== "object" ||
+    Array.isArray(manifest) ||
+    typeof (manifest as Record<string, unknown>).version !== "string" ||
+    ((manifest as Record<string, unknown>).version as string).length === 0
+  ) {
+    throw new Error(`${label} package.json has an invalid version`);
+  }
+  return {
+    manifest: manifest as Record<string, unknown>,
+    version: (manifest as Record<string, unknown>).version as string,
+  };
+}
+
+export function planBinaryVersionBump(input: BinaryVersionPlanInput): BinaryVersionPlan {
+  const working = parsePackageManifest(input.packageJsonContents, input.packageName);
+  const committed = parsePackageManifest(
+    input.committedPackageJsonContents,
+    `${input.packageName} committed`,
+  );
+  if (parseCalVer(committed.version) === null) {
+    throw new Error(
+      `${input.packageName} committed version is not valid CalVer: ${committed.version}`,
+    );
+  }
+
+  if (input.changelogContents === undefined) {
+    throw new Error(`${input.packageName}: CHANGELOG.md is required`);
+  }
+  const currentHeading = /^## ([^\r\n]+)(?=\r?$)/m.exec(input.changelogContents);
+  if (currentHeading === null || currentHeading[1] !== working.version) {
+    throw new Error(`${input.packageName}: CHANGELOG.md top release header is inconsistent`);
+  }
+
+  if (working.version === committed.version) {
+    return {
+      packageName: input.packageName,
+      packageJsonPath: input.packageJsonPath,
+      changelogPath: input.changelogPath,
+      oldVersion: working.version,
+      committedVersion: committed.version,
+      newVersion: working.version,
+      packageJsonContents: input.packageJsonContents,
+      changelogContents: input.changelogContents,
+      packageChanged: false,
+      changelogChanged: false,
+    };
+  }
+
+  const publishedVersions = parseRegistryVersions(input.registryVersionsJson);
+  const newVersion = nextCalVer([committed.version, ...publishedVersions], input.now);
+  const packageChanged = working.version !== newVersion;
+  const packageJsonContents = packageChanged
+    ? `${JSON.stringify({ ...working.manifest, version: newVersion }, null, 2)}\n`
+    : input.packageJsonContents;
+
+  let changelogContents = input.changelogContents;
+  let changelogChanged = false;
+  if (packageChanged) {
+    const rewrite = rewriteFirstChangelogHeader(changelogContents, working.version, newVersion);
+    if (!rewrite.changed) {
+      throw new Error(`${input.packageName}: CHANGELOG.md top release header is inconsistent`);
+    }
+    changelogContents = rewrite.contents;
+    changelogChanged = rewrite.changed;
+  }
+  const plannedHeading = /^## ([^\r\n]+)(?=\r?$)/m.exec(changelogContents);
+  if (plannedHeading === null || plannedHeading[1] !== newVersion) {
+    throw new Error(`${input.packageName}: CHANGELOG.md planned release header is inconsistent`);
+  }
+
+  return {
+    packageName: input.packageName,
+    packageJsonPath: input.packageJsonPath,
+    changelogPath: input.changelogPath,
+    oldVersion: working.version,
+    committedVersion: committed.version,
+    newVersion,
+    packageJsonContents,
+    changelogContents,
+    packageChanged,
+    changelogChanged,
+  };
+}
+
+interface CommandOptions {
+  readonly cwd: string;
+  readonly encoding: "utf8";
+  readonly stdio: readonly ["ignore", "pipe", "pipe"];
+  readonly timeout: number;
+}
+
+export interface CalVerBumpDependencies {
+  readonly execFileSync: (
+    command: string,
+    args: readonly string[],
+    options: CommandOptions,
+  ) => string;
+  readonly readFileSync: (path: string, encoding: "utf8") => string;
+  readonly writeFileSync: (path: string, contents: string) => void;
+  readonly existsSync: (path: string) => boolean;
+  readonly log: (message: string) => void;
+}
+
+export interface CalVerBumpOptions {
+  readonly rootDir?: string;
+  readonly now?: Date;
+  readonly packages?: readonly string[];
+  readonly dependencies?: Partial<CalVerBumpDependencies>;
+}
+
+const defaultDependencies: CalVerBumpDependencies = {
+  execFileSync(command, args, options) {
+    return nodeExecFileSync(command, [...args], {
+      cwd: options.cwd,
+      encoding: options.encoding,
+      stdio: [...options.stdio],
+      timeout: options.timeout,
+    });
+  },
+  readFileSync(path, encoding) {
+    return nodeReadFileSync(path, encoding);
+  },
+  writeFileSync(path, contents) {
+    nodeWriteFileSync(path, contents);
+  },
+  existsSync(path) {
+    return nodeExistsSync(path);
+  },
+  log(message) {
+    console.log(message);
+  },
+};
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function commandOutput(
+  dependencies: CalVerBumpDependencies,
+  command: string,
+  args: readonly string[],
+  rootDir: string,
+  label: string,
+): string {
+  try {
+    return dependencies.execFileSync(command, args, {
+      cwd: rootDir,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: 30_000,
+    });
+  } catch {
+    throw new Error(`${label} failed`);
+  }
+}
+
+export function main(options: CalVerBumpOptions = {}): BinaryVersionPlan[] {
+  const rootDir = options.rootDir ?? process.cwd();
+  const now = options.now ?? new Date();
+  const packages = options.packages ?? BINARY_PACKAGES;
+  const dependencies: CalVerBumpDependencies = {
+    ...defaultDependencies,
+    ...options.dependencies,
+  };
+
+  const plans: BinaryVersionPlan[] = [];
+  for (const packageName of packages) {
+    const packageJsonPath = join(rootDir, "packages", packageName, "package.json");
+    const changelogPath = join(rootDir, "packages", packageName, "CHANGELOG.md");
+    const packageJsonContents = dependencies.readFileSync(packageJsonPath, "utf8");
+    const committedPackageJsonContents = commandOutput(
+      dependencies,
+      "git",
+      ["show", `HEAD:packages/${packageName}/package.json`],
+      rootDir,
+      `git show for ${packageName}`,
+    );
+    const workingVersion = parsePackageManifest(packageJsonContents, packageName).version;
+    const committedVersion = parsePackageManifest(
+      committedPackageJsonContents,
+      `${packageName} committed`,
+    ).version;
+    const registryVersionsJson =
+      workingVersion === committedVersion
+        ? "[]"
+        : commandOutput(
+            dependencies,
+            "npm",
+            ["view", packageName, "versions", "--json", "--registry=https://registry.npmjs.org"],
+            rootDir,
+            `npm view ${packageName} versions`,
+          );
+    const changelogContents = dependencies.existsSync(changelogPath)
+      ? dependencies.readFileSync(changelogPath, "utf8")
+      : undefined;
+
+    plans.push(
+      planBinaryVersionBump({
+        packageName,
+        packageJsonPath,
+        changelogPath,
+        packageJsonContents,
+        committedPackageJsonContents,
+        registryVersionsJson,
+        changelogContents,
+        now,
+      }),
+    );
+  }
+
+  for (const plan of plans) {
+    if (!plan.packageChanged) {
+      dependencies.log(`${plan.packageName}: already ${plan.newVersion} (no bump)`);
+      continue;
+    }
+    dependencies.writeFileSync(plan.packageJsonPath, plan.packageJsonContents);
+    if (plan.changelogChanged && plan.changelogContents !== undefined) {
+      dependencies.writeFileSync(plan.changelogPath, plan.changelogContents);
+      dependencies.log(
+        `${plan.packageName}: CHANGELOG.md header ${plan.oldVersion} → ${plan.newVersion}`,
+      );
+    }
+    dependencies.log(`${plan.packageName}: ${plan.oldVersion} → ${plan.newVersion}`);
+  }
+
+  return plans;
+}
+
+export function runCli(
+  options: CalVerBumpOptions = {},
+  reportError: (message: string) => void = (message) => console.error(message),
+): number {
+  try {
+    main(options);
+    return 0;
+  } catch (error) {
+    reportError(errorMessage(error));
+    return 1;
+  }
+}
+
+const isCliEntry =
+  process.argv[1] !== undefined && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isCliEntry) {
+  process.exitCode = runCli();
 }


### PR DESCRIPTION
## Summary

- restore stable `YYYY.MONTH.RELEASE-WITHIN-MONTH` versions with UTC rollover and monotonic npm/repository occupancy
- preserve installed historical suffix compatibility while explicitly ignoring the package's `0.0.1` bootstrap release
- make the release planner fail closed before writes, validate only the top changelog release, and skip npm plus all writes when Changesets did not bump the binary
- pin registry allocation to npmjs and keep child-process or registry-controlled text out of release logs
- align updater tests and contributor/package versioning guidance with the stable policy

## Validation

- `pnpm exec vitest run tools/bump-binaries-to-calver.test.ts packages/core/tests/updater.test.ts` — 51 passed
- `pnpm --filter @enduragent/core check`
- focused TypeScript compile for the version tool and tests
- scoped oxlint, oxfmt, and `git diff --check`
- live npm version history checked against the compatibility matrix
- three read-only release/security/architecture reviews passed

## Scope

This is the version-policy foundation for Desktop self-update. Updater state/IPC, signed packaging, and the real two-version round trip remain separate slices.

No changeset: this changes release allocation infrastructure and does not alter the currently shipped athlete experience.
