### PR TITLE
Attest imported activity publication

### DIFF
--- a/.changeset/canonical-publication-attestation.md
+++ b/.changeset/canonical-publication-attestation.md
@@ -1,0 +1,7 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Ride-file imports now report coaching availability only after the imported activities and streams are verified readable.
+
+Verify one exact canonical workout presentation per accepted file through coaching list and detail reads, plus a bounded stream read when source samples exist.

--- a/packages/coach/src/operations.ts
+++ b/packages/coach/src/operations.ts
@@ -38,6 +38,7 @@ import {
   type AuthoredIdentity,
 } from "@enduragent/kernel-node/home";
 import { importFilesWithReport } from "@enduragent/kernel-node/ingest";
+import type { ImportReport } from "@enduragent/kernel/ingest";
 import { runIntervalsBackfillInWriter } from "./backfill.js";
 import type { LocalStoreRuntime } from "./composition.js";
 import type { CoachStoreWriterContext } from "./runtime.js";
@@ -69,6 +70,29 @@ function sameHome(left: AthleteHome, right: AthleteHome): boolean {
     left.archiveDir === right.archiveDir &&
     left.configDir === right.configDir
   );
+}
+
+function importedWorkoutKeys(report: ImportReport): readonly string[] {
+  const importedAddresses = [
+    ...new Set(
+      report.files.filter((file) => file.outcome === "imported").map((file) => file.address),
+    ),
+  ].sort();
+  if (importedAddresses.length === 0) return [];
+  const importedAddressSet = new Set(importedAddresses);
+  const matchedAddresses = new Set<string>();
+  const workoutKeys = new Set<string>();
+  for (const cluster of report.clusters) {
+    for (const member of cluster.members) {
+      if (!importedAddressSet.has(member)) continue;
+      matchedAddresses.add(member);
+      workoutKeys.add(cluster.workout_key);
+    }
+  }
+  if (importedAddresses.some((address) => !matchedAddresses.has(address))) {
+    throw new Error("Imported file has no canonical workout.");
+  }
+  return [...workoutKeys].sort();
 }
 
 function createSerializedLane(): <T>(operation: () => Promise<T>) => Promise<T> {
@@ -117,7 +141,7 @@ export function createCoachOperations(
         .runActivityWrite(async () => {
           deliver(onEvent, { phase: "started", completed: 0, total: paths.length });
           return importFiles({ inputPaths: paths, archiveDir, store });
-        })
+        }, importedWorkoutKeys)
         .then(({ value: report, activityReadAvailable }) => {
           const result = ImportFilesRpcResultSchema.parse({
             schemaVersion: 2,

--- a/packages/coach/src/store-runtime.ts
+++ b/packages/coach/src/store-runtime.ts
@@ -31,6 +31,9 @@ export const TOTAL_REQUEST_LIMIT = 79 as const;
 export const STORE_MAX_ARTIFACTS = 1_000;
 export const STORE_REQUEST_TIMEOUT_MS = 30_000;
 export const STORE_WINDOW_DEADLINE_MS = 600_000;
+const CANONICAL_KEY = /^[0-9a-f]{64}$/;
+const PUBLICATION_PAGE_SIZE = 200;
+const PUBLICATION_DEADLINE_MS = 30_000;
 
 export interface StoreWindowResult {
   readonly published: boolean;
@@ -243,15 +246,106 @@ export class StoreRuntime {
     return createCanonicalActivityReader(this.readonlyStore);
   }
 
-  runActivityWrite<T>(work: (signal: AbortSignal) => Promise<T>): Promise<StoreWriteResult<T>> {
+  private async attestCanonicalActivities(
+    workoutKeys: readonly string[],
+    signal: AbortSignal,
+  ): Promise<boolean> {
+    if (workoutKeys.length < 1 || workoutKeys.some((key) => !CANONICAL_KEY.test(key))) {
+      return false;
+    }
+    const uniqueWorkoutKeys = [...new Set(workoutKeys)];
+    if (uniqueWorkoutKeys.length !== workoutKeys.length) return false;
+    const reader = this.canonicalActivityReader();
+    const deadline = this.dependencies.monotonicNow() + PUBLICATION_DEADLINE_MS;
+    const withinBudget = (): boolean => {
+      signal.throwIfAborted();
+      return this.dependencies.monotonicNow() <= deadline;
+    };
+    let streamReadbackComplete = false;
+    for (const workoutKey of uniqueWorkoutKeys) {
+      if (!withinBudget()) return false;
+      const rows = await this.readonlyStore!.all(
+        `SELECT
+  s.session_key,
+  count(st.channel) AS stream_count,
+  count(CASE WHEN st.channel = 'time' THEN 1 END) AS time_count
+FROM session AS s
+LEFT JOIN stream AS st ON st.session_key = s.session_key
+WHERE s.workout_key = ?
+GROUP BY s.session_key, s.session_seq
+ORDER BY time_count DESC, stream_count DESC, s.session_seq ASC, s.session_key ASC
+LIMIT 1`,
+        [workoutKey],
+      );
+      if (!withinBudget() || rows.length !== 1) return false;
+      const row = rows[0]!;
+      if (typeof row.session_key !== "string" || !CANONICAL_KEY.test(row.session_key)) {
+        return false;
+      }
+      if (
+        typeof row.stream_count !== "number" ||
+        !Number.isSafeInteger(row.stream_count) ||
+        row.stream_count < 0 ||
+        typeof row.time_count !== "number" ||
+        !Number.isSafeInteger(row.time_count) ||
+        row.time_count < 0 ||
+        row.time_count > 1 ||
+        (row.stream_count === 0 && row.time_count !== 0) ||
+        (row.stream_count > 0 && row.time_count !== 1)
+      ) {
+        return false;
+      }
+      const detail = await reader.getActivity({ id: row.session_key });
+      if (!withinBudget() || detail === undefined || detail.workoutId !== workoutKey) return false;
+      let cursor: { readonly startEpochSeconds: number; readonly id: string } | undefined;
+      let listed = false;
+      while (!listed) {
+        if (!withinBudget()) return false;
+        const page = await reader.listActivities({
+          start: detail.localDate,
+          end: detail.localDate,
+          limit: PUBLICATION_PAGE_SIZE,
+          ...(cursor === undefined ? {} : { cursor }),
+        });
+        if (!withinBudget()) return false;
+        listed = page.activities.some(
+          (activity) => activity.id === detail.id && activity.workoutId === workoutKey,
+        );
+        if (listed) break;
+        if (page.nextCursor === null) return false;
+        cursor = page.nextCursor;
+      }
+      if (row.stream_count > 0 && !streamReadbackComplete) {
+        const readable = await reader.getStreams({ id: detail.id, channels: ["time"] });
+        if (
+          !withinBudget() ||
+          readable === undefined ||
+          readable.activityId !== detail.id ||
+          !Array.isArray(readable.channels.time) ||
+          readable.channels.time.length < 1
+        ) {
+          return false;
+        }
+        streamReadbackComplete = true;
+      }
+    }
+    return true;
+  }
+
+  runActivityWrite<T>(
+    work: (signal: AbortSignal) => Promise<T>,
+    workoutKeys: (value: T) => readonly string[],
+  ): Promise<StoreWriteResult<T>> {
     return this.runExclusive(async (signal) => {
       const value = await work(signal);
+      signal.throwIfAborted();
       let activityReadAvailable = false;
       try {
-        const date = this.dependencies.now().toISOString().slice(0, 10);
-        await this.canonicalActivities.listActivities({ start: date, end: date, limit: 1 });
-        activityReadAvailable = true;
-      } catch {}
+        activityReadAvailable = await this.attestCanonicalActivities(workoutKeys(value), signal);
+      } catch {
+        signal.throwIfAborted();
+      }
+      signal.throwIfAborted();
       return Object.freeze({ value, activityReadAvailable });
     });
   }

--- a/packages/coach/tests/canonical-activity-coaching.test.ts
+++ b/packages/coach/tests/canonical-activity-coaching.test.ts
@@ -268,7 +268,7 @@ FROM session`,
         value: { distanceMeters: platformDistance },
       });
       if (!immediate.detail.ok) throw new Error("mixed-source detail read failed");
-      const activityId = immediate.detail.value.id;
+      const activityId = (immediate.detail.value as { readonly id: string }).id;
       await expect(
         selected.runtime.athleteData.getStreams({ id: activityId, keys: ["time", "power"] }),
       ).resolves.toMatchObject({

--- a/packages/coach/tests/canonical-activity-coaching.test.ts
+++ b/packages/coach/tests/canonical-activity-coaching.test.ts
@@ -1,11 +1,13 @@
-import { mkdir, mkdtemp, realpath, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, realpath, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import type { Config, ReferenceRuntime } from "@enduragent/core";
 import { runMigrations } from "@enduragent/kernel/store";
 import { MIGRATIONS } from "@enduragent/kernel/store/migrations";
 import type { AthleteHome } from "@enduragent/kernel-node/home";
+import { createNodeImportRuntime, importFilesWithReport } from "@enduragent/kernel-node/ingest";
 import { openReadonlySqliteStorage, openSqliteStorage } from "@enduragent/kernel-node/sqlite";
+import { mapActivityLanding } from "@enduragent/sync-intervals-icu";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createCoachOperations } from "../src/operations.js";
 import type { CoachStoreWriterContext } from "../src/runtime.js";
@@ -33,6 +35,46 @@ const config = (root: string): Config => ({
   dataDir: root,
 });
 
+function runtimeFor(
+  home: AthleteHome,
+  context: CoachStoreWriterContext,
+  dependencies: StoreRuntimeDependencies = {},
+): {
+  readonly runtime: ReturnType<typeof createStoreRuntime>;
+  readonly operations: ReturnType<typeof createCoachOperations>;
+} {
+  const reference = {
+    scheduler: { stop: vi.fn() },
+    services: {},
+    runScheduledOnce: vi.fn(async () => ({
+      kind: "ran",
+      lastSyncAt: "1998-07-18T12:00:00.000Z",
+      refreshed: [],
+    })),
+  } as unknown as ReferenceRuntime;
+  const runtime = createStoreRuntime({
+    env: {},
+    config: config(home.root),
+    home,
+    reference,
+    writerContext: context,
+    dependencies: {
+      now: () => new Date("1998-07-18T12:00:00.000Z"),
+      monotonicNow: () => 1,
+      ...dependencies,
+    },
+  });
+  const operations = createCoachOperations({
+    home,
+    context,
+    runtime,
+    intervalsCredentials: { read: async () => ({ apiKey: "", athleteId: "" }) },
+    historyNewestDate: () => "1998-07-18",
+    applyRuntimeConfig: async () => {},
+  });
+  return { runtime, operations };
+}
+
 async function fixture(dependencies: StoreRuntimeDependencies = {}): Promise<{
   readonly home: AthleteHome;
   readonly context: CoachStoreWriterContext;
@@ -59,47 +101,28 @@ async function fixture(dependencies: StoreRuntimeDependencies = {}): Promise<{
     store,
     listener: {} as CoachStoreWriterContext["listener"],
   };
-  const reference = {
-    scheduler: { stop: vi.fn() },
-    services: {},
-    runScheduledOnce: vi.fn(async () => ({
-      kind: "ran",
-      lastSyncAt: "1998-07-18T12:00:00.000Z",
-      refreshed: [],
-    })),
-  } as unknown as ReferenceRuntime;
-  const runtime = createStoreRuntime({
-    env: {},
-    config: config(root),
-    home,
-    reference,
-    writerContext: context,
-    dependencies: {
-      now: () => new Date("1998-07-18T12:00:00.000Z"),
-      monotonicNow: () => 1,
-      ...dependencies,
-    },
-  });
-  const operations = createCoachOperations({
-    home,
-    context,
-    runtime,
-    intervalsCredentials: { read: async () => ({ apiKey: "", athleteId: "" }) },
-    historyNewestDate: () => "1998-07-18",
-    applyRuntimeConfig: async () => {},
-  });
-  return { home, context, runtime, operations };
+  return { home, context, ...runtimeFor(home, context, dependencies) };
 }
 
 const importPath = resolve(
   import.meta.dirname,
   "../../kernel-node/tests/fixtures/ingest/triathlon-multisport.fit",
 );
+const mixedImportPath = resolve(
+  import.meta.dirname,
+  "../../kernel-node/tests/fixtures/ingest/brick-cycling.fit",
+);
 
-async function coachingSnapshot(runtime: ReturnType<typeof createStoreRuntime>) {
-  const listed = await runtime.athleteData.listActivities({
+async function coachingSnapshot(
+  runtime: ReturnType<typeof createStoreRuntime>,
+  range: { readonly start: string; readonly end: string } = {
     start: "1998-07-01",
     end: "1998-07-31",
+  },
+) {
+  const listed = await runtime.athleteData.listActivities({
+    start: range.start,
+    end: range.end,
   });
   expect(listed.ok).toBe(true);
   const activities = listed.ok ? listed.value : [];
@@ -120,6 +143,13 @@ async function coachingSnapshot(runtime: ReturnType<typeof createStoreRuntime>) 
 describe("canonical activity coaching cutover", () => {
   it("reads an import immediately and identically after a credential-free restart", async () => {
     const first = await fixture();
+    let firstWriterOpen = true;
+    let reopened:
+      | {
+          readonly store: ReturnType<typeof openSqliteStorage>;
+          readonly runtime: ReturnType<typeof createStoreRuntime>;
+        }
+      | undefined;
     try {
       await expect(first.operations.importFiles({ paths: [importPath] })).resolves.toMatchObject({
         schemaVersion: 2,
@@ -128,35 +158,277 @@ describe("canonical activity coaching cutover", () => {
       });
       const immediate = await coachingSnapshot(first.runtime);
       await first.runtime.close();
-
-      const reference = {
-        scheduler: { stop: vi.fn() },
-        services: {},
-        runScheduledOnce: vi.fn(async () => ({
-          kind: "ran",
-          lastSyncAt: "1998-07-18T12:00:00.000Z",
-          refreshed: [],
-        })),
-      } as unknown as ReferenceRuntime;
-      const reopened = createStoreRuntime({
-        env: {},
-        config: config(first.home.root),
+      await first.context.store.close();
+      firstWriterOpen = false;
+      const store = openSqliteStorage(join(first.home.storeDir, "store.db"));
+      const context: CoachStoreWriterContext = {
         home: first.home,
-        reference,
-        writerContext: first.context,
-        dependencies: {
-          now: () => new Date("1998-07-18T12:00:00.000Z"),
-          monotonicNow: () => 1,
-        },
-      });
-      try {
-        expect(await coachingSnapshot(reopened)).toEqual(immediate);
-      } finally {
-        await reopened.close();
-      }
+        store,
+        listener: {} as CoachStoreWriterContext["listener"],
+      };
+      reopened = { store, runtime: runtimeFor(first.home, context).runtime };
+      expect(await coachingSnapshot(reopened.runtime)).toEqual(immediate);
     } finally {
       await first.runtime.close();
-      await first.context.store.close();
+      if (firstWriterOpen) await first.context.store.close();
+      await reopened?.runtime.close();
+      await reopened?.store.close();
+    }
+  });
+
+  it("preserves one FIT-winning mixed-source presentation through a full store reopen", async () => {
+    const bytes = new Uint8Array(await readFile(mixedImportPath));
+    const probeRoot = await mkdtemp(join(await realpath(tmpdir()), "canonical-mixed-probe-"));
+    roots.push(probeRoot);
+    const probeStore = openSqliteStorage(join(probeRoot, "store.db"));
+    await runMigrations(probeStore, MIGRATIONS);
+    let fit: {
+      readonly sport: string;
+      readonly start: number;
+      readonly elapsed: number;
+      readonly distance: number;
+      readonly localDate: string;
+    };
+    try {
+      const probeNode = createNodeImportRuntime({
+        archiveDir: join(probeRoot, "archive"),
+        store: probeStore,
+      });
+      await probeNode.importBatchWithReport({
+        files: [{ input_path: "probe.fit", bytes, ext: "fit" }],
+        platform_records: [],
+      });
+      const row = await probeStore.get(
+        `SELECT sport, start_utc, elapsed_s, distance_m, local_date_key
+FROM session`,
+      );
+      expect(row).toBeDefined();
+      const compactDate = String(row!.local_date_key).padStart(8, "0");
+      fit = {
+        sport: String(row!.sport),
+        start: Number(row!.start_utc),
+        elapsed: Number(row!.elapsed_s),
+        distance: Number(row!.distance_m),
+        localDate: `${compactDate.slice(0, 4)}-${compactDate.slice(4, 6)}-${compactDate.slice(6)}`,
+      };
+      expect(fit.distance).toBeGreaterThan(0);
+    } finally {
+      await probeStore.close();
+    }
+
+    const selected = await fixture();
+    let selectedWriterOpen = true;
+    let reopened:
+      | {
+          readonly store: ReturnType<typeof openSqliteStorage>;
+          readonly runtime: ReturnType<typeof createStoreRuntime>;
+        }
+      | undefined;
+    try {
+      const node = createNodeImportRuntime({
+        archiveDir: selected.home.archiveDir,
+        store: selected.context.store,
+      });
+      const platformDistance = fit.distance * 0.95;
+      const activity = {
+        id: "synthetic-mixed-activity",
+        start_date: new Date(fit.start * 1_000).toISOString(),
+        start_date_local: `${fit.localDate}T00:00:00`,
+        type: fit.sport === "running" ? "Run" : "Ride",
+        moving_time: Math.max(0, fit.elapsed - 1),
+        elapsed_time: fit.elapsed,
+        distance: platformDistance,
+      };
+      const archiveInstant = { epochSeconds: fit.start };
+      const archive = await node.archive.writeSnapshot(activity, archiveInstant);
+      const platform = await mapActivityLanding({
+        normalized: activity,
+        archiveInstant,
+        archive,
+      });
+      await node.importBatchWithReport({ files: [], platform_records: [platform] });
+
+      await expect(
+        selected.operations.importFiles({ paths: [mixedImportPath] }),
+      ).resolves.toMatchObject({
+        files: { imported: 1, quarantined: 0 },
+        publication: { status: "available" },
+      });
+      const immediate = await coachingSnapshot(selected.runtime, {
+        start: fit.localDate,
+        end: fit.localDate,
+      });
+      expect(immediate.listed).toMatchObject({ ok: true, value: [expect.any(Object)] });
+      expect(immediate.detail).toMatchObject({
+        ok: true,
+        value: { distanceMeters: fit.distance },
+      });
+      expect(immediate.detail).not.toMatchObject({
+        ok: true,
+        value: { distanceMeters: platformDistance },
+      });
+      if (!immediate.detail.ok) throw new Error("mixed-source detail read failed");
+      const activityId = immediate.detail.value.id;
+      await expect(
+        selected.runtime.athleteData.getStreams({ id: activityId, keys: ["time", "power"] }),
+      ).resolves.toMatchObject({
+        ok: true,
+        value: {
+          time: expect.any(Array),
+          power: expect.arrayContaining([expect.any(Number)]),
+        },
+      });
+
+      await selected.runtime.close();
+      await selected.context.store.close();
+      selectedWriterOpen = false;
+      const store = openSqliteStorage(join(selected.home.storeDir, "store.db"));
+      const context: CoachStoreWriterContext = {
+        home: selected.home,
+        store,
+        listener: {} as CoachStoreWriterContext["listener"],
+      };
+      reopened = { store, runtime: runtimeFor(selected.home, context).runtime };
+      expect(
+        await coachingSnapshot(reopened.runtime, {
+          start: fit.localDate,
+          end: fit.localDate,
+        }),
+      ).toEqual(immediate);
+      await expect(
+        reopened.runtime.athleteData.getStreams({ id: activityId, keys: ["time", "power"] }),
+      ).resolves.toMatchObject({
+        ok: true,
+        value: {
+          time: expect.any(Array),
+          power: expect.arrayContaining([expect.any(Number)]),
+        },
+      });
+    } finally {
+      await selected.runtime.close();
+      if (selectedWriterOpen) await selected.context.store.close();
+      await reopened?.runtime.close();
+      await reopened?.store.close();
+    }
+  });
+
+  it("does not mistake an unrelated readable activity for the imported workout", async () => {
+    const selected = await fixture();
+    let addAbsentWorkout = false;
+    const absentWorkoutKey = "f".repeat(64);
+    const importFiles = vi.fn(async (options: Parameters<typeof importFilesWithReport>[0]) => {
+      const report = await importFilesWithReport(options);
+      if (!addAbsentWorkout) return report;
+      const importedAddresses = new Set(
+        report.files.filter((file) => file.outcome === "imported").map((file) => file.address),
+      );
+      const matching = report.clusters.find((cluster) =>
+        cluster.members.some((member) => importedAddresses.has(member)),
+      );
+      expect(matching).toBeDefined();
+      return {
+        ...report,
+        clusters: [...report.clusters, { ...matching!, workout_key: absentWorkoutKey }],
+      };
+    });
+    const operations = createCoachOperations(
+      {
+        home: selected.home,
+        context: selected.context,
+        runtime: selected.runtime,
+        intervalsCredentials: { read: async () => ({ apiKey: "", athleteId: "" }) },
+        historyNewestDate: () => "1998-07-18",
+        applyRuntimeConfig: async () => {},
+      },
+      { importFiles },
+    );
+    try {
+      await expect(operations.importFiles({ paths: [importPath] })).resolves.toMatchObject({
+        changes: { rawFilesInserted: 1 },
+        publication: { status: "available" },
+      });
+      await coachingSnapshot(selected.runtime);
+
+      addAbsentWorkout = true;
+      await expect(operations.importFiles({ paths: [importPath] })).resolves.toMatchObject({
+        changes: { rawFilesInserted: 0 },
+        publication: { status: "retryable-failure" },
+      });
+      await coachingSnapshot(selected.runtime);
+    } finally {
+      await selected.runtime.close();
+      await selected.context.store.close();
+    }
+  });
+
+  it("prefers a sampled session and still publishes a workout with no streams", async () => {
+    const streamReads: string[] = [];
+    const selected = await fixture({
+      openReadonlyStore(path) {
+        const store = openReadonlySqliteStorage(path);
+        return {
+          get: store.get.bind(store),
+          async all(sql, params) {
+            if (sql.includes("WITH selected AS")) streamReads.push(String(params?.at(-1)));
+            return store.all(sql, params);
+          },
+          close: store.close.bind(store),
+        };
+      },
+    });
+    try {
+      await expect(selected.operations.importFiles({ paths: [importPath] })).resolves.toMatchObject(
+        {
+          publication: { status: "available" },
+        },
+      );
+      const sessions = await selected.context.store.all(
+        `SELECT s.session_key, s.session_seq, count(st.channel) AS stream_count
+FROM session AS s
+LEFT JOIN stream AS st ON st.session_key = s.session_key
+GROUP BY s.session_key, s.session_seq
+ORDER BY s.session_seq ASC, s.session_key ASC`,
+      );
+      expect(sessions.length).toBeGreaterThan(1);
+      const firstSessionId = String(sessions[0]!.session_key);
+      const sampledLaterSession = sessions.find(
+        (row, index) => index > 0 && Number(row.stream_count) > 0,
+      );
+      expect(sampledLaterSession).toBeDefined();
+      await selected.context.store.run("DELETE FROM stream WHERE session_key = ?", [
+        firstSessionId,
+      ]);
+
+      streamReads.length = 0;
+      await expect(selected.operations.importFiles({ paths: [importPath] })).resolves.toMatchObject(
+        {
+          changes: { rawFilesInserted: 0 },
+          publication: { status: "available" },
+        },
+      );
+      expect(streamReads).toEqual([sampledLaterSession!.session_key]);
+
+      await selected.context.store.run("DELETE FROM stream");
+      streamReads.length = 0;
+      await expect(selected.operations.importFiles({ paths: [importPath] })).resolves.toMatchObject(
+        {
+          changes: { rawFilesInserted: 0 },
+          publication: { status: "available" },
+        },
+      );
+      expect(streamReads).toEqual([]);
+      await expect(
+        selected.runtime.athleteData.getActivity({ id: firstSessionId }),
+      ).resolves.toMatchObject({
+        ok: true,
+        value: { id: firstSessionId },
+      });
+      await expect(
+        selected.runtime.athleteData.getStreams({ id: firstSessionId, keys: ["time"] }),
+      ).resolves.toEqual({ ok: true, value: {} });
+    } finally {
+      await selected.runtime.close();
+      await selected.context.store.close();
     }
   });
 
@@ -169,6 +441,13 @@ describe("canonical activity coaching cutover", () => {
         return openReadonlySqliteStorage(path);
       },
     });
+    let selectedWriterOpen = true;
+    let reopened:
+      | {
+          readonly store: ReturnType<typeof openSqliteStorage>;
+          readonly runtime: ReturnType<typeof createStoreRuntime>;
+        }
+      | undefined;
     try {
       await expect(selected.operations.importFiles({ paths: [importPath] })).resolves.toMatchObject(
         {
@@ -180,17 +459,28 @@ describe("canonical activity coaching cutover", () => {
       await expect(
         selected.context.store.get("SELECT count(*) AS count FROM raw_file"),
       ).resolves.toEqual({ count: 1 });
-      await expect(selected.operations.importFiles({ paths: [importPath] })).resolves.toMatchObject(
-        {
-          schemaVersion: 2,
-          changes: { rawFilesInserted: 0 },
-          publication: { status: "available" },
-        },
-      );
-      await coachingSnapshot(selected.runtime);
-    } finally {
       await selected.runtime.close();
       await selected.context.store.close();
+      selectedWriterOpen = false;
+      const store = openSqliteStorage(join(selected.home.storeDir, "store.db"));
+      const context: CoachStoreWriterContext = {
+        home: selected.home,
+        store,
+        listener: {} as CoachStoreWriterContext["listener"],
+      };
+      const pair = runtimeFor(selected.home, context);
+      reopened = { store, runtime: pair.runtime };
+      await expect(pair.operations.importFiles({ paths: [importPath] })).resolves.toMatchObject({
+        schemaVersion: 2,
+        changes: { rawFilesInserted: 0 },
+        publication: { status: "available" },
+      });
+      await coachingSnapshot(reopened.runtime);
+    } finally {
+      await selected.runtime.close();
+      if (selectedWriterOpen) await selected.context.store.close();
+      await reopened?.runtime.close();
+      await reopened?.store.close();
     }
   });
 });

--- a/packages/coach/tests/store-runtime.test.ts
+++ b/packages/coach/tests/store-runtime.test.ts
@@ -333,20 +333,23 @@ describe("StoreRuntime", () => {
     const { runtime, capture } = await makeRuntime();
     let releaseWrite!: () => void;
     const trace: string[] = [];
-    const write = runtime.runActivityWrite(async () => {
-      trace.push("write:start");
-      await new Promise<void>((resolve) => {
-        releaseWrite = resolve;
-      });
-      trace.push("write:end");
-      return "written";
-    });
+    const write = runtime.runActivityWrite(
+      async () => {
+        trace.push("write:start");
+        await new Promise<void>((resolve) => {
+          releaseWrite = resolve;
+        });
+        trace.push("write:end");
+        return "written";
+      },
+      () => [],
+    );
     const windowAfterWrite = runtime.runWindow();
     expect(capture).not.toHaveBeenCalled();
     releaseWrite();
     await expect(write).resolves.toEqual({
       value: "written",
-      activityReadAvailable: true,
+      activityReadAvailable: false,
     });
     await windowAfterWrite;
     expect(capture).toHaveBeenCalledTimes(1);
@@ -361,17 +364,20 @@ describe("StoreRuntime", () => {
       return manifest;
     });
     const window = runtime.runWindow();
-    const writeAfterWindow = runtime.runActivityWrite(async () => {
-      trace.push("write:after-window");
-      return "second";
-    });
+    const writeAfterWindow = runtime.runActivityWrite(
+      async () => {
+        trace.push("write:after-window");
+        return "second";
+      },
+      () => [],
+    );
     await Promise.resolve();
     expect(trace).not.toContain("write:after-window");
     releaseWindow();
     await window;
     await expect(writeAfterWindow).resolves.toMatchObject({
       value: "second",
-      activityReadAvailable: true,
+      activityReadAvailable: false,
     });
     expect(trace).toEqual([
       "write:start",
@@ -433,6 +439,29 @@ describe("StoreRuntime", () => {
     await expect(runtime.runWindowAfter(async () => {})).rejects.toThrow(
       "Store runtime is closed.",
     );
+  });
+
+  it("aborts a completed activity write before publication attestation on close", async () => {
+    const readonlyStore = emptyReadonlyStore();
+    const { runtime } = await makeRuntime(config, undefined, readonlyStore);
+    let signal!: AbortSignal;
+    const write = runtime.runActivityWrite(
+      async (selectedSignal) => {
+        signal = selectedSignal;
+        await new Promise<void>((resolve) => {
+          selectedSignal.addEventListener("abort", () => resolve(), { once: true });
+        });
+        return "written";
+      },
+      () => ["a".repeat(64)],
+    );
+    while (signal === undefined) await Promise.resolve();
+    const rejectedWrite = expect(write).rejects.toThrow("Store runtime closed.");
+    const close = runtime.close();
+    expect(signal.aborted).toBe(true);
+    await rejectedWrite;
+    await expect(close).resolves.toBeUndefined();
+    expect(readonlyStore.all).not.toHaveBeenCalled();
   });
 
   it("cancels an active window when closed and rejects later windows", async () => {


### PR DESCRIPTION
## Summary

- Tie publication availability to every canonical workout associated with accepted ride files.
- Verify coaching list and detail reads plus one bounded stream read, including mixed-source selection, restart recovery, and valid streamless workouts.
- Preserve durable ingestion on readback failure and propagate shutdown cancellation through publication attestation.

## Test plan

- [x] 107 focused Coach tests
- [x] Coach TypeScript check
- [x] Scoped oxlint
- [x] Changeset user-facing validation
- [x] Persistence, security/resource, and concurrency reviews