### PR TITLE
feat(kernel): add canonical activity reader

### DIFF
--- a/packages/kernel-node/tests/canonical-activity-reader.test.ts
+++ b/packages/kernel-node/tests/canonical-activity-reader.test.ts
@@ -1,0 +1,258 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createCanonicalActivityReader, runMigrations } from "@enduragent/kernel/store";
+import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
+import { importFilesWithReport } from "../src/ingest/import-files.js";
+import { openReadonlySqliteStorage, openSqliteStorage } from "../src/sqlite/index.js";
+
+const roots = new Set<string>();
+const fixture = (name: string) => resolve(`packages/kernel-node/tests/fixtures/ingest/${name}`);
+
+afterEach(() => {
+  for (const root of roots) rmSync(root, { recursive: true, force: true });
+  roots.clear();
+});
+
+async function importedStore(
+  inputPaths: readonly string[] = [fixture("triathlon-multisport.fit")],
+) {
+  const root = mkdtempSync(join(tmpdir(), "canonical-reader-"));
+  roots.add(root);
+  const databasePath = join(root, "store.sqlite");
+  const writer = openSqliteStorage(databasePath);
+  await runMigrations(writer, MIGRATIONS);
+  await importFilesWithReport({
+    inputPaths,
+    archiveDir: join(root, "archive"),
+    store: writer,
+  });
+  return { databasePath, writer };
+}
+
+async function canonicalFixtureSnapshot(
+  databasePath: string,
+  activityId?: string,
+  channels?: readonly string[],
+) {
+  const store = openReadonlySqliteStorage(databasePath);
+  try {
+    const reader = createCanonicalActivityReader(store);
+    const page = await reader.listActivities({
+      start: "1998-07-01",
+      end: "1998-07-31",
+      limit: 20,
+    });
+    const selectedId = activityId ?? page.activities.find(({ sport }) => sport === "cycling")!.id;
+    return {
+      page,
+      detail: await reader.getActivity({ id: selectedId }),
+      streams: await reader.getStreams({
+        id: selectedId,
+        channels: channels ?? ["time", "power", "heart_rate", "cadence"],
+      }),
+    };
+  } finally {
+    await store.close();
+  }
+}
+
+describe("canonical activity reader with real SQLite", () => {
+  it("reads multisport sessions, transitions, laps, and streams identically after reopen", async () => {
+    const { databasePath, writer } = await importedStore();
+    try {
+      const cycling = await writer.get("SELECT session_key FROM session WHERE sport='cycling'");
+      const activityId = String(cycling!.session_key);
+      const channels = (
+        await writer.all("SELECT channel FROM stream WHERE session_key=? ORDER BY channel", [
+          activityId,
+        ])
+      ).map((row) => String(row.channel));
+
+      const first = await canonicalFixtureSnapshot(databasePath, activityId, channels);
+      expect(first.page.activities).toHaveLength(5);
+      expect(first.page.activities.map(({ sessionSequence }) => sessionSequence)).toEqual([
+        4, 3, 2, 1, 0,
+      ]);
+      expect(first.page.activities.every(({ isMultisport }) => isMultisport)).toBe(true);
+      expect(
+        first.page.activities.filter(({ isTransition }) => isTransition).map(({ sport }) => sport),
+      ).toEqual(["transition", "transition"]);
+      expect(first.detail?.laps.length).toBeGreaterThan(0);
+      expect(Object.keys(first.streams?.channels ?? {})).toEqual(channels);
+      expect(channels.length).toBeGreaterThan(0);
+
+      const bytesBeforeClose = JSON.stringify(first);
+      await writer.close();
+      const reopened = await canonicalFixtureSnapshot(databasePath, activityId, channels);
+      expect(JSON.stringify(reopened)).toBe(bytesBeforeClose);
+    } catch (error) {
+      await writer.close().catch(() => undefined);
+      throw error;
+    }
+  });
+
+  it("shows one complete committed version across a writer transaction", async () => {
+    const { databasePath, writer } = await importedStore();
+    const readonly = openReadonlySqliteStorage(databasePath);
+    try {
+      const selected = await writer.get(
+        `SELECT s.session_key
+FROM session AS s
+WHERE EXISTS (SELECT 1 FROM lap AS l WHERE l.session_key = s.session_key)
+ORDER BY s.session_key
+LIMIT 1`,
+      );
+      const activityId = String(selected!.session_key);
+      const reader = createCanonicalActivityReader(readonly);
+      const before = await reader.getActivity({ id: activityId });
+      expect(before?.laps.length).toBeGreaterThan(0);
+
+      await writer.exec("BEGIN IMMEDIATE");
+      await writer.run("UPDATE session SET distance_m=? WHERE session_key=?", [
+        12_345.5,
+        activityId,
+      ]);
+      await writer.run("UPDATE lap SET distance_m=? WHERE session_key=?", [1_234.5, activityId]);
+      expect(await reader.getActivity({ id: activityId })).toEqual(before);
+      await writer.exec("COMMIT");
+
+      const after = await reader.getActivity({ id: activityId });
+      expect(after?.distanceMeters).toBe(12_345.5);
+      expect(after?.laps.every(({ distanceMeters }) => distanceMeters === 1_234.5)).toBe(true);
+    } finally {
+      await readonly.close();
+      await writer.close();
+    }
+  });
+
+  it("reports unsupported and corrupt persisted streams as typed decode failures", async () => {
+    const { databasePath, writer } = await importedStore();
+    const readonly = openReadonlySqliteStorage(databasePath);
+    try {
+      const selected = await writer.get(
+        "SELECT stream_key,session_key,channel,encoding FROM stream ORDER BY stream_key LIMIT 1",
+      );
+      const streamKey = String(selected!.stream_key);
+      const activityId = String(selected!.session_key);
+      const channel = String(selected!.channel);
+      const encoding = String(selected!.encoding);
+      const reader = createCanonicalActivityReader(readonly);
+
+      await writer.run("UPDATE stream SET encoding='unsupported' WHERE stream_key=?", [streamKey]);
+      await expect(reader.getStreams({ id: activityId, channels: [channel] })).rejects.toEqual(
+        expect.objectContaining({
+          name: "CanonicalActivityReadError",
+          code: "stream_decode_failed",
+        }),
+      );
+
+      await writer.run("UPDATE stream SET encoding=?,data=? WHERE stream_key=?", [
+        encoding,
+        new Uint8Array([1]),
+        streamKey,
+      ]);
+      await expect(reader.getStreams({ id: activityId, channels: [channel] })).rejects.toEqual(
+        expect.objectContaining({
+          name: "CanonicalActivityReadError",
+          code: "stream_decode_failed",
+        }),
+      );
+    } finally {
+      await readonly.close();
+      await writer.close();
+    }
+  });
+
+  it("caps lap rows with a real SQLite sentinel read", async () => {
+    const { databasePath, writer } = await importedStore();
+    try {
+      const selected = await writer.get(
+        "SELECT session_key FROM session ORDER BY session_key LIMIT 1",
+      );
+      const activityId = String(selected!.session_key);
+      await writer.run("DELETE FROM lap WHERE session_key=?", [activityId]);
+      await writer.run(
+        `WITH RECURSIVE seq(x) AS (
+  SELECT 0
+  UNION ALL
+  SELECT x + 1 FROM seq WHERE x < 10000
+)
+INSERT INTO lap (
+  lap_key, session_key, lap_seq, start_utc, elapsed_s, timer_s, distance_m, summary_json
+)
+SELECT printf('%064x', x + 1), ?, x, NULL, NULL, NULL, NULL, NULL
+FROM seq`,
+        [activityId],
+      );
+      const readonly = openReadonlySqliteStorage(databasePath);
+      try {
+        await expect(
+          createCanonicalActivityReader(readonly).getActivity({ id: activityId }),
+        ).rejects.toEqual(expect.objectContaining({ code: "invalid_row" }));
+      } finally {
+        await readonly.close();
+      }
+    } finally {
+      await writer.close();
+    }
+  });
+
+  it("projects oversized text to a small invalid sentinel before rows reach JavaScript", async () => {
+    const { databasePath, writer } = await importedStore();
+    try {
+      const selected = await writer.get(
+        "SELECT session_key FROM session ORDER BY session_key LIMIT 1",
+      );
+      const activityId = String(selected!.session_key);
+      const marker = `oversized-sport-marker-${"x".repeat(256)}`;
+      await writer.run("UPDATE session SET sport=? WHERE session_key=?", [marker, activityId]);
+      const readonly = openReadonlySqliteStorage(databasePath);
+      const captured: unknown[] = [];
+      try {
+        const reader = createCanonicalActivityReader({
+          async all(sql, params = []) {
+            const rows = await readonly.all(sql, params);
+            captured.push(rows);
+            return rows;
+          },
+        });
+        await expect(reader.getActivity({ id: activityId })).rejects.toEqual(
+          expect.objectContaining({ code: "invalid_row" }),
+        );
+        expect(JSON.stringify(captured)).not.toContain("oversized-sport-marker");
+      } finally {
+        await readonly.close();
+      }
+    } finally {
+      await writer.close();
+    }
+  });
+
+  it("keeps every committed ingest fixture below the reader stream caps", async () => {
+    const manifest = JSON.parse(readFileSync(fixture("manifest.json"), "utf8")) as {
+      readonly files: readonly { readonly path: string }[];
+    };
+    const { writer } = await importedStore(manifest.files.map(({ path }) => resolve(path)));
+    try {
+      const maxima = await writer.get(
+        `SELECT max(n) AS max_n, max(length(data)) AS max_blob_bytes
+FROM stream`,
+      );
+      const perSession = await writer.get(
+        `SELECT max(total_n) AS max_total_n
+FROM (
+  SELECT sum(n) AS total_n
+  FROM stream
+  GROUP BY session_key
+)`,
+      );
+      expect(Number(maxima!.max_n)).toBeLessThanOrEqual(1_000_000);
+      expect(Number(maxima!.max_blob_bytes)).toBeLessThanOrEqual(16 * 1_024 * 1_024);
+      expect(Number(perSession!.max_total_n)).toBeLessThanOrEqual(4_000_000);
+    } finally {
+      await writer.close();
+    }
+  });
+});

