### PR TITLE
Harden the Desktop package layout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,4 +114,5 @@ jobs:
       - name: Test Desktop IME composition
         run: pnpm --filter @enduragent/desktop exec vitest run tests/chat-panels.integration.test.ts --testNamePattern "preserves IME composition until committed Enter"
       - run: pnpm --filter @enduragent/desktop test:packaged-self-test
+      - run: pnpm --filter @enduragent/desktop verify:package-layout
       - run: pnpm --filter @enduragent/desktop run smoke:security -- --mode=packaged --output=/tmp/desktop-security-packaged

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -1,11 +1,19 @@
 appId: icu.enduragent.desktop
 productName: Enduragent
 asar: true
+electronLanguages:
+  - en
 directories:
   output: dist
 files:
   - out/**
   - package.json
+  - "!**/*.map"
+  - "!**/.env*"
+  - "!**/{test,tests,__tests__,fixture,fixtures,dev-fixture,dev-fixtures}/**"
+  - "!**/*.{test,spec}.{js,cjs,mjs,ts,cts,mts,jsx,tsx}"
+  - "!**/node_modules/vitest/**"
+  - "!**/node_modules/@vitest/**"
   - from: resources
     to: resources
     filter:

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -12,6 +12,8 @@ files:
   - "!**/.env*"
   - "!**/{test,tests,__tests__,fixture,fixtures,dev-fixture,dev-fixtures}/**"
   - "!**/*.{test,spec}.{js,cjs,mjs,ts,cts,mts,jsx,tsx}"
+  - "!**/vitest.config.{js,cjs,mjs,ts,cts,mts}"
+  - "!**/vitest.workspace.{js,cjs,mjs,ts,cts,mts}"
   - "!**/node_modules/vitest/**"
   - "!**/node_modules/@vitest/**"
   - from: resources

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -13,6 +13,7 @@
     "stage:extra-resources": "node scripts/stage-extra-resources.mjs",
     "test:self-test-resources": "vitest run tests/self-test-resources.test.ts",
     "test:packaged-self-test": "node scripts/verify-packaged-self-test.mjs",
+    "verify:package-layout": "node scripts/verify-package-layout.mjs",
     "smoke:runtime": "node scripts/electron-smoke.mjs runtime",
     "smoke:security": "node scripts/electron-smoke.mjs security",
     "accept:residency": "node ./scripts/accept-residency.mjs",
