### PR TITLE
Add provider and model Settings

### DIFF
--- a/.changeset/coach-route-settings.md
+++ b/.changeset/coach-route-settings.md
@@ -1,0 +1,7 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Added Settings for viewing and changing the coach provider and model without repeating Setup.
+
+Keep Setup focused on credential and training-data recovery while provider and model changes use a dedicated coach settings dialog.

--- a/apps/desktop-renderer/src/index.ts
+++ b/apps/desktop-renderer/src/index.ts
@@ -9,6 +9,7 @@ import "./training-context/styles.css";
 import "./spend-meter/styles.css";
 import "./release-notes/styles.css";
 import "./update/styles.css";
+import "./settings/styles.css";
 import "./onboarding/onboarding.css";
 import "./ride-import.css";
 import { createChatController } from "./chat/controller.js";
@@ -28,6 +29,8 @@ import { createReleaseNotesController } from "./release-notes/controller.js";
 import { createReleaseNotesView } from "./release-notes/view.js";
 import { createDesktopUpdateController } from "./update/controller.js";
 import { createDesktopUpdateView } from "./update/view.js";
+import { createProviderModelSettingsController } from "./settings/provider-model-controller.js";
+import { createProviderModelSettingsView } from "./settings/provider-model-view.js";
 import {
   createRideImportController,
   mountResidentRideImport,
@@ -282,6 +285,16 @@ setup.addEventListener(
   "click",
   () => void onboardingCompletion.openManually(() => onboarding.open()),
 );
+const providerModelSettingsController = createProviderModelSettingsController({
+  load: () => window.enduragentAuth.llmConfiguration(),
+  apply: (selection) => window.enduragentAuth.applyLlmSelection(selection),
+  openSetup: () => setup.click(),
+  view: createProviderModelSettingsView({
+    document,
+    actionHost: topbarActions,
+    before: setup,
+  }),
+});
 const disposeDroppedRideImports = subscribeToDroppedRideImports({
   subscribe: onboardingBridge.onDroppedImportFiles,
   onboarding,
@@ -308,6 +321,7 @@ window.addEventListener(
   () => {
     releaseNotesController.dispose();
     desktopUpdateController.dispose();
+    providerModelSettingsController.dispose();
     disposeDroppedRideImports();
     onboarding.dispose();
     residentRideImport.dispose();

--- a/apps/desktop-renderer/src/settings/provider-model-controller.ts
+++ b/apps/desktop-renderer/src/settings/provider-model-controller.ts
@@ -1,0 +1,384 @@
+import type {
+  OnboardingLlmConfiguration,
+  OnboardingLlmProviderConfiguration,
+  OnboardingLlmSelection,
+  OnboardingLlmSelectionResult,
+} from "../onboarding/bridge.js";
+import { CUSTOM_MODEL_SELECTION } from "../onboarding/constants.js";
+
+export type ProviderModelValidationError =
+  | "model-required"
+  | "model-too-long"
+  | "model-control-characters";
+
+export type ProviderModelSaveError =
+  | Extract<OnboardingLlmSelectionResult, { readonly status: "refused" }>["reason"]
+  | "request-failed";
+
+export interface ProviderModelDraft {
+  readonly provider: OnboardingLlmProviderConfiguration;
+  readonly modelChoice: string;
+  readonly customModel: string;
+}
+
+export interface ProviderModelFormState {
+  readonly providers: readonly OnboardingLlmProviderConfiguration[];
+  readonly active: OnboardingLlmConfiguration["active"];
+  readonly draft: ProviderModelDraft | null;
+  readonly dirty: boolean;
+  readonly validationError: ProviderModelValidationError | null;
+}
+
+export type ProviderModelSettingsState =
+  | { readonly status: "closed" }
+  | { readonly status: "loading" }
+  | ({ readonly status: "ready" | "saving" | "saved" } & ProviderModelFormState)
+  | {
+      readonly status: "error";
+      readonly kind: "load";
+      readonly reason: "configuration-unavailable";
+    }
+  | ({
+      readonly status: "error";
+      readonly kind: "save";
+      readonly reason: ProviderModelSaveError;
+    } & ProviderModelFormState);
+
+export interface ProviderModelSettingsView {
+  bind(handlers: {
+    readonly onOpen: () => void;
+    readonly onClose: () => void;
+    readonly onRetry: () => void;
+    readonly onProviderChange: (provider: string) => void;
+    readonly onModelChange: (model: string) => void;
+    readonly onCustomModelChange: (model: string) => void;
+    readonly onSave: () => void;
+    readonly onOpenSetup: () => void;
+  }): void;
+  open(): void;
+  close(): void;
+  render(state: Exclude<ProviderModelSettingsState, { readonly status: "closed" }>): void;
+  dispose(): void;
+}
+
+export interface ProviderModelSettingsController {
+  activate(): Promise<void>;
+  close(): void;
+  state(): ProviderModelSettingsState;
+  dispose(): void;
+}
+
+interface EditableState {
+  readonly providers: readonly OnboardingLlmProviderConfiguration[];
+  readonly active: OnboardingLlmConfiguration["active"];
+  readonly draft: ProviderModelDraft | null;
+}
+
+function hasControlCharacters(value: string): boolean {
+  return Array.from(value).some((character) => {
+    const codePoint = character.codePointAt(0);
+    return codePoint !== undefined && (codePoint <= 31 || (codePoint >= 127 && codePoint <= 159));
+  });
+}
+
+function draftFor(
+  provider: OnboardingLlmProviderConfiguration,
+  model = provider.defaultModel,
+): ProviderModelDraft {
+  const known = provider.models.some((option) => option.value === model);
+  return {
+    provider,
+    modelChoice: known ? model : CUSTOM_MODEL_SELECTION,
+    customModel: known ? "" : model,
+  };
+}
+
+function selectedModel(draft: ProviderModelDraft): string {
+  return (
+    draft.modelChoice === CUSTOM_MODEL_SELECTION ? draft.customModel : draft.modelChoice
+  ).trim();
+}
+
+function validationError(draft: ProviderModelDraft | null): ProviderModelValidationError | null {
+  if (draft === null || draft.modelChoice !== CUSTOM_MODEL_SELECTION) return null;
+  if (hasControlCharacters(draft.customModel)) return "model-control-characters";
+  const model = draft.customModel.trim();
+  if (model.length === 0) return "model-required";
+  if (model.length > 512) return "model-too-long";
+  return null;
+}
+
+function isDirty(
+  active: OnboardingLlmConfiguration["active"],
+  draft: ProviderModelDraft | null,
+): boolean {
+  if (draft === null) return false;
+  if (active === null) return true;
+  return active.provider !== draft.provider.provider || active.model !== selectedModel(draft);
+}
+
+function formState(editable: EditableState): ProviderModelFormState {
+  return {
+    providers: editable.providers,
+    active: editable.active,
+    draft: editable.draft,
+    dirty: isDirty(editable.active, editable.draft),
+    validationError: validationError(editable.draft),
+  };
+}
+
+function editableState(state: ProviderModelSettingsState): EditableState | null {
+  if (
+    state.status === "ready" ||
+    state.status === "saving" ||
+    state.status === "saved" ||
+    (state.status === "error" && state.kind === "save")
+  ) {
+    return state;
+  }
+  return null;
+}
+
+export function createProviderModelSettingsController(input: {
+  readonly load: () => Promise<OnboardingLlmConfiguration>;
+  readonly apply: (selection: OnboardingLlmSelection) => Promise<OnboardingLlmSelectionResult>;
+  readonly openSetup: () => void;
+  readonly view: ProviderModelSettingsView;
+}): ProviderModelSettingsController {
+  let currentState: ProviderModelSettingsState = { status: "closed" };
+  let generation = 0;
+  let disposed = false;
+  let loadOperation: Promise<void> | undefined;
+  let saveOperation: Promise<void> | undefined;
+  let providerDrafts = new Map<string, ProviderModelDraft>();
+
+  const render = (state: Exclude<ProviderModelSettingsState, { status: "closed" }>): void => {
+    currentState = state;
+    input.view.render(state);
+  };
+
+  const startLoad = (): Promise<void> => {
+    if (disposed) return Promise.resolve();
+    const operationGeneration = ++generation;
+    render({ status: "loading" });
+    input.view.open();
+    const pending = Promise.resolve()
+      .then(() => input.load())
+      .then(
+        (configuration) => {
+          if (disposed || generation !== operationGeneration) return;
+          const activeProvider =
+            configuration.active === null
+              ? undefined
+              : configuration.providers.find(
+                  (provider) => provider.provider === configuration.active?.provider,
+                );
+          if (
+            configuration.providers.length === 0 ||
+            (configuration.active !== null && !activeProvider)
+          ) {
+            render({
+              status: "error",
+              kind: "load",
+              reason: "configuration-unavailable",
+            });
+            return;
+          }
+          providerDrafts = new Map();
+          const draft =
+            configuration.active === null
+              ? null
+              : draftFor(activeProvider!, configuration.active.model);
+          if (draft !== null) providerDrafts.set(draft.provider.provider, draft);
+          render({
+            status: "ready",
+            ...formState({
+              providers: configuration.providers,
+              active: configuration.active,
+              draft,
+            }),
+          });
+        },
+        () => {
+          if (!disposed && generation === operationGeneration) {
+            render({
+              status: "error",
+              kind: "load",
+              reason: "configuration-unavailable",
+            });
+          }
+        },
+      )
+      .finally(() => {
+        if (loadOperation === pending) loadOperation = undefined;
+      });
+    loadOperation = pending;
+    return pending;
+  };
+
+  const close = (): void => {
+    if (disposed) return;
+    ++generation;
+    loadOperation = undefined;
+    saveOperation = undefined;
+    currentState = { status: "closed" };
+    input.view.close();
+  };
+
+  const updateDraft = (draft: ProviderModelDraft): void => {
+    if (disposed || currentState.status === "saving") return;
+    const editable = editableState(currentState);
+    if (editable === null) return;
+    providerDrafts.set(draft.provider.provider, draft);
+    render({
+      status: "ready",
+      ...formState({ ...editable, draft }),
+    });
+  };
+
+  const changeProvider = (providerName: string): void => {
+    if (disposed || currentState.status === "saving") return;
+    const editable = editableState(currentState);
+    const provider = editable?.providers.find((entry) => entry.provider === providerName);
+    if (editable === null || provider === undefined) return;
+    updateDraft(providerDrafts.get(provider.provider) ?? draftFor(provider));
+  };
+
+  const changeModel = (model: string): void => {
+    if (disposed || currentState.status === "saving") return;
+    const editable = editableState(currentState);
+    const draft = editable?.draft;
+    if (
+      draft === null ||
+      draft === undefined ||
+      (model !== CUSTOM_MODEL_SELECTION &&
+        !draft.provider.models.some((option) => option.value === model))
+    ) {
+      return;
+    }
+    updateDraft({ ...draft, modelChoice: model });
+  };
+
+  const changeCustomModel = (model: string): void => {
+    if (disposed || currentState.status === "saving") return;
+    const editable = editableState(currentState);
+    const draft = editable?.draft;
+    if (draft === null || draft === undefined || draft.modelChoice !== CUSTOM_MODEL_SELECTION) {
+      return;
+    }
+    updateDraft({ ...draft, customModel: model });
+  };
+
+  const save = (): Promise<void> => {
+    if (disposed || saveOperation !== undefined) return saveOperation ?? Promise.resolve();
+    const editable = editableState(currentState);
+    if (editable === null || currentState.status === "saving") return Promise.resolve();
+    const form = formState(editable);
+    if (form.draft === null || !form.dirty || form.validationError !== null) {
+      return Promise.resolve();
+    }
+    const selection: OnboardingLlmSelection = {
+      provider: form.draft.provider.provider,
+      model: selectedModel(form.draft),
+      endpoint: { mode: "automatic" },
+    };
+    const operationGeneration = ++generation;
+    render({ status: "saving", ...form });
+    const pending = Promise.resolve()
+      .then(() => input.apply(selection))
+      .then(
+        (result) => {
+          if (disposed || generation !== operationGeneration) return;
+          if (result.status === "refused") {
+            render({
+              status: "error",
+              kind: "save",
+              reason: result.reason,
+              ...form,
+            });
+            return;
+          }
+          const active = { provider: selection.provider, model: selection.model };
+          render({
+            status: "saved",
+            ...formState({
+              providers: form.providers,
+              active,
+              draft: form.draft,
+            }),
+          });
+        },
+        () => {
+          if (!disposed && generation === operationGeneration) {
+            render({
+              status: "error",
+              kind: "save",
+              reason: "request-failed",
+              ...form,
+            });
+          }
+        },
+      )
+      .finally(() => {
+        if (saveOperation === pending) saveOperation = undefined;
+      });
+    saveOperation = pending;
+    return pending;
+  };
+
+  const retry = (): void => {
+    if (disposed) return;
+    if (currentState.status === "error" && currentState.kind === "load") {
+      void startLoad();
+      return;
+    }
+    if (currentState.status === "error" && currentState.kind === "save") void save();
+  };
+
+  const openSetup = (): void => {
+    if (
+      disposed ||
+      currentState.status !== "error" ||
+      currentState.kind !== "save" ||
+      currentState.reason !== "credential-required"
+    ) {
+      return;
+    }
+    close();
+    input.openSetup();
+  };
+
+  input.view.bind({
+    onOpen: () => void startLoad(),
+    onClose: close,
+    onRetry: retry,
+    onProviderChange: changeProvider,
+    onModelChange: changeModel,
+    onCustomModelChange: changeCustomModel,
+    onSave: () => void save(),
+    onOpenSetup: openSetup,
+  });
+
+  return {
+    activate() {
+      if (disposed) return Promise.resolve();
+      if (currentState.status !== "closed") {
+        input.view.open();
+        return loadOperation ?? saveOperation ?? Promise.resolve();
+      }
+      return startLoad();
+    },
+    close,
+    state: () => currentState,
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      ++generation;
+      loadOperation = undefined;
+      saveOperation = undefined;
+      currentState = { status: "closed" };
+      providerDrafts.clear();
+      input.view.dispose();
+    },
+  };
+}

--- a/apps/desktop-renderer/src/settings/provider-model-view.ts
+++ b/apps/desktop-renderer/src/settings/provider-model-view.ts
@@ -1,0 +1,431 @@
+import { CUSTOM_MODEL_SELECTION, ONBOARDING_LLM_PROVIDER_LABELS } from "../onboarding/constants.js";
+import type {
+  ProviderModelFormState,
+  ProviderModelSettingsState,
+  ProviderModelSettingsView,
+  ProviderModelValidationError,
+} from "./provider-model-controller.js";
+
+const VALIDATION_COPY: Readonly<Record<ProviderModelValidationError, string>> = {
+  "model-required": "Enter a model name.",
+  "model-too-long": "Model names must be 512 characters or fewer.",
+  "model-control-characters": "Model names can’t contain control characters.",
+};
+
+const SAVE_ERROR_COPY = {
+  "invalid-input": "That provider or model wasn’t accepted. Check the model name and try again.",
+  "credential-required":
+    "This provider needs a saved credential before it can coach you. Open Setup to add one.",
+  "runtime-unavailable": "Coach settings couldn’t become active. Try saving again.",
+  "request-failed": "Coach settings couldn’t be saved right now. Try again.",
+} as const;
+
+function element<K extends keyof HTMLElementTagNameMap>(
+  document: Document,
+  name: K,
+  className?: string,
+  text?: string,
+): HTMLElementTagNameMap[K] {
+  const value = document.createElement(name);
+  if (className !== undefined) value.className = className;
+  if (text !== undefined) value.textContent = text;
+  return value;
+}
+
+function formState(
+  state: Exclude<ProviderModelSettingsState, { readonly status: "closed" }>,
+): ProviderModelFormState | null {
+  if (
+    state.status === "ready" ||
+    state.status === "saving" ||
+    state.status === "saved" ||
+    (state.status === "error" && state.kind === "save")
+  ) {
+    return state;
+  }
+  return null;
+}
+
+function providerLabel(provider: ProviderModelFormState["providers"][number]["provider"]): string {
+  return ONBOARDING_LLM_PROVIDER_LABELS[provider];
+}
+
+function modelLabel(form: ProviderModelFormState): string {
+  const draft = form.draft;
+  if (draft === null) return "";
+  if (draft.modelChoice === CUSTOM_MODEL_SELECTION) {
+    return draft.customModel.trim() || "Choose a model";
+  }
+  return (
+    draft.provider.models.find((model) => model.value === draft.modelChoice)?.label ??
+    draft.modelChoice
+  );
+}
+
+export function createProviderModelSettingsView(input: {
+  readonly document: Document;
+  readonly actionHost: HTMLElement;
+  readonly before?: Node | null;
+}): ProviderModelSettingsView {
+  const opener = element(input.document, "button", "provider-model-settings-button", "Settings");
+  opener.type = "button";
+  opener.setAttribute("aria-label", "Coach settings");
+  opener.setAttribute("aria-haspopup", "dialog");
+  opener.setAttribute("aria-controls", "provider-model-settings-dialog");
+  opener.setAttribute("aria-expanded", "false");
+
+  const dialog = element(input.document, "dialog", "provider-model-settings-dialog");
+  dialog.id = "provider-model-settings-dialog";
+  dialog.setAttribute("aria-labelledby", "provider-model-settings-title");
+  dialog.setAttribute("aria-describedby", "provider-model-settings-intro");
+  dialog.setAttribute("aria-modal", "true");
+
+  const form = element(input.document, "form", "provider-model-settings");
+  const header = element(input.document, "header", "provider-model-settings__header");
+  const heading = element(input.document, "div");
+  const kicker = element(input.document, "p", "provider-model-settings__kicker", "Coach settings");
+  const title = element(input.document, "h2", undefined, "Provider and model");
+  title.id = "provider-model-settings-title";
+  const intro = element(
+    input.document,
+    "p",
+    "provider-model-settings__intro",
+    "Choose which provider and model power your coaching conversations.",
+  );
+  intro.id = "provider-model-settings-intro";
+  heading.append(kicker, title, intro);
+  const close = element(input.document, "button", "provider-model-settings__close", "Close");
+  close.type = "button";
+  close.setAttribute("aria-label", "Close coach settings");
+  header.append(heading, close);
+
+  const current = element(input.document, "p", "provider-model-settings__current");
+  const route = element(input.document, "div", "coach-route");
+  const routeHeading = element(input.document, "span", "coach-route__heading", "Coach route");
+  const routePath = element(input.document, "span", "coach-route__path");
+  const routeProvider = element(input.document, "span", "coach-route__provider");
+  const routeArrow = element(input.document, "span", "coach-route__arrow", "→");
+  routeArrow.setAttribute("aria-hidden", "true");
+  const routeModel = element(input.document, "span", "coach-route__model");
+  routePath.append(routeProvider, routeArrow, routeModel);
+  const routeState = element(input.document, "span", "coach-route__state");
+  route.append(routeHeading, routePath, routeState);
+
+  const fields = element(input.document, "div", "provider-model-settings__fields");
+  const providerField = element(input.document, "label", "provider-model-settings__field");
+  providerField.htmlFor = "provider-model-settings-provider";
+  providerField.append(
+    element(input.document, "span", "provider-model-settings__label", "Provider"),
+  );
+  const provider = element(input.document, "select");
+  provider.id = "provider-model-settings-provider";
+  provider.setAttribute("aria-describedby", "provider-model-settings-current");
+  providerField.append(provider);
+
+  const modelField = element(input.document, "label", "provider-model-settings__field");
+  modelField.htmlFor = "provider-model-settings-model";
+  modelField.append(element(input.document, "span", "provider-model-settings__label", "Model"));
+  const model = element(input.document, "select");
+  model.id = "provider-model-settings-model";
+  modelField.append(model);
+
+  const customField = element(
+    input.document,
+    "label",
+    "provider-model-settings__field provider-model-settings__custom",
+  );
+  customField.htmlFor = "provider-model-settings-custom-model";
+  customField.append(
+    element(input.document, "span", "provider-model-settings__label", "Custom model name"),
+  );
+  const customModel = element(input.document, "input");
+  customModel.id = "provider-model-settings-custom-model";
+  customModel.type = "text";
+  customModel.autocomplete = "off";
+  customModel.setAttribute("aria-describedby", "provider-model-settings-validation");
+  customField.append(customModel);
+
+  const validation = element(input.document, "p", "provider-model-settings__validation");
+  validation.id = "provider-model-settings-validation";
+  validation.setAttribute("aria-live", "polite");
+  fields.append(providerField, modelField, customField, validation);
+
+  const feedback = element(input.document, "p", "provider-model-settings__feedback");
+  feedback.setAttribute("role", "status");
+  feedback.setAttribute("aria-live", "polite");
+  feedback.setAttribute("aria-atomic", "true");
+
+  const actions = element(input.document, "footer", "provider-model-settings__actions");
+  const retry = element(input.document, "button", "provider-model-settings__retry", "Retry");
+  retry.type = "button";
+  const openSetup = element(
+    input.document,
+    "button",
+    "provider-model-settings__setup",
+    "Open Setup",
+  );
+  openSetup.type = "button";
+  const cancel = element(input.document, "button", "provider-model-settings__cancel", "Cancel");
+  cancel.type = "button";
+  const save = element(input.document, "button", "provider-model-settings__save", "Save changes");
+  save.type = "submit";
+  actions.append(retry, openSetup, cancel, save);
+  form.append(header, current, route, fields, feedback, actions);
+  dialog.append(form);
+
+  input.actionHost.insertBefore(opener, input.before ?? null);
+  input.document.body.append(dialog);
+
+  let disposed = false;
+  let saving = false;
+  let handlers:
+    | {
+        readonly onOpen: () => void;
+        readonly onClose: () => void;
+        readonly onRetry: () => void;
+        readonly onProviderChange: (provider: string) => void;
+        readonly onModelChange: (model: string) => void;
+        readonly onCustomModelChange: (model: string) => void;
+        readonly onSave: () => void;
+        readonly onOpenSetup: () => void;
+      }
+    | undefined;
+
+  const requestClose = (): void => {
+    if (!disposed && !saving) handlers?.onClose();
+  };
+  const onOpen = (): void => {
+    if (!disposed) handlers?.onOpen();
+  };
+  const onCancel = (event: Event): void => {
+    event.preventDefault();
+    requestClose();
+  };
+  const onBackdropClick = (event: MouseEvent): void => {
+    if (event.target === dialog) requestClose();
+  };
+  const onKeyDown = (event: KeyboardEvent): void => {
+    if (event.key !== "Tab") return;
+    const focusable = [close, provider, model, customModel, retry, openSetup, cancel, save].filter(
+      (control) =>
+        !control.disabled && !control.hidden && (control !== customModel || !customField.hidden),
+    );
+    if (focusable.length === 0) return;
+    const first = focusable[0]!;
+    const last = focusable[focusable.length - 1]!;
+    if (event.shiftKey && input.document.activeElement === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && input.document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  };
+  const onSubmit = (event: SubmitEvent): void => {
+    event.preventDefault();
+    if (!save.disabled && !disposed) handlers?.onSave();
+  };
+  const onProviderChange = (): void => {
+    if (!provider.disabled && !disposed) handlers?.onProviderChange(provider.value);
+  };
+  const onModelChange = (): void => {
+    if (model.disabled || disposed) return;
+    handlers?.onModelChange(model.value);
+    if (model.value === CUSTOM_MODEL_SELECTION) customModel.focus();
+  };
+  const onCustomModelChange = (): void => {
+    if (!customModel.disabled && !disposed) handlers?.onCustomModelChange(customModel.value);
+  };
+  const onRetry = (): void => {
+    if (!retry.disabled && !disposed) handlers?.onRetry();
+  };
+  const onOpenSetup = (): void => {
+    if (!openSetup.disabled && !disposed) handlers?.onOpenSetup();
+  };
+
+  opener.addEventListener("click", onOpen);
+  close.addEventListener("click", requestClose);
+  cancel.addEventListener("click", requestClose);
+  retry.addEventListener("click", onRetry);
+  openSetup.addEventListener("click", onOpenSetup);
+  provider.addEventListener("change", onProviderChange);
+  model.addEventListener("change", onModelChange);
+  customModel.addEventListener("input", onCustomModelChange);
+  form.addEventListener("submit", onSubmit);
+  dialog.addEventListener("cancel", onCancel);
+  dialog.addEventListener("click", onBackdropClick);
+  dialog.addEventListener("keydown", onKeyDown);
+
+  const renderProviderOptions = (state: ProviderModelFormState): void => {
+    const options: HTMLOptionElement[] = [];
+    if (state.draft === null) {
+      const placeholder = element(input.document, "option", undefined, "Choose a provider");
+      placeholder.value = "";
+      placeholder.disabled = true;
+      options.push(placeholder);
+    }
+    for (const entry of state.providers) {
+      const option = element(input.document, "option", undefined, providerLabel(entry.provider));
+      option.value = entry.provider;
+      options.push(option);
+    }
+    provider.replaceChildren(...options);
+    provider.value = state.draft?.provider.provider ?? "";
+  };
+
+  const renderModelOptions = (state: ProviderModelFormState): void => {
+    const options: HTMLOptionElement[] = [];
+    if (state.draft === null) {
+      const placeholder = element(input.document, "option", undefined, "Choose a provider first");
+      placeholder.value = "";
+      options.push(placeholder);
+    } else {
+      for (const entry of state.draft.provider.models) {
+        const option = element(
+          input.document,
+          "option",
+          undefined,
+          entry.hint === undefined ? entry.label : `${entry.label} · ${entry.hint}`,
+        );
+        option.value = entry.value;
+        options.push(option);
+      }
+      const customOption = element(input.document, "option", undefined, "Other model…");
+      customOption.value = CUSTOM_MODEL_SELECTION;
+      options.push(customOption);
+    }
+    model.replaceChildren(...options);
+    model.value = state.draft?.modelChoice ?? "";
+  };
+
+  return {
+    bind(nextHandlers) {
+      handlers = nextHandlers;
+    },
+    open() {
+      if (disposed || dialog.open) return;
+      dialog.showModal();
+      opener.setAttribute("aria-expanded", "true");
+      close.focus();
+    },
+    close() {
+      if (disposed) return;
+      if (dialog.open) dialog.close();
+      opener.setAttribute("aria-expanded", "false");
+      opener.focus();
+    },
+    render(state) {
+      if (disposed) return;
+      const editable = formState(state);
+      saving = state.status === "saving";
+      const loading = state.status === "loading";
+      const loadError = state.status === "error" && state.kind === "load";
+      opener.disabled = saving;
+      close.disabled = saving;
+      cancel.disabled = saving;
+      provider.disabled = saving || editable?.draft === null;
+      model.disabled = saving || editable?.draft === null;
+      customModel.disabled = saving;
+      retry.disabled = saving;
+      openSetup.disabled = saving;
+      if (loading || saving) dialog.setAttribute("aria-busy", "true");
+      else dialog.removeAttribute("aria-busy");
+
+      current.hidden = editable === null;
+      route.hidden = editable === null;
+      fields.hidden = editable === null;
+      retry.hidden = !loadError;
+      openSetup.hidden = !(
+        state.status === "error" &&
+        state.kind === "save" &&
+        state.reason === "credential-required"
+      );
+
+      if (editable !== null) {
+        current.id = "provider-model-settings-current";
+        current.textContent =
+          editable.active === null
+            ? "Active coach settings are unavailable or not configured."
+            : `Currently active: ${providerLabel(editable.active.provider)} · ${editable.active.model}`;
+        renderProviderOptions(editable);
+        renderModelOptions(editable);
+        const hasDraft = editable.draft !== null;
+        provider.disabled = saving;
+        model.disabled = saving || !hasDraft;
+        routeProvider.textContent = hasDraft
+          ? providerLabel(editable.draft!.provider.provider)
+          : "Not configured";
+        routeArrow.hidden = !hasDraft;
+        routeModel.hidden = !hasDraft;
+        routeModel.textContent = modelLabel(editable);
+        routeState.textContent = !hasDraft ? "Not active" : editable.dirty ? "Unsaved" : "Active";
+        route.dataset.state = !hasDraft ? "empty" : editable.dirty ? "dirty" : "active";
+        route.setAttribute(
+          "aria-label",
+          hasDraft
+            ? `Coach route: ${routeProvider.textContent} to ${routeModel.textContent}. ${routeState.textContent}.`
+            : "Coach route: not configured.",
+        );
+        const custom = editable.draft?.modelChoice === CUSTOM_MODEL_SELECTION;
+        customField.hidden = !custom;
+        const customModelValue = editable.draft?.customModel ?? "";
+        if (customModel.value !== customModelValue) customModel.value = customModelValue;
+        validation.hidden = editable.validationError === null;
+        validation.textContent =
+          editable.validationError === null ? "" : VALIDATION_COPY[editable.validationError];
+        if (editable.validationError === null) customModel.removeAttribute("aria-invalid");
+        else customModel.setAttribute("aria-invalid", "true");
+      } else {
+        customField.hidden = true;
+        validation.hidden = true;
+        validation.textContent = "";
+        customModel.removeAttribute("aria-invalid");
+      }
+
+      feedback.hidden = false;
+      if (loading) {
+        feedback.textContent = "Loading coach settings…";
+      } else if (loadError) {
+        feedback.textContent = "Coach settings aren’t available right now. Try again.";
+      } else if (state.status === "saving") {
+        feedback.textContent = "Saving coach settings…";
+      } else if (state.status === "saved") {
+        feedback.textContent = "Coach settings saved.";
+      } else if (state.status === "error" && state.kind === "save") {
+        feedback.textContent = SAVE_ERROR_COPY[state.reason];
+      } else {
+        feedback.textContent = "";
+        feedback.hidden = true;
+      }
+
+      const canSave =
+        editable !== null &&
+        editable.draft !== null &&
+        editable.dirty &&
+        editable.validationError === null;
+      save.disabled = saving || !canSave;
+      save.textContent = saving ? "Saving…" : "Save changes";
+    },
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      saving = false;
+      handlers = undefined;
+      opener.removeEventListener("click", onOpen);
+      close.removeEventListener("click", requestClose);
+      cancel.removeEventListener("click", requestClose);
+      retry.removeEventListener("click", onRetry);
+      openSetup.removeEventListener("click", onOpenSetup);
+      provider.removeEventListener("change", onProviderChange);
+      model.removeEventListener("change", onModelChange);
+      customModel.removeEventListener("input", onCustomModelChange);
+      form.removeEventListener("submit", onSubmit);
+      dialog.removeEventListener("cancel", onCancel);
+      dialog.removeEventListener("click", onBackdropClick);
+      dialog.removeEventListener("keydown", onKeyDown);
+      if (dialog.open) dialog.close();
+      opener.remove();
+      dialog.remove();
+    },
+  };
+}

--- a/apps/desktop-renderer/src/settings/styles.css
+++ b/apps/desktop-renderer/src/settings/styles.css
@@ -1,0 +1,338 @@
+.provider-model-settings-button {
+  min-height: 34px;
+  padding: 0 12px;
+  white-space: nowrap;
+  border: 1px solid var(--line-strong);
+  border-radius: 999px;
+  color: var(--moss-strong);
+  background: var(--surface-solid);
+  cursor: pointer;
+}
+
+.provider-model-settings-button:disabled {
+  cursor: default;
+  opacity: 0.55;
+}
+
+.provider-model-settings-dialog {
+  width: min(580px, calc(100vw - 32px));
+  max-width: none;
+  max-height: min(760px, calc(100vh - 32px));
+  padding: 0;
+  overflow-y: auto;
+  border: 1px solid var(--line-strong);
+  border-radius: 20px;
+  color: var(--ink);
+  background: var(--surface-solid);
+  box-shadow: 0 28px 80px color-mix(in srgb, var(--ink) 25%, transparent);
+  animation: provider-model-settings-enter 160ms ease-out;
+}
+
+.provider-model-settings-dialog::backdrop {
+  background: color-mix(in srgb, var(--ink) 38%, transparent);
+}
+
+.provider-model-settings {
+  padding: 28px;
+}
+
+.provider-model-settings__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.provider-model-settings__kicker,
+.provider-model-settings__intro,
+.provider-model-settings__current,
+.provider-model-settings__validation,
+.provider-model-settings__feedback {
+  margin: 0;
+}
+
+.provider-model-settings__kicker {
+  margin-bottom: 8px;
+  color: var(--moss);
+  font-size: 11px;
+  font-weight: 720;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+.provider-model-settings__header h2 {
+  margin: 0;
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: clamp(26px, 5vw, 34px);
+  font-weight: 500;
+  line-height: 1.08;
+  letter-spacing: -0.025em;
+}
+
+.provider-model-settings__intro {
+  max-width: 440px;
+  margin-top: 10px;
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.provider-model-settings__close,
+.provider-model-settings__retry,
+.provider-model-settings__setup,
+.provider-model-settings__cancel,
+.provider-model-settings__save {
+  min-height: 38px;
+  padding: 0 15px;
+  white-space: nowrap;
+  border-radius: 999px;
+  cursor: pointer;
+}
+
+.provider-model-settings__close,
+.provider-model-settings__retry,
+.provider-model-settings__cancel {
+  border: 1px solid var(--line-strong);
+  color: var(--ink);
+  background: var(--surface-solid);
+}
+
+.provider-model-settings__setup {
+  border: 1px solid var(--coral);
+  color: var(--ink);
+  background: var(--surface-solid);
+}
+
+.provider-model-settings__save {
+  border: 1px solid var(--moss);
+  color: var(--surface-solid);
+  background: var(--moss);
+}
+
+.provider-model-settings__close:disabled,
+.provider-model-settings__retry:disabled,
+.provider-model-settings__setup:disabled,
+.provider-model-settings__cancel:disabled,
+.provider-model-settings__save:disabled {
+  cursor: default;
+  opacity: 0.5;
+}
+
+.provider-model-settings__current {
+  margin-top: 22px;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.coach-route {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 14px;
+  align-items: center;
+  margin-top: 11px;
+  padding: 13px 15px;
+  border: 1px solid color-mix(in srgb, var(--moss) 32%, var(--line));
+  border-radius: 12px;
+  background: var(--moss-soft);
+}
+
+.coach-route__heading,
+.coach-route__state {
+  font-size: 11px;
+  font-weight: 720;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.coach-route__heading {
+  color: var(--moss-strong);
+}
+
+.coach-route__path {
+  display: flex;
+  gap: 9px;
+  align-items: baseline;
+  min-width: 0;
+}
+
+.coach-route__provider {
+  font-weight: 680;
+}
+
+.coach-route__arrow {
+  color: var(--coral);
+  font-weight: 800;
+}
+
+.coach-route__model {
+  min-width: 0;
+  overflow: hidden;
+  font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.coach-route__state {
+  color: var(--muted);
+}
+
+.coach-route[data-state="dirty"] .coach-route__state {
+  color: var(--coral);
+}
+
+.provider-model-settings__fields {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+  margin-top: 22px;
+}
+
+.provider-model-settings__field {
+  display: grid;
+  gap: 8px;
+  min-width: 0;
+}
+
+.provider-model-settings__label {
+  font-size: 13px;
+  font-weight: 680;
+}
+
+.provider-model-settings__field select,
+.provider-model-settings__field input {
+  width: 100%;
+  min-width: 0;
+  min-height: 44px;
+  padding: 0 12px;
+  border: 1px solid var(--line-strong);
+  border-radius: 10px;
+  color: var(--ink);
+  background: var(--surface-solid);
+  font: inherit;
+}
+
+.provider-model-settings__field select:focus-visible {
+  outline: 3px solid var(--focus);
+  outline-offset: 2px;
+}
+
+.provider-model-settings__field select:disabled,
+.provider-model-settings__field input:disabled {
+  opacity: 0.6;
+}
+
+.provider-model-settings__custom,
+.provider-model-settings__validation {
+  grid-column: 1 / -1;
+}
+
+.provider-model-settings__validation {
+  color: var(--coral);
+  font-size: 13px;
+}
+
+.provider-model-settings__feedback {
+  min-height: 21px;
+  margin-top: 18px;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.provider-model-settings__feedback[hidden],
+.provider-model-settings__validation[hidden],
+.provider-model-settings__field[hidden],
+.provider-model-settings__retry[hidden],
+.provider-model-settings__setup[hidden] {
+  display: none;
+}
+
+.provider-model-settings__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+  margin-top: 16px;
+}
+
+.provider-model-settings__cancel {
+  margin-left: auto;
+}
+
+@keyframes provider-model-settings-enter {
+  from {
+    opacity: 0;
+    transform: translateY(8px) scale(0.99);
+  }
+}
+
+@media (max-width: 760px) {
+  .provider-model-settings-button {
+    width: 44px;
+    min-width: 44px;
+    padding: 0;
+    overflow: hidden;
+    font-size: 0;
+  }
+
+  .provider-model-settings-button::before {
+    font-size: 10px;
+    font-weight: 750;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    content: "Coach";
+  }
+
+  .provider-model-settings {
+    padding: 23px;
+  }
+
+  .provider-model-settings__fields {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .provider-model-settings__custom,
+  .provider-model-settings__validation {
+    grid-column: 1;
+  }
+
+  .coach-route {
+    grid-template-columns: 1fr auto;
+  }
+
+  .coach-route__path {
+    grid-column: 1 / -1;
+    grid-row: 2;
+  }
+}
+
+@media (max-width: 440px) {
+  .provider-model-settings-dialog {
+    width: calc(100vw - 20px);
+    max-height: calc(100vh - 20px);
+  }
+
+  .provider-model-settings {
+    padding: 20px;
+  }
+
+  .provider-model-settings__header {
+    gap: 14px;
+  }
+
+  .provider-model-settings__cancel {
+    margin-left: 0;
+  }
+
+  .provider-model-settings__save {
+    margin-left: auto;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .provider-model-settings-dialog {
+    animation: none;
+  }
+}

--- a/apps/desktop-renderer/tests/provider-model-settings.test.ts
+++ b/apps/desktop-renderer/tests/provider-model-settings.test.ts
@@ -1,0 +1,739 @@
+import { readFile } from "node:fs/promises";
+import { describe, expect, it, vi } from "vitest";
+import type {
+  OnboardingLlmConfiguration,
+  OnboardingLlmProviderConfiguration,
+  OnboardingLlmSelectionResult,
+} from "../src/onboarding/bridge.js";
+import { CUSTOM_MODEL_SELECTION } from "../src/onboarding/constants.js";
+import {
+  createProviderModelSettingsController,
+  type ProviderModelFormState,
+  type ProviderModelSettingsController,
+  type ProviderModelSettingsState,
+  type ProviderModelSettingsView,
+} from "../src/settings/provider-model-controller.js";
+import { createProviderModelSettingsView } from "../src/settings/provider-model-view.js";
+
+interface Deferred<T> {
+  readonly promise: Promise<T>;
+  resolve(value: T): void;
+  reject(error: unknown): void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+const PROVIDERS = [
+  {
+    provider: "anthropic",
+    defaultModel: "claude-sonnet",
+    models: [
+      { value: "claude-sonnet", label: "Claude Sonnet" },
+      { value: "claude-opus", label: "Claude Opus" },
+    ],
+  },
+  {
+    provider: "openai",
+    defaultModel: "gpt-standard",
+    models: [
+      { value: "gpt-standard", label: "GPT Standard" },
+      { value: "gpt-reasoning", label: "GPT Reasoning", hint: "More deliberate" },
+    ],
+  },
+] as const satisfies readonly OnboardingLlmProviderConfiguration[];
+
+function configuration(
+  active: OnboardingLlmConfiguration["active"] = {
+    provider: "anthropic",
+    model: "claude-sonnet",
+  },
+): OnboardingLlmConfiguration {
+  return { schemaVersion: 1, providers: PROVIDERS, active };
+}
+
+function fakeView() {
+  let handlers:
+    | {
+        readonly onOpen: () => void;
+        readonly onClose: () => void;
+        readonly onRetry: () => void;
+        readonly onProviderChange: (provider: string) => void;
+        readonly onModelChange: (model: string) => void;
+        readonly onCustomModelChange: (model: string) => void;
+        readonly onSave: () => void;
+        readonly onOpenSetup: () => void;
+      }
+    | undefined;
+  const view: ProviderModelSettingsView = {
+    bind: vi.fn((value) => {
+      handlers = value;
+    }),
+    open: vi.fn(),
+    close: vi.fn(),
+    render: vi.fn(),
+    dispose: vi.fn(),
+  };
+  return {
+    view,
+    open: () => handlers?.onOpen(),
+    close: () => handlers?.onClose(),
+    retry: () => handlers?.onRetry(),
+    provider: (value: string) => handlers?.onProviderChange(value),
+    model: (value: string) => handlers?.onModelChange(value),
+    customModel: (value: string) => handlers?.onCustomModelChange(value),
+    save: () => handlers?.onSave(),
+    openSetup: () => handlers?.onOpenSetup(),
+  };
+}
+
+function createSubject(input: {
+  readonly load?: () => Promise<OnboardingLlmConfiguration>;
+  readonly apply?: () => Promise<OnboardingLlmSelectionResult>;
+  readonly openSetup?: () => void;
+}) {
+  const subject = fakeView();
+  const load = input.load ?? vi.fn(async () => configuration());
+  const apply =
+    input.apply ??
+    vi.fn(async () => ({ status: "configured" as const, runtimeReady: true as const }));
+  const controller = createProviderModelSettingsController({
+    load,
+    apply,
+    openSetup: input.openSetup ?? vi.fn(),
+    view: subject.view,
+  });
+  return { controller, subject, load, apply };
+}
+
+function formState(controller: ProviderModelSettingsController) {
+  const state = controller.state();
+  if (
+    state.status !== "ready" &&
+    state.status !== "saving" &&
+    state.status !== "saved" &&
+    !(state.status === "error" && state.kind === "save")
+  ) {
+    throw new Error(`Expected form state, received ${state.status}`);
+  }
+  return state;
+}
+
+describe("provider and model settings controller", () => {
+  it("opens with visible loading state before resolving a known active model", async () => {
+    const gate = deferred<OnboardingLlmConfiguration>();
+    const { controller, subject } = createSubject({ load: vi.fn(() => gate.promise) });
+
+    const pending = controller.activate();
+
+    expect(subject.view.open).toHaveBeenCalled();
+    expect(controller.state()).toEqual({ status: "loading" });
+    expect(subject.view.render).toHaveBeenLastCalledWith({ status: "loading" });
+
+    gate.resolve(configuration());
+    await pending;
+    expect(formState(controller)).toMatchObject({
+      status: "ready",
+      active: { provider: "anthropic", model: "claude-sonnet" },
+      draft: {
+        provider: { provider: "anthropic" },
+        modelChoice: "claude-sonnet",
+        customModel: "",
+      },
+      dirty: false,
+      validationError: null,
+    });
+  });
+
+  it("represents an unknown active model as Other without making it dirty", async () => {
+    const { controller } = createSubject({
+      load: vi.fn(async () => configuration({ provider: "anthropic", model: "claude-future" })),
+    });
+
+    await controller.activate();
+
+    expect(formState(controller)).toMatchObject({
+      status: "ready",
+      draft: {
+        modelChoice: CUSTOM_MODEL_SELECTION,
+        customModel: "claude-future",
+      },
+      dirty: false,
+      validationError: null,
+    });
+  });
+
+  it("leaves active:null unconfigured until the athlete chooses a provider", async () => {
+    const { controller, subject } = createSubject({
+      load: vi.fn(async () => configuration(null)),
+    });
+
+    await controller.activate();
+    expect(formState(controller)).toMatchObject({
+      status: "ready",
+      active: null,
+      draft: null,
+      dirty: false,
+    });
+
+    subject.provider("openai");
+    expect(formState(controller)).toMatchObject({
+      draft: {
+        provider: { provider: "openai" },
+        modelChoice: "gpt-standard",
+      },
+      dirty: true,
+    });
+  });
+
+  it("uses each provider default first and retains a previously edited provider draft", async () => {
+    const { controller, subject } = createSubject({});
+    await controller.activate();
+
+    subject.provider("openai");
+    expect(formState(controller).draft).toMatchObject({
+      provider: { provider: "openai" },
+      modelChoice: "gpt-standard",
+    });
+    subject.model(CUSTOM_MODEL_SELECTION);
+    subject.customModel("  gpt-private  ");
+    subject.provider("anthropic");
+    subject.model("claude-opus");
+    subject.provider("openai");
+
+    expect(formState(controller).draft).toMatchObject({
+      provider: { provider: "openai" },
+      modelChoice: CUSTOM_MODEL_SELECTION,
+      customModel: "  gpt-private  ",
+    });
+  });
+
+  it("validates trimmed custom model names for presence, length, and control characters", async () => {
+    const { controller, subject, apply } = createSubject({});
+    await controller.activate();
+    subject.model(CUSTOM_MODEL_SELECTION);
+    expect(formState(controller).validationError).toBe("model-required");
+
+    subject.customModel(`valid\u0007name`);
+    expect(formState(controller).validationError).toBe("model-control-characters");
+
+    subject.customModel(`valid\u0085name`);
+    expect(formState(controller).validationError).toBe("model-control-characters");
+
+    subject.customModel("x".repeat(513));
+    expect(formState(controller).validationError).toBe("model-too-long");
+    subject.save();
+    await Promise.resolve();
+    expect(apply).not.toHaveBeenCalled();
+
+    subject.customModel(`  ${"x".repeat(512)}  `);
+    expect(formState(controller).validationError).toBeNull();
+
+    subject.save();
+    await vi.waitFor(() => expect(controller.state().status).toBe("saved"));
+    expect(apply).toHaveBeenCalledWith({
+      provider: "anthropic",
+      model: "x".repeat(512),
+      endpoint: { mode: "automatic" },
+    });
+
+    subject.customModel("  claude-private  ");
+    expect(formState(controller)).toMatchObject({
+      validationError: null,
+      dirty: true,
+    });
+  });
+
+  it("submits the exact automatic-endpoint payload once and makes success current", async () => {
+    const gate = deferred<OnboardingLlmSelectionResult>();
+    const apply = vi.fn(() => gate.promise);
+    const { controller, subject } = createSubject({ apply });
+    await controller.activate();
+    subject.model(CUSTOM_MODEL_SELECTION);
+    subject.customModel("  claude-private  ");
+
+    subject.save();
+    subject.save();
+    await vi.waitFor(() => expect(apply).toHaveBeenCalledTimes(1));
+    expect(apply).toHaveBeenCalledWith({
+      provider: "anthropic",
+      model: "claude-private",
+      endpoint: { mode: "automatic" },
+    });
+    expect(controller.state().status).toBe("saving");
+
+    gate.resolve({ status: "configured", runtimeReady: true });
+    await vi.waitFor(() => expect(controller.state().status).toBe("saved"));
+    expect(formState(controller)).toMatchObject({
+      status: "saved",
+      active: { provider: "anthropic", model: "claude-private" },
+      dirty: false,
+    });
+  });
+
+  it.each(["invalid-input", "credential-required", "runtime-unavailable"] as const)(
+    "retains the draft after %s and allows Save to retry",
+    async (reason) => {
+      const apply = vi
+        .fn()
+        .mockResolvedValueOnce({ status: "refused", reason })
+        .mockResolvedValueOnce({ status: "configured", runtimeReady: true });
+      const { controller, subject } = createSubject({ apply });
+      await controller.activate();
+      subject.provider("openai");
+      subject.model("gpt-reasoning");
+
+      subject.save();
+      await vi.waitFor(() =>
+        expect(controller.state()).toMatchObject({
+          status: "error",
+          kind: "save",
+          reason,
+          draft: {
+            provider: { provider: "openai" },
+            modelChoice: "gpt-reasoning",
+          },
+          dirty: true,
+        }),
+      );
+
+      subject.save();
+      await vi.waitFor(() => expect(controller.state().status).toBe("saved"));
+      expect(apply).toHaveBeenCalledTimes(2);
+    },
+  );
+
+  it("closes Settings before opening Setup for credential recovery", async () => {
+    const sequence: string[] = [];
+    const { controller, subject } = createSubject({
+      apply: vi.fn(
+        async (): Promise<OnboardingLlmSelectionResult> => ({
+          status: "refused",
+          reason: "credential-required",
+        }),
+      ),
+      openSetup: () => sequence.push("setup"),
+    });
+    vi.mocked(subject.view.close).mockImplementation(() => sequence.push("close"));
+    await controller.activate();
+    subject.provider("openai");
+    subject.save();
+    await vi.waitFor(() => expect(controller.state().status).toBe("error"));
+
+    subject.openSetup();
+
+    expect(sequence).toEqual(["close", "setup"]);
+    expect(controller.state()).toEqual({ status: "closed" });
+  });
+
+  it("ignores a stale load after close and reopen", async () => {
+    const first = deferred<OnboardingLlmConfiguration>();
+    const second = deferred<OnboardingLlmConfiguration>();
+    const load = vi.fn().mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise);
+    const { controller } = createSubject({ load });
+    const firstOpen = controller.activate();
+    controller.close();
+    const secondOpen = controller.activate();
+
+    first.resolve(configuration({ provider: "anthropic", model: "claude-future" }));
+    await firstOpen;
+    expect(controller.state()).toEqual({ status: "loading" });
+
+    second.resolve(configuration({ provider: "openai", model: "gpt-standard" }));
+    await secondOpen;
+    expect(formState(controller)).toMatchObject({
+      status: "ready",
+      draft: { provider: { provider: "openai" }, modelChoice: "gpt-standard" },
+    });
+  });
+
+  it("ignores a stale save after close and a fresh reload", async () => {
+    const saveGate = deferred<OnboardingLlmSelectionResult>();
+    const load = vi
+      .fn()
+      .mockResolvedValueOnce(configuration())
+      .mockResolvedValueOnce(configuration({ provider: "openai", model: "gpt-standard" }));
+    const { controller, subject } = createSubject({
+      load,
+      apply: vi.fn(() => saveGate.promise),
+    });
+    await controller.activate();
+    subject.model("claude-opus");
+    subject.save();
+    await vi.waitFor(() => expect(controller.state().status).toBe("saving"));
+    controller.close();
+    await controller.activate();
+
+    saveGate.resolve({ status: "configured", runtimeReady: true });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(formState(controller)).toMatchObject({
+      status: "ready",
+      active: { provider: "openai", model: "gpt-standard" },
+      draft: { provider: { provider: "openai" }, modelChoice: "gpt-standard" },
+    });
+  });
+
+  it.each(["load", "save"] as const)(
+    "does not render a stale %s completion after disposal",
+    async (operation) => {
+      const loadGate = deferred<OnboardingLlmConfiguration>();
+      const saveGate = deferred<OnboardingLlmSelectionResult>();
+      const { controller, subject } = createSubject({
+        load: operation === "load" ? vi.fn(() => loadGate.promise) : undefined,
+        apply: vi.fn(() => saveGate.promise),
+      });
+      const pending = controller.activate();
+      if (operation === "save") {
+        await pending;
+        subject.model("claude-opus");
+        subject.save();
+        await vi.waitFor(() => expect(controller.state().status).toBe("saving"));
+      }
+      const renders = vi.mocked(subject.view.render).mock.calls.length;
+      controller.dispose();
+      if (operation === "load") loadGate.resolve(configuration());
+      else saveGate.resolve({ status: "configured", runtimeReady: true });
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(subject.view.render).toHaveBeenCalledTimes(renders);
+      expect(subject.view.dispose).toHaveBeenCalledOnce();
+      expect(controller.state()).toEqual({ status: "closed" });
+    },
+  );
+
+  it("maps a rejected load to a retryable loading cycle", async () => {
+    const load = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("private detail"))
+      .mockResolvedValueOnce(configuration());
+    const { controller, subject } = createSubject({ load });
+    await controller.activate();
+    expect(controller.state()).toEqual({
+      status: "error",
+      kind: "load",
+      reason: "configuration-unavailable",
+    });
+
+    subject.retry();
+    await vi.waitFor(() => expect(controller.state().status).toBe("ready"));
+    expect(load).toHaveBeenCalledTimes(2);
+  });
+});
+
+class FakeElement {
+  readonly children: FakeElement[] = [];
+  readonly attributes = new Map<string, string>();
+  readonly dataset: Record<string, string> = {};
+  readonly listeners = new Map<string, Set<(event: never) => void>>();
+  parent: FakeElement | undefined;
+  className = "";
+  disabled = false;
+  hidden = false;
+  open = false;
+  id = "";
+  type = "";
+  value = "";
+  htmlFor = "";
+  autocomplete = "";
+  private ownText = "";
+
+  constructor(
+    readonly tagName: string,
+    private readonly document: FakeDocument,
+  ) {}
+
+  get textContent(): string {
+    return this.ownText + this.children.map((child) => child.textContent).join("");
+  }
+
+  set textContent(value: string) {
+    this.ownText = value;
+    for (const child of this.children) child.parent = undefined;
+    this.children.splice(0);
+  }
+
+  append(...nodes: FakeElement[]): void {
+    for (const node of nodes) {
+      node.remove();
+      node.parent = this;
+      this.children.push(node);
+    }
+  }
+
+  insertBefore(node: FakeElement, before: FakeElement | null): void {
+    node.remove();
+    node.parent = this;
+    const index = before === null ? -1 : this.children.indexOf(before);
+    if (index === -1) this.children.push(node);
+    else this.children.splice(index, 0, node);
+  }
+
+  replaceChildren(...nodes: FakeElement[]): void {
+    for (const child of this.children) child.parent = undefined;
+    this.children.splice(0);
+    this.ownText = "";
+    this.append(...nodes);
+  }
+
+  setAttribute(name: string, value: string): void {
+    this.attributes.set(name, value);
+  }
+
+  removeAttribute(name: string): void {
+    this.attributes.delete(name);
+  }
+
+  addEventListener(name: string, listener: (event: never) => void): void {
+    const listeners = this.listeners.get(name) ?? new Set();
+    listeners.add(listener);
+    this.listeners.set(name, listeners);
+  }
+
+  removeEventListener(name: string, listener: (event: never) => void): void {
+    this.listeners.get(name)?.delete(listener);
+  }
+
+  dispatch(name: string, event: Record<string, unknown> = {}): void {
+    const value = {
+      target: this,
+      preventDefault() {},
+      shiftKey: false,
+      ...event,
+    };
+    for (const listener of this.listeners.get(name) ?? []) listener(value as never);
+  }
+
+  click(): void {
+    if (!this.disabled) this.dispatch("click");
+  }
+
+  focus(): void {
+    if (!this.disabled) this.document.activeElement = this;
+  }
+
+  showModal(): void {
+    this.open = true;
+  }
+
+  close(): void {
+    this.open = false;
+  }
+
+  remove(): void {
+    if (this.parent === undefined) return;
+    const index = this.parent.children.indexOf(this);
+    if (index >= 0) this.parent.children.splice(index, 1);
+    this.parent = undefined;
+  }
+}
+
+class FakeDocument {
+  readonly body = new FakeElement("body", this);
+  activeElement: FakeElement | null = this.body;
+
+  createElement(name: string): FakeElement {
+    return new FakeElement(name, this);
+  }
+
+  createTextNode(value: string): FakeElement {
+    const node = new FakeElement("#text", this);
+    node.textContent = value;
+    return node;
+  }
+}
+
+function descendants(root: FakeElement): FakeElement[] {
+  return root.children.flatMap((child) => [child, ...descendants(child)]);
+}
+
+function find(root: FakeElement, predicate: (node: FakeElement) => boolean): FakeElement {
+  const value = [root, ...descendants(root)].find(predicate);
+  if (value === undefined) throw new Error("Element not found");
+  return value;
+}
+
+function readyState(
+  overrides: Partial<ProviderModelFormState & { readonly status: "ready" }> = {},
+): ProviderModelFormState & { readonly status: "ready" } {
+  return {
+    status: "ready",
+    providers: PROVIDERS,
+    active: { provider: "anthropic", model: "claude-sonnet" },
+    draft: {
+      provider: PROVIDERS[0],
+      modelChoice: "claude-opus",
+      customModel: "",
+    },
+    dirty: true,
+    validationError: null,
+    ...overrides,
+  };
+}
+
+describe("provider and model settings view", () => {
+  it("announces loading, empty, saved, and refusal states in athlete-facing copy", () => {
+    const document = new FakeDocument();
+    const actionHost = new FakeElement("div", document);
+    document.body.append(actionHost);
+    const view = createProviderModelSettingsView({
+      document: document as never,
+      actionHost: actionHost as never,
+    });
+    view.open();
+    view.render({ status: "loading" });
+    const dialog = find(document.body, (node) => node.tagName === "dialog");
+    const close = find(dialog, (node) => node.className === "provider-model-settings__close");
+    expect(dialog.open).toBe(true);
+    expect(document.activeElement).toBe(close);
+    expect(dialog.textContent).toContain("Loading coach settings…");
+
+    view.render({
+      status: "ready",
+      providers: PROVIDERS,
+      active: null,
+      draft: null,
+      dirty: false,
+      validationError: null,
+    });
+    const provider = find(dialog, (node) => node.id === "provider-model-settings-provider");
+    const route = find(dialog, (node) => node.className === "coach-route");
+    const save = find(dialog, (node) => node.className === "provider-model-settings__save");
+    expect(provider.value).toBe("");
+    expect(route.textContent).toContain("Not configured");
+    expect(route.attributes.get("aria-label")).toBe("Coach route: not configured.");
+    expect(dialog.textContent).toContain(
+      "Active coach settings are unavailable or not configured.",
+    );
+    expect(save.disabled).toBe(true);
+
+    view.render({
+      ...readyState(),
+      status: "saved",
+      active: { provider: "anthropic", model: "claude-opus" },
+      dirty: false,
+    });
+    expect(dialog.textContent).toContain("Coach settings saved.");
+    expect(route.textContent).toContain("Anthropic→Claude OpusActive");
+    expect(save.disabled).toBe(true);
+
+    for (const [reason, copy] of [
+      [
+        "invalid-input",
+        "That provider or model wasn’t accepted. Check the model name and try again.",
+      ],
+      [
+        "credential-required",
+        "This provider needs a saved credential before it can coach you. Open Setup to add one.",
+      ],
+      ["runtime-unavailable", "Coach settings couldn’t become active. Try saving again."],
+    ] as const) {
+      view.render({
+        ...readyState(),
+        status: "error",
+        kind: "save",
+        reason,
+      });
+      expect(dialog.textContent).toContain(copy);
+    }
+  });
+
+  it("renders Other, disables every dialog control while saving, traps focus, and guards close", () => {
+    const document = new FakeDocument();
+    const actionHost = new FakeElement("div", document);
+    document.body.append(actionHost);
+    const view = createProviderModelSettingsView({
+      document: document as never,
+      actionHost: actionHost as never,
+    });
+    const onClose = vi.fn(() => view.close());
+    view.bind({
+      onOpen: vi.fn(),
+      onClose,
+      onRetry: vi.fn(),
+      onProviderChange: vi.fn(),
+      onModelChange: vi.fn(),
+      onCustomModelChange: vi.fn(),
+      onSave: vi.fn(),
+      onOpenSetup: vi.fn(),
+    });
+    view.open();
+    const dialog = find(document.body, (node) => node.tagName === "dialog");
+    const close = find(dialog, (node) => node.className === "provider-model-settings__close");
+    const save = find(dialog, (node) => node.className === "provider-model-settings__save");
+    const custom = find(dialog, (node) => node.id === "provider-model-settings-custom-model");
+    const customField = find(dialog, (node) =>
+      node.className.includes("provider-model-settings__custom"),
+    );
+    view.render({
+      ...readyState(),
+      active: { provider: "anthropic", model: "claude-future" },
+      draft: {
+        provider: PROVIDERS[0],
+        modelChoice: CUSTOM_MODEL_SELECTION,
+        customModel: "claude-future",
+      },
+      dirty: false,
+    });
+    expect(customField.hidden).toBe(false);
+    expect(custom.value).toBe("claude-future");
+    expect(custom.attributes.has("aria-invalid")).toBe(false);
+
+    view.render({
+      ...readyState(),
+      draft: {
+        provider: PROVIDERS[0],
+        modelChoice: CUSTOM_MODEL_SELECTION,
+        customModel: "",
+      },
+      validationError: "model-required",
+    });
+    expect(custom.attributes.get("aria-invalid")).toBe("true");
+
+    view.render({ ...readyState(), status: "saving" });
+    const controls = descendants(dialog).filter((node) =>
+      ["button", "select", "input"].includes(node.tagName),
+    );
+    expect(controls.every((control) => control.disabled)).toBe(true);
+    const preventDefault = vi.fn();
+    dialog.dispatch("cancel", { preventDefault });
+    dialog.dispatch("click", { target: dialog });
+    expect(preventDefault).toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+    expect(dialog.open).toBe(true);
+
+    view.render(readyState());
+    save.focus();
+    dialog.dispatch("keydown", { key: "Tab", preventDefault });
+    expect(preventDefault).toHaveBeenCalled();
+    expect(document.activeElement).toBe(close);
+    dialog.dispatch("cancel", { preventDefault });
+    expect(onClose).toHaveBeenCalledOnce();
+    expect(dialog.open).toBe(false);
+    const opener = find(actionHost, (node) => node.className === "provider-model-settings-button");
+    expect(opener.attributes.get("aria-label")).toBe("Coach settings");
+    expect(document.activeElement).toBe(opener);
+
+    view.open();
+    dialog.dispatch("click", { target: dialog });
+    expect(onClose).toHaveBeenCalledTimes(2);
+    expect(dialog.open).toBe(false);
+  });
+
+  it("ships compact topbar, mobile dialog, and reduced-motion treatment", async () => {
+    const styles = await readFile(new URL("../src/settings/styles.css", import.meta.url), "utf8");
+    expect(styles).toContain("@media (max-width: 760px)");
+    expect(styles).toContain('content: "Coach"');
+    expect(styles).toContain("@media (max-width: 440px)");
+    expect(styles).toContain("@media (prefers-reduced-motion: reduce)");
+    expect(styles).toContain("animation: none");
+  });
+});

--- a/apps/desktop/tests/chat-panels.integration.test.ts
+++ b/apps/desktop/tests/chat-panels.integration.test.ts
@@ -1007,6 +1007,10 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
     const compactDrawerGeometry = await fixture.evaluate<{
       readonly documentOverflow: boolean;
       readonly topbarFits: boolean;
+      readonly settingsResident: boolean;
+      readonly settingsReachable: boolean;
+      readonly settingsAccessibleLabel: string;
+      readonly settingsCompactLabel: string;
       readonly drawerOpen: boolean;
       readonly buttonResident: boolean;
       readonly buttonReachable: boolean;
@@ -1018,15 +1022,26 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       compactOpener.click();
       await new Promise((resolve) => setTimeout(resolve, 250));
       const topbar = document.querySelector(".topbar");
+      const settings = document.querySelector(".provider-model-settings-button");
       const compactDrawer = document.querySelector("#training-context-drawer");
       const compactButton = compactDrawer.querySelector(".training-sync__button");
       const compactStatus = compactDrawer.querySelector(".training-sync__status");
       const compactRegion = compactDrawer.querySelector(".training-sync");
       const drawerRect = compactDrawer.getBoundingClientRect();
       const buttonRect = compactButton.getBoundingClientRect();
+      const topbarRect = topbar.getBoundingClientRect();
+      const settingsRect = settings.getBoundingClientRect();
       return {
         documentOverflow: document.documentElement.scrollWidth > document.documentElement.clientWidth,
         topbarFits: topbar.scrollWidth <= topbar.clientWidth,
+        settingsResident: topbar.contains(settings),
+        settingsReachable:
+          settingsRect.left >= topbarRect.left &&
+          settingsRect.right <= topbarRect.right &&
+          settingsRect.top >= topbarRect.top &&
+          settingsRect.bottom <= topbarRect.bottom,
+        settingsAccessibleLabel: settings.getAttribute("aria-label"),
+        settingsCompactLabel: getComputedStyle(settings, "::before").content.replace(/['"]/gu, ""),
         drawerOpen: compactDrawer.open,
         buttonResident: compactDrawer.querySelectorAll(".training-sync__button").length === 1,
         buttonReachable:
@@ -1045,6 +1060,10 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
     expect(compactDrawerGeometry).toEqual({
       documentOverflow: false,
       topbarFits: true,
+      settingsResident: true,
+      settingsReachable: true,
+      settingsAccessibleLabel: "Coach settings",
+      settingsCompactLabel: "Coach",
       drawerOpen: true,
       buttonResident: true,
       buttonReachable: true,


### PR DESCRIPTION
## Summary

- add a dedicated Settings dialog for viewing and changing the active coach provider and model
- reuse the existing redacted read/apply contract without widening IPC, preload, or daemon surfaces
- preserve per-provider drafts, custom models, exact automatic-endpoint behavior, and truthful unconfigured state
- retain draft and recovery actions across credential/runtime refusals while fencing stale async completions
- add responsive, keyboard-accessible presentation with a compact Provider → Model route summary

## Validation

- focused provider/model Settings tests (18/18)
- full renderer suite (333/333)
- root `pnpm check:types`
- renderer and Desktop production builds
- real Electron 720px shell/Settings geometry integration
- user-facing changeset gate (94 changesets clean)
- changed-file oxlint, oxfmt, and diff checks
- independent renderer/accessibility review: PASS

## Scope

This closes the provider/model slice only. Athlete identity, timezone/session tuning, and credential deletion remain separate persistence/security changes.
