### PR TITLE
Guard runtime athlete account ownership

### DIFF
--- a/.changeset/calm-falcons-guard.md
+++ b/.changeset/calm-falcons-guard.md
@@ -1,0 +1,7 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Athlete account changes now stop safely unless the selected account owns the existing training history.
+
+Guard configured, startup, and live athlete account changes before updating daemon configuration or refreshing training data.

--- a/packages/coach/src/backfill.ts
+++ b/packages/coach/src/backfill.ts
@@ -45,6 +45,42 @@ export interface StoreOwnerCheckOptions {
   readonly attemptLedger?: PhysicalRequestLedger;
 }
 
+type RuntimeAthleteOwnerLookupOptions = Omit<StoreOwnerCheckOptions, "signal" | "budget">;
+
+export interface RuntimeAthleteOwnerGuardOptions {
+  readonly current: RuntimeAthleteOwnerLookupOptions;
+  readonly candidate: RuntimeAthleteOwnerLookupOptions;
+  readonly signal: AbortSignal;
+  readonly timeoutMs?: number;
+  readonly claimUnownedCandidateWithoutCurrent?: boolean;
+}
+
+export interface RuntimeAthleteOwnerClaim {
+  claim(): Promise<void>;
+}
+
+export type RuntimeAthleteOwnerRefusalReason =
+  | "current-credential-missing"
+  | "current-unresolved"
+  | "candidate-unresolved"
+  | "mismatch";
+
+export class RuntimeAthleteOwnerRefusal extends Error {
+  readonly reason: RuntimeAthleteOwnerRefusalReason;
+
+  constructor(reason: RuntimeAthleteOwnerRefusalReason) {
+    super(
+      reason === "mismatch"
+        ? "training account mismatch"
+        : reason === "current-credential-missing"
+          ? "active training credential is unavailable"
+          : "training account owner unresolved",
+    );
+    this.name = "RuntimeAthleteOwnerRefusal";
+    this.reason = reason;
+  }
+}
+
 export type StoreOwnerCheckResult =
   | "unowned"
   | "matched"