--- a/packages/kernel-node/tests/inv2-ingest-order.test.ts
+++ b/packages/kernel-node/tests/inv2-ingest-order.test.ts
@@ -6,7 +6,13 @@ import { afterEach, describe, expect, it } from "vitest";
 import { canonicalPick, createMaterializeClusterInTransaction, importArtifactsWithReport, type ConcernValue,
   type ImportArtifact, type PlatformImportArtifact, type RepairFixerSettings } from "@enduragent/kernel/ingest";
 import type { ArchiveManager } from "@enduragent/kernel/archive";
-import { dumpStore, runMigrations, sortKeys } from "@enduragent/kernel/store";
+import {
+  createCanonicalActivityReader,
+  dumpStore,
+  runMigrations,
+  sortKeys,
+  type SqlReadStore,
+} from "@enduragent/kernel/store";
 import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
 import { createNodeImportRuntime, importFilesWithReport } from "../src/ingest/import-files.js";
 import { openSqliteStorage } from "../src/sqlite/index.js";
@@ -80,6 +86,44 @@ function matchingPlatformArtifact(): PlatformImportArtifact {
     concerns, raw_snapshot_address: null, raw_snapshot_rel_path: null };
 }
 
+const streamChannelGroups = [
+  [
+    "time",
+    "lat",
+    "lng",
+    "distance",
+    "heart_rate",
+    "cadence",
+    "fractional_cadence",
+    "power",
+    "temperature",
+    "altitude",
+    "speed",
+    "stance_time",
+    "stance_time_balance",
+    "vertical_oscillation",
+    "vertical_ratio",
+    "step_length",
+  ],
+  ["left_right_balance", "respiration_rate"],
+] as const;
+
+async function serializedCanonicalReaderOutput(store: Pick<SqlReadStore, "all">): Promise<string> {
+  const reader = createCanonicalActivityReader(store);
+  const page = await reader.listActivities({ start: "1998-07-01", end: "1998-07-31", limit: 200 });
+  return JSON.stringify({
+    page,
+    activities: await Promise.all(
+      page.activities.map(async ({ id }) => ({
+        detail: await reader.getActivity({ id }),
+        streams: await Promise.all(
+          streamChannelGroups.map((channels) => reader.getStreams({ id, channels })),
+        ),
+      })),
+    ),
+  });
+}
+
 describe("real SQLite dedup ordering", () => {
   it("[PR05-SQL-001] makes forward and reverse paths converge to identical state", async () => {
     const left = await fresh(), right = await fresh();
@@ -88,6 +132,8 @@ describe("real SQLite dedup ordering", () => {
       const a = await importFilesWithReport({ inputPaths: files, archiveDir: left.archiveDir, store: left.store });
       const b = await importFilesWithReport({ inputPaths: [...files].reverse(), archiveDir: right.archiveDir, store: right.store });
       expect(await dumpStore(left.store)).toBe(await dumpStore(right.store));
+      expect(await serializedCanonicalReaderOutput(left.store))
+        .toBe(await serializedCanonicalReaderOutput(right.store));
       expect({ ...a, files: [] }).toEqual({ ...b, files: [] });
     } finally { await left.store.close(); await right.store.close(); }
   });
@@ -132,6 +178,8 @@ describe("real SQLite dedup ordering", () => {
         expect(await value.store.get("SELECT count(*) c FROM session")).toEqual({ c: 1 });
       }
       expect(await dumpStore(apiFirst.store)).toBe(await dumpStore(fitFirst.store));
+      expect(await serializedCanonicalReaderOutput(apiFirst.store))
+        .toBe(await serializedCanonicalReaderOutput(fitFirst.store));
       const before = await dumpStore(apiFirst.store);
       const replayApi = await leftRuntime.importBatchWithReport({ files: [], platform_records: [platform] });
       const replayFit = await importFilesWithReport({ inputPaths: [fitPath], archiveDir: apiFirst.archiveDir, store: apiFirst.store });

--- a/packages/kernel/src/ingest/stream-codec.ts
+++ b/packages/kernel/src/ingest/stream-codec.ts
@@ -41,16 +41,14 @@ export interface DecodeStreamInput {
   readonly n: number;
   readonly kind: StreamKind;
   readonly data: Uint8Array;
+  readonly maxInflatedBytes?: number;
 }
 
 function validN(n: number): boolean {
   return Number.isSafeInteger(n) && n >= 1 && n <= 0xffffffff;
 }
 
-export function encodeStream(
-  kind: StreamKind,
-  values: readonly (number | null)[],
-): EncodedStream {
+export function encodeStream(kind: StreamKind, values: readonly (number | null)[]): EncodedStream {
   const n = values.length;
   if (!validN(n)) throw new StreamCodecError("invalid_n");
   for (const value of values) {
@@ -87,11 +85,27 @@ export function encodeStream(
 
 export function decodeStream(input: DecodeStreamInput): readonly (number | null)[] {
   if (input.encoding !== STREAM_ENCODING) throw new StreamCodecError("unsupported_encoding");
+  if (!validN(input.n)) throw new StreamCodecError("invalid_n");
+  const maxInflatedBytes = input.maxInflatedBytes;
+  if (
+    maxInflatedBytes !== undefined &&
+    (!Number.isSafeInteger(maxInflatedBytes) ||
+      maxInflatedBytes < 0 ||
+      maxInflatedBytes >= 0xffffffff)
+  ) {
+    throw new StreamCodecError("payload_length");
+  }
   let payload: Uint8Array;
   try {
-    payload = unzlibSync(input.data);
+    payload =
+      maxInflatedBytes === undefined
+        ? unzlibSync(input.data)
+        : unzlibSync(input.data, { out: new Uint8Array(maxInflatedBytes + 1) });
   } catch {
     throw new StreamCodecError("inflate_failed");
+  }
+  if (maxInflatedBytes !== undefined && payload.length > maxInflatedBytes) {
+    throw new StreamCodecError("payload_length");
   }
   if (payload.length < 16) throw new StreamCodecError("payload_length");
   if (payload[0] !== 0x53 || payload[1] !== 0x54 || payload[2] !== 0x52 || payload[3] !== 0x4d)
@@ -102,7 +116,7 @@ export function decodeStream(input: DecodeStreamInput): readonly (number | null)
   if (payload[7] !== 0) throw new StreamCodecError("bad_endian");
   const view = new DataView(payload.buffer, payload.byteOffset, payload.byteLength);
   const headerN = view.getUint32(8, true);
-  if (!validN(input.n) || !validN(headerN)) throw new StreamCodecError("invalid_n");
+  if (!validN(headerN)) throw new StreamCodecError("invalid_n");
   if (headerN !== input.n) throw new StreamCodecError("n_mismatch");
   const bitmapLength = view.getUint32(12, true);
   const expectedBitmapLength = Math.ceil(headerN / 8);

--- a/packages/kernel/src/store/canonical-activity-reader.ts
+++ b/packages/kernel/src/store/canonical-activity-reader.ts
@@ -1,0 +1,738 @@
+import type { Row, SqlReadStore } from "./ports.js";
+import { decodeStream, STREAM_ENCODING } from "../ingest/stream-codec.js";
+
+export type CanonicalSessionId = string;
+
+export interface CanonicalActivityCursor {
+  readonly startEpochSeconds: number;
+  readonly id: CanonicalSessionId;
+}
+
+export interface CanonicalActivitySummary {
+  readonly id: CanonicalSessionId;
+  readonly workoutId: string;
+  readonly sessionSequence: number;
+  readonly isMultisport: boolean;
+  readonly sport: string;
+  readonly subSport: string | null;
+  readonly isTransition: boolean;
+  readonly startEpochSeconds: number;
+  readonly timezoneOffsetSeconds: number | null;
+  readonly localDate: string;
+  readonly elapsedSeconds: number | null;
+  readonly timerSeconds: number | null;
+  readonly movingSeconds: number | null;
+  readonly distanceMeters: number | null;
+}
+
+export interface CanonicalActivityLap {
+  readonly lapSequence: number;
+  readonly startEpochSeconds: number | null;
+  readonly elapsedSeconds: number | null;
+  readonly timerSeconds: number | null;
+  readonly distanceMeters: number | null;
+}
+
+export interface CanonicalActivityDetail extends CanonicalActivitySummary {
+  readonly laps: readonly CanonicalActivityLap[];
+}
+
+export interface CanonicalActivityPage {
+  readonly activities: readonly CanonicalActivitySummary[];
+  readonly nextCursor: CanonicalActivityCursor | null;
+}
+
+export interface CanonicalActivityStreams {
+  readonly activityId: CanonicalSessionId;
+  readonly channels: Readonly<Record<string, readonly (number | null)[]>>;
+}
+
+export type CanonicalActivityReadErrorCode =
+  | "invalid_input"
+  | "invalid_row"
+  | "stream_limit_exceeded"
+  | "stream_decode_failed";
+
+export class CanonicalActivityReadError extends Error {
+  readonly code: CanonicalActivityReadErrorCode;
+
+  constructor(code: CanonicalActivityReadErrorCode) {
+    super(`canonical activity read rejected: ${code}`);
+    this.name = "CanonicalActivityReadError";
+    this.code = code;
+  }
+}
+
+export interface CanonicalActivityReader {
+  listActivities(input: {
+    readonly start: string;
+    readonly end: string;
+    readonly limit?: number;
+    readonly cursor?: CanonicalActivityCursor;
+  }): Promise<CanonicalActivityPage>;
+  getActivity(input: { readonly id: string }): Promise<CanonicalActivityDetail | undefined>;
+  getStreams(input: {
+    readonly id: string;
+    readonly channels: readonly string[];
+  }): Promise<CanonicalActivityStreams | undefined>;
+}
+
+const SESSION_ID = /^[0-9a-f]{64}$/;
+const CIVIL_DATE = /^\d{4}-\d{2}-\d{2}$/;
+const DAY_MS = 86_400_000;
+const MAX_CHANNELS = 16;
+const MAX_LAPS = 10_000;
+const MAX_STREAM_SAMPLES = 1_000_000;
+const MAX_TOTAL_STREAM_SAMPLES = 4_000_000;
+const MAX_STREAM_BLOB_BYTES = 16 * 1_024 * 1_024;
+const MAX_TOTAL_STREAM_BLOB_BYTES = 64 * 1_024 * 1_024;
+const PUBLIC_STREAM_CHANNELS = new Set([
+  "time",
+  "lat",
+  "lng",
+  "distance",
+  "altitude",
+  "speed",
+  "heart_rate",
+  "cadence",
+  "fractional_cadence",
+  "power",
+  "temperature",
+  "stance_time",
+  "stance_time_balance",
+  "vertical_oscillation",
+  "vertical_ratio",
+  "step_length",
+  "left_right_balance",
+  "respiration_rate",
+]);
+
+function invalidInput(): never {
+  throw new CanonicalActivityReadError("invalid_input");
+}
+
+function invalidRow(): never {
+  throw new CanonicalActivityReadError("invalid_row");
+}
+
+function isSessionId(value: unknown): value is CanonicalSessionId {
+  return typeof value === "string" && SESSION_ID.test(value);
+}
+
+function strictUtf8Length(value: string): number | undefined {
+  let bytes = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    const codeUnit = value.charCodeAt(index);
+    if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
+      if (index + 1 >= value.length) return undefined;
+      const next = value.charCodeAt(index + 1);
+      if (next < 0xdc00 || next > 0xdfff) return undefined;
+      bytes += 4;
+      index += 1;
+    } else if (codeUnit >= 0xdc00 && codeUnit <= 0xdfff) {
+      return undefined;
+    } else if (codeUnit <= 0x7f) {
+      bytes += 1;
+    } else if (codeUnit <= 0x7ff) {
+      bytes += 2;
+    } else {
+      bytes += 3;
+    }
+  }
+  return bytes;
+}
+
+function isPublicStreamChannel(value: unknown): value is string {
+  return typeof value === "string" && PUBLIC_STREAM_CHANNELS.has(value);
+}
+
+function civilDateEpoch(value: unknown): number {
+  if (typeof value !== "string" || !CIVIL_DATE.test(value)) invalidInput();
+  const epoch = Date.parse(`${value}T00:00:00.000Z`);
+  if (!Number.isFinite(epoch) || new Date(epoch).toISOString().slice(0, 10) !== value) {
+    invalidInput();
+  }
+  return epoch;
+}
+
+function dateKey(value: string): number {
+  return Number(value.replaceAll("-", ""));
+}
+
+function readString(row: Row, key: string): string {
+  const value = row[key];
+  if (typeof value !== "string") invalidRow();
+  return value;
+}
+
+function readNonemptyString(row: Row, key: string): string {
+  const value = readString(row, key);
+  if (value.length === 0) invalidRow();
+  return value;
+}
+
+function readBoundedNonemptyString(row: Row, key: string, maxBytes: number): string {
+  const value = readNonemptyString(row, key);
+  const bytes = strictUtf8Length(value);
+  if (bytes === undefined || bytes > maxBytes) invalidRow();
+  return value;
+}
+
+function readBoundedNullableString(
+  row: Row,
+  key: string,
+  validKey: string,
+  maxBytes: number,
+): string | null {
+  if (!readFlag(row, validKey)) invalidRow();
+  const value = row[key];
+  if (value === null) return null;
+  if (typeof value !== "string" || value.length === 0) invalidRow();
+  const bytes = strictUtf8Length(value);
+  if (bytes === undefined || bytes > maxBytes) invalidRow();
+  return value;
+}
+
+function readNumber(row: Row, key: string): number {
+  const value = row[key];
+  if (typeof value !== "number" || !Number.isFinite(value)) invalidRow();
+  return value;
+}
+
+function readInteger(row: Row, key: string): number {
+  const value = readNumber(row, key);
+  if (!Number.isSafeInteger(value)) invalidRow();
+  return value;
+}
+
+function readNonnegativeInteger(row: Row, key: string): number {
+  const value = readInteger(row, key);
+  if (value < 0) invalidRow();
+  return value;
+}
+
+function readNullableInteger(row: Row, key: string): number | null {
+  if (row[key] === null) return null;
+  return readInteger(row, key);
+}
+
+function readNullableNonnegativeInteger(row: Row, key: string): number | null {
+  const value = readNullableInteger(row, key);
+  if (value !== null && value < 0) invalidRow();
+  return value;
+}
+
+function readNullableNonnegativeNumber(row: Row, key: string): number | null {
+  if (row[key] === null) return null;
+  const value = readNumber(row, key);
+  if (value < 0) invalidRow();
+  return value;
+}
+
+function readFlag(row: Row, key: string): boolean {
+  const value = readInteger(row, key);
+  if (value !== 0 && value !== 1) invalidRow();
+  return value === 1;
+}
+
+function readSessionId(row: Row, key: string): CanonicalSessionId {
+  const value = row[key];
+  if (!isSessionId(value)) invalidRow();
+  return value;
+}
+
+function localDate(row: Row): string {
+  const value = readNonnegativeInteger(row, "local_date_key");
+  const compact = String(value).padStart(8, "0");
+  if (compact.length !== 8) invalidRow();
+  const formatted = `${compact.slice(0, 4)}-${compact.slice(4, 6)}-${compact.slice(6, 8)}`;
+  const epoch = Date.parse(`${formatted}T00:00:00.000Z`);
+  if (!Number.isFinite(epoch) || new Date(epoch).toISOString().slice(0, 10) !== formatted) {
+    invalidRow();
+  }
+  return formatted;
+}
+
+function activitySummary(row: Row): CanonicalActivitySummary {
+  const id = readSessionId(row, "session_key");
+  const workoutId = readSessionId(row, "workout_key");
+  return {
+    id,
+    workoutId,
+    sessionSequence: readNonnegativeInteger(row, "session_seq"),
+    isMultisport: readFlag(row, "is_multisport"),
+    sport: readBoundedNonemptyString(row, "sport", 64),
+    subSport: readBoundedNullableString(row, "sub_sport", "sub_sport_valid", 128),
+    isTransition: readFlag(row, "is_transition"),
+    startEpochSeconds: readInteger(row, "start_utc"),
+    timezoneOffsetSeconds: readNullableInteger(row, "tz_offset_s"),
+    localDate: localDate(row),
+    elapsedSeconds: readNullableNonnegativeInteger(row, "elapsed_s"),
+    timerSeconds: readNullableNonnegativeInteger(row, "timer_s"),
+    movingSeconds: readNullableNonnegativeInteger(row, "moving_s"),
+    distanceMeters: readNullableNonnegativeNumber(row, "distance_m"),
+  };
+}
+
+function activityLap(row: Row): CanonicalActivityLap | null {
+  const lapKey = row.joined_lap_key;
+  if (lapKey === null) {
+    if (
+      row.lap_seq !== null ||
+      row.lap_start_utc !== null ||
+      row.lap_elapsed_s !== null ||
+      row.lap_timer_s !== null ||
+      row.lap_distance_m !== null
+    ) {
+      invalidRow();
+    }
+    return null;
+  }
+  if (!isSessionId(lapKey)) invalidRow();
+  return {
+    lapSequence: readNonnegativeInteger(row, "lap_seq"),
+    startEpochSeconds: readNullableInteger(row, "lap_start_utc"),
+    elapsedSeconds: readNullableNonnegativeInteger(row, "lap_elapsed_s"),
+    timerSeconds: readNullableNonnegativeInteger(row, "lap_timer_s"),
+    distanceMeters: readNullableNonnegativeNumber(row, "lap_distance_m"),
+  };
+}
+
+function sameSummary(left: CanonicalActivitySummary, right: CanonicalActivitySummary): boolean {
+  return (
+    left.id === right.id &&
+    left.workoutId === right.workoutId &&
+    left.sessionSequence === right.sessionSequence &&
+    left.isMultisport === right.isMultisport &&
+    left.sport === right.sport &&
+    left.subSport === right.subSport &&
+    left.isTransition === right.isTransition &&
+    left.startEpochSeconds === right.startEpochSeconds &&
+    left.timezoneOffsetSeconds === right.timezoneOffsetSeconds &&
+    left.localDate === right.localDate &&
+    left.elapsedSeconds === right.elapsedSeconds &&
+    left.timerSeconds === right.timerSeconds &&
+    left.movingSeconds === right.movingSeconds &&
+    left.distanceMeters === right.distanceMeters
+  );
+}
+
+function validateListInput(input: {
+  readonly start: string;
+  readonly end: string;
+  readonly limit?: number;
+  readonly cursor?: CanonicalActivityCursor;
+}): {
+  readonly start: string;
+  readonly end: string;
+  readonly startKey: number;
+  readonly endKey: number;
+  readonly limit: number;
+  readonly cursor?: CanonicalActivityCursor;
+} {
+  if (input === null || typeof input !== "object") invalidInput();
+  const startEpoch = civilDateEpoch(input.start);
+  const endEpoch = civilDateEpoch(input.end);
+  if (startEpoch > endEpoch || (endEpoch - startEpoch) / DAY_MS + 1 > 366) invalidInput();
+  const limit = input.limit ?? 100;
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > 200) invalidInput();
+  const cursor = input.cursor;
+  if (cursor !== undefined) {
+    if (
+      cursor === null ||
+      typeof cursor !== "object" ||
+      !Number.isSafeInteger(cursor.startEpochSeconds) ||
+      !isSessionId(cursor.id)
+    ) {
+      invalidInput();
+    }
+  }
+  return {
+    start: input.start,
+    end: input.end,
+    startKey: dateKey(input.start),
+    endKey: dateKey(input.end),
+    limit,
+    ...(cursor === undefined ? {} : { cursor }),
+  };
+}
+
+function validateStreamsInput(input: {
+  readonly id: string;
+  readonly channels: readonly string[];
+}): { readonly id: CanonicalSessionId; readonly channels: readonly string[] } {
+  if (
+    input === null ||
+    typeof input !== "object" ||
+    !isSessionId(input.id) ||
+    !Array.isArray(input.channels) ||
+    input.channels.length < 1 ||
+    input.channels.length > MAX_CHANNELS
+  ) {
+    invalidInput();
+  }
+  const seen = new Set<string>();
+  for (const channel of input.channels) {
+    if (!isPublicStreamChannel(channel) || seen.has(channel)) invalidInput();
+    seen.add(channel);
+  }
+  return { id: input.id, channels: input.channels };
+}
+
+interface PendingStream {
+  readonly channel: string;
+  readonly n: number;
+  readonly data: Uint8Array;
+}
+
+const SUMMARY_COLUMNS = `CASE
+    WHEN typeof(s.session_key) = 'text'
+      AND length(CAST(s.session_key AS BLOB)) <= 64 THEN s.session_key
+    ELSE NULL
+  END AS session_key,
+  CASE
+    WHEN typeof(s.workout_key) = 'text'
+      AND length(CAST(s.workout_key AS BLOB)) <= 64 THEN s.workout_key
+    ELSE NULL
+  END AS workout_key,
+  s.session_seq, w.is_multisport,
+  CASE
+    WHEN typeof(s.sport) = 'text'
+      AND length(CAST(s.sport AS BLOB)) <= 64 THEN s.sport
+    ELSE NULL
+  END AS sport,
+  CASE
+    WHEN typeof(s.sub_sport) = 'text'
+      AND length(CAST(s.sub_sport AS BLOB)) <= 128 THEN s.sub_sport
+    ELSE NULL
+  END AS sub_sport,
+  CASE
+    WHEN s.sub_sport IS NULL
+      OR (
+        typeof(s.sub_sport) = 'text'
+        AND length(CAST(s.sub_sport AS BLOB)) <= 128
+      ) THEN 1
+    ELSE 0
+  END AS sub_sport_valid,
+  s.is_transition, s.start_utc, s.tz_offset_s,
+  s.local_date_key, s.elapsed_s, s.timer_s, s.moving_s, s.distance_m`;
+
+function streamPayloadBytes(n: number): number {
+  return 16 + Math.ceil(n / 8) + n * 8;
+}
+
+export function createCanonicalActivityReader(
+  store: Pick<SqlReadStore, "all">,
+): CanonicalActivityReader {
+  return {
+    async listActivities(input) {
+      const validated = validateListInput(input);
+      const cursorSql =
+        validated.cursor === undefined
+          ? ""
+          : "\n  AND (s.start_utc < ? OR (s.start_utc = ? AND s.session_key < ?))";
+      const params =
+        validated.cursor === undefined
+          ? [validated.startKey, validated.endKey, validated.limit + 1]
+          : [
+              validated.startKey,
+              validated.endKey,
+              validated.cursor.startEpochSeconds,
+              validated.cursor.startEpochSeconds,
+              validated.cursor.id,
+              validated.limit + 1,
+            ];
+      const rows = await store.all(
+        `SELECT ${SUMMARY_COLUMNS}
+FROM session AS s
+JOIN workout AS w ON w.workout_key = s.workout_key
+WHERE s.local_date_key BETWEEN ? AND ?${cursorSql}
+ORDER BY s.start_utc DESC, s.session_key DESC
+LIMIT ?`,
+        params,
+      );
+      if (rows.length > validated.limit + 1) invalidRow();
+      const mapped = rows.map(activitySummary);
+      let boundary = validated.cursor;
+      for (const activity of mapped) {
+        if (activity.localDate < validated.start || activity.localDate > validated.end)
+          invalidRow();
+        if (
+          boundary !== undefined &&
+          !(
+            activity.startEpochSeconds < boundary.startEpochSeconds ||
+            (activity.startEpochSeconds === boundary.startEpochSeconds && activity.id < boundary.id)
+          )
+        ) {
+          invalidRow();
+        }
+        boundary = { startEpochSeconds: activity.startEpochSeconds, id: activity.id };
+      }
+      const activities = mapped.slice(0, validated.limit);
+      const last = activities.at(-1);
+      return {
+        activities,
+        nextCursor:
+          mapped.length > validated.limit && last !== undefined
+            ? { startEpochSeconds: last.startEpochSeconds, id: last.id }
+            : null,
+      };
+    },
+    async getActivity(input) {
+      if (input === null || typeof input !== "object" || !isSessionId(input.id)) invalidInput();
+      const rows = await store.all(
+        `SELECT ${SUMMARY_COLUMNS},
+  CASE
+    WHEN typeof(l.lap_key) = 'text'
+      AND length(CAST(l.lap_key AS BLOB)) <= 64 THEN l.lap_key
+    ELSE NULL
+  END AS joined_lap_key,
+  l.lap_seq,
+  l.start_utc AS lap_start_utc, l.elapsed_s AS lap_elapsed_s,
+  l.timer_s AS lap_timer_s, l.distance_m AS lap_distance_m
+FROM session AS s
+JOIN workout AS w ON w.workout_key = s.workout_key
+LEFT JOIN lap AS l ON l.session_key = s.session_key
+WHERE s.session_key = ?
+ORDER BY l.lap_seq ASC, l.lap_key ASC
+LIMIT 10001`,
+        [input.id],
+      );
+      if (rows.length === 0) return undefined;
+      if (rows.length > MAX_LAPS) invalidRow();
+      const summary = activitySummary(rows[0]!);
+      if (summary.id !== input.id) invalidRow();
+      const laps: CanonicalActivityLap[] = [];
+      const lapKeys = new Set<string>();
+      let previousLapSequence = -1;
+      for (const row of rows) {
+        const currentSummary = activitySummary(row);
+        if (!sameSummary(summary, currentSummary)) invalidRow();
+        const lap = activityLap(row);
+        if (lap === null) {
+          if (rows.length !== 1) invalidRow();
+          continue;
+        }
+        const lapKey = row.joined_lap_key as string;
+        if (lapKeys.has(lapKey)) invalidRow();
+        lapKeys.add(lapKey);
+        if (lap.lapSequence <= previousLapSequence) invalidRow();
+        previousLapSequence = lap.lapSequence;
+        laps.push(lap);
+      }
+      return { ...summary, laps };
+    },
+    async getStreams(input) {
+      const validated = validateStreamsInput(input);
+      const placeholders = validated.channels.map(() => "?").join(", ");
+      const rows = await store.all(
+        `WITH selected AS (
+  SELECT
+    CASE
+      WHEN typeof(s.session_key) = 'text'
+        AND length(CAST(s.session_key AS BLOB)) <= 64 THEN s.session_key
+      ELSE NULL
+    END AS session_key,
+    st.channel,
+    CASE
+      WHEN typeof(st.n) = 'integer'
+        AND st.n BETWEEN 1 AND 9007199254740991 THEN st.n
+      ELSE NULL
+    END AS n,
+    CASE
+      WHEN st.channel IS NULL
+        OR (
+          typeof(st.n) = 'integer'
+          AND st.n BETWEEN 1 AND 9007199254740991
+        ) THEN 1
+      ELSE 0
+    END AS n_valid,
+    CASE
+      WHEN st.channel IS NULL
+        OR (typeof(st.n) = 'integer' AND st.n BETWEEN 1 AND 1000000) THEN 1
+      ELSE 0
+    END AS n_within_limit,
+    CASE
+      WHEN st.channel IS NULL OR typeof(st.data) = 'blob' THEN 1
+      ELSE 0
+    END AS blob_valid,
+    CASE
+      WHEN st.channel IS NULL
+        OR (typeof(st.data) = 'blob' AND length(st.data) <= 16777216) THEN 1
+      ELSE 0
+    END AS blob_within_limit,
+    CASE
+      WHEN st.channel IS NULL OR typeof(st.encoding) = 'text' THEN 1
+      ELSE 0
+    END AS encoding_valid,
+    CASE
+      WHEN st.channel IS NULL
+        OR (typeof(st.encoding) = 'text' AND st.encoding = ?) THEN 1
+      ELSE 0
+    END AS encoding_ok,
+    CASE
+      WHEN typeof(st.data) = 'blob' AND length(st.data) <= 16777216
+        THEN length(st.data)
+      ELSE NULL
+    END AS data_bytes,
+    CASE
+      WHEN typeof(st.data) = 'blob' AND length(st.data) <= 16777216
+        THEN st.data
+      ELSE NULL
+    END AS bounded_data
+  FROM session AS s
+  LEFT JOIN stream AS st
+    ON st.session_key = s.session_key
+    AND st.channel IN (${placeholders})
+  WHERE s.session_key = ?
+  ORDER BY st.channel ASC
+  LIMIT 17
+),
+bounded AS (
+  SELECT
+    *,
+    count(channel) OVER () AS channel_count,
+    sum(
+      CASE
+        WHEN channel IS NULL THEN 0
+        WHEN n_within_limit = 1 THEN n
+        ELSE 4000001
+      END
+    ) OVER () AS total_n,
+    sum(
+      CASE
+        WHEN channel IS NULL THEN 0
+        WHEN blob_within_limit = 1 THEN data_bytes
+        ELSE 67108865
+      END
+    ) OVER () AS total_data_bytes
+  FROM selected
+)
+SELECT
+  session_key, channel, n, n_valid, n_within_limit,
+  blob_valid, blob_within_limit, encoding_valid, encoding_ok,
+  data_bytes, channel_count, total_n, total_data_bytes,
+  CASE
+    WHEN n_within_limit = 1
+      AND blob_within_limit = 1
+      AND encoding_ok = 1
+      AND channel_count <= 16
+      AND total_n <= 4000000
+      AND total_data_bytes <= 67108864 THEN bounded_data
+    ELSE NULL
+  END AS data
+FROM bounded
+ORDER BY channel ASC
+LIMIT 17`,
+        [STREAM_ENCODING, ...validated.channels, validated.id],
+      );
+      if (rows.length === 0) return undefined;
+      if (rows.length > MAX_CHANNELS) invalidRow();
+      const requested = new Set(validated.channels);
+      const seen = new Set<string>();
+      const pending: PendingStream[] = [];
+      let emptyJoin = false;
+      const channelCount = readNonnegativeInteger(rows[0]!, "channel_count");
+      const totalSamples = readNonnegativeInteger(rows[0]!, "total_n");
+      const totalDataBytes = readNonnegativeInteger(rows[0]!, "total_data_bytes");
+      if (channelCount > MAX_CHANNELS) invalidRow();
+      const aggregateLimitExceeded =
+        totalSamples > MAX_TOTAL_STREAM_SAMPLES || totalDataBytes > MAX_TOTAL_STREAM_BLOB_BYTES;
+      let rowLimitExceeded = false;
+      let unsupportedEncoding = false;
+      for (const row of rows) {
+        if (readSessionId(row, "session_key") !== validated.id) invalidRow();
+        if (
+          readNonnegativeInteger(row, "channel_count") !== channelCount ||
+          readNonnegativeInteger(row, "total_n") !== totalSamples ||
+          readNonnegativeInteger(row, "total_data_bytes") !== totalDataBytes
+        ) {
+          invalidRow();
+        }
+        if (row.channel === null) {
+          if (
+            rows.length !== 1 ||
+            channelCount !== 0 ||
+            row.n !== null ||
+            row.data !== null ||
+            row.data_bytes !== null ||
+            !readFlag(row, "n_valid") ||
+            !readFlag(row, "n_within_limit") ||
+            !readFlag(row, "blob_valid") ||
+            !readFlag(row, "blob_within_limit") ||
+            !readFlag(row, "encoding_valid") ||
+            !readFlag(row, "encoding_ok")
+          ) {
+            invalidRow();
+          }
+          emptyJoin = true;
+          continue;
+        }
+        const channel = row.channel;
+        if (!isPublicStreamChannel(channel) || !requested.has(channel) || seen.has(channel)) {
+          invalidRow();
+        }
+        seen.add(channel);
+        if (!readFlag(row, "n_valid")) invalidRow();
+        if (!readFlag(row, "blob_valid")) invalidRow();
+        if (!readFlag(row, "encoding_valid")) invalidRow();
+        const nWithinLimit = readFlag(row, "n_within_limit");
+        const blobWithinLimit = readFlag(row, "blob_within_limit");
+        const encodingOk = readFlag(row, "encoding_ok");
+        const n = readNonnegativeInteger(row, "n");
+        if (n < 1) invalidRow();
+        if (nWithinLimit !== n <= MAX_STREAM_SAMPLES) invalidRow();
+        if (!nWithinLimit || !blobWithinLimit) rowLimitExceeded = true;
+        let dataBytes: number | null = null;
+        if (blobWithinLimit) {
+          dataBytes = readNonnegativeInteger(row, "data_bytes");
+          if (dataBytes > MAX_STREAM_BLOB_BYTES) invalidRow();
+        } else if (row.data_bytes !== null) {
+          invalidRow();
+        }
+        if (!encodingOk) unsupportedEncoding = true;
+        if (!aggregateLimitExceeded && !rowLimitExceeded && encodingOk) {
+          if (
+            !(row.data instanceof Uint8Array) ||
+            dataBytes === null ||
+            dataBytes !== row.data.byteLength
+          ) {
+            invalidRow();
+          }
+          pending.push({ channel, n, data: row.data });
+        } else if (row.data !== null) {
+          invalidRow();
+        }
+      }
+      if (channelCount !== seen.size) invalidRow();
+      if (emptyJoin) return { activityId: validated.id, channels: {} };
+      if (aggregateLimitExceeded || rowLimitExceeded) {
+        throw new CanonicalActivityReadError("stream_limit_exceeded");
+      }
+      if (unsupportedEncoding) {
+        throw new CanonicalActivityReadError("stream_decode_failed");
+      }
+      const decoded: [string, readonly (number | null)[]][] = [];
+      for (const stream of pending) {
+        try {
+          decoded.push([
+            stream.channel,
+            decodeStream({
+              encoding: STREAM_ENCODING,
+              n: stream.n,
+              kind: stream.channel === "time" ? "time" : "value",
+              data: stream.data,
+              maxInflatedBytes: streamPayloadBytes(stream.n),
+            }),
+          ]);
+        } catch {
+          throw new CanonicalActivityReadError("stream_decode_failed");
+        }
+      }
+      return {
+        activityId: validated.id,
+        channels: Object.fromEntries(decoded),
+      };
+    },
+  };
+}

--- a/packages/kernel/src/store/index.ts
+++ b/packages/kernel/src/store/index.ts
@@ -8,6 +8,7 @@ export * from "./repair-log-repository.js";
 export * from "./dedup-confirmation-repository.js";
 export * from "./intake-repository.js";
 export * from "./activity-repository.js";
+export * from "./canonical-activity-reader.js";
 export * from "./derived-key.js";
 export * from "./sync-source.js";
 export * from "./sync-state-repository.js";

--- a/packages/kernel/tests/canonical-activity-reader.test.ts
+++ b/packages/kernel/tests/canonical-activity-reader.test.ts
@@ -1,0 +1,735 @@
+import { describe, expect, it } from "vitest";
+import {
+  CanonicalActivityReadError,
+  createCanonicalActivityReader,
+  type SqlReadStore,
+} from "../src/store/index.js";
+import { encodeStream, STREAM_ENCODING } from "../src/ingest/stream-codec.js";
+import { zlibSync } from "fflate";
+
+const SESSION_A = "a".repeat(64);
+const SESSION_B = "b".repeat(64);
+const SESSION_C = "c".repeat(64);
+const WORKOUT = "d".repeat(64);
+const LAP_A = "e".repeat(64);
+const LAP_B = "f".repeat(64);
+const PUBLIC_CHANNELS = [
+  "time",
+  "lat",
+  "lng",
+  "distance",
+  "altitude",
+  "speed",
+  "heart_rate",
+  "cadence",
+  "fractional_cadence",
+  "power",
+  "temperature",
+  "stance_time",
+  "stance_time_balance",
+  "vertical_oscillation",
+  "vertical_ratio",
+  "step_length",
+  "left_right_balance",
+  "respiration_rate",
+] as const;
+
+function summaryRow(sessionKey: string, startUtc: number, sessionSequence: number) {
+  return {
+    session_key: sessionKey,
+    workout_key: WORKOUT,
+    session_seq: sessionSequence,
+    is_multisport: 1,
+    sport: "cycling",
+    sub_sport: null,
+    sub_sport_valid: 1,
+    is_transition: 0,
+    start_utc: startUtc,
+    tz_offset_s: 21_600,
+    local_date_key: 19980704,
+    elapsed_s: 3_600,
+    timer_s: 3_500,
+    moving_s: 3_400,
+    distance_m: 40_000.5,
+  };
+}
+
+function streamRow(
+  channel: string,
+  n: number,
+  data: Uint8Array | null,
+  overrides: Readonly<Record<string, unknown>> = {},
+) {
+  const dataBytes = data?.byteLength ?? null;
+  return {
+    session_key: SESSION_A,
+    channel,
+    n,
+    n_valid: 1,
+    n_within_limit: 1,
+    blob_valid: 1,
+    blob_within_limit: 1,
+    encoding_valid: 1,
+    encoding_ok: 1,
+    data_bytes: dataBytes,
+    channel_count: 1,
+    total_n: n,
+    total_data_bytes: dataBytes ?? 0,
+    data,
+    ...overrides,
+  };
+}
+
+describe("canonical activity reader", () => {
+  it("pages the exact descending start/key order without skipping tied starts", async () => {
+    const calls: { readonly sql: string; readonly params: readonly unknown[] }[] = [];
+    const store: Pick<SqlReadStore, "all"> = {
+      async all(sql, params = []) {
+        calls.push({ sql, params });
+        return calls.length === 1
+          ? [
+              summaryRow(SESSION_C, 900, 2),
+              summaryRow(SESSION_B, 900, 1),
+              summaryRow(SESSION_A, 800, 0),
+            ]
+          : [summaryRow(SESSION_A, 800, 0)];
+      },
+    };
+
+    const reader = createCanonicalActivityReader(store);
+    const page = await reader.listActivities({
+      start: "1998-07-01",
+      end: "1998-07-31",
+      limit: 2,
+    });
+    const next = await reader.listActivities({
+      start: "1998-07-01",
+      end: "1998-07-31",
+      limit: 2,
+      cursor: page.nextCursor!,
+    });
+
+    expect(page.activities.map(({ id }) => id)).toEqual([SESSION_C, SESSION_B]);
+    expect(Object.keys(page.activities[0]!)).toEqual([
+      "id",
+      "workoutId",
+      "sessionSequence",
+      "isMultisport",
+      "sport",
+      "subSport",
+      "isTransition",
+      "startEpochSeconds",
+      "timezoneOffsetSeconds",
+      "localDate",
+      "elapsedSeconds",
+      "timerSeconds",
+      "movingSeconds",
+      "distanceMeters",
+    ]);
+    expect(page.nextCursor).toEqual({ startEpochSeconds: 900, id: SESSION_B });
+    expect(next.activities.map(({ id }) => id)).toEqual([SESSION_A]);
+    expect(next.nextCursor).toBeNull();
+    expect(calls).toHaveLength(2);
+    expect(calls[0]!.sql).toContain("ORDER BY s.start_utc DESC, s.session_key DESC");
+    expect(calls[0]!.sql).toContain("length(CAST(s.sport AS BLOB)) <= 64");
+    expect(calls[0]!.sql).toContain("length(CAST(s.sub_sport AS BLOB)) <= 128");
+    expect(calls[0]!.params).toEqual([19980701, 19980731, 3]);
+    expect(calls[1]!.params).toEqual([19980701, 19980731, 900, 900, SESSION_B, 3]);
+  });
+
+  it("returns transition details and whitelisted lap fields from one read", async () => {
+    let calls = 0;
+    const privateColumns = {
+      name: "private workout name",
+      notes: "private workout notes",
+      summary_json: '{"private":true}',
+      source: "private source",
+      path: "/private/path",
+    };
+    const store: Pick<SqlReadStore, "all"> = {
+      async all() {
+        calls += 1;
+        const base = {
+          ...summaryRow(SESSION_A, 900, 0),
+          is_transition: 1,
+          ...privateColumns,
+        };
+        return [
+          {
+            ...base,
+            joined_lap_key: LAP_A,
+            lap_seq: 0,
+            lap_start_utc: 900,
+            lap_elapsed_s: 100,
+            lap_timer_s: 90,
+            lap_distance_m: 1_000,
+          },
+          {
+            ...base,
+            joined_lap_key: LAP_B,
+            lap_seq: 1,
+            lap_start_utc: null,
+            lap_elapsed_s: null,
+            lap_timer_s: null,
+            lap_distance_m: null,
+          },
+        ];
+      },
+    };
+
+    const detail = await createCanonicalActivityReader(store).getActivity({ id: SESSION_A });
+
+    expect(calls).toBe(1);
+    expect(detail).toEqual({
+      id: SESSION_A,
+      workoutId: WORKOUT,
+      sessionSequence: 0,
+      isMultisport: true,
+      sport: "cycling",
+      subSport: null,
+      isTransition: true,
+      startEpochSeconds: 900,
+      timezoneOffsetSeconds: 21_600,
+      localDate: "1998-07-04",
+      elapsedSeconds: 3_600,
+      timerSeconds: 3_500,
+      movingSeconds: 3_400,
+      distanceMeters: 40_000.5,
+      laps: [
+        {
+          lapSequence: 0,
+          startEpochSeconds: 900,
+          elapsedSeconds: 100,
+          timerSeconds: 90,
+          distanceMeters: 1_000,
+        },
+        {
+          lapSequence: 1,
+          startEpochSeconds: null,
+          elapsedSeconds: null,
+          timerSeconds: null,
+          distanceMeters: null,
+        },
+      ],
+    });
+    expect(Object.keys(detail!)).toEqual([
+      "id",
+      "workoutId",
+      "sessionSequence",
+      "isMultisport",
+      "sport",
+      "subSport",
+      "isTransition",
+      "startEpochSeconds",
+      "timezoneOffsetSeconds",
+      "localDate",
+      "elapsedSeconds",
+      "timerSeconds",
+      "movingSeconds",
+      "distanceMeters",
+      "laps",
+    ]);
+    expect(Object.keys(detail!.laps[0]!)).toEqual([
+      "lapSequence",
+      "startEpochSeconds",
+      "elapsedSeconds",
+      "timerSeconds",
+      "distanceMeters",
+    ]);
+    expect(JSON.stringify(detail)).not.toContain("private");
+  });
+
+  it("rejects the lap sentinel row and non-strict lap sequences", async () => {
+    const base = summaryRow(SESSION_A, 900, 0);
+    const lapRow = (lapKey: string, lapSequence: number) => ({
+      ...base,
+      joined_lap_key: lapKey,
+      lap_seq: lapSequence,
+      lap_start_utc: null,
+      lap_elapsed_s: null,
+      lap_timer_s: null,
+      lap_distance_m: null,
+    });
+    const oversizedStore: Pick<SqlReadStore, "all"> = {
+      async all(sql) {
+        expect(sql).toContain("LIMIT 10001");
+        return Array.from({ length: 10_001 }, (_, index) =>
+          lapRow(index.toString(16).padStart(64, "0"), index),
+        );
+      },
+    };
+    const repeatedSequenceStore: Pick<SqlReadStore, "all"> = {
+      async all() {
+        return [lapRow(LAP_A, 1), lapRow(LAP_B, 1)];
+      },
+    };
+
+    await expect(
+      createCanonicalActivityReader(oversizedStore).getActivity({ id: SESSION_A }),
+    ).rejects.toEqual(expect.objectContaining({ code: "invalid_row" }));
+    await expect(
+      createCanonicalActivityReader(repeatedSequenceStore).getActivity({ id: SESSION_A }),
+    ).rejects.toEqual(expect.objectContaining({ code: "invalid_row" }));
+  });
+
+  it("returns only requested stored channels while preserving names and nulls", async () => {
+    const power = encodeStream("value", [200, null, 240]);
+    const time = encodeStream("time", [0, 1, 2]);
+    const calls: { readonly sql: string; readonly params: readonly unknown[] }[] = [];
+    const store: Pick<SqlReadStore, "all"> = {
+      async all(sql, params = []) {
+        calls.push({ sql, params });
+        const totalN = power.n + time.n;
+        const totalDataBytes = power.data.byteLength + time.data.byteLength;
+        return [
+          streamRow("power", power.n, power.data, {
+            channel_count: 2,
+            total_n: totalN,
+            total_data_bytes: totalDataBytes,
+          }),
+          streamRow("time", time.n, time.data, {
+            channel_count: 2,
+            total_n: totalN,
+            total_data_bytes: totalDataBytes,
+          }),
+        ];
+      },
+    };
+
+    const streams = await createCanonicalActivityReader(store).getStreams({
+      id: SESSION_A,
+      channels: ["time", "power", "speed"],
+    });
+
+    expect(streams).toEqual({
+      activityId: SESSION_A,
+      channels: {
+        power: [200, null, 240],
+        time: [0, 1, 2],
+      },
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.sql).toContain("LEFT JOIN stream");
+    expect(calls[0]!.sql).toContain("total_data_bytes <= 67108864");
+    expect(calls[0]!.sql).toContain("LIMIT 17");
+    expect(calls[0]!.sql).not.toContain("st.encoding,");
+    expect(calls[0]!.params).toEqual([STREAM_ENCODING, "time", "power", "speed", SESSION_A]);
+  });
+
+  it("rejects every invalid input before issuing SQL", async () => {
+    let calls = 0;
+    const store: Pick<SqlReadStore, "all"> = {
+      async all() {
+        calls += 1;
+        return [];
+      },
+    };
+    const reader = createCanonicalActivityReader(store);
+    const invalidCalls = [
+      () => reader.listActivities({ start: "1998-02-30", end: "1998-03-01" }),
+      () => reader.listActivities({ start: "1998-07-02", end: "1998-07-01" }),
+      () => reader.listActivities({ start: "1997-01-01", end: "1998-01-02" }),
+      () => reader.listActivities({ start: "1998-01-01", end: "1998-01-01", limit: 0 }),
+      () => reader.listActivities({ start: "1998-01-01", end: "1998-01-01", limit: 201 }),
+      () =>
+        reader.listActivities({
+          start: "1998-01-01",
+          end: "1998-01-01",
+          cursor: { startEpochSeconds: 1, id: SESSION_A.toUpperCase() },
+        }),
+      () => reader.getActivity({ id: `session:${SESSION_A}` }),
+      () => reader.getStreams({ id: SESSION_A, channels: [] }),
+      () => reader.getStreams({ id: SESSION_A, channels: ["power", "power"] }),
+      () => reader.getStreams({ id: SESSION_A, channels: ["unknown"] }),
+      () => reader.getStreams({ id: SESSION_A, channels: ["dev:power"] }),
+      () => reader.getStreams({ id: SESSION_A, channels: ["\ud800"] }),
+      () =>
+        reader.getStreams({
+          id: SESSION_A,
+          channels: [
+            "time",
+            "lat",
+            "lng",
+            "distance",
+            "altitude",
+            "speed",
+            "heart_rate",
+            "cadence",
+            "fractional_cadence",
+            "power",
+            "temperature",
+            "stance_time",
+            "stance_time_balance",
+            "vertical_oscillation",
+            "vertical_ratio",
+            "step_length",
+            "left_right_balance",
+          ],
+        }),
+    ];
+
+    for (const call of invalidCalls) {
+      await expect(call()).rejects.toEqual(
+        expect.objectContaining({
+          name: "CanonicalActivityReadError",
+          code: "invalid_input",
+        }),
+      );
+    }
+    expect(calls).toBe(0);
+  });
+
+  it("accepts every fixed public stream channel and no arbitrary extension channel", async () => {
+    const calls: readonly unknown[][] = [];
+    const mutableCalls = calls as unknown[][];
+    const store: Pick<SqlReadStore, "all"> = {
+      async all(_sql, params = []) {
+        mutableCalls.push([...params]);
+        return [];
+      },
+    };
+    const reader = createCanonicalActivityReader(store);
+
+    await expect(
+      reader.getStreams({ id: SESSION_A, channels: PUBLIC_CHANNELS.slice(0, 16) }),
+    ).resolves.toBeUndefined();
+    await expect(
+      reader.getStreams({ id: SESSION_A, channels: PUBLIC_CHANNELS.slice(16) }),
+    ).resolves.toBeUndefined();
+
+    expect(calls).toHaveLength(2);
+  });
+
+  it("returns undefined for a stale but valid activity ID", async () => {
+    let calls = 0;
+    const store: Pick<SqlReadStore, "all"> = {
+      async all() {
+        calls += 1;
+        return [];
+      },
+    };
+    const reader = createCanonicalActivityReader(store);
+
+    await expect(reader.getActivity({ id: SESSION_A })).resolves.toBeUndefined();
+    await expect(reader.getStreams({ id: SESSION_A, channels: ["time"] })).resolves.toBeUndefined();
+    expect(calls).toBe(2);
+  });
+
+  it("distinguishes an existing activity with none of the requested streams", async () => {
+    const store: Pick<SqlReadStore, "all"> = {
+      async all() {
+        return [
+          {
+            session_key: SESSION_A,
+            channel: null,
+            n: null,
+            data: null,
+            data_bytes: null,
+            n_valid: 1,
+            n_within_limit: 1,
+            blob_valid: 1,
+            blob_within_limit: 1,
+            encoding_valid: 1,
+            encoding_ok: 1,
+            channel_count: 0,
+            total_n: 0,
+            total_data_bytes: 0,
+          },
+        ];
+      },
+    };
+
+    await expect(
+      createCanonicalActivityReader(store).getStreams({
+        id: SESSION_A,
+        channels: ["speed"],
+      }),
+    ).resolves.toEqual({ activityId: SESSION_A, channels: {} });
+  });
+
+  it("preflights every stream limit before attempting any inflate", async () => {
+    const store: Pick<SqlReadStore, "all"> = {
+      async all() {
+        return [
+          streamRow("power", 1, null, {
+            channel_count: 2,
+            total_n: 4_000_001,
+            total_data_bytes: 2,
+            data_bytes: 1,
+          }),
+          streamRow("cadence", 1_000_001, null, {
+            n_within_limit: 0,
+            channel_count: 2,
+            total_n: 4_000_001,
+            total_data_bytes: 2,
+            data_bytes: 1,
+          }),
+        ];
+      },
+    };
+
+    await expect(
+      createCanonicalActivityReader(store).getStreams({
+        id: SESSION_A,
+        channels: ["power", "cadence"],
+      }),
+    ).rejects.toEqual(
+      expect.objectContaining({
+        name: "CanonicalActivityReadError",
+        code: "stream_limit_exceeded",
+      }),
+    );
+  });
+
+  it("rejects an oversized stream BLOB before requiring its bytes in JavaScript", async () => {
+    const store: Pick<SqlReadStore, "all"> = {
+      async all() {
+        return [
+          streamRow("power", 1, null, {
+            blob_within_limit: 0,
+            data_bytes: null,
+            total_data_bytes: 64 * 1_024 * 1_024 + 1,
+          }),
+        ];
+      },
+    };
+
+    await expect(
+      createCanonicalActivityReader(store).getStreams({
+        id: SESSION_A,
+        channels: ["power"],
+      }),
+    ).rejects.toEqual(
+      expect.objectContaining({
+        name: "CanonicalActivityReadError",
+        code: "stream_limit_exceeded",
+      }),
+    );
+  });
+
+  it.each([
+    ["sample", { total_n: 4_000_001, total_data_bytes: 1 }],
+    ["compressed-byte", { total_n: 1, total_data_bytes: 64 * 1_024 * 1_024 + 1 }],
+  ])("rejects an aggregate %s cap before requiring BLOB bytes", async (_label, totals) => {
+    const store: Pick<SqlReadStore, "all"> = {
+      async all() {
+        return [streamRow("power", 1, null, { ...totals, data_bytes: 1 })];
+      },
+    };
+
+    await expect(
+      createCanonicalActivityReader(store).getStreams({
+        id: SESSION_A,
+        channels: ["power"],
+      }),
+    ).rejects.toEqual(expect.objectContaining({ code: "stream_limit_exceeded" }));
+  });
+
+  it("rejects a compressed expansion beyond the exact declared stream payload", async () => {
+    const compressedBomb = zlibSync(new Uint8Array(4_000_000));
+    const store: Pick<SqlReadStore, "all"> = {
+      async all() {
+        return [streamRow("power", 1, compressedBomb)];
+      },
+    };
+
+    await expect(
+      createCanonicalActivityReader(store).getStreams({
+        id: SESSION_A,
+        channels: ["power"],
+      }),
+    ).rejects.toEqual(expect.objectContaining({ code: "stream_decode_failed" }));
+  });
+
+  it("rejects the seventeenth returned stream row", async () => {
+    const store: Pick<SqlReadStore, "all"> = {
+      async all(sql) {
+        expect(sql).toContain("LIMIT 17");
+        return Array.from({ length: 17 }, (_, index) =>
+          streamRow("power", 1, new Uint8Array([1]), {
+            channel_count: 17,
+            total_n: 17,
+            total_data_bytes: 17,
+            session_key: index === 0 ? SESSION_A : SESSION_B,
+          }),
+        );
+      },
+    };
+
+    await expect(
+      createCanonicalActivityReader(store).getStreams({
+        id: SESSION_A,
+        channels: ["power"],
+      }),
+    ).rejects.toEqual(expect.objectContaining({ code: "invalid_row" }));
+  });
+
+  it.each([
+    ["unsupported codec", streamRow("power", 1, null, { encoding_ok: 0, data_bytes: 1 })],
+    ["corrupt payload", streamRow("power", 1, new Uint8Array([1]))],
+  ])("reports %s as a typed decode failure", async (_label, row) => {
+    const store: Pick<SqlReadStore, "all"> = {
+      async all() {
+        return [row];
+      },
+    };
+    await expect(
+      createCanonicalActivityReader(store).getStreams({
+        id: SESSION_A,
+        channels: ["power"],
+      }),
+    ).rejects.toEqual(
+      expect.objectContaining({
+        name: "CanonicalActivityReadError",
+        code: "stream_decode_failed",
+      }),
+    );
+  });
+
+  it("does not wrap SQL availability failures", async () => {
+    const unavailable = new Error("database is unavailable");
+    const store: Pick<SqlReadStore, "all"> = {
+      async all() {
+        throw unavailable;
+      },
+    };
+
+    await expect(
+      createCanonicalActivityReader(store).getActivity({
+        id: SESSION_A,
+      }),
+    ).rejects.toBe(unavailable);
+  });
+
+  it.each([
+    [
+      "uppercase session key",
+      [{ ...summaryRow(SESSION_A, 900, 0), session_key: SESSION_A.toUpperCase() }],
+    ],
+    [
+      "invalid workout key",
+      [{ ...summaryRow(SESSION_A, 900, 0), workout_key: `workout:${WORKOUT}` }],
+    ],
+    ["invalid flag", [{ ...summaryRow(SESSION_A, 900, 0), is_multisport: 2 }]],
+    ["invalid civil date", [{ ...summaryRow(SESSION_A, 900, 0), local_date_key: 19980230 }]],
+    [
+      "unsafe integer",
+      [{ ...summaryRow(SESSION_A, 900, 0), start_utc: Number.MAX_SAFE_INTEGER + 1 }],
+    ],
+    [
+      "nonfinite real",
+      [{ ...summaryRow(SESSION_A, 900, 0), distance_m: Number.POSITIVE_INFINITY }],
+    ],
+    ["fractional sequence", [{ ...summaryRow(SESSION_A, 900, 0), session_seq: 0.5 }]],
+    ["empty sport", [{ ...summaryRow(SESSION_A, 900, 0), sport: "" }]],
+    ["oversized projected sport", [{ ...summaryRow(SESSION_A, 900, 0), sport: null }]],
+    [
+      "oversized projected sub-sport",
+      [{ ...summaryRow(SESSION_A, 900, 0), sub_sport: null, sub_sport_valid: 0 }],
+    ],
+    ["out-of-order rows", [summaryRow(SESSION_A, 800, 0), summaryRow(SESSION_B, 900, 1)]],
+    ["duplicate session rows", [summaryRow(SESSION_A, 900, 0), summaryRow(SESSION_A, 900, 0)]],
+  ])("fails closed on malformed list rows: %s", async (_label, rows) => {
+    const store: Pick<SqlReadStore, "all"> = {
+      async all() {
+        return rows;
+      },
+    };
+    await expect(
+      createCanonicalActivityReader(store).listActivities({
+        start: "1998-01-01",
+        end: "1998-12-31",
+      }),
+    ).rejects.toEqual(
+      expect.objectContaining({
+        name: "CanonicalActivityReadError",
+        code: "invalid_row",
+      }),
+    );
+  });
+
+  it.each([
+    [
+      "non-string encoding",
+      [
+        streamRow("power", 1, null, {
+          encoding_valid: 0,
+          encoding_ok: 0,
+          data_bytes: 1,
+        }),
+      ],
+    ],
+    [
+      "zero samples",
+      [
+        streamRow("power", 0, null, {
+          n: null,
+          n_valid: 0,
+          n_within_limit: 0,
+          data_bytes: 1,
+          total_n: 4_000_001,
+        }),
+      ],
+    ],
+    [
+      "non-BLOB data",
+      [
+        streamRow("power", 1, null, {
+          blob_valid: 0,
+          blob_within_limit: 0,
+          total_data_bytes: 64 * 1_024 * 1_024 + 1,
+        }),
+      ],
+    ],
+    [
+      "incorrect BLOB length",
+      [
+        streamRow("power", 1, new Uint8Array([1]), {
+          data_bytes: 2,
+          total_data_bytes: 2,
+        }),
+      ],
+    ],
+    [
+      "duplicate channels",
+      [
+        streamRow("power", 1, new Uint8Array([1]), {
+          channel_count: 2,
+          total_n: 2,
+          total_data_bytes: 2,
+        }),
+        streamRow("power", 1, new Uint8Array([1]), {
+          channel_count: 2,
+          total_n: 2,
+          total_data_bytes: 2,
+        }),
+      ],
+    ],
+  ])("fails closed on malformed stream rows: %s", async (_label, rows) => {
+    const store: Pick<SqlReadStore, "all"> = {
+      async all() {
+        return rows;
+      },
+    };
+    await expect(
+      createCanonicalActivityReader(store).getStreams({
+        id: SESSION_A,
+        channels: ["power"],
+      }),
+    ).rejects.toEqual(
+      expect.objectContaining({
+        name: "CanonicalActivityReadError",
+        code: "invalid_row",
+      }),
+    );
+  });
+
+  it("exposes a fixed typed error-code vocabulary", () => {
+    expect(new CanonicalActivityReadError("invalid_row")).toEqual(
+      expect.objectContaining({
+        name: "CanonicalActivityReadError",
+        code: "invalid_row",
+      }),
+    );
+  });
+});

--- a/packages/kernel/tests/stream-codec.test.ts
+++ b/packages/kernel/tests/stream-codec.test.ts
@@ -68,4 +68,13 @@ describe("STRM v1 codec",()=>{
     const missingAndNonmonotonic=changed([1,2,1],p=>{p[16]&=~1;p.fill(0,17,25)});
     rejects(()=>decodeStream({...encodeStream("value",[1,2,1]),data:missingAndNonmonotonic,kind:"time"}),"time_missing");
   });
+  it("bounds optional inflate output while preserving the legacy unbounded call",()=>{
+    const good=encodeStream("value",[1]);
+    const expected=16+Math.ceil(good.n/8)+good.n*8;
+    expect(decodeStream({...good,kind:"value",maxInflatedBytes:expected})).toEqual([1]);
+    expect(decodeStream({...good,kind:"value"})).toEqual([1]);
+    const bomb=compressed(new Uint8Array(4_000_000));
+    rejects(()=>decodeStream({...good,data:bomb,kind:"value",maxInflatedBytes:expected}),"payload_length");
+    rejects(()=>decodeStream({...good,n:0,data:new Uint8Array([1]),kind:"value",maxInflatedBytes:expected}),"invalid_n");
+  });
 });


### PR DESCRIPTION
## Summary

- add a source-neutral, read-only activity model over the canonical workout/session/lap/stream winner tables
- expose deterministic bounded list, detail, and requested-stream reads keyed by canonical session IDs
- preserve multisport sessions, transitions, null samples, and canonical time/channel semantics while excluding names, notes, summaries, paths, provenance, and developer channels
- bound dates, pages, laps, stream rows, compressed bytes, aggregate samples, SQL text projections, and decompression output before data reaches coaching consumers
- prove restart, transaction visibility, corruption handling, and file/platform import-order convergence with real SQLite coverage

## Validation

- 4 focused test files — 56 passed
- Kernel build/DTS
- Kernel and kernel-node typechecks
- scoped oxlint and oxfmt
- trademark, fixture-privacy, package-dependency, and kernel-discipline gates
- `git diff --check`
- three read-only storage/resource/consumer reviews

## Scope

This is the dark canonical reader foundation for file-import coaching publication. Runtime publication after import, credential-free startup rehydration, publication outcomes, and coaching-tool cutover remain separate slices.

No changeset: no runtime composition or athlete-visible behavior changes in this foundation.
