### PR TITLE
Add provider and model selection to Desktop Setup

### DIFF
--- a/.changeset/desktop-setup-model-selection.md
+++ b/.changeset/desktop-setup-model-selection.md
@@ -1,0 +1,10 @@
+---
+"@enduragent/core": patch
+"@enduragent/desktop": patch
+"@enduragent/desktop-renderer": patch
+"cycling-coach": patch
+---
+
+User-facing: Desktop Setup now lets you choose your coaching provider, model, and compatible endpoint before starting.
+
+Add curated and custom model selection, write-only endpoint overrides, explicit provider activation, and retry-safe non-secret Setup drafts.

--- a/apps/desktop-renderer/src/global.d.ts
+++ b/apps/desktop-renderer/src/global.d.ts
@@ -9,9 +9,12 @@ interface EnduragentAuth {
   writeCredential(input: {
     readonly slot: DesktopCredentialSlot;
     readonly value: string;
+    readonly selection?: OnboardingLlmSelection;
   }): Promise<CredentialWriteResult>;
+  llmConfiguration(): Promise<OnboardingLlmConfiguration>;
+  applyLlmSelection(input: OnboardingLlmSelection): Promise<OnboardingLlmSelectionResult>;
   chatgptStatus(): Promise<ChatGptStatus>;
-  chatgptLogin(): Promise<ChatGptLoginResult>;
+  chatgptLogin(input: OnboardingLlmSelection): Promise<ChatGptLoginResult>;
   chooseImportFiles(): Promise<readonly string[]>;
   onDroppedImportFiles(listener: (paths: readonly string[]) => void): () => void;
   releaseNotes(): Promise<ReleaseNotesResult>;
@@ -54,6 +57,48 @@ type DesktopCredentialSlot =
   | "zai"
   | "intervals-icu";
 
+type LlmProvider = Exclude<DesktopCredentialSlot, "intervals-icu"> | "openai-codex";
+
+interface OnboardingLlmModelOption {
+  readonly value: string;
+  readonly label: string;
+  readonly hint?: string;
+}
+
+interface OnboardingLlmProviderConfiguration {
+  readonly provider: LlmProvider;
+  readonly defaultModel: string;
+  readonly models: readonly OnboardingLlmModelOption[];
+  readonly defaultBaseUrl?: string;
+}
+
+interface OnboardingLlmConfiguration {
+  readonly schemaVersion: 1;
+  readonly providers: readonly OnboardingLlmProviderConfiguration[];
+  readonly active: {
+    readonly provider: LlmProvider;
+    readonly model: string;
+  } | null;
+}
+
+type OnboardingLlmEndpointSelection =
+  | { readonly mode: "automatic" }
+  | { readonly mode: "default" }
+  | { readonly mode: "custom"; readonly value: string };
+
+interface OnboardingLlmSelection {
+  readonly provider: LlmProvider;
+  readonly model: string;
+  readonly endpoint: OnboardingLlmEndpointSelection;
+}
+
+type OnboardingLlmSelectionResult =
+  | { readonly status: "configured"; readonly runtimeReady: true }
+  | {
+      readonly status: "refused";
+      readonly reason: "invalid-input" | "credential-required" | "runtime-unavailable";
+    };
+
 type CredentialState = "missing" | "configured" | "re-prompt";
 type CredentialRuntimeState = "active" | "stored-inactive" | "failed";
 
@@ -86,7 +131,7 @@ type CredentialWriteResult =
   | {
       readonly slot: DesktopCredentialSlot;
       readonly status: "configured";
-      readonly runtimeReady: true;
+      readonly runtimeReady: boolean;
     }
   | {
       readonly slot: DesktopCredentialSlot;

--- a/apps/desktop-renderer/src/index.ts
+++ b/apps/desktop-renderer/src/index.ts
@@ -215,8 +215,10 @@ const onboardingBridge: OnboardingBridge = {
   credentialStatuses: () => window.enduragentAuth.credentialStatuses(),
   retryFailedCredentials: () => window.enduragentAuth.retryFailedCredentials(),
   writeCredential: (value) => window.enduragentAuth.writeCredential(value),
+  llmConfiguration: () => window.enduragentAuth.llmConfiguration(),
+  applyLlmSelection: (value) => window.enduragentAuth.applyLlmSelection(value),
   chatGptStatus: () => window.enduragentAuth.chatgptStatus(),
-  chatGptLogin: () => window.enduragentAuth.chatgptLogin(),
+  chatGptLogin: (value) => window.enduragentAuth.chatgptLogin(value),
   chooseImportFiles: () => window.enduragentAuth.chooseImportFiles(),
   onDroppedImportFiles: (listener) => window.enduragentAuth.onDroppedImportFiles(listener),
   async importFiles(paths, onProgress) {

--- a/apps/desktop-renderer/src/onboarding/bridge.ts
+++ b/apps/desktop-renderer/src/onboarding/bridge.ts
@@ -5,6 +5,7 @@ import {
   SaveIntakeRpcParamsSchema,
   type CoachOperationProgressNotificationEnvelope,
   type ImportFilesRpcResult,
+  type LlmProvider,
   type SaveIntakeRpcParams,
 } from "@enduragent/coach-contract";
 import { SUPPORTED_IMPORT_EXTENSIONS, type DesktopCredentialSlot } from "./constants.js";
@@ -14,7 +15,7 @@ export type CredentialWriteResult =
   | {
       readonly slot: DesktopCredentialSlot;
       readonly status: "configured";
-      readonly runtimeReady: true;
+      readonly runtimeReady: boolean;
     }
   | {
       readonly slot: DesktopCredentialSlot;
@@ -28,15 +29,60 @@ export type CredentialWriteResult =
         | "training-account-mismatch";
     };
 
+export interface OnboardingLlmModelOption {
+  readonly value: string;
+  readonly label: string;
+  readonly hint?: string;
+}
+
+export interface OnboardingLlmProviderConfiguration {
+  readonly provider: LlmProvider;
+  readonly defaultModel: string;
+  readonly models: readonly OnboardingLlmModelOption[];
+  readonly defaultBaseUrl?: string;
+}
+
+export interface OnboardingLlmConfiguration {
+  readonly schemaVersion: 1;
+  readonly providers: readonly OnboardingLlmProviderConfiguration[];
+  readonly active: {
+    readonly provider: LlmProvider;
+    readonly model: string;
+  } | null;
+}
+
+export type OnboardingLlmEndpointSelection =
+  | { readonly mode: "automatic" }
+  | { readonly mode: "default" }
+  | { readonly mode: "custom"; readonly value: string };
+
+export interface OnboardingLlmSelection {
+  readonly provider: LlmProvider;
+  readonly model: string;
+  readonly endpoint: OnboardingLlmEndpointSelection;
+}
+
+export type OnboardingLlmSelectionResult =
+  | { readonly status: "configured"; readonly runtimeReady: true }
+  | {
+      readonly status: "refused";
+      readonly reason: "invalid-input" | "credential-required" | "runtime-unavailable";
+    };
+
+export interface OnboardingCredentialWriteInput {
+  readonly slot: DesktopCredentialSlot;
+  readonly value: string;
+  readonly selection?: OnboardingLlmSelection;
+}
+
 export interface OnboardingBridge {
   credentialStatuses(): Promise<readonly CredentialSlotStatus[]>;
   retryFailedCredentials(): Promise<readonly CredentialSlotStatus[]>;
-  writeCredential(input: {
-    readonly slot: DesktopCredentialSlot;
-    readonly value: string;
-  }): Promise<CredentialWriteResult>;
+  writeCredential(input: OnboardingCredentialWriteInput): Promise<CredentialWriteResult>;
+  llmConfiguration(): Promise<OnboardingLlmConfiguration>;
+  applyLlmSelection(input: OnboardingLlmSelection): Promise<OnboardingLlmSelectionResult>;
   chatGptStatus(): Promise<ChatGptStatus>;
-  chatGptLogin(): Promise<ChatGptLoginResult>;
+  chatGptLogin(input: OnboardingLlmSelection): Promise<ChatGptLoginResult>;
   chooseImportFiles(): Promise<readonly string[]>;
   onDroppedImportFiles(listener: (paths: readonly string[]) => void): () => void;
   importFiles(
@@ -53,12 +99,11 @@ export interface DesktopOnboardingAuth {
   }>;
   credentialStatuses(): Promise<readonly CredentialSlotStatus[]>;
   retryFailedCredentials(): Promise<readonly CredentialSlotStatus[]>;
-  writeCredential(input: {
-    readonly slot: DesktopCredentialSlot;
-    readonly value: string;
-  }): Promise<CredentialWriteResult>;
+  writeCredential(input: OnboardingCredentialWriteInput): Promise<CredentialWriteResult>;
+  llmConfiguration(): Promise<OnboardingLlmConfiguration>;
+  applyLlmSelection(input: OnboardingLlmSelection): Promise<OnboardingLlmSelectionResult>;
   chatgptStatus(): Promise<ChatGptStatus>;
-  chatgptLogin(): Promise<ChatGptLoginResult>;
+  chatgptLogin(input: OnboardingLlmSelection): Promise<ChatGptLoginResult>;
   chooseImportFiles(): Promise<readonly string[]>;
   onDroppedImportFiles(listener: (paths: readonly string[]) => void): () => void;
 }
@@ -126,8 +171,10 @@ export function createOnboardingBridge(
     retryFailedCredentials: () =>
       auth.retryFailedCredentials() as Promise<readonly CredentialSlotStatus[]>,
     writeCredential: (input) => auth.writeCredential(input) as Promise<CredentialWriteResult>,
+    llmConfiguration: () => auth.llmConfiguration(),
+    applyLlmSelection: (input) => auth.applyLlmSelection(input),
     chatGptStatus: () => auth.chatgptStatus(),
-    chatGptLogin: () => auth.chatgptLogin(),
+    chatGptLogin: (input) => auth.chatgptLogin(input),
     chooseImportFiles: () => auth.chooseImportFiles(),
     onDroppedImportFiles: (listener) => auth.onDroppedImportFiles(listener),
     async importFiles(paths, onProgress) {

--- a/apps/desktop-renderer/src/onboarding/constants.ts
+++ b/apps/desktop-renderer/src/onboarding/constants.ts
@@ -1,3 +1,5 @@
+import type { LlmProvider } from "@enduragent/coach-contract";
+
 export const ONBOARDING_STEP_IDS = [
   "coach-keys",
   "training-data",
@@ -37,6 +39,21 @@ export const DESKTOP_CREDENTIAL_SLOTS = [
 
 export type DesktopCredentialSlot = (typeof DESKTOP_CREDENTIAL_SLOTS)[number];
 export type ModelCredentialSlot = Exclude<DesktopCredentialSlot, "intervals-icu">;
+
+export const ONBOARDING_LLM_PROVIDER_LABELS = {
+  anthropic: "Anthropic",
+  openai: "OpenAI",
+  google: "Google",
+  "openai-codex": "ChatGPT subscription",
+  deepseek: "DeepSeek",
+  qwen: "Qwen",
+  minimax: "MiniMax",
+  kimi: "Kimi",
+  zai: "Z.AI",
+  openrouter: "OpenRouter",
+} as const satisfies Readonly<Record<LlmProvider, string>>;
+
+export const CUSTOM_MODEL_SELECTION = "__custom__" as const;
 
 export const CHATGPT_LOGIN_REFUSAL_REASONS = [
   "already-in-progress",

--- a/apps/desktop-renderer/src/onboarding/machine.ts
+++ b/apps/desktop-renderer/src/onboarding/machine.ts
@@ -41,6 +41,10 @@ export type OnboardingErrorCode =
   | "runtime-unavailable"
   | "credential-status-unavailable"
   | "credential-reenter-required"
+  | "configuration-unavailable"
+  | "model-selection-required"
+  | "endpoint-invalid"
+  | "model-runtime-unavailable"
   | "training-account-mismatch"
   | "training-data-required"
   | "intake-incomplete"
@@ -175,10 +179,13 @@ export function toDesktopIntakeFlags(draft: DesktopIntakeDraft): SaveIntakeRpcPa
   });
 }
 
-export function nextStep(state: OnboardingState): OnboardingState {
+export function nextStep(
+  state: OnboardingState,
+  runtimeModelConfigured = hasConfiguredModel(state),
+): OnboardingState {
   const index = ONBOARDING_STEP_IDS.indexOf(state.step);
   if (index >= ONBOARDING_STEP_IDS.length - 1) return state;
-  if (state.step === "coach-keys" && !hasConfiguredModel(state)) {
+  if (state.step === "coach-keys" && !runtimeModelConfigured) {
     return { ...state, fixedError: "credential-required" };
   }
   if (state.step === "training-data" && !hasTrainingData(state)) {

--- a/apps/desktop-renderer/src/onboarding/mount.ts
+++ b/apps/desktop-renderer/src/onboarding/mount.ts
@@ -1,16 +1,25 @@
 import {
   ADVANCED_MODEL_CREDENTIAL_SLOTS,
+  CUSTOM_MODEL_SELECTION,
   INTERVALS_GUIDANCE,
+  ONBOARDING_LLM_PROVIDER_LABELS,
   ONBOARDING_STEP_IDS,
   PRIMARY_MODEL_CREDENTIAL_SLOTS,
   type DesktopCredentialSlot,
   type ModelCredentialSlot,
 } from "./constants.js";
-import type { CredentialWriteResult, OnboardingBridge } from "./bridge.js";
+import type {
+  CredentialWriteResult,
+  OnboardingBridge,
+  OnboardingCredentialWriteInput,
+  OnboardingLlmConfiguration,
+  OnboardingLlmEndpointSelection,
+  OnboardingLlmProviderConfiguration,
+  OnboardingLlmSelection,
+} from "./bridge.js";
 import { credentialPresentation } from "./credential-presentation.js";
 import {
   createOnboardingState,
-  hasConfiguredModel,
   hasTrainingData,
   nextStep,
   previousStep,
@@ -62,17 +71,19 @@ export interface TransientPasswordInput {
 
 export async function handoffCredential(
   input: TransientPasswordInput,
-  write: (value: {
-    readonly slot: DesktopCredentialSlot;
-    readonly value: string;
-  }) => Promise<unknown>,
+  write: (value: OnboardingCredentialWriteInput) => Promise<unknown>,
+  selection?: OnboardingLlmSelection,
 ): Promise<boolean> {
   let secret: string | undefined;
   try {
     secret = input.value;
     input.value = "";
     if (secret.trim().length === 0) return false;
-    await write({ slot: input.dataset.slot as DesktopCredentialSlot, value: secret });
+    await write({
+      slot: input.dataset.slot as DesktopCredentialSlot,
+      value: secret,
+      ...(selection === undefined ? {} : { selection }),
+    });
     return true;
   } finally {
     input.value = "";
@@ -94,6 +105,12 @@ const ERROR_COPY: Readonly<Record<OnboardingErrorCode, string>> = {
   "credential-status-unavailable":
     "That key was saved, but its status could not be refreshed. Close and reopen Setup to check again.",
   "credential-reenter-required": "That saved key could not be used. Enter it again to continue.",
+  "configuration-unavailable":
+    "Coach choices are unavailable right now. Close and reopen Setup to try again.",
+  "model-selection-required": "Choose a model or enter a custom model name.",
+  "endpoint-invalid": "Enter a valid HTTPS endpoint, or a loopback HTTP endpoint.",
+  "model-runtime-unavailable":
+    "Your provider choice is saved, but it is not active yet. Choose Continue to retry it.",
   "training-account-mismatch":
     "That intervals.icu key belongs to a different athlete than the training history already stored. Switching accounts is not supported yet.",
   "training-data-required": "Connect intervals.icu or import at least one ride file.",
@@ -148,7 +165,7 @@ function make<K extends keyof HTMLElementTagNameMap>(
 function focusableElements(root: HTMLElement): readonly HTMLElement[] {
   return Array.from(
     root.querySelectorAll<HTMLElement>(
-      'button:not([disabled]), input:not([disabled]), summary, [tabindex]:not([tabindex="-1"])',
+      'button:not([disabled]), input:not([disabled]), select:not([disabled]), summary, [tabindex]:not([tabindex="-1"])',
     ),
   ).filter((element) => {
     if (element.hasAttribute("hidden")) return false;
@@ -188,6 +205,129 @@ function passwordControl(
   return field;
 }
 
+interface LlmSelectionDraft {
+  provider: OnboardingLlmProviderConfiguration;
+  modelChoice: string;
+  customModel: string;
+  endpointMode: OnboardingLlmEndpointSelection["mode"];
+  customEndpoint: string;
+}
+
+function initialLlmDraft(
+  configuration: OnboardingLlmConfiguration,
+  statuses: readonly CredentialSlotStatus[],
+  chatGptStatus: ChatGptStatus,
+): LlmSelectionDraft | undefined {
+  const activeCredential = statuses.find(
+    (status) => status.slot !== "intervals-icu" && status.runtimeState === "active",
+  );
+  const preferredProvider =
+    configuration.active?.provider ??
+    activeCredential?.slot ??
+    (chatGptStatus.state === "configured" && chatGptStatus.runtimeReady
+      ? "openai-codex"
+      : undefined);
+  const provider =
+    configuration.providers.find((entry) => entry.provider === preferredProvider) ??
+    configuration.providers[0];
+  if (provider === undefined) return undefined;
+  const active = configuration.active;
+  const activeModel = active?.provider === provider.provider ? active.model : provider.defaultModel;
+  const knownModel = provider.models.some((model) => model.value === activeModel);
+  return {
+    provider,
+    modelChoice: knownModel ? activeModel : CUSTOM_MODEL_SELECTION,
+    customModel: knownModel ? "" : activeModel,
+    endpointMode: "automatic",
+    customEndpoint: "",
+  };
+}
+
+function hasControlCharacters(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code <= 0x1f || code === 0x7f) return true;
+  }
+  return false;
+}
+
+function validCustomEndpoint(value: string): boolean {
+  if (
+    value.length === 0 ||
+    value.length > 4_096 ||
+    value.trim() !== value ||
+    hasControlCharacters(value)
+  ) {
+    return false;
+  }
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return false;
+  }
+  if (
+    url.username !== "" ||
+    url.password !== "" ||
+    url.search !== "" ||
+    url.hash !== "" ||
+    url.href.includes("?") ||
+    url.href.includes("#") ||
+    (url.protocol !== "https:" && url.protocol !== "http:")
+  ) {
+    return false;
+  }
+  if (url.protocol === "https:") return true;
+  const hostname = url.hostname.toLowerCase();
+  if (hostname === "localhost" || hostname.endsWith(".localhost") || hostname === "[::1]") {
+    return true;
+  }
+  const octets = hostname.split(".");
+  return (
+    octets.length === 4 &&
+    octets.every((octet) => /^(?:0|[1-9]\d{0,2})$/u.test(octet)) &&
+    Number(octets[0]) === 127 &&
+    octets.every((octet) => Number(octet) <= 255)
+  );
+}
+
+function llmSelectionFromDraft(
+  draft: LlmSelectionDraft | undefined,
+):
+  | { readonly selection: OnboardingLlmSelection; readonly error: null }
+  | { readonly selection: null; readonly error: OnboardingErrorCode } {
+  if (draft === undefined) return { selection: null, error: "configuration-unavailable" };
+  const model =
+    draft.modelChoice === CUSTOM_MODEL_SELECTION ? draft.customModel.trim() : draft.modelChoice;
+  if (
+    model.length === 0 ||
+    model.length > 512 ||
+    model.trim() !== model ||
+    hasControlCharacters(model)
+  ) {
+    return { selection: null, error: "model-selection-required" };
+  }
+  if (draft.provider.defaultBaseUrl === undefined && draft.endpointMode !== "automatic") {
+    return { selection: null, error: "endpoint-invalid" };
+  }
+  let endpoint: OnboardingLlmEndpointSelection;
+  if (draft.endpointMode === "custom") {
+    const value = draft.customEndpoint.trim();
+    if (!validCustomEndpoint(value)) return { selection: null, error: "endpoint-invalid" };
+    endpoint = { mode: "custom", value };
+  } else {
+    endpoint = { mode: draft.endpointMode };
+  }
+  return {
+    selection: {
+      provider: draft.provider.provider,
+      model,
+      endpoint,
+    },
+    error: null,
+  };
+}
+
 export function mountOnboarding(options: MountOnboardingOptions): OnboardingController {
   const rideImports = options.rideImports ?? createRideImportController(options.bridge);
   let state = createOnboardingState();
@@ -199,6 +339,14 @@ export function mountOnboarding(options: MountOnboardingOptions): OnboardingCont
   let opening = false;
   let visit = 0;
   let presentingRideImports = false;
+  let llmConfiguration: OnboardingLlmConfiguration | undefined;
+  let llmDraft: LlmSelectionDraft | undefined;
+  let llmDrafts: Record<string, LlmSelectionDraft> = {};
+
+  const setLlmDraft = (next: LlmSelectionDraft | undefined): void => {
+    llmDraft = next;
+    if (next !== undefined) llmDrafts[next.provider.provider] = next;
+  };
 
   const setRideImportPresentation = (presenting: boolean): void => {
     if (presentingRideImports === presenting) return;
@@ -212,6 +360,24 @@ export function mountOnboarding(options: MountOnboardingOptions): OnboardingCont
       state: state.credentialStatus[slot],
       runtimeState: null,
     };
+
+  const setFixedError = (fixedError: OnboardingErrorCode | null): void => {
+    state = { ...state, fixedError };
+    const error = scrim?.querySelector<HTMLElement>("#onboarding-error");
+    if (error !== null && error !== undefined) {
+      error.textContent = fixedError === null ? "" : ERROR_COPY[fixedError];
+    }
+  };
+
+  const selectedProviderIsReady = (): boolean => {
+    const provider = llmDraft?.provider.provider;
+    if (provider === undefined) return false;
+    if (llmConfiguration?.active?.provider === provider) return true;
+    if (provider === "openai-codex") {
+      return state.chatGptState === "configured" && state.chatGptRuntimeReady;
+    }
+    return status(provider).state === "configured" && status(provider).runtimeState === "active";
+  };
 
   const clearPasswordInputs = (): void => {
     for (const input of scrim?.querySelectorAll<HTMLInputElement>('input[type="password"]') ?? []) {
@@ -258,7 +424,11 @@ export function mountOnboarding(options: MountOnboardingOptions): OnboardingCont
   const savePasswordControls = async (
     root: HTMLElement,
     expectedVisit: number,
-  ): Promise<OnboardingErrorCode | null> => {
+    selection?: OnboardingLlmSelection,
+  ): Promise<{
+    readonly error: OnboardingErrorCode | null;
+    readonly selectedApplied: boolean;
+  } | null> => {
     const controls = Array.from(
       root.querySelectorAll<HTMLInputElement>('input[type="password"][data-slot]'),
       (input): TransientPasswordInput => {
@@ -268,7 +438,14 @@ export function mountOnboarding(options: MountOnboardingOptions): OnboardingCont
         return control;
       },
     );
+    const selectedSlot = selection?.provider === "openai-codex" ? undefined : selection?.provider;
+    controls.sort((left, right) => {
+      const leftSelected = left.dataset.slot === selectedSlot ? 1 : 0;
+      const rightSelected = right.dataset.slot === selectedSlot ? 1 : 0;
+      return leftSelected - rightSelected;
+    });
     let attempted = false;
+    let selectedApplied = false;
     const outcome: {
       failure: OnboardingErrorCode | null;
       nonRuntimeFailure: OnboardingErrorCode | null;
@@ -281,22 +458,28 @@ export function mountOnboarding(options: MountOnboardingOptions): OnboardingCont
         if (input.value.trim().length === 0) continue;
         attempted = true;
         let configured = false;
-        await handoffCredential(input, async (value) => {
-          const result = await options.bridge.writeCredential(value);
-          if (disposed || visit !== expectedVisit || scrim === undefined) return;
-          if (result.status === "configured") {
-            configured = true;
-          } else {
-            if (result.reason === "runtime-unavailable") {
-              runtimeUnavailableSlots.add(result.slot);
+        const appliesSelection = input.dataset.slot === selectedSlot;
+        await handoffCredential(
+          input,
+          async (value) => {
+            const result = await options.bridge.writeCredential(value);
+            if (disposed || visit !== expectedVisit || scrim === undefined) return;
+            if (result.status === "configured") {
+              configured = true;
+              if (appliesSelection && result.runtimeReady) selectedApplied = true;
+            } else {
+              if (result.reason === "runtime-unavailable") {
+                runtimeUnavailableSlots.add(result.slot);
+              }
+              const writeFailure = credentialWriteRefusalError(result.reason);
+              outcome.failure ??= writeFailure;
+              if (writeFailure !== "runtime-unavailable") {
+                outcome.nonRuntimeFailure ??= writeFailure;
+              }
             }
-            const writeFailure = credentialWriteRefusalError(result.reason);
-            outcome.failure ??= writeFailure;
-            if (writeFailure !== "runtime-unavailable") {
-              outcome.nonRuntimeFailure ??= writeFailure;
-            }
-          }
-        });
+          },
+          appliesSelection ? selection : undefined,
+        );
         if (disposed || visit !== expectedVisit || scrim === undefined) return null;
         if (!configured && outcome.failure === null) {
           outcome.failure = "credential-save-failed";
@@ -317,12 +500,17 @@ export function mountOnboarding(options: MountOnboardingOptions): OnboardingCont
       if (disposed || visit !== expectedVisit || scrim === undefined) return null;
     }
     if (statusRefreshFailed) {
-      return outcome.nonRuntimeFailure ?? "credential-status-unavailable";
+      return {
+        error: outcome.nonRuntimeFailure ?? "credential-status-unavailable",
+        selectedApplied,
+      };
     }
     if (runtimeUnavailableSlots.size === 0) {
-      return outcome.failure;
+      return { error: outcome.failure, selectedApplied };
     }
-    if (outcome.nonRuntimeFailure !== null) return outcome.nonRuntimeFailure;
+    if (outcome.nonRuntimeFailure !== null) {
+      return { error: outcome.nonRuntimeFailure, selectedApplied };
+    }
     const refreshedRuntimeStatuses = Array.from(runtimeUnavailableSlots, (slot) =>
       credentialStatuses.find((entry) => entry.slot === slot),
     );
@@ -332,12 +520,12 @@ export function mountOnboarding(options: MountOnboardingOptions): OnboardingCont
           status === undefined || status.state === "missing" || status.state === "re-prompt",
       )
     ) {
-      return "credential-reenter-required";
+      return { error: "credential-reenter-required", selectedApplied };
     }
     if (refreshedRuntimeStatuses.some((status) => status?.runtimeState === "failed")) {
-      return "runtime-unavailable";
+      return { error: "runtime-unavailable", selectedApplied };
     }
-    return null;
+    return { error: null, selectedApplied };
   };
 
   const importStatusCopy = (): string => {
@@ -397,14 +585,235 @@ export function mountOnboarding(options: MountOnboardingOptions): OnboardingCont
     return label;
   };
 
+  const renderLlmSelectionPanel = (panel: HTMLElement): void => {
+    panel.replaceChildren();
+    if (llmConfiguration === undefined || llmDraft === undefined) {
+      panel.append(
+        make(
+          options.document,
+          "p",
+          "llm-configuration-unavailable",
+          ERROR_COPY["configuration-unavailable"],
+        ),
+      );
+      return;
+    }
+
+    const providerField = make(options.document, "label", "llm-selection-field");
+    providerField.htmlFor = "onboarding-llm-provider";
+    providerField.append(
+      make(options.document, "span", "llm-selection-label", "Active coach provider"),
+    );
+    const providerSelect = make(options.document, "select");
+    providerSelect.id = "onboarding-llm-provider";
+    providerSelect.disabled = state.busy;
+    for (const provider of llmConfiguration.providers) {
+      const option = make(options.document, "option");
+      option.value = provider.provider;
+      option.textContent = ONBOARDING_LLM_PROVIDER_LABELS[provider.provider];
+      providerSelect.append(option);
+    }
+    providerSelect.value = llmDraft.provider.provider;
+    providerSelect.addEventListener("change", () => {
+      const provider = llmConfiguration?.providers.find(
+        (entry) => entry.provider === providerSelect.value,
+      );
+      if (provider === undefined) return;
+      setLlmDraft(
+        llmDrafts[provider.provider] ?? {
+          provider,
+          modelChoice: provider.defaultModel,
+          customModel: "",
+          endpointMode: "automatic",
+          customEndpoint: "",
+        },
+      );
+      setFixedError(null);
+      renderLlmSelectionPanel(panel);
+      panel.querySelector<HTMLSelectElement>("#onboarding-llm-provider")?.focus();
+    });
+    providerField.append(providerSelect);
+
+    const modelField = make(options.document, "label", "llm-selection-field");
+    modelField.htmlFor = "onboarding-llm-model";
+    modelField.append(make(options.document, "span", "llm-selection-label", "Model"));
+    const modelSelect = make(options.document, "select");
+    modelSelect.id = "onboarding-llm-model";
+    modelSelect.disabled = state.busy;
+    for (const model of llmDraft.provider.models) {
+      const option = make(options.document, "option");
+      option.value = model.value;
+      option.textContent =
+        model.hint === undefined ? model.label : `${model.label} · ${model.hint}`;
+      modelSelect.append(option);
+    }
+    const customOption = make(options.document, "option");
+    customOption.value = CUSTOM_MODEL_SELECTION;
+    customOption.textContent = "Other model…";
+    modelSelect.append(customOption);
+    modelSelect.value = llmDraft.modelChoice;
+    modelSelect.addEventListener("change", () => {
+      if (llmDraft === undefined) return;
+      setLlmDraft({
+        ...llmDraft,
+        modelChoice: modelSelect.value,
+        customModel: modelSelect.value === CUSTOM_MODEL_SELECTION ? llmDraft.customModel : "",
+      });
+      setFixedError(null);
+      renderLlmSelectionPanel(panel);
+      const target =
+        modelSelect.value === CUSTOM_MODEL_SELECTION
+          ? panel.querySelector<HTMLInputElement>("#onboarding-custom-model")
+          : panel.querySelector<HTMLSelectElement>("#onboarding-llm-model");
+      target?.focus();
+    });
+    modelField.append(modelSelect);
+
+    panel.append(providerField, modelField);
+
+    if (llmDraft.modelChoice === CUSTOM_MODEL_SELECTION) {
+      const customModelField = make(options.document, "label", "llm-selection-field");
+      customModelField.htmlFor = "onboarding-custom-model";
+      customModelField.append(
+        make(options.document, "span", "llm-selection-label", "Custom model name"),
+      );
+      const customModel = make(options.document, "input");
+      customModel.id = "onboarding-custom-model";
+      customModel.type = "text";
+      customModel.autocomplete = "off";
+      customModel.maxLength = 512;
+      customModel.value = llmDraft.customModel;
+      customModel.disabled = state.busy;
+      customModel.setAttribute("aria-describedby", "onboarding-error");
+      customModel.addEventListener("input", () => {
+        if (llmDraft === undefined) return;
+        setLlmDraft({ ...llmDraft, customModel: customModel.value });
+        setFixedError(null);
+      });
+      customModelField.append(customModel);
+      panel.append(customModelField);
+    }
+
+    if (llmDraft.provider.defaultBaseUrl !== undefined) {
+      const endpointField = make(options.document, "label", "llm-selection-field");
+      endpointField.htmlFor = "onboarding-endpoint-mode";
+      endpointField.append(make(options.document, "span", "llm-selection-label", "Endpoint"));
+      const endpointMode = make(options.document, "select");
+      endpointMode.id = "onboarding-endpoint-mode";
+      endpointMode.disabled = state.busy;
+      for (const [value, copy] of [
+        ["automatic", "Keep current, or use provider default"],
+        ["default", "Reset to provider default"],
+        ["custom", "Use a custom endpoint"],
+      ] as const) {
+        const option = make(options.document, "option");
+        option.value = value;
+        option.textContent = copy;
+        endpointMode.append(option);
+      }
+      endpointMode.value = llmDraft.endpointMode;
+      endpointMode.addEventListener("change", () => {
+        if (
+          llmDraft === undefined ||
+          !["automatic", "default", "custom"].includes(endpointMode.value)
+        ) {
+          return;
+        }
+        setLlmDraft({
+          ...llmDraft,
+          endpointMode: endpointMode.value as OnboardingLlmEndpointSelection["mode"],
+        });
+        setFixedError(null);
+        renderLlmSelectionPanel(panel);
+        const target =
+          endpointMode.value === "custom"
+            ? panel.querySelector<HTMLInputElement>("#onboarding-custom-endpoint")
+            : panel.querySelector<HTMLSelectElement>("#onboarding-endpoint-mode");
+        target?.focus();
+      });
+      endpointField.append(endpointMode);
+      panel.append(endpointField);
+
+      const endpointHelp = make(options.document, "p", "llm-endpoint-help");
+      endpointHelp.textContent = `Provider default: ${llmDraft.provider.defaultBaseUrl}`;
+      panel.append(endpointHelp);
+
+      if (llmDraft.endpointMode === "custom") {
+        const customEndpointField = make(options.document, "label", "llm-selection-field");
+        customEndpointField.htmlFor = "onboarding-custom-endpoint";
+        customEndpointField.append(
+          make(options.document, "span", "llm-selection-label", "Custom endpoint"),
+        );
+        const customEndpoint = make(options.document, "input");
+        customEndpoint.id = "onboarding-custom-endpoint";
+        customEndpoint.type = "url";
+        customEndpoint.autocomplete = "off";
+        customEndpoint.maxLength = 4_096;
+        customEndpoint.value = llmDraft.customEndpoint;
+        customEndpoint.disabled = state.busy;
+        customEndpoint.setAttribute("aria-describedby", "onboarding-error");
+        customEndpoint.addEventListener("input", () => {
+          if (llmDraft === undefined) return;
+          setLlmDraft({ ...llmDraft, customEndpoint: customEndpoint.value });
+          setFixedError(null);
+        });
+        customEndpointField.append(customEndpoint);
+        panel.append(customEndpointField);
+      }
+    }
+  };
+
+  const renderLlmSelection = (body: HTMLElement): void => {
+    const section = make(options.document, "section", "llm-selection");
+    section.setAttribute("aria-labelledby", "llm-selection-heading");
+    const heading = make(options.document, "h2", undefined, "Choose provider and model");
+    heading.id = "llm-selection-heading";
+    section.append(
+      heading,
+      make(
+        options.document,
+        "p",
+        "llm-selection-copy",
+        "Your selected provider becomes active when you continue. Other saved keys stay available but inactive.",
+      ),
+    );
+    const panel = make(options.document, "div", "llm-selection-panel");
+    renderLlmSelectionPanel(panel);
+    section.append(panel);
+    body.append(section);
+  };
+
   const startChatGptLogin = (): void => {
     if (disposed || scrim === undefined || state.busy || state.chatGptState === "pending") {
+      return;
+    }
+    if (llmDraft?.provider.provider !== "openai-codex") {
+      const chatGpt = llmConfiguration?.providers.find(
+        (provider) => provider.provider === "openai-codex",
+      );
+      if (chatGpt === undefined) {
+        setFixedError("configuration-unavailable");
+        return;
+      }
+      setLlmDraft(
+        llmDrafts[chatGpt.provider] ?? {
+          provider: chatGpt,
+          modelChoice: chatGpt.defaultModel,
+          customModel: "",
+          endpointMode: "automatic",
+          customEndpoint: "",
+        },
+      );
+    }
+    const parsedSelection = llmSelectionFromDraft(llmDraft);
+    if (parsedSelection.error !== null) {
+      setFixedError(parsedSelection.error);
       return;
     }
     const loginVisit = visit;
     state = withChatGptPending(state);
     render();
-    void options.bridge.chatGptLogin().then(
+    void options.bridge.chatGptLogin(parsedSelection.selection).then(
       async (result) => {
         if (
           disposed ||
@@ -450,7 +859,7 @@ export function mountOnboarding(options: MountOnboardingOptions): OnboardingCont
   };
 
   const currentStepOwnsCredentialSlot = (slot: DesktopCredentialSlot): boolean => {
-    if (state.step === "coach-keys") return slot !== "intervals-icu";
+    if (state.step === "coach-keys") return false;
     return state.step === "training-data" && slot === "intervals-icu";
   };
 
@@ -512,6 +921,7 @@ export function mountOnboarding(options: MountOnboardingOptions): OnboardingCont
         "ChatGPT sign-in is saved in a local profile file. API keys are encrypted by macOS. The local coaching service uses your choice to contact the provider.",
       ),
     );
+    renderLlmSelection(body);
     const chatGptLane = make(options.document, "section", "chatgpt-lane");
     const chatGptHeading = make(options.document, "div", "chatgpt-lane-heading");
     const chatGptActive = state.chatGptState === "configured" && state.chatGptRuntimeReady;
@@ -759,26 +1169,70 @@ export function mountOnboarding(options: MountOnboardingOptions): OnboardingCont
     state = withBusy(state, true);
     for (const button of dialog.querySelectorAll<HTMLButtonElement>("button"))
       button.disabled = true;
+    for (const input of dialog.querySelectorAll<HTMLInputElement>("input")) input.disabled = true;
+    for (const select of dialog.querySelectorAll<HTMLSelectElement>("select"))
+      select.disabled = true;
     const actionStatus = dialog.querySelector<HTMLElement>(".onboarding-action-status");
     if (actionStatus !== null) {
       actionStatus.textContent = "Working…";
       actionStatus.hidden = false;
     }
     if (state.step === "coach-keys") {
-      const saveError = await savePasswordControls(dialog, submitVisit);
+      const parsedSelection = llmSelectionFromDraft(llmDraft);
+      if (parsedSelection.error !== null) {
+        state = withError(state, parsedSelection.error);
+        render();
+        focusCurrentTitle();
+        return;
+      }
+      const saved = await savePasswordControls(dialog, submitVisit, parsedSelection.selection);
       if (visit !== submitVisit || scrim === undefined) return;
+      if (saved === null) return;
+      let saveError = saved.error;
+      if (saveError === "runtime-unavailable") saveError = "model-runtime-unavailable";
+      if (saveError === null && !saved.selectedApplied) {
+        try {
+          const applied = await options.bridge.applyLlmSelection(parsedSelection.selection);
+          if (visit !== submitVisit || scrim === undefined) return;
+          if (applied.status === "refused") {
+            saveError =
+              applied.reason === "credential-required"
+                ? "credential-required"
+                : applied.reason === "runtime-unavailable"
+                  ? "model-runtime-unavailable"
+                  : "invalid-input";
+          } else {
+            if (llmConfiguration !== undefined) {
+              llmConfiguration = {
+                ...llmConfiguration,
+                active: {
+                  provider: parsedSelection.selection.provider,
+                  model: parsedSelection.selection.model,
+                },
+              };
+            }
+            if (!(await refreshStatuses(submitVisit))) {
+              saveError = "credential-status-unavailable";
+            }
+          }
+        } catch {
+          if (visit !== submitVisit || scrim === undefined) return;
+          saveError = "model-runtime-unavailable";
+        }
+      }
       state = withBusy(state, false);
       if (saveError !== null) state = withError(state, saveError);
-      else if (currentStepHasRetryableCredential()) state = withError(state, "runtime-unavailable");
-      else if (!hasConfiguredModel(state)) state = withError(state, "credential-required");
-      else state = nextStep(state);
+      else if (!selectedProviderIsReady()) state = withError(state, "model-runtime-unavailable");
+      else state = nextStep(state, true);
       render();
       focusCurrentTitle();
       return;
     }
     if (state.step === "training-data") {
-      const saveError = await savePasswordControls(dialog, submitVisit);
+      const saved = await savePasswordControls(dialog, submitVisit);
       if (visit !== submitVisit || scrim === undefined) return;
+      if (saved === null) return;
+      const saveError = saved.error;
       state = withBusy(state, false);
       if (saveError !== null) state = withError(state, saveError);
       else if (currentStepHasRetryableCredential()) state = withError(state, "runtime-unavailable");
@@ -901,6 +1355,7 @@ export function mountOnboarding(options: MountOnboardingOptions): OnboardingCont
     footer.append(submit);
     dialog.append(header, body, footer);
     dialog.addEventListener("keydown", (event) => {
+      const targetTagName = (event.target as HTMLElement | null)?.tagName;
       if (event.key === "Escape") {
         event.preventDefault();
         close();
@@ -908,8 +1363,9 @@ export function mountOnboarding(options: MountOnboardingOptions): OnboardingCont
       }
       if (
         event.key === "Enter" &&
-        !(event.target instanceof HTMLButtonElement) &&
-        !(event.target instanceof HTMLElement && event.target.tagName === "SUMMARY")
+        targetTagName !== "BUTTON" &&
+        targetTagName !== "SUMMARY" &&
+        targetTagName !== "SELECT"
       ) {
         event.preventDefault();
         void submitCurrentStep(dialog);
@@ -952,15 +1408,24 @@ export function mountOnboarding(options: MountOnboardingOptions): OnboardingCont
       const restored = await Promise.allSettled([
         options.bridge.credentialStatuses(),
         options.bridge.chatGptStatus(),
+        options.bridge.llmConfiguration(),
       ]);
       if (restored[0].status === "fulfilled") statuses = restored[0].value;
       if (restored[1].status === "fulfilled") restoredChatGptStatus = restored[1].value;
+      llmConfiguration = restored[2].status === "fulfilled" ? restored[2].value : undefined;
+      llmDrafts = {};
+      setLlmDraft(
+        llmConfiguration === undefined
+          ? undefined
+          : initialLlmDraft(llmConfiguration, statuses, restoredChatGptStatus),
+      );
       if (disposed || visit !== openVisit || scrim !== undefined) {
         opening = false;
         return;
       }
       credentialStatuses = statuses;
       state = createOnboardingState(statuses, restoredChatGptStatus);
+      if (llmDraft === undefined) state = withError(state, "configuration-unavailable");
       state = withImportedRideFileCount(state, rideImports.importedFileCount());
       scrim = make(options.document, "div", "onboarding-scrim");
       options.document.body.append(scrim);

--- a/apps/desktop-renderer/src/onboarding/onboarding.css
+++ b/apps/desktop-renderer/src/onboarding/onboarding.css
@@ -90,6 +90,55 @@
   line-height: 1.55;
 }
 
+.llm-selection {
+  display: grid;
+  gap: 12px;
+  margin-bottom: 22px;
+  padding: 16px;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+}
+
+.llm-selection h2 {
+  margin: 0;
+  font-size: 16px;
+}
+
+.llm-selection-copy,
+.llm-endpoint-help,
+.llm-configuration-unavailable {
+  margin: 0;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.llm-selection-panel {
+  display: grid;
+  gap: 12px;
+}
+
+.llm-selection-field {
+  display: grid;
+  gap: 7px;
+}
+
+.llm-selection-label {
+  font-size: 13px;
+  font-weight: 650;
+}
+
+.llm-selection select,
+.llm-selection input {
+  width: 100%;
+  min-height: 42px;
+  padding: 0 12px;
+  border: 1px solid var(--line);
+  border-radius: 11px;
+  color: var(--ink);
+  background: var(--surface);
+}
+
 .credential-list {
   display: grid;
   gap: 14px;

--- a/apps/desktop-renderer/tests/onboarding-mount.test.ts
+++ b/apps/desktop-renderer/tests/onboarding-mount.test.ts
@@ -1,9 +1,81 @@
 import { randomUUID } from "node:crypto";
 import { describe, expect, it, vi } from "vitest";
-import type { CredentialWriteResult, OnboardingBridge } from "../src/onboarding/bridge.js";
+import type {
+  CredentialWriteResult,
+  OnboardingBridge,
+  OnboardingLlmConfiguration,
+} from "../src/onboarding/bridge.js";
 import { mountOnboarding } from "../src/onboarding/mount.js";
 import type { ChatGptLoginResult } from "../src/onboarding/machine.js";
 import { createRideImportController } from "../src/ride-import.js";
+
+const TEST_LLM_CONFIGURATION: OnboardingLlmConfiguration = {
+  schemaVersion: 1,
+  providers: [
+    {
+      provider: "anthropic",
+      defaultModel: "claude-sonnet-4-6",
+      models: [{ value: "claude-sonnet-4-6", label: "Claude Sonnet 4.6" }],
+    },
+    {
+      provider: "openai-codex",
+      defaultModel: "gpt-5.5",
+      models: [{ value: "gpt-5.5", label: "GPT-5.5" }],
+    },
+    {
+      provider: "openrouter",
+      defaultModel: "deepseek/deepseek-v4-flash",
+      models: [
+        {
+          value: "deepseek/deepseek-v4-flash",
+          label: "DeepSeek V4 Flash",
+        },
+      ],
+      defaultBaseUrl: "https://openrouter.ai/api/v1",
+    },
+    {
+      provider: "openai",
+      defaultModel: "gpt-5.5",
+      models: [{ value: "gpt-5.5", label: "GPT-5.5" }],
+    },
+    {
+      provider: "google",
+      defaultModel: "gemini-3.5-flash",
+      models: [{ value: "gemini-3.5-flash", label: "Gemini 3.5 Flash" }],
+    },
+    {
+      provider: "deepseek",
+      defaultModel: "deepseek-v4-flash",
+      models: [{ value: "deepseek-v4-flash", label: "DeepSeek V4 Flash" }],
+      defaultBaseUrl: "https://api.deepseek.com/v1",
+    },
+    {
+      provider: "qwen",
+      defaultModel: "qwen3.5-plus",
+      models: [{ value: "qwen3.5-plus", label: "Qwen3.5 Plus" }],
+      defaultBaseUrl: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+    },
+    {
+      provider: "minimax",
+      defaultModel: "MiniMax-M2.7",
+      models: [{ value: "MiniMax-M2.7", label: "MiniMax M2.7" }],
+      defaultBaseUrl: "https://api.minimax.io/v1",
+    },
+    {
+      provider: "kimi",
+      defaultModel: "kimi-k2.6",
+      models: [{ value: "kimi-k2.6", label: "Kimi K2.6" }],
+      defaultBaseUrl: "https://api.moonshot.ai/v1",
+    },
+    {
+      provider: "zai",
+      defaultModel: "glm-4.7",
+      models: [{ value: "glm-4.7", label: "GLM-4.7" }],
+      defaultBaseUrl: "https://api.z.ai/api/openai/v1",
+    },
+  ],
+  active: null,
+};
 
 class FakeElement {
   readonly children: FakeElement[] = [];
@@ -75,9 +147,9 @@ class FakeElement {
     this.listeners.get(name)?.delete(listener);
   }
 
-  dispatch(name: string): void {
-    if (name === "click" && this.disabled) return;
-    const event = { target: this, preventDefault() {} };
+  dispatch(name: string, overrides: Record<string, unknown> = {}): void {
+    if (this.disabled && ["click", "change", "input"].includes(name)) return;
+    const event = { target: this, preventDefault() {}, ...overrides };
     for (const listener of this.listeners.get(name) ?? []) listener(event);
   }
 
@@ -138,6 +210,8 @@ class FakeDocument {
 
 function bridge(login: () => Promise<ChatGptLoginResult>): OnboardingBridge & {
   readonly credentialStatuses: ReturnType<typeof vi.fn<OnboardingBridge["credentialStatuses"]>>;
+  readonly llmConfiguration: ReturnType<typeof vi.fn<OnboardingBridge["llmConfiguration"]>>;
+  readonly applyLlmSelection: ReturnType<typeof vi.fn<OnboardingBridge["applyLlmSelection"]>>;
   readonly chatGptStatus: ReturnType<typeof vi.fn<OnboardingBridge["chatGptStatus"]>>;
   readonly chatGptLogin: ReturnType<typeof vi.fn<OnboardingBridge["chatGptLogin"]>>;
   readonly importFiles: ReturnType<typeof vi.fn<OnboardingBridge["importFiles"]>>;
@@ -149,6 +223,13 @@ function bridge(login: () => Promise<ChatGptLoginResult>): OnboardingBridge & {
     runtimeReady: true,
   }));
   const chatGptLogin = vi.fn<OnboardingBridge["chatGptLogin"]>(login);
+  const llmConfiguration = vi.fn<OnboardingBridge["llmConfiguration"]>(
+    async () => TEST_LLM_CONFIGURATION,
+  );
+  const applyLlmSelection = vi.fn<OnboardingBridge["applyLlmSelection"]>(async () => ({
+    status: "configured",
+    runtimeReady: true,
+  }));
   const importFiles = vi.fn<OnboardingBridge["importFiles"]>(async () => ({
     schemaVersion: 2,
     files: { total: 0, imported: 0, quarantined: 0 },
@@ -169,6 +250,8 @@ function bridge(login: () => Promise<ChatGptLoginResult>): OnboardingBridge & {
       status: "configured",
       runtimeReady: true,
     })),
+    llmConfiguration,
+    applyLlmSelection,
     chatGptStatus,
     chatGptLogin,
     chooseImportFiles: vi.fn<OnboardingBridge["chooseImportFiles"]>(async () => []),
@@ -202,6 +285,18 @@ function passwordInputFor(document: FakeDocument, slot: string): FakeElement {
   return input;
 }
 
+function controlById(document: FakeDocument, id: string): FakeElement {
+  const control = document.body.querySelector(`#${id}`);
+  if (control === null) throw new Error(`Control not found: ${id}`);
+  return control;
+}
+
+function changeControl(document: FakeDocument, id: string, value: string): void {
+  const control = controlById(document, id);
+  control.value = value;
+  control.dispatch("change");
+}
+
 function radioInputFor(document: FakeDocument, name: string, copy: string): FakeElement {
   const input = document.body
     .querySelectorAll("input")
@@ -229,33 +324,39 @@ type CredentialWriteRefusalReason = Extract<
 const CREDENTIAL_REFUSAL_CASES = [
   {
     reason: "invalid-input",
+    fixedError: "invalid-input",
     copy: "That key was not accepted. Check it and enter it again.",
   },
   {
     reason: "encryption-unavailable",
+    fixedError: "encryption-unavailable",
     copy: "macOS encryption is unavailable. Make sure Keychain is available, then try again.",
   },
   {
     reason: "unsafe-backend",
+    fixedError: "unsafe-backend",
     copy: "The app cannot safely store that key with the current storage backend.",
   },
   {
     reason: "storage-failed",
+    fixedError: "storage-failed",
     copy: "The app could not confirm that key was saved securely. Check that secure storage is available and try again.",
   },
   {
     reason: "runtime-unavailable",
-    copy: "That key was saved, but it is not active yet. Choose Retry saved keys to activate it.",
+    fixedError: "model-runtime-unavailable",
+    copy: "Your provider choice is saved, but it is not active yet. Choose Continue to retry it.",
   },
 ] as const satisfies ReadonlyArray<{
   readonly reason: CredentialWriteRefusalReason;
+  readonly fixedError: CredentialWriteRefusalReason | "model-runtime-unavailable";
   readonly copy: string;
 }>;
 
 describe("mounted onboarding", () => {
   it.each(CREDENTIAL_REFUSAL_CASES)(
     "keeps the athlete on coach keys and explains $reason refusals",
-    async ({ reason, copy }) => {
+    async ({ reason, fixedError, copy }) => {
       const document = new FakeDocument();
       const baseBridge = bridge(async () => ({
         status: "configured",
@@ -289,7 +390,7 @@ describe("mounted onboarding", () => {
 
       buttonWithText(document, "Continue").dispatch("click");
 
-      await vi.waitFor(() => expect(controller.state().fixedError).toBe(reason));
+      await vi.waitFor(() => expect(controller.state().fixedError).toBe(fixedError));
       expect(document.body.querySelector("#onboarding-error")?.textContent).toBe(copy);
       expect(controller.state().step).toBe("coach-keys");
       expect(passwordInput.value).toBe("");
@@ -341,7 +442,7 @@ describe("mounted onboarding", () => {
     controller.dispose();
   });
 
-  it("offers one retry for a saved key that could not be activated", async () => {
+  it("retries a saved provider choice with Continue without rewriting the key", async () => {
     const document = new FakeDocument();
     const failedStatuses = [
       { slot: "anthropic", state: "configured", runtimeState: "failed" },
@@ -354,15 +455,13 @@ describe("mounted onboarding", () => {
       runtimeReady: true,
     }));
     baseBridge.chatGptStatus.mockResolvedValue({ state: "absent", runtimeReady: false });
-    baseBridge.credentialStatuses.mockResolvedValueOnce([]).mockResolvedValueOnce(failedStatuses);
-    const retry = deferred<readonly (typeof activeStatuses)[number][]>();
-    const retryFailedCredentials = vi.fn<OnboardingBridge["retryFailedCredentials"]>(
-      () => retry.promise,
-    );
+    baseBridge.credentialStatuses
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce(failedStatuses)
+      .mockResolvedValueOnce(activeStatuses);
     let credentialWriteCount = 0;
     const onboardingBridge: OnboardingBridge = {
       ...baseBridge,
-      retryFailedCredentials,
       async writeCredential({ slot }) {
         credentialWriteCount += 1;
         return { slot, status: "refused", reason: "runtime-unavailable" };
@@ -381,62 +480,34 @@ describe("mounted onboarding", () => {
 
     buttonWithText(document, "Continue").dispatch("click");
 
-    await vi.waitFor(() => expect(controller.state().fixedError).toBe("runtime-unavailable"));
-    expect(document.body.textContent).toContain("That key was saved, but it is not active yet.");
-    expect(document.body.textContent).toContain("Choose Retry saved keys to activate it.");
-    expect(buttonWithText(document, "Retry saved keys").disabled).toBe(false);
-    expect(passwordInput.value).toBe("");
-    expect(baseBridge.credentialStatuses).toHaveBeenCalledTimes(2);
-
-    buttonWithText(document, "Continue").dispatch("click");
-
-    await vi.waitFor(() => expect(controller.state().busy).toBe(false));
-    expect(controller.state()).toMatchObject({
-      step: "coach-keys",
-      fixedError: "runtime-unavailable",
-    });
-    expect(credentialWriteCount).toBe(1);
-
-    const detachedPassword = passwordInputFor(document, "anthropic");
-    detachedPassword.value = randomUUID();
-    const retryButton = buttonWithText(document, "Retry saved keys");
-    retryButton.dispatch("click");
-    retryButton.dispatch("click");
-    buttonWithText(document, "Retry saved keys").dispatch("click");
-
-    expect(retryFailedCredentials).toHaveBeenCalledTimes(1);
-    expect(detachedPassword.value).toBe("");
-    expect(controller.state()).toMatchObject({ busy: true, fixedError: null });
-    expect(document.body.querySelector("#onboarding-error")?.textContent).toBe("");
-    expect(passwordInputFor(document, "anthropic").disabled).toBe(true);
-    expect(document.body.querySelector(".onboarding-action-status")?.textContent).toBe("Working…");
-    retry.resolve(activeStatuses);
-
-    await vi.waitFor(() => {
-      expect(baseBridge.credentialStatuses).toHaveBeenCalledTimes(2);
-      expect(controller.state()).toMatchObject({
-        step: "coach-keys",
-        busy: false,
-        fixedError: null,
-        credentialStatus: { anthropic: "configured" },
-      });
-      expect(
-        passwordInputFor(document, "anthropic").parent?.querySelector(".credential-state")
-          ?.textContent,
-      ).toBe("Configured");
-    });
+    await vi.waitFor(() => expect(controller.state().fixedError).toBe("model-runtime-unavailable"));
+    expect(document.body.textContent).toContain(
+      "Your provider choice is saved, but it is not active yet. Choose Continue to retry it.",
+    );
     expect(
       document.body
         .querySelectorAll("button")
         .some((button) => button.textContent === "Retry saved keys"),
     ).toBe(false);
+    expect(passwordInput.value).toBe("");
+    expect(baseBridge.credentialStatuses).toHaveBeenCalledTimes(2);
+
+    buttonWithText(document, "Continue").dispatch("click");
+
+    await vi.waitFor(() => expect(controller.state().step).toBe("training-data"));
+    expect(baseBridge.applyLlmSelection).toHaveBeenCalledWith({
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+      endpoint: { mode: "automatic" },
+    });
+    expect(baseBridge.credentialStatuses).toHaveBeenCalledTimes(3);
     expect(credentialWriteCount).toBe(1);
-    expect(retryFailedCredentials).toHaveBeenCalledTimes(1);
+    expect(baseBridge.retryFailedCredentials).not.toHaveBeenCalled();
     expect(onComplete).not.toHaveBeenCalled();
     controller.dispose();
   });
 
-  it("keeps activation copy and retry available when retrying fails", async () => {
+  it("keeps Continue activation recovery available when applying the provider fails", async () => {
     const document = new FakeDocument();
     const failedStatuses = [
       { slot: "anthropic", state: "configured", runtimeState: "failed" },
@@ -449,7 +520,7 @@ describe("mounted onboarding", () => {
     baseBridge.credentialStatuses.mockResolvedValueOnce([]).mockResolvedValueOnce(failedStatuses);
     const onboardingBridge: OnboardingBridge = {
       ...baseBridge,
-      async retryFailedCredentials() {
+      async applyLlmSelection() {
         throw new Error("private daemon failure");
       },
       async writeCredential({ slot }) {
@@ -465,16 +536,21 @@ describe("mounted onboarding", () => {
     await controller.open();
     passwordInputFor(document, "anthropic").value = randomUUID();
     buttonWithText(document, "Continue").dispatch("click");
-    await vi.waitFor(() => expect(controller.state().fixedError).toBe("runtime-unavailable"));
+    await vi.waitFor(() => expect(controller.state().fixedError).toBe("model-runtime-unavailable"));
 
-    buttonWithText(document, "Retry saved keys").dispatch("click");
+    buttonWithText(document, "Continue").dispatch("click");
 
     await vi.waitFor(() => expect(controller.state().busy).toBe(false));
-    expect(controller.state().fixedError).toBe("runtime-unavailable");
+    expect(controller.state().fixedError).toBe("model-runtime-unavailable");
     expect(document.body.querySelector("#onboarding-error")?.textContent).toBe(
-      "That key was saved, but it is not active yet. Choose Retry saved keys to activate it.",
+      "Your provider choice is saved, but it is not active yet. Choose Continue to retry it.",
     );
-    expect(buttonWithText(document, "Retry saved keys").disabled).toBe(false);
+    expect(
+      document.body
+        .querySelectorAll("button")
+        .some((button) => button.textContent === "Retry saved keys"),
+    ).toBe(false);
+    expect(baseBridge.retryFailedCredentials).not.toHaveBeenCalled();
     expect(document.body.textContent).not.toContain("private daemon failure");
     controller.dispose();
   });
@@ -654,72 +730,410 @@ describe("mounted onboarding", () => {
     controller.dispose();
   });
 
-  it.each([
-    { runtimeState: "active", badge: "Configured" },
-    { runtimeState: "stored-inactive", badge: "Saved · Not in use" },
-  ] as const)("treats a $runtimeState post-write refresh as recovered", async (status) => {
+  it("writes the explicitly selected provider last and attaches its model choice", async () => {
     const document = new FakeDocument();
-    const baseBridge = bridge(async () => ({
-      status: "configured",
-      runtimeReady: true,
-    }));
+    const anthropicKey = randomUUID();
+    const openRouterKey = randomUUID();
+    const baseBridge = bridge(async () => ({ status: "refused", reason: "cancelled" }));
     baseBridge.chatGptStatus.mockResolvedValue({ state: "absent", runtimeReady: false });
     baseBridge.credentialStatuses
       .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([
-        { slot: "anthropic", state: "configured", runtimeState: status.runtimeState },
-      ]);
-    let credentialWriteCount = 0;
-    const onboardingBridge: OnboardingBridge = {
-      ...baseBridge,
-      async writeCredential({ slot }) {
-        credentialWriteCount += 1;
-        return { slot, status: "refused", reason: "runtime-unavailable" };
-      },
-    };
+      .mockResolvedValueOnce([{ slot: "openrouter", state: "configured", runtimeState: "active" }]);
+    const writeCredential = vi.fn<OnboardingBridge["writeCredential"]>(
+      async ({ slot, selection }) => ({
+        slot,
+        status: "configured",
+        runtimeReady: selection !== undefined,
+      }),
+    );
     const controller = mountOnboarding({
       document: documentBoundary(document),
-      bridge: onboardingBridge,
+      bridge: { ...baseBridge, writeCredential },
       opener: elementBoundary(document.createElement("button")),
       onComplete: vi.fn(),
     });
     await controller.open();
-    passwordInputFor(document, "anthropic").value = randomUUID();
+    changeControl(document, "onboarding-llm-provider", "openrouter");
+    passwordInputFor(document, "anthropic").value = anthropicKey;
+    passwordInputFor(document, "openrouter").value = openRouterKey;
 
     buttonWithText(document, "Continue").dispatch("click");
 
     await vi.waitFor(() => expect(controller.state().step).toBe("training-data"));
-    expect(controller.state().fixedError).toBeNull();
-    expect(document.body.textContent).not.toContain(
-      "That key was saved, but it is not active yet.",
-    );
-    expect(
-      document.body
-        .querySelectorAll("button")
-        .some((button) => button.textContent === "Retry saved keys"),
-    ).toBe(false);
-    buttonWithText(document, "Back").dispatch("click");
-    expect(
-      passwordInputFor(document, "anthropic").parent?.querySelector(".credential-state")
-        ?.textContent,
-    ).toBe(status.badge);
-    expect(
-      document.body
-        .querySelectorAll("button")
-        .some((button) => button.textContent === "Retry saved keys"),
-    ).toBe(false);
-    expect(credentialWriteCount).toBe(1);
+    expect(writeCredential).toHaveBeenNthCalledWith(1, {
+      slot: "anthropic",
+      value: anthropicKey,
+    });
+    expect(writeCredential).toHaveBeenNthCalledWith(2, {
+      slot: "openrouter",
+      value: openRouterKey,
+      selection: {
+        provider: "openrouter",
+        model: "deepseek/deepseek-v4-flash",
+        endpoint: { mode: "automatic" },
+      },
+    });
+    expect(baseBridge.applyLlmSelection).not.toHaveBeenCalled();
     controller.dispose();
   });
 
-  it("keeps a later failed key retryable when an earlier key recovers", async () => {
+  it("applies a changed model for an active provider without a Desktop-owned key", async () => {
+    const document = new FakeDocument();
+    const baseBridge = bridge(async () => ({ status: "refused", reason: "cancelled" }));
+    baseBridge.chatGptStatus.mockResolvedValue({ state: "absent", runtimeReady: false });
+    baseBridge.llmConfiguration.mockResolvedValue({
+      ...TEST_LLM_CONFIGURATION,
+      active: { provider: "anthropic", model: "claude-sonnet-4-6" },
+    });
+    baseBridge.credentialStatuses.mockResolvedValue([]);
+    const controller = mountOnboarding({
+      document: documentBoundary(document),
+      bridge: baseBridge,
+      opener: elementBoundary(document.createElement("button")),
+      onComplete: vi.fn(),
+    });
+    await controller.open();
+    changeControl(document, "onboarding-llm-model", "__custom__");
+    const customModel = controlById(document, "onboarding-custom-model");
+    customModel.value = "athlete-selected-model";
+    customModel.dispatch("input");
+
+    buttonWithText(document, "Continue").dispatch("click");
+
+    await vi.waitFor(() => expect(controller.state().step).toBe("training-data"));
+    expect(baseBridge.writeCredential).not.toHaveBeenCalled();
+    expect(baseBridge.applyLlmSelection).toHaveBeenCalledWith({
+      provider: "anthropic",
+      model: "athlete-selected-model",
+      endpoint: { mode: "automatic" },
+    });
+    controller.dispose();
+  });
+
+  it("continues with an active ChatGPT profile without signing in again", async () => {
+    const document = new FakeDocument();
+    const baseBridge = bridge(async () => ({ status: "refused", reason: "cancelled" }));
+    baseBridge.llmConfiguration.mockResolvedValue({
+      ...TEST_LLM_CONFIGURATION,
+      active: { provider: "openai-codex", model: "custom-chat-model" },
+    });
+    baseBridge.chatGptStatus.mockResolvedValue({ state: "configured", runtimeReady: true });
+    const controller = mountOnboarding({
+      document: documentBoundary(document),
+      bridge: baseBridge,
+      opener: elementBoundary(document.createElement("button")),
+      onComplete: vi.fn(),
+    });
+    await controller.open();
+
+    buttonWithText(document, "Continue").dispatch("click");
+
+    await vi.waitFor(() => expect(controller.state().step).toBe("training-data"));
+    expect(baseBridge.chatGptLogin).not.toHaveBeenCalled();
+    expect(baseBridge.applyLlmSelection).toHaveBeenCalledWith({
+      provider: "openai-codex",
+      model: "custom-chat-model",
+      endpoint: { mode: "automatic" },
+    });
+    controller.dispose();
+  });
+
+  it("applies an endpoint change for an already-active provider without requiring the key again", async () => {
+    const document = new FakeDocument();
+    const baseBridge = bridge(async () => ({ status: "refused", reason: "cancelled" }));
+    baseBridge.chatGptStatus.mockResolvedValue({ state: "absent", runtimeReady: false });
+    baseBridge.llmConfiguration.mockResolvedValue({
+      ...TEST_LLM_CONFIGURATION,
+      active: { provider: "openrouter", model: "deepseek/deepseek-v4-flash" },
+    });
+    baseBridge.credentialStatuses.mockResolvedValue([
+      { slot: "openrouter", state: "configured", runtimeState: "active" },
+    ]);
+    const controller = mountOnboarding({
+      document: documentBoundary(document),
+      bridge: baseBridge,
+      opener: elementBoundary(document.createElement("button")),
+      onComplete: vi.fn(),
+    });
+    await controller.open();
+    changeControl(document, "onboarding-endpoint-mode", "custom");
+    const endpoint = controlById(document, "onboarding-custom-endpoint");
+    endpoint.value = "https://models.example.test/v1";
+    endpoint.dispatch("input");
+
+    buttonWithText(document, "Continue").dispatch("click");
+
+    await vi.waitFor(() => expect(controller.state().step).toBe("training-data"));
+    expect(baseBridge.writeCredential).not.toHaveBeenCalled();
+    expect(baseBridge.applyLlmSelection).toHaveBeenCalledWith({
+      provider: "openrouter",
+      model: "deepseek/deepseek-v4-flash",
+      endpoint: { mode: "custom", value: "https://models.example.test/v1" },
+    });
+    controller.dispose();
+  });
+
+  it("freezes provider, model, and endpoint controls while applying a selection", async () => {
+    const document = new FakeDocument();
+    const pending = deferred<{
+      readonly status: "configured";
+      readonly runtimeReady: true;
+    }>();
+    let active = false;
+    const baseBridge = bridge(async () => ({ status: "refused", reason: "cancelled" }));
+    baseBridge.chatGptStatus.mockResolvedValue({ state: "absent", runtimeReady: false });
+    baseBridge.credentialStatuses.mockImplementation(async () => [
+      {
+        slot: "openrouter",
+        state: "configured",
+        runtimeState: active ? "active" : "stored-inactive",
+      },
+    ]);
+    baseBridge.applyLlmSelection.mockImplementation(() => pending.promise);
+    const controller = mountOnboarding({
+      document: documentBoundary(document),
+      bridge: baseBridge,
+      opener: elementBoundary(document.createElement("button")),
+      onComplete: vi.fn(),
+    });
+    await controller.open();
+    changeControl(document, "onboarding-llm-provider", "openrouter");
+
+    buttonWithText(document, "Continue").dispatch("click");
+
+    await vi.waitFor(() => expect(baseBridge.applyLlmSelection).toHaveBeenCalledOnce());
+    const provider = controlById(document, "onboarding-llm-provider");
+    const model = controlById(document, "onboarding-llm-model");
+    const endpoint = controlById(document, "onboarding-endpoint-mode");
+    expect(provider.disabled).toBe(true);
+    expect(model.disabled).toBe(true);
+    expect(endpoint.disabled).toBe(true);
+
+    active = true;
+    pending.resolve({ status: "configured", runtimeReady: true });
+    await vi.waitFor(() => expect(controller.state().step).toBe("training-data"));
+    expect(baseBridge.applyLlmSelection).toHaveBeenCalledWith({
+      provider: "openrouter",
+      model: "deepseek/deepseek-v4-flash",
+      endpoint: { mode: "automatic" },
+    });
+    controller.dispose();
+  });
+
+  it("does not submit the wizard when Enter is handled by a selection control", async () => {
+    const document = new FakeDocument();
+    const baseBridge = bridge(async () => ({ status: "refused", reason: "cancelled" }));
+    const controller = mountOnboarding({
+      document: documentBoundary(document),
+      bridge: baseBridge,
+      opener: elementBoundary(document.createElement("button")),
+      onComplete: vi.fn(),
+    });
+    await controller.open();
+    const provider = controlById(document, "onboarding-llm-provider");
+    const dialog = document.body.querySelector(".onboarding");
+    if (dialog === null) throw new Error("Dialog not found");
+    const preventDefault = vi.fn();
+
+    dialog.dispatch("keydown", { key: "Enter", target: provider, preventDefault });
+
+    expect(preventDefault).not.toHaveBeenCalled();
+    expect(baseBridge.applyLlmSelection).not.toHaveBeenCalled();
+    expect(controller.state().busy).toBe(false);
+    controller.dispose();
+  });
+
+  it("retains a custom model and endpoint through provider switches and activation retry", async () => {
+    const document = new FakeDocument();
+    const secret = randomUUID();
+    const selection = {
+      provider: "openrouter" as const,
+      model: "vendor/private-model",
+      endpoint: { mode: "custom" as const, value: "https://models.example.test/v1" },
+    };
+    const baseBridge = bridge(async () => ({ status: "refused", reason: "cancelled" }));
+    baseBridge.chatGptStatus.mockResolvedValue({ state: "absent", runtimeReady: false });
+    baseBridge.credentialStatuses
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ slot: "openrouter", state: "configured", runtimeState: "failed" }])
+      .mockResolvedValueOnce([{ slot: "openrouter", state: "configured", runtimeState: "active" }]);
+    const writeCredential = vi.fn<OnboardingBridge["writeCredential"]>(async ({ slot }) => ({
+      slot,
+      status: "refused",
+      reason: "runtime-unavailable",
+    }));
+    const controller = mountOnboarding({
+      document: documentBoundary(document),
+      bridge: { ...baseBridge, writeCredential },
+      opener: elementBoundary(document.createElement("button")),
+      onComplete: vi.fn(),
+    });
+    await controller.open();
+    changeControl(document, "onboarding-llm-provider", "openrouter");
+    changeControl(document, "onboarding-llm-model", "__custom__");
+    const customModel = controlById(document, "onboarding-custom-model");
+    customModel.value = selection.model;
+    customModel.dispatch("input");
+    changeControl(document, "onboarding-endpoint-mode", "custom");
+    const customEndpoint = controlById(document, "onboarding-custom-endpoint");
+    customEndpoint.value = selection.endpoint.value;
+    customEndpoint.dispatch("input");
+
+    changeControl(document, "onboarding-llm-provider", "anthropic");
+    changeControl(document, "onboarding-llm-provider", "openrouter");
+
+    expect(controlById(document, "onboarding-llm-model").value).toBe("__custom__");
+    expect(controlById(document, "onboarding-custom-model").value).toBe(selection.model);
+    expect(controlById(document, "onboarding-endpoint-mode").value).toBe("custom");
+    expect(controlById(document, "onboarding-custom-endpoint").value).toBe(
+      selection.endpoint.value,
+    );
+    passwordInputFor(document, "openrouter").value = secret;
+
+    buttonWithText(document, "Continue").dispatch("click");
+
+    await vi.waitFor(() => expect(controller.state().fixedError).toBe("model-runtime-unavailable"));
+    expect(writeCredential).toHaveBeenCalledWith({
+      slot: "openrouter",
+      value: secret,
+      selection,
+    });
+    expect(passwordInputFor(document, "openrouter").value).toBe("");
+    expect(controlById(document, "onboarding-custom-model").value).toBe(selection.model);
+    expect(controlById(document, "onboarding-custom-endpoint").value).toBe(
+      selection.endpoint.value,
+    );
+
+    buttonWithText(document, "Continue").dispatch("click");
+
+    await vi.waitFor(() => expect(controller.state().step).toBe("training-data"));
+    expect(baseBridge.applyLlmSelection).toHaveBeenCalledWith(selection);
+    expect(writeCredential).toHaveBeenCalledTimes(1);
+    controller.dispose();
+  });
+
+  it("blocks a non-loopback HTTP endpoint before invoking credential or runtime IPC", async () => {
+    const document = new FakeDocument();
+    const baseBridge = bridge(async () => ({ status: "refused", reason: "cancelled" }));
+    const controller = mountOnboarding({
+      document: documentBoundary(document),
+      bridge: baseBridge,
+      opener: elementBoundary(document.createElement("button")),
+      onComplete: vi.fn(),
+    });
+    await controller.open();
+    changeControl(document, "onboarding-llm-provider", "openrouter");
+    changeControl(document, "onboarding-endpoint-mode", "custom");
+    const endpoint = controlById(document, "onboarding-custom-endpoint");
+    endpoint.value = "http://models.example.test/v1";
+    endpoint.dispatch("input");
+    passwordInputFor(document, "openrouter").value = randomUUID();
+
+    buttonWithText(document, "Continue").dispatch("click");
+
+    await vi.waitFor(() => expect(controller.state().fixedError).toBe("endpoint-invalid"));
+    expect(baseBridge.writeCredential).not.toHaveBeenCalled();
+    expect(baseBridge.applyLlmSelection).not.toHaveBeenCalled();
+    controller.dispose();
+  });
+
+  it("passes the selected model to ChatGPT sign-in", async () => {
+    const document = new FakeDocument();
+    const chatGptLogin = bridge(async () => ({ status: "refused", reason: "cancelled" }));
+    const controller = mountOnboarding({
+      document: documentBoundary(document),
+      bridge: chatGptLogin,
+      opener: elementBoundary(document.createElement("button")),
+      onComplete: vi.fn(),
+    });
+    await controller.open();
+    changeControl(document, "onboarding-llm-provider", "openai-codex");
+    changeControl(document, "onboarding-llm-model", "__custom__");
+    const customModel = controlById(document, "onboarding-custom-model");
+    customModel.value = "gpt-5.5-codex-max";
+    customModel.dispatch("input");
+
+    buttonWithText(document, "Sign in again").dispatch("click");
+
+    await vi.waitFor(() => expect(chatGptLogin.chatGptLogin).toHaveBeenCalledOnce());
+    expect(chatGptLogin.chatGptLogin).toHaveBeenCalledWith({
+      provider: "openai-codex",
+      model: "gpt-5.5-codex-max",
+      endpoint: { mode: "automatic" },
+    });
+    controller.dispose();
+  });
+
+  it.each([{ runtimeState: "active" }, { runtimeState: "stored-inactive" }] as const)(
+    "recovers a selected provider from $runtimeState only after it is active",
+    async (status) => {
+      const document = new FakeDocument();
+      const baseBridge = bridge(async () => ({
+        status: "configured",
+        runtimeReady: true,
+      }));
+      baseBridge.chatGptStatus.mockResolvedValue({ state: "absent", runtimeReady: false });
+      baseBridge.credentialStatuses
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([
+          { slot: "anthropic", state: "configured", runtimeState: status.runtimeState },
+        ])
+        .mockResolvedValueOnce([
+          { slot: "anthropic", state: "configured", runtimeState: "active" },
+        ]);
+      let credentialWriteCount = 0;
+      const onboardingBridge: OnboardingBridge = {
+        ...baseBridge,
+        async writeCredential({ slot }) {
+          credentialWriteCount += 1;
+          return { slot, status: "refused", reason: "runtime-unavailable" };
+        },
+      };
+      const controller = mountOnboarding({
+        document: documentBoundary(document),
+        bridge: onboardingBridge,
+        opener: elementBoundary(document.createElement("button")),
+        onComplete: vi.fn(),
+      });
+      await controller.open();
+      passwordInputFor(document, "anthropic").value = randomUUID();
+
+      buttonWithText(document, "Continue").dispatch("click");
+
+      await vi.waitFor(() => expect(controller.state().step).toBe("training-data"));
+      expect(controller.state().fixedError).toBeNull();
+      expect(document.body.textContent).not.toContain(
+        "That key was saved, but it is not active yet.",
+      );
+      expect(
+        document.body
+          .querySelectorAll("button")
+          .some((button) => button.textContent === "Retry saved keys"),
+      ).toBe(false);
+      buttonWithText(document, "Back").dispatch("click");
+      expect(
+        passwordInputFor(document, "anthropic").parent?.querySelector(".credential-state")
+          ?.textContent,
+      ).toBe("Configured");
+      expect(
+        document.body
+          .querySelectorAll("button")
+          .some((button) => button.textContent === "Retry saved keys"),
+      ).toBe(false);
+      expect(baseBridge.applyLlmSelection).toHaveBeenCalledOnce();
+      expect(credentialWriteCount).toBe(1);
+      controller.dispose();
+    },
+  );
+
+  it("uses Continue instead of credential retry when an unrelated saved key failed", async () => {
     const document = new FakeDocument();
     const baseBridge = bridge(async () => ({
       status: "configured",
       runtimeReady: true,
     }));
     baseBridge.chatGptStatus.mockResolvedValue({ state: "absent", runtimeReady: false });
-    baseBridge.credentialStatuses.mockResolvedValueOnce([]).mockResolvedValueOnce([
+    baseBridge.credentialStatuses.mockResolvedValueOnce([]).mockResolvedValue([
       { slot: "anthropic", state: "configured", runtimeState: "active" },
       { slot: "openrouter", state: "configured", runtimeState: "failed" },
     ]);
@@ -743,13 +1157,17 @@ describe("mounted onboarding", () => {
 
     buttonWithText(document, "Continue").dispatch("click");
 
-    await vi.waitFor(() => expect(controller.state().fixedError).toBe("runtime-unavailable"));
+    await vi.waitFor(() => expect(controller.state().fixedError).toBe("model-runtime-unavailable"));
     expect(controller.state().step).toBe("coach-keys");
     expect(
       document.body
         .querySelectorAll("button")
         .filter((button) => button.textContent === "Retry saved keys"),
-    ).toHaveLength(1);
+    ).toHaveLength(0);
+
+    buttonWithText(document, "Continue").dispatch("click");
+
+    await vi.waitFor(() => expect(controller.state().step).toBe("training-data"));
     expect(credentialWriteCount).toBe(2);
     controller.dispose();
   });
@@ -941,6 +1359,7 @@ describe("mounted onboarding", () => {
       onComplete: vi.fn(),
     });
     await controller.open();
+    changeControl(document, "onboarding-llm-provider", "anthropic");
     passwordInputFor(document, "anthropic").value = randomUUID();
 
     buttonWithText(document, "Continue").dispatch("click");

--- a/apps/desktop-renderer/tests/onboarding-provider-status.test.ts
+++ b/apps/desktop-renderer/tests/onboarding-provider-status.test.ts
@@ -65,8 +65,13 @@ class FakeElement {
     this.listeners.set(name, listeners);
   }
 
+  dispatch(name: string): void {
+    if (name === "click" && this.disabled) return;
+    for (const listener of this.listeners.get(name) ?? []) listener();
+  }
+
   click(): void {
-    for (const listener of this.listeners.get("click") ?? []) listener();
+    this.dispatch("click");
   }
 
   focus(): void {
@@ -130,6 +135,13 @@ function findByText(root: FakeElement, tagName: string, text: string): FakeEleme
   return node;
 }
 
+function selectProvider(root: FakeElement, provider: string): void {
+  const select = root.querySelector("#onboarding-llm-provider");
+  if (select === null) throw new Error("Provider select not found");
+  select.value = provider;
+  select.dispatch("change");
+}
+
 function providerLaneBadges(root: FakeElement): FakeElement[] {
   return descendants(root).filter(
     (node) =>
@@ -154,6 +166,23 @@ function createBridge(overrides: Partial<OnboardingBridge>): OnboardingBridge {
     credentialStatuses: vi.fn(async () => []),
     retryFailedCredentials: vi.fn(async () => []),
     writeCredential: vi.fn(),
+    llmConfiguration: vi.fn(async () => ({
+      schemaVersion: 1,
+      providers: [
+        {
+          provider: "anthropic",
+          defaultModel: "claude-sonnet-4-6",
+          models: [{ value: "claude-sonnet-4-6", label: "Claude Sonnet 4.6" }],
+        },
+        {
+          provider: "openai-codex",
+          defaultModel: "gpt-5.5",
+          models: [{ value: "gpt-5.5", label: "GPT-5.5" }],
+        },
+      ],
+      active: null,
+    })),
+    applyLlmSelection: vi.fn(async () => ({ status: "configured", runtimeReady: true })),
     chatGptStatus: vi.fn(async () => ({ state: "absent", runtimeReady: false })),
     chatGptLogin: vi.fn(async () => ({ status: "refused", reason: "cancelled" })),
     chooseImportFiles: vi.fn(async () => []),
@@ -240,6 +269,7 @@ describe("onboarding provider status", () => {
       onComplete: vi.fn(),
     });
     await controller.open();
+    selectProvider(document.body, "anthropic");
     const input = descendants(document.body).find((node) => node.dataset.slot === "anthropic");
     if (input === undefined) throw new Error("Element not found");
     input.value = randomUUID();
@@ -256,7 +286,7 @@ describe("onboarding provider status", () => {
     controller.dispose();
   });
 
-  it("shows only the API-key provider as active after retry succeeds", async () => {
+  it("shows only the selected API-key provider as active after Continue succeeds", async () => {
     const document = new FakeDocument();
     let selectedProvider: "anthropic" | "chatgpt" = "chatgpt";
     const credentialStatuses = vi.fn(async () => [
@@ -270,23 +300,27 @@ describe("onboarding provider status", () => {
       state: "configured" as const,
       runtimeReady: selectedProvider === "chatgpt",
     }));
-    const retryFailedCredentials = vi.fn(async () => {
+    const applyLlmSelection = vi.fn(async () => {
       selectedProvider = "anthropic";
-      return credentialStatuses();
+      return { status: "configured" as const, runtimeReady: true as const };
     });
     const controller = mountOnboarding({
       document: document as never,
-      bridge: createBridge({ credentialStatuses, chatGptStatus, retryFailedCredentials }),
+      bridge: createBridge({ credentialStatuses, chatGptStatus, applyLlmSelection }),
       opener: new FakeElement("button", document) as never,
       onComplete: vi.fn(),
     });
     await controller.open();
+    selectProvider(document.body, "anthropic");
 
-    findByText(document.body, "button", "Retry saved keys").click();
+    findByText(document.body, "button", "Continue").click();
 
     await vi.waitFor(() => {
-      expect(retryFailedCredentials).toHaveBeenCalledOnce();
+      expect(applyLlmSelection).toHaveBeenCalledOnce();
       expect(chatGptStatus).toHaveBeenCalledTimes(2);
+    });
+    findByText(document.body, "button", "Back").click();
+    await vi.waitFor(() => {
       expectOneActiveProvider(document.body);
     });
     expect(activeProviderLanes(document.body)[0]?.textContent).toBe("Configured");
@@ -297,36 +331,45 @@ describe("onboarding provider status", () => {
     controller.dispose();
   });
 
-  it("fails ChatGPT activity closed when its post-retry status is unavailable", async () => {
+  it("fails ChatGPT activity closed when its post-selection status is unavailable", async () => {
     const document = new FakeDocument();
-    const failedStatuses = [
-      { slot: "anthropic" as const, state: "configured" as const, runtimeState: "failed" as const },
-    ];
-    const activeStatuses = [
-      { slot: "anthropic" as const, state: "configured" as const, runtimeState: "active" as const },
-    ];
+    let selectedProvider: "anthropic" | "chatgpt" = "chatgpt";
     const chatGptStatus = vi
       .fn<OnboardingBridge["chatGptStatus"]>()
       .mockResolvedValueOnce({ state: "configured", runtimeReady: true })
       .mockRejectedValueOnce(new Error("private status failure"));
-    const retryFailedCredentials = vi.fn(async () => activeStatuses);
+    const credentialStatuses = vi.fn(async () => [
+      {
+        slot: "anthropic" as const,
+        state: "configured" as const,
+        runtimeState: selectedProvider === "anthropic" ? ("active" as const) : ("failed" as const),
+      },
+    ]);
+    const applyLlmSelection = vi.fn(async () => {
+      selectedProvider = "anthropic";
+      return { status: "configured" as const, runtimeReady: true as const };
+    });
     const controller = mountOnboarding({
       document: document as never,
       bridge: createBridge({
-        credentialStatuses: vi.fn(async () => failedStatuses),
+        credentialStatuses,
         chatGptStatus,
-        retryFailedCredentials,
+        applyLlmSelection,
       }),
       opener: new FakeElement("button", document) as never,
       onComplete: vi.fn(),
     });
     await controller.open();
+    selectProvider(document.body, "anthropic");
 
-    findByText(document.body, "button", "Retry saved keys").click();
+    findByText(document.body, "button", "Continue").click();
 
     await vi.waitFor(() => {
-      expect(retryFailedCredentials).toHaveBeenCalledOnce();
+      expect(applyLlmSelection).toHaveBeenCalledOnce();
       expect(chatGptStatus).toHaveBeenCalledTimes(2);
+    });
+    findByText(document.body, "button", "Back").click();
+    await vi.waitFor(() => {
       expectOneActiveProvider(document.body);
     });
     expect(activeProviderLanes(document.body)[0]?.textContent).toBe("Configured");

--- a/apps/desktop-renderer/tests/onboarding-wizard.test.ts
+++ b/apps/desktop-renderer/tests/onboarding-wizard.test.ts
@@ -152,14 +152,20 @@ describe("desktop onboarding wizard", () => {
     } as unknown as DesktopOnboardingAuth;
     const connect = vi.fn();
     const bridge = createOnboardingBridge(auth, connect);
+    const selection = {
+      provider: "openai-codex" as const,
+      model: "gpt-5.5",
+      endpoint: { mode: "automatic" as const },
+    };
     await expect(bridge.chatGptStatus()).resolves.toEqual({
       state: "configured",
       runtimeReady: false,
     });
-    await expect(bridge.chatGptLogin()).resolves.toEqual({
+    await expect(bridge.chatGptLogin(selection)).resolves.toEqual({
       status: "configured",
       runtimeReady: true,
     });
+    expect(auth.chatgptLogin).toHaveBeenCalledWith(selection);
     await expect(bridge.retryFailedCredentials()).resolves.toEqual([
       { slot: "anthropic", state: "configured", runtimeState: "active" },
     ]);

--- a/apps/desktop/scripts/electron-smoke.mjs
+++ b/apps/desktop/scripts/electron-smoke.mjs
@@ -273,6 +273,7 @@ async function security() {
         preloadBridge:
           JSON.stringify(ready.bridgeKeys) ===
           JSON.stringify([
+            "applyLlmSelection",
             "chatgptLogin",
             "chatgptStatus",
             "checkForUpdates",
@@ -280,6 +281,7 @@ async function security() {
             "credentialStatuses",
             "getDaemonConnection",
             "getUpdateState",
+            "llmConfiguration",
             "onDroppedImportFiles",
             "onUpdateState",
             "releaseNotes",

--- a/apps/desktop/src/main/chatgpt-auth.ts
+++ b/apps/desktop/src/main/chatgpt-auth.ts
@@ -7,6 +7,12 @@ import {
   type CodexLoginOptions,
 } from "@enduragent/core";
 import type { ConfigureRuntimeRpcParams, RuntimeConfigSnapshot } from "@enduragent/coach-contract";
+import {
+  parseChatGptLlmSelection,
+  runtimeConfigurationForSelection,
+  type OnboardingLlmSelection,
+  type OnboardingLlmSelectionResult,
+} from "./llm-selection.js";
 
 export const CHATGPT_PROFILE_NAME = "openai-codex" as const;
 export const CHATGPT_LOGIN_TIMEOUT_MS = 5 * 60 * 1000;
@@ -31,7 +37,8 @@ export type ChatGptLoginResult =
 
 export interface ChatGptAuthController {
   status(): Promise<ChatGptStatus>;
-  login(): Promise<ChatGptLoginResult>;
+  login(selection: OnboardingLlmSelection): Promise<ChatGptLoginResult>;
+  activate(selection: OnboardingLlmSelection): Promise<OnboardingLlmSelectionResult>;
 }
 
 interface ChatGptAuthDependencies {
@@ -129,7 +136,29 @@ export function createChatGptAuth(options: CreateChatGptAuthOptions): ChatGptAut
   const storeProfile = options.dependencies?.writeProfile ?? writeChatGptProfile;
   let activeLogin: Promise<ChatGptLoginResult> | undefined;
 
-  const performLogin = async (): Promise<ChatGptLoginResult> => {
+  const applySelection = async (
+    selection: OnboardingLlmSelection,
+  ): Promise<OnboardingLlmSelectionResult> => {
+    let parsed: ReturnType<typeof parseChatGptLlmSelection>;
+    try {
+      parsed = parseChatGptLlmSelection(selection);
+    } catch {
+      return { status: "refused", reason: "invalid-input" };
+    }
+    if (!(await hasChatGptProfile(options.configDir))) {
+      return { status: "refused", reason: "credential-required" };
+    }
+    try {
+      await options.applyRuntimeConfig(runtimeConfigurationForSelection(parsed));
+    } catch {
+      return { status: "refused", reason: "runtime-unavailable" };
+    }
+    return { status: "configured", runtimeReady: true };
+  };
+
+  const performLogin = async (
+    selection: ReturnType<typeof parseChatGptLlmSelection>,
+  ): Promise<ChatGptLoginResult> => {
     const timeoutSignal = AbortSignal.timeout(options.timeoutMs ?? CHATGPT_LOGIN_TIMEOUT_MS);
     const browserController = new AbortController();
     const signals = [timeoutSignal, browserController.signal];
@@ -162,9 +191,7 @@ export function createChatGptAuth(options: CreateChatGptAuthOptions): ChatGptAut
       return { status: "refused", reason: "storage-failed" };
     }
     try {
-      await options.applyRuntimeConfig({
-        llm: { provider: CHATGPT_PROFILE_NAME },
-      });
+      await options.applyRuntimeConfig(runtimeConfigurationForSelection(selection));
     } catch {
       return { status: "refused", reason: "runtime-unavailable" };
     }
@@ -180,11 +207,12 @@ export function createChatGptAuth(options: CreateChatGptAuthOptions): ChatGptAut
         runtimeReady: runtimeReady ?? false,
       };
     },
-    async login() {
+    async login(input) {
+      const selection = parseChatGptLlmSelection(input);
       if (activeLogin !== undefined) {
         return { status: "refused", reason: "already-in-progress" };
       }
-      const pending = performLogin();
+      const pending = performLogin(selection);
       activeLogin = pending;
       try {
         return await pending;
@@ -192,5 +220,6 @@ export function createChatGptAuth(options: CreateChatGptAuthOptions): ChatGptAut
         if (activeLogin === pending) activeLogin = undefined;
       }
     },
+    activate: applySelection,
   };
 }

--- a/apps/desktop/src/main/credential-runtime.ts
+++ b/apps/desktop/src/main/credential-runtime.ts
@@ -15,6 +15,10 @@ export interface LlmProviderSelectionEvidence {
 
 export interface CredentialRuntimeApplication {
   applyExplicit(request: ConfigureRuntimeRpcParams): Promise<void>;
+  applyExistingLlmSelection(
+    provider: LlmProvider,
+    request: ConfigureRuntimeRpcParams,
+  ): Promise<boolean>;
   reapplyStoredCredential(
     slot: DesktopCredentialSlot,
     value: string,
@@ -95,6 +99,15 @@ export function createCredentialRuntimeApplication(
   return {
     applyExplicit(request) {
       return serialize(() => options.configureRuntime(request));
+    },
+    applyExistingLlmSelection(provider, request) {
+      return serialize(async () => {
+        if (request.llm === undefined || request.llm.provider !== undefined) throw new TypeError();
+        const selectedProvider = await options.selectedLlmProvider([]);
+        if (selectedProvider !== provider) return false;
+        await options.configureRuntime(request);
+        return true;
+      });
     },
     reapplyStoredCredential(slot, value, storedCredentialSlots) {
       return serialize(async () => {

--- a/apps/desktop/src/main/credential-vault.ts
+++ b/apps/desktop/src/main/credential-vault.ts
@@ -1,6 +1,11 @@
 import { randomUUID } from "node:crypto";
 import { lstat, mkdir, open, readFile, rename, rm } from "node:fs/promises";
 import { join } from "node:path";
+import {
+  parseOnboardingLlmSelection,
+  type OnboardingLlmSelection,
+  type OnboardingLlmSelectionResult,
+} from "./llm-selection.js";
 
 export const DESKTOP_CREDENTIAL_SLOTS = [
   "anthropic",
@@ -30,7 +35,7 @@ export type CredentialWriteResult =
   | {
       readonly slot: DesktopCredentialSlot;
       readonly status: "configured";
-      readonly runtimeReady: true;
+      readonly runtimeReady: boolean;
     }
   | {
       readonly slot: DesktopCredentialSlot;
@@ -56,10 +61,17 @@ export interface CredentialEncryptionPort {
 }
 
 export interface CredentialVault {
-  writeCredential(input: {
-    readonly slot: DesktopCredentialSlot;
-    readonly value: string;
-  }): Promise<CredentialWriteResult>;
+  writeCredential(
+    input: {
+      readonly slot: DesktopCredentialSlot;
+      readonly value: string;
+      readonly selection?: OnboardingLlmSelection;
+    },
+    behavior?: {
+      readonly activate?: boolean;
+    },
+  ): Promise<CredentialWriteResult>;
+  applyLlmSelection(input: OnboardingLlmSelection): Promise<OnboardingLlmSelectionResult>;
   credentialStatuses(): Promise<readonly CredentialSlotStatus[]>;
   reapplyConfigured(): Promise<void>;
   retryFailed(): Promise<void>;
@@ -71,7 +83,11 @@ interface CredentialVaultOptions {
   readonly runtimeState?: CredentialRuntimeStateMap;
   readonly onRuntimeStateChange?: (slot: DesktopCredentialSlot) => void;
   readonly createRuntimePublicationGuard?: (slot: DesktopCredentialSlot) => () => boolean;
-  readonly applyCredential: (slot: DesktopCredentialSlot, value: string) => Promise<void>;
+  readonly applyCredential: (
+    slot: DesktopCredentialSlot,
+    value: string,
+    selection?: OnboardingLlmSelection,
+  ) => Promise<void>;
   readonly reapplyCredential?: (
     slot: DesktopCredentialSlot,
     value: string,
@@ -256,13 +272,24 @@ export function createCredentialVault(options: CredentialVaultOptions): Credenti
   };
 
   return {
-    async writeCredential(input): Promise<CredentialWriteResult> {
+    async writeCredential(input, behavior): Promise<CredentialWriteResult> {
       if (!isCredentialSlot(input?.slot) || typeof input.value !== "string") {
         return {
           slot: isCredentialSlot(input?.slot) ? input.slot : "anthropic",
           status: "refused",
           reason: "invalid-input",
         };
+      }
+      let selection: OnboardingLlmSelection | undefined;
+      try {
+        if (input.selection !== undefined) {
+          selection = parseOnboardingLlmSelection(input.selection);
+          if (input.slot === "intervals-icu" || selection.provider !== input.slot) {
+            throw new TypeError();
+          }
+        }
+      } catch {
+        return { slot: input.slot, status: "refused", reason: "invalid-input" };
       }
       const value = input.value.trim();
       if (value.length === 0) {
@@ -314,15 +341,49 @@ export function createCredentialVault(options: CredentialVaultOptions): Credenti
       } finally {
         encrypted?.fill(0);
       }
+      if (behavior?.activate === false) {
+        setRuntimeState(input.slot, "stored-inactive");
+        return { slot: input.slot, status: "configured", runtimeReady: false };
+      }
       try {
         const canPublish = options.createRuntimePublicationGuard?.(input.slot);
-        await options.applyCredential(input.slot, value);
+        if (selection === undefined) {
+          await options.applyCredential(input.slot, value);
+        } else {
+          await options.applyCredential(input.slot, value, selection);
+        }
         if (canPublish !== undefined && !canPublish()) throw new TypeError();
         setRuntimeState(input.slot, "active");
         return { slot: input.slot, status: "configured", runtimeReady: true };
       } catch {
         setRuntimeState(input.slot, "failed");
         return { slot: input.slot, status: "refused", reason: "runtime-unavailable" };
+      }
+    },
+
+    async applyLlmSelection(input): Promise<OnboardingLlmSelectionResult> {
+      let selection: OnboardingLlmSelection;
+      let slot: DesktopCredentialSlot;
+      try {
+        selection = parseOnboardingLlmSelection(input);
+        if (selection.provider === "openai-codex") throw new TypeError();
+        slot = selection.provider;
+      } catch {
+        return { status: "refused", reason: "invalid-input" };
+      }
+      const credential = await readSlot(slot);
+      if (credential.state !== "configured" || credential.value === undefined) {
+        return { status: "refused", reason: "credential-required" };
+      }
+      try {
+        const canPublish = options.createRuntimePublicationGuard?.(slot);
+        await options.applyCredential(slot, credential.value, selection);
+        if (canPublish !== undefined && !canPublish()) throw new TypeError();
+        setRuntimeState(slot, "active");
+        return { status: "configured", runtimeReady: true };
+      } catch {
+        setRuntimeState(slot, "failed");
+        return { status: "refused", reason: "runtime-unavailable" };
       }
     },
 

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -46,6 +46,10 @@ import {
   startupRefusalCopy,
   unexpectedStartupCopy,
 } from "./lifecycle-messages.js";
+import {
+  runtimeConfigurationForExistingSelection,
+  type OnboardingLlmSelection,
+} from "./llm-selection.js";
 import { registerOnboardingIpc, runtimeConfigurationForCredential } from "./onboarding-ipc.js";
 import { installDesktopReleaseNotesIpc } from "./release-notes-ipc.js";
 import { createDesktopResidency, type DesktopResidency } from "./residency.js";
@@ -309,6 +313,21 @@ async function runDesktop(): Promise<void> {
       url: resolution.url,
       token: resolution.token,
     });
+    const readActiveRuntimeConfig = async () => {
+      const binding = activeRuntimeBinding;
+      const lifecycleState = daemonLifecycle?.snapshot();
+      if (binding === undefined || lifecycleState?.status !== "ready") throw new TypeError();
+      const snapshot = await binding.authority.getRuntimeConfig();
+      const currentLifecycleState = daemonLifecycle?.snapshot();
+      if (
+        activeRuntimeBinding !== binding ||
+        currentLifecycleState?.status !== "ready" ||
+        currentLifecycleState.generation !== lifecycleState.generation
+      ) {
+        throw new TypeError();
+      }
+      return snapshot;
+    };
     const credentialRoot = join(app.getPath("userData"), CREDENTIAL_DIRECTORY_NAME);
     const vault = createCredentialVault({
       root: credentialRoot,
@@ -330,24 +349,38 @@ async function runDesktop(): Promise<void> {
           return canPublish;
         };
       },
-      async applyCredential(slot, value) {
+      async applyCredential(slot, value, selection) {
         const binding = activeRuntimeBinding!;
-        if (daemonLifecycle?.snapshot().status !== "ready") throw new TypeError();
-        await binding.credentials.applyExplicit(runtimeConfigurationForCredential(slot, value));
-        if (activeRuntimeBinding !== binding || daemonLifecycle?.snapshot().status !== "ready") {
+        const lifecycleState = daemonLifecycle?.snapshot();
+        if (lifecycleState?.status !== "ready") throw new TypeError();
+        await binding.credentials.applyExplicit(
+          runtimeConfigurationForCredential(slot, value, selection),
+        );
+        const currentLifecycleState = daemonLifecycle?.snapshot();
+        if (
+          activeRuntimeBinding !== binding ||
+          currentLifecycleState?.status !== "ready" ||
+          currentLifecycleState.generation !== lifecycleState.generation
+        ) {
           if (slot !== "intervals-icu") failModelCredentialRuntimeStates();
           throw new TypeError();
         }
       },
       async reapplyCredential(slot, value, storedCredentialSlots) {
         const binding = activeRuntimeBinding!;
-        if (daemonLifecycle?.snapshot().status !== "ready") throw new TypeError();
+        const lifecycleState = daemonLifecycle?.snapshot();
+        if (lifecycleState?.status !== "ready") throw new TypeError();
         const status = await binding.credentials.reapplyStoredCredential(
           slot,
           value,
           storedCredentialSlots,
         );
-        if (activeRuntimeBinding !== binding || daemonLifecycle?.snapshot().status !== "ready") {
+        const currentLifecycleState = daemonLifecycle?.snapshot();
+        if (
+          activeRuntimeBinding !== binding ||
+          currentLifecycleState?.status !== "ready" ||
+          currentLifecycleState.generation !== lifecycleState.generation
+        ) {
           if (slot !== "intervals-icu") failModelCredentialRuntimeStates();
           throw new TypeError();
         }
@@ -386,9 +419,15 @@ async function runDesktop(): Promise<void> {
       configDir,
       async applyRuntimeConfig(request) {
         const binding = activeRuntimeBinding!;
-        if (daemonLifecycle?.snapshot().status !== "ready") throw new TypeError();
+        const lifecycleState = daemonLifecycle?.snapshot();
+        if (lifecycleState?.status !== "ready") throw new TypeError();
         await binding.credentials.applyExplicit(request);
-        if (activeRuntimeBinding !== binding || daemonLifecycle?.snapshot().status !== "ready") {
+        const currentLifecycleState = daemonLifecycle?.snapshot();
+        if (
+          activeRuntimeBinding !== binding ||
+          currentLifecycleState?.status !== "ready" ||
+          currentLifecycleState.generation !== lifecycleState.generation
+        ) {
           failModelCredentialRuntimeStates();
           throw new TypeError();
         }
@@ -398,7 +437,7 @@ async function runDesktop(): Promise<void> {
           markCredentialRuntimeChange,
         );
       },
-      getRuntimeConfig: () => activeRuntimeBinding!.authority.getRuntimeConfig(),
+      getRuntimeConfig: readActiveRuntimeConfig,
       openExternal: (url) => shell.openExternal(url),
       signal: controller.signal,
     });
@@ -434,6 +473,27 @@ async function runDesktop(): Promise<void> {
             window: created,
             vault,
             chatGptAuth,
+            getRuntimeConfig: readActiveRuntimeConfig,
+            applyExistingLlmSelection: async (selection: OnboardingLlmSelection) => {
+              const binding = activeRuntimeBinding;
+              const lifecycleState = daemonLifecycle?.snapshot();
+              if (binding === undefined || lifecycleState?.status !== "ready") {
+                throw new TypeError();
+              }
+              const applied = await binding.credentials.applyExistingLlmSelection(
+                selection.provider,
+                runtimeConfigurationForExistingSelection(selection),
+              );
+              const currentLifecycleState = daemonLifecycle?.snapshot();
+              if (
+                activeRuntimeBinding !== binding ||
+                currentLifecycleState?.status !== "ready" ||
+                currentLifecycleState.generation !== lifecycleState.generation
+              ) {
+                throw new TypeError();
+              }
+              return applied;
+            },
             checkIntervalsCredentialOwner: async (value) => {
               const snapshot = await activeRuntimeBinding!.authority.getRuntimeConfig();
               return checkIntervalsStoreOwnerAtPath(

--- a/apps/desktop/src/main/llm-selection.ts
+++ b/apps/desktop/src/main/llm-selection.ts
@@ -1,0 +1,202 @@
+import { LLM_MODEL_CATALOGUE, LLM_PROVIDERS, type LlmProvider } from "@enduragent/core";
+import type { ConfigureRuntimeRpcParams } from "@enduragent/coach-contract";
+
+export interface OnboardingLlmModelOption {
+  readonly value: string;
+  readonly label: string;
+  readonly hint?: string;
+}
+
+export interface OnboardingLlmProviderConfiguration {
+  readonly provider: LlmProvider;
+  readonly defaultModel: string;
+  readonly models: readonly OnboardingLlmModelOption[];
+  readonly defaultBaseUrl?: string;
+}
+
+export interface OnboardingLlmConfiguration {
+  readonly schemaVersion: 1;
+  readonly providers: readonly OnboardingLlmProviderConfiguration[];
+  readonly active: {
+    readonly provider: LlmProvider;
+    readonly model: string;
+  } | null;
+}
+
+export type OnboardingLlmEndpointSelection =
+  | { readonly mode: "automatic" }
+  | { readonly mode: "default" }
+  | { readonly mode: "custom"; readonly value: string };
+
+export interface OnboardingLlmSelection {
+  readonly provider: LlmProvider;
+  readonly model: string;
+  readonly endpoint: OnboardingLlmEndpointSelection;
+}
+
+export type OnboardingLlmSelectionResult =
+  | { readonly status: "configured"; readonly runtimeReady: true }
+  | {
+      readonly status: "refused";
+      readonly reason: "invalid-input" | "credential-required" | "runtime-unavailable";
+    };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function hasExactKeys(value: Record<string, unknown>, keys: readonly string[]): boolean {
+  return (
+    value !== null && JSON.stringify(Object.keys(value).sort()) === JSON.stringify([...keys].sort())
+  );
+}
+
+function normalizedText(value: unknown, maximumLength: number): string {
+  if (typeof value !== "string" || value.length === 0 || value.length > maximumLength) {
+    throw new TypeError();
+  }
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code <= 0x1f || code === 0x7f) throw new TypeError();
+  }
+  const normalized = value.trim();
+  if (normalized.length === 0 || normalized.length > maximumLength) throw new TypeError();
+  return normalized;
+}
+
+function isLoopbackHost(hostname: string): boolean {
+  const normalized = hostname.toLowerCase();
+  if (normalized === "localhost" || normalized.endsWith(".localhost") || normalized === "[::1]") {
+    return true;
+  }
+  const octets = normalized.split(".");
+  return (
+    octets.length === 4 &&
+    octets.every((octet) => /^(?:0|[1-9]\d{0,2})$/.test(octet)) &&
+    Number(octets[0]) === 127 &&
+    octets.every((octet) => Number(octet) <= 255)
+  );
+}
+
+function normalizedEndpoint(value: unknown): string {
+  const normalized = normalizedText(value, 4_096);
+  let parsed: URL;
+  try {
+    parsed = new URL(normalized);
+  } catch {
+    throw new TypeError();
+  }
+  if (
+    (parsed.protocol !== "http:" && parsed.protocol !== "https:") ||
+    parsed.username.length > 0 ||
+    parsed.password.length > 0 ||
+    parsed.search.length > 0 ||
+    parsed.hash.length > 0 ||
+    parsed.href.includes("?") ||
+    parsed.href.includes("#") ||
+    parsed.hostname.length === 0 ||
+    (parsed.protocol === "http:" && !isLoopbackHost(parsed.hostname))
+  ) {
+    throw new TypeError();
+  }
+  return normalized;
+}
+
+function providerCatalogue(provider: LlmProvider) {
+  return LLM_MODEL_CATALOGUE.find((entry) => entry.provider === provider);
+}
+
+export function parseOnboardingLlmSelection(value: unknown): OnboardingLlmSelection {
+  if (!isRecord(value) || !hasExactKeys(value, ["provider", "model", "endpoint"])) {
+    throw new TypeError();
+  }
+  if (
+    typeof value.provider !== "string" ||
+    !(LLM_PROVIDERS as readonly string[]).includes(value.provider)
+  ) {
+    throw new TypeError();
+  }
+  const provider = value.provider as LlmProvider;
+  const model = normalizedText(value.model, 512);
+  if (!isRecord(value.endpoint) || typeof value.endpoint.mode !== "string") {
+    throw new TypeError();
+  }
+  let endpoint: OnboardingLlmEndpointSelection;
+  if (value.endpoint.mode === "automatic" && hasExactKeys(value.endpoint, ["mode"])) {
+    endpoint = { mode: "automatic" };
+  } else if (value.endpoint.mode === "default" && hasExactKeys(value.endpoint, ["mode"])) {
+    endpoint = { mode: "default" };
+  } else if (value.endpoint.mode === "custom" && hasExactKeys(value.endpoint, ["mode", "value"])) {
+    endpoint = { mode: "custom", value: normalizedEndpoint(value.endpoint.value) };
+  } else {
+    throw new TypeError();
+  }
+  if (endpoint.mode !== "automatic" && providerCatalogue(provider)?.defaultBaseUrl === undefined) {
+    throw new TypeError();
+  }
+  return { provider, model, endpoint };
+}
+
+export function parseChatGptLlmSelection(value: unknown): OnboardingLlmSelection & {
+  readonly provider: "openai-codex";
+  readonly endpoint: { readonly mode: "automatic" };
+} {
+  const selection = parseOnboardingLlmSelection(value);
+  if (selection.provider !== "openai-codex" || selection.endpoint.mode !== "automatic") {
+    throw new TypeError();
+  }
+  return selection as OnboardingLlmSelection & {
+    readonly provider: "openai-codex";
+    readonly endpoint: { readonly mode: "automatic" };
+  };
+}
+
+export function runtimeConfigurationForSelection(
+  selection: OnboardingLlmSelection,
+  apiKey?: string,
+): ConfigureRuntimeRpcParams {
+  const endpoint =
+    selection.endpoint.mode === "automatic"
+      ? {}
+      : selection.endpoint.mode === "default"
+        ? { base_url: null }
+        : { base_url: selection.endpoint.value };
+  return {
+    llm: {
+      provider: selection.provider,
+      model: selection.model,
+      ...(apiKey === undefined ? {} : { api_key: apiKey }),
+      ...endpoint,
+    },
+  };
+}
+
+export function runtimeConfigurationForExistingSelection(
+  selection: OnboardingLlmSelection,
+): ConfigureRuntimeRpcParams {
+  const endpoint =
+    selection.endpoint.mode === "automatic"
+      ? {}
+      : selection.endpoint.mode === "default"
+        ? { base_url: null }
+        : { base_url: selection.endpoint.value };
+  return {
+    llm: {
+      model: selection.model,
+      ...endpoint,
+    },
+  };
+}
+
+export function publicLlmProviderConfiguration(): readonly OnboardingLlmProviderConfiguration[] {
+  return LLM_MODEL_CATALOGUE.map((entry) => ({
+    provider: entry.provider,
+    defaultModel: entry.defaultModel,
+    models: entry.models.map((model) => ({
+      value: model.value,
+      label: model.label,
+      ...(model.hint === undefined ? {} : { hint: model.hint }),
+    })),
+    ...(entry.defaultBaseUrl === undefined ? {} : { defaultBaseUrl: entry.defaultBaseUrl }),
+  }));
+}

--- a/apps/desktop/src/main/onboarding-ipc.ts
+++ b/apps/desktop/src/main/onboarding-ipc.ts
@@ -1,7 +1,15 @@
 import { extname, isAbsolute } from "node:path";
-import type { ConfigureRuntimeRpcParams, LlmProvider } from "@enduragent/coach-contract";
+import type {
+  ConfigureRuntimeRpcParams,
+  LlmProvider,
+  RuntimeConfigSnapshot,
+} from "@enduragent/coach-contract";
 import type { BrowserWindow, IpcMain, IpcMainInvokeEvent, OpenDialogOptions } from "electron";
-import type { ChatGptAuthController } from "./chatgpt-auth.js";
+import {
+  type ChatGptAuthController,
+  type ChatGptLoginResult,
+  type ChatGptStatus,
+} from "./chatgpt-auth.js";
 import {
   DESKTOP_CREDENTIAL_SLOTS,
   type CredentialSlotStatus,
@@ -9,10 +17,22 @@ import {
   type CredentialWriteResult,
   type DesktopCredentialSlot,
 } from "./credential-vault.js";
+import {
+  parseChatGptLlmSelection,
+  parseOnboardingLlmSelection,
+  publicLlmProviderConfiguration,
+  runtimeConfigurationForSelection,
+  type OnboardingLlmConfiguration,
+  type OnboardingLlmSelection,
+  type OnboardingLlmSelectionResult,
+} from "./llm-selection.js";
 
 export const DESKTOP_CREDENTIAL_STATUS_CHANNEL = "enduragent:onboarding:credential-status" as const;
 export const DESKTOP_CREDENTIAL_RETRY_CHANNEL = "enduragent:onboarding:credential-retry" as const;
 export const DESKTOP_CREDENTIAL_WRITE_CHANNEL = "enduragent:onboarding:credential-write" as const;
+export const DESKTOP_LLM_CONFIGURATION_CHANNEL = "enduragent:onboarding:llm-configuration" as const;
+export const DESKTOP_LLM_SELECTION_APPLY_CHANNEL =
+  "enduragent:onboarding:llm-selection-apply" as const;
 export const DESKTOP_CHATGPT_STATUS_CHANNEL = "enduragent:onboarding:chatgpt-status" as const;
 export const DESKTOP_CHATGPT_LOGIN_CHANNEL = "enduragent:onboarding:chatgpt-login" as const;
 export const DESKTOP_CHOOSE_IMPORT_FILES_CHANNEL =
@@ -31,6 +51,8 @@ interface RegisterOnboardingIpcOptions {
   readonly window: BrowserWindow;
   readonly vault: CredentialVault;
   readonly chatGptAuth: ChatGptAuthController;
+  readonly getRuntimeConfig: () => Promise<RuntimeConfigSnapshot>;
+  readonly applyExistingLlmSelection: (selection: OnboardingLlmSelection) => Promise<boolean>;
   readonly isTrusted: (event: IpcMainInvokeEvent) => boolean;
   readonly checkIntervalsCredentialOwner: (
     value: string,
@@ -42,9 +64,16 @@ const SUPPORTED_EXTENSIONS = new Set([".fit", ".tcx", ".gpx"]);
 export function runtimeConfigurationForCredential(
   slot: DesktopCredentialSlot,
   value: string,
+  selection?: OnboardingLlmSelection,
 ): ConfigureRuntimeRpcParams {
   if (slot === "intervals-icu") {
+    if (selection !== undefined) throw new TypeError();
     return { intervals: { api_key: value } };
+  }
+  if (selection !== undefined) {
+    const parsed = parseOnboardingLlmSelection(selection);
+    if (parsed.provider !== slot) throw new TypeError();
+    return runtimeConfigurationForSelection(parsed, value);
   }
   return {
     llm: {
@@ -63,11 +92,13 @@ function isSlot(value: unknown): value is DesktopCredentialSlot {
 function parseWriteInput(value: unknown): {
   readonly slot: DesktopCredentialSlot;
   readonly value: string;
+  readonly selection?: OnboardingLlmSelection;
 } {
   if (typeof value !== "object" || value === null || Array.isArray(value)) throw new TypeError();
   const input = value as Record<string, unknown>;
+  const hasSelection = Object.hasOwn(input, "selection");
   if (
-    Object.keys(input).length !== 2 ||
+    Object.keys(input).length !== (hasSelection ? 3 : 2) ||
     !Object.hasOwn(input, "slot") ||
     !Object.hasOwn(input, "value") ||
     !isSlot(input.slot) ||
@@ -75,7 +106,11 @@ function parseWriteInput(value: unknown): {
   ) {
     throw new TypeError();
   }
-  return { slot: input.slot, value: input.value };
+  if (!hasSelection) return { slot: input.slot, value: input.value };
+  if (input.slot === "intervals-icu") throw new TypeError();
+  const selection = parseOnboardingLlmSelection(input.selection);
+  if (selection.provider !== input.slot) throw new TypeError();
+  return { slot: input.slot, value: input.value, selection };
 }
 
 function minimizeStatuses(value: readonly CredentialSlotStatus[]): readonly CredentialSlotStatus[] {
@@ -88,9 +123,40 @@ function minimizeStatuses(value: readonly CredentialSlotStatus[]): readonly Cred
 
 function minimizeWrite(value: CredentialWriteResult): CredentialWriteResult {
   if (value.status === "configured") {
-    return { slot: value.slot, status: "configured", runtimeReady: true };
+    return { slot: value.slot, status: "configured", runtimeReady: value.runtimeReady };
   }
   return { slot: value.slot, status: "refused", reason: value.reason };
+}
+
+function minimizeSelection(value: OnboardingLlmSelectionResult): OnboardingLlmSelectionResult {
+  if (value.status === "configured") return { status: "configured", runtimeReady: true };
+  return { status: "refused", reason: value.reason };
+}
+
+function minimizeChatGptStatus(value: ChatGptStatus): ChatGptStatus {
+  return { state: value.state, runtimeReady: value.runtimeReady };
+}
+
+function minimizeChatGptLogin(value: ChatGptLoginResult): ChatGptLoginResult {
+  if (value.status === "configured") return { status: "configured", runtimeReady: true };
+  return { status: "refused", reason: value.reason };
+}
+
+async function llmConfiguration(
+  getRuntimeConfig: () => Promise<RuntimeConfigSnapshot>,
+): Promise<OnboardingLlmConfiguration> {
+  let active: OnboardingLlmConfiguration["active"] = null;
+  try {
+    const snapshot = await getRuntimeConfig();
+    if (snapshot.llm.credential_configured) {
+      active = { provider: snapshot.llm.provider, model: snapshot.llm.model };
+    }
+  } catch {}
+  return {
+    schemaVersion: 1,
+    providers: publicLlmProviderConfiguration(),
+    active,
+  };
 }
 
 export function registerOnboardingIpc(options: RegisterOnboardingIpcOptions): () => void {
@@ -133,20 +199,52 @@ export function registerOnboardingIpc(options: RegisterOnboardingIpcOptions): ()
           };
         }
       }
-      return minimizeWrite(await options.vault.writeCredential(input));
+      const stored =
+        input.slot !== "intervals-icu" && input.selection === undefined
+          ? await options.vault.writeCredential(input, { activate: false })
+          : await options.vault.writeCredential(input);
+      return minimizeWrite(stored);
     } catch {
       return { slot: input.slot, status: "refused", reason: "storage-failed" };
+    }
+  });
+  options.ipcMain.handle(DESKTOP_LLM_CONFIGURATION_CHANNEL, async (event, ...args) => {
+    requireTrusted(event);
+    if (args.length !== 0) throw new TypeError();
+    return llmConfiguration(options.getRuntimeConfig);
+  });
+  options.ipcMain.handle(DESKTOP_LLM_SELECTION_APPLY_CHANNEL, async (event, ...args) => {
+    requireTrusted(event);
+    if (args.length !== 1) throw new TypeError();
+    let selection: OnboardingLlmSelection;
+    try {
+      selection = parseOnboardingLlmSelection(args[0]);
+    } catch {
+      return { status: "refused", reason: "invalid-input" };
+    }
+    try {
+      if (await options.applyExistingLlmSelection(selection)) {
+        return { status: "configured", runtimeReady: true };
+      }
+      const result =
+        selection.provider === "openai-codex"
+          ? await options.chatGptAuth.activate(parseChatGptLlmSelection(selection))
+          : await options.vault.applyLlmSelection(selection);
+      return minimizeSelection(result);
+    } catch {
+      return { status: "refused", reason: "runtime-unavailable" };
     }
   });
   options.ipcMain.handle(DESKTOP_CHATGPT_STATUS_CHANNEL, async (event, ...args) => {
     requireTrusted(event);
     if (args.length !== 0) throw new TypeError();
-    return options.chatGptAuth.status();
+    return minimizeChatGptStatus(await options.chatGptAuth.status());
   });
   options.ipcMain.handle(DESKTOP_CHATGPT_LOGIN_CHANNEL, async (event, ...args) => {
     requireTrusted(event);
-    if (args.length !== 0) throw new TypeError();
-    return options.chatGptAuth.login();
+    if (args.length !== 1) throw new TypeError();
+    const selection = parseChatGptLlmSelection(args[0]);
+    return minimizeChatGptLogin(await options.chatGptAuth.login(selection));
   });
   options.ipcMain.handle(DESKTOP_CHOOSE_IMPORT_FILES_CHANNEL, async (event, ...args) => {
     requireTrusted(event);
@@ -173,6 +271,8 @@ export function registerOnboardingIpc(options: RegisterOnboardingIpcOptions): ()
     options.ipcMain.removeHandler(DESKTOP_CREDENTIAL_STATUS_CHANNEL);
     options.ipcMain.removeHandler(DESKTOP_CREDENTIAL_RETRY_CHANNEL);
     options.ipcMain.removeHandler(DESKTOP_CREDENTIAL_WRITE_CHANNEL);
+    options.ipcMain.removeHandler(DESKTOP_LLM_CONFIGURATION_CHANNEL);
+    options.ipcMain.removeHandler(DESKTOP_LLM_SELECTION_APPLY_CHANNEL);
     options.ipcMain.removeHandler(DESKTOP_CHATGPT_STATUS_CHANNEL);
     options.ipcMain.removeHandler(DESKTOP_CHATGPT_LOGIN_CHANNEL);
     options.ipcMain.removeHandler(DESKTOP_CHOOSE_IMPORT_FILES_CHANNEL);

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -13,6 +13,8 @@ import {
 const DESKTOP_CREDENTIAL_STATUS_CHANNEL = "enduragent:onboarding:credential-status";
 const DESKTOP_CREDENTIAL_RETRY_CHANNEL = "enduragent:onboarding:credential-retry";
 const DESKTOP_CREDENTIAL_WRITE_CHANNEL = "enduragent:onboarding:credential-write";
+const DESKTOP_LLM_CONFIGURATION_CHANNEL = "enduragent:onboarding:llm-configuration";
+const DESKTOP_LLM_SELECTION_APPLY_CHANNEL = "enduragent:onboarding:llm-selection-apply";
 const DESKTOP_CHATGPT_STATUS_CHANNEL = "enduragent:onboarding:chatgpt-status";
 const DESKTOP_CHATGPT_LOGIN_CHANNEL = "enduragent:onboarding:chatgpt-login";
 const DESKTOP_CHOOSE_IMPORT_FILES_CHANNEL = "enduragent:onboarding:choose-import-files";
@@ -28,6 +30,27 @@ const SLOTS = new Set([
   "kimi",
   "zai",
   "intervals-icu",
+]);
+const LLM_PROVIDER_ORDER = [
+  "anthropic",
+  "openai",
+  "google",
+  "openai-codex",
+  "deepseek",
+  "qwen",
+  "minimax",
+  "kimi",
+  "zai",
+  "openrouter",
+] as const;
+const LLM_PROVIDERS = new Set<string>(LLM_PROVIDER_ORDER);
+const DEFAULT_ENDPOINT_PROVIDERS = new Set([
+  "deepseek",
+  "qwen",
+  "minimax",
+  "kimi",
+  "zai",
+  "openrouter",
 ]);
 const STATES = new Set(["missing", "configured", "re-prompt"]);
 const RUNTIME_STATES = new Set(["active", "stored-inactive", "failed"]);
@@ -78,6 +101,123 @@ function safeString(value: unknown, maximumLength: number): value is string {
     if (code <= 0x1f || code === 0x7f) return false;
   }
   return true;
+}
+
+function normalizedSelectionText(value: unknown, maximumLength: number): string {
+  if (typeof value !== "string" || value.length === 0 || value.length > maximumLength) {
+    throw new TypeError();
+  }
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code <= 0x1f || code === 0x7f) throw new TypeError();
+  }
+  const normalized = value.trim();
+  if (normalized.length === 0 || normalized.length > maximumLength) throw new TypeError();
+  return normalized;
+}
+
+function loopbackHost(hostname: string): boolean {
+  const normalized = hostname.toLowerCase();
+  if (normalized === "localhost" || normalized.endsWith(".localhost") || normalized === "[::1]") {
+    return true;
+  }
+  const octets = normalized.split(".");
+  return (
+    octets.length === 4 &&
+    octets.every((octet) => /^(?:0|[1-9]\d{0,2})$/.test(octet)) &&
+    Number(octets[0]) === 127 &&
+    octets.every((octet) => Number(octet) <= 255)
+  );
+}
+
+function normalizedEndpoint(value: unknown): string {
+  const normalized = normalizedSelectionText(value, 4_096);
+  let parsed: URL;
+  try {
+    parsed = new URL(normalized);
+  } catch {
+    throw new TypeError();
+  }
+  if (
+    (parsed.protocol !== "http:" && parsed.protocol !== "https:") ||
+    parsed.username.length > 0 ||
+    parsed.password.length > 0 ||
+    parsed.search.length > 0 ||
+    parsed.hash.length > 0 ||
+    parsed.href.includes("?") ||
+    parsed.href.includes("#") ||
+    parsed.hostname.length === 0 ||
+    (parsed.protocol === "http:" && !loopbackHost(parsed.hostname))
+  ) {
+    throw new TypeError();
+  }
+  return normalized;
+}
+
+type PreloadLlmSelection = {
+  readonly provider: (typeof LLM_PROVIDER_ORDER)[number];
+  readonly model: string;
+  readonly endpoint:
+    | { readonly mode: "automatic" }
+    | { readonly mode: "default" }
+    | { readonly mode: "custom"; readonly value: string };
+};
+
+function parseLlmSelection(value: unknown): PreloadLlmSelection {
+  if (!record(value) || !exactKeys(value, ["provider", "model", "endpoint"])) {
+    throw new TypeError();
+  }
+  if (typeof value.provider !== "string" || !LLM_PROVIDERS.has(value.provider)) {
+    throw new TypeError();
+  }
+  const provider = value.provider as PreloadLlmSelection["provider"];
+  const model = normalizedSelectionText(value.model, 512);
+  if (!record(value.endpoint) || typeof value.endpoint.mode !== "string") {
+    throw new TypeError();
+  }
+  let endpoint: PreloadLlmSelection["endpoint"];
+  if (value.endpoint.mode === "automatic" && exactKeys(value.endpoint, ["mode"])) {
+    endpoint = { mode: "automatic" };
+  } else if (value.endpoint.mode === "default" && exactKeys(value.endpoint, ["mode"])) {
+    endpoint = { mode: "default" };
+  } else if (value.endpoint.mode === "custom" && exactKeys(value.endpoint, ["mode", "value"])) {
+    endpoint = { mode: "custom", value: normalizedEndpoint(value.endpoint.value) };
+  } else {
+    throw new TypeError();
+  }
+  if (endpoint.mode !== "automatic" && !DEFAULT_ENDPOINT_PROVIDERS.has(provider)) {
+    throw new TypeError();
+  }
+  return { provider, model, endpoint };
+}
+
+function parseChatGptSelection(value: unknown): PreloadLlmSelection {
+  const selection = parseLlmSelection(value);
+  if (selection.provider !== "openai-codex" || selection.endpoint.mode !== "automatic") {
+    throw new TypeError();
+  }
+  return selection;
+}
+
+function parseCredentialWriteInput(value: unknown): {
+  readonly slot: string;
+  readonly value: string;
+  readonly selection?: PreloadLlmSelection;
+} {
+  if (!record(value)) throw new TypeError();
+  const hasSelection = Object.hasOwn(value, "selection");
+  if (
+    !exactKeys(value, hasSelection ? ["slot", "value", "selection"] : ["slot", "value"]) ||
+    !SLOTS.has(value.slot as string) ||
+    typeof value.value !== "string"
+  ) {
+    throw new TypeError();
+  }
+  if (!hasSelection) return { slot: value.slot as string, value: value.value };
+  if (value.slot === "intervals-icu") throw new TypeError();
+  const selection = parseLlmSelection(value.selection);
+  if (selection.provider !== value.slot) throw new TypeError();
+  return { slot: value.slot as string, value: value.value, selection };
 }
 
 function releaseVersion(value: unknown): value is string {
@@ -197,9 +337,9 @@ function parseWriteResult(value: unknown): unknown {
   if (
     value.status === "configured" &&
     exactKeys(value, ["slot", "status", "runtimeReady"]) &&
-    value.runtimeReady === true
+    typeof value.runtimeReady === "boolean"
   ) {
-    return { slot: value.slot, status: "configured", runtimeReady: true };
+    return { slot: value.slot, status: "configured", runtimeReady: value.runtimeReady };
   }
   if (
     value.status === "refused" &&
@@ -207,6 +347,111 @@ function parseWriteResult(value: unknown): unknown {
     REASONS.has(value.reason as string)
   ) {
     return { slot: value.slot, status: "refused", reason: value.reason };
+  }
+  throw new TypeError();
+}
+
+function parseLlmConfiguration(value: unknown): unknown {
+  if (
+    !record(value) ||
+    !exactKeys(value, ["schemaVersion", "providers", "active"]) ||
+    value.schemaVersion !== 1 ||
+    !Array.isArray(value.providers) ||
+    value.providers.length !== LLM_PROVIDER_ORDER.length
+  ) {
+    throw new TypeError();
+  }
+  const providers = value.providers.map((entry, index) => {
+    if (
+      !record(entry) ||
+      entry.provider !== LLM_PROVIDER_ORDER[index] ||
+      typeof entry.provider !== "string"
+    ) {
+      throw new TypeError();
+    }
+    const hasDefaultBaseUrl = DEFAULT_ENDPOINT_PROVIDERS.has(entry.provider);
+    if (
+      !exactKeys(
+        entry,
+        hasDefaultBaseUrl
+          ? ["provider", "defaultModel", "models", "defaultBaseUrl"]
+          : ["provider", "defaultModel", "models"],
+      ) ||
+      !safeString(entry.defaultModel, 512) ||
+      !Array.isArray(entry.models) ||
+      entry.models.length === 0 ||
+      entry.models.length > 100
+    ) {
+      throw new TypeError();
+    }
+    if (
+      hasDefaultBaseUrl &&
+      (typeof entry.defaultBaseUrl !== "string" ||
+        normalizedEndpoint(entry.defaultBaseUrl) !== entry.defaultBaseUrl)
+    ) {
+      throw new TypeError();
+    }
+    const models = entry.models.map((model) => {
+      if (!record(model)) throw new TypeError();
+      const hasHint = Object.hasOwn(model, "hint");
+      if (
+        !exactKeys(model, hasHint ? ["value", "label", "hint"] : ["value", "label"]) ||
+        !safeString(model.value, 512) ||
+        !safeString(model.label, 512) ||
+        (hasHint && !safeString(model.hint, 512))
+      ) {
+        throw new TypeError();
+      }
+      return {
+        value: model.value,
+        label: model.label,
+        ...(hasHint ? { hint: model.hint } : {}),
+      };
+    });
+    if (
+      new Set(models.map((model) => model.value)).size !== models.length ||
+      !models.some((model) => model.value === entry.defaultModel)
+    ) {
+      throw new TypeError();
+    }
+    return {
+      provider: entry.provider,
+      defaultModel: entry.defaultModel,
+      models,
+      ...(hasDefaultBaseUrl ? { defaultBaseUrl: entry.defaultBaseUrl } : {}),
+    };
+  });
+  let active: { readonly provider: string; readonly model: string } | null = null;
+  if (value.active !== null) {
+    if (
+      !record(value.active) ||
+      !exactKeys(value.active, ["provider", "model"]) ||
+      typeof value.active.provider !== "string" ||
+      !LLM_PROVIDERS.has(value.active.provider) ||
+      !safeString(value.active.model, 512)
+    ) {
+      throw new TypeError();
+    }
+    active = { provider: value.active.provider, model: value.active.model };
+  }
+  return { schemaVersion: 1, providers, active };
+}
+
+function parseLlmSelectionResult(value: unknown): unknown {
+  if (!record(value)) throw new TypeError();
+  if (
+    value.status === "configured" &&
+    exactKeys(value, ["status", "runtimeReady"]) &&
+    value.runtimeReady === true
+  ) {
+    return { status: "configured", runtimeReady: true };
+  }
+  if (
+    value.status === "refused" &&
+    exactKeys(value, ["status", "reason"]) &&
+    ["invalid-input", "credential-required", "runtime-unavailable"].includes(value.reason as string)
+  ) {
+    return { status: "refused", reason: value.reason };
   }
   throw new TypeError();
 }
@@ -335,20 +580,23 @@ contextBridge.exposeInMainWorld(
     retryFailedCredentials: async () =>
       parseStatuses(await ipcRenderer.invoke(DESKTOP_CREDENTIAL_RETRY_CHANNEL)),
     writeCredential: async (input: unknown) => {
-      if (
-        !record(input) ||
-        !exactKeys(input, ["slot", "value"]) ||
-        !SLOTS.has(input.slot as string) ||
-        typeof input.value !== "string"
-      ) {
-        throw new TypeError();
-      }
-      return parseWriteResult(await ipcRenderer.invoke(DESKTOP_CREDENTIAL_WRITE_CHANNEL, input));
+      const parsed = parseCredentialWriteInput(input);
+      return parseWriteResult(await ipcRenderer.invoke(DESKTOP_CREDENTIAL_WRITE_CHANNEL, parsed));
+    },
+    llmConfiguration: async () =>
+      parseLlmConfiguration(await ipcRenderer.invoke(DESKTOP_LLM_CONFIGURATION_CHANNEL)),
+    applyLlmSelection: async (input: unknown) => {
+      const selection = parseLlmSelection(input);
+      return parseLlmSelectionResult(
+        await ipcRenderer.invoke(DESKTOP_LLM_SELECTION_APPLY_CHANNEL, selection),
+      );
     },
     chatgptStatus: async () =>
       parseChatGptStatus(await ipcRenderer.invoke(DESKTOP_CHATGPT_STATUS_CHANNEL)),
-    chatgptLogin: async () =>
-      parseChatGptLogin(await ipcRenderer.invoke(DESKTOP_CHATGPT_LOGIN_CHANNEL)),
+    chatgptLogin: async (input: unknown) => {
+      const selection = parseChatGptSelection(input);
+      return parseChatGptLogin(await ipcRenderer.invoke(DESKTOP_CHATGPT_LOGIN_CHANNEL, selection));
+    },
     chooseImportFiles: async () =>
       parsePaths(await ipcRenderer.invoke(DESKTOP_CHOOSE_IMPORT_FILES_CHANNEL)),
     releaseNotes: async () =>

--- a/apps/desktop/tests/chat-panels.integration.test.ts
+++ b/apps/desktop/tests/chat-panels.integration.test.ts
@@ -558,6 +558,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
     expect(initial).toEqual({
       location: "enduragent://app/index.html",
       bridgeKeys: [
+        "applyLlmSelection",
         "chatgptLogin",
         "chatgptStatus",
         "checkForUpdates",
@@ -565,6 +566,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
         "credentialStatuses",
         "getDaemonConnection",
         "getUpdateState",
+        "llmConfiguration",
         "onDroppedImportFiles",
         "onUpdateState",
         "releaseNotes",

--- a/apps/desktop/tests/chatgpt-auth.test.ts
+++ b/apps/desktop/tests/chatgpt-auth.test.ts
@@ -26,6 +26,14 @@ function credentials() {
   };
 }
 
+function selection(model = "gpt-5.5") {
+  return {
+    provider: "openai-codex" as const,
+    model,
+    endpoint: { mode: "automatic" as const },
+  };
+}
+
 function runtimeSnapshot(
   provider: LlmProvider = "openai-codex",
   credentialConfigured = provider === "openai-codex",
@@ -199,7 +207,10 @@ describe("desktop ChatGPT auth", () => {
       dependencies: { loginCodex: async () => credentials() },
     });
 
-    await expect(auth.login()).resolves.toEqual({ status: "configured", runtimeReady: true });
+    await expect(auth.login(selection())).resolves.toEqual({
+      status: "configured",
+      runtimeReady: true,
+    });
     expect(await readFile(`${path}.corrupt`)).toEqual(originalBytes);
     expect((await stat(`${path}.corrupt`)).mode & 0o777).toBe(0o600);
     expect((await stat(path)).mode & 0o777).toBe(0o600);
@@ -219,7 +230,7 @@ describe("desktop ChatGPT auth", () => {
       applyRuntimeConfig: async () => {},
       dependencies: { loginCodex: async () => credentials() },
     });
-    await expect(auth.login()).resolves.toEqual({
+    await expect(auth.login(selection())).resolves.toEqual({
       status: "refused",
       reason: "storage-failed",
     });
@@ -242,7 +253,10 @@ describe("desktop ChatGPT auth", () => {
           }),
       },
     });
-    await expect(timedOut.login()).resolves.toEqual({ status: "refused", reason: "timed-out" });
+    await expect(timedOut.login(selection())).resolves.toEqual({
+      status: "refused",
+      reason: "timed-out",
+    });
 
     const cancelled = createChatGptAuth({
       configDir: directory,
@@ -261,7 +275,10 @@ describe("desktop ChatGPT auth", () => {
         },
       },
     });
-    await expect(cancelled.login()).resolves.toEqual({ status: "refused", reason: "cancelled" });
+    await expect(cancelled.login(selection())).resolves.toEqual({
+      status: "refused",
+      reason: "cancelled",
+    });
 
     const exchange = createChatGptAuth({
       configDir: directory,
@@ -273,7 +290,7 @@ describe("desktop ChatGPT auth", () => {
         },
       },
     });
-    await expect(exchange.login()).resolves.toEqual({
+    await expect(exchange.login(selection())).resolves.toEqual({
       status: "refused",
       reason: "exchange-failed",
     });
@@ -301,7 +318,7 @@ describe("desktop ChatGPT auth", () => {
       },
     });
 
-    await expect(auth.login()).resolves.toEqual({
+    await expect(auth.login(selection())).resolves.toEqual({
       status: "refused",
       reason: "callback-unavailable",
     });
@@ -325,7 +342,10 @@ describe("desktop ChatGPT auth", () => {
       },
     });
 
-    await expect(auth.login()).resolves.toEqual({ status: "configured", runtimeReady: true });
+    await expect(auth.login(selection())).resolves.toEqual({
+      status: "configured",
+      runtimeReady: true,
+    });
     expect(openExternal).toHaveBeenCalledOnce();
   });
 
@@ -363,12 +383,70 @@ describe("desktop ChatGPT auth", () => {
         },
       },
     });
-    await expect(auth.login()).resolves.toEqual({ status: "configured", runtimeReady: true });
+    await expect(auth.login(selection())).resolves.toEqual({
+      status: "configured",
+      runtimeReady: true,
+    });
     expect(applyRuntimeConfig).toHaveBeenCalledWith({
-      llm: { provider: "openai-codex" },
+      llm: { provider: "openai-codex", model: "gpt-5.5" },
     });
     expect(order).toEqual(["browser", "storage", "runtime"]);
     await expect(auth.status()).resolves.toEqual({ state: "configured", runtimeReady: true });
+  });
+
+  it("activates a stored profile with the selected model without reauthenticating", async () => {
+    const directory = await configDir();
+    await writeChatGptProfile(directory, credentials());
+    const applyRuntimeConfig = vi.fn(async () => {});
+    const loginCodex = vi.fn(async () => credentials());
+    const auth = createChatGptAuth({
+      configDir: directory,
+      openExternal: async () => {},
+      applyRuntimeConfig,
+      dependencies: { loginCodex },
+    });
+
+    await expect(auth.activate(selection("athlete-custom-model"))).resolves.toEqual({
+      status: "configured",
+      runtimeReady: true,
+    });
+    expect(applyRuntimeConfig).toHaveBeenCalledWith({
+      llm: { provider: "openai-codex", model: "athlete-custom-model" },
+    });
+    expect(loginCodex).not.toHaveBeenCalled();
+  });
+
+  it("returns fixed stored-profile activation refusals", async () => {
+    const directory = await configDir();
+    const absent = createChatGptAuth({
+      configDir: directory,
+      openExternal: async () => {},
+      applyRuntimeConfig: async () => {},
+    });
+    await expect(absent.activate(selection())).resolves.toEqual({
+      status: "refused",
+      reason: "credential-required",
+    });
+    await expect(
+      absent.activate({
+        provider: "anthropic",
+        model: "model",
+        endpoint: { mode: "automatic" },
+      }),
+    ).resolves.toEqual({ status: "refused", reason: "invalid-input" });
+
+    await writeChatGptProfile(directory, credentials());
+    const unavailable = createChatGptAuth({
+      configDir: directory,
+      openExternal: async () => {},
+      applyRuntimeConfig: async () => {
+        throw new Error("private runtime detail");
+      },
+    });
+    await expect(unavailable.activate(selection())).resolves.toEqual({
+      status: "refused",
+      reason: "runtime-unavailable",
+    });
   });
 
   it("restores configured runtime readiness from the daemon snapshot", async () => {
@@ -431,8 +509,8 @@ describe("desktop ChatGPT auth", () => {
         },
       },
     });
-    const first = auth.login();
-    await expect(auth.login()).resolves.toEqual({
+    const first = auth.login(selection());
+    await expect(auth.login(selection())).resolves.toEqual({
       status: "refused",
       reason: "already-in-progress",
     });
@@ -450,7 +528,7 @@ describe("desktop ChatGPT auth", () => {
         },
       },
     });
-    await expect(callback.login()).resolves.toEqual({
+    await expect(callback.login(selection())).resolves.toEqual({
       status: "refused",
       reason: "callback-unavailable",
     });
@@ -466,7 +544,7 @@ describe("desktop ChatGPT auth", () => {
         },
       },
     });
-    await expect(storage.login()).resolves.toEqual({
+    await expect(storage.login(selection())).resolves.toEqual({
       status: "refused",
       reason: "storage-failed",
     });
@@ -479,7 +557,7 @@ describe("desktop ChatGPT auth", () => {
       },
       dependencies: { loginCodex: async () => credentials() },
     });
-    await expect(runtime.login()).resolves.toEqual({
+    await expect(runtime.login(selection())).resolves.toEqual({
       status: "refused",
       reason: "runtime-unavailable",
     });
@@ -501,7 +579,10 @@ describe("desktop ChatGPT auth", () => {
       getRuntimeConfig: async () => runtimeSnapshot(provider),
       dependencies: { loginCodex: async () => credentials() },
     });
-    await expect(auth.login()).resolves.toEqual({ status: "configured", runtimeReady: true });
+    await expect(auth.login(selection())).resolves.toEqual({
+      status: "configured",
+      runtimeReady: true,
+    });
     await expect(auth.status()).resolves.toEqual({ state: "configured", runtimeReady: true });
 
     await writeFile(

--- a/apps/desktop/tests/credential-runtime.test.ts
+++ b/apps/desktop/tests/credential-runtime.test.ts
@@ -102,8 +102,13 @@ function fakeVault(initialRuntime: CredentialRuntimeApplication) {
   const port: CredentialVault = {
     async writeCredential(input) {
       slots.add(input.slot);
-      await runtime.applyExplicit(runtimeConfigurationForCredential(input.slot, randomUUID()));
+      await runtime.applyExplicit(
+        runtimeConfigurationForCredential(input.slot, randomUUID(), input.selection),
+      );
       return { slot: input.slot, status: "configured", runtimeReady: true };
+    },
+    async applyLlmSelection() {
+      return { status: "configured", runtimeReady: true };
     },
     async credentialStatuses() {
       return [...slots].map((slot) => ({
@@ -148,7 +153,10 @@ async function pollCredentialStatuses(vault: CredentialVault): Promise<void> {
     chatGptAuth: {
       status: async () => ({ state: "absent", runtimeReady: false }),
       login: async () => ({ status: "refused", reason: "cancelled" }),
+      activate: async () => ({ status: "refused", reason: "credential-required" }),
     },
+    getRuntimeConfig: async () => runtimeSnapshot("anthropic"),
+    applyExistingLlmSelection: async () => false,
     isTrusted: () => true,
     checkIntervalsCredentialOwner,
   });
@@ -424,6 +432,29 @@ describe("desktop credential runtime precedence", () => {
 
     expect(selectedProvider).toBe("openai-codex");
   });
+
+  it.each(["anthropic", "openai-codex"] as const)(
+    "edits an existing %s selection without resending the provider",
+    async (provider) => {
+      const configureRuntime = vi.fn(async () => {});
+      const runtime = createCredentialRuntimeApplication({
+        selectedLlmProvider: async () => provider,
+        configureRuntime,
+      });
+      const request = { llm: { model: "athlete-selected-model" } };
+
+      await expect(runtime.applyExistingLlmSelection(provider, request)).resolves.toBe(true);
+      await expect(
+        runtime.applyExistingLlmSelection(
+          provider === "anthropic" ? "openai-codex" : "anthropic",
+          request,
+        ),
+      ).resolves.toBe(false);
+
+      expect(configureRuntime).toHaveBeenCalledOnce();
+      expect(configureRuntime).toHaveBeenCalledWith(request);
+    },
+  );
 
   it("keeps a later ChatGPT selection when stored model credentials reapply at boot", async () => {
     const daemon = fakeDaemon("anthropic");

--- a/apps/desktop/tests/credential-vault.test.ts
+++ b/apps/desktop/tests/credential-vault.test.ts
@@ -466,6 +466,177 @@ describe("desktop credential vault", () => {
     );
   });
 
+  it("stores an unrelated key without replacing the selected provider's custom endpoint", async () => {
+    const root = await temporaryRoot();
+    let selectedProvider = "openrouter";
+    let baseUrl: string | undefined = "https://private.models.example/v1";
+    const applyCredential = vi.fn(async (slot, _value, selection) => {
+      const providerChanged = selectedProvider !== slot;
+      selectedProvider = slot;
+      if (providerChanged) {
+        baseUrl = slot === "openrouter" ? "https://openrouter.ai/api/v1" : undefined;
+      }
+      if (selection?.endpoint.mode === "default") {
+        baseUrl = "https://openrouter.ai/api/v1";
+      } else if (selection?.endpoint.mode === "custom") {
+        baseUrl = selection.endpoint.value;
+      }
+    });
+    const vault = createCredentialVault({
+      root,
+      encryption: encryption(),
+      applyCredential,
+    });
+
+    await expect(
+      vault.writeCredential(
+        { slot: "anthropic", value: "stored-anthropic-secret" },
+        { activate: false },
+      ),
+    ).resolves.toEqual({
+      slot: "anthropic",
+      status: "configured",
+      runtimeReady: false,
+    });
+    await expect(
+      vault.writeCredential({
+        slot: "openrouter",
+        value: "selected-openrouter-secret",
+        selection: {
+          provider: "openrouter",
+          model: "deepseek/deepseek-v4-flash",
+          endpoint: { mode: "automatic" },
+        },
+      }),
+    ).resolves.toEqual({
+      slot: "openrouter",
+      status: "configured",
+      runtimeReady: true,
+    });
+
+    expect(applyCredential).toHaveBeenCalledOnce();
+    expect(selectedProvider).toBe("openrouter");
+    expect(baseUrl).toBe("https://private.models.example/v1");
+    await expect(vault.credentialStatuses()).resolves.toEqual(
+      expect.arrayContaining([
+        { slot: "anthropic", state: "configured", runtimeState: "stored-inactive" },
+        { slot: "openrouter", state: "configured", runtimeState: "active" },
+      ]),
+    );
+  });
+
+  it("applies a credential and matching selection through one guarded callback", async () => {
+    const root = await temporaryRoot();
+    const applyCredential = vi.fn(async () => {});
+    const vault = createCredentialVault({
+      root,
+      encryption: encryption(),
+      applyCredential,
+    });
+    const modelSelection = {
+      provider: "openrouter" as const,
+      model: "athlete-model",
+      endpoint: { mode: "default" as const },
+    };
+
+    await expect(
+      vault.writeCredential({
+        slot: "openrouter",
+        value: "  obviously-fake-key  ",
+        selection: modelSelection,
+      }),
+    ).resolves.toEqual({
+      slot: "openrouter",
+      status: "configured",
+      runtimeReady: true,
+    });
+    expect(applyCredential).toHaveBeenCalledOnce();
+    expect(applyCredential).toHaveBeenCalledWith(
+      "openrouter",
+      "obviously-fake-key",
+      modelSelection,
+    );
+  });
+
+  it("activates a stored key without returning it and supports a failed activation retry", async () => {
+    const root = await temporaryRoot();
+    let failSelection = false;
+    const applyCredential = vi.fn(async (_slot, _value, selected) => {
+      if (selected !== undefined && failSelection) throw new TypeError();
+    });
+    const vault = createCredentialVault({
+      root,
+      encryption: encryption(),
+      applyCredential,
+    });
+    await vault.writeCredential({
+      slot: "anthropic",
+      value: "stored-anthropic-secret",
+    });
+    await vault.writeCredential({
+      slot: "openrouter",
+      value: "stored-openrouter-secret",
+    });
+    const modelSelection = {
+      provider: "anthropic" as const,
+      model: "athlete-model",
+      endpoint: { mode: "automatic" as const },
+    };
+
+    failSelection = true;
+    const failed = await vault.applyLlmSelection(modelSelection);
+    expect(failed).toEqual({ status: "refused", reason: "runtime-unavailable" });
+    expect(JSON.stringify(failed)).not.toContain("stored-anthropic-secret");
+    await expect(vault.credentialStatuses()).resolves.toContainEqual({
+      slot: "anthropic",
+      state: "configured",
+      runtimeState: "failed",
+    });
+
+    failSelection = false;
+    await expect(vault.applyLlmSelection(modelSelection)).resolves.toEqual({
+      status: "configured",
+      runtimeReady: true,
+    });
+    await expect(vault.credentialStatuses()).resolves.toEqual(
+      expect.arrayContaining([
+        { slot: "anthropic", state: "configured", runtimeState: "active" },
+        { slot: "openrouter", state: "configured", runtimeState: "stored-inactive" },
+      ]),
+    );
+    expect(applyCredential).toHaveBeenLastCalledWith(
+      "anthropic",
+      "stored-anthropic-secret",
+      modelSelection,
+    );
+  });
+
+  it("requires a securely readable matching key before applying a selection", async () => {
+    const root = await temporaryRoot();
+    const applyCredential = vi.fn(async () => {});
+    const vault = createCredentialVault({
+      root,
+      encryption: encryption(),
+      applyCredential,
+    });
+
+    await expect(
+      vault.applyLlmSelection({
+        provider: "anthropic",
+        model: "model",
+        endpoint: { mode: "automatic" },
+      }),
+    ).resolves.toEqual({ status: "refused", reason: "credential-required" });
+    await expect(
+      vault.applyLlmSelection({
+        provider: "openai-codex",
+        model: "model",
+        endpoint: { mode: "automatic" },
+      }),
+    ).resolves.toEqual({ status: "refused", reason: "invalid-input" });
+    expect(applyCredential).not.toHaveBeenCalled();
+  });
+
   it("marks model credentials inactive when a profile becomes selected", () => {
     const runtimeState = new Map([
       ["anthropic" as const, "active" as const],

--- a/apps/desktop/tests/onboarding-ipc.test.ts
+++ b/apps/desktop/tests/onboarding-ipc.test.ts
@@ -7,9 +7,12 @@ import {
   DESKTOP_CREDENTIAL_RETRY_CHANNEL,
   DESKTOP_CREDENTIAL_STATUS_CHANNEL,
   DESKTOP_CREDENTIAL_WRITE_CHANNEL,
+  DESKTOP_LLM_CONFIGURATION_CHANNEL,
+  DESKTOP_LLM_SELECTION_APPLY_CHANNEL,
   registerOnboardingIpc,
   runtimeConfigurationForCredential,
 } from "../src/main/onboarding-ipc.js";
+import { runtimeConfigurationForExistingSelection } from "../src/main/llm-selection.js";
 import type { CredentialVault } from "../src/main/credential-vault.js";
 
 type Handler = (event: IpcMainInvokeEvent, ...args: unknown[]) => unknown;
@@ -26,8 +29,12 @@ function harness(
     removeHandler: vi.fn((channel: string) => handlers.delete(channel)),
   };
   const vault: CredentialVault = {
-    writeCredential: vi.fn(async (input) => ({
+    writeCredential: vi.fn(async (input, behavior) => ({
       slot: input.slot,
+      status: "configured" as const,
+      runtimeReady: behavior?.activate !== false,
+    })),
+    applyLlmSelection: vi.fn(async () => ({
       status: "configured" as const,
       runtimeReady: true as const,
     })),
@@ -50,7 +57,25 @@ function harness(
   const chatGptAuth = {
     status: vi.fn(async () => ({ state: "configured" as const, runtimeReady: true })),
     login: vi.fn(async () => ({ status: "configured" as const, runtimeReady: true as const })),
+    activate: vi.fn(async () => ({ status: "configured" as const, runtimeReady: true as const })),
   };
+  const getRuntimeConfig = vi.fn(async () => ({
+    schemaVersion: 1 as const,
+    llm: {
+      provider: "anthropic" as const,
+      model: "athlete-selected-model",
+      credential_configured: true,
+    },
+    intervals: { athlete_id: "synthetic-athlete" },
+    session: {
+      historyTokenBudgetRatio: 0.3,
+      idleMinutes: 0,
+      dailyResetHour: 4,
+      resetArchiveRetentionDays: 0,
+      timezone: "UTC",
+    },
+  }));
+  const applyExistingLlmSelection = vi.fn(async () => false);
   const trustedEvent = {} as IpcMainInvokeEvent;
   const dispose = registerOnboardingIpc({
     ipcMain: ipcMain as never,
@@ -58,6 +83,8 @@ function harness(
     window: {} as never,
     vault,
     chatGptAuth,
+    getRuntimeConfig,
+    applyExistingLlmSelection,
     isTrusted: (event) => event === trustedEvent,
     checkIntervalsCredentialOwner,
   });
@@ -68,6 +95,8 @@ function harness(
     ipcMain,
     vault,
     chatGptAuth,
+    getRuntimeConfig,
+    applyExistingLlmSelection,
     dialog,
     checkIntervalsCredentialOwner,
     trustedEvent,
@@ -144,6 +173,72 @@ describe("desktop onboarding IPC", () => {
     expect(runtimeConfigurationForCredential("intervals-icu", "synthetic")).toEqual({
       intervals: { api_key: "synthetic" },
     });
+    expect(
+      runtimeConfigurationForCredential("openrouter", "synthetic", {
+        provider: "openrouter",
+        model: "athlete-model",
+        endpoint: { mode: "automatic" },
+      }),
+    ).toEqual({
+      llm: {
+        provider: "openrouter",
+        model: "athlete-model",
+        api_key: "synthetic",
+      },
+    });
+    expect(
+      runtimeConfigurationForCredential("openrouter", "synthetic", {
+        provider: "openrouter",
+        model: "athlete-model",
+        endpoint: { mode: "default" },
+      }),
+    ).toEqual({
+      llm: {
+        provider: "openrouter",
+        model: "athlete-model",
+        api_key: "synthetic",
+        base_url: null,
+      },
+    });
+    expect(
+      runtimeConfigurationForCredential("openrouter", "synthetic", {
+        provider: "openrouter",
+        model: "athlete-model",
+        endpoint: { mode: "custom", value: "https://models.example.invalid/v1" },
+      }),
+    ).toEqual({
+      llm: {
+        provider: "openrouter",
+        model: "athlete-model",
+        api_key: "synthetic",
+        base_url: "https://models.example.invalid/v1",
+      },
+    });
+    expect(() =>
+      runtimeConfigurationForCredential("anthropic", "synthetic", {
+        provider: "anthropic",
+        model: "athlete-model",
+        endpoint: { mode: "default" },
+      }),
+    ).toThrow(TypeError);
+    expect(
+      runtimeConfigurationForExistingSelection({
+        provider: "openai-codex",
+        model: "athlete-chat-model",
+        endpoint: { mode: "automatic" },
+      }),
+    ).toEqual({
+      llm: { model: "athlete-chat-model" },
+    });
+    expect(
+      runtimeConfigurationForExistingSelection({
+        provider: "openrouter",
+        model: "athlete-model",
+        endpoint: { mode: "default" },
+      }),
+    ).toEqual({
+      llm: { model: "athlete-model", base_url: null },
+    });
   });
 
   it("registers only semantic onboarding channels and returns metadata", async () => {
@@ -153,6 +248,8 @@ describe("desktop onboarding IPC", () => {
         DESKTOP_CREDENTIAL_STATUS_CHANNEL,
         DESKTOP_CREDENTIAL_RETRY_CHANNEL,
         DESKTOP_CREDENTIAL_WRITE_CHANNEL,
+        DESKTOP_LLM_CONFIGURATION_CHANNEL,
+        DESKTOP_LLM_SELECTION_APPLY_CHANNEL,
         DESKTOP_CHATGPT_STATUS_CHANNEL,
         DESKTOP_CHATGPT_LOGIN_CHANNEL,
         DESKTOP_CHOOSE_IMPORT_FILES_CHANNEL,
@@ -211,13 +308,245 @@ describe("desktop onboarding IPC", () => {
     expect(subject.vault.reapplyConfigured).not.toHaveBeenCalled();
   });
 
+  it("returns only the ordered public catalogue and minimized active selection", async () => {
+    const subject = harness();
+
+    const result = (await subject.invoke(
+      DESKTOP_LLM_CONFIGURATION_CHANNEL,
+      subject.trustedEvent,
+    )) as {
+      readonly schemaVersion: number;
+      readonly providers: readonly Record<string, unknown>[];
+      readonly active: Record<string, unknown>;
+    };
+
+    expect(result.schemaVersion).toBe(1);
+    expect(result.providers.map((provider) => provider.provider)).toEqual([
+      "anthropic",
+      "openai",
+      "google",
+      "openai-codex",
+      "deepseek",
+      "qwen",
+      "minimax",
+      "kimi",
+      "zai",
+      "openrouter",
+    ]);
+    expect(result.active).toEqual({
+      provider: "anthropic",
+      model: "athlete-selected-model",
+    });
+    expect(Object.keys(result.active).sort()).toEqual(["model", "provider"]);
+    expect(JSON.stringify(result)).not.toMatch(/credential|api[_-]?key|path|error/i);
+    await expect(
+      subject.invoke(DESKTOP_LLM_CONFIGURATION_CHANNEL, {} as IpcMainInvokeEvent),
+    ).rejects.toBeInstanceOf(TypeError);
+    await expect(
+      subject.invoke(DESKTOP_LLM_CONFIGURATION_CHANNEL, subject.trustedEvent, null),
+    ).rejects.toBeInstanceOf(TypeError);
+  });
+
+  it("keeps the catalogue available with a null active selection when snapshotting fails", async () => {
+    const subject = harness();
+    subject.getRuntimeConfig.mockRejectedValueOnce(new Error("private daemon path and token"));
+
+    const result = (await subject.invoke(
+      DESKTOP_LLM_CONFIGURATION_CHANNEL,
+      subject.trustedEvent,
+    )) as { readonly providers: readonly unknown[]; readonly active: unknown };
+
+    expect(result.providers).toHaveLength(10);
+    expect(result.active).toBeNull();
+    expect(JSON.stringify(result)).not.toContain("private daemon path and token");
+  });
+
+  it("dispatches strict model selection to a stored key or stored ChatGPT profile", async () => {
+    const subject = harness();
+    const apiSelection = {
+      provider: "openrouter",
+      model: "  athlete-model  ",
+      endpoint: { mode: "custom", value: "  https://models.example.invalid/v1  " },
+    };
+    await expect(
+      subject.invoke(DESKTOP_LLM_SELECTION_APPLY_CHANNEL, subject.trustedEvent, apiSelection),
+    ).resolves.toEqual({ status: "configured", runtimeReady: true });
+    expect(subject.vault.applyLlmSelection).toHaveBeenCalledWith({
+      provider: "openrouter",
+      model: "athlete-model",
+      endpoint: { mode: "custom", value: "https://models.example.invalid/v1" },
+    });
+
+    const chatGpt = {
+      provider: "openai-codex",
+      model: "gpt-5.4-mini",
+      endpoint: { mode: "automatic" },
+    };
+    await expect(
+      subject.invoke(DESKTOP_LLM_SELECTION_APPLY_CHANNEL, subject.trustedEvent, chatGpt),
+    ).resolves.toEqual({ status: "configured", runtimeReady: true });
+    expect(subject.chatGptAuth.activate).toHaveBeenCalledWith(chatGpt);
+  });
+
+  it.each([
+    {
+      description: "API credential",
+      selection: {
+        provider: "anthropic" as const,
+        model: "athlete-selected-model",
+        endpoint: { mode: "automatic" as const },
+      },
+    },
+    {
+      description: "custom ChatGPT profile",
+      selection: {
+        provider: "openai-codex" as const,
+        model: "gpt-5.4-mini",
+        endpoint: { mode: "automatic" as const },
+      },
+    },
+  ])(
+    "preserves an active $description without requiring Desktop-owned credentials",
+    async ({ selection }) => {
+      const subject = harness();
+      subject.applyExistingLlmSelection.mockResolvedValueOnce(true);
+
+      await expect(
+        subject.invoke(DESKTOP_LLM_SELECTION_APPLY_CHANNEL, subject.trustedEvent, selection),
+      ).resolves.toEqual({ status: "configured", runtimeReady: true });
+
+      expect(subject.applyExistingLlmSelection).toHaveBeenCalledWith(selection);
+      expect(subject.vault.applyLlmSelection).not.toHaveBeenCalled();
+      expect(subject.chatGptAuth.activate).not.toHaveBeenCalled();
+    },
+  );
+
+  it("fails an active-provider apply closed without falling back to another credential", async () => {
+    const subject = harness();
+    subject.applyExistingLlmSelection.mockRejectedValueOnce(new Error("private runtime failure"));
+
+    await expect(
+      subject.invoke(DESKTOP_LLM_SELECTION_APPLY_CHANNEL, subject.trustedEvent, {
+        provider: "anthropic",
+        model: "athlete-selected-model",
+        endpoint: { mode: "automatic" },
+      }),
+    ).resolves.toEqual({ status: "refused", reason: "runtime-unavailable" });
+
+    expect(subject.vault.applyLlmSelection).not.toHaveBeenCalled();
+    expect(subject.chatGptAuth.activate).not.toHaveBeenCalled();
+  });
+
+  it("returns fixed selection refusals and rejects unsafe endpoint shapes", async () => {
+    const subject = harness();
+    vi.mocked(subject.vault.applyLlmSelection)
+      .mockResolvedValueOnce({ status: "refused", reason: "credential-required" })
+      .mockRejectedValueOnce(new Error("private runtime failure"));
+    const automatic = {
+      provider: "anthropic",
+      model: "model",
+      endpoint: { mode: "automatic" },
+    };
+    await expect(
+      subject.invoke(DESKTOP_LLM_SELECTION_APPLY_CHANNEL, subject.trustedEvent, automatic),
+    ).resolves.toEqual({ status: "refused", reason: "credential-required" });
+    await expect(
+      subject.invoke(DESKTOP_LLM_SELECTION_APPLY_CHANNEL, subject.trustedEvent, automatic),
+    ).resolves.toEqual({ status: "refused", reason: "runtime-unavailable" });
+
+    for (const selection of [
+      { provider: "anthropic", model: "model", endpoint: { mode: "default" } },
+      {
+        provider: "openrouter",
+        model: "model",
+        endpoint: { mode: "custom", value: "http://models.example.invalid/v1" },
+      },
+      {
+        provider: "openrouter",
+        model: "model",
+        endpoint: { mode: "custom", value: "https://user:secret@example.invalid/v1" },
+      },
+      {
+        provider: "openrouter",
+        model: "model",
+        endpoint: { mode: "custom", value: "https://example.invalid/v1?secret=value" },
+      },
+      {
+        provider: "openrouter",
+        model: "model",
+        endpoint: { mode: "custom", value: "https://example.invalid/v1?" },
+      },
+      {
+        provider: "openrouter",
+        model: "bad\u007fmodel",
+        endpoint: { mode: "automatic" },
+      },
+      {
+        provider: "openrouter",
+        model: "\nmodel",
+        endpoint: { mode: "automatic" },
+      },
+    ]) {
+      await expect(
+        subject.invoke(DESKTOP_LLM_SELECTION_APPLY_CHANNEL, subject.trustedEvent, selection),
+      ).resolves.toEqual({ status: "refused", reason: "invalid-input" });
+    }
+    await expect(
+      subject.invoke(DESKTOP_LLM_SELECTION_APPLY_CHANNEL, subject.trustedEvent, {
+        provider: "openrouter",
+        model: "loopback-model",
+        endpoint: { mode: "custom", value: "http://127.0.0.1:11434/v1" },
+      }),
+    ).resolves.toEqual({ status: "configured", runtimeReady: true });
+  });
+
+  it("passes an optional matching selection through the credential transaction", async () => {
+    const subject = harness();
+    const selection = {
+      provider: "openrouter",
+      model: "athlete-model",
+      endpoint: { mode: "default" },
+    };
+
+    await expect(
+      subject.invoke(DESKTOP_CREDENTIAL_WRITE_CHANNEL, subject.trustedEvent, {
+        slot: "openrouter",
+        value: "synthetic",
+        selection,
+      }),
+    ).resolves.toEqual({ slot: "openrouter", status: "configured", runtimeReady: true });
+    expect(subject.vault.writeCredential).toHaveBeenCalledWith({
+      slot: "openrouter",
+      value: "synthetic",
+      selection,
+    });
+    await expect(
+      subject.invoke(DESKTOP_CREDENTIAL_WRITE_CHANNEL, subject.trustedEvent, {
+        slot: "anthropic",
+        value: "synthetic",
+        selection,
+      }),
+    ).rejects.toBeInstanceOf(TypeError);
+    await expect(
+      subject.invoke(DESKTOP_CREDENTIAL_WRITE_CHANNEL, subject.trustedEvent, {
+        slot: "intervals-icu",
+        value: "synthetic",
+        selection,
+      }),
+    ).rejects.toBeInstanceOf(TypeError);
+  });
+
   it("gates strict ChatGPT status and login invokes", async () => {
     const subject = harness();
     await expect(
       subject.invoke(DESKTOP_CHATGPT_STATUS_CHANNEL, subject.trustedEvent),
     ).resolves.toEqual({ state: "configured", runtimeReady: true });
     await expect(
-      subject.invoke(DESKTOP_CHATGPT_LOGIN_CHANNEL, subject.trustedEvent),
+      subject.invoke(DESKTOP_CHATGPT_LOGIN_CHANNEL, subject.trustedEvent, {
+        provider: "openai-codex",
+        model: "gpt-5.5",
+        endpoint: { mode: "automatic" },
+      }),
     ).resolves.toEqual({ status: "configured", runtimeReady: true });
     await expect(
       subject.invoke(DESKTOP_CHATGPT_LOGIN_CHANNEL, {} as IpcMainInvokeEvent),
@@ -226,7 +555,7 @@ describe("desktop onboarding IPC", () => {
       subject.invoke(DESKTOP_CHATGPT_STATUS_CHANNEL, subject.trustedEvent, null),
     ).rejects.toBeInstanceOf(TypeError);
     await expect(
-      subject.invoke(DESKTOP_CHATGPT_LOGIN_CHANNEL, subject.trustedEvent, null),
+      subject.invoke(DESKTOP_CHATGPT_LOGIN_CHANNEL, subject.trustedEvent),
     ).rejects.toBeInstanceOf(TypeError);
     expect(subject.chatGptAuth.status).toHaveBeenCalledOnce();
     expect(subject.chatGptAuth.login).toHaveBeenCalledOnce();
@@ -258,8 +587,12 @@ describe("desktop onboarding IPC", () => {
         slot: "anthropic",
         value: "synthetic",
       }),
-    ).resolves.toEqual({ slot: "anthropic", status: "configured", runtimeReady: true });
+    ).resolves.toEqual({ slot: "anthropic", status: "configured", runtimeReady: false });
     expect(subject.vault.writeCredential).toHaveBeenCalledTimes(1);
+    expect(subject.vault.writeCredential).toHaveBeenCalledWith(
+      { slot: "anthropic", value: "synthetic" },
+      { activate: false },
+    );
   });
 
   it("minimizes failures without exposing raw errors", async () => {
@@ -296,10 +629,10 @@ describe("desktop onboarding IPC", () => {
     ).resolves.toEqual([]);
   });
 
-  it("disposes only its six handlers", () => {
+  it("disposes only its eight handlers", () => {
     const subject = harness();
     subject.dispose();
     expect(subject.handlers.size).toBe(0);
-    expect(subject.ipcMain.removeHandler).toHaveBeenCalledTimes(6);
+    expect(subject.ipcMain.removeHandler).toHaveBeenCalledTimes(8);
   });
 });

--- a/apps/desktop/tests/preload-auth.test.ts
+++ b/apps/desktop/tests/preload-auth.test.ts
@@ -41,13 +41,62 @@ interface AuthBridge {
   getDaemonConnection(failedGeneration?: number): Promise<unknown>;
   credentialStatuses(): Promise<unknown>;
   retryFailedCredentials(): Promise<unknown>;
+  writeCredential(input: unknown): Promise<unknown>;
+  llmConfiguration(): Promise<unknown>;
+  applyLlmSelection(input: unknown): Promise<unknown>;
   releaseNotes(): Promise<unknown>;
   chatgptStatus(): Promise<unknown>;
-  chatgptLogin(): Promise<unknown>;
+  chatgptLogin(input: unknown): Promise<unknown>;
   getUpdateState(): Promise<unknown>;
   checkForUpdates(): Promise<unknown>;
   restartToUpdate(): Promise<unknown>;
   onUpdateState(listener: (state: unknown) => void): () => void;
+}
+
+const chatGptSelection = {
+  provider: "openai-codex",
+  model: "gpt-5.5",
+  endpoint: { mode: "automatic" },
+} as const;
+
+const providerOrder = [
+  "anthropic",
+  "openai",
+  "google",
+  "openai-codex",
+  "deepseek",
+  "qwen",
+  "minimax",
+  "kimi",
+  "zai",
+  "openrouter",
+] as const;
+
+const defaultEndpointProviders = new Set([
+  "deepseek",
+  "qwen",
+  "minimax",
+  "kimi",
+  "zai",
+  "openrouter",
+]);
+
+function llmConfiguration() {
+  return {
+    schemaVersion: 1,
+    providers: providerOrder.map((provider) => {
+      const defaultModel = `${provider}-default`;
+      return {
+        provider,
+        defaultModel,
+        models: [{ value: defaultModel, label: `${provider} default` }],
+        ...(defaultEndpointProviders.has(provider)
+          ? { defaultBaseUrl: `https://${provider}.example.invalid/v1` }
+          : {}),
+      };
+    }),
+    active: { provider: "anthropic", model: "athlete-custom-model" },
+  };
 }
 
 let bridge: AuthBridge;
@@ -99,12 +148,14 @@ describe("desktop preload ChatGPT auth", () => {
     expect(Object.keys(mocks.exposed)).toEqual(["enduragentAuth"]);
     expect(Object.keys(bridge).sort()).toEqual(
       [
+        "applyLlmSelection",
         "chatgptLogin",
         "chatgptStatus",
         "chooseImportFiles",
         "credentialStatuses",
         "getUpdateState",
         "getDaemonConnection",
+        "llmConfiguration",
         "checkForUpdates",
         "onDroppedImportFiles",
         "onUpdateState",
@@ -420,6 +471,182 @@ describe("desktop preload ChatGPT auth", () => {
     ]);
   });
 
+  it("copies the bounded model catalogue and active selection from its private channel", async () => {
+    const configuration = llmConfiguration();
+    mocks.invoke.mockResolvedValueOnce(configuration);
+
+    const copied = (await bridge.llmConfiguration()) as typeof configuration;
+
+    expect(copied).toEqual(configuration);
+    expect(copied).not.toBe(configuration);
+    expect(copied.providers).not.toBe(configuration.providers);
+    expect(copied.providers[0]?.models).not.toBe(configuration.providers[0]?.models);
+    expect(mocks.invoke).toHaveBeenCalledWith("enduragent:onboarding:llm-configuration");
+  });
+
+  it("normalizes strict selections and credential writes before invoking main", async () => {
+    mocks.invoke
+      .mockResolvedValueOnce({ status: "configured", runtimeReady: true })
+      .mockResolvedValueOnce({
+        slot: "openrouter",
+        status: "configured",
+        runtimeReady: true,
+      });
+    const selection = {
+      provider: "openrouter",
+      model: "  athlete-model  ",
+      endpoint: { mode: "custom", value: "  https://models.example.invalid/v1  " },
+    };
+
+    await expect(bridge.applyLlmSelection(selection)).resolves.toEqual({
+      status: "configured",
+      runtimeReady: true,
+    });
+    await expect(
+      bridge.writeCredential({
+        slot: "openrouter",
+        value: "obviously-fake-key",
+        selection,
+      }),
+    ).resolves.toMatchObject({ status: "configured" });
+    const normalized = {
+      provider: "openrouter",
+      model: "athlete-model",
+      endpoint: { mode: "custom", value: "https://models.example.invalid/v1" },
+    };
+    expect(mocks.invoke.mock.calls).toEqual([
+      ["enduragent:onboarding:llm-selection-apply", normalized],
+      [
+        "enduragent:onboarding:credential-write",
+        { slot: "openrouter", value: "obviously-fake-key", selection: normalized },
+      ],
+    ]);
+  });
+
+  it("accepts a securely stored inactive credential result", async () => {
+    mocks.invoke.mockResolvedValueOnce({
+      slot: "anthropic",
+      status: "configured",
+      runtimeReady: false,
+    });
+
+    await expect(
+      bridge.writeCredential({
+        slot: "anthropic",
+        value: "obviously-fake-key",
+      }),
+    ).resolves.toEqual({
+      slot: "anthropic",
+      status: "configured",
+      runtimeReady: false,
+    });
+  });
+
+  it("rejects malformed model and endpoint inputs before IPC", async () => {
+    const malformed = [
+      { provider: "anthropic", model: "", endpoint: { mode: "automatic" } },
+      { provider: "anthropic", model: "x".repeat(513), endpoint: { mode: "automatic" } },
+      { provider: "anthropic", model: "bad\u0000model", endpoint: { mode: "automatic" } },
+      { provider: "anthropic", model: "\tmodel", endpoint: { mode: "automatic" } },
+      { provider: "anthropic", model: "model", endpoint: { mode: "default" } },
+      {
+        provider: "openrouter",
+        model: "model",
+        endpoint: { mode: "custom", value: "http://models.example.invalid/v1" },
+      },
+      {
+        provider: "openrouter",
+        model: "model",
+        endpoint: { mode: "custom", value: "https://user:secret@example.invalid/v1" },
+      },
+      {
+        provider: "openrouter",
+        model: "model",
+        endpoint: { mode: "custom", value: "https://example.invalid/v1?secret=value" },
+      },
+      {
+        provider: "openrouter",
+        model: "model",
+        endpoint: { mode: "custom", value: "https://example.invalid/v1#" },
+      },
+      {
+        provider: "openrouter",
+        model: "model",
+        endpoint: { mode: "custom", value: "https://example.invalid/v1#secret" },
+      },
+      {
+        provider: "openrouter",
+        model: "model",
+        endpoint: { mode: "custom", value: `https://example.invalid/${"x".repeat(4_096)}` },
+      },
+      {
+        provider: "openrouter",
+        model: "model",
+        endpoint: { mode: "automatic", extra: true },
+      },
+    ];
+
+    for (const selection of malformed) {
+      await expect(bridge.applyLlmSelection(selection)).rejects.toBeInstanceOf(TypeError);
+    }
+    await expect(
+      bridge.writeCredential({
+        slot: "anthropic",
+        value: "obviously-fake-key",
+        selection: {
+          provider: "openrouter",
+          model: "model",
+          endpoint: { mode: "automatic" },
+        },
+      }),
+    ).rejects.toBeInstanceOf(TypeError);
+    await expect(
+      bridge.chatgptLogin({
+        provider: "anthropic",
+        model: "model",
+        endpoint: { mode: "automatic" },
+      }),
+    ).rejects.toBeInstanceOf(TypeError);
+    expect(mocks.invoke).not.toHaveBeenCalled();
+  });
+
+  it("rejects malformed privileged model responses without exposing extra fields", async () => {
+    const configuration = llmConfiguration();
+    const malformed = [
+      { ...configuration, secret: "private" },
+      {
+        ...configuration,
+        providers: configuration.providers.map((provider, index) =>
+          index === 0 ? { ...provider, rawBaseUrl: "https://private.invalid" } : provider,
+        ),
+      },
+      {
+        ...configuration,
+        providers: configuration.providers.map((provider, index) =>
+          index === 0 ? { ...provider, defaultModel: "not-in-models" } : provider,
+        ),
+      },
+      { ...configuration, active: { ...configuration.active, apiKey: "private" } },
+    ];
+    for (const value of malformed) {
+      mocks.invoke.mockResolvedValueOnce(value);
+      await expect(bridge.llmConfiguration()).rejects.toBeInstanceOf(TypeError);
+    }
+    for (const value of [
+      { status: "configured", runtimeReady: true, raw: "private" },
+      { status: "refused", reason: "storage-failed" },
+    ]) {
+      mocks.invoke.mockResolvedValueOnce(value);
+      await expect(
+        bridge.applyLlmSelection({
+          provider: "anthropic",
+          model: "model",
+          endpoint: { mode: "automatic" },
+        }),
+      ).rejects.toBeInstanceOf(TypeError);
+    }
+  });
+
   it("exposes strict status and configured results", async () => {
     mocks.invoke
       .mockResolvedValueOnce({ state: "configured", runtimeReady: false })
@@ -428,7 +655,7 @@ describe("desktop preload ChatGPT auth", () => {
       state: "configured",
       runtimeReady: false,
     });
-    await expect(bridge.chatgptLogin()).resolves.toEqual({
+    await expect(bridge.chatgptLogin(chatGptSelection)).resolves.toEqual({
       status: "configured",
       runtimeReady: true,
     });
@@ -440,7 +667,7 @@ describe("desktop preload ChatGPT auth", () => {
 
   it("accepts only closed refusal reasons and exact keys", async () => {
     mocks.invoke.mockResolvedValueOnce({ status: "refused", reason: "timed-out" });
-    await expect(bridge.chatgptLogin()).resolves.toEqual({
+    await expect(bridge.chatgptLogin(chatGptSelection)).resolves.toEqual({
       status: "refused",
       reason: "timed-out",
     });
@@ -453,7 +680,7 @@ describe("desktop preload ChatGPT auth", () => {
       mocks.invoke.mockResolvedValueOnce(value);
       const operation = Object.hasOwn(value, "state")
         ? bridge.chatgptStatus()
-        : bridge.chatgptLogin();
+        : bridge.chatgptLogin(chatGptSelection);
       await expect(operation).rejects.toBeInstanceOf(TypeError);
     }
   });

--- a/apps/desktop/tests/spend-meter.integration.test.ts
+++ b/apps/desktop/tests/spend-meter.integration.test.ts
@@ -294,6 +294,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop spend me
       };
     `);
     expect(state.bridgeKeys).toEqual([
+      "applyLlmSelection",
       "chatgptLogin",
       "chatgptStatus",
       "checkForUpdates",
@@ -301,6 +302,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop spend me
       "credentialStatuses",
       "getDaemonConnection",
       "getUpdateState",
+      "llmConfiguration",
       "onDroppedImportFiles",
       "onUpdateState",
       "releaseNotes",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -160,6 +160,7 @@ export type { DataSource } from "./config.js";
 export {
   COMPACT_MODEL_DEFAULTS,
   DEFAULT_MODELS,
+  LLM_MODEL_CATALOGUE,
   LLM_PROVIDERS,
   PROVIDER_BASE_URLS,
   contextWindowForModel,
@@ -168,6 +169,8 @@ export {
 } from "./runtime-config.js";
 export type {
   EffectiveRuntimeConfig,
+  LlmModelCatalogueEntry,
+  LlmModelOption,
   LlmProvider,
   RuntimeConfigPatch,
   RuntimeConfigResolverOptions,

--- a/packages/core/src/runtime-config.ts
+++ b/packages/core/src/runtime-config.ts
@@ -35,6 +35,132 @@ export const PROVIDER_BASE_URLS = {
   openrouter: "https://openrouter.ai/api/v1",
 } as const satisfies Partial<Record<LlmProvider, string>>;
 
+export interface LlmModelOption {
+  readonly value: string;
+  readonly label: string;
+  readonly hint?: string;
+}
+
+export interface LlmModelCatalogueEntry {
+  readonly provider: LlmProvider;
+  readonly label: string;
+  readonly hint?: string;
+  readonly defaultModel: string;
+  readonly models: readonly LlmModelOption[];
+  readonly defaultBaseUrl?: string;
+}
+
+export const LLM_MODEL_CATALOGUE: readonly LlmModelCatalogueEntry[] = [
+  {
+    provider: "anthropic",
+    label: "Anthropic (Claude)",
+    defaultModel: DEFAULT_MODELS.anthropic,
+    models: [
+      { value: "claude-sonnet-4-6", label: "Claude Sonnet 4.6", hint: "recommended" },
+      { value: "claude-haiku-4-5-20251001", label: "Claude Haiku 4.5", hint: "fast & cheap" },
+      { value: "claude-opus-4-8", label: "Claude Opus 4.8", hint: "most capable" },
+    ],
+  },
+  {
+    provider: "openai",
+    label: "OpenAI (GPT)",
+    defaultModel: DEFAULT_MODELS.openai,
+    models: [
+      { value: "gpt-5.5", label: "GPT-5.5", hint: "recommended" },
+      { value: "gpt-5.4-mini", label: "GPT-5.4 Mini", hint: "fast & cheap" },
+      { value: "gpt-5.4-nano", label: "GPT-5.4 Nano", hint: "cheapest" },
+    ],
+  },
+  {
+    provider: "google",
+    label: "Google (Gemini)",
+    defaultModel: DEFAULT_MODELS.google,
+    models: [
+      { value: "gemini-3.5-flash", label: "Gemini 3.5 Flash", hint: "recommended" },
+      { value: "gemini-3.1-pro-preview", label: "Gemini 3.1 Pro", hint: "most capable" },
+      { value: "gemini-3.1-flash-lite", label: "Gemini 3.1 Flash Lite", hint: "cheapest" },
+    ],
+  },
+  {
+    provider: "openai-codex",
+    label: "OpenAI Codex (ChatGPT subscription)",
+    hint: "experimental",
+    defaultModel: DEFAULT_MODELS["openai-codex"],
+    models: [
+      { value: "gpt-5.5", label: "GPT-5.5", hint: "recommended" },
+      { value: "gpt-5.4-mini", label: "GPT-5.4 Mini", hint: "faster" },
+    ],
+  },
+  {
+    provider: "deepseek",
+    label: "DeepSeek",
+    defaultModel: DEFAULT_MODELS.deepseek,
+    defaultBaseUrl: PROVIDER_BASE_URLS.deepseek,
+    models: [
+      { value: "deepseek-v4-flash", label: "DeepSeek V4 Flash", hint: "recommended" },
+      { value: "deepseek-v4-pro", label: "DeepSeek V4 Pro", hint: "most capable" },
+    ],
+  },
+  {
+    provider: "qwen",
+    label: "Qwen (Alibaba Model Studio)",
+    defaultModel: DEFAULT_MODELS.qwen,
+    defaultBaseUrl: PROVIDER_BASE_URLS.qwen,
+    models: [
+      { value: "qwen3.5-plus", label: "Qwen3.5 Plus", hint: "recommended" },
+      { value: "qwen3-max", label: "Qwen3 Max", hint: "most capable" },
+    ],
+  },
+  {
+    provider: "minimax",
+    label: "MiniMax",
+    defaultModel: DEFAULT_MODELS.minimax,
+    defaultBaseUrl: PROVIDER_BASE_URLS.minimax,
+    models: [
+      { value: "MiniMax-M2.7", label: "MiniMax M2.7", hint: "recommended" },
+      { value: "MiniMax-M3", label: "MiniMax M3", hint: "most capable" },
+    ],
+  },
+  {
+    provider: "kimi",
+    label: "Kimi (Moonshot AI)",
+    defaultModel: DEFAULT_MODELS.kimi,
+    defaultBaseUrl: PROVIDER_BASE_URLS.kimi,
+    models: [
+      { value: "kimi-k2.6", label: "Kimi K2.6", hint: "recommended" },
+      { value: "kimi-k2.5", label: "Kimi K2.5", hint: "cheaper" },
+    ],
+  },
+  {
+    provider: "zai",
+    label: "Z.AI (GLM)",
+    defaultModel: DEFAULT_MODELS.zai,
+    defaultBaseUrl: PROVIDER_BASE_URLS.zai,
+    models: [
+      { value: "glm-4.7", label: "GLM-4.7", hint: "recommended" },
+      { value: "glm-5.2", label: "GLM-5.2", hint: "most capable" },
+      { value: "glm-4.7-flashx", label: "GLM-4.7 FlashX", hint: "cheapest" },
+    ],
+  },
+  {
+    provider: "openrouter",
+    label: "OpenRouter",
+    hint: "one key, many models",
+    defaultModel: DEFAULT_MODELS.openrouter,
+    defaultBaseUrl: PROVIDER_BASE_URLS.openrouter,
+    models: [
+      {
+        value: "deepseek/deepseek-v4-flash",
+        label: "DeepSeek V4 Flash (via OpenRouter)",
+        hint: "cheap",
+      },
+      { value: "z-ai/glm-5.2", label: "GLM-5.2 (via OpenRouter)", hint: "most capable" },
+      { value: "qwen/qwen3.7-plus", label: "Qwen3.7 Plus (via OpenRouter)" },
+      { value: "moonshotai/kimi-k2.6", label: "Kimi K2.6 (via OpenRouter)" },
+    ],
+  },
+] as const;
+
 export const COMPACT_MODEL_DEFAULTS = {
   anthropic: "claude-haiku-4-5-20251001",
   openrouter: "deepseek/deepseek-v4-flash",

--- a/packages/core/src/setup.ts
+++ b/packages/core/src/setup.ts
@@ -14,7 +14,7 @@ import { existsSync, mkdirSync, writeFileSync, readFileSync, unlinkSync, chmodSy
 import { stringify as toYaml } from "yaml";
 import { type BinaryConfig, binaryEnvVar } from "./binary.js";
 import { CONFIG_DIR, CONFIG_FILE, envInt, readConfigYaml } from "./config.js";
-import { DEFAULT_MODELS, PROVIDER_BASE_URLS } from "./runtime-config.js";
+import { LLM_MODEL_CATALOGUE } from "./runtime-config.js";
 import { captureAndPersistOperator } from "./channels/operator-capture.js";
 import { loadAllowedSenders } from "./channels/allowed-senders.js";
 import { runCodexLogin } from "./auth/openai-codex-login.js";
@@ -48,18 +48,11 @@ import {
 // TYPES
 // ============================================================================
 
-const PROVIDERS = [
-  { value: "anthropic", label: "Anthropic (Claude)" },
-  { value: "openai", label: "OpenAI (GPT)" },
-  { value: "google", label: "Google (Gemini)" },
-  { value: "openai-codex", label: "OpenAI Codex (ChatGPT subscription)", hint: "experimental" },
-  { value: "deepseek", label: "DeepSeek" },
-  { value: "qwen", label: "Qwen (Alibaba Model Studio)" },
-  { value: "minimax", label: "MiniMax" },
-  { value: "kimi", label: "Kimi (Moonshot AI)" },
-  { value: "zai", label: "Z.AI (GLM)" },
-  { value: "openrouter", label: "OpenRouter", hint: "one key, many models" },
-];
+const PROVIDERS = LLM_MODEL_CATALOGUE.map(({ provider, label, hint }) => ({
+  value: provider,
+  label,
+  ...(hint === undefined ? {} : { hint }),
+}));
 
 const API_KEY_LABELS: Record<string, string> = {
   anthropic: "Anthropic API key",
@@ -71,59 +64,6 @@ const API_KEY_LABELS: Record<string, string> = {
   kimi: "Moonshot API key",
   zai: "Z.AI API key",
   openrouter: "OpenRouter API key",
-};
-
-const MODELS: Record<string, { value: string; label: string; hint?: string }[]> = {
-  anthropic: [
-    { value: "claude-sonnet-4-6", label: "Claude Sonnet 4.6", hint: "recommended" },
-    { value: "claude-haiku-4-5-20251001", label: "Claude Haiku 4.5", hint: "fast & cheap" },
-    { value: "claude-opus-4-8", label: "Claude Opus 4.8", hint: "most capable" },
-  ],
-  openai: [
-    { value: "gpt-5.5", label: "GPT-5.5", hint: "recommended" },
-    { value: "gpt-5.4-mini", label: "GPT-5.4 Mini", hint: "fast & cheap" },
-    { value: "gpt-5.4-nano", label: "GPT-5.4 Nano", hint: "cheapest" },
-  ],
-  google: [
-    { value: "gemini-3.5-flash", label: "Gemini 3.5 Flash", hint: "recommended" },
-    { value: "gemini-3.1-pro-preview", label: "Gemini 3.1 Pro", hint: "most capable" },
-    { value: "gemini-3.1-flash-lite", label: "Gemini 3.1 Flash Lite", hint: "cheapest" },
-  ],
-  "openai-codex": [
-    { value: "gpt-5.5", label: "GPT-5.5", hint: "recommended" },
-    { value: "gpt-5.4-mini", label: "GPT-5.4 Mini", hint: "faster" },
-  ],
-  deepseek: [
-    { value: "deepseek-v4-flash", label: "DeepSeek V4 Flash", hint: "recommended" },
-    { value: "deepseek-v4-pro", label: "DeepSeek V4 Pro", hint: "most capable" },
-  ],
-  qwen: [
-    { value: "qwen3.5-plus", label: "Qwen3.5 Plus", hint: "recommended" },
-    { value: "qwen3-max", label: "Qwen3 Max", hint: "most capable" },
-  ],
-  minimax: [
-    { value: "MiniMax-M2.7", label: "MiniMax M2.7", hint: "recommended" },
-    { value: "MiniMax-M3", label: "MiniMax M3", hint: "most capable" },
-  ],
-  kimi: [
-    { value: "kimi-k2.6", label: "Kimi K2.6", hint: "recommended" },
-    { value: "kimi-k2.5", label: "Kimi K2.5", hint: "cheaper" },
-  ],
-  zai: [
-    { value: "glm-4.7", label: "GLM-4.7", hint: "recommended" },
-    { value: "glm-5.2", label: "GLM-5.2", hint: "most capable" },
-    { value: "glm-4.7-flashx", label: "GLM-4.7 FlashX", hint: "cheapest" },
-  ],
-  openrouter: [
-    {
-      value: "deepseek/deepseek-v4-flash",
-      label: "DeepSeek V4 Flash (via OpenRouter)",
-      hint: "cheap",
-    },
-    { value: "z-ai/glm-5.2", label: "GLM-5.2 (via OpenRouter)", hint: "most capable" },
-    { value: "qwen/qwen3.7-plus", label: "Qwen3.7 Plus (via OpenRouter)" },
-    { value: "moonshotai/kimi-k2.6", label: "Kimi K2.6 (via OpenRouter)" },
-  ],
 };
 
 const CUSTOM_MODEL_SENTINEL = "__custom__";
@@ -319,20 +259,21 @@ async function _runWizardCore(ctx: WizardCtx, binary: BinaryConfig): Promise<voi
   });
   handleCancel(providerResp, ctx, binary);
   const provider = providerResp as string;
+  const catalogue = LLM_MODEL_CATALOGUE.find((entry) => entry.provider === provider);
 
   // Model
   const sameProvider = provider === prevProvider;
-  const knownModel = MODELS[provider]?.some((m) => m.value === prevModel);
+  const knownModel = catalogue?.models.some((candidate) => candidate.value === prevModel);
   const initialModel =
     sameProvider && prevModel
       ? knownModel
         ? prevModel
         : CUSTOM_MODEL_SENTINEL
-      : DEFAULT_MODELS[provider as keyof typeof DEFAULT_MODELS];
+      : catalogue?.defaultModel;
   const modelResp = await select({
     message: "Model",
     options: [
-      ...(MODELS[provider] ?? []),
+      ...(catalogue?.models ?? []),
       { value: CUSTOM_MODEL_SENTINEL, label: "Other (type model name)" },
     ],
     initialValue: initialModel,
@@ -352,10 +293,10 @@ async function _runWizardCore(ctx: WizardCtx, binary: BinaryConfig): Promise<voi
   }
 
   // Base URL — only for OpenAI-compatible / direct providers that declare a
-  // default. The built-in providers (anthropic/openai/google/openai-codex) have
-  // no PROVIDER_BASE_URLS entry, so their prompt order is unchanged.
+  // default. The built-in providers have no default endpoint, so their prompt
+  // order is unchanged.
   let baseUrl: string | undefined;
-  const defaultBaseUrl = PROVIDER_BASE_URLS[provider as keyof typeof PROVIDER_BASE_URLS];
+  const defaultBaseUrl = catalogue?.defaultBaseUrl;
   if (defaultBaseUrl) {
     const prevBaseUrl = getString(previous, "llm", "base_url");
     const baseUrlResp = await text({

--- a/packages/core/tests/model-catalogue.test.ts
+++ b/packages/core/tests/model-catalogue.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_MODELS,
+  LLM_MODEL_CATALOGUE,
+  LLM_PROVIDERS,
+  PROVIDER_BASE_URLS,
+  resolveRuntimeConfig,
+} from "../src/runtime-config.js";
+
+describe("LLM model catalogue", () => {
+  it("covers providers in setup order with every default among its advisory options", () => {
+    expect(LLM_MODEL_CATALOGUE.map((entry) => entry.provider)).toEqual(LLM_PROVIDERS);
+    for (const entry of LLM_MODEL_CATALOGUE) {
+      expect(entry.defaultModel).toBe(DEFAULT_MODELS[entry.provider]);
+      expect(entry.models.map((model) => model.value)).toContain(entry.defaultModel);
+      expect(new Set(entry.models.map((model) => model.value)).size).toBe(entry.models.length);
+    }
+  });
+
+  it("projects only the resolver's declared provider defaults", () => {
+    for (const entry of LLM_MODEL_CATALOGUE) {
+      expect(entry.defaultBaseUrl).toBe(
+        PROVIDER_BASE_URLS[entry.provider as keyof typeof PROVIDER_BASE_URLS],
+      );
+    }
+  });
+
+  it("keeps the catalogue advisory by accepting a custom model", () => {
+    expect(
+      resolveRuntimeConfig({
+        llm: {
+          provider: "anthropic",
+          model: "athlete-custom-model",
+          apiKey: "obviously-fake-key",
+        },
+      }).llm.model,
+    ).toBe("athlete-custom-model");
+  });
+});


### PR DESCRIPTION
## Summary

- add one shared provider and model catalogue for Core, Desktop main, preload, and Setup
- add strict, redacted IPC for provider, model, and compatible endpoint selection
- preserve existing npm credentials, private endpoints, and custom ChatGPT profiles while keeping non-selected keys inactive
- keep per-provider Setup drafts through switches and retries without persisting secrets in the renderer

## Test plan

- [x] 174 focused Core, Desktop, preload, credential, and renderer tests
- [x] Core, Desktop main, and Desktop renderer typechecks
- [x] Desktop production build
- [x] dependency, trademark, format, lint, and staged-diff gates
- [ ] full CI suite
