### PR TITLE
feat(desktop): add protected training account settings

### DIFF
--- a/.changeset/desktop-training-account-settings.md
+++ b/.changeset/desktop-training-account-settings.md
@@ -1,0 +1,7 @@
+---
+"cycling-coach": patch
+---
+
+User-facing: Added a protected Training account setting for identifying the currently connected training account.
+
+Expose credential and environment-ownership state without secrets, and return fixed account-guard refusals across the desktop runtime protocol.

--- a/apps/desktop-renderer/src/index.ts
+++ b/apps/desktop-renderer/src/index.ts
@@ -31,6 +31,8 @@ import { createDesktopUpdateController } from "./update/controller.js";
 import { createDesktopUpdateView } from "./update/view.js";
 import { createProviderModelSettingsController } from "./settings/provider-model-controller.js";
 import { createProviderModelSettingsView } from "./settings/provider-model-view.js";
+import { createAthleteSettingsController } from "./settings/athlete-controller.js";
+import { createAthleteSettingsView } from "./settings/athlete-view.js";
 import { createResidentSettingsShell } from "./settings/shell.js";
 import { createSessionSettingsController } from "./settings/session-controller.js";
 import { createSessionSettingsView } from "./settings/session-view.js";
@@ -293,31 +295,51 @@ const settingsShell = createResidentSettingsShell({
   actionHost: topbarActions,
   before: setup,
 });