@@ -28,6 +29,7 @@
     "yaml": "^2.8.3"
   },
   "devDependencies": {
+    "@electron/asar": "3.4.1",
     "@enduragent/desktop-renderer": "workspace:*",
     "@enduragent/kernel": "workspace:*",
     "@types/node": "^25.6.0",

--- a/apps/desktop/scripts/verify-package-layout.d.mts
+++ b/apps/desktop/scripts/verify-package-layout.d.mts
@@ -1,0 +1,15 @@
+export interface BuilderAuthority {
+  readonly asarSourceRoot: string;
+  readonly externalSourceRoot: string;
+}
+
+export interface PackageLayoutOptions {
+  readonly desktopRoot?: string;
+}
+
+export function readBuilderAuthority(desktopRoot?: string): Promise<BuilderAuthority>;
+
+export function verifyPackageLayout(
+  application: string,
+  options?: PackageLayoutOptions,
+): Promise<void>;

--- a/apps/desktop/scripts/verify-package-layout.mjs
+++ b/apps/desktop/scripts/verify-package-layout.mjs
@@ -1,0 +1,579 @@
+import { createHash } from "node:crypto";
+import { lstat, readFile, readdir } from "node:fs/promises";
+import { isAbsolute, dirname, join, relative, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+import { extractFile, listPackage, statFile, uncache } from "@electron/asar";
+import { parse } from "yaml";
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+const canonicalDesktopRoot = resolve(scriptDirectory, "..");
+const canonicalApplication = join(canonicalDesktopRoot, "dist/mac-arm64/Enduragent.app");
+const requiredAsarFiles = [
+  "out/main/index.js",
+  "out/main/daemon-utility.js",
+  "out/preload/index.cjs",
+  "out/renderer/index.html",
+  "out/renderer/tray.html",
+  "package.json",
+  "resources/self-test/matrix.json",
+  "resources/self-test/matrix.sha256",
+];
+const requiredFilePatterns = [
+  "out/**",
+  "package.json",
+  "!**/*.map",
+  "!**/.env*",
+  "!**/{test,tests,__tests__,fixture,fixtures,dev-fixture,dev-fixtures}/**",
+  "!**/*.{test,spec}.{js,cjs,mjs,ts,cts,mts,jsx,tsx}",
+  "!**/node_modules/vitest/**",
+  "!**/node_modules/@vitest/**",
+];
+const reservedResourceNames = new Set([
+  "app.asar",
+  "app.asar.unpacked",
+  "electron.icns",
+  "en.lproj",
+]);
+const forbiddenDirectoryNames = new Set([
+  "test",
+  "tests",
+  "__tests__",
+  "fixture",
+  "fixtures",
+  "dev-fixture",
+  "dev-fixtures",
+  "vitest",
+  "@vitest",
+]);
+const knownSecretMarkers = [
+  "desktop-sentinel-model-key",
+  "private-token-marker",
+  "sentinel-anthropic-api-key",
+  "sentinel-openai-api-key",
+  "sentinel-google-generative-ai-api-key",
+  "sentinel-deepseek-api-key",
+  "sentinel-alibaba-api-key",
+  "sentinel-minimax-api-key",
+  "sentinel-moonshot-api-key",
+  "sentinel-zai-api-key",
+  "sentinel-openrouter-api-key",
+  "sentinel-llm-api-key",
+  "sentinel-intervals-api-key",
+  "sentinel-telegram-bot-token",
+  "sentinel-my-llm-key",
+  "synthetic-secret",
+];
+
+class PackageLayoutError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "PackageLayoutError";
+  }
+}
+
+function fail(message, path) {
+  const suffix = path === undefined ? "" : `: ${displayPath(path)}`;
+  throw new PackageLayoutError(`${message}${suffix}`);
+}
+
+function displayPath(path) {
+  const printable = Array.from(String(path).replaceAll("\\", "/"), (character) => {
+    const code = character.codePointAt(0);
+    return code !== undefined && (code < 32 || code === 127) ? "?" : character;
+  }).join("");
+  const normalized = printable.replace(/^\/+/u, "");
+  if (normalized.length <= 180) return normalized;
+  return `${normalized.slice(0, 177)}...`;
+}
+
+function exactObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function contained(root, path) {
+  const relation = relative(root, path);
+  return (
+    relation === "" ||
+    (relation !== ".." && !relation.startsWith(`..${sep}`) && !isAbsolute(relation))
+  );
+}
+
+function nested(left, right) {
+  return left !== right && contained(left, right);
+}
+
+async function safeLstat(path, label) {
+  try {
+    return await lstat(path);
+  } catch {
+    fail("missing or unreadable package entry", label);
+  }
+}
+
+async function safeReadFile(path, label) {
+  try {
+    return await readFile(path);
+  } catch {
+    fail("missing or unreadable package file", label);
+  }
+}
+
+async function safeReadDirectory(path, label) {
+  try {
+    return await readdir(path);
+  } catch {
+    fail("missing or unreadable package directory", label);
+  }
+}
+
+function assertRegularFile(stat, label) {
+  if (stat.isSymbolicLink()) fail("symbolic links are forbidden", label);
+  if (!stat.isFile()) fail("expected a regular file", label);
+}
+
+function assertDirectory(stat, label) {
+  if (stat.isSymbolicLink()) fail("symbolic links are forbidden", label);
+  if (!stat.isDirectory()) fail("expected a directory", label);
+}
+
+function validateRelativePath(path, label) {
+  const normalized = path.replaceAll("\\", "/").replace(/^\/+/u, "");
+  const segments = normalized.split("/");
+  if (
+    normalized.length === 0 ||
+    normalized.includes("\u0000") ||
+    segments.some((segment) => segment.length === 0 || segment === "." || segment === "..")
+  ) {
+    fail("invalid relative package path", label);
+  }
+  return normalized;
+}
+
+function forbiddenPathReason(path) {
+  const lower = path.toLowerCase();
+  const segments = lower.split("/");
+  const base = segments.at(-1) ?? "";
+  if (base.endsWith(".map")) return "source map";
+  if (base.startsWith(".env")) return "environment file";
+  if (segments.some((segment) => forbiddenDirectoryNames.has(segment))) {
+    return "test or fixture directory";
+  }
+  if (/(?:^|\.)(?:test|spec)\./u.test(base)) return "test or spec source";
+  return undefined;
+}
+
+function inspectPath(path, label) {
+  const reason = forbiddenPathReason(path);
+  if (reason !== undefined) fail(`forbidden ${reason}`, label);
+}
+
+function inspectContents(bytes, label) {
+  const text = bytes.toString("latin1").toLowerCase();
+  if (
+    knownSecretMarkers.some((marker) => text.includes(marker)) ||
+    /obviously-fake-[a-z0-9-]{1,96}key\b/u.test(text) ||
+    /(?:^|[^a-z0-9])sk-secret(?:[^a-z0-9]|$)/u.test(text)
+  ) {
+    fail("known plaintext secret marker", label);
+  }
+}
+
+function fileSet(value) {
+  if (!exactObject(value) || typeof value.from !== "string" || typeof value.to !== "string") {
+    fail("invalid builder FileSet");
+  }
+  return value;
+}
+
+function outputChild(desktopRoot, outputRoot, source, label) {
+  if (isAbsolute(source)) fail("builder source must be relative", label);
+  const resolved = resolve(desktopRoot, source);
+  if (resolved === outputRoot || !contained(outputRoot, resolved)) {
+    fail("builder source must be inside its output directory", label);
+  }
+  return resolved;
+}
+
+export async function readBuilderAuthority(desktopRoot = canonicalDesktopRoot) {
+  if (!isAbsolute(desktopRoot)) fail("desktop root must be absolute");
+  const configPath = join(desktopRoot, "electron-builder.yml");
+  const bytes = await safeReadFile(configPath, "electron-builder.yml");
+  let config;
+  try {
+    config = parse(bytes.toString("utf8"));
+  } catch {
+    fail("invalid builder configuration", "electron-builder.yml");
+  }
+  if (
+    !exactObject(config) ||
+    config.asar !== true ||
+    !Array.isArray(config.electronLanguages) ||
+    config.electronLanguages.length !== 1 ||
+    config.electronLanguages[0] !== "en" ||
+    !exactObject(config.directories) ||
+    config.directories.output !== "dist" ||
+    !Array.isArray(config.files) ||
+    !Array.isArray(config.extraResources)
+  ) {
+    fail("invalid builder packaging authority", "electron-builder.yml");
+  }
+
+  const patternEntries = config.files.filter((entry) => typeof entry === "string");
+  if (
+    patternEntries.length !== requiredFilePatterns.length ||
+    new Set(patternEntries).size !== patternEntries.length ||
+    requiredFilePatterns.some((pattern) => !patternEntries.includes(pattern))
+  ) {
+    fail("builder file exclusions are incomplete", "electron-builder.yml");
+  }
+
+  const configuredFileSets = config.files.filter((entry) => typeof entry !== "string").map(fileSet);
+  const resourceSets = configuredFileSets.filter(
+    (entry) => entry.from === "resources" && entry.to === "resources",
+  );
+  if (
+    resourceSets.length !== 1 ||
+    !Array.isArray(resourceSets[0].filter) ||
+    resourceSets[0].filter.length !== 2 ||
+    !resourceSets[0].filter.includes("trayTemplate.png") ||
+    !resourceSets[0].filter.includes("trayTemplate@2x.png")
+  ) {
+    fail("builder runtime resources are incomplete", "electron-builder.yml");
+  }
+  const asarSets = configuredFileSets.filter((entry) => entry.to === ".");
+  if (configuredFileSets.length !== 2 || asarSets.length !== 1) {
+    fail("builder ASAR staging authority is ambiguous", "electron-builder.yml");
+  }
+  if (Object.keys(asarSets[0]).some((key) => !["from", "to"].includes(key))) {
+    fail("builder ASAR staging authority is filtered", "electron-builder.yml");
+  }
+  if (config.extraResources.length !== 1) {
+    fail("builder external staging authority is ambiguous", "electron-builder.yml");
+  }
+  const externalSet = fileSet(config.extraResources[0]);
+  if (
+    externalSet.to !== "." ||
+    Object.keys(externalSet).some((key) => !["from", "to"].includes(key))
+  ) {
+    fail("builder external staging authority is filtered", "electron-builder.yml");
+  }
+
+  const outputRoot = resolve(desktopRoot, "dist");
+  const asarSourceRoot = outputChild(
+    desktopRoot,
+    outputRoot,
+    asarSets[0].from,
+    "electron-builder.yml/files",
+  );
+  const externalSourceRoot = outputChild(
+    desktopRoot,
+    outputRoot,
+    externalSet.from,
+    "electron-builder.yml/extraResources",
+  );
+  if (
+    asarSourceRoot === externalSourceRoot ||
+    nested(asarSourceRoot, externalSourceRoot) ||
+    nested(externalSourceRoot, asarSourceRoot)
+  ) {
+    fail("builder staging roots must be disjoint", "electron-builder.yml");
+  }
+  return { asarSourceRoot, externalSourceRoot };
+}
+
+async function collectTree(root, labelRoot, scan) {
+  const rootStat = await safeLstat(root, labelRoot);
+  assertDirectory(rootStat, labelRoot);
+  const tree = new Map();
+
+  async function visit(directory, relativeRoot) {
+    const names = (await safeReadDirectory(directory, labelRoot)).sort();
+    for (const name of names) {
+      const relativePath = validateRelativePath(
+        relativeRoot.length === 0 ? name : `${relativeRoot}/${name}`,
+        labelRoot,
+      );
+      const label = `${labelRoot}/${relativePath}`;
+      if (scan) inspectPath(relativePath, label);
+      const absolutePath = join(directory, name);
+      const stat = await safeLstat(absolutePath, label);
+      if (stat.isSymbolicLink()) fail("symbolic links are forbidden", label);
+      if (stat.isDirectory()) {
+        tree.set(relativePath, { type: "directory" });
+        await visit(absolutePath, relativePath);
+        continue;
+      }
+      if (!stat.isFile()) fail("unsupported package entry type", label);
+      const bytes = await safeReadFile(absolutePath, label);
+      if (scan) inspectContents(bytes, label);
+      tree.set(relativePath, { type: "file", bytes });
+    }
+  }
+
+  await visit(root, "");
+  return tree;
+}
+
+function safeAsarList(archivePath) {
+  try {
+    return listPackage(archivePath);
+  } catch {
+    fail("invalid ASAR archive", "Contents/Resources/app.asar");
+  }
+}
+
+function safeAsarStat(archivePath, path) {
+  try {
+    return statFile(archivePath, path, false);
+  } catch {
+    fail("invalid ASAR entry", `app.asar/${path}`);
+  }
+}
+
+function safeAsarExtract(archivePath, path) {
+  try {
+    return extractFile(archivePath, path, false);
+  } catch {
+    fail("unreadable ASAR entry", `app.asar/${path}`);
+  }
+}
+
+function collectAsar(archivePath) {
+  uncache(archivePath);
+  const tree = new Map();
+  for (const listedPath of safeAsarList(archivePath)) {
+    const path = validateRelativePath(listedPath, "Contents/Resources/app.asar");
+    if (tree.has(path)) fail("duplicate ASAR entry", `app.asar/${path}`);
+    const label = `app.asar/${path}`;
+    inspectPath(path, label);
+    const metadata = safeAsarStat(archivePath, path);
+    if ("link" in metadata) fail("symbolic links are forbidden", label);
+    if ("files" in metadata) {
+      tree.set(path, { type: "directory", unpacked: metadata.unpacked === true });
+      continue;
+    }
+    let bytes;
+    if (metadata.unpacked !== true) {
+      bytes = safeAsarExtract(archivePath, path);
+      inspectContents(bytes, label);
+    }
+    tree.set(path, { type: "file", unpacked: metadata.unpacked === true, bytes });
+  }
+  return tree;
+}
+
+async function validateUnpackedTree(resourcesRoot, asar, present) {
+  const expected = new Map();
+  for (const [path, entry] of asar) {
+    if (entry.type !== "file" || entry.unpacked !== true) continue;
+    const segments = path.split("/");
+    for (let index = 1; index < segments.length; index += 1) {
+      expected.set(segments.slice(0, index).join("/"), { type: "directory" });
+    }
+    expected.set(path, { type: "file" });
+  }
+  if (!present) {
+    if (expected.size > 0) {
+      fail("declared unpacked resources are missing", "Contents/Resources/app.asar.unpacked");
+    }
+    return;
+  }
+  const actual = await collectTree(
+    join(resourcesRoot, "app.asar.unpacked"),
+    "Contents/Resources/app.asar.unpacked",
+    true,
+  );
+  const expectedPaths = [...expected.keys()].sort();
+  const actualPaths = [...actual.keys()].sort();
+  if (
+    expectedPaths.length !== actualPaths.length ||
+    expectedPaths.some((path, index) => path !== actualPaths[index])
+  ) {
+    fail("undeclared unpacked resource", "Contents/Resources/app.asar.unpacked");
+  }
+  for (const path of expectedPaths) {
+    if (expected.get(path).type !== actual.get(path).type) {
+      fail("unpacked resource type differs from ASAR", `app.asar.unpacked/${path}`);
+    }
+  }
+}
+
+function compareStagedTree(expected, actual, actualRoot) {
+  const expectedPaths = [...expected.keys()].sort();
+  const actualPaths = [...actual.keys()].sort();
+  if (
+    expectedPaths.length !== actualPaths.length ||
+    expectedPaths.some((path, index) => path !== actualPaths[index])
+  ) {
+    fail("packaged external resource tree differs from staging", actualRoot);
+  }
+  for (const path of expectedPaths) {
+    const expectedEntry = expected.get(path);
+    const actualEntry = actual.get(path);
+    if (expectedEntry.type !== actualEntry.type) {
+      fail("packaged external resource type differs from staging", `${actualRoot}/${path}`);
+    }
+    if (expectedEntry.type === "file" && !expectedEntry.bytes.equals(actualEntry.bytes)) {
+      fail("packaged external resource bytes differ from staging", `${actualRoot}/${path}`);
+    }
+  }
+}
+
+function compareAsarStaging(expected, asar) {
+  for (const [path, expectedEntry] of expected) {
+    const actualEntry = asar.get(path);
+    if (
+      actualEntry === undefined ||
+      actualEntry.type !== expectedEntry.type ||
+      actualEntry.unpacked === true
+    ) {
+      fail("ASAR staging entry is missing or unpacked", `app.asar/${path}`);
+    }
+    if (
+      expectedEntry.type === "file" &&
+      (!Buffer.isBuffer(actualEntry.bytes) || !expectedEntry.bytes.equals(actualEntry.bytes))
+    ) {
+      fail("ASAR staging bytes differ from source", `app.asar/${path}`);
+    }
+  }
+}
+
+function validateRequiredAsarFiles(asar) {
+  for (const path of requiredAsarFiles) {
+    const entry = asar.get(path);
+    if (entry === undefined || entry.type !== "file" || entry.unpacked === true) {
+      fail("required runtime file is missing from ASAR", `app.asar/${path}`);
+    }
+  }
+  for (const path of asar.keys()) {
+    if (path.split("/").at(-1) === "self-test-runner.cjs") {
+      fail("self-test runner must remain external", `app.asar/${path}`);
+    }
+  }
+
+  const manifestBytes = asar.get("package.json").bytes;
+  let manifest;
+  try {
+    manifest = JSON.parse(manifestBytes.toString("utf8"));
+  } catch {
+    fail("packaged manifest is invalid", "app.asar/package.json");
+  }
+  if (!exactObject(manifest) || manifest.main !== "out/main/index.js") {
+    fail("packaged manifest has an invalid main entry", "app.asar/package.json");
+  }
+
+  const matrix = asar.get("resources/self-test/matrix.json").bytes;
+  const checksum = asar.get("resources/self-test/matrix.sha256").bytes;
+  const expectedChecksum = `${createHash("sha256").update(matrix).digest("hex")}  matrix.json\n`;
+  if (checksum.toString("utf8") !== expectedChecksum) {
+    fail("self-test checksum does not match its matrix", "app.asar/resources/self-test");
+  }
+}
+
+async function validateResourceEnvelope(resourcesRoot, externalSource) {
+  const names = (await safeReadDirectory(resourcesRoot, "Contents/Resources")).sort();
+  const sourceTopLevel = new Set([...externalSource.keys()].map((path) => path.split("/")[0]));
+  for (const name of sourceTopLevel) {
+    if (reservedResourceNames.has(name)) {
+      fail("external resources collide with reserved package entries", "dist/extra-resources");
+    }
+  }
+  const expected = new Set(["app.asar", "electron.icns", "en.lproj", ...sourceTopLevel]);
+  if (names.includes("app.asar.unpacked")) expected.add("app.asar.unpacked");
+  if (names.length !== expected.size || names.some((name) => !expected.has(name))) {
+    fail("undeclared package resource", "Contents/Resources");
+  }
+
+  const iconStat = await safeLstat(
+    join(resourcesRoot, "electron.icns"),
+    "Contents/Resources/electron.icns",
+  );
+  assertRegularFile(iconStat, "Contents/Resources/electron.icns");
+  await collectTree(join(resourcesRoot, "en.lproj"), "Contents/Resources/en.lproj", true);
+}
+
+export async function verifyPackageLayout(application, options = {}) {
+  if (!isAbsolute(application) || !application.endsWith(".app")) {
+    fail("application path must be one absolute .app path");
+  }
+  const desktopRoot = options.desktopRoot ?? canonicalDesktopRoot;
+  if (!isAbsolute(desktopRoot)) fail("desktop root must be absolute");
+
+  try {
+    const applicationStat = await safeLstat(application, "Enduragent.app");
+    assertDirectory(applicationStat, "Enduragent.app");
+    const contentsRoot = join(application, "Contents");
+    const contentsStat = await safeLstat(contentsRoot, "Contents");
+    assertDirectory(contentsStat, "Contents");
+    const resourcesRoot = join(contentsRoot, "Resources");
+    const resourcesStat = await safeLstat(resourcesRoot, "Contents/Resources");
+    assertDirectory(resourcesStat, "Contents/Resources");
+
+    const authority = await readBuilderAuthority(desktopRoot);
+    const [asarStaging, externalSource] = await Promise.all([
+      collectTree(authority.asarSourceRoot, "dist/ASAR-staging", false),
+      collectTree(authority.externalSourceRoot, "dist/extra-resources", false),
+    ]);
+    await validateResourceEnvelope(resourcesRoot, externalSource);
+
+    const archivePath = join(resourcesRoot, "app.asar");
+    const archiveStat = await safeLstat(archivePath, "Contents/Resources/app.asar");
+    assertRegularFile(archiveStat, "Contents/Resources/app.asar");
+    const asar = collectAsar(archivePath);
+    validateRequiredAsarFiles(asar);
+    compareAsarStaging(asarStaging, asar);
+
+    const externalPackaged = new Map();
+    for (const topLevel of new Set([...externalSource.keys()].map((path) => path.split("/")[0]))) {
+      const subtree = await collectTree(
+        join(resourcesRoot, topLevel),
+        `Contents/Resources/${topLevel}`,
+        true,
+      );
+      externalPackaged.set(topLevel, { type: "directory" });
+      for (const [path, entry] of subtree) {
+        externalPackaged.set(`${topLevel}/${path}`, entry);
+      }
+    }
+    compareStagedTree(externalSource, externalPackaged, "Contents/Resources");
+    const runner = externalPackaged.get("self-test/self-test-runner.cjs");
+    if (runner === undefined || runner.type !== "file") {
+      fail(
+        "external self-test runner is missing",
+        "Contents/Resources/self-test/self-test-runner.cjs",
+      );
+    }
+
+    const unpackedPresent = (await safeReadDirectory(resourcesRoot, "Contents/Resources")).includes(
+      "app.asar.unpacked",
+    );
+    await validateUnpackedTree(resourcesRoot, asar, unpackedPresent);
+  } catch (error) {
+    if (error instanceof PackageLayoutError) throw error;
+    fail("package layout verification failed");
+  }
+}
+
+function applicationArgument(args) {
+  if (args.length === 0) return canonicalApplication;
+  if (args.length !== 1 || !isAbsolute(args[0]) || !args[0].endsWith(".app")) {
+    fail("expected zero arguments or one absolute .app path");
+  }
+  return args[0];
+}
+
+async function main() {
+  try {
+    await verifyPackageLayout(applicationArgument(process.argv.slice(2)));
+    process.stdout.write("package layout verified\n");
+  } catch (error) {
+    const message =
+      error instanceof PackageLayoutError ? error.message : "package layout verification failed";
+    process.stderr.write(`${message}\n`);
+    process.exitCode = 1;
+  }
+}
+
+if (process.argv[1] !== undefined && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  await main();
+}