@@ -70,6 +106,8 @@ const lookupArchive: ArchiveManager = Object.freeze({
 const CLAIM_STORE_OWNER_SQL =
   "INSERT INTO store_owner (singleton, account_fingerprint) VALUES (1, ?)";
 const STORE_OWNER_CHECK_BUSY_TIMEOUT_MS = 5_000;
+const RUNTIME_ATHLETE_OWNER_TIMEOUT_MS = 20_000;
+const RUNTIME_ATHLETE_OWNER_REQUEST_TIMEOUT_MS = 8_000;
 
 async function readStoreOwnerFingerprint(
   store: Pick<SqlStore, "get">,
@@ -139,6 +177,113 @@ export async function resolveIntervalsStoreOwnerFingerprint(
   return createHash("sha256")
     .update(JSON.stringify(["store-owner-v1", [...resolved][0]]))
     .digest("hex");
+}
+
+export async function assertRuntimeAthleteOwner(
+  store: SqlStore,
+  options: RuntimeAthleteOwnerGuardOptions,
+  resolveFingerprint: (
+    options: StoreOwnerCheckOptions,
+  ) => Promise<string | null> = resolveIntervalsStoreOwnerFingerprint,
+): Promise<RuntimeAthleteOwnerClaim | undefined> {
+  const timeoutMs = options.timeoutMs ?? RUNTIME_ATHLETE_OWNER_TIMEOUT_MS;
+  if (!Number.isSafeInteger(timeoutMs) || timeoutMs <= 0) {
+    throw new TypeError("runtime athlete owner timeout is invalid");
+  }
+  const timeoutController = new AbortController();
+  const timeout = setTimeout(
+    () => timeoutController.abort(new Error("runtime athlete owner lookup timed out")),
+    timeoutMs,
+  );
+  timeout.unref();
+  const signal = AbortSignal.any([options.signal, timeoutController.signal]);
+  const budget: SyncBudget = {
+    signal,
+    clock: { monotonicNow: () => options.current.clock.monotonicNow() },
+    deadlineMonotonicMs: options.current.clock.monotonicNow() + timeoutMs,
+    perRequestTimeoutMs: Math.min(RUNTIME_ATHLETE_OWNER_REQUEST_TIMEOUT_MS, timeoutMs),
+    maxRequests: REQUEST_ATTEMPTS,
+    maxArtifacts: 1_000,
+  };
+  const resolveRequiredFingerprint = async (
+    selected: RuntimeAthleteOwnerLookupOptions,
+    reason: Extract<
+      RuntimeAthleteOwnerRefusalReason,
+      "current-unresolved" | "candidate-unresolved"
+    >,
+  ): Promise<string> => {
+    let fingerprint: string | null;
+    try {
+      signal.throwIfAborted();
+      fingerprint = await resolveFingerprint({ ...selected, signal, budget });
+      signal.throwIfAborted();
+    } catch {
+      throw new RuntimeAthleteOwnerRefusal(reason);
+    }
+    if (fingerprint === null) throw new RuntimeAthleteOwnerRefusal(reason);
+    return fingerprint;
+  };
+
+  try {
+    if ((await readStoreOwnerFingerprint(store)) === undefined) {
+      if (options.claimUnownedCandidateWithoutCurrent === true) {
+        const candidateFingerprint = await resolveRequiredFingerprint(
+          options.candidate,
+          "candidate-unresolved",
+        );
+        return Object.freeze({
+          async claim() {
+            try {
+              signal.throwIfAborted();
+            } catch {
+              throw new RuntimeAthleteOwnerRefusal("candidate-unresolved");
+            }
+            await store.run(CLAIM_STORE_OWNER_SQL, [candidateFingerprint]);
+          },
+        });
+      }
+      if (options.current.apiKey.length === 0) {
+        throw new RuntimeAthleteOwnerRefusal("current-credential-missing");
+      }
+      const currentFingerprint = await resolveRequiredFingerprint(
+        options.current,
+        "current-unresolved",
+      );
+      try {
+        signal.throwIfAborted();
+      } catch {
+        throw new RuntimeAthleteOwnerRefusal("current-unresolved");
+      }
+      await store.run(CLAIM_STORE_OWNER_SQL, [currentFingerprint]);
+      try {
+        signal.throwIfAborted();
+      } catch {
+        throw new RuntimeAthleteOwnerRefusal("current-unresolved");
+      }
+      if (
+        options.current.apiKey === options.candidate.apiKey &&
+        options.current.athleteId === options.candidate.athleteId
+      ) {
+        return;
+      }
+    }
+
+    const candidateFingerprint = await resolveRequiredFingerprint(
+      options.candidate,
+      "candidate-unresolved",
+    );
+    const ownership = await compareStoreOwner(store, candidateFingerprint);
+    try {
+      signal.throwIfAborted();
+    } catch {
+      throw new RuntimeAthleteOwnerRefusal("candidate-unresolved");
+    }
+    if (ownership !== "matched") {
+      throw new RuntimeAthleteOwnerRefusal("mismatch");
+    }
+  } finally {
+    clearTimeout(timeout);
+  }
 }
 
 async function enforceIntervalsStoreOwner(

--- a/packages/coach/src/composition.ts
+++ b/packages/coach/src/composition.ts
@@ -8,6 +8,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { join } from "node:path";
+import { performance } from "node:perf_hooks";
 import { parse as parseYaml, stringify as toYaml } from "yaml";
 import {
   ChatStore,
@@ -58,6 +59,10 @@ import {
 } from "@enduragent/coach-contract";
 import { cyclingSport } from "@enduragent/sport-cycling";
 import { createPersistedAthleteStateSource } from "./athlete-state-reader.js";
+import {
+  assertRuntimeAthleteOwner,
+  type RuntimeAthleteOwnerClaim,
+} from "./backfill.js";
 import { createCoachEngineAdapter } from "./coach-engine-adapter.js";
 import {
   createStoreRuntime,
@@ -109,6 +114,9 @@ export interface LocalCoachCompositionDependencies {
   readonly closeHostAdapters?: () => void | Promise<void>;
   readonly operationsDependencies?: CoachOperationsDependencies;
   readonly persistRuntimeConfig?: typeof persistRuntimeConfig;
+  readonly assertRuntimeAthleteOwner?: (
+    ...args: Parameters<typeof assertRuntimeAthleteOwner>
+  ) => Promise<RuntimeAthleteOwnerClaim | void>;
 }
 
 export interface LocalReferenceRuntime {
@@ -185,6 +193,45 @@ function assignOptionalField(
   else target[field] = value;
 }
 
+function replacePrivateFile(path: string, content: string | Uint8Array): void {
+  const temporaryPath = `${path}.tmp.${randomBytes(4).toString("hex")}`;
+  try {
+    writeFileSync(temporaryPath, content, { mode: 0o600 });
+    chmodSync(temporaryPath, 0o600);
+    renameSync(temporaryPath, path);
+  } catch (error) {
+    try {
+      unlinkSync(temporaryPath);
+    } catch {}
+    throw error;
+  }
+}
+
+interface RuntimeConfigFileSnapshot {
+  readonly content?: Buffer;
+}
+
+function captureRuntimeConfigFile(configDir: string): RuntimeConfigFileSnapshot {
+  const path = join(configDir, "config.yaml");
+  return existsSync(path) ? { content: readFileSync(path) } : {};
+}
+
+function restoreRuntimeConfigFile(
+  configDir: string,
+  snapshot: RuntimeConfigFileSnapshot,
+): void {
+  const path = join(configDir, "config.yaml");
+  if (snapshot.content !== undefined) {
+    replacePrivateFile(path, snapshot.content);
+    return;
+  }
+  try {
+    unlinkSync(path);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+}
+
 function persistRuntimeConfig(
   configDir: string,
   candidate: Config,
@@ -221,17 +268,7 @@ function persistRuntimeConfig(
       athlete_id: candidate.intervals.athleteId,
     };
   }
-  const temporaryPath = `${path}.tmp.${randomBytes(4).toString("hex")}`;
-  try {
-    writeFileSync(temporaryPath, toYaml(next), { mode: 0o600 });
-    chmodSync(temporaryPath, 0o600);
-    renameSync(temporaryPath, path);
-  } catch (error) {
-    try {
-      unlinkSync(temporaryPath);
-    } catch {}
-    throw error;
-  }
+  replacePrivateFile(path, toYaml(next));
 }
 
 function runtimeCredentialConfigured(configDir: string, config: Config): boolean {
@@ -264,7 +301,7 @@ function runtimeConfigSnapshot(configDir: string, config: Config): GetRuntimeCon
 
 function createReconfigurableEngine(initial: CoachEngine): {
   readonly engine: CoachEngine;
-  replace(create: () => CoachEngine): Promise<void>;
+  replace(create: () => CoachEngine | Promise<CoachEngine>): Promise<void>;
 } {
   let active = initial;
   let admission = Promise.resolve();
@@ -305,7 +342,7 @@ function createReconfigurableEngine(initial: CoachEngine): {
         if (activeCalls > 0) {
           await new Promise<void>((resolve) => drainWaiters.add(resolve));
         }
-        active = create();
+        active = await create();
       } finally {
         release();
       }
@@ -477,6 +514,32 @@ export async function createLocalCoachComposition(
     throw new TypeError("Ready engine configuration does not match the selected athlete home.");
   }
   const now = dependencies.now ?? Date.now;
+  const ownerClock = { now, monotonicNow: () => performance.now() };
+  const ownerLookup = (intervals: Config["intervals"]) => ({
+    apiKey: intervals.apiKey,
+    athleteId: intervals.athleteId.length === 0 ? "0" : intervals.athleteId,
+    historyNewestDate: new Date(now()).toISOString().slice(0, 10),
+    clock: ownerClock,
+  });
+  const assertIntervalsOwner = async (
+    current: Config["intervals"],
+    candidate: Config["intervals"],
+    signal: AbortSignal,
+    claimUnownedCandidateWithoutCurrent = false,
+  ): Promise<RuntimeAthleteOwnerClaim | undefined> => {
+    const approval = await (dependencies.assertRuntimeAthleteOwner ?? assertRuntimeAthleteOwner)(
+      input.context.store,
+      {
+        current: ownerLookup(current),
+        candidate: ownerLookup(candidate),
+        signal,
+        ...(claimUnownedCandidateWithoutCurrent
+          ? { claimUnownedCandidateWithoutCurrent: true }
+          : {}),
+      },
+    );
+    return approval ?? undefined;
+  };
   const spendMeter = createSpendMeterService({
     dataDir: input.home.root,
     configDir: input.home.configDir,
@@ -484,10 +547,27 @@ export async function createLocalCoachComposition(
     now,
   });
   let activeConfig = copyConfig(input.config);
+  if (
+    activeConfig.intervals.apiKey.length > 0 &&
+    activeConfig.intervals.athleteId.length === 0
+  ) {
+    activeConfig = {
+      ...activeConfig,
+      intervals: { ...activeConfig.intervals, athleteId: "0" },
+    };
+  }
   let runtime: LocalStoreRuntime | undefined;
   let reference: LocalReferenceRuntime | undefined;
   let closePromise: Promise<void> | undefined;
   try {
+    if (activeConfig.intervals.apiKey.length > 0) {
+      const startupOwnerClaim = await assertIntervalsOwner(
+        activeConfig.intervals,
+        activeConfig.intervals,
+        new AbortController().signal,
+      );
+      await startupOwnerClaim?.claim();
+    }
     reference = await (dependencies.bootstrap ?? bootstrapReference)({
       dataDir: input.home.root,
       intervals: activeConfig.intervals,
@@ -580,8 +660,42 @@ export async function createLocalCoachComposition(
     };
     const reconfigurable = createReconfigurableEngine(buildEngine(activeConfig));
     const persistConfig = dependencies.persistRuntimeConfig ?? persistRuntimeConfig;
-    const applyRuntimeConfig = async (request: ConfigureRuntimeRpcParams): Promise<void> => {
+    const applyRuntimeConfig = async (
+      request: ConfigureRuntimeRpcParams,
+      signal: AbortSignal,
+    ): Promise<void> => {
+      signal.throwIfAborted();
       const candidate = mergedRuntimeConfig(activeConfig, request);
+      const activeAthleteId =
+        activeConfig.intervals.athleteId.length === 0 ? "0" : activeConfig.intervals.athleteId;
+      const candidateAthleteId =
+        candidate.intervals.athleteId.length === 0 ? "0" : candidate.intervals.athleteId;
+      const athleteIdChanged =
+        request.intervals?.athlete_id !== undefined &&
+        candidateAthleteId !== activeAthleteId;
+      const apiKeyChanged =
+        request.intervals?.api_key !== undefined &&
+        candidate.intervals.apiKey !== activeConfig.intervals.apiKey;
+      let pendingOwnerClaim: RuntimeAthleteOwnerClaim | undefined;
+      if (athleteIdChanged || apiKeyChanged) {
+        if (athleteIdChanged && input.env.INTERVALS_ATHLETE_ID !== undefined) {
+          throw new Error("runtime athlete ID is controlled by the daemon environment");
+        }
+        if (
+          apiKeyChanged &&
+          input.env.INTERVALS_API_KEY !== undefined &&
+          input.env.INTERVALS_API_KEY !== ""
+        ) {
+          throw new Error("runtime intervals credential is controlled by the daemon environment");
+        }
+        pendingOwnerClaim = await assertIntervalsOwner(
+          activeConfig.intervals,
+          candidate.intervals,
+          signal,
+          activeConfig.intervals.apiKey.length === 0 &&
+            candidate.intervals.apiKey.length > 0,
+        );
+      }
       if (request.llm !== undefined && candidate.llm.provider === "openai-codex") {
         credential(
           loadStoredProfileSnapshot(
@@ -591,8 +705,29 @@ export async function createLocalCoachComposition(
         );
       }
       const replacement = buildEngine(candidate);
-      persistConfig(input.home.configDir, candidate, request, activeConfig);
-      await reconfigurable.replace(() => {
+      signal.throwIfAborted();
+      await reconfigurable.replace(async () => {
+        signal.throwIfAborted();
+        const previousConfigFile =
+          pendingOwnerClaim === undefined
+            ? undefined
+            : captureRuntimeConfigFile(input.home.configDir);
+        try {
+          persistConfig(input.home.configDir, candidate, request, activeConfig);
+          await pendingOwnerClaim?.claim();
+        } catch (error) {
+          if (previousConfigFile !== undefined) {
+            try {
+              restoreRuntimeConfigFile(input.home.configDir, previousConfigFile);
+            } catch (rollbackError) {
+              throw new AggregateError(
+                [error, rollbackError],
+                "Runtime account claim failed and configuration rollback was unsuccessful.",
+              );
+            }
+          }
+          throw error;
+        }
         activeConfig = candidate;
         return replacement;
       });

--- a/packages/coach/src/operations.ts
+++ b/packages/coach/src/operations.ts
@@ -52,7 +52,10 @@ export interface CreateCoachOperationsInput {
     read(): Promise<Readonly<{ apiKey: string; athleteId: string }>>;
   }>;
   readonly historyNewestDate: () => string;
-  readonly applyRuntimeConfig: (request: ConfigureRuntimeRpcParams) => Promise<void>;
+  readonly applyRuntimeConfig: (
+    request: ConfigureRuntimeRpcParams,
+    signal: AbortSignal,
+  ) => Promise<void>;
   readonly readRuntimeConfig?: () => GetRuntimeConfigRpcResult;
 }
 
@@ -61,6 +64,7 @@ export interface CoachOperationsDependencies {
   readonly backfill?: typeof runIntervalsBackfillInWriter;
   readonly createIdentity?: (configDir: string) => AuthoredIdentity;
   readonly createIntakeRepository?: typeof createIntakeRepository;
+  readonly runtimeConfigurationDeadlineMs?: number;
 }
 
 function sameHome(left: AthleteHome, right: AthleteHome): boolean {
@@ -107,6 +111,9 @@ function createSerializedLane(): <T>(operation: () => Promise<T>) => Promise<T> 
   };
 }
 
+// Must stay below the client call timeout so queued work cannot mutate after its caller detaches.
+export const RUNTIME_CONFIGURATION_DEADLINE_MS = 25_000;
+
 export function createCoachOperations(
   input: CreateCoachOperationsInput,
   dependencies: CoachOperationsDependencies = {},
@@ -121,6 +128,14 @@ export function createCoachOperations(
   const unitsPreference = createUnitsPreferenceService(createUnitsPreferenceRepository(store));
   const importFiles = dependencies.importFiles ?? importFilesWithReport;
   const backfill = dependencies.backfill ?? runIntervalsBackfillInWriter;
+  const runtimeConfigurationDeadlineMs =
+    dependencies.runtimeConfigurationDeadlineMs ?? RUNTIME_CONFIGURATION_DEADLINE_MS;
+  if (
+    !Number.isSafeInteger(runtimeConfigurationDeadlineMs) ||
+    runtimeConfigurationDeadlineMs <= 0
+  ) {
+    throw new TypeError("Runtime configuration deadline is invalid.");
+  }
   const enqueueRuntimeConfiguration = createSerializedLane();
 
   const deliver = (
@@ -213,9 +228,15 @@ export function createCoachOperations(
     },
     configureRuntime(request: ConfigureRuntimeRpcParams): Promise<ConfigureRuntimeRpcResult> {
       const parsedRequest = ConfigureRuntimeRpcParamsSchema.parse(request);
+      const deadlineSignal = AbortSignal.timeout(runtimeConfigurationDeadlineMs);
       return enqueueRuntimeConfiguration(async () => {
-        const apply = async (): Promise<ConfigureRuntimeRpcResult> => {
-          await input.applyRuntimeConfig(parsedRequest);
+        const apply = async (admissionSignal?: AbortSignal): Promise<ConfigureRuntimeRpcResult> => {
+          const signal =
+            admissionSignal === undefined
+              ? deadlineSignal
+              : AbortSignal.any([deadlineSignal, admissionSignal]);
+          signal.throwIfAborted();
+          await input.applyRuntimeConfig(parsedRequest, signal);
           return ConfigureRuntimeRpcResultSchema.parse({
             schemaVersion: 1,
             applied: {

--- a/packages/coach/tests/backfill.test.ts
+++ b/packages/coach/tests/backfill.test.ts
@@ -14,6 +14,7 @@ import { openSqliteStorage } from "@enduragent/kernel-node/sqlite";
 import type { IntervalsIcuSource } from "@enduragent/sync-intervals-icu";
 import type { AthleteHome } from "@enduragent/kernel-node/home";
 import {
+  assertRuntimeAthleteOwner,
   checkIntervalsStoreOwnerAtPath,
   createIntervalsBackfillSource,
   runBackfillPages,
@@ -493,6 +494,359 @@ describe("incremental backfill pages", () => {
       }),
     ).resolves.toBe("mismatch");
     expect(mismatchFetch).toHaveBeenCalledOnce();
+  });
+
+  it("claims an ownerless store from the current account before resolving the candidate", async () => {
+    const value = await fresh();
+    const fingerprint = "a".repeat(64);
+    const resolveFingerprint = vi.fn(async (options: { readonly apiKey: string }) => {
+      if (options.apiKey === "current-key") {
+        expect(await value.store.get("SELECT count(*) AS count FROM store_owner")).toEqual({
+          count: 0,
+        });
+      } else {
+        expect(options.apiKey).toBe("candidate-key");
+        expect(await value.store.get("SELECT account_fingerprint FROM store_owner")).toEqual({
+          account_fingerprint: fingerprint,
+        });
+      }
+      return fingerprint;
+    });
+    try {
+      await assertRuntimeAthleteOwner(
+        value.store,
+        {
+          current: {
+            apiKey: "current-key",
+            athleteId: "current-athlete",
+            historyNewestDate: "1900-12-31",
+            clock,
+          },
+          candidate: {
+            apiKey: "candidate-key",
+            athleteId: "candidate-athlete",
+            historyNewestDate: "1900-12-31",
+            clock,
+          },
+          signal: new AbortController().signal,
+        },
+        resolveFingerprint,
+      );
+
+      expect(resolveFingerprint.mock.calls.map(([options]) => options.athleteId)).toEqual([
+        "current-athlete",
+        "candidate-athlete",
+      ]);
+    } finally {
+      await value.store.close();
+    }
+  });
+
+  it("skips current-account lookup when the store already has an owner", async () => {
+    const value = await fresh();
+    const fingerprint = "a".repeat(64);
+    await value.store.run(
+      "INSERT INTO store_owner (singleton, account_fingerprint) VALUES (1, ?)",
+      [fingerprint],
+    );
+    const resolveFingerprint = vi.fn(async () => fingerprint);
+    try {
+      await assertRuntimeAthleteOwner(
+        value.store,
+        {
+          current: {
+            apiKey: "",
+            athleteId: "0",
+            historyNewestDate: "1900-12-31",
+            clock,
+          },
+          candidate: {
+            apiKey: "candidate-key",
+            athleteId: "0",
+            historyNewestDate: "1900-12-31",
+            clock,
+          },
+          signal: new AbortController().signal,
+        },
+        resolveFingerprint,
+      );
+
+      expect(resolveFingerprint).toHaveBeenCalledOnce();
+      expect(resolveFingerprint).toHaveBeenCalledWith(
+        expect.objectContaining({ apiKey: "candidate-key", athleteId: "0" }),
+      );
+    } finally {
+      await value.store.close();
+    }
+  });
+
+  it("defers and claims a resolved first credential when no current account exists", async () => {
+    const value = await fresh();
+    const fingerprint = "a".repeat(64);
+    const resolveFingerprint = vi.fn(async () => fingerprint);
+    try {
+      const pendingClaim = await assertRuntimeAthleteOwner(
+        value.store,
+        {
+          current: {
+            apiKey: "",
+            athleteId: "0",
+            historyNewestDate: "1900-12-31",
+            clock,
+          },
+          candidate: {
+            apiKey: "candidate-key",
+            athleteId: "0",
+            historyNewestDate: "1900-12-31",
+            clock,
+          },
+          signal: new AbortController().signal,
+          claimUnownedCandidateWithoutCurrent: true,
+        },
+        resolveFingerprint,
+      );
+
+      expect(resolveFingerprint).toHaveBeenCalledOnce();
+      expect(resolveFingerprint).toHaveBeenCalledWith(
+        expect.objectContaining({ apiKey: "candidate-key", athleteId: "0" }),
+      );
+      expect(await value.store.get("SELECT count(*) AS count FROM store_owner")).toEqual({
+        count: 0,
+      });
+      await pendingClaim?.claim();
+      expect(await value.store.get("SELECT account_fingerprint FROM store_owner")).toEqual({
+        account_fingerprint: fingerprint,
+      });
+    } finally {
+      await value.store.close();
+    }
+  });
+
+  it.each(["null", "rejection", "abort"] as const)(
+    "does not bind a first credential after candidate %s",
+    async (failure) => {
+      const value = await fresh();
+      const controller = new AbortController();
+      const resolveFingerprint = vi.fn(async () => {
+        if (failure === "null") return null;
+        if (failure === "rejection") throw new Error("synthetic candidate lookup failure");
+        controller.abort(new Error("synthetic admission close"));
+        return "a".repeat(64);
+      });
+      try {
+        await expect(
+          assertRuntimeAthleteOwner(
+            value.store,
+            {
+              current: {
+                apiKey: "",
+                athleteId: "0",
+                historyNewestDate: "1900-12-31",
+                clock,
+              },
+              candidate: {
+                apiKey: "candidate-key",
+                athleteId: "0",
+                historyNewestDate: "1900-12-31",
+                clock,
+              },
+              signal: controller.signal,
+              claimUnownedCandidateWithoutCurrent: true,
+            },
+            resolveFingerprint,
+          ),
+        ).rejects.toMatchObject({ reason: "candidate-unresolved" });
+        expect(await value.store.get("SELECT count(*) AS count FROM store_owner")).toEqual({
+          count: 0,
+        });
+      } finally {
+        await value.store.close();
+      }
+    },
+  );
+
+  it("refuses an unowned athlete change without a current credential", async () => {
+    const value = await fresh();
+    const resolveFingerprint = vi.fn(async () => "a".repeat(64));
+    try {
+      await expect(
+        assertRuntimeAthleteOwner(
+          value.store,
+          {
+            current: {
+              apiKey: "",
+              athleteId: "0",
+              historyNewestDate: "1900-12-31",
+              clock,
+            },
+            candidate: {
+              apiKey: "candidate-key",
+              athleteId: "candidate-athlete",
+              historyNewestDate: "1900-12-31",
+              clock,
+            },
+            signal: new AbortController().signal,
+          },
+          resolveFingerprint,
+        ),
+      ).rejects.toMatchObject({ reason: "current-credential-missing" });
+      expect(resolveFingerprint).not.toHaveBeenCalled();
+      expect(await value.store.get("SELECT count(*) AS count FROM store_owner")).toEqual({
+        count: 0,
+      });
+    } finally {
+      await value.store.close();
+    }
+  });
+
+  it("aborts a bounded owner lookup before claiming the store", async () => {
+    const value = await fresh();
+    const resolveFingerprint = vi.fn(
+      async (options: { readonly signal?: AbortSignal }): Promise<string> =>
+        await new Promise((_, reject) => {
+          options.signal?.addEventListener("abort", () => reject(options.signal?.reason), {
+            once: true,
+          });
+        }),
+    );
+    try {
+      await expect(
+        assertRuntimeAthleteOwner(
+          value.store,
+          {
+            current: {
+              apiKey: "current-key",
+              athleteId: "current-athlete",
+              historyNewestDate: "1900-12-31",
+              clock: { now: clock.now, monotonicNow: () => performance.now() },
+            },
+            candidate: {
+              apiKey: "candidate-key",
+              athleteId: "candidate-athlete",
+              historyNewestDate: "1900-12-31",
+              clock: { now: clock.now, monotonicNow: () => performance.now() },
+            },
+            signal: new AbortController().signal,
+            timeoutMs: 5,
+          },
+          resolveFingerprint,
+        ),
+      ).rejects.toMatchObject({ reason: "current-unresolved" });
+      expect(await value.store.get("SELECT count(*) AS count FROM store_owner")).toEqual({
+        count: 0,
+      });
+    } finally {
+      await value.store.close();
+    }
+  });
+
+  it("distinguishes unresolved current and candidate ownership", async () => {
+    const currentUnresolved = await fresh();
+    try {
+      await expect(
+        assertRuntimeAthleteOwner(
+          currentUnresolved.store,
+          {
+            current: {
+              apiKey: "current-key",
+              athleteId: "current-athlete",
+              historyNewestDate: "1900-12-31",
+              clock,
+            },
+            candidate: {
+              apiKey: "candidate-key",
+              athleteId: "candidate-athlete",
+              historyNewestDate: "1900-12-31",
+              clock,
+            },
+            signal: new AbortController().signal,
+          },
+          async () => null,
+        ),
+      ).rejects.toMatchObject({ reason: "current-unresolved" });
+      expect(
+        await currentUnresolved.store.get("SELECT count(*) AS count FROM store_owner"),
+      ).toEqual({
+        count: 0,
+      });
+    } finally {
+      await currentUnresolved.store.close();
+    }
+
+    const candidateUnresolved = await fresh();
+    const fingerprint = "a".repeat(64);
+    const resolveFingerprint = vi
+      .fn()
+      .mockResolvedValueOnce(fingerprint)
+      .mockRejectedValueOnce(new Error("synthetic candidate lookup failure"));
+    try {
+      await expect(
+        assertRuntimeAthleteOwner(
+          candidateUnresolved.store,
+          {
+            current: {
+              apiKey: "current-key",
+              athleteId: "current-athlete",
+              historyNewestDate: "1900-12-31",
+              clock,
+            },
+            candidate: {
+              apiKey: "candidate-key",
+              athleteId: "candidate-athlete",
+              historyNewestDate: "1900-12-31",
+              clock,
+            },
+            signal: new AbortController().signal,
+          },
+          resolveFingerprint,
+        ),
+      ).rejects.toMatchObject({ reason: "candidate-unresolved" });
+      expect(
+        await candidateUnresolved.store.get("SELECT account_fingerprint FROM store_owner"),
+      ).toEqual({
+        account_fingerprint: fingerprint,
+      });
+    } finally {
+      await candidateUnresolved.store.close();
+    }
+  });
+
+  it("refuses a candidate whose resolved owner differs from the current owner", async () => {
+    const value = await fresh();
+    const currentFingerprint = "a".repeat(64);
+    const candidateFingerprint = "b".repeat(64);
+    const resolveFingerprint = vi
+      .fn()
+      .mockResolvedValueOnce(currentFingerprint)
+      .mockResolvedValueOnce(candidateFingerprint);
+    try {
+      await expect(
+        assertRuntimeAthleteOwner(
+          value.store,
+          {
+            current: {
+              apiKey: "current-key",
+              athleteId: "current-athlete",
+              historyNewestDate: "1900-12-31",
+              clock,
+            },
+            candidate: {
+              apiKey: "candidate-key",
+              athleteId: "candidate-athlete",
+              historyNewestDate: "1900-12-31",
+              clock,
+            },
+            signal: new AbortController().signal,
+          },
+          resolveFingerprint,
+        ),
+      ).rejects.toMatchObject({ reason: "mismatch" });
+      expect(await value.store.get("SELECT account_fingerprint FROM store_owner")).toEqual({
+        account_fingerprint: currentFingerprint,
+      });
+    } finally {
+      await value.store.close();
+    }
   });
 
   it("claims an upgraded store without re-walking or changing its existing history", async () => {

--- a/packages/coach/tests/backfill.test.ts
+++ b/packages/coach/tests/backfill.test.ts
@@ -499,19 +499,21 @@ describe("incremental backfill pages", () => {
   it("claims an ownerless store from the current account before resolving the candidate", async () => {
     const value = await fresh();
     const fingerprint = "a".repeat(64);
-    const resolveFingerprint = vi.fn(async (options: { readonly apiKey: string }) => {
-      if (options.apiKey === "current-key") {
-        expect(await value.store.get("SELECT count(*) AS count FROM store_owner")).toEqual({
-          count: 0,
-        });
-      } else {
-        expect(options.apiKey).toBe("candidate-key");
-        expect(await value.store.get("SELECT account_fingerprint FROM store_owner")).toEqual({
-          account_fingerprint: fingerprint,
-        });
-      }
-      return fingerprint;
-    });
+    const resolveFingerprint = vi.fn(
+      async (options: { readonly apiKey: string; readonly athleteId: string }) => {
+        if (options.apiKey === "current-key") {
+          expect(await value.store.get("SELECT count(*) AS count FROM store_owner")).toEqual({
+            count: 0,
+          });
+        } else {
+          expect(options.apiKey).toBe("candidate-key");
+          expect(await value.store.get("SELECT account_fingerprint FROM store_owner")).toEqual({
+            account_fingerprint: fingerprint,
+          });
+        }
+        return fingerprint;
+      },
+    );
     try {
       await assertRuntimeAthleteOwner(
         value.store,

--- a/packages/coach/tests/composition.test.ts
+++ b/packages/coach/tests/composition.test.ts
@@ -1513,7 +1513,16 @@ describe("local coach composition", () => {
 
   it("guards a key-only change for canonical athlete zero", async () => {
     const home = await freshHome();
-    const assertRuntimeAthleteOwner = vi.fn(async () => {});
+    const assertRuntimeAthleteOwner = vi.fn(
+      async (
+        _store: Parameters<
+          NonNullable<LocalCoachCompositionDependencies["assertRuntimeAthleteOwner"]>
+        >[0],
+        _options: Parameters<
+          NonNullable<LocalCoachCompositionDependencies["assertRuntimeAthleteOwner"]>
+        >[1],
+      ) => {},
+    );
     const lifecycle = await compose(
       home,
       {
@@ -1556,11 +1565,13 @@ describe("local coach composition", () => {
       trace.push(`owner:${options.candidate.athleteId}`);
     });
     const createRuntime = vi.fn((options: LocalStoreRuntimeOptions) => {
+      if (options.readConfig === undefined) throw new Error("Expected live runtime configuration.");
+      const readConfig = options.readConfig;
       trace.push(`runtime:${options.config.intervals.athleteId}`);
       return {
         ...selectedRuntime,
         async runWindow() {
-          trace.push(`window:${options.readConfig().intervals.athleteId}`);
+          trace.push(`window:${readConfig().intervals.athleteId}`);
           return selectedRuntime.runWindow();
         },
       };

--- a/packages/coach/tests/composition.test.ts
+++ b/packages/coach/tests/composition.test.ts
@@ -31,6 +31,7 @@ import {
   type LocalCoachCompositionDependencies,
   type LocalReferenceRuntime,
   type LocalStoreRuntime,
+  type LocalStoreRuntimeOptions,
 } from "../src/composition.js";
 import { checkHomeReadiness } from "../src/readiness.js";
 import type { CoachStoreWriterContext } from "../src/runtime.js";
@@ -274,17 +275,21 @@ async function compose(
   context = fakeContext(home),
   intervals?: Config["intervals"],
   configOverride?: Config,
+  env: Record<string, string | undefined> = { ENDURAGENT_HOME: home.root },
 ) {
   const coreConfig = configOverride ?? config(home, intervals);
   return createLocalCoachComposition(
     {
-      env: { ENDURAGENT_HOME: home.root },
+      env,
       home,
       context,
       config: coreConfig,
       engineConfig: engineConfigFromConfig(coreConfig),
     },
-    dependencies,
+    {
+      assertRuntimeAthleteOwner: async () => {},
+      ...dependencies,
+    },
   );
 }
 
@@ -1013,6 +1018,9 @@ describe("local coach composition", () => {
       text: "openrouter:model-first",
     });
     await lifecycle.operations.configureRuntime({
+      intervals: { api_key: "placeholder" },
+    });
+    await lifecycle.operations.configureRuntime({
       intervals: { api_key: "placeholder", athlete_id: "athlete-a" },
     });
     await lifecycle.operations.configureRuntime({
@@ -1035,6 +1043,7 @@ describe("local coach composition", () => {
     ).toEqual([
       { provider: "anthropic", model: "synthetic", apiKey: "", intervals: true },
       { provider: "openrouter", model: "model-first", apiKey: "placeholder", intervals: true },
+      { provider: "openrouter", model: "model-first", apiKey: "placeholder", intervals: false },
       { provider: "openrouter", model: "model-first", apiKey: "placeholder", intervals: false },
       { provider: "google", model: "model-second", apiKey: "placeholder", intervals: false },
     ]);
@@ -1066,7 +1075,7 @@ describe("local coach composition", () => {
         createResolver: () => missingResolver(),
       },
       fakeContext(home),
-      { apiKey: "", athleteId: "fake-initial-athlete" },
+      { apiKey: "current-key", athleteId: "fake-initial-athlete" },
     );
 
     await lifecycle.operations.configureRuntime({
@@ -1118,10 +1127,10 @@ describe("local coach composition", () => {
       },
       fakeContext(home),
       undefined,
-      config(home, { apiKey: "", athleteId: "" }),
+      config(home, { apiKey: "current-key", athleteId: "current-athlete" }),
     );
 
-    expect(windows).toEqual([{ apiKey: "", athleteId: "" }]);
+    expect(windows).toEqual([{ apiKey: "current-key", athleteId: "current-athlete" }]);
 
     await expect(
       lifecycle.operations.configureRuntime({
@@ -1137,9 +1146,581 @@ describe("local coach composition", () => {
       athleteId: "replayed-athlete",
     });
     expect(windows).toEqual([
-      { apiKey: "", athleteId: "" },
+      { apiKey: "current-key", athleteId: "current-athlete" },
       { apiKey: "obviously-fake-replayed-key", athleteId: "replayed-athlete" },
     ]);
+    await lifecycle.close();
+  });
+
+  it.each([
+    {
+      label: "a daemon athlete override",
+      activeApiKey: "current-key",
+      candidateApiKey: "candidate-key",
+      envAthleteId: "environment-athlete",
+      ownerFailure: undefined,
+      expectedOwnerChecks: 0,
+    },
+    {
+      label: "an empty daemon athlete override",
+      activeApiKey: "current-key",
+      candidateApiKey: "candidate-key",
+      envAthleteId: "",
+      ownerFailure: undefined,
+      expectedOwnerChecks: 0,
+    },
+    {
+      label: "a missing active credential",
+      activeApiKey: "",
+      candidateApiKey: undefined,
+      envAthleteId: undefined,
+      ownerFailure: "current-credential-missing",
+      expectedOwnerChecks: 1,
+    },
+    {
+      label: "an unresolved current owner",
+      activeApiKey: "current-key",
+      candidateApiKey: "candidate-key",
+      envAthleteId: undefined,
+      ownerFailure: "current-unresolved",
+      expectedOwnerChecks: 1,
+    },
+    {
+      label: "an unresolved candidate owner",
+      activeApiKey: "current-key",
+      candidateApiKey: "candidate-key",
+      envAthleteId: undefined,
+      ownerFailure: "candidate-unresolved",
+      expectedOwnerChecks: 1,
+    },
+    {
+      label: "a mismatched candidate owner",
+      activeApiKey: "current-key",
+      candidateApiKey: "candidate-key",
+      envAthleteId: undefined,
+      ownerFailure: "mismatch",
+      expectedOwnerChecks: 1,
+    },
+  ])(
+    "fails closed before runtime mutation for $label and keeps serialized lanes usable",
+    async ({
+      activeApiKey,
+      candidateApiKey,
+      envAthleteId,
+      ownerFailure,
+      expectedOwnerChecks,
+    }) => {
+      const home = await freshHome();
+      const initialYaml = "sentinel: unchanged\n";
+      await writeFile(join(home.configDir, "config.yaml"), initialYaml);
+      const selectedRuntime = runtime();
+      const runWindowAfter = vi.fn(selectedRuntime.runWindowAfter);
+      const createBackend = vi.fn(() => backend());
+      let remainingOwnerFailures = ownerFailure === undefined ? 0 : 1;
+      const assertRuntimeAthleteOwner = vi.fn(
+        async (
+          _store: Parameters<
+            NonNullable<LocalCoachCompositionDependencies["assertRuntimeAthleteOwner"]>
+          >[0],
+          options: Parameters<
+            NonNullable<LocalCoachCompositionDependencies["assertRuntimeAthleteOwner"]>
+          >[1],
+        ) => {
+          if (
+            ownerFailure !== undefined &&
+            remainingOwnerFailures > 0 &&
+            (options.current.apiKey !== options.candidate.apiKey ||
+              options.current.athleteId !== options.candidate.athleteId)
+          ) {
+            remainingOwnerFailures -= 1;
+            throw new Error(ownerFailure);
+          }
+        },
+      );
+      const lifecycle = await compose(
+        home,
+        {
+          bootstrap: async () => reference(),
+          createRuntime: () => ({ ...selectedRuntime, runWindowAfter }),
+          createBackend,
+          createRepository: () => ({
+            insertIfAbsent: async () => false,
+            readCurrent: async () => undefined,
+          }),
+          createResolver: () => missingResolver(),
+          assertRuntimeAthleteOwner,
+        },
+        fakeContext(home),
+        undefined,
+        config(home, { apiKey: activeApiKey, athleteId: "current-athlete" }),
+        {
+          ENDURAGENT_HOME: home.root,
+          ...(envAthleteId === undefined ? {} : { INTERVALS_ATHLETE_ID: envAthleteId }),
+        },
+      );
+      const ownerChecksBefore = assertRuntimeAthleteOwner.mock.calls.length;
+      const before = await lifecycle.operations.getRuntimeConfig({});
+
+      await expect(
+        lifecycle.operations.configureRuntime({
+          intervals: {
+            ...(candidateApiKey === undefined ? {} : { api_key: candidateApiKey }),
+            athlete_id: "candidate-athlete",
+          },
+        }),
+      ).rejects.toThrow();
+
+      await expect(readFile(join(home.configDir, "config.yaml"), "utf8")).resolves.toBe(
+        initialYaml,
+      );
+      await expect(lifecycle.operations.getRuntimeConfig({})).resolves.toEqual(before);
+      expect(createBackend).toHaveBeenCalledTimes(1);
+      expect(runWindowAfter).not.toHaveBeenCalled();
+      expect(assertRuntimeAthleteOwner.mock.calls.length - ownerChecksBefore).toBe(
+        expectedOwnerChecks,
+      );
+      if (expectedOwnerChecks === 1) {
+        expect(assertRuntimeAthleteOwner).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.objectContaining({
+            current: expect.objectContaining({
+              apiKey: activeApiKey,
+              athleteId: "current-athlete",
+            }),
+            candidate: expect.objectContaining({
+              apiKey: candidateApiKey ?? activeApiKey,
+              athleteId: "candidate-athlete",
+            }),
+          }),
+        );
+      }
+
+      await expect(
+        lifecycle.operations.configureRuntime({ llm: { model: "queue-recovered-model" } }),
+      ).resolves.toMatchObject({ applied: { llm: true, intervals: false } });
+      await expect(
+        lifecycle.operations.configureRuntime({ intervals: { api_key: "writer-recovered-key" } }),
+      ).resolves.toMatchObject({ applied: { llm: false, intervals: true } });
+      expect(createBackend).toHaveBeenCalledTimes(3);
+      expect(runWindowAfter).toHaveBeenCalledOnce();
+      await lifecycle.close();
+    },
+  );
+
+  it.each([
+    { envApiKey: "environment-key", rejected: true },
+    { envApiKey: "", rejected: false },
+  ])(
+    "treats daemon API-key environment value '$envApiKey' as effective authority: $rejected",
+    async ({ envApiKey, rejected }) => {
+      const home = await freshHome();
+      const selectedRuntime = runtime();
+      const runWindowAfter = vi.fn(selectedRuntime.runWindowAfter);
+      const createBackend = vi.fn(() => backend());
+      const assertRuntimeAthleteOwner = vi.fn(async () => {});
+      const lifecycle = await compose(
+        home,
+        {
+          bootstrap: async () => reference(),
+          createRuntime: () => ({ ...selectedRuntime, runWindowAfter }),
+          createBackend,
+          createRepository: () => ({
+            insertIfAbsent: async () => false,
+            readCurrent: async () => undefined,
+          }),
+          createResolver: () => missingResolver(),
+          assertRuntimeAthleteOwner,
+        },
+        fakeContext(home),
+        { apiKey: "current-key", athleteId: "0" },
+        undefined,
+        { ENDURAGENT_HOME: home.root, INTERVALS_API_KEY: envApiKey },
+      );
+      const ownerChecksBefore = assertRuntimeAthleteOwner.mock.calls.length;
+      const change = lifecycle.operations.configureRuntime({
+        intervals: { api_key: "candidate-key" },
+      });
+
+      if (rejected) {
+        await expect(change).rejects.toThrow(
+          "runtime intervals credential is controlled by the daemon environment",
+        );
+        expect(createBackend).toHaveBeenCalledTimes(1);
+        expect(runWindowAfter).not.toHaveBeenCalled();
+        expect(assertRuntimeAthleteOwner).toHaveBeenCalledTimes(ownerChecksBefore);
+      } else {
+        await expect(change).resolves.toMatchObject({ applied: { intervals: true } });
+        expect(createBackend).toHaveBeenCalledTimes(2);
+        expect(runWindowAfter).toHaveBeenCalledOnce();
+        expect(assertRuntimeAthleteOwner).toHaveBeenCalledTimes(ownerChecksBefore + 1);
+      }
+      await lifecycle.close();
+    },
+  );
+
+  it("guards a combined first credential and canonical athlete selection", async () => {
+    const home = await freshHome();
+    const assertRuntimeAthleteOwner = vi.fn(async () => {});
+    const lifecycle = await compose(
+      home,
+      {
+        bootstrap: async () => reference(),
+        createRuntime: () => runtime(),
+        createBackend: () => backend(),
+        createRepository: () => ({
+          insertIfAbsent: async () => false,
+          readCurrent: async () => undefined,
+        }),
+        createResolver: () => missingResolver(),
+        assertRuntimeAthleteOwner,
+      },
+      fakeContext(home),
+      undefined,
+      config(home, { apiKey: "", athleteId: "" }),
+    );
+
+    await expect(
+      lifecycle.operations.configureRuntime({
+        intervals: { api_key: "candidate-key", athlete_id: "first-athlete" },
+      }),
+    ).resolves.toMatchObject({ applied: { intervals: true } });
+    expect(assertRuntimeAthleteOwner).toHaveBeenCalledOnce();
+    expect(assertRuntimeAthleteOwner).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        current: expect.objectContaining({ apiKey: "", athleteId: "0" }),
+        candidate: expect.objectContaining({
+          apiKey: "candidate-key",
+          athleteId: "first-athlete",
+        }),
+        claimUnownedCandidateWithoutCurrent: true,
+      }),
+    );
+    await lifecycle.close();
+  });
+
+  it.each(["oauth-validation", "persistence"] as const)(
+    "does not claim a first credential after downstream %s failure",
+    async (failurePoint) => {
+      const home = await freshHome();
+      if (failurePoint === "oauth-validation") {
+        await writeFile(
+          join(home.configDir, "auth-profiles.json"),
+          JSON.stringify({ "openai-codex": { type: "oauth" } }),
+          { mode: 0o600 },
+        );
+      }
+      const claim = vi.fn(async () => {});
+      const createBackend = vi.fn(() => backend());
+      const selectedRuntime = runtime();
+      const runWindowAfter = vi.fn(selectedRuntime.runWindowAfter);
+      const lifecycle = await compose(
+        home,
+        {
+          bootstrap: async () => reference(),
+          createRuntime: () => ({ ...selectedRuntime, runWindowAfter }),
+          createBackend,
+          createRepository: () => ({
+            insertIfAbsent: async () => false,
+            readCurrent: async () => undefined,
+          }),
+          createResolver: () => missingResolver(),
+          assertRuntimeAthleteOwner: async () => ({ claim }),
+          ...(failurePoint === "persistence"
+            ? {
+                persistRuntimeConfig: () => {
+                  throw new Error("synthetic persistence failure");
+                },
+              }
+            : {}),
+        },
+        fakeContext(home),
+        undefined,
+        config(home, { apiKey: "", athleteId: "" }),
+      );
+
+      await expect(
+        lifecycle.operations.configureRuntime({
+          intervals: { api_key: "candidate-key", athlete_id: "first-athlete" },
+          ...(failurePoint === "oauth-validation"
+            ? { llm: { provider: "openai-codex", model: "gpt-5.5" } }
+            : {}),
+        }),
+      ).rejects.toThrow(
+        failurePoint === "oauth-validation"
+          ? "OAuth profile is invalid."
+          : "synthetic persistence failure",
+      );
+      expect(claim).not.toHaveBeenCalled();
+      expect(createBackend).toHaveBeenCalledTimes(
+        failurePoint === "oauth-validation" ? 1 : 2,
+      );
+      expect(runWindowAfter).not.toHaveBeenCalled();
+      await expect(lifecycle.operations.getRuntimeConfig({})).resolves.toMatchObject({
+        intervals: { athlete_id: "" },
+      });
+      await expect(readFile(join(home.configDir, "config.yaml"), "utf8")).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+      await lifecycle.close();
+    },
+  );
+
+  it("restores runtime configuration when a deferred first-account claim fails", async () => {
+    const home = await freshHome();
+    const originalYaml = "sentinel: unchanged\n";
+    await writeFile(join(home.configDir, "config.yaml"), originalYaml, { mode: 0o600 });
+    const claim = vi.fn(async () => {
+      throw new Error("synthetic owner claim failure");
+    });
+    const createBackend = vi.fn(() => backend());
+    const selectedRuntime = runtime();
+    const runWindowAfter = vi.fn(selectedRuntime.runWindowAfter);
+    const lifecycle = await compose(
+      home,
+      {
+        bootstrap: async () => reference(),
+        createRuntime: () => ({ ...selectedRuntime, runWindowAfter }),
+        createBackend,
+        createRepository: () => ({
+          insertIfAbsent: async () => false,
+          readCurrent: async () => undefined,
+        }),
+        createResolver: () => missingResolver(),
+        assertRuntimeAthleteOwner: async () => ({ claim }),
+      },
+      fakeContext(home),
+      undefined,
+      config(home, { apiKey: "", athleteId: "" }),
+    );
+
+    await expect(
+      lifecycle.operations.configureRuntime({
+        intervals: { api_key: "candidate-key", athlete_id: "first-athlete" },
+      }),
+    ).rejects.toThrow("synthetic owner claim failure");
+    expect(claim).toHaveBeenCalledOnce();
+    expect(createBackend).toHaveBeenCalledTimes(2);
+    expect(runWindowAfter).not.toHaveBeenCalled();
+    await expect(lifecycle.operations.getRuntimeConfig({})).resolves.toMatchObject({
+      intervals: { athlete_id: "" },
+    });
+    await expect(readFile(join(home.configDir, "config.yaml"), "utf8")).resolves.toBe(
+      originalYaml,
+    );
+    await lifecycle.close();
+  });
+
+  it("guards a key-only change for canonical athlete zero", async () => {
+    const home = await freshHome();
+    const assertRuntimeAthleteOwner = vi.fn(async () => {});
+    const lifecycle = await compose(
+      home,
+      {
+        bootstrap: async () => reference(),
+        createRuntime: () => runtime(),
+        createBackend: () => backend(),
+        createRepository: () => ({
+          insertIfAbsent: async () => false,
+          readCurrent: async () => undefined,
+        }),
+        createResolver: () => missingResolver(),
+        assertRuntimeAthleteOwner,
+      },
+      fakeContext(home),
+      undefined,
+      config(home, { apiKey: "current-key", athleteId: "" }),
+    );
+    const ownerChecksBefore = assertRuntimeAthleteOwner.mock.calls.length;
+
+    await expect(
+      lifecycle.operations.configureRuntime({
+        intervals: { api_key: "candidate-key" },
+      }),
+    ).resolves.toMatchObject({ applied: { intervals: true } });
+    expect(assertRuntimeAthleteOwner).toHaveBeenCalledTimes(ownerChecksBefore + 1);
+    expect(assertRuntimeAthleteOwner.mock.calls.at(-1)?.[1]).toEqual(
+      expect.objectContaining({
+        current: expect.objectContaining({ apiKey: "current-key", athleteId: "0" }),
+        candidate: expect.objectContaining({ apiKey: "candidate-key", athleteId: "0" }),
+      }),
+    );
+    await lifecycle.close();
+  });
+
+  it("validates and canonicalizes a configured account before the first provider window", async () => {
+    const home = await freshHome();
+    const trace: string[] = [];
+    const selectedRuntime = runtime();
+    const assertRuntimeAthleteOwner = vi.fn(async (_store, options) => {
+      trace.push(`owner:${options.candidate.athleteId}`);
+    });
+    const createRuntime = vi.fn((options: LocalStoreRuntimeOptions) => {
+      trace.push(`runtime:${options.config.intervals.athleteId}`);
+      return {
+        ...selectedRuntime,
+        async runWindow() {
+          trace.push(`window:${options.readConfig().intervals.athleteId}`);
+          return selectedRuntime.runWindow();
+        },
+      };
+    });
+
+    const lifecycle = await compose(
+      home,
+      {
+        bootstrap: async () => reference(),
+        createRuntime,
+        createBackend: () => backend(),
+        createRepository: () => ({
+          insertIfAbsent: async () => false,
+          readCurrent: async () => undefined,
+        }),
+        createResolver: () => missingResolver(),
+        assertRuntimeAthleteOwner,
+      },
+      fakeContext(home),
+      undefined,
+      config(home, { apiKey: "configured-key", athleteId: "" }),
+    );
+
+    expect(trace.slice(0, 3)).toEqual(["owner:0", "runtime:0", "window:0"]);
+    await lifecycle.close();
+  });
+
+  it("does not create a provider runtime after configured account ownership is refused", async () => {
+    const home = await freshHome();
+    const bootstrap = vi.fn(async () => reference());
+    const createRuntime = vi.fn(() => runtime());
+
+    await expect(
+      compose(
+        home,
+        {
+          bootstrap,
+          createRuntime,
+          createBackend: () => backend(),
+          createRepository: () => ({
+            insertIfAbsent: async () => false,
+            readCurrent: async () => undefined,
+          }),
+          createResolver: () => missingResolver(),
+          assertRuntimeAthleteOwner: async () => {
+            throw new Error("synthetic configured account mismatch");
+          },
+        },
+        fakeContext(home),
+        { apiKey: "configured-key", athleteId: "configured-athlete" },
+      ),
+    ).rejects.toThrow("synthetic configured account mismatch");
+    expect(bootstrap).not.toHaveBeenCalled();
+    expect(createRuntime).not.toHaveBeenCalled();
+  });
+
+  it("does not resolve identity when the athlete ID is unchanged", async () => {
+    const home = await freshHome();
+    const assertRuntimeAthleteOwner = vi.fn(async () => {});
+    const lifecycle = await compose(
+      home,
+      {
+        bootstrap: async () => reference(),
+        createRuntime: () => runtime(),
+        createBackend: () => backend(),
+        createRepository: () => ({
+          insertIfAbsent: async () => false,
+          readCurrent: async () => undefined,
+        }),
+        createResolver: () => missingResolver(),
+        assertRuntimeAthleteOwner,
+      },
+      fakeContext(home),
+      { apiKey: "current-key", athleteId: "current-athlete" },
+    );
+    const ownerChecksBefore = assertRuntimeAthleteOwner.mock.calls.length;
+
+    await expect(
+      lifecycle.operations.configureRuntime({
+        intervals: { api_key: "current-key", athlete_id: "current-athlete" },
+      }),
+    ).resolves.toMatchObject({ applied: { intervals: true } });
+    expect(assertRuntimeAthleteOwner).toHaveBeenCalledTimes(ownerChecksBefore);
+    await lifecycle.close();
+  });
+
+  it("applies an owner-approved athlete ID change before replacing and refreshing", async () => {
+    const home = await freshHome();
+    await writeFile(
+      join(home.configDir, "config.yaml"),
+      toYaml({
+        retained_root: true,
+        intervals: { athlete_id: "current-athlete", retained_intervals: true },
+      }),
+    );
+    const selectedRuntime = runtime();
+    const runWindowAfter = vi.fn(selectedRuntime.runWindowAfter);
+    const createBackend = vi.fn(() => backend());
+    const assertRuntimeAthleteOwner = vi.fn(async () => {});
+    let runtimeOptions:
+      | Parameters<NonNullable<LocalCoachCompositionDependencies["createRuntime"]>>[0]
+      | undefined;
+    const lifecycle = await compose(
+      home,
+      {
+        bootstrap: async () => reference(),
+        createRuntime: (options) => {
+          runtimeOptions = options;
+          return { ...selectedRuntime, runWindowAfter };
+        },
+        createBackend,
+        createRepository: () => ({
+          insertIfAbsent: async () => false,
+          readCurrent: async () => undefined,
+        }),
+        createResolver: () => missingResolver(),
+        assertRuntimeAthleteOwner,
+      },
+      fakeContext(home),
+      { apiKey: "current-key", athleteId: "current-athlete" },
+    );
+
+    await expect(
+      lifecycle.operations.configureRuntime({
+        intervals: {
+          api_key: "candidate-key",
+          athlete_id: "candidate-athlete",
+        },
+      }),
+    ).resolves.toMatchObject({ applied: { intervals: true } });
+
+    expect(assertRuntimeAthleteOwner).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        current: expect.objectContaining({
+          apiKey: "current-key",
+          athleteId: "current-athlete",
+        }),
+        candidate: expect.objectContaining({
+          apiKey: "candidate-key",
+          athleteId: "candidate-athlete",
+        }),
+      }),
+    );
+    expect(parseYaml(await readFile(join(home.configDir, "config.yaml"), "utf8"))).toEqual({
+      retained_root: true,
+      intervals: {
+        athlete_id: "candidate-athlete",
+        retained_intervals: true,
+      },
+    });
+    expect(runtimeOptions?.readConfig?.().intervals).toEqual({
+      apiKey: "candidate-key",
+      athleteId: "candidate-athlete",
+    });
+    await expect(lifecycle.operations.getRuntimeConfig({})).resolves.toMatchObject({
+      intervals: { athlete_id: "candidate-athlete" },
+    });
+    expect(createBackend).toHaveBeenCalledTimes(2);
+    expect(runWindowAfter).toHaveBeenCalledOnce();
     await lifecycle.close();
   });
 
@@ -1310,16 +1891,21 @@ describe("local coach composition", () => {
           rejectRefresh = reject;
         }),
     );
-    const lifecycle = await compose(home, {
-      bootstrap: async () => reference(),
-      createRuntime: () => ({ ...initial, runWindowAfter }),
-      createBackend: () => backend(),
-      createRepository: () => ({
-        insertIfAbsent: async () => false,
-        readCurrent: async () => undefined,
-      }),
-      createResolver: () => missingResolver(),
-    });
+    const lifecycle = await compose(
+      home,
+      {
+        bootstrap: async () => reference(),
+        createRuntime: () => ({ ...initial, runWindowAfter }),
+        createBackend: () => backend(),
+        createRepository: () => ({
+          insertIfAbsent: async () => false,
+          readCurrent: async () => undefined,
+        }),
+        createResolver: () => missingResolver(),
+      },
+      fakeContext(home),
+      { apiKey: "current-key", athleteId: "current-athlete" },
+    );
 
     await expect(
       lifecycle.operations.configureRuntime({

--- a/packages/coach/tests/operations.test.ts
+++ b/packages/coach/tests/operations.test.ts
@@ -796,6 +796,52 @@ describe("coach operations", () => {
     ]);
   });
 
+  it("expires an intervals configuration before delayed store admission without late mutation", async () => {
+    const syncStarted = promiseGate();
+    const releaseSync = promiseGate();
+    const applyRuntimeConfig = vi.fn(async () => {});
+    const operations = createCoachOperations(
+      {
+        home,
+        context: context(),
+        runtime: operationRuntime(async (work) => {
+          syncStarted.release();
+          await releaseSync.promise;
+          await work(new AbortController().signal);
+          return {
+            published: true,
+            legacySucceeded: true,
+            counts: requestCounts(0, 0),
+          };
+        }),
+        intervalsCredentials: intervalsCredentials(),
+        historyNewestDate: () => "1998-07-18",
+        applyRuntimeConfig,
+      },
+      { runtimeConfigurationDeadlineMs: 5 },
+    );
+
+    const sync = operations.sync({});
+    await syncStarted.promise;
+    const stale = operations
+      .configureRuntime({
+        intervals: { api_key: "placeholder-intervals", athlete_id: "synthetic-athlete" },
+      })
+      .catch((error: unknown) => error);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    releaseSync.release();
+
+    await expect(sync).resolves.toMatchObject({ schemaVersion: 1 });
+    expect(await stale).toBeInstanceOf(Error);
+    expect(applyRuntimeConfig).not.toHaveBeenCalled();
+    await expect(
+      operations.configureRuntime({
+        llm: { provider: "openai", model: "recovered-model", api_key: "placeholder" },
+      }),
+    ).resolves.toMatchObject({ applied: { llm: true, intervals: false } });
+    expect(applyRuntimeConfig).toHaveBeenCalledOnce();
+  });
+
   it("serializes runtime configuration writes and reads in strict admission order", async () => {
     const firstStarted = promiseGate();
     const releaseFirst = promiseGate();


### PR DESCRIPTION
## Summary

- validate configured, startup, and live training credentials against the store owner before provider access
- serialize runtime account changes under bounded cancellation and canonical athlete identity handling
- defer first-account ownership until the candidate is ready, restoring the exact prior configuration if the claim fails

## Test plan

- [x] `pnpm --filter @enduragent/coach check`
- [x] `pnpm check`
- [x] `pnpm exec oxlint packages/coach/src/backfill.ts packages/coach/src/composition.ts packages/coach/src/operations.ts packages/coach/tests/backfill.test.ts packages/coach/tests/composition.test.ts packages/coach/tests/operations.test.ts`
- [x] `pnpm vitest run packages/coach/tests/backfill.test.ts packages/coach/tests/composition.test.ts packages/coach/tests/operations.test.ts` (114 tests)
- [x] `git diff --check`