+const providerModelSettingsView = createProviderModelSettingsView({
+  document,
+  shell: settingsShell,
+});
+const athleteSettingsView = createAthleteSettingsView({ document, shell: settingsShell });
+const sessionSettingsView = createSessionSettingsView({ document, shell: settingsShell });
 const sessionSettingsController = createSessionSettingsController({
   clients,
   beginMutation: () => settingsShell.beginMutation("session"),
-  view: createSessionSettingsView({ document, shell: settingsShell }),
+  view: sessionSettingsView,
+});
+const athleteSettingsController = createAthleteSettingsController({
+  clients,
+  openSetup: () => {
+    providerModelSettingsController.close();
+    athleteSettingsController.close();
+    sessionSettingsController.close();
+    settingsShell.close();
+    setup.click();
+  },
+  beginMutation: () => settingsShell.beginMutation("athlete"),
+  view: athleteSettingsView,
 });
 const providerModelSettingsController = createProviderModelSettingsController({
   load: () => window.enduragentAuth.llmConfiguration(),
   apply: (selection) => window.enduragentAuth.applyLlmSelection(selection),
   openSetup: () => {
+    providerModelSettingsController.close();
+    athleteSettingsController.close();
     sessionSettingsController.close();
+    settingsShell.close();
     setup.click();
   },
   beginMutation: () => settingsShell.beginMutation("provider-model"),
-  view: createProviderModelSettingsView({
-    document,
-    shell: settingsShell,
-  }),
+  view: providerModelSettingsView,
 });
 settingsShell.bind({
   onOpen() {
     void providerModelSettingsController.activate();
+    void athleteSettingsController.activate();
     void sessionSettingsController.activate();
   },
   onClose() {
     providerModelSettingsController.close();
+    athleteSettingsController.close();
     sessionSettingsController.close();
     settingsShell.close();
   },
@@ -349,6 +371,7 @@ window.addEventListener(
     releaseNotesController.dispose();
     desktopUpdateController.dispose();
     providerModelSettingsController.dispose();
+    athleteSettingsController.dispose();
     sessionSettingsController.dispose();
     settingsShell.dispose();
     disposeDroppedRideImports();

--- a/apps/desktop-renderer/src/settings/athlete-controller.ts
+++ b/apps/desktop-renderer/src/settings/athlete-controller.ts
@@ -1,0 +1,322 @@
+import {
+  CoachClientDisconnectedError,
+  CoachClientProtocolError,
+  type CoachClient,
+} from "@enduragent/coach-client";
+import type {
+  ConfigureRuntimeRpcRefusalReason,
+  RuntimeConfigSnapshot,
+} from "@enduragent/coach-contract";
+import type { DesktopCoachClientProvider } from "../coach-client.js";
+
+export type AthleteSettingsValidationError =
+  | "athlete-required"
+  | "athlete-whitespace"
+  | "athlete-too-long"
+  | "athlete-control-characters";
+
+export type AthleteSettingsSaveError =
+  | ConfigureRuntimeRpcRefusalReason
+  | "request-failed"
+  | "not-applied"
+  | "runtime-unavailable";
+
+export interface AthleteSettingsFormState {
+  readonly effective: RuntimeConfigSnapshot["intervals"];
+  readonly draft: string;
+  readonly dirty: boolean;
+  readonly validationError: AthleteSettingsValidationError | null;
+}
+
+export type AthleteSettingsState =
+  | { readonly status: "closed" }
+  | { readonly status: "loading" }
+  | ({ readonly status: "ready" | "refreshing" | "saving" | "saved" } & AthleteSettingsFormState)
+  | {
+      readonly status: "error";
+      readonly kind: "load";
+      readonly reason: "runtime-unavailable";
+    }
+  | ({
+      readonly status: "error";
+      readonly kind: "save";
+      readonly reason: AthleteSettingsSaveError;
+    } & AthleteSettingsFormState);
+
+export interface AthleteSettingsView {
+  bind(handlers: {
+    readonly onRetry: () => void;
+    readonly onChange: (value: string) => void;
+    readonly onSave: () => void;
+    readonly onOpenSetup: () => void;
+  }): void;
+  render(state: Exclude<AthleteSettingsState, { readonly status: "closed" }>): void;
+  dispose(): void;
+}
+
+export interface AthleteSettingsController {
+  activate(): Promise<void>;
+  close(): void;
+  state(): AthleteSettingsState;
+  dispose(): void;
+}
+
+function hasControlCharacters(value: string): boolean {
+  return Array.from(value).some((character) => {
+    const codePoint = character.codePointAt(0);
+    return codePoint !== undefined && (codePoint <= 31 || (codePoint >= 127 && codePoint <= 159));
+  });
+}
+
+function validationError(value: string): AthleteSettingsValidationError | null {
+  if (value.length === 0) return "athlete-required";
+  if (value.trim() !== value) return "athlete-whitespace";
+  if (value.length > 512) return "athlete-too-long";
+  if (hasControlCharacters(value)) return "athlete-control-characters";
+  return null;
+}
+
+function formState(
+  effective: RuntimeConfigSnapshot["intervals"],
+  draft: string,
+): AthleteSettingsFormState {
+  return {
+    effective,
+    draft,
+    dirty:
+      effective.credential_configured &&
+      !effective.managedByEnvironment.athleteId &&
+      draft !== effective.athlete_id,
+    validationError: validationError(draft),
+  };
+}
+
+function editableState(state: AthleteSettingsState): AthleteSettingsFormState | null {
+  if (
+    state.status === "ready" ||
+    state.status === "refreshing" ||
+    state.status === "saving" ||
+    state.status === "saved" ||
+    (state.status === "error" && state.kind === "save")
+  ) {
+    return state;
+  }
+  return null;
+}
+
+function reconcileDraft(
+  previous: AthleteSettingsFormState | null,
+  effective: RuntimeConfigSnapshot["intervals"],
+): string {
+  if (
+    effective.credential_configured &&
+    !effective.managedByEnvironment.athleteId &&
+    previous !== null &&
+    previous.draft !== previous.effective.athlete_id
+  ) {
+    return previous.draft;
+  }
+  return effective.athlete_id;
+}
+
+export function createAthleteSettingsController(input: {
+  readonly clients: DesktopCoachClientProvider;
+  readonly view: AthleteSettingsView;
+  readonly beginMutation: () => (() => void) | null;
+  readonly openSetup: () => void;
+}): AthleteSettingsController {
+  let currentState: AthleteSettingsState = { status: "closed" };
+  let generation = 0;
+  let disposed = false;
+  let operation: Promise<void> | undefined;
+  let reconnectRequired = false;
+  let failedClient: CoachClient | undefined;
+
+  const render = (state: Exclude<AthleteSettingsState, { readonly status: "closed" }>): void => {
+    currentState = state;
+    input.view.render(state);
+  };
+
+  const clientForOperation = async (): Promise<CoachClient> => {
+    if (!reconnectRequired) return input.clients.getClient();
+    const current = await input.clients.getClient();
+    const client =
+      failedClient !== undefined && current === failedClient
+        ? await input.clients.reconnect()
+        : current;
+    reconnectRequired = false;
+    failedClient = undefined;
+    return client;
+  };
+
+  const noteFailure = (error: unknown, client: CoachClient | undefined): void => {
+    if (error instanceof CoachClientDisconnectedError) {
+      reconnectRequired = true;
+      failedClient = client;
+    }
+  };
+
+  const startLoad = (preserveDraft: boolean): Promise<void> => {
+    if (disposed || operation !== undefined) return operation ?? Promise.resolve();
+    const previous = preserveDraft ? editableState(currentState) : null;
+    const operationGeneration = ++generation;
+    if (previous === null) render({ status: "loading" });
+    else render({ ...previous, status: "refreshing" });
+    let activeClient: CoachClient | undefined;
+    const pending = Promise.resolve()
+      .then(async () => {
+        activeClient = await clientForOperation();
+        return activeClient.call("getRuntimeConfig", {});
+      })
+      .then(
+        (snapshot) => {
+          if (disposed || generation !== operationGeneration) return;
+          const draft = reconcileDraft(previous, snapshot.intervals);
+          render({ status: "ready", ...formState(snapshot.intervals, draft) });
+        },
+        (error: unknown) => {
+          noteFailure(error, activeClient);
+          if (disposed || generation !== operationGeneration) return;
+          if (previous === null) {
+            render({ status: "error", kind: "load", reason: "runtime-unavailable" });
+          } else {
+            render({
+              ...previous,
+              status: "error",
+              kind: "save",
+              reason: "runtime-unavailable",
+            });
+          }
+        },
+      )
+      .finally(() => {
+        if (operation === pending) operation = undefined;
+      });
+    operation = pending;
+    return pending;
+  };
+
+  const change = (value: string): void => {
+    if (disposed || currentState.status === "saving" || currentState.status === "refreshing")
+      return;
+    const editable = editableState(currentState);
+    if (
+      editable === null ||
+      !editable.effective.credential_configured ||
+      editable.effective.managedByEnvironment.athleteId
+    ) {
+      return;
+    }
+    render({ status: "ready", ...formState(editable.effective, value) });
+  };
+
+  const save = (): Promise<void> => {
+    if (disposed || operation !== undefined) return operation ?? Promise.resolve();
+    const editable = editableState(currentState);
+    if (
+      editable === null ||
+      !editable.dirty ||
+      editable.validationError !== null ||
+      !editable.effective.credential_configured ||
+      editable.effective.managedByEnvironment.athleteId
+    ) {
+      return Promise.resolve();
+    }
+    const releaseMutation = input.beginMutation();
+    if (releaseMutation === null) return Promise.resolve();
+    const operationGeneration = ++generation;
+    render({ ...editable, status: "saving" });
+    let activeClient: CoachClient | undefined;
+    let applied = false;
+    const pending = Promise.resolve()
+      .then(async () => {
+        activeClient = await clientForOperation();
+        const result = await activeClient.call("configureRuntime", {
+          intervals: { athlete_id: editable.draft },
+        });
+        if (result.status === "refused") return result;
+        if (result.applied.intervals !== true) throw new CoachClientProtocolError();
+        applied = true;
+        return activeClient.call("getRuntimeConfig", {});
+      })
+      .then(
+        (result) => {
+          if (disposed || generation !== operationGeneration) return;
+          if (!("intervals" in result)) {
+            render({
+              ...editable,
+              status: "error",
+              kind: "save",
+              reason: result.reason,
+            });
+            return;
+          }
+          render({
+            status: "saved",
+            ...formState(result.intervals, result.intervals.athlete_id),
+          });
+        },
+        (error: unknown) => {
+          noteFailure(error, activeClient);
+          if (disposed || generation !== operationGeneration) return;
+          render({
+            ...editable,
+            status: "error",
+            kind: "save",
+            reason: applied
+              ? "runtime-unavailable"
+              : error instanceof CoachClientProtocolError
+                ? "not-applied"
+                : "request-failed",
+          });
+        },
+      )
+      .finally(() => {
+        releaseMutation();
+        if (operation === pending) operation = undefined;
+      });
+    operation = pending;
+    return pending;
+  };
+
+  const openSetup = (): void => {
+    const editable = editableState(currentState);
+    const credentialRequired =
+      editable?.effective.credential_configured === false ||
+      (currentState.status === "error" &&
+        currentState.kind === "save" &&
+        currentState.reason === "credential-required");
+    if (disposed || !credentialRequired) return;
+    input.openSetup();
+  };
+
+  input.view.bind({
+    onRetry: () => void startLoad(currentState.status === "error" && currentState.kind === "save"),
+    onChange: change,
+    onSave: () => void save(),
+    onOpenSetup: openSetup,
+  });
+
+  return {
+    activate() {
+      if (disposed) return Promise.resolve();
+      if (currentState.status !== "closed") return operation ?? Promise.resolve();
+      return startLoad(false);
+    },
+    close() {
+      if (disposed) return;
+      ++generation;
+      operation = undefined;
+      currentState = { status: "closed" };
+    },
+    state: () => currentState,
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      ++generation;
+      operation = undefined;
+      currentState = { status: "closed" };
+      input.view.dispose();
+    },
+  };
+}

--- a/apps/desktop-renderer/src/settings/athlete-view.ts
+++ b/apps/desktop-renderer/src/settings/athlete-view.ts
@@ -1,0 +1,276 @@
+import type {
+  AthleteSettingsFormState,
+  AthleteSettingsState,
+  AthleteSettingsValidationError,
+  AthleteSettingsView,
+} from "./athlete-controller.js";
+import type { ResidentSettingsShell } from "./shell.js";
+
+const VALIDATION_COPY: Readonly<Record<AthleteSettingsValidationError, string>> = {
+  "athlete-required": "Enter the athlete ID for the connected training account.",
+  "athlete-whitespace": "Athlete IDs cannot begin or end with whitespace.",
+  "athlete-too-long": "Athlete IDs must be 512 characters or fewer.",
+  "athlete-control-characters": "Athlete IDs can’t contain control characters.",
+};
+
+const SAVE_ERROR_COPY = {
+  "credential-required": "Connect the training account in Setup before saving its athlete ID.",
+  "ownership-unavailable":
+    "The connected training account couldn’t be verified. Reconnect and reload before trying again.",
+  "training-account-mismatch":
+    "That athlete ID does not identify the currently connected training account.",
+  "managed-by-environment": "The athlete ID is managed outside Enduragent and wasn’t changed.",
+  "request-failed": "The athlete ID couldn’t be saved. Your edit is still here.",
+  "not-applied": "The athlete ID wasn’t applied. Reconnect and reload before trying again.",
+  "runtime-unavailable":
+    "The current training account couldn’t be reloaded. Your edit is still here.",
+} as const;
+
+function element<K extends keyof HTMLElementTagNameMap>(
+  document: Document,
+  name: K,
+  className?: string,
+  text?: string,
+): HTMLElementTagNameMap[K] {
+  const value = document.createElement(name);
+  if (className !== undefined) value.className = className;
+  if (text !== undefined) value.textContent = text;
+  return value;
+}
+
+function formState(
+  state: Exclude<AthleteSettingsState, { readonly status: "closed" }>,
+): AthleteSettingsFormState | null {
+  if (
+    state.status === "ready" ||
+    state.status === "refreshing" ||
+    state.status === "saving" ||
+    state.status === "saved" ||
+    (state.status === "error" && state.kind === "save")
+  ) {
+    return state;
+  }
+  return null;
+}
+
+export function createAthleteSettingsView(input: {
+  readonly document: Document;
+  readonly shell: ResidentSettingsShell;
+}): AthleteSettingsView {
+  const form = element(input.document, "form", "athlete-settings");
+  form.noValidate = true;
+  const section = element(input.document, "fieldset", "settings-section athlete-settings__section");
+  const legend = element(input.document, "legend", "settings-section__legend", "Training account");
+  legend.tabIndex = -1;
+  const intro = element(
+    input.document,
+    "p",
+    "settings-section__intro",
+    "This may only identify the currently connected training account. It cannot switch accounts.",
+  );
+  const field = element(input.document, "div", "athlete-settings__field");
+  const label = element(input.document, "label", "athlete-settings__label", "Athlete ID");
+  label.htmlFor = "athlete-settings-id";
+  const athleteId = element(input.document, "input");
+  athleteId.id = "athlete-settings-id";
+  athleteId.type = "text";
+  athleteId.autocomplete = "off";
+  athleteId.spellcheck = false;
+  const help = element(
+    input.document,
+    "p",
+    "athlete-settings__help",
+    "Use the exact identifier associated with the credential already connected in Setup.",
+  );
+  help.id = "athlete-settings-help";
+  const managed = element(
+    input.document,
+    "p",
+    "athlete-settings__managed",
+    "Managed by an environment variable. Change it outside Enduragent.",
+  );
+  managed.id = "athlete-settings-managed";
+  managed.hidden = true;
+  const credential = element(
+    input.document,
+    "p",
+    "athlete-settings__credential",
+    "No training account credential is connected. Open Setup to connect one.",
+  );
+  credential.id = "athlete-settings-credential";
+  credential.hidden = true;
+  const validation = element(input.document, "p", "athlete-settings__validation");
+  validation.id = "athlete-settings-validation";
+  validation.setAttribute("aria-live", "polite");
+  validation.setAttribute("aria-atomic", "true");
+  validation.hidden = true;
+  athleteId.setAttribute("aria-describedby", help.id);
+  field.append(label, athleteId, help, managed, credential, validation);
+
+  const feedback = element(input.document, "p", "athlete-settings__feedback");
+  feedback.setAttribute("role", "status");
+  feedback.setAttribute("aria-live", "polite");
+  feedback.setAttribute("aria-atomic", "true");
+  feedback.tabIndex = -1;
+  const actions = element(input.document, "footer", "athlete-settings__actions");
+  const retry = element(input.document, "button", "athlete-settings__retry", "Reconnect & reload");
+  retry.type = "button";
+  const openSetup = element(input.document, "button", "athlete-settings__setup", "Open Setup");
+  openSetup.type = "button";
+  const save = element(input.document, "button", "athlete-settings__save", "Save athlete ID");
+  save.type = "submit";
+  actions.append(retry, openSetup, save);
+  section.append(legend, intro, field, feedback, actions);
+  form.append(section);
+  input.shell.body.append(form);
+
+  let disposed = false;
+  let ownSaving = false;
+  let anyMutation = input.shell.mutationActive;
+  let retryFocusPending = false;
+  let lastState: Exclude<AthleteSettingsState, { readonly status: "closed" }> | undefined;
+  let handlers:
+    | {
+        readonly onRetry: () => void;
+        readonly onChange: (value: string) => void;
+        readonly onSave: () => void;
+        readonly onOpenSetup: () => void;
+      }
+    | undefined;
+
+  const applyInteractivity = (): void => {
+    const editable = lastState === undefined ? null : formState(lastState);
+    const busy =
+      anyMutation ||
+      ownSaving ||
+      lastState?.status === "refreshing" ||
+      lastState?.status === "loading";
+    const locked =
+      editable === null ||
+      !editable.effective.credential_configured ||
+      editable.effective.managedByEnvironment.athleteId;
+    athleteId.disabled = busy || locked;
+    retry.disabled = busy;
+    openSetup.disabled = busy;
+    save.disabled =
+      busy || editable === null || !editable.dirty || editable.validationError !== null || locked;
+    save.textContent = ownSaving ? "Saving…" : "Save athlete ID";
+  };
+
+  const onInput = (): void => {
+    if (!athleteId.disabled && !disposed) handlers?.onChange(athleteId.value);
+  };
+  const onRetry = (): void => {
+    if (!retry.disabled && !disposed) handlers?.onRetry();
+  };
+  const onOpenSetup = (): void => {
+    if (!openSetup.disabled && !disposed) handlers?.onOpenSetup();
+  };
+  const onSubmit = (event: SubmitEvent): void => {
+    event.preventDefault();
+    if (!save.disabled && !disposed) handlers?.onSave();
+  };
+  athleteId.addEventListener("input", onInput);
+  retry.addEventListener("click", onRetry);
+  openSetup.addEventListener("click", onOpenSetup);
+  form.addEventListener("submit", onSubmit);
+
+  const unregisterFocusables = input.shell.registerFocusables(() => [
+    athleteId,
+    retry,
+    openSetup,
+    save,
+  ]);
+  const unsubscribeMutation = input.shell.subscribeToMutation((active) => {
+    anyMutation = active;
+    applyInteractivity();
+  });
+
+  return {
+    bind(nextHandlers) {
+      handlers = nextHandlers;
+    },
+    render(state) {
+      if (disposed) return;
+      lastState = state;
+      ownSaving = state.status === "saving";
+      input.shell.setSectionSaving("athlete", ownSaving);
+      const editable = formState(state);
+      const loadError = state.status === "error" && state.kind === "load";
+      const retryHadFocus = input.document.activeElement === retry;
+      field.hidden = editable === null;
+      retry.hidden = !(loadError || (state.status === "error" && state.kind === "save"));
+      const credentialRequired =
+        editable?.effective.credential_configured === false ||
+        (state.status === "error" &&
+          state.kind === "save" &&
+          state.reason === "credential-required");
+      openSetup.hidden = !credentialRequired;
+
+      if (editable !== null) {
+        if (athleteId.value !== editable.draft) athleteId.value = editable.draft;
+        const externallyManaged = editable.effective.managedByEnvironment.athleteId;
+        managed.hidden = !externallyManaged;
+        credential.hidden = editable.effective.credential_configured;
+        validation.hidden = editable.validationError === null;
+        validation.textContent =
+          editable.validationError === null ? "" : VALIDATION_COPY[editable.validationError];
+        if (editable.validationError === null) athleteId.removeAttribute("aria-invalid");
+        else athleteId.setAttribute("aria-invalid", "true");
+        const describedBy = [
+          help.id,
+          ...(externallyManaged ? [managed.id] : []),
+          ...(!editable.effective.credential_configured ? [credential.id] : []),
+          ...(editable.validationError === null ? [] : [validation.id]),
+        ];
+        athleteId.setAttribute("aria-describedby", describedBy.join(" "));
+      }
+
+      feedback.hidden = false;
+      if (state.status === "loading") {
+        feedback.textContent = "Loading training account settings…";
+      } else if (state.status === "refreshing") {
+        feedback.textContent = "Reconnecting and checking the current training account…";
+      } else if (loadError) {
+        feedback.textContent = "Training account settings aren’t available. Reconnect and reload.";
+      } else if (state.status === "saving") {
+        feedback.textContent = "Saving athlete ID…";
+      } else if (state.status === "saved") {
+        feedback.textContent = "Athlete ID saved.";
+      } else if (state.status === "error" && state.kind === "save") {
+        feedback.textContent = SAVE_ERROR_COPY[state.reason];
+      } else {
+        feedback.textContent = "";
+        feedback.hidden = true;
+      }
+      applyInteractivity();
+      const retryInProgress = state.status === "loading" || state.status === "refreshing";
+      if (retry.hidden && retryHadFocus) {
+        retryFocusPending = true;
+        feedback.focus();
+      }
+      if (retryFocusPending && !retryInProgress) {
+        retryFocusPending = false;
+        if (!retry.hidden && !retry.disabled) retry.focus();
+        else if (!field.hidden && !athleteId.disabled) athleteId.focus();
+        else if (!openSetup.hidden && !openSetup.disabled) openSetup.focus();
+        else legend.focus();
+      }
+    },
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      ownSaving = false;
+      input.shell.setSectionSaving("athlete", false);
+      handlers = undefined;
+      lastState = undefined;
+      unsubscribeMutation();
+      unregisterFocusables();
+      athleteId.removeEventListener("input", onInput);
+      retry.removeEventListener("click", onRetry);
+      openSetup.removeEventListener("click", onOpenSetup);
+      form.removeEventListener("submit", onSubmit);
+      form.remove();
+    },
+  };
+}

--- a/apps/desktop-renderer/src/settings/session-controller.ts
+++ b/apps/desktop-renderer/src/settings/session-controller.ts
@@ -359,7 +359,9 @@ export function createSessionSettingsController(input: {
       .then(async () => {
         activeClient = await clientForOperation();
         const result = await activeClient.call("configureRuntime", { session: patch });
-        if (result.applied.session !== true) throw new CoachClientProtocolError();
+        if (result.status !== "applied" || result.applied.session !== true) {
+          throw new CoachClientProtocolError();
+        }
         return activeClient.call("getRuntimeConfig", {});
       })
       .then(

--- a/apps/desktop-renderer/src/settings/shell.ts
+++ b/apps/desktop-renderer/src/settings/shell.ts
@@ -68,7 +68,7 @@ export function createResidentSettingsShell(input: {
     input.document,
     "p",
     "provider-model-settings__intro",
-    "Choose the coach route and conversation rhythm that work for you.",
+    "Choose the coach route and conversation rhythm, and review the currently connected training account.",
   );
   intro.id = "provider-model-settings-intro";
   heading.append(kicker, title, intro);

--- a/apps/desktop-renderer/src/settings/styles.css
+++ b/apps/desktop-renderer/src/settings/styles.css
@@ -46,6 +46,7 @@
 }
 
 .provider-model-settings__section,
+.athlete-settings,
 .session-settings {
   min-width: 0;
   margin: 0;
@@ -243,6 +244,7 @@
 
 .provider-model-settings__field select,
 .provider-model-settings__field input,
+.athlete-settings__field input,
 .session-settings__field input {
   width: 100%;
   min-width: 0;
@@ -257,6 +259,7 @@
 
 .provider-model-settings__field select:focus-visible,
 .provider-model-settings__field input:focus-visible,
+.athlete-settings__field input:focus-visible,
 .session-settings__field input:focus-visible {
   outline: 3px solid var(--focus);
   outline-offset: 2px;
@@ -264,6 +267,7 @@
 
 .provider-model-settings__field select:disabled,
 .provider-model-settings__field input:disabled,
+.athlete-settings__field input:disabled,
 .session-settings__field input:disabled {
   opacity: 0.6;
 }
@@ -300,6 +304,112 @@
   gap: 10px;
   align-items: center;
   margin-top: 16px;
+}
+
+.athlete-settings__field {
+  display: grid;
+  gap: 7px;
+  margin-top: 18px;
+}
+
+.athlete-settings__label {
+  font-size: 13px;
+  font-weight: 680;
+}
+
+.athlete-settings__help,
+.athlete-settings__managed,
+.athlete-settings__credential,
+.athlete-settings__validation,
+.athlete-settings__feedback {
+  margin: 0;
+  overflow-wrap: anywhere;
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.athlete-settings__help,
+.athlete-settings__feedback {
+  color: var(--muted);
+}
+
+.athlete-settings__managed {
+  color: var(--moss-strong);
+  font-weight: 650;
+}
+
+.athlete-settings__managed::before {
+  margin-right: 6px;
+  color: var(--coral);
+  content: "External";
+  font-size: 9px;
+  font-weight: 760;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.athlete-settings__credential,
+.athlete-settings__validation {
+  color: var(--coral);
+}
+
+.athlete-settings__feedback {
+  min-height: 18px;
+  margin-top: 14px;
+}
+
+.athlete-settings__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: flex-end;
+  margin-top: 12px;
+}
+
+.athlete-settings__retry,
+.athlete-settings__setup,
+.athlete-settings__save {
+  min-height: 38px;
+  padding: 0 15px;
+  white-space: nowrap;
+  border-radius: 999px;
+  cursor: pointer;
+}
+
+.athlete-settings__retry {
+  margin-right: auto;
+  border: 1px solid var(--line-strong);
+  color: var(--ink);
+  background: var(--surface-solid);
+}
+
+.athlete-settings__setup {
+  border: 1px solid var(--coral);
+  color: var(--ink);
+  background: var(--surface-solid);
+}
+
+.athlete-settings__save {
+  border: 1px solid var(--moss);
+  color: var(--surface-solid);
+  background: var(--moss);
+}
+
+.athlete-settings__retry:disabled,
+.athlete-settings__setup:disabled,
+.athlete-settings__save:disabled {
+  cursor: default;
+  opacity: 0.5;
+}
+
+.athlete-settings__field[hidden],
+.athlete-settings__managed[hidden],
+.athlete-settings__credential[hidden],
+.athlete-settings__validation[hidden],
+.athlete-settings__feedback[hidden],
+.athlete-settings__retry[hidden],
+.athlete-settings__setup[hidden] {
+  display: none;
 }
 
 .provider-model-settings__cancel {

--- a/apps/desktop-renderer/tests/athlete-settings.test.ts
+++ b/apps/desktop-renderer/tests/athlete-settings.test.ts
@@ -1,0 +1,721 @@
+import { readFile } from "node:fs/promises";
+import { describe, expect, it, vi } from "vitest";
+import {
+  CoachClientDisconnectedError,
+  CoachClientProtocolError,
+  type CoachClient,
+} from "@enduragent/coach-client";
+import type {
+  ConfigureRuntimeRpcRefusalReason,
+  RuntimeConfigSnapshot,
+} from "@enduragent/coach-contract";
+import type { DesktopCoachClientProvider } from "../src/coach-client.js";
+import {
+  createAthleteSettingsController,
+  type AthleteSettingsController,
+  type AthleteSettingsView,
+} from "../src/settings/athlete-controller.js";
+import { createAthleteSettingsView } from "../src/settings/athlete-view.js";
+import type { ResidentSettingsShell } from "../src/settings/shell.js";
+
+interface Deferred<T> {
+  readonly promise: Promise<T>;
+  resolve(value: T): void;
+  reject(error: unknown): void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function snapshot(
+  athleteId = "0",
+  overrides: Partial<RuntimeConfigSnapshot["intervals"]> = {},
+): RuntimeConfigSnapshot {
+  return {
+    schemaVersion: 3,
+    llm: {
+      provider: "anthropic",
+      model: "claude-sonnet",
+      credential_configured: true,
+    },
+    intervals: {
+      athlete_id: athleteId,
+      credential_configured: true,
+      managedByEnvironment: { athleteId: false },
+      ...overrides,
+    },
+    session: {
+      historyTokenBudgetRatio: 0.3,
+      idleMinutes: 0,
+      dailyResetHour: 4,
+      resetArchiveRetentionDays: 0,
+      timezone: "UTC",
+      managedByEnvironment: {
+        historyTokenBudgetRatio: false,
+        idleMinutes: false,
+        dailyResetHour: false,
+        resetArchiveRetentionDays: false,
+        timezone: false,
+      },
+    },
+  };
+}
+
+function applied(intervals = true) {
+  return {
+    schemaVersion: 3,
+    status: "applied",
+    applied: { llm: false, intervals, session: false },
+  } as const;
+}
+
+function fakeView() {
+  let handlers:
+    | {
+        readonly onRetry: () => void;
+        readonly onChange: (value: string) => void;
+        readonly onSave: () => void;
+        readonly onOpenSetup: () => void;
+      }
+    | undefined;
+  const view: AthleteSettingsView = {
+    bind: vi.fn((next) => {
+      handlers = next;
+    }),
+    render: vi.fn(),
+    dispose: vi.fn(),
+  };
+  return {
+    view,
+    retry: () => handlers?.onRetry(),
+    change: (value: string) => handlers?.onChange(value),
+    save: () => handlers?.onSave(),
+    openSetup: () => handlers?.onOpenSetup(),
+  };
+}
+
+function clientWith(call: (method: string, request: unknown) => Promise<unknown>): CoachClient {
+  return {
+    handshake: {} as never,
+    call,
+    close: vi.fn(async () => {}),
+  } as unknown as CoachClient;
+}
+
+function providerWith(client: CoachClient): DesktopCoachClientProvider {
+  return {
+    getClient: vi.fn(async () => client),
+    reconnect: vi.fn(async () => client),
+    close: vi.fn(async () => {}),
+  };
+}
+
+function createSubject(input: {
+  readonly client?: CoachClient;
+  readonly clients?: DesktopCoachClientProvider;
+  readonly beginMutation?: () => (() => void) | null;
+  readonly openSetup?: () => void;
+}) {
+  const subject = fakeView();
+  const client =
+    input.client ??
+    clientWith(async (method) => {
+      if (method === "getRuntimeConfig") return snapshot();
+      if (method === "configureRuntime") return applied();
+      throw new Error(`Unexpected method ${method}`);
+    });
+  const clients = input.clients ?? providerWith(client);
+  const controller = createAthleteSettingsController({
+    clients,
+    view: subject.view,
+    beginMutation: input.beginMutation ?? (() => () => {}),
+    openSetup: input.openSetup ?? vi.fn(),
+  });
+  return { controller, subject, clients, client };
+}
+
+function form(controller: AthleteSettingsController) {
+  const state = controller.state();
+  if (
+    state.status !== "ready" &&
+    state.status !== "refreshing" &&
+    state.status !== "saving" &&
+    state.status !== "saved" &&
+    !(state.status === "error" && state.kind === "save")
+  ) {
+    throw new Error(`Expected athlete form state, received ${state.status}`);
+  }
+  return state;
+}
+
+describe("training account settings controller", () => {
+  it.each([
+    ["", false],
+    ["0", true],
+    ["custom-athlete", true],
+  ] as const)(
+    "loads the authoritative athlete ID %j without coercion",
+    async (athleteId, ready) => {
+      const { controller } = createSubject({
+        client: clientWith(async () =>
+          snapshot(athleteId, { credential_configured: athleteId !== "" }),
+        ),
+      });
+
+      await controller.activate();
+
+      expect(form(controller)).toMatchObject({
+        status: "ready",
+        draft: athleteId,
+        dirty: false,
+        validationError: ready ? null : "athlete-required",
+      });
+    },
+  );
+
+  it("validates blank, whitespace, length, and C0/C1 controls without trimming", async () => {
+    const call = vi.fn(async (method: string) =>
+      method === "getRuntimeConfig" ? snapshot("current") : applied(),
+    );
+    const { controller, subject } = createSubject({ client: clientWith(call) });
+    await controller.activate();
+
+    for (const [value, error] of [
+      ["", "athlete-required"],
+      [" candidate", "athlete-whitespace"],
+      ["candidate ", "athlete-whitespace"],
+      ["a".repeat(513), "athlete-too-long"],
+      [`candidate${String.fromCharCode(7)}`, "athlete-control-characters"],
+      [`candidate${String.fromCharCode(133)}`, "athlete-control-characters"],
+    ] as const) {
+      subject.change(value);
+      expect(form(controller)).toMatchObject({ draft: value, validationError: error });
+      subject.save();
+      await Promise.resolve();
+    }
+    expect(call).toHaveBeenCalledTimes(1);
+
+    subject.change("a".repeat(512));
+    expect(form(controller).validationError).toBeNull();
+  });
+
+  it.each(["0", "custom-athlete"] as const)(
+    "sends only the exact athlete patch for %s and rereads authority",
+    async (draft) => {
+      const calls: Array<{ readonly method: string; readonly request: unknown }> = [];
+      const call = vi.fn(async (method: string, request: unknown) => {
+        calls.push({ method, request });
+        if (method === "configureRuntime") return applied();
+        return calls.length === 1 ? snapshot("current") : snapshot(draft);
+      });
+      const release = vi.fn();
+      const beginMutation = vi.fn(() => release);
+      const { controller, subject } = createSubject({
+        client: clientWith(call),
+        beginMutation,
+      });
+      await controller.activate();
+      subject.change(draft);
+      subject.save();
+      await vi.waitFor(() => expect(controller.state().status).toBe("saved"));
+
+      expect(calls).toEqual([
+        { method: "getRuntimeConfig", request: {} },
+        {
+          method: "configureRuntime",
+          request: { intervals: { athlete_id: draft } },
+        },
+        { method: "getRuntimeConfig", request: {} },
+      ]);
+      expect(JSON.stringify(calls[1])).not.toContain("api_key");
+      expect(beginMutation).toHaveBeenCalledOnce();
+      expect(release).toHaveBeenCalledOnce();
+      expect(form(controller)).toMatchObject({
+        status: "saved",
+        draft,
+        effective: { athlete_id: draft },
+        dirty: false,
+      });
+    },
+  );
+
+  it.each([
+    "credential-required",
+    "ownership-unavailable",
+    "training-account-mismatch",
+    "managed-by-environment",
+  ] as const)("retains the dirty draft after a typed %s refusal", async (reason) => {
+    const call = vi.fn(async (method: string) => {
+      if (method === "getRuntimeConfig") return snapshot("current");
+      return { schemaVersion: 3, status: "refused", reason } as const;
+    });
+    const { controller, subject } = createSubject({ client: clientWith(call) });
+    await controller.activate();
+    subject.change("candidate");
+    subject.save();
+    await vi.waitFor(() => expect(controller.state().status).toBe("error"));
+
+    expect(controller.state()).toMatchObject({
+      status: "error",
+      kind: "save",
+      reason,
+      draft: "candidate",
+      dirty: true,
+    });
+    expect(call).toHaveBeenCalledTimes(2);
+  });
+
+  it("requires an applied intervals bit before the authoritative reread", async () => {
+    const call = vi.fn(async (method: string) =>
+      method === "getRuntimeConfig" ? snapshot("current") : applied(false),
+    );
+    const { controller, subject } = createSubject({ client: clientWith(call) });
+    await controller.activate();
+    subject.change("candidate");
+    subject.save();
+    await vi.waitFor(() => expect(controller.state().status).toBe("error"));
+
+    expect(controller.state()).toMatchObject({
+      status: "error",
+      kind: "save",
+      reason: "not-applied",
+      draft: "candidate",
+    });
+    expect(call).toHaveBeenCalledTimes(2);
+  });
+
+  it("disables mutations under environment authority and credential absence", async () => {
+    for (const intervals of [
+      {
+        credential_configured: true,
+        managedByEnvironment: { athleteId: true },
+      },
+      {
+        credential_configured: false,
+        managedByEnvironment: { athleteId: false },
+      },
+    ] as const) {
+      const call = vi.fn(async () => snapshot("managed", intervals));
+      const { controller, subject } = createSubject({ client: clientWith(call) });
+      await controller.activate();
+      subject.change("candidate");
+      subject.save();
+      await Promise.resolve();
+      expect(form(controller)).toMatchObject({ draft: "managed", dirty: false });
+      expect(call).toHaveBeenCalledExactlyOnceWith("getRuntimeConfig", {});
+    }
+  });
+
+  it("replaces a dirty draft when recovery newly locks the training account", async () => {
+    for (const intervals of [
+      {
+        credential_configured: true,
+        managedByEnvironment: { athleteId: true },
+      },
+      {
+        credential_configured: false,
+        managedByEnvironment: { athleteId: false },
+      },
+    ] as const) {
+      const call = vi
+        .fn()
+        .mockResolvedValueOnce(snapshot("current"))
+        .mockRejectedValueOnce(new Error("private detail"))
+        .mockResolvedValueOnce(snapshot("authoritative", intervals));
+      const { controller, subject } = createSubject({ client: clientWith(call) });
+      await controller.activate();
+      subject.change("candidate");
+      subject.save();
+      await vi.waitFor(() => expect(controller.state().status).toBe("error"));
+
+      subject.retry();
+      await vi.waitFor(() => expect(controller.state().status).toBe("ready"));
+      expect(form(controller)).toMatchObject({
+        effective: { athlete_id: "authoritative", ...intervals },
+        draft: "authoritative",
+        dirty: false,
+      });
+      expect(call).toHaveBeenLastCalledWith("getRuntimeConfig", {});
+    }
+  });
+
+  it("opens Setup only for credential recovery", async () => {
+    const openSetup = vi.fn();
+    const { controller, subject } = createSubject({
+      client: clientWith(async () =>
+        snapshot("", {
+          credential_configured: false,
+          managedByEnvironment: { athleteId: false },
+        }),
+      ),
+      openSetup,
+    });
+    await controller.activate();
+    subject.openSetup();
+    expect(openSetup).toHaveBeenCalledOnce();
+  });
+
+  it("does not replay a disconnected save and preserves the draft through reconnect", async () => {
+    const disconnected = new CoachClientDisconnectedError(1006, "");
+    const firstCall = vi
+      .fn()
+      .mockResolvedValueOnce(snapshot("current"))
+      .mockRejectedValueOnce(disconnected);
+    const secondCall = vi.fn(async () => snapshot("current"));
+    const first = clientWith(firstCall);
+    const second = clientWith(secondCall);
+    const clients: DesktopCoachClientProvider = {
+      getClient: vi.fn(async () => first),
+      reconnect: vi.fn(async () => second),
+      close: vi.fn(async () => {}),
+    };
+    const { controller, subject } = createSubject({ clients });
+    await controller.activate();
+    subject.change("candidate");
+    subject.save();
+    await vi.waitFor(() => expect(controller.state().status).toBe("error"));
+    expect(form(controller).draft).toBe("candidate");
+
+    subject.retry();
+    await vi.waitFor(() => expect(controller.state().status).toBe("ready"));
+    expect(clients.reconnect).toHaveBeenCalledOnce();
+    expect(secondCall).toHaveBeenCalledExactlyOnceWith("getRuntimeConfig", {});
+    expect(firstCall.mock.calls.filter(([method]) => method === "configureRuntime")).toHaveLength(
+      1,
+    );
+    expect(form(controller)).toMatchObject({ draft: "candidate", dirty: true });
+  });
+
+  it("retains a dirty draft when the authoritative reread fails", async () => {
+    for (const error of [new Error("private detail"), new CoachClientProtocolError()]) {
+      const call = vi
+        .fn()
+        .mockResolvedValueOnce(snapshot("current"))
+        .mockResolvedValueOnce(applied())
+        .mockRejectedValueOnce(error);
+      const { controller, subject } = createSubject({ client: clientWith(call) });
+      await controller.activate();
+      subject.change("candidate");
+      subject.save();
+      await vi.waitFor(() => expect(controller.state().status).toBe("error"));
+      expect(controller.state()).toMatchObject({
+        status: "error",
+        kind: "save",
+        reason: "runtime-unavailable",
+        draft: "candidate",
+        dirty: true,
+      });
+    }
+  });
+
+  it("does not overlap another Settings mutation", async () => {
+    const call = vi.fn(async () => snapshot("current"));
+    const { controller, subject } = createSubject({
+      client: clientWith(call),
+      beginMutation: () => null,
+    });
+    await controller.activate();
+    subject.change("candidate");
+    subject.save();
+    await Promise.resolve();
+    expect(call).toHaveBeenCalledExactlyOnceWith("getRuntimeConfig", {});
+    expect(form(controller)).toMatchObject({ draft: "candidate", dirty: true });
+  });
+
+  it("fences stale load, save, and reread completions across close and reopen", async () => {
+    const firstLoad = deferred<RuntimeConfigSnapshot>();
+    const save = deferred<ReturnType<typeof applied>>();
+    const reread = deferred<RuntimeConfigSnapshot>();
+    const call = vi
+      .fn()
+      .mockReturnValueOnce(firstLoad.promise)
+      .mockResolvedValueOnce(snapshot("fresh"))
+      .mockReturnValueOnce(save.promise)
+      .mockReturnValueOnce(reread.promise)
+      .mockResolvedValueOnce(snapshot("reopened"));
+    const { controller, subject } = createSubject({ client: clientWith(call) });
+
+    const initial = controller.activate();
+    controller.close();
+    const reopened = controller.activate();
+    firstLoad.resolve(snapshot("stale"));
+    await initial;
+    await reopened;
+    expect(form(controller).draft).toBe("fresh");
+
+    subject.change("candidate");
+    subject.save();
+    await vi.waitFor(() => expect(controller.state().status).toBe("saving"));
+    save.resolve(applied());
+    await vi.waitFor(() => expect(call).toHaveBeenCalledTimes(4));
+    controller.close();
+    const finalOpen = controller.activate();
+    reread.resolve(snapshot("stale-reread"));
+    await finalOpen;
+    expect(form(controller).draft).toBe("reopened");
+  });
+
+  it.each(["load", "save"] as const)(
+    "does not render a stale %s completion after disposal",
+    async (operation) => {
+      const loadGate = deferred<RuntimeConfigSnapshot>();
+      const saveGate = deferred<ReturnType<typeof applied>>();
+      const call =
+        operation === "load"
+          ? vi.fn(() => loadGate.promise)
+          : vi
+              .fn()
+              .mockResolvedValueOnce(snapshot("current"))
+              .mockReturnValueOnce(saveGate.promise);
+      const { controller, subject } = createSubject({ client: clientWith(call) });
+      const pending = controller.activate();
+      if (operation === "save") {
+        await pending;
+        subject.change("candidate");
+        subject.save();
+        await vi.waitFor(() => expect(controller.state().status).toBe("saving"));
+      }
+      const renders = vi.mocked(subject.view.render).mock.calls.length;
+      controller.dispose();
+      if (operation === "load") loadGate.resolve(snapshot());
+      else saveGate.resolve(applied());
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(subject.view.render).toHaveBeenCalledTimes(renders);
+      expect(subject.view.dispose).toHaveBeenCalledOnce();
+      expect(controller.state()).toEqual({ status: "closed" });
+    },
+  );
+});
+
+class FakeElement {
+  readonly children: FakeElement[] = [];
+  readonly attributes = new Map<string, string>();
+  readonly listeners = new Map<string, Set<(event: never) => void>>();
+  parent: FakeElement | undefined;
+  className = "";
+  disabled = false;
+  hidden = false;
+  id = "";
+  type = "";
+  value = "";
+  htmlFor = "";
+  autocomplete = "";
+  spellcheck = true;
+  noValidate = false;
+  tabIndex = 0;
+  private ownText = "";
+
+  constructor(
+    readonly tagName: string,
+    private readonly document?: FakeDocument,
+  ) {}
+
+  get textContent(): string {
+    return this.ownText + this.children.map((child) => child.textContent).join("");
+  }
+
+  set textContent(value: string) {
+    this.ownText = value;
+    this.children.splice(0);
+  }
+
+  append(...nodes: FakeElement[]): void {
+    for (const node of nodes) {
+      node.parent = this;
+      this.children.push(node);
+    }
+  }
+
+  setAttribute(name: string, value: string): void {
+    this.attributes.set(name, value);
+  }
+
+  removeAttribute(name: string): void {
+    this.attributes.delete(name);
+  }
+
+  addEventListener(name: string, listener: (event: never) => void): void {
+    const listeners = this.listeners.get(name) ?? new Set();
+    listeners.add(listener);
+    this.listeners.set(name, listeners);
+  }
+
+  removeEventListener(name: string, listener: (event: never) => void): void {
+    this.listeners.get(name)?.delete(listener);
+  }
+
+  focus(): void {
+    if (!this.disabled && this.document !== undefined) this.document.activeElement = this;
+  }
+
+  remove(): void {
+    if (this.parent === undefined) return;
+    const index = this.parent.children.indexOf(this);
+    if (index >= 0) this.parent.children.splice(index, 1);
+    this.parent = undefined;
+  }
+}
+
+class FakeDocument {
+  readonly body = new FakeElement("body", this);
+  activeElement: FakeElement | null = this.body;
+
+  createElement(name: string): FakeElement {
+    return new FakeElement(name, this);
+  }
+}
+
+function descendants(root: FakeElement): FakeElement[] {
+  return root.children.flatMap((child) => [child, ...descendants(child)]);
+}
+
+function find(root: FakeElement, predicate: (node: FakeElement) => boolean): FakeElement {
+  const value = [root, ...descendants(root)].find(predicate);
+  if (value === undefined) throw new Error("Element not found");
+  return value;
+}
+
+describe("training account settings view", () => {
+  it("exposes accessible descriptions, fixed refusal copy, and recovery controls", () => {
+    const document = new FakeDocument();
+    let focusables: (() => readonly HTMLElement[]) | undefined;
+    const shell = {
+      body: document.body,
+      mutationActive: false,
+      setSectionSaving: vi.fn(),
+      registerFocusables: vi.fn((values: () => readonly HTMLElement[]) => {
+        focusables = values;
+        return () => {};
+      }),
+      subscribeToMutation: vi.fn((listener: (active: boolean) => void) => {
+        listener(false);
+        return () => {};
+      }),
+    } as unknown as ResidentSettingsShell;
+    const view = createAthleteSettingsView({
+      document: document as unknown as Document,
+      shell,
+    });
+    view.render({
+      status: "ready",
+      effective: {
+        athlete_id: "managed",
+        credential_configured: true,
+        managedByEnvironment: { athleteId: true },
+      },
+      draft: "managed",
+      dirty: false,
+      validationError: null,
+    });
+
+    const input = find(document.body, (node) => node.id === "athlete-settings-id");
+    const label = find(document.body, (node) => node.className === "athlete-settings__label");
+    const feedback = find(document.body, (node) => node.className === "athlete-settings__feedback");
+    const managed = find(document.body, (node) => node.id === "athlete-settings-managed");
+    expect(label.htmlFor).toBe(input.id);
+    expect(input.disabled).toBe(true);
+    expect(managed.hidden).toBe(false);
+    expect(input.attributes.get("aria-describedby")).toContain(managed.id);
+    expect(feedback.attributes.get("aria-live")).toBe("polite");
+    expect(feedback.attributes.get("aria-atomic")).toBe("true");
+    expect(focusables?.()).toHaveLength(4);
+
+    for (const [reason, copy] of [
+      [
+        "credential-required",
+        "Connect the training account in Setup before saving its athlete ID.",
+      ],
+      ["ownership-unavailable", "The connected training account couldn’t be verified."],
+      [
+        "training-account-mismatch",
+        "That athlete ID does not identify the currently connected training account.",
+      ],
+      [
+        "managed-by-environment",
+        "The athlete ID is managed outside Enduragent and wasn’t changed.",
+      ],
+    ] as const satisfies readonly (readonly [ConfigureRuntimeRpcRefusalReason, string])[]) {
+      view.render({
+        status: "error",
+        kind: "save",
+        reason,
+        effective: {
+          athlete_id: "current",
+          credential_configured: true,
+          managedByEnvironment: { athleteId: false },
+        },
+        draft: "candidate",
+        dirty: true,
+        validationError: null,
+      });
+      expect(document.body.textContent).toContain(copy);
+    }
+
+    view.render({
+      status: "ready",
+      effective: {
+        athlete_id: "",
+        credential_configured: false,
+        managedByEnvironment: { athleteId: false },
+      },
+      draft: "",
+      dirty: false,
+      validationError: "athlete-required",
+    });
+    const setup = find(document.body, (node) => node.className === "athlete-settings__setup");
+    const validation = find(document.body, (node) => node.id === "athlete-settings-validation");
+    expect(setup.hidden).toBe(false);
+    expect(input.attributes.get("aria-invalid")).toBe("true");
+    expect(validation.attributes.get("aria-live")).toBe("polite");
+    expect(validation.attributes.get("aria-atomic")).toBe("true");
+
+    const retry = find(document.body, (node) => node.className === "athlete-settings__retry");
+    retry.focus();
+    view.render({
+      status: "refreshing",
+      effective: {
+        athlete_id: "current",
+        credential_configured: true,
+        managedByEnvironment: { athleteId: false },
+      },
+      draft: "candidate",
+      dirty: true,
+      validationError: null,
+    });
+    expect(retry.hidden).toBe(true);
+    expect(document.activeElement).toBe(feedback);
+    view.render({
+      status: "ready",
+      effective: {
+        athlete_id: "current",
+        credential_configured: true,
+        managedByEnvironment: { athleteId: false },
+      },
+      draft: "current",
+      dirty: false,
+      validationError: null,
+    });
+    expect(document.activeElement).toBe(input);
+  });
+
+  it("ships account-guard help and compact scroll-safe styling", async () => {
+    const source = await readFile(
+      new URL("../src/settings/athlete-view.ts", import.meta.url),
+      "utf8",
+    );
+    const styles = await readFile(new URL("../src/settings/styles.css", import.meta.url), "utf8");
+    expect(source).toContain("may only identify the currently connected training account");
+    expect(source).toContain("It cannot switch accounts");
+    expect(source).toContain("Save athlete ID");
+    expect(styles).toContain("overflow-y: auto");
+    expect(styles).toContain(".athlete-settings__field");
+  });
+});

--- a/apps/desktop-renderer/tests/provider-model-settings.test.ts
+++ b/apps/desktop-renderer/tests/provider-model-settings.test.ts
@@ -13,6 +13,7 @@ import {
   type ProviderModelSettingsView,
 } from "../src/settings/provider-model-controller.js";
 import { createProviderModelSettingsView } from "../src/settings/provider-model-view.js";
+import { createAthleteSettingsView } from "../src/settings/athlete-view.js";
 import { createResidentSettingsShell } from "../src/settings/shell.js";
 import { createSessionSettingsView } from "../src/settings/session-view.js";
 
@@ -698,10 +699,7 @@ describe("provider and model settings view", () => {
       validationError: "model-required",
     });
     expect(custom.attributes.get("aria-invalid")).toBe("true");
-    const validation = find(
-      dialog,
-      (node) => node.id === "provider-model-settings-validation",
-    );
+    const validation = find(dialog, (node) => node.id === "provider-model-settings-validation");
     expect(validation.attributes.get("aria-live")).toBe("polite");
     expect(validation.attributes.get("aria-atomic")).toBe("true");
 
@@ -746,7 +744,7 @@ describe("provider and model settings view", () => {
 });
 
 describe("resident settings shell", () => {
-  it("hosts both independent forms, shares mutation state, and contains focus", () => {
+  it("hosts three independent forms, shares mutation state, and contains focus", () => {
     const document = new FakeDocument();
     const actionHost = new FakeElement("div", document);
     document.body.append(actionHost);
@@ -754,7 +752,12 @@ describe("resident settings shell", () => {
       document: document as never,
       actionHost: actionHost as never,
     });
+    expect(document.body.textContent).toContain("review the currently connected training account");
     const providerView = createProviderModelSettingsView({
+      document: document as never,
+      shell,
+    });
+    const athleteView = createAthleteSettingsView({
       document: document as never,
       shell,
     });
@@ -765,6 +768,17 @@ describe("resident settings shell", () => {
     const onClose = vi.fn(() => shell.close());
     shell.bind({ onOpen: vi.fn(), onClose });
     providerView.render(readyState());
+    athleteView.render({
+      status: "ready",
+      effective: {
+        athlete_id: "current-athlete",
+        credential_configured: true,
+        managedByEnvironment: { athleteId: false },
+      },
+      draft: "candidate-athlete",
+      dirty: true,
+      validationError: null,
+    });
     sessionView.render({
       status: "ready",
       effective: {
@@ -798,8 +812,9 @@ describe("resident settings shell", () => {
     expect(dialogs).toHaveLength(1);
     const dialog = dialogs[0]!;
     expect(dialog.textContent).toContain("Provider & model");
+    expect(dialog.textContent).toContain("Training account");
     expect(dialog.textContent).toContain("Conversation & time");
-    expect(descendants(dialog).filter((node) => node.tagName === "fieldset")).toHaveLength(2);
+    expect(descendants(dialog).filter((node) => node.tagName === "fieldset")).toHaveLength(3);
 
     const timezone = find(dialog, (node) => node.id === "session-settings-timezone");
     const timezoneManaged = find(dialog, (node) => node.id === "session-settings-timezone-managed");
@@ -846,8 +861,10 @@ describe("resident settings shell", () => {
       validationErrors: {},
     });
     const provider = find(dialog, (node) => node.id === "provider-model-settings-provider");
+    const athlete = find(dialog, (node) => node.id === "athlete-settings-id");
     const close = find(dialog, (node) => node.className === "provider-model-settings__close");
     expect(provider.disabled).toBe(true);
+    expect(athlete.disabled).toBe(true);
     expect(close.disabled).toBe(true);
     const preventDefault = vi.fn();
     dialog.dispatch("cancel", { preventDefault });
@@ -891,6 +908,7 @@ describe("resident settings shell", () => {
     expect(document.activeElement).toBe(opener);
 
     sessionView.dispose();
+    athleteView.dispose();
     providerView.dispose();
     shell.dispose();
   });

--- a/apps/desktop-renderer/tests/session-settings.test.ts
+++ b/apps/desktop-renderer/tests/session-settings.test.ts
@@ -31,13 +31,17 @@ function snapshot(
   overrides: Partial<RuntimeConfigSnapshot["session"]> = {},
 ): RuntimeConfigSnapshot {
   return {
-    schemaVersion: 2,
+    schemaVersion: 3,
     llm: {
       provider: "anthropic",
       model: "claude-sonnet",
       credential_configured: true,
     },
-    intervals: { athlete_id: "0" },
+    intervals: {
+      athlete_id: "0",
+      credential_configured: true,
+      managedByEnvironment: { athleteId: false },
+    },
     session: {
       historyTokenBudgetRatio: 0.3,
       idleMinutes: 0,
@@ -106,7 +110,11 @@ function createSubject(input: {
     clientWith(async (method) => {
       if (method === "getRuntimeConfig") return snapshot();
       if (method === "configureRuntime") {
-        return { schemaVersion: 2, applied: { llm: false, intervals: false, session: true } };
+        return {
+          schemaVersion: 3,
+          status: "applied",
+          applied: { llm: false, intervals: false, session: true },
+        };
       }
       throw new Error(`Unexpected method ${method}`);
     });
@@ -210,7 +218,11 @@ describe("conversation and time settings controller", () => {
     const call = vi.fn(async (method: string, request: unknown) => {
       calls.push({ method, request });
       if (method === "configureRuntime") {
-        return { schemaVersion: 2, applied: { llm: false, intervals: false, session: true } };
+        return {
+          schemaVersion: 3,
+          status: "applied",
+          applied: { llm: false, intervals: false, session: true },
+        };
       }
       return calls.length === 1 ? snapshot() : snapshot({ idleMinutes: 45 });
     });
@@ -245,7 +257,11 @@ describe("conversation and time settings controller", () => {
   it("retains the draft when the daemon refuses to apply the session patch", async () => {
     const call = vi.fn(async (method: string) => {
       if (method === "getRuntimeConfig") return snapshot();
-      return { schemaVersion: 2, applied: { llm: false, intervals: false, session: false } };
+      return {
+        schemaVersion: 3,
+        status: "refused",
+        reason: "managed-by-environment",
+      };
     });
     const beginMutation = vi.fn(() => () => {});
     const { controller, subject } = createSubject({

--- a/apps/desktop/src/main/credential-runtime.ts
+++ b/apps/desktop/src/main/credential-runtime.ts
@@ -70,8 +70,11 @@ export function createConnectionRuntimeAuthority(
     async configureRuntime(request) {
       const result = await call((client) => client.call("configureRuntime", request));
       if (
+        !("status" in result) ||
+        result.status !== "applied" ||
         (request.llm !== undefined && !result.applied.llm) ||
-        (request.intervals !== undefined && !result.applied.intervals)
+        (request.intervals !== undefined && !result.applied.intervals) ||
+        (request.session !== undefined && !result.applied.session)
       ) {
         throw new TypeError();
       }

--- a/apps/desktop/tests/chat-panels.integration.test.ts
+++ b/apps/desktop/tests/chat-panels.integration.test.ts
@@ -190,19 +190,24 @@ ${"nonwrapping".repeat(36)}
       if (request.method === "saveIntake") return response({ schemaVersion: 1, saved: true });
       if (request.method === "configureRuntime") {
         return response({
-          schemaVersion: 2,
+          schemaVersion: 3,
+          status: "applied",
           applied: { llm: true, intervals: true, session: true },
         });
       }
       if (request.method === "getRuntimeConfig") {
         return response({
-          schemaVersion: 2,
+          schemaVersion: 3,
           llm: {
             provider: "anthropic",
             model: "claude-sonnet-4-6",
             credential_configured: true,
           },
-          intervals: { athlete_id: "0" },
+          intervals: {
+            athlete_id: "0",
+            credential_configured: true,
+            managedByEnvironment: { athleteId: false },
+          },
           session: {
             historyTokenBudgetRatio: 0.3,
             idleMinutes: 0,
@@ -1105,7 +1110,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
     const compactSettingsGeometry = await fixture.evaluate<{
       readonly open: boolean;
       readonly oneDialog: boolean;
-      readonly hasBothSections: boolean;
+      readonly hasThreeSections: boolean;
       readonly horizontalOverflow: boolean;
       readonly withinViewport: boolean;
       readonly saveReachableAfterScroll: boolean;
@@ -1126,9 +1131,10 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
       return {
         open: dialog.open,
         oneDialog: document.querySelectorAll("#provider-model-settings-dialog").length === 1,
-        hasBothSections:
-          dialog.querySelectorAll("fieldset").length === 2 &&
+        hasThreeSections:
+          dialog.querySelectorAll("fieldset").length === 3 &&
           copy.includes("Provider & model") &&
+          copy.includes("Training account") &&
           copy.includes("Conversation & time"),
         horizontalOverflow:
           dialog.scrollWidth > dialog.clientWidth ||
@@ -1154,7 +1160,7 @@ describe.skipIf(process.platform !== "darwin" || !hasLoopback)("desktop chat pan
     expect(compactSettingsGeometry).toEqual({
       open: true,
       oneDialog: true,
-      hasBothSections: true,
+      hasThreeSections: true,
       horizontalOverflow: false,
       withinViewport: true,
       saveReachableAfterScroll: true,

--- a/apps/desktop/tests/chatgpt-auth.test.ts
+++ b/apps/desktop/tests/chatgpt-auth.test.ts
@@ -39,13 +39,17 @@ function runtimeSnapshot(
   credentialConfigured = provider === "openai-codex",
 ): RuntimeConfigSnapshot {
   return {
-    schemaVersion: 2,
+    schemaVersion: 3,
     llm: {
       provider,
       model: "custom-selected-model",
       credential_configured: credentialConfigured,
     },
-    intervals: { athlete_id: "custom-athlete" },
+    intervals: {
+      athlete_id: "custom-athlete",
+      credential_configured: true,
+      managedByEnvironment: { athleteId: false },
+    },
     session: {
       historyTokenBudgetRatio: 0.3,
       idleMinutes: 0,

--- a/apps/desktop/tests/credential-runtime.test.ts
+++ b/apps/desktop/tests/credential-runtime.test.ts
@@ -44,9 +44,13 @@ function runtimeSnapshot(
   athleteId = "custom-athlete",
 ): RuntimeConfigSnapshot {
   return {
-    schemaVersion: 2,
+    schemaVersion: 3,
     llm: { provider, model, credential_configured: credentialConfigured },
-    intervals: { athlete_id: athleteId },
+    intervals: {
+      athlete_id: athleteId,
+      credential_configured: true,
+      managedByEnvironment: { athleteId: false },
+    },
     session: {
       historyTokenBudgetRatio: 0.3,
       idleMinutes: 0,
@@ -631,7 +635,8 @@ describe("desktop credential runtime precedence", () => {
         calls.push(method);
         if (method === "getRuntimeConfig") return runtimeSnapshot("anthropic");
         return {
-          schemaVersion: 2,
+          schemaVersion: 3,
+          status: "applied",
           applied: { llm: true, intervals: false, session: false },
         };
       },
@@ -663,6 +668,59 @@ describe("desktop credential runtime precedence", () => {
   });
 
   it.each([
+    [
+      { llm: { model: "candidate-model" } },
+      {
+        schemaVersion: 3,
+        status: "applied",
+        applied: { llm: false, intervals: false, session: false },
+      },
+    ],
+    [
+      { intervals: { athlete_id: "candidate-athlete" } },
+      {
+        schemaVersion: 3,
+        status: "applied",
+        applied: { llm: false, intervals: false, session: false },
+      },
+    ],
+    [
+      { session: { idleMinutes: 30 } },
+      {
+        schemaVersion: 3,
+        status: "applied",
+        applied: { llm: false, intervals: false, session: false },
+      },
+    ],
+    [
+      { intervals: { athlete_id: "candidate-athlete" } },
+      {
+        schemaVersion: 3,
+        status: "refused",
+        reason: "training-account-mismatch",
+      },
+    ],
+  ] as const)(
+    "accepts only an applied result for every requested runtime slot",
+    async (request, result) => {
+      const connect = vi.fn(async () => ({
+        handshake: {} as never,
+        call: vi.fn(async () => result),
+        close: vi.fn(async () => {}),
+      }));
+      const authority = createConnectionRuntimeAuthority(
+        {
+          url: "ws://127.0.0.1:45004/rpc",
+          token: "obviously-fake-successor-token",
+        },
+        connect as never,
+      );
+
+      await expect(authority.configureRuntime(request)).rejects.toBeInstanceOf(TypeError);
+    },
+  );
+
+  it.each([
     ["externally configured provider", runtimeSnapshot("google", "external-model", true)],
     ["custom active ChatGPT profile", runtimeSnapshot("openai-codex", "chat-model", true)],
   ])(
@@ -675,7 +733,8 @@ describe("desktop credential runtime precedence", () => {
           calls.push(method);
           if (method === "getRuntimeConfig") return snapshot;
           return {
-            schemaVersion: 2,
+            schemaVersion: 3,
+            status: "applied",
             applied: { llm: true, intervals: false, session: false },
           };
         },

--- a/apps/desktop/tests/onboarding-ipc.test.ts
+++ b/apps/desktop/tests/onboarding-ipc.test.ts
@@ -60,13 +60,17 @@ function harness(
     activate: vi.fn(async () => ({ status: "configured" as const, runtimeReady: true as const })),
   };
   const getRuntimeConfig = vi.fn(async () => ({
-    schemaVersion: 2 as const,
+    schemaVersion: 3 as const,
     llm: {
       provider: "anthropic" as const,
       model: "athlete-selected-model",
       credential_configured: true,
     },
-    intervals: { athlete_id: "synthetic-athlete" },
+    intervals: {
+      athlete_id: "synthetic-athlete",
+      credential_configured: true,
+      managedByEnvironment: { athleteId: false },
+    },
     session: {
       historyTokenBudgetRatio: 0.3,
       idleMinutes: 0,

--- a/apps/desktop/tests/spend-meter.integration.test.ts
+++ b/apps/desktop/tests/spend-meter.integration.test.ts
@@ -168,7 +168,8 @@ function script(calls: ScriptRequest[], initial: "reached" | "complete") {
       if (request.method === "saveIntake") return response({ schemaVersion: 1, saved: true });
       if (request.method === "configureRuntime") {
         return response({
-          schemaVersion: 2,
+          schemaVersion: 3,
+          status: "applied",
           applied: { llm: true, intervals: true, session: false },
         });
       }

--- a/packages/coach-client/tests/client.test.ts
+++ b/packages/coach-client/tests/client.test.ts
@@ -517,9 +517,13 @@ describe("RPC receive and observers", () => {
           jsonrpc: "2.0",
           id: request.id,
           result: {
-            schemaVersion: 2,
+            schemaVersion: 3,
             llm: { provider: "anthropic", model: "synthetic-model" },
-            intervals: { athlete_id: "" },
+            intervals: {
+              athlete_id: "",
+              credential_configured: false,
+              managedByEnvironment: { athleteId: false },
+            },
             session: {
               historyTokenBudgetRatio: 0.3,
               idleMinutes: 0,
@@ -622,17 +626,22 @@ describe("RPC receive and observers", () => {
         },
         saveIntake: { schemaVersion: 1, saved: true },
         configureRuntime: {
-          schemaVersion: 2,
+          schemaVersion: 3,
+          status: "applied",
           applied: { llm: true, intervals: false, session: false },
         },
         getRuntimeConfig: {
-          schemaVersion: 2,
+          schemaVersion: 3,
           llm: {
             provider: "anthropic",
             model: "synthetic-model",
             credential_configured: true,
           },
-          intervals: { athlete_id: "synthetic-athlete" },
+          intervals: {
+            athlete_id: "synthetic-athlete",
+            credential_configured: true,
+            managedByEnvironment: { athleteId: false },
+          },
           session: {
             historyTokenBudgetRatio: 0.3,
             idleMinutes: 0,
@@ -726,7 +735,8 @@ describe("RPC receive and observers", () => {
         llm: { provider: "anthropic", model: "synthetic", api_key: "synthetic" },
       }),
     ).resolves.toEqual({
-      schemaVersion: 2,
+      schemaVersion: 3,
+      status: "applied",
       applied: { llm: true, intervals: false, session: false },
     });
     await expect(client.call("getRuntimeConfig", {})).resolves.toMatchObject({

--- a/packages/coach-contract/src/rpc.ts
+++ b/packages/coach-contract/src/rpc.ts
@@ -357,23 +357,43 @@ export const ConfigureRuntimeRpcParamsSchema = z
   });
 export type ConfigureRuntimeRpcParams = z.infer<typeof ConfigureRuntimeRpcParamsSchema>;
 
-export const ConfigureRuntimeRpcResultSchema = z
-  .object({
-    schemaVersion: z.literal(2),
-    applied: z
-      .object({
-        llm: z.boolean(),
-        intervals: z.boolean(),
-        session: z.boolean(),
-      })
-      .strict(),
-  })
-  .strict();
+export const ConfigureRuntimeRpcRefusalReasonSchema = z.enum([
+  "credential-required",
+  "ownership-unavailable",
+  "training-account-mismatch",
+  "managed-by-environment",
+]);
+export type ConfigureRuntimeRpcRefusalReason = z.infer<
+  typeof ConfigureRuntimeRpcRefusalReasonSchema
+>;
+
+export const ConfigureRuntimeRpcResultSchema = z.discriminatedUnion("status", [
+  z
+    .object({
+      schemaVersion: z.literal(3),
+      status: z.literal("applied"),
+      applied: z
+        .object({
+          llm: z.boolean(),
+          intervals: z.boolean(),
+          session: z.boolean(),
+        })
+        .strict(),
+    })
+    .strict(),
+  z
+    .object({
+      schemaVersion: z.literal(3),
+      status: z.literal("refused"),
+      reason: ConfigureRuntimeRpcRefusalReasonSchema,
+    })
+    .strict(),
+]);
 export type ConfigureRuntimeRpcResult = z.infer<typeof ConfigureRuntimeRpcResultSchema>;
 
 export const RuntimeConfigSnapshotSchema = z
   .object({
-    schemaVersion: z.literal(2),
+    schemaVersion: z.literal(3),
     llm: z
       .object({
         provider: LlmProviderSchema,
@@ -384,6 +404,12 @@ export const RuntimeConfigSnapshotSchema = z
     intervals: z
       .object({
         athlete_id: z.string().max(512),
+        credential_configured: z.boolean(),
+        managedByEnvironment: z
+          .object({
+            athleteId: z.boolean(),
+          })
+          .strict(),
       })
       .strict(),
     session: z

--- a/packages/coach-contract/src/version.ts
+++ b/packages/coach-contract/src/version.ts
@@ -1,1 +1,1 @@
-export const PROTOCOL_VERSION = 8;
+export const PROTOCOL_VERSION = 9;

--- a/packages/coach-contract/tests/contract.test.ts
+++ b/packages/coach-contract/tests/contract.test.ts
@@ -84,8 +84,8 @@ describe("exit codes", () => {
 });
 
 describe("protocol version", () => {
-  it("is 8", () => {
-    expect(PROTOCOL_VERSION).toBe(8);
+  it("is 9", () => {
+    expect(PROTOCOL_VERSION).toBe(9);
   });
 });
 

--- a/packages/coach-contract/tests/wire-contract.test.ts
+++ b/packages/coach-contract/tests/wire-contract.test.ts
@@ -452,22 +452,44 @@ describe("coach request and event projection", () => {
       expect(ConfigureRuntimeRpcParamsSchema.safeParse(invalid).success).toBe(false);
     }
     const result = {
-      schemaVersion: 2,
+      schemaVersion: 3,
+      status: "applied",
       applied: { llm: true, intervals: false, session: false },
     } as const;
     expect(ConfigureRuntimeRpcResultSchema.parse(result)).toEqual(result);
     expect(
       ConfigureRuntimeRpcResultSchema.safeParse({ ...result, api_key: "placeholder" }).success,
     ).toBe(false);
+    for (const reason of [
+      "credential-required",
+      "ownership-unavailable",
+      "training-account-mismatch",
+      "managed-by-environment",
+    ] as const) {
+      const refused = { schemaVersion: 3, status: "refused", reason } as const;
+      expect(ConfigureRuntimeRpcResultSchema.parse(refused)).toEqual(refused);
+    }
+    expect(
+      ConfigureRuntimeRpcResultSchema.safeParse({
+        schemaVersion: 3,
+        status: "refused",
+        reason: "ownership-unavailable",
+        applied: { llm: false, intervals: false, session: false },
+      }).success,
+    ).toBe(false);
     expect(JSON.stringify(result)).not.toContain("placeholder");
     const snapshot = {
-      schemaVersion: 2,
+      schemaVersion: 3,
       llm: {
         provider: "openrouter",
         model: "model-a",
         credential_configured: true,
       },
-      intervals: { athlete_id: "athlete-a" },
+      intervals: {
+        athlete_id: "athlete-a",
+        credential_configured: true,
+        managedByEnvironment: { athleteId: false },
+      },
       session: {
         historyTokenBudgetRatio: 0.3,
         idleMinutes: 0,
@@ -492,7 +514,11 @@ describe("coach request and event projection", () => {
           model: "model-a",
           credential_configured: true,
         },
-        intervals: { athlete_id: "" },
+        intervals: {
+          athlete_id: "",
+          credential_configured: false,
+          managedByEnvironment: { athleteId: true },
+        },
       }),
     ).toEqual({
       ...snapshot,
@@ -501,7 +527,11 @@ describe("coach request and event projection", () => {
         model: "model-a",
         credential_configured: true,
       },
-      intervals: { athlete_id: "" },
+      intervals: {
+        athlete_id: "",
+        credential_configured: false,
+        managedByEnvironment: { athleteId: true },
+      },
     });
     for (const malformed of [
       { ...snapshot, api_key: "placeholder" },
@@ -515,7 +545,21 @@ describe("coach request and event projection", () => {
       },
       { ...snapshot, llm: { ...snapshot.llm, credential_configured: "true" } },
       { ...snapshot, intervals: { ...snapshot.intervals, api_key: "placeholder" } },
-      { ...snapshot, intervals: { athlete_id: "a".repeat(513) } },
+      { ...snapshot, intervals: { ...snapshot.intervals, athlete_id: "a".repeat(513) } },
+      {
+        ...snapshot,
+        intervals: {
+          athlete_id: "athlete-a",
+          credential_configured: true,
+        },
+      },
+      {
+        ...snapshot,
+        intervals: {
+          ...snapshot.intervals,
+          managedByEnvironment: { athleteId: "false" },
+        },
+      },
       {
         ...snapshot,
         session: {
@@ -600,7 +644,8 @@ describe("coach request and event projection", () => {
       }),
       saveIntake: async () => ({ schemaVersion: 1, saved: true }),
       configureRuntime: async ({ llm, intervals, session }) => ({
-        schemaVersion: 2,
+        schemaVersion: 3,
+        status: "applied",
         applied: {
           llm: llm !== undefined,
           intervals: intervals !== undefined,
@@ -608,9 +653,13 @@ describe("coach request and event projection", () => {
         },
       }),
       getRuntimeConfig: async () => ({
-        schemaVersion: 2,
+        schemaVersion: 3,
         llm: { provider: "anthropic", model: "model", credential_configured: false },
-        intervals: { athlete_id: "athlete" },
+        intervals: {
+          athlete_id: "athlete",
+          credential_configured: false,
+          managedByEnvironment: { athleteId: false },
+        },
         session: {
           historyTokenBudgetRatio: 0.3,
           idleMinutes: 0,
@@ -949,7 +998,7 @@ describe("additive protocol signals", () => {
     expect(AgentErrorKindSchema.safeParse("aborted").success).toBe(false);
   });
 
-  it("uses protocol version eight", () => {
-    expect(PROTOCOL_VERSION).toBe(8);
+  it("uses protocol version nine", () => {
+    expect(PROTOCOL_VERSION).toBe(9);
   });
 });

--- a/packages/coach/src/composition.ts
+++ b/packages/coach/src/composition.ts
@@ -56,12 +56,14 @@ import {
   type CoachEngine,
   type CoachOperations,
   type ConfigureRuntimeRpcParams,
+  type ConfigureRuntimeRpcRefusalReason,
   type GetRuntimeConfigRpcResult,
 } from "@enduragent/coach-contract";
 import { cyclingSport } from "@enduragent/sport-cycling";
 import { createPersistedAthleteStateSource } from "./athlete-state-reader.js";
 import {
   assertRuntimeAthleteOwner,
+  RuntimeAthleteOwnerRefusal,
   type RuntimeAthleteOwnerClaim,
 } from "./backfill.js";
 import { createCoachEngineAdapter } from "./coach-engine-adapter.js";
@@ -218,10 +220,7 @@ function captureRuntimeConfigFile(configDir: string): RuntimeConfigFileSnapshot 
   return existsSync(path) ? { content: readFileSync(path) } : {};
 }
 
-function restoreRuntimeConfigFile(
-  configDir: string,
-  snapshot: RuntimeConfigFileSnapshot,
-): void {
+function restoreRuntimeConfigFile(configDir: string, snapshot: RuntimeConfigFileSnapshot): void {
   const path = join(configDir, "config.yaml");
   if (snapshot.content !== undefined) {
     replacePrivateFile(path, snapshot.content);
@@ -312,13 +311,19 @@ function runtimeConfigSnapshot(
   timezone: string,
 ): GetRuntimeConfigRpcResult {
   return {
-    schemaVersion: 2,
+    schemaVersion: 3,
     llm: {
       provider: config.llm.provider,
       model: config.llm.model,
       credential_configured: runtimeCredentialConfigured(configDir, config),
     },
-    intervals: { athlete_id: config.intervals.athleteId },
+    intervals: {
+      athlete_id: config.intervals.athleteId,
+      credential_configured: config.intervals.apiKey.length > 0,
+      managedByEnvironment: {
+        athleteId: environment.INTERVALS_ATHLETE_ID !== undefined,
+      },
+    },
     session: {
       ...config.session,
       timezone,
@@ -583,10 +588,7 @@ export async function createLocalCoachComposition(
     return approval ?? undefined;
   };
   let activeConfig = copyConfig(input.config);
-  if (
-    activeConfig.intervals.apiKey.length > 0 &&
-    activeConfig.intervals.athleteId.length === 0
-  ) {
+  if (activeConfig.intervals.apiKey.length > 0 && activeConfig.intervals.athleteId.length === 0) {
     activeConfig = {
       ...activeConfig,
       intervals: { ...activeConfig.intervals, athleteId: "0" },
@@ -656,10 +658,7 @@ export async function createLocalCoachComposition(
               session: { ...config.session, timezone },
             };
       const memory = new Memory(input.home.root, timezone);
-      const chatStore = new ChatStore(
-        input.home.root,
-        config.session.resetArchiveRetentionDays,
-      );
+      const chatStore = new ChatStore(input.home.root, config.session.resetArchiveRetentionDays);
       const projectedConfig = engineConfigFromConfig(effectiveConfig);
       const legacyClient =
         config.intervals.apiKey.length === 0
@@ -720,8 +719,14 @@ export async function createLocalCoachComposition(
     const applyRuntimeConfig = async (
       request: ConfigureRuntimeRpcParams,
       signal: AbortSignal,
-    ): Promise<void> => {
+    ): Promise<ConfigureRuntimeRpcRefusalReason | void> => {
       signal.throwIfAborted();
+      if (
+        request.intervals?.athlete_id !== undefined &&
+        input.env.INTERVALS_ATHLETE_ID !== undefined
+      ) {
+        return "managed-by-environment";
+      }
       if (request.session !== undefined) {
         const ownership = sessionConfigEnvironmentOwnership(input.env);
         for (const field of [
@@ -742,16 +747,12 @@ export async function createLocalCoachComposition(
       const candidateAthleteId =
         candidate.intervals.athleteId.length === 0 ? "0" : candidate.intervals.athleteId;
       const athleteIdChanged =
-        request.intervals?.athlete_id !== undefined &&
-        candidateAthleteId !== activeAthleteId;
+        request.intervals?.athlete_id !== undefined && candidateAthleteId !== activeAthleteId;
       const apiKeyChanged =
         request.intervals?.api_key !== undefined &&
         candidate.intervals.apiKey !== activeConfig.intervals.apiKey;
       let pendingOwnerClaim: RuntimeAthleteOwnerClaim | undefined;
       if (athleteIdChanged || apiKeyChanged) {
-        if (athleteIdChanged && input.env.INTERVALS_ATHLETE_ID !== undefined) {
-          throw new Error("runtime athlete ID is controlled by the daemon environment");
-        }
         if (
           apiKeyChanged &&
           input.env.INTERVALS_API_KEY !== undefined &&
@@ -759,13 +760,19 @@ export async function createLocalCoachComposition(
         ) {
           throw new Error("runtime intervals credential is controlled by the daemon environment");
         }
-        pendingOwnerClaim = await assertIntervalsOwner(
-          activeConfig.intervals,
-          candidate.intervals,
-          signal,
-          activeConfig.intervals.apiKey.length === 0 &&
-            candidate.intervals.apiKey.length > 0,
-        );
+        try {
+          pendingOwnerClaim = await assertIntervalsOwner(
+            activeConfig.intervals,
+            candidate.intervals,
+            signal,
+            activeConfig.intervals.apiKey.length === 0 && candidate.intervals.apiKey.length > 0,
+          );
+        } catch (error) {
+          if (!(error instanceof RuntimeAthleteOwnerRefusal)) throw error;
+          if (error.reason === "current-credential-missing") return "credential-required";
+          if (error.reason === "mismatch") return "training-account-mismatch";
+          return "ownership-unavailable";
+        }
       }
       if (request.llm !== undefined && candidate.llm.provider === "openai-codex") {
         credential(
@@ -822,12 +829,7 @@ export async function createLocalCoachComposition(
         historyNewestDate: () => new Date(now()).toISOString().slice(0, 10),
         applyRuntimeConfig,
         readRuntimeConfig: () =>
-          runtimeConfigSnapshot(
-            input.home.configDir,
-            activeConfig,
-            input.env,
-            activeTimezone,
-          ),
+          runtimeConfigSnapshot(input.home.configDir, activeConfig, input.env, activeTimezone),
       },
       dependencies.operationsDependencies,
     );

--- a/packages/coach/src/operations.ts
+++ b/packages/coach/src/operations.ts
@@ -15,6 +15,7 @@ import {
   SyncRpcParamsSchema,
   SyncRpcResultSchema,
   type ConfigureRuntimeRpcParams,
+  type ConfigureRuntimeRpcRefusalReason,
   type ConfigureRuntimeRpcResult,
   type GetRuntimeConfigRpcParams,
   type GetRuntimeConfigRpcResult,
@@ -55,7 +56,7 @@ export interface CreateCoachOperationsInput {
   readonly applyRuntimeConfig: (
     request: ConfigureRuntimeRpcParams,
     signal: AbortSignal,
-  ) => Promise<void>;
+  ) => Promise<ConfigureRuntimeRpcRefusalReason | void>;
   readonly readRuntimeConfig?: () => GetRuntimeConfigRpcResult;
 }
 
@@ -236,9 +237,17 @@ export function createCoachOperations(
               ? deadlineSignal
               : AbortSignal.any([deadlineSignal, admissionSignal]);
           signal.throwIfAborted();
-          await input.applyRuntimeConfig(parsedRequest, signal);
+          const refusal = await input.applyRuntimeConfig(parsedRequest, signal);
+          if (refusal !== undefined) {
+            return ConfigureRuntimeRpcResultSchema.parse({
+              schemaVersion: 3,
+              status: "refused",
+              reason: refusal,
+            });
+          }
           return ConfigureRuntimeRpcResultSchema.parse({
-            schemaVersion: 2,
+            schemaVersion: 3,
+            status: "applied",
             applied: {
               llm: parsedRequest.llm !== undefined,
               intervals: parsedRequest.intervals !== undefined,

--- a/packages/coach/tests/cli-verbs-rpc.test.ts
+++ b/packages/coach/tests/cli-verbs-rpc.test.ts
@@ -47,7 +47,8 @@ const operations: CoachOperations = {
   }),
   saveIntake: async () => ({ schemaVersion: 1, saved: true }),
   configureRuntime: async ({ llm, intervals, session }) => ({
-    schemaVersion: 2,
+    schemaVersion: 3,
+    status: "applied",
     applied: {
       llm: llm !== undefined,
       intervals: intervals !== undefined,
@@ -55,9 +56,13 @@ const operations: CoachOperations = {
     },
   }),
   getRuntimeConfig: async () => ({
-    schemaVersion: 2,
+    schemaVersion: 3,
     llm: { provider: "anthropic", model: "synthetic-model", credential_configured: false },
-    intervals: { athlete_id: "synthetic-athlete" },
+    intervals: {
+      athlete_id: "synthetic-athlete",
+      credential_configured: false,
+      managedByEnvironment: { athleteId: false },
+    },
     session: {
       historyTokenBudgetRatio: 0.3,
       idleMinutes: 0,

--- a/packages/coach/tests/composition.test.ts
+++ b/packages/coach/tests/composition.test.ts
@@ -33,6 +33,7 @@ import {
   type LocalStoreRuntime,
   type LocalStoreRuntimeOptions,
 } from "../src/composition.js";
+import { RuntimeAthleteOwnerRefusal } from "../src/backfill.js";
 import { checkHomeReadiness } from "../src/readiness.js";
 import type { CoachStoreWriterContext } from "../src/runtime.js";
 
@@ -1125,7 +1126,8 @@ describe("local coach composition", () => {
     releaseOld();
     await expect(oldTurn).resolves.toEqual({ text: "UTC" });
     await expect(configuration).resolves.toEqual({
-      schemaVersion: 2,
+      schemaVersion: 3,
+      status: "applied",
       applied: { llm: false, intervals: false, session: true },
     });
     await expect(postCommitSpend).resolves.toMatchObject({
@@ -1144,9 +1146,9 @@ describe("local coach composition", () => {
     });
     expect(received[1]?.ports.memory).not.toBe(received[0]?.ports.memory);
     expect(received[1]?.ports.chatStore).not.toBe(received[0]?.ports.chatStore);
-    expect(
-      (received[1]!.ports.memory as unknown as { readonly tz: string }).tz,
-    ).toBe("America/Los_Angeles");
+    expect((received[1]!.ports.memory as unknown as { readonly tz: string }).tz).toBe(
+      "America/Los_Angeles",
+    );
     expect(
       (
         received[1]!.ports.chatStore as unknown as {
@@ -1155,7 +1157,7 @@ describe("local coach composition", () => {
       ).resetArchiveRetentionDays,
     ).toBe(9);
     await expect(lifecycle.operations.getRuntimeConfig({})).resolves.toMatchObject({
-      schemaVersion: 2,
+      schemaVersion: 3,
       session: {
         historyTokenBudgetRatio: 0.45,
         idleMinutes: 25,
@@ -1193,13 +1195,12 @@ describe("local coach composition", () => {
       undefined,
       initial,
     );
-    const expectedTimezone =
-      Intl.DateTimeFormat().resolvedOptions().timeZone?.trim() || "UTC";
+    const expectedTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone?.trim() || "UTC";
 
     expect(received[0]?.ports.config.session.timezone).toBe(expectedTimezone);
-    expect(
-      (received[0]!.ports.memory as unknown as { readonly tz: string }).tz,
-    ).toBe(expectedTimezone);
+    expect((received[0]!.ports.memory as unknown as { readonly tz: string }).tz).toBe(
+      expectedTimezone,
+    );
     await expect(lifecycle.spendMeter.getSpendSummary()).resolves.toMatchObject({
       timezone: expectedTimezone,
     });
@@ -1344,9 +1345,9 @@ describe("local coach composition", () => {
       );
       const before = await lifecycle.operations.getRuntimeConfig({});
 
-      await expect(
-        lifecycle.operations.configureRuntime({ session: patch }),
-      ).rejects.toThrow(`runtime session ${field} is controlled by the daemon environment`);
+      await expect(lifecycle.operations.configureRuntime({ session: patch })).rejects.toThrow(
+        `runtime session ${field} is controlled by the daemon environment`,
+      );
       await expect(lifecycle.operations.getRuntimeConfig({})).resolves.toEqual(before);
       expect(before.session.managedByEnvironment[field]).toBe(true);
       expect(createBackend).toHaveBeenCalledOnce();
@@ -1501,7 +1502,7 @@ describe("local coach composition", () => {
           athlete_id: "replayed-athlete",
         },
       }),
-    ).resolves.toMatchObject({ applied: { intervals: true } });
+    ).resolves.toMatchObject({ status: "applied", applied: { intervals: true } });
 
     expect(runtimeOptions?.readConfig?.().intervals).toEqual({
       apiKey: "obviously-fake-replayed-key",
@@ -1521,6 +1522,7 @@ describe("local coach composition", () => {
       candidateApiKey: "candidate-key",
       envAthleteId: "environment-athlete",
       ownerFailure: undefined,
+      expectedReason: "managed-by-environment",
       expectedOwnerChecks: 0,
     },
     {
@@ -1529,6 +1531,7 @@ describe("local coach composition", () => {
       candidateApiKey: "candidate-key",
       envAthleteId: "",
       ownerFailure: undefined,
+      expectedReason: "managed-by-environment",
       expectedOwnerChecks: 0,
     },
     {
@@ -1537,6 +1540,7 @@ describe("local coach composition", () => {
       candidateApiKey: undefined,
       envAthleteId: undefined,
       ownerFailure: "current-credential-missing",
+      expectedReason: "credential-required",
       expectedOwnerChecks: 1,
     },
     {
@@ -1545,6 +1549,7 @@ describe("local coach composition", () => {
       candidateApiKey: "candidate-key",
       envAthleteId: undefined,
       ownerFailure: "current-unresolved",
+      expectedReason: "ownership-unavailable",
       expectedOwnerChecks: 1,
     },
     {
@@ -1553,6 +1558,7 @@ describe("local coach composition", () => {
       candidateApiKey: "candidate-key",
       envAthleteId: undefined,
       ownerFailure: "candidate-unresolved",
+      expectedReason: "ownership-unavailable",
       expectedOwnerChecks: 1,
     },
     {
@@ -1561,15 +1567,17 @@ describe("local coach composition", () => {
       candidateApiKey: "candidate-key",
       envAthleteId: undefined,
       ownerFailure: "mismatch",
+      expectedReason: "training-account-mismatch",
       expectedOwnerChecks: 1,
     },
-  ])(
+  ] as const)(
     "fails closed before runtime mutation for $label and keeps serialized lanes usable",
     async ({
       activeApiKey,
       candidateApiKey,
       envAthleteId,
       ownerFailure,
+      expectedReason,
       expectedOwnerChecks,
     }) => {
       const home = await freshHome();
@@ -1595,7 +1603,7 @@ describe("local coach composition", () => {
               options.current.athleteId !== options.candidate.athleteId)
           ) {
             remainingOwnerFailures -= 1;
-            throw new Error(ownerFailure);
+            throw new RuntimeAthleteOwnerRefusal(ownerFailure);
           }
         },
       );
@@ -1623,14 +1631,17 @@ describe("local coach composition", () => {
       const ownerChecksBefore = assertRuntimeAthleteOwner.mock.calls.length;
       const before = await lifecycle.operations.getRuntimeConfig({});
 
-      await expect(
-        lifecycle.operations.configureRuntime({
-          intervals: {
-            ...(candidateApiKey === undefined ? {} : { api_key: candidateApiKey }),
-            athlete_id: "candidate-athlete",
-          },
-        }),
-      ).rejects.toThrow();
+      const result = await lifecycle.operations.configureRuntime({
+        intervals: {
+          ...(candidateApiKey === undefined ? {} : { api_key: candidateApiKey }),
+          athlete_id: "candidate-athlete",
+        },
+      });
+      expect(result).toEqual({
+        schemaVersion: 3,
+        status: "refused",
+        reason: expectedReason,
+      });
 
       await expect(readFile(join(home.configDir, "config.yaml"), "utf8")).resolves.toBe(
         initialYaml,
@@ -1659,15 +1670,74 @@ describe("local coach composition", () => {
 
       await expect(
         lifecycle.operations.configureRuntime({ llm: { model: "queue-recovered-model" } }),
-      ).resolves.toMatchObject({ applied: { llm: true, intervals: false } });
+      ).resolves.toMatchObject({
+        status: "applied",
+        applied: { llm: true, intervals: false },
+      });
       await expect(
         lifecycle.operations.configureRuntime({ intervals: { api_key: "writer-recovered-key" } }),
-      ).resolves.toMatchObject({ applied: { llm: false, intervals: true } });
+      ).resolves.toMatchObject({
+        status: "applied",
+        applied: { llm: false, intervals: true },
+      });
       expect(createBackend).toHaveBeenCalledTimes(3);
       expect(runWindowAfter).toHaveBeenCalledOnce();
       await lifecycle.close();
     },
   );
+
+  it("refuses an environment-managed athlete field even when the requested value is unchanged", async () => {
+    const home = await freshHome();
+    const initialYaml = "sentinel: unchanged\n";
+    await writeFile(join(home.configDir, "config.yaml"), initialYaml);
+    const createBackend = vi.fn(() => backend());
+    const assertRuntimeAthleteOwner = vi.fn(async () => {});
+    const lifecycle = await compose(
+      home,
+      {
+        bootstrap: async () => reference(),
+        createRuntime: () => runtime(),
+        createBackend,
+        createRepository: () => ({
+          insertIfAbsent: async () => false,
+          readCurrent: async () => undefined,
+        }),
+        createResolver: () => missingResolver(),
+        assertRuntimeAthleteOwner,
+      },
+      fakeContext(home),
+      undefined,
+      config(home, { apiKey: "current-key", athleteId: "environment-athlete" }),
+      {
+        ENDURAGENT_HOME: home.root,
+        COACH_TZ: "UTC",
+        INTERVALS_ATHLETE_ID: "environment-athlete",
+      },
+    );
+    const ownerChecksBefore = assertRuntimeAthleteOwner.mock.calls.length;
+    await expect(lifecycle.operations.getRuntimeConfig({})).resolves.toMatchObject({
+      intervals: {
+        athlete_id: "environment-athlete",
+        credential_configured: true,
+        managedByEnvironment: { athleteId: true },
+      },
+    });
+
+    await expect(
+      lifecycle.operations.configureRuntime({
+        intervals: { athlete_id: "environment-athlete" },
+        session: { timezone: "Asia/Almaty" },
+      }),
+    ).resolves.toEqual({
+      schemaVersion: 3,
+      status: "refused",
+      reason: "managed-by-environment",
+    });
+    expect(assertRuntimeAthleteOwner).toHaveBeenCalledTimes(ownerChecksBefore);
+    expect(createBackend).toHaveBeenCalledOnce();
+    await expect(readFile(join(home.configDir, "config.yaml"), "utf8")).resolves.toBe(initialYaml);
+    await lifecycle.close();
+  });
 
   it.each([
     { envApiKey: "environment-key", rejected: true },
@@ -1711,7 +1781,10 @@ describe("local coach composition", () => {
         expect(runWindowAfter).not.toHaveBeenCalled();
         expect(assertRuntimeAthleteOwner).toHaveBeenCalledTimes(ownerChecksBefore);
       } else {
-        await expect(change).resolves.toMatchObject({ applied: { intervals: true } });
+        await expect(change).resolves.toMatchObject({
+          status: "applied",
+          applied: { intervals: true },
+        });
         expect(createBackend).toHaveBeenCalledTimes(2);
         expect(runWindowAfter).toHaveBeenCalledOnce();
         expect(assertRuntimeAthleteOwner).toHaveBeenCalledTimes(ownerChecksBefore + 1);
@@ -1745,7 +1818,7 @@ describe("local coach composition", () => {
       lifecycle.operations.configureRuntime({
         intervals: { api_key: "candidate-key", athlete_id: "first-athlete" },
       }),
-    ).resolves.toMatchObject({ applied: { intervals: true } });
+    ).resolves.toMatchObject({ status: "applied", applied: { intervals: true } });
     expect(assertRuntimeAthleteOwner).toHaveBeenCalledOnce();
     expect(assertRuntimeAthleteOwner).toHaveBeenCalledWith(
       expect.anything(),
@@ -1814,9 +1887,7 @@ describe("local coach composition", () => {
           : "synthetic persistence failure",
       );
       expect(claim).not.toHaveBeenCalled();
-      expect(createBackend).toHaveBeenCalledTimes(
-        failurePoint === "oauth-validation" ? 1 : 2,
-      );
+      expect(createBackend).toHaveBeenCalledTimes(failurePoint === "oauth-validation" ? 1 : 2);
       expect(runWindowAfter).not.toHaveBeenCalled();
       await expect(lifecycle.operations.getRuntimeConfig({})).resolves.toMatchObject({
         intervals: { athlete_id: "" },
@@ -1867,9 +1938,7 @@ describe("local coach composition", () => {
     await expect(lifecycle.operations.getRuntimeConfig({})).resolves.toMatchObject({
       intervals: { athlete_id: "" },
     });
-    await expect(readFile(join(home.configDir, "config.yaml"), "utf8")).resolves.toBe(
-      originalYaml,
-    );
+    await expect(readFile(join(home.configDir, "config.yaml"), "utf8")).resolves.toBe(originalYaml);
     await lifecycle.close();
   });
 
@@ -1908,7 +1977,7 @@ describe("local coach composition", () => {
       lifecycle.operations.configureRuntime({
         intervals: { api_key: "candidate-key" },
       }),
-    ).resolves.toMatchObject({ applied: { intervals: true } });
+    ).resolves.toMatchObject({ status: "applied", applied: { intervals: true } });
     expect(assertRuntimeAthleteOwner).toHaveBeenCalledTimes(ownerChecksBefore + 1);
     expect(assertRuntimeAthleteOwner.mock.calls.at(-1)?.[1]).toEqual(
       expect.objectContaining({
@@ -2015,7 +2084,7 @@ describe("local coach composition", () => {
       lifecycle.operations.configureRuntime({
         intervals: { api_key: "current-key", athlete_id: "current-athlete" },
       }),
-    ).resolves.toMatchObject({ applied: { intervals: true } });
+    ).resolves.toMatchObject({ status: "applied", applied: { intervals: true } });
     expect(assertRuntimeAthleteOwner).toHaveBeenCalledTimes(ownerChecksBefore);
     await lifecycle.close();
   });
@@ -2063,7 +2132,7 @@ describe("local coach composition", () => {
           athlete_id: "candidate-athlete",
         },
       }),
-    ).resolves.toMatchObject({ applied: { intervals: true } });
+    ).resolves.toMatchObject({ status: "applied", applied: { intervals: true } });
 
     expect(assertRuntimeAthleteOwner).toHaveBeenCalledWith(
       expect.anything(),
@@ -2237,7 +2306,7 @@ describe("local coach composition", () => {
           athlete_id: "new-athlete",
         },
       }),
-    ).resolves.toMatchObject({ applied: { intervals: true } });
+    ).resolves.toMatchObject({ status: "applied", applied: { intervals: true } });
     expect(runWindowAfter).toHaveBeenCalledTimes(1);
     expect(windows).toHaveLength(2);
 
@@ -2287,7 +2356,7 @@ describe("local coach composition", () => {
           athlete_id: "replayed-athlete",
         },
       }),
-    ).resolves.toMatchObject({ applied: { intervals: true } });
+    ).resolves.toMatchObject({ status: "applied", applied: { intervals: true } });
     expect(runWindowAfter).toHaveBeenCalledTimes(1);
 
     rejectRefresh(failure);
@@ -2613,7 +2682,11 @@ describe("local coach composition", () => {
 
     await expect(lifecycle.operations.getRuntimeConfig({})).resolves.toMatchObject({
       llm: { credential_configured: false },
-      intervals: { athlete_id: "" },
+      intervals: {
+        athlete_id: "",
+        credential_configured: false,
+        managedByEnvironment: { athleteId: false },
+      },
     });
     expect(() =>
       lifecycle.operations.configureRuntime({ intervals: { athlete_id: "" } } as never),
@@ -2628,7 +2701,11 @@ describe("local coach composition", () => {
       athleteId: "0",
     });
     await expect(lifecycle.operations.getRuntimeConfig({})).resolves.toMatchObject({
-      intervals: { athlete_id: "0" },
+      intervals: {
+        athlete_id: "0",
+        credential_configured: true,
+        managedByEnvironment: { athleteId: false },
+      },
     });
     expect(parseYaml(await readFile(join(home.configDir, "config.yaml"), "utf8"))).toMatchObject({
       intervals: { athlete_id: "0" },
@@ -2855,13 +2932,17 @@ describe("local coach composition", () => {
       intervals: { athleteId: "previous-athlete" },
     });
     await expect(lifecycle.operations.getRuntimeConfig({})).resolves.toEqual({
-      schemaVersion: 2,
+      schemaVersion: 3,
       llm: {
         provider: "openrouter",
         model: "previous-model",
         credential_configured: true,
       },
-      intervals: { athlete_id: "previous-athlete" },
+      intervals: {
+        athlete_id: "previous-athlete",
+        credential_configured: true,
+        managedByEnvironment: { athleteId: false },
+      },
       session: {
         ...initial.session,
         managedByEnvironment: {

--- a/packages/coach/tests/daemon-handshake.test.ts
+++ b/packages/coach/tests/daemon-handshake.test.ts
@@ -168,7 +168,8 @@ describe.skipIf(!hasLoopback)("production peer observations", () => {
         }),
         saveIntake: async () => ({ schemaVersion: 1, saved: true }),
         configureRuntime: async ({ llm, intervals, session }) => ({
-          schemaVersion: 2,
+          schemaVersion: 3,
+          status: "applied",
           applied: {
             llm: llm !== undefined,
             intervals: intervals !== undefined,
@@ -176,13 +177,17 @@ describe.skipIf(!hasLoopback)("production peer observations", () => {
           },
         }),
         getRuntimeConfig: async () => ({
-          schemaVersion: 2,
+          schemaVersion: 3,
           llm: {
             provider: "anthropic",
             model: "synthetic-model",
             credential_configured: false,
           },
-          intervals: { athlete_id: "synthetic-athlete" },
+          intervals: {
+            athlete_id: "synthetic-athlete",
+            credential_configured: false,
+            managedByEnvironment: { athleteId: false },
+          },
           session: {
             historyTokenBudgetRatio: 0.3,
             idleMinutes: 0,

--- a/packages/coach/tests/daemon-rpc-server.test.ts
+++ b/packages/coach/tests/daemon-rpc-server.test.ts
@@ -75,7 +75,8 @@ const operations: CoachOperations = {
   }),
   saveIntake: async () => ({ schemaVersion: 1, saved: true }),
   configureRuntime: async ({ llm, intervals, session }) => ({
-    schemaVersion: 2,
+    schemaVersion: 3,
+    status: "applied",
     applied: {
       llm: llm !== undefined,
       intervals: intervals !== undefined,
@@ -83,13 +84,17 @@ const operations: CoachOperations = {
     },
   }),
   getRuntimeConfig: async () => ({
-    schemaVersion: 2,
+    schemaVersion: 3,
     llm: {
       provider: "anthropic",
       model: "synthetic-model",
       credential_configured: false,
     },
-    intervals: { athlete_id: "synthetic-athlete" },
+    intervals: {
+      athlete_id: "synthetic-athlete",
+      credential_configured: false,
+      managedByEnvironment: { athleteId: false },
+    },
     session: {
       historyTokenBudgetRatio: 0.3,
       idleMinutes: 0,
@@ -455,7 +460,8 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
     const token = "x".repeat(43);
     const saveIntake = vi.fn(async () => ({ schemaVersion: 1 as const, saved: true as const }));
     const configureRuntime = vi.fn(async ({ llm, intervals, session }) => ({
-      schemaVersion: 2 as const,
+      schemaVersion: 3 as const,
+      status: "applied" as const,
       applied: {
         llm: llm !== undefined,
         intervals: intervals !== undefined,
@@ -463,13 +469,17 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
       },
     }));
     const runtimeSnapshot = {
-      schemaVersion: 2 as const,
+      schemaVersion: 3 as const,
       llm: {
         provider: "openrouter" as const,
         model: "model-a",
         credential_configured: true,
       },
-      intervals: { athlete_id: "athlete-a" },
+      intervals: {
+        athlete_id: "athlete-a",
+        credential_configured: true,
+        managedByEnvironment: { athleteId: false },
+      },
       session: {
         historyTokenBudgetRatio: 0.3,
         idleMinutes: 0,
@@ -535,7 +545,8 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
       jsonrpc: "2.0",
       id: "runtime",
       result: {
-        schemaVersion: 2,
+        schemaVersion: 3,
+        status: "applied",
         applied: { llm: true, intervals: true, session: false },
       },
     });
@@ -561,6 +572,57 @@ describe.skipIf(!hasLoopback)("authenticated RPC projection", () => {
     expect(JSON.stringify(snapshotResponse)).not.toContain("api_key");
     expect(JSON.stringify(snapshotResponse)).not.toContain("token");
     expect(JSON.stringify(snapshotResponse)).not.toContain("path");
+    await client.close();
+  });
+
+  it("delivers fixed runtime refusals without serializing submitted credentials or account IDs", async () => {
+    const token = "x".repeat(43);
+    const reasons = [
+      "credential-required",
+      "ownership-unavailable",
+      "training-account-mismatch",
+      "managed-by-environment",
+    ] as const;
+    let call = 0;
+    const configureRuntime = vi.fn(async () => ({
+      schemaVersion: 3 as const,
+      status: "refused" as const,
+      reason: reasons[call++]!,
+    }));
+    const rpc = createCoachRpcServer({
+      engine: engine(),
+      operations: { ...operations, configureRuntime },
+      token,
+      owner: "app-supervised",
+    });
+    const client = await openSocket(rpc);
+    client.ws.send(JSON.stringify(createClientHandshakeFrame(token)));
+    await client.frames.next();
+
+    for (const [index, reason] of reasons.entries()) {
+      client.ws.send(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: `refusal-${index}`,
+          method: "configureRuntime",
+          params: {
+            intervals: {
+              api_key: `obviously-fake-private-key-${index}`,
+              athlete_id: `private-athlete-${index}`,
+            },
+          },
+        }),
+      );
+      const response = parseCoachRpcEnvelope(await client.frames.next());
+      expect(response).toEqual({
+        jsonrpc: "2.0",
+        id: `refusal-${index}`,
+        result: { schemaVersion: 3, status: "refused", reason },
+      });
+      expect(JSON.stringify(response)).not.toContain("private");
+    }
+
+    expect(configureRuntime).toHaveBeenCalledTimes(reasons.length);
     await client.close();
   });
 

--- a/packages/coach/tests/daemon/redaction-rpc-cli.test.ts
+++ b/packages/coach/tests/daemon/redaction-rpc-cli.test.ts
@@ -166,7 +166,8 @@ async function startRpc(coachEngine: CoachEngine): Promise<RunningRpc> {
       }),
       saveIntake: async () => ({ schemaVersion: 1, saved: true }),
       configureRuntime: async ({ llm, intervals, session }) => ({
-        schemaVersion: 2,
+        schemaVersion: 3,
+        status: "applied",
         applied: {
           llm: llm !== undefined,
           intervals: intervals !== undefined,
@@ -174,13 +175,17 @@ async function startRpc(coachEngine: CoachEngine): Promise<RunningRpc> {
         },
       }),
       getRuntimeConfig: async () => ({
-        schemaVersion: 2,
+        schemaVersion: 3,
         llm: {
           provider: "anthropic",
           model: "synthetic-model",
           credential_configured: false,
         },
-        intervals: { athlete_id: "synthetic-athlete" },
+        intervals: {
+          athlete_id: "synthetic-athlete",
+          credential_configured: false,
+          managedByEnvironment: { athleteId: false },
+        },
         session: {
           historyTokenBudgetRatio: 0.3,
           idleMinutes: 0,

--- a/packages/coach/tests/enduragent-entry.test.ts
+++ b/packages/coach/tests/enduragent-entry.test.ts
@@ -77,7 +77,8 @@ const operations: CoachOperations = {
   }),
   saveIntake: async () => ({ schemaVersion: 1, saved: true }),
   configureRuntime: async ({ llm, intervals, session }) => ({
-    schemaVersion: 2,
+    schemaVersion: 3,
+    status: "applied",
     applied: {
       llm: llm !== undefined,
       intervals: intervals !== undefined,
@@ -85,9 +86,13 @@ const operations: CoachOperations = {
     },
   }),
   getRuntimeConfig: async () => ({
-    schemaVersion: 2,
+    schemaVersion: 3,
     llm: { provider: "anthropic", model: "synthetic-model", credential_configured: false },
-    intervals: { athlete_id: "synthetic-athlete" },
+    intervals: {
+      athlete_id: "synthetic-athlete",
+      credential_configured: false,
+      managedByEnvironment: { athleteId: false },
+    },
     session: {
       historyTokenBudgetRatio: 0.3,
       idleMinutes: 0,

--- a/packages/coach/tests/enduragent-redaction.test.ts
+++ b/packages/coach/tests/enduragent-redaction.test.ts
@@ -159,7 +159,8 @@ describe.skipIf(!hasLoopback)("local CLI redaction boundary", () => {
             }),
             saveIntake: async () => ({ schemaVersion: 1, saved: true }),
             configureRuntime: async ({ llm, intervals, session }) => ({
-              schemaVersion: 2,
+              schemaVersion: 3,
+              status: "applied",
               applied: {
                 llm: llm !== undefined,
                 intervals: intervals !== undefined,
@@ -167,13 +168,17 @@ describe.skipIf(!hasLoopback)("local CLI redaction boundary", () => {
               },
             }),
             getRuntimeConfig: async () => ({
-              schemaVersion: 2,
+              schemaVersion: 3,
               llm: {
                 provider: "anthropic",
                 model: "synthetic-model",
                 credential_configured: false,
               },
-              intervals: { athlete_id: "synthetic-athlete" },
+              intervals: {
+                athlete_id: "synthetic-athlete",
+                credential_configured: false,
+                managedByEnvironment: { athleteId: false },
+              },
               session: {
                 historyTokenBudgetRatio: 0.3,
                 idleMinutes: 0,

--- a/packages/coach/tests/local-runner.test.ts
+++ b/packages/coach/tests/local-runner.test.ts
@@ -76,7 +76,8 @@ const operations: CoachOperations = {
   }),
   saveIntake: async () => ({ schemaVersion: 1, saved: true }),
   configureRuntime: async ({ llm, intervals, session }) => ({
-    schemaVersion: 2,
+    schemaVersion: 3,
+    status: "applied",
     applied: {
       llm: llm !== undefined,
       intervals: intervals !== undefined,
@@ -84,9 +85,13 @@ const operations: CoachOperations = {
     },
   }),
   getRuntimeConfig: async () => ({
-    schemaVersion: 2,
+    schemaVersion: 3,
     llm: { provider: "anthropic", model: "synthetic-model", credential_configured: false },
-    intervals: { athlete_id: "synthetic-athlete" },
+    intervals: {
+      athlete_id: "synthetic-athlete",
+      credential_configured: false,
+      managedByEnvironment: { athleteId: false },
+    },
     session: {
       historyTokenBudgetRatio: 0.3,
       idleMinutes: 0,

--- a/packages/coach/tests/operations.test.ts
+++ b/packages/coach/tests/operations.test.ts
@@ -614,16 +614,16 @@ describe("coach operations", () => {
       home,
       context: context(),
       runtime: operationRuntime(async (work) => {
-          trace.push("sync-start");
-          syncStarted.release();
-          await releaseSync.promise;
-          await work(new AbortController().signal);
-          trace.push("sync-end");
-          return {
-            published: true,
-            legacySucceeded: true,
-            counts: requestCounts(0, 0),
-          };
+        trace.push("sync-start");
+        syncStarted.release();
+        await releaseSync.promise;
+        await work(new AbortController().signal);
+        trace.push("sync-end");
+        return {
+          published: true,
+          legacySucceeded: true,
+          counts: requestCounts(0, 0),
+        };
       }),
       intervalsCredentials: intervalsCredentials(),
       historyNewestDate: () => "1998-07-18",
@@ -639,7 +639,8 @@ describe("coach operations", () => {
         session: { dailyResetHour: 6, timezone: "Europe/Berlin" },
       }),
     ).resolves.toEqual({
-      schemaVersion: 2,
+      schemaVersion: 3,
+      status: "applied",
       applied: { llm: false, intervals: false, session: true },
     });
     expect(trace).toEqual(["sync-start", "configure"]);
@@ -649,6 +650,35 @@ describe("coach operations", () => {
     expect(trace).toEqual(["sync-start", "configure", "sync-end"]);
   });
 
+  it.each([
+    "credential-required",
+    "ownership-unavailable",
+    "training-account-mismatch",
+    "managed-by-environment",
+  ] as const)(
+    "returns a strict fixed %s runtime refusal without echoing request values",
+    async (reason) => {
+      const operations = createCoachOperations({
+        home,
+        context: context(),
+        runtime: operationRuntime(),
+        intervalsCredentials: intervalsCredentials(),
+        historyNewestDate: () => "1998-07-18",
+        applyRuntimeConfig: async () => reason,
+      });
+
+      const result = await operations.configureRuntime({
+        intervals: {
+          api_key: "obviously-fake-private-credential",
+          athlete_id: "private-candidate-athlete",
+        },
+      });
+
+      expect(result).toEqual({ schemaVersion: 3, status: "refused", reason });
+      expect(JSON.stringify(result)).not.toContain("private");
+    },
+  );
+
   it("reads runtime configuration while a store sync is blocked", async () => {
     const syncStarted = promiseGate();
     const releaseSync = promiseGate();
@@ -657,16 +687,16 @@ describe("coach operations", () => {
       home,
       context: context(),
       runtime: operationRuntime(async (work) => {
-          trace.push("sync-start");
-          syncStarted.release();
-          await releaseSync.promise;
-          await work(new AbortController().signal);
-          trace.push("sync-end");
-          return {
-            published: true,
-            legacySucceeded: true,
-            counts: requestCounts(0, 0),
-          };
+        trace.push("sync-start");
+        syncStarted.release();
+        await releaseSync.promise;
+        await work(new AbortController().signal);
+        trace.push("sync-end");
+        return {
+          published: true,
+          legacySucceeded: true,
+          counts: requestCounts(0, 0),
+        };
       }),
       intervalsCredentials: intervalsCredentials(),
       historyNewestDate: () => "1998-07-18",
@@ -674,9 +704,13 @@ describe("coach operations", () => {
       readRuntimeConfig: () => {
         trace.push("read");
         return {
-          schemaVersion: 2,
+          schemaVersion: 3,
           llm: { provider: "openai", model: "model-a", credential_configured: true },
-          intervals: { athlete_id: "synthetic-athlete" },
+          intervals: {
+            athlete_id: "synthetic-athlete",
+            credential_configured: true,
+            managedByEnvironment: { athleteId: false },
+          },
           session: {
             historyTokenBudgetRatio: 0.3,
             idleMinutes: 0,
@@ -698,7 +732,7 @@ describe("coach operations", () => {
     const sync = operations.sync({});
     await syncStarted.promise;
     await expect(operations.getRuntimeConfig({})).resolves.toMatchObject({
-      schemaVersion: 2,
+      schemaVersion: 3,
       llm: { model: "model-a" },
     });
     expect(trace).toEqual(["sync-start", "read"]);
@@ -717,16 +751,16 @@ describe("coach operations", () => {
       home,
       context: context(),
       runtime: operationRuntime(async (work) => {
-          trace.push("sync-start");
-          syncStarted.release();
-          await releaseSync.promise;
-          await work(new AbortController().signal);
-          trace.push("sync-end");
-          return {
-            published: true,
-            legacySucceeded: true,
-            counts: requestCounts(0, 0),
-          };
+        trace.push("sync-start");
+        syncStarted.release();
+        await releaseSync.promise;
+        await work(new AbortController().signal);
+        trace.push("sync-end");
+        return {
+          published: true,
+          legacySucceeded: true,
+          counts: requestCounts(0, 0),
+        };
       }),
       intervalsCredentials: intervalsCredentials(),
       historyNewestDate: () => "1998-07-18",
@@ -742,9 +776,13 @@ describe("coach operations", () => {
       readRuntimeConfig: () => {
         trace.push(`read-${activeModel}`);
         return {
-          schemaVersion: 2,
+          schemaVersion: 3,
           llm: { provider: "openai", model: activeModel, credential_configured: true },
-          intervals: { athlete_id: "synthetic-athlete" },
+          intervals: {
+            athlete_id: "synthetic-athlete",
+            credential_configured: true,
+            managedByEnvironment: { athleteId: false },
+          },
           session: {
             historyTokenBudgetRatio: 0.3,
             idleMinutes: 0,
@@ -792,11 +830,13 @@ describe("coach operations", () => {
     ]);
     expect(syncResult).toMatchObject({ schemaVersion: 1 });
     expect(intervalsResult).toEqual({
-      schemaVersion: 2,
+      schemaVersion: 3,
+      status: "applied",
       applied: { llm: true, intervals: true, session: false },
     });
     expect(laterLlmResult).toEqual({
-      schemaVersion: 2,
+      schemaVersion: 3,
+      status: "applied",
       applied: { llm: true, intervals: false, session: false },
     });
     expect(laterReadResult.llm.model).toBe("model-b");
@@ -880,9 +920,13 @@ describe("coach operations", () => {
       readRuntimeConfig: () => {
         trace.push(`read-${activeModel}`);
         return {
-          schemaVersion: 2,
+          schemaVersion: 3,
           llm: { provider: "openai", model: activeModel, credential_configured: true },
-          intervals: { athlete_id: "synthetic-athlete" },
+          intervals: {
+            athlete_id: "synthetic-athlete",
+            credential_configured: true,
+            managedByEnvironment: { athleteId: false },
+          },
           session: {
             historyTokenBudgetRatio: 0.3,
             idleMinutes: 0,
@@ -915,11 +959,13 @@ describe("coach operations", () => {
     releaseFirst.release();
     const [firstResult, secondResult, readResult] = await Promise.all([first, second, read]);
     expect(firstResult).toEqual({
-      schemaVersion: 2,
+      schemaVersion: 3,
+      status: "applied",
       applied: { llm: true, intervals: false, session: false },
     });
     expect(secondResult).toEqual({
-      schemaVersion: 2,
+      schemaVersion: 3,
+      status: "applied",
       applied: { llm: true, intervals: false, session: false },
     });
     expect(readResult.llm.model).toBe("model-b");
@@ -942,19 +988,19 @@ describe("coach operations", () => {
       home,
       context: context(),
       runtime: operationRuntime(async (work) => {
-          syncAttempt += 1;
-          trace.push(`sync-${syncAttempt}-start`);
-          if (syncAttempt === 1) {
-            syncStarted.release();
-            await releaseSync.promise;
-          }
-          await work(new AbortController().signal);
-          trace.push(`sync-${syncAttempt}-end`);
-          return {
-            published: true,
-            legacySucceeded: true,
-            counts: requestCounts(0, 0),
-          };
+        syncAttempt += 1;
+        trace.push(`sync-${syncAttempt}-start`);
+        if (syncAttempt === 1) {
+          syncStarted.release();
+          await releaseSync.promise;
+        }
+        await work(new AbortController().signal);
+        trace.push(`sync-${syncAttempt}-end`);
+        return {
+          published: true,
+          legacySucceeded: true,
+          counts: requestCounts(0, 0),
+        };
       }),
       intervalsCredentials: intervalsCredentials(),
       historyNewestDate: () => "1998-07-18",
@@ -967,9 +1013,13 @@ describe("coach operations", () => {
         trace.push(`llm-${activeModel}`);
       },
       readRuntimeConfig: () => ({
-        schemaVersion: 2,
+        schemaVersion: 3,
         llm: { provider: "openai", model: activeModel, credential_configured: true },
-        intervals: { athlete_id: "synthetic-athlete" },
+        intervals: {
+          athlete_id: "synthetic-athlete",
+          credential_configured: true,
+          managedByEnvironment: { athleteId: false },
+        },
         session: {
           historyTokenBudgetRatio: 0.3,
           idleMinutes: 0,
@@ -1008,7 +1058,8 @@ describe("coach operations", () => {
       expect.objectContaining({ message: "synthetic configuration failure" }),
     );
     await expect(laterLlm).resolves.toEqual({
-      schemaVersion: 2,
+      schemaVersion: 3,
+      status: "applied",
       applied: { llm: true, intervals: false, session: false },
     });
     await expect(laterRead).resolves.toMatchObject({ llm: { model: "model-b" } });
@@ -1032,9 +1083,13 @@ describe("coach operations", () => {
       historyNewestDate: () => "1998-07-18",
       applyRuntimeConfig,
       readRuntimeConfig: () => ({
-        schemaVersion: 2,
+        schemaVersion: 3,
         llm: { provider: "google", model: "third", credential_configured: true },
-        intervals: { athlete_id: "athlete-b" },
+        intervals: {
+          athlete_id: "athlete-b",
+          credential_configured: true,
+          managedByEnvironment: { athleteId: false },
+        },
         session: {
           historyTokenBudgetRatio: 0.3,
           idleMinutes: 0,
@@ -1070,10 +1125,26 @@ describe("coach operations", () => {
       }),
     ];
     expect(results).toEqual([
-      { schemaVersion: 2, applied: { llm: true, intervals: false, session: false } },
-      { schemaVersion: 2, applied: { llm: false, intervals: true, session: false } },
-      { schemaVersion: 2, applied: { llm: true, intervals: true, session: false } },
-      { schemaVersion: 2, applied: { llm: true, intervals: false, session: false } },
+      {
+        schemaVersion: 3,
+        status: "applied",
+        applied: { llm: true, intervals: false, session: false },
+      },
+      {
+        schemaVersion: 3,
+        status: "applied",
+        applied: { llm: false, intervals: true, session: false },
+      },
+      {
+        schemaVersion: 3,
+        status: "applied",
+        applied: { llm: true, intervals: true, session: false },
+      },
+      {
+        schemaVersion: 3,
+        status: "applied",
+        applied: { llm: true, intervals: false, session: false },
+      },
     ]);
     expect(applied).toEqual([
       llmFirst,
@@ -1088,9 +1159,13 @@ describe("coach operations", () => {
       expect(serializedResults).not.toContain(value);
     }
     await expect(operations.getRuntimeConfig({})).resolves.toEqual({
-      schemaVersion: 2,
+      schemaVersion: 3,
       llm: { provider: "google", model: "third", credential_configured: true },
-      intervals: { athlete_id: "athlete-b" },
+      intervals: {
+        athlete_id: "athlete-b",
+        credential_configured: true,
+        managedByEnvironment: { athleteId: false },
+      },
       session: {
         historyTokenBudgetRatio: 0.3,
         idleMinutes: 0,
@@ -1132,15 +1207,15 @@ describe("coach operations", () => {
           listener: {} as CoachStoreWriterContext["listener"],
         },
         runtime: operationRuntime(async (work) => {
-            order.push("sync-start");
-            await gate;
-            await work(new AbortController().signal);
-            order.push("sync-end");
-            return {
-              published: true,
-              legacySucceeded: true,
-              counts: requestCounts(0, 0),
-            };
+          order.push("sync-start");
+          await gate;
+          await work(new AbortController().signal);
+          order.push("sync-end");
+          return {
+            published: true,
+            legacySucceeded: true,
+            counts: requestCounts(0, 0),
+          };
         }),
         intervalsCredentials: intervalsCredentials(),
         historyNewestDate: () => "1998-07-18",

--- a/packages/coach/tests/serve.test.ts
+++ b/packages/coach/tests/serve.test.ts
@@ -73,7 +73,8 @@ const operations: CoachOperations = {
   }),
   saveIntake: async () => ({ schemaVersion: 1, saved: true }),
   configureRuntime: async ({ llm, intervals, session }) => ({
-    schemaVersion: 2,
+    schemaVersion: 3,
+    status: "applied",
     applied: {
       llm: llm !== undefined,
       intervals: intervals !== undefined,
@@ -81,9 +82,13 @@ const operations: CoachOperations = {
     },
   }),
   getRuntimeConfig: async () => ({
-    schemaVersion: 2,
+    schemaVersion: 3,
     llm: { provider: "anthropic", model: "synthetic-model", credential_configured: false },
-    intervals: { athlete_id: "synthetic-athlete" },
+    intervals: {
+      athlete_id: "synthetic-athlete",
+      credential_configured: false,
+      managedByEnvironment: { athleteId: false },
+    },
     session: {
       historyTokenBudgetRatio: 0.3,
       idleMinutes: 0,


### PR DESCRIPTION
## Summary

- add a resident Training account section for editing only the athlete ID of the currently connected account
- enforce credential presence, environment authority, and same-owner checks through typed protocol refusals
- preserve drafts across recoverable failures while reconciling locked authority and deterministic keyboard focus

## Verification

- 398 targeted tests passed with sandbox-only loopback skips
- 50 Settings tests passed after final accessibility fixes
- five affected package type checks passed
- real Electron chat-panels integration scenario passed
- focused lint, format, changeset, and diff checks passed
- three independent security, concurrency/protocol, and UX/accessibility reviews are clean