--- a/apps/desktop/scripts/verify-package-layout.mjs
+++ b/apps/desktop/scripts/verify-package-layout.mjs
@@ -25,6 +25,8 @@ const requiredFilePatterns = [
   "!**/.env*",
   "!**/{test,tests,__tests__,fixture,fixtures,dev-fixture,dev-fixtures}/**",
   "!**/*.{test,spec}.{js,cjs,mjs,ts,cts,mts,jsx,tsx}",
+  "!**/vitest.config.{js,cjs,mjs,ts,cts,mts}",
+  "!**/vitest.workspace.{js,cjs,mjs,ts,cts,mts}",
   "!**/node_modules/vitest/**",
   "!**/node_modules/@vitest/**",
 ];
@@ -159,6 +161,7 @@ function forbiddenPathReason(path) {
     return "test or fixture directory";
   }
   if (/(?:^|\.)(?:test|spec)\./u.test(base)) return "test or spec source";
+  if (/^vitest\.(?:config|workspace)\./u.test(base)) return "Vitest configuration";
   return undefined;
 }
 
@@ -216,6 +219,12 @@ export async function readBuilderAuthority(desktopRoot = canonicalDesktopRoot) {
     !Array.isArray(config.extraResources)
   ) {
     fail("invalid builder packaging authority", "electron-builder.yml");
+  }
+  if (
+    config.extraFiles !== undefined ||
+    (exactObject(config.mac) && config.mac.extraFiles !== undefined)
+  ) {
+    fail("alternate builder copy surfaces are forbidden", "electron-builder.yml");
   }
 
   const patternEntries = config.files.filter((entry) => typeof entry === "string");
@@ -484,11 +493,11 @@ async function validateResourceEnvelope(resourcesRoot, externalSource) {
     fail("undeclared package resource", "Contents/Resources");
   }
 
-  const iconStat = await safeLstat(
-    join(resourcesRoot, "electron.icns"),
-    "Contents/Resources/electron.icns",
-  );
-  assertRegularFile(iconStat, "Contents/Resources/electron.icns");
+  const iconPath = join(resourcesRoot, "electron.icns");
+  const iconLabel = "Contents/Resources/electron.icns";
+  const iconStat = await safeLstat(iconPath, iconLabel);
+  assertRegularFile(iconStat, iconLabel);
+  inspectContents(await safeReadFile(iconPath, iconLabel), iconLabel);
   await collectTree(join(resourcesRoot, "en.lproj"), "Contents/Resources/en.lproj", true);
 }
 

--- a/apps/desktop/tests/package-layout.test.ts
+++ b/apps/desktop/tests/package-layout.test.ts
@@ -1,0 +1,457 @@
+import { createHash } from "node:crypto";
+import { cp, mkdir, mkdtemp, rename, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createPackage, createPackageWithOptions } from "@electron/asar";
+import { afterEach, describe, expect, it } from "vitest";
+import { readBuilderAuthority, verifyPackageLayout } from "../scripts/verify-package-layout.mjs";
+
+const desktopRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const temporaryRoots: string[] = [];
+const exclusions = [
+  "!**/*.map",
+  "!**/.env*",
+  "!**/{test,tests,__tests__,fixture,fixtures,dev-fixture,dev-fixtures}/**",
+  "!**/*.{test,spec}.{js,cjs,mjs,ts,cts,mts,jsx,tsx}",
+  "!**/node_modules/vitest/**",
+  "!**/node_modules/@vitest/**",
+];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots.splice(0).map((root) => rm(root, { force: true, recursive: true })),
+  );
+});
+
+function checksum(bytes: Buffer): Buffer {
+  return Buffer.from(`${createHash("sha256").update(bytes).digest("hex")}  matrix.json\n`);
+}
+
+function builderYaml(
+  asarSource = "dist/self-test-asar",
+  externalSource = "dist/extra-resources",
+): string {
+  return [
+    "appId: icu.enduragent.desktop",
+    "productName: Enduragent",
+    "asar: true",
+    "electronLanguages:",
+    "  - en",
+    "directories:",
+    "  output: dist",
+    "files:",
+    "  - out/**",
+    "  - package.json",
+    ...exclusions.map((pattern) => `  - ${JSON.stringify(pattern)}`),
+    "  - from: resources",
+    "    to: resources",
+    "    filter:",
+    "      - trayTemplate.png",
+    "      - trayTemplate@2x.png",
+    `  - from: ${asarSource}`,
+    "    to: .",
+    "extraResources:",
+    `  - from: ${externalSource}`,
+    "    to: .",
+    "",
+  ].join("\n");
+}
+
+type SyntheticPackage = {
+  app: string;
+  archiveSource: string;
+  desktop: string;
+  externalPackaged: string;
+  externalSource: string;
+  resources: string;
+  rebuild: () => Promise<void>;
+  writeArchive: (path: string, bytes?: string | Buffer) => Promise<void>;
+};
+
+async function syntheticPackage(): Promise<SyntheticPackage> {
+  const root = await mkdtemp(join(tmpdir(), "desktop-package-layout-"));
+  temporaryRoots.push(root);
+  const desktop = join(root, "desktop");
+  const app = join(root, "Synthetic.app");
+  const resources = join(app, "Contents/Resources");
+  const archiveSource = join(root, "archive-source");
+  const asarSource = join(desktop, "dist/self-test-asar");
+  const externalSource = join(desktop, "dist/extra-resources");
+  const externalPackaged = join(resources, "self-test");
+  const matrix = Buffer.from('{"schemaVersion":1}\n');
+  const matrixChecksum = checksum(matrix);
+
+  await Promise.all([
+    mkdir(resources, { recursive: true }),
+    mkdir(join(resources, "en.lproj"), { recursive: true }),
+    mkdir(archiveSource, { recursive: true }),
+    mkdir(join(asarSource, "resources/self-test"), { recursive: true }),
+    mkdir(join(externalSource, "self-test"), { recursive: true }),
+    mkdir(desktop, { recursive: true }),
+  ]);
+  await Promise.all([
+    writeFile(join(desktop, "electron-builder.yml"), builderYaml()),
+    writeFile(join(resources, "electron.icns"), "synthetic icon"),
+    writeFile(join(asarSource, "resources/self-test/matrix.json"), matrix),
+    writeFile(join(asarSource, "resources/self-test/matrix.sha256"), matrixChecksum),
+    writeFile(join(externalSource, "self-test/matrix.json"), matrix),
+    writeFile(join(externalSource, "self-test/matrix.sha256"), matrixChecksum),
+    writeFile(
+      join(externalSource, "self-test/self-test-runner.cjs"),
+      "module.exports = { runSelfTest() { return { ok: true }; } };\n",
+    ),
+  ]);
+
+  const writeArchive = async (
+    path: string,
+    bytes: string | Buffer = "synthetic runtime\n",
+  ): Promise<void> => {
+    const target = join(archiveSource, path);
+    await mkdir(dirname(target), { recursive: true });
+    await writeFile(target, bytes);
+  };
+  await Promise.all([
+    writeArchive("out/main/index.js"),
+    writeArchive("out/main/daemon-utility.js"),
+    writeArchive("out/preload/index.cjs"),
+    writeArchive("out/renderer/index.html", "<!doctype html>\n"),
+    writeArchive("out/renderer/tray.html", "<!doctype html>\n"),
+    writeArchive("package.json", '{"name":"synthetic","main":"out/main/index.js"}\n'),
+    writeArchive("resources/self-test/matrix.json", matrix),
+    writeArchive("resources/self-test/matrix.sha256", matrixChecksum),
+  ]);
+
+  const rebuild = async (): Promise<void> => {
+    await rm(join(resources, "app.asar"), { force: true });
+    await createPackage(archiveSource, join(resources, "app.asar"));
+  };
+  await rebuild();
+  await cp(join(externalSource, "self-test"), externalPackaged, { recursive: true });
+  return {
+    app,
+    archiveSource,
+    desktop,
+    externalPackaged,
+    externalSource,
+    resources,
+    rebuild,
+    writeArchive,
+  };
+}
+
+describe("desktop package layout", () => {
+  it("accepts the complete canonical package envelope", async () => {
+    const fixture = await syntheticPackage();
+    await expect(
+      verifyPackageLayout(fixture.app, { desktopRoot: fixture.desktop }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("uses the YAML-declared disjoint staging roots as authority", async () => {
+    const fixture = await syntheticPackage();
+    const alternateAsar = join(fixture.desktop, "dist/inside-authority");
+    const alternateExternal = join(fixture.desktop, "dist/outside-authority");
+    await Promise.all([
+      rename(join(fixture.desktop, "dist/self-test-asar"), alternateAsar),
+      rename(fixture.externalSource, alternateExternal),
+    ]);
+    await writeFile(
+      join(fixture.desktop, "electron-builder.yml"),
+      builderYaml("dist/inside-authority", "dist/outside-authority"),
+    );
+    await expect(
+      verifyPackageLayout(fixture.app, { desktopRoot: fixture.desktop }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("rejects overlapping or escaping YAML staging roots", async () => {
+    const fixture = await syntheticPackage();
+    await writeFile(
+      join(fixture.desktop, "electron-builder.yml"),
+      builderYaml("dist/self-test-asar", "dist/self-test-asar/nested"),
+    );
+    await expect(
+      verifyPackageLayout(fixture.app, { desktopRoot: fixture.desktop }),
+    ).rejects.toThrow("builder staging roots must be disjoint");
+
+    await writeFile(
+      join(fixture.desktop, "electron-builder.yml"),
+      builderYaml("dist/self-test-asar", "../outside"),
+    );
+    await expect(
+      verifyPackageLayout(fixture.app, { desktopRoot: fixture.desktop }),
+    ).rejects.toThrow("builder source must be inside its output directory");
+  });
+
+  it.each(exclusions)("requires the builder exclusion %s", async (exclusion) => {
+    const fixture = await syntheticPackage();
+    const yaml = builderYaml().replace(`  - ${JSON.stringify(exclusion)}\n`, "");
+    await writeFile(join(fixture.desktop, "electron-builder.yml"), yaml);
+    await expect(
+      verifyPackageLayout(fixture.app, { desktopRoot: fixture.desktop }),
+    ).rejects.toThrow("builder file exclusions are incomplete");
+  });
+
+  it("validates the checked-in builder authority", async () => {
+    await expect(readBuilderAuthority(desktopRoot)).resolves.toMatchObject({
+      asarSourceRoot: join(desktopRoot, "dist/self-test-asar"),
+      externalSourceRoot: join(desktopRoot, "dist/extra-resources"),
+    });
+  });
+
+  it("pins the sole audited Electron locale", async () => {
+    const fixture = await syntheticPackage();
+    const yaml = builderYaml().replace("electronLanguages:\n  - en\n", "");
+    await writeFile(join(fixture.desktop, "electron-builder.yml"), yaml);
+    await expect(
+      verifyPackageLayout(fixture.app, { desktopRoot: fixture.desktop }),
+    ).rejects.toThrow("invalid builder packaging authority");
+
+    await writeFile(
+      join(fixture.desktop, "electron-builder.yml"),
+      builderYaml().replace("  - en\n", "  - en\n  - fr\n"),
+    );
+    await expect(
+      verifyPackageLayout(fixture.app, { desktopRoot: fixture.desktop }),
+    ).rejects.toThrow("invalid builder packaging authority");
+  });
+
+  it.each([
+    "debug.js.map",
+    ".env.production",
+    "test/helper.js",
+    "tests/helper.js",
+    "__tests__/helper.js",
+    "fixture/data.json",
+    "fixtures/data.json",
+    "dev-fixture/data.json",
+    "dev-fixtures/data.json",
+    "feature.test.js",
+    "feature.spec.ts",
+    "node_modules/vitest/index.js",
+    "node_modules/@vitest/runner/index.js",
+  ])("rejects forbidden ASAR path %s", async (path) => {
+    const fixture = await syntheticPackage();
+    await fixture.writeArchive(path);
+    await fixture.rebuild();
+    await expect(
+      verifyPackageLayout(fixture.app, { desktopRoot: fixture.desktop }),
+    ).rejects.toThrow(/forbidden/u);
+  });
+
+  it("rejects forbidden paths in external and unpacked resources", async () => {
+    const externalFixture = await syntheticPackage();
+    await mkdir(join(externalFixture.externalPackaged, "fixture"), { recursive: true });
+    await writeFile(join(externalFixture.externalPackaged, "fixture/private.json"), "{}\n");
+    await expect(
+      verifyPackageLayout(externalFixture.app, { desktopRoot: externalFixture.desktop }),
+    ).rejects.toThrow("forbidden test or fixture directory");
+
+    const unpackedFixture = await syntheticPackage();
+    const unpackedTest = join(
+      unpackedFixture.resources,
+      "app.asar.unpacked/node_modules/@vitest/runner.js",
+    );
+    await mkdir(dirname(unpackedTest), { recursive: true });
+    await writeFile(unpackedTest, "synthetic runtime\n");
+    await expect(
+      verifyPackageLayout(unpackedFixture.app, { desktopRoot: unpackedFixture.desktop }),
+    ).rejects.toThrow("forbidden test or fixture directory");
+  });
+
+  it.each([
+    "sentinel-anthropic-api-key",
+    "sentinel-telegram-bot-token",
+    "desktop-sentinel-model-key",
+    "synthetic-secret",
+    "obviously-fake-provider-key",
+    "sk-SECRET",
+    "private-token-marker",
+  ])("rejects known synthetic plaintext secret marker %s", async (marker) => {
+    const fixture = await syntheticPackage();
+    await fixture.writeArchive("out/main/private-marker.js", marker);
+    await fixture.rebuild();
+    await expect(
+      verifyPackageLayout(fixture.app, { desktopRoot: fixture.desktop }),
+    ).rejects.toThrow("known plaintext secret marker");
+  });
+
+  it("scans external and unpacked files for synthetic secret markers", async () => {
+    const externalFixture = await syntheticPackage();
+    await writeFile(
+      join(externalFixture.externalPackaged, "matrix.json"),
+      "sentinel-openai-api-key",
+    );
+    await expect(
+      verifyPackageLayout(externalFixture.app, { desktopRoot: externalFixture.desktop }),
+    ).rejects.toThrow("known plaintext secret marker");
+
+    const unpackedFixture = await syntheticPackage();
+    const nativeFile = join(unpackedFixture.resources, "app.asar.unpacked/native/addon.node");
+    await mkdir(dirname(nativeFile), { recursive: true });
+    await writeFile(nativeFile, "sentinel-intervals-api-key");
+    await expect(
+      verifyPackageLayout(unpackedFixture.app, { desktopRoot: unpackedFixture.desktop }),
+    ).rejects.toThrow("known plaintext secret marker");
+  });
+
+  it("allows only unpacked files declared by the ASAR header", async () => {
+    const declared = await syntheticPackage();
+    await declared.writeArchive("native/addon.node", "synthetic native bytes\n");
+    await rm(join(declared.resources, "app.asar"));
+    await createPackageWithOptions(declared.archiveSource, join(declared.resources, "app.asar"), {
+      unpack: "**/*.node",
+    });
+    await expect(
+      verifyPackageLayout(declared.app, { desktopRoot: declared.desktop }),
+    ).resolves.toBeUndefined();
+
+    const undeclared = await syntheticPackage();
+    const stale = join(undeclared.resources, "app.asar.unpacked/native/addon.node");
+    await mkdir(dirname(stale), { recursive: true });
+    await writeFile(stale, "synthetic native bytes\n");
+    await expect(
+      verifyPackageLayout(undeclared.app, { desktopRoot: undeclared.desktop }),
+    ).rejects.toThrow("undeclared unpacked resource");
+  });
+
+  it.each([
+    "out/main/index.js",
+    "out/main/daemon-utility.js",
+    "out/preload/index.cjs",
+    "out/renderer/index.html",
+    "out/renderer/tray.html",
+    "package.json",
+    "resources/self-test/matrix.json",
+    "resources/self-test/matrix.sha256",
+  ])("rejects missing required ASAR runtime %s", async (path) => {
+    const fixture = await syntheticPackage();
+    await rm(join(fixture.archiveSource, path));
+    await fixture.rebuild();
+    await expect(
+      verifyPackageLayout(fixture.app, { desktopRoot: fixture.desktop }),
+    ).rejects.toThrow("required runtime file is missing from ASAR");
+  });
+
+  it("rejects stale ASAR staging bytes", async () => {
+    const fixture = await syntheticPackage();
+    const changedMatrix = Buffer.from('{"schemaVersion":2}\n');
+    await fixture.writeArchive("resources/self-test/matrix.json", changedMatrix);
+    await fixture.writeArchive("resources/self-test/matrix.sha256", checksum(changedMatrix));
+    await fixture.rebuild();
+    await expect(
+      verifyPackageLayout(fixture.app, { desktopRoot: fixture.desktop }),
+    ).rejects.toThrow("ASAR staging bytes differ from source");
+  });
+
+  it("rejects missing, stale, and unexpected external staging", async () => {
+    const missing = await syntheticPackage();
+    await rm(join(missing.externalPackaged, "matrix.sha256"));
+    await expect(
+      verifyPackageLayout(missing.app, { desktopRoot: missing.desktop }),
+    ).rejects.toThrow("packaged external resource tree differs from staging");
+
+    const stale = await syntheticPackage();
+    await writeFile(join(stale.externalPackaged, "self-test-runner.cjs"), "module.exports = {};\n");
+    await expect(verifyPackageLayout(stale.app, { desktopRoot: stale.desktop })).rejects.toThrow(
+      "packaged external resource bytes differ from staging",
+    );
+
+    const unexpected = await syntheticPackage();
+    await writeFile(join(unexpected.externalPackaged, "unexpected.bin"), "unexpected\n");
+    await expect(
+      verifyPackageLayout(unexpected.app, { desktopRoot: unexpected.desktop }),
+    ).rejects.toThrow("packaged external resource tree differs from staging");
+  });
+
+  it("rejects undeclared top-level resources", async () => {
+    const fixture = await syntheticPackage();
+    await writeFile(join(fixture.resources, "stale-resource.json"), "{}\n");
+    await expect(
+      verifyPackageLayout(fixture.app, { desktopRoot: fixture.desktop }),
+    ).rejects.toThrow("undeclared package resource");
+  });
+
+  it("rejects undeclared locale directories and locale symlinks", async () => {
+    const undeclared = await syntheticPackage();
+    await mkdir(join(undeclared.resources, "fr.lproj"));
+    await expect(
+      verifyPackageLayout(undeclared.app, { desktopRoot: undeclared.desktop }),
+    ).rejects.toThrow("undeclared package resource");
+
+    const linked = await syntheticPackage();
+    await rm(join(linked.resources, "en.lproj"), { recursive: true });
+    await symlink(linked.resources, join(linked.resources, "en.lproj"));
+    await expect(verifyPackageLayout(linked.app, { desktopRoot: linked.desktop })).rejects.toThrow(
+      "symbolic links are forbidden",
+    );
+  });
+
+  it("requires app.asar to be a regular nonsymlink file", async () => {
+    const fixture = await syntheticPackage();
+    const archive = join(fixture.resources, "app.asar");
+    const target = join(dirname(fixture.app), "saved.asar");
+    await rename(archive, target);
+    await symlink(target, archive);
+    await expect(
+      verifyPackageLayout(fixture.app, { desktopRoot: fixture.desktop }),
+    ).rejects.toThrow("symbolic links are forbidden");
+  });
+
+  it("recursively rejects external and unpacked symlinks", async () => {
+    const external = await syntheticPackage();
+    await symlink(
+      join(external.externalPackaged, "matrix.json"),
+      join(external.externalPackaged, "matrix-link.json"),
+    );
+    await expect(
+      verifyPackageLayout(external.app, { desktopRoot: external.desktop }),
+    ).rejects.toThrow("symbolic links are forbidden");
+
+    const unpacked = await syntheticPackage();
+    const unpackedRoot = join(unpacked.resources, "app.asar.unpacked");
+    await mkdir(unpackedRoot);
+    await symlink(unpackedRoot, join(unpackedRoot, "loop"));
+    await expect(
+      verifyPackageLayout(unpacked.app, { desktopRoot: unpacked.desktop }),
+    ).rejects.toThrow("symbolic links are forbidden");
+  });
+
+  it("keeps the external runner out of app.asar", async () => {
+    const fixture = await syntheticPackage();
+    await fixture.writeArchive(
+      "resources/self-test/self-test-runner.cjs",
+      "module.exports = {};\n",
+    );
+    await fixture.rebuild();
+    await expect(
+      verifyPackageLayout(fixture.app, { desktopRoot: fixture.desktop }),
+    ).rejects.toThrow("self-test runner must remain external");
+  });
+
+  it("redacts absolute roots and secret contents from bounded errors", async () => {
+    const fixture = await syntheticPackage();
+    const marker = "sentinel-openrouter-api-key";
+    await fixture.writeArchive("out/main/private.js", marker);
+    await fixture.rebuild();
+    let message = "";
+    try {
+      await verifyPackageLayout(fixture.app, { desktopRoot: fixture.desktop });
+    } catch (error) {
+      message = (error as Error).message;
+    }
+    expect(message).toContain("app.asar/out/main/private.js");
+    expect(message.length).toBeLessThanOrEqual(256);
+    expect(message).not.toContain(fixture.app);
+    expect(message).not.toContain(fixture.desktop);
+    expect(message).not.toContain(marker);
+    expect(message).not.toContain(process.env.HOME ?? "unreachable-home");
+  });
+
+  it("rejects relative application paths before filesystem access", async () => {
+    await expect(verifyPackageLayout("dist/Enduragent.app")).rejects.toThrow(
+      "application path must be one absolute .app path",
+    );
+  });
+});

--- a/apps/desktop/tests/package-layout.test.ts
+++ b/apps/desktop/tests/package-layout.test.ts
@@ -14,6 +14,8 @@ const exclusions = [
   "!**/.env*",
   "!**/{test,tests,__tests__,fixture,fixtures,dev-fixture,dev-fixtures}/**",
   "!**/*.{test,spec}.{js,cjs,mjs,ts,cts,mts,jsx,tsx}",
+  "!**/vitest.config.{js,cjs,mjs,ts,cts,mts}",
+  "!**/vitest.workspace.{js,cjs,mjs,ts,cts,mts}",
   "!**/node_modules/vitest/**",
   "!**/node_modules/@vitest/**",
 ];
@@ -193,6 +195,29 @@ describe("desktop package layout", () => {
     ).rejects.toThrow("builder file exclusions are incomplete");
   });
 
+  it.each([
+    [
+      "top-level extraFiles",
+      ["extraFiles:", "  - from: dist/extra-files", "    to: leaked.test.js", ""].join("\n"),
+    ],
+    [
+      "mac.extraFiles",
+      [
+        "mac:",
+        "  extraFiles:",
+        "    - from: dist/extra-files",
+        "      to: leaked.test.js",
+        "",
+      ].join("\n"),
+    ],
+  ])("rejects the alternate builder copy surface %s", async (_label, addition) => {
+    const fixture = await syntheticPackage();
+    await writeFile(join(fixture.desktop, "electron-builder.yml"), `${builderYaml()}${addition}`);
+    await expect(
+      verifyPackageLayout(fixture.app, { desktopRoot: fixture.desktop }),
+    ).rejects.toThrow("alternate builder copy surfaces are forbidden");
+  });
+
   it("validates the checked-in builder authority", async () => {
     await expect(readBuilderAuthority(desktopRoot)).resolves.toMatchObject({
       asarSourceRoot: join(desktopRoot, "dist/self-test-asar"),
@@ -229,6 +254,8 @@ describe("desktop package layout", () => {
     "dev-fixtures/data.json",
     "feature.test.js",
     "feature.spec.ts",
+    "node_modules/@enduragent/sport-cycling/vitest.config.ts",
+    "node_modules/@enduragent/sport-cycling/vitest.workspace.mts",
     "node_modules/vitest/index.js",
     "node_modules/@vitest/runner/index.js",
   ])("rejects forbidden ASAR path %s", async (path) => {
@@ -293,6 +320,17 @@ describe("desktop package layout", () => {
     await writeFile(nativeFile, "sentinel-intervals-api-key");
     await expect(
       verifyPackageLayout(unpackedFixture.app, { desktopRoot: unpackedFixture.desktop }),
+    ).rejects.toThrow("known plaintext secret marker");
+  });
+
+  it("scans the packaged icon for synthetic secret markers", async () => {
+    const fixture = await syntheticPackage();
+    await writeFile(
+      join(fixture.resources, "electron.icns"),
+      "sentinel-google-generative-ai-api-key",
+    );
+    await expect(
+      verifyPackageLayout(fixture.app, { desktopRoot: fixture.desktop }),
     ).rejects.toThrow("known plaintext secret marker");
   });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,6 +99,9 @@ importers:
         specifier: ^2.8.3
         version: 2.8.3
     devDependencies:
+      '@electron/asar':
+        specifier: 3.4.1
+        version: 3.4.1
       '@enduragent/desktop-renderer':
         specifier: workspace:*
         version: link:../desktop-renderer


### PR DESCRIPTION
## Summary

- define a closed Electron packaging authority with English-only runtime resources
- reject test sources, fixture content, source maps, environment files, Vitest assets, known plaintext secret markers, symbolic links, undeclared unpacked files, and alternate builder copy surfaces
- compare packaged ASAR and external-resource bytes with their audited staging roots
- run the verifier in CI immediately after the packaged self-test

## Validation

- `pnpm --filter @enduragent/desktop exec vitest run tests/package-layout.test.ts` (58/58)
- `pnpm --filter @enduragent/desktop test` (343 passed, 7 skipped)
- `pnpm check:types`
- real unsigned `pnpm --filter @enduragent/desktop package:dir`
- canonical and explicit-path package-layout verification
- packaged self-test: 602 parity cases and 84 differential cases passed
- packaged security smoke: all seven assertions passed
- runtime/CI and security specialist reviews: PASS

## Release note

No changeset: this hardens package construction and CI verification without changing athlete-facing behavior.